### PR TITLE
docs(core): update C++ standard references to C++23

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ sensitive material in issues or pull requests.
 
 ## Prerequisites
 
-- A C++20 toolchain and [CMake](https://cmake.org/) (>= 3.15)
+- A C++23 toolchain and [CMake](https://cmake.org/) (>= 3.20)
 - [Conan 2](https://conan.io/) for C++ dependencies
 - [fnm](https://github.com/Schniz/fnm) (Node is pinned via `.node-version`)
 - [uv](https://docs.astral.sh/uv/) for the Python environment

--- a/framework/core/src/libyijinjing/EMBEDDING.md
+++ b/framework/core/src/libyijinjing/EMBEDDING.md
@@ -21,7 +21,7 @@ target_link_libraries(your_tool yijinjing)
 ```
 
 `<kungfu>` can be a git checkout, a submodule or a FetchContent source
-directory. The target propagates its include directories and C++20
+directory. The target propagates its include directories and C++23
 requirement (`std::atomic_ref` implements the frame publication protocol,
 see ADR-0001), so the consumer needs no extra configuration.
 


### PR DESCRIPTION
CONTRIBUTING and the yijinjing EMBEDDING guide still said C++20; align them with the adopted CMAKE_CXX_STANDARD 23 (and CMake >= 3.20).