### PR TITLE
docs(skill): anchor skills in accountable agent work

### DIFF
--- a/docs/skills.md
+++ b/docs/skills.md
@@ -1,8 +1,10 @@
 # Kungfu Skills
 
-Kungfu Skills are the agent-facing capability layer above kfx. A skill tells an
-agent when and how to act; kfx packages remain the governed runtime artifacts
-that execute UI, runtime facets, and future tool surfaces.
+Kungfu Skills are the agent-facing capability layer above kfx. A skill teaches
+Kungfu and the agent context how to manage, verify, explain, and govern a class
+of delegated agent work. It may guide agent actions, but action is not its root
+authority: kfx packages remain the governed runtime artifacts that execute UI,
+runtime facets, and future tool surfaces.
 
 This page is the design contract for the first Kungfu Skill surface. The
 architecture decision is [ADR-0015](../framework/core/docs/adr/ADR-0015-kungfu-skill-agent-context-layer.md).
@@ -32,6 +34,16 @@ SKILL.md -> catalog -> context envelope -> agent
 ```
 
 The agent sees skills. The runtime executes kfx.
+
+This distinction is load-bearing:
+
+```text
+Generic agent skills teach agents how to act.
+Kungfu Skills teach Kungfu how to make delegated agent work accountable.
+```
+
+A Kungfu Skill should therefore keep cost, state, proof, audit, and recovery in
+view even when it contains operational instructions for an agent.
 
 ## Minimal valid skill
 
@@ -305,6 +317,11 @@ Provenance should include source path or source URL, version, source hash, any
 packaged kfx artifact hashes, and the generated catalog hash. When Buildchain
 provenance is available, the skill record should carry the build passport or
 release reference rather than inventing a parallel trust story.
+
+Audit is part of the work fact model, not a loose application log. Skill
+advertisement, full instruction loading, dependency invocation, and trust
+refusal should be recordable by the journal-backed responsibility layer so a
+later user or agent can explain why a skill influenced a work decision.
 
 ## First implementation slice
 

--- a/framework/core/docs/adr/ADR-0015-kungfu-skill-agent-context-layer.md
+++ b/framework/core/docs/adr/ADR-0015-kungfu-skill-agent-context-layer.md
@@ -50,6 +50,11 @@ This creates two pressures:
 The design must preserve the kfx trust boundary while making skills first-class
 agent context objects.
 
+This ADR deliberately distinguishes Kungfu Skills from generic agent skills:
+generic agent skills teach agents how to act; Kungfu Skills make delegated agent
+work accountable through catalog injection, audited loading, kfx trust
+boundaries, and journal-backed proof.
+
 ## Decision
 
 Model Kungfu Skill as the agent-facing capability layer above kfx.
@@ -80,6 +85,8 @@ Kungfu must support two manage modes over the same schemas:
 Both managers discover installed skills, filter them for the session, generate
 the same compact catalog, inject the same context envelope shape, expose the
 same on-demand `kungfu.skill.read` operation, and write the same audit events.
+Those audit events are part of the responsibility trail for the delegated work,
+not merely debug logs for the skill subsystem.
 
 The shared contract home is:
 
@@ -99,6 +106,8 @@ Python under `framework/core/src/python/kungfu/skill`, Node/Electron under
   instruction-only by default and receives no runtime privilege.
 - The agent sees a compact skill catalog first, not every full `SKILL.md`.
   Loading full instructions is explicit, on demand, and audited.
+- The skill layer is accountability-first. It may guide actions, but its root
+  purpose is to help Kungfu explain, verify, recover, and govern delegated work.
 - A skill can depend on multiple kfx packages without copying them per skill.
   Dependencies install into the normal kfx registry and are shared by key.
 - Removing a skill does not remove shared kfx dependencies unless a separate


### PR DESCRIPTION
## Summary
- Anchor Kungfu Skills in accountable delegated agent work, not generic action-first agent skills.
- Clarify that skill audit events belong to the responsibility trail / journal-backed proof model.
- Keep the existing Skill -> catalog -> context envelope -> KFX trust gate architecture unchanged.

## Verification
- git diff --check
- git show --check HEAD

## Risk
- Documentation-only change.
