### PR TITLE
rewind: attribute managed-run cost to the GUI session, decode events by reflection

### DIFF
--- a/extensions/terminal/src/view/index.tsx
+++ b/extensions/terminal/src/view/index.tsx
@@ -79,7 +79,10 @@ const INBOX: RunProfile[] = [
 // How to launch a managed run: `kungfu managed-run --provider … --prompt …`.
 // The launcher is `kungfu` on PATH in a packaged runtime; KUNGFU_MANAGED_RUN_CMD
 // overrides it so a source checkout can point at its built runtime.
-function launchCommand(profile: RunProfile): {
+function launchCommand(
+  profile: RunProfile,
+  runId: string,
+): {
   command: string;
   args: string[];
 } {
@@ -96,8 +99,22 @@ function launchCommand(profile: RunProfile): {
       profile.provider,
       '--prompt',
       profile.prompt,
+      // Bind the supervisor's cost/journal run_id to this GUI session's runId so
+      // cost/state/proof facts attribute back to the pane (W6 fact base).
+      '--run-id',
+      runId,
     ],
   };
+}
+
+// A tmux-safe run identity minted GUI-side. It becomes the session runId, the
+// tmux name token, and the supervisor's cost/journal run_id — one id across all
+// three so cost/state/proof facts attribute back to the on-screen session.
+function mintRunId(): string {
+  const raw =
+    globalThis.crypto?.randomUUID?.() ??
+    `${Date.now().toString(16)}-${Math.floor(Math.random() * 0xffffff).toString(16)}`;
+  return `kfr-${raw.replace(/[^a-f0-9]/gi, '').slice(0, 12)}`;
 }
 
 // One pane on the canvas, bound to an already-created session by runId. The
@@ -775,7 +792,10 @@ function SessionWorkspace({
 
   const launch = React.useCallback(
     async (profile: RunProfile) => {
-      const { command, args } = launchCommand(profile);
+      // Mint the run identity here so one id binds the GUI session, the tmux
+      // name, and the supervisor's cost/journal run_id (W6 fact base).
+      const runId = mintRunId();
+      const { command, args } = launchCommand(profile, runId);
       let session: TerminalSession;
       let durable = true;
       try {
@@ -783,6 +803,7 @@ function SessionWorkspace({
           caps.terminal.spawn({
             command,
             args,
+            runId,
             provider: profile.provider,
             backend: 'tmux',
             cols: 80,
@@ -800,6 +821,7 @@ function SessionWorkspace({
           caps.terminal.spawn({
             command,
             args,
+            runId,
             provider: profile.provider,
             cols: 80,
             rows: 24,

--- a/framework/api/src/capability/rewind.ts
+++ b/framework/api/src/capability/rewind.ts
@@ -1,45 +1,45 @@
 // Rewind-domain capability handles: open the runtime home's recorded traced
 // runs, list them, and load one run as decoded events plus its causal tree.
 // Additive module beside the ADR-0011 five handles — same factory style, no
-// import-time side effects. Decoding uses the flatc-generated accessors for
-// the rewind event schema (open-layer msg types 30001-30099); the raw payload
-// bytes come from the native frame via dataBytes().
-import * as flatbuffers from 'flatbuffers';
+// import-time side effects.
+//
+// Events are decoded by reflection over each run's manifest-bound `.bfbs` —
+// the same "decodable by reflection alone, no generated code" contract that
+// C++ and Python honour (see kungfu.rewind README / replay.py). The shared
+// ReflectionDecoder walks the schema; raw payload bytes come from the native
+// journal frame via dataBytes(), and the schema bytes + msg_type→table binding
+// come from the run's bundle (manifest.json + schemas/<hash>.bfbs), read
+// through injected fs primitives. Adding a new event type (e.g. CostSnapshot)
+// needs no change here: bind it in the schema, and reflection decodes it.
 import {
   CallStatus,
-  CaptureLayer,
-  ModelRequest,
-  ModelResponse,
-  RetryMarker,
-  RunBegin,
-  RunEnd,
-  RunStatus,
-  ToolCall,
-  ToolResult,
+  type CaptureLayer,
+  type RunStatus,
 } from './generated/rewind/fb.js';
+import { ReflectionDecoder } from './schema.js';
 import {
   type KfLocator,
   type KfNativeBinding,
   resolveRuntimeDir,
 } from './types.js';
 
-// the event-status vocabulary is part of this handle's surface
+// the event-status vocabulary is part of this handle's surface (value enums,
+// not table decoders — consumers compare status === CallStatus.Error etc.)
 export { CallStatus, CaptureLayer, RunStatus } from './generated/rewind/fb.js';
 
-export const REWIND_MSG = {
-  RunBegin: 30001,
-  RunEnd: 30002,
-  ModelRequest: 30003,
-  ModelResponse: 30004,
-  ToolCall: 30005,
-  ToolResult: 30006,
-  RetryMarker: 30007,
-} as const;
-
-const REWIND_MSG_MIN = 30001;
-const REWIND_MSG_MAX = 30007;
-
-export type RewindEventKind = keyof typeof REWIND_MSG;
+// Known first-party event kinds (manifest binding.name). kfx events carry a
+// fully-qualified table name, so the type stays open.
+export type RewindEventKind =
+  | 'RunBegin'
+  | 'RunEnd'
+  | 'ModelRequest'
+  | 'ModelResponse'
+  | 'ToolCall'
+  | 'ToolResult'
+  | 'RetryMarker'
+  | 'CostSnapshot'
+  | 'ApprovalDecision'
+  | (string & {});
 
 export type RewindEvent = {
   kind: RewindEventKind;
@@ -71,6 +71,19 @@ export type RewindEvent = {
   runtime?: string;
   exitCode?: number;
   runStatus?: RunStatus;
+  // cost facts (CostSnapshot). attribution is the confidence level
+  // (0 ExactRun .. 4 ManualEstimate); ambiguousAttribution flags shared-account
+  // / shared-window usage that the source could not isolate.
+  costUsd?: number;
+  costUsdKnown?: boolean;
+  attribution?: number;
+  ambiguousAttribution?: boolean;
+  workId?: string;
+  sessionId?: string;
+  surface?: string;
+  // any decoded field not mapped to a typed slot above (kfx events, or new
+  // schema fields added before this mapping table learns them).
+  extra?: Record<string, unknown>;
 };
 
 export type RewindSpan = {
@@ -91,6 +104,13 @@ export type RewindRunSummary = {
   exitCode?: number;
   eventCount: number;
   errorCount: number;
+  // run-level cost rollup (summed across the run's CostSnapshot events)
+  costUsd?: number;
+  costUsdKnown?: boolean;
+  inputTokens?: bigint;
+  outputTokens?: bigint;
+  ambiguousAttribution?: boolean;
+  attribution?: number;
 };
 
 export type RewindRun = {
@@ -109,108 +129,84 @@ export type Rewind = {
 export type OpenRewindOptions = {
   binding: KfNativeBinding;
   locator: KfLocator;
+  // Injected fs primitives — the SDK never touches the filesystem itself (same
+  // environment-agnostic contract as the native binding). Rewind needs them to
+  // read each run's bundle manifest + `.bfbs` schema blobs for reflection.
+  readFile: (path: string) => Uint8Array;
+  readDir: (dir: string) => string[];
 };
 
-const str = (value: string | null | undefined) => value ?? undefined;
+const decoder = new TextDecoder();
 
-function decode(
-  msgType: number,
-  bytes: Uint8Array,
-): Omit<RewindEvent, 'genTime'> | null {
-  const bb = new flatbuffers.ByteBuffer(bytes);
-  switch (msgType) {
-    case REWIND_MSG.RunBegin: {
-      const e = RunBegin.getRootAsRunBegin(bb);
-      return {
-        kind: 'RunBegin',
-        runId: e.runId() ?? '',
-        command: str(e.command()),
-        runtime: str(e.runtime()),
-      };
+// snake_case (reflection field name) -> camelCase (RewindEvent slot). The
+// decode is otherwise field-name agnostic; only the causal/cost slots we type
+// explicitly need mapping, everything else lands in `extra`.
+function snakeToCamel(s: string): string {
+  return s.replace(/_([a-z])/g, (_m, c: string) => c.toUpperCase());
+}
+
+// The typed slots on RewindEvent (camelCase). Anything else goes to `extra`.
+const TYPED_SLOTS = new Set<string>([
+  'runId',
+  'spanId',
+  'parentSpanId',
+  'layer',
+  'status',
+  'provider',
+  'model',
+  'requestBody',
+  'responseBody',
+  'finishReason',
+  'inputTokens',
+  'outputTokens',
+  'toolName',
+  'input',
+  'output',
+  'error',
+  'latencyNs',
+  'retryOfSpanId',
+  'attempt',
+  'command',
+  'runtime',
+  'exitCode',
+  'costUsd',
+  'costUsdKnown',
+  'attribution',
+  'ambiguousAttribution',
+  'workId',
+  'sessionId',
+  'surface',
+]);
+
+// Map a reflection-decoded record (snake_case fields, null for absent scalars)
+// into the typed RewindEvent. `kind` comes from the manifest binding, not a
+// per-type switch.
+function toEvent(
+  kind: string,
+  genTime: bigint,
+  raw: Record<string, unknown>,
+): RewindEvent {
+  const e: Record<string, unknown> = { kind, genTime, runId: '' };
+  const extra: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(raw)) {
+    if (value === null || value === undefined) continue;
+    const camel = snakeToCamel(key);
+    // RunEnd's `status` is a RunStatus; every other event's `status` is a
+    // CallStatus. Route the run-terminal status to its own slot.
+    if (kind === 'RunEnd' && camel === 'status') {
+      e.runStatus = Number(value);
+      continue;
     }
-    case REWIND_MSG.RunEnd: {
-      const e = RunEnd.getRootAsRunEnd(bb);
-      return {
-        kind: 'RunEnd',
-        runId: e.runId() ?? '',
-        runStatus: e.status(),
-        exitCode: e.exitCode(),
-      };
-    }
-    case REWIND_MSG.ModelRequest: {
-      const e = ModelRequest.getRootAsModelRequest(bb);
-      return {
-        kind: 'ModelRequest',
-        runId: e.runId() ?? '',
-        spanId: str(e.spanId()),
-        parentSpanId: str(e.parentSpanId()),
-        layer: e.layer(),
-        provider: str(e.provider()),
-        model: str(e.model()),
-        requestBody: str(e.requestBody()),
-        attempt: e.attempt(),
-      };
-    }
-    case REWIND_MSG.ModelResponse: {
-      const e = ModelResponse.getRootAsModelResponse(bb);
-      return {
-        kind: 'ModelResponse',
-        runId: e.runId() ?? '',
-        spanId: str(e.spanId()),
-        layer: e.layer(),
-        status: e.status(),
-        responseBody: str(e.responseBody()),
-        error: str(e.error()),
-        finishReason: str(e.finishReason()),
-        inputTokens: e.inputTokens(),
-        outputTokens: e.outputTokens(),
-        latencyNs: e.latencyNs(),
-      };
-    }
-    case REWIND_MSG.ToolCall: {
-      const e = ToolCall.getRootAsToolCall(bb);
-      return {
-        kind: 'ToolCall',
-        runId: e.runId() ?? '',
-        spanId: str(e.spanId()),
-        parentSpanId: str(e.parentSpanId()),
-        layer: e.layer(),
-        toolName: str(e.toolName()),
-        input: str(e.input()),
-      };
-    }
-    case REWIND_MSG.ToolResult: {
-      const e = ToolResult.getRootAsToolResult(bb);
-      return {
-        kind: 'ToolResult',
-        runId: e.runId() ?? '',
-        spanId: str(e.spanId()),
-        layer: e.layer(),
-        status: e.status(),
-        output: str(e.output()),
-        error: str(e.error()),
-        latencyNs: e.latencyNs(),
-      };
-    }
-    case REWIND_MSG.RetryMarker: {
-      const e = RetryMarker.getRootAsRetryMarker(bb);
-      return {
-        kind: 'RetryMarker',
-        runId: e.runId() ?? '',
-        spanId: str(e.spanId()),
-        retryOfSpanId: str(e.retryOfSpanId()),
-        attempt: e.attempt(),
-      };
-    }
-    default:
-      return null;
+    if (TYPED_SLOTS.has(camel)) e[camel] = value;
+    else extra[camel] = value;
   }
+  if (Object.keys(extra).length > 0) e.extra = extra;
+  return e as unknown as RewindEvent;
 }
 
 // The causal tree: spans open on ModelRequest/ToolCall/RetryMarker, close on
-// their span-matched response/result; children hang off parentSpanId. Same
-// reconstruction the CLI's forensic replay performs — one fact model, two
-// surfaces.
+// their span-matched response/result; children hang off parentSpanId. Non-span
+// events (RunBegin/RunEnd/CostSnapshot) carry no spanId and are skipped here.
 function buildTree(events: RewindEvent[]): RewindSpan[] {
   const spans = new Map<string, RewindSpan>();
   const order: string[] = [];
@@ -247,26 +243,111 @@ function buildTree(events: RewindEvent[]): RewindSpan[] {
   return roots;
 }
 
+// Roll a run's CostSnapshot events into one honest cost summary: report a total
+// USD only when every snapshot's usd is known (else leave it undefined and fall
+// back to tokens); flag ambiguous if any snapshot is ambiguous; keep the weakest
+// attribution as the run's confidence floor (0 ExactRun strongest .. 4 weakest).
+function summarizeCost(costs: RewindEvent[]): Partial<RewindRunSummary> {
+  if (costs.length === 0) return {};
+  let inputTokens = 0n;
+  let outputTokens = 0n;
+  let usd = 0;
+  let allKnown = true;
+  let ambiguousAttribution = false;
+  let weakest = 0;
+  for (const c of costs) {
+    inputTokens += c.inputTokens ?? 0n;
+    outputTokens += c.outputTokens ?? 0n;
+    if (c.costUsdKnown) usd += c.costUsd ?? 0;
+    else allKnown = false;
+    if (c.ambiguousAttribution) ambiguousAttribution = true;
+    if (c.attribution !== undefined && c.attribution > weakest) {
+      weakest = c.attribution;
+    }
+  }
+  return {
+    costUsd: allKnown ? usd : undefined,
+    costUsdKnown: allKnown,
+    inputTokens,
+    outputTokens,
+    ambiguousAttribution,
+    attribution: weakest,
+  };
+}
+
 export function openRewind(options: OpenRewindOptions): Rewind {
-  const { binding } = options;
+  const { binding, readFile, readDir } = options;
   const runtimeDir = resolveRuntimeDir(options.locator);
 
   let cache: Map<string, RewindEvent[]> | null = null;
 
+  // Build msgType -> {kind, decoder} from every run's bundle manifest.
+  // First-party schemas are content-addressed, so all runs bind the same
+  // `.bfbs`; decoders are deduped by schema hash. (A per-run kfx schema reusing
+  // one msgType with different bytes across runs would collide here — the
+  // first-party rewind events this surface renders do not.)
+  const loadBinders = (): Map<
+    number,
+    { kind: string; decoder: ReflectionDecoder }
+  > => {
+    const binders = new Map<
+      number,
+      { kind: string; decoder: ReflectionDecoder }
+    >();
+    const byHash = new Map<string, ReflectionDecoder>();
+    let runIds: string[];
+    try {
+      runIds = readDir(`${runtimeDir}/rewind`);
+    } catch {
+      return binders; // no rewind runs recorded yet
+    }
+    for (const runId of runIds) {
+      const bundle = `${runtimeDir}/rewind/${runId}/bundle`;
+      let manifest: {
+        schema_bindings?: Record<string, { name: string; schema_hash: string }>;
+      };
+      try {
+        manifest = JSON.parse(
+          decoder.decode(readFile(`${bundle}/manifest.json`)),
+        );
+      } catch {
+        continue; // no bundle yet (e.g. a live run not exported), skip
+      }
+      for (const [mt, binding_] of Object.entries(
+        manifest.schema_bindings ?? {},
+      )) {
+        const msgType = Number(mt);
+        if (binders.has(msgType)) continue;
+        let dec = byHash.get(binding_.schema_hash);
+        if (!dec) {
+          try {
+            dec = new ReflectionDecoder(
+              readFile(`${bundle}/schemas/${binding_.schema_hash}.bfbs`),
+            );
+          } catch {
+            continue; // schema blob missing/unreadable, skip this binding
+          }
+          byHash.set(binding_.schema_hash, dec);
+        }
+        binders.set(msgType, { kind: binding_.name, decoder: dec });
+      }
+    }
+    return binders;
+  };
+
   const scan = (): Map<string, RewindEvent[]> => {
+    const binders = loadBinders();
     const byRun = new Map<string, RewindEvent[]>();
     const assemble = new binding.Assemble([runtimeDir]);
     while (assemble.dataAvailable()) {
       const frame = assemble.currentFrame();
-      const msgType = frame.msgType();
-      if (msgType >= REWIND_MSG_MIN && msgType <= REWIND_MSG_MAX) {
-        const decoded = decode(msgType, frame.dataBytes());
-        if (decoded) {
-          const event: RewindEvent = { ...decoded, genTime: frame.genTime() };
-          const bucket = byRun.get(event.runId);
-          if (bucket) bucket.push(event);
-          else byRun.set(event.runId, [event]);
-        }
+      const bound = binders.get(frame.msgType());
+      if (bound) {
+        const raw = bound.decoder.decode(frame.dataBytes(), bound.kind);
+        const event = toEvent(bound.kind, frame.genTime(), raw);
+        const bucket = byRun.get(event.runId);
+        if (bucket) bucket.push(event);
+        else byRun.set(event.runId, [event]);
       }
       assemble.next();
     }
@@ -289,6 +370,7 @@ export function openRewind(options: OpenRewindOptions): Rewind {
   ): RewindRunSummary => {
     const begin = events.find((e) => e.kind === 'RunBegin');
     const end = events.find((e) => e.kind === 'RunEnd');
+    const cost = summarizeCost(events.filter((e) => e.kind === 'CostSnapshot'));
     return {
       runId,
       command: begin?.command,
@@ -298,6 +380,7 @@ export function openRewind(options: OpenRewindOptions): Rewind {
       exitCode: end?.exitCode,
       eventCount: events.length,
       errorCount: events.filter((e) => e.status === CallStatus.Error).length,
+      ...cost,
     };
   };
 

--- a/framework/api/src/capability/schema.ts
+++ b/framework/api/src/capability/schema.ts
@@ -8,8 +8,8 @@
 import * as flatbuffers from 'flatbuffers';
 import {
   BaseType,
-  Field,
-  Object_,
+  type Field,
+  type Object_,
   Schema,
 } from './generated/reflection/reflection.js';
 
@@ -72,9 +72,23 @@ export class ReflectionDecoder {
 
     if (base === BaseType.String) return o ? bb.__string(pos + o) : null;
 
-    if (base !== undefined && base in SCALARS) {
-      const [read, _w] = SCALARS[base]!;
-      return o ? read(bb, pos + o) : null;
+    const scalar = base !== undefined ? SCALARS[base] : undefined;
+    if (scalar) {
+      const [read] = scalar;
+      if (o) return read(bb, pos + o);
+      // Absent scalar: flatbuffers omits default-valued scalars, so recover the
+      // schema default (matching the core's Python BundleDecoder) instead of
+      // null — else a meaningful 0/false (e.g. attribution=ExactRun(0),
+      // ambiguous_attribution=false) is silently dropped. Match the JS type the
+      // non-default reader would have produced for this base_type.
+      if (base === BaseType.Bool) return f.defaultInteger() !== 0n;
+      if (base === BaseType.Float || base === BaseType.Double) {
+        return f.defaultReal();
+      }
+      if (base === BaseType.Long || base === BaseType.ULong) {
+        return f.defaultInteger();
+      }
+      return Number(f.defaultInteger());
     }
 
     if (base === BaseType.Vector) {
@@ -88,8 +102,9 @@ export class ReflectionDecoder {
           bb.__string(start + i * 4),
         );
       }
-      if (elem !== undefined && elem in SCALARS) {
-        const [read, w] = SCALARS[elem]!;
+      const elemScalar = elem !== undefined ? SCALARS[elem] : undefined;
+      if (elemScalar) {
+        const [read, w] = elemScalar;
         return Array.from({ length: len }, (_, i) => read(bb, start + i * w));
       }
       return `<vector-elem:${elem}>`;

--- a/framework/core/src/python/kungfu/rewind/managed_cli.py
+++ b/framework/core/src/python/kungfu/rewind/managed_cli.py
@@ -76,6 +76,7 @@ def run_and_report(
     *,
     runtime_dir,
     work_id=None,
+    run_id=None,
     home=None,
     skill_paths=None,
     skill_profile=None,
@@ -89,7 +90,10 @@ def run_and_report(
     """Run one managed provider run on a journal under runtime_dir and print its
     cost. Returns the provider's exit code. Shared by the `kungfu managed-run`
     console command and the `python -m` entry."""
-    run_id = uuid.uuid4().hex[:12]
+    # A caller that already owns the run (e.g. the GUI managed-session workspace)
+    # injects run_id so the supervisor's cost/journal facts share one identity
+    # with the on-screen session (W6 fact base); otherwise we mint one here.
+    run_id = run_id or uuid.uuid4().hex[:12]
 
     disc = discover_provider(provider)
     if not quiet:
@@ -302,6 +306,11 @@ def main(argv=None):
     ap.add_argument("--home", default=None, help="runtime dir for the journal")
     ap.add_argument("--work-id", default=None, help="work item this run belongs to")
     ap.add_argument(
+        "--run-id",
+        default=None,
+        help="run identity to bind cost/journal facts to (defaults to a fresh id)",
+    )
+    ap.add_argument(
         "--skill-path",
         action="append",
         default=[],
@@ -331,6 +340,7 @@ def main(argv=None):
         args.prompt,
         runtime_dir=runtime,
         work_id=args.work_id,
+        run_id=args.run_id,
         home=runtime,
         skill_paths=args.skill_path,
         skill_profile=args.skill_profile,

--- a/framework/gui/src/renderer/src/runtime.ts
+++ b/framework/gui/src/renderer/src/runtime.ts
@@ -197,7 +197,13 @@ export function bootRuntime(): Runtime {
       join: { name: APP_NAME },
     });
     const domain = openDomainState({ binding, locator: { runtimeDir } });
-    const rewind = openRewind({ binding, locator: { runtimeDir } });
+    const rewindFs = window.require('node:fs');
+    const rewind = openRewind({
+      binding,
+      locator: { runtimeDir },
+      readFile: (p: string) => rewindFs.readFileSync(p),
+      readDir: (d: string) => rewindFs.readdirSync(d),
+    });
     const work = openWork({ binding, locator: { runtimeDir } });
     // node-pty is a native addon loaded like the kungfu binding; if it is
     // absent or built for another ABI the terminal handle stays null and the


### PR DESCRIPTION
Two additive fact-base changes on the rewind path:
- managed-run takes the GUI session runId (--run-id) so CostSnapshot/journal facts share one identity with the on-screen session.
- the rewind capability decodes events by reflection over the manifest-bound .bfbs (no generated event classes); CostSnapshot and future event types decode with no per-type code. Also recovers schema-default scalars the reflection decoder was dropping.