### PR TITLE
feat(first-party): bake the frozen manifest for packaged/frozen builds (ADR-0013)

### DIFF
--- a/framework/core/src/python/kungfu/rewind/first_party.py
+++ b/framework/core/src/python/kungfu/rewind/first_party.py
@@ -15,12 +15,13 @@
 
 import json
 import os
+import sys
 
 ENV_FIRST_PARTY_MANIFEST = "KF_FIRST_PARTY_MANIFEST"
+BAKED_MANIFEST_NAME = "first-party.json"
 
 
-def _manifest_keys():
-    path = os.environ.get(ENV_FIRST_PARTY_MANIFEST)
+def _read_keys(path):
     if not path or not os.path.isfile(path):
         return None
     try:
@@ -30,6 +31,15 @@ def _manifest_keys():
         return None
     keys = data.get("keys")
     return set(keys) if isinstance(keys, dict) else None
+
+
+def _baked_manifest_path():
+    # A frozen build ships the manifest next to the executable (in dist/kungfu,
+    # which the app also ships to Resources/kungfu); a source interpreter has no
+    # such neighbour, so this is None-ish there and the source scan takes over.
+    return os.path.join(
+        os.path.dirname(os.path.abspath(sys.executable)), BAKED_MANIFEST_NAME
+    )
 
 
 def _source_extensions_root():
@@ -67,8 +77,14 @@ def _scan_keys(root):
 
 
 def first_party_keys():
-    """The set of extension keys the supervisor may trust to inject an adapter."""
-    keys = _manifest_keys()
+    """The set of extension keys the supervisor may trust to inject an adapter.
+    Resolved in order: the explicit KF_FIRST_PARTY_MANIFEST, then the manifest a
+    frozen build bakes next to the executable, then a source-checkout scan of the
+    product's own extensions/ tree."""
+    keys = _read_keys(os.environ.get(ENV_FIRST_PARTY_MANIFEST))
+    if keys is not None:
+        return keys
+    keys = _read_keys(_baked_manifest_path())
     if keys is not None:
         return keys
     return _scan_keys(_source_extensions_root())

--- a/framework/core/tests/python/test_first_party_baked.py
+++ b/framework/core/tests/python/test_first_party_baked.py
@@ -1,0 +1,37 @@
+#  SPDX-License-Identifier: Apache-2.0
+#
+# A frozen build has no source extensions/ tree; it reads the first-party set
+# from the manifest baked next to its executable (ADR-0013). Resolution order:
+# KF_FIRST_PARTY_MANIFEST, then the baked manifest, then a source scan.
+
+import json
+
+from kungfu.rewind import first_party
+
+
+def _write_manifest(path, keys):
+    path.write_text(
+        json.dumps({"version": 1, "keys": {k: {"sha256": "x"} for k in keys}})
+    )
+
+
+def test_reads_baked_manifest_next_to_executable(tmp_path, monkeypatch):
+    exe = tmp_path / "kungfu"
+    exe.write_text("")
+    _write_manifest(tmp_path / "first-party.json", ["work-dashboard", "rewind"])
+    monkeypatch.setattr("sys.executable", str(exe))
+    monkeypatch.delenv("KF_FIRST_PARTY_MANIFEST", raising=False)
+    assert first_party.first_party_keys() == {"work-dashboard", "rewind"}
+    assert first_party.is_first_party("work-dashboard")
+    assert not first_party.is_first_party("evil")
+
+
+def test_env_manifest_wins_over_baked(tmp_path, monkeypatch):
+    exe = tmp_path / "kungfu"
+    exe.write_text("")
+    _write_manifest(tmp_path / "first-party.json", ["baked-only"])
+    env_manifest = tmp_path / "env.json"
+    _write_manifest(env_manifest, ["env-only"])
+    monkeypatch.setattr("sys.executable", str(exe))
+    monkeypatch.setenv("KF_FIRST_PARTY_MANIFEST", str(env_manifest))
+    assert first_party.first_party_keys() == {"env-only"}

--- a/framework/gui/electron-builder.yml
+++ b/framework/gui/electron-builder.yml
@@ -4,6 +4,9 @@ productName: Kungfu
 # directly from Resources/kungfu at runtime.
 asar: false
 npmRebuild: false
+# Bake the frozen first-party manifest (ADR-0013) into dist/kungfu before it is
+# shipped to Resources/kungfu, so trust is granted by verifiable source.
+beforePack: ./scripts/before-pack.cjs
 files:
   - out/**/*
   - package.json

--- a/framework/gui/package.json
+++ b/framework/gui/package.json
@@ -19,6 +19,7 @@
     "ensure-electron": "node scripts/ensure-electron.mjs",
     "dev": "pnpm run ensure-electron && electron-vite dev",
     "build": "electron-vite build",
+    "gen:first-party-manifest": "node --experimental-transform-types scripts/gen-first-party-manifest.mjs",
     "start": "pnpm run ensure-electron && electron-vite preview",
     "pack": "pnpm --filter @kungfu-tech/tui run bundle && pnpm run ensure-electron && electron-vite build && electron-builder --dir --config.electronDist=$(node -p \"require('path').dirname(require.resolve('electron'))+'/dist'\")",
     "dist": "pnpm --filter @kungfu-tech/tui run bundle && pnpm run ensure-electron && electron-vite build && electron-builder --config.electronDist=$(node -p \"require('path').dirname(require.resolve('electron'))+'/dist'\")",

--- a/framework/gui/scripts/before-pack.cjs
+++ b/framework/gui/scripts/before-pack.cjs
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+// electron-builder beforePack hook: bake the frozen first-party manifest into
+// dist/kungfu just before it is shipped to Resources/kungfu, so the packaged
+// app grants extension trust by verifiable source (ADR-0013). Runs after the
+// build, so the extension view bundles are present to pin.
+const { spawnSync } = require('node:child_process');
+const path = require('node:path');
+
+exports.default = async function beforePack() {
+  const gen = path.join(__dirname, 'gen-first-party-manifest.mjs');
+  const result = spawnSync(
+    process.execPath,
+    ['--experimental-transform-types', gen],
+    { stdio: 'inherit' },
+  );
+  if (result.status !== 0) {
+    throw new Error('failed to bake the first-party manifest before pack');
+  }
+};

--- a/framework/gui/scripts/gen-first-party-manifest.mjs
+++ b/framework/gui/scripts/gen-first-party-manifest.mjs
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+// Bake the frozen first-party manifest (ADR-0013): scan the product's own
+// extensions/ tree, pin each built view bundle by content hash, and write
+// first-party.json into framework/core/dist/kungfu. That directory is the frozen
+// CLI's home (the supervisor reads the manifest next to its executable) and is
+// shipped to the app's Resources/kungfu (the packaged GUI reads it there) — so a
+// single baked manifest lets both grant trust by verifiable source without the
+// source extensions/ tree.
+//
+// Pinned: run AFTER the extension view bundles are built (`kfs kfx build`); a key
+// whose bundle is not built is omitted (stays untrusted) rather than trusted by
+// key alone. Run: node --experimental-transform-types gen-first-party-manifest.mjs
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { generateFirstPartyManifest } from '../src/main/first-party-manifest.ts';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const extensionsRoot = join(here, '..', '..', '..', 'extensions');
+const outPath = join(
+  here,
+  '..',
+  '..',
+  'core',
+  'dist',
+  'kungfu',
+  'first-party.json',
+);
+
+const manifest = generateFirstPartyManifest(extensionsRoot, { pin: true });
+mkdirSync(dirname(outPath), { recursive: true });
+writeFileSync(outPath, JSON.stringify(manifest), 'utf8');
+
+const n = Object.keys(manifest.keys).length;
+console.log(`[first-party] wrote ${n} pinned key(s) -> ${outPath}`);
+if (n === 0) {
+  console.warn(
+    '[first-party] no pinned keys — build the extension view bundles first ' +
+      '(`kfs kfx build`), or the frozen build will trust only system views',
+  );
+}

--- a/framework/gui/src/main/first-party-manifest.ts
+++ b/framework/gui/src/main/first-party-manifest.ts
@@ -60,14 +60,17 @@ export function generateFirstPartyManifest(
     const view = config?.config?.view;
     if (!config?.key || !view) continue; // only view facets carry a runtime tier
     if (config.key in keys) continue; // first occurrence wins, like the loader
-    let sha: string | null = null;
     if (opts.pin) {
+      // a pinned build records the bundle hash; a key whose bundle is not built
+      // cannot be pinned, so it is omitted (stays untrusted) rather than trusted
+      // by key alone — an unpinned entry in a shipped manifest would be forgeable.
       const bundlePath = join(dir, view.entry ?? 'dist/view/index.js');
-      sha = existsSync(bundlePath)
-        ? sha256(readFileSync(bundlePath, 'utf8'))
-        : null;
+      if (!existsSync(bundlePath)) continue;
+      keys[config.key] = { sha256: sha256(readFileSync(bundlePath, 'utf8')) };
+    } else {
+      // development: bundles are rebuilt constantly, so trust the key unpinned.
+      keys[config.key] = { sha256: null };
     }
-    keys[config.key] = { sha256: sha };
   }
   return { version: 1, keys };
 }

--- a/framework/gui/src/main/index.ts
+++ b/framework/gui/src/main/index.ts
@@ -73,12 +73,14 @@ process.env.KF_EXTENSION_PATH =
 //        (bundles change on every rebuild, so they are trusted by key, unpinned).
 //   packaged: point at a build-baked resource with pinned bundle hashes; if the
 //        bake step has not run the manifest is absent and only system views are
-//        trusted (safe by default). Shipping the pinned resource is the
-//        packaging follow-up, tracked with the built-in-extension shipping work.
+//        trusted (safe by default). The pinned resource is baked at build time
+//        by scripts/gen-first-party-manifest.mjs into dist/kungfu, which ships to
+//        Resources/kungfu alongside the runtime.
 if (!process.env.KF_FIRST_PARTY_MANIFEST) {
   if (app.isPackaged) {
     process.env.KF_FIRST_PARTY_MANIFEST = path.join(
       process.resourcesPath,
+      'kungfu',
       'first-party.json',
     );
   } else if (process.env.KF_RUNTIME_DIR) {


### PR DESCRIPTION
Closes the last ADR-0013 gap: a frozen CLI and a packaged app have no source `extensions/` tree, so the first-party set was empty and they trusted **only** system views (adapters all refused). Bake the manifest at build time and read it at runtime, so both grant trust by verifiable source.

- **generation** — `gen-first-party-manifest.mjs` + an electron-builder `beforePack` hook write `first-party.json` into `dist/kungfu` (which ships to `Resources/kungfu`). The **pinned** build records each built view bundle's content hash; a key whose bundle is not built is **omitted** (stays untrusted) rather than trusted by key alone — an unpinned entry in a shipped manifest would be forgeable.
- **frozen CLI read-path** — `first_party.py` resolves the set as `KF_FIRST_PARTY_MANIFEST`, then the manifest baked next to the executable, then a source scan (dev).
- **packaged GUI** — main points the packaged manifest at `Resources/kungfu/first-party.json`.

**Validated (units):** the generator pins built bundles and omits unbuilt ones; the beforePack hook bakes the manifest; the supervisor reads the baked manifest next to a (simulated) executable, with the env manifest taking precedence; TS typechecks, Python ruff-clean, pytest added. The full electron-builder package run is not exercised in CI here — the hook is proven in isolation.

This completes the ADR-0013 implementation surface end to end (design → decision C → Phases 0-4 → dual-platform OS isolation → packaged bake). Follow-up beyond trust: shipping built-in extensions to a read-only packaged location, and Landlock read-confinement on Linux.