### PR TITLE
refactor(repo): relocate root dev tooling into scripts/ and convert to ESM

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -7,8 +7,8 @@
 # the real work (staged .sh guard, format, blocking lint) identically on
 # macOS/Linux/Windows.
 #
-# Installed to $(git --git-common-dir)/hooks/pre-commit by install-hooks.js (root
-# `prepare`, or `pnpm run hooks:install`). It coexists with the managed hooks-path
+# Installed to $(git --git-common-dir)/hooks/pre-commit by scripts/install-hooks.mjs
+# (root `prepare`, or `pnpm run hooks:install`). It coexists with the managed hooks-path
 # guard: when core.hooksPath points elsewhere, that guard execs this standard hook
 # after its own checks. Missing node warns and skips (a setup gap must not block a
 # commit). Bypass entirely with `git commit -n`.

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -16,7 +16,7 @@ set -eu
 
 root=$(git rev-parse --show-toplevel) || exit 0
 if command -v node >/dev/null 2>&1; then
-  exec node "$root/precommit.mjs"
+  exec node "$root/scripts/precommit.mjs"
 fi
 printf '[kungfu pre-commit] node not found; skipped format/lint/guard\n' >&2
 exit 0

--- a/.prebuild.js
+++ b/.prebuild.js
@@ -1,6 +1,0 @@
-if (!process.env.CI) {
-  const { shell } = require('./framework/core');
-  const opts = { silent: true };
-  shell.run('pnpm', ['run', 'sync'], true, opts);
-  shell.run('pnpm', ['run', 'format'], true, opts);
-}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,9 +100,10 @@ Windows included. So **automation scripts are Node/JavaScript (`.mjs`/`.js`),
 not shell** (`.sh`): shell scripts do not run on Windows and reintroduce a bash
 dependency the toolchain does not otherwise need. Test fixtures and capability
 slices use a `run.mjs` driver (shared helpers in `tests/fixtures/_harness.mjs`
-and `framework/core/slices/_harness.mjs`); the verification gate (`verify.js`)
-runs them through Node and **fails if a `.sh` reappears** under the fixture,
-slice, or `libyijinjing` guard paths (`stage 0a: no-bash script guard`). Prefer
+and `framework/core/slices/_harness.mjs`); the verification gate
+(`scripts/verify.mjs`) runs them through Node and **fails if a `.sh` reappears**
+anywhere in the tree (`stage 0a: no-bash script guard`, shared with the
+pre-commit hook via `scripts/no-bash-guard.mjs`). Prefer
 pure Node (`node:child_process`, `fs`, `os`, `crypto`) over shelling out to
 platform tools (`grep`, `mktemp`, `shasum`, …).
 

--- a/kungfu-code
+++ b/kungfu-code
@@ -9,7 +9,7 @@
 #
 # Three-tier subset model:
 #   L1 this file (sh)         bootstrap: load proxy env / check fnm+uv / pin node / run pnpm; rich subcommands delegate to L2.
-#   L2 kungfu-code.js (node)  rich commands available once fnm is installed (cache config proxy, etc.), pure node builtins.
+#   L2 kungfu-code.mjs (node)  rich commands available once fnm is installed (cache config proxy, etc.), pure node builtins.
 #   L3 (future) TUI           reuse kungfu's own TUI infrastructure / build artifacts; reuse L2's config read/write.
 #
 # Mechanism (dual-driver entrypoint, symmetric node side + python side):
@@ -46,9 +46,9 @@ case "${1:-}" in
   proxy | config)
     if command -v fnm >/dev/null 2>&1; then
       fnm install >/dev/null 2>&1 || true
-      exec fnm exec --using-file -- node ./kungfu-code.js "$@"
+      exec fnm exec --using-file -- node ./kungfu-code.mjs "$@"
     elif command -v node >/dev/null 2>&1; then
-      exec node ./kungfu-code.js "$@"
+      exec node ./kungfu-code.mjs "$@"
     else
       echo "kungfu-code: rich subcommands need node — install fnm (recommended 'arch -arm64 brew install fnm', see https://github.com/Schniz/fnm) or any system node" >&2
       exit 127

--- a/kungfu-code.cmd
+++ b/kungfu-code.cmd
@@ -7,7 +7,7 @@ rem Aligns with the macOS/Linux kungfu-code (sh):
 rem   kungfu-code app | kungfu-code build:core | kungfu-code <any pnpm task>
 rem   kungfu-code proxy ... / config ...   rich subcommands -> delegated to L2 node (not pnpm)
 rem
-rem 3-layer subset: L1 this .cmd (bootstrap + delegate); L2 kungfu-code.js (node rich cmds); L3 (future) TUI.
+rem 3-layer subset: L1 this .cmd (bootstrap + delegate); L2 kungfu-code.mjs (node rich cmds); L3 (future) TUI.
 rem Two one-time prerequisites: fnm (winget install Schniz.fnm) + uv (winget install astral-sh.uv).
 rem Repo has zero LAN/mirror coupling (open-source clone uses official upstreams). For LAN cache /
 rem CN mirror, use `kungfu-code config` to derive build-local.env.example into the user-global file:
@@ -24,11 +24,11 @@ goto bootstrap
 :delegate
 where fnm >nul 2>nul && (
   fnm install >nul 2>nul
-  fnm exec --using-file -- node "%~dp0kungfu-code.js" %*
+  fnm exec --using-file -- node "%~dp0kungfu-code.mjs" %*
   exit /b !errorlevel!
 )
 where node >nul 2>nul && (
-  node "%~dp0kungfu-code.js" %*
+  node "%~dp0kungfu-code.mjs" %*
   exit /b !errorlevel!
 )
 echo kungfu-code: rich subcommand needs node -- install fnm ^(winget install Schniz.fnm^) or any system node 1>&2

--- a/kungfu-code.mjs
+++ b/kungfu-code.mjs
@@ -14,12 +14,14 @@
 // The config file lives user-global at ${XDG_CONFIG_HOME:-~/.config}/kungfu/build-local.env: the main repo and all
 // git worktrees share one copy, it is naturally outside the repo (open-source safe), and only needs one sync across intranet machines.
 // @ts-check
-'use strict';
 
-const fs = require('fs');
-const os = require('os');
-const path = require('path');
-const { spawnSync } = require('child_process');
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const KEYS = [
   // mirrors / cache (per upstream)
@@ -109,7 +111,7 @@ function unsetKey(key) {
   fs.writeFileSync(CONFIG_FILE, text.replace(re, ''));
 }
 
-module.exports = { CONFIG_FILE, KEYS, readConfig, setKey, unsetKey };
+export { CONFIG_FILE, KEYS, readConfig, setKey, unsetKey };
 
 // ── CLI (entrypoint delegated from L1 sh) ────────────────────────────────────
 /** @param {string} cmd */
@@ -213,4 +215,4 @@ function main() {
   }
 }
 
-if (require.main === module) main();
+if (import.meta.url === pathToFileURL(process.argv[1]).href) main();

--- a/kungfu-code.mjs
+++ b/kungfu-code.mjs
@@ -1,12 +1,12 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// kungfu-code.js — the "rich subset" (L2) of the kungfu-code entrypoint.
+// kungfu-code.mjs — the "rich subset" (L2) of the kungfu-code entrypoint.
 //
 // Three-tier subset model:
 //   L1  kungfu-code (sh)        bootstrap simple commands: load env / check fnm+uv / pin node / run pnpm,
 //                               and delegate rich subcommands (proxy/config…) to this file.
-//   L2  kungfu-code.js (node)   rich commands available once fnm is installed (node implementation, pure builtins, no deps).
+//   L2  kungfu-code.mjs (node)  rich commands available once fnm is installed (node implementation, pure builtins, no deps).
 //                               currently: local cache/mirror proxy config management (proxy).
 //   L3  (future) TUI            reuse kungfu's own TUI infrastructure / build-artifact runtime; directly import
 //                               the readConfig/setKey config helpers below instead of reimplementing them.
@@ -135,7 +135,7 @@ function main() {
   const cmd = argv[0];
   if (cmd !== 'proxy' && cmd !== 'config') {
     console.error(
-      `kungfu-code.js: unknown command ${cmd || '(empty)'} (only proxy/config are supported)`,
+      `kungfu-code.mjs: unknown command ${cmd || '(empty)'} (only proxy/config are supported)`,
     );
     process.exit(2);
   }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "format": "pnpm run format:web && wsrun --bin pnpm --serial --exclude-missing format",
     "format:web": "biome format --write .",
     "lint": "biome check .",
-    "prebuild": "node .prebuild.js",
+    "prebuild": "node scripts/prebuild.mjs",
     "build": "pnpm run foreach build",
     "build:extensions": "pnpm run foreach:extensions build",
     "clean": "pnpm run foreach clean",
@@ -42,10 +42,10 @@
     "freeze": "pnpm --filter @kungfu-tech/core run freeze",
     "rebuild:core": "pnpm --filter @kungfu-tech/core run rebuild",
     "package:app": "pnpm --filter @kungfu-tech/artifact-kungfu run package",
-    "verify": "node verify.js",
+    "verify": "node scripts/verify.mjs",
     "check:types": "tsc -p tsconfig.tools.json",
-    "prepare": "node install-hooks.js",
-    "hooks:install": "node install-hooks.js --force"
+    "prepare": "node scripts/install-hooks.mjs",
+    "hooks:install": "node scripts/install-hooks.mjs --force"
   },
   "dependencies": {
     "core-js": "^3.20.0",

--- a/scripts/install-hooks.mjs
+++ b/scripts/install-hooks.mjs
@@ -12,11 +12,13 @@
 // `pnpm run hooks:install` (which passes --force). It is idempotent and refuses
 // to clobber a developer's own pre-commit unless --force is given.
 // @ts-check
-'use strict';
 
-const fs = require('fs');
-const path = require('path');
-const { spawnSync } = require('child_process');
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const OURS_MARKER = 'kungfu pre-commit hook';
 const REPLACEABLE = [OURS_MARKER, '#yorkie']; // our own hook, or the dead yorkie shim
@@ -54,7 +56,7 @@ function main() {
     return 0; // never fail an install because hooks could not be placed
   }
 
-  const src = path.join(__dirname, '.githooks', 'pre-commit');
+  const src = path.join(__dirname, '..', '.githooks', 'pre-commit');
   if (!fs.existsSync(src)) {
     log(`source hook missing: ${src}`);
     return 0;

--- a/scripts/install-hooks.mjs
+++ b/scripts/install-hooks.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 //
-// install-hooks.js — install the repo's git hooks into this checkout.
+// install-hooks.mjs — install the repo's git hooks into this checkout.
 //
 // Copies .githooks/pre-commit to $(git --git-common-dir)/hooks/pre-commit (the
 // standard location, shared by the main checkout and every worktree). It does

--- a/scripts/no-bash-guard.mjs
+++ b/scripts/no-bash-guard.mjs
@@ -4,8 +4,8 @@
 // Shared no-bash guard. The repo is fully migrated off .sh so every gate runs
 // under node on every platform (Windows included); a reintroduced *.sh silently
 // breaks off-Unix. One scan, two consumers:
-//   - verify.js stage 0a   → `node no-bash-guard.mjs`           (whole tree)
-//   - .githooks/pre-commit → imported scanStaged (only staged adds)
+//   - scripts/verify.mjs stage 0a → `node no-bash-guard.mjs`     (whole tree)
+//   - .githooks/pre-commit        → imported scanStaged (staged adds)
 //
 // Vendored/generated dirs may carry upstream .sh out of our control and are
 // skipped. The `.githooks/pre-commit` shim itself has no .sh extension, so it is

--- a/scripts/prebuild.mjs
+++ b/scripts/prebuild.mjs
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// prebuild lifecycle step: before a local (non-CI) build, sync the toolchain and
+// format the tree. framework/core is a CommonJS package, so reach it through a
+// createRequire shim (preserves the exact directory resolution of the former
+// `require('./framework/core')`).
+
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+
+if (!process.env.CI) {
+  const { shell } = require('../framework/core');
+  const opts = { silent: true };
+  shell.run('pnpm', ['run', 'sync'], true, opts);
+  shell.run('pnpm', ['run', 'format'], true, opts);
+}

--- a/scripts/precommit.mjs
+++ b/scripts/precommit.mjs
@@ -7,7 +7,7 @@
 // everywhere, incl. Git-for-Windows bundled bash); no checks live in the shim.
 //
 // On the staged (Added/Copied/Modified) set it, in order:
-//   1. blocks a reintroduced *.sh (shares the scan with verify.js stage 0a);
+//   1. blocks a reintroduced *.sh (shares the scan with scripts/verify.mjs 0a);
 //   2. auto-formats C++ (clang-format), Python (ruff) and re-stages;
 //   3. runs `biome check --write` on staged JS/TS: applies safe format + lint +
 //      import fixes, then BLOCKS on any remaining (unfixable) lint error.

--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -25,13 +25,14 @@
 // window launch is left as a manual / CI-display step.
 // @ts-check
 
-'use strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-const fs = require('fs');
-const path = require('path');
-const { spawnSync } = require('child_process');
-
-const ROOT = __dirname;
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const ROOT = path.resolve(__dirname, '..'); // repo root (this file lives in scripts/)
 const isWin = process.platform === 'win32';
 
 // Prefer a cross-platform run.mjs (node) over the legacy run.sh (bash) so
@@ -121,10 +122,8 @@ function main() {
   console.log('\n[verify] stage 0a: no-bash script guard');
   const noBash = spawnSync(
     process.execPath,
-    [path.join(ROOT, 'no-bash-guard.mjs')],
-    {
-      encoding: 'utf8',
-    },
+    [path.join(__dirname, 'no-bash-guard.mjs')],
+    { encoding: 'utf8' },
   );
   if (noBash.status === 0)
     pass('no-bash script guard', 'gates are Node-only (cross-platform)');

--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -6,7 +6,7 @@
 // build:app → launch app) with no single criterion — into a reproducible "one command + assert
 // artifacts" criterion, which also serves as a CI smoke baseline.
 //
-// Usage (node pinned via the entrypoint; plain `node verify.js` also works):
+// Usage (node pinned via the entrypoint; plain `node scripts/verify.mjs` works):
 //   ./kungfu-code verify              quick: only assert "existing" artifacts (dist/kungfu exists + kfc runs + version matches)
 //   ./kungfu-code verify --full       full: rebuild:core + freeze first, then assert; also builds and runs the
 //                                     capability slices (framework/core/slices) + yijinjing dependency guard


### PR DESCRIPTION
De-clutters the repo root: moves verify/install-hooks/prebuild/precommit/no-bash-guard into scripts/ (per-package scripts/ convention) and converts the .js tooling + kungfu-code entrypoint to ESM (.mjs; surgical rename, not root type:module, which would flip the CJS test fixtures). All refs updated (package.json, pre-commit shim, kungfu-code sh/cmd wrappers, CONTRIBUTING). Validated on macOS: verify --help / quick run / guard / kungfu-code proxy / precommit all work.