### PR TITLE
feat(rewind): capture tool semantics in-process, gate the fixtures in verify

### DIFF
--- a/framework/core/src/python/kungfu/rewind/hook/rewind_client.py
+++ b/framework/core/src/python/kungfu/rewind/hook/rewind_client.py
@@ -1,0 +1,231 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Capture layer L2, child side — pure stdlib, zero kungfu dependencies.
+#
+# This module runs inside the *user's* interpreter. Two hard rules:
+#   1. it must never break or slow the traced program: every operation is
+#      best-effort, and the first failure disables emission for the run;
+#   2. it must not import anything beyond the standard library — the traced
+#      environment owes us nothing.
+#
+# Events go as line-delimited JSON to the local ingest endpoint the
+# supervisor announced in KUNGFU_REWIND_INGEST.
+
+import importlib
+import importlib.abc
+import importlib.util
+import json
+import os
+import socket
+import sys
+import threading
+import time
+import uuid
+
+ENV_INGEST = "KUNGFU_REWIND_INGEST"
+ENV_RUN_ID = "KUNGFU_REWIND_RUN_ID"
+
+
+class _Emitter:
+    def __init__(self, endpoint):
+        host, port = endpoint.rsplit(":", 1)
+        self._address = (host, int(port))
+        self._sock = None
+        self._dead = False
+
+    def emit(self, message):
+        if self._dead:
+            return
+        try:
+            if self._sock is None:
+                self._sock = socket.create_connection(self._address, timeout=1)
+            self._sock.sendall(json.dumps(message).encode() + b"\n")
+        except OSError:
+            self._dead = True
+            self._sock = None
+
+    def close(self):
+        if self._sock is not None:
+            try:
+                self._sock.close()
+            except OSError:
+                pass
+            self._sock = None
+
+
+_emitter = None
+
+
+def enabled():
+    return _emitter is not None
+
+
+def setup():
+    global _emitter
+    endpoint = os.environ.get(ENV_INGEST)
+    if endpoint and _emitter is None:
+        _emitter = _Emitter(endpoint)
+    return _emitter is not None
+
+
+def emit(message):
+    if _emitter is not None:
+        _emitter.emit(message)
+
+
+def new_span():
+    return uuid.uuid4().hex
+
+
+def tool_call(span_id, tool_name, input_body, parent_span_id=None):
+    emit(
+        {
+            "event": "tool_call",
+            "span_id": span_id,
+            "parent_span_id": parent_span_id,
+            "tool_name": tool_name,
+            "input": input_body,
+        }
+    )
+
+
+def tool_result(span_id, status, output=None, error=None, latency_ns=0):
+    emit(
+        {
+            "event": "tool_result",
+            "span_id": span_id,
+            "status": status,
+            "output": output,
+            "error": error,
+            "latency_ns": latency_ns,
+        }
+    )
+
+
+def retry(span_id, retry_of_span_id, attempt, reason=None):
+    emit(
+        {
+            "event": "retry",
+            "span_id": span_id,
+            "retry_of_span_id": retry_of_span_id,
+            "attempt": attempt,
+            "reason": reason,
+        }
+    )
+
+
+class _CallCapture:
+    """Wraps one tool invocation: call/result/error/retry facts around a fn."""
+
+    def __init__(self, tool_name, retry_of=None, attempt=1, parent_span_id=None):
+        self.span_id = new_span()
+        self.tool_name = tool_name
+        if retry_of is not None:
+            retry(self.span_id, retry_of, attempt)
+        self._parent = parent_span_id
+
+    def run(self, fn, input_body, *args, **kwargs):
+        tool_call(self.span_id, self.tool_name, input_body, self._parent)
+        started = time.monotonic_ns()
+        try:
+            result = fn(*args, **kwargs)
+        except Exception as e:
+            tool_result(
+                self.span_id,
+                "error",
+                error=f"{type(e).__name__}: {e}",
+                latency_ns=time.monotonic_ns() - started,
+            )
+            raise
+        tool_result(
+            self.span_id,
+            "ok",
+            output=_render(result),
+            latency_ns=time.monotonic_ns() - started,
+        )
+        return result
+
+
+def _render(value):
+    try:
+        return json.dumps(value)
+    except (TypeError, ValueError):
+        return repr(value)
+
+
+# ── post-import adapters ────────────────────────────────────────────
+#
+# Frameworks are patched after they are imported, from a table of adapters.
+# Detection must not import anything eagerly: a meta-path finder watches for
+# the module names and applies the patch once the real import completes.
+
+
+def _patch_demo_toolkit(module):
+    # the toolkit's natural seams: Tool.run is the user-facing call, and
+    # Tool._invoke is one attempt inside the retry loop — the same shape the
+    # per-attempt boundary takes in real frameworks
+    original_run = module.Tool.run
+    original_invoke = module.Tool._invoke
+    state = threading.local()
+
+    def traced_run(self, tool_input):
+        state.attempt = 0
+        state.prev_span = None
+        return original_run(self, tool_input)
+
+    def traced_invoke(self, tool_input):
+        state.attempt = getattr(state, "attempt", 0) + 1
+        capture = _CallCapture(
+            self.name,
+            retry_of=getattr(state, "prev_span", None) if state.attempt > 1 else None,
+            attempt=state.attempt,
+        )
+        state.prev_span = capture.span_id
+        return capture.run(
+            lambda: original_invoke(self, tool_input), _render(tool_input)
+        )
+
+    module.Tool.run = traced_run
+    module.Tool._invoke = traced_invoke
+
+
+ADAPTERS = {
+    "rewind_demo_toolkit": _patch_demo_toolkit,
+}
+
+
+class _AdapterLoader(importlib.abc.Loader):
+    def __init__(self, original_loader, patcher):
+        self._original = original_loader
+        self._patcher = patcher
+
+    def create_module(self, spec):
+        return None
+
+    def exec_module(self, module):
+        self._original.exec_module(module)
+        try:
+            self._patcher(module)
+        except Exception:  # noqa: BLE001 — adapters must never break imports
+            pass
+
+
+class _AdapterFinder(importlib.abc.MetaPathFinder):
+    def find_spec(self, fullname, path, target=None):
+        patcher = ADAPTERS.get(fullname)
+        if patcher is None:
+            return None
+        sys.meta_path.remove(self)
+        try:
+            spec = importlib.util.find_spec(fullname)
+        finally:
+            sys.meta_path.insert(0, self)
+        if spec is None or spec.loader is None:
+            return None
+        spec.loader = _AdapterLoader(spec.loader, patcher)
+        return spec
+
+
+def install_adapters():
+    if setup():
+        sys.meta_path.insert(0, _AdapterFinder())

--- a/framework/core/src/python/kungfu/rewind/hook/sitecustomize.py
+++ b/framework/core/src/python/kungfu/rewind/hook/sitecustomize.py
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Injected into the child interpreter by the supervisor (this directory is
+# prepended to PYTHONPATH, python's site machinery imports the first
+# sitecustomize it finds). Everything here is best-effort: a traced program
+# must behave exactly like an untraced one, minus nothing.
+
+try:
+    import rewind_client
+
+    rewind_client.install_adapters()
+except Exception:  # noqa: BLE001 — never break the user's interpreter
+    pass
+
+# python imports only the first sitecustomize on the path; if the user's
+# environment had its own, run it too so tracing does not eat their setup
+try:
+    import importlib.util
+    import os
+    import sys
+
+    _here = os.path.dirname(os.path.abspath(__file__))
+    _rest = [p for p in sys.path if os.path.abspath(p or os.getcwd()) != _here]
+    _spec = None
+    for _p in _rest:
+        _candidate = os.path.join(_p or os.getcwd(), "sitecustomize.py")
+        if os.path.exists(_candidate):
+            _spec = importlib.util.spec_from_file_location(
+                "sitecustomize_user", _candidate
+            )
+            break
+    if _spec and _spec.loader:
+        _module = importlib.util.module_from_spec(_spec)
+        _spec.loader.exec_module(_module)
+except Exception:  # noqa: BLE001
+    pass

--- a/framework/core/src/python/kungfu/rewind/ingest.py
+++ b/framework/core/src/python/kungfu/rewind/ingest.py
@@ -1,0 +1,109 @@
+#  SPDX-License-Identifier: Apache-2.0
+#
+# Capture layer L2, supervisor side — the in-process event ingest.
+#
+# In-process hooks run inside the *user's* interpreter, which has no kungfu
+# dependencies by design (traced code needs no installation either); they
+# speak line-delimited JSON over a local TCP endpoint the supervisor announces
+# in the environment. This keeps the child-side shim pure stdlib; the channel
+# framing is an implementation detail behind the announced endpoint and can be
+# swapped (e.g. to nng) without touching the hook protocol. The supervisor
+# stays the single journal writer: ingest validates, serializes, and enqueues.
+
+import json
+import socketserver
+import threading
+
+from kungfu.rewind import (
+    MSG_RETRY_MARKER,
+    MSG_TOOL_CALL,
+    MSG_TOOL_RESULT,
+)
+from kungfu.rewind import events
+from kungfu.rewind.fb.CallStatus import CallStatus
+from kungfu.rewind.fb.CaptureLayer import CaptureLayer
+
+_STATUS = {
+    "ok": CallStatus.Ok,
+    "error": CallStatus.Error,
+    "timeout": CallStatus.Timeout,
+    "cancelled": CallStatus.Cancelled,
+}
+
+
+class _Handler(socketserver.StreamRequestHandler):
+    def handle(self):
+        server = self.server
+        for line in self.rfile:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                server.ingest.accept(json.loads(line))
+            except (ValueError, KeyError, TypeError):
+                # a malformed hook line must never take capture down
+                continue
+
+
+class IngestServer:
+    def __init__(self, run_id, sink):
+        self.run_id = run_id
+        self.sink = sink
+        self._server = socketserver.ThreadingTCPServer(
+            ("127.0.0.1", 0), _Handler, bind_and_activate=True
+        )
+        self._server.daemon_threads = True
+        self._server.ingest = self
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+
+    @property
+    def endpoint(self):
+        host, port = self._server.server_address
+        return f"{host}:{port}"
+
+    def start(self):
+        self._thread.start()
+
+    def stop(self):
+        self._server.shutdown()
+        self._server.server_close()
+        self._thread.join(timeout=5)
+
+    def accept(self, message):
+        kind = message.get("event")
+        if kind == "tool_call":
+            self.sink(
+                MSG_TOOL_CALL,
+                events.tool_call(
+                    run_id=self.run_id,
+                    span_id=message.get("span_id"),
+                    parent_span_id=message.get("parent_span_id"),
+                    layer=CaptureLayer.InProcessHook,
+                    tool_name=message.get("tool_name"),
+                    input_body=message.get("input"),
+                ),
+            )
+        elif kind == "tool_result":
+            self.sink(
+                MSG_TOOL_RESULT,
+                events.tool_result(
+                    run_id=self.run_id,
+                    span_id=message.get("span_id"),
+                    layer=CaptureLayer.InProcessHook,
+                    status=_STATUS.get(message.get("status"), CallStatus.Error),
+                    output=message.get("output"),
+                    error=message.get("error"),
+                    latency_ns=int(message.get("latency_ns") or 0),
+                ),
+            )
+        elif kind == "retry":
+            self.sink(
+                MSG_RETRY_MARKER,
+                events.retry_marker(
+                    run_id=self.run_id,
+                    span_id=message.get("span_id"),
+                    retry_of_span_id=message.get("retry_of_span_id"),
+                    attempt=int(message.get("attempt") or 0),
+                    reason=message.get("reason"),
+                ),
+            )

--- a/framework/core/src/python/kungfu/rewind/supervisor.py
+++ b/framework/core/src/python/kungfu/rewind/supervisor.py
@@ -35,6 +35,7 @@ from kungfu.rewind import (
 )
 from kungfu.rewind import bundle, events
 from kungfu.rewind.fb.RunStatus import RunStatus
+from kungfu.rewind.ingest import IngestServer
 from kungfu.rewind.proxy import (
     DEFAULT_ANTHROPIC_UPSTREAM,
     DEFAULT_OPENAI_UPSTREAM,
@@ -45,7 +46,10 @@ lf = kungfu.__binding__.longfist
 yjj = kungfu.__binding__.yijinjing
 
 ENV_RUN_ID = "KUNGFU_REWIND_RUN_ID"
+ENV_INGEST = "KUNGFU_REWIND_INGEST"
 PUBLIC_DEST = 0
+
+_HOOK_DIR = os.path.join(os.path.dirname(__file__), "hook")
 
 # base-url variables the proxy takes over in the child environment; the
 # parent's own values (if any) become the forward targets
@@ -80,6 +84,7 @@ class Supervisor:
         self.proxy = ModelWireProxy(
             self.run_id, self.enqueue, upstreams=self._upstreams()
         )
+        self.ingest = IngestServer(self.run_id, self.enqueue)
 
     @staticmethod
     def _upstreams():
@@ -109,6 +114,11 @@ class Supervisor:
         env[ENV_RUN_ID] = self.run_id
         for key in _OPENAI_ENV + _ANTHROPIC_ENV:
             env[key] = self.proxy.base_url
+        # L2: announce the ingest endpoint and let python's site machinery
+        # pull in the hook (sitecustomize) inside the child interpreter
+        env[ENV_INGEST] = self.ingest.endpoint
+        existing = env.get("PYTHONPATH")
+        env["PYTHONPATH"] = _HOOK_DIR + os.pathsep + existing if existing else _HOOK_DIR
         return env
 
     def bundle_dir(self):
@@ -118,6 +128,7 @@ class Supervisor:
         writer_thread = threading.Thread(target=self._drain_events)
         writer_thread.start()
         self.proxy.start()
+        self.ingest.start()
         self.enqueue(
             MSG_RUN_BEGIN,
             events.run_begin(
@@ -141,9 +152,11 @@ class Supervisor:
             exit_code = child.wait()
             status = RunStatus.Interrupted
         finally:
-            # child gone -> no new wire events; stop the proxy before the
-            # RunEnd bracket so every captured event lands inside the run
+            # child gone -> no new wire or hook events; stop the capture
+            # layers before the RunEnd bracket so every event lands inside
+            # the run
             self.proxy.stop()
+            self.ingest.stop()
             self.enqueue(
                 MSG_RUN_END,
                 events.run_end(self.run_id, status, exit_code),

--- a/tests/fixtures/rewind-demo-happy/check_capture.py
+++ b/tests/fixtures/rewind-demo-happy/check_capture.py
@@ -23,16 +23,22 @@ import kungfu
 from kungfu.rewind import (
     MSG_MODEL_REQUEST,
     MSG_MODEL_RESPONSE,
+    MSG_RETRY_MARKER,
     MSG_RUN_BEGIN,
     MSG_RUN_END,
+    MSG_TOOL_CALL,
+    MSG_TOOL_RESULT,
     MSG_TYPE_NAMES,
 )
 from kungfu.rewind.fb.CallStatus import CallStatus
 from kungfu.rewind.fb.CaptureLayer import CaptureLayer
 from kungfu.rewind.fb.ModelRequest import ModelRequest
 from kungfu.rewind.fb.ModelResponse import ModelResponse
+from kungfu.rewind.fb.RetryMarker import RetryMarker
 from kungfu.rewind.fb.RunBegin import RunBegin
 from kungfu.rewind.fb.RunEnd import RunEnd
+from kungfu.rewind.fb.ToolCall import ToolCall
+from kungfu.rewind.fb.ToolResult import ToolResult
 
 lf = kungfu.__binding__.longfist
 yjj = kungfu.__binding__.yijinjing
@@ -108,6 +114,52 @@ if resp_frames:
         "ModelResponse.response_body has answer",
         resp_body.get("choices", [{}])[0].get("message", {}).get("content")
         == "the demo answer",
+    )
+
+call_frames = yjj.assemble(location, 0).read_bytes(MSG_TOOL_CALL)
+check("two ToolCall frames (attempt + retry)", len(call_frames) == 2)
+call_spans = []
+for _, payload in call_frames:
+    call = ToolCall.GetRootAs(bytes(payload), 0)
+    call_spans.append((call.SpanId() or b"").decode())
+    check("ToolCall.run_id matches", (call.RunId() or b"").decode() == run_id)
+    check("ToolCall.layer == InProcessHook", call.Layer() == CaptureLayer.InProcessHook)
+    check("ToolCall.tool_name == lookup", (call.ToolName() or b"").decode() == "lookup")
+    check("ToolCall.input captured", "query" in (call.Input() or b"").decode())
+
+result_frames = yjj.assemble(location, 0).read_bytes(MSG_TOOL_RESULT)
+check("two ToolResult frames", len(result_frames) == 2)
+statuses = {}
+for _, payload in result_frames:
+    result = ToolResult.GetRootAs(bytes(payload), 0)
+    statuses[(result.SpanId() or b"").decode()] = result.Status()
+    check("ToolResult.latency_ns > 0", result.LatencyNs() > 0)
+    if result.Status() == CallStatus.Error:
+        check(
+            "failed attempt has error detail",
+            "transient lookup failure" in (result.Error() or b"").decode(),
+        )
+    else:
+        check(
+            "retried attempt has output",
+            "THE DEMO ANSWER" in (result.Output() or b"").decode(),
+        )
+check(
+    "one attempt errored and one succeeded",
+    sorted(statuses.values()) == sorted([CallStatus.Ok, CallStatus.Error]),
+)
+check("tool results correlate to tool calls", set(statuses) == set(call_spans))
+
+retry_frames = yjj.assemble(location, 0).read_bytes(MSG_RETRY_MARKER)
+check("one RetryMarker frame", len(retry_frames) == 1)
+if retry_frames and len(call_spans) == 2:
+    _, payload = retry_frames[0]
+    marker = RetryMarker.GetRootAs(bytes(payload), 0)
+    check("RetryMarker.attempt == 2", marker.Attempt() == 2)
+    check(
+        "RetryMarker links retry to first attempt",
+        (marker.RetryOfSpanId() or b"").decode() == call_spans[0]
+        and (marker.SpanId() or b"").decode() == call_spans[1],
     )
 
 asm2 = yjj.assemble(location, 0)

--- a/tests/fixtures/rewind-demo-happy/demo_agent.py
+++ b/tests/fixtures/rewind-demo-happy/demo_agent.py
@@ -40,4 +40,24 @@ if content != "the demo answer":
     print(f"unexpected model answer: {content}", file=sys.stderr)
     sys.exit(1)
 
-print(f"demo agent got model answer under traced run {run_id}")
+# act on the model's answer with a tool, through the stand-in framework;
+# the first attempt fails to exercise the retry path
+import rewind_demo_toolkit
+
+_attempts = {"n": 0}
+
+
+def flaky_lookup(tool_input):
+    _attempts["n"] += 1
+    if _attempts["n"] == 1:
+        raise ValueError("transient lookup failure")
+    return {"answer": tool_input["query"].upper()}
+
+
+tool = rewind_demo_toolkit.Tool("lookup", flaky_lookup, retries=1)
+result = tool.run({"query": content})
+if result != {"answer": "THE DEMO ANSWER"}:
+    print(f"unexpected tool result: {result}", file=sys.stderr)
+    sys.exit(1)
+
+print(f"demo agent got model answer and tool result under traced run {run_id}")

--- a/tests/fixtures/rewind-demo-happy/rewind_demo_toolkit.py
+++ b/tests/fixtures/rewind-demo-happy/rewind_demo_toolkit.py
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# A miniature tool framework standing in for the third-party ones agents use.
+# It knows nothing about kungfu or tracing: the in-process adapter patches its
+# natural seams (Tool.run = the user-facing call, Tool._invoke = one attempt
+# inside the retry loop) from outside, exactly as adapters do for real
+# frameworks. Keeping it a capability probe, not a product.
+
+
+class Tool:
+    def __init__(self, name, fn, retries=0):
+        self.name = name
+        self.fn = fn
+        self.retries = retries
+
+    def _invoke(self, tool_input):
+        return self.fn(tool_input)
+
+    def run(self, tool_input):
+        attempts = self.retries + 1
+        for attempt in range(attempts):
+            try:
+                return self._invoke(tool_input)
+            except Exception:
+                if attempt == attempts - 1:
+                    raise

--- a/verify.js
+++ b/verify.js
@@ -189,6 +189,24 @@ function main() {
       const guard = spawnSync('bash', [path.join(core, 'src', 'libyijinjing', 'check-deps.sh')], { encoding: 'utf8' });
       if (guard.status === 0) pass('yijinjing dependency guard', 'check-deps.sh');
       else fail('yijinjing dependency guard', tail3(guard));
+
+      // ── Stage 6: rewind capture fixtures (full mode) ──────────────
+      // Each fixture under tests/fixtures/rewind-demo-*/ proves a capture
+      // gate end to end against the built dist/kfc (G2 capture, G3 event
+      // completeness); a red fixture means the capture contract regressed.
+      console.log('\n[verify] stage 6: rewind capture fixtures');
+      const fixturesDir = path.join(ROOT, 'tests', 'fixtures');
+      const fixtures = fs.existsSync(fixturesDir)
+        ? fs
+            .readdirSync(fixturesDir)
+            .filter((d) => d.startsWith('rewind-demo-') && fs.existsSync(path.join(fixturesDir, d, 'run.sh')))
+            .sort()
+        : [];
+      for (const name of fixtures) {
+        const r = spawnSync('bash', [path.join(fixturesDir, name, 'run.sh')], { encoding: 'utf8' });
+        if (r.status === 0) pass(`fixture ${name}`, 'capture facts hold');
+        else fail(`fixture ${name}`, `run.sh exit ${r.status == null ? 'signal ' + r.signal : r.status}; tail: ${tail3(r)}`);
+      }
     }
   }
 


### PR DESCRIPTION
## What

Capture layer L2, completing the G3 (event completeness) evidence, plus the fixtures becoming a release gate:

- **In-process hooks over an announced endpoint**: the supervisor starts a local ingest listener and prepends a hook directory to the child's `PYTHONPATH`; python's site machinery pulls in `sitecustomize`, which installs a meta-path finder that patches known frameworks **after** they import, at their natural seams (user-facing call + per-attempt boundary). No eager imports, no user code changes.
- **Child-side hook is pure stdlib and best-effort by hard rule** — the traced environment owes us nothing, and a traced program must behave exactly like an untraced one (every hook operation degrades silently; a user `sitecustomize` shadowed by ours is chained through). Events travel as line-delimited JSON to the announced endpoint; the framing is swappable behind the endpoint without touching the hook protocol.
- **Single-writer discipline holds**: ingest validates, serializes, enqueues; the one writer thread stays the only journal writer.
- `ToolCall`/`ToolResult`/`RetryMarker` land with provenance `InProcessHook`: per-attempt calls, error detail on the failed attempt, output on the retried one, and the retry edge linking both spans.
- **Fixture**: a stand-in tool framework (capability probe, not a product — it knows nothing about kungfu) plus a flaky tool failing once then succeeding; `check_capture` asserts **43 facts** end to end.
- **`verify --full` gains stage 6**: every `tests/fixtures/rewind-demo-*/run.sh` is now a build-chain gate — a red fixture means the capture contract regressed (build dogfoods the product, per ADR-0009).

## Validation

- Fixture 43/43 green (run bracketing, model wire facts, tool per-attempt facts, retry linkage, result-to-call correlation, bundle manifest/blob).
- `ruff format` clean (flatc-generated `fb/` deliberately left as emitted); `node --check verify.js` clean; python-only.

## Known limits (recorded)

- Cross-layer parent linking (tool span → wire model span) is timeline-ordered, not span-linked yet; frame-level `trigger_frame_uid` chaining and the cross-runtime fixture belong to the G7/G-Moat line.
- Streaming (SSE) responses are captured verbatim, not parsed into usage facts.
- Adapter table ships with the demo-toolkit entry; real framework adapters (LangChain et al.) grow in the adapter table by the same pattern.