### PR TITLE
fix(skill): load manager view in gui renderer

### DIFF
--- a/extensions/system/skill-manager/src/view/index.tsx
+++ b/extensions/system/skill-manager/src/view/index.tsx
@@ -20,6 +20,24 @@ function asSkillManagerView(value: unknown): SkillManagerView | null {
   return null;
 }
 
+function readSkillManagerViewFromEnv(): SkillManagerView | null {
+  try {
+    const win = window as unknown as {
+      require?: (id: string) => {
+        readFileSync: (p: string, enc: string) => string;
+      };
+      process?: { env?: Record<string, string | undefined> };
+    };
+    const managerPath = win.process?.env?.KF_SKILL_MANAGER_FILE;
+    if (!managerPath || !win.require) return null;
+    return asSkillManagerView(
+      JSON.parse(win.require('node:fs').readFileSync(managerPath, 'utf8')),
+    );
+  } catch {
+    return null;
+  }
+}
+
 function packageLabel(
   row: SkillManagerEntry['dependencies']['dependencies'][0],
 ) {
@@ -29,7 +47,9 @@ function packageLabel(
 }
 
 function SkillManagerViewComponent({ shell }: KfxViewProps) {
-  const view = asSkillManagerView(shell.info.skillManager);
+  const view =
+    asSkillManagerView(shell.info.skillManager) ??
+    readSkillManagerViewFromEnv();
   const cell: React.CSSProperties = { padding: '2px 12px 2px 0' };
   if (!view) {
     return (

--- a/framework/gui/src/renderer/src/runtime.ts
+++ b/framework/gui/src/renderer/src/runtime.ts
@@ -171,9 +171,20 @@ export function bootRuntime(): Runtime {
     let skillManager: Record<string, unknown> | null = null;
     try {
       const fs = window.require('node:fs');
-      const managerPath = env.KF_SKILL_MANAGER_FILE;
-      if (managerPath) {
-        skillManager = JSON.parse(fs.readFileSync(managerPath, 'utf8'));
+      const path = window.require('node:path');
+      const managerPaths = [
+        env.KF_SKILL_MANAGER_FILE,
+        runtimeDir
+          ? path.join(runtimeDir, 'skill-manager', 'default.json')
+          : '',
+      ].filter((p): p is string => Boolean(p));
+      for (const managerPath of managerPaths) {
+        try {
+          skillManager = JSON.parse(fs.readFileSync(managerPath, 'utf8'));
+          break;
+        } catch {
+          skillManager = null;
+        }
       }
     } catch {
       skillManager = null;


### PR DESCRIPTION
## Summary
- load the Skill Manager JSON from the renderer runtime fallback path when the shell info payload is unavailable
- let the Skill Manager system view read KF_SKILL_MANAGER_FILE directly as a last-resort fallback
- keep the rendered dependency table available for GUI dogfood runs with a precomputed Node manager state

## Validation
- node ../../../developer/sdk/src/sdk.js kfx build (extensions/system/skill-manager)
- ./kungfu-code --filter @kungfu-tech/gui run build
- ./kungfu-code exec biome check framework/gui/src/renderer/src/runtime.ts extensions/system/skill-manager/src/view/index.tsx
- launched the GUI with KF_RUNTIME_DIR, KF_SKILL_PATH, KF_SKILL_MANAGER_FILE, and KFE_INITIAL_VIEW=skill-manager; verified the Skill Manager page shows 2 installed skills and 1 unresolved required kfx