### PR TITLE
feat(core): minimal fact-ledger slice (journal spine without runtime)

### DIFF
--- a/framework/core/CMakeLists.txt
+++ b/framework/core/CMakeLists.txt
@@ -54,6 +54,7 @@ option(NNG_TESTS "" OFF)
 option(NNG_TOOLS "" OFF)
 option(NNG_ENABLE_NNGCAT "" OFF)
 option(KUNGFU_WITH_DEBUG_EXAMPLE "" OFF)
+option(KUNGFU_WITH_FACT_LEDGER_SLICE "build the minimal fact-ledger host + export tools" OFF)
 
 ##########################################################################
 
@@ -150,5 +151,12 @@ endif()
 if (KUNGFU_WITH_DEBUG_EXAMPLE)
   message(STATUS "Enabled kungfu_debug_example")
   add_subdirectory(debug-example)
+endif()
+
+# Minimal fact-ledger slice (journal spine embedded without the trading runtime).
+# Needs libkungfu; only wired when the libkungfu target exists.
+if (KUNGFU_WITH_FACT_LEDGER_SLICE AND TARGET ${LIBKUNGFU_NAME})
+  message(STATUS "Enabled fact_ledger_slice")
+  add_subdirectory(fact-ledger-slice)
 endif()
 

--- a/framework/core/fact-ledger-slice/CMakeLists.txt
+++ b/framework/core/fact-ledger-slice/CMakeLists.txt
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Minimal fact-ledger slice: two standalone executables that embed the journal
+# spine without starting the trading runtime.
+#
+#   fact_ledger_host    write path  -- appends a causal chain of Json events
+#   fact_ledger_export  read path   -- reopens the directory, emits JSONL + manifest
+#
+# Both link the existing libkungfu (${LIBKUNGFU_NAME}); the parent CMakeLists
+# already puts src/include and the conan libs on the global include/link path.
+
+project(fact_ledger_slice)
+
+add_executable(fact_ledger_host host.cpp)
+target_link_libraries(fact_ledger_host ${LIBKUNGFU_NAME})
+
+add_executable(fact_ledger_export export.cpp)
+target_link_libraries(fact_ledger_export ${LIBKUNGFU_NAME})
+
+# Find libkungfu at its build location when running from the build tree.
+set_target_properties(fact_ledger_host fact_ledger_export PROPERTIES
+  BUILD_WITH_INSTALL_RPATH FALSE
+  SKIP_BUILD_RPATH FALSE)

--- a/framework/core/fact-ledger-slice/README.md
+++ b/framework/core/fact-ledger-slice/README.md
@@ -1,0 +1,106 @@
+# Minimal fact-ledger slice
+
+A minimal, verifiable slice that embeds the yijinjing journal spine in a plain
+process **without starting the trading runtime** (no master, no bus drain loop,
+no nng sockets), records a causal chain inside the spine, and then proves it can
+be reopened and exported by a fully independent tool.
+
+Two standalone executables:
+
+| binary | path | role |
+| --- | --- | --- |
+| `fact_ledger_host` | `host.cpp` | write path: append N (>=3) `Json` events, chain each to its parent, exit |
+| `fact_ledger_export` | `export.cpp` | read path: reopen the directory, emit stable JSONL + a run manifest |
+
+What it demonstrates in one run:
+
+- the journal core can be embedded and driven by hand-fed causality;
+- the format opens without the runtime that produced it;
+- export is lossless and order-preserving, and carries provenance you can verify
+  with a stock `sha256sum`.
+
+## Build
+
+Everything runs from `framework/core`. Dependencies come from conan 2 (warm
+cache); node and python bindings are skipped so only `libkungfu` and the two
+tools build.
+
+```bash
+cd framework/core
+
+# 1. resolve C++ deps + generate the CMake toolchain (conan 2)
+uv run --frozen conan install . --output-folder build --build=missing -s build_type=Release
+
+# 2. configure: skip node/python bindings, enable this slice
+KUNGFU_BUILD_SKIP_KUNGFU_NODE=1 KUNGFU_BUILD_SKIP_PYKUNGFU=1 \
+cmake -S . -B build -G Ninja \
+  -DCMAKE_TOOLCHAIN_FILE="$(pwd)/build/conan_toolchain.cmake" \
+  -DCMAKE_POLICY_DEFAULT_CMP0091=NEW \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DKUNGFU_WITH_FACT_LEDGER_SLICE=ON
+
+# 3. build only the two tools (pulls libkungfu as a dependency)
+cmake --build build --target fact_ledger_host fact_ledger_export -j 8
+```
+
+## Run
+
+```bash
+# writes into a fresh temp dir, exports, and checksum-verifies end to end
+fact-ledger-slice/run_slice.sh build 5
+```
+
+Or by hand:
+
+```bash
+work="$(mktemp -d)"
+build/fact-ledger-slice/fact_ledger_host "$work" 5     # writes, then exits
+build/fact-ledger-slice/fact_ledger_export "$work" fact_ledger_slice host "$work/export"
+sha256sum "$work/export.jsonl"                          # matches manifest.event_log.segment_sha256
+```
+
+## Expected output
+
+`fact_ledger_host` prints the location identity plus the expected
+`(frame_uid, trigger_frame_uid)` chain. `fact_ledger_export` writes:
+
+- `export.jsonl` — one line per event, in written order, each with
+  `frame_uid / trigger_frame_uid / gen_time / trigger_time / msg_type / source /
+  initial_source / dest / data_type / stream_id / payload_raw / payload /
+  payload_sha256`;
+- `export.manifest.json` — `spec_version`, `format_version`, `producer`,
+  `platform {os, arch}`, `hash_algorithm`, per-event checksums, the whole-segment
+  checksum, `causal_chain_verified`, and an explicit `capture_boundary`.
+
+The export tool exits non-zero if nothing was read or the causal chain does not
+link back correctly, so CI can gate on it.
+
+## Acceptance criteria mapping
+
+1. **Causal chain in the spine** — `host.cpp` feeds `bus->set_trigger_frame_uid(uid_{k-1})`
+   before each frame; event k's `trigger_frame_uid` == event k-1's `frame_uid`.
+   `export.cpp` re-checks the link and sets `causal_chain_verified`.
+2. **Independent reopen** — `export.cpp` reconstructs the location from directory
+   coordinates and iterates via `assemble` (noop bus); no trading runtime.
+3. **Stable JSONL** — required fields present, order == write order, payload
+   carried verbatim in `payload_raw`.
+4. **Run manifest + loss boundary** — `spec/format` versions, platform, per-event
+   and whole-segment `sha256`, provenance, and the `capture_boundary` declaration.
+5. **No uid recompute** — `export.cpp` reads `frame_uid`/`trigger_frame_uid`
+   straight off the header; it never calls `writer::current_frame_uid()`
+   (ADR-0010 4.6).
+6. **Reproducible build+run** — the commands above, plus `run_slice.sh`.
+
+## Honest capture boundary (what this slice does NOT claim)
+
+- **Runtime-decoupled, not link-decoupled.** The build still links the monolithic
+  `libkungfu`; only the *runtime* is cut out (no master/bus/nng). Extracting a
+  pure journal-only core is future work.
+- **No in-frame content hash yet.** Content commitment lives at the manifest
+  layer (checksums over exported payloads), not as a per-frame `payload_hash` in
+  the spine (the external hash-blob store of the full design is future work).
+- **`msg_type` is an opaque int.** No self-describing schema registry is bundled;
+  decoding still assumes the reader knows the meaning of a type.
+- **`frame_uid` is stable within a bundle and across re-reads, but not
+  reproducible across separate write runs** (per-writer nano-hash low bits;
+  ADR-0010 8.2.3 determinism not adopted).

--- a/framework/core/fact-ledger-slice/export.cpp
+++ b/framework/core/fact-ledger-slice/export.cpp
@@ -1,0 +1,235 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Independent fact-ledger export tool (read path).
+//
+// Reopens a journal directory that some other process wrote and then exited,
+// WITHOUT starting the trading runtime (no master, no bus drain loop, no nng).
+// It iterates the frames in written order and produces two portable artifacts:
+//
+//   <out>.jsonl          one line per event, stable field set, payload verbatim
+//   <out>.manifest.json  spec/platform/provenance + content checksums + the
+//                        explicit capture-boundary (what is and isn't captured)
+//
+// ADR-0010 4.6 invariant: frame_uid / trigger_frame_uid are read straight off
+// each recorded frame header and copied out verbatim. We never call
+// writer::current_frame_uid() or otherwise regenerate an id on the read path --
+// doing so would break the causal graph the spine records.
+//
+// Usage:  fact_ledger_export <journal-root-dir> [group] [name] [out-prefix]
+
+#include <kungfu/yijinjing/common.h>
+#include <kungfu/yijinjing/journal/assemble.h>
+#include <kungfu/yijinjing/journal/journal.h>
+
+#include <nlohmann/json.hpp>
+
+#include "sha256.h"
+
+#include <cstdint>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <vector>
+
+using namespace kungfu::yijinjing;
+namespace longfist = kungfu::longfist;
+using kungfu::fact_ledger_slice::sha256;
+
+namespace {
+constexpr const char *SPEC_VERSION = "0.1";      // portable-bundle format contract
+constexpr const char *FORMAT_VERSION = "0.1";    // event-log line schema
+constexpr const char *PRODUCER = "fact_ledger_export/0.1.0";
+constexpr const char *HASH_ALGORITHM = "sha256";
+
+const char *platform_os() {
+#if defined(__APPLE__)
+  return "macos";
+#elif defined(__linux__)
+  return "linux";
+#elif defined(_WIN32)
+  return "windows";
+#else
+  return "unknown";
+#endif
+}
+
+const char *platform_arch() {
+#if defined(__aarch64__) || defined(_M_ARM64)
+  return "arm64";
+#elif defined(__x86_64__) || defined(_M_X64)
+  return "x86_64";
+#else
+  return "unknown";
+#endif
+}
+
+// The journal reserves payload space rounded up to a CPU word, so the recorded
+// data_length can carry trailing NUL padding after the JSON text. JSON text
+// never contains an interior NUL, so stripping trailing NULs recovers the exact
+// bytes the writer memcpy'd -- the verbatim payload.
+std::string strip_trailing_nuls(std::string s) {
+  while (!s.empty() && s.back() == '\0') {
+    s.pop_back();
+  }
+  return s;
+}
+
+const char *data_type_name(int8_t dt) {
+  switch (dt) {
+  case int8_t(longfist::enums::FrameDataType::Raw):
+    return "Raw";
+  case int8_t(longfist::enums::FrameDataType::Json):
+    return "Json";
+  default:
+    return "Unknown";
+  }
+}
+} // namespace
+
+int main(int argc, char **argv) {
+  if (argc < 2) {
+    std::cerr << "usage: fact_ledger_export <journal-root-dir> [group] [name] [out-prefix]\n";
+    return 2;
+  }
+  const std::string root = argv[1];
+  const std::string group = argc >= 3 ? argv[2] : "fact_ledger_slice";
+  const std::string name = argc >= 4 ? argv[3] : "host";
+  const std::string out_prefix = argc >= 5 ? argv[4] : (root + "/export");
+
+  // Reconstruct the same location identity from the directory coordinates and
+  // reopen it read-only. assemble uses a noop bus internally; nothing here
+  // starts the runtime.
+  auto locator = std::make_shared<data::locator>(root);
+  auto location = data::location::make_shared(longfist::enums::mode::LIVE, longfist::enums::category::SYSTEM, group, name,
+                                              locator);
+  journal::assemble reader(location, data::location::PUBLIC, longfist::enums::AssembleMode::Channel, 0);
+
+  // Build the JSONL body in memory so the whole-segment checksum is computed
+  // over exactly the bytes we write out.
+  std::string jsonl;
+  std::vector<nlohmann::json> event_digests; // per-event checksum records for the manifest
+  std::vector<int64_t> prev_uid_seen;        // to assert the causal chain links back
+
+  std::size_t count = 0;
+  bool chain_ok = true;
+  uint64_t last_uid = 0;
+
+  while (reader.data_available()) {
+    auto frame = reader.current_frame();
+
+    const uint64_t frame_uid = frame->frame_uid();               // read verbatim, never recomputed
+    const uint64_t trigger_frame_uid = frame->trigger_frame_uid(); // read verbatim
+    const std::string payload_raw = frame->is_json() ? strip_trailing_nuls(frame->data_as_string()) : std::string{};
+    const std::string payload_sha = sha256::hex(payload_raw);
+
+    // Causal-chain check: event 0 is root (trigger 0); event k (k>0) must point
+    // at event k-1's frame_uid.
+    if (count == 0) {
+      if (trigger_frame_uid != 0) {
+        chain_ok = false;
+      }
+    } else if (trigger_frame_uid != last_uid) {
+      chain_ok = false;
+    }
+    last_uid = frame_uid;
+
+    nlohmann::json line = {
+        {"seq", count},
+        {"frame_uid", frame_uid},
+        {"trigger_frame_uid", trigger_frame_uid},
+        {"gen_time", frame->gen_time()},
+        {"trigger_time", frame->trigger_time()},
+        {"msg_type", frame->msg_type()},
+        {"source", frame->source()},
+        {"initial_source", frame->initial_source()},
+        {"dest", frame->dest()},
+        {"data_type", data_type_name(frame->data_type())},
+        {"stream_id", frame->stream_id()},
+        {"payload_sha256", payload_sha},
+    };
+    // Verbatim payload text + parsed structure (parsed only when it is valid JSON).
+    line["payload_raw"] = payload_raw;
+    if (frame->is_json() && !payload_raw.empty()) {
+      line["payload"] = nlohmann::json::parse(payload_raw, nullptr, /*allow_exceptions=*/false);
+    }
+
+    jsonl += line.dump();
+    jsonl += "\n";
+
+    event_digests.push_back({{"seq", count}, {"frame_uid", frame_uid}, {"payload_sha256", payload_sha}});
+
+    ++count;
+    reader.next();
+  }
+
+  // Write the event log.
+  const std::string jsonl_path = out_prefix + ".jsonl";
+  {
+    std::ofstream f(jsonl_path, std::ios::binary | std::ios::trunc);
+    if (!f) {
+      std::cerr << "cannot open output: " << jsonl_path << "\n";
+      return 1;
+    }
+    f.write(jsonl.data(), static_cast<std::streamsize>(jsonl.size()));
+  }
+
+  // Whole-segment checksum over exactly the bytes written -- verifiable with
+  // `shasum -a 256 <jsonl>`.
+  const std::string segment_sha = sha256::hex(jsonl);
+
+  nlohmann::json manifest = {
+      {"spec_version", SPEC_VERSION},
+      {"format_version", FORMAT_VERSION},
+      {"producer", PRODUCER},
+      {"platform", {{"os", platform_os()}, {"arch", platform_arch()}}},
+      {"hash_algorithm", HASH_ALGORITHM},
+      {"source", {{"root", root}, {"mode", "LIVE"}, {"category", "SYSTEM"}, {"group", group}, {"name", name}, {"dest", data::location::PUBLIC}}},
+      {"event_count", count},
+      {"event_log", {{"path", jsonl_path}, {"segment_sha256", segment_sha}}},
+      {"event_checksums", event_digests},
+      {"causal_chain_verified", chain_ok},
+  };
+
+  // D1 honesty: state exactly what this bundle captures and what it does not.
+  manifest["capture_boundary"] = {
+      {"completeness", "complete"},
+      {"scope", "single_process"},
+      {"what_captured",
+       {"frame_uid", "trigger_frame_uid (causal parent)", "gen_time", "trigger_time", "msg_type", "source",
+        "initial_source", "dest", "data_type", "stream_id", "json_payload_verbatim"}},
+      {"what_not_captured",
+       {"in_frame_payload_content_hash (design B2, external blob store is future work)",
+        "self_describing_schema_registry (msg_type is an opaque int here)",
+        "wall_clock_to_external_trusted_time_source", "system_calls / memory / external_io"}},
+      {"known_limitations",
+       {"Build-time link still depends on the monolithic libkungfu; only the RUNTIME is decoupled "
+        "(no master, no bus drain loop, no nng sockets). Pure journal-core extraction is future work.",
+        "frame_uid low bits are derived from a per-writer-run nano hash, so uids are stable within a "
+        "bundle and across re-reads, but not reproducible across separate write runs (ADR-0010 8.2.3 not adopted)."}},
+  };
+
+  const std::string manifest_path = out_prefix + ".manifest.json";
+  {
+    std::ofstream f(manifest_path, std::ios::binary | std::ios::trunc);
+    if (!f) {
+      std::cerr << "cannot open output: " << manifest_path << "\n";
+      return 1;
+    }
+    const std::string body = manifest.dump(2);
+    f.write(body.data(), static_cast<std::streamsize>(body.size()));
+    f.put('\n');
+  }
+
+  std::cout << "exported " << count << " events\n"
+            << "  jsonl:    " << jsonl_path << "\n"
+            << "  manifest: " << manifest_path << "\n"
+            << "  segment_sha256: " << segment_sha << "\n"
+            << "  causal_chain_verified: " << (chain_ok ? "true" : "false") << "\n";
+
+  // Non-zero exit if the causal chain did not verify or nothing was read, so the
+  // driver / CI can gate on it.
+  if (count == 0 || !chain_ok) {
+    return 1;
+  }
+  return 0;
+}

--- a/framework/core/fact-ledger-slice/host.cpp
+++ b/framework/core/fact-ledger-slice/host.cpp
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Minimal fact-ledger host (write path).
+//
+// Proves that the journal spine can be embedded in a plain process that starts
+// no master, no bus drain loop and no network sockets: it opens a journal
+// location with a noop bus + noop publisher, appends N (>= 3) Json events, and
+// records a causal chain inside the spine -- event k's trigger_frame_uid points
+// at event k-1's frame_uid. The process then exits; an independent tool reopens
+// the directory and exports it (see export.cpp).
+//
+// Usage:  fact_ledger_host <journal-root-dir> [event-count]
+//
+// The causal parent is fed explicitly through bus::set_trigger_frame_uid before
+// each frame is closed. In the live trading runtime this value is set by the
+// hero drain loop; here we set it by hand, which is exactly the point of the
+// "cut the core out of the runtime" test.
+
+#include <kungfu/yijinjing/common.h>
+#include <kungfu/yijinjing/journal/journal.h>
+#include <kungfu/yijinjing/time.h>
+
+#include <nlohmann/json.hpp>
+
+#include <cstdint>
+#include <cstring>
+#include <iostream>
+#include <string>
+#include <vector>
+
+using namespace kungfu::yijinjing;
+namespace longfist = kungfu::longfist;
+using longfist::enums::FrameDataType;
+
+namespace {
+// Custom application message types for this slice. These are opaque ints on the
+// wire; the export tool carries them through verbatim (a real deployment would
+// resolve them via a schema registry, which this minimal slice does not build).
+constexpr int32_t MSG_OBSERVE = 10001;
+constexpr int32_t MSG_DECIDE = 10002;
+constexpr int32_t MSG_ACT = 10003;
+
+// One logical run of the causal chain, tagged onto every frame's stream_id so a
+// consumer can group a bundle by run.
+constexpr uint64_t STREAM_ID = 1;
+
+int32_t msg_type_for_step(std::size_t step) {
+  switch (step % 3) {
+  case 0:
+    return MSG_OBSERVE;
+  case 1:
+    return MSG_DECIDE;
+  default:
+    return MSG_ACT;
+  }
+}
+
+std::string step_kind(std::size_t step) {
+  switch (step % 3) {
+  case 0:
+    return "observe";
+  case 1:
+    return "decide";
+  default:
+    return "act";
+  }
+}
+} // namespace
+
+int main(int argc, char **argv) {
+  if (argc < 2) {
+    std::cerr << "usage: fact_ledger_host <journal-root-dir> [event-count]\n";
+    return 2;
+  }
+  const std::string root = argv[1];
+  const std::size_t n = argc >= 3 ? static_cast<std::size_t>(std::stoul(argv[2])) : 3;
+  if (n < 3) {
+    std::cerr << "event-count must be >= 3 (need a chain to verify)\n";
+    return 2;
+  }
+
+  // Location identity. A separate reader reconstructs the same identity to
+  // reopen the directory, so we print it as JSON for the driver / export tool.
+  const std::string group = "fact_ledger_slice";
+  const std::string name = "host";
+
+  auto locator = std::make_shared<data::locator>(root);
+  auto location = data::location::make_shared(longfist::enums::mode::LIVE, longfist::enums::category::SYSTEM, group, name,
+                                              locator);
+
+  // The whole point: a noop bus (no hero/drain loop) and a noop publisher (no
+  // nng socket). Nothing here starts the trading runtime.
+  auto bus = std::make_shared<journal::bus>(false);
+  auto publisher = std::make_shared<journal::noop_publisher>();
+  auto writer =
+      std::make_shared<journal::writer>(location, data::location::PUBLIC, /*lazy=*/true, publisher,
+                                        /*low_latency=*/false, bus);
+
+  uint64_t prev_uid = 0;   // 0 == root cause (no parent) for the first event
+  int64_t prev_gen_time = 0;
+
+  std::vector<nlohmann::json> chain; // for a human-readable stderr trace only
+
+  for (std::size_t i = 0; i < n; ++i) {
+    nlohmann::json payload = {
+        {"step", i},
+        {"kind", step_kind(i)},
+        {"note", "minimal fact-ledger slice event"},
+    };
+    const std::string body = payload.dump();
+
+    // Feed the causal parent explicitly, then open/close the frame. close_frame
+    // reads this value off the bus and stamps it into trigger_frame_uid.
+    bus->set_trigger_frame_uid(prev_uid);
+
+    const int64_t gen_time = time::now_in_nano();
+    auto frame = writer->open_frame(/*trigger_time=*/prev_gen_time, msg_type_for_step(i), body.size(), STREAM_ID);
+    frame->set_data_type(FrameDataType::Json);
+    std::memcpy(const_cast<void *>(frame->data_address()), body.data(), body.size());
+
+    // Capture the uid this frame will be stamped with, BEFORE close_frame's
+    // internal next() advances the shared frame object. This is the write-side
+    // canonical uid (writer::current_frame_uid), and it is what we feed as the
+    // next event's causal parent.
+    const uint64_t this_uid = writer->current_frame_uid();
+    writer->close_frame(body.size(), gen_time);
+
+    chain.push_back({{"step", i}, {"frame_uid", this_uid}, {"trigger_frame_uid", prev_uid}});
+    prev_uid = this_uid;
+    prev_gen_time = gen_time;
+  }
+
+  // Emit the location identity + the expected chain to stdout so the driver can
+  // locate the journal. Authoritative verification is done by the independent
+  // export tool re-deriving these from disk, not from this print.
+  nlohmann::json out = {
+      {"root", root},
+      {"mode", "LIVE"},
+      {"category", "SYSTEM"},
+      {"group", group},
+      {"name", name},
+      {"dest", data::location::PUBLIC},
+      {"event_count", n},
+      {"expected_chain", chain},
+  };
+  std::cout << out.dump(2) << std::endl;
+  return 0;
+}

--- a/framework/core/fact-ledger-slice/run_slice.sh
+++ b/framework/core/fact-ledger-slice/run_slice.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Drive the minimal fact-ledger slice end to end:
+#   1. run the host (write path); it exits
+#   2. run the independent export tool (read path) on the same directory
+#   3. verify the manifest's whole-segment checksum with the system shasum
+#
+# Usage: run_slice.sh [build-dir] [event-count]
+#   build-dir defaults to ../build (relative to framework/core)
+#   event-count defaults to 5
+
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+core_dir="$(cd "${here}/.." && pwd)"
+build_dir="${1:-${core_dir}/build}"
+event_count="${2:-5}"
+
+# Executables land in the project's global runtime output dir (build/Release);
+# fall back to the per-subdir location for other generators.
+find_bin() {
+  local name="$1"
+  for cand in "${build_dir}/Release/${name}" "${build_dir}/fact-ledger-slice/${name}" "${build_dir}/${name}"; do
+    if [[ -x "${cand}" ]]; then
+      echo "${cand}"
+      return 0
+    fi
+  done
+  return 1
+}
+
+host_bin="$(find_bin fact_ledger_host || true)"
+export_bin="$(find_bin fact_ledger_export || true)"
+
+if [[ -z "${host_bin}" || -z "${export_bin}" ]]; then
+  echo "error: fact_ledger_host / fact_ledger_export not found under ${build_dir}" >&2
+  echo "build first, e.g.:" >&2
+  echo "  cmake --build ${build_dir} --target fact_ledger_host fact_ledger_export" >&2
+  exit 1
+fi
+
+work="$(mktemp -d "${TMPDIR:-/tmp}/fact-ledger-slice.XXXXXX")"
+echo "== journal root: ${work}"
+
+echo "== step 1: host writes ${event_count} events, then exits"
+"${host_bin}" "${work}" "${event_count}"
+
+echo
+echo "== step 2: independent export tool reopens the directory"
+"${export_bin}" "${work}" fact_ledger_slice host "${work}/export"
+
+echo
+echo "== step 3: verify whole-segment checksum with system shasum"
+declared="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["event_log"]["segment_sha256"])' "${work}/export.manifest.json")"
+if command -v sha256sum >/dev/null 2>&1; then
+  recomputed="$(sha256sum "${work}/export.jsonl" | awk '{print $1}')"
+else
+  recomputed="$(shasum -a 256 "${work}/export.jsonl" | awk '{print $1}')"
+fi
+echo "declared:   ${declared}"
+echo "recomputed: ${recomputed}"
+if [[ "${declared}" != "${recomputed}" ]]; then
+  echo "FAIL: segment checksum mismatch" >&2
+  exit 1
+fi
+
+echo
+echo "== exported event log (${work}/export.jsonl):"
+cat "${work}/export.jsonl"
+echo
+echo "== run manifest (${work}/export.manifest.json):"
+cat "${work}/export.manifest.json"
+echo
+echo "OK: host wrote, independent tool reopened, checksum verified."
+echo "artifacts in ${work}"

--- a/framework/core/fact-ledger-slice/sha256.h
+++ b/framework/core/fact-ledger-slice/sha256.h
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Minimal, dependency-free SHA-256 (FIPS 180-4). Self-contained on purpose: the
+// run manifest's content checksums must be verifiable by anyone with a stock
+// `shasum -a 256` / `sha256sum`, without linking any crypto library. This is the
+// "content commitment" leg of the fact-ledger slice at the manifest layer (the
+// in-frame content hash of the full design is future work).
+
+#ifndef KUNGFU_FACT_LEDGER_SLICE_SHA256_H
+#define KUNGFU_FACT_LEDGER_SLICE_SHA256_H
+
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <string>
+
+namespace kungfu::fact_ledger_slice {
+
+class sha256 {
+public:
+  sha256() { reset(); }
+
+  void update(const void *data, std::size_t len) {
+    const auto *p = static_cast<const uint8_t *>(data);
+    for (std::size_t i = 0; i < len; ++i) {
+      buffer_[buffer_len_++] = p[i];
+      if (buffer_len_ == 64) {
+        transform(buffer_.data());
+        bit_len_ += 512;
+        buffer_len_ = 0;
+      }
+    }
+  }
+
+  void update(const std::string &s) { update(s.data(), s.size()); }
+
+  std::string hex_digest() {
+    std::array<uint8_t, 32> digest{};
+    finalize(digest.data());
+    static const char *hex = "0123456789abcdef";
+    std::string out;
+    out.reserve(64);
+    for (uint8_t b : digest) {
+      out.push_back(hex[b >> 4]);
+      out.push_back(hex[b & 0x0f]);
+    }
+    return out;
+  }
+
+  static std::string hex(const std::string &s) {
+    sha256 h;
+    h.update(s);
+    return h.hex_digest();
+  }
+
+private:
+  std::array<uint8_t, 64> buffer_{};
+  std::size_t buffer_len_ = 0;
+  uint64_t bit_len_ = 0;
+  std::array<uint32_t, 8> state_{};
+
+  void reset() {
+    buffer_len_ = 0;
+    bit_len_ = 0;
+    state_ = {0x6a09e667u, 0xbb67ae85u, 0x3c6ef372u, 0xa54ff53au,
+              0x510e527fu, 0x9b05688cu, 0x1f83d9abu, 0x5be0cd19u};
+  }
+
+  static uint32_t rotr(uint32_t x, uint32_t n) { return (x >> n) | (x << (32 - n)); }
+
+  void transform(const uint8_t *chunk) {
+    static const uint32_t k[64] = {
+        0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+        0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+        0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+        0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+        0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+        0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+        0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+        0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2};
+
+    uint32_t w[64];
+    for (int i = 0; i < 16; ++i) {
+      w[i] = (uint32_t(chunk[i * 4]) << 24) | (uint32_t(chunk[i * 4 + 1]) << 16) |
+             (uint32_t(chunk[i * 4 + 2]) << 8) | (uint32_t(chunk[i * 4 + 3]));
+    }
+    for (int i = 16; i < 64; ++i) {
+      uint32_t s0 = rotr(w[i - 15], 7) ^ rotr(w[i - 15], 18) ^ (w[i - 15] >> 3);
+      uint32_t s1 = rotr(w[i - 2], 17) ^ rotr(w[i - 2], 19) ^ (w[i - 2] >> 10);
+      w[i] = w[i - 16] + s0 + w[i - 7] + s1;
+    }
+
+    uint32_t a = state_[0], b = state_[1], c = state_[2], d = state_[3];
+    uint32_t e = state_[4], f = state_[5], g = state_[6], h = state_[7];
+    for (int i = 0; i < 64; ++i) {
+      uint32_t s1 = rotr(e, 6) ^ rotr(e, 11) ^ rotr(e, 25);
+      uint32_t ch = (e & f) ^ (~e & g);
+      uint32_t t1 = h + s1 + ch + k[i] + w[i];
+      uint32_t s0 = rotr(a, 2) ^ rotr(a, 13) ^ rotr(a, 22);
+      uint32_t maj = (a & b) ^ (a & c) ^ (b & c);
+      uint32_t t2 = s0 + maj;
+      h = g;
+      g = f;
+      f = e;
+      e = d + t1;
+      d = c;
+      c = b;
+      b = a;
+      a = t1 + t2;
+    }
+    state_[0] += a;
+    state_[1] += b;
+    state_[2] += c;
+    state_[3] += d;
+    state_[4] += e;
+    state_[5] += f;
+    state_[6] += g;
+    state_[7] += h;
+  }
+
+  void finalize(uint8_t *out) {
+    bit_len_ += static_cast<uint64_t>(buffer_len_) * 8;
+    buffer_[buffer_len_++] = 0x80;
+    if (buffer_len_ > 56) {
+      while (buffer_len_ < 64)
+        buffer_[buffer_len_++] = 0;
+      transform(buffer_.data());
+      buffer_len_ = 0;
+    }
+    while (buffer_len_ < 56)
+      buffer_[buffer_len_++] = 0;
+    for (int i = 7; i >= 0; --i)
+      buffer_[buffer_len_++] = static_cast<uint8_t>((bit_len_ >> (i * 8)) & 0xff);
+    transform(buffer_.data());
+    for (int i = 0; i < 8; ++i) {
+      out[i * 4] = static_cast<uint8_t>((state_[i] >> 24) & 0xff);
+      out[i * 4 + 1] = static_cast<uint8_t>((state_[i] >> 16) & 0xff);
+      out[i * 4 + 2] = static_cast<uint8_t>((state_[i] >> 8) & 0xff);
+      out[i * 4 + 3] = static_cast<uint8_t>(state_[i] & 0xff);
+    }
+  }
+};
+
+} // namespace kungfu::fact_ledger_slice
+
+#endif // KUNGFU_FACT_LEDGER_SLICE_SHA256_H


### PR DESCRIPTION
Two standalone tools embedding the yijinjing journal spine without the trading runtime: fact_ledger_host appends a causal chain of Json events and exits; fact_ledger_export independently reopens the directory and emits stable JSONL plus a run manifest with content checksums and an explicit capture boundary. Guarded behind KUNGFU_WITH_FACT_LEDGER_SLICE (default off); node/python bindings and existing behaviour untouched.