### PR TITLE
feat(rewind): framework adapters become a kfx runtime facet

### DIFF
--- a/developer/sdk/src/kfs.js
+++ b/developer/sdk/src/kfs.js
@@ -157,18 +157,28 @@ const KFX_EXTERNALS = [
   '@kungfu-tech/api/capability',
 ];
 
-function readViewDecl() {
+function readManifest() {
   const manifestPath = path.resolve('package.json');
   if (!fs.existsSync(manifestPath)) fail('no package.json in current directory');
-  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
-  const view = manifest.kungfuConfig?.config?.view;
-  if (!view)
-    fail('package.json has no kungfuConfig.config.view — not a view extension');
-  return { manifest, view };
+  return JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
 }
 
 async function kfxBuild() {
-  const { manifest, view } = readViewDecl();
+  const manifest = readManifest();
+  const config = manifest.kungfuConfig?.config ?? {};
+  const view = config.view;
+  if (!view) {
+    // An adapter facet is a runtime extension: it ships source per child
+    // runtime (python/node) and the capture supervisor injects it — there is
+    // nothing to bundle. Succeed so `kfs kfx build` is usable on any kfx.
+    if (config.adapter) {
+      process.stdout.write(
+        `${manifest.name ?? 'adapter extension'}: adapter facet ships source (no bundle step)\n`,
+      );
+      return;
+    }
+    fail('package.json has no kungfuConfig.config.view or .adapter facet');
+  }
   const entry = ['src/view/index.tsx', 'src/view/index.ts'].find((candidate) =>
     fs.existsSync(path.resolve(candidate)),
   );
@@ -192,7 +202,7 @@ async function kfxBuild() {
 }
 
 function kfxClean() {
-  readViewDecl();
+  readManifest();
   fs.rmSync(path.resolve('dist'), { recursive: true, force: true });
   process.stdout.write('cleaned dist\n');
 }

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -105,14 +105,24 @@ A failing kfx renders its error panel; it cannot take the shell down.
 An **adapter facet** has no bundle step — it ships source per child runtime,
 and the capture supervisor injects it into a traced child, where it runs in
 the user's own interpreter. `kfs kfx build` reports this and does nothing for
-an adapter-only package. A python adapter's entry file registers its patcher
-through the capture hook's `register_adapter` (it imports `rewind_client`, the
-dependency-free hook, never `kungfu`), so an unmodified framework run is
-captured with no code change. Discovery and injection live in the supervisor
-(source of truth:
+an adapter-only package. To add an adapter for a framework, declare
+`config.adapter` (its `targets` / `runtimes` / `entry`) and write one entry
+file per runtime that registers a patcher — each depends on nothing but the
+runtime's built-ins:
+
+- **python** (`entry.python`): `import rewind_client` (the dependency-free
+  hook, never `kungfu`) and call `rewind_client.register_adapter(module_name,
+  patcher)`; build spans with `rewind_client._CallCapture` / `_render`.
+- **node** (`entry.node`): read `globalThis.__kungfuRewind` (the hook exposes
+  it) and call `registerAdapter(moduleName, patcher)`; build spans with its
+  `captureInvoke` / `render`.
+
+A patcher receives the framework module once it is imported/required and wraps
+its tool seam, so an unmodified run is captured with no code change. Discovery
+and injection live in the supervisor (source of truth:
 [`../framework/core/src/python/kungfu/rewind/adapters.py`](../framework/core/src/python/kungfu/rewind/adapters.py)),
-so the hook stays dependency-free. `extensions/langchain-adapter` is the first
-adapter facet.
+so the hooks stay dependency-free. `extensions/langchain-adapter` is the first
+adapter facet (python); its `src/adapter/python/index.py` is the reference.
 
 ## Discovery
 

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -8,10 +8,13 @@ bottom are the machine-checked proof.
 
 Three words carry the model — keep them apart:
 
-- **facet** — what a package *does*, declared under `kungfuConfig.config`.
-  The shipped facet today is `view` (a GUI screen); runtime facets (trading
-  adapters, operators) exist as earlier-generation examples and are
-  mid-migration (see [status](#runtime-extensions-current-status)).
+- **facet** — what a package *does*, declared under `kungfuConfig.config`. A
+  package may declare more than one; a facet's loader picks up only what it
+  understands. Two are supported: `view` (a GUI screen the shell loads) and
+  `adapter` (a **runtime facet** — capture-side framework instrumentation the
+  trace supervisor loads; the first v4 runtime facet). Older trading adapters
+  and operators are a separate earlier-generation line, still mid-migration
+  (see [status](#runtime-extensions-current-status)).
 - **package (kfx)** — the unit of development and distribution: an npm
   package whose `package.json` carries a `kungfuConfig` manifest. `npm pack`
   of a built package is its complete, offline install unit.
@@ -67,6 +70,10 @@ types `KfxViewDecl` / `KfxSettingDecl` / `KfxSuiteDecl`):
 | `config.view.system` | Shell-owned views (settings, kfx manager, status); not disableable. Third-party packages leave this unset. |
 | `config.view.settings` | Entries (`key` / `label` / `fallback`) this view contributes to the shell Settings view; values persist in the runtime home's ConfigStore. |
 | `config.view.entry` | Bundle path relative to the package root; default `dist/view/index.js`. |
+| `config.adapter.targets` | Module import names whose import triggers the patch (informative — e.g. `langchain_core.tools.base`). |
+| `config.adapter.runtimes` | Child runtimes this adapter instruments (`python`, `node`). The supervisor injects an adapter into a child of a matching runtime. |
+| `config.adapter.entry` | Adapter source per runtime, relative to the package root (e.g. `{ "python": "src/adapter/python/index.py" }`). An adapter ships source — there is no bundle step. |
+| `config.adapter.capabilities` | Capture-side capabilities the adapter needs; the same permission seam as a view's `capabilities` (reserved for enforcement). |
 | `suite.title`, `suite.members` | Marks a suite package; `members` lists member `key`s. Members arrive as their own packages (npm `dependencies`) and install individually. |
 
 The manifest is a welded surface the moment packages are published; until
@@ -94,6 +101,18 @@ The bundle must export `View` (a React component taking
 anything else (verify:
 [`../framework/gui/src/renderer/src/kfx-loader.ts`](../framework/gui/src/renderer/src/kfx-loader.ts)).
 A failing kfx renders its error panel; it cannot take the shell down.
+
+An **adapter facet** has no bundle step — it ships source per child runtime,
+and the capture supervisor injects it into a traced child, where it runs in
+the user's own interpreter. `kfs kfx build` reports this and does nothing for
+an adapter-only package. A python adapter's entry file registers its patcher
+through the capture hook's `register_adapter` (it imports `rewind_client`, the
+dependency-free hook, never `kungfu`), so an unmodified framework run is
+captured with no code change. Discovery and injection live in the supervisor
+(source of truth:
+[`../framework/core/src/python/kungfu/rewind/adapters.py`](../framework/core/src/python/kungfu/rewind/adapters.py)),
+so the hook stays dependency-free. `extensions/langchain-adapter` is the first
+adapter facet.
 
 ## Discovery
 
@@ -132,15 +151,20 @@ evolution notes).
 
 ## Runtime extensions: current status
 
+The first v4 runtime facet has landed: `config.adapter`, a capture-side
+framework adapter the trace supervisor discovers and injects
+(`extensions/langchain-adapter` captures unmodified LangChain runs). It needs
+no bundle step — an adapter ships source per child runtime — so the v4 build
+chain for this facet is "ships source", not a new packager.
+
 Earlier-generation runtime extensions — trading adapters (`td`/`md`),
-operators, strategies — exist under [`../examples/`](../examples) with
-their sources and manifests, but their build surface (`kfs extension
-build`/`package`) predates the v4 SDK and is not provided by it. They are
-kept as reference probes while their coverage role moves to neutral
-replacements (see [`known-limits.md`](known-limits.md), "Reference
-extensions are mid-migration"). The supported extension path today is the
-view kfx documented above; this page will grow the runtime facets when
-their v4 build chain lands, not before.
+operators, strategies — are a separate line: they exist under
+[`../examples/`](../examples) with their sources and manifests, but their
+build surface (`kfs extension build`/`package`) predates the v4 SDK and is not
+provided by it. They are kept as reference probes while their coverage role
+moves to neutral replacements (see [`known-limits.md`](known-limits.md),
+"Reference extensions are mid-migration"). Other runtime facets (operators,
+strategies) will grow on this page when their v4 path lands, not before.
 
 ## Verified by
 
@@ -150,6 +174,10 @@ their v4 build chain lands, not before.
 - [`../tests/fixtures/kfx-demo-install/`](../tests/fixtures/kfx-demo-install)
   — the managed lifecycle against a real shipped view package (double
   install refusal, `--force`, remove).
+- [`../tests/fixtures/rewind-demo-langchain/`](../tests/fixtures/rewind-demo-langchain)
+  — the `adapter` facet: an unmodified LangChain agent, captured under
+  `kungfu trace` by `extensions/langchain-adapter` discovered on the extension
+  root, with no adapter code in the kernel.
 
-Both run in `verify --full` (fixture stage); a red fixture means this page
+All run in `verify --full` (fixture stage); a red fixture means this page
 overclaims.

--- a/extensions/langchain-adapter/package.json
+++ b/extensions/langchain-adapter/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@kungfu-tech/kfx-adapter-langchain",
+  "version": "0.1.0",
+  "description": "Capture unmodified LangChain agent runs under kungfu trace.",
+  "private": true,
+  "kungfuConfig": {
+    "key": "langchain-adapter",
+    "name": "LangChain adapter",
+    "config": {
+      "adapter": {
+        "targets": ["langchain_core.tools.base", "langchain_core.tools"],
+        "runtimes": ["python"],
+        "entry": { "python": "src/adapter/python/index.py" }
+      }
+    }
+  },
+  "files": ["src"]
+}

--- a/extensions/langchain-adapter/src/adapter/python/index.py
+++ b/extensions/langchain-adapter/src/adapter/python/index.py
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# LangChain adapter — a kfx runtime facet (config.adapter, python). The trace
+# supervisor discovers this package and injects this file into the traced
+# child, where it registers a patcher for LangChain's tool seam so an
+# unmodified `create_agent` run is captured with no code change. It uses the
+# capture primitives the hook exposes (rewind_client) — no kungfu import — so
+# it runs in the user's own interpreter.
+#
+# The seam: every tool execution — an agent's tool node calling
+# `tool.invoke(...)` / `tool.ainvoke(...)`, or user code calling `tool.run(...)`
+# — funnels through `BaseTool.run` (the async path runs the sync `run` in an
+# executor), so wrapping this one method captures the whole tool call as a
+# single span across sync and async agents. Model turns are captured upstream
+# at the wire proxy; this adapter owns tool semantics only.
+
+import os
+
+import rewind_client
+
+
+def _patch_langchain(module):
+    base_tool = getattr(module, "BaseTool", None)
+    if base_tool is None or getattr(base_tool, "_kungfu_rewind_patched", False):
+        return
+    original_run = base_tool.run
+
+    def traced_run(self, *args, **kwargs):
+        tool_input = args[0] if args else kwargs.get("tool_input")
+        name = getattr(self, "name", None) or type(self).__name__
+        capture = rewind_client._CallCapture(
+            name, parent_span_id=os.environ.get(rewind_client.ENV_PARENT_SPAN)
+        )
+        return capture.run(
+            lambda: original_run(self, *args, **kwargs),
+            rewind_client._render(tool_input),
+        )
+
+    base_tool.run = traced_run
+    base_tool._kungfu_rewind_patched = True
+
+
+# BaseTool lives in `langchain_core.tools.base`; older layouts exposed it from
+# the `langchain_core.tools` package. Register both — the patcher no-ops when
+# BaseTool is absent or already wrapped.
+rewind_client.register_adapter("langchain_core.tools.base", _patch_langchain)
+rewind_client.register_adapter("langchain_core.tools", _patch_langchain)

--- a/framework/core/src/python/kungfu/rewind/adapters.py
+++ b/framework/core/src/python/kungfu/rewind/adapters.py
@@ -20,8 +20,10 @@ import json
 import os
 
 ENV_EXTENSION_PATH = "KF_EXTENSION_PATH"
-# shared contract string with the child hook (rewind_client.ENV_PLUGIN_ADAPTERS)
+# shared contract strings with the child hooks (per runtime): the python hook
+# reads ENV_PLUGIN_ADAPTERS, the node hook reads ENV_NODE_ADAPTERS.
 ENV_PLUGIN_ADAPTERS = "KUNGFU_REWIND_ADAPTERS"
+ENV_NODE_ADAPTERS = "KUNGFU_REWIND_NODE_ADAPTERS"
 
 
 def _extension_roots(runtime_dir):
@@ -51,10 +53,10 @@ def _scan_packages(root):
                     yield nested
 
 
-def discover_python_adapters(runtime_dir):
-    """Return (entry_files, package_dirs) for kfx packages declaring a python
-    adapter form. First occurrence of a package path wins; missing entry files
-    are skipped."""
+def discover_adapters(runtime_dir, runtime):
+    """Return (entry_files, package_dirs) for kfx packages declaring an adapter
+    form for `runtime` ('python' or 'node'). First occurrence of a package path
+    wins; missing entry files are skipped."""
     entries, dirs, seen = [], [], set()
     for root in _extension_roots(runtime_dir):
         for pkg in _scan_packages(root):
@@ -65,9 +67,9 @@ def discover_python_adapters(runtime_dir):
                 continue
             config = (manifest.get("kungfuConfig") or {}).get("config") or {}
             adapter = config.get("adapter") or {}
-            if "python" not in (adapter.get("runtimes") or []):
+            if runtime not in (adapter.get("runtimes") or []):
                 continue
-            entry = (adapter.get("entry") or {}).get("python")
+            entry = (adapter.get("entry") or {}).get(runtime)
             if not entry:
                 continue
             path = os.path.abspath(os.path.join(pkg, entry))

--- a/framework/core/src/python/kungfu/rewind/adapters.py
+++ b/framework/core/src/python/kungfu/rewind/adapters.py
@@ -1,0 +1,79 @@
+#  SPDX-License-Identifier: Apache-2.0
+#
+# kfx adapter discovery — the supervisor side of the plugin bridge.
+#
+# Framework adapters are a kfx extension form (`kungfuConfig.config.adapter`),
+# not core code. The supervisor has kungfu and reads manifests, so it does the
+# discovery: it scans the same extension roots the GUI shell scans, finds
+# packages whose manifest declares a python adapter, and announces their entry
+# files to the child. The child-side hook stays dependency-free and only loads
+# what it is told — see rewind_client._load_plugin_adapters.
+#
+# A manifest's adapter form:
+#   "kungfuConfig": { "config": { "adapter": {
+#       "targets": ["langchain_core.tools.base"],   # informative
+#       "runtimes": ["python"],                      # forms this covers
+#       "entry": { "python": "dist/adapter/python/index.py" }
+#   } } }
+
+import json
+import os
+
+ENV_EXTENSION_PATH = "KF_EXTENSION_PATH"
+# shared contract string with the child hook (rewind_client.ENV_PLUGIN_ADAPTERS)
+ENV_PLUGIN_ADAPTERS = "KUNGFU_REWIND_ADAPTERS"
+
+
+def _extension_roots(runtime_dir):
+    # priority order mirrors framework/gui kfx-loader: KF_EXTENSION_PATH entries
+    # (dev override) then <home>/extensions next to the runtime dir.
+    roots = []
+    for entry in os.environ.get(ENV_EXTENSION_PATH, "").split(os.pathsep):
+        if entry:
+            roots.append(entry)
+    if runtime_dir:
+        roots.append(os.path.join(os.path.dirname(runtime_dir), "extensions"))
+    return roots
+
+
+def _scan_packages(root):
+    # two levels deep, so suite members nested under a suite directory are found
+    if not os.path.isdir(root):
+        return
+    for name in sorted(os.listdir(root)):
+        pkg = os.path.join(root, name)
+        if os.path.isfile(os.path.join(pkg, "package.json")):
+            yield pkg
+        elif os.path.isdir(pkg):
+            for sub in sorted(os.listdir(pkg)):
+                nested = os.path.join(pkg, sub)
+                if os.path.isfile(os.path.join(nested, "package.json")):
+                    yield nested
+
+
+def discover_python_adapters(runtime_dir):
+    """Return (entry_files, package_dirs) for kfx packages declaring a python
+    adapter form. First occurrence of a package path wins; missing entry files
+    are skipped."""
+    entries, dirs, seen = [], [], set()
+    for root in _extension_roots(runtime_dir):
+        for pkg in _scan_packages(root):
+            try:
+                with open(os.path.join(pkg, "package.json")) as f:
+                    manifest = json.load(f)
+            except (OSError, ValueError):
+                continue
+            config = (manifest.get("kungfuConfig") or {}).get("config") or {}
+            adapter = config.get("adapter") or {}
+            if "python" not in (adapter.get("runtimes") or []):
+                continue
+            entry = (adapter.get("entry") or {}).get("python")
+            if not entry:
+                continue
+            path = os.path.abspath(os.path.join(pkg, entry))
+            if path in seen or not os.path.exists(path):
+                continue
+            seen.add(path)
+            entries.append(path)
+            dirs.append(os.path.abspath(pkg))
+    return entries, dirs

--- a/framework/core/src/python/kungfu/rewind/hook/rewind_client.py
+++ b/framework/core/src/python/kungfu/rewind/hook/rewind_client.py
@@ -260,14 +260,49 @@ def _patch_langchain(module):
     base_tool._kungfu_rewind_patched = True
 
 
+# The demo toolkit is the built-in mechanism probe (the seam shape). Real
+# framework adapters ship as kfx packages whose `config.adapter` form the
+# supervisor discovers and injects, registering themselves here at load time.
+# LangChain is still built in transitionally — it migrates to a kfx package in
+# the next stage; keeping it registered means nothing regresses meanwhile.
 ADAPTERS = {
     "rewind_demo_toolkit": _patch_demo_toolkit,
-    # BaseTool lives in `langchain_core.tools.base`; older layouts exposed it
-    # from the `langchain_core.tools` package itself. Register both — the
-    # patcher no-ops when BaseTool is absent or already wrapped.
-    "langchain_core.tools.base": _patch_langchain,
-    "langchain_core.tools": _patch_langchain,
+    "langchain_core.tools.base": _patch_langchain,  # TODO(kfx-migrate): -> kfx package
+    "langchain_core.tools": _patch_langchain,       # TODO(kfx-migrate): -> kfx package
 }
+
+# module names a kfx adapter file may import as its patch API (they are the
+# capture primitives above; exposed so an out-of-core adapter needs no kungfu
+# import to build spans): register_adapter, _CallCapture, _render, new_span,
+# ENV_PARENT_SPAN.
+ENV_PLUGIN_ADAPTERS = "KUNGFU_REWIND_ADAPTERS"
+
+
+def register_adapter(module_name, patcher):
+    """Bind a post-import patcher to a module name. A kfx adapter file calls
+    this at load time; the meta-path finder applies the patch once that module
+    is imported by the traced program."""
+    ADAPTERS[module_name] = patcher
+
+
+def _load_plugin_adapters():
+    # The supervisor discovers kfx `config.adapter` forms and announces their
+    # python entry files in the environment (pathsep-joined). Import each so it
+    # registers its patchers. Discovery lives in the supervisor (it has kungfu
+    # and reads manifests); this hook stays dependency-free and just loads what
+    # it is told — a bad adapter never breaks the traced program.
+    listed = os.environ.get(ENV_PLUGIN_ADAPTERS, "")
+    for index, path in enumerate(p for p in listed.split(os.pathsep) if p):
+        try:
+            spec = importlib.util.spec_from_file_location(
+                f"_kfx_adapter_{index}", path
+            )
+            if spec is None or spec.loader is None:
+                continue
+            module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(module)
+        except Exception:  # noqa: BLE001 — a broken kfx adapter must not break the run
+            continue
 
 
 class _AdapterLoader(importlib.abc.Loader):
@@ -304,4 +339,7 @@ class _AdapterFinder(importlib.abc.MetaPathFinder):
 
 def install_adapters():
     if setup():
+        # load kfx adapter plugins first so their patchers are registered
+        # before any traced import can trigger the finder
+        _load_plugin_adapters()
         sys.meta_path.insert(0, _AdapterFinder())

--- a/framework/core/src/python/kungfu/rewind/hook/rewind_client.py
+++ b/framework/core/src/python/kungfu/rewind/hook/rewind_client.py
@@ -232,43 +232,12 @@ def _patch_demo_toolkit(module):
     module.Tool._invoke = traced_invoke
 
 
-def _patch_langchain(module):
-    # LangChain's tool seam: every tool execution — whether an agent's tool
-    # node calls `tool.invoke(...)`, `tool.ainvoke(...)`, or user code calls
-    # `tool.run(...)` — funnels through `BaseTool.run`. `invoke`/`ainvoke`
-    # dispatch to it, and the async path runs the sync `run` in an executor,
-    # so wrapping this one method captures the whole tool call (including the
-    # subclass `_run` beneath it) as a single span across sync and async
-    # agents. The model turns that drive these calls are captured upstream at
-    # the wire proxy, so the in-process adapter only owns tool semantics.
-    base_tool = getattr(module, "BaseTool", None)
-    if base_tool is None or getattr(base_tool, "_kungfu_rewind_patched", False):
-        return
-    original_run = base_tool.run
-
-    def traced_run(self, *args, **kwargs):
-        tool_input = args[0] if args else kwargs.get("tool_input")
-        name = getattr(self, "name", None) or type(self).__name__
-        # root under the ambient span so a langchain tool invoked inside an
-        # outer captured span (including across a runtime boundary) nests
-        capture = _CallCapture(name, parent_span_id=os.environ.get(ENV_PARENT_SPAN))
-        return capture.run(
-            lambda: original_run(self, *args, **kwargs), _render(tool_input)
-        )
-
-    base_tool.run = traced_run
-    base_tool._kungfu_rewind_patched = True
-
-
-# The demo toolkit is the built-in mechanism probe (the seam shape). Real
-# framework adapters ship as kfx packages whose `config.adapter` form the
-# supervisor discovers and injects, registering themselves here at load time.
-# LangChain is still built in transitionally — it migrates to a kfx package in
-# the next stage; keeping it registered means nothing regresses meanwhile.
+# The demo toolkit is the built-in mechanism probe (the seam shape) and the
+# only adapter core carries. Real framework adapters (LangChain, etc.) are kfx
+# packages whose `config.adapter` form the supervisor discovers and injects;
+# they register their patchers here at load time via register_adapter.
 ADAPTERS = {
     "rewind_demo_toolkit": _patch_demo_toolkit,
-    "langchain_core.tools.base": _patch_langchain,  # TODO(kfx-migrate): -> kfx package
-    "langchain_core.tools": _patch_langchain,       # TODO(kfx-migrate): -> kfx package
 }
 
 # module names a kfx adapter file may import as its patch API (they are the

--- a/framework/core/src/python/kungfu/rewind/hook/rewind_hook.js
+++ b/framework/core/src/python/kungfu/rewind/hook/rewind_hook.js
@@ -124,7 +124,38 @@ if (endpoint) {
     return exports;
   };
 
+  // The demo toolkit is the built-in mechanism probe; real framework adapters
+  // are kfx packages the supervisor discovers and announces.
   const ADAPTERS = { rewind_demo_toolkit: patchDemoToolkit };
+
+  const registerAdapter = (name, patcher) => {
+    ADAPTERS[name] = patcher;
+  };
+
+  // Expose the capture API to plugin adapters loaded later. A node kfx adapter
+  // reads globalThis.__kungfuRewind (it depends on nothing else) and registers
+  // its patcher — the node analogue of the python hook's importable primitives.
+  globalThis.__kungfuRewind = {
+    registerAdapter,
+    captureInvoke,
+    newSpan,
+    render,
+    parentSpan: bootParent,
+  };
+
+  // Load the node kfx adapter plugins the supervisor announced; requiring each
+  // registers its patchers before the require hook below goes live. A broken
+  // adapter must never break the traced program.
+  for (const entry of (process.env.KUNGFU_REWIND_NODE_ADAPTERS || '').split(
+    require('path').delimiter,
+  )) {
+    if (!entry) continue;
+    try {
+      require(entry);
+    } catch (e) {
+      /* best-effort: skip a broken kfx adapter */
+    }
+  }
 
   const originalLoad = Module._load;
   Module._load = function (request, parent, isMain) {

--- a/framework/core/src/python/kungfu/rewind/supervisor.py
+++ b/framework/core/src/python/kungfu/rewind/supervisor.py
@@ -131,13 +131,17 @@ class Supervisor:
         # whatever the environment already had.
         env[ENV_INGEST] = self.ingest.endpoint
         existing = env.get("PYTHONPATH")
-        # kfx adapter plugins: discover python adapter forms in the extension
-        # roots and announce their entry files to the child hook; put their
-        # package dirs on PYTHONPATH so an adapter can import its own siblings.
-        adapter_entries, adapter_dirs = adapters.discover_python_adapters(self.runtime_dir)
-        if adapter_entries:
-            env[adapters.ENV_PLUGIN_ADAPTERS] = os.pathsep.join(adapter_entries)
-        pythonpath_parts = [_HOOK_DIR, *adapter_dirs]
+        # kfx adapter plugins: discover adapter forms in the extension roots and
+        # announce their entry files to each runtime's child hook. Python
+        # adapters also put their package dirs on PYTHONPATH so an adapter can
+        # import its own siblings; node adapters are required by absolute path.
+        py_entries, py_dirs = adapters.discover_adapters(self.runtime_dir, "python")
+        node_entries, _ = adapters.discover_adapters(self.runtime_dir, "node")
+        if py_entries:
+            env[adapters.ENV_PLUGIN_ADAPTERS] = os.pathsep.join(py_entries)
+        if node_entries:
+            env[adapters.ENV_NODE_ADAPTERS] = os.pathsep.join(node_entries)
+        pythonpath_parts = [_HOOK_DIR, *py_dirs]
         if existing:
             pythonpath_parts.append(existing)
         env["PYTHONPATH"] = os.pathsep.join(pythonpath_parts)

--- a/framework/core/src/python/kungfu/rewind/supervisor.py
+++ b/framework/core/src/python/kungfu/rewind/supervisor.py
@@ -33,7 +33,7 @@ from kungfu.rewind import (
     MSG_RUN_END,
     SCHEMA_VERSION,
 )
-from kungfu.rewind import bundle, events
+from kungfu.rewind import adapters, bundle, events
 from kungfu.rewind.fb.RunStatus import RunStatus
 from kungfu.rewind.ingest import IngestServer
 from kungfu.rewind.schema_registry import register_user_schema
@@ -131,7 +131,16 @@ class Supervisor:
         # whatever the environment already had.
         env[ENV_INGEST] = self.ingest.endpoint
         existing = env.get("PYTHONPATH")
-        env["PYTHONPATH"] = _HOOK_DIR + os.pathsep + existing if existing else _HOOK_DIR
+        # kfx adapter plugins: discover python adapter forms in the extension
+        # roots and announce their entry files to the child hook; put their
+        # package dirs on PYTHONPATH so an adapter can import its own siblings.
+        adapter_entries, adapter_dirs = adapters.discover_python_adapters(self.runtime_dir)
+        if adapter_entries:
+            env[adapters.ENV_PLUGIN_ADAPTERS] = os.pathsep.join(adapter_entries)
+        pythonpath_parts = [_HOOK_DIR, *adapter_dirs]
+        if existing:
+            pythonpath_parts.append(existing)
+        env["PYTHONPATH"] = os.pathsep.join(pythonpath_parts)
         node_require = f"--require {os.path.join(_HOOK_DIR, 'rewind_hook.js')}"
         node_existing = env.get("NODE_OPTIONS")
         env["NODE_OPTIONS"] = (

--- a/framework/gui/docs/shell-and-kfx.md
+++ b/framework/gui/docs/shell-and-kfx.md
@@ -109,11 +109,27 @@ the shell depends on any workflow methodology — an opinionated workflow
 arrives as another profile without touching the shell. User-defined event
 schemas and generic core concepts stay out of v1 deliberately.
 
+## Runtime facets: the shell is not the only loader
+
+A kfx facet is declared under `kungfuConfig.config`; a package may carry more
+than one, and each facet has its own loader. The shell loads the `view` facet.
+The `adapter` facet — capture-side framework instrumentation, the first v4
+runtime facet — is loaded by the **trace supervisor**, not the shell: it scans
+the same extension roots, finds packages declaring an adapter for a child
+runtime, and injects the adapter source into the traced child, where the
+dependency-free capture hook loads it. So "installable kfx package" spans both
+planes — a GUI view and a capture-side adapter share one package model,
+manifest, extension root and install lifecycle, but different loaders. Full
+contract in [`../../../docs/extensions.md`](../../../docs/extensions.md);
+`extensions/langchain-adapter` is the first adapter facet.
+
 ## Evolution notes
 
 - External untrusted kfx need the `sandboxed-ipc` runtime tier; the manifest
   seam exists, the tier does not. Installed kfx currently run
-  node-integrated — installing a kfx is trusting it.
+  node-integrated — installing a kfx is trusting it. This tier will govern
+  adapter facets too (a sandboxed adapter's schema compilation is already
+  bounded; its runtime isolation is the same missing tier).
 - The manifest is a welded surface the moment packages are published. Until
   then it may evolve freely, but every field addition should come with a
   consumer in this repository.

--- a/framework/kfx/src/index.ts
+++ b/framework/kfx/src/index.ts
@@ -51,6 +51,23 @@ export type KfxViewDecl = {
   entry?: string;
 };
 
+// `kungfuConfig.config.adapter` — a runtime facet. Unlike a view (a GUI screen
+// the shell loads), an adapter is capture-side instrumentation: the trace
+// supervisor discovers it, and injects it into the traced child, where it
+// patches a framework's seam so unmodified runs are captured. It ships source
+// per child runtime (nothing to bundle), not a `dist/view` artifact.
+export type KfxAdapterDecl = {
+  // module import names whose import triggers the patch (informative)
+  targets: string[];
+  // child runtimes this adapter instruments
+  runtimes: ('python' | 'node')[];
+  // adapter entry per runtime, relative to the package root
+  entry: { python?: string; node?: string };
+  // capture-side capabilities the adapter needs; undeclared stay absent — the
+  // same permission seam a view's `capabilities` is (reserved for enforcement)
+  capabilities?: string[];
+};
+
 // `kungfuConfig.suite` — a suite groups related kfx for distribution and
 // operation: navigation grouping, enable/disable as a unit, lockstep
 // versioning. Membership is expressed through npm dependencies; `members`

--- a/tests/fixtures/rewind-demo-langchain/run.sh
+++ b/tests/fixtures/rewind-demo-langchain/run.sh
@@ -59,6 +59,13 @@ export OPENAI_API_KEY
 DYLD_FALLBACK_LIBRARY_PATH="$core_dir/dist/kfc${DYLD_FALLBACK_LIBRARY_PATH:+:$DYLD_FALLBACK_LIBRARY_PATH}"
 export DYLD_FALLBACK_LIBRARY_PATH
 
+# The LangChain adapter is NOT in core — it is the kfx package under
+# extensions/langchain-adapter. Point the extension root at the workspace
+# extensions tree so the supervisor discovers and injects it; capture of an
+# unmodified langchain run therefore comes from the package, not the kernel.
+KF_EXTENSION_PATH="$core_dir/../../extensions${KF_EXTENSION_PATH:+:$KF_EXTENSION_PATH}"
+export KF_EXTENSION_PATH
+
 cd "$core_dir"
 uv run --frozen python .devtools/kfc.py -H "$home" trace --run-id "$run_id" -- \
   "$agent_py" "$fixture_dir/langchain_agent.py"


### PR DESCRIPTION
Make framework capture adapters a kfx extension form (config.adapter) instead of kernel code — the first v4 runtime facet. The trace supervisor scans the same extension roots the GUI shell does, finds packages declaring a python or node adapter, and injects the adapter source into the traced child, where the dependency-free capture hook loads it and it registers its patcher (register_adapter in python; globalThis.__kungfuRewind in node). Discovery lives in the supervisor so the hooks stay dependency-free. LangChain support moves out of core into extensions/langchain-adapter; the kernel's built-in table keeps only the demo toolkit probe. @kungfu-tech/kfx gains the KfxAdapterDecl contract type, kfs kfx build tolerates an adapter-only package (an adapter ships source, nothing to bundle), and docs/extensions.md plus shell-and-kfx.md grow the adapter facet and its per-runtime registration recipe. Verified: external python and node adapters found on the extension root capture a toy framework under kungfu trace; the langchain fixture captures an unmodified real agent from the package with no adapter code in core; cross-runtime and happy fixtures still pass.