### PR TITLE
docs(rewind): the onboarding page, hardened by a stranger walking it

### DIFF
--- a/docs/MAP.md
+++ b/docs/MAP.md
@@ -38,6 +38,7 @@ and the map routes a question to whichever doc answers it.
 | Where does a release binary come from, and how do I verify it? | `provenance.md` | verify | blocked · needs release infra |
 | What gates must a release pass? | `provenance.md` + [`version-release-design.md`](version-release-design.md) | verify | partial |
 | If kungfu itself misbehaves, how do I localize it? | [`debugging.md`](debugging.md) | verify | stable |
+| How do I record an agent run and find why it failed (Rewind)? | [`rewind.md`](rewind.md) | use | stable · pre-release install path |
 | How do I write an extension (`kfx`)? | `extensions.md` (+ [`../examples/`](../examples)) | use | to write · examples exist |
 
 ## Also asking about

--- a/docs/rewind.md
+++ b/docs/rewind.md
@@ -1,0 +1,147 @@
+# Kungfu Rewind — record an agent run, then open it
+
+> Pre-release. Rewind is the local agent flight recorder built on the kungfu
+> runtime: one command wraps an **unmodified** agent run, every model call and
+> tool call lands in one local journal, and you re-open the run afterwards —
+> in the desktop app or from the command line. Nothing is uploaded anywhere.
+
+This page is the complete path: install → capture → diagnose → replay →
+clean up. It assumes nothing beyond a shell.
+
+## Install (pre-release: from a built workspace)
+
+Release binaries are not published yet; today Rewind runs from a built
+workspace. Install `fnm` and `uv` once (see [CONTRIBUTING](../CONTRIBUTING.md)),
+then:
+
+```sh
+git clone git@github.com:kungfu-systems/kungfu.git
+cd kungfu
+./kungfu-code sync && ./kungfu-code build
+```
+
+Everything below runs from the repository root. `kungfu` (alias `kfc`) is the
+runtime CLI; the desktop app is the reference GUI.
+
+## Capture a run
+
+Wrap any command. The traced program needs **no code changes and no SDK** —
+the only contact surface is the environment the supervisor injects. In a
+workspace build, run the CLI from `framework/core`:
+
+```sh
+cd framework/core
+uv run --frozen python .devtools/kfc.py -H <home-dir> \
+  trace -- python3 my_agent.py
+```
+
+- `<home-dir>` is where the run store lives (any directory you own).
+- `trace` assigns the run id and prints it on the `[rewind] run <id> starts`
+  line — note it down, the diagnosis commands take it via `--run`.
+- `trace` exits with the traced program's own exit code, so it drops into
+  scripts and CI without changing failure semantics.
+- Model calls are captured at the wire: the supervisor points
+  `OPENAI_BASE_URL` / `ANTHROPIC_BASE_URL` at a local proxy and forwards to
+  the upstream your run would have used anyway — it reads your environment's
+  own base-url variables before overriding them for the child, falling back
+  to the providers' official endpoints. Request/response bodies are recorded;
+  **headers are never captured** (that is where API keys live).
+- Tool calls, results, errors and retries are captured in-process by hooks
+  injected through `PYTHONPATH` (python) and `NODE_OPTIONS` (node). A process
+  spawned inside a tool inherits its causal parent — one chain, across
+  runtimes, in one journal.
+- A run writes two things under `<home-dir>/runtime`: the journal itself
+  (under `system/rewind/<run-id>/` — the recorded frames) and the trace
+  bundle (under `rewind/<run-id>/bundle/` — the schema blob + manifest that
+  make the journal decodable without this runtime).
+
+## Diagnose from the command line
+
+```sh
+# from framework/core, same -H <home-dir> as the capture:
+
+# the causal tree: model spans, tool spans (cross-runtime nested),
+# retries, per-span latency, failed nodes with their error detail
+uv run --frozen python .devtools/kfc.py -H <home-dir> rewind show --run <run-id>
+
+# prove the record self-describes: decode every frame two independent
+# ways (native accessors vs the bundle's reflection schema) and diff
+uv run --frozen python .devtools/kfc.py -H <home-dir> rewind verify --run <run-id>
+```
+
+(In a packaged install these are just `kungfu rewind show` / `kungfu rewind
+verify`; the long prefix is the workspace-build spelling.)
+
+`show` answers the first diagnosis questions in one screen: which step failed
+(✗ with the error detail inline), how long each step took, and how the run
+ended. Full input/output bodies live in the app's node pane; the CLI shows
+them only as far as the error message carries them. `verify` is forensic
+replay: the journal is re-read on the same runtime that recorded it, and the
+trace bundle alone must reproduce every fact — tampering or schema drift
+fails loudly.
+
+## Diagnose in the app
+
+```sh
+KF_RUNTIME_DIR=<home-dir>/runtime ./kungfu-code app
+```
+
+The **Rewind** tab (first in the left nav) shows three panes:
+
+- **runs** — every recorded run; ● red means the run had errors.
+- **trace** — the causal tree. Failed nodes are marked ✗; a tool executed in
+  another runtime (e.g. a node tool called from python) nests under its
+  caller, because both runtimes wrote the same journal.
+- **node** — select any node: status, latency, tokens, the error, and the
+  full input/output bodies, pretty-printed.
+
+The 2-minute drill for "why did my run fail": open the run with the red dot →
+follow the ✗ down the tree → read the node's `error` and `input`. That is the
+whole workflow.
+
+## Delete a run / privacy
+
+A run is files under `<home-dir>/runtime` — delete the run's directories and
+it is gone:
+
+```sh
+rm -r <home-dir>/runtime/system/rewind/<run-id> <home-dir>/runtime/rewind/<run-id>
+```
+
+Default mode never uploads anything: capture, storage, diagnosis and replay
+are all local. The proxy only talks to the model upstream your run already
+used.
+
+## Demos
+
+Deterministic end-to-end demos live under `tests/fixtures/` and double as
+release gates (`./kungfu-code verify --full` runs them all):
+
+| Demo | Shows |
+| --- | --- |
+| `rewind-demo-happy/` | capture basics + a flaky tool that retries and recovers |
+| `rewind-demo-tool-failure/` | a tool failing for real: ✗ node, error detail, non-zero exit |
+| `rewind-demo-model-drift/` | the model picks a tool that does not exist — the drift is visible in the model node's output, and the consequence in the failing step after it |
+| `rewind-demo-cross-runtime/` | python agent → node tool, one causal chain in one journal |
+| `rewind-demo-forensic-replay/` | re-open + two-path verify + tamper rejection |
+
+Each runs standalone: `tests/fixtures/<name>/run.sh`.
+
+## Known limits (pre-release)
+
+- Install is workspace-build only; packaged three-platform installers are the
+  next release gate.
+- On macOS, run the workspace CLI from `framework/core` with
+  `DYLD_FALLBACK_LIBRARY_PATH=<repo>/framework/core/dist/kfc` exported: the
+  dev-python binding resolves `libnode` relative to the executable, and shell
+  wrappers strip `DYLD_*` across re-exec, so exporting it in your own shell
+  right before the command is the reliable spelling.
+- The CLI tree does not yet label which runtime executed each node (the
+  cross-runtime nesting itself is recorded and shown; the per-node runtime
+  tag is a schema addition on the list).
+- Streaming (SSE) model responses are captured verbatim, not parsed into
+  token/usage facts.
+- Replay is forensic (re-open, walk, verify); deterministic re-execution is a
+  later differentiator gate.
+- Framework auto-instrumentation ships with the demo toolkit adapter;
+  real-framework adapters (LangChain et al.) grow in the same adapter table.

--- a/framework/core/src/python/kungfu/rewind/replay.py
+++ b/framework/core/src/python/kungfu/rewind/replay.py
@@ -228,8 +228,10 @@ def render_tree(runtime_dir, run_id):
             head = f"retry attempt {facts.get('attempt')} of {facts.get('retry_of_span_id', '')[:8]}"
         if close:
             _, cf = close
-            status = "ok" if cf.get("status") == 0 else f"status={cf.get('status')}"
+            status = "ok" if cf.get("status") == 0 else "✗ error"
             head += f"  [{status}, {cf.get('latency_ns', 0) / 1e6:.1f}ms]"
+            if cf.get("status") != 0 and cf.get("error"):
+                head += f" — {cf.get('error')}"
         return head
 
     def walk(span, depth):

--- a/framework/gui/src/renderer/src/main.tsx
+++ b/framework/gui/src/renderer/src/main.tsx
@@ -116,7 +116,11 @@ function App() {
   const [runtime] = React.useState(bootRuntime);
   const versions = window.process.versions;
   const [live, setLive] = React.useState(false);
-  const [active, setActive] = React.useState('overview');
+  // deep-link the initial view (demos, QA harnesses, "open straight to the
+  // run I just traced"): KFE_INITIAL_VIEW=<kfx id|overview>
+  const [active, setActive] = React.useState(
+    window.process.env.KFE_INITIAL_VIEW || 'overview',
+  );
 
   React.useEffect(() => {
     const ledger = runtime.ledger;

--- a/tests/fixtures/rewind-demo-model-drift/check_capture.py
+++ b/tests/fixtures/rewind-demo-model-drift/check_capture.py
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Model-drift assertions (gate G6/D3): the drift must be visible as recorded
+# semantics — the model node's response names a tool that does not exist, and
+# the step right after it fails on exactly that name. Log files show only the
+# KeyError; the trace shows where the wrongness began.
+#
+# Usage: check_capture.py <runtime-dir> <run-id>
+
+import os
+import sys
+
+_core = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "..", "framework", "core")
+)
+sys.path.insert(0, os.path.join(_core, "src", "python"))
+sys.path.insert(0, os.path.join(_core, "dist", "kfc"))
+
+import kungfu
+
+from kungfu.rewind import (
+    MSG_MODEL_RESPONSE,
+    MSG_RUN_END,
+    MSG_TOOL_CALL,
+    MSG_TOOL_RESULT,
+)
+from kungfu.rewind.fb.CallStatus import CallStatus
+from kungfu.rewind.fb.ModelResponse import ModelResponse
+from kungfu.rewind.fb.RunEnd import RunEnd
+from kungfu.rewind.fb.RunStatus import RunStatus
+from kungfu.rewind.fb.ToolCall import ToolCall
+from kungfu.rewind.fb.ToolResult import ToolResult
+
+lf = kungfu.__binding__.longfist
+yjj = kungfu.__binding__.yijinjing
+
+runtime_dir, run_id = sys.argv[1], sys.argv[2]
+failures = []
+
+
+def check(name, ok, detail=""):
+    print(f"  {'ok' if ok else 'FAIL'}  {name}{': ' + detail if detail else ''}")
+    if not ok:
+        failures.append(name)
+
+
+locator = yjj.locator(runtime_dir)
+location = yjj.location(
+    lf.enums.mode.LIVE, lf.enums.category.SYSTEM, "rewind", run_id, locator
+)
+
+
+def read(msg_type):
+    return yjj.assemble(location, 0).read_bytes(msg_type)
+
+
+responses = read(MSG_MODEL_RESPONSE)
+check("model response present", len(responses) == 1)
+drift_time = None
+if responses:
+    header, payload = responses[0]
+    resp = ModelResponse.GetRootAs(bytes(payload), 0)
+    body = (resp.ResponseBody() or b"").decode()
+    check("drift visible in model output (web-search)", "web-search" in body)
+    check("model itself reported no error", resp.Status() == CallStatus.Ok)
+    drift_time = header.gen_time
+
+calls = read(MSG_TOOL_CALL)
+check("routing step captured", len(calls) == 1)
+if calls:
+    header, payload = calls[0]
+    call = ToolCall.GetRootAs(bytes(payload), 0)
+    check("router received the drifted selection", "web-search" in (call.Input() or b"").decode())
+    if drift_time is not None:
+        check("consequence follows the drift on the timeline", header.gen_time > drift_time)
+
+results = read(MSG_TOOL_RESULT)
+check("routing result captured", len(results) == 1)
+if results:
+    result = ToolResult.GetRootAs(bytes(results[0][1]), 0)
+    check("routing failed", result.Status() == CallStatus.Error)
+    error = (result.Error() or b"").decode()
+    check("failure names the drifted tool", "web-search" in error)
+    check("failure lists what was actually available", "lookup" in error)
+
+ends = read(MSG_RUN_END)
+check("run failed with exit 1", len(ends) == 1 and RunEnd.GetRootAs(bytes(ends[0][1]), 0).ExitCode() == 1 and RunEnd.GetRootAs(bytes(ends[0][1]), 0).Status() == RunStatus.Failed)
+
+if failures:
+    print(f"model-drift check failed: {failures}")
+    sys.exit(1)
+print("model-drift check passed")

--- a/tests/fixtures/rewind-demo-model-drift/demo_agent.py
+++ b/tests/fixtures/rewind-demo-model-drift/demo_agent.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Model-drift demo (gate G6/D3): the model selects a tool the agent does not
+# have. Nothing threw on the model side — the wrongness is semantic, inside
+# the model's answer. The trace must show the drift point (the model node's
+# response naming a nonexistent tool) and its consequence (the routing step
+# failing on exactly that name).
+
+import json
+import os
+import re
+import sys
+import urllib.request
+
+import rewind_demo_toolkit
+
+run_id = os.environ.get("KUNGFU_REWIND_RUN_ID")
+base_url = os.environ.get("OPENAI_BASE_URL")
+if not run_id or not base_url:
+    print("injected capture environment missing", file=sys.stderr)
+    sys.exit(2)
+
+request = urllib.request.Request(
+    base_url.rstrip("/") + "/chat/completions",
+    data=json.dumps(
+        {
+            "model": "demo-model",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "find the demo answer (available tools: lookup)",
+                }
+            ],
+        }
+    ).encode(),
+    headers={"Content-Type": "application/json"},
+    method="POST",
+)
+with urllib.request.urlopen(request, timeout=30) as response:
+    answer = json.load(response)
+content = answer["choices"][0]["message"]["content"]
+
+TOOLS = {"lookup": lambda i: {"answer": str(i.get("query", "")).upper()}}
+
+
+def route(tool_input):
+    selected = tool_input["selected"]
+    if selected not in TOOLS:
+        raise KeyError(
+            f"model selected unknown tool {selected!r}; available: {sorted(TOOLS)}"
+        )
+    return TOOLS[selected](tool_input)
+
+
+match = re.search(r"use tool: ([\w-]+)", content)
+selected = match.group(1) if match else "none"
+
+router = rewind_demo_toolkit.Tool("tool-router", route)
+try:
+    router.run({"selected": selected, "query": "demo answer"})
+except KeyError as e:
+    print(f"agent failed on model drift: {e}", file=sys.stderr)
+    sys.exit(1)
+
+print("unexpected success", file=sys.stderr)
+sys.exit(2)

--- a/tests/fixtures/rewind-demo-model-drift/mock_model.py
+++ b/tests/fixtures/rewind-demo-model-drift/mock_model.py
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Drift stand-in: the "model" confidently selects a tool that does not exist
+# in the agent's registry. The wrongness lives in the model output itself —
+# exactly the class of failure that is invisible in exception logs and obvious
+# in a trace that shows the model node's actual response.
+#
+# Usage: mock_model.py <port-file>
+
+import http.server
+import json
+import sys
+
+CANNED = {
+    "id": "chatcmpl-fixture-drift",
+    "object": "chat.completion",
+    "model": "demo-model",
+    "choices": [
+        {
+            "index": 0,
+            "message": {
+                "role": "assistant",
+                "content": "use tool: web-search with query 'demo answer'",
+            },
+            "finish_reason": "stop",
+        }
+    ],
+    "usage": {"prompt_tokens": 9, "completion_tokens": 8, "total_tokens": 17},
+}
+
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, format, *args):
+        pass
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", 0))
+        self.rfile.read(length)
+        body = json.dumps(CANNED).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+server = http.server.HTTPServer(("127.0.0.1", 0), Handler)
+with open(sys.argv[1], "w") as f:
+    f.write(str(server.server_address[1]))
+server.serve_forever()

--- a/tests/fixtures/rewind-demo-model-drift/rewind_demo_toolkit.py
+++ b/tests/fixtures/rewind-demo-model-drift/rewind_demo_toolkit.py
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# A miniature tool framework standing in for the third-party ones agents use.
+# It knows nothing about kungfu or tracing: the in-process adapter patches its
+# natural seams (Tool.run = the user-facing call, Tool._invoke = one attempt
+# inside the retry loop) from outside, exactly as adapters do for real
+# frameworks. Keeping it a capability probe, not a product.
+
+
+class Tool:
+    def __init__(self, name, fn, retries=0):
+        self.name = name
+        self.fn = fn
+        self.retries = retries
+
+    def _invoke(self, tool_input):
+        return self.fn(tool_input)
+
+    def run(self, tool_input):
+        attempts = self.retries + 1
+        for attempt in range(attempts):
+            try:
+                return self._invoke(tool_input)
+            except Exception:
+                if attempt == attempts - 1:
+                    raise

--- a/tests/fixtures/rewind-demo-model-drift/run.sh
+++ b/tests/fixtures/rewind-demo-model-drift/run.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+# SPDX-License-Identifier: Apache-2.0
+#
+# Model-drift fixture (gate G6/D3): the model selects a nonexistent tool;
+# the record must show the drift point (the model node output) and its
+# consequence (the routing step failing on that exact name).
+#
+# Usage: tests/fixtures/rewind-demo-model-drift/run.sh
+
+set -eu
+fixture_dir="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+core_dir="$(CDPATH= cd -- "$fixture_dir/../../../framework/core" && pwd)"
+
+home="$(mktemp -d)"
+run_id="fixturedrift$(date +%s)"
+
+port_file="$home/mock-port"
+# stdio-detached, killed by the trap — see rewind-demo-happy/run.sh for why
+python3 "$fixture_dir/mock_model.py" "$port_file" >/dev/null 2>&1 &
+mock_pid=$!
+trap 'kill "$mock_pid" 2>/dev/null; rm -rf "$home"' EXIT
+while [ ! -s "$port_file" ]; do sleep 0.1; done
+OPENAI_BASE_URL="http://127.0.0.1:$(cat "$port_file")/v1"
+export OPENAI_BASE_URL
+
+DYLD_FALLBACK_LIBRARY_PATH="$core_dir/dist/kfc${DYLD_FALLBACK_LIBRARY_PATH:+:$DYLD_FALLBACK_LIBRARY_PATH}"
+export DYLD_FALLBACK_LIBRARY_PATH
+
+cd "$core_dir"
+# the traced run is EXPECTED to fail with exit 1; anything else is a fixture bug
+set +e
+uv run --frozen python .devtools/kfc.py -H "$home" trace --run-id "$run_id" -- \
+  python3 "$fixture_dir/demo_agent.py"
+rc=$?
+set -e
+[ "$rc" -eq 1 ] || { echo "FAIL: expected traced run to exit 1, got $rc"; exit 1; }
+
+tree="$(uv run --frozen python .devtools/kfc.py -H "$home" rewind show --run "$run_id")"
+printf '%s\n' "$tree"
+printf '%s' "$tree" | grep -q '✗' || { echo "FAIL: failed node not marked in tree"; exit 1; }
+echo "ok  tree marks the failure"
+
+uv run --frozen python "$fixture_dir/check_capture.py" "$home/runtime" "$run_id"

--- a/tests/fixtures/rewind-demo-tool-failure/check_capture.py
+++ b/tests/fixtures/rewind-demo-tool-failure/check_capture.py
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Tool-failure assertions (gate G6/D2): the failed step must be explicit in
+# the record — an errored ToolResult carrying the actual error detail, a
+# failed run status, and the tree marking the node.
+#
+# Usage: check_capture.py <runtime-dir> <run-id>
+
+import os
+import sys
+
+_core = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "..", "framework", "core")
+)
+sys.path.insert(0, os.path.join(_core, "src", "python"))
+sys.path.insert(0, os.path.join(_core, "dist", "kfc"))
+
+import kungfu
+
+from kungfu.rewind import MSG_RUN_END, MSG_TOOL_CALL, MSG_TOOL_RESULT
+from kungfu.rewind.fb.CallStatus import CallStatus
+from kungfu.rewind.fb.RunEnd import RunEnd
+from kungfu.rewind.fb.RunStatus import RunStatus
+from kungfu.rewind.fb.ToolCall import ToolCall
+from kungfu.rewind.fb.ToolResult import ToolResult
+
+lf = kungfu.__binding__.longfist
+yjj = kungfu.__binding__.yijinjing
+
+runtime_dir, run_id = sys.argv[1], sys.argv[2]
+failures = []
+
+
+def check(name, ok, detail=""):
+    print(f"  {'ok' if ok else 'FAIL'}  {name}{': ' + detail if detail else ''}")
+    if not ok:
+        failures.append(name)
+
+
+locator = yjj.locator(runtime_dir)
+location = yjj.location(
+    lf.enums.mode.LIVE, lf.enums.category.SYSTEM, "rewind", run_id, locator
+)
+
+
+def read(msg_type):
+    return yjj.assemble(location, 0).read_bytes(msg_type)
+
+
+calls = read(MSG_TOOL_CALL)
+check("exactly one tool call (no retry loop)", len(calls) == 1)
+if calls:
+    call = ToolCall.GetRootAs(bytes(calls[0][1]), 0)
+    check("tool is lookup", (call.ToolName() or b"").decode() == "lookup")
+    check("input captured", "query" in (call.Input() or b"").decode())
+
+results = read(MSG_TOOL_RESULT)
+check("exactly one tool result", len(results) == 1)
+if results:
+    result = ToolResult.GetRootAs(bytes(results[0][1]), 0)
+    check("result is an error", result.Status() == CallStatus.Error)
+    error = (result.Error() or b"").decode()
+    check("error names the broken contract", "missing field 'answer'" in error)
+    check("error carries the query", "the demo answer" in error)
+
+ends = read(MSG_RUN_END)
+check("RunEnd present", len(ends) == 1)
+if ends:
+    end = RunEnd.GetRootAs(bytes(ends[0][1]), 0)
+    check("run failed", end.Status() == RunStatus.Failed)
+    check("exit code 1", end.ExitCode() == 1)
+
+if failures:
+    print(f"tool-failure check failed: {failures}")
+    sys.exit(1)
+print("tool-failure check passed")

--- a/tests/fixtures/rewind-demo-tool-failure/demo_agent.py
+++ b/tests/fixtures/rewind-demo-tool-failure/demo_agent.py
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Tool-failure demo (gate G6/D2): the model answers fine, then the tool the
+# agent acts with fails for real — bad schema from a downstream service, no
+# retry can save it. The recorded run must make the failure diagnosable in one
+# look: which step (✗), what went in, what came back. Unmodified user code, as
+# always: only the injected environment connects it to the recorder.
+
+import json
+import os
+import sys
+import urllib.request
+
+import rewind_demo_toolkit
+
+run_id = os.environ.get("KUNGFU_REWIND_RUN_ID")
+base_url = os.environ.get("OPENAI_BASE_URL")
+if not run_id or not base_url:
+    print("injected capture environment missing", file=sys.stderr)
+    sys.exit(2)
+
+request = urllib.request.Request(
+    base_url.rstrip("/") + "/chat/completions",
+    data=json.dumps(
+        {
+            "model": "demo-model",
+            "messages": [{"role": "user", "content": "look up the demo answer"}],
+        }
+    ).encode(),
+    headers={"Content-Type": "application/json"},
+    method="POST",
+)
+with urllib.request.urlopen(request, timeout=30) as response:
+    answer = json.load(response)
+content = answer["choices"][0]["message"]["content"]
+
+
+def broken_lookup(tool_input):
+    # downstream returns a malformed record; the tool surfaces it as a hard error
+    record = {"status": "ok"}  # missing the 'answer' field the contract requires
+    if "answer" not in record:
+        raise ValueError(
+            f"lookup returned invalid schema: missing field 'answer' "
+            f"(got keys {sorted(record)}) for query {tool_input['query']!r}"
+        )
+    return record
+
+
+tool = rewind_demo_toolkit.Tool("lookup", broken_lookup)
+try:
+    tool.run({"query": content})
+except ValueError as e:
+    print(f"agent failed: {e}", file=sys.stderr)
+    sys.exit(1)
+
+print("unexpected success", file=sys.stderr)
+sys.exit(2)

--- a/tests/fixtures/rewind-demo-tool-failure/mock_model.py
+++ b/tests/fixtures/rewind-demo-tool-failure/mock_model.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Deterministic stand-in for a model provider: an openai-compatible chat
+# completions endpoint with fixed content and usage, so the fixture asserts
+# capture facts without network or keys.
+#
+# Usage: mock_model.py <port-file>   (binds an ephemeral port, writes it there)
+
+import http.server
+import json
+import sys
+
+CANNED = {
+    "id": "chatcmpl-fixture",
+    "object": "chat.completion",
+    "model": "demo-model",
+    "choices": [
+        {
+            "index": 0,
+            "message": {"role": "assistant", "content": "the demo answer"},
+            "finish_reason": "stop",
+        }
+    ],
+    "usage": {"prompt_tokens": 7, "completion_tokens": 3, "total_tokens": 10},
+}
+
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, format, *args):
+        pass
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", 0))
+        self.rfile.read(length)
+        body = json.dumps(CANNED).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+server = http.server.HTTPServer(("127.0.0.1", 0), Handler)
+with open(sys.argv[1], "w") as f:
+    f.write(str(server.server_address[1]))
+server.serve_forever()

--- a/tests/fixtures/rewind-demo-tool-failure/rewind_demo_toolkit.py
+++ b/tests/fixtures/rewind-demo-tool-failure/rewind_demo_toolkit.py
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# A miniature tool framework standing in for the third-party ones agents use.
+# It knows nothing about kungfu or tracing: the in-process adapter patches its
+# natural seams (Tool.run = the user-facing call, Tool._invoke = one attempt
+# inside the retry loop) from outside, exactly as adapters do for real
+# frameworks. Keeping it a capability probe, not a product.
+
+
+class Tool:
+    def __init__(self, name, fn, retries=0):
+        self.name = name
+        self.fn = fn
+        self.retries = retries
+
+    def _invoke(self, tool_input):
+        return self.fn(tool_input)
+
+    def run(self, tool_input):
+        attempts = self.retries + 1
+        for attempt in range(attempts):
+            try:
+                return self._invoke(tool_input)
+            except Exception:
+                if attempt == attempts - 1:
+                    raise

--- a/tests/fixtures/rewind-demo-tool-failure/run.sh
+++ b/tests/fixtures/rewind-demo-tool-failure/run.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+# SPDX-License-Identifier: Apache-2.0
+#
+# Tool-failure fixture (gate G6/D2): the traced agent fails on a broken tool;
+# the record must make the failure diagnosable — errored ToolResult with the
+# real detail, failed run status, ✗ in the rendered tree.
+#
+# Usage: tests/fixtures/rewind-demo-tool-failure/run.sh
+
+set -eu
+fixture_dir="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+core_dir="$(CDPATH= cd -- "$fixture_dir/../../../framework/core" && pwd)"
+
+home="$(mktemp -d)"
+run_id="fixturetoolfail$(date +%s)"
+
+port_file="$home/mock-port"
+# stdio-detached, killed by the trap — see rewind-demo-happy/run.sh for why
+python3 "$fixture_dir/mock_model.py" "$port_file" >/dev/null 2>&1 &
+mock_pid=$!
+trap 'kill "$mock_pid" 2>/dev/null; rm -rf "$home"' EXIT
+while [ ! -s "$port_file" ]; do sleep 0.1; done
+OPENAI_BASE_URL="http://127.0.0.1:$(cat "$port_file")/v1"
+export OPENAI_BASE_URL
+
+DYLD_FALLBACK_LIBRARY_PATH="$core_dir/dist/kfc${DYLD_FALLBACK_LIBRARY_PATH:+:$DYLD_FALLBACK_LIBRARY_PATH}"
+export DYLD_FALLBACK_LIBRARY_PATH
+
+cd "$core_dir"
+# the traced run is EXPECTED to fail with exit 1; anything else is a fixture bug
+set +e
+uv run --frozen python .devtools/kfc.py -H "$home" trace --run-id "$run_id" -- \
+  python3 "$fixture_dir/demo_agent.py"
+rc=$?
+set -e
+[ "$rc" -eq 1 ] || { echo "FAIL: expected traced run to exit 1, got $rc"; exit 1; }
+
+tree="$(uv run --frozen python .devtools/kfc.py -H "$home" rewind show --run "$run_id")"
+printf '%s\n' "$tree"
+printf '%s' "$tree" | grep -q '✗' || { echo "FAIL: failed node not marked in tree"; exit 1; }
+echo "ok  tree marks the failure"
+
+uv run --frozen python "$fixture_dir/check_capture.py" "$home/runtime" "$run_id"


### PR DESCRIPTION
## What

The Rewind onboarding surface plus the completed demo three-pack — the substance behind gates G9 (docs onboarding), G6 (demo three-pack) and the fresh-reader validation loop:

- **`docs/rewind.md`** — the complete stranger path: install → capture → diagnose (CLI + app) → forensic replay → delete/privacy → demos → honest known limits. Routed from `MAP.md`.
- **Hardened by an actual fresh walk-through**: a reader following only this page (no source access) captured a failing agent run, diagnosed it in **one command**, correctly articulated the cross-runtime causal chain of a second run, ran `verify` and interpreted it — and reported eight friction points, all fixed here: the capture command spelling that survives shell re-exec (macOS dyld quirk documented in known limits), run-id assignment stated, the show-vs-app split for input/output bodies made honest, the two on-disk directories explained, exit-code propagation and upstream discovery documented, the missing per-node runtime tag acknowledged as a schema addition on the list.
- **Demo three-pack completed** (each 12-assertion gated, auto-run by `verify --full`):
  - `rewind-demo-tool-failure/` — a tool failing for real: single call, errored result carrying the actual contract violation, failed run status, ✗ in the rendered tree;
  - `rewind-demo-model-drift/` — the model picks a tool that does not exist: the drift is visible in the model node's recorded output, the consequence in the routing step right after it, ordered on the timeline.
- **Two small product improvements the walk-through motivated**: the CLI tree renders failed nodes as `✗ error — <detail>` (was a bare status code), and the app accepts `KFE_INITIAL_VIEW` to open straight onto a chosen view (deep-linking for demos and drills).

## Validation

- All five fixtures green standalone (tool-failure and model-drift 12/12 each; happy 43, cross-runtime 12, forensic full regression).
- gui lint/build clean; ruff clean; the fresh-reader walk-through itself is the G9 evidence (transcript recorded in the control-plane records).

## Notes

The reader's attribution answer is worth quoting in spirit: for a single-process failure a generic per-process log diagnoses equally well — the differentiated value shows exactly where the plan said it would: the cross-runtime causal edge, the two-path `verify`, and wire capture with zero agent modification.