### PR TITLE
fix(core): include <queue> in yijinjing journal.h

### DIFF
--- a/framework/core/src/libyijinjing/include/kungfu/yijinjing/journal/journal.h
+++ b/framework/core/src/libyijinjing/include/kungfu/yijinjing/journal/journal.h
@@ -11,6 +11,7 @@
 #include <kungfu/yijinjing/journal/page.h>
 #include <kungfu/yijinjing/time.h>
 #include <mutex>
+#include <queue>
 
 namespace kungfu::yijinjing::journal {
 


### PR DESCRIPTION
journal.h declares std::priority_queue has_data_journals_heap_ but only included <mutex>; it failed to compile on gcc/libstdc++ (priority_queue does not name a template type). Caught by a native core build on Linux. One-line include fix.