### PR TITLE
docs: state fact-first product goal

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@ load-bearing truth rest on a claim you could fake — weld it to something that
 can't. ([design philosophy](docs/design-philosophy.md); [facts before
 trust](docs/facts-before-trust.md).)
 
+The product goal is to make fact-first responsibility the path of least
+resistance: once a user starts relying on Kungfu, the natural way to use it
+should be to inspect facts, understand responsibility, and make control
+decisions from local proof rather than from opaque claims.
+
 At its core is a low-latency, append-only event journal with a shared,
 strongly-typed schema, exposed zero-copy to C++, Python, and Node. Kungfu
 offers these capabilities — the journal, in-process state, and deterministic

--- a/docs/design-philosophy.md
+++ b/docs/design-philosophy.md
@@ -27,6 +27,13 @@ rationale, see the [ADRs](../framework/core/docs/adr). For the public product
 stance that connects these choices to agent work, release evidence, extension
 trust, and known limits, see [`facts-before-trust.md`](facts-before-trust.md).
 
+The product goal follows directly from this stance: Kungfu should make
+fact-first responsibility the path of least resistance. A user who starts with a
+practical need — inspect an agent run, verify an extension, understand a release,
+recover a failed workflow — should naturally move through local facts,
+responsibility state, and proof-backed control decisions because that is the
+simplest reliable way the product works.
+
 ## Principle 1 — The machine adapts to the person
 
 Kungfu absorbs toolchain and runtime complexity into the product so its users do

--- a/docs/facts-before-trust.md
+++ b/docs/facts-before-trust.md
@@ -26,6 +26,28 @@ Each of those statements is cheaper to say than to prove. Kungfu's design bias
 is to turn the statement into a local, inspectable, replayable, or otherwise
 verifiable object.
 
+## Product Goal
+
+Kungfu should make fact-first responsibility the path of least resistance.
+
+Users should not need to adopt a philosophy before the product helps them. They
+may arrive because an agent run failed, a long task is burning tokens, an
+extension needs review, or a release artifact needs proof. But after the first
+use, the easiest reliable path should be the Kungfu path:
+
+```text
+capture the work
+inspect the local facts
+understand the responsibility state
+decide the next action from proof
+keep the record exportable and reviewable
+```
+
+This is how the product carries the principle instead of merely describing it.
+The interface, runtime, extensions, skills, and release evidence should make
+the fact-first path feel cheaper than guessing, asking for summaries, or
+trusting an opaque control plane.
+
 ## Facts Before Trust
 
 A user should not have to trust a dashboard, a hosted service, a maintainer, or


### PR DESCRIPTION
## Summary
- state the product goal in README: make fact-first responsibility the path of least resistance
- add a Product Goal section to docs/facts-before-trust.md
- connect the goal from docs/design-philosophy.md

## Validation
- git diff --check
- checked the public docs patch for Atlas or AI-maintenance leakage terms