### PR TITLE
Rename the runtime command from kfc to kungfu

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ layout, and code style.
 ```
 
 `verify` is the single done-check: it asserts the build artifacts and runs a
-`kfc` runtime smoke, rather than trusting a "looks built" impression.
+`kungfu` runtime smoke, rather than trusting a "looks built" impression.
 
 ## Proposing changes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ Kungfu is a pnpm-workspaces monorepo. See [`docs/architecture.md`](docs/architec
 for how the layers fit together; the main areas:
 
 - `framework/core` — the C++ core (`longfist` type system, `yijinjing` journal
-  runtime) plus its Python and Node (N-API) bindings and the `kfc` runtime,
+  runtime) plus its Python and Node (N-API) bindings and the `kungfu` runtime,
   packaged as `@kungfu-tech/core`. Build orchestration lives in
   `framework/core/.gyp/`.
 - `framework/api` — the capability SDK (typed access to journal / state / replay).
@@ -43,12 +43,10 @@ for how the layers fit together; the main areas:
 - `extensions/*` — kfx extensions; `examples/*` — samples.
 - `artifact` — the dogfood installer bundling the runtime, reference UIs and SDK.
 
-Three command-line entry points, kept forward-compatible:
+Two command-line entry points, kept forward-compatible:
 
 - `kungfu` — the end-user CLI command (`kungfu --version`, journal subcommands,
-  …). It fronts the `kfc` runtime; `kfc` works as a short alias of the same
-  command.
-- `kfc` — the runtime binary that `kungfu` fronts, and the short alias.
+  …). It fronts the `kungfu` runtime.
 - `./kungfu-code` — the development/build orchestrator used while working on the
   repo (see below).
 
@@ -67,7 +65,7 @@ cd kungfu
 
 ./kungfu-code sync          # install JS dependencies (frozen lockfile)
 ./kungfu-code build         # build all workspaces (C++ core + bindings + app)
-./kungfu-code freeze        # produce the standalone kfc bundle
+./kungfu-code freeze        # produce the standalone kungfu bundle
 ./kungfu-code build:app     # build the desktop app bundle
 ./kungfu-code app           # launch the desktop app
 ```

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ demonstrates and exercises these capabilities.
 ## The toolchain comes with the runtime
 
 A guiding principle of kungfu is that the machine adapts to the person, not the
-other way around. The `kfc` runtime is batteries-included: it embeds a Python
+other way around. The `kungfu` runtime is batteries-included: it embeds a Python
 and a Node runtime and brings a full Python development lifecycle — dependency
 management, formatting, and ahead-of-time compilation — reachable through
 `kungfu engage`. Building a kfx extension does not start by assembling a
@@ -58,10 +58,10 @@ built on mainstream, well-maintained foundations.
 ## Components
 
 - **Core & runtime** — `longfist` (type system) and `yijinjing` (journal
-  runtime) with Python and Node bindings, plus the `kfc` runtime, packaged as
-  `@kungfu-tech/core`. `kfc` embeds a Python and a Node runtime and is fronted
-  by the `kungfu` end-user command (`kfc` remains a short alias); the richer
-  end-user shell is planned under the same name.
+  runtime) with Python and Node bindings, plus the `kungfu` runtime, packaged as
+  `@kungfu-tech/core`. It embeds a Python and a Node runtime and is fronted
+  by the `kungfu` end-user command; the richer end-user shell is planned under
+  the same name.
 - **Capability SDK** — typed, framework-neutral access to journal / state /
   replay (`framework/api`).
 - **Application SDK** — scaffolding to build kfx extensions and assemble
@@ -95,7 +95,7 @@ right document, and is readable by both people and agents.
 
 - [`docs/MAP.md`](docs/MAP.md) — the question-indexed map of all documentation.
 - [`docs/concepts.md`](docs/concepts.md) — the vocabulary in one place
-  (`kungfu`/`kfc`/`kfx`/`kfs`, `libkungfu`, `longfist`, `yijinjing`, journal, …).
+  (`kungfu`/`kfx`/`kfs`, `libkungfu`, `longfist`, `yijinjing`, journal, …).
 - [`docs/design-philosophy.md`](docs/design-philosophy.md) — the two first
   principles the whole design follows from, and how the architecture falls out
   of them.

--- a/developer/sdk/README.md
+++ b/developer/sdk/README.md
@@ -36,4 +36,4 @@ Options (both `create` targets):
   scaffolding inside the monorepo.
 
 The generated app is self-contained: `pnpm pack` produces a distributable
-bundle with the kungfu runtime under `Resources/kfc`.
+bundle with the kungfu runtime under `Resources/kungfu`.

--- a/developer/sdk/src/kfs.js
+++ b/developer/sdk/src/kfs.js
@@ -119,7 +119,7 @@ function createApp(directory, options) {
       'next steps:',
       `  cd ${directory}`,
       '  pnpm install   # or npm/yarn',
-      '  pnpm dev       # launch against a built kungfu-core (KFC_DIR to override)',
+      '  pnpm dev       # launch against a built kungfu-core (KUNGFU_DIR to override)',
       '',
     ].join('\n'),
   );

--- a/developer/sdk/templates/app/electron-builder.yml.tmpl
+++ b/developer/sdk/templates/app/electron-builder.yml.tmpl
@@ -1,7 +1,7 @@
 appId: __APP_ID__
 productName: __APP_NAME__
-# asar:false so the native binding (.node) and kfc dylibs can be require()d
-# directly from Resources/kfc at runtime.
+# asar:false so the native binding (.node) and kungfu dylibs can be require()d
+# directly from Resources/kungfu at runtime.
 asar: false
 npmRebuild: false
 files:
@@ -9,9 +9,9 @@ files:
   - package.json
 extraResources:
   # Ship the kungfu runtime (libkungfu + the binding) so the packaged app
-  # loads it from Resources/kfc, matching the binding's rpath.
-  - from: node_modules/@kungfu-tech/core/dist/kfc
-    to: kfc
+  # loads it from Resources/kungfu, matching the binding's rpath.
+  - from: node_modules/@kungfu-tech/core/dist/kungfu
+    to: kungfu
 mac:
   target: dir
   identity: null

--- a/developer/sdk/templates/app/electron.vite.config.mjs
+++ b/developer/sdk/templates/app/electron.vite.config.mjs
@@ -2,7 +2,7 @@ import { defineConfig, externalizeDepsPlugin } from 'electron-vite';
 import react from '@vitejs/plugin-react';
 
 // - main: externalize deps so the native binding is never bundled; it is loaded
-//   via require() at runtime from kungfu-core's dist/kfc.
+//   via require() at runtime from kungfu-core's dist/kungfu.
 // - renderer: react; keep electron and the native binding external so the
 //   renderer require()s them at runtime under nodeIntegration.
 export default defineConfig({

--- a/developer/sdk/templates/app/src/main/index.ts
+++ b/developer/sdk/templates/app/src/main/index.ts
@@ -8,7 +8,7 @@ import path from 'node:path';
 // here, before any window (and therefore the renderer process) is created.
 import { BrowserWindow, app } from 'electron';
 
-// Resolve the kungfu runtime directory (kfc) that holds libkungfu.dylib and the
+// Resolve the kungfu runtime directory that holds libkungfu.dylib and the
 // kungfu_electron.node binding. In development it lives in the kungfu-core
 // package; once packaged it is shipped as an extraResource under Resources/kungfu.
 const kungfuDir = app.isPackaged

--- a/developer/sdk/templates/app/src/main/index.ts
+++ b/developer/sdk/templates/app/src/main/index.ts
@@ -10,13 +10,13 @@ import { BrowserWindow, app } from 'electron';
 
 // Resolve the kungfu runtime directory (kfc) that holds libkungfu.dylib and the
 // kungfu_electron.node binding. In development it lives in the kungfu-core
-// package; once packaged it is shipped as an extraResource under Resources/kfc.
+// package; once packaged it is shipped as an extraResource under Resources/kungfu.
 const kfcDir = app.isPackaged
-  ? path.join(process.resourcesPath, 'kfc')
+  ? path.join(process.resourcesPath, 'kungfu')
   : path.join(
       path.dirname(require.resolve('@kungfu-tech/core/package.json')),
       'dist',
-      'kfc',
+      'kungfu',
     );
 
 const bindingPath = path.join(kfcDir, 'kungfu_electron.node');
@@ -34,7 +34,7 @@ process.env.KFE_PATH = process.env.KFE_PATH || bindingPath;
 // Prove the frozen runtime CLI runs standalone next to the binding, and hand
 // the result to the renderer for display.
 try {
-  const kfcBin = path.join(path.dirname(process.env.KFE_PATH), 'kfc');
+  const kfcBin = path.join(path.dirname(process.env.KFE_PATH), 'kungfu');
   const out = execFileSync(kfcBin, ['--version'], { timeout: 10000 });
   process.env.KFC_VERSION = out.toString().trim();
 } catch {

--- a/developer/sdk/templates/app/src/main/index.ts
+++ b/developer/sdk/templates/app/src/main/index.ts
@@ -11,7 +11,7 @@ import { BrowserWindow, app } from 'electron';
 // Resolve the kungfu runtime directory (kfc) that holds libkungfu.dylib and the
 // kungfu_electron.node binding. In development it lives in the kungfu-core
 // package; once packaged it is shipped as an extraResource under Resources/kungfu.
-const kfcDir = app.isPackaged
+const kungfuDir = app.isPackaged
   ? path.join(process.resourcesPath, 'kungfu')
   : path.join(
       path.dirname(require.resolve('@kungfu-tech/core/package.json')),
@@ -19,7 +19,7 @@ const kfcDir = app.isPackaged
       'kungfu',
     );
 
-const bindingPath = path.join(kfcDir, 'kungfu_electron.node');
+const bindingPath = path.join(kungfuDir, 'kungfu_electron.node');
 
 // Export before the renderer process is created so both processes inherit them.
 // The default runtime home must be writable: userData when packaged (never
@@ -34,11 +34,11 @@ process.env.KFE_PATH = process.env.KFE_PATH || bindingPath;
 // Prove the frozen runtime CLI runs standalone next to the binding, and hand
 // the result to the renderer for display.
 try {
-  const kfcBin = path.join(path.dirname(process.env.KFE_PATH), 'kungfu');
-  const out = execFileSync(kfcBin, ['--version'], { timeout: 10000 });
-  process.env.KFC_VERSION = out.toString().trim();
+  const kungfuBin = path.join(path.dirname(process.env.KFE_PATH), 'kungfu');
+  const out = execFileSync(kungfuBin, ['--version'], { timeout: 10000 });
+  process.env.KUNGFU_VERSION = out.toString().trim();
 } catch {
-  process.env.KFC_VERSION = '';
+  process.env.KUNGFU_VERSION = '';
 }
 
 // Probe the binding in the main (node) process.

--- a/developer/sdk/templates/app/src/renderer/src/main.tsx
+++ b/developer/sdk/templates/app/src/renderer/src/main.tsx
@@ -126,7 +126,7 @@ function App() {
         <Ledger kfe={state.kfe} runtimeDir={state.runtimeDir} />
       ) : (
         <p style={{ ...mono, color: '#858585' }}>
-          build @kungfu-tech/core (or set KFC_DIR) and relaunch
+          build @kungfu-tech/core (or set KUNGFU_DIR) and relaunch
         </p>
       )}
     </div>

--- a/developer/sdk/templates/extension/src/view/index.tsx
+++ b/developer/sdk/templates/extension/src/view/index.tsx
@@ -14,7 +14,7 @@ export function View({ shell }: KfxViewProps) {
     <div style={panelStyle}>
       <h2 style={headingStyle}>__EXT_NAME__</h2>
       <div style={mono}>
-        runtime {shell.info.kfcVersion || 'n/a'} · profile{' '}
+        runtime {shell.info.kungfuVersion || 'n/a'} · profile{' '}
         {shell.state.profileId}
       </div>
     </div>

--- a/docs/MAP.md
+++ b/docs/MAP.md
@@ -23,7 +23,7 @@ and the map routes a question to whichever doc answers it.
 | Your question | Document | Plane | Status |
 |---|---|---|---|
 | What is kungfu, in one idea? | [`../README.md`](../README.md) | — | stable |
-| What do the terms mean (`kfc` / `longfist` / journal …)? | [`concepts.md`](concepts.md) | use | stable |
+| What do the terms mean (`kungfu` / `longfist` / journal …)? | [`concepts.md`](concepts.md) | use | stable |
 | Why is it built this way? What is load-bearing? | [`design-philosophy.md`](design-philosophy.md) | why | stable |
 | Why this versioning / release design (don't replace it naively)? | [`version-release-design.md`](version-release-design.md) | why | stable |
 | When must a change open a minor or major (and when must it not)? | [`versioning.md`](versioning.md) (rule: KFD-1, adopted by ADR-0010) | verify | stable |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -3,7 +3,7 @@
 How the Kungfu repository is layered, and the principle that shapes it. For the
 two first principles the whole design follows from, see
 [`design-philosophy.md`](design-philosophy.md); for the vocabulary
-(`kfc`/`kfx`/`kfs`, `libkungfu`, `longfist`, `yijinjing`, …) see
+(`kungfu`/`kfx`/`kfs`, `libkungfu`, `longfist`, `yijinjing`, …) see
 [`concepts.md`](concepts.md); for the data-plane concepts
 (journal, zero-copy, replay) see the [README](../README.md); for build and
 contribution see [CONTRIBUTING](../CONTRIBUTING.md); for specific decisions see
@@ -16,7 +16,7 @@ test, not the product* — and how the architecture follows from both are set ou
 in [`design-philosophy.md`](design-philosophy.md).
 
 Kungfu absorbs toolchain and runtime complexity into the product so that its
-users do not have to assemble it themselves. The `kfc` runtime embeds both a
+users do not have to assemble it themselves. The `kungfu` runtime embeds both a
 Python and a Node runtime and bridges a full Python development lifecycle —
 dependency management, formatting, and ahead-of-time compilation — so most
 extension development needs no separately installed language runtimes or package
@@ -67,8 +67,8 @@ group into the following layers.
 
 The foundation: the `longfist` type system and the `yijinjing` append-only
 journal runtime in C++, with Python and Node (N-API) bindings, exposed zero-copy
-in-process. It also produces `kfc`, the runtime that embeds the Python and Node
-runtimes and bridges the development toolchain. `kfc` is the base for the
+in-process. It also produces the `kungfu` runtime, which embeds the Python and
+Node runtimes and bridges the development toolchain; it is the base for the
 planned `kungfu` end-user shell.
 
 ### Capability SDK — `framework/api`
@@ -153,7 +153,7 @@ build` bundles with esbuild.
 
 ```
 framework/
-  core        runtime + core (C++ longfist / yijinjing, bindings, kfc)
+  core        runtime + core (C++ longfist / yijinjing, bindings, kungfu)
   api         capability SDK
   gui         reference GUI (Electron + React)
   tui         reference TUI

--- a/docs/buildchain.md
+++ b/docs/buildchain.md
@@ -28,7 +28,7 @@ under those pinned tools.
 | `libkungfu` (C++ core: longfist + yijinjing) | `framework/core/src` | CMake + Conan 2; build orchestration in `framework/core/.gyp/` |
 | Python binding (`py_kungfu`) | `framework/core/src/bindings/python` | pybind11, built under the pinned CPython |
 | Node addon (`kungfu_node.node`) | `framework/core/src/bindings/node` | N-API via the `.gyp` build |
-| `kfc` (the frozen runtime) | the above + embedded Python/Node runtimes | `./kungfu-code freeze` |
+| `kungfu` (the frozen runtime) | the above + embedded Python/Node runtimes | `./kungfu-code freeze` |
 | app / artifact bundles | the SDK assembling the above | `./kungfu-code build:app`, the `kfs` packaging |
 
 ## Where the prebuilt binaries come from
@@ -36,7 +36,7 @@ under those pinned tools.
 kungfu distributes prebuilt cross-platform binaries rather than expecting users to
 compile (see [`version-release-design.md`](version-release-design.md)): the native
 artifacts are published via node-pre-gyp (configuration in
-[`framework/core/package.json`](../framework/core/package.json)), and `kfc` is
+[`framework/core/package.json`](../framework/core/package.json)), and the `kungfu` runtime is
 shipped frozen. A tag is bound to its binaries atomically — *tag exists ⇒ the
 matching binaries exist* — which is the trust property the release mechanism
 exists to hold.

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -9,17 +9,16 @@ principles behind them see [`design-philosophy.md`](design-philosophy.md).
 
 | Name | What it is |
 |---|---|
-| `kfc` | The **kungfu core runtime** binary. It embeds a Python and a Node runtime and exposes the journal/state APIs; it is the runtime everything else runs on. |
 | `kfx` | A **kungfu extension** — a plugin built on the extension contract (the units under `extensions/`). |
 | `kfs` | The **application/extension SDK command**: scaffolds and builds `kfx` extensions, assembles applications, and produces packaged artifacts. |
-| `kungfu` | The **end-user CLI command** — the canonical way to invoke kungfu from the command line. Today it fronts the `kfc` runtime (same executable, two names; `kfc` remains a short alias); the richer end-user shell is planned to grow under this name. |
+| `kungfu` | The **kungfu runtime binary and end-user CLI command** — the canonical way to invoke kungfu from the command line. It embeds a Python and a Node runtime and exposes the journal/state APIs; it is the runtime everything else runs on. The richer end-user shell is planned to grow under this name. |
 | `./kungfu-code` | The **development/build orchestrator** used while working on the repo (pins Node, Python, and the package manager so a fresh clone builds with one command). It is build-time only, not shipped. |
 
 ## Core building blocks
 
 | Term | What it is |
 |---|---|
-| **libkungfu** | The C++ **core library**: the `longfist` type system and the `yijinjing` journal runtime, with C++/Python/Node bindings. This is what the README calls the "zero-copy, multi-language runtime"; it is packaged as `@kungfu-tech/core` and is the foundation `kfc` is built on. |
+| **libkungfu** | The C++ **core library**: the `longfist` type system and the `yijinjing` journal runtime, with C++/Python/Node bindings. This is what the README calls the "zero-copy, multi-language runtime"; it is packaged as `@kungfu-tech/core` and is the foundation the `kungfu` runtime is built on. |
 | **longfist** | The unified **type system / schema** (FlatBuffers-based). Its binary layout *is* the cross-language and on-disk contract — see [ADR-0008](../framework/core/docs/adr/ADR-0008-longfist-schema-evolution-and-minor-maintenance.md). |
 | **yijinjing** | The append-only **journal runtime** — the event bus that carries the data plane. |
 | **journal** | The append-only **event log**: one shared, strongly-typed stream of frames that every component consumes, rather than each inventing its own format. |

--- a/docs/design-philosophy.md
+++ b/docs/design-philosophy.md
@@ -20,7 +20,7 @@ principles**. This document states them and shows how the architecture falls out
 of them, so you can understand *why* kungfu is built the way it is, not just
 *what* it contains.
 
-For the vocabulary used below (`kfc`, `kfs`, `libkungfu`, `longfist`, journal,
+For the vocabulary used below (`kungfu`, `kfs`, `libkungfu`, `longfist`, journal,
 zero-copy, …), see [`concepts.md`](concepts.md); for how the pieces are layered,
 see [`architecture.md`](architecture.md); for specific decisions and their
 rationale, see the [ADRs](../framework/core/docs/adr).
@@ -28,7 +28,7 @@ rationale, see the [ADRs](../framework/core/docs/adr).
 ## Principle 1 — The machine adapts to the person
 
 Kungfu absorbs toolchain and runtime complexity into the product so its users do
-not have to assemble it themselves. The `kfc` runtime embeds both a Python and a
+not have to assemble it themselves. The `kungfu` runtime embeds both a Python and a
 Node runtime and brings a full development lifecycle, so most extension
 development needs no separately installed language runtimes or package managers.
 The project carries the complexity so the user does not.
@@ -67,7 +67,7 @@ The architecture below is how kungfu makes that test un-skippable.
 ### The build runs on the product
 
 Kungfu's own build is a closed loop that runs on the very capabilities kungfu
-offers: the application SDK (`kfs`) runs on the `kfc` runtime; assembling the
+offers: the application SDK (`kfs`) runs on the `kungfu` runtime; assembling the
 distribution exercises the SDK end to end. If a core capability regresses,
 **building kungfu itself fails first** — so the maker cannot ship a broken core
 without their own work stopping. This is the load-bearing self-bootstrap, set out
@@ -83,7 +83,7 @@ surface where an expert and a novice meet at the level of the senses.** An exper
 can route around a rough library API using knowledge a newcomer lacks; nobody can
 route around the UI — the pixels are the same for everyone. By making the maker
 run through the same interface a user runs through (the TUI even boots through
-`kfc`), the maker's path is forced to converge with the user's, on the surface
+`kungfu`), the maker's path is forced to converge with the user's, on the surface
 where most usability failure actually lives.
 
 This is why kungfu carries `gui`/`tui` in the same repository even though the core

--- a/docs/known-limits.md
+++ b/docs/known-limits.md
@@ -60,8 +60,7 @@ infrastructure it would describe (see [`MAP.md`](MAP.md), `provenance.md` —
 
 ## The end-user shell is planned, not shipped
 
-`kfc` is the runtime today, and the `kungfu` command already exists as the
-canonical CLI facade over it (same executable; `kfc` remains a short alias).
+The `kungfu` command is the runtime today and the canonical CLI over it.
 The richer end-user *shell* under that name is still planned; the zero-setup
 experience is fully real for `kfx` *development* (the runtime absorbs the
 toolchain), and the shell is the part still to come.

--- a/docs/rewind.md
+++ b/docs/rewind.md
@@ -36,7 +36,7 @@ cd kungfu
 ./kungfu-code sync && ./kungfu-code build
 ```
 
-Everything below runs from the repository root. `kungfu` (alias `kfc`) is the
+Everything below runs from the repository root. `kungfu` is the
 runtime CLI; the desktop app is the reference GUI.
 
 ## Capture a run
@@ -172,7 +172,7 @@ Each runs standalone: `tests/fixtures/<name>/run.sh`.
   Linux/Windows targets and signing/notarization belong to the release
   pipeline — the next gate before public artifacts.
 - On macOS, run the workspace CLI from `framework/core` with
-  `DYLD_FALLBACK_LIBRARY_PATH=<repo>/framework/core/dist/kfc` exported: the
+  `DYLD_FALLBACK_LIBRARY_PATH=<repo>/framework/core/dist/kungfu` exported: the
   dev-python binding resolves `libnode` relative to the executable, and shell
   wrappers strip `DYLD_*` across re-exec, so exporting it in your own shell
   right before the command is the reliable spelling.

--- a/docs/version-release-design.md
+++ b/docs/version-release-design.md
@@ -62,7 +62,7 @@ npm-ecosystem projection; if it drifts it is a cosmetic mismatch, not a function
 
 **3. A release tag carries weight = code-freeze ⊗ binary distribution, performed
 atomically.** kungfu ships **prebuilt cross-platform binaries** (node-pre-gyp artifacts via
-`prebuilt.libkungfu.cc`, plus the frozen `kfc`), not source for users to compile. For such
+`prebuilt.libkungfu.cc`, plus the frozen `kungfu` runtime), not source for users to compile. For such
 a project, a tag that does *not* guarantee the corresponding binaries are built and
 distributed is an empty promise (users see `v1.0` but cannot download a `v1.0` binary). The
 `alpha → release` merge therefore performs tag + full-platform build + distribution as **one

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -15,7 +15,7 @@ the rule. For what each surface guarantees and how to verify it, see
 | `longfist-layout` | longfist binary layout (in-memory == wire == on-disk) | integration + cross-time | [ADR-0008](../framework/core/docs/adr/ADR-0008-longfist-schema-evolution-and-minor-maintenance.md), [`contracts.md`](contracts.md) |
 | `capability-sdk-api` | capability SDK surface (`framework/api`) | integration | [ADR-0006](../framework/core/docs/adr/ADR-0006-v4-frontend-platform-architecture.md) |
 | `kfx-contract` | kfx extension contract (contribution points, load semantics) | integration | [ADR-0006](../framework/core/docs/adr/ADR-0006-v4-frontend-platform-architecture.md), [ADR-0007](../framework/core/docs/adr/ADR-0007-v4-tui-platform-reference-surface.md) |
-| `kungfu-cli` | kungfu CLI surface (canonical `kungfu` command with `kfc` alias; commands, journal subcommand output conventions) | integration | [`debugging.md`](debugging.md) |
+| `kungfu-cli` | kungfu CLI surface (canonical `kungfu` command; commands, journal subcommand output conventions) | integration | [`debugging.md`](debugging.md) |
 | `journal-replayability` | cross-version cold-path decode of recorded journals | cross-time | [ADR-0008](../framework/core/docs/adr/ADR-0008-longfist-schema-evolution-and-minor-maintenance.md) |
 | `rewind-event-schema` | Rewind capture event model (open-layer msg_types 30001-30099, `rewind_events.fbs`; trace bundles bind and outlive runs) | integration + cross-time | [`msg-type-ranges.md`](../framework/core/docs/msg-type-ranges.md), [`kungfu/rewind/README.md`](../framework/core/src/python/kungfu/rewind/README.md) |
 

--- a/examples/slicetool-cpp-101/package.json
+++ b/examples/slicetool-cpp-101/package.json
@@ -12,7 +12,7 @@
     "build": "kfs strategy build",
     "package": "kfs  strategy package",
     "format": "node ../../framework/core/.gyp/run-format-cpp.js src",
-    "dev": "kfc -l debug tool -c md -g md -n md -t build/target/KungfuToolCpp.cp39-win_amd64.pyd  -b \"2022-01-01\" -e \"2024-01-01\""
+    "dev": "kungfu -l debug tool -c md -g md -n md -t build/target/KungfuToolCpp.cp39-win_amd64.pyd  -b \"2022-01-01\" -e \"2024-01-01\""
   },
   "devDependencies": {
     "@kungfu-tech/sdk": "workspace:*"

--- a/examples/strategy-cpp-101/package.json
+++ b/examples/strategy-cpp-101/package.json
@@ -13,10 +13,10 @@
     "build": "kfs extension build",
     "package": "kfs extension package",
     "format": "node ../../framework/core/.gyp/run-format-cpp.js src",
-    "dev:win": "kfc -l trace run -c strategy -g KungfuStrategy101Cpp -n demo ./dist/KungfuStrategy101Cpp/KungfuStrategy101Cpp.cp39-win_amd64.pyd -x",
-    "dev:linux": "kfc -l debug run -c strategy -g KungfuStrategy101Cpp -n demo ./dist/KungfuStrategy101Cpp/KungfuStrategy101Cpp.cpython-39-x86_64-linux-gnu.so -x",
-    "master": "kfc -l debug run -c system -g master -n master",
-    "ledger": "kfc -l debug run -c system -g service -n ledger"
+    "dev:win": "kungfu -l trace run -c strategy -g KungfuStrategy101Cpp -n demo ./dist/KungfuStrategy101Cpp/KungfuStrategy101Cpp.cp39-win_amd64.pyd -x",
+    "dev:linux": "kungfu -l debug run -c strategy -g KungfuStrategy101Cpp -n demo ./dist/KungfuStrategy101Cpp/KungfuStrategy101Cpp.cpython-39-x86_64-linux-gnu.so -x",
+    "master": "kungfu -l debug run -c system -g master -n master",
+    "ledger": "kungfu -l debug run -c system -g service -n ledger"
   },
   "devDependencies": {
     "@kungfu-tech/sdk": "workspace:*"

--- a/extensions/system/status/src/view/index.tsx
+++ b/extensions/system/status/src/view/index.tsx
@@ -38,7 +38,7 @@ function SystemStatusView({
             </span>
           </div>
           <div>core: {String(info.buildInfo?.version ?? 'unknown')}</div>
-          <div>kfc: {info.kungfuVersion || 'unavailable'}</div>
+          <div>kungfu: {info.kungfuVersion || 'unavailable'}</div>
           <div>
             electron: {versions.electron} · node: {versions.node}
           </div>

--- a/extensions/system/status/src/view/index.tsx
+++ b/extensions/system/status/src/view/index.tsx
@@ -38,7 +38,7 @@ function SystemStatusView({
             </span>
           </div>
           <div>core: {String(info.buildInfo?.version ?? 'unknown')}</div>
-          <div>kfc: {info.kfcVersion || 'unavailable'}</div>
+          <div>kfc: {info.kungfuVersion || 'unavailable'}</div>
           <div>
             electron: {versions.electron} · node: {versions.node}
           </div>

--- a/framework/api/src/config/pathConfig.ts
+++ b/framework/api/src/config/pathConfig.ts
@@ -200,16 +200,16 @@ process.env.CLI_DIR = CLI_DIR;
 //================== cli end ======================================
 
 //================== kfc start ====================================
-const staticDevKfcDir = path.resolve('..', 'core', 'dist', 'kfc');
+const staticDevKfcDir = path.resolve('..', 'core', 'dist', 'kungfu');
 export const KFC_PARENT_DIR = production
   ? globalThis.__kfResourcesPath
   : path.dirname(process.env.KFC_DIR || staticDevKfcDir);
-export const KFC_DIR = process.env.KFC_DIR || path.join(KFC_PARENT_DIR, 'kfc');
+export const KFC_DIR = process.env.KFC_DIR || path.join(KFC_PARENT_DIR, 'kungfu');
 process.env.KFC_DIR = KFC_DIR;
 
 export const PY_WHL_DIR = path.join(KFC_DIR, 'kungfu-wheel');
 
-export const KFC_EXECUTABLE = process.platform === 'win32' ? 'kfc.exe' : 'kfc';
+export const KFC_EXECUTABLE = process.platform === 'win32' ? 'kungfu.exe' : 'kungfu';
 export const EXTENSION_DIRS: string[] = Array.from(
   new Set(
     production

--- a/framework/api/src/config/pathConfig.ts
+++ b/framework/api/src/config/pathConfig.ts
@@ -201,15 +201,15 @@ process.env.CLI_DIR = CLI_DIR;
 
 //================== kfc start ====================================
 const staticDevKfcDir = path.resolve('..', 'core', 'dist', 'kungfu');
-export const KFC_PARENT_DIR = production
+export const KUNGFU_PARENT_DIR = production
   ? globalThis.__kfResourcesPath
-  : path.dirname(process.env.KFC_DIR || staticDevKfcDir);
-export const KFC_DIR = process.env.KFC_DIR || path.join(KFC_PARENT_DIR, 'kungfu');
-process.env.KFC_DIR = KFC_DIR;
+  : path.dirname(process.env.KUNGFU_DIR || staticDevKfcDir);
+export const KUNGFU_DIR = process.env.KUNGFU_DIR || path.join(KUNGFU_PARENT_DIR, 'kungfu');
+process.env.KUNGFU_DIR = KUNGFU_DIR;
 
-export const PY_WHL_DIR = path.join(KFC_DIR, 'kungfu-wheel');
+export const PY_WHL_DIR = path.join(KUNGFU_DIR, 'kungfu-wheel');
 
-export const KFC_EXECUTABLE = process.platform === 'win32' ? 'kungfu.exe' : 'kungfu';
+export const KUNGFU_EXECUTABLE = process.platform === 'win32' ? 'kungfu.exe' : 'kungfu';
 export const EXTENSION_DIRS: string[] = Array.from(
   new Set(
     production
@@ -218,7 +218,7 @@ export const EXTENSION_DIRS: string[] = Array.from(
           ...((process.env.EXTENSION_DIRS || '').split(path.delimiter) || []),
         ]
       : [
-          path.resolve(KFC_PARENT_DIR, '..', '..', '..', 'extensions'),
+          path.resolve(KUNGFU_PARENT_DIR, '..', '..', '..', 'extensions'),
           path.resolve('node_modules', '@kungfu-tech'),
           path.resolve('dist'),
           ...((process.env.EXTENSION_DIRS || '').split(path.delimiter) || []),

--- a/framework/api/src/setGlobalEnv.ts
+++ b/framework/api/src/setGlobalEnv.ts
@@ -1,6 +1,6 @@
 import {
   CLI_DIR,
-  KFC_DIR,
+  KUNGFU_DIR,
   KF_CONFIG_DIR,
   KF_HOME,
   KF_RUNTIME_DIR,
@@ -44,7 +44,7 @@ if (booleanProcessEnv(globalSetting?.system?.verifyLocation)) {
   process.env.KF_VERIFY_LOCATION = true;
 }
 
-process.env.KFC_DIR = dealSpaceInPath(KFC_DIR);
+process.env.KUNGFU_DIR = dealSpaceInPath(KUNGFU_DIR);
 process.env.CLI_DIR = dealSpaceInPath(CLI_DIR);
 process.env.KF_HOME = dealSpaceInPath(KF_HOME);
 process.env.KF_RUNTIME_DIR = dealSpaceInPath(KF_RUNTIME_DIR);

--- a/framework/api/src/typings/global.d.ts
+++ b/framework/api/src/typings/global.d.ts
@@ -35,7 +35,7 @@ declare global {
       APP_ID: string;
       EXTENSION_DIRS: string;
       KF_VERIFY_LOCATION: boolean;
-      KFC_DIR: string;
+      KUNGFU_DIR: string;
       KF_CONFIG_DIR: string;
       KF_APP_RUNTIME_DIR: string;
       KF_LOG_FRAME: boolean;

--- a/framework/api/src/utils/processUtils.ts
+++ b/framework/api/src/utils/processUtils.ts
@@ -30,7 +30,7 @@ import { kfLogger } from '../utils/logUtils';
 import {
   buildProcessLogPath,
   EXTENSION_DIRS,
-  KFC_DIR,
+  KUNGFU_DIR,
   KF_CONFIG_DIR,
   KF_HOME,
   KF_RUNTIME_DIR,
@@ -160,7 +160,7 @@ export const forceKillByKeyWords = (
   });
 };
 
-const kfcName = isWin ? 'kungfu.exe' : 'kungfu';
+const kungfuName = isWin ? 'kungfu.exe' : 'kungfu';
 const appDirName = getAppRuntimeDirName();
 const appDirNameRegExp = new RegExp(appDirName, 'i');
 
@@ -196,7 +196,7 @@ const isProcessBelongsToCurrentApp = (pro: FindProcessResult) => {
 export const killKfc = (byCurrentApp = false): Promise<void> => {
   const isKfDev = ifKfDev();
   return new Promise((resolve) => {
-    findProcessByKeywords([kfcName], false)
+    findProcessByKeywords([kungfuName], false)
       .then((processList) => {
         const processes = processList.filter((item) => {
           if (isCurrentProcess(item)) return false;
@@ -207,7 +207,7 @@ export const killKfc = (byCurrentApp = false): Promise<void> => {
         const pids = processes.map((item) => item.pid);
 
         kfLogger.info(
-          `Target to force kill processList about [${kfcName}]: `,
+          `Target to force kill processList about [${kungfuName}]: `,
           JSON.stringify(processes),
         );
         return forceKill(pids);
@@ -525,25 +525,25 @@ export function pm2LaunchBus(cb: (err: Error, pm2_bus: Pm2Bus) => void) {
   pm2.launchBus(cb);
 }
 
-type KfcEnvOptType<T> =
+type KungfuEnvOptType<T> =
   | T
   | {
       value: T;
       prefix?: 'ENV' | 'ARG';
     };
 
-export interface KfcEnvs {
-  logFrame?: KfcEnvOptType<boolean>;
-  bypassCached?: KfcEnvOptType<boolean>;
-  bypassAccounting?: KfcEnvOptType<boolean>;
-  bypassRefreshBook?: KfcEnvOptType<boolean>;
-  bypassSyncAsset?: KfcEnvOptType<boolean>;
-  bypassSyncPosition?: KfcEnvOptType<boolean>;
-  verifyLocation?: KfcEnvOptType<boolean>;
-  lowMemory?: KfcEnvOptType<boolean>;
-  keepPage?: KfcEnvOptType<boolean>;
-  preload?: KfcEnvOptType<boolean>;
-  maxPreCreateSize?: KfcEnvOptType<number>;
+export interface KungfuEnvs {
+  logFrame?: KungfuEnvOptType<boolean>;
+  bypassCached?: KungfuEnvOptType<boolean>;
+  bypassAccounting?: KungfuEnvOptType<boolean>;
+  bypassRefreshBook?: KungfuEnvOptType<boolean>;
+  bypassSyncAsset?: KungfuEnvOptType<boolean>;
+  bypassSyncPosition?: KungfuEnvOptType<boolean>;
+  verifyLocation?: KungfuEnvOptType<boolean>;
+  lowMemory?: KungfuEnvOptType<boolean>;
+  keepPage?: KungfuEnvOptType<boolean>;
+  preload?: KungfuEnvOptType<boolean>;
+  maxPreCreateSize?: KungfuEnvOptType<number>;
 }
 
 export const startProcess = async (
@@ -578,7 +578,7 @@ export const startProcess = async (
       globalSetting?.trade?.bypassSyncPosition ?? false;
     const bypassCached = globalSetting?.system?.bypassCached ?? false;
     const lowMemory = globalSetting?.performance?.lowMemory ?? false;
-    const extraEnvArgs = buildKfcEnv({
+    const extraEnvArgs = buildKungfuEnv({
       bypassRefreshBook,
       bypassSyncPosition,
       bypassCached,
@@ -591,8 +591,8 @@ export const startProcess = async (
   const optionsResolved: Pm2StartOptions = {
     name: options.name,
     args: args,
-    cwd: options.cwd || path.join(KFC_DIR),
-    script: options.script || kfcName,
+    cwd: options.cwd || path.join(KUNGFU_DIR),
+    script: options.script || kungfuName,
     interpreter: options.interpreter || 'none',
     output: buildProcessLogPath(options.name),
     error: buildProcessLogPath(options.name),
@@ -611,7 +611,7 @@ export const startProcess = async (
       EXTENSION_DIRS: extDirs
         .map((dir) => dealSpaceInPath(path.dirname(dir)))
         .join(path.delimiter),
-      KFC_DIR: process.env.KFC_DIR || '',
+      KUNGFU_DIR: process.env.KUNGFU_DIR || '',
       CLI_DIR: process.env.CLI_DIR || '',
       IS_KF_DEV: ifKfDev() ? 'true' : '',
       KF_HOME: dealSpaceInPath(KF_HOME),
@@ -621,7 +621,7 @@ export const startProcess = async (
       PYTHONUTF8: '1',
       PYTHONIOENCODING: 'utf8',
 
-      KFC_AS_VARIANT: '',
+      KUNGFU_AS_VARIANT: '',
       ...options.env,
 
       // cover father process env
@@ -921,10 +921,10 @@ function buildRocketParams(args: string, ifRocket: boolean) {
   return rocket;
 }
 
-function buildKfcEnv(env: KfcEnvs) {
+function buildKungfuEnv(env: KungfuEnvs) {
   return Object.keys(env)
     .map((key) => {
-      const opt = env[key as keyof KfcEnvs];
+      const opt = env[key as keyof KungfuEnvs];
       if (!opt) return null;
 
       const isOptObj = typeof opt === 'object';
@@ -944,7 +944,7 @@ function buildKfcEnv(env: KfcEnvs) {
     .join(' ');
 }
 
-function buildKfcArgs(options: {
+function buildKungfuArgs(options: {
   prefix?: string;
   logLevel?: string;
   extensionDirs?: string;
@@ -952,7 +952,7 @@ function buildKfcArgs(options: {
   extraArgs?: string;
   args?: string;
   suffix?: string;
-  env?: KfcEnvs;
+  env?: KungfuEnvs;
   canLogFrame?: boolean;
 }): string {
   const globalSetting = getKfGlobalSettingsValue();
@@ -973,7 +973,7 @@ function buildKfcArgs(options: {
   } = options;
 
   const fullArgsArray: string[] = [
-    buildKfcEnv({
+    buildKungfuEnv({
       verifyLocation,
     }),
   ];
@@ -1006,11 +1006,11 @@ function buildKfcArgs(options: {
   }
 
   if (canLogFrame) {
-    fullArgsArray.push(buildKfcEnv({ logFrame }));
+    fullArgsArray.push(buildKungfuEnv({ logFrame }));
   }
 
   if (env) {
-    fullArgsArray.push(buildKfcEnv(env));
+    fullArgsArray.push(buildKungfuEnv(env));
   }
 
   const fullArgs = fullArgsArray.join(' ');
@@ -1074,7 +1074,7 @@ export function startArchiveMakeTask(
   return startProcessGetStatusUntilStop(
     {
       name: ProcessId,
-      args: buildKfcArgs({
+      args: buildKungfuArgs({
         extraArgs: `journal archive ${bypassArchive ? '-m delete' : ''}`,
         canLogFrame: false,
       }),
@@ -1091,7 +1091,7 @@ export const startMaster = async (force = false): Promise<void> => {
   try {
     await preStartProcess(ProcessId, force);
     if (force) await killKfc();
-    const args = buildKfcArgs({
+    const args = buildKungfuArgs({
       location,
     });
     await startProcess({
@@ -1121,13 +1121,13 @@ export const startLedger = async (
     !isReplay ? await preStartProcess(ProcessId, force) : '';
 
     if (isReplay && replayConfig) {
-      args = buildKfcArgs({
+      args = buildKungfuArgs({
         logLevel: replayConfig.log_level,
         location,
         suffix: `-b '${replayConfig.begin_time}' -e '${replayConfig.end_time}'`,
       });
     } else {
-      args = buildKfcArgs({
+      args = buildKungfuArgs({
         location,
       });
     }
@@ -1171,7 +1171,7 @@ export const startMd = async (
 ): Promise<Proc | void> => {
   const processId = getProcessIdByKfLocation(kfConfig);
   const extDirs = await flattenExtensionModuleDirs(EXTENSION_DIRS);
-  const args = buildKfcArgs({
+  const args = buildKungfuArgs({
     extensionDirs: `"${extDirs
       .map((dir) => dealSpaceInPath(path.dirname(dir)))
       .join(path.delimiter)}"`,
@@ -1197,7 +1197,7 @@ export const startMd = async (
       {
         name: processId,
         cwd,
-        script: `${dealSpaceInPath(path.join(KFC_DIR, kfcName))}`,
+        script: `${dealSpaceInPath(path.join(KUNGFU_DIR, kungfuName))}`,
         args,
         max_restarts: 3,
         autorestart: true,
@@ -1237,7 +1237,7 @@ export const startTd = async (
       name: replayConfig.session_name,
       mode: mode,
     };
-    args = buildKfcArgs({
+    args = buildKungfuArgs({
       logLevel: replayConfig.log_level,
       extensionDirs: `"${extDirs
         .map((dir) => dealSpaceInPath(path.dirname(dir)))
@@ -1247,7 +1247,7 @@ export const startTd = async (
     });
     fullProcessId = getProcessIdByKfLocation(location);
   } else {
-    args = buildKfcArgs({
+    args = buildKungfuArgs({
       extensionDirs: `"${extDirs
         .map((dir) => dealSpaceInPath(path.dirname(dir)))
         .join(path.delimiter)}"`,
@@ -1266,7 +1266,7 @@ export const startTd = async (
       {
         name: fullProcessId,
         cwd,
-        script: `${dealSpaceInPath(path.join(KFC_DIR, kfcName))}`,
+        script: `${dealSpaceInPath(path.join(KUNGFU_DIR, kungfuName))}`,
         args,
         ...(notAutorestart
           ? {}
@@ -1314,7 +1314,7 @@ export const startTask = async (
       }
     }
 
-    argsResolved = buildKfcArgs({
+    argsResolved = buildKungfuArgs({
       logLevel: replayConfig.log_level,
       extensionDirs: `"${extDirs
         .map((dir) => dealSpaceInPath(path.dirname(dir)))
@@ -1332,7 +1332,7 @@ export const startTask = async (
       suffix: `${backtestArgs} -b '${replayConfig.begin_time}' -e '${replayConfig.end_time}'`,
     });
   } else {
-    argsResolved = buildKfcArgs({
+    argsResolved = buildKungfuArgs({
       extensionDirs: `"${extDirs
         .map((dir) => dealSpaceInPath(path.dirname(dir)))
         .join(path.delimiter)}"`,
@@ -1375,7 +1375,7 @@ export const startOperatorByExt = async (
   );
   await fse.ensureDir(cwd);
   if (isReplay && replayConfig) {
-    args = buildKfcArgs({
+    args = buildKungfuArgs({
       logLevel: replayConfig.log_level,
       location: {
         category: 'operator',
@@ -1396,7 +1396,7 @@ export const startOperatorByExt = async (
       mode: mode,
     });
   } else {
-    args = buildKfcArgs({
+    args = buildKungfuArgs({
       location: {
         category: 'operator',
         group: `"${group}"`,
@@ -1415,7 +1415,7 @@ export const startOperatorByExt = async (
       {
         name: fullProcessId,
         cwd,
-        script: `${dealSpaceInPath(path.join(KFC_DIR, kfcName))}`,
+        script: `${dealSpaceInPath(path.join(KUNGFU_DIR, kungfuName))}`,
         args,
         force: true,
       },
@@ -1462,7 +1462,7 @@ export const startStrategyOperatorByLocalPython = async (
       }
     }
 
-    args = buildKfcArgs({
+    args = buildKungfuArgs({
       prefix: '-m kungfu',
       logLevel: replayConfig.log_level,
       location: {
@@ -1484,7 +1484,7 @@ export const startStrategyOperatorByLocalPython = async (
       mode: mode,
     });
   } else {
-    args = buildKfcArgs({
+    args = buildKungfuArgs({
       prefix: '-m kungfu',
       location: KfLocation,
       suffix: `'${filePath}'`,
@@ -1568,7 +1568,7 @@ export const startStrategyOperator = async (
           );
         }
       }
-      const args = buildKfcArgs({
+      const args = buildKungfuArgs({
         logLevel: replayConfig.log_level,
         location: {
           category: replayConfig.category,
@@ -1595,7 +1595,7 @@ export const startStrategyOperator = async (
   if (ifLocalPython && filePath.endsWith('.py')) {
     return startStrategyOperatorByLocalPython(kfLocation, filePath, pythonPath);
   } else {
-    const args = buildKfcArgs({
+    const args = buildKungfuArgs({
       location: kfLocation,
       suffix: `'${filePath}'`,
     });
@@ -1617,11 +1617,11 @@ export const startDzxy = () => {
     args: '',
     cwd: process.env.CLI_DIR,
     script: 'dzxy.js',
-    interpreter: path.join(KFC_DIR, kfcName),
+    interpreter: path.join(KUNGFU_DIR, kungfuName),
     force: true,
     watch: process.env.NODE_ENV === 'production' ? false : true,
     env: {
-      KFC_AS_VARIANT: 'node',
+      KUNGFU_AS_VARIANT: 'node',
     },
     kill_timeout: 500,
   }).catch((err) => {
@@ -1642,17 +1642,17 @@ export const startExtService = async (
         args: '',
         cwd,
         script,
-        interpreter: path.join(KFC_DIR, kfcName),
+        interpreter: path.join(KUNGFU_DIR, kungfuName),
         force: true,
         watch: process.env.NODE_ENV === 'production' ? false : true,
         env: {
-          KFC_AS_VARIANT: 'node',
+          KUNGFU_AS_VARIANT: 'node',
         },
         kill_timeout: 500,
       };
     } else {
       const extDirs = await flattenExtensionModuleDirs(EXTENSION_DIRS);
-      const args = buildKfcArgs({
+      const args = buildKungfuArgs({
         extensionDirs: `"${
           cwd ||
           extDirs
@@ -1669,7 +1669,7 @@ export const startExtService = async (
       return {
         name: processId,
         cwd,
-        script: `${dealSpaceInPath(path.join(KFC_DIR, kfcName))}`,
+        script: `${dealSpaceInPath(path.join(KUNGFU_DIR, kungfuName))}`,
         args,
         force: true,
       };
@@ -1691,7 +1691,7 @@ export const startCustomProcess = (
   targetName: string,
   params: string,
 ): Promise<Proc | void> => {
-  const args = buildKfcArgs({
+  const args = buildKungfuArgs({
     extraArgs: `${targetName} ${params}`,
   });
   return startProcess({

--- a/framework/api/src/utils/processUtils.ts
+++ b/framework/api/src/utils/processUtils.ts
@@ -160,7 +160,7 @@ export const forceKillByKeyWords = (
   });
 };
 
-const kfcName = isWin ? 'kfc.exe' : 'kfc';
+const kfcName = isWin ? 'kungfu.exe' : 'kungfu';
 const appDirName = getAppRuntimeDirName();
 const appDirNameRegExp = new RegExp(appDirName, 'i');
 

--- a/framework/core/.cmake/compiler.cmake
+++ b/framework/core/.cmake/compiler.cmake
@@ -44,7 +44,7 @@ if (APPLE)
   set(KFC_INSTALL_RPATH
       "@loader_path"
       "@loader_path/../../"
-      "@executable_path/../../../../Resources/kfc"
+      "@executable_path/../../../../Resources/kungfu"
       )
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations -Wno-unqualified-std-cast-call -Wno-unused-value")
   set(CMAKE_INSTALL_RPATH "${KFC_INSTALL_RPATH}")

--- a/framework/core/.devtools/env.py
+++ b/framework/core/.devtools/env.py
@@ -7,13 +7,13 @@ from os.path import abspath, dirname
 
 base_dir = dirname(abspath(dirname(__file__)))
 python_dir = os.path.join(base_dir, "src", "python")
-kfc_dir = os.path.join(base_dir, "dist", "kfc")
-build_info_file = os.path.join(kfc_dir, "kungfubuildinfo.json")
+kungfu_dir = os.path.join(base_dir, "dist", "kungfu")
+build_info_file = os.path.join(kungfu_dir, "kungfubuildinfo.json")
 
 sys.path.append(python_dir)
-sys.path.append(kfc_dir)
-os.environ["PATH"] += os.pathsep + kfc_dir
+sys.path.append(kungfu_dir)
+os.environ["PATH"] += os.pathsep + kungfu_dir
 os.environ["KF_LOG_LEVEL"] = "trace"
 
 
-__frozen__ = os.path.exists(kfc_dir) and os.path.exists(build_info_file)
+__frozen__ = os.path.exists(kungfu_dir) and os.path.exists(build_info_file)

--- a/framework/core/.devtools/kfc.py
+++ b/framework/core/.devtools/kfc.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from os import environ
 
 
-environ["KUNGFU_DIR"] = Path("dist/kfc").resolve().as_posix()
+environ["KUNGFU_DIR"] = Path("dist/kungfu").resolve().as_posix()
 environ["KF_CLI_DEV_PATH"] = Path("../cli/dist/cli/index.js").resolve().as_posix()
 
 

--- a/framework/core/.devtools/kfc.py
+++ b/framework/core/.devtools/kfc.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from os import environ
 
 
-environ["KFC_DIR"] = Path("dist/kfc").resolve().as_posix()
+environ["KUNGFU_DIR"] = Path("dist/kfc").resolve().as_posix()
 environ["KF_CLI_DEV_PATH"] = Path("../cli/dist/cli/index.js").resolve().as_posix()
 
 

--- a/framework/core/.devtools/kfs.py
+++ b/framework/core/.devtools/kfs.py
@@ -1,12 +1,12 @@
 #  SPDX-License-Identifier: Apache-2.0
 
-from env import __frozen__, kfc_dir
+from env import __frozen__, kungfu_dir
 from kungfu import __tool__ as origin
 from os import environ
 from pathlib import Path
 
 environ["KFS_PATH"] = Path("../../developer/sdk/dist/sdk/kfs.js").resolve().as_posix()
-environ["KFC_PATH"] = kfc_dir.replace("\\", "/")
+environ["KUNGFU_PATH"] = kungfu_dir.replace("\\", "/")
 
 if __frozen__:
     origin.sdk()

--- a/framework/core/.gyp/freeze-kfc.sh
+++ b/framework/core/.gyp/freeze-kfc.sh
@@ -60,6 +60,6 @@ PYTHONPATH="$RELEASE" uv run --frozen python -m nuitka \
   --include-data-files="$BUILDINFO=kungfubuildinfo.json" \
   src/python/kfc.py
 
-BIN="$OUTDIR/kfc.dist/kfc.bin"
+BIN="$OUTDIR/kfc.dist/kungfu.bin"
 echo "[freeze] done: $BIN"
 ls -la "$BIN"

--- a/framework/core/.gyp/run-build.js
+++ b/framework/core/.gyp/run-build.js
@@ -14,7 +14,7 @@ function cpVsDependencies() {
   // hoist 布局下才解得到）。与 useUvPython() 用 __dirname 的写法一致。
   const core_dir = path.join(__dirname, '..');
   const vs_dir = path.join(core_dir, '.deps', 'vs');
-  const kfc_dist = path.join(core_dir, 'dist', 'kfc');
+  const kfc_dist = path.join(core_dir, 'dist', 'kungfu');
   fs.cpSync(vs_dir, kfc_dist, { recursive: true });
 }
 

--- a/framework/core/.gyp/run-conan.js
+++ b/framework/core/.gyp/run-conan.js
@@ -78,7 +78,7 @@ function conanBuild() {
 }
 
 // conan2 移除了独立的 `conan package` 本地命令(package() 经 conan create/export-pkg 触发)。
-// Stage C 决定 freeze 脱离 conan：kfc 的 freeze→dist/kfc 已迁到独立入口 `.gyp/run-freeze.js`
+// Stage C 决定 freeze 脱离 conan：kfc 的 freeze→dist/kungfu 已迁到独立入口 `.gyp/run-freeze.js`
 // (pnpm freeze → ./kungfu-code freeze)，见 docs/conan2-migration.md。此处 `package` 子命令
 // 仅保留 conan build(编译)语义，不再承担 freeze。
 function conanPackage() {

--- a/framework/core/.gyp/run-freeze.js
+++ b/framework/core/.gyp/run-freeze.js
@@ -201,15 +201,15 @@ function freezeNuitka(bt) {
   fs.mkdirSync(path.dirname(distKfc), { recursive: true });
   fs.renameSync(kfcDist, distKfc);
 
-  // nuitka standalone 入口名为 kfc.bin(Unix)/kfc.exe(Win)；app 栈按 'kungfu'(Unix)/'kungfu.exe'(Win)
-  // 定位可执行（framework/api pathConfig/processUtils 的 kfcName）。把 nuitka 入口重命名为
+  // nuitka standalone 入口名为 kfc.bin(Unix)/kungfu.exe(Win)；app 栈按 'kungfu'(Unix)/'kungfu.exe'(Win)
+  // 定位可执行（framework/api pathConfig/processUtils 的 kungfuName）。把 nuitka 入口重命名为
   // kungfu（用 rename 不用符号链，保持 nuitka 产物无符号链、electron-builder 打包干净）。
   if (!isWin) {
     const binPath = path.join(distKfc, 'kfc.bin');
     const kungfuPath = path.join(distKfc, 'kungfu');
     if (fs.existsSync(binPath)) fs.renameSync(binPath, kungfuPath);
   } else {
-    const exePath = path.join(distKfc, 'kfc.exe');
+    const exePath = path.join(distKfc, 'kungfu.exe');
     const kungfuExe = path.join(distKfc, 'kungfu.exe');
     if (fs.existsSync(exePath)) fs.renameSync(exePath, kungfuExe);
   }
@@ -245,13 +245,13 @@ function freezePyinstaller(bt) {
       env: {
         ...process.env,
         CMAKE_BUILD_TYPE: bt,
-        KFC_PYI_HOOKS_PATH: path.join(CORE, 'src', 'python', 'pyi-hooks'),
+        KUNGFU_PYI_HOOKS_PATH: path.join(CORE, 'src', 'python', 'pyi-hooks'),
       },
     },
   );
   mergeKfs();
   promote();
-  if (isWin) verifyWindowsSymbols(path.join(CORE, 'dist', 'kfc'));
+  if (isWin) verifyWindowsSymbols(path.join(CORE, 'dist', 'kungfu'));
   console.log('[freeze] ✅ dist/kfc 就绪（pyinstaller 扁平视图 + _internal 真身）');
 }
 

--- a/framework/core/.gyp/run-freeze.js
+++ b/framework/core/.gyp/run-freeze.js
@@ -9,11 +9,11 @@
 // 两条 freezer 路径（可人 2026-06-17 决策 Nuitka 2.x，不行回退 PyInstaller；
 // .v4 线 Nuitka 三平台已跑通，见 docs/conan2-migration.md §4c）：
 //
-// - nuitka（默认）：编译成 C，产物 kfc.dist 本就扁平（无 _internal），移到 dist/kfc 即可，
+// - nuitka（默认）：编译成 C，产物 kfc.dist 本就扁平（无 _internal），移到 dist/kungfu 即可，
 //   不需要 promote。kfc.py 内嵌 nuitka-project 选项（--standalone 等）。Nuitka 只跟随
 //   kfc.py 的 import，故 app/electron 侧 node native（drone.node / kungfu_node.node /
 //   kungfu_electron.node）需 freeze 后从 build/<type> 补拷（kfc python 进程不 import 它们）。
-// - pyinstaller（fallback）：onedir 把数据/库放进 _internal/，而 app 栈假设 dist/kfc 扁平，
+// - pyinstaller（fallback）：onedir 把数据/库放进 _internal/，而 app 栈假设 dist/kungfu 扁平，
 //   故 freeze 后 promote（_internal/*→顶层，Unix 符号链/Win 拷贝）。
 
 const fs = require('fs');
@@ -64,7 +64,7 @@ function ensureBuildInfo(bt) {
 }
 
 // app/electron 侧 node native：kfc python 进程不 import，Nuitka 不带，需从 build/<type> 补拷。
-// app 栈通过 @kungfu-tech/core/dist/kfc/<x> 解析它们（getKfcDir / webpack require.resolve）。
+// app 栈通过 @kungfu-tech/core/dist/kungfu/<x> 解析它们（getKfcDir / webpack require.resolve）。
 const APP_NATIVE = [
   'drone.node',
   'kungfu_node.node',
@@ -129,7 +129,7 @@ function findFileShallow(root, re) {
   return null;
 }
 
-// Windows only：把 python binding(pykungfu) 与 libnode 运行库补拷进 dist/kfc。
+// Windows only：把 python binding(pykungfu) 与 libnode 运行库补拷进 dist/kungfu。
 //
 // 缘由：MSVC 多配置生成器与 Mac/Linux 单配置生成器的产物布局不一致——Win 把
 // pykungfu.<abi>.pyd 产在 build/ 根、libnode.dll 产在 build/<bt>；而 Nuitka freeze 用
@@ -191,7 +191,7 @@ function freezeNuitka(bt) {
     { cwd: CORE, env: { ...process.env, PYTHONPATH: rel } },
   );
 
-  // Nuitka standalone 产物 kfc.dist 本就扁平 → 直接移到 dist/kfc（无 _internal、无 promote）。
+  // Nuitka standalone 产物 kfc.dist 本就扁平 → 直接移到 dist/kungfu（无 _internal、无 promote）。
   const kfcDist = path.join(out, 'kfc.dist');
   if (!fs.existsSync(kfcDist)) {
     console.error(`[freeze] 错误：未找到 ${kfcDist}（nuitka 产物布局变化？）`);
@@ -252,7 +252,7 @@ function freezePyinstaller(bt) {
   mergeKfs();
   promote();
   if (isWin) verifyWindowsSymbols(path.join(CORE, 'dist', 'kungfu'));
-  console.log('[freeze] ✅ dist/kfc 就绪（pyinstaller 扁平视图 + _internal 真身）');
+  console.log('[freeze] ✅ dist/kungfu 就绪（pyinstaller 扁平视图 + _internal 真身）');
 }
 
 // MERGE 模式下 kfs 与 kfc 共享 _internal，dist/kfs 仅余 kfs 入口，拷进 kfc 后删除。
@@ -270,7 +270,7 @@ function mergeKfs() {
   fs.rmSync(distKfs, { recursive: true, force: true });
 }
 
-// _internal/* 在 dist/kfc 顶层补一层视图，满足 app 栈的扁平布局假设（仅 pyinstaller 路径）。
+// _internal/* 在 dist/kungfu 顶层补一层视图，满足 app 栈的扁平布局假设（仅 pyinstaller 路径）。
 function promote() {
   const distKfc = path.join(CORE, 'dist', 'kungfu');
   const internal = path.join(distKfc, '_internal');

--- a/framework/core/.gyp/run-freeze.js
+++ b/framework/core/.gyp/run-freeze.js
@@ -95,7 +95,7 @@ function copyPdbSibling(binPath, destDir) {
 
 function copyAppNative(bt) {
   const rel = path.join(CORE, 'build', bt);
-  const distKfc = path.join(CORE, 'dist', 'kfc');
+  const distKfc = path.join(CORE, 'dist', 'kungfu');
   let n = 0;
   for (const f of APP_NATIVE) {
     const from = path.join(rel, f);
@@ -141,7 +141,7 @@ function findFileShallow(root, re) {
 // 冻结 kfc 可执行会加载与其同目录的 pykungfu.pyd + libnode.dll（已实测通过），故补拷即可。
 function copyPyBindingWin(bt) {
   if (!isWin) return;
-  const distKfc = path.join(CORE, 'dist', 'kfc');
+  const distKfc = path.join(CORE, 'dist', 'kungfu');
   const buildDir = path.join(CORE, 'build');
   const pyd = findFileShallow(buildDir, /^pykungfu.*\.pyd$/i);
   const btDll = path.join(buildDir, bt, 'libnode.dll');
@@ -157,7 +157,7 @@ function copyPyBindingWin(bt) {
   if (pyd) copyPdbSibling(pyd, distKfc);
   if (!pyd) console.error('[freeze] Win 警告：build 树未找到 pykungfu*.pyd');
   if (!dll) console.error('[freeze] Win 警告：build 树未找到 libnode.dll');
-  console.log(`[freeze] Win：补拷 python binding → dist/kfc：${n} 项`);
+  console.log(`[freeze] Win：补拷 python binding → dist/kungfu：${n} 项`);
 }
 
 // ----------------------------------------------------------------- nuitka
@@ -165,7 +165,7 @@ function copyPyBindingWin(bt) {
 function freezeNuitka(bt) {
   const rel = path.join(CORE, 'build', bt); // 三 native（pykungfu/libkungfu/libnode）同目录
   const out = path.join(CORE, 'build', 'kfc-nuitka');
-  const distKfc = path.join(CORE, 'dist', 'kfc');
+  const distKfc = path.join(CORE, 'dist', 'kungfu');
   const info = ensureBuildInfo(bt);
 
   console.log(`[freeze] nuitka kfc.py（PYTHONPATH=${path.relative(CORE, rel)}）`);
@@ -201,19 +201,23 @@ function freezeNuitka(bt) {
   fs.mkdirSync(path.dirname(distKfc), { recursive: true });
   fs.renameSync(kfcDist, distKfc);
 
-  // nuitka standalone 入口名为 kfc.bin(Unix)/kfc.exe(Win)；app 栈按 'kfc'(Unix)/'kfc.exe'(Win)
-  // 定位可执行（framework/api pathConfig/processUtils 的 kfcName）。Win 已匹配；Unix 把
-  // kfc.bin 重命名为 kfc（用 rename 不用符号链，保持 nuitka 产物无符号链、electron-builder 打包干净）。
+  // nuitka standalone 入口名为 kfc.bin(Unix)/kfc.exe(Win)；app 栈按 'kungfu'(Unix)/'kungfu.exe'(Win)
+  // 定位可执行（framework/api pathConfig/processUtils 的 kfcName）。把 nuitka 入口重命名为
+  // kungfu（用 rename 不用符号链，保持 nuitka 产物无符号链、electron-builder 打包干净）。
   if (!isWin) {
     const binPath = path.join(distKfc, 'kfc.bin');
-    const kfcPath = path.join(distKfc, 'kfc');
-    if (fs.existsSync(binPath)) fs.renameSync(binPath, kfcPath);
+    const kungfuPath = path.join(distKfc, 'kungfu');
+    if (fs.existsSync(binPath)) fs.renameSync(binPath, kungfuPath);
+  } else {
+    const exePath = path.join(distKfc, 'kfc.exe');
+    const kungfuExe = path.join(distKfc, 'kungfu.exe');
+    if (fs.existsSync(exePath)) fs.renameSync(exePath, kungfuExe);
   }
 
   copyAppNative(bt);
   copyPyBindingWin(bt);
-  if (isWin) verifyWindowsSymbols(path.join(CORE, 'dist', 'kfc'));
-  console.log('[freeze] ✅ dist/kfc 就绪（nuitka 扁平产物 + app native）');
+  if (isWin) verifyWindowsSymbols(path.join(CORE, 'dist', 'kungfu'));
+  console.log('[freeze] ✅ dist/kungfu 就绪（nuitka 扁平产物 + app native）');
 }
 
 // ------------------------------------------------------------- pyinstaller
@@ -253,7 +257,7 @@ function freezePyinstaller(bt) {
 
 // MERGE 模式下 kfs 与 kfc 共享 _internal，dist/kfs 仅余 kfs 入口，拷进 kfc 后删除。
 function mergeKfs() {
-  const distKfc = path.join(CORE, 'dist', 'kfc');
+  const distKfc = path.join(CORE, 'dist', 'kungfu');
   const distKfs = path.join(CORE, 'dist', 'kfs');
   if (!fs.existsSync(distKfs)) return;
   console.log('[freeze] 合并 kfs → kfc');
@@ -268,7 +272,7 @@ function mergeKfs() {
 
 // _internal/* 在 dist/kfc 顶层补一层视图，满足 app 栈的扁平布局假设（仅 pyinstaller 路径）。
 function promote() {
-  const distKfc = path.join(CORE, 'dist', 'kfc');
+  const distKfc = path.join(CORE, 'dist', 'kungfu');
   const internal = path.join(distKfc, '_internal');
   if (!fs.existsSync(internal)) {
     console.error(

--- a/framework/core/.gyp/verify-windows-symbols.js
+++ b/framework/core/.gyp/verify-windows-symbols.js
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// Release constraint: every kungfu-compiled native shipped into dist/kfc on
+// Release constraint: every kungfu-compiled native shipped into dist/kungfu on
 // Windows MUST have its PDB alongside it. Without the PDB the field crash
 // stackwalker can only print module+offset instead of function names and source
 // lines (see docs/windows-crash-symbols.md).

--- a/framework/core/.gyp/verify-windows-symbols.js
+++ b/framework/core/.gyp/verify-windows-symbols.js
@@ -13,7 +13,7 @@
 //   node .gyp/verify-windows-symbols.js [dist-kfc-dir]
 // or from the freeze pipeline:
 //   const { verifyWindowsSymbols } = require('./verify-windows-symbols');
-//   verifyWindowsSymbols(path.join(CORE, 'dist', 'kfc'));
+//   verifyWindowsSymbols(path.join(CORE, 'dist', 'kungfu'));
 
 const fs = require('fs');
 const path = require('path');
@@ -62,6 +62,6 @@ function verifyWindowsSymbols(distKfc) {
 module.exports = { verifyWindowsSymbols };
 
 if (require.main === module) {
-  const dir = process.argv[2] || path.resolve(__dirname, '..', 'dist', 'kfc');
+  const dir = process.argv[2] || path.resolve(__dirname, '..', 'dist', 'kungfu');
   verifyWindowsSymbols(dir);
 }

--- a/framework/core/binding.gyp
+++ b/framework/core/binding.gyp
@@ -22,7 +22,7 @@
       "<@(module_inputs)",
       "<!@(node -p \"require('glob').sync('src/python/**/*.*(py|spec)').join(' ');\")"
     ],
-    "kfc_inputs": [
+    "kungfu_inputs": [
       "<@(wheel_inputs)"
     ]
   },
@@ -150,7 +150,7 @@
         {
           "action_name": "freeze",
           "inputs": [
-            "<@(kfc_inputs)"
+            "<@(kungfu_inputs)"
           ],
           "outputs": [
             "<(module_path)/kungfubuildinfo.json"

--- a/framework/core/conanfile.py
+++ b/framework/core/conanfile.py
@@ -113,7 +113,7 @@ class KungfuCoreConan(ConanFile):
     build_info_file = "kungfubuildinfo.json"
     build_dir = path.join(conanfile_dir, "build")
     dist_dir = path.join(conanfile_dir, "dist")
-    kfc_dir = path.join(dist_dir, "kfc")
+    kungfu_dir = path.join(dist_dir, "kungfu")
     kfs_dir = path.join(dist_dir, "kfs")
 
     def config_options(self):
@@ -200,8 +200,8 @@ class KungfuCoreConan(ConanFile):
             copy(
                 self,
                 "*",
-                path.join(src, "dist", "kfc"),
-                path.join(self.package_folder, "kfc"),
+                path.join(src, "dist", "kungfu"),
+                path.join(self.package_folder, "kungfu"),
             )
 
     def package_info(self):
@@ -473,7 +473,7 @@ class KungfuCoreConan(ConanFile):
         from wcmatch import glob as wcglob
 
         for file in wcglob.glob("*kfs*", flags=wcglob.EXTGLOB, root_dir=self.kfs_dir):
-            shutil.copy(path.join(self.kfs_dir, file), self.kfc_dir)
+            shutil.copy(path.join(self.kfs_dir, file), self.kungfu_dir)
         shutil.rmtree(self.kfs_dir)
         self.output.success("PyInstaller done")
 
@@ -489,13 +489,13 @@ class KungfuCoreConan(ConanFile):
         finally:
             os.chdir(cwd)
 
-        kfc_dist_dir = path.join(self.build_dir, "kfc.dist")
-        shutil.copytree(build_type, kfc_dist_dir)
-        shutil.rmtree(self.kfc_dir, ignore_errors=True)
-        shutil.move(kfc_dist_dir, self.kfc_dir)
+        kungfu_dist_dir = path.join(self.build_dir, "kfc.dist")
+        shutil.copytree(build_type, kungfu_dist_dir)
+        shutil.rmtree(self.kungfu_dir, ignore_errors=True)
+        shutil.move(kungfu_dist_dir, self.kungfu_dir)
         self.output.success("Nuitka done")
 
     def __run_freeze(self, build_type):
-        os.environ["KFC_PYI_HOOKS_PATH"] = self.pyi_hooks_dir
+        os.environ["KUNGFU_PYI_HOOKS_PATH"] = self.pyi_hooks_dir
         freeze = {"pyinstaller": self.__run_pyinstaller, "nuitka": self.__run_nuitka}
         freeze[str(self.options.freezer)](build_type)

--- a/framework/core/docs/adr/ADR-0009-load-bearing-self-bootstrap.md
+++ b/framework/core/docs/adr/ADR-0009-load-bearing-self-bootstrap.md
@@ -8,7 +8,7 @@
 - Category: (principle) product-layer first principle — names and generalizes
   the property that "the build dogfoods the SDK" (`docs/architecture.md`) was a
   single instance of.
-- Subsystem: whole product — runtime (`framework/core`/`kfc`), capability SDK
+- Subsystem: whole product — runtime (`framework/core`/`kungfu`), capability SDK
   (`framework/api`), application SDK (`developer/sdk`/`kfs`), reference surfaces
   (`framework/gui`, `framework/tui`), distribution (`artifact`).
 - Related: the dynamic counterpart to the version mechanism's
@@ -45,7 +45,7 @@ self-sustaining**.
 ## The engine (three steps, none skippable)
 
 1. **Load-bearing coupling (the precondition).** Each ring genuinely consumes
-   the ring beneath it — `kfs` runs *on* `kfc`; the TUI starts *through* `kfc`'s
+   the ring beneath it — `kfs` runs *on* `kungfu`; the TUI starts *through* `kungfu`'s
    Node runtime. This step is the switch: degrade any ring into a wrapper / mock
    / optional side path and steps 2–3 break at once.
 
@@ -101,34 +101,34 @@ consume (hence validate) the ring beneath:
 
 - **libkungfu** — the polyglot membrane: zero-copy cross-language access plus the
   longfist binary layout. The base everything else bootstraps onto.
-- **kfc** — the first-layer binary. It embeds a Python and a Node runtime and
+- **kungfu** — the first-layer binary. It embeds a Python and a Node runtime and
   loads libkungfu's companion bindings (`py_kungfu`, `kungfu_node.node`)
   in-process. *First bootstrap:* the runtime is itself a consumer of the membrane.
-- **kfx development toolchain** — `kfc` bridges a full Python lifecycle
-  (dependency management, ahead-of-time compilation via `kfc engage`); the
+- **kfx development toolchain** — `kungfu` bridges a full Python lifecycle
+  (dependency management, ahead-of-time compilation via `kungfu engage`); the
   repository's own `kfx` extensions are built through it. *Bootstrap:* the repo's
-  own build is a user of the toolchain `kfc` ships.
+  own build is a user of the toolchain `kungfu` ships.
 - **Reference surfaces (GUI / TUI)** — no paradigm innovation (Electron/React,
   Ink); their job is to let a human *see* libkungfu's capability rather than read
   about it. They load the binding in-process to preserve zero-copy, and the TUI
-  starts through `kfc`'s Node runtime — repeatedly re-exercising `kfc` on every
+  starts through `kungfu`'s Node runtime — repeatedly re-exercising `kungfu` on every
   launch.
 - **Application SDK (`kfs`)** — supports building/packaging extensions, yet `kfs`
-  itself launches on `kfc` as its runtime, so a user develops a `kfx` with no
-  separately installed Node or Python. *Bootstrap:* `kfs` is a consumer of `kfc`.
-- **`artifact`** — bundles `kfc`, the reference surfaces, and `kfx`, and is
+  itself launches on `kungfu` as its runtime, so a user develops a `kfx` with no
+  separately installed Node or Python. *Bootstrap:* `kfs` is a consumer of `kungfu`.
+- **`artifact`** — bundles `kungfu`, the reference surfaces, and `kfx`, and is
   assembled *using* `kfs`. *Bootstrap:* assembling the installer is the real test
   that `kfs` can package a complete application.
 
 Three instances are easy to miss and worth naming explicitly, because they are
 the ones that close the loop:
 
-- **Stage-0 bootstrap (the compiler analogy).** `kfc` *embeds* runtimes for the
-  user, but *building* `kfc` needs a Python/Node toolchain that does not yet
+- **Stage-0 bootstrap (the compiler analogy).** `kungfu` *embeds* runtimes for the
+  user, but *building* `kungfu` needs a Python/Node toolchain that does not yet
   exist inside it — supplied externally by `./kungfu-code` (Node via fnm, Python
   via uv, the package manager via Corepack). There is a handoff: an external
-  stage-0 toolchain produces `kfc`, after which `kfx` development switches to
-  `kfc`'s own embedded toolchain. This is exactly a self-hosting compiler's
+  stage-0 toolchain produces `kungfu`, after which `kfx` development switches to
+  `kungfu`'s own embedded toolchain. This is exactly a self-hosting compiler's
   stage-0 → stage-1: borrow an external compiler once, then self-host.
 - **Single-schema codegen.** The membrane's cross-language identity ("C++,
   Python, and Node read the same layout") is not hand-synchronized; it is
@@ -153,7 +153,7 @@ the engine:
    proof — it is the *opposite* of this principle, not a lighter version of it.
 2. **Bootstrap only toward decreasing change-rate** (the safety constraint). An
    outer, fast-changing ring may bootstrap onto an inner, slower-changing one —
-   UI onto `kfc`, `kfc` onto libkungfu — never the reverse. "One move used many
+   UI onto `kungfu`, `kungfu` onto libkungfu — never the reverse. "One move used many
    times" has a dual: *one broken move breaks many things.* The chain is only
    safe because the things everyone depends on are the things that change least
    (the longfist layout as true invariant, [ADR-0008](ADR-0008-longfist-schema-evolution-and-minor-maintenance.md)).
@@ -192,7 +192,7 @@ exactly what an unguarded "just add a nicer demo" instinct produces.
 
 - **Self-hosting compilers** — stage-0 builds the compiler with an external
   toolchain, after which the compiler compiles itself; a broken core cannot
-  rebuild anything. The kfc/kfx toolchain handoff is the same shape.
+  rebuild anything. The kungfu/kfx toolchain handoff is the same shape.
 - **Dogfooding** as an industry practice — but stated here as a *forcing
   function and a trust-removal*, not merely "use your own product".
 - **Eat-your-own-output validation** — deterministic replay re-consuming the

--- a/framework/core/docs/windows-crash-symbols.md
+++ b/framework/core/docs/windows-crash-symbols.md
@@ -3,7 +3,7 @@
 ## Constraint
 
 Every kungfu-compiled native shipped in a Windows release **must** have its PDB
-next to it in `dist/kfc`:
+next to it in `dist/kungfu`:
 
 | Native | PDB |
 | --- | --- |
@@ -41,7 +41,7 @@ those two PDBs cover the whole native surface — there is no separate
    links with `/DEBUG /OPT:REF /OPT:ICF` (emit `<target>.pdb` while keeping the
    Release size optimizations `/DEBUG` otherwise disables).
 2. **Packaging** — `.gyp/run-freeze.js` copies each native's `.pdb` sibling into
-   `dist/kfc` alongside the binary.
+   `dist/kungfu` alongside the binary.
 3. **Verification** — `.gyp/verify-windows-symbols.js` runs at the end of the
    Windows freeze and `exit(1)`s if any required native lacks a PDB, so a release
    that would ship unsymbolizable crash reports fails the build instead.
@@ -49,7 +49,7 @@ those two PDBs cover the whole native surface — there is no separate
 Run the check standalone against a staged release:
 
 ```
-node .gyp/verify-windows-symbols.js dist/kfc
+node .gyp/verify-windows-symbols.js dist/kungfu
 ```
 
 ## Symbolizing an old report offline

--- a/framework/core/lib/executable.js
+++ b/framework/core/lib/executable.js
@@ -3,12 +3,12 @@
 const path = require('path');
 
 function resolve(name) {
-  const kfcDir = path.resolve(__dirname, '..', 'dist', 'kfc');
+  const kfcDir = path.resolve(__dirname, '..', 'dist', 'kungfu');
   const bin = process.platform === 'win32' ? `${name}.exe` : name;
   return path.resolve(kfcDir, bin);
 }
 
 module.exports = {
-  kfc: resolve('kfc'),
+  kfc: resolve('kungfu'),
   kfs: resolve('kfs'),
 };

--- a/framework/core/lib/executable.js
+++ b/framework/core/lib/executable.js
@@ -3,9 +3,9 @@
 const path = require('path');
 
 function resolve(name) {
-  const kfcDir = path.resolve(__dirname, '..', 'dist', 'kungfu');
+  const kungfuDir = path.resolve(__dirname, '..', 'dist', 'kungfu');
   const bin = process.platform === 'win32' ? `${name}.exe` : name;
-  return path.resolve(kfcDir, bin);
+  return path.resolve(kungfuDir, bin);
 }
 
 module.exports = {

--- a/framework/core/lib/kfs.js
+++ b/framework/core/lib/kfs.js
@@ -15,6 +15,6 @@ shell.run(kfs, process.argv.slice(2), true, {
       'sdk',
       'kfs.js',
     ),
-    KFC_PATH: path.join(__dirname, '..', 'dist', 'kfc'),
+    KFC_PATH: path.join(__dirname, '..', 'dist', 'kungfu'),
   },
 });

--- a/framework/core/lib/kfs.js
+++ b/framework/core/lib/kfs.js
@@ -15,6 +15,6 @@ shell.run(kfs, process.argv.slice(2), true, {
       'sdk',
       'kfs.js',
     ),
-    KFC_PATH: path.join(__dirname, '..', 'dist', 'kungfu'),
+    KUNGFU_PATH: path.join(__dirname, '..', 'dist', 'kungfu'),
   },
 });

--- a/framework/core/lib/kungfu.js
+++ b/framework/core/lib/kungfu.js
@@ -6,22 +6,22 @@ module.exports = function () {
       const moduleName = '@kungfu-tech/core';
       const config = require(`${moduleName}/package.json`);
       const binary = config.binary;
-      const kfcDir =
-        process.env.KFC_DIR || `${moduleName}/${binary.module_path}`;
+      const kungfuDir =
+        process.env.KUNGFU_DIR || `${moduleName}/${binary.module_path}`;
 
       const nodeBinding = require.resolve(
-        `${kfcDir}/${binary.module_name}.node`,
+        `${kungfuDir}/${binary.module_name}.node`,
       );
       const electronBinding = nodeBinding.replace('_node.', '_electron.');
-      const kfcBinding = nodeBinding.replace('_node.', '_kfc.');
+      const kungfuBinding = nodeBinding.replace('_node.', '_cli.');
       const useElectron =
         process.platform !== 'win32' && 'electron' in process.versions;
       const useKfc =
-        process.platform === 'linux' && process.env.KFC_AS_VARIANT === 'node';
+        process.platform === 'linux' && process.env.KUNGFU_AS_VARIANT === 'node';
       const binding_path = useElectron
         ? electronBinding
         : useKfc
-        ? kfcBinding
+        ? kungfuBinding
         : nodeBinding;
       return require(binding_path);
     } catch (e) {

--- a/framework/core/package.json
+++ b/framework/core/package.json
@@ -28,7 +28,7 @@
   },
   "binary": {
     "module_name": "kungfu_node",
-    "module_path": "dist/kfc",
+    "module_path": "dist/kungfu",
     "remote_path": "kungfu-core/v{major}/v{version}",
     "package_name": "kfc-v{version}-{platform}-{arch}-{configuration}.tar.gz",
     "host": "https://prebuilt.libkungfu.cc"

--- a/framework/core/package.json
+++ b/framework/core/package.json
@@ -16,8 +16,7 @@
     "access": "public"
   },
   "bin": {
-    "kungfu": "lib/kfc.js",
-    "kfc": "lib/kfc.js"
+    "kungfu": "lib/kfc.js"
   },
   "config": {
     "build_type": "Release",
@@ -30,7 +29,7 @@
     "module_name": "kungfu_node",
     "module_path": "dist/kungfu",
     "remote_path": "kungfu-core/v{major}/v{version}",
-    "package_name": "kfc-v{version}-{platform}-{arch}-{configuration}.tar.gz",
+    "package_name": "kungfu-v{version}-{platform}-{arch}-{configuration}.tar.gz",
     "host": "https://prebuilt.libkungfu.cc"
   },
   "binaryGithub": {
@@ -53,9 +52,9 @@
     "format:cpp": "node .gyp/run-format-cpp.js src",
     "format:python": "node .gyp/run-format-python.js . src src/*/*.spec .*/*.py",
     "format:js": "node .gyp/run-format-js.js \"(.gyp|lib)/**.js\"",
-    "kfc": "node lib/kfc.js",
+    "kungfu": "node lib/kfc.js",
     "kfs": "node lib/kfs.js",
-    "dev:kfc": "uv run --frozen python .devtools/kfc.py",
+    "dev:kungfu": "uv run --frozen python .devtools/kfc.py",
     "dev:kfs": "uv run --frozen python .devtools/kfs.py"
   },
   "dependencies": {

--- a/framework/core/src/bindings/node/binding/kungfu_node.cpp
+++ b/framework/core/src/bindings/node/binding/kungfu_node.cpp
@@ -29,12 +29,12 @@ static FARPROC WINAPI load_exe_hook(unsigned int event, DelayLoadInfo *info) {
   char buf[1024];
   auto length = GetModuleFileNameA(NULL, buf, sizeof(buf));
   std::string main_exe_name(buf);
-  std::regex kfc_exe("kfc.exe");
+  std::regex kungfu_exe("kungfu.exe");
 
-  auto name_end = buf + length - strlen("kfc.exe");
-  auto libnode_dll = std::regex_replace(main_exe_name, kfc_exe, "libnode.dll");
+  auto name_end = buf + length - strlen("kungfu.exe");
+  auto libnode_dll = std::regex_replace(main_exe_name, kungfu_exe, "libnode.dll");
 
-  m = _stricmp(name_end, "kfc.exe") != 0 ? GetModuleHandle(NULL) : GetModuleHandleA(libnode_dll.c_str());
+  m = _stricmp(name_end, "kungfu.exe") != 0 ? GetModuleHandle(NULL) : GetModuleHandleA(libnode_dll.c_str());
   return (FARPROC)m;
 }
 

--- a/framework/core/src/python/kfc.spec
+++ b/framework/core/src/python/kfc.spec
@@ -100,22 +100,22 @@ def extend_hiddenimports(modules, executable_modules):
 
 
 def get_hookspath():
-    key = "KFC_PYI_HOOKS_PATH"
+    key = "KUNGFU_PYI_HOOKS_PATH"
     return [] if key not in os.environ else os.environ[key].split(os.pathsep)
 
 
 def get_runtimehooks():
-    key = "KFC_PYI_RUNTIME_HOOKS"
+    key = "KUNGFU_PYI_RUNTIME_HOOKS"
     return None if key not in os.environ else os.environ[key].split(",")
 
 
 ###############################################################################
 block_cipher = None
 
-kfc_name = "kfc"
+kungfu_name = "kungfu"
 kfs_name = "kfs"
 
-kfc_a = Analysis(
+kungfu_a = Analysis(
     scripts=["kfc.py"],
     pathex=extra_python_paths,
     binaries=[],
@@ -172,20 +172,20 @@ kfc_a = Analysis(
 )
 kfs_a = Analysis(scripts=["kfs.py"], pathex=extra_python_paths, cipher=block_cipher)
 
-MERGE((kfc_a, kfc_name, kfc_name), (kfs_a, kfs_name, kfs_name))
+MERGE((kungfu_a, kungfu_name, kungfu_name), (kfs_a, kfs_name, kfs_name))
 
-kfc_pyz = PYZ(kfc_a.pure, kfc_a.zipped_data, cipher=block_cipher)
-kfc_exe = EXE(
-    kfc_pyz,
-    kfc_a.scripts,
-    name=kfc_name,
+kungfu_pyz = PYZ(kungfu_a.pure, kungfu_a.zipped_data, cipher=block_cipher)
+kungfu_exe = EXE(
+    kungfu_pyz,
+    kungfu_a.scripts,
+    name=kungfu_name,
     console=True,
     debug=False,
     exclude_binaries=True,
     strip=False,
 )
-kfc_coll = COLLECT(
-    kfc_exe, kfc_a.binaries, kfc_a.zipfiles, kfc_a.datas, name=kfc_name, strip=False
+kungfu_coll = COLLECT(
+    kungfu_exe, kungfu_a.binaries, kungfu_a.zipfiles, kungfu_a.datas, name=kungfu_name, strip=False
 )
 
 kfs_pyz = PYZ(kfs_a.pure, kfs_a.zipped_data, cipher=block_cipher)
@@ -213,12 +213,12 @@ def copy_dll_x64(dll_pattern):
     """
     from wcmatch import glob
 
-    kfc_dir = kfc_coll.name
+    kungfu_dir = kungfu_coll.name
 
     def locate(file):
-        return abspath(make_path(kfc_dir, file))
+        return abspath(make_path(kungfu_dir, file))
 
-    for dll_file in glob.glob(dll_pattern, flags=glob.EXTGLOB, root_dir=kfc_dir):
+    for dll_file in glob.glob(dll_pattern, flags=glob.EXTGLOB, root_dir=kungfu_dir):
         dll_path = pathlib.Path(dll_file)
         x64_dll = make_path(dll_path.parent, dll_path.stem + "-x64" + ".dll")
         logger.info(f"Copying {locate(dll_path)} to {locate(x64_dll)}")

--- a/framework/core/src/python/kungfu/console/commands/__init__.py
+++ b/framework/core/src/python/kungfu/console/commands/__init__.py
@@ -112,7 +112,7 @@ class PrioritizedCommandGroup(click.Group):
         return copy_from_parent
 
 
-@click.group("kfc", invoke_without_command=True, cls=PrioritizedCommandGroup)
+@click.group("kungfu", invoke_without_command=True, cls=PrioritizedCommandGroup)
 @click.option(
     "-H",
     "--home",

--- a/framework/core/src/python/kungfu/console/commands/cli.py
+++ b/framework/core/src/python/kungfu/console/commands/cli.py
@@ -14,7 +14,7 @@ import os
 @click.option("-v", "--version", is_flag=True, help="show cli version")
 @kfc.pass_context()
 def cli(ctx, commands, list, help, version):
-    os.environ["KFC_AS_VARIANT"] = "node"
+    os.environ["KUNGFU_AS_VARIANT"] = "node"
     cli_prod_path = os.path.abspath(
         os.path.join(
             os.path.dirname(__file__),

--- a/framework/core/src/python/kungfu/console/variants/__init__.py
+++ b/framework/core/src/python/kungfu/console/variants/__init__.py
@@ -2,7 +2,7 @@
 
 from os import environ
 
-ENV_VARIANT_KEY = "KFC_AS_VARIANT"
+ENV_VARIANT_KEY = "KUNGFU_AS_VARIANT"
 
 
 def disable():

--- a/framework/core/tests/bench/README.md
+++ b/framework/core/tests/bench/README.md
@@ -22,7 +22,7 @@ pre-dispatched fast path).
 
 ## Runs
 
-Master form (requires built `dist/kfc`):
+Master form (requires built `dist/kungfu`):
 
 ```sh
 KF_BYPASS_CACHED=1 tests/bench/dispatch_bench.sh   # rx-isolated: no storage feed

--- a/framework/core/tests/bench/dispatch_bench.sh
+++ b/framework/core/tests/bench/dispatch_bench.sh
@@ -6,7 +6,7 @@
 # Starts a master with the KF_DISPATCH_PROBE instrument enabled, drives it
 # with an open-layer event burst from a registered apprentice
 # (dispatch_load.py), then prints the probe reports collected on the master
-# side. Requires the core dev environment (built dist/kfc).
+# side. Requires the core dev environment (built dist/kungfu).
 #
 # Usage: tests/bench/dispatch_bench.sh [event-count] [load-type]
 #
@@ -34,7 +34,7 @@ export KF_DISPATCH_PROBE
 
 # Dev-python import of pykungfu: give dyld the dist dir as fallback (same as
 # the capture fixtures).
-DYLD_FALLBACK_LIBRARY_PATH="$core_dir/dist/kfc${DYLD_FALLBACK_LIBRARY_PATH:+:$DYLD_FALLBACK_LIBRARY_PATH}"
+DYLD_FALLBACK_LIBRARY_PATH="$core_dir/dist/kungfu${DYLD_FALLBACK_LIBRARY_PATH:+:$DYLD_FALLBACK_LIBRARY_PATH}"
 export DYLD_FALLBACK_LIBRARY_PATH
 
 cd "$core_dir"

--- a/framework/core/tests/bench/dispatch_bench.sh
+++ b/framework/core/tests/bench/dispatch_bench.sh
@@ -39,7 +39,7 @@ export DYLD_FALLBACK_LIBRARY_PATH
 
 cd "$core_dir"
 
-# same invocation shape the app supervisor uses (processUtils buildKfcArgs)
+# same invocation shape the app supervisor uses (processUtils buildKungfuArgs)
 uv run --frozen python .devtools/kfc.py -H "$home" \
   run -c system -g master -n master -m live \
   >"$home/master.out" 2>&1 &

--- a/framework/core/tests/bench/dispatch_bench_watcher.sh
+++ b/framework/core/tests/bench/dispatch_bench_watcher.sh
@@ -6,7 +6,7 @@
 # Starts a master, attaches the real node Watcher under plain node
 # (dispatch_watcher_bench.js), drives typed Quote load through a registered
 # apprentice, then prints the probe reports collected on the watcher side.
-# Requires the core dev environment (built dist/kfc) and fnm (repo-pinned
+# Requires the core dev environment (built dist/kungfu) and fnm (repo-pinned
 # node, same bootstrap as ./kungfu-code).
 #
 # Usage: tests/bench/dispatch_bench_watcher.sh [event-count]
@@ -26,7 +26,7 @@ echo "bench home: $home"
 KF_DISPATCH_PROBE=1
 export KF_DISPATCH_PROBE
 
-DYLD_FALLBACK_LIBRARY_PATH="$core_dir/dist/kfc${DYLD_FALLBACK_LIBRARY_PATH:+:$DYLD_FALLBACK_LIBRARY_PATH}"
+DYLD_FALLBACK_LIBRARY_PATH="$core_dir/dist/kungfu${DYLD_FALLBACK_LIBRARY_PATH:+:$DYLD_FALLBACK_LIBRARY_PATH}"
 export DYLD_FALLBACK_LIBRARY_PATH
 
 cd "$core_dir"

--- a/framework/core/tests/bench/dispatch_load.py
+++ b/framework/core/tests/bench/dispatch_load.py
@@ -25,7 +25,7 @@ import time
 
 _core = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 sys.path.insert(0, os.path.join(_core, "src", "python"))
-sys.path.insert(0, os.path.join(_core, "dist", "kfc"))
+sys.path.insert(0, os.path.join(_core, "dist", "kungfu"))
 
 import kungfu
 

--- a/framework/core/tests/bench/dispatch_watcher_bench.js
+++ b/framework/core/tests/bench/dispatch_watcher_bench.js
@@ -25,7 +25,7 @@ const coreDir = path.resolve(__dirname, '..', '..');
 // require the binding artifact directly: the lib/kungfu.js loader resolves
 // the '@kungfu-tech/core' package name, which is not self-linked inside this
 // package's own node_modules
-const binding = require(path.join(coreDir, 'dist', 'kfc', 'kungfu_node.node'));
+const binding = require(path.join(coreDir, 'dist', 'kungfu', 'kungfu_node.node'));
 
 const runtimeDir = path.join(home, 'runtime');
 // bypassRestore=true: no config-db state to restore in a bench home;

--- a/framework/gui/electron-builder.yml
+++ b/framework/gui/electron-builder.yml
@@ -1,7 +1,7 @@
 appId: com.kungfu.app
 productName: Kungfu
-# asar:false so the native binding (.node) and kfc dylibs can be require()d
-# directly from Resources/kfc at runtime.
+# asar:false so the native binding (.node) and kungfu dylibs can be require()d
+# directly from Resources/kungfu at runtime.
 asar: false
 npmRebuild: false
 files:
@@ -9,9 +9,9 @@ files:
   - package.json
 extraResources:
   # Ship the kungfu runtime (libkungfu.dylib + kungfu_electron.node) so the
-  # packaged app loads the binding from Resources/kfc, matching its rpath.
-  - from: ../core/dist/kfc
-    to: kfc
+  # packaged app loads the binding from Resources/kungfu, matching its rpath.
+  - from: ../core/dist/kungfu
+    to: kungfu
 mac:
   # dir = the pack verb's unpacked app (fast, CI-friendly); dmg + zip = the
   # dist verb's installable artifacts. Unsigned pre-release (identity: null):

--- a/framework/gui/electron-builder.yml
+++ b/framework/gui/electron-builder.yml
@@ -12,6 +12,10 @@ extraResources:
   # packaged app loads the binding from Resources/kungfu, matching its rpath.
   - from: ../core/dist/kungfu
     to: kungfu
+  # The CLI wrapper that "Install 'kungfu' Command in PATH" symlinks into
+  # /usr/local/bin; it resolves the bundled runtime next to it and execs it.
+  - from: resources/cli
+    to: cli
 mac:
   # dir = the pack verb's unpacked app (fast, CI-friendly); dmg + zip = the
   # dist verb's installable artifacts. Unsigned pre-release (identity: null):

--- a/framework/gui/electron.vite.config.mjs
+++ b/framework/gui/electron.vite.config.mjs
@@ -6,7 +6,7 @@ import { defineConfig, externalizeDepsPlugin } from 'electron-vite';
 const rootDir = dirname(fileURLToPath(import.meta.url));
 
 // - main: externalize deps so the native binding is never bundled; it is loaded
-//   via require() at runtime from kungfu-core's dist/kfc.
+//   via require() at runtime from kungfu-core's dist/kungfu.
 // - preload: the sandbox preload — the only bridge an isolated sandboxed view
 //   gets (contextBridge exposes __kfxBridge); built as its own entry.
 // - renderer: react; keep electron and the native binding external so the

--- a/framework/gui/resources/cli/kungfu
+++ b/framework/gui/resources/cli/kungfu
@@ -22,5 +22,5 @@ done
 here=$(cd "$(dirname "$target")" && pwd)      # <app>/Contents/Resources/cli
 runtime=$(cd "$here/../kungfu" && pwd)        # <app>/Contents/Resources/kungfu
 
-export KFC_DIR="$runtime"
+export KUNGFU_DIR="$runtime"
 exec "$runtime/kungfu" "$@"

--- a/framework/gui/resources/cli/kungfu
+++ b/framework/gui/resources/cli/kungfu
@@ -1,0 +1,26 @@
+#!/bin/sh
+# kungfu — CLI wrapper installed into PATH by the Kungfu app.
+#
+# The app's "Install 'kungfu' Command in PATH" action symlinks
+#   /usr/local/bin/kungfu -> <Kungfu.app>/Contents/Resources/cli/kungfu
+# This script resolves its own real location through that symlink, finds the
+# bundled frozen runtime sitting next to it (../kungfu/kungfu), and execs it.
+# The frozen binary is self-contained (its dylibs load via @loader_path), so the
+# wrapper only needs to point the runtime dir env at the bundle and hand off.
+set -e
+
+# Resolve symlinks to this script's real path (POSIX sh, no realpath dependency).
+target=$0
+while [ -L "$target" ]; do
+  link=$(readlink "$target")
+  case $link in
+    /*) target=$link ;;
+    *) target=$(dirname "$target")/$link ;;
+  esac
+done
+
+here=$(cd "$(dirname "$target")" && pwd)      # <app>/Contents/Resources/cli
+runtime=$(cd "$here/../kungfu" && pwd)        # <app>/Contents/Resources/kungfu
+
+export KFC_DIR="$runtime"
+exec "$runtime/kungfu" "$@"

--- a/framework/gui/src/main/index.ts
+++ b/framework/gui/src/main/index.ts
@@ -17,15 +17,15 @@ import {
 } from '../sandbox/channels';
 import { type Rect, SandboxManager } from './sandbox-manager';
 
-// Resolve the kungfu runtime directory (kfc) that holds libkungfu.dylib and the
+// Resolve the kungfu runtime directory that holds libkungfu.dylib and the
 // kungfu_electron.node binding. In development it lives in the kungfu-core
-// package; once packaged it is shipped as an extraResource under Resources/kfc.
+// package; once packaged it is shipped as an extraResource under Resources/kungfu.
 const kfcDir = app.isPackaged
-  ? path.join(process.resourcesPath, 'kfc')
+  ? path.join(process.resourcesPath, 'kungfu')
   : path.join(
       path.dirname(require.resolve('@kungfu-tech/core/package.json')),
       'dist',
-      'kfc',
+      'kungfu',
     );
 
 const bindingPath = path.join(kfcDir, 'kungfu_electron.node');
@@ -52,7 +52,7 @@ process.env.KF_EXTENSION_PATH =
 // Prove the frozen runtime CLI runs standalone next to the binding, and hand
 // the result to the renderer for display.
 try {
-  const kfcBin = path.join(path.dirname(process.env.KFE_PATH), 'kfc');
+  const kfcBin = path.join(path.dirname(process.env.KFE_PATH), 'kungfu');
   const out = execFileSync(kfcBin, ['--version'], { timeout: 10000 });
   process.env.KFC_VERSION = out.toString().trim();
 } catch {

--- a/framework/gui/src/main/index.ts
+++ b/framework/gui/src/main/index.ts
@@ -31,7 +31,7 @@ import {
 // Resolve the kungfu runtime directory that holds libkungfu.dylib and the
 // kungfu_electron.node binding. In development it lives in the kungfu-core
 // package; once packaged it is shipped as an extraResource under Resources/kungfu.
-const kfcDir = app.isPackaged
+const kungfuDir = app.isPackaged
   ? path.join(process.resourcesPath, 'kungfu')
   : path.join(
       path.dirname(require.resolve('@kungfu-tech/core/package.json')),
@@ -39,7 +39,7 @@ const kfcDir = app.isPackaged
       'kungfu',
     );
 
-const bindingPath = path.join(kfcDir, 'kungfu_electron.node');
+const bindingPath = path.join(kungfuDir, 'kungfu_electron.node');
 
 // Export before the renderer process is created so both processes inherit them.
 // The default runtime home must be writable: userData when packaged (never
@@ -63,11 +63,11 @@ process.env.KF_EXTENSION_PATH =
 // Prove the frozen runtime CLI runs standalone next to the binding, and hand
 // the result to the renderer for display.
 try {
-  const kfcBin = path.join(path.dirname(process.env.KFE_PATH), 'kungfu');
-  const out = execFileSync(kfcBin, ['--version'], { timeout: 10000 });
-  process.env.KFC_VERSION = out.toString().trim();
+  const kungfuBin = path.join(path.dirname(process.env.KFE_PATH), 'kungfu');
+  const out = execFileSync(kungfuBin, ['--version'], { timeout: 10000 });
+  process.env.KUNGFU_VERSION = out.toString().trim();
 } catch {
-  process.env.KFC_VERSION = '';
+  process.env.KUNGFU_VERSION = '';
 }
 
 // Probe the binding in the main (node) process.

--- a/framework/gui/src/main/index.ts
+++ b/framework/gui/src/main/index.ts
@@ -6,7 +6,14 @@ import path from 'node:path';
 // environment variables present when the process starts. The renderer process
 // is spawned by this main process, so the runtime directory must be exported
 // here, before any window (and therefore the renderer process) is created.
-import { BrowserWindow, WebContentsView, app, ipcMain } from 'electron';
+import {
+  BrowserWindow,
+  Menu,
+  WebContentsView,
+  app,
+  dialog,
+  ipcMain,
+} from 'electron';
 
 import {
   DESTROY_CHANNEL,
@@ -16,6 +23,10 @@ import {
   SHOW_CHANNEL,
 } from '../sandbox/channels';
 import { type Rect, SandboxManager } from './sandbox-manager';
+import {
+  installKungfuCliToPath,
+  uninstallKungfuCliFromPath,
+} from './installCli';
 
 // Resolve the kungfu runtime directory that holds libkungfu.dylib and the
 // kungfu_electron.node binding. In development it lives in the kungfu-core
@@ -106,6 +117,51 @@ ipcMain.on(DESTROY_CHANNEL, (_event, payload) => {
   manager?.destroyView((payload as { id: string }).id);
 });
 
+// Application menu with the VS Code-style "Install 'kungfu' Command in PATH"
+// action, so a real user who installed Kungfu.app can use `kungfu` in a shell.
+function buildMenu() {
+  const cliSubmenu: Electron.MenuItemConstructorOptions[] = [
+    {
+      label: "Install 'kungfu' Command in PATH",
+      click: async () => {
+        const r = installKungfuCliToPath();
+        await dialog.showMessageBox({
+          type: r.ok ? 'info' : 'error',
+          message: r.ok
+            ? "Shell command 'kungfu' installed"
+            : "Could not install 'kungfu' command",
+          detail: r.message,
+        });
+      },
+    },
+    {
+      label: "Uninstall 'kungfu' Command from PATH",
+      click: async () => {
+        const r = uninstallKungfuCliFromPath();
+        await dialog.showMessageBox({
+          type: r.ok ? 'info' : 'error',
+          message: r.ok
+            ? "Shell command 'kungfu' removed"
+            : "Could not remove 'kungfu' command",
+          detail: r.message,
+        });
+      },
+    },
+  ];
+
+  const template: Electron.MenuItemConstructorOptions[] = [
+    ...(process.platform === 'darwin'
+      ? [{ role: 'appMenu' as const }]
+      : []),
+    { label: 'kungfu', submenu: cliSubmenu },
+    { role: 'editMenu' },
+    { role: 'viewMenu' },
+    { role: 'windowMenu' },
+  ];
+
+  Menu.setApplicationMenu(Menu.buildFromTemplate(template));
+}
+
 function createWindow() {
   const win = new BrowserWindow({
     width: 1280,
@@ -139,7 +195,10 @@ function createWindow() {
   }
 }
 
-app.whenReady().then(createWindow);
+app.whenReady().then(() => {
+  buildMenu();
+  createWindow();
+});
 
 app.on('activate', () => {
   if (BrowserWindow.getAllWindows().length === 0) createWindow();

--- a/framework/gui/src/main/installCli.ts
+++ b/framework/gui/src/main/installCli.ts
@@ -1,0 +1,94 @@
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { app } from 'electron';
+
+// Where the `kungfu` command is installed. /usr/local/bin is on the default
+// macOS PATH and is the conventional home for user-installed CLIs (the same
+// spot VS Code uses for its `code` command).
+const PATH_TARGET = '/usr/local/bin/kungfu';
+
+export interface CliInstallResult {
+  ok: boolean;
+  message: string;
+}
+
+// Absolute path to the wrapper script shipped inside the app bundle
+// (Resources/cli/kungfu); in development it lives in the gui package resources.
+function wrapperPath(): string {
+  return app.isPackaged
+    ? path.join(process.resourcesPath, 'cli', 'kungfu')
+    : path.join(__dirname, '..', '..', 'resources', 'cli', 'kungfu');
+}
+
+function shq(s: string): string {
+  return `'${s.replace(/'/g, `'\\''`)}'`;
+}
+
+function isPermissionError(e: unknown): boolean {
+  const code = (e as NodeJS.ErrnoException).code;
+  return code === 'EACCES' || code === 'EPERM' || code === 'EROFS';
+}
+
+// Run a shell command with a macOS administrator prompt (osascript). Used only
+// when /usr/local/bin is not writable by the current user.
+function elevate(script: string): void {
+  execFileSync('osascript', [
+    '-e',
+    `do shell script "${script.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}" with administrator privileges`,
+  ]);
+}
+
+// Create /usr/local/bin/kungfu -> wrapper. Direct symlink first; on a
+// permission error, retry once with an administrator prompt.
+export function installKungfuCliToPath(): CliInstallResult {
+  const wrapper = wrapperPath();
+  if (!fs.existsSync(wrapper)) {
+    return { ok: false, message: `wrapper not found: ${wrapper}` };
+  }
+  try {
+    fs.rmSync(PATH_TARGET, { force: true });
+    fs.symlinkSync(wrapper, PATH_TARGET);
+    return { ok: true, message: `Installed: ${PATH_TARGET} -> ${wrapper}` };
+  } catch (e) {
+    if (isPermissionError(e)) {
+      try {
+        elevate(`mkdir -p ${shq(path.dirname(PATH_TARGET))} && ln -sf ${shq(wrapper)} ${shq(PATH_TARGET)}`);
+        return { ok: true, message: `Installed (elevated): ${PATH_TARGET} -> ${wrapper}` };
+      } catch (e2) {
+        return { ok: false, message: `elevated install failed: ${(e2 as Error).message}` };
+      }
+    }
+    return { ok: false, message: `install failed: ${(e as Error).message}` };
+  }
+}
+
+// Remove /usr/local/bin/kungfu. Absent is treated as success.
+export function uninstallKungfuCliFromPath(): CliInstallResult {
+  if (!fs.lstatSync(PATH_TARGET, { throwIfNoEntry: false })) {
+    return { ok: true, message: `Not installed: ${PATH_TARGET}` };
+  }
+  try {
+    fs.rmSync(PATH_TARGET, { force: true });
+    return { ok: true, message: `Removed ${PATH_TARGET}` };
+  } catch (e) {
+    if (isPermissionError(e)) {
+      try {
+        elevate(`rm -f ${shq(PATH_TARGET)}`);
+        return { ok: true, message: `Removed (elevated) ${PATH_TARGET}` };
+      } catch (e2) {
+        return { ok: false, message: `elevated uninstall failed: ${(e2 as Error).message}` };
+      }
+    }
+    return { ok: false, message: `uninstall failed: ${(e as Error).message}` };
+  }
+}
+
+// Whether the command is currently installed and points at this app's wrapper.
+export function isKungfuCliInstalled(): boolean {
+  try {
+    return fs.realpathSync(PATH_TARGET) === fs.realpathSync(wrapperPath());
+  } catch {
+    return false;
+  }
+}

--- a/framework/gui/src/renderer/src/main.tsx
+++ b/framework/gui/src/renderer/src/main.tsx
@@ -240,7 +240,7 @@ function App() {
       ok: runtime.ok,
       message: runtime.message,
       runtimeDir: runtime.runtimeDir,
-      kfcVersion: runtime.kfcVersion,
+      kungfuVersion: runtime.kungfuVersion,
       buildInfo: runtime.buildInfo,
       exports: runtime.exports,
       longfistTypes: runtime.longfistTypes,

--- a/framework/gui/src/renderer/src/runtime.ts
+++ b/framework/gui/src/renderer/src/runtime.ts
@@ -27,7 +27,7 @@ export type Runtime = {
   ok: boolean;
   message: string;
   runtimeDir: string;
-  kfcVersion: string;
+  kungfuVersion: string;
   buildInfo: Record<string, unknown> | null;
   exports: string[];
   longfistTypes: { name: string; fields: string[] }[];
@@ -59,7 +59,7 @@ export function bootRuntime(): Runtime {
   const runtimeDir = env.KF_RUNTIME_DIR || '';
   const base: Omit<Runtime, 'ok' | 'message'> = {
     runtimeDir,
-    kfcVersion: env.KFC_VERSION || '',
+    kungfuVersion: env.KUNGFU_VERSION || '',
     buildInfo: null,
     exports: [],
     longfistTypes: [],

--- a/framework/kfx/src/index.ts
+++ b/framework/kfx/src/index.ts
@@ -112,7 +112,7 @@ export type ShellRuntimeInfo = {
   ok: boolean;
   message: string;
   runtimeDir: string;
-  kfcVersion: string;
+  kungfuVersion: string;
   buildInfo: Record<string, unknown> | null;
   exports: string[];
   longfistTypes: { name: string; fields: string[] }[];

--- a/framework/spec/docs/handbooks/cli.md
+++ b/framework/spec/docs/handbooks/cli.md
@@ -1,8 +1,7 @@
 # kungfu CLI handbook — `kungfu`
 
 > Pre-release (spec 0.1) · minimal recipe. `kungfu` is the kungfu CLI
-> (`@kungfu-tech/core`); it fronts the `kfc` runtime, and `kfc` works as a
-> short alias of the same command. The generated command reference (from the
+> (`@kungfu-tech/core`) and the runtime it invokes. The generated command reference (from the
 > CLI's own definitions) and the agent-first `--json` provenance surface are
 > planned; this page is a hand-written getting-started.
 
@@ -16,7 +15,7 @@ the [format spec](../../spec/).
 
 ```bash
 pnpm add @kungfu-tech/core
-# kungfu is now on your PATH inside the workspace (kfc is an alias)
+# kungfu is now on your PATH inside the workspace
 kungfu --version
 ```
 

--- a/framework/tui/src/main.tsx
+++ b/framework/tui/src/main.tsx
@@ -24,7 +24,7 @@ function boot() {
     path.join(
       path.dirname(nodeRequire.resolve('@kungfu-tech/core/package.json')),
       'dist',
-      'kfc',
+      'kungfu',
     );
   const runtimeDir =
     process.env.KF_RUNTIME_DIR || path.join(process.cwd(), 'demo-runtime');

--- a/framework/tui/src/main.tsx
+++ b/framework/tui/src/main.tsx
@@ -19,8 +19,8 @@ import React from 'react';
 const nodeRequire = createRequire(import.meta.url);
 
 function boot() {
-  const kfcDir =
-    process.env.KFC_DIR ||
+  const kungfuDir =
+    process.env.KUNGFU_DIR ||
     path.join(
       path.dirname(nodeRequire.resolve('@kungfu-tech/core/package.json')),
       'dist',
@@ -28,7 +28,7 @@ function boot() {
     );
   const runtimeDir =
     process.env.KF_RUNTIME_DIR || path.join(process.cwd(), 'demo-runtime');
-  const binding = nodeRequire(path.join(kfcDir, 'kungfu_node.node'));
+  const binding = nodeRequire(path.join(kungfuDir, 'kungfu_node.node'));
   const ledger = openLedger({
     binding,
     locator: { runtimeDir },

--- a/kungfu-code
+++ b/kungfu-code
@@ -29,7 +29,7 @@ set -eu
 cd "$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
 
 # Load local cache proxy config: user-global first, then layer the optional in-repo override (both exported → passed to subprocesses).
-kfc_load_proxy() {
+kungfu_load_proxy() {
   _f="${XDG_CONFIG_HOME:-$HOME/.config}/kungfu/build-local.env"
   # shellcheck disable=SC1090
   [ -f "$_f" ] && . "$_f"
@@ -57,7 +57,7 @@ case "${1:-}" in
 esac
 
 # Normal build/dev task: load proxy config → check the two prerequisites → pin node → corepack pnpm
-kfc_load_proxy
+kungfu_load_proxy
 
 if ! command -v fnm >/dev/null 2>&1; then
   echo "kungfu-code: install fnm once first (node-side prerequisite) — 'arch -arm64 brew install fnm' (or see https://github.com/Schniz/fnm)" >&2

--- a/tests/fixtures/atlas-demo-import/check_import.py
+++ b/tests/fixtures/atlas-demo-import/check_import.py
@@ -12,12 +12,12 @@ import os
 import sys
 
 # Self-contained path bootstrap: the fixture runs outside the dev entry, so it
-# wires the core python package and the built dist/kfc (pykungfu) itself.
+# wires the core python package and the built dist/kungfu (pykungfu) itself.
 _core = os.path.abspath(
     os.path.join(os.path.dirname(__file__), "..", "..", "..", "framework", "core")
 )
 sys.path.insert(0, os.path.join(_core, "src", "python"))
-sys.path.insert(0, os.path.join(_core, "dist", "kfc"))
+sys.path.insert(0, os.path.join(_core, "dist", "kungfu"))
 
 from kungfu.atlas import (  # noqa: E402
     MSG_GOAL_SNAPSHOT,

--- a/tests/fixtures/atlas-demo-import/run.sh
+++ b/tests/fixtures/atlas-demo-import/run.sh
@@ -5,7 +5,7 @@
 # imported twice; the journal carries both snapshot batches and the projection
 # folds the latest one. Read-only against the source tree — the fixture also
 # asserts the sample tree is byte-identical after both imports. Asserted by
-# check_import.py. Requires the core dev environment (built dist/kfc).
+# check_import.py. Requires the core dev environment (built dist/kungfu).
 #
 # Usage: tests/fixtures/atlas-demo-import/run.sh
 
@@ -19,7 +19,7 @@ trap 'rm -rf "$home"' EXIT
 # Dev-python import of pykungfu: its libnode install name is
 # @executable_path-relative (correct for the frozen kfc executable); when the
 # interpreter is uv's python instead, give dyld the dist dir as fallback.
-DYLD_FALLBACK_LIBRARY_PATH="$core_dir/dist/kfc${DYLD_FALLBACK_LIBRARY_PATH:+:$DYLD_FALLBACK_LIBRARY_PATH}"
+DYLD_FALLBACK_LIBRARY_PATH="$core_dir/dist/kungfu${DYLD_FALLBACK_LIBRARY_PATH:+:$DYLD_FALLBACK_LIBRARY_PATH}"
 export DYLD_FALLBACK_LIBRARY_PATH
 
 before="$(find "$fixture_dir/sample-root" -type f -exec cksum {} + | sort)"

--- a/tests/fixtures/kfx-demo-install/run.sh
+++ b/tests/fixtures/kfx-demo-install/run.sh
@@ -5,7 +5,7 @@
 # offline installable unit. Packs the real work-dashboard package, installs
 # the tgz into a clean home through `kungfu kfx install`, and asserts the
 # managed lifecycle: list, double-install refusal, --force replace, remove.
-# Requires the core dev environment (built dist/kfc) and the extension's
+# Requires the core dev environment (built dist/kungfu) and the extension's
 # own build output (dist/view/index.js, from `kfs kfx build`).
 #
 # Usage: tests/fixtures/kfx-demo-install/run.sh
@@ -19,7 +19,7 @@ home="$(mktemp -d)"
 packdir="$(mktemp -d)"
 trap 'rm -rf "$home" "$packdir"' EXIT
 
-DYLD_FALLBACK_LIBRARY_PATH="$core_dir/dist/kfc${DYLD_FALLBACK_LIBRARY_PATH:+:$DYLD_FALLBACK_LIBRARY_PATH}"
+DYLD_FALLBACK_LIBRARY_PATH="$core_dir/dist/kungfu${DYLD_FALLBACK_LIBRARY_PATH:+:$DYLD_FALLBACK_LIBRARY_PATH}"
 export DYLD_FALLBACK_LIBRARY_PATH
 
 # the distribution unit: a plain npm tgz of the built extension package

--- a/tests/fixtures/kfx-demo-scaffold/run.sh
+++ b/tests/fixtures/kfx-demo-scaffold/run.sh
@@ -7,7 +7,7 @@
 # offline), builds it with `kfs kfx build`, asserts the bundle honors the
 # load contract (View export, shell-injected modules left external), then
 # packs the tgz and runs it through the `kungfu kfx install` lifecycle.
-# Requires the core dev environment (built dist/kfc) and the repository's
+# Requires the core dev environment (built dist/kungfu) and the repository's
 # installed node_modules (the sdk's esbuild).
 #
 # Usage: tests/fixtures/kfx-demo-scaffold/run.sh
@@ -23,7 +23,7 @@ home="$(mktemp -d)"
 packdir="$(mktemp -d)"
 trap 'rm -rf "$work" "$home" "$packdir"' EXIT
 
-DYLD_FALLBACK_LIBRARY_PATH="$core_dir/dist/kfc${DYLD_FALLBACK_LIBRARY_PATH:+:$DYLD_FALLBACK_LIBRARY_PATH}"
+DYLD_FALLBACK_LIBRARY_PATH="$core_dir/dist/kungfu${DYLD_FALLBACK_LIBRARY_PATH:+:$DYLD_FALLBACK_LIBRARY_PATH}"
 export DYLD_FALLBACK_LIBRARY_PATH
 
 ext_dir="$work/my-view"

--- a/tests/fixtures/rewind-demo-cross-runtime/check_capture.py
+++ b/tests/fixtures/rewind-demo-cross-runtime/check_capture.py
@@ -16,7 +16,7 @@ _core = os.path.abspath(
     os.path.join(os.path.dirname(__file__), "..", "..", "..", "framework", "core")
 )
 sys.path.insert(0, os.path.join(_core, "src", "python"))
-sys.path.insert(0, os.path.join(_core, "dist", "kfc"))
+sys.path.insert(0, os.path.join(_core, "dist", "kungfu"))
 
 import kungfu
 

--- a/tests/fixtures/rewind-demo-cross-runtime/run.sh
+++ b/tests/fixtures/rewind-demo-cross-runtime/run.sh
@@ -4,7 +4,7 @@
 # Cross-runtime single-journal fixture (gate G7): a python agent calls a Node
 # tool under one traced run; both runtimes' events must land in one journal
 # with a shared run id, a causal edge across the boundary, and one timeline.
-# Requires the core dev environment (built dist/kfc) and node on PATH.
+# Requires the core dev environment (built dist/kungfu) and node on PATH.
 #
 # Usage: tests/fixtures/rewind-demo-cross-runtime/run.sh
 
@@ -30,7 +30,7 @@ while [ ! -s "$port_file" ]; do sleep 0.1; done
 OPENAI_BASE_URL="http://127.0.0.1:$(cat "$port_file")/v1"
 export OPENAI_BASE_URL
 
-DYLD_FALLBACK_LIBRARY_PATH="$core_dir/dist/kfc${DYLD_FALLBACK_LIBRARY_PATH:+:$DYLD_FALLBACK_LIBRARY_PATH}"
+DYLD_FALLBACK_LIBRARY_PATH="$core_dir/dist/kungfu${DYLD_FALLBACK_LIBRARY_PATH:+:$DYLD_FALLBACK_LIBRARY_PATH}"
 export DYLD_FALLBACK_LIBRARY_PATH
 
 cd "$core_dir"

--- a/tests/fixtures/rewind-demo-export/run.sh
+++ b/tests/fixtures/rewind-demo-export/run.sh
@@ -26,7 +26,7 @@ while [ ! -s "$port_file" ]; do sleep 0.1; done
 OPENAI_BASE_URL="http://127.0.0.1:$(cat "$port_file")/v1"
 export OPENAI_BASE_URL
 
-DYLD_FALLBACK_LIBRARY_PATH="$core_dir/dist/kfc${DYLD_FALLBACK_LIBRARY_PATH:+:$DYLD_FALLBACK_LIBRARY_PATH}"
+DYLD_FALLBACK_LIBRARY_PATH="$core_dir/dist/kungfu${DYLD_FALLBACK_LIBRARY_PATH:+:$DYLD_FALLBACK_LIBRARY_PATH}"
 export DYLD_FALLBACK_LIBRARY_PATH
 
 cd "$core_dir"

--- a/tests/fixtures/rewind-demo-forensic-replay/run.sh
+++ b/tests/fixtures/rewind-demo-forensic-replay/run.sh
@@ -33,7 +33,7 @@ while [ ! -s "$port_file" ]; do sleep 0.1; done
 OPENAI_BASE_URL="http://127.0.0.1:$(cat "$port_file")/v1"
 export OPENAI_BASE_URL
 
-DYLD_FALLBACK_LIBRARY_PATH="$core_dir/dist/kfc${DYLD_FALLBACK_LIBRARY_PATH:+:$DYLD_FALLBACK_LIBRARY_PATH}"
+DYLD_FALLBACK_LIBRARY_PATH="$core_dir/dist/kungfu${DYLD_FALLBACK_LIBRARY_PATH:+:$DYLD_FALLBACK_LIBRARY_PATH}"
 export DYLD_FALLBACK_LIBRARY_PATH
 
 cd "$core_dir"

--- a/tests/fixtures/rewind-demo-happy/check_capture.py
+++ b/tests/fixtures/rewind-demo-happy/check_capture.py
@@ -11,12 +11,12 @@ import os
 import sys
 
 # Self-contained path bootstrap: the fixture runs outside the dev entry, so it
-# wires the core python package and the built dist/kfc (pykungfu) itself.
+# wires the core python package and the built dist/kungfu (pykungfu) itself.
 _core = os.path.abspath(
     os.path.join(os.path.dirname(__file__), "..", "..", "..", "framework", "core")
 )
 sys.path.insert(0, os.path.join(_core, "src", "python"))
-sys.path.insert(0, os.path.join(_core, "dist", "kfc"))
+sys.path.insert(0, os.path.join(_core, "dist", "kungfu"))
 
 import kungfu
 

--- a/tests/fixtures/rewind-demo-happy/run.sh
+++ b/tests/fixtures/rewind-demo-happy/run.sh
@@ -4,7 +4,7 @@
 # Happy-path capture fixture (gate G2, L0 slice): one command wraps an
 # unmodified child process and produces a local run store — journal frames
 # bracketing the run plus a self-describing trace bundle. Asserted by
-# check_capture.py. Requires the core dev environment (built dist/kfc).
+# check_capture.py. Requires the core dev environment (built dist/kungfu).
 #
 # Usage: tests/fixtures/rewind-demo-happy/run.sh
 
@@ -33,7 +33,7 @@ export OPENAI_BASE_URL
 # Dev-python import of pykungfu: its libnode install name is
 # @executable_path-relative (correct for the frozen kfc executable); when the
 # interpreter is uv's python instead, give dyld the dist dir as fallback.
-DYLD_FALLBACK_LIBRARY_PATH="$core_dir/dist/kfc${DYLD_FALLBACK_LIBRARY_PATH:+:$DYLD_FALLBACK_LIBRARY_PATH}"
+DYLD_FALLBACK_LIBRARY_PATH="$core_dir/dist/kungfu${DYLD_FALLBACK_LIBRARY_PATH:+:$DYLD_FALLBACK_LIBRARY_PATH}"
 export DYLD_FALLBACK_LIBRARY_PATH
 
 cd "$core_dir"

--- a/tests/fixtures/rewind-demo-kfx-schema/check_capture.py
+++ b/tests/fixtures/rewind-demo-kfx-schema/check_capture.py
@@ -17,7 +17,7 @@ _core = os.path.abspath(
     os.path.join(os.path.dirname(__file__), "..", "..", "..", "framework", "core")
 )
 sys.path.insert(0, os.path.join(_core, "src", "python"))
-sys.path.insert(0, os.path.join(_core, "dist", "kfc"))
+sys.path.insert(0, os.path.join(_core, "dist", "kungfu"))
 
 import kungfu
 

--- a/tests/fixtures/rewind-demo-kfx-schema/kfx_program.py
+++ b/tests/fixtures/rewind-demo-kfx-schema/kfx_program.py
@@ -14,7 +14,7 @@ _HERE = os.path.dirname(os.path.abspath(__file__))
 _CORE = os.path.abspath(os.path.join(_HERE, "..", "..", "..", "framework", "core"))
 # reach the kungfu package + the built binding (compile_schema lives in libkungfu)
 sys.path.insert(0, os.path.join(_CORE, "src", "python"))
-sys.path.insert(0, os.path.join(_CORE, "dist", "kfc"))
+sys.path.insert(0, os.path.join(_CORE, "dist", "kungfu"))
 
 import flatbuffers
 

--- a/tests/fixtures/rewind-demo-kfx-schema/run.sh
+++ b/tests/fixtures/rewind-demo-kfx-schema/run.sh
@@ -6,7 +6,7 @@
 # event lands in the journal, the schema binds into the bundle under the kfx band
 # (40000-49999), and it decodes by reflection with no generated accessor — the
 # run-internal proof of the native-compile open layer. Asserted by check_capture.py.
-# Requires the core dev environment (built dist/kfc, whose python has flatbuffers).
+# Requires the core dev environment (built dist/kungfu, whose python has flatbuffers).
 #
 # Usage: tests/fixtures/rewind-demo-kfx-schema/run.sh
 
@@ -20,7 +20,7 @@ trap 'rm -rf "$home"' EXIT
 
 # dyld fallback so both the supervisor and the kfx child can import pykungfu
 # (compile_schema) when the interpreter is uv's python rather than frozen kfc
-DYLD_FALLBACK_LIBRARY_PATH="$core_dir/dist/kfc${DYLD_FALLBACK_LIBRARY_PATH:+:$DYLD_FALLBACK_LIBRARY_PATH}"
+DYLD_FALLBACK_LIBRARY_PATH="$core_dir/dist/kungfu${DYLD_FALLBACK_LIBRARY_PATH:+:$DYLD_FALLBACK_LIBRARY_PATH}"
 export DYLD_FALLBACK_LIBRARY_PATH
 
 cd "$core_dir"

--- a/tests/fixtures/rewind-demo-langchain/check_capture.py
+++ b/tests/fixtures/rewind-demo-langchain/check_capture.py
@@ -22,7 +22,7 @@ _core = os.path.abspath(
     os.path.join(os.path.dirname(__file__), "..", "..", "..", "framework", "core")
 )
 sys.path.insert(0, os.path.join(_core, "src", "python"))
-sys.path.insert(0, os.path.join(_core, "dist", "kfc"))
+sys.path.insert(0, os.path.join(_core, "dist", "kungfu"))
 
 import kungfu
 

--- a/tests/fixtures/rewind-demo-langchain/run.sh
+++ b/tests/fixtures/rewind-demo-langchain/run.sh
@@ -16,7 +16,7 @@
 # by a real framework.
 #
 # Usage: tests/fixtures/rewind-demo-langchain/run.sh
-#   Requires the core dev environment (built dist/kfc) and network on first run
+#   Requires the core dev environment (built dist/kungfu) and network on first run
 #   to install langchain; the run itself uses a deterministic mock model.
 
 set -eu
@@ -56,7 +56,7 @@ export OPENAI_API_KEY
 
 # Dev-python import of pykungfu (supervisor + check side): dyld fallback to the
 # dist dir when the interpreter is uv's python rather than the frozen kfc.
-DYLD_FALLBACK_LIBRARY_PATH="$core_dir/dist/kfc${DYLD_FALLBACK_LIBRARY_PATH:+:$DYLD_FALLBACK_LIBRARY_PATH}"
+DYLD_FALLBACK_LIBRARY_PATH="$core_dir/dist/kungfu${DYLD_FALLBACK_LIBRARY_PATH:+:$DYLD_FALLBACK_LIBRARY_PATH}"
 export DYLD_FALLBACK_LIBRARY_PATH
 
 # The LangChain adapter is NOT in core — it is the kfx package under

--- a/tests/fixtures/rewind-demo-model-drift/check_capture.py
+++ b/tests/fixtures/rewind-demo-model-drift/check_capture.py
@@ -14,7 +14,7 @@ _core = os.path.abspath(
     os.path.join(os.path.dirname(__file__), "..", "..", "..", "framework", "core")
 )
 sys.path.insert(0, os.path.join(_core, "src", "python"))
-sys.path.insert(0, os.path.join(_core, "dist", "kfc"))
+sys.path.insert(0, os.path.join(_core, "dist", "kungfu"))
 
 import kungfu
 

--- a/tests/fixtures/rewind-demo-model-drift/run.sh
+++ b/tests/fixtures/rewind-demo-model-drift/run.sh
@@ -23,7 +23,7 @@ while [ ! -s "$port_file" ]; do sleep 0.1; done
 OPENAI_BASE_URL="http://127.0.0.1:$(cat "$port_file")/v1"
 export OPENAI_BASE_URL
 
-DYLD_FALLBACK_LIBRARY_PATH="$core_dir/dist/kfc${DYLD_FALLBACK_LIBRARY_PATH:+:$DYLD_FALLBACK_LIBRARY_PATH}"
+DYLD_FALLBACK_LIBRARY_PATH="$core_dir/dist/kungfu${DYLD_FALLBACK_LIBRARY_PATH:+:$DYLD_FALLBACK_LIBRARY_PATH}"
 export DYLD_FALLBACK_LIBRARY_PATH
 
 cd "$core_dir"

--- a/tests/fixtures/rewind-demo-tool-failure/check_capture.py
+++ b/tests/fixtures/rewind-demo-tool-failure/check_capture.py
@@ -13,7 +13,7 @@ _core = os.path.abspath(
     os.path.join(os.path.dirname(__file__), "..", "..", "..", "framework", "core")
 )
 sys.path.insert(0, os.path.join(_core, "src", "python"))
-sys.path.insert(0, os.path.join(_core, "dist", "kfc"))
+sys.path.insert(0, os.path.join(_core, "dist", "kungfu"))
 
 import kungfu
 

--- a/tests/fixtures/rewind-demo-tool-failure/run.sh
+++ b/tests/fixtures/rewind-demo-tool-failure/run.sh
@@ -23,7 +23,7 @@ while [ ! -s "$port_file" ]; do sleep 0.1; done
 OPENAI_BASE_URL="http://127.0.0.1:$(cat "$port_file")/v1"
 export OPENAI_BASE_URL
 
-DYLD_FALLBACK_LIBRARY_PATH="$core_dir/dist/kfc${DYLD_FALLBACK_LIBRARY_PATH:+:$DYLD_FALLBACK_LIBRARY_PATH}"
+DYLD_FALLBACK_LIBRARY_PATH="$core_dir/dist/kungfu${DYLD_FALLBACK_LIBRARY_PATH:+:$DYLD_FALLBACK_LIBRARY_PATH}"
 export DYLD_FALLBACK_LIBRARY_PATH
 
 cd "$core_dir"

--- a/tests/fixtures/work-demo-lifecycle/check_lifecycle.py
+++ b/tests/fixtures/work-demo-lifecycle/check_lifecycle.py
@@ -12,12 +12,12 @@ import os
 import sys
 
 # Self-contained path bootstrap: the fixture runs outside the dev entry, so it
-# wires the core python package and the built dist/kfc (pykungfu) itself.
+# wires the core python package and the built dist/kungfu (pykungfu) itself.
 _core = os.path.abspath(
     os.path.join(os.path.dirname(__file__), "..", "..", "..", "framework", "core")
 )
 sys.path.insert(0, os.path.join(_core, "src", "python"))
-sys.path.insert(0, os.path.join(_core, "dist", "kfc"))
+sys.path.insert(0, os.path.join(_core, "dist", "kungfu"))
 
 from kungfu.work import (  # noqa: E402
     MSG_ARTIFACT_RECORDED,

--- a/tests/fixtures/work-demo-lifecycle/run.sh
+++ b/tests/fixtures/work-demo-lifecycle/run.sh
@@ -5,7 +5,7 @@
 # default-profile vocabulary — create, every lifecycle verb, next action,
 # checkpoint, decision, validation, artifact, linked run — and the journal
 # plus the folded projection carry every fact. Asserted by check_lifecycle.py.
-# Requires the core dev environment (built dist/kfc).
+# Requires the core dev environment (built dist/kungfu).
 #
 # Usage: tests/fixtures/work-demo-lifecycle/run.sh
 
@@ -19,7 +19,7 @@ trap 'rm -rf "$home"' EXIT
 # Dev-python import of pykungfu: its libnode install name is
 # @executable_path-relative (correct for the frozen kfc executable); when the
 # interpreter is uv's python instead, give dyld the dist dir as fallback.
-DYLD_FALLBACK_LIBRARY_PATH="$core_dir/dist/kfc${DYLD_FALLBACK_LIBRARY_PATH:+:$DYLD_FALLBACK_LIBRARY_PATH}"
+DYLD_FALLBACK_LIBRARY_PATH="$core_dir/dist/kungfu${DYLD_FALLBACK_LIBRARY_PATH:+:$DYLD_FALLBACK_LIBRARY_PATH}"
 export DYLD_FALLBACK_LIBRARY_PATH
 
 cd "$core_dir"

--- a/verify.js
+++ b/verify.js
@@ -7,15 +7,15 @@
 // artifacts" criterion, which also serves as a CI smoke baseline.
 //
 // Usage (node pinned via the entrypoint; plain `node verify.js` also works):
-//   ./kungfu-code verify              quick: only assert "existing" artifacts (dist/kfc exists + kfc runs + version matches)
+//   ./kungfu-code verify              quick: only assert "existing" artifacts (dist/kungfu exists + kfc runs + version matches)
 //   ./kungfu-code verify --full       full: rebuild:core + freeze first, then assert; also builds and runs the
 //                                     capability slices (framework/core/slices) + yijinjing dependency guard
 //   ./kungfu-code verify --with-app   also assert the build:app artifact (with --full it builds the app first)
 //   ./kungfu-code verify --help
 //
 // Assertion targets (all grounded in the build scripts, not guessed):
-//   - framework/core/dist/kfc/                     freeze artifact directory (run-freeze.js renameSync target)
-//   - framework/core/dist/kfc/kfc[.exe]           kfc executable (path resolved by lib/executable.js)
+//   - framework/core/dist/kungfu/                     freeze artifact directory (run-freeze.js renameSync target)
+//   - framework/core/dist/kungfu/kfc[.exe]           kfc executable (path resolved by lib/executable.js)
 //   - `kfc --version` exits 0 and output contains the expected version   frozen Python runtime runs end to end (runtime smoke)
 //   - framework/gui/dist/app/                      (--with-app) build:app webpack artifact
 //
@@ -116,7 +116,7 @@ function main() {
       if (pyProbeBuild.status !== 0) {
         throw new Error(`python probe build failed (exit ${pyProbeBuild.status == null ? 'signal ' + pyProbeBuild.signal : pyProbeBuild.status})`);
       }
-      runPnpm('freeze'); // nuitka → framework/core/dist/kfc
+      runPnpm('freeze'); // nuitka → framework/core/dist/kungfu
       if (withApp) runPnpm('build:app'); // webpack → framework/gui/dist/app
     } catch (e) {
       fail('build stage', e.message);
@@ -130,7 +130,7 @@ function main() {
   const distKfc = path.join(ROOT, 'framework', 'core', 'dist', 'kungfu');
   let kungfuBin = null;
   if (fs.existsSync(distKfc) && fs.statSync(distKfc).isDirectory()) {
-    pass('dist/kfc directory exists', path.relative(ROOT, distKfc));
+    pass('dist/kungfu directory exists', path.relative(ROOT, distKfc));
     kungfuBin = path.join(distKfc, isWin ? 'kungfu.exe' : 'kungfu');
     if (fs.existsSync(kungfuBin) && fs.statSync(kungfuBin).isFile()) {
       let detail = path.relative(ROOT, kungfuBin);
@@ -144,7 +144,7 @@ function main() {
       kungfuBin = null;
     }
   } else {
-    fail('dist/kfc directory exists', `not found ${path.relative(ROOT, distKfc)} (freeze first; in quick mode, confirm it was built)`);
+    fail('dist/kungfu directory exists', `not found ${path.relative(ROOT, distKfc)} (freeze first; in quick mode, confirm it was built)`);
   }
 
   // ── Stage 2b: C++ extension probe artifact ────────────────────────
@@ -248,7 +248,7 @@ function main() {
 
       // ── Stage 6: journal fact fixtures (full mode) ────────────────
       // Each fixture under tests/fixtures/rewind-demo-*/ proves a capture
-      // gate end to end against the built dist/kfc (G2 capture, G3 event
+      // gate end to end against the built dist/kungfu (G2 capture, G3 event
       // completeness); tests/fixtures/work-demo-*/ prove the default work
       // profile the same way (P1 vocabulary, P2 lifecycle), and
       // tests/fixtures/atlas-demo-*/ prove the read-only control-plane

--- a/verify.js
+++ b/verify.js
@@ -127,21 +127,21 @@ function main() {
 
   // ── Stage 2: kfc artifact assertions ──────────────────────────────
   console.log('\n[verify] stage 2: kfc artifact assertions');
-  const distKfc = path.join(ROOT, 'framework', 'core', 'dist', 'kfc');
-  let kfcBin = null;
+  const distKfc = path.join(ROOT, 'framework', 'core', 'dist', 'kungfu');
+  let kungfuBin = null;
   if (fs.existsSync(distKfc) && fs.statSync(distKfc).isDirectory()) {
     pass('dist/kfc directory exists', path.relative(ROOT, distKfc));
-    kfcBin = path.join(distKfc, isWin ? 'kfc.exe' : 'kfc');
-    if (fs.existsSync(kfcBin) && fs.statSync(kfcBin).isFile()) {
-      let detail = path.relative(ROOT, kfcBin);
+    kungfuBin = path.join(distKfc, isWin ? 'kungfu.exe' : 'kungfu');
+    if (fs.existsSync(kungfuBin) && fs.statSync(kungfuBin).isFile()) {
+      let detail = path.relative(ROOT, kungfuBin);
       if (!isWin) {
-        const mode = fs.statSync(kfcBin).mode;
-        if (!(mode & 0o111)) { fail('kfc executable', `${detail} missing executable bit`); kfcBin = null; }
+        const mode = fs.statSync(kungfuBin).mode;
+        if (!(mode & 0o111)) { fail('kfc executable', `${detail} missing executable bit`); kungfuBin = null; }
         else pass('kfc executable exists', detail);
       } else pass('kfc executable exists', detail);
     } else {
-      fail('kfc executable exists', `not found ${path.relative(ROOT, kfcBin)} (freeze first)`);
-      kfcBin = null;
+      fail('kfc executable exists', `not found ${path.relative(ROOT, kungfuBin)} (freeze first)`);
+      kungfuBin = null;
     }
   } else {
     fail('dist/kfc directory exists', `not found ${path.relative(ROOT, distKfc)} (freeze first; in quick mode, confirm it was built)`);
@@ -183,8 +183,8 @@ function main() {
 
   // ── Stage 3: kfc runtime smoke ────────────────────────────────────
   console.log('\n[verify] stage 3: kfc runtime smoke (kfc --version)');
-  if (kfcBin) {
-    const r = spawnSync(kfcBin, ['--version'], { encoding: 'utf8' });
+  if (kungfuBin) {
+    const r = spawnSync(kungfuBin, ['--version'], { encoding: 'utf8' });
     const out = `${r.stdout || ''}${r.stderr || ''}`.trim();
     if (r.status !== 0) {
       fail('kfc --version exits 0', `exit ${r.status == null ? 'signal ' + r.signal : r.status}; output: ${out.slice(0, 200)}`);


### PR DESCRIPTION
Rename the runtime command and its packaged artifacts from `kfc` to `kungfu`, so the product exposes a single canonical name end to end.

## What changed

- **core** freezes the standalone runtime as `kungfu` under `dist/kungfu` (nuitka entry output + `binary.module_path`); the launcher and `kfs` resolve the executable and shared runtime dir there.
- **packaging** ships `core/dist/kungfu` to `Resources/kungfu`, and the binding install rpath points at `Resources/kungfu`; the gui/tui/api and the SDK app template resolve the runtime and the `kungfu` executable there.
- **install to PATH** — the reference app gains a VS Code–style "Install 'kungfu' Command in PATH" menu action: it ships a small wrapper that locates the bundled runtime and execs it, and symlinks `/usr/local/bin/kungfu` (elevating only when that directory is not user-writable).
- **runtime identifiers** — the runtime env contract (`KFC_*` → `KUNGFU_*`) is renamed in sync across the writers (api/gui/tui/sdk) and readers (core binding loader, Python variants/cli); TS/JS helpers, the freeze/spec internals, the binding variant suffix, the Windows delay-load hook, and the CLI group all take the `kungfu` name.
- **public surface** — the `kfc` bin alias is dropped (`kungfu` is the sole command), the prebuilt package name becomes `kungfu-v*`, examples/fixtures invoke `kungfu`, and the docs describe a single `kungfu` runtime and CLI.

## Deliberately kept

- Invisible internal build filenames (`kfc.py`, `kfc.spec`, the `kfc.dist`/`kfc-nuitka` intermediates, the `lib/kfc.js` launcher, `.devtools/kfc.py`) — never user-visible, so renaming them buys nothing.
- The `Kf*` domain model (`KfConfig`/`KfCategory`/`KfLocation`/…) is a separate namespace and is untouched.
- Dated ADR / versioning-ledger records that mention the former alias are left as accurate history.

## Verification

A from-scratch core build produces a runnable `dist/kungfu/kungfu` that presents as `kungfu` in `--help`; the packed app carries `Resources/kungfu/kungfu` (rpath resolves in the packaged layout) and the bundled CLI wrapper runs `kungfu` from PATH end to end.
