### PR TITLE
ci: fallback release verify runners outside official repo

### DIFF
--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -17,9 +17,9 @@ jobs:
   try:
     uses: kungfu-systems/workflows/.github/workflows/.release-verify.yml@dev/v1/v1.2
     with:
-      build-runner-linux-labels: '["self-hosted","Linux","X64","agent-120","kungfu-build","linux-x64"]'
-      build-runner-macos-labels: '["self-hosted","macOS","ARM64","mac-studio","kungfu-build","macos-arm64"]'
-      build-runner-windows-labels: '["self-hosted","Windows","X64","darkhero","kungfu-build","windows-x64"]'
+      build-runner-linux-labels: ${{ github.repository == 'kungfu-systems/kungfu' && '["self-hosted","Linux","X64","agent-120","kungfu-build","linux-x64"]' || '' }}
+      build-runner-macos-labels: ${{ github.repository == 'kungfu-systems/kungfu' && '["self-hosted","macOS","ARM64","mac-studio","kungfu-build","macos-arm64"]' || '' }}
+      build-runner-windows-labels: ${{ github.repository == 'kungfu-systems/kungfu' && '["self-hosted","Windows","X64","darkhero","kungfu-build","windows-x64"]' || '' }}
       use-pipenv: true
       build-timeout-minutes: 150
       max-build-attempts: 3


### PR DESCRIPTION
Make the release-verify caller pass self-hosted runner labels only when the workflow runs in the official kungfu-systems/kungfu repository.\n\nForks and other repositories leave the label inputs empty, so the reusable workflow falls back to its GitHub-hosted defaults. This PR targets dev/v2/v2.4 and does not trigger the alpha/release heavy build workflow.