### PR TITLE
test(core): pin the embedding contract with a standalone consumer slice

### DIFF
--- a/framework/core/slices/README.md
+++ b/framework/core/slices/README.md
@@ -53,3 +53,4 @@ run slices.
 | Slice | Proof |
 | --- | --- |
 | `fact-ledger/` | The journal spine (yijinjing static core) is embeddable without the trading runtime: a standalone host writes a causal chain of events, an independent tool reopens the directory and exports a checksummed, provenance-carrying JSONL — with zero dynamic dependencies beyond the system runtime. |
+| `embedding/` | The core's distribution form holds: a standalone CMake project (not part of this build; see its README) consumes `src/libyijinjing` via `add_subdirectory`, builds from scratch, and round-trips a causal chain — pinning the `EMBEDDING.md` contract. Its probe runs through `run.sh` like every other slice, but its targets are deliberately absent from this aggregate. |

--- a/framework/core/slices/embedding/CMakeLists.txt
+++ b/framework/core/slices/embedding/CMakeLists.txt
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Embedding slice: a STANDALONE CMake project simulating an external consumer
+# of the yijinjing core (the D30 distribution form: source/static embedding
+# via add_subdirectory; contract in src/libyijinjing/EMBEDDING.md).
+#
+# Deliberately NOT wired into slices/CMakeLists.txt: the proof is that this
+# project configures and builds against src/libyijinjing alone, with no help
+# from the kungfu parent build. run.sh configures it from scratch in a
+# throwaway build directory; the embedder provides its own dependencies
+# (here: the conan toolchain, as any conan-using embedder would).
+
+cmake_minimum_required(VERSION 3.15)
+project(yijinjing_embed_smoke CXX)
+
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../../src/libyijinjing libyijinjing)
+
+add_executable(embed_smoke main.cpp)
+target_link_libraries(embed_smoke yijinjing)

--- a/framework/core/slices/embedding/README.md
+++ b/framework/core/slices/embedding/README.md
@@ -1,0 +1,34 @@
+# Embedding slice
+
+**Probe statement.** This slice pins the distribution form of the yijinjing
+core: source/static embedding via `add_subdirectory` is the one supported way
+to consume it (contract: `src/libyijinjing/EMBEDDING.md`). A standalone CMake
+project — configured from scratch, never through the kungfu parent build —
+pulls in `src/libyijinjing` alone, builds an executable against it, writes a
+causal chain of Json events, reopens the directory with `assemble`, and
+asserts the chain and payloads survived the round trip.
+
+A red run means the embedding contract regressed. The usual suspect: the core
+`CMakeLists.txt` grew a dependency on a kungfu parent-scope variable or
+target, so external embedders can no longer configure it standalone.
+
+## Run
+
+```bash
+# from framework/core (seed the conan toolchain first: conan install / rebuild:core)
+slices/embedding/run.sh
+```
+
+The script configures the embedder in a throwaway build directory using the
+core build's conan toolchain — standing in for the embedder's own dependency
+provisioning (fmt, spdlog, nlohmann_json; see EMBEDDING.md for what an
+embedder must supply). `embed_smoke` exits 0 only if every event read back
+carries the exact `frame_uid` recorded at write time, the causal links match,
+and the Json payloads parse to what was written.
+
+## What this does NOT cover
+
+- Windows (`run.sh` is bash; verify skips slices there).
+- FetchContent-style embedding from outside this repository — same mechanism,
+  but the vendored boost::hana fallback next to the core tree is absent in
+  that layout and the embedder must provide `<boost/hana.hpp>` itself.

--- a/framework/core/slices/embedding/main.cpp
+++ b/framework/core/slices/embedding/main.cpp
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Embedding slice: a minimal EXTERNAL consumer of the yijinjing core.
+//
+// This program is built by a standalone CMake project (see CMakeLists.txt next
+// to this file) that pulls the core in with add_subdirectory -- never through
+// the kungfu parent build. It writes a short causal chain of Json events with
+// a noop bus + noop publisher, closes the writer, reopens the directory with
+// assemble, and asserts the chain survived the round trip.
+//
+// Exit 0 means the embedding contract holds end to end; any other exit means
+// the contract regressed.
+//
+// Usage:  embed_smoke <journal-root-dir>
+
+#include <kungfu/yijinjing/common.h>
+#include <kungfu/yijinjing/journal/assemble.h>
+#include <kungfu/yijinjing/journal/journal.h>
+#include <kungfu/yijinjing/time.h>
+
+#include <nlohmann/json.hpp>
+
+#include <cstdint>
+#include <cstring>
+#include <iostream>
+#include <string>
+#include <vector>
+
+using namespace kungfu::yijinjing;
+namespace longfist = kungfu::longfist;
+using longfist::enums::FrameDataType;
+
+namespace {
+constexpr int32_t MSG_SMOKE = 20001;
+constexpr uint64_t STREAM_ID = 1;
+constexpr std::size_t EVENT_COUNT = 3;
+
+std::string strip_trailing_nuls(std::string s) {
+  while (!s.empty() && s.back() == '\0') {
+    s.pop_back();
+  }
+  return s;
+}
+} // namespace
+
+int main(int argc, char **argv) {
+  if (argc < 2) {
+    std::cerr << "usage: embed_smoke <journal-root-dir>\n";
+    return 2;
+  }
+  const std::string root = argv[1];
+  const std::string group = "embedding_slice";
+  const std::string name = "smoke";
+
+  // ── write side ────────────────────────────────────────────────────
+  std::vector<uint64_t> written_uids;
+  {
+    auto locator = std::make_shared<data::locator>(root);
+    auto location = data::location::make_shared(longfist::enums::mode::LIVE, longfist::enums::category::SYSTEM, group,
+                                                name, locator);
+    auto bus = std::make_shared<journal::bus>(false);
+    auto publisher = std::make_shared<journal::noop_publisher>();
+    auto writer = std::make_shared<journal::writer>(location, data::location::PUBLIC, /*lazy=*/true, publisher,
+                                                    /*low_latency=*/false, bus);
+
+    uint64_t prev_uid = 0;
+    int64_t prev_gen_time = 0;
+    for (std::size_t i = 0; i < EVENT_COUNT; ++i) {
+      const std::string body = nlohmann::json{{"step", i}, {"note", "embedding smoke"}}.dump();
+      bus->set_trigger_frame_uid(prev_uid);
+      const int64_t gen_time = time::now_in_nano();
+      auto frame = writer->open_frame(/*trigger_time=*/prev_gen_time, MSG_SMOKE, body.size(), STREAM_ID);
+      frame->set_data_type(FrameDataType::Json);
+      std::memcpy(const_cast<void *>(frame->data_address()), body.data(), body.size());
+      const uint64_t this_uid = writer->current_frame_uid();
+      writer->close_frame(body.size(), gen_time);
+      written_uids.push_back(this_uid);
+      prev_uid = this_uid;
+      prev_gen_time = gen_time;
+    }
+  } // writer closed; from here on the process only reads the format
+
+  // ── read side: reconstruct the identity, reopen, assert the chain ──
+  auto locator = std::make_shared<data::locator>(root);
+  auto location =
+      data::location::make_shared(longfist::enums::mode::LIVE, longfist::enums::category::SYSTEM, group, name, locator);
+  journal::assemble reader(location, data::location::PUBLIC, longfist::enums::AssembleMode::Channel, 0);
+
+  std::size_t count = 0;
+  uint64_t last_uid = 0;
+  while (reader.data_available()) {
+    auto frame = reader.current_frame();
+    const uint64_t frame_uid = frame->frame_uid();
+    const uint64_t trigger_frame_uid = frame->trigger_frame_uid();
+
+    if (count >= written_uids.size()) {
+      std::cerr << "FAIL: more events read than written\n";
+      return 1;
+    }
+    if (frame_uid != written_uids[count]) {
+      std::cerr << "FAIL: event " << count << " frame_uid mismatch (recomputed instead of read back?)\n";
+      return 1;
+    }
+    if (count == 0 ? trigger_frame_uid != 0 : trigger_frame_uid != last_uid) {
+      std::cerr << "FAIL: causal chain broken at event " << count << "\n";
+      return 1;
+    }
+    const std::string payload = strip_trailing_nuls(frame->data_as_string());
+    const auto parsed = nlohmann::json::parse(payload, nullptr, /*allow_exceptions=*/false);
+    if (parsed.is_discarded() || parsed.value("step", SIZE_MAX) != count) {
+      std::cerr << "FAIL: payload did not round-trip at event " << count << "\n";
+      return 1;
+    }
+    last_uid = frame_uid;
+    ++count;
+    reader.next();
+  }
+
+  if (count != EVENT_COUNT) {
+    std::cerr << "FAIL: wrote " << EVENT_COUNT << " events, read back " << count << "\n";
+    return 1;
+  }
+
+  std::cout << "OK: embedded core wrote and re-read a " << count << "-event causal chain (root: " << root << ")"
+            << std::endl;
+  return 0;
+}

--- a/framework/core/slices/embedding/run.sh
+++ b/framework/core/slices/embedding/run.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Drive the embedding slice end to end:
+#   1. configure the standalone embedder project from scratch in a throwaway
+#      build directory (add_subdirectory of src/libyijinjing; no kungfu parent)
+#   2. build it
+#   3. run embed_smoke: write a causal chain, reopen with assemble, assert
+#
+# Usage: run.sh [core-build-dir]
+#   core-build-dir defaults to ../../build (relative to framework/core); it is
+#   only used to locate the conan toolchain that stands in for the embedder's
+#   own dependency provisioning.
+
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+core_dir="$(cd "${here}/../.." && pwd)"
+core_build="${1:-${core_dir}/build}"
+
+toolchain="${core_build}/conan_toolchain.cmake"
+if [[ ! -f "${toolchain}" ]]; then
+  echo "error: ${toolchain} not found" >&2
+  echo "seed the core build first (conan install / rebuild:core); the embedder" >&2
+  echo "borrows its dependency provisioning from that toolchain." >&2
+  exit 1
+fi
+
+scratch="$(mktemp -d "${TMPDIR:-/tmp}/embedding-slice-build.XXXXXX")"
+work="$(mktemp -d "${TMPDIR:-/tmp}/embedding-slice-journal.XXXXXX")"
+
+echo "== step 1: configure the standalone embedder (scratch: ${scratch})"
+cmake -S "${here}" -B "${scratch}" \
+  -DCMAKE_TOOLCHAIN_FILE="${toolchain}" \
+  -DCMAKE_POLICY_DEFAULT_CMP0091=NEW \
+  -DCMAKE_BUILD_TYPE=Release >/dev/null
+
+echo "== step 2: build"
+cmake --build "${scratch}" --target embed_smoke >/dev/null
+
+echo "== step 3: write + reopen + assert the causal chain"
+"${scratch}/embed_smoke" "${work}"
+
+echo "artifacts in ${work} (embedder build: ${scratch})"


### PR DESCRIPTION
The source/static embedding contract of the yijinjing core (EMBEDDING.md, adopted with the distribution-form decision) previously had no machine guard: it was validated once with a scratch project outside the repository. This adds slices/embedding — a standalone CMake project that consumes src/libyijinjing via add_subdirectory without the kungfu parent build, builds from scratch in a throwaway directory, writes a causal chain and asserts the assemble round trip. verify --full picks it up through the regular slice discovery.