### PR TITLE
per-session OS windows behind a flag (ADR-0016 stage 2)

### DIFF
--- a/extensions/terminal/src/view/index.tsx
+++ b/extensions/terminal/src/view/index.tsx
@@ -17,10 +17,12 @@
 // sessions (no durability) and says so per pane. tmux is only a backend — this
 // view speaks "session", never "tmux".
 //
-// Out of scope here (later slices): real OS windows across monitors with saved
-// display bounds (a gui main-process concern), cost/proof badges, and
-// cross-restart layout persistence. This slice delivers in-view concurrency plus
-// detach / discover / reattach against one running app.
+// Popping a session into its own OS window (ADR-0016 stage 2) is offered through
+// the shell: the view stays electron-free and simply asks `shell.popOutSession`,
+// which the node-integrated shell owns; the main process places and persists the
+// window (F7 clamp on restore). Rendering the live terminal *inside* that OS
+// window, rather than the stage-2 placeholder, is the next slice; cost/proof
+// badges are later still.
 //
 // The capability is async at the sandbox boundary (an IPC hop cannot be
 // synchronous); `resolve` awaits both the sync (node-integrated) and Promise
@@ -32,9 +34,10 @@ import { FitAddon } from '@xterm/addon-fit';
 import { Terminal as XTerm } from '@xterm/xterm';
 import React from 'react';
 import {
+  type PersistedWindow,
+  type WorkspaceLayout,
   loadWorkspaceLayout,
   saveWorkspaceLayout,
-  type WorkspaceLayout,
 } from './persistence';
 
 async function resolve<T>(value: T | Promise<T>): Promise<T> {
@@ -158,11 +161,15 @@ function SessionPane({
   pane,
   onDetach,
   onKill,
+  onPopOut,
 }: {
   caps: KfxCapabilities;
   pane: Pane;
   onDetach: (pane: Pane) => void;
   onKill: (pane: Pane) => void;
+  // Present only when the shell can drive OS windows (ADR-0016 stage 2); the
+  // pop-out affordance is hidden otherwise.
+  onPopOut?: () => void;
 }) {
   const hostRef = React.useRef<HTMLDivElement>(null);
   const [status, setStatus] = React.useState<string>('running');
@@ -330,6 +337,16 @@ function SessionPane({
         >
           {status}
         </span>
+        {onPopOut && (
+          <button
+            type="button"
+            onClick={onPopOut}
+            title="Open this session in its own window"
+            style={iconButtonStyle}
+          >
+            Pop out
+          </button>
+        )}
         {!ended && pane.durable && (
           <button
             type="button"
@@ -485,10 +502,21 @@ function RecoverableTray({
   );
 }
 
-function SessionWorkspace({ caps }: { caps: KfxCapabilities; shell: Shell }) {
+function SessionWorkspace({
+  caps,
+  shell,
+}: { caps: KfxCapabilities; shell: Shell }) {
   const [panes, setPanes] = React.useState<Pane[]>([]);
   const [recoverable, setRecoverable] = React.useState<TerminalSession[]>([]);
   const [notice, setNotice] = React.useState<string | null>(null);
+  // The per-session OS window set (ADR-0016 stage 2). Seeded from the persisted
+  // layout, then driven by the main process, which owns the real windows and
+  // pushes a snapshot on every open/close/move; we mirror it back into the
+  // layout. Empty and inert when the shell cannot drive windows (flag off /
+  // sandbox), in which case the persisted windows are preserved untouched.
+  const [windowRecords, setWindowRecords] = React.useState<PersistedWindow[]>(
+    [],
+  );
   // Persistence is gated on the domain capability; absent it the workspace is
   // ephemeral. `hydrated` blocks the save effect until the initial restore has
   // read the stored layout, so mounting never clobbers it with an empty set.
@@ -503,6 +531,7 @@ function SessionWorkspace({ caps }: { caps: KfxCapabilities; shell: Shell }) {
   // Restore on mount (W4): read the persisted layout and re-adopt each durable
   // session by runId. A session still alive on the tmux socket comes back
   // attached; a gone one is dropped (direct sessions cannot survive a restart).
+  // biome-ignore lint/correctness/useExhaustiveDependencies: mount-only restore; caps/domain/shell identity is stable per runtime
   React.useEffect(() => {
     if (!domain) {
       hydrated.current = true;
@@ -511,6 +540,9 @@ function SessionWorkspace({ caps }: { caps: KfxCapabilities; shell: Shell }) {
     // Read synchronously before the save effect can run, so the stored layout
     // is captured even though adoption is async.
     const layout = loadWorkspaceLayout(domain);
+    // Seed the window set so the first persist preserves it; the main process
+    // then becomes the source of truth once it restores and emits a snapshot.
+    setWindowRecords(layout.windows);
     let cancelled = false;
     void (async () => {
       const restored: Pane[] = [];
@@ -546,6 +578,14 @@ function SessionWorkspace({ caps }: { caps: KfxCapabilities; shell: Shell }) {
       }
       if (!cancelled) {
         if (restored.length > 0) setPanes(restored);
+        // Restore only windows whose session actually came back; a window for a
+        // gone session cannot show anything, so it is dropped. The main process
+        // clamps each saved rectangle onto a present display (F7).
+        const liveRunIds = new Set(restored.map((r) => r.runId));
+        const liveWindows = layout.windows.filter((w) =>
+          liveRunIds.has(w.runId),
+        );
+        if (liveWindows.length > 0) shell.restoreSessionWindows?.(liveWindows);
         hydrated.current = true;
         // the pane-set change triggers the tray refresh effect below; no need
         // to call refresh() here (it is declared later)
@@ -554,12 +594,20 @@ function SessionWorkspace({ caps }: { caps: KfxCapabilities; shell: Shell }) {
     return () => {
       cancelled = true;
     };
-    // run once on mount; caps/domain identity is stable for a given runtime
-    // biome-ignore lint/correctness/useExhaustiveDependencies: mount-only restore
+    // run once on mount; caps/domain/shell identity is stable for a given runtime
   }, []);
 
-  // Persist on change (W4): once hydrated, mirror the live pane set into the
-  // config-backed layout so a restart can bring the durable sessions back.
+  // Mirror the main process's live window set into our state so the persist
+  // effect writes it into the layout. Inert when the shell cannot drive windows.
+  React.useEffect(() => {
+    return shell.onSessionWindowsSnapshot?.((windows) =>
+      setWindowRecords(windows),
+    );
+  }, [shell]);
+
+  // Persist on change (W4): once hydrated, mirror the live pane set and the
+  // per-session window set into the config-backed layout so a restart can bring
+  // the durable sessions and their windows back.
   React.useEffect(() => {
     if (!domain || !hydrated.current) return;
     const layout: WorkspaceLayout = {
@@ -576,9 +624,10 @@ function SessionWorkspace({ caps }: { caps: KfxCapabilities; shell: Shell }) {
         startedAt: p.startedAt,
         order: i,
       })),
+      windows: windowRecords,
     };
     saveWorkspaceLayout(domain, layout);
-  }, [panes, domain]);
+  }, [panes, domain, windowRecords]);
 
   const refresh = React.useCallback(async () => {
     try {
@@ -775,6 +824,11 @@ function SessionWorkspace({ caps }: { caps: KfxCapabilities; shell: Shell }) {
               pane={pane}
               onDetach={detachPane}
               onKill={killPane}
+              onPopOut={
+                shell.popOutSession
+                  ? () => shell.popOutSession?.(pane.runId)
+                  : undefined
+              }
             />
           ))}
         </div>

--- a/extensions/terminal/src/view/persistence.ts
+++ b/extensions/terminal/src/view/persistence.ts
@@ -35,14 +35,33 @@ export type PersistedPane = {
   order: number;
 };
 
+// An OS window that shows one session (ADR-0016 stage 2). Window identity is a
+// separate layer from session identity: this record *references* a session by
+// runId — it does not carry terminal state — so the in-shell grid and the OS
+// windows are two views of the same session set, and neither owns the other.
+// `displayId` is the F7 stable display key (see gui window-placement.displayKey)
+// the window was last seen on; on restore the main process clamps the saved
+// rectangle back onto a currently-connected display.
+export type PersistedWindow = {
+  windowId: string;
+  runId: string;
+  displayId: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  lastSeenAt: number;
+};
+
 export type WorkspaceLayout = {
   version: 1;
   workspaceId: string;
   panes: PersistedPane[];
+  windows: PersistedWindow[];
 };
 
 export function emptyLayout(): WorkspaceLayout {
-  return { version: 1, workspaceId: 'default', panes: [] };
+  return { version: 1, workspaceId: 'default', panes: [], windows: [] };
 }
 
 function asStringArray(value: unknown): string[] | undefined {
@@ -69,9 +88,37 @@ function parsePane(value: unknown, index: number): PersistedPane | null {
   };
 }
 
+function parseWindow(value: unknown): PersistedWindow | null {
+  if (typeof value !== 'object' || value === null) return null;
+  const v = value as Record<string, unknown>;
+  if (typeof v.windowId !== 'string' || v.windowId.length === 0) return null;
+  if (typeof v.runId !== 'string' || v.runId.length === 0) return null;
+  if (typeof v.displayId !== 'string' || v.displayId.length === 0) return null;
+  // A window with a non-numeric rectangle cannot be placed, so drop it rather
+  // than restore it at NaN and let the OS decide — same tolerant policy as panes.
+  if (
+    typeof v.x !== 'number' ||
+    typeof v.y !== 'number' ||
+    typeof v.width !== 'number' ||
+    typeof v.height !== 'number'
+  ) {
+    return null;
+  }
+  return {
+    windowId: v.windowId,
+    runId: v.runId,
+    displayId: v.displayId,
+    x: v.x,
+    y: v.y,
+    width: v.width,
+    height: v.height,
+    lastSeenAt: typeof v.lastSeenAt === 'number' ? v.lastSeenAt : 0,
+  };
+}
+
 // Tolerant read (F5): a malformed or partial blob yields an empty layout or
-// drops only the bad panes — it never throws, because the GUI, CLI and agents
-// all read this record and a boot must not hinge on its shape.
+// drops only the bad panes/windows — it never throws, because the GUI, CLI and
+// agents all read this record and a boot must not hinge on its shape.
 export function parseWorkspaceLayout(raw: string): WorkspaceLayout {
   try {
     const obj = JSON.parse(raw) as unknown;
@@ -81,11 +128,16 @@ export function parseWorkspaceLayout(raw: string): WorkspaceLayout {
     const panes = rawPanes
       .map((p, i) => parsePane(p, i))
       .filter((p): p is PersistedPane => p !== null);
+    const rawWindows = Array.isArray(o.windows) ? o.windows : [];
+    const windows = rawWindows
+      .map((w) => parseWindow(w))
+      .filter((w): w is PersistedWindow => w !== null);
     return {
       version: 1,
       workspaceId:
         typeof o.workspaceId === 'string' ? o.workspaceId : 'default',
       panes,
+      windows,
     };
   } catch {
     return emptyLayout();

--- a/framework/core/docs/adr/ADR-0016-managed-session-host-placement.md
+++ b/framework/core/docs/adr/ADR-0016-managed-session-host-placement.md
@@ -152,3 +152,32 @@ in-renderer host, so the working single-window app is untouched and parity is
 preserved by construction, while the main-process path is exercised by flipping
 the flag on a real machine. Promoting it to the default happens only after that
 real-machine parity check passes.
+
+## Implementation note — stage 2 windows are driven through the shell, not a capability
+
+Stage 2 adds the per-session OS window: a session can be popped out of the
+in-shell grid into its own restorable window, placed on the display it was last
+on. Three pieces land together — a `windows[]` layer on the persisted
+`WorkspaceLayout` (a window references a session by runId, so window identity
+stays separate from session identity and a closing window never ends the
+session), a pure `placeWindow` geometry that implements F7 (a saved rectangle is
+clamped into a currently-connected display's work area; a display that is gone
+falls back to the primary, so a stale off-screen origin cannot survive), and a
+main-process window registry that owns the BrowserWindows and pushes a layout
+snapshot back to the shell on every open / close / move.
+
+The view stays electron-free. Rather than teach the terminal view about
+`ipcRenderer` — which would break its "runs identically node-integrated or
+sandboxed" property — pop-out is offered as a **shell service**
+(`shell.popOutSession` / `restoreSessionWindows` / `onSessionWindowsSnapshot`),
+present only on the node-integrated shell that can reach main and absent in a
+sandbox, where popping a session into an OS window has no meaning. This keeps the
+window host out of the ADR-0011 / ADR-0014 capability contract: it is a shell
+concern, not a new capability.
+
+Stage 2 lands **behind a flag** (`KF_SESSION_WINDOWS=1`), default off, so the
+single-window app is untouched and parity holds by construction. The window's
+content is a placeholder in stage 2; mounting the live terminal view against the
+window's runId over the host proxy is stage 3. Promotion and the
+terminal-in-window render happen only after a real-machine check of window
+placement, restore, and the IPC output path.

--- a/framework/gui/src/main/index.ts
+++ b/framework/gui/src/main/index.ts
@@ -32,6 +32,7 @@ import {
   uninstallKungfuCliFromPath,
 } from './installCli';
 import { type Rect, SandboxManager } from './sandbox-manager';
+import { bindSessionWindows } from './session-windows-host';
 import { writeGuiSkillContextFile } from './skill-context';
 import {
   bindElectronTerminalHost,
@@ -153,6 +154,10 @@ function harnessEntry(): string {
 // `activate` (which re-runs createWindow) from double-registering a channel.
 let manager: SandboxManager | null = null;
 
+// The current shell window, tracked so the per-session window host (ADR-0016
+// stage 2) can push layout snapshots back to it for persistence.
+let shellWindow: BrowserWindow | null = null;
+
 ipcMain.handle(ENSURE_CHANNEL, (_event, payload) => {
   const { id, bundlePath, declared } = payload as {
     id: string;
@@ -232,6 +237,7 @@ function createWindow() {
       sandbox: false,
     },
   });
+  shellWindow = win;
 
   // The trusted renderer holds the real capabilities and runs the capability
   // host; this manager embeds sandboxed views and relays their invokes to it.
@@ -262,6 +268,17 @@ app.whenReady().then(() => {
       bindElectronTerminalHost(ipcMain, createMainTerminalHost());
     } catch (e) {
       console.log(`KF_TERMINAL_HOST_MAIN_FAIL ${(e as Error).message}`);
+    }
+  }
+  // ADR-0016 stage 2 (flagged): let a session pop out of the in-shell grid into
+  // its own restorable OS window. The handlers are global, so bind once; the
+  // registry pushes layout snapshots to the current shell window. Default off
+  // keeps the single-window app untouched until this is validated on a machine.
+  if (process.env.KF_SESSION_WINDOWS === '1') {
+    try {
+      bindSessionWindows({ ipcMain, getShellWindow: () => shellWindow });
+    } catch (e) {
+      console.log(`KF_SESSION_WINDOWS_FAIL ${(e as Error).message}`);
     }
   }
   createWindow();

--- a/framework/gui/src/main/index.ts
+++ b/framework/gui/src/main/index.ts
@@ -158,6 +158,10 @@ let manager: SandboxManager | null = null;
 // stage 2) can push layout snapshots back to it for persistence.
 let shellWindow: BrowserWindow | null = null;
 
+// Set once the app is quitting; the session-window host reads it so window
+// closes during shutdown do not overwrite the persisted layout restore needs.
+let appQuitting = false;
+
 ipcMain.handle(ENSURE_CHANNEL, (_event, payload) => {
   const { id, bundlePath, declared } = payload as {
     id: string;
@@ -276,7 +280,11 @@ app.whenReady().then(() => {
   // keeps the single-window app untouched until this is validated on a machine.
   if (process.env.KF_SESSION_WINDOWS === '1') {
     try {
-      bindSessionWindows({ ipcMain, getShellWindow: () => shellWindow });
+      bindSessionWindows({
+        ipcMain,
+        getShellWindow: () => shellWindow,
+        isQuitting: () => appQuitting,
+      });
     } catch (e) {
       console.log(`KF_SESSION_WINDOWS_FAIL ${(e as Error).message}`);
     }
@@ -286,6 +294,12 @@ app.whenReady().then(() => {
 
 app.on('activate', () => {
   if (BrowserWindow.getAllWindows().length === 0) createWindow();
+});
+
+app.on('before-quit', () => {
+  // Freeze the persisted session-window layout: the window closes that follow
+  // are shutdown, not the user dropping windows, so they must not overwrite it.
+  appQuitting = true;
 });
 
 app.on('window-all-closed', () => {

--- a/framework/gui/src/main/session-windows-host.ts
+++ b/framework/gui/src/main/session-windows-host.ts
@@ -1,0 +1,161 @@
+// Electron glue for the per-session OS window registry (ADR-0016 stage 2). The
+// lifecycle logic is electron-free in session-windows; this is the thin shell
+// that supplies real BrowserWindows and `screen` displays and wires the ipcMain
+// channels — the same pure-core / glue split terminal-host uses.
+//
+// Gated by KF_SESSION_WINDOWS (see index.ts): default off keeps the single-window
+// app exactly as it is (parity by construction); the multi-window path is
+// exercised by flipping the flag on a real machine, the discipline ADR-0016
+// stage 1 used for the main-process host.
+import { BrowserWindow, type IpcMain, screen } from 'electron';
+
+import {
+  SESSION_WINDOW_CLOSE_CHANNEL,
+  SESSION_WINDOW_OPEN_CHANNEL,
+  SESSION_WINDOW_RESTORE_CHANNEL,
+  SESSION_WINDOW_SNAPSHOT_CHANNEL,
+} from '../sandbox/channels';
+import {
+  type SessionWindow,
+  type SessionWindowRegistry,
+  createSessionWindowRegistry,
+} from './session-windows';
+import {
+  type DisplayInfo,
+  type Placement,
+  type Rect,
+  displayKey,
+} from './window-placement';
+
+function toDisplayInfo(d: Electron.Display): DisplayInfo {
+  return { id: displayKey(d), workArea: d.workArea };
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(/[<>&"]/g, (c) => {
+    switch (c) {
+      case '<':
+        return '&lt;';
+      case '>':
+        return '&gt;';
+      case '&':
+        return '&amp;';
+      case '"':
+        return '&quot;';
+      default:
+        return c;
+    }
+  });
+}
+
+// A minimal placeholder page (ADR-0016 stage 2). What stage 2 proves is the
+// window lifecycle, bounds, F7 restore and persistence; mounting the real
+// terminal view against this window's runId over the host proxy is stage 3,
+// which swaps this data: URL for a session-window renderer entry.
+function placeholderPage(runId: string, windowId: string): string {
+  const r = escapeHtml(runId);
+  const w = escapeHtml(windowId);
+  return [
+    '<!doctype html><meta charset="utf-8">',
+    `<title>Session ${r}</title>`,
+    '<style>html,body{margin:0;height:100%;background:#1e1e1e;color:#ddd;',
+    'font:14px/1.6 -apple-system,system-ui,sans-serif;display:flex;',
+    'align-items:center;justify-content:center}main{text-align:center}',
+    'code{color:#6cf}small{color:#888}</style>',
+    `<main><div>managed session <code>${r}</code></div>`,
+    '<div><small>ADR-0016 stage 2 — window shell (terminal view lands in stage 3)</small></div>',
+    `<div><small>window ${w}</small></div></main>`,
+  ].join('');
+}
+
+function createSessionWindow(args: {
+  windowId: string;
+  runId: string;
+  bounds: Rect;
+}): SessionWindow {
+  const win = new BrowserWindow({
+    x: args.bounds.x,
+    y: args.bounds.y,
+    width: args.bounds.width,
+    height: args.bounds.height,
+    show: false,
+    backgroundColor: '#1e1e1e',
+    title: `Session ${args.runId}`,
+    webPreferences: {
+      nodeIntegration: false,
+      contextIsolation: true,
+      sandbox: true,
+    },
+  });
+  win.on('ready-to-show', () => win.show());
+  void win.loadURL(
+    `data:text/html;charset=utf-8,${encodeURIComponent(
+      placeholderPage(args.runId, args.windowId),
+    )}`,
+  );
+  return {
+    getBounds: () => win.getBounds(),
+    focus: () => {
+      if (!win.isDestroyed()) win.focus();
+    },
+    close: () => {
+      if (!win.isDestroyed()) win.close();
+    },
+    // end-of-gesture events, so persistence is not written on every drag pixel
+    onBoundsChanged: (cb) => {
+      win.on('moved', cb);
+      win.on('resized', cb);
+    },
+    onClosed: (cb) => win.on('closed', cb),
+  };
+}
+
+// Create the registry backed by Electron and register the ipcMain handlers.
+// Called once, under the flag, after the app is ready (screen needs a ready app).
+export function bindSessionWindows(opts: {
+  ipcMain: IpcMain;
+  getShellWindow: () => BrowserWindow | null;
+}): SessionWindowRegistry {
+  const registry = createSessionWindowRegistry({
+    displays: () => ({
+      list: screen.getAllDisplays().map(toDisplayInfo),
+      primaryId: displayKey(screen.getPrimaryDisplay()),
+    }),
+    displayKeyForBounds: (bounds) =>
+      displayKey(screen.getDisplayMatching(bounds)),
+    createWindow: createSessionWindow,
+    onChange: (snapshot) => {
+      const shell = opts.getShellWindow();
+      if (shell && !shell.isDestroyed()) {
+        shell.webContents.send(SESSION_WINDOW_SNAPSHOT_CHANNEL, { snapshot });
+      }
+    },
+    now: () => Date.now(),
+  });
+
+  // Fresh pop-out from the shell grid; returns where the window actually landed.
+  opts.ipcMain.handle(SESSION_WINDOW_OPEN_CHANNEL, (_e, payload) => {
+    const { windowId, runId } = payload as { windowId: string; runId: string };
+    return registry.open({ windowId, runId });
+  });
+  // Restore the persisted window set on boot; each saved rectangle is clamped
+  // back onto a present display (F7).
+  opts.ipcMain.handle(SESSION_WINDOW_RESTORE_CHANNEL, (_e, payload) => {
+    const { windows } = payload as {
+      windows: Array<{ windowId: string; runId: string; saved: Placement }>;
+    };
+    return windows.map((entry) =>
+      registry.open({
+        windowId: entry.windowId,
+        runId: entry.runId,
+        saved: entry.saved,
+      }),
+    );
+  });
+  opts.ipcMain.on(SESSION_WINDOW_CLOSE_CHANNEL, (_e, payload) => {
+    const { runId } = payload as { runId: string };
+    registry.close(runId);
+  });
+
+  return registry;
+}

--- a/framework/gui/src/main/session-windows-host.ts
+++ b/framework/gui/src/main/session-windows-host.ts
@@ -115,6 +115,9 @@ function createSessionWindow(args: {
 export function bindSessionWindows(opts: {
   ipcMain: IpcMain;
   getShellWindow: () => BrowserWindow | null;
+  // true once the app is quitting: window closes during shutdown must not be
+  // persisted, or they would wipe the set that restore needs (ADR-0016 stage 2).
+  isQuitting?: () => boolean;
 }): SessionWindowRegistry {
   const registry = createSessionWindowRegistry({
     displays: () => ({
@@ -125,6 +128,10 @@ export function bindSessionWindows(opts: {
       displayKey(screen.getDisplayMatching(bounds)),
     createWindow: createSessionWindow,
     onChange: (snapshot) => {
+      // On app quit every window closes, which would emit an empty snapshot and
+      // overwrite the persisted set; skip persistence during shutdown so the
+      // last live layout survives for restore.
+      if (opts.isQuitting?.()) return;
       const shell = opts.getShellWindow();
       if (shell && !shell.isDestroyed()) {
         shell.webContents.send(SESSION_WINDOW_SNAPSHOT_CHANNEL, { snapshot });

--- a/framework/gui/src/main/session-windows.ts
+++ b/framework/gui/src/main/session-windows.ts
@@ -1,0 +1,197 @@
+// Per-session OS window registry (ADR-0016 stage 2). One session can be popped
+// out of the in-shell grid into its own restorable OS window, placed on the
+// display the user left it on. This module owns the *lifecycle* — which session
+// has a window, where it sits, and cleanup on close — but stays electron-free:
+// index.ts supplies the Electron BrowserWindow + screen implementation of the
+// deps below. The same pure-core / thin-glue split terminal-host uses; the only
+// non-trivial geometry (F7 clamp) already lives in window-placement.
+//
+// Window identity is a layer above session identity: a record references a
+// session by runId and never holds terminal state, so a window closing does not
+// end the session (the durable host outlives it) — it just drops the view.
+import {
+  type DisplayInfo,
+  type Placement,
+  type Rect,
+  centeredBounds,
+  placeWindow,
+} from './window-placement';
+
+// Default size for a fresh pop-out (no saved placement); centered on the
+// primary display's work area.
+const DEFAULT_WINDOW_WIDTH = 900;
+const DEFAULT_WINDOW_HEIGHT = 680;
+
+// The OS window this registry drives. index.ts implements it over a
+// BrowserWindow; onBoundsChanged must be wired to end-of-gesture events
+// ('moved' / 'resized'), not the continuous ones, so persistence is not chatty.
+export type SessionWindow = {
+  getBounds(): Rect;
+  focus(): void;
+  close(): void;
+  onBoundsChanged(cb: () => void): void;
+  onClosed(cb: () => void): void;
+};
+
+// A window row as persisted into WorkspaceLayout.windows[] (structurally the
+// terminal extension's PersistedWindow; it crosses IPC as plain JSON, so the
+// renderer maps it there — no cross-package import from a main-process module).
+export type SessionWindowSnapshot = {
+  windowId: string;
+  runId: string;
+  displayId: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  lastSeenAt: number;
+};
+
+export type SessionWindowDeps = {
+  // currently-connected displays plus the primary's stable key (F7 input)
+  displays: () => { list: DisplayInfo[]; primaryId: string };
+  // the stable display key for whichever display a rectangle now sits on,
+  // used to refresh a record after the user drags it to another monitor
+  displayKeyForBounds: (bounds: Rect) => string;
+  // create an OS window at bounds showing runId (glue: a BrowserWindow)
+  createWindow: (args: {
+    windowId: string;
+    runId: string;
+    bounds: Rect;
+  }) => SessionWindow;
+  // persist hook, called on every open-set or bounds change with the full set
+  onChange: (snapshot: SessionWindowSnapshot[]) => void;
+  // clock for lastSeenAt, a dep so the core stays deterministic
+  now: () => number;
+};
+
+export type OpenSpec = {
+  windowId: string;
+  runId: string;
+  // saved placement when restoring; omit for a fresh pop-out
+  saved?: Placement;
+};
+
+type WindowRecord = {
+  windowId: string;
+  runId: string;
+  displayId: string;
+  window: SessionWindow;
+};
+
+export type SessionWindowRegistry = {
+  open: (spec: OpenSpec) => Placement;
+  close: (runId: string) => void;
+  has: (runId: string) => boolean;
+  snapshot: () => SessionWindowSnapshot[];
+  closeAll: () => void;
+};
+
+export function createSessionWindowRegistry(
+  deps: SessionWindowDeps,
+): SessionWindowRegistry {
+  const byRun = new Map<string, WindowRecord>();
+
+  function snapshot(): SessionWindowSnapshot[] {
+    const now = deps.now();
+    return [...byRun.values()].map((r) => {
+      const b = r.window.getBounds();
+      return {
+        windowId: r.windowId,
+        runId: r.runId,
+        displayId: r.displayId,
+        x: b.x,
+        y: b.y,
+        width: b.width,
+        height: b.height,
+        lastSeenAt: now,
+      };
+    });
+  }
+
+  function emitChange(): void {
+    deps.onChange(snapshot());
+  }
+
+  function freshPlacement(list: DisplayInfo[], primaryId: string): Placement {
+    const primary = list.find((d) => d.id === primaryId) ?? list[0];
+    if (!primary)
+      return {
+        displayId: '',
+        bounds: {
+          x: 0,
+          y: 0,
+          width: DEFAULT_WINDOW_WIDTH,
+          height: DEFAULT_WINDOW_HEIGHT,
+        },
+      };
+    return {
+      displayId: primary.id,
+      bounds: centeredBounds(
+        primary.workArea,
+        DEFAULT_WINDOW_WIDTH,
+        DEFAULT_WINDOW_HEIGHT,
+      ),
+    };
+  }
+
+  function open(spec: OpenSpec): Placement {
+    // One window per session: a second open just focuses the existing one.
+    const existing = byRun.get(spec.runId);
+    if (existing) {
+      existing.window.focus();
+      return {
+        displayId: existing.displayId,
+        bounds: existing.window.getBounds(),
+      };
+    }
+
+    const { list, primaryId } = deps.displays();
+    // Restore clamps the saved rectangle onto a present display (F7); a fresh
+    // pop-out centers a default size on the primary.
+    const placement = spec.saved
+      ? placeWindow(spec.saved, list, primaryId)
+      : freshPlacement(list, primaryId);
+
+    const window = deps.createWindow({
+      windowId: spec.windowId,
+      runId: spec.runId,
+      bounds: placement.bounds,
+    });
+    const rec: WindowRecord = {
+      windowId: spec.windowId,
+      runId: spec.runId,
+      displayId: placement.displayId,
+      window,
+    };
+    byRun.set(spec.runId, rec);
+
+    window.onBoundsChanged(() => {
+      // The window may have crossed to another monitor; refresh its display key.
+      rec.displayId = deps.displayKeyForBounds(window.getBounds());
+      emitChange();
+    });
+    window.onClosed(() => {
+      byRun.delete(spec.runId);
+      emitChange();
+    });
+
+    emitChange();
+    return placement;
+  }
+
+  function close(runId: string): void {
+    // cleanup + emitChange run in the onClosed handler
+    byRun.get(runId)?.window.close();
+  }
+
+  return {
+    open,
+    close,
+    has: (runId) => byRun.has(runId),
+    snapshot,
+    closeAll: () => {
+      for (const rec of [...byRun.values()]) rec.window.close();
+    },
+  };
+}

--- a/framework/gui/src/main/window-placement.ts
+++ b/framework/gui/src/main/window-placement.ts
@@ -1,0 +1,105 @@
+// Window placement for per-session OS windows (ADR-0016 stage 2, F7). Pure
+// geometry: it decides which currently-visible display a saved window belongs
+// on and clamps its rectangle into that display's usable area. No electron
+// import — the caller (session-windows) turns Electron `screen` displays into
+// the abstract DisplayInfo below and applies the result — so this stays a
+// contract-testable pure module, the same split terminal-host uses.
+//
+// F7 in one sentence: a window whose saved display is gone falls back to the
+// primary, and an off-screen window is pulled back onto a visible display —
+// realized here because we always resolve a present target display and then
+// clamp the saved bounds into its work area, so a stale off-screen origin can
+// never survive.
+
+export type Rect = { x: number; y: number; width: number; height: number };
+
+// A display as this module needs it: a stable identity plus the usable area
+// (Electron's workArea excludes the menu bar / dock, so a restored window never
+// lands under them). The caller derives `id` with displayKey below.
+export type DisplayInfo = { id: string; workArea: Rect };
+
+// A stable display identifier (F7). Electron's numeric Display.id is not stable
+// across reconnects/reboots, so we prefer the human label (e.g. "Built-in Retina
+// Display") and fall back to the physical bounds signature, which stays the same
+// for the same monitor at the same resolution/position. The numeric id is the
+// last resort so the key is always non-empty. Kept pure (takes only the fields
+// it reads) so both the glue and any check can call it.
+export function displayKey(display: {
+  label?: string;
+  id?: number;
+  bounds: Rect;
+}): string {
+  const label = display.label?.trim();
+  if (label) return `label:${label}`;
+  const b = display.bounds;
+  return `bounds:${b.x},${b.y},${b.width},${b.height}`;
+}
+
+function clampRange(value: number, min: number, max: number): number {
+  // max can fall below min when the window is wider/taller than the work area;
+  // in that case we already shrank the size to fit, so min wins (top-left align).
+  if (max < min) return min;
+  if (value < min) return min;
+  if (value > max) return max;
+  return value;
+}
+
+// Shrink to fit, then move fully inside: a window larger than the work area is
+// capped to it, and its origin is pulled in so the whole rectangle is visible.
+export function clampToWorkArea(bounds: Rect, workArea: Rect): Rect {
+  const width = Math.min(bounds.width, workArea.width);
+  const height = Math.min(bounds.height, workArea.height);
+  const x = clampRange(
+    bounds.x,
+    workArea.x,
+    workArea.x + workArea.width - width,
+  );
+  const y = clampRange(
+    bounds.y,
+    workArea.y,
+    workArea.y + workArea.height - height,
+  );
+  return { x, y, width, height };
+}
+
+// Center a default-sized rectangle in a work area, for a brand-new pop-out
+// window that has no saved placement. Shrinks to fit a small work area.
+export function centeredBounds(
+  workArea: Rect,
+  width: number,
+  height: number,
+): Rect {
+  const w = Math.min(width, workArea.width);
+  const h = Math.min(height, workArea.height);
+  return {
+    x: Math.round(workArea.x + (workArea.width - w) / 2),
+    y: Math.round(workArea.y + (workArea.height - h) / 2),
+    width: w,
+    height: h,
+  };
+}
+
+export type Placement = { displayId: string; bounds: Rect };
+
+// Place a saved window onto a currently-connected display (F7):
+//   - saved display present  → clamp the saved bounds into its work area;
+//   - saved display gone      → fall back to the primary, clamp into it;
+//   - no displays at all      → return the saved placement unchanged (headless;
+//                               a real machine always has at least one display).
+// The returned displayId is the display the window actually landed on, so the
+// caller persists the resolved identity, not the stale saved one.
+export function placeWindow(
+  saved: Placement,
+  displays: DisplayInfo[],
+  primaryId: string,
+): Placement {
+  if (displays.length === 0) return saved;
+  const target =
+    displays.find((d) => d.id === saved.displayId) ??
+    displays.find((d) => d.id === primaryId) ??
+    displays[0];
+  return {
+    displayId: target.id,
+    bounds: clampToWorkArea(saved.bounds, target.workArea),
+  };
+}

--- a/framework/gui/src/renderer/src/main.tsx
+++ b/framework/gui/src/renderer/src/main.tsx
@@ -12,6 +12,7 @@ import * as capability from '@kungfu-tech/api/capability';
 import type {
   KfxCapabilities,
   KfxEntry,
+  SessionWindowRecord,
   Shell,
   ShellState,
 } from '@kungfu-tech/kfx';
@@ -20,6 +21,11 @@ import React from 'react';
 import * as ReactDOM from 'react-dom';
 import { createRoot } from 'react-dom/client';
 import * as jsxRuntime from 'react/jsx-runtime';
+import {
+  SESSION_WINDOW_OPEN_CHANNEL,
+  SESSION_WINDOW_RESTORE_CHANNEL,
+  SESSION_WINDOW_SNAPSHOT_CHANNEL,
+} from '../../sandbox/channels';
 import { type KfxLoadResult, loadKfx } from './kfx-loader';
 import { type Runtime, bootRuntime } from './runtime';
 import { sandboxClient } from './sandbox-client';
@@ -228,6 +234,64 @@ function App() {
   );
   const activeKfx = enabled.find((k) => k.id === active) ?? enabled[0] ?? null;
 
+  // ADR-0016 stage 2: expose per-session OS window control to views through the
+  // shell so a view stays electron-free. Present only when the flag is on and
+  // this (node-integrated) renderer can reach ipc; absent otherwise, so a view
+  // feature-detects and hides the affordance. Built once — the ipc handle and
+  // flag are stable over the shell's life.
+  const sessionWindowShell = React.useMemo<Partial<Shell>>(() => {
+    if (window.process?.env?.KF_SESSION_WINDOWS !== '1') return {};
+    type SessionWindowIpc = {
+      invoke: (channel: string, payload: unknown) => Promise<unknown>;
+      on: (
+        channel: string,
+        listener: (event: unknown, payload: unknown) => void,
+      ) => void;
+      removeListener: (
+        channel: string,
+        listener: (event: unknown, payload: unknown) => void,
+      ) => void;
+    };
+    let ipc: SessionWindowIpc | null = null;
+    try {
+      ipc = (window.require('electron') as { ipcRenderer: SessionWindowIpc })
+        .ipcRenderer;
+    } catch {
+      ipc = null;
+    }
+    if (!ipc) return {};
+    const ipcRenderer = ipc;
+    return {
+      popOutSession: (runId) => {
+        const windowId = globalThis.crypto?.randomUUID?.() ?? `w-${runId}`;
+        void ipcRenderer.invoke(SESSION_WINDOW_OPEN_CHANNEL, {
+          windowId,
+          runId,
+        });
+      },
+      restoreSessionWindows: (windows) => {
+        if (windows.length === 0) return;
+        void ipcRenderer.invoke(SESSION_WINDOW_RESTORE_CHANNEL, {
+          windows: windows.map((w) => ({
+            windowId: w.windowId,
+            runId: w.runId,
+            saved: {
+              displayId: w.displayId,
+              bounds: { x: w.x, y: w.y, width: w.width, height: w.height },
+            },
+          })),
+        });
+      },
+      onSessionWindowsSnapshot: (fn) => {
+        const handler = (_event: unknown, payload: unknown) =>
+          fn((payload as { snapshot: SessionWindowRecord[] }).snapshot);
+        ipcRenderer.on(SESSION_WINDOW_SNAPSHOT_CHANNEL, handler);
+        return () =>
+          ipcRenderer.removeListener(SESSION_WINDOW_SNAPSHOT_CHANNEL, handler);
+      },
+    };
+  }, []);
+
   const shell: Shell = {
     open: (kfxId, nextParams) => {
       setParams(nextParams ?? {});
@@ -253,6 +317,7 @@ function App() {
     registry: loaded.entries,
     suites: loaded.suites,
     profiles: PROFILES,
+    ...sessionWindowShell,
   };
 
   const navButton = (id: string, title: string) => (

--- a/framework/gui/src/sandbox/channels.ts
+++ b/framework/gui/src/sandbox/channels.ts
@@ -21,3 +21,14 @@ export const TERMINAL_CALL_CHANNEL = 'kf-terminal:call';
 export const TERMINAL_SUBSCRIBE_CHANNEL = 'kf-terminal:subscribe';
 export const TERMINAL_UNSUBSCRIBE_CHANNEL = 'kf-terminal:unsubscribe';
 export const TERMINAL_EVENT_CHANNEL = 'kf-terminal:event';
+
+// shell renderer <-> main: per-session OS window lifecycle (ADR-0016 stage 2).
+// The shell asks main to pop a session out into its own window or to restore
+// the saved set; main pushes a snapshot back on every open-set/bounds change so
+// the shell persists WorkspaceLayout.windows[]. OS window bounds live in main
+// (only it owns the BrowserWindow), but the durable record stays a renderer
+// config fact, so the two exchange it over these channels.
+export const SESSION_WINDOW_OPEN_CHANNEL = 'kf-session-window:open';
+export const SESSION_WINDOW_RESTORE_CHANNEL = 'kf-session-window:restore';
+export const SESSION_WINDOW_CLOSE_CHANNEL = 'kf-session-window:close';
+export const SESSION_WINDOW_SNAPSHOT_CHANNEL = 'kf-session-window:snapshot';

--- a/framework/kfx/src/index.ts
+++ b/framework/kfx/src/index.ts
@@ -188,6 +188,22 @@ export type KfxEntry = {
   View: KfxViewComponent;
 };
 
+// One per-session OS window as it crosses the shell boundary (ADR-0016 stage 2).
+// Structurally the terminal extension's PersistedWindow, defined here so the
+// shell contract does not import an extension. Window identity is separate from
+// session identity: this references a session by runId, it does not carry
+// terminal state.
+export type SessionWindowRecord = {
+  windowId: string;
+  runId: string;
+  displayId: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  lastSeenAt: number;
+};
+
 export type Shell = {
   // cross-kfx navigation with parameters; params reach the target view
   open: (kfxId: string, params?: Record<string, string>) => void;
@@ -208,6 +224,19 @@ export type Shell = {
   suites: Record<string, KfxSuiteDecl>;
   // available profiles (shell-defined; a profile selects kfx + first screen)
   profiles: ProfileManifest[];
+  // Per-session OS windows (ADR-0016 stage 2). Present only when the shell can
+  // drive main-process windows — the node-integrated gui with KF_SESSION_WINDOWS
+  // on — and absent in a sandbox, where popping a session into its own OS window
+  // has no meaning. A view feature-detects and hides the affordance when absent,
+  // so it stays electron-free: it asks the shell, which owns the ipc.
+  //   popOutSession        pop a session into its own restorable OS window
+  //   restoreSessionWindows re-open the persisted window set on boot (F7 clamp)
+  //   onSessionWindowsSnapshot subscribe to the live window set for persistence
+  popOutSession?: (runId: string) => void;
+  restoreSessionWindows?: (windows: SessionWindowRecord[]) => void;
+  onSessionWindowsSnapshot?: (
+    fn: (windows: SessionWindowRecord[]) => void,
+  ) => () => void;
 };
 
 export type KfxViewProps = { caps: KfxCapabilities; shell: Shell };


### PR DESCRIPTION
Add the per-session OS window (ADR-0016 stage 2): pop a managed session out of the in-shell grid into its own restorable window, placed on the display it was last on. Pure F7 placement + a main-process window registry + a windows[] layer on WorkspaceLayout; pop-out is a shell service so the view stays electron-free. Behind KF_SESSION_WINDOWS (default off); window content is a stage-2 placeholder. Includes a fix so app quit does not wipe the persisted layout. Validated on a real machine (pop out / cross-display move / quit / restore with clamp).