### PR TITLE
feat(core): make the yijinjing core embeddable standalone

### DIFF
--- a/framework/core/src/libyijinjing/CMakeLists.txt
+++ b/framework/core/src/libyijinjing/CMakeLists.txt
@@ -8,15 +8,53 @@
 # type registry, nng, rxcpp, sqlite or rocksdb. libkungfu links this target
 # and must not recompile these sources; minimal tools (fact-ledger slice)
 # link only this target.
+#
+# This file is self-sufficient on purpose: inside the kungfu build the parent
+# provides toolchain, dependency targets and output conventions, and every
+# block below defers to them; embedded standalone (add_subdirectory /
+# FetchContent from another project) the fallbacks kick in. The embedding
+# contract is documented in EMBEDDING.md next to this file.
 
-project(yijinjing)
+cmake_minimum_required(VERSION 3.15)
+project(yijinjing CXX)
+
+# header-only dependencies -- resolved here only when no enclosing build
+# already provides the targets (the kungfu build supplies them via conan)
+if(NOT TARGET fmt::fmt-header-only AND NOT TARGET fmt::fmt)
+  find_package(fmt REQUIRED)
+endif()
+if(NOT TARGET spdlog::spdlog_header_only AND NOT TARGET spdlog::spdlog)
+  find_package(spdlog REQUIRED)
+endif()
+if(NOT TARGET nlohmann_json::nlohmann_json)
+  find_package(nlohmann_json REQUIRED)
+endif()
 
 file(GLOB_RECURSE YIJINJING_SOURCE_FILES ${PROJECT_SOURCE_DIR}/src/*.cpp)
 
 add_library(yijinjing STATIC ${YIJINJING_SOURCE_FILES})
+# the ADR-0001 publication protocol uses std::atomic_ref; a target-level
+# requirement holds even when the embedder's global standard is older
+target_compile_features(yijinjing PUBLIC cxx_std_20)
 # linked into the SHARED libkungfu on Mac/Linux
-set_target_properties(yijinjing PROPERTIES
-  POSITION_INDEPENDENT_CODE ON
-  ARCHIVE_OUTPUT_DIRECTORY ${KUNGFU_BUILD_DIR})
+set_target_properties(yijinjing PROPERTIES POSITION_INDEPENDENT_CODE ON)
+if(DEFINED KUNGFU_BUILD_DIR)
+  set_target_properties(yijinjing PROPERTIES ARCHIVE_OUTPUT_DIRECTORY ${KUNGFU_BUILD_DIR})
+endif()
 target_include_directories(yijinjing PUBLIC ${PROJECT_SOURCE_DIR}/include)
-target_compile_options(yijinjing PRIVATE "$<$<CONFIG:Release>:${COMPILER_OPTIMIZE_ON_OPTIONS}>")
+
+# boost::hana is header-only; the kungfu build puts its vendored copy on the
+# global include path. Standalone, fall back to that same vendored copy when
+# the embedder has not provided <boost/hana.hpp> some other way.
+if(NOT DEFINED KUNGFU_BUILD_DIR AND EXISTS ${PROJECT_SOURCE_DIR}/../../.deps/hana-1.80.0/include)
+  target_include_directories(yijinjing PUBLIC ${PROJECT_SOURCE_DIR}/../../.deps/hana-1.80.0/include)
+endif()
+
+target_link_libraries(yijinjing PUBLIC
+  $<IF:$<TARGET_EXISTS:fmt::fmt-header-only>,fmt::fmt-header-only,fmt::fmt>
+  $<IF:$<TARGET_EXISTS:spdlog::spdlog_header_only>,spdlog::spdlog_header_only,spdlog::spdlog>
+  nlohmann_json::nlohmann_json)
+
+if(DEFINED COMPILER_OPTIMIZE_ON_OPTIONS AND NOT "${COMPILER_OPTIMIZE_ON_OPTIONS}" STREQUAL "")
+  target_compile_options(yijinjing PRIVATE "$<$<CONFIG:Release>:${COMPILER_OPTIMIZE_ON_OPTIONS}>")
+endif()

--- a/framework/core/src/libyijinjing/EMBEDDING.md
+++ b/framework/core/src/libyijinjing/EMBEDDING.md
@@ -1,0 +1,81 @@
+# Embedding the yijinjing journal core
+
+`yijinjing` is the journal spine of kungfu -- frame/page mmap machinery,
+reader/writer, assemble, locator/location and the base utilities they stand
+on -- built as a standalone static library (`libyijinjing.a`). This document
+is the embedding contract: what you get, what you must provide, and what is
+deliberately not offered.
+
+## Distribution form
+
+The supported form is **source embedding of a static target**. There is no
+packaged artifact, no shared library and no ABI promise (see
+"Deliberately not offered" for why and for the escalation criteria).
+
+```cmake
+# your CMakeLists.txt -- nothing from the kungfu build system is required
+add_subdirectory(<kungfu>/framework/core/src/libyijinjing yijinjing)
+
+add_executable(your_tool main.cpp)
+target_link_libraries(your_tool yijinjing)
+```
+
+`<kungfu>` can be a git checkout, a submodule or a FetchContent source
+directory. The target propagates its include directories and C++20
+requirement (`std::atomic_ref` implements the frame publication protocol,
+see ADR-0001), so the consumer needs no extra configuration.
+
+## What you must provide
+
+Header-only dependencies, resolvable as CMake targets via `find_package`
+(any package manager works; the kungfu build itself uses conan 2):
+
+| dependency | accepted targets |
+| --- | --- |
+| fmt | `fmt::fmt-header-only` or `fmt::fmt` |
+| spdlog | `spdlog::spdlog_header_only` or `spdlog::spdlog` |
+| nlohmann_json | `nlohmann_json::nlohmann_json` |
+| boost::hana | any include path providing `<boost/hana.hpp>`; falls back to the repository's vendored copy (`framework/core/.deps/hana-1.80.0`) |
+
+If your enclosing build already defines these targets, the core uses them
+as-is and performs no `find_package` of its own.
+
+## What you get
+
+- target `yijinjing` (STATIC, position-independent), include roots for
+  `<kungfu/common.h>`, `<kungfu/longfist/core.h>` and
+  `<kungfu/yijinjing/...>`;
+- the full journal write/read surface with a noop bus and noop publisher --
+  no master, no event loop, no sockets, no databases. The
+  `fact-ledger-slice/` tools next to this directory are the reference
+  consumers;
+- a dependency-direction guarantee, enforced by `check-deps.sh`: the core
+  never includes runtime, transport or storage headers, the trading type
+  registry, or any trading type.
+
+## Deliberately not offered
+
+- **`libyijinjing.so` / ABI stability.** The API surface is still moving
+  with the runtime fact ledger design. A dynamic library would freeze an
+  interface nobody has embedded against yet and add rpath/ABI failure modes
+  for every regular user of libkungfu.
+- **Package-manager artifacts** (conan/vcpkg/npm/homebrew packages of the
+  core alone). Publishing infrastructure before there is an external
+  consumer inverts the demand direction.
+
+Escalation criteria -- revisit the distribution form when any of these is
+actually true, not before:
+
+1. an embedder outside this repository maintains code against the core and
+   source embedding demonstrably blocks them (submodule/FetchContent churn,
+   toolchain mismatch they cannot control);
+2. the core's public headers have gone a full minor release line without a
+   breaking change, so an interface freeze would describe reality instead
+   of aspiration;
+3. a consumer needs to load the core into a process it does not build
+   (plugin/FFI case) -- the first scenario a static target genuinely cannot
+   serve.
+
+Until then, the static core stays the single supported form, and
+`libkungfu.so/.dylib/.dll` remains the runtime entry point for everything
+user-facing.


### PR DESCRIPTION
Makes src/libyijinjing/CMakeLists.txt self-sufficient so a third-party project can consume the journal core via add_subdirectory alone: dependency targets resolved only when no enclosing build provides them, C++20 declared at target level (std::atomic_ref carries the ADR-0001 publication protocol), vendored hana fallback, parent output/optimization variables optional. EMBEDDING.md pins the contract: source embedding of the static target is the single supported distribution form; .so/ABI stability and standalone package artifacts are deliberately not offered, with three concrete escalation criteria. Verified both ways: an external scratch project builds and re-reads a causally chained journal via add_subdirectory alone; the in-tree build (libkungfu, slice, run_slice.sh, check-deps.sh) is unchanged and green.