### PR TITLE
feat(capability): subprocess transport + Python guest for the relay (ADR-0013 Phase 2)

### DIFF
--- a/framework/api/src/capability/subprocess.ts
+++ b/framework/api/src/capability/subprocess.ts
@@ -1,0 +1,87 @@
+// The CLI-plane transport for the capability relay (ADR-0013): pure stdio framing
+// that connects a trusted capability host to a sandboxed guest running in a child
+// process, over the child's stdio as newline-delimited JSON. It is the sibling of
+// the GUI-plane Electron IPC transport (framework/gui/src/sandbox) — the same
+// transport-agnostic contract (HostRequest/HostEvent), a different channel.
+//
+// It is deliberately decoupled from the host implementation: the caller passes a
+// factory that builds the host given an event sink (compose it with
+// createCapabilityHost from ./sandbox), so the framing serves any host and stays
+// testable without a capability instance. The host holds the real capabilities;
+// an undeclared capability is rejected there and never reachable from the child.
+//
+// Wire protocol (one JSON object per line, both directions):
+//   child -> host   { "t": "invoke", "id": n, "cap", "method", "args" }
+//   host  -> child  { "t": "result", "id": n, "ok": true,  "value" }
+//                   { "t": "result", "id": n, "ok": false, "error" }
+//   host  -> child  { "t": "event",  "callback": n, "args" }   (a bridged callback)
+import { createInterface } from 'node:readline';
+
+export type HostRequest = { cap: string; method: string; args: unknown[] };
+export type HostEvent = { callback: number; args: unknown[] };
+
+// The trusted side of one guest connection: resolve a call, and drop any
+// subscriptions the guest left open on disconnect. createCapabilityHost
+// (./sandbox) produces exactly this shape.
+export type RelayHost = {
+  handle: (req: HostRequest) => Promise<unknown>;
+  dispose: () => void;
+};
+
+// The subset of a child process this needs — structural so a caller can pass a
+// Node ChildProcess or a test double.
+export type SubprocessChannel = {
+  stdout: NodeJS.ReadableStream;
+  stdin: { write: (chunk: string) => void };
+  once: (event: 'exit' | 'close', cb: () => void) => void;
+};
+
+export type SubprocessHost = { dispose: () => void };
+
+export function serveSubprocessCapabilities(
+  child: SubprocessChannel,
+  createHost: (emit: (event: HostEvent) => void) => RelayHost,
+): SubprocessHost {
+  const send = (msg: unknown): void => {
+    child.stdin.write(`${JSON.stringify(msg)}\n`);
+  };
+  const host = createHost((event) => send({ t: 'event', ...event }));
+
+  const lines = createInterface({ input: child.stdout });
+  lines.on('line', (line: string) => {
+    if (!line) return;
+    let msg: {
+      t?: string;
+      id?: number;
+      cap?: string;
+      method?: string;
+      args?: unknown[];
+    };
+    try {
+      msg = JSON.parse(line);
+    } catch {
+      return; // ignore anything that is not a protocol frame
+    }
+    if (msg.t !== 'invoke' || typeof msg.id !== 'number') return;
+    const id = msg.id;
+    Promise.resolve()
+      .then(() =>
+        host.handle({
+          cap: msg.cap ?? '',
+          method: msg.method ?? '',
+          args: msg.args ?? [],
+        }),
+      )
+      .then((value) => send({ t: 'result', id, ok: true, value }))
+      .catch((e: unknown) =>
+        send({ t: 'result', id, ok: false, error: (e as Error).message }),
+      );
+  });
+
+  const dispose = () => {
+    lines.close();
+    host.dispose();
+  };
+  child.once('exit', dispose);
+  return { dispose };
+}

--- a/framework/core/src/python/kungfu/capability/__init__.py
+++ b/framework/core/src/python/kungfu/capability/__init__.py
@@ -1,0 +1,13 @@
+#  SPDX-License-Identifier: Apache-2.0
+#
+# The guest (sandboxed) side of the capability relay for a Python child process
+# (ADR-0013). A child reaches only its declared capabilities, forwarded to the
+# trusted host over a newline-delimited JSON channel (its stdio by default). This
+# is the Python port of framework/api/src/capability/sandbox.ts
+# createCapabilityGuest: each method call and each callback argument is
+# marshalled over the channel, and a capability that was not declared is absent —
+# not merely un-injected, but never built.
+
+from kungfu.capability.guest import connect
+
+__all__ = ["connect"]

--- a/framework/core/src/python/kungfu/capability/guest.py
+++ b/framework/core/src/python/kungfu/capability/guest.py
@@ -1,0 +1,108 @@
+#  SPDX-License-Identifier: Apache-2.0
+#
+# Python port of the guest half of framework/api/src/capability/sandbox.ts. A
+# sandboxed Python child builds a capability object from its declared set alone
+# and forwards each call to the trusted host over a newline-delimited JSON
+# channel; the host resolves it against the real capabilities and rejects an
+# undeclared one. A callback argument is replaced on the wire by a
+# {"__sandboxCallback": id} marker; when the host bridges it back as an event,
+# the registered callback fires.
+
+import json
+import sys
+import threading
+
+
+class _Channel:
+    """Reads host->guest frames on a background thread: results wake the
+    invoke() that is waiting on their id; events fire registered callbacks."""
+
+    def __init__(self, read_stream, write_stream):
+        self._read = read_stream
+        self._write = write_stream
+        self._write_lock = threading.Lock()
+        self._cond = threading.Condition()
+        self._results = {}
+        self._seq = 0
+        self._callbacks = {}
+        self._reader = threading.Thread(target=self._read_loop, daemon=True)
+        self._reader.start()
+
+    def _send(self, msg):
+        line = json.dumps(msg) + "\n"
+        with self._write_lock:
+            self._write.write(line)
+            self._write.flush()
+
+    def _read_loop(self):
+        while True:
+            line = self._read.readline()
+            if not line:
+                break  # EOF: the host closed the channel
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                msg = json.loads(line)
+            except ValueError:
+                continue
+            kind = msg.get("t")
+            if kind == "result":
+                with self._cond:
+                    self._results[msg.get("id")] = msg
+                    self._cond.notify_all()
+            elif kind == "event":
+                callback = self._callbacks.get(msg.get("callback"))
+                if callback is not None:
+                    callback(*msg.get("args", []))
+
+    def _marshal(self, args):
+        out = []
+        for arg in args:
+            if callable(arg):
+                self._seq += 1
+                self._callbacks[self._seq] = arg
+                out.append({"__sandboxCallback": self._seq})
+            else:
+                out.append(arg)
+        return out
+
+    def invoke(self, cap, method, args):
+        self._seq += 1
+        ident = self._seq
+        self._send(
+            {
+                "t": "invoke",
+                "id": ident,
+                "cap": cap,
+                "method": method,
+                "args": self._marshal(args),
+            }
+        )
+        with self._cond:
+            while ident not in self._results:
+                self._cond.wait()
+            result = self._results.pop(ident)
+        if not result.get("ok"):
+            raise RuntimeError(result.get("error") or "capability call failed")
+        return result.get("value")
+
+
+class _Capability:
+    def __init__(self, channel, cap):
+        self._channel = channel
+        self._cap = cap
+
+    def __getattr__(self, method):
+        def call(*args):
+            return self._channel.invoke(self._cap, method, list(args))
+
+        return call
+
+
+def connect(declared, read_stream=None, write_stream=None):
+    """Build the capability object a sandboxed Python child receives: exactly the
+    declared capabilities, each forwarded to the host over the channel (the
+    child's stdio by default)."""
+    channel = _Channel(read_stream or sys.stdin, write_stream or sys.stdout)
+    return {cap: _Capability(channel, cap) for cap in declared}

--- a/tests/fixtures/kfx-demo-subprocess-caps/child.py
+++ b/tests/fixtures/kfx-demo-subprocess-caps/child.py
@@ -1,0 +1,62 @@
+#  SPDX-License-Identifier: Apache-2.0
+#
+# The sandboxed Python guest for the subprocess capability transport gate. It
+# reaches only its declared capabilities, forwarded to the Node host over stdio;
+# its ok/FAIL report goes to stderr (stdout is the protocol channel) and its exit
+# code is the gate result.
+
+import importlib.util
+import os
+import sys
+import threading
+
+# Load the guest by path so the gate is self-contained: guest.py is stdlib-only,
+# and importing it through the kungfu package would pull in the native binding
+# this transport does not need. Real callers use `from kungfu.capability import
+# connect` (see kungfu/capability/__init__.py).
+_guest_path = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)),
+    *[".."] * 3,
+    "framework/core/src/python/kungfu/capability/guest.py",
+)
+_spec = importlib.util.spec_from_file_location("_kungfu_capability_guest", _guest_path)
+_guest = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_guest)
+connect = _guest.connect
+
+fails = []
+
+
+def ck(name, ok):
+    sys.stderr.write(f"  {'ok' if ok else 'FAIL'}  {name}\n")
+    if not ok:
+        fails.append(name)
+
+
+caps = connect(["rewind", "ledger"])  # stdin/stdout is the channel
+
+# a declared capability call round-trips to the host and back
+ck("declared call forwards + returns", caps["rewind"].runs() == ["run-A", "run-B"])
+
+# an undeclared capability is absent — the guest is built from the declared set
+ck("undeclared capability absent", "work" not in caps)
+
+# a callback argument bridges back as host->guest events
+received = []
+done = threading.Event()
+
+
+def on_event(value):
+    received.append(value)
+    if len(received) == 2:
+        done.set()
+
+
+caps["ledger"].subscribe(on_event)
+done.wait(2.0)
+ck("subscription bridges host->guest", received == [7, 9])
+
+sys.stderr.write(
+    "subprocess caps check " + (f"failed {fails}" if fails else "passed") + "\n"
+)
+sys.exit(1 if fails else 0)

--- a/tests/fixtures/kfx-demo-subprocess-caps/parent.mjs
+++ b/tests/fixtures/kfx-demo-subprocess-caps/parent.mjs
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+// Gate: a sandboxed Python child reaches only its declared capabilities over the
+// subprocess capability transport (ADR-0013) — the CLI-plane sibling of the GUI
+// Electron IPC transport, same sandbox.ts core, different channel. Headless: a
+// Node host holding mock caps + a Python guest (child.py), no Electron. The
+// child asserts the roundtrip, an undeclared-capability absence, and a bridged
+// subscription; its exit code is this gate's result. Requires node >= 22 (native
+// TS type-stripping) and python3.
+import { spawn } from 'node:child_process';
+
+import { createCapabilityHost } from '../../../framework/api/src/capability/sandbox.ts';
+import { serveSubprocessCapabilities } from '../../../framework/api/src/capability/subprocess.ts';
+
+const caps = {
+  rewind: { runs: () => ['run-A', 'run-B'] },
+  ledger: {
+    subscribe: (cb) => {
+      // fire two events shortly after the subscribe call returns
+      const timer = setTimeout(() => {
+        cb(7);
+        cb(9);
+      }, 10);
+      return { stop: () => clearTimeout(timer) };
+    },
+  },
+};
+
+const child = spawn('python3', [new URL('./child.py', import.meta.url).pathname], {
+  stdio: ['pipe', 'pipe', 'inherit'], // stdin/stdout = protocol channel; stderr = child's report
+});
+serveSubprocessCapabilities(child, (emit) =>
+  createCapabilityHost(caps, ['rewind', 'ledger'], emit),
+);
+child.once('exit', (code) => process.exit(code ?? 1));

--- a/tests/fixtures/kfx-demo-subprocess-caps/run.sh
+++ b/tests/fixtures/kfx-demo-subprocess-caps/run.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+# SPDX-License-Identifier: Apache-2.0
+# Gate: the subprocess capability transport (ADR-0013). A Node host serves mock
+# capabilities to a sandboxed Python guest over the child's stdio; the guest
+# reaches only its declared capabilities, and a bridged subscription round-trips.
+# Headless — no Electron. Requires node >= 22 (native TS type-stripping) and a
+# python3 that can import kungfu.capability (the core dev environment).
+set -eu
+fixture_dir="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+node --experimental-transform-types "$fixture_dir/parent.mjs"


### PR DESCRIPTION
The capability relay (`sandbox.ts`) was transport-agnostic but shipped only the Electron IPC channel (GUI plane). This adds the **CLI-plane channel**: a sandboxed guest can run in a child process, reaching only its declared capabilities over the child's stdio.

- `api/capability/subprocess.ts` — pure newline-delimited-JSON stdio framing, **decoupled from the host** (the caller composes it with `createCapabilityHost`), so it serves any host and is testable without a capability instance. The host holds the real caps; an undeclared capability is rejected there, never reachable.
- `kungfu/capability` (`guest.py`) — the **Python port** of `createCapabilityGuest`: a child builds its capability object from the declared set alone, marshals callback args as `{"__sandboxCallback"}` markers, and receives bridged events on a background reader thread.
- fixture `kfx-demo-subprocess-caps` (verify --full stage 6) — a Node host + a **Python guest over a real subprocess** prove a declared call round-trips, an undeclared capability is absent, and a subscription bridges host→guest.

Validated: fixture passes end-to-end (Node ↔ Python), `subprocess.ts` typechecks, `guest.py` ruff-clean.

Builds on the two-tier trust work (#204 Phase 0, #206 Phase 1). This is the default-tier *transport*; the OS-sandbox launcher that isolates the child is Phase 3.