### PR TITLE
feat(gui): managed terminal — PTY-backed terminal capability + view

### DIFF
--- a/extensions/terminal/package.json
+++ b/extensions/terminal/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "@kungfu-tech/kfx-view-terminal",
+  "author": {
+    "name": "Kungfu",
+    "email": "info@kungfu.link"
+  },
+  "version": "4.0.0-alpha.0",
+  "description": "Kungfu view extension: managed terminal (PTY-backed, bound to a run)",
+  "license": "Apache-2.0",
+  "main": "package.json",
+  "repository": {
+    "url": "https://github.com/kungfu-systems/kungfu.git"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  },
+  "files": [
+    "dist",
+    "package.json",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "kfs kfx build",
+    "clean": "kfs kfx clean"
+  },
+  "dependencies": {
+    "@kungfu-tech/api": "workspace:*",
+    "@kungfu-tech/kfx": "workspace:*",
+    "@xterm/addon-fit": "^0.10.0",
+    "@xterm/xterm": "^5.5.0"
+  },
+  "devDependencies": {
+    "@kungfu-tech/sdk": "workspace:*",
+    "@types/react": "^18.3.3"
+  },
+  "peerDependencies": {
+    "react": "^18.3.1"
+  },
+  "kungfuConfig": {
+    "key": "terminal",
+    "name": "Terminal",
+    "config": {
+      "view": {
+        "title": "Terminal",
+        "capabilities": [
+          "terminal"
+        ]
+      }
+    }
+  }
+}

--- a/extensions/terminal/src/view/index.tsx
+++ b/extensions/terminal/src/view/index.tsx
@@ -1,0 +1,156 @@
+// Managed terminal — a PTY-backed terminal hosted inside the Kungfu GUI, so a
+// user interacts with a managed agent process without leaving Kungfu. The view
+// is pure interaction UI: xterm.js for rendering and keyboard, and the declared
+// `terminal` capability for the process. It never touches node-pty directly —
+// the PTY host lives in the trusted renderer behind the capability boundary, so
+// this view runs identically whether it is loaded node-integrated or in a
+// locked sandbox reaching the capability over IPC.
+//
+// The capability is async at the sandbox boundary (an IPC hop cannot be
+// synchronous); `resolve` awaits both the sync (node-integrated) and Promise
+// (sandboxed-ipc) shapes so one code path serves both tiers. A sandboxed
+// subscription has no local stop(); it is released when the view unmounts and
+// the shell disposes the capability host — so cleanup calls stop() when present
+// and relies on host disposal otherwise.
+//
+// MVP scope: this auto-starts one login shell to prove the PTY + xterm + run
+// binding end to end. Choosing the provider (codex/claude) from a work/run
+// inbox is a later slice, not this one.
+import '@xterm/xterm/css/xterm.css';
+import type { KfxCapabilities, Shell } from '@kungfu-tech/kfx';
+import { mono, panelStyle } from '@kungfu-tech/kfx';
+import { FitAddon } from '@xterm/addon-fit';
+import { Terminal as XTerm } from '@xterm/xterm';
+import React from 'react';
+
+async function resolve<T>(value: T | Promise<T>): Promise<T> {
+  return await value;
+}
+
+function TerminalView({ caps }: { caps: KfxCapabilities; shell: Shell }) {
+  const hostRef = React.useRef<HTMLDivElement>(null);
+  const [status, setStatus] = React.useState('starting…');
+  const [meta, setMeta] = React.useState<{ runId: string; pid: number } | null>(
+    null,
+  );
+
+  React.useEffect(() => {
+    const el = hostRef.current;
+    if (!el) return;
+
+    const term = new XTerm({
+      fontFamily: 'monospace',
+      fontSize: 13,
+      cursorBlink: true,
+      theme: { background: '#1e1e1e' },
+    });
+    const fit = new FitAddon();
+    term.loadAddon(fit);
+    term.open(el);
+    try {
+      fit.fit();
+    } catch {
+      // fit needs a laid-out element; a first-frame failure is harmless
+    }
+
+    let disposed = false;
+    let dataSub: { stop?: () => void } | undefined;
+    let exitSub: { stop?: () => void } | undefined;
+    let activeRunId: string | undefined;
+
+    void (async () => {
+      try {
+        const session = await resolve(
+          caps.terminal.spawn({
+            command: '/bin/bash',
+            args: ['-l'],
+            cols: term.cols,
+            rows: term.rows,
+          }),
+        );
+        // the effect was torn down while spawn was in flight — do not leak the pty
+        if (disposed) {
+          void resolve(caps.terminal.kill(session.runId));
+          return;
+        }
+        activeRunId = session.runId;
+        setMeta({ runId: session.runId, pid: session.pid });
+        setStatus('running');
+
+        dataSub = await resolve(
+          caps.terminal.onData(session.runId, (data: string) =>
+            term.write(data),
+          ),
+        );
+        exitSub = await resolve(
+          caps.terminal.onExit(session.runId, (exit) => {
+            setStatus(`exited (${exit.exitCode})`);
+            term.write(
+              `\r\n\x1b[90m[process exited: code ${exit.exitCode}]\x1b[0m\r\n`,
+            );
+          }),
+        );
+
+        term.onData((data) => {
+          void resolve(caps.terminal.write(session.runId, data));
+        });
+        term.onResize(({ cols, rows }) => {
+          void resolve(caps.terminal.resize(session.runId, cols, rows));
+        });
+      } catch (e) {
+        setStatus('unavailable');
+        term.write(
+          `\r\n\x1b[31m[terminal capability unavailable: ${
+            (e as Error).message
+          }]\x1b[0m\r\n`,
+        );
+      }
+    })();
+
+    const onWindowResize = () => {
+      try {
+        fit.fit();
+      } catch {
+        // ignore transient layout failures
+      }
+    };
+    window.addEventListener('resize', onWindowResize);
+
+    return () => {
+      disposed = true;
+      window.removeEventListener('resize', onWindowResize);
+      dataSub?.stop?.();
+      exitSub?.stop?.();
+      if (activeRunId) {
+        try {
+          void resolve(caps.terminal.kill(activeRunId));
+        } catch {
+          // best-effort teardown
+        }
+      }
+      term.dispose();
+    };
+  }, [caps.terminal]);
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        height: '100%',
+        gap: 6,
+      }}
+    >
+      <div style={{ ...mono, fontSize: 12, color: '#9cdcfe' }}>
+        Terminal{meta ? ` · run ${meta.runId} · pid ${meta.pid}` : ''} ·{' '}
+        {status}
+      </div>
+      <div
+        ref={hostRef}
+        style={{ ...panelStyle, flex: 1, padding: 6, overflow: 'hidden' }}
+      />
+    </div>
+  );
+}
+
+export const View = TerminalView;

--- a/framework/api/src/capability/index.ts
+++ b/framework/api/src/capability/index.ts
@@ -7,4 +7,5 @@ export * from './domain';
 export * from './rewind';
 export * from './schema';
 export * from './sandbox';
+export * from './terminal';
 export * from './work';

--- a/framework/api/src/capability/terminal.ts
+++ b/framework/api/src/capability/terminal.ts
@@ -1,0 +1,277 @@
+// Terminal-domain capability handle: a PTY host that owns managed agent
+// processes and binds each to a run. Factory-style, no import-time side
+// effects, same shape as the other capability handles (ADR-0011).
+//
+// Trust/placement: this handle lives in the trusted renderer (it needs node +
+// a native addon — node-pty — exactly like the kungfu binding). A sandboxed
+// kfx reaches it only through its declared `terminal` capability, marshalled
+// over IPC. Because a sandboxed view codes against a Promise surface and its
+// callbacks are bridged, `onData`/`onExit` follow the Subscription `{stop}`
+// convention the sandbox layer already understands — a bridged callback plus a
+// retained subscription, no terminal-specific transport.
+//
+// node-pty is injected (PtyModule), not imported, so the SDK stays
+// binding-agnostic and testable without a real pty. The trusted renderer wires
+// in `window.require('node-pty')`.
+import type { Subscription } from './types';
+
+// --- injected node-pty surface (the minimal subset this handle needs) ------
+
+export interface PtyDisposable {
+  dispose(): void;
+}
+
+export interface PtyProcess {
+  readonly pid: number;
+  onData(cb: (data: string) => void): PtyDisposable;
+  onExit(
+    cb: (event: { exitCode: number; signal?: number }) => void,
+  ): PtyDisposable;
+  write(data: string): void;
+  resize(cols: number, rows: number): void;
+  kill(signal?: string): void;
+}
+
+export interface PtySpawnOptions {
+  name?: string;
+  cols?: number;
+  rows?: number;
+  cwd?: string;
+  env?: Record<string, string>;
+}
+
+export interface PtyModule {
+  spawn(
+    file: string,
+    args: string[] | string,
+    options: PtySpawnOptions,
+  ): PtyProcess;
+}
+
+// --- public surface ---------------------------------------------------------
+
+export type TerminalSpawnOptions = {
+  command: string;
+  args?: string[];
+  cwd?: string;
+  env?: Record<string, string | undefined>;
+  cols?: number;
+  rows?: number;
+  // The managed-run identity this terminal serves. A caller that already owns a
+  // run (supervisor-assigned) passes runId; otherwise the host mints one. workId
+  // is the higher-level work item the run belongs to.
+  runId?: string;
+  workId?: string;
+};
+
+export type TerminalSession = {
+  runId: string;
+  pid: number;
+  workId?: string;
+  command: string;
+  args: string[];
+  cwd?: string;
+  startedAt: number; // epoch ms
+  status: 'running' | 'exited';
+  exitCode?: number;
+  exitSignal?: number;
+  endedAt?: number;
+};
+
+export type TerminalExit = {
+  runId: string;
+  exitCode: number;
+  signal?: number;
+};
+
+export type Terminal = {
+  // Start a managed process bound to a run. Returns the session snapshot; the
+  // run is addressable by runId for every other method.
+  spawn: (options: TerminalSpawnOptions) => TerminalSession;
+  // Feed stdin. No-op-safe? No: an unknown/exited run throws, so a caller never
+  // silently writes into the void.
+  write: (runId: string, data: string) => void;
+  resize: (runId: string, cols: number, rows: number) => void;
+  // Signal the process. Default SIGHUP mirrors node-pty; the process still gets
+  // a final exit event and a recorded end state.
+  kill: (runId: string, signal?: string) => void;
+  // Subscribe to output. The already-buffered output is replayed to this
+  // listener first (so a GUI that attaches late — or reattaches after a
+  // refresh — sees the whole session), then live data streams. Returns a
+  // Subscription; stop() detaches this listener only.
+  onData: (runId: string, onData: (data: string) => void) => Subscription;
+  // Subscribe to termination. If the run already exited, the listener fires
+  // immediately with the recorded exit, then the subscription is inert.
+  onExit: (runId: string, onExit: (exit: TerminalExit) => void) => Subscription;
+  // All sessions this host knows, running and exited, newest last.
+  list: () => TerminalSession[];
+  get: (runId: string) => TerminalSession | undefined;
+};
+
+export type OpenTerminalOptions = {
+  pty: PtyModule;
+  // Injected for determinism in tests; defaults avoid crypto/import-time deps.
+  makeRunId?: () => string;
+  now?: () => number;
+  // Per-session output buffer cap. Output beyond this is dropped from the FRONT
+  // (a long run keeps its tail, which is what a late attach wants). 0 disables
+  // buffering. Default 256 KiB.
+  maxBufferBytes?: number;
+  // Base environment merged under each spawn's env (the trusted renderer passes
+  // its process.env so a spawned shell inherits PATH etc.); a spawn's own env
+  // overrides it. A sandboxed view sends no env, so this is where PATH comes
+  // from.
+  baseEnv?: Record<string, string | undefined>;
+};
+
+const DEFAULT_MAX_BUFFER = 256 * 1024;
+
+type Session = {
+  meta: TerminalSession;
+  pty: PtyProcess;
+  buffer: string;
+  dataListeners: Set<(data: string) => void>;
+  exitListeners: Set<(exit: TerminalExit) => void>;
+};
+
+export function openTerminal(options: OpenTerminalOptions): Terminal {
+  const { pty } = options;
+  const now = options.now ?? (() => Date.now());
+  const maxBuffer = options.maxBufferBytes ?? DEFAULT_MAX_BUFFER;
+  let seq = 0;
+  const makeRunId =
+    options.makeRunId ??
+    (() => {
+      seq += 1;
+      return `pty-${now()}-${seq}`;
+    });
+
+  const sessions = new Map<string, Session>();
+
+  const require_ = (runId: string): Session => {
+    const session = sessions.get(runId);
+    if (!session) throw new Error(`no terminal run '${runId}'`);
+    return session;
+  };
+
+  const appendBuffer = (session: Session, data: string) => {
+    if (maxBuffer <= 0) return;
+    session.buffer += data;
+    if (session.buffer.length > maxBuffer) {
+      // keep the tail — a late attach cares about recent output
+      session.buffer = session.buffer.slice(session.buffer.length - maxBuffer);
+    }
+  };
+
+  const spawn: Terminal['spawn'] = (spawnOptions) => {
+    if (!spawnOptions.command)
+      throw new Error('terminal.spawn requires a command');
+    const runId = spawnOptions.runId ?? makeRunId();
+    if (sessions.has(runId))
+      throw new Error(`terminal run '${runId}' already exists`);
+    const args = spawnOptions.args ?? [];
+
+    // node-pty wants a string map; merge the injected base env (PATH etc.) under
+    // the spawn's own env, dropping undefined values.
+    const env: Record<string, string> = {};
+    for (const source of [options.baseEnv, spawnOptions.env]) {
+      for (const [k, v] of Object.entries(source ?? {})) {
+        if (typeof v === 'string') env[k] = v;
+      }
+    }
+
+    const child = pty.spawn(spawnOptions.command, args, {
+      name: 'xterm-color',
+      cols: spawnOptions.cols ?? 80,
+      rows: spawnOptions.rows ?? 24,
+      cwd: spawnOptions.cwd,
+      env: Object.keys(env).length > 0 ? env : undefined,
+    });
+
+    const meta: TerminalSession = {
+      runId,
+      pid: child.pid,
+      workId: spawnOptions.workId,
+      command: spawnOptions.command,
+      args,
+      cwd: spawnOptions.cwd,
+      startedAt: now(),
+      status: 'running',
+    };
+    const session: Session = {
+      meta,
+      pty: child,
+      buffer: '',
+      dataListeners: new Set(),
+      exitListeners: new Set(),
+    };
+    sessions.set(runId, session);
+
+    child.onData((data) => {
+      appendBuffer(session, data);
+      for (const listener of session.dataListeners) listener(data);
+    });
+    child.onExit(({ exitCode, signal }) => {
+      session.meta.status = 'exited';
+      session.meta.exitCode = exitCode;
+      session.meta.exitSignal = signal;
+      session.meta.endedAt = now();
+      const exit: TerminalExit = { runId, exitCode, signal };
+      for (const listener of session.exitListeners) listener(exit);
+    });
+
+    return { ...meta };
+  };
+
+  const write: Terminal['write'] = (runId, data) => {
+    const session = require_(runId);
+    if (session.meta.status === 'exited') {
+      throw new Error(`terminal run '${runId}' has exited`);
+    }
+    session.pty.write(data);
+  };
+
+  const resize: Terminal['resize'] = (runId, cols, rows) => {
+    const session = require_(runId);
+    if (session.meta.status === 'exited') return;
+    session.pty.resize(cols, rows);
+  };
+
+  const kill: Terminal['kill'] = (runId, signal) => {
+    const session = require_(runId);
+    if (session.meta.status === 'exited') return;
+    session.pty.kill(signal);
+  };
+
+  const onData: Terminal['onData'] = (runId, listener) => {
+    const session = require_(runId);
+    // replay what the session has produced so far, then stream live
+    if (session.buffer.length > 0) listener(session.buffer);
+    session.dataListeners.add(listener);
+    return { stop: () => session.dataListeners.delete(listener) };
+  };
+
+  const onExit: Terminal['onExit'] = (runId, listener) => {
+    const session = require_(runId);
+    if (session.meta.status === 'exited') {
+      listener({
+        runId,
+        exitCode: session.meta.exitCode ?? 0,
+        signal: session.meta.exitSignal,
+      });
+      return { stop: () => {} };
+    }
+    session.exitListeners.add(listener);
+    return { stop: () => session.exitListeners.delete(listener) };
+  };
+
+  const list: Terminal['list'] = () =>
+    Array.from(sessions.values()).map((s) => ({ ...s.meta }));
+
+  const get: Terminal['get'] = (runId) => {
+    const session = sessions.get(runId);
+    return session ? { ...session.meta } : undefined;
+  };
+
+  return { spawn, write, resize, kill, onData, onExit, list, get };
+}

--- a/framework/gui/package.json
+++ b/framework/gui/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@kungfu-tech/api": "workspace:*",
     "@kungfu-tech/core": "workspace:*",
+    "node-pty": "^1.1.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "@kungfu-tech/kfx": "workspace:*"

--- a/framework/gui/src/renderer/src/main.tsx
+++ b/framework/gui/src/renderer/src/main.tsx
@@ -76,6 +76,7 @@ function subsetCaps(runtime: Runtime, entry: KfxEntry): KfxCapabilities | null {
     ledger: runtime.ledger,
     domain: runtime.domain,
     rewind: runtime.rewind,
+    terminal: runtime.terminal,
     work: runtime.work,
   } as Record<string, unknown>;
   const subset: Record<string, unknown> = {};
@@ -101,6 +102,7 @@ function sandboxSubset(
     ledger: runtime.ledger,
     domain: runtime.domain,
     rewind: runtime.rewind,
+    terminal: runtime.terminal,
     work: runtime.work,
   };
   const subset: Record<string, Record<string, unknown>> = {};

--- a/framework/gui/src/renderer/src/runtime.ts
+++ b/framework/gui/src/renderer/src/runtime.ts
@@ -6,11 +6,14 @@ import {
   type DomainState,
   type KfNativeBinding,
   type Ledger,
+  type PtyModule,
   type Rewind,
+  type Terminal,
   type Work,
   openDomainState,
   openLedger,
   openRewind,
+  openTerminal,
   openWork,
 } from '@kungfu-tech/api/capability';
 
@@ -35,6 +38,7 @@ export type Runtime = {
   ledger: Ledger | null;
   domain: DomainState | null;
   rewind: Rewind | null;
+  terminal: Terminal | null;
   work: Work | null;
 };
 
@@ -67,6 +71,7 @@ export function bootRuntime(): Runtime {
     ledger: null,
     domain: null,
     rewind: null,
+    terminal: null,
     work: null,
   };
   try {
@@ -98,6 +103,19 @@ export function bootRuntime(): Runtime {
     const domain = openDomainState({ binding, locator: { runtimeDir } });
     const rewind = openRewind({ binding, locator: { runtimeDir } });
     const work = openWork({ binding, locator: { runtimeDir } });
+    // node-pty is a native addon loaded like the kungfu binding; if it is
+    // absent or built for another ABI the terminal handle stays null and the
+    // terminal view surfaces the absence rather than crashing the runtime.
+    let terminal: Terminal | null = null;
+    try {
+      const ptyModule = window.require('node-pty') as PtyModule;
+      terminal = openTerminal({
+        pty: ptyModule,
+        baseEnv: window.process.env as Record<string, string | undefined>,
+      });
+    } catch {
+      terminal = null;
+    }
     return {
       ...base,
       ok: true,
@@ -109,6 +127,7 @@ export function bootRuntime(): Runtime {
       ledger,
       domain,
       rewind,
+      terminal,
       work,
     };
   } catch (e) {

--- a/framework/gui/src/renderer/src/shell-state.ts
+++ b/framework/gui/src/renderer/src/shell-state.ts
@@ -20,7 +20,13 @@ export const PROFILES: ProfileManifest[] = [
   {
     id: 'default',
     title: 'Default — work control plane',
-    kfx: ['work-dashboard', 'rewind', 'journal-manager', 'config-manager'],
+    kfx: [
+      'work-dashboard',
+      'rewind',
+      'terminal',
+      'journal-manager',
+      'config-manager',
+    ],
     defaultView: 'work-dashboard',
   },
   {

--- a/framework/kfx/src/index.ts
+++ b/framework/kfx/src/index.ts
@@ -13,6 +13,7 @@ import type {
   DomainState,
   Ledger,
   Rewind,
+  Terminal,
   Work,
 } from '@kungfu-tech/api/capability';
 import type React from 'react';
@@ -23,6 +24,7 @@ export type KfxCapabilities = {
   ledger: Ledger;
   domain: DomainState;
   rewind: Rewind;
+  terminal: Terminal;
   work: Work;
 };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -220,6 +220,31 @@ importers:
         specifier: ^18.3.3
         version: 18.3.31
 
+  extensions/terminal:
+    dependencies:
+      '@kungfu-tech/api':
+        specifier: workspace:*
+        version: link:../../framework/api
+      '@kungfu-tech/kfx':
+        specifier: workspace:*
+        version: link:../../framework/kfx
+      '@xterm/addon-fit':
+        specifier: ^0.10.0
+        version: 0.10.0(@xterm/xterm@5.5.0)
+      '@xterm/xterm':
+        specifier: ^5.5.0
+        version: 5.5.0
+      react:
+        specifier: ^18.3.1
+        version: 18.3.1
+    devDependencies:
+      '@kungfu-tech/sdk':
+        specifier: workspace:*
+        version: link:../../developer/sdk
+      '@types/react':
+        specifier: ^18.3.3
+        version: 18.3.31
+
   extensions/work-dashboard:
     dependencies:
       '@kungfu-tech/api':
@@ -354,6 +379,9 @@ importers:
       '@kungfu-tech/kfx':
         specifier: workspace:*
         version: link:../kfx
+      node-pty:
+        specifier: ^1.1.0
+        version: 1.1.0
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -1648,6 +1676,14 @@ packages:
   '@xmldom/xmldom@0.9.10':
     resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
     engines: {node: '>=14.6'}
+
+  '@xterm/addon-fit@0.10.0':
+    resolution: {integrity: sha512-UFYkDm4HUahf2lnEyHvio51TNGiLK66mqP2JoATy7hRZeXaGMRDr00JiSF7m63vR5WKATF605yEggJKsw0JpMQ==}
+    peerDependencies:
+      '@xterm/xterm': ^5.0.0
+
+  '@xterm/xterm@5.5.0':
+    resolution: {integrity: sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==}
 
   '@yarnpkg/lockfile@1.1.0':
     resolution: {integrity: sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==}
@@ -3371,6 +3407,9 @@ packages:
   node-addon-api@1.7.2:
     resolution: {integrity: sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==}
 
+  node-addon-api@7.1.1:
+    resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
+
   node-addon-api@8.9.0:
     resolution: {integrity: sha512-ekZMeaaIzSQTSpr7X2X3iJM7lTzgnx8ahAG9pJfT/7+14mlEM8ZYQ9cgCDvSSRbReFK0oHli3WrZdCiRsgAT9Q==}
     engines: {node: ^18 || ^20 || >= 21}
@@ -3391,6 +3430,9 @@ packages:
     resolution: {integrity: sha512-FYYyBDWdc+kzoyPd5PqHUgM9DGs1C/Z4jxBZAOnA2GRUVXPivKRREq5q+VVPXVr9aGVqGMaMqyFHbviy/yb7Hg==}
     engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
     hasBin: true
+
+  node-pty@1.1.0:
+    resolution: {integrity: sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==}
 
   node-releases@2.0.50:
     resolution: {integrity: sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==}
@@ -5677,6 +5719,12 @@ snapshots:
 
   '@xmldom/xmldom@0.9.10': {}
 
+  '@xterm/addon-fit@0.10.0(@xterm/xterm@5.5.0)':
+    dependencies:
+      '@xterm/xterm': 5.5.0
+
+  '@xterm/xterm@5.5.0': {}
+
   '@yarnpkg/lockfile@1.1.0': {}
 
   '@zkochan/js-yaml@0.0.7':
@@ -7649,6 +7697,8 @@ snapshots:
   node-addon-api@1.7.2:
     optional: true
 
+  node-addon-api@7.1.1: {}
+
   node-addon-api@8.9.0: {}
 
   node-api-headers@1.9.0: {}
@@ -7671,6 +7721,10 @@ snapshots:
       tinyglobby: 0.2.12
       undici: 6.27.0
       which: 7.0.0
+
+  node-pty@1.1.0:
+    dependencies:
+      node-addon-api: 7.1.1
 
   node-releases@2.0.50: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,6 +11,7 @@ allowBuilds:
   core-js: true
   electron: true
   esbuild: true
+  node-pty: true
   nx: true
   vue-demi: true
 # Disable pnpm's default minimum-release-age supply-chain check. We frequently


### PR DESCRIPTION
Managed terminal: PTY-backed terminal capability (trusted-renderer PTY host) + sandboxed-ipc xterm view + node-pty (Electron 42 ABI). Verified: typecheck, gui build, kfs bundle, 26-assert capability behavior test, and an Electron render smoke (PTY output renders into the DOM). Full kungfu-shell end-to-end deferred to a native build.