### PR TITLE
feat(gui,terminal): managed session workspace with main-process host (ADR-0016 stage 1)

### DIFF
--- a/extensions/terminal/package.json
+++ b/extensions/terminal/package.json
@@ -44,7 +44,8 @@
       "view": {
         "title": "Terminal",
         "capabilities": [
-          "terminal"
+          "terminal",
+          "domain"
         ]
       }
     }

--- a/extensions/terminal/src/view/index.tsx
+++ b/extensions/terminal/src/view/index.tsx
@@ -31,6 +31,11 @@ import { headingStyle, mono, panelStyle } from '@kungfu-tech/kfx';
 import { FitAddon } from '@xterm/addon-fit';
 import { Terminal as XTerm } from '@xterm/xterm';
 import React from 'react';
+import {
+  loadWorkspaceLayout,
+  saveWorkspaceLayout,
+  type WorkspaceLayout,
+} from './persistence';
 
 async function resolve<T>(value: T | Promise<T>): Promise<T> {
   return await value;
@@ -103,6 +108,11 @@ interface Pane {
   pid: number;
   startedAt: number;
   durable: boolean; // tmux-backed (survives close) vs direct
+  // Retained so the pane can be persisted and re-adopted after a restart; the
+  // surviving tmux session keeps its own process, these only label the record.
+  command?: string;
+  args?: string[];
+  cwd?: string;
 }
 
 function providerChipStyle(provider: string): React.CSSProperties {
@@ -460,11 +470,96 @@ function SessionWorkspace({ caps }: { caps: KfxCapabilities; shell: Shell }) {
   const [panes, setPanes] = React.useState<Pane[]>([]);
   const [recoverable, setRecoverable] = React.useState<TerminalSession[]>([]);
   const [notice, setNotice] = React.useState<string | null>(null);
+  // Persistence is gated on the domain capability; absent it the workspace is
+  // ephemeral. `hydrated` blocks the save effect until the initial restore has
+  // read the stored layout, so mounting never clobbers it with an empty set.
+  const domain = caps.domain;
+  const hydrated = React.useRef(false);
 
   const panedIds = React.useMemo(
     () => new Set(panes.map((p) => p.runId)),
     [panes],
   );
+
+  // Restore on mount (W4): read the persisted layout and re-adopt each durable
+  // session by runId. A session still alive on the tmux socket comes back
+  // attached; a gone one is dropped (direct sessions cannot survive a restart).
+  React.useEffect(() => {
+    if (!domain) {
+      hydrated.current = true;
+      return;
+    }
+    // Read synchronously before the save effect can run, so the stored layout
+    // is captured even though adoption is async.
+    const layout = loadWorkspaceLayout(domain);
+    let cancelled = false;
+    void (async () => {
+      const restored: Pane[] = [];
+      for (const p of [...layout.panes].sort((a, b) => a.order - b.order)) {
+        if (p.backend !== 'tmux') continue;
+        try {
+          const s = await resolve(
+            caps.terminal.adopt({
+              runId: p.runId,
+              provider: p.provider,
+              command: p.command,
+              args: p.args,
+              cwd: p.cwd,
+            }),
+          );
+          if (s.status === 'running') {
+            restored.push({
+              key: s.runId,
+              runId: s.runId,
+              title: p.title,
+              provider: p.provider,
+              pid: s.pid,
+              startedAt: p.startedAt || s.startedAt,
+              durable: true,
+              command: p.command,
+              args: p.args,
+              cwd: p.cwd,
+            });
+          }
+        } catch {
+          // un-adoptable (gone / no tmux) — leave it out of the restored set
+        }
+      }
+      if (!cancelled) {
+        if (restored.length > 0) setPanes(restored);
+        hydrated.current = true;
+        // the pane-set change triggers the tray refresh effect below; no need
+        // to call refresh() here (it is declared later)
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+    // run once on mount; caps/domain identity is stable for a given runtime
+    // biome-ignore lint/correctness/useExhaustiveDependencies: mount-only restore
+  }, []);
+
+  // Persist on change (W4): once hydrated, mirror the live pane set into the
+  // config-backed layout so a restart can bring the durable sessions back.
+  React.useEffect(() => {
+    if (!domain || !hydrated.current) return;
+    const layout: WorkspaceLayout = {
+      version: 1,
+      workspaceId: 'default',
+      panes: panes.map((p, i) => ({
+        runId: p.runId,
+        provider: p.provider,
+        title: p.title,
+        backend: p.durable ? 'tmux' : 'direct',
+        command: p.command,
+        args: p.args,
+        cwd: p.cwd,
+        startedAt: p.startedAt,
+        order: i,
+      })),
+    };
+    saveWorkspaceLayout(domain, layout);
+  }, [panes, domain]);
 
   const refresh = React.useCallback(async () => {
     try {
@@ -531,6 +626,8 @@ function SessionWorkspace({ caps }: { caps: KfxCapabilities; shell: Shell }) {
           pid: session.pid,
           startedAt: session.startedAt,
           durable,
+          command,
+          args,
         },
       ]);
     },
@@ -580,6 +677,9 @@ function SessionWorkspace({ caps }: { caps: KfxCapabilities; shell: Shell }) {
                   pid: session.pid,
                   startedAt: session.startedAt,
                   durable: true,
+                  command: session.command,
+                  args: session.args,
+                  cwd: session.cwd,
                 },
               ],
         );

--- a/extensions/terminal/src/view/index.tsx
+++ b/extensions/terminal/src/view/index.tsx
@@ -1,24 +1,33 @@
-// Managed terminal — a PTY-backed terminal hosted inside the Kungfu GUI, so a
-// user starts and interacts with a managed agent process without leaving Kungfu.
+// Managed session workspace — a canvas of PTY-backed terminals hosted inside
+// the Kungfu GUI, so a user runs and watches several managed agent sessions at
+// once without leaving Kungfu. This is the visual-concurrency wedge: many
+// sessions visible on one screen (a grid that wraps), not a list you page
+// through one detail at a time.
+//
 // The view is pure interaction UI: xterm.js for rendering and keyboard, and the
 // declared `terminal` capability for the process. It never touches node-pty
 // directly — the PTY host lives in the trusted renderer behind the capability
 // boundary, so this view runs identically whether it is loaded node-integrated
 // or in a locked sandbox reaching the capability over IPC.
 //
+// Durability: sessions start on the tmux backend (`backend: 'tmux'`) when the
+// host has one, so closing a pane detaches (the agent keeps running) rather than
+// killing it, and a detached session can be reattached from the recoverable
+// tray. When no tmux backend is present the workspace degrades to direct
+// sessions (no durability) and says so per pane. tmux is only a backend — this
+// view speaks "session", never "tmux".
+//
+// Out of scope here (later slices): real OS windows across monitors with saved
+// display bounds (a gui main-process concern), cost/proof badges, and
+// cross-restart layout persistence. This slice delivers in-view concurrency plus
+// detach / discover / reattach against one running app.
+//
 // The capability is async at the sandbox boundary (an IPC hop cannot be
 // synchronous); `resolve` awaits both the sync (node-integrated) and Promise
 // (sandboxed-ipc) shapes so one code path serves both tiers.
-//
-// The view opens on an inbox of managed-run profiles. Picking one starts a
-// managed provider run in the terminal, which reports its cost. The command is
-// resolved from KUNGFU_MANAGED_RUN_CMD (a launcher on PATH in a packaged
-// runtime); a dev override lets a source checkout point at its built runtime.
-// Seeding the inbox in the view is MVP scope — importing real work/run cards
-// from the runtime is a later slice.
 import '@xterm/xterm/css/xterm.css';
-import type { KfxCapabilities, Shell } from '@kungfu-tech/kfx';
-import { mono, panelStyle } from '@kungfu-tech/kfx';
+import type { KfxCapabilities, Shell, TerminalSession } from '@kungfu-tech/kfx';
+import { headingStyle, mono, panelStyle } from '@kungfu-tech/kfx';
 import { FitAddon } from '@xterm/addon-fit';
 import { Terminal as XTerm } from '@xterm/xterm';
 import React from 'react';
@@ -83,7 +92,20 @@ function launchCommand(profile: RunProfile): {
   };
 }
 
-function providerChipStyle(provider: Provider): React.CSSProperties {
+// One pane on the canvas, bound to an already-created session by runId. The
+// workspace owns creation (an event handler, not an effect) so a session is
+// never spawned twice; a pane only attaches to it.
+interface Pane {
+  key: string;
+  runId: string;
+  title: string;
+  provider: string;
+  pid: number;
+  startedAt: number;
+  durable: boolean; // tmux-backed (survives close) vs direct
+}
+
+function providerChipStyle(provider: string): React.CSSProperties {
   const claude = provider === 'claude';
   return {
     ...mono,
@@ -92,100 +114,50 @@ function providerChipStyle(provider: Provider): React.CSSProperties {
     borderRadius: 999,
     color: claude ? '#c7a86a' : '#7fb4d8',
     background: claude ? 'rgba(199,168,106,0.14)' : 'rgba(127,180,216,0.14)',
+    whiteSpace: 'nowrap',
   };
 }
 
-function Inbox({ onRun }: { onRun: (p: RunProfile) => void }) {
-  return (
-    <div
-      style={{
-        display: 'flex',
-        flexDirection: 'column',
-        height: '100%',
-        gap: 10,
-      }}
-    >
-      <div style={{ ...mono, fontSize: 12, color: '#9cdcfe' }}>
-        Managed-run inbox · pick a run to start
-      </div>
-      <div
-        style={{
-          ...panelStyle,
-          flex: 1,
-          padding: 10,
-          overflow: 'auto',
-          display: 'flex',
-          flexDirection: 'column',
-          gap: 8,
-        }}
-      >
-        {INBOX.map((p) => (
-          <div
-            key={p.id}
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: 12,
-              padding: '10px 12px',
-              borderRadius: 8,
-              border: '1px solid #2b2b2b',
-              background: '#232323',
-            }}
-          >
-            <span style={providerChipStyle(p.provider)}>{p.provider}</span>
-            <div style={{ flex: 1, minWidth: 0 }}>
-              <div style={{ fontSize: 13, color: '#e6e6e6' }}>{p.label}</div>
-              <div
-                style={{
-                  ...mono,
-                  fontSize: 11,
-                  color: '#8a8a8a',
-                  overflow: 'hidden',
-                  textOverflow: 'ellipsis',
-                  whiteSpace: 'nowrap',
-                }}
-              >
-                {p.prompt}
-              </div>
-            </div>
-            <button
-              type="button"
-              onClick={() => onRun(p)}
-              style={{
-                ...mono,
-                fontSize: 12,
-                fontWeight: 600,
-                cursor: 'pointer',
-                color: '#0f151b',
-                background: '#3fb950',
-                border: 'none',
-                borderRadius: 7,
-                padding: '6px 14px',
-              }}
-            >
-              Run
-            </button>
-          </div>
-        ))}
-      </div>
-    </div>
-  );
+function formatElapsed(ms: number): string {
+  const s = Math.max(0, Math.floor(ms / 1000));
+  const h = Math.floor(s / 3600);
+  const m = Math.floor((s % 3600) / 60);
+  const sec = s % 60;
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return h > 0 ? `${h}:${pad(m)}:${pad(sec)}` : `${m}:${pad(sec)}`;
 }
 
-function RunTerminal({
+const iconButtonStyle: React.CSSProperties = {
+  ...mono,
+  fontSize: 11,
+  cursor: 'pointer',
+  color: '#cccccc',
+  background: 'transparent',
+  border: '1px solid #3a3a3a',
+  borderRadius: 6,
+  padding: '2px 8px',
+};
+
+// A single session pane: an xterm attached to `runId`. It never spawns or kills
+// on mount/unmount — creation and teardown are explicit workspace actions — so
+// navigating away or a StrictMode double-mount cannot leak or double-run a
+// session. Unmount only detaches the local listeners and disposes the terminal;
+// the session keeps running behind the capability.
+function SessionPane({
   caps,
-  profile,
-  onBack,
+  pane,
+  onDetach,
+  onKill,
 }: {
   caps: KfxCapabilities;
-  profile: RunProfile;
-  onBack: () => void;
+  pane: Pane;
+  onDetach: (pane: Pane) => void;
+  onKill: (pane: Pane) => void;
 }) {
   const hostRef = React.useRef<HTMLDivElement>(null);
-  const [status, setStatus] = React.useState('starting…');
-  const [meta, setMeta] = React.useState<{ runId: string; pid: number } | null>(
-    null,
-  );
+  const [status, setStatus] = React.useState<string>('running');
+  const [ended, setEnded] = React.useState(false);
+  const [nowTs, setNowTs] = React.useState(() => pane.startedAt);
 
   React.useEffect(() => {
     const el = hostRef.current;
@@ -193,97 +165,443 @@ function RunTerminal({
 
     const term = new XTerm({
       fontFamily: 'monospace',
-      fontSize: 13,
+      fontSize: 12.5,
       cursorBlink: true,
-      theme: { background: '#1e1e1e' },
+      theme: { background: '#1a1a1a' },
     });
     const fit = new FitAddon();
     term.loadAddon(fit);
     term.open(el);
-    try {
-      fit.fit();
-    } catch {
-      // fit needs a laid-out element; a first-frame failure is harmless
-    }
+    const refit = () => {
+      try {
+        fit.fit();
+      } catch {
+        // fit needs a laid-out element; transient failures are harmless
+      }
+    };
+    refit();
 
-    let disposed = false;
     let dataSub: { stop?: () => void } | undefined;
     let exitSub: { stop?: () => void } | undefined;
-    let activeRunId: string | undefined;
 
     void (async () => {
       try {
-        const { command, args } = launchCommand(profile);
-        const session = await resolve(
-          caps.terminal.spawn({
-            command,
-            args,
-            cols: term.cols,
-            rows: term.rows,
-          }),
-        );
-        if (disposed) {
-          void resolve(caps.terminal.kill(session.runId));
-          return;
-        }
-        activeRunId = session.runId;
-        setMeta({ runId: session.runId, pid: session.pid });
-        setStatus('running');
-
+        // onData replays the session's buffered output first, so a pane that
+        // attaches to a session already in flight (including a reattach) shows
+        // its history before live output.
         dataSub = await resolve(
-          caps.terminal.onData(session.runId, (data: string) =>
-            term.write(data),
-          ),
+          caps.terminal.onData(pane.runId, (data: string) => term.write(data)),
         );
         exitSub = await resolve(
-          caps.terminal.onExit(session.runId, (exit) => {
+          caps.terminal.onExit(pane.runId, (exit) => {
             setStatus(`exited (${exit.exitCode})`);
+            setEnded(true);
             term.write(
-              `\r\n\x1b[90m[process exited: code ${exit.exitCode}]\x1b[0m\r\n`,
+              `\r\n\x1b[90m[session ended: code ${exit.exitCode}]\x1b[0m\r\n`,
             );
           }),
         );
-
         term.onData((data) => {
-          void resolve(caps.terminal.write(session.runId, data));
+          void resolve(caps.terminal.write(pane.runId, data)).catch(() => {
+            // writing to an ended session throws; the exit listener already
+            // surfaced the end, so swallow the race here
+          });
         });
         term.onResize(({ cols, rows }) => {
-          void resolve(caps.terminal.resize(session.runId, cols, rows));
+          void resolve(caps.terminal.resize(pane.runId, cols, rows));
         });
       } catch (e) {
         setStatus('unavailable');
         term.write(
-          `\r\n\x1b[31m[terminal capability unavailable: ${
-            (e as Error).message
-          }]\x1b[0m\r\n`,
+          `\r\n\x1b[31m[session unavailable: ${(e as Error).message}]\x1b[0m\r\n`,
         );
       }
     })();
 
-    const onWindowResize = () => {
-      try {
-        fit.fit();
-      } catch {
-        // ignore transient layout failures
-      }
-    };
-    window.addEventListener('resize', onWindowResize);
+    // Refit to the grid cell, not just the window: a pane resizes whenever the
+    // canvas reflows (another pane added/removed, panel split moved).
+    const ro = new ResizeObserver(refit);
+    ro.observe(el);
 
     return () => {
-      disposed = true;
-      window.removeEventListener('resize', onWindowResize);
+      ro.disconnect();
       dataSub?.stop?.();
       exitSub?.stop?.();
-      if (activeRunId) {
-        try {
-          void resolve(caps.terminal.kill(activeRunId));
-        } catch {
-          // best-effort teardown
-        }
-      }
       term.dispose();
     };
-  }, [caps.terminal, profile]);
+  }, [caps.terminal, pane.runId]);
+
+  // Elapsed-time tick; stops once the session ends.
+  React.useEffect(() => {
+    if (ended) return;
+    const id = setInterval(() => setNowTs(Date.now()), 1000);
+    return () => clearInterval(id);
+  }, [ended]);
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        minHeight: 260,
+        border: '1px solid #333',
+        borderRadius: 8,
+        background: '#1e1e1e',
+        overflow: 'hidden',
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 8,
+          padding: '6px 8px',
+          borderBottom: '1px solid #2b2b2b',
+          background: '#232323',
+        }}
+      >
+        <span style={providerChipStyle(pane.provider)}>{pane.provider}</span>
+        <div
+          style={{
+            flex: 1,
+            minWidth: 0,
+            display: 'flex',
+            flexDirection: 'column',
+          }}
+        >
+          <span
+            style={{
+              fontSize: 12,
+              color: '#e6e6e6',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {pane.title}
+          </span>
+          <span style={{ ...mono, fontSize: 10, color: '#7a7a7a' }}>
+            run {pane.runId} · pid {pane.pid} ·{' '}
+            <span
+              title={
+                pane.durable
+                  ? 'tmux-backed (survives close)'
+                  : 'direct (no durability)'
+              }
+            >
+              {pane.durable ? '● durable' : '○ direct'}
+            </span>{' '}
+            · {formatElapsed(nowTs - pane.startedAt)}
+          </span>
+        </div>
+        <span
+          style={{
+            ...mono,
+            fontSize: 10.5,
+            color: ended ? '#c46b6b' : '#5bbf6a',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {status}
+        </span>
+        {!ended && pane.durable && (
+          <button
+            type="button"
+            onClick={() => onDetach(pane)}
+            title="Close this pane but keep the agent running (reattach later)"
+            style={iconButtonStyle}
+          >
+            Detach
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={() => onKill(pane)}
+          title={
+            ended ? 'Remove this pane' : 'End the session and remove the pane'
+          }
+          style={{ ...iconButtonStyle, color: ended ? '#cccccc' : '#d98a8a' }}
+        >
+          {ended ? 'Close' : 'Kill'}
+        </button>
+      </div>
+      <div ref={hostRef} style={{ flex: 1, padding: 6, overflow: 'hidden' }} />
+    </div>
+  );
+}
+
+// Compact launcher: clicking a profile ADDS a pane (concurrent), it does not
+// replace the canvas. The list is an overview, never the main interaction.
+function LauncherStrip({
+  onLaunch,
+}: {
+  onLaunch: (profile: RunProfile) => void;
+}) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 8,
+        flexWrap: 'wrap',
+      }}
+    >
+      <span style={{ ...mono, fontSize: 11, color: '#858585' }}>launch:</span>
+      {INBOX.map((p) => (
+        <button
+          key={p.id}
+          type="button"
+          onClick={() => onLaunch(p)}
+          title={p.prompt}
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 6,
+            ...mono,
+            fontSize: 11.5,
+            cursor: 'pointer',
+            color: '#e6e6e6',
+            background: '#2a2a2a',
+            border: '1px solid #3a3a3a',
+            borderRadius: 7,
+            padding: '4px 9px',
+          }}
+        >
+          <span style={providerChipStyle(p.provider)}>{p.provider}</span>
+          {p.label.replace(/^.*·\s*/, '')}
+          <span style={{ color: '#5bbf6a', fontWeight: 600 }}>+</span>
+        </button>
+      ))}
+    </div>
+  );
+}
+
+// Sessions that are alive-but-detached or dead-but-recorded and not currently on
+// the canvas. Detached sessions reattach into a fresh pane; orphaned/ended ones
+// can only be dismissed (killed to clear the record).
+function RecoverableTray({
+  sessions,
+  onReattach,
+  onDismiss,
+  onRefresh,
+}: {
+  sessions: TerminalSession[];
+  onReattach: (session: TerminalSession) => void;
+  onDismiss: (session: TerminalSession) => void;
+  onRefresh: () => void;
+}) {
+  return (
+    <div style={{ ...panelStyle, padding: 8 }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+        <span style={{ ...headingStyle, margin: 0 }}>
+          recoverable sessions · {sessions.length}
+        </span>
+        <button type="button" onClick={onRefresh} style={iconButtonStyle}>
+          Refresh
+        </button>
+      </div>
+      {sessions.length > 0 && (
+        <div
+          style={{
+            display: 'flex',
+            flexWrap: 'wrap',
+            gap: 8,
+            marginTop: 8,
+          }}
+        >
+          {sessions.map((s) => {
+            const detached = s.status === 'detached';
+            return (
+              <div
+                key={s.runId}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 8,
+                  padding: '4px 8px',
+                  borderRadius: 7,
+                  border: '1px solid #333',
+                  background: '#232323',
+                }}
+              >
+                <span style={providerChipStyle(s.provider ?? 'agent')}>
+                  {s.provider ?? 'agent'}
+                </span>
+                <span style={{ ...mono, fontSize: 10.5, color: '#9a9a9a' }}>
+                  {s.runId} · {s.status}
+                </span>
+                {detached ? (
+                  <button
+                    type="button"
+                    onClick={() => onReattach(s)}
+                    style={{ ...iconButtonStyle, color: '#7fb4d8' }}
+                  >
+                    Reattach
+                  </button>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={() => onDismiss(s)}
+                    style={{ ...iconButtonStyle, color: '#d98a8a' }}
+                  >
+                    Dismiss
+                  </button>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function SessionWorkspace({ caps }: { caps: KfxCapabilities; shell: Shell }) {
+  const [panes, setPanes] = React.useState<Pane[]>([]);
+  const [recoverable, setRecoverable] = React.useState<TerminalSession[]>([]);
+  const [notice, setNotice] = React.useState<string | null>(null);
+
+  const panedIds = React.useMemo(
+    () => new Set(panes.map((p) => p.runId)),
+    [panes],
+  );
+
+  const refresh = React.useCallback(async () => {
+    try {
+      // discover reconciles the known session map (marks truly-gone sessions
+      // orphaned; a dead socket is left untouched), then list reflects it.
+      await resolve(caps.terminal.discover()).catch(() => undefined);
+      const all = await resolve(caps.terminal.list());
+      setRecoverable(
+        all.filter(
+          (s) =>
+            (s.status === 'detached' || s.status === 'orphaned') &&
+            !panedIds.has(s.runId),
+        ),
+      );
+    } catch {
+      setRecoverable([]);
+    }
+  }, [caps.terminal, panedIds]);
+
+  React.useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const launch = React.useCallback(
+    async (profile: RunProfile) => {
+      const { command, args } = launchCommand(profile);
+      let session: TerminalSession;
+      let durable = true;
+      try {
+        session = await resolve(
+          caps.terminal.spawn({
+            command,
+            args,
+            provider: profile.provider,
+            backend: 'tmux',
+            cols: 80,
+            rows: 24,
+          }),
+        );
+      } catch {
+        // No tmux backend on this host: fall back to a direct (non-durable)
+        // session so the workspace still works, and flag the pane as such.
+        durable = false;
+        setNotice(
+          'no tmux backend — sessions run directly and do not survive close',
+        );
+        session = await resolve(
+          caps.terminal.spawn({
+            command,
+            args,
+            provider: profile.provider,
+            cols: 80,
+            rows: 24,
+          }),
+        );
+      }
+      setPanes((prev) => [
+        ...prev,
+        {
+          key: session.runId,
+          runId: session.runId,
+          title: profile.label,
+          provider: profile.provider,
+          pid: session.pid,
+          startedAt: session.startedAt,
+          durable,
+        },
+      ]);
+    },
+    [caps.terminal],
+  );
+
+  const detachPane = React.useCallback(
+    (pane: Pane) => {
+      try {
+        caps.terminal.detach(pane.runId);
+      } catch {
+        // a non-durable or already-ended session has nothing to detach
+      }
+      setPanes((prev) => prev.filter((p) => p.key !== pane.key));
+      void refresh();
+    },
+    [caps.terminal, refresh],
+  );
+
+  const killPane = React.useCallback(
+    (pane: Pane) => {
+      try {
+        caps.terminal.kill(pane.runId);
+      } catch {
+        // best-effort
+      }
+      setPanes((prev) => prev.filter((p) => p.key !== pane.key));
+      void refresh();
+    },
+    [caps.terminal, refresh],
+  );
+
+  const reattach = React.useCallback(
+    async (s: TerminalSession) => {
+      try {
+        const session = await resolve(caps.terminal.reattach(s.runId));
+        setPanes((prev) =>
+          prev.some((p) => p.runId === session.runId)
+            ? prev
+            : [
+                ...prev,
+                {
+                  key: session.runId,
+                  runId: session.runId,
+                  title: `${session.provider ?? 'agent'} · ${session.command}`,
+                  provider: session.provider ?? 'agent',
+                  pid: session.pid,
+                  startedAt: session.startedAt,
+                  durable: true,
+                },
+              ],
+        );
+      } catch (e) {
+        setNotice(`reattach failed: ${(e as Error).message}`);
+      }
+      void refresh();
+    },
+    [caps.terminal, refresh],
+  );
+
+  const dismiss = React.useCallback(
+    (s: TerminalSession) => {
+      try {
+        caps.terminal.kill(s.runId);
+      } catch {
+        // best-effort
+      }
+      void refresh();
+    },
+    [caps.terminal, refresh],
+  );
 
   return (
     <div
@@ -291,55 +609,59 @@ function RunTerminal({
         display: 'flex',
         flexDirection: 'column',
         height: '100%',
-        gap: 6,
+        gap: 8,
       }}
     >
-      <div
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          gap: 10,
-          ...mono,
-          fontSize: 12,
-          color: '#9cdcfe',
-        }}
-      >
-        <button
-          type="button"
-          onClick={onBack}
+      <LauncherStrip onLaunch={launch} />
+      {notice && (
+        <div style={{ ...mono, fontSize: 11, color: '#c9a227' }}>{notice}</div>
+      )}
+      <RecoverableTray
+        sessions={recoverable}
+        onReattach={reattach}
+        onDismiss={dismiss}
+        onRefresh={() => void refresh()}
+      />
+      {panes.length === 0 ? (
+        <div
           style={{
+            ...panelStyle,
+            flex: 1,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            color: '#6a6a6a',
             ...mono,
-            fontSize: 11,
-            cursor: 'pointer',
-            color: '#9cdcfe',
-            background: 'transparent',
-            border: '1px solid #3a3a3a',
-            borderRadius: 6,
-            padding: '2px 8px',
+            fontSize: 12,
           }}
         >
-          ← Inbox
-        </button>
-        <span>
-          {profile.provider} · {profile.label}
-          {meta ? ` · run ${meta.runId} · pid ${meta.pid}` : ''} · {status}
-        </span>
-      </div>
-      <div
-        ref={hostRef}
-        style={{ ...panelStyle, flex: 1, padding: 6, overflow: 'hidden' }}
-      />
+          launch a session above — panes stack here, several visible at once
+        </div>
+      ) : (
+        <div
+          style={{
+            flex: 1,
+            overflow: 'auto',
+            display: 'grid',
+            gridTemplateColumns: 'repeat(auto-fill, minmax(380px, 1fr))',
+            gridAutoRows: 'minmax(260px, 1fr)',
+            gap: 10,
+            alignContent: 'start',
+          }}
+        >
+          {panes.map((pane) => (
+            <SessionPane
+              key={pane.key}
+              caps={caps}
+              pane={pane}
+              onDetach={detachPane}
+              onKill={killPane}
+            />
+          ))}
+        </div>
+      )}
     </div>
   );
 }
 
-function TerminalView({ caps }: { caps: KfxCapabilities; shell: Shell }) {
-  const [active, setActive] = React.useState<RunProfile | null>(null);
-  return active ? (
-    <RunTerminal caps={caps} profile={active} onBack={() => setActive(null)} />
-  ) : (
-    <Inbox onRun={setActive} />
-  );
-}
-
-export const View = TerminalView;
+export const View = SessionWorkspace;

--- a/extensions/terminal/src/view/index.tsx
+++ b/extensions/terminal/src/view/index.tsx
@@ -174,8 +174,13 @@ function SessionPane({
     if (!el) return;
 
     const term = new XTerm({
-      fontFamily: 'monospace',
-      fontSize: 12.5,
+      // Concrete font + integer size + explicit lineHeight so FitAddon's cell
+      // measurement matches the actual render height; a fractional size (12.5)
+      // let the two drift, so fit proposed ~2 more rows than fit the box and a
+      // full-screen TUI's bottom rows (tmux's status line) were clipped.
+      fontFamily: 'Menlo, Monaco, monospace',
+      fontSize: 13,
+      lineHeight: 1.2,
       cursorBlink: true,
       theme: { background: '#1a1a1a' },
     });
@@ -229,8 +234,19 @@ function SessionPane({
     })();
 
     // Refit to the grid cell, not just the window: a pane resizes whenever the
-    // canvas reflows (another pane added/removed, panel split moved).
-    const ro = new ResizeObserver(refit);
+    // canvas reflows (another pane added/removed, panel split moved). Observing
+    // fires once with the settled size, which is what syncs the session away
+    // from its spawn size — so a full-screen TUI (tmux) draws its status line at
+    // the real bottom row. The fit's own resize event also propagates, but push
+    // the session size explicitly here so a size that fit() considers unchanged
+    // still reaches the pty.
+    const syncSize = () => {
+      refit();
+      if (term.cols > 0 && term.rows > 0) {
+        void resolve(caps.terminal.resize(pane.runId, term.cols, term.rows));
+      }
+    };
+    const ro = new ResizeObserver(syncSize);
     ro.observe(el);
 
     return () => {
@@ -335,7 +351,10 @@ function SessionPane({
           {ended ? 'Close' : 'Kill'}
         </button>
       </div>
-      <div ref={hostRef} style={{ flex: 1, padding: 6, overflow: 'hidden' }} />
+      <div
+        ref={hostRef}
+        style={{ flex: 1, minHeight: 0, overflow: 'hidden' }}
+      />
     </div>
   );
 }

--- a/extensions/terminal/src/view/persistence.ts
+++ b/extensions/terminal/src/view/persistence.ts
@@ -1,0 +1,120 @@
+// Workspace layout persistence for the managed session workspace (W4).
+//
+// The set of open sessions and their arrangement is a journal-backed config
+// fact, not a private GUI file: it lives in the runtime home's ConfigStore at a
+// stable location, so the CLI and agents read and write the same record the GUI
+// shows (the same shape shell-state.ts uses for shell state). This is the F4
+// boundary — session lifecycle identity is a config fact the workspace owns —
+// and the F5 contract — a stable, tolerant JSON read that other surfaces can
+// depend on.
+//
+// Only the durable (tmux-backed) identity is restorable across an app restart:
+// on relaunch the in-memory session map is empty, so the workspace re-adopts
+// each persisted tmux session by runId. Direct (non-durable) sessions are
+// recorded for completeness but cannot be brought back — their process died
+// with the previous renderer.
+import type { DomainState, KfLocation } from '@kungfu-tech/kfx';
+
+// One JSON blob, addressed like shell state (system/shell/…/live).
+export const WORKSPACE_LOCATION: KfLocation = {
+  category: 'system',
+  group: 'shell',
+  name: 'terminal-workspace',
+  mode: 'live',
+};
+
+export type PersistedPane = {
+  runId: string;
+  provider: string;
+  title: string;
+  backend: 'tmux' | 'direct';
+  command?: string;
+  args?: string[];
+  cwd?: string;
+  startedAt: number;
+  order: number;
+};
+
+export type WorkspaceLayout = {
+  version: 1;
+  workspaceId: string;
+  panes: PersistedPane[];
+};
+
+export function emptyLayout(): WorkspaceLayout {
+  return { version: 1, workspaceId: 'default', panes: [] };
+}
+
+function asStringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  return value.filter((v): v is string => typeof v === 'string');
+}
+
+function parsePane(value: unknown, index: number): PersistedPane | null {
+  if (typeof value !== 'object' || value === null) return null;
+  const v = value as Record<string, unknown>;
+  if (typeof v.runId !== 'string' || v.runId.length === 0) return null;
+  if (typeof v.provider !== 'string') return null;
+  const backend = v.backend === 'direct' ? 'direct' : 'tmux';
+  return {
+    runId: v.runId,
+    provider: v.provider,
+    title: typeof v.title === 'string' ? v.title : v.runId,
+    backend,
+    command: typeof v.command === 'string' ? v.command : undefined,
+    args: asStringArray(v.args),
+    cwd: typeof v.cwd === 'string' ? v.cwd : undefined,
+    startedAt: typeof v.startedAt === 'number' ? v.startedAt : 0,
+    order: typeof v.order === 'number' ? v.order : index,
+  };
+}
+
+// Tolerant read (F5): a malformed or partial blob yields an empty layout or
+// drops only the bad panes — it never throws, because the GUI, CLI and agents
+// all read this record and a boot must not hinge on its shape.
+export function parseWorkspaceLayout(raw: string): WorkspaceLayout {
+  try {
+    const obj = JSON.parse(raw) as unknown;
+    if (typeof obj !== 'object' || obj === null) return emptyLayout();
+    const o = obj as Record<string, unknown>;
+    const rawPanes = Array.isArray(o.panes) ? o.panes : [];
+    const panes = rawPanes
+      .map((p, i) => parsePane(p, i))
+      .filter((p): p is PersistedPane => p !== null);
+    return {
+      version: 1,
+      workspaceId:
+        typeof o.workspaceId === 'string' ? o.workspaceId : 'default',
+      panes,
+    };
+  } catch {
+    return emptyLayout();
+  }
+}
+
+export function loadWorkspaceLayout(domain: DomainState): WorkspaceLayout {
+  try {
+    const entry = domain
+      .configs()
+      .find(
+        (row) =>
+          row.location.category === WORKSPACE_LOCATION.category &&
+          row.location.group === WORKSPACE_LOCATION.group &&
+          row.location.name === WORKSPACE_LOCATION.name,
+      );
+    return entry ? parseWorkspaceLayout(entry.value) : emptyLayout();
+  } catch {
+    return emptyLayout();
+  }
+}
+
+export function saveWorkspaceLayout(
+  domain: DomainState,
+  layout: WorkspaceLayout,
+): void {
+  try {
+    domain.setConfig(WORKSPACE_LOCATION, JSON.stringify(layout));
+  } catch {
+    // persistence is best-effort; a failed write never breaks the workspace
+  }
+}

--- a/framework/api/src/capability/terminal.ts
+++ b/framework/api/src/capability/terminal.ts
@@ -13,6 +13,16 @@
 // node-pty is injected (PtyModule), not imported, so the SDK stays
 // binding-agnostic and testable without a real pty. The trusted renderer wires
 // in `window.require('node-pty')`.
+//
+// Durability backend (W2/W3): a session may run its process directly under the
+// pty (`backend: 'direct'`, the default and the original behaviour) or behind a
+// tmux server on a dedicated, isolated socket (`backend: 'tmux'`). The tmux
+// backend is what lets a managed agent survive GUI close/crash and be
+// reattached after a restart. tmux is only a *backend* — the product model
+// never speaks "tmux"; the Kungfu session registry is the authoritative
+// mapping and this handle exposes a backend-agnostic surface. Like node-pty,
+// the non-interactive tmux control channel is injected (TmuxControl), so the
+// SDK stays binding-agnostic and testable without a real tmux.
 import type { Subscription } from './types.js';
 
 // --- injected node-pty surface (the minimal subset this handle needs) ------
@@ -48,7 +58,118 @@ export interface PtyModule {
   ): PtyProcess;
 }
 
+// --- injected tmux surface (durability backend) -----------------------------
+
+// A dedicated tmux socket + binary. The socket name isolates every Kungfu
+// managed session from the user's own default-socket tmux sessions: all tmux
+// commands carry `-L <socket>`, so they physically cannot reach the default
+// socket. `bin` is an absolute tmux path (a non-interactive shell must not rely
+// on a shell function shim).
+export interface TmuxConfig {
+  socket: string;
+  bin: string;
+}
+
+export interface TmuxRunResult {
+  code: number;
+  stdout: string;
+  stderr: string;
+}
+
+// The non-interactive tmux control channel (list/kill/has-session). Interactive
+// attach/create still goes through the pty; this is only for control commands
+// that must run to completion and report an exit code. The trusted renderer
+// wires in a child_process.execFile-backed implementation.
+export interface TmuxControl {
+  run(args: string[]): Promise<TmuxRunResult>;
+}
+
+export interface TmuxBinding {
+  config: TmuxConfig;
+  control: TmuxControl;
+}
+
+// --- pure tmux helpers (testable, reusable, no side effects) ----------------
+
+// tmux session names may not contain '.' or ':' or whitespace; keep a readable,
+// stable, collision-resistant token derived from the input.
+const sanitizeTmuxToken = (value: string): string =>
+  value.replace(/[^A-Za-z0-9_-]+/g, '-').replace(/^-+|-+$/g, '') || 'x';
+
+// Deterministic tmux session name for a managed run. Determinism is what makes
+// reattach work: after a restart the caller reconstructs runId from the
+// registry, computes the same name, and `new-session -A` attaches to the
+// surviving session instead of creating a new one.
+export function tmuxSessionName(provider: string, runId: string): string {
+  return `kf_${sanitizeTmuxToken(provider)}_${sanitizeTmuxToken(runId)}`;
+}
+
+// `new-session -A`: attach-or-create. When the named session already exists this
+// behaves like attach-session (command is ignored — the running agent is
+// untouched), which is exactly the W3 reattach path. Otherwise it creates the
+// session and runs `command args` as its first window. `-x/-y` seed the initial
+// size on creation.
+export function buildTmuxNewSessionArgs(
+  config: TmuxConfig,
+  name: string,
+  command: string,
+  args: string[],
+  cols: number,
+  rows: number,
+): string[] {
+  return [
+    '-L',
+    config.socket,
+    'new-session',
+    '-A',
+    '-s',
+    name,
+    '-x',
+    String(cols),
+    '-y',
+    String(rows),
+    command,
+    ...args,
+  ];
+}
+
+export function buildTmuxKillSessionArgs(
+  config: TmuxConfig,
+  name: string,
+): string[] {
+  return ['-L', config.socket, 'kill-session', '-t', name];
+}
+
+export function buildTmuxListArgs(config: TmuxConfig): string[] {
+  return ['-L', config.socket, 'list-sessions', '-F', '#{session_name}'];
+}
+
+export function buildTmuxHasSessionArgs(
+  config: TmuxConfig,
+  name: string,
+): string[] {
+  return ['-L', config.socket, 'has-session', '-t', name];
+}
+
 // --- public surface ---------------------------------------------------------
+
+export type TerminalBackend = 'direct' | 'tmux';
+
+export type TerminalBackendDetail = {
+  kind: 'tmux';
+  socket: string;
+  tmuxName: string;
+};
+
+// Lifecycle states:
+//  - running:  process alive, a pty client is attached
+//  - detached: (tmux only) session alive on the server, no client attached —
+//              reattachable; the agent keeps running
+//  - orphaned: (tmux only) we owned the session but the server says it is gone
+//              and we did not kill it — it died outside our control, not
+//              reattachable, and distinct from a clean commanded exit
+//  - exited:   process/session ended (clean exit, or after our kill)
+export type TerminalStatus = 'running' | 'detached' | 'orphaned' | 'exited';
 
 export type TerminalSpawnOptions = {
   command: string;
@@ -62,17 +183,26 @@ export type TerminalSpawnOptions = {
   // is the higher-level work item the run belongs to.
   runId?: string;
   workId?: string;
+  // Durability backend. Defaults to 'direct' (original behaviour). 'tmux'
+  // requires openTerminal to have been given a tmux binding.
+  backend?: TerminalBackend;
+  // Agent provider label (e.g. 'codex', 'claude'), used for the tmux session
+  // name and carried on the session snapshot.
+  provider?: string;
 };
 
 export type TerminalSession = {
   runId: string;
   pid: number;
   workId?: string;
+  provider?: string;
   command: string;
   args: string[];
   cwd?: string;
   startedAt: number; // epoch ms
-  status: 'running' | 'exited';
+  status: TerminalStatus;
+  backend: TerminalBackend;
+  backendDetail?: TerminalBackendDetail;
   exitCode?: number;
   exitSignal?: number;
   endedAt?: number;
@@ -84,6 +214,17 @@ export type TerminalExit = {
   signal?: number;
 };
 
+// A tmux session found on the managed socket. `owned` means this host has it in
+// its session map (so it can be addressed by runId); an un-owned live session is
+// one a previous process left behind and can be adopted via reattach.
+export type DiscoveredSession = {
+  tmuxName: string;
+  owned: boolean;
+  attached: boolean;
+  runId?: string;
+  provider?: string;
+};
+
 export type Terminal = {
   // Start a managed process bound to a run. Returns the session snapshot; the
   // run is addressable by runId for every other method.
@@ -93,16 +234,32 @@ export type Terminal = {
   write: (runId: string, data: string) => void;
   resize: (runId: string, cols: number, rows: number) => void;
   // Signal the process. Default SIGHUP mirrors node-pty; the process still gets
-  // a final exit event and a recorded end state.
+  // a final exit event and a recorded end state. For a tmux session this kills
+  // the server-side session (the agent really dies), not just the client.
   kill: (runId: string, signal?: string) => void;
+  // Detach a tmux session's client without killing the agent: the process keeps
+  // running on the tmux server and the session becomes 'detached' and
+  // reattachable. This is what "close the GUI window" maps to. Throws for a
+  // direct-backend run, which has nothing to detach.
+  detach: (runId: string) => void;
   // Subscribe to output. The already-buffered output is replayed to this
   // listener first (so a GUI that attaches late — or reattaches after a
   // refresh — sees the whole session), then live data streams. Returns a
   // Subscription; stop() detaches this listener only.
   onData: (runId: string, onData: (data: string) => void) => Subscription;
   // Subscribe to termination. If the run already exited, the listener fires
-  // immediately with the recorded exit, then the subscription is inert.
+  // immediately with the recorded exit, then the subscription is inert. A
+  // detach does NOT fire this — detach is not termination.
   onExit: (runId: string, onExit: (exit: TerminalExit) => void) => Subscription;
+  // List tmux sessions on the managed socket and reconcile the known session
+  // map against them (F6: only conclude a known session is orphaned when the
+  // server answered and its name is absent; a dead socket/server is 'unknown'
+  // and leaves statuses untouched). Requires a tmux binding.
+  discover: () => Promise<DiscoveredSession[]>;
+  // Reattach a live-but-detached tmux session with a fresh client. Guards with
+  // has-session so a gone session is never silently recreated (which would
+  // re-run the agent command). Requires a tmux binding.
+  reattach: (runId: string) => Promise<TerminalSession>;
   // All sessions this host knows, running and exited, newest last.
   list: () => TerminalSession[];
   get: (runId: string) => TerminalSession | undefined;
@@ -110,6 +267,9 @@ export type Terminal = {
 
 export type OpenTerminalOptions = {
   pty: PtyModule;
+  // The tmux durability backend. Only required when a spawn asks for
+  // `backend: 'tmux'` (or when calling detach/discover/reattach on tmux runs).
+  tmux?: TmuxBinding;
   // Injected for determinism in tests; defaults avoid crypto/import-time deps.
   makeRunId?: () => string;
   now?: () => number;
@@ -130,6 +290,12 @@ type Session = {
   meta: TerminalSession;
   pty: PtyProcess;
   buffer: string;
+  cols: number;
+  rows: number;
+  tmuxName?: string;
+  // What we asked for, so the pty's onExit can tell a commanded detach/kill from
+  // an unexpected client death.
+  intent?: 'detach' | 'kill';
   dataListeners: Set<(data: string) => void>;
   exitListeners: Set<(exit: TerminalExit) => void>;
 };
@@ -154,6 +320,26 @@ export function openTerminal(options: OpenTerminalOptions): Terminal {
     return session;
   };
 
+  const requireTmux = (op: string): TmuxBinding => {
+    if (!options.tmux)
+      throw new Error(`terminal.${op} requires openTerminal({ tmux })`);
+    return options.tmux;
+  };
+
+  const buildEnv = (
+    extra?: Record<string, string | undefined>,
+  ): Record<string, string> | undefined => {
+    // node-pty wants a string map; merge the injected base env (PATH etc.) under
+    // the spawn's own env, dropping undefined values.
+    const env: Record<string, string> = {};
+    for (const source of [options.baseEnv, extra]) {
+      for (const [k, v] of Object.entries(source ?? {})) {
+        if (typeof v === 'string') env[k] = v;
+      }
+    }
+    return Object.keys(env).length > 0 ? env : undefined;
+  };
+
   const appendBuffer = (session: Session, data: string) => {
     if (maxBuffer <= 0) return;
     session.buffer += data;
@@ -163,6 +349,66 @@ export function openTerminal(options: OpenTerminalOptions): Terminal {
     }
   };
 
+  const finalizeExit = (
+    session: Session,
+    exitCode: number,
+    signal: number | undefined,
+    status: 'exited' | 'orphaned' = 'exited',
+  ) => {
+    session.meta.status = status;
+    session.meta.exitCode = exitCode;
+    session.meta.exitSignal = signal;
+    session.meta.endedAt = now();
+    session.intent = undefined;
+    const exit: TerminalExit = { runId: session.meta.runId, exitCode, signal };
+    for (const listener of session.exitListeners) listener(exit);
+  };
+
+  // Wire a (possibly fresh, after reattach) pty child's data/exit into a
+  // session. Kept separate so spawn and reattach share exactly one handler.
+  const wireChild = (session: Session, child: PtyProcess) => {
+    child.onData((data) => {
+      appendBuffer(session, data);
+      for (const listener of session.dataListeners) listener(data);
+    });
+    child.onExit(({ exitCode, signal }) => {
+      if (session.meta.backend !== 'tmux') {
+        // direct backend: the client IS the process; its exit is the end
+        finalizeExit(session, exitCode, signal);
+        return;
+      }
+      if (session.intent === 'detach') {
+        // commanded detach: the tmux session lives on, agent keeps running
+        session.meta.status = 'detached';
+        session.intent = undefined;
+        return;
+      }
+      if (session.intent === 'kill') {
+        finalizeExit(session, exitCode, signal);
+        return;
+      }
+      // Unexpected client exit. It could be a detach-by-signal (session alive)
+      // or a genuine end (session gone). Ask the server rather than guess (F6).
+      const tmux = options.tmux;
+      if (tmux && session.tmuxName) {
+        void tmux.control
+          .run(buildTmuxHasSessionArgs(tmux.config, session.tmuxName))
+          .then(({ code }) => {
+            if (code === 0) {
+              // survived: reattachable
+              session.meta.status = 'detached';
+            } else {
+              // gone but we didn't kill it: it died outside our control
+              finalizeExit(session, exitCode, signal, 'orphaned');
+            }
+          })
+          .catch(() => finalizeExit(session, exitCode, signal, 'orphaned'));
+      } else {
+        finalizeExit(session, exitCode, signal, 'orphaned');
+      }
+    });
+  };
+
   const spawn: Terminal['spawn'] = (spawnOptions) => {
     if (!spawnOptions.command)
       throw new Error('terminal.spawn requires a command');
@@ -170,62 +416,78 @@ export function openTerminal(options: OpenTerminalOptions): Terminal {
     if (sessions.has(runId))
       throw new Error(`terminal run '${runId}' already exists`);
     const args = spawnOptions.args ?? [];
+    const cols = spawnOptions.cols ?? 80;
+    const rows = spawnOptions.rows ?? 24;
+    const backend: TerminalBackend = spawnOptions.backend ?? 'direct';
 
-    // node-pty wants a string map; merge the injected base env (PATH etc.) under
-    // the spawn's own env, dropping undefined values.
-    const env: Record<string, string> = {};
-    for (const source of [options.baseEnv, spawnOptions.env]) {
-      for (const [k, v] of Object.entries(source ?? {})) {
-        if (typeof v === 'string') env[k] = v;
-      }
+    // Decide what the pty actually launches: the command directly, or a tmux
+    // attach-or-create client that owns it.
+    let file = spawnOptions.command;
+    let ptyArgs = args;
+    let tmuxName: string | undefined;
+    let backendDetail: TerminalBackendDetail | undefined;
+    if (backend === 'tmux') {
+      const tmux = requireTmux('spawn');
+      tmuxName = tmuxSessionName(spawnOptions.provider ?? 'agent', runId);
+      file = tmux.config.bin;
+      ptyArgs = buildTmuxNewSessionArgs(
+        tmux.config,
+        tmuxName,
+        spawnOptions.command,
+        args,
+        cols,
+        rows,
+      );
+      backendDetail = {
+        kind: 'tmux',
+        socket: tmux.config.socket,
+        tmuxName,
+      };
     }
 
-    const child = pty.spawn(spawnOptions.command, args, {
+    const child = pty.spawn(file, ptyArgs, {
       name: 'xterm-color',
-      cols: spawnOptions.cols ?? 80,
-      rows: spawnOptions.rows ?? 24,
+      cols,
+      rows,
       cwd: spawnOptions.cwd,
-      env: Object.keys(env).length > 0 ? env : undefined,
+      env: buildEnv(spawnOptions.env),
     });
 
     const meta: TerminalSession = {
       runId,
       pid: child.pid,
       workId: spawnOptions.workId,
+      provider: spawnOptions.provider,
       command: spawnOptions.command,
       args,
       cwd: spawnOptions.cwd,
       startedAt: now(),
       status: 'running',
+      backend,
+      backendDetail,
     };
     const session: Session = {
       meta,
       pty: child,
       buffer: '',
+      cols,
+      rows,
+      tmuxName,
       dataListeners: new Set(),
       exitListeners: new Set(),
     };
     sessions.set(runId, session);
-
-    child.onData((data) => {
-      appendBuffer(session, data);
-      for (const listener of session.dataListeners) listener(data);
-    });
-    child.onExit(({ exitCode, signal }) => {
-      session.meta.status = 'exited';
-      session.meta.exitCode = exitCode;
-      session.meta.exitSignal = signal;
-      session.meta.endedAt = now();
-      const exit: TerminalExit = { runId, exitCode, signal };
-      for (const listener of session.exitListeners) listener(exit);
-    });
+    wireChild(session, child);
 
     return { ...meta };
   };
 
   const write: Terminal['write'] = (runId, data) => {
     const session = require_(runId);
-    if (session.meta.status === 'exited') {
+    if (
+      session.meta.status === 'exited' ||
+      session.meta.status === 'orphaned'
+    ) {
       throw new Error(`terminal run '${runId}' has exited`);
     }
     session.pty.write(data);
@@ -233,14 +495,52 @@ export function openTerminal(options: OpenTerminalOptions): Terminal {
 
   const resize: Terminal['resize'] = (runId, cols, rows) => {
     const session = require_(runId);
-    if (session.meta.status === 'exited') return;
+    session.cols = cols;
+    session.rows = rows;
+    if (session.meta.status !== 'running') return;
     session.pty.resize(cols, rows);
   };
 
   const kill: Terminal['kill'] = (runId, signal) => {
     const session = require_(runId);
-    if (session.meta.status === 'exited') return;
+    if (session.meta.status === 'exited' || session.meta.status === 'orphaned')
+      return;
+    if (session.meta.backend === 'tmux') {
+      session.intent = 'kill';
+      const tmux = options.tmux;
+      if (tmux && session.tmuxName) {
+        // Really end the session on the server (the agent dies). The attached
+        // client, if any, then exits and onExit finalizes with intent 'kill'.
+        void tmux.control
+          .run(buildTmuxKillSessionArgs(tmux.config, session.tmuxName))
+          .catch(() => {});
+      }
+      if (session.meta.status === 'detached') {
+        // No attached client, so no pty onExit will fire; finalize now.
+        finalizeExit(session, 0, undefined);
+        return;
+      }
+      // Attached: signal the client too so it tears down promptly.
+      try {
+        session.pty.kill(signal);
+      } catch {
+        /* client may already be gone */
+      }
+      return;
+    }
     session.pty.kill(signal);
+  };
+
+  const detach: Terminal['detach'] = (runId) => {
+    const session = require_(runId);
+    if (session.meta.backend !== 'tmux')
+      throw new Error(`terminal run '${runId}' has no detachable backend`);
+    if (session.meta.status !== 'running') return;
+    // Kill the attach client (SIGHUP by default): the tmux client detaches and
+    // the session keeps running on the server. onExit sees intent 'detach' and
+    // marks the session detached without firing exit listeners.
+    session.intent = 'detach';
+    session.pty.kill();
   };
 
   const onData: Terminal['onData'] = (runId, listener) => {
@@ -253,7 +553,10 @@ export function openTerminal(options: OpenTerminalOptions): Terminal {
 
   const onExit: Terminal['onExit'] = (runId, listener) => {
     const session = require_(runId);
-    if (session.meta.status === 'exited') {
+    if (
+      session.meta.status === 'exited' ||
+      session.meta.status === 'orphaned'
+    ) {
       listener({
         runId,
         exitCode: session.meta.exitCode ?? 0,
@@ -265,6 +568,100 @@ export function openTerminal(options: OpenTerminalOptions): Terminal {
     return { stop: () => session.exitListeners.delete(listener) };
   };
 
+  const discover: Terminal['discover'] = async () => {
+    const tmux = requireTmux('discover');
+    const res = await tmux.control.run(buildTmuxListArgs(tmux.config));
+    if (res.code !== 0) {
+      // No server / empty socket: the server did not answer, so we cannot
+      // conclude anything about known sessions (F6 "unknown"). Leave statuses
+      // untouched and report nothing live.
+      return [];
+    }
+    const liveNames = res.stdout
+      .split('\n')
+      .map((s) => s.trim())
+      .filter((s) => s.startsWith('kf_'));
+    const liveSet = new Set(liveNames);
+
+    // Reconcile known tmux sessions against the live set. Only runs here, where
+    // the server actually answered.
+    const ownedByName = new Map<string, Session>();
+    for (const session of sessions.values()) {
+      if (session.meta.backend !== 'tmux' || !session.tmuxName) continue;
+      ownedByName.set(session.tmuxName, session);
+      if (session.meta.status === 'exited') continue;
+      if (liveSet.has(session.tmuxName)) {
+        // Still on the server. If we'd marked it orphaned on a bad probe, it is
+        // actually just detached (reattachable). A 'running' stays 'running'.
+        if (session.meta.status === 'orphaned')
+          session.meta.status = 'detached';
+      } else {
+        // Server answered and our name is absent → truly gone, and we did not
+        // command it → orphaned.
+        session.meta.status = 'orphaned';
+        session.meta.endedAt = session.meta.endedAt ?? now();
+      }
+    }
+
+    return liveNames.map((tmuxName) => {
+      const owned = ownedByName.get(tmuxName);
+      return {
+        tmuxName,
+        owned: !!owned,
+        attached: owned?.meta.status === 'running',
+        runId: owned?.meta.runId,
+        provider: owned?.meta.provider,
+      };
+    });
+  };
+
+  const reattach: Terminal['reattach'] = async (runId) => {
+    const session = require_(runId);
+    const tmux = requireTmux('reattach');
+    if (session.meta.backend !== 'tmux' || !session.tmuxName)
+      throw new Error(`terminal run '${runId}' is not a tmux session`);
+    if (session.meta.status === 'running') return { ...session.meta };
+    // Guard: never let attach-or-create silently recreate a gone session (which
+    // would re-run the agent command). Only reattach one that still exists.
+    const has = await tmux.control.run(
+      buildTmuxHasSessionArgs(tmux.config, session.tmuxName),
+    );
+    if (has.code !== 0) {
+      session.meta.status = 'orphaned';
+      session.meta.endedAt = session.meta.endedAt ?? now();
+      throw new Error(
+        `tmux session '${session.tmuxName}' is gone; cannot reattach`,
+      );
+    }
+    const child = pty.spawn(
+      tmux.config.bin,
+      buildTmuxNewSessionArgs(
+        tmux.config,
+        session.tmuxName,
+        session.meta.command,
+        session.meta.args,
+        session.cols,
+        session.rows,
+      ),
+      {
+        name: 'xterm-color',
+        cols: session.cols,
+        rows: session.rows,
+        cwd: session.meta.cwd,
+        env: buildEnv(),
+      },
+    );
+    session.pty = child;
+    session.meta.pid = child.pid;
+    session.meta.status = 'running';
+    session.meta.exitCode = undefined;
+    session.meta.exitSignal = undefined;
+    session.meta.endedAt = undefined;
+    session.intent = undefined;
+    wireChild(session, child);
+    return { ...session.meta };
+  };
+
   const list: Terminal['list'] = () =>
     Array.from(sessions.values()).map((s) => ({ ...s.meta }));
 
@@ -273,5 +670,17 @@ export function openTerminal(options: OpenTerminalOptions): Terminal {
     return session ? { ...session.meta } : undefined;
   };
 
-  return { spawn, write, resize, kill, onData, onExit, list, get };
+  return {
+    spawn,
+    write,
+    resize,
+    kill,
+    detach,
+    onData,
+    onExit,
+    discover,
+    reattach,
+    list,
+    get,
+  };
 }

--- a/framework/api/src/capability/terminal.ts
+++ b/framework/api/src/capability/terminal.ts
@@ -225,6 +225,21 @@ export type DiscoveredSession = {
   provider?: string;
 };
 
+// Enough persisted identity to re-adopt a session the host did not create this
+// run — a workspace restoring after an app restart, when the in-memory session
+// map is empty but the tmux session may still be alive on the socket. runId +
+// provider recompute the deterministic tmux name; command/args/cwd only label
+// the restored snapshot (the surviving session keeps its own running process).
+export type AdoptSpec = {
+  runId: string;
+  provider?: string;
+  command?: string;
+  args?: string[];
+  cwd?: string;
+  cols?: number;
+  rows?: number;
+};
+
 export type Terminal = {
   // Start a managed process bound to a run. Returns the session snapshot; the
   // run is addressable by runId for every other method.
@@ -260,6 +275,12 @@ export type Terminal = {
   // has-session so a gone session is never silently recreated (which would
   // re-run the agent command). Requires a tmux binding.
   reattach: (runId: string) => Promise<TerminalSession>;
+  // Re-adopt a persisted session after a restart: register a runId the host did
+  // not create this run and attach to its surviving tmux session. If the tmux
+  // session is gone it returns an 'orphaned' snapshot WITHOUT registering it (so
+  // a caller can drop it), rather than recreating and re-running the command.
+  // Requires a tmux binding.
+  adopt: (spec: AdoptSpec) => Promise<TerminalSession>;
   // All sessions this host knows, running and exited, newest last.
   list: () => TerminalSession[];
   get: (runId: string) => TerminalSession | undefined;
@@ -662,6 +683,84 @@ export function openTerminal(options: OpenTerminalOptions): Terminal {
     return { ...session.meta };
   };
 
+  const adopt: Terminal['adopt'] = async (spec) => {
+    const tmux = requireTmux('adopt');
+    // Already known this run: defer to the normal paths.
+    const existing = sessions.get(spec.runId);
+    if (existing) {
+      if (existing.meta.status === 'running') return { ...existing.meta };
+      return reattach(spec.runId);
+    }
+    const provider = spec.provider ?? 'agent';
+    const tmuxName = tmuxSessionName(provider, spec.runId);
+    const cols = spec.cols ?? 80;
+    const rows = spec.rows ?? 24;
+    const command = spec.command ?? '';
+    const args = spec.args ?? [];
+    const backendDetail: TerminalBackendDetail = {
+      kind: 'tmux',
+      socket: tmux.config.socket,
+      tmuxName,
+    };
+    const has = await tmux.control.run(
+      buildTmuxHasSessionArgs(tmux.config, tmuxName),
+    );
+    if (has.code !== 0) {
+      // Gone: report it as orphaned but do NOT register it, so attach-or-create
+      // never recreates and re-runs the command, and the caller can drop it.
+      return {
+        runId: spec.runId,
+        pid: -1,
+        provider,
+        command,
+        args,
+        cwd: spec.cwd,
+        startedAt: now(),
+        status: 'orphaned',
+        backend: 'tmux',
+        backendDetail,
+      };
+    }
+    // Alive: register the run and attach a fresh client (command ignored on an
+    // existing session).
+    const child = pty.spawn(
+      tmux.config.bin,
+      buildTmuxNewSessionArgs(tmux.config, tmuxName, command, args, cols, rows),
+      {
+        name: 'xterm-color',
+        cols,
+        rows,
+        cwd: spec.cwd,
+        env: buildEnv(),
+      },
+    );
+    const meta: TerminalSession = {
+      runId: spec.runId,
+      pid: child.pid,
+      provider,
+      command,
+      args,
+      cwd: spec.cwd,
+      startedAt: now(),
+      status: 'running',
+      backend: 'tmux',
+      backendDetail,
+    };
+    const session: Session = {
+      meta,
+      pty: child,
+      buffer: '',
+      cols,
+      rows,
+      tmuxName,
+      dataListeners: new Set(),
+      exitListeners: new Set(),
+    };
+    sessions.set(spec.runId, session);
+    wireChild(session, child);
+    return { ...meta };
+  };
+
   const list: Terminal['list'] = () =>
     Array.from(sessions.values()).map((s) => ({ ...s.meta }));
 
@@ -680,6 +779,7 @@ export function openTerminal(options: OpenTerminalOptions): Terminal {
     onExit,
     discover,
     reattach,
+    adopt,
     list,
     get,
   };

--- a/framework/api/src/capability/terminal.ts
+++ b/framework/api/src/capability/terminal.ts
@@ -610,7 +610,12 @@ export function openTerminal(options: OpenTerminalOptions): Terminal {
     for (const session of sessions.values()) {
       if (session.meta.backend !== 'tmux' || !session.tmuxName) continue;
       ownedByName.set(session.tmuxName, session);
-      if (session.meta.status === 'exited') continue;
+      // A 'running' session has a live attached pty client, so its tmux session
+      // is guaranteed to exist; a racing list snapshot taken while the client is
+      // still attaching would not list it yet, and must not orphan it. Only
+      // client-gone sessions ('detached'/'orphaned') need liveSet reconciliation.
+      if (session.meta.status === 'exited' || session.meta.status === 'running')
+        continue;
       if (liveSet.has(session.tmuxName)) {
         // Still on the server. If we'd marked it orphaned on a bad probe, it is
         // actually just detached (reattachable). A 'running' stays 'running'.

--- a/framework/core/docs/adr/ADR-0015-managed-session-host-placement.md
+++ b/framework/core/docs/adr/ADR-0015-managed-session-host-placement.md
@@ -1,0 +1,126 @@
+# ADR-0015: managed session host placement — a shared durable host for multi-window session workspaces
+
+- Status: proposed
+- Date: 2026-07-05
+- Category: (architecture) process placement — where the terminal/session
+  capability host runs, and how multiple GUI windows reach it.
+- Subsystem: the terminal capability (`framework/api/src/capability/terminal.ts`),
+  the reference-app window model (`framework/gui` main + renderer), and the
+  managed session workspace (`extensions/terminal`).
+- Related: ADR-0011 pinned the capability SDK contract — tier declaration and
+  the zero-copy-vs-serialized split for the GUI view plane. ADR-0014 pinned the
+  uniform capability surface across trust tiers: one source runs unchanged
+  whether its capabilities are held in-process or addressed over an async
+  capability relay. ADR-0006 pinned the v4 frontend platform. This ADR pins
+  where the *session* host lives once the workspace must span more than one OS
+  window.
+
+## Context
+
+The managed session workspace is the visual-concurrency wedge: it exists to
+replace the seven-to-eight terminal windows a user spreads across monitors to
+watch that many agent sessions at once. A single OS window cannot span
+monitors, so a real replacement needs more than one OS window — in the limit,
+one restorable window per session, placed on the display the user put it on.
+
+Today the reference app is a single `BrowserWindow` with a single renderer. The
+terminal/session capability host (`openTerminal` — a node-pty PTY host plus the
+tmux durability backend added on this branch) lives in that one renderer, and a
+session is addressable only through that renderer's in-memory session map.
+
+Two capabilities already landed on this branch move the problem to exactly one
+remaining blocker:
+
+- The tmux durability backend lets a session survive GUI close/crash; `detach`
+  keeps the agent running, `discover`/`reattach` bring it back.
+- A persisted `WorkspaceLayout` (a journal-backed config fact) restores the open
+  set after an app restart via `adopt`, which re-registers a session by runId
+  and reattaches to its surviving tmux session.
+
+The blocker: a second `BrowserWindow` is a separate renderer process. It cannot
+reach the first renderer's in-memory session host. To show sessions in more than
+one OS window, the durable session host must be reachable from every window —
+which is a placement question, not a feature.
+
+### Forces
+
+1. **Durability wants the host to outlive any window.** That is the point of the
+   whole line. Today the tmux backend keeps the *agent* alive when a window
+   closes, but the host *handle* dies with the renderer and must rediscover and
+   reattach. A host that outlives windows removes that gap.
+2. **The moat (ADR-0011) keeps zero-copy journal/state access in the trusted
+   renderer.** But the terminal host is not the zero-copy journal path — it is
+   node-pty and tmux, already separable from the kungfu binding, and it already
+   exposes a Promise-friendly surface (the view uses one `resolve()` path for
+   both the sync and async shapes).
+3. **The uniform capability surface (ADR-0014) already tolerates an out-of-process
+   host.** A sandboxed view addresses its capabilities over an async relay today;
+   the transport and the capability proxy already exist. An out-of-renderer
+   terminal host is within that design envelope, not a new IPC invention.
+
+## Options
+
+**A. Host stays in the shell renderer; extra windows relay to it.** Each session
+window is a `BrowserWindow` that reaches the shell renderer's host through main
+(window → main → shell renderer → host → back). A three-hop relay, and the host
+still dies with the shell window — the durability gap in force (1) remains. High
+complexity for a worse durability story. Rejected.
+
+**B. Move the session host to the main process.** node-pty + the tmux backend run
+in main (main is node, app-lifetime). Every renderer — the shell and each
+per-session window — reaches the host through `ipcMain`, reusing the ADR-0014
+capability relay; `caps.terminal` becomes an IPC proxy for all consumers.
+`onData`/`onExit` become relayed event streams. The host outlives every window,
+which is exactly force (1); it reuses the existing relay per force (3); and it
+leaves the zero-copy journal moat untouched in the trusted renderer per force
+(2), since the terminal host was never on that path.
+
+**C. Stay single-window (the in-view grid only).** No monitor spanning; the wedge
+is only partially met (three panes on one screen, not seven across three
+monitors). Acceptable as a resting point, not as the destination.
+
+## Decision (proposed)
+
+Adopt **Option B**: the managed session host moves to the main process and is
+addressed by every window over the existing capability relay.
+
+Rationale: it is the only option where the durable host genuinely outlives
+windows (matching the intent of the whole durability line); it reuses the
+ADR-0014 relay rather than inventing transport; and it cleanly separates the
+session host (node-pty/tmux) from the zero-copy journal moat that stays in the
+trusted renderer under ADR-0011. tmux remains a backend detail; the product
+model still speaks "session", never "tmux".
+
+### Migration plan (staged, each stage validated on a real machine)
+
+1. **Extract the host to main, proxy to the renderer.** Move `openTerminal`
+   wiring from the renderer runtime into a main-process module; expose it over
+   `ipcMain` through the capability transport; keep the renderer `caps.terminal`
+   as an IPC proxy of the same `Terminal` interface. Validate parity: the
+   existing single-window workspace behaves identically (no product change).
+2. **Per-session windows + bounds.** Add `BrowserWindow`-per-session management in
+   main and extend `WorkspaceLayout` with `windows[]` carrying display identity
+   and bounds. Land F7: a stable display identifier plus clamp rules — an
+   off-screen window is pulled back onto a visible display, a window whose saved
+   display is gone falls back to the primary.
+3. **Session-window entry.** A window renderer that mounts the existing terminal
+   view against a single runId over the proxy.
+4. **Overview.** Keep the in-shell grid as an at-a-glance overview; the OS windows
+   are the working surface.
+
+## Consequences
+
+- **Positive.** Real multi-monitor session windows; a host that survives window
+  churn; reuse of the existing relay; the journal moat is untouched.
+- **Negative.** The terminal capability now always crosses IPC, so high-throughput
+  output pays relay cost — mitigated by the host's existing 256 KiB per-session
+  buffer and late-attach replay, but it needs real-machine validation of
+  streaming and backpressure. The main-process surface grows (window lifecycle,
+  per-session windows). None of this is verifiable without running Electron, so
+  each stage lands behind a real-machine check.
+- **Neutral.** ADR-0011 is unaffected: journal/state zero-copy stays in the
+  trusted renderer. ADR-0014's relay gains a first-party, non-sandbox consumer.
+
+Status remains **proposed** until this placement is accepted; the single-window
+workspace, tmux backend, and layout persistence already on this branch stand on
+their own and do not depend on the decision.

--- a/framework/core/docs/adr/ADR-0015-managed-session-host-placement.md
+++ b/framework/core/docs/adr/ADR-0015-managed-session-host-placement.md
@@ -1,6 +1,6 @@
 # ADR-0015: managed session host placement — a shared durable host for multi-window session workspaces
 
-- Status: proposed
+- Status: accepted
 - Date: 2026-07-05
 - Category: (architecture) process placement — where the terminal/session
   capability host runs, and how multiple GUI windows reach it.
@@ -121,6 +121,34 @@ model still speaks "session", never "tmux".
 - **Neutral.** ADR-0011 is unaffected: journal/state zero-copy stays in the
   trusted renderer. ADR-0014's relay gains a first-party, non-sandbox consumer.
 
-Status remains **proposed** until this placement is accepted; the single-window
-workspace, tmux backend, and layout persistence already on this branch stand on
-their own and do not depend on the decision.
+**Accepted** 2026-07-05: the placement is adopted and the migration proceeds
+stage by stage, each behind a real-machine check. The single-window workspace,
+tmux backend, and layout persistence already on this branch stand on their own
+and were not blocked on this decision.
+
+## Implementation note — the relay does not round-trip a subscription's stop()
+
+The obvious way to reach a main-process host is to reuse the existing capability
+relay (`createCapabilityHost` / `createCapabilityGuest`). That relay does
+marshal callback arguments (an `onData` listener crosses as a callback ref, and
+the host emits events back), but it does **not** round-trip a per-subscription
+`stop()`: the host returns a `{ __sandboxSubscription }` marker and only drops
+subscriptions in bulk when the whole guest disconnects (`host.dispose()`). The
+guest proxy hands that marker straight back, so `sub.stop()` is a no-op on a
+sandboxed view.
+
+That is fine for a view-lifetime capability, but wrong for the terminal host,
+whose subscriptions churn continuously — every pane adds and removes `onData` /
+`onExit`, and a `stop()` that does nothing would leak listeners on a long-lived
+host and keep writing into disposed terminals. So Stage 1 uses a **terminal-
+specific IPC proxy** with an explicit subscribe / unsubscribe protocol
+(subscribe returns a real `{ stop }` that calls back to release the host-side
+subscription), rather than extending the shared relay. Extending the shared
+relay to round-trip `stop()` is a larger change to an ADR-0014 contract module
+and is deferred; the terminal proxy stays self-contained.
+
+Stage 1 lands **behind a flag** (`KF_TERMINAL_HOST=main`): the default keeps the
+in-renderer host, so the working single-window app is untouched and parity is
+preserved by construction, while the main-process path is exercised by flipping
+the flag on a real machine. Promoting it to the default happens only after that
+real-machine parity check passes.

--- a/framework/core/docs/adr/ADR-0016-managed-session-host-placement.md
+++ b/framework/core/docs/adr/ADR-0016-managed-session-host-placement.md
@@ -1,4 +1,4 @@
-# ADR-0015: managed session host placement — a shared durable host for multi-window session workspaces
+# ADR-0016: managed session host placement — a shared durable host for multi-window session workspaces
 
 - Status: accepted
 - Date: 2026-07-05

--- a/framework/core/docs/adr/README.md
+++ b/framework/core/docs/adr/README.md
@@ -31,6 +31,7 @@ A record's **Status** says where it stands:
 | [0013](ADR-0013-cli-runtime-extension-isolation-trusted-channel.md) | proposed | extension isolation and the trusted channel on the runtime plane — trust by verifiable origin, default-deny OS sandbox, zero-copy only for the trusted channel |
 | [0014](ADR-0014-extension-execution-contract-uniform-capability-surface.md) | proposed | the extension execution contract — one uniform capability surface across trust tiers, restriction as transparent interception, a binding-less guest host |
 | [0015](ADR-0015-kungfu-skill-agent-context-layer.md) | accepted | Kungfu Skill as the agent context layer above kfx |
+| [0015](ADR-0015-managed-session-host-placement.md) | proposed | managed session host placement — move the durable session host to main so multiple OS windows share it |
 
 ## Reading by theme
 

--- a/framework/core/docs/adr/README.md
+++ b/framework/core/docs/adr/README.md
@@ -31,7 +31,7 @@ A record's **Status** says where it stands:
 | [0013](ADR-0013-cli-runtime-extension-isolation-trusted-channel.md) | proposed | extension isolation and the trusted channel on the runtime plane — trust by verifiable origin, default-deny OS sandbox, zero-copy only for the trusted channel |
 | [0014](ADR-0014-extension-execution-contract-uniform-capability-surface.md) | proposed | the extension execution contract — one uniform capability surface across trust tiers, restriction as transparent interception, a binding-less guest host |
 | [0015](ADR-0015-kungfu-skill-agent-context-layer.md) | accepted | Kungfu Skill as the agent context layer above kfx |
-| [0015](ADR-0015-managed-session-host-placement.md) | accepted | managed session host placement — move the durable session host to main so multiple OS windows share it |
+| [0016](ADR-0016-managed-session-host-placement.md) | accepted | managed session host placement — move the durable session host to main so multiple OS windows share it |
 
 ## Reading by theme
 

--- a/framework/core/docs/adr/README.md
+++ b/framework/core/docs/adr/README.md
@@ -31,7 +31,7 @@ A record's **Status** says where it stands:
 | [0013](ADR-0013-cli-runtime-extension-isolation-trusted-channel.md) | proposed | extension isolation and the trusted channel on the runtime plane — trust by verifiable origin, default-deny OS sandbox, zero-copy only for the trusted channel |
 | [0014](ADR-0014-extension-execution-contract-uniform-capability-surface.md) | proposed | the extension execution contract — one uniform capability surface across trust tiers, restriction as transparent interception, a binding-less guest host |
 | [0015](ADR-0015-kungfu-skill-agent-context-layer.md) | accepted | Kungfu Skill as the agent context layer above kfx |
-| [0015](ADR-0015-managed-session-host-placement.md) | proposed | managed session host placement — move the durable session host to main so multiple OS windows share it |
+| [0015](ADR-0015-managed-session-host-placement.md) | accepted | managed session host placement — move the durable session host to main so multiple OS windows share it |
 
 ## Reading by theme
 

--- a/framework/gui/electron.vite.config.mjs
+++ b/framework/gui/electron.vite.config.mjs
@@ -1,9 +1,74 @@
+import { createRequire } from 'node:module';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import react from '@vitejs/plugin-react';
 import { defineConfig, externalizeDepsPlugin } from 'electron-vite';
 
 const rootDir = dirname(fileURLToPath(import.meta.url));
+const nodeRequire = createRequire(import.meta.url);
+
+// The trusted renderer runs under nodeIntegration, so node builtins are
+// available via require() at runtime. Marking them `external` alone is not
+// enough: in an ESM browser bundle an external `node:fs` stays an `import` the
+// Chromium loader tries to fetch as a URL (ERR_UNKNOWN_URL_SCHEME), failing the
+// whole chunk. The capability SDK's node-only host modules (the OS-sandbox
+// launcher, the subprocess relay) sit in the renderer graph and are not
+// tree-shaken because the shell injects the whole capability namespace. This
+// plugin resolves every `node:*` (and its bare alias) to a tiny CJS shim that
+// re-exports the real builtin via window.require, so those static imports load
+// (and a renderer that never calls them pays nothing).
+function nodeBuiltinRequireShim() {
+  const PREFIX = '\0kf-node-builtin:';
+  const builtins = new Set([
+    'fs',
+    'os',
+    'path',
+    'child_process',
+    'readline',
+    'util',
+    'events',
+    'stream',
+    'net',
+    'crypto',
+    'url',
+    'assert',
+    'buffer',
+    'tty',
+  ]);
+  const bare = (id) => (id.startsWith('node:') ? id.slice(5) : id);
+  return {
+    name: 'kf-node-builtin-require-shim',
+    enforce: 'pre',
+    resolveId(id) {
+      const name = bare(id);
+      if (id.startsWith('node:') || builtins.has(name)) return PREFIX + name;
+      return null;
+    },
+    load(id) {
+      if (!id.startsWith(PREFIX)) return null;
+      const name = id.slice(PREFIX.length);
+      // Enumerate the real builtin's exports here (the config runs in node), so
+      // the generated ESM re-exports every named import a consumer might use.
+      // The values come from window.require at runtime under nodeIntegration.
+      let keys = [];
+      try {
+        const real = nodeRequire(`node:${name}`);
+        keys = Object.keys(real).filter(
+          (k) => k !== 'default' && /^[A-Za-z_$][\w$]*$/.test(k),
+        );
+      } catch {
+        keys = [];
+      }
+      const spec = JSON.stringify(`node:${name}`);
+      return [
+        `const req = (typeof window !== 'undefined' && window.require) ? window.require : null;`,
+        `const m = req ? req(${spec}) : {};`,
+        'export default m;',
+        ...keys.map((k) => `export const ${k} = m[${JSON.stringify(k)}];`),
+      ].join('\n');
+    },
+  };
+}
 
 // - main: externalize deps so the native binding is never bundled; it is loaded
 //   via require() at runtime from kungfu-core's dist/kungfu.
@@ -35,16 +100,12 @@ export default defineConfig({
     },
   },
   renderer: {
-    plugins: [react()],
+    // nodeBuiltinRequireShim maps node:* to a window.require CJS shim (see its
+    // definition above); electron stays external and is require()d at runtime.
+    plugins: [nodeBuiltinRequireShim(), react()],
     build: {
       rollupOptions: {
-        // The trusted renderer runs under nodeIntegration, so keep electron and
-        // the node builtins external — they are require()d at runtime. The
-        // capability SDK re-exports node-only host modules (the OS-sandbox
-        // launcher, the subprocess relay) that a renderer never invokes; leaving
-        // node: builtins external lets those modules sit in the graph without
-        // the browser build trying to bundle node:fs / node:os.
-        external: ['electron', /^node:/],
+        external: ['electron'],
         input: {
           index: resolve(rootDir, 'src/renderer/index.html'),
           'sandbox-view-harness': resolve(

--- a/framework/gui/src/main/index.ts
+++ b/framework/gui/src/main/index.ts
@@ -253,7 +253,7 @@ function createWindow() {
 
 app.whenReady().then(() => {
   buildMenu();
-  // ADR-0015 stage 1 (flagged): run the durable session host in main so it
+  // ADR-0016 stage 1 (flagged): run the durable session host in main so it
   // outlives windows. The ipcMain handlers are global, so bind once; events are
   // sent back to whichever renderer subscribed. Default keeps the in-renderer
   // host, so the working app is untouched until this path is validated.

--- a/framework/gui/src/main/index.ts
+++ b/framework/gui/src/main/index.ts
@@ -33,6 +33,10 @@ import {
 } from './installCli';
 import { type Rect, SandboxManager } from './sandbox-manager';
 import { writeGuiSkillContextFile } from './skill-context';
+import {
+  bindElectronTerminalHost,
+  createMainTerminalHost,
+} from './terminal-host';
 
 // Resolve the kungfu runtime directory that holds libkungfu.dylib and the
 // kungfu_electron.node binding. In development it lives in the kungfu-core
@@ -249,6 +253,17 @@ function createWindow() {
 
 app.whenReady().then(() => {
   buildMenu();
+  // ADR-0015 stage 1 (flagged): run the durable session host in main so it
+  // outlives windows. The ipcMain handlers are global, so bind once; events are
+  // sent back to whichever renderer subscribed. Default keeps the in-renderer
+  // host, so the working app is untouched until this path is validated.
+  if (process.env.KF_TERMINAL_HOST === 'main') {
+    try {
+      bindElectronTerminalHost(ipcMain, createMainTerminalHost());
+    } catch (e) {
+      console.log(`KF_TERMINAL_HOST_MAIN_FAIL ${(e as Error).message}`);
+    }
+  }
   createWindow();
 });
 

--- a/framework/gui/src/main/sandbox-manager.ts
+++ b/framework/gui/src/main/sandbox-manager.ts
@@ -193,7 +193,7 @@ export class SandboxManager {
         );
         return;
       }
-      // `kfs kfx build` emits the view's styles as a sibling index.css. Ship it
+      // `kungfu sdk kfx build` emits the view's styles as a sibling index.css. Ship it
       // alongside the bundle so the sandboxed view's CSS (xterm.css, which
       // positions rows, maps mouse coordinates, and hides the helper textarea)
       // actually applies inside the isolated page. A view without a stylesheet

--- a/framework/gui/src/main/sandbox-manager.ts
+++ b/framework/gui/src/main/sandbox-manager.ts
@@ -193,8 +193,22 @@ export class SandboxManager {
         );
         return;
       }
+      // `kfs kfx build` emits the view's styles as a sibling index.css. Ship it
+      // alongside the bundle so the sandboxed view's CSS (xterm.css, which
+      // positions rows, maps mouse coordinates, and hides the helper textarea)
+      // actually applies inside the isolated page. A view without a stylesheet
+      // simply loads no css.
+      let css = '';
+      const cssPath = opts.bundlePath.replace(/\.js$/, '.css');
+      if (cssPath !== opts.bundlePath) {
+        try {
+          css = readFileSync(cssPath, 'utf8');
+        } catch {
+          // no sibling stylesheet — view ships no CSS
+        }
+      }
       void view.webContents.executeJavaScript(
-        `window.${HARNESS_GLOBAL}.load(${JSON.stringify(source)})`,
+        `window.${HARNESS_GLOBAL}.load(${JSON.stringify(source)}, ${JSON.stringify(css)})`,
       );
     });
 

--- a/framework/gui/src/main/terminal-host.ts
+++ b/framework/gui/src/main/terminal-host.ts
@@ -1,4 +1,4 @@
-// Main-process managed session host (ADR-0015 stage 1). The durable session
+// Main-process managed session host (ADR-0016 stage 1). The durable session
 // host — node-pty plus the tmux backend — runs here, in the app-lifetime main
 // process, so it outlives any single window and (later) is reachable from every
 // window. Renderers reach it over a terminal-specific relay (see

--- a/framework/gui/src/main/terminal-host.ts
+++ b/framework/gui/src/main/terminal-host.ts
@@ -1,0 +1,193 @@
+// Main-process managed session host (ADR-0015 stage 1). The durable session
+// host — node-pty plus the tmux backend — runs here, in the app-lifetime main
+// process, so it outlives any single window and (later) is reachable from every
+// window. Renderers reach it over a terminal-specific relay (see
+// terminal-channels): a per-subscription stop() round-trips, which the shared
+// capability relay does not do and which the terminal's churning onData/onExit
+// subscriptions require.
+//
+// This is gated by KF_TERMINAL_HOST=main; the default keeps the in-renderer
+// host, so the working single-window app is untouched until this path is
+// validated on a real machine.
+//
+// The relay core (createTerminalRelay) is pure and contract-testable; the
+// ipcMain glue (bindElectronTerminalHost) is the thin electron-only shell, the
+// same split sandbox-host.ts uses.
+import {
+  type PtyModule,
+  type Subscription,
+  type Terminal,
+  type TmuxBinding,
+  openTerminal,
+} from '@kungfu-tech/api/capability';
+
+import {
+  TERMINAL_CALL_CHANNEL,
+  TERMINAL_EVENT_CHANNEL,
+  TERMINAL_SUBSCRIBE_CHANNEL,
+  TERMINAL_UNSUBSCRIBE_CHANNEL,
+} from '../sandbox/channels';
+
+// Resolve an absolute tmux binary + isolated socket in the main process (node,
+// so require('node:*') is available directly — no window.require shim). Returns
+// null when no tmux is present; the host then runs sessions directly.
+function resolveTmuxBinding(): TmuxBinding | null {
+  try {
+    // Minimal local shapes rather than `typeof import('…')`, whose formatted
+    // multiline form is fragile; we need only existsSync and execFile.
+    const fs = require('node:fs') as {
+      existsSync: (p: string) => boolean;
+    };
+    const cp = require('node:child_process') as {
+      execFile: (
+        file: string,
+        args: string[],
+        options: { encoding: 'utf8' },
+        cb: (
+          err: (Error & { code?: number }) | null,
+          stdout: string,
+          stderr: string,
+        ) => void,
+      ) => void;
+    };
+    const socket = process.env.KF_TMUX_SOCKET || 'kungfu-managed';
+    const candidates = [
+      process.env.KF_TMUX_BIN,
+      '/opt/homebrew/bin/tmux',
+      '/usr/local/bin/tmux',
+      '/usr/bin/tmux',
+    ].filter((p): p is string => typeof p === 'string' && p.length > 0);
+    const bin = candidates.find((p) => {
+      try {
+        return fs.existsSync(p);
+      } catch {
+        return false;
+      }
+    });
+    if (!bin) return null;
+    return {
+      config: { socket, bin },
+      control: {
+        run: (args) =>
+          new Promise((resolve) => {
+            cp.execFile(
+              bin,
+              args,
+              { encoding: 'utf8' },
+              (err, stdout, stderr) => {
+                const code =
+                  err && typeof (err as { code?: unknown }).code === 'number'
+                    ? (err as { code: number }).code
+                    : err
+                      ? 1
+                      : 0;
+                resolve({ code, stdout: stdout ?? '', stderr: stderr ?? '' });
+              },
+            );
+          }),
+      },
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function createMainTerminalHost(): Terminal {
+  const pty = require('node-pty') as PtyModule;
+  const tmux = resolveTmuxBinding() ?? undefined;
+  return openTerminal({
+    pty,
+    tmux,
+    baseEnv: process.env as Record<string, string | undefined>,
+  });
+}
+
+// ── pure relay core ─────────────────────────────────────────────────────────
+
+type SubscribeMethod = 'onData' | 'onExit';
+
+// Wire a Terminal host behind three transport verbs. `call` dispatches a value
+// method; `subscribe` opens an onData/onExit stream whose events are pushed via
+// the per-subscription `emit`; `unsubscribe` releases exactly that stream. The
+// subId is minted by the guest, so stop() on the guest maps back to one stream.
+export function createTerminalRelay(host: Terminal) {
+  const subs = new Map<number, Subscription>();
+  return {
+    async call(method: string, args: unknown[]): Promise<unknown> {
+      const fn = (host as unknown as Record<string, unknown>)[method];
+      if (typeof fn !== 'function') {
+        throw new Error(`terminal has no method '${method}'`);
+      }
+      return await (fn as (...a: unknown[]) => unknown).apply(host, args);
+    },
+    subscribe(
+      method: SubscribeMethod,
+      runId: string,
+      subId: number,
+      emit: (args: unknown[]) => void,
+    ): void {
+      // replace any prior stream on this subId (defensive; guest ids are unique)
+      subs.get(subId)?.stop();
+      const sub =
+        method === 'onExit'
+          ? host.onExit(runId, (exit) => emit([exit]))
+          : host.onData(runId, (data) => emit([data]));
+      subs.set(subId, sub);
+    },
+    unsubscribe(subId: number): void {
+      subs.get(subId)?.stop();
+      subs.delete(subId);
+    },
+    dispose(): void {
+      for (const sub of subs.values()) sub.stop();
+      subs.clear();
+    },
+  };
+}
+
+// ── electron glue ───────────────────────────────────────────────────────────
+
+type TerminalInvokeEvent = {
+  sender: { send: (channel: string, payload: unknown) => void };
+};
+
+type IpcMainLike = {
+  handle: (
+    channel: string,
+    listener: (event: TerminalInvokeEvent, ...args: unknown[]) => unknown,
+  ) => void;
+  removeHandler: (channel: string) => void;
+};
+
+export function bindElectronTerminalHost(ipcMain: IpcMainLike, host: Terminal) {
+  const relay = createTerminalRelay(host);
+  ipcMain.handle(TERMINAL_CALL_CHANNEL, (_event, payload) => {
+    const { method, args } = payload as { method: string; args: unknown[] };
+    return relay.call(method, args);
+  });
+  ipcMain.handle(TERMINAL_SUBSCRIBE_CHANNEL, (event, payload) => {
+    const { method, runId, subId } = payload as {
+      method: SubscribeMethod;
+      runId: string;
+      subId: number;
+    };
+    // events go back to the renderer that subscribed
+    relay.subscribe(method, runId, subId, (args) =>
+      event.sender.send(TERMINAL_EVENT_CHANNEL, { subId, args }),
+    );
+    return undefined;
+  });
+  ipcMain.handle(TERMINAL_UNSUBSCRIBE_CHANNEL, (_event, payload) => {
+    const { subId } = payload as { subId: number };
+    relay.unsubscribe(subId);
+    return undefined;
+  });
+  return {
+    dispose() {
+      relay.dispose();
+      ipcMain.removeHandler(TERMINAL_CALL_CHANNEL);
+      ipcMain.removeHandler(TERMINAL_SUBSCRIBE_CHANNEL);
+      ipcMain.removeHandler(TERMINAL_UNSUBSCRIBE_CHANNEL);
+    },
+  };
+}

--- a/framework/gui/src/renderer/sandbox-view-harness/harness.ts
+++ b/framework/gui/src/renderer/sandbox-view-harness/harness.ts
@@ -34,7 +34,7 @@ declare global {
     __kfxHarness: {
       caps: Record<string, unknown>;
       bridge: SandboxBridge;
-      load: (code: string) => void;
+      load: (code: string, css?: string) => void;
       fail: (message: string) => void;
     };
   }
@@ -93,8 +93,17 @@ function fail(message: string): void {
   rootEl().textContent = `sandboxed view failed: ${message}`;
 }
 
-function load(code: string): void {
+function load(code: string, css?: string): void {
   try {
+    // `kfs kfx build` emits the view's styles as a sibling index.css that main
+    // reads and hands over here. Inject it before mounting so view CSS (e.g.
+    // xterm.css, which positions rows, maps mouse coordinates, and hides the
+    // helper textarea) actually applies inside this isolated sandbox document.
+    if (css) {
+      const style = document.createElement('style');
+      style.textContent = css;
+      document.head.appendChild(style);
+    }
     const requireShim = (id: string): unknown => {
       if (id in shared) return shared[id];
       throw new Error(

--- a/framework/gui/src/renderer/sandbox-view-harness/harness.ts
+++ b/framework/gui/src/renderer/sandbox-view-harness/harness.ts
@@ -95,7 +95,7 @@ function fail(message: string): void {
 
 function load(code: string, css?: string): void {
   try {
-    // `kfs kfx build` emits the view's styles as a sibling index.css that main
+    // `kungfu sdk kfx build` emits the view's styles as a sibling index.css that main
     // reads and hands over here. Inject it before mounting so view CSS (e.g.
     // xterm.css, which positions rows, maps mouse coordinates, and hides the
     // helper textarea) actually applies inside this isolated sandbox document.

--- a/framework/gui/src/renderer/src/kfx-loader.ts
+++ b/framework/gui/src/renderer/src/kfx-loader.ts
@@ -125,6 +125,22 @@ function loadBundle(
   shared: SharedModules,
 ): KfxViewComponent {
   const code = fs.readFileSync(bundlePath, 'utf8');
+  // `kfs kfx build` emits the view's styles as a sibling index.css. The bundle
+  // eval below only runs JS, so without this the view's CSS (e.g. xterm.css,
+  // which positions rows, maps mouse coordinates, and hides the helper textarea)
+  // never applies. Inject it into this renderer's document once per bundle.
+  const cssPath = bundlePath.replace(/\.js$/, '.css');
+  if (cssPath !== bundlePath) {
+    try {
+      const css = fs.readFileSync(cssPath, 'utf8');
+      const style = document.createElement('style');
+      style.dataset.kfxView = bundlePath;
+      style.textContent = css;
+      document.head.appendChild(style);
+    } catch {
+      // no sibling stylesheet — the view ships no CSS
+    }
+  }
   const requireShim = (id: string) => {
     if (id in shared) return shared[id];
     throw new Error(

--- a/framework/gui/src/renderer/src/kfx-loader.ts
+++ b/framework/gui/src/renderer/src/kfx-loader.ts
@@ -125,7 +125,7 @@ function loadBundle(
   shared: SharedModules,
 ): KfxViewComponent {
   const code = fs.readFileSync(bundlePath, 'utf8');
-  // `kfs kfx build` emits the view's styles as a sibling index.css. The bundle
+  // `kungfu sdk kfx build` emits the view's styles as a sibling index.css. The bundle
   // eval below only runs JS, so without this the view's CSS (e.g. xterm.css,
   // which positions rows, maps mouse coordinates, and hides the helper textarea)
   // never applies. Inject it into this renderer's document once per bundle.

--- a/framework/gui/src/renderer/src/runtime.ts
+++ b/framework/gui/src/renderer/src/runtime.ts
@@ -17,6 +17,7 @@ import {
   openTerminal,
   openWork,
 } from '@kungfu-tech/api/capability';
+import { type IpcRendererLike, createTerminalProxy } from './terminal-proxy';
 
 declare global {
   interface Window {
@@ -180,15 +181,25 @@ export function bootRuntime(): Runtime {
     // terminal view surfaces the absence rather than crashing the runtime.
     let terminal: Terminal | null = null;
     try {
-      const ptyModule = window.require('node-pty') as PtyModule;
-      // The tmux durability backend is optional: if no tmux binary is present
-      // the terminal still runs sessions directly (backend: 'direct').
-      const tmux = resolveTmuxBinding(window) ?? undefined;
-      terminal = openTerminal({
-        pty: ptyModule,
-        tmux,
-        baseEnv: window.process.env as Record<string, string | undefined>,
-      });
+      if (env.KF_TERMINAL_HOST === 'main') {
+        // ADR-0015: the durable host runs in the main process; reach it over the
+        // terminal relay. The host outlives windows and (later) is shared by
+        // every window.
+        const ipcRenderer = (
+          window.require('electron') as { ipcRenderer: IpcRendererLike }
+        ).ipcRenderer;
+        terminal = createTerminalProxy(ipcRenderer);
+      } else {
+        // Default: the host runs in this renderer. The tmux durability backend
+        // is optional; without a tmux binary sessions run directly.
+        const ptyModule = window.require('node-pty') as PtyModule;
+        const tmux = resolveTmuxBinding(window) ?? undefined;
+        terminal = openTerminal({
+          pty: ptyModule,
+          tmux,
+          baseEnv: window.process.env as Record<string, string | undefined>,
+        });
+      }
     } catch {
       terminal = null;
     }

--- a/framework/gui/src/renderer/src/runtime.ts
+++ b/framework/gui/src/renderer/src/runtime.ts
@@ -39,9 +39,21 @@ const TMUX_SOCKET = 'kungfu-managed';
 function resolveTmuxBinding(win: Window): TmuxBinding | null {
   try {
     const fs = win.require('node:fs');
-    const { execFile } = win.require('node:child_process') as typeof import(
-      'node:child_process',
-    );
+    // Minimal local type for execFile rather than `typeof import('…')`, whose
+    // formatted multiline form is fragile; we only need this one call shape.
+    type ExecFile = (
+      file: string,
+      args: string[],
+      options: { encoding: 'utf8' },
+      cb: (
+        err: (Error & { code?: number }) | null,
+        stdout: string,
+        stderr: string,
+      ) => void,
+    ) => void;
+    const { execFile } = win.require('node:child_process') as {
+      execFile: ExecFile;
+    };
     const socket = win.process.env.KF_TMUX_SOCKET || TMUX_SOCKET;
     const candidates = [
       win.process.env.KF_TMUX_BIN,

--- a/framework/gui/src/renderer/src/runtime.ts
+++ b/framework/gui/src/renderer/src/runtime.ts
@@ -182,7 +182,7 @@ export function bootRuntime(): Runtime {
     let terminal: Terminal | null = null;
     try {
       if (env.KF_TERMINAL_HOST === 'main') {
-        // ADR-0015: the durable host runs in the main process; reach it over the
+        // ADR-0016: the durable host runs in the main process; reach it over the
         // terminal relay. The host outlives windows and (later) is shared by
         // every window.
         const ipcRenderer = (

--- a/framework/gui/src/renderer/src/runtime.ts
+++ b/framework/gui/src/renderer/src/runtime.ts
@@ -9,6 +9,7 @@ import {
   type PtyModule,
   type Rewind,
   type Terminal,
+  type TmuxBinding,
   type Work,
   openDomainState,
   openLedger,
@@ -25,6 +26,65 @@ declare global {
 }
 
 export const APP_NAME = 'reference_app';
+
+// Dedicated tmux socket for Kungfu managed sessions. Every managed tmux command
+// carries `-L <socket>`, so it physically cannot touch the user's own
+// default-socket tmux sessions. Overridable for tests/other hosts.
+const TMUX_SOCKET = 'kungfu-managed';
+
+// A non-interactive shell must not rely on a `tmux` shell-function shim, so we
+// resolve an absolute binary. Candidates cover Homebrew (arm64/x86) and system
+// paths; `KF_TMUX_BIN` overrides. Returns null when no tmux is available, in
+// which case the terminal handle simply runs without a durability backend.
+function resolveTmuxBinding(win: Window): TmuxBinding | null {
+  try {
+    const fs = win.require('node:fs');
+    const { execFile } = win.require('node:child_process') as typeof import(
+      'node:child_process',
+    );
+    const socket = win.process.env.KF_TMUX_SOCKET || TMUX_SOCKET;
+    const candidates = [
+      win.process.env.KF_TMUX_BIN,
+      '/opt/homebrew/bin/tmux',
+      '/usr/local/bin/tmux',
+      '/usr/bin/tmux',
+    ].filter((p): p is string => typeof p === 'string' && p.length > 0);
+    const bin = candidates.find((p) => {
+      try {
+        return fs.existsSync(p);
+      } catch {
+        return false;
+      }
+    });
+    if (!bin) return null;
+    return {
+      config: { socket, bin },
+      control: {
+        run: (args) =>
+          new Promise((resolve) => {
+            execFile(bin, args, { encoding: 'utf8' }, (err, stdout, stderr) => {
+              // A non-zero tmux exit (e.g. has-session miss) arrives as an
+              // error carrying the numeric exit code; surface it as a code,
+              // not a rejection, so callers branch on it.
+              const code =
+                err && typeof (err as { code?: unknown }).code === 'number'
+                  ? (err as { code: number }).code
+                  : err
+                    ? 1
+                    : 0;
+              resolve({
+                code,
+                stdout: stdout ?? '',
+                stderr: stderr ?? '',
+              });
+            });
+          }),
+      },
+    };
+  } catch {
+    return null;
+  }
+}
 
 export type Runtime = {
   ok: boolean;
@@ -109,8 +169,12 @@ export function bootRuntime(): Runtime {
     let terminal: Terminal | null = null;
     try {
       const ptyModule = window.require('node-pty') as PtyModule;
+      // The tmux durability backend is optional: if no tmux binary is present
+      // the terminal still runs sessions directly (backend: 'direct').
+      const tmux = resolveTmuxBinding(window) ?? undefined;
       terminal = openTerminal({
         pty: ptyModule,
+        tmux,
         baseEnv: window.process.env as Record<string, string | undefined>,
       });
     } catch {

--- a/framework/gui/src/renderer/src/terminal-proxy.ts
+++ b/framework/gui/src/renderer/src/terminal-proxy.ts
@@ -1,0 +1,78 @@
+// Renderer-side proxy for the main-process managed session host (ADR-0015
+// stage 1). It presents the same Terminal surface the in-renderer host does,
+// but every method crosses IPC, so calls resolve asynchronously — the terminal
+// view already awaits both shapes through its `resolve()` helper, so it is
+// unchanged. Subscriptions round-trip a real stop(): the guest mints the subId,
+// so stop() releases exactly that host-side stream (see terminal-host.ts).
+//
+// Only reached when KF_TERMINAL_HOST=main; otherwise the renderer keeps the
+// in-process host and this module is never constructed.
+import type { Subscription, Terminal } from '@kungfu-tech/api/capability';
+
+import {
+  TERMINAL_CALL_CHANNEL,
+  TERMINAL_EVENT_CHANNEL,
+  TERMINAL_SUBSCRIBE_CHANNEL,
+  TERMINAL_UNSUBSCRIBE_CHANNEL,
+} from '../../sandbox/channels';
+
+export type IpcRendererLike = {
+  invoke: (channel: string, payload: unknown) => Promise<unknown>;
+  on: (
+    channel: string,
+    listener: (event: unknown, payload: unknown) => void,
+  ) => void;
+};
+
+type SubscribeMethod = 'onData' | 'onExit';
+
+export function createTerminalProxy(ipc: IpcRendererLike): Terminal {
+  const listeners = new Map<number, (...args: unknown[]) => void>();
+  let subSeq = 0;
+
+  ipc.on(TERMINAL_EVENT_CHANNEL, (_event, payload) => {
+    const { subId, args } = payload as { subId: number; args: unknown[] };
+    listeners.get(subId)?.(...args);
+  });
+
+  const call = (method: string, args: unknown[]): Promise<unknown> =>
+    ipc.invoke(TERMINAL_CALL_CHANNEL, { method, args });
+
+  const subscribe = (
+    method: SubscribeMethod,
+    runId: string,
+    cb: (...args: unknown[]) => void,
+  ): Subscription => {
+    const subId = (subSeq += 1);
+    listeners.set(subId, cb);
+    void ipc.invoke(TERMINAL_SUBSCRIBE_CHANNEL, { method, runId, subId });
+    return {
+      stop: () => {
+        if (!listeners.delete(subId)) return;
+        void ipc.invoke(TERMINAL_UNSUBSCRIBE_CHANNEL, { subId });
+      },
+    };
+  };
+
+  // The proxy is async where the Terminal type is sync; the view awaits every
+  // call through resolve(), so the surface it codes against is unchanged. The
+  // cast is the ADR-0014 tier bridge: one source over a sync or async handle.
+  const proxy = {
+    spawn: (options: unknown) => call('spawn', [options]),
+    write: (runId: string, data: string) => call('write', [runId, data]),
+    resize: (runId: string, cols: number, rows: number) =>
+      call('resize', [runId, cols, rows]),
+    kill: (runId: string, signal?: string) => call('kill', [runId, signal]),
+    detach: (runId: string) => call('detach', [runId]),
+    onData: (runId: string, onData: (data: string) => void) =>
+      subscribe('onData', runId, (data) => onData(data as string)),
+    onExit: (runId: string, onExit: (exit: unknown) => void) =>
+      subscribe('onExit', runId, (exit) => onExit(exit)),
+    discover: () => call('discover', []),
+    reattach: (runId: string) => call('reattach', [runId]),
+    adopt: (spec: unknown) => call('adopt', [spec]),
+    list: () => call('list', []),
+    get: (runId: string) => call('get', [runId]),
+  };
+  return proxy as unknown as Terminal;
+}

--- a/framework/gui/src/renderer/src/terminal-proxy.ts
+++ b/framework/gui/src/renderer/src/terminal-proxy.ts
@@ -1,4 +1,4 @@
-// Renderer-side proxy for the main-process managed session host (ADR-0015
+// Renderer-side proxy for the main-process managed session host (ADR-0016
 // stage 1). It presents the same Terminal surface the in-renderer host does,
 // but every method crosses IPC, so calls resolve asynchronously — the terminal
 // view already awaits both shapes through its `resolve()` helper, so it is

--- a/framework/gui/src/sandbox/channels.ts
+++ b/framework/gui/src/sandbox/channels.ts
@@ -13,3 +13,11 @@ export const SET_BOUNDS_CHANNEL = 'kfx:view-set-bounds';
 export const SHOW_CHANNEL = 'kfx:view-show';
 export const HIDE_CHANNEL = 'kfx:view-hide';
 export const DESTROY_CHANNEL = 'kfx:view-destroy';
+
+// renderer <-> main: the managed session (terminal) host relay (ADR-0015). Its
+// own channels, separate from the sandbox relay, and terminal-specific so a
+// per-subscription stop() round-trips (the shared relay only bulk-disposes).
+export const TERMINAL_CALL_CHANNEL = 'kf-terminal:call';
+export const TERMINAL_SUBSCRIBE_CHANNEL = 'kf-terminal:subscribe';
+export const TERMINAL_UNSUBSCRIBE_CHANNEL = 'kf-terminal:unsubscribe';
+export const TERMINAL_EVENT_CHANNEL = 'kf-terminal:event';

--- a/framework/gui/src/sandbox/channels.ts
+++ b/framework/gui/src/sandbox/channels.ts
@@ -14,7 +14,7 @@ export const SHOW_CHANNEL = 'kfx:view-show';
 export const HIDE_CHANNEL = 'kfx:view-hide';
 export const DESTROY_CHANNEL = 'kfx:view-destroy';
 
-// renderer <-> main: the managed session (terminal) host relay (ADR-0015). Its
+// renderer <-> main: the managed session (terminal) host relay (ADR-0016). Its
 // own channels, separate from the sandbox relay, and terminal-specific so a
 // per-subscription stop() round-trips (the shared relay only bulk-disposes).
 export const TERMINAL_CALL_CHANNEL = 'kf-terminal:call';

--- a/framework/kfx/src/index.ts
+++ b/framework/kfx/src/index.ts
@@ -18,6 +18,20 @@ import type {
 } from '@kungfu-tech/api/capability';
 import type React from 'react';
 
+// Re-export the terminal session types a view needs to build its own UI (pane
+// snapshots, discovery, spawn options). The view contract package is the one
+// place a view imports from, so it should surface these rather than making a
+// view reach into @kungfu-tech/api directly.
+export type {
+  DiscoveredSession,
+  Terminal,
+  TerminalBackend,
+  TerminalExit,
+  TerminalSession,
+  TerminalSpawnOptions,
+  TerminalStatus,
+} from '@kungfu-tech/api/capability';
+
 // ── capability surface ────────────────────────────────────────────────────
 
 export type KfxCapabilities = {

--- a/framework/kfx/src/index.ts
+++ b/framework/kfx/src/index.ts
@@ -23,7 +23,11 @@ import type React from 'react';
 // place a view imports from, so it should surface these rather than making a
 // view reach into @kungfu-tech/api directly.
 export type {
+  AdoptSpec,
+  ConfigEntry,
   DiscoveredSession,
+  DomainState,
+  KfLocation,
   Terminal,
   TerminalBackend,
   TerminalExit,


### PR DESCRIPTION
Multi-pane managed session workspace in the GUI: run and watch several PTY-backed agent sessions on one screen. Adds the tmux durability backend to the terminal capability (detach/discover/reattach), runs the session host in the main process behind KF_TERMINAL_HOST=main (ADR-0016 stage 1), persists and restores the workspace layout, and fixes real-app blockers found on device (renderer node: bundling, discover race, sizing, and loading each kfx view's sibling stylesheet).