### PR TITLE
refactor(core): clear the mypy baseline snapshot (fix 7 modules)

### DIFF
--- a/framework/core/pyproject.toml
+++ b/framework/core/pyproject.toml
@@ -114,27 +114,12 @@ ignore = ["E501", "F403", "F405"]
 # so mypy runs lenient: untyped defs are skipped (no big-bang wall of errors),
 # and a module gets real checking once its functions are annotated. Native
 # pykungfu and unstubbed third-party libs have no stubs, so missing imports are
-# ignored. Tighten per-module (via [[tool.mypy.overrides]]) as coverage grows.
+# ignored. The whole package is error-clean today (no ignore-errors overrides);
+# keep it that way — fix or annotate a module rather than silencing it.
 [tool.mypy]
 python_version = "3.13"
 ignore_missing_imports = true
 exclude = ['(^|/)(fb|generated)/', '_fb\.py$', '(^|/)\.deps/']
-
-# Baseline snapshot of pre-existing type errors so the gate is green from day one
-# (13 errors across these modules: native pykungfu used without stubs, and
-# partially-typed click-decorator/CLI return types). New code is still checked;
-# drop a module from this list as it is fixed or annotated. Typing follow-up.
-[[tool.mypy.overrides]]
-module = [
-    "kungfu.cli.commands",
-    "kungfu.cli.commands.engage",
-    "kungfu.cli.commands.journal",
-    "kungfu.rewind.managed_run",
-    "kungfu.yijinjing.practice.apprentice",
-    "kungfu.yijinjing.sinks.archive",
-    "kungfu.yijinjing.sinks.csv",
-]
-ignore_errors = true
 
 [tool.uv]
 # 钉 uv 自管 standalone CPython(而非系统/发行版 python)：跨机一致,且根治 nuitka 在

--- a/framework/core/src/python/kungfu/cli/commands/__init__.py
+++ b/framework/core/src/python/kungfu/cli/commands/__init__.py
@@ -106,7 +106,7 @@ class PrioritizedCommandGroup(click.Group):
                     ctx.__dict__[key] = ctx.parent.__dict__[key]
                 return f(ctx, *args, **kwargs)
 
-            return update_wrapper(typing.cast(CLI, new_func), f)
+            return typing.cast(CLI, update_wrapper(new_func, f))
 
         return copy_from_parent
 

--- a/framework/core/src/python/kungfu/cli/commands/engage.py
+++ b/framework/core/src/python/kungfu/cli/commands/engage.py
@@ -25,7 +25,7 @@ def engage_command_context():
             sys.argv = [sys.argv[0], *ctx.args]
             return kfc.pass_context()(f)(*args, **kwargs)
 
-        return update_wrapper(typing.cast(CLI, new_func), f)
+        return typing.cast(CLI, update_wrapper(new_func, f))
 
     return build_bridge
 
@@ -83,7 +83,7 @@ def engaged_nuitka_context():
             build_bridge = engage_command_context()
             return build_bridge(f)(*args, **kwargs)
 
-        return update_wrapper(typing.cast(CLI, new_func), f)
+        return typing.cast(CLI, update_wrapper(new_func, f))
 
     return nuitka_context
 

--- a/framework/core/src/python/kungfu/cli/commands/journal.py
+++ b/framework/core/src/python/kungfu/cli/commands/journal.py
@@ -11,7 +11,7 @@ import zipfile
 
 from collections import deque
 from datetime import datetime, timedelta
-from tabulate import tabulate
+from tabulate import tabulate  # type: ignore[import-untyped]  # no stubs
 
 from kungfu.cli.commands import kfc, PrioritizedCommandGroup
 from kungfu.yijinjing import LOG_PATTERN, ARCHIVE_PREFIX
@@ -38,13 +38,13 @@ journal_command_context = kfc.pass_context(
 
 @kfc.group(cls=PrioritizedCommandGroup, help_priority=2)
 @click.option(
-    "-m", "--mode", default="*", type=click.Choice(kfj.MODES.keys()), help="mode"
+    "-m", "--mode", default="*", type=click.Choice(list(kfj.MODES)), help="mode"
 )
 @click.option(
     "-c",
     "--category",
     default="*",
-    type=click.Choice(kfj.CATEGORIES.keys()),
+    type=click.Choice(list(kfj.CATEGORIES)),
     help="category",
 )
 @click.option("-g", "--group", type=str, default="*", help="group")

--- a/framework/core/src/python/kungfu/rewind/managed_run.py
+++ b/framework/core/src/python/kungfu/rewind/managed_run.py
@@ -25,7 +25,7 @@ import dataclasses
 import json
 import subprocess
 import time
-from typing import Callable, List, Optional
+from typing import Callable, List, Optional, TypedDict
 
 from kungfu.rewind import MSG_MODEL_RESPONSE, events
 from kungfu.rewind import cost_wire
@@ -35,12 +35,19 @@ from kungfu.rewind.cost.model import CostSnapshot
 from kungfu.rewind.fb.CallStatus import CallStatus
 from kungfu.rewind.fb.CaptureLayer import CaptureLayer
 
+
 # Provider -> how to invoke it for structured output and how to parse it back.
 # argv keeps the provider's own structured-output flags; the prompt is the last
 # positional. The two structured-output paths a managed run supports:
 #   codex exec --json <prompt>              -> turn.completed.usage (tokens only)
 #   claude --print --output-format json ... -> usage + total_cost_usd + session
-_SPECS = {
+class _ProviderSpec(TypedDict):
+    surface: str
+    argv: Callable[[str, str], list[str]]
+    parse: Callable[..., CostSnapshot]
+
+
+_SPECS: dict[str, _ProviderSpec] = {
     "codex": {
         "surface": "exec_json",
         "argv": lambda binary, prompt: [binary, "exec", "--json", prompt],

--- a/framework/core/src/python/kungfu/yijinjing/practice/apprentice.py
+++ b/framework/core/src/python/kungfu/yijinjing/practice/apprentice.py
@@ -5,9 +5,12 @@ import psutil
 import signal
 import kungfu.yijinjing.io as kfio
 import kungfu.yijinjing.journal as kfj
-from . import os_signal
+from typing import Any
 
-yjj = kungfu.__binding__.yijinjing
+from . import os_signal  # type: ignore[attr-defined]  # native submodule
+
+# native pybind11 binding (no stubs); Any so `yjj.apprentice` is a usable base
+yjj: Any = kungfu.__binding__.yijinjing
 
 
 class Apprentice(yjj.apprentice):

--- a/framework/core/src/python/kungfu/yijinjing/sinks/archive.py
+++ b/framework/core/src/python/kungfu/yijinjing/sinks/archive.py
@@ -3,10 +3,13 @@
 import kungfu
 import os
 
+from typing import Any
+
 from kungfu.yijinjing.time import DAY_IN_NANO
 
 lf = kungfu.__binding__.longfist
-yjj = kungfu.__binding__.yijinjing
+# native pybind11 binding (no stubs); Any so `yjj.sink` is a usable base class
+yjj: Any = kungfu.__binding__.yijinjing
 
 
 class ArchiveSink(yjj.sink):

--- a/framework/core/src/python/kungfu/yijinjing/sinks/csv.py
+++ b/framework/core/src/python/kungfu/yijinjing/sinks/csv.py
@@ -5,9 +5,11 @@ import kungfu
 import os
 
 from contextlib import contextmanager
+from typing import Any
 
 lf = kungfu.__binding__.longfist
-yjj = kungfu.__binding__.yijinjing
+# native pybind11 binding (no stubs); Any so `yjj.sink` is a usable base class
+yjj: Any = kungfu.__binding__.yijinjing
 
 
 class CsvSink(yjj.sink):


### PR DESCRIPTION
Fix the 7 pre-existing type-error modules and remove the ignore-errors override — mypy now checks the whole kungfu package clean. Native pykungfu bindings typed Any, click decorators cast to CLI, click.Choice takes list(), tabulate marked untyped, managed-run provider table gets a _ProviderSpec TypedDict.