### PR TITLE
feat(gui): managed-run inbox in the terminal + kungfu managed-run command

### DIFF
--- a/extensions/terminal/src/view/index.tsx
+++ b/extensions/terminal/src/view/index.tsx
@@ -1,21 +1,21 @@
 // Managed terminal — a PTY-backed terminal hosted inside the Kungfu GUI, so a
-// user interacts with a managed agent process without leaving Kungfu. The view
-// is pure interaction UI: xterm.js for rendering and keyboard, and the declared
-// `terminal` capability for the process. It never touches node-pty directly —
-// the PTY host lives in the trusted renderer behind the capability boundary, so
-// this view runs identically whether it is loaded node-integrated or in a
-// locked sandbox reaching the capability over IPC.
+// user starts and interacts with a managed agent process without leaving Kungfu.
+// The view is pure interaction UI: xterm.js for rendering and keyboard, and the
+// declared `terminal` capability for the process. It never touches node-pty
+// directly — the PTY host lives in the trusted renderer behind the capability
+// boundary, so this view runs identically whether it is loaded node-integrated
+// or in a locked sandbox reaching the capability over IPC.
 //
 // The capability is async at the sandbox boundary (an IPC hop cannot be
 // synchronous); `resolve` awaits both the sync (node-integrated) and Promise
-// (sandboxed-ipc) shapes so one code path serves both tiers. A sandboxed
-// subscription has no local stop(); it is released when the view unmounts and
-// the shell disposes the capability host — so cleanup calls stop() when present
-// and relies on host disposal otherwise.
+// (sandboxed-ipc) shapes so one code path serves both tiers.
 //
-// MVP scope: this auto-starts one login shell to prove the PTY + xterm + run
-// binding end to end. Choosing the provider (codex/claude) from a work/run
-// inbox is a later slice, not this one.
+// The view opens on an inbox of managed-run profiles. Picking one starts a
+// managed provider run in the terminal, which reports its cost. The command is
+// resolved from KUNGFU_MANAGED_RUN_CMD (a launcher on PATH in a packaged
+// runtime); a dev override lets a source checkout point at its built runtime.
+// Seeding the inbox in the view is MVP scope — importing real work/run cards
+// from the runtime is a later slice.
 import '@xterm/xterm/css/xterm.css';
 import type { KfxCapabilities, Shell } from '@kungfu-tech/kfx';
 import { mono, panelStyle } from '@kungfu-tech/kfx';
@@ -27,7 +27,160 @@ async function resolve<T>(value: T | Promise<T>): Promise<T> {
   return await value;
 }
 
-function TerminalView({ caps }: { caps: KfxCapabilities; shell: Shell }) {
+type Provider = 'claude' | 'codex';
+
+interface RunProfile {
+  id: string;
+  label: string;
+  provider: Provider;
+  prompt: string;
+}
+
+// MVP inbox: a few runnable managed-run profiles. A later slice imports real
+// work/go cards from the runtime instead of seeding them here.
+const INBOX: RunProfile[] = [
+  {
+    id: 'claude-hello',
+    label: 'Claude · greet from a managed run',
+    provider: 'claude',
+    prompt: 'In one short sentence, say hello from a Kungfu managed run.',
+  },
+  {
+    id: 'claude-summary',
+    label: 'Claude · one-line status',
+    provider: 'claude',
+    prompt: 'Reply with exactly one line: managed run OK.',
+  },
+  {
+    id: 'codex-check',
+    label: 'Codex · quick check',
+    provider: 'codex',
+    prompt: 'Reply with exactly: OK',
+  },
+];
+
+// How to launch a managed run: `kungfu managed-run --provider … --prompt …`.
+// The launcher is `kungfu` on PATH in a packaged runtime; KUNGFU_MANAGED_RUN_CMD
+// overrides it so a source checkout can point at its built runtime.
+function launchCommand(profile: RunProfile): {
+  command: string;
+  args: string[];
+} {
+  const env =
+    typeof process !== 'undefined'
+      ? process.env
+      : ({} as Record<string, string>);
+  const base = env.KUNGFU_MANAGED_RUN_CMD || 'kungfu';
+  return {
+    command: base,
+    args: [
+      'managed-run',
+      '--provider',
+      profile.provider,
+      '--prompt',
+      profile.prompt,
+    ],
+  };
+}
+
+function providerChipStyle(provider: Provider): React.CSSProperties {
+  const claude = provider === 'claude';
+  return {
+    ...mono,
+    fontSize: 10.5,
+    padding: '1px 7px',
+    borderRadius: 999,
+    color: claude ? '#c7a86a' : '#7fb4d8',
+    background: claude ? 'rgba(199,168,106,0.14)' : 'rgba(127,180,216,0.14)',
+  };
+}
+
+function Inbox({ onRun }: { onRun: (p: RunProfile) => void }) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        height: '100%',
+        gap: 10,
+      }}
+    >
+      <div style={{ ...mono, fontSize: 12, color: '#9cdcfe' }}>
+        Managed-run inbox · pick a run to start
+      </div>
+      <div
+        style={{
+          ...panelStyle,
+          flex: 1,
+          padding: 10,
+          overflow: 'auto',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 8,
+        }}
+      >
+        {INBOX.map((p) => (
+          <div
+            key={p.id}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 12,
+              padding: '10px 12px',
+              borderRadius: 8,
+              border: '1px solid #2b2b2b',
+              background: '#232323',
+            }}
+          >
+            <span style={providerChipStyle(p.provider)}>{p.provider}</span>
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div style={{ fontSize: 13, color: '#e6e6e6' }}>{p.label}</div>
+              <div
+                style={{
+                  ...mono,
+                  fontSize: 11,
+                  color: '#8a8a8a',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                {p.prompt}
+              </div>
+            </div>
+            <button
+              type="button"
+              onClick={() => onRun(p)}
+              style={{
+                ...mono,
+                fontSize: 12,
+                fontWeight: 600,
+                cursor: 'pointer',
+                color: '#0f151b',
+                background: '#3fb950',
+                border: 'none',
+                borderRadius: 7,
+                padding: '6px 14px',
+              }}
+            >
+              Run
+            </button>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function RunTerminal({
+  caps,
+  profile,
+  onBack,
+}: {
+  caps: KfxCapabilities;
+  profile: RunProfile;
+  onBack: () => void;
+}) {
   const hostRef = React.useRef<HTMLDivElement>(null);
   const [status, setStatus] = React.useState('starting…');
   const [meta, setMeta] = React.useState<{ runId: string; pid: number } | null>(
@@ -60,15 +213,15 @@ function TerminalView({ caps }: { caps: KfxCapabilities; shell: Shell }) {
 
     void (async () => {
       try {
+        const { command, args } = launchCommand(profile);
         const session = await resolve(
           caps.terminal.spawn({
-            command: '/bin/bash',
-            args: ['-l'],
+            command,
+            args,
             cols: term.cols,
             rows: term.rows,
           }),
         );
-        // the effect was torn down while spawn was in flight — do not leak the pty
         if (disposed) {
           void resolve(caps.terminal.kill(session.runId));
           return;
@@ -130,7 +283,7 @@ function TerminalView({ caps }: { caps: KfxCapabilities; shell: Shell }) {
       }
       term.dispose();
     };
-  }, [caps.terminal]);
+  }, [caps.terminal, profile]);
 
   return (
     <div
@@ -141,15 +294,51 @@ function TerminalView({ caps }: { caps: KfxCapabilities; shell: Shell }) {
         gap: 6,
       }}
     >
-      <div style={{ ...mono, fontSize: 12, color: '#9cdcfe' }}>
-        Terminal{meta ? ` · run ${meta.runId} · pid ${meta.pid}` : ''} ·{' '}
-        {status}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 10,
+          ...mono,
+          fontSize: 12,
+          color: '#9cdcfe',
+        }}
+      >
+        <button
+          type="button"
+          onClick={onBack}
+          style={{
+            ...mono,
+            fontSize: 11,
+            cursor: 'pointer',
+            color: '#9cdcfe',
+            background: 'transparent',
+            border: '1px solid #3a3a3a',
+            borderRadius: 6,
+            padding: '2px 8px',
+          }}
+        >
+          ← Inbox
+        </button>
+        <span>
+          {profile.provider} · {profile.label}
+          {meta ? ` · run ${meta.runId} · pid ${meta.pid}` : ''} · {status}
+        </span>
       </div>
       <div
         ref={hostRef}
         style={{ ...panelStyle, flex: 1, padding: 6, overflow: 'hidden' }}
       />
     </div>
+  );
+}
+
+function TerminalView({ caps }: { caps: KfxCapabilities; shell: Shell }) {
+  const [active, setActive] = React.useState<RunProfile | null>(null);
+  return active ? (
+    <RunTerminal caps={caps} profile={active} onBack={() => setActive(null)} />
+  ) : (
+    <Inbox onRun={setActive} />
   );
 }
 

--- a/framework/core/src/python/kungfu/console/commands/__registry__.py
+++ b/framework/core/src/python/kungfu/console/commands/__registry__.py
@@ -11,6 +11,7 @@ from . import assemble
 from . import login
 from . import backtest
 from . import trace
+from . import managed_run
 from . import rewind
 from . import schema
 from . import work
@@ -29,6 +30,7 @@ __all__ = [
     "login",
     "backtest",
     "trace",
+    "managed_run",
     "rewind",
     "schema",
     "work",

--- a/framework/core/src/python/kungfu/console/commands/managed_run.py
+++ b/framework/core/src/python/kungfu/console/commands/managed_run.py
@@ -1,0 +1,38 @@
+#  SPDX-License-Identifier: Apache-2.0
+
+import sys
+
+import click
+
+from kungfu.console.commands import kfc
+from kungfu.rewind.managed_cli import run_and_report
+from kungfu.rewind.managed_run import managed_providers
+
+managed_run_command_context = kfc.pass_context()
+
+
+@kfc.command(
+    help_priority=3,
+    help=(
+        "run a provider under management and report its cost: "
+        "kungfu managed-run --provider claude --prompt <task>"
+    ),
+)
+@click.option(
+    "--provider",
+    required=True,
+    type=click.Choice(managed_providers()),
+    help="which provider CLI to run under management",
+)
+@click.option("--prompt", required=True, help="the task to run")
+@click.option(
+    "--work-id",
+    type=str,
+    default=None,
+    help="work item this run belongs to, when known",
+)
+@managed_run_command_context
+def managed_run(ctx, provider, prompt, work_id):
+    sys.exit(
+        run_and_report(provider, prompt, runtime_dir=ctx.runtime_dir, work_id=work_id)
+    )

--- a/framework/core/src/python/kungfu/rewind/managed_cli.py
+++ b/framework/core/src/python/kungfu/rewind/managed_cli.py
@@ -45,31 +45,22 @@ def _rule(label=""):
     return f"─ {label} " + "─" * max(0, 44 - len(label))
 
 
-def main(argv=None):
-    ap = argparse.ArgumentParser(prog="kungfu managed-run")
-    ap.add_argument(
-        "--provider", required=True, choices=managed_run.managed_providers()
-    )
-    ap.add_argument("--prompt", required=True, help="the task to run")
-    ap.add_argument("--home", default=None, help="runtime dir for the journal")
-    ap.add_argument("--work-id", default=None, help="work item this run belongs to")
-    args = ap.parse_args(argv)
-
-    runtime = args.home or tempfile.mkdtemp(prefix="kungfu-managed-")
+def run_and_report(provider, prompt, *, runtime_dir, work_id=None):
+    """Run one managed provider run on a journal under runtime_dir and print its
+    cost. Returns the provider's exit code. Shared by the `kungfu managed-run`
+    console command and the `python -m` entry."""
     run_id = uuid.uuid4().hex[:12]
 
-    disc = discover_provider(args.provider)
-    print(
-        f"\033[1m◆ Kungfu managed run\033[0m  provider={args.provider}  run_id={run_id}"
-    )
+    disc = discover_provider(provider)
+    print(f"\033[1m◆ Kungfu managed run\033[0m  provider={provider}  run_id={run_id}")
     if not disc.found:
         print(f"  provider not available: {disc.error}")
         return 2
     print(f"  binary  {disc.path}  ({disc.path_class}, {disc.version})")
-    print(f"  prompt  {args.prompt}")
+    print(f"  prompt  {prompt}")
     print("  running the provider under management …\n")
 
-    writer = _open_journal(runtime, run_id)
+    writer = _open_journal(runtime_dir, run_id)
 
     def emit(msg_type, data):
         writer.write_bytes(0, msg_type, list(data), len(data))
@@ -78,7 +69,7 @@ def main(argv=None):
         MSG_RUN_BEGIN,
         events.run_begin(
             run_id=run_id,
-            command=f"{args.provider} managed-run",
+            command=f"{provider} managed-run",
             runtime=sys.platform,
             supervisor_version=kungfu.__version__,
             schema_version=SCHEMA_VERSION,
@@ -86,12 +77,7 @@ def main(argv=None):
     )
 
     result = managed_run.run_managed(
-        args.provider,
-        disc.path,
-        args.prompt,
-        emit=emit,
-        run_id=run_id,
-        work_id=args.work_id,
+        provider, disc.path, prompt, emit=emit, run_id=run_id, work_id=work_id
     )
 
     status = RunStatus.Succeeded if result.exit_code == 0 else RunStatus.Failed
@@ -100,8 +86,8 @@ def main(argv=None):
     # persist without an explicit flush; the writer releases at function end.
 
     manifest = bundle.emit(
-        os.path.join(runtime, "rewind", run_id, "bundle"),
-        runtime,
+        os.path.join(runtime_dir, "rewind", run_id, "bundle"),
+        runtime_dir,
         {
             "mode": "LIVE",
             "category": "SYSTEM",
@@ -143,6 +129,21 @@ def main(argv=None):
     print(f"  proof        {manifest}")
     print("─" * 46)
     return result.exit_code
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(prog="kungfu managed-run")
+    ap.add_argument(
+        "--provider", required=True, choices=managed_run.managed_providers()
+    )
+    ap.add_argument("--prompt", required=True, help="the task to run")
+    ap.add_argument("--home", default=None, help="runtime dir for the journal")
+    ap.add_argument("--work-id", default=None, help="work item this run belongs to")
+    args = ap.parse_args(argv)
+    runtime = args.home or tempfile.mkdtemp(prefix="kungfu-managed-")
+    return run_and_report(
+        args.provider, args.prompt, runtime_dir=runtime, work_id=args.work_id
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The GUI terminal opens on an inbox of managed-run profiles; picking one runs a provider under management and reports its cost. Adds the 'kungfu managed-run' console subcommand and reworks the terminal view into an inbox + run terminal. Verified end to end in the GUI against a real claude run.