### PR TITLE
fix(gui): boot the sandboxed-view app and surface installed views

### DIFF
--- a/framework/gui/electron.vite.config.mjs
+++ b/framework/gui/electron.vite.config.mjs
@@ -14,10 +14,10 @@ const rootDir = dirname(fileURLToPath(import.meta.url));
 //   entries: the shell (index) and the isolated sandboxed-view harness.
 export default defineConfig({
   main: {
-    plugins: [externalizeDepsPlugin()],
+    plugins: [externalizeDepsPlugin({ exclude: ['@kungfu-tech/api', '@kungfu-tech/kfx'] })],
   },
   preload: {
-    plugins: [externalizeDepsPlugin()],
+    plugins: [externalizeDepsPlugin({ exclude: ['@kungfu-tech/api', '@kungfu-tech/kfx'] })],
     build: {
       rollupOptions: {
         input: {

--- a/framework/gui/src/main/sandbox-view.ts
+++ b/framework/gui/src/main/sandbox-view.ts
@@ -32,9 +32,17 @@ const SAMPLE_INTERVAL_MS = 2000;
 export function lockedDownPartition(id: string): string {
   const partition = `sandbox:${id}`;
   const ses: Session = session.fromPartition(partition);
+  // In development the harness page is served by the renderer dev server
+  // (ELECTRON_RENDERER_URL, an http origin), so that exact origin is allowed
+  // alongside file:/devtools:. In production ELECTRON_RENDERER_URL is unset and
+  // the harness loads over file:, so only file:/devtools: pass — the network
+  // stays denied.
+  const devOrigin = process.env.ELECTRON_RENDERER_URL;
   ses.webRequest.onBeforeRequest((details, callback) => {
     const ok =
-      details.url.startsWith('file:') || details.url.startsWith('devtools:');
+      details.url.startsWith('file:') ||
+      details.url.startsWith('devtools:') ||
+      (!!devOrigin && details.url.startsWith(devOrigin));
     callback({ cancel: !ok });
   });
   return partition;

--- a/framework/gui/src/renderer/src/main.tsx
+++ b/framework/gui/src/renderer/src/main.tsx
@@ -217,6 +217,9 @@ function App() {
   const enabled = loaded.entries.filter(
     (entry) =>
       entry.system ||
+      // installed third-party views (sandboxed-ipc) are visible once installed,
+      // independent of the profile's built-in kfx list
+      entry.tier === 'sandboxed-ipc' ||
       (profile.kfx.includes(entry.id) &&
         !state.disabledKfx.includes(entry.id) &&
         !(entry.suite && state.disabledSuites.includes(entry.suite))),


### PR DESCRIPTION
Running the full reference app end to end — not just the headless capability harness — surfaced three defects on the embedded sandboxed-view path. Each is fixed here; the production isolation posture is unchanged.

## Fixes

1. **App fails to start.** The electron main/preload externalized the pure-TS workspace packages `@kungfu-tech/api` and `@kungfu-tech/kfx`, so at runtime node's ESM loader tried to resolve their extensionless `src` imports (`export * from './types'`) and threw `ERR_MODULE_NOT_FOUND`. Bundle them into main/preload instead; the native `@kungfu-tech/core` stays external and is `require()`d at runtime.

2. **Installed third-party view invisible.** An installed (sandboxed-ipc) view loaded into the registry but never appeared in the shell nav, because the nav only listed `system` views or views in the active profile's built-in `kfx` list. Surface installed sandboxed views independently of the profile.

3. **Sandboxed view blank in development.** A sandboxed view's locked-down partition denies all non-`file:`/`devtools:` requests. In development the harness page is served over the renderer dev-server origin (`ELECTRON_RENDERER_URL`, an http origin), so it was blocked (`ERR_BLOCKED_BY_CLIENT`) and the view rendered blank. Allow that origin through in development only; production has no such env and still passes only `file:`/`devtools:`.

## Verification

Ran the reference app against a real native-backed runtime with a third-party view installed into `<home>/extensions`, and verified in the live app:

- the third-party view is classified `sandboxed-ipc` and renders in an isolated renderer with no node (`window.require`/`process` absent);
- its declared `ledger` capability round-trips over IPC to the real runtime and returns live health/anchors/records;
- an undeclared capability is absent on the guest and a forged call is rejected at the host;
- the view is killed when it breaches the working-set cap, while the shell survives;
- the embedded view tracks the window on resize.
