### PR TITLE
fix(core): report signal-killed subprocesses as failures, not success

### DIFF
--- a/framework/core/.gyp/run-wheel.js
+++ b/framework/core/.gyp/run-wheel.js
@@ -4,6 +4,9 @@
 const fse = require('fs-extra');
 const path = require('path');
 const { spawnSync } = require('child_process');
+// shell.exitCode only pulls in child_process/fs/os/path — safe to require here
+// even though the wheel may be packaged before the native addon is built.
+const shell = require('../lib/shell');
 
 // npm/pnpm package config always sets build_type when these build scripts run;
 // assert string so path.join accepts it (process.env values are string | undefined).
@@ -39,6 +42,7 @@ const result = spawnSync('uv', uv_args, {
   cwd: wheelDir,
 });
 
-// spawnSync().status is null when the child was terminated by a signal; treat
-// that as a failure (1) instead of letting process.exit(null) report success (0).
-process.exit(result.status ?? 0);
+// spawnSync().status is null when the child was terminated by a signal; map it
+// via shell.exitCode (128+signal) instead of letting process.exit(null) report
+// success (0) — otherwise a SIGKILL/OOM-killed wheel build would falsely pass.
+process.exit(shell.exitCode(result));

--- a/framework/core/lib/shell.js
+++ b/framework/core/lib/shell.js
@@ -3,6 +3,7 @@
 
 const { spawnSync } = require('child_process');
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
 
 const GithubBinaryHost = 'https://prebuilt.libkungfu.io';
@@ -231,6 +232,27 @@ const shell = {
   },
 
   /**
+   * Resolve the process exit code for a finished spawnSync result. Uses the
+   * child's own numeric exit status; when the child was terminated by a signal
+   * (`status === null`), maps to the POSIX `128 + signal` convention (e.g.
+   * SIGKILL/OOM → 137, SIGTERM → 143, SIGINT → 130) so a signal kill reports
+   * failure instead of `process.exit(null)` collapsing to a false success (0).
+   * Any other null-status case (e.g. the command failed to spawn) falls back to
+   * a generic failure code (1).
+   * @param {Pick<import('child_process').SpawnSyncReturns<unknown>, 'status' | 'signal'>} result
+   * @returns {number}
+   */
+  exitCode: function (result) {
+    if (result.status !== null && result.status !== undefined) {
+      return result.status;
+    }
+    const signalNumber = result.signal
+      ? os.constants.signals[result.signal]
+      : undefined;
+    return signalNumber ? 128 + signalNumber : 1;
+  },
+
+  /**
    * spawnSync a command with the shell, inheriting stdio, from the real
    * (symlink-resolved) cwd. When `check` is set, exit the process on a non-zero
    * status unless `opts.tolerant` is set.
@@ -251,9 +273,10 @@ const shell = {
       ...opts,
     });
     if (check && result.status !== 0) {
-      // status is null when the child was terminated by a signal; keep the
-      // original runtime behaviour (process.exit(null) === exit code 0).
-      process.exit(opts.tolerant ? 0 : (result.status ?? 0));
+      // status is null when the child was terminated by a signal; shell.exitCode
+      // maps that to 128+signal so a signal kill (SIGKILL/SIGTERM/OOM) reports
+      // failure instead of process.exit(null) collapsing to a false success (0).
+      process.exit(opts.tolerant ? 0 : shell.exitCode(result));
     }
     return result;
   },

--- a/framework/core/package.json
+++ b/framework/core/package.json
@@ -53,6 +53,7 @@
     "format:python": "node .gyp/run-format-python.js . src src/*/*.spec .*/*.py",
     "kungfu": "node lib/kungfu-cli.js",
     "kfs": "node lib/kfs.js",
+    "test:tooling": "node --test tests/shell-exit-code.test.js",
     "dev:kungfu": "uv run --frozen python .devtools/kungfu_cli.py",
     "dev:kfs": "uv run --frozen python .devtools/kfs.py"
   },

--- a/framework/core/tests/shell-exit-code.test.js
+++ b/framework/core/tests/shell-exit-code.test.js
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Signal-termination exit-code regression tests for the JS tooling layer.
+//
+// Guards the bug where `process.exit(spawnSync(...).status)` reported success
+// (exit 0) when the child was terminated by a signal (`status === null`): a
+// SIGKILL/OOM- or SIGTERM-killed build must report failure, not falsely pass.
+//
+//   1. unit — shell.exitCode maps (status, signal) to the right code
+//   2. integration — shell.run() actually exits non-zero on the real
+//      process.exit path when its child is signal-killed
+//
+// Run: node --test tests/shell-exit-code.test.js  (node pinned via .node-version)
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const shell = require('../lib/shell');
+
+const SHELL_PATH = path.resolve(__dirname, '..', 'lib', 'shell.js');
+const isWin = process.platform === 'win32';
+const sig = os.constants.signals;
+
+test('exitCode: normal success stays 0', () => {
+  assert.strictEqual(shell.exitCode({ status: 0, signal: null }), 0);
+});
+
+test('exitCode: normal non-zero status passes through unchanged', () => {
+  assert.strictEqual(shell.exitCode({ status: 2, signal: null }), 2);
+  assert.strictEqual(shell.exitCode({ status: 127, signal: null }), 127);
+});
+
+test('exitCode: signal termination maps to POSIX 128+signal', () => {
+  assert.strictEqual(
+    shell.exitCode({ status: null, signal: 'SIGKILL' }),
+    128 + sig.SIGKILL,
+  ); // 137
+  assert.strictEqual(
+    shell.exitCode({ status: null, signal: 'SIGTERM' }),
+    128 + sig.SIGTERM,
+  ); // 143
+  assert.strictEqual(
+    shell.exitCode({ status: null, signal: 'SIGINT' }),
+    128 + sig.SIGINT,
+  ); //   130
+});
+
+test('exitCode: null status with no signal (e.g. failed to spawn) is a generic failure', () => {
+  assert.strictEqual(shell.exitCode({ status: null, signal: null }), 1);
+});
+
+test('exitCode: a signal kill never collapses to 0 (the original bug)', () => {
+  assert.notStrictEqual(shell.exitCode({ status: null, signal: 'SIGKILL' }), 0);
+});
+
+// Integration — drive the real shell.run() process.exit path in a child process.
+// shell.run() hardcodes shell:true, so `kill -s KILL $$` makes the shell (the
+// direct child) signal-kill itself → status===null, signal==='SIGKILL' → run()
+// must process.exit(137), reproducing exactly the OOM/SIGKILL-during-build path.
+const runDriver = (opts) =>
+  spawnSync(
+    process.execPath,
+    [
+      '-e',
+      `const shell = require(${JSON.stringify(SHELL_PATH)});\n` +
+        `shell.run('kill -s KILL $$', [], true, ${JSON.stringify(opts)});\n` +
+        `process.exit(0);`,
+    ],
+    { encoding: 'utf8' },
+  );
+
+test(
+  'shell.run: a signal-killed command exits 137 (128+SIGKILL), not 0',
+  { skip: isWin ? 'POSIX signals only' : false },
+  () => {
+    const r = runDriver({ silent: true });
+    assert.strictEqual(
+      r.signal,
+      null,
+      'the driver process itself must exit normally',
+    );
+    assert.strictEqual(
+      r.status,
+      128 + sig.SIGKILL,
+      `expected exit ${128 + sig.SIGKILL} (128+SIGKILL), got status=${r.status} signal=${r.signal}`,
+    );
+  },
+);
+
+test(
+  'shell.run: tolerant still swallows a signal kill as 0 (escape hatch preserved)',
+  { skip: isWin ? 'POSIX signals only' : false },
+  () => {
+    const r = runDriver({ silent: true, tolerant: true });
+    assert.strictEqual(
+      r.status,
+      0,
+      `tolerant should exit 0, got status=${r.status} signal=${r.signal}`,
+    );
+  },
+);


### PR DESCRIPTION
Merge fix/shell-signal-kill-exit-code into dev/v4/v4.0 (kungfu-systems zone dual-account PR flow).