### PR TITLE
feat(agent): ship local onboarding pack

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,9 @@ restating them.
   start at the documentation map, [`docs/MAP.md`](docs/MAP.md). It routes any
   question ("what does it guarantee", "how do I localize a failure", "what is the
   journal / replay model") to the document that answers it, and is written to be
-  read by both people and agents.
+  read by both people and agents. In an installed runtime, agents should first
+  read the local pack with `kungfu agent brief` and choose a mode with
+  `kungfu agent choose-mode --json`.
 - **Building or contributing to this repo** — read the rest of this file, then
   [`CONTRIBUTING.md`](CONTRIBUTING.md).
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ Start at the [**documentation map**](docs/MAP.md) — it routes your question
 (why it's built this way / how to trust the artifact / how to use it) to the
 right document, and is readable by both people and agents.
 
+- Installed agent entrypoint: `kungfu agent brief`,
+  `kungfu agent capabilities --json`, and `kungfu agent choose-mode --json`.
 - [`docs/MAP.md`](docs/MAP.md) — the question-indexed map of all documentation.
 - [`docs/concepts.md`](docs/concepts.md) — the vocabulary in one place
   (`kungfu`/`kfx`/`sdk`, `libkungfu`, `longfist`, `yijinjing`, journal, …).

--- a/docs/MAP.md
+++ b/docs/MAP.md
@@ -40,6 +40,7 @@ and the map routes a question to whichever doc answers it.
 | What gates must a release pass? | `provenance.md` + [`version-release-design.md`](version-release-design.md) | verify | partial |
 | If kungfu itself misbehaves, how do I localize it? | [`debugging.md`](debugging.md) | verify | stable |
 | How do I record an agent run and find why it failed (Rewind)? | [`rewind.md`](rewind.md) | use | stable · pre-release install path |
+| What should an installed agent read first, and which mode should it choose? | installed pack: `kungfu agent brief`, `kungfu agent capabilities --json`, `kungfu agent choose-mode --json` | use | stable |
 | How do I write an extension (`kfx`)? | [`extensions.md`](extensions.md) | use | stable · view kfx; runtime facets mid-migration |
 | Where is global config, and how do agents read it? | [`config.md`](config.md) | use | draft |
 | How is a kfx loaded, trusted, and confined? (the topology) | [`kfx-topology.md`](kfx-topology.md) (design: ADR-0017; trust boundary ADR-0013; uniform capability surface ADR-0014) | use | draft · load plan + `service` facet proposed |
@@ -79,6 +80,9 @@ route to the row that answers them:
 - **SKILL.md / agent skill / skill catalog / context injection / Node manager /
   Python manager / skill audit / skill-manager view / kfx dependency binding** →
   *agent-facing Kungfu Skill* ([`skills.md`](skills.md)).
+- **agent onboarding / mode selection / choose-mode / report mode / trace mode /
+  managed-run / remote sync / local agent facts** → the installed Agent
+  Onboarding Pack (`kungfu agent brief`, `kungfu agent capabilities --json`).
 - **signature / checksum / supply chain / SBOM** → *verify a release binary*
   (`provenance.md`, `blocked` — see [`known-limits.md`](known-limits.md)).
 - **trademark / fork / hosted service / provider compliance / cost attribution

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -150,6 +150,22 @@ on demand. A skill can reference kfx dependencies, but it cannot grant those
 packages additional runtime authority; the kfx trust gate still decides what
 can execute.
 
+### Agent onboarding pack — `kungfu agent`
+
+The installed runtime also carries a small local Agent Onboarding Pack under the
+core Python package. It is the first fact source for agents choosing whether to
+read, report structured work facts, trace an existing command, run a managed
+provider session, or handle remote evidence. The pack is exposed through
+`kungfu agent brief`, `kungfu agent capabilities --json`, and
+`kungfu agent choose-mode --json`, and it ships with provider-specific
+`SKILL.md` files that can be previewed before explicit installation.
+
+This pack is not another authority layer. It records current commands, maturity
+labels, safety boundaries, and examples so Electron, standalone CLI, npm, and
+PyPI installs do not depend on stale external notes. Future Homebrew, winget,
+container, and kfx channels must pass the same pack validation before claiming
+agent-ready packaging.
+
 ### Distribution — `artifact` (`@kungfu-tech/artifact-kungfu`)
 
 The dogfood installer: it bundles the runtime, both reference UIs and the SDK

--- a/extensions/work-dashboard/package.json
+++ b/extensions/work-dashboard/package.json
@@ -29,6 +29,7 @@
     "@kungfu-tech/kfx": "workspace:*"
   },
   "devDependencies": {
+    "@kungfu-tech/core": "workspace:*",
     "@kungfu-tech/sdk": "workspace:*",
     "@types/react": "^18.3.3"
   },

--- a/framework/core/.gyp/run-freeze.js
+++ b/framework/core/.gyp/run-freeze.js
@@ -91,6 +91,26 @@ const APP_NATIVE = [
   'link_node.node',
 ];
 
+function agentPackDataArgs() {
+  const root = path.join(CORE, 'src', 'python', 'kungfu', 'agent');
+  /** @type {string[]} */
+  const args = [];
+  /** @param {string} dir */
+  function walk(dir) {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (entry.name !== '__pycache__') walk(full);
+      } else if (!entry.name.endsWith('.py')) {
+        const rel = path.relative(root, full);
+        args.push(`--include-data-files=${full}=${path.join('agent', rel)}`);
+      }
+    }
+  }
+  walk(root);
+  return args;
+}
+
 // Ship <binary>.pdb next to a native so Windows field crash reports can resolve
 // kungfu frames to symbols; without it the stackwalker only prints module+offset
 // (see docs/windows-crash-symbols.md). No-op off Windows or when no PDB exists
@@ -241,6 +261,7 @@ function freezeNuitka(bt) {
         (m) =>
           `--include-data-files=${path.join(CORE, 'src', 'python', 'kungfu', m, `${m}_events.bfbs`)}=${m}_events.bfbs`,
       ),
+      ...agentPackDataArgs(),
       path.join('src', 'python', 'kungfu_cli.py'),
     ],
     true,

--- a/framework/core/src/python/kungfu/agent/__init__.py
+++ b/framework/core/src/python/kungfu/agent/__init__.py
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from .resources import (
+    choose_mode,
+    commands,
+    document_text,
+    index,
+    pack_root,
+    skill_path,
+)
+
+__all__ = [
+    "choose_mode",
+    "commands",
+    "document_text",
+    "index",
+    "pack_root",
+    "skill_path",
+]

--- a/framework/core/src/python/kungfu/agent/brief.md
+++ b/framework/core/src/python/kungfu/agent/brief.md
@@ -1,0 +1,32 @@
+# Kungfu Agent Onboarding Pack
+
+This installed runtime carries a local agent pack. Use it before guessing from
+old docs, release notes, or memory.
+
+Start here:
+
+```sh
+kungfu agent brief
+kungfu agent capabilities --json
+kungfu agent choose-mode --json
+```
+
+Kungfu is journal-first infrastructure for capturing local facts, replaying
+runs, and making control decisions from evidence. The agent-facing layer is not
+ambient permission. It is a set of local facts, command contracts, Skill
+instructions, and kfx trust boundaries that must remain inspectable after
+installation.
+
+Use the modes this way:
+
+- **brief**: read the local facts; no runtime action.
+- **report**: create or inspect structured work facts with `kungfu work`.
+- **trace**: capture an existing command with `kungfu trace -- <command>`.
+- **managed-run**: let Kungfu launch a provider CLI with skill context and run
+  evidence; this surface is experimental.
+- **remote-sync**: move or compare evidence across runtime boundaries; stable
+  local publishing commands are still planned.
+
+The pack is included by the Electron artifact, the standalone CLI, npm
+`@kungfu-tech/core`, and the PyPI wheel. Future Homebrew, winget, container, and
+kfx packaging must keep the same pack validation gate before claiming support.

--- a/framework/core/src/python/kungfu/agent/commands.json
+++ b/framework/core/src/python/kungfu/agent/commands.json
@@ -1,0 +1,92 @@
+{
+  "schema": "kungfu.agent-commands/v1",
+  "commands": [
+    {
+      "name": "kungfu agent brief",
+      "maturity": "stable",
+      "purpose": "Print the local onboarding brief."
+    },
+    {
+      "name": "kungfu agent docs",
+      "maturity": "stable",
+      "purpose": "Show where the installed agent pack lives and list its documents."
+    },
+    {
+      "name": "kungfu agent capabilities --json",
+      "maturity": "stable",
+      "purpose": "Print the machine-readable pack index and command catalog."
+    },
+    {
+      "name": "kungfu agent choose-mode --json",
+      "maturity": "stable",
+      "purpose": "Choose brief, report, trace, managed-run, or remote-sync from explicit flags."
+    },
+    {
+      "name": "kungfu agent install-skill --target codex",
+      "maturity": "stable",
+      "purpose": "Preview or explicitly copy the Codex skill file."
+    },
+    {
+      "name": "kungfu agent install-skill --target claude",
+      "maturity": "stable",
+      "purpose": "Preview or explicitly copy the Claude skill file."
+    },
+    {
+      "name": "kungfu trace -- <command>",
+      "maturity": "stable",
+      "purpose": "Capture an existing command into a local Rewind trace."
+    },
+    {
+      "name": "kungfu managed-run --provider <provider> --prompt <task>",
+      "maturity": "experimental",
+      "purpose": "Run a provider CLI under Kungfu supervision, skill context, and cost/audit capture."
+    },
+    {
+      "name": "kungfu work create <title> --json",
+      "maturity": "stable",
+      "purpose": "Create structured work facts in the local journal."
+    },
+    {
+      "name": "kungfu skill catalog --json",
+      "maturity": "stable",
+      "purpose": "Print the compact agent-visible Kungfu Skill catalog."
+    },
+    {
+      "name": "kungfu skill read <key-or-path> --json",
+      "maturity": "stable",
+      "purpose": "Load a full SKILL.md on demand with audit evidence."
+    },
+    {
+      "name": "kungfu kfx install <source>",
+      "maturity": "stable",
+      "purpose": "Install a kfx package through the trust disclosure path."
+    }
+  ],
+  "modes": {
+    "brief": {
+      "maturity": "stable",
+      "next": "kungfu agent brief",
+      "when": "Read local facts before choosing a runtime action."
+    },
+    "report": {
+      "maturity": "stable",
+      "next": "kungfu work create <title> --json",
+      "when": "The useful output is structured work state, decisions, checkpoints, or artifacts."
+    },
+    "trace": {
+      "maturity": "stable",
+      "next": "kungfu trace -- <command>",
+      "when": "An existing command or agent run should be captured without rewriting it."
+    },
+    "managed-run": {
+      "maturity": "experimental",
+      "next": "kungfu managed-run --provider <provider> --prompt <task>",
+      "when": "Kungfu should launch the provider CLI and bind skill context, run evidence, and reported cost."
+    },
+    "remote-sync": {
+      "maturity": "planned",
+      "next": "Use exported bundles and journal facts; remote publishing is not a stable local command yet.",
+      "when": "The main problem is moving evidence across machines or trust boundaries."
+    }
+  }
+}

--- a/framework/core/src/python/kungfu/agent/examples/managed-run.md
+++ b/framework/core/src/python/kungfu/agent/examples/managed-run.md
@@ -1,0 +1,13 @@
+# Managed Run Example
+
+Use managed-run when Kungfu should launch the provider CLI and bind Skill
+context before the run starts.
+
+```sh
+kungfu managed-run --provider claude --prompt "Inspect this failed trace"
+kungfu managed-run --provider codex --prompt "Summarize the local work facts" --print-response
+```
+
+This mode is experimental. Treat provider cost as reported only when the
+provider actually reports usage. If the provider reports tokens but no dollars,
+the dollar cost is unknown, not zero.

--- a/framework/core/src/python/kungfu/agent/examples/remote-sync.md
+++ b/framework/core/src/python/kungfu/agent/examples/remote-sync.md
@@ -1,0 +1,13 @@
+# Remote Sync Example
+
+Remote sync is planned as a stable product surface. Until a concrete installed
+command exists, use local exports and explicit provenance.
+
+```sh
+kungfu rewind export <run-id> --out ./rewind-bundle
+kungfu work artifact <work-id> --path ./rewind-bundle --json
+```
+
+When moving evidence across machines, keep source runtime, export time, bundle
+hash, and receiving runtime separate. Do not treat remote availability as proof
+that the local runtime observed the fact.

--- a/framework/core/src/python/kungfu/agent/examples/report-mode.md
+++ b/framework/core/src/python/kungfu/agent/examples/report-mode.md
@@ -1,0 +1,16 @@
+# Report Mode Example
+
+Use report mode when the useful durable fact is work state, not a captured
+process.
+
+```sh
+kungfu work create "Inspect failed extension load" --kind investigation --json
+kungfu work checkpoint <work-id> --summary "Reproduced with local bundle" --json
+kungfu work ready <work-id> --reason "Evidence attached" --json
+```
+
+Keep facts labeled:
+
+- observed: local command output, local bundle paths, local journal records.
+- reported: user description, provider output, remote service response.
+- imported: copied bundles or reports from another runtime.

--- a/framework/core/src/python/kungfu/agent/examples/trace-mode.md
+++ b/framework/core/src/python/kungfu/agent/examples/trace-mode.md
@@ -1,0 +1,13 @@
+# Trace Mode Example
+
+Use trace mode when there is already a command to run.
+
+```sh
+kungfu trace -- python3 my_agent.py
+kungfu rewind show <run-id>
+kungfu rewind export <run-id> --out ./rewind-bundle
+```
+
+`trace` should wrap the command with minimal changes. If the command already has
+its own model calls, tools, or subprocesses, keep them intact and let Rewind
+capture what the runtime can observe.

--- a/framework/core/src/python/kungfu/agent/index.json
+++ b/framework/core/src/python/kungfu/agent/index.json
@@ -1,0 +1,37 @@
+{
+  "schema": "kungfu.agent-pack/v1",
+  "title": "Kungfu Agent Onboarding Pack",
+  "summary": "Local facts for agents and people working with an installed Kungfu runtime.",
+  "version": 1,
+  "maturity": "stable",
+  "documents": [
+    { "path": "index.json", "purpose": "pack manifest", "maturity": "stable" },
+    { "path": "brief.md", "purpose": "first-read overview", "maturity": "stable" },
+    { "path": "mode-selection.md", "purpose": "choose the right operating mode", "maturity": "stable" },
+    { "path": "commands.json", "purpose": "machine-readable command and mode catalog", "maturity": "stable" },
+    { "path": "safety.md", "purpose": "fact boundaries and non-goals", "maturity": "stable" },
+    { "path": "examples/report-mode.md", "purpose": "structured work facts without process capture", "maturity": "stable" },
+    { "path": "examples/trace-mode.md", "purpose": "capture an existing command", "maturity": "stable" },
+    { "path": "examples/managed-run.md", "purpose": "supervise a provider CLI run", "maturity": "experimental" },
+    { "path": "examples/remote-sync.md", "purpose": "remote runtime boundary guidance", "maturity": "planned" }
+  ],
+  "skills": [
+    { "target": "codex", "path": "skills/codex/SKILL.md", "maturity": "stable" },
+    { "target": "claude", "path": "skills/claude/SKILL.md", "maturity": "stable" }
+  ],
+  "installChannels": [
+    { "channel": "electron", "includes": "bundled @kungfu-tech/core runtime and CLI", "maturity": "stable" },
+    { "channel": "standalone-cli", "includes": "frozen kungfu runtime", "maturity": "stable" },
+    { "channel": "npm", "includes": "@kungfu-tech/core package files", "maturity": "stable" },
+    { "channel": "pypi", "includes": "kungfu wheel package data", "maturity": "stable" },
+    { "channel": "homebrew", "includes": "future formula packaging check", "maturity": "planned" },
+    { "channel": "winget", "includes": "future installer manifest packaging check", "maturity": "planned" },
+    { "channel": "container", "includes": "future image label and filesystem check", "maturity": "planned" },
+    { "channel": "kfx", "includes": "future extension-package distribution check", "maturity": "planned" }
+  ],
+  "entrypoints": {
+    "human": "kungfu agent brief",
+    "machine": "kungfu agent capabilities --json",
+    "modeChoice": "kungfu agent choose-mode --json"
+  }
+}

--- a/framework/core/src/python/kungfu/agent/mode-selection.md
+++ b/framework/core/src/python/kungfu/agent/mode-selection.md
@@ -1,0 +1,23 @@
+# Agent Mode Selection
+
+Choose the smallest mode that preserves evidence.
+
+| Mode | Use when | First command | Maturity |
+|---|---|---|---|
+| brief | You need local facts before acting. | `kungfu agent brief` | stable |
+| report | You need structured work facts, status, decisions, or artifacts. | `kungfu work create <title> --json` | stable |
+| trace | You already have a command or agent process to capture. | `kungfu trace -- <command>` | stable |
+| managed-run | Kungfu should launch the provider CLI and bind skill context. | `kungfu managed-run --provider <provider> --prompt <task>` | experimental |
+| remote-sync | Evidence must cross machines or trust boundaries. | Use exported bundles and journal facts. | planned |
+
+Rules:
+
+- Prefer `trace` for unmodified programs.
+- Prefer `managed-run` only when Kungfu is responsible for launching the agent
+  process.
+- Prefer `report` when no process capture is needed and the durable fact is a
+  work item, checkpoint, decision, or artifact link.
+- Treat `remote-sync` as planned unless a concrete installed command says
+  otherwise.
+- Use `kungfu agent choose-mode --json` when an agent needs a machine-readable
+  recommendation.

--- a/framework/core/src/python/kungfu/agent/resources.py
+++ b/framework/core/src/python/kungfu/agent/resources.py
@@ -1,0 +1,84 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import sys
+from importlib import resources
+from pathlib import Path
+
+_PACKAGE = "kungfu.agent"
+
+
+def pack_root():
+    frozen = _frozen_pack_root()
+    if frozen is not None:
+        return frozen
+    return resources.files(_PACKAGE)
+
+
+def _frozen_pack_root():
+    candidates = []
+    executable = getattr(sys, "executable", "")
+    if executable:
+        candidates.append(Path(executable).resolve().parent / "agent")
+    argv0 = sys.argv[0] if sys.argv else ""
+    if argv0:
+        candidates.append(Path(argv0).resolve().parent / "agent")
+    for candidate in candidates:
+        if (candidate / "index.json").is_file():
+            return candidate
+    return None
+
+
+def _read_json(name):
+    return json.loads((pack_root() / name).read_text(encoding="utf-8"))
+
+
+def index():
+    return _read_json("index.json")
+
+
+def commands():
+    return _read_json("commands.json")
+
+
+def document_text(name):
+    return (pack_root() / name).read_text(encoding="utf-8")
+
+
+def skill_path(target):
+    return pack_root() / "skills" / target / "SKILL.md"
+
+
+def choose_mode(
+    *,
+    command=None,
+    needs_supervision=False,
+    has_existing_run=False,
+    needs_structured_work=False,
+    remote_runtime=False,
+):
+    if remote_runtime:
+        mode = "remote-sync"
+        reason = "Remote/runtime boundary is the primary constraint."
+    elif has_existing_run or command:
+        mode = "trace"
+        reason = "There is an existing command or run to capture without rewriting it."
+    elif needs_supervision:
+        mode = "managed-run"
+        reason = (
+            "A provider CLI should run under Kungfu supervision and cost/audit capture."
+        )
+    elif needs_structured_work:
+        mode = "report"
+        reason = "The task mainly needs structured work facts rather than a captured process."
+    else:
+        mode = "brief"
+        reason = "No runtime action is required; read the local pack first."
+    return {
+        "schema": "kungfu.agent-mode-choice/v1",
+        "mode": mode,
+        "reason": reason,
+        "command": command,
+        "maturity": commands()["modes"][mode]["maturity"],
+        "next": commands()["modes"][mode]["next"],
+    }

--- a/framework/core/src/python/kungfu/agent/safety.md
+++ b/framework/core/src/python/kungfu/agent/safety.md
@@ -1,0 +1,26 @@
+# Agent Safety Boundaries
+
+Kungfu starts from local proof, not trust in a claim.
+
+Fact labels:
+
+- **observed**: read directly from the installed runtime, local journal, local
+  bundle, local command output, or package files.
+- **reported**: provided by a provider CLI, external service, user, or imported
+  text. Keep the source attached.
+- **imported**: copied from another runtime, bundle, machine, or repository.
+  Keep provenance and do not silently promote it to observed.
+- **remote**: depends on a network service or remote machine. Treat availability,
+  identity, and freshness as separate facts.
+
+Boundaries:
+
+- A Skill instructs an agent; it does not grant runtime authority.
+- A kfx package is the executable trust artifact; its origin and trust tier are
+  decided by Kungfu, not by the path where it was found.
+- A managed run may report cost or token facts only when the provider actually
+  reports them. Missing cost is unknown, not zero.
+- Do not scrape private provider sessions, bypass billing or quota systems, or
+  misrepresent usage attribution.
+- Do not publish secrets, credentials, private logs, or local-only evidence as
+  public support material.

--- a/framework/core/src/python/kungfu/agent/skills/claude/SKILL.md
+++ b/framework/core/src/python/kungfu/agent/skills/claude/SKILL.md
@@ -1,0 +1,35 @@
+---
+key: kungfu-agent-onboarding
+title: Kungfu Agent Onboarding
+description: Use the installed Kungfu agent pack before choosing report, trace, managed-run, or remote-sync mode.
+triggers:
+  - kungfu
+  - kfx
+  - rewind
+  - managed-run
+  - trace
+capabilities:
+  - local-fact-review
+  - mode-selection
+---
+
+# Kungfu Agent Onboarding
+
+Before acting in a Kungfu runtime, read local facts from the installed pack:
+
+```sh
+kungfu agent brief
+kungfu agent capabilities --json
+kungfu agent choose-mode --json
+```
+
+Use the smallest mode that preserves evidence:
+
+- `report` for structured work facts.
+- `trace` for an existing command.
+- `managed-run` when Kungfu launches the provider CLI.
+- `remote-sync` only when the task is about crossing runtime or machine
+  boundaries; stable publishing commands are planned unless the local pack says
+  otherwise.
+
+Keep observed, reported, imported, and remote facts distinct.

--- a/framework/core/src/python/kungfu/agent/skills/codex/SKILL.md
+++ b/framework/core/src/python/kungfu/agent/skills/codex/SKILL.md
@@ -1,0 +1,35 @@
+---
+key: kungfu-agent-onboarding
+title: Kungfu Agent Onboarding
+description: Use the installed Kungfu agent pack before choosing report, trace, managed-run, or remote-sync mode.
+triggers:
+  - kungfu
+  - kfx
+  - rewind
+  - managed-run
+  - trace
+capabilities:
+  - local-fact-review
+  - mode-selection
+---
+
+# Kungfu Agent Onboarding
+
+Before acting in a Kungfu runtime, read local facts from the installed pack:
+
+```sh
+kungfu agent brief
+kungfu agent capabilities --json
+kungfu agent choose-mode --json
+```
+
+Use the smallest mode that preserves evidence:
+
+- `report` for structured work facts.
+- `trace` for an existing command.
+- `managed-run` when Kungfu launches the provider CLI.
+- `remote-sync` only when the task is about crossing runtime or machine
+  boundaries; stable publishing commands are planned unless the local pack says
+  otherwise.
+
+Keep observed, reported, imported, and remote facts distinct.

--- a/framework/core/src/python/kungfu/cli/commands/__registry__.py
+++ b/framework/core/src/python/kungfu/cli/commands/__registry__.py
@@ -13,6 +13,7 @@ from . import work
 from . import atlas
 from . import kfx
 from . import skill
+from . import agent
 from . import sdk
 
 __all__ = [
@@ -29,5 +30,6 @@ __all__ = [
     "atlas",
     "kfx",
     "skill",
+    "agent",
     "sdk",
 ]

--- a/framework/core/src/python/kungfu/cli/commands/agent.py
+++ b/framework/core/src/python/kungfu/cli/commands/agent.py
@@ -1,11 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
+import os
 import sys
 from pathlib import Path
 
 import click
 
+from kungfu import agent as agent_pack
 from kungfu.cli.commands import kfc, PrioritizedCommandGroup
 from kungfu.config import resolve_config
 
@@ -14,7 +16,7 @@ agent_command_context = kfc.pass_context()
 
 @kfc.group(
     cls=PrioritizedCommandGroup,
-    help_priority=3,
+    help_priority=2,
     help="agent-facing local Kungfu discovery entrypoint",
 )
 @click.help_option("-h", "--help")
@@ -25,6 +27,7 @@ def agent(ctx):
 
 def _context(ctx):
     config = resolve_config(runtime_home=ctx.home)
+    index = agent_pack.index()
     return {
         "schema": "kungfu.agent-context/v1",
         "entrypoint": "kungfu agent",
@@ -40,6 +43,12 @@ def _context(ctx):
             "kfx": "kungfu kfx list --json",
         },
         "docs": _docs_context(),
+        "agentPack": {
+            "packRoot": str(agent_pack.pack_root()),
+            "documents": index["documents"],
+            "skills": index["skills"],
+            "commands": agent_pack.commands(),
+        },
     }
 
 
@@ -89,19 +98,148 @@ def _json(payload):
     click.echo(json.dumps(payload, indent=2, sort_keys=True))
 
 
-@agent.command(help="print a short agent-facing brief")
+@agent.command(help="print the local onboarding brief")
 @agent_command_context
 def brief(ctx):
-    try:
-        data = _context(ctx)
-    except (OSError, ValueError, json.JSONDecodeError) as e:
-        click.echo(f"[agent] failed to load context: {e}", err=True)
-        sys.exit(1)
-    click.echo(
-        "Kungfu is available locally. Use `kungfu agent context --json` as the "
-        "single source for local config, runtime paths, skills, kfx, and docs."
+    click.echo(agent_pack.document_text("brief.md"), nl=False)
+
+
+@agent.command(help="show the installed pack path and document list")
+@click.option("--json", "as_json", is_flag=True, help="machine-readable output")
+@agent_command_context
+def docs(ctx, as_json):
+    index = agent_pack.index()
+    root = str(agent_pack.pack_root())
+    payload = {
+        "schema": "kungfu.agent-docs/v1",
+        "packRoot": root,
+        "documents": index["documents"],
+        "skills": index["skills"],
+    }
+    if as_json:
+        _json(payload)
+        return
+    click.echo(f"Agent pack: {root}")
+    for row in index["documents"]:
+        click.echo(f"- {row['path']} [{row['maturity']}]: {row['purpose']}")
+    for row in index["skills"]:
+        click.echo(f"- {row['path']} [{row['maturity']}]: {row['target']} skill")
+
+
+@agent.command(help="print machine-readable agent capabilities")
+@click.option("--json", "as_json", is_flag=True, help="machine-readable output")
+@agent_command_context
+def capabilities(ctx, as_json):
+    payload = {
+        "schema": "kungfu.agent-capabilities/v1",
+        "index": agent_pack.index(),
+        "commands": agent_pack.commands(),
+    }
+    if as_json:
+        _json(payload)
+        return
+    click.echo("Kungfu Agent Pack capabilities")
+    for row in payload["commands"]["commands"]:
+        click.echo(f"- {row['name']} [{row['maturity']}]: {row['purpose']}")
+
+
+@agent.command(help="choose the right agent operating mode")
+@click.option("--command", type=str, default=None, help="existing command to capture")
+@click.option(
+    "--needs-supervision",
+    is_flag=True,
+    help="Kungfu should launch and supervise the provider CLI",
+)
+@click.option(
+    "--has-existing-run",
+    is_flag=True,
+    help="there is already a process or run to inspect",
+)
+@click.option(
+    "--needs-structured-work",
+    is_flag=True,
+    help="the useful fact is work state, not process capture",
+)
+@click.option(
+    "--remote-runtime",
+    is_flag=True,
+    help="evidence crosses a machine or runtime boundary",
+)
+@click.option("--json", "as_json", is_flag=True, help="machine-readable output")
+@agent_command_context
+def choose_mode(
+    ctx,
+    command,
+    needs_supervision,
+    has_existing_run,
+    needs_structured_work,
+    remote_runtime,
+    as_json,
+):
+    payload = agent_pack.choose_mode(
+        command=command,
+        needs_supervision=needs_supervision,
+        has_existing_run=has_existing_run,
+        needs_structured_work=needs_structured_work,
+        remote_runtime=remote_runtime,
     )
-    click.echo(f"Config: {data['config']['configPath']}")
+    if as_json:
+        _json(payload)
+        return
+    click.echo(f"{payload['mode']} [{payload['maturity']}]: {payload['reason']}")
+    click.echo(f"next: {payload['next']}")
+
+
+@agent.command(help="preview or copy a provider skill file")
+@click.option(
+    "--target",
+    required=True,
+    type=click.Choice(["codex", "claude"]),
+    help="which provider skill to install",
+)
+@click.option(
+    "--out",
+    "out_dir",
+    type=click.Path(file_okay=False, dir_okay=True),
+    default=None,
+    help="destination directory; required with --execute",
+)
+@click.option("--execute", is_flag=True, help="copy the file after preview")
+@click.option("--force", is_flag=True, help="replace an existing SKILL.md")
+@click.option("--json", "as_json", is_flag=True, help="machine-readable output")
+@agent_command_context
+def install_skill(ctx, target, out_dir, execute, force, as_json):
+    src = agent_pack.skill_path(target)
+    dest = os.path.join(out_dir, "SKILL.md") if out_dir else None
+    payload = {
+        "schema": "kungfu.agent-skill-install/v1",
+        "target": target,
+        "source": str(src),
+        "destination": dest,
+        "execute": execute,
+        "force": force,
+        "changed": False,
+    }
+    if execute:
+        if not out_dir:
+            click.echo("[agent] --execute requires --out <directory>", err=True)
+            sys.exit(1)
+        os.makedirs(out_dir, exist_ok=True)
+        if os.path.exists(dest) and not force:
+            click.echo(f"[agent] {dest} exists (use --force to replace)", err=True)
+            sys.exit(1)
+        with open(dest, "wb") as f:
+            f.write(src.read_bytes())
+        payload["changed"] = True
+    if as_json:
+        _json(payload)
+        return
+    action = "copied" if payload["changed"] else "preview"
+    click.echo(f"[agent] {action}: {target} skill")
+    click.echo(f"[agent] source: {src}")
+    click.echo(f"[agent] destination: {dest or '<choose with --out>'}")
+    if not execute:
+        click.echo("[agent] no files changed; add --execute --out <directory> to copy")
 
 
 @agent.command(help="print the canonical agent context")

--- a/framework/core/src/python/kungfu_cli.py
+++ b/framework/core/src/python/kungfu_cli.py
@@ -23,11 +23,12 @@
 # 它只是 requests 的可选字符集探测器，缺失时 requests 回退 charset_normalizer，故不跟随编译。
 # nuitka-project: --nofollow-import-to=chardet
 #
-# `kfc engage` 的开发工具桥接(black/pdm/scons/nuitka)：这些工具均为 mypyc 编译包(.so __init__)，
+# `kfc engage` / verify 的开发工具(black/pdm/scons/nuitka/mypy)：这些工具里部分为 mypyc 编译包(.so __init__)，
 # Nuitka 4.x 拒绝把 .so 当源码编译；且把 Nuitka/SCons 自身打进冻结 kfc 不合理。bridging 全是函数内
 # 懒加载，不影响 kfc 启动与核心命令(journal/trace/rewind/schema/work/kfx)。故运行时
 # 冻结版不跟随编译这些 dev 工具；`kfc engage <tool>` 需开发环境另装这些工具（engage 打包另案处理）。
 # nuitka-project: --nofollow-import-to=black
+# nuitka-project: --nofollow-import-to=mypy
 # nuitka-project: --nofollow-import-to=pdm
 # nuitka-project: --nofollow-import-to=SCons
 # nuitka-project: --nofollow-import-to=scons

--- a/framework/core/src/python/setup.py
+++ b/framework/core/src/python/setup.py
@@ -69,7 +69,19 @@ setup(
     url=urls.get("homepage"),
     project_urls={"repository": urls["repository"]} if "repository" in urls else {},
     packages=[""] + find_packages(exclude=["test"]),
-    package_data={"": ["*.dll", "*.dylib", "*.pyd", "*.so", "*.so.*", "*.json"]},
+    package_data={
+        "": [
+            "*.dll",
+            "*.dylib",
+            "*.pyd",
+            "*.so",
+            "*.so.*",
+            "*.json",
+            "*.md",
+            "examples/*.md",
+            "skills/*/SKILL.md",
+        ]
+    },
     include_package_data=True,
     # [project].dependencies 已是 PEP 508 完整约束（含平台 marker），直接作为 wheel
     # 的 install_requires；与旧 poetry 把全部 deps 注入 install_requires 行为等价。

--- a/framework/gui/src/main/index.ts
+++ b/framework/gui/src/main/index.ts
@@ -228,6 +228,31 @@ function buildMenu() {
         });
       },
     },
+    {
+      label: 'Show Agent Onboarding Brief',
+      click: async () => {
+        const kungfuBin = path.join(
+          path.dirname(process.env.KFE_PATH),
+          'kungfu',
+        );
+        try {
+          const out = execFileSync(kungfuBin, ['agent', 'brief'], {
+            timeout: 10000,
+          });
+          await dialog.showMessageBox({
+            type: 'info',
+            message: 'Kungfu Agent Onboarding',
+            detail: out.toString().slice(0, 4000),
+          });
+        } catch (e) {
+          await dialog.showMessageBox({
+            type: 'error',
+            message: 'Could not read Agent Onboarding brief',
+            detail: (e as Error).message,
+          });
+        }
+      },
+    },
   ];
 
   const template: Electron.MenuItemConstructorOptions[] = [

--- a/framework/tui/src/main.tsx
+++ b/framework/tui/src/main.tsx
@@ -144,6 +144,9 @@ function App({
       <Text dimColor>
         runtime home: {ledger.runtimeDir} · runs: {runs} · press q to quit
       </Text>
+      <Text dimColor>
+        agent quickstart: kungfu agent brief · kungfu agent capabilities --json
+      </Text>
       <KfxPanel plan={kfxPlan} />
       <Box flexDirection="column" borderStyle="round" paddingX={1}>
         <Text dimColor>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -273,6 +273,9 @@ importers:
         specifier: ^18.3.1
         version: 18.3.1
     devDependencies:
+      '@kungfu-tech/core':
+        specifier: workspace:*
+        version: link:../../framework/core
       '@kungfu-tech/sdk':
         specifier: workspace:*
         version: link:../../developer/sdk

--- a/scripts/no-bash-guard.mjs
+++ b/scripts/no-bash-guard.mjs
@@ -46,7 +46,9 @@ export function scanTree(root) {
     }
     for (const e of entries) {
       if (e.isDirectory()) {
-        if (!SKIP_DIRS.has(e.name)) walk(path.join(dir, e.name));
+        if (!SKIP_DIRS.has(e.name) && !e.name.startsWith('.venv')) {
+          walk(path.join(dir, e.name));
+        }
       } else if (e.name.endsWith('.sh')) {
         hits.push(path.relative(root, path.join(dir, e.name)));
       }

--- a/scripts/verify-agent-pack.mjs
+++ b/scripts/verify-agent-pack.mjs
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: Apache-2.0
+// @ts-check
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const ROOT = path.resolve(__dirname, '..');
+const PACK = path.join(
+  ROOT,
+  'framework',
+  'core',
+  'src',
+  'python',
+  'kungfu',
+  'agent',
+);
+
+const REQUIRED = [
+  'index.json',
+  'brief.md',
+  'mode-selection.md',
+  'commands.json',
+  'safety.md',
+  'examples/report-mode.md',
+  'examples/trace-mode.md',
+  'examples/managed-run.md',
+  'examples/remote-sync.md',
+  'skills/codex/SKILL.md',
+  'skills/claude/SKILL.md',
+];
+
+/** @type {string[]} */
+const failures = [];
+
+function fail(message) {
+  failures.push(message);
+}
+
+function read(rel) {
+  return fs.readFileSync(path.join(PACK, rel), 'utf8');
+}
+
+function readJson(rel) {
+  return JSON.parse(read(rel));
+}
+
+function exists(rel) {
+  return fs.existsSync(path.join(PACK, rel));
+}
+
+for (const rel of REQUIRED) {
+  if (!exists(rel)) fail(`missing ${rel}`);
+}
+
+let index = null;
+let commands = null;
+try {
+  index = readJson('index.json');
+} catch (e) {
+  fail(`index.json is invalid JSON: ${e instanceof Error ? e.message : e}`);
+}
+try {
+  commands = readJson('commands.json');
+} catch (e) {
+  fail(`commands.json is invalid JSON: ${e instanceof Error ? e.message : e}`);
+}
+
+if (index) {
+  const docs = new Set((index.documents || []).map((row) => row.path));
+  const skills = new Set((index.skills || []).map((row) => row.path));
+  for (const rel of REQUIRED) {
+    if (rel.startsWith('skills/')) {
+      if (!skills.has(rel)) fail(`index.json does not list ${rel}`);
+    } else if (!docs.has(rel)) {
+      fail(`index.json does not list ${rel}`);
+    }
+  }
+  for (const channel of [
+    'electron',
+    'standalone-cli',
+    'npm',
+    'pypi',
+    'homebrew',
+    'winget',
+    'container',
+    'kfx',
+  ]) {
+    if (!(index.installChannels || []).some((row) => row.channel === channel)) {
+      fail(`index.json missing install channel ${channel}`);
+    }
+  }
+}
+
+if (commands) {
+  const names = new Set((commands.commands || []).map((row) => row.name));
+  for (const name of [
+    'kungfu agent brief',
+    'kungfu agent docs',
+    'kungfu agent capabilities --json',
+    'kungfu agent choose-mode --json',
+    'kungfu agent install-skill --target codex',
+    'kungfu agent install-skill --target claude',
+    'kungfu trace -- <command>',
+    'kungfu managed-run --provider <provider> --prompt <task>',
+    'kungfu work create <title> --json',
+    'kungfu skill catalog --json',
+    'kungfu kfx install <source>',
+  ]) {
+    if (!names.has(name)) fail(`commands.json missing command ${name}`);
+  }
+  for (const mode of [
+    'brief',
+    'report',
+    'trace',
+    'managed-run',
+    'remote-sync',
+  ]) {
+    if (!commands.modes?.[mode]) fail(`commands.json missing mode ${mode}`);
+    if (!commands.modes?.[mode]?.maturity)
+      fail(`commands.json mode ${mode} missing maturity`);
+  }
+}
+
+const safety = exists('safety.md') ? read('safety.md') : '';
+for (const term of ['observed', 'reported', 'imported', 'remote']) {
+  if (!safety.includes(`**${term}**`)) fail(`safety.md missing ${term} label`);
+}
+for (const phrase of ['does not grant runtime authority', 'kfx package']) {
+  if (!safety.includes(phrase))
+    fail(`safety.md missing safety phrase: ${phrase}`);
+}
+
+const commandPrefixes = commands
+  ? (commands.commands || []).map((row) =>
+      row.name
+        .split(' --')[0]
+        .replace(/ <[^>]+>/g, '')
+        .trim(),
+    )
+  : [];
+for (const rel of REQUIRED.filter((p) => p.endsWith('.md'))) {
+  const text = read(rel);
+  const matches = text.matchAll(/^(kungfu [^\n]+)/gm);
+  for (const match of matches) {
+    const bare = match[1].trim();
+    if (
+      bare.startsWith('kungfu agent') ||
+      bare.startsWith('kungfu trace') ||
+      bare.startsWith('kungfu managed-run') ||
+      bare.startsWith('kungfu work') ||
+      bare.startsWith('kungfu rewind')
+    ) {
+      const known =
+        commandPrefixes.some((prefix) => bare.startsWith(prefix)) ||
+        bare.startsWith('kungfu rewind') ||
+        bare.startsWith('kungfu work checkpoint') ||
+        bare.startsWith('kungfu work ready') ||
+        bare.startsWith('kungfu work artifact');
+      if (!known) fail(`${rel} references undeclared command: ${match[1]}`);
+    }
+  }
+}
+
+const registry = fs.readFileSync(
+  path.join(
+    ROOT,
+    'framework',
+    'core',
+    'src',
+    'python',
+    'kungfu',
+    'cli',
+    'commands',
+    '__registry__.py',
+  ),
+  'utf8',
+);
+if (!registry.includes('from . import agent'))
+  fail('CLI registry does not import agent');
+
+const setup = fs.readFileSync(
+  path.join(ROOT, 'framework', 'core', 'src', 'python', 'setup.py'),
+  'utf8',
+);
+for (const pattern of ['*.md', 'examples/*.md', 'skills/*/SKILL.md']) {
+  if (!setup.includes(pattern))
+    fail(`setup.py package_data missing ${pattern}`);
+}
+
+const freeze = fs.readFileSync(
+  path.join(ROOT, 'framework', 'core', '.gyp', 'run-freeze.js'),
+  'utf8',
+);
+if (!freeze.includes('agentPackDataArgs()')) {
+  fail('run-freeze.js does not include agent pack data helper');
+}
+
+const gui = fs.readFileSync(
+  path.join(ROOT, 'framework', 'gui', 'src', 'main', 'index.ts'),
+  'utf8',
+);
+if (!gui.includes("['agent', 'brief']"))
+  fail('GUI menu does not expose agent brief');
+
+const tui = fs.readFileSync(
+  path.join(ROOT, 'framework', 'tui', 'src', 'main.tsx'),
+  'utf8',
+);
+if (!tui.includes('kungfu agent brief'))
+  fail('TUI does not point to agent brief');
+
+if (failures.length) {
+  console.error(failures.map((f) => `- ${f}`).join('\n'));
+  process.exit(1);
+}
+
+console.log(
+  `ok (${REQUIRED.length} files, ${commands?.commands?.length || 0} commands)`,
+);

--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -17,7 +17,7 @@
 //   - framework/core/dist/kungfu/                     freeze artifact directory (run-freeze.js renameSync target)
 //   - framework/core/dist/kungfu/kfc[.exe]           kfc executable (path resolved by lib/executable.js)
 //   - `kfc --version` exits 0 and output contains the expected version   frozen Python runtime runs end to end (runtime smoke)
-//   - framework/gui/dist/app/                      (--with-app) build:app webpack artifact
+//   - framework/gui/out/                           (--with-app) build:app electron-vite artifact
 //
 // Exit codes: all green 0; any failed assertion 1 (fail-fast prints copy-pastable troubleshooting info).
 // Note: an Electron app's "interactive launch" cannot be asserted in a headless environment, so kfc
@@ -170,6 +170,24 @@ function main() {
         .join(' | ') || `mypy exited ${mypy.status}`,
     );
 
+  // ── Stage 0c: installed agent onboarding pack ────────────────────
+  // The pack is a shipped local fact source. It must be present before any
+  // artifact can honestly claim agent-ready install paths.
+  console.log('\n[verify] stage 0c: agent onboarding pack');
+  const agentPack = spawnSync(
+    process.execPath,
+    [path.join(__dirname, 'verify-agent-pack.mjs')],
+    { encoding: 'utf8' },
+  );
+  if (agentPack.status === 0)
+    pass('agent onboarding pack', (agentPack.stdout || '').trim());
+  else
+    fail(
+      'agent onboarding pack',
+      `${agentPack.stdout || ''}${agentPack.stderr || ''}`.trim() ||
+        `verify-agent-pack exited ${agentPack.status}`,
+    );
+
   // ── Stage 0: toolchain preflight (read-only) ──────────────────────
   console.log('\n[verify] stage 0: toolchain preflight');
   const uv = spawnSync('uv', ['--version'], { encoding: 'utf8', shell: isWin });
@@ -235,7 +253,24 @@ function main() {
           `python probe build failed (exit ${exitLabel(pyProbeBuild.status, pyProbeBuild.signal)})`,
         );
       }
-      if (withApp) runPnpm('build:app'); // webpack → framework/gui/dist/app
+      // KFX distribution fixtures pack/install the real work-dashboard
+      // extension. Build it here so `verify --full` is a complete gate instead
+      // of depending on a manual pre-run `kungfu sdk kfx build`.
+      const workDashboardBuild = spawnSync(
+        'pnpm',
+        ['--filter', '@kungfu-tech/kfx-view-work-dashboard', 'run', 'build'],
+        {
+          cwd: ROOT,
+          stdio: 'inherit',
+          shell: isWin,
+        },
+      );
+      if (workDashboardBuild.status !== 0) {
+        throw new Error(
+          `work-dashboard kfx build failed (exit ${exitLabel(workDashboardBuild.status, workDashboardBuild.signal)})`,
+        );
+      }
+      if (withApp) runPnpm('build:app'); // electron-vite → framework/gui/out
     } catch (e) {
       fail('build stage', e instanceof Error ? e.message : String(e));
       return summarize(); // on build failure, wrap up directly and do not assert half-built artifacts
@@ -429,17 +464,25 @@ function main() {
   // ── Stage 4: (optional) app build artifact ────────────────────────
   if (withApp) {
     console.log('\n[verify] stage 4: app build artifact assertion');
-    const appDist = path.join(ROOT, 'framework', 'app', 'dist', 'app');
+    const appOut = path.join(ROOT, 'framework', 'gui', 'out');
+    const requiredAppArtifacts = [
+      'main/index.js',
+      'preload/sandbox.js',
+      'renderer/index.html',
+    ];
+    const missing = requiredAppArtifacts.filter(
+      (rel) => !fs.existsSync(path.join(appOut, rel)),
+    );
     if (
-      fs.existsSync(appDist) &&
-      fs.statSync(appDist).isDirectory() &&
-      fs.readdirSync(appDist).length > 0
+      missing.length === 0 &&
+      fs.existsSync(appOut) &&
+      fs.statSync(appOut).isDirectory()
     ) {
-      pass('build:app artifact exists', path.relative(ROOT, appDist));
+      pass('build:app artifact exists', path.relative(ROOT, appOut));
     } else {
       fail(
         'build:app artifact exists',
-        `non-empty ${path.relative(ROOT, appDist)} not found (build:app first)`,
+        `missing ${missing.join(', ') || path.relative(ROOT, appOut)} (build:app first)`,
       );
     }
   }

--- a/tests/fixtures/_harness.mjs
+++ b/tests/fixtures/_harness.mjs
@@ -161,6 +161,7 @@ export function background(cmd, args, opts = {}) {
       /* already gone */
     }
   });
+  child.unref();
   return child;
 }
 

--- a/tests/fixtures/kfx-demo-sandbox-launch/run.mjs
+++ b/tests/fixtures/kfx-demo-sandbox-launch/run.mjs
@@ -12,6 +12,10 @@ import path from 'node:path';
 import { locate } from '../_harness.mjs';
 
 const { fixtureDir } = locate(import.meta.url);
+const resolver = path.resolve(
+  fixtureDir,
+  '../../../framework/api/src/capability/guest-harness/ts-resolve.mjs',
+);
 
 // parent.mjs is the gate entry: it composes the launcher/transport/host and
 // spawns child.py under the OS sandbox. It self-skips (exit 0) when no OS
@@ -19,7 +23,12 @@ const { fixtureDir } = locate(import.meta.url);
 // under the TS type-stripping flag and surface its exit code verbatim.
 const r = spawnSync(
   process.execPath,
-  ['--experimental-transform-types', path.join(fixtureDir, 'parent.mjs')],
+  [
+    '--import',
+    resolver,
+    '--experimental-transform-types',
+    path.join(fixtureDir, 'parent.mjs'),
+  ],
   { stdio: 'inherit' },
 );
 process.exit(r.status ?? 1);

--- a/tests/fixtures/kfx-demo-subprocess-caps/run.mjs
+++ b/tests/fixtures/kfx-demo-subprocess-caps/run.mjs
@@ -12,12 +12,21 @@ import path from 'node:path';
 import { locate } from '../_harness.mjs';
 
 const { fixtureDir } = locate(import.meta.url);
+const resolver = path.resolve(
+  fixtureDir,
+  '../../../framework/api/src/capability/guest-harness/ts-resolve.mjs',
+);
 
 // parent.mjs is the gate entry (a Node host that spawns child.py over stdio);
 // run it unchanged under the TS type-stripping flag and surface its exit code.
 const r = spawnSync(
   process.execPath,
-  ['--experimental-transform-types', path.join(fixtureDir, 'parent.mjs')],
+  [
+    '--import',
+    resolver,
+    '--experimental-transform-types',
+    path.join(fixtureDir, 'parent.mjs'),
+  ],
   { stdio: 'inherit' },
 );
 process.exit(r.status ?? 1);

--- a/tests/fixtures/rewind-demo-langchain/.gitignore
+++ b/tests/fixtures/rewind-demo-langchain/.gitignore
@@ -1,2 +1,2 @@
-# provisioned on demand by run.sh; the real framework install, not source
+# provisioned on demand by run.mjs; the real framework install, not source
 .venv-langchain/

--- a/tests/fixtures/rewind-demo-langchain/run.mjs
+++ b/tests/fixtures/rewind-demo-langchain/run.mjs
@@ -18,6 +18,7 @@
 //   Requires the core dev environment (built dist/kungfu) and network on first run
 //   to install langchain; the run itself uses a deterministic mock model.
 
+import fs from 'node:fs';
 import path from 'node:path';
 import {
   locate,
@@ -41,6 +42,7 @@ const agentPy =
     : path.join(venv, 'bin', 'python');
 
 const hasLangchain = () =>
+  fs.existsSync(agentPy) &&
   run(agentPy, ['-c', 'import langchain, langchain_openai'], {
     allowFail: true,
   }).status === 0;


### PR DESCRIPTION
## Summary
- ship a local Kungfu Agent Onboarding Pack with docs, command metadata, mode selection, safety boundaries, and provider skills
- expose `kungfu agent` as the local discovery surface and package the pack into the frozen runtime
- extend verification so pack files, package data, frozen data files, GUI/TUI pointers, and kfx sandbox fixtures stay covered

## Validation
- `./kungfu-code verify --full --with-app` -> 39/39 passed on the linear branch
- `node scripts/no-bash-guard.mjs && git diff --check`
- `node scripts/verify-agent-pack.mjs`
- `uv run --frozen mypy src/python/kungfu`

Supersedes #280; this branch has an identical tracked tree but a linear single-commit history for the repository rebase-only merge policy.