### PR TITLE
feat(rewind): define the capture event schema as open-layer types

### DIFF
--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -17,6 +17,7 @@ the rule. For what each surface guarantees and how to verify it, see
 | `kfx-contract` | kfx extension contract (contribution points, load semantics) | integration | [ADR-0006](../framework/core/docs/adr/ADR-0006-v4-frontend-platform-architecture.md), [ADR-0007](../framework/core/docs/adr/ADR-0007-v4-tui-platform-reference-surface.md) |
 | `kungfu-cli` | kungfu CLI surface (canonical `kungfu` command with `kfc` alias; commands, journal subcommand output conventions) | integration | [`debugging.md`](debugging.md) |
 | `journal-replayability` | cross-version cold-path decode of recorded journals | cross-time | [ADR-0008](../framework/core/docs/adr/ADR-0008-longfist-schema-evolution-and-minor-maintenance.md) |
+| `rewind-event-schema` | Rewind capture event model (open-layer msg_types 30001-30099, `rewind_events.fbs`; trace bundles bind and outlive runs) | integration + cross-time | [`msg-type-ranges.md`](../framework/core/docs/msg-type-ranges.md), [`kungfu/rewind/README.md`](../framework/core/src/python/kungfu/rewind/README.md) |
 
 A surface is registered when consumers bind to it at integration time without
 runtime negotiation, or when its outputs remain depended on after the run.
@@ -30,5 +31,6 @@ registered surface was touched.
 
 | Date | Action | Line | Faces | Class | Rationale | PR |
 |---|---|---|---|---|---|---|
+| 2026-07-02 | register | — | rewind-event-schema | additive | New face: Rewind capture event model as open-layer types (30001-30099) with per-run `.bfbs` manifest bindings; capture skeleton rides the frame header, semantics ride the tables. Nothing existing touched | — |
 | 2026-07-02 | update | — | kungfu-cli (was kfc-cli) | additive | `kungfu` becomes the canonical CLI command, fronting the `kfc` runtime; `kfc` stays a working alias. Pre-release, no line open, nothing removed | #147 |
 | 2026-07-02 | register | — | longfist-layout, capability-sdk-api, kfx-contract, kfc-cli, journal-replayability | additive | Initial register established on adopting KFD-1 (ADR-0010) | — |

--- a/framework/core/docs/msg-type-ranges.md
+++ b/framework/core/docs/msg-type-ranges.md
@@ -20,3 +20,11 @@ Within the capability-slice range:
 | `20001` | `slices/embedding` |
 | `20011 – 20013` | `slices/fact-ledger` |
 | `20021 – 20022` | `slices/schema-registry` |
+
+First-party allocations within the open layer (informative — the binding
+authority remains each run's manifest, but first-party products reserve their
+numbers here to avoid colliding with each other):
+
+| Numbers | Product | Schema |
+| --- | --- | --- |
+| `30001 – 30099` | Kungfu Rewind capture events | `src/python/kungfu/rewind/rewind_events.fbs` (30001 RunBegin, 30002 RunEnd, 30003 ModelRequest, 30004 ModelResponse, 30005 ToolCall, 30006 ToolResult, 30007 RetryMarker) |

--- a/framework/core/src/python/kungfu/rewind/README.md
+++ b/framework/core/src/python/kungfu/rewind/README.md
@@ -1,0 +1,47 @@
+# kungfu.rewind — capture event model
+
+The event contract for Kungfu Rewind's capture layer (`kungfu trace`). This
+package will grow the capture supervisor; today it owns the schema.
+
+## Event model
+
+One traced run = one supervisor process = one journal writer. The supervisor
+assigns `run_id`, injects capture environments into the child process tree, and
+writes every event as an open-layer journal frame:
+
+| msg_type | Table | Fact |
+|---|---|---|
+| 30001 | `RunBegin` | run identity, traced command, runtime |
+| 30002 | `RunEnd` | terminal status, exit code |
+| 30003 | `ModelRequest` | provider, model, request body, attempt |
+| 30004 | `ModelResponse` | status, response body, error, tokens, latency |
+| 30005 | `ToolCall` | tool name, input, parent span |
+| 30006 | `ToolResult` | status, output, error, latency |
+| 30007 | `RetryMarker` | retry edge (attempt N of span X) |
+
+Allocation is recorded in [`docs/msg-type-ranges.md`](../../../../../../docs/msg-type-ranges.md);
+the schema surface is registered in [`docs/versioning.md`](../../../../../../docs/versioning.md).
+
+## How the minimal facts are carried
+
+- **Timing** — the frame header's nanosecond `gen_time` (event time) plus
+  `latency_ns` on responses/results.
+- **Causality** — two layers, deliberately redundant: the frame header's
+  `trigger_frame_uid` (frame-level, what replay walks) and `span_id` /
+  `parent_span_id` (semantic, what survives export).
+- **Error and retry** — `CallStatus` + `error` on results; `attempt` and
+  `RetryMarker` for retry edges.
+- **Cross-runtime identity** — `run_id` is shared by every runtime feeding the
+  same supervisor journal; `CaptureLayer` keeps provenance (wire truth vs
+  in-process semantics vs adapters).
+
+Payload bodies (`request_body`, `input`, ...) are JSON strings: capture keeps
+full local fidelity; redaction is an export-time concern, never a capture-time
+one.
+
+## Decode without the writer
+
+Rewind events are open-layer: each run's manifest binds these msg_types to the
+content-addressed `.bfbs` of this schema, so a trace bundle is decodable by
+reflection alone — no generated code, no compiled registry. The mechanism (and
+its regression probe) is `slices/schema-registry`.

--- a/framework/core/src/python/kungfu/rewind/rewind_events.fbs
+++ b/framework/core/src/python/kungfu/rewind/rewind_events.fbs
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Kungfu Rewind capture events — the open-layer event schema for `kungfu trace`.
+//
+// Layering: these are application types (msg_type 30001-30099, see
+// docs/msg-type-ranges.md), NOT longfist kernel types. They ride the journal as
+// self-describing open-layer events: the capture supervisor binds each msg_type
+// to this schema's .bfbs in the run manifest (content-addressed, per-run), so a
+// trace bundle decodes through FlatBuffers reflection without the runtime that
+// wrote it — the same mechanism slices/schema-registry pins.
+//
+// Fact model: the frame header already carries the capture skeleton — gen_time
+// (nanosecond event time) and trigger_frame_uid (frame-level causality). These
+// tables add the semantic layer: run identity, span correlation across capture
+// layers, model/tool payloads, status and retry facts. Payload bodies are JSON
+// strings by design: local-first capture keeps full fidelity, structure lives
+// in the fields schema checks assert on, and redaction happens at export time,
+// never at capture time.
+//
+// Evolution rules (same discipline as longfist fb schemas): append new fields
+// at the tail only; never reorder, delete, or reuse field ids; no `required`
+// fields. Schema evolution happens between runs — two runs binding different
+// versions of this schema coexist and both decode.
+
+namespace kungfu.rewind.fb;
+
+// Terminal state of a traced run.
+enum RunStatus : byte {
+  Running = 0,
+  Succeeded = 1,
+  Failed = 2,
+  Interrupted = 3
+}
+
+// Outcome of a single model or tool invocation.
+enum CallStatus : byte {
+  Ok = 0,
+  Error = 1,
+  Timeout = 2,
+  Cancelled = 3
+}
+
+// Which capture layer produced the event. The supervisor is the only journal
+// writer; events arriving through different layers keep their provenance so
+// diagnosis (and the moat gate) can tell wire truth from in-process semantics.
+enum CaptureLayer : byte {
+  Supervisor = 0,
+  ModelWire = 1,
+  InProcessHook = 2,
+  Adapter = 3
+}
+
+// msg_type 30001. Opens a traced run; run_id is supervisor-assigned and shared
+// by every runtime and capture layer in the run — the single-journal anchor.
+table RunBegin {
+  run_id:string;
+  command:string;
+  runtime:string;
+  supervisor_version:string;
+  schema_version:uint;
+}
+
+// msg_type 30002. Closes a traced run.
+table RunEnd {
+  run_id:string;
+  status:RunStatus;
+  exit_code:int;
+}
+
+// msg_type 30003. A model invocation as sent (wire request or hook call).
+table ModelRequest {
+  run_id:string;
+  span_id:string;
+  parent_span_id:string;
+  layer:CaptureLayer;
+  provider:string;
+  model:string;
+  request_body:string;
+  attempt:uint;
+}
+
+// msg_type 30004. The model's answer; span_id matches its ModelRequest.
+table ModelResponse {
+  run_id:string;
+  span_id:string;
+  layer:CaptureLayer;
+  status:CallStatus;
+  response_body:string;
+  error:string;
+  finish_reason:string;
+  input_tokens:long;
+  output_tokens:long;
+  latency_ns:long;
+}
+
+// msg_type 30005. A tool invocation observed in the run.
+table ToolCall {
+  run_id:string;
+  span_id:string;
+  parent_span_id:string;
+  layer:CaptureLayer;
+  tool_name:string;
+  input:string;
+}
+
+// msg_type 30006. The tool's outcome; error facts live here (status + error),
+// span_id matches its ToolCall.
+table ToolResult {
+  run_id:string;
+  span_id:string;
+  layer:CaptureLayer;
+  status:CallStatus;
+  output:string;
+  error:string;
+  latency_ns:long;
+}
+
+// msg_type 30007. Marks a retry edge: attempt N of span retry_of_span_id.
+table RetryMarker {
+  run_id:string;
+  span_id:string;
+  retry_of_span_id:string;
+  attempt:uint;
+  reason:string;
+}
+
+root_type RunBegin;


### PR DESCRIPTION
## What

The event contract for the `kungfu trace` capture layer, as the first Rewind component:

- `framework/core/src/python/kungfu/rewind/rewind_events.fbs` — `RunBegin`/`RunEnd`, `ModelRequest`/`ModelResponse`, `ToolCall`/`ToolResult`, `RetryMarker` under `kungfu.rewind.fb`, following the longfist fb evolution discipline (tail-append only, no id reuse, no `required`).
- **Open-layer placement, not kernel**: msg_types `30001–30099`. The capture skeleton (nanosecond timing via `gen_time`, frame-level causality via `trigger_frame_uid`) rides the existing frame header; tables add run identity, cross-layer span correlation (`span_id`/`parent_span_id`/`CaptureLayer`), payload bodies, and status/retry facts. Payloads are JSON strings — full local fidelity at capture, redaction only at export.
- Trace bundles bind these msg_types to the schema's content-addressed `.bfbs` per run and decode by reflection alone — the exact mechanism `slices/schema-registry` pins.
- `msg-type-ranges.md`: adds an informative first-party open-layer allocation table (binding authority stays with each run's manifest).
- `docs/versioning.md`: registers welded surface `rewind-event-schema` (integration + cross-time; additive decision-log entry).

## Why open layer

Rewind is a product on top of the substrate, not part of it. Welding its event types into the longfist closed set would couple the kernel registry to application churn; the open layer exists precisely for self-describing application schemas, and using it here dogfoods the schema-registry mechanism on the first real product.

## Validation

Schema compiles clean with the conan-provided flatc 25.9.23 (`--cpp --scoped-enums`, `-b --schema`, `--python`). Build wiring (`.bfbs` generation/packaging) intentionally lands with its consumer — the capture supervisor — in the next change.