### PR TITLE
feat(rewind): refuse untrusted adapters at the trace supervisor (ADR-0013 Phase 1)

### DIFF
--- a/framework/core/src/python/kungfu/rewind/adapters.py
+++ b/framework/core/src/python/kungfu/rewind/adapters.py
@@ -19,6 +19,8 @@
 import json
 import os
 
+from kungfu.rewind import first_party
+
 ENV_EXTENSION_PATH = "KF_EXTENSION_PATH"
 # shared contract strings with the child hooks (per runtime): the python hook
 # reads ENV_PLUGIN_ADAPTERS, the node hook reads ENV_NODE_ADAPTERS.
@@ -54,10 +56,17 @@ def _scan_packages(root):
 
 
 def discover_adapters(runtime_dir, runtime):
-    """Return (entry_files, package_dirs) for kfx packages declaring an adapter
-    form for `runtime` ('python' or 'node'). First occurrence of a package path
-    wins; missing entry files are skipped."""
-    entries, dirs, seen = [], [], set()
+    """Return (entry_files, package_dirs, refused) for kfx packages declaring an
+    adapter form for `runtime` ('python' or 'node'). First occurrence of a
+    package path wins; missing entry files are skipped.
+
+    Trust gate (ADR-0013): an adapter runs in-process inside the traced program
+    and cannot be sandboxed, so only a package whose key is in the frozen
+    first-party set is injected. An untrusted adapter is refused — returned in
+    `refused` as {"key", "package"} so the caller can report it — never injected.
+    """
+    trusted = first_party.first_party_keys()
+    entries, dirs, refused, seen = [], [], [], set()
     for root in _extension_roots(runtime_dir):
         for pkg in _scan_packages(root):
             try:
@@ -65,8 +74,8 @@ def discover_adapters(runtime_dir, runtime):
                     manifest = json.load(f)
             except (OSError, ValueError):
                 continue
-            config = (manifest.get("kungfuConfig") or {}).get("config") or {}
-            adapter = config.get("adapter") or {}
+            kfx = manifest.get("kungfuConfig") or {}
+            adapter = (kfx.get("config") or {}).get("adapter") or {}
             if runtime not in (adapter.get("runtimes") or []):
                 continue
             entry = (adapter.get("entry") or {}).get(runtime)
@@ -76,6 +85,9 @@ def discover_adapters(runtime_dir, runtime):
             if path in seen or not os.path.exists(path):
                 continue
             seen.add(path)
+            if kfx.get("key") not in trusted:
+                refused.append({"key": kfx.get("key"), "package": os.path.abspath(pkg)})
+                continue
             entries.append(path)
             dirs.append(os.path.abspath(pkg))
-    return entries, dirs
+    return entries, dirs, refused

--- a/framework/core/src/python/kungfu/rewind/first_party.py
+++ b/framework/core/src/python/kungfu/rewind/first_party.py
@@ -1,0 +1,74 @@
+#  SPDX-License-Identifier: Apache-2.0
+#
+# The frozen first-party set (ADR-0013), supervisor side. Trust is granted by
+# membership in this set — a verifiable origin — never by which extension root a
+# package loaded from. An adapter is capture-side instrumentation that runs
+# in-process inside the traced program; it cannot be sandboxed, so an untrusted
+# adapter is refused, not contained — only a source-verified first-party adapter
+# may inject.
+#
+# The set is read from the shared manifest (KF_FIRST_PARTY_MANIFEST, the same one
+# the GUI loader consumes) when present; otherwise, in a source checkout, it is
+# derived from the product's own extensions/ tree. A frozen build with no baked
+# manifest trusts none — adapters are refused until the manifest ships (tracked
+# with built-in-extension shipping).
+
+import json
+import os
+
+ENV_FIRST_PARTY_MANIFEST = "KF_FIRST_PARTY_MANIFEST"
+
+
+def _manifest_keys():
+    path = os.environ.get(ENV_FIRST_PARTY_MANIFEST)
+    if not path or not os.path.isfile(path):
+        return None
+    try:
+        with open(path) as f:
+            data = json.load(f)
+    except (OSError, ValueError):
+        return None
+    keys = data.get("keys")
+    return set(keys) if isinstance(keys, dict) else None
+
+
+def _source_extensions_root():
+    # In a source checkout the product's own extensions/ tree is the first-party
+    # root; None in a frozen build, where the baked manifest is authoritative.
+    root = os.path.abspath(
+        os.path.join(os.path.dirname(__file__), *([os.pardir] * 6), "extensions")
+    )
+    return root if os.path.isdir(root) else None
+
+
+def _package_key(pkg):
+    try:
+        with open(os.path.join(pkg, "package.json")) as f:
+            return (json.load(f).get("kungfuConfig") or {}).get("key")
+    except (OSError, ValueError):
+        return None
+
+
+def _scan_keys(root):
+    # two levels deep, mirroring the loader / adapter discovery scan
+    keys = set()
+    if not root or not os.path.isdir(root):
+        return keys
+    for name in sorted(os.listdir(root)):
+        pkg = os.path.join(root, name)
+        candidates = [pkg]
+        if os.path.isdir(pkg):
+            candidates += [os.path.join(pkg, s) for s in sorted(os.listdir(pkg))]
+        for cand in candidates:
+            key = _package_key(cand)
+            if key:
+                keys.add(key)
+    return keys
+
+
+def first_party_keys():
+    """The set of extension keys the supervisor may trust to inject an adapter."""
+    keys = _manifest_keys()
+    if keys is not None:
+        return keys
+    return _scan_keys(_source_extensions_root())

--- a/framework/core/src/python/kungfu/rewind/supervisor.py
+++ b/framework/core/src/python/kungfu/rewind/supervisor.py
@@ -135,8 +135,20 @@ class Supervisor:
         # announce their entry files to each runtime's child hook. Python
         # adapters also put their package dirs on PYTHONPATH so an adapter can
         # import its own siblings; node adapters are required by absolute path.
-        py_entries, py_dirs = adapters.discover_adapters(self.runtime_dir, "python")
-        node_entries, _ = adapters.discover_adapters(self.runtime_dir, "node")
+        py_entries, py_dirs, py_refused = adapters.discover_adapters(
+            self.runtime_dir, "python"
+        )
+        node_entries, _, node_refused = adapters.discover_adapters(
+            self.runtime_dir, "node"
+        )
+        for refused in py_refused + node_refused:
+            # an adapter injects into the traced program in-process; an untrusted
+            # one cannot be sandboxed, so it is refused rather than contained.
+            sys.stderr.write(
+                f"[kungfu trace] refusing untrusted adapter "
+                f"{refused['key']!r} at {refused['package']}: only a "
+                f"source-verified first-party adapter may inject.\n"
+            )
         if py_entries:
             env[adapters.ENV_PLUGIN_ADAPTERS] = os.pathsep.join(py_entries)
         if node_entries:

--- a/framework/core/tests/python/test_adapter_trust.py
+++ b/framework/core/tests/python/test_adapter_trust.py
@@ -1,0 +1,86 @@
+#  SPDX-License-Identifier: Apache-2.0
+#
+# The trace supervisor injects a kfx adapter into the traced program in-process;
+# an untrusted adapter cannot be sandboxed, so it must be refused, not injected
+# (ADR-0013). Trust is by first-party-set membership, never by which extension
+# root the package sits on.
+
+import json
+import os
+
+from kungfu.rewind import adapters
+
+
+def _write_adapter(root, key, runtime="python"):
+    pkg = os.path.join(root, key)
+    entry = os.path.join("src", "adapter", runtime, "index.py")
+    os.makedirs(os.path.join(pkg, os.path.dirname(entry)), exist_ok=True)
+    with open(os.path.join(pkg, "package.json"), "w") as f:
+        json.dump(
+            {
+                "name": f"@kungfu-tech/kfx-adapter-{key}",
+                "kungfuConfig": {
+                    "key": key,
+                    "config": {
+                        "adapter": {"runtimes": [runtime], "entry": {runtime: entry}}
+                    },
+                },
+            },
+            f,
+        )
+    with open(os.path.join(pkg, entry), "w") as f:
+        f.write("# adapter source\n")
+    return pkg
+
+
+def _write_manifest(path, keys):
+    with open(path, "w") as f:
+        json.dump({"version": 1, "keys": {k: {"sha256": None} for k in keys}}, f)
+
+
+def _injected_keys(dirs):
+    return {os.path.basename(d) for d in dirs}
+
+
+def _setup(tmp_path, monkeypatch, trusted_keys):
+    ext = tmp_path / "ext"
+    _write_adapter(str(ext), "trusted-a")
+    _write_adapter(str(ext), "evil")
+    manifest = tmp_path / "first-party.json"
+    _write_manifest(str(manifest), trusted_keys)
+    monkeypatch.setenv("KF_FIRST_PARTY_MANIFEST", str(manifest))
+    monkeypatch.setenv("KF_EXTENSION_PATH", str(ext))
+    return ext
+
+
+def test_untrusted_adapter_is_refused_not_injected(tmp_path, monkeypatch):
+    _setup(tmp_path, monkeypatch, trusted_keys=["trusted-a"])
+    entries, dirs, refused = adapters.discover_adapters(None, "python")
+    assert _injected_keys(dirs) == {"trusted-a"}
+    assert {r["key"] for r in refused} == {"evil"}
+    assert len(entries) == 1
+
+
+def test_extension_path_does_not_confer_trust(tmp_path, monkeypatch):
+    # both adapters sit on KF_EXTENSION_PATH; membership, not the root, decides.
+    _setup(tmp_path, monkeypatch, trusted_keys=[])
+    entries, dirs, refused = adapters.discover_adapters(None, "python")
+    assert dirs == [] and entries == []
+    assert {r["key"] for r in refused} == {"trusted-a", "evil"}
+
+
+def test_install_root_adapter_is_refused(tmp_path, monkeypatch):
+    # an adapter dropped in <home>/extensions (the install root, runtime_dir
+    # based) is not first-party and must be refused.
+    home = tmp_path / "home"
+    # the install root is <dirname(runtime_dir)>/extensions
+    install_root = home / "extensions"
+    _write_adapter(str(install_root), "installed-evil")
+    manifest = tmp_path / "first-party.json"
+    _write_manifest(str(manifest), ["trusted-a"])
+    monkeypatch.setenv("KF_FIRST_PARTY_MANIFEST", str(manifest))
+    monkeypatch.delenv("KF_EXTENSION_PATH", raising=False)
+    runtime_dir = str(home / "runtime")
+    entries, dirs, refused = adapters.discover_adapters(runtime_dir, "python")
+    assert entries == []
+    assert {r["key"] for r in refused} == {"installed-evil"}


### PR DESCRIPTION
Extends the ADR-0013 source-authority verdict from the GUI view plane (Phase 0, #204) to the **runtime/capture plane**.

**The hole:** a capture-side `adapter` facet is injected by the trace supervisor into the traced program **in-process**, and the supervisor injected *every* discovered adapter with no trust check. Installing a third-party adapter, or pointing `KF_EXTENSION_PATH` at one, gave it full in-process reach over the run.

**Why refuse, not sandbox:** an adapter runs inside the traced program's own process by construction (it patches the framework's tool seam) — isolating it would defeat the instrumentation. So an untrusted adapter is **refused, not contained**; injecting third-party code into a run requires the trusted channel (source verification).

**The change:**
- `first_party.py` — the first-party key set, read from the shared manifest (`KF_FIRST_PARTY_MANIFEST`, the same one the GUI loader uses) or, in a source checkout, derived from the product's own `extensions/` tree. A frozen build with no baked manifest trusts none.
- `discover_adapters` now returns `(entries, dirs, refused)`; only a package whose key is in the first-party set is injected. The supervisor logs each refusal on stderr.
- `test_adapter_trust` — an untrusted adapter is refused whether it sits on `KF_EXTENSION_PATH` or the install root; a first-party adapter is injected. Trust is by set membership, never by root.

**No regression:** the `rewind-demo-langchain` fixture runs from source (`uv run python .devtools/kungfu_cli.py`), so the first-party set is derived from the real `extensions/` tree and `langchain-adapter` stays trusted.

**Follow-up (shared with Phase 0):** the packaged/frozen path needs the baked first-party manifest (rides with built-in-extension shipping); until then a frozen build refuses adapters.

Builds on #204.