### PR TITLE
feat(rewind): managed provider run emits a CostSnapshot event

### DIFF
--- a/framework/core/src/python/kungfu/rewind/managed_run.py
+++ b/framework/core/src/python/kungfu/rewind/managed_run.py
@@ -1,0 +1,149 @@
+#  SPDX-License-Identifier: Apache-2.0
+#
+# A managed provider run: the seam that turns the cost parse layer and the cost
+# wire event into one real act — launch a provider CLI in a structured-output
+# mode, capture its output, parse it into a CostSnapshot, and emit that fact as
+# a CostSnapshot journal event (msg_type 30008).
+#
+# Everything that touches the outside world is injected so the wiring is
+# testable without a real CLI or the native journal writer:
+#   - `runner`  launches the process and returns (exit_code, stdout, stderr).
+#               Production uses subprocess; tests pass canned provider output.
+#   - `emit`    takes (msg_type, event_bytes). Its signature is exactly
+#               Supervisor.enqueue, so a Kungfu-managed run wires the supervisor
+#               in with one argument; tests pass a list-collecting sink.
+#
+# Honesty: a cost event is emitted only when the provider actually reported
+# usage or a dollar cost. A crashed or silent run yields a result with the exit
+# code and reason but no fabricated exact-run-zero event. Because the supervisor
+# launched and parsed its own child here, the fact is Supervisor-layer
+# provenance, not a third-party Adapter.
+
+from __future__ import annotations
+
+import dataclasses
+import subprocess
+from typing import Callable, List, Optional
+
+from kungfu.rewind import cost_wire
+from kungfu.rewind.cost.claude import parse_claude_print_json
+from kungfu.rewind.cost.codex import parse_codex_exec_json_text
+from kungfu.rewind.cost.model import CostSnapshot
+from kungfu.rewind.fb.CaptureLayer import CaptureLayer
+
+# Provider -> how to invoke it for structured output and how to parse it back.
+# argv keeps the provider's own structured-output flags; the prompt is the last
+# positional. The two structured-output paths a managed run supports:
+#   codex exec --json <prompt>              -> turn.completed.usage (tokens only)
+#   claude --print --output-format json ... -> usage + total_cost_usd + session
+_SPECS = {
+    "codex": {
+        "surface": "exec_json",
+        "argv": lambda binary, prompt: [binary, "exec", "--json", prompt],
+        "parse": lambda text, **kw: parse_codex_exec_json_text(text, **kw),
+    },
+    "claude": {
+        "surface": "print_json",
+        "argv": lambda binary, prompt: [
+            binary,
+            "--print",
+            "--output-format",
+            "json",
+            prompt,
+        ],
+        "parse": lambda text, **kw: parse_claude_print_json(text, **kw),
+    },
+}
+
+
+@dataclasses.dataclass
+class ManagedRunResult:
+    """Outcome of one managed provider run.
+
+    `snapshot` is the parsed cost fact (None if parsing failed). `emitted` says
+    whether a CostSnapshot event was put on the sink — false when the run
+    reported no usage, so a consumer never mistakes silence for a zero-cost run.
+    """
+
+    provider: str
+    exit_code: int
+    snapshot: Optional[CostSnapshot]
+    emitted: bool
+    stdout: str
+    stderr: str
+    error: Optional[str] = None
+
+
+def _subprocess_runner(argv, env=None):
+    proc = subprocess.run(argv, capture_output=True, text=True, env=env)
+    return proc.returncode, proc.stdout, proc.stderr
+
+
+def _has_usage(snapshot: CostSnapshot) -> bool:
+    t = snapshot.tokens
+    return bool(
+        t.input_tokens
+        or t.output_tokens
+        or t.cached_input_tokens
+        or t.cache_creation_input_tokens
+        or t.reasoning_tokens
+        or snapshot.cost_usd is not None
+    )
+
+
+def run_managed(
+    provider: str,
+    binary: str,
+    prompt: str,
+    *,
+    emit: Callable[[int, bytes], None],
+    run_id: str,
+    work_id: Optional[str] = None,
+    usage_mode: str = "accumulate",
+    runner: Callable = _subprocess_runner,
+    env=None,
+) -> ManagedRunResult:
+    """Run a provider under Kungfu management and emit its cost fact.
+
+    Returns a ManagedRunResult; emits a CostSnapshot event through `emit` only
+    when the run reported real usage. `run_id` binds the fact back to the
+    supervisor's journal run; `work_id` links it to a work item when known.
+    """
+    spec = _SPECS.get(provider)
+    if spec is None:
+        raise ValueError(f"unknown managed provider: {provider!r}")
+
+    argv = spec["argv"](binary, prompt)
+    exit_code, stdout, stderr = runner(argv, env=env)
+
+    snapshot: Optional[CostSnapshot] = None
+    error: Optional[str] = None
+    parse_kwargs = {"run_id": run_id, "work_id": work_id}
+    if provider == "codex":
+        parse_kwargs["usage_mode"] = usage_mode
+    try:
+        snapshot = spec["parse"](stdout, **parse_kwargs)
+    except Exception as exc:  # a malformed provider payload must not crash the run
+        error = f"cost parse failed: {exc}"
+
+    emitted = False
+    if snapshot is not None and _has_usage(snapshot):
+        msg_type, payload = cost_wire.snapshot_to_event(
+            snapshot, layer=CaptureLayer.Supervisor
+        )
+        emit(msg_type, payload)
+        emitted = True
+
+    return ManagedRunResult(
+        provider=provider,
+        exit_code=exit_code,
+        snapshot=snapshot,
+        emitted=emitted,
+        stdout=stdout,
+        stderr=stderr,
+        error=error,
+    )
+
+
+def managed_providers() -> List[str]:
+    return sorted(_SPECS)

--- a/tests/fixtures/rewind-demo-managed-run/check_managed_run.py
+++ b/tests/fixtures/rewind-demo-managed-run/check_managed_run.py
@@ -1,0 +1,229 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Wiring assertions for a managed provider run. Proves the seam that joins the
+# cost parse layer and the cost wire event into one act: launch a provider,
+# parse its structured output into a CostSnapshot, and emit a CostSnapshot
+# journal event (msg_type 30008) bound to the run.
+#
+# It drives run_managed with an injected fake process runner and a
+# list-collecting emit sink, so nothing here spawns a real CLI or needs the
+# native journal writer. The emit sink's (msg_type, bytes) signature is exactly
+# Supervisor.enqueue, so this is the same seam production wires the supervisor
+# into. It asserts:
+#   1. codex exec --json is invoked and accumulated into an EXACT_RUN cost event
+#      with no fabricated dollar cost, at Supervisor-layer provenance;
+#   2. claude --print --output-format json carries total_cost_usd + session;
+#   3. a run that reported no usage emits nothing (silence is not zero cost);
+#   4. a malformed payload fails soft — no event, an error on the result;
+#   5. run_id / work_id bind the fact back to the run/work item.
+#
+# Needs flatbuffers (run under `uv run --frozen python`), not pykungfu: it stubs
+# only the top-level kungfu package, like the cost-wire fixture.
+#
+# Usage: check_managed_run.py <fixture-dir>
+
+import json
+import os
+import sys
+import types
+
+fixture_dir = (
+    sys.argv[1] if len(sys.argv) > 1 else os.path.dirname(os.path.abspath(__file__))
+)
+core_src = os.path.abspath(
+    os.path.join(fixture_dir, "..", "..", "..", "framework", "core", "src", "python")
+)
+sys.path.insert(0, core_src)
+
+if "kungfu" not in sys.modules:
+    _m = types.ModuleType("kungfu")
+    _m.__path__ = [os.path.join(core_src, "kungfu")]
+    _m.schema_data_path = lambda module_file, name: os.path.join(
+        os.path.dirname(module_file), name
+    )
+    sys.modules["kungfu"] = _m
+
+from kungfu.rewind import MSG_COST_SNAPSHOT, managed_run  # noqa: E402
+from kungfu.rewind.fb.Attribution import Attribution as FbAttribution  # noqa: E402
+from kungfu.rewind.fb.CaptureLayer import CaptureLayer as FbCaptureLayer  # noqa: E402
+from kungfu.rewind.fb.CostSnapshot import CostSnapshot as FbCostSnapshot  # noqa: E402
+
+failures = []
+
+
+def check(name, ok, detail=""):
+    if not ok:
+        failures.append(name + (f" ({detail})" if detail else ""))
+
+
+def fake_runner(exit_code, stdout, stderr=""):
+    """A process runner that records its argv and returns canned output."""
+    seen = {}
+
+    def run(argv, env=None):
+        seen["argv"] = argv
+        seen["env"] = env
+        return exit_code, stdout, stderr
+
+    return run, seen
+
+
+def sink():
+    events = []
+
+    def emit(msg_type, data):
+        events.append((msg_type, bytes(data)))
+
+    return emit, events
+
+
+def decode(events):
+    assert len(events) == 1, f"expected 1 event, got {len(events)}"
+    msg_type, payload = events[0]
+    assert msg_type == MSG_COST_SNAPSHOT
+    return FbCostSnapshot.GetRootAs(payload, 0)
+
+
+# --- provider registry ------------------------------------------------------
+check(
+    "managed providers are codex + claude",
+    managed_run.managed_providers() == ["claude", "codex"],
+)
+
+# --- codex: two turns accumulate into one EXACT_RUN, tokens-only ------------
+codex_jsonl = "\n".join(
+    [
+        json.dumps(
+            {
+                "type": "turn.completed",
+                "model": "gpt-5-codex",
+                "usage": {
+                    "input_tokens": 1000,
+                    "cached_input_tokens": 200,
+                    "output_tokens": 300,
+                    "reasoning_output_tokens": 50,
+                },
+            }
+        ),
+        json.dumps(
+            {
+                "type": "turn.completed",
+                "usage": {
+                    "input_tokens": 500,
+                    "cached_input_tokens": 100,
+                    "output_tokens": 120,
+                    "reasoning_output_tokens": 30,
+                },
+            }
+        ),
+    ]
+)
+run, seen = fake_runner(0, codex_jsonl)
+emit, events = sink()
+result = managed_run.run_managed(
+    "codex",
+    "/opt/codex",
+    "summarize the diff",
+    emit=emit,
+    run_id="run-codex-1",
+    work_id="work-42",
+    runner=run,
+)
+check(
+    "codex argv is exec --json <prompt>",
+    seen["argv"] == ["/opt/codex", "exec", "--json", "summarize the diff"],
+    str(seen["argv"]),
+)
+check("codex run exit 0", result.exit_code == 0)
+check("codex run emitted", result.emitted is True)
+ev = decode(events)
+check(
+    "codex event input_tokens accumulated",
+    ev.InputTokens() == 1500,
+    str(ev.InputTokens()),
+)
+check("codex event cached accumulated", ev.CachedInputTokens() == 300)
+check("codex event output accumulated", ev.OutputTokens() == 420)
+check("codex event reasoning accumulated", ev.ReasoningTokens() == 80)
+check("codex event attribution ExactRun", ev.Attribution() == FbAttribution.ExactRun)
+check("codex managed layer is Supervisor", ev.Layer() == FbCaptureLayer.Supervisor)
+check("codex event run_id bound", ev.RunId() == b"run-codex-1")
+check("codex event work_id bound", ev.WorkId() == b"work-42")
+check("codex event model", ev.Model() == b"gpt-5-codex")
+check("codex cost stays unknown", not ev.CostUsdKnown())
+
+# --- claude: print json carries dollar cost + session ----------------------
+claude_json = json.dumps(
+    {
+        "session_id": "sess-77",
+        "total_cost_usd": 0.0231,
+        "usage": {
+            "input_tokens": 800,
+            "output_tokens": 500,
+            "cache_read_input_tokens": 128,
+            "cache_creation_input_tokens": 64,
+        },
+        "modelUsage": {"claude-sonnet-5": {"inputTokens": 800, "outputTokens": 500}},
+    }
+)
+run, seen = fake_runner(0, claude_json)
+emit, events = sink()
+result = managed_run.run_managed(
+    "claude", "/opt/claude", "review this", emit=emit, run_id="run-claude-1", runner=run
+)
+check(
+    "claude argv is --print --output-format json <prompt>",
+    seen["argv"]
+    == ["/opt/claude", "--print", "--output-format", "json", "review this"],
+    str(seen["argv"]),
+)
+check("claude run emitted", result.emitted is True)
+ev = decode(events)
+check("claude cost known", bool(ev.CostUsdKnown()))
+check("claude cost value", abs(ev.CostUsd() - 0.0231) < 1e-9, str(ev.CostUsd()))
+check("claude session_id", ev.SessionId() == b"sess-77")
+check("claude cache_read -> cached", ev.CachedInputTokens() == 128)
+check("claude cache_creation carried", ev.CacheCreationInputTokens() == 64)
+check("claude managed layer is Supervisor", ev.Layer() == FbCaptureLayer.Supervisor)
+
+# --- no usage reported: silence must not become a zero-cost event ----------
+run, _ = fake_runner(0, "hello, no json here\n")
+emit, events = sink()
+result = managed_run.run_managed(
+    "codex", "/opt/codex", "noop", emit=emit, run_id="run-empty", runner=run
+)
+check("no-usage run does not emit", result.emitted is False)
+check("no-usage sink stays empty", events == [])
+check("no-usage still returns a snapshot", result.snapshot is not None)
+
+# --- malformed payload fails soft: no event, error recorded ----------------
+run, _ = fake_runner(1, "not json {", "boom")
+emit, events = sink()
+result = managed_run.run_managed(
+    "claude", "/opt/claude", "bad", emit=emit, run_id="run-bad", runner=run
+)
+check("malformed run does not emit", result.emitted is False)
+check(
+    "malformed run records error",
+    result.error is not None and "parse failed" in result.error,
+)
+check("malformed run keeps exit code", result.exit_code == 1)
+
+# --- unknown provider is a hard error --------------------------------------
+try:
+    managed_run.run_managed(
+        "gemini",
+        "/opt/gemini",
+        "x",
+        emit=lambda *a: None,
+        run_id="r",
+        runner=fake_runner(0, "")[0],
+    )
+    check("unknown provider raises", False, "no error")
+except ValueError:
+    check("unknown provider raises", True)
+
+if failures:
+    print(f"managed run check failed: {failures}")
+    sys.exit(1)
+print("managed run check passed")

--- a/tests/fixtures/rewind-demo-managed-run/run.sh
+++ b/tests/fixtures/rewind-demo-managed-run/run.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# SPDX-License-Identifier: Apache-2.0
+#
+# Managed-run fixture. Proves the seam that joins the cost parse layer and the
+# cost wire event into one managed act: launch a provider, parse its
+# structured output, and emit a CostSnapshot journal event bound to the run.
+# Drives run_managed with an injected fake process runner and a list-collecting
+# emit sink (the same (msg_type, bytes) signature the supervisor exposes), so it
+# spawns no real CLI and needs no native journal writer.
+#
+# Runs under `uv run --frozen python` for flatbuffers; stubs the top-level
+# kungfu package so the native binding import is skipped.
+#
+# Usage: tests/fixtures/rewind-demo-managed-run/run.sh
+set -eu
+fixture_dir="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+core_dir="$(CDPATH= cd -- "$fixture_dir/../../../framework/core" && pwd)"
+
+cd "$core_dir"
+uv run --frozen python "$fixture_dir/check_managed_run.py" "$fixture_dir"


### PR DESCRIPTION
run_managed launches codex/claude in structured-output mode, parses usage via the cost adapters, and emits a CostSnapshot journal event (msg_type 30008) bound to the run. Process runner + emit sink injected; fixture rewind-demo-managed-run proves the wiring flatbuffers-only.