### PR TITLE
feat(rewind): capture an unmodified LangChain agent via the adapter table

### DIFF
--- a/docs/rewind.md
+++ b/docs/rewind.md
@@ -65,7 +65,11 @@ uv run --frozen python .devtools/kfc.py -H <home-dir> \
 - Tool calls, results, errors and retries are captured in-process by hooks
   injected through `PYTHONPATH` (python) and `NODE_OPTIONS` (node). A process
   spawned inside a tool inherits its causal parent — one chain, across
-  runtimes, in one journal.
+  runtimes, in one journal. The hook carries an adapter table that patches a
+  framework's tool seam once it imports — **LangChain is captured unmodified**
+  (its `BaseTool.run` seam, covering `.invoke` / `.ainvoke` / agent tool
+  nodes); the demo toolkit stands in for frameworks the table does not yet
+  know.
 - A run writes two things under `<home-dir>/runtime`: the journal itself
   (under `journal/system/rewind/<run-id>/` — the recorded frames) and the
   trace bundle (under `rewind/<run-id>/bundle/` — the schema blob + manifest
@@ -179,5 +183,8 @@ Each runs standalone: `tests/fixtures/<name>/run.sh`.
   token/usage facts.
 - Replay is forensic (re-open, walk, verify); deterministic re-execution is a
   later differentiator gate.
-- Framework auto-instrumentation ships with the demo toolkit adapter;
-  real-framework adapters (LangChain et al.) grow in the same adapter table.
+- Framework auto-instrumentation ships with a real LangChain adapter (and the
+  demo toolkit for the seam shape); further frameworks grow in the same adapter
+  table. The LangChain adapter wraps the synchronous `BaseTool.run` funnel,
+  which also carries `.invoke` and `.ainvoke` for ordinary tools; a tool whose
+  execution runs *only* through the async `_arun` path is not yet covered.

--- a/framework/core/src/python/kungfu/rewind/hook/rewind_client.py
+++ b/framework/core/src/python/kungfu/rewind/hook/rewind_client.py
@@ -200,8 +200,41 @@ def _patch_demo_toolkit(module):
     module.Tool._invoke = traced_invoke
 
 
+def _patch_langchain(module):
+    # LangChain's tool seam: every tool execution — whether an agent's tool
+    # node calls `tool.invoke(...)`, `tool.ainvoke(...)`, or user code calls
+    # `tool.run(...)` — funnels through `BaseTool.run`. `invoke`/`ainvoke`
+    # dispatch to it, and the async path runs the sync `run` in an executor,
+    # so wrapping this one method captures the whole tool call (including the
+    # subclass `_run` beneath it) as a single span across sync and async
+    # agents. The model turns that drive these calls are captured upstream at
+    # the wire proxy, so the in-process adapter only owns tool semantics.
+    base_tool = getattr(module, "BaseTool", None)
+    if base_tool is None or getattr(base_tool, "_kungfu_rewind_patched", False):
+        return
+    original_run = base_tool.run
+
+    def traced_run(self, *args, **kwargs):
+        tool_input = args[0] if args else kwargs.get("tool_input")
+        name = getattr(self, "name", None) or type(self).__name__
+        # root under the ambient span so a langchain tool invoked inside an
+        # outer captured span (including across a runtime boundary) nests
+        capture = _CallCapture(name, parent_span_id=os.environ.get(ENV_PARENT_SPAN))
+        return capture.run(
+            lambda: original_run(self, *args, **kwargs), _render(tool_input)
+        )
+
+    base_tool.run = traced_run
+    base_tool._kungfu_rewind_patched = True
+
+
 ADAPTERS = {
     "rewind_demo_toolkit": _patch_demo_toolkit,
+    # BaseTool lives in `langchain_core.tools.base`; older layouts exposed it
+    # from the `langchain_core.tools` package itself. Register both — the
+    # patcher no-ops when BaseTool is absent or already wrapped.
+    "langchain_core.tools.base": _patch_langchain,
+    "langchain_core.tools": _patch_langchain,
 }
 
 

--- a/tests/fixtures/rewind-demo-langchain/.gitignore
+++ b/tests/fixtures/rewind-demo-langchain/.gitignore
@@ -1,0 +1,2 @@
+# provisioned on demand by run.sh; the real framework install, not source
+.venv-langchain/

--- a/tests/fixtures/rewind-demo-langchain/check_capture.py
+++ b/tests/fixtures/rewind-demo-langchain/check_capture.py
@@ -1,0 +1,215 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Capture assertions for the real-LangChain fixture. Proves that an unmodified
+# third-party agent framework, run once under `kungfu trace`, lands a complete
+# fact set in ONE journal: both model turns captured at the wire, the tool call
+# captured in-process by the adapter, and the tool causally bracketed between
+# the turns. Runs inside the dev kfc environment (needs pykungfu).
+#
+# Honest scope: this is a single-runtime run, so it upgrades the *zero-code-
+# change real-framework capture* leg of the moat from the toy toolkit to a real
+# framework. Cross-runtime causal edges and replay double-path are proved by
+# their own fixtures; this one does not restate those claims.
+#
+# Usage: check_capture.py <runtime-dir> <run-id>
+
+import hashlib
+import json
+import os
+import sys
+
+_core = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "..", "framework", "core")
+)
+sys.path.insert(0, os.path.join(_core, "src", "python"))
+sys.path.insert(0, os.path.join(_core, "dist", "kfc"))
+
+import kungfu
+
+from kungfu.rewind import (
+    MSG_MODEL_REQUEST,
+    MSG_MODEL_RESPONSE,
+    MSG_RETRY_MARKER,
+    MSG_RUN_BEGIN,
+    MSG_RUN_END,
+    MSG_TOOL_CALL,
+    MSG_TOOL_RESULT,
+    MSG_TYPE_NAMES,
+)
+from kungfu.rewind.fb.CallStatus import CallStatus
+from kungfu.rewind.fb.CaptureLayer import CaptureLayer
+from kungfu.rewind.fb.ModelRequest import ModelRequest
+from kungfu.rewind.fb.ModelResponse import ModelResponse
+from kungfu.rewind.fb.RunBegin import RunBegin
+from kungfu.rewind.fb.RunEnd import RunEnd
+from kungfu.rewind.fb.ToolCall import ToolCall
+from kungfu.rewind.fb.ToolResult import ToolResult
+
+lf = kungfu.__binding__.longfist
+yjj = kungfu.__binding__.yijinjing
+
+runtime_dir, run_id = sys.argv[1], sys.argv[2]
+failures = []
+
+
+def check(name, ok, detail=""):
+    print(f"  {'ok' if ok else 'FAIL'}  {name}{': ' + detail if detail else ''}")
+    if not ok:
+        failures.append(name)
+
+
+locator = yjj.locator(runtime_dir)
+location = yjj.location(
+    lf.enums.mode.LIVE, lf.enums.category.SYSTEM, "rewind", run_id, locator
+)
+
+
+def frames(msg_type):
+    return yjj.assemble(location, 0).read_bytes(msg_type)
+
+
+# ── run bracket ──────────────────────────────────────────────────────
+begin_frames = frames(MSG_RUN_BEGIN)
+check("RunBegin frame present", len(begin_frames) == 1)
+if begin_frames:
+    header, payload = begin_frames[0]
+    begin = RunBegin.GetRootAs(bytes(payload), 0)
+    check("RunBegin.run_id matches", (begin.RunId() or b"").decode() == run_id)
+    check("RunBegin.gen_time set", header.gen_time > 0)
+
+# ── model turns, captured at the wire (framework-agnostic) ───────────
+req_frames = frames(MSG_MODEL_REQUEST)
+check("two ModelRequest frames (tool-call turn + final turn)", len(req_frames) == 2)
+req_spans = []
+req_times = []
+for hdr, payload in req_frames:
+    req = ModelRequest.GetRootAs(bytes(payload), 0)
+    req_spans.append((req.SpanId() or b"").decode())
+    req_times.append(hdr.gen_time)
+    check("ModelRequest.run_id matches", (req.RunId() or b"").decode() == run_id)
+    check("ModelRequest.layer == ModelWire", req.Layer() == CaptureLayer.ModelWire)
+    check(
+        "ModelRequest.provider == openai", (req.Provider() or b"").decode() == "openai"
+    )
+    check(
+        "ModelRequest.model == fixture-model",
+        (req.Model() or b"").decode() == "fixture-model",
+    )
+    body = json.loads((req.RequestBody() or b"{}").decode())
+    check("ModelRequest.request_body has messages", bool(body.get("messages")))
+
+resp_frames = frames(MSG_MODEL_RESPONSE)
+check("two ModelResponse frames", len(resp_frames) == 2)
+finish_reasons = []
+resp_spans = []
+resp_times = []
+for hdr, payload in resp_frames:
+    resp = ModelResponse.GetRootAs(bytes(payload), 0)
+    resp_spans.append((resp.SpanId() or b"").decode())
+    resp_times.append(hdr.gen_time)
+    finish_reasons.append((resp.FinishReason() or b"").decode())
+    check("ModelResponse.status == Ok", resp.Status() == CallStatus.Ok)
+    check("ModelResponse.latency_ns > 0", resp.LatencyNs() > 0)
+    check(
+        "ModelResponse.tokens captured",
+        resp.InputTokens() > 0 and resp.OutputTokens() > 0,
+    )
+check(
+    "model turns are a tool-call turn then a stop turn",
+    sorted(finish_reasons) == ["stop", "tool_calls"],
+    ",".join(finish_reasons),
+)
+check(
+    "each ModelResponse correlates to a ModelRequest",
+    set(resp_spans) == set(req_spans) and len(set(resp_spans)) == 2,
+)
+
+# ── the tool call, captured in-process by the adapter (zero code change) ─
+call_frames = frames(MSG_TOOL_CALL)
+check("one ToolCall frame from the real BaseTool seam", len(call_frames) == 1)
+call_span = None
+call_time = None
+if call_frames:
+    hdr, payload = call_frames[0]
+    call = ToolCall.GetRootAs(bytes(payload), 0)
+    call_span = (call.SpanId() or b"").decode()
+    call_time = hdr.gen_time
+    check("ToolCall.run_id matches", (call.RunId() or b"").decode() == run_id)
+    check(
+        "ToolCall.layer == InProcessHook", call.Layer() == CaptureLayer.InProcessHook
+    )
+    check("ToolCall.tool_name == lookup", (call.ToolName() or b"").decode() == "lookup")
+    check(
+        "ToolCall.input carries the model's tool args",
+        "kungfu rewind" in (call.Input() or b"").decode(),
+    )
+
+result_frames = frames(MSG_TOOL_RESULT)
+check("one ToolResult frame", len(result_frames) == 1)
+if result_frames:
+    _, payload = result_frames[0]
+    result = ToolResult.GetRootAs(bytes(payload), 0)
+    check("ToolResult.status == Ok", result.Status() == CallStatus.Ok)
+    check("ToolResult.latency_ns > 0", result.LatencyNs() > 0)
+    check(
+        "ToolResult correlates to the ToolCall span",
+        (result.SpanId() or b"").decode() == call_span,
+    )
+    check(
+        "ToolResult carries the tool's output",
+        "KUNGFU REWIND" in (result.Output() or b"").decode(),
+    )
+
+# retries are not fabricated: a real agent loop's re-calls would be distinct
+# tool spans, and this happy run has none
+check("no RetryMarker fabricated for the real run", len(frames(MSG_RETRY_MARKER)) == 0)
+
+# ── one journal, one causal timeline ─────────────────────────────────
+# the tool call must sit between the model turn that requested it and the turn
+# that consumed its result — the real agent's causal story, in event time
+if call_time is not None and len(req_times) == 2 and len(resp_times) == 2:
+    first_turn_end = min(resp_times)
+    last_turn_start = max(req_times)
+    check(
+        "tool call is bracketed by the two model turns",
+        first_turn_end <= call_time <= last_turn_start,
+        f"resp0={first_turn_end} call={call_time} req1={last_turn_start}",
+    )
+
+end_frames = frames(MSG_RUN_END)
+check("RunEnd frame present", len(end_frames) == 1)
+if end_frames:
+    _, payload = end_frames[0]
+    end = RunEnd.GetRootAs(bytes(payload), 0)
+    check("RunEnd.run_id matches", (end.RunId() or b"").decode() == run_id)
+    check("RunEnd.exit_code == 0", end.ExitCode() == 0)
+
+# ── self-describing bundle (decode without the writer) ───────────────
+bundle_dir = os.path.join(runtime_dir, "rewind", run_id, "bundle")
+manifest_path = os.path.join(bundle_dir, "manifest.json")
+check("bundle manifest exists", os.path.exists(manifest_path), manifest_path)
+if os.path.exists(manifest_path):
+    with open(manifest_path) as f:
+        manifest = json.load(f)
+    bindings = manifest.get("schema_bindings", {})
+    check(
+        "all rewind msg_types bound",
+        set(bindings.keys()) == {str(t) for t in MSG_TYPE_NAMES},
+    )
+    hashes = {b["schema_hash"] for b in bindings.values()}
+    check("single schema hash across bindings", len(hashes) == 1)
+    if len(hashes) == 1:
+        schema_hash = hashes.pop()
+        blob_path = os.path.join(bundle_dir, "schemas", schema_hash + ".bfbs")
+        check("schema blob exists", os.path.exists(blob_path))
+        if os.path.exists(blob_path):
+            with open(blob_path, "rb") as f:
+                check(
+                    "schema blob content-addressed",
+                    hashlib.sha256(f.read()).hexdigest() == schema_hash,
+                )
+
+if failures:
+    print(f"capture check failed: {failures}")
+    sys.exit(1)
+print("capture check passed")

--- a/tests/fixtures/rewind-demo-langchain/langchain_agent.py
+++ b/tests/fixtures/rewind-demo-langchain/langchain_agent.py
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# A real LangChain agent — not a stand-in toolkit. It builds a tool-calling
+# agent with `langchain.agents.create_agent` (the langgraph runtime) and a
+# `ChatOpenAI` model, then runs one turn that calls a tool and answers.
+#
+# The red line holds exactly as for the toy: this file must not import kungfu.
+# Capture happens entirely through the environment the supervisor injects —
+# the model-wire base url (ChatOpenAI honours OPENAI_BASE_URL) carries the
+# model turns to the proxy, and the in-process adapter patches LangChain's
+# `BaseTool.run` seam once `langchain_core.tools.base` imports. Proving the
+# capture on a genuine third-party framework, run unmodified, is the whole
+# point of this fixture.
+
+import os
+import sys
+
+run_id = os.environ.get("KUNGFU_REWIND_RUN_ID")
+if not run_id:
+    print("KUNGFU_REWIND_RUN_ID missing from injected environment", file=sys.stderr)
+    sys.exit(1)
+
+if not os.environ.get("OPENAI_BASE_URL"):
+    print("OPENAI_BASE_URL missing from injected environment", file=sys.stderr)
+    sys.exit(1)
+
+from langchain.agents import create_agent
+from langchain_core.tools import tool
+from langchain_openai import ChatOpenAI
+
+
+@tool
+def lookup(query: str) -> str:
+    """Look up a term and return its normalized (uppercase) form."""
+    return query.upper()
+
+
+# temperature omitted / model name is whatever the mock echoes; the mock is
+# deterministic, so the run is reproducible without a real provider or key
+model = ChatOpenAI(model="fixture-model", temperature=0)
+agent = create_agent(model, [lookup])
+
+result = agent.invoke(
+    {"messages": [{"role": "user", "content": "normalize the term kungfu rewind"}]}
+)
+
+final = result["messages"][-1].content
+if "done" not in final.lower():
+    print(f"unexpected final answer from real langchain agent: {final!r}", file=sys.stderr)
+    sys.exit(1)
+
+print(f"real langchain agent ran a tool and answered under traced run {run_id}")

--- a/tests/fixtures/rewind-demo-langchain/mock_model.py
+++ b/tests/fixtures/rewind-demo-langchain/mock_model.py
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Deterministic stand-in for an OpenAI-compatible provider, sized for a real
+# LangChain tool-calling agent. Two turns:
+#   1. the first request (no tool result yet) -> a tool_call for `lookup`;
+#   2. the follow-up request (carrying the tool's result) -> a final answer.
+# Branching on the presence of a tool-role message, not a call counter, keeps
+# it robust to health checks or reordering at the proxy.
+#
+# Usage: mock_model.py <port-file>   (binds an ephemeral port, writes it there)
+
+import http.server
+import json
+import sys
+
+TOOL_CALL_TURN = {
+    "id": "chatcmpl-fixture-1",
+    "object": "chat.completion",
+    "model": "fixture-model",
+    "choices": [
+        {
+            "index": 0,
+            "message": {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_lookup_1",
+                        "type": "function",
+                        "function": {
+                            "name": "lookup",
+                            "arguments": json.dumps({"query": "kungfu rewind"}),
+                        },
+                    }
+                ],
+            },
+            "finish_reason": "tool_calls",
+        }
+    ],
+    "usage": {"prompt_tokens": 11, "completion_tokens": 5, "total_tokens": 16},
+}
+
+FINAL_TURN = {
+    "id": "chatcmpl-fixture-2",
+    "object": "chat.completion",
+    "model": "fixture-model",
+    "choices": [
+        {
+            "index": 0,
+            "message": {"role": "assistant", "content": "done: KUNGFU REWIND"},
+            "finish_reason": "stop",
+        }
+    ],
+    "usage": {"prompt_tokens": 19, "completion_tokens": 4, "total_tokens": 23},
+}
+
+
+def _has_tool_result(body):
+    try:
+        messages = json.loads(body).get("messages", [])
+    except (ValueError, AttributeError):
+        return False
+    return any(m.get("role") == "tool" for m in messages)
+
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, format, *args):
+        pass
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", 0))
+        raw = self.rfile.read(length) if length else b""
+        turn = FINAL_TURN if _has_tool_result(raw) else TOOL_CALL_TURN
+        body = json.dumps(turn).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+server = http.server.HTTPServer(("127.0.0.1", 0), Handler)
+with open(sys.argv[1], "w") as f:
+    f.write(str(server.server_address[1]))
+server.serve_forever()

--- a/tests/fixtures/rewind-demo-langchain/requirements.txt
+++ b/tests/fixtures/rewind-demo-langchain/requirements.txt
@@ -1,0 +1,5 @@
+# Real third-party agent framework this fixture captures, unmodified.
+# Pinned to the versions the adapter was validated against; the two top-level
+# packages resolve langchain-core, langgraph and the openai SDK transitively.
+langchain==1.3.11
+langchain-openai==1.3.3

--- a/tests/fixtures/rewind-demo-langchain/run.sh
+++ b/tests/fixtures/rewind-demo-langchain/run.sh
@@ -1,0 +1,66 @@
+#!/bin/sh
+# SPDX-License-Identifier: Apache-2.0
+#
+# Real-framework capture fixture (Rewind next-falsification main item): one
+# command wraps an *unmodified* LangChain agent — the langgraph `create_agent`
+# runtime with a `ChatOpenAI` model and a real `BaseTool` — and produces a
+# local run store whose journal carries the model turns (wire proxy) and the
+# tool call (in-process adapter patching `BaseTool.run`). Asserted by
+# check_capture.py. This replaces the toy toolkit as the moat evidence for
+# zero-code-change capture: the toy proved the mechanism, this proves it on a
+# framework kungfu does not control.
+#
+# The real framework is provisioned into a cached, git-ignored venv. The gate
+# genuinely requires it: if langchain cannot be provisioned this fixture FAILS
+# loudly rather than silently passing — a real-framework claim must be backed
+# by a real framework.
+#
+# Usage: tests/fixtures/rewind-demo-langchain/run.sh
+#   Requires the core dev environment (built dist/kfc) and network on first run
+#   to install langchain; the run itself uses a deterministic mock model.
+
+set -eu
+fixture_dir="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+core_dir="$(CDPATH= cd -- "$fixture_dir/../../../framework/core" && pwd)"
+
+# ── provision the real framework (cached across runs) ────────────────
+venv="$fixture_dir/.venv-langchain"
+agent_py="$venv/bin/python"
+if ! "$agent_py" -c "import langchain, langchain_openai" >/dev/null 2>&1; then
+  echo "[langchain-fixture] provisioning real langchain venv (first run)…"
+  uv venv "$venv" --python 3.13 >/dev/null
+  VIRTUAL_ENV="$venv" uv pip install -q -r "$fixture_dir/requirements.txt"
+fi
+if ! "$agent_py" -c "import langchain, langchain_openai" >/dev/null 2>&1; then
+  echo "[langchain-fixture] FAIL: real langchain framework unavailable" >&2
+  exit 1
+fi
+
+home="$(mktemp -d)"
+run_id="fixturelangchain$(date +%s)"
+
+# deterministic model upstream: the mock (stdlib only, system python3) binds an
+# ephemeral port and reports it; the supervisor picks it up as the openai
+# forward target and points the child's ChatOpenAI at its own proxy.
+port_file="$home/mock-port"
+python3 "$fixture_dir/mock_model.py" "$port_file" >/dev/null 2>&1 &
+mock_pid=$!
+trap 'kill "$mock_pid" 2>/dev/null; rm -rf "$home"' EXIT
+while [ ! -s "$port_file" ]; do sleep 0.1; done
+OPENAI_BASE_URL="http://127.0.0.1:$(cat "$port_file")/v1"
+export OPENAI_BASE_URL
+# the openai SDK refuses to construct a client without a key; the proxy never
+# forwards request headers, so this dummy never leaves the machine
+OPENAI_API_KEY="sk-langchain-fixture"
+export OPENAI_API_KEY
+
+# Dev-python import of pykungfu (supervisor + check side): dyld fallback to the
+# dist dir when the interpreter is uv's python rather than the frozen kfc.
+DYLD_FALLBACK_LIBRARY_PATH="$core_dir/dist/kfc${DYLD_FALLBACK_LIBRARY_PATH:+:$DYLD_FALLBACK_LIBRARY_PATH}"
+export DYLD_FALLBACK_LIBRARY_PATH
+
+cd "$core_dir"
+uv run --frozen python .devtools/kfc.py -H "$home" trace --run-id "$run_id" -- \
+  "$agent_py" "$fixture_dir/langchain_agent.py"
+
+uv run --frozen python "$fixture_dir/check_capture.py" "$home/runtime" "$run_id"


### PR DESCRIPTION
Add a LangChain adapter to the in-process capture hook's adapter table: patch BaseTool.run once langchain_core.tools imports, so a real create_agent (langgraph) run's tool calls land in the journal with zero code change. Model turns are already captured at the wire proxy. A new rewind-demo-langchain fixture runs a genuine langchain agent against a deterministic mock model and asserts the full fact set in one journal (both model turns, the tool call from the real seam, causal bracketing); verify's double-path decode holds on the real run and verify --full picks the fixture up automatically.