### PR TITLE
build(core): pin clang-format via uv for reproducible C++ formatting

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -56,13 +56,19 @@ done
 changed=''
 warn() { printf '[kungfu pre-commit] %s\n' "$1" >&2; }
 
-# C++ — clang-format reads the repo-root .clang-format via -style=file.
+# C++ — clang-format reads the repo-root .clang-format via -style=file. Pin the
+# version to framework/core/pyproject.toml (keep both in sync) so output is
+# byte-identical across machines; prefer the uv-provided pin over a system one.
 if [ -n "$cpp" ]; then
-  if command -v clang-format >/dev/null 2>&1; then
+  if command -v uvx >/dev/null 2>&1; then
+    # shellcheck disable=SC2086
+    uvx clang-format@20.1.8 -style=file -i $cpp && changed="$changed $cpp"
+  elif command -v clang-format >/dev/null 2>&1; then
+    warn "using system clang-format ($(clang-format --version | head -1)); may differ from pinned 20.1.8"
     # shellcheck disable=SC2086
     clang-format -style=file -i $cpp && changed="$changed $cpp"
   else
-    warn "clang-format not found; skipped C++:$cpp"
+    warn "clang-format (uv) not found; skipped C++:$cpp"
   fi
 fi
 

--- a/framework/core/.gyp/run-format-cpp.js
+++ b/framework/core/.gyp/run-format-cpp.js
@@ -8,16 +8,21 @@ function main(argv) {
   const cwd = process.cwd().toString();
   process.chdir(path.dirname(__dirname));
 
-  shell.run('clang-format', ['--version'], true, { tolerant: true });
+  // clang-format is pinned in pyproject and provided by the uv venv (same lane as
+  // ruff), so C++ formatting is byte-identical across machines instead of relying
+  // on the ambient system clang-format. Format every file in one uv invocation to
+  // avoid paying the `uv run` startup cost per file.
+  const clangFormat = ['run', '--frozen', 'clang-format'];
+  shell.run('uv', [...clangFormat, '--version'], true, { tolerant: true });
 
-  argv.forEach((dir) =>
+  const files = argv.flatMap((dir) =>
     glob
       .sync('**/*.@(h|hpp|hxx|cpp|c|cc|cxx)', { cwd: path.join(cwd, dir) })
-      .forEach((p) => {
-        const file = path.join(cwd, dir, p);
-        shell.run('clang-format', ['-style=file', '-i', file]);
-      }),
+      .map((p) => path.join(cwd, dir, p)),
   );
+  if (files.length) {
+    shell.run('uv', [...clangFormat, '-style=file', '-i', ...files]);
+  }
 }
 
 module.exports.main = main;

--- a/framework/core/pyproject.toml
+++ b/framework/core/pyproject.toml
@@ -16,6 +16,10 @@ requires-python = ">=3.13,<3.14"
 dependencies = [
     # Compiler
     "ruff~=0.15.0",
+    # clang-format via PyPI wheel, same uv toolchain lane as ruff. Pinned exactly
+    # (==) because a version bump changes C++ formatting output; an exact pin keeps
+    # the result byte-identical across machines instead of the ambient system one.
+    "clang-format==20.1.8",
     "nuitka~=4.1.0",
     "pdm~=2.28.0",
     "pdm-pep517~=1.1.0",

--- a/framework/core/src/bindings/node/binding/operators.h
+++ b/framework/core/src/bindings/node/binding/operators.h
@@ -340,7 +340,7 @@ private:
 
 class JsUpdateState {
 public:
-  explicit JsUpdateState(Napi::ObjectReference &state) : state_(state){};
+  explicit JsUpdateState(Napi::ObjectReference &state) : state_(state) {};
 
   template <typename DataType>
   void operator()(int64_t update_time, uint32_t source, uint32_t dest, const DataType &data) {

--- a/framework/core/src/bindings/node/binding/session_store.cpp
+++ b/framework/core/src/bindings/node/binding/session_store.cpp
@@ -14,7 +14,7 @@ SessionStore::SessionStore(const Napi::CallbackInfo &info)
     : ObjectWrap(info),                                                                                      //
       io_device_(std::make_shared<io_device>(                                                                //
           IODevice::ExtractLocation(info, 0, IODevice::ExtractRuntimeLocatorByIndex(info, 1)), false, true)) //
-      {};
+{};
 
 SessionStore::~SessionStore() { io_device_.reset(); }
 

--- a/framework/core/src/bindings/python/binding/py-yijinjing.cpp
+++ b/framework/core/src/bindings/python/binding/py-yijinjing.cpp
@@ -329,13 +329,12 @@ void bind(pybind11::module &&m) {
       .def(py::init<const yijinjing::data::location_ptr &, uint32_t, uint32_t, int64_t>(), py::arg("source_location"),
            py::arg("dest_id"), py::arg("assemble_mode") = longfist::enums::AssembleMode::Channel,
            py::arg("from_time") = 0)
-      .def("read_headers", (std::vector<frame_header>(assemble::*)(int32_t, int64_t)) & assemble::read_headers,
+      .def("read_headers", (std::vector<frame_header> (assemble::*)(int32_t, int64_t))&assemble::read_headers,
            py::arg("msg_type"), py::arg("end_time") = INT64_MAX, py::return_value_policy::move)
-      .def(
-          "read_bytes",
-          (std::vector<std::pair<longfist::types::frame_header, std::vector<uint8_t>>>(assemble::*)(int32_t, int64_t)) &
-              assemble::read_bytes,
-          py::arg("msg_type"), py::arg("end_time") = INT64_MAX, py::return_value_policy::move)
+      .def("read_bytes",
+           (std::vector<std::pair<longfist::types::frame_header, std::vector<uint8_t>>> (assemble::*)(
+               int32_t, int64_t))&assemble::read_bytes,
+           py::arg("msg_type"), py::arg("end_time") = INT64_MAX, py::return_value_policy::move)
       .def("__plus__", &assemble::operator+)
       .def("__rshift__", &assemble::operator>>);
   boost::hana::for_each(AllDataTypes, [&](auto type) {

--- a/framework/core/src/libkungfu/include/kungfu/longfist/enums.h
+++ b/framework/core/src/libkungfu/include/kungfu/longfist/enums.h
@@ -301,8 +301,8 @@ KF_JSON_SERIALIZE_ENUM(AlgoOrderActionFlag, {
 inline std::ostream &operator<<(std::ostream &os, AlgoOrderActionFlag t) { return os << int32_t(t); }
 
 enum class PriceType : int8_t {
-  Limit, // 限价,证券通用
-  Any, // 市价，证券通用，对于股票上海为最优五档剩余撤销，深圳为即时成交剩余撤销，建议客户采用
+  Limit,          // 限价,证券通用
+  Any,            // 市价，证券通用，对于股票上海为最优五档剩余撤销，深圳为即时成交剩余撤销，建议客户采用
   FakBest5,       // 上海深圳最优五档即时成交剩余撤销，不需要报价
   ForwardBest,    // 深圳本方方最优价格申报, 不需要报价
   ReverseBest,    // 上海最优五档即时成交剩余转限价, 深圳对手方最优价格申报，不需要报价

--- a/framework/core/src/libkungfu/include/kungfu/longfist/types.h
+++ b/framework/core/src/libkungfu/include/kungfu/longfist/types.h
@@ -172,9 +172,9 @@ KF_DEFINE_PACK_TYPE(                                                            
 
     (double, margin),       // 保证金(期货)
     (double, position_pnl), // 持仓盈亏(期货), 最新价 - 昨结算, 表示今日的盈亏, 本地不计算改变
-    (double, close_pnl), // 平仓盈亏(期货), 平仓价 - 昨结算, 表示今日的平仓盈亏, 本地不计算改变
+    (double, close_pnl),    // 平仓盈亏(期货), 平仓价 - 昨结算, 表示今日的平仓盈亏, 本地不计算改变
 
-    (double, realized_pnl), // 已实现盈亏, 平仓价 - 昨结算, 表示今日的平仓盈亏, 随着交易被本地计算改变
+    (double, realized_pnl),   // 已实现盈亏, 平仓价 - 昨结算, 表示今日的平仓盈亏, 随着交易被本地计算改变
     (double, unrealized_pnl), // 未实现盈亏, 最新价 - 昨结算, 表示今日的盈亏, 随着交易被本地计算改变
 
     (uint32_t, source_id),   // 来源账户
@@ -234,9 +234,9 @@ KF_DEFINE_PACK_TYPE(                                           //
     (kungfu::array<char, EXTERNAL_ID_LEN>, external_order_id), // 柜台订单id
     (uint64_t, parent_id),                                     // 母单号
 
-    (int64_t, insert_time),  // 订单写入时间
-    (int64_t, update_time),  // 订单更新时间
-    (int64_t, restore_time), // 根据这个时间决定是否要恢复该数据, 主要针对期货夜盘
+    (int64_t, insert_time),                       // 订单写入时间
+    (int64_t, update_time),                       // 订单更新时间
+    (int64_t, restore_time),                      // 根据这个时间决定是否要恢复该数据, 主要针对期货夜盘
     (kungfu::array<char, DATE_LEN>, trading_day), // 针对模拟盘交易日与实际时间不对应
 
     (kungfu::array<char, INSTRUMENT_ID_LEN>, instrument_id), // 合约ID
@@ -276,8 +276,8 @@ KF_DEFINE_PACK_TYPE(                                   //
     (kungfu::array<char, EXTERNAL_ID_LEN>, external_order_id), // 柜台订单id
     (kungfu::array<char, EXTERNAL_ID_LEN>, external_trade_id), // 柜台成交编号id
 
-    (int64_t, trade_time),   // 成交时间
-    (int64_t, restore_time), // 根据这个时间决定是否要恢复该数据, 主要针对期货夜盘
+    (int64_t, trade_time),                        // 成交时间
+    (int64_t, restore_time),                      // 根据这个时间决定是否要恢复该数据, 主要针对期货夜盘
     (kungfu::array<char, DATE_LEN>, trading_day), // 针对模拟盘交易日与实际时间不对应
 
     (kungfu::array<char, INSTRUMENT_ID_LEN>, instrument_id), // 合约ID
@@ -311,13 +311,13 @@ KF_DEFINE_PACK_TYPE(                                                    //
     (kungfu::array<char, EXTERNAL_ID_LEN>, external_order_id), // 撤单原委托柜台订单id, 新生成撤单委托编号不记录
     (uint64_t, order_action_id),                               // 订单操作ID
     (int32_t, error_id),                                       // 错误ID
-    (kungfu::array<char, ERROR_MSG_LEN>, error_msg), // 错误信息
-    (int64_t, insert_time)                           // 写入时间
+    (kungfu::array<char, ERROR_MSG_LEN>, error_msg),           // 错误信息
+    (int64_t, insert_time)                                     // 写入时间
 );
 
 KF_DEFINE_PACK_TYPE(                                         //
     BlockMessage, 206, PK(block_id), TIMESTAMP(insert_time), //
-    (uint64_t, block_id), // 大宗交易信息id, 用于TD从OrderInput找到此数据
+    (uint64_t, block_id),                                    // 大宗交易信息id, 用于TD从OrderInput找到此数据
     (kungfu::array<char, OPPONENT_SEAT_LEN>, opponent_seat), // 对手方席号
     (uint64_t, match_number),                                // 成交约定号
     (bool, is_specific),                                     // 是否受限(特定)股份
@@ -370,9 +370,9 @@ KF_DEFINE_PACK_TYPE(                                             //
     (kungfu::array<char, EXTERNAL_ID_LEN>, external_order_id),   // 柜台订单id
     (enums::OrderTriggerFlag, action_flag),                      // 预埋下单 or 预埋撤单
 
-    (int64_t, insert_time),  // 触发器写入时间
-    (int64_t, update_time),  // 触发器更新时间
-    (int64_t, restore_time), // 根据这个时间决定是否要恢复该数据, 主要针对期货夜盘
+    (int64_t, insert_time),                       // 触发器写入时间
+    (int64_t, update_time),                       // 触发器更新时间
+    (int64_t, restore_time),                      // 根据这个时间决定是否要恢复该数据, 主要针对期货夜盘
     (kungfu::array<char, DATE_LEN>, trading_day), // 针对模拟盘交易日与实际时间不对应
 
     (kungfu::array<char, INSTRUMENT_ID_LEN>, instrument_id), // 合约ID
@@ -410,11 +410,11 @@ KF_DEFINE_PACK_TYPE(                                                            
 KF_DEFINE_PACK_TYPE(                                                                   //
     OrderTriggerActionError, 212, PK(order_trigger_action_id), TIMESTAMP(insert_time), //
     (uint64_t, trigger_id),                                                            // 订单ID
-    (kungfu::array<char, EXTERNAL_ID_LEN>, external_trigger_id), // 要删除的预埋单的ParkedId
-    (uint64_t, order_trigger_action_id),                         // 订单操作ID
-    (int32_t, error_id),                                         // 错误ID
-    (kungfu::array<char, ERROR_MSG_LEN>, error_msg),             // 错误信息
-    (int64_t, insert_time)                                       // 写入时间
+    (kungfu::array<char, EXTERNAL_ID_LEN>, external_trigger_id),                       // 要删除的预埋单的ParkedId
+    (uint64_t, order_trigger_action_id),                                               // 订单操作ID
+    (int32_t, error_id),                                                               // 错误ID
+    (kungfu::array<char, ERROR_MSG_LEN>, error_msg),                                   // 错误信息
+    (int64_t, insert_time)                                                             // 写入时间
 );
 
 KF_DEFINE_DATA_TYPE(                                           //
@@ -454,7 +454,7 @@ KF_DEFINE_PACK_TYPE(                                           //
     (int64_t, update_time),                                    // 更新时间
     (int64_t, begin_time),                                     // 开始时间
     (int64_t, end_time),                                       // 结束时间
-    (int64_t, restore_time), // 根据这个时间决定是否要恢复该数据, 主要针对期货夜盘
+    (int64_t, restore_time),                                   // 根据这个时间决定是否要恢复该数据, 主要针对期货夜盘
 
     (kungfu::array<char, INSTRUMENT_ID_LEN>, instrument_id), // 合约代码
     (kungfu::array<char, EXCHANGE_ID_LEN>, exchange_id),     // 交易所代码

--- a/framework/core/src/libkungfu/include/kungfu/yijinjing/nanomsg/socket.h
+++ b/framework/core/src/libkungfu/include/kungfu/yijinjing/nanomsg/socket.h
@@ -93,7 +93,7 @@ DECLARE_PTR(nn_exception)
 
 class socket {
 public:
-  explicit socket(protocol p) : socket(p, MAX_MSG_LENGTH){};
+  explicit socket(protocol p) : socket(p, MAX_MSG_LENGTH) {};
 
   socket(protocol p, int buffer_size);
 

--- a/framework/core/src/libkungfu/include/kungfu/yijinjing/rx.h
+++ b/framework/core/src/libkungfu/include/kungfu/yijinjing/rx.h
@@ -34,8 +34,8 @@ static constexpr auto complete_handler_log = [](const std::string &subscriber_na
 };
 
 template <typename EventType>
-static constexpr auto instanceof
-    = []() { return filter([](const event_ptr &event) { return dynamic_cast<EventType *>(event.get()) != nullptr; }); };
+static constexpr auto instanceof =
+    []() { return filter([](const event_ptr &event) { return dynamic_cast<EventType *>(event.get()) != nullptr; }); };
 
 static constexpr auto is_custom_event = [](const event_ptr &event) -> bool {
   return event->msg_type() > 0 and longfist::AllTypesTags.find(event->msg_type()) == longfist::AllTypesTags.end();

--- a/framework/core/src/libkungfu/src/yijinjing/practice/master.cpp
+++ b/framework/core/src/libkungfu/src/yijinjing/practice/master.cpp
@@ -210,7 +210,7 @@ void master::react() {
   events_ | is(CacheReset::tag) | $([&](const event_ptr &event) { cached_.cache_reset(event); });
   events_ | is(CachedPause::tag) | $$(cached_.switch_feed_storage(true));
   events_ | is(CachedResume::tag) | $$(cached_.switch_feed_storage(false));
-  events_ | instanceof <yijinjing::journal::frame>() | $$(feed(event));
+  events_ | instanceof<yijinjing::journal::frame>() | $$(feed(event));
 
   // have to be at bottom of react, for avoid event still required after reader disjoin
   events_ | is(RequestDeregister::tag) | $$(on_request_deregister(event));

--- a/framework/core/src/libkungfu/src/yijinjing/util/webserver.cpp
+++ b/framework/core/src/libkungfu/src/yijinjing/util/webserver.cpp
@@ -218,8 +218,7 @@ websocket_server::websocket_server(http_server_ptr http_server, const nng_url *b
                                    bool is_text_mode, bool tcp_no_delay, size_t max_num_connections)
     : url_(base_url), is_text_mode_(is_text_mode), tcp_no_delay_(tcp_no_delay), session_max_(max_num_connections),
       http_server_(std::move(http_server)), session_num_(0) {
-  int rv = nng_aio_alloc(
-      &aio_listener_, [](void *arg) { ((websocket_server *)arg)->accept_cb(); }, this);
+  int rv = nng_aio_alloc(&aio_listener_, [](void *arg) { ((websocket_server *)arg)->accept_cb(); }, this);
   if (rv != 0) {
     fatal("nng_aio_alloc", rv);
   }

--- a/framework/core/src/libwingchun/include/kungfu/wingchun/book/bookkeeper.h
+++ b/framework/core/src/libwingchun/include/kungfu/wingchun/book/bookkeeper.h
@@ -20,8 +20,8 @@ typedef std::unordered_map<uint32_t, kungfu::state<longfist::types::Quote>> Quot
 
 class BookListener {
 public:
-  virtual void on_position_sync_reset(const Book &old_book, const Book &new_book){};
-  virtual void on_asset_sync_reset(const longfist::types::Asset &old_asset, const longfist::types::Asset &new_asset){};
+  virtual void on_position_sync_reset(const Book &old_book, const Book &new_book) {};
+  virtual void on_asset_sync_reset(const longfist::types::Asset &old_asset, const longfist::types::Asset &new_asset) {};
 };
 DECLARE_PTR(BookListener)
 

--- a/framework/core/src/libwingchun/include/kungfu/wingchun/broker/marketdata.h
+++ b/framework/core/src/libwingchun/include/kungfu/wingchun/broker/marketdata.h
@@ -39,7 +39,7 @@ class MarketData : public BrokerService {
   friend class MarketDataVendor;
 
 public:
-  explicit MarketData(BrokerVendor &vendor) : BrokerService(vendor){};
+  explicit MarketData(BrokerVendor &vendor) : BrokerService(vendor) {};
 
   virtual bool subscribe(const std::vector<longfist::types::InstrumentKey> &instrument_keys) = 0;
 

--- a/framework/core/src/libwingchun/include/kungfu/wingchun/broker/trader.h
+++ b/framework/core/src/libwingchun/include/kungfu/wingchun/broker/trader.h
@@ -55,15 +55,15 @@ inline std::pair<bool, bool> get_status(const Orders &orders) {
 
 class BaseService {
 public:
-  explicit BaseService(TraderVendor &vendor) : vendor_(vendor){};
+  explicit BaseService(TraderVendor &vendor) : vendor_(vendor) {};
 
   virtual ~BaseService() = default;
 
   virtual void on_recover() { recover_done_ = true; };
 
-  virtual void on_active(){};
+  virtual void on_active() {};
 
-  virtual void on_frame(){};
+  virtual void on_frame() {};
 
 protected:
   TraderVendor &vendor_;
@@ -280,7 +280,7 @@ class Trader : public BrokerService {
   friend class TraderVendor;
 
 public:
-  explicit Trader(BrokerVendor &vendor) : BrokerService(vendor){};
+  explicit Trader(BrokerVendor &vendor) : BrokerService(vendor) {};
 
   [[nodiscard]] virtual longfist::enums::AccountType get_account_type() const = 0;
 
@@ -374,7 +374,7 @@ public:
 
   void disable_recover();
 
-  virtual void on_recover(){};
+  virtual void on_recover() {};
 
   [[nodiscard]] bool is_sync_account() const { return sync_account_; }
 

--- a/framework/core/src/libwingchun/include/kungfu/wingchun/factor/crosssection.h
+++ b/framework/core/src/libwingchun/include/kungfu/wingchun/factor/crosssection.h
@@ -68,17 +68,17 @@ public:
   virtual void on_start(const rx::connectable_observable<event_ptr> &events);
 
 protected:
-  virtual void on_tick(const longfist::types::Tick &tick){};
+  virtual void on_tick(const longfist::types::Tick &tick) {};
 
   virtual void on_quote(const longfist::types::Quote &quote);
 
-  virtual void on_entrust(const longfist::types::Entrust &entrust){};
+  virtual void on_entrust(const longfist::types::Entrust &entrust) {};
 
-  virtual void on_transaction(const longfist::types::Transaction &transaction){};
+  virtual void on_transaction(const longfist::types::Transaction &transaction) {};
 
-  virtual void on_tree(const longfist::types::Tree &tree){};
+  virtual void on_tree(const longfist::types::Tree &tree) {};
 
-  virtual void on_depth(const longfist::types::Depth &depth){};
+  virtual void on_depth(const longfist::types::Depth &depth) {};
 
   int64_t now() const {
     if (not app_)

--- a/framework/core/src/libwingchun/include/kungfu/wingchun/operator/backtest.h
+++ b/framework/core/src/libwingchun/include/kungfu/wingchun/operator/backtest.h
@@ -168,7 +168,7 @@ private:
     int64_t nanotime;
     std::function<void(event_ptr)> call_back;
     TimerTask(int32_t id, int64_t nanotime, std::function<void(event_ptr)> cb)
-        : timer_id(id), nanotime(nanotime), call_back(std::move(cb)){};
+        : timer_id(id), nanotime(nanotime), call_back(std::move(cb)) {};
     bool operator<(const TimerTask &other) const { return other.nanotime < this->nanotime; }
   };
 

--- a/framework/core/src/libwingchun/include/kungfu/wingchun/operator/context.h
+++ b/framework/core/src/libwingchun/include/kungfu/wingchun/operator/context.h
@@ -88,7 +88,7 @@ public:
    * @param exchange_id exchange ID
    */
   virtual void unsubscribe(const std::string &source, const std::vector<std::string> &instrument_ids,
-                           const std::string &exchange_id){};
+                           const std::string &exchange_id) {};
 
   /**
    * Subscribe all from given MD
@@ -148,7 +148,7 @@ public:
    * @param resume_policy
    * @return void
    */
-  virtual void set_resume_policy(longfist::enums::ResumePolicy resume_policy){};
+  virtual void set_resume_policy(longfist::enums::ResumePolicy resume_policy) {};
 
   /**
    *
@@ -182,11 +182,11 @@ protected:
   std::string operator_dir_;
   bool started_ = false;
 
-  virtual void on_start(){};
+  virtual void on_start() {};
 
   virtual void prepare(const event_ptr &event) = 0;
 
-  virtual void post_stop(){};
+  virtual void post_stop() {};
 
 private:
   friend void enable(Context &context) { context.on_start(); }

--- a/framework/core/src/libwingchun/include/kungfu/wingchun/operator/operator.h
+++ b/framework/core/src/libwingchun/include/kungfu/wingchun/operator/operator.h
@@ -13,73 +13,73 @@ public:
   virtual ~Operator() = default;
 
   // 运行前
-  virtual void pre_start(Context_ptr &context){};
+  virtual void pre_start(Context_ptr &context) {};
 
-  virtual void post_start(Context_ptr &context){};
+  virtual void post_start(Context_ptr &context) {};
 
   // 退出前
-  virtual void pre_stop(Context_ptr &context){};
+  virtual void pre_stop(Context_ptr &context) {};
 
-  virtual void post_stop(Context_ptr &context){};
+  virtual void post_stop(Context_ptr &context) {};
 
   // 行情数据更新回调
   //@param quote             行情数据
   virtual void on_quote(Context_ptr &context, const longfist::types::Quote &quote,
-                        const kungfu::yijinjing::data::location_ptr &location, uint32_t dest){};
+                        const kungfu::yijinjing::data::location_ptr &location, uint32_t dest) {};
 
   // 逐笔委托更新回调
   //@param entrust           逐笔委托数据
   virtual void on_entrust(Context_ptr &context, const longfist::types::Entrust &entrust,
-                          const kungfu::yijinjing::data::location_ptr &location, uint32_t dest){};
+                          const kungfu::yijinjing::data::location_ptr &location, uint32_t dest) {};
 
   // 逐笔成交更新回调
   //@param transaction       逐笔成交数据
   virtual void on_transaction(Context_ptr &context, const longfist::types::Transaction &transaction,
-                              const kungfu::yijinjing::data::location_ptr &location, uint32_t dest){};
+                              const kungfu::yijinjing::data::location_ptr &location, uint32_t dest) {};
 
   // 行情数据更新回调
   // @param tree              行情数据
   // @param location          数据来源
   virtual void on_tree(Context_ptr &context, const longfist::types::Tree &tree,
-                       const kungfu::yijinjing::data::location_ptr &location, uint32_t dest){};
+                       const kungfu::yijinjing::data::location_ptr &location, uint32_t dest) {};
 
   // 行情数据更新回调
   // @param depth              行情数据
   // @param location          数据来源
   virtual void on_depth(Context_ptr &context, const longfist::types::Depth &depth,
-                        const kungfu::yijinjing::data::location_ptr &location, uint32_t dest){};
+                        const kungfu::yijinjing::data::location_ptr &location, uint32_t dest) {};
 
   // 行情数据更新回调
   // @param tick              行情数据
   // @param location          数据来源
   virtual void on_tick(Context_ptr &context, const longfist::types::Tick &tick,
-                       const kungfu::yijinjing::data::location_ptr &location, uint32_t dest){};
+                       const kungfu::yijinjing::data::location_ptr &location, uint32_t dest) {};
 
   // 用于做行情转录时的任意类型行情事件回调, 考虑不提供python binding
   //@param event md发布的任意类型行情事件
-  virtual void on_event(Context_ptr &context, const event_ptr &event){};
+  virtual void on_event(Context_ptr &context, const event_ptr &event) {};
 
   // Operator publish 的 synthetic_data 回调
   //@param synthetic_data   Operator publish 的 synthetic_data
   virtual void on_synthetic_data(Context_ptr &context, const longfist::types::SyntheticData &synthetic_data,
-                                 const kungfu::yijinjing::data::location_ptr &location, uint32_t dest){};
+                                 const kungfu::yijinjing::data::location_ptr &location, uint32_t dest) {};
 
   // 断开回调
   //@param deregister     断开数据
   virtual void on_deregister(Context_ptr &context, const longfist::types::Deregister &deregister,
-                             const kungfu::yijinjing::data::location_ptr &location){};
+                             const kungfu::yijinjing::data::location_ptr &location) {};
 
   // 客户端状态变化回调
   //@param broker_state_update     状态变化
   virtual void on_broker_state_change(Context_ptr &context,
                                       const longfist::types::BrokerStateUpdate &broker_state_update,
-                                      const kungfu::yijinjing::data::location_ptr &location){};
+                                      const kungfu::yijinjing::data::location_ptr &location) {};
 
   // 订阅的其他算子器状态变化回调
   //@param operator_state_update     状态变化
   virtual void on_operator_state_change(Context_ptr &context,
                                         const longfist::types::OperatorStateUpdate &operator_state_update,
-                                        const kungfu::yijinjing::data::location_ptr &location){};
+                                        const kungfu::yijinjing::data::location_ptr &location) {};
 };
 
 DECLARE_PTR(Operator)

--- a/framework/core/src/libwingchun/include/kungfu/wingchun/orderbook/orderbooks.h
+++ b/framework/core/src/libwingchun/include/kungfu/wingchun/orderbook/orderbooks.h
@@ -95,7 +95,7 @@ public:
   [[nodiscard]] longfist::enums::Side get_side() const { return side_; }
 
 protected:
-  explicit OrderbookSide(longfist::enums::Side side) : side_(side){};
+  explicit OrderbookSide(longfist::enums::Side side) : side_(side) {};
 
 private:
   longfist::enums::Side side_;

--- a/framework/core/src/libwingchun/include/kungfu/wingchun/strategy/backtest.h
+++ b/framework/core/src/libwingchun/include/kungfu/wingchun/strategy/backtest.h
@@ -361,7 +361,7 @@ private:
     int64_t nanotime;
     std::function<void(event_ptr)> call_back;
     TimerTask(int32_t id, int64_t nanotime, std::function<void(event_ptr)> cb)
-        : timer_id(id), nanotime(nanotime), call_back(std::move(cb)){};
+        : timer_id(id), nanotime(nanotime), call_back(std::move(cb)) {};
     bool operator<(const TimerTask &other) const { return other.nanotime < this->nanotime; }
   };
 

--- a/framework/core/src/libwingchun/include/kungfu/wingchun/strategy/context.h
+++ b/framework/core/src/libwingchun/include/kungfu/wingchun/strategy/context.h
@@ -101,7 +101,7 @@ public:
    * @param exchange_id exchange ID
    */
   virtual void unsubscribe(const std::string &source, const std::vector<std::string> &instrument_ids,
-                           const std::string &exchange_id){};
+                           const std::string &exchange_id) {};
 
   /**
    * Subscribe all from given MD
@@ -359,14 +359,14 @@ public:
    * request deregister.
    * @return void
    */
-  virtual void req_deregister(){};
+  virtual void req_deregister() {};
 
   /**
    * Update Strategy State
    * @param state StrategyState
    * @param infos vector<string>, info_a, info_b, info_c.
    */
-  virtual void update_strategy_state(longfist::types::StrategyStateUpdate &state_update){};
+  virtual void update_strategy_state(longfist::types::StrategyStateUpdate &state_update) {};
 
   /**
    *
@@ -380,7 +380,7 @@ public:
    * @param resume_policy
    * @return void
    */
-  virtual void set_resume_policy(longfist::enums::ResumePolicy resume_policy){};
+  virtual void set_resume_policy(longfist::enums::ResumePolicy resume_policy) {};
 
   /**
    *
@@ -414,11 +414,11 @@ protected:
   std::string strategy_dir_;
   bool started_ = false;
 
-  virtual void on_start(){};
+  virtual void on_start() {};
 
   virtual void prepare(const event_ptr &event) = 0;
 
-  virtual void post_stop(){};
+  virtual void post_stop() {};
 
 private:
   bool book_held_ = false;

--- a/framework/core/src/libwingchun/include/kungfu/wingchun/strategy/matcher.h
+++ b/framework/core/src/libwingchun/include/kungfu/wingchun/strategy/matcher.h
@@ -17,38 +17,38 @@ public:
 
   // 行情数据更新回调
   //@param quote             行情数据
-  virtual void on_quote(const longfist::types::Quote &quote){};
+  virtual void on_quote(const longfist::types::Quote &quote) {};
 
   // 逐笔委托更新回调
   //@param entrust           逐笔委托数据
-  virtual void on_entrust(const longfist::types::Entrust &entrust){};
+  virtual void on_entrust(const longfist::types::Entrust &entrust) {};
 
   // 逐笔成交更新回调
   //@param transaction       逐笔成交数据
-  virtual void on_transaction(const longfist::types::Transaction &transaction){};
+  virtual void on_transaction(const longfist::types::Transaction &transaction) {};
 
   // 行情数据更新回调
   // @param tree              行情数据
   // @param location          数据来源
-  virtual void on_tree(const longfist::types::Tree &tree){};
+  virtual void on_tree(const longfist::types::Tree &tree) {};
 
   // 行情数据更新回调
   // @param tree              行情数据
   // @param location          数据来源
-  virtual void on_depth(const longfist::types::Depth &depth){};
+  virtual void on_depth(const longfist::types::Depth &depth) {};
 
   // 行情数据更新回调
   // @param tree              行情数据
   // @param location          数据来源
-  virtual void on_tick(const longfist::types::Tick &tick){};
+  virtual void on_tick(const longfist::types::Tick &tick) {};
 
   // 订单信息更新回调
   //@param order             订单信息数据
-  virtual void on_order_input(const longfist::types::OrderInput &order_input){};
+  virtual void on_order_input(const longfist::types::OrderInput &order_input) {};
 
   // 订单操作回调
   //@param order             订单信息数据
-  virtual void on_order_action(const longfist::types::OrderAction &order_action){};
+  virtual void on_order_action(const longfist::types::OrderAction &order_action) {};
 
   void update_order(const longfist::types::Order &order);
 

--- a/framework/core/src/libwingchun/include/kungfu/wingchun/strategy/strategy.h
+++ b/framework/core/src/libwingchun/include/kungfu/wingchun/strategy/strategy.h
@@ -18,150 +18,150 @@ public:
   virtual ~Strategy() = default;
 
   // 运行前
-  virtual void pre_start(Context_ptr &context){};
+  virtual void pre_start(Context_ptr &context) {};
 
-  virtual void post_start(Context_ptr &context){};
+  virtual void post_start(Context_ptr &context) {};
 
   // 退出前
-  virtual void pre_stop(Context_ptr &context){};
+  virtual void pre_stop(Context_ptr &context) {};
 
-  virtual void post_stop(Context_ptr &context){};
+  virtual void post_stop(Context_ptr &context) {};
 
   // 行情数据更新回调
   // @param quote             行情数据
   // @param location          数据来源
   virtual void on_quote(Context_ptr &context, const longfist::types::Quote &quote,
-                        const kungfu::yijinjing::data::location_ptr &location, uint32_t dest){};
+                        const kungfu::yijinjing::data::location_ptr &location, uint32_t dest) {};
 
   // 行情数据更新回调
   // @param tree              行情数据
   // @param location          数据来源
   virtual void on_tree(Context_ptr &context, const longfist::types::Tree &tree,
-                       const kungfu::yijinjing::data::location_ptr &location, uint32_t dest){};
+                       const kungfu::yijinjing::data::location_ptr &location, uint32_t dest) {};
 
   // 行情数据更新回调
   // @param tree              行情数据
   // @param location          数据来源
   virtual void on_depth(Context_ptr &context, const longfist::types::Depth &depth,
-                        const kungfu::yijinjing::data::location_ptr &location, uint32_t dest){};
+                        const kungfu::yijinjing::data::location_ptr &location, uint32_t dest) {};
 
   // 行情数据更新回调
   // @param tree              行情数据
   // @param location          数据来源
   virtual void on_tick(Context_ptr &context, const longfist::types::Tick &tick,
-                       const kungfu::yijinjing::data::location_ptr &location, uint32_t dest){};
+                       const kungfu::yijinjing::data::location_ptr &location, uint32_t dest) {};
 
   // 逐笔委托更新回调
   // @param entrust           逐笔委托数据
   // @param location          数据来源
   virtual void on_entrust(Context_ptr &context, const longfist::types::Entrust &entrust,
-                          const kungfu::yijinjing::data::location_ptr &location, uint32_t dest){};
+                          const kungfu::yijinjing::data::location_ptr &location, uint32_t dest) {};
 
   // 逐笔成交更新回调
   // @param transaction       逐笔成交数据
   // @param location          数据来源
   virtual void on_transaction(Context_ptr &context, const longfist::types::Transaction &transaction,
-                              const kungfu::yijinjing::data::location_ptr &location, uint32_t dest){};
+                              const kungfu::yijinjing::data::location_ptr &location, uint32_t dest) {};
 
   // Operator publish 的 synthetic_data 回调
   //@param synthetic_data   Operator publish 的 synthetic_data
   virtual void on_synthetic_data(Context_ptr &context, const longfist::types::SyntheticData &synthetic_data,
-                                 const kungfu::yijinjing::data::location_ptr &location, uint32_t dest){};
+                                 const kungfu::yijinjing::data::location_ptr &location, uint32_t dest) {};
 
   // 订单信息更新回调
   // @param order             订单信息数据
   // @param location          数据来源
   virtual void on_order(Context_ptr &context, const longfist::types::Order &order,
-                        const kungfu::yijinjing::data::location_ptr &location, uint32_t dest){};
+                        const kungfu::yijinjing::data::location_ptr &location, uint32_t dest) {};
 
   // 预埋单或者条件单信息更新回调
   // @param order_trigger     触发器信息
   // @param location          数据来源
   virtual void on_order_trigger(Context_ptr &context, const longfist::types::OrderTrigger &order_trigger,
-                                const kungfu::yijinjing::data::location_ptr &location, uint32_t dest){};
+                                const kungfu::yijinjing::data::location_ptr &location, uint32_t dest) {};
 
   // 算法单回调
   // @param algo_order    算法单信息
   // @param location          数据来源
   virtual void on_algo_order(Context_ptr &context, const longfist::types::AlgoOrder &algo_order,
-                             const kungfu::yijinjing::data::location_ptr &location, uint32_t dest){};
+                             const kungfu::yijinjing::data::location_ptr &location, uint32_t dest) {};
 
   // 订单操作错误回调
   // @param order             订单信息数据
   // @param location          数据来源
   virtual void on_order_action_error(Context_ptr &context, const longfist::types::OrderActionError &error,
-                                     const kungfu::yijinjing::data::location_ptr &location, uint32_t dest){};
+                                     const kungfu::yijinjing::data::location_ptr &location, uint32_t dest) {};
 
   // 订单操作错误回调
   // @param order             订单信息数据
   // @param location          数据来源
   virtual void on_order_trigger_action_error(Context_ptr &context,
                                              const longfist::types::OrderTriggerActionError &error,
-                                             const kungfu::yijinjing::data::location_ptr &location, uint32_t dest){};
+                                             const kungfu::yijinjing::data::location_ptr &location, uint32_t dest) {};
 
   virtual void on_algo_order_action_error(Context_ptr &context, const longfist::types::AlgoOrderActionError &error,
-                                          const kungfu::yijinjing::data::location_ptr &location, uint32_t dest){};
+                                          const kungfu::yijinjing::data::location_ptr &location, uint32_t dest) {};
 
   // 订单成交回报回调
   // @param trade             订单成交数据
   // @param location          数据来源
   virtual void on_trade(Context_ptr &context, const longfist::types::Trade &trade,
-                        const kungfu::yijinjing::data::location_ptr &location, uint32_t dest){};
+                        const kungfu::yijinjing::data::location_ptr &location, uint32_t dest) {};
 
   // 历史订单回报回调
   // @param history_order     历史订单数据
   // @param location          数据来源
   virtual void on_history_order(Context_ptr &context, const longfist::types::HistoryOrder &history_order,
-                                const kungfu::yijinjing::data::location_ptr &location, uint32_t dest){};
+                                const kungfu::yijinjing::data::location_ptr &location, uint32_t dest) {};
 
   // 历史订单成交回报回调
   // @param history_order     历史订单成交数据
   // @param location          数据来源
   virtual void on_history_trade(Context_ptr &context, const longfist::types::HistoryTrade &history_trade,
-                                const kungfu::yijinjing::data::location_ptr &location, uint32_t dest){};
+                                const kungfu::yijinjing::data::location_ptr &location, uint32_t dest) {};
 
   // 历史订单查询报错回调
   // @param error              报错信息
   // @param location          数据来源
   virtual void on_req_history_order_error(Context_ptr &context, const longfist::types::RequestHistoryOrderError &error,
-                                          const kungfu::yijinjing::data::location_ptr &location, uint32_t dest){};
+                                          const kungfu::yijinjing::data::location_ptr &location, uint32_t dest) {};
 
   // 历史成交查询报错回调
   // @param error              报错信息
   // @param location          数据来源
   virtual void on_req_history_trade_error(Context_ptr &context, const longfist::types::RequestHistoryTradeError &error,
-                                          const kungfu::yijinjing::data::location_ptr &location, uint32_t dest){};
+                                          const kungfu::yijinjing::data::location_ptr &location, uint32_t dest) {};
 
   // 同步柜台资金持仓信息回调
   // @param old_book          更新前本地维护的旧数据
   // @param new_book          更新后重新从柜台获取的新数据
   virtual void on_position_sync_reset(Context_ptr &context, const kungfu::wingchun::book::Book &old_book,
-                                      const kungfu::wingchun::book::Book &new_book){};
+                                      const kungfu::wingchun::book::Book &new_book) {};
 
   // 同步柜台资金信息回调
   // @param old_asset         更新前本地维护的旧数据
   // @param new_asset         更新后重新从柜台获取的新数据
   virtual void on_asset_sync_reset(Context_ptr &context, const kungfu::longfist::types::Asset &old_asset,
-                                   const kungfu::longfist::types::Asset &new_asset){};
+                                   const kungfu::longfist::types::Asset &new_asset) {};
 
   // 断开回调
   // @param deregister     断开数据
   // @param location          数据来源
   virtual void on_deregister(Context_ptr &context, const longfist::types::Deregister &deregister,
-                             const kungfu::yijinjing::data::location_ptr &location){};
+                             const kungfu::yijinjing::data::location_ptr &location) {};
 
   // 客户端状态变化回调
   // @param brokerStateUpdate     状态变化
   // @param location          数据来源
   virtual void on_broker_state_change(Context_ptr &context,
                                       const longfist::types::BrokerStateUpdate &broker_state_update,
-                                      const kungfu::yijinjing::data::location_ptr &location){};
+                                      const kungfu::yijinjing::data::location_ptr &location) {};
 
   // 订阅的其他算子器状态变化回调
   //@param operator_state_update     状态变化
   virtual void on_operator_state_change(Context_ptr &context,
                                         const longfist::types::OperatorStateUpdate &operator_state_update,
-                                        const kungfu::yijinjing::data::location_ptr &location){};
+                                        const kungfu::yijinjing::data::location_ptr &location) {};
 
   /**
    * 自定义数据回调, 如果数据的msg_type不在AllTypes, 则会通过此函数响应
@@ -172,7 +172,7 @@ public:
    * @param location 数据来源
    */
   virtual void on_custom_data(Context_ptr &context, uint32_t msg_type, const std::vector<uint8_t> &data,
-                              uint32_t length, const kungfu::yijinjing::data::location_ptr &location, uint32_t dest){};
+                              uint32_t length, const kungfu::yijinjing::data::location_ptr &location, uint32_t dest) {};
 };
 
 DECLARE_PTR(Strategy)

--- a/framework/core/src/libwingchun/include/kungfu/wingchun/tool/cachetool.h
+++ b/framework/core/src/libwingchun/include/kungfu/wingchun/tool/cachetool.h
@@ -28,7 +28,7 @@ public:
 
   yijinjing::data::location_ptr get_location() const { return cache_location_; }
 
-  virtual void run(){};
+  virtual void run() {};
 
   template <typename T> void write_at(int64_t gen_time, int64_t trigger_time, uint32_t dest_id, const T &data) {
     valid_time(gen_time, trigger_time);

--- a/framework/core/src/libwingchun/include/kungfu/wingchun/tool/report.h
+++ b/framework/core/src/libwingchun/include/kungfu/wingchun/tool/report.h
@@ -20,7 +20,7 @@ public:
   book::Bookkeeper *get_bookkeeper() const { return bookkeeper_; };
 
   // 初始化
-  virtual void init(){};
+  virtual void init() {};
 
   // 报告撰写
   //@return 报告文本
@@ -28,43 +28,43 @@ public:
 
   // 行情数据更新回调
   //@param quote             行情数据
-  virtual void on_quote(const longfist::types::Quote &quote){};
+  virtual void on_quote(const longfist::types::Quote &quote) {};
 
   // 逐笔委托更新回调
   //@param entrust           逐笔委托数据
-  virtual void on_entrust(const longfist::types::Entrust &entrust){};
+  virtual void on_entrust(const longfist::types::Entrust &entrust) {};
 
   // 逐笔成交更新回调
   //@param transaction       逐笔成交数据
-  virtual void on_transaction(const longfist::types::Transaction &transaction){};
+  virtual void on_transaction(const longfist::types::Transaction &transaction) {};
 
   // 行情数据更新回调
   // @param tree              行情数据
-  virtual void on_tree(const longfist::types::Tree &tree){};
+  virtual void on_tree(const longfist::types::Tree &tree) {};
 
   // 行情数据更新回调
   // @param depth 行情数据
-  virtual void on_depth(const longfist::types::Depth &depth){};
+  virtual void on_depth(const longfist::types::Depth &depth) {};
 
   // 行情数据更新回调
   // @param tick              行情数据
-  virtual void on_tick(const longfist::types::Tick &tick){};
+  virtual void on_tick(const longfist::types::Tick &tick) {};
 
   // 接收合成数据更新回调
   // @param synthetic_data    合成数据
-  virtual void on_read_synthetic_data(const longfist::types::SyntheticData &synthetic_data){};
+  virtual void on_read_synthetic_data(const longfist::types::SyntheticData &synthetic_data) {};
 
   // 发出合成数据更新回调
   // @param synthetic_data    合成数据
-  virtual void on_write_synthetic_data(const longfist::types::SyntheticData &synthetic_data){};
+  virtual void on_write_synthetic_data(const longfist::types::SyntheticData &synthetic_data) {};
 
   // 订单信息更新回调
   // @param order             订单信息数据
-  virtual void on_order(const longfist::types::Order &order){};
+  virtual void on_order(const longfist::types::Order &order) {};
 
   // 订单成交回报回调
   // @param trade             订单成交数据
-  virtual void on_trade(const longfist::types::Trade &trade){};
+  virtual void on_trade(const longfist::types::Trade &trade) {};
 
   int64_t now() const { return app_->now(); };
 

--- a/framework/core/src/libwingchun/include/kungfu/wingchun/tool/slicetool.h
+++ b/framework/core/src/libwingchun/include/kungfu/wingchun/tool/slicetool.h
@@ -27,7 +27,7 @@ public:
 
   std::string get_arguments() const { return arguments_; }
 
-  virtual void run(){};
+  virtual void run() {};
 
   template <typename DataType, std::enable_if_t<longfist::is_market_data<DataType>()>...>
   void write_at(int64_t gen_time, int64_t trigger_time, uint32_t dest_id, const DataType &data) {

--- a/framework/core/src/libyijinjing/include/kungfu/common.h
+++ b/framework/core/src/libyijinjing/include/kungfu/common.h
@@ -64,9 +64,9 @@ using namespace boost::hana::literals;
     static constexpr auto timestamp_key = TIMESTAMP_KEY;                                                               \
     static constexpr bool has_timestamp = boost::hana::is_just(TIMESTAMP_KEY);                                         \
     static constexpr bool has_data = true;                                                                             \
-    NAME(){};                                                                                                          \
+    NAME() {};                                                                                                         \
     explicit NAME(const char *address, const uint32_t length) { parse(address, length); };                             \
-    explicit NAME(const std::string &text) : NAME(text.c_str(), text.length()){};                                      \
+    explicit NAME(const std::string &text) : NAME(text.c_str(), text.length()) {};                                     \
     BOOST_HANA_DEFINE_STRUCT(NAME, __VA_ARGS__);                                                                       \
   }
 

--- a/framework/core/src/libyijinjing/include/kungfu/yijinjing/journal/assemble.h
+++ b/framework/core/src/libyijinjing/include/kungfu/yijinjing/journal/assemble.h
@@ -20,7 +20,7 @@ public:
   sink();
   virtual ~sink() = default;
   virtual void put(const data::location_ptr &location, uint32_t dest_id, const frame_ptr &frame) = 0;
-  virtual void close(){};
+  virtual void close() {};
   uint64_t find_page_size(const data::location_ptr &location, uint32_t dest_id);
 
   [[nodiscard]] publisher_ptr get_publisher();
@@ -35,7 +35,7 @@ DECLARE_PTR(sink)
 class null_sink : public sink {
 public:
   null_sink() = default;
-  void put(const data::location_ptr &location, uint32_t dest_id, const frame_ptr &frame) override{};
+  void put(const data::location_ptr &location, uint32_t dest_id, const frame_ptr &frame) override {};
 };
 
 class copy_sink : public sink {

--- a/framework/core/src/libyijinjing/include/kungfu/yijinjing/journal/bus.h
+++ b/framework/core/src/libyijinjing/include/kungfu/yijinjing/journal/bus.h
@@ -6,7 +6,7 @@ namespace kungfu::yijinjing::journal {
 
 class bus {
 public:
-  explicit bus(const bool on_load_page_required) : on_load_page_required_(on_load_page_required){};
+  explicit bus(const bool on_load_page_required) : on_load_page_required_(on_load_page_required) {};
 
   virtual ~bus() = default;
 

--- a/framework/core/uv.lock
+++ b/framework/core/uv.lock
@@ -166,6 +166,31 @@ wheels = [
 ]
 
 [[package]]
+name = "clang-format"
+version = "20.1.8"
+source = { registry = "http://192.168.100.222:3141/root/pypi/+simple/" }
+sdist = { url = "http://192.168.100.222:3141/root/pypi/+f/8eb/d717257d8c7da/clang_format-20.1.8.tar.gz", hash = "sha256:8ebd717257d8c7daf6bb1f703a4024f009a58941723eeb0d92ec493ce26aa520" }
+wheels = [
+    { url = "http://192.168.100.222:3141/root/pypi/+f/e94/22bc81b3bea6c/clang_format-20.1.8-py2.py3-none-macosx_10_9_x86_64.whl", hash = "sha256:e9422bc81b3bea6c0ee773662fbe3bfd8a9479ae70e59008095dfae7001c5a84" },
+    { url = "http://192.168.100.222:3141/root/pypi/+f/c0c/f62720247a7dd/clang_format-20.1.8-py2.py3-none-macosx_11_0_arm64.whl", hash = "sha256:c0cf62720247a7dd1e2d610816a2f7d7016433f9c2869880cba655449bd09616" },
+    { url = "http://192.168.100.222:3141/root/pypi/+f/4f9/98e5c19e10f69/clang_format-20.1.8-py2.py3-none-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:4f998e5c19e10f69b87af6991ccb14db934b5fa36fd28c7dbfc17dee957007f4" },
+    { url = "http://192.168.100.222:3141/root/pypi/+f/34d/e32fe53452a07/clang_format-20.1.8-py2.py3-none-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:34de32fe53452a07497793d5faf3fd03f7cf8b960b915417471ae81227461a39" },
+    { url = "http://192.168.100.222:3141/root/pypi/+f/139/7b1b700ee78af/clang_format-20.1.8-py2.py3-none-manylinux_2_27_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1397b1b700ee78af73b14c5d65ad777c570c79a175c220768056fbcb7afed113" },
+    { url = "http://192.168.100.222:3141/root/pypi/+f/e19/5b5f6b79d89d4/clang_format-20.1.8-py2.py3-none-manylinux_2_27_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e195b5f6b79d89d42d4094d103f0a4f47ff3997d6474811622b95ab596f01fd2" },
+    { url = "http://192.168.100.222:3141/root/pypi/+f/7c6/bcb7e01ba4f05/clang_format-20.1.8-py2.py3-none-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7c6bcb7e01ba4f05a4c980fda147b330f7e4833c2aea8c92a0c2df9573ae7afe" },
+    { url = "http://192.168.100.222:3141/root/pypi/+f/d99/a5f3d7a252ab7/clang_format-20.1.8-py2.py3-none-manylinux_2_31_armv7l.whl", hash = "sha256:d99a5f3d7a252ab762ed79bc2a271a63fe593ae2e2565ce287835c00ce13c37e" },
+    { url = "http://192.168.100.222:3141/root/pypi/+f/0a6/87c6efd770822/clang_format-20.1.8-py2.py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:0a687c6efd7708227eafec37e98143e0b4b7dbeca82ff8e1de110d434f4e63ac" },
+    { url = "http://192.168.100.222:3141/root/pypi/+f/d64/91195d8edc788/clang_format-20.1.8-py2.py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:d6491195d8edc788de8abfaea30b78ff74ad3f5ee89653cd0a27a4af4feb1317" },
+    { url = "http://192.168.100.222:3141/root/pypi/+f/9ce/ae6a1fbd594ec/clang_format-20.1.8-py2.py3-none-musllinux_1_2_i686.whl", hash = "sha256:9ceae6a1fbd594ec2a31157997378b70df42273795a0177be0725a4e96336231" },
+    { url = "http://192.168.100.222:3141/root/pypi/+f/941/396455b529ca1/clang_format-20.1.8-py2.py3-none-musllinux_1_2_ppc64le.whl", hash = "sha256:941396455b529ca130fae24d6d95bdf9a236d2ad22318991090d0b7ae53d236a" },
+    { url = "http://192.168.100.222:3141/root/pypi/+f/8db/bdfce85bdde67/clang_format-20.1.8-py2.py3-none-musllinux_1_2_s390x.whl", hash = "sha256:8dbbdfce85bdde675dee98fdbcddee445e6a9492b2a2b04afabfd33525be5642" },
+    { url = "http://192.168.100.222:3141/root/pypi/+f/abc/1b72f42db5db6/clang_format-20.1.8-py2.py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:abc1b72f42db5db695d539b0a1b3cc3c125dfaa9c5baea0a94a3a2d6d1e50c1f" },
+    { url = "http://192.168.100.222:3141/root/pypi/+f/635/b57361fa3caeb/clang_format-20.1.8-py2.py3-none-win32.whl", hash = "sha256:635b57361fa3caeb9449aa62584d7cd38fbee81dbf3addd6b1d7c377eb34e766" },
+    { url = "http://192.168.100.222:3141/root/pypi/+f/346/ac8cab571eaba/clang_format-20.1.8-py2.py3-none-win_amd64.whl", hash = "sha256:346ac8cab571eaba4d6b89dfa30fdbbc512db82a66ab0eeb1763cacc5977e325" },
+    { url = "http://192.168.100.222:3141/root/pypi/+f/d18/b7b69697e97b6/clang_format-20.1.8-py2.py3-none-win_arm64.whl", hash = "sha256:d18b7b69697e97b6917a69f4bf48bf94e3827b016b491c90dd0f6ab917e37cf9" },
+]
+
+[[package]]
 name = "click"
 version = "8.1.8"
 source = { registry = "http://192.168.100.222:3141/root/pypi/+simple/" }
@@ -461,6 +486,7 @@ dependencies = [
     { name = "cffi", marker = "sys_platform != 'win32'" },
     { name = "chardet" },
     { name = "charset-normalizer" },
+    { name = "clang-format" },
     { name = "click" },
     { name = "colorama", marker = "os_name == 'nt'" },
     { name = "cryptography", marker = "sys_platform == 'linux'" },
@@ -520,6 +546,7 @@ requires-dist = [
     { name = "cffi", marker = "sys_platform != 'win32'", specifier = "==1.17.1" },
     { name = "chardet" },
     { name = "charset-normalizer" },
+    { name = "clang-format", specifier = "==20.1.8" },
     { name = "click", specifier = "~=8.1.7" },
     { name = "colorama", marker = "os_name == 'nt'", specifier = "==0.4.6" },
     { name = "cryptography", marker = "sys_platform == 'linux'", specifier = "==43.0.3" },


### PR DESCRIPTION
Pin clang-format==20.1.8 as a uv-managed dependency (PyPI wheel, same lane as ruff) so C++ formatting is byte-identical across machines. run-format-cpp.js and the pre-commit hook use the uv-provided binary; the C++ tree is reformatted to the pinned version.