### PR TITLE
feat(skill): expose dependency state to managers

### DIFF
--- a/docs/skills.md
+++ b/docs/skills.md
@@ -229,6 +229,8 @@ framework/skill/
     skill.schema.json
     skill-catalog.schema.json
     skill-context.schema.json
+    skill-dependencies.schema.json
+    skill-manager.schema.json
   fixtures/
     minimal/SKILL.md
     with-frontmatter/SKILL.md
@@ -245,7 +247,6 @@ framework/core/src/python/kungfu/skill/
 
 framework/core/src/python/kungfu/cli/commands/skill.py
 
-framework/gui/src/main/skill-manager.ts
 framework/gui/src/main/skill-context.ts
 
 extensions/system/skill-manager/
@@ -281,8 +282,12 @@ duplicated under each skill. Dependency rows are `resolved` when a matching
 package already exists in `<home>/extensions/<kfx-key>` and `unresolved`
 otherwise. `catalog` is the compact agent-visible catalog before full skill
 loading. `context` wraps that catalog in the same envelope shape used by Python
-and Node manage modes. `deps` prints the binding/resolution state. `verify`
-runs a real provider through `managed-run`, asks it to echo the advertised
+and Node manage modes. `deps` prints the binding/resolution state. The Node
+manager also builds a `kungfu.skill-manager/v1` document for GUI use, joining
+installed skills with the same kfx dependency binding semantics as the Python
+CLI and summarizing resolved, unresolved, and unresolved-required dependencies
+before an agent process starts. `verify` runs a real provider through
+`managed-run`, asks it to echo the advertised
 schema, first skill key, and `advertisedSkillsHash`, then checks the Rewind
 `response.json` evidence. Use `--manager node` to build the envelope through
 the Node manager path used by the Electron GUI. `read` is the operation the
@@ -304,14 +309,21 @@ which creates only:
 
 ## GUI surface
 
-The GUI should expose a first-party system view, `skill-manager`, rather than
-folding every skill concern into the existing kfx manager. The view should show:
+The GUI exposes a first-party system view, `skill-manager`, rather than folding
+every skill concern into the existing kfx manager. Electron main writes the Node
+manager document to `KF_SKILL_MANAGER_FILE`, and the renderer exposes it through
+`shell.info.skillManager`. The first view slice shows:
 
 - installed skills and their generated catalog entries;
-- full `SKILL.md` for inspection;
 - declared kfx dependencies and whether each dependency is installed;
-- trust/provenance state and source hashes;
+- resolved/unresolved dependency counts, including unresolved required kfx;
+- shared kfx registry paths and package coordinates for resolved dependencies;
 - which capabilities a skill requests;
+
+Later slices should add:
+
+- full `SKILL.md` for inspection;
+- trust/provenance state and source hashes beyond the catalog hash;
 - audit events: advertised, loaded, dependency invoked, and install/update.
 
 The kfx manager remains the extension/package manager. The skill manager is the

--- a/extensions/system/package.json
+++ b/extensions/system/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@kungfu-tech/kfx-view-settings": "workspace:*",
     "@kungfu-tech/kfx-view-kfx-manager": "workspace:*",
+    "@kungfu-tech/kfx-view-skill-manager": "workspace:*",
     "@kungfu-tech/kfx-view-status": "workspace:*"
   },
   "kungfuConfig": {
@@ -32,6 +33,7 @@
       "members": [
         "settings",
         "kfx-manager",
+        "skill-manager",
         "system-status"
       ]
     }

--- a/extensions/system/skill-manager/package.json
+++ b/extensions/system/skill-manager/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@kungfu-tech/kfx-view-skill-manager",
+  "author": {
+    "name": "Kungfu",
+    "email": "info@kungfu.link"
+  },
+  "version": "4.0.0-alpha.0",
+  "description": "Kungfu view extension: Skills",
+  "license": "Apache-2.0",
+  "main": "package.json",
+  "repository": {
+    "url": "https://github.com/kungfu-systems/kungfu.git"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  },
+  "files": [
+    "dist",
+    "package.json",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "kungfu sdk kfx build",
+    "clean": "kungfu sdk kfx clean"
+  },
+  "dependencies": {
+    "@kungfu-tech/api": "workspace:*",
+    "@kungfu-tech/kfx": "workspace:*",
+    "@kungfu-tech/skill": "workspace:*"
+  },
+  "devDependencies": {
+    "@kungfu-tech/sdk": "workspace:*",
+    "@types/react": "^18.3.3"
+  },
+  "peerDependencies": {
+    "react": "^18.3.1"
+  },
+  "kungfuConfig": {
+    "key": "skill-manager",
+    "name": "Skills",
+    "config": {
+      "view": {
+        "title": "Skills",
+        "capabilities": [],
+        "system": true
+      }
+    }
+  }
+}

--- a/extensions/system/skill-manager/src/view/index.tsx
+++ b/extensions/system/skill-manager/src/view/index.tsx
@@ -1,0 +1,140 @@
+// System view: Skill Manager. Shows the Node manager's pre-agent dependency
+// view: installed skills, compact catalog entries, and kfx binding status.
+import {
+  type KfxViewProps,
+  headingStyle,
+  mono,
+  panelStyle,
+} from '@kungfu-tech/kfx';
+import type { SkillManagerEntry, SkillManagerView } from '@kungfu-tech/skill';
+import React from 'react';
+
+function asSkillManagerView(value: unknown): SkillManagerView | null {
+  if (
+    value &&
+    typeof value === 'object' &&
+    (value as { schema?: unknown }).schema === 'kungfu.skill-manager/v1'
+  ) {
+    return value as SkillManagerView;
+  }
+  return null;
+}
+
+function packageLabel(
+  row: SkillManagerEntry['dependencies']['dependencies'][0],
+) {
+  return row.package
+    ? `${row.package.name ?? row.package.key}@${row.package.version ?? '?'}`
+    : (row.reason ?? 'not resolved');
+}
+
+function SkillManagerViewComponent({ shell }: KfxViewProps) {
+  const view = asSkillManagerView(shell.info.skillManager);
+  const cell: React.CSSProperties = { padding: '2px 12px 2px 0' };
+  if (!view) {
+    return (
+      <section style={panelStyle}>
+        <h2 style={headingStyle}>Skills</h2>
+        <div style={{ ...mono, color: '#f48771' }}>
+          skill manager view unavailable
+        </div>
+        <div style={{ ...mono, color: '#6a6a6a', marginTop: 4 }}>
+          KF_SKILL_MANAGER_FILE was not readable before the renderer booted
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section style={panelStyle}>
+      <h2 style={headingStyle}>
+        Skills · {view.summary.skills} installed ·{' '}
+        {view.summary.unresolvedRequired} unresolved required kfx
+      </h2>
+      <div style={{ ...mono, color: '#6a6a6a', marginBottom: 8 }}>
+        registry: {view.registry.root}
+      </div>
+      {view.skills.length === 0 ? (
+        <div style={{ ...mono, color: '#6a6a6a' }}>no installed skills</div>
+      ) : (
+        <table style={{ ...mono, borderCollapse: 'collapse', minWidth: 760 }}>
+          <thead>
+            <tr style={{ color: '#858585', textAlign: 'left' }}>
+              <th style={cell}>skill</th>
+              <th style={cell}>kind</th>
+              <th style={cell}>triggers</th>
+              <th style={cell}>kfx</th>
+              <th style={cell}>state</th>
+            </tr>
+          </thead>
+          <tbody>
+            {view.skills.map((skill) => (
+              <React.Fragment key={skill.key}>
+                <tr>
+                  <td style={{ ...cell, color: '#9cdcfe' }}>{skill.key}</td>
+                  <td style={cell}>{skill.kind}</td>
+                  <td style={{ ...cell, color: '#ce9178' }}>
+                    {skill.triggers.join(', ') || 'manual'}
+                  </td>
+                  <td style={cell}>
+                    {skill.dependencySummary.total} total ·{' '}
+                    <span style={{ color: '#4ec9b0' }}>
+                      {skill.dependencySummary.resolved} resolved
+                    </span>{' '}
+                    ·{' '}
+                    <span
+                      style={{
+                        color: skill.hasUnresolvedRequiredDependencies
+                          ? '#f48771'
+                          : '#858585',
+                      }}
+                    >
+                      {skill.dependencySummary.unresolved} unresolved
+                    </span>
+                  </td>
+                  <td style={cell}>
+                    {skill.hasUnresolvedRequiredDependencies ? (
+                      <span style={{ color: '#f48771' }}>blocked</span>
+                    ) : (
+                      <span style={{ color: '#4ec9b0' }}>ready</span>
+                    )}
+                  </td>
+                </tr>
+                {skill.dependencies.dependencies.map((row, index) => (
+                  <tr key={`${skill.key}:${row.kfxKey}:${index}`}>
+                    <td style={cell} />
+                    <td style={{ ...cell, color: '#858585' }}>
+                      {row.required ? 'required' : 'optional'}
+                    </td>
+                    <td style={{ ...cell, color: '#858585' }}>
+                      role={row.role ?? '-'}
+                    </td>
+                    <td
+                      style={{
+                        ...cell,
+                        color:
+                          row.status === 'resolved' ? '#4ec9b0' : '#f48771',
+                      }}
+                    >
+                      {row.status} · {row.kfxKey}
+                    </td>
+                    <td style={{ ...cell, color: '#6a6a6a' }}>
+                      {packageLabel(row)}
+                    </td>
+                  </tr>
+                ))}
+              </React.Fragment>
+            ))}
+          </tbody>
+        </table>
+      )}
+      {view.summary.unresolvedKfxKeys.length > 0 && (
+        <div style={{ ...mono, color: '#f48771', marginTop: 8 }}>
+          unresolved: {view.summary.unresolvedKfxKeys.join(', ')}
+        </div>
+      )}
+    </section>
+  );
+}
+
+export const View = SkillManagerViewComponent;

--- a/framework/gui/src/main/index.ts
+++ b/framework/gui/src/main/index.ts
@@ -33,7 +33,10 @@ import {
 } from './installCli';
 import { type Rect, SandboxManager } from './sandbox-manager';
 import { bindSessionWindows } from './session-windows-host';
-import { writeGuiSkillContextFile } from './skill-context';
+import {
+  writeGuiSkillContextFile,
+  writeGuiSkillManagerViewFile,
+} from './skill-context';
 import {
   bindElectronTerminalHost,
   createMainTerminalHost,
@@ -116,6 +119,17 @@ if (!process.env.KF_SKILL_CONTEXT_FILE && process.env.KF_RUNTIME_DIR) {
     });
   } catch (e) {
     console.log(`KF_SKILL_CONTEXT_FAIL ${(e as Error).message}`);
+  }
+}
+
+if (!process.env.KF_SKILL_MANAGER_FILE && process.env.KF_RUNTIME_DIR) {
+  try {
+    process.env.KF_SKILL_MANAGER_FILE = writeGuiSkillManagerViewFile({
+      home: process.env.KF_RUNTIME_DIR,
+      env: process.env,
+    });
+  } catch (e) {
+    console.log(`KF_SKILL_MANAGER_FAIL ${(e as Error).message}`);
   }
 }
 

--- a/framework/gui/src/main/skill-context.ts
+++ b/framework/gui/src/main/skill-context.ts
@@ -1,7 +1,10 @@
 import {
   type SkillContextEnvelope,
+  type SkillManagerView,
   buildSkillContext,
+  buildSkillManagerView,
   writeSkillContextFile,
+  writeSkillManagerViewFile,
 } from '@kungfu-tech/skill';
 
 export function buildGuiSkillContext(options: {
@@ -30,6 +33,24 @@ export function writeGuiSkillContextFile(options: {
     manager: 'node',
     profile: options.profile,
     agent: options.agent,
+    env: options.env,
+  });
+}
+
+export function buildGuiSkillManagerView(options: {
+  home: string;
+  env?: Record<string, string | undefined>;
+}): SkillManagerView {
+  return buildSkillManagerView(options.home, {
+    env: options.env,
+  });
+}
+
+export function writeGuiSkillManagerViewFile(options: {
+  home: string;
+  env?: Record<string, string | undefined>;
+}): string {
+  return writeSkillManagerViewFile(options.home, {
     env: options.env,
   });
 }

--- a/framework/gui/src/renderer/src/runtime.ts
+++ b/framework/gui/src/renderer/src/runtime.ts
@@ -105,6 +105,7 @@ export type Runtime = {
   runtimeDir: string;
   kungfuVersion: string;
   buildInfo: Record<string, unknown> | null;
+  skillManager: Record<string, unknown> | null;
   exports: string[];
   longfistTypes: { name: string; fields: string[] }[];
   binding: KfNativeBinding | null;
@@ -138,6 +139,7 @@ export function bootRuntime(): Runtime {
     runtimeDir,
     kungfuVersion: env.KUNGFU_VERSION || '',
     buildInfo: null,
+    skillManager: null,
     exports: [],
     longfistTypes: [],
     binding: null,
@@ -165,6 +167,16 @@ export function bootRuntime(): Runtime {
       );
     } catch {
       buildInfo = null;
+    }
+    let skillManager: Record<string, unknown> | null = null;
+    try {
+      const fs = window.require('node:fs');
+      const managerPath = env.KF_SKILL_MANAGER_FILE;
+      if (managerPath) {
+        skillManager = JSON.parse(fs.readFileSync(managerPath, 'utf8'));
+      }
+    } catch {
+      skillManager = null;
     }
     // Joining initializes a fresh runtime home's layout and connects to a
     // live master when one is running; the domain handle needs the layout.
@@ -208,6 +220,7 @@ export function bootRuntime(): Runtime {
       ok: true,
       message: `in-process binding loaded · ${Object.keys(binding).length} exports`,
       buildInfo,
+      skillManager,
       exports: Object.keys(binding),
       longfistTypes: readLongfistTypes(binding),
       binding,

--- a/framework/gui/src/renderer/src/shell-state.ts
+++ b/framework/gui/src/renderer/src/shell-state.ts
@@ -22,6 +22,7 @@ export const PROFILES: ProfileManifest[] = [
     title: 'Default — work control plane',
     kfx: [
       'work-dashboard',
+      'skill-manager',
       'rewind',
       'terminal',
       'journal-manager',

--- a/framework/kfx/src/index.ts
+++ b/framework/kfx/src/index.ts
@@ -164,6 +164,7 @@ export type ShellRuntimeInfo = {
   runtimeDir: string;
   kungfuVersion: string;
   buildInfo: Record<string, unknown> | null;
+  skillManager: Record<string, unknown> | null;
   exports: string[];
   longfistTypes: { name: string; fields: string[] }[];
 };

--- a/framework/skill/README.md
+++ b/framework/skill/README.md
@@ -27,6 +27,19 @@ node --experimental-transform-types framework/skill/scripts/context.mjs \
   --out <context.json>
 ```
 
+Skill Manager and GUI views use the same Node-side dependency binding semantics:
+
+```sh
+node --experimental-transform-types framework/skill/scripts/manager.mjs \
+  --home <kungfu-home> \
+  --path <skill-or-root> \
+  --out <skill-manager.json>
+```
+
+The manager view reports installed skills, catalog entries, declared kfx
+dependencies, shared registry paths, and resolved/unresolved counts before an
+agent is launched.
+
 `fixtures/golden/` pins the catalog and context envelopes used to keep the
 Python and TypeScript implementations schema-equivalent.
 

--- a/framework/skill/schema/skill-manager.schema.json
+++ b/framework/skill/schema/skill-manager.schema.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "kungfu.skill-manager/v1",
+  "title": "Kungfu Skill Manager View",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "registry", "skills", "summary"],
+  "properties": {
+    "schema": { "const": "kungfu.skill-manager/v1" },
+    "registry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "root"],
+      "properties": {
+        "type": { "const": "kfx" },
+        "root": { "type": "string" }
+      }
+    },
+    "skills": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "key",
+          "title",
+          "description",
+          "kind",
+          "triggers",
+          "capabilities",
+          "sourceHash",
+          "sourcePath",
+          "catalogEntry",
+          "dependencies",
+          "dependencySummary",
+          "hasUnresolvedRequiredDependencies"
+        ],
+        "properties": {
+          "key": { "type": "string", "minLength": 1 },
+          "title": { "type": "string", "minLength": 1 },
+          "description": { "type": "string" },
+          "kind": { "enum": ["instruction-only", "kfx-backed"] },
+          "triggers": { "type": "array", "items": { "type": "string" } },
+          "capabilities": { "type": "array", "items": { "type": "string" } },
+          "sourceHash": { "type": "string", "pattern": "^sha256:" },
+          "sourcePath": { "type": "string" },
+          "catalogEntry": { "$ref": "kungfu.skill-catalog/v1#/properties/skills/items" },
+          "dependencies": { "$ref": "kungfu.skill-dependencies/v1" },
+          "dependencySummary": {
+            "$ref": "kungfu.skill-dependencies/v1#/properties/summary"
+          },
+          "hasUnresolvedRequiredDependencies": { "type": "boolean" }
+        }
+      }
+    },
+    "summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "skills",
+        "dependencies",
+        "resolved",
+        "unresolved",
+        "unresolvedRequired",
+        "kfxKeys",
+        "unresolvedKfxKeys"
+      ],
+      "properties": {
+        "skills": { "type": "integer", "minimum": 0 },
+        "dependencies": { "type": "integer", "minimum": 0 },
+        "resolved": { "type": "integer", "minimum": 0 },
+        "unresolved": { "type": "integer", "minimum": 0 },
+        "unresolvedRequired": { "type": "integer", "minimum": 0 },
+        "kfxKeys": { "type": "array", "items": { "type": "string" } },
+        "unresolvedKfxKeys": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/framework/skill/scripts/golden.mjs
+++ b/framework/skill/scripts/golden.mjs
@@ -1,16 +1,18 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import assert from 'node:assert/strict';
-import { mkdtempSync, readFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
   buildCatalog,
   buildContextEnvelope,
+  buildSkillManagerView,
   injectSkillContext,
   parseSkill,
   writeSkillContextFile,
+  writeSkillManagerViewFile,
 } from '../src/index.ts';
 
 const root = dirname(dirname(fileURLToPath(import.meta.url)));
@@ -47,5 +49,63 @@ writeSkillContextFile(root, {
 assert.deepEqual(
   readJson('fixtures/golden/context-node.json'),
   JSON.parse(readFileSync(out, 'utf8')),
+);
+
+const home = mkdtempSync(join(tmpdir(), 'kungfu-skill-manager-'));
+const rewindInspectorRoot = join(home, 'extensions', 'rewind-inspector');
+mkdirSync(rewindInspectorRoot, { recursive: true });
+writeFileSync(
+  join(rewindInspectorRoot, 'package.json'),
+  `${JSON.stringify(
+    {
+      name: '@kungfu-tech/kfx-view-rewind-inspector',
+      version: '4.0.0-alpha.0',
+      kungfuConfig: {
+        key: 'rewind-inspector',
+        config: { view: { title: 'Rewind', capabilities: [] } },
+      },
+    },
+    null,
+    2,
+  )}\n`,
+  'utf8',
+);
+const managerView = buildSkillManagerView(home, {
+  extraPaths: [
+    join(root, 'fixtures', 'minimal'),
+    join(root, 'fixtures', 'with-frontmatter'),
+  ],
+});
+assert.equal(managerView.schema, 'kungfu.skill-manager/v1');
+assert.deepEqual(managerView.summary, {
+  skills: 2,
+  dependencies: 2,
+  resolved: 1,
+  unresolved: 1,
+  unresolvedRequired: 1,
+  kfxKeys: ['journal-manager', 'rewind-inspector'],
+  unresolvedKfxKeys: ['journal-manager'],
+});
+assert.equal(
+  managerView.skills.find((skill) => skill.key === 'minimal')
+    ?.hasUnresolvedRequiredDependencies,
+  false,
+);
+assert.equal(
+  managerView.skills.find((skill) => skill.key === 'trace-failure-investigator')
+    ?.hasUnresolvedRequiredDependencies,
+  true,
+);
+const managerOut = join(home, 'manager.json');
+writeSkillManagerViewFile(home, {
+  extraPaths: [
+    join(root, 'fixtures', 'minimal'),
+    join(root, 'fixtures', 'with-frontmatter'),
+  ],
+  out: managerOut,
+});
+assert.deepEqual(
+  JSON.parse(JSON.stringify(managerView)),
+  JSON.parse(readFileSync(managerOut, 'utf8')),
 );
 console.log('skill golden fixtures match');

--- a/framework/skill/scripts/manager.mjs
+++ b/framework/skill/scripts/manager.mjs
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { writeFileSync } from 'node:fs';
+import {
+  buildSkillManagerView,
+  writeSkillManagerViewFile,
+} from '../src/index.ts';
+
+function parseArgs(argv) {
+  const args = {
+    home: undefined,
+    paths: [],
+    out: undefined,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const value = () => {
+      i += 1;
+      if (i >= argv.length) throw new Error(`missing value for ${arg}`);
+      return argv[i];
+    };
+    if (arg === '--home') args.home = value();
+    else if (arg === '--path') args.paths.push(value());
+    else if (arg === '--out') args.out = value();
+    else if (arg === '--help' || arg === '-h') {
+      printHelp();
+      process.exit(0);
+    } else {
+      throw new Error(`unknown option: ${arg}`);
+    }
+  }
+  if (!args.home) throw new Error('--home is required');
+  return args;
+}
+
+function printHelp() {
+  console.log(`Usage: node --experimental-transform-types scripts/manager.mjs --home <dir> [options]
+
+Build a Kungfu Skill manager view through the Node manager implementation.
+
+Options:
+  --path <dir>                skill directory or skill root, repeatable
+  --out <file>                write manager view to file instead of stdout
+`);
+}
+
+try {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.out) {
+    writeSkillManagerViewFile(args.home, {
+      extraPaths: args.paths,
+      out: args.out,
+    });
+    console.log(args.out);
+  } else {
+    const view = buildSkillManagerView(args.home, { extraPaths: args.paths });
+    writeFileSync(1, `${JSON.stringify(view, null, 2)}\n`, 'utf8');
+  }
+} catch (e) {
+  console.error(`skill manager failed: ${e.message}`);
+  process.exit(1);
+}

--- a/framework/skill/src/index.ts
+++ b/framework/skill/src/index.ts
@@ -113,6 +113,39 @@ export interface SkillDependencyBinding {
   };
 }
 
+export interface SkillManagerEntry {
+  key: string;
+  title: string;
+  description: string;
+  kind: SkillKind;
+  triggers: string[];
+  capabilities: string[];
+  sourceHash: string;
+  sourcePath: string;
+  catalogEntry: SkillCatalogEntry;
+  dependencies: SkillDependencyBinding;
+  dependencySummary: SkillDependencyBinding['summary'];
+  hasUnresolvedRequiredDependencies: boolean;
+}
+
+export interface SkillManagerView {
+  schema: 'kungfu.skill-manager/v1';
+  registry: {
+    type: 'kfx';
+    root: string;
+  };
+  skills: SkillManagerEntry[];
+  summary: {
+    skills: number;
+    dependencies: number;
+    resolved: number;
+    unresolved: number;
+    unresolvedRequired: number;
+    kfxKeys: string[];
+    unresolvedKfxKeys: string[];
+  };
+}
+
 type Frontmatter = Record<string, unknown>;
 
 export interface SkillContextOptions {
@@ -125,6 +158,15 @@ export interface SkillContextOptions {
 }
 
 export interface SkillContextFileOptions extends SkillContextOptions {
+  out?: string;
+}
+
+export interface SkillManagerViewOptions {
+  extraPaths?: string[];
+  env?: Record<string, string | undefined>;
+}
+
+export interface SkillManagerViewFileOptions extends SkillManagerViewOptions {
   out?: string;
 }
 
@@ -331,6 +373,72 @@ export function readSkillDependencyBinding(
   skillKey: string,
 ): SkillDependencyBinding {
   return JSON.parse(readFileSync(skillBindingPath(home, skillKey), 'utf8'));
+}
+
+export function buildSkillManagerView(
+  home: string,
+  options: SkillManagerViewOptions = {},
+): SkillManagerView {
+  const skills = discoverSkills(
+    home,
+    options.extraPaths ?? [],
+    options.env ?? process.env,
+  ).map((skill) => {
+    const dependencies = buildSkillDependencyBinding(home, skill);
+    return {
+      key: skill.key,
+      title: skill.title,
+      description: skill.description,
+      kind: skill.kind,
+      triggers: skill.triggers,
+      capabilities: skill.capabilities,
+      sourceHash: skill.source.hash,
+      sourcePath: skill.source.path,
+      catalogEntry: toCatalogEntry(skill),
+      dependencySummary: dependencies.summary,
+      dependencies,
+      hasUnresolvedRequiredDependencies: dependencies.dependencies.some(
+        (row) => row.required && row.status === 'unresolved',
+      ),
+    };
+  });
+  const allRows = skills.flatMap((skill) => skill.dependencies.dependencies);
+  return {
+    schema: 'kungfu.skill-manager/v1',
+    registry: {
+      type: 'kfx',
+      root: kfxRegistryRoot(home),
+    },
+    skills,
+    summary: {
+      skills: skills.length,
+      dependencies: allRows.length,
+      resolved: allRows.filter((row) => row.status === 'resolved').length,
+      unresolved: allRows.filter((row) => row.status === 'unresolved').length,
+      unresolvedRequired: allRows.filter(
+        (row) => row.required && row.status === 'unresolved',
+      ).length,
+      kfxKeys: uniqueSorted(allRows.map((row) => row.kfxKey)),
+      unresolvedKfxKeys: uniqueSorted(
+        allRows
+          .filter((row) => row.status === 'unresolved')
+          .map((row) => row.kfxKey),
+      ),
+    },
+  };
+}
+
+export function writeSkillManagerViewFile(
+  home: string,
+  options: SkillManagerViewFileOptions = {},
+): string {
+  const view = buildSkillManagerView(home, options);
+  const out = options.out
+    ? resolve(options.out)
+    : join(home, 'skill-manager', 'default.json');
+  mkdirSync(dirname(out), { recursive: true });
+  writeFileSync(out, `${JSON.stringify(view, null, 2)}\n`, 'utf8');
+  return out;
 }
 
 export function hasAdvertisedSkills(envelope: SkillContextEnvelope): boolean {
@@ -593,4 +701,8 @@ function booleanValue(value: unknown, fallback: boolean): boolean {
     if (['false', 'no', '0'].includes(normalized)) return false;
   }
   return fallback;
+}
+
+function uniqueSorted(values: string[]): string[] {
+  return [...new Set(values)].sort();
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -150,6 +150,9 @@ importers:
       '@kungfu-tech/kfx-view-settings':
         specifier: workspace:*
         version: link:settings
+      '@kungfu-tech/kfx-view-skill-manager':
+        specifier: workspace:*
+        version: link:skill-manager
       '@kungfu-tech/kfx-view-status':
         specifier: workspace:*
         version: link:status
@@ -181,6 +184,28 @@ importers:
       '@kungfu-tech/kfx':
         specifier: workspace:*
         version: link:../../../framework/kfx
+      react:
+        specifier: ^18.3.1
+        version: 18.3.1
+    devDependencies:
+      '@kungfu-tech/sdk':
+        specifier: workspace:*
+        version: link:../../../developer/sdk
+      '@types/react':
+        specifier: ^18.3.3
+        version: 18.3.31
+
+  extensions/system/skill-manager:
+    dependencies:
+      '@kungfu-tech/api':
+        specifier: workspace:*
+        version: link:../../../framework/api
+      '@kungfu-tech/kfx':
+        specifier: workspace:*
+        version: link:../../../framework/kfx
+      '@kungfu-tech/skill':
+        specifier: workspace:*
+        version: link:../../../framework/skill
       react:
         specifier: ^18.3.1
         version: 18.3.1


### PR DESCRIPTION
## Summary
- add a `kungfu.skill-manager/v1` Node manager view that joins installed skills with kfx dependency binding state
- write `KF_SKILL_MANAGER_FILE` from Electron main and expose it through `shell.info.skillManager`
- add the first-party `skill-manager` system view to show resolved/unresolved kfx dependencies before agent launch

## Validation
- `./kungfu-code --filter @kungfu-tech/skill run build`
- `./kungfu-code --filter @kungfu-tech/skill run test:golden`
- `./kungfu-code --filter @kungfu-tech/kfx run build`
- `./kungfu-code --filter @kungfu-tech/gui run build`
- `./kungfu-code exec biome check framework/skill/src/index.ts framework/skill/scripts/golden.mjs framework/skill/scripts/manager.mjs framework/gui/src/main/index.ts framework/gui/src/main/skill-context.ts framework/gui/src/renderer/src/runtime.ts framework/gui/src/renderer/src/shell-state.ts framework/kfx/src/index.ts extensions/system/package.json extensions/system/skill-manager/package.json extensions/system/skill-manager/src/view/index.tsx`
- `node --experimental-transform-types framework/skill/scripts/manager.mjs --home <tmp> --path framework/skill/fixtures/minimal --path framework/skill/fixtures/with-frontmatter`
- `node ../../../developer/sdk/src/sdk.js kfx build` from `extensions/system/skill-manager`

## Notes
- Full `./kungfu-code lint` is not a clean signal on this branch because existing unrelated files currently fail Biome import/style rules; changed-file Biome check passes.
- The package script `kungfu sdk kfx build` resolves to the local global `/usr/local/bin/kungfu` on this machine, which lacks `sdk`; the view bundle was verified through the repo SDK entrypoint directly.
