### PR TITLE
refactor(core): narrow the yijinjing namespace to the journal core

### DIFF
--- a/framework/core/src/bindings/node/binding/basket_instrument_store.h
+++ b/framework/core/src/bindings/node/binding/basket_instrument_store.h
@@ -37,7 +37,7 @@ private:
   serialize::JsGet get = {};
   serialize::JsSet set = {};
   yijinjing::data::locator_ptr locator_;
-  yijinjing::cache::profile profile_;
+  cache::profile profile_;
 
   static Napi::FunctionReference constructor;
   static void cleanup() {

--- a/framework/core/src/bindings/node/binding/basket_store.h
+++ b/framework/core/src/bindings/node/binding/basket_store.h
@@ -33,7 +33,7 @@ private:
   serialize::JsGet get = {};
   serialize::JsSet set = {};
   yijinjing::data::locator_ptr locator_;
-  yijinjing::cache::profile profile_;
+  cache::profile profile_;
 
   static Napi::FunctionReference constructor;
   static void cleanup() {

--- a/framework/core/src/bindings/node/binding/commission_store.h
+++ b/framework/core/src/bindings/node/binding/commission_store.h
@@ -38,7 +38,7 @@ private:
   serialize::JsGet get = {};
   serialize::JsSet set = {};
   yijinjing::data::locator_ptr locator_;
-  yijinjing::cache::profile profile_;
+  cache::profile profile_;
 
   static Napi::FunctionReference constructor;
   static void cleanup() {

--- a/framework/core/src/bindings/node/binding/config_store.h
+++ b/framework/core/src/bindings/node/binding/config_store.h
@@ -35,7 +35,7 @@ public:
 private:
   serialize::JsSet set;
   yijinjing::data::locator_ptr locator_;
-  yijinjing::cache::profile profile_;
+  cache::profile profile_;
 
   static Napi::FunctionReference constructor;
   static void cleanup() {

--- a/framework/core/src/bindings/node/binding/history.cpp
+++ b/framework/core/src/bindings/node/binding/history.cpp
@@ -14,7 +14,7 @@ using namespace kungfu::rx;
 using namespace kungfu::longfist;
 using namespace kungfu::longfist::enums;
 using namespace kungfu::longfist::types;
-using namespace kungfu::yijinjing::cache;
+using namespace kungfu::cache;
 using namespace kungfu::yijinjing;
 using namespace kungfu::yijinjing::data;
 
@@ -28,11 +28,11 @@ History::History(const Napi::CallbackInfo &info)
       profile_(locator_) {}
 
 Napi::Value History::SelectPeriod(const Napi::CallbackInfo &info) {
-  auto parse_time = [&](auto i) { return time::strptime(info[i].ToString().Utf8Value(), KUNGFU_HISTORY_DAY_FORMAT); };
+  auto parse_time = [&](auto i) { return yijinjing::time::strptime(info[i].ToString().Utf8Value(), KUNGFU_HISTORY_DAY_FORMAT); };
   try {
     int64_t from = parse_time(0);
-    int64_t to = info.Length() > 1 ? parse_time(1) : from + time_unit::NANOSECONDS_PER_DAY;
-    SPDLOG_INFO("select period from {} to {}", time::strftime(from), time::strftime(to));
+    int64_t to = info.Length() > 1 ? parse_time(1) : from + yijinjing::time_unit::NANOSECONDS_PER_DAY;
+    SPDLOG_INFO("select period from {} to {}", yijinjing::time::strftime(from), yijinjing::time::strftime(to));
     Napi::ObjectReference result_ref = Napi::ObjectReference::New(Napi::Object::New(info.Env()));
     serialize::InitStateMap(info, result_ref, "history");
     for (const auto &config : profile_.get_all(Config{})) {

--- a/framework/core/src/bindings/node/binding/history.h
+++ b/framework/core/src/bindings/node/binding/history.h
@@ -29,7 +29,7 @@ private:
   yijinjing::data::locator_ptr locator_;
   yijinjing::data::location_ptr ledger_location_;
   yijinjing::data::location_ptr renderer_location_;
-  yijinjing::cache::profile profile_;
+  cache::profile profile_;
   static Napi::FunctionReference constructor;
   static void cleanup() {
     SPDLOG_INFO("History reset");

--- a/framework/core/src/bindings/node/binding/op_publish_state.cpp
+++ b/framework/core/src/bindings/node/binding/op_publish_state.cpp
@@ -12,7 +12,7 @@ using namespace kungfu::longfist::enums;
 using namespace kungfu::longfist::types;
 using namespace kungfu::yijinjing;
 using namespace kungfu::yijinjing::data;
-using namespace kungfu::yijinjing::practice;
+using namespace kungfu::practice;
 
 namespace kungfu::node::serialize {
 JsPublishState::JsPublishState(apprentice &app, Napi::ObjectReference &state) : app_(app), state_(state) {}

--- a/framework/core/src/bindings/node/binding/op_reset_cache.cpp
+++ b/framework/core/src/bindings/node/binding/op_reset_cache.cpp
@@ -12,7 +12,7 @@ using namespace kungfu::longfist::enums;
 using namespace kungfu::longfist::types;
 using namespace kungfu::yijinjing;
 using namespace kungfu::yijinjing::data;
-using namespace kungfu::yijinjing::practice;
+using namespace kungfu::practice;
 
 namespace kungfu::node::serialize {
 JsResetCache::JsResetCache(apprentice &app, Napi::ObjectReference &state) : app_(app), state_(state) {}

--- a/framework/core/src/bindings/node/binding/op_restore_state.cpp
+++ b/framework/core/src/bindings/node/binding/op_restore_state.cpp
@@ -12,7 +12,7 @@ using namespace kungfu::longfist::enums;
 using namespace kungfu::longfist::types;
 using namespace kungfu::yijinjing;
 using namespace kungfu::yijinjing::data;
-using namespace kungfu::yijinjing::practice;
+using namespace kungfu::practice;
 
 namespace kungfu::node::serialize {
 JsRestoreState::JsRestoreState(Napi::ObjectReference &state, location_ptr location)
@@ -21,7 +21,7 @@ JsRestoreState::JsRestoreState(Napi::ObjectReference &state, location_ptr locati
 }
 
 void JsRestoreState::operator()(int64_t from, int64_t to, bool sync_schema) {
-  auto now = time::now_in_nano();
+  auto now = yijinjing::time::now_in_nano();
   auto source = location_->uid;
   auto locator = location_->locator;
 

--- a/framework/core/src/bindings/node/binding/operators.cpp
+++ b/framework/core/src/bindings/node/binding/operators.cpp
@@ -12,7 +12,7 @@ using namespace kungfu::longfist::enums;
 using namespace kungfu::longfist::types;
 using namespace kungfu::yijinjing;
 using namespace kungfu::yijinjing::data;
-using namespace kungfu::yijinjing::practice;
+using namespace kungfu::practice;
 
 namespace kungfu::node::serialize {
 void InitObjectReference(const Napi::CallbackInfo &info, Napi::ObjectReference &data) {

--- a/framework/core/src/bindings/node/binding/operators.h
+++ b/framework/core/src/bindings/node/binding/operators.h
@@ -309,7 +309,7 @@ public:
 
     for (auto dest : locator->list_location_dest_by_db(location_)) {
       auto db_file = locator->layout_file(location_, longfist::enums::layout::SQLITE, fmt::format("{:08x}", dest));
-      auto storage = yijinjing::cache::make_storage_ptr(db_file, longfist::StateDataTypes);
+      auto storage = cache::make_storage_ptr(db_file, longfist::StateDataTypes);
       if (sync_schema) {
         storage->sync_schema();
       }
@@ -320,7 +320,7 @@ public:
           return;
         }
 
-        for (const auto &data : yijinjing::cache::time_spec<DataType>::get_all(storage, from, to)) {
+        for (const auto &data : cache::time_spec<DataType>::get_all(storage, from, to)) {
           try {
             set(data, state_, source, dest, now);
           } catch (const std::exception &e) {
@@ -358,24 +358,24 @@ private:
 
 class JsPublishState {
 public:
-  JsPublishState(yijinjing::practice::apprentice &app, Napi::ObjectReference &state);
+  JsPublishState(practice::apprentice &app, Napi::ObjectReference &state);
 
   void operator()(Napi::Object object);
 
 private:
-  yijinjing::practice::apprentice &app_;
+  practice::apprentice &app_;
   Napi::ObjectReference &state_;
   JsGet get = {};
 };
 
 class JsResetCache {
 public:
-  JsResetCache(yijinjing::practice::apprentice &app, Napi::ObjectReference &state);
+  JsResetCache(practice::apprentice &app, Napi::ObjectReference &state);
 
   void operator()(const state<longfist::types::CacheReset> &state);
 
 private:
-  yijinjing::practice::apprentice &app_;
+  practice::apprentice &app_;
   Napi::ObjectReference &state_;
 };
 

--- a/framework/core/src/bindings/node/binding/risk_setting_store.h
+++ b/framework/core/src/bindings/node/binding/risk_setting_store.h
@@ -38,7 +38,7 @@ private:
   serialize::JsGet get = {};
   serialize::JsSet set = {};
   yijinjing::data::locator_ptr locator_;
-  yijinjing::cache::profile profile_;
+  cache::profile profile_;
 
   static Napi::FunctionReference constructor;
   static void cleanup() {

--- a/framework/core/src/bindings/node/binding/session_store.cpp
+++ b/framework/core/src/bindings/node/binding/session_store.cpp
@@ -19,13 +19,13 @@ SessionStore::SessionStore(const Napi::CallbackInfo &info)
 SessionStore::~SessionStore() { io_device_.reset(); }
 
 Napi::Value SessionStore::GetAllSessions(const Napi::CallbackInfo &info) {
-  auto session_finder = std::make_shared<yijinjing::index::session_finder>(io_device_);
+  auto session_finder = std::make_shared<index::session_finder>(io_device_);
   auto sessions = session_finder->find_sessions(time::restore_start(), INT64_MAX);
   return ParseSessions(info, sessions);
 }
 
 Napi::Value SessionStore::GetSessionsForLocation(const Napi::CallbackInfo &info) {
-  auto session_finder = std::make_shared<yijinjing::index::session_finder>(io_device_);
+  auto session_finder = std::make_shared<index::session_finder>(io_device_);
   auto location = IODevice::ExtractLocation(info, 0, io_device_->get_locator());
   auto sessions = session_finder->find_sessions_for(location, time::restore_start(), INT64_MAX);
   return ParseSessions(info, sessions);

--- a/framework/core/src/bindings/node/binding/session_store.h
+++ b/framework/core/src/bindings/node/binding/session_store.h
@@ -28,7 +28,7 @@ private:
   serialize::JsSet set;
   yijinjing::io_device_ptr io_device_;
 
-  Napi::Value ParseSessions(const Napi::CallbackInfo &info, yijinjing::index::SessionVector sessions) {
+  Napi::Value ParseSessions(const Napi::CallbackInfo &info, index::SessionVector sessions) {
     size_t session_size = sessions.size();
     auto list = Napi::Array::New(info.Env(), session_size);
     for (int i = 0; i < session_size; i++) {

--- a/framework/core/src/bindings/node/binding/watcher.cpp
+++ b/framework/core/src/bindings/node/binding/watcher.cpp
@@ -23,7 +23,7 @@ using namespace kungfu::longfist::types;
 using namespace kungfu::wingchun;
 using namespace kungfu::wingchun::map;
 using namespace kungfu::yijinjing;
-using namespace kungfu::yijinjing::cache;
+using namespace kungfu::cache;
 using namespace kungfu::yijinjing::data;
 
 namespace kungfu::node {
@@ -48,7 +48,7 @@ inline location_ptr GetWatcherLocation(const Napi::CallbackInfo &info) {
   auto name = info[1].As<Napi::String>().Utf8Value();
   auto result =
       std::make_shared<location>(mode::LIVE, category::SYSTEM, "node", name, IODevice::GetRuntimeLocator(runtime_dir));
-  log::copy_log_settings(result, result->name);
+  yijinjing::log::copy_log_settings(result, result->name);
   return result;
 }
 
@@ -85,7 +85,7 @@ Watcher::Watcher(const Napi::CallbackInfo &info)
 
   serialize::InitStateMap(info, ledger_ref_, "ledger");
 
-  auto today = time::restore_start();
+  auto today = yijinjing::time::restore_start();
   auto config_store = ConfigStore::Unwrap(config_ref_.Value());
 
   bool sync_schema = not get_io_device()->is_usable();
@@ -182,7 +182,7 @@ Napi::Value Watcher::GetAppStates(const Napi::CallbackInfo &info) { return app_s
 Napi::Value Watcher::GetStrategyStates(const Napi::CallbackInfo &info) { return strategy_states_ref_.Value(); }
 
 Napi::Value Watcher::Now(const Napi::CallbackInfo &info) {
-  return Napi::BigInt::New(ledger_ref_.Env(), time::now_in_nano());
+  return Napi::BigInt::New(ledger_ref_.Env(), yijinjing::time::now_in_nano());
 }
 
 Napi::Value Watcher::IsUsable(const Napi::CallbackInfo &info) { return Napi::Boolean::New(info.Env(), is_usable()); }
@@ -266,7 +266,7 @@ Napi::Value Watcher::IssueMark(const Napi::CallbackInfo &info) {
   if (not has_writer(target_location->location_uid)) {
     return Napi::Boolean::New(info.Env(), false);
   }
-  get_writer(target_location->location_uid)->mark(time::now_in_nano(), tag);
+  get_writer(target_location->location_uid)->mark(yijinjing::time::now_in_nano(), tag);
   return Napi::Boolean::New(info.Env(), true);
 }
 
@@ -386,7 +386,7 @@ void Watcher::on_react() {
 
 bool Watcher::has_writer(uint32_t dest_id) const { return writers_.find(dest_id) != writers_.end(); }
 
-journal::writer_ptr Watcher::get_writer(uint32_t dest_id) const {
+yijinjing::journal::writer_ptr Watcher::get_writer(uint32_t dest_id) const {
   if (writers_.find(dest_id) == writers_.end()) {
     SPDLOG_ERROR("no writer for {}", get_location_uname(dest_id));
   }
@@ -656,7 +656,7 @@ void Watcher::StartWorker() {
     }
 
     watcher->AfterMasterDown(info);
-    watcher->set_begin_time(time::now_in_nano());
+    watcher->set_begin_time(yijinjing::time::now_in_nano());
     SPDLOG_INFO("Restart watcher uv loop");
     // master may quit within watcher running time,
     // so, once master deregistered, the uv logic in watcher need to be restarte.

--- a/framework/core/src/bindings/node/binding/watcher.h
+++ b/framework/core/src/bindings/node/binding/watcher.h
@@ -25,7 +25,7 @@ constexpr uint32_t PAGE_ID_MASK = 0x80000000;
 constexpr uint32_t TRANSFER_STATIC_DATA_LIMIT = 2000;
 constexpr uint32_t TRANSFER_TRADING_DATA_LIMIT = 2000;
 
-class Watcher : public Napi::ObjectWrap<Watcher>, public yijinjing::practice::apprentice {
+class Watcher : public Napi::ObjectWrap<Watcher>, public practice::apprentice {
   typedef std::unordered_map<uint32_t, longfist::types::InstrumentKey> InstrumentKeyMap;
 
 public:
@@ -140,9 +140,9 @@ private:
   Napi::ObjectReference config_ref_;
   serialize::JsUpdateState update_ledger;
   serialize::JsResetCache reset_cache;
-  yijinjing::cache::bank data_bank_;
-  yijinjing::cache::bank trading_data_bank_;
-  yijinjing::cache::deque_bank trading_data_cached_bank_;
+  cache::bank data_bank_;
+  cache::bank trading_data_bank_;
+  cache::deque_bank trading_data_cached_bank_;
   std::vector<kungfu::state<longfist::types::CacheReset>> reset_cache_states_;
   InstrumentKeyMap subscribed_instruments_ = {};
   std::unordered_map<uint32_t, int> broker_states_map_ = {};
@@ -154,7 +154,7 @@ private:
   typedef longfist::enums::mode mode;
   typedef longfist::enums::category category;
 
-  static constexpr auto bypass = [](yijinjing::practice::apprentice *app, bool bypass_quotes) {
+  static constexpr auto bypass = [](practice::apprentice *app, bool bypass_quotes) {
     return rx::filter([&](const event_ptr &event) {
       return not(app->get_location(event->source())->category == longfist::enums::category::MD and
                  event->msg_type() != longfist::types::Instrument::tag and bypass_quotes);

--- a/framework/core/src/bindings/python/binding/py-wingchun-broker.cpp
+++ b/framework/core/src/bindings/python/binding/py-wingchun-broker.cpp
@@ -107,7 +107,7 @@ public:
 };
 
 void bind_broker(pybind11::module &m) {
-  py::class_<BrokerVendor, PyBrokerVendor, kungfu::yijinjing::practice::apprentice, std::shared_ptr<BrokerVendor>>(
+  py::class_<BrokerVendor, PyBrokerVendor, kungfu::practice::apprentice, std::shared_ptr<BrokerVendor>>(
       m, "BrokerVendor")
       .def(py::init<location_ptr, bool, const std::string &>());
 

--- a/framework/core/src/bindings/python/binding/py-wingchun-operator.cpp
+++ b/framework/core/src/bindings/python/binding/py-wingchun-operator.cpp
@@ -90,7 +90,7 @@ public:
 
 void bind_operator(pybind11::module &m) {
 
-  py::class_<op::Runner, PyOpRunner, kungfu::yijinjing::practice::apprentice, std::shared_ptr<op::Runner>>(m,
+  py::class_<op::Runner, PyOpRunner, kungfu::practice::apprentice, std::shared_ptr<op::Runner>>(m,
                                                                                                            "OpRunner")
       .def(py::init<kungfu::yijinjing::data::locator_ptr, const std::string &, const std::string &,
                     longfist::enums::mode, bool, const std::string &>())

--- a/framework/core/src/bindings/python/binding/py-wingchun-service.cpp
+++ b/framework/core/src/bindings/python/binding/py-wingchun-service.cpp
@@ -8,7 +8,7 @@ using namespace kungfu::longfist::enums;
 using namespace kungfu::longfist::types;
 using namespace kungfu::yijinjing::data;
 using namespace kungfu::yijinjing::journal;
-using namespace kungfu::yijinjing::practice;
+using namespace kungfu::practice;
 using namespace kungfu::wingchun::service;
 
 namespace py = pybind11;

--- a/framework/core/src/bindings/python/binding/py-wingchun-strategy.cpp
+++ b/framework/core/src/bindings/python/binding/py-wingchun-strategy.cpp
@@ -165,7 +165,7 @@ public:
 
 void bind_strategy(pybind11::module &m) {
 
-  py::class_<strategy::Runner, PyRunner, kungfu::yijinjing::practice::apprentice, std::shared_ptr<strategy::Runner>>(
+  py::class_<strategy::Runner, PyRunner, kungfu::practice::apprentice, std::shared_ptr<strategy::Runner>>(
       m, "Runner")
       .def(py::init<kungfu::yijinjing::data::locator_ptr, const std::string &, const std::string &,
                     longfist::enums::mode, bool, const std::string &>())

--- a/framework/core/src/bindings/python/binding/py-wingchun-streamdatabatcher.cpp
+++ b/framework/core/src/bindings/python/binding/py-wingchun-streamdatabatcher.cpp
@@ -104,7 +104,7 @@ void bind_stream_data_batcher(pybind11::module &m) {
 
   py::class_<BackTestStreamDataBatcher, std::shared_ptr<BackTestStreamDataBatcher>, StreamDataBatcher>(
       m, "BackTestStreamDataBatcher")
-      .def(py::init<yijinjing::practice::apprentice &, tool::SliceIndexer_ptr>(), py::arg("app"),
+      .def(py::init<practice::apprentice &, tool::SliceIndexer_ptr>(), py::arg("app"),
            py::arg("from_indexer"));
 
   py::class_<LiveStreamDataBatcher, std::shared_ptr<LiveStreamDataBatcher>, StreamDataBatcher>(m,

--- a/framework/core/src/bindings/python/binding/py-yijinjing.cpp
+++ b/framework/core/src/bindings/python/binding/py-yijinjing.cpp
@@ -21,12 +21,12 @@
 using namespace kungfu::longfist;
 using namespace kungfu::longfist::types;
 using namespace kungfu::longfist::enums;
-using namespace kungfu::yijinjing::cache;
+using namespace kungfu::cache;
 using namespace kungfu::yijinjing::data;
-using namespace kungfu::yijinjing::index;
+using namespace kungfu::index;
 using namespace kungfu::yijinjing::journal;
 using namespace kungfu::yijinjing::nanomsg;
-using namespace kungfu::yijinjing::practice;
+using namespace kungfu::practice;
 
 namespace py = pybind11;
 
@@ -104,7 +104,7 @@ public:
 
 class PySink : public sink {
 public:
-  void put(const data::location_ptr &location, uint32_t dest_id, const frame_ptr &frame) override {
+  void put(const yijinjing::data::location_ptr &location, uint32_t dest_id, const frame_ptr &frame) override {
     PYBIND11_OVERLOAD_PURE(void, sink, put, location, dest_id, frame);
   }
   void close() override { PYBIND11_OVERLOAD(void, sink, close); }
@@ -142,38 +142,38 @@ void bind(pybind11::module &&m) {
   yijinjing::ensure_sqlite_initilize();
 
   // nanosecond-time related
-  m.def("now_in_nano", &time::now_in_nano);
-  m.def("nano_hashed", &time::nano_hashed);
-  m.def("next_minute", &time::next_minute);
-  m.def("next_trading_day_end", &time::next_trading_day_end);
-  m.def("calendar_day_start", &time::calendar_day_start);
-  m.def("today_start", &time::today_start);
-  m.def("trading_day_start", &time::trading_day_start);
-  m.def("restore_start", &time::restore_start);
-  m.def("strftime", &time::strftime, py::arg("nanotime"), py::arg("format") = KUNGFU_TIMESTAMP_FORMAT);
-  m.def("strptime", py::overload_cast<const std::string &, const std::string &>(&time::strptime), py::arg("timestr"),
+  m.def("now_in_nano", &yijinjing::time::now_in_nano);
+  m.def("nano_hashed", &yijinjing::time::nano_hashed);
+  m.def("next_minute", &yijinjing::time::next_minute);
+  m.def("next_trading_day_end", &yijinjing::time::next_trading_day_end);
+  m.def("calendar_day_start", &yijinjing::time::calendar_day_start);
+  m.def("today_start", &yijinjing::time::today_start);
+  m.def("trading_day_start", &yijinjing::time::trading_day_start);
+  m.def("restore_start", &yijinjing::time::restore_start);
+  m.def("strftime", &yijinjing::time::strftime, py::arg("nanotime"), py::arg("format") = KUNGFU_TIMESTAMP_FORMAT);
+  m.def("strptime", py::overload_cast<const std::string &, const std::string &>(&yijinjing::time::strptime), py::arg("timestr"),
         py::arg("format") = KUNGFU_TIMESTAMP_FORMAT);
-  m.def("strfnow", &time::strfnow, py::arg("format") = KUNGFU_TIMESTAMP_FORMAT);
+  m.def("strfnow", &yijinjing::time::strfnow, py::arg("format") = KUNGFU_TIMESTAMP_FORMAT);
 
   m.def("get_page_path", &page::get_page_path);
 
-  m.def("thread_id", &util::get_thread_id);
-  m.def("in_color_terminal", &util::in_color_terminal);
-  m.def("color_print", &util::color_print);
+  m.def("thread_id", &yijinjing::util::get_thread_id);
+  m.def("in_color_terminal", &yijinjing::util::in_color_terminal);
+  m.def("color_print", &yijinjing::util::color_print);
 
-  m.def("hash_32", &util::hash_32, py::arg("key"), py::arg("length"), py::arg("seed") = KUNGFU_HASH_SEED);
-  m.def("hash_str_32", &util::hash_str_32, py::arg("key"), py::arg("seed") = KUNGFU_HASH_SEED);
+  m.def("hash_32", &yijinjing::util::hash_32, py::arg("key"), py::arg("length"), py::arg("seed") = KUNGFU_HASH_SEED);
+  m.def("hash_str_32", &yijinjing::util::hash_str_32, py::arg("key"), py::arg("seed") = KUNGFU_HASH_SEED);
 
-  m.def("setup_log", &log::setup_log);
-  m.def("emit_log", &log::emit_log);
+  m.def("setup_log", &yijinjing::log::setup_log);
+  m.def("emit_log", &yijinjing::log::emit_log);
 
-  py::enum_<nanomsg::protocol>(m, "protocol", py::arithmetic(), "Nanomsg Protocol")
-      .value("REPLY", nanomsg::protocol::REPLY)
-      .value("REQUEST", nanomsg::protocol::REQUEST)
-      .value("PUSH", nanomsg::protocol::PUSH)
-      .value("PULL", nanomsg::protocol::PULL)
-      .value("PUBLISH", nanomsg::protocol::PUBLISH)
-      .value("SUBSCRIBE", nanomsg::protocol::SUBSCRIBE)
+  py::enum_<yijinjing::nanomsg::protocol>(m, "protocol", py::arithmetic(), "Nanomsg Protocol")
+      .value("REPLY", yijinjing::nanomsg::protocol::REPLY)
+      .value("REQUEST", yijinjing::nanomsg::protocol::REQUEST)
+      .value("PUSH", yijinjing::nanomsg::protocol::PUSH)
+      .value("PULL", yijinjing::nanomsg::protocol::PULL)
+      .value("PUBLISH", yijinjing::nanomsg::protocol::PUBLISH)
+      .value("SUBSCRIBE", yijinjing::nanomsg::protocol::SUBSCRIBE)
       .export_values();
 
   auto event_class = py::class_<event, PyEvent, std::shared_ptr<event>>(m, "event");
@@ -229,7 +229,7 @@ void bind(pybind11::module &&m) {
            py::arg("name") = "*", py::arg("mode") = "*")
       .def("list_location_dest", &locator::list_location_dest);
 
-  py::class_<nanomsg::socket, socket_ptr>(m, "socket")
+  py::class_<yijinjing::nanomsg::socket, socket_ptr>(m, "socket")
       .def(py::init<protocol>(), py::arg("protocol"))
       .def("setsockopt", &socket::setsockopt_str, py::arg("option"), py::arg("value"))
       .def("setsockopt", &socket::setsockopt_int, py::arg("option"), py::arg("value"))
@@ -268,7 +268,7 @@ void bind(pybind11::module &&m) {
 
   auto writer_class = py::class_<writer, writer_ptr>(m, "writer");
   writer_class
-      .def(py::init<const data::location_ptr &, uint32_t, bool, publisher_ptr, bool, const bus_ptr &, uint32_t>())
+      .def(py::init<const yijinjing::data::location_ptr &, uint32_t, bool, publisher_ptr, bool, const bus_ptr &, uint32_t>())
       .def("current_frame_uid", &writer::current_frame_uid)
       .def("get_location", &writer::get_location)
       .def("get_dest", &writer::get_dest)
@@ -295,16 +295,16 @@ void bind(pybind11::module &&m) {
   py::class_<null_sink, sink, std::shared_ptr<null_sink>>(m, "null_sink").def(py::init<>());
 
   py::class_<copy_sink, sink, std::shared_ptr<copy_sink>>(m, "copy_sink")
-      .def(py::init<data::locator_ptr>())
+      .def(py::init<yijinjing::data::locator_ptr>())
       .def("put", &copy_sink::put);
 
   auto assemble_class = py::class_<assemble, assemble_ptr>(m, "assemble");
   assemble_class
-      .def(py::init<const std::vector<data::locator_ptr> &, const std::string &, const std::string &,
+      .def(py::init<const std::vector<yijinjing::data::locator_ptr> &, const std::string &, const std::string &,
                     const std::string &, const std::string &>(),
            py::arg("locators"), py::arg("mode") = "*", py::arg("category") = "*", py::arg("group") = "*",
            py::arg("name") = "*")
-      .def(py::init<const data::location_ptr &, uint32_t, uint32_t, int64_t>(), py::arg("source_location"),
+      .def(py::init<const yijinjing::data::location_ptr &, uint32_t, uint32_t, int64_t>(), py::arg("source_location"),
            py::arg("dest_id"), py::arg("assemble_mode") = longfist::enums::AssembleMode::Channel,
            py::arg("from_time") = 0)
       .def("read_headers", (std::vector<frame_header>(assemble::*)(int32_t, int64_t)) & assemble::read_headers,
@@ -329,7 +329,7 @@ void bind(pybind11::module &&m) {
                        py::arg("data") = DataType{}, py::arg("end_time") = INT64_MAX, py::return_value_policy::move);
   });
 
-  py::class_<io_device, io_device_ptr>(m, "io_device")
+  py::class_<io_device, yijinjing::io_device_ptr>(m, "io_device")
       .def(py::init<location_ptr, bool, bool>(), py::arg("home"), py::arg("low_latency") = false,
            py::arg("lazy") = true)
       .def_property_readonly("publisher", &io_device::get_publisher)
@@ -343,25 +343,25 @@ void bind(pybind11::module &&m) {
       .def("open_reader_to_subscribe", &io_device::open_reader_to_subscribe)
       .def("open_writer", &io_device::open_writer);
 
-  py::class_<io_device_master, io_device, io_device_master_ptr>(m, "io_device_master")
+  py::class_<yijinjing::io_device_master, io_device, io_device_master_ptr>(m, "yijinjing::io_device_master")
       .def(py::init<location_ptr, bool>(), py::arg("home"), py::arg("low_latency"));
 
-  py::class_<io_device_client, io_device, io_device_client_ptr>(m, "io_device_client")
+  py::class_<yijinjing::io_device_client, io_device, io_device_client_ptr>(m, "yijinjing::io_device_client")
       .def(py::init<location_ptr, bool>(), py::arg("home"), py::arg("low_latency"));
 
-  py::class_<io_device_console, io_device, io_device_console_ptr>(m, "io_device_console")
+  py::class_<yijinjing::io_device_console, io_device, io_device_console_ptr>(m, "yijinjing::io_device_console")
       .def(py::init<location_ptr, uint32_t, uint32_t>(), py::arg("home"), py::arg("width"), py::arg("height"))
-      .def("trace", &io_device_console::trace)
-      .def("show", &io_device_console::show);
+      .def("trace", &yijinjing::io_device_console::trace)
+      .def("show", &yijinjing::io_device_console::show);
 
   py::class_<session_finder, std::shared_ptr<session_finder>>(m, "session_finder")
-      .def(py::init<io_device_ptr>())
+      .def(py::init<yijinjing::io_device_ptr>())
       .def("find_sessions", &session_finder::find_sessions, py::arg("from") = 0, py::arg("to") = INT64_MAX)
       .def("find_sessions_for", &session_finder::find_sessions_for, py::arg("source"), py::arg("from") = 0,
            py::arg("to") = INT64_MAX);
 
   py::class_<session_builder, session_finder, std::shared_ptr<session_builder>>(m, "session_builder")
-      .def(py::init<io_device_ptr>())
+      .def(py::init<yijinjing::io_device_ptr>())
       .def("rebuild_index_db", &session_builder::rebuild_index_db)
       .def("update_index_db", &session_builder::update_index_db);
 

--- a/framework/core/src/include/kungfu/wingchun/book/bookkeeper.h
+++ b/framework/core/src/include/kungfu/wingchun/book/bookkeeper.h
@@ -27,7 +27,7 @@ DECLARE_PTR(BookListener)
 
 class Bookkeeper {
 public:
-  explicit Bookkeeper(yijinjing::practice::apprentice &app, broker::Client &broker_client, bool bypass_quote = false,
+  explicit Bookkeeper(practice::apprentice &app, broker::Client &broker_client, bool bypass_quote = false,
                       bool bypass_replace_trading_data = false);
 
   virtual ~Bookkeeper() = default;
@@ -50,7 +50,7 @@ public:
   void on_algo_order_input(int64_t update_time, uint32_t source, uint32_t dest,
                            const longfist::types::AlgoOrderInput &input);
 
-  void restore(const yijinjing::cache::bank &state_bank);
+  void restore(const cache::bank &state_bank);
 
   void guard_positions();
 
@@ -148,7 +148,7 @@ public:
   }
 
 private:
-  yijinjing::practice::apprentice &app_;
+  practice::apprentice &app_;
   broker::Client &broker_client_;
   book::StaticData static_data_;
   const bool bypass_quote_;

--- a/framework/core/src/include/kungfu/wingchun/book/staticdata.h
+++ b/framework/core/src/include/kungfu/wingchun/book/staticdata.h
@@ -9,13 +9,13 @@ namespace kungfu::wingchun::book {
 
 class StaticData {
 public:
-  explicit StaticData(yijinjing::practice::apprentice &app);
+  explicit StaticData(practice::apprentice &app);
 
   virtual ~StaticData() = default;
 
   void on_start(const rx::connectable_observable<event_ptr> &events);
 
-  void restore(const yijinjing::cache::bank &state_bank);
+  void restore(const cache::bank &state_bank);
 
   const map::BasketMap &get_baskets() const { return baskets_; }
 
@@ -28,7 +28,7 @@ public:
   const map::InstrumentFactorMap &get_instrument_factors() const { return instrument_factors_; }
 
 private:
-  yijinjing::practice::apprentice &app_;
+  practice::apprentice &app_;
   map::BasketMap baskets_ = {};
   map::BasketInstrumentMap basket_instruments_ = {};
   map::CommissionMap commissions_ = {};

--- a/framework/core/src/include/kungfu/wingchun/broker/broker.h
+++ b/framework/core/src/include/kungfu/wingchun/broker/broker.h
@@ -18,7 +18,7 @@ namespace kungfu::wingchun::broker {
 FORWARD_DECLARE_CLASS_PTR(BrokerVendor)
 FORWARD_DECLARE_CLASS_PTR(BrokerService)
 
-class BrokerVendor : public yijinjing::practice::apprentice {
+class BrokerVendor : public practice::apprentice {
 public:
   typedef yijinjing::data::locator_ptr locator_ptr;
   typedef yijinjing::data::location_ptr location_ptr;
@@ -107,7 +107,7 @@ public:
     vendor_.try_write_raw_to(trigger_time, msg_type, data, length, dest_id);
   }
 
-  [[nodiscard]] const yijinjing::cache::bank &get_state_bank() const;
+  [[nodiscard]] const cache::bank &get_state_bank() const;
 
   [[nodiscard]] bool check_if_stored_instruments(const std::string &trading_day) const;
 

--- a/framework/core/src/include/kungfu/wingchun/broker/client.h
+++ b/framework/core/src/include/kungfu/wingchun/broker/client.h
@@ -18,10 +18,10 @@ namespace kungfu::wingchun::broker {
  * Policy interface to decide the time point to resume when connecting to a broker.
  */
 struct ResumePolicy {
-  [[nodiscard]] virtual int64_t get_connect_time(const yijinjing::practice::apprentice &app,
+  [[nodiscard]] virtual int64_t get_connect_time(const practice::apprentice &app,
                                                  const longfist::types::Register &target) const;
 
-  [[nodiscard]] virtual int64_t get_resume_time(const yijinjing::practice::apprentice &app,
+  [[nodiscard]] virtual int64_t get_resume_time(const practice::apprentice &app,
                                                 const longfist::types::Register &target) const = 0;
 };
 
@@ -31,7 +31,7 @@ DECLARE_PTR(ResumePolicy);
  * Always resume from the last unread frame, is intended to be used by system services that needs continuity.
  */
 struct StatelessResumePolicy : public ResumePolicy {
-  [[nodiscard]] int64_t get_resume_time(const yijinjing::practice::apprentice &app,
+  [[nodiscard]] int64_t get_resume_time(const practice::apprentice &app,
                                         const longfist::types::Register &target) const override;
 };
 
@@ -39,7 +39,7 @@ struct StatelessResumePolicy : public ResumePolicy {
  * Always resume from the last unread frame, is intended to be used by system services that needs continuity.
  */
 struct ContinuousResumePolicy : public ResumePolicy {
-  [[nodiscard]] int64_t get_resume_time(const yijinjing::practice::apprentice &app,
+  [[nodiscard]] int64_t get_resume_time(const practice::apprentice &app,
                                         const longfist::types::Register &target) const override;
 };
 
@@ -48,15 +48,15 @@ struct ContinuousResumePolicy : public ResumePolicy {
  * This policy ensures the client does not look back data before today, is intended to be used by strategies.
  */
 struct IntradayResumePolicy : public ResumePolicy {
-  [[nodiscard]] int64_t get_resume_time(const yijinjing::practice::apprentice &app,
+  [[nodiscard]] int64_t get_resume_time(const practice::apprentice &app,
                                         const longfist::types::Register &target) const override;
 };
 
 struct FromNowResumePolicy : public ResumePolicy {
-  [[nodiscard]] int64_t get_connect_time(const yijinjing::practice::apprentice &app,
+  [[nodiscard]] int64_t get_connect_time(const practice::apprentice &app,
                                          const longfist::types::Register &target) const override;
 
-  [[nodiscard]] int64_t get_resume_time(const yijinjing::practice::apprentice &app,
+  [[nodiscard]] int64_t get_resume_time(const practice::apprentice &app,
                                         const longfist::types::Register &target) const override;
 };
 
@@ -71,7 +71,7 @@ class Client {
   typedef std::unordered_map<uint32_t, yijinjing::data::location_ptr> InstrumentSourceMap;
 
 public:
-  explicit Client(yijinjing::practice::apprentice &app);
+  explicit Client(practice::apprentice &app);
 
   virtual ~Client() = default;
 
@@ -142,7 +142,7 @@ public:
   [[nodiscard]] bool has_channel(uint32_t source, uint32_t dest) const { return app_.has_channel(source, dest); }
 
 protected:
-  yijinjing::practice::apprentice &app_;
+  practice::apprentice &app_;
 
 private:
   BrokerStateMap broker_states_ = {};
@@ -208,7 +208,7 @@ private:
  */
 class AutoClient : public Client {
 public:
-  explicit AutoClient(yijinjing::practice::apprentice &app);
+  explicit AutoClient(practice::apprentice &app);
 
   [[nodiscard]] ResumePolicy_ptr get_resume_policy() const override;
 
@@ -249,7 +249,7 @@ private:
  */
 class SilentAutoClient : public AutoClient {
 public:
-  explicit SilentAutoClient(yijinjing::practice::apprentice &app);
+  explicit SilentAutoClient(practice::apprentice &app);
 
   // [[nodiscard]] bool is_subscribed(const std::string &exchange_id, const std::string &instrument_id) const override;
 
@@ -267,7 +267,7 @@ class PassiveClient : public Client {
   typedef std::unordered_map<uint32_t, std::vector<longfist::types::CustomSubscribe>> CustomSubscribeMap;
 
 public:
-  explicit PassiveClient(yijinjing::practice::apprentice &app);
+  explicit PassiveClient(practice::apprentice &app);
 
   [[nodiscard]] ResumePolicy_ptr get_resume_policy() const override;
 

--- a/framework/core/src/include/kungfu/wingchun/extension.h
+++ b/framework/core/src/include/kungfu/wingchun/extension.h
@@ -19,7 +19,7 @@
   m.def("service",                                                                                                     \
         [&](kungfu::yijinjing::data::locator_ptr locator, const std::string &group, const std::string &name,           \
             kungfu::longfist::enums::mode m, bool low_latency = false, const std::string &arguments = "{}") {          \
-          return std::static_pointer_cast<kungfu::yijinjing::practice::apprentice>(                                    \
+          return std::static_pointer_cast<kungfu::practice::apprentice>(                                    \
               std::make_shared<ServiceType>(locator, group, name, m, low_latency, arguments));                         \
         })
 

--- a/framework/core/src/include/kungfu/wingchun/factor/backteststreamdatabatcher.h
+++ b/framework/core/src/include/kungfu/wingchun/factor/backteststreamdatabatcher.h
@@ -17,7 +17,7 @@ namespace kungfu::wingchun::factor {
 
 class BackTestStreamDataBatcher : public StreamDataBatcher {
 public:
-  BackTestStreamDataBatcher(yijinjing::practice::apprentice &app, tool::SliceIndexer_ptr from_indexer)
+  BackTestStreamDataBatcher(practice::apprentice &app, tool::SliceIndexer_ptr from_indexer)
       : app_(app), from_indexer_(std::move(from_indexer)) {}
   ~BackTestStreamDataBatcher() = default;
 
@@ -129,7 +129,7 @@ protected:
   }
 
 private:
-  yijinjing::practice::apprentice &app_;
+  practice::apprentice &app_;
   tool::SliceIndexer_ptr from_indexer_;
   std::unordered_map<std::string, int64_t> time_stamp_map_;
   int64_t get_begin_time(const std::string instrument_exchange_type_id);

--- a/framework/core/src/include/kungfu/wingchun/factor/crosssection.h
+++ b/framework/core/src/include/kungfu/wingchun/factor/crosssection.h
@@ -91,9 +91,9 @@ private:
     int64_t time;
     double price;
   };
-  friend void set_runner(MultiCrossSectionalFactor &factor_cache, yijinjing::practice::apprentice *runner);
+  friend void set_runner(MultiCrossSectionalFactor &factor_cache, practice::apprentice *runner);
 
-  yijinjing::practice::apprentice *app_;
+  practice::apprentice *app_;
   std::map<std::string, std::unordered_map<std::string, double>> multi_cross_sectional_factor_cache_;
   std::unordered_map<std::string, TimeStampPrice> price_cache_;
 };

--- a/framework/core/src/include/kungfu/wingchun/operator/backtest.h
+++ b/framework/core/src/include/kungfu/wingchun/operator/backtest.h
@@ -11,7 +11,7 @@
 namespace kungfu::wingchun::op {
 class BacktestContext : public Context {
 public:
-  explicit BacktestContext(yijinjing::practice::apprentice &app, const rx::connectable_observable<event_ptr> &events,
+  explicit BacktestContext(practice::apprentice &app, const rx::connectable_observable<event_ptr> &events,
                            tool::SliceIndexer_ptr from_indexer, tool::SliceIndexer_ptr to_indexer,
                            tool::Report_ptr report, int64_t time_interval, std::string backtest_config);
 

--- a/framework/core/src/include/kungfu/wingchun/operator/context.h
+++ b/framework/core/src/include/kungfu/wingchun/operator/context.h
@@ -17,7 +17,7 @@
 namespace kungfu::wingchun::op {
 class Context : public std::enable_shared_from_this<Context> {
 public:
-  Context(yijinjing::practice::apprentice &app, const rx::connectable_observable<event_ptr> &events);
+  Context(practice::apprentice &app, const rx::connectable_observable<event_ptr> &events);
 
   virtual ~Context() = default;
 
@@ -177,7 +177,7 @@ public:
   virtual std::shared_ptr<wingchun::factor::StreamDataBatcher> batch_streaming() = 0;
 
 protected:
-  yijinjing::practice::apprentice &app_;
+  practice::apprentice &app_;
   const rx::connectable_observable<event_ptr> &events_;
   std::string operator_dir_;
   bool started_ = false;

--- a/framework/core/src/include/kungfu/wingchun/operator/live.h
+++ b/framework/core/src/include/kungfu/wingchun/operator/live.h
@@ -8,7 +8,7 @@
 namespace kungfu::wingchun::op {
 class LiveContext : public Context {
 public:
-  explicit LiveContext(yijinjing::practice::apprentice &app, const rx::connectable_observable<event_ptr> &events);
+  explicit LiveContext(practice::apprentice &app, const rx::connectable_observable<event_ptr> &events);
 
   /**
    * checked_ is strated started.

--- a/framework/core/src/include/kungfu/wingchun/operator/runner.h
+++ b/framework/core/src/include/kungfu/wingchun/operator/runner.h
@@ -8,7 +8,7 @@
 #include <kungfu/yijinjing/practice/apprentice.h>
 
 namespace kungfu::wingchun::op {
-class Runner : public yijinjing::practice::apprentice {
+class Runner : public practice::apprentice {
 public:
   Runner(yijinjing::data::locator_ptr locator, const std::string &group, const std::string &name,
          longfist::enums::mode m, bool low_latency, const std::string &arguments = "{}");

--- a/framework/core/src/include/kungfu/wingchun/service/ledger.h
+++ b/framework/core/src/include/kungfu/wingchun/service/ledger.h
@@ -16,7 +16,7 @@
 
 namespace kungfu::wingchun::service {
 
-class Ledger : public yijinjing::practice::apprentice {
+class Ledger : public practice::apprentice {
   typedef std::unordered_map<uint32_t, longfist::types::BrokerStateUpdate> BrokerStateMap;
   typedef std::unordered_map<uint32_t, longfist::types::OperatorStateUpdate> OperatorStateMap;
 

--- a/framework/core/src/include/kungfu/wingchun/strategy/backtest.h
+++ b/framework/core/src/include/kungfu/wingchun/strategy/backtest.h
@@ -17,7 +17,7 @@
 namespace kungfu::wingchun::strategy {
 class BacktestContext : public Context {
 public:
-  explicit BacktestContext(yijinjing::practice::apprentice &app, const rx::connectable_observable<event_ptr> &events,
+  explicit BacktestContext(practice::apprentice &app, const rx::connectable_observable<event_ptr> &events,
                            Matcher_ptr matcher, tool::SliceIndexer_ptr from_indexer, tool::SliceIndexer_ptr to_indexer,
                            tool::Report_ptr report, int64_t time_interval, std::string backtest_config);
 

--- a/framework/core/src/include/kungfu/wingchun/strategy/context.h
+++ b/framework/core/src/include/kungfu/wingchun/strategy/context.h
@@ -23,7 +23,7 @@ namespace kungfu::wingchun::strategy {
 
 class Context : public std::enable_shared_from_this<Context> {
 public:
-  Context(yijinjing::practice::apprentice &app, const rx::connectable_observable<event_ptr> &events);
+  Context(practice::apprentice &app, const rx::connectable_observable<event_ptr> &events);
 
   virtual ~Context() = default;
 
@@ -409,7 +409,7 @@ public:
   virtual std::shared_ptr<wingchun::factor::StreamDataBatcher> batch_streaming() = 0;
 
 protected:
-  yijinjing::practice::apprentice &app_;
+  practice::apprentice &app_;
   const rx::connectable_observable<event_ptr> &events_;
   std::string strategy_dir_;
   bool started_ = false;

--- a/framework/core/src/include/kungfu/wingchun/strategy/live.h
+++ b/framework/core/src/include/kungfu/wingchun/strategy/live.h
@@ -12,7 +12,7 @@
 namespace kungfu::wingchun::strategy {
 class LiveContext : public Context {
 public:
-  explicit LiveContext(yijinjing::practice::apprentice &app, const rx::connectable_observable<event_ptr> &events);
+  explicit LiveContext(practice::apprentice &app, const rx::connectable_observable<event_ptr> &events);
 
   /**
    * Get current time in nano seconds.

--- a/framework/core/src/include/kungfu/wingchun/strategy/matcher.h
+++ b/framework/core/src/include/kungfu/wingchun/strategy/matcher.h
@@ -69,7 +69,7 @@ private:
   friend void init_matcher(Matcher &matcher, book::Bookkeeper *bookkeeper, const std::string &matcher_config);
   friend void add_order_id(Matcher &matcher, uint64_t order_id, uint32_t source, uint32_t dest);
   friend void remove_order_id(Matcher &matcher, uint64_t order_id);
-  yijinjing::practice::apprentice *app_;
+  practice::apprentice *app_;
   book::Bookkeeper *bookkeeper_;
   std::unordered_map<uint64_t, std::pair<uint32_t, uint32_t>> order_ids_; // <order_id, std::pair<source, dest>>
   std::string config_{"{}"};

--- a/framework/core/src/include/kungfu/wingchun/strategy/runner.h
+++ b/framework/core/src/include/kungfu/wingchun/strategy/runner.h
@@ -14,7 +14,7 @@
 #include <kungfu/yijinjing/practice/apprentice.h>
 
 namespace kungfu::wingchun::strategy {
-class Runner : public yijinjing::practice::apprentice {
+class Runner : public practice::apprentice {
 public:
   Runner(const yijinjing::data::locator_ptr &locator, const std::string &group, const std::string &name,
          longfist::enums::mode m, bool low_latency, const std::string &arguments = "{}");

--- a/framework/core/src/include/kungfu/wingchun/tool/report.h
+++ b/framework/core/src/include/kungfu/wingchun/tool/report.h
@@ -71,14 +71,14 @@ public:
   std::string get_config() const { return config_; };
 
 private:
-  friend void init_report(Report &report, yijinjing::practice::apprentice *runner, book::Bookkeeper *bookkeeper,
+  friend void init_report(Report &report, practice::apprentice *runner, book::Bookkeeper *bookkeeper,
                           const std::string &config) {
     report.app_ = runner;
     report.bookkeeper_ = bookkeeper;
     report.config_ = config;
   }
 
-  yijinjing::practice::apprentice *app_;
+  practice::apprentice *app_;
   book::Bookkeeper *bookkeeper_;
   std::string config_{"{}"};
 };

--- a/framework/core/src/include/kungfu/wingchun/tool/slicetool.h
+++ b/framework/core/src/include/kungfu/wingchun/tool/slicetool.h
@@ -80,7 +80,7 @@ protected:
   std::string name_;
   SliceIndexer_ptr indexer_;
   bool overwrite_;
-  std::unordered_map<yijinjing::data::location, yijinjing::practice::WriterMap> writer_maps_;
+  std::unordered_map<yijinjing::data::location, practice::WriterMap> writer_maps_;
   std::map<int64_t, std::vector<yijinjing::data::location_ptr>> lease_locations_{};
   yijinjing::journal::reader_ptr reader_;
   mutable int64_t last_gen_time_;

--- a/framework/core/src/include/kungfu/yijinjing/cache/backend.h
+++ b/framework/core/src/include/kungfu/yijinjing/cache/backend.h
@@ -13,7 +13,7 @@
 #include <kungfu/yijinjing/journal/journal.h>
 #include <kungfu/yijinjing/time.h>
 
-namespace kungfu::yijinjing::cache {
+namespace kungfu::cache {
 template <typename ValueType> std::enable_if_t<std::is_arithmetic_v<ValueType>, ValueType> make_default() { return 0; }
 
 template <typename ValueType> std::enable_if_t<std::is_enum_v<ValueType>, int> make_default() { return 0; }
@@ -58,7 +58,7 @@ constexpr auto make_storage_ptr = [](const std::string &db_file, const auto &typ
     return [&](auto... tables) {
       using storage_type = decltype(sqlite_orm::make_storage(db_file, tables...));
       auto storage_ptr = std::make_shared<storage_type>(sqlite_orm::make_storage(db_file, tables...));
-      storage_ptr->busy_timeout(time_unit::MILLISECONDS_PER_SECOND);
+      storage_ptr->busy_timeout(yijinjing::time_unit::MILLISECONDS_PER_SECOND);
       return storage_ptr;
     };
   };
@@ -217,7 +217,7 @@ private:
     }
   }
 
-  template <typename DataType> void restore(yijinjing::cache::bank &bank, uint32_t dest, StateStoragePtr &storage) {
+  template <typename DataType> void restore(cache::bank &bank, uint32_t dest, StateStoragePtr &storage) {
     auto from = yijinjing::time::restore_start();
     for (auto &data : time_spec<DataType>::get_all(storage, from, INT64_MAX)) {
       bank << state(location_->uid, dest, from, data);
@@ -225,7 +225,7 @@ private:
   }
 
   template <typename DataType>
-  void restore(yijinjing::cache::bank &bank, uint32_t dest, StateStoragePtr &storage, int limit) {
+  void restore(cache::bank &bank, uint32_t dest, StateStoragePtr &storage, int limit) {
     auto from = yijinjing::time::restore_start();
     for (auto &data : time_spec<DataType>::get_all(storage, from, INT64_MAX, limit)) {
       bank << state(location_->uid, dest, from, data);
@@ -234,6 +234,6 @@ private:
 };
 
 DECLARE_PTR(shift)
-} // namespace kungfu::yijinjing::cache
+} // namespace kungfu::cache
 
 #endif // KUNGFU_CACHE_BACKEND_H

--- a/framework/core/src/include/kungfu/yijinjing/cache/cached.h
+++ b/framework/core/src/include/kungfu/yijinjing/cache/cached.h
@@ -11,14 +11,14 @@
 
 #include <memory>
 
-namespace kungfu::yijinjing::cache {
+namespace kungfu::cache {
 
 // 开放层运行时投影器（与 hana 闭集并存，默认 OFF）；完整定义见 open_layer_projector.h，仅在 cached.cpp include。
 class open_layer_projector;
 
 using ProfileDataTypesType = decltype(longfist::ProfileDataTypes);
 using ProfileStateMapType = decltype(longfist::build_state_map(longfist::ProfileDataTypes));
-typedef yijinjing::cache::typed_bank<ProfileDataTypesType, ProfileStateMapType> ProfileStateBank;
+typedef cache::typed_bank<ProfileDataTypesType, ProfileStateMapType> ProfileStateBank;
 
 class cached {
 public:
@@ -65,17 +65,17 @@ public:
 
   void store_profile_feeds();
 
-  void open_session(const data::location_ptr &location, int64_t open_time);
+  void open_session(const yijinjing::data::location_ptr &location, int64_t open_time);
 
-  void close_session(const data::location_ptr &location, int64_t close_time);
+  void close_session(const yijinjing::data::location_ptr &location, int64_t close_time);
 
   void close_all_sessions(int64_t close_time);
 
-  int64_t find_last_active_time(const data::location_ptr &source_location);
+  int64_t find_last_active_time(const yijinjing::data::location_ptr &source_location);
 
-  void update_session(const journal::frame_ptr &frame);
+  void update_session(const yijinjing::journal::frame_ptr &frame);
 
-  yijinjing::index::SessionMap &get_all_sessions();
+  index::SessionMap &get_all_sessions();
 
   void switch_feed_storage(bool pause_storage);
 
@@ -127,11 +127,11 @@ public:
 private:
   index::session_builder session_builder_;
   std::unordered_map<uint32_t, yijinjing::data::location_ptr> locations_ = {};
-  yijinjing::cache::profile profile_;
+  cache::profile profile_;
   ProfileStateBank profile_feed_bank_ = ProfileStateBank(longfist::ProfileDataTypes);
   ProfileStateBank profile_restore_bank_ = ProfileStateBank(longfist::ProfileDataTypes);
-  std::unordered_map<uint32_t, yijinjing::cache::shift> app_states_shift_ = {};
-  yijinjing::cache::bank states_feed_bank_;
+  std::unordered_map<uint32_t, cache::shift> app_states_shift_ = {};
+  cache::bank states_feed_bank_;
   bool bypass_cached_;
   std::thread store_states_worker_;
   std::thread store_profile_worker_;
@@ -194,6 +194,6 @@ private:
       };
 };
 
-} // namespace kungfu::yijinjing::cache
+} // namespace kungfu::cache
 
 #endif // KUNGFU_CACHED_H

--- a/framework/core/src/include/kungfu/yijinjing/cache/fb_projector.h
+++ b/framework/core/src/include/kungfu/yijinjing/cache/fb_projector.h
@@ -14,7 +14,7 @@
 #include <string>
 #include <vector>
 
-namespace kungfu::yijinjing::cache::projector {
+namespace kungfu::cache::projector {
 
 // reflection BaseType -> SQLite 列类型（对齐 sqlite_orm_ext.h 的映射：
 // enum/算术整型 -> INTEGER，float/double -> REAL，string -> TEXT，array/vector/obj -> BLOB）。
@@ -138,6 +138,6 @@ inline std::vector<std::string> alter_add_missing(sqlite3 *db, const reflection:
   return added;
 }
 
-} // namespace kungfu::yijinjing::cache::projector
+} // namespace kungfu::cache::projector
 
 #endif // KUNGFU_YIJINJING_CACHE_FB_PROJECTOR_H

--- a/framework/core/src/include/kungfu/yijinjing/cache/fb_schema_registry.h
+++ b/framework/core/src/include/kungfu/yijinjing/cache/fb_schema_registry.h
@@ -21,7 +21,7 @@
 #include <string>
 #include <vector>
 
-namespace kungfu::yijinjing::cache::projector {
+namespace kungfu::cache::projector {
 
 class SchemaRegistry {
 public:
@@ -118,6 +118,6 @@ inline void project_frame(sqlite3 *db, const SchemaRegistry::Entry &e, const uin
   sqlite3_finalize(ins);
 }
 
-} // namespace kungfu::yijinjing::cache::projector
+} // namespace kungfu::cache::projector
 
 #endif // KUNGFU_YIJINJING_CACHE_FB_SCHEMA_REGISTRY_H

--- a/framework/core/src/include/kungfu/yijinjing/cache/open_layer_projector.h
+++ b/framework/core/src/include/kungfu/yijinjing/cache/open_layer_projector.h
@@ -30,7 +30,7 @@
 #include <thread>
 #include <vector>
 
-namespace kungfu::yijinjing::cache {
+namespace kungfu::cache {
 
 class open_layer_projector {
 public:
@@ -169,6 +169,6 @@ private:
 };
 
 DECLARE_PTR(open_layer_projector)
-} // namespace kungfu::yijinjing::cache
+} // namespace kungfu::cache
 
 #endif // KUNGFU_YIJINJING_CACHE_OPEN_LAYER_PROJECTOR_H

--- a/framework/core/src/include/kungfu/yijinjing/cache/profile.h
+++ b/framework/core/src/include/kungfu/yijinjing/cache/profile.h
@@ -11,7 +11,7 @@
 #include "kungfu/longfist/longfist.h"
 #include "kungfu/yijinjing/common.h"
 
-namespace kungfu::yijinjing::cache {
+namespace kungfu::cache {
 class profile {
 public:
   explicit profile(const yijinjing::data::locator_ptr &locator);
@@ -65,10 +65,10 @@ public:
 private:
   const std::string profile_db_file_;
 
-  yijinjing::cache::ProfileStoragePtr &get_storage();
+  cache::ProfileStoragePtr &get_storage();
 
   explicit profile(std::string profile_db_file);
 };
-} // namespace kungfu::yijinjing::cache
+} // namespace kungfu::cache
 
 #endif // KUNGFU_CONFIG_STORE_H

--- a/framework/core/src/include/kungfu/yijinjing/cache/runtime.h
+++ b/framework/core/src/include/kungfu/yijinjing/cache/runtime.h
@@ -10,7 +10,7 @@
 #include <kungfu/longfist/longfist.h>
 #include <kungfu/yijinjing/journal/journal.h>
 
-namespace kungfu::yijinjing::cache {
+namespace kungfu::cache {
 class bank {
 public:
   template <typename DataType> void operator<<(const state<DataType> &state) {
@@ -44,7 +44,7 @@ public:
     });
   }
 
-  void operator>>(yijinjing::cache::bank &bank) {
+  void operator>>(cache::bank &bank) {
     boost::hana::for_each(longfist::StateDataTypes, [&](auto it) {
       auto type = boost::hana::second(it);
       for (const auto &element : state_map_[type]) {
@@ -110,7 +110,7 @@ public:
     });
   }
 
-  void operator>>(yijinjing::cache::deque_bank &bank) {
+  void operator>>(cache::deque_bank &bank) {
     boost::hana::for_each(longfist::StateDataTypes, [&](auto it) {
       auto type = boost::hana::second(it);
       for (const auto &element : state_map_[type]) {
@@ -195,7 +195,7 @@ public:
     });
   }
 
-  void operator>>(yijinjing::cache::bank &bank) {
+  void operator>>(cache::bank &bank) {
     boost::hana::for_each(types_, [&](auto it) {
       auto type = boost::hana::second(it);
       for (const auto &element : state_map_[type]) {
@@ -221,6 +221,6 @@ private:
   DataTypesMap state_map_;
 };
 
-} // namespace kungfu::yijinjing::cache
+} // namespace kungfu::cache
 
 #endif // KUNGFU_CACHE_RUNTIME_H

--- a/framework/core/src/include/kungfu/yijinjing/index/session.h
+++ b/framework/core/src/include/kungfu/yijinjing/index/session.h
@@ -14,7 +14,7 @@
 #include <kungfu/yijinjing/journal/journal.h>
 #include <kungfu/yijinjing/time.h>
 
-namespace kungfu::yijinjing::index {
+namespace kungfu::index {
 typedef std::vector<longfist::types::Session> SessionVector;
 typedef std::unordered_map<uint32_t, longfist::types::Session> SessionMap;
 
@@ -24,11 +24,11 @@ public:
 
   virtual ~session_finder();
 
-  virtual int64_t find_last_active_time(const data::location_ptr &source_location);
+  virtual int64_t find_last_active_time(const yijinjing::data::location_ptr &source_location);
 
   SessionVector find_sessions(int64_t from = 0, int64_t to = INT64_MAX);
 
-  SessionVector find_sessions_for(const data::location_ptr &source_location, int64_t from = 0, int64_t to = INT64_MAX);
+  SessionVector find_sessions_for(const yijinjing::data::location_ptr &source_location, int64_t from = 0, int64_t to = INT64_MAX);
 
 protected:
   yijinjing::io_device_ptr io_device_;
@@ -39,15 +39,15 @@ class session_builder : public session_finder {
 public:
   explicit session_builder(const yijinjing::io_device_ptr &io_device);
 
-  int64_t find_last_active_time(const data::location_ptr &source_location) override;
+  int64_t find_last_active_time(const yijinjing::data::location_ptr &source_location) override;
 
-  longfist::types::Session &open_session(const data::location_ptr &source_location, int64_t time);
+  longfist::types::Session &open_session(const yijinjing::data::location_ptr &source_location, int64_t time);
 
-  void close_session(const data::location_ptr &source_location, int64_t time);
+  void close_session(const yijinjing::data::location_ptr &source_location, int64_t time);
 
   void close_all_sessions(int64_t time);
 
-  void update_session(const journal::frame_ptr &frame);
+  void update_session(const yijinjing::journal::frame_ptr &frame);
 
   void rebuild_index_db();
 
@@ -59,6 +59,6 @@ private:
   SessionMap live_sessions_ = {};
   std::mutex update_session_mutex_;
 };
-} // namespace kungfu::yijinjing::index
+} // namespace kungfu::index
 
 #endif // KUNGFU_SESSION_H

--- a/framework/core/src/include/kungfu/yijinjing/practice/apprentice.h
+++ b/framework/core/src/include/kungfu/yijinjing/practice/apprentice.h
@@ -12,7 +12,7 @@
 #include <kungfu/yijinjing/practice/hero.h>
 #include <kungfu/yijinjing/time.h>
 
-namespace kungfu::yijinjing::practice {
+namespace kungfu::practice {
 class apprentice;
 
 class resource_manager {
@@ -37,7 +37,7 @@ private:
 
 class apprentice : public hero {
 public:
-  explicit apprentice(const data::location_ptr &home, bool low_latency = false, std::string arguments = "{}");
+  explicit apprentice(const yijinjing::data::location_ptr &home, bool low_latency = false, std::string arguments = "{}");
 
   explicit apprentice(const yijinjing::io_device_ptr &io_device, std::string arguments = "{}");
 
@@ -59,12 +59,12 @@ public:
 
   void request_read_from_sync(int64_t trigger_time, uint32_t source_id, int64_t from_time, uint64_t page_size = 0);
 
-  void request_read_from_source_to_dest(int64_t trigger_time, const data::location_ptr &source_location,
+  void request_read_from_source_to_dest(int64_t trigger_time, const yijinjing::data::location_ptr &source_location,
                                         uint32_t dest_id, uint64_t page_size = 0);
 
   void request_write_to(int64_t trigger_time, uint32_t dest_id, uint64_t page_size = 0);
 
-  void request_write_to_band(int64_t trigger_time, const data::location_ptr &location, uint64_t page_size = 0);
+  void request_write_to_band(int64_t trigger_time, const yijinjing::data::location_ptr &location, uint64_t page_size = 0);
 
   uint32_t request_band(const std::string &band_name, uint64_t page_size = 0);
 
@@ -169,17 +169,17 @@ public:
 
   void preload_next_page();
 
-  journal::writer_ptr &get_thread_writer(uint64_t page_size = 0);
+  yijinjing::journal::writer_ptr &get_thread_writer(uint64_t page_size = 0);
 
-  journal::writer_ptr &get_public_writer();
+  yijinjing::journal::writer_ptr &get_public_writer();
 
 protected:
   cache::bank state_bank_;
-  journal::writer_ptr master_cmd_writer_for_thread_ = nullptr;
-  journal::writer_ptr public_writer_ = nullptr;
-  inline static thread_local journal::writer_ptr thread_writer_ = nullptr;
+  yijinjing::journal::writer_ptr master_cmd_writer_for_thread_ = nullptr;
+  yijinjing::journal::writer_ptr public_writer_ = nullptr;
+  inline static thread_local yijinjing::journal::writer_ptr thread_writer_ = nullptr;
 
-  friend void add_location(practice::apprentice &app, const data::location_ptr &location) {
+  friend void add_location(practice::apprentice &app, const yijinjing::data::location_ptr &location) {
     app.add_location(app.now(), location);
   }
 
@@ -357,6 +357,6 @@ private:
 };
 
 DECLARE_PTR(apprentice)
-} // namespace kungfu::yijinjing::practice
+} // namespace kungfu::practice
 
 #endif // KUNGFU_APPRENTICE_H

--- a/framework/core/src/include/kungfu/yijinjing/practice/hero.h
+++ b/framework/core/src/include/kungfu/yijinjing/practice/hero.h
@@ -20,10 +20,10 @@
 #define KUNGFU_SETUP_LOG() kungfu::yijinjing::log::copy_log_settings(get_home(), get_home()->name)
 #endif // KUNGFU_SETUP_LOG
 
-namespace kungfu::yijinjing::practice {
+namespace kungfu::practice {
 
 inline yijinjing::data::location_ptr make_system_location(const std::string &group, const std::string &name,
-                                                          const data::locator_ptr &locator,
+                                                          const yijinjing::data::locator_ptr &locator,
                                                           uint32_t seed = KUNGFU_HASH_SEED) {
   return yijinjing::data::location::make_shared(locator->get_dir_mode(), longfist::enums::category::SYSTEM, group, name,
                                                 locator, seed);
@@ -31,7 +31,7 @@ inline yijinjing::data::location_ptr make_system_location(const std::string &gro
 
 typedef std::unordered_map<uint32_t, yijinjing::journal::writer_ptr> WriterMap;
 
-class hero : public resource {
+class hero : public yijinjing::resource {
 public:
   explicit hero(yijinjing::io_device_ptr io_device);
 
@@ -67,7 +67,7 @@ public:
 
   [[nodiscard]] int64_t get_end_time() const;
 
-  [[nodiscard]] const data::locator_ptr &get_locator() const;
+  [[nodiscard]] const yijinjing::data::locator_ptr &get_locator() const;
 
   [[nodiscard]] yijinjing::io_device_ptr get_io_device() const;
 
@@ -155,7 +155,7 @@ public:
 
   virtual void ensure_master_rocksdb();
 
-  void write_location_to_rocksdb(const data::location_ptr &location);
+  void write_location_to_rocksdb(const yijinjing::data::location_ptr &location);
 
   void request_deregister() {
     continual_ = false;
@@ -279,5 +279,5 @@ protected:
 
   static void delegate_produce(hero *instance, const rx::subscriber<event_ptr> &subscriber);
 };
-} // namespace kungfu::yijinjing::practice
+} // namespace kungfu::practice
 #endif // KUNGFU_HERO_H

--- a/framework/core/src/include/kungfu/yijinjing/practice/master.h
+++ b/framework/core/src/include/kungfu/yijinjing/practice/master.h
@@ -12,7 +12,7 @@
 #include <kungfu/yijinjing/journal/common.h>
 #include <kungfu/yijinjing/practice/hero.h>
 
-namespace kungfu::yijinjing::practice {
+namespace kungfu::practice {
 
 struct timer_task {
   int64_t checkpoint;
@@ -55,7 +55,7 @@ public:
 
 protected:
   int64_t last_check_;
-  yijinjing::cache::cached cached_;
+  cache::cached cached_;
 
   std::unordered_map<uint32_t, uint32_t> app_cmd_locations_ = {};
   std::unordered_map<uint32_t, std::unordered_map<int32_t, timer_task>> timer_tasks_ = {};
@@ -66,7 +66,7 @@ protected:
 
   void on_frame() final;
 
-  void try_add_location(int64_t trigger_time, const data::location_ptr &app_location);
+  void try_add_location(int64_t trigger_time, const yijinjing::data::location_ptr &app_location);
 
 private:
   void handle_timer_tasks();
@@ -93,15 +93,15 @@ private:
 
   void on_new_location(const event_ptr &event);
 
-  static void write_time_reset(int64_t trigger_time, const journal::writer_ptr &writer);
+  static void write_time_reset(int64_t trigger_time, const yijinjing::journal::writer_ptr &writer);
 
-  void write_locations(int64_t trigger_time, const journal::writer_ptr &writer);
+  void write_locations(int64_t trigger_time, const yijinjing::journal::writer_ptr &writer);
 
-  void write_registries(int64_t trigger_time, const journal::writer_ptr &writer);
+  void write_registries(int64_t trigger_time, const yijinjing::journal::writer_ptr &writer);
 
-  void write_channels(int64_t trigger_time, const journal::writer_ptr &writer);
+  void write_channels(int64_t trigger_time, const yijinjing::journal::writer_ptr &writer);
 
-  void write_bands(int64_t trigger_time, const journal::writer_ptr &writer);
+  void write_bands(int64_t trigger_time, const yijinjing::journal::writer_ptr &writer);
 };
-} // namespace kungfu::yijinjing::practice
+} // namespace kungfu::practice
 #endif // KUNGFU_MASTER_H

--- a/framework/core/src/libkungfu/wingchun/book/book.cpp
+++ b/framework/core/src/libkungfu/wingchun/book/book.cpp
@@ -12,7 +12,7 @@
 using namespace kungfu::rx;
 using namespace kungfu::longfist::types;
 using namespace kungfu::longfist::enums;
-using namespace kungfu::yijinjing::practice;
+using namespace kungfu::practice;
 using namespace kungfu::yijinjing;
 using namespace kungfu::yijinjing::data;
 using namespace kungfu::wingchun::map;

--- a/framework/core/src/libkungfu/wingchun/book/bookkeeper.cpp
+++ b/framework/core/src/libkungfu/wingchun/book/bookkeeper.cpp
@@ -11,7 +11,7 @@ using namespace kungfu::longfist::enums;
 using namespace kungfu::longfist::types;
 using namespace kungfu::wingchun::broker;
 using namespace kungfu::wingchun::map;
-using namespace kungfu::yijinjing::practice;
+using namespace kungfu::practice;
 using namespace kungfu::yijinjing;
 using namespace kungfu::yijinjing::data;
 using namespace kungfu::yijinjing::util;

--- a/framework/core/src/libkungfu/wingchun/book/staticdata.cpp
+++ b/framework/core/src/libkungfu/wingchun/book/staticdata.cpp
@@ -4,7 +4,7 @@ using namespace kungfu::rx;
 using namespace kungfu::wingchun;
 using namespace kungfu::longfist::enums;
 using namespace kungfu::longfist::types;
-using namespace kungfu::yijinjing::practice;
+using namespace kungfu::practice;
 using namespace kungfu::yijinjing;
 using namespace kungfu::yijinjing::data;
 using namespace kungfu::yijinjing::util;

--- a/framework/core/src/libkungfu/wingchun/broker/algoorder.cpp
+++ b/framework/core/src/libkungfu/wingchun/broker/algoorder.cpp
@@ -5,7 +5,7 @@ using namespace kungfu::wingchun;
 using namespace kungfu::wingchun::broker;
 using namespace kungfu::longfist::enums;
 using namespace kungfu::longfist::types;
-using namespace kungfu::yijinjing::practice;
+using namespace kungfu::practice;
 using namespace kungfu::yijinjing;
 using namespace kungfu::yijinjing::data;
 using namespace kungfu::yijinjing::util;
@@ -42,7 +42,7 @@ void AlgoOrderService::on_algo_order_input(const event_ptr &event) {
     target_algo_order.volume = algo_order_input.volume;
 
     // waiting_record_local_algo_orders_.insert_or_assign(target_algo_order.order_id, target_algo_order_state);
-    writer->write(time::now_in_nano(), target_algo_order);
+    writer->write(yijinjing::time::now_in_nano(), target_algo_order);
 
     return;
   }
@@ -75,7 +75,7 @@ void AlgoOrderService::on_algo_order_action(const event_ptr &event) {
       algo_order.status = OrderStatus::PartialFilledNotActive;
     }
 
-    vendor_.get_writer(dest)->write(time::now_in_nano(), algo_order);
+    vendor_.get_writer(dest)->write(yijinjing::time::now_in_nano(), algo_order);
   }
 
   state<AlgoOrderAction> algo_order_action_state(event->source(), event->dest(), event->gen_time(), algo_order_action);
@@ -133,7 +133,7 @@ void AlgoOrderService::on_order(int64_t gen_time, uint32_t source, uint32_t dest
       }
     }
   }
-  target_algo_order.update_time = time::now_in_nano();
+  target_algo_order.update_time = yijinjing::time::now_in_nano();
   waiting_record_local_algo_orders_.insert_or_assign(target_algo_order.order_id, target_algo_order_state);
 }
 
@@ -205,7 +205,7 @@ void AlgoOrderService::clean_algo_orders(bool bypass_recover) {
     if (not is_final_status(algo_order.status) and
         (bypass_recover or (not algo_order.is_local and algo_order.external_order_id.to_string().empty()))) {
       algo_order.status = OrderStatus::Lost;
-      algo_order.update_time = time::now_in_nano();
+      algo_order.update_time = yijinjing::time::now_in_nano();
       vendor_.try_write_to(vendor_.now(), algo_order, pair.second.dest);
     }
   });
@@ -219,7 +219,7 @@ void AlgoOrderService::clean_algo_orders(uint32_t source, const AlgoOrderInput &
   AlgoOrder algo_order{};
   algo_order_from_input(algo_order_input, algo_order);
   algo_order.status = OrderStatus::Lost;
-  algo_order.update_time = time::now_in_nano();
+  algo_order.update_time = yijinjing::time::now_in_nano();
   vendor_.try_write_to(vendor_.now(), algo_order, source);
 }
 

--- a/framework/core/src/libkungfu/wingchun/broker/broker.cpp
+++ b/framework/core/src/libkungfu/wingchun/broker/broker.cpp
@@ -13,7 +13,7 @@
 using namespace kungfu::rx;
 using namespace kungfu::longfist::enums;
 using namespace kungfu::longfist::types;
-using namespace kungfu::yijinjing::practice;
+using namespace kungfu::practice;
 using namespace kungfu::yijinjing;
 using namespace kungfu::yijinjing::data;
 using namespace kungfu::yijinjing::journal;
@@ -148,7 +148,7 @@ void BrokerService::record_stored_instruments_trading_day(const std::string &tra
 
   // 为了解决夜盘的问题
   TimeKeyValue instrument_stored_trading_day_next_day_tkv = {};
-  instrument_stored_trading_day_next_day_tkv.update_time = time::next_trading_day_end(now());
+  instrument_stored_trading_day_next_day_tkv.update_time = yijinjing::time::next_trading_day_end(now());
   instrument_stored_trading_day_next_day_tkv.key = "instrument_stored_trading_day_next_day";
   instrument_stored_trading_day_next_day_tkv.value = trading_day;
   get_public_writer()->write(now(), instrument_stored_trading_day_next_day_tkv);
@@ -200,7 +200,7 @@ void BrokerService::update_broker_state(BrokerState state) {
   get_public_writer()->close_data();
 }
 
-io_device_ptr BrokerService::get_io_device() const { return get_vendor().get_io_device(); }
+yijinjing::io_device_ptr BrokerService::get_io_device() const { return get_vendor().get_io_device(); }
 
 writer_ptr &BrokerService::get_thread_writer(uint32_t page_size) { return vendor_.get_thread_writer(page_size); }
 

--- a/framework/core/src/libkungfu/wingchun/broker/client.cpp
+++ b/framework/core/src/libkungfu/wingchun/broker/client.cpp
@@ -9,14 +9,14 @@
 using namespace kungfu::rx;
 using namespace kungfu::longfist::types;
 using namespace kungfu::longfist::enums;
-using namespace kungfu::yijinjing::practice;
+using namespace kungfu::practice;
 using namespace kungfu::yijinjing;
 using namespace kungfu::yijinjing::data;
 
 namespace kungfu::wingchun::broker {
 int64_t ResumePolicy::get_connect_time(const apprentice &app, const Register &target) const {
   auto target_checkin_time = target.checkin_time;
-  auto target_checkin_time_str = time::strftime(target_checkin_time);
+  auto target_checkin_time_str = yijinjing::time::strftime(target_checkin_time);
   if (app.get_last_active_time() == INT64_MIN) {
     SPDLOG_DEBUG("app has no previous session, connect from target checkin_time {}", target_checkin_time_str);
     return target_checkin_time;
@@ -41,34 +41,34 @@ int64_t ResumePolicy::get_connect_time(const apprentice &app, const Register &ta
 
 int64_t StatelessResumePolicy::get_resume_time(const apprentice &app, const Register &target) const {
   auto resume_time = target.checkin_time;
-  SPDLOG_DEBUG("Stateless resume policy, connect from target checkin_time {}", time::strftime(resume_time));
+  SPDLOG_DEBUG("Stateless resume policy, connect from target checkin_time {}", yijinjing::time::strftime(resume_time));
   return resume_time;
 }
 
 int64_t ContinuousResumePolicy::get_resume_time(const apprentice &app, const Register &target) const {
   auto resume_time = app.get_last_active_time();
-  SPDLOG_DEBUG("Continuous resume policy, connect from app last_active_time {}", time::strftime(resume_time));
+  SPDLOG_DEBUG("Continuous resume policy, connect from app last_active_time {}", yijinjing::time::strftime(resume_time));
   return resume_time;
 }
 
 int64_t IntradayResumePolicy::get_resume_time(const apprentice &app, const Register &target) const {
-  auto resume_time = std::max(app.get_last_active_time(), time::calendar_day_start(app.now()));
+  auto resume_time = std::max(app.get_last_active_time(), yijinjing::time::calendar_day_start(app.now()));
   SPDLOG_DEBUG("Intraday resume policy, connect from max(app last_active_time, today_start) {}",
-               time::strftime(resume_time));
+               yijinjing::time::strftime(resume_time));
   return resume_time;
 }
 
 int64_t FromNowResumePolicy::get_connect_time(const apprentice &app, const Register &target) const {
   if (target.checkin_time >= app.get_checkin_time()) {
     SPDLOG_DEBUG("case[0] target started later than current, connect from target checkin_time {}",
-                 time::strftime(target.checkin_time));
+                 yijinjing::time::strftime(target.checkin_time));
     return target.checkin_time;
   }
   return get_resume_time(app, target);
 }
 
 int64_t FromNowResumePolicy::get_resume_time(const apprentice &app, const Register &target) const {
-  SPDLOG_DEBUG("From now resume policy, connect from now {}", time::strftime(app.now()));
+  SPDLOG_DEBUG("From now resume policy, connect from now {}", yijinjing::time::strftime(app.now()));
   return app.now();
 }
 
@@ -193,7 +193,7 @@ void Client::connect(const event_ptr &event, const Register &register_data) {
     auto resume_time_point = get_resume_policy()->get_connect_time(app_, register_data);
     app_.request_write_to(app_.now(), app_uid);
     app_.request_read_from_public(app_.now(), app_uid, resume_time_point);
-    SPDLOG_INFO("resume {} connection from {}", app_location->uname, time::strftime(resume_time_point));
+    SPDLOG_INFO("resume {} connection from {}", app_location->uname, yijinjing::time::strftime(resume_time_point));
   }
   if (app_location->category == category::TD and should_connect_td(app_location)) {
     auto resume_time_point = get_resume_policy()->get_connect_time(app_, register_data);
@@ -201,14 +201,14 @@ void Client::connect(const event_ptr &event, const Register &register_data) {
     app_.request_read_from(app_.now(), app_uid, resume_time_point);
     app_.request_read_from_public(app_.now(), app_uid, resume_time_point);
     app_.request_read_from_sync(app_.now(), app_uid, resume_time_point);
-    SPDLOG_INFO("resume {} connection from {}", app_location->uname, time::strftime(resume_time_point));
+    SPDLOG_INFO("resume {} connection from {}", app_location->uname, yijinjing::time::strftime(resume_time_point));
   }
   if (app_location->category == category::STRATEGY and should_connect_strategy(app_location)) {
     auto resume_time_point = get_resume_policy()->get_connect_time(app_, register_data);
     app_.request_write_to(app_.now(), app_location->uid);
     app_.request_read_from(app_.now(), app_location->uid, resume_time_point);
     app_.request_read_from_public(app_.now(), app_location->uid, resume_time_point);
-    SPDLOG_INFO("resume {} connection from {}", app_location->uname, time::strftime(resume_time_point));
+    SPDLOG_INFO("resume {} connection from {}", app_location->uname, yijinjing::time::strftime(resume_time_point));
   }
   if (app_location->category == category::OPERATOR and should_connect_operator(app_location)) {
     auto resume_time_point = get_resume_policy()->get_connect_time(app_, register_data);
@@ -217,7 +217,7 @@ void Client::connect(const event_ptr &event, const Register &register_data) {
       app_.request_read_from(app_.now(), app_location->uid, resume_time_point);
     }
     app_.request_read_from_public(app_.now(), app_location->uid, resume_time_point);
-    SPDLOG_INFO("resume {} connection from {}", app_location->uname, time::strftime(resume_time_point));
+    SPDLOG_INFO("resume {} connection from {}", app_location->uname, yijinjing::time::strftime(resume_time_point));
   }
 }
 

--- a/framework/core/src/libkungfu/wingchun/broker/marketdata.cpp
+++ b/framework/core/src/libkungfu/wingchun/broker/marketdata.cpp
@@ -9,7 +9,7 @@
 using namespace kungfu::rx;
 using namespace kungfu::longfist::types;
 using namespace kungfu::longfist::enums;
-using namespace kungfu::yijinjing::practice;
+using namespace kungfu::practice;
 using namespace kungfu::yijinjing;
 using namespace kungfu::yijinjing::data;
 
@@ -36,7 +36,7 @@ void MarketDataVendor::on_start() {
   events_ | is(Band::tag) | $$(service_->on_band(event));
   service_->on_start();
 
-  add_time_interval(time_unit::NANOSECONDS_PER_SECOND, [&](auto e) { service_->try_subscribe(); });
+  add_time_interval(yijinjing::time_unit::NANOSECONDS_PER_SECOND, [&](auto e) { service_->try_subscribe(); });
 }
 
 BrokerService_ptr MarketDataVendor::get_service() { return service_; }

--- a/framework/core/src/libkungfu/wingchun/broker/order.cpp
+++ b/framework/core/src/libkungfu/wingchun/broker/order.cpp
@@ -5,14 +5,14 @@ using namespace kungfu::wingchun;
 using namespace kungfu::wingchun::broker;
 using namespace kungfu::longfist::enums;
 using namespace kungfu::longfist::types;
-using namespace kungfu::yijinjing::practice;
+using namespace kungfu::practice;
 using namespace kungfu::yijinjing;
 using namespace kungfu::yijinjing::data;
 using namespace kungfu::yijinjing::util;
 
 namespace kungfu::wingchun::broker {
 
-constexpr uint64_t ORDER_CLAEN_THROTTLE = 5 * time_unit::NANOSECONDS_PER_MINUTE;
+constexpr uint64_t ORDER_CLAEN_THROTTLE = 5 * yijinjing::time_unit::NANOSECONDS_PER_MINUTE;
 
 void OrderService::on_order_input(const event_ptr &event) {
   auto &order_input = event->data<OrderInput>();
@@ -86,7 +86,7 @@ void OrderService::lost_orders(bool bypass_recover) {
     Order &order = pair.second.data;
     if (not is_final_status(order.status) and (bypass_recover or order.external_order_id.to_string().empty())) {
       order.status = OrderStatus::Lost;
-      order.update_time = time::now_in_nano();
+      order.update_time = yijinjing::time::now_in_nano();
       vendor_.try_write_to(vendor_.now(), order, pair.second.dest);
     }
   });
@@ -100,13 +100,13 @@ void OrderService::lost_orders(uint32_t source, const OrderInput &order_input, b
   Order order{};
   order_from_input(order_input, order);
   order.status = OrderStatus::Lost;
-  order.update_time = time::now_in_nano();
+  order.update_time = yijinjing::time::now_in_nano();
   vendor_.try_write_to(vendor_.now(), order, source);
 }
 
 void OrderService::clean_finished_orders(uint64_t now) {
   auto before_clean_order_size = orders_.size();
-  auto start = time::now_in_nano();
+  auto start = yijinjing::time::now_in_nano();
   auto iter = orders_.begin();
   while (iter != orders_.end()) {
     auto &state = iter->second;
@@ -117,7 +117,7 @@ void OrderService::clean_finished_orders(uint64_t now) {
     }
   }
   auto after_clean_order_size = orders_.size();
-  auto end = time::now_in_nano();
+  auto end = yijinjing::time::now_in_nano();
   SPDLOG_DEBUG("clean_finished_orders clean size {}, takes {}ns", before_clean_order_size - after_clean_order_size,
                end - start);
 }

--- a/framework/core/src/libkungfu/wingchun/broker/ordertrigger.cpp
+++ b/framework/core/src/libkungfu/wingchun/broker/ordertrigger.cpp
@@ -5,7 +5,7 @@ using namespace kungfu::wingchun;
 using namespace kungfu::wingchun::broker;
 using namespace kungfu::longfist::enums;
 using namespace kungfu::longfist::types;
-using namespace kungfu::yijinjing::practice;
+using namespace kungfu::practice;
 using namespace kungfu::yijinjing;
 using namespace kungfu::yijinjing::data;
 using namespace kungfu::yijinjing::util;
@@ -45,7 +45,7 @@ void OrderTriggerService::clean_order_triggers(bool bypass_recover) {
     OrderTrigger &trigger = pair.second.data;
     if (not is_final_status(trigger.status) and (bypass_recover or trigger.external_trigger_id.to_string().empty())) {
       trigger.status = OrderStatus::Lost;
-      trigger.update_time = time::now_in_nano();
+      trigger.update_time = yijinjing::time::now_in_nano();
       vendor_.try_write_to(vendor_.now(), trigger, pair.second.dest);
     }
   });
@@ -61,7 +61,7 @@ void OrderTriggerService::clean_order_triggers(uint32_t source,
   OrderTrigger trigger{};
   order_trigger_from_input(order_trigger_input, trigger);
   trigger.status = OrderStatus::Lost;
-  trigger.update_time = time::now_in_nano();
+  trigger.update_time = yijinjing::time::now_in_nano();
   vendor_.try_write_to(vendor_.now(), trigger, source);
 }
 

--- a/framework/core/src/libkungfu/wingchun/broker/trader.cpp
+++ b/framework/core/src/libkungfu/wingchun/broker/trader.cpp
@@ -13,11 +13,11 @@
 using namespace kungfu::rx;
 using namespace kungfu::longfist::types;
 using namespace kungfu::longfist::enums;
-using namespace kungfu::yijinjing::practice;
+using namespace kungfu::practice;
 using namespace kungfu::yijinjing;
 using namespace kungfu::yijinjing::data;
 using namespace kungfu::yijinjing::journal;
-using namespace kungfu::yijinjing::cache;
+using namespace kungfu::cache;
 
 namespace kungfu::wingchun::broker {
 
@@ -139,7 +139,7 @@ void Trader::recover() {
 }
 
 void Trader::recover_from_journal() {
-  tracer trc(get_live_home(), false, true, time::restore_start(), time::now_in_nano());
+  tracer trc(get_live_home(), false, true, yijinjing::time::restore_start(), yijinjing::time::now_in_nano());
   SPDLOG_DEBUG("before tracer read");
   int64_t count = 0;
   auto &state_bank = const_cast<cache::bank &>(get_vendor().get_state_bank());
@@ -238,7 +238,7 @@ void Trader::deal_read_frame() {
 
 void Trader::clean_finished_orders() {
   if (state_ == BrokerState::Ready) {
-    get_order_service().clean_finished_orders(time::now_in_nano());
+    get_order_service().clean_finished_orders(yijinjing::time::now_in_nano());
   }
 }
 

--- a/framework/core/src/libkungfu/wingchun/broker/tradervendor.cpp
+++ b/framework/core/src/libkungfu/wingchun/broker/tradervendor.cpp
@@ -5,7 +5,7 @@
 using namespace kungfu::rx;
 using namespace kungfu::longfist::types;
 using namespace kungfu::longfist::enums;
-using namespace kungfu::yijinjing::practice;
+using namespace kungfu::practice;
 using namespace kungfu::yijinjing;
 using namespace kungfu::yijinjing::data;
 using namespace kungfu::yijinjing::journal;
@@ -33,7 +33,7 @@ TraderWriterHook::TraderWriterHook(TraderVendor &vendor) : vendor_(vendor) {}
 void TraderWriterHook::on_open_frame(int64_t trigger_time, frame_ptr frame) {}
 
 void TraderWriterHook::on_close_frame(int64_t gen_time, frame_ptr frame) {
-  auto now = time::now_in_nano();
+  auto now = yijinjing::time::now_in_nano();
   switch (frame->msg_type()) {
   case Order::tag: {
     auto &order = guard_update_time<Order>(frame->data<Order>());
@@ -152,12 +152,12 @@ void TraderVendor::on_start() {
   service_->on_start();
 
   // after recover done, which take some time, then start to try req account
-  add_time_interval(SYNC_ASSET_INTERVAL * time_unit::NANOSECONDS_PER_SECOND,
+  add_time_interval(SYNC_ASSET_INTERVAL * yijinjing::time_unit::NANOSECONDS_PER_SECOND,
                     [&](auto e) { service_->try_req_account(); });
 
   if (get_low_memory_mode()) {
     SPDLOG_WARN("Low memory mode, clear finished order every {}s", ORDER_CLEAN_INTERVAL);
-    add_time_interval(ORDER_CLEAN_INTERVAL * time_unit::NANOSECONDS_PER_SECOND,
+    add_time_interval(ORDER_CLEAN_INTERVAL * yijinjing::time_unit::NANOSECONDS_PER_SECOND,
                       [&](auto e) { service_->clean_finished_orders(); });
   }
 }

--- a/framework/core/src/libkungfu/wingchun/factor/crosssection.cpp
+++ b/framework/core/src/libkungfu/wingchun/factor/crosssection.cpp
@@ -1,7 +1,7 @@
 #include <kungfu/wingchun/factor/crosssection.h>
 
 using namespace kungfu::yijinjing;
-using namespace kungfu::yijinjing::practice;
+using namespace kungfu::practice;
 using namespace kungfu::longfist::types;
 using namespace kungfu::rx;
 namespace kungfu::wingchun::factor {
@@ -63,7 +63,7 @@ void MultiCrossSectionalFactor::on_quote(const Quote &quote) {
   const double bid1_price = quote.bid_price[0];
   if (ask1_price == 0 || bid1_price == 0) {
     SPDLOG_WARN("Invalid quote in instrument={} at={}, ask1_price={}, bid1_price={}", quote.instrument_id,
-                time::strftime(quote.data_time), ask1_price, bid1_price);
+                yijinjing::time::strftime(quote.data_time), ask1_price, bid1_price);
     return;
   }
   double mid_price = (ask1_price + bid1_price) / 2.0;
@@ -83,9 +83,9 @@ MultiCrossSectionalFactor::generate_cross_sectional_factor(bool clear_price_cach
   std::unordered_map<std::string, double> cross_sectional_prices;
   int64_t _now = now();
   for (const auto &[instrument_key, time_stamp_price] : price_cache_) {
-    if (_now - time_stamp_price.time > 10 * time_unit::NANOSECONDS_PER_SECOND) {
+    if (_now - time_stamp_price.time > 10 * yijinjing::time_unit::NANOSECONDS_PER_SECOND) {
       SPDLOG_WARN("Price is too old, instrument_key={}, last update time={}, now={}", instrument_key,
-                  time::strftime(time_stamp_price.time), time::strftime(_now));
+                  yijinjing::time::strftime(time_stamp_price.time), yijinjing::time::strftime(_now));
     }
     cross_sectional_prices[instrument_key] = time_stamp_price.price;
   }

--- a/framework/core/src/libkungfu/wingchun/operator/backtest.cpp
+++ b/framework/core/src/libkungfu/wingchun/operator/backtest.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 #include <kungfu/wingchun/operator/backtest.h>
 
-using namespace kungfu::yijinjing::practice;
+using namespace kungfu::practice;
 using namespace kungfu::rx;
 using namespace kungfu::longfist;
 using namespace kungfu::longfist::types;
@@ -204,7 +204,7 @@ void BacktestContext::subscribe_slice(const location_ptr &slice_location, int64_
       if (slice_location->locator->list_page_id(slice_location, location::PUBLIC).empty()) {
         SPDLOG_WARN("failed to subscribe data between {} and {}, md public journal in locator={}, location={} "
                     "not exists",
-                    time::strftime(nanotime + 1), time::strftime(nanotime + offset),
+                    yijinjing::time::strftime(nanotime + 1), yijinjing::time::strftime(nanotime + offset),
                     slice_location->locator->get_root(), slice_location->uname);
       }
       for (const auto dest_id : slice_location->locator->list_location_dest(slice_location)) {
@@ -218,7 +218,7 @@ void BacktestContext::subscribe_slice(const location_ptr &slice_location, int64_
     default:
       SPDLOG_ERROR(" probably failed to acquire data between {} and {}, public journal in locator={}, location={} "
                    "not exists",
-                   time::strftime(nanotime + 1), time::strftime(nanotime + offset), slice_location->locator->get_root(),
+                   yijinjing::time::strftime(nanotime + 1), yijinjing::time::strftime(nanotime + offset), slice_location->locator->get_root(),
                    slice_location->uname);
       SPDLOG_ERROR("invalid slice state={} with reference count={} at slice data confirm acquiring stage.",
                    static_cast<int>(reference_count.state), reference_count.reference_count);
@@ -238,7 +238,7 @@ void BacktestContext::subscribe_slice(const location_ptr &slice_location, int64_
     case SliceState::Acquired:
       SPDLOG_WARN("slice data between {} and {} is already acquired with reference count={}, public journal in "
                   "locator={}, location={}",
-                  time::strftime(nanotime + 1), time::strftime(nanotime + offset), reference_count.reference_count,
+                  yijinjing::time::strftime(nanotime + 1), yijinjing::time::strftime(nanotime + offset), reference_count.reference_count,
                   slice_location->locator->get_root(), slice_location->uname);
       break;
     default:

--- a/framework/core/src/libkungfu/wingchun/operator/context.cpp
+++ b/framework/core/src/libkungfu/wingchun/operator/context.cpp
@@ -10,7 +10,7 @@
 #include <kungfu/yijinjing/log.h>
 #include <kungfu/yijinjing/time.h>
 
-using namespace kungfu::yijinjing::practice;
+using namespace kungfu::practice;
 using namespace kungfu::rx;
 using namespace kungfu::longfist;
 using namespace kungfu::longfist::types;

--- a/framework/core/src/libkungfu/wingchun/operator/live.cpp
+++ b/framework/core/src/libkungfu/wingchun/operator/live.cpp
@@ -6,7 +6,7 @@
 #include <kungfu/yijinjing/log.h>
 #include <kungfu/yijinjing/time.h>
 
-using namespace kungfu::yijinjing::practice;
+using namespace kungfu::practice;
 using namespace kungfu::rx;
 using namespace kungfu::longfist;
 using namespace kungfu::longfist::types;

--- a/framework/core/src/libkungfu/wingchun/operator/runner.cpp
+++ b/framework/core/src/libkungfu/wingchun/operator/runner.cpp
@@ -7,7 +7,7 @@ using namespace kungfu::longfist::types;
 using namespace kungfu::wingchun::broker;
 using namespace kungfu::yijinjing;
 using namespace kungfu::yijinjing::data;
-using namespace kungfu::yijinjing::practice;
+using namespace kungfu::practice;
 
 namespace kungfu::wingchun::op {
 Runner::Runner(locator_ptr locator, const std::string &group, const std::string &name, mode m, bool low_latency,
@@ -53,7 +53,7 @@ void Runner::set_time_interval(int64_t time_interval) {
   if (time_interval <= 0) {
     throw wingchun_error(fmt::format("time_interval should be positive other than {}", time_interval_));
   }
-  if (time_interval <= 100 * time_unit::NANOSECONDS_PER_MILLISECOND) {
+  if (time_interval <= 100 * yijinjing::time_unit::NANOSECONDS_PER_MILLISECOND) {
     SPDLOG_WARN("No need to make time_interval smaller than 100ms which will cause to much resource.");
   }
   time_interval_ = time_interval;

--- a/framework/core/src/libkungfu/wingchun/service/ledger.cpp
+++ b/framework/core/src/libkungfu/wingchun/service/ledger.cpp
@@ -13,14 +13,14 @@
 #include <kungfu/yijinjing/time.h>
 
 using namespace kungfu::rx;
-using namespace kungfu::yijinjing::practice;
+using namespace kungfu::practice;
 using namespace kungfu::longfist;
 using namespace kungfu::longfist::enums;
 using namespace kungfu::longfist::types;
 using namespace kungfu::wingchun::map;
 using namespace kungfu::yijinjing;
 using namespace kungfu::yijinjing::data;
-using namespace kungfu::yijinjing::cache;
+using namespace kungfu::cache;
 
 #define DEFAULT_AVG_VALID_VALUE 10000.0
 
@@ -97,11 +97,11 @@ void Ledger::on_start() {
   events_ | is(PositionEnd::tag) | $$(update_account_book(event->gen_time(), event->data<PositionEnd>().holder_uid));
 
   if (sync_asset_) {
-    add_time_interval(time_unit::NANOSECONDS_PER_MINUTE,
+    add_time_interval(yijinjing::time_unit::NANOSECONDS_PER_MINUTE,
                       [&](const event_ptr &e) { request_asset_sync(e->gen_time()); });
   }
   if (sync_position_) {
-    add_time_interval(time_unit::NANOSECONDS_PER_MINUTE,
+    add_time_interval(yijinjing::time_unit::NANOSECONDS_PER_MINUTE,
                       [&](const event_ptr &e) { request_position_sync(e->gen_time()); });
   }
 

--- a/framework/core/src/libkungfu/wingchun/strategy/backtest.cpp
+++ b/framework/core/src/libkungfu/wingchun/strategy/backtest.cpp
@@ -6,7 +6,7 @@
 
 #include <kungfu/wingchun/strategy/backtest.h>
 
-using namespace kungfu::yijinjing::practice;
+using namespace kungfu::practice;
 using namespace kungfu::rx;
 using namespace kungfu::longfist;
 using namespace kungfu::longfist::types;
@@ -224,7 +224,7 @@ void BacktestContext::subscribe_slice(const location_ptr &slice_location, int64_
       if (slice_location->locator->list_page_id(slice_location, location::PUBLIC).empty()) {
         SPDLOG_WARN("failed to subscribe data between {} and {}, md public journal in locator={}, location={} "
                     "not exists",
-                    time::strftime(nanotime + 1), time::strftime(nanotime + offset),
+                    yijinjing::time::strftime(nanotime + 1), yijinjing::time::strftime(nanotime + offset),
                     slice_location->locator->get_root(), slice_location->uname);
       }
       for (const auto dest_id : slice_location->locator->list_location_dest(slice_location)) {
@@ -238,7 +238,7 @@ void BacktestContext::subscribe_slice(const location_ptr &slice_location, int64_
     default:
       SPDLOG_ERROR(" probably failed to acquire data between {} and {}, public journal in locator={}, location={} "
                    "not exists",
-                   time::strftime(nanotime + 1), time::strftime(nanotime + offset), slice_location->locator->get_root(),
+                   yijinjing::time::strftime(nanotime + 1), yijinjing::time::strftime(nanotime + offset), slice_location->locator->get_root(),
                    slice_location->uname);
       SPDLOG_ERROR("invalid slice state={} with reference count={} at slice data confirm acquiring stage.",
                    static_cast<int>(reference_count.state), reference_count.reference_count);
@@ -258,7 +258,7 @@ void BacktestContext::subscribe_slice(const location_ptr &slice_location, int64_
     case SliceState::Acquired:
       SPDLOG_WARN("slice data between {} and {} is already acquired with reference count={}, public journal in "
                   "locator={}, location={}",
-                  time::strftime(nanotime + 1), time::strftime(nanotime + offset), reference_count.reference_count,
+                  yijinjing::time::strftime(nanotime + 1), yijinjing::time::strftime(nanotime + offset), reference_count.reference_count,
                   slice_location->locator->get_root(), slice_location->uname);
       break;
     default:

--- a/framework/core/src/libkungfu/wingchun/strategy/context.cpp
+++ b/framework/core/src/libkungfu/wingchun/strategy/context.cpp
@@ -6,7 +6,7 @@
 
 #include <kungfu/wingchun/strategy/context.h>
 
-using namespace kungfu::yijinjing::practice;
+using namespace kungfu::practice;
 using namespace kungfu::rx;
 using namespace kungfu::longfist;
 using namespace kungfu::longfist::types;

--- a/framework/core/src/libkungfu/wingchun/strategy/live.cpp
+++ b/framework/core/src/libkungfu/wingchun/strategy/live.cpp
@@ -10,7 +10,7 @@
 #include <kungfu/yijinjing/log.h>
 #include <kungfu/yijinjing/time.h>
 
-using namespace kungfu::yijinjing::practice;
+using namespace kungfu::practice;
 using namespace kungfu::rx;
 using namespace kungfu::longfist;
 using namespace kungfu::longfist::types;

--- a/framework/core/src/libkungfu/wingchun/strategy/matcher.cpp
+++ b/framework/core/src/libkungfu/wingchun/strategy/matcher.cpp
@@ -11,7 +11,7 @@
 
 #include <cstdlib>
 
-// using namespace kungfu::yijinjing::practice;
+// using namespace kungfu::practice;
 using namespace kungfu::rx;
 using namespace kungfu::longfist;
 using namespace kungfu::longfist::types;

--- a/framework/core/src/libkungfu/wingchun/strategy/runner.cpp
+++ b/framework/core/src/libkungfu/wingchun/strategy/runner.cpp
@@ -12,7 +12,7 @@ using namespace kungfu::longfist::types;
 using namespace kungfu::wingchun::broker;
 using namespace kungfu::yijinjing;
 using namespace kungfu::yijinjing::data;
-using namespace kungfu::yijinjing::practice;
+using namespace kungfu::practice;
 
 namespace kungfu::wingchun::strategy {
 
@@ -69,7 +69,7 @@ void Runner::set_time_interval(int64_t time_interval) {
   if (time_interval <= 0) {
     throw wingchun_error(fmt::format("time_interval should be positive other than {}", time_interval_));
   }
-  if (time_interval <= 100 * time_unit::NANOSECONDS_PER_MILLISECOND) {
+  if (time_interval <= 100 * yijinjing::time_unit::NANOSECONDS_PER_MILLISECOND) {
     SPDLOG_WARN("No need to make time_interval smaller than 100ms which will cause to much resource.");
   }
   time_interval_ = time_interval;

--- a/framework/core/src/libkungfu/yijinjing/cache/backend.cpp
+++ b/framework/core/src/libkungfu/yijinjing/cache/backend.cpp
@@ -6,7 +6,7 @@
 
 #include <kungfu/yijinjing/cache/backend.h>
 
-namespace kungfu::yijinjing::cache {
+namespace kungfu::cache {
 
 namespace fs = std::filesystem;
 
@@ -33,4 +33,4 @@ bool shift::check_storage_exists(uint32_t dest) {
   return fs::exists(db_file);
 }
 
-} // namespace kungfu::yijinjing::cache
+} // namespace kungfu::cache

--- a/framework/core/src/libkungfu/yijinjing/cache/cached.cpp
+++ b/framework/core/src/libkungfu/yijinjing/cache/cached.cpp
@@ -12,9 +12,9 @@ using namespace kungfu::longfist;
 using namespace kungfu::longfist::enums;
 using namespace kungfu::longfist::types;
 using namespace kungfu::yijinjing;
-using namespace kungfu::yijinjing::practice;
+using namespace kungfu::practice;
 using namespace kungfu::yijinjing::data;
-using namespace kungfu::yijinjing::cache;
+using namespace kungfu::cache;
 
 // https://sqlite.org/limits.html
 // The maximum number of bytes in the text of an SQL statement is limited to SQLITE_MAX_SQL_LENGTH which defaults to
@@ -23,11 +23,11 @@ using namespace kungfu::yijinjing::cache;
 #define STORE_INTERVAL 100
 #define RESTORE_LIMIT 5000
 
-namespace kungfu::yijinjing::cache {
+namespace kungfu::cache {
 
 cached::cached(const yijinjing::io_device_ptr &io_device)
     : session_builder_(io_device), profile_(io_device->get_locator()),
-      ledger_home_location_(yijinjing::practice::make_system_location("service", "ledger", io_device->get_locator())) {
+      ledger_home_location_(practice::make_system_location("service", "ledger", io_device->get_locator())) {
   bypass_cached_ = std::getenv("KF_BYPASS_CACHED") != nullptr;
   profile_.setup();
   profile_get_all(profile_, profile_restore_bank_);
@@ -183,7 +183,7 @@ void cached::restore_states(const yijinjing::data::location_ptr &location,
   }
 }
 
-void cached::restore(const location_ptr &location, const journal::writer_ptr &writer) {
+void cached::restore(const location_ptr &location, const yijinjing::journal::writer_ptr &writer) {
   restore_profile(location, writer);
   restore_states(location, writer);
 }
@@ -305,8 +305,8 @@ void cached::do_store_profile_feeds() {
 }
 
 void cached::store_states_feeds() {
-  yijinjing::cache::location_bank tmp_location_bank = {};
-  auto store_state_data_start_time = time::now_in_nano();
+  cache::location_bank tmp_location_bank = {};
+  auto store_state_data_start_time = yijinjing::time::now_in_nano();
 
   feed_mutex_.lock();
   // tracing-foundation Phase 1: 交易类型拆出闭集 cache,移除 TradingDataTypes transfer(states_feed_bank_
@@ -351,7 +351,7 @@ void cached::store_states_feeds() {
     });
   });
 
-  auto store_state_data_end_time = time::now_in_nano();
+  auto store_state_data_end_time = yijinjing::time::now_in_nano();
   if (trading_data_count + others_data_count > 0) {
     SPDLOG_DEBUG("store states data take {}ns, trading data count {}, others data count {}",
                  store_state_data_end_time - store_state_data_start_time, trading_data_count, others_data_count);
@@ -360,7 +360,7 @@ void cached::store_states_feeds() {
 
 void cached::store_profile_feeds() {
   ProfileStateBank tmp_profile_bank = ProfileStateBank(ProfileDataTypes);
-  auto store_profile_data_start_time = time::now_in_nano();
+  auto store_profile_data_start_time = yijinjing::time::now_in_nano();
 
   feed_mutex_.lock();
   auto count = transfer_from_bank<ProfileStateBank, ProfileStateBank>(
@@ -391,7 +391,7 @@ void cached::store_profile_feeds() {
     profile_store_mutex_.unlock();
   });
 
-  auto store_profile_data_end_time = time::now_in_nano();
+  auto store_profile_data_end_time = yijinjing::time::now_in_nano();
   if (count > 0) {
     SPDLOG_DEBUG("store profile data take {}ns, count {}", store_profile_data_end_time - store_profile_data_start_time,
                  count);
@@ -418,7 +418,7 @@ int64_t cached::find_last_active_time(const location_ptr &location) {
   return session_builder_.find_last_active_time(location);
 }
 
-void cached::update_session(const journal::frame_ptr &frame) {
+void cached::update_session(const yijinjing::journal::frame_ptr &frame) {
   if (bypass_cached_ or storage_pause_) {
     return;
   }
@@ -427,4 +427,4 @@ void cached::update_session(const journal::frame_ptr &frame) {
 
 void cached::switch_feed_storage(bool pause_storage) { storage_pause_ = pause_storage; }
 
-} // namespace kungfu::yijinjing::cache
+} // namespace kungfu::cache

--- a/framework/core/src/libkungfu/yijinjing/cache/profile.cpp
+++ b/framework/core/src/libkungfu/yijinjing/cache/profile.cpp
@@ -10,7 +10,7 @@ using namespace kungfu::longfist;
 using namespace kungfu::longfist::enums;
 using namespace kungfu::yijinjing::data;
 
-namespace kungfu::yijinjing::cache {
+namespace kungfu::cache {
 
 std::string default_db_file(const locator_ptr &locator) {
   auto config_location = std::make_shared<location>(mode::LIVE, category::SYSTEM, "etc", "kungfu", locator);
@@ -28,8 +28,8 @@ void profile::setup() {
   storage->sync_schema();
 }
 
-yijinjing::cache::ProfileStoragePtr &profile::get_storage() {
-  static auto storage = yijinjing::cache::make_storage_ptr(profile_db_file_, ProfileDataTypes);
+cache::ProfileStoragePtr &profile::get_storage() {
+  static auto storage = cache::make_storage_ptr(profile_db_file_, ProfileDataTypes);
   return storage;
 }
-} // namespace kungfu::yijinjing::cache
+} // namespace kungfu::cache

--- a/framework/core/src/libkungfu/yijinjing/index/session.cpp
+++ b/framework/core/src/libkungfu/yijinjing/index/session.cpp
@@ -12,18 +12,18 @@ using namespace kungfu::longfist;
 using namespace kungfu::longfist::enums;
 using namespace kungfu::longfist::types;
 using namespace kungfu::yijinjing;
-using namespace kungfu::yijinjing::cache;
+using namespace kungfu::cache;
 using namespace kungfu::yijinjing::data;
 using namespace kungfu::yijinjing::journal;
 
-namespace kungfu::yijinjing::index {
-std::string get_index_db_file(const io_device_ptr &io_device) {
+namespace kungfu::index {
+std::string get_index_db_file(const yijinjing::io_device_ptr &io_device) {
   auto locator = io_device->get_locator();
   auto index_location = location::make_shared(mode::LIVE, category::SYSTEM, "journal", "index", locator);
   return locator->layout_file(index_location, layout::SQLITE, "index");
 }
 
-session_finder::session_finder(const io_device_ptr &io_device)
+session_finder::session_finder(const yijinjing::io_device_ptr &io_device)
     : io_device_(io_device),
       session_storage_(cache::make_storage_ptr(get_index_db_file(io_device), longfist::SessionDataTypes)) {
   if (not session_storage_->sync_schema_simulate().empty()) {
@@ -33,7 +33,7 @@ session_finder::session_finder(const io_device_ptr &io_device)
 
 session_finder::~session_finder() { io_device_.reset(); }
 
-int64_t session_finder::find_last_active_time(const data::location_ptr &source_location) {
+int64_t session_finder::find_last_active_time(const yijinjing::data::location_ptr &source_location) {
   auto range = where(eq(&Session::location_uid, source_location->uid));
   auto order = order_by(&Session::begin_time).desc();
   auto sessions = session_storage_->get_all<Session>(range, order, limit(1));
@@ -55,7 +55,7 @@ SessionVector session_finder::find_sessions_for(const location_ptr &source_locat
   return session_storage_->get_all<Session>(range, order_by(bt));
 }
 
-session_builder::session_builder(const io_device_ptr &io_device) : session_finder(io_device) {
+session_builder::session_builder(const yijinjing::io_device_ptr &io_device) : session_finder(io_device) {
   std::lock_guard<std::mutex> lock(update_session_mutex_);
   if (not session_storage_->sync_schema_simulate().empty()) {
     session_storage_->sync_schema();
@@ -64,7 +64,7 @@ session_builder::session_builder(const io_device_ptr &io_device) : session_finde
   session_storage_->pragma.synchronous(0);
 }
 
-int64_t session_builder::find_last_active_time(const data::location_ptr &source_location) {
+int64_t session_builder::find_last_active_time(const yijinjing::data::location_ptr &source_location) {
   return session_finder::find_last_active_time(source_location);
 }
 
@@ -214,4 +214,4 @@ SessionMap &session_builder::get_all_sessions() {
   std::lock_guard<std::mutex> lock(update_session_mutex_);
   return live_sessions_;
 }
-} // namespace kungfu::yijinjing::index
+} // namespace kungfu::index

--- a/framework/core/src/libkungfu/yijinjing/practice/apprentice.cpp
+++ b/framework/core/src/libkungfu/yijinjing/practice/apprentice.cpp
@@ -16,14 +16,14 @@ using namespace kungfu::longfist::types;
 using namespace kungfu::longfist::enums;
 using namespace kungfu::yijinjing;
 using namespace kungfu::yijinjing::data;
-using namespace kungfu::yijinjing::cache;
+using namespace kungfu::cache;
 using namespace std::chrono;
 namespace fs = std::filesystem;
 
-namespace kungfu::yijinjing::practice {
+namespace kungfu::practice {
 
-apprentice::apprentice(const data::location_ptr &home, bool low_latency, std::string arguments)
-    : apprentice(std::make_shared<io_device_client>(home, low_latency), std::move(arguments)) {}
+apprentice::apprentice(const yijinjing::data::location_ptr &home, bool low_latency, std::string arguments)
+    : apprentice(std::make_shared<yijinjing::io_device_client>(home, low_latency), std::move(arguments)) {}
 
 apprentice::apprentice(const yijinjing::io_device_ptr &io_device, std::string arguments)
     : hero(io_device), manager_(*this), arguments_(std::move(arguments)) {}
@@ -285,7 +285,7 @@ void apprentice::reader_join(uint32_t source_id, uint32_t dest_id, int64_t from_
 }
 
 void apprentice::checkin() {
-  auto now = time::now_in_nano();
+  auto now = yijinjing::time::now_in_nano();
   auto home = get_live_home();
   Register register_data{};
   register_data.mode = home->mode;
@@ -329,7 +329,7 @@ void apprentice::expect_start() {
 }
 
 void apprentice::reset_time(const longfist::types::TimeReset &time_reset) {
-  time::reset(time_reset.system_clock_count, time_reset.steady_clock_count);
+  yijinjing::time::reset(time_reset.system_clock_count, time_reset.steady_clock_count);
 }
 
 std::thread &apprentice::get_resource_management_worker() { return manager_.get_resource_management_worker(); }
@@ -340,9 +340,9 @@ bool apprentice::is_timer_enabled(int32_t timer_id) { return timers_.try_emplace
 
 void apprentice::enable_timer(int32_t timer_id) { timers_.insert_or_assign(timer_id, true); }
 
-journal::writer_ptr &apprentice::get_thread_writer(uint64_t page_size) {
+yijinjing::journal::writer_ptr &apprentice::get_thread_writer(uint64_t page_size) {
   if (not thread_writer_) {
-    uint32_t dest_id = util::get_thread_id();
+    uint32_t dest_id = yijinjing::util::get_thread_id();
     thread_writer_ = get_io_device()->open_writer(dest_id, page_size);
 
     /// join channel in sub-thread will crash, so tell master to ask myself to join
@@ -361,6 +361,6 @@ journal::writer_ptr &apprentice::get_thread_writer(uint64_t page_size) {
   return thread_writer_;
 }
 
-journal::writer_ptr &apprentice::get_public_writer() { return public_writer_; }
+yijinjing::journal::writer_ptr &apprentice::get_public_writer() { return public_writer_; }
 
-} // namespace kungfu::yijinjing::practice
+} // namespace kungfu::practice

--- a/framework/core/src/libkungfu/yijinjing/practice/hero.cpp
+++ b/framework/core/src/libkungfu/yijinjing/practice/hero.cpp
@@ -18,29 +18,29 @@ using namespace kungfu::longfist::enums;
 using namespace kungfu::longfist::types;
 using namespace kungfu::yijinjing;
 using namespace kungfu::yijinjing::util;
-using namespace kungfu::yijinjing::cache;
+using namespace kungfu::cache;
 using namespace kungfu::yijinjing::data;
 using namespace kungfu::yijinjing::journal;
 using namespace kungfu::yijinjing::nanomsg;
 
-namespace kungfu::yijinjing::practice {
+namespace kungfu::practice {
 
-inline std::string encode(const io_device_ptr &io_device) {
+inline std::string encode(const yijinjing::io_device_ptr &io_device) {
   auto home_uid =
       io_device->get_home()->mode == mode::BACKTEST ? io_device->get_home()->uid : io_device->get_live_home()->uid;
   return fmt::format("{:08x}", home_uid);
 }
 
-hero::hero(io_device_ptr io_device)
-    : begin_time_(time::now_in_nano()), end_time_(INT64_MAX),
+hero::hero(yijinjing::io_device_ptr io_device)
+    : begin_time_(yijinjing::time::now_in_nano()), end_time_(INT64_MAX),
       master_home_location_(make_system_location("master", "master", io_device->get_locator())),
       master_cmd_location_(
           make_system_location("master", encode(io_device), io_device->get_locator(), io_device->get_home()->seed)),
       ledger_home_location_(make_system_location("service", "ledger", io_device->get_locator())),
-      io_device_(std::move(io_device)), now_(0), main_thread_id_(util::get_thread_id()) {
+      io_device_(std::move(io_device)), now_(0), main_thread_id_(yijinjing::util::get_thread_id()) {
 
   os::handle_os_signals(this);
-  util::set_error_log_dir(get_locator()->layout_dir(get_home(), layout::LOG));
+  yijinjing::util::set_error_log_dir(get_locator()->layout_dir(get_home(), layout::LOG));
   reader_ = io_device_->open_reader_to_subscribe();
 }
 
@@ -89,7 +89,7 @@ void hero::step(uint32_t step_limit) {
 
 void hero::run(uint32_t step_limit) {
   SPDLOG_INFO("[{:08x}] {} running", get_home_uid(), get_home_uname());
-  SPDLOG_DEBUG("from {} until {}", time::strftime(begin_time_), time::strftime(end_time_));
+  SPDLOG_DEBUG("from {} until {}", yijinjing::time::strftime(begin_time_), yijinjing::time::strftime(end_time_));
   step_limit_ = step_limit;
   pre_setup();
   setup();
@@ -125,7 +125,7 @@ int64_t hero::get_end_time() const { return end_time_; }
 
 const locator_ptr &hero::get_locator() const { return io_device_->get_locator(); }
 
-io_device_ptr hero::get_io_device() const { return io_device_; }
+yijinjing::io_device_ptr hero::get_io_device() const { return io_device_; }
 
 const location_ptr &hero::get_home() const { return get_io_device()->get_home(); }
 
@@ -140,14 +140,14 @@ uint32_t hero::get_live_home_uid() const { return get_io_device()->get_live_home
 reader_ptr hero::get_reader() const { return reader_; }
 
 bool hero::has_writer(uint32_t dest_id) const {
-  if (util::get_thread_id() != main_thread_id_) {
+  if (yijinjing::util::get_thread_id() != main_thread_id_) {
     return has_band_writer(dest_id) or writers_.find(dest_id) != writers_.end();
   }
   return writers_.find(dest_id) != writers_.end();
 }
 
 writer_ptr hero::get_writer(uint32_t dest_id) const {
-  if (util::get_thread_id() != main_thread_id_) {
+  if (yijinjing::util::get_thread_id() != main_thread_id_) {
     try {
       return get_band_writer(dest_id);
     } catch (const std::exception &e) {
@@ -228,7 +228,7 @@ const std::unordered_map<uint64_t, longfist::types::Channel> &hero::get_channels
 
 const std::unordered_map<uint32_t, longfist::types::Register> &hero::get_registry() const { return registry_; }
 
-const std::unordered_map<uint32_t, data::location_ptr> &hero::get_locations() const { return locations_; }
+const std::unordered_map<uint32_t, yijinjing::data::location_ptr> &hero::get_locations() const { return locations_; }
 
 bool hero::has_band(uint32_t source, uint32_t dest) const { return has_band(make_source_dest_hash(source, dest)); }
 
@@ -298,7 +298,7 @@ void hero::add_location(int64_t, const location_ptr &location) {
 }
 
 void hero::add_location(int64_t trigger_time, const Location &location) {
-  add_location(trigger_time, data::location::make_shared(location, get_locator()));
+  add_location(trigger_time, yijinjing::data::location::make_shared(location, get_locator()));
 }
 
 void hero::remove_location(int64_t trigger_time, uint32_t location_uid) { locations_.erase(location_uid); }
@@ -395,7 +395,7 @@ void hero::require_write_to(int64_t trigger_time, uint32_t source_id, uint32_t d
   writer->close_data();
 }
 
-void hero::require_write_to_band(int64_t trigger_time, uint32_t source_id, const data::location_ptr &location,
+void hero::require_write_to_band(int64_t trigger_time, uint32_t source_id, const yijinjing::data::location_ptr &location,
                                  uint64_t page_size) const {
   auto writer = get_writer(source_id);
   RequestWriteToBand msg = {};
@@ -430,7 +430,7 @@ void hero::deal_notice(bool bypass, bool notify, const rx::subscriber<event_ptr>
     return;
 
   const std::string &notice = io_device_->get_observer()->get_notice();
-  now_ = time::now_in_nano();
+  now_ = yijinjing::time::now_in_nano();
   if (notice.length() > 2) {
     const auto frame = std::make_shared<nanomsg_json>(notice);
     io_device_->get_bus()->set_trigger_frame(frame);
@@ -462,12 +462,12 @@ bool hero::drain(const rx::subscriber<event_ptr> &sb) {
       reader_->next();
       cleanup_reader_disjoin();
     } else {
-      SPDLOG_INFO("reached journal end {}", time::strftime(frame->gen_time()));
+      SPDLOG_INFO("reached journal end {}", yijinjing::time::strftime(frame->gen_time()));
       return false;
     }
   }
   if (get_io_device()->get_home()->mode != mode::LIVE and not reader_->data_available()) {
-    SPDLOG_INFO("reached journal end {}", time::strftime(now()));
+    SPDLOG_INFO("reached journal end {}", yijinjing::time::strftime(now()));
     return false;
   }
   return true;
@@ -477,7 +477,7 @@ void hero::delegate_produce(hero *instance, const rx::subscriber<event_ptr> &sub
 #ifdef _WINDOWS
   __try {
     instance->produce(subscriber);
-  } __except (util::print_stack_trace(GetExceptionInformation())) {
+  } __except (yijinjing::util::print_stack_trace(GetExceptionInformation())) {
   }
 #else
   instance->produce(subscriber);
@@ -679,4 +679,4 @@ void hero::read_location_from_rocksdb() {
     }
   }
 }
-} // namespace kungfu::yijinjing::practice
+} // namespace kungfu::practice

--- a/framework/core/src/libkungfu/yijinjing/practice/master.cpp
+++ b/framework/core/src/libkungfu/yijinjing/practice/master.cpp
@@ -15,14 +15,14 @@ using namespace kungfu::rx;
 using namespace kungfu::longfist;
 using namespace kungfu::longfist::types;
 using namespace kungfu::longfist::enums;
-using namespace kungfu::yijinjing::cache;
+using namespace kungfu::cache;
 using namespace kungfu::yijinjing::data;
 using namespace kungfu::yijinjing::journal;
 
-namespace kungfu::yijinjing::practice {
+namespace kungfu::practice {
 
 master::master(const location_ptr &home, bool low_latency)
-    : master(std::make_shared<io_device_master>(home, low_latency)) {}
+    : master(std::make_shared<yijinjing::io_device_master>(home, low_latency)) {}
 
 master::master(const yijinjing::io_device_ptr &io_device) : hero(io_device), last_check_(0), cached_(io_device) {}
 
@@ -53,7 +53,7 @@ void master::notify_deregister_on_exit() {
     auto &session = iter.second;
     auto location_from_session = location::make_shared(session, get_locator());
     if (session.location_uid != master_home_location_->uid) {
-      get_writer(location::PUBLIC)->write(time::now_in_nano(), location_from_session->to<Deregister>());
+      get_writer(location::PUBLIC)->write(yijinjing::time::now_in_nano(), location_from_session->to<Deregister>());
     }
   }
 }
@@ -66,7 +66,7 @@ void master::notify_master_deregister_on_exit() {
 
     if (has_writer(session.location_uid)) {
       auto writer = get_writer(session.location_uid);
-      writer->write(time::now_in_nano(), master_home_location_->to<Deregister>());
+      writer->write(yijinjing::time::now_in_nano(), master_home_location_->to<Deregister>());
     } else {
       SPDLOG_WARN("no writer {} {}", session.location_uid, get_location_uname(session.location_uid));
     }
@@ -74,20 +74,20 @@ void master::notify_master_deregister_on_exit() {
 }
 
 void master::mark_session_end_on_exit() {
-  get_writer(location::PUBLIC)->mark(time::now_in_nano(), SessionEnd::tag);
+  get_writer(location::PUBLIC)->mark(yijinjing::time::now_in_nano(), SessionEnd::tag);
   auto &live_sessions = cached_.get_all_sessions();
   for (auto &iter : live_sessions) {
     auto &session = iter.second;
     if (has_writer(session.location_uid)) {
       auto writer = get_writer(session.location_uid);
-      writer->mark(time::now_in_nano(), SessionEnd::tag);
+      writer->mark(yijinjing::time::now_in_nano(), SessionEnd::tag);
     } else {
       SPDLOG_WARN("no writer {} {}", session.location_uid, get_location_uname(session.location_uid));
     }
   }
 
   // have to use new now, ensuring later than all messages
-  cached_.close_all_sessions(time::now_in_nano());
+  cached_.close_all_sessions(yijinjing::time::now_in_nano());
 }
 
 void master::on_notify() { get_io_device()->get_publisher()->notify(); }
@@ -110,7 +110,7 @@ void master::register_app(const event_ptr &event) {
   register_location(event->gen_time(), register_data);
   try_add_location(event->gen_time(), app_location);
 
-  auto now = time::now_in_nano();
+  auto now = yijinjing::time::now_in_nano();
   auto uid_str = fmt::format("{:08x}", app_location->uid);
   auto master_cmd_location =
       location::make_shared(mode::LIVE, category::SYSTEM, "master", uid_str, home->locator, app_location->seed);
@@ -142,7 +142,7 @@ void master::register_app(const event_ptr &event) {
 
   write_time_reset(event->gen_time(), app_cmd_writer);
   app_cmd_writer->mark(event->gen_time(), SessionStart::tag);
-  app_cmd_writer->mark(time::now_in_nano(), RequestStart::tag);
+  app_cmd_writer->mark(yijinjing::time::now_in_nano(), RequestStart::tag);
 
   // have to be at this position, for triggering strategy(other) prepare
   write_locations(event->gen_time(), app_cmd_writer);
@@ -174,7 +174,7 @@ void master::deregister_app(int64_t trigger_time, uint32_t app_location_uid) {
   const Deregister deregister = location->to<Deregister>();
   SPDLOG_DEBUG("Deregister: {}", deregister.to_string());
   get_writer(location::PUBLIC)->write(trigger_time, deregister);
-  cached_.close_session(location, time::now_in_nano());
+  cached_.close_session(location, yijinjing::time::now_in_nano());
 }
 
 void master::on_request_deregister(const event_ptr &event) {
@@ -210,15 +210,15 @@ void master::react() {
   events_ | is(CacheReset::tag) | $([&](const event_ptr &event) { cached_.cache_reset(event); });
   events_ | is(CachedPause::tag) | $$(cached_.switch_feed_storage(true));
   events_ | is(CachedResume::tag) | $$(cached_.switch_feed_storage(false));
-  events_ | instanceof <journal::frame>() | $$(feed(event));
+  events_ | instanceof <yijinjing::journal::frame>() | $$(feed(event));
 
   // have to be at bottom of react, for avoid event still required after reader disjoin
   events_ | is(RequestDeregister::tag) | $$(on_request_deregister(event));
 }
 
 void master::on_active() {
-  auto now = time::now_in_nano();
-  if (last_check_ + time_unit::NANOSECONDS_PER_SECOND < now) {
+  auto now = yijinjing::time::now_in_nano();
+  if (last_check_ + yijinjing::time_unit::NANOSECONDS_PER_SECOND < now) {
     on_interval_check(now);
     last_check_ = now;
   }
@@ -228,7 +228,7 @@ void master::on_active() {
 void master::on_frame() { handle_timer_tasks(); }
 
 void master::handle_timer_tasks() {
-  auto now = time::now_in_nano();
+  auto now = yijinjing::time::now_in_nano();
   for (auto &app : timer_tasks_) {
     uint32_t app_id = app.first;
     auto &app_tasks = app.second;
@@ -262,7 +262,7 @@ void master::feed(const event_ptr &event) {
     return;
   }
 
-  cached_.update_session(std::dynamic_pointer_cast<journal::frame>(event));
+  cached_.update_session(std::dynamic_pointer_cast<yijinjing::journal::frame>(event));
 
   if (event->dest() == location::SYNC) {
     return;
@@ -409,12 +409,12 @@ void master::on_time_request(const event_ptr &event) {
 
 void master::on_new_location(const event_ptr &event) {
   const Location &location = event->data<Location>();
-  try_add_location(event->gen_time(), data::location::make_shared(location, get_locator()));
+  try_add_location(event->gen_time(), yijinjing::data::location::make_shared(location, get_locator()));
   get_writer(location::PUBLIC)->write(event->gen_time(), location);
 }
 
 void master::write_time_reset(int64_t, const writer_ptr &writer) {
-  auto time_base = time::get_base();
+  auto time_base = yijinjing::time::get_base();
   TimeReset &time_reset = writer->open_data<TimeReset>();
   time_reset.system_clock_count = time_base.system_clock_count;
   time_reset.steady_clock_count = time_base.steady_clock_count;
@@ -447,4 +447,4 @@ void master::write_bands(int64_t trigger_time, const writer_ptr &writer) {
 
 bool master::is_reactable(const event_ptr &event) { return not is_custom_event(event); }
 
-} // namespace kungfu::yijinjing::practice
+} // namespace kungfu::practice

--- a/framework/core/src/libkungfu/yijinjing/practice/resource_manager.cpp
+++ b/framework/core/src/libkungfu/yijinjing/practice/resource_manager.cpp
@@ -1,10 +1,10 @@
 
 #include <kungfu/yijinjing/practice/apprentice.h>
 
-using namespace kungfu::yijinjing::practice;
+using namespace kungfu::practice;
 using namespace kungfu::longfist::enums;
 
-namespace kungfu::yijinjing::practice {
+namespace kungfu::practice {
 
 resource_manager::resource_manager(apprentice &app) : app_(app) {}
 
@@ -46,4 +46,4 @@ resource_manager::~resource_manager() {
   }
 }
 
-} // namespace kungfu::yijinjing::practice
+} // namespace kungfu::practice

--- a/framework/core/src/libkungfu/yijinjing/util/signal.cpp
+++ b/framework/core/src/libkungfu/yijinjing/util/signal.cpp
@@ -12,7 +12,7 @@
 using namespace kungfu::yijinjing::util;
 
 namespace kungfu::yijinjing::os {
-static yijinjing::practice::hero *hero_instance = {};
+static practice::hero *hero_instance = {};
 static bool signals_handler_enabled = true;
 
 void stop_hero() {
@@ -130,7 +130,7 @@ void handle_os_signals(void *hero) {
     throw yijinjing_error("kungfu can only have one hero instance per process");
   }
 
-  hero_instance = static_cast<yijinjing::practice::hero *>(hero);
+  hero_instance = static_cast<practice::hero *>(hero);
 
   if (not signals_handler_enabled) {
     KF_LOG_WARN("OS signals hander disabled");


### PR DESCRIPTION
Move the runtime components practice, cache and index out of kungfu::yijinjing into top-level namespaces (kungfu::practice / kungfu::cache / kungfu::index) so the namespace boundary matches the physical boundary drawn by the libyijinjing extraction. References that had been resolving through the old enclosing namespace are explicitly qualified with yijinjing::, matching the existing wingchun convention. Include paths unchanged, no compatibility aliases, pure rename (83 files, symmetric replacement). libkungfu + fact-ledger slice build green; run_slice.sh verifies end to end; check-deps.sh passes.