### PR TITLE
feat(kfx): disclose the trust verdict at install time (ADR-0013 Phase 4)

### DIFF
--- a/framework/core/src/python/kungfu/console/commands/kfx.py
+++ b/framework/core/src/python/kungfu/console/commands/kfx.py
@@ -17,6 +17,7 @@ import sys
 import tarfile
 
 from kungfu.console.commands import kfc, PrioritizedCommandGroup
+from kungfu.rewind import first_party
 
 kfx_command_context = kfc.pass_context()
 
@@ -55,6 +56,36 @@ def _kind(manifest):
         return "suite"
     facets = sorted((config.get("config") or {}).keys())
     return "+".join(facets) if facets else "unknown"
+
+
+def _trusted(manifest):
+    return first_party.is_first_party((manifest.get("kungfuConfig") or {}).get("key"))
+
+
+def _trust_notice(manifest):
+    """The install-time trust disclosure (ADR-0013): what tier each declared facet
+    runs at, decided by whether the package is in the frozen first-party set —
+    by verifiable source, never by the install path. Returns display lines."""
+    config = (manifest.get("kungfuConfig") or {}).get("config") or {}
+    trusted = _trusted(manifest)
+    origin = "first-party (trusted)" if trusted else "third-party (untrusted)"
+    lines = [f"[kfx] trust: {origin} — granted by source, not by install path"]
+    if "view" in config:
+        tier = (
+            "node-integrated (shares the shell, full access)"
+            if trusted
+            else "sandboxed-ipc (isolated renderer, only its declared capabilities)"
+        )
+        lines.append(f"[kfx]   view runs {tier}")
+    if "adapter" in config and not trusted:
+        lines.append(
+            "[kfx]   adapter will be REFUSED at trace time: an adapter runs "
+            "in-process in the traced program and cannot be sandboxed, so only a "
+            "source-verified first-party adapter may inject"
+        )
+    elif "adapter" in config:
+        lines.append("[kfx]   adapter may inject into traced runs (in-process)")
+    return lines
 
 
 @kfx.command(help="install a kfx package (npm pack tgz, or a package directory)")
@@ -107,6 +138,8 @@ def install(ctx, source, force):
         f"[kfx] installed {manifest.get('name', key)}@{manifest.get('version', '?')} "
         f"({_kind(manifest)}) -> {dest}"
     )
+    for line in _trust_notice(manifest):
+        click.echo(line)
 
 
 @kfx.command(name="list", help="list kfx installed for this home")
@@ -133,6 +166,7 @@ def list_installed(ctx, as_json):
                     "package": manifest.get("name"),
                     "version": manifest.get("version"),
                     "kind": _kind(manifest),
+                    "trusted": _trusted(manifest),
                     "path": package_dir,
                 }
             )
@@ -146,8 +180,10 @@ def list_installed(ctx, as_json):
         if "error" in row:
             click.echo(f"{row['key']}  !{row['error']}")
         else:
+            trust = "first-party" if row["trusted"] else "third-party"
             click.echo(
-                f"{row['key']}  {row['package']}@{row['version']}  ({row['kind']})"
+                f"{row['key']}  {row['package']}@{row['version']}  "
+                f"({row['kind']}, {trust})"
             )
 
 

--- a/framework/core/src/python/kungfu/rewind/first_party.py
+++ b/framework/core/src/python/kungfu/rewind/first_party.py
@@ -72,3 +72,9 @@ def first_party_keys():
     if keys is not None:
         return keys
     return _scan_keys(_source_extensions_root())
+
+
+def is_first_party(key):
+    """Whether an extension key is in the frozen first-party set (ADR-0013).
+    Trust follows from the source, not from where the package is installed."""
+    return key is not None and key in first_party_keys()

--- a/framework/core/tests/python/test_kfx_trust_notice.py
+++ b/framework/core/tests/python/test_kfx_trust_notice.py
@@ -1,0 +1,46 @@
+#  SPDX-License-Identifier: Apache-2.0
+#
+# `kungfu kfx install` / `list` disclose the trust verdict (ADR-0013): a package
+# is first-party (trusted) or third-party (untrusted) by source, and each facet's
+# consequence — a sandboxed view, or a refused adapter — is stated at install
+# time so the trust grant is informed.
+
+import json
+
+from kungfu.console.commands import kfx
+
+
+def _manifest(key, facet):
+    return {"kungfuConfig": {"key": key, "config": {facet: {}}}}
+
+
+def _write_manifest(path, keys):
+    with open(path, "w") as f:
+        json.dump({"version": 1, "keys": {k: {"sha256": None} for k in keys}}, f)
+
+
+def _notice(tmp_path, monkeypatch, key, facet, trusted_keys):
+    manifest_path = tmp_path / "first-party.json"
+    _write_manifest(str(manifest_path), trusted_keys)
+    monkeypatch.setenv("KF_FIRST_PARTY_MANIFEST", str(manifest_path))
+    return "\n".join(kfx._trust_notice(_manifest(key, facet)))
+
+
+def test_trusted_view_is_node_integrated(tmp_path, monkeypatch):
+    out = _notice(tmp_path, monkeypatch, "v", "view", ["v"])
+    assert "first-party" in out and "node-integrated" in out
+
+
+def test_untrusted_view_is_sandboxed(tmp_path, monkeypatch):
+    out = _notice(tmp_path, monkeypatch, "evil", "view", [])
+    assert "third-party" in out and "sandboxed-ipc" in out
+
+
+def test_untrusted_adapter_is_refused(tmp_path, monkeypatch):
+    out = _notice(tmp_path, monkeypatch, "evil", "adapter", [])
+    assert "third-party" in out and "REFUSED" in out
+
+
+def test_trusted_adapter_may_inject(tmp_path, monkeypatch):
+    out = _notice(tmp_path, monkeypatch, "a", "adapter", ["a"])
+    assert "first-party" in out and "may inject" in out


### PR DESCRIPTION
`kungfu kfx install` extracted a package with no word about the trust it would run at — the install-time trust prompt ADR-0013 and `docs/extensions.md` called for. This discloses it, so the trust grant is informed.

- A package is **first-party (trusted)** or **third-party (untrusted)** by source, never by the install path.
- Each declared facet's consequence is stated at install:
  - a **view** runs `node-integrated` (trusted) or `sandboxed-ipc` (untrusted, isolated + declared capabilities only);
  - an **untrusted adapter will be REFUSED** at trace time — it runs in-process in the traced program and cannot be sandboxed, so only a source-verified first-party adapter may inject.
- `kfx list` gains the same first-party/third-party marker (and a `trusted` field in `--json`).

`first_party.is_first_party(key)` is the shared membership check; `test_kfx_trust_notice` covers trusted/untrusted × view/adapter. Reuses the frozen first-party set from #206.

Completes the ADR-0013 implementation surface (Phases 0-4): trust by verifiable origin, refuse untrusted in-process adapters, sandboxed transport, OS isolation, and now the install-time consent surface. Remaining follow-ups: the Linux launcher and the packaged first-party-manifest bake.