### PR TITLE
feat(rewind): capture managed-run responses

### DIFF
--- a/framework/core/src/python/kungfu/cli/commands/managed_run.py
+++ b/framework/core/src/python/kungfu/cli/commands/managed_run.py
@@ -51,6 +51,11 @@ managed_run_command_context = kfc.pass_context()
     is_flag=True,
     help="disable Kungfu Skill context injection",
 )
+@click.option(
+    "--print-response",
+    is_flag=True,
+    help="print the provider response text after the managed-run report",
+)
 @managed_run_command_context
 def managed_run(
     ctx,
@@ -62,6 +67,7 @@ def managed_run(
     agent,
     skill_context_file,
     no_skill_context,
+    print_response,
 ):
     sys.exit(
         run_and_report(
@@ -75,5 +81,6 @@ def managed_run(
             agent=agent,
             skill_context=not no_skill_context,
             skill_context_file=skill_context_file,
+            print_response=print_response,
         )
     )

--- a/framework/core/src/python/kungfu/rewind/README.md
+++ b/framework/core/src/python/kungfu/rewind/README.md
@@ -41,6 +41,15 @@ Payload bodies (`request_body`, `input`, ...) are JSON strings: capture keeps
 full local fidelity; redaction is an export-time concern, never a capture-time
 one.
 
+## Managed-run response evidence
+
+`kungfu managed-run` drives provider CLIs through their structured-output
+surfaces (`codex exec --json`, `claude --print --output-format json`). Besides
+the `CostSnapshot` cost fact, it emits a Supervisor-layer `ModelResponse` with
+the provider's response body and writes `response.json` next to the run
+`manifest.json` in the rewind bundle. Use `--print-response` when a smoke test
+needs to assert the provider's answer text directly.
+
 ## Decode without the writer
 
 Rewind events are open-layer: each run's manifest binds these msg_types to the

--- a/framework/core/src/python/kungfu/rewind/managed_cli.py
+++ b/framework/core/src/python/kungfu/rewind/managed_cli.py
@@ -10,6 +10,8 @@
 # environment (built dist/kungfu) or the packaged runtime.
 
 import argparse
+import hashlib
+import json
 import os
 import sys
 import tempfile
@@ -64,6 +66,7 @@ def run_and_report(
     agent=None,
     skill_context=True,
     skill_context_file=None,
+    print_response=False,
 ):
     """Run one managed provider run on a journal under runtime_dir and print its
     cost. Returns the provider's exit code. Shared by the `kungfu managed-run`
@@ -133,8 +136,26 @@ def run_and_report(
     # frames are written straight to the memory-mapped journal page, so they
     # persist without an explicit flush; the writer releases at function end.
 
+    bundle_dir = os.path.join(runtime_dir, "rewind", run_id, "bundle")
+    os.makedirs(bundle_dir, exist_ok=True)
+    response_path = os.path.join(bundle_dir, "response.json")
+    response_doc = {
+        "schema": "kungfu.managed-run.response/v1",
+        "run_id": run_id,
+        "provider": provider,
+        "exit_code": result.exit_code,
+        "text": result.response_text,
+        "body": json.loads(result.response_body) if result.response_body else None,
+        "error": result.response_error,
+    }
+    with open(response_path, "w", encoding="utf-8") as f:
+        json.dump(response_doc, f, ensure_ascii=False, indent=2)
+        f.write("\n")
+    with open(response_path, "rb") as f:
+        response_hash = hashlib.sha256(f.read()).hexdigest()
+
     manifest = bundle.emit(
-        os.path.join(runtime_dir, "rewind", run_id, "bundle"),
+        bundle_dir,
         runtime_dir,
         {
             "mode": "LIVE",
@@ -142,6 +163,15 @@ def run_and_report(
             "group": "rewind",
             "name": run_id,
             "dest": 0,
+        },
+        extra={
+            "managed_run_response": {
+                "schema": response_doc["schema"],
+                "path": "response.json",
+                "sha256": response_hash,
+                "text_known": result.response_text is not None,
+                "error_known": result.response_error is not None,
+            }
         },
     )
 
@@ -173,9 +203,21 @@ def run_and_report(
             f"  no cost reported   emitted={result.emitted}  exit={result.exit_code}"
             + (f"  error={result.error}" if result.error else "")
         )
+    print(_rule("response"))
+    print("  event        ModelResponse (msg_type 30004) written to the journal")
+    print(f"  response     {response_path}")
+    if result.response_text:
+        first_line = result.response_text.splitlines()[0]
+        print(f"  text         {first_line[:120]}")
+    elif result.response_error:
+        print(f"  error        {result.response_error[:120]}")
+    else:
+        print("  text         — no provider text field found")
     print(f"  run_id       {run_id}")
     print(f"  proof        {manifest}")
     print("─" * 46)
+    if print_response and result.response_text:
+        print(result.response_text)
     return result.exit_code
 
 
@@ -205,6 +247,11 @@ def main(argv=None):
         action="store_true",
         help="disable Kungfu Skill context injection",
     )
+    ap.add_argument(
+        "--print-response",
+        action="store_true",
+        help="print the provider response text after the managed-run report",
+    )
     args = ap.parse_args(argv)
     runtime = args.home or tempfile.mkdtemp(prefix="kungfu-managed-")
     return run_and_report(
@@ -218,6 +265,7 @@ def main(argv=None):
         agent=args.agent,
         skill_context=not args.no_skill_context,
         skill_context_file=args.skill_context_file,
+        print_response=args.print_response,
     )
 
 

--- a/framework/core/src/python/kungfu/rewind/managed_run.py
+++ b/framework/core/src/python/kungfu/rewind/managed_run.py
@@ -22,13 +22,17 @@
 from __future__ import annotations
 
 import dataclasses
+import json
 import subprocess
+import time
 from typing import Callable, List, Optional
 
+from kungfu.rewind import MSG_MODEL_RESPONSE, events
 from kungfu.rewind import cost_wire
 from kungfu.rewind.cost.claude import parse_claude_print_json
 from kungfu.rewind.cost.codex import parse_codex_exec_json_text
 from kungfu.rewind.cost.model import CostSnapshot
+from kungfu.rewind.fb.CallStatus import CallStatus
 from kungfu.rewind.fb.CaptureLayer import CaptureLayer
 
 # Provider -> how to invoke it for structured output and how to parse it back.
@@ -72,11 +76,118 @@ class ManagedRunResult:
     stdout: str
     stderr: str
     error: Optional[str] = None
+    response_text: Optional[str] = None
+    response_body: Optional[str] = None
+    response_error: Optional[str] = None
+    response_emitted: bool = False
 
 
 def _subprocess_runner(argv, env=None):
     proc = subprocess.run(argv, capture_output=True, text=True, env=env)
     return proc.returncode, proc.stdout, proc.stderr
+
+
+def _content_text(value) -> str:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, list):
+        parts = []
+        for item in value:
+            if isinstance(item, str):
+                parts.append(item)
+            elif isinstance(item, dict):
+                text = item.get("text") or item.get("content")
+                if isinstance(text, str):
+                    parts.append(text)
+        return "".join(parts)
+    return ""
+
+
+def _codex_assistant_text(event: dict) -> Optional[str]:
+    candidates = []
+    if isinstance(event.get("item"), dict):
+        candidates.append(event["item"])
+    if isinstance(event.get("message"), dict):
+        candidates.append(event["message"])
+    candidates.append(event)
+
+    for candidate in candidates:
+        if candidate.get("role") not in (None, "assistant"):
+            continue
+        text = _content_text(candidate.get("content"))
+        if text:
+            return text
+        text = candidate.get("text") or candidate.get("output_text")
+        if isinstance(text, str) and text:
+            return text
+    return None
+
+
+def _extract_codex_response(stdout: str):
+    texts = []
+    raw = None
+    error = None
+    for line in stdout.splitlines():
+        try:
+            event = json.loads(line)
+        except (TypeError, ValueError):
+            continue
+        if not isinstance(event, dict):
+            continue
+        event_type = event.get("type")
+        if event_type in {"turn.failed", "error"}:
+            found = event.get("error") or event.get("message")
+            if isinstance(found, str):
+                error = found
+        text = _codex_assistant_text(event)
+        if text:
+            texts.append(text)
+            raw = event
+    return "\n".join(texts) if texts else None, raw, error
+
+
+def _extract_claude_response(stdout: str):
+    payload = json.loads(stdout)
+    if not isinstance(payload, dict):
+        raise TypeError("claude response payload must be a JSON object")
+    text = payload.get("result")
+    if not isinstance(text, str):
+        text = (
+            payload.get("message") if isinstance(payload.get("message"), str) else None
+        )
+    error = payload.get("error")
+    if not isinstance(error, str):
+        error = None
+    if bool(payload.get("is_error")) and error is None and text:
+        error = text
+    return text, payload, error
+
+
+def _extract_response(
+    provider: str, surface: str, stdout: str, stderr: str, exit_code: int
+):
+    text = None
+    raw = None
+    error = None
+    try:
+        if provider == "claude":
+            text, raw, error = _extract_claude_response(stdout)
+        elif provider == "codex":
+            text, raw, error = _extract_codex_response(stdout)
+    except Exception as exc:
+        error = f"response parse failed: {exc}"
+
+    if error is None and exit_code != 0 and stderr:
+        error = stderr.strip()
+    body = {
+        "provider": provider,
+        "surface": surface,
+        "text": text,
+        "raw": raw,
+    }
+    if error:
+        body["error"] = error
+    return text, json.dumps(body, ensure_ascii=False, sort_keys=True), error
 
 
 def _has_usage(snapshot: CostSnapshot) -> bool:
@@ -114,7 +225,9 @@ def run_managed(
         raise ValueError(f"unknown managed provider: {provider!r}")
 
     argv = spec["argv"](binary, prompt)
+    started_ns = time.monotonic_ns()
     exit_code, stdout, stderr = runner(argv, env=env)
+    latency_ns = max(0, time.monotonic_ns() - started_ns)
 
     snapshot: Optional[CostSnapshot] = None
     error: Optional[str] = None
@@ -134,6 +247,30 @@ def run_managed(
         emit(msg_type, payload)
         emitted = True
 
+    response_text, response_body, response_error = _extract_response(
+        provider, spec["surface"], stdout, stderr, exit_code
+    )
+    status = CallStatus.Error if exit_code != 0 or response_error else CallStatus.Ok
+    input_tokens = output_tokens = 0
+    if snapshot is not None:
+        input_tokens = snapshot.tokens.input_tokens
+        output_tokens = snapshot.tokens.output_tokens
+    emit(
+        MSG_MODEL_RESPONSE,
+        events.model_response(
+            run_id=run_id,
+            span_id=f"{run_id}:managed-provider",
+            layer=CaptureLayer.Supervisor,
+            status=status,
+            response_body=response_body,
+            error=response_error,
+            finish_reason="provider_exit",
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            latency_ns=latency_ns,
+        ),
+    )
+
     return ManagedRunResult(
         provider=provider,
         exit_code=exit_code,
@@ -142,6 +279,10 @@ def run_managed(
         stdout=stdout,
         stderr=stderr,
         error=error,
+        response_text=response_text,
+        response_body=response_body,
+        response_error=response_error,
+        response_emitted=True,
     )
 
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -355,6 +355,7 @@ importers:
       node-addon-api:
         specifier: ^8.0.0
         version: 8.9.0
+
   framework/gui:
     dependencies:
       '@kungfu-tech/api':
@@ -2346,6 +2347,7 @@ packages:
   electron-vite@5.0.0:
     resolution: {integrity: sha512-OHp/vjdlubNlhNkPkL/+3JD34ii5ov7M0GpuXEVdQeqdQ3ulvVR7Dg/rNBLfS5XPIFwgoBLDf9sjjrL+CuDyRQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
     peerDependencies:
       '@swc/core': ^1.0.0
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0
@@ -3488,6 +3490,7 @@ packages:
 
   nx@22.7.6:
     resolution: {integrity: sha512-cT2iX6NAtuNT/yaMTtwpIuNQBrW2Zhg4X8zdTEo/h27bz/JYnFm7B9MAKbAXNWK6k0Yxz+jv7zJoMBHutd1Dww==}
+    hasBin: true
     peerDependencies:
       '@swc-node/register': ^1.11.1
       '@swc/core': ^1.15.8
@@ -4367,6 +4370,7 @@ packages:
 
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+    hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
 
@@ -4389,6 +4393,7 @@ packages:
   vite@6.4.3:
     resolution: {integrity: sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
     peerDependencies:
       '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
       jiti: '>=1.21.0'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,6 +10,7 @@ allowBuilds:
   '@kungfu-tech/libnode': true
   core-js: true
   electron: true
+  electron-winstaller: true
   esbuild: true
   node-pty: true
   nx: true

--- a/tests/fixtures/rewind-demo-managed-run/check_managed_run.py
+++ b/tests/fixtures/rewind-demo-managed-run/check_managed_run.py
@@ -43,10 +43,12 @@ if "kungfu" not in sys.modules:
     )
     sys.modules["kungfu"] = _m
 
-from kungfu.rewind import MSG_COST_SNAPSHOT, managed_run  # noqa: E402
+from kungfu.rewind import MSG_COST_SNAPSHOT, MSG_MODEL_RESPONSE, managed_run  # noqa: E402
 from kungfu.rewind.fb.Attribution import Attribution as FbAttribution  # noqa: E402
+from kungfu.rewind.fb.CallStatus import CallStatus as FbCallStatus  # noqa: E402
 from kungfu.rewind.fb.CaptureLayer import CaptureLayer as FbCaptureLayer  # noqa: E402
 from kungfu.rewind.fb.CostSnapshot import CostSnapshot as FbCostSnapshot  # noqa: E402
+from kungfu.rewind.fb.ModelResponse import ModelResponse as FbModelResponse  # noqa: E402
 
 failures = []
 
@@ -78,10 +80,20 @@ def sink():
 
 
 def decode(events):
-    assert len(events) == 1, f"expected 1 event, got {len(events)}"
-    msg_type, payload = events[0]
+    cost_events = [row for row in events if row[0] == MSG_COST_SNAPSHOT]
+    assert len(cost_events) == 1, f"expected 1 cost event, got {len(cost_events)}"
+    msg_type, payload = cost_events[0]
     assert msg_type == MSG_COST_SNAPSHOT
     return FbCostSnapshot.GetRootAs(payload, 0)
+
+
+def decode_response(events):
+    response_events = [row for row in events if row[0] == MSG_MODEL_RESPONSE]
+    assert len(response_events) == 1, (
+        f"expected 1 model response event, got {len(response_events)}"
+    )
+    _, payload = response_events[0]
+    return FbModelResponse.GetRootAs(payload, 0)
 
 
 # --- provider registry ------------------------------------------------------
@@ -93,6 +105,21 @@ check(
 # --- codex: two turns accumulate into one EXACT_RUN, tokens-only ------------
 codex_jsonl = "\n".join(
     [
+        json.dumps(
+            {
+                "type": "item.completed",
+                "item": {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "output_text",
+                            "text": "codex managed response body",
+                        }
+                    ],
+                },
+            }
+        ),
         json.dumps(
             {
                 "type": "turn.completed",
@@ -136,6 +163,16 @@ check(
 )
 check("codex run exit 0", result.exit_code == 0)
 check("codex run emitted", result.emitted is True)
+check(
+    "codex response text captured",
+    result.response_text == "codex managed response body",
+)
+resp = decode_response(events)
+check("codex response event status ok", resp.Status() == FbCallStatus.Ok)
+check(
+    "codex response body has answer",
+    "codex managed response body" in (resp.ResponseBody() or b"").decode(),
+)
 ev = decode(events)
 check(
     "codex event input_tokens accumulated",
@@ -155,6 +192,10 @@ check("codex cost stays unknown", not ev.CostUsdKnown())
 # --- claude: print json carries dollar cost + session ----------------------
 claude_json = json.dumps(
     {
+        "type": "result",
+        "subtype": "success",
+        "is_error": False,
+        "result": "claude managed response body",
         "session_id": "sess-77",
         "total_cost_usd": 0.0231,
         "usage": {
@@ -178,6 +219,16 @@ check(
     str(seen["argv"]),
 )
 check("claude run emitted", result.emitted is True)
+check(
+    "claude response text captured",
+    result.response_text == "claude managed response body",
+)
+resp = decode_response(events)
+check("claude response event status ok", resp.Status() == FbCallStatus.Ok)
+check(
+    "claude response body has answer",
+    "claude managed response body" in (resp.ResponseBody() or b"").decode(),
+)
 ev = decode(events)
 check("claude cost known", bool(ev.CostUsdKnown()))
 check("claude cost value", abs(ev.CostUsd() - 0.0231) < 1e-9, str(ev.CostUsd()))
@@ -193,16 +244,21 @@ result = managed_run.run_managed(
     "codex", "/opt/codex", "noop", emit=emit, run_id="run-empty", runner=run
 )
 check("no-usage run does not emit", result.emitted is False)
-check("no-usage sink stays empty", events == [])
+check(
+    "no-usage emits only response", [row[0] for row in events] == [MSG_MODEL_RESPONSE]
+)
 check("no-usage still returns a snapshot", result.snapshot is not None)
+check("no-usage response text absent", result.response_text is None)
 
-# --- malformed payload fails soft: no event, error recorded ----------------
+# --- malformed payload fails soft: no cost event, response error recorded ---
 run, _ = fake_runner(1, "not json {", "boom")
 emit, events = sink()
 result = managed_run.run_managed(
     "claude", "/opt/claude", "bad", emit=emit, run_id="run-bad", runner=run
 )
 check("malformed run does not emit", result.emitted is False)
+resp = decode_response(events)
+check("malformed response event status error", resp.Status() == FbCallStatus.Error)
 check(
     "malformed run records error",
     result.error is not None and "parse failed" in result.error,


### PR DESCRIPTION
## Summary

- Capture provider response text for `kungfu managed-run` and emit a Supervisor-layer `ModelResponse` (`msg_type 30004`) next to the existing `CostSnapshot`.
- Write a hash-bound `response.json` sidecar into the Rewind bundle manifest and expose `--print-response` for provider smoke tests.
- Cover both `codex exec --json` and `claude --print --output-format json` response extraction paths in the managed-run fixture.
- Allow the newly introduced `electron-winstaller` install script in pnpm `allowBuilds`; inspected script only selects the host-arch 7z vendor binary, which preserves GUI/Windows packaging behavior.

## Verification

- `uv --project framework/core run ruff check framework/core/src/python/kungfu/rewind/managed_run.py framework/core/src/python/kungfu/rewind/managed_cli.py framework/core/src/python/kungfu/cli/commands/managed_run.py tests/fixtures/rewind-demo-managed-run/check_managed_run.py`
- `uv --project framework/core run python tests/fixtures/rewind-demo-managed-run/check_managed_run.py tests/fixtures/rewind-demo-managed-run`
- `PYTHONPATH=framework/core/src/python uv --project framework/core run pytest framework/core/tests/python/test_skill.py`
- `git diff --check`
- `./kungfu-code build:core`
- `./kungfu-code freeze`
- `./kungfu-code verify`
- `framework/core/dist/kungfu/kungfu managed-run --help | rg -- '--print-response|--skill-path|--provider'`
- Real Claude managed-run with `framework/skill/fixtures/minimal`: response sidecar and journal `ModelResponse` contain `kungfu.skill-context/v1` and the advertised skill hash.
- Real Codex managed-run with `framework/skill/fixtures/minimal`: response sidecar and journal `ModelResponse` contain `kungfu.skill-context/v1` and the advertised skill hash.
