### PR TITLE
docs(governance): define provider-risk boundaries

### DIFF
--- a/ACCEPTABLE_USE.md
+++ b/ACCEPTABLE_USE.md
@@ -1,0 +1,74 @@
+# Acceptable Use Policy
+
+This policy applies to official Kungfu services and maintainer-operated
+infrastructure. It does not change the Apache-2.0 license for the source code in
+this repository.
+
+Examples of official services and infrastructure may include hosted sync,
+managed sessions, relay services, mobile push, official release infrastructure,
+official package distribution, official support channels, and maintainer-run CI
+or deployment resources.
+
+## Allowed Purpose
+
+Official Kungfu services are intended to help users and teams manage legitimate
+agent-assisted work with better cost visibility, work state, evidence, replay,
+and recovery.
+
+Users remain responsible for:
+
+- the work they ask agents or automation to perform;
+- the credentials, accounts, repositories, data, and systems they connect;
+- complying with laws, upstream provider terms, and organization policies that
+  apply to their use.
+
+## Disallowed Use
+
+Do not use official Kungfu services or infrastructure to:
+
+- access systems, accounts, data, repositories, or services without
+  authorization;
+- steal, expose, sell, or mishandle credentials, tokens, session data, secrets,
+  private keys, customer data, or private logs;
+- bypass billing, quota, rate limits, approval flows, safety controls, or access
+  controls of upstream providers;
+- operate shared hidden provider accounts, credential pools, or proxy services
+  that misrepresent who is using an upstream platform;
+- generate or distribute malware, exploit chains, phishing infrastructure, or
+  unauthorized intrusion tooling;
+- overload, degrade, probe, or attack official Kungfu infrastructure or
+  upstream provider infrastructure;
+- misrepresent unofficial software, services, releases, or forks as official
+  Kungfu offerings;
+- use official services in a way that creates legal, security, abuse, or trust
+  risk for other users, the maintainers, or upstream providers.
+
+## Managed Agent Sessions
+
+When Kungfu manages an agent session, the expected model is:
+
+- the user owns the upstream account or credential;
+- Kungfu records cost, state, evidence, approvals, and artifacts for the user's
+  work;
+- Kungfu does not provide hidden shared accounts or pooled credentials;
+- Kungfu does not bypass provider billing, quota, rate-limit, or approval
+  systems;
+- attribution confidence is labeled honestly when cost or usage cannot be
+  tied exactly to a run or session.
+
+## Enforcement
+
+The maintainers may refuse, suspend, limit, or terminate access to official
+services or infrastructure for uses that violate this policy or create material
+risk. They may also remove misleading official-brand claims from project
+channels or package distribution surfaces they control.
+
+Where practical, maintainers may contact affected users before taking action.
+Immediate action may be taken for security incidents, abuse, infrastructure
+risk, provider-risk incidents, or misleading official-brand use.
+
+## Security Reports
+
+Report vulnerabilities, credential exposure, or service-abuse issues through the
+private reporting path in `SECURITY.md`, not through public issues.
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,11 +55,17 @@ layout, and code style.
 - Bugs, feature requests, questions, and documentation issues go through GitHub
   issues; security vulnerabilities use private vulnerability reporting — see
   [`SECURITY.md`](SECURITY.md).
+- Brand, hosted-service, and upstream-provider boundaries are documented in
+  [`TRADEMARK.md`](TRADEMARK.md), [`ACCEPTABLE_USE.md`](ACCEPTABLE_USE.md), and
+  [`PROVIDER_COMPLIANCE.md`](PROVIDER_COMPLIANCE.md).
 
 ## Ground rules
 
 - Never include secrets, credentials, tokens, or private logs in code, commits,
   issues, or pull requests.
+- Do not build or document official integrations that scrape private provider
+  sessions, bypass provider billing or quota systems, or misrepresent usage
+  attribution.
 - Prefer the smallest change that holds, and keep documentation in sync with
   behavior.
 - [`docs/MAP.md`](docs/MAP.md) and [`CONTRIBUTING.md`](CONTRIBUTING.md) are the

--- a/LICENSE-POLICY.md
+++ b/LICENSE-POLICY.md
@@ -38,11 +38,26 @@ Apache-2.0 grants copyright and patent permissions. It does not grant trademark
 rights. Names, logos, domain names, and product marks such as "Kungfu" and
 "Kungfu Tracer" may be governed by separate brand guidelines.
 
+See [TRADEMARK.md](TRADEMARK.md) for the official project mark and fork identity
+boundary.
+
 ## Hosted and commercial services
 
 The open source license covers this repository. Hosted services, team features,
 enterprise support, managed deployments, commercial connectors, or other
 services offered by the project maintainers may use separate terms.
+
+See [ACCEPTABLE_USE.md](ACCEPTABLE_USE.md) for acceptable use of official hosted,
+managed, or maintainer-operated services.
+
+## Upstream provider integrations
+
+Official Kungfu integrations should use documented provider APIs, CLIs,
+telemetry, or other public integration surfaces, and should not bypass provider
+billing, quota, approval, safety, credential, or rate-limit systems.
+
+See [PROVIDER_COMPLIANCE.md](PROVIDER_COMPLIANCE.md) for the official provider
+integration posture.
 
 ## Third-party software
 

--- a/PROVIDER_COMPLIANCE.md
+++ b/PROVIDER_COMPLIANCE.md
@@ -1,0 +1,86 @@
+# Provider Compliance Policy
+
+Kungfu integrates with developer tools, agent runtimes, model providers, local
+CLIs, package registries, release platforms, and cloud services. This policy
+records the official integration posture.
+
+The official project should make user work more observable and auditable. It
+should not become a tool for bypassing upstream provider rules.
+
+## Official Integration Posture
+
+Official Kungfu integrations should use provider-supported or public surfaces,
+such as:
+
+- documented APIs and SDKs;
+- documented CLI commands and structured output modes;
+- OpenTelemetry or other documented telemetry exports;
+- user-approved local process execution;
+- GitHub Actions, package registries, and cloud APIs used according to their
+  documented permission model;
+- explicit user-provided credentials or environment configuration.
+
+Official integrations should preserve the user's ability to understand:
+
+- which provider or tool was used;
+- which account, project, repository, or credential boundary was involved;
+- what action was taken;
+- what usage, cost, artifact, approval, or evidence was recorded;
+- how confident Kungfu is about attribution.
+
+## Prohibited Official Integration Patterns
+
+Official Kungfu code and services must not intentionally:
+
+- scrape private web application state when a documented API, CLI, telemetry, or
+  export surface is the appropriate integration path;
+- read browser cookies, private session databases, provider auth files, billing
+  pages, or hidden local session stores to obtain usage or account data;
+- share hidden provider accounts, rotate pooled credentials, or proxy user work
+  through maintainer-owned accounts without clear terms and user consent;
+- bypass or weaken provider billing, quota, rate-limit, approval, or safety
+  systems;
+- mislabel account-level or window-level usage as exact run-level cost;
+- hide provider identity, model identity, execution surface, or credential
+  boundary from the user;
+- encourage users to violate upstream provider terms.
+
+## User-Owned Credentials
+
+Kungfu may run local tools or provider CLIs under credentials already configured
+by the user. The official project should treat those credentials as user-owned
+and should not copy, print, upload, sell, or repurpose them.
+
+Credential handling should prefer:
+
+- process-level use of the user's existing CLI login;
+- documented environment variables or provider config files when the provider
+  supports them;
+- least-privilege tokens for hosted or team services;
+- explicit user consent when a service needs to store or transmit a credential.
+
+## Cost And Usage Attribution
+
+Cost and usage facts must be labeled by confidence. Exact per-run structured
+events are different from session deltas, account snapshots, or manual
+estimates.
+
+When concurrent sessions or external tools make attribution ambiguous, Kungfu
+should say so instead of splitting cost by guesswork.
+
+## Provider Requests
+
+If an upstream provider reports that an official Kungfu integration creates
+abuse, security, compliance, or infrastructure risk, maintainers should:
+
+1. identify whether the behavior is official code, official service behavior, a
+   third-party fork, or user configuration;
+2. preserve enough evidence to understand the affected integration path without
+   exposing user secrets;
+3. disable, limit, or patch official behavior when needed;
+4. clarify public documentation when the boundary was ambiguous.
+
+This policy does not make the official project responsible for every third-party
+fork or downstream use. It defines the posture of the official project and the
+services maintained by its maintainers.
+

--- a/README.md
+++ b/README.md
@@ -104,6 +104,13 @@ right document, and is readable by both people and agents.
 - [`CONTRIBUTING.md`](CONTRIBUTING.md) — toolchain, build, conventions, releases.
 - [`LICENSE-POLICY.md`](LICENSE-POLICY.md) — project licensing, DCO-based
   contributions, third-party notice policy, and commercial boundary.
+- [`TRADEMARK.md`](TRADEMARK.md) — official project mark and fork identity
+  boundary.
+- [`ACCEPTABLE_USE.md`](ACCEPTABLE_USE.md) — acceptable use of official hosted,
+  managed, and maintainer-operated services.
+- [`PROVIDER_COMPLIANCE.md`](PROVIDER_COMPLIANCE.md) — official posture for
+  provider APIs, CLIs, credentials, usage attribution, and anti-bypass
+  boundaries.
 - [`SECURITY.md`](SECURITY.md) — how to report vulnerabilities privately.
 - [`docs/version-release-design.md`](docs/version-release-design.md) — versioning
   and release mechanism rationale.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -31,6 +31,12 @@ Security reports may cover:
 - dependency or build-chain vulnerabilities;
 - credential, token, or private data exposure.
 
+Service-abuse, provider-compliance, credential-handling, or misleading official
+identity reports may also be security-sensitive. Use private vulnerability
+reporting when public disclosure would expose credentials, provider account
+details, user data, or an exploitable bypass. See `ACCEPTABLE_USE.md`,
+`PROVIDER_COMPLIANCE.md`, and `TRADEMARK.md` for the related policy boundaries.
+
 ## Public disclosure
 
 Please allow maintainers time to investigate and prepare a fix before public

--- a/TRADEMARK.md
+++ b/TRADEMARK.md
@@ -1,0 +1,82 @@
+# Trademark Policy
+
+This policy explains how the official Kungfu project names and marks may be
+used. It is about project identity, not the copyright license for this
+repository.
+
+## Project Marks
+
+Kungfu project marks include names, logos, domain names, release names, product
+names, package names, and other identifiers associated with the official
+project, including:
+
+- Kungfu
+- Kungfu Tracer
+- Kungfu Rewind
+- Kungfu Origin
+- kungfu.tech
+- package or product names that use the Kungfu brand
+
+The Apache-2.0 license for this repository grants copyright and patent
+permissions. It does not grant trademark rights or permission to imply that an
+unofficial product, fork, service, release, package, or organization is the
+official Kungfu project.
+
+## Allowed Uses
+
+You may use the Kungfu name to make truthful, non-confusing references, such as:
+
+- describing that your software is built with Kungfu;
+- linking to the official Kungfu repository or website;
+- discussing Kungfu in documentation, issues, articles, benchmarks, or talks;
+- identifying an unmodified official release by its original name.
+
+Use the marks in a way that makes clear who is responsible for your software,
+service, or content.
+
+## Uses That Need Permission
+
+Please get written permission before using Kungfu marks in ways that may imply
+official status, sponsorship, endorsement, or control, including:
+
+- naming a fork, hosted service, commercial product, package, app, or extension
+  as if it were the official Kungfu project;
+- using Kungfu logos or visual identity as the primary branding for an
+  unofficial product or service;
+- registering domains, social accounts, app names, package names, or
+  organization names that are confusingly similar to official Kungfu marks;
+- distributing modified builds in a way that makes them look like official
+  builds.
+
+## Forks And Modified Builds
+
+Forks and modified builds should use names that are clearly distinct from the
+official project. A reasonable pattern is:
+
+```text
+<Your Product>, powered by Kungfu
+<Your Fork>, based on Kungfu
+```
+
+Do not use a name, logo, release channel, package namespace, signing identity,
+or download page that makes users believe your fork is produced or endorsed by
+the official Kungfu maintainers.
+
+## Official Channels
+
+Official channels may include:
+
+- the `kungfu-systems` GitHub organization;
+- official package scopes and registries used by the maintainers;
+- official release pages and signed artifacts;
+- official project domains such as `kungfu.tech`.
+
+If a channel is not controlled by the official maintainers, it should not claim
+or imply that it is official.
+
+## Reporting Confusing Use
+
+If you see confusing or misleading use of Kungfu marks, open an issue or contact
+the maintainers through the official project channels. Security-sensitive cases
+should use the private vulnerability reporting path in `SECURITY.md`.
+

--- a/docs/MAP.md
+++ b/docs/MAP.md
@@ -40,6 +40,7 @@ and the map routes a question to whichever doc answers it.
 | If kungfu itself misbehaves, how do I localize it? | [`debugging.md`](debugging.md) | verify | stable |
 | How do I record an agent run and find why it failed (Rewind)? | [`rewind.md`](rewind.md) | use | stable · pre-release install path |
 | How do I write an extension (`kfx`)? | [`extensions.md`](extensions.md) | use | stable · view kfx; runtime facets mid-migration |
+| What license, trademark, service-use, and provider-compliance boundaries apply? | [`../LICENSE-POLICY.md`](../LICENSE-POLICY.md) + [`../TRADEMARK.md`](../TRADEMARK.md) + [`../ACCEPTABLE_USE.md`](../ACCEPTABLE_USE.md) + [`../PROVIDER_COMPLIANCE.md`](../PROVIDER_COMPLIANCE.md) | use | stable |
 
 ## Also asking about
 
@@ -65,6 +66,10 @@ route to the row that answers them:
   ([`adapters.md`](adapters.md)).
 - **signature / checksum / supply chain / SBOM** → *verify a release binary*
   (`provenance.md`, `blocked` — see [`known-limits.md`](known-limits.md)).
+- **trademark / fork / hosted service / provider compliance / cost attribution
+  boundary** → [`../TRADEMARK.md`](../TRADEMARK.md),
+  [`../ACCEPTABLE_USE.md`](../ACCEPTABLE_USE.md), and
+  [`../PROVIDER_COMPLIANCE.md`](../PROVIDER_COMPLIANCE.md).
 
 ## How this map is maintained
 


### PR DESCRIPTION
Merge docs/open-source-provider-governance into dev/v4/v4.0 (kungfu-systems zone dual-account PR flow).