### PR TITLE
build(core): build the native addon from source on install

### DIFF
--- a/extensions/indexer-live/package.json
+++ b/extensions/indexer-live/package.json
@@ -15,18 +15,10 @@
     "registry": "https://registry.npmjs.org/",
     "access": "public"
   },
-  "binary": {
-    "module_name": "kfx-indexer-live",
-    "module_path": "dist/IndexerLive",
-    "remote_path": "{module_name}/v{major}/v{version}",
-    "package_name": "{module_name}-v{version}-{platform}-{arch}-{configuration}.tar.gz",
-    "host": "https://prebuilt.libkungfu.cc"
-  },
   "scripts": {
     "build": "kfs strategy build",
     "clean": "kfs strategy clean",
     "format": "node ../../framework/core/.gyp/run-format-python.js src",
-    "install": "node -e \"require('@kungfu-tech/core').prebuilt('install')\"",
     "package": "kfs project package"
   },
   "dependencies": {

--- a/framework/api/package.json
+++ b/framework/api/package.json
@@ -15,20 +15,11 @@
     "registry": "https://registry.npmjs.org/",
     "access": "public"
   },
-  "binary": {
-    "module_name": "api",
-    "module_path": "dist/api",
-    "remote_path": "{module_name}/v{major}/v{version}",
-    "package_name": "{module_name}-v{version}-{platform}-{arch}-{configuration}.tar.gz",
-    "host": "https://prebuilt.libkungfu.cc"
-  },
   "types": "./src/typings/index.d.ts",
   "main": "lib/index.js",
   "scripts": {
     "build": "tsc --noEmit",
-    "clean": "rimraf build dist",
-    "install": "node -e \"require('@kungfu-tech/core').prebuilt('install')\"",
-    "package": "node -e \"require('@kungfu-tech/core').prebuilt('package')\""
+    "clean": "rimraf build dist"
   },
   "dependencies": {
     "@fast-csv/format": "^4.3.5",

--- a/framework/core/.gyp/run-build.js
+++ b/framework/core/.gyp/run-build.js
@@ -77,11 +77,25 @@ module.exports = require('../lib/sywac')(
   (/** @type {any} */ cli) => {
     cli
       .command('install', () => {
-        const fallbackBuild = process.env.KF_INSTALL_FALLBACK_BUILD === 'true';
-        callPrebuilt(
-          fallbackBuild ? ['install', '--fallback-to-build'] : ['install'],
-          fallbackBuild,
+        // 4.0 publishes no prebuilt binary and the self-hosted download host is
+        // retired, so build the native addon from source when it is missing (a
+        // later install skips the recompile). Set KF_SKIP_INSTALL_BUILD=true to
+        // skip when the build runs as an explicit separate step. Prebuilt
+        // binaries return later via npm platform packages, not a download.
+        if (process.env.KF_SKIP_INSTALL_BUILD === 'true') {
+          return;
+        }
+        const builtAddon = path.join(
+          __dirname,
+          '..',
+          'dist',
+          'kungfu',
+          'kungfu_node.node',
         );
+        if (fs.existsSync(builtAddon)) {
+          return;
+        }
+        build();
       })
       .command('build', () => build())
       .command('clean', () => clean())

--- a/framework/core/package.json
+++ b/framework/core/package.json
@@ -30,9 +30,6 @@
     "module_path": "dist/kungfu",
     "remote_path": "kungfu-core/v{major}/v{version}",
     "package_name": "kungfu-v{version}-{platform}-{arch}-{configuration}.tar.gz",
-    "host": "https://prebuilt.libkungfu.cc"
-  },
-  "binaryGithub": {
     "host": "https://prebuilt.libkungfu.io"
   },
   "scripts": {


### PR DESCRIPTION
The self-hosted prebuilt host (prebuilt.libkungfu.cc) has an expired cert and publishes no 4.0 binary, so the node-pre-gyp download on install always failed. 4.0 now builds the native addon from source on install (skips when already built). Removes vestigial binary/install config from api and indexer-live. Verified end to end: a clean install compiles kungfu_node.node in ~10min. Follow-up: retire the node-pre-gyp/node-gyp/binding.gyp orchestration (it only circles back to run-conan.js) and distribute via npm platform packages.