### PR TITLE
feat(sdk): build C++ kfx extensions via kfs, add a libkungfu FlatBuffers probe

### DIFF
--- a/developer/sdk/src/kfs.js
+++ b/developer/sdk/src/kfs.js
@@ -6,6 +6,7 @@
 // binding), wired the same way as the reference GUI. The generated app is
 // self-contained; it consumes the platform through published packages, or
 // through the workspace when scaffolded inside the monorepo (--workspace).
+import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -33,6 +34,10 @@ function usage(code) {
       'kungfuConfig.config.view); build bundles src/view/ to dist/view/index.js',
       'with react and the capability SDK left external — the shell injects',
       'its own instances at load time.',
+      '',
+      'kfx build also handles adapter facets (ships source) and C++ extensions',
+      '(a package with a CMakeLists.txt): it drives CMake with the core conan',
+      'toolchain to compile src/cpp/ into a native pybind11 module under dist/.',
       '',
     ].join('\n'),
   );
@@ -163,11 +168,78 @@ function readManifest() {
   return JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
 }
 
+// ── kfx C++ extension build ────────────────────────────────────────────────
+// A C++ kfx compiles src/cpp/*.cpp against the libkungfu API (headers + the
+// built shared library) and its FlatBuffers data structures into a native
+// pybind11 module. The extension's CMakeLists.txt includes a libkungfu-only
+// helper (cmake/kungfu.cmake); this driver invokes CMake with the core's conan
+// toolchain and pins the module to the core's Python so it loads in kfc.
+
+function locateCoreDir(startDir) {
+  let dir = startDir;
+  for (let i = 0; i < 8; i += 1) {
+    const candidate = path.join(dir, 'framework', 'core');
+    if (fs.existsSync(path.join(candidate, 'conanfile.py'))) return candidate;
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return null;
+}
+
+function runOrFail(cmd, args) {
+  const result = spawnSync(cmd, args, { stdio: 'inherit' });
+  if (result.error) fail(`${cmd} not runnable: ${result.error.message}`);
+  if (result.status !== 0) {
+    fail(`${cmd} ${args.join(' ')} failed (exit ${result.status ?? `signal ${result.signal}`})`);
+  }
+}
+
+function cppBuild(manifest) {
+  const coreDir = locateCoreDir(process.cwd());
+  if (!coreDir) fail('cannot locate framework/core (a cpp kfx build needs the monorepo core)');
+  const toolchain = path.join(coreDir, 'build', 'conan_toolchain.cmake');
+  if (!fs.existsSync(toolchain)) {
+    fail(`core not built: ${toolchain} is missing. Run \`./kungfu-code rebuild:core\` first.`);
+  }
+  const buildDir = path.resolve('build');
+  const distDir = path.resolve('dist', manifest.kungfuConfig?.key ?? 'cpp');
+  fs.mkdirSync(distDir, { recursive: true });
+  const configureArgs = [
+    '-S',
+    '.',
+    '-B',
+    buildDir,
+    `-DCMAKE_TOOLCHAIN_FILE=${toolchain}`,
+    '-DCMAKE_BUILD_TYPE=Release',
+    `-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=${distDir}`,
+  ];
+  // Pin the module to the core's Python (the uv-managed venv) so it is ABI-
+  // compatible with the runtime and loads alongside pykungfu. Pass both the
+  // classic (FindPythonInterp) and modern (FindPython) hint variables so the
+  // pin holds regardless of which pybind11 lookup mode is active.
+  const corePython = path.join(coreDir, '.venv', 'bin', 'python3');
+  if (fs.existsSync(corePython)) {
+    configureArgs.push(`-DPYTHON_EXECUTABLE=${corePython}`, `-DPython_EXECUTABLE=${corePython}`);
+  }
+  runOrFail('cmake', configureArgs);
+  runOrFail('cmake', ['--build', buildDir, '--config', 'Release']);
+  process.stdout.write(
+    `built ${manifest.name ?? 'cpp extension'} -> ${path.relative(process.cwd(), distDir)}\n`,
+  );
+}
+
 async function kfxBuild() {
   const manifest = readManifest();
   const config = manifest.kungfuConfig?.config ?? {};
   const view = config.view;
   if (!view) {
+    // A C++ extension compiles native code against libkungfu into a pybind11
+    // module. It is detected by a CMakeLists.txt at the package root.
+    if (fs.existsSync(path.resolve('CMakeLists.txt'))) {
+      cppBuild(manifest);
+      return;
+    }
     // An adapter facet is a runtime extension: it ships source per child
     // runtime (python/node) and the capture supervisor injects it — there is
     // nothing to bundle. Succeed so `kfs kfx build` is usable on any kfx.
@@ -177,7 +249,7 @@ async function kfxBuild() {
       );
       return;
     }
-    fail('package.json has no kungfuConfig.config.view or .adapter facet');
+    fail('package.json has no kungfuConfig.config.view or .adapter facet, and no CMakeLists.txt (cpp)');
   }
   const entry = ['src/view/index.tsx', 'src/view/index.ts'].find((candidate) =>
     fs.existsSync(path.resolve(candidate)),
@@ -204,6 +276,8 @@ async function kfxBuild() {
 function kfxClean() {
   readManifest();
   fs.rmSync(path.resolve('dist'), { recursive: true, force: true });
+  // A cpp extension also has a CMake build tree.
+  fs.rmSync(path.resolve('build'), { recursive: true, force: true });
   process.stdout.write('cleaned dist\n');
 }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -137,10 +137,12 @@ exercises a distinct extension path:
 SDK can package a complete application from the runtime, the reference surfaces
 and the extensions. Trading-specific reference extensions from earlier versions
 are being retired, and their coverage role is being handed to neutral
-replacements that exercise the same paths. This is mid-transition: the Python
-path stays covered by a neutral extension (`indexer-live`), while the C++
-probe's neutral replacement is not yet in place — so the C++ extension path is
-temporarily without a dedicated build-time probe until it lands.
+replacements that exercise the same paths. The C++ path is covered by
+[`extensions/probe-cpp`](../extensions/probe-cpp): a neutral probe that compiles
+against the `libkungfu` API and its FlatBuffers data structures into a native
+module (`kfs kfx build` drives CMake through the core toolchain). The remaining
+paths — a Python extension through the bundled ahead-of-time toolchain, and a
+JavaScript / TypeScript extension — are still being reinstated.
 
 ## Repository layout
 

--- a/extensions/probe-cpp/CMakeLists.txt
+++ b/extensions/probe-cpp/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_minimum_required(VERSION 3.23)
+project(probe_cpp CXX)
+
+include(${CMAKE_CURRENT_LIST_DIR}/cmake/kungfu.cmake)
+
+kungfu_cpp_extension(probe_cpp)

--- a/extensions/probe-cpp/cmake/kungfu.cmake
+++ b/extensions/probe-cpp/cmake/kungfu.cmake
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Minimal, libkungfu-only build helper for a kfx C++ extension (v4 rewrite of the
+# retired v2/v3 build/kungfu.cmake). It:
+#   - locates the in-repo built core (libkungfu + its conan dependencies),
+#   - wires pybind11 and FlatBuffers via the conan-generated configs,
+#   - compiles src/cpp/*.cpp into a native pybind11 module (.so/.dylib/.pyd).
+#
+# It deliberately does NOT depend on libwingchun and does NOT invoke a separate
+# flatc binary: the extension consumes libkungfu's already-generated FlatBuffers
+# headers. Configure with the core's conan toolchain for ABI compatibility:
+#
+#   cmake -S . -B build \
+#     -DCMAKE_TOOLCHAIN_FILE=<repo>/framework/core/build/conan_toolchain.cmake
+#   cmake --build build
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+get_filename_component(KF_CORE_DIR "${CMAKE_CURRENT_LIST_DIR}/../../../framework/core" ABSOLUTE)
+if(NOT EXISTS "${KF_CORE_DIR}/src/libkungfu/include")
+  message(FATAL_ERROR "libkungfu headers not found under ${KF_CORE_DIR}. Build the core first: ./kungfu-code rebuild:core")
+endif()
+
+# conan-generated find_package() configs/modules live in the core build dir.
+list(PREPEND CMAKE_PREFIX_PATH "${KF_CORE_DIR}/build")
+list(PREPEND CMAKE_MODULE_PATH "${KF_CORE_DIR}/build")
+
+find_package(pybind11 REQUIRED)
+find_package(flatbuffers REQUIRED)
+
+# The built libkungfu shared library.
+find_library(KF_LIBKUNGFU
+  NAMES kungfu libkungfu
+  PATHS "${KF_CORE_DIR}/build/Release" "${KF_CORE_DIR}/dist/kfc"
+  NO_DEFAULT_PATH)
+if(NOT KF_LIBKUNGFU)
+  message(FATAL_ERROR "libkungfu shared library not found under ${KF_CORE_DIR}. Build the core first: ./kungfu-code rebuild:core")
+endif()
+
+# Compile src/cpp/*.cpp of the current extension into a native pybind11 module
+# named ${_target}, linked against libkungfu + FlatBuffers.
+macro(kungfu_cpp_extension _target)
+  file(GLOB _kf_srcs CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/*.cpp")
+  pybind11_add_module(${_target} SHARED ${_kf_srcs})
+  target_include_directories(${_target} PRIVATE
+    "${KF_CORE_DIR}/src/libkungfu/include"
+    "${KF_CORE_DIR}/src/libyijinjing/include")
+  target_link_libraries(${_target} PRIVATE ${KF_LIBKUNGFU} flatbuffers::flatbuffers)
+endmacro()

--- a/extensions/probe-cpp/package.json
+++ b/extensions/probe-cpp/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@kungfu-tech/kfx-probe-cpp",
+  "author": "kungfu",
+  "version": "4.0.0-alpha.0",
+  "description": "C++ dogfood coverage probe: compiles against libkungfu and its FlatBuffers data structures into a native module, exercising the C++ kfx build path.",
+  "license": "Apache-2.0",
+  "private": true,
+  "kungfuConfig": {
+    "key": "ProbeCpp"
+  },
+  "scripts": {
+    "build": "kfs kfx build",
+    "clean": "kfs kfx clean"
+  },
+  "devDependencies": {
+    "@kungfu-tech/core": "workspace:*",
+    "@kungfu-tech/sdk": "workspace:*"
+  },
+  "repository": {
+    "url": "https://github.com/kungfu-systems/kungfu.git"
+  }
+}

--- a/extensions/probe-cpp/src/cpp/probe.cpp
+++ b/extensions/probe-cpp/src/cpp/probe.cpp
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// C++ dogfood coverage probe for the v4 kfx build path.
+//
+// Purpose: prove — at build time — that a standalone kfx extension can compile
+// C++ against the libkungfu API, reference its FlatBuffers-generated data
+// structures, and link into a native pybind11 module (.so / .dylib / .pyd).
+//
+// It is deliberately neutral: it depends only on libkungfu (no libwingchun) and
+// consumes libkungfu's already-generated FlatBuffers accessors directly, so the
+// build needs no separate flatc invocation. Building this module *is* the probe
+// — if FlatBuffers codegen or the libkungfu include/ABI surface regresses, this
+// stops compiling, so a core capability break shows up as a build failure.
+
+#include <cstdint>
+
+#include <flatbuffers/flatbuffers.h>
+#include <kungfu/longfist/fb/order_generated.h> // libkungfu's flatc-generated FB accessors
+#include <kungfu/yijinjing/time.h>              // a real (non-inline) libkungfu API symbol
+
+#include <pybind11/pybind11.h>
+
+namespace py = pybind11;
+namespace fb = kungfu::longfist::fb;
+
+// Build a FlatBuffers payload with libkungfu's generated schema, then read the
+// field back. This exercises, at C++ compile time, the generated header, the
+// FlatBuffers runtime, and the libkungfu public include surface.
+static std::uint64_t fb_roundtrip(std::uint64_t order_id) {
+  flatbuffers::FlatBufferBuilder fbb;
+  fb::OrderBuilder builder(fbb);
+  builder.add_order_id(order_id);
+  fbb.Finish(builder.Finish());
+  const fb::Order *decoded = fb::GetOrder(fbb.GetBufferPointer());
+  return decoded->order_id();
+}
+
+// Call a real libkungfu symbol (not header-only) so the module genuinely links
+// against libkungfu — proving the link surface, not just the headers.
+static std::int64_t now_in_nano() { return kungfu::yijinjing::time::now_in_nano(); }
+
+PYBIND11_MODULE(probe_cpp, m) {
+  m.doc() = "kfx C++ build-time coverage probe: libkungfu + FlatBuffers -> native module";
+  m.def("fb_roundtrip", &fb_roundtrip, py::arg("order_id"),
+        "Round-trip a value through a libkungfu FlatBuffers Order table.");
+  m.def("now_in_nano", &now_in_nano, "Call into libkungfu (yijinjing::time) to prove the link surface.");
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -151,6 +151,15 @@ importers:
 
   extensions/langchain-adapter: {}
 
+  extensions/probe-cpp:
+    devDependencies:
+      '@kungfu-tech/core':
+        specifier: workspace:*
+        version: link:../../framework/core
+      '@kungfu-tech/sdk':
+        specifier: workspace:*
+        version: link:../../developer/sdk
+
   extensions/rewind-inspector:
     dependencies:
       '@kungfu-tech/api':

--- a/verify.js
+++ b/verify.js
@@ -94,6 +94,17 @@ function main() {
   if (doFull) {
     try {
       runPnpm('rebuild:core'); // clean + build:conan C++/wheel/native
+      // C++ dogfood probe: compile the reference cpp kfx against the freshly
+      // built libkungfu (headers + shared lib + FlatBuffers) into a native
+      // module. If a core capability regresses, this build breaks here.
+      const probeBuild = spawnSync('pnpm', ['--filter', '@kungfu-tech/kfx-probe-cpp', 'run', 'build'], {
+        cwd: ROOT,
+        stdio: 'inherit',
+        shell: isWin,
+      });
+      if (probeBuild.status !== 0) {
+        throw new Error(`cpp probe build failed (exit ${probeBuild.status == null ? 'signal ' + probeBuild.signal : probeBuild.status})`);
+      }
       runPnpm('freeze'); // nuitka → framework/core/dist/kfc
       if (withApp) runPnpm('build:app'); // webpack → framework/gui/dist/app
     } catch (e) {
@@ -123,6 +134,23 @@ function main() {
     }
   } else {
     fail('dist/kfc directory exists', `not found ${path.relative(ROOT, distKfc)} (freeze first; in quick mode, confirm it was built)`);
+  }
+
+  // ── Stage 2b: C++ extension probe artifact ────────────────────────
+  // The reference cpp kfx (extensions/probe-cpp) compiles against libkungfu and
+  // its FlatBuffers types into a native module; its presence proves the C++
+  // extension build path. Built in Stage 1 under --full.
+  console.log('\n[verify] stage 2b: C++ extension probe artifact');
+  const probeDist = path.join(ROOT, 'extensions', 'probe-cpp', 'dist', 'ProbeCpp');
+  const probeSo = fs.existsSync(probeDist)
+    ? fs.readdirSync(probeDist).find((f) => /^probe_cpp\..*\.(so|dylib|pyd)$/.test(f))
+    : null;
+  if (probeSo) {
+    pass('cpp probe native module built', path.relative(ROOT, path.join(probeDist, probeSo)));
+  } else if (doFull) {
+    fail('cpp probe native module built', `no probe_cpp.*.(so|dylib|pyd) under ${path.relative(ROOT, probeDist)}`);
+  } else {
+    console.log(`  (skipped: no cpp probe artifact; build it with 'pnpm --filter @kungfu-tech/kfx-probe-cpp run build' or --full)`);
   }
 
   // ── Stage 3: kfc runtime smoke ────────────────────────────────────


### PR DESCRIPTION
## What

Adds first-class C++ kfx extension support to the v4 SDK, plus a neutral
reference probe that reinstates the C++ dogfood coverage lane.

Before this, `kfs` only built view extensions (esbuild) and adapter facets
(ship source); a package with C++ sources had no working v4 build path (the old
`build/kungfu.cmake` and the v2/v3 `*-cpp-101` examples are dead). This wires
C++ back in cleanly, libkungfu-only.

## Changes

- **`kfs kfx build`** detects a `CMakeLists.txt` at the package root and drives
  CMake with the core's conan toolchain, pinned to the core's Python, compiling
  `src/cpp/` into a native pybind11 module under `dist/`.
- **`extensions/probe-cpp`** — a neutral C++ kfx:
  - `src/cpp/probe.cpp`: round-trips a value through libkungfu's generated
    FlatBuffers `Order` table and calls a real libkungfu symbol
    (`yijinjing::time::now_in_nano`), so it genuinely links libkungfu.
  - `cmake/kungfu.cmake`: a fresh, libkungfu-only build helper — no libwingchun,
    no separate `flatc` binary (it consumes libkungfu's generated FB headers),
    `find_package(pybind11/flatbuffers)` via the conan configs.
- **`verify`** builds the probe under `--full` (after `rebuild:core`) and
  asserts the native module exists, so a core capability regression surfaces as
  a C++ build failure.
- **`docs/architecture.md`**: the C++ coverage path is now covered by
  `probe-cpp`; the Python and JS/TS paths are noted as still being reinstated.

## Validation

Local macOS arm64: `./kungfu-code rebuild:core` then `kfs kfx build` in
`extensions/probe-cpp` produces `probe_cpp.cpython-313-darwin.so`, `otool -L`
shows it links `@rpath/libkungfu.dylib`, and loading it under the core Python
runs `fb_roundtrip(7) == 7` and `now_in_nano() > 0`. Relying on the
`buildchain-validate` CI gate for the full cross-platform build.
