### PR TITLE
fix(rewind): fixture mocks must not outlive their run

### DIFF
--- a/tests/fixtures/rewind-demo-cross-runtime/run.sh
+++ b/tests/fixtures/rewind-demo-cross-runtime/run.sh
@@ -18,7 +18,12 @@ home="$(mktemp -d)"
 run_id="fixturecross$(date +%s)"
 
 port_file="$home/mock-port"
-python3 "$fixture_dir/mock_model.py" "$port_file" &
+# The mock detaches from stdio and dies with this script: it must not hold a
+# captured pipe open (a harness reading our output would wait for EOF forever),
+# and the cleanup trap must actually run (no exec below — exec replaces the
+# shell and silently disarms the trap; that leaked mocks and deadlocked
+# verify's stage 6 the first time this ran under spawnSync).
+python3 "$fixture_dir/mock_model.py" "$port_file" >/dev/null 2>&1 &
 mock_pid=$!
 trap 'kill "$mock_pid" 2>/dev/null; rm -rf "$home"' EXIT
 while [ ! -s "$port_file" ]; do sleep 0.1; done
@@ -32,4 +37,4 @@ cd "$core_dir"
 uv run --frozen python .devtools/kfc.py -H "$home" trace --run-id "$run_id" -- \
   python3 "$fixture_dir/demo_agent.py"
 
-exec uv run --frozen python "$fixture_dir/check_capture.py" "$home/runtime" "$run_id"
+uv run --frozen python "$fixture_dir/check_capture.py" "$home/runtime" "$run_id"

--- a/tests/fixtures/rewind-demo-forensic-replay/run.sh
+++ b/tests/fixtures/rewind-demo-forensic-replay/run.sh
@@ -21,7 +21,12 @@ home="$(mktemp -d)"
 run_id="fixturereplay$(date +%s)"
 
 port_file="$home/mock-port"
-python3 "$fixture_dir/mock_model.py" "$port_file" &
+# The mock detaches from stdio and dies with this script: it must not hold a
+# captured pipe open (a harness reading our output would wait for EOF forever),
+# and the cleanup trap must actually run (no exec below — exec replaces the
+# shell and silently disarms the trap; that leaked mocks and deadlocked
+# verify's stage 6 the first time this ran under spawnSync).
+python3 "$fixture_dir/mock_model.py" "$port_file" >/dev/null 2>&1 &
 mock_pid=$!
 trap 'kill "$mock_pid" 2>/dev/null; rm -rf "$home"' EXIT
 while [ ! -s "$port_file" ]; do sleep 0.1; done

--- a/tests/fixtures/rewind-demo-happy/run.sh
+++ b/tests/fixtures/rewind-demo-happy/run.sh
@@ -18,7 +18,12 @@ run_id="fixturehappy$(date +%s)"
 # deterministic model upstream: the mock binds an ephemeral port and reports
 # it through a file; the supervisor picks it up as the openai forward target
 port_file="$home/mock-port"
-python3 "$fixture_dir/mock_model.py" "$port_file" &
+# The mock detaches from stdio and dies with this script: it must not hold a
+# captured pipe open (a harness reading our output would wait for EOF forever),
+# and the cleanup trap must actually run (no exec below — exec replaces the
+# shell and silently disarms the trap; that leaked mocks and deadlocked
+# verify's stage 6 the first time this ran under spawnSync).
+python3 "$fixture_dir/mock_model.py" "$port_file" >/dev/null 2>&1 &
 mock_pid=$!
 trap 'kill "$mock_pid" 2>/dev/null; rm -rf "$home"' EXIT
 while [ ! -s "$port_file" ]; do sleep 0.1; done
@@ -35,4 +40,4 @@ cd "$core_dir"
 uv run --frozen python .devtools/kfc.py -H "$home" trace --run-id "$run_id" -- \
   python3 "$fixture_dir/demo_agent.py"
 
-exec uv run --frozen python "$fixture_dir/check_capture.py" "$home/runtime" "$run_id"
+uv run --frozen python "$fixture_dir/check_capture.py" "$home/runtime" "$run_id"


### PR DESCRIPTION
## What

Two harness bugs that `verify --full` stage 6 itself surfaced the first time it ran the rewind fixtures under `spawnSync` — the gate catching its own probes:

1. **Disarmed cleanup trap**: ending `run.sh` with `exec` replaced the shell, so the `EXIT` trap never fired and the background mock model leaked (several multi-hour mock processes accumulated across manual runs).
2. **Pipe-EOF deadlock**: the leaked mock inherited the captured stdout pipe; a harness waiting for pipe EOF (`spawnSync`) waited forever — stage 6 hung on a fixture that had actually passed.

Fix: the mock detaches from stdio at spawn (`>/dev/null 2>&1`) and the final check runs without `exec` so the trap actually fires. The reasoning is recorded as a comment at the spawn site in all three fixtures.

## Validation

`./kungfu-code verify --full`: **14/14 passed** — full rebuild + freeze + runtime smoke + 3 capability slices + yijinjing dependency guard + all 3 rewind fixtures green under the gated (spawnSync) environment, no leftover processes.