### PR TITLE
feat(rewind): export a run as one portable file; ship the app as an installer

### DIFF
--- a/docs/rewind.md
+++ b/docs/rewind.md
@@ -8,11 +8,27 @@
 This page is the complete path: install → capture → diagnose → replay →
 clean up. It assumes nothing beyond a shell.
 
-## Install (pre-release: from a built workspace)
+## Install
 
-Release binaries are not published yet; today Rewind runs from a built
-workspace. Install `fnm` and `uv` once (see [CONTRIBUTING](../CONTRIBUTING.md)),
-then:
+Release binaries are not published yet. Two paths today:
+
+**Desktop app (macOS arm64)** — build the installer once from a workspace:
+
+```sh
+./kungfu-code --filter @kungfu-tech/artifact-kungfu run dist
+```
+
+This produces `framework/gui/dist/Kungfu-<version>-arm64.dmg` (and a zip).
+Mount, drag `Kungfu.app` to Applications, launch. The app is self-contained —
+the kungfu runtime ships inside it. Pre-release builds are unsigned: on first
+launch use right-click → Open, or `xattr -d com.apple.quarantine
+/Applications/Kungfu.app`. Point it at a home with
+`KF_RUNTIME_DIR=<home-dir>/runtime`. Linux (AppImage/deb) and Windows (nsis)
+use the same electron-builder config and get wired up with signing in the
+release pipeline (next gate).
+
+**CLI (pre-release: from a built workspace)** — install `fnm` and `uv` once
+(see [CONTRIBUTING](../CONTRIBUTING.md)), then:
 
 ```sh
 git clone git@github.com:kungfu-systems/kungfu.git
@@ -51,9 +67,9 @@ uv run --frozen python .devtools/kfc.py -H <home-dir> \
   spawned inside a tool inherits its causal parent — one chain, across
   runtimes, in one journal.
 - A run writes two things under `<home-dir>/runtime`: the journal itself
-  (under `system/rewind/<run-id>/` — the recorded frames) and the trace
-  bundle (under `rewind/<run-id>/bundle/` — the schema blob + manifest that
-  make the journal decodable without this runtime).
+  (under `journal/system/rewind/<run-id>/` — the recorded frames) and the
+  trace bundle (under `rewind/<run-id>/bundle/` — the schema blob + manifest
+  that make the journal decodable without this runtime).
 
 ## Diagnose from the command line
 
@@ -80,6 +96,23 @@ replay: the journal is re-read on the same runtime that recorded it, and the
 trace bundle alone must reproduce every fact — tampering or schema drift
 fails loudly.
 
+## Share a run — export, open anywhere
+
+A run exports into one portable file (journal + the self-describing bundle),
+and that file re-opens anywhere — offline, no services, even after the
+original home is gone:
+
+```sh
+# pack:  <run-id>.rewind.zip
+uv run --frozen python .devtools/kfc.py -H <home-dir> rewind export --run <run-id>
+
+# open anywhere: extract, verify the record end to end, print the causal tree
+uv run --frozen python .devtools/kfc.py -H <anything> rewind open <file.rewind.zip>
+```
+
+`open` refuses quietly wrong data: the archive's record must pass the same
+two-path verification as a local run before anything is shown.
+
 ## Diagnose in the app
 
 ```sh
@@ -105,7 +138,8 @@ A run is files under `<home-dir>/runtime` — delete the run's directories and
 it is gone:
 
 ```sh
-rm -r <home-dir>/runtime/system/rewind/<run-id> <home-dir>/runtime/rewind/<run-id>
+rm -r <home-dir>/runtime/journal/system/rewind/<run-id> \
+      <home-dir>/runtime/rewind/<run-id>
 ```
 
 Default mode never uploads anything: capture, storage, diagnosis and replay
@@ -124,13 +158,15 @@ release gates (`./kungfu-code verify --full` runs them all):
 | `rewind-demo-model-drift/` | the model picks a tool that does not exist — the drift is visible in the model node's output, and the consequence in the failing step after it |
 | `rewind-demo-cross-runtime/` | python agent → node tool, one causal chain in one journal |
 | `rewind-demo-forensic-replay/` | re-open + two-path verify + tamper rejection |
+| `rewind-demo-export/` | export one portable file, delete the original, open + verify elsewhere |
 
 Each runs standalone: `tests/fixtures/<name>/run.sh`.
 
 ## Known limits (pre-release)
 
-- Install is workspace-build only; packaged three-platform installers are the
-  next release gate.
+- Installers are built-from-workspace, macOS arm64 only, unsigned. The
+  Linux/Windows targets and signing/notarization belong to the release
+  pipeline — the next gate before public artifacts.
 - On macOS, run the workspace CLI from `framework/core` with
   `DYLD_FALLBACK_LIBRARY_PATH=<repo>/framework/core/dist/kfc` exported: the
   dev-python binding resolves `libnode` relative to the executable, and shell

--- a/framework/api/src/capability/rewind.ts
+++ b/framework/api/src/capability/rewind.ts
@@ -77,6 +77,8 @@ export type RewindSpan = {
   spanId: string;
   open: RewindEvent;
   close?: RewindEvent;
+  // a retry is an annotation on the attempt's span (same span_id), not a node
+  retry?: RewindEvent;
   children: RewindSpan[];
 };
 
@@ -209,14 +211,20 @@ function decode(msgType: number, bytes: Uint8Array): Omit<RewindEvent, 'genTime'
 function buildTree(events: RewindEvent[]): RewindSpan[] {
   const spans = new Map<string, RewindSpan>();
   const order: string[] = [];
+  const pendingRetry = new Map<string, RewindEvent>();
   for (const event of events) {
     if (!event.spanId) continue;
-    if (
-      event.kind === 'ModelRequest' ||
-      event.kind === 'ToolCall' ||
-      event.kind === 'RetryMarker'
-    ) {
-      spans.set(event.spanId, { spanId: event.spanId, open: event, children: [] });
+    if (event.kind === 'RetryMarker') {
+      // arrives just before the attempt's ToolCall with the same span_id
+      pendingRetry.set(event.spanId, event);
+    } else if (event.kind === 'ModelRequest' || event.kind === 'ToolCall') {
+      spans.set(event.spanId, {
+        spanId: event.spanId,
+        open: event,
+        retry: pendingRetry.get(event.spanId),
+        children: [],
+      });
+      pendingRetry.delete(event.spanId);
       order.push(event.spanId);
     } else {
       const span = spans.get(event.spanId);

--- a/framework/core/src/python/kungfu/console/commands/rewind.py
+++ b/framework/core/src/python/kungfu/console/commands/rewind.py
@@ -64,3 +64,65 @@ def verify(ctx, run_id, bundle_dir):
         f"[rewind] verify passed: {frame_count} frames decode identically through "
         f"the native path and the bundle's reflection path"
     )
+
+
+@rewind.command(
+    name="export",
+    help="pack a run (journal + self-describing bundle) into one portable "
+    "file — offline, share it, open it anywhere",
+)
+@click.option("--run", "run_id", type=str, required=True, help="run id")
+@click.option("-o", "--out", "out_path", type=str, default=None, help="output file")
+@rewind_command_context
+def export_cmd(ctx, run_id, out_path):
+    from kungfu.rewind import export
+
+    try:
+        path = export.export_run(ctx.runtime_dir, run_id, out_path)
+    except (FileNotFoundError, ValueError) as e:
+        click.echo(f"[rewind] export failed: {e}", err=True)
+        sys.exit(1)
+    click.echo(f"[rewind] exported run {run_id} to {os.path.abspath(path)}")
+
+
+@rewind.command(
+    name="open",
+    help="open an exported run: extract it, verify the record self-describes, "
+    "and print the causal tree",
+)
+@click.argument("archive", type=str)
+@click.option(
+    "--dir",
+    "target_dir",
+    type=str,
+    default=None,
+    help="extract here (defaults to a fresh directory next to the archive)",
+)
+@rewind_command_context
+def open_cmd(ctx, archive, target_dir):
+    from kungfu.rewind import export, replay
+
+    target_dir = target_dir or (os.path.abspath(archive) + ".opened")
+    os.makedirs(target_dir, exist_ok=True)
+    try:
+        run_id, runtime_dir = export.open_export(archive, target_dir)
+        bundle_dir = os.path.join(runtime_dir, "rewind", run_id, "bundle")
+        frame_count, differences = replay.verify(runtime_dir, run_id, bundle_dir)
+    except (ValueError, KeyError, FileNotFoundError) as e:
+        click.echo(f"[rewind] open failed: {e}", err=True)
+        sys.exit(1)
+    if differences:
+        click.echo(
+            f"[rewind] open: record verification FAILED "
+            f"({len(differences)} difference(s))",
+            err=True,
+        )
+        sys.exit(1)
+    click.echo(
+        f"[rewind] opened run {run_id} at {runtime_dir} — {frame_count} frames verified"
+    )
+    click.echo(replay.render_tree(runtime_dir, run_id))
+    click.echo(
+        f"[rewind] inspect further: kungfu -H {os.path.dirname(runtime_dir)} "
+        f"rewind show --run {run_id}"
+    )

--- a/framework/core/src/python/kungfu/rewind/export.py
+++ b/framework/core/src/python/kungfu/rewind/export.py
@@ -1,0 +1,72 @@
+#  SPDX-License-Identifier: Apache-2.0
+#
+# Export a recorded run as one portable file, and open such a file anywhere —
+# offline, no services (gate G8). The export preserves the run's on-disk
+# layout (journal pages + the self-describing bundle), so an opened export is
+# a fully functional runtime home for that run: show, verify and the app all
+# work against it exactly as against the original.
+
+import json
+import os
+import zipfile
+
+import kungfu
+
+lf = kungfu.__binding__.longfist
+yjj = kungfu.__binding__.yijinjing
+
+EXPORT_META = "rewind-export.json"
+EXPORT_SUFFIX = ".rewind.zip"
+
+
+def _run_paths(runtime_dir, run_id):
+    journal_dir = os.path.join(runtime_dir, "journal", "system", "rewind", run_id)
+    bundle_dir = os.path.join(runtime_dir, "rewind", run_id)
+    return journal_dir, bundle_dir
+
+
+def export_run(runtime_dir, run_id, out_path=None):
+    """Zip one run's journal + bundle, layout-preserving. Returns the path."""
+    journal_dir, bundle_dir = _run_paths(runtime_dir, run_id)
+    if not os.path.isdir(journal_dir):
+        raise FileNotFoundError(f"run {run_id!r} has no journal under {runtime_dir}")
+    if not os.path.isdir(bundle_dir):
+        raise FileNotFoundError(f"run {run_id!r} has no bundle under {runtime_dir}")
+
+    out_path = out_path or (run_id + EXPORT_SUFFIX)
+    with zipfile.ZipFile(out_path, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr(
+            EXPORT_META,
+            json.dumps(
+                {
+                    "format": "kungfu-rewind-export",
+                    "format_version": 1,
+                    "run_id": run_id,
+                    "layout": "runtime/-rooted, open with -H on the extracted dir",
+                },
+                indent=2,
+            ),
+        )
+        for base in (journal_dir, bundle_dir):
+            for root, _, files in os.walk(base):
+                for name in files:
+                    full = os.path.join(root, name)
+                    arc = os.path.join("runtime", os.path.relpath(full, runtime_dir))
+                    zf.write(full, arc)
+    return out_path
+
+
+def open_export(archive_path, target_dir):
+    """Extract an export into target_dir; returns (run_id, runtime_dir)."""
+    with zipfile.ZipFile(archive_path) as zf:
+        meta_raw = zf.read(EXPORT_META)
+        meta = json.loads(meta_raw)
+        if meta.get("format") != "kungfu-rewind-export":
+            raise ValueError(f"{archive_path} is not a rewind export")
+        for info in zf.infolist():
+            # defensive extraction: stay inside target_dir
+            dest = os.path.realpath(os.path.join(target_dir, info.filename))
+            if not dest.startswith(os.path.realpath(target_dir) + os.sep):
+                raise ValueError(f"unsafe path in archive: {info.filename}")
+        zf.extractall(target_dir)
+    return meta["run_id"], os.path.join(target_dir, "runtime")

--- a/framework/core/src/python/kungfu/rewind/replay.py
+++ b/framework/core/src/python/kungfu/rewind/replay.py
@@ -182,6 +182,7 @@ def causal_tree(runtime_dir, run_id):
     spans = {}
     order = []
     run_facts = {}
+    pending_retry = {}
     for msg_type, header, payload in frames:
         name = MSG_TYPE_NAMES[msg_type]
         facts = decode_native(msg_type, payload)
@@ -190,8 +191,16 @@ def causal_tree(runtime_dir, run_id):
             run_facts[name] = facts
             continue
         span = facts.get("span_id")
-        if name in ("ModelRequest", "ToolCall", "RetryMarker"):
-            spans[span] = {"open": (name, facts), "close": None}
+        if name == "RetryMarker":
+            # a retry is an annotation on the attempt's span, not a node of
+            # its own — the hook gives it the same span_id as the attempt
+            pending_retry[span] = facts
+        elif name in ("ModelRequest", "ToolCall"):
+            spans[span] = {
+                "open": (name, facts),
+                "close": None,
+                "retry": pending_retry.pop(span, None),
+            }
             order.append(span)
         else:
             if span in spans:
@@ -222,10 +231,11 @@ def render_tree(runtime_dir, run_id):
         close = spans[span]["close"]
         if kind == "ModelRequest":
             head = f"model {facts.get('provider')}/{facts.get('model')}"
-        elif kind == "ToolCall":
-            head = f"tool {facts.get('tool_name')}"
         else:
-            head = f"retry attempt {facts.get('attempt')} of {facts.get('retry_of_span_id', '')[:8]}"
+            head = f"tool {facts.get('tool_name')}"
+        retry = spans[span].get("retry")
+        if retry:
+            head += f" (retry #{retry.get('attempt')})"
         if close:
             _, cf = close
             status = "ok" if cf.get("status") == 0 else "✗ error"

--- a/framework/gui/electron-builder.yml
+++ b/framework/gui/electron-builder.yml
@@ -13,5 +13,12 @@ extraResources:
   - from: ../core/dist/kfc
     to: kfc
 mac:
-  target: dir
+  # dir = the pack verb's unpacked app (fast, CI-friendly); dmg + zip = the
+  # dist verb's installable artifacts. Unsigned pre-release (identity: null):
+  # first launch needs right-click-Open or removing the quarantine attribute
+  # — documented in docs/rewind.md.
+  target:
+    - dir
+    - dmg
+    - zip
   identity: null

--- a/framework/gui/src/renderer/src/kfx/rewind-inspector.tsx
+++ b/framework/gui/src/renderer/src/kfx/rewind-inspector.tsx
@@ -38,22 +38,22 @@ function spanFailed(span: RewindSpan): boolean {
 }
 
 function spanLabel(span: RewindSpan): { head: string; color: string } {
-  const { open, close } = span;
+  const { open, close, retry } = span;
+  const suffix = retry ? ` (retry #${retry.attempt ?? '?'})` : '';
   if (open.kind === 'ModelRequest') {
     return {
-      head: `model ${open.provider ?? '?'}/${open.model ?? '?'}`,
+      head: `model ${open.provider ?? '?'}/${open.model ?? '?'}${suffix}`,
       color: close?.status === CallStatus.Error ? COLOR.error : COLOR.accent,
     };
   }
-  if (open.kind === 'ToolCall') {
-    return {
-      head: `tool ${open.toolName ?? '?'}`,
-      color: close?.status === CallStatus.Error ? COLOR.error : COLOR.ok,
-    };
-  }
   return {
-    head: `retry #${open.attempt ?? '?'}`,
-    color: COLOR.retry,
+    head: `tool ${open.toolName ?? '?'}${suffix}`,
+    color:
+      close?.status === CallStatus.Error
+        ? COLOR.error
+        : retry
+          ? COLOR.retry
+          : COLOR.ok,
   };
 }
 
@@ -242,10 +242,10 @@ function SpanDetail({ span }: { span: RewindSpan }) {
       {open.kind === 'ToolCall' ? (
         <Fact name="tool" value={open.toolName} />
       ) : null}
-      {open.kind === 'RetryMarker' ? (
+      {span.retry ? (
         <>
-          <Fact name="attempt" value={open.attempt} />
-          <Fact name="retry of" value={open.retryOfSpanId?.slice(0, 16)} />
+          <Fact name="retry attempt" value={span.retry.attempt} />
+          <Fact name="retry of" value={span.retry.retryOfSpanId?.slice(0, 16)} />
         </>
       ) : null}
       {close?.error ? (

--- a/tests/fixtures/rewind-demo-export/demo_agent.py
+++ b/tests/fixtures/rewind-demo-export/demo_agent.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Happy-path demo agent: a minimal "agent" making one model call the way an
+# SDK would — POST to $OPENAI_BASE_URL/chat/completions. It must not import
+# kungfu — the red line is that traced code needs no modification, so the
+# only contact surface is the environment the supervisor injects (run id and
+# the base url pointing at the model-wire proxy).
+
+import json
+import os
+import sys
+import urllib.request
+
+run_id = os.environ.get("KUNGFU_REWIND_RUN_ID")
+if not run_id:
+    print("KUNGFU_REWIND_RUN_ID missing from injected environment", file=sys.stderr)
+    sys.exit(1)
+
+base_url = os.environ.get("OPENAI_BASE_URL")
+if not base_url:
+    print("OPENAI_BASE_URL missing from injected environment", file=sys.stderr)
+    sys.exit(1)
+
+request = urllib.request.Request(
+    base_url.rstrip("/") + "/chat/completions",
+    data=json.dumps(
+        {
+            "model": "demo-model",
+            "messages": [{"role": "user", "content": "what is the demo answer?"}],
+        }
+    ).encode(),
+    headers={"Content-Type": "application/json"},
+    method="POST",
+)
+with urllib.request.urlopen(request, timeout=30) as response:
+    answer = json.load(response)
+
+content = answer["choices"][0]["message"]["content"]
+if content != "the demo answer":
+    print(f"unexpected model answer: {content}", file=sys.stderr)
+    sys.exit(1)
+
+# act on the model's answer with a tool, through the stand-in framework;
+# the first attempt fails to exercise the retry path
+import rewind_demo_toolkit
+
+_attempts = {"n": 0}
+
+
+def flaky_lookup(tool_input):
+    _attempts["n"] += 1
+    if _attempts["n"] == 1:
+        raise ValueError("transient lookup failure")
+    return {"answer": tool_input["query"].upper()}
+
+
+tool = rewind_demo_toolkit.Tool("lookup", flaky_lookup, retries=1)
+result = tool.run({"query": content})
+if result != {"answer": "THE DEMO ANSWER"}:
+    print(f"unexpected tool result: {result}", file=sys.stderr)
+    sys.exit(1)
+
+print(f"demo agent got model answer and tool result under traced run {run_id}")

--- a/tests/fixtures/rewind-demo-export/mock_model.py
+++ b/tests/fixtures/rewind-demo-export/mock_model.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Deterministic stand-in for a model provider: an openai-compatible chat
+# completions endpoint with fixed content and usage, so the fixture asserts
+# capture facts without network or keys.
+#
+# Usage: mock_model.py <port-file>   (binds an ephemeral port, writes it there)
+
+import http.server
+import json
+import sys
+
+CANNED = {
+    "id": "chatcmpl-fixture",
+    "object": "chat.completion",
+    "model": "demo-model",
+    "choices": [
+        {
+            "index": 0,
+            "message": {"role": "assistant", "content": "the demo answer"},
+            "finish_reason": "stop",
+        }
+    ],
+    "usage": {"prompt_tokens": 7, "completion_tokens": 3, "total_tokens": 10},
+}
+
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, format, *args):
+        pass
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", 0))
+        self.rfile.read(length)
+        body = json.dumps(CANNED).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+server = http.server.HTTPServer(("127.0.0.1", 0), Handler)
+with open(sys.argv[1], "w") as f:
+    f.write(str(server.server_address[1]))
+server.serve_forever()

--- a/tests/fixtures/rewind-demo-export/rewind_demo_toolkit.py
+++ b/tests/fixtures/rewind-demo-export/rewind_demo_toolkit.py
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# A miniature tool framework standing in for the third-party ones agents use.
+# It knows nothing about kungfu or tracing: the in-process adapter patches its
+# natural seams (Tool.run = the user-facing call, Tool._invoke = one attempt
+# inside the retry loop) from outside, exactly as adapters do for real
+# frameworks. Keeping it a capability probe, not a product.
+
+
+class Tool:
+    def __init__(self, name, fn, retries=0):
+        self.name = name
+        self.fn = fn
+        self.retries = retries
+
+    def _invoke(self, tool_input):
+        return self.fn(tool_input)
+
+    def run(self, tool_input):
+        attempts = self.retries + 1
+        for attempt in range(attempts):
+            try:
+                return self._invoke(tool_input)
+            except Exception:
+                if attempt == attempts - 1:
+                    raise

--- a/tests/fixtures/rewind-demo-export/run.sh
+++ b/tests/fixtures/rewind-demo-export/run.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+# SPDX-License-Identifier: Apache-2.0
+#
+# Export/open fixture (gate G8): a recorded run packs into one portable file
+# that re-opens ANYWHERE — proven the hard way: the original home is deleted
+# before the export is opened in a fresh location, and the opened copy must
+# still verify (two-path decode) and render the full causal tree. Offline,
+# no services.
+#
+# Usage: tests/fixtures/rewind-demo-export/run.sh
+
+set -eu
+fixture_dir="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+core_dir="$(CDPATH= cd -- "$fixture_dir/../../../framework/core" && pwd)"
+
+home="$(mktemp -d)"
+opened="$(mktemp -d)"
+run_id="fixtureexport$(date +%s)"
+
+port_file="$home/mock-port"
+# stdio-detached, killed by the trap — see rewind-demo-happy/run.sh for why
+python3 "$fixture_dir/mock_model.py" "$port_file" >/dev/null 2>&1 &
+mock_pid=$!
+trap 'kill "$mock_pid" 2>/dev/null; rm -rf "$home" "$opened"' EXIT
+while [ ! -s "$port_file" ]; do sleep 0.1; done
+OPENAI_BASE_URL="http://127.0.0.1:$(cat "$port_file")/v1"
+export OPENAI_BASE_URL
+
+DYLD_FALLBACK_LIBRARY_PATH="$core_dir/dist/kfc${DYLD_FALLBACK_LIBRARY_PATH:+:$DYLD_FALLBACK_LIBRARY_PATH}"
+export DYLD_FALLBACK_LIBRARY_PATH
+
+cd "$core_dir"
+kfc() { uv run --frozen python .devtools/kfc.py "$@"; }
+
+kfc -H "$home" trace --run-id "$run_id" -- python3 "$fixture_dir/demo_agent.py"
+
+archive="$opened/$run_id.rewind.zip"
+kfc -H "$home" rewind export --run "$run_id" -o "$archive"
+[ -s "$archive" ] || { echo "FAIL: export produced no archive"; exit 1; }
+echo "ok  export produced $(wc -c < "$archive" | tr -d ' ') bytes"
+
+# the hard part: the original home disappears entirely
+rm -rf "$home/runtime"
+echo "ok  original home deleted"
+
+out="$(kfc -H "$opened" rewind open "$archive" --dir "$opened/reopened")"
+printf '%s\n' "$out"
+printf '%s' "$out" | grep -q "frames verified"        || { echo "FAIL: opened export did not verify"; exit 1; }
+printf '%s' "$out" | grep -q "tool lookup"             || { echo "FAIL: tree missing tool node"; exit 1; }
+printf '%s' "$out" | grep -q "model openai/demo-model" || { echo "FAIL: tree missing model node"; exit 1; }
+printf '%s' "$out" | grep -q "(retry #2)"         || { echo "FAIL: tree missing retry annotation"; exit 1; }
+echo "ok  opened export verifies and renders the full tree"
+
+echo "export/open check passed"


### PR DESCRIPTION
## What

The distribution face — gates **G8 (export bundle)** and **G1 (installers, macOS arm64 first)**:

- **`rewind export --run <id>`** → one portable `.rewind.zip` (journal pages + the self-describing bundle, layout-preserving). **`rewind open <file>`** extracts anywhere, runs the same two-path verification as a local run before showing anything, prints the causal tree, and leaves a fully functional home behind. Offline, no services.
- **`rewind-demo-export` fixture** proves it the hard way: capture → export → **delete the original home** → open in a fresh location → verify green + full tree (retry annotation included). Auto-discovered by `verify --full`.
- **Installable app**: electron-builder targets grow `dmg` + `zip` (pack verb unchanged). Validated end to end: `dist` produced the dmg, it was mounted, `Kungfu.app` copied out (simulated install) and launched from the installed copy against a captured home — binding loads (20 exports), Rewind inspector renders identically to the workspace build. Unsigned pre-release; quarantine note documented. Linux/Windows + signing stay with the release pipeline (documented as the next gate).
- **Tree-builder bug fixed in both surfaces**: a RetryMarker shares its span_id with the attempt that follows it; both the CLI and GUI tree builders opened a span for it, which the ToolCall then overwrote in place — node rendered twice, retry edge lost. Retries are now annotations on the attempt's span: `(retry #2)` in the CLI, retry-tinted label + detail facts in the app.
- Docs: install section covers the dmg path; export/open section added; the on-disk journal path corrected to the real layout (`journal/system/rewind/<run-id>`).

## Validation

- All six rewind fixtures green (new export fixture: verify-after-delete + tree assertions).
- api tsc clean, gui lint/build clean, ruff format clean.
- dmg install → standalone launch → inspector renders: verified on darwin-arm64.

## Notes

Installer size is hefty (~1.25GB dmg) — the frozen kfc runtime ships inside. Size optimization is real follow-up work but not a gate for the pre-release window.