### PR TITLE
feat(gui,terminal): render the live terminal in a per-session window (ADR-0016 stage 3)

### DIFF
--- a/extensions/terminal/src/view/index.tsx
+++ b/extensions/terminal/src/view/index.tsx
@@ -837,4 +837,116 @@ function SessionWorkspace({
   );
 }
 
-export const View = SessionWorkspace;
+// The content of a per-session OS window (ADR-0016 stage 3): it adopts one
+// already-created session by runId over the shared main-process host and renders
+// a single full-window pane, replacing the stage-2 placeholder page. It owns no
+// launcher, tray, or layout persistence — the in-shell grid owns those; this
+// window is only a view onto one session. Closing the window never ends the
+// session (window identity is separate from session identity, ADR-0016): detach
+// keeps the agent running and kill ends it, and either way the window closes.
+function SingleSessionWindow({
+  caps,
+  runId,
+}: { caps: KfxCapabilities; runId: string }) {
+  const [pane, setPane] = React.useState<Pane | null>(null);
+  const [error, setError] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        // The session already exists on the shared host; just read its snapshot
+        // to label the pane. The pane attaches to the live stream on its own.
+        const session = await resolve(caps.terminal.get(runId));
+        if (cancelled) return;
+        if (!session) {
+          setError(`session ${runId} is not on the host`);
+          return;
+        }
+        setPane({
+          key: session.runId,
+          runId: session.runId,
+          title: `${session.provider ?? 'agent'} · ${session.command}`,
+          provider: session.provider ?? 'agent',
+          pid: session.pid,
+          startedAt: session.startedAt,
+          durable: session.backend === 'tmux',
+          command: session.command,
+          args: session.args,
+          cwd: session.cwd,
+        });
+      } catch (e) {
+        if (!cancelled) setError((e as Error).message);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [caps.terminal, runId]);
+
+  const frame: React.CSSProperties = {
+    height: '100vh',
+    boxSizing: 'border-box',
+    padding: 8,
+    background: '#1e1e1e',
+  };
+
+  if (error) {
+    return (
+      <div style={{ ...frame, ...mono, fontSize: 12, color: '#c46b6b' }}>
+        {error}
+      </div>
+    );
+  }
+  if (!pane) {
+    return (
+      <div style={{ ...frame, ...mono, fontSize: 12, color: '#7a7a7a' }}>
+        attaching to session {runId}…
+      </div>
+    );
+  }
+  return (
+    // one grid cell that stretches the pane to fill the window, the same way the
+    // in-shell grid stretches a cell — SessionPane needs a stretching parent
+    <div
+      style={{
+        ...frame,
+        display: 'grid',
+        gridTemplateColumns: '1fr',
+        gridTemplateRows: '1fr',
+      }}
+    >
+      <SessionPane
+        caps={caps}
+        pane={pane}
+        onDetach={(p) => {
+          try {
+            caps.terminal.detach(p.runId);
+          } catch {
+            // a direct (non-tmux) session has nothing to detach; close anyway
+          }
+          window.close();
+        }}
+        onKill={(p) => {
+          try {
+            caps.terminal.kill(p.runId);
+          } catch {
+            // best-effort; close the window regardless
+          }
+          window.close();
+        }}
+      />
+    </div>
+  );
+}
+
+// The kfx entry. In the shell it renders the full session workspace; opened as a
+// per-session OS window (ADR-0016 stage 3) the renderer passes the target runId
+// through `shell.params.sessionWindowRunId`, and it renders that one session.
+function View({ caps, shell }: { caps: KfxCapabilities; shell: Shell }) {
+  const runId = shell.params?.sessionWindowRunId;
+  if (runId) return <SingleSessionWindow caps={caps} runId={runId} />;
+  return <SessionWorkspace caps={caps} shell={shell} />;
+}
+
+export { View };

--- a/framework/gui/electron.vite.config.mjs
+++ b/framework/gui/electron.vite.config.mjs
@@ -75,8 +75,9 @@ function nodeBuiltinRequireShim() {
 // - preload: the sandbox preload — the only bridge an isolated sandboxed view
 //   gets (contextBridge exposes __kfxBridge); built as its own entry.
 // - renderer: react; keep electron and the native binding external so the
-//   trusted renderer require()s them at runtime under nodeIntegration. Two html
-//   entries: the shell (index) and the isolated sandboxed-view harness.
+//   trusted renderer require()s them at runtime under nodeIntegration. Three html
+//   entries: the shell (index), the isolated sandboxed-view harness, and the
+//   per-session OS window (session-window, ADR-0016 stage 3).
 export default defineConfig({
   main: {
     plugins: [
@@ -111,6 +112,12 @@ export default defineConfig({
           'sandbox-view-harness': resolve(
             rootDir,
             'src/renderer/sandbox-view-harness/index.html',
+          ),
+          // per-session OS window (ADR-0016 stage 3); node-integrated like the
+          // shell, mounts the terminal view against one runId over the relay
+          'session-window': resolve(
+            rootDir,
+            'src/renderer/session-window/index.html',
           ),
         },
       },

--- a/framework/gui/src/main/session-windows-host.ts
+++ b/framework/gui/src/main/session-windows-host.ts
@@ -7,6 +7,7 @@
 // app exactly as it is (parity by construction); the multi-window path is
 // exercised by flipping the flag on a real machine, the discipline ADR-0016
 // stage 1 used for the main-process host.
+import path from 'node:path';
 import { BrowserWindow, type IpcMain, screen } from 'electron';
 
 import {
@@ -31,41 +32,20 @@ function toDisplayInfo(d: Electron.Display): DisplayInfo {
   return { id: displayKey(d), workArea: d.workArea };
 }
 
-function escapeHtml(s: string): string {
-  return s.replace(/[<>&"]/g, (c) => {
-    switch (c) {
-      case '<':
-        return '&lt;';
-      case '>':
-        return '&gt;';
-      case '&':
-        return '&amp;';
-      case '"':
-        return '&quot;';
-      default:
-        return c;
-    }
-  });
-}
-
-// A minimal placeholder page (ADR-0016 stage 2). What stage 2 proves is the
-// window lifecycle, bounds, F7 restore and persistence; mounting the real
-// terminal view against this window's runId over the host proxy is stage 3,
-// which swaps this data: URL for a session-window renderer entry.
-function placeholderPage(runId: string, windowId: string): string {
-  const r = escapeHtml(runId);
-  const w = escapeHtml(windowId);
-  return [
-    '<!doctype html><meta charset="utf-8">',
-    `<title>Session ${r}</title>`,
-    '<style>html,body{margin:0;height:100%;background:#1e1e1e;color:#ddd;',
-    'font:14px/1.6 -apple-system,system-ui,sans-serif;display:flex;',
-    'align-items:center;justify-content:center}main{text-align:center}',
-    'code{color:#6cf}small{color:#888}</style>',
-    `<main><div>managed session <code>${r}</code></div>`,
-    '<div><small>ADR-0016 stage 2 — window shell (terminal view lands in stage 3)</small></div>',
-    `<div><small>window ${w}</small></div></main>`,
-  ].join('');
+// The per-session window renderer entry, with the runId it should mount (and its
+// windowId, for logging). Dev serves it from the electron-vite dev server; a
+// packaged app loads the built file — the same dev/prod split the shell and the
+// sandbox harness use. Query is percent-encoded, so a runId is safe in the URL.
+function sessionWindowEntry(runId: string, windowId: string): string {
+  const query =
+    `?runId=${encodeURIComponent(runId)}` +
+    `&windowId=${encodeURIComponent(windowId)}`;
+  return process.env.ELECTRON_RENDERER_URL
+    ? `${process.env.ELECTRON_RENDERER_URL}/session-window/index.html${query}`
+    : `file://${path.join(
+        __dirname,
+        '../renderer/session-window/index.html',
+      )}${query}`;
 }
 
 function createSessionWindow(args: {
@@ -82,17 +62,17 @@ function createSessionWindow(args: {
     backgroundColor: '#1e1e1e',
     title: `Session ${args.runId}`,
     webPreferences: {
-      nodeIntegration: false,
-      contextIsolation: true,
-      sandbox: true,
+      // ADR-0016 stage 3: the window renderer mounts the terminal view and
+      // reaches the main-process host over the relay via ipcRenderer, so it runs
+      // node-integrated like the shell (a first-party window loading a
+      // first-party bundle) rather than the stage-2 sandboxed placeholder.
+      nodeIntegration: true,
+      contextIsolation: false,
+      sandbox: false,
     },
   });
   win.on('ready-to-show', () => win.show());
-  void win.loadURL(
-    `data:text/html;charset=utf-8,${encodeURIComponent(
-      placeholderPage(args.runId, args.windowId),
-    )}`,
-  );
+  void win.loadURL(sessionWindowEntry(args.runId, args.windowId));
   return {
     getBounds: () => win.getBounds(),
     focus: () => {

--- a/framework/gui/src/main/terminal-host.ts
+++ b/framework/gui/src/main/terminal-host.ts
@@ -110,8 +110,17 @@ type SubscribeMethod = 'onData' | 'onExit';
 // method; `subscribe` opens an onData/onExit stream whose events are pushed via
 // the per-subscription `emit`; `unsubscribe` releases exactly that stream. The
 // subId is minted by the guest, so stop() on the guest maps back to one stream.
+//
+// Subscriptions are keyed by `<clientKey>:<subId>`, not by subId alone: since
+// ADR-0016 stage 3 the shell and each per-session OS window are separate guest
+// renderers reaching this one host, and each mints its own subId sequence from
+// scratch. Keyed by subId alone, the second guest's subId 1 would evict the
+// first guest's subId 1 (the defensive replace below), silently killing an
+// unrelated live pane. The clientKey (the sender's webContents id, supplied by
+// the glue) namespaces those sequences so guests never collide.
 export function createTerminalRelay(host: Terminal) {
-  const subs = new Map<number, Subscription>();
+  const subs = new Map<string, Subscription>();
+  const subKey = (clientKey: string, subId: number) => `${clientKey}:${subId}`;
   return {
     async call(method: string, args: unknown[]): Promise<unknown> {
       const fn = (host as unknown as Record<string, unknown>)[method];
@@ -121,22 +130,38 @@ export function createTerminalRelay(host: Terminal) {
       return await (fn as (...a: unknown[]) => unknown).apply(host, args);
     },
     subscribe(
+      clientKey: string,
       method: SubscribeMethod,
       runId: string,
       subId: number,
       emit: (args: unknown[]) => void,
     ): void {
-      // replace any prior stream on this subId (defensive; guest ids are unique)
-      subs.get(subId)?.stop();
+      const key = subKey(clientKey, subId);
+      // replace any prior stream on this key (defensive; a guest's ids are
+      // unique within itself, and the clientKey separates guests)
+      subs.get(key)?.stop();
       const sub =
         method === 'onExit'
           ? host.onExit(runId, (exit) => emit([exit]))
           : host.onData(runId, (data) => emit([data]));
-      subs.set(subId, sub);
+      subs.set(key, sub);
     },
-    unsubscribe(subId: number): void {
-      subs.get(subId)?.stop();
-      subs.delete(subId);
+    unsubscribe(clientKey: string, subId: number): void {
+      const key = subKey(clientKey, subId);
+      subs.get(key)?.stop();
+      subs.delete(key);
+    },
+    // Release every stream a guest holds when its webContents goes away without
+    // unsubscribing (a session window closed abruptly): the host must neither
+    // leak the subscriptions nor keep emitting into a destroyed sender.
+    unsubscribeClient(clientKey: string): void {
+      const prefix = `${clientKey}:`;
+      for (const [key, sub] of subs) {
+        if (key.startsWith(prefix)) {
+          sub.stop();
+          subs.delete(key);
+        }
+      }
     },
     dispose(): void {
       for (const sub of subs.values()) sub.stop();
@@ -148,7 +173,16 @@ export function createTerminalRelay(host: Terminal) {
 // ── electron glue ───────────────────────────────────────────────────────────
 
 type TerminalInvokeEvent = {
-  sender: { send: (channel: string, payload: unknown) => void };
+  // The subscribing renderer's webContents. `id` namespaces this guest's subId
+  // sequence in the relay (ADR-0016 stage 3 gives the shell and every session
+  // window their own sequence); `isDestroyed`/`once('destroyed')` let the host
+  // stop emitting into — and release the streams of — a window that closed.
+  sender: {
+    id: number;
+    send: (channel: string, payload: unknown) => void;
+    isDestroyed?: () => boolean;
+    once?: (event: 'destroyed', listener: () => void) => void;
+  };
 };
 
 type IpcMainLike = {
@@ -161,6 +195,8 @@ type IpcMainLike = {
 
 export function bindElectronTerminalHost(ipcMain: IpcMainLike, host: Terminal) {
   const relay = createTerminalRelay(host);
+  // guests we have wired a destroyed-cleanup for, so we register it once each
+  const cleanupWired = new Set<number>();
   ipcMain.handle(TERMINAL_CALL_CHANNEL, (_event, payload) => {
     const { method, args } = payload as { method: string; args: unknown[] };
     return relay.call(method, args);
@@ -171,15 +207,28 @@ export function bindElectronTerminalHost(ipcMain: IpcMainLike, host: Terminal) {
       runId: string;
       subId: number;
     };
+    const sender = event.sender;
+    const clientKey = String(sender.id);
+    // A per-session window can close without its React cleanup running (the
+    // whole webContents is torn down); release every stream it held so the host
+    // stops emitting into a dead sender and does not leak.
+    if (!cleanupWired.has(sender.id)) {
+      cleanupWired.add(sender.id);
+      sender.once?.('destroyed', () => {
+        relay.unsubscribeClient(clientKey);
+        cleanupWired.delete(sender.id);
+      });
+    }
     // events go back to the renderer that subscribed
-    relay.subscribe(method, runId, subId, (args) =>
-      event.sender.send(TERMINAL_EVENT_CHANNEL, { subId, args }),
-    );
+    relay.subscribe(clientKey, method, runId, subId, (args) => {
+      if (sender.isDestroyed?.()) return;
+      sender.send(TERMINAL_EVENT_CHANNEL, { subId, args });
+    });
     return undefined;
   });
-  ipcMain.handle(TERMINAL_UNSUBSCRIBE_CHANNEL, (_event, payload) => {
+  ipcMain.handle(TERMINAL_UNSUBSCRIBE_CHANNEL, (event, payload) => {
     const { subId } = payload as { subId: number };
-    relay.unsubscribe(subId);
+    relay.unsubscribe(String(event.sender.id), subId);
     return undefined;
   });
   return {

--- a/framework/gui/src/renderer/session-window/index.html
+++ b/framework/gui/src/renderer/session-window/index.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Kungfu session</title>
+    <style>
+      html,
+      body,
+      #root {
+        margin: 0;
+        height: 100%;
+        background: #1e1e1e;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./main.tsx"></script>
+  </body>
+</html>

--- a/framework/gui/src/renderer/session-window/main.tsx
+++ b/framework/gui/src/renderer/session-window/main.tsx
@@ -1,0 +1,89 @@
+// Per-session OS window renderer (ADR-0016 stage 3). A separate BrowserWindow
+// renderer that mounts the terminal view against a single runId, reaching the
+// durable session host in the main process over the terminal relay — the same
+// host the shell's grid uses, so a session renders identically in the grid and
+// in its own window. Node-integrated like the shell because it needs ipcRenderer
+// to reach the relay; unlike the shell it holds no zero-copy runtime, only the
+// terminal proxy, because a session window renders one live terminal and nothing
+// else. The stage-2 placeholder page is replaced by this entry.
+import * as capability from '@kungfu-tech/api/capability';
+import type { KfxCapabilities, KfxEntry, Shell } from '@kungfu-tech/kfx';
+import React from 'react';
+import * as ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
+import * as jsxRuntime from 'react/jsx-runtime';
+import { loadKfx } from '../src/kfx-loader';
+import {
+  type IpcRendererLike,
+  createTerminalProxy,
+} from '../src/terminal-proxy';
+
+// The externals contract `kungfu sdk kfx build` injects into every kfx bundle:
+// one React instance and one capability surface (see renderer/src/main.tsx).
+const SHARED_MODULES = {
+  react: React,
+  'react/jsx-runtime': jsxRuntime,
+  'react-dom': ReactDOM,
+  '@kungfu-tech/api': capability,
+  '@kungfu-tech/api/capability': capability,
+};
+
+// Render a plain failure line into #root. A session window has no shell chrome
+// to fall back to, so a misconfigured launch should still say why.
+function fail(message: string): void {
+  const root = document.getElementById('root');
+  if (!root) return;
+  root.textContent = message;
+  root.setAttribute(
+    'style',
+    'height:100vh;display:flex;align-items:center;justify-content:center;' +
+      'color:#c46b6b;font:12px/1.5 monospace;padding:16px;text-align:center',
+  );
+}
+
+function main(): void {
+  const runId = new URLSearchParams(window.location.search).get('runId');
+  if (!runId) {
+    fail('session window opened without a runId');
+    return;
+  }
+
+  // The durable host runs in the main process (ADR-0016); a window can only reach
+  // it over ipc, so this renderer is always a relay client and never owns an
+  // in-renderer host.
+  let ipc: IpcRendererLike;
+  try {
+    ipc = (window.require('electron') as { ipcRenderer: IpcRendererLike })
+      .ipcRenderer;
+  } catch (e) {
+    fail(`electron ipc unavailable: ${(e as Error).message}`);
+    return;
+  }
+  const terminal = createTerminalProxy(ipc);
+
+  // Load the terminal kfx the same way the shell does, so its code and its CSS
+  // (injected by loadKfx) match the grid exactly; the single-session branch is
+  // selected by shell.params.sessionWindowRunId below.
+  const loaded = loadKfx(window.process.env, SHARED_MODULES);
+  const entry = loaded.entries.find(
+    (e: KfxEntry) =>
+      e.tier === 'node-integrated' && e.capabilities.includes('terminal'),
+  );
+  if (!entry) {
+    fail('terminal view not found on the extension path');
+    return;
+  }
+
+  // Only caps.terminal is real and only shell.params is read (to select the
+  // single-session branch and carry the runId); the rest of the capability and
+  // shell surfaces are absent by construction — this window is a view onto one
+  // live session, not the full workspace.
+  const caps = { terminal } as unknown as KfxCapabilities;
+  const shell = { params: { sessionWindowRunId: runId } } as unknown as Shell;
+
+  createRoot(document.getElementById('root') as HTMLElement).render(
+    <entry.View caps={caps} shell={shell} />,
+  );
+}
+
+main();

--- a/framework/gui/src/renderer/src/main.tsx
+++ b/framework/gui/src/renderer/src/main.tsx
@@ -234,13 +234,23 @@ function App() {
   );
   const activeKfx = enabled.find((k) => k.id === active) ?? enabled[0] ?? null;
 
-  // ADR-0016 stage 2: expose per-session OS window control to views through the
+  // ADR-0016 stage 2/3: expose per-session OS window control to views through the
   // shell so a view stays electron-free. Present only when the flag is on and
   // this (node-integrated) renderer can reach ipc; absent otherwise, so a view
   // feature-detects and hides the affordance. Built once — the ipc handle and
   // flag are stable over the shell's life.
+  //
+  // Also requires the durable host to run in the main process (stage 3): a
+  // popped-out window renders the live terminal by reaching that shared host over
+  // the relay, which is impossible when the host lives in this renderer. So
+  // pop-out is offered only when both flags are on, never a window that cannot
+  // reach its session.
   const sessionWindowShell = React.useMemo<Partial<Shell>>(() => {
-    if (window.process?.env?.KF_SESSION_WINDOWS !== '1') return {};
+    if (
+      window.process?.env?.KF_SESSION_WINDOWS !== '1' ||
+      window.process?.env?.KF_TERMINAL_HOST !== 'main'
+    )
+      return {};
     type SessionWindowIpc = {
       invoke: (channel: string, payload: unknown) => Promise<unknown>;
       on: (


### PR DESCRIPTION
Replace the stage-2 placeholder in each per-session OS window with the real terminal view, mounted against one runId over the main-process session host, so a session renders identically in the in-shell grid and in its own window. Adds a node-integrated session-window renderer entry, the electron-vite html entry for it, and dispatches the terminal kfx View on shell.params.sessionWindowRunId. Also namespaces terminal-host relay subscriptions by webContents id so the shell and each session window (now separate guest renderers on one host) no longer collide subIds and silently kill an unrelated pane, with destroyed-sender cleanup. Behind KF_SESSION_WINDOWS, default off; type-checks, builds, and passed a real-machine check (pop-out live terminal, grid pane survives pop-out, cross-display drag, quit/relaunch restore).