### PR TITLE
fix(yijinjing): write a minidump alongside the Windows crash report

### DIFF
--- a/framework/core/docs/windows-crash-symbols.md
+++ b/framework/core/docs/windows-crash-symbols.md
@@ -59,3 +59,71 @@ this constraint, or a stripped third-party frame), resolve them against the
 matching PDB with any of: WinDbg (`!address` / `ln module+RVA`), `cvdump`, or a
 short DbgHelp `SymFromAddr` helper. The RVA plus the exact-version PDB is enough;
 keep PDBs archived per release so past crash reports stay decodable.
+
+## Minidump companion (`.dmp`)
+
+On a real fault (the SEH `__except` in `hero::produce` and the
+`SetUnhandledExceptionFilter` backstop, both of which carry an exception
+context), the crash handler writes a **minidump** alongside the text report, in
+the same directory (`$KF_HOME/logview`), with the same `<pid>_<ts>` stem. The
+non-fatal diagnostic call `print_stack_trace()` (no exception context, used by
+node/rx catch blocks) stays text-only and does not emit a dump.
+
+| File | Contents | Best for |
+| --- | --- | --- |
+| `hs_err_pid<pid>_<ts>.log` | Text report: exception code + symbolized native stack + system/module info | Quick on-box reading, no tools |
+| `hs_err_pid<pid>_<ts>.dmp` | `MiniDumpNormal`: thread stacks, register contexts, module list, handles | Offline post-mortem in WinDbg / Visual Studio |
+
+**Why both.** The text report resolves symbols in-process via DbgHelp (`Sym*`),
+which allocates on the crashing heap — fine normally, but the heap is exactly
+what is broken in a heap-corruption crash, the case most worth diagnosing. The
+minidump snapshots memory and the module list and defers symbolization to
+offline, so it needs no in-handler symbol allocation and usually survives
+heap-corruption crashes that truncate the text stack.
+
+### Residual limitations (by tier)
+
+1. **Normal fault (null-deref AV):** full symbolized text stack; dump fully
+   usable. No loss.
+2. **Moderate heap corruption:** text stack may degrade to `module+offset`
+   (still offline-symbolizable, above); the minidump is normally intact and is
+   the preferred artifact.
+3. **Extreme heap corruption:** both can truncate — `MiniDumpWriteDump` itself
+   walks loader data and allocates, so a sufficiently corrupted process can
+   defeat it. Accepted limitation.
+4. **Stack overflow:** little stack is left to run a heavy dump call, so the
+   minidump is deliberately skipped (attempting it just faults) and only the
+   text report is written; native frames there are limited. Accepted limitation.
+
+A `.dmp` is written to a `.part` sibling first and renamed only on success, so a
+`hs_err_*.dmp` file always means a complete minidump. A leftover `hs_err_*.dmp.part`
+means the dump was defeated mid-write by extreme heap corruption (tier 3) — the
+paired `.log` still holds the exception line.
+
+Removing tiers 3–4 would require an out-of-process dumper (a resident helper
+that dumps the frozen target across process boundaries, immune to the target's
+heap and stack). That was evaluated and **not adopted**: the resident process,
+IPC protocol, and packaging/lifecycle surface it adds are not justified by the
+residual once the in-process minidump is in place. The in-process minidump is
+the deliberate stopping point.
+
+### Opening a `.dmp`
+
+Use the release PDBs that this doc already requires (matched by PDB GUID + age):
+
+```
+cdb -z hs_err_pid1234_20260703_120000.dmp -y <pdb-path> -c "k; lm; q"
+```
+
+Visual Studio: open the `.dmp`, point the symbol path at the archived PDBs, then
+"Debug with Native Only".
+
+### Privacy
+
+A minidump contains process memory (stacks, registers, module list).
+`MiniDumpNormal` is used deliberately to stay small and avoid the full working
+set, but still treat `.dmp` files as **private**: they live under a runtime
+directory (never the repo), should not be attached to public issues, and should
+be rotated like other crash logs. If richer dumps (`MiniDumpWithFullMemory`) are
+ever needed, gate them behind an explicit opt-in — full memory captures the
+entire working set and materially widens the privacy surface.

--- a/framework/core/src/libyijinjing/src/util/stacktrace.cpp
+++ b/framework/core/src/libyijinjing/src/util/stacktrace.cpp
@@ -15,6 +15,7 @@
 #pragma comment(lib, "dbghelp.lib")
 
 #include "StackWalker.h"
+#include <DbgHelp.h>
 #include <cstring>
 #include <ostream>
 #include <streambuf>
@@ -54,14 +55,20 @@ namespace {
 // building; it uses Win32 primitives (CreateFileA / WriteFile / GetLocalTime)
 // and preallocated buffers instead.
 //
-// Accepted residual risk (W-A): DbgHelp (Sym*) uses the heap and StackWalker's
+// Accepted residual risk: DbgHelp (Sym*) uses the heap and StackWalker's
 // std::ostream formatting touches locale facets, so this is hardening, not a
-// strict async-signal-safe guarantee. Extreme heap corruption can still defeat
-// DbgHelp; out-of-process / minidump capture (W-B/W-C) is recorded as future
-// work in docs/windows-crash-symbols.md.
+// strict async-signal-safe guarantee. W-B (below) additionally writes a minidump
+// so most heap-corruption crashes still yield a symbolizable artifact offline,
+// but both the text walk and the in-process minidump can still be defeated by
+// extreme heap corruption or a stack overflow. The out-of-process dumper (W-C)
+// that would remove that residual was evaluated and declined for its permanent
+// maintenance cost; the residual tiers are documented in
+// docs/windows-crash-symbols.md.
 
-// Preallocated crash-report path buffer; never built with std::string in-handler.
-char kf_crash_pathbuf[1024];
+// Preallocated crash-report path buffers; never built with std::string in-handler.
+char kf_crash_pathbuf[1024];     // text hs_err_*.log (W-A)
+char kf_dump_pathbuf[1024];      // minidump hs_err_*.dmp (W-B), same pid/timestamp
+char kf_dumppart_pathbuf[1024];  // ".part" sibling the dump is written to first
 
 // Minimal WriteFile-backed streambuf so StackWalker can keep writing to a
 // std::ostream while bypassing the CRT stdio file lock the faulting thread might
@@ -201,6 +208,74 @@ void write_exception_line(HANDLE h, DWORD code) {
   }
   OutputDebugStringA(line);
 }
+
+// Write a MiniDumpNormal next to the text report, sharing its pid + timestamp so
+// the two artifacts pair up (only the extension differs). MiniDumpNormal keeps
+// the footprint small (thread stacks + module list + handles, not the full
+// working set) so the privacy surface stays bounded, and defers symbolization to
+// offline analysis with the matching .pdb -- it needs no DbgHelp Sym* heap
+// allocation, so it is a more robust artifact under heap corruption than the
+// text stack walk.
+//
+// This runs before the fragile DbgHelp stack walk (which can truncate or fault
+// under extreme heap corruption) but after the cheap header + exception line, so
+// the essential "what/where" is already on disk and the robust dump gets its shot
+// before the risky symbol walk (validated: with the dump written after the walk,
+// heap-corruption crashes that truncated the text to a stub produced no dump at
+// all). Still in-process, so extreme heap corruption or a stack overflow can
+// defeat MiniDumpWriteDump too -- accepted limitation, see
+// docs/windows-crash-symbols.md; the out-of-process dumper (W-C) that would
+// remove it was evaluated and declined for its permanent maintenance cost.
+void write_crash_minidump(EXCEPTION_POINTERS *ep, const SYSTEMTIME &st) {
+  // A stack overflow leaves too little stack to run MiniDumpWriteDump (a heavy
+  // call); attempting it just faults inside the handler. Skip it -- the text path
+  // already recorded the exception, and stack overflow is an accepted limitation.
+  if (ep->ExceptionRecord->ExceptionCode == EXCEPTION_STACK_OVERFLOW) {
+    return;
+  }
+
+  // Final "<dir>/hs_err_pid<pid>_<YYYYMMDD_HHMMSS>.dmp" path (paired with .log).
+  size_t dp = as_put_str(kf_dump_pathbuf, sizeof(kf_dump_pathbuf), 0, error_log_dir.c_str());
+  dp = as_put_str(kf_dump_pathbuf, sizeof(kf_dump_pathbuf), dp, "/hs_err_pid");
+  dp = as_put_uint(kf_dump_pathbuf, sizeof(kf_dump_pathbuf), dp, static_cast<unsigned long>(GetCurrentProcessId()));
+  dp = as_put_str(kf_dump_pathbuf, sizeof(kf_dump_pathbuf), dp, "_");
+  dp = as_put_uint(kf_dump_pathbuf, sizeof(kf_dump_pathbuf), dp, st.wYear);
+  dp = as_put_uint2(kf_dump_pathbuf, sizeof(kf_dump_pathbuf), dp, st.wMonth);
+  dp = as_put_uint2(kf_dump_pathbuf, sizeof(kf_dump_pathbuf), dp, st.wDay);
+  dp = as_put_str(kf_dump_pathbuf, sizeof(kf_dump_pathbuf), dp, "_");
+  dp = as_put_uint2(kf_dump_pathbuf, sizeof(kf_dump_pathbuf), dp, st.wHour);
+  dp = as_put_uint2(kf_dump_pathbuf, sizeof(kf_dump_pathbuf), dp, st.wMinute);
+  dp = as_put_uint2(kf_dump_pathbuf, sizeof(kf_dump_pathbuf), dp, st.wSecond);
+  as_put_str(kf_dump_pathbuf, sizeof(kf_dump_pathbuf), dp, ".dmp");
+
+  // Write to a ".part" sibling and rename only on success, so a .dmp file always
+  // means a complete minidump. If MiniDumpWriteDump faults mid-write under extreme
+  // corruption, the leftover is a clearly-incomplete ".part", not a 0-byte ".dmp"
+  // that looks like real evidence.
+  size_t pn = as_put_str(kf_dumppart_pathbuf, sizeof(kf_dumppart_pathbuf), 0, kf_dump_pathbuf);
+  as_put_str(kf_dumppart_pathbuf, sizeof(kf_dumppart_pathbuf), pn, ".part");
+
+  HANDLE hd = CreateFileA(kf_dumppart_pathbuf, GENERIC_WRITE, FILE_SHARE_READ, nullptr, CREATE_ALWAYS,
+                          FILE_ATTRIBUTE_NORMAL, nullptr);
+  if (hd == INVALID_HANDLE_VALUE) {
+    return;
+  }
+  MINIDUMP_EXCEPTION_INFORMATION mei;
+  mei.ThreadId = GetCurrentThreadId();
+  mei.ExceptionPointers = ep;
+  mei.ClientPointers = FALSE;
+  BOOL ok = MiniDumpWriteDump(GetCurrentProcess(), GetCurrentProcessId(), hd, MiniDumpNormal, &mei, nullptr, nullptr);
+  CloseHandle(hd);
+  if (!ok) {
+    DeleteFileA(kf_dumppart_pathbuf);
+    OutputDebugStringA("# kungfu minidump write failed; removed partial file\n");
+    return;
+  }
+  MoveFileExA(kf_dumppart_pathbuf, kf_dump_pathbuf, MOVEFILE_REPLACE_EXISTING);
+  OutputDebugStringA("# kungfu minidump saved: ");
+  OutputDebugStringA(kf_dump_pathbuf);
+  OutputDebugStringA("\n");
+}
 } // namespace
 
 // Crash dump for the Windows SEH / unhandled-exception path. Keeps returning
@@ -241,6 +316,15 @@ DWORD print_stack_trace(EXCEPTION_POINTERS *ep) {
 
   if (ep != nullptr) {
     write_exception_line(h, ep->ExceptionRecord->ExceptionCode);
+  }
+
+  // Capture the minidump after the cheap header + exception line above (so the
+  // essential fault info is already flushed) but before the fragile DbgHelp stack
+  // walk below (which can truncate/fault under extreme heap corruption). Only real
+  // faults carry an EXCEPTION_POINTERS; the non-fatal print_stack_trace()
+  // diagnostic path (ep == nullptr) stays text-only.
+  if (ep != nullptr) {
+    write_crash_minidump(ep, st);
   }
 
   // Symbolized stack goes straight to the file via the WriteFile-backed streambuf.


### PR DESCRIPTION
## What

On a fatal native crash, write a `MiniDumpNormal` `.dmp` next to the existing
text `hs_err_*.log`, sharing the same `pid_timestamp` stem. Builds on #174
(crash-handler deadlock hardening).

## Why

The text report resolves symbols in-process via DbgHelp, which allocates on the
crashing heap. Under heap corruption -- the case most worth diagnosing -- that
truncates or degrades to `module+offset`. A minidump snapshots memory and the
module list and defers symbolization to offline analysis with the matching PDB,
so it usually survives heap-corruption crashes that truncate the text stack.

## Behavior

- The dump is written only on real faults carrying an exception context (the SEH
  `__except` in `hero::produce` and the `SetUnhandledExceptionFilter` backstop).
  The non-fatal `print_stack_trace()` diagnostic path (node/rx catch blocks)
  stays text-only.
- Ordering (settled by on-hardware validation): exception line first, then the
  minidump, then the fragile DbgHelp stack walk -- so the fault is recorded even
  if a later step faults, and the robust dump runs before the risky symbol walk.
- Stack overflow: the dump is skipped (too little stack is left to run
  `MiniDumpWriteDump`; it would only fault). The text report still records the
  exception.
- The dump is written to a `.part` sibling and renamed on success, so a `.dmp`
  file always means a complete minidump.
- `MiniDumpNormal` (thread stacks + module list + handles, no full working set)
  keeps the footprint and privacy surface small.

## Limitations (accepted)

Still in-process: extreme heap corruption or a stack overflow can defeat the dump
too. Out-of-process capture would remove that but adds a permanent
resident-process + IPC maintenance surface, which is not justified here; it was
evaluated and declined. Residual tiers are documented in
`framework/core/docs/windows-crash-symbols.md`.

## Validation

Standalone MSVC harness compiling the real `stacktrace.cpp` + `StackWalker.cpp`,
one process per scenario with a 20s watchdog, across AV / heap-corruption AV /
stack overflow / non-fatal catch, on both the SEUF and SEH paths:

- No deadlock or double-fault in any scenario (the process always exits).
- Common AVs: full symbolized log + valid ~48KB minidump every run.
- Recoverable heap corruption: full log + valid minidump; total corruption: a
  text stub with the exception line, no dump, no stray file.
- Stack overflow: dump skipped, text-only. Non-fatal catch: text-only.
- No 0-byte `.dmp` and no `.part` leftovers.

No public header or ABI change (`print_stack_trace` signature is unchanged; the
helper is file-local). `dbghelp.lib` was already linked, so there is no build
change.
