### PR TITLE
feat(gui): embed sandboxed views in an isolated WebContentsView over a capability relay

### DIFF
--- a/framework/gui/electron.vite.config.mjs
+++ b/framework/gui/electron.vite.config.mjs
@@ -1,19 +1,43 @@
-import { defineConfig, externalizeDepsPlugin } from 'electron-vite';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import react from '@vitejs/plugin-react';
+import { defineConfig, externalizeDepsPlugin } from 'electron-vite';
+
+const rootDir = dirname(fileURLToPath(import.meta.url));
 
 // - main: externalize deps so the native binding is never bundled; it is loaded
 //   via require() at runtime from kungfu-core's dist/kfc.
+// - preload: the sandbox preload — the only bridge an isolated sandboxed view
+//   gets (contextBridge exposes __kfxBridge); built as its own entry.
 // - renderer: react; keep electron and the native binding external so the
-//   renderer require()s them at runtime under nodeIntegration.
+//   trusted renderer require()s them at runtime under nodeIntegration. Two html
+//   entries: the shell (index) and the isolated sandboxed-view harness.
 export default defineConfig({
   main: {
     plugins: [externalizeDepsPlugin()],
+  },
+  preload: {
+    plugins: [externalizeDepsPlugin()],
+    build: {
+      rollupOptions: {
+        input: {
+          sandbox: resolve(rootDir, 'src/preload/sandbox.ts'),
+        },
+      },
+    },
   },
   renderer: {
     plugins: [react()],
     build: {
       rollupOptions: {
         external: ['electron'],
+        input: {
+          index: resolve(rootDir, 'src/renderer/index.html'),
+          'sandbox-view-harness': resolve(
+            rootDir,
+            'src/renderer/sandbox-view-harness/index.html',
+          ),
+        },
       },
     },
   },

--- a/framework/gui/src/main/index.ts
+++ b/framework/gui/src/main/index.ts
@@ -6,7 +6,16 @@ import path from 'node:path';
 // environment variables present when the process starts. The renderer process
 // is spawned by this main process, so the runtime directory must be exported
 // here, before any window (and therefore the renderer process) is created.
-import { BrowserWindow, app } from 'electron';
+import { BrowserWindow, WebContentsView, app, ipcMain } from 'electron';
+
+import {
+  DESTROY_CHANNEL,
+  ENSURE_CHANNEL,
+  HIDE_CHANNEL,
+  SET_BOUNDS_CHANNEL,
+  SHOW_CHANNEL,
+} from '../sandbox/channels';
+import { type Rect, SandboxManager } from './sandbox-manager';
 
 // Resolve the kungfu runtime directory (kfc) that holds libkungfu.dylib and the
 // kungfu_electron.node binding. In development it lives in the kungfu-core
@@ -62,6 +71,41 @@ try {
   console.log(`KFE_MAIN_FAIL ${(e as Error).message}`);
 }
 
+// The isolated sandboxed-view harness page. In dev it is served by the renderer
+// dev server; once built it sits beside the main renderer under out/renderer.
+function harnessEntry(): string {
+  return process.env.ELECTRON_RENDERER_URL
+    ? `${process.env.ELECTRON_RENDERER_URL}/sandbox-view-harness/index.html`
+    : `file://${path.join(__dirname, '../renderer/sandbox-view-harness/index.html')}`;
+}
+
+// The embedded-view manager is created per shell window; the ipcMain control
+// handlers are registered once and dispatch to the current manager. This keeps
+// `activate` (which re-runs createWindow) from double-registering a channel.
+let manager: SandboxManager | null = null;
+
+ipcMain.handle(ENSURE_CHANNEL, (_event, payload) => {
+  const { id, bundlePath, declared } = payload as {
+    id: string;
+    bundlePath: string;
+    declared: string[];
+  };
+  manager?.ensureView({ id, bundlePath, declared });
+});
+ipcMain.on(SET_BOUNDS_CHANNEL, (_event, payload) => {
+  const { id, rect } = payload as { id: string; rect: Rect };
+  manager?.setBounds(id, rect);
+});
+ipcMain.on(SHOW_CHANNEL, (_event, payload) => {
+  manager?.show((payload as { id: string }).id);
+});
+ipcMain.on(HIDE_CHANNEL, (_event, payload) => {
+  manager?.hide((payload as { id: string }).id);
+});
+ipcMain.on(DESTROY_CHANNEL, (_event, payload) => {
+  manager?.destroyView((payload as { id: string }).id);
+});
+
 function createWindow() {
   const win = new BrowserWindow({
     width: 1280,
@@ -75,6 +119,15 @@ function createWindow() {
       contextIsolation: false,
       sandbox: false,
     },
+  });
+
+  // The trusted renderer holds the real capabilities and runs the capability
+  // host; this manager embeds sandboxed views and relays their invokes to it.
+  manager = new SandboxManager({
+    shell: win,
+    ipcMain,
+    WebContentsView,
+    harnessEntry,
   });
 
   win.on('ready-to-show', () => win.show());

--- a/framework/gui/src/main/sandbox-manager.ts
+++ b/framework/gui/src/main/sandbox-manager.ts
@@ -1,0 +1,244 @@
+// Main-process manager for embedded sandboxed kfx views. A sandboxed view runs
+// in an isolated renderer with node stripped; it is embedded in the shell window
+// as a child WebContentsView and positioned over the shell's content area. The
+// view reaches only its declared capabilities, and those real capabilities live
+// in the trusted node-integrated renderer (they hold the native binding). So the
+// capability path is three hops:
+//
+//   sandboxed view --IPC(INVOKE_CHANNEL)--> main (this manager, a relay)
+//     --IPC(kfx:host-invoke)--> trusted renderer's capability host (real caps)
+//
+// and events flow back the reverse way. Main is a pure relay: it never sees the
+// real capabilities and never interprets the {cap,method,args} payload — the
+// declared-only enforcement lives in the trusted renderer's createCapabilityHost
+// (co-located with the caps it guards). This keeps the guest<->host callback and
+// subscription protocol intact end to end; the relay just forwards two channels.
+import { readFileSync } from 'node:fs';
+import type { BrowserWindow, WebContents, WebContentsView } from 'electron';
+
+import type { HostEvent, HostRequest } from '@kungfu-tech/api/capability';
+import {
+  HOST_EVENT_CHANNEL,
+  HOST_INVOKE_CHANNEL,
+  HOST_REPLY_CHANNEL,
+} from '../sandbox/channels';
+import { EVENT_CHANNEL, INVOKE_CHANNEL } from '../sandbox/transport';
+import { sandboxWebPreferences, startResourceGuard } from './sandbox-view';
+
+// The global the isolated harness page exposes; main injects the view bundle
+// source through its `load` method (see sandbox-view-harness/harness.ts). The
+// bundle is read by main (trusted) and shipped as a string, so the sandboxed
+// renderer never gets fs/require — it only receives the wrapped source.
+const HARNESS_GLOBAL = '__kfxHarness';
+
+export type EnsureViewOptions = {
+  id: string;
+  // capability keys the view's manifest declares
+  declared: readonly string[];
+  // absolute path to the view bundle the isolated harness will load
+  bundlePath: string;
+  // preload override (the built sandbox preload by default, via webPrefs)
+  preload?: string;
+  // working-set cap in KiB; over it the view is killed
+  memoryCapKb?: number;
+};
+
+export type Rect = { x: number; y: number; width: number; height: number };
+
+// The Electron surface the manager needs, kept as a small structural type so the
+// manager is unit-constructible with fakes and only the app supplies real
+// electron. WebContentsView / BrowserWindow / ipcMain match these shapes.
+type IpcMainLike = {
+  handle: (
+    channel: string,
+    listener: (event: { sender: WebContents }, payload: unknown) => unknown,
+  ) => void;
+  removeHandler: (channel: string) => void;
+  on: (
+    channel: string,
+    listener: (event: { sender: WebContents }, payload: unknown) => void,
+  ) => void;
+};
+
+type WebContentsViewCtor = new (opts: {
+  webPreferences: ReturnType<typeof sandboxWebPreferences>;
+}) => WebContentsView;
+
+export type SandboxManagerDeps = {
+  // the shell (trusted) window: its contentView hosts the child views and its
+  // webContents runs the trusted capability host service
+  shell: Pick<BrowserWindow, 'contentView'> & { webContents: WebContents };
+  ipcMain: IpcMainLike;
+  WebContentsView: WebContentsViewCtor;
+  // resolve the isolated harness page URL (the manager stays free of the app's
+  // asset layout; the app / harness supplies this)
+  harnessEntry: () => string;
+  // read a view bundle's source (main is trusted; defaults to node fs). Injected
+  // so the manager is unit-constructible without the real filesystem.
+  readBundleSource?: (bundlePath: string) => string;
+};
+
+type ViewEntry = {
+  id: string;
+  view: WebContentsView;
+  stopGuard: () => void;
+  visible: boolean;
+};
+
+export class SandboxManager {
+  private readonly deps: SandboxManagerDeps;
+  private readonly views = new Map<string, ViewEntry>();
+  // route an INVOKE by the sender webContents id back to the view id
+  private readonly bySender = new Map<number, string>();
+  // pending main<->trusted-renderer request correlation
+  private readonly pending = new Map<
+    number,
+    { resolve: (v: unknown) => void; reject: (e: Error) => void }
+  >();
+  private reqSeq = 0;
+
+  constructor(deps: SandboxManagerDeps) {
+    this.deps = deps;
+    const { ipcMain } = deps;
+
+    // Hop 1 -> 2: an invoke from a sandboxed view is forwarded to the trusted
+    // renderer's host, keyed to the view the sender belongs to.
+    ipcMain.handle(INVOKE_CHANNEL, (event, payload) => {
+      const viewId = this.bySender.get(event.sender.id);
+      if (!viewId) {
+        return Promise.reject(
+          new Error('sandboxed invoke from an unknown view'),
+        );
+      }
+      return this.forwardToHost(viewId, payload as HostRequest);
+    });
+
+    // Hop 2 reply: the trusted renderer answers a forwarded invoke.
+    ipcMain.on(HOST_REPLY_CHANNEL, (_event, payload) => {
+      const { reqId, ok, value, error } = payload as {
+        reqId: number;
+        ok: boolean;
+        value?: unknown;
+        error?: string;
+      };
+      const waiter = this.pending.get(reqId);
+      if (!waiter) return;
+      this.pending.delete(reqId);
+      if (ok) waiter.resolve(value);
+      else waiter.reject(new Error(error ?? 'sandbox host error'));
+    });
+
+    // Host -> guest event: a bridged callback fired in the trusted host; relay
+    // it to the owning sandboxed view.
+    ipcMain.on(HOST_EVENT_CHANNEL, (_event, payload) => {
+      const { id, event } = payload as { id: string; event: HostEvent };
+      const entry = this.views.get(id);
+      if (entry && !entry.view.webContents.isDestroyed()) {
+        entry.view.webContents.send(EVENT_CHANNEL, event);
+      }
+    });
+  }
+
+  private forwardToHost(id: string, req: HostRequest): Promise<unknown> {
+    const trusted = this.deps.shell.webContents;
+    if (trusted.isDestroyed()) {
+      return Promise.reject(new Error('trusted renderer is gone'));
+    }
+    this.reqSeq += 1;
+    const reqId = this.reqSeq;
+    return new Promise<unknown>((resolve, reject) => {
+      this.pending.set(reqId, { resolve, reject });
+      trusted.send(HOST_INVOKE_CHANNEL, { id, reqId, req });
+    });
+  }
+
+  // Create (or reuse) the sandboxed view and embed it in the shell content view.
+  ensureView(opts: EnsureViewOptions): void {
+    if (this.views.has(opts.id)) return;
+    const view = new this.deps.WebContentsView({
+      webPreferences: sandboxWebPreferences({
+        declared: opts.declared,
+        partitionId: `${opts.id}:${this.reqSeq}`,
+        preload: opts.preload,
+      }),
+    });
+    this.deps.shell.contentView.addChildView(view);
+    // start hidden until the shell reports the content-area rect
+    view.setVisible(false);
+
+    const stopGuard = startResourceGuard(view.webContents, {
+      memoryCapKb: opts.memoryCapKb,
+      onBreach: () => this.destroyView(opts.id),
+    });
+
+    const entry: ViewEntry = { id: opts.id, view, stopGuard, visible: false };
+    this.views.set(opts.id, entry);
+    this.bySender.set(view.webContents.id, opts.id);
+
+    // Once the harness page is up, ship the bundle source into it. Main reads
+    // the file (trusted) and hands the isolated page a string; the page wraps it
+    // with a require shim and mounts the view. Nothing widens the sandbox.
+    const read =
+      this.deps.readBundleSource ?? ((p: string) => readFileSync(p, 'utf8'));
+    view.webContents.on('did-finish-load', () => {
+      if (view.webContents.isDestroyed()) return;
+      let source: string;
+      try {
+        source = read(opts.bundlePath);
+      } catch (e) {
+        void view.webContents.executeJavaScript(
+          `window.${HARNESS_GLOBAL}.fail(${JSON.stringify(
+            `cannot read bundle: ${(e as Error).message}`,
+          )})`,
+        );
+        return;
+      }
+      void view.webContents.executeJavaScript(
+        `window.${HARNESS_GLOBAL}.load(${JSON.stringify(source)})`,
+      );
+    });
+
+    void view.webContents.loadURL(this.deps.harnessEntry());
+  }
+
+  // Position the view over the shell's content area (WebContentsView is an
+  // overlay; the shell reports its content rect and we mirror it here).
+  setBounds(id: string, rect: Rect): void {
+    const entry = this.views.get(id);
+    if (!entry) return;
+    entry.view.setBounds(rect);
+  }
+
+  show(id: string): void {
+    const entry = this.views.get(id);
+    if (!entry) return;
+    entry.visible = true;
+    entry.view.setVisible(true);
+  }
+
+  hide(id: string): void {
+    const entry = this.views.get(id);
+    if (!entry) return;
+    entry.visible = false;
+    entry.view.setVisible(false);
+  }
+
+  destroyView(id: string): void {
+    const entry = this.views.get(id);
+    if (!entry) return;
+    this.views.delete(id);
+    this.bySender.delete(entry.view.webContents.id);
+    entry.stopGuard();
+    this.deps.shell.contentView.removeChildView(entry.view);
+    if (!entry.view.webContents.isDestroyed()) {
+      // WebContentsView has no window to close; drop its renderer explicitly
+      (
+        entry.view.webContents as WebContents & { close?: () => void }
+      ).close?.();
+    }
+  }
+
+  has(id: string): boolean {
+    return this.views.has(id);
+  }
+}

--- a/framework/gui/src/main/sandbox-view.ts
+++ b/framework/gui/src/main/sandbox-view.ts
@@ -1,21 +1,86 @@
 import path from 'node:path';
-// The main-process factory for a sandboxed kfx view: a BrowserWindow with node
-// stripped (nodeIntegration:false / contextIsolation:true / sandbox:true), the
-// sandbox preload, and the view's declared capability keys passed as an
-// additionalArgument. The capability host is bound to the window's webContents
-// so the isolated view's only reach is the declared capabilities over IPC.
+// Main-process building blocks for a sandboxed kfx renderer: the locked-down
+// webPreferences (node stripped, contextIsolation, sandbox, network denied), the
+// resource guard (working-set sampler that kills on breach), and the standalone
+// `createSandboxedView` (a BrowserWindow form, proven live in the harness). The
+// embedded production form — a WebContentsView placed inside the shell window —
+// reuses the same pieces from sandbox-manager; keeping them here as one source
+// means the standalone and embedded views can never drift on isolation posture.
 //
-// This is the production form of the harness proven live: in a real sandboxed
-// renderer window.require/process/Buffer are absent, __kfxBridge carries only
-// the declared keys, a declared call round-trips, and an undeclared call is
-// rejected host-side.
-import { BrowserWindow, app, ipcMain, session } from 'electron';
+// In a real sandboxed renderer window.require/process/Buffer are absent,
+// __kfxBridge carries only the declared keys, a declared call round-trips, and
+// an undeclared call is rejected host-side.
+import {
+  BrowserWindow,
+  type Session,
+  type WebContents,
+  type WebPreferences,
+  app,
+  ipcMain,
+  session,
+} from 'electron';
 
 import { bindElectronHost } from './sandbox-host';
 
 // default resource bounds for a sandboxed view (option A's resource-limit half)
-const DEFAULT_MEMORY_CAP_KB = 512 * 1024; // 512 MiB working set
+export const DEFAULT_MEMORY_CAP_KB = 512 * 1024; // 512 MiB working set
 const SAMPLE_INTERVAL_MS = 2000;
+
+// Give each sandboxed view its own session partition with the network denied:
+// a sandboxed view loads a local bundle and reaches the outside only through
+// its declared capabilities, never http(s).
+export function lockedDownPartition(id: string): string {
+  const partition = `sandbox:${id}`;
+  const ses: Session = session.fromPartition(partition);
+  ses.webRequest.onBeforeRequest((details, callback) => {
+    const ok =
+      details.url.startsWith('file:') || details.url.startsWith('devtools:');
+    callback({ cancel: !ok });
+  });
+  return partition;
+}
+
+// The webPreferences that strip node and lock a sandboxed renderer to its
+// declared capabilities. Shared by the standalone window and the embedded
+// WebContentsView so the isolation posture is defined exactly once.
+export function sandboxWebPreferences(opts: {
+  declared: readonly string[];
+  partitionId: string;
+  preload?: string;
+}): WebPreferences {
+  return {
+    nodeIntegration: false,
+    contextIsolation: true,
+    sandbox: true,
+    partition: lockedDownPartition(opts.partitionId),
+    preload: opts.preload ?? path.join(__dirname, '../preload/sandbox.js'),
+    additionalArguments: [
+      `--kfx-declared=${JSON.stringify([...opts.declared])}`,
+    ],
+  };
+}
+
+// Sample a renderer's OS process working set; call onBreach when it exceeds the
+// cap. Returns a stop function to clear the sampler. Kept transport-free so both
+// the standalone window (destroy the window) and the embedded view (remove +
+// destroy the webContents) supply their own kill action.
+export function startResourceGuard(
+  webContents: WebContents,
+  opts: { memoryCapKb?: number; onBreach: () => void },
+): () => void {
+  const cap = opts.memoryCapKb ?? DEFAULT_MEMORY_CAP_KB;
+  const sampler = setInterval(() => {
+    if (webContents.isDestroyed()) return;
+    // Read the pid each tick: an embedded WebContentsView has no OS process yet
+    // at construction (getOSProcessId() returns 0 until the renderer spawns), so
+    // capturing it once would never match a metric.
+    const pid = webContents.getOSProcessId();
+    if (!pid) return;
+    const metric = app.getAppMetrics().find((m) => m.pid === pid);
+    if (metric && metric.memory.workingSetSize > cap) opts.onBreach();
+  }, SAMPLE_INTERVAL_MS);
+  return () => clearInterval(sampler);
+}
 
 export type SandboxedViewOptions = {
   // the view's manifest capability declaration
@@ -30,35 +95,19 @@ export type SandboxedViewOptions = {
   memoryCapKb?: number;
 };
 
-// Give each sandboxed view its own session partition with the network denied:
-// a sandboxed view loads a local bundle and reaches the outside only through
-// its declared capabilities, never http(s).
-function lockedDownPartition(id: string) {
-  const partition = `sandbox:${id}`;
-  const ses = session.fromPartition(partition);
-  ses.webRequest.onBeforeRequest((details, callback) => {
-    const ok =
-      details.url.startsWith('file:') || details.url.startsWith('devtools:');
-    callback({ cancel: !ok });
-  });
-  return partition;
-}
-
+// Standalone sandboxed view: a hidden BrowserWindow with node stripped and the
+// capability host bound directly to concrete caps. This is the contract-proven
+// form; the embedded, shell-integrated form lives in sandbox-manager.
 export function createSandboxedView(
   options: SandboxedViewOptions,
 ): BrowserWindow {
   const win = new BrowserWindow({
     show: false,
-    webPreferences: {
-      nodeIntegration: false,
-      contextIsolation: true,
-      sandbox: true,
-      partition: lockedDownPartition(String(Date.now())),
-      preload: options.preload ?? path.join(__dirname, '../preload/sandbox.js'),
-      additionalArguments: [
-        `--kfx-declared=${JSON.stringify([...options.declared])}`,
-      ],
-    },
+    webPreferences: sandboxWebPreferences({
+      declared: options.declared,
+      partitionId: String(Date.now()),
+      preload: options.preload,
+    }),
   });
 
   const host = bindElectronHost(
@@ -68,17 +117,15 @@ export function createSandboxedView(
     options.declared,
   );
 
-  // resource guard: sample the view's process working set; kill on breach
-  const cap = options.memoryCapKb ?? DEFAULT_MEMORY_CAP_KB;
-  const pid = win.webContents.getOSProcessId();
-  const sampler = setInterval(() => {
-    if (win.isDestroyed()) return;
-    const metric = app.getAppMetrics().find((m) => m.pid === pid);
-    if (metric && metric.memory.workingSetSize > cap) win.destroy();
-  }, SAMPLE_INTERVAL_MS);
+  const stopGuard = startResourceGuard(win.webContents, {
+    memoryCapKb: options.memoryCapKb,
+    onBreach: () => {
+      if (!win.isDestroyed()) win.destroy();
+    },
+  });
 
   win.on('closed', () => {
-    clearInterval(sampler);
+    stopGuard();
     host.dispose();
   });
 

--- a/framework/gui/src/renderer/sandbox-view-harness/harness.ts
+++ b/framework/gui/src/renderer/sandbox-view-harness/harness.ts
@@ -1,0 +1,128 @@
+// The page that runs inside a sandboxed kfx's isolated renderer. Under
+// nodeIntegration:false / contextIsolation:true / sandbox:true this page has no
+// node and no require — its only inbound surface is window.__kfxBridge (the
+// declared capability keys + an invoke fn + an event subscription, from the
+// sandbox preload). It:
+//   - builds the ergonomic capability object from the bridge with the api guest
+//     (createCapabilityGuest), so the view codes against caps.* not raw IPC;
+//   - waits for main to inject the view bundle source (main is trusted; it reads
+//     the file and hands this page a string via __kfxHarness.load, so fs/require
+//     are never exposed to the sandbox);
+//   - CommonJS-wraps the bundle with a require shim that supplies exactly the
+//     externals the shell contract injects (one React, the capability surface),
+//     then mounts the view's <View caps shell/> in a real React root — proving
+//     the third-party bundle renders live inside the isolated renderer.
+//
+// Shell bridging (navigation, settings, shared refresh) is a follow-up; the
+// capability boundary — the security-critical surface — is fully wired here.
+import * as capability from '@kungfu-tech/api/capability';
+import { createCapabilityGuest } from '@kungfu-tech/api/capability';
+import type {
+  KfxCapabilities,
+  KfxViewComponent,
+  Shell,
+} from '@kungfu-tech/kfx';
+import React from 'react';
+import * as ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
+import * as jsxRuntime from 'react/jsx-runtime';
+import { type SandboxBridge, bridgeChannel } from '../../sandbox/transport';
+
+declare global {
+  interface Window {
+    __kfxBridge: SandboxBridge;
+    __kfxHarness: {
+      caps: Record<string, unknown>;
+      bridge: SandboxBridge;
+      load: (code: string) => void;
+      fail: (message: string) => void;
+    };
+  }
+}
+
+const bridge = window.__kfxBridge;
+// exactly the declared capabilities, each call marshalled over the bridge
+const caps = createCapabilityGuest(bridge.declared, bridgeChannel(bridge));
+
+// The externals a `kfs kfx build` bundle expects, same contract as the shared
+// renderer: one React instance and the capability surface. A sandboxed view that
+// tries to require anything else fails loudly rather than reaching node.
+const shared: Record<string, unknown> = {
+  react: React,
+  'react-dom': ReactDOM,
+  'react-dom/client': { createRoot },
+  'react/jsx-runtime': jsxRuntime,
+  '@kungfu-tech/api': capability,
+  '@kungfu-tech/api/capability': capability,
+};
+
+// A minimal shell for the sandboxed view. Only the capability boundary is wired;
+// the rest is inert until shell bridging lands.
+const shell: Shell = {
+  open: () => {},
+  params: {},
+  onRefresh: () => () => {},
+  setting: () => '',
+  updateState: () => {},
+  state: { profileId: '', disabledKfx: [], disabledSuites: [], settings: {} },
+  info: {
+    ok: true,
+    message: 'sandboxed',
+    runtimeDir: '',
+    kfcVersion: '',
+    buildInfo: null,
+    exports: [],
+    longfistTypes: [],
+  },
+  registry: [],
+  suites: {},
+  profiles: [],
+};
+
+function rootEl(): HTMLElement {
+  let el = document.getElementById('root');
+  if (!el) {
+    el = document.createElement('div');
+    el.id = 'root';
+    document.body.appendChild(el);
+  }
+  return el;
+}
+
+function fail(message: string): void {
+  rootEl().textContent = `sandboxed view failed: ${message}`;
+}
+
+function load(code: string): void {
+  try {
+    const requireShim = (id: string): unknown => {
+      if (id in shared) return shared[id];
+      throw new Error(
+        `sandboxed bundle requires "${id}" which the harness does not provide — it must be bundled by \`kfs kfx build\` or added to the externals contract`,
+      );
+    };
+    const module = { exports: {} as { View?: KfxViewComponent } };
+    // The bundle is CommonJS-wrapped exactly like the shared-renderer loader;
+    // the sandbox strips node regardless, so this eval reaches nothing but the
+    // injected externals and the declared capabilities.
+    new Function('require', 'module', 'exports', code)(
+      requireShim,
+      module,
+      module.exports,
+    );
+    const View = module.exports.View;
+    if (typeof View !== 'function') {
+      throw new Error('bundle does not export a View component');
+    }
+    createRoot(rootEl()).render(
+      React.createElement(View, {
+        caps: caps as unknown as KfxCapabilities,
+        shell,
+      }),
+    );
+  } catch (e) {
+    fail((e as Error).message);
+  }
+}
+
+window.__kfxHarness = { caps, bridge, load, fail };

--- a/framework/gui/src/renderer/sandbox-view-harness/index.html
+++ b/framework/gui/src/renderer/sandbox-view-harness/index.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'none'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'unsafe-inline'"
+    />
+    <title>kfx sandboxed view</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        height: 100%;
+        background: #1e1e1e;
+        color: #cccccc;
+        font-family: system-ui, sans-serif;
+      }
+      #root {
+        height: 100%;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./harness.ts"></script>
+  </body>
+</html>

--- a/framework/gui/src/renderer/src/kfx-loader.ts
+++ b/framework/gui/src/renderer/src/kfx-loader.ts
@@ -50,6 +50,7 @@ type NodeFs = {
 type NodePath = {
   join: (...parts: string[]) => string;
   dirname: (p: string) => string;
+  resolve: (...parts: string[]) => string;
   delimiter: string;
 };
 

--- a/framework/gui/src/renderer/src/kfx-loader.ts
+++ b/framework/gui/src/renderer/src/kfx-loader.ts
@@ -11,15 +11,22 @@
 //      `kungfu kfx install` populates)
 // Scanning goes two levels deep so suite members nested under a suite
 // directory (extensions/system/<member>) are found in the workspace layout.
+import { resolveRuntimeTier } from '@kungfu-tech/kfx';
 import type {
   KfxCapabilityKey,
   KfxEntry,
+  KfxRuntimeTier,
   KfxSettingDecl,
   KfxSuiteDecl,
   KfxViewComponent,
 } from '@kungfu-tech/kfx';
 
 export type SharedModules = Record<string, unknown>;
+
+// A sandboxed view is never mounted in the shared renderer — the shell embeds
+// it as an isolated renderer from its bundlePath. This placeholder stands in
+// for its KfxEntry.View so the type stays uniform; mounting it is a shell bug.
+const sandboxedPlaceholder: KfxViewComponent = () => null;
 
 export type KfxLoadFailure = {
   dir: string;
@@ -116,7 +123,15 @@ export function loadKfx(
   const failures: KfxLoadFailure[] = [];
   const seen = new Set<string>();
 
+  // the install root (<home>/extensions) is where `kungfu kfx install` puts
+  // third-party packages; a view loaded from there is installed (untrusted).
+  const installRoot = env.KF_RUNTIME_DIR
+    ? path.resolve(path.join(path.dirname(env.KF_RUNTIME_DIR), 'extensions'))
+    : null;
+
   for (const root of extensionRoots(env)) {
+    const installed =
+      installRoot !== null && path.resolve(root) === installRoot;
     for (const dir of packageDirs(root)) {
       try {
         const manifest = JSON.parse(
@@ -131,6 +146,7 @@ export function loadKfx(
               view?: {
                 title?: string;
                 capabilities?: KfxCapabilityKey[];
+                runtime?: KfxRuntimeTier;
                 system?: boolean;
                 settings?: KfxSettingDecl[];
                 entry?: string;
@@ -148,6 +164,10 @@ export function loadKfx(
         if (seen.has(config.key)) continue; // earlier root wins
         seen.add(config.key);
         const bundlePath = path.join(dir, view.entry ?? 'dist/view/index.js');
+        const tier = resolveRuntimeTier(
+          view,
+          installed ? 'installed' : 'built-in',
+        );
         entries.push({
           id: config.key,
           title: view.title ?? config.key,
@@ -157,7 +177,13 @@ export function loadKfx(
           packageName: manifest.name,
           version: manifest.version,
           source: root,
-          View: loadBundle(bundlePath, shared),
+          tier,
+          bundlePath,
+          // a sandboxed view is loaded in an isolated renderer, never here
+          View:
+            tier === 'sandboxed-ipc'
+              ? sandboxedPlaceholder
+              : loadBundle(bundlePath, shared),
         });
       } catch (e) {
         failures.push({ dir, error: (e as Error).message });

--- a/framework/gui/src/renderer/src/main.tsx
+++ b/framework/gui/src/renderer/src/main.tsx
@@ -22,6 +22,7 @@ import { createRoot } from 'react-dom/client';
 import * as jsxRuntime from 'react/jsx-runtime';
 import { type KfxLoadResult, loadKfx } from './kfx-loader';
 import { type Runtime, bootRuntime } from './runtime';
+import { sandboxClient } from './sandbox-client';
 import {
   PROFILES,
   loadShellState,
@@ -85,6 +86,85 @@ function subsetCaps(runtime: Runtime, entry: KfxEntry): KfxCapabilities | null {
   // only declared handles are populated; undeclared access is a kfx bug the
   // error boundary contains
   return subset as unknown as KfxCapabilities;
+}
+
+// The declared capability handles the trusted renderer holds for a sandboxed
+// view. Unlike subsetCaps this never returns null: a missing handle is simply
+// absent, and the trusted host rejects a call to it — the sandboxed view has no
+// direct handle to fault on. These stay in this (trusted) renderer; only invoke
+// results cross to the isolated view.
+function sandboxSubset(
+  runtime: Runtime,
+  entry: KfxEntry,
+): Record<string, Record<string, unknown>> {
+  const full: Record<string, unknown> = {
+    ledger: runtime.ledger,
+    domain: runtime.domain,
+    rewind: runtime.rewind,
+    work: runtime.work,
+  };
+  const subset: Record<string, Record<string, unknown>> = {};
+  for (const key of entry.capabilities) {
+    const handle = full[key];
+    if (handle) subset[key] = handle as Record<string, unknown>;
+  }
+  return subset;
+}
+
+// A sandboxed-ipc view is not mounted in this renderer. The shell registers its
+// trusted capability host, asks main to embed the isolated WebContentsView, and
+// keeps the overlay positioned over this slot's content rect. The slot itself is
+// an empty box; the view renders in its own process, layered above.
+function SandboxSlot({
+  entry,
+  caps,
+}: {
+  entry: KfxEntry;
+  caps: Record<string, Record<string, unknown>>;
+}) {
+  const ref = React.useRef<HTMLDivElement>(null);
+  // caps identity is stable for a given runtime and entry.capabilities is a
+  // property of the same entry; re-embedding keys only on the view identity.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: caps/entry.capabilities are stable per active view; re-embed keys on id + bundlePath only
+  React.useEffect(() => {
+    const id = entry.id;
+    const sync = () => {
+      const el = ref.current;
+      if (!el) return;
+      const r = el.getBoundingClientRect();
+      sandboxClient.setBounds(id, {
+        x: Math.round(r.x),
+        y: Math.round(r.y),
+        width: Math.round(r.width),
+        height: Math.round(r.height),
+      });
+    };
+    sandboxClient.registerHost(id, caps, entry.capabilities);
+    let cancelled = false;
+    void sandboxClient
+      .ensure(id, {
+        bundlePath: entry.bundlePath,
+        declared: entry.capabilities,
+      })
+      .then(() => {
+        if (cancelled) return;
+        sync();
+        sandboxClient.show(id);
+      });
+    const ro = new ResizeObserver(sync);
+    if (ref.current) ro.observe(ref.current);
+    window.addEventListener('resize', sync);
+    return () => {
+      cancelled = true;
+      ro.disconnect();
+      window.removeEventListener('resize', sync);
+      sandboxClient.destroy(id);
+      sandboxClient.disposeHost(id);
+    };
+    // re-embed only when the active sandboxed view changes; caps identity is
+    // stable for a given runtime
+  }, [entry.id, entry.bundlePath]);
+  return <div ref={ref} style={{ width: '100%', height: '100%' }} />;
 }
 
 function App() {
@@ -261,7 +341,16 @@ function App() {
             )}
           </nav>
           <div style={{ flex: 1, minHeight: 0 }}>
-            {activeKfx && caps ? (
+            {activeKfx && activeKfx.tier === 'sandboxed-ipc' ? (
+              // isolated third-party view: embedded, not mounted here
+              <KfxErrorBoundary kfxId={activeKfx.id}>
+                <SandboxSlot
+                  key={activeKfx.id}
+                  entry={activeKfx}
+                  caps={sandboxSubset(runtime, activeKfx)}
+                />
+              </KfxErrorBoundary>
+            ) : activeKfx && caps ? (
               <KfxErrorBoundary kfxId={activeKfx.id}>
                 <activeKfx.View caps={caps} shell={shell} />
               </KfxErrorBoundary>

--- a/framework/gui/src/renderer/src/sandbox-client.ts
+++ b/framework/gui/src/renderer/src/sandbox-client.ts
@@ -1,0 +1,69 @@
+// Shell-renderer client for the sandboxed-ipc view path. The shell renderer is
+// node-integrated (contextIsolation:false), so it reaches ipcRenderer directly
+// and needs no preload. This module pairs the two sides the shell drives:
+//   - registerHost/disposeHost: the trusted-renderer capability host for a view,
+//     created before the embedded view is asked to load so its first invoke has
+//     a host to answer it;
+//   - ensure/setBounds/show/hide/destroy: the main-process WebContentsView the
+//     shell positions over its content area.
+import {
+  DESTROY_CHANNEL,
+  ENSURE_CHANNEL,
+  HIDE_CHANNEL,
+  SET_BOUNDS_CHANNEL,
+  SHOW_CHANNEL,
+} from '../../sandbox/channels';
+import { SandboxHostService } from './sandbox-host-service';
+
+type IpcRenderer = {
+  invoke: (channel: string, ...args: unknown[]) => Promise<unknown>;
+  send: (channel: string, ...args: unknown[]) => void;
+  on: (
+    channel: string,
+    listener: (event: unknown, payload: unknown) => void,
+  ) => void;
+};
+
+export type Rect = { x: number; y: number; width: number; height: number };
+
+const ipcRenderer = (window.require('electron') as { ipcRenderer: IpcRenderer })
+  .ipcRenderer;
+
+const hostService = new SandboxHostService(ipcRenderer);
+
+export const sandboxClient = {
+  // trusted-renderer capability host for a view (real caps live here)
+  registerHost(
+    id: string,
+    caps: Record<string, Record<string, unknown>>,
+    declared: readonly string[],
+  ): void {
+    hostService.register(id, caps, declared);
+  },
+  disposeHost(id: string): void {
+    hostService.dispose(id);
+  },
+  // main-process embedded WebContentsView lifecycle / layout
+  ensure(
+    id: string,
+    opts: { bundlePath: string; declared: readonly string[] },
+  ): Promise<unknown> {
+    return ipcRenderer.invoke(ENSURE_CHANNEL, {
+      id,
+      bundlePath: opts.bundlePath,
+      declared: [...opts.declared],
+    });
+  },
+  setBounds(id: string, rect: Rect): void {
+    ipcRenderer.send(SET_BOUNDS_CHANNEL, { id, rect });
+  },
+  show(id: string): void {
+    ipcRenderer.send(SHOW_CHANNEL, { id });
+  },
+  hide(id: string): void {
+    ipcRenderer.send(HIDE_CHANNEL, { id });
+  },
+  destroy(id: string): void {
+    ipcRenderer.send(DESTROY_CHANNEL, { id });
+  },
+};

--- a/framework/gui/src/renderer/src/sandbox-host-service.ts
+++ b/framework/gui/src/renderer/src/sandbox-host-service.ts
@@ -1,0 +1,95 @@
+// Trusted-renderer side of the sandboxed-ipc capability path. The real
+// capabilities are created here, in the node-integrated renderer that holds the
+// native binding (runtime.ts). A sandboxed view cannot touch them; instead its
+// invokes arrive relayed through main, and this service resolves them against a
+// per-view capability host. The host is createCapabilityHost from the api layer,
+// so the declared-only enforcement — and the guest<->host callback/subscription
+// protocol — is exactly the contract-tested one; only the transport is the
+// main relay (see sandbox-manager for the main-side wiring).
+import {
+  type HostEvent,
+  type HostRequest,
+  createCapabilityHost,
+} from '@kungfu-tech/api/capability';
+
+import {
+  HOST_EVENT_CHANNEL,
+  HOST_INVOKE_CHANNEL,
+  HOST_REPLY_CHANNEL,
+} from '../../sandbox/channels';
+
+type IpcRendererLike = {
+  on: (
+    channel: string,
+    listener: (event: unknown, payload: unknown) => void,
+  ) => void;
+  send: (channel: string, payload: unknown) => void;
+};
+
+type Host = {
+  handle: (req: HostRequest) => Promise<unknown>;
+  dispose: () => void;
+};
+
+// One service per trusted renderer. It owns the ipcRenderer relay endpoint and a
+// map of per-view hosts; the shell registers a host before it asks main to embed
+// the matching sandboxed view.
+export class SandboxHostService {
+  private readonly ipc: IpcRendererLike;
+  private readonly hosts = new Map<string, Host>();
+
+  constructor(ipc: IpcRendererLike) {
+    this.ipc = ipc;
+    // main forwards a sandboxed view's invoke here; resolve it against that
+    // view's host and reply with the correlated reqId.
+    ipc.on(HOST_INVOKE_CHANNEL, (_event, payload) => {
+      const { id, reqId, req } = payload as {
+        id: string;
+        reqId: number;
+        req: HostRequest;
+      };
+      const host = this.hosts.get(id);
+      if (!host) {
+        ipc.send(HOST_REPLY_CHANNEL, {
+          reqId,
+          ok: false,
+          error: `no capability host for sandboxed view '${id}'`,
+        });
+        return;
+      }
+      host
+        .handle(req)
+        .then((value) =>
+          ipc.send(HOST_REPLY_CHANNEL, { reqId, ok: true, value }),
+        )
+        .catch((e: unknown) =>
+          ipc.send(HOST_REPLY_CHANNEL, {
+            reqId,
+            ok: false,
+            error: e instanceof Error ? e.message : String(e),
+          }),
+        );
+    });
+  }
+
+  // Register the capability host for one sandboxed view. `caps` is the real
+  // capability subset (only what this renderer holds); `declared` is the
+  // manifest declaration. Undeclared capabilities are rejected by the host.
+  register(
+    id: string,
+    caps: Record<string, Record<string, unknown>>,
+    declared: readonly string[],
+  ): void {
+    this.dispose(id);
+    const emit = (event: HostEvent) =>
+      this.ipc.send(HOST_EVENT_CHANNEL, { id, event });
+    this.hosts.set(id, createCapabilityHost(caps, declared, emit));
+  }
+
+  dispose(id: string): void {
+    const host = this.hosts.get(id);
+    if (!host) return;
+    host.dispose();
+    this.hosts.delete(id);
+  }
+}

--- a/framework/gui/src/sandbox/channels.ts
+++ b/framework/gui/src/sandbox/channels.ts
@@ -1,0 +1,15 @@
+// IPC channel names for the sandboxed-ipc view path, kept electron-free so both
+// the main-process manager and the trusted-renderer host service (and any test)
+// can import them without pulling node/electron into a renderer bundle.
+
+// main <-> trusted renderer capability host relay
+export const HOST_INVOKE_CHANNEL = 'kfx:host-invoke';
+export const HOST_REPLY_CHANNEL = 'kfx:host-invoke-reply';
+export const HOST_EVENT_CHANNEL = 'kfx:host-event';
+
+// shell renderer -> main: embedded WebContentsView lifecycle / layout control
+export const ENSURE_CHANNEL = 'kfx:view-ensure';
+export const SET_BOUNDS_CHANNEL = 'kfx:view-set-bounds';
+export const SHOW_CHANNEL = 'kfx:view-show';
+export const HIDE_CHANNEL = 'kfx:view-hide';
+export const DESTROY_CHANNEL = 'kfx:view-destroy';

--- a/framework/kfx/src/index.ts
+++ b/framework/kfx/src/index.ts
@@ -107,6 +107,12 @@ export type KfxEntry = {
   packageName?: string;
   version?: string;
   source: 'built-in' | string; // extension root the entry was loaded from
+  // resolved trust tier (resolveRuntimeTier). A node-integrated view carries a
+  // loaded View mounted in the shared renderer; a sandboxed-ipc view carries
+  // only its bundlePath, loaded in an isolated renderer, and View is a
+  // placeholder the shell must not mount directly.
+  tier: KfxRuntimeTier;
+  bundlePath: string;
   View: KfxViewComponent;
 };
 


### PR DESCRIPTION
Completes the runtime integration the loader tier seam left open. The shell now routes a `sandboxed-ipc` view to an isolated renderer instead of blank-rendering it.

## What
- **`main/sandbox-manager`** — embeds a sandboxed view as a child `WebContentsView` (node stripped, network denied, its own session), positioned over the shell's content area, and relays its capability invokes. Main reads the view bundle (trusted) and injects it into the isolated harness, so the sandbox never gets `fs`/`require`.
- **`renderer/sandbox-view-harness`** — the isolated page: builds `caps` from the bridge with the api guest, CommonJS-wraps the injected bundle over the shell's externals contract (one React + the capability surface), and mounts `<View caps shell/>` in a real React root.
- **`renderer/sandbox-host-service`** + **`sandbox-client`** + **`main.tsx`** — the shell registers a view's trusted capability host, asks main to embed it, and keeps the overlay synced to its content rect.
- **`sandbox-view`** — the isolation posture (webPreferences, locked-down partition, resource guard) is factored into shared helpers; the guard now reads the pid each sample so an embedded view (no OS process at construction) is covered.
- **`electron.vite.config`** — builds the sandbox preload and the harness page.

## Why this shape
The real capabilities live in the trusted node-integrated renderer (they hold the native binding), so the capability path is three hops:

```
sandboxed view --IPC--> main (SandboxManager, a pure relay)
  --IPC--> trusted renderer's capability host (the real caps)
```

Main is a pure relay: it never sees the real capabilities and never interprets the `{cap,method,args}` payload — the declared-only enforcement stays in the trusted renderer's `createCapabilityHost`, co-located with the caps it guards. This keeps the guest↔host callback/subscription protocol intact end to end.

## Validation
`tsc` clean · `biome check` clean · `electron-vite build` green (preload + harness page emitted) · a headless Electron harness driving these production modules asserts, all passing: tier routing; isolation (no `require`/`process`); bridge exposes declared keys only; a declared capability round-trips through the relay; an undeclared capability is rejected host-side; a third-party bundle mounts live in the isolated renderer; `setBounds` positions the overlay; an over-limit view is killed by the resource guard.