### PR TITLE
chore: add opt-in @ts-check type safety to the JS tooling layer

### DIFF
--- a/developer/sdk/src/kfs.js
+++ b/developer/sdk/src/kfs.js
@@ -6,6 +6,7 @@
 // binding), wired the same way as the reference GUI. The generated app is
 // self-contained; it consumes the platform through published packages, or
 // through the workspace when scaffolded inside the monorepo (--workspace).
+// @ts-check
 import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
@@ -17,6 +18,11 @@ const TEMPLATE_ROOT = path.join(
   'templates',
 );
 
+/**
+ * Print CLI usage and exit with the given status code.
+ * @param {number} code
+ * @returns {never}
+ */
 function usage(code) {
   process.stdout.write(
     [
@@ -45,11 +51,26 @@ function usage(code) {
   process.exit(code);
 }
 
+/**
+ * Print an error to stderr and exit non-zero.
+ * @param {string} message
+ * @returns {never}
+ */
 function fail(message) {
   process.stderr.write(`kfs: ${message}\n`);
   process.exit(1);
 }
 
+/**
+ * Parsed CLI options shared by the create verbs.
+ * @typedef {{ workspace: boolean, name: string }} CreateOptions
+ */
+
+/**
+ * Split argv into positional arguments and named options.
+ * @param {string[]} argv
+ * @returns {{ positional: string[], options: CreateOptions }}
+ */
 function parseArgs(argv) {
   const positional = [];
   const options = { workspace: false, name: '' };
@@ -66,13 +87,30 @@ function parseArgs(argv) {
   return { positional, options };
 }
 
+/**
+ * Derive a reverse-DNS application id from a product name.
+ * @param {string} name
+ * @returns {string}
+ */
 function toAppId(name) {
   const slug = name.toLowerCase().replace(/[^a-z0-9]+/g, '-');
   return `com.kungfu.app.${slug.replace(/-/g, '')}`;
 }
 
+/**
+ * Copy a template tree into targetDir, substituting placeholder tokens.
+ * @param {string} templateName
+ * @param {string} targetDir
+ * @param {Record<string, string>} replacements
+ * @returns {void}
+ */
 function scaffold(templateName, targetDir, replacements) {
   const templateDir = path.join(TEMPLATE_ROOT, templateName);
+  /**
+   * @param {string} from
+   * @param {string} to
+   * @returns {void}
+   */
   const copy = (from, to) => {
     for (const entry of fs.readdirSync(from, { withFileTypes: true })) {
       // npm strips dotfiles from published packages; templates store them
@@ -98,6 +136,12 @@ function scaffold(templateName, targetDir, replacements) {
   copy(templateDir, targetDir);
 }
 
+/**
+ * Scaffold a complete Kungfu desktop app into `directory`.
+ * @param {string | undefined} directory
+ * @param {CreateOptions} options
+ * @returns {void}
+ */
 function createApp(directory, options) {
   if (!directory) usage(1);
   const targetDir = path.resolve(directory);
@@ -125,6 +169,12 @@ function createApp(directory, options) {
   );
 }
 
+/**
+ * Scaffold a view extension package (kfx) into `directory`.
+ * @param {string | undefined} directory
+ * @param {CreateOptions} options
+ * @returns {void}
+ */
 function createExtension(directory, options) {
   if (!directory) usage(1);
   const targetDir = path.resolve(directory);
@@ -163,6 +213,24 @@ const KFX_EXTERNALS = [
   '@kungfu-tech/api/capability',
 ];
 
+/**
+ * The subset of a kfx package.json this driver reads.
+ * @typedef {object} Manifest
+ * @property {string} [name]
+ * @property {{
+ *   key?: string,
+ *   config?: {
+ *     view?: { entry?: string },
+ *     adapter?: unknown,
+ *   },
+ * }} [kungfuConfig]
+ * @property {{ python?: unknown }} [kungfuBuild]
+ */
+
+/**
+ * Read and parse the package.json in the current working directory.
+ * @returns {Manifest}
+ */
 function readManifest() {
   const manifestPath = path.resolve('package.json');
   if (!fs.existsSync(manifestPath))
@@ -177,6 +245,11 @@ function readManifest() {
 // helper (cmake/kungfu.cmake); this driver invokes CMake with the core's conan
 // toolchain and pins the module to the core's Python so it loads in kfc.
 
+/**
+ * Walk up from startDir looking for the monorepo's framework/core.
+ * @param {string} startDir
+ * @returns {string | null} the core directory, or null if not found
+ */
 function locateCoreDir(startDir) {
   let dir = startDir;
   for (let i = 0; i < 8; i += 1) {
@@ -189,6 +262,13 @@ function locateCoreDir(startDir) {
   return null;
 }
 
+/**
+ * Run a child process synchronously, aborting the CLI if it fails.
+ * @param {string} cmd
+ * @param {string[]} args
+ * @param {import('node:child_process').SpawnSyncOptions} [opts]
+ * @returns {void}
+ */
 function runOrFail(cmd, args, opts = {}) {
   const result = spawnSync(cmd, args, { stdio: 'inherit', ...opts });
   if (result.error) fail(`${cmd} not runnable: ${result.error.message}`);
@@ -199,6 +279,11 @@ function runOrFail(cmd, args, opts = {}) {
   }
 }
 
+/**
+ * Configure and build a C++ kfx into a native pybind11 module.
+ * @param {Manifest} manifest
+ * @returns {void}
+ */
 function cppBuild(manifest) {
   const coreDir = locateCoreDir(process.cwd());
   if (!coreDir)
@@ -247,6 +332,11 @@ function cppBuild(manifest) {
 // ahead-of-time compiled into a native module (`kungfu engage nuitka
 // --module`) — exercising the same python development lifecycle kfc ships.
 
+/**
+ * Install deps and AOT-compile a Python kfx into a native module.
+ * @param {Manifest} manifest
+ * @returns {void}
+ */
 function pythonAotBuild(manifest) {
   const coreDir = locateCoreDir(process.cwd());
   if (!coreDir)
@@ -303,6 +393,10 @@ function pythonAotBuild(manifest) {
   );
 }
 
+/**
+ * Dispatch `kfs kfx build` to the right builder for the current package.
+ * @returns {Promise<void>}
+ */
 async function kfxBuild() {
   const manifest = readManifest();
   const config = manifest.kungfuConfig?.config ?? {};
@@ -355,6 +449,10 @@ async function kfxBuild() {
   );
 }
 
+/**
+ * Remove the dist/ and build/ trees produced by `kfs kfx build`.
+ * @returns {void}
+ */
 function kfxClean() {
   readManifest();
   fs.rmSync(path.resolve('dist'), { recursive: true, force: true });

--- a/framework/core/.gyp/run-build.js
+++ b/framework/core/.gyp/run-build.js
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
+// @ts-check
 
 const fs = require('fs');
 const glob = require('glob');
@@ -60,6 +61,10 @@ function useUvPython() {
   }
 }
 
+/**
+ * @param {string[]} args
+ * @param {boolean} [check]
+ */
 function callPrebuilt(args, check = true) {
   useUvPython();
   const buildType = process.env.npm_package_config_build_type;
@@ -67,22 +72,25 @@ function callPrebuilt(args, check = true) {
   return prebuilt(...buildTypeOpt, ...args);
 }
 
-module.exports = require('../lib/sywac')(module, (cli) => {
-  cli
-    .command('install', () => {
-      const fallbackBuild = process.env.KF_INSTALL_FALLBACK_BUILD === 'true';
-      callPrebuilt(
-        fallbackBuild ? ['install', '--fallback-to-build'] : ['install'],
-        fallbackBuild,
-      );
-    })
-    .command('build', () => build())
-    .command('clean', () => clean())
-    .command('rebuild', () => {
-      clean();
-      build();
-    })
-    .command('package', () => {
-      callPrebuilt(['package']).onSuccess(makePackage);
-    });
-});
+module.exports = require('../lib/sywac')(
+  /** @type {NodeModule} */ (module),
+  (/** @type {any} */ cli) => {
+    cli
+      .command('install', () => {
+        const fallbackBuild = process.env.KF_INSTALL_FALLBACK_BUILD === 'true';
+        callPrebuilt(
+          fallbackBuild ? ['install', '--fallback-to-build'] : ['install'],
+          fallbackBuild,
+        );
+      })
+      .command('build', () => build())
+      .command('clean', () => clean())
+      .command('rebuild', () => {
+        clean();
+        build();
+      })
+      .command('package', () => {
+        callPrebuilt(['package']).onSuccess(makePackage);
+      });
+  },
+);

--- a/framework/core/.gyp/run-conan.js
+++ b/framework/core/.gyp/run-conan.js
@@ -1,9 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
+// @ts-check
 
 const fse = require('fs-extra');
 const path = require('path');
 const { shell } = require('../lib');
 
+/** @param {string[]} cmd */
 function conan(cmd) {
   // uv 接管 env（S1 阶段 A）：在 uv 项目 venv 中运行全局 conan2；--frozen 不偷改 uv.lock。
   const uv_args = ['run', '--frozen', 'conan', ...cmd];
@@ -32,10 +34,12 @@ function getNodeVersionOptions() {
   ];
 }
 
+/** @param {string} name */
 function makeConanSetting(name) {
   return ['-s', `${name}=${shell.getConfigValue(name)}`];
 }
 
+/** @param {string[]} names */
 function makeConanSettings(names) {
   return names.map(makeConanSetting).flat();
 }
@@ -47,10 +51,12 @@ function platformConanSettings() {
   return process.platform === 'win32' ? ['-s', 'compiler.cppstd=17'] : [];
 }
 
+/** @param {string} name */
 function makeConanOption(name) {
   return ['-o', `${name}=${shell.getConfigValue(name)}`];
 }
 
+/** @param {string[]} names */
 function makeConanOptions(names) {
   return names.map(makeConanOption).flat().concat(getNodeVersionOptions());
 }

--- a/framework/core/.gyp/run-format-cpp.js
+++ b/framework/core/.gyp/run-format-cpp.js
@@ -1,9 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
+// @ts-check
 
 const glob = require('glob');
 const path = require('path');
 const { shell } = require('../lib');
 
+/** @param {string[]} argv */
 function main(argv) {
   const cwd = process.cwd().toString();
   process.chdir(path.dirname(__dirname));
@@ -15,10 +17,10 @@ function main(argv) {
   const clangFormat = ['run', '--frozen', 'clang-format'];
   shell.run('uv', [...clangFormat, '--version'], true, { tolerant: true });
 
-  const files = argv.flatMap((dir) =>
+  const files = argv.flatMap((/** @type {string} */ dir) =>
     glob
       .sync('**/*.@(h|hpp|hxx|cpp|c|cc|cxx)', { cwd: path.join(cwd, dir) })
-      .map((p) => path.join(cwd, dir, p)),
+      .map((/** @type {string} */ p) => path.join(cwd, dir, p)),
   );
   if (files.length) {
     shell.run('uv', [...clangFormat, '-style=file', '-i', ...files]);

--- a/framework/core/.gyp/run-freeze.js
+++ b/framework/core/.gyp/run-freeze.js
@@ -15,6 +15,7 @@
 //   kungfu_electron.node）需 freeze 后从 build/<type> 补拷（kfc python 进程不 import 它们）。
 // - pyinstaller（fallback）：onedir 把数据/库放进 _internal/，而 app 栈假设 dist/kungfu 扁平，
 //   故 freeze 后 promote（_internal/*→顶层，Unix 符号链/Win 拷贝）。
+// @ts-check
 
 const fs = require('fs');
 const path = require('path');
@@ -48,6 +49,10 @@ function stage() {
 }
 
 // kungfu/__init__ 读 pykungfu 同目录的 kungfubuildinfo.json 取 version；缺则生成。
+/**
+ * @param {string} bt
+ * @returns {string}
+ */
 function ensureBuildInfo(bt) {
   const dir = path.join(CORE, 'build', bt);
   const info = path.join(dir, 'kungfubuildinfo.json');
@@ -82,12 +87,17 @@ const APP_NATIVE = [
 // kungfu frames to symbols; without it the stackwalker only prints module+offset
 // (see docs/windows-crash-symbols.md). No-op off Windows or when no PDB exists
 // (e.g. third-party natives, or a build without /Z7 + /DEBUG).
+/**
+ * @param {string} binPath
+ * @param {string} destDir
+ */
 function copyPdbSibling(binPath, destDir) {
   const dir = path.dirname(binPath);
   const stem = path
     .basename(binPath)
     .replace(/\.(node|pyd|dll|exe)$/i, '')
     .split('.')[0];
+  /** @type {string | null} */
   let pdb = binPath.replace(/\.(node|pyd|dll|exe)$/i, '.pdb');
   if (pdb === binPath || !fs.existsSync(pdb)) {
     // Fall back to any <stem>*.pdb the linker emitted next to the binary; the
@@ -105,6 +115,7 @@ function copyPdbSibling(binPath, destDir) {
   fs.copyFileSync(pdb, path.join(destDir, path.basename(pdb)));
 }
 
+/** @param {string} bt */
 function copyAppNative(bt) {
   const rel = path.join(CORE, 'build', bt);
   const distKfc = path.join(CORE, 'dist', 'kungfu');
@@ -120,10 +131,16 @@ function copyAppNative(bt) {
 }
 
 // BFS 查 build 树里首个匹配文件（返回最浅一份，避开 obj/临时深目录里的副本）。
+/**
+ * @param {string} root
+ * @param {RegExp} re
+ * @returns {string | null}
+ */
 function findFileShallow(root, re) {
   const queue = [root];
   while (queue.length) {
     const dir = queue.shift();
+    if (dir === undefined) break;
     let entries;
     try {
       entries = fs.readdirSync(dir, { withFileTypes: true });
@@ -151,6 +168,7 @@ function findFileShallow(root, re) {
 // Mac/Linux 无此问题：pykungfu.so 就在 build/<bt>，其 libnode 依赖经 rpath(@loader_path/
 // $ORIGIN) 解析、Nuitka 依赖扫描连带打包，故 freeze 自洽（本函数在非 Win 直接返回）。
 // 冻结 kfc 可执行会加载与其同目录的 pykungfu.pyd + libnode.dll（已实测通过），故补拷即可。
+/** @param {string} bt */
 function copyPyBindingWin(bt) {
   if (!isWin) return;
   const distKfc = path.join(CORE, 'dist', 'kungfu');
@@ -176,6 +194,7 @@ function copyPyBindingWin(bt) {
 
 // ----------------------------------------------------------------- nuitka
 
+/** @param {string} bt */
 function freezeNuitka(bt) {
   const rel = path.join(CORE, 'build', bt); // 三 native（pykungfu/libkungfu/libnode）同目录
   const out = path.join(CORE, 'build', 'kungfu-nuitka');
@@ -251,6 +270,7 @@ function freezeNuitka(bt) {
 
 // ------------------------------------------------------------- pyinstaller
 
+/** @param {string} bt */
 function freezePyinstaller(bt) {
   stage();
   ensureBuildInfo(bt);
@@ -328,6 +348,7 @@ function promote() {
   console.log(`[freeze] promote 完成：${n} 项`);
 }
 
+/** @param {string} p */
 function existsLstat(p) {
   try {
     fs.lstatSync(p);

--- a/framework/core/.gyp/run-link-node.js
+++ b/framework/core/.gyp/run-link-node.js
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
+// @ts-check
 
 const libnode = require('@kungfu-tech/libnode');
 const fs = require('fs');
@@ -8,15 +9,20 @@ const path = require('path');
 const { shell } = require('../lib');
 
 function main() {
-  const buildType = shell.getConfigValue('build_type');
-  glob.sync('*.*', { cwd: libnode.libpath }).forEach((p) => {
-    const src = path.join(libnode.libpath, p);
-    const dst = path.join('build', buildType, path.basename(p));
-    if (fs.lstatSync(src).isFile()) {
-      console.log(`$ cp ${src} ${dst}`);
-      fse.copySync(src, dst, { overwrite: true });
-    }
-  });
+  // build_type is always provided via npm/pnpm package config when these build
+  // scripts run; assert string so path.join accepts it (getConfigValue reads
+  // process.env, whose type is string | undefined).
+  const buildType = /** @type {string} */ (shell.getConfigValue('build_type'));
+  glob
+    .sync('*.*', { cwd: libnode.libpath })
+    .forEach((/** @type {string} */ p) => {
+      const src = path.join(libnode.libpath, p);
+      const dst = path.join('build', buildType, path.basename(p));
+      if (fs.lstatSync(src).isFile()) {
+        console.log(`$ cp ${src} ${dst}`);
+        fse.copySync(src, dst, { overwrite: true });
+      }
+    });
 }
 
 module.exports.main = main;

--- a/framework/core/.gyp/run-wheel.js
+++ b/framework/core/.gyp/run-wheel.js
@@ -1,10 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0
+// @ts-check
 
 const fse = require('fs-extra');
 const path = require('path');
 const { spawnSync } = require('child_process');
 
-const buildType = process.env.npm_package_config_build_type;
+// npm/pnpm package config always sets build_type when these build scripts run;
+// assert string so path.join accepts it (process.env values are string | undefined).
+const buildType = /** @type {string} */ (
+  process.env.npm_package_config_build_type
+);
 const srcDir = path.join('src', 'python');
 const buildDir = path.join('build', buildType);
 const wheelDir = path.join('build', 'python');
@@ -12,10 +17,10 @@ const vsDir = path.join('.deps', 'vs');
 
 fse.removeSync(wheelDir);
 fse.copySync(srcDir, wheelDir, {
-  filter: (p) => !path.basename(p).startsWith('kfc.'),
+  filter: (/** @type {string} */ p) => !path.basename(p).startsWith('kfc.'),
 });
 fse.copySync(buildDir, wheelDir, {
-  filter: (p) => !path.basename(p).endsWith('.node'),
+  filter: (/** @type {string} */ p) => !path.basename(p).endsWith('.node'),
 });
 if (process.platform == 'win32') {
   fse.copySync(vsDir, wheelDir);
@@ -34,4 +39,6 @@ const result = spawnSync('uv', uv_args, {
   cwd: wheelDir,
 });
 
-process.exit(result.status);
+// spawnSync().status is null when the child was terminated by a signal; treat
+// that as a failure (1) instead of letting process.exit(null) report success (0).
+process.exit(result.status ?? 0);

--- a/framework/core/.gyp/verify-windows-symbols.js
+++ b/framework/core/.gyp/verify-windows-symbols.js
@@ -14,6 +14,7 @@
 // or from the freeze pipeline:
 //   const { verifyWindowsSymbols } = require('./verify-windows-symbols');
 //   verifyWindowsSymbols(path.join(CORE, 'dist', 'kungfu'));
+// @ts-check
 
 const fs = require('fs');
 const path = require('path');
@@ -32,6 +33,12 @@ const REQUIRED = [
 
 // The linker PDB is named after the target's output base, so accept
 // "<module>.pdb" as well as an ABI-suffixed "<module>.<abi>.pdb".
+/**
+ * @param {string} dir
+ * @param {string} binName
+ * @param {string[]} pdbNames
+ * @returns {boolean}
+ */
 function hasSiblingPdb(dir, binName, pdbNames) {
   const stem = binName
     .replace(/\.(node|pyd)$/i, '')
@@ -40,9 +47,11 @@ function hasSiblingPdb(dir, binName, pdbNames) {
   return pdbNames.some((p) => p.toLowerCase().startsWith(stem));
 }
 
+/** @param {string} distKfc */
 function verifyWindowsSymbols(distKfc) {
   const entries = fs.existsSync(distKfc) ? fs.readdirSync(distKfc) : [];
   const pdbNames = entries.filter((f) => /\.pdb$/i.test(f));
+  /** @type {string[]} */
   const missing = [];
   for (const re of REQUIRED) {
     const bin = entries.find((f) => re.test(f));

--- a/framework/core/lib/executable.js
+++ b/framework/core/lib/executable.js
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
+// @ts-check
 
 const path = require('path');
 
+/** @param {string} name @returns {string} */
 function resolve(name) {
   const kungfuDir = path.resolve(__dirname, '..', 'dist', 'kungfu');
   const bin = process.platform === 'win32' ? `${name}.exe` : name;

--- a/framework/core/lib/kungfu.js
+++ b/framework/core/lib/kungfu.js
@@ -1,6 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
+// @ts-check
 
+/**
+ * Load the native kungfu binding and expose its typed factory surface.
+ *
+ * The binding is a dynamically-resolved native addon, so it has no static
+ * type. It is treated as `any` here; the annotations below describe the
+ * public factory API this module hands to callers, not the addon internals.
+ * @returns {Record<string, any>}
+ */
 module.exports = function () {
+  /** @type {any} */
   const binding = (() => {
     try {
       const moduleName = '@kungfu-tech/core';
@@ -42,6 +52,14 @@ module.exports = function () {
     pyEvalFile: binding.pyEvalFile,
     shutdown: binding.shutdown,
     Longfist: () => new binding.Longfist(),
+    /**
+     * @param {any} arg a single location or an array of locations
+     * @param {string} [mode]
+     * @param {string} [category]
+     * @param {string} [group]
+     * @param {string} [name]
+     * @returns {any}
+     */
     Assemble: function (
       arg,
       mode = '*',
@@ -56,34 +74,62 @@ module.exports = function () {
       }
     },
 
+    /** @param {any} home @returns {any} */
     History: function (home) {
       return new binding.History(home);
     },
+    /** @param {any} home @returns {any} */
     ConfigStore: function (home) {
       return new binding.ConfigStore(home);
     },
+    /** @param {any} home @returns {any} */
     RiskSettingStore: function (home) {
       return new binding.RiskSettingStore(home);
     },
+    /** @param {any} home @returns {any} */
     CommissionStore: function (home) {
       return new binding.CommissionStore(home);
     },
+    /** @param {any} home @returns {any} */
     BasketStore: function (home) {
       return new binding.BasketStore(home);
     },
+    /** @param {any} home @returns {any} */
     BasketInstrumentStore: function (home) {
       return new binding.BasketInstrumentStore(home);
     },
+    /** @param {any} location @param {any} home @returns {any} */
     SessionStore: function (location, home) {
       return new binding.SessionStore(location, home);
     },
+    /** @param {any} location @param {any} home @returns {any} */
     IODevice: function (location, home) {
       return new binding.IODevice(location, home);
     },
+    /**
+     * @param {any} location
+     * @param {any} home
+     * @param {boolean} read
+     * @param {boolean} write
+     * @param {number} begin
+     * @param {number} end
+     * @returns {any}
+     */
     tracer: function (location, home, read, write, begin, end) {
       return new binding.Tracer(location, home, read, write, begin, end);
     },
 
+    /**
+     * @param {any} home
+     * @param {string} name
+     * @param {boolean} [bypassRestore]
+     * @param {boolean} [bypassAccounting]
+     * @param {boolean} [bypassTradingData]
+     * @param {boolean} [refreshTradingDataBeforeSync]
+     * @param {boolean} [bypassRefreshBook]
+     * @param {number} [millisecondsSleepAfterStep]
+     * @returns {any}
+     */
     watcher: function (
       home,
       name,

--- a/framework/core/lib/prebuilt.js
+++ b/framework/core/lib/prebuilt.js
@@ -1,14 +1,27 @@
 // SPDX-License-Identifier: Apache-2.0
+// @ts-check
 
+/**
+ * Drive @mapbox/node-pre-gyp's command pipeline, installing binary-host config
+ * before the `install` step and tolerating missing prebuilt binaries.
+ * @param {...string} argv extra node-pre-gyp CLI args
+ * @returns {any} the Runner instance (exposes onSuccess/onFailure)
+ */
 const main = (...argv) => {
+  /** @type {any} @mapbox/node-pre-gyp has no bundled types */
   const node_pre_gyp = require('@mapbox/node-pre-gyp');
   const shell = require('./shell');
 
+  /**
+   * @type {any}
+   * @this {any}
+   */
   const Runner = function () {
     const prog = new node_pre_gyp.Run({
       argv: [process.execPath, __filename, ...argv],
     });
 
+    /** @param {any} runner */
     const run = (runner) => {
       const command = prog.todo.shift();
       if (!command) {
@@ -18,24 +31,27 @@ const main = (...argv) => {
         shell.setAutoConfig();
         shell.showAutoConfig();
       }
-      prog.commands[command.name](command.args, function (err) {
-        if (!err) {
-          process.nextTick(() => run(runner));
-          return;
-        }
-        if (
-          command.name !== 'install' ||
-          '--build-from-source' in command.args
-        ) {
-          runner.failure(err);
-        }
-        const msg = 'safely ignore missing binaries (expected to build)';
-        try {
-          require('npmlog').info('install', msg);
-        } catch (e) {
-          console.log(msg);
-        }
-      });
+      prog.commands[command.name](
+        command.args,
+        /** @param {any} err */ function (err) {
+          if (!err) {
+            process.nextTick(() => run(runner));
+            return;
+          }
+          if (
+            command.name !== 'install' ||
+            '--build-from-source' in command.args
+          ) {
+            runner.failure(err);
+          }
+          const msg = 'safely ignore missing binaries (expected to build)';
+          try {
+            require('npmlog').info('install', msg);
+          } catch (e) {
+            console.log(msg);
+          }
+        },
+      );
     };
 
     if (prog.todo.length > 0) {
@@ -46,15 +62,18 @@ const main = (...argv) => {
   };
 
   const proto = Runner.prototype;
+  /** @param {any} err */
   proto.failure = (err) => {
     console.error(err);
     process.exit(-1);
   };
   proto.success = () => true;
+  /** @param {any} cb */
   proto.onFailure = function (cb) {
     this.failure = cb;
     return this;
   };
+  /** @param {any} cb */
   proto.onSuccess = function (cb) {
     this.success = cb;
     return this;

--- a/framework/core/lib/shell.js
+++ b/framework/core/lib/shell.js
@@ -1,22 +1,32 @@
 // SPDX-License-Identifier: Apache-2.0
+// @ts-check
 
 const { spawnSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
 
 const GithubBinaryHost = 'https://prebuilt.libkungfu.io';
+/**
+ * Identity predicate used with Array#filter to drop null/undefined entries.
+ * @template T
+ * @param {T} e
+ * @returns {T}
+ */
 const defined = (e) => e;
 
 const utils = {
+  /** @param {unknown} error */
   exitOnError: function (error) {
     console.error(error);
     process.exit(-1);
   },
 
+  /** @param {string} npmConfigValue @returns {string} */
   getScope: function (npmConfigValue) {
     return npmConfigValue === 'undefined' ? '[package.json]' : '[user]';
   },
 
+  /** @param {string} cmd @param {string[]} argv @param {{ silent?: boolean }} opts */
   trace: function (cmd, argv, opts) {
     if (!opts.silent) {
       console.log(`$ ${cmd} ${argv.join(' ')}`);
@@ -28,12 +38,20 @@ const utils = {
     return local ? '.gyp' : path.resolve(__dirname);
   },
 
+  /** @param {string} key @returns {string} */
   getNpmConfigValue: function (key) {
     return shell.runAndCollect('npm', ['config', 'get', key], { silent: true })
       .out;
   },
 
+  /**
+   * Collect the package names in a package.json's dependency maps that
+   * themselves declare a node-pre-gyp `binary` block.
+   * @param {any} packageJson a parsed package.json (untyped shape)
+   * @returns {string[]}
+   */
   findBinaryDependency: function (packageJson) {
+    /** @param {Record<string, string>} deps */
     const hasBinary = (deps) =>
       Object.keys(deps)
         .map((key) => {
@@ -53,6 +71,7 @@ const utils = {
       .flat();
   },
 
+  /** @param {string} [packageName] */
   setBinaryHostConfig: function (packageName) {
     const packageJson = shell.getPackageJson(packageName);
     if (!packageJson) {
@@ -67,6 +86,7 @@ const utils = {
     }
   },
 
+  /** @param {string} key */
   showProjectConfig: function (key) {
     const packageJson = shell.getPackageJson();
     const projectName = packageJson.name;
@@ -79,6 +99,7 @@ const utils = {
     );
   },
 
+  /** @param {string} [packageName] */
   showBinaryHostConfig: function (packageName) {
     const packageJson = shell.getPackageJson(packageName);
     if (!packageJson) {
@@ -98,8 +119,10 @@ const utils = {
 };
 
 const shell = {
+  /** @returns {string | undefined} */
   getElectronArch: function () {
     try {
+      /** @type {any} electron's main-process require has no bundled types here */
       const electron = require('electron');
       const electronVersionScript = path.resolve(
         path.dirname(__dirname),
@@ -115,6 +138,7 @@ const shell = {
           silent: true,
         },
       ).out;
+      /** @param {string | undefined} arch */
       const resolveHeadless = (arch) => {
         return arch || shell.getTargetArch();
       };
@@ -124,6 +148,7 @@ const shell = {
     }
   },
 
+  /** @returns {string} */
   getTargetArch: function () {
     // tracing-foundation Phase 1: config.arch 未显式设置时回退到宿主架构(process.arch)。
     // 原 config 硬编码 'x64'(x64 时代),在 arm64 机器上会误判;回退使本机构建自动匹配
@@ -133,7 +158,14 @@ const shell = {
     );
   },
 
+  /**
+   * Read and parse a package.json: the current working dir's when no name is
+   * given, otherwise the named package's (resolved via require.resolve).
+   * @param {string} [packageName]
+   * @returns {any} parsed package.json, or undefined if the named one is unresolvable
+   */
   getPackageJson: function (packageName) {
+    /** @param {string} filepath */
     const toJSON = (filepath) => {
       return JSON.parse(fs.readFileSync(filepath, 'utf8').toString());
     };
@@ -147,10 +179,12 @@ const shell = {
     }
   },
 
+  /** @param {string} name @returns {string | undefined} */
   getConfigValue: function (name) {
     return process.env[`npm_package_config_${name}`];
   },
 
+  /** @param {string[]} npmArgs */
   npmCall: function (npmArgs) {
     return shell.run('npm', npmArgs);
   },
@@ -196,6 +230,16 @@ const shell = {
     }
   },
 
+  /**
+   * spawnSync a command with the shell, inheriting stdio, from the real
+   * (symlink-resolved) cwd. When `check` is set, exit the process on a non-zero
+   * status unless `opts.tolerant` is set.
+   * @param {string} cmd
+   * @param {string[]} [argv]
+   * @param {boolean} [check]
+   * @param {import('child_process').SpawnSyncOptions & { silent?: boolean, tolerant?: boolean }} [opts]
+   * @returns {import('child_process').SpawnSyncReturns<string | Buffer>}
+   */
   run: function (cmd, argv = [], check = true, opts = {}) {
     const real_cwd = fs.realpathSync(path.resolve(process.cwd().toString()));
     utils.trace(cmd, argv, opts);
@@ -207,11 +251,21 @@ const shell = {
       ...opts,
     });
     if (check && result.status !== 0) {
-      process.exit(opts.tolerant ? 0 : result.status);
+      // status is null when the child was terminated by a signal; keep the
+      // original runtime behaviour (process.exit(null) === exit code 0).
+      process.exit(opts.tolerant ? 0 : (result.status ?? 0));
     }
     return result;
   },
 
+  /**
+   * Like `run` but pipes stdout and returns it, trimmed, as an extra `out`
+   * field on the spawn result.
+   * @param {string} cmd
+   * @param {string[]} [argv]
+   * @param {import('child_process').SpawnSyncOptions & { silent?: boolean }} [opts]
+   * @returns {import('child_process').SpawnSyncReturns<string | Buffer> & { out: string }}
+   */
   runAndCollect: function (cmd, argv = [], opts = {}) {
     utils.trace(cmd, argv, opts);
     const result = spawnSync(cmd, argv, {
@@ -220,10 +274,17 @@ const shell = {
       windowsHide: true,
       ...opts,
     });
-    result.out = result.stdout.toString().trim();
-    return result;
+    const out = result.stdout.toString().trim();
+    return Object.assign(result, { out });
   },
 
+  /**
+   * Run a command; if it succeeds, exit the process with code 0, otherwise
+   * return the spawn result for the caller to handle.
+   * @param {string} cmd
+   * @param {string[]} [argv]
+   * @param {import('child_process').SpawnSyncOptions & { silent?: boolean, tolerant?: boolean }} [opts]
+   */
   runAndExit: function (cmd, argv = [], opts = {}) {
     const result = shell.run(cmd, argv, false, opts);
     if (result.status === 0) {
@@ -265,6 +326,7 @@ const shell = {
     utils.findBinaryDependency(packageJson).map(utils.showBinaryHostConfig);
   },
 
+  /** @param {string} filename @param {string} [dirname] */
   touch: function (filename, dirname = process.cwd().toString()) {
     const now = new Date();
     const filepath = path.resolve(dirname, filename);

--- a/framework/core/lib/sywac.js
+++ b/framework/core/lib/sywac.js
@@ -1,7 +1,19 @@
 // SPDX-License-Identifier: Apache-2.0
+// @ts-check
 
+/**
+ * Build a sywac CLI: wire the caller's `setup`, optional -h/--help and
+ * -v/--version, and parse+exit when run as the main module. Returns the cli
+ * instance so callers can further configure it.
+ * @param {NodeModule} module the caller's `module`, to detect `require.main`
+ * @param {(cli: any) => void} setup callback that registers commands/options
+ * @param {{ silent?: boolean, tolerant?: boolean, help?: boolean, version?: boolean }} [opts]
+ * @returns {any} the configured sywac cli instance
+ */
 module.exports = function (module, setup, opts = {}) {
+  /** @type {any} sywac has no bundled types */
   const cli = require('sywac').strict();
+  /** @param {any} result */
   const exitHandler = (result) => {
     if (result.output) {
       console.log(result.output);
@@ -13,6 +25,7 @@ module.exports = function (module, setup, opts = {}) {
     }
     return result.argv;
   };
+  /** @param {any} error */
   const errorHandler = (error) => {
     console.error(error);
     opts.tolerant || process.exit(-1);

--- a/framework/core/src/python/kungfu/rewind/hook/rewind_hook.js
+++ b/framework/core/src/python/kungfu/rewind/hook/rewind_hook.js
@@ -12,6 +12,7 @@
 // it around cross-process tool execution); spans created here root under it,
 // so one causal chain spans both runtimes inside the same journal.
 'use strict';
+// @ts-check
 
 const net = require('net');
 const crypto = require('crypto');
@@ -21,8 +22,10 @@ const endpoint = process.env.KUNGFU_REWIND_INGEST;
 const bootParent = process.env.KUNGFU_REWIND_PARENT_SPAN || null;
 
 if (endpoint) {
+  /** @type {import('net').Socket | null} */
   let sock = null;
   let dead = false;
+  /** @type {string[]} */
   const pending = [];
 
   const [host, port] = (() => {
@@ -31,18 +34,23 @@ if (endpoint) {
   })();
 
   const connect = () => {
-    sock = net.createConnection({ host, port, timeout: 1000 });
-    sock.on('connect', () => {
-      for (const line of pending.splice(0)) sock.write(line);
+    // Hold the created socket in a local so the connect handler writes to this
+    // exact connection even if `sock` is later nulled by the error handler
+    // (also lets @ts-check narrow away the Socket | null union).
+    const s = net.createConnection({ host, port, timeout: 1000 });
+    sock = s;
+    s.on('connect', () => {
+      for (const line of pending.splice(0)) s.write(line);
     });
-    sock.on('error', () => {
+    s.on('error', () => {
       dead = true;
       sock = null;
     });
-    sock.unref(); // never keep the traced process alive
+    s.unref(); // never keep the traced process alive
   };
   connect();
 
+  /** @param {unknown} message */
   const emit = (message) => {
     if (dead) return;
     const line = JSON.stringify(message) + '\n';
@@ -56,6 +64,15 @@ if (endpoint) {
 
   const newSpan = () => crypto.randomBytes(16).toString('hex');
 
+  /**
+   * @param {string} toolName
+   * @param {string | null} parentSpan
+   * @param {string | null} retryOf
+   * @param {number} attempt
+   * @param {string} input
+   * @param {() => any} fn
+   * @returns {{ result: any, spanId: string }}
+   */
   const captureInvoke = (toolName, parentSpan, retryOf, attempt, input, fn) => {
     const spanId = newSpan();
     if (retryOf) {
@@ -74,6 +91,11 @@ if (endpoint) {
       input,
     });
     const started = process.hrtime.bigint();
+    /**
+     * @param {string} status
+     * @param {string | null} output
+     * @param {string | null} error
+     */
     const done = (status, output, error) =>
       emit({
         event: 'tool_result',
@@ -88,11 +110,13 @@ if (endpoint) {
       done('ok', render(result), null);
       return { result, spanId };
     } catch (e) {
-      done('error', null, `${e.name || 'Error'}: ${e.message || e}`);
+      const err = /** @type {Error} */ (e);
+      done('error', null, `${err.name || 'Error'}: ${err.message || err}`);
       throw e;
     }
   };
 
+  /** @param {unknown} value */
   const render = (value) => {
     try {
       return JSON.stringify(value);
@@ -102,18 +126,23 @@ if (endpoint) {
   };
 
   // ── post-require adapters (mini require-in-the-middle) ──────────
+  /**
+   * @param {any} exports the loaded demo-toolkit module (arbitrary shape)
+   * @returns {any}
+   */
   const patchDemoToolkit = (exports) => {
     const originalRun = exports.Tool.prototype.run;
     const originalInvoke = exports.Tool.prototype._invoke;
     let attempt = 0;
+    /** @type {string | null} */
     let prevSpan = null;
 
-    exports.Tool.prototype.run = function (toolInput) {
+    exports.Tool.prototype.run = function (/** @type {any} */ toolInput) {
       attempt = 0;
       prevSpan = null;
       return originalRun.call(this, toolInput);
     };
-    exports.Tool.prototype._invoke = function (toolInput) {
+    exports.Tool.prototype._invoke = function (/** @type {any} */ toolInput) {
       attempt += 1;
       const { result, spanId } = captureInvoke(
         this.name,
@@ -131,8 +160,13 @@ if (endpoint) {
 
   // The demo toolkit is the built-in mechanism probe; real framework adapters
   // are kfx packages the supervisor discovers and announces.
+  /** @type {Record<string, (exports: any) => any>} */
   const ADAPTERS = { rewind_demo_toolkit: patchDemoToolkit };
 
+  /**
+   * @param {string} name
+   * @param {(exports: any) => any} patcher
+   */
   const registerAdapter = (name, patcher) => {
     ADAPTERS[name] = patcher;
   };
@@ -140,7 +174,7 @@ if (endpoint) {
   // Expose the capture API to plugin adapters loaded later. A node kfx adapter
   // reads globalThis.__kungfuRewind (it depends on nothing else) and registers
   // its patcher — the node analogue of the python hook's importable primitives.
-  globalThis.__kungfuRewind = {
+  /** @type {any} */ (globalThis).__kungfuRewind = {
     registerAdapter,
     captureInvoke,
     newSpan,
@@ -162,12 +196,19 @@ if (endpoint) {
     }
   }
 
-  const originalLoad = Module._load;
-  Module._load = function (request, parent, isMain) {
+  // Module._load is an internal, undocumented API absent from @types/node,
+  // so the module object is cast to any to reach it (require-in-the-middle).
+  const ModuleInternal = /** @type {any} */ (Module);
+  const originalLoad = ModuleInternal._load;
+  ModuleInternal._load = function (
+    /** @type {string} */ request,
+    /** @type {any} */ parent,
+    /** @type {boolean} */ isMain,
+  ) {
     const exports = originalLoad.apply(this, arguments);
     try {
       const name = request.replace(/\.js$/, '').split(/[\\/]/).pop();
-      const patcher = ADAPTERS[name];
+      const patcher = name ? ADAPTERS[name] : undefined;
       if (patcher && !exports.__rewind_patched__) {
         Object.defineProperty(exports, '__rewind_patched__', { value: true });
         return patcher(exports);

--- a/framework/gui/lib/index.js
+++ b/framework/gui/lib/index.js
@@ -1,4 +1,5 @@
 'use strict';
+// @ts-check
 
 // Build/dev entry points for the kungfu reference app, kept so the developer/sdk
 // `craft` flow (`require('@kungfu-tech/gui').electronBuild / .devRun`)
@@ -13,6 +14,13 @@ const { spawn } = require('child_process');
 
 const appDir = path.join(__dirname, '..');
 
+/**
+ * Spawn a locally-installed bin (from the app's node_modules/.bin), inheriting
+ * stdio; resolve on exit code 0, reject otherwise.
+ * @param {string} bin
+ * @param {string[]} args
+ * @returns {Promise<void>}
+ */
 function runBin(bin, args) {
   return new Promise((resolve, reject) => {
     const binPath = path.join(

--- a/framework/gui/scripts/ensure-electron.mjs
+++ b/framework/gui/scripts/ensure-electron.mjs
@@ -7,6 +7,7 @@
 // launch/package verb runs this first: present -> no-op in milliseconds,
 // missing -> run electron's own install script in place (ELECTRON_MIRROR and
 // friends come from the environment kungfu-code already loads).
+// @ts-check
 
 import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';

--- a/framework/spec/index.js
+++ b/framework/spec/index.js
@@ -5,6 +5,7 @@
 // The bundle's authoritative payload is a set of files (manifest.json + the six
 // categories + three handbooks); this module only exposes stable locators so a
 // consumer can find the contract and, once built, the generated manifest.
+// @ts-check
 
 const path = require('path');
 

--- a/framework/spec/scripts/aggregate.js
+++ b/framework/spec/scripts/aggregate.js
@@ -10,6 +10,7 @@
 // stubs; their real generators (framework/core etc.) replace them later
 // (drift = build fail once that flow lands). Ownership is recorded in the
 // manifest so nothing is silently faked.
+// @ts-check
 
 const fs = require('fs');
 const path = require('path');
@@ -18,20 +19,33 @@ const { execFileSync } = require('child_process');
 const pkgRoot = path.resolve(__dirname, '..');
 const distDir = path.join(pkgRoot, 'dist');
 
+/** @param {string} msg */
 function log(msg) {
   console.log(`[spec:aggregate] ${msg}`);
 }
 
+/**
+ * @param {string} p
+ * @returns {any}
+ */
 function readJson(p) {
   return JSON.parse(fs.readFileSync(p, 'utf8'));
 }
 
+/**
+ * @param {string} rel
+ * @param {unknown} obj
+ */
 function writeJson(rel, obj) {
   const abs = path.join(distDir, rel);
   fs.mkdirSync(path.dirname(abs), { recursive: true });
   fs.writeFileSync(abs, JSON.stringify(obj, null, 2) + '\n');
 }
 
+/**
+ * @param {string} rel
+ * @param {string} text
+ */
 function writeText(rel, text) {
   const abs = path.join(distDir, rel);
   fs.mkdirSync(path.dirname(abs), { recursive: true });
@@ -62,6 +76,10 @@ function main() {
   fs.rmSync(distDir, { recursive: true, force: true });
   fs.mkdirSync(distDir, { recursive: true });
 
+  /**
+   * @param {string} srcRel
+   * @param {string} distRel
+   */
   const copyDoc = (srcRel, distRel) =>
     writeText(distRel, fs.readFileSync(path.join(pkgRoot, srcRel), 'utf8'));
 

--- a/framework/spec/scripts/verify.js
+++ b/framework/spec/scripts/verify.js
@@ -14,6 +14,7 @@
 //   3. all six categories + three handbooks declared, each with required fields
 //   4. every path the manifest references actually exists in the bundle
 //   5. spec_version is consistently routed into docs_url_base
+// @ts-check
 
 const fs = require('fs');
 const path = require('path');
@@ -23,7 +24,12 @@ const distDir = path.join(pkgRoot, 'dist');
 const schemaPath = path.join(pkgRoot, 'schema', 'manifest.schema.json');
 const manifestPath = path.join(distDir, 'manifest.json');
 
+/** @type {string[]} */
 const failures = [];
+/**
+ * @param {unknown} cond
+ * @param {string} msg
+ */
 function check(cond, msg) {
   if (!cond) failures.push(msg);
 }
@@ -35,7 +41,7 @@ function main() {
     schema = JSON.parse(fs.readFileSync(schemaPath, 'utf8'));
   } catch (err) {
     console.error(
-      `[spec:verify] FAIL: cannot read/parse manifest schema: ${err.message}`,
+      `[spec:verify] FAIL: cannot read/parse manifest schema: ${/** @type {Error} */ (err).message}`,
     );
     return 1;
   }
@@ -52,7 +58,7 @@ function main() {
     m = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
   } catch (err) {
     console.error(
-      `[spec:verify] FAIL: dist/manifest.json does not parse: ${err.message}`,
+      `[spec:verify] FAIL: dist/manifest.json does not parse: ${/** @type {Error} */ (err).message}`,
     );
     return 1;
   }

--- a/framework/tui/build-bundle.mjs
+++ b/framework/tui/build-bundle.mjs
@@ -6,6 +6,7 @@
 // await, which the CJS format cannot represent. The kungfu_node binding is
 // loaded at runtime by absolute path (a dynamic require esbuild leaves alone),
 // so it stays external.
+// @ts-check
 
 import esbuild from 'esbuild';
 
@@ -14,6 +15,12 @@ import esbuild from 'esbuild';
 // empty module so the bundle is self-contained.
 const stubDevtools = {
   name: 'stub-react-devtools-core',
+  /**
+   * esbuild plugin setup hook. `build` is esbuild's PluginBuild object; it
+   * is typed as `any` here because esbuild ships no types in this checkout.
+   * @param {any} build
+   * @returns {void}
+   */
   setup(build) {
     build.onResolve({ filter: /^react-devtools-core$/ }, () => ({
       path: 'react-devtools-core',

--- a/install-hooks.js
+++ b/install-hooks.js
@@ -11,6 +11,7 @@
 // Run automatically from the root `prepare` script on install, or manually via
 // `pnpm run hooks:install` (which passes --force). It is idempotent and refuses
 // to clobber a developer's own pre-commit unless --force is given.
+// @ts-check
 'use strict';
 
 const fs = require('fs');
@@ -20,11 +21,17 @@ const { spawnSync } = require('child_process');
 const OURS_MARKER = 'kungfu pre-commit hook';
 const REPLACEABLE = [OURS_MARKER, '#yorkie']; // our own hook, or the dead yorkie shim
 
+/**
+ * Run git with the given args and return trimmed stdout, or null on failure.
+ * @param {string[]} args
+ * @returns {string | null}
+ */
 function git(args) {
   const r = spawnSync('git', args, { encoding: 'utf8' });
   return r.status === 0 ? String(r.stdout).trim() : null;
 }
 
+/** @param {string} msg */
 function log(msg) {
   process.stderr.write(`[install-hooks] ${msg}\n`);
 }

--- a/kungfu-code.js
+++ b/kungfu-code.js
@@ -13,6 +13,7 @@
 //
 // The config file lives user-global at ${XDG_CONFIG_HOME:-~/.config}/kungfu/build-local.env: the main repo and all
 // git worktrees share one copy, it is naturally outside the repo (open-source safe), and only needs one sync across intranet machines.
+// @ts-check
 'use strict';
 
 const fs = require('fs');
@@ -47,7 +48,12 @@ function readRaw() {
   }
 }
 
+/**
+ * Parse the config file into a key/value map.
+ * @returns {Record<string, string>}
+ */
 function readConfig() {
+  /** @type {Record<string, string>} */
   const out = {};
   for (const line of readRaw().split('\n')) {
     const m = line.match(/^\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)=(.*)$/);
@@ -64,6 +70,11 @@ function readConfig() {
   return out;
 }
 
+/**
+ * Single-quote a value for safe embedding in the shell env file.
+ * @param {string} v
+ * @returns {string}
+ */
 function shQuote(v) {
   return "'" + String(v).replace(/'/g, "'\\''") + "'";
 }
@@ -72,6 +83,11 @@ function ensureDir() {
   fs.mkdirSync(path.dirname(CONFIG_FILE), { recursive: true });
 }
 
+/**
+ * Upsert one KEY=value entry in the config file.
+ * @param {string} key
+ * @param {string} val
+ */
 function setKey(key, val) {
   ensureDir();
   let text = readRaw();
@@ -82,6 +98,10 @@ function setKey(key, val) {
   fs.writeFileSync(CONFIG_FILE, text);
 }
 
+/**
+ * Remove one KEY=value entry from the config file.
+ * @param {string} key
+ */
 function unsetKey(key) {
   const text = readRaw();
   if (!text) return;
@@ -92,6 +112,7 @@ function unsetKey(key) {
 module.exports = { CONFIG_FILE, KEYS, readConfig, setKey, unsetKey };
 
 // ── CLI (entrypoint delegated from L1 sh) ────────────────────────────────────
+/** @param {string} cmd */
 function help(cmd) {
   console.error(
     `kungfu-code ${cmd} — manage local build environment config: mirrors/cache + compile params (user-global build-local.env)\n` +

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "rebuild:core": "pnpm --filter @kungfu-tech/core run rebuild",
     "package:app": "pnpm --filter @kungfu-tech/artifact-kungfu run package",
     "verify": "node verify.js",
+    "check:types": "tsc -p tsconfig.tools.json",
     "prepare": "node install-hooks.js",
     "hooks:install": "node install-hooks.js --force"
   },
@@ -53,6 +54,10 @@
     "wsrun": "^5.2.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "1.9.4"
+    "@biomejs/biome": "1.9.4",
+    "@types/fs-extra": "^11.0.4",
+    "@types/node": "^22.0.0",
+    "@types/npmlog": "^7.0.0",
+    "typescript": "^5.6.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,7 @@ importers:
         version: 1.11.21
       lerna:
         specifier: ^9.0.0
-        version: 9.0.7(@types/node@24.13.2)(debug@4.4.3)
+        version: 9.0.7(@types/node@22.20.0)(debug@4.4.3)
       wsrun:
         specifier: ^5.2.0
         version: 5.2.4
@@ -27,6 +27,18 @@ importers:
       '@biomejs/biome':
         specifier: 1.9.4
         version: 1.9.4
+      '@types/fs-extra':
+        specifier: ^11.0.4
+        version: 11.0.4
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.20.0
+      '@types/npmlog':
+        specifier: ^7.0.0
+        version: 7.0.0
+      typescript:
+        specifier: ^5.6.0
+        version: 5.9.3
 
   artifact:
     dependencies:
@@ -1565,6 +1577,9 @@ packages:
   '@types/find-root@1.1.4':
     resolution: {integrity: sha512-2EXK/+gVhVgtt4JqThbEncORvpYJKzi9tQGmI3EkU2jTgMzQsrPm/hbd5xe5uPdeFzIW5gh2PRvvPjaUsI8vpg==}
 
+  '@types/fs-extra@11.0.4':
+    resolution: {integrity: sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ==}
+
   '@types/fs-extra@9.0.13':
     resolution: {integrity: sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==}
 
@@ -1576,6 +1591,9 @@ packages:
 
   '@types/istanbul-reports@1.1.2':
     resolution: {integrity: sha512-P/W9yOX/3oPZSpaYOCQzGqgCQRXn0FFO/V8bWrCQs+wLmvVVxk6CRBXALEvNs9OHIatlnlFokfhuDo2ug01ciw==}
+
+  '@types/jsonfile@6.1.4':
+    resolution: {integrity: sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ==}
 
   '@types/minimist@1.2.5':
     resolution: {integrity: sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==}
@@ -1594,6 +1612,9 @@ packages:
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
+
+  '@types/npmlog@7.0.0':
+    resolution: {integrity: sha512-hJWbrKFvxKyWwSUXjZMYTINsSOY6IclhvGOZ97M8ac2tmR9hMwmTnYaMdpGhvju9ctWLTPhCS+eLfQNluiEjQQ==}
 
   '@types/plist@3.0.5':
     resolution: {integrity: sha512-E6OCaRmAe4WDmWNsL/9RMqdkkzDCY1etutkflWk4c+AcjDU07Pcz1fQwTX0TQz+Pxqn9i4L1TU3UFpjnrcDgxA==}
@@ -4932,128 +4953,128 @@ snapshots:
 
   '@inquirer/ansi@1.0.2': {}
 
-  '@inquirer/checkbox@4.3.2(@types/node@24.13.2)':
+  '@inquirer/checkbox@4.3.2(@types/node@22.20.0)':
     dependencies:
       '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.2(@types/node@24.13.2)
+      '@inquirer/core': 10.3.2(@types/node@22.20.0)
       '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@24.13.2)
+      '@inquirer/type': 3.0.10(@types/node@22.20.0)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 24.13.2
+      '@types/node': 22.20.0
 
-  '@inquirer/confirm@5.1.21(@types/node@24.13.2)':
+  '@inquirer/confirm@5.1.21(@types/node@22.20.0)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@24.13.2)
-      '@inquirer/type': 3.0.10(@types/node@24.13.2)
+      '@inquirer/core': 10.3.2(@types/node@22.20.0)
+      '@inquirer/type': 3.0.10(@types/node@22.20.0)
     optionalDependencies:
-      '@types/node': 24.13.2
+      '@types/node': 22.20.0
 
-  '@inquirer/core@10.3.2(@types/node@24.13.2)':
+  '@inquirer/core@10.3.2(@types/node@22.20.0)':
     dependencies:
       '@inquirer/ansi': 1.0.2
       '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@24.13.2)
+      '@inquirer/type': 3.0.10(@types/node@22.20.0)
       cli-width: 4.1.0
       mute-stream: 2.0.0
       signal-exit: 4.1.0
       wrap-ansi: 6.2.0
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 24.13.2
+      '@types/node': 22.20.0
 
-  '@inquirer/editor@4.2.23(@types/node@24.13.2)':
+  '@inquirer/editor@4.2.23(@types/node@22.20.0)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@24.13.2)
-      '@inquirer/external-editor': 1.0.3(@types/node@24.13.2)
-      '@inquirer/type': 3.0.10(@types/node@24.13.2)
+      '@inquirer/core': 10.3.2(@types/node@22.20.0)
+      '@inquirer/external-editor': 1.0.3(@types/node@22.20.0)
+      '@inquirer/type': 3.0.10(@types/node@22.20.0)
     optionalDependencies:
-      '@types/node': 24.13.2
+      '@types/node': 22.20.0
 
-  '@inquirer/expand@4.0.23(@types/node@24.13.2)':
+  '@inquirer/expand@4.0.23(@types/node@22.20.0)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@24.13.2)
-      '@inquirer/type': 3.0.10(@types/node@24.13.2)
+      '@inquirer/core': 10.3.2(@types/node@22.20.0)
+      '@inquirer/type': 3.0.10(@types/node@22.20.0)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 24.13.2
+      '@types/node': 22.20.0
 
-  '@inquirer/external-editor@1.0.3(@types/node@24.13.2)':
+  '@inquirer/external-editor@1.0.3(@types/node@22.20.0)':
     dependencies:
       chardet: 2.2.0
       iconv-lite: 0.7.2
     optionalDependencies:
-      '@types/node': 24.13.2
+      '@types/node': 22.20.0
 
   '@inquirer/figures@1.0.15': {}
 
-  '@inquirer/input@4.3.1(@types/node@24.13.2)':
+  '@inquirer/input@4.3.1(@types/node@22.20.0)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@24.13.2)
-      '@inquirer/type': 3.0.10(@types/node@24.13.2)
+      '@inquirer/core': 10.3.2(@types/node@22.20.0)
+      '@inquirer/type': 3.0.10(@types/node@22.20.0)
     optionalDependencies:
-      '@types/node': 24.13.2
+      '@types/node': 22.20.0
 
-  '@inquirer/number@3.0.23(@types/node@24.13.2)':
+  '@inquirer/number@3.0.23(@types/node@22.20.0)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@24.13.2)
-      '@inquirer/type': 3.0.10(@types/node@24.13.2)
+      '@inquirer/core': 10.3.2(@types/node@22.20.0)
+      '@inquirer/type': 3.0.10(@types/node@22.20.0)
     optionalDependencies:
-      '@types/node': 24.13.2
+      '@types/node': 22.20.0
 
-  '@inquirer/password@4.0.23(@types/node@24.13.2)':
-    dependencies:
-      '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.2(@types/node@24.13.2)
-      '@inquirer/type': 3.0.10(@types/node@24.13.2)
-    optionalDependencies:
-      '@types/node': 24.13.2
-
-  '@inquirer/prompts@7.10.1(@types/node@24.13.2)':
-    dependencies:
-      '@inquirer/checkbox': 4.3.2(@types/node@24.13.2)
-      '@inquirer/confirm': 5.1.21(@types/node@24.13.2)
-      '@inquirer/editor': 4.2.23(@types/node@24.13.2)
-      '@inquirer/expand': 4.0.23(@types/node@24.13.2)
-      '@inquirer/input': 4.3.1(@types/node@24.13.2)
-      '@inquirer/number': 3.0.23(@types/node@24.13.2)
-      '@inquirer/password': 4.0.23(@types/node@24.13.2)
-      '@inquirer/rawlist': 4.1.11(@types/node@24.13.2)
-      '@inquirer/search': 3.2.2(@types/node@24.13.2)
-      '@inquirer/select': 4.4.2(@types/node@24.13.2)
-    optionalDependencies:
-      '@types/node': 24.13.2
-
-  '@inquirer/rawlist@4.1.11(@types/node@24.13.2)':
-    dependencies:
-      '@inquirer/core': 10.3.2(@types/node@24.13.2)
-      '@inquirer/type': 3.0.10(@types/node@24.13.2)
-      yoctocolors-cjs: 2.1.3
-    optionalDependencies:
-      '@types/node': 24.13.2
-
-  '@inquirer/search@3.2.2(@types/node@24.13.2)':
-    dependencies:
-      '@inquirer/core': 10.3.2(@types/node@24.13.2)
-      '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@24.13.2)
-      yoctocolors-cjs: 2.1.3
-    optionalDependencies:
-      '@types/node': 24.13.2
-
-  '@inquirer/select@4.4.2(@types/node@24.13.2)':
+  '@inquirer/password@4.0.23(@types/node@22.20.0)':
     dependencies:
       '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.2(@types/node@24.13.2)
-      '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@24.13.2)
+      '@inquirer/core': 10.3.2(@types/node@22.20.0)
+      '@inquirer/type': 3.0.10(@types/node@22.20.0)
+    optionalDependencies:
+      '@types/node': 22.20.0
+
+  '@inquirer/prompts@7.10.1(@types/node@22.20.0)':
+    dependencies:
+      '@inquirer/checkbox': 4.3.2(@types/node@22.20.0)
+      '@inquirer/confirm': 5.1.21(@types/node@22.20.0)
+      '@inquirer/editor': 4.2.23(@types/node@22.20.0)
+      '@inquirer/expand': 4.0.23(@types/node@22.20.0)
+      '@inquirer/input': 4.3.1(@types/node@22.20.0)
+      '@inquirer/number': 3.0.23(@types/node@22.20.0)
+      '@inquirer/password': 4.0.23(@types/node@22.20.0)
+      '@inquirer/rawlist': 4.1.11(@types/node@22.20.0)
+      '@inquirer/search': 3.2.2(@types/node@22.20.0)
+      '@inquirer/select': 4.4.2(@types/node@22.20.0)
+    optionalDependencies:
+      '@types/node': 22.20.0
+
+  '@inquirer/rawlist@4.1.11(@types/node@22.20.0)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@22.20.0)
+      '@inquirer/type': 3.0.10(@types/node@22.20.0)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 24.13.2
+      '@types/node': 22.20.0
 
-  '@inquirer/type@3.0.10(@types/node@24.13.2)':
+  '@inquirer/search@3.2.2(@types/node@22.20.0)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@22.20.0)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@22.20.0)
+      yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 24.13.2
+      '@types/node': 22.20.0
+
+  '@inquirer/select@4.4.2(@types/node@22.20.0)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/core': 10.3.2(@types/node@22.20.0)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@22.20.0)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 22.20.0
+
+  '@inquirer/type@3.0.10(@types/node@22.20.0)':
+    optionalDependencies:
+      '@types/node': 22.20.0
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -5572,6 +5593,11 @@ snapshots:
 
   '@types/find-root@1.1.4': {}
 
+  '@types/fs-extra@11.0.4':
+    dependencies:
+      '@types/jsonfile': 6.1.4
+      '@types/node': 22.20.0
+
   '@types/fs-extra@9.0.13':
     dependencies:
       '@types/node': 22.20.0
@@ -5586,6 +5612,10 @@ snapshots:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-lib-report': 3.0.3
+
+  '@types/jsonfile@6.1.4':
+    dependencies:
+      '@types/node': 22.20.0
 
   '@types/minimist@1.2.5': {}
 
@@ -5602,6 +5632,10 @@ snapshots:
       undici-types: 7.18.2
 
   '@types/normalize-package-data@2.4.4': {}
+
+  '@types/npmlog@7.0.0':
+    dependencies:
+      '@types/node': 22.20.0
 
   '@types/plist@3.0.5':
     dependencies:
@@ -7026,17 +7060,17 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  inquirer@12.9.6(@types/node@24.13.2):
+  inquirer@12.9.6(@types/node@22.20.0):
     dependencies:
       '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.2(@types/node@24.13.2)
-      '@inquirer/prompts': 7.10.1(@types/node@24.13.2)
-      '@inquirer/type': 3.0.10(@types/node@24.13.2)
+      '@inquirer/core': 10.3.2(@types/node@22.20.0)
+      '@inquirer/prompts': 7.10.1(@types/node@22.20.0)
+      '@inquirer/type': 3.0.10(@types/node@22.20.0)
       mute-stream: 2.0.0
       run-async: 4.0.6
       rxjs: 7.8.2
     optionalDependencies:
-      '@types/node': 24.13.2
+      '@types/node': 22.20.0
 
   ip-address@10.2.0: {}
 
@@ -7217,7 +7251,7 @@ snapshots:
     dependencies:
       readable-stream: 2.3.8
 
-  lerna@9.0.7(@types/node@24.13.2)(debug@4.4.3):
+  lerna@9.0.7(@types/node@22.20.0)(debug@4.4.3):
     dependencies:
       '@npmcli/arborist': 9.1.6
       '@npmcli/package-json': 7.0.2
@@ -7248,7 +7282,7 @@ snapshots:
       import-local: 3.1.0
       ini: 1.3.8
       init-package-json: 8.2.2
-      inquirer: 12.9.6(@types/node@24.13.2)
+      inquirer: 12.9.6(@types/node@22.20.0)
       is-ci: 3.0.1
       jest-diff: 30.4.1
       js-yaml: 4.1.1

--- a/tsconfig.tools.json
+++ b/tsconfig.tools.json
@@ -1,0 +1,38 @@
+{
+  "//": "Type-checks the JS tooling/bootstrap layer via per-file `// @ts-check`.",
+  "//2": "checkJs is off: only files that opt in with `// @ts-check` are checked;",
+  "//3": "product code is TypeScript and has its own build. Run: pnpm run check:types.",
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": false,
+    "noEmit": true,
+    "strict": true,
+    "target": "es2022",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": [
+    "*.js",
+    "*.mjs",
+    "types/**/*.d.ts",
+    "framework/core/.gyp/**/*.js",
+    "framework/core/lib/**/*.js",
+    "framework/core/src/python/kungfu/rewind/hook/*.js",
+    "framework/spec/**/*.js",
+    "developer/sdk/src/**/*.js",
+    "framework/gui/lib/**/*.js",
+    "framework/gui/scripts/**/*.mjs",
+    "framework/tui/*.mjs"
+  ],
+  "exclude": [
+    "**/node_modules",
+    "**/dist",
+    "**/out",
+    "**/build",
+    "**/.deps",
+    "**/generated",
+    "tests/fixtures"
+  ]
+}

--- a/types/vendor-shims.d.ts
+++ b/types/vendor-shims.d.ts
@@ -1,0 +1,5 @@
+// Ambient shims for third-party build/tooling deps that ship no type
+// declarations, so `pnpm run check:types` resolves them (as untyped `any`)
+// instead of failing on TS7016. Keep this list minimal — prefer real @types.
+
+declare module 'sywac';

--- a/verify.js
+++ b/verify.js
@@ -23,6 +23,7 @@
 // Note: an Electron app's "interactive launch" cannot be asserted in a headless environment, so kfc
 // runtime smoke + app build artifact existence serve as the machine-assertable equivalent; the real
 // window launch is left as a manual / CI-display step.
+// @ts-check
 
 'use strict';
 
@@ -54,17 +55,28 @@ function expectedVersion() {
   return lerna.version;
 }
 
+/** @typedef {{ name: string, ok: boolean, detail: string }} Result */
+/** @type {Result[]} */
 const results = [];
+/**
+ * @param {string} name
+ * @param {string} [detail]
+ */
 function pass(name, detail) {
   results.push({ name, ok: true, detail: detail || '' });
   console.log(`  ✅ ${name}${detail ? ' — ' + detail : ''}`);
 }
+/**
+ * @param {string} name
+ * @param {string} [detail]
+ */
 function fail(name, detail) {
   results.push({ name, ok: false, detail: detail || '' });
   console.error(`  ❌ ${name}${detail ? ' — ' + detail : ''}`);
 }
 
 // run one pnpm task (via the pnpm dispatched by the current node/corepack); throw on failure
+/** @param {string} task */
 function runPnpm(task) {
   console.log(`\n[verify] build stage: pnpm ${task}`);
   const r = spawnSync('pnpm', ['run', task], {
@@ -151,7 +163,7 @@ function main() {
       runPnpm('freeze'); // nuitka → framework/core/dist/kungfu
       if (withApp) runPnpm('build:app'); // webpack → framework/gui/dist/app
     } catch (e) {
-      fail('build stage', e.message);
+      fail('build stage', e instanceof Error ? e.message : String(e));
       return summarize(); // on build failure, wrap up directly and do not assert half-built artifacts
     }
     pass('build stage', 'full chain executed');
@@ -328,6 +340,7 @@ function main() {
         return summarize();
       }
       pass('slices build', 'KUNGFU_WITH_SLICES=ON');
+      /** @param {import('child_process').SpawnSyncReturns<string>} r */
       const tail3 = (r) =>
         `${r.stdout || ''}${r.stderr || ''}`
           .trim()


### PR DESCRIPTION
Add // @ts-check + JSDoc across the bootstrap/tooling/entry JS (zero compilation), plus a tsconfig.tools.json + check:types script. Type-checking surfaced and fixed real defects (a socket null-race and an undefined-key lookup in rewind_hook.js, an unknown-catch in verify.js). No runtime behavior change.