### PR TITLE
feat(rewind): capture model calls at the wire

### DIFF
--- a/framework/core/src/python/kungfu/rewind/proxy.py
+++ b/framework/core/src/python/kungfu/rewind/proxy.py
@@ -1,0 +1,164 @@
+#  SPDX-License-Identifier: Apache-2.0
+#
+# Capture layer L1 — the model-wire proxy.
+#
+# The supervisor points the child's model SDKs at this local endpoint via
+# base-url environment variables; every request is forwarded to the real
+# upstream and captured as a ModelRequest/ModelResponse pair at the wire.
+# Wire truth: bodies exactly as sent and received, provenance CaptureLayer
+# ModelWire. Request/response HEADERS are never captured — that is where API
+# keys live; capture takes JSON bodies only.
+#
+# Upstream resolution: the parent environment's own base urls (the ones the
+# run would have used untraced), falling back to the providers' defaults.
+# Routing: anthropic paths (/v1/messages) go to the anthropic upstream,
+# everything else to the openai-compatible upstream.
+
+import http.server
+import json
+import threading
+import time
+import urllib.error
+import urllib.request
+import uuid
+
+from kungfu.rewind import MSG_MODEL_REQUEST, MSG_MODEL_RESPONSE
+from kungfu.rewind import events
+from kungfu.rewind.fb.CallStatus import CallStatus
+from kungfu.rewind.fb.CaptureLayer import CaptureLayer
+
+DEFAULT_OPENAI_UPSTREAM = "https://api.openai.com/v1"
+DEFAULT_ANTHROPIC_UPSTREAM = "https://api.anthropic.com/v1"
+
+# headers that must not be forwarded verbatim (hop-by-hop / recomputed)
+_SKIP_FORWARD = {"host", "content-length", "connection", "accept-encoding"}
+
+
+def _provider_for(path):
+    return "anthropic" if path.rstrip("/").endswith("/messages") else "openai"
+
+
+class _Handler(http.server.BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    # the proxy is capture infrastructure; stay quiet on the child's stderr
+    def log_message(self, format, *args):
+        pass
+
+    def do_POST(self):
+        proxy = self.server.rewind_proxy
+        length = int(self.headers.get("Content-Length", 0))
+        body = self.rfile.read(length) if length else b""
+        provider = _provider_for(self.path)
+        span_id = uuid.uuid4().hex
+
+        model = None
+        try:
+            model = json.loads(body).get("model")
+        except (ValueError, AttributeError):
+            pass
+
+        proxy.sink(
+            MSG_MODEL_REQUEST,
+            events.model_request(
+                run_id=proxy.run_id,
+                span_id=span_id,
+                parent_span_id=None,
+                layer=CaptureLayer.ModelWire,
+                provider=provider,
+                model=model,
+                request_body=body.decode("utf-8", errors="replace"),
+            ),
+        )
+
+        upstream = proxy.upstreams[provider]
+        url = (
+            upstream.rstrip("/") + self.path[len("/v1") :]
+            if self.path.startswith("/v1")
+            else upstream.rstrip("/") + self.path
+        )
+        request = urllib.request.Request(url, data=body, method="POST")
+        for name, value in self.headers.items():
+            if name.lower() not in _SKIP_FORWARD:
+                request.add_header(name, value)
+
+        started = time.monotonic_ns()
+        status, response_body, error = CallStatus.Ok, b"", None
+        http_status = 502
+        try:
+            with urllib.request.urlopen(request, timeout=proxy.timeout) as response:
+                response_body = response.read()
+                http_status = response.status
+        except urllib.error.HTTPError as e:
+            response_body = e.read()
+            http_status = e.code
+            status, error = CallStatus.Error, f"upstream http {e.code}"
+        except Exception as e:  # noqa: BLE001 — the child must get an answer
+            status, error = CallStatus.Error, str(e)
+        latency_ns = time.monotonic_ns() - started
+
+        finish_reason, input_tokens, output_tokens = None, 0, 0
+        try:
+            parsed = json.loads(response_body)
+            usage = parsed.get("usage") or {}
+            input_tokens = usage.get("prompt_tokens") or usage.get("input_tokens") or 0
+            output_tokens = (
+                usage.get("completion_tokens") or usage.get("output_tokens") or 0
+            )
+            choices = parsed.get("choices") or []
+            if choices:
+                finish_reason = choices[0].get("finish_reason")
+            finish_reason = finish_reason or parsed.get("stop_reason")
+        except ValueError:
+            pass
+
+        proxy.sink(
+            MSG_MODEL_RESPONSE,
+            events.model_response(
+                run_id=proxy.run_id,
+                span_id=span_id,
+                layer=CaptureLayer.ModelWire,
+                status=status,
+                response_body=response_body.decode("utf-8", errors="replace"),
+                error=error,
+                finish_reason=finish_reason,
+                input_tokens=int(input_tokens),
+                output_tokens=int(output_tokens),
+                latency_ns=latency_ns,
+            ),
+        )
+
+        payload = response_body or (error or "").encode()
+        self.send_response(http_status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+
+class ModelWireProxy:
+    def __init__(self, run_id, sink, upstreams=None, timeout=600):
+        self.run_id = run_id
+        self.sink = sink
+        self.timeout = timeout
+        self.upstreams = {
+            "openai": DEFAULT_OPENAI_UPSTREAM,
+            "anthropic": DEFAULT_ANTHROPIC_UPSTREAM,
+            **(upstreams or {}),
+        }
+        self._server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+        self._server.rewind_proxy = self
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+
+    @property
+    def base_url(self):
+        host, port = self._server.server_address
+        return f"http://{host}:{port}/v1"
+
+    def start(self):
+        self._thread.start()
+
+    def stop(self):
+        self._server.shutdown()
+        self._server.server_close()
+        self._thread.join(timeout=5)

--- a/framework/core/src/python/kungfu/rewind/supervisor.py
+++ b/framework/core/src/python/kungfu/rewind/supervisor.py
@@ -9,15 +9,21 @@
 #
 # Ingestion layers (design decision D):
 #   L0 this file            process supervision, run identity, run bracketing
-#   L1 model-wire proxy     model request/response at the wire (next change)
+#   L1 model-wire proxy     model request/response at the wire (proxy.py)
 #   L2 in-process hooks     tool/framework semantics fed over the local
 #                           ingest endpoint announced in the environment
 #   L3 adapters             optional, never the moat evidence path
+#
+# Threading: the journal keeps its single-writer discipline by construction —
+# capture layers never touch the writer, they enqueue serialized events and one
+# writer thread drains the queue in arrival order.
 
 import os
+import queue
 import signal
 import subprocess
 import sys
+import threading
 import uuid
 
 import kungfu
@@ -29,12 +35,24 @@ from kungfu.rewind import (
 )
 from kungfu.rewind import bundle, events
 from kungfu.rewind.fb.RunStatus import RunStatus
+from kungfu.rewind.proxy import (
+    DEFAULT_ANTHROPIC_UPSTREAM,
+    DEFAULT_OPENAI_UPSTREAM,
+    ModelWireProxy,
+)
 
 lf = kungfu.__binding__.longfist
 yjj = kungfu.__binding__.yijinjing
 
 ENV_RUN_ID = "KUNGFU_REWIND_RUN_ID"
 PUBLIC_DEST = 0
+
+# base-url variables the proxy takes over in the child environment; the
+# parent's own values (if any) become the forward targets
+_OPENAI_ENV = ("OPENAI_BASE_URL", "OPENAI_API_BASE")
+_ANTHROPIC_ENV = ("ANTHROPIC_BASE_URL",)
+
+_STOP = object()
 
 
 class Supervisor:
@@ -58,21 +76,49 @@ class Supervisor:
         self.writer = yjj.writer(
             self.location, PUBLIC_DEST, True, self.publisher, False, self.bus, 0
         )
+        self.events = queue.SimpleQueue()
+        self.proxy = ModelWireProxy(
+            self.run_id, self.enqueue, upstreams=self._upstreams()
+        )
 
-    def write_event(self, msg_type, data):
-        # the binding takes the payload as a byte sequence (list[int])
-        self.writer.write_bytes(0, msg_type, list(data), len(data))
+    @staticmethod
+    def _upstreams():
+        openai = next((os.environ[k] for k in _OPENAI_ENV if os.environ.get(k)), None)
+        anthropic = next(
+            (os.environ[k] for k in _ANTHROPIC_ENV if os.environ.get(k)), None
+        )
+        return {
+            "openai": openai or DEFAULT_OPENAI_UPSTREAM,
+            "anthropic": anthropic or DEFAULT_ANTHROPIC_UPSTREAM,
+        }
+
+    def enqueue(self, msg_type, data):
+        self.events.put((msg_type, data))
+
+    def _drain_events(self):
+        while True:
+            item = self.events.get()
+            if item is _STOP:
+                return
+            msg_type, data = item
+            # the binding takes the payload as a byte sequence (list[int])
+            self.writer.write_bytes(0, msg_type, list(data), len(data))
 
     def child_env(self):
         env = dict(os.environ)
         env[ENV_RUN_ID] = self.run_id
+        for key in _OPENAI_ENV + _ANTHROPIC_ENV:
+            env[key] = self.proxy.base_url
         return env
 
     def bundle_dir(self):
         return os.path.join(self.runtime_dir, "rewind", self.run_id, "bundle")
 
     def run(self):
-        self.write_event(
+        writer_thread = threading.Thread(target=self._drain_events)
+        writer_thread.start()
+        self.proxy.start()
+        self.enqueue(
             MSG_RUN_BEGIN,
             events.run_begin(
                 run_id=self.run_id,
@@ -95,10 +141,15 @@ class Supervisor:
             exit_code = child.wait()
             status = RunStatus.Interrupted
         finally:
-            self.write_event(
+            # child gone -> no new wire events; stop the proxy before the
+            # RunEnd bracket so every captured event lands inside the run
+            self.proxy.stop()
+            self.enqueue(
                 MSG_RUN_END,
                 events.run_end(self.run_id, status, exit_code),
             )
+            self.events.put(_STOP)
+            writer_thread.join()
             manifest_path = bundle.emit(
                 self.bundle_dir(),
                 self.runtime_dir,

--- a/tests/fixtures/rewind-demo-happy/check_capture.py
+++ b/tests/fixtures/rewind-demo-happy/check_capture.py
@@ -20,7 +20,17 @@ sys.path.insert(0, os.path.join(_core, "dist", "kfc"))
 
 import kungfu
 
-from kungfu.rewind import MSG_RUN_BEGIN, MSG_RUN_END, MSG_TYPE_NAMES
+from kungfu.rewind import (
+    MSG_MODEL_REQUEST,
+    MSG_MODEL_RESPONSE,
+    MSG_RUN_BEGIN,
+    MSG_RUN_END,
+    MSG_TYPE_NAMES,
+)
+from kungfu.rewind.fb.CallStatus import CallStatus
+from kungfu.rewind.fb.CaptureLayer import CaptureLayer
+from kungfu.rewind.fb.ModelRequest import ModelRequest
+from kungfu.rewind.fb.ModelResponse import ModelResponse
 from kungfu.rewind.fb.RunBegin import RunBegin
 from kungfu.rewind.fb.RunEnd import RunEnd
 
@@ -54,6 +64,51 @@ if begin_frames:
         (begin.RunId() or b"").decode(),
     )
     check("RunBegin.gen_time set", header.gen_time > 0)
+
+req_frames = yjj.assemble(location, 0).read_bytes(MSG_MODEL_REQUEST)
+check("ModelRequest frame present", len(req_frames) == 1)
+req_span = None
+if req_frames:
+    _, payload = req_frames[0]
+    req = ModelRequest.GetRootAs(bytes(payload), 0)
+    req_span = (req.SpanId() or b"").decode()
+    check("ModelRequest.run_id matches", (req.RunId() or b"").decode() == run_id)
+    check("ModelRequest.layer == ModelWire", req.Layer() == CaptureLayer.ModelWire)
+    check(
+        "ModelRequest.provider == openai", (req.Provider() or b"").decode() == "openai"
+    )
+    check(
+        "ModelRequest.model == demo-model",
+        (req.Model() or b"").decode() == "demo-model",
+    )
+    req_body = json.loads((req.RequestBody() or b"{}").decode())
+    check("ModelRequest.request_body has messages", bool(req_body.get("messages")))
+
+resp_frames = yjj.assemble(location, 0).read_bytes(MSG_MODEL_RESPONSE)
+check("ModelResponse frame present", len(resp_frames) == 1)
+if resp_frames:
+    _, payload = resp_frames[0]
+    resp = ModelResponse.GetRootAs(bytes(payload), 0)
+    check(
+        "ModelResponse.span_id matches request",
+        req_span and (resp.SpanId() or b"").decode() == req_span,
+    )
+    check("ModelResponse.status == Ok", resp.Status() == CallStatus.Ok)
+    check(
+        "ModelResponse.finish_reason == stop",
+        (resp.FinishReason() or b"").decode() == "stop",
+    )
+    check(
+        "ModelResponse.tokens captured",
+        resp.InputTokens() == 7 and resp.OutputTokens() == 3,
+    )
+    check("ModelResponse.latency_ns > 0", resp.LatencyNs() > 0)
+    resp_body = json.loads((resp.ResponseBody() or b"{}").decode())
+    check(
+        "ModelResponse.response_body has answer",
+        resp_body.get("choices", [{}])[0].get("message", {}).get("content")
+        == "the demo answer",
+    )
 
 asm2 = yjj.assemble(location, 0)
 end_frames = asm2.read_bytes(MSG_RUN_END)

--- a/tests/fixtures/rewind-demo-happy/demo_agent.py
+++ b/tests/fixtures/rewind-demo-happy/demo_agent.py
@@ -1,16 +1,43 @@
 # SPDX-License-Identifier: Apache-2.0
 #
-# Happy-path demo agent, capture-layer L0 smoke: a trivial child process the
-# supervisor wraps. It must not import kungfu — the red line is that traced
-# code needs no modification, so the only contact surface is the environment
-# the supervisor injects. Model/tool activity arrives with the L1 proxy.
+# Happy-path demo agent: a minimal "agent" making one model call the way an
+# SDK would — POST to $OPENAI_BASE_URL/chat/completions. It must not import
+# kungfu — the red line is that traced code needs no modification, so the
+# only contact surface is the environment the supervisor injects (run id and
+# the base url pointing at the model-wire proxy).
 
+import json
 import os
 import sys
+import urllib.request
 
 run_id = os.environ.get("KUNGFU_REWIND_RUN_ID")
 if not run_id:
     print("KUNGFU_REWIND_RUN_ID missing from injected environment", file=sys.stderr)
     sys.exit(1)
 
-print(f"demo agent alive under traced run {run_id}")
+base_url = os.environ.get("OPENAI_BASE_URL")
+if not base_url:
+    print("OPENAI_BASE_URL missing from injected environment", file=sys.stderr)
+    sys.exit(1)
+
+request = urllib.request.Request(
+    base_url.rstrip("/") + "/chat/completions",
+    data=json.dumps(
+        {
+            "model": "demo-model",
+            "messages": [{"role": "user", "content": "what is the demo answer?"}],
+        }
+    ).encode(),
+    headers={"Content-Type": "application/json"},
+    method="POST",
+)
+with urllib.request.urlopen(request, timeout=30) as response:
+    answer = json.load(response)
+
+content = answer["choices"][0]["message"]["content"]
+if content != "the demo answer":
+    print(f"unexpected model answer: {content}", file=sys.stderr)
+    sys.exit(1)
+
+print(f"demo agent got model answer under traced run {run_id}")

--- a/tests/fixtures/rewind-demo-happy/mock_model.py
+++ b/tests/fixtures/rewind-demo-happy/mock_model.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Deterministic stand-in for a model provider: an openai-compatible chat
+# completions endpoint with fixed content and usage, so the fixture asserts
+# capture facts without network or keys.
+#
+# Usage: mock_model.py <port-file>   (binds an ephemeral port, writes it there)
+
+import http.server
+import json
+import sys
+
+CANNED = {
+    "id": "chatcmpl-fixture",
+    "object": "chat.completion",
+    "model": "demo-model",
+    "choices": [
+        {
+            "index": 0,
+            "message": {"role": "assistant", "content": "the demo answer"},
+            "finish_reason": "stop",
+        }
+    ],
+    "usage": {"prompt_tokens": 7, "completion_tokens": 3, "total_tokens": 10},
+}
+
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, format, *args):
+        pass
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", 0))
+        self.rfile.read(length)
+        body = json.dumps(CANNED).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+server = http.server.HTTPServer(("127.0.0.1", 0), Handler)
+with open(sys.argv[1], "w") as f:
+    f.write(str(server.server_address[1]))
+server.serve_forever()

--- a/tests/fixtures/rewind-demo-happy/run.sh
+++ b/tests/fixtures/rewind-demo-happy/run.sh
@@ -13,8 +13,17 @@ fixture_dir="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
 core_dir="$(CDPATH= cd -- "$fixture_dir/../../../framework/core" && pwd)"
 
 home="$(mktemp -d)"
-trap 'rm -rf "$home"' EXIT
 run_id="fixturehappy$(date +%s)"
+
+# deterministic model upstream: the mock binds an ephemeral port and reports
+# it through a file; the supervisor picks it up as the openai forward target
+port_file="$home/mock-port"
+python3 "$fixture_dir/mock_model.py" "$port_file" &
+mock_pid=$!
+trap 'kill "$mock_pid" 2>/dev/null; rm -rf "$home"' EXIT
+while [ ! -s "$port_file" ]; do sleep 0.1; done
+OPENAI_BASE_URL="http://127.0.0.1:$(cat "$port_file")/v1"
+export OPENAI_BASE_URL
 
 # Dev-python import of pykungfu: its libnode install name is
 # @executable_path-relative (correct for the frozen kfc executable); when the


### PR DESCRIPTION
## What

Capture layer L1 — the model-wire proxy, completing the G2 capture evidence:

- The supervisor runs a local proxy (ephemeral localhost port) and points the child's model SDKs at it through the base-url environment variables (`OPENAI_BASE_URL`, `OPENAI_API_BASE`, `ANTHROPIC_BASE_URL`). No code change in the traced program — env injection only.
- Every request forwards to the upstream the run would have used untraced (the parent environment's own base urls, falling back to provider defaults; anthropic paths route to the anthropic upstream, everything else openai-compatible). Each call lands as a `ModelRequest`/`ModelResponse` pair: provider, model, bodies as sent/received, finish reason, token usage, wire latency, span-id correlation, provenance `ModelWire`.
- **Headers are never captured** — that is where API keys live; capture takes JSON bodies only. Redaction remains an export-time concern by design.
- **Single-writer discipline by construction**: capture layers enqueue serialized events; one writer thread drains in arrival order. The journal writer is never touched from handler threads.
- Fixture upgraded to a real model call: the demo agent posts a chat completion the way an SDK would, a deterministic local mock serves as upstream, and `check_capture` asserts the full round-trip — **24 assertions green**.

## Validation

- Fixture end to end 24/24 (run bracketing + model request/response facts + span correlation + bundle manifest/blob).
- `ruff format` clean; python-only change, no build-chain surface touched.

## Scope

L2 in-process hooks (tool/framework semantics over the announced ingest endpoint) and the G3 completeness assertions land next.