### PR TITLE
docs(architecture): JS/TS coverage is the existing view extensions

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -144,8 +144,10 @@ module (`kfs kfx build` drives CMake through the core toolchain). The Python
 ahead-of-time path is covered by
 [`extensions/probe-python`](../extensions/probe-python): a neutral probe whose
 dependency is installed with `kungfu engage pdm` and whose module is
-Nuitka-compiled with `kungfu engage nuitka`. The JavaScript / TypeScript
-extension path is still being reinstated.
+Nuitka-compiled with `kungfu engage nuitka`. The JavaScript / TypeScript path is
+covered by the reference view extensions (such as
+[`extensions/rewind-inspector`](../extensions/rewind-inspector)), which `kfs kfx
+build` bundles with esbuild.
 
 ## Repository layout
 


### PR DESCRIPTION
The JS/TS extension coverage lane was never missing — the reference view extensions (rewind-inspector, work-dashboard, config-manager, journal-manager) build with esbuild via `kfs kfx build`. Corrects the wording introduced alongside the python-AOT probe that called it 'still being reinstated'. With the cpp (probe-cpp) and python-AOT (probe-python) probes, all three extension coverage lanes are now accurately documented.