### PR TITLE
feat(rewind): one causal chain across python and node in one journal

### DIFF
--- a/framework/core/src/python/kungfu/rewind/hook/rewind_client.py
+++ b/framework/core/src/python/kungfu/rewind/hook/rewind_client.py
@@ -24,6 +24,10 @@ import uuid
 
 ENV_INGEST = "KUNGFU_REWIND_INGEST"
 ENV_RUN_ID = "KUNGFU_REWIND_RUN_ID"
+# carries the active span across process boundaries: child processes spawned
+# inside a tool invocation inherit it, and the other runtime's hook roots its
+# spans under it — one causal chain across runtimes in the same journal
+ENV_PARENT_SPAN = "KUNGFU_REWIND_PARENT_SPAN"
 
 
 class _Emitter:
@@ -127,6 +131,8 @@ class _CallCapture:
     def run(self, fn, input_body, *args, **kwargs):
         tool_call(self.span_id, self.tool_name, input_body, self._parent)
         started = time.monotonic_ns()
+        outer_span = os.environ.get(ENV_PARENT_SPAN)
+        os.environ[ENV_PARENT_SPAN] = self.span_id
         try:
             result = fn(*args, **kwargs)
         except Exception as e:
@@ -137,6 +143,11 @@ class _CallCapture:
                 latency_ns=time.monotonic_ns() - started,
             )
             raise
+        finally:
+            if outer_span is None:
+                os.environ.pop(ENV_PARENT_SPAN, None)
+            else:
+                os.environ[ENV_PARENT_SPAN] = outer_span
         tool_result(
             self.span_id,
             "ok",

--- a/framework/core/src/python/kungfu/rewind/hook/rewind_hook.js
+++ b/framework/core/src/python/kungfu/rewind/hook/rewind_hook.js
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Capture layer L2, child side for Node — pure node built-ins, zero deps.
+// The Node counterpart of sitecustomize.py: the supervisor injects it via
+// NODE_OPTIONS="--require .../rewind_hook.js". Same two hard rules as the
+// python hook: never break or slow the traced program (every operation is
+// best-effort; the first failure disables emission), and depend on nothing
+// beyond the runtime's built-ins.
+//
+// Cross-runtime causality: KUNGFU_REWIND_PARENT_SPAN carries the calling
+// runtime's active span across the process boundary (the python adapter sets
+// it around cross-process tool execution); spans created here root under it,
+// so one causal chain spans both runtimes inside the same journal.
+'use strict';
+
+const net = require('net');
+const crypto = require('crypto');
+const Module = require('module');
+
+const endpoint = process.env.KUNGFU_REWIND_INGEST;
+const bootParent = process.env.KUNGFU_REWIND_PARENT_SPAN || null;
+
+if (endpoint) {
+  let sock = null;
+  let dead = false;
+  const pending = [];
+
+  const [host, port] = (() => {
+    const i = endpoint.lastIndexOf(':');
+    return [endpoint.slice(0, i), Number(endpoint.slice(i + 1))];
+  })();
+
+  const connect = () => {
+    sock = net.createConnection({ host, port, timeout: 1000 });
+    sock.on('connect', () => {
+      for (const line of pending.splice(0)) sock.write(line);
+    });
+    sock.on('error', () => {
+      dead = true;
+      sock = null;
+    });
+    sock.unref(); // never keep the traced process alive
+  };
+  connect();
+
+  const emit = (message) => {
+    if (dead) return;
+    const line = JSON.stringify(message) + '\n';
+    try {
+      if (sock && !sock.connecting) sock.write(line);
+      else pending.push(line);
+    } catch (e) {
+      dead = true;
+    }
+  };
+
+  const newSpan = () => crypto.randomBytes(16).toString('hex');
+
+  const captureInvoke = (toolName, parentSpan, retryOf, attempt, input, fn) => {
+    const spanId = newSpan();
+    if (retryOf) {
+      emit({ event: 'retry', span_id: spanId, retry_of_span_id: retryOf, attempt });
+    }
+    emit({
+      event: 'tool_call',
+      span_id: spanId,
+      parent_span_id: parentSpan,
+      tool_name: toolName,
+      input,
+    });
+    const started = process.hrtime.bigint();
+    const done = (status, output, error) =>
+      emit({
+        event: 'tool_result',
+        span_id: spanId,
+        status,
+        output,
+        error,
+        latency_ns: Number(process.hrtime.bigint() - started),
+      });
+    try {
+      const result = fn();
+      done('ok', render(result), null);
+      return { result, spanId };
+    } catch (e) {
+      done('error', null, `${e.name || 'Error'}: ${e.message || e}`);
+      throw e;
+    }
+  };
+
+  const render = (value) => {
+    try {
+      return JSON.stringify(value);
+    } catch (e) {
+      return String(value);
+    }
+  };
+
+  // ── post-require adapters (mini require-in-the-middle) ──────────
+  const patchDemoToolkit = (exports) => {
+    const originalRun = exports.Tool.prototype.run;
+    const originalInvoke = exports.Tool.prototype._invoke;
+    let attempt = 0;
+    let prevSpan = null;
+
+    exports.Tool.prototype.run = function (toolInput) {
+      attempt = 0;
+      prevSpan = null;
+      return originalRun.call(this, toolInput);
+    };
+    exports.Tool.prototype._invoke = function (toolInput) {
+      attempt += 1;
+      const { result, spanId } = captureInvoke(
+        this.name,
+        bootParent,
+        attempt > 1 ? prevSpan : null,
+        attempt,
+        render(toolInput),
+        () => originalInvoke.call(this, toolInput),
+      );
+      prevSpan = spanId;
+      return result;
+    };
+    return exports;
+  };
+
+  const ADAPTERS = { rewind_demo_toolkit: patchDemoToolkit };
+
+  const originalLoad = Module._load;
+  Module._load = function (request, parent, isMain) {
+    const exports = originalLoad.apply(this, arguments);
+    try {
+      const name = request.replace(/\.js$/, '').split(/[\\/]/).pop();
+      const patcher = ADAPTERS[name];
+      if (patcher && !exports.__rewind_patched__) {
+        Object.defineProperty(exports, '__rewind_patched__', { value: true });
+        return patcher(exports);
+      }
+    } catch (e) {
+      // adapters must never break the user's require
+    }
+    return exports;
+  };
+}

--- a/framework/core/src/python/kungfu/rewind/supervisor.py
+++ b/framework/core/src/python/kungfu/rewind/supervisor.py
@@ -114,11 +114,18 @@ class Supervisor:
         env[ENV_RUN_ID] = self.run_id
         for key in _OPENAI_ENV + _ANTHROPIC_ENV:
             env[key] = self.proxy.base_url
-        # L2: announce the ingest endpoint and let python's site machinery
-        # pull in the hook (sitecustomize) inside the child interpreter
+        # L2: announce the ingest endpoint and let each runtime's preload
+        # machinery pull in its hook — python via site (sitecustomize on
+        # PYTHONPATH), node via NODE_OPTIONS --require. Both preserve
+        # whatever the environment already had.
         env[ENV_INGEST] = self.ingest.endpoint
         existing = env.get("PYTHONPATH")
         env["PYTHONPATH"] = _HOOK_DIR + os.pathsep + existing if existing else _HOOK_DIR
+        node_require = f"--require {os.path.join(_HOOK_DIR, 'rewind_hook.js')}"
+        node_existing = env.get("NODE_OPTIONS")
+        env["NODE_OPTIONS"] = (
+            f"{node_existing} {node_require}" if node_existing else node_require
+        )
         return env
 
     def bundle_dir(self):

--- a/tests/fixtures/rewind-demo-cross-runtime/check_capture.py
+++ b/tests/fixtures/rewind-demo-cross-runtime/check_capture.py
@@ -1,0 +1,145 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Cross-runtime single-journal assertions (gate G7, the machine-checkable half
+# of G-Moat): python and node events from one traced run must land in ONE
+# journal with a shared run id, a causal edge crossing the runtime boundary,
+# and one nanosecond timeline — not two logs stitched offline. A generic
+# baseline (per-runtime logs joined afterwards) cannot satisfy these facts.
+#
+# Usage: check_capture.py <runtime-dir> <run-id>
+
+import json
+import os
+import sys
+
+_core = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "..", "framework", "core")
+)
+sys.path.insert(0, os.path.join(_core, "src", "python"))
+sys.path.insert(0, os.path.join(_core, "dist", "kfc"))
+
+import kungfu
+
+from kungfu.rewind import (
+    MSG_MODEL_REQUEST,
+    MSG_RUN_BEGIN,
+    MSG_RUN_END,
+    MSG_TOOL_CALL,
+    MSG_TOOL_RESULT,
+)
+from kungfu.rewind.fb.CallStatus import CallStatus
+from kungfu.rewind.fb.ModelRequest import ModelRequest
+from kungfu.rewind.fb.RunBegin import RunBegin
+from kungfu.rewind.fb.RunEnd import RunEnd
+from kungfu.rewind.fb.ToolCall import ToolCall
+from kungfu.rewind.fb.ToolResult import ToolResult
+
+lf = kungfu.__binding__.longfist
+yjj = kungfu.__binding__.yijinjing
+
+runtime_dir, run_id = sys.argv[1], sys.argv[2]
+failures = []
+
+
+def check(name, ok, detail=""):
+    print(f"  {'ok' if ok else 'FAIL'}  {name}{': ' + detail if detail else ''}")
+    if not ok:
+        failures.append(name)
+
+
+locator = yjj.locator(runtime_dir)
+location = yjj.location(
+    lf.enums.mode.LIVE, lf.enums.category.SYSTEM, "rewind", run_id, locator
+)
+
+
+def read(msg_type):
+    return yjj.assemble(location, 0).read_bytes(msg_type)
+
+
+# run bracket
+begin = read(MSG_RUN_BEGIN)
+end = read(MSG_RUN_END)
+check("RunBegin/RunEnd present", len(begin) == 1 and len(end) == 1)
+check(
+    "run ids match",
+    (RunBegin.GetRootAs(bytes(begin[0][1]), 0).RunId() or b"").decode() == run_id
+    and (RunEnd.GetRootAs(bytes(end[0][1]), 0).RunId() or b"").decode() == run_id,
+)
+
+# one model call at the wire
+reqs = read(MSG_MODEL_REQUEST)
+check("ModelRequest present", len(reqs) == 1)
+
+# tool calls: the python delegate and the node lookup — in the SAME journal
+calls = {}
+call_times = {}
+for header, payload in read(MSG_TOOL_CALL):
+    c = ToolCall.GetRootAs(bytes(payload), 0)
+    name = (c.ToolName() or b"").decode()
+    calls[name] = {
+        "span": (c.SpanId() or b"").decode(),
+        "parent": (c.ParentSpanId() or b"").decode(),
+        "run_id": (c.RunId() or b"").decode(),
+    }
+    call_times[name] = header.gen_time
+
+check("python delegate tool captured", "delegate" in calls)
+check("node tool captured in same journal", "node-lookup" in calls)
+
+if "delegate" in calls and "node-lookup" in calls:
+    check(
+        "shared run id across runtimes",
+        calls["delegate"]["run_id"] == run_id
+        and calls["node-lookup"]["run_id"] == run_id,
+    )
+    check(
+        "cross-runtime causal edge (node parent == python span)",
+        calls["node-lookup"]["parent"] == calls["delegate"]["span"]
+        and calls["delegate"]["span"] != "",
+        f"node.parent={calls['node-lookup']['parent'][:12]} py.span={calls['delegate']['span'][:12]}",
+    )
+    check(
+        "single timeline orders the boundary (python call before node call)",
+        call_times["delegate"] < call_times["node-lookup"],
+    )
+
+# results for both, ok, with latency
+results = {}
+for _, payload in read(MSG_TOOL_RESULT):
+    r = ToolResult.GetRootAs(bytes(payload), 0)
+    results[(r.SpanId() or b"").decode()] = (r.Status(), r.LatencyNs())
+check(
+    "both tool results present and ok",
+    len(results) == 2
+    and all(
+        status == CallStatus.Ok and latency > 0 for status, latency in results.values()
+    ),
+)
+if "delegate" in calls and "node-lookup" in calls:
+    check(
+        "results correlate to calls across runtimes",
+        set(results) == {calls["delegate"]["span"], calls["node-lookup"]["span"]},
+    )
+
+# G-Moat counter-assertion: the whole causal chain lives in one location's
+# frames (one store, one writer, natively re-readable) — nothing was stitched
+all_msg_types = [
+    MSG_RUN_BEGIN,
+    MSG_MODEL_REQUEST,
+    MSG_TOOL_CALL,
+    MSG_TOOL_RESULT,
+    MSG_RUN_END,
+]
+total = sum(len(read(t)) for t in all_msg_types)
+check("entire chain in one journal location", total >= 7, f"{total} frames")
+
+bundle_dir = os.path.join(runtime_dir, "rewind", run_id, "bundle")
+check(
+    "bundle manifest exists", os.path.exists(os.path.join(bundle_dir, "manifest.json"))
+)
+
+if failures:
+    print(f"cross-runtime check failed: {failures}")
+    sys.exit(1)
+print("cross-runtime check passed")

--- a/tests/fixtures/rewind-demo-cross-runtime/demo_agent.py
+++ b/tests/fixtures/rewind-demo-cross-runtime/demo_agent.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Cross-runtime demo agent (gate G7): a python agent makes one model call,
+# then acts on it with a tool that delegates to a *Node* process. Everything
+# stays unmodified user code: the python framework seam is patched by the
+# python hook, the node process is patched by the node hook via NODE_OPTIONS,
+# and the causal parent crosses the process boundary in the environment the
+# python hook maintains — so one causal chain lands in one journal.
+
+import json
+import os
+import subprocess
+import sys
+import urllib.request
+
+import rewind_demo_toolkit
+
+run_id = os.environ.get("KUNGFU_REWIND_RUN_ID")
+base_url = os.environ.get("OPENAI_BASE_URL")
+if not run_id or not base_url:
+    print("injected capture environment missing", file=sys.stderr)
+    sys.exit(1)
+
+request = urllib.request.Request(
+    base_url.rstrip("/") + "/chat/completions",
+    data=json.dumps(
+        {
+            "model": "demo-model",
+            "messages": [
+                {"role": "user", "content": "what should the node tool reverse?"}
+            ],
+        }
+    ).encode(),
+    headers={"Content-Type": "application/json"},
+    method="POST",
+)
+with urllib.request.urlopen(request, timeout=30) as response:
+    answer = json.load(response)
+content = answer["choices"][0]["message"]["content"]
+
+
+def delegate_to_node(tool_input):
+    completed = subprocess.run(
+        [
+            "node",
+            os.path.join(os.path.dirname(__file__), "node_tool.js"),
+            json.dumps(tool_input),
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return json.loads(completed.stdout)
+
+
+tool = rewind_demo_toolkit.Tool("delegate", delegate_to_node)
+result = tool.run({"query": content})
+
+expected = content[::-1]
+if result != {"answer": expected}:
+    print(f"unexpected cross-runtime result: {result}", file=sys.stderr)
+    sys.exit(1)
+
+print(f"cross-runtime demo done under traced run {run_id}")

--- a/tests/fixtures/rewind-demo-cross-runtime/mock_model.py
+++ b/tests/fixtures/rewind-demo-cross-runtime/mock_model.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Deterministic stand-in for a model provider: an openai-compatible chat
+# completions endpoint with fixed content and usage, so the fixture asserts
+# capture facts without network or keys.
+#
+# Usage: mock_model.py <port-file>   (binds an ephemeral port, writes it there)
+
+import http.server
+import json
+import sys
+
+CANNED = {
+    "id": "chatcmpl-fixture",
+    "object": "chat.completion",
+    "model": "demo-model",
+    "choices": [
+        {
+            "index": 0,
+            "message": {"role": "assistant", "content": "the demo answer"},
+            "finish_reason": "stop",
+        }
+    ],
+    "usage": {"prompt_tokens": 7, "completion_tokens": 3, "total_tokens": 10},
+}
+
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, format, *args):
+        pass
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", 0))
+        self.rfile.read(length)
+        body = json.dumps(CANNED).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+server = http.server.HTTPServer(("127.0.0.1", 0), Handler)
+with open(sys.argv[1], "w") as f:
+    f.write(str(server.server_address[1]))
+server.serve_forever()

--- a/tests/fixtures/rewind-demo-cross-runtime/node_tool.js
+++ b/tests/fixtures/rewind-demo-cross-runtime/node_tool.js
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The Node side of the cross-runtime demo: an unmodified "tool process" that
+// uses the stand-in framework to do one lookup and prints the result. It never
+// mentions kungfu — the hook arrives through NODE_OPTIONS, the causal parent
+// through the environment, exactly as an SDK-free user process would see it.
+'use strict';
+
+const { Tool } = require('./rewind_demo_toolkit.js');
+
+const input = JSON.parse(process.argv[2] || '{}');
+const tool = new Tool('node-lookup', (i) => ({ answer: String(i.query || '').split('').reverse().join('') }));
+process.stdout.write(JSON.stringify(tool.run(input)));

--- a/tests/fixtures/rewind-demo-cross-runtime/rewind_demo_toolkit.js
+++ b/tests/fixtures/rewind-demo-cross-runtime/rewind_demo_toolkit.js
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Node twin of the python stand-in tool framework: same natural seams
+// (Tool.run = user-facing call, Tool._invoke = one attempt inside the retry
+// loop), same rule — it knows nothing about kungfu or tracing; the node hook
+// patches it from outside after require.
+'use strict';
+
+class Tool {
+  constructor(name, fn, retries = 0) {
+    this.name = name;
+    this.fn = fn;
+    this.retries = retries;
+  }
+
+  _invoke(toolInput) {
+    return this.fn(toolInput);
+  }
+
+  run(toolInput) {
+    const attempts = this.retries + 1;
+    for (let attempt = 0; attempt < attempts; attempt += 1) {
+      try {
+        return this._invoke(toolInput);
+      } catch (e) {
+        if (attempt === attempts - 1) throw e;
+      }
+    }
+    return undefined;
+  }
+}
+
+module.exports = { Tool };

--- a/tests/fixtures/rewind-demo-cross-runtime/rewind_demo_toolkit.py
+++ b/tests/fixtures/rewind-demo-cross-runtime/rewind_demo_toolkit.py
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# A miniature tool framework standing in for the third-party ones agents use.
+# It knows nothing about kungfu or tracing: the in-process adapter patches its
+# natural seams (Tool.run = the user-facing call, Tool._invoke = one attempt
+# inside the retry loop) from outside, exactly as adapters do for real
+# frameworks. Keeping it a capability probe, not a product.
+
+
+class Tool:
+    def __init__(self, name, fn, retries=0):
+        self.name = name
+        self.fn = fn
+        self.retries = retries
+
+    def _invoke(self, tool_input):
+        return self.fn(tool_input)
+
+    def run(self, tool_input):
+        attempts = self.retries + 1
+        for attempt in range(attempts):
+            try:
+                return self._invoke(tool_input)
+            except Exception:
+                if attempt == attempts - 1:
+                    raise

--- a/tests/fixtures/rewind-demo-cross-runtime/run.sh
+++ b/tests/fixtures/rewind-demo-cross-runtime/run.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+# SPDX-License-Identifier: Apache-2.0
+#
+# Cross-runtime single-journal fixture (gate G7): a python agent calls a Node
+# tool under one traced run; both runtimes' events must land in one journal
+# with a shared run id, a causal edge across the boundary, and one timeline.
+# Requires the core dev environment (built dist/kfc) and node on PATH.
+#
+# Usage: tests/fixtures/rewind-demo-cross-runtime/run.sh
+
+set -eu
+fixture_dir="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+core_dir="$(CDPATH= cd -- "$fixture_dir/../../../framework/core" && pwd)"
+
+command -v node >/dev/null || { echo "node not on PATH"; exit 2; }
+
+home="$(mktemp -d)"
+run_id="fixturecross$(date +%s)"
+
+port_file="$home/mock-port"
+python3 "$fixture_dir/mock_model.py" "$port_file" &
+mock_pid=$!
+trap 'kill "$mock_pid" 2>/dev/null; rm -rf "$home"' EXIT
+while [ ! -s "$port_file" ]; do sleep 0.1; done
+OPENAI_BASE_URL="http://127.0.0.1:$(cat "$port_file")/v1"
+export OPENAI_BASE_URL
+
+DYLD_FALLBACK_LIBRARY_PATH="$core_dir/dist/kfc${DYLD_FALLBACK_LIBRARY_PATH:+:$DYLD_FALLBACK_LIBRARY_PATH}"
+export DYLD_FALLBACK_LIBRARY_PATH
+
+cd "$core_dir"
+uv run --frozen python .devtools/kfc.py -H "$home" trace --run-id "$run_id" -- \
+  python3 "$fixture_dir/demo_agent.py"
+
+exec uv run --frozen python "$fixture_dir/check_capture.py" "$home/runtime" "$run_id"


### PR DESCRIPTION
## What

Gate **G7 (cross-runtime single journal)** — the machine-checkable half of G-Moat, and the attribution load-bearing wall: without this, Rewind's success would only prove a generic local tracer.

- **Node hook** (`hook/rewind_hook.js`): injected via `NODE_OPTIONS --require` (the node counterpart of sitecustomize), pure node built-ins, same hard rules as the python hook — best-effort everywhere, socket `unref()` so tracing never keeps the traced process alive, frameworks patched after require at the same natural seams via a minimal require interceptor.
- **Cross-runtime span propagation**: the python hook maintains the active span in `KUNGFU_REWIND_PARENT_SPAN` around each tool invocation (restored after, exception-safe); child processes inherit their causal parent through the environment, and the other runtime's spans root under it. One causal chain, two runtimes, one journal.
- **Fixture** `tests/fixtures/rewind-demo-cross-runtime/` (auto-gated by `verify --full` stage 6): python agent → model call (wire) → tool delegated to a node process (node twin of the stand-in framework). **12 assertions**, the decisive ones:
  - cross-runtime causal edge: node ToolCall's `parent_span_id` **equals** the python delegate's `span_id`;
  - shared `run_id` across runtimes; single nanosecond timeline ordering the boundary; results correlate to calls across runtimes; the entire chain lives in one journal location.
- A generic baseline (per-runtime logs joined offline / OTLP viewer) cannot satisfy these facts — that is the point of the assertion design.

## Validation

- Cross-runtime fixture 12/12 green; happy-path fixture regression 43/43 green; `ruff format` + `node --check` clean.

## Scope

Next change adds the forensic-replay surface (`kungfu rewind show/verify`: native journal walk vs bundle reflection decode, consistency diff) — v1 is forensic replay; deterministic rerun stays a next-stage differentiator gate.