### PR TITLE
refactor(core): annotate the package + skill public API (Stage 3)

### DIFF
--- a/framework/core/src/python/kungfu/__init__.py
+++ b/framework/core/src/python/kungfu/__init__.py
@@ -1,7 +1,10 @@
 #  SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 import json
 import os
+from typing import Any
 
 # The native binding is imported lazily (PEP 562 module __getattr__) rather than
 # at package import. This lets the pure-stdlib capability guest
@@ -12,11 +15,11 @@ import os
 # use, exactly where it did before; only the paths that never touch it (the guest
 # proxy) no longer pull it in.
 
-_binding = None
-_build_info = None
+_binding: Any = None
+_build_info: dict[str, Any] | None = None
 
 
-def _load_binding():
+def _load_binding() -> Any:
     global _binding
     if _binding is None:
         import pykungfu as binding
@@ -25,7 +28,7 @@ def _load_binding():
     return _binding
 
 
-def _load_build_info():
+def _load_build_info() -> dict[str, Any]:
     global _build_info
     if _build_info is None:
         binding = _load_binding()
@@ -37,7 +40,7 @@ def _load_build_info():
     return _build_info
 
 
-def __getattr__(name):
+def __getattr__(name: str) -> Any:
     if name == "__binding__":
         return _load_binding()
     if name == "__build_info__":
@@ -47,7 +50,7 @@ def __getattr__(name):
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
-def schema_data_path(module_file, name):
+def schema_data_path(module_file: str, name: str) -> str:
     """Resolve a package data file (e.g. a *.bfbs schema blob) in both layouts.
 
     In a source checkout the file sits next to its module; in the frozen

--- a/framework/core/src/python/kungfu/skill/catalog.py
+++ b/framework/core/src/python/kungfu/skill/catalog.py
@@ -1,7 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
 
-def catalog_entry(skill):
+from collections.abc import Iterable
+from typing import Any
+
+
+def catalog_entry(skill: dict[str, Any]) -> dict[str, Any]:
     return {
         "key": skill["key"],
         "title": skill["title"],
@@ -15,7 +20,7 @@ def catalog_entry(skill):
     }
 
 
-def build_catalog(skills):
+def build_catalog(skills: Iterable[dict[str, Any]]) -> dict[str, Any]:
     return {
         "schema": "kungfu.skill-catalog/v1",
         "skills": [catalog_entry(skill) for skill in skills],

--- a/framework/core/src/python/kungfu/skill/context.py
+++ b/framework/core/src/python/kungfu/skill/context.py
@@ -1,10 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 import hashlib
 import json
+from collections.abc import Mapping
+from typing import Any
 
 
-def build_context_envelope(catalog, session):
+def build_context_envelope(
+    catalog: dict[str, Any], session: Mapping[str, Any]
+) -> dict[str, Any]:
     advertised = json.dumps(
         catalog.get("skills", []),
         sort_keys=True,

--- a/framework/core/src/python/kungfu/skill/provider.py
+++ b/framework/core/src/python/kungfu/skill/provider.py
@@ -1,7 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 import json
 import os
+from collections.abc import Mapping
+from typing import Any
 
 from .catalog import build_catalog
 from .context import build_context_envelope
@@ -9,14 +13,14 @@ from .registry import discover_skills
 
 
 def build_skill_context(
-    home,
+    home: str,
     *,
-    source,
-    manager,
-    profile=None,
-    agent=None,
-    extra_paths=None,
-):
+    source: str,
+    manager: str,
+    profile: str | None = None,
+    agent: str | None = None,
+    extra_paths: list[str] | None = None,
+) -> dict[str, Any]:
     session = {"source": source, "manager": manager}
     if profile:
         session["profile"] = profile
@@ -28,16 +32,16 @@ def build_skill_context(
     )
 
 
-def load_skill_context_file(path):
+def load_skill_context_file(path: str) -> dict[str, Any]:
     with open(path, encoding="utf-8") as f:
         return json.load(f)
 
 
-def has_advertised_skills(envelope):
+def has_advertised_skills(envelope: Mapping[str, Any] | None) -> bool:
     return bool(envelope and envelope.get("catalog"))
 
 
-def format_skill_context_prompt(envelope):
+def format_skill_context_prompt(envelope: Mapping[str, Any]) -> str:
     return "\n".join(
         [
             "Kungfu Skill context envelope (compact, on-demand instructions):",
@@ -50,12 +54,12 @@ def format_skill_context_prompt(envelope):
     )
 
 
-def inject_skill_context(prompt, envelope):
-    if not has_advertised_skills(envelope):
+def inject_skill_context(prompt: str, envelope: Mapping[str, Any] | None) -> str:
+    if envelope is None or not has_advertised_skills(envelope):
         return prompt
     return f"{format_skill_context_prompt(envelope)}\n\nUser task:\n{prompt}"
 
 
-def context_file_from_env():
+def context_file_from_env() -> str | None:
     path = os.environ.get("KF_SKILL_CONTEXT_FILE")
     return path if path else None

--- a/framework/core/src/python/kungfu/skill/registry.py
+++ b/framework/core/src/python/kungfu/skill/registry.py
@@ -1,12 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 import os
+from typing import Any
 
 from .parser import SkillError, parse_skill
 
 
-def skill_roots(home, extra_paths=None):
-    roots = []
+def skill_roots(home: str, extra_paths: list[str] | None = None) -> list[str]:
+    roots: list[str] = []
     env_path = os.environ.get("KF_SKILL_PATH")
     if env_path:
         roots.extend(path for path in env_path.split(os.pathsep) if path)
@@ -16,9 +19,11 @@ def skill_roots(home, extra_paths=None):
     return roots
 
 
-def discover_skills(home, extra_paths=None):
-    rows = []
-    seen = set()
+def discover_skills(
+    home: str, extra_paths: list[str] | None = None
+) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    seen: set[str] = set()
     for root in skill_roots(home, extra_paths):
         for skill_dir in _candidate_skill_dirs(root):
             try:
@@ -32,7 +37,9 @@ def discover_skills(home, extra_paths=None):
     return rows
 
 
-def find_skill(home, key_or_path, extra_paths=None):
+def find_skill(
+    home: str, key_or_path: str, extra_paths: list[str] | None = None
+) -> dict[str, Any]:
     if os.path.exists(key_or_path):
         return parse_skill(key_or_path)
     for skill in discover_skills(home, extra_paths):
@@ -41,13 +48,15 @@ def find_skill(home, key_or_path, extra_paths=None):
     raise SkillError(f"skill not found: {key_or_path}")
 
 
-def read_skill_markdown(home, key_or_path, extra_paths=None):
+def read_skill_markdown(
+    home: str, key_or_path: str, extra_paths: list[str] | None = None
+) -> tuple[dict[str, Any], str]:
     skill = find_skill(home, key_or_path, extra_paths)
     with open(skill["source"]["path"], encoding="utf-8") as f:
         return skill, f.read()
 
 
-def _candidate_skill_dirs(root):
+def _candidate_skill_dirs(root: str) -> list[str]:
     if not root or not os.path.exists(root):
         return []
     root = os.path.abspath(root)
@@ -55,7 +64,7 @@ def _candidate_skill_dirs(root):
         return [root]
     if not os.path.isdir(root):
         return []
-    rows = []
+    rows: list[str] = []
     for name in sorted(os.listdir(root)):
         path = os.path.join(root, name)
         if os.path.isdir(path) and os.path.isfile(os.path.join(path, "SKILL.md")):


### PR DESCRIPTION
Gradual typing goal Stage 3 — SDK/public API: annotate kungfu/__init__.py and the skill public surface (context/catalog/registry/provider). Typing surfaced a real None-narrowing gap in inject_skill_context, now fixed. mypy zero-override baseline green.