### PR TITLE
Make kungfu tui cwd-independent and let trace run -c commands

### DIFF
--- a/framework/core/.gyp/run-freeze.js
+++ b/framework/core/.gyp/run-freeze.js
@@ -200,6 +200,11 @@ function freezeNuitka(bt) {
       'nuitka',
       ...clangOpt,
       '--output-dir=build/kungfu-nuitka',
+      // `kungfu trace -- <cmd>` spawns arbitrary child commands; some (e.g.
+      // `sh -c ...`) carry a `-c` argument that Nuitka's deployment mode
+      // mistakes for the frozen binary being asked to self-execute. The runtime
+      // never re-executes itself, so disabling this guard is safe.
+      '--no-deployment-flag=self-execution',
       `--include-data-files=${info}=kungfubuildinfo.json`,
       // Fact-ledger schema blobs: the kungfu package's *_events.bfbs are read at
       // runtime (rewind/atlas/work) but Nuitka does not follow non-.py package

--- a/framework/core/src/python/kungfu/console/commands/tui.py
+++ b/framework/core/src/python/kungfu/console/commands/tui.py
@@ -41,6 +41,11 @@ def tui(ctx, commands):
     # kungfu_node.node from the shipped runtime rather than resolving a
     # workspace package that does not exist in the packaged app.
     os.environ.setdefault("KUNGFU_DIR", os.path.dirname(kungfu.__binding__.__file__))
+    # Open the same runtime home the rest of the CLI uses (<home>/runtime),
+    # not a directory derived from the current working directory — otherwise
+    # the TUI shows a different/empty ledger per cwd and crashes when the cwd
+    # is not writable.
+    os.environ.setdefault("KF_RUNTIME_DIR", ctx.runtime_dir)
     entry = _resolve_tui_entry()
     if not entry:
         raise click.ClickException(


### PR DESCRIPTION
Two robustness fixes surfaced by dogfooding the packaged app.

- **`kungfu tui` was cwd-dependent and could crash.** It derived its runtime home from `cwd/demo-runtime`, so it showed a different (usually empty) ledger per directory and crashed with a native exception when the cwd was not writable. Default `KF_RUNTIME_DIR` to the same `<home>/runtime` the rest of the CLI uses (`ctx.runtime_dir`), so the TUI opens the real runtime regardless of where it is launched.

- **`kungfu trace -- sh -c '...'` tripped Nuitka's self-execution guard.** Tracing a child command whose arguments include `-c` was mistaken by Nuitka's deployment mode for the frozen binary being asked to self-execute. The runtime never re-executes itself, so the freeze now passes `--no-deployment-flag=self-execution`.

Verified on a fresh build: `kungfu trace -- sh -c 'echo a; echo b'` captures the run; `kungfu tui` launched from a read-only directory renders against the home runtime instead of crashing.
