### PR TITLE
fix(yijinjing): fix Windows crash stack traces — rewrite walker and ship PDBs

### DIFF
--- a/framework/core/.cmake/compiler.cmake
+++ b/framework/core/.cmake/compiler.cmake
@@ -62,6 +62,21 @@ if (MSVC)
   add_compile_definitions(_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING)
   set(COMPILER_OPTIMIZE_ON_OPTIONS "/O2")
   set(COMPILER_OPTIMIZE_OFF_OPTIONS "/Od")
+  # Emit debug info as PDBs so Windows crash reports symbolize in the field.
+  # kungfu ships no source on the box and the C++ core is linked statically into
+  # kungfu_node.node / pykungfu.pyd; without the matching PDB next to those
+  # binaries the native stackwalker can only print module+offset. /Z7 keeps the
+  # debug info inside each .obj (sccache-cacheable; /Zi serializes through
+  # mspdbsrv and defeats the MSVC compiler cache). /DEBUG makes the linker emit
+  # <target>.pdb, and /OPT:REF /OPT:ICF restore the size optimizations that
+  # /DEBUG turns off by default so Release binaries stay lean. The release must
+  # ship these PDBs -- see docs/windows-crash-symbols.md, enforced at freeze time
+  # by .gyp/verify-windows-symbols.js.
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /Z7")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Z7")
+  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /DEBUG /OPT:REF /OPT:ICF")
+  set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} /DEBUG /OPT:REF /OPT:ICF")
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /DEBUG /OPT:REF /OPT:ICF")
 endif ()
 
 if (${CMAKE_CXX_COMPILER_ID} MATCHES GNU)

--- a/framework/core/.gyp/run-freeze.js
+++ b/framework/core/.gyp/run-freeze.js
@@ -19,6 +19,7 @@
 const fs = require('fs');
 const path = require('path');
 const { shell } = require('../lib');
+const { verifyWindowsSymbols } = require('./verify-windows-symbols');
 
 const CORE = path.resolve(__dirname, '..'); // framework/core
 const isWin = process.platform === 'win32';
@@ -71,6 +72,27 @@ const APP_NATIVE = [
   'link_node.node',
 ];
 
+// Ship <binary>.pdb next to a native so Windows field crash reports can resolve
+// kungfu frames to symbols; without it the stackwalker only prints module+offset
+// (see docs/windows-crash-symbols.md). No-op off Windows or when no PDB exists
+// (e.g. third-party natives, or a build without /Z7 + /DEBUG).
+function copyPdbSibling(binPath, destDir) {
+  const dir = path.dirname(binPath);
+  const stem = path.basename(binPath).replace(/\.(node|pyd|dll|exe)$/i, '').split('.')[0];
+  let pdb = binPath.replace(/\.(node|pyd|dll|exe)$/i, '.pdb');
+  if (pdb === binPath || !fs.existsSync(pdb)) {
+    // Fall back to any <stem>*.pdb the linker emitted next to the binary; the
+    // PDB name follows the target output base, which for pykungfu carries an ABI
+    // suffix. Matches the stem check in verify-windows-symbols.js.
+    const cand = fs
+      .readdirSync(dir)
+      .find((f) => /\.pdb$/i.test(f) && f.toLowerCase().startsWith(stem.toLowerCase()));
+    pdb = cand ? path.join(dir, cand) : null;
+  }
+  if (!pdb || !fs.existsSync(pdb)) return;
+  fs.copyFileSync(pdb, path.join(destDir, path.basename(pdb)));
+}
+
 function copyAppNative(bt) {
   const rel = path.join(CORE, 'build', bt);
   const distKfc = path.join(CORE, 'dist', 'kfc');
@@ -79,6 +101,7 @@ function copyAppNative(bt) {
     const from = path.join(rel, f);
     if (!fs.existsSync(from)) continue;
     fs.copyFileSync(from, path.join(distKfc, f));
+    copyPdbSibling(from, distKfc);
     n++;
   }
   console.log(`[freeze] 补拷 app native：${n}/${APP_NATIVE.length} 项`);
@@ -129,6 +152,9 @@ function copyPyBindingWin(bt) {
     fs.copyFileSync(src, path.join(distKfc, path.basename(src)));
     n++;
   }
+  // pykungfu.pdb ships the symbols for the python binding + statically-linked
+  // core; libnode.dll is third-party and carries no PDB of ours.
+  if (pyd) copyPdbSibling(pyd, distKfc);
   if (!pyd) console.error('[freeze] Win 警告：build 树未找到 pykungfu*.pyd');
   if (!dll) console.error('[freeze] Win 警告：build 树未找到 libnode.dll');
   console.log(`[freeze] Win：补拷 python binding → dist/kfc：${n} 项`);
@@ -186,6 +212,7 @@ function freezeNuitka(bt) {
 
   copyAppNative(bt);
   copyPyBindingWin(bt);
+  if (isWin) verifyWindowsSymbols(path.join(CORE, 'dist', 'kfc'));
   console.log('[freeze] ✅ dist/kfc 就绪（nuitka 扁平产物 + app native）');
 }
 
@@ -220,6 +247,7 @@ function freezePyinstaller(bt) {
   );
   mergeKfs();
   promote();
+  if (isWin) verifyWindowsSymbols(path.join(CORE, 'dist', 'kfc'));
   console.log('[freeze] ✅ dist/kfc 就绪（pyinstaller 扁平视图 + _internal 真身）');
 }
 

--- a/framework/core/.gyp/verify-windows-symbols.js
+++ b/framework/core/.gyp/verify-windows-symbols.js
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Release constraint: every kungfu-compiled native shipped into dist/kfc on
+// Windows MUST have its PDB alongside it. Without the PDB the field crash
+// stackwalker can only print module+offset instead of function names and source
+// lines (see docs/windows-crash-symbols.md).
+//
+// This is the enforcement point. It exits non-zero when a required PDB is
+// missing so a broken release fails loudly at freeze time instead of silently
+// shipping crash reports that cannot be symbolized in the field.
+//
+// Usage:
+//   node .gyp/verify-windows-symbols.js [dist-kfc-dir]
+// or from the freeze pipeline:
+//   const { verifyWindowsSymbols } = require('./verify-windows-symbols');
+//   verifyWindowsSymbols(path.join(CORE, 'dist', 'kfc'));
+
+const fs = require('fs');
+const path = require('path');
+
+// Natives kungfu compiles from source and therefore owns the PDBs for. The
+// C++ core (libkungfu / libyijinjing, including the stackwalker) is linked
+// statically into these on Windows, so their PDBs cover the whole native side.
+// Third-party natives (libnode.dll, link_node.node) are intentionally excluded:
+// they ship without PDBs of ours.
+const REQUIRED = [
+  /^kungfu_node\.node$/i,
+  /^kungfu_electron\.node$/i,
+  /^drone\.node$/i,
+  /^pykungfu.*\.pyd$/i,
+];
+
+// The linker PDB is named after the target's output base, so accept
+// "<module>.pdb" as well as an ABI-suffixed "<module>.<abi>.pdb".
+function hasSiblingPdb(dir, binName, pdbNames) {
+  const stem = binName.replace(/\.(node|pyd)$/i, '').split('.')[0].toLowerCase();
+  return pdbNames.some((p) => p.toLowerCase().startsWith(stem));
+}
+
+function verifyWindowsSymbols(distKfc) {
+  const entries = fs.existsSync(distKfc) ? fs.readdirSync(distKfc) : [];
+  const pdbNames = entries.filter((f) => /\.pdb$/i.test(f));
+  const missing = [];
+  for (const re of REQUIRED) {
+    const bin = entries.find((f) => re.test(f));
+    if (!bin) continue; // this native is not part of the current build target set
+    if (!hasSiblingPdb(distKfc, bin, pdbNames)) missing.push(bin);
+  }
+  if (missing.length) {
+    console.error(
+      `[verify-windows-symbols] FAIL: native(s) shipped without a PDB in ${distKfc}:\n` +
+        missing.map((m) => `  - ${m}`).join('\n') +
+        '\nWindows crash reports for these cannot be symbolized. Build with debug ' +
+        'info (/Z7 + /DEBUG, see .cmake/compiler.cmake) and ship the PDB alongside ' +
+        'the binary. See docs/windows-crash-symbols.md.',
+    );
+    process.exit(1);
+  }
+  console.log('[verify-windows-symbols] ok: every shipped kungfu native has a PDB');
+}
+
+module.exports = { verifyWindowsSymbols };
+
+if (require.main === module) {
+  const dir = process.argv[2] || path.resolve(__dirname, '..', 'dist', 'kfc');
+  verifyWindowsSymbols(dir);
+}

--- a/framework/core/docs/windows-crash-symbols.md
+++ b/framework/core/docs/windows-crash-symbols.md
@@ -1,0 +1,61 @@
+# Windows crash symbols (ship the PDBs)
+
+## Constraint
+
+Every kungfu-compiled native shipped in a Windows release **must** have its PDB
+next to it in `dist/kfc`:
+
+| Native | PDB |
+| --- | --- |
+| `kungfu_node.node` | `kungfu_node.pdb` |
+| `kungfu_electron.node` | `kungfu_electron.pdb` |
+| `drone.node` | `drone.pdb` |
+| `pykungfu*.pyd` | `pykungfu*.pdb` |
+
+Third-party natives (`libnode.dll`, `link_node.node`) are out of scope — they
+ship without PDBs of ours.
+
+## Why
+
+When a native crash reaches the yijinjing stackwalker (an access violation in the
+`hero::produce` event loop, or a C++ exception escaping into `std::terminate` in
+the node binding), the walker resolves each frame through DbgHelp. On Windows,
+unlike Linux/macOS, the binary carries **no** symbol table — the function names
+and source lines live only in the PDB.
+
+- **PDB present** → frames resolve to `func+0xNN (file:line)`, so a field crash
+  report points at the exact failure site.
+- **PDB absent** → frames degrade to `[kungfu_node.node+0xRVA]`. Still
+  recoverable offline (see below), but the on-box report is not directly
+  readable.
+
+The C++ core (`libkungfu` / `libyijinjing`, including the stackwalker itself) is
+linked **statically** into `kungfu_node.node` / `pykungfu.pyd` on Windows, so
+those two PDBs cover the whole native surface — there is no separate
+`libkungfu.dll` PDB to ship.
+
+## How it is enforced
+
+1. **Generation** — `.cmake/compiler.cmake` builds MSVC targets with `/Z7`
+   (debug info embedded per-`.obj`, so `sccache` still caches the compile) and
+   links with `/DEBUG /OPT:REF /OPT:ICF` (emit `<target>.pdb` while keeping the
+   Release size optimizations `/DEBUG` otherwise disables).
+2. **Packaging** — `.gyp/run-freeze.js` copies each native's `.pdb` sibling into
+   `dist/kfc` alongside the binary.
+3. **Verification** — `.gyp/verify-windows-symbols.js` runs at the end of the
+   Windows freeze and `exit(1)`s if any required native lacks a PDB, so a release
+   that would ship unsymbolizable crash reports fails the build instead.
+
+Run the check standalone against a staged release:
+
+```
+node .gyp/verify-windows-symbols.js dist/kfc
+```
+
+## Symbolizing an old report offline
+
+If a crash report only has `[module+0xRVA]` lines (e.g. from a build made before
+this constraint, or a stripped third-party frame), resolve them against the
+matching PDB with any of: WinDbg (`!address` / `ln module+RVA`), `cvdump`, or a
+short DbgHelp `SymFromAddr` helper. The RVA plus the exact-version PDB is enough;
+keep PDBs archived per release so past crash reports stay decodable.

--- a/framework/core/src/libyijinjing/src/util/StackWalker.cpp
+++ b/framework/core/src/libyijinjing/src/util/StackWalker.cpp
@@ -1,1988 +1,395 @@
 // SPDX-License-Identifier: Apache-2.0
 
-/**********************************************************************
- *
- * StackWalker.cpp
- * https://github.com/JochenKalmbach/StackWalker
- *
- * Old location: http://stackwalker.codeplex.com/
- *
- *
- * History:
- *  2005-07-27   v1    - First public release on http://www.codeproject.com/
- *                       http://www.codeproject.com/threads/StackWalker.asp
- *  2005-07-28   v2    - Changed the params of the constructor and ShowCallstack
- *                       (to simplify the usage)
- *  2005-08-01   v3    - Changed to use 'CONTEXT_FULL' instead of CONTEXT_ALL
- *                       (should also be enough)
- *                     - Changed to compile correctly with the PSDK of VC7.0
- *                       (GetFileVersionInfoSizeA and GetFileVersionInfoA is wrongly defined:
- *                        it uses LPSTR instead of LPCSTR as first parameter)
- *                     - Added declarations to support VC5/6 without using 'dbghelp.h'
- *                     - Added a 'pUserData' member to the ShowCallstack function and the
- *                       PReadProcessMemoryRoutine declaration (to pass some user-defined data,
- *                       which can be used in the readMemoryFunction-callback)
- *  2005-08-02   v4    - OnSymInit now also outputs the OS-Version by default
- *                     - Added example for doing an exception-callstack-walking in main.cpp
- *                       (thanks to owillebo: http://www.codeproject.com/script/profile/whos_who.asp?id=536268)
- *  2005-08-05   v5    - Removed most Lint (http://www.gimpel.com/) errors... thanks to Okko Willeboordse!
- *  2008-08-04   v6    - Fixed Bug: Missing LEAK-end-tag
- *                       http://www.codeproject.com/KB/applications/leakfinder.aspx?msg=2502890#xx2502890xx
- *                       Fixed Bug: Compiled with "WIN32_LEAN_AND_MEAN"
- *                       http://www.codeproject.com/KB/applications/leakfinder.aspx?msg=1824718#xx1824718xx
- *                       Fixed Bug: Compiling with "/Wall"
- *                       http://www.codeproject.com/KB/threads/StackWalker.aspx?msg=2638243#xx2638243xx
- *                       Fixed Bug: Now checking SymUseSymSrv
- *                       http://www.codeproject.com/KB/threads/StackWalker.aspx?msg=1388979#xx1388979xx
- *                       Fixed Bug: Support for recursive function calls
- *                       http://www.codeproject.com/KB/threads/StackWalker.aspx?msg=1434538#xx1434538xx
- *                       Fixed Bug: Missing FreeLibrary call in "GetModuleListTH32"
- *                       http://www.codeproject.com/KB/threads/StackWalker.aspx?msg=1326923#xx1326923xx
- *                       Fixed Bug: SymDia is number 7, not 9!
- *  2008-09-11   v7      For some (undocumented) reason, dbhelp.h is needing a packing of 8!
- *                       Thanks to Teajay which reported the bug...
- *                       http://www.codeproject.com/KB/applications/leakfinder.aspx?msg=2718933#xx2718933xx
- *  2008-11-27   v8      Debugging Tools for Windows are now stored in a different directory
- *                       Thanks to Luiz Salamon which reported this "bug"...
- *                       http://www.codeproject.com/KB/threads/StackWalker.aspx?msg=2822736#xx2822736xx
- *  2009-04-10   v9      License slightly corrected (<ORGANIZATION> replaced)
- *  2009-11-01   v10     Moved to http://stackwalker.codeplex.com/
- *  2009-11-02   v11     Now try to use IMAGEHLP_MODULE64_V3 if available
- *  2010-04-15   v12     Added support for VS2010 RTM
- *  2010-05-25   v13     Now using secure MyStrcCpy. Thanks to luke.simon:
- *                       http://www.codeproject.com/KB/applications/leakfinder.aspx?msg=3477467#xx3477467xx
- *  2013-01-07   v14     Runtime Check Error VS2010 Debug Builds fixed:
- *                       http://stackwalker.codeplex.com/workitem/10511
- *
- *
- * LICENSE (http://www.opensource.org/licenses/bsd-license.php)
- *
- *   Copyright (c) 2005-2013, Jochen Kalmbach
- *   All rights reserved.
- *
- *   Redistribution and use in source and binary forms, with or without modification,
- *   are permitted provided that the following conditions are met:
- *
- *   Redistributions of source code must retain the above copyright notice,
- *   this list of conditions and the following disclaimer.
- *   Redistributions in binary form must reproduce the above copyright notice,
- *   this list of conditions and the following disclaimer in the documentation
- *   and/or other materials provided with the distribution.
- *   Neither the name of Jochen Kalmbach nor the names of its contributors may be
- *   used to endorse or promote products derived from this software without
- *   specific prior written permission.
- *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- *   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
- *   THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- *   ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
- *   FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- *   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- *   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- *   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- *   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- *   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- *
- **********************************************************************/
-
-#ifdef _WINDOWS
+//
+// Windows crash-report stack walker for yijinjing.
+//
+// Rewritten to converge on a single, correct, architecture-neutral
+// implementation. The native stack is produced by the OS unwinder
+// (RtlCaptureStackBackTrace for the current thread, StackWalk64 seeded from an
+// exception CONTEXT) and symbolized with DbgHelp. The previously vendored
+// StackWalker library (BSD, Jochen Kalmbach) and its hand-rolled frame walk,
+// along with dead VC5/6 compatibility code, have been removed.
+//
+// Thread-safety: DbgHelp (DbgHelp.dll) is documented as single-threaded; all
+// Sym*/StackWalk calls here are serialized by one process-wide mutex.
+//
+// Scope note: this runs from signal handlers and SEH filters and still uses
+// std::ostream and the logging sink, which are not async-signal-safe. Making the
+// crash dump fully signal-safe is a separate, larger change and is intentionally
+// out of scope here; this change fixes correctness (the walk produced garbage
+// frames and no symbols) and thread-safety.
+//
 
 #include "StackWalker.h"
+
+#if defined(_MSC_VER)
+
 #include <kungfu/common.h>
 #include <kungfu/yijinjing/log.h>
 
-#include <cstdio>
-#include <cstdlib>
-#include <tchar.h>
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
 #include <windows.h>
 
-#include <Psapi.h>
-#include <VersionHelpers.h>
-#include <inttypes.h> //---PRIxPTR
-#include <process.h>
-
-#pragma comment(lib, "version.lib") // for "VerQueryValue"
-#pragma warning(disable : 4826)
-#if _MSC_VER >= 1900
-#pragma warning(disable : 4091) // For fix unnamed enums from DbgHelp.h
-#endif
-
-// If VC7 and later, then use the shipped 'dbghelp.h'-file
-#pragma pack(push, 8)
-#if _MSC_VER >= 1300
 #include <dbghelp.h>
-#else
-// inline the important dbghelp.h-declarations...
-typedef enum {
-  SymNone = 0,
-  SymCoff,
-  SymCv,
-  SymPdb,
-  SymExport,
-  SymDeferred,
-  SymSym,
-  SymDia,
-  SymVirtual,
-  NumSymTypes
-} SYM_TYPE;
-typedef struct _IMAGEHLP_LINE64 {
-  DWORD SizeOfStruct; // set to sizeof(IMAGEHLP_LINE64)
-  PVOID Key;          // internal
-  DWORD LineNumber;   // line number in file
-  PCHAR FileName;     // full filename
-  DWORD64 Address;    // first instruction of line
-} IMAGEHLP_LINE64, *PIMAGEHLP_LINE64;
-typedef struct _IMAGEHLP_MODULE64 {
-  DWORD SizeOfStruct;        // set to sizeof(IMAGEHLP_MODULE64)
-  DWORD64 BaseOfImage;       // base load address of module
-  DWORD ImageSize;           // virtual size of the loaded module
-  DWORD TimeDateStamp;       // date/time stamp from pe header
-  DWORD CheckSum;            // checksum from the pe header
-  DWORD NumSyms;             // number of symbols in the symbol table
-  SYM_TYPE SymType;          // type of symbols loaded
-  CHAR ModuleName[32];       // module name
-  CHAR ImageName[256];       // image name
-  CHAR LoadedImageName[256]; // symbol file name
-} IMAGEHLP_MODULE64, *PIMAGEHLP_MODULE64;
-typedef struct _IMAGEHLP_SYMBOL64 {
-  DWORD SizeOfStruct;  // set to sizeof(IMAGEHLP_SYMBOL64)
-  DWORD64 Address;     // virtual address including dll base address
-  DWORD Size;          // estimated size of symbol, can be zero
-  DWORD Flags;         // info about the symbols, see the SYMF defines
-  DWORD MaxNameLength; // maximum size of symbol name in 'Name'
-  CHAR Name[1];        // symbol name (null terminated string)
-} IMAGEHLP_SYMBOL64, *PIMAGEHLP_SYMBOL64;
-typedef enum { AddrMode1616, AddrMode1632, AddrModeReal, AddrModeFlat } ADDRESS_MODE;
-typedef struct _tagADDRESS64 {
-  DWORD64 Offset;
-  WORD Segment;
-  ADDRESS_MODE Mode;
-} ADDRESS64, *LPADDRESS64;
-typedef struct _KDHELP64 {
-  DWORD64 Thread;
-  DWORD ThCallbackStack;
-  DWORD ThCallbackBStore;
-  DWORD NextCallback;
-  DWORD FramePointer;
-  DWORD64 KiCallUserMode;
-  DWORD64 KeUserCallbackDispatcher;
-  DWORD64 SystemRangeStart;
-  DWORD64 Reserved[8];
-} KDHELP64, *PKDHELP64;
-typedef struct _tagSTACKFRAME64 {
-  ADDRESS64 AddrPC;     // program counter
-  ADDRESS64 AddrReturn; // return address
-  ADDRESS64 AddrFrame;  // frame pointer
-  ADDRESS64 AddrStack;  // stack pointer
-  ADDRESS64 AddrBStore; // backing store pointer
-  PVOID FuncTableEntry; // pointer to pdata/fpo or NULL
-  DWORD64 Params[4];    // possible arguments to the function
-  BOOL Far;             // WOW far call
-  BOOL Virtual;         // is this a virtual frame?
-  DWORD64 Reserved[3];
-  KDHELP64 KdHelp;
-} STACKFRAME64, *LPSTACKFRAME64;
-typedef BOOL(__stdcall *PREAD_PROCESS_MEMORY_ROUTINE64)(HANDLE hProcess, DWORD64 qwBaseAddress, PVOID lpBuffer,
-                                                        DWORD nSize, LPDWORD lpNumberOfBytesRead);
-typedef PVOID(__stdcall *PFUNCTION_TABLE_ACCESS_ROUTINE64)(HANDLE hProcess, DWORD64 AddrBase);
-typedef DWORD64(__stdcall *PGET_MODULE_BASE_ROUTINE64)(HANDLE hProcess, DWORD64 Address);
-typedef DWORD64(__stdcall *PTRANSLATE_ADDRESS_ROUTINE64)(HANDLE hProcess, HANDLE hThread, LPADDRESS64 lpaddr);
-
-// clang-format off
-#define SYMOPT_CASE_INSENSITIVE         0x00000001
-#define SYMOPT_UNDNAME                  0x00000002
-#define SYMOPT_DEFERRED_LOADS           0x00000004
-#define SYMOPT_NO_CPP                   0x00000008
-#define SYMOPT_LOAD_LINES               0x00000010
-#define SYMOPT_OMAP_FIND_NEAREST        0x00000020
-#define SYMOPT_LOAD_ANYTHING            0x00000040
-#define SYMOPT_IGNORE_CVREC             0x00000080
-#define SYMOPT_NO_UNQUALIFIED_LOADS     0x00000100
-#define SYMOPT_FAIL_CRITICAL_ERRORS     0x00000200
-#define SYMOPT_EXACT_SYMBOLS            0x00000400
-#define SYMOPT_ALLOW_ABSOLUTE_SYMBOLS   0x00000800
-#define SYMOPT_IGNORE_NT_SYMPATH        0x00001000
-#define SYMOPT_INCLUDE_32BIT_MODULES    0x00002000
-#define SYMOPT_PUBLICS_ONLY             0x00004000
-#define SYMOPT_NO_PUBLICS               0x00008000
-#define SYMOPT_AUTO_PUBLICS             0x00010000
-#define SYMOPT_NO_IMAGE_SEARCH          0x00020000
-#define SYMOPT_SECURE                   0x00040000
-#define SYMOPT_DEBUG                    0x80000000
-#define UNDNAME_COMPLETE                 (0x0000) // Enable full undecoration
-#define UNDNAME_NAME_ONLY                (0x1000) // Crack only the name for primary declaration;
-// clang-format on
-
-#endif // _MSC_VER < 1300
-#pragma pack(pop)
-
-// Some missing defines (for VC5/6):
-#ifndef INVALID_FILE_ATTRIBUTES
-#define INVALID_FILE_ATTRIBUTES ((DWORD)-1)
-#endif
-
-// secure-CRT_functions are only available starting with VC8
-#if _MSC_VER < 1400
-#define strcpy_s(dst, len, src) strcpy(dst, src)
-#define strncpy_s(dst, len, src, maxLen) strncpy(dst, len, src)
-#define strcat_s(dst, len, src) strcat(dst, src)
-#define _snprintf_s _snprintf
-#define _tcscat_s _tcscat
-#endif
-
-static void MyStrCpy(char *szDest, size_t nMaxDestSize, const char *szSrc) {
-  if (nMaxDestSize == 0)
-    return;
-  strncpy_s(szDest, nMaxDestSize, szSrc, _TRUNCATE);
-  // INFO: _TRUNCATE will ensure that it is null-terminated;
-  // but with older compilers (<1400) it uses "strncpy" and this does not!)
-  szDest[nMaxDestSize - 1] = 0;
-} // MyStrCpy
-
-// Normally it should be enough to use 'CONTEXT_FULL' (better would be 'CONTEXT_ALL')
-#define USED_CONTEXT_FLAGS CONTEXT_FULL
-
-static const char *file_separator() { return "/"; }
-
-static int console_count = 5;
-
-struct _modinfo {
-  address addr;
-  char *full_path; // point to a char buffer
-  int buflen;      // size of the buffer
-  address base_addr;
-};
-
-char buffer_console[2048];
-
-class StackWalkerInternal {
-public:
-  StackWalkerInternal(StackWalker *parent, HANDLE hProcess) : m_hDbhHelp(NULL), m_hProcess(NULL), m_szSymPath(NULL) {
-    m_parent = parent;
-    // m_hDbhHelp = NULL;
-    pSC = NULL;
-    // m_hProcess = hProcess;
-    // m_szSymPath = NULL;
-    pSFTA = NULL;
-    pSGLFA = NULL;
-    pSGMB = NULL;
-    pSGMI = NULL;
-    pSGO = NULL;
-    pSGSFA = NULL;
-    pSI = NULL;
-    pSLM = NULL;
-    pSSO = NULL;
-    pSW = NULL;
-    pUDSN = NULL;
-    pSGSP = NULL;
-  }
-  ~StackWalkerInternal() {
-    if (pSC != NULL)
-      pSC(m_hProcess); // SymCleanup
-    if (m_hDbhHelp != NULL)
-      FreeLibrary(m_hDbhHelp);
-    m_hDbhHelp = NULL;
-    m_parent = NULL;
-    if (m_szSymPath != NULL)
-      free(m_szSymPath);
-    m_szSymPath = NULL;
-  }
-  BOOL Init(LPCSTR szSymPath) {
-    if (m_parent == NULL)
-      return FALSE;
-    // Dynamically load the Entry-Points for dbghelp.dll:
-    // First try to load the newest one from
-    TCHAR szTemp[4096];
-    // But before we do this, we first check if the ".local" file exists
-    if (GetModuleFileName(NULL, szTemp, 4096) > 0) { // 返回执行程序的当前的绝对路径
-      _tcscat_s(szTemp, _T(".local"));
-      if (GetFileAttributes(szTemp) == INVALID_FILE_ATTRIBUTES) { // 若文件不存在
-        // ".local" file does not exist, so we can try to load the dbghelp.dll from the "Debugging Tools for Windows"
-        // Ok, first try the new path according to the architecture:
-#ifdef _M_IX86
-        if ((m_hDbhHelp == NULL) && (GetEnvironmentVariable(_T("ProgramFiles"), szTemp, 4096) > 0)) {
-          _tcscat_s(szTemp, _T("\\Debugging Tools for Windows (x86)\\dbghelp.dll"));
-          // now check if the file exists:
-          if (GetFileAttributes(szTemp) != INVALID_FILE_ATTRIBUTES) {
-            m_hDbhHelp = LoadLibrary(szTemp);
-          }
-        }
-#elif _M_X64
-        if ((m_hDbhHelp == NULL) && (GetEnvironmentVariable(_T("ProgramFiles"), szTemp, 4096) > 0)) {
-          _tcscat_s(szTemp, _T("\\Debugging Tools for Windows (x64)\\dbghelp.dll"));
-          // now check if the file exists:
-          if (GetFileAttributes(szTemp) != INVALID_FILE_ATTRIBUTES) {
-            m_hDbhHelp = LoadLibraryA(szTemp);
-          }
-        }
-#elif _M_IA64
-        if ((m_hDbhHelp == NULL) && (GetEnvironmentVariable(_T("ProgramFiles"), szTemp, 4096) > 0)) {
-          _tcscat_s(szTemp, _T("\\Debugging Tools for Windows (ia64)\\dbghelp.dll"));
-          // now check if the file exists:
-          if (GetFileAttributes(szTemp) != INVALID_FILE_ATTRIBUTES) {
-            m_hDbhHelp = LoadLibrary(szTemp);
-          }
-        }
-#endif
-        // If still not found, try the old directories...
-        // ，返回值是lpBuffer所指向的缓冲区中存储的字符数，不包括结束的空字符。
-        // 如果lpBuffer没有足够大来保存数据，返回值是缓冲区的大小
-        if ((m_hDbhHelp == NULL) && (GetEnvironmentVariable(_T("ProgramFiles"), szTemp, 4096) > 0)) {
-          _tcscat_s(szTemp, _T("\\Debugging Tools for Windows\\dbghelp.dll"));
-          // now check if the file exists:
-          if (GetFileAttributes(szTemp) != INVALID_FILE_ATTRIBUTES) {
-            m_hDbhHelp = LoadLibraryA(szTemp); // 根据模块名称加载路径
-          }
-        }
-#if defined _M_X64 || defined _M_IA64
-        // Still not found? Then try to load the (old) 64-Bit version:
-        if ((m_hDbhHelp == NULL) && (GetEnvironmentVariable(_T("ProgramFiles"), szTemp, 4096) > 0)) {
-          _tcscat_s(szTemp, _T("\\Debugging Tools for Windows 64-Bit\\dbghelp.dll"));
-          if (GetFileAttributes(szTemp) != INVALID_FILE_ATTRIBUTES) {
-            m_hDbhHelp = LoadLibraryA(szTemp);
-          }
-        }
-#endif
-      }
-    }
-    if (m_hDbhHelp == NULL) // if not already loaded, try to load a default-one
-      m_hDbhHelp = LoadLibraryA(_T("dbghelp.dll"));
-    if (m_hDbhHelp == NULL)
-      return FALSE;
-    pSI = (tSI)GetProcAddress(m_hDbhHelp, "SymInitialize");
-    pSC = (tSC)GetProcAddress(m_hDbhHelp, "SymCleanup");
-
-    pSW = (tSW)GetProcAddress(m_hDbhHelp, "StackWalk64"); ///
-    pSGO = (tSGO)GetProcAddress(m_hDbhHelp, "SymGetOptions");
-    pSSO = (tSSO)GetProcAddress(m_hDbhHelp, "SymSetOptions");
-
-    pSFTA = (tSFTA)GetProcAddress(m_hDbhHelp, "SymFunctionTableAccess64"); //
-    pSGLFA = (tSGLFA)GetProcAddress(m_hDbhHelp, "SymGetLineFromAddr64");
-    pSGMB = (tSGMB)GetProcAddress(m_hDbhHelp, "SymGetModuleBase64");
-    pSGMI = (tSGMI)GetProcAddress(m_hDbhHelp, "SymGetModuleInfo64");
-    pSGSFA = (tSGSFA)GetProcAddress(m_hDbhHelp, "SymGetSymFromAddr64");
-    pUDSN = (tUDSN)GetProcAddress(m_hDbhHelp, "UnDecorateSymbolName");
-    pSLM = (tSLM)GetProcAddress(m_hDbhHelp, "SymLoadModule64");
-    pSGSP = (tSGSP)GetProcAddress(m_hDbhHelp, "SymGetSearchPath");
-
-    if (pSC == NULL || pSFTA == NULL || pSGMB == NULL || pSGMI == NULL || pSGO == NULL || pSGSFA == NULL ||
-        pSI == NULL || pSSO == NULL || pSW == NULL || pUDSN == NULL || pSLM == NULL) {
-      FreeLibrary(m_hDbhHelp);
-      m_hDbhHelp = NULL;
-      pSC = NULL;
-      return FALSE;
-    }
-
-    // SymInitialize
-    if (szSymPath != NULL)
-      m_szSymPath = _strdup(szSymPath);
-    if (this->pSI(m_hProcess, m_szSymPath, FALSE) == FALSE)
-      this->m_parent->OnDbgHelpErr("SymInitialize", GetLastError(), 0);
-
-    DWORD symOptions = this->pSGO(); // SymGetOptions
-    symOptions |= SYMOPT_LOAD_LINES;
-    symOptions |= SYMOPT_FAIL_CRITICAL_ERRORS;
-    // symOptions |= SYMOPT_NO_PROMPTS;
-    // SymSetOptions
-    symOptions = this->pSSO(symOptions);
-
-    char buf[StackWalker::STACKWALK_MAX_NAMELEN] = {0};
-    if (this->pSGSP != NULL) {
-      if (this->pSGSP(m_hProcess, buf, StackWalker::STACKWALK_MAX_NAMELEN) == FALSE)
-        this->m_parent->OnDbgHelpErr("SymGetSearchPath", GetLastError(), 0);
-    }
-    char szUserName[1024] = {0};
-    DWORD dwSize = 1024;
-    GetUserNameA(szUserName, &dwSize);
-    this->m_parent->OnSymInit(buf, symOptions, szUserName);
-
-    return TRUE;
-  }
-
-  StackWalker *m_parent;
-
-  HMODULE m_hDbhHelp;
-  HANDLE m_hProcess;
-  LPSTR m_szSymPath;
-
-#pragma pack(push, 8)
-  typedef struct IMAGEHLP_MODULE64_V3 {
-    DWORD SizeOfStruct;        // set to sizeof(IMAGEHLP_MODULE64)
-    DWORD64 BaseOfImage;       // base load address of module
-    DWORD ImageSize;           // virtual size of the loaded module
-    DWORD TimeDateStamp;       // date/time stamp from pe header
-    DWORD CheckSum;            // checksum from the pe header
-    DWORD NumSyms;             // number of symbols in the symbol table
-    SYM_TYPE SymType;          // type of symbols loaded
-    CHAR ModuleName[32];       // module name
-    CHAR ImageName[256];       // image name
-    CHAR LoadedImageName[256]; // symbol file name
-    // new elements: 07-Jun-2002
-    CHAR LoadedPdbName[256];   // pdb file name
-    DWORD CVSig;               // Signature of the CV record in the debug directories
-    CHAR CVData[MAX_PATH * 3]; // Contents of the CV record
-    DWORD PdbSig;              // Signature of PDB
-    GUID PdbSig70;             // Signature of PDB (VC 7 and up)
-    DWORD PdbAge;              // DBI age of pdb
-    BOOL PdbUnmatched;         // loaded an unmatched pdb
-    BOOL DbgUnmatched;         // loaded an unmatched dbg
-    BOOL LineNumbers;          // we have line number information
-    BOOL GlobalSymbols;        // we have internal symbol information
-    BOOL TypeInfo;             // we have type information
-    // new elements: 17-Dec-2003
-    BOOL SourceIndexed; // pdb supports source server
-    BOOL Publics;       // contains public symbols
-  };
-
-  typedef struct IMAGEHLP_MODULE64_V2 {
-    DWORD SizeOfStruct;        // set to sizeof(IMAGEHLP_MODULE64)
-    DWORD64 BaseOfImage;       // base load address of module
-    DWORD ImageSize;           // virtual size of the loaded module
-    DWORD TimeDateStamp;       // date/time stamp from pe header
-    DWORD CheckSum;            // checksum from the pe header
-    DWORD NumSyms;             // number of symbols in the symbol table
-    SYM_TYPE SymType;          // type of symbols loaded
-    CHAR ModuleName[32];       // module name
-    CHAR ImageName[256];       // image name
-    CHAR LoadedImageName[256]; // symbol file name
-  };
-#pragma pack(pop)
-
-  // SymCleanup()
-  typedef BOOL(__stdcall *tSC)(IN HANDLE hProcess);
-  tSC pSC;
-
-  // SymFunctionTableAccess64()
-  typedef PVOID(__stdcall *tSFTA)(HANDLE hProcess, DWORD64 AddrBase);
-  tSFTA pSFTA;
-
-  // SymGetLineFromAddr64()
-  typedef BOOL(__stdcall *tSGLFA)(IN HANDLE hProcess, IN DWORD64 dwAddr, OUT PDWORD pdwDisplacement,
-                                  OUT PIMAGEHLP_LINE64 Line);
-  tSGLFA pSGLFA;
-
-  // SymGetModuleBase64()
-  typedef DWORD64(__stdcall *tSGMB)(IN HANDLE hProcess, IN DWORD64 dwAddr);
-  tSGMB pSGMB;
-
-  // SymGetModuleInfo64()
-  typedef BOOL(__stdcall *tSGMI)(IN HANDLE hProcess, IN DWORD64 dwAddr, OUT IMAGEHLP_MODULE64_V3 *ModuleInfo);
-  tSGMI pSGMI;
-
-  // SymGetOptions()
-  typedef DWORD(__stdcall *tSGO)(VOID);
-  tSGO pSGO;
-
-  // SymGetSymFromAddr64()
-  typedef BOOL(__stdcall *tSGSFA)(IN HANDLE hProcess, IN DWORD64 dwAddr, OUT PDWORD64 pdwDisplacement,
-                                  OUT PIMAGEHLP_SYMBOL64 Symbol);
-  tSGSFA pSGSFA;
-
-  // SymInitialize()
-  typedef BOOL(__stdcall *tSI)(IN HANDLE hProcess, IN PSTR UserSearchPath, IN BOOL fInvadeProcess);
-  tSI pSI;
-
-  // SymLoadModule64()
-  typedef DWORD64(__stdcall *tSLM)(IN HANDLE hProcess, IN HANDLE hFile, IN PSTR ImageName, IN PSTR ModuleName,
-                                   IN DWORD64 BaseOfDll, IN DWORD SizeOfDll);
-  tSLM pSLM;
-
-  // SymSetOptions()
-  typedef DWORD(__stdcall *tSSO)(IN DWORD SymOptions);
-  tSSO pSSO;
-
-  // StackWalk64()
-  typedef BOOL(__stdcall *tSW)(DWORD MachineType, HANDLE hProcess, HANDLE hThread, LPSTACKFRAME64 StackFrame,
-                               PVOID ContextRecord, PREAD_PROCESS_MEMORY_ROUTINE64 ReadMemoryRoutine,
-                               PFUNCTION_TABLE_ACCESS_ROUTINE64 FunctionTableAccessRoutine,
-                               PGET_MODULE_BASE_ROUTINE64 GetModuleBaseRoutine,
-                               PTRANSLATE_ADDRESS_ROUTINE64 TranslateAddress);
-  tSW pSW;
-
-  // UnDecorateSymbolName()
-  typedef DWORD(__stdcall WINAPI *tUDSN)(PCSTR DecoratedName, PSTR UnDecoratedName, DWORD UndecoratedLength,
-                                         DWORD Flags);
-  tUDSN pUDSN;
-
-  typedef BOOL(__stdcall WINAPI *tSGSP)(HANDLE hProcess, PSTR SearchPath, DWORD SearchPathLength);
-  tSGSP pSGSP;
-
-private:
-// **************************************** ToolHelp32 ************************
-#define MAX_MODULE_NAME32 255
-#define TH32CS_SNAPMODULE 0x00000008
-#pragma pack(push, 8)
-  typedef struct tagMODULEENTRY32 {
-    DWORD dwSize;
-    DWORD th32ModuleID;  // This module
-    DWORD th32ProcessID; // owning process
-    DWORD GlblcntUsage;  // Global usage count on the module
-    DWORD ProccntUsage;  // Module usage count in th32ProcessID's context
-    BYTE *modBaseAddr;   // Base address of module in th32ProcessID's context
-    DWORD modBaseSize;   // Size in bytes of module starting at modBaseAddr
-    HMODULE hModule;     // The hModule of this module in th32ProcessID's context
-    char szModule[MAX_MODULE_NAME32 + 1];
-    char szExePath[MAX_PATH];
-  } MODULEENTRY32;
-  typedef MODULEENTRY32 *PMODULEENTRY32;
-  typedef MODULEENTRY32 *LPMODULEENTRY32;
-#pragma pack(pop)
-
-  BOOL GetModuleListTH32(HANDLE hProcess, DWORD pid) {
-    // CreateToolhelp32Snapshot()
-    typedef HANDLE(__stdcall * tCT32S)(DWORD dwFlags, DWORD th32ProcessID);
-    // Module32First()
-    typedef BOOL(__stdcall * tM32F)(HANDLE hSnapshot, LPMODULEENTRY32 lpme);
-    // Module32Next()
-    typedef BOOL(__stdcall * tM32N)(HANDLE hSnapshot, LPMODULEENTRY32 lpme);
-
-    // try both dlls...
-    const TCHAR *dllname[] = {_T("kernel32.dll"), _T("tlhelp32.dll")};
-    HINSTANCE hToolhelp = NULL;
-    tCT32S pCT32S = NULL;
-    tM32F pM32F = NULL;
-    tM32N pM32N = NULL;
-
-    HANDLE hSnap;
-    MODULEENTRY32 me;
-    me.dwSize = sizeof(me);
-    BOOL keepGoing;
-    size_t i;
-
-    for (i = 0; i < (sizeof(dllname) / sizeof(dllname[0])); i++) {
-      hToolhelp = LoadLibraryA(dllname[i]);
-      if (hToolhelp == NULL)
-        continue;
-      pCT32S = reinterpret_cast<tCT32S>(GetProcAddress(hToolhelp, "CreateToolhelp32Snapshot"));
-      pM32F = reinterpret_cast<tM32F>(GetProcAddress(hToolhelp, "Module32First"));
-      pM32N = reinterpret_cast<tM32N>(GetProcAddress(hToolhelp, "Module32Next"));
-      if ((pCT32S != NULL) && (pM32F != NULL) && (pM32N != NULL))
-        break; // found the functions!
-      FreeLibrary(hToolhelp);
-      hToolhelp = NULL;
-    }
-
-    if (hToolhelp == NULL)
-      return FALSE;
-
-    hSnap = pCT32S(TH32CS_SNAPMODULE, pid);
-    if (hSnap == (HANDLE)-1) {
-      FreeLibrary(hToolhelp);
-      return FALSE;
-    }
-
-    keepGoing = !!pM32F(hSnap, &me);
-    int cnt = 0;
-    while (keepGoing) {
-      this->LoadModule(hProcess, me.szExePath, me.szModule, (DWORD64)me.modBaseAddr, me.modBaseSize);
-      cnt++;
-      keepGoing = !!pM32N(hSnap, &me);
-    }
-    CloseHandle(hSnap);
-    FreeLibrary(hToolhelp);
-    if (cnt <= 0)
-      return FALSE;
-    return TRUE;
-  } // GetModuleListTH32
-
-  // **************************************** PSAPI ************************
-  typedef struct _MODULEINFO {
-    LPVOID lpBaseOfDll;
-    DWORD SizeOfImage;
-    LPVOID EntryPoint;
-  } MODULEINFO, *LPMODULEINFO;
-
-  BOOL GetModuleListPSAPI(HANDLE hProcess) {
-    // EnumProcessModules()
-    typedef BOOL(__stdcall * tEPM)(HANDLE hProcess, HMODULE * lphModule, DWORD cb, LPDWORD lpcbNeeded);
-    // GetModuleFileNameEx()
-    typedef DWORD(__stdcall * tGMFNE)(HANDLE hProcess, HMODULE hModule, LPSTR lpFilename, DWORD nSize);
-    // GetModuleBaseName()
-    typedef DWORD(__stdcall * tGMBN)(HANDLE hProcess, HMODULE hModule, LPSTR lpFilename, DWORD nSize);
-    // GetModuleInformation()
-    typedef BOOL(__stdcall * tGMI)(HANDLE hProcess, HMODULE hModule, LPMODULEINFO pmi, DWORD nSize);
-
-    HINSTANCE hPsapi;
-    tEPM pEPM;
-    tGMFNE pGMFNE;
-    tGMBN pGMBN;
-    tGMI pGMI;
-
-    DWORD i;
-    // ModuleEntry e;
-    DWORD cbNeeded;
-    MODULEINFO mi;
-    HMODULE *hMods = 0;
-    char *tt = NULL;
-    char *tt2 = NULL;
-    const SIZE_T TTBUFLEN = 8096;
-    int cnt = 0;
-
-    hPsapi = LoadLibraryA(_T("psapi.dll"));
-    if (hPsapi == NULL)
-      return FALSE;
-
-    pEPM = reinterpret_cast<tEPM>(GetProcAddress(hPsapi, "EnumProcessModules"));
-    pGMFNE = reinterpret_cast<tGMFNE>(GetProcAddress(hPsapi, "GetModuleFileNameExA"));
-    pGMBN = reinterpret_cast<tGMFNE>(GetProcAddress(hPsapi, "GetModuleBaseNameA"));
-    pGMI = reinterpret_cast<tGMI>(GetProcAddress(hPsapi, "GetModuleInformation"));
-    if ((pEPM == NULL) || (pGMFNE == NULL) || (pGMBN == NULL) || (pGMI == NULL)) {
-      // we couldn't find all functions
-      FreeLibrary(hPsapi);
-      return FALSE;
-    }
-
-    hMods = reinterpret_cast<HMODULE *>(malloc(sizeof(HMODULE) * (TTBUFLEN / sizeof(HMODULE))));
-    tt = reinterpret_cast<char *>(malloc(sizeof(char) * TTBUFLEN));
-    tt2 = reinterpret_cast<char *>(malloc(sizeof(char) * TTBUFLEN));
-    if ((hMods == NULL) || (tt == NULL) || (tt2 == NULL))
-      goto cleanup;
-
-    if (!pEPM(hProcess, hMods, TTBUFLEN, &cbNeeded)) {
-      //_ftprintf(fLogFile, _T("%lu: EPM failed, GetLastError = %lu\n"), g_dwShowCount, gle );
-      goto cleanup;
-    }
-
-    if (cbNeeded > TTBUFLEN) {
-      //_ftprintf(fLogFile, _T("%lu: More than %lu module handles. Huh?\n"), g_dwShowCount, lenof( hMods ) );
-      goto cleanup;
-    }
-
-    for (i = 0; i < cbNeeded / sizeof(hMods[0]); i++) {
-      // base address, size
-      pGMI(hProcess, hMods[i], &mi, sizeof(mi));
-      // image file name
-      tt[0] = 0;
-      pGMFNE(hProcess, hMods[i], tt, TTBUFLEN);
-      // module name
-      tt2[0] = 0;
-      pGMBN(hProcess, hMods[i], tt2, TTBUFLEN);
-
-      DWORD dwRes = this->LoadModule(hProcess, tt, tt2, (DWORD64)mi.lpBaseOfDll, mi.SizeOfImage);
-      if (dwRes != ERROR_SUCCESS)
-        this->m_parent->OnDbgHelpErr("LoadModule", dwRes, 0);
-      cnt++;
-    }
-
-  cleanup:
-    if (hPsapi != NULL)
-      FreeLibrary(hPsapi);
-    if (tt2 != NULL)
-      free(tt2);
-    if (tt != NULL)
-      free(tt);
-    if (hMods != NULL)
-      free(hMods);
-
-    return cnt != 0;
-  } // GetModuleListPSAPI
-
-  DWORD LoadModule(HANDLE hProcess, LPCSTR img, LPCSTR mod, DWORD64 baseAddr, DWORD size) {
-    CHAR *szImg = _strdup(img);
-    CHAR *szMod = _strdup(mod);
-    DWORD result = ERROR_SUCCESS;
-    if ((szImg == NULL) || (szMod == NULL))
-      result = ERROR_NOT_ENOUGH_MEMORY;
-    else {
-      if (pSLM(hProcess, 0, szImg, szMod, baseAddr, size) == 0)
-        result = GetLastError();
-    }
-    ULONGLONG fileVersion = 0;
-    if ((m_parent != NULL) && (szImg != NULL)) {
-      // try to retrieve the file-version:
-      if ((this->m_parent->m_options & StackWalker::RetrieveFileVersion) != 0) {
-        VS_FIXEDFILEINFO *fInfo = NULL;
-        DWORD dwHandle;
-        DWORD dwSize = GetFileVersionInfoSizeA(szImg, &dwHandle);
-        if (dwSize > 0) {
-          LPVOID vData = malloc(dwSize);
-          if (vData != NULL) {
-            if (GetFileVersionInfoA(szImg, dwHandle, dwSize, vData) != 0) {
-              UINT len;
-              TCHAR szSubBlock[] = _T("\\");
-              if (VerQueryValue(vData, szSubBlock, (LPVOID *)&fInfo, &len) == 0)
-                fInfo = NULL;
-              else {
-                fileVersion = ((ULONGLONG)fInfo->dwFileVersionLS) + ((ULONGLONG)fInfo->dwFileVersionMS << 32);
-              }
-            }
-            free(vData);
-          }
-        }
-      }
-
-      // Retrieve some additional-infos about the module
-      IMAGEHLP_MODULE64_V3 Module;
-      const char *szSymType = "-unknown-";
-      if (this->GetModuleInfo(hProcess, baseAddr, &Module) != FALSE) {
-        switch (Module.SymType) {
-        case SymNone:
-          szSymType = "-nosymbols-";
-          break;
-        case SymCoff: // 1
-          szSymType = "COFF";
-          break;
-        case SymCv: // 2
-          szSymType = "CV";
-          break;
-        case SymPdb: // 3
-          szSymType = "PDB";
-          break;
-        case SymExport: // 4
-          szSymType = "-exported-";
-          break;
-        case SymDeferred: // 5
-          szSymType = "-deferred-";
-          break;
-        case SymSym: // 6
-          szSymType = "SYM";
-          break;
-        case 7: // SymDia:
-          szSymType = "DIA";
-          break;
-        case 8: // SymVirtual:
-          szSymType = "Virtual";
-          break;
-        }
-      }
-      LPCSTR pdbName = Module.LoadedImageName;
-      if (Module.LoadedPdbName[0] != 0)
-        pdbName = Module.LoadedPdbName;
-      this->m_parent->OnLoadModule(img, mod, baseAddr, size, result, szSymType, pdbName, fileVersion);
-    }
-    if (szImg != NULL)
-      free(szImg);
-    if (szMod != NULL)
-      free(szMod);
-    return result;
-  }
-
-public:
-  BOOL LoadModules(HANDLE hProcess, DWORD dwProcessId) {
-    // first try toolhelp32
-    if (GetModuleListTH32(hProcess, dwProcessId))
-      return true;
-    // then try psapi
-    return GetModuleListPSAPI(hProcess);
-  }
-
-  BOOL GetModuleInfo(HANDLE hProcess, DWORD64 baseAddr, IMAGEHLP_MODULE64_V3 *pModuleInfo) {
-    memset(pModuleInfo, 0, sizeof(IMAGEHLP_MODULE64_V3));
-    if (this->pSGMI == NULL) {
-      SetLastError(ERROR_DLL_INIT_FAILED);
-      return FALSE;
-    }
-    // First try to use the larger ModuleInfo-Structure
-    pModuleInfo->SizeOfStruct = sizeof(IMAGEHLP_MODULE64_V3);
-    void *pData = malloc(4096); // reserve enough memory, so the bug in v6.3.5.1 does not lead to memory-overwrites...
-    if (pData == NULL) {
-      SetLastError(ERROR_NOT_ENOUGH_MEMORY);
-      return FALSE;
-    }
-    memcpy(pData, pModuleInfo, sizeof(IMAGEHLP_MODULE64_V3));
-    static bool s_useV3Version = true;
-    if (s_useV3Version) {
-      if (this->pSGMI(hProcess, baseAddr, reinterpret_cast<IMAGEHLP_MODULE64_V3 *>(pData)) != FALSE) {
-        // only copy as much memory as is reserved...
-        memcpy(pModuleInfo, pData, sizeof(IMAGEHLP_MODULE64_V3));
-        pModuleInfo->SizeOfStruct = sizeof(IMAGEHLP_MODULE64_V3);
-        free(pData);
-        return TRUE;
-      }
-      s_useV3Version = false; // to prevent unnecessary calls with the larger struct...
-    }
-
-    // could not retrieve the bigger structure, try with the smaller one (as defined in VC7.1)...
-    pModuleInfo->SizeOfStruct = sizeof(IMAGEHLP_MODULE64_V2);
-    memcpy(pData, pModuleInfo, sizeof(IMAGEHLP_MODULE64_V2));
-    if (this->pSGMI(hProcess, baseAddr, reinterpret_cast<IMAGEHLP_MODULE64_V3 *>(pData)) != FALSE) {
-      // only copy as much memory as is reserved...
-      memcpy(pModuleInfo, pData, sizeof(IMAGEHLP_MODULE64_V2));
-      pModuleInfo->SizeOfStruct = sizeof(IMAGEHLP_MODULE64_V2);
-      free(pData);
-      return TRUE;
-    }
-    free(pData);
-    SetLastError(ERROR_DLL_INIT_FAILED);
-    return FALSE;
-  }
-};
-
-// #############################################################
-StackWalker::StackWalker(DWORD dwProcessId, HANDLE hProcess) {
-  this->m_options = OptionsAll;
-  this->m_modulesLoaded = FALSE;
-  this->m_hProcess = hProcess;
-  this->m_sw = new StackWalkerInternal(this, this->m_hProcess);
-  this->m_dwProcessId = dwProcessId;
-  this->m_szSymPath = NULL;
-  this->m_MaxRecursionCount = 1000;
-}
-StackWalker::StackWalker(int options, LPCSTR szSymPath, DWORD dwProcessId, HANDLE hProcess) {
-  this->m_options = options;
-  this->m_modulesLoaded = FALSE;
-  this->m_hProcess = hProcess;
-  this->m_sw = new StackWalkerInternal(this, this->m_hProcess);
-  this->m_dwProcessId = dwProcessId;
-  if (szSymPath != NULL) {
-    this->m_szSymPath = _strdup(szSymPath);
-    this->m_options |= SymBuildPath;
-  } else
-    this->m_szSymPath = NULL;
-  this->m_MaxRecursionCount = 1000;
-}
-
-StackWalker::~StackWalker() {
-  if (m_szSymPath != NULL)
-    free(m_szSymPath);
-  m_szSymPath = NULL;
-  if (this->m_sw != NULL)
-    delete this->m_sw;
-  this->m_sw = NULL;
-}
-
-BOOL StackWalker::LoadModules() {
-  if (this->m_sw == NULL) {
-    SetLastError(ERROR_DLL_INIT_FAILED);
-    return FALSE;
-  }
-  if (m_modulesLoaded != FALSE)
-    return TRUE;
-
-  // Build the sym-path:
-  char *szSymPath = NULL;
-  if ((this->m_options & SymBuildPath) != 0) {
-    const size_t nSymPathLen = 4096;
-    szSymPath = reinterpret_cast<char *>(malloc(nSymPathLen));
-    if (szSymPath == NULL) {
-      SetLastError(ERROR_NOT_ENOUGH_MEMORY);
-      return FALSE;
-    }
-    szSymPath[0] = 0;
-    // Now first add the (optional) provided sympath:
-    if (this->m_szSymPath != NULL) {
-      strcat_s(szSymPath, nSymPathLen, this->m_szSymPath);
-      strcat_s(szSymPath, nSymPathLen, ";");
-    }
-
-    strcat_s(szSymPath, nSymPathLen, ".;");
-
-    const size_t nTempLen = 1024;
-    char szTemp[nTempLen];
-    // Now add the current directory:
-    if (GetCurrentDirectoryA(nTempLen, szTemp) > 0) {
-      szTemp[nTempLen - 1] = 0;
-      strcat_s(szSymPath, nSymPathLen, szTemp);
-      strcat_s(szSymPath, nSymPathLen, ";");
-    }
-
-    // Now add the path for the main-module:
-    if (GetModuleFileNameA(NULL, szTemp, nTempLen) > 0) {
-      szTemp[nTempLen - 1] = 0;
-      for (char *p = (szTemp + strlen(szTemp) - 1); p >= szTemp; --p) {
-        // locate the rightmost path separator
-        if ((*p == '\\') || (*p == '/') || (*p == ':')) {
-          *p = 0;
-          break;
-        }
-      } // for (search for path separator...)
-      if (strlen(szTemp) > 0) {
-        strcat_s(szSymPath, nSymPathLen, szTemp);
-        strcat_s(szSymPath, nSymPathLen, ";");
-      }
-    }
-    if (GetEnvironmentVariableA("_NT_SYMBOL_PATH", szTemp, nTempLen) > 0) {
-      szTemp[nTempLen - 1] = 0;
-      strcat_s(szSymPath, nSymPathLen, szTemp);
-      strcat_s(szSymPath, nSymPathLen, ";");
-    }
-    if (GetEnvironmentVariableA("_NT_ALTERNATE_SYMBOL_PATH", szTemp, nTempLen) > 0) {
-      szTemp[nTempLen - 1] = 0;
-      strcat_s(szSymPath, nSymPathLen, szTemp);
-      strcat_s(szSymPath, nSymPathLen, ";");
-    }
-    if (GetEnvironmentVariableA("SYSTEMROOT", szTemp, nTempLen) > 0) {
-      szTemp[nTempLen - 1] = 0;
-      strcat_s(szSymPath, nSymPathLen, szTemp);
-      strcat_s(szSymPath, nSymPathLen, ";");
-      // also add the "system32"-directory:
-      strcat_s(szTemp, nTempLen, "\\system32");
-      strcat_s(szSymPath, nSymPathLen, szTemp);
-      strcat_s(szSymPath, nSymPathLen, ";");
-    }
-
-    if ((this->m_options & SymUseSymSrv) != 0) {
-      if (GetEnvironmentVariableA("SYSTEMDRIVE", szTemp, nTempLen) > 0) {
-        szTemp[nTempLen - 1] = 0;
-        strcat_s(szSymPath, nSymPathLen, "SRV*");
-        strcat_s(szSymPath, nSymPathLen, szTemp);
-        strcat_s(szSymPath, nSymPathLen, "\\websymbols");
-        strcat_s(szSymPath, nSymPathLen, "*http://msdl.microsoft.com/download/symbols;");
-      } else
-        strcat_s(szSymPath, nSymPathLen, "SRV*c:\\websymbols*http://msdl.microsoft.com/download/symbols;");
-    }
-  } // if SymBuildPath
-
-  // First Init the whole stuff...
-  BOOL bRet = this->m_sw->Init(szSymPath);
-  if (szSymPath != NULL)
-    free(szSymPath);
-  szSymPath = NULL;
-  if (bRet == FALSE) {
-    this->OnDbgHelpErr("Error while initializing dbghelp.dll", 0, 0);
-    SetLastError(ERROR_DLL_INIT_FAILED);
-    return FALSE;
-  }
-
-  bRet = this->m_sw->LoadModules(this->m_hProcess, this->m_dwProcessId);
-  if (bRet != FALSE)
-    m_modulesLoaded = TRUE;
-  return bRet;
-}
-
-// The following is used to pass the "userData"-Pointer to the user-provided readMemoryFunction
-// This has to be done due to a problem with the "hProcess"-parameter in x64...
-// Because this class is in no case multi-threading-enabled (because of the limitations
-// of dbghelp.dll) it is "safe" to use a static-variable
-static StackWalker::PReadProcessMemoryRoutine s_readMemoryFunction = NULL;
-static LPVOID s_readMemoryFunction_UserData = NULL;
-
-BOOL StackWalker::ShowCallstack(HANDLE hThread, const CONTEXT *context, PReadProcessMemoryRoutine readMemoryFunction,
-                                LPVOID pUserData) {
-  CONTEXT c;
-  CallstackEntry csEntry;
-  IMAGEHLP_SYMBOL64 *pSym = NULL;
-  StackWalkerInternal::IMAGEHLP_MODULE64_V3 Module;
-  IMAGEHLP_LINE64 Line;
-  int frameNum;
-  bool bLastEntryCalled = true;
-  int curRecursionCount = 0;
-
-  if (m_modulesLoaded == FALSE)
-    this->LoadModules(); // ignore the result...
-
-  if (this->m_sw->m_hDbhHelp == NULL) { // dll加载失败
-    SetLastError(ERROR_DLL_INIT_FAILED);
-    return FALSE;
-  }
-
-  s_readMemoryFunction = readMemoryFunction;
-  s_readMemoryFunction_UserData = pUserData;
-
-  if (context == NULL) { // 如果context是null，则进行调用进行获取
-                         // If no context is provided, capture the context
-                         // See: https://stackwalker.codeplex.com/discussions/446958
-#if _WIN32_WINNT <= 0x0501
-    // If we need to support XP, we need to use the "old way", because "GetThreadId" is not available!
-    if (hThread == GetCurrentThread())
-#else
-    if (GetThreadId(hThread) == GetCurrentThreadId())
-#endif
-    {
-      GET_CURRENT_CONTEXT_STACKWALKER_CODEPLEX(c, USED_CONTEXT_FLAGS);
-    } else {
-      SuspendThread(hThread);
-      memset(&c, 0, sizeof(CONTEXT));
-      c.ContextFlags = USED_CONTEXT_FLAGS;
-
-      // TODO: Detect if you want to get a thread context of a different process, which is running a different processor
-      // architecture... This does only work if we are x64 and the target process is x64 or x86; It cannot work, if this
-      // process is x64 and the target process is x64... this is not supported... See also:
-      // http://www.howzatt.demon.co.uk/articles/DebuggingInWin64.html
-      if (GetThreadContext(hThread, &c) == FALSE) {
-        ResumeThread(hThread);
-        return FALSE;
-      }
-    }
-  } else
-    c = *context;
-
-  // init STACKFRAME for first call
-  STACKFRAME64 s; // in/out stackframe
-  memset(&s, 0, sizeof(s));
-  DWORD imageType;
-#ifdef _M_IX86
-  // normally, call ImageNtHeader() and use machine info from PE header
-  imageType = IMAGE_FILE_MACHINE_I386;
-  s.AddrPC.Offset = c.Eip;
-  s.AddrPC.Mode = AddrModeFlat;
-  s.AddrFrame.Offset = c.Ebp;
-  s.AddrFrame.Mode = AddrModeFlat;
-  s.AddrStack.Offset = c.Esp;
-  s.AddrStack.Mode = AddrModeFlat;
-#elif _M_X64
-  imageType = IMAGE_FILE_MACHINE_AMD64;
-  s.AddrPC.Offset = c.Rip;
-  s.AddrPC.Mode = AddrModeFlat;
-  s.AddrFrame.Offset = c.Rsp;
-  s.AddrFrame.Mode = AddrModeFlat;
-  s.AddrStack.Offset = c.Rsp;
-  s.AddrStack.Mode = AddrModeFlat;
-#elif _M_IA64
-  imageType = IMAGE_FILE_MACHINE_IA64;
-  s.AddrPC.Offset = c.StIIP;
-  s.AddrPC.Mode = AddrModeFlat;
-  s.AddrFrame.Offset = c.IntSp;
-  s.AddrFrame.Mode = AddrModeFlat;
-  s.AddrBStore.Offset = c.RsBSP;
-  s.AddrBStore.Mode = AddrModeFlat;
-  s.AddrStack.Offset = c.IntSp;
-  s.AddrStack.Mode = AddrModeFlat;
-#else
-#error "Platform not supported!"
-#endif
-
-  // 设置好IMAGEHLP_SYMBOL64
-  pSym = reinterpret_cast<IMAGEHLP_SYMBOL64 *>(malloc(sizeof(IMAGEHLP_SYMBOL64) + STACKWALK_MAX_NAMELEN));
-  if (!pSym)
-    goto cleanup; // not enough memory...
-  memset(pSym, 0, sizeof(IMAGEHLP_SYMBOL64) + STACKWALK_MAX_NAMELEN);
-  pSym->SizeOfStruct = sizeof(IMAGEHLP_SYMBOL64);
-  pSym->MaxNameLength = STACKWALK_MAX_NAMELEN;
-
-  memset(&Line, 0, sizeof(Line));
-  Line.SizeOfStruct = sizeof(Line);
-
-  memset(&Module, 0, sizeof(Module));
-  Module.SizeOfStruct = sizeof(Module);
-
-  for (frameNum = 0;; ++frameNum) {
-    // get next stack frame (StackWalk64(), SymFunctionTableAccess64(), SymGetModuleBase64())
-    // if this returns ERROR_INVALID_ADDRESS (487) or ERROR_NOACCESS (998), you can
-    // assume that either you are done, or that the stack is so hosed that the next
-    // deeper frame could not be found.
-    // CONTEXT need not to be supplied if imageTyp is IMAGE_FILE_MACHINE_I386!
-    if (!this->m_sw->pSW(imageType, this->m_hProcess, hThread, &s, &c, myReadProcMem, this->m_sw->pSFTA,
-                         this->m_sw->pSGMB, NULL)) {
-      // INFO: "StackWalk64" does not set "GetLastError"...
-      this->OnDbgHelpErr("StackWalk64", 0, s.AddrPC.Offset);
-      break;
-    }
-
-    csEntry.offset = s.AddrPC.Offset;
-    csEntry.name[0] = 0;
-    csEntry.undName[0] = 0;
-    csEntry.undFullName[0] = 0;
-    csEntry.offsetFromSmybol = 0;
-    csEntry.offsetFromLine = 0;
-    csEntry.lineFileName[0] = 0;
-    csEntry.lineNumber = 0;
-    csEntry.loadedImageName[0] = 0;
-    csEntry.moduleName[0] = 0;
-    if (s.AddrPC.Offset == s.AddrReturn.Offset) {
-      if ((this->m_MaxRecursionCount > 0) && (curRecursionCount > m_MaxRecursionCount)) {
-        this->OnDbgHelpErr("StackWalk64-Endless-Callstack!", 0, s.AddrPC.Offset);
-        break;
-      }
-      curRecursionCount++;
-    } else
-      curRecursionCount = 0;
-    if (s.AddrPC.Offset != 0) {
-      // we seem to have a valid PC
-      // show procedure info (SymGetSymFromAddr64())
-      if (this->m_sw->pSGSFA(this->m_hProcess, s.AddrPC.Offset, &(csEntry.offsetFromSmybol), pSym) != FALSE) {
-        MyStrCpy(csEntry.name, STACKWALK_MAX_NAMELEN, pSym->Name);
-        this->m_sw->pUDSN(pSym->Name, csEntry.undName, STACKWALK_MAX_NAMELEN, UNDNAME_NAME_ONLY);
-        this->m_sw->pUDSN(pSym->Name, csEntry.undFullName, STACKWALK_MAX_NAMELEN, UNDNAME_COMPLETE);
-      } else {
-        this->OnDbgHelpErr("SymGetSymFromAddr64", GetLastError(), s.AddrPC.Offset);
-      }
-
-      // show line number info, NT5.0-method (SymGetLineFromAddr64())
-      if (this->m_sw->pSGLFA != NULL) { // yes, we have SymGetLineFromAddr64()
-        if (this->m_sw->pSGLFA(this->m_hProcess, s.AddrPC.Offset, &(csEntry.offsetFromLine), &Line) != FALSE) {
-          csEntry.lineNumber = Line.LineNumber;
-          MyStrCpy(csEntry.lineFileName, STACKWALK_MAX_NAMELEN, Line.FileName);
-        } else {
-          this->OnDbgHelpErr("SymGetLineFromAddr64", GetLastError(), s.AddrPC.Offset);
-        }
-      } // yes, we have SymGetLineFromAddr64()
-
-      // show module info (SymGetModuleInfo64())
-      if (this->m_sw->GetModuleInfo(this->m_hProcess, s.AddrPC.Offset, &Module) != FALSE) { // got module info OK
-        switch (Module.SymType) {
-        case SymNone:
-          csEntry.symTypeString = "-nosymbols-";
-          break;
-        case SymCoff:
-          csEntry.symTypeString = "COFF";
-          break;
-        case SymCv:
-          csEntry.symTypeString = "CV";
-          break;
-        case SymPdb:
-          csEntry.symTypeString = "PDB";
-          break;
-        case SymExport:
-          csEntry.symTypeString = "-exported-";
-          break;
-        case SymDeferred:
-          csEntry.symTypeString = "-deferred-";
-          break;
-        case SymSym:
-          csEntry.symTypeString = "SYM";
-          break;
-#if API_VERSION_NUMBER >= 9
-        case SymDia:
-          csEntry.symTypeString = "DIA";
-          break;
-#endif
-        case 8: // SymVirtual:
-          csEntry.symTypeString = "Virtual";
-          break;
-        default:
-          //_snprintf( ty, sizeof(ty), "symtype=%ld", (long) Module.SymType );
-          csEntry.symTypeString = nullptr;
-          break;
-        }
-        MyStrCpy(csEntry.moduleName, STACKWALK_MAX_NAMELEN, Module.ModuleName);
-        csEntry.baseOfImage = Module.BaseOfImage;
-        MyStrCpy(csEntry.loadedImageName, STACKWALK_MAX_NAMELEN, Module.LoadedImageName);
-      } // got module info OK
-      else {
-        this->OnDbgHelpErr("SymGetModuleInfo64", GetLastError(), s.AddrPC.Offset);
-      }
-    } // we seem to have a valid PC
-
-    CallstackEntryType et = nextEntry;
-    if (frameNum == 0)
-      et = firstEntry;
-    bLastEntryCalled = false;
-    this->OnCallstackEntry(et, csEntry);
-
-    if (s.AddrReturn.Offset == 0) {
-      bLastEntryCalled = true;
-      this->OnCallstackEntry(lastEntry, csEntry);
-      SetLastError(ERROR_SUCCESS);
-      break;
-    }
-  } // for ( frameNum )
-
-cleanup:
-  if (pSym)
-    free(pSym);
-
-  if (bLastEntryCalled == false)
-    this->OnCallstackEntry(lastEntry, csEntry);
-
-  if (context == NULL)
-    ResumeThread(hThread);
-
-  return TRUE;
-}
-
-BOOL StackWalker::ShowObject(LPVOID pObject) {
-  // Load modules if not done yet
-  if (m_modulesLoaded == FALSE)
-    this->LoadModules(); // ignore the result...
-
-  // Verify that the DebugHelp.dll was actually found
-  if (this->m_sw->m_hDbhHelp == NULL) {
-    SetLastError(ERROR_DLL_INIT_FAILED);
-    return FALSE;
-  }
-
-  // SymGetSymFromAddr64() is required
-  if (this->m_sw->pSGSFA == NULL)
-    return FALSE;
-
-  // Show object info (SymGetSymFromAddr64())
-  DWORD64 dwAddress = DWORD64(pObject);
-  DWORD64 dwDisplacement = 0;
-  IMAGEHLP_SYMBOL64 *pSym =
-      reinterpret_cast<IMAGEHLP_SYMBOL64 *>(malloc(sizeof(IMAGEHLP_SYMBOL64) + STACKWALK_MAX_NAMELEN));
-  memset(pSym, 0, sizeof(IMAGEHLP_SYMBOL64) + STACKWALK_MAX_NAMELEN);
-  pSym->SizeOfStruct = sizeof(IMAGEHLP_SYMBOL64);
-  pSym->MaxNameLength = STACKWALK_MAX_NAMELEN;
-  if (this->m_sw->pSGSFA(this->m_hProcess, dwAddress, &dwDisplacement, pSym) == FALSE) {
-    this->OnDbgHelpErr("SymGetSymFromAddr64", GetLastError(), dwAddress);
-    return FALSE;
-  }
-  // Object name output
-  this->OnOutput(pSym->Name);
-
-  free(pSym);
-  return TRUE;
-};
-
-BOOL __stdcall StackWalker::myReadProcMem(HANDLE hProcess, DWORD64 qwBaseAddress, PVOID lpBuffer, DWORD nSize,
-                                          LPDWORD lpNumberOfBytesRead) {
-  if (s_readMemoryFunction == NULL) {
-    SIZE_T st;
-    BOOL bRet = ReadProcessMemory(hProcess, (LPVOID)qwBaseAddress, lpBuffer, nSize, &st);
-    *lpNumberOfBytesRead = (DWORD)st;
-    // printf("ReadMemory: hProcess: %p, baseAddr: %p, buffer: %p, size: %d, read: %d, result: %d\n", hProcess, (LPVOID)
-    // qwBaseAddress, lpBuffer, nSize, (DWORD) st, (DWORD) bRet);
-    return bRet;
-  } else {
-    return s_readMemoryFunction(hProcess, qwBaseAddress, lpBuffer, nSize, lpNumberOfBytesRead,
-                                s_readMemoryFunction_UserData);
-  }
-}
-
-void StackWalker::OnLoadModule(LPCSTR img, LPCSTR mod, DWORD64 baseAddr, DWORD size, DWORD result, LPCSTR symType,
-                               LPCSTR pdbName, ULONGLONG fileVersion) {
-  CHAR buffer[STACKWALK_MAX_NAMELEN];
-  size_t maxLen = STACKWALK_MAX_NAMELEN;
-#if _MSC_VER >= 1400
-  maxLen = _TRUNCATE;
-#endif
-  if (fileVersion == 0)
-    _snprintf_s(buffer, maxLen, "%s:%s (%p), size: %d (result: %d), SymType: '%s', PDB: '%s'\n", img, mod,
-                (LPVOID)baseAddr, size, result, symType, pdbName);
-  else {
-    DWORD v4 = (DWORD)(fileVersion & 0xFFFF);
-    DWORD v3 = (DWORD)((fileVersion >> 16) & 0xFFFF);
-    DWORD v2 = (DWORD)((fileVersion >> 32) & 0xFFFF);
-    DWORD v1 = (DWORD)((fileVersion >> 48) & 0xFFFF);
-    _snprintf_s(buffer, maxLen,
-                "%s:%s (%p), size: %d (result: %d), SymType: '%s', PDB: '%s', fileVersion: %d.%d.%d.%d\n", img, mod,
-                (LPVOID)baseAddr, size, result, symType, pdbName, v1, v2, v3, v4);
-  }
-  buffer[STACKWALK_MAX_NAMELEN - 1] = 0; // be sure it is NULL terminated
-  OnOutput(buffer);
-}
-
-void StackWalker::OnCallstackEntry(CallstackEntryType eType, CallstackEntry &entry) {
-  CHAR buffer[STACKWALK_MAX_NAMELEN];
-  size_t maxLen = STACKWALK_MAX_NAMELEN;
-#if _MSC_VER >= 1400
-  maxLen = _TRUNCATE;
-#endif
-  if ((eType != lastEntry) && (entry.offset != 0)) {
-    if (entry.name[0] == 0) {
-      MyStrCpy(entry.name, STACKWALK_MAX_NAMELEN, "(function-name not available)");
-    }
-    if (entry.undName[0] != 0) {
-      MyStrCpy(entry.name, STACKWALK_MAX_NAMELEN, entry.undName);
-    }
-    if (entry.undFullName[0] != 0) {
-      MyStrCpy(entry.name, STACKWALK_MAX_NAMELEN, entry.undFullName);
-    }
-    if (entry.lineFileName[0] == 0) {
-      MyStrCpy(entry.lineFileName, STACKWALK_MAX_NAMELEN, "()");
-      if (entry.moduleName[0] == 0)
-        MyStrCpy(entry.moduleName, STACKWALK_MAX_NAMELEN, "(module-name not available)");
-      _snprintf_s(buffer, maxLen, "%-16s %p: %s: %s", entry.moduleName, (LPVOID)entry.offset, entry.lineFileName,
-                  entry.name);
-    } else {
-      _snprintf_s(buffer, maxLen, "%-16s %s:%d: %s", entry.moduleName, entry.lineFileName, entry.lineNumber,
-                  entry.name);
-    }
-    buffer[STACKWALK_MAX_NAMELEN - 1] = 0;
-    OnOutput(buffer);
-    KF_LOG_CRITICAL("{}", buffer);
-  }
-}
-
-void StackWalker::OnDbgHelpErr(LPCSTR szFuncName, DWORD gle, DWORD64 addr) {
-  CHAR buffer[STACKWALK_MAX_NAMELEN];
-  size_t maxLen = STACKWALK_MAX_NAMELEN;
-#if _MSC_VER >= 1400
-  maxLen = _TRUNCATE;
-#endif
-  _snprintf_s(buffer, maxLen, "ERROR: %s, GetLastError: %d (Address: %p)\n", szFuncName, gle, (LPVOID)addr);
-  buffer[STACKWALK_MAX_NAMELEN - 1] = 0;
-  OnOutput(buffer);
-}
-
-void StackWalker::OnSymInit(LPCSTR szSearchPath, DWORD symOptions, LPCSTR szUserName) {
-  CHAR buffer[STACKWALK_MAX_NAMELEN];
-  size_t maxLen = STACKWALK_MAX_NAMELEN;
-#if _MSC_VER >= 1400
-  maxLen = _TRUNCATE;
-#endif
-  _snprintf_s(buffer, maxLen, "SymInit: Symbol-SearchPath: '%s', symOptions: %d, UserName: '%s'\n", szSearchPath,
-              symOptions, szUserName);
-  buffer[STACKWALK_MAX_NAMELEN - 1] = 0;
-  OnOutput(buffer);
-  // Also display the OS-version
-#if _MSC_VER <= 1200
-  OSVERSIONINFOA ver;
-  ZeroMemory(&ver, sizeof(OSVERSIONINFOA));
-  ver.dwOSVersionInfoSize = sizeof(ver);
-  if (GetVersionExA(&ver) != FALSE) {
-    _snprintf_s(buffer, maxLen, "OS-Version: %d.%d.%d (%s)\n", ver.dwMajorVersion, ver.dwMinorVersion,
-                ver.dwBuildNumber, ver.szCSDVersion);
-    buffer[STACKWALK_MAX_NAMELEN - 1] = 0;
-    OnOutput(buffer);
-  }
-#else
-  OSVERSIONINFOEXA ver;
-  ZeroMemory(&ver, sizeof(OSVERSIONINFOEXA));
-  ver.dwOSVersionInfoSize = sizeof(ver);
-#if _MSC_VER >= 1900
-#pragma warning(push)
+#include <psapi.h>
+#include <versionhelpers.h>
+
+#include <cstdint>
+#include <cstring>
+#include <iomanip>
+#include <mutex>
+#include <process.h>
+#include <sstream>
+#include <string>
+
+#pragma comment(lib, "dbghelp.lib")
+#pragma comment(lib, "psapi.lib")
+#pragma comment(lib, "version.lib")
+#pragma comment(lib, "advapi32.lib")
+
+// GetFileVersionInfo / _dupenv_s deprecation noise from strict SDKs.
 #pragma warning(disable : 4996)
-#endif
-  if (GetVersionExA((OSVERSIONINFOA *)&ver) != FALSE) {
-    _snprintf_s(buffer, maxLen, "OS-Version: %d.%d.%d (%s) 0x%x-0x%x\n", ver.dwMajorVersion, ver.dwMinorVersion,
-                ver.dwBuildNumber, ver.szCSDVersion, ver.wSuiteMask, ver.wProductType);
-    buffer[STACKWALK_MAX_NAMELEN - 1] = 0;
-    OnOutput(buffer);
-  }
-#if _MSC_VER >= 1900
-#pragma warning(pop)
-#endif
-#endif
+
+namespace kungfu::yijinjing::util {
+
+namespace {
+
+constexpr int kMaxFrames = 256;
+constexpr int kConsoleEchoFrames = 16;
+
+// DbgHelp is single-threaded; serialize the whole symbol engine so concurrent
+// crash handlers cannot corrupt it.
+std::mutex &dbghelp_mutex() {
+  static std::mutex m;
+  return m;
 }
 
-void StackWalker::OnOutput(LPCSTR buffer) { OutputDebugStringA(buffer); }
+// One-time SymInitialize with fInvadeProcess=TRUE so that module symbols are
+// loaded eagerly (the previous code used FALSE and relied on a manual module
+// load that never registered unwind tables, which broke x64 walking). Must be
+// called while holding dbghelp_mutex().
+bool ensure_sym_initialized() {
+  static bool initialized = false;
+  if (!initialized) {
+    SymSetOptions(SYMOPT_LOAD_LINES | SYMOPT_UNDNAME | SYMOPT_DEFERRED_LOADS | SYMOPT_FAIL_CRITICAL_ERRORS);
+    initialized = SymInitialize(GetCurrentProcess(), nullptr, TRUE) != FALSE;
+  }
+  return initialized;
+}
+
+// Collect up to kMaxFrames return addresses into `frames`.
+//   context == nullptr -> current thread stack via RtlCaptureStackBackTrace
+//                         (architecture-neutral, no register handling).
+//   context != nullptr -> unwind from the given CONTEXT via StackWalk64.
+// Returns the number of frames captured.
+int collect_frames(const CONTEXT *context, void **frames) {
+  if (context == nullptr) {
+    return static_cast<int>(RtlCaptureStackBackTrace(0, kMaxFrames, frames, nullptr));
+  }
+
+  CONTEXT ctx = *context; // StackWalk64 mutates the context; walk a copy.
+  STACKFRAME64 frame;
+  std::memset(&frame, 0, sizeof(frame));
+
+  DWORD machine;
+#if defined(_M_X64)
+  machine = IMAGE_FILE_MACHINE_AMD64;
+  frame.AddrPC.Offset = ctx.Rip;
+  frame.AddrFrame.Offset = ctx.Rbp;
+  frame.AddrStack.Offset = ctx.Rsp;
+#elif defined(_M_ARM64)
+  machine = IMAGE_FILE_MACHINE_ARM64;
+  frame.AddrPC.Offset = ctx.Pc;
+  frame.AddrFrame.Offset = ctx.Fp;
+  frame.AddrStack.Offset = ctx.Sp;
+#else
+  return 0; // unsupported architecture; current Windows targets are x64/arm64.
+#endif
+  frame.AddrPC.Mode = AddrModeFlat;
+  frame.AddrFrame.Mode = AddrModeFlat;
+  frame.AddrStack.Mode = AddrModeFlat;
+
+  HANDLE proc = GetCurrentProcess();
+  HANDLE thread = GetCurrentThread();
+  int count = 0;
+  while (count < kMaxFrames) {
+    if (!StackWalk64(machine, proc, thread, &frame, &ctx, nullptr, SymFunctionTableAccess64, SymGetModuleBase64,
+                     nullptr)) {
+      break;
+    }
+    if (frame.AddrPC.Offset == 0) {
+      break;
+    }
+    frames[count++] = reinterpret_cast<void *>(frame.AddrPC.Offset);
+  }
+  return count;
+}
+
+// Base file name of the module owning `addr`, e.g. "kungfu_node.node".
+std::string module_base_name(DWORD64 addr) {
+  HMODULE mod = nullptr;
+  if (!GetModuleHandleExA(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                          reinterpret_cast<LPCSTR>(addr), &mod) ||
+      mod == nullptr) {
+    return {};
+  }
+  char path[MAX_PATH] = {0};
+  if (GetModuleFileNameA(mod, path, MAX_PATH) == 0) {
+    return {};
+  }
+  const char *base = std::strrchr(path, '\\');
+  return base != nullptr ? std::string(base + 1) : std::string(path);
+}
+
+// Format one frame as "[module+0xrva]  symbol+0xoff  (file:line)".
+// Must be called while holding dbghelp_mutex().
+void format_frame(std::ostream &st, DWORD64 addr) {
+  HANDLE proc = GetCurrentProcess();
+
+  const std::string mod = module_base_name(addr);
+  const DWORD64 mod_base = SymGetModuleBase64(proc, addr);
+  if (!mod.empty()) {
+    st << "[" << mod;
+    if (mod_base != 0) {
+      st << "+0x" << std::hex << (addr - mod_base) << std::dec;
+    }
+    st << "]";
+  } else {
+    st << "0x" << std::hex << std::setw(16) << std::setfill('0') << addr << std::dec << std::setfill(' ');
+  }
+
+  alignas(SYMBOL_INFO) char sym_storage[sizeof(SYMBOL_INFO) + MAX_SYM_NAME] = {0};
+  auto *sym = reinterpret_cast<SYMBOL_INFO *>(sym_storage);
+  sym->SizeOfStruct = sizeof(SYMBOL_INFO);
+  sym->MaxNameLen = MAX_SYM_NAME;
+  DWORD64 sym_disp = 0;
+  if (SymFromAddr(proc, addr, &sym_disp, sym)) {
+    st << "  " << sym->Name << "+0x" << std::hex << sym_disp << std::dec;
+  }
+
+  IMAGEHLP_LINE64 line;
+  std::memset(&line, 0, sizeof(line));
+  line.SizeOfStruct = sizeof(line);
+  DWORD line_disp = 0;
+  if (SymGetLineFromAddr64(proc, addr, &line_disp, &line) && line.FileName != nullptr) {
+    const char *file = std::strrchr(line.FileName, '\\');
+    st << "  (" << (file != nullptr ? file + 1 : line.FileName) << ":" << line.LineNumber << ")";
+  }
+}
+
+} // namespace
+
+void StackWalker::print_native_stack(std::ostream &st, const void *context) {
+  st << std::endl;
+  st << "-------------------------Native Stack--------------------------" << std::endl;
+
+  void *frames[kMaxFrames];
+  std::lock_guard<std::mutex> guard(dbghelp_mutex());
+  ensure_sym_initialized();
+
+  const int n = collect_frames(static_cast<const CONTEXT *>(context), frames);
+  if (n == 0) {
+    st << "  <no frames captured>" << std::endl;
+    return;
+  }
+
+  for (int i = 0; i < n; ++i) {
+    std::ostringstream frame;
+    format_frame(frame, reinterpret_cast<DWORD64>(frames[i]));
+    const std::string text = frame.str();
+    st << text << std::endl;
+    if (i < kConsoleEchoFrames) {
+      KF_LOG_CRITICAL("{}", text);
+    }
+  }
+  st << std::endl;
+}
+
+void StackWalker::show_callstack(std::ostream &os, const void *context) {
+  print_windows_version(os);
+  print_cpu_info(os);
+  print_environment_variables(os);
+  print_loaded_modules(os);
+  print_stack_bound(os);
+  print_native_stack(os, context);
+}
 
 void StackWalker::print_windows_version(std::ostream &st) {
-
   st << std::endl;
   st << "--------------------------Windows version-----------------------------" << std::endl;
-  VS_FIXEDFILEINFO *file_info;
+
+  const bool is_workstation = !IsWindowsServer();
+
+  // Version comes from \Windows\System32\kernel32.dll's file version resource.
   TCHAR kernel32_path[MAX_PATH];
-  UINT len, ret;
-
-  bool is_workstation = !IsWindowsServer();
-
-  // Get the full path to \Windows\System32\kernel32.dll and use that for
-  // determining what version of Windows we're running on.
-  len = MAX_PATH - (UINT)strlen("\\kernel32.dll") - 1;
-  ret = GetSystemDirectory(kernel32_path, len);
+  UINT len = MAX_PATH - static_cast<UINT>(lstrlen(TEXT("\\kernel32.dll"))) - 1;
+  UINT ret = GetSystemDirectory(kernel32_path, len);
   if (ret == 0 || ret > len) {
-    st << "Call to GetSystemDirectory failed\n";
+    st << "GetSystemDirectory failed" << std::endl;
     return;
   }
+  lstrcat(kernel32_path, TEXT("\\kernel32.dll"));
 
-  // TCHAR --> char* 需要unicode字符集换成多字节字符集
-  // strncat(c_kernel32_path, "\\kernel32.dll", MAX_PATH - ret);
-
-  // 改用windows库函数
-  lstrcat(kernel32_path, _T("\\kernel32.dll"));
-
-  DWORD version_size = GetFileVersionInfoSize(kernel32_path, NULL);
+  DWORD version_size = GetFileVersionInfoSize(kernel32_path, nullptr);
   if (version_size == 0) {
-    st << "Call to GetFileVersionInfoSize failed\n";
+    st << "GetFileVersionInfoSize failed" << std::endl;
     return;
   }
-  // 与java原来相比，简化了申请内存方式，合理性存疑。。。
-  LPTSTR version_info = (LPTSTR)malloc(version_size * sizeof(DWORD));
-  if (version_info == NULL) {
-    st << "Failed to allocate version_info";
+  std::string version_info(version_size, '\0');
+  if (!GetFileVersionInfo(kernel32_path, 0, version_size, version_info.data())) {
+    st << "GetFileVersionInfo failed" << std::endl;
     return;
   }
-  //
-  if (!GetFileVersionInfo(kernel32_path, NULL, version_size, version_info)) {
-    free(version_info);
-    st << "Call to GetFileVersionInfo failed\n";
-    return;
-  }
-
-  if (!VerQueryValue(version_info, TEXT("\\"), (LPVOID *)&file_info, &len)) {
-    free(version_info);
-    st << "Call to VerQueryValue failed" << std::endl;
+  VS_FIXEDFILEINFO *file_info = nullptr;
+  UINT file_info_len = 0;
+  if (!VerQueryValue(version_info.data(), TEXT("\\"), reinterpret_cast<LPVOID *>(&file_info), &file_info_len)) {
+    st << "VerQueryValue failed" << std::endl;
     return;
   }
 
-  int major_version = HIWORD(file_info->dwProductVersionMS);
-  int minor_version = LOWORD(file_info->dwProductVersionMS);
-  int build_number = HIWORD(file_info->dwProductVersionLS);
-  int build_minor = LOWORD(file_info->dwProductVersionLS);
-  int os_vers = major_version * 1000 + minor_version;
-  free(version_info);
+  const int major_version = HIWORD(file_info->dwProductVersionMS);
+  const int minor_version = LOWORD(file_info->dwProductVersionMS);
+  const int build_number = HIWORD(file_info->dwProductVersionLS);
+  const int build_minor = LOWORD(file_info->dwProductVersionLS);
+  const int os_vers = major_version * 1000 + minor_version;
 
   st << " Windows ";
   switch (os_vers) {
   case 6000:
-    if (is_workstation) {
-      st << "Vista";
-    } else {
-      st << "Server 2008";
-    }
+    st << (is_workstation ? "Vista" : "Server 2008");
     break;
-
   case 6001:
-    if (is_workstation) {
-      st << "7";
-    } else {
-      st << "Server 2008 R2";
-    }
+    st << (is_workstation ? "7" : "Server 2008 R2");
     break;
-
   case 6002:
-    if (is_workstation) {
-      st << "8";
-    } else {
-      st << "Server 2012";
-    }
+    st << (is_workstation ? "8" : "Server 2012");
     break;
-
   case 6003:
-    if (is_workstation) {
-      st << "8.1";
-    } else {
-      st << "Server 2012 R2";
-    }
+    st << (is_workstation ? "8.1" : "Server 2012 R2");
     break;
-
   case 10000:
     if (is_workstation) {
-      if (build_number >= 22000) {
-        st << "11";
-      } else {
-        st << "10";
-      }
+      st << (build_number >= 22000 ? "11" : "10");
+    } else if (build_number > 20347) {
+      st << "Server 2022";
+    } else if (build_number > 17762) {
+      st << "Server 2019";
     } else {
-      // distinguish Windows Server by build number
-      // - 2016 GA 10/2016 build: 14393
-      // - 2019 GA 11/2018 build: 17763
-      // - 2022 GA 08/2021 build: 20348
-      if (build_number > 20347) {
-        st << "Server 2022";
-      } else if (build_number > 17762) {
-        st << "Server 2019";
-      } else {
-        st << "Server 2016";
-      }
+      st << "Server 2016";
     }
     break;
   default:
-    // Unrecognized windows, print out its major and minor versions
     st << major_version << "." << minor_version;
     break;
   }
-  // Retrieve SYSTEM_INFO from GetNativeSystemInfo call so that we could
-  // find out whether we are running on 64 bit processor or not
+
   SYSTEM_INFO si;
-  ZeroMemory(&si, sizeof(SYSTEM_INFO));
+  ZeroMemory(&si, sizeof(si));
   GetNativeSystemInfo(&si);
-  if ((si.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_AMD64) ||
-      (si.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_ARM64)) {
+  if (si.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_AMD64 ||
+      si.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_ARM64) {
     st << " , 64 bit";
   }
   st << " Build " << build_number;
   st << " (" << major_version << "." << minor_version << "." << build_number << "." << build_minor << ")";
-
   st << std::endl;
 }
 
-void StackWalker::get_sys_info(std::ostream &st) {
+void StackWalker::print_cpu_info(std::ostream &st) {
   st << std::endl;
-  st << "--------------------------CPU Info-------------------------------------\n";
-  SYSTEM_INFO sysInfo; // 该结构体包含了当前计算机的信息：os体系结构、cpu的类型、cpu的数量、页面的大小以及其他信息。
-  GetSystemInfo(&sysInfo);
-  if (sysInfo.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_AMD64) {
-    st << "System Architecture: X64(AMD or Intel)" << std::endl;
-  } else if (sysInfo.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_ARM) {
+  st << "--------------------------CPU Info-------------------------------------" << std::endl;
+  SYSTEM_INFO sys_info;
+  GetSystemInfo(&sys_info);
+  switch (sys_info.wProcessorArchitecture) {
+  case PROCESSOR_ARCHITECTURE_AMD64:
+    st << "System Architecture: X64 (AMD or Intel)" << std::endl;
+    break;
+  case PROCESSOR_ARCHITECTURE_ARM64:
+    st << "System Architecture: ARM64" << std::endl;
+    break;
+  case PROCESSOR_ARCHITECTURE_ARM:
     st << "System Architecture: ARM" << std::endl;
-  } else if (sysInfo.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_IA64) {
-    st << "System Architecture: Intel Itanium-based " << std::endl;
-  } else if (sysInfo.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_INTEL) {
-    st << "System Architecture: X86\n" << std::endl;
-  } else {
-    st << "System Architecture: Unknown architecture.\n" << std::endl;
-  }
-
-  st << "CPU level :  " << sysInfo.wProcessorLevel << std::endl;
-  st << "CPU revision :  " << std::hex << sysInfo.wProcessorRevision << std::dec << std::endl;
-  st << "type of processor :  ";
-  switch (sysInfo.dwProcessorType) {
-  case 386:
-    st << "intel 386\n";
     break;
-  case 486:
-    st << "intel 486\n";
-    break;
-  case 586:
-    st << "intel Pentium\n";
-    break;
-  case 2200:
-    st << "intel IA64\n";
-    break;
-  case 8664:
-    st << "AMD X8664\n";
+  case PROCESSOR_ARCHITECTURE_INTEL:
+    st << "System Architecture: X86" << std::endl;
     break;
   default:
-    st << "Unknown processor\n";
+    st << "System Architecture: Unknown" << std::endl;
     break;
   }
-  st << "page size :  " << sysInfo.dwPageSize << std::endl;
-  st << "number of logical processors in the current group : " << sysInfo.dwNumberOfProcessors << std::endl;
-  st << "the lowest memory address accessible to applications and DLLs :  " << sysInfo.lpMinimumApplicationAddress
-     << std::endl;
-  st << "the highest memory accessible to applications and DLLs :  " << sysInfo.lpMaximumApplicationAddress
-     << std::endl;
-  st << "The granularity for the starting address :  " << sysInfo.dwAllocationGranularity << std::endl;
+  st << "CPU level :  " << sys_info.wProcessorLevel << std::endl;
+  st << "CPU revision :  " << std::hex << sys_info.wProcessorRevision << std::dec << std::endl;
+  st << "page size :  " << sys_info.dwPageSize << std::endl;
+  st << "number of logical processors :  " << sys_info.dwNumberOfProcessors << std::endl;
+  st << "lowest application address :  " << sys_info.lpMinimumApplicationAddress << std::endl;
+  st << "highest application address :  " << sys_info.lpMaximumApplicationAddress << std::endl;
+  st << "allocation granularity :  " << sys_info.dwAllocationGranularity << std::endl;
 }
 
 void StackWalker::print_environment_variables(std::ostream &st) {
   st << std::endl;
   st << "-------------------------environment variables--------------------------" << std::endl;
-  // List of environment variables that should be reported in error log file.
-  const char *env_list[] = {//// All platforms
-                            "JAVA_HOME", "JAVA_TOOL_OPTIONS", "_JAVA_OPTIONS", "CLASSPATH", "PATH", "USERNAME",
-
-                            //// Env variables that are defined on Linux/BSD
-                            "LD_LIBRARY_PATH", "LD_PRELOAD", "SHELL", "DISPLAY", "HOSTTYPE", "OSTYPE", "ARCH",
-                            "MACHTYPE", "LANG", "LC_ALL", "LC_CTYPE", "LC_NUMERIC", "LC_TIME", "TERM", "TMPDIR", "TZ",
-
-                            //// defined on AIX
-                            "LIBPATH", "LDR_PRELOAD", "LDR_PRELOAD64",
-
-                            // defined on Linux/AIX/BSD
-                            "_JAVA_SR_SIGNUM",
-
-                            //// defined on Darwin
-                            "DYLD_LIBRARY_PATH", "DYLD_FALLBACK_LIBRARY_PATH", "DYLD_FRAMEWORK_PATH",
-                            "DYLD_FALLBACK_FRAMEWORK_PATH", "DYLD_INSERT_LIBRARIES",
-
-                            // defined on Windows
-                            "OS", "PROCESSOR_IDENTIFIER", "_ALT_JAVA_HOME_DIR", "TMP", "TEMP", (const char *)0};
-  if (env_list) {
-    st << "Environment Variables:" << std::endl;
-
-    for (int i = 0; env_list[i] != NULL; i++) {
-      // char* envvar = ::getenv(env_list[i]);
-      // 将getenv替换成_dupenv_s函数
-      char *envvar = nullptr;
-      size_t sz = 0;
-      if (_dupenv_s(&envvar, &sz, env_list[i]) == 0 && envvar != NULL) {
-        st << env_list[i] << "=" << envvar;
-        // Use separate cr() printing to avoid unnecessary buffer operations that might cause truncation.
-        st << std::endl;
-      }
+  static const char *const env_list[] = {"PATH",  "USERNAME", "OS",   "PROCESSOR_IDENTIFIER",
+                                         "SHELL", "TMP",      "TEMP", nullptr};
+  for (int i = 0; env_list[i] != nullptr; ++i) {
+    char *value = nullptr;
+    size_t sz = 0;
+    if (_dupenv_s(&value, &sz, env_list[i]) == 0 && value != nullptr) {
+      st << env_list[i] << "=" << value << std::endl;
+      free(value);
     }
   }
 }
 
-int StackWalker::get_loaded_modules_info(LoadedModulesCallbackFunc callback, void *param) {
-  HANDLE hProcess;
-
-#define MAX_NUM_MODULES 128
-  HMODULE modules[MAX_NUM_MODULES];
-  static char filename[MAX_PATH];
-  int result = 0;
-  int pid = _getpid(); // 修改 ----得到当前进程ID
-  hProcess = OpenProcess(PROCESS_QUERY_INFORMATION | PROCESS_VM_READ, FALSE, pid);
-  if (hProcess == NULL)
-    return 0;
-
-  DWORD size_needed;
-  if (!EnumProcessModules(hProcess, modules, sizeof(modules), &size_needed)) {
-    CloseHandle(hProcess);
-    return 0;
+void StackWalker::print_loaded_modules(std::ostream &st) {
+  st << std::endl;
+  st << "--------------------------Dynamic libraries-----------------------------" << std::endl;
+  HANDLE proc = GetCurrentProcess();
+  HMODULE modules[256];
+  DWORD needed = 0;
+  if (!EnumProcessModules(proc, modules, sizeof(modules), &needed)) {
+    st << "  <EnumProcessModules failed>" << std::endl;
+    return;
   }
-
-  // number of modules that are currently loaded
-  int num_modules = size_needed / sizeof(HMODULE);
-
-  for (int i = 0; i < min(num_modules, MAX_NUM_MODULES); i++) {
-    // Get Full pathname:
-
-    if (!GetModuleFileNameExA(hProcess, modules[i], filename, sizeof(filename))) {
-      filename[0] = '\0';
-    }
-
-    MODULEINFO modinfo;
-    if (!GetModuleInformation(hProcess, modules[i], &modinfo, sizeof(modinfo))) {
-      modinfo.lpBaseOfDll = nullptr;
-      modinfo.SizeOfImage = 0;
-    }
-
-    // Invoke callback function
-    result = callback(filename, (address)modinfo.lpBaseOfDll,
-                      (address)((uint64_t)modinfo.lpBaseOfDll + (uint64_t)modinfo.SizeOfImage), param);
-    if (result)
-      break;
+  int count = static_cast<int>(needed / sizeof(HMODULE));
+  if (count > 256) {
+    count = 256;
   }
-
-  CloseHandle(hProcess);
-  return result;
-}
-
-int StackWalker::print_module(const char *fname, address base_address, address top_address, void *param) {
-  // #define PTR_FORMAT "0x%08" PRIxPTR
-  if (!param)
-    return -1;
-  std::ostream *st = (std::ostream *)param;
-
-  //(*st)<<fmt::format("{0x%08}-{0x%08} \t{%s}",base_address,top_address,fname)<<std::endl;
-
-  (*st) << "0x" << std::hex << std::setw(8) << std::setfill('0') << (intptr_t)base_address << " - " // setw只生效一次
-        << "0x" << std::setw(8) << (intptr_t)top_address << "  \t" << fname << std::hex << std::endl;
-
-  // printf(PTR_FORMAT " - " PTR_FORMAT " \t%s\n", base_address, top_address, fname);
-  return 0;
-};
-
-void StackWalker::print_dll_info(std::ostream *st) {
-  (*st) << std::endl;
-  (*st) << "--------------------------Dynamic libraries-----------------------------" << std::endl;
-  get_loaded_modules_info(StackWalker::print_module, (void *)st);
-}
-
-u_char *StackWalker::current_stack_base() {
-  MEMORY_BASIC_INFORMATION minfo;
-  address stack_bottom;
-  size_t stack_size;
-
-  VirtualQuery(&minfo, &minfo, sizeof(minfo));
-  stack_bottom = (address)minfo.AllocationBase;
-  stack_size = minfo.RegionSize;
-
-  // Add up the sizes of all the regions with the same
-  // AllocationBase.
-  while (1) {
-    VirtualQuery(stack_bottom + stack_size, &minfo, sizeof(minfo));
-    if (stack_bottom == (address)minfo.AllocationBase) {
-      stack_size += minfo.RegionSize;
-    } else {
-      break;
+  for (int i = 0; i < count; ++i) {
+    MODULEINFO mi;
+    char path[MAX_PATH] = {0};
+    if (GetModuleInformation(proc, modules[i], &mi, sizeof(mi)) &&
+        GetModuleFileNameExA(proc, modules[i], path, MAX_PATH) != 0) {
+      const auto base = reinterpret_cast<DWORD64>(mi.lpBaseOfDll);
+      st << "0x" << std::hex << base << " - 0x" << (base + mi.SizeOfImage) << std::dec << "  \t" << path << std::endl;
     }
   }
-  return stack_bottom + stack_size;
 }
 
-// 返回当前栈的大小
-size_t StackWalker::current_stack_size() {
-  size_t sz;
-  MEMORY_BASIC_INFORMATION minfo;
-  VirtualQuery(&minfo, &minfo, sizeof(minfo));
-  sz = (size_t)current_stack_base() - (size_t)minfo.AllocationBase;
-  return sz;
-}
-
-// 打印堆栈边界
 void StackWalker::print_stack_bound(std::ostream &st) {
-  st << "\n\n";
-  st << "stack:   ";
-  address stack_top = current_stack_base();
-  size_t stack_size = current_stack_size();
-  address stack_bottom = stack_top - stack_size;
+  st << "\n\n"
+     << "stack:   ";
+  MEMORY_BASIC_INFORMATION minfo;
+  VirtualQuery(&minfo, &minfo, sizeof(minfo));
+  auto *const alloc_base = static_cast<uint8_t *>(minfo.AllocationBase);
 
-  st << "0x" << std::hex << std::setw(8) << (intptr_t)stack_bottom << " - 0x" // setw只生效一次
-     << std::setw(8) << (intptr_t)stack_top << std::dec << "\n\n";
+  // Sum contiguous regions sharing the same AllocationBase to find the top.
+  uint8_t *cursor = alloc_base;
+  SIZE_T total = 0;
+  while (VirtualQuery(cursor, &minfo, sizeof(minfo)) == sizeof(minfo) &&
+         static_cast<uint8_t *>(minfo.AllocationBase) == alloc_base) {
+    total += minfo.RegionSize;
+    cursor += minfo.RegionSize;
+  }
+  uint8_t *const top = alloc_base + total;
 
-  // st<<fmt::format("[{PTR_FORMAT},{PTR_FORMAT}]",(intptr_t)(stack_bottom),(intptr_t)(stack_top))<<std::endl;
-
-  // printf("[" PTR_FORMAT "," PTR_FORMAT "]", (intptr_t)(stack_bottom), (intptr_t)(stack_top));
-  st << std::endl;
+  st << "0x" << std::hex << reinterpret_cast<uintptr_t>(alloc_base) << " - 0x" << reinterpret_cast<uintptr_t>(top)
+     << std::dec << "\n"
+     << std::endl;
 }
 
-int StackWalker::_locate_module_by_addr(const char *mod_fname, address base_addr, address top_address, void *param) {
-  struct _modinfo *pmod = (struct _modinfo *)param;
-  if (!pmod)
-    return -1;
+} // namespace kungfu::yijinjing::util
 
-  if (base_addr <= pmod->addr && top_address > pmod->addr) {
-    // if a buffer is provided, copy path name to the buffer
-    if (pmod->full_path) {
-      snprintf(pmod->full_path, pmod->buflen, "%s", mod_fname);
-    }
-    pmod->base_addr = base_addr;
-    return 1;
-  }
-  return 0;
-}
-
-bool StackWalker::dll_address_to_library_name(address addr, char *buf, int buflen, int *offset) {
-  // NOTE: the reason we don't use SymGetModuleInfo() is it doesn't always
-  //       return the full path to the DLL file, sometimes it returns path
-  //       to the corresponding PDB file (debug info); sometimes it only
-  //       returns partial path, which makes life painful.
-
-  struct _modinfo mi;
-  mi.addr = addr;
-  mi.full_path = buf;
-  mi.buflen = buflen;
-  if (get_loaded_modules_info(StackWalker::_locate_module_by_addr, (void *)&mi)) {
-    // buf already contains path name
-    if (offset)
-      *offset = addr - mi.base_addr;
-    return true;
-  }
-
-  buf[0] = '\0';
-  if (offset)
-    *offset = -1;
-  return false;
-}
-
-bool StackWalker::dll_address_to_function_name(address addr, char *buf, int buflen, int *offset, bool demangle) {
-
-  if (decode(addr, buf, buflen, offset, demangle)) // decode
-  {
-    return true;
-  }
-  if (offset != NULL)
-    *offset = -1;
-  buf[0] = '\0';
-  return false;
-}
-
-bool StackWalker::decode(const void *addr, char *buf, int buflen, int *offset, bool do_demangle) {
-  buf[0] = '\0';
-  *offset = -1;
-
-  if (addr == NULL) {
-    return false;
-  }
-
-  // Try decoding the symbol once. If we fail, attempt to rebuild the
-  // symbol search path - maybe the pc points to a dll whose pdb file is
-  // outside our search path. Then do attempt the decode again.
-  bool success = decode_locked(addr, buf, buflen, offset, do_demangle);
-
-  return success;
-}
-
-bool StackWalker::decode_locked(const void *addr, char *buf, int buflen, int *offset, bool do_demangle) {
-
-  DWORD64 displacement;
-  PIMAGEHLP_SYMBOL64 pSymbol = nullptr;
-  bool success = false;
-
-  pSymbol = (IMAGEHLP_SYMBOL64 *)malloc(sizeof(IMAGEHLP_SYMBOL64) + STACKWALK_MAX_NAMELEN);
-  if (!pSymbol) {
-    KF_LOG_CRITICAL("not enough memory....");
-    return false;
-  }
-  ::memset(pSymbol, 0, sizeof(IMAGEHLP_SYMBOL64) + STACKWALK_MAX_NAMELEN);
-  pSymbol->SizeOfStruct = sizeof(IMAGEHLP_SYMBOL64);
-  pSymbol->MaxNameLength = STACKWALK_MAX_NAMELEN;
-
-  // It is unclear how SymGetSymFromAddr64 handles truncation. Experiments
-  // show it will return TRUE but not zero terminate (which is a really bad
-  // combination). Lets be super careful.
-  ::memset(pSymbol->Name, 0, pSymbol->MaxNameLength); // To catch truncation.
-
-  success = this->m_sw->pSGSFA(::GetCurrentProcess(), (DWORD64)addr, &displacement, pSymbol);
-  if (success) {
-    // success = true;
-    if (pSymbol->Name[pSymbol->MaxNameLength - 1] != '\0') {
-      // Symbol was truncated. Do not attempt to demangle. Instead, zero terminate the
-      // truncated string. We still return success - the truncated string may still
-      // be usable for the caller.
-      pSymbol->Name[pSymbol->MaxNameLength - 1] = '\0';
-      do_demangle = false;
-    }
-
-    // Attempt to demangle.
-    if (do_demangle && this->m_sw->pUDSN(pSymbol->Name, buf, buflen, UNDNAME_COMPLETE)) {
-      // ok.
-    } else {
-      strncpy_s(buf, buflen - 1, pSymbol->Name, buflen - 1);
-    }
-    buf[buflen - 1] = '\0';
-    *offset = (int)displacement;
-  }
-#if 0
-    if (success == false) {
-        DWORD error_code = GetLastError();
-        std::cout << "\tsymGetSymFromAddr64 returned error,error code: " << error_code << std::endl;
-    }
-#endif
-
-  free(pSymbol);
-
-  // DEBUG_ONLY(g_buffers.decode_buffer.check();)
-
-  return success;
-}
-
-void StackWalker::print_C_frame(std::ostream &st, char *buf, int buflen, address pc) {
-
-  int offset;
-  bool found;
-
-  if (buf == NULL || buflen < 1)
-    return;
-  // libname
-  buf[0] = '\0';
-  buffer_console[0] = '\0';
-  found = dll_address_to_library_name(pc, buf, buflen, &offset);
-  if (found && buf[0] != '\0') {
-    // skip directory names
-    const char *p1, *p2;
-    p1 = buf;
-    int len = (int)strlen(file_separator());
-    while ((p2 = strstr(p1, file_separator())) != NULL)
-      p1 = p2 + len;
-    st << "[" << p1 << "+0x" << std::hex << offset << "]" << std::dec;
-
-    if (console_count >= 0) {
-      // printf("[%s+0x%x]", p1, offset);
-      snprintf(buffer_console, STACKWALK_MAX_NAMELEN, "[%s+0x%x]", p1, offset);
-      // MyStrCpy(buffer_console, STACKWALK_MAX_NAMELEN, p1);
-    }
-  } else {
-    st << std::hex << std::setw(8) << (intptr_t)(pc) // setw只生效一次
-       << std::dec;
-
-    if (console_count >= 0) {
-      snprintf(buffer_console + strlen(buffer_console), STACKWALK_MAX_NAMELEN, "  0x%08llx", (intptr_t)(pc));
-      // printf("  0x%08llx", (intptr_t)(pc));
-    }
-  }
-
-  found = dll_address_to_function_name(pc, buf, buflen, &offset, /*默认参数true*/ true);
-  if (found) {
-    st << "  " << buf << "+0x" << std::hex << offset << std::dec;
-    if (console_count) {
-      snprintf(buffer_console + strlen(buffer_console), STACKWALK_MAX_NAMELEN, "  %s+0x%x", buf, offset);
-      // printf("  %s+0x%x", buf, offset);
-    }
-  }
-}
-
-bool StackWalker::get_source_info(const void *addr, char *buf, size_t buflen, int *line_no) {
-  buf[0] = '\0';
-  *line_no = -1;
-
-  if (addr == NULL) {
-    return false;
-  }
-
-  IMAGEHLP_LINE64 lineinfo;
-  memset(&lineinfo, 0, sizeof(lineinfo));
-  lineinfo.SizeOfStruct = sizeof(lineinfo);
-  DWORD displacement;
-  if (this->m_sw->pSGLFA(::GetCurrentProcess(), (DWORD64)addr, &displacement, &lineinfo)) {
-    if (buf != NULL && buflen > 0 && lineinfo.FileName != NULL) {
-      // We only return the file name, not the whole path.
-      char *p = lineinfo.FileName;
-      char *q = strrchr(lineinfo.FileName, '\\');
-      if (q) {
-        p = q + 1;
-      }
-      strncpy_s(buf, buflen - 1, p, buflen - 1);
-      buf[buflen - 1] = '\0';
-    }
-    if (line_no != 0) {
-      *line_no = lineinfo.LineNumber;
-    }
-    return true;
-  }
-#if 0
-    else{
-      DWORD error_code = GetLastError();
-      KF_LOG_CRITICAL("\tsymGetLineFromAddr64 returned error, error code: {:d}", error_code);
-    }
-#endif
-  return false;
-}
-
-bool StackWalker::_print_native_stack(std::ostream &st, const void *context, char *buf, int buf_size) {
-
-  CONTEXT ctx;
-  if (context != nullptr) {
-    memcpy(&ctx, context, sizeof(ctx));
-  } else {
-    memset(&ctx, 0, sizeof(CONTEXT));
-    ctx.ContextFlags = USED_CONTEXT_FLAGS;
-    RtlCaptureContext(&ctx);
-  }
-
-  st << "-------------------------Native Stack--------------------------" << std::endl;
-
-  STACKFRAME stk;
-  memset(&stk, 0, sizeof(stk));
-  stk.AddrStack.Offset = ctx.Rsp;
-  stk.AddrStack.Mode = AddrModeFlat;
-  stk.AddrFrame.Offset = ctx.Rbp;
-  stk.AddrFrame.Mode = AddrModeFlat;
-  stk.AddrPC.Offset = ctx.Rip;
-  stk.AddrPC.Mode = AddrModeFlat;
-
-  int count = 0;
-  address lastpc = 0;
-
-  intptr_t StackPrintLimit = 128; // 手动定义
-
-  while (count++ < StackPrintLimit) {
-    intptr_t *sp = (intptr_t *)stk.AddrStack.Offset;
-    intptr_t *fp = (intptr_t *)stk.AddrFrame.Offset; // NOT necessarily the same as ctx.Rbp!
-    address pc = (address)stk.AddrPC.Offset;
-
-    if (pc != NULL) {
-      if (count == 2 && lastpc == pc) {
-        // Skip it -- StackWalk64() may return the same PC
-        // (but different SP) on the first try.
-      } else {
-        // Don't try to create a frame(sp, fp, pc) -- on WinX64, stk.AddrFrame
-        // may not contain what Java expects, and may cause the frame() constructor
-        // to crash. Let's just print out the symbolic address.
-        print_C_frame(st, buf, buf_size, pc);
-        // print source file and line, if available
-        char buf[128];
-        int line_no;
-        if (get_source_info(pc, buf, sizeof(buf), &line_no)) {
-          st << "  (" << buf << ":" << line_no << ")";
-          if (console_count >= 0) {
-            snprintf(buffer_console, STACKWALK_MAX_NAMELEN, "  (%s:%d)", buf, line_no);
-          }
-        }
-        if (console_count > 0) {
-          KF_LOG_CRITICAL("{}", buffer_console);
-          console_count--;
-        }
-        st << std::endl;
-      }
-      lastpc = pc;
-    }
-#if 0 
-      PVOID p = this->m_sw->pSFTA(GetCurrentProcess(), stk.AddrPC.Offset);
-      if (!p) {
-          // StackWalk64() can't handle this PC. Calling StackWalk64 again may cause crash.
-          DWORD error_code = GetLastError();
-          st<<"SymFunctionTableAccess64 returned error, error code: "<<error_code<<"\n";
-          //break;
-      }
-#endif
-
-    BOOL result = this->m_sw->pSW(IMAGE_FILE_MACHINE_AMD64, // __in      DWORD MachineType,
-                                  GetCurrentProcess(),      // __in      HANDLE hProcess,
-                                  GetCurrentThread(),       // __in      HANDLE hThread,
-                                  &stk,                     // __inout   LP STACKFRAME64 StackFrame,
-                                  &ctx,                     // __inout   PVOID ContextRecord,
-                                  nullptr,                  // ReadMemoryRoutine
-                                  this->m_sw->pSFTA,        // FunctionTableAccessRoutine,
-                                  this->m_sw->pSGMB,        // GetModuleBaseRoutine
-                                  nullptr                   // TranslateAddressRoutine
-    );
-
-    if (!result) {
-      break;
-    }
-  }
-  if (count > StackPrintLimit) {
-    st << "...<more frames>..." << std::endl;
-  }
-  st << std::endl;
-
-  return true;
-}
-
-void StackWalker::show_callstack(std::ostream &os, const void *context) {
-
-  if (m_modulesLoaded == FALSE)
-    this->LoadModules(); // ignore the result...
-
-  if (this->m_sw->m_hDbhHelp == NULL) {
-    SetLastError(ERROR_DLL_INIT_FAILED);
-    return;
-  }
-  // Windows version info
-  print_windows_version(os);
-
-  // CPU info
-  get_sys_info(os);
-
-  // environment variables info
-  print_environment_variables(os);
-
-  // Dynamic link library info
-  print_dll_info(&os);
-
-  // stack bound
-  print_stack_bound(os);
-
-  // stack info  ---------- _print_native_stack()可以用ShowCallstack()替换，输出stack信息没有区别（格式不同）
-  static char buf[2048];
-  _print_native_stack(os, context, buf, sizeof(buf));
-}
-
-#endif
+#endif // defined(_MSC_VER)

--- a/framework/core/src/libyijinjing/src/util/StackWalker.h
+++ b/framework/core/src/libyijinjing/src/util/StackWalker.h
@@ -1,255 +1,48 @@
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef __STACKWALKER_H__
-#define __STACKWALKER_H__
+//
+// Windows crash-report stack walker for yijinjing.
+//
+// This is a lean, architecture-neutral replacement for the previously vendored
+// StackWalker library (BSD, Jochen Kalmbach). Only the single entry point used
+// by the rest of the codebase -- show_callstack() -- is exposed; symbol lookup
+// and stack unwinding are delegated to the modern DbgHelp / RtlCaptureStackBackTrace
+// APIs rather than a hand-rolled frame walk.
+//
+
+#ifndef KUNGFU_UTIL_STACKWALKER_H
+#define KUNGFU_UTIL_STACKWALKER_H
 
 #if defined(_MSC_VER)
 
-/**********************************************************************
- *
- * StackWalker.h
- *
- *
- *
- * LICENSE (http://www.opensource.org/licenses/bsd-license.php)
- *
- *   Copyright (c) 2005-2009, Jochen Kalmbach
- *   All rights reserved.
- *
- *   Redistribution and use in source and binary forms, with or without modification,
- *   are permitted provided that the following conditions are met:
- *
- *   Redistributions of source code must retain the above copyright notice,
- *   this list of conditions and the following disclaimer.
- *   Redistributions in binary form must reproduce the above copyright notice,
- *   this list of conditions and the following disclaimer in the documentation
- *   and/or other materials provided with the distribution.
- *   Neither the name of Jochen Kalmbach nor the names of its contributors may be
- *   used to endorse or promote products derived from this software without
- *   specific prior written permission.
- *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- *   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
- *   THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- *   ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
- *   FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- *   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- *   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- *   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- *   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- *   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- *
- * **********************************************************************/
-// #pragma once is supported starting with _MSC_VER 1000,
-// so we need not to check the version (because we only support _MSC_VER >= 1100)!
-#pragma once
+#include <ostream>
 
-#include <iostream>
-#include <windows.h>
+namespace kungfu::yijinjing::util {
 
-#if _MSC_VER >= 1900
-#pragma warning(disable : 4091)
-#endif
-
-// special defines for VC5/6 (if no actual PSDK is installed):
-#if _MSC_VER < 1300
-typedef unsigned __int64 DWORD64, *PDWORD64;
-#if defined(_WIN64)
-typedef unsigned __int64 SIZE_T, *PSIZE_T;
-#else
-typedef unsigned long SIZE_T, *PSIZE_T;
-#endif
-#endif // _MSC_VER < 1300
-
-typedef unsigned char *address;
-
-class StackWalkerInternal; // forward
 class StackWalker {
 public:
-  typedef enum StackWalkOptions {
-    // No addition info will be retrieved
-    // (only the address is available)
-    RetrieveNone = 0,
+  StackWalker() = default;
 
-    // Try to get the symbol-name
-    RetrieveSymbol = 1,
-
-    // Try to get the line for this symbol
-    RetrieveLine = 2,
-
-    // Try to retrieve the module-infos
-    RetrieveModuleInfo = 4,
-
-    // Also retrieve the version for the DLL/EXE
-    RetrieveFileVersion = 8,
-
-    // Contains all the above
-    RetrieveVerbose = 0xF,
-
-    // Generate a "good" symbol-search-path
-    SymBuildPath = 0x10,
-
-    // Also use the public Microsoft-Symbol-Server
-    SymUseSymSrv = 0x20,
-
-    // Contains all the above "Sym"-options
-    SymAll = 0x30,
-
-    // Contains all options (default)
-    OptionsAll = 0x3F
-  } StackWalkOptions;
-
-  explicit StackWalker(int options = OptionsAll, // 'int' is by design, to combine the enum-flags
-                       LPCSTR szSymPath = nullptr, DWORD dwProcessId = GetCurrentProcessId(),
-                       HANDLE hProcess = GetCurrentProcess());
-  StackWalker(DWORD dwProcessId, HANDLE hProcess);
-  virtual ~StackWalker();
-
-  typedef BOOL(__stdcall *PReadProcessMemoryRoutine)(
-      HANDLE hProcess, DWORD64 qwBaseAddress, PVOID lpBuffer, DWORD nSize, LPDWORD lpNumberOfBytesRead,
-      LPVOID pUserData // optional data, which was passed in "ShowCallstack"
-  );
-
-  BOOL LoadModules();
-
-  BOOL ShowCallstack(HANDLE hThread = GetCurrentThread(), const CONTEXT *context = nullptr,
-                     PReadProcessMemoryRoutine readMemoryFunction = nullptr,
-                     LPVOID pUserData = nullptr // optional to identify some data in the 'readMemoryFunction'-callback
-  );
-
-  BOOL ShowObject(LPVOID pObject);
-
-  // new add
-  typedef int (*LoadedModulesCallbackFunc)(const char *, address, address, void *);
-  void print_windows_version(std::ostream &st);
-  void print_environment_variables(std::ostream &st); // 环境变量
-
-  void get_sys_info(std::ostream &st); // CPU
-
-  int get_loaded_modules_info(LoadedModulesCallbackFunc callback, void *param);
-  static int print_module(const char *fname, address base_address, address top_address, void *param);
-  void print_dll_info(std::ostream *st); // dll
-
-  address current_stack_base();
-  size_t current_stack_size();              // 返回当前栈的大小
-  void print_stack_bound(std::ostream &st); // 打印堆栈边界
-
+  // Write a crash report (OS version, CPU, environment, loaded modules, stack
+  // bounds and a symbolized native stack) to `os`.
+  //
+  // `context` is an optional pointer to a CONTEXT record, passed as void* to
+  // keep this header free of <windows.h>:
+  //   - nullptr : capture and walk the current thread stack.
+  //   - non-null: unwind from the given (e.g. exception) context.
   void show_callstack(std::ostream &os, const void *context = nullptr);
 
-  //----堆栈信息的函数
-  bool dll_address_to_library_name(address addr, char *buf, int buflen, int *offset);
-  static int _locate_module_by_addr(const char *mod_fname, address base_addr, address top_address, void *param);
-  void print_C_frame(std::ostream &st, char *buf, int buflen, address pc);
-  bool _print_native_stack(std::ostream &st, const void *context, char *buf, int buf_size);
-  bool get_source_info(const void *addr, char *buf, size_t buflen, int *line_no);
-  bool decode(const void *addr, char *buf, int buflen, int *offset, bool do_demangle);
-  bool dll_address_to_function_name(address addr, char *buf, int buflen, int *offset, bool demangle);
-  bool decode_locked(const void *addr, char *buf, int buflen, int *offset, bool do_demangle);
-  //----堆栈信息的函数
+private:
+  void print_windows_version(std::ostream &st);
+  void print_cpu_info(std::ostream &st);
+  void print_environment_variables(std::ostream &st);
+  void print_loaded_modules(std::ostream &st);
+  void print_stack_bound(std::ostream &st);
+  void print_native_stack(std::ostream &st, const void *context);
+};
 
-#if _MSC_VER >= 1300
-  // due to some reasons, the "STACKWALK_MAX_NAMELEN" must be declared as "public"
-  // in older compilers in order to use it... starting with VC7 we can declare it as "protected"
-protected:
-#endif
-  enum { STACKWALK_MAX_NAMELEN = 1024 }; // max name length for found symbols
-
-protected:
-  // Entry for each Callstack-Entry
-  typedef struct CallstackEntry {
-    DWORD64 offset; // if 0, we have no valid entry
-    CHAR name[STACKWALK_MAX_NAMELEN];
-    CHAR undName[STACKWALK_MAX_NAMELEN];
-    CHAR undFullName[STACKWALK_MAX_NAMELEN];
-    DWORD64 offsetFromSmybol;
-    DWORD offsetFromLine;
-    DWORD lineNumber;
-    CHAR lineFileName[STACKWALK_MAX_NAMELEN];
-    DWORD symType;
-    LPCSTR symTypeString;
-    CHAR moduleName[STACKWALK_MAX_NAMELEN];
-    DWORD64 baseOfImage;
-    CHAR loadedImageName[STACKWALK_MAX_NAMELEN];
-  } CallstackEntry;
-
-  typedef enum CallstackEntryType { firstEntry, nextEntry, lastEntry } CallstackEntryType;
-
-  virtual void OnSymInit(LPCSTR szSearchPath, DWORD symOptions, LPCSTR szUserName);
-  virtual void OnLoadModule(LPCSTR img, LPCSTR mod, DWORD64 baseAddr, DWORD size, DWORD result, LPCSTR symType,
-                            LPCSTR pdbName, ULONGLONG fileVersion);
-  virtual void OnCallstackEntry(CallstackEntryType eType, CallstackEntry &entry);
-  virtual void OnDbgHelpErr(LPCSTR szFuncName, DWORD gle, DWORD64 addr);
-  virtual void OnOutput(LPCSTR szText);
-
-  StackWalkerInternal *m_sw;
-  HANDLE m_hProcess;
-  DWORD m_dwProcessId;
-  BOOL m_modulesLoaded;
-  LPSTR m_szSymPath;
-
-  int m_options;
-  int m_MaxRecursionCount;
-
-  static BOOL __stdcall myReadProcMem(HANDLE hProcess, DWORD64 qwBaseAddress, PVOID lpBuffer, DWORD nSize,
-                                      LPDWORD lpNumberOfBytesRead);
-
-  friend StackWalkerInternal;
-}; // class StackWalker
-
-// The "ugly" assembler-implementation is needed for systems before XP
-// If you have a new PSDK and you only compile for XP and later, then you can use
-// the "RtlCaptureContext"
-// Currently there is no define which determines the PSDK-Version...
-// So we just use the compiler-version (and assumes that the PSDK is
-// the one which was installed by the VS-IDE)
-
-// INFO: If you want, you can use the RtlCaptureContext if you only target XP and later...
-//       But I currently use it in x64/IA64 environments...
-// #if defined(_M_IX86) && (_WIN32_WINNT <= 0x0500) && (_MSC_VER < 1400)
-
-#if defined(_M_IX86)
-#ifdef CURRENT_THREAD_VIA_EXCEPTION
-// TODO: The following is not a "good" implementation,
-// because the callstack is only valid in the "__except" block...
-#define GET_CURRENT_CONTEXT_STACKWALKER_CODEPLEX(c, contextFlags)                                                      \
-  do {                                                                                                                 \
-    memset(&c, 0, sizeof(CONTEXT));                                                                                    \
-    EXCEPTION_POINTERS *pExp = NULL;                                                                                   \
-    __try {                                                                                                            \
-      throw 0;                                                                                                         \
-    } __except (((pExp = GetExceptionInformation()) ? EXCEPTION_EXECUTE_HANDLER : EXCEPTION_EXECUTE_HANDLER)) {        \
-    }                                                                                                                  \
-    if (pExp != NULL)                                                                                                  \
-      memcpy(&c, pExp->ContextRecord, sizeof(CONTEXT));                                                                \
-    c.ContextFlags = contextFlags;                                                                                     \
-  } while (0);
-#else
-// clang-format off
-// The following should be enough for walking the callstack...
-#define GET_CURRENT_CONTEXT_STACKWALKER_CODEPLEX(c, contextFlags) \
-  do                                                              \
-  {                                                               \
-    memset(&c, 0, sizeof(CONTEXT));                               \
-    c.ContextFlags = contextFlags;                                \
-    __asm    call x                                               \
-    __asm x: pop eax                                              \
-    __asm    mov c.Eip, eax                                       \
-    __asm    mov c.Ebp, ebp                                       \
-    __asm    mov c.Esp, esp                                       \
-  } while (0)
-// clang-format on
-#endif
-
-#else
-
-// The following is defined for x86 (XP and higher), x64 and IA64:
-#define GET_CURRENT_CONTEXT_STACKWALKER_CODEPLEX(c, contextFlags)                                                      \
-  do {                                                                                                                 \
-    memset(&c, 0, sizeof(CONTEXT));                                                                                    \
-    c.ContextFlags = contextFlags;                                                                                     \
-    RtlCaptureContext(&c);                                                                                             \
-  } while (0);
-#endif
+} // namespace kungfu::yijinjing::util
 
 #endif // defined(_MSC_VER)
 
-#endif // __STACKWALKER_H__
+#endif // KUNGFU_UTIL_STACKWALKER_H


### PR DESCRIPTION
## What

Windows crash reports carried no usable native stack. Two parts:

1. **Rewrite the stackwalker** (`fix(yijinjing)`): the hand-rolled StackWalk64 walk, seeded from a manual STACKFRAME with DbgHelp `fInvadeProcess=FALSE` and no registered unwind tables, produced garbage frames and no symbols on x64. Replaced with the OS unwinder (`RtlCaptureStackBackTrace` for the current thread, `StackWalk64` from the exception `CONTEXT` for SEH) symbolized via `SymFromAddr` / `SymGetLineFromAddr64`. Architecture-neutral (x64 + ARM64), DbgHelp serialized behind one process-wide mutex. Collapses the file from ~2000 lines to ~350 and removes the dead vendored walker and VC5/6 compatibility code.

2. **Ship PDBs** (`build(windows)`): the MSVC build emitted no debug info, so even with a correct walker kungfu frames would resolve only to `module+offset` in the field. Build with `/Z7` + `/DEBUG /OPT:REF /OPT:ICF`, copy each native's PDB into `dist/kfc` at freeze, and fail the freeze if a shipped kungfu native lacks its PDB. See `docs/windows-crash-symbols.md`.

## Validation

The walker was validated with a standalone harness compiling the real `StackWalker.cpp` + `stacktrace.cpp` under VS2022: before → garbage frames / no symbols; after → fully symbolized stacks for both the SEH crash path and the capture path, including exact `file:line` at the fault site. The full in-tree Windows `.node` build is currently blocked by unrelated toolchain issues (cmake-js/Ninja resource-compiler, rocksdb MSVC mismatch), so these changes are not yet exercised end-to-end there; the freeze-time PDB check fails safe when symbols are missing.

## Version impact

Patch — internal bug fix plus build hardening, no public interface change.
