### PR TITLE
fix(kfx-sandbox): fix the Windows AppContainer relay spawn hang

### DIFF
--- a/framework/api/src/capability/guest-harness/facet-knobs.mjs
+++ b/framework/api/src/capability/guest-harness/facet-knobs.mjs
@@ -33,15 +33,18 @@ import { networkInterfaces, homedir } from 'node:os';
 import { join } from 'node:path';
 
 function tryFsWrite() {
-  // Probe a write to an explicit USER-space path (the home directory), not the
-  // OS temp dir. On Windows the guest's node runtime needs a writable temp just
-  // to start, so the launcher redirects the guest's TEMP to the AppContainer's
-  // own writable folder; the deny-write knob must therefore be observed on a
-  // path that is NOT that runtime scratch — a user-owned location a confined
-  // guest should not reach. macOS Seatbelt `(deny file-write*)` and Linux
-  // `--ro-bind /` deny writes globally, so home is refused there too when the
-  // knob is on, and writable under a permissive profile.
-  const path = join(homedir(), `.kfx-knob-write-probe-${process.pid}.tmp`);
+  // Probe a write into a launcher-designated user-space scratch dir. On Windows,
+  // AppContainer write access is governed by the container SID's own ACE (a lowbox
+  // token does not honour the user's ACEs), so the launcher passes KFX_WRITE_PROBE
+  // pointing at a scratch dir it grants the container SID write on under a
+  // permissive profile and leaves ungranted under deny-write — the knob is
+  // observed here. The node runtime's own TEMP is redirected elsewhere (the
+  // AppContainer folder), so this path is purely the facet's write target, not the
+  // runtime scratch. Off-Windows the launcher leaves KFX_WRITE_PROBE unset and the
+  // probe falls back to the home dir, which macOS Seatbelt `(deny file-write*)` and
+  // Linux `--ro-bind /` deny globally when the knob is on and allow when permissive.
+  const dir = process.env.KFX_WRITE_PROBE ?? homedir();
+  const path = join(dir, `.kfx-knob-write-probe-${process.pid}.tmp`);
   try {
     writeFileSync(path, 'kfx');
     try {

--- a/framework/api/src/capability/guest-harness/facet-knobs.mjs
+++ b/framework/api/src/capability/guest-harness/facet-knobs.mjs
@@ -29,11 +29,19 @@
 //     asserts it, to avoid regressing the mac/linux signals already proven green.
 import net from 'node:net';
 import { writeFileSync, unlinkSync } from 'node:fs';
-import { networkInterfaces, tmpdir } from 'node:os';
+import { networkInterfaces, homedir } from 'node:os';
 import { join } from 'node:path';
 
 function tryFsWrite() {
-  const path = join(tmpdir(), `kfx-knob-${process.pid}.tmp`);
+  // Probe a write to an explicit USER-space path (the home directory), not the
+  // OS temp dir. On Windows the guest's node runtime needs a writable temp just
+  // to start, so the launcher redirects the guest's TEMP to the AppContainer's
+  // own writable folder; the deny-write knob must therefore be observed on a
+  // path that is NOT that runtime scratch — a user-owned location a confined
+  // guest should not reach. macOS Seatbelt `(deny file-write*)` and Linux
+  // `--ro-bind /` deny writes globally, so home is refused there too when the
+  // knob is on, and writable under a permissive profile.
+  const path = join(homedir(), `.kfx-knob-write-probe-${process.pid}.tmp`);
   try {
     writeFileSync(path, 'kfx');
     try {

--- a/framework/api/src/capability/guest-harness/facet-knobs.mjs
+++ b/framework/api/src/capability/guest-harness/facet-knobs.mjs
@@ -8,7 +8,7 @@
 // observes a refused syscall — a narrower result — never a withdrawn method. It
 // is not re-adapted; it just sees 'refused' where it saw 'ok'.
 //
-// The network knob narrows differently per platform, so the facet reports two
+// The network knob narrows differently per platform, so the facet reports three
 // distinct observables and the runner asserts the platform-relevant one:
 //   - loopback: a 127.0.0.1 round-trip. macOS Seatbelt `(deny network*)` refuses
 //     every socket, loopback included, so this is the macOS signal.
@@ -16,6 +16,17 @@
 //     `--unshare-net` puts the guest in a private network namespace with only a
 //     loopback up — loopback still works, but external egress is gone — so the
 //     absence of an external interface is the Linux signal.
+//   - externalEgress: whether an EXTERNAL (non-loopback) connect is permitted to
+//     even try. A Windows AppContainer gates the network through the internetClient
+//     capability, which controls external egress ONLY — a raw AppContainer permits
+//     loopback regardless (loopback is governed by the network-isolation exemption,
+//     not internetClient), and it does not remove interfaces. So neither loopback
+//     nor externalNet can observe deny-network on Windows; the signal is an
+//     external connect that the socket layer refuses (WSAEACCES) without the
+//     capability. This probe is platform-neutral (macOS Seatbelt refuses with
+//     EPERM, Linux --unshare-net has no route with ENETUNREACH), so it could
+//     unify the network observable later; for now only the runner's win32 branch
+//     asserts it, to avoid regressing the mac/linux signals already proven green.
 import net from 'node:net';
 import { writeFileSync, unlinkSync } from 'node:fs';
 import { networkInterfaces, tmpdir } from 'node:os';
@@ -70,9 +81,60 @@ function hasExternalInterface() {
   return false;
 }
 
+// Probe whether an EXTERNAL egress is permitted to try. TEST-NET-1 192.0.2.1
+// (RFC 5737) is reserved and never answers, so a permitted connect never truly
+// connects — it stalls and our timer fires, which we read as 'ok' (egress was
+// allowed to leave the socket layer). A denied guest is rejected before the
+// packet leaves: a capability/permission refusal (Windows AppContainer WSAEACCES
+// → EACCES, macOS Seatbelt EPERM) or no route out (Linux --unshare-net
+// ENETUNREACH). Those codes read as 'refused'; a stall, a real connect, or a
+// host-level ECONNREFUSED (egress worked, peer said no) read as 'ok'.
+const EGRESS_REFUSED = new Set([
+  'EACCES',
+  'EPERM',
+  'ENETUNREACH',
+  'EHOSTUNREACH',
+  'EADDRNOTAVAIL',
+  'ENETDOWN',
+]);
+
+function tryExternalEgress() {
+  return new Promise((resolve) => {
+    let settled = false;
+    let socket;
+    const done = (v) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      try {
+        socket?.destroy();
+      } catch {}
+      resolve(v);
+    };
+    const timer = setTimeout(() => done('ok'), 600);
+    timer.unref?.();
+    try {
+      socket = net.connect({ host: '192.0.2.1', port: 80 });
+      socket.on('connect', () => done('ok'));
+      socket.on('error', (err) =>
+        done(EGRESS_REFUSED.has(err.code) ? `refused:${err.code}` : 'ok'),
+      );
+    } catch (err) {
+      done(EGRESS_REFUSED.has(err.code) ? `refused:${err.code}` : 'ok');
+    }
+  });
+}
+
 export async function run(caps) {
   const fsWrite = tryFsWrite();
   const loopback = await tryLoopbackNet();
   const externalNet = hasExternalInterface() ? 'ok' : 'refused';
-  await caps.report.result({ facet: 'knobs', fsWrite, loopback, externalNet });
+  const externalEgress = await tryExternalEgress();
+  await caps.report.result({
+    facet: 'knobs',
+    fsWrite,
+    loopback,
+    externalNet,
+    externalEgress,
+  });
 }

--- a/framework/api/src/capability/guest-harness/run-knobs.ts
+++ b/framework/api/src/capability/guest-harness/run-knobs.ts
@@ -30,12 +30,23 @@ const RESOLVER = join(DIR, 'ts-resolve.mjs');
 const NODE_CHILD = join(DIR, 'node-child.mjs');
 const FACET = join(DIR, 'facet-knobs.mjs');
 
-// The network knob's narrowing shows up in a different observable per platform.
-// macOS Seatbelt and Windows AppContainer refuse the socket itself (loopback
-// included — on Windows the permissive profile re-permits loopback via the
-// network-isolation exemption, so deny-network shows as a refused loopback);
-// Linux --unshare-net leaves loopback up but removes external interfaces.
-const NET_FIELD = platform() === 'linux' ? 'externalNet' : 'loopback';
+// The network knob's narrowing shows up in a different observable per platform:
+//   - macOS Seatbelt `(deny network*)` refuses every socket, loopback included,
+//     so a refused loopback round-trip is the signal.
+//   - Linux --unshare-net leaves loopback up but removes external interfaces, so
+//     the absence of an external interface is the signal.
+//   - Windows AppContainer gates the network through the internetClient
+//     capability, which controls EXTERNAL egress only — a raw AppContainer
+//     permits loopback regardless (governed by the network-isolation loopback
+//     exemption, not internetClient) and removes no interfaces. So loopback and
+//     externalNet both miss deny-network on Windows; the signal is an external
+//     connect the socket layer refuses (WSAEACCES) without the capability.
+const NET_FIELD =
+  platform() === 'linux'
+    ? 'externalNet'
+    : platform() === 'win32'
+      ? 'externalEgress'
+      : 'loopback';
 
 type KnobCase = {
   label: string;

--- a/framework/api/src/capability/guest-windows.ts
+++ b/framework/api/src/capability/guest-windows.ts
@@ -16,8 +16,11 @@
 // kungfu-guest holds no binding itself — the same injection discipline ADR-0011
 // applies to capabilities. The relay never touches stdout/stdin content here; it
 // just gets a GuestChild whose streams happen to be named pipes.
+import { existsSync } from 'node:fs';
 import * as net from 'node:net';
 import type { Server, Socket } from 'node:net';
+import { dirname, isAbsolute } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import type { AppContainerSpec } from './sandbox-launcher.js';
 import type { GuestChild, WindowsSandboxSpawn } from './kungfu-guest.js';
@@ -46,10 +49,44 @@ export type LibkungfuWindowsBinding = {
     capabilities: readonly string[];
     allowBroadWrite: boolean;
     allowLoopback: boolean;
+    // directories the launcher grants the AppContainer SID read+execute on (plus
+    // traverse on their ancestors) so the guest stays readable under denyWrite,
+    // where its user SID is deny-only and reads no longer resolve through the
+    // user's own ACEs. Derived from the interpreter + guest entry paths.
+    readPaths: readonly string[];
     // "KEY=VALUE" pairs
     env: readonly string[];
   }) => AppContainerProcess;
 };
+
+// The directories the guest must be readable from: the interpreter's own
+// directory and the directory of each absolute path passed on its argv (the
+// resolver hook, the child bootstrap, the facet entry). Granting the containing
+// directory — rather than each file — keeps the guest bundle readable as it
+// resolves siblings, and the native launcher adds ancestor traverse. This
+// codifies what a basic AppContainer previously needed manual icacls for.
+function deriveReadPaths(
+  command: string,
+  args: readonly string[],
+): readonly string[] {
+  const dirs = new Set<string>();
+  const addFileDir = (p: string) => {
+    if (isAbsolute(p) && existsSync(p)) dirs.add(dirname(p));
+  };
+  addFileDir(command);
+  for (const arg of args) {
+    let candidate = arg;
+    if (candidate.startsWith('file://')) {
+      try {
+        candidate = fileURLToPath(candidate);
+      } catch {
+        continue;
+      }
+    }
+    addFileDir(candidate);
+  }
+  return [...dirs];
+}
 
 let pipeSeq = 0;
 
@@ -98,6 +135,7 @@ export function createLibkungfuWindowsSpawn(
       capabilities: spec.capabilities,
       allowBroadWrite: spec.allowBroadWrite,
       allowLoopback: spec.allowLoopback,
+      readPaths: deriveReadPaths(command, args),
       env: Object.entries(options.env)
         .filter(([, v]) => v !== undefined)
         .map(([k, v]) => `${k}=${v}`),

--- a/framework/api/src/capability/guest-windows.ts
+++ b/framework/api/src/capability/guest-windows.ts
@@ -23,8 +23,8 @@ import { homedir } from 'node:os';
 import { dirname, isAbsolute, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import type { AppContainerSpec } from './sandbox-launcher.js';
 import type { GuestChild, WindowsSandboxSpawn } from './kungfu-guest.js';
+import type { AppContainerSpec } from './sandbox-launcher.js';
 
 // The native process object libkungfu `spawn_app_container` returns. It owns the
 // Windows process HANDLE; JS never sees a raw handle.
@@ -64,6 +64,17 @@ export type LibkungfuWindowsBinding = {
   }) => AppContainerProcess;
 };
 
+// The guest process started but then EXITED before it ever connected its relay
+// pipes — a genuine startup failure (e.g. the denyNetwork guest early-exit).
+// Retrying with fresh pipes would not change the outcome, so the spawn loop
+// surfaces this immediately instead of retrying.
+class GuestExitedBeforeConnect extends Error {}
+
+// The guest neither connected its relay pipes nor exited within the handshake
+// window — the intermittent named-pipe OVERLAPPED handshake loss that used to
+// hang forever. This IS retryable: a fresh pair of pipes usually connects.
+class RelayHandshakeTimeout extends Error {}
+
 // The directories the guest must be readable from: the interpreter's own
 // directory and the directory of each absolute path passed on its argv (the
 // resolver hook, the child bootstrap, the facet entry). Granting the containing
@@ -102,54 +113,80 @@ function uniquePipe(kind: string): string {
 }
 
 // Create a named-pipe server and resolve with the socket the native client
-// connects (the child's std handle is that client end).
+// connects (the child's std handle is that client end). `listening` resolves
+// once the pipe instance actually exists — the native launcher opens the pipe
+// with CreateFile(OPEN_EXISTING), which has no wait/retry of its own, so the
+// host must not spawn until both pipes are listening.
 function serveNamedPipe(pipePath: string): {
   path: string;
+  listening: Promise<void>;
   connected: Promise<Socket>;
   close: () => void;
 } {
-  let server: Server | undefined;
+  let resolveConnected!: (socket: Socket) => void;
+  let rejectConnected!: (err: unknown) => void;
   const connected = new Promise<Socket>((resolve, reject) => {
-    server = net.createServer((socket) => resolve(socket));
-    server.on('error', reject);
-    server.listen(pipePath);
+    resolveConnected = resolve;
+    rejectConnected = reject;
   });
+  const server: Server = net.createServer((socket) => resolveConnected(socket));
+  server.on('error', (err) => rejectConnected(err));
+  const listening = new Promise<void>((resolve, reject) => {
+    server.once('listening', () => resolve());
+    server.once('error', reject);
+  });
+  server.listen(pipePath);
   return {
     path: pipePath,
+    listening,
     connected,
-    close: () => server?.close(),
+    close: () => server.close(),
   };
 }
 
-// Build the WindowsSandboxSpawn from an injected libkungfu binding. Host usage:
-//   launchSandboxedGuest({ ..., windowsSpawn: createLibkungfuWindowsSpawn(binding) })
-export function createLibkungfuWindowsSpawn(
+// One spawn attempt: create fresh pipes, wait until they are listening, launch
+// the guest, and wait for the relay handshake — bounded by `timeoutMs`. Resolves
+// with the wired GuestChild, or throws GuestExitedBeforeConnect / a native error
+// / RelayHandshakeTimeout so the caller can decide whether to retry.
+async function spawnGuestOnce(
   binding: LibkungfuWindowsBinding,
-): WindowsSandboxSpawn {
-  return async (command, args, spec: AppContainerSpec, options) => {
-    const stdinServer = serveNamedPipe(uniquePipe('in'));
-    const stdoutServer = serveNamedPipe(uniquePipe('out'));
+  command: string,
+  args: readonly string[],
+  spec: AppContainerSpec,
+  options: { env: Record<string, string | undefined> },
+  timeoutMs: number,
+): Promise<GuestChild> {
+  const stdinServer = serveNamedPipe(uniquePipe('in'));
+  const stdoutServer = serveNamedPipe(uniquePipe('out'));
 
-    // A per-launch write-probe scratch dir under the home directory — a clean
-    // user-space location the AppContainer inherits no write ACE on. permissive
-    // grants the container SID write here (via writeScratch); denyWrite does not,
-    // so the facet's write is refused. It sits outside the runtime's TEMP (which
-    // the native launcher redirects to the AppContainer folder), so it observes
-    // only the write knob. Removed when the guest exits.
-    pipeSeq += 1;
-    const scratch = join(
-      homedir(),
-      '.kfx-guest-scratch',
-      `${process.pid}-${pipeSeq}`,
-    );
-    mkdirSync(scratch, { recursive: true });
-    const cleanupScratch = () => {
-      try {
-        rmSync(scratch, { recursive: true, force: true });
-      } catch {}
-    };
+  // Both pipe instances must exist BEFORE the native launcher opens them as
+  // client handles: CreateFile(OPEN_EXISTING) fails outright if the pipe is not
+  // yet created, and `server.listen()` is asynchronous. Waiting here removes the
+  // host-listen-vs-native-CreateFile race entirely.
+  await Promise.all([stdinServer.listening, stdoutServer.listening]);
 
-    const proc = binding.spawnAppContainer({
+  // A per-launch write-probe scratch dir under the home directory — a clean
+  // user-space location the AppContainer inherits no write ACE on. permissive
+  // grants the container SID write here (via writeScratch); denyWrite does not,
+  // so the facet's write is refused. It sits outside the runtime's TEMP (which
+  // the native launcher redirects to the AppContainer folder), so it observes
+  // only the write knob. Removed when the guest exits.
+  pipeSeq += 1;
+  const scratch = join(
+    homedir(),
+    '.kfx-guest-scratch',
+    `${process.pid}-${pipeSeq}`,
+  );
+  mkdirSync(scratch, { recursive: true });
+  const cleanupScratch = () => {
+    try {
+      rmSync(scratch, { recursive: true, force: true });
+    } catch {}
+  };
+
+  let proc: AppContainerProcess;
+  try {
+    proc = binding.spawnAppContainer({
       command,
       args,
       stdinPipe: stdinServer.path,
@@ -165,70 +202,149 @@ export function createLibkungfuWindowsSpawn(
         .filter(([, v]) => v !== undefined)
         .map(([k, v]) => `${k}=${v}`),
     });
+  } catch (err) {
+    // native CreateProcess / CreateFile failed synchronously — no process to
+    // wait on. Clean the pipes and scratch here (the exit-wiring below never
+    // ran) and let the caller retry.
+    stdinServer.close();
+    stdoutServer.close();
+    cleanupScratch();
+    throw err;
+  }
 
-    // A single exit wait, shared between the startup guard below and the exit
-    // event wiring.
-    const exited = proc.wait();
-    const exitListeners = new Set<(code: number | null) => void>();
-    exited
-      .then((code) => {
-        for (const cb of exitListeners) cb(code);
-      })
-      .catch(() => {
-        for (const cb of exitListeners) cb(null);
-      })
-      .finally(() => {
-        stdinServer.close();
-        stdoutServer.close();
-        cleanupScratch();
-      });
+  // A single exit wait, shared between the startup guard below and the exit
+  // event wiring.
+  const exited = proc.wait();
+  const exitListeners = new Set<(code: number | null) => void>();
+  exited
+    .then((code) => {
+      for (const cb of exitListeners) cb(code);
+    })
+    .catch(() => {
+      for (const cb of exitListeners) cb(null);
+    })
+    .finally(() => {
+      stdinServer.close();
+      stdoutServer.close();
+      cleanupScratch();
+    });
 
-    // native opened the pipes as the child's stdio; the servers accept those
-    // connections. host WRITES to stdin, READS child stdout. If the guest exits
-    // BEFORE connecting its pipes (a startup failure — e.g. the runtime cannot
-    // initialize under the AppContainer), the connected promises would hang
-    // forever. Race them against the exit so a failed launch surfaces as an error
-    // carrying the exit code instead of a deadlock. The `connectedOk` flag makes
-    // the exit branch throw ONLY while the pipes are still pending, so a normal
-    // later exit does not reject an already-settled race (an unhandled rejection).
-    let connectedOk = false;
-    const connections = Promise.all([
-      stdinServer.connected,
-      stdoutServer.connected,
-    ]).then((pair) => {
-      connectedOk = true;
-      return pair;
-    });
-    const startupGuard = exited.then((code) => {
-      if (!connectedOk) {
-        throw new Error(
-          `sandboxed guest exited before connecting its relay pipes (exit code ${code})`,
-        );
-      }
-      return undefined as never;
-    });
-    const [stdin, stdout] = (await Promise.race([
+  // native opened the pipes as the child's stdio; the servers accept those
+  // connections. host WRITES to stdin, READS child stdout. Three ways the wait
+  // ends: (a) both pipes connect — success; (b) the guest exits BEFORE connecting
+  // (a startup failure) — surface the exit code, no retry; (c) neither happens
+  // within the handshake window (the intermittent OVERLAPPED handshake loss) —
+  // kill the stuck guest and let the caller retry with fresh pipes. The
+  // `connectedOk` flag makes the exit branch throw ONLY while the pipes are still
+  // pending, so a normal later exit does not reject an already-settled race.
+  let connectedOk = false;
+  const connections = Promise.all([
+    stdinServer.connected,
+    stdoutServer.connected,
+  ]).then((pair) => {
+    connectedOk = true;
+    return pair;
+  });
+  const startupGuard = exited.then((code) => {
+    if (!connectedOk) {
+      throw new GuestExitedBeforeConnect(
+        `sandboxed guest exited before connecting its relay pipes (exit code ${code})`,
+      );
+    }
+    return undefined as never;
+  });
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      reject(
+        new RelayHandshakeTimeout(
+          `sandboxed guest did not connect its relay pipes within ${timeoutMs}ms`,
+        ),
+      );
+    }, timeoutMs);
+    // do not let the handshake timer keep the event loop alive on its own
+    timer.unref?.();
+  });
+
+  let stdin: Socket;
+  let stdout: Socket;
+  try {
+    [stdin, stdout] = (await Promise.race([
       connections,
       startupGuard,
+      timeout,
     ])) as [Socket, Socket];
+  } catch (err) {
+    if (err instanceof RelayHandshakeTimeout) {
+      // the guest is up but never connected — kill it so the retry starts from a
+      // clean slate. The kill drives `exited`, whose finally closes the servers
+      // and removes the scratch dir.
+      proc.kill();
+    }
+    // GuestExitedBeforeConnect: the process already exited, so `exited.finally`
+    // handles pipe/scratch cleanup. Native errors are handled above.
+    throw err;
+  } finally {
+    clearTimeout(timer);
+  }
 
-    const child: GuestChild = {
-      stdout,
-      stdin,
-      on(event, cb) {
-        if (event === 'exit') exitListeners.add(cb);
-      },
-      once(event, cb) {
-        if (event === 'exit' || event === 'close') {
-          const wrap = () => {
-            exitListeners.delete(wrap as never);
-            cb();
-          };
-          exitListeners.add(wrap as never);
+  const child: GuestChild = {
+    stdout,
+    stdin,
+    on(event, cb) {
+      if (event === 'exit') exitListeners.add(cb);
+    },
+    once(event, cb) {
+      if (event === 'exit' || event === 'close') {
+        const wrap = () => {
+          exitListeners.delete(wrap as never);
+          cb();
+        };
+        exitListeners.add(wrap as never);
+      }
+    },
+    kill: () => proc.kill(),
+  };
+  return child;
+}
+
+// Build the WindowsSandboxSpawn from an injected libkungfu binding. Host usage:
+//   launchSandboxedGuest({ ..., windowsSpawn: createLibkungfuWindowsSpawn(binding) })
+export function createLibkungfuWindowsSpawn(
+  binding: LibkungfuWindowsBinding,
+): WindowsSandboxSpawn {
+  return async (command, args, spec: AppContainerSpec, options) => {
+    // The relay handshake (host pipe servers ↔ the native CreateFile client ends)
+    // is intermittently lost on Windows: the guest starts but never appears on
+    // the pipes, so the connection wait would hang forever. Bound each attempt
+    // with a timeout and retry the whole spawn with fresh pipes. A guest that
+    // EXITS before connecting is a real startup failure (the denyNetwork
+    // early-exit) and is surfaced immediately — a fresh pipe would not save it.
+    const HANDSHAKE_TIMEOUT_MS = 15_000;
+    const MAX_ATTEMPTS = 3;
+
+    let lastErr: unknown;
+    for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt += 1) {
+      try {
+        return await spawnGuestOnce(
+          binding,
+          command,
+          args,
+          spec,
+          options,
+          HANDSHAKE_TIMEOUT_MS,
+        );
+      } catch (err) {
+        lastErr = err;
+        if (
+          err instanceof GuestExitedBeforeConnect ||
+          attempt === MAX_ATTEMPTS
+        ) {
+          throw err;
         }
-      },
-      kill: () => proc.kill(),
-    };
-    return child;
+        // relay handshake timed out or the pipe open raced — retry with fresh pipes
+      }
+    }
+    throw lastErr;
   };
 }

--- a/framework/api/src/capability/guest-windows.ts
+++ b/framework/api/src/capability/guest-windows.ts
@@ -16,10 +16,11 @@
 // kungfu-guest holds no binding itself — the same injection discipline ADR-0011
 // applies to capabilities. The relay never touches stdout/stdin content here; it
 // just gets a GuestChild whose streams happen to be named pipes.
-import { existsSync } from 'node:fs';
+import { existsSync, mkdirSync, rmSync } from 'node:fs';
 import * as net from 'node:net';
 import type { Server, Socket } from 'node:net';
-import { dirname, isAbsolute } from 'node:path';
+import { homedir } from 'node:os';
+import { dirname, isAbsolute, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import type { AppContainerSpec } from './sandbox-launcher.js';
@@ -50,10 +51,14 @@ export type LibkungfuWindowsBinding = {
     allowBroadWrite: boolean;
     allowLoopback: boolean;
     // directories the launcher grants the AppContainer SID read+execute on (plus
-    // traverse on their ancestors) so the guest stays readable under denyWrite,
-    // where its user SID is deny-only and reads no longer resolve through the
-    // user's own ACEs. Derived from the interpreter + guest entry paths.
+    // traverse on their ancestors) so the guest stays readable — AppContainer file
+    // access is governed by the container SID's ACE, not the user's. Derived from
+    // the interpreter + guest entry paths.
     readPaths: readonly string[];
+    // a user-space scratch dir passed to the guest as KFX_WRITE_PROBE. A permissive
+    // profile grants the container SID write on it (so the guest's write succeeds);
+    // denyWrite leaves it ungranted (so the write is refused).
+    writeScratch: string;
     // "KEY=VALUE" pairs
     env: readonly string[];
   }) => AppContainerProcess;
@@ -125,6 +130,25 @@ export function createLibkungfuWindowsSpawn(
     const stdinServer = serveNamedPipe(uniquePipe('in'));
     const stdoutServer = serveNamedPipe(uniquePipe('out'));
 
+    // A per-launch write-probe scratch dir under the home directory — a clean
+    // user-space location the AppContainer inherits no write ACE on. permissive
+    // grants the container SID write here (via writeScratch); denyWrite does not,
+    // so the facet's write is refused. It sits outside the runtime's TEMP (which
+    // the native launcher redirects to the AppContainer folder), so it observes
+    // only the write knob. Removed when the guest exits.
+    pipeSeq += 1;
+    const scratch = join(
+      homedir(),
+      '.kfx-guest-scratch',
+      `${process.pid}-${pipeSeq}`,
+    );
+    mkdirSync(scratch, { recursive: true });
+    const cleanupScratch = () => {
+      try {
+        rmSync(scratch, { recursive: true, force: true });
+      } catch {}
+    };
+
     const proc = binding.spawnAppContainer({
       command,
       args,
@@ -136,6 +160,7 @@ export function createLibkungfuWindowsSpawn(
       allowBroadWrite: spec.allowBroadWrite,
       allowLoopback: spec.allowLoopback,
       readPaths: deriveReadPaths(command, args),
+      writeScratch: scratch,
       env: Object.entries(options.env)
         .filter(([, v]) => v !== undefined)
         .map(([k, v]) => `${k}=${v}`),
@@ -160,6 +185,7 @@ export function createLibkungfuWindowsSpawn(
       .finally(() => {
         stdinServer.close();
         stdoutServer.close();
+        cleanupScratch();
       });
 
     const child: GuestChild = {

--- a/framework/api/src/capability/guest-windows.ts
+++ b/framework/api/src/capability/guest-windows.ts
@@ -188,14 +188,28 @@ export function createLibkungfuWindowsSpawn(
     // BEFORE connecting its pipes (a startup failure — e.g. the runtime cannot
     // initialize under the AppContainer), the connected promises would hang
     // forever. Race them against the exit so a failed launch surfaces as an error
-    // carrying the exit code instead of a deadlock.
-    const [stdin, stdout] = (await Promise.race([
-      Promise.all([stdinServer.connected, stdoutServer.connected]),
-      exited.then((code) => {
+    // carrying the exit code instead of a deadlock. The `connectedOk` flag makes
+    // the exit branch throw ONLY while the pipes are still pending, so a normal
+    // later exit does not reject an already-settled race (an unhandled rejection).
+    let connectedOk = false;
+    const connections = Promise.all([
+      stdinServer.connected,
+      stdoutServer.connected,
+    ]).then((pair) => {
+      connectedOk = true;
+      return pair;
+    });
+    const startupGuard = exited.then((code) => {
+      if (!connectedOk) {
         throw new Error(
           `sandboxed guest exited before connecting its relay pipes (exit code ${code})`,
         );
-      }),
+      }
+      return undefined as never;
+    });
+    const [stdin, stdout] = (await Promise.race([
+      connections,
+      startupGuard,
     ])) as [Socket, Socket];
 
     const child: GuestChild = {

--- a/framework/api/src/capability/guest-windows.ts
+++ b/framework/api/src/capability/guest-windows.ts
@@ -166,16 +166,11 @@ export function createLibkungfuWindowsSpawn(
         .map(([k, v]) => `${k}=${v}`),
     });
 
-    // native opened the pipes as the child's stdio; the servers accept those
-    // connections. host WRITES to stdin, READS child stdout.
-    const [stdin, stdout] = await Promise.all([
-      stdinServer.connected,
-      stdoutServer.connected,
-    ]);
-
+    // A single exit wait, shared between the startup guard below and the exit
+    // event wiring.
+    const exited = proc.wait();
     const exitListeners = new Set<(code: number | null) => void>();
-    proc
-      .wait()
+    exited
       .then((code) => {
         for (const cb of exitListeners) cb(code);
       })
@@ -187,6 +182,21 @@ export function createLibkungfuWindowsSpawn(
         stdoutServer.close();
         cleanupScratch();
       });
+
+    // native opened the pipes as the child's stdio; the servers accept those
+    // connections. host WRITES to stdin, READS child stdout. If the guest exits
+    // BEFORE connecting its pipes (a startup failure — e.g. the runtime cannot
+    // initialize under the AppContainer), the connected promises would hang
+    // forever. Race them against the exit so a failed launch surfaces as an error
+    // carrying the exit code instead of a deadlock.
+    const [stdin, stdout] = (await Promise.race([
+      Promise.all([stdinServer.connected, stdoutServer.connected]),
+      exited.then((code) => {
+        throw new Error(
+          `sandboxed guest exited before connecting its relay pipes (exit code ${code})`,
+        );
+      }),
+    ])) as [Socket, Socket];
 
     const child: GuestChild = {
       stdout,

--- a/framework/core/src/bindings/node/binding/app_container.cpp
+++ b/framework/core/src/bindings/node/binding/app_container.cpp
@@ -108,6 +108,7 @@ Napi::Value SpawnAppContainer(const Napi::CallbackInfo &info) {
   options.capabilities = to_string_vector(spec.Get("capabilities"));
   options.allow_broad_write = spec.Get("allowBroadWrite").ToBoolean().Value();
   options.allow_loopback = spec.Get("allowLoopback").ToBoolean().Value();
+  options.read_paths = to_string_vector(spec.Get("readPaths"));
   options.env = to_string_vector(spec.Get("env"));
 
   try {

--- a/framework/core/src/bindings/node/binding/app_container.cpp
+++ b/framework/core/src/bindings/node/binding/app_container.cpp
@@ -109,6 +109,9 @@ Napi::Value SpawnAppContainer(const Napi::CallbackInfo &info) {
   options.allow_broad_write = spec.Get("allowBroadWrite").ToBoolean().Value();
   options.allow_loopback = spec.Get("allowLoopback").ToBoolean().Value();
   options.read_paths = to_string_vector(spec.Get("readPaths"));
+  if (spec.Get("writeScratch").IsString()) {
+    options.write_scratch = spec.Get("writeScratch").As<Napi::String>().Utf8Value();
+  }
   options.env = to_string_vector(spec.Get("env"));
 
   try {

--- a/framework/core/src/libyijinjing/CMakeLists.txt
+++ b/framework/core/src/libyijinjing/CMakeLists.txt
@@ -62,8 +62,11 @@ target_link_libraries(yijinjing PUBLIC
 # once wired; it is deferred in app_container.cpp for now.
 if(WIN32)
   # userenv: CreateAppContainerProfile / DeriveAppContainerSidFromAppContainerName
-  # advapi32: FreeSid, SetEntriesInAcl. user32: window-station/desktop ACLs so a
-  # USER32-linked guest (node) can initialize under the AppContainer.
+  # advapi32: FreeSid, SetEntriesInAcl, GetNamedSecurityInfo/SetNamedSecurityInfo
+  # (read-path ACLs), and CreateRestrictedToken/OpenProcessToken/GetTokenInformation
+  # /CreateProcessAsUser (the denyWrite deny-only-user-SID launch). user32:
+  # window-station/desktop ACLs so a USER32-linked guest (node) can initialize
+  # under the AppContainer.
   # DeriveCapabilitySidsFromName is resolved dynamically from KernelBase.dll in
   # app_container.cpp (its import library varies across SDKs).
   target_link_libraries(yijinjing PUBLIC userenv advapi32 user32)

--- a/framework/core/src/libyijinjing/CMakeLists.txt
+++ b/framework/core/src/libyijinjing/CMakeLists.txt
@@ -64,9 +64,8 @@ if(WIN32)
   # userenv: CreateAppContainerProfile / DeriveAppContainerSidFromAppContainerName
   # + GetAppContainerFolderPath (TEMP redirect to the container's writable folder).
   # advapi32: FreeSid, SetEntriesInAcl, GetNamedSecurityInfo/SetNamedSecurityInfo
-  # (read-path ACLs), CreateRestrictedToken/OpenProcessToken/GetTokenInformation
-  # /CreateProcessAsUser (the denyWrite deny-only-user-SID launch), and
-  # ConvertSidToStringSid. ole32: CoTaskMemFree (frees GetAppContainerFolderPath's
+  # (read/write-path ACLs — the container SID governs AppContainer file access),
+  # and ConvertSidToStringSid. ole32: CoTaskMemFree (frees GetAppContainerFolderPath's
   # path). user32: window-station/desktop ACLs so a USER32-linked guest (node) can
   # initialize under the AppContainer.
   # DeriveCapabilitySidsFromName is resolved dynamically from KernelBase.dll in

--- a/framework/core/src/libyijinjing/CMakeLists.txt
+++ b/framework/core/src/libyijinjing/CMakeLists.txt
@@ -62,14 +62,16 @@ target_link_libraries(yijinjing PUBLIC
 # once wired; it is deferred in app_container.cpp for now.
 if(WIN32)
   # userenv: CreateAppContainerProfile / DeriveAppContainerSidFromAppContainerName
+  # + GetAppContainerFolderPath (TEMP redirect to the container's writable folder).
   # advapi32: FreeSid, SetEntriesInAcl, GetNamedSecurityInfo/SetNamedSecurityInfo
-  # (read-path ACLs), and CreateRestrictedToken/OpenProcessToken/GetTokenInformation
-  # /CreateProcessAsUser (the denyWrite deny-only-user-SID launch). user32:
-  # window-station/desktop ACLs so a USER32-linked guest (node) can initialize
-  # under the AppContainer.
+  # (read-path ACLs), CreateRestrictedToken/OpenProcessToken/GetTokenInformation
+  # /CreateProcessAsUser (the denyWrite deny-only-user-SID launch), and
+  # ConvertSidToStringSid. ole32: CoTaskMemFree (frees GetAppContainerFolderPath's
+  # path). user32: window-station/desktop ACLs so a USER32-linked guest (node) can
+  # initialize under the AppContainer.
   # DeriveCapabilitySidsFromName is resolved dynamically from KernelBase.dll in
   # app_container.cpp (its import library varies across SDKs).
-  target_link_libraries(yijinjing PUBLIC userenv advapi32 user32)
+  target_link_libraries(yijinjing PUBLIC userenv advapi32 user32 ole32)
 endif()
 
 if(DEFINED COMPILER_OPTIMIZE_ON_OPTIONS AND NOT "${COMPILER_OPTIMIZE_ON_OPTIONS}" STREQUAL "")

--- a/framework/core/src/libyijinjing/include/kungfu/yijinjing/util/os.h
+++ b/framework/core/src/libyijinjing/include/kungfu/yijinjing/util/os.h
@@ -60,6 +60,13 @@ struct app_container_options {
   std::vector<std::string> capabilities;
   // permissive lets the guest write outside its AppContainer folder
   bool allow_broad_write = false;
+  // a user-space directory the guest's write probe targets, passed to the guest as
+  // KFX_WRITE_PROBE under every profile so the same facet writes the same path.
+  // AppContainer write access is governed by the container SID's ACE (a lowbox
+  // token does not honour the user's own ACEs), so permissive grants the container
+  // SID write here (+ ancestor traverse) and deny-write leaves it ungranted — the
+  // write then succeeds or is refused accordingly. Empty = no probe dir passed.
+  std::string write_scratch;
   // permissive adds the loopback network-isolation exemption so relay-local
   // sockets work (AppContainer blocks loopback by default)
   bool allow_loopback = false;

--- a/framework/core/src/libyijinjing/include/kungfu/yijinjing/util/os.h
+++ b/framework/core/src/libyijinjing/include/kungfu/yijinjing/util/os.h
@@ -63,6 +63,14 @@ struct app_container_options {
   // permissive adds the loopback network-isolation exemption so relay-local
   // sockets work (AppContainer blocks loopback by default)
   bool allow_loopback = false;
+  // filesystem paths the guest must be able to READ (interpreter dirs, guest
+  // bundle root). Under denyWrite the guest's user SID is deny-only, so reads no
+  // longer resolve through the user's own ACEs — the launcher grants the
+  // AppContainer SID read+execute on these paths (and traverse on their
+  // ancestors) so the interpreter and guest stay readable. This codifies what a
+  // basic AppContainer previously needed manual icacls for; empty leaves file
+  // ACLs untouched (the legacy manual path).
+  std::vector<std::string> read_paths;
   // child environment as "KEY=VALUE" entries
   std::vector<std::string> env;
 };

--- a/framework/core/src/libyijinjing/src/util/app_container.cpp
+++ b/framework/core/src/libyijinjing/src/util/app_container.cpp
@@ -199,10 +199,57 @@ void grant_path_read(const std::wstring &path, PSID sid) {
   set_path_ace(path, ea);
 }
 
+// True if `path`'s DACL already grants ALL APPLICATION PACKAGES (S-1-15-2-1)
+// traverse/execute. A basic (non-LPAC) AppContainer runs with that group SID, so
+// where it is already present the container can traverse the directory without us
+// re-writing the DACL. This matters because re-writing a large user-profile
+// directory's DACL (C:\Users\<user>, its AppData) triggers NTFS to re-propagate
+// inheritable ACEs across the whole subtree — tens of seconds, or effectively a
+// hang for a big profile. System and profile ancestors carry ALL APPLICATION
+// PACKAGES:(RX) by default, so skipping them removes the redundant slow writes
+// that were the real cause of the spawn hang, while still granting any ancestor
+// that genuinely lacks the right.
+bool all_app_packages_can_traverse(const std::wstring &path) {
+  PSID all_app_packages = nullptr;
+  if (!::ConvertStringSidToSidW(L"S-1-15-2-1", &all_app_packages)) {
+    return false;
+  }
+  bool granted = false;
+  PACL dacl = nullptr;
+  PSECURITY_DESCRIPTOR descriptor = nullptr;
+  if (::GetNamedSecurityInfoW(path.c_str(), SE_FILE_OBJECT, DACL_SECURITY_INFORMATION, nullptr, nullptr, &dacl, nullptr,
+                              &descriptor) == ERROR_SUCCESS &&
+      dacl != nullptr) {
+    for (DWORD i = 0; i < dacl->AceCount; ++i) {
+      LPVOID raw = nullptr;
+      if (!::GetAce(dacl, i, &raw)) {
+        continue;
+      }
+      auto *header = static_cast<ACE_HEADER *>(raw);
+      if (header->AceType != ACCESS_ALLOWED_ACE_TYPE) {
+        continue;
+      }
+      auto *allowed = reinterpret_cast<ACCESS_ALLOWED_ACE *>(raw);
+      if (::EqualSid(&allowed->SidStart, all_app_packages) && (allowed->Mask & FILE_TRAVERSE) == FILE_TRAVERSE) {
+        granted = true;
+        break;
+      }
+    }
+  }
+  if (descriptor != nullptr) {
+    ::LocalFree(descriptor);
+  }
+  ::LocalFree(all_app_packages);
+  return granted;
+}
+
 // Grant traverse (list + execute, non-inheritable) on each ancestor directory up
 // to the drive root, so the container SID can walk down to a granted read path.
 // NTFS requires traverse on every parent unless SeChangeNotifyPrivilege bypass
-// applies, which a deny-only / AppContainer token cannot rely on.
+// applies, which a deny-only / AppContainer token cannot rely on. Ancestors that
+// already grant ALL APPLICATION PACKAGES traverse are skipped — see
+// all_app_packages_can_traverse: writing their DACL is both redundant and, for
+// large profile directories, pathologically slow.
 void grant_ancestors_traverse(const std::wstring &path, PSID sid) {
   std::wstring current = path;
   for (;;) {
@@ -219,14 +266,16 @@ void grant_ancestors_traverse(const std::wstring &path, PSID sid) {
     if (target.size() == 2 && target[1] == L':') {
       target += L'\\';
     }
-    EXPLICIT_ACCESSW ea = {};
-    ea.grfAccessPermissions = FILE_TRAVERSE | FILE_LIST_DIRECTORY | READ_CONTROL;
-    ea.grfAccessMode = GRANT_ACCESS;
-    ea.grfInheritance = NO_INHERITANCE;
-    ea.Trustee.TrusteeForm = TRUSTEE_IS_SID;
-    ea.Trustee.TrusteeType = TRUSTEE_IS_GROUP;
-    ea.Trustee.ptstrName = reinterpret_cast<LPWSTR>(sid);
-    set_path_ace(target, ea);
+    if (!all_app_packages_can_traverse(target)) {
+      EXPLICIT_ACCESSW ea = {};
+      ea.grfAccessPermissions = FILE_TRAVERSE | FILE_LIST_DIRECTORY | READ_CONTROL;
+      ea.grfAccessMode = GRANT_ACCESS;
+      ea.grfInheritance = NO_INHERITANCE;
+      ea.Trustee.TrusteeForm = TRUSTEE_IS_SID;
+      ea.Trustee.TrusteeType = TRUSTEE_IS_GROUP;
+      ea.Trustee.ptstrName = reinterpret_cast<LPWSTR>(sid);
+      set_path_ace(target, ea);
+    }
     if (target.size() <= 3) { // reached "C:\"
       break;
     }

--- a/framework/core/src/libyijinjing/src/util/app_container.cpp
+++ b/framework/core/src/libyijinjing/src/util/app_container.cpp
@@ -29,6 +29,9 @@
 #include <userenv.h>
 // SetEntriesInAcl (link: advapi32); window-station/desktop ACLs use user32.
 #include <aclapi.h>
+// ConvertSidToStringSid (link: advapi32) for GetAppContainerFolderPath (userenv).
+#include <algorithm>
+#include <sddl.h>
 #include <vector>
 
 // DeriveCapabilitySidsFromName is declared in securitybaseapi.h (via windows.h)
@@ -47,6 +50,39 @@ std::wstring widen(const std::string &s) {
   std::wstring w(static_cast<size_t>(n), L'\0');
   ::MultiByteToWideChar(CP_UTF8, 0, s.c_str(), static_cast<int>(s.size()), w.data(), n);
   return w;
+}
+
+std::string narrow(const std::wstring &w) {
+  if (w.empty()) {
+    return std::string();
+  }
+  int n = ::WideCharToMultiByte(CP_UTF8, 0, w.c_str(), static_cast<int>(w.size()), nullptr, 0, nullptr, nullptr);
+  std::string s(static_cast<size_t>(n), '\0');
+  ::WideCharToMultiByte(CP_UTF8, 0, w.c_str(), static_cast<int>(w.size()), s.data(), n, nullptr, nullptr);
+  return s;
+}
+
+// The AppContainer's own writable data folder (%LOCALAPPDATA%\Packages\<moniker>\AC).
+// The container SID owns it, so the guest can write there without being granted
+// the user's temp — which deny-write must refuse. The launcher redirects the
+// guest's TEMP/TMP here so the node runtime has a writable scratch under every
+// profile (including deny-write, where the user's own paths are unreachable). A
+// basic AppContainer runs as the user, but its runtime still needs the container
+// SID's own writable folder to start — the user's temp cannot be that scratch, or
+// deny-write could never bite the write the facet actually performs.
+std::wstring app_container_folder(PSID sid) {
+  LPWSTR sid_str = nullptr;
+  if (!::ConvertSidToStringSidW(sid, &sid_str)) {
+    return std::wstring();
+  }
+  PWSTR path = nullptr;
+  std::wstring result;
+  if (SUCCEEDED(::GetAppContainerFolderPath(sid_str, &path)) && path != nullptr) {
+    result = path;
+    ::CoTaskMemFree(path);
+  }
+  ::LocalFree(sid_str);
+  return result;
 }
 
 [[noreturn]] void throw_win32(const char *context) {
@@ -388,9 +424,27 @@ std::shared_ptr<app_container_process> spawn_app_container(const app_container_o
   //    cannot be built the launch falls back to the plain path rather than
   //    silently proceeding, and the demo's fs-write assertion reports the knob as
   //    not enforced.
+  // Redirect the guest's TEMP/TMP to the AppContainer's own writable folder, so
+  // the node runtime has a writable scratch under every profile without reaching
+  // the user's temp. This lets deny-write refuse the user-space write the facet
+  // performs while the runtime still starts, and removes the need to grant the
+  // container SID write on the user's temp (the manual-icacls path this replaces).
+  std::vector<std::string> env = options.env;
+  const std::wstring ac_folder = app_container_folder(app_container_sid);
+  if (!ac_folder.empty()) {
+    const std::string ac = narrow(ac_folder);
+    auto is_temp_var = [](const std::string &entry) {
+      return entry.rfind("TEMP=", 0) == 0 || entry.rfind("TMP=", 0) == 0 || entry.rfind("temp=", 0) == 0 ||
+             entry.rfind("tmp=", 0) == 0 || entry.rfind("Temp=", 0) == 0 || entry.rfind("Tmp=", 0) == 0;
+    };
+    env.erase(std::remove_if(env.begin(), env.end(), is_temp_var), env.end());
+    env.push_back("TEMP=" + ac);
+    env.push_back("TMP=" + ac);
+  }
+
   std::wstring command_line = build_command_line(options.command, options.args);
-  std::wstring environment = build_environment_block(options.env);
-  LPVOID environment_block = options.env.empty() ? nullptr : environment.data();
+  std::wstring environment = build_environment_block(env);
+  LPVOID environment_block = env.empty() ? nullptr : environment.data();
   const DWORD creation_flags = EXTENDED_STARTUPINFO_PRESENT | CREATE_UNICODE_ENVIRONMENT;
   PROCESS_INFORMATION process_info = {};
   HANDLE deny_write_token = options.allow_broad_write ? nullptr : make_deny_write_token();

--- a/framework/core/src/libyijinjing/src/util/app_container.cpp
+++ b/framework/core/src/libyijinjing/src/util/app_container.cpp
@@ -127,6 +127,107 @@ void grant_user_object(HANDLE object, PSID sid) {
   }
   ::LocalFree(new_dacl);
 }
+
+// Merge one allow ACE for `sid` into a filesystem path's DACL, preserving the
+// existing entries. Best-effort: the host runs as the owning user (WRITE_DAC on
+// its own tree), so a path it does not own — e.g. a system directory — fails
+// silently and surfaces as a guest read error rather than a false grant.
+void set_path_ace(const std::wstring &path, EXPLICIT_ACCESSW &ea) {
+  PACL old_dacl = nullptr;
+  PSECURITY_DESCRIPTOR descriptor = nullptr;
+  if (::GetNamedSecurityInfoW(path.c_str(), SE_FILE_OBJECT, DACL_SECURITY_INFORMATION, nullptr, nullptr, &old_dacl,
+                              nullptr, &descriptor) != ERROR_SUCCESS) {
+    return;
+  }
+  PACL new_dacl = nullptr;
+  if (::SetEntriesInAclW(1, &ea, old_dacl, &new_dacl) == ERROR_SUCCESS) {
+    ::SetNamedSecurityInfoW(const_cast<LPWSTR>(path.c_str()), SE_FILE_OBJECT, DACL_SECURITY_INFORMATION, nullptr,
+                            nullptr, new_dacl, nullptr);
+    ::LocalFree(new_dacl);
+  }
+  ::LocalFree(descriptor);
+}
+
+// Grant the AppContainer SID read+execute on a path, inheritable so files and
+// directories beneath it are readable. Under denyWrite the guest's user SID is
+// deny-only, so the interpreter and guest can only be read through the container
+// SID's own ACE — this is what makes deny-write shippable without manual icacls.
+void grant_path_read(const std::wstring &path, PSID sid) {
+  EXPLICIT_ACCESSW ea = {};
+  ea.grfAccessPermissions = GENERIC_READ | GENERIC_EXECUTE;
+  ea.grfAccessMode = GRANT_ACCESS;
+  ea.grfInheritance = OBJECT_INHERIT_ACE | CONTAINER_INHERIT_ACE;
+  ea.Trustee.TrusteeForm = TRUSTEE_IS_SID;
+  ea.Trustee.TrusteeType = TRUSTEE_IS_GROUP;
+  ea.Trustee.ptstrName = reinterpret_cast<LPWSTR>(sid);
+  set_path_ace(path, ea);
+}
+
+// Grant traverse (list + execute, non-inheritable) on each ancestor directory up
+// to the drive root, so the container SID can walk down to a granted read path.
+// NTFS requires traverse on every parent unless SeChangeNotifyPrivilege bypass
+// applies, which a deny-only / AppContainer token cannot rely on.
+void grant_ancestors_traverse(const std::wstring &path, PSID sid) {
+  std::wstring current = path;
+  for (;;) {
+    const size_t slash = current.find_last_of(L"\\/");
+    if (slash == std::wstring::npos) {
+      break;
+    }
+    current = current.substr(0, slash);
+    if (current.empty()) {
+      break;
+    }
+    // a bare drive letter "C:" addresses the root as "C:\".
+    std::wstring target = current;
+    if (target.size() == 2 && target[1] == L':') {
+      target += L'\\';
+    }
+    EXPLICIT_ACCESSW ea = {};
+    ea.grfAccessPermissions = FILE_TRAVERSE | FILE_LIST_DIRECTORY | READ_CONTROL;
+    ea.grfAccessMode = GRANT_ACCESS;
+    ea.grfInheritance = NO_INHERITANCE;
+    ea.Trustee.TrusteeForm = TRUSTEE_IS_SID;
+    ea.Trustee.TrusteeType = TRUSTEE_IS_GROUP;
+    ea.Trustee.ptstrName = reinterpret_cast<LPWSTR>(sid);
+    set_path_ace(target, ea);
+    if (target.size() <= 3) { // reached "C:\"
+      break;
+    }
+  }
+}
+
+// Build a restricted primary token whose user SID is deny-only, so the guest no
+// longer satisfies the allow ACEs the user owns on temp/home. A basic
+// AppContainer runs AS the user, so those user ACEs override the container SID's
+// default-deny and file ACLs alone cannot deny the user's writes (goal decision
+// D2). Deny-only means the user SID is still evaluated for DENY ACEs but never
+// grants access. Returns nullptr on failure; the caller then falls back to the
+// plain launch rather than silently dropping the write restriction.
+HANDLE make_deny_write_token() {
+  HANDLE process_token = nullptr;
+  if (!::OpenProcessToken(::GetCurrentProcess(),
+                          TOKEN_DUPLICATE | TOKEN_ASSIGN_PRIMARY | TOKEN_QUERY | TOKEN_ADJUST_DEFAULT,
+                          &process_token)) {
+    return nullptr;
+  }
+  DWORD needed = 0;
+  ::GetTokenInformation(process_token, TokenUser, nullptr, 0, &needed);
+  HANDLE restricted = nullptr;
+  if (needed > 0) {
+    std::vector<BYTE> buffer(needed);
+    auto user = reinterpret_cast<PTOKEN_USER>(buffer.data());
+    if (::GetTokenInformation(process_token, TokenUser, user, needed, &needed)) {
+      SID_AND_ATTRIBUTES to_disable = {};
+      to_disable.Sid = user->User.Sid;
+      if (!::CreateRestrictedToken(process_token, 0, 1, &to_disable, 0, nullptr, 0, nullptr, &restricted)) {
+        restricted = nullptr;
+      }
+    }
+  }
+  ::CloseHandle(process_token);
+  return restricted;
+}
 } // namespace
 
 app_container_process::app_container_process(void *process_handle, unsigned long pid)
@@ -269,15 +370,43 @@ std::shared_ptr<app_container_process> spawn_app_container(const app_container_o
     grant_user_object(desktop, app_container_sid);
   }
 
-  // 6. Launch into the AppContainer.
+  // 5c. Grant the AppContainer SID read+execute on the guest's read paths, plus
+  //     traverse on their ancestors. Required under denyWrite (the user SID is
+  //     deny-only, so reads cannot resolve through the user's own ACEs); harmless
+  //     and idempotent under permissive. This codifies what previously needed
+  //     manual icacls, so a shipped Windows guest needs no out-of-band ACL setup.
+  for (const auto &read_path : options.read_paths) {
+    const std::wstring wide_path = widen(read_path);
+    grant_path_read(wide_path, app_container_sid);
+    grant_ancestors_traverse(wide_path, app_container_sid);
+  }
+
+  // 6. Launch into the AppContainer. Under denyWrite, launch with a restricted
+  //    token whose user SID is deny-only so the guest cannot write through the
+  //    user's own ACEs (a basic AppContainer runs AS the user; file ACLs alone
+  //    cannot deny the user's writes — goal decision D2). If the restricted token
+  //    cannot be built the launch falls back to the plain path rather than
+  //    silently proceeding, and the demo's fs-write assertion reports the knob as
+  //    not enforced.
   std::wstring command_line = build_command_line(options.command, options.args);
   std::wstring environment = build_environment_block(options.env);
+  LPVOID environment_block = options.env.empty() ? nullptr : environment.data();
+  const DWORD creation_flags = EXTENDED_STARTUPINFO_PRESENT | CREATE_UNICODE_ENVIRONMENT;
   PROCESS_INFORMATION process_info = {};
-  BOOL ok = ::CreateProcessW(
-      nullptr, command_line.data(), nullptr, nullptr, TRUE, EXTENDED_STARTUPINFO_PRESENT | CREATE_UNICODE_ENVIRONMENT,
-      options.env.empty() ? nullptr : environment.data(), nullptr, &startup.StartupInfo, &process_info);
+  HANDLE deny_write_token = options.allow_broad_write ? nullptr : make_deny_write_token();
+  BOOL ok;
+  if (deny_write_token != nullptr) {
+    ok = ::CreateProcessAsUserW(deny_write_token, nullptr, command_line.data(), nullptr, nullptr, TRUE, creation_flags,
+                                environment_block, nullptr, &startup.StartupInfo, &process_info);
+  } else {
+    ok = ::CreateProcessW(nullptr, command_line.data(), nullptr, nullptr, TRUE, creation_flags, environment_block,
+                          nullptr, &startup.StartupInfo, &process_info);
+  }
 
   // cleanup regardless of success
+  if (deny_write_token != nullptr) {
+    ::CloseHandle(deny_write_token);
+  }
   ::DeleteProcThreadAttributeList(startup.lpAttributeList);
   ::HeapFree(::GetProcessHeap(), 0, startup.lpAttributeList);
   ::CloseHandle(h_stdin);

--- a/framework/core/src/libyijinjing/src/util/app_container.cpp
+++ b/framework/core/src/libyijinjing/src/util/app_container.cpp
@@ -233,36 +233,22 @@ void grant_ancestors_traverse(const std::wstring &path, PSID sid) {
   }
 }
 
-// Build a restricted primary token whose user SID is deny-only, so the guest no
-// longer satisfies the allow ACEs the user owns on temp/home. A basic
-// AppContainer runs AS the user, so those user ACEs override the container SID's
-// default-deny and file ACLs alone cannot deny the user's writes (goal decision
-// D2). Deny-only means the user SID is still evaluated for DENY ACEs but never
-// grants access. Returns nullptr on failure; the caller then falls back to the
-// plain launch rather than silently dropping the write restriction.
-HANDLE make_deny_write_token() {
-  HANDLE process_token = nullptr;
-  if (!::OpenProcessToken(::GetCurrentProcess(),
-                          TOKEN_DUPLICATE | TOKEN_ASSIGN_PRIMARY | TOKEN_QUERY | TOKEN_ADJUST_DEFAULT,
-                          &process_token)) {
-    return nullptr;
-  }
-  DWORD needed = 0;
-  ::GetTokenInformation(process_token, TokenUser, nullptr, 0, &needed);
-  HANDLE restricted = nullptr;
-  if (needed > 0) {
-    std::vector<BYTE> buffer(needed);
-    auto user = reinterpret_cast<PTOKEN_USER>(buffer.data());
-    if (::GetTokenInformation(process_token, TokenUser, user, needed, &needed)) {
-      SID_AND_ATTRIBUTES to_disable = {};
-      to_disable.Sid = user->User.Sid;
-      if (!::CreateRestrictedToken(process_token, 0, 1, &to_disable, 0, nullptr, 0, nullptr, &restricted)) {
-        restricted = nullptr;
-      }
-    }
-  }
-  ::CloseHandle(process_token);
-  return restricted;
+// Grant the AppContainer SID write (create/modify/delete) on a path, inheritable
+// so files created beneath it are writable. AppContainer write access is governed
+// by the container SID's own ACE — a lowbox token does not honour the user's own
+// ACEs — so this is what makes a write succeed. permissive grants it on the write
+// probe's scratch dir; deny-write leaves it ungranted so the guest's write is
+// refused (ACCESS_DENIED / EACCES). This is the real deny-write mechanism, in
+// place of a restricted token: the user SID never governed AppContainer writes.
+void grant_path_write(const std::wstring &path, PSID sid) {
+  EXPLICIT_ACCESSW ea = {};
+  ea.grfAccessPermissions = GENERIC_READ | GENERIC_WRITE | GENERIC_EXECUTE | DELETE;
+  ea.grfAccessMode = GRANT_ACCESS;
+  ea.grfInheritance = OBJECT_INHERIT_ACE | CONTAINER_INHERIT_ACE;
+  ea.Trustee.TrusteeForm = TRUSTEE_IS_SID;
+  ea.Trustee.TrusteeType = TRUSTEE_IS_GROUP;
+  ea.Trustee.ptstrName = reinterpret_cast<LPWSTR>(sid);
+  set_path_ace(path, ea);
 }
 } // namespace
 
@@ -407,29 +393,40 @@ std::shared_ptr<app_container_process> spawn_app_container(const app_container_o
   }
 
   // 5c. Grant the AppContainer SID read+execute on the guest's read paths, plus
-  //     traverse on their ancestors. Required under denyWrite (the user SID is
-  //     deny-only, so reads cannot resolve through the user's own ACEs); harmless
-  //     and idempotent under permissive. This codifies what previously needed
-  //     manual icacls, so a shipped Windows guest needs no out-of-band ACL setup.
+  //     traverse on their ancestors. AppContainer access is governed by the
+  //     container SID's own ACE (a lowbox token does not honour the user's ACEs),
+  //     so the interpreter and guest can only be read through this grant. This
+  //     codifies what previously needed manual icacls, so a shipped Windows guest
+  //     needs no out-of-band ACL setup.
   for (const auto &read_path : options.read_paths) {
     const std::wstring wide_path = widen(read_path);
     grant_path_read(wide_path, app_container_sid);
     grant_ancestors_traverse(wide_path, app_container_sid);
   }
 
-  // 6. Launch into the AppContainer. Under denyWrite, launch with a restricted
-  //    token whose user SID is deny-only so the guest cannot write through the
-  //    user's own ACEs (a basic AppContainer runs AS the user; file ACLs alone
-  //    cannot deny the user's writes — goal decision D2). If the restricted token
-  //    cannot be built the launch falls back to the plain path rather than
-  //    silently proceeding, and the demo's fs-write assertion reports the knob as
-  //    not enforced.
-  // Redirect the guest's TEMP/TMP to the AppContainer's own writable folder, so
-  // the node runtime has a writable scratch under every profile without reaching
-  // the user's temp. This lets deny-write refuse the user-space write the facet
-  // performs while the runtime still starts, and removes the need to grant the
-  // container SID write on the user's temp (the manual-icacls path this replaces).
+  // 5d. The write knob. AppContainer write access is governed by the container
+  //     SID's ACE — the user SID never governs it — so deny-write is simply the
+  //     absence of a container-SID write grant. Under a permissive profile, grant
+  //     the container SID write on the write-probe scratch dir (+ ancestor
+  //     traverse) so the guest's write succeeds; deny-write leaves it ungranted so
+  //     the same write is refused (ACCESS_DENIED). The scratch dir is passed to the
+  //     guest as KFX_WRITE_PROBE under every profile so the same facet targets the
+  //     same path either way.
   std::vector<std::string> env = options.env;
+  if (!options.write_scratch.empty()) {
+    env.push_back("KFX_WRITE_PROBE=" + options.write_scratch);
+    if (options.allow_broad_write) {
+      const std::wstring wide_scratch = widen(options.write_scratch);
+      grant_path_write(wide_scratch, app_container_sid);
+      grant_ancestors_traverse(wide_scratch, app_container_sid);
+    }
+  }
+
+  // 6. Redirect the guest's TEMP/TMP to the AppContainer's own writable folder, so
+  //    the node runtime has a writable scratch under every profile without reaching
+  //    the user's temp. Without this the runtime cannot start (it needs a writable
+  //    temp), and it keeps the runtime's scratch separate from the facet's write
+  //    probe so deny-write can refuse the probe while the runtime still runs.
   const std::wstring ac_folder = app_container_folder(app_container_sid);
   if (!ac_folder.empty()) {
     const std::string ac = narrow(ac_folder);
@@ -442,25 +439,16 @@ std::shared_ptr<app_container_process> spawn_app_container(const app_container_o
     env.push_back("TMP=" + ac);
   }
 
+  // 7. Launch into the AppContainer.
   std::wstring command_line = build_command_line(options.command, options.args);
   std::wstring environment = build_environment_block(env);
   LPVOID environment_block = env.empty() ? nullptr : environment.data();
   const DWORD creation_flags = EXTENDED_STARTUPINFO_PRESENT | CREATE_UNICODE_ENVIRONMENT;
   PROCESS_INFORMATION process_info = {};
-  HANDLE deny_write_token = options.allow_broad_write ? nullptr : make_deny_write_token();
-  BOOL ok;
-  if (deny_write_token != nullptr) {
-    ok = ::CreateProcessAsUserW(deny_write_token, nullptr, command_line.data(), nullptr, nullptr, TRUE, creation_flags,
-                                environment_block, nullptr, &startup.StartupInfo, &process_info);
-  } else {
-    ok = ::CreateProcessW(nullptr, command_line.data(), nullptr, nullptr, TRUE, creation_flags, environment_block,
-                          nullptr, &startup.StartupInfo, &process_info);
-  }
+  BOOL ok = ::CreateProcessW(nullptr, command_line.data(), nullptr, nullptr, TRUE, creation_flags, environment_block,
+                             nullptr, &startup.StartupInfo, &process_info);
 
   // cleanup regardless of success
-  if (deny_write_token != nullptr) {
-    ::CloseHandle(deny_write_token);
-  }
   ::DeleteProcThreadAttributeList(startup.lpAttributeList);
   ::HeapFree(::GetProcessHeap(), 0, startup.lpAttributeList);
   ::CloseHandle(h_stdin);


### PR DESCRIPTION
Root-cause and fix the intermittent Windows AppContainer relay spawn hang: ancestor traverse ACL grants on large user-profile directories (C:\Users\<user>, AppData) triggered NTFS inheritance re-propagation and blocked spawn synchronously. Skip ancestor grants where ALL APPLICATION PACKAGES already has traverse. Also harden the host relay handshake (listen-readiness, timeout, retry). Verified on a real Windows machine: the knob matrix (permissive/denyWrite/denyNetwork) runs green in one pass and the js/py x trusted/sandbox matrix is 4/4 green, both without manual icacls.