### PR TITLE
chore(core): use latest libnode alpha

### DIFF
--- a/framework/core/package.json
+++ b/framework/core/package.json
@@ -67,7 +67,7 @@
   },
   "devDependencies": {
     "@kungfu-tech/toolchain": "workspace:*",
-    "@kungfu-tech/libnode": "22.22.3",
+    "@kungfu-tech/libnode": "22.22.3-kf.0",
     "electron": "^42.5.0",
     "node-addon-api": "^8.0.0"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -543,8 +543,8 @@ importers:
         version: 1.3.0
     devDependencies:
       '@kungfu-tech/libnode':
-        specifier: 22.22.3
-        version: 22.22.3(encoding@0.1.13)
+        specifier: 22.22.3-kf.0
+        version: 22.22.3-kf.0
       '@kungfu-tech/toolchain':
         specifier: workspace:*
         version: link:../../developer/toolchain
@@ -1774,8 +1774,23 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@kungfu-tech/libnode@22.22.3':
-    resolution: {integrity: sha512-n3/HSdYwPZmsasXFMUe6p0LMgF1s9aFAaRpnbg9aGnAKwm5Bp8fvNTNp0z7lmZSOAanhQZo7sOSSy3Bad39DEw==}
+  '@kungfu-tech/libnode-darwin-arm64@22.22.3-kf.0':
+    resolution: {integrity: sha512-HJhTdTY6Eovbg/6DvjSlNc7QlrxzIJD7DQU3lAAgnmDmX3QmB2ioC00736vX/FEazakqdtrxV98idQF95GP8vQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@kungfu-tech/libnode-linux-x64@22.22.3-kf.0':
+    resolution: {integrity: sha512-A7AMfNiGP2pia70ZhOPzzsD5xdnJ2dubh5urAj8PdB0XhfWr355xer+jrwROTNaZXDy9bHtkl8tSaA+MHzun8w==}
+    cpu: [x64]
+    os: [linux]
+
+  '@kungfu-tech/libnode-win32-x64@22.22.3-kf.0':
+    resolution: {integrity: sha512-9cMp1BDdpbrMV01ndpybIqdukID+w/DovLb0yYuqnNBEInuRwefCS/Zcpm1zN7hNh/Xfp0iovYAvmumIJC9nYQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@kungfu-tech/libnode@22.22.3-kf.0':
+    resolution: {integrity: sha512-UjPPt0YlDu970TkiREvDfgg4MYObxi15IQ+F4NZ86kkHD3PToIM/i6OB8Ba/n0sP8DA9PC1DsuUgsrpF9XEhhQ==}
 
   '@leichtgewicht/ip-codec@2.0.5':
     resolution: {integrity: sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==}
@@ -9768,13 +9783,20 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@kungfu-tech/libnode@22.22.3(encoding@0.1.13)':
-    dependencies:
-      '@mapbox/node-pre-gyp': 1.0.11(encoding@0.1.13)
-      sywac: 1.3.0
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
+  '@kungfu-tech/libnode-darwin-arm64@22.22.3-kf.0':
+    optional: true
+
+  '@kungfu-tech/libnode-linux-x64@22.22.3-kf.0':
+    optional: true
+
+  '@kungfu-tech/libnode-win32-x64@22.22.3-kf.0':
+    optional: true
+
+  '@kungfu-tech/libnode@22.22.3-kf.0':
+    optionalDependencies:
+      '@kungfu-tech/libnode-darwin-arm64': 22.22.3-kf.0
+      '@kungfu-tech/libnode-linux-x64': 22.22.3-kf.0
+      '@kungfu-tech/libnode-win32-x64': 22.22.3-kf.0
 
   '@leichtgewicht/ip-codec@2.0.5': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,6 +11,11 @@ allowBuilds:
   esbuild: true
   nx: true
   vue-demi: true
+minimumReleaseAgeExclude:
+  - '@kungfu-tech/libnode-win32-x64@22.22.3-kf.0'
+  - '@kungfu-tech/libnode@22.22.3-kf.0'
+  - '@kungfu-tech/libnode-darwin-arm64@22.22.3-kf.0'
+  - '@kungfu-tech/libnode-linux-x64@22.22.3-kf.0'
 overrides:
   # node-gyp 9.x cannot detect Visual Studio 2026; 13.x adds VS2026 support, which
   # the Windows build needs to match the prebuilt (MSVC 19.5) conan dependencies.


### PR DESCRIPTION
## Summary
- update @kungfu-tech/libnode to 22.22.3-kf.0
- refresh pnpm lock entries for the new platform-split libnode packages
- allow the freshly published libnode alpha packages through pnpm minimum release age policy

## Verification
- ./kungfu-code install --lockfile-only --frozen-lockfile
- git diff --check
- npm/pnpm metadata checks against registry.npmjs.org for the new libnode package set

## Notes
- The local npm proxy at 192.168.100.222:4873 initially did not expose the newly published darwin/linux platform packages, so official npm registry was used to verify metadata and tarball integrity.
