### PR TITLE
fix(gui): ship a single core runtime in app bundle

### DIFF
--- a/framework/api/package.json
+++ b/framework/api/package.json
@@ -23,7 +23,6 @@
   },
   "dependencies": {
     "@fast-csv/format": "^4.3.5",
-    "@kungfu-tech/core": "workspace:*",
     "cfonts": "^2.10.0",
     "chalk": "^4.1.0",
     "dayjs-business-days": "^1.0.4",

--- a/framework/core/package.json
+++ b/framework/core/package.json
@@ -18,6 +18,11 @@
   "bin": {
     "kungfu": "lib/kungfu-cli.js"
   },
+  "files": [
+    "lib",
+    "dist/kungfu",
+    ".gyp/noop-install.js"
+  ],
   "config": {
     "build_type": "Release",
     "log_level": "trace",

--- a/framework/gui/electron-builder.yml
+++ b/framework/gui/electron-builder.yml
@@ -7,9 +7,15 @@ npmRebuild: false
 # Bake the frozen first-party manifest (ADR-0013) into dist/kungfu before it is
 # shipped to Resources/kungfu, so trust is granted by verifiable source.
 beforePack: ./scripts/before-pack.cjs
+afterPack: ./scripts/after-pack.cjs
 files:
   - out/**/*
   - package.json
+  - "!node_modules/@kungfu-tech/core{,/**}"
+  - "!node_modules/@kungfu-tech/**/node_modules/@kungfu-tech/core{,/**}"
+  - "!node_modules/@kungfu-tech/**/.venv{,/**}"
+  - "!node_modules/@kungfu-tech/**/build{,/**}"
+  - "!node_modules/@kungfu-tech/**/dist/kungfu{,/**}"
 extraResources:
   # Ship the kungfu runtime (libkungfu.dylib + kungfu_electron.node) so the
   # packaged app loads the binding from Resources/kungfu, matching its rpath.

--- a/framework/gui/package.json
+++ b/framework/gui/package.json
@@ -20,6 +20,7 @@
     "dev": "pnpm run ensure-electron && electron-vite dev",
     "build": "electron-vite build",
     "gen:first-party-manifest": "node --experimental-transform-types scripts/gen-first-party-manifest.mjs",
+    "audit:bundle": "node scripts/bundle-core-audit.cjs",
     "start": "pnpm run ensure-electron && electron-vite preview",
     "pack": "pnpm --filter @kungfu-tech/tui run bundle && pnpm run ensure-electron && electron-vite build && electron-builder --dir --config.electronDist=$(node -p \"require('path').dirname(require.resolve('electron'))+'/dist'\")",
     "dist": "pnpm --filter @kungfu-tech/tui run bundle && pnpm run ensure-electron && electron-vite build && electron-builder --config.electronDist=$(node -p \"require('path').dirname(require.resolve('electron'))+'/dist'\")",
@@ -27,13 +28,13 @@
   },
   "dependencies": {
     "@kungfu-tech/api": "workspace:*",
-    "@kungfu-tech/core": "workspace:*",
     "node-pty": "^1.1.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "@kungfu-tech/kfx": "workspace:*"
   },
   "devDependencies": {
+    "@kungfu-tech/core": "workspace:*",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react": "^4.3.1",

--- a/framework/gui/scripts/after-pack.cjs
+++ b/framework/gui/scripts/after-pack.cjs
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+// electron-builder afterPack hook: enforce that the app ships a single copy of
+// the frozen core runtime under Contents/Resources/kungfu.
+const {
+  auditPackagedApp,
+  findAppFromContext,
+} = require('./bundle-core-audit.cjs');
+
+exports.default = async function afterPack(context) {
+  if (context.electronPlatformName !== 'darwin') return;
+  auditPackagedApp(findAppFromContext(context), { prune: true });
+};

--- a/framework/gui/scripts/bundle-core-audit.cjs
+++ b/framework/gui/scripts/bundle-core-audit.cjs
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: Apache-2.0
+// Audit/prune the packaged Electron app so the frozen kungfu runtime is shipped
+// exactly once: Contents/Resources/kungfu. Workspace/package-manager layouts can
+// otherwise copy @kungfu-tech/core through nested app dependencies.
+const fs = require('node:fs');
+const path = require('node:path');
+
+function exists(p) {
+  return fs.existsSync(p);
+}
+
+function listDirs(root) {
+  if (!exists(root)) return [];
+  const dirs = [];
+  const stack = [root];
+  while (stack.length > 0) {
+    const dir = stack.pop();
+    dirs.push(dir);
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      if (entry.isDirectory()) stack.push(path.join(dir, entry.name));
+    }
+  }
+  return dirs;
+}
+
+function isScopedCoreDir(dir) {
+  return (
+    path.basename(dir) === 'core' &&
+    path.basename(path.dirname(dir)) === '@kungfu-tech'
+  );
+}
+
+function isUnderScopedCore(dir, appNodeModules) {
+  const rel = path.relative(appNodeModules, dir).split(path.sep);
+  for (let i = 0; i < rel.length - 1; i += 1) {
+    if (rel[i] === '@kungfu-tech' && rel[i + 1] === 'core') return true;
+  }
+  return false;
+}
+
+function findDefaultApp() {
+  const dist = path.join(__dirname, '..', 'dist');
+  if (!exists(dist)) return null;
+  const stack = [dist];
+  while (stack.length > 0) {
+    const dir = stack.pop();
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const p = path.join(dir, entry.name);
+      if (entry.isDirectory() && entry.name.endsWith('.app')) return p;
+      if (entry.isDirectory()) stack.push(p);
+    }
+  }
+  return null;
+}
+
+function findAppFromContext(context) {
+  const out = context.appOutDir;
+  const expected = path.join(
+    out,
+    `${context.packager.appInfo.productFilename}.app`,
+  );
+  if (exists(expected)) return expected;
+  const apps = fs
+    .readdirSync(out, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && entry.name.endsWith('.app'))
+    .map((entry) => path.join(out, entry.name));
+  if (apps.length === 1) return apps[0];
+  throw new Error(`could not resolve packaged .app under ${out}`);
+}
+
+function resolveExplicitApp(appArg) {
+  if (path.isAbsolute(appArg) || exists(appArg)) return appArg;
+  if (process.env.INIT_CWD) {
+    const fromInitialCwd = path.resolve(process.env.INIT_CWD, appArg);
+    if (exists(fromInitialCwd)) return fromInitialCwd;
+  }
+  return appArg;
+}
+
+function auditPackagedApp(appDir, options = {}) {
+  const prune = Boolean(options.prune);
+  const resources = path.join(appDir, 'Contents', 'Resources');
+  const runtimeDir = path.join(resources, 'kungfu');
+  const appNodeModules = path.join(resources, 'app', 'node_modules');
+
+  if (!exists(runtimeDir)) {
+    throw new Error(`missing bundled runtime directory: ${runtimeDir}`);
+  }
+  for (const required of [
+    'kungfu',
+    'kungfu_electron.node',
+    'libkungfu.dylib',
+  ]) {
+    const p = path.join(runtimeDir, required);
+    if (!exists(p)) throw new Error(`missing runtime file: ${p}`);
+  }
+
+  const dirs = listDirs(appNodeModules);
+  const duplicateCoreDirs = dirs.filter(isScopedCoreDir);
+  const duplicateRuntimeDirs = dirs.filter(
+    (dir) =>
+      path.basename(dir) === 'kungfu' &&
+      path.basename(path.dirname(dir)) === 'dist' &&
+      exists(path.join(dir, 'kungfu_electron.node')),
+  );
+  const devArtifactDirs = dirs.filter(
+    (dir) =>
+      isUnderScopedCore(dir, appNodeModules) &&
+      (path.basename(dir) === '.venv' || path.basename(dir) === 'build'),
+  );
+
+  const toRemove = [
+    ...duplicateCoreDirs,
+    ...duplicateRuntimeDirs,
+    ...devArtifactDirs,
+  ];
+  if (prune) {
+    for (const dir of [...new Set(toRemove)].sort(
+      (a, b) => b.length - a.length,
+    )) {
+      fs.rmSync(dir, { recursive: true, force: true });
+      console.log(`[bundle-core-audit] pruned ${dir}`);
+    }
+  }
+
+  const remainingDirs = listDirs(appNodeModules);
+  const remainingCore = remainingDirs.filter(isScopedCoreDir);
+  const remainingRuntime = remainingDirs.filter(
+    (dir) =>
+      path.basename(dir) === 'kungfu' &&
+      path.basename(path.dirname(dir)) === 'dist' &&
+      exists(path.join(dir, 'kungfu_electron.node')),
+  );
+  const remainingDev = remainingDirs.filter(
+    (dir) =>
+      isUnderScopedCore(dir, appNodeModules) &&
+      (path.basename(dir) === '.venv' || path.basename(dir) === 'build'),
+  );
+
+  const allRuntimeDirs = listDirs(resources).filter(
+    (dir) =>
+      exists(path.join(dir, 'kungfu_electron.node')) &&
+      exists(path.join(dir, 'libkungfu.dylib')),
+  );
+  const nonCanonicalRuntimeDirs = allRuntimeDirs.filter(
+    (dir) => path.resolve(dir) !== path.resolve(runtimeDir),
+  );
+
+  const failures = [];
+  if (remainingCore.length > 0) {
+    failures.push(
+      `duplicate @kungfu-tech/core package trees:\n${remainingCore.join('\n')}`,
+    );
+  }
+  if (remainingRuntime.length > 0) {
+    failures.push(
+      `duplicate dist/kungfu runtime trees:\n${remainingRuntime.join('\n')}`,
+    );
+  }
+  if (remainingDev.length > 0) {
+    failures.push(
+      `first-party dev artifact directories:\n${remainingDev.join('\n')}`,
+    );
+  }
+  if (nonCanonicalRuntimeDirs.length > 0) {
+    failures.push(
+      `runtime payload exists outside Contents/Resources/kungfu:\n${nonCanonicalRuntimeDirs.join('\n')}`,
+    );
+  }
+  if (failures.length > 0) {
+    throw new Error(failures.join('\n\n'));
+  }
+
+  console.log(`[bundle-core-audit] ok: single kungfu runtime at ${runtimeDir}`);
+}
+
+if (require.main === module) {
+  const args = process.argv.slice(2).filter((arg) => arg !== '--');
+  const prune = args.includes('--prune');
+  const explicit = args.find((arg) => arg !== '--prune');
+  const appDir = explicit ? resolveExplicitApp(explicit) : findDefaultApp();
+  if (!appDir) {
+    console.error(
+      'usage: node scripts/bundle-core-audit.cjs [--prune] <Kungfu.app>',
+    );
+    process.exit(2);
+  }
+  try {
+    auditPackagedApp(appDir, { prune });
+  } catch (e) {
+    console.error(`[bundle-core-audit] failed: ${e.message}`);
+    process.exit(1);
+  }
+}
+
+module.exports = { auditPackagedApp, findAppFromContext };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -256,9 +256,6 @@ importers:
       '@fast-csv/format':
         specifier: ^4.3.5
         version: 4.3.5
-      '@kungfu-tech/core':
-        specifier: workspace:*
-        version: link:../core
       cfonts:
         specifier: ^2.10.0
         version: 2.10.1
@@ -360,9 +357,6 @@ importers:
       '@kungfu-tech/api':
         specifier: workspace:*
         version: link:../api
-      '@kungfu-tech/core':
-        specifier: workspace:*
-        version: link:../core
       '@kungfu-tech/kfx':
         specifier: workspace:*
         version: link:../kfx
@@ -376,6 +370,9 @@ importers:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
     devDependencies:
+      '@kungfu-tech/core':
+        specifier: workspace:*
+        version: link:../core
       '@types/react':
         specifier: ^18.3.3
         version: 18.3.31


### PR DESCRIPTION
## Summary
- stop production packaging from copying workspace @kungfu-tech/core trees into the Electron app node_modules
- ship the frozen runtime only from Contents/Resources/kungfu
- add an afterPack bundle audit/prune hook and a manual audit:bundle command

## Validation
- ./kungfu-code build:core
- ./kungfu-code freeze
- ./kungfu-code package:app
- ./kungfu-code verify
- pnpm --filter @kungfu-tech/gui run audit:bundle -- framework/gui/dist/mac-arm64/Kungfu.app
- packaged CLI entries returned 4.0.0-alpha.0
- bounded GUI smoke loaded KFE_MAIN_OK

## Bundle Result
- Kungfu.app: 1.1G
- Contents/Resources/kungfu: 744M
- Contents/Resources/app: 32M
- duplicate @kungfu-tech/core package trees: 0
- .venv directories in app resources: 0
