### PR TITLE
build: extend format coverage to the whole tree via root biome.json

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -37,8 +37,9 @@ cpp='' py='' web='' corejs=''
 for f in $staged; do
   [ -f "$f" ] || continue          # skip deletions / renamed-away paths
   is_generated "$f" && continue
-  # Dispatch mirrors the packages that define a `format` script; trees without
-  # one (repo-root scripts, framework/api) keep their current coverage.
+  # Repo-wide dispatch: C++ -> clang-format, Python -> ruff, framework/core's own
+  # build scripts -> prettier, everything else JS/TS -> biome (root biome.json,
+  # which ignores generated/, fixtures/, framework/core/ and JSON).
   case "$f" in
     *.h|*.hpp|*.hxx|*.cpp|*.c|*.cc|*.cxx)
       cpp="$cpp $f" ;;
@@ -46,10 +47,8 @@ for f in $staged; do
       py="$py $f" ;;
     framework/core/*.js|framework/core/*.cjs|framework/core/*.mjs)
       corejs="$corejs $f" ;;                 # core build scripts use prettier
-    developer/sdk/*|framework/gui/*|framework/tui/*|framework/kfx/*)
-      case "$f" in                           # biome-managed packages only
-        *.ts|*.tsx|*.js|*.jsx|*.mjs|*.cjs|*.json|*.jsonc) web="$web $f" ;;
-      esac ;;
+    *.ts|*.tsx|*.js|*.jsx|*.mjs|*.cjs)
+      web="$web $f" ;;                        # all other JS/TS -> biome (root config)
   esac
 done
 

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "files": {
+    "ignore": [
+      "**/node_modules/**",
+      "**/out/**",
+      "**/dist/**",
+      "**/build/**",
+      "**/.deps/**",
+      "**/generated/**",
+      "**/fixtures/**",
+      "framework/core/**"
+    ]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 80
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true
+    }
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single",
+      "trailingCommas": "all"
+    }
+  },
+  "json": {
+    "formatter": {
+      "enabled": false
+    }
+  }
+}

--- a/developer/sdk/templates/app/src/renderer/src/main.tsx
+++ b/developer/sdk/templates/app/src/renderer/src/main.tsx
@@ -20,7 +20,9 @@ type KfFrame = {
 };
 
 type Kfe = {
-  Assemble: new (runtimeDirs: string[]) => {
+  Assemble: new (
+    runtimeDirs: string[],
+  ) => {
     dataAvailable: () => boolean;
     next: () => void;
     currentFrame: () => KfFrame;
@@ -68,7 +70,8 @@ function Ledger({ kfe, runtimeDir }: { kfe: Kfe; runtimeDir: string }) {
           const frame = asm.currentFrame();
           let genTime = String(frame.genTime());
           try {
-            if (kfe.formatTime) genTime = kfe.formatTime(frame.genTime(), '%H:%M:%S.%N');
+            if (kfe.formatTime)
+              genTime = kfe.formatTime(frame.genTime(), '%H:%M:%S.%N');
           } catch {
             // keep raw nanoseconds
           }
@@ -95,7 +98,10 @@ function Ledger({ kfe, runtimeDir }: { kfe: Kfe; runtimeDir: string }) {
         ledger events: {rows.length} · runtime home: {runtimeDir}
       </p>
       {rows.slice(-15).map((row, index) => (
-        <div key={`${row.genTime}-${index}`} style={{ ...mono, color: '#9cdcfe' }}>
+        <div
+          key={`${row.genTime}-${index}`}
+          style={{ ...mono, color: '#9cdcfe' }}
+        >
           {row.genTime} · msg {row.msgType} · {row.length} B
         </div>
       ))}

--- a/extensions/system/kfx-manager/src/view/index.tsx
+++ b/extensions/system/kfx-manager/src/view/index.tsx
@@ -128,7 +128,9 @@ function KfxManagerView({ shell }: KfxViewProps) {
                   color: disabled ? '#f48771' : '#4ec9b0',
                 }}
               >
-                {disabled ? 'suite disabled — enable' : 'suite enabled — disable'}
+                {disabled
+                  ? 'suite disabled — enable'
+                  : 'suite enabled — disable'}
               </button>
             )}
           </div>

--- a/framework/api/src/actions/index.ts
+++ b/framework/api/src/actions/index.ts
@@ -25,10 +25,7 @@ import {
   getAllKfRiskSettings,
   setAllKfRiskSettings,
 } from '../kungfu/riskSetting';
-import {
-  basketStore,
-  basketInstrumentStore,
-} from '@kungfu-tech/api/kungfu';
+import { basketStore, basketInstrumentStore } from '@kungfu-tech/api/kungfu';
 
 export const getAllKfConfigOriginData = (
   watcher?: KungfuApi.Watcher,

--- a/framework/api/src/capability/rewind.ts
+++ b/framework/api/src/capability/rewind.ts
@@ -113,7 +113,10 @@ export type OpenRewindOptions = {
 
 const str = (value: string | null | undefined) => value ?? undefined;
 
-function decode(msgType: number, bytes: Uint8Array): Omit<RewindEvent, 'genTime'> | null {
+function decode(
+  msgType: number,
+  bytes: Uint8Array,
+): Omit<RewindEvent, 'genTime'> | null {
   const bb = new flatbuffers.ByteBuffer(bytes);
   switch (msgType) {
     case REWIND_MSG.RunBegin: {
@@ -268,7 +271,9 @@ export function openRewind(options: OpenRewindOptions): Rewind {
       assemble.next();
     }
     for (const events of byRun.values()) {
-      events.sort((a, b) => (a.genTime < b.genTime ? -1 : a.genTime > b.genTime ? 1 : 0));
+      events.sort((a, b) =>
+        a.genTime < b.genTime ? -1 : a.genTime > b.genTime ? 1 : 0,
+      );
     }
     return byRun;
   };
@@ -278,7 +283,10 @@ export function openRewind(options: OpenRewindOptions): Rewind {
     return cache;
   };
 
-  const summarize = (runId: string, events: RewindEvent[]): RewindRunSummary => {
+  const summarize = (
+    runId: string,
+    events: RewindEvent[],
+  ): RewindRunSummary => {
     const begin = events.find((e) => e.kind === 'RunBegin');
     const end = events.find((e) => e.kind === 'RunEnd');
     return {
@@ -307,7 +315,11 @@ export function openRewind(options: OpenRewindOptions): Rewind {
     loadRun: (runId: string) => {
       const events = ensure().get(runId);
       if (!events) return null;
-      return { summary: summarize(runId, events), events, roots: buildTree(events) };
+      return {
+        summary: summarize(runId, events),
+        events,
+        roots: buildTree(events),
+      };
     },
   };
 }

--- a/framework/api/src/capability/sandbox.ts
+++ b/framework/api/src/capability/sandbox.ts
@@ -52,7 +52,8 @@ export function createCapabilityHost(
       const id = arg.__sandboxCallback;
       // a forwarding function: when the real capability calls it, ship the
       // arguments back to the guest's registered callback
-      return (...callbackArgs: unknown[]) => emit({ callback: id, args: callbackArgs });
+      return (...callbackArgs: unknown[]) =>
+        emit({ callback: id, args: callbackArgs });
     });
 
   return {
@@ -65,12 +66,16 @@ export function createCapabilityHost(
       if (typeof fn !== 'function') {
         throw new Error(`capability '${cap}' has no method '${method}'`);
       }
-      const result = (fn as (...a: unknown[]) => unknown).apply(handle, revive(args));
+      const result = (fn as (...a: unknown[]) => unknown).apply(
+        handle,
+        revive(args),
+      );
       // a Subscription-shaped result ({ stop }) is retained host-side and
       // referenced by the callback id the guest sent, so the guest can stop it
       if (result && typeof (result as { stop?: unknown }).stop === 'function') {
         const cbId = args.find(isCallbackRef)?.__sandboxCallback;
-        if (cbId !== undefined) subscriptions.set(cbId, result as { stop: () => void });
+        if (cbId !== undefined)
+          subscriptions.set(cbId, result as { stop: () => void });
         return { __sandboxSubscription: cbId };
       }
       return result;

--- a/framework/api/src/capability/schema.ts
+++ b/framework/api/src/capability/schema.ts
@@ -6,7 +6,12 @@
 // C++ and Python decode a registered kfx event by reflection, and so does the
 // Electron inspector, with no per-schema codegen.
 import * as flatbuffers from 'flatbuffers';
-import { BaseType, Field, Object_, Schema } from './generated/reflection/reflection.js';
+import {
+  BaseType,
+  Field,
+  Object_,
+  Schema,
+} from './generated/reflection/reflection.js';
 
 // (ByteBuffer reader, element width in bytes) per reflection scalar base type.
 type Reader = (bb: flatbuffers.ByteBuffer, pos: number) => unknown;
@@ -57,7 +62,11 @@ export class ReflectionDecoder {
     return out;
   }
 
-  private static readField(bb: flatbuffers.ByteBuffer, pos: number, f: Field): unknown {
+  private static readField(
+    bb: flatbuffers.ByteBuffer,
+    pos: number,
+    f: Field,
+  ): unknown {
     const o = bb.__offset(pos, f.offset());
     const base = f.type()?.baseType();
 
@@ -75,7 +84,9 @@ export class ReflectionDecoder {
       const start = bb.__vector(slot);
       const len = bb.__vector_len(slot);
       if (elem === BaseType.String) {
-        return Array.from({ length: len }, (_, i) => bb.__string(start + i * 4));
+        return Array.from({ length: len }, (_, i) =>
+          bb.__string(start + i * 4),
+        );
       }
       if (elem !== undefined && elem in SCALARS) {
         const [read, w] = SCALARS[elem]!;

--- a/framework/api/src/capability/types.ts
+++ b/framework/api/src/capability/types.ts
@@ -113,7 +113,9 @@ export type KfNativeBinding = {
   Longfist?: new () => {
     types: Record<string, () => Record<string, unknown>>;
   };
-  Assemble: new (runtimeDirs: string[]) => {
+  Assemble: new (
+    runtimeDirs: string[],
+  ) => {
     dataAvailable: () => boolean;
     next: () => void;
     currentFrame: () => KfNativeFrame;
@@ -122,7 +124,9 @@ export type KfNativeBinding = {
     location: Record<string, string>,
     runtimeDir: string,
   ) => { getAllSessions: () => unknown };
-  ConfigStore: new (runtimeDir: string) => {
+  ConfigStore: new (
+    runtimeDir: string,
+  ) => {
     setConfig: (
       category: string,
       group: string,

--- a/framework/api/src/capability/work.ts
+++ b/framework/api/src/capability/work.ts
@@ -111,17 +111,24 @@ export function openWork(options: OpenWorkOptions): Work {
   // Fold the event stream into current items — the same projection the
   // python store computes; state never lives anywhere but the fold.
   const scan = (): Map<string, WorkItem> => {
-    const frames: { genTime: bigint; msgType: number; bytes: Uint8Array }[] = [];
+    const frames: { genTime: bigint; msgType: number; bytes: Uint8Array }[] =
+      [];
     const assemble = new binding.Assemble([runtimeDir]);
     while (assemble.dataAvailable()) {
       const frame = assemble.currentFrame();
       const msgType = frame.msgType();
       if (msgType >= WORK_MSG_MIN && msgType <= WORK_MSG_MAX) {
-        frames.push({ genTime: frame.genTime(), msgType, bytes: frame.dataBytes() });
+        frames.push({
+          genTime: frame.genTime(),
+          msgType,
+          bytes: frame.dataBytes(),
+        });
       }
       assemble.next();
     }
-    frames.sort((a, b) => (a.genTime < b.genTime ? -1 : a.genTime > b.genTime ? 1 : 0));
+    frames.sort((a, b) =>
+      a.genTime < b.genTime ? -1 : a.genTime > b.genTime ? 1 : 0,
+    );
 
     const items = new Map<string, WorkItem>();
     const entry = (workId: string, time: bigint): WorkItem => {
@@ -226,7 +233,11 @@ export function openWork(options: OpenWorkOptions): Work {
     },
     items: () =>
       [...ensure().values()].sort((a, b) =>
-        a.updatedTime < b.updatedTime ? 1 : a.updatedTime > b.updatedTime ? -1 : 0,
+        a.updatedTime < b.updatedTime
+          ? 1
+          : a.updatedTime > b.updatedTime
+            ? -1
+            : 0,
       ),
     item: (workId: string) => ensure().get(workId) ?? null,
   };

--- a/framework/api/src/config/globalSettings.ts
+++ b/framework/api/src/config/globalSettings.ts
@@ -10,10 +10,7 @@ import {
   CodeTabSetting,
   OrderInputKeySetting,
 } from './tradingConfig';
-import {
-  languageList,
-  langDefault,
-} from '@kungfu-tech/api/language';
+import { languageList, langDefault } from '@kungfu-tech/api/language';
 import VueI18n from '@kungfu-tech/api/language';
 import { readRootPackageJsonSync } from '@kungfu-tech/api/utils/fileUtils';
 import { getDefaultHomeDir } from './homePathConfig';

--- a/framework/api/src/config/pathConfig.ts
+++ b/framework/api/src/config/pathConfig.ts
@@ -204,12 +204,14 @@ const staticDevKfcDir = path.resolve('..', 'core', 'dist', 'kungfu');
 export const KUNGFU_PARENT_DIR = production
   ? globalThis.__kfResourcesPath
   : path.dirname(process.env.KUNGFU_DIR || staticDevKfcDir);
-export const KUNGFU_DIR = process.env.KUNGFU_DIR || path.join(KUNGFU_PARENT_DIR, 'kungfu');
+export const KUNGFU_DIR =
+  process.env.KUNGFU_DIR || path.join(KUNGFU_PARENT_DIR, 'kungfu');
 process.env.KUNGFU_DIR = KUNGFU_DIR;
 
 export const PY_WHL_DIR = path.join(KUNGFU_DIR, 'kungfu-wheel');
 
-export const KUNGFU_EXECUTABLE = process.platform === 'win32' ? 'kungfu.exe' : 'kungfu';
+export const KUNGFU_EXECUTABLE =
+  process.platform === 'win32' ? 'kungfu.exe' : 'kungfu';
 export const EXTENSION_DIRS: string[] = Array.from(
   new Set(
     production

--- a/framework/api/src/hooks/lifeCycleHook.ts
+++ b/framework/api/src/hooks/lifeCycleHook.ts
@@ -20,10 +20,13 @@ export class LifeCycleHook {
   }
 
   private buildInitCallbacksMap() {
-    return Object.values(LifeCycleKeys).reduce((map, key) => {
-      map[key] = new Map();
-      return map;
-    }, {} as Record<LifeCycleKeys, Map<string, Array<Callback>>>);
+    return Object.values(LifeCycleKeys).reduce(
+      (map, key) => {
+        map[key] = new Map();
+        return map;
+      },
+      {} as Record<LifeCycleKeys, Map<string, Array<Callback>>>,
+    );
   }
 
   register(

--- a/framework/api/src/hooks/resolveStartProcessOptionsHook.ts
+++ b/framework/api/src/hooks/resolveStartProcessOptionsHook.ts
@@ -11,6 +11,7 @@ export type ResolveStartOptionsHook = (
   options: StartProcessOptions,
 ) => Promise<StartProcessOptions>;
 
-export default new ResetOptionHook<ResolveStartOptionsHook, StartProcessOptions>(
-  'ResolveStartOptionsHook',
-);
+export default new ResetOptionHook<
+  ResolveStartOptionsHook,
+  StartProcessOptions
+>('ResolveStartOptionsHook');

--- a/framework/api/src/language/translator.ts
+++ b/framework/api/src/language/translator.ts
@@ -116,7 +116,10 @@ export const createTranslator = (options: {
     messages: state.messages,
     t,
     mergeLocaleMessage: (locale: string, messages: LocaleMessages) => {
-      state.messages[locale] = deepMerge(state.messages[locale] ?? {}, messages);
+      state.messages[locale] = deepMerge(
+        state.messages[locale] ?? {},
+        messages,
+      );
     },
   };
 

--- a/framework/api/src/typings/index.d.ts
+++ b/framework/api/src/typings/index.d.ts
@@ -111,8 +111,8 @@ declare namespace KungfuApi {
   type FunctionOrData<U extends 'func' | 'data', T> = U extends 'func'
     ? () => T
     : U extends 'data'
-    ? T
-    : never;
+      ? T
+      : never;
 
   export type KfConfigItemSupportedTypes =
     | 'str'

--- a/framework/api/src/utils/busiUtils.ts
+++ b/framework/api/src/utils/busiUtils.ts
@@ -410,7 +410,9 @@ export const dealDateToNanotimeRange = (
 
   const startTime = (
     isTradingDay
-      ? day.add(dayOfWeek === 1 ? -3 : -1, 'day').hour(15) // last trading day 15:00
+      ? day
+          .add(dayOfWeek === 1 ? -3 : -1, 'day')
+          .hour(15) // last trading day 15:00
       : day.hour(0)
   )
     .minute(0)
@@ -514,15 +516,18 @@ export const dealAppStates = (
     return {} as Record<string, BrokerStateStatusTypes>;
   }
 
-  return Object.keys(appStates || {}).reduce((appStatesResolved, key) => {
-    const kfLocation = watcher.getLocation(key);
-    const processId = getProcessIdByKfLocation(kfLocation);
-    const appStateValue = appStates[key];
-    appStatesResolved[processId] = BrokerStateStatusEnum[
-      appStateValue
-    ] as BrokerStateStatusTypes;
-    return appStatesResolved;
-  }, {} as Record<string, BrokerStateStatusTypes>);
+  return Object.keys(appStates || {}).reduce(
+    (appStatesResolved, key) => {
+      const kfLocation = watcher.getLocation(key);
+      const processId = getProcessIdByKfLocation(kfLocation);
+      const appStateValue = appStates[key];
+      appStatesResolved[processId] = BrokerStateStatusEnum[
+        appStateValue
+      ] as BrokerStateStatusTypes;
+      return appStatesResolved;
+    },
+    {} as Record<string, BrokerStateStatusTypes>,
+  );
 };
 
 export const dealStrategyStates = (
@@ -557,17 +562,20 @@ export const dealAssetsByHolderUID = <T extends KungfuApi.Asset>(
     return {} as Record<string, T>;
   }
 
-  return Object.values(assets).reduce((assetsResolved, asset) => {
-    const { holder_uid } = asset;
-    const kfLocation = watcher.getLocation(holder_uid);
+  return Object.values(assets).reduce(
+    (assetsResolved, asset) => {
+      const { holder_uid } = asset;
+      const kfLocation = watcher.getLocation(holder_uid);
 
-    if (kfLocation) {
-      const processId = getProcessIdByKfLocation(kfLocation);
-      assetsResolved[processId] = asset;
-    }
+      if (kfLocation) {
+        const processId = getProcessIdByKfLocation(kfLocation);
+        assetsResolved[processId] = asset;
+      }
 
-    return assetsResolved;
-  }, {} as Record<string, T>);
+      return assetsResolved;
+    },
+    {} as Record<string, T>,
+  );
 };
 
 export const dealOrderTradingData = <T>(
@@ -844,12 +852,12 @@ export const initFormStateByConfig = (
       return isBoolean
         ? false
         : isNumber
-        ? 0
-        : isTime
-        ? null
-        : isArray
-        ? []
-        : '';
+          ? 0
+          : isTime
+            ? null
+            : isArray
+              ? []
+              : '';
     };
 
     if (typeof item?.default === 'object') {
@@ -880,8 +888,8 @@ export const initFormStateByConfig = (
         defaultValue === 'true'
           ? true
           : defaultValue === 'false'
-          ? false
-          : !!defaultValue;
+            ? false
+            : !!defaultValue;
     } else if (KfConfigValueNumberType.includes(type)) {
       defaultValue = +defaultValue;
     } else if (KfConfigValueArrayType.includes(type)) {

--- a/framework/api/src/utils/commonUtils.ts
+++ b/framework/api/src/utils/commonUtils.ts
@@ -700,17 +700,20 @@ export const buildObjectFromArray = <T>(
   targetKey: number | string,
   targetValueKey?: number | string,
 ): Record<string | number, T | T[keyof T] | undefined> => {
-  return list.reduce((item1, item2) => {
-    const key: number | string | symbol = (item2 || {})[targetKey] || '';
-    if (key !== '' && key !== undefined) {
-      if (targetValueKey === undefined) {
-        item1[key] = item2;
-      } else {
-        item1[key] = (item2 || {})[targetValueKey];
+  return list.reduce(
+    (item1, item2) => {
+      const key: number | string | symbol = (item2 || {})[targetKey] || '';
+      if (key !== '' && key !== undefined) {
+        if (targetValueKey === undefined) {
+          item1[key] = item2;
+        } else {
+          item1[key] = (item2 || {})[targetValueKey];
+        }
       }
-    }
-    return item1;
-  }, {} as Record<string | number, T | T[keyof T] | undefined>);
+      return item1;
+    },
+    {} as Record<string | number, T | T[keyof T] | undefined>,
+  );
 };
 
 export const timestampToTimeString = (
@@ -838,10 +841,13 @@ export const kfConfigItemsToProcessArgs = (
       .filter((item) => {
         return formState[item.key] !== undefined;
       })
-      .reduce((pre, item) => {
-        pre[item.key] = formState[item.key];
-        return pre;
-      }, {} as Record<string, KungfuApi.KfConfigValue>),
+      .reduce(
+        (pre, item) => {
+          pre[item.key] = formState[item.key];
+          return pre;
+        },
+        {} as Record<string, KungfuApi.KfConfigValue>,
+      ),
   );
 };
 
@@ -1116,8 +1122,8 @@ export const buildTableColumnSorterWithStrike = <T, U = object>(
       let aVal: string | number | NonNullable<T[keyof T]>;
       let bVal: string | number | NonNullable<T[keyof T]>;
       if (transform) {
-        aVal = isNaN(Number(transform(a))) ? '--' : transform(a) ?? '--';
-        bVal = isNaN(Number(transform(b))) ? '--' : transform(b) ?? '--';
+        aVal = isNaN(Number(transform(a))) ? '--' : (transform(a) ?? '--');
+        bVal = isNaN(Number(transform(b))) ? '--' : (transform(b) ?? '--');
       } else {
         aVal = a[dataIndex as keyof T] ?? '--';
         bVal = b[dataIndex as keyof T] ?? '--';
@@ -1149,10 +1155,13 @@ export const omitObject = <T extends object, U extends Array<keyof T>>(
   const strKeys = keys.map((key) => key.toString());
   return Object.keys(obj)
     .filter((key) => !strKeys.includes(key))
-    .reduce((result, key) => {
-      result[key] = obj[key];
-      return result;
-    }, {} as Omit<T, U[number]>);
+    .reduce(
+      (result, key) => {
+        result[key] = obj[key];
+        return result;
+      },
+      {} as Omit<T, U[number]>,
+    );
 };
 
 export const escapeSpecialChar = (str: string) => {

--- a/framework/api/src/utils/extUtils.ts
+++ b/framework/api/src/utils/extUtils.ts
@@ -188,12 +188,15 @@ export const getKfExtConfigList = async (): Promise<
 
 export const getKfExtOriginConfigsByType = () => {
   return getKfExtConfigList().then((extList) => {
-    return extList.reduce((configsByType, extConfig) => {
-      if (!configsByType[extConfig.type]) configsByType[extConfig.type] = {};
+    return extList.reduce(
+      (configsByType, extConfig) => {
+        if (!configsByType[extConfig.type]) configsByType[extConfig.type] = {};
 
-      configsByType[extConfig.type][extConfig.key] = extConfig;
-      return configsByType;
-    }, {} as Partial<KungfuApi.KfExtOriginConfigs>);
+        configsByType[extConfig.type][extConfig.key] = extConfig;
+        return configsByType;
+      },
+      {} as Partial<KungfuApi.KfExtOriginConfigs>,
+    );
   });
 };
 
@@ -203,13 +206,16 @@ const resolveOrderTriggerConfig = (
   if (originConfig) {
     const orderTriggerOriginConfig = originConfig.td?.order_trigger || {};
     const orderTriggerTypesKeys = Object.keys(OrderTriggerConfigTypeEnum);
-    return Object.keys(orderTriggerOriginConfig).reduce((config, key) => {
-      if (orderTriggerTypesKeys.includes(key)) {
-        config[OrderTriggerConfigTypeEnum[key]] =
-          !!orderTriggerOriginConfig[key];
-      }
-      return config;
-    }, {} as KungfuApi.KfTdExtConfig['orderTrigger']);
+    return Object.keys(orderTriggerOriginConfig).reduce(
+      (config, key) => {
+        if (orderTriggerTypesKeys.includes(key)) {
+          config[OrderTriggerConfigTypeEnum[key]] =
+            !!orderTriggerOriginConfig[key];
+        }
+        return config;
+      },
+      {} as KungfuApi.KfTdExtConfig['orderTrigger'],
+    );
   }
 
   return {} as KungfuApi.KfTdExtConfig['orderTrigger'];
@@ -587,7 +593,7 @@ export const getAvailExtServiceList = async (): Promise<
                 mode: 'live',
                 cwd: config.extPath,
                 script: config.script,
-              } as KungfuApi.KfExtServiceLocation),
+              }) as KungfuApi.KfExtServiceLocation,
           ),
       ];
       return extServiceList;
@@ -620,7 +626,7 @@ export const getAvailCliExtServiceList = async (): Promise<
                 mode: 'live',
                 cwd: config.extPath,
                 script: config.script,
-              } as KungfuApi.KfExtServiceLocation),
+              }) as KungfuApi.KfExtServiceLocation,
           ),
       ];
       return extServiceList;

--- a/framework/api/src/utils/tradingUtils.ts
+++ b/framework/api/src/utils/tradingUtils.ts
@@ -343,8 +343,8 @@ export const getKungfuDataByDateRange = (
     dateType == HistoryDateEnum.naturalDate
       ? dayjs(targetDate).format('YYYY-MM-DD HH:mm:ss')
       : isYesterdayBusinessDay
-      ? dayjs(yesterdayDate).format('YYYY-MM-DD HH:mm:ss')
-      : dayjs(fridayDate).format('YYYY-MM-DD HH:mm:ss');
+        ? dayjs(yesterdayDate).format('YYYY-MM-DD HH:mm:ss')
+        : dayjs(fridayDate).format('YYYY-MM-DD HH:mm:ss');
   let to = dayjs(targetDate).add(1, 'day').format('YYYY-MM-DD HH:mm:ss');
 
   if (dateType == HistoryDateEnum.tradingDate) {
@@ -1202,7 +1202,7 @@ export const getOrderResolved = (
     frozen_price: dealKfDecimalPrecision(order.frozen_price, precision),
     avg_price_resolved: latencyData
       ? dealKfNumber(latencyData.avg_price, tickPrecision || precision)
-      : orderStatResolved?.avg_price ?? '--',
+      : (orderStatResolved?.avg_price ?? '--'),
     status_resolved: {
       name: statusData.name,
       color: statusData.color || 'default',

--- a/framework/gui/electron.vite.config.mjs
+++ b/framework/gui/electron.vite.config.mjs
@@ -14,10 +14,18 @@ const rootDir = dirname(fileURLToPath(import.meta.url));
 //   entries: the shell (index) and the isolated sandboxed-view harness.
 export default defineConfig({
   main: {
-    plugins: [externalizeDepsPlugin({ exclude: ['@kungfu-tech/api', '@kungfu-tech/kfx'] })],
+    plugins: [
+      externalizeDepsPlugin({
+        exclude: ['@kungfu-tech/api', '@kungfu-tech/kfx'],
+      }),
+    ],
   },
   preload: {
-    plugins: [externalizeDepsPlugin({ exclude: ['@kungfu-tech/api', '@kungfu-tech/kfx'] })],
+    plugins: [
+      externalizeDepsPlugin({
+        exclude: ['@kungfu-tech/api', '@kungfu-tech/kfx'],
+      }),
+    ],
     build: {
       rollupOptions: {
         input: {

--- a/framework/kfx/src/index.ts
+++ b/framework/kfx/src/index.ts
@@ -10,20 +10,20 @@
 // managers and installers read them without executing the extension. The
 // code side exports exactly one thing — the View component.
 import type {
-	DomainState,
-	Ledger,
-	Rewind,
-	Work,
-} from "@kungfu-tech/api/capability";
-import type React from "react";
+  DomainState,
+  Ledger,
+  Rewind,
+  Work,
+} from '@kungfu-tech/api/capability';
+import type React from 'react';
 
 // ── capability surface ────────────────────────────────────────────────────
 
 export type KfxCapabilities = {
-	ledger: Ledger;
-	domain: DomainState;
-	rewind: Rewind;
-	work: Work;
+  ledger: Ledger;
+  domain: DomainState;
+  rewind: Rewind;
+  work: Work;
 };
 
 export type KfxCapabilityKey = keyof KfxCapabilities;
@@ -33,31 +33,31 @@ export type KfxCapabilityKey = keyof KfxCapabilities;
 // A settings entry a view contributes to the shell's Settings view. Values
 // are strings; the shell persists them in the runtime home's ConfigStore.
 export type KfxSettingDecl = {
-	key: string;
-	label: string;
-	fallback: string;
+  key: string;
+  label: string;
+  fallback: string;
 };
 
 // `kungfuConfig.config.view` — the static half of a view extension.
 // ADR-0011 trust tier. `node-integrated` (trusted) shares the shell's renderer,
 // React and capability instances; `sandboxed-ipc` runs the view in an isolated
 // renderer with no node, reaching only its declared capabilities over IPC.
-export type KfxRuntimeTier = "node-integrated" | "sandboxed-ipc";
+export type KfxRuntimeTier = 'node-integrated' | 'sandboxed-ipc';
 
 export type KfxViewDecl = {
-	title: string;
-	// capability handles this view receives; undeclared handles stay absent
-	capabilities: KfxCapabilityKey[];
-	// trust tier (default node-integrated). The install source is authoritative
-	// over this hint: a third-party package is never elevated above sandboxed-ipc
-	// just because its manifest asks for node-integrated.
-	runtime?: KfxRuntimeTier;
-	// shell-owned views (settings, kfx manager, status); not disableable
-	system?: boolean;
-	// settings this view contributes to the shell Settings view
-	settings?: KfxSettingDecl[];
-	// bundle entry relative to the package root (default: dist/view/index.js)
-	entry?: string;
+  title: string;
+  // capability handles this view receives; undeclared handles stay absent
+  capabilities: KfxCapabilityKey[];
+  // trust tier (default node-integrated). The install source is authoritative
+  // over this hint: a third-party package is never elevated above sandboxed-ipc
+  // just because its manifest asks for node-integrated.
+  runtime?: KfxRuntimeTier;
+  // shell-owned views (settings, kfx manager, status); not disableable
+  system?: boolean;
+  // settings this view contributes to the shell Settings view
+  settings?: KfxSettingDecl[];
+  // bundle entry relative to the package root (default: dist/view/index.js)
+  entry?: string;
 };
 
 // The single source of the trust decision: what tier a loaded view actually
@@ -65,12 +65,12 @@ export type KfxViewDecl = {
 // installed third-party view is sandboxed unless it is trusted by source, and
 // its manifest may only ask to *stay* sandboxed, never to elevate.
 export function resolveRuntimeTier(
-	view: Pick<KfxViewDecl, "runtime" | "system">,
-	source: "built-in" | "installed",
+  view: Pick<KfxViewDecl, 'runtime' | 'system'>,
+  source: 'built-in' | 'installed',
 ): KfxRuntimeTier {
-	if (view.system || source === "built-in") return "node-integrated";
-	// third-party installed: sandboxed by default; the manifest cannot elevate
-	return "sandboxed-ipc";
+  if (view.system || source === 'built-in') return 'node-integrated';
+  // third-party installed: sandboxed by default; the manifest cannot elevate
+  return 'sandboxed-ipc';
 }
 
 // `kungfuConfig.config.adapter` — a runtime facet. Unlike a view (a GUI screen
@@ -79,15 +79,15 @@ export function resolveRuntimeTier(
 // patches a framework's seam so unmodified runs are captured. It ships source
 // per child runtime (nothing to bundle), not a `dist/view` artifact.
 export type KfxAdapterDecl = {
-	// module import names whose import triggers the patch (informative)
-	targets: string[];
-	// child runtimes this adapter instruments
-	runtimes: ("python" | "node")[];
-	// adapter entry per runtime, relative to the package root
-	entry: { python?: string; node?: string };
-	// capture-side capabilities the adapter needs; undeclared stay absent — the
-	// same permission seam a view's `capabilities` is (reserved for enforcement)
-	capabilities?: string[];
+  // module import names whose import triggers the patch (informative)
+  targets: string[];
+  // child runtimes this adapter instruments
+  runtimes: ('python' | 'node')[];
+  // adapter entry per runtime, relative to the package root
+  entry: { python?: string; node?: string };
+  // capture-side capabilities the adapter needs; undeclared stay absent — the
+  // same permission seam a view's `capabilities` is (reserved for enforcement)
+  capabilities?: string[];
 };
 
 // `kungfuConfig.suite` — a suite groups related kfx for distribution and
@@ -95,69 +95,69 @@ export type KfxAdapterDecl = {
 // versioning. Membership is expressed through npm dependencies; `members`
 // lists the kungfuConfig keys for the shell.
 export type KfxSuiteDecl = {
-	title: string;
-	members: string[];
+  title: string;
+  members: string[];
 };
 
 // ── runtime contract (what the shell hands a mounted view) ────────────────
 
 export type ShellState = {
-	profileId: string;
-	disabledKfx: string[];
-	disabledSuites: string[];
-	settings: Record<string, string>;
+  profileId: string;
+  disabledKfx: string[];
+  disabledSuites: string[];
+  settings: Record<string, string>;
 };
 
 export type ShellRuntimeInfo = {
-	ok: boolean;
-	message: string;
-	runtimeDir: string;
-	kungfuVersion: string;
-	buildInfo: Record<string, unknown> | null;
-	exports: string[];
-	longfistTypes: { name: string; fields: string[] }[];
+  ok: boolean;
+  message: string;
+  runtimeDir: string;
+  kungfuVersion: string;
+  buildInfo: Record<string, unknown> | null;
+  exports: string[];
+  longfistTypes: { name: string; fields: string[] }[];
 };
 
 // One loaded view as the shell sees it: manifest data joined with the code.
 export type KfxEntry = {
-	id: string;
-	title: string;
-	capabilities: KfxCapabilityKey[];
-	system: boolean;
-	settings: KfxSettingDecl[];
-	suite?: string;
-	packageName?: string;
-	version?: string;
-	source: "built-in" | string; // extension root the entry was loaded from
-	// resolved trust tier (resolveRuntimeTier). A node-integrated view carries a
-	// loaded View mounted in the shared renderer; a sandboxed-ipc view carries
-	// only its bundlePath, loaded in an isolated renderer, and View is a
-	// placeholder the shell must not mount directly.
-	tier: KfxRuntimeTier;
-	bundlePath: string;
-	View: KfxViewComponent;
+  id: string;
+  title: string;
+  capabilities: KfxCapabilityKey[];
+  system: boolean;
+  settings: KfxSettingDecl[];
+  suite?: string;
+  packageName?: string;
+  version?: string;
+  source: 'built-in' | string; // extension root the entry was loaded from
+  // resolved trust tier (resolveRuntimeTier). A node-integrated view carries a
+  // loaded View mounted in the shared renderer; a sandboxed-ipc view carries
+  // only its bundlePath, loaded in an isolated renderer, and View is a
+  // placeholder the shell must not mount directly.
+  tier: KfxRuntimeTier;
+  bundlePath: string;
+  View: KfxViewComponent;
 };
 
 export type Shell = {
-	// cross-kfx navigation with parameters; params reach the target view
-	open: (kfxId: string, params?: Record<string, string>) => void;
-	// the params this view was last opened with
-	params: Record<string, string>;
-	// shared refresh bus (one shell-owned timer); returns the unsubscribe
-	onRefresh: (fn: () => void) => () => void;
-	// read a settings value (view-declared or shell-owned), fallback applied
-	setting: (key: string) => string;
-	// persist shell state changes; the shell owns the ConfigStore write
-	updateState: (patch: Partial<ShellState>) => void;
-	state: ShellState;
-	// runtime facts for system views
-	info: ShellRuntimeInfo;
-	// every loaded kfx (for the manager and settings views)
-	registry: KfxEntry[];
-	// suites by key (for grouping and unit enable/disable)
-	suites: Record<string, KfxSuiteDecl>;
-	// available profiles (shell-defined; a profile selects kfx + first screen)
-	profiles: ProfileManifest[];
+  // cross-kfx navigation with parameters; params reach the target view
+  open: (kfxId: string, params?: Record<string, string>) => void;
+  // the params this view was last opened with
+  params: Record<string, string>;
+  // shared refresh bus (one shell-owned timer); returns the unsubscribe
+  onRefresh: (fn: () => void) => () => void;
+  // read a settings value (view-declared or shell-owned), fallback applied
+  setting: (key: string) => string;
+  // persist shell state changes; the shell owns the ConfigStore write
+  updateState: (patch: Partial<ShellState>) => void;
+  state: ShellState;
+  // runtime facts for system views
+  info: ShellRuntimeInfo;
+  // every loaded kfx (for the manager and settings views)
+  registry: KfxEntry[];
+  // suites by key (for grouping and unit enable/disable)
+  suites: Record<string, KfxSuiteDecl>;
+  // available profiles (shell-defined; a profile selects kfx + first screen)
+  profiles: ProfileManifest[];
 };
 
 export type KfxViewProps = { caps: KfxCapabilities; shell: Shell };
@@ -165,47 +165,47 @@ export type KfxViewComponent = React.ComponentType<KfxViewProps>;
 
 // A view extension's bundle exports exactly this shape.
 export type KfxViewModule = {
-	View: KfxViewComponent;
+  View: KfxViewComponent;
 };
 
 // A profile bundles kfx ids, a default first view and vocabulary labels.
 export type ProfileManifest = {
-	id: string;
-	title: string;
-	kfx: string[];
-	defaultView: string;
+  id: string;
+  title: string;
+  kfx: string[];
+  defaultView: string;
 };
 
 // ── UI tokens (dark, dense, monospace — no component library) ─────────────
 
 export const panelStyle: React.CSSProperties = {
-	background: "#252526",
-	border: "1px solid #3c3c3c",
-	borderRadius: 6,
-	padding: 12,
-	overflow: "auto",
-	minHeight: 0,
+  background: '#252526',
+  border: '1px solid #3c3c3c',
+  borderRadius: 6,
+  padding: 12,
+  overflow: 'auto',
+  minHeight: 0,
 };
 
 export const headingStyle: React.CSSProperties = {
-	fontSize: 11,
-	fontWeight: 600,
-	textTransform: "uppercase",
-	letterSpacing: 1,
-	color: "#858585",
-	margin: "0 0 8px 0",
+  fontSize: 11,
+  fontWeight: 600,
+  textTransform: 'uppercase',
+  letterSpacing: 1,
+  color: '#858585',
+  margin: '0 0 8px 0',
 };
 
 export const mono: React.CSSProperties = {
-	fontFamily: "SF Mono, Menlo, monospace",
-	fontSize: 12,
+  fontFamily: 'SF Mono, Menlo, monospace',
+  fontSize: 12,
 };
 
 export const inputStyle: React.CSSProperties = {
-	...mono,
-	padding: 4,
-	background: "#1e1e1e",
-	border: "1px solid #3c3c3c",
-	borderRadius: 4,
-	color: "#cccccc",
+  ...mono,
+  padding: 4,
+  background: '#1e1e1e',
+  border: '1px solid #3c3c3c',
+  borderRadius: 4,
+  color: '#cccccc',
 };

--- a/framework/spec/scripts/aggregate.js
+++ b/framework/spec/scripts/aggregate.js
@@ -74,33 +74,82 @@ function main() {
   // --- machine categories: minimal, with a couple of real seed entries so a
   //     consumer renders real rows rather than empty pages. Real generators
   //     (framework/core) replace these; note marks them as seed. ---
-  writeJson('registry.json', { spec_version: specVersion, note: PENDING, schemas: [] });
+  writeJson('registry.json', {
+    spec_version: specVersion,
+    note: PENDING,
+    schemas: [],
+  });
   writeJson('errors.json', {
     spec_version: specVersion,
     note: `seed entries; full dictionary ${PENDING}`,
     errors: [
-      { code: 'E_PAYLOAD_MISSING', meaning: 'Referenced payload is absent from the blob store.', next: 'Distinguish redacted vs lost vs not-yet-written via the three-state marker.' },
-      { code: 'E_HASH_MISMATCH', meaning: 'Recomputed payload hash does not match the event reference.', next: 'Treat the payload as tampered or corrupted; the manifest commitment is authoritative.' },
-      { code: 'E_SCHEMA_UNKNOWN', meaning: 'Event type has no entry in the schema registry.', next: 'Upgrade the registry, or read the event as opaque with its raw type tag.' },
+      {
+        code: 'E_PAYLOAD_MISSING',
+        meaning: 'Referenced payload is absent from the blob store.',
+        next: 'Distinguish redacted vs lost vs not-yet-written via the three-state marker.',
+      },
+      {
+        code: 'E_HASH_MISMATCH',
+        meaning: 'Recomputed payload hash does not match the event reference.',
+        next: 'Treat the payload as tampered or corrupted; the manifest commitment is authoritative.',
+      },
+      {
+        code: 'E_SCHEMA_UNKNOWN',
+        meaning: 'Event type has no entry in the schema registry.',
+        next: 'Upgrade the registry, or read the event as opaque with its raw type tag.',
+      },
     ],
   });
   writeJson('capabilities.json', {
     spec_version: specVersion,
     note: `seed entries; full table ${PENDING}`,
     capabilities: [
-      { id: 'append_only', since: '0.1', summary: 'Committed events are never rewritten or reordered.' },
-      { id: 'recorded_causality', since: '0.1', summary: 'Each event carries its causal parent at write time.' },
-      { id: 'runtime_free_read', since: '0.1', summary: 'A bundle can be opened and verified without the producing runtime.' },
+      {
+        id: 'append_only',
+        since: '0.1',
+        summary: 'Committed events are never rewritten or reordered.',
+      },
+      {
+        id: 'recorded_causality',
+        since: '0.1',
+        summary: 'Each event carries its causal parent at write time.',
+      },
+      {
+        id: 'runtime_free_read',
+        since: '0.1',
+        summary:
+          'A bundle can be opened and verified without the producing runtime.',
+      },
     ],
   });
-  writeJson('vectors/index.json', { spec_version: specVersion, note: PENDING, vectors: [] });
-  writeJson('conformance.json', { spec_version: specVersion, note: PENDING, implements: [] });
+  writeJson('vectors/index.json', {
+    spec_version: specVersion,
+    note: PENDING,
+    vectors: [],
+  });
+  writeJson('conformance.json', {
+    spec_version: specVersion,
+    note: PENDING,
+    implements: [],
+  });
 
   // --- three handbooks: real minimal recipes (copied from docs/handbooks) ---
   const handbooks = {
-    kungfu: { dir: 'handbooks/cli', src: 'docs/handbooks/cli.md', api_ref_source: 'developer/toolchain' },
-    pypi: { dir: 'handbooks/python', src: 'docs/handbooks/python.md', api_ref_source: 'framework/core' },
-    npm: { dir: 'handbooks/node', src: 'docs/handbooks/node.md', api_ref_source: 'framework/api' },
+    kungfu: {
+      dir: 'handbooks/cli',
+      src: 'docs/handbooks/cli.md',
+      api_ref_source: 'developer/toolchain',
+    },
+    pypi: {
+      dir: 'handbooks/python',
+      src: 'docs/handbooks/python.md',
+      api_ref_source: 'framework/core',
+    },
+    npm: {
+      dir: 'handbooks/node',
+      src: 'docs/handbooks/node.md',
+      api_ref_source: 'framework/api',
+    },
   };
   for (const h of Object.values(handbooks)) {
     copyDoc(h.src, `${h.dir}/index.md`);
@@ -122,11 +171,26 @@ function main() {
     overview: { path: 'overview/', source_package: 'framework/spec' },
     categories: {
       format_spec: { path: 'format-spec/', source_package: 'framework/spec' },
-      schema_registry: { path: 'registry.json', source_package: 'framework/core' },
-      error_dictionary: { path: 'errors.json', source_package: 'framework/core' },
-      capabilities: { path: 'capabilities.json', source_package: 'framework/core' },
-      conformance_vectors: { path: 'vectors/', source_package: 'framework/core' },
-      conformance_map: { path: 'conformance.json', source_package: 'framework/spec' },
+      schema_registry: {
+        path: 'registry.json',
+        source_package: 'framework/core',
+      },
+      error_dictionary: {
+        path: 'errors.json',
+        source_package: 'framework/core',
+      },
+      capabilities: {
+        path: 'capabilities.json',
+        source_package: 'framework/core',
+      },
+      conformance_vectors: {
+        path: 'vectors/',
+        source_package: 'framework/core',
+      },
+      conformance_map: {
+        path: 'conformance.json',
+        source_package: 'framework/spec',
+      },
     },
     handbooks: {
       kungfu: {
@@ -151,8 +215,12 @@ function main() {
   };
   writeJson('manifest.json', manifest);
 
-  log(`built spec ${specVersion} bundle -> dist/ (package ${pkg.name}@${pkg.version})`);
-  log('overview + format_spec + 3 handbooks = real minimal prose; machine categories = seed/stub.');
+  log(
+    `built spec ${specVersion} bundle -> dist/ (package ${pkg.name}@${pkg.version})`,
+  );
+  log(
+    'overview + format_spec + 3 handbooks = real minimal prose; machine categories = seed/stub.',
+  );
   return 0;
 }
 

--- a/framework/spec/scripts/verify.js
+++ b/framework/spec/scripts/verify.js
@@ -34,12 +34,16 @@ function main() {
   try {
     schema = JSON.parse(fs.readFileSync(schemaPath, 'utf8'));
   } catch (err) {
-    console.error(`[spec:verify] FAIL: cannot read/parse manifest schema: ${err.message}`);
+    console.error(
+      `[spec:verify] FAIL: cannot read/parse manifest schema: ${err.message}`,
+    );
     return 1;
   }
 
   if (!fs.existsSync(manifestPath)) {
-    console.error('[spec:verify] FAIL: dist/manifest.json missing — run build (aggregate) first.');
+    console.error(
+      '[spec:verify] FAIL: dist/manifest.json missing — run build (aggregate) first.',
+    );
     return 1;
   }
 
@@ -47,7 +51,9 @@ function main() {
   try {
     m = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
   } catch (err) {
-    console.error(`[spec:verify] FAIL: dist/manifest.json does not parse: ${err.message}`);
+    console.error(
+      `[spec:verify] FAIL: dist/manifest.json does not parse: ${err.message}`,
+    );
     return 1;
   }
 
@@ -55,29 +61,45 @@ function main() {
   for (const key of schema.required) {
     check(key in m, `manifest missing required key: ${key}`);
   }
-  check(m.manifest_version === '1', `manifest_version must be "1", got ${JSON.stringify(m.manifest_version)}`);
-  check(m.package && m.package.name === '@kungfu-tech/spec', 'package.name must be @kungfu-tech/spec');
-  check(/^[0-9]+\.[0-9]+$/.test(m.spec_version || ''), `spec_version malformed: ${m.spec_version}`);
+  check(
+    m.manifest_version === '1',
+    `manifest_version must be "1", got ${JSON.stringify(m.manifest_version)}`,
+  );
+  check(
+    m.package && m.package.name === '@kungfu-tech/spec',
+    'package.name must be @kungfu-tech/spec',
+  );
+  check(
+    /^[0-9]+\.[0-9]+$/.test(m.spec_version || ''),
+    `spec_version malformed: ${m.spec_version}`,
+  );
   check(
     /^[a-z][a-z0-9]*(:[a-z0-9-]+)+$/.test(m.format_namespace || ''),
-    `format_namespace must be a domain-free id: ${m.format_namespace}`
+    `format_namespace must be a domain-free id: ${m.format_namespace}`,
   );
   check(
     !/[a-z]+\.[a-z]+/.test(m.format_namespace || ''),
-    `format_namespace must not embed a domain: ${m.format_namespace}`
+    `format_namespace must not embed a domain: ${m.format_namespace}`,
   );
 
   // 5. spec_version routed into docs_url_base.
   check(
-    typeof m.docs_url_base === 'string' && m.docs_url_base.includes(`/spec/${m.spec_version}/`),
-    `docs_url_base must route /spec/${m.spec_version}/: ${m.docs_url_base}`
+    typeof m.docs_url_base === 'string' &&
+      m.docs_url_base.includes(`/spec/${m.spec_version}/`),
+    `docs_url_base must route /spec/${m.spec_version}/: ${m.docs_url_base}`,
   );
 
   // optional overview: if declared, its path must exist.
   if (m.overview) {
-    check(m.overview.path && m.overview.source_package, 'overview missing path/source_package');
+    check(
+      m.overview.path && m.overview.source_package,
+      'overview missing path/source_package',
+    );
     if (m.overview.path) {
-      check(fs.existsSync(path.join(distDir, m.overview.path)), `overview path not in bundle: ${m.overview.path}`);
+      check(
+        fs.existsSync(path.join(distDir, m.overview.path)),
+        `overview path not in bundle: ${m.overview.path}`,
+      );
     }
   }
 
@@ -85,9 +107,15 @@ function main() {
   const catKeys = Object.keys(schema.properties.categories.properties);
   for (const k of catKeys) {
     const entry = (m.categories || {})[k];
-    check(entry && entry.path && entry.source_package, `category ${k} missing path/source_package`);
+    check(
+      entry && entry.path && entry.source_package,
+      `category ${k} missing path/source_package`,
+    );
     if (entry && entry.path) {
-      check(fs.existsSync(path.join(distDir, entry.path)), `category ${k} path not in bundle: ${entry.path}`);
+      check(
+        fs.existsSync(path.join(distDir, entry.path)),
+        `category ${k} path not in bundle: ${entry.path}`,
+      );
     }
   }
 
@@ -96,11 +124,18 @@ function main() {
   for (const k of hbKeys) {
     const entry = (m.handbooks || {})[k];
     check(
-      entry && entry.path && entry.binding_version && entry.docs_url && entry.api_ref_source,
-      `handbook ${k} missing required fields`
+      entry &&
+        entry.path &&
+        entry.binding_version &&
+        entry.docs_url &&
+        entry.api_ref_source,
+      `handbook ${k} missing required fields`,
     );
     if (entry && entry.path) {
-      check(fs.existsSync(path.join(distDir, entry.path)), `handbook ${k} path not in bundle: ${entry.path}`);
+      check(
+        fs.existsSync(path.join(distDir, entry.path)),
+        `handbook ${k} path not in bundle: ${entry.path}`,
+      );
     }
   }
 
@@ -110,8 +145,12 @@ function main() {
     return 1;
   }
 
-  console.log(`[spec:verify] OK — spec ${m.spec_version} bundle coheres with the manifest contract`);
-  console.log(`[spec:verify] ${catKeys.length} categories + ${hbKeys.length} handbooks present; all referenced paths exist.`);
+  console.log(
+    `[spec:verify] OK — spec ${m.spec_version} bundle coheres with the manifest contract`,
+  );
+  console.log(
+    `[spec:verify] ${catKeys.length} categories + ${hbKeys.length} handbooks present; all referenced paths exist.`,
+  );
   return 0;
 }
 

--- a/install-hooks.js
+++ b/install-hooks.js
@@ -33,7 +33,10 @@ function main() {
   const force = process.argv.includes('--force');
 
   // Skip in environments that never commit (CI) unless explicitly forced.
-  if (!force && (process.env.KUNGFU_SKIP_INSTALL_HOOKS === '1' || process.env.CI === 'true')) {
+  if (
+    !force &&
+    (process.env.KUNGFU_SKIP_INSTALL_HOOKS === '1' || process.env.CI === 'true')
+  ) {
     log('skipped (CI / KUNGFU_SKIP_INSTALL_HOOKS); pass --force to override');
     return 0;
   }
@@ -74,7 +77,9 @@ function main() {
   // hook when the configured path chains into it (e.g. a managed identity guard).
   const hooksPath = git(['config', '--get', 'core.hooksPath']);
   if (hooksPath) {
-    log(`note: core.hooksPath=${hooksPath} — relies on that guard chaining into the standard hook`);
+    log(
+      `note: core.hooksPath=${hooksPath} — relies on that guard chaining into the standard hook`,
+    );
   }
   return 0;
 }

--- a/kungfu-code.js
+++ b/kungfu-code.js
@@ -53,7 +53,10 @@ function readConfig() {
     const m = line.match(/^\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)=(.*)$/);
     if (!m) continue;
     let v = m[2].trim();
-    if ((v.startsWith("'") && v.endsWith("'")) || (v.startsWith('"') && v.endsWith('"'))) {
+    if (
+      (v.startsWith("'") && v.endsWith("'")) ||
+      (v.startsWith('"') && v.endsWith('"'))
+    ) {
       v = v.slice(1, -1);
     }
     out[m[1]] = v;
@@ -108,7 +111,9 @@ function main() {
   const argv = process.argv.slice(2);
   const cmd = argv[0];
   if (cmd !== 'proxy' && cmd !== 'config') {
-    console.error(`kungfu-code.js: unknown command ${cmd || '(empty)'} (only proxy/config are supported)`);
+    console.error(
+      `kungfu-code.js: unknown command ${cmd || '(empty)'} (only proxy/config are supported)`,
+    );
     process.exit(2);
   }
   const sub = argv[1] || 'help';
@@ -122,13 +127,17 @@ function main() {
       } else {
         ensureDir();
         fs.copyFileSync(TEMPLATE, CONFIG_FILE);
-        console.error(`Created from template: ${CONFIG_FILE} (edit it or use set to fill values)`);
+        console.error(
+          `Created from template: ${CONFIG_FILE} (edit it or use set to fill values)`,
+        );
       }
       break;
     case 'edit': {
       ensureDir();
       if (!fs.existsSync(CONFIG_FILE)) fs.copyFileSync(TEMPLATE, CONFIG_FILE);
-      const r = spawnSync(process.env.EDITOR || 'vi', [CONFIG_FILE], { stdio: 'inherit' });
+      const r = spawnSync(process.env.EDITOR || 'vi', [CONFIG_FILE], {
+        stdio: 'inherit',
+      });
       process.exit(r.status || 0);
       break;
     }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   "scripts": {
     "foreach": "wsrun --bin pnpm --serial --exclude-missing --fast-exit",
     "foreach:extensions": "wsrun --bin pnpm --serial --package '@kungfu-tech/kfx-*' --exclude-missing --fast-exit",
-    "format": "wsrun --bin pnpm --serial --exclude-missing format",
+    "format": "pnpm run format:web && wsrun --bin pnpm --serial --exclude-missing format",
+    "format:web": "biome format --write .",
     "prebuild": "node .prebuild.js",
     "build": "pnpm run foreach build",
     "build:extensions": "pnpm run foreach:extensions build",

--- a/verify.js
+++ b/verify.js
@@ -48,7 +48,9 @@ const withApp = args.includes('--with-app');
 
 // expected version: single source of truth is lerna.json (the version maintained by the org repo action-bump-version)
 function expectedVersion() {
-  const lerna = JSON.parse(fs.readFileSync(path.join(ROOT, 'lerna.json'), 'utf8'));
+  const lerna = JSON.parse(
+    fs.readFileSync(path.join(ROOT, 'lerna.json'), 'utf8'),
+  );
   return lerna.version;
 }
 
@@ -65,29 +67,47 @@ function fail(name, detail) {
 // run one pnpm task (via the pnpm dispatched by the current node/corepack); throw on failure
 function runPnpm(task) {
   console.log(`\n[verify] build stage: pnpm ${task}`);
-  const r = spawnSync('pnpm', ['run', task], { cwd: ROOT, stdio: 'inherit', shell: isWin });
+  const r = spawnSync('pnpm', ['run', task], {
+    cwd: ROOT,
+    stdio: 'inherit',
+    shell: isWin,
+  });
   if (r.status !== 0) {
-    throw new Error(`pnpm ${task} failed (exit ${r.status == null ? 'signal ' + r.signal : r.status})`);
+    throw new Error(
+      `pnpm ${task} failed (exit ${r.status == null ? 'signal ' + r.signal : r.status})`,
+    );
   }
 }
 
 function main() {
   const version = expectedVersion();
-  console.log(`[verify] kungfu build-chain verification — expected version ${version}`);
-  console.log(`[verify] mode: ${doFull ? 'full (build first)' : 'quick (assert existing artifacts only)'}${withApp ? ' + app' : ''}`);
+  console.log(
+    `[verify] kungfu build-chain verification — expected version ${version}`,
+  );
+  console.log(
+    `[verify] mode: ${doFull ? 'full (build first)' : 'quick (assert existing artifacts only)'}${withApp ? ' + app' : ''}`,
+  );
 
   // ── Stage 0: toolchain preflight (read-only) ──────────────────────
   console.log('\n[verify] stage 0: toolchain preflight');
   const uv = spawnSync('uv', ['--version'], { encoding: 'utf8', shell: isWin });
   if (uv.status === 0) pass('uv available', (uv.stdout || '').trim());
-  else fail('uv available', 'uv not found (the Python build chain depends on uv); a full build will fail');
+  else
+    fail(
+      'uv available',
+      'uv not found (the Python build chain depends on uv); a full build will fail',
+    );
 
   const nodeVersionFile = path.join(ROOT, '.node-version');
   if (fs.existsSync(nodeVersionFile)) {
     const want = fs.readFileSync(nodeVersionFile, 'utf8').trim();
     const got = process.versions.node;
     if (got === want) pass('node version pinned', `v${got}`);
-    else fail('node version pinned', `current v${got} ≠ .node-version ${want} (run via ./kungfu-code)`);
+    else
+      fail(
+        'node version pinned',
+        `current v${got} ≠ .node-version ${want} (run via ./kungfu-code)`,
+      );
   }
 
   // ── Stage 1: (optional) build ─────────────────────────────────────
@@ -97,24 +117,36 @@ function main() {
       // C++ dogfood probe: compile the reference cpp kfx against the freshly
       // built libkungfu (headers + shared lib + FlatBuffers) into a native
       // module. If a core capability regresses, this build breaks here.
-      const probeBuild = spawnSync('pnpm', ['--filter', '@kungfu-tech/examples-probe-cpp', 'run', 'build'], {
-        cwd: ROOT,
-        stdio: 'inherit',
-        shell: isWin,
-      });
+      const probeBuild = spawnSync(
+        'pnpm',
+        ['--filter', '@kungfu-tech/examples-probe-cpp', 'run', 'build'],
+        {
+          cwd: ROOT,
+          stdio: 'inherit',
+          shell: isWin,
+        },
+      );
       if (probeBuild.status !== 0) {
-        throw new Error(`cpp probe build failed (exit ${probeBuild.status == null ? 'signal ' + probeBuild.signal : probeBuild.status})`);
+        throw new Error(
+          `cpp probe build failed (exit ${probeBuild.status == null ? 'signal ' + probeBuild.signal : probeBuild.status})`,
+        );
       }
       // Python AOT dogfood probe: install its dependency (engage pdm) and
       // Nuitka-compile it (engage nuitka) — exercises the bundled python
       // toolchain against the freshly built core.
-      const pyProbeBuild = spawnSync('pnpm', ['--filter', '@kungfu-tech/examples-probe-python', 'run', 'build'], {
-        cwd: ROOT,
-        stdio: 'inherit',
-        shell: isWin,
-      });
+      const pyProbeBuild = spawnSync(
+        'pnpm',
+        ['--filter', '@kungfu-tech/examples-probe-python', 'run', 'build'],
+        {
+          cwd: ROOT,
+          stdio: 'inherit',
+          shell: isWin,
+        },
+      );
       if (pyProbeBuild.status !== 0) {
-        throw new Error(`python probe build failed (exit ${pyProbeBuild.status == null ? 'signal ' + pyProbeBuild.signal : pyProbeBuild.status})`);
+        throw new Error(
+          `python probe build failed (exit ${pyProbeBuild.status == null ? 'signal ' + pyProbeBuild.signal : pyProbeBuild.status})`,
+        );
       }
       runPnpm('freeze'); // nuitka → framework/core/dist/kungfu
       if (withApp) runPnpm('build:app'); // webpack → framework/gui/dist/app
@@ -136,15 +168,23 @@ function main() {
       let detail = path.relative(ROOT, kungfuBin);
       if (!isWin) {
         const mode = fs.statSync(kungfuBin).mode;
-        if (!(mode & 0o111)) { fail('kfc executable', `${detail} missing executable bit`); kungfuBin = null; }
-        else pass('kfc executable exists', detail);
+        if (!(mode & 0o111)) {
+          fail('kfc executable', `${detail} missing executable bit`);
+          kungfuBin = null;
+        } else pass('kfc executable exists', detail);
       } else pass('kfc executable exists', detail);
     } else {
-      fail('kfc executable exists', `not found ${path.relative(ROOT, kungfuBin)} (freeze first)`);
+      fail(
+        'kfc executable exists',
+        `not found ${path.relative(ROOT, kungfuBin)} (freeze first)`,
+      );
       kungfuBin = null;
     }
   } else {
-    fail('dist/kungfu directory exists', `not found ${path.relative(ROOT, distKfc)} (freeze first; in quick mode, confirm it was built)`);
+    fail(
+      'dist/kungfu directory exists',
+      `not found ${path.relative(ROOT, distKfc)} (freeze first; in quick mode, confirm it was built)`,
+    );
   }
 
   // ── Stage 2b: C++ extension probe artifact ────────────────────────
@@ -152,16 +192,32 @@ function main() {
   // its FlatBuffers types into a native module; its presence proves the C++
   // extension build path. Built in Stage 1 under --full.
   console.log('\n[verify] stage 2b: C++ extension probe artifact');
-  const probeDist = path.join(ROOT, 'examples', 'probe-cpp', 'dist', 'ProbeCpp');
+  const probeDist = path.join(
+    ROOT,
+    'examples',
+    'probe-cpp',
+    'dist',
+    'ProbeCpp',
+  );
   const probeSo = fs.existsSync(probeDist)
-    ? fs.readdirSync(probeDist).find((f) => /^probe_cpp\..*\.(so|dylib|pyd)$/.test(f))
+    ? fs
+        .readdirSync(probeDist)
+        .find((f) => /^probe_cpp\..*\.(so|dylib|pyd)$/.test(f))
     : null;
   if (probeSo) {
-    pass('cpp probe native module built', path.relative(ROOT, path.join(probeDist, probeSo)));
+    pass(
+      'cpp probe native module built',
+      path.relative(ROOT, path.join(probeDist, probeSo)),
+    );
   } else if (doFull) {
-    fail('cpp probe native module built', `no probe_cpp.*.(so|dylib|pyd) under ${path.relative(ROOT, probeDist)}`);
+    fail(
+      'cpp probe native module built',
+      `no probe_cpp.*.(so|dylib|pyd) under ${path.relative(ROOT, probeDist)}`,
+    );
   } else {
-    console.log(`  (skipped: no cpp probe artifact; build it with 'pnpm --filter @kungfu-tech/examples-probe-cpp run build' or --full)`);
+    console.log(
+      `  (skipped: no cpp probe artifact; build it with 'pnpm --filter @kungfu-tech/examples-probe-cpp run build' or --full)`,
+    );
   }
 
   // ── Stage 2c: Python AOT extension probe artifact ─────────────────
@@ -169,16 +225,32 @@ function main() {
   // native module through the bundled toolchain; its presence proves the
   // python-AOT extension build path. Built in Stage 1 under --full.
   console.log('\n[verify] stage 2c: Python AOT extension probe artifact');
-  const pyProbeDist = path.join(ROOT, 'examples', 'probe-python', 'dist', 'ProbePython');
+  const pyProbeDist = path.join(
+    ROOT,
+    'examples',
+    'probe-python',
+    'dist',
+    'ProbePython',
+  );
   const pyProbeSo = fs.existsSync(pyProbeDist)
-    ? fs.readdirSync(pyProbeDist).find((f) => /^ProbePython\..*\.(so|dylib|pyd)$/.test(f))
+    ? fs
+        .readdirSync(pyProbeDist)
+        .find((f) => /^ProbePython\..*\.(so|dylib|pyd)$/.test(f))
     : null;
   if (pyProbeSo) {
-    pass('python probe native module built', path.relative(ROOT, path.join(pyProbeDist, pyProbeSo)));
+    pass(
+      'python probe native module built',
+      path.relative(ROOT, path.join(pyProbeDist, pyProbeSo)),
+    );
   } else if (doFull) {
-    fail('python probe native module built', `no ProbePython.*.(so|dylib|pyd) under ${path.relative(ROOT, pyProbeDist)}`);
+    fail(
+      'python probe native module built',
+      `no ProbePython.*.(so|dylib|pyd) under ${path.relative(ROOT, pyProbeDist)}`,
+    );
   } else {
-    console.log(`  (skipped: no python probe artifact; build it with 'pnpm --filter @kungfu-tech/examples-probe-python run build' or --full)`);
+    console.log(
+      `  (skipped: no python probe artifact; build it with 'pnpm --filter @kungfu-tech/examples-probe-python run build' or --full)`,
+    );
   }
 
   // ── Stage 3: kfc runtime smoke ────────────────────────────────────
@@ -187,9 +259,15 @@ function main() {
     const r = spawnSync(kungfuBin, ['--version'], { encoding: 'utf8' });
     const out = `${r.stdout || ''}${r.stderr || ''}`.trim();
     if (r.status !== 0) {
-      fail('kfc --version exits 0', `exit ${r.status == null ? 'signal ' + r.signal : r.status}; output: ${out.slice(0, 200)}`);
+      fail(
+        'kfc --version exits 0',
+        `exit ${r.status == null ? 'signal ' + r.signal : r.status}; output: ${out.slice(0, 200)}`,
+      );
     } else if (!out.includes(version)) {
-      fail('kfc version matches', `expected to contain ${version}, got: ${out.slice(0, 200)}`);
+      fail(
+        'kfc version matches',
+        `expected to contain ${version}, got: ${out.slice(0, 200)}`,
+      );
     } else {
       pass('kfc runtime smoke', `--version contains ${version}`);
     }
@@ -201,10 +279,17 @@ function main() {
   if (withApp) {
     console.log('\n[verify] stage 4: app build artifact assertion');
     const appDist = path.join(ROOT, 'framework', 'app', 'dist', 'app');
-    if (fs.existsSync(appDist) && fs.statSync(appDist).isDirectory() && fs.readdirSync(appDist).length > 0) {
+    if (
+      fs.existsSync(appDist) &&
+      fs.statSync(appDist).isDirectory() &&
+      fs.readdirSync(appDist).length > 0
+    ) {
       pass('build:app artifact exists', path.relative(ROOT, appDist));
     } else {
-      fail('build:app artifact exists', `non-empty ${path.relative(ROOT, appDist)} not found (build:app first)`);
+      fail(
+        'build:app artifact exists',
+        `non-empty ${path.relative(ROOT, appDist)} not found (build:app first)`,
+      );
     }
   }
 
@@ -216,34 +301,64 @@ function main() {
   if (doFull) {
     console.log('\n[verify] stage 5: capability slices');
     if (isWin) {
-      console.log('  (skipped on Windows: slice probes are bash scripts; not asserted on this platform)');
+      console.log(
+        '  (skipped on Windows: slice probes are bash scripts; not asserted on this platform)',
+      );
     } else {
       const core = path.join(ROOT, 'framework', 'core');
       const buildDir = path.join(core, 'build');
       const slicesDir = path.join(core, 'slices');
-      const cfg = spawnSync('cmake', ['-S', core, '-B', buildDir, '-DKUNGFU_WITH_SLICES=ON'], { stdio: 'inherit' });
+      const cfg = spawnSync(
+        'cmake',
+        ['-S', core, '-B', buildDir, '-DKUNGFU_WITH_SLICES=ON'],
+        { stdio: 'inherit' },
+      );
       if (cfg.status !== 0) {
-        fail('slices configure', `cmake -DKUNGFU_WITH_SLICES=ON failed (exit ${cfg.status}); rebuild:core must run first to seed the build tree`);
+        fail(
+          'slices configure',
+          `cmake -DKUNGFU_WITH_SLICES=ON failed (exit ${cfg.status}); rebuild:core must run first to seed the build tree`,
+        );
         return summarize();
       }
-      const bld = spawnSync('cmake', ['--build', buildDir], { stdio: 'inherit' });
+      const bld = spawnSync('cmake', ['--build', buildDir], {
+        stdio: 'inherit',
+      });
       if (bld.status !== 0) {
         fail('slices build', `cmake --build failed (exit ${bld.status})`);
         return summarize();
       }
       pass('slices build', 'KUNGFU_WITH_SLICES=ON');
-      const tail3 = (r) => `${r.stdout || ''}${r.stderr || ''}`.trim().split('\n').slice(-3).join(' | ').slice(0, 300);
+      const tail3 = (r) =>
+        `${r.stdout || ''}${r.stderr || ''}`
+          .trim()
+          .split('\n')
+          .slice(-3)
+          .join(' | ')
+          .slice(0, 300);
       const slices = fs
         .readdirSync(slicesDir)
         .filter((d) => fs.existsSync(path.join(slicesDir, d, 'run.sh')))
         .sort();
       for (const name of slices) {
-        const r = spawnSync('bash', [path.join(slicesDir, name, 'run.sh'), buildDir], { encoding: 'utf8' });
+        const r = spawnSync(
+          'bash',
+          [path.join(slicesDir, name, 'run.sh'), buildDir],
+          { encoding: 'utf8' },
+        );
         if (r.status === 0) pass(`slice ${name}`, 'proof holds');
-        else fail(`slice ${name}`, `run.sh exit ${r.status == null ? 'signal ' + r.signal : r.status}; tail: ${tail3(r)}`);
+        else
+          fail(
+            `slice ${name}`,
+            `run.sh exit ${r.status == null ? 'signal ' + r.signal : r.status}; tail: ${tail3(r)}`,
+          );
       }
-      const guard = spawnSync('bash', [path.join(core, 'src', 'libyijinjing', 'check-deps.sh')], { encoding: 'utf8' });
-      if (guard.status === 0) pass('yijinjing dependency guard', 'check-deps.sh');
+      const guard = spawnSync(
+        'bash',
+        [path.join(core, 'src', 'libyijinjing', 'check-deps.sh')],
+        { encoding: 'utf8' },
+      );
+      if (guard.status === 0)
+        pass('yijinjing dependency guard', 'check-deps.sh');
       else fail('yijinjing dependency guard', tail3(guard));
 
       // ── Stage 6: journal fact fixtures (full mode) ────────────────
@@ -273,9 +388,15 @@ function main() {
             .sort()
         : [];
       for (const name of fixtures) {
-        const r = spawnSync('bash', [path.join(fixturesDir, name, 'run.sh')], { encoding: 'utf8' });
+        const r = spawnSync('bash', [path.join(fixturesDir, name, 'run.sh')], {
+          encoding: 'utf8',
+        });
         if (r.status === 0) pass(`fixture ${name}`, 'journal facts hold');
-        else fail(`fixture ${name}`, `run.sh exit ${r.status == null ? 'signal ' + r.signal : r.status}; tail: ${tail3(r)}`);
+        else
+          fail(
+            `fixture ${name}`,
+            `run.sh exit ${r.status == null ? 'signal ' + r.signal : r.status}; tail: ${tail3(r)}`,
+          );
       }
     }
   }
@@ -285,9 +406,13 @@ function main() {
 
 function summarize() {
   const failed = results.filter((r) => !r.ok);
-  console.log(`\n[verify] result: ${results.length - failed.length}/${results.length} passed`);
+  console.log(
+    `\n[verify] result: ${results.length - failed.length}/${results.length} passed`,
+  );
   if (failed.length) {
-    console.error(`[verify] ❌ verification failed (${failed.length} item(s)): ${failed.map((r) => r.name).join(', ')}`);
+    console.error(
+      `[verify] ❌ verification failed (${failed.length} item(s)): ${failed.map((r) => r.name).join(', ')}`,
+    );
     process.exit(1);
   }
   console.log('[verify] ✅ build-chain end-to-end verification passed');


### PR DESCRIPTION
Add a root biome.json covering all JS/TS outside framework/core (ignoring generated, fixtures, build, JSON). framework/api, framework/spec, extension views, the SDK template and repo-root scripts are now formatted to the biome baseline, and the pre-commit dispatch is widened repo-wide. Pure formatting + tooling; no behavior change.