### PR TITLE
build(repo): move the pre-commit hook to node (cross-platform format + lint guard)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,104 +1,22 @@
 #!/bin/sh
-# kungfu pre-commit hook — format staged files in place, then re-stage them.
+# kungfu pre-commit hook — cross-platform shim; all logic lives in precommit.mjs.
 #
-# Scope: only staged (Added/Copied/Modified) files, dispatched by extension to
-# the matching formatter (clang-format / ruff / biome). Generated
-# outputs (flatbuffers tables, files carrying a "do not modify" header) are
-# skipped so regeneration stays authoritative.
+# git must be able to launch the hook file, and POSIX sh is the one interpreter
+# it ships on every platform (incl. Git-for-Windows' bundled bash). So this stays
+# a tiny sh shim that only execs node — no checks live here. precommit.mjs runs
+# the real work (staged .sh guard, format, blocking lint) identically on
+# macOS/Linux/Windows.
 #
-# Installed to $(git --git-common-dir)/hooks/pre-commit by install-hooks.js
-# (root `prepare`, or `pnpm run hooks:install`). It coexists with a managed
-# hooks-path guard: when core.hooksPath points elsewhere, that guard execs this
-# standard hook after its own checks pass, so this file stays the single place
-# that formats staged code.
-#
-# A missing formatter warns and skips (a setup gap must not block a commit); run
-# `./kungfu-code sync` to install the toolchain. Bypass entirely with `git
-# commit -n`.
+# Installed to $(git --git-common-dir)/hooks/pre-commit by install-hooks.js (root
+# `prepare`, or `pnpm run hooks:install`). It coexists with the managed hooks-path
+# guard: when core.hooksPath points elsewhere, that guard execs this standard hook
+# after its own checks. Missing node warns and skips (a setup gap must not block a
+# commit). Bypass entirely with `git commit -n`.
 set -eu
 
-root=$(git rev-parse --show-toplevel)
-cd "$root"
-
-staged=$(git diff --cached --name-only --diff-filter=ACM || true)
-[ -n "$staged" ] || exit 0
-
-# A file is "generated" if its path matches a known generated shape or its head
-# carries a generator marker. Kept in sync with the ruff/biome exclude configs.
-is_generated() {
-  case "$1" in
-    */generated/*|*/fb/[A-Z]*.py|*_fb.py|*_generated.*) return 0 ;;
-  esac
-  head -n 3 "$1" 2>/dev/null | grep -qiE 'automatically generated|do not (edit|modify)' && return 0
-  return 1
-}
-
-cpp='' py='' web=''
-for f in $staged; do
-  [ -f "$f" ] || continue          # skip deletions / renamed-away paths
-  is_generated "$f" && continue
-  # Repo-wide dispatch: C++ -> clang-format, Python -> ruff, all JS/TS -> biome
-  # (single root biome.json, which ignores generated/, fixtures/ and JSON).
-  case "$f" in
-    *.h|*.hpp|*.hxx|*.cpp|*.c|*.cc|*.cxx)
-      cpp="$cpp $f" ;;
-    *.py)
-      py="$py $f" ;;
-    *.ts|*.tsx|*.js|*.jsx|*.mjs|*.cjs)
-      web="$web $f" ;;
-  esac
-done
-
-changed=''
-warn() { printf '[kungfu pre-commit] %s\n' "$1" >&2; }
-
-# C++ — clang-format reads the repo-root .clang-format via -style=file. Pin the
-# version to framework/core/pyproject.toml (keep both in sync) so output is
-# byte-identical across machines; prefer the uv-provided pin over a system one.
-if [ -n "$cpp" ]; then
-  if command -v uvx >/dev/null 2>&1; then
-    # shellcheck disable=SC2086
-    uvx clang-format@20.1.8 -style=file -i $cpp && changed="$changed $cpp"
-  elif command -v clang-format >/dev/null 2>&1; then
-    warn "using system clang-format ($(clang-format --version | head -1)); may differ from pinned 20.1.8"
-    # shellcheck disable=SC2086
-    clang-format -style=file -i $cpp && changed="$changed $cpp"
-  else
-    warn "clang-format (uv) not found; skipped C++:$cpp"
-  fi
+root=$(git rev-parse --show-toplevel) || exit 0
+if command -v node >/dev/null 2>&1; then
+  exec node "$root/precommit.mjs"
 fi
-
-# Python — ruff finds framework/core/pyproject.toml per file (line-length 88,
-# generated excludes). Prefer a repo/global ruff, else uv's ephemeral runner.
-if [ -n "$py" ]; then
-  if command -v ruff >/dev/null 2>&1; then
-    # shellcheck disable=SC2086
-    ruff format $py && changed="$changed $py"
-  elif command -v uvx >/dev/null 2>&1; then
-    # shellcheck disable=SC2086
-    uvx ruff format $py && changed="$changed $py"
-  else
-    warn "ruff/uv not found; skipped Python:$py"
-  fi
-fi
-
-# JS/TS — biome uses the single root biome.json. Pin the version to match the
-# formatting baseline so results do not drift.
-if [ -n "$web" ]; then
-  if command -v biome >/dev/null 2>&1; then
-    # shellcheck disable=SC2086
-    biome format --write $web && changed="$changed $web"
-  elif command -v pnpm >/dev/null 2>&1; then
-    # shellcheck disable=SC2086
-    pnpm dlx @biomejs/biome@1.9.4 format --write $web && changed="$changed $web"
-  else
-    warn "biome/pnpm not found; skipped TS/JS:$web"
-  fi
-fi
-
-# Re-stage whatever was reformatted so the commit captures the clean result.
-if [ -n "$changed" ]; then
-  # shellcheck disable=SC2086
-  git add -- $changed
-fi
+printf '[kungfu pre-commit] node not found; skipped format/lint/guard\n' >&2
 exit 0

--- a/no-bash-guard.mjs
+++ b/no-bash-guard.mjs
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: Apache-2.0
+//
+// Shared no-bash guard. The repo is fully migrated off .sh so every gate runs
+// under node on every platform (Windows included); a reintroduced *.sh silently
+// breaks off-Unix. One scan, two consumers:
+//   - verify.js stage 0a   → `node no-bash-guard.mjs`           (whole tree)
+//   - .githooks/pre-commit → imported scanStaged (only staged adds)
+//
+// Vendored/generated dirs may carry upstream .sh out of our control and are
+// skipped. The `.githooks/pre-commit` shim itself has no .sh extension, so it is
+// not a false positive.
+
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SKIP_DIRS = new Set(['node_modules', '.git', 'build', 'dist', 'out']);
+
+/** Repo-root path via git, or cwd if that fails. */
+export function repoRoot(cwd = process.cwd()) {
+  const r = spawnSync('git', ['rev-parse', '--show-toplevel'], {
+    cwd,
+    encoding: 'utf8',
+  });
+  return r.status === 0 ? r.stdout.trim() : cwd;
+}
+
+/** Every tracked-or-untracked *.sh under root, minus vendored/generated dirs. */
+export function scanTree(root) {
+  const hits = [];
+  const walk = (dir) => {
+    let entries;
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const e of entries) {
+      if (e.isDirectory()) {
+        if (!SKIP_DIRS.has(e.name)) walk(path.join(dir, e.name));
+      } else if (e.name.endsWith('.sh')) {
+        hits.push(path.relative(root, path.join(dir, e.name)));
+      }
+    }
+  };
+  walk(root);
+  return hits.sort();
+}
+
+/** Staged (Added/Copied/Modified) *.sh files — the pre-commit scope. */
+export function scanStaged(root) {
+  const r = spawnSync(
+    'git',
+    ['diff', '--cached', '--name-only', '--diff-filter=ACM'],
+    { cwd: root, encoding: 'utf8' },
+  );
+  if (r.status !== 0) return [];
+  return r.stdout
+    .split('\n')
+    .map((s) => s.trim())
+    .filter((f) => f.endsWith('.sh'))
+    .sort();
+}
+
+export function reportHits(
+  hits,
+  write = (s) => process.stderr.write(`${s}\n`),
+) {
+  write('bash scripts must be Node (.mjs) so gates run on Windows too:');
+  for (const h of hits) write(`  ${h}`);
+}
+
+// CLI: `node no-bash-guard.mjs [--staged]` — exit 1 (+ list) on any hit.
+if (
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+  const root = repoRoot();
+  const hits = process.argv.includes('--staged')
+    ? scanStaged(root)
+    : scanTree(root);
+  if (hits.length === 0) process.exit(0);
+  reportHits(hits);
+  process.exit(1);
+}

--- a/precommit.mjs
+++ b/precommit.mjs
@@ -1,0 +1,157 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: Apache-2.0
+//
+// kungfu pre-commit logic — all in Node so it runs identically on macOS, Linux
+// and Windows. The .githooks/pre-commit shim is a tiny POSIX sh file that only
+// execs this (git needs a launchable hook and sh is the one interpreter it ships
+// everywhere, incl. Git-for-Windows bundled bash); no checks live in the shim.
+//
+// On the staged (Added/Copied/Modified) set it, in order:
+//   1. blocks a reintroduced *.sh (shares the scan with verify.js stage 0a);
+//   2. auto-formats C++ (clang-format), Python (ruff) and re-stages;
+//   3. runs `biome check --write` on staged JS/TS: applies safe format + lint +
+//      import fixes, then BLOCKS on any remaining (unfixable) lint error.
+//
+// A missing formatter warns and skips — a setup gap must not block a commit; run
+// `./kungfu-code sync` to install the toolchain. A real .sh or an unfixable lint
+// error blocks. Bypass everything with `git commit -n`.
+// @ts-check
+
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { scanStaged } from './no-bash-guard.mjs';
+
+const isWin = process.platform === 'win32';
+
+function git(args, opts = {}) {
+  return spawnSync('git', args, { encoding: 'utf8', ...opts });
+}
+
+const ROOT = git(['rev-parse', '--show-toplevel']).stdout?.trim();
+if (!ROOT) process.exit(0);
+
+function warn(msg) {
+  process.stderr.write(`[kungfu pre-commit] ${msg}\n`);
+}
+
+/** command-on-PATH probe (which/where — real executables, not shell builtins). */
+function has(cmd) {
+  return (
+    spawnSync(isWin ? 'where' : 'which', [cmd], { stdio: 'ignore' }).status ===
+    0
+  );
+}
+
+/** Run a tool at ROOT, inheriting stdio so its output reaches the committer. */
+function run(cmd, args) {
+  return spawnSync(cmd, args, { cwd: ROOT, stdio: 'inherit' });
+}
+
+function isFile(rel) {
+  try {
+    return fs.statSync(path.join(ROOT, rel)).isFile();
+  } catch {
+    return false;
+  }
+}
+
+const staged = git(['diff', '--cached', '--name-only', '--diff-filter=ACM'])
+  .stdout.split('\n')
+  .map((s) => s.trim())
+  .filter(Boolean);
+if (staged.length === 0) process.exit(0);
+
+// ── 1. no-bash guard (fail fast) ───────────────────────────────────
+const shHits = scanStaged(ROOT);
+if (shHits.length) {
+  warn('bash scripts must be Node (.mjs) so gates run on Windows too:');
+  for (const h of shHits) warn(`  ${h}`);
+  process.exit(1);
+}
+
+// A file is "generated" if its path matches a known generated shape or its head
+// carries a generator marker; regeneration stays authoritative, so skip it.
+// Kept in sync with the ruff/biome exclude configs.
+function isGenerated(rel) {
+  if (
+    /(?:^|\/)generated\//.test(rel) ||
+    /\/fb\/[A-Z][^/]*\.py$/.test(rel) ||
+    /_fb\.py$/.test(rel) ||
+    /_generated\.[^/]+$/.test(rel)
+  ) {
+    return true;
+  }
+  try {
+    const head = fs
+      .readFileSync(path.join(ROOT, rel), 'utf8')
+      .split('\n', 3)
+      .join('\n');
+    return /automatically generated|do not (edit|modify)/i.test(head);
+  } catch {
+    return false;
+  }
+}
+
+const src = staged.filter((f) => isFile(f) && !isGenerated(f));
+const cpp = src.filter((f) => /\.(h|hpp|hxx|cpp|c|cc|cxx)$/.test(f));
+const py = src.filter((f) => /\.py$/.test(f));
+const web = src.filter((f) => /\.(ts|tsx|js|jsx|mjs|cjs)$/.test(f));
+const changed = [];
+
+// ── 2a. C++ — clang-format, pinned via uvx (byte-identical across machines) ──
+if (cpp.length) {
+  if (has('uvx')) {
+    run('uvx', ['clang-format@20.1.8', '-style=file', '-i', ...cpp]);
+    changed.push(...cpp);
+  } else if (has('clang-format')) {
+    warn('using system clang-format; may differ from pinned 20.1.8');
+    run('clang-format', ['-style=file', '-i', ...cpp]);
+    changed.push(...cpp);
+  } else {
+    warn(`clang-format (uv) not found; skipped C++: ${cpp.join(' ')}`);
+  }
+}
+
+// ── 2b. Python — ruff format (--force-exclude honors excludes on explicit args) ─
+if (py.length) {
+  if (has('ruff')) {
+    run('ruff', ['format', '--force-exclude', ...py]);
+    changed.push(...py);
+  } else if (has('uvx')) {
+    run('uvx', ['ruff', 'format', '--force-exclude', ...py]);
+    changed.push(...py);
+  } else {
+    warn(`ruff/uv not found; skipped Python: ${py.join(' ')}`);
+  }
+}
+
+// ── 2c/3. JS/TS — biome check --write: format + safe lint/import fixes, then a
+// non-zero exit means real (unfixable) lint errors remain → block. Explicit
+// paths still honor biome.json ignores (generated/, fixtures/), so ignored
+// staged files are simply skipped.
+let biomeBlocked = false;
+if (web.length) {
+  const biomeArgs = ['check', '--write', '--no-errors-on-unmatched', ...web];
+  let r = null;
+  if (has('biome')) r = run('biome', biomeArgs);
+  else if (has('pnpm')) r = run('pnpm', ['exec', 'biome', ...biomeArgs]);
+  else warn('biome/pnpm not found; skipped JS/TS format + lint');
+  if (r) {
+    changed.push(...web);
+    if (r.status !== 0) biomeBlocked = true;
+  }
+}
+
+// Re-stage exactly the files a formatter processed (parity with the prior hook:
+// unrelated unstaged edits to an untouched file are never captured).
+const restage = [...new Set(changed)].filter(isFile);
+if (restage.length) git(['add', '--', ...restage], { stdio: 'ignore' });
+
+if (biomeBlocked) {
+  warn(
+    'biome reported lint errors needing manual fixes (above); fix and re-stage, or `git commit -n` to bypass.',
+  );
+  process.exit(1);
+}
+process.exit(0);

--- a/verify.js
+++ b/verify.js
@@ -116,29 +116,23 @@ function main() {
   // Tooling drives its fixtures/slices/guards/benches through Node so it runs on
   // every platform pnpm runs on (Windows included). A bash `.sh` anywhere in the
   // tree silently breaks off-Unix — the repo is fully migrated (zero .sh), so
-  // guard the whole tree and fail loudly on any reintroduction. Vendored and
-  // generated dirs (node_modules, .git, build outputs) may carry upstream .sh
-  // and are out of our control, so they are skipped.
+  // fail loudly on any reintroduction. The scan is shared with the pre-commit
+  // hook via no-bash-guard.mjs (single source of truth); run it whole-tree here.
   console.log('\n[verify] stage 0a: no-bash script guard');
-  const shSkipDirs = new Set(['node_modules', '.git', 'build', 'dist']);
-  const shPaths = [];
-  const scanSh = (dir) => {
-    if (!fs.existsSync(dir)) return;
-    for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
-      if (e.isDirectory()) {
-        if (!shSkipDirs.has(e.name)) scanSh(path.join(dir, e.name));
-      } else if (e.name.endsWith('.sh')) {
-        shPaths.push(path.relative(ROOT, path.join(dir, e.name)));
-      }
-    }
-  };
-  scanSh(ROOT);
-  if (shPaths.length === 0)
+  const noBash = spawnSync(
+    process.execPath,
+    [path.join(ROOT, 'no-bash-guard.mjs')],
+    {
+      encoding: 'utf8',
+    },
+  );
+  if (noBash.status === 0)
     pass('no-bash script guard', 'gates are Node-only (cross-platform)');
   else
     fail(
       'no-bash script guard',
-      `bash scripts must be Node (.mjs) so the gate runs on Windows too:\n  ${shPaths.join('\n  ')}`,
+      `${noBash.stdout || ''}${noBash.stderr || ''}`.trim() ||
+        'bash scripts must be Node (.mjs) so the gate runs on Windows too',
     );
 
   // ── Stage 0: toolchain preflight (read-only) ──────────────────────


### PR DESCRIPTION
JS-ify the pre-commit hook so it works on Windows: all logic moves to precommit.mjs (staged .sh guard, clang-format/ruff format, biome check --write that blocks on unfixable lint), .githooks/pre-commit becomes a thin POSIX exec-node shim, and the no-bash scan is extracted to no-bash-guard.mjs shared with verify stage 0a. Validated on macOS: sh-block / format+restage / lint-block all behave.