### PR TITLE
feat(capability): Linux OS sandbox launcher via bubblewrap (ADR-0013)

### DIFF
--- a/framework/api/src/capability/sandbox-launcher.ts
+++ b/framework/api/src/capability/sandbox-launcher.ts
@@ -6,9 +6,13 @@
 // risk, not an absolute guarantee.
 //
 // macOS confines the child with a Seatbelt profile via `sandbox-exec`. Linux
-// (Landlock + seccomp-BPF + user/pid/net namespaces) is not implemented yet and
-// is refused rather than run unconfined: a sandbox that silently does nothing is
-// worse than an explicit, visible gap.
+// confines it with bubblewrap (`bwrap`): a read-only root, unshared network, and
+// its own user/pid/mount namespaces — the practical, unprivileged sandbox on
+// current distributions, where raw namespaces are blocked (e.g. Ubuntu's
+// AppArmor unprivileged-userns restriction) but bwrap is permitted. If bwrap is
+// absent the launch is refused rather than run unconfined: a sandbox that
+// silently does nothing is worse than an explicit, visible gap.
+import { existsSync } from 'node:fs';
 import { platform } from 'node:os';
 
 // Deny by default; allow exec/fork and reads (the interpreter needs its runtime)
@@ -29,10 +33,39 @@ const MACOS_SEATBELT_PROFILE = [
   '(deny network*)',
 ].join('');
 
+// bubblewrap: a read-only view of the whole filesystem (reads work, every write
+// is denied), no network (--unshare-all includes the network namespace), its own
+// user/pid/mount namespaces, and death with the parent. Inherited stdio is
+// untouched, so the capability relay still flows.
+const LINUX_BWRAP_ARGS = [
+  '--unshare-all',
+  '--ro-bind',
+  '/',
+  '/',
+  '--proc',
+  '/proc',
+  '--dev',
+  '/dev',
+  '--die-with-parent',
+];
+
+const BWRAP_PATHS = ['/usr/bin/bwrap', '/bin/bwrap', '/usr/local/bin/bwrap'];
+
+function hasBwrap(): boolean {
+  return BWRAP_PATHS.some((p) => existsSync(p));
+}
+
 export type SandboxedCommand = { command: string; args: string[] };
 
 export function isOsSandboxSupported(): boolean {
-  return platform() === 'darwin';
+  switch (platform()) {
+    case 'darwin':
+      return true;
+    case 'linux':
+      return hasBwrap();
+    default:
+      return false;
+  }
 }
 
 // Wrap a command so it runs inside the OS default-deny sandbox. Throws on a
@@ -49,10 +82,16 @@ export function osSandboxCommand(
         args: ['-p', MACOS_SEATBELT_PROFILE, command, ...args],
       };
     case 'linux':
-      throw new Error(
-        'os sandbox not implemented on linux yet (Landlock + seccomp + namespaces); ' +
-          'refusing to launch an untrusted guest unconfined',
-      );
+      if (!hasBwrap()) {
+        throw new Error(
+          'os sandbox on linux requires bubblewrap (bwrap); ' +
+            'refusing to launch an untrusted guest unconfined',
+        );
+      }
+      return {
+        command: 'bwrap',
+        args: [...LINUX_BWRAP_ARGS, command, ...args],
+      };
     default:
       throw new Error(
         `os sandbox not available on ${platform()}; ` +

--- a/tests/fixtures/kfx-demo-sandbox-launch/child.py
+++ b/tests/fixtures/kfx-demo-sandbox-launch/child.py
@@ -35,23 +35,23 @@ caps = _guest.connect(["rewind"])
 # 1. the capability relay is reachable through the sandbox — the only egress
 ck("capability relay works inside sandbox", caps["rewind"].runs() == ["run-A", "run-B"])
 
-# 2. a filesystem write is denied by the sandbox (EPERM -> PermissionError)
+# 2. a filesystem write is denied by the sandbox — EPERM on macOS Seatbelt,
+#    EROFS on the Linux bwrap read-only root; both surface as OSError.
 try:
     with open("/tmp/kfx_sandbox_leak", "w") as f:
         f.write("x")
     ck("filesystem write denied", False)
-except PermissionError:
+except OSError:
     ck("filesystem write denied", True)
 
-# 3. the network is denied by the sandbox (the connect is refused, not merely
-#    unreachable — so this holds offline too)
+# 3. the network is denied by the sandbox — the connect is refused (EPERM) or
+#    has no route out (unshared, empty network namespace), never a real timeout,
+#    so this holds offline too.
 try:
     socket.create_connection(("1.1.1.1", 80), timeout=3)
     ck("network denied", False)
-except PermissionError:
+except OSError:
     ck("network denied", True)
-except OSError as e:
-    ck("network denied", isinstance(e, PermissionError))
 
 sys.stderr.write(
     "sandbox launch check " + (f"failed {fails}" if fails else "passed") + "\n"

--- a/tests/fixtures/kfx-demo-sandbox-launch/parent.mjs
+++ b/tests/fixtures/kfx-demo-sandbox-launch/parent.mjs
@@ -7,8 +7,16 @@
 import { execSync, spawn } from 'node:child_process';
 
 import { createCapabilityHost } from '../../../framework/api/src/capability/sandbox.ts';
-import { osSandboxCommand } from '../../../framework/api/src/capability/sandbox-launcher.ts';
+import {
+  isOsSandboxSupported,
+  osSandboxCommand,
+} from '../../../framework/api/src/capability/sandbox-launcher.ts';
 import { serveSubprocessCapabilities } from '../../../framework/api/src/capability/subprocess.ts';
+
+if (!isOsSandboxSupported()) {
+  console.error('skipped: no os sandbox on this platform (macOS Seatbelt / Linux bwrap)');
+  process.exit(0);
+}
 
 const python = execSync('command -v python3').toString().trim();
 const childScript = new URL('./child.py', import.meta.url).pathname;

--- a/tests/fixtures/kfx-demo-sandbox-launch/run.sh
+++ b/tests/fixtures/kfx-demo-sandbox-launch/run.sh
@@ -2,13 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # Gate: the default-tier OS sandbox (ADR-0013). A guest launched under the OS
 # sandbox relays capabilities over its stdio but cannot touch the filesystem or
-# the network. macOS only (Seatbelt via sandbox-exec); the Linux launcher
-# (Landlock + seccomp + namespaces) is not implemented yet, so this gate skips
-# there rather than pass vacuously. Requires node >= 22 and python3.
+# the network. macOS uses Seatbelt (sandbox-exec); Linux uses bubblewrap (bwrap).
+# On a platform with no sandbox (or Linux without bwrap) parent.mjs skips rather
+# than pass vacuously. Requires node >= 22 and python3.
 set -eu
 fixture_dir="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
-if [ "$(uname)" != "Darwin" ]; then
-  echo "skipped: os sandbox gate runs on darwin only (linux launcher not implemented)"
-  exit 0
-fi
 node --experimental-transform-types "$fixture_dir/parent.mjs"


### PR DESCRIPTION
Implements the default-tier OS sandbox on **Linux**, so the isolation base is no longer macOS-only (Phase 3 shipped Seatbelt; Linux was explicitly refused).

- `sandbox-launcher.ts` — on Linux, wrap the guest in **bubblewrap** (`bwrap --unshare-all --ro-bind / / --proc /proc --dev /dev --die-with-parent`): a read-only root (every write denied), an unshared empty network namespace (no network), its own user/pid/mount namespaces, dies with the parent. Inherited stdio is untouched, so the capability relay still flows. This is the practical unprivileged sandbox where raw namespaces are blocked (Ubuntu's AppArmor unprivileged-userns restriction) but bwrap is permitted; **if bwrap is absent the launch is refused, never run unconfined**.
- `isOsSandboxSupported()` now reports Linux support by bwrap presence; the `kfx-demo-sandbox-launch` fixture runs on Linux too (skip logic moved into `parent.mjs`), and its denial assertions accept `OSError` (EPERM on Seatbelt, EROFS / no-route on bwrap).

**Validated on real hardware (both platforms):**
- macOS arm64: relay works, `/tmp` write → PermissionError, socket → PermissionError.
- Linux (Ubuntu 24.04, kernel 6.8, bwrap): relay works through the sandbox, `/tmp` write denied, network denied, no leak file — the fixture's 3 assertions pass end-to-end.

Follow-up remaining: the packaged first-party-manifest bake. Landlock (available on the kernel) could later add finer-grained read confinement; bwrap's read-only root is the coarse boundary the ADR records as residual risk.