### PR TITLE
Ship the fact-ledger schemas and the Ink TUI in the packaged app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ framework/core/src/libkungfu/include/kungfu/longfist/fb/*.bfbs
 # Local cache/mirror proxy per-checkout override (optional); the real values and primary config
 # live in the user-global ~/.config/kungfu/build-local.env, not committed
 /build-local.env
+demo-runtime/

--- a/framework/core/.gyp/run-freeze.js
+++ b/framework/core/.gyp/run-freeze.js
@@ -185,6 +185,14 @@ function freezeNuitka(bt) {
       ...clangOpt,
       '--output-dir=build/kungfu-nuitka',
       `--include-data-files=${info}=kungfubuildinfo.json`,
+      // Fact-ledger schema blobs: the kungfu package's *_events.bfbs are read at
+      // runtime (rewind/atlas/work) but Nuitka does not follow non-.py package
+      // data, so ship them flat next to the binding where schema_data_path falls
+      // back to when the compiled module dir is not a real directory.
+      ...['rewind', 'atlas', 'work'].map(
+        (m) =>
+          `--include-data-files=${path.join(CORE, 'src', 'python', 'kungfu', m, `${m}_events.bfbs`)}=${m}_events.bfbs`,
+      ),
       path.join('src', 'python', 'kungfu_cli.py'),
     ],
     true,

--- a/framework/core/src/python/kungfu/__init__.py
+++ b/framework/core/src/python/kungfu/__init__.py
@@ -12,3 +12,18 @@ with open(
     __build_info__ = json.load(build_info_file)
 
 __version__ = __build_info__["version"]
+
+
+def schema_data_path(module_file, name):
+    """Resolve a package data file (e.g. a *.bfbs schema blob) in both layouts.
+
+    In a source checkout the file sits next to its module; in the frozen
+    standalone runtime the module is compiled into the executable (so
+    ``dirname(__file__)`` is not a real directory) and data files are shipped
+    flat next to the binding — the same place ``kungfubuildinfo.json`` lands.
+    Try the source layout first, then fall back to the binding directory.
+    """
+    beside_module = os.path.join(os.path.dirname(module_file), name)
+    if os.path.exists(beside_module):
+        return beside_module
+    return os.path.join(os.path.dirname(__binding__.__file__), name)

--- a/framework/core/src/python/kungfu/atlas/store.py
+++ b/framework/core/src/python/kungfu/atlas/store.py
@@ -36,7 +36,7 @@ PUBLIC_DEST = 0
 ATLAS_GROUP = "atlas"
 ATLAS_NAME = "import"
 
-_BFBS_FILE = os.path.join(os.path.dirname(__file__), "atlas_events.bfbs")
+_BFBS_FILE = __import__("kungfu").schema_data_path(__file__, "atlas_events.bfbs")
 
 
 def _location(runtime_dir):

--- a/framework/core/src/python/kungfu/console/commands/__registry__.py
+++ b/framework/core/src/python/kungfu/console/commands/__registry__.py
@@ -4,6 +4,7 @@ from . import engage
 from . import journal
 from . import run
 from . import cli
+from . import tui
 from . import tool
 from . import slicetool
 from . import assemble
@@ -21,6 +22,7 @@ __all__ = [
     "journal",
     "run",
     "cli",
+    "tui",
     "tool",
     "slicetool",
     "assemble",

--- a/framework/core/src/python/kungfu/console/commands/tui.py
+++ b/framework/core/src/python/kungfu/console/commands/tui.py
@@ -1,0 +1,53 @@
+#  SPDX-License-Identifier: Apache-2.0
+
+# The reference TUI (Ink) runs through kungfu's own embedded Node runtime
+# (libnode), the same bridge `kungfu cli` uses — no separate node install. The
+# TUI bundle is shipped next to the runtime (packaged app: Resources/tui/tui.mjs)
+# and loads the kungfu_node binding at runtime from KUNGFU_DIR.
+
+import os
+import sys
+
+import click
+
+import kungfu
+from kungfu.console.commands import kfc
+
+
+def _resolve_tui_entry():
+    override = os.environ.get("KUNGFU_TUI_ENTRY")
+    if override and os.path.exists(override):
+        return os.path.abspath(override)
+    # Packaged app: the frozen runtime is Resources/kungfu; the TUI bundle is
+    # shipped as a sibling Resources/tui/tui.mjs.
+    binding_dir = os.path.dirname(kungfu.__binding__.__file__)
+    candidates = [
+        os.path.join(binding_dir, "..", "tui", "tui.mjs"),
+        os.path.join(binding_dir, "tui.mjs"),
+    ]
+    for candidate in candidates:
+        if os.path.exists(candidate):
+            return os.path.abspath(candidate)
+    return None
+
+
+@kfc.command(help_priority=1)
+@click.argument("commands", nargs=-1, required=False)
+@kfc.pass_context()
+def tui(ctx, commands):
+    """Kungfu reference TUI (Ink) — the shell-native reference surface."""
+    os.environ["KUNGFU_AS_VARIANT"] = "node"
+    # Point the TUI at this runtime's binding directory so it loads
+    # kungfu_node.node from the shipped runtime rather than resolving a
+    # workspace package that does not exist in the packaged app.
+    os.environ.setdefault(
+        "KUNGFU_DIR", os.path.dirname(kungfu.__binding__.__file__)
+    )
+    entry = _resolve_tui_entry()
+    if not entry:
+        raise click.ClickException(
+            "kungfu TUI bundle not found; the packaged app ships it under "
+            "Resources/tui, or set KUNGFU_TUI_ENTRY to a built tui.mjs"
+        )
+    argv = [sys.argv[0], entry, *commands]
+    kungfu.__binding__.libnode.run(*argv)

--- a/framework/core/src/python/kungfu/rewind/bundle.py
+++ b/framework/core/src/python/kungfu/rewind/bundle.py
@@ -11,7 +11,7 @@ import os
 
 from kungfu.rewind import MSG_TYPE_NAMES, SCHEMA_VERSION
 
-_BFBS_FILE = os.path.join(os.path.dirname(__file__), "rewind_events.bfbs")
+_BFBS_FILE = __import__("kungfu").schema_data_path(__file__, "rewind_events.bfbs")
 
 
 def read_schema_blob():

--- a/framework/core/src/python/kungfu/work/store.py
+++ b/framework/core/src/python/kungfu/work/store.py
@@ -51,7 +51,7 @@ PUBLIC_DEST = 0
 WORK_GROUP = "work"
 WORK_NAME = "items"
 
-_BFBS_FILE = os.path.join(os.path.dirname(__file__), "work_events.bfbs")
+_BFBS_FILE = __import__("kungfu").schema_data_path(__file__, "work_events.bfbs")
 
 STATUS_NAMES = {
     WorkStatus.Active: "active",

--- a/framework/gui/electron-builder.yml
+++ b/framework/gui/electron-builder.yml
@@ -16,6 +16,10 @@ extraResources:
   # /usr/local/bin; it resolves the bundled runtime next to it and execs it.
   - from: resources/cli
     to: cli
+  # The Ink reference TUI, bundled to a single ES module and run through
+  # kungfu's embedded Node (libnode) via `kungfu tui`.
+  - from: ../tui/dist
+    to: tui
 mac:
   # dir = the pack verb's unpacked app (fast, CI-friendly); dmg + zip = the
   # dist verb's installable artifacts. Unsigned pre-release (identity: null):

--- a/framework/gui/package.json
+++ b/framework/gui/package.json
@@ -20,8 +20,8 @@
     "dev": "pnpm run ensure-electron && electron-vite dev",
     "build": "electron-vite build",
     "start": "pnpm run ensure-electron && electron-vite preview",
-    "pack": "pnpm run ensure-electron && electron-vite build && electron-builder --dir --config.electronDist=$(node -p \"require('path').dirname(require.resolve('electron'))+'/dist'\")",
-    "dist": "pnpm run ensure-electron && electron-vite build && electron-builder --config.electronDist=$(node -p \"require('path').dirname(require.resolve('electron'))+'/dist'\")",
+    "pack": "pnpm --filter @kungfu-tech/tui run bundle && pnpm run ensure-electron && electron-vite build && electron-builder --dir --config.electronDist=$(node -p \"require('path').dirname(require.resolve('electron'))+'/dist'\")",
+    "dist": "pnpm --filter @kungfu-tech/tui run bundle && pnpm run ensure-electron && electron-vite build && electron-builder --config.electronDist=$(node -p \"require('path').dirname(require.resolve('electron'))+'/dist'\")",
     "lint": "biome check src",
     "format": "biome format --write src",
     "clean": "rimraf out dist node_modules/.vite"

--- a/framework/tui/build-bundle.mjs
+++ b/framework/tui/build-bundle.mjs
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Bundle the Ink TUI into a single self-contained ES module so the packaged app
+// can run it through kungfu's embedded Node runtime (libnode) with no
+// node_modules. ESM output is required: Ink 5 and yoga-layout use top-level
+// await, which the CJS format cannot represent. The kungfu_node binding is
+// loaded at runtime by absolute path (a dynamic require esbuild leaves alone),
+// so it stays external.
+
+import esbuild from 'esbuild';
+
+// Ink statically imports react-devtools-core for its optional devtools
+// integration, but it is an unused optional dependency here. Stub it to an
+// empty module so the bundle is self-contained.
+const stubDevtools = {
+  name: 'stub-react-devtools-core',
+  setup(build) {
+    build.onResolve({ filter: /^react-devtools-core$/ }, () => ({
+      path: 'react-devtools-core',
+      namespace: 'stub',
+    }));
+    build.onLoad({ filter: /.*/, namespace: 'stub' }, () => ({
+      contents: 'export function connectToDevTools() {}\nexport default {};\n',
+      loader: 'js',
+    }));
+  },
+};
+
+await esbuild.build({
+  entryPoints: ['src/main.tsx'],
+  bundle: true,
+  platform: 'node',
+  format: 'esm',
+  target: 'node20',
+  outfile: 'dist/tui.mjs',
+  plugins: [stubDevtools],
+  // Bundled CJS deps (signal-exit, etc.) call require() for Node builtins;
+  // give the ESM bundle a real require so esbuild's shim falls back to it.
+  banner: {
+    js: [
+      "import { createRequire as __kfCreateRequire } from 'node:module';",
+      'const require = __kfCreateRequire(import.meta.url);',
+    ].join('\n'),
+  },
+  logLevel: 'info',
+});

--- a/framework/tui/package.json
+++ b/framework/tui/package.json
@@ -20,7 +20,8 @@
     "build": "tsc",
     "lint": "biome check src",
     "format": "biome format --write src",
-    "clean": "rimraf dist"
+    "clean": "rimraf dist",
+    "bundle": "node build-bundle.mjs"
   },
   "dependencies": {
     "@kungfu-tech/api": "workspace:*",
@@ -32,6 +33,7 @@
     "@biomejs/biome": "^1.9.4",
     "@types/node": "^22.0.0",
     "@types/react": "^18.3.3",
+    "esbuild": "^0.28.1",
     "rimraf": "^6.0.0",
     "tsx": "^4.19.0",
     "typescript": "^5.6.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -435,6 +435,9 @@ importers:
       '@types/react':
         specifier: ^18.3.3
         version: 18.3.31
+      esbuild:
+        specifier: ^0.28.1
+        version: 0.28.1
       rimraf:
         specifier: ^6.0.0
         version: 6.1.3


### PR DESCRIPTION
The installed app now exercises the full runtime: the fact-ledger features work frozen, and the Ink reference TUI ships and runs.

## Fact-ledger schema blobs (`kungfu trace` / rewind / work / atlas)

The `*_events.bfbs` reflection schemas were never bundled into the frozen runtime, and were read via `dirname(__file__)` — not a real directory inside the standalone binary — so `kungfu trace` failed with `NotADirectoryError`. Ship the blobs flat next to the binding (the `kungfubuildinfo.json` pattern) and resolve them through a `schema_data_path` helper that tries the source layout first, then the binding directory.

## Reference TUI in the dmg

The Ink TUI was not shipped at all. Bundle it to a single self-contained ES module (esbuild; ESM is required for Ink 5 / yoga-layout top-level await), stub Ink's optional `react-devtools-core`, add a `require` shim for bundled CJS deps, ship it under `Resources/tui`, and add a `kungfu tui` command that runs it through kungfu's embedded Node runtime (`libnode`) — the same bridge `kungfu cli` uses — with `KUNGFU_DIR` pointed at the shipped runtime so it loads `kungfu_node.node` in-process.

## Verification

From the packaged app: `kungfu trace -- echo ...` captures a run and writes its bundle; `kungfu tui` loads the in-process binding and renders the ledger view.
