### PR TITLE
feat(capability): OS sandbox launcher for the default tier — macOS (ADR-0013 Phase 3)

### DIFF
--- a/framework/api/src/capability/sandbox-launcher.ts
+++ b/framework/api/src/capability/sandbox-launcher.ts
@@ -1,0 +1,62 @@
+// The default-tier isolation base (ADR-0013): launch an untrusted guest inside an
+// OS sandbox so its only egress is the capability relay carried on its stdio
+// (framework/api/src/capability/subprocess.ts). Filesystem writes and the network
+// are denied by default; reads are allowed, because an interpreter must read its
+// own runtime — the read boundary is coarse, which the ADR records as residual
+// risk, not an absolute guarantee.
+//
+// macOS confines the child with a Seatbelt profile via `sandbox-exec`. Linux
+// (Landlock + seccomp-BPF + user/pid/net namespaces) is not implemented yet and
+// is refused rather than run unconfined: a sandbox that silently does nothing is
+// worse than an explicit, visible gap.
+import { platform } from 'node:os';
+
+// Deny by default; allow exec/fork and reads (the interpreter needs its runtime)
+// and the /dev nodes a process needs; deny every filesystem write and all network.
+// Inherited stdio (fds 0-2) is unaffected, so the capability relay still flows.
+// Seatbelt is last-match-wins, so the /dev write allowances follow the blanket
+// write denial.
+const MACOS_SEATBELT_PROFILE = [
+  '(version 1)',
+  '(deny default)',
+  '(allow process-fork)',
+  '(allow process-exec)',
+  '(allow sysctl-read)',
+  '(allow file-read*)',
+  '(deny file-write*)',
+  '(allow file-write-data (literal "/dev/null"))',
+  '(allow file-write-data (literal "/dev/dtracehelper"))',
+  '(deny network*)',
+].join('');
+
+export type SandboxedCommand = { command: string; args: string[] };
+
+export function isOsSandboxSupported(): boolean {
+  return platform() === 'darwin';
+}
+
+// Wrap a command so it runs inside the OS default-deny sandbox. Throws on a
+// platform whose sandbox is not implemented — the caller must not fall back to
+// launching the guest unconfined.
+export function osSandboxCommand(
+  command: string,
+  args: readonly string[] = [],
+): SandboxedCommand {
+  switch (platform()) {
+    case 'darwin':
+      return {
+        command: 'sandbox-exec',
+        args: ['-p', MACOS_SEATBELT_PROFILE, command, ...args],
+      };
+    case 'linux':
+      throw new Error(
+        'os sandbox not implemented on linux yet (Landlock + seccomp + namespaces); ' +
+          'refusing to launch an untrusted guest unconfined',
+      );
+    default:
+      throw new Error(
+        `os sandbox not available on ${platform()}; ` +
+          'refusing to launch an untrusted guest unconfined',
+      );
+  }
+}

--- a/tests/fixtures/kfx-demo-sandbox-launch/child.py
+++ b/tests/fixtures/kfx-demo-sandbox-launch/child.py
@@ -1,0 +1,59 @@
+#  SPDX-License-Identifier: Apache-2.0
+#
+# The sandboxed guest for the OS-sandbox gate. Launched under the OS default-deny
+# sandbox, it proves that the capability relay still works (its only egress) while
+# the filesystem and the network are denied. ok/FAIL goes to stderr; stdout is the
+# protocol channel; the exit code is the gate result.
+
+import importlib.util
+import os
+import socket
+import sys
+
+# load the guest by path (stdlib-only; avoids the native binding); reads are
+# allowed under the sandbox, so importing the source is fine.
+_guest_path = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)),
+    *[".."] * 3,
+    "framework/core/src/python/kungfu/capability/guest.py",
+)
+_spec = importlib.util.spec_from_file_location("_kungfu_capability_guest", _guest_path)
+_guest = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_guest)
+
+fails = []
+
+
+def ck(name, ok):
+    sys.stderr.write(f"  {'ok' if ok else 'FAIL'}  {name}\n")
+    if not ok:
+        fails.append(name)
+
+
+caps = _guest.connect(["rewind"])
+
+# 1. the capability relay is reachable through the sandbox — the only egress
+ck("capability relay works inside sandbox", caps["rewind"].runs() == ["run-A", "run-B"])
+
+# 2. a filesystem write is denied by the sandbox (EPERM -> PermissionError)
+try:
+    with open("/tmp/kfx_sandbox_leak", "w") as f:
+        f.write("x")
+    ck("filesystem write denied", False)
+except PermissionError:
+    ck("filesystem write denied", True)
+
+# 3. the network is denied by the sandbox (the connect is refused, not merely
+#    unreachable — so this holds offline too)
+try:
+    socket.create_connection(("1.1.1.1", 80), timeout=3)
+    ck("network denied", False)
+except PermissionError:
+    ck("network denied", True)
+except OSError as e:
+    ck("network denied", isinstance(e, PermissionError))
+
+sys.stderr.write(
+    "sandbox launch check " + (f"failed {fails}" if fails else "passed") + "\n"
+)
+sys.exit(1 if fails else 0)

--- a/tests/fixtures/kfx-demo-sandbox-launch/parent.mjs
+++ b/tests/fixtures/kfx-demo-sandbox-launch/parent.mjs
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+// Gate: the default-tier OS sandbox (ADR-0013). A guest launched under the OS
+// sandbox reaches out only through the capability relay on its stdio — the
+// filesystem and the network are denied. This composes the three pieces: the
+// launcher (sandbox-launcher.ts), the transport (subprocess.ts), and the host
+// (sandbox.ts). Headless, macOS only (Seatbelt); run.sh skips elsewhere.
+import { execSync, spawn } from 'node:child_process';
+
+import { createCapabilityHost } from '../../../framework/api/src/capability/sandbox.ts';
+import { osSandboxCommand } from '../../../framework/api/src/capability/sandbox-launcher.ts';
+import { serveSubprocessCapabilities } from '../../../framework/api/src/capability/subprocess.ts';
+
+const python = execSync('command -v python3').toString().trim();
+const childScript = new URL('./child.py', import.meta.url).pathname;
+const { command, args } = osSandboxCommand(python, [childScript]);
+
+const caps = { rewind: { runs: () => ['run-A', 'run-B'] } };
+const child = spawn(command, args, {
+  stdio: ['pipe', 'pipe', 'inherit'], // stdin/stdout = relay channel; stderr = child's report
+});
+serveSubprocessCapabilities(child, (emit) =>
+  createCapabilityHost(caps, ['rewind'], emit),
+);
+child.once('exit', (code) => process.exit(code ?? 1));

--- a/tests/fixtures/kfx-demo-sandbox-launch/run.sh
+++ b/tests/fixtures/kfx-demo-sandbox-launch/run.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+# SPDX-License-Identifier: Apache-2.0
+# Gate: the default-tier OS sandbox (ADR-0013). A guest launched under the OS
+# sandbox relays capabilities over its stdio but cannot touch the filesystem or
+# the network. macOS only (Seatbelt via sandbox-exec); the Linux launcher
+# (Landlock + seccomp + namespaces) is not implemented yet, so this gate skips
+# there rather than pass vacuously. Requires node >= 22 and python3.
+set -eu
+fixture_dir="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+if [ "$(uname)" != "Darwin" ]; then
+  echo "skipped: os sandbox gate runs on darwin only (linux launcher not implemented)"
+  exit 0
+fi
+node --experimental-transform-types "$fixture_dir/parent.mjs"


### PR DESCRIPTION
The isolation base for the default tier: launch an untrusted guest inside an OS default-deny sandbox so its **only egress is the capability relay** (Phase 2) on its stdio. Filesystem writes and the network are denied; reads are allowed (an interpreter must read its own runtime — a coarse boundary the ADR records as residual risk).

- `sandbox-launcher.ts` — wrap a command in a Seatbelt profile via `sandbox-exec` on macOS. **Linux (Landlock + seccomp + namespaces) is not implemented yet and is refused, not run unconfined** — a silent no-op sandbox is worse than a visible gap.
- fixture `kfx-demo-sandbox-launch` (verify --full stage 6, macOS only) — composes launcher + transport + host: a guest under the sandbox relays a capability call through its stdio, while a filesystem write and a network connection are **both denied**.

**Validated on macOS arm64** (this machine): relay works through the sandbox, `/tmp` write → PermissionError, socket connect → PermissionError, no leak file created.

Completes the default-tier isolation: Phase 1 refuses untrusted in-process adapters, Phase 2 gave the relay a subprocess channel, Phase 3 confines that subprocess. Builds on #204/#206/#207. Remaining: Phase 4 (install-time trust consent), the Linux launcher, and the packaged first-party-manifest bake.