### PR TITLE
build(core): adopt C++23

### DIFF
--- a/framework/core/.cmake/compiler.cmake
+++ b/framework/core/.cmake/compiler.cmake
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD 23)
 
 ############################################################
 

--- a/framework/core/.gyp/run-conan.js
+++ b/framework/core/.gyp/run-conan.js
@@ -45,7 +45,9 @@ function makeConanSettings(names) {
 }
 
 // Windows 端口固化：conan profile detect 在 MSVC 上把 compiler.cppstd 探成 14，
-// 但本项目是 C++17，rocksdb 等无 cppstd=14 的 prebuilt(只 17/20/23)，conan install 会失败。
+// 依赖(如 flatbuffers/nng)只有 17/20/23 的 prebuilt,cppstd=14 会让 conan install 失败。
+// 这里钉的是 **依赖 ABI 解析用的 cppstd**,与项目自身的 C++ 标准(.cmake/compiler.cmake,
+// 现为 C++23)解耦——依赖多为 header-only 或 C ABI,17 的 prebuilt 与 23 的项目可共存。
 // 显式钉 17 仅在 Windows 加(Mac/Linux profile 本就 gnu17，强制 17 会改 package id 致缓存失效，故不动)。
 function platformConanSettings() {
   return process.platform === 'win32' ? ['-s', 'compiler.cppstd=17'] : [];

--- a/framework/core/src/libkungfu/CMakeLists.txt
+++ b/framework/core/src/libkungfu/CMakeLists.txt
@@ -13,7 +13,7 @@ add_library_object(kungfu_optim "${KUNGFU_OPTIM_SOURCE_FILES}" "${COMPILER_OPTIM
 
 # the OBJECT libraries compile independently of the final target, so they
 # need the runtime headers, the vendored sqlite_orm, and the yijinjing core
-# usage requirements (headers, hana, cxx_std_20) at their own scope
+# usage requirements (headers, hana, cxx_std_23) at their own scope
 set(LIBKUNGFU_SQLITE_ORM_INCLUDE ${PROJECT_SOURCE_DIR}/../../.deps/sqlite_orm-1.7.1/include)
 foreach(_kf_obj kungfu_cache kungfu_optim)
   target_include_directories(${_kf_obj} PRIVATE ${PROJECT_SOURCE_DIR}/include ${LIBKUNGFU_SQLITE_ORM_INCLUDE})

--- a/framework/core/src/libyijinjing/CMakeLists.txt
+++ b/framework/core/src/libyijinjing/CMakeLists.txt
@@ -35,7 +35,7 @@ file(GLOB_RECURSE YIJINJING_SOURCE_FILES ${PROJECT_SOURCE_DIR}/src/*.cpp)
 add_library(yijinjing STATIC ${YIJINJING_SOURCE_FILES})
 # the ADR-0001 publication protocol uses std::atomic_ref; a target-level
 # requirement holds even when the embedder's global standard is older
-target_compile_features(yijinjing PUBLIC cxx_std_20)
+target_compile_features(yijinjing PUBLIC cxx_std_23)
 # linked into the SHARED libkungfu on Mac/Linux
 set_target_properties(yijinjing PROPERTIES POSITION_INDEPENDENT_CODE ON)
 if(DEFINED KUNGFU_BUILD_DIR)


### PR DESCRIPTION
Raise the project C++ standard 20→23 (conan dep cppstd stays 17, decoupled). Validated clean builds on macOS (AppleClang 21) and Linux (GCC 13.3); only boost::hana emits deprecation warnings. Windows/MSVC build was env-blocked (missing _WINDOWS platform macro in the ad-hoc vcvars shell), not a C++23 incompatibility — a proper DARKHERO build verification is a fast-follow. Adopting now to keep the long-term core on a modern standard.