### PR TITLE
feat(cli): promote kungfu to the canonical CLI command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,8 +45,10 @@ for how the layers fit together; the main areas:
 
 Three command-line entry points, kept forward-compatible:
 
-- `kfc` — the runtime CLI (`kfc --version`, journal subcommands, …).
-- `kungfu` — reserved for a future end-user CLI.
+- `kungfu` — the end-user CLI command (`kungfu --version`, journal subcommands,
+  …). It fronts the `kfc` runtime; `kfc` works as a short alias of the same
+  command.
+- `kfc` — the runtime binary that `kungfu` fronts, and the short alias.
 - `./kungfu-code` — the development/build orchestrator used while working on the
   repo (see below).
 

--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ A guiding principle of kungfu is that the machine adapts to the person, not the
 other way around. The `kfc` runtime is batteries-included: it embeds a Python
 and a Node runtime and brings a full Python development lifecycle — dependency
 management, formatting, and ahead-of-time compilation — reachable through
-`kfc engage`. Building a kfx extension does not start by assembling a toolchain:
-most extension development needs no separately installed Python, Node, or
-package manager.
+`kungfu engage`. Building a kfx extension does not start by assembling a
+toolchain: most extension development needs no separately installed Python,
+Node, or package manager.
 
 The runtime deliberately absorbs this complexity so its users do not have to. To
 keep that convenience sustainable rather than bespoke, the absorbed tooling is
@@ -59,8 +59,9 @@ built on mainstream, well-maintained foundations.
 
 - **Core & runtime** — `longfist` (type system) and `yijinjing` (journal
   runtime) with Python and Node bindings, plus the `kfc` runtime, packaged as
-  `@kungfu-tech/core`. `kfc` embeds a Python and a Node runtime and is
-  the base for the planned `kungfu` end-user shell.
+  `@kungfu-tech/core`. `kfc` embeds a Python and a Node runtime and is fronted
+  by the `kungfu` end-user command (`kfc` remains a short alias); the richer
+  end-user shell is planned under the same name.
 - **Capability SDK** — typed, framework-neutral access to journal / state /
   replay (`framework/api`).
 - **Application SDK** — scaffolding to build kfx extensions and assemble
@@ -94,7 +95,7 @@ right document, and is readable by both people and agents.
 
 - [`docs/MAP.md`](docs/MAP.md) — the question-indexed map of all documentation.
 - [`docs/concepts.md`](docs/concepts.md) — the vocabulary in one place
-  (`kfc`/`kfx`/`kfs`, `libkungfu`, `longfist`, `yijinjing`, journal, …).
+  (`kungfu`/`kfc`/`kfx`/`kfs`, `libkungfu`, `longfist`, `yijinjing`, journal, …).
 - [`docs/design-philosophy.md`](docs/design-philosophy.md) — the two first
   principles the whole design follows from, and how the architecture falls out
   of them.

--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -68,5 +68,5 @@ hot path. The boundaries that are **not** zero-copy:
 
 - across processes, frames travel through the mmap journal (still no per-frame
   serialization, but a different mechanism than in-process sharing);
-- any export out of the system (e.g. `kfc journal show -o file.csv`, see
+- any export out of the system (e.g. `kungfu journal show -o file.csv`, see
   [`debugging.md`](debugging.md)) is an explicit, non-zero-copy conversion.

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -12,7 +12,7 @@ principles behind them see [`design-philosophy.md`](design-philosophy.md).
 | `kfc` | The **kungfu core runtime** binary. It embeds a Python and a Node runtime and exposes the journal/state APIs; it is the runtime everything else runs on. |
 | `kfx` | A **kungfu extension** — a plugin built on the extension contract (the units under `extensions/`). |
 | `kfs` | The **application/extension SDK command**: scaffolds and builds `kfx` extensions, assembles applications, and produces packaged artifacts. |
-| `kungfu` | Reserved name for a future **end-user CLI / shell** built on `kfc`. |
+| `kungfu` | The **end-user CLI command** — the canonical way to invoke kungfu from the command line. Today it fronts the `kfc` runtime (same executable, two names; `kfc` remains a short alias); the richer end-user shell is planned to grow under this name. |
 | `./kungfu-code` | The **development/build orchestrator** used while working on the repo (pins Node, Python, and the package manager so a fresh clone builds with one command). It is build-time only, not shipped. |
 
 ## Core building blocks

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -11,12 +11,12 @@ to "what is actually in the journal?" — which you can inspect directly.
 
 ## Inspect the journal
 
-`kfc` exposes a `journal` command group (implemented in
+`kungfu` exposes a `journal` command group (implemented in
 [`console/commands/journal.py`](../framework/core/src/python/kungfu/console/commands/journal.py)):
 
-- **List recorded sessions** — `kfc journal sessions` (sortable, multiple table
-  formats). Tells you what was recorded, when, and by which source.
-- **Show a session's frames** — `kfc journal show -i <session_id>`, selecting
+- **List recorded sessions** — `kungfu journal sessions` (sortable, multiple
+  table formats). Tells you what was recorded, when, and by which source.
+- **Show a session's frames** — `kungfu journal show -i <session_id>`, selecting
   input or output frames, with `-o <file>.csv` to export. This is how you see the
   exact frames a component produced or consumed — the direct answer to "did the
   data actually flow?"
@@ -44,7 +44,7 @@ moment that produced it.
 
 | Symptom | Where to look first |
 |---|---|
-| A reader sees no / stale / torn data | The publish/visibility contract is [ADR-0001](../framework/core/docs/adr/ADR-0001-yijinjing-publish-barrier.md); first confirm with `kfc journal show` whether the frame is in the journal at all. |
+| A reader sees no / stale / torn data | The publish/visibility contract is [ADR-0001](../framework/core/docs/adr/ADR-0001-yijinjing-publish-barrier.md); first confirm with `kungfu journal show` whether the frame is in the journal at all. |
 | Data is there but a language binding reads it wrong | The adapter boundary — see [`adapters.md`](adapters.md); the layout is the contract ([`contracts.md`](contracts.md)). |
 | Replay diverges from live | Determinism boundary — see [`contracts.md`](contracts.md) and `known-limits` on cross-version/cross-machine reproduction. |
 | Build / runtime won't start | The build path — see [`buildchain.md`](buildchain.md). |

--- a/docs/known-limits.md
+++ b/docs/known-limits.md
@@ -60,9 +60,11 @@ infrastructure it would describe (see [`MAP.md`](MAP.md), `provenance.md` —
 
 ## The end-user shell is planned, not shipped
 
-`kfc` is the runtime today. The end-user `kungfu` shell built on it is planned;
-the zero-setup experience is fully real for `kfx` *development* (the runtime
-absorbs the toolchain), and the end-user shell is the part still to come.
+`kfc` is the runtime today, and the `kungfu` command already exists as the
+canonical CLI facade over it (same executable; `kfc` remains a short alias).
+The richer end-user *shell* under that name is still planned; the zero-setup
+experience is fully real for `kfx` *development* (the runtime absorbs the
+toolchain), and the shell is the part still to come.
 
 ## Reference extensions are mid-migration
 

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -15,7 +15,7 @@ the rule. For what each surface guarantees and how to verify it, see
 | `longfist-layout` | longfist binary layout (in-memory == wire == on-disk) | integration + cross-time | [ADR-0008](../framework/core/docs/adr/ADR-0008-longfist-schema-evolution-and-minor-maintenance.md), [`contracts.md`](contracts.md) |
 | `capability-sdk-api` | capability SDK surface (`framework/api`) | integration | [ADR-0006](../framework/core/docs/adr/ADR-0006-v4-frontend-platform-architecture.md) |
 | `kfx-contract` | kfx extension contract (contribution points, load semantics) | integration | [ADR-0006](../framework/core/docs/adr/ADR-0006-v4-frontend-platform-architecture.md), [ADR-0007](../framework/core/docs/adr/ADR-0007-v4-tui-platform-reference-surface.md) |
-| `kfc-cli` | kfc CLI surface (commands, journal subcommand output conventions) | integration | [`debugging.md`](debugging.md) |
+| `kungfu-cli` | kungfu CLI surface (canonical `kungfu` command with `kfc` alias; commands, journal subcommand output conventions) | integration | [`debugging.md`](debugging.md) |
 | `journal-replayability` | cross-version cold-path decode of recorded journals | cross-time | [ADR-0008](../framework/core/docs/adr/ADR-0008-longfist-schema-evolution-and-minor-maintenance.md) |
 
 A surface is registered when consumers bind to it at integration time without
@@ -30,4 +30,5 @@ registered surface was touched.
 
 | Date | Action | Line | Faces | Class | Rationale | PR |
 |---|---|---|---|---|---|---|
+| 2026-07-02 | update | — | kungfu-cli (was kfc-cli) | additive | `kungfu` becomes the canonical CLI command, fronting the `kfc` runtime; `kfc` stays a working alias. Pre-release, no line open, nothing removed | — |
 | 2026-07-02 | register | — | longfist-layout, capability-sdk-api, kfx-contract, kfc-cli, journal-replayability | additive | Initial register established on adopting KFD-1 (ADR-0010) | — |

--- a/framework/core/package.json
+++ b/framework/core/package.json
@@ -16,6 +16,7 @@
     "access": "public"
   },
   "bin": {
+    "kungfu": "lib/kfc.js",
     "kfc": "lib/kfc.js"
   },
   "config": {

--- a/framework/spec/docs/handbooks/cli.md
+++ b/framework/spec/docs/handbooks/cli.md
@@ -1,22 +1,23 @@
-# kungfu CLI handbook — `kfc`
+# kungfu CLI handbook — `kungfu`
 
-> Pre-release (spec 0.1) · minimal recipe. `kfc` is the current kungfu CLI
-> (`@kungfu-tech/core`). The generated command reference (from the CLI's own
-> definitions) and the agent-first `--json` provenance surface are planned; this
-> page is a hand-written getting-started.
+> Pre-release (spec 0.1) · minimal recipe. `kungfu` is the kungfu CLI
+> (`@kungfu-tech/core`); it fronts the `kfc` runtime, and `kfc` works as a
+> short alias of the same command. The generated command reference (from the
+> CLI's own definitions) and the agent-first `--json` provenance surface are
+> planned; this page is a hand-written getting-started.
 
-`kfc` is how you produce and inspect fact-ledger records from the command line.
-Everything below produces or reads the same portable bundle described in the
-[format spec](../../spec/).
+`kungfu` is how you produce and inspect fact-ledger records from the command
+line. Everything below produces or reads the same portable bundle described in
+the [format spec](../../spec/).
 
 ## Install
 
-`kfc` ships with `@kungfu-tech/core`:
+`kungfu` ships with `@kungfu-tech/core`:
 
 ```bash
 pnpm add @kungfu-tech/core
-# kfc is now on your PATH inside the workspace
-kfc --version
+# kungfu is now on your PATH inside the workspace (kfc is an alias)
+kungfu --version
 ```
 
 ## Produce a record
@@ -26,10 +27,10 @@ fact-ledger you can open afterward:
 
 ```bash
 # execute a workflow and record it
-kfc run --mode backtest --category <category> --name <name>
+kungfu run --mode backtest --category <category> --name <name>
 
 # re-run a previously recorded session deterministically
-kfc run --mode replay --name <name>
+kungfu run --mode replay --name <name>
 ```
 
 `run` modes: `live`, `backtest`, `data`, `replay`. `replay` and `backtest` are
@@ -39,16 +40,16 @@ the record-producing paths.
 
 ```bash
 # inspect recorded data over a time window
-kfc tool --begin <t0> --end <t1> --category <category> --name <name>
+kungfu tool --begin <t0> --end <t1> --category <category> --name <name>
 
 # slice a recorded ledger into a portable extract
-kfc slicetool --begin <t0> --end <t1> --name <name>
+kungfu slicetool --begin <t0> --end <t1> --name <name>
 ```
 
 ## Assemble a bundle
 
 ```bash
-kfc assemble <config.json>
+kungfu assemble <config.json>
 ```
 
 ## All commands
@@ -62,11 +63,11 @@ kfc assemble <config.json>
 | `login` | authenticate an account (for `live` workflows) |
 | `cli` | open the interactive Node CLI |
 
-Run `kfc <command> --help` for the full option list.
+Run `kungfu <command> --help` for the full option list.
 
 ## Planned
 
-- `kfc --json` emitting provenance + the authoritative `docs_url` for the
+- `kungfu --json` emitting provenance + the authoritative `docs_url` for the
   installed version, so an agent can fetch the right doc automatically.
 - A generated command reference kept in lock-step with the CLI definitions
   (drift = build fail).

--- a/framework/spec/docs/overview.md
+++ b/framework/spec/docs/overview.md
@@ -23,7 +23,7 @@ called, and decided, captured as facts you can replay and verify.
   anatomy, how it stays verifiable and portable.
 - **Handbooks** — get an agent working against kungfu, per runtime:
   - **[kungfu (CLI)](handbooks/cli/)** — produce and inspect ledgers from the
-    command line with `kfc`.
+    command line with `kungfu`.
   - **[Python](handbooks/python/)** — embed recording in a Python script.
   - **[Node](handbooks/node/)** — embed recording in a Node/TypeScript script.
 - **Reference** — machine-addressable data: schema registry, error dictionary,


### PR DESCRIPTION
## What

- `@kungfu-tech/core` now installs both `kungfu` and `kfc` bins pointing at the same entry (`lib/kfc.js`): `kungfu` is the canonical end-user command, `kfc` stays a short alias and remains the runtime binary name.
- Docs switch command examples to `kungfu` where they teach what to type (CLI handbook, debugging, adapters, spec overview) and keep `kfc` where they describe the runtime (architecture, design-philosophy, buildchain).
- `concepts.md` / `known-limits.md` / `CONTRIBUTING.md` updated: the reserved `kungfu` name is now realized as the CLI facade; the richer end-user shell remains planned under the same name.
- Welded-surface register: `kfc-cli` → `kungfu-cli` with an additive decision-log entry (pre-release, no line open, nothing removed).

## Why

The `kungfu` name was reserved for the end-user CLI. Realizing it now, before any release line opens, is the only free window: after release the command name is a welded surface and a rename would be a major break. The freeze pipeline and `dist/kfc` internals are untouched — the bin map is the only mechanical change.