### PR TITLE
docs(governance): add PR risk checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,6 +11,20 @@ Write the description in English. Sign commits with the DCO (git commit -s).
 
 ## Verification
 
+## Governance risk check
+
+Does this PR touch any of these boundaries?
+
+- [ ] credentials, tokens, secrets, or private logs
+- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
+- [ ] official hosted or managed services
+- [ ] official branding, package names, release identity, or domains
+- [ ] release evidence, provenance, package publishing, or deployment surfaces
+- [ ] none of the above
+
+If any item is checked, describe the boundary and the verification evidence in
+the summary or verification section.
+
 ## Checklist
 
 - [ ] Commits are signed off (DCO)


### PR DESCRIPTION
## Summary

Add a lightweight governance risk checklist to the pull request template.

## Verification

- git diff --check
- public leakage scan for Atlas/Codex/Claude/AI-maintenance/local paths

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [x] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

This PR only updates the PR template so future changes surface these boundaries explicitly.