### PR TITLE
refactor: rename the 'tui' command to 'cockpit'

### DIFF
--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -31,6 +31,7 @@ registered surface was touched.
 
 | Date | Action | Line | Faces | Class | Rationale | PR |
 |---|---|---|---|---|---|---|
+| 2026-07-05 | update | — | kungfu-cli | additive | Rename the terminal reference-surface command `kungfu tui` → `kungfu cockpit` (an operator surface: monitor + config + mission ops). The Ink renderer stays the `tui` substrate (`framework/tui`, `@kungfu-tech/tui`, `tui.mjs`, `Resources/tui`); only the command/experience name changes. Pre-release, no line open | — |
 | 2026-07-05 | update | — | kungfu-cli | additive | Fold the application-assembly SDK into the CLI as the `kungfu sdk` subcommand (was the standalone `kfs` command); extension/example builds now run `kungfu sdk kfx build`. Pre-release, no line open; `kfs` was never a registered surface | — |
 | 2026-07-04 | update | — | rewind-event-schema | additive | Append `ApprovalDecision` (msg_type 30009): human approve/deny/interrupt/resume decision recorded as a run fact, `SCHEMA_VERSION` 2→3. Tail-only, existing 30001-30008 untouched |
 | 2026-07-04 | update | — | rewind-event-schema | additive | Append `CostSnapshot` (msg_type 30008): normalized token/cost usage with attribution + confidence, `SCHEMA_VERSION` 1→2. Tail-only table, existing 30001-30007 untouched; old runs still decode through their own pinned `.bfbs` | — |

--- a/framework/core/src/python/kungfu/console/commands/__registry__.py
+++ b/framework/core/src/python/kungfu/console/commands/__registry__.py
@@ -2,7 +2,7 @@
 
 from . import engage
 from . import journal
-from . import tui
+from . import cockpit
 from . import trace
 from . import managed_run
 from . import rewind
@@ -15,7 +15,7 @@ from . import sdk
 __all__ = [
     "engage",
     "journal",
-    "tui",
+    "cockpit",
     "trace",
     "managed_run",
     "rewind",

--- a/framework/core/src/python/kungfu/console/commands/cockpit.py
+++ b/framework/core/src/python/kungfu/console/commands/cockpit.py
@@ -34,8 +34,9 @@ def _resolve_tui_entry():
 @kfc.command(help_priority=1)
 @click.argument("commands", nargs=-1, required=False)
 @kfc.pass_context()
-def tui(ctx, commands):
-    """Kungfu reference TUI (Ink) — the shell-native reference surface."""
+def cockpit(ctx, commands):
+    """Kungfu cockpit — the terminal operator surface: monitor and operate the
+    running system (rendered by the reference TUI, Ink)."""
     os.environ["KUNGFU_AS_VARIANT"] = "node"
     # Point the TUI at this runtime's binding directory so it loads
     # kungfu_node.node from the shipped runtime rather than resolving a

--- a/framework/core/src/python/kungfu/console/commands/sdk.py
+++ b/framework/core/src/python/kungfu/console/commands/sdk.py
@@ -2,8 +2,8 @@
 
 # `kungfu sdk` — the application assembly toolkit: scaffold apps and view
 # extensions, and build/clean kfx packages. It runs the SDK's Node CLI through
-# kungfu's own embedded Node runtime (libnode), the same bridge `kungfu tui`
-# uses — no separate node install. Unlike the TUI, the SDK is a plain Node
+# kungfu's own embedded Node runtime (libnode), the same bridge `kungfu cockpit`
+# uses — no separate node install. Unlike the cockpit, the SDK is a plain Node
 # program (esbuild + fs) that does not load the kungfu_node binding, so it needs
 # no runtime-home wiring.
 

--- a/framework/gui/electron-builder.yml
+++ b/framework/gui/electron-builder.yml
@@ -20,7 +20,7 @@ extraResources:
   - from: resources/cli
     to: cli
   # The Ink reference TUI, bundled to a single ES module and run through
-  # kungfu's embedded Node (libnode) via `kungfu tui`.
+  # kungfu's embedded Node (libnode) via `kungfu cockpit`.
   - from: ../tui/dist
     to: tui
 mac:

--- a/framework/spec/docs/handbooks/cli.md
+++ b/framework/spec/docs/handbooks/cli.md
@@ -47,7 +47,7 @@ kungfu rewind <subcommand>
 | `schema` | compile kfx FlatBuffers schemas into open-layer `.bfbs` (in-process, no flatc) |
 | `work` | manage work items: create, drive the lifecycle, and inspect state |
 | `kfx` | install, list and remove kfx packages for this home |
-| `tui` | open the reference TUI (Ink) |
+| `cockpit` | open the cockpit — the terminal operator surface (rendered by the reference TUI, Ink) |
 | `atlas` | Atlas repo integration surface |
 | `engage` | developer tooling (formatting and related helpers) |
 


### PR DESCRIPTION
Name the terminal reference surface by its experience: kungfu tui -> kungfu cockpit (an operator surface — monitor + config + mission ops). The Ink renderer stays the tui substrate (framework/tui, @kungfu-tech/tui, tui.mjs, Resources/tui); only the command/experience name changes. ~6 files, no package/dir/packaging changes.