### PR TITLE
feat(skill): audit context usage

### DIFF
--- a/docs/skills.md
+++ b/docs/skills.md
@@ -268,6 +268,7 @@ kungfu skill catalog [--path <dir>] [--json]
 kungfu skill context [--path <dir>] [--source cli|gui|test] [--manager python|node]
 kungfu skill verify --provider <claude|codex> --path <dir> [--manager python|node]
 kungfu skill read <key-or-path> [--path <dir>]
+kungfu skill audit --run-id <id>
 kungfu skill explain <key-or-path>
 ```
 
@@ -280,7 +281,8 @@ through `managed-run`, asks it to echo the advertised schema, first skill key,
 and `advertisedSkillsHash`, then checks the Rewind `response.json` evidence.
 Use `--manager node` to build the envelope through the Node manager path used
 by the Electron GUI. `read` is the operation the agent tool uses to load the
-full `SKILL.md` after selection.
+full `SKILL.md` after selection. `audit` reads the Skill audit sidecar from a
+managed-run bundle or a standalone audit file.
 
 The SDK may add:
 
@@ -330,6 +332,17 @@ advertisement, full instruction loading, dependency invocation, and trust
 refusal should be recordable by the journal-backed responsibility layer so a
 later user or agent can explain why a skill influenced a work decision.
 
+The first audit slice records:
+
+- `SkillAdvertised` in the managed-run bundle when Python or Node manager
+  envelopes advertise skills to a provider. The bundle manifest points to
+  `skill-audit.json` and records its hash and event types.
+- `SkillLoaded` when `kungfu skill read` loads full `SKILL.md` content. This
+  records the selected skill key, source hash, content hash, source path, source,
+  manager, and optional run id.
+- `kungfu skill audit --run-id <id>` to inspect bundle evidence, plus
+  `--audit-file` for standalone JSON/JSONL audit files.
+
 ## First implementation slice
 
 The first slice proves the context loop before broad execution:
@@ -347,10 +360,9 @@ The first slice proves the context loop before broad execution:
 
 Follow-up slices should:
 
-1. Audit advertised and loaded skills.
-2. Bind declared kfx dependencies through the normal kfx registry without
+1. Bind declared kfx dependencies through the normal kfx registry without
    copying them per skill.
-3. Display installed skills in a first-party `skill-manager` view.
+2. Display installed skills in a first-party `skill-manager` view.
 
 Out of scope for the first slice:
 
@@ -370,12 +382,14 @@ The first implementation slice is verified by:
   fixtures;
 - frozen CLI `skill verify --manager python` and `skill verify --manager node`
   with provider response evidence;
+- `SkillAdvertised` audit sidecars discoverable through
+  `kungfu skill audit --run-id`;
+- `SkillLoaded` audit events from `kungfu skill read`;
 - a skill with two kfx declarations proving the skill object can reference
   multiple kfx packages without granting runtime privilege.
 
 Follow-up verification should add:
 
-- audit records for advertised and loaded skills;
 - kfx dependency installation through the shared registry, with deduplication;
 - a third-party adapter dependency proving that skill composition does not bypass
   the existing runtime trust refusal.

--- a/framework/core/src/python/kungfu/cli/commands/skill.py
+++ b/framework/core/src/python/kungfu/cli/commands/skill.py
@@ -15,6 +15,7 @@ from kungfu.rewind.managed_cli import run_and_report
 from kungfu.rewind.managed_run import managed_providers
 from kungfu.skill import (
     SkillError,
+    append_audit_event,
     build_catalog,
     build_context_envelope,
     build_skill_context,
@@ -23,7 +24,9 @@ from kungfu.skill import (
     has_advertised_skills,
     load_skill_context_file,
     parse_skill,
+    read_audit_file,
     read_skill_markdown,
+    skill_loaded_event,
 )
 
 skill_command_context = kfc.pass_context()
@@ -100,6 +103,22 @@ def _write_node_envelope_file(ctx, paths, source, profile, agent):
         detail = (proc.stderr or proc.stdout).strip()
         raise SkillError(f"node manager context failed: {detail}")
     return out
+
+
+def _default_skill_audit_log(ctx):
+    return os.path.join(ctx.runtime_dir, "skill-audit.jsonl")
+
+
+def _bundle_audit_path(ctx, run_id, bundle_dir=None, audit_file=None):
+    if audit_file:
+        return audit_file
+    if bundle_dir:
+        return os.path.join(bundle_dir, "skill-audit.json")
+    if run_id:
+        return os.path.join(
+            ctx.runtime_dir, "rewind", run_id, "bundle", "skill-audit.json"
+        )
+    raise SkillError("pass --run-id, --bundle, or --audit-file")
 
 
 def _verify_response_text(text, expected_schema, expected_key, expected_hash):
@@ -340,6 +359,7 @@ def verify(
         "run_id": report.run_id if report else None,
         "response_path": report.response_path if report else None,
         "manifest_path": report.manifest_path if report else None,
+        "skill_audit_path": report.skill_audit_path if report else None,
         "failures": failures,
     }
     if as_json:
@@ -352,6 +372,8 @@ def verify(
         )
         click.echo(f"[skill] response {summary['response_path']}")
         click.echo(f"[skill] proof {summary['manifest_path']}")
+        if summary["skill_audit_path"]:
+            click.echo(f"[skill] audit {summary['skill_audit_path']}")
     else:
         click.echo(f"[skill] verify failed: {', '.join(failures)}", err=True)
     if not ok:
@@ -361,9 +383,17 @@ def verify(
 @skill.command(help="load full SKILL.md by key or path")
 @click.argument("key_or_path", type=str)
 @click.option("--path", "paths", multiple=True, type=click.Path(exists=True))
+@click.option("--run-id", default=None, help="associate this read with a run id")
+@click.option(
+    "--audit-file",
+    type=click.Path(),
+    default=None,
+    help="append SkillLoaded audit event to this JSONL file",
+)
+@click.option("--no-audit", is_flag=True, help="do not write a SkillLoaded event")
 @click.option("--json", "as_json", is_flag=True, help="machine-readable output")
 @skill_command_context
-def read(ctx, key_or_path, paths, as_json):
+def read(ctx, key_or_path, paths, run_id, audit_file, no_audit, as_json):
     try:
         parsed, markdown = read_skill_markdown(
             ctx.home, key_or_path, _extra_paths(paths)
@@ -371,10 +401,81 @@ def read(ctx, key_or_path, paths, as_json):
     except SkillError as e:
         click.echo(f"[skill] {e}", err=True)
         sys.exit(1)
+    event = skill_loaded_event(
+        parsed,
+        markdown,
+        run_id=run_id,
+        source="cli",
+        manager="python",
+    )
+    audit_path = None
+    if not no_audit:
+        audit_path = audit_file or _default_skill_audit_log(ctx)
+        append_audit_event(audit_path, event)
     if as_json:
-        _json({"skill": parsed, "markdown": markdown})
+        _json(
+            {
+                "skill": parsed,
+                "markdown": markdown,
+                "audit": event,
+                "audit_path": audit_path,
+            }
+        )
     else:
         click.echo(markdown, nl=False)
+
+
+@skill.command(help="inspect Skill audit evidence for a managed run or audit file")
+@click.option("--run-id", default=None, help="managed-run id under this runtime")
+@click.option(
+    "--bundle",
+    "bundle_dir",
+    type=click.Path(exists=True, file_okay=False),
+    default=None,
+    help="bundle directory containing skill-audit.json",
+)
+@click.option(
+    "--audit-file",
+    type=click.Path(exists=True),
+    default=None,
+    help="skill-audit.json or skill-audit.jsonl to inspect",
+)
+@click.option("--json", "as_json", is_flag=True, help="machine-readable output")
+@skill_command_context
+def audit(ctx, run_id, bundle_dir, audit_file, as_json):
+    try:
+        path = _bundle_audit_path(ctx, run_id, bundle_dir, audit_file)
+        data = read_audit_file(path)
+    except (OSError, SkillError, ValueError) as e:
+        click.echo(f"[skill] audit unavailable: {e}", err=True)
+        sys.exit(1)
+    if as_json:
+        _json(data)
+        return
+    click.echo(f"Skill audit: {data.get('run_id') or 'unscoped'}")
+    for event in data.get("events", []):
+        if event.get("type") == "SkillAdvertised":
+            skills = ", ".join(row["key"] for row in event.get("skills", []))
+            click.echo(
+                "SkillAdvertised "
+                f"run={event.get('run_id')} "
+                f"manager={event.get('manager')} "
+                f"source={event.get('source')} "
+                f"skills={skills} "
+                f"hash={event.get('advertisedSkillsHash')}"
+            )
+        elif event.get("type") == "SkillLoaded":
+            skill_data = event.get("skill", {})
+            click.echo(
+                "SkillLoaded "
+                f"run={event.get('run_id') or '-'} "
+                f"manager={event.get('manager')} "
+                f"source={event.get('source')} "
+                f"skill={skill_data.get('key')} "
+                f"hash={skill_data.get('contentHash')}"
+            )
+        else:
+            click.echo(f"{event.get('type') or 'SkillAuditEvent'} {event}")
 
 
 @skill.command(help="explain a Kungfu Skill without granting runtime privileges")

--- a/framework/core/src/python/kungfu/rewind/managed_cli.py
+++ b/framework/core/src/python/kungfu/rewind/managed_cli.py
@@ -35,6 +35,9 @@ from kungfu.skill import (
     has_advertised_skills,
     inject_skill_context,
     load_skill_context_file,
+    skill_advertised_event,
+    skill_audit_document,
+    write_audit_document,
 )
 
 lf = kungfu.__binding__.longfist
@@ -49,6 +52,8 @@ class ManagedRunCliReport:
     response_path: str
     manifest_path: str
     response_doc: dict
+    skill_audit_path: str | None
+    skill_audit_doc: dict | None
 
 
 def _open_journal(runtime_dir, run_id):
@@ -99,6 +104,7 @@ def run_and_report(
         print(f"  binary  {disc.path}  ({disc.path_class}, {disc.version})")
     prompt_for_provider = prompt
     envelope = None
+    skill_audit_events = []
     if skill_context:
         context_path = skill_context_file or context_file_from_env()
         if context_path:
@@ -114,6 +120,15 @@ def run_and_report(
             )
         if has_advertised_skills(envelope):
             prompt_for_provider = inject_skill_context(prompt, envelope)
+            skill_audit_events.append(
+                skill_advertised_event(
+                    envelope,
+                    run_id=run_id,
+                    provider=provider,
+                    work_id=work_id,
+                    context_file=context_path,
+                )
+            )
 
     if not quiet:
         print(f"  prompt  {prompt}")
@@ -172,7 +187,36 @@ def run_and_report(
         f.write("\n")
     with open(response_path, "rb") as f:
         response_hash = hashlib.sha256(f.read()).hexdigest()
+    skill_audit_doc = None
+    skill_audit_path = None
+    skill_audit_hash = None
+    if skill_audit_events:
+        skill_audit_path = os.path.join(bundle_dir, "skill-audit.json")
+        skill_audit_doc = skill_audit_document(
+            run_id=run_id,
+            provider=provider,
+            work_id=work_id,
+            events=skill_audit_events,
+        )
+        skill_audit_hash = write_audit_document(skill_audit_path, skill_audit_doc)
 
+    extra = {
+        "managed_run_response": {
+            "schema": response_doc["schema"],
+            "path": "response.json",
+            "sha256": response_hash,
+            "text_known": result.response_text is not None,
+            "error_known": result.response_error is not None,
+        }
+    }
+    if skill_audit_doc:
+        extra["skill_audit"] = {
+            "schema": skill_audit_doc["schema"],
+            "path": "skill-audit.json",
+            "sha256": skill_audit_hash,
+            "event_count": skill_audit_doc["event_count"],
+            "event_types": sorted({row["type"] for row in skill_audit_events}),
+        }
     manifest = bundle.emit(
         bundle_dir,
         runtime_dir,
@@ -183,15 +227,7 @@ def run_and_report(
             "name": run_id,
             "dest": 0,
         },
-        extra={
-            "managed_run_response": {
-                "schema": response_doc["schema"],
-                "path": "response.json",
-                "sha256": response_hash,
-                "text_known": result.response_text is not None,
-                "error_known": result.response_error is not None,
-            }
-        },
+        extra=extra,
     )
     report = ManagedRunCliReport(
         provider=provider,
@@ -200,6 +236,8 @@ def run_and_report(
         response_path=response_path,
         manifest_path=manifest,
         response_doc=response_doc,
+        skill_audit_path=skill_audit_path,
+        skill_audit_doc=skill_audit_doc,
     )
     if report_callback is not None:
         report_callback(report)
@@ -247,6 +285,8 @@ def run_and_report(
         print("  text         — no provider text field found")
     print(f"  run_id       {run_id}")
     print(f"  proof        {manifest}")
+    if skill_audit_path:
+        print(f"  skill_audit  {skill_audit_path}")
     print("─" * 46)
     if print_response and result.response_text:
         print(result.response_text)

--- a/framework/core/src/python/kungfu/skill/__init__.py
+++ b/framework/core/src/python/kungfu/skill/__init__.py
@@ -2,6 +2,14 @@
 
 from .catalog import build_catalog, catalog_entry
 from .context import build_context_envelope
+from .audit import (
+    append_audit_event,
+    read_audit_file,
+    skill_advertised_event,
+    skill_audit_document,
+    skill_loaded_event,
+    write_audit_document,
+)
 from .parser import SkillError, parse_skill
 from .provider import (
     build_skill_context,
@@ -15,6 +23,7 @@ from .registry import discover_skills, find_skill, read_skill_markdown, skill_ro
 
 __all__ = [
     "SkillError",
+    "append_audit_event",
     "build_catalog",
     "build_context_envelope",
     "build_skill_context",
@@ -27,6 +36,11 @@ __all__ = [
     "inject_skill_context",
     "load_skill_context_file",
     "parse_skill",
+    "read_audit_file",
     "read_skill_markdown",
+    "skill_advertised_event",
+    "skill_audit_document",
+    "skill_loaded_event",
     "skill_roots",
+    "write_audit_document",
 ]

--- a/framework/core/src/python/kungfu/skill/audit.py
+++ b/framework/core/src/python/kungfu/skill/audit.py
@@ -1,0 +1,128 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from datetime import datetime, timezone
+import hashlib
+import json
+import os
+
+
+AUDIT_SCHEMA = "kungfu.skill-audit/v1"
+AUDIT_EVENT_SCHEMA = "kungfu.skill-audit-event/v1"
+
+
+def skill_advertised_event(
+    envelope,
+    *,
+    run_id,
+    provider=None,
+    work_id=None,
+    context_file=None,
+):
+    session = dict(envelope.get("session") or {})
+    audit = dict(envelope.get("audit") or {})
+    return {
+        "schema": AUDIT_EVENT_SCHEMA,
+        "type": "SkillAdvertised",
+        "at": _now(),
+        "run_id": run_id,
+        "work_id": work_id,
+        "provider": provider,
+        "source": session.get("source"),
+        "manager": session.get("manager"),
+        "profile": session.get("profile"),
+        "agent": session.get("agent"),
+        "context_file": context_file,
+        "advertisedSkillsHash": audit.get("advertisedSkillsHash"),
+        "tool_names": [tool.get("name") for tool in envelope.get("tools", [])],
+        "skills": [_advertised_skill(row) for row in envelope.get("catalog", [])],
+    }
+
+
+def skill_loaded_event(
+    skill,
+    markdown,
+    *,
+    run_id=None,
+    source="cli",
+    manager="python",
+    agent=None,
+):
+    content_hash = "sha256:" + hashlib.sha256(markdown.encode()).hexdigest()
+    return {
+        "schema": AUDIT_EVENT_SCHEMA,
+        "type": "SkillLoaded",
+        "at": _now(),
+        "run_id": run_id,
+        "source": source,
+        "manager": manager,
+        "agent": agent,
+        "skill": {
+            "key": skill["key"],
+            "title": skill["title"],
+            "kind": skill["kind"],
+            "sourceHash": skill["source"]["hash"],
+            "contentHash": content_hash,
+            "sourcePath": skill["source"]["path"],
+        },
+        "load_method": "kungfu.skill.read",
+    }
+
+
+def skill_audit_document(*, run_id=None, provider=None, work_id=None, events=None):
+    rows = list(events or [])
+    return {
+        "schema": AUDIT_SCHEMA,
+        "run_id": run_id,
+        "provider": provider,
+        "work_id": work_id,
+        "event_count": len(rows),
+        "events": rows,
+    }
+
+
+def write_audit_document(path, document):
+    os.makedirs(os.path.dirname(os.path.abspath(path)), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(document, f, ensure_ascii=False, indent=2, sort_keys=True)
+        f.write("\n")
+    return file_sha256(path)
+
+
+def append_audit_event(path, event):
+    os.makedirs(os.path.dirname(os.path.abspath(path)), exist_ok=True)
+    with open(path, "a", encoding="utf-8") as f:
+        f.write(json.dumps(event, ensure_ascii=False, sort_keys=True))
+        f.write("\n")
+
+
+def read_audit_file(path):
+    with open(path, encoding="utf-8") as f:
+        text = f.read().strip()
+    if not text:
+        return skill_audit_document(events=[])
+    if text.startswith("{"):
+        parsed = json.loads(text)
+        if parsed.get("schema") == AUDIT_SCHEMA:
+            return parsed
+    events = [json.loads(line) for line in text.splitlines() if line.strip()]
+    run_id = events[-1].get("run_id") if events else None
+    return skill_audit_document(run_id=run_id, events=events)
+
+
+def file_sha256(path):
+    with open(path, "rb") as f:
+        return hashlib.sha256(f.read()).hexdigest()
+
+
+def _advertised_skill(row):
+    return {
+        "key": row.get("key"),
+        "title": row.get("title"),
+        "kind": row.get("kind"),
+        "loadPolicy": row.get("loadPolicy"),
+        "sourceHash": row.get("sourceHash"),
+    }
+
+
+def _now():
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")

--- a/framework/core/tests/python/test_skill.py
+++ b/framework/core/tests/python/test_skill.py
@@ -4,11 +4,17 @@ from pathlib import Path
 import json
 
 from kungfu.skill import (
+    append_audit_event,
     build_catalog,
     build_context_envelope,
     build_skill_context,
     inject_skill_context,
     parse_skill,
+    read_audit_file,
+    skill_advertised_event,
+    skill_audit_document,
+    skill_loaded_event,
+    write_audit_document,
 )
 
 
@@ -95,3 +101,51 @@ def test_provider_builds_and_injects_skill_context():
     assert envelope["catalog"][0]["key"] == "minimal"
     assert "Kungfu Skill context envelope" in injected
     assert injected.endswith("\n\nUser task:\nhello")
+
+
+def test_skill_audit_records_advertised_and_loaded_events(tmp_path):
+    skill = parse_skill(_fixture("minimal"))
+    envelope = build_context_envelope(
+        build_catalog([skill]),
+        {"source": "test", "manager": "python", "agent": "codex"},
+    )
+    advertised = skill_advertised_event(
+        envelope,
+        run_id="run-1",
+        provider="codex",
+        context_file="/tmp/context.json",
+    )
+    markdown = Path(skill["source"]["path"]).read_text(encoding="utf-8")
+    loaded = skill_loaded_event(skill, markdown, run_id="run-1")
+    document = skill_audit_document(
+        run_id="run-1",
+        provider="codex",
+        events=[advertised, loaded],
+    )
+    audit_path = tmp_path / "skill-audit.json"
+    digest = write_audit_document(audit_path, document)
+
+    assert digest
+    assert advertised["type"] == "SkillAdvertised"
+    assert advertised["skills"][0]["key"] == "minimal"
+    assert (
+        advertised["advertisedSkillsHash"] == envelope["audit"]["advertisedSkillsHash"]
+    )
+    assert loaded["type"] == "SkillLoaded"
+    assert loaded["skill"]["sourceHash"] == skill["source"]["hash"]
+    assert loaded["skill"]["contentHash"] == skill["source"]["hash"]
+    assert read_audit_file(audit_path)["event_count"] == 2
+
+
+def test_skill_audit_reads_jsonl_events(tmp_path):
+    skill = parse_skill(_fixture("minimal"))
+    markdown = Path(skill["source"]["path"]).read_text(encoding="utf-8")
+    event = skill_loaded_event(skill, markdown, run_id="run-jsonl")
+    audit_path = tmp_path / "skill-audit.jsonl"
+
+    append_audit_event(audit_path, event)
+
+    document = read_audit_file(audit_path)
+    assert document["schema"] == "kungfu.skill-audit/v1"
+    assert document["run_id"] == "run-jsonl"
+    assert document["events"][0]["skill"]["key"] == "minimal"


### PR DESCRIPTION
## Summary
- record `SkillAdvertised` audit sidecars in managed-run bundles and reference them from `manifest.json`
- record `SkillLoaded` events when `kungfu skill read` loads full `SKILL.md` content
- add `kungfu skill audit` to inspect run bundle evidence or standalone audit files

## Validation
- `uv --project framework/core run ruff check framework/core/src/python/kungfu/skill/audit.py framework/core/src/python/kungfu/skill/__init__.py framework/core/src/python/kungfu/cli/commands/skill.py framework/core/src/python/kungfu/rewind/managed_cli.py framework/core/tests/python/test_skill.py`
- `PYTHONPATH=framework/core/src/python uv --project framework/core run pytest framework/core/tests/python/test_skill.py`
- `./kungfu-code build:core`
- `./kungfu-code --filter @kungfu-tech/skill run build`
- `./kungfu-code --filter @kungfu-tech/skill run test:golden`
- `./kungfu-code freeze`
- `./kungfu-code verify`
- frozen `kungfu skill verify --provider codex --manager python --json` + `kungfu skill audit --run-id ...` -> `SkillAdvertised`
- frozen `kungfu skill read ... --audit-file ... --json` + `kungfu skill audit --audit-file ...` -> `SkillLoaded`
- frozen Node-generated GUI context + `kungfu skill verify --skill-context-file ... --manager node --json` + `skill audit --run-id ...` -> `manager=node`, `source=gui`
