### PR TITLE
feat(skill): bind kfx dependencies

### DIFF
--- a/docs/skills.md
+++ b/docs/skills.md
@@ -120,8 +120,9 @@ should not be inferred from prose alone.
 A skill can contain or reference multiple kfx packages, but kfx remains
 deduplicated and governed independently:
 
-- Installing a skill installs missing kfx dependencies into the normal kfx
-  registry by `kungfuConfig.key`; the same kfx package is not copied per skill.
+- Installing a skill writes a skill-to-kfx binding document under the Kungfu
+  home. kfx packages are resolved from the normal kfx registry by
+  `kungfuConfig.key`; the same kfx package is not copied per skill.
 - Removing a skill removes the skill binding. It does not remove shared kfx
   dependencies unless an explicit orphan-cleanup command proves they are unused.
 - A kfx package does not gain more authority because a skill referenced it.
@@ -268,21 +269,25 @@ kungfu skill catalog [--path <dir>] [--json]
 kungfu skill context [--path <dir>] [--source cli|gui|test] [--manager python|node]
 kungfu skill verify --provider <claude|codex> --path <dir> [--manager python|node]
 kungfu skill read <key-or-path> [--path <dir>]
+kungfu skill deps <key-or-path> [--path <dir>] [--json]
 kungfu skill audit --run-id <id>
 kungfu skill explain <key-or-path>
 ```
 
 `kungfu skill install` installs the skill source into the Kungfu home skill
-directory, but it does not elevate runtime privileges or install executable kfx
-dependencies in the first slice. `catalog` is the compact agent-visible catalog
-before full skill loading. `context` wraps that catalog in the same envelope
-shape used by Python and Node manage modes. `verify` runs a real provider
-through `managed-run`, asks it to echo the advertised schema, first skill key,
-and `advertisedSkillsHash`, then checks the Rewind `response.json` evidence.
-Use `--manager node` to build the envelope through the Node manager path used
-by the Electron GUI. `read` is the operation the agent tool uses to load the
-full `SKILL.md` after selection. `audit` reads the Skill audit sidecar from a
-managed-run bundle or a standalone audit file.
+directory, writes a kfx dependency binding under `<home>/skill-bindings/`, and
+skips any embedded `kfx/` payload directory so kfx package bodies do not get
+duplicated under each skill. Dependency rows are `resolved` when a matching
+package already exists in `<home>/extensions/<kfx-key>` and `unresolved`
+otherwise. `catalog` is the compact agent-visible catalog before full skill
+loading. `context` wraps that catalog in the same envelope shape used by Python
+and Node manage modes. `deps` prints the binding/resolution state. `verify`
+runs a real provider through `managed-run`, asks it to echo the advertised
+schema, first skill key, and `advertisedSkillsHash`, then checks the Rewind
+`response.json` evidence. Use `--manager node` to build the envelope through
+the Node manager path used by the Electron GUI. `read` is the operation the
+agent tool uses to load the full `SKILL.md` after selection. `audit` reads the
+Skill audit sidecar from a managed-run bundle or a standalone audit file.
 
 The SDK may add:
 
@@ -340,6 +345,9 @@ The first audit slice records:
 - `SkillLoaded` when `kungfu skill read` loads full `SKILL.md` content. This
   records the selected skill key, source hash, content hash, source path, source,
   manager, and optional run id.
+- `SkillDependenciesBound` when `kungfu skill install` writes the kfx dependency
+  binding document. This records the skill key, dependency keys, registry paths,
+  and resolved/unresolved counts without copying kfx package bodies per skill.
 - `kungfu skill audit --run-id <id>` to inspect bundle evidence, plus
   `--audit-file` for standalone JSON/JSONL audit files.
 
@@ -357,12 +365,14 @@ The first slice proves the context loop before broad execution:
 7. Verify Python and Node manager envelopes through `managed-run` response
    evidence.
 8. Scaffold a minimal skill with only `SKILL.md` through the developer SDK.
+9. Bind declared kfx dependencies through `<home>/skill-bindings/<skill>.json`
+   while resolving package bodies only from `<home>/extensions/<kfx-key>`.
 
 Follow-up slices should:
 
-1. Bind declared kfx dependencies through the normal kfx registry without
-   copying them per skill.
-2. Display installed skills in a first-party `skill-manager` view.
+1. Display installed skills in a first-party `skill-manager` view.
+2. Add explicit kfx artifact acquisition for unresolved dependencies, still
+   installing artifacts into the shared kfx registry rather than under a skill.
 
 Out of scope for the first slice:
 
@@ -390,6 +400,6 @@ The first implementation slice is verified by:
 
 Follow-up verification should add:
 
-- kfx dependency installation through the shared registry, with deduplication;
+- kfx dependency binding through the shared registry, with deduplication;
 - a third-party adapter dependency proving that skill composition does not bypass
   the existing runtime trust refusal.

--- a/framework/core/src/python/kungfu/cli/commands/skill.py
+++ b/framework/core/src/python/kungfu/cli/commands/skill.py
@@ -16,6 +16,7 @@ from kungfu.rewind.managed_run import managed_providers
 from kungfu.skill import (
     SkillError,
     append_audit_event,
+    build_skill_dependency_binding,
     build_catalog,
     build_context_envelope,
     build_skill_context,
@@ -26,7 +27,9 @@ from kungfu.skill import (
     parse_skill,
     read_audit_file,
     read_skill_markdown,
+    skill_dependencies_bound_event,
     skill_loaded_event,
+    write_skill_dependency_binding,
 )
 
 skill_command_context = kfc.pass_context()
@@ -109,6 +112,13 @@ def _default_skill_audit_log(ctx):
     return os.path.join(ctx.runtime_dir, "skill-audit.jsonl")
 
 
+def _copy_skill_source(source, dest):
+    def ignore_kfx_payloads(path, names):
+        return {"kfx"} if path == os.path.abspath(source) and "kfx" in names else set()
+
+    shutil.copytree(source, dest, ignore=ignore_kfx_payloads)
+
+
 def _bundle_audit_path(ctx, run_id, bundle_dir=None, audit_file=None):
     if audit_file:
         return audit_file
@@ -176,8 +186,9 @@ def validate(ctx, path, as_json):
 @skill.command(help="install a Kungfu Skill source directory into this home")
 @click.argument("source", type=click.Path(exists=True))
 @click.option("--force", is_flag=True, help="replace an existing skill install")
+@click.option("--json", "as_json", is_flag=True, help="machine-readable output")
 @skill_command_context
-def install(ctx, source, force):
+def install(ctx, source, force, as_json):
     try:
         parsed = parse_skill(source)
     except SkillError as e:
@@ -195,8 +206,31 @@ def install(ctx, source, force):
             sys.exit(1)
         shutil.rmtree(dest)
     os.makedirs(root, exist_ok=True)
-    shutil.copytree(source, dest)
-    click.echo(f"[skill] installed {parsed['key']} -> {dest}")
+    _copy_skill_source(os.path.abspath(source), dest)
+    installed = parse_skill(dest)
+    binding_path, binding = write_skill_dependency_binding(ctx.home, installed)
+    append_audit_event(
+        _default_skill_audit_log(ctx),
+        skill_dependencies_bound_event(binding, source="cli", manager="python"),
+    )
+    result = {
+        "skill": installed,
+        "install_path": dest,
+        "binding_path": binding_path,
+        "dependencies": binding,
+    }
+    if as_json:
+        _json(result)
+        return
+    click.echo(f"[skill] installed {installed['key']} -> {dest}")
+    if os.path.exists(os.path.join(os.path.abspath(source), "kfx")):
+        click.echo("[skill] skipped bundled kfx/ payloads; dependencies bind by key")
+    summary = binding["summary"]
+    click.echo(
+        "[skill] kfx bindings "
+        f"{summary['total']} total, {summary['resolved']} resolved, "
+        f"{summary['unresolved']} unresolved -> {binding_path}"
+    )
 
 
 @skill.command(name="list", help="list installed or path-provided Kungfu Skills")
@@ -474,8 +508,54 @@ def audit(ctx, run_id, bundle_dir, audit_file, as_json):
                 f"skill={skill_data.get('key')} "
                 f"hash={skill_data.get('contentHash')}"
             )
+        elif event.get("type") == "SkillDependenciesBound":
+            skill_data = event.get("skill", {})
+            summary = event.get("summary", {})
+            click.echo(
+                "SkillDependenciesBound "
+                f"skill={skill_data.get('key')} "
+                f"total={summary.get('total', 0)} "
+                f"resolved={summary.get('resolved', 0)} "
+                f"unresolved={summary.get('unresolved', 0)}"
+            )
         else:
             click.echo(f"{event.get('type') or 'SkillAuditEvent'} {event}")
+
+
+@skill.command(help="inspect declared kfx dependencies and registry bindings")
+@click.argument("key_or_path", type=str)
+@click.option("--path", "paths", multiple=True, type=click.Path(exists=True))
+@click.option("--json", "as_json", is_flag=True, help="machine-readable output")
+@skill_command_context
+def deps(ctx, key_or_path, paths, as_json):
+    try:
+        parsed = find_skill(ctx.home, key_or_path, _extra_paths(paths))
+    except SkillError as e:
+        click.echo(f"[skill] {e}", err=True)
+        sys.exit(1)
+    binding = build_skill_dependency_binding(ctx.home, parsed)
+    if as_json:
+        _json(binding)
+        return
+    summary = binding["summary"]
+    click.echo(
+        f"{parsed['key']} kfx dependencies: "
+        f"{summary['total']} total, {summary['resolved']} resolved, "
+        f"{summary['unresolved']} unresolved"
+    )
+    if not binding["dependencies"]:
+        return
+    for row in binding["dependencies"]:
+        package = row.get("package") or {}
+        label = (
+            f"{package.get('name')}@{package.get('version')}"
+            if package
+            else row.get("reason")
+        )
+        click.echo(
+            f"{row['status']}  {row['kfxKey']}  "
+            f"role={row.get('role') or '-'}  {label}  {row['registryPath']}"
+        )
 
 
 @skill.command(help="explain a Kungfu Skill without granting runtime privileges")
@@ -498,6 +578,7 @@ def explain(ctx, key_or_path, paths, as_json):
         if parsed["kind"] == "instruction-only"
         else "requested-via-kfx-trust-gate",
         "kfx": parsed["kfx"],
+        "dependencies": build_skill_dependency_binding(ctx.home, parsed),
         "capabilities": parsed["capabilities"],
         "trustBoundary": (
             "Skill instructions do not elevate permissions. Any executable "

--- a/framework/core/src/python/kungfu/skill/__init__.py
+++ b/framework/core/src/python/kungfu/skill/__init__.py
@@ -2,11 +2,19 @@
 
 from .catalog import build_catalog, catalog_entry
 from .context import build_context_envelope
+from .dependencies import (
+    build_skill_dependency_binding,
+    read_skill_dependency_binding,
+    skill_binding_path,
+    skill_binding_root,
+    write_skill_dependency_binding,
+)
 from .audit import (
     append_audit_event,
     read_audit_file,
     skill_advertised_event,
     skill_audit_document,
+    skill_dependencies_bound_event,
     skill_loaded_event,
     write_audit_document,
 )
@@ -26,6 +34,7 @@ __all__ = [
     "append_audit_event",
     "build_catalog",
     "build_context_envelope",
+    "build_skill_dependency_binding",
     "build_skill_context",
     "catalog_entry",
     "context_file_from_env",
@@ -37,10 +46,15 @@ __all__ = [
     "load_skill_context_file",
     "parse_skill",
     "read_audit_file",
+    "read_skill_dependency_binding",
     "read_skill_markdown",
+    "skill_binding_path",
+    "skill_binding_root",
     "skill_advertised_event",
     "skill_audit_document",
+    "skill_dependencies_bound_event",
     "skill_loaded_event",
     "skill_roots",
     "write_audit_document",
+    "write_skill_dependency_binding",
 ]

--- a/framework/core/src/python/kungfu/skill/audit.py
+++ b/framework/core/src/python/kungfu/skill/audit.py
@@ -68,6 +68,37 @@ def skill_loaded_event(
     }
 
 
+def skill_dependencies_bound_event(
+    binding,
+    *,
+    source="cli",
+    manager="python",
+    agent=None,
+):
+    return {
+        "schema": AUDIT_EVENT_SCHEMA,
+        "type": "SkillDependenciesBound",
+        "at": _now(),
+        "source": source,
+        "manager": manager,
+        "agent": agent,
+        "skill": dict(binding.get("skill") or {}),
+        "summary": dict(binding.get("summary") or {}),
+        "dependencies": [
+            {
+                "kfxKey": row.get("kfxKey"),
+                "role": row.get("role"),
+                "required": row.get("required"),
+                "status": row.get("status"),
+                "registryKey": row.get("registryKey"),
+                "registryPath": row.get("registryPath"),
+                "reason": row.get("reason"),
+            }
+            for row in binding.get("dependencies", [])
+        ],
+    }
+
+
 def skill_audit_document(*, run_id=None, provider=None, work_id=None, events=None):
     rows = list(events or [])
     return {
@@ -101,8 +132,11 @@ def read_audit_file(path):
     if not text:
         return skill_audit_document(events=[])
     if text.startswith("{"):
-        parsed = json.loads(text)
-        if parsed.get("schema") == AUDIT_SCHEMA:
+        try:
+            parsed = json.loads(text)
+        except json.JSONDecodeError:
+            parsed = None
+        if isinstance(parsed, dict) and parsed.get("schema") == AUDIT_SCHEMA:
             return parsed
     events = [json.loads(line) for line in text.splitlines() if line.strip()]
     run_id = events[-1].get("run_id") if events else None

--- a/framework/core/src/python/kungfu/skill/dependencies.py
+++ b/framework/core/src/python/kungfu/skill/dependencies.py
@@ -1,0 +1,128 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import os
+
+
+DEPENDENCY_SCHEMA = "kungfu.skill-dependencies/v1"
+
+
+def skill_binding_root(home):
+    return os.path.join(home, "skill-bindings")
+
+
+def skill_binding_path(home, skill_key):
+    return os.path.join(skill_binding_root(home), f"{skill_key}.json")
+
+
+def build_skill_dependency_binding(home, skill):
+    rows = [_dependency_row(home, skill, dep) for dep in skill.get("kfx", [])]
+    resolved = sum(1 for row in rows if row["status"] == "resolved")
+    return {
+        "schema": DEPENDENCY_SCHEMA,
+        "skill": {
+            "key": skill["key"],
+            "title": skill["title"],
+            "kind": skill["kind"],
+            "sourceHash": skill["source"]["hash"],
+            "sourcePath": skill["source"]["path"],
+        },
+        "registry": {
+            "type": "kfx",
+            "root": _kfx_registry_root(home),
+        },
+        "dependencies": rows,
+        "summary": {
+            "total": len(rows),
+            "resolved": resolved,
+            "unresolved": len(rows) - resolved,
+        },
+    }
+
+
+def write_skill_dependency_binding(home, skill):
+    document = build_skill_dependency_binding(home, skill)
+    path = skill_binding_path(home, skill["key"])
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(document, f, ensure_ascii=False, indent=2, sort_keys=True)
+        f.write("\n")
+    return path, document
+
+
+def read_skill_dependency_binding(home, skill_key):
+    path = skill_binding_path(home, skill_key)
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _dependency_row(home, skill, dep):
+    key = str(dep["key"])
+    package_dir = os.path.join(_kfx_registry_root(home), key)
+    resolved = _resolve_kfx_package(package_dir, key)
+    version = dep.get("version")
+    if version is not None:
+        version = str(version)
+    status = "resolved" if resolved else "unresolved"
+    reason = None
+    if resolved and version and resolved.get("version") != version:
+        status = "unresolved"
+        reason = f"installed version {resolved.get('version')} does not match {version}"
+    elif not resolved:
+        reason = "not installed in kfx registry"
+    row = {
+        "skillKey": skill["key"],
+        "kfxKey": key,
+        "role": dep.get("role"),
+        "version": version,
+        "required": _bool(dep.get("required"), True),
+        "status": status,
+        "registryKey": key,
+        "registryPath": package_dir,
+    }
+    for extra_key, extra_value in sorted(dep.items()):
+        if extra_key not in {"key", "role", "version", "required"}:
+            row[extra_key] = extra_value
+    if resolved:
+        row["package"] = resolved
+    if reason:
+        row["reason"] = reason
+    return row
+
+
+def _resolve_kfx_package(package_dir, expected_key):
+    manifest_path = os.path.join(package_dir, "package.json")
+    if not os.path.isfile(manifest_path):
+        return None
+    try:
+        with open(manifest_path, encoding="utf-8") as f:
+            manifest = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return None
+    config = manifest.get("kungfuConfig") or {}
+    key = config.get("key") or os.path.basename(package_dir)
+    if key != expected_key:
+        return None
+    facets = sorted((config.get("config") or {}).keys())
+    return {
+        "key": key,
+        "name": manifest.get("name"),
+        "version": manifest.get("version"),
+        "kind": "+".join(facets) if facets else "unknown",
+    }
+
+
+def _kfx_registry_root(home):
+    return os.path.join(home, "extensions")
+
+
+def _bool(value, default):
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"true", "yes", "1"}:
+            return True
+        if normalized in {"false", "no", "0"}:
+            return False
+    return default

--- a/framework/core/tests/python/test_skill.py
+++ b/framework/core/tests/python/test_skill.py
@@ -5,6 +5,7 @@ import json
 
 from kungfu.skill import (
     append_audit_event,
+    build_skill_dependency_binding,
     build_catalog,
     build_context_envelope,
     build_skill_context,
@@ -13,7 +14,9 @@ from kungfu.skill import (
     read_audit_file,
     skill_advertised_event,
     skill_audit_document,
+    skill_dependencies_bound_event,
     skill_loaded_event,
+    write_skill_dependency_binding,
     write_audit_document,
 )
 
@@ -149,3 +152,161 @@ def test_skill_audit_reads_jsonl_events(tmp_path):
     assert document["schema"] == "kungfu.skill-audit/v1"
     assert document["run_id"] == "run-jsonl"
     assert document["events"][0]["skill"]["key"] == "minimal"
+
+
+def test_skill_audit_reads_multi_event_jsonl(tmp_path):
+    skill = parse_skill(_fixture("minimal"))
+    markdown = Path(skill["source"]["path"]).read_text(encoding="utf-8")
+    audit_path = tmp_path / "skill-audit.jsonl"
+
+    append_audit_event(audit_path, skill_loaded_event(skill, markdown, run_id="run-1"))
+    append_audit_event(audit_path, skill_loaded_event(skill, markdown, run_id="run-2"))
+
+    document = read_audit_file(audit_path)
+    assert document["event_count"] == 2
+    assert [event["run_id"] for event in document["events"]] == ["run-1", "run-2"]
+
+
+def test_skill_dependency_binding_resolves_installed_kfx(tmp_path):
+    home = tmp_path / "home"
+    extension = home / "extensions" / "journal-manager"
+    extension.mkdir(parents=True)
+    (extension / "package.json").write_text(
+        json.dumps(
+            {
+                "name": "@kungfu-tech/kfx-view-journal-manager",
+                "version": "4.0.0-alpha.0",
+                "kungfuConfig": {
+                    "key": "journal-manager",
+                    "config": {"view": {}},
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    skill = parse_skill(_fixture("with-frontmatter"))
+
+    binding_path, binding = write_skill_dependency_binding(home, skill)
+
+    assert Path(binding_path).name == "trace-failure-investigator.json"
+    assert binding["schema"] == "kungfu.skill-dependencies/v1"
+    assert binding["summary"] == {"total": 2, "resolved": 1, "unresolved": 1}
+    by_key = {row["kfxKey"]: row for row in binding["dependencies"]}
+    assert by_key["journal-manager"]["status"] == "resolved"
+    assert by_key["journal-manager"]["package"]["kind"] == "view"
+    assert by_key["rewind-inspector"]["status"] == "unresolved"
+    assert by_key["rewind-inspector"]["reason"] == "not installed in kfx registry"
+
+
+def test_multiple_skills_bind_one_shared_kfx_without_duplicate_registry(tmp_path):
+    home = tmp_path / "home"
+    extension = home / "extensions" / "shared-view"
+    extension.mkdir(parents=True)
+    (extension / "package.json").write_text(
+        json.dumps(
+            {
+                "name": "@kungfu-tech/kfx-view-shared",
+                "version": "1.2.3",
+                "kungfuConfig": {
+                    "key": "shared-view",
+                    "config": {"view": {}},
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    skill_dirs = []
+    for key in ("first-skill", "second-skill"):
+        skill_dir = tmp_path / key
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text(
+            "\n".join(
+                [
+                    "---",
+                    f"key: {key}",
+                    "kfx:",
+                    "  - key: shared-view",
+                    "    role: shared-tool",
+                    "---",
+                    "",
+                    f"# {key}",
+                    "",
+                    "Use the shared view.",
+                ]
+            ),
+            encoding="utf-8",
+        )
+        skill_dirs.append(skill_dir)
+
+    bindings = [
+        write_skill_dependency_binding(home, parse_skill(skill_dir))
+        for skill_dir in skill_dirs
+    ]
+
+    assert len(list((home / "extensions").iterdir())) == 1
+    assert bindings[0][0] != bindings[1][0]
+    first = bindings[0][1]["dependencies"][0]
+    second = bindings[1][1]["dependencies"][0]
+    assert first["status"] == "resolved"
+    assert second["status"] == "resolved"
+    assert first["registryPath"] == second["registryPath"]
+    assert first["package"] == second["package"]
+
+
+def test_skill_dependency_binding_marks_version_mismatch_unresolved(tmp_path):
+    home = tmp_path / "home"
+    extension = home / "extensions" / "versioned-view"
+    extension.mkdir(parents=True)
+    (extension / "package.json").write_text(
+        json.dumps(
+            {
+                "name": "@kungfu-tech/kfx-view-versioned",
+                "version": "1.0.0",
+                "kungfuConfig": {
+                    "key": "versioned-view",
+                    "config": {"view": {}},
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    skill_dir = tmp_path / "versioned-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        "\n".join(
+            [
+                "---",
+                "key: versioned-skill",
+                "kfx:",
+                "  - key: versioned-view",
+                "    version: 2.0.0",
+                "    required: false",
+                "---",
+                "",
+                "# versioned-skill",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    binding = build_skill_dependency_binding(home, parse_skill(skill_dir))
+    row = binding["dependencies"][0]
+
+    assert binding["summary"] == {"total": 1, "resolved": 0, "unresolved": 1}
+    assert row["status"] == "unresolved"
+    assert row["required"] is False
+    assert "does not match 2.0.0" in row["reason"]
+
+
+def test_skill_audit_records_dependency_binding_event(tmp_path):
+    skill = parse_skill(_fixture("with-frontmatter"))
+    binding = build_skill_dependency_binding(tmp_path / "home", skill)
+    event = skill_dependencies_bound_event(binding)
+
+    assert event["type"] == "SkillDependenciesBound"
+    assert event["skill"]["key"] == "trace-failure-investigator"
+    assert event["summary"]["total"] == 2
+    assert [row["status"] for row in event["dependencies"]] == [
+        "unresolved",
+        "unresolved",
+    ]

--- a/framework/skill/schema/skill-dependencies.schema.json
+++ b/framework/skill/schema/skill-dependencies.schema.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "kungfu.skill-dependencies/v1",
+  "title": "Kungfu Skill kfx Dependency Bindings",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "skill", "registry", "dependencies", "summary"],
+  "properties": {
+    "schema": { "const": "kungfu.skill-dependencies/v1" },
+    "skill": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["key", "title", "kind", "sourceHash", "sourcePath"],
+      "properties": {
+        "key": { "type": "string", "minLength": 1 },
+        "title": { "type": "string", "minLength": 1 },
+        "kind": { "enum": ["instruction-only", "kfx-backed"] },
+        "sourceHash": { "type": "string", "pattern": "^sha256:" },
+        "sourcePath": { "type": "string" }
+      }
+    },
+    "registry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "root"],
+      "properties": {
+        "type": { "const": "kfx" },
+        "root": { "type": "string" }
+      }
+    },
+    "dependencies": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": [
+          "skillKey",
+          "kfxKey",
+          "status",
+          "registryKey",
+          "registryPath"
+        ],
+        "properties": {
+          "skillKey": { "type": "string", "minLength": 1 },
+          "kfxKey": { "type": "string", "minLength": 1 },
+          "role": { "type": ["string", "null"] },
+          "version": { "type": ["string", "null"] },
+          "required": { "type": "boolean" },
+          "status": { "enum": ["resolved", "unresolved"] },
+          "registryKey": { "type": "string", "minLength": 1 },
+          "registryPath": { "type": "string" },
+          "reason": { "type": "string" },
+          "package": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["key", "kind"],
+            "properties": {
+              "key": { "type": "string", "minLength": 1 },
+              "name": { "type": ["string", "null"] },
+              "version": { "type": ["string", "null"] },
+              "kind": { "type": "string", "minLength": 1 }
+            }
+          }
+        }
+      }
+    },
+    "summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["total", "resolved", "unresolved"],
+      "properties": {
+        "total": { "type": "integer", "minimum": 0 },
+        "resolved": { "type": "integer", "minimum": 0 },
+        "unresolved": { "type": "integer", "minimum": 0 }
+      }
+    }
+  }
+}

--- a/framework/skill/src/index.ts
+++ b/framework/skill/src/index.ts
@@ -71,6 +71,48 @@ export interface SkillContextEnvelope {
   };
 }
 
+export interface SkillDependencyPackage {
+  key: string;
+  name?: string;
+  version?: string;
+  kind: string;
+}
+
+export interface SkillDependencyBindingRow {
+  skillKey: string;
+  kfxKey: string;
+  role?: string;
+  version?: string;
+  required: boolean;
+  status: 'resolved' | 'unresolved';
+  registryKey: string;
+  registryPath: string;
+  reason?: string;
+  package?: SkillDependencyPackage;
+  [key: string]: unknown;
+}
+
+export interface SkillDependencyBinding {
+  schema: 'kungfu.skill-dependencies/v1';
+  skill: {
+    key: string;
+    title: string;
+    kind: SkillKind;
+    sourceHash: string;
+    sourcePath: string;
+  };
+  registry: {
+    type: 'kfx';
+    root: string;
+  };
+  dependencies: SkillDependencyBindingRow[];
+  summary: {
+    total: number;
+    resolved: number;
+    unresolved: number;
+  };
+}
+
 type Frontmatter = Record<string, unknown>;
 
 export interface SkillContextOptions {
@@ -231,6 +273,64 @@ export function writeSkillContextFile(
   mkdirSync(dirname(out), { recursive: true });
   writeFileSync(out, `${JSON.stringify(envelope, null, 2)}\n`, 'utf8');
   return out;
+}
+
+export function skillBindingRoot(home: string): string {
+  return join(home, 'skill-bindings');
+}
+
+export function skillBindingPath(home: string, skillKey: string): string {
+  return join(skillBindingRoot(home), `${skillKey}.json`);
+}
+
+export function buildSkillDependencyBinding(
+  home: string,
+  skill: SkillSource,
+): SkillDependencyBinding {
+  const dependencies = skill.kfx.map((dependency) =>
+    dependencyBindingRow(home, skill, dependency),
+  );
+  const resolved = dependencies.filter(
+    (row) => row.status === 'resolved',
+  ).length;
+  return {
+    schema: 'kungfu.skill-dependencies/v1',
+    skill: {
+      key: skill.key,
+      title: skill.title,
+      kind: skill.kind,
+      sourceHash: skill.source.hash,
+      sourcePath: skill.source.path,
+    },
+    registry: {
+      type: 'kfx',
+      root: kfxRegistryRoot(home),
+    },
+    dependencies,
+    summary: {
+      total: dependencies.length,
+      resolved,
+      unresolved: dependencies.length - resolved,
+    },
+  };
+}
+
+export function writeSkillDependencyBinding(
+  home: string,
+  skill: SkillSource,
+): { path: string; binding: SkillDependencyBinding } {
+  const binding = buildSkillDependencyBinding(home, skill);
+  const out = skillBindingPath(home, skill.key);
+  mkdirSync(dirname(out), { recursive: true });
+  writeFileSync(out, `${JSON.stringify(binding, null, 2)}\n`, 'utf8');
+  return { path: out, binding };
+}
+
+export function readSkillDependencyBinding(
+  home: string,
+  skillKey: string,
+): SkillDependencyBinding {
+  return JSON.parse(readFileSync(skillBindingPath(home, skillKey), 'utf8'));
 }
 
 export function hasAdvertisedSkills(envelope: SkillContextEnvelope): boolean {
@@ -409,4 +509,88 @@ function kfxDependencies(value: unknown): SkillKfxDependency[] {
       return Boolean(item && typeof item === 'object' && stringValue(item.key));
     })
     .map((item) => ({ ...item, key: String(item.key) }));
+}
+
+function dependencyBindingRow(
+  home: string,
+  skill: SkillSource,
+  dependency: SkillKfxDependency,
+): SkillDependencyBindingRow {
+  const key = String(dependency.key);
+  const registryPath = join(kfxRegistryRoot(home), key);
+  const resolved = resolveKfxPackage(registryPath, key);
+  const version =
+    dependency.version === undefined ? undefined : String(dependency.version);
+  let status: SkillDependencyBindingRow['status'] = resolved
+    ? 'resolved'
+    : 'unresolved';
+  let reason: string | undefined = resolved
+    ? undefined
+    : 'not installed in kfx registry';
+  if (resolved && version && resolved.version !== version) {
+    status = 'unresolved';
+    reason = `installed version ${resolved.version} does not match ${version}`;
+  }
+  const row: SkillDependencyBindingRow = {
+    skillKey: skill.key,
+    kfxKey: key,
+    role: typeof dependency.role === 'string' ? dependency.role : undefined,
+    version,
+    required: booleanValue(dependency.required, true),
+    status,
+    registryKey: key,
+    registryPath,
+  };
+  for (const [extraKey, extraValue] of Object.entries(dependency).sort()) {
+    if (!['key', 'role', 'version', 'required'].includes(extraKey)) {
+      row[extraKey] = extraValue;
+    }
+  }
+  if (resolved) row.package = resolved;
+  if (reason) row.reason = reason;
+  return row;
+}
+
+function resolveKfxPackage(
+  packageDir: string,
+  expectedKey: string,
+): SkillDependencyPackage | undefined {
+  const manifestPath = join(packageDir, 'package.json');
+  if (!existsSync(manifestPath)) return undefined;
+  let manifest: Record<string, unknown>;
+  try {
+    manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+  } catch {
+    return undefined;
+  }
+  const config = objectValue(manifest.kungfuConfig);
+  const key = stringValue(config?.key) || basename(packageDir);
+  if (key !== expectedKey) return undefined;
+  const facets = Object.keys(objectValue(config?.config) ?? {}).sort();
+  return {
+    key,
+    name: stringValue(manifest.name),
+    version: stringValue(manifest.version),
+    kind: facets.length ? facets.join('+') : 'unknown',
+  };
+}
+
+function kfxRegistryRoot(home: string): string {
+  return join(home, 'extensions');
+}
+
+function objectValue(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === 'object'
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function booleanValue(value: unknown, fallback: boolean): boolean {
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    if (['true', 'yes', '1'].includes(normalized)) return true;
+    if (['false', 'no', '0'].includes(normalized)) return false;
+  }
+  return fallback;
 }


### PR DESCRIPTION
## Summary
- add Skill kfx dependency binding documents under the Kungfu home
- resolve declared kfx dependencies against the shared kfx registry without copying kfx payloads per skill
- expose `kungfu skill deps` plus Python and Node binding helpers
- record `SkillDependenciesBound` audit events and support multi-event JSONL audit reads

## Verification
- `uv --project framework/core run ruff check framework/core/src/python/kungfu/skill framework/core/src/python/kungfu/cli/commands/skill.py framework/core/tests/python/test_skill.py`
- `PYTHONPATH=framework/core/src/python uv --project framework/core run pytest framework/core/tests/python/test_skill.py`
- `./kungfu-code --filter @kungfu-tech/skill run build`
- `./kungfu-code --filter @kungfu-tech/skill run test:golden`
- `./kungfu-code build:core`
- `./kungfu-code freeze`
- frozen `framework/core/dist/kungfu/kungfu` install/deps smoke with two skills sharing one kfx registry entry
- `./kungfu-code verify`
