### PR TITLE
docs(adr): adopt KFD-1 release versioning via ADR-0010 with welded-surface register

### DIFF
--- a/docs/MAP.md
+++ b/docs/MAP.md
@@ -26,6 +26,7 @@ and the map routes a question to whichever doc answers it.
 | What do the terms mean (`kfc` / `longfist` / journal …)? | [`concepts.md`](concepts.md) | use | stable |
 | Why is it built this way? What is load-bearing? | [`design-philosophy.md`](design-philosophy.md) | why | stable |
 | Why this versioning / release design (don't replace it naively)? | [`version-release-design.md`](version-release-design.md) | why | stable |
+| When must a change open a minor or major (and when must it not)? | [`versioning.md`](versioning.md) (rule: KFD-1, adopted by ADR-0010) | verify | stable |
 | Why was a past decision made? | [`../framework/core/docs/adr/`](../framework/core/docs/adr) | why | stable |
 | How is the repository layered? | [`architecture.md`](architecture.md) | use | stable |
 | What are the known limits / what is *not* yet guaranteed? | [`known-limits.md`](known-limits.md) | verify | stable |

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -1,0 +1,33 @@
+# Versioning — welded surfaces and the decision log
+
+How this repository decides patch, minor, and major. The rule is
+[KFD-1](https://github.com/kungfu-systems/kfd/blob/dev/v1/v1.0/decisions/kfd-0001-release-versioning.md)
+(adopted by [ADR-0010](../framework/core/docs/adr/ADR-0010-adopt-kfd-1-release-versioning.md));
+this document is the living register and decision log — it does not restate
+the rule. For what each surface guarantees and how to verify it, see
+[`contracts.md`](contracts.md); for how lines are opened and maintained, see
+[`version-release-design.md`](version-release-design.md).
+
+## Welded-surface register
+
+| ID | Surface | Kind | Where it is specified |
+|---|---|---|---|
+| `longfist-layout` | longfist binary layout (in-memory == wire == on-disk) | integration + cross-time | [ADR-0008](../framework/core/docs/adr/ADR-0008-longfist-schema-evolution-and-minor-maintenance.md), [`contracts.md`](contracts.md) |
+| `capability-sdk-api` | capability SDK surface (`framework/api`) | integration | [ADR-0006](../framework/core/docs/adr/ADR-0006-v4-frontend-platform-architecture.md) |
+| `kfx-contract` | kfx extension contract (contribution points, load semantics) | integration | [ADR-0006](../framework/core/docs/adr/ADR-0006-v4-frontend-platform-architecture.md), [ADR-0007](../framework/core/docs/adr/ADR-0007-v4-tui-platform-reference-surface.md) |
+| `kfc-cli` | kfc CLI surface (commands, journal subcommand output conventions) | integration | [`debugging.md`](debugging.md) |
+| `journal-replayability` | cross-version cold-path decode of recorded journals | cross-time | [ADR-0008](../framework/core/docs/adr/ADR-0008-longfist-schema-evolution-and-minor-maintenance.md) |
+
+A surface is registered when consumers bind to it at integration time without
+runtime negotiation, or when its outputs remain depended on after the run.
+Register changes are maintainer decisions and are logged below.
+
+## Decision log
+
+Line openings (minor/major), register changes, and deprecations are recorded
+here, newest first. Patches are intentionally absent — silence means no
+registered surface was touched.
+
+| Date | Action | Line | Faces | Class | Rationale | PR |
+|---|---|---|---|---|---|---|
+| 2026-07-02 | register | — | longfist-layout, capability-sdk-api, kfx-contract, kfc-cli, journal-replayability | additive | Initial register established on adopting KFD-1 (ADR-0010) | — |

--- a/framework/core/docs/adr/ADR-0010-adopt-kfd-1-release-versioning.md
+++ b/framework/core/docs/adr/ADR-0010-adopt-kfd-1-release-versioning.md
@@ -1,0 +1,53 @@
+# ADR-0010: adopt KFD-1 — welded-surface registers decide patch, minor, and major
+
+- Status: accepted
+- Date: 2026-07-02
+- Category: (principle) version governance — adoption of an organization-wide rule
+- Subsystem: whole repository (release lines, longfist layout, capability SDK, kfx contract, kfc CLI)
+- Related: generalizes [ADR-0008](ADR-0008-longfist-schema-evolution-and-minor-maintenance.md)
+  (the longfist layout as the true invariant) from one surface to a register of
+  surfaces; complements `docs/version-release-design.md` (the mechanism that
+  opens and maintains lines; KFD-1 decides *when* a line must or must not open).
+
+## Decision
+
+Adopt [KFD-1](https://github.com/kungfu-systems/kfd/blob/dev/v1/v1.0/decisions/kfd-0001-release-versioning.md)
+as this repository's versioning rule. KFD-1 classifies every change against a
+**welded-surface register**: breaking a registered surface forces a major;
+additively evolving a surface or adding one opens a minor; a change that
+touches no registered surface is a patch regardless of size; an unclassifiable
+change means the register itself is deficient and must be fixed first.
+
+This repository's living register and decision log are kept in
+[`docs/versioning.md`](../../../../docs/versioning.md). This ADR is the
+immutable adoption record; the rule text itself lives in the KFD registry and
+is not restated here.
+
+## Context
+
+ADR-0008 already established that the longfist binary layout is the true
+compatibility invariant beneath the tag, and that minor lines pin layout
+epochs. It answered "what happens when the layout changes" but left open what
+a breaking change to any *other* contract surface — the capability SDK, the
+kfx extension contract, the kfc CLI — implies for version lines, and when a
+new line should *not* be opened. KFD-1 generalizes ADR-0008's move: the layout
+becomes one entry in a register of welded surfaces, and the decision procedure
+covers all of them uniformly.
+
+## Consequences
+
+- The longfist layout keeps its ADR-0008 semantics as the register entry
+  `longfist-layout`; nothing about hot-path pinning or cold-path additive
+  evolution changes.
+- Breaking the capability SDK or the kfx contract without touching the layout
+  is now, explicitly, a major.
+- Feature volume no longer has version semantics: features ride patches on the
+  current line unless a registered surface changed.
+- Line openings and register changes must be recorded in the decision log in
+  `docs/versioning.md`; patches stay silent by design.
+
+## Reversibility
+
+Adopting a classification rule is process, not code: reversal means recording
+a superseding decision, not migrating data. The register and decision log
+remain useful history either way.

--- a/framework/core/docs/adr/README.md
+++ b/framework/core/docs/adr/README.md
@@ -26,6 +26,7 @@ A record's **Status** says where it stands:
 | [0007](ADR-0007-v4-tui-platform-reference-surface.md) | accepted | v4 TUI = the platform's second reference surface |
 | [0008](ADR-0008-longfist-schema-evolution-and-minor-maintenance.md) | proposed | longfist binary layout as the true compatibility invariant; schema-evolution policy |
 | [0009](ADR-0009-load-bearing-self-bootstrap.md) | accepted | load-bearing self-bootstrap — the adoption path is the validation path |
+| [0010](ADR-0010-adopt-kfd-1-release-versioning.md) | accepted | adopt KFD-1 — welded-surface registers decide patch, minor, and major |
 
 ## Reading by theme
 


### PR DESCRIPTION
Merge docs/kfd-adoption into dev/v4/v4.0 (kungfu-systems zone dual-account PR flow).