### PR TITLE
feat(capability): uniform capability surface across trust tiers (ADR-0014 first delivery)

### DIFF
--- a/framework/api/src/capability/guest-harness/facet-knobs.mjs
+++ b/framework/api/src/capability/guest-harness/facet-knobs.mjs
@@ -1,15 +1,24 @@
 // A facet that exercises the restriction knobs (ADR-0014 decision 3: restriction
-// is transparent interception, never API removal). It attempts a filesystem
-// write and a loopback network round-trip, then reports the outcome of each —
-// through the same report capability, over the same relay, in every profile.
+// is transparent interception, never API removal). It probes a filesystem write
+// and the network, then reports each outcome — through the same report
+// capability, over the same relay, in every profile.
 //
 // The point: this ONE source runs unchanged under a permissive profile and under
 // each knob turned on. When a knob narrows what a capability reaches, the facet
 // observes a refused syscall — a narrower result — never a withdrawn method. It
 // is not re-adapted; it just sees 'refused' where it saw 'ok'.
+//
+// The network knob narrows differently per platform, so the facet reports two
+// distinct observables and the runner asserts the platform-relevant one:
+//   - loopback: a 127.0.0.1 round-trip. macOS Seatbelt `(deny network*)` refuses
+//     every socket, loopback included, so this is the macOS signal.
+//   - externalNet: whether any non-loopback network interface is present. Linux
+//     `--unshare-net` puts the guest in a private network namespace with only a
+//     loopback up — loopback still works, but external egress is gone — so the
+//     absence of an external interface is the Linux signal.
 import net from 'node:net';
 import { writeFileSync, unlinkSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { networkInterfaces, tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 function tryFsWrite() {
@@ -51,8 +60,19 @@ function tryLoopbackNet() {
   });
 }
 
+function hasExternalInterface() {
+  const ifaces = networkInterfaces();
+  for (const addrs of Object.values(ifaces)) {
+    for (const addr of addrs ?? []) {
+      if (!addr.internal) return true;
+    }
+  }
+  return false;
+}
+
 export async function run(caps) {
   const fsWrite = tryFsWrite();
-  const network = await tryLoopbackNet();
-  await caps.report.result({ facet: 'knobs', fsWrite, network });
+  const loopback = await tryLoopbackNet();
+  const externalNet = hasExternalInterface() ? 'ok' : 'refused';
+  await caps.report.result({ facet: 'knobs', fsWrite, loopback, externalNet });
 }

--- a/framework/api/src/capability/guest-harness/facet-knobs.mjs
+++ b/framework/api/src/capability/guest-harness/facet-knobs.mjs
@@ -1,0 +1,58 @@
+// A facet that exercises the restriction knobs (ADR-0014 decision 3: restriction
+// is transparent interception, never API removal). It attempts a filesystem
+// write and a loopback network round-trip, then reports the outcome of each —
+// through the same report capability, over the same relay, in every profile.
+//
+// The point: this ONE source runs unchanged under a permissive profile and under
+// each knob turned on. When a knob narrows what a capability reaches, the facet
+// observes a refused syscall — a narrower result — never a withdrawn method. It
+// is not re-adapted; it just sees 'refused' where it saw 'ok'.
+import net from 'node:net';
+import { writeFileSync, unlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+function tryFsWrite() {
+  const path = join(tmpdir(), `kfx-knob-${process.pid}.tmp`);
+  try {
+    writeFileSync(path, 'kfx');
+    try {
+      unlinkSync(path);
+    } catch {}
+    return 'ok';
+  } catch (err) {
+    return `refused:${err.code ?? err.message}`;
+  }
+}
+
+function tryLoopbackNet() {
+  return new Promise((resolve) => {
+    let server;
+    const done = (v) => {
+      try {
+        server?.close();
+      } catch {}
+      resolve(v);
+    };
+    try {
+      server = net.createServer((socket) => socket.end());
+      server.on('error', (err) => done(`refused:${err.code ?? err.message}`));
+      server.listen(0, '127.0.0.1', () => {
+        const { port } = server.address();
+        const client = net.connect(port, '127.0.0.1', () => {
+          client.end();
+          done('ok');
+        });
+        client.on('error', (err) => done(`refused:${err.code ?? err.message}`));
+      });
+    } catch (err) {
+      done(`refused:${err.code ?? err.message}`);
+    }
+  });
+}
+
+export async function run(caps) {
+  const fsWrite = tryFsWrite();
+  const network = await tryLoopbackNet();
+  await caps.report.result({ facet: 'knobs', fsWrite, network });
+}

--- a/framework/api/src/capability/guest-harness/facet.mjs
+++ b/framework/api/src/capability/guest-harness/facet.mjs
@@ -1,0 +1,23 @@
+// A JavaScript facet — a real extension written once against the uniform
+// asynchronous capability surface (ADR-0014). This exact source runs unchanged
+// in both trust tiers: co-resident (in-process, zero-copy) and sandboxed (an
+// OS-sandboxed child reaching the host over the stdio relay). It never branches
+// on which tier it is running in.
+//
+// What it observes IS the transport difference the contract hides from the
+// author: it reads records from the ledger capability and reports the runtime
+// type of a 64-bit genTime. Co-resident it is a bigint (returned by reference);
+// sandboxed it is a decimal string (the relay serialized it). The facet does not
+// know or care — it just calls the same async method and reports what it got.
+export async function run(caps) {
+  const records = await caps.ledger.records({ limit: 3 });
+  const health = await caps.ledger.health();
+  const first = records[0];
+  await caps.report.result({
+    facet: 'js',
+    recordCount: records.length,
+    firstGenTime: String(first.genTime),
+    genTimeType: typeof first.genTime,
+    joined: health.joined,
+  });
+}

--- a/framework/api/src/capability/guest-harness/facet.py
+++ b/framework/api/src/capability/guest-harness/facet.py
@@ -1,0 +1,27 @@
+#  SPDX-License-Identifier: Apache-2.0
+#
+# A Python facet — a real extension written once against the uniform capability
+# surface (ADR-0014). This exact source runs unchanged in both trust tiers:
+# co-resident (in-process, by reference) and sandboxed (an OS-sandboxed child
+# reaching the host over the stdio relay). It never branches on the tier.
+#
+# What it observes IS the transport difference the contract hides from the
+# author: it reads records from the ledger capability and reports the runtime
+# type of a 64-bit genTime. Co-resident it is a Python int (by reference);
+# sandboxed it is a decimal string (the JSON relay serialized it). The facet
+# calls the same method either way and reports what it got.
+
+
+def run(caps):
+    records = caps["ledger"].records({"limit": 3})
+    health = caps["ledger"].health()
+    first = records[0]
+    caps["report"].result(
+        {
+            "facet": "py",
+            "recordCount": len(records),
+            "firstGenTime": str(first["genTime"]),
+            "genTimeType": type(first["genTime"]).__name__,
+            "joined": health["joined"],
+        }
+    )

--- a/framework/api/src/capability/guest-harness/fixture-caps.ts
+++ b/framework/api/src/capability/guest-harness/fixture-caps.ts
@@ -1,0 +1,80 @@
+// The trusted host's real capability surface for the guest-host harness, built
+// from an injected in-memory binding (ADR-0011: the SDK never loads the native
+// binding; the host injects it). This exercises the real ledger capability code
+// path — openLedger().records() — without a live journal, so the harness proves
+// the execution contract and the transport property, not the trading engine.
+//
+// `ledger.records()` returns LedgerRecord[] whose genTime is a bigint. That is
+// the zero-copy probe: the trusted in-process tier returns it by reference with
+// the bigint intact; the sandbox relay serializes it (bigintSafe → a decimal
+// string). A facet computes typeof genTime from what it received, so the same
+// source reports 'bigint' co-resident and 'string' sandboxed — the transport
+// difference the uniform surface is designed to hide from the developer.
+//
+// `report` is the harness output sink: a facet delivers its result by calling
+// report.result(obj) in BOTH tiers, so its source never branches on the tier.
+import type { KfNativeBinding } from '../types';
+import { type Ledger, openLedger } from '../ledger';
+
+const FIXTURE_FRAMES = [
+  { genTime: 1_700_000_000_000_000_001n, msgType: 101, source: 11, dest: 21 },
+  { genTime: 1_700_000_000_000_000_002n, msgType: 102, source: 12, dest: 22 },
+  { genTime: 1_700_000_000_000_000_003n, msgType: 103, source: 13, dest: 23 },
+];
+
+// A minimal KfNativeBinding: only Assemble is exercised (records()); the other
+// constructors are present to satisfy the type but unused by this harness.
+function fixtureBinding(): KfNativeBinding {
+  class Assemble {
+    private i = 0;
+    private readonly frames = FIXTURE_FRAMES;
+    constructor(_runtimeDirs: string[]) {}
+    dataAvailable(): boolean {
+      return this.i < this.frames.length;
+    }
+    next(): void {
+      this.i += 1;
+    }
+    currentFrame() {
+      const f = this.frames[this.i];
+      return {
+        genTime: () => f.genTime,
+        triggerTime: () => f.genTime,
+        msgType: () => f.msgType,
+        source: () => f.source,
+        dest: () => f.dest,
+        dataLength: () => 0,
+        dataBytes: () => new Uint8Array(0),
+      };
+    }
+  }
+  return { Assemble } as unknown as KfNativeBinding;
+}
+
+export type ReportSink = {
+  result: (value: Record<string, unknown>) => void;
+};
+
+export type FixtureCaps = {
+  caps: { ledger: Ledger; report: ReportSink };
+  declared: readonly string[];
+  readReport: () => Record<string, unknown> | null;
+};
+
+export function buildFixtureCaps(): FixtureCaps {
+  let reported: Record<string, unknown> | null = null;
+  const ledger = openLedger({
+    binding: fixtureBinding(),
+    locator: { runtimeDir: '/tmp/kfx-guest-harness-fixture' },
+  });
+  const report: ReportSink = {
+    result(value) {
+      reported = value;
+    },
+  };
+  return {
+    caps: { ledger, report },
+    declared: ['ledger', 'report'],
+    readReport: () => reported,
+  };
+}

--- a/framework/api/src/capability/guest-harness/node-child.mjs
+++ b/framework/api/src/capability/guest-harness/node-child.mjs
@@ -1,0 +1,23 @@
+// The sandboxed Node child bootstrap: it runs INSIDE the OS sandbox, builds its
+// declared capability object from the stdio relay (connectStdio — the Node guest
+// proxy this delivery adds), imports the facet, and runs it. Its only egress is
+// the relay on stdout/stdin; diagnostics go to stderr. Launch it under the TS
+// resolver hook so the capability SDK source loads unchanged:
+//   node --import ./ts-resolve.mjs node-child.mjs
+import { pathToFileURL } from 'node:url';
+
+import { connectStdio } from '../guest-node.ts';
+
+const declared = JSON.parse(process.env.KFX_DECLARED ?? '[]');
+const facetPath = process.env.KFX_FACET;
+
+const { caps, close } = connectStdio(declared);
+try {
+  const facet = await import(pathToFileURL(facetPath).href);
+  await facet.run(caps);
+} catch (err) {
+  process.stderr.write(`[node-child] ${err?.stack ?? err}\n`);
+  process.exitCode = 1;
+} finally {
+  close();
+}

--- a/framework/api/src/capability/guest-harness/py-child.py
+++ b/framework/api/src/capability/guest-harness/py-child.py
@@ -1,0 +1,34 @@
+#  SPDX-License-Identifier: Apache-2.0
+#
+# The sandboxed Python child bootstrap: it runs INSIDE the OS sandbox, builds its
+# declared capability object from the stdio relay (kungfu.capability.connect —
+# the Python guest proxy), imports the facet, and runs it. Its only egress is the
+# relay on stdout/stdin; diagnostics go to stderr. The host sets PYTHONPATH so
+# kungfu.capability is importable.
+
+import importlib.util
+import json
+import os
+import sys
+
+from kungfu.capability import connect
+
+
+def main():
+    declared = json.loads(os.environ.get("KFX_DECLARED", "[]"))
+    facet_path = os.environ["KFX_FACET"]
+    caps = connect(declared)
+
+    spec = importlib.util.spec_from_file_location("kfx_facet", facet_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    module.run(caps)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as err:  # noqa: BLE001 — report and fail visibly
+        sys.stderr.write(f"[py-child] {err}\n")
+        sys.exit(1)

--- a/framework/api/src/capability/guest-harness/py_fixture.py
+++ b/framework/api/src/capability/guest-harness/py_fixture.py
@@ -1,0 +1,37 @@
+#  SPDX-License-Identifier: Apache-2.0
+#
+# The Python trusted tier's in-process capability surface: the co-resident
+# analogue of fixture-caps.ts. A trusted Python facet is co-resident with a
+# Python-side binding (ADR-0014 §1.4: an adapter is co-resident instrumentation),
+# so it reaches these capabilities in-process and by reference — genTime is a
+# real Python int, not a serialized string. The sandbox tier, by contrast, is
+# served by the Node host over the relay and receives the decimal-string copy.
+
+_FIXTURE_FRAMES = [
+    {"genTime": 1_700_000_000_000_000_001, "msgType": 101, "source": 11, "dest": 21},
+    {"genTime": 1_700_000_000_000_000_002, "msgType": 102, "source": 12, "dest": 22},
+    {"genTime": 1_700_000_000_000_000_003, "msgType": 103, "source": 13, "dest": 23},
+]
+
+
+class _Ledger:
+    def records(self, filt=None):
+        limit = (filt or {}).get("limit", len(_FIXTURE_FRAMES))
+        return [dict(frame) for frame in _FIXTURE_FRAMES[:limit]]
+
+    def health(self):
+        return {"joined": False, "live": False, "usable": False}
+
+
+class _Report:
+    def __init__(self):
+        self.value = None
+
+    def result(self, value):
+        self.value = value
+
+
+def build_caps():
+    """Return (caps, report_sink): exactly the declared capabilities, in-process."""
+    report = _Report()
+    return {"ledger": _Ledger(), "report": report}, report

--- a/framework/api/src/capability/guest-harness/py_trusted.py
+++ b/framework/api/src/capability/guest-harness/py_trusted.py
@@ -1,0 +1,30 @@
+#  SPDX-License-Identifier: Apache-2.0
+#
+# The Python trusted (co-resident) tier runner: build the in-process capability
+# surface, run the SAME facet source the sandboxed child runs, and print the
+# result the facet delivered through the report sink. Here stdout is free (no
+# relay), so the harness reads the JSON result from it.
+
+import importlib.util
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from py_fixture import build_caps  # noqa: E402 — after sys.path setup
+
+
+def main():
+    facet_path = os.environ["KFX_FACET"]
+    caps, report = build_caps()
+
+    spec = importlib.util.spec_from_file_location("kfx_facet", facet_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    module.run(caps)
+    sys.stdout.write(json.dumps(report.value))
+
+
+if __name__ == "__main__":
+    main()

--- a/framework/api/src/capability/guest-harness/run-knobs.ts
+++ b/framework/api/src/capability/guest-harness/run-knobs.ts
@@ -5,10 +5,16 @@
 // that confinement is additive: an extension written against the full surface is
 // not re-adapted when a restriction is enabled.
 //
-// The knobs are OS-level and language-agnostic (a Seatbelt rule on macOS, a
-// bwrap namespace/bind on Linux), so one runtime demonstrates them for both. On
-// Linux the network knob is `--unshare-net`; on macOS it is Seatbelt `(deny
-// network*)`. Run under the TS resolver hook:
+// The knobs are OS-level (a Seatbelt rule on macOS, a bwrap namespace/bind on
+// Linux). The write knob narrows the same way on both. The network knob narrows
+// DIFFERENTLY, so the demo asserts the platform-relevant observable:
+//   - macOS Seatbelt `(deny network*)` refuses every socket, so a loopback
+//     round-trip is refused.
+//   - Linux `--unshare-net` puts the guest in a private network namespace with a
+//     working loopback but no external interface, so loopback still succeeds and
+//     external egress is gone — the absence of an external interface is the
+//     narrowing. (This is why a loopback-only probe would miss it on Linux.)
+// Run under the TS resolver hook:
 //   node --import ./ts-resolve.mjs run-knobs.ts
 import { platform } from 'node:os';
 import { join } from 'node:path';
@@ -20,6 +26,9 @@ const DIR = import.meta.dirname;
 const RESOLVER = join(DIR, 'ts-resolve.mjs');
 const NODE_CHILD = join(DIR, 'node-child.mjs');
 const FACET = join(DIR, 'facet-knobs.mjs');
+
+// The network knob's narrowing shows up in a different observable per platform.
+const NET_FIELD = platform() === 'darwin' ? 'loopback' : 'externalNet';
 
 type KnobCase = {
   label: string;
@@ -73,7 +82,9 @@ function outcome(value: unknown): 'ok' | 'refused' {
 }
 
 async function main() {
-  console.log(`\nkfx restriction-knob demo — platform: ${platform()}\n`);
+  console.log(
+    `\nkfx restriction-knob demo — platform: ${platform()} (network observable: ${NET_FIELD})\n`,
+  );
   console.log('  profile                 fs write     network      verdict');
   console.log('  ' + '-'.repeat(58));
   let failed = 0;
@@ -84,7 +95,7 @@ async function main() {
     try {
       const report = await runCase(c.profile);
       fs = String(report?.fsWrite ?? '—');
-      netv = String(report?.network ?? '—');
+      netv = String(report?.[NET_FIELD] ?? '—');
       const okFacet = report !== null; // the facet still ran and reported
       const fsMatch = outcome(fs) === c.expectFs;
       const netMatch = outcome(netv) === c.expectNet;
@@ -103,8 +114,8 @@ async function main() {
   console.log('  ' + '-'.repeat(58));
   console.log(
     `\n  same facet source in every row: a knob narrows what a capability` +
-      ` reaches (a refused syscall), never removes a method — the facet is not` +
-      ` re-adapted.`,
+      ` reaches (a refused syscall / a removed interface), never removes a` +
+      ` method — the facet is not re-adapted.`,
   );
   console.log(
     `\n  ${failed === 0 ? 'KNOB DEMO GREEN' : `${failed} CASE(S) FAILED`}\n`,

--- a/framework/api/src/capability/guest-harness/run-knobs.ts
+++ b/framework/api/src/capability/guest-harness/run-knobs.ts
@@ -1,0 +1,115 @@
+// The restriction-knob demonstration (ADR-0014 acceptance #3, "可拧性"): run the
+// SAME sandboxed facet under a permissive profile and under each knob turned on,
+// and show that the facet keeps running while the narrowed capability returns a
+// refused result — never a withdrawn method. This is the mechanical guarantee
+// that confinement is additive: an extension written against the full surface is
+// not re-adapted when a restriction is enabled.
+//
+// The knobs are OS-level and language-agnostic (a Seatbelt rule on macOS, a
+// bwrap namespace/bind on Linux), so one runtime demonstrates them for both. On
+// Linux the network knob is `--unshare-net`; on macOS it is Seatbelt `(deny
+// network*)`. Run under the TS resolver hook:
+//   node --import ./ts-resolve.mjs run-knobs.ts
+import { platform } from 'node:os';
+import { join } from 'node:path';
+
+import { type SandboxProfile, launchSandboxedGuest } from '../kungfu-guest';
+import { buildFixtureCaps } from './fixture-caps';
+
+const DIR = import.meta.dirname;
+const RESOLVER = join(DIR, 'ts-resolve.mjs');
+const NODE_CHILD = join(DIR, 'node-child.mjs');
+const FACET = join(DIR, 'facet-knobs.mjs');
+
+type KnobCase = {
+  label: string;
+  profile: SandboxProfile;
+  expectFs: 'ok' | 'refused';
+  expectNet: 'ok' | 'refused';
+};
+
+const CASES: KnobCase[] = [
+  {
+    label: 'permissive (no knob)',
+    profile: { base: 'permissive' },
+    expectFs: 'ok',
+    expectNet: 'ok',
+  },
+  {
+    label: 'knob: denyWrite',
+    profile: { base: 'permissive', denyWrite: true },
+    expectFs: 'refused',
+    expectNet: 'ok',
+  },
+  {
+    label: 'knob: denyNetwork',
+    profile: { base: 'permissive', denyNetwork: true },
+    expectFs: 'ok',
+    expectNet: 'refused',
+  },
+];
+
+async function runCase(
+  profile: SandboxProfile,
+): Promise<Record<string, unknown> | null> {
+  const { caps, declared, readReport } = buildFixtureCaps();
+  const guest = await launchSandboxedGuest({
+    runtime: {
+      command: process.execPath,
+      args: ['--import', RESOLVER, NODE_CHILD],
+      env: { KFX_DECLARED: JSON.stringify(declared), KFX_FACET: FACET },
+    },
+    caps,
+    declared,
+    profile,
+  });
+  const code = await guest.exited;
+  if (code !== 0) throw new Error(`facet child exited ${code}`);
+  return readReport();
+}
+
+function outcome(value: unknown): 'ok' | 'refused' {
+  return String(value).startsWith('refused') ? 'refused' : 'ok';
+}
+
+async function main() {
+  console.log(`\nkfx restriction-knob demo — platform: ${platform()}\n`);
+  console.log('  profile                 fs write     network      verdict');
+  console.log('  ' + '-'.repeat(58));
+  let failed = 0;
+  for (const c of CASES) {
+    let fs = '—';
+    let netv = '—';
+    let verdict = 'PASS';
+    try {
+      const report = await runCase(c.profile);
+      fs = String(report?.fsWrite ?? '—');
+      netv = String(report?.network ?? '—');
+      const okFacet = report !== null; // the facet still ran and reported
+      const fsMatch = outcome(fs) === c.expectFs;
+      const netMatch = outcome(netv) === c.expectNet;
+      if (!okFacet || !fsMatch || !netMatch) {
+        verdict = `FAIL(fs=${outcome(fs)} net=${outcome(netv)})`;
+        failed += 1;
+      }
+    } catch (e) {
+      verdict = `FAIL: ${(e as Error).message}`;
+      failed += 1;
+    }
+    console.log(
+      `  ${c.label.padEnd(22)}  ${fs.padEnd(11)}  ${netv.padEnd(11)}  ${verdict}`,
+    );
+  }
+  console.log('  ' + '-'.repeat(58));
+  console.log(
+    `\n  same facet source in every row: a knob narrows what a capability` +
+      ` reaches (a refused syscall), never removes a method — the facet is not` +
+      ` re-adapted.`,
+  );
+  console.log(
+    `\n  ${failed === 0 ? 'KNOB DEMO GREEN' : `${failed} CASE(S) FAILED`}\n`,
+  );
+  process.exit(failed === 0 ? 0 : 1);
+}
+
+main();

--- a/framework/api/src/capability/guest-harness/run.ts
+++ b/framework/api/src/capability/guest-harness/run.ts
@@ -1,0 +1,180 @@
+// The guest-host harness: prove the ADR-0014 execution contract on the current
+// platform. It runs the SAME facet source per language across both trust tiers
+// and checks that a facet never branches on the tier while the transport
+// property is exactly as designed — the trusted co-resident tier returns a
+// 64-bit genTime by reference (a native bigint / Python int), the sandbox tier
+// returns the serialized decimal-string copy.
+//
+// Cells (one platform's contribution to the {js,py} × {mac, linux} matrix):
+//   js  trusted   in-process async caps, zero-copy by reference     → bigint
+//   js  sandbox   OS-sandboxed Node child over the stdio relay       → string
+//   py  trusted   in-process Python caps, co-resident by reference   → int
+//   py  sandbox   OS-sandboxed Python child over the stdio relay      → str
+//
+// Run it under the TS resolver hook so the capability SDK source loads unchanged:
+//   node --import ./ts-resolve.mjs run.ts
+import { spawnSync } from 'node:child_process';
+import { platform } from 'node:os';
+import { join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import {
+  createInProcessAsyncCaps,
+  launchSandboxedGuest,
+} from '../kungfu-guest';
+import { buildFixtureCaps } from './fixture-caps';
+
+const DIR = import.meta.dirname;
+const RESOLVER = join(DIR, 'ts-resolve.mjs');
+const NODE_CHILD = join(DIR, 'node-child.mjs');
+const PY_CHILD = join(DIR, 'py-child.py');
+const PY_TRUSTED = join(DIR, 'py_trusted.py');
+const FACET_JS = join(DIR, 'facet.mjs');
+const FACET_PY = join(DIR, 'facet.py');
+const CORE_PYTHON = resolve(DIR, '../../../../core/src/python');
+
+type Report = Record<string, unknown> | null;
+
+type Cell = {
+  name: string;
+  facet: 'js' | 'py';
+  tier: 'trusted' | 'sandbox';
+  expectType: string;
+  run: () => Promise<Report>;
+};
+
+async function jsTrusted(): Promise<Report> {
+  const { caps, declared, readReport } = buildFixtureCaps();
+  const asyncCaps = createInProcessAsyncCaps(caps, declared);
+  const facet = await import(pathToFileURL(FACET_JS).href);
+  await facet.run(asyncCaps);
+  return readReport();
+}
+
+async function jsSandbox(): Promise<Report> {
+  const { caps, declared, readReport } = buildFixtureCaps();
+  const guest = await launchSandboxedGuest({
+    runtime: {
+      command: process.execPath,
+      args: ['--import', RESOLVER, NODE_CHILD],
+      env: { KFX_DECLARED: JSON.stringify(declared), KFX_FACET: FACET_JS },
+    },
+    caps,
+    declared,
+    profile: { base: 'permissive' },
+  });
+  const code = await guest.exited;
+  if (code !== 0) throw new Error(`node child exited with code ${code}`);
+  return readReport();
+}
+
+function pyTrusted(): Promise<Report> {
+  const out = spawnSync('python3', [PY_TRUSTED], {
+    encoding: 'utf8',
+    env: { ...process.env, KFX_FACET: FACET_PY },
+  });
+  if (out.status !== 0) {
+    throw new Error(`py trusted exited ${out.status}: ${out.stderr}`);
+  }
+  return JSON.parse(out.stdout.trim());
+}
+
+async function pySandbox(): Promise<Report> {
+  const { caps, declared, readReport } = buildFixtureCaps();
+  const guest = await launchSandboxedGuest({
+    runtime: {
+      command: 'python3',
+      args: [PY_CHILD],
+      env: {
+        KFX_DECLARED: JSON.stringify(declared),
+        KFX_FACET: FACET_PY,
+        PYTHONPATH: CORE_PYTHON,
+      },
+    },
+    caps,
+    declared,
+    profile: { base: 'permissive' },
+  });
+  const code = await guest.exited;
+  if (code !== 0) throw new Error(`python child exited with code ${code}`);
+  return readReport();
+}
+
+const CELLS: Cell[] = [
+  {
+    name: 'js  · trusted',
+    facet: 'js',
+    tier: 'trusted',
+    expectType: 'bigint',
+    run: jsTrusted,
+  },
+  {
+    name: 'js  · sandbox',
+    facet: 'js',
+    tier: 'sandbox',
+    expectType: 'string',
+    run: jsSandbox,
+  },
+  {
+    name: 'py  · trusted',
+    facet: 'py',
+    tier: 'trusted',
+    expectType: 'int',
+    run: () => Promise.resolve(pyTrusted()),
+  },
+  {
+    name: 'py  · sandbox',
+    facet: 'py',
+    tier: 'sandbox',
+    expectType: 'str',
+    run: pySandbox,
+  },
+];
+
+function check(report: Report, expectType: string): string | null {
+  if (!report) return 'no report delivered';
+  if (report.recordCount !== 3) return `recordCount ${report.recordCount} != 3`;
+  if (report.joined !== false) return `joined ${report.joined} != false`;
+  if (report.genTimeType !== expectType) {
+    return `genTimeType '${report.genTimeType}' != '${expectType}'`;
+  }
+  const first = String(report.firstGenTime);
+  if (first !== '1700000000000000001')
+    return `firstGenTime ${first} unexpected`;
+  return null;
+}
+
+async function main() {
+  const os = platform();
+  console.log(`\nkfx guest-host contract harness — platform: ${os}\n`);
+  console.log('  cell            tier      genTime type   result');
+  console.log('  ' + '-'.repeat(52));
+  let failed = 0;
+  for (const cell of CELLS) {
+    let report: Report = null;
+    let error: string | null = null;
+    try {
+      report = await cell.run();
+      error = check(report, cell.expectType);
+    } catch (e) {
+      error = (e as Error).message;
+    }
+    const got = report?.genTimeType ?? '—';
+    const status = error ? `FAIL: ${error}` : 'PASS';
+    if (error) failed += 1;
+    console.log(
+      `  ${cell.name.padEnd(14)}  ${cell.tier.padEnd(8)}  ${String(got).padEnd(13)}  ${status}`,
+    );
+  }
+  console.log('  ' + '-'.repeat(52));
+  console.log(
+    `\n  zero-copy proof: trusted returns genTime by reference (native ` +
+      `bigint / int); sandbox returns the serialized string copy over the relay.`,
+  );
+  console.log(
+    `\n  ${failed === 0 ? 'ALL CELLS GREEN' : `${failed} CELL(S) FAILED`}\n`,
+  );
+  process.exit(failed === 0 ? 0 : 1);
+}
+
+main();

--- a/framework/api/src/capability/guest-harness/ts-resolve.mjs
+++ b/framework/api/src/capability/guest-harness/ts-resolve.mjs
@@ -1,0 +1,22 @@
+// Dev-only ESM resolver hook: let Node's native TypeScript type-stripping run
+// the capability SDK source unchanged. The package's internal imports are
+// extensionless (they are bundled by consumers, not run directly by Node), so
+// append the TypeScript extension when a bare relative import does not resolve.
+import { registerHooks } from 'node:module';
+
+registerHooks({
+  resolve(specifier, context, next) {
+    try {
+      return next(specifier, context);
+    } catch (err) {
+      if (specifier.startsWith('.') && !/\.[cm]?[jt]sx?$/.test(specifier)) {
+        for (const ext of ['.ts', '.tsx', '/index.ts']) {
+          try {
+            return next(specifier + ext, context);
+          } catch {}
+        }
+      }
+      throw err;
+    }
+  },
+});

--- a/framework/api/src/capability/guest-node.ts
+++ b/framework/api/src/capability/guest-node.ts
@@ -1,0 +1,103 @@
+// The Node child-side guest proxy (ADR-0014): the missing sibling of
+// framework/core/src/python/kungfu/capability/guest.py. A sandboxed Node child
+// reaches only its declared capabilities, forwarded to the trusted host over a
+// newline-delimited JSON channel carried on its stdio. Until now the Node guest
+// half (createCapabilityGuest in ./sandbox) had only an Electron IPC transport;
+// this binds it to a child process's stdio so the same guest object runs in an
+// OS-sandboxed CLI child, not just an isolated renderer.
+//
+// The wire protocol is the one serveSubprocessCapabilities (./subprocess) speaks
+// from the host side: the child writes `invoke` frames to its stdout and reads
+// `result`/`event` frames from its stdin. Diagnostics MUST go to stderr — the
+// child's stdout is the relay, and anything else written there corrupts it.
+import { createInterface } from 'node:readline';
+
+import {
+  type GuestChannel,
+  type HostEvent,
+  createCapabilityGuest,
+} from './sandbox';
+
+type ResultFrame = {
+  t: 'result';
+  id: number;
+  ok: boolean;
+  value?: unknown;
+  error?: string;
+};
+type EventFrame = { t: 'event'; callback: number; args: unknown[] };
+
+// The stdio channel a sandboxed Node child speaks to its host. Reads host->child
+// frames on the input stream: a result wakes the invoke() waiting on its id; an
+// event fires the registered listeners. Structural streams so a test can drive
+// it without a real child process.
+export type NodeGuestStreams = {
+  input: NodeJS.ReadableStream;
+  output: { write: (chunk: string) => void };
+};
+
+export function createStdioGuestChannel(
+  streams: NodeGuestStreams,
+): GuestChannel & { close: () => void } {
+  const pending = new Map<
+    number,
+    { resolve: (v: unknown) => void; reject: (e: Error) => void }
+  >();
+  const listeners = new Set<(event: HostEvent) => void>();
+  let seq = 0;
+
+  const send = (msg: unknown): void => {
+    streams.output.write(`${JSON.stringify(msg)}\n`);
+  };
+
+  const lines = createInterface({ input: streams.input });
+  lines.on('line', (line: string) => {
+    if (!line) return;
+    let msg: ResultFrame | EventFrame;
+    try {
+      msg = JSON.parse(line);
+    } catch {
+      return; // ignore anything that is not a protocol frame
+    }
+    if (msg.t === 'result' && typeof msg.id === 'number') {
+      const waiter = pending.get(msg.id);
+      if (!waiter) return;
+      pending.delete(msg.id);
+      if (msg.ok) waiter.resolve(msg.value);
+      else waiter.reject(new Error(msg.error ?? 'capability call failed'));
+    } else if (msg.t === 'event' && typeof msg.callback === 'number') {
+      for (const fn of listeners)
+        fn({ callback: msg.callback, args: msg.args ?? [] });
+    }
+  });
+
+  return {
+    invoke(req) {
+      const id = (seq += 1);
+      return new Promise<unknown>((resolve, reject) => {
+        pending.set(id, { resolve, reject });
+        send({ t: 'invoke', id, ...req });
+      });
+    },
+    onEvent(fn) {
+      listeners.add(fn);
+      return () => listeners.delete(fn);
+    },
+    close() {
+      lines.close();
+    },
+  };
+}
+
+// Build the capability object a sandboxed Node child receives: exactly the
+// declared capabilities, each call and each callback argument marshalled over
+// the child's stdio to the trusted host. The uniform surface (ADR-0014): every
+// method returns a Promise, the same shape the trusted tier presents in-process.
+export function connectStdio(
+  declared: readonly string[],
+  streams: NodeGuestStreams = { input: process.stdin, output: process.stdout },
+): { caps: Record<string, unknown>; close: () => void } {
+  const channel = createStdioGuestChannel(streams);
+  const caps = createCapabilityGuest(declared, channel);
+  return { caps, close: channel.close };
+}

--- a/framework/api/src/capability/index.ts
+++ b/framework/api/src/capability/index.ts
@@ -9,3 +9,20 @@ export * from './schema';
 export * from './sandbox';
 export * from './terminal';
 export * from './work';
+
+// The runtime-plane trust boundary (ADR-0013 / ADR-0014): the OS-sandbox
+// launcher, the child-process relay transport, the Node child-side guest proxy,
+// and the binding-less host that composes them into the uniform capability
+// surface across trust tiers. subprocess.ts re-declares HostRequest/HostEvent
+// structurally to stay decoupled; those names are already exported from
+// ./sandbox, so only the transport's own names are re-exported here to avoid an
+// ambiguous star-export.
+export * from './sandbox-launcher';
+export { serveSubprocessCapabilities } from './subprocess';
+export type {
+  RelayHost,
+  SubprocessChannel,
+  SubprocessHost,
+} from './subprocess';
+export * from './guest-node';
+export * from './kungfu-guest';

--- a/framework/api/src/capability/kungfu-guest.ts
+++ b/framework/api/src/capability/kungfu-guest.ts
@@ -1,0 +1,182 @@
+// The binding-less guest host (ADR-0014): the production caller the ADR-0013
+// runtime-plane primitives were built for. It composes the OS-sandbox launcher
+// (./sandbox-launcher), the child-process relay transport (./subprocess), and a
+// per-runtime guest proxy (./guest-node for Node, capability/guest.py for
+// Python) into one host that presents a single uniform capability surface to
+// every extension runtime — the trust tier selecting the channel underneath.
+//
+// The surface is uniform and asynchronous in both tiers (an extension never
+// branches on which tier it runs in):
+//
+//   - Trusted, co-resident: createInProcessAsyncCaps short-circuits every call
+//     in-process against the real capabilities and returns their results BY
+//     REFERENCE — the zero-copy trusted channel of ADR-0013, wrapped only in an
+//     immediately-resolved promise so the surface matches the sandbox tier.
+//   - Default, sandboxed: launchSandboxedGuest runs the guest in an OS sandbox
+//     and serves its declared capabilities over the stdio relay, which returns
+//     serialized copies. The performance split ADR-0013 cut along the trust axis
+//     is preserved; only the surface is unified.
+//
+// The host never hands the guest the native binding: it addresses only the
+// capability surface either way. Undeclared capabilities are absent in both
+// tiers — rejected at the relay host, and never built into the in-process proxy.
+import { type SandboxProfile, osSandboxCommand } from './sandbox-launcher';
+import { createCapabilityHost } from './sandbox';
+import { serveSubprocessCapabilities } from './subprocess';
+
+// ── trusted tier: in-process async surface, zero-copy by reference ───────────
+
+// Build the uniform async capability object for a co-resident trusted guest. It
+// contains exactly the declared capabilities; each method calls the real
+// capability in-process and resolves immediately with the real return value —
+// no serialization, no copy, journal handles kept by reference. The Promise
+// wrapper is the only thing the trusted tier adds, so an extension's source is
+// identical to the sandboxed tier's. An undeclared capability, or a method the
+// capability does not have, rejects — the same boundary the relay host enforces.
+export function createInProcessAsyncCaps(
+  caps: Record<string, Record<string, unknown>>,
+  declared: readonly string[],
+): Record<string, unknown> {
+  const allowed = new Set(declared);
+  const out: Record<string, unknown> = {};
+  for (const cap of declared) {
+    out[cap] = new Proxy(
+      {},
+      {
+        get(_target, method) {
+          if (typeof method !== 'string') return undefined;
+          return (...args: unknown[]): Promise<unknown> => {
+            if (!allowed.has(cap)) {
+              return Promise.reject(
+                new Error(`capability '${cap}' is not declared by this kfx`),
+              );
+            }
+            const handle = caps[cap];
+            const fn = handle?.[method];
+            if (typeof fn !== 'function') {
+              return Promise.reject(
+                new Error(`capability '${cap}' has no method '${method}'`),
+              );
+            }
+            try {
+              // apply in-process; the result — an array, a journal handle, a
+              // Subscription — is returned by reference, then wrapped so the
+              // surface is a Promise like the sandbox tier's.
+              return Promise.resolve(
+                (fn as (...a: unknown[]) => unknown).apply(handle, args),
+              );
+            } catch (e) {
+              return Promise.reject(e as Error);
+            }
+          };
+        },
+      },
+    );
+  }
+  return out;
+}
+
+// ── default tier: OS-sandboxed child served over the stdio relay ─────────────
+
+// The subset of a spawned child process the host wires. Structural so a test can
+// pass a double instead of a real ChildProcess.
+export type GuestChild = {
+  stdout: NodeJS.ReadableStream | null;
+  stdin: { write: (chunk: string) => void } | null;
+  on: (event: 'exit', cb: (code: number | null) => void) => void;
+  once: (event: 'exit' | 'close', cb: () => void) => void;
+  kill?: (signal?: NodeJS.Signals) => void;
+};
+
+export type SpawnFn = (
+  command: string,
+  args: readonly string[],
+  options: { stdio: ['pipe', 'pipe', 'inherit']; env: NodeJS.ProcessEnv },
+) => GuestChild;
+
+// How to boot the child-side guest proxy: the interpreter and its argv, plus any
+// env the child bootstrap reads (e.g. the declared set and the facet entry). The
+// command is wrapped in the OS sandbox before it is spawned.
+export type GuestRuntimeLaunch = {
+  command: string;
+  args: readonly string[];
+  env?: Record<string, string>;
+};
+
+export type SandboxedGuestOptions = {
+  runtime: GuestRuntimeLaunch;
+  // the real capabilities the host resolves calls against
+  caps: Record<string, Record<string, unknown>>;
+  // the capability keys this guest declared; only these are reachable
+  declared: readonly string[];
+  // OS sandbox profile; defaults to the ADR-0014 permissive first-delivery
+  // profile — able to run, not yet restricted. Turn a knob on to narrow it.
+  profile?: SandboxProfile;
+  // injectable for tests; defaults to node:child_process spawn
+  spawn?: SpawnFn;
+};
+
+export type SandboxedGuest = {
+  // stop serving and terminate the child
+  dispose: () => void;
+  // resolves with the child's exit code (null if signalled)
+  exited: Promise<number | null>;
+};
+
+async function defaultSpawn(
+  command: string,
+  args: readonly string[],
+  options: { stdio: ['pipe', 'pipe', 'inherit']; env: NodeJS.ProcessEnv },
+): Promise<GuestChild> {
+  const { spawn } = await import('node:child_process');
+  return spawn(command, args as string[], options) as unknown as GuestChild;
+}
+
+// Launch a guest inside the OS sandbox and serve its declared capabilities over
+// the stdio relay. The interpreter runs confined; its only egress is the relay
+// on its stdio (stderr is inherited for diagnostics). Returns a handle whose
+// `exited` promise resolves when the child exits.
+export async function launchSandboxedGuest(
+  opts: SandboxedGuestOptions,
+): Promise<SandboxedGuest> {
+  const wrapped = osSandboxCommand(
+    opts.runtime.command,
+    opts.runtime.args,
+    opts.profile ?? { base: 'permissive' },
+  );
+  const env: NodeJS.ProcessEnv = { ...process.env, ...opts.runtime.env };
+  const spawnFn = opts.spawn;
+  const child = spawnFn
+    ? spawnFn(wrapped.command, wrapped.args, {
+        stdio: ['pipe', 'pipe', 'inherit'],
+        env,
+      })
+    : await defaultSpawn(wrapped.command, wrapped.args, {
+        stdio: ['pipe', 'pipe', 'inherit'],
+        env,
+      });
+
+  if (!child.stdout || !child.stdin) {
+    throw new Error('sandboxed guest child has no piped stdio to relay over');
+  }
+
+  const host = serveSubprocessCapabilities(
+    { stdout: child.stdout, stdin: child.stdin, once: child.once.bind(child) },
+    (emit) => createCapabilityHost(opts.caps, opts.declared, emit),
+  );
+
+  const exited = new Promise<number | null>((resolve) => {
+    child.on('exit', (code) => {
+      host.dispose();
+      resolve(code);
+    });
+  });
+
+  return {
+    dispose() {
+      host.dispose();
+      child.kill?.();
+    },
+    exited,
+  };
+}

--- a/framework/api/src/capability/sandbox-launcher.ts
+++ b/framework/api/src/capability/sandbox-launcher.ts
@@ -1,53 +1,98 @@
-// The default-tier isolation base (ADR-0013): launch an untrusted guest inside an
-// OS sandbox so its only egress is the capability relay carried on its stdio
-// (framework/api/src/capability/subprocess.ts). Filesystem writes and the network
-// are denied by default; reads are allowed, because an interpreter must read its
-// own runtime — the read boundary is coarse, which the ADR records as residual
-// risk, not an absolute guarantee.
+// The default-tier isolation base (ADR-0013 / ADR-0014): launch an untrusted
+// guest inside an OS sandbox so its only egress is the capability relay carried
+// on its stdio (framework/api/src/capability/subprocess.ts).
+//
+// A profile is composed from a base disposition and independent restriction
+// knobs, so the same launcher serves the first delivery's permissive default
+// (ADR-0014: run first, restrict later) and each restriction turned on as a
+// transparent narrowing rather than a code path of its own:
+//
+//   - base 'permissive' — reads, writes and the network are all allowed; the
+//     guest can run its own runtime and reach the network, confined only by the
+//     OS sandbox membrane and its own namespaces. This is the day-one profile
+//     the uniform surface is proven against before any restriction is layered on.
+//   - base 'restrictive' — writes and the network are denied (reads stay open,
+//     an interpreter must read its runtime). This is the isolation ADR-0013
+//     describes and the network/filesystem-write denials verified on hardware.
+//
+// Each knob (`denyNetwork`, `denyWrite`) overrides its base default, so a single
+// narrowing — e.g. deny the network on an otherwise permissive guest — is one
+// flag, not a separate profile. An extension written against the full capability
+// surface keeps running when a knob is turned on; it observes a narrower result
+// (a refused socket, a read-only mount), never a withdrawn capability.
 //
 // macOS confines the child with a Seatbelt profile via `sandbox-exec`. Linux
-// confines it with bubblewrap (`bwrap`): a read-only root, unshared network, and
-// its own user/pid/mount namespaces — the practical, unprivileged sandbox on
-// current distributions, where raw namespaces are blocked (e.g. Ubuntu's
+// confines it with bubblewrap (`bwrap`): its own user/pid/ipc/uts namespaces, a
+// bound root (read-only when writes are denied), and the network namespace
+// unshared only when the network is denied — the practical, unprivileged sandbox
+// on current distributions, where raw namespaces are blocked (e.g. Ubuntu's
 // AppArmor unprivileged-userns restriction) but bwrap is permitted. If bwrap is
 // absent the launch is refused rather than run unconfined: a sandbox that
 // silently does nothing is worse than an explicit, visible gap.
 import { existsSync } from 'node:fs';
 import { platform } from 'node:os';
 
-// Deny by default; allow exec/fork and reads (the interpreter needs its runtime)
-// and the /dev nodes a process needs; deny every filesystem write and all network.
-// Inherited stdio (fds 0-2) is unaffected, so the capability relay still flows.
-// Seatbelt is last-match-wins, so the /dev write allowances follow the blanket
-// write denial.
-const MACOS_SEATBELT_PROFILE = [
-  '(version 1)',
-  '(deny default)',
-  '(allow process-fork)',
-  '(allow process-exec)',
-  '(allow sysctl-read)',
-  '(allow file-read*)',
-  '(deny file-write*)',
-  '(allow file-write-data (literal "/dev/null"))',
-  '(allow file-write-data (literal "/dev/dtracehelper"))',
-  '(deny network*)',
-].join('');
+// A profile disposition plus the restriction knobs that narrow it. Omitted knobs
+// take the base default: a permissive base allows the network and writes; a
+// restrictive base denies both. Reads are always allowed — the guest must read
+// its own interpreter and runtime; narrowing reads is a follow-up (ADR-0014
+// feasibility map: Landlock on Linux, profile read rules on macOS).
+export type SandboxProfile = {
+  base?: 'permissive' | 'restrictive';
+  denyNetwork?: boolean;
+  denyWrite?: boolean;
+};
 
-// bubblewrap: a read-only view of the whole filesystem (reads work, every write
-// is denied), no network (--unshare-all includes the network namespace), its own
-// user/pid/mount namespaces, and death with the parent. Inherited stdio is
-// untouched, so the capability relay still flows.
-const LINUX_BWRAP_ARGS = [
-  '--unshare-all',
-  '--ro-bind',
-  '/',
-  '/',
-  '--proc',
-  '/proc',
-  '--dev',
-  '/dev',
-  '--die-with-parent',
-];
+type ResolvedProfile = { denyNetwork: boolean; denyWrite: boolean };
+
+function resolveProfile(profile: SandboxProfile = {}): ResolvedProfile {
+  const restrictive = profile.base === 'restrictive';
+  return {
+    denyNetwork: profile.denyNetwork ?? restrictive,
+    denyWrite: profile.denyWrite ?? restrictive,
+  };
+}
+
+// Seatbelt is last-match-wins; the /dev write allowances follow the blanket
+// write denial. Inherited stdio (fds 0-2) is unaffected either way, so the
+// capability relay still flows.
+function macosSeatbeltProfile(resolved: ResolvedProfile): string {
+  const rules = [
+    '(version 1)',
+    '(deny default)',
+    '(allow process-fork)',
+    '(allow process-exec)',
+    '(allow sysctl-read)',
+    '(allow file-read*)',
+  ];
+  if (resolved.denyWrite) {
+    rules.push('(deny file-write*)');
+    rules.push('(allow file-write-data (literal "/dev/null"))');
+    rules.push('(allow file-write-data (literal "/dev/dtracehelper"))');
+  } else {
+    rules.push('(allow file-write*)');
+  }
+  rules.push(resolved.denyNetwork ? '(deny network*)' : '(allow network*)');
+  return rules.join('');
+}
+
+// bubblewrap: own user/pid/ipc/uts namespaces; a bound root, read-only when
+// writes are denied; the network namespace unshared only when the network is
+// denied; death with the parent. Inherited stdio is untouched, so the capability
+// relay still flows.
+function linuxBwrapArgs(resolved: ResolvedProfile): string[] {
+  const args = [
+    '--unshare-user',
+    '--unshare-ipc',
+    '--unshare-pid',
+    '--unshare-uts',
+    '--unshare-cgroup-try',
+  ];
+  if (resolved.denyNetwork) args.push('--unshare-net');
+  args.push(resolved.denyWrite ? '--ro-bind' : '--bind', '/', '/');
+  args.push('--proc', '/proc', '--dev', '/dev', '--die-with-parent');
+  return args;
+}
 
 const BWRAP_PATHS = ['/usr/bin/bwrap', '/bin/bwrap', '/usr/local/bin/bwrap'];
 
@@ -68,18 +113,23 @@ export function isOsSandboxSupported(): boolean {
   }
 }
 
-// Wrap a command so it runs inside the OS default-deny sandbox. Throws on a
-// platform whose sandbox is not implemented — the caller must not fall back to
-// launching the guest unconfined.
+// Wrap a command so it runs inside the OS sandbox under the given profile. The
+// profile defaults to the restrictive disposition (writes and network denied),
+// so an unparameterised call keeps ADR-0013's default-deny isolation; a caller
+// that wants the ADR-0014 permissive first-delivery profile, or a single knob
+// turned on, passes it explicitly. Throws on a platform whose sandbox is not
+// implemented — the caller must not fall back to launching the guest unconfined.
 export function osSandboxCommand(
   command: string,
   args: readonly string[] = [],
+  profile: SandboxProfile = { base: 'restrictive' },
 ): SandboxedCommand {
+  const resolved = resolveProfile(profile);
   switch (platform()) {
     case 'darwin':
       return {
         command: 'sandbox-exec',
-        args: ['-p', MACOS_SEATBELT_PROFILE, command, ...args],
+        args: ['-p', macosSeatbeltProfile(resolved), command, ...args],
       };
     case 'linux':
       if (!hasBwrap()) {
@@ -90,7 +140,7 @@ export function osSandboxCommand(
       }
       return {
         command: 'bwrap',
-        args: [...LINUX_BWRAP_ARGS, command, ...args],
+        args: [...linuxBwrapArgs(resolved), command, ...args],
       };
     default:
       throw new Error(

--- a/framework/api/src/capability/subprocess.ts
+++ b/framework/api/src/capability/subprocess.ts
@@ -15,7 +15,15 @@
 //   host  -> child  { "t": "result", "id": n, "ok": true,  "value" }
 //                   { "t": "result", "id": n, "ok": false, "error" }
 //   host  -> child  { "t": "event",  "callback": n, "args" }   (a bridged callback)
+//
+// Every frame crosses the relay serialized: this is the sandbox tier's defining
+// property (ADR-0014). A capability result is a copy, not a live handle — 64-bit
+// identifiers are emitted as decimal strings (bigintSafe), functions and typed
+// arrays do not survive JSON. The trusted co-resident tier keeps those by
+// reference; the relay deliberately does not.
 import { createInterface } from 'node:readline';
+
+import { bigintSafe } from './types';
 
 export type HostRequest = { cap: string; method: string; args: unknown[] };
 export type HostEvent = { callback: number; args: unknown[] };
@@ -43,7 +51,7 @@ export function serveSubprocessCapabilities(
   createHost: (emit: (event: HostEvent) => void) => RelayHost,
 ): SubprocessHost {
   const send = (msg: unknown): void => {
-    child.stdin.write(`${JSON.stringify(msg)}\n`);
+    child.stdin.write(`${JSON.stringify(msg, bigintSafe)}\n`);
   };
   const host = createHost((event) => send({ t: 'event', ...event }));
 

--- a/framework/core/docs/adr/ADR-0014-extension-execution-contract-uniform-capability-surface.md
+++ b/framework/core/docs/adr/ADR-0014-extension-execution-contract-uniform-capability-surface.md
@@ -1,6 +1,6 @@
 # ADR-0014: the extension execution contract — a uniform capability surface across trust tiers
 
-- Status: proposed
+- Status: accepted
 - Date: 2026-07-04
 - Category: (architecture) contract — the developer-facing execution surface for
   runtime extensions
@@ -169,14 +169,26 @@ must preserve.
   per-plane transport duplication the binding-less host removes, and it is where
   a tier-dependent surface creeps back in.
 
-## Next (implementation, follow-up)
+## First delivery — landed
 
-1. Assemble the binding-less guest host from the existing OS-sandbox launcher,
-   child-process transport, and guest proxy; add the missing Node child-side
-   guest proxy.
-2. Present the uniform asynchronous capability surface across tiers, with the
-   trusted tier short-circuiting in-process and returning handles by reference
-   to keep zero-copy.
-3. Author the permissive default-tier profile and run the interpreted forms on
-   macOS and Linux with no restriction, proving the contract before confinement
-   is layered on.
+The three steps below are delivered as the first cut, with the permissive
+default profile and no restriction applied:
+
+1. The binding-less guest host is assembled from the existing OS-sandbox
+   launcher, child-process transport, and guest proxy, and the missing Node
+   child-side guest proxy is added.
+2. The uniform asynchronous capability surface is presented across tiers; the
+   trusted tier short-circuits in-process and returns handles by reference, so
+   zero-copy is preserved under the uniform surface.
+3. The permissive default-tier profile is authored and the interpreted forms
+   (a JavaScript facet and a Python facet) run under it with no restriction on
+   macOS (Seatbelt) and Linux (bubblewrap), the same source unchanged in both
+   trust tiers. The restriction knobs are demonstrated on both platforms:
+   denying filesystem writes and denying the network narrow what the facet
+   reaches without re-adapting it — a refused write, a removed external
+   interface — never a withdrawn method.
+
+Follow-ups remain as recorded in the feasibility map and out-of-scope notes:
+the confinement profiles beyond the permissive default, the
+shadow-reconciliation layer, narrowed reads (Landlock on Linux, profile read
+rules on macOS), resource ceilings, and the native-compiled extension forms.

--- a/framework/core/src/python/kungfu/__init__.py
+++ b/framework/core/src/python/kungfu/__init__.py
@@ -3,15 +3,48 @@
 import json
 import os
 
-import pykungfu as __binding__
+# The native binding is imported lazily (PEP 562 module __getattr__) rather than
+# at package import. This lets the pure-stdlib capability guest
+# (kungfu.capability.guest) be imported in an OS-sandboxed child that has no
+# native binding — the binding-less guest the runtime-plane trust boundary
+# requires (ADR-0013 / ADR-0014). Any consumer that touches kungfu.__binding__,
+# kungfu.__version__ or kungfu.__build_info__ still resolves the binding on first
+# use, exactly where it did before; only the paths that never touch it (the guest
+# proxy) no longer pull it in.
 
-with open(
-    os.path.join(os.path.dirname(__binding__.__file__), "kungfubuildinfo.json"),
-    "r",
-) as build_info_file:
-    __build_info__ = json.load(build_info_file)
+_binding = None
+_build_info = None
 
-__version__ = __build_info__["version"]
+
+def _load_binding():
+    global _binding
+    if _binding is None:
+        import pykungfu as binding
+
+        _binding = binding
+    return _binding
+
+
+def _load_build_info():
+    global _build_info
+    if _build_info is None:
+        binding = _load_binding()
+        with open(
+            os.path.join(os.path.dirname(binding.__file__), "kungfubuildinfo.json"),
+            "r",
+        ) as build_info_file:
+            _build_info = json.load(build_info_file)
+    return _build_info
+
+
+def __getattr__(name):
+    if name == "__binding__":
+        return _load_binding()
+    if name == "__build_info__":
+        return _load_build_info()
+    if name == "__version__":
+        return _load_build_info()["version"]
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def schema_data_path(module_file, name):
@@ -26,4 +59,4 @@ def schema_data_path(module_file, name):
     beside_module = os.path.join(os.path.dirname(module_file), name)
     if os.path.exists(beside_module):
         return beside_module
-    return os.path.join(os.path.dirname(__binding__.__file__), name)
+    return os.path.join(os.path.dirname(_load_binding().__file__), name)


### PR DESCRIPTION
Assemble the binding-less guest host into one uniform asynchronous capability surface across trust tiers: the trusted co-resident tier short-circuits in-process and keeps zero-copy by reference, the default tier runs in an OS sandbox and reaches the host over the stdio relay (serialized copies). Adds the missing Node child-side guest proxy, a permissive first-delivery profile with independent write/network restriction knobs, and serializes relay frames with the bigint rule. Verified on macOS (Seatbelt) and Linux (bubblewrap): a JavaScript and a Python facet run unchanged in both tiers, and the restriction knobs narrow what a facet reaches without re-adapting it. ADR-0014 accepted.