### PR TITLE
feat(kfx): grant view trust by source-authority verdict, not by path (ADR-0013 Phase 0)

### DIFF
--- a/framework/gui/src/main/first-party-manifest.ts
+++ b/framework/gui/src/main/first-party-manifest.ts
@@ -1,0 +1,79 @@
+// Generate the frozen first-party manifest (ADR-0013): the build-time record of
+// which extension identities are trusted. It is produced by scanning a
+// *first-party root* — a compile/ship-time-controlled location, never a
+// user-writable install root or a KF_EXTENSION_PATH entry — so a package can
+// only enter the trusted set by being shipped as first-party, not by where it
+// is later dropped on disk.
+//
+// `pin: true` (packaging) records a sha256 of each view bundle, so a first-party
+// key whose bundle was tampered no longer matches. `pin: false` (development,
+// whose bundles change on every rebuild) records `sha256: null` — trusted by key
+// alone. The hash must be computed exactly as the loader computes it
+// (`sha256(readFileSync(bundlePath, 'utf8'))`) or pinned keys will never match.
+import { createHash } from 'node:crypto';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+import type { FirstPartyManifest, FirstPartyPin } from '@kungfu-tech/kfx';
+
+function sha256(data: string): string {
+  return createHash('sha256').update(data).digest('hex');
+}
+
+// Two levels deep, mirroring the loader's packageDirs: suite members live under
+// a suite directory (extensions/system/<member>).
+function packageDirs(root: string): string[] {
+  if (!existsSync(root)) return [];
+  const dirs: string[] = [];
+  for (const entry of readdirSync(root, { withFileTypes: true })) {
+    if (!entry.isDirectory() || entry.name === 'node_modules') continue;
+    const dir = join(root, entry.name);
+    if (existsSync(join(dir, 'package.json'))) dirs.push(dir);
+    for (const nested of readdirSync(dir, { withFileTypes: true })) {
+      if (!nested.isDirectory() || nested.name === 'node_modules') continue;
+      const nestedDir = join(dir, nested.name);
+      if (existsSync(join(nestedDir, 'package.json'))) dirs.push(nestedDir);
+    }
+  }
+  return dirs;
+}
+
+type ViewManifest = {
+  kungfuConfig?: { key?: string; config?: { view?: { entry?: string } } };
+};
+
+export function generateFirstPartyManifest(
+  firstPartyRoot: string,
+  opts: { pin: boolean },
+): FirstPartyManifest {
+  const keys: Record<string, FirstPartyPin> = {};
+  for (const dir of packageDirs(firstPartyRoot)) {
+    let manifest: ViewManifest;
+    try {
+      manifest = JSON.parse(
+        readFileSync(join(dir, 'package.json'), 'utf8'),
+      ) as ViewManifest;
+    } catch {
+      continue;
+    }
+    const config = manifest.kungfuConfig;
+    const view = config?.config?.view;
+    if (!config?.key || !view) continue; // only view facets carry a runtime tier
+    if (config.key in keys) continue; // first occurrence wins, like the loader
+    let sha: string | null = null;
+    if (opts.pin) {
+      const bundlePath = join(dir, view.entry ?? 'dist/view/index.js');
+      sha = existsSync(bundlePath)
+        ? sha256(readFileSync(bundlePath, 'utf8'))
+        : null;
+    }
+    keys[config.key] = { sha256: sha };
+  }
+  return { version: 1, keys };
+}
+
+// Convenience for the main process: derive the runtime manifest path next to the
+// runtime home, alongside <home>/extensions.
+export function firstPartyManifestPath(runtimeDir: string): string {
+  return join(dirname(runtimeDir), 'first-party.json');
+}

--- a/framework/gui/src/main/index.ts
+++ b/framework/gui/src/main/index.ts
@@ -1,4 +1,5 @@
 import { execFileSync } from 'node:child_process';
+import { mkdirSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 // Minimal Electron main process for the kungfu reference app.
 //
@@ -22,6 +23,10 @@ import {
   SET_BOUNDS_CHANNEL,
   SHOW_CHANNEL,
 } from '../sandbox/channels';
+import {
+  firstPartyManifestPath,
+  generateFirstPartyManifest,
+} from './first-party-manifest';
 import { type Rect, SandboxManager } from './sandbox-manager';
 import {
   installKungfuCliToPath,
@@ -59,6 +64,39 @@ process.env.KF_EXTENSION_PATH =
   (app.isPackaged
     ? ''
     : path.join(__dirname, '..', '..', '..', '..', 'extensions'));
+
+// The frozen first-party set (ADR-0013): which extension keys the renderer's
+// loader may trust with node-integrated tier. It is derived from a *fixed
+// first-party root* — never from KF_EXTENSION_PATH, which a user may extend, so
+// dropping a package on the extension path can no longer confer trust.
+//   dev: generate from the workspace extensions/ tree at startup, keys only
+//        (bundles change on every rebuild, so they are trusted by key, unpinned).
+//   packaged: point at a build-baked resource with pinned bundle hashes; if the
+//        bake step has not run the manifest is absent and only system views are
+//        trusted (safe by default). Shipping the pinned resource is the
+//        packaging follow-up, tracked with the built-in-extension shipping work.
+if (!process.env.KF_FIRST_PARTY_MANIFEST) {
+  if (app.isPackaged) {
+    process.env.KF_FIRST_PARTY_MANIFEST = path.join(
+      process.resourcesPath,
+      'first-party.json',
+    );
+  } else if (process.env.KF_RUNTIME_DIR) {
+    const firstPartyRoot = path.join(
+      __dirname,
+      '..',
+      '..',
+      '..',
+      '..',
+      'extensions',
+    );
+    const manifest = generateFirstPartyManifest(firstPartyRoot, { pin: false });
+    const manifestPath = firstPartyManifestPath(process.env.KF_RUNTIME_DIR);
+    mkdirSync(path.dirname(manifestPath), { recursive: true });
+    writeFileSync(manifestPath, JSON.stringify(manifest), 'utf8');
+    process.env.KF_FIRST_PARTY_MANIFEST = manifestPath;
+  }
+}
 
 // Prove the frozen runtime CLI runs standalone next to the binding, and hand
 // the result to the renderer for display.

--- a/framework/gui/src/renderer/src/kfx-loader.ts
+++ b/framework/gui/src/renderer/src/kfx-loader.ts
@@ -11,8 +11,9 @@
 //      `kungfu kfx install` populates)
 // Scanning goes two levels deep so suite members nested under a suite
 // directory (extensions/system/<member>) are found in the workspace layout.
-import { resolveRuntimeTier } from '@kungfu-tech/kfx';
+import { authorizeFirstParty, resolveRuntimeTier } from '@kungfu-tech/kfx';
 import type {
+  FirstPartyManifest,
   KfxCapabilityKey,
   KfxEntry,
   KfxRuntimeTier,
@@ -54,8 +55,38 @@ type NodePath = {
   delimiter: string;
 };
 
+type NodeCrypto = {
+  createHash: (algo: string) => {
+    update: (data: string) => { digest: (enc: string) => string };
+  };
+};
+
 const fs = window.require('node:fs') as NodeFs;
 const path = window.require('node:path') as NodePath;
+const crypto = window.require('node:crypto') as NodeCrypto;
+
+function sha256(data: string): string {
+  return crypto.createHash('sha256').update(data).digest('hex');
+}
+
+// The frozen first-party set (ADR-0013): trust is granted by membership here —
+// a verifiable origin — never by which extension root a package loaded from.
+// It ships as a build-generated JSON pointed to by KF_FIRST_PARTY_MANIFEST. A
+// missing/unreadable manifest yields `null`, which trusts nothing but the
+// shell's own `system` views (safe by default, never a path fallback).
+export function loadFirstPartyManifest(
+  env: Record<string, string | undefined>,
+): FirstPartyManifest | null {
+  const p = env.KF_FIRST_PARTY_MANIFEST;
+  if (!p || !fs.existsSync(p)) return null;
+  try {
+    const parsed = JSON.parse(fs.readFileSync(p, 'utf8')) as FirstPartyManifest;
+    if (parsed?.version !== 1 || typeof parsed.keys !== 'object') return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
 
 export function extensionRoots(
   env: Record<string, string | undefined>,
@@ -124,15 +155,11 @@ export function loadKfx(
   const failures: KfxLoadFailure[] = [];
   const seen = new Set<string>();
 
-  // the install root (<home>/extensions) is where `kungfu kfx install` puts
-  // third-party packages; a view loaded from there is installed (untrusted).
-  const installRoot = env.KF_RUNTIME_DIR
-    ? path.resolve(path.join(path.dirname(env.KF_RUNTIME_DIR), 'extensions'))
-    : null;
+  // trust is granted by the frozen first-party set (ADR-0013), never by which
+  // root a package loaded from — a KF_EXTENSION_PATH entry no longer confers it.
+  const firstParty = loadFirstPartyManifest(env);
 
   for (const root of extensionRoots(env)) {
-    const installed =
-      installRoot !== null && path.resolve(root) === installRoot;
     for (const dir of packageDirs(root)) {
       try {
         const manifest = JSON.parse(
@@ -165,10 +192,19 @@ export function loadKfx(
         if (seen.has(config.key)) continue; // earlier root wins
         seen.add(config.key);
         const bundlePath = path.join(dir, view.entry ?? 'dist/view/index.js');
-        const tier = resolveRuntimeTier(
-          view,
-          installed ? 'installed' : 'built-in',
+        // hash the bundle only when the key is pinned in the frozen set; an
+        // unpinned or absent key is decided by identity alone (verdict below).
+        const pin = firstParty?.keys[config.key];
+        const contentHash =
+          pin && pin.sha256 !== null && fs.existsSync(bundlePath)
+            ? sha256(fs.readFileSync(bundlePath, 'utf8'))
+            : null;
+        const trusted = authorizeFirstParty(
+          firstParty,
+          config.key,
+          contentHash,
         );
+        const tier = resolveRuntimeTier(view, trusted);
         entries.push({
           id: config.key,
           title: view.title ?? config.key,

--- a/framework/kfx/src/index.ts
+++ b/framework/kfx/src/index.ts
@@ -48,9 +48,9 @@ export type KfxViewDecl = {
   title: string;
   // capability handles this view receives; undeclared handles stay absent
   capabilities: KfxCapabilityKey[];
-  // trust tier (default node-integrated). The install source is authoritative
-  // over this hint: a third-party package is never elevated above sandboxed-ipc
-  // just because its manifest asks for node-integrated.
+  // trust tier hint (default node-integrated). The source-authority verdict is
+  // authoritative over this hint: an unauthorized package is never elevated
+  // above sandboxed-ipc just because its manifest asks for node-integrated.
   runtime?: KfxRuntimeTier;
   // shell-owned views (settings, kfx manager, status); not disableable
   system?: boolean;
@@ -60,16 +60,46 @@ export type KfxViewDecl = {
   entry?: string;
 };
 
-// The single source of the trust decision: what tier a loaded view actually
-// runs at. System and built-in (workspace/source) views are trusted; an
-// installed third-party view is sandboxed unless it is trusted by source, and
-// its manifest may only ask to *stay* sandboxed, never to elevate.
+// The frozen first-party set (ADR-0013): the build-time record of which
+// extension identities are trusted. It maps a kfx `key` to an integrity pin —
+// a sha256 of the loaded bundle, or `null` when the key is trusted without a
+// content pin (development source builds, whose bundle changes on every
+// rebuild). Trust is granted by membership in this set — a verifiable origin —
+// never by which filesystem root a package happened to load from.
+export type FirstPartyPin = { sha256: string | null };
+export type FirstPartyManifest = {
+  version: 1;
+  keys: Record<string, FirstPartyPin>;
+};
+
+// The source-authority verdict (ADR-0013, decision C): is this package an
+// authorized first-party extension? The frozen-set check below is the first
+// verdict implementation; a signature check can be added as a second without
+// changing `resolveRuntimeTier` or its caller — the verdict is the pluggable
+// seam. A `null` manifest (none shipped) trusts nothing: safe by default, and
+// deliberately NOT a fallback to path-based trust.
+export function authorizeFirstParty(
+  manifest: FirstPartyManifest | null,
+  key: string,
+  contentHash: string | null,
+): boolean {
+  const pin = manifest?.keys[key];
+  if (!pin) return false; // key is not in the frozen first-party set
+  if (pin.sha256 === null) return true; // trusted by key alone (dev / unpinned)
+  return pin.sha256 === contentHash; // pinned: bundle content must match
+}
+
+// The single source of the trust decision: what tier a loaded view runs at. A
+// system view, or a package the source-authority verdict authorized as
+// first-party (`authorizeFirstParty` — never a filesystem path), is
+// node-integrated; everything else is sandboxed. The manifest's `runtime` hint
+// may only keep a view sandboxed, never elevate it.
 export function resolveRuntimeTier(
   view: Pick<KfxViewDecl, 'runtime' | 'system'>,
-  source: 'built-in' | 'installed',
+  trusted: boolean,
 ): KfxRuntimeTier {
-  if (view.system || source === 'built-in') return 'node-integrated';
-  // third-party installed: sandboxed by default; the manifest cannot elevate
+  if (view.system || trusted) return 'node-integrated';
+  // untrusted third-party: sandboxed by default; the manifest cannot elevate
   return 'sandboxed-ipc';
 }
 

--- a/tests/fixtures/kfx-demo-trust-authority/authority.test.mjs
+++ b/tests/fixtures/kfx-demo-trust-authority/authority.test.mjs
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+// Gate for the source-authority verdict (ADR-0013): a view is granted the
+// node-integrated tier only when its key is in the frozen first-party set and,
+// when pinned, its bundle content hash matches — never because of which
+// extension root it loaded from. Headless — the verdict is pure
+// (framework/kfx/src/index.ts) and the manifest generator scans a fixed
+// first-party root (framework/gui/src/main/first-party-manifest.ts).
+import { createHash } from 'node:crypto';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  authorizeFirstParty,
+  resolveRuntimeTier,
+} from '../../../framework/kfx/src/index.ts';
+import { generateFirstPartyManifest } from '../../../framework/gui/src/main/first-party-manifest.ts';
+
+const sha256 = (s) => createHash('sha256').update(s).digest('hex');
+const fails = [];
+const ck = (n, ok) => {
+  console.log(`  ${ok ? 'ok' : 'FAIL'}  ${n}`);
+  if (!ok) fails.push(n);
+};
+
+// A view kfx package on disk: manifest + bundle with the given content.
+function writeView(root, key, bundleContent) {
+  const dir = join(root, key);
+  mkdirSync(join(dir, 'dist', 'view'), { recursive: true });
+  writeFileSync(
+    join(dir, 'package.json'),
+    JSON.stringify({
+      name: `@kungfu-tech/kfx-view-${key}`,
+      kungfuConfig: { key, config: { view: { title: key, capabilities: [] } } },
+    }),
+  );
+  writeFileSync(join(dir, 'dist', 'view', 'index.js'), bundleContent);
+}
+
+// First-party root (shipped) with two views; a *separate* third-party root
+// (what a KF_EXTENSION_PATH entry or the install root would be) with a squatter.
+const base = mkdtempSync(join(tmpdir(), 'kfx-trust-'));
+const firstPartyRoot = join(base, 'first-party');
+const thirdPartyRoot = join(base, 'third-party');
+writeView(firstPartyRoot, 'work-dashboard', 'FIRST-PARTY-A');
+writeView(firstPartyRoot, 'rewind', 'FIRST-PARTY-B');
+writeView(thirdPartyRoot, 'evil', 'THIRD-PARTY');
+
+const view = { title: 't', capabilities: [] };
+const tier = (manifest, key, hash, v = view) =>
+  resolveRuntimeTier(v, authorizeFirstParty(manifest, key, hash));
+
+// 1. The generator scans only the first-party root — a package that lives on a
+//    different root is simply not in the set, no matter where it sits.
+const pinned = generateFirstPartyManifest(firstPartyRoot, { pin: true });
+ck('generator includes first-party keys', 'work-dashboard' in pinned.keys && 'rewind' in pinned.keys);
+ck('generator excludes a key from another root', !('evil' in pinned.keys));
+ck('generator pins the bundle hash', pinned.keys['work-dashboard'].sha256 === sha256('FIRST-PARTY-A'));
+
+// 2. The crux: a third-party package on the extension path is NOT trusted, even
+//    though under the old rule any non-install root conferred node-integrated.
+ck('third-party key on another root is sandboxed', tier(pinned, 'evil', sha256('THIRD-PARTY')) === 'sandboxed-ipc');
+
+// 3. A first-party key is node-integrated only with the matching content.
+ck('first-party key + matching hash is node-integrated', tier(pinned, 'work-dashboard', sha256('FIRST-PARTY-A')) === 'node-integrated');
+ck('first-party key + tampered bundle is sandboxed', tier(pinned, 'work-dashboard', sha256('TAMPERED')) === 'sandboxed-ipc');
+
+// 4. Dev (unpinned) trusts a first-party key by identity alone.
+const dev = generateFirstPartyManifest(firstPartyRoot, { pin: false });
+ck('dev manifest is unpinned', dev.keys['work-dashboard'].sha256 === null);
+ck('dev first-party key is node-integrated regardless of content', tier(dev, 'work-dashboard', sha256('anything')) === 'node-integrated');
+
+// 5. No manifest trusts nothing but the shell's own system views.
+ck('null manifest: a view is sandboxed', tier(null, 'work-dashboard', sha256('FIRST-PARTY-A')) === 'sandboxed-ipc');
+ck('system view is node-integrated without a manifest', tier(null, 'settings', null, { ...view, system: true }) === 'node-integrated');
+
+if (fails.length) {
+  console.log(`trust-authority check failed: ${fails}`);
+  process.exit(1);
+}
+console.log('trust-authority check passed');

--- a/tests/fixtures/kfx-demo-trust-authority/run.sh
+++ b/tests/fixtures/kfx-demo-trust-authority/run.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+# SPDX-License-Identifier: Apache-2.0
+# Gate: the source-authority verdict (ADR-0013) grants the node-integrated tier
+# by first-party-set membership and (when pinned) bundle content hash, never by
+# which extension root a package loaded from. Headless — no Electron; the pure
+# verdict is framework/kfx/src/index.ts and the manifest generator is
+# framework/gui/src/main/first-party-manifest.ts. Requires node >= 22 (native
+# TS type-stripping).
+set -eu
+fixture_dir="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+node --experimental-transform-types "$fixture_dir/authority.test.mjs"


### PR DESCRIPTION
First implementation slice of ADR-0013: grant a view the node-integrated tier by a **source-authority verdict**, never by which extension root it loaded from.

**The hole:** `resolveRuntimeTier` trusted a view whenever it loaded from any root other than the install root — so a `KF_EXTENSION_PATH` entry (or any writable built-in root) conferred full `node-integrated` trust.

**The change:**
- **kfx** — `FirstPartyManifest` + `authorizeFirstParty(manifest, key, contentHash)`: a view is trusted only if its key is in the frozen first-party set and, when pinned, its bundle content hash matches. This is the pluggable verdict — a signature check can be a second implementation without touching `resolveRuntimeTier`, which now takes a `trusted` boolean.
- **gui loader** — resolve the tier from the manifest (`KF_FIRST_PARTY_MANIFEST`) + bundle hash; path no longer confers trust. A missing manifest trusts nothing but the shell's own `system` views (safe default, never a path fallback).
- **manifest generation** — derived from a *fixed* first-party root (never `KF_EXTENSION_PATH`). Dev generates it at startup, keys only (bundles rebuild constantly → trusted by key). Packaged points at a build-baked resource with pinned hashes.

**Design note (surfaced during grounding):** content-hash trust conflicts with dev source builds (hashes change every rebuild). Resolved by making the verdict identity-based — packaged pins `key+hash`, dev trusts first-party `key` unpinned — so both modes close the `KF_EXTENSION_PATH` hole.

**Gate:** `tests/fixtures/kfx-demo-trust-authority` (verify --full stage 6, 10 assertions) — a third-party key on another root is sandboxed, a first-party key is node-integrated only with matching content, a tampered bundle is rejected, no manifest trusts nothing but system views.

**Follow-up (out of scope here):** the packaged pinned-manifest bake rides with built-in-extension shipping (a separate pre-existing gap); until then packaged apps trust only system views. Untrusted capture-side adapters (the runtime plane) are a later slice.