### PR TITLE
feat(skill): add first Kungfu Skill CLI slice

### DIFF
--- a/developer/sdk/src/sdk.js
+++ b/developer/sdk/src/sdk.js
@@ -28,6 +28,7 @@ function usage(code) {
     [
       'usage: kungfu sdk create app <directory> [options]',
       '       kungfu sdk create extension <directory> [options]',
+      '       kungfu sdk create skill <directory> [options]',
       '       kungfu sdk kfx build | clean',
       '',
       'create options:',
@@ -45,6 +46,10 @@ function usage(code) {
       'package with a CMakeLists.txt — CMake via the core conan toolchain), and',
       'Python AOT extensions (kungfuBuild.python — engage pdm install + engage',
       'nuitka --module), each producing a native module under dist/.',
+      '',
+      'create skill scaffolds the minimum valid Kungfu Skill source: a directory',
+      'containing only SKILL.md. It is instruction-only until it explicitly',
+      'declares kfx dependencies or capabilities.',
       '',
     ].join('\n'),
   );
@@ -197,6 +202,34 @@ function createExtension(directory, options) {
       '  pnpm install   # or npm/yarn',
       '  pnpm build     # kungfu sdk kfx build -> dist/view/index.js',
       '  npm pack       # the tgz is the install unit: kungfu kfx install <tgz>',
+      '',
+    ].join('\n'),
+  );
+}
+
+/**
+ * Scaffold a minimum valid Kungfu Skill source into `directory`.
+ * @param {string | undefined} directory
+ * @param {CreateOptions} options
+ * @returns {void}
+ */
+function createSkill(directory, options) {
+  if (!directory) usage(1);
+  const targetDir = path.resolve(directory);
+  if (fs.existsSync(targetDir) && fs.readdirSync(targetDir).length > 0) {
+    fail(`target directory is not empty: ${targetDir}`);
+  }
+  const skillName = options.name || path.basename(targetDir);
+  scaffold('skill', targetDir, {
+    __SKILL_NAME__: skillName,
+  });
+  process.stdout.write(
+    [
+      `created ${skillName} at ${targetDir}`,
+      '',
+      'next steps:',
+      `  kungfu skill validate ${directory}`,
+      `  kungfu skill catalog --path ${directory} --json`,
       '',
     ].join('\n'),
   );
@@ -468,7 +501,8 @@ if (!command) usage(1);
 if (command === 'create') {
   if (kind === 'app') createApp(directory, options);
   else if (kind === 'extension') createExtension(directory, options);
-  else fail(`unknown target: ${kind} (supported: app, extension)`);
+  else if (kind === 'skill') createSkill(directory, options);
+  else fail(`unknown target: ${kind} (supported: app, extension, skill)`);
 } else if (command === 'kfx') {
   if (kind === 'build') await kfxBuild();
   else if (kind === 'clean') kfxClean();

--- a/developer/sdk/templates/skill/SKILL.md.tmpl
+++ b/developer/sdk/templates/skill/SKILL.md.tmpl
@@ -1,0 +1,7 @@
+# __SKILL_NAME__
+
+Describe when an agent should use this skill and what outcome it should produce.
+
+Keep the instructions specific enough that the agent can decide whether to load
+this skill from the compact catalog. Runtime privileges are not granted by this
+file; executable dependencies remain governed by the kfx trust gate.

--- a/docs/MAP.md
+++ b/docs/MAP.md
@@ -40,7 +40,7 @@ and the map routes a question to whichever doc answers it.
 | If kungfu itself misbehaves, how do I localize it? | [`debugging.md`](debugging.md) | verify | stable |
 | How do I record an agent run and find why it failed (Rewind)? | [`rewind.md`](rewind.md) | use | stable · pre-release install path |
 | How do I write an extension (`kfx`)? | [`extensions.md`](extensions.md) | use | stable · view kfx; runtime facets mid-migration |
-| How do I write an agent-facing Kungfu Skill? | [`skills.md`](skills.md) (design target; decided by ADR-0015) | use | draft |
+| How do I write an agent-facing Kungfu Skill? | [`skills.md`](skills.md) (first CLI slice; decided by ADR-0015) | use | draft |
 | What license, trademark, service-use, and provider-compliance boundaries apply? | [`../LICENSE-POLICY.md`](../LICENSE-POLICY.md) + [`../TRADEMARK.md`](../TRADEMARK.md) + [`../ACCEPTABLE_USE.md`](../ACCEPTABLE_USE.md) + [`../PROVIDER_COMPLIANCE.md`](../PROVIDER_COMPLIANCE.md) | use | stable |
 
 ## Also asking about

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -250,18 +250,20 @@ The first CLI should be explicit and inspectable:
 
 ```sh
 kungfu skill validate <path>
-kungfu skill install <path-or-package>
-kungfu skill list [--json]
-kungfu skill catalog [--profile <name>] [--json]
-kungfu skill read <key>
+kungfu skill install <path>
+kungfu skill list [--path <dir>] [--json]
+kungfu skill catalog [--path <dir>] [--json]
+kungfu skill context [--path <dir>] [--source cli|gui|test] [--manager python|node]
+kungfu skill read <key-or-path> [--path <dir>]
 kungfu skill explain <key-or-path>
-kungfu skill audit <key>
 ```
 
-`kungfu skill install` installs the skill source and any declared kfx
-dependencies, but it does not elevate runtime privileges. `catalog` is the exact
-agent-visible catalog before full skill loading. `read` is the same operation the
-agent tool uses, with the same audit semantics.
+`kungfu skill install` installs the skill source into the Kungfu home skill
+directory, but it does not elevate runtime privileges or install executable kfx
+dependencies in the first slice. `catalog` is the compact agent-visible catalog
+before full skill loading. `context` wraps that catalog in the same envelope
+shape used by Python and Node manage modes. `read` is the operation the agent
+tool uses to load the full `SKILL.md` after selection.
 
 The SDK may add:
 
@@ -308,15 +310,23 @@ release reference rather than inventing a parallel trust story.
 
 ## First implementation slice
 
-The first delivery should prove the context loop before broad execution:
+The first slice proves the context loop before broad execution:
 
 1. Accept `SKILL.md`-only directories as valid instruction-only skills.
 2. Add schema and fixtures under `framework/skill`.
-3. Implement equivalent Node and Python catalog builders over the same fixtures.
-4. Implement `kungfu skill validate/list/catalog/read/explain`.
-5. Inject compact catalogs from both Node and Python manager paths.
-6. Audit advertised and loaded skills.
-7. Display installed skills in a first-party `skill-manager` view.
+3. Implement TypeScript and Python catalog/context builders over the same
+   fixtures.
+4. Implement `kungfu skill validate/install/list/catalog/context/read/explain`.
+5. Generate compact catalogs and context envelopes from the Python CLI manager.
+6. Scaffold a minimal skill with only `SKILL.md` through the developer SDK.
+
+Follow-up slices should:
+
+1. Inject compact catalogs from the Node/Electron GUI manager path.
+2. Audit advertised and loaded skills.
+3. Bind declared kfx dependencies through the normal kfx registry without
+   copying them per skill.
+4. Display installed skills in a first-party `skill-manager` view.
 
 Out of scope for the first slice:
 
@@ -328,13 +338,18 @@ Out of scope for the first slice:
 
 ## Verified by
 
-This page is a design target. The implementation is not yet landed. When it
-lands, the minimum verification set should include:
+The first implementation slice is verified by:
 
-- a `SKILL.md`-only fixture accepted by both Node and Python validators;
-- Node and Python catalog output equivalence over shared fixtures;
-- CLI `catalog` output matching the context envelope injected into an agent run;
+- a `SKILL.md`-only fixture accepted by Python and TypeScript validators;
+- TypeScript and Python catalog/context output over shared fixtures;
+- frozen CLI `validate/catalog/context/read/explain` over shared fixtures;
+- a skill with two kfx declarations proving the skill object can reference
+  multiple kfx packages without granting runtime privilege.
+
+Follow-up verification should add:
+
+- Node/Electron agent injection receiving the same context envelope;
 - audit records for advertised and loaded skills;
-- a skill with two kfx dependencies proving dependency deduplication;
+- kfx dependency installation through the shared registry, with deduplication;
 - a third-party adapter dependency proving that skill composition does not bypass
   the existing runtime trust refusal.

--- a/framework/core/docs/adr/ADR-0015-kungfu-skill-agent-context-layer.md
+++ b/framework/core/docs/adr/ADR-0015-kungfu-skill-agent-context-layer.md
@@ -2,8 +2,10 @@
 
 - Status: accepted
 - Date: 2026-07-05
-- Implementation: not yet landed; this ADR pins the architecture and first
-  delivery target.
+- Implementation: first slice landed. `framework/skill`, the Python CLI manager,
+  shared fixtures/schemas, and SDK `SKILL.md` scaffolding are implemented;
+  GUI-manager wiring, audit persistence, and kfx dependency install binding
+  remain follow-up work.
 - Category: (architecture) agent capability model — skill discovery, context
   injection, and kfx composition
 - Subsystem: `framework/skill` (new shared skill contract), `framework/core`
@@ -111,7 +113,8 @@ Python under `framework/core/src/python/kungfu/skill`, Node/Electron under
 
 ## Repository layout
 
-The first implementation should land in these areas:
+The first implementation lands the shared contract, Python manager, and SDK
+scaffolding in these areas:
 
 ```text
 framework/skill/
@@ -135,12 +138,16 @@ framework/core/src/python/kungfu/skill/
 
 framework/core/src/python/kungfu/cli/commands/skill.py
 
+developer/sdk/templates/skill/
+```
+
+The planned Node/Electron manager and first-party GUI view remain in:
+
+```text
 framework/gui/src/main/skill-manager.ts
 framework/gui/src/main/skill-context.ts
 
 extensions/system/skill-manager/
-
-developer/sdk/templates/skill/
 ```
 
 The first implementation should not put the canonical skill contract inside
@@ -150,17 +157,25 @@ because both Python and Node managers must share the same semantics.
 
 ## First delivery
 
-The first delivery should be intentionally narrow:
+The first delivery is intentionally narrow:
 
 1. Accept `SKILL.md`-only directories as valid instruction-only skills.
 2. Define `skill`, `skill-catalog`, and `skill-context` schemas.
 3. Add shared fixtures for minimal and front-matter skills.
-4. Implement Node and Python catalog builders with fixture equivalence tests.
-5. Add `kungfu skill validate`, `list`, `catalog`, `read`, and `explain`.
-6. Let both Node and Python agent managers inject compact catalogs and expose
-   `kungfu.skill.read`.
-7. Write audit events for catalog advertisement and full skill loading.
-8. Add a first-party `skill-manager` view that shows installed skills, full
+4. Implement TypeScript and Python catalog/context builders over the same
+   fixtures.
+5. Add `kungfu skill validate`, `install`, `list`, `catalog`, `context`,
+   `read`, and `explain`.
+6. Let the Python manager generate compact catalogs and expose the
+   `kungfu.skill.read` contract.
+
+Follow-up deliveries should:
+
+1. Wire Node/Electron manager injection to the same catalog/context contract.
+2. Write audit events for catalog advertisement and full skill loading.
+3. Bind declared kfx dependencies through the normal kfx registry without
+   copying them per skill.
+4. Add a first-party `skill-manager` view that shows installed skills, full
    source, generated catalog, dependency state, trust/provenance and audit.
 
 Explicitly out of scope for the first delivery:
@@ -203,20 +218,24 @@ Explicitly out of scope for the first delivery:
 - Users may expect uninstalling a skill to remove its packaged dependencies.
   The product must make shared dependency ownership explicit and provide a
   separate orphan cleanup flow.
-- The first delivery proves context injection and audit, not arbitrary tool
-  execution. That limitation should stay visible in `docs/known-limits.md` if
-  the implementation lands before executable skill flows.
+- The first slice proves parsing, catalog/context generation, and frozen CLI
+  operation, not arbitrary tool execution or GUI-launched injection.
 
 ## Verification target
 
-When implemented, this decision is verified by:
+The first slice is verified by:
 
-- a `SKILL.md`-only fixture accepted by both Python and Node validators;
-- Python and Node catalog output equivalence over shared fixtures;
-- `kungfu skill catalog --json` matching the catalog injected into a CLI agent
-  session;
+- a `SKILL.md`-only fixture accepted by both Python and TypeScript validators;
+- Python and TypeScript catalog/context output over shared fixtures;
+- frozen `dist/kungfu/kungfu skill validate/catalog/context/read/explain`
+  commands over the shared fixtures;
+- a skill with two declared kfx dependencies proving skill metadata can compose
+  multiple kfx references without granting runtime privilege.
+
+Follow-up verification should add:
+
 - a GUI-launched agent session receiving the same envelope schema;
 - audit entries for advertised skills and on-demand full skill loading;
-- a skill with two kfx dependencies proving deduplicated install/binding;
+- deduplicated kfx install/binding through the kfx registry;
 - a third-party runtime facet dependency proving that skill composition does not
   bypass the existing runtime trust refusal.

--- a/framework/core/src/python/kungfu/cli/commands/__registry__.py
+++ b/framework/core/src/python/kungfu/cli/commands/__registry__.py
@@ -10,6 +10,7 @@ from . import schema
 from . import work
 from . import atlas
 from . import kfx
+from . import skill
 from . import sdk
 
 __all__ = [
@@ -23,5 +24,6 @@ __all__ = [
     "work",
     "atlas",
     "kfx",
+    "skill",
     "sdk",
 ]

--- a/framework/core/src/python/kungfu/cli/commands/skill.py
+++ b/framework/core/src/python/kungfu/cli/commands/skill.py
@@ -1,0 +1,197 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import os
+import shutil
+import sys
+
+import click
+
+from kungfu.cli.commands import PrioritizedCommandGroup, kfc
+from kungfu.skill import (
+    SkillError,
+    build_catalog,
+    build_context_envelope,
+    discover_skills,
+    find_skill,
+    parse_skill,
+    read_skill_markdown,
+)
+
+skill_command_context = kfc.pass_context()
+
+
+@kfc.group(
+    cls=PrioritizedCommandGroup,
+    help_priority=2,
+    help="manage Kungfu Skills and build agent context catalogs",
+)
+@click.help_option("-h", "--help")
+@kfc.pass_context()
+def skill(ctx):
+    pass
+
+
+def _json(data):
+    click.echo(json.dumps(data, indent=2, sort_keys=True))
+
+
+def _extra_paths(paths):
+    return [os.path.abspath(path) for path in paths]
+
+
+@skill.command(help="validate a Kungfu Skill source directory")
+@click.argument("path", type=click.Path(exists=True))
+@click.option("--json", "as_json", is_flag=True, help="machine-readable output")
+@skill_command_context
+def validate(ctx, path, as_json):
+    try:
+        parsed = parse_skill(path)
+    except SkillError as e:
+        if as_json:
+            _json({"ok": False, "error": str(e)})
+        else:
+            click.echo(f"[skill] invalid: {e}", err=True)
+        sys.exit(1)
+    if as_json:
+        _json({"ok": True, "skill": parsed})
+    else:
+        click.echo(
+            f"[skill] ok {parsed['key']} ({parsed['kind']}) "
+            f"from {parsed['source']['path']}"
+        )
+
+
+@skill.command(help="install a Kungfu Skill source directory into this home")
+@click.argument("source", type=click.Path(exists=True))
+@click.option("--force", is_flag=True, help="replace an existing skill install")
+@skill_command_context
+def install(ctx, source, force):
+    try:
+        parsed = parse_skill(source)
+    except SkillError as e:
+        click.echo(f"[skill] invalid: {e}", err=True)
+        sys.exit(1)
+    root = os.path.join(ctx.home, "skills")
+    dest = os.path.join(root, parsed["key"])
+    if os.path.exists(dest):
+        if not force:
+            click.echo(
+                f"[skill] {parsed['key']} is already installed "
+                "(use --force to replace)",
+                err=True,
+            )
+            sys.exit(1)
+        shutil.rmtree(dest)
+    os.makedirs(root, exist_ok=True)
+    shutil.copytree(source, dest)
+    click.echo(f"[skill] installed {parsed['key']} -> {dest}")
+
+
+@skill.command(name="list", help="list installed or path-provided Kungfu Skills")
+@click.option("--path", "paths", multiple=True, type=click.Path(exists=True))
+@click.option("--json", "as_json", is_flag=True, help="machine-readable output")
+@skill_command_context
+def list_skills(ctx, paths, as_json):
+    rows = discover_skills(ctx.home, _extra_paths(paths))
+    if as_json:
+        _json(rows)
+        return
+    if not rows:
+        click.echo(f"[skill] nothing found under {os.path.join(ctx.home, 'skills')}")
+        return
+    for row in rows:
+        click.echo(f"{row['key']}  {row['title']}  ({row['kind']})")
+
+
+@skill.command(help="print the compact agent-visible Kungfu Skill catalog")
+@click.option("--path", "paths", multiple=True, type=click.Path(exists=True))
+@click.option("--json", "as_json", is_flag=True, help="machine-readable output")
+@skill_command_context
+def catalog(ctx, paths, as_json):
+    data = build_catalog(discover_skills(ctx.home, _extra_paths(paths)))
+    if as_json:
+        _json(data)
+        return
+    if not data["skills"]:
+        click.echo("[skill] catalog is empty")
+        return
+    for row in data["skills"]:
+        triggers = ", ".join(row["triggers"]) if row["triggers"] else "manual"
+        click.echo(f"{row['key']}: {row['description']} [use: {triggers}]")
+
+
+@skill.command(help="print a skill context envelope for an agent invocation")
+@click.option("--path", "paths", multiple=True, type=click.Path(exists=True))
+@click.option("--source", default="cli", type=click.Choice(["cli", "gui", "test"]))
+@click.option("--manager", default="python", type=click.Choice(["python", "node"]))
+@click.option("--profile", default=None, type=str)
+@click.option("--agent", default=None, type=str)
+@click.option("--json", "as_json", is_flag=True, help="machine-readable output")
+@skill_command_context
+def context(ctx, paths, source, manager, profile, agent, as_json):
+    session = {"source": source, "manager": manager}
+    if profile:
+        session["profile"] = profile
+    if agent:
+        session["agent"] = agent
+    data = build_context_envelope(
+        build_catalog(discover_skills(ctx.home, _extra_paths(paths))),
+        session,
+    )
+    _json(data)
+
+
+@skill.command(help="load full SKILL.md by key or path")
+@click.argument("key_or_path", type=str)
+@click.option("--path", "paths", multiple=True, type=click.Path(exists=True))
+@click.option("--json", "as_json", is_flag=True, help="machine-readable output")
+@skill_command_context
+def read(ctx, key_or_path, paths, as_json):
+    try:
+        parsed, markdown = read_skill_markdown(
+            ctx.home, key_or_path, _extra_paths(paths)
+        )
+    except SkillError as e:
+        click.echo(f"[skill] {e}", err=True)
+        sys.exit(1)
+    if as_json:
+        _json({"skill": parsed, "markdown": markdown})
+    else:
+        click.echo(markdown, nl=False)
+
+
+@skill.command(help="explain a Kungfu Skill without granting runtime privileges")
+@click.argument("key_or_path", type=str)
+@click.option("--path", "paths", multiple=True, type=click.Path(exists=True))
+@click.option("--json", "as_json", is_flag=True, help="machine-readable output")
+@skill_command_context
+def explain(ctx, key_or_path, paths, as_json):
+    try:
+        parsed = find_skill(ctx.home, key_or_path, _extra_paths(paths))
+    except SkillError as e:
+        click.echo(f"[skill] {e}", err=True)
+        sys.exit(1)
+    explanation = {
+        "key": parsed["key"],
+        "title": parsed["title"],
+        "kind": parsed["kind"],
+        "sourceHash": parsed["source"]["hash"],
+        "runtimePrivilege": "none"
+        if parsed["kind"] == "instruction-only"
+        else "requested-via-kfx-trust-gate",
+        "kfx": parsed["kfx"],
+        "capabilities": parsed["capabilities"],
+        "trustBoundary": (
+            "Skill instructions do not elevate permissions. Any executable "
+            "dependency remains governed by the kfx trust gate."
+        ),
+    }
+    if as_json:
+        _json(explanation)
+        return
+    click.echo(f"{explanation['key']} — {explanation['title']}")
+    click.echo(f"kind: {explanation['kind']}")
+    click.echo(f"runtime privilege: {explanation['runtimePrivilege']}")
+    click.echo(f"source hash: {explanation['sourceHash']}")
+    click.echo(explanation["trustBoundary"])

--- a/framework/core/src/python/kungfu/skill/__init__.py
+++ b/framework/core/src/python/kungfu/skill/__init__.py
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from .catalog import build_catalog, catalog_entry
+from .context import build_context_envelope
+from .parser import SkillError, parse_skill
+from .registry import discover_skills, find_skill, read_skill_markdown, skill_roots
+
+__all__ = [
+    "SkillError",
+    "build_catalog",
+    "build_context_envelope",
+    "catalog_entry",
+    "discover_skills",
+    "find_skill",
+    "parse_skill",
+    "read_skill_markdown",
+    "skill_roots",
+]

--- a/framework/core/src/python/kungfu/skill/catalog.py
+++ b/framework/core/src/python/kungfu/skill/catalog.py
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: Apache-2.0
+
+
+def catalog_entry(skill):
+    return {
+        "key": skill["key"],
+        "title": skill["title"],
+        "description": skill["description"],
+        "kind": skill["kind"],
+        "triggers": list(skill.get("triggers", [])),
+        "capabilities": list(skill.get("capabilities", [])),
+        "kfx": list(skill.get("kfx", [])),
+        "loadPolicy": "on-demand",
+        "sourceHash": skill["source"]["hash"],
+    }
+
+
+def build_catalog(skills):
+    return {
+        "schema": "kungfu.skill-catalog/v1",
+        "skills": [catalog_entry(skill) for skill in skills],
+    }

--- a/framework/core/src/python/kungfu/skill/context.py
+++ b/framework/core/src/python/kungfu/skill/context.py
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import hashlib
+import json
+
+
+def build_context_envelope(catalog, session):
+    advertised = json.dumps(
+        catalog.get("skills", []),
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return {
+        "schema": "kungfu.skill-context/v1",
+        "session": dict(session),
+        "catalog": list(catalog.get("skills", [])),
+        "tools": [
+            {
+                "name": "kungfu.skill.read",
+                "description": "Load the full SKILL.md for a selected skill key.",
+            }
+        ],
+        "audit": {
+            "advertisedSkillsHash": "sha256:"
+            + hashlib.sha256(advertised.encode()).hexdigest(),
+        },
+    }

--- a/framework/core/src/python/kungfu/skill/parser.py
+++ b/framework/core/src/python/kungfu/skill/parser.py
@@ -1,0 +1,141 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import hashlib
+import os
+import re
+
+
+class SkillError(ValueError):
+    pass
+
+
+def parse_skill(skill_dir):
+    root = os.path.abspath(skill_dir)
+    if not os.path.isdir(root):
+        raise SkillError(f"skill path is not a directory: {skill_dir}")
+    skill_path = os.path.join(root, "SKILL.md")
+    if not os.path.isfile(skill_path):
+        raise SkillError(f"missing SKILL.md: {skill_path}")
+    with open(skill_path, encoding="utf-8") as f:
+        markdown = f.read()
+    frontmatter, body = _split_frontmatter(markdown)
+    title = _string(frontmatter.get("title")) or _first_heading(body)
+    title = title or os.path.basename(root)
+    description = _string(frontmatter.get("description")) or _first_paragraph(body)
+    capabilities = _string_list(frontmatter.get("capabilities"))
+    kfx = _kfx_dependencies(frontmatter.get("kfx"))
+    return {
+        "schema": "kungfu.skill/v1",
+        "key": _string(frontmatter.get("key"))
+        or _normalize_key(os.path.basename(root)),
+        "title": title,
+        "description": description or "",
+        "kind": "kfx-backed" if capabilities or kfx else "instruction-only",
+        "triggers": _string_list(frontmatter.get("triggers")),
+        "capabilities": capabilities,
+        "kfx": kfx,
+        "source": {
+            "path": skill_path,
+            "hash": "sha256:" + hashlib.sha256(markdown.encode()).hexdigest(),
+        },
+    }
+
+
+def _split_frontmatter(markdown):
+    if not markdown.startswith("---\n"):
+        return {}, markdown
+    end = markdown.find("\n---\n", 4)
+    if end < 0:
+        return {}, markdown
+    return _parse_simple_yaml(markdown[4:end]), markdown[end + 5 :]
+
+
+def _parse_simple_yaml(src):
+    root = {}
+    current_key = None
+    current_array = None
+    current_object = None
+    for raw in src.splitlines():
+        if not raw.strip() or raw.strip().startswith("#"):
+            continue
+        list_match = re.match(r"^  -\s+(.*)$", raw)
+        if list_match and current_key and current_array is not None:
+            value = list_match.group(1)
+            kv = re.match(r"^([A-Za-z0-9_.-]+):\s*(.*)$", value)
+            if kv:
+                current_object = {kv.group(1): _strip_quotes(kv.group(2))}
+                current_array.append(current_object)
+            else:
+                current_object = None
+                current_array.append(_strip_quotes(value))
+            continue
+        nested_match = re.match(r"^    ([A-Za-z0-9_.-]+):\s*(.*)$", raw)
+        if nested_match and current_object is not None:
+            current_object[nested_match.group(1)] = _strip_quotes(nested_match.group(2))
+            continue
+        scalar_match = re.match(r"^([A-Za-z0-9_.-]+):\s*(.*)$", raw)
+        if not scalar_match:
+            continue
+        current_key = scalar_match.group(1)
+        current_object = None
+        value = scalar_match.group(2)
+        if value == "":
+            current_array = []
+            root[current_key] = current_array
+        else:
+            current_array = None
+            root[current_key] = _strip_quotes(value)
+    return root
+
+
+def _first_heading(body):
+    for line in body.splitlines():
+        match = re.match(r"^#\s+(.+?)\s*$", line)
+        if match:
+            return match.group(1)
+    return None
+
+
+def _first_paragraph(body):
+    without_title = re.sub(r"^#\s+.+$", "", body, count=1, flags=re.MULTILINE)
+    for chunk in re.split(r"\n\s*\n", without_title):
+        paragraph = re.sub(r"\s+", " ", chunk).strip()
+        if paragraph:
+            return paragraph
+    return None
+
+
+def _normalize_key(value):
+    key = re.sub(r"[^a-z0-9_.-]+", "-", value.strip().lower())
+    key = key.strip("-")
+    return key or "skill"
+
+
+def _strip_quotes(value):
+    value = value.strip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
+        return value[1:-1]
+    return value
+
+
+def _string(value):
+    return value.strip() if isinstance(value, str) and value.strip() else None
+
+
+def _string_list(value):
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, str)]
+
+
+def _kfx_dependencies(value):
+    if not isinstance(value, list):
+        return []
+    rows = []
+    for item in value:
+        if not isinstance(item, dict) or not _string(item.get("key")):
+            continue
+        row = dict(item)
+        row["key"] = str(row["key"])
+        rows.append(row)
+    return rows

--- a/framework/core/src/python/kungfu/skill/registry.py
+++ b/framework/core/src/python/kungfu/skill/registry.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+
+from .parser import SkillError, parse_skill
+
+
+def skill_roots(home, extra_paths=None):
+    roots = []
+    env_path = os.environ.get("KF_SKILL_PATH")
+    if env_path:
+        roots.extend(path for path in env_path.split(os.pathsep) if path)
+    if extra_paths:
+        roots.extend(extra_paths)
+    roots.append(os.path.join(home, "skills"))
+    return roots
+
+
+def discover_skills(home, extra_paths=None):
+    rows = []
+    seen = set()
+    for root in skill_roots(home, extra_paths):
+        for skill_dir in _candidate_skill_dirs(root):
+            try:
+                skill = parse_skill(skill_dir)
+            except SkillError:
+                continue
+            if skill["key"] in seen:
+                continue
+            seen.add(skill["key"])
+            rows.append(skill)
+    return rows
+
+
+def find_skill(home, key_or_path, extra_paths=None):
+    if os.path.exists(key_or_path):
+        return parse_skill(key_or_path)
+    for skill in discover_skills(home, extra_paths):
+        if skill["key"] == key_or_path:
+            return skill
+    raise SkillError(f"skill not found: {key_or_path}")
+
+
+def read_skill_markdown(home, key_or_path, extra_paths=None):
+    skill = find_skill(home, key_or_path, extra_paths)
+    with open(skill["source"]["path"], encoding="utf-8") as f:
+        return skill, f.read()
+
+
+def _candidate_skill_dirs(root):
+    if not root or not os.path.exists(root):
+        return []
+    root = os.path.abspath(root)
+    if os.path.isfile(os.path.join(root, "SKILL.md")):
+        return [root]
+    if not os.path.isdir(root):
+        return []
+    rows = []
+    for name in sorted(os.listdir(root)):
+        path = os.path.join(root, name)
+        if os.path.isdir(path) and os.path.isfile(os.path.join(path, "SKILL.md")):
+            rows.append(path)
+    return rows

--- a/framework/core/tests/python/test_skill.py
+++ b/framework/core/tests/python/test_skill.py
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+
+from kungfu.skill import build_catalog, build_context_envelope, parse_skill
+
+
+def _repo_root():
+    return Path(__file__).resolve().parents[4]
+
+
+def _fixture(name):
+    return _repo_root() / "framework" / "skill" / "fixtures" / name
+
+
+def test_minimal_skill_is_instruction_only():
+    skill = parse_skill(_fixture("minimal"))
+
+    assert skill["schema"] == "kungfu.skill/v1"
+    assert skill["key"] == "minimal"
+    assert skill["title"] == "Trace Failure Investigator"
+    assert skill["kind"] == "instruction-only"
+    assert skill["capabilities"] == []
+    assert skill["kfx"] == []
+    assert skill["source"]["hash"].startswith("sha256:")
+
+
+def test_frontmatter_skill_declares_kfx_and_capabilities():
+    skill = parse_skill(_fixture("with-frontmatter"))
+
+    assert skill["key"] == "trace-failure-investigator"
+    assert skill["kind"] == "kfx-backed"
+    assert skill["triggers"] == ["trace failed", "replay failed"]
+    assert skill["capabilities"] == ["rewind", "ledger"]
+    assert [row["key"] for row in skill["kfx"]] == [
+        "rewind-inspector",
+        "journal-manager",
+    ]
+
+
+def test_catalog_and_context_envelope_are_compact():
+    skill = parse_skill(_fixture("minimal"))
+    catalog = build_catalog([skill])
+    envelope = build_context_envelope(
+        catalog,
+        {"source": "test", "manager": "python"},
+    )
+
+    assert catalog["schema"] == "kungfu.skill-catalog/v1"
+    assert catalog["skills"][0]["loadPolicy"] == "on-demand"
+    assert "source" not in catalog["skills"][0]
+    assert envelope["schema"] == "kungfu.skill-context/v1"
+    assert envelope["tools"][0]["name"] == "kungfu.skill.read"
+    assert envelope["audit"]["advertisedSkillsHash"].startswith("sha256:")

--- a/framework/skill/README.md
+++ b/framework/skill/README.md
@@ -1,0 +1,8 @@
+# Kungfu Skill Contract
+
+This package contains the shared schemas, fixtures, and TypeScript helpers for
+Kungfu Skills. A skill is the agent-facing capability object above kfx. The
+minimum valid source is a directory containing only `SKILL.md`.
+
+See [`../../docs/skills.md`](../../docs/skills.md) and
+[`../core/docs/adr/ADR-0015-kungfu-skill-agent-context-layer.md`](../core/docs/adr/ADR-0015-kungfu-skill-agent-context-layer.md).

--- a/framework/skill/fixtures/minimal/SKILL.md
+++ b/framework/skill/fixtures/minimal/SKILL.md
@@ -1,0 +1,7 @@
+# Trace Failure Investigator
+
+Help an agent inspect a failed trace run, identify likely failure layers, and
+produce a short audit note.
+
+Use this when a user asks why a Kungfu trace, replay, adapter, or journal write
+failed.

--- a/framework/skill/fixtures/with-frontmatter/SKILL.md
+++ b/framework/skill/fixtures/with-frontmatter/SKILL.md
@@ -1,0 +1,19 @@
+---
+key: trace-failure-investigator
+triggers:
+  - trace failed
+  - replay failed
+capabilities:
+  - rewind
+  - ledger
+kfx:
+  - key: rewind-inspector
+    role: trace-view
+  - key: journal-manager
+    role: evidence-view
+---
+
+# Trace Failure Investigator
+
+Help an agent inspect a failed trace run, identify likely failure layers, and
+produce a short audit note.

--- a/framework/skill/package.json
+++ b/framework/skill/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@kungfu-tech/skill",
+  "author": {
+    "name": "Kungfu",
+    "email": "info@kungfu.link"
+  },
+  "version": "4.0.0-alpha.0",
+  "description": "Kungfu Skill schemas and catalog/context helpers",
+  "license": "Apache-2.0",
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "repository": {
+    "url": "https://github.com/kungfu-systems/kungfu.git"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  },
+  "files": ["src", "schema", "fixtures", "README.md"],
+  "scripts": {
+    "build": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.6.0"
+  }
+}

--- a/framework/skill/schema/skill-catalog.schema.json
+++ b/framework/skill/schema/skill-catalog.schema.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "kungfu.skill-catalog/v1",
+  "title": "Kungfu Skill Catalog",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "skills"],
+  "properties": {
+    "schema": { "const": "kungfu.skill-catalog/v1" },
+    "skills": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "key",
+          "title",
+          "description",
+          "kind",
+          "triggers",
+          "capabilities",
+          "kfx",
+          "loadPolicy",
+          "sourceHash"
+        ],
+        "properties": {
+          "key": { "type": "string" },
+          "title": { "type": "string" },
+          "description": { "type": "string" },
+          "kind": { "enum": ["instruction-only", "kfx-backed"] },
+          "triggers": { "type": "array", "items": { "type": "string" } },
+          "capabilities": { "type": "array", "items": { "type": "string" } },
+          "kfx": { "type": "array" },
+          "loadPolicy": { "const": "on-demand" },
+          "sourceHash": { "type": "string", "pattern": "^sha256:" }
+        }
+      }
+    }
+  }
+}

--- a/framework/skill/schema/skill-context.schema.json
+++ b/framework/skill/schema/skill-context.schema.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "kungfu.skill-context/v1",
+  "title": "Kungfu Skill Context Envelope",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "session", "catalog", "tools", "audit"],
+  "properties": {
+    "schema": { "const": "kungfu.skill-context/v1" },
+    "session": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["source", "manager"],
+      "properties": {
+        "source": { "enum": ["gui", "cli", "test"] },
+        "manager": { "enum": ["node", "python"] },
+        "profile": { "type": "string" },
+        "agent": { "type": "string" }
+      }
+    },
+    "catalog": { "type": "array" },
+    "tools": { "type": "array" },
+    "audit": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["advertisedSkillsHash"],
+      "properties": {
+        "runId": { "type": "string" },
+        "advertisedSkillsHash": { "type": "string", "pattern": "^sha256:" }
+      }
+    }
+  }
+}

--- a/framework/skill/schema/skill.schema.json
+++ b/framework/skill/schema/skill.schema.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "kungfu.skill/v1",
+  "title": "Kungfu Skill Source Metadata",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "key", "title", "description", "kind", "source"],
+  "properties": {
+    "schema": { "const": "kungfu.skill/v1" },
+    "key": { "type": "string", "minLength": 1 },
+    "title": { "type": "string", "minLength": 1 },
+    "description": { "type": "string" },
+    "kind": { "enum": ["instruction-only", "kfx-backed"] },
+    "triggers": { "type": "array", "items": { "type": "string" } },
+    "capabilities": { "type": "array", "items": { "type": "string" } },
+    "kfx": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": ["key"],
+        "properties": {
+          "key": { "type": "string", "minLength": 1 },
+          "role": { "type": "string" },
+          "version": { "type": "string" },
+          "required": { "type": "boolean" }
+        }
+      }
+    },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "hash"],
+      "properties": {
+        "path": { "type": "string" },
+        "hash": { "type": "string", "pattern": "^sha256:" }
+      }
+    }
+  }
+}

--- a/framework/skill/src/index.ts
+++ b/framework/skill/src/index.ts
@@ -1,0 +1,269 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { createHash } from 'node:crypto';
+import { readFileSync, statSync } from 'node:fs';
+import { basename, join, resolve } from 'node:path';
+
+export type SkillKind = 'instruction-only' | 'kfx-backed';
+
+export interface SkillKfxDependency {
+  key: string;
+  role?: string;
+  version?: string;
+  required?: boolean;
+  [key: string]: unknown;
+}
+
+export interface SkillSource {
+  schema: 'kungfu.skill/v1';
+  key: string;
+  title: string;
+  description: string;
+  kind: SkillKind;
+  triggers: string[];
+  capabilities: string[];
+  kfx: SkillKfxDependency[];
+  source: {
+    path: string;
+    hash: string;
+  };
+}
+
+export interface SkillCatalogEntry {
+  key: string;
+  title: string;
+  description: string;
+  kind: SkillKind;
+  triggers: string[];
+  capabilities: string[];
+  kfx: SkillKfxDependency[];
+  loadPolicy: 'on-demand';
+  sourceHash: string;
+}
+
+export interface SkillCatalog {
+  schema: 'kungfu.skill-catalog/v1';
+  skills: SkillCatalogEntry[];
+}
+
+export interface SkillContextEnvelope {
+  schema: 'kungfu.skill-context/v1';
+  session: {
+    source: 'gui' | 'cli' | 'test';
+    manager: 'node' | 'python';
+    profile?: string;
+    agent?: string;
+    [key: string]: unknown;
+  };
+  catalog: SkillCatalogEntry[];
+  tools: Array<{ name: string; description: string }>;
+  audit: {
+    runId?: string;
+    advertisedSkillsHash: string;
+    [key: string]: unknown;
+  };
+}
+
+type Frontmatter = Record<string, unknown>;
+
+export function parseSkill(skillDir: string): SkillSource {
+  const root = resolve(skillDir);
+  if (!statSync(root).isDirectory()) {
+    throw new Error(`skill path is not a directory: ${skillDir}`);
+  }
+  const skillPath = join(root, 'SKILL.md');
+  const markdown = readFileSync(skillPath, 'utf8');
+  const { frontmatter, body } = splitFrontmatter(markdown);
+  const title =
+    stringValue(frontmatter.title) || firstHeading(body) || basename(root);
+  const description =
+    stringValue(frontmatter.description) || firstParagraph(body) || '';
+  const kfx = kfxDependencies(frontmatter.kfx);
+  const capabilities = stringList(frontmatter.capabilities);
+  return {
+    schema: 'kungfu.skill/v1',
+    key: stringValue(frontmatter.key) || normalizeKey(basename(root)),
+    title,
+    description,
+    kind: kfx.length || capabilities.length ? 'kfx-backed' : 'instruction-only',
+    triggers: stringList(frontmatter.triggers),
+    capabilities,
+    kfx,
+    source: {
+      path: skillPath,
+      hash: `sha256:${createHash('sha256').update(markdown).digest('hex')}`,
+    },
+  };
+}
+
+export function toCatalogEntry(skill: SkillSource): SkillCatalogEntry {
+  return {
+    key: skill.key,
+    title: skill.title,
+    description: skill.description,
+    kind: skill.kind,
+    triggers: skill.triggers,
+    capabilities: skill.capabilities,
+    kfx: skill.kfx,
+    loadPolicy: 'on-demand',
+    sourceHash: skill.source.hash,
+  };
+}
+
+export function buildCatalog(skills: SkillSource[]): SkillCatalog {
+  return {
+    schema: 'kungfu.skill-catalog/v1',
+    skills: skills.map(toCatalogEntry),
+  };
+}
+
+export function buildContextEnvelope(
+  catalog: SkillCatalog,
+  session: SkillContextEnvelope['session'],
+): SkillContextEnvelope {
+  const advertised = stableStringify(catalog.skills);
+  return {
+    schema: 'kungfu.skill-context/v1',
+    session,
+    catalog: catalog.skills,
+    tools: [
+      {
+        name: 'kungfu.skill.read',
+        description: 'Load the full SKILL.md for a selected skill key.',
+      },
+    ],
+    audit: {
+      advertisedSkillsHash: `sha256:${createHash('sha256')
+        .update(advertised)
+        .digest('hex')}`,
+    },
+  };
+}
+
+function stableStringify(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(',')}]`;
+  }
+  if (value && typeof value === 'object') {
+    const object = value as Record<string, unknown>;
+    return `{${Object.keys(object)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${stableStringify(object[key])}`)
+      .join(',')}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function splitFrontmatter(markdown: string): {
+  frontmatter: Frontmatter;
+  body: string;
+} {
+  if (!markdown.startsWith('---\n')) {
+    return { frontmatter: {}, body: markdown };
+  }
+  const end = markdown.indexOf('\n---\n', 4);
+  if (end < 0) {
+    return { frontmatter: {}, body: markdown };
+  }
+  return {
+    frontmatter: parseSimpleYaml(markdown.slice(4, end)),
+    body: markdown.slice(end + 5),
+  };
+}
+
+function parseSimpleYaml(src: string): Frontmatter {
+  const root: Frontmatter = {};
+  const lines = src.split(/\r?\n/);
+  let currentKey: string | undefined;
+  let currentArray: unknown[] | undefined;
+  let currentObject: Record<string, unknown> | undefined;
+  for (const raw of lines) {
+    if (!raw.trim() || raw.trim().startsWith('#')) continue;
+    const listMatch = raw.match(/^  -\s+(.*)$/);
+    if (listMatch && currentKey && currentArray) {
+      const value = listMatch[1];
+      const kv = value.match(/^([A-Za-z0-9_.-]+):\s*(.*)$/);
+      if (kv) {
+        currentObject = { [kv[1]]: stripQuotes(kv[2]) };
+        currentArray.push(currentObject);
+      } else {
+        currentObject = undefined;
+        currentArray.push(stripQuotes(value));
+      }
+      continue;
+    }
+    const nestedMatch = raw.match(/^    ([A-Za-z0-9_.-]+):\s*(.*)$/);
+    if (nestedMatch && currentObject) {
+      currentObject[nestedMatch[1]] = stripQuotes(nestedMatch[2]);
+      continue;
+    }
+    const scalarMatch = raw.match(/^([A-Za-z0-9_.-]+):\s*(.*)$/);
+    if (!scalarMatch) continue;
+    currentKey = scalarMatch[1];
+    currentObject = undefined;
+    if (scalarMatch[2] === '') {
+      currentArray = [];
+      root[currentKey] = currentArray;
+    } else {
+      currentArray = undefined;
+      root[currentKey] = stripQuotes(scalarMatch[2]);
+    }
+  }
+  return root;
+}
+
+function firstHeading(body: string): string | undefined {
+  for (const line of body.split(/\r?\n/)) {
+    const match = line.match(/^#\s+(.+?)\s*$/);
+    if (match) return match[1];
+  }
+  return undefined;
+}
+
+function firstParagraph(body: string): string | undefined {
+  const chunks = body
+    .replace(/^#\s+.+$/m, '')
+    .split(/\n\s*\n/)
+    .map((chunk) => chunk.replace(/\s+/g, ' ').trim())
+    .filter(Boolean);
+  return chunks[0];
+}
+
+function normalizeKey(value: string): string {
+  const key = value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_.-]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return key || 'skill';
+}
+
+function stripQuotes(value: string): string {
+  const trimmed = value.trim();
+  if (
+    (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+    (trimmed.startsWith("'") && trimmed.endsWith("'"))
+  ) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+function stringList(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === 'string')
+    : [];
+}
+
+function kfxDependencies(value: unknown): SkillKfxDependency[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .filter((item): item is Record<string, unknown> => {
+      return Boolean(item && typeof item === 'object' && stringValue(item.key));
+    })
+    .map((item) => ({ ...item, key: String(item.key) }));
+}

--- a/framework/skill/tsconfig.json
+++ b/framework/skill/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "skipLibCheck": true,
+    "allowImportingTsExtensions": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -417,6 +417,15 @@ importers:
         specifier: ^5.5.4
         version: 5.9.3
 
+  framework/skill:
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.20.0
+      typescript:
+        specifier: ^5.6.0
+        version: 5.9.3
+
   framework/spec:
     devDependencies:
       rimraf:


### PR DESCRIPTION
## Summary
- add framework/skill schemas, fixtures, and TypeScript helpers for SKILL.md-based Kungfu Skills
- add Python skill parser/catalog/context registry plus kungfu skill validate/install/list/catalog/context/read/explain
- add SDK skill scaffolding and update skill docs/ADR to first-slice implementation status

## Verification
- ./kungfu-code build:core
- pnpm --filter @kungfu-tech/core run freeze
- framework/core/dist/kungfu/kungfu --version
- framework/core/dist/kungfu/kungfu -H /tmp/kungfu-skill-home skill validate framework/skill/fixtures/minimal --json
- framework/core/dist/kungfu/kungfu -H /tmp/kungfu-skill-home skill context --path framework/skill/fixtures --source cli --manager python --json
- framework/core/dist/kungfu/kungfu -H /tmp/kungfu-skill-home skill explain trace-failure-investigator --path framework/skill/fixtures --json
- PYTHONPATH=framework/core/src/python uv run --frozen --project framework/core pytest framework/core/tests/python/test_skill.py
- pnpm --filter @kungfu-tech/skill run build
- uv run --frozen --project framework/core ruff check framework/core/src/python/kungfu/skill framework/core/src/python/kungfu/cli/commands/skill.py framework/core/tests/python/test_skill.py
- node developer/sdk/src/sdk.js create skill /tmp/kungfu-skill-sdk-smoke --name "Smoke Skill"
- ./kungfu-code verify

## Follow-up scope
- Node/Electron GUI manager injection
- persistent audit events for advertised/read skills
- kfx dependency install/dedup binding through the kfx registry
