### PR TITLE
Extension devkit: scaffold, docs and fixture for view kfx

### DIFF
--- a/developer/sdk/README.md
+++ b/developer/sdk/README.md
@@ -17,9 +17,21 @@ pnpm install
 pnpm dev                       # launch against a built @kungfu-tech/core
 ```
 
-Options:
+It also scaffolds view extensions (kfx) — installable view packages the
+reference shell discovers and mounts (see `docs/extensions.md` in the
+repository root for the contract):
 
-- `--name <name>` — product name (defaults to the directory basename).
+```sh
+kfs create extension my-view   # scaffold into ./my-view
+cd my-view
+pnpm install
+pnpm build                     # kfs kfx build → dist/view/index.js
+npm pack                       # the tgz installs via `kungfu kfx install`
+```
+
+Options (both `create` targets):
+
+- `--name <name>` — product/view name (defaults to the directory basename).
 - `--workspace` — wire platform dependencies as `workspace:*` when
   scaffolding inside the monorepo.
 

--- a/developer/sdk/src/kfs.js
+++ b/developer/sdk/src/kfs.js
@@ -20,13 +20,16 @@ function usage(code) {
   process.stdout.write(
     [
       'usage: kfs create app <directory> [options]',
+      '       kfs create extension <directory> [options]',
       '       kfs kfx build | clean',
       '',
-      'create app options:',
-      '  --name <name>   product name (defaults to the directory basename)',
+      'create options:',
+      '  --name <name>   product/view name (defaults to the directory basename)',
       '  --workspace     wire platform deps as workspace:* (inside the monorepo)',
       '',
-      'kfx commands run inside a view extension package (a package.json with',
+      'create extension scaffolds a view extension package (kfx): src/view/',
+      'exports the View component, package.json carries the kungfuConfig',
+      'manifest. kfx commands run inside such a package (a package.json with',
       'kungfuConfig.config.view); build bundles src/view/ to dist/view/index.js',
       'with react and the capability SDK left external — the shell injects',
       'its own instances at load time.',
@@ -116,6 +119,33 @@ function createApp(directory, options) {
   );
 }
 
+function createExtension(directory, options) {
+  if (!directory) usage(1);
+  const targetDir = path.resolve(directory);
+  if (fs.existsSync(targetDir) && fs.readdirSync(targetDir).length > 0) {
+    fail(`target directory is not empty: ${targetDir}`);
+  }
+  const extName = options.name || path.basename(targetDir);
+  const extKey = extName.toLowerCase().replace(/[^a-z0-9]+/g, '-');
+  scaffold('extension', targetDir, {
+    __EXT_NAME__: extName,
+    __EXT_KEY__: extKey,
+    __KF_DEP_VERSION__: options.workspace ? 'workspace:*' : '^4.0.0-alpha.0',
+  });
+  process.stdout.write(
+    [
+      `created ${extName} at ${targetDir}`,
+      '',
+      'next steps:',
+      `  cd ${directory}`,
+      '  pnpm install   # or npm/yarn',
+      '  pnpm build     # kfs kfx build -> dist/view/index.js',
+      '  npm pack       # the tgz is the install unit: kungfu kfx install <tgz>',
+      '',
+    ].join('\n'),
+  );
+}
+
 // ── kfx view extension build ──────────────────────────────────────────────
 // Modules that stay external and are injected by the shell at load time; a
 // view extension must never ship its own copy of these.
@@ -172,8 +202,9 @@ const [command, kind, directory] = positional;
 
 if (!command) usage(1);
 if (command === 'create') {
-  if (kind !== 'app') fail(`unknown target: ${kind} (supported: app)`);
-  createApp(directory, options);
+  if (kind === 'app') createApp(directory, options);
+  else if (kind === 'extension') createExtension(directory, options);
+  else fail(`unknown target: ${kind} (supported: app, extension)`);
 } else if (command === 'kfx') {
   if (kind === 'build') await kfxBuild();
   else if (kind === 'clean') kfxClean();

--- a/developer/sdk/templates/extension/README.md.tmpl
+++ b/developer/sdk/templates/extension/README.md.tmpl
@@ -1,0 +1,25 @@
+# __EXT_NAME__
+
+A Kungfu view extension (kfx). One package, one view: `src/view/index.tsx`
+exports the `View` component; everything static about it lives in
+`package.json` under `kungfuConfig`.
+
+## Develop
+
+```sh
+pnpm install
+pnpm build       # kfs kfx build → dist/view/index.js
+```
+
+## Distribute
+
+```sh
+npm pack                          # the tgz is the complete install unit
+kungfu kfx install <tgz>          # extracts into <home>/extensions/__EXT_KEY__
+kungfu kfx list
+kungfu kfx remove __EXT_KEY__
+```
+
+See `docs/extensions.md` in the kungfu repository for the full contract:
+manifest fields, the build externals, discovery roots and the install
+lifecycle.

--- a/developer/sdk/templates/extension/_gitignore
+++ b/developer/sdk/templates/extension/_gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+*.tgz

--- a/developer/sdk/templates/extension/package.json.tmpl
+++ b/developer/sdk/templates/extension/package.json.tmpl
@@ -1,0 +1,36 @@
+{
+  "name": "__EXT_KEY__",
+  "version": "0.1.0",
+  "description": "__EXT_NAME__ — a Kungfu view extension",
+  "main": "package.json",
+  "files": [
+    "dist",
+    "package.json",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "kfs kfx build",
+    "clean": "kfs kfx clean"
+  },
+  "dependencies": {
+    "@kungfu-tech/api": "__KF_DEP_VERSION__",
+    "@kungfu-tech/kfx": "__KF_DEP_VERSION__"
+  },
+  "devDependencies": {
+    "@kungfu-tech/sdk": "__KF_DEP_VERSION__",
+    "@types/react": "^18.3.3"
+  },
+  "peerDependencies": {
+    "react": "^18.3.1"
+  },
+  "kungfuConfig": {
+    "key": "__EXT_KEY__",
+    "name": "__EXT_NAME__",
+    "config": {
+      "view": {
+        "title": "__EXT_NAME__",
+        "capabilities": []
+      }
+    }
+  }
+}

--- a/developer/sdk/templates/extension/src/view/index.tsx
+++ b/developer/sdk/templates/extension/src/view/index.tsx
@@ -1,0 +1,22 @@
+// __EXT_NAME__ — a Kungfu view extension.
+//
+// The bundle exports exactly one thing: the View component. Everything
+// static about the view (title, capability handles, settings) lives in
+// package.json under `kungfuConfig.config.view`; the shell reads it without
+// executing code, and at load time injects the declared capability handles
+// plus its own react instance. Declare capabilities in the manifest and they
+// arrive here as `caps.<name>`.
+import type { KfxViewProps } from '@kungfu-tech/kfx';
+import { headingStyle, mono, panelStyle } from '@kungfu-tech/kfx';
+
+export function View({ shell }: KfxViewProps) {
+  return (
+    <div style={panelStyle}>
+      <h2 style={headingStyle}>__EXT_NAME__</h2>
+      <div style={mono}>
+        runtime {shell.info.kfcVersion || 'n/a'} · profile{' '}
+        {shell.state.profileId}
+      </div>
+    </div>
+  );
+}

--- a/docs/MAP.md
+++ b/docs/MAP.md
@@ -39,7 +39,7 @@ and the map routes a question to whichever doc answers it.
 | What gates must a release pass? | `provenance.md` + [`version-release-design.md`](version-release-design.md) | verify | partial |
 | If kungfu itself misbehaves, how do I localize it? | [`debugging.md`](debugging.md) | verify | stable |
 | How do I record an agent run and find why it failed (Rewind)? | [`rewind.md`](rewind.md) | use | stable · pre-release install path |
-| How do I write an extension (`kfx`)? | `extensions.md` (+ [`../examples/`](../examples)) | use | to write · examples exist |
+| How do I write an extension (`kfx`)? | [`extensions.md`](extensions.md) | use | stable · view kfx; runtime facets mid-migration |
 
 ## Also asking about
 
@@ -59,8 +59,8 @@ route to the row that answers them:
   ([`event-model.md`](event-model.md)).
 - **how do I run it / get started / install** → *source to a binary*
   ([`buildchain.md`](buildchain.md)) and [`../CONTRIBUTING.md`](../CONTRIBUTING.md).
-  (A one-command run-it path is planned — see `extensions.md` status and the
-  build/release work tracked in [`known-limits.md`](known-limits.md).)
+  (A one-command run-it path is planned — see the build/release work tracked
+  in [`known-limits.md`](known-limits.md).)
 - **N-API / pybind11 / bindings / FFI** → *adapter boundaries*
   ([`adapters.md`](adapters.md)).
 - **signature / checksum / supply chain / SBOM** → *verify a release binary*

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -1,0 +1,155 @@
+# Extensions (kfx)
+
+How to write, build and install a kungfu extension. This is the
+developer-facing page (*use* plane); the internal shell/kfx contract note is
+[`../framework/gui/docs/shell-and-kfx.md`](../framework/gui/docs/shell-and-kfx.md).
+Per claim, this page says where to verify it; the fixtures named at the
+bottom are the machine-checked proof.
+
+Three words carry the model — keep them apart:
+
+- **facet** — what a package *does*, declared under `kungfuConfig.config`.
+  The shipped facet today is `view` (a GUI screen); runtime facets (trading
+  adapters, operators) exist as earlier-generation examples and are
+  mid-migration (see [status](#runtime-extensions-current-status)).
+- **package (kfx)** — the unit of development and distribution: an npm
+  package whose `package.json` carries a `kungfuConfig` manifest. `npm pack`
+  of a built package is its complete, offline install unit.
+- **suite** — a group of kfx distributed and operated together (navigation
+  grouping, enable/disable as a unit, lockstep versioning). Membership is
+  npm `dependencies`; the manifest lists member keys.
+
+The word *bundle* is reserved for the self-describing trace/export package
+(see [`rewind.md`](rewind.md)) and is never used for kfx groups.
+
+## A view kfx, from zero to installed
+
+Inside the repository (the SDK is pre-release; see
+[`known-limits.md`](known-limits.md) on release infrastructure):
+
+```sh
+node developer/sdk/src/kfs.js create extension my-view --workspace
+cd my-view
+pnpm install                 # once published: plain npm/yarn also work
+pnpm build                   # kfs kfx build → dist/view/index.js
+npm pack                     # my-view-0.1.0.tgz — the install unit
+kungfu kfx install my-view-0.1.0.tgz
+kungfu kfx list
+```
+
+The scaffold is two files that matter plus a README:
+
+```
+my-view/
+├── package.json          # identity + kungfuConfig manifest
+└── src/view/index.tsx    # exports exactly one thing: the View component
+```
+
+Launch the reference app and the view appears in navigation — the shell
+scans the install root at startup. During development, point
+`KF_EXTENSION_PATH` at a directory containing your package to load it from
+source builds without installing (rebuild with `pnpm build`, reload the
+app).
+
+## The manifest (`kungfuConfig`)
+
+The static half of an extension lives in `package.json` — managers and
+installers read it without executing code. Field reference (source of
+truth: [`../framework/kfx/src/index.ts`](../framework/kfx/src/index.ts),
+types `KfxViewDecl` / `KfxSettingDecl` / `KfxSuiteDecl`):
+
+| Field | Meaning |
+|---|---|
+| `key` | Install/identity key. Install target is `<home>/extensions/<key>`; first occurrence across roots wins. Required for every kfx. |
+| `name` | Human-readable package display name. |
+| `config.view.title` | Navigation title (falls back to `key`). |
+| `config.view.capabilities` | Capability handles the view receives (`ledger`, `domain`, `rewind`, `work`); undeclared handles stay absent. This is the permission seam. |
+| `config.view.system` | Shell-owned views (settings, kfx manager, status); not disableable. Third-party packages leave this unset. |
+| `config.view.settings` | Entries (`key` / `label` / `fallback`) this view contributes to the shell Settings view; values persist in the runtime home's ConfigStore. |
+| `config.view.entry` | Bundle path relative to the package root; default `dist/view/index.js`. |
+| `suite.title`, `suite.members` | Marks a suite package; `members` lists member `key`s. Members arrive as their own packages (npm `dependencies`) and install individually. |
+
+The manifest is a welded surface the moment packages are published; until
+then it evolves with its in-repo consumers. Do not invent fields — the
+loader ignores what it does not know, and nothing else will read them.
+
+## The build contract
+
+`kfs kfx build` bundles `src/view/index.tsx` (or `.ts`) to a CommonJS
+bundle at `dist/view/index.js`, leaving external (source of truth:
+`KFX_EXTERNALS` in
+[`../developer/sdk/src/kfs.js`](../developer/sdk/src/kfs.js)):
+
+- `react`, `react/jsx-runtime`, `react-dom`
+- `@kungfu-tech/api`, `@kungfu-tech/api/capability`
+
+The shell injects its own instances of these through a require shim at load
+time, so every kfx shares one React and one capability surface — a view
+extension must never ship its own copy. `@kungfu-tech/kfx` (contract types
++ UI tokens) is the opposite: types and plain objects, never stateful, and
+bundled into each extension.
+
+The bundle must export `View` (a React component taking
+`{ caps, shell }: KfxViewProps`) as a named export — the loader rejects
+anything else (verify:
+[`../framework/gui/src/renderer/src/kfx-loader.ts`](../framework/gui/src/renderer/src/kfx-loader.ts)).
+A failing kfx renders its error panel; it cannot take the shell down.
+
+## Discovery
+
+The loader scans extension roots in priority order — first occurrence of a
+key wins:
+
+1. `KF_EXTENSION_PATH` entries (path-separator list; in development this
+   defaults to the workspace `extensions/` tree);
+2. `<home>/extensions` next to the runtime dir — the root
+   `kungfu kfx install` populates.
+
+Scanning goes two levels deep, so suite members nested under a suite
+directory are found in the workspace layout.
+
+## Install lifecycle
+
+`kungfu kfx` manages installs for a home (source of truth:
+[`../framework/core/src/python/kungfu/console/commands/kfx.py`](../framework/core/src/python/kungfu/console/commands/kfx.py)):
+
+```sh
+kungfu kfx install <tgz-or-directory>    # extract into <home>/extensions/<key>
+kungfu kfx install <tgz> --force         # replace an existing install
+kungfu kfx list [--json]                 # key, package, version, kind
+kungfu kfx remove <key>                  # scoped to the managed install root
+```
+
+A double install without `--force` refuses; `remove` never touches paths
+outside the install root. The CLI and the kfx-manager view operate on the
+same facts.
+
+Installed kfx currently run node-integrated — installing a kfx is trusting
+it. The manifest's capability declaration is the seam for a future
+sandboxed tier; the tier does not exist yet (see
+[`../framework/gui/docs/shell-and-kfx.md`](../framework/gui/docs/shell-and-kfx.md),
+evolution notes).
+
+## Runtime extensions: current status
+
+Earlier-generation runtime extensions — trading adapters (`td`/`md`),
+operators, strategies — exist under [`../examples/`](../examples) with
+their sources and manifests, but their build surface (`kfs extension
+build`/`package`) predates the v4 SDK and is not provided by it. They are
+kept as reference probes while their coverage role moves to neutral
+replacements (see [`known-limits.md`](known-limits.md), "Reference
+extensions are mid-migration"). The supported extension path today is the
+view kfx documented above; this page will grow the runtime facets when
+their v4 build chain lands, not before.
+
+## Verified by
+
+- [`../tests/fixtures/kfx-demo-scaffold/`](../tests/fixtures/kfx-demo-scaffold)
+  — scaffold → build → pack → install → remove, from a clean directory,
+  asserting the load contract on the produced bundle.
+- [`../tests/fixtures/kfx-demo-install/`](../tests/fixtures/kfx-demo-install)
+  — the managed lifecycle against a real shipped view package (double
+  install refusal, `--force`, remove).
+
+Both run in `verify --full` (fixture stage); a red fixture means this page
+overclaims.

--- a/tests/fixtures/kfx-demo-scaffold/run.sh
+++ b/tests/fixtures/kfx-demo-scaffold/run.sh
@@ -1,0 +1,73 @@
+#!/bin/sh
+# SPDX-License-Identifier: Apache-2.0
+#
+# Kfx scaffold fixture: `kfs create extension` output builds and installs
+# from a clean directory. Scaffolds a view extension into a temp dir, links
+# the workspace contract packages the way pnpm would (the fixture stays
+# offline), builds it with `kfs kfx build`, asserts the bundle honors the
+# load contract (View export, shell-injected modules left external), then
+# packs the tgz and runs it through the `kungfu kfx install` lifecycle.
+# Requires the core dev environment (built dist/kfc) and the repository's
+# installed node_modules (the sdk's esbuild).
+#
+# Usage: tests/fixtures/kfx-demo-scaffold/run.sh
+
+set -eu
+fixture_dir="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+repo_dir="$(CDPATH= cd -- "$fixture_dir/../../.." && pwd)"
+core_dir="$repo_dir/framework/core"
+kfs="$repo_dir/developer/sdk/src/kfs.js"
+
+work="$(mktemp -d)"
+home="$(mktemp -d)"
+packdir="$(mktemp -d)"
+trap 'rm -rf "$work" "$home" "$packdir"' EXIT
+
+DYLD_FALLBACK_LIBRARY_PATH="$core_dir/dist/kfc${DYLD_FALLBACK_LIBRARY_PATH:+:$DYLD_FALLBACK_LIBRARY_PATH}"
+export DYLD_FALLBACK_LIBRARY_PATH
+
+ext_dir="$work/my-view"
+node "$kfs" create extension "$ext_dir" --workspace
+[ -f "$ext_dir/package.json" ] || { echo "FAIL: no package.json scaffolded"; exit 1; }
+[ -f "$ext_dir/.gitignore" ] || { echo "FAIL: _gitignore not renamed to .gitignore"; exit 1; }
+grep -q '__EXT_' "$ext_dir/package.json" && { echo "FAIL: unreplaced template token"; exit 1; }
+
+# workspace deps in a standalone dir: link the contract packages like pnpm
+# would inside the monorepo (the build only needs their sources)
+mkdir -p "$ext_dir/node_modules/@kungfu-tech"
+ln -s "$repo_dir/framework/kfx" "$ext_dir/node_modules/@kungfu-tech/kfx"
+ln -s "$repo_dir/framework/api" "$ext_dir/node_modules/@kungfu-tech/api"
+
+(cd "$ext_dir" && node "$kfs" kfx build)
+bundle="$ext_dir/dist/view/index.js"
+[ -f "$bundle" ] || { echo "FAIL: kfs kfx build produced no bundle"; exit 1; }
+
+# the load contract, asserted the way the shell loads it: CommonJS-wrap with
+# a require shim; only shell-provided modules may be required; the bundle
+# must export a View component function
+node -e '
+const fs = require("node:fs");
+const code = fs.readFileSync(process.argv[1], "utf8");
+const provided = ["react", "react/jsx-runtime", "react-dom", "@kungfu-tech/api", "@kungfu-tech/api/capability"];
+const m = { exports: {} };
+new Function("require", "module", "exports", code)(
+  (id) => { if (provided.includes(id)) return {}; throw new Error("unexpected require: " + id); },
+  m, m.exports,
+);
+if (typeof m.exports.View !== "function") { console.error("FAIL: bundle does not export View"); process.exit(1); }
+' "$bundle"
+
+# the distribution unit: npm pack, then the managed install lifecycle
+tgz="$(cd "$ext_dir" && npm pack --pack-destination "$packdir" 2>/dev/null | tail -1)"
+tgz="$packdir/$tgz"
+[ -f "$tgz" ] || { echo "FAIL: npm pack produced no tgz"; exit 1; }
+
+cd "$core_dir"
+kfc="uv run --frozen python .devtools/kfc.py -H $home"
+
+$kfc kfx install "$tgz"
+$kfc kfx list | grep -q "my-view" || { echo "FAIL: installed kfx not listed"; exit 1; }
+[ -f "$home/extensions/my-view/dist/view/index.js" ] || { echo "FAIL: bundle missing from install root"; exit 1; }
+$kfc kfx remove my-view
+[ ! -d "$home/extensions/my-view" ] || { echo "FAIL: not removed"; exit 1; }
+echo "[kfx-demo-scaffold] scaffold-to-install ok"


### PR DESCRIPTION
## What

Closes the developer-facing gap in the kfx distribution chain: a newcomer can go from an empty directory to an installed view extension without reading platform sources.

- `kfs create extension <dir>` scaffolds a view kfx (same token mechanism as `create app`): manifest with `kungfuConfig.config.view`, a minimal `View` component on the contract tokens, build/clean scripts, README. `--workspace` wires `workspace:*` deps.
- `docs/extensions.md` fills the MAP's `to write` slot: facet/package/suite vocabulary, scaffold-to-install quickstart, `kungfuConfig` field reference tied to `framework/kfx` types, the build externals contract, discovery roots, install lifecycle, and the honest status of runtime facets (mid-migration, per `known-limits.md`). MAP row goes `stable`.
- `tests/fixtures/kfx-demo-scaffold/` proves the chain end to end: scaffold → build → load-contract assertion (named `View` export, only shell-provided modules required) → `npm pack` → `kungfu kfx install`/`list`/`remove` in a clean home. Picked up automatically by `verify --full` via the `kfx-demo-` prefix.

## Validation

- Scaffold → build → contract assertion → pack ran green offline from a clean directory; the tgz contains exactly `dist/`, `package.json`, `README.md`.
- `create app` regression-smoked (workspace token, non-empty-dir refusal); `node --check` and biome on `kfs.js` (the one formatter finding predates this change).
- The fixture's install stage requires a built `dist/kfc` (same precondition as `kfx-demo-install`); first full run lands with the next `verify --full` on a built tree.

## Not in scope

Loader/CLI/contract semantics are only consumed, never changed; the runtime facet build chain stays as documented status.