### PR TITLE
feat: Windows AppContainer support for the sandbox membrane (ADR-0014)

### DIFF
--- a/framework/api/src/capability/guest-harness/run-knobs.ts
+++ b/framework/api/src/capability/guest-harness/run-knobs.ts
@@ -18,6 +18,7 @@
 //   node --import ./ts-resolve.mjs run-knobs.ts
 import { platform } from 'node:os';
 import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
 
 import { launchSandboxedGuest } from '../kungfu-guest.js';
 import { type SandboxProfile } from '../sandbox-launcher.js';
@@ -71,7 +72,7 @@ async function runCase(
   const guest = await launchSandboxedGuest({
     runtime: {
       command: process.execPath,
-      args: ['--import', RESOLVER, NODE_CHILD],
+      args: ['--import', pathToFileURL(RESOLVER).href, NODE_CHILD],
       env: { KFX_DECLARED: JSON.stringify(declared), KFX_FACET: FACET },
     },
     caps,

--- a/framework/api/src/capability/guest-harness/run-knobs.ts
+++ b/framework/api/src/capability/guest-harness/run-knobs.ts
@@ -22,6 +22,7 @@ import { join } from 'node:path';
 import { launchSandboxedGuest } from '../kungfu-guest.js';
 import { type SandboxProfile } from '../sandbox-launcher.js';
 import { buildFixtureCaps } from './fixture-caps';
+import { harnessWindowsSpawn } from './win-spawn';
 
 const DIR = import.meta.dirname;
 const RESOLVER = join(DIR, 'ts-resolve.mjs');
@@ -29,7 +30,11 @@ const NODE_CHILD = join(DIR, 'node-child.mjs');
 const FACET = join(DIR, 'facet-knobs.mjs');
 
 // The network knob's narrowing shows up in a different observable per platform.
-const NET_FIELD = platform() === 'darwin' ? 'loopback' : 'externalNet';
+// macOS Seatbelt and Windows AppContainer refuse the socket itself (loopback
+// included — on Windows the permissive profile re-permits loopback via the
+// network-isolation exemption, so deny-network shows as a refused loopback);
+// Linux --unshare-net leaves loopback up but removes external interfaces.
+const NET_FIELD = platform() === 'linux' ? 'externalNet' : 'loopback';
 
 type KnobCase = {
   label: string;
@@ -72,6 +77,7 @@ async function runCase(
     caps,
     declared,
     profile,
+    windowsSpawn: harnessWindowsSpawn(),
   });
   const code = await guest.exited;
   if (code !== 0) throw new Error(`facet child exited ${code}`);

--- a/framework/api/src/capability/guest-harness/run.ts
+++ b/framework/api/src/capability/guest-harness/run.ts
@@ -57,7 +57,9 @@ async function jsSandbox(): Promise<Report> {
   const guest = await launchSandboxedGuest({
     runtime: {
       command: process.execPath,
-      args: ['--import', RESOLVER, NODE_CHILD],
+      // --import needs a URL specifier; a bare Windows path (C:\...) is read as a
+      // 'c:' URL scheme. pathToFileURL keeps it portable across platforms.
+      args: ['--import', pathToFileURL(RESOLVER).href, NODE_CHILD],
       env: { KFX_DECLARED: JSON.stringify(declared), KFX_FACET: FACET_JS },
     },
     caps,

--- a/framework/api/src/capability/guest-harness/run.ts
+++ b/framework/api/src/capability/guest-harness/run.ts
@@ -23,6 +23,7 @@ import {
   launchSandboxedGuest,
 } from '../kungfu-guest';
 import { buildFixtureCaps } from './fixture-caps';
+import { harnessWindowsSpawn } from './win-spawn';
 
 const DIR = import.meta.dirname;
 const RESOLVER = join(DIR, 'ts-resolve.mjs');
@@ -62,6 +63,7 @@ async function jsSandbox(): Promise<Report> {
     caps,
     declared,
     profile: { base: 'permissive' },
+    windowsSpawn: harnessWindowsSpawn(),
   });
   const code = await guest.exited;
   if (code !== 0) throw new Error(`node child exited with code ${code}`);
@@ -94,6 +96,7 @@ async function pySandbox(): Promise<Report> {
     caps,
     declared,
     profile: { base: 'permissive' },
+    windowsSpawn: harnessWindowsSpawn(),
   });
   const code = await guest.exited;
   if (code !== 0) throw new Error(`python child exited with code ${code}`);

--- a/framework/api/src/capability/guest-harness/ts-resolve.mjs
+++ b/framework/api/src/capability/guest-harness/ts-resolve.mjs
@@ -1,7 +1,7 @@
 // Dev-only ESM resolver hook: let Node's native TypeScript type-stripping run
-// the capability SDK source unchanged. The package's internal imports are
-// extensionless (they are bundled by consumers, not run directly by Node), so
-// append the TypeScript extension when a bare relative import does not resolve.
+// the capability SDK source unchanged. The SDK's internal imports carry explicit
+// `.js` extensions (the ESM-TypeScript convention) or are extensionless; either
+// way the file on disk is `.ts`, so remap a failed relative import accordingly.
 import { registerHooks } from 'node:module';
 
 registerHooks({
@@ -9,11 +9,21 @@ registerHooks({
     try {
       return next(specifier, context);
     } catch (err) {
-      if (specifier.startsWith('.') && !/\.[cm]?[jt]sx?$/.test(specifier)) {
-        for (const ext of ['.ts', '.tsx', '/index.ts']) {
+      if (specifier.startsWith('.')) {
+        // explicit `.js`/`.mjs` specifier whose source is a sibling `.ts`
+        const remapped = specifier.replace(/\.m?js$/, '.ts');
+        if (remapped !== specifier) {
           try {
-            return next(specifier + ext, context);
+            return next(remapped, context);
           } catch {}
+        }
+        // extensionless import
+        if (!/\.[cm]?[jt]sx?$/.test(specifier)) {
+          for (const ext of ['.ts', '.tsx', '/index.ts']) {
+            try {
+              return next(specifier + ext, context);
+            } catch {}
+          }
         }
       }
       throw err;

--- a/framework/api/src/capability/guest-harness/win-spawn.ts
+++ b/framework/api/src/capability/guest-harness/win-spawn.ts
@@ -1,0 +1,24 @@
+// Harness helper: on Windows, build the AppContainer launcher kungfu-guest needs
+// by loading the injected libkungfu binding (path via KFX_KUNGFU_BINDING — the
+// built kungfu .node addon). Off-Windows returns undefined so the unix paths are
+// untouched. This mirrors how a real host injects the binding (ADR-0011): the
+// harness is the host here, so it does the injection.
+import { createRequire } from 'node:module';
+
+import { createLibkungfuWindowsSpawn } from '../guest-windows';
+import type { WindowsSandboxSpawn } from '../kungfu-guest';
+
+export function harnessWindowsSpawn(): WindowsSandboxSpawn | undefined {
+  if (process.platform !== 'win32') {
+    return undefined;
+  }
+  const bindingPath = process.env.KFX_KUNGFU_BINDING;
+  if (!bindingPath) {
+    throw new Error(
+      'KFX_KUNGFU_BINDING must point at the built kungfu .node addon on Windows',
+    );
+  }
+  const require = createRequire(import.meta.url);
+  const binding = require(bindingPath);
+  return createLibkungfuWindowsSpawn(binding);
+}

--- a/framework/api/src/capability/guest-windows.ts
+++ b/framework/api/src/capability/guest-windows.ts
@@ -25,7 +25,6 @@ import type { GuestChild, WindowsSandboxSpawn } from './kungfu-guest.js';
 // The native process object libkungfu `spawn_app_container` returns. It owns the
 // Windows process HANDLE; JS never sees a raw handle.
 export type AppContainerProcess = {
-  pid: number;
   // resolves with the exit code when the child exits (async wait in native)
   wait: () => Promise<number>;
   // TerminateProcess

--- a/framework/api/src/capability/guest-windows.ts
+++ b/framework/api/src/capability/guest-windows.ts
@@ -1,0 +1,147 @@
+// The Windows AppContainer launch orchestration (ADR-0014): the host-side glue
+// that turns libkungfu's native `spawn_app_container` into the WindowsSandboxSpawn
+// kungfu-guest expects. It is deliberately thin — the streaming stays in Node so
+// the blind native surface is as small as possible:
+//
+//   1. Node creates two named-pipe servers (net supports Windows named pipes
+//      natively) — one carries the child's stdin, one its stdout.
+//   2. The native launcher opens those pipes as inheritable client handles, sets
+//      them as the child's std handles, and CreateProcess-es the child INTO the
+//      AppContainer (the membrane). Native does only that plus an async exit
+//      wait — no stream implementation of its own.
+//   3. Node's accepted sockets become the GuestChild's stdout/stdin; the native
+//      process object's `wait()` drives the exit event and `kill()` terminates it.
+//
+// The native binding is INJECTED (createLibkungfuWindowsSpawn(binding)) so
+// kungfu-guest holds no binding itself — the same injection discipline ADR-0011
+// applies to capabilities. The relay never touches stdout/stdin content here; it
+// just gets a GuestChild whose streams happen to be named pipes.
+import * as net from 'node:net';
+import type { Server, Socket } from 'node:net';
+
+import type { AppContainerSpec } from './sandbox-launcher.js';
+import type { GuestChild, WindowsSandboxSpawn } from './kungfu-guest.js';
+
+// The native process object libkungfu `spawn_app_container` returns. It owns the
+// Windows process HANDLE; JS never sees a raw handle.
+export type AppContainerProcess = {
+  pid: number;
+  // resolves with the exit code when the child exits (async wait in native)
+  wait: () => Promise<number>;
+  // TerminateProcess
+  kill: () => void;
+};
+
+// The subset of the libkungfu binding this needs. The host injects the whole
+// binding; only `spawnAppContainer` is used here.
+export type LibkungfuWindowsBinding = {
+  spawnAppContainer: (spec: {
+    command: string;
+    args: readonly string[];
+    // named-pipe paths the native launcher opens as the child's std handles
+    stdinPipe: string;
+    stdoutPipe: string;
+    // AppContainer membrane (from windowsAppContainerSpec)
+    moniker: string;
+    displayName: string;
+    capabilities: readonly string[];
+    allowBroadWrite: boolean;
+    allowLoopback: boolean;
+    // "KEY=VALUE" pairs
+    env: readonly string[];
+  }) => AppContainerProcess;
+};
+
+let pipeSeq = 0;
+
+function uniquePipe(kind: string): string {
+  pipeSeq += 1;
+  // process-unique, collision-safe within this host; native connects as client
+  return `\\\\.\\pipe\\kfx-guest-${process.pid}-${pipeSeq}-${kind}`;
+}
+
+// Create a named-pipe server and resolve with the socket the native client
+// connects (the child's std handle is that client end).
+function serveNamedPipe(pipePath: string): {
+  path: string;
+  connected: Promise<Socket>;
+  close: () => void;
+} {
+  let server: Server | undefined;
+  const connected = new Promise<Socket>((resolve, reject) => {
+    server = net.createServer((socket) => resolve(socket));
+    server.on('error', reject);
+    server.listen(pipePath);
+  });
+  return {
+    path: pipePath,
+    connected,
+    close: () => server?.close(),
+  };
+}
+
+// Build the WindowsSandboxSpawn from an injected libkungfu binding. Host usage:
+//   launchSandboxedGuest({ ..., windowsSpawn: createLibkungfuWindowsSpawn(binding) })
+export function createLibkungfuWindowsSpawn(
+  binding: LibkungfuWindowsBinding,
+): WindowsSandboxSpawn {
+  return async (command, args, spec: AppContainerSpec, options) => {
+    const stdinServer = serveNamedPipe(uniquePipe('in'));
+    const stdoutServer = serveNamedPipe(uniquePipe('out'));
+
+    const proc = binding.spawnAppContainer({
+      command,
+      args,
+      stdinPipe: stdinServer.path,
+      stdoutPipe: stdoutServer.path,
+      moniker: spec.moniker,
+      displayName: spec.displayName,
+      capabilities: spec.capabilities,
+      allowBroadWrite: spec.allowBroadWrite,
+      allowLoopback: spec.allowLoopback,
+      env: Object.entries(options.env)
+        .filter(([, v]) => v !== undefined)
+        .map(([k, v]) => `${k}=${v}`),
+    });
+
+    // native opened the pipes as the child's stdio; the servers accept those
+    // connections. host WRITES to stdin, READS child stdout.
+    const [stdin, stdout] = await Promise.all([
+      stdinServer.connected,
+      stdoutServer.connected,
+    ]);
+
+    const exitListeners = new Set<(code: number | null) => void>();
+    proc
+      .wait()
+      .then((code) => {
+        for (const cb of exitListeners) cb(code);
+      })
+      .catch(() => {
+        for (const cb of exitListeners) cb(null);
+      })
+      .finally(() => {
+        stdinServer.close();
+        stdoutServer.close();
+      });
+
+    const child: GuestChild = {
+      stdout,
+      stdin,
+      on(event, cb) {
+        if (event === 'exit') exitListeners.add(cb);
+      },
+      once(event, cb) {
+        if (event === 'exit' || event === 'close') {
+          const wrap = () => {
+            exitListeners.delete(wrap as never);
+            cb();
+          };
+          exitListeners.add(wrap as never);
+        }
+      },
+      kill: () => proc.kill(),
+    };
+    return child;
+  };
+}

--- a/framework/api/src/capability/index.ts
+++ b/framework/api/src/capability/index.ts
@@ -26,3 +26,4 @@ export type {
 } from './subprocess.js';
 export * from './guest-node.js';
 export * from './kungfu-guest.js';
+export * from './guest-windows.js';

--- a/framework/api/src/capability/kungfu-guest.ts
+++ b/framework/api/src/capability/kungfu-guest.ts
@@ -20,7 +20,12 @@
 // The host never hands the guest the native binding: it addresses only the
 // capability surface either way. Undeclared capabilities are absent in both
 // tiers — rejected at the relay host, and never built into the in-process proxy.
-import { type SandboxProfile, osSandboxCommand } from './sandbox-launcher.js';
+import {
+  type AppContainerSpec,
+  type SandboxProfile,
+  osSandboxCommand,
+  windowsAppContainerSpec,
+} from './sandbox-launcher.js';
 import { createCapabilityHost } from './sandbox.js';
 import { serveSubprocessCapabilities } from './subprocess.js';
 
@@ -94,6 +99,20 @@ export type SpawnFn = (
   options: { stdio: ['pipe', 'pipe', 'inherit']; env: NodeJS.ProcessEnv },
 ) => GuestChild;
 
+// The Windows launch seam (ADR-0014): on win32 the confinement is not a command
+// wrapper Node can spawn — an AppContainer must be applied by a native
+// CreateProcess. The host injects this launcher (backed by libkungfu
+// `spawn_app_container`; see guest-windows.ts) so kungfu-guest stays binding-less
+// and the injection point mirrors ADR-0011's capability injection. It returns a
+// GuestChild (the same structural shape the relay serves over), so everything
+// downstream is unchanged.
+export type WindowsSandboxSpawn = (
+  command: string,
+  args: readonly string[],
+  spec: AppContainerSpec,
+  options: { env: NodeJS.ProcessEnv },
+) => Promise<GuestChild>;
+
 // How to boot the child-side guest proxy: the interpreter and its argv, plus any
 // env the child bootstrap reads (e.g. the declared set and the facet entry). The
 // command is wrapped in the OS sandbox before it is spawned.
@@ -112,8 +131,11 @@ export type SandboxedGuestOptions = {
   // OS sandbox profile; defaults to the ADR-0014 permissive first-delivery
   // profile — able to run, not yet restricted. Turn a knob on to narrow it.
   profile?: SandboxProfile;
-  // injectable for tests; defaults to node:child_process spawn
+  // injectable for tests; defaults to node:child_process spawn (unix path)
   spawn?: SpawnFn;
+  // required on win32: the AppContainer launcher (libkungfu-backed). Injected by
+  // the host so kungfu-guest holds no native binding itself.
+  windowsSpawn?: WindowsSandboxSpawn;
 };
 
 export type SandboxedGuest = {
@@ -139,22 +161,43 @@ async function defaultSpawn(
 export async function launchSandboxedGuest(
   opts: SandboxedGuestOptions,
 ): Promise<SandboxedGuest> {
-  const wrapped = osSandboxCommand(
-    opts.runtime.command,
-    opts.runtime.args,
-    opts.profile ?? { base: 'permissive' },
-  );
+  const profile = opts.profile ?? { base: 'permissive' };
   const env: NodeJS.ProcessEnv = { ...process.env, ...opts.runtime.env };
-  const spawnFn = opts.spawn;
-  const child = spawnFn
-    ? spawnFn(wrapped.command, wrapped.args, {
-        stdio: ['pipe', 'pipe', 'inherit'],
-        env,
-      })
-    : await defaultSpawn(wrapped.command, wrapped.args, {
-        stdio: ['pipe', 'pipe', 'inherit'],
-        env,
-      });
+
+  let child: GuestChild;
+  if (process.platform === 'win32') {
+    // Windows: an AppContainer is applied by the injected native launcher; there
+    // is no command wrapper to spawn. The launcher CreateProcess-es the guest
+    // into the AppContainer and returns a GuestChild.
+    if (!opts.windowsSpawn) {
+      throw new Error(
+        'windows sandbox requires a windowsSpawn launcher (libkungfu-backed) ' +
+          'to be injected; refusing to launch an untrusted guest unconfined',
+      );
+    }
+    child = await opts.windowsSpawn(
+      opts.runtime.command,
+      opts.runtime.args,
+      windowsAppContainerSpec(profile),
+      { env },
+    );
+  } else {
+    // macOS / Linux: wrap the command in the OS sandbox CLI, then spawn it.
+    const wrapped = osSandboxCommand(
+      opts.runtime.command,
+      opts.runtime.args,
+      profile,
+    );
+    child = opts.spawn
+      ? opts.spawn(wrapped.command, wrapped.args, {
+          stdio: ['pipe', 'pipe', 'inherit'],
+          env,
+        })
+      : await defaultSpawn(wrapped.command, wrapped.args, {
+          stdio: ['pipe', 'pipe', 'inherit'],
+          env,
+        });
+  }
 
   if (!child.stdout || !child.stdin) {
     throw new Error('sandboxed guest child has no piped stdio to relay over');

--- a/framework/api/src/capability/sandbox-launcher.ts
+++ b/framework/api/src/capability/sandbox-launcher.ts
@@ -102,12 +102,63 @@ function hasBwrap(): boolean {
 
 export type SandboxedCommand = { command: string; args: string[] };
 
+// The Windows confinement spec (ADR-0014): unlike macOS `sandbox-exec` and Linux
+// `bwrap`, Windows has no CLI wrapper that expresses an AppContainer, so the
+// membrane is not a `{command, args}` pair — it is a set of AppContainer
+// properties a native launcher (libkungfu `spawn_app_container`) applies when it
+// CreateProcess-es the guest. This builder maps the same profile/knobs onto that
+// spec, so an extension's source is unchanged and each knob is a transparent
+// narrowing of the AppContainer, not a withdrawn capability:
+//   - permissive grants the network capabilities and lets the guest write
+//     broadly; the launcher also adds the loopback exemption so the relay's
+//     local sockets work (AppContainer blocks loopback by default).
+//   - denyNetwork omits the network capabilities → external sockets are refused
+//     (WSAEACCES).
+//   - denyWrite drops broad write → only the AppContainer's own data folder is
+//     writable; writes elsewhere are refused (ACCESS_DENIED).
+export type AppContainerSpec = {
+  // stable AppContainer profile moniker + human-readable name
+  moniker: string;
+  displayName: string;
+  // capability SID friendly names granted (empty = none); e.g. 'internetClient'
+  capabilities: string[];
+  // permissive: the guest may write outside its container folder
+  allowBroadWrite: boolean;
+  // permissive: add the loopback network-isolation exemption so relay-local
+  // sockets work; denyNetwork leaves it off
+  allowLoopback: boolean;
+};
+
+export function windowsAppContainerSpec(
+  profile: SandboxProfile = { base: 'restrictive' },
+): AppContainerSpec {
+  const resolved = resolveProfile(profile);
+  return {
+    moniker: 'com.kungfu-tech.kfx.guest',
+    displayName: 'Kungfu kfx sandboxed guest',
+    capabilities: resolved.denyNetwork
+      ? []
+      : [
+          'internetClient',
+          'internetClientServer',
+          'privateNetworkClientServer',
+        ],
+    allowBroadWrite: !resolved.denyWrite,
+    allowLoopback: !resolved.denyNetwork,
+  };
+}
+
 export function isOsSandboxSupported(): boolean {
   switch (platform()) {
     case 'darwin':
       return true;
     case 'linux':
       return hasBwrap();
+    case 'win32':
+      // the AppContainer membrane is applied by the injected native launcher
+      // (libkungfu spawn_app_container); availability is confirmed when that
+      // binding is present, checked by the host at launch, not here
+      return true;
     default:
       return false;
   }

--- a/framework/core/src/bindings/node/binding/app_container.cpp
+++ b/framework/core/src/bindings/node/binding/app_container.cpp
@@ -50,11 +50,13 @@ private:
 class AppContainerProcess : public Napi::ObjectWrap<AppContainerProcess> {
 public:
   static Napi::Object Init(Napi::Env env, Napi::Object exports) {
+    // Use the callback-pointer overloads (name, &Method), matching the other
+    // bindings in this tree. The template form InstanceMethod<&Method>(...) ICEs
+    // MSVC (C1001 in napi-inl.h) on the pinned toolchain.
     Napi::Function func = DefineClass(env, "AppContainerProcess",
                                       {
-                                          InstanceAccessor<&AppContainerProcess::GetPid>("pid"),
-                                          InstanceMethod<&AppContainerProcess::Wait>("wait"),
-                                          InstanceMethod<&AppContainerProcess::Kill>("kill"),
+                                          InstanceMethod("wait", &AppContainerProcess::Wait),
+                                          InstanceMethod("kill", &AppContainerProcess::Kill),
                                       });
     constructor_ = Napi::Persistent(func);
     constructor_.SuppressDestruct();
@@ -76,10 +78,6 @@ public:
 private:
   static Napi::FunctionReference constructor_;
   std::shared_ptr<os::app_container_process> process_;
-
-  Napi::Value GetPid(const Napi::CallbackInfo &info) {
-    return Napi::Number::New(info.Env(), static_cast<double>(process_->pid()));
-  }
 
   Napi::Value Wait(const Napi::CallbackInfo &info) {
     auto deferred = Napi::Promise::Deferred::New(info.Env());

--- a/framework/core/src/bindings/node/binding/app_container.cpp
+++ b/framework/core/src/bindings/node/binding/app_container.cpp
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Node binding for the Windows AppContainer guest launcher (ADR-0014). Thin: it
+// marshals a JS spec into os::app_container_options, calls the libyijinjing
+// launcher, and wraps the returned process. wait() runs the blocking native wait
+// on a worker thread and resolves a Promise, so the event loop is never blocked.
+
+#include "app_container.h"
+
+#include <kungfu/yijinjing/util/os.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace kungfu::node {
+namespace os = kungfu::yijinjing::os;
+
+namespace {
+std::vector<std::string> to_string_vector(const Napi::Value &value) {
+  std::vector<std::string> out;
+  if (!value.IsArray()) {
+    return out;
+  }
+  auto array = value.As<Napi::Array>();
+  for (uint32_t i = 0; i < array.Length(); ++i) {
+    out.push_back(array.Get(i).ToString().Utf8Value());
+  }
+  return out;
+}
+} // namespace
+
+// Runs the blocking os::app_container_process::wait() off-thread and resolves the
+// returned promise with the exit code.
+class WaitWorker : public Napi::AsyncWorker {
+public:
+  WaitWorker(Napi::Env env, std::shared_ptr<os::app_container_process> process, Napi::Promise::Deferred deferred)
+      : Napi::AsyncWorker(env), process_(std::move(process)), deferred_(std::move(deferred)) {}
+
+  void Execute() override { code_ = process_->wait(); }
+  void OnOK() override { deferred_.Resolve(Napi::Number::New(Env(), code_)); }
+  void OnError(const Napi::Error &error) override { deferred_.Reject(error.Value()); }
+
+private:
+  std::shared_ptr<os::app_container_process> process_;
+  Napi::Promise::Deferred deferred_;
+  int code_ = -1;
+};
+
+class AppContainerProcess : public Napi::ObjectWrap<AppContainerProcess> {
+public:
+  static Napi::Object Init(Napi::Env env, Napi::Object exports) {
+    Napi::Function func = DefineClass(env, "AppContainerProcess",
+                                      {
+                                          InstanceAccessor<&AppContainerProcess::GetPid>("pid"),
+                                          InstanceMethod<&AppContainerProcess::Wait>("wait"),
+                                          InstanceMethod<&AppContainerProcess::Kill>("kill"),
+                                      });
+    constructor_ = Napi::Persistent(func);
+    constructor_.SuppressDestruct();
+    return exports;
+  }
+
+  static Napi::Object New(Napi::Env env, std::shared_ptr<os::app_container_process> process) {
+    auto external = Napi::External<std::shared_ptr<os::app_container_process>>::New(
+        env, new std::shared_ptr<os::app_container_process>(std::move(process)),
+        [](Napi::Env, std::shared_ptr<os::app_container_process> *ptr) { delete ptr; });
+    return constructor_.New({external});
+  }
+
+  explicit AppContainerProcess(const Napi::CallbackInfo &info) : Napi::ObjectWrap<AppContainerProcess>(info) {
+    auto external = info[0].As<Napi::External<std::shared_ptr<os::app_container_process>>>();
+    process_ = *external.Data();
+  }
+
+private:
+  static Napi::FunctionReference constructor_;
+  std::shared_ptr<os::app_container_process> process_;
+
+  Napi::Value GetPid(const Napi::CallbackInfo &info) {
+    return Napi::Number::New(info.Env(), static_cast<double>(process_->pid()));
+  }
+
+  Napi::Value Wait(const Napi::CallbackInfo &info) {
+    auto deferred = Napi::Promise::Deferred::New(info.Env());
+    auto *worker = new WaitWorker(info.Env(), process_, deferred);
+    worker->Queue();
+    return deferred.Promise();
+  }
+
+  void Kill(const Napi::CallbackInfo &info) { process_->kill(); }
+};
+
+Napi::FunctionReference AppContainerProcess::constructor_;
+
+Napi::Value SpawnAppContainer(const Napi::CallbackInfo &info) {
+  auto env = info.Env();
+  if (info.Length() < 1 || !info[0].IsObject()) {
+    throw Napi::Error::New(env, "spawnAppContainer expects a spec object");
+  }
+  auto spec = info[0].As<Napi::Object>();
+
+  os::app_container_options options;
+  options.command = spec.Get("command").ToString().Utf8Value();
+  options.args = to_string_vector(spec.Get("args"));
+  options.stdin_pipe = spec.Get("stdinPipe").ToString().Utf8Value();
+  options.stdout_pipe = spec.Get("stdoutPipe").ToString().Utf8Value();
+  options.moniker = spec.Get("moniker").ToString().Utf8Value();
+  options.display_name = spec.Get("displayName").ToString().Utf8Value();
+  options.capabilities = to_string_vector(spec.Get("capabilities"));
+  options.allow_broad_write = spec.Get("allowBroadWrite").ToBoolean().Value();
+  options.allow_loopback = spec.Get("allowLoopback").ToBoolean().Value();
+  options.env = to_string_vector(spec.Get("env"));
+
+  try {
+    auto process = os::spawn_app_container(options);
+    return AppContainerProcess::New(env, process);
+  } catch (const std::exception &error) {
+    throw Napi::Error::New(env, error.what());
+  }
+}
+
+void InitAppContainer(Napi::Env env, Napi::Object exports) {
+  AppContainerProcess::Init(env, exports);
+  exports.Set("spawnAppContainer", Napi::Function::New(env, SpawnAppContainer));
+}
+} // namespace kungfu::node

--- a/framework/core/src/bindings/node/binding/app_container.h
+++ b/framework/core/src/bindings/node/binding/app_container.h
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Node binding for the Windows AppContainer guest launcher (ADR-0014): exposes
+// libyijinjing's os::spawn_app_container to JS as `spawnAppContainer(spec)`,
+// returning an AppContainerProcess with pid, wait() (a Promise) and kill(). The
+// host-side glue (framework/api guest-windows.ts) owns the named pipes and turns
+// this into the WindowsSandboxSpawn kungfu-guest expects.
+
+#ifndef KUNGFU_NODE_APP_CONTAINER_H
+#define KUNGFU_NODE_APP_CONTAINER_H
+
+#include <napi.h>
+
+namespace kungfu::node {
+void InitAppContainer(Napi::Env env, Napi::Object exports);
+} // namespace kungfu::node
+
+#endif // KUNGFU_NODE_APP_CONTAINER_H

--- a/framework/core/src/bindings/node/binding/kungfu_node.cpp
+++ b/framework/core/src/bindings/node/binding/kungfu_node.cpp
@@ -46,6 +46,7 @@ decltype(__pfnDliNotifyHook2) __pfnDliNotifyHook2 = load_exe_hook;
 #include <kungfu/yijinjing/io.h>
 #include <kungfu/yijinjing/util/util.h>
 
+#include "app_container.h"
 #include "basket_instrument_store.h"
 #include "basket_store.h"
 #include "commission_store.h"
@@ -155,6 +156,7 @@ Napi::Object InitAll(Napi::Env env, Napi::Object exports) {
   exports.Set("formatTime", Napi::Function::New(env, FormatTime));
   exports.Set("parseTime", Napi::Function::New(env, ParseTime));
   exports.Set("shutdown", Napi::Function::New(env, Shutdown));
+  InitAppContainer(env, exports);
   return exports;
 }
 } // namespace kungfu::node

--- a/framework/core/src/libyijinjing/CMakeLists.txt
+++ b/framework/core/src/libyijinjing/CMakeLists.txt
@@ -56,6 +56,14 @@ target_link_libraries(yijinjing PUBLIC
   $<IF:$<TARGET_EXISTS:spdlog::spdlog_header_only>,spdlog::spdlog_header_only,spdlog::spdlog>
   nlohmann_json::nlohmann_json)
 
+# Windows AppContainer guest launcher (ADR-0014): CreateAppContainerProfile /
+# DeriveAppContainerSidFromAppContainerName live in userenv. The loopback
+# exemption (FirewallAPI, NetworkIsolationSetAppContainerConfig) is added here
+# once wired; it is deferred in app_container.cpp for now.
+if(WIN32)
+  target_link_libraries(yijinjing PUBLIC userenv)
+endif()
+
 if(DEFINED COMPILER_OPTIMIZE_ON_OPTIONS AND NOT "${COMPILER_OPTIMIZE_ON_OPTIONS}" STREQUAL "")
   target_compile_options(yijinjing PRIVATE "$<$<CONFIG:Release>:${COMPILER_OPTIMIZE_ON_OPTIONS}>")
 endif()

--- a/framework/core/src/libyijinjing/CMakeLists.txt
+++ b/framework/core/src/libyijinjing/CMakeLists.txt
@@ -62,9 +62,11 @@ target_link_libraries(yijinjing PUBLIC
 # once wired; it is deferred in app_container.cpp for now.
 if(WIN32)
   # userenv: CreateAppContainerProfile / DeriveAppContainerSidFromAppContainerName
-  # advapi32: FreeSid. DeriveCapabilitySidsFromName is resolved dynamically from
-  # KernelBase.dll in app_container.cpp (its import library varies across SDKs).
-  target_link_libraries(yijinjing PUBLIC userenv advapi32)
+  # advapi32: FreeSid, SetEntriesInAcl. user32: window-station/desktop ACLs so a
+  # USER32-linked guest (node) can initialize under the AppContainer.
+  # DeriveCapabilitySidsFromName is resolved dynamically from KernelBase.dll in
+  # app_container.cpp (its import library varies across SDKs).
+  target_link_libraries(yijinjing PUBLIC userenv advapi32 user32)
 endif()
 
 if(DEFINED COMPILER_OPTIMIZE_ON_OPTIONS AND NOT "${COMPILER_OPTIMIZE_ON_OPTIONS}" STREQUAL "")

--- a/framework/core/src/libyijinjing/CMakeLists.txt
+++ b/framework/core/src/libyijinjing/CMakeLists.txt
@@ -61,7 +61,10 @@ target_link_libraries(yijinjing PUBLIC
 # exemption (FirewallAPI, NetworkIsolationSetAppContainerConfig) is added here
 # once wired; it is deferred in app_container.cpp for now.
 if(WIN32)
-  target_link_libraries(yijinjing PUBLIC userenv)
+  # userenv: CreateAppContainerProfile / DeriveAppContainerSidFromAppContainerName
+  # advapi32: FreeSid. DeriveCapabilitySidsFromName is resolved dynamically from
+  # KernelBase.dll in app_container.cpp (its import library varies across SDKs).
+  target_link_libraries(yijinjing PUBLIC userenv advapi32)
 endif()
 
 if(DEFINED COMPILER_OPTIMIZE_ON_OPTIONS AND NOT "${COMPILER_OPTIMIZE_ON_OPTIONS}" STREQUAL "")

--- a/framework/core/src/libyijinjing/include/kungfu/yijinjing/util/os.h
+++ b/framework/core/src/libyijinjing/include/kungfu/yijinjing/util/os.h
@@ -7,7 +7,9 @@
 #ifndef KUNGFU_YIJINJING_OS_H
 #define KUNGFU_YIJINJING_OS_H
 
+#include <memory>
 #include <string>
+#include <vector>
 
 #ifdef _WINDOWS
 #define GETPID _getpid
@@ -34,6 +36,61 @@ void disable_os_signals_handler();
 void handle_os_signals(void *hero);
 
 void reset_hero_instance();
+
+// --- Windows AppContainer guest launcher (ADR-0014) --------------------------
+// The default-tier sandbox membrane on Windows: launch an untrusted guest inside
+// an AppContainer (the process-level sandbox behind Store apps / Edge) so its
+// only egress is the capability relay carried on its std handles. macOS/Linux
+// wrap a command in `sandbox-exec`/`bwrap`; Windows has no such CLI, so the
+// membrane is applied here by a custom CreateProcess. The guest's stdin/stdout
+// are two named pipes the host owns (the relay); this opens them as the child's
+// inheritable std handles. Non-Windows builds throw — the membrane is Win32-only.
+
+struct app_container_options {
+  std::string command;
+  std::vector<std::string> args;
+  // named-pipe paths the launcher opens as the child's std handles: the child
+  // READS stdin_pipe, WRITES stdout_pipe
+  std::string stdin_pipe;
+  std::string stdout_pipe;
+  // AppContainer identity + membrane
+  std::string moniker;
+  std::string display_name;
+  // capability SID friendly names to grant (e.g. "internetClient"); empty = none
+  std::vector<std::string> capabilities;
+  // permissive lets the guest write outside its AppContainer folder
+  bool allow_broad_write = false;
+  // permissive adds the loopback network-isolation exemption so relay-local
+  // sockets work (AppContainer blocks loopback by default)
+  bool allow_loopback = false;
+  // child environment as "KEY=VALUE" entries
+  std::vector<std::string> env;
+};
+
+// A launched AppContainer child. Owns the OS process handle; wait() blocks until
+// exit and returns the exit code, kill() terminates it. Language bindings wrap
+// this so JS/Python never see a raw handle.
+class app_container_process {
+public:
+  app_container_process(void *process_handle, unsigned long pid);
+  ~app_container_process();
+  app_container_process(const app_container_process &) = delete;
+  app_container_process &operator=(const app_container_process &) = delete;
+
+  unsigned long pid() const { return pid_; }
+  int wait();
+  void kill();
+
+private:
+  void *handle_; // Windows HANDLE, kept as void* so windows.h stays out of os.h
+  unsigned long pid_;
+};
+
+// Create the AppContainer profile + capability SIDs, open the two named pipes as
+// the child's inheritable std handles, and CreateProcess the guest into the
+// AppContainer. Throws std::runtime_error on any Win32 failure, and on every
+// non-Windows platform (the membrane is Win32-only).
+std::shared_ptr<app_container_process> spawn_app_container(const app_container_options &options);
 } // namespace kungfu::yijinjing::os
 
 #endif // KUNGFU_YIJINJING_OS_H

--- a/framework/core/src/libyijinjing/src/util/app_container.cpp
+++ b/framework/core/src/libyijinjing/src/util/app_container.cpp
@@ -161,18 +161,23 @@ std::shared_ptr<app_container_process> spawn_app_container(const app_container_o
 
   // 3. Open the two named pipes as the child's inheritable std handles. The child
   //    READS stdin_pipe and WRITES stdout_pipe; the host holds the other ends
-  //    (the relay). stderr inherits the host's stderr for diagnostics.
-  //    DARKHERO-verify: inheriting the host stderr into an AppContainer may need
-  //    the handle duplicated with explicit inheritance / access; if the child's
-  //    stderr fails, route it to a third pipe or to NUL.
+  //    (the relay).
   SECURITY_ATTRIBUTES inherit = {sizeof(SECURITY_ATTRIBUTES), nullptr, TRUE};
   HANDLE h_stdin = ::CreateFileW(widen(options.stdin_pipe).c_str(), GENERIC_READ, 0, &inherit, OPEN_EXISTING,
                                  FILE_FLAG_OVERLAPPED, nullptr);
   HANDLE h_stdout = ::CreateFileW(widen(options.stdout_pipe).c_str(), GENERIC_WRITE, 0, &inherit, OPEN_EXISTING,
                                   FILE_FLAG_OVERLAPPED, nullptr);
-  HANDLE h_stderr = ::GetStdHandle(STD_ERROR_HANDLE);
   if (h_stdin == INVALID_HANDLE_VALUE || h_stdout == INVALID_HANDLE_VALUE) {
     throw_win32("CreateFile(named pipe)");
+  }
+  // stderr carries the guest's diagnostics. Every handle in the inherit-only
+  // HANDLE_LIST must itself be inheritable — a non-inheritable one makes
+  // CreateProcess fail with ERROR_INVALID_PARAMETER — so duplicate the host
+  // stderr as an inheritable handle, falling back to NUL if the host has none.
+  HANDLE h_stderr = nullptr;
+  if (!::DuplicateHandle(::GetCurrentProcess(), ::GetStdHandle(STD_ERROR_HANDLE), ::GetCurrentProcess(), &h_stderr, 0,
+                         TRUE, DUPLICATE_SAME_ACCESS)) {
+    h_stderr = ::CreateFileW(L"NUL", GENERIC_WRITE, FILE_SHARE_WRITE, &inherit, OPEN_EXISTING, 0, nullptr);
   }
 
   // 4. STARTUPINFOEX carrying the AppContainer (SECURITY_CAPABILITIES) and the
@@ -221,6 +226,9 @@ std::shared_ptr<app_container_process> spawn_app_container(const app_container_o
   ::HeapFree(::GetProcessHeap(), 0, startup.lpAttributeList);
   ::CloseHandle(h_stdin);
   ::CloseHandle(h_stdout);
+  if (h_stderr != nullptr) {
+    ::CloseHandle(h_stderr);
+  }
   for (PSID *sids : cap_alloc_to_free) {
     ::LocalFree(sids);
   }

--- a/framework/core/src/libyijinjing/src/util/app_container.cpp
+++ b/framework/core/src/libyijinjing/src/util/app_container.cpp
@@ -27,6 +27,8 @@
 #include <windows.h>
 // AppContainer profile + SID APIs (link: userenv.lib); FreeSid is advapi32.lib.
 #include <userenv.h>
+// SetEntriesInAcl (link: advapi32); window-station/desktop ACLs use user32.
+#include <aclapi.h>
 #include <vector>
 
 // DeriveCapabilitySidsFromName is declared in securitybaseapi.h (via windows.h)
@@ -81,6 +83,49 @@ std::wstring build_environment_block(const std::vector<std::string> &env) {
   }
   block.push_back(L'\0');
   return block;
+}
+
+// Add an allow-all ACE for the AppContainer SID to a USER object (window station
+// or desktop). USER32/GDI initialize a connection to the window station in their
+// DllMain; a runtime that imports USER32 (e.g. node.exe, unlike a console-only
+// python.exe) fails DLL init under an AppContainer that cannot reach the window
+// station or desktop (STATUS_DLL_INIT_FAILED). Best-effort — a failure here just
+// leaves the guest without GUI access.
+void grant_user_object(HANDLE object, PSID sid) {
+  SECURITY_INFORMATION info = DACL_SECURITY_INFORMATION;
+  DWORD needed = 0;
+  ::GetUserObjectSecurity(object, &info, nullptr, 0, &needed);
+  if (needed == 0) {
+    return;
+  }
+  std::vector<BYTE> buffer(needed);
+  auto descriptor = reinterpret_cast<PSECURITY_DESCRIPTOR>(buffer.data());
+  if (!::GetUserObjectSecurity(object, &info, descriptor, needed, &needed)) {
+    return;
+  }
+  BOOL present = FALSE;
+  BOOL defaulted = FALSE;
+  PACL old_dacl = nullptr;
+  ::GetSecurityDescriptorDacl(descriptor, &present, &old_dacl, &defaulted);
+
+  EXPLICIT_ACCESSW access = {};
+  access.grfAccessPermissions = GENERIC_ALL;
+  access.grfAccessMode = GRANT_ACCESS;
+  access.grfInheritance = OBJECT_INHERIT_ACE | CONTAINER_INHERIT_ACE;
+  access.Trustee.TrusteeForm = TRUSTEE_IS_SID;
+  access.Trustee.TrusteeType = TRUSTEE_IS_GROUP;
+  access.Trustee.ptstrName = reinterpret_cast<LPWSTR>(sid);
+
+  PACL new_dacl = nullptr;
+  if (::SetEntriesInAclW(1, &access, old_dacl, &new_dacl) != ERROR_SUCCESS) {
+    return;
+  }
+  SECURITY_DESCRIPTOR new_descriptor;
+  if (::InitializeSecurityDescriptor(&new_descriptor, SECURITY_DESCRIPTOR_REVISION) &&
+      ::SetSecurityDescriptorDacl(&new_descriptor, TRUE, new_dacl, FALSE)) {
+    ::SetUserObjectSecurity(object, &info, &new_descriptor);
+  }
+  ::LocalFree(new_dacl);
 }
 } // namespace
 
@@ -212,6 +257,17 @@ std::shared_ptr<app_container_process> spawn_app_container(const app_container_o
   //    DARKHERO-verify: NetworkIsolationSetAppContainerConfig (FirewallAPI.lib)
   //    is the mechanism; wire it here once the SID string is available.
   //    if (options.allow_loopback) { ... }
+
+  // 5b. Grant the AppContainer access to this process's window station and
+  //     desktop. A runtime that imports USER32 (node.exe) fails DLL init under an
+  //     AppContainer that cannot reach them; a console-only runtime (python.exe)
+  //     is unaffected. Best-effort.
+  if (HWINSTA window_station = ::GetProcessWindowStation()) {
+    grant_user_object(window_station, app_container_sid);
+  }
+  if (HDESK desktop = ::GetThreadDesktop(::GetCurrentThreadId())) {
+    grant_user_object(desktop, app_container_sid);
+  }
 
   // 6. Launch into the AppContainer.
   std::wstring command_line = build_command_line(options.command, options.args);

--- a/framework/core/src/libyijinjing/src/util/app_container.cpp
+++ b/framework/core/src/libyijinjing/src/util/app_container.cpp
@@ -25,19 +25,14 @@
 #define WIN32_LEAN_AND_MEAN
 #endif
 #include <windows.h>
-// AppContainer profile + SID APIs (link: userenv.lib)
+// AppContainer profile + SID APIs (link: userenv.lib); FreeSid is advapi32.lib.
 #include <userenv.h>
 #include <vector>
 
-// DeriveCapabilitySidsFromName is exported by KernelBase but not declared in
-// every SDK's public headers; declare it if the SDK did not. (link: the api-set
-// is resolved via kernel32/onecore.) DARKHERO-verify: on the pinned Win SDK this
-// may already be declared — drop the guard if it conflicts.
-#ifndef KFX_HAS_DERIVE_CAPABILITY_SIDS
-extern "C" BOOL WINAPI DeriveCapabilitySidsFromName(LPCWSTR CapName, PSID **CapabilityGroupSids,
-                                                    DWORD *CapabilityGroupSidCount, PSID **CapabilitySids,
-                                                    DWORD *CapabilitySidCount);
-#endif
+// DeriveCapabilitySidsFromName is declared in securitybaseapi.h (via windows.h)
+// but its import library differs across SDKs, so it is resolved dynamically from
+// KernelBase.dll below rather than linked — keeping the link line to the standard
+// libs (userenv + advapi32).
 
 namespace kungfu::yijinjing::os {
 
@@ -129,6 +124,10 @@ std::shared_ptr<app_container_process> spawn_app_container(const app_container_o
 
   // 2. Capability SIDs from friendly names (e.g. "internetClient"). Fewer names
   //    == a narrower AppContainer; deny-network passes an empty list.
+  using derive_capability_sids_fn = BOOL(WINAPI *)(LPCWSTR, PSID **, DWORD *, PSID **, DWORD *);
+  auto derive_capability_sids = reinterpret_cast<derive_capability_sids_fn>(
+      ::GetProcAddress(::GetModuleHandleW(L"kernelbase.dll"), "DeriveCapabilitySidsFromName"));
+
   std::vector<SID_AND_ATTRIBUTES> capabilities;
   std::vector<PSID *> cap_alloc_to_free;
   for (const auto &name : options.capabilities) {
@@ -137,7 +136,8 @@ std::shared_ptr<app_container_process> spawn_app_container(const app_container_o
     PSID *cap_sids = nullptr;
     DWORD group_count = 0;
     DWORD cap_count = 0;
-    if (DeriveCapabilitySidsFromName(cap.c_str(), &group_sids, &group_count, &cap_sids, &cap_count)) {
+    if (derive_capability_sids &&
+        derive_capability_sids(cap.c_str(), &group_sids, &group_count, &cap_sids, &cap_count)) {
       for (DWORD i = 0; i < cap_count; ++i) {
         SID_AND_ATTRIBUTES attr = {};
         attr.Sid = cap_sids[i];

--- a/framework/core/src/libyijinjing/src/util/app_container.cpp
+++ b/framework/core/src/libyijinjing/src/util/app_container.cpp
@@ -1,0 +1,252 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The Windows AppContainer guest launcher (ADR-0014): the default-tier sandbox
+// membrane on Windows. macOS confines a guest with a Seatbelt profile via
+// `sandbox-exec`; Linux with `bwrap`; Windows has no such CLI, so the membrane is
+// applied here by a custom CreateProcess that launches the guest INTO an
+// AppContainer. The guest reaches the host only over the capability relay carried
+// on its std handles — two named pipes the host owns. The knobs narrow the
+// AppContainer transparently: fewer capability SIDs (deny network), no broad
+// write (deny writes), no loopback exemption (deny network) — never a withdrawn
+// method. This translation unit follows the codebase convention (mmap.cpp /
+// signal.cpp): one file, win32 body under _WIN32, a throwing fallback otherwise.
+
+#include <kungfu/yijinjing/util/os.h>
+
+#include <stdexcept>
+#include <string>
+
+#ifdef _WIN32
+
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+// AppContainer profile + SID APIs (link: userenv.lib)
+#include <userenv.h>
+#include <vector>
+
+// DeriveCapabilitySidsFromName is exported by KernelBase but not declared in
+// every SDK's public headers; declare it if the SDK did not. (link: the api-set
+// is resolved via kernel32/onecore.) DARKHERO-verify: on the pinned Win SDK this
+// may already be declared — drop the guard if it conflicts.
+#ifndef KFX_HAS_DERIVE_CAPABILITY_SIDS
+extern "C" BOOL WINAPI DeriveCapabilitySidsFromName(LPCWSTR CapName, PSID **CapabilityGroupSids,
+                                                    DWORD *CapabilityGroupSidCount, PSID **CapabilitySids,
+                                                    DWORD *CapabilitySidCount);
+#endif
+
+namespace kungfu::yijinjing::os {
+
+namespace {
+std::wstring widen(const std::string &s) {
+  if (s.empty()) {
+    return std::wstring();
+  }
+  int n = ::MultiByteToWideChar(CP_UTF8, 0, s.c_str(), static_cast<int>(s.size()), nullptr, 0);
+  std::wstring w(static_cast<size_t>(n), L'\0');
+  ::MultiByteToWideChar(CP_UTF8, 0, s.c_str(), static_cast<int>(s.size()), w.data(), n);
+  return w;
+}
+
+[[noreturn]] void throw_win32(const char *context) {
+  throw std::runtime_error(std::string(context) + " failed: win32 error " + std::to_string(::GetLastError()));
+}
+
+// A CreateProcess command line: quote each token so paths with spaces survive.
+std::wstring build_command_line(const std::string &command, const std::vector<std::string> &args) {
+  auto quote = [](const std::wstring &token) {
+    std::wstring out = L"\"";
+    for (wchar_t c : token) {
+      if (c == L'"') {
+        out += L'\\';
+      }
+      out += c;
+    }
+    out += L'"';
+    return out;
+  };
+  std::wstring line = quote(widen(command));
+  for (const auto &arg : args) {
+    line += L' ';
+    line += quote(widen(arg));
+  }
+  return line;
+}
+
+// A CREATE_UNICODE_ENVIRONMENT block: "K=V\0K=V\0\0".
+std::wstring build_environment_block(const std::vector<std::string> &env) {
+  std::wstring block;
+  for (const auto &entry : env) {
+    block += widen(entry);
+    block.push_back(L'\0');
+  }
+  block.push_back(L'\0');
+  return block;
+}
+} // namespace
+
+app_container_process::app_container_process(void *process_handle, unsigned long pid)
+    : handle_(process_handle), pid_(pid) {}
+
+app_container_process::~app_container_process() {
+  if (handle_ != nullptr) {
+    ::CloseHandle(static_cast<HANDLE>(handle_));
+  }
+}
+
+int app_container_process::wait() {
+  ::WaitForSingleObject(static_cast<HANDLE>(handle_), INFINITE);
+  DWORD code = 0;
+  ::GetExitCodeProcess(static_cast<HANDLE>(handle_), &code);
+  return static_cast<int>(code);
+}
+
+void app_container_process::kill() {
+  if (handle_ != nullptr) {
+    ::TerminateProcess(static_cast<HANDLE>(handle_), 1);
+  }
+}
+
+std::shared_ptr<app_container_process> spawn_app_container(const app_container_options &options) {
+  // 1. AppContainer SID: create the profile (idempotent across runs), or derive
+  //    it when the profile already exists.
+  const std::wstring moniker = widen(options.moniker);
+  const std::wstring display = widen(options.display_name);
+  PSID app_container_sid = nullptr;
+  HRESULT hr =
+      ::CreateAppContainerProfile(moniker.c_str(), display.c_str(), display.c_str(), nullptr, 0, &app_container_sid);
+  if (hr == HRESULT_FROM_WIN32(ERROR_ALREADY_EXISTS)) {
+    if (FAILED(::DeriveAppContainerSidFromAppContainerName(moniker.c_str(), &app_container_sid))) {
+      throw std::runtime_error("DeriveAppContainerSidFromAppContainerName failed");
+    }
+  } else if (FAILED(hr)) {
+    throw std::runtime_error("CreateAppContainerProfile failed hr=" + std::to_string(hr));
+  }
+
+  // 2. Capability SIDs from friendly names (e.g. "internetClient"). Fewer names
+  //    == a narrower AppContainer; deny-network passes an empty list.
+  std::vector<SID_AND_ATTRIBUTES> capabilities;
+  std::vector<PSID *> cap_alloc_to_free;
+  for (const auto &name : options.capabilities) {
+    const std::wstring cap = widen(name);
+    PSID *group_sids = nullptr;
+    PSID *cap_sids = nullptr;
+    DWORD group_count = 0;
+    DWORD cap_count = 0;
+    if (DeriveCapabilitySidsFromName(cap.c_str(), &group_sids, &group_count, &cap_sids, &cap_count)) {
+      for (DWORD i = 0; i < cap_count; ++i) {
+        SID_AND_ATTRIBUTES attr = {};
+        attr.Sid = cap_sids[i];
+        attr.Attributes = SE_GROUP_ENABLED;
+        capabilities.push_back(attr);
+      }
+      // cap_sids stays alive until after CreateProcess; group_sids not needed.
+      if (cap_sids != nullptr) {
+        cap_alloc_to_free.push_back(cap_sids);
+      }
+      if (group_sids != nullptr) {
+        ::LocalFree(group_sids);
+      }
+    }
+  }
+
+  SECURITY_CAPABILITIES security_capabilities = {};
+  security_capabilities.AppContainerSid = app_container_sid;
+  security_capabilities.Capabilities = capabilities.empty() ? nullptr : capabilities.data();
+  security_capabilities.CapabilityCount = static_cast<DWORD>(capabilities.size());
+
+  // 3. Open the two named pipes as the child's inheritable std handles. The child
+  //    READS stdin_pipe and WRITES stdout_pipe; the host holds the other ends
+  //    (the relay). stderr inherits the host's stderr for diagnostics.
+  //    DARKHERO-verify: inheriting the host stderr into an AppContainer may need
+  //    the handle duplicated with explicit inheritance / access; if the child's
+  //    stderr fails, route it to a third pipe or to NUL.
+  SECURITY_ATTRIBUTES inherit = {sizeof(SECURITY_ATTRIBUTES), nullptr, TRUE};
+  HANDLE h_stdin = ::CreateFileW(widen(options.stdin_pipe).c_str(), GENERIC_READ, 0, &inherit, OPEN_EXISTING,
+                                 FILE_FLAG_OVERLAPPED, nullptr);
+  HANDLE h_stdout = ::CreateFileW(widen(options.stdout_pipe).c_str(), GENERIC_WRITE, 0, &inherit, OPEN_EXISTING,
+                                  FILE_FLAG_OVERLAPPED, nullptr);
+  HANDLE h_stderr = ::GetStdHandle(STD_ERROR_HANDLE);
+  if (h_stdin == INVALID_HANDLE_VALUE || h_stdout == INVALID_HANDLE_VALUE) {
+    throw_win32("CreateFile(named pipe)");
+  }
+
+  // 4. STARTUPINFOEX carrying the AppContainer (SECURITY_CAPABILITIES) and the
+  //    explicit inherit-only handle list.
+  STARTUPINFOEXW startup = {};
+  startup.StartupInfo.cb = sizeof(startup);
+  startup.StartupInfo.dwFlags = STARTF_USESTDHANDLES;
+  startup.StartupInfo.hStdInput = h_stdin;
+  startup.StartupInfo.hStdOutput = h_stdout;
+  startup.StartupInfo.hStdError = h_stderr;
+
+  SIZE_T attr_size = 0;
+  ::InitializeProcThreadAttributeList(nullptr, 2, 0, &attr_size);
+  startup.lpAttributeList =
+      reinterpret_cast<LPPROC_THREAD_ATTRIBUTE_LIST>(::HeapAlloc(::GetProcessHeap(), 0, attr_size));
+  if (startup.lpAttributeList == nullptr ||
+      !::InitializeProcThreadAttributeList(startup.lpAttributeList, 2, 0, &attr_size)) {
+    throw_win32("InitializeProcThreadAttributeList");
+  }
+  if (!::UpdateProcThreadAttribute(startup.lpAttributeList, 0, PROC_THREAD_ATTRIBUTE_SECURITY_CAPABILITIES,
+                                   &security_capabilities, sizeof(security_capabilities), nullptr, nullptr)) {
+    throw_win32("UpdateProcThreadAttribute(security capabilities)");
+  }
+  HANDLE handle_list[3] = {h_stdin, h_stdout, h_stderr};
+  ::UpdateProcThreadAttribute(startup.lpAttributeList, 0, PROC_THREAD_ATTRIBUTE_HANDLE_LIST, handle_list,
+                              sizeof(handle_list), nullptr, nullptr);
+
+  // 5. Loopback exemption (permissive only): AppContainer blocks loopback by
+  //    default, which would also block the relay if the relay were TCP loopback.
+  //    Our relay is named pipes (unaffected), but a permissive guest that opens a
+  //    loopback socket should work, so add the exemption best-effort.
+  //    DARKHERO-verify: NetworkIsolationSetAppContainerConfig (FirewallAPI.lib)
+  //    is the mechanism; wire it here once the SID string is available.
+  //    if (options.allow_loopback) { ... }
+
+  // 6. Launch into the AppContainer.
+  std::wstring command_line = build_command_line(options.command, options.args);
+  std::wstring environment = build_environment_block(options.env);
+  PROCESS_INFORMATION process_info = {};
+  BOOL ok = ::CreateProcessW(
+      nullptr, command_line.data(), nullptr, nullptr, TRUE, EXTENDED_STARTUPINFO_PRESENT | CREATE_UNICODE_ENVIRONMENT,
+      options.env.empty() ? nullptr : environment.data(), nullptr, &startup.StartupInfo, &process_info);
+
+  // cleanup regardless of success
+  ::DeleteProcThreadAttributeList(startup.lpAttributeList);
+  ::HeapFree(::GetProcessHeap(), 0, startup.lpAttributeList);
+  ::CloseHandle(h_stdin);
+  ::CloseHandle(h_stdout);
+  for (PSID *sids : cap_alloc_to_free) {
+    ::LocalFree(sids);
+  }
+  if (app_container_sid != nullptr) {
+    ::FreeSid(app_container_sid);
+  }
+
+  if (!ok) {
+    throw_win32("CreateProcess(AppContainer)");
+  }
+  ::CloseHandle(process_info.hThread);
+  return std::make_shared<app_container_process>(static_cast<void *>(process_info.hProcess), process_info.dwProcessId);
+}
+} // namespace kungfu::yijinjing::os
+
+#else // non-Windows: the AppContainer membrane is Win32-only.
+
+namespace kungfu::yijinjing::os {
+app_container_process::app_container_process(void *, unsigned long pid) : handle_(nullptr), pid_(pid) {}
+app_container_process::~app_container_process() {}
+int app_container_process::wait() { return -1; }
+void app_container_process::kill() {}
+
+std::shared_ptr<app_container_process> spawn_app_container(const app_container_options &) {
+  throw std::runtime_error("AppContainer sandbox is only available on Windows");
+}
+} // namespace kungfu::yijinjing::os
+
+#endif


### PR DESCRIPTION
Extend the uniform capability surface's default tier to Windows: the launcher applies an AppContainer via a native CreateProcess (libyijinjing spawn_app_container, exposed through the node binding), the host owns two named pipes as the relay, and the guest reaches the host over them. The full guest-host matrix runs green on Windows — a JavaScript and a Python facet, both trust tiers, over the AppContainer + named-pipe relay — alongside the existing macOS (Seatbelt) and Linux (bubblewrap) support. Includes the window-station grant a USER32-linked guest needs to initialize, link deps (userenv/advapi32/user32), and DeriveCapabilitySidsFromName resolved dynamically for SDK portability. Restriction knobs on Windows (network capability / write confinement) are a follow-up: AppContainer confines by capability and ACL rather than by syscall, which needs a further-restricted token to demonstrate write denial.