### PR TITLE
fix(kfx-sandbox): fix the Windows AppContainer relay spawn hang

### DIFF
--- a/framework/api/src/capability/guest-windows.ts
+++ b/framework/api/src/capability/guest-windows.ts
@@ -23,8 +23,8 @@ import { homedir } from 'node:os';
 import { dirname, isAbsolute, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import type { AppContainerSpec } from './sandbox-launcher.js';
 import type { GuestChild, WindowsSandboxSpawn } from './kungfu-guest.js';
+import type { AppContainerSpec } from './sandbox-launcher.js';
 
 // The native process object libkungfu `spawn_app_container` returns. It owns the
 // Windows process HANDLE; JS never sees a raw handle.
@@ -64,6 +64,17 @@ export type LibkungfuWindowsBinding = {
   }) => AppContainerProcess;
 };
 
+// The guest process started but then EXITED before it ever connected its relay
+// pipes — a genuine startup failure (e.g. the denyNetwork guest early-exit).
+// Retrying with fresh pipes would not change the outcome, so the spawn loop
+// surfaces this immediately instead of retrying.
+class GuestExitedBeforeConnect extends Error {}
+
+// The guest neither connected its relay pipes nor exited within the handshake
+// window — the intermittent named-pipe OVERLAPPED handshake loss that used to
+// hang forever. This IS retryable: a fresh pair of pipes usually connects.
+class RelayHandshakeTimeout extends Error {}
+
 // The directories the guest must be readable from: the interpreter's own
 // directory and the directory of each absolute path passed on its argv (the
 // resolver hook, the child bootstrap, the facet entry). Granting the containing
@@ -102,54 +113,80 @@ function uniquePipe(kind: string): string {
 }
 
 // Create a named-pipe server and resolve with the socket the native client
-// connects (the child's std handle is that client end).
+// connects (the child's std handle is that client end). `listening` resolves
+// once the pipe instance actually exists — the native launcher opens the pipe
+// with CreateFile(OPEN_EXISTING), which has no wait/retry of its own, so the
+// host must not spawn until both pipes are listening.
 function serveNamedPipe(pipePath: string): {
   path: string;
+  listening: Promise<void>;
   connected: Promise<Socket>;
   close: () => void;
 } {
-  let server: Server | undefined;
+  let resolveConnected!: (socket: Socket) => void;
+  let rejectConnected!: (err: unknown) => void;
   const connected = new Promise<Socket>((resolve, reject) => {
-    server = net.createServer((socket) => resolve(socket));
-    server.on('error', reject);
-    server.listen(pipePath);
+    resolveConnected = resolve;
+    rejectConnected = reject;
   });
+  const server: Server = net.createServer((socket) => resolveConnected(socket));
+  server.on('error', (err) => rejectConnected(err));
+  const listening = new Promise<void>((resolve, reject) => {
+    server.once('listening', () => resolve());
+    server.once('error', reject);
+  });
+  server.listen(pipePath);
   return {
     path: pipePath,
+    listening,
     connected,
-    close: () => server?.close(),
+    close: () => server.close(),
   };
 }
 
-// Build the WindowsSandboxSpawn from an injected libkungfu binding. Host usage:
-//   launchSandboxedGuest({ ..., windowsSpawn: createLibkungfuWindowsSpawn(binding) })
-export function createLibkungfuWindowsSpawn(
+// One spawn attempt: create fresh pipes, wait until they are listening, launch
+// the guest, and wait for the relay handshake — bounded by `timeoutMs`. Resolves
+// with the wired GuestChild, or throws GuestExitedBeforeConnect / a native error
+// / RelayHandshakeTimeout so the caller can decide whether to retry.
+async function spawnGuestOnce(
   binding: LibkungfuWindowsBinding,
-): WindowsSandboxSpawn {
-  return async (command, args, spec: AppContainerSpec, options) => {
-    const stdinServer = serveNamedPipe(uniquePipe('in'));
-    const stdoutServer = serveNamedPipe(uniquePipe('out'));
+  command: string,
+  args: readonly string[],
+  spec: AppContainerSpec,
+  options: { env: Record<string, string | undefined> },
+  timeoutMs: number,
+): Promise<GuestChild> {
+  const stdinServer = serveNamedPipe(uniquePipe('in'));
+  const stdoutServer = serveNamedPipe(uniquePipe('out'));
 
-    // A per-launch write-probe scratch dir under the home directory — a clean
-    // user-space location the AppContainer inherits no write ACE on. permissive
-    // grants the container SID write here (via writeScratch); denyWrite does not,
-    // so the facet's write is refused. It sits outside the runtime's TEMP (which
-    // the native launcher redirects to the AppContainer folder), so it observes
-    // only the write knob. Removed when the guest exits.
-    pipeSeq += 1;
-    const scratch = join(
-      homedir(),
-      '.kfx-guest-scratch',
-      `${process.pid}-${pipeSeq}`,
-    );
-    mkdirSync(scratch, { recursive: true });
-    const cleanupScratch = () => {
-      try {
-        rmSync(scratch, { recursive: true, force: true });
-      } catch {}
-    };
+  // Both pipe instances must exist BEFORE the native launcher opens them as
+  // client handles: CreateFile(OPEN_EXISTING) fails outright if the pipe is not
+  // yet created, and `server.listen()` is asynchronous. Waiting here removes the
+  // host-listen-vs-native-CreateFile race entirely.
+  await Promise.all([stdinServer.listening, stdoutServer.listening]);
 
-    const proc = binding.spawnAppContainer({
+  // A per-launch write-probe scratch dir under the home directory — a clean
+  // user-space location the AppContainer inherits no write ACE on. permissive
+  // grants the container SID write here (via writeScratch); denyWrite does not,
+  // so the facet's write is refused. It sits outside the runtime's TEMP (which
+  // the native launcher redirects to the AppContainer folder), so it observes
+  // only the write knob. Removed when the guest exits.
+  pipeSeq += 1;
+  const scratch = join(
+    homedir(),
+    '.kfx-guest-scratch',
+    `${process.pid}-${pipeSeq}`,
+  );
+  mkdirSync(scratch, { recursive: true });
+  const cleanupScratch = () => {
+    try {
+      rmSync(scratch, { recursive: true, force: true });
+    } catch {}
+  };
+
+  let proc: AppContainerProcess;
+  try {
+    proc = binding.spawnAppContainer({
       command,
       args,
       stdinPipe: stdinServer.path,
@@ -165,70 +202,149 @@ export function createLibkungfuWindowsSpawn(
         .filter(([, v]) => v !== undefined)
         .map(([k, v]) => `${k}=${v}`),
     });
+  } catch (err) {
+    // native CreateProcess / CreateFile failed synchronously — no process to
+    // wait on. Clean the pipes and scratch here (the exit-wiring below never
+    // ran) and let the caller retry.
+    stdinServer.close();
+    stdoutServer.close();
+    cleanupScratch();
+    throw err;
+  }
 
-    // A single exit wait, shared between the startup guard below and the exit
-    // event wiring.
-    const exited = proc.wait();
-    const exitListeners = new Set<(code: number | null) => void>();
-    exited
-      .then((code) => {
-        for (const cb of exitListeners) cb(code);
-      })
-      .catch(() => {
-        for (const cb of exitListeners) cb(null);
-      })
-      .finally(() => {
-        stdinServer.close();
-        stdoutServer.close();
-        cleanupScratch();
-      });
+  // A single exit wait, shared between the startup guard below and the exit
+  // event wiring.
+  const exited = proc.wait();
+  const exitListeners = new Set<(code: number | null) => void>();
+  exited
+    .then((code) => {
+      for (const cb of exitListeners) cb(code);
+    })
+    .catch(() => {
+      for (const cb of exitListeners) cb(null);
+    })
+    .finally(() => {
+      stdinServer.close();
+      stdoutServer.close();
+      cleanupScratch();
+    });
 
-    // native opened the pipes as the child's stdio; the servers accept those
-    // connections. host WRITES to stdin, READS child stdout. If the guest exits
-    // BEFORE connecting its pipes (a startup failure — e.g. the runtime cannot
-    // initialize under the AppContainer), the connected promises would hang
-    // forever. Race them against the exit so a failed launch surfaces as an error
-    // carrying the exit code instead of a deadlock. The `connectedOk` flag makes
-    // the exit branch throw ONLY while the pipes are still pending, so a normal
-    // later exit does not reject an already-settled race (an unhandled rejection).
-    let connectedOk = false;
-    const connections = Promise.all([
-      stdinServer.connected,
-      stdoutServer.connected,
-    ]).then((pair) => {
-      connectedOk = true;
-      return pair;
-    });
-    const startupGuard = exited.then((code) => {
-      if (!connectedOk) {
-        throw new Error(
-          `sandboxed guest exited before connecting its relay pipes (exit code ${code})`,
-        );
-      }
-      return undefined as never;
-    });
-    const [stdin, stdout] = (await Promise.race([
+  // native opened the pipes as the child's stdio; the servers accept those
+  // connections. host WRITES to stdin, READS child stdout. Three ways the wait
+  // ends: (a) both pipes connect — success; (b) the guest exits BEFORE connecting
+  // (a startup failure) — surface the exit code, no retry; (c) neither happens
+  // within the handshake window (the intermittent OVERLAPPED handshake loss) —
+  // kill the stuck guest and let the caller retry with fresh pipes. The
+  // `connectedOk` flag makes the exit branch throw ONLY while the pipes are still
+  // pending, so a normal later exit does not reject an already-settled race.
+  let connectedOk = false;
+  const connections = Promise.all([
+    stdinServer.connected,
+    stdoutServer.connected,
+  ]).then((pair) => {
+    connectedOk = true;
+    return pair;
+  });
+  const startupGuard = exited.then((code) => {
+    if (!connectedOk) {
+      throw new GuestExitedBeforeConnect(
+        `sandboxed guest exited before connecting its relay pipes (exit code ${code})`,
+      );
+    }
+    return undefined as never;
+  });
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      reject(
+        new RelayHandshakeTimeout(
+          `sandboxed guest did not connect its relay pipes within ${timeoutMs}ms`,
+        ),
+      );
+    }, timeoutMs);
+    // do not let the handshake timer keep the event loop alive on its own
+    timer.unref?.();
+  });
+
+  let stdin: Socket;
+  let stdout: Socket;
+  try {
+    [stdin, stdout] = (await Promise.race([
       connections,
       startupGuard,
+      timeout,
     ])) as [Socket, Socket];
+  } catch (err) {
+    if (err instanceof RelayHandshakeTimeout) {
+      // the guest is up but never connected — kill it so the retry starts from a
+      // clean slate. The kill drives `exited`, whose finally closes the servers
+      // and removes the scratch dir.
+      proc.kill();
+    }
+    // GuestExitedBeforeConnect: the process already exited, so `exited.finally`
+    // handles pipe/scratch cleanup. Native errors are handled above.
+    throw err;
+  } finally {
+    clearTimeout(timer);
+  }
 
-    const child: GuestChild = {
-      stdout,
-      stdin,
-      on(event, cb) {
-        if (event === 'exit') exitListeners.add(cb);
-      },
-      once(event, cb) {
-        if (event === 'exit' || event === 'close') {
-          const wrap = () => {
-            exitListeners.delete(wrap as never);
-            cb();
-          };
-          exitListeners.add(wrap as never);
+  const child: GuestChild = {
+    stdout,
+    stdin,
+    on(event, cb) {
+      if (event === 'exit') exitListeners.add(cb);
+    },
+    once(event, cb) {
+      if (event === 'exit' || event === 'close') {
+        const wrap = () => {
+          exitListeners.delete(wrap as never);
+          cb();
+        };
+        exitListeners.add(wrap as never);
+      }
+    },
+    kill: () => proc.kill(),
+  };
+  return child;
+}
+
+// Build the WindowsSandboxSpawn from an injected libkungfu binding. Host usage:
+//   launchSandboxedGuest({ ..., windowsSpawn: createLibkungfuWindowsSpawn(binding) })
+export function createLibkungfuWindowsSpawn(
+  binding: LibkungfuWindowsBinding,
+): WindowsSandboxSpawn {
+  return async (command, args, spec: AppContainerSpec, options) => {
+    // The relay handshake (host pipe servers ↔ the native CreateFile client ends)
+    // is intermittently lost on Windows: the guest starts but never appears on
+    // the pipes, so the connection wait would hang forever. Bound each attempt
+    // with a timeout and retry the whole spawn with fresh pipes. A guest that
+    // EXITS before connecting is a real startup failure (the denyNetwork
+    // early-exit) and is surfaced immediately — a fresh pipe would not save it.
+    const HANDSHAKE_TIMEOUT_MS = 15_000;
+    const MAX_ATTEMPTS = 3;
+
+    let lastErr: unknown;
+    for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt += 1) {
+      try {
+        return await spawnGuestOnce(
+          binding,
+          command,
+          args,
+          spec,
+          options,
+          HANDSHAKE_TIMEOUT_MS,
+        );
+      } catch (err) {
+        lastErr = err;
+        if (
+          err instanceof GuestExitedBeforeConnect ||
+          attempt === MAX_ATTEMPTS
+        ) {
+          throw err;
         }
-      },
-      kill: () => proc.kill(),
-    };
-    return child;
+        // relay handshake timed out or the pipe open raced — retry with fresh pipes
+      }
+    }
+    throw lastErr;
   };
 }

--- a/framework/core/src/libyijinjing/src/util/app_container.cpp
+++ b/framework/core/src/libyijinjing/src/util/app_container.cpp
@@ -199,10 +199,57 @@ void grant_path_read(const std::wstring &path, PSID sid) {
   set_path_ace(path, ea);
 }
 
+// True if `path`'s DACL already grants ALL APPLICATION PACKAGES (S-1-15-2-1)
+// traverse/execute. A basic (non-LPAC) AppContainer runs with that group SID, so
+// where it is already present the container can traverse the directory without us
+// re-writing the DACL. This matters because re-writing a large user-profile
+// directory's DACL (C:\Users\<user>, its AppData) triggers NTFS to re-propagate
+// inheritable ACEs across the whole subtree — tens of seconds, or effectively a
+// hang for a big profile. System and profile ancestors carry ALL APPLICATION
+// PACKAGES:(RX) by default, so skipping them removes the redundant slow writes
+// that were the real cause of the spawn hang, while still granting any ancestor
+// that genuinely lacks the right.
+bool all_app_packages_can_traverse(const std::wstring &path) {
+  PSID all_app_packages = nullptr;
+  if (!::ConvertStringSidToSidW(L"S-1-15-2-1", &all_app_packages)) {
+    return false;
+  }
+  bool granted = false;
+  PACL dacl = nullptr;
+  PSECURITY_DESCRIPTOR descriptor = nullptr;
+  if (::GetNamedSecurityInfoW(path.c_str(), SE_FILE_OBJECT, DACL_SECURITY_INFORMATION, nullptr, nullptr, &dacl, nullptr,
+                              &descriptor) == ERROR_SUCCESS &&
+      dacl != nullptr) {
+    for (DWORD i = 0; i < dacl->AceCount; ++i) {
+      LPVOID raw = nullptr;
+      if (!::GetAce(dacl, i, &raw)) {
+        continue;
+      }
+      auto *header = static_cast<ACE_HEADER *>(raw);
+      if (header->AceType != ACCESS_ALLOWED_ACE_TYPE) {
+        continue;
+      }
+      auto *allowed = reinterpret_cast<ACCESS_ALLOWED_ACE *>(raw);
+      if (::EqualSid(&allowed->SidStart, all_app_packages) && (allowed->Mask & FILE_TRAVERSE) == FILE_TRAVERSE) {
+        granted = true;
+        break;
+      }
+    }
+  }
+  if (descriptor != nullptr) {
+    ::LocalFree(descriptor);
+  }
+  ::LocalFree(all_app_packages);
+  return granted;
+}
+
 // Grant traverse (list + execute, non-inheritable) on each ancestor directory up
 // to the drive root, so the container SID can walk down to a granted read path.
 // NTFS requires traverse on every parent unless SeChangeNotifyPrivilege bypass
-// applies, which a deny-only / AppContainer token cannot rely on.
+// applies, which a deny-only / AppContainer token cannot rely on. Ancestors that
+// already grant ALL APPLICATION PACKAGES traverse are skipped — see
+// all_app_packages_can_traverse: writing their DACL is both redundant and, for
+// large profile directories, pathologically slow.
 void grant_ancestors_traverse(const std::wstring &path, PSID sid) {
   std::wstring current = path;
   for (;;) {
@@ -219,14 +266,16 @@ void grant_ancestors_traverse(const std::wstring &path, PSID sid) {
     if (target.size() == 2 && target[1] == L':') {
       target += L'\\';
     }
-    EXPLICIT_ACCESSW ea = {};
-    ea.grfAccessPermissions = FILE_TRAVERSE | FILE_LIST_DIRECTORY | READ_CONTROL;
-    ea.grfAccessMode = GRANT_ACCESS;
-    ea.grfInheritance = NO_INHERITANCE;
-    ea.Trustee.TrusteeForm = TRUSTEE_IS_SID;
-    ea.Trustee.TrusteeType = TRUSTEE_IS_GROUP;
-    ea.Trustee.ptstrName = reinterpret_cast<LPWSTR>(sid);
-    set_path_ace(target, ea);
+    if (!all_app_packages_can_traverse(target)) {
+      EXPLICIT_ACCESSW ea = {};
+      ea.grfAccessPermissions = FILE_TRAVERSE | FILE_LIST_DIRECTORY | READ_CONTROL;
+      ea.grfAccessMode = GRANT_ACCESS;
+      ea.grfInheritance = NO_INHERITANCE;
+      ea.Trustee.TrusteeForm = TRUSTEE_IS_SID;
+      ea.Trustee.TrusteeType = TRUSTEE_IS_GROUP;
+      ea.Trustee.ptstrName = reinterpret_cast<LPWSTR>(sid);
+      set_path_ace(target, ea);
+    }
     if (target.size() <= 3) { // reached "C:\"
       break;
     }


### PR DESCRIPTION
Root-cause and fix the intermittent Windows AppContainer relay spawn hang: ancestor traverse ACL grants on large user-profile directories (C:\Users\<user>, AppData) triggered NTFS inheritance re-propagation and blocked spawn synchronously. Skip ancestor grants where ALL APPLICATION PACKAGES already has traverse. Also harden the host relay handshake (listen-readiness, timeout, retry). Verified on a real Windows machine: the knob matrix (permissive/denyWrite/denyNetwork) runs green in one pass and the js/py x trusted/sandbox matrix is 4/4 green, both without manual icacls.