### PR TITLE
feat(rewind): add provider cost adapters — discovery + Codex/Claude parse layer

### DIFF
--- a/framework/core/src/python/kungfu/rewind/cost/__init__.py
+++ b/framework/core/src/python/kungfu/rewind/cost/__init__.py
@@ -1,0 +1,47 @@
+#  SPDX-License-Identifier: Apache-2.0
+#
+# kungfu.rewind.cost — provider cost/usage adapters (parse layer).
+#
+# Discover the Codex and Claude CLIs and parse their structured output into a
+# normalized, honestly-attributed CostSnapshot. There is no journal and no wire
+# event here — see model.py for why these are dataclasses until a later slice
+# puts them on the rewind open layer.
+#
+# This subpackage is pure stdlib on purpose: it must import and run without the
+# native pykungfu binding, so the parse contract can be tested on its own.
+
+from kungfu.rewind.cost.model import (
+    COST_SCHEMA_VERSION,
+    AttributionLevel,
+    CostSnapshot,
+    ProviderRunMetadata,
+    TokenUsage,
+    confidence_for,
+)
+from kungfu.rewind.cost.discovery import (
+    CODEX_APP_BUNDLE,
+    ProviderDiscovery,
+    discover_provider,
+    discover_providers,
+)
+from kungfu.rewind.cost.codex import (
+    parse_codex_exec_json_text,
+    parse_codex_exec_jsonl,
+)
+from kungfu.rewind.cost.claude import parse_claude_print_json
+
+__all__ = [
+    "COST_SCHEMA_VERSION",
+    "AttributionLevel",
+    "CostSnapshot",
+    "ProviderRunMetadata",
+    "TokenUsage",
+    "confidence_for",
+    "CODEX_APP_BUNDLE",
+    "ProviderDiscovery",
+    "discover_provider",
+    "discover_providers",
+    "parse_codex_exec_json_text",
+    "parse_codex_exec_jsonl",
+    "parse_claude_print_json",
+]

--- a/framework/core/src/python/kungfu/rewind/cost/claude.py
+++ b/framework/core/src/python/kungfu/rewind/cost/claude.py
@@ -1,0 +1,119 @@
+#  SPDX-License-Identifier: Apache-2.0
+#
+# Claude adapter — turn a `claude --print --output-format json` run into a
+# normalized CostSnapshot.
+#
+# `claude --print --output-format json` emits ONE JSON object with structured
+# usage AND a dollar cost the CLI computed itself:
+#
+#   {"session_id":"969ea637-…",
+#    "total_cost_usd":0.15698,
+#    "usage":{"input_tokens":1,"cache_creation_input_tokens":15605,
+#             "output_tokens":13},
+#    "modelUsage":{"claude-…":{"costUSD":0.15638}}}
+#
+# Because Claude reports total_cost_usd, this adapter carries a real cost_usd
+# (no pricing math needed). session_id is Claude's own handle.
+#
+# Attribution: a single `--print` invocation is one run → EXACT_RUN by default.
+# When the caller resumed a persistent session (so the usage spans turns keyed
+# by session_id), it should pass attribution=EXACT_SESSION. This parser cannot
+# tell these apart from the payload alone, so the honest default is EXACT_RUN
+# and the caller narrows it.
+
+from __future__ import annotations
+
+import json
+from typing import Optional, Union
+
+from kungfu.rewind.cost.model import AttributionLevel, CostSnapshot, TokenUsage
+
+PROVIDER = "claude"
+SURFACE = "print_json"
+SOURCE = "claude_print_json"
+
+_ALLOWED_ATTRIBUTION = (AttributionLevel.EXACT_RUN, AttributionLevel.EXACT_SESSION)
+
+
+def _usage_from(usage: dict) -> TokenUsage:
+    """Map Claude's usage object into the normalized TokenUsage.
+
+    Claude splits cache into creation vs read: `cache_creation_input_tokens`
+    is billed distinctly, `cache_read_input_tokens` is the cached portion of
+    input. Both map to their normalized slots; `or 0` guards absence.
+    """
+    return TokenUsage(
+        input_tokens=int(usage.get("input_tokens") or 0),
+        output_tokens=int(usage.get("output_tokens") or 0),
+        cached_input_tokens=int(usage.get("cache_read_input_tokens") or 0),
+        cache_creation_input_tokens=int(usage.get("cache_creation_input_tokens") or 0),
+    )
+
+
+def _primary_model(model_usage) -> Optional[str]:
+    """Pick the model that carried most of the cost as the snapshot's model.
+
+    `modelUsage` maps model name -> {costUSD, tokens…}. A `--print` run is
+    usually one model, but a run that fell back across models still gets a
+    single honest headline: the one that dominated the bill.
+    """
+    if not isinstance(model_usage, dict) or not model_usage:
+        return None
+    best, best_cost = None, -1.0
+    for name, info in model_usage.items():
+        cost = 0.0
+        if isinstance(info, dict):
+            try:
+                cost = float(info.get("costUSD") or 0.0)
+            except (TypeError, ValueError):
+                cost = 0.0
+        if cost > best_cost:
+            best, best_cost = name, cost
+    return best
+
+
+def parse_claude_print_json(
+    payload: Union[str, dict],
+    *,
+    run_id: Optional[str] = None,
+    work_id: Optional[str] = None,
+    attribution: AttributionLevel = AttributionLevel.EXACT_RUN,
+) -> CostSnapshot:
+    """Parse a `claude --print --output-format json` object into a CostSnapshot.
+
+    `payload` is the JSON text or an already-parsed dict. `attribution` must be
+    EXACT_RUN (default) or EXACT_SESSION — a Claude print result is always at
+    least session-attributed truth; the caller says which when it resumed a
+    session.
+    """
+    if attribution not in _ALLOWED_ATTRIBUTION:
+        raise ValueError(
+            f"claude attribution must be EXACT_RUN or EXACT_SESSION, got {attribution}"
+        )
+    if isinstance(payload, str):
+        payload = json.loads(payload)
+    if not isinstance(payload, dict):
+        raise TypeError("claude payload must be a JSON object")
+
+    usage = payload.get("usage")
+    tokens = _usage_from(usage) if isinstance(usage, dict) else TokenUsage()
+
+    cost_usd = payload.get("total_cost_usd")
+    if cost_usd is not None:
+        cost_usd = float(cost_usd)
+
+    session_id = payload.get("session_id")
+    model = _primary_model(payload.get("modelUsage"))
+
+    return CostSnapshot(
+        provider=PROVIDER,
+        surface=SURFACE,
+        attribution=attribution,
+        source=SOURCE,
+        tokens=tokens,
+        model=model,
+        session_id=session_id if isinstance(session_id, str) else None,
+        run_id=run_id,
+        work_id=work_id,
+        cost_usd=cost_usd,
+    )

--- a/framework/core/src/python/kungfu/rewind/cost/codex.py
+++ b/framework/core/src/python/kungfu/rewind/cost/codex.py
@@ -1,0 +1,119 @@
+#  SPDX-License-Identifier: Apache-2.0
+#
+# Codex adapter — turn a `codex exec --json` run into a normalized CostSnapshot.
+#
+# `codex exec --json` streams JSONL events; the usage facts ride
+# `turn.completed` events:
+#
+#   {"type":"turn.completed",
+#    "usage":{"input_tokens":36419,"cached_input_tokens":4480,
+#             "output_tokens":28,"reasoning_output_tokens":17}}
+#
+# This is a per-run structured surface, so the result is attributed EXACT_RUN.
+# Codex reports token counts but no dollar cost, so `cost_usd` stays None — this
+# layer does no pricing math and will not fabricate a 0.0.
+#
+# Honest gap: whether a multi-turn `codex exec` reports per-turn deltas or a
+# running cumulative snapshot on each `turn.completed` is not pinned by the one
+# smoke sample we have. `usage_mode` makes the assumption explicit and
+# switchable; the default accumulates (treats each event as a delta). A managed
+# run in a later slice should confirm this against a real multi-turn exec.
+
+from __future__ import annotations
+
+import json
+from typing import Iterable, Optional
+
+from kungfu.rewind.cost.model import AttributionLevel, CostSnapshot, TokenUsage
+
+PROVIDER = "codex"
+SURFACE = "exec_json"
+SOURCE = "codex_exec_json"
+
+_TURN_COMPLETED = "turn.completed"
+
+
+def _usage_from(event_usage: dict) -> TokenUsage:
+    """Map a codex usage object into the normalized TokenUsage.
+
+    `or 0` guards missing/None fields; codex has no cache-creation dimension, so
+    that stays 0. reasoning_output_tokens is a subset of output; it is recorded
+    separately, not double-added into output_tokens.
+    """
+    return TokenUsage(
+        input_tokens=int(event_usage.get("input_tokens") or 0),
+        output_tokens=int(event_usage.get("output_tokens") or 0),
+        cached_input_tokens=int(event_usage.get("cached_input_tokens") or 0),
+        reasoning_tokens=int(event_usage.get("reasoning_output_tokens") or 0),
+    )
+
+
+def parse_codex_exec_jsonl(
+    lines: Iterable[str],
+    *,
+    run_id: Optional[str] = None,
+    work_id: Optional[str] = None,
+    usage_mode: str = "accumulate",
+) -> CostSnapshot:
+    """Parse `codex exec --json` JSONL into one CostSnapshot for the run.
+
+    `lines` is any iterable of raw JSONL lines (a file object, a list, a
+    stream). Non-JSON / blank lines are skipped — the JSON events carry the
+    facts, and codex may interleave other output. `usage_mode`:
+
+      "accumulate"  sum usage across every turn.completed (per-turn deltas)
+      "last"        take only the final turn.completed (cumulative snapshots)
+    """
+    if usage_mode not in ("accumulate", "last"):
+        raise ValueError(f"usage_mode must be 'accumulate' or 'last', got {usage_mode}")
+
+    total = TokenUsage()
+    last: Optional[TokenUsage] = None
+    turns = 0
+    model: Optional[str] = None
+
+    for raw in lines:
+        raw = raw.strip()
+        if not raw:
+            continue
+        try:
+            event = json.loads(raw)
+        except (ValueError, TypeError):
+            # not a JSON event line — skip, do not fail the whole parse
+            continue
+        if not isinstance(event, dict):
+            continue
+        # a model name may appear on any event; keep the most recent non-empty
+        found_model = event.get("model")
+        if isinstance(found_model, str) and found_model:
+            model = found_model
+        if event.get("type") != _TURN_COMPLETED:
+            continue
+        usage = event.get("usage")
+        if not isinstance(usage, dict):
+            continue
+        turns += 1
+        turn_usage = _usage_from(usage)
+        total = total.add(turn_usage)
+        last = turn_usage
+
+    tokens = total if usage_mode == "accumulate" else (last or TokenUsage())
+
+    return CostSnapshot(
+        provider=PROVIDER,
+        surface=SURFACE,
+        attribution=AttributionLevel.EXACT_RUN,
+        source=SOURCE,
+        tokens=tokens,
+        model=model,
+        run_id=run_id,
+        work_id=work_id,
+        # codex exec has no session handle and reports tokens only
+        session_id=None,
+        cost_usd=None,
+    )
+
+
+def parse_codex_exec_json_text(text: str, **kwargs) -> CostSnapshot:
+    """Convenience wrapper: parse a full JSONL blob (splitlines) in one call."""
+    return parse_codex_exec_jsonl(text.splitlines(), **kwargs)

--- a/framework/core/src/python/kungfu/rewind/cost/discovery.py
+++ b/framework/core/src/python/kungfu/rewind/cost/discovery.py
@@ -1,0 +1,158 @@
+#  SPDX-License-Identifier: Apache-2.0
+#
+# Provider binary discovery — locate the Codex and Claude CLIs a managed run
+# would drive, and record enough to attribute a run to a concrete binary.
+#
+# Privacy boundary: discovery reads the PATH, a small set of known install
+# locations, and the binary's own `--version`. It NEVER reads auth.json,
+# cookies, the keychain,
+# API keys, billing pages, or session databases. Version probing runs the
+# binary with `--version` only.
+
+from __future__ import annotations
+
+import dataclasses
+import shutil
+import subprocess
+import sys
+from typing import Callable, Optional
+
+# Codex ships a working CLI inside the macOS app bundle even when `codex` is not
+# on the shell PATH (smoke evidence 2026-07-04). Discovery checks it explicitly
+# so a Codex App user needs no PATH surgery.
+CODEX_APP_BUNDLE = "/Applications/Codex.app/Contents/Resources/codex"
+
+# how a binary was located — travels with the discovery for diagnostics and so
+# a run can record which install it drove.
+PATH_CLASS_PATH = "path"
+PATH_CLASS_CODEX_APP_BUNDLE = "codex_app_bundle"
+
+_VERSION_TIMEOUT_S = 5.0
+
+
+@dataclasses.dataclass
+class ProviderDiscovery:
+    """Result of looking for one provider's CLI.
+
+    `found` is the headline; `path`/`path_class`/`version` describe the hit;
+    `candidates_checked` and `error` explain a miss so a failure is diagnosable
+    rather than silent.
+    """
+
+    provider: str
+    found: bool = False
+    path: Optional[str] = None
+    path_class: Optional[str] = None
+    version: Optional[str] = None
+    candidates_checked: list = dataclasses.field(default_factory=list)
+    error: Optional[str] = None
+
+    def to_dict(self) -> dict:
+        return dataclasses.asdict(self)
+
+
+def _default_version_probe(path: str) -> Optional[str]:
+    """Run `<path> --version` read-only and return the first non-empty line.
+
+    Any failure (missing binary, timeout, non-zero exit) returns None — a
+    version is a nice-to-have, never a reason to fail discovery.
+    """
+    try:
+        proc = subprocess.run(
+            [path, "--version"],
+            capture_output=True,
+            text=True,
+            timeout=_VERSION_TIMEOUT_S,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    out = (proc.stdout or proc.stderr or "").strip()
+    if not out:
+        return None
+    return out.splitlines()[0].strip()
+
+
+# Candidate builders: given the resolver, yield (path, path_class) pairs to try
+# in priority order. Each provider owns its own known locations here.
+def _codex_candidates(which, platform):
+    hits = []
+    on_path = which("codex")
+    if on_path:
+        hits.append((on_path, PATH_CLASS_PATH))
+    if platform == "darwin":
+        hits.append((CODEX_APP_BUNDLE, PATH_CLASS_CODEX_APP_BUNDLE))
+    return hits
+
+
+def _claude_candidates(which, platform):
+    hits = []
+    on_path = which("claude")
+    if on_path:
+        hits.append((on_path, PATH_CLASS_PATH))
+    return hits
+
+
+_PROVIDER_CANDIDATES = {
+    "codex": _codex_candidates,
+    "claude": _claude_candidates,
+}
+
+
+def _exists(path: str) -> bool:
+    # a PATH hit is already resolved; a known-location candidate must be checked.
+    import os
+
+    return os.path.isfile(path) and os.access(path, os.X_OK)
+
+
+def discover_provider(
+    provider: str,
+    *,
+    which: Callable[[str], Optional[str]] = shutil.which,
+    version_probe: Optional[Callable[[str], Optional[str]]] = None,
+    platform: str = sys.platform,
+    exists: Callable[[str], bool] = _exists,
+) -> ProviderDiscovery:
+    """Locate one provider's CLI.
+
+    Injectable `which` / `version_probe` / `platform` / `exists` keep this
+    testable without a real binary on the machine — fixtures drive it with
+    synthetic resolvers. `version_probe=None` uses the real `--version` runner;
+    pass a stub to avoid executing anything.
+    """
+    if provider not in _PROVIDER_CANDIDATES:
+        return ProviderDiscovery(
+            provider=provider,
+            found=False,
+            error=f"unknown provider: {provider}",
+        )
+    probe = version_probe if version_probe is not None else _default_version_probe
+    result = ProviderDiscovery(provider=provider)
+    for path, path_class in _PROVIDER_CANDIDATES[provider](which, platform):
+        result.candidates_checked.append(path)
+        # PATH hits are pre-resolved by `which`; known-location candidates
+        # (the app bundle) must be confirmed to exist and be executable.
+        if path_class == PATH_CLASS_PATH or exists(path):
+            result.found = True
+            result.path = path
+            result.path_class = path_class
+            result.version = probe(path)
+            return result
+    if not result.found and result.error is None:
+        result.error = "not found on PATH or known install locations"
+    return result
+
+
+def discover_providers(
+    providers: Optional[list] = None,
+    **kwargs,
+) -> dict:
+    """Discover several providers at once; returns {provider: ProviderDiscovery}.
+
+    Defaults to the built-in provider set (codex, claude). All keyword args pass
+    through to `discover_provider` (which/version_probe/platform/exists).
+    """
+    if providers is None:
+        providers = ["codex", "claude"]
+    return {p: discover_provider(p, **kwargs) for p in providers}

--- a/framework/core/src/python/kungfu/rewind/cost/model.py
+++ b/framework/core/src/python/kungfu/rewind/cost/model.py
@@ -1,0 +1,209 @@
+#  SPDX-License-Identifier: Apache-2.0
+#
+# The normalized cost contract — the language-layer shape every provider adapter
+# produces, before any of it becomes a journal event.
+#
+# Layering: this is the parse-layer contract — a plain dataclass shape, NOT a
+# wire event: no flatbuffers, no msg_type, no journal. Its job is to prove a
+# run's cost/usage facts can be parsed out of a provider CLI's structured output
+# honestly and completely. When a later slice puts these facts on the journal,
+# this contract is the draft the rewind open-layer event (msg_type 30008+) is
+# pinned from — one place decides the fields.
+#
+# Honesty is the whole product promise here. Every snapshot carries an
+# `attribution` level and, when the source cannot separate concurrent work, an
+# `ambiguous_attribution` flag. A number without its attribution level is a lie
+# this contract refuses to represent.
+
+from __future__ import annotations
+
+import dataclasses
+import enum
+from typing import Optional
+
+# Language-layer contract version. This is not the wire SCHEMA_VERSION (that
+# lives beside the .fbs and is minted when these facts become journal events
+# later); it just lets fixtures and callers detect contract drift.
+COST_SCHEMA_VERSION = 1
+
+
+class AttributionLevel(enum.Enum):
+    """How trustworthy the join between a cost number and a unit of work is.
+
+    Ordered strongest to weakest. The label travels with every snapshot so the
+    UI never has to guess whether a number is billing-grade or a rough window
+    delta.
+    """
+
+    # Usage belongs to one Kungfu-managed run, from structured per-run output.
+    # (codex `exec --json` turn.completed.usage; claude `--print` result usage)
+    EXACT_RUN = "exact_run"
+    # Usage belongs to one session, possibly spanning turns/internal calls.
+    # (claude session_id-keyed usage; future Codex session event stream)
+    EXACT_SESSION = "exact_session"
+    # Kungfu owns the session window and computes a before/after delta, but the
+    # metric is not a native per-run usage event.
+    OBSERVED_SESSION_DELTA = "observed_session_delta"
+    # Account/product-surface snapshot delta; concurrent work may be mixed in.
+    OBSERVED_WINDOW = "observed_window"
+    # User-entered or imported approximate value.
+    MANUAL_ESTIMATE = "manual_estimate"
+
+
+# Attribution level -> a coarse confidence label, so callers/tests share one
+# mapping instead of re-deriving it. exact_* is provider-structured truth;
+# observed_* and manual are progressively softer.
+_CONFIDENCE_BY_LEVEL = {
+    AttributionLevel.EXACT_RUN: "high",
+    AttributionLevel.EXACT_SESSION: "high",
+    AttributionLevel.OBSERVED_SESSION_DELTA: "medium",
+    AttributionLevel.OBSERVED_WINDOW: "low",
+    AttributionLevel.MANUAL_ESTIMATE: "low",
+}
+
+# Levels whose source cannot, on its own, separate concurrent work on the same
+# account/window. A snapshot at one of these levels is ambiguous whenever more
+# than one unit of work could share the window.
+_WINDOW_LEVELS = frozenset(
+    {AttributionLevel.OBSERVED_WINDOW, AttributionLevel.MANUAL_ESTIMATE}
+)
+
+
+def confidence_for(level: AttributionLevel) -> str:
+    return _CONFIDENCE_BY_LEVEL[level]
+
+
+@dataclasses.dataclass
+class TokenUsage:
+    """Token counts for one run/session, normalized across providers.
+
+    Providers spell these differently (OpenAI `prompt_tokens`, Anthropic
+    `input_tokens`, Codex `cached_input_tokens`, Claude
+    `cache_creation_input_tokens`); the adapters map into these fields so
+    downstream code sees one shape. All counts are non-negative; 0 means the
+    provider did not report that dimension, not "free".
+    """
+
+    input_tokens: int = 0
+    output_tokens: int = 0
+    # portion of input served from cache (Codex `cached_input_tokens`; Anthropic
+    # cache-read). A subset of input_tokens, kept separate for cost weighting.
+    cached_input_tokens: int = 0
+    # tokens spent writing to the cache (Anthropic/Claude
+    # `cache_creation_input_tokens`); billed distinctly from plain input.
+    cache_creation_input_tokens: int = 0
+    # reasoning/thinking tokens (Codex `reasoning_output_tokens`); a subset of
+    # output_tokens on providers that separate it.
+    reasoning_tokens: int = 0
+
+    def __post_init__(self) -> None:
+        for name in (
+            "input_tokens",
+            "output_tokens",
+            "cached_input_tokens",
+            "cache_creation_input_tokens",
+            "reasoning_tokens",
+        ):
+            value = getattr(self, name)
+            if not isinstance(value, int) or isinstance(value, bool):
+                raise TypeError(f"{name} must be int, got {type(value).__name__}")
+            if value < 0:
+                raise ValueError(f"{name} must be non-negative, got {value}")
+
+    @property
+    def billable_input_tokens(self) -> int:
+        """Fresh (non-cached) input tokens — total input minus the cached read.
+
+        Never negative even if a provider double-counts cache reads outside the
+        input total; that is the honest floor, not an assertion the provider is
+        consistent.
+        """
+        return max(self.input_tokens - self.cached_input_tokens, 0)
+
+    def add(self, other: "TokenUsage") -> "TokenUsage":
+        """Accumulate another usage into a new TokenUsage (for JSONL streams
+        that report usage per turn)."""
+        return TokenUsage(
+            input_tokens=self.input_tokens + other.input_tokens,
+            output_tokens=self.output_tokens + other.output_tokens,
+            cached_input_tokens=self.cached_input_tokens + other.cached_input_tokens,
+            cache_creation_input_tokens=(
+                self.cache_creation_input_tokens + other.cache_creation_input_tokens
+            ),
+            reasoning_tokens=self.reasoning_tokens + other.reasoning_tokens,
+        )
+
+    def to_dict(self) -> dict:
+        return dataclasses.asdict(self)
+
+
+@dataclasses.dataclass
+class ProviderRunMetadata:
+    """Identity of the provider process that produced a cost snapshot.
+
+    `run_id` is the join key back to the rewind run (supervisor-assigned at capture);
+    `session_id` is the provider's own session handle when it exposes one
+    (Claude does, Codex `exec` does not). `surface` names the invocation shape
+    so the UI can tell an exec run from an interactive session.
+    """
+
+    provider: str  # "codex" | "claude" | ...
+    surface: str  # "exec_json" | "print_json" | "interactive" | "usage" | ...
+    model: Optional[str] = None
+    session_id: Optional[str] = None
+    run_id: Optional[str] = None
+    cli_version: Optional[str] = None
+
+    def to_dict(self) -> dict:
+        return dataclasses.asdict(self)
+
+
+@dataclasses.dataclass
+class CostSnapshot:
+    """One normalized cost/usage fact tied to a unit of work.
+
+    This is the parse-layer output: what an adapter returns after reading a
+    provider CLI's structured output. `cost_usd` is None when the provider
+    reports tokens only (Codex exec) — this layer does no pricing math, so an
+    unknown cost stays None rather than a fabricated 0.0.
+    """
+
+    provider: str
+    surface: str
+    attribution: AttributionLevel
+    source: str  # e.g. "codex_exec_json", "claude_print_json"
+    tokens: TokenUsage = dataclasses.field(default_factory=TokenUsage)
+    model: Optional[str] = None
+    session_id: Optional[str] = None
+    run_id: Optional[str] = None
+    work_id: Optional[str] = None
+    cost_usd: Optional[float] = None
+    # True when the source cannot separate concurrent work sharing this
+    # account/window. Auto-set for window/manual levels unless the caller has
+    # proven isolation; exact_run/exact_session default False.
+    ambiguous_attribution: bool = False
+    # opaque reference to the redacted raw payload kept under the local ledger
+    # boundary (never the raw bytes here) — populated in later slices.
+    raw_ref: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.attribution, AttributionLevel):
+            raise TypeError("attribution must be an AttributionLevel")
+        if self.cost_usd is not None and self.cost_usd < 0:
+            raise ValueError(f"cost_usd must be non-negative, got {self.cost_usd}")
+        # window/manual levels are ambiguous by nature; only an explicit
+        # isolation claim (caller passing ambiguous_attribution=False AND a
+        # session/run key) would narrow it, which this layer never asserts.
+        if self.attribution in _WINDOW_LEVELS:
+            self.ambiguous_attribution = True
+
+    @property
+    def confidence(self) -> str:
+        return confidence_for(self.attribution)
+
+    def to_dict(self) -> dict:
+        d = dataclasses.asdict(self)
+        d["attribution"] = self.attribution.value
+        d["confidence"] = self.confidence
+        d["schema_version"] = COST_SCHEMA_VERSION
+        return d

--- a/tests/fixtures/rewind-demo-cost-adapter/check_cost_adapter.py
+++ b/tests/fixtures/rewind-demo-cost-adapter/check_cost_adapter.py
@@ -1,0 +1,364 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Parse-layer assertions for the cost adapters. Proves three things without a
+# journal or the native binding:
+#   1. provider discovery locates Codex (PATH + macOS app bundle) and Claude and
+#      records misses diagnosably, touching no credential;
+#   2. the Codex `exec --json` adapter accumulates turn.completed usage into an
+#      EXACT_RUN snapshot with no fabricated dollar cost;
+#   3. the Claude `--print --output-format json` adapter carries the real
+#      total_cost_usd, session id, and cache-split tokens;
+# plus the normalized contract's honesty invariants (attribution -> confidence,
+# window levels are ambiguous, no negative/absurd values).
+#
+# Usage: check_cost_adapter.py <fixture-dir>
+
+import json
+import os
+import sys
+import types
+
+fixture_dir = (
+    sys.argv[1] if len(sys.argv) > 1 else os.path.dirname(os.path.abspath(__file__))
+)
+core_src = os.path.abspath(
+    os.path.join(fixture_dir, "..", "..", "..", "framework", "core", "src", "python")
+)
+sys.path.insert(0, core_src)
+
+# Stub the heavy package parents. kungfu/__init__.py imports the native pykungfu
+# binding; the cost subpackage does not need it. Giving each stub a real
+# __path__ lets Python still resolve the real cost/ subpackage on disk, so this
+# fixture stays pure-stdlib and fast while importing the actual product code.
+for _name in ("kungfu", "kungfu.rewind"):
+    if _name not in sys.modules:
+        _m = types.ModuleType(_name)
+        _m.__path__ = [os.path.join(core_src, *_name.split("."))]
+        sys.modules[_name] = _m
+
+from kungfu.rewind.cost import (
+    AttributionLevel,
+    CostSnapshot,
+    COST_SCHEMA_VERSION,
+    ProviderDiscovery,
+    TokenUsage,
+    confidence_for,
+    discover_provider,
+    discover_providers,
+    parse_claude_print_json,
+    parse_codex_exec_json_text,
+    parse_codex_exec_jsonl,
+)
+from kungfu.rewind.cost.discovery import CODEX_APP_BUNDLE
+
+failures = []
+
+
+def check(name, ok, detail=""):
+    print(f"  {'ok' if ok else 'FAIL'}  {name}{': ' + detail if detail else ''}")
+    if not ok:
+        failures.append(name)
+
+
+def raises(exc, fn):
+    try:
+        fn()
+    except exc:
+        return True
+    except Exception:  # noqa: BLE001 — wrong exception type is still a failure
+        return False
+    return False
+
+
+def which_from(table):
+    return lambda name: table.get(name)
+
+
+# ── 1. provider discovery (injected resolvers — no real binary needed) ───────
+print("[discovery]")
+
+# a probe that records whether it ran, to prove discovery never execs when a
+# stub is supplied and that it does capture the version string.
+probe_calls = []
+
+
+def fake_probe(path):
+    probe_calls.append(path)
+    return "codex-cli 0.142.5"
+
+
+d = discover_provider(
+    "codex",
+    which=which_from({"codex": "/usr/local/bin/codex"}),
+    version_probe=fake_probe,
+    platform="linux",
+)
+check("codex found on PATH", d.found and d.path == "/usr/local/bin/codex")
+check("codex path_class == path", d.path_class == "path")
+check("codex version captured", d.version == "codex-cli 0.142.5")
+check("version probe was called for the hit", probe_calls == ["/usr/local/bin/codex"])
+
+# codex missing from PATH but present in the macOS app bundle
+d = discover_provider(
+    "codex",
+    which=which_from({}),
+    version_probe=lambda p: "codex-cli 0.142.5",
+    platform="darwin",
+    exists=lambda p: p == CODEX_APP_BUNDLE,
+)
+check(
+    "codex found in macOS app bundle when off PATH",
+    d.found and d.path == CODEX_APP_BUNDLE,
+)
+check("codex app-bundle path_class", d.path_class == "codex_app_bundle")
+
+# app bundle only tried on darwin — a linux box with no PATH hit finds nothing
+d = discover_provider("codex", which=which_from({}), platform="linux")
+check("codex not found on linux without PATH -> found False", not d.found)
+check("codex miss records an error", bool(d.error))
+check(
+    "codex miss lists no false candidate", CODEX_APP_BUNDLE not in d.candidates_checked
+)
+
+# claude on PATH
+d = discover_provider(
+    "claude",
+    which=which_from({"claude": "/opt/claude/bin/claude"}),
+    version_probe=lambda p: "2.1.201 (Claude Code)",
+    platform="darwin",
+)
+check("claude found on PATH", d.found and d.path == "/opt/claude/bin/claude")
+check("claude version captured", d.version == "2.1.201 (Claude Code)")
+
+# unknown provider is a diagnosable miss, not a crash
+d = discover_provider("bogus", which=which_from({}))
+check("unknown provider -> found False + error", (not d.found) and bool(d.error))
+
+# discover_providers over the default set, no execution
+res = discover_providers(
+    which=which_from({"codex": "/c/codex", "claude": "/c/claude"}),
+    version_probe=lambda p: None,
+    platform="linux",
+)
+check(
+    "discover_providers returns both defaults",
+    set(res) == {"codex", "claude"}
+    and all(isinstance(v, ProviderDiscovery) for v in res.values()),
+)
+check("both defaults found with injected PATH", all(v.found for v in res.values()))
+
+
+# ── 2. Codex exec --json adapter ─────────────────────────────────────────────
+print("[codex]")
+
+with open(os.path.join(fixture_dir, "samples", "codex-exec.jsonl")) as f:
+    codex_text = f.read()
+
+snap = parse_codex_exec_json_text(codex_text, run_id="run-codex-1", work_id="work-7")
+check("codex attribution == exact_run", snap.attribution is AttributionLevel.EXACT_RUN)
+check("codex source label", snap.source == "codex_exec_json")
+check("codex surface label", snap.surface == "exec_json")
+check(
+    "codex accumulates input_tokens",
+    snap.tokens.input_tokens == 37619,
+    str(snap.tokens.input_tokens),
+)
+check(
+    "codex accumulates output_tokens",
+    snap.tokens.output_tokens == 73,
+    str(snap.tokens.output_tokens),
+)
+check("codex accumulates cached_input_tokens", snap.tokens.cached_input_tokens == 5280)
+check("codex accumulates reasoning_tokens", snap.tokens.reasoning_tokens == 27)
+check(
+    "codex billable input = total - cached", snap.tokens.billable_input_tokens == 32339
+)
+check("codex has no fabricated cost (tokens only)", snap.cost_usd is None)
+check("codex model captured from session event", snap.model == "gpt-5-codex")
+check(
+    "codex run_id/work_id threaded",
+    snap.run_id == "run-codex-1" and snap.work_id == "work-7",
+)
+check("codex confidence high", snap.confidence == "high")
+check("codex not ambiguous (per-run)", snap.ambiguous_attribution is False)
+
+# usage_mode="last" takes only the final turn.completed (cumulative-snapshot mode)
+snap_last = parse_codex_exec_json_text(codex_text, usage_mode="last")
+check("codex last-mode input == final turn", snap_last.tokens.input_tokens == 1200)
+check("codex last-mode output == final turn", snap_last.tokens.output_tokens == 45)
+
+# robustness: blank and non-JSON lines are skipped, not fatal
+messy = [
+    "",
+    "not json at all",
+    '{"type":"turn.completed","usage":{"input_tokens":10,"output_tokens":2}}',
+    "   ",
+]
+snap_messy = parse_codex_exec_jsonl(messy)
+check("codex skips blank/garbage lines", snap_messy.tokens.input_tokens == 10)
+
+# no turns at all -> zero usage, still a valid exact_run snapshot
+snap_empty = parse_codex_exec_jsonl([])
+check("codex empty stream -> zero tokens", snap_empty.tokens.input_tokens == 0)
+check(
+    "codex empty stream still exact_run",
+    snap_empty.attribution is AttributionLevel.EXACT_RUN,
+)
+
+check(
+    "codex bad usage_mode rejected",
+    raises(ValueError, lambda: parse_codex_exec_jsonl([], usage_mode="bogus")),
+)
+
+
+# ── 3. Claude --print --output-format json adapter ───────────────────────────
+print("[claude]")
+
+with open(os.path.join(fixture_dir, "samples", "claude-print.json")) as f:
+    claude_text = f.read()
+
+snap = parse_claude_print_json(claude_text, run_id="run-claude-1")
+check(
+    "claude carries real total_cost_usd", snap.cost_usd == 0.15698, str(snap.cost_usd)
+)
+check(
+    "claude session_id captured",
+    snap.session_id == "00000000-0000-4000-8000-000000000000",
+)
+check("claude input_tokens", snap.tokens.input_tokens == 1)
+check(
+    "claude cache_creation_input_tokens",
+    snap.tokens.cache_creation_input_tokens == 15605,
+)
+check("claude output_tokens", snap.tokens.output_tokens == 13)
+check("claude model = dominant-cost model", snap.model == "claude-fable-5")
+check("claude source label", snap.source == "claude_print_json")
+check(
+    "claude default attribution exact_run",
+    snap.attribution is AttributionLevel.EXACT_RUN,
+)
+check("claude confidence high", snap.confidence == "high")
+check("claude not ambiguous", snap.ambiguous_attribution is False)
+check("claude run_id threaded", snap.run_id == "run-claude-1")
+
+# a resumed session is the caller's call — exact_session is accepted
+snap_sess = parse_claude_print_json(
+    json.loads(claude_text), attribution=AttributionLevel.EXACT_SESSION
+)
+check(
+    "claude accepts exact_session from caller",
+    snap_sess.attribution is AttributionLevel.EXACT_SESSION,
+)
+check("claude exact_session still high confidence", snap_sess.confidence == "high")
+
+# claude adapter refuses an attribution it cannot honestly claim
+check(
+    "claude rejects observed_window attribution",
+    raises(
+        ValueError,
+        lambda: parse_claude_print_json(
+            claude_text, attribution=AttributionLevel.OBSERVED_WINDOW
+        ),
+    ),
+)
+check(
+    "claude rejects non-object payload",
+    raises(TypeError, lambda: parse_claude_print_json("[1,2,3]")),
+)
+
+
+# ── 4. normalized contract honesty invariants ───────────────────────────────
+print("[contract]")
+
+# attribution -> confidence mapping is shared, not re-derived
+check("exact_run -> high", confidence_for(AttributionLevel.EXACT_RUN) == "high")
+check(
+    "observed_session_delta -> medium",
+    confidence_for(AttributionLevel.OBSERVED_SESSION_DELTA) == "medium",
+)
+check(
+    "observed_window -> low", confidence_for(AttributionLevel.OBSERVED_WINDOW) == "low"
+)
+
+# window / manual levels are ambiguous by construction — the caller cannot
+# accidentally present an account-window number as clean per-run truth
+win = CostSnapshot(
+    provider="codex",
+    surface="usage",
+    attribution=AttributionLevel.OBSERVED_WINDOW,
+    source="codex_usage",
+    cost_usd=1.23,
+)
+check(
+    "observed_window auto-sets ambiguous_attribution", win.ambiguous_attribution is True
+)
+manual = CostSnapshot(
+    provider="manual",
+    surface="paste",
+    attribution=AttributionLevel.MANUAL_ESTIMATE,
+    source="manual",
+)
+check("manual_estimate is ambiguous", manual.ambiguous_attribution is True)
+
+# TokenUsage math
+t = TokenUsage(input_tokens=100, output_tokens=20, cached_input_tokens=30)
+check("billable = input - cached", t.billable_input_tokens == 70)
+check(
+    "billable floors at 0 when cache >= input",
+    TokenUsage(input_tokens=10, cached_input_tokens=25).billable_input_tokens == 0,
+)
+summed = TokenUsage(input_tokens=5, output_tokens=3).add(
+    TokenUsage(input_tokens=7, output_tokens=1)
+)
+check(
+    "TokenUsage.add sums fields",
+    summed.input_tokens == 12 and summed.output_tokens == 4,
+)
+
+# type/value guards
+check(
+    "negative tokens rejected", raises(ValueError, lambda: TokenUsage(input_tokens=-1))
+)
+check(
+    "bool token rejected (not silently int)",
+    raises(TypeError, lambda: TokenUsage(input_tokens=True)),
+)
+check(
+    "negative cost rejected",
+    raises(
+        ValueError,
+        lambda: CostSnapshot(
+            provider="p",
+            surface="s",
+            attribution=AttributionLevel.EXACT_RUN,
+            source="x",
+            cost_usd=-0.5,
+        ),
+    ),
+)
+check(
+    "non-enum attribution rejected",
+    raises(
+        TypeError,
+        lambda: CostSnapshot(
+            provider="p", surface="s", attribution="exact_run", source="x"
+        ),
+    ),
+)
+
+# to_dict is self-describing: value label, confidence, and contract version
+d = win.to_dict()
+check("to_dict emits attribution value string", d["attribution"] == "observed_window")
+check("to_dict emits confidence", d["confidence"] == "low")
+check("to_dict emits schema_version", d["schema_version"] == COST_SCHEMA_VERSION)
+check(
+    "to_dict nests tokens dict",
+    isinstance(d["tokens"], dict) and "input_tokens" in d["tokens"],
+)
+
+
+# ── verdict ──────────────────────────────────────────────────────────────────
+if failures:
+    print(f"\ncost-adapter check failed: {failures}")
+    sys.exit(1)
+print("\ncost-adapter check passed")

--- a/tests/fixtures/rewind-demo-cost-adapter/run.sh
+++ b/tests/fixtures/rewind-demo-cost-adapter/run.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# SPDX-License-Identifier: Apache-2.0
+#
+# Cost-adapter parse fixture. Proves
+# the provider cost adapters turn Codex `exec --json` JSONL and Claude `--print
+# --output-format json` into a normalized, honestly-attributed CostSnapshot, and
+# that provider binary discovery locates the CLIs (incl. the macOS Codex App
+# bundle) without touching any credential.
+#
+# Unlike the other rewind-demo-* fixtures this one is PARSE-ONLY: pure stdlib,
+# no built dist/kungfu, no journal writer, no network. It runs under plain
+# python3 in well under a second. The check stubs the heavy kungfu package
+# parents so the pure-stdlib cost subpackage imports without the native binding.
+# When a later slice puts these facts on the journal, a heavier journal fixture
+# will join it; this one stays the fast contract test for the parse layer.
+#
+# Usage: tests/fixtures/rewind-demo-cost-adapter/run.sh
+set -eu
+fixture_dir="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+python3 "$fixture_dir/check_cost_adapter.py" "$fixture_dir"

--- a/tests/fixtures/rewind-demo-cost-adapter/samples/claude-print.json
+++ b/tests/fixtures/rewind-demo-cost-adapter/samples/claude-print.json
@@ -1,0 +1,20 @@
+{
+  "type": "result",
+  "subtype": "success",
+  "is_error": false,
+  "session_id": "00000000-0000-4000-8000-000000000000",
+  "total_cost_usd": 0.15698,
+  "usage": {
+    "input_tokens": 1,
+    "cache_creation_input_tokens": 15605,
+    "cache_read_input_tokens": 0,
+    "output_tokens": 13
+  },
+  "modelUsage": {
+    "claude-fable-5": {
+      "costUSD": 0.15638,
+      "inputTokens": 1,
+      "outputTokens": 13
+    }
+  }
+}

--- a/tests/fixtures/rewind-demo-cost-adapter/samples/codex-exec.jsonl
+++ b/tests/fixtures/rewind-demo-cost-adapter/samples/codex-exec.jsonl
@@ -1,0 +1,6 @@
+{"type":"session.created","model":"gpt-5-codex"}
+{"type":"turn.started"}
+{"type":"turn.completed","usage":{"input_tokens":36419,"cached_input_tokens":4480,"output_tokens":28,"reasoning_output_tokens":17}}
+{"type":"turn.started"}
+{"type":"turn.completed","usage":{"input_tokens":1200,"cached_input_tokens":800,"output_tokens":45,"reasoning_output_tokens":10}}
+{"type":"turn.failed","error":"synthetic non-usage event, ignored by the adapter"}


### PR DESCRIPTION
Provider cost adapters (parse layer): discover Codex/Claude CLIs (incl. macOS Codex App bundle) and parse their structured output into a normalized, honestly-attributed CostSnapshot. Codex exec --json (tokens only, no pricing) and Claude --print json (total_cost_usd + session + cache-split usage). Parse-only, pure stdlib, no journal/wire/credentials; new fixture asserts the contract under verify.js stage 6.