### PR TITLE
build(core): adopt @kungfu-tech/libnode 22.22.3-kf.1

### DIFF
--- a/framework/core/package.json
+++ b/framework/core/package.json
@@ -67,7 +67,7 @@
   },
   "devDependencies": {
     "@kungfu-tech/toolchain": "workspace:*",
-    "@kungfu-tech/libnode": "22.22.3-kf.0",
+    "@kungfu-tech/libnode": "22.22.3-kf.1",
     "electron": "^42.5.0",
     "node-addon-api": "^8.0.0"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -543,8 +543,8 @@ importers:
         version: 1.3.0
     devDependencies:
       '@kungfu-tech/libnode':
-        specifier: 22.22.3-kf.0
-        version: 22.22.3-kf.0
+        specifier: 22.22.3-kf.1
+        version: 22.22.3-kf.1
       '@kungfu-tech/toolchain':
         specifier: workspace:*
         version: link:../../developer/toolchain
@@ -1774,23 +1774,23 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@kungfu-tech/libnode-darwin-arm64@22.22.3-kf.0':
-    resolution: {integrity: sha512-HJhTdTY6Eovbg/6DvjSlNc7QlrxzIJD7DQU3lAAgnmDmX3QmB2ioC00736vX/FEazakqdtrxV98idQF95GP8vQ==}
+  '@kungfu-tech/libnode-darwin-arm64@22.22.3-kf.1':
+    resolution: {integrity: sha512-IJpMSrcxs77vw/unEbI6v0a6BrArQjC9/ZLDW+WKn9Kzk7ZXcBKz3N/F7exldwc67n7R4tp0wOSIGcwjs75M2A==}
     cpu: [arm64]
     os: [darwin]
 
-  '@kungfu-tech/libnode-linux-x64@22.22.3-kf.0':
-    resolution: {integrity: sha512-A7AMfNiGP2pia70ZhOPzzsD5xdnJ2dubh5urAj8PdB0XhfWr355xer+jrwROTNaZXDy9bHtkl8tSaA+MHzun8w==}
+  '@kungfu-tech/libnode-linux-x64@22.22.3-kf.1':
+    resolution: {integrity: sha512-z2lYmVslpiAfsuUEBQRdLU6mXLZm2KKGIJ59noA72m8Re/ewTZpB82I9ZDZBsOdRHKCDKzJ96vszJbuKMikS9A==}
     cpu: [x64]
     os: [linux]
 
-  '@kungfu-tech/libnode-win32-x64@22.22.3-kf.0':
-    resolution: {integrity: sha512-9cMp1BDdpbrMV01ndpybIqdukID+w/DovLb0yYuqnNBEInuRwefCS/Zcpm1zN7hNh/Xfp0iovYAvmumIJC9nYQ==}
+  '@kungfu-tech/libnode-win32-x64@22.22.3-kf.1':
+    resolution: {integrity: sha512-6m/+IjHFyxOzAbMTscApRB5uXbWIJiJ/vvCFrEw5ETF2vjW8KJa287tJp5NIufg1tALCLnArAqf8VxXjHnWFdw==}
     cpu: [x64]
     os: [win32]
 
-  '@kungfu-tech/libnode@22.22.3-kf.0':
-    resolution: {integrity: sha512-UjPPt0YlDu970TkiREvDfgg4MYObxi15IQ+F4NZ86kkHD3PToIM/i6OB8Ba/n0sP8DA9PC1DsuUgsrpF9XEhhQ==}
+  '@kungfu-tech/libnode@22.22.3-kf.1':
+    resolution: {integrity: sha512-4KpxBhR6lzdxIwoapTGn3CmTA1lISNGqiiNIdXHT1yJWlM5S4tGnF4N6+CAjkv+PUP7M8wSPTRGSgMDmd4bpDA==}
 
   '@leichtgewicht/ip-codec@2.0.5':
     resolution: {integrity: sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==}
@@ -9783,20 +9783,20 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@kungfu-tech/libnode-darwin-arm64@22.22.3-kf.0':
+  '@kungfu-tech/libnode-darwin-arm64@22.22.3-kf.1':
     optional: true
 
-  '@kungfu-tech/libnode-linux-x64@22.22.3-kf.0':
+  '@kungfu-tech/libnode-linux-x64@22.22.3-kf.1':
     optional: true
 
-  '@kungfu-tech/libnode-win32-x64@22.22.3-kf.0':
+  '@kungfu-tech/libnode-win32-x64@22.22.3-kf.1':
     optional: true
 
-  '@kungfu-tech/libnode@22.22.3-kf.0':
+  '@kungfu-tech/libnode@22.22.3-kf.1':
     optionalDependencies:
-      '@kungfu-tech/libnode-darwin-arm64': 22.22.3-kf.0
-      '@kungfu-tech/libnode-linux-x64': 22.22.3-kf.0
-      '@kungfu-tech/libnode-win32-x64': 22.22.3-kf.0
+      '@kungfu-tech/libnode-darwin-arm64': 22.22.3-kf.1
+      '@kungfu-tech/libnode-linux-x64': 22.22.3-kf.1
+      '@kungfu-tech/libnode-win32-x64': 22.22.3-kf.1
 
   '@leichtgewicht/ip-codec@2.0.5': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,11 +11,11 @@ allowBuilds:
   esbuild: true
   nx: true
   vue-demi: true
-minimumReleaseAgeExclude:
-  - '@kungfu-tech/libnode-win32-x64@22.22.3-kf.0'
-  - '@kungfu-tech/libnode@22.22.3-kf.0'
-  - '@kungfu-tech/libnode-darwin-arm64@22.22.3-kf.0'
-  - '@kungfu-tech/libnode-linux-x64@22.22.3-kf.0'
+# Disable pnpm's default minimum-release-age supply-chain check. We frequently
+# publish first-party @kungfu-tech/libnode platform builds and consume them
+# immediately; the age gate would otherwise block every fresh libnode bump until
+# it ages past the cutoff, forcing a per-version allow-list. 0 = no minimum age.
+minimumReleaseAge: 0
 overrides:
   # node-gyp 9.x cannot detect Visual Studio 2026; 13.x adds VS2026 support, which
   # the Windows build needs to match the prebuilt (MSVC 19.5) conan dependencies.


### PR DESCRIPTION
## What

- Bump `@kungfu-tech/libnode` `22.22.3-kf.0` → `22.22.3-kf.1` and refresh the lockfile.
- Disable pnpm's minimum-release-age supply-chain gate (`minimumReleaseAge: 0`), replacing the per-version allow-list.

## Why

kf.0 only shipped the versioned `libnode.127.dylib`, so the core native binding failed to link (`ld: library 'node' not found`, `-lnode` needs the unversioned name). kf.1 ships the unversioned shared library on macOS and Linux, fixing the link step.

We publish first-party libnode platform builds and consume them immediately; the release-age gate blocked every fresh bump until it aged past the cutoff and forced a growing per-version allow-list. Turning it off keeps libnode work unblocked.

## Verify

On macOS arm64, a clean `rebuild:core` + `verify --full` passes 6/6 (C++ compile + link + Nuitka freeze + kfc runtime smoke, `kfc --version` = 4.0.0-alpha.0).