### PR TITLE
feat(rewind): add fact bridge ingestion sync

### DIFF
--- a/framework/api/src/capability/index.ts
+++ b/framework/api/src/capability/index.ts
@@ -5,6 +5,7 @@ export * from './types.js';
 export * from './ledger.js';
 export * from './domain.js';
 export * from './rewind.js';
+export * from './remote.js';
 export * from './schema.js';
 export * from './sandbox.js';
 export * from './terminal.js';

--- a/framework/api/src/capability/remote.ts
+++ b/framework/api/src/capability/remote.ts
@@ -1,0 +1,170 @@
+import {
+  type KfLocator,
+  type KfNativeBinding,
+  resolveRuntimeDir,
+} from './types.js';
+// Remote-source capability handle: read source-scoped mirrors under
+// <runtime>/remotes without promoting them into the local authoritative
+// runtime. GUI/TUI surfaces can render remote work with source and staleness
+// labels while continuing to use the same Work projection shape.
+import { type WorkItem, openWork } from './work.js';
+
+export type RemoteSyncState = 'fresh' | 'stale' | 'failed' | 'never' | string;
+
+export type RemoteSource = {
+  id: string;
+  host?: string;
+  home?: string;
+  transport?: string;
+  [key: string]: unknown;
+};
+
+export type RemoteProjection = {
+  sourceId: string;
+  source: RemoteSource;
+  sourceLabel: string;
+  syncState: RemoteSyncState;
+  lastSyncedAt?: string;
+  mirrorRuntime: string;
+  captureMode: 'imported';
+};
+
+export type RemoteWorkItem = WorkItem & {
+  source: string;
+  sourceId: string;
+  syncState: RemoteSyncState;
+  lastSyncedAt?: string;
+  mirrorRuntime: string;
+  captureMode: 'imported';
+};
+
+export type RemoteWork = {
+  runtimeDir: string;
+  sources: () => RemoteProjection[];
+  items: () => RemoteWorkItem[];
+  refresh: () => void;
+};
+
+export type OpenRemoteWorkOptions = {
+  binding: KfNativeBinding;
+  locator: KfLocator;
+  readFile: (path: string) => Uint8Array;
+  readDir: (dir: string) => string[];
+};
+
+const decoder = new TextDecoder();
+
+function decodeJson<T>(
+  readFile: (path: string) => Uint8Array,
+  path: string,
+): T {
+  return JSON.parse(decoder.decode(readFile(path))) as T;
+}
+
+function sourceProjection(
+  runtimeDir: string,
+  source: RemoteSource,
+  readFile: (path: string) => Uint8Array,
+): RemoteProjection {
+  const sourceId = String(source.id);
+  const mirrorRuntime = `${runtimeDir}/remotes/${sourceId}/runtime`;
+  let syncState: RemoteSyncState = 'never';
+  let lastSyncedAt: string | undefined;
+  try {
+    const manifest = decodeJson<{
+      sync_state?: string;
+      last_synced_at?: string;
+      mirror_runtime?: string;
+    }>(readFile, `${runtimeDir}/remotes/${sourceId}/sync-manifest.json`);
+    syncState = manifest.sync_state ?? 'stale';
+    lastSyncedAt = manifest.last_synced_at;
+    return {
+      sourceId,
+      source,
+      sourceLabel: `remote:${sourceId}`,
+      syncState,
+      lastSyncedAt,
+      mirrorRuntime: manifest.mirror_runtime ?? mirrorRuntime,
+      captureMode: 'imported',
+    };
+  } catch {
+    return {
+      sourceId,
+      source,
+      sourceLabel: `remote:${sourceId}`,
+      syncState,
+      mirrorRuntime,
+      captureMode: 'imported',
+    };
+  }
+}
+
+export function openRemoteWork(options: OpenRemoteWorkOptions): RemoteWork {
+  const { binding, readFile } = options;
+  const runtimeDir = resolveRuntimeDir(options.locator);
+
+  let cachedSources: RemoteProjection[] | null = null;
+  let cachedItems: RemoteWorkItem[] | null = null;
+
+  const loadSources = (): RemoteProjection[] => {
+    if (cachedSources) return cachedSources;
+    let raw: { sources?: Record<string, RemoteSource> };
+    try {
+      raw = decodeJson(readFile, `${runtimeDir}/remotes/sources.json`);
+    } catch {
+      cachedSources = [];
+      return cachedSources;
+    }
+    cachedSources = Object.entries(raw.sources ?? {})
+      .map(([sourceId, source]) =>
+        sourceProjection(
+          runtimeDir,
+          { ...source, id: source.id ?? sourceId },
+          readFile,
+        ),
+      )
+      .sort((a, b) => a.sourceId.localeCompare(b.sourceId));
+    return cachedSources;
+  };
+
+  const loadItems = (): RemoteWorkItem[] => {
+    if (cachedItems) return cachedItems;
+    cachedItems = [];
+    for (const projection of loadSources()) {
+      if (projection.syncState === 'never') continue;
+      const work = openWork({
+        binding,
+        locator: { runtimeDir: projection.mirrorRuntime },
+      });
+      for (const item of work.items()) {
+        cachedItems.push({
+          ...item,
+          source: projection.sourceLabel,
+          sourceId: projection.sourceId,
+          syncState: projection.syncState,
+          lastSyncedAt: projection.lastSyncedAt,
+          mirrorRuntime: projection.mirrorRuntime,
+          captureMode: projection.captureMode,
+        });
+      }
+    }
+    cachedItems.sort((a, b) =>
+      a.updatedTime < b.updatedTime
+        ? 1
+        : a.updatedTime > b.updatedTime
+          ? -1
+          : 0,
+    );
+    return cachedItems;
+  };
+
+  return {
+    runtimeDir,
+    refresh: () => {
+      cachedSources = null;
+      cachedItems = null;
+    },
+    sources: () => loadSources(),
+    items: () => loadItems(),
+  };
+}

--- a/framework/api/src/capability/rewind.ts
+++ b/framework/api/src/capability/rewind.ts
@@ -81,6 +81,13 @@ export type RewindEvent = {
   workId?: string;
   sessionId?: string;
   surface?: string;
+  // approval facts (ApprovalDecision). `decision` follows the generated
+  // Decision enum (0 Approve, 1 Deny, 2 Interrupt, 3 Resume).
+  requestId?: string;
+  decision?: number;
+  decidedBy?: string;
+  detail?: string;
+  reason?: string;
   // any decoded field not mapped to a typed slot above (kfx events, or new
   // schema fields added before this mapping table learns them).
   extra?: Record<string, unknown>;
@@ -176,6 +183,11 @@ const TYPED_SLOTS = new Set<string>([
   'workId',
   'sessionId',
   'surface',
+  'requestId',
+  'decision',
+  'decidedBy',
+  'detail',
+  'reason',
 ]);
 
 // Map a reflection-decoded record (snake_case fields, null for absent scalars)

--- a/framework/api/src/capability/types.js
+++ b/framework/api/src/capability/types.js
@@ -1,3 +1,9 @@
 // Runtime shim for Node's native TypeScript transform in source-level fixtures.
 // TypeScript resolves `./types.js` to `types.ts`; Node needs a real JS module.
-export { bigintSafe, toSerializable } from './types.ts';
+export {
+  bigintSafe,
+  categoryName,
+  modeName,
+  resolveRuntimeDir,
+  toSerializable,
+} from './types.ts';

--- a/framework/core/src/python/kungfu/agent/brief.md
+++ b/framework/core/src/python/kungfu/agent/brief.md
@@ -20,12 +20,14 @@ installation.
 Use the modes this way:
 
 - **brief**: read the local facts; no runtime action.
-- **report**: create or inspect structured work facts with `kungfu work`.
+- **report**: create or inspect structured work facts with `kungfu work`, and
+  append external run facts with `kungfu report`.
 - **trace**: capture an existing command with `kungfu trace -- <command>`.
 - **managed-run**: let Kungfu launch a provider CLI with skill context and run
   evidence; this surface is experimental.
-- **remote-sync**: move or compare evidence across runtime boundaries; stable
-  local publishing commands are still planned.
+- **remote-sync**: mirror evidence across runtime boundaries with source labels;
+  `kungfu remote` is experimental and does not merge remote facts into local
+  authoritative truth.
 
 The pack is included by the Electron artifact, the standalone CLI, npm
 `@kungfu-tech/core`, and the PyPI wheel. Future Homebrew, winget, container, and

--- a/framework/core/src/python/kungfu/agent/commands.json
+++ b/framework/core/src/python/kungfu/agent/commands.json
@@ -47,6 +47,31 @@
       "purpose": "Create structured work facts in the local journal."
     },
     {
+      "name": "kungfu report run begin --work <work-id> --provider <provider> --json",
+      "maturity": "experimental",
+      "purpose": "Open a reported external agent run without changing how the agent is launched."
+    },
+    {
+      "name": "kungfu report cost --run <run-id> --provider <provider> --json",
+      "maturity": "experimental",
+      "purpose": "Append reported token and cost facts to a run journal."
+    },
+    {
+      "name": "kungfu report run end --run <run-id> --status <status> --json",
+      "maturity": "experimental",
+      "purpose": "Close a reported external run and refresh its manifest."
+    },
+    {
+      "name": "kungfu remote add <source-id> --host <host> --home <kf-home> --json",
+      "maturity": "experimental",
+      "purpose": "Register a source runtime for source-scoped evidence sync."
+    },
+    {
+      "name": "kungfu remote sync <source-id> --json",
+      "maturity": "experimental",
+      "purpose": "Mirror source runtime facts under remotes/<source-id>/runtime without mixing them into local truth."
+    },
+    {
       "name": "kungfu skill catalog --json",
       "maturity": "stable",
       "purpose": "Print the compact agent-visible Kungfu Skill catalog."
@@ -70,8 +95,8 @@
     },
     "report": {
       "maturity": "stable",
-      "next": "kungfu work create <title> --json",
-      "when": "The useful output is structured work state, decisions, checkpoints, or artifacts."
+      "next": "kungfu work create <title> --json; use kungfu report run begin when the fact belongs to an external run.",
+      "when": "The useful output is structured work state, decisions, checkpoints, artifacts, or reported external run facts."
     },
     "trace": {
       "maturity": "stable",
@@ -84,9 +109,9 @@
       "when": "Kungfu should launch the provider CLI and bind skill context, run evidence, and reported cost."
     },
     "remote-sync": {
-      "maturity": "planned",
-      "next": "Use exported bundles and journal facts; remote publishing is not a stable local command yet.",
-      "when": "The main problem is moving evidence across machines or trust boundaries."
+      "maturity": "experimental",
+      "next": "kungfu remote add <source-id> --host <host> --home <kf-home> --json; kungfu remote sync <source-id> --json",
+      "when": "The main problem is moving evidence across machines or runtime trust boundaries."
     }
   }
 }

--- a/framework/core/src/python/kungfu/agent/examples/remote-sync.md
+++ b/framework/core/src/python/kungfu/agent/examples/remote-sync.md
@@ -1,13 +1,14 @@
 # Remote Sync Example
 
-Remote sync is planned as a stable product surface. Until a concrete installed
-command exists, use local exports and explicit provenance.
+Remote sync mirrors a source runtime into a source-scoped local projection.
+It is experimental and does not merge remote facts into local authoritative
+truth.
 
 ```sh
-kungfu rewind export <run-id> --out ./rewind-bundle
-kungfu work artifact <work-id> --path ./rewind-bundle --json
+kungfu remote add ubuntu --host ubuntu.local --home /home/dkr/.kungfu --json
+kungfu remote sync ubuntu --json
 ```
 
 When moving evidence across machines, keep source runtime, export time, bundle
-hash, and receiving runtime separate. Do not treat remote availability as proof
-that the local runtime observed the fact.
+hash when available, and receiving runtime separate. Do not treat remote
+availability as proof that the local runtime observed the fact.

--- a/framework/core/src/python/kungfu/agent/examples/report-mode.md
+++ b/framework/core/src/python/kungfu/agent/examples/report-mode.md
@@ -9,6 +9,14 @@ kungfu work checkpoint <work-id> --summary "Reproduced with local bundle" --json
 kungfu work ready <work-id> --reason "Evidence attached" --json
 ```
 
+For an external agent run that should not be launched by Kungfu:
+
+```sh
+kungfu report run begin --work <work-id> --provider codex --json
+kungfu report cost --run <run-id> --provider codex --model gpt-5 --usd 0.42 --json
+kungfu report run end --run <run-id> --status succeeded --json
+```
+
 Keep facts labeled:
 
 - observed: local command output, local bundle paths, local journal records.

--- a/framework/core/src/python/kungfu/agent/index.json
+++ b/framework/core/src/python/kungfu/agent/index.json
@@ -13,7 +13,7 @@
     { "path": "examples/report-mode.md", "purpose": "structured work facts without process capture", "maturity": "stable" },
     { "path": "examples/trace-mode.md", "purpose": "capture an existing command", "maturity": "stable" },
     { "path": "examples/managed-run.md", "purpose": "supervise a provider CLI run", "maturity": "experimental" },
-    { "path": "examples/remote-sync.md", "purpose": "remote runtime boundary guidance", "maturity": "planned" }
+    { "path": "examples/remote-sync.md", "purpose": "remote runtime boundary guidance", "maturity": "experimental" }
   ],
   "skills": [
     { "target": "codex", "path": "skills/codex/SKILL.md", "maturity": "stable" },

--- a/framework/core/src/python/kungfu/agent/mode-selection.md
+++ b/framework/core/src/python/kungfu/agent/mode-selection.md
@@ -5,10 +5,10 @@ Choose the smallest mode that preserves evidence.
 | Mode | Use when | First command | Maturity |
 |---|---|---|---|
 | brief | You need local facts before acting. | `kungfu agent brief` | stable |
-| report | You need structured work facts, status, decisions, or artifacts. | `kungfu work create <title> --json` | stable |
+| report | You need structured work facts, status, decisions, artifacts, or reported external run facts. | `kungfu work create <title> --json` or `kungfu report run begin --work <work-id> --provider <provider> --json` | stable |
 | trace | You already have a command or agent process to capture. | `kungfu trace -- <command>` | stable |
 | managed-run | Kungfu should launch the provider CLI and bind skill context. | `kungfu managed-run --provider <provider> --prompt <task>` | experimental |
-| remote-sync | Evidence must cross machines or trust boundaries. | Use exported bundles and journal facts. | planned |
+| remote-sync | Evidence must cross machines or runtime trust boundaries. | `kungfu remote add <source-id> --host <host> --home <kf-home> --json` then `kungfu remote sync <source-id> --json` | experimental |
 
 Rules:
 
@@ -16,8 +16,9 @@ Rules:
 - Prefer `managed-run` only when Kungfu is responsible for launching the agent
   process.
 - Prefer `report` when no process capture is needed and the durable fact is a
-  work item, checkpoint, decision, or artifact link.
-- Treat `remote-sync` as planned unless a concrete installed command says
-  otherwise.
+  work item, checkpoint, decision, artifact link, or reported external run fact.
+- Treat `remote-sync` as source-scoped import: remote facts stay under
+  `remotes/<source-id>/runtime` unless a later command explicitly promotes
+  them.
 - Use `kungfu agent choose-mode --json` when an agent needs a machine-readable
   recommendation.

--- a/framework/core/src/python/kungfu/cli/commands/__registry__.py
+++ b/framework/core/src/python/kungfu/cli/commands/__registry__.py
@@ -6,6 +6,8 @@ from . import cockpit
 from . import trace
 from . import managed_run
 from . import contract
+from . import report
+from . import remote
 from . import config
 from . import agent
 from . import rewind
@@ -24,6 +26,8 @@ __all__ = [
     "trace",
     "managed_run",
     "contract",
+    "report",
+    "remote",
     "config",
     "agent",
     "rewind",

--- a/framework/core/src/python/kungfu/cli/commands/__registry__.py
+++ b/framework/core/src/python/kungfu/cli/commands/__registry__.py
@@ -5,9 +5,9 @@ from . import journal
 from . import cockpit
 from . import trace
 from . import managed_run
-from . import contract
 from . import report
 from . import remote
+from . import contract
 from . import config
 from . import agent
 from . import rewind
@@ -25,9 +25,9 @@ __all__ = [
     "cockpit",
     "trace",
     "managed_run",
-    "contract",
     "report",
     "remote",
+    "contract",
     "config",
     "agent",
     "rewind",

--- a/framework/core/src/python/kungfu/cli/commands/remote.py
+++ b/framework/core/src/python/kungfu/cli/commands/remote.py
@@ -1,0 +1,106 @@
+#  SPDX-License-Identifier: Apache-2.0
+
+import json
+import sys
+
+import click
+
+from kungfu.cli.commands import kfc, PrioritizedCommandGroup
+from kungfu.remote import store
+
+remote_command_context = kfc.pass_context()
+
+
+@kfc.group(
+    cls=PrioritizedCommandGroup,
+    help_priority=3,
+    help="manage remote Kungfu fact sources and source-scoped mirrors",
+)
+@click.help_option("-h", "--help")
+@kfc.pass_context()
+def remote(ctx):
+    pass
+
+
+def _json(payload):
+    click.echo(json.dumps(payload, indent=2, sort_keys=True))
+
+
+@remote.command(help="register a remote Kungfu runtime source")
+@click.argument("source_id", type=str)
+@click.option("--host", required=True, type=str, help="ssh host or localhost")
+@click.option("--home", required=True, type=str, help="remote KF_HOME/runtime root")
+@click.option("--json", "as_json", is_flag=True, help="machine-readable output")
+@remote_command_context
+def add(ctx, source_id, host, home, as_json):
+    row = store.add_source(ctx.runtime_dir, source_id, host, home)
+    payload = {"schema": "kungfu.remote-add/v1", "source": row}
+    if as_json:
+        _json(payload)
+    else:
+        click.echo(f"[remote] added {source_id} ({row['transport']}): {host}:{home}")
+
+
+@remote.command(name="list", help="list registered remote sources")
+@click.option("--json", "as_json", is_flag=True, help="machine-readable output")
+@remote_command_context
+def list_sources(ctx, as_json):
+    sources = store.load_sources(ctx.runtime_dir)
+    payload = {"schema": "kungfu.remote-list/v1", "sources": sources}
+    if as_json:
+        _json(payload)
+        return
+    if not sources:
+        click.echo("[remote] no sources")
+        return
+    for source_id, row in sorted(sources.items()):
+        click.echo(f"{source_id}  {row['transport']}  {row['host']}:{row['home']}")
+
+
+@remote.command(help="show one remote source and last sync manifest")
+@click.argument("source_id", type=str)
+@click.option("--json", "as_json", is_flag=True, help="machine-readable output")
+@remote_command_context
+def show(ctx, source_id, as_json):
+    sources = store.load_sources(ctx.runtime_dir)
+    if source_id not in sources:
+        click.echo(f"[remote] unknown source: {source_id}", err=True)
+        sys.exit(1)
+    manifest = None
+    path = store.manifest_path(ctx.runtime_dir, source_id)
+    if path.exists():
+        with path.open("r", encoding="utf-8") as f:
+            manifest = json.load(f)
+    payload = {
+        "schema": "kungfu.remote-show/v1",
+        "source": sources[source_id],
+        "manifest": manifest,
+    }
+    if as_json:
+        _json(payload)
+    else:
+        row = sources[source_id]
+        click.echo(f"[remote] {source_id}: {row['host']}:{row['home']}")
+        click.echo(
+            f"[remote] sync_state: {manifest.get('sync_state') if manifest else 'never'}"
+        )
+
+
+@remote.command(help="sync a remote source into a source-scoped local mirror")
+@click.argument("source_id", type=str)
+@click.option("--json", "as_json", is_flag=True, help="machine-readable output")
+@remote_command_context
+def sync(ctx, source_id, as_json):
+    try:
+        manifest = store.sync_source(ctx.runtime_dir, source_id)
+    except KeyError:
+        click.echo(f"[remote] unknown source: {source_id}", err=True)
+        sys.exit(1)
+    payload = {"schema": "kungfu.remote-sync/v1", "manifest": manifest}
+    if as_json:
+        _json(payload)
+    else:
+        click.echo(
+            f"[remote] {source_id}: {manifest['sync_state']} -> "
+            f"{manifest['mirror_runtime']}"
+        )

--- a/framework/core/src/python/kungfu/cli/commands/remote.py
+++ b/framework/core/src/python/kungfu/cli/commands/remote.py
@@ -104,3 +104,53 @@ def sync(ctx, source_id, as_json):
             f"[remote] {source_id}: {manifest['sync_state']} -> "
             f"{manifest['mirror_runtime']}"
         )
+
+
+@remote.command(name="work", help="list mirrored remote work items with source labels")
+@click.argument("source_id", required=False, type=str)
+@click.option("--json", "as_json", is_flag=True, help="machine-readable output")
+@remote_command_context
+def work_items(ctx, source_id, as_json):
+    try:
+        items = store.list_work(ctx.runtime_dir, source_id)
+    except KeyError:
+        click.echo(f"[remote] unknown source: {source_id}", err=True)
+        sys.exit(1)
+    payload = {"schema": "kungfu.remote-work/v1", "items": items}
+    if as_json:
+        _json(payload)
+        return
+    if not items:
+        click.echo("[remote] no mirrored work items")
+        return
+    for item in items:
+        next_hint = f"  next: {item['next_action']}" if item["next_action"] else ""
+        click.echo(
+            f"{item['source']}  {item['work_id']}  [{item['status']}]  "
+            f"sync={item['sync_state']}  ({item['kind']})  {item['title']}"
+            f"{next_hint}"
+        )
+
+
+@remote.command(name="runs", help="list mirrored remote Rewind runs with source labels")
+@click.argument("source_id", required=False, type=str)
+@click.option("--json", "as_json", is_flag=True, help="machine-readable output")
+@remote_command_context
+def runs(ctx, source_id, as_json):
+    try:
+        rows = store.list_runs(ctx.runtime_dir, source_id)
+    except KeyError:
+        click.echo(f"[remote] unknown source: {source_id}", err=True)
+        sys.exit(1)
+    payload = {"schema": "kungfu.remote-runs/v1", "runs": rows}
+    if as_json:
+        _json(payload)
+        return
+    if not rows:
+        click.echo("[remote] no mirrored runs")
+        return
+    for row in rows:
+        click.echo(
+            f"{row['source']}  {row['run_id']}  sync={row['sync_state']}  "
+            f"manifest={row['manifest'] or 'missing'}"
+        )

--- a/framework/core/src/python/kungfu/cli/commands/report.py
+++ b/framework/core/src/python/kungfu/cli/commands/report.py
@@ -1,0 +1,274 @@
+#  SPDX-License-Identifier: Apache-2.0
+
+import json
+import os
+import sys
+
+import click
+
+from kungfu.cli.commands import kfc, PrioritizedCommandGroup
+from kungfu.rewind import reporting
+
+report_command_context = kfc.pass_context()
+
+
+@kfc.group(
+    cls=PrioritizedCommandGroup,
+    help_priority=3,
+    help="report external agent work facts into Kungfu without managed-run",
+)
+@click.help_option("-h", "--help")
+@kfc.pass_context()
+def report(ctx):
+    pass
+
+
+def _json(payload):
+    click.echo(json.dumps(payload, indent=2, sort_keys=True))
+
+
+def _require_work(runtime_dir, work_id):
+    if not work_id:
+        return
+    from kungfu.work import store
+
+    if work_id not in store.load(runtime_dir):
+        click.echo(f"[report] unknown work item: {work_id}", err=True)
+        sys.exit(1)
+
+
+def _link_work(runtime_dir, work_id, run_id):
+    if not work_id:
+        return
+    from kungfu.work.store import WorkStore
+
+    WorkStore(runtime_dir).link_run(work_id, run_id)
+
+
+@report.group(help="report a non-managed run lifecycle")
+@report_command_context
+def run(ctx):
+    pass
+
+
+@run.command(name="begin", help="begin a reported run and optionally link work")
+@click.option("--work", "work_id", type=str, default=None, help="work item id")
+@click.option("--provider", required=True, type=str, help="provider label")
+@click.option("--cwd", type=str, default=None, help="working directory of the run")
+@click.option("--run-id", type=str, default=None, help="stable run id")
+@click.option("--command", type=str, default=None, help="reported command label")
+@click.option("--json", "as_json", is_flag=True, help="machine-readable output")
+@report_command_context
+def begin(ctx, work_id, provider, cwd, run_id, command, as_json):
+    _require_work(ctx.runtime_dir, work_id)
+    actual_run_id = run_id or reporting.new_run_id()
+    manifest = reporting.begin_run(
+        ctx.runtime_dir,
+        run_id=actual_run_id,
+        provider=provider,
+        cwd=cwd or os.getcwd(),
+        work_id=work_id,
+        command=command,
+    )
+    _link_work(ctx.runtime_dir, work_id, actual_run_id)
+    payload = {
+        "schema": "kungfu.report-run-begin/v1",
+        "run_id": actual_run_id,
+        "work_id": work_id,
+        "provider": provider,
+        "capture_mode": "reported",
+        "manifest": manifest,
+    }
+    if as_json:
+        _json(payload)
+    else:
+        click.echo(f"[report] run {actual_run_id} began ({provider})")
+
+
+@run.command(name="end", help="end a reported run")
+@click.option("--run", "run_id", required=True, type=str, help="run id")
+@click.option(
+    "--status",
+    required=True,
+    type=click.Choice(["succeeded", "failed", "blocked", "interrupted"]),
+    help="terminal run status",
+)
+@click.option("--exit-code", type=int, default=0, help="reported exit code")
+@click.option("--json", "as_json", is_flag=True, help="machine-readable output")
+@report_command_context
+def end(ctx, run_id, status, exit_code, as_json):
+    manifest = reporting.end_run(
+        ctx.runtime_dir, run_id=run_id, status=status, exit_code=exit_code
+    )
+    payload = {
+        "schema": "kungfu.report-run-end/v1",
+        "run_id": run_id,
+        "status": status,
+        "exit_code": exit_code,
+        "manifest": manifest,
+    }
+    if as_json:
+        _json(payload)
+    else:
+        click.echo(f"[report] run {run_id} ended: {status}")
+
+
+@report.command(help="report a cost or usage snapshot for a run")
+@click.option("--run", "run_id", required=True, type=str, help="run id")
+@click.option("--work", "work_id", type=str, default=None, help="work item id")
+@click.option("--provider", required=True, type=str, help="provider label")
+@click.option("--surface", default="reported", help="provider surface")
+@click.option("--model", default=None, help="model name")
+@click.option("--session-id", default=None, help="provider session id")
+@click.option(
+    "--source",
+    default="manual_report",
+    help="source label for this reported cost fact",
+)
+@click.option(
+    "--attribution",
+    type=click.Choice(sorted(reporting.ATTRIBUTION_BY_NAME)),
+    default="manual_estimate",
+    help="cost attribution level",
+)
+@click.option("--input-tokens", type=int, default=0)
+@click.option("--output-tokens", type=int, default=0)
+@click.option("--cached-input-tokens", type=int, default=0)
+@click.option("--cache-creation-input-tokens", type=int, default=0)
+@click.option("--reasoning-tokens", type=int, default=0)
+@click.option("--usd", "cost_usd", type=float, default=None)
+@click.option("--raw-ref", type=str, default=None)
+@click.option("--json", "as_json", is_flag=True, help="machine-readable output")
+@report_command_context
+def cost(
+    ctx,
+    run_id,
+    work_id,
+    provider,
+    surface,
+    model,
+    session_id,
+    source,
+    attribution,
+    input_tokens,
+    output_tokens,
+    cached_input_tokens,
+    cache_creation_input_tokens,
+    reasoning_tokens,
+    cost_usd,
+    raw_ref,
+    as_json,
+):
+    _require_work(ctx.runtime_dir, work_id)
+    manifest = reporting.report_cost(
+        ctx.runtime_dir,
+        run_id=run_id,
+        work_id=work_id,
+        provider=provider,
+        surface=surface,
+        model=model,
+        session_id=session_id,
+        source=source,
+        attribution=attribution,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        cached_input_tokens=cached_input_tokens,
+        cache_creation_input_tokens=cache_creation_input_tokens,
+        reasoning_tokens=reasoning_tokens,
+        cost_usd=cost_usd,
+        raw_ref=raw_ref,
+    )
+    payload = {
+        "schema": "kungfu.report-cost/v1",
+        "run_id": run_id,
+        "work_id": work_id,
+        "provider": provider,
+        "attribution": attribution,
+        "cost_usd_known": cost_usd is not None,
+        "manifest": manifest,
+    }
+    if as_json:
+        _json(payload)
+    else:
+        click.echo(f"[report] cost recorded for run {run_id} ({attribution})")
+
+
+@report.command(help="report an approval decision fact for a run")
+@click.option("--run", "run_id", required=True, type=str, help="run id")
+@click.option(
+    "--decision",
+    required=True,
+    type=click.Choice(sorted(reporting.DECISION_BY_NAME)),
+    help="decision label",
+)
+@click.option("--request-id", default=None, help="provider request id")
+@click.option("--surface", default="reported", help="decision surface")
+@click.option("--decided-by", default=None, help="who made the decision")
+@click.option("--detail", default=None, help="decision detail")
+@click.option("--reason", default=None, help="decision reason")
+@click.option("--json", "as_json", is_flag=True, help="machine-readable output")
+@report_command_context
+def approval(
+    ctx,
+    run_id,
+    decision,
+    request_id,
+    surface,
+    decided_by,
+    detail,
+    reason,
+    as_json,
+):
+    manifest = reporting.report_approval(
+        ctx.runtime_dir,
+        run_id=run_id,
+        decision=decision,
+        request_id=request_id,
+        surface=surface,
+        decided_by=decided_by,
+        detail=detail,
+        reason=reason,
+    )
+    payload = {
+        "schema": "kungfu.report-approval/v1",
+        "run_id": run_id,
+        "decision": decision,
+        "manifest": manifest,
+    }
+    if as_json:
+        _json(payload)
+    else:
+        click.echo(f"[report] approval recorded for run {run_id}: {decision}")
+
+
+@report.command(help="append a reported run event note")
+@click.option("--run", "run_id", required=True, type=str, help="run id")
+@click.option("--type", "event_type", required=True, type=str, help="event type")
+@click.option("--message", required=True, type=str, help="event message")
+@click.option(
+    "--severity",
+    type=click.Choice(["info", "warning", "error"]),
+    default="info",
+    help="event severity",
+)
+@click.option("--json", "as_json", is_flag=True, help="machine-readable output")
+@report_command_context
+def event(ctx, run_id, event_type, message, severity, as_json):
+    manifest = reporting.report_event(
+        ctx.runtime_dir,
+        run_id=run_id,
+        event_type=event_type,
+        message=message,
+        severity=severity,
+    )
+    payload = {
+        "schema": "kungfu.report-event/v1",
+        "run_id": run_id,
+        "type": event_type,
+        "severity": severity,
+        "manifest": manifest,
+    }
+    if as_json:
+        _json(payload)
+    else:
+        click.echo(f"[report] event recorded for run {run_id}: {event_type}")

--- a/framework/core/src/python/kungfu/remote/__init__.py
+++ b/framework/core/src/python/kungfu/remote/__init__.py
@@ -1,0 +1,2 @@
+#  SPDX-License-Identifier: Apache-2.0
+

--- a/framework/core/src/python/kungfu/remote/store.py
+++ b/framework/core/src/python/kungfu/remote/store.py
@@ -1,0 +1,187 @@
+#  SPDX-License-Identifier: Apache-2.0
+#
+# Source registry and mirror boundary for remote Kungfu facts. A synced source
+# is copied into a source-scoped read-only projection area; it is not merged into
+# the local authoritative runtime.
+
+from __future__ import annotations
+
+import datetime as dt
+import io
+import json
+import os
+import shutil
+import subprocess
+import tarfile
+from pathlib import Path
+from typing import Any
+
+SYNC_DIRS = ("rewind", "work")
+LOCAL_HOSTS = {"", "local", "localhost", "127.0.0.1", "::1"}
+
+
+def _registry_dir(runtime_dir: str) -> Path:
+    path = Path(runtime_dir) / "remotes"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def registry_path(runtime_dir: str) -> Path:
+    return _registry_dir(runtime_dir) / "sources.json"
+
+
+def load_sources(runtime_dir: str) -> dict[str, Any]:
+    path = registry_path(runtime_dir)
+    if not path.exists():
+        return {}
+    with path.open("r", encoding="utf-8") as f:
+        data = json.load(f)
+    return dict(data.get("sources", {}))
+
+
+def save_sources(runtime_dir: str, sources: dict[str, Any]) -> Path:
+    path = registry_path(runtime_dir)
+    with path.open("w", encoding="utf-8") as f:
+        json.dump(
+            {"schema": "kungfu.remote-sources/v1", "sources": sources},
+            f,
+            indent=2,
+            sort_keys=True,
+        )
+        f.write("\n")
+    return path
+
+
+def add_source(
+    runtime_dir: str, source_id: str, host: str, home: str
+) -> dict[str, Any]:
+    sources = load_sources(runtime_dir)
+    row = {
+        "id": source_id,
+        "host": host,
+        "home": home,
+        "transport": "local" if host in LOCAL_HOSTS else "ssh",
+    }
+    sources[source_id] = row
+    save_sources(runtime_dir, sources)
+    return row
+
+
+def mirror_runtime_dir(runtime_dir: str, source_id: str) -> Path:
+    path = _registry_dir(runtime_dir) / source_id / "runtime"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def manifest_path(runtime_dir: str, source_id: str) -> Path:
+    return _registry_dir(runtime_dir) / source_id / "sync-manifest.json"
+
+
+def _now() -> str:
+    return dt.datetime.now(dt.timezone.utc).replace(microsecond=0).isoformat()
+
+
+def _copy_local(source_home: Path, target: Path) -> list[str]:
+    copied: list[str] = []
+    for name in SYNC_DIRS:
+        src = source_home / name
+        if not src.exists():
+            continue
+        dst = target / name
+        if dst.exists():
+            if dst.is_dir():
+                shutil.rmtree(dst)
+            else:
+                dst.unlink()
+        if src.is_dir():
+            shutil.copytree(src, dst)
+        else:
+            shutil.copy2(src, dst)
+        copied.append(name)
+    return copied
+
+
+def _safe_extract(tf: tarfile.TarFile, target: Path) -> list[str]:
+    copied: list[str] = []
+    safe_members: list[tarfile.TarInfo] = []
+    target_resolved = target.resolve()
+    for member in tf.getmembers():
+        name = member.name.strip("/")
+        if not name or name.startswith("../") or "/../" in name:
+            continue
+        root = name.split("/", 1)[0]
+        if root not in SYNC_DIRS:
+            continue
+        dest = (target / name).resolve()
+        try:
+            dest.relative_to(target_resolved)
+        except ValueError:
+            continue
+        member.name = name
+        safe_members.append(member)
+        if root not in copied:
+            copied.append(root)
+    for root in copied:
+        dst = target / root
+        if dst.exists():
+            if dst.is_dir():
+                shutil.rmtree(dst)
+            else:
+                dst.unlink()
+    tf.extractall(target, members=safe_members)
+    return copied
+
+
+def _copy_ssh(host: str, home: str, target: Path) -> list[str]:
+    command = ["ssh", host, "tar", "-C", home, "-cf", "-", *SYNC_DIRS]
+    result = subprocess.run(
+        command,
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=60,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.decode("utf-8", "replace").strip()
+        raise RuntimeError(detail or f"ssh tar failed with exit {result.returncode}")
+    with tarfile.open(fileobj=io.BytesIO(result.stdout), mode="r:") as tf:
+        return _safe_extract(tf, target)
+
+
+def sync_source(runtime_dir: str, source_id: str) -> dict[str, Any]:
+    sources = load_sources(runtime_dir)
+    if source_id not in sources:
+        raise KeyError(source_id)
+    source = sources[source_id]
+    target = mirror_runtime_dir(runtime_dir, source_id)
+    try:
+        if source.get("transport") == "local":
+            copied = _copy_local(Path(os.path.expanduser(source["home"])), target)
+        else:
+            copied = _copy_ssh(str(source["host"]), str(source["home"]), target)
+        state = "fresh"
+        error = None
+    except Exception as exc:  # noqa: BLE001 - error is persisted in the manifest
+        copied = []
+        state = "failed"
+        error = str(exc)
+    manifest = {
+        "schema": "kungfu.remote-sync-manifest/v1",
+        "source_id": source_id,
+        "source": source,
+        "mirror_runtime": str(target),
+        "sync_state": state,
+        "last_synced_at": _now(),
+        "copied": copied,
+        "capture_boundary": (
+            "remote facts stay source-scoped under remotes/<source-id>/runtime; "
+            "they are not merged into the local authoritative runtime"
+        ),
+    }
+    if error:
+        manifest["error"] = error
+    path = manifest_path(runtime_dir, source_id)
+    with path.open("w", encoding="utf-8") as f:
+        json.dump(manifest, f, indent=2, sort_keys=True)
+        f.write("\n")
+    return manifest

--- a/framework/core/src/python/kungfu/remote/store.py
+++ b/framework/core/src/python/kungfu/remote/store.py
@@ -10,13 +10,14 @@ import datetime as dt
 import io
 import json
 import os
+import shlex
 import shutil
 import subprocess
 import tarfile
 from pathlib import Path
 from typing import Any
 
-SYNC_DIRS = ("rewind", "work")
+SYNC_DIRS = ("journal", "rewind", "work")
 LOCAL_HOSTS = {"", "local", "localhost", "127.0.0.1", "::1"}
 
 
@@ -81,7 +82,15 @@ def _now() -> str:
     return dt.datetime.now(dt.timezone.utc).replace(microsecond=0).isoformat()
 
 
+def _source_runtime_root(source_home: Path) -> Path:
+    runtime = source_home / "runtime"
+    if runtime.exists():
+        return runtime
+    return source_home
+
+
 def _copy_local(source_home: Path, target: Path) -> list[str]:
+    source_home = _source_runtime_root(source_home)
     copied: list[str] = []
     for name in SYNC_DIRS:
         src = source_home / name
@@ -133,7 +142,17 @@ def _safe_extract(tf: tarfile.TarFile, target: Path) -> list[str]:
 
 
 def _copy_ssh(host: str, home: str, target: Path) -> list[str]:
-    command = ["ssh", host, "tar", "-C", home, "-cf", "-", *SYNC_DIRS]
+    quoted_home = shlex.quote(home)
+    quoted_dirs = " ".join(shlex.quote(name) for name in SYNC_DIRS)
+    remote_script = (
+        f"root={quoted_home}; "
+        'if [ -d "$root/runtime" ]; then root="$root/runtime"; fi; '
+        "set --; "
+        f'for d in {quoted_dirs}; do [ -e "$root/$d" ] && set -- "$@" "$d"; done; '
+        '[ "$#" -gt 0 ] || exit 0; '
+        'tar -C "$root" -cf - "$@"'
+    )
+    command = ["ssh", host, "sh", "-lc", remote_script]
     result = subprocess.run(
         command,
         check=False,
@@ -144,8 +163,115 @@ def _copy_ssh(host: str, home: str, target: Path) -> list[str]:
     if result.returncode != 0:
         detail = result.stderr.decode("utf-8", "replace").strip()
         raise RuntimeError(detail or f"ssh tar failed with exit {result.returncode}")
+    if not result.stdout:
+        return []
     with tarfile.open(fileobj=io.BytesIO(result.stdout), mode="r:") as tf:
         return _safe_extract(tf, target)
+
+
+def _load_manifest(runtime_dir: str, source_id: str) -> dict[str, Any] | None:
+    path = manifest_path(runtime_dir, source_id)
+    if not path.exists():
+        return None
+    with path.open("r", encoding="utf-8") as f:
+        return dict(json.load(f))
+
+
+def source_projection(runtime_dir: str, source_id: str) -> dict[str, Any]:
+    sources = load_sources(runtime_dir)
+    if source_id not in sources:
+        raise KeyError(source_id)
+    manifest = _load_manifest(runtime_dir, source_id)
+    mirror = Path(runtime_dir) / "remotes" / source_id / "runtime"
+    sync_state = "never"
+    last_synced_at = None
+    if manifest:
+        sync_state = str(manifest.get("sync_state") or "stale")
+        last_synced_at = manifest.get("last_synced_at")
+        if sync_state == "fresh" and not mirror.exists():
+            sync_state = "stale"
+    return {
+        "source_id": source_id,
+        "source": sources[source_id],
+        "source_label": f"remote:{source_id}",
+        "sync_state": sync_state,
+        "last_synced_at": last_synced_at,
+        "mirror_runtime": str(mirror),
+        "manifest": manifest,
+        "capture_mode": "imported",
+    }
+
+
+def list_work(runtime_dir: str, source_id: str | None = None) -> list[dict[str, Any]]:
+    from kungfu.work import store as work_store
+
+    source_ids = [source_id] if source_id else sorted(load_sources(runtime_dir))
+    rows: list[dict[str, Any]] = []
+    for current in source_ids:
+        projection = source_projection(runtime_dir, current)
+        if projection["sync_state"] == "never":
+            continue
+        for item in work_store.load(projection["mirror_runtime"]).values():
+            row = dict(item)
+            row.update(
+                {
+                    "source": projection["source_label"],
+                    "source_id": current,
+                    "sync_state": projection["sync_state"],
+                    "last_synced_at": projection["last_synced_at"],
+                    "mirror_runtime": projection["mirror_runtime"],
+                    "capture_mode": projection["capture_mode"],
+                }
+            )
+            rows.append(row)
+    rows.sort(
+        key=lambda row: (
+            row.get("updated_time") or 0,
+            row.get("source_id") or "",
+            row.get("work_id") or "",
+        ),
+        reverse=True,
+    )
+    return rows
+
+
+def list_runs(runtime_dir: str, source_id: str | None = None) -> list[dict[str, Any]]:
+    source_ids = [source_id] if source_id else sorted(load_sources(runtime_dir))
+    rows: list[dict[str, Any]] = []
+    for current in source_ids:
+        projection = source_projection(runtime_dir, current)
+        if projection["sync_state"] == "never":
+            continue
+        rewind_dir = Path(projection["mirror_runtime"]) / "rewind"
+        if not rewind_dir.exists():
+            continue
+        for entry in rewind_dir.iterdir():
+            if not entry.is_dir():
+                continue
+            manifest = entry / "bundle" / "manifest.json"
+            row: dict[str, Any] = {
+                "run_id": entry.name,
+                "source": projection["source_label"],
+                "source_id": current,
+                "sync_state": projection["sync_state"],
+                "last_synced_at": projection["last_synced_at"],
+                "mirror_runtime": projection["mirror_runtime"],
+                "capture_mode": projection["capture_mode"],
+                "manifest": str(manifest) if manifest.exists() else None,
+            }
+            if manifest.exists():
+                try:
+                    with manifest.open("r", encoding="utf-8") as f:
+                        data = json.load(f)
+                    row["manifest_schema"] = data.get("schema") or data.get(
+                        "spec_version"
+                    )
+                except json.JSONDecodeError:
+                    row["sync_state"] = "stale"
+                    row["manifest_error"] = "invalid json"
+            rows.append(row)
+    rows.sort(key=lambda row: (row["source_id"], row["run_id"]))
+    return rows
 
 
 def sync_source(runtime_dir: str, source_id: str) -> dict[str, Any]:
@@ -175,7 +301,8 @@ def sync_source(runtime_dir: str, source_id: str) -> dict[str, Any]:
         "copied": copied,
         "capture_boundary": (
             "remote facts stay source-scoped under remotes/<source-id>/runtime; "
-            "they are not merged into the local authoritative runtime"
+            "journal/rewind/work are mirrored but not merged into the local "
+            "authoritative runtime"
         ),
     }
     if error:

--- a/framework/core/src/python/kungfu/rewind/reporting.py
+++ b/framework/core/src/python/kungfu/rewind/reporting.py
@@ -1,0 +1,262 @@
+#  SPDX-License-Identifier: Apache-2.0
+#
+# Shared append helpers for reported Rewind facts. Managed-run and trace own
+# processes; this module owns the lower-fidelity path where a user, agent, or
+# script reports facts after using an external workflow.
+
+from __future__ import annotations
+
+import json
+import os
+import uuid
+from typing import Any
+
+import kungfu
+from kungfu.rewind import (
+    MSG_APPROVAL_DECISION,
+    MSG_COST_SNAPSHOT,
+    MSG_RUN_BEGIN,
+    MSG_RUN_END,
+    SCHEMA_VERSION,
+    bundle,
+    cost_wire,
+    events,
+)
+from kungfu.rewind.cost.model import AttributionLevel, CostSnapshot, TokenUsage
+from kungfu.rewind.fb.CaptureLayer import CaptureLayer
+from kungfu.rewind.fb.Decision import Decision
+from kungfu.rewind.fb.RunStatus import RunStatus
+
+lf = kungfu.__binding__.longfist
+yjj = kungfu.__binding__.yijinjing
+
+DECISION_BY_NAME = {
+    "approve": Decision.Approve,
+    "deny": Decision.Deny,
+    "interrupt": Decision.Interrupt,
+    "resume": Decision.Resume,
+}
+
+RUN_STATUS_BY_NAME = {
+    "running": RunStatus.Running,
+    "succeeded": RunStatus.Succeeded,
+    "failed": RunStatus.Failed,
+    "interrupted": RunStatus.Interrupted,
+    "blocked": RunStatus.Failed,
+}
+
+ATTRIBUTION_BY_NAME = {level.value: level for level in AttributionLevel}
+
+
+def new_run_id() -> str:
+    return uuid.uuid4().hex[:12]
+
+
+def _open_journal(runtime_dir: str, run_id: str) -> Any:
+    loc = yjj.locator(runtime_dir)
+    location = yjj.location(
+        lf.enums.mode.LIVE, lf.enums.category.SYSTEM, "rewind", run_id, loc
+    )
+    pub = yjj.noop_publisher()
+    bus = yjj.bus(False)
+    return yjj.writer(location, 0, True, pub, False, bus, 0)
+
+
+def _source(run_id: str, runtime_dir: str) -> dict[str, Any]:
+    return {
+        "mode": "LIVE",
+        "category": "SYSTEM",
+        "group": "rewind",
+        "name": run_id,
+        "dest": 0,
+    }
+
+
+def bundle_dir(runtime_dir: str, run_id: str) -> str:
+    return os.path.join(runtime_dir, "rewind", run_id, "bundle")
+
+
+def emit_manifest(
+    runtime_dir: str,
+    run_id: str,
+    *,
+    capture_mode: str = "reported",
+    extra: dict[str, Any] | None = None,
+) -> str:
+    target = bundle_dir(runtime_dir, run_id)
+    os.makedirs(target, exist_ok=True)
+    manifest_extra = {
+        "fact_bridge": {
+            "schema": "kungfu.fact-bridge/v1",
+            "capture_mode": capture_mode,
+            "source": "reported",
+        }
+    }
+    if extra:
+        manifest_extra["fact_bridge"].update(extra)
+    return bundle.emit(
+        target, runtime_dir, _source(run_id, runtime_dir), manifest_extra
+    )
+
+
+def emit_event(runtime_dir: str, run_id: str, msg_type: int, payload: bytes) -> None:
+    writer = _open_journal(runtime_dir, run_id)
+    writer.write_bytes(0, msg_type, list(payload), len(payload))
+
+
+def begin_run(
+    runtime_dir: str,
+    *,
+    run_id: str,
+    provider: str,
+    cwd: str | None,
+    work_id: str | None,
+    command: str | None = None,
+) -> str:
+    command_text = command or f"{provider} reported-run"
+    runtime = f"reported:{cwd}" if cwd else "reported"
+    emit_event(
+        runtime_dir,
+        run_id,
+        MSG_RUN_BEGIN,
+        events.run_begin(
+            run_id=run_id,
+            command=command_text,
+            runtime=runtime,
+            supervisor_version=kungfu.__version__,
+            schema_version=SCHEMA_VERSION,
+        ),
+    )
+    return emit_manifest(
+        runtime_dir,
+        run_id,
+        extra={"provider": provider, "work_id": work_id, "cwd": cwd},
+    )
+
+
+def end_run(runtime_dir: str, *, run_id: str, status: str, exit_code: int) -> str:
+    emit_event(
+        runtime_dir,
+        run_id,
+        MSG_RUN_END,
+        events.run_end(run_id, RUN_STATUS_BY_NAME[status], exit_code),
+    )
+    return emit_manifest(runtime_dir, run_id, extra={"status": status})
+
+
+def report_cost(
+    runtime_dir: str,
+    *,
+    run_id: str,
+    provider: str,
+    surface: str,
+    source: str,
+    attribution: str,
+    work_id: str | None = None,
+    model: str | None = None,
+    session_id: str | None = None,
+    input_tokens: int = 0,
+    output_tokens: int = 0,
+    cached_input_tokens: int = 0,
+    cache_creation_input_tokens: int = 0,
+    reasoning_tokens: int = 0,
+    cost_usd: float | None = None,
+    raw_ref: str | None = None,
+) -> str:
+    snapshot = CostSnapshot(
+        provider=provider,
+        surface=surface,
+        attribution=ATTRIBUTION_BY_NAME[attribution],
+        source=source,
+        tokens=TokenUsage(
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cached_input_tokens=cached_input_tokens,
+            cache_creation_input_tokens=cache_creation_input_tokens,
+            reasoning_tokens=reasoning_tokens,
+        ),
+        model=model,
+        session_id=session_id,
+        run_id=run_id,
+        work_id=work_id,
+        cost_usd=cost_usd,
+        raw_ref=raw_ref,
+    )
+    msg_type, payload = cost_wire.snapshot_to_event(snapshot, CaptureLayer.Adapter)
+    assert msg_type == MSG_COST_SNAPSHOT
+    emit_event(runtime_dir, run_id, msg_type, payload)
+    return emit_manifest(
+        runtime_dir,
+        run_id,
+        extra={
+            "cost_attribution": snapshot.attribution.value,
+            "cost_confidence": snapshot.confidence,
+            "cost_usd_known": snapshot.cost_usd is not None,
+        },
+    )
+
+
+def report_approval(
+    runtime_dir: str,
+    *,
+    run_id: str,
+    decision: str,
+    request_id: str | None = None,
+    surface: str | None = None,
+    decided_by: str | None = None,
+    detail: str | None = None,
+    reason: str | None = None,
+) -> str:
+    emit_event(
+        runtime_dir,
+        run_id,
+        MSG_APPROVAL_DECISION,
+        events.approval_decision(
+            run_id=run_id,
+            request_id=request_id,
+            decision=DECISION_BY_NAME[decision],
+            surface=surface,
+            decided_by=decided_by,
+            detail=detail,
+            reason=reason,
+        ),
+    )
+    return emit_manifest(
+        runtime_dir,
+        run_id,
+        extra={"approval_decision": decision, "approval_surface": surface},
+    )
+
+
+def report_event(
+    runtime_dir: str,
+    *,
+    run_id: str,
+    event_type: str,
+    message: str,
+    severity: str = "info",
+) -> str:
+    target = bundle_dir(runtime_dir, run_id)
+    os.makedirs(target, exist_ok=True)
+    path = os.path.join(target, "report-events.jsonl")
+    row = {
+        "schema": "kungfu.report-event/v1",
+        "run_id": run_id,
+        "type": event_type,
+        "severity": severity,
+        "message": message,
+    }
+    with open(path, "a", encoding="utf-8") as f:
+        f.write(json.dumps(row, sort_keys=True))
+        f.write("\n")
+    return emit_manifest(
+        runtime_dir,
+        run_id,
+        extra={
+            "report_events": {
+                "path": "report-events.jsonl",
+                "latest_type": event_type,
+                "latest_severity": severity,
+            }
+        },
+    )

--- a/framework/gui/src/renderer/src/runtime.ts
+++ b/framework/gui/src/renderer/src/runtime.ts
@@ -7,12 +7,14 @@ import {
   type KfNativeBinding,
   type Ledger,
   type PtyModule,
+  type RemoteWork,
   type Rewind,
   type Terminal,
   type TmuxBinding,
   type Work,
   openDomainState,
   openLedger,
+  openRemoteWork,
   openRewind,
   openTerminal,
   openWork,
@@ -112,6 +114,7 @@ export type Runtime = {
   ledger: Ledger | null;
   domain: DomainState | null;
   rewind: Rewind | null;
+  remoteWork: RemoteWork | null;
   terminal: Terminal | null;
   work: Work | null;
 };
@@ -146,6 +149,7 @@ export function bootRuntime(): Runtime {
     ledger: null,
     domain: null,
     rewind: null,
+    remoteWork: null,
     terminal: null,
     work: null,
   };
@@ -205,6 +209,12 @@ export function bootRuntime(): Runtime {
       readDir: (d: string) => rewindFs.readdirSync(d),
     });
     const work = openWork({ binding, locator: { runtimeDir } });
+    const remoteWork = openRemoteWork({
+      binding,
+      locator: { runtimeDir },
+      readFile: (p: string) => rewindFs.readFileSync(p),
+      readDir: (d: string) => rewindFs.readdirSync(d),
+    });
     // node-pty is a native addon loaded like the kungfu binding; if it is
     // absent or built for another ABI the terminal handle stays null and the
     // terminal view surfaces the absence rather than crashing the runtime.
@@ -244,6 +254,7 @@ export function bootRuntime(): Runtime {
       ledger,
       domain,
       rewind,
+      remoteWork,
       terminal,
       work,
     };

--- a/framework/tui/src/main.tsx
+++ b/framework/tui/src/main.tsx
@@ -1,3 +1,4 @@
+import fs from 'node:fs';
 // Kungfu reference TUI — the platform's second reference surface (ADR-0007),
 // consuming the capability SDK (ADR-0011).
 //
@@ -11,7 +12,9 @@ import path from 'node:path';
 import {
   type Ledger,
   type LedgerRecord,
+  type RemoteWork,
   openLedger,
+  openRemoteWork,
 } from '@kungfu-tech/api/capability';
 import type { KfxLoadPlan } from '@kungfu-tech/kfx';
 import { Box, Text, render, useApp, useInput, useStdin } from 'ink';
@@ -37,10 +40,21 @@ function boot() {
     locator: { runtimeDir },
     join: { name: 'reference_tui' },
   });
+  const remoteWork = openRemoteWork({
+    binding,
+    locator: { runtimeDir },
+    readFile: (p) => fs.readFileSync(p),
+    readDir: (d) => fs.readdirSync(d),
+  });
   // dual-entry loading (ADR-0017): the TUI discovers + decides kfx with the same
   // planKfx the gui uses, so both hosts reach an identical trust/tier verdict.
   const kfxPlan = loadTuiKfxPlan(process.env);
-  return { ledger, exportCount: Object.keys(binding).length, kfxPlan };
+  return {
+    ledger,
+    remoteWork,
+    exportCount: Object.keys(binding).length,
+    kfxPlan,
+  };
 }
 
 // The discovered-kfx panel: what the TUI loaded through the shared planKfx rule.
@@ -94,10 +108,12 @@ function KfxPanel({ plan }: { plan: KfxLoadPlan }) {
 
 function App({
   ledger,
+  remoteWork,
   exportCount,
   kfxPlan,
 }: {
   ledger: Ledger;
+  remoteWork: RemoteWork;
   exportCount: number;
   kfxPlan: KfxLoadPlan;
 }) {
@@ -106,6 +122,8 @@ function App({
   const [total, setTotal] = React.useState(0);
   const [live, setLive] = React.useState(false);
   const [runs, setRuns] = React.useState(0);
+  const [remoteItems, setRemoteItems] = React.useState(0);
+  const [remoteStates, setRemoteStates] = React.useState('');
 
   const { isRawModeSupported } = useStdin();
   useInput(
@@ -125,12 +143,20 @@ function App({
     const timer = setInterval(() => {
       setLive(ledger.health().live);
       setRuns(ledger.replayAnchors().length);
+      remoteWork.refresh();
+      setRemoteItems(remoteWork.items().length);
+      setRemoteStates(
+        remoteWork
+          .sources()
+          .map((source) => `${source.sourceLabel}:${source.syncState}`)
+          .join(' · '),
+      );
     }, 2000);
     return () => {
       subscription.stop();
       clearInterval(timer);
     };
-  }, [ledger]);
+  }, [ledger, remoteWork]);
 
   return (
     <Box flexDirection="column">
@@ -142,7 +168,9 @@ function App({
         </Text>
       </Box>
       <Text dimColor>
-        runtime home: {ledger.runtimeDir} · runs: {runs} · press q to quit
+        runtime home: {ledger.runtimeDir} · runs: {runs} · remote work:{' '}
+        {remoteItems}
+        {remoteStates ? ` (${remoteStates})` : ''} · press q to quit
       </Text>
       <Text dimColor>
         agent quickstart: kungfu agent brief · kungfu agent capabilities --json
@@ -182,6 +210,7 @@ const booted = boot();
 render(
   <App
     ledger={booted.ledger}
+    remoteWork={booted.remoteWork}
     exportCount={booted.exportCount}
     kfxPlan={booted.kfxPlan}
   />,

--- a/scripts/verify-agent-pack.mjs
+++ b/scripts/verify-agent-pack.mjs
@@ -106,6 +106,11 @@ if (commands) {
     'kungfu trace -- <command>',
     'kungfu managed-run --provider <provider> --prompt <task>',
     'kungfu work create <title> --json',
+    'kungfu report run begin --work <work-id> --provider <provider> --json',
+    'kungfu report cost --run <run-id> --provider <provider> --json',
+    'kungfu report run end --run <run-id> --status <status> --json',
+    'kungfu remote add <source-id> --host <host> --home <kf-home> --json',
+    'kungfu remote sync <source-id> --json',
     'kungfu skill catalog --json',
     'kungfu kfx install <source>',
   ]) {
@@ -151,6 +156,8 @@ for (const rel of REQUIRED.filter((p) => p.endsWith('.md'))) {
       bare.startsWith('kungfu trace') ||
       bare.startsWith('kungfu managed-run') ||
       bare.startsWith('kungfu work') ||
+      bare.startsWith('kungfu report') ||
+      bare.startsWith('kungfu remote') ||
       bare.startsWith('kungfu rewind')
     ) {
       const known =

--- a/tests/fixtures/rewind-demo-remote-sync/run.mjs
+++ b/tests/fixtures/rewind-demo-remote-sync/run.mjs
@@ -3,7 +3,6 @@
 // into remotes/<source-id>/runtime with a sync manifest instead of mixing it
 // into the local authoritative runtime.
 
-import fs from 'node:fs';
 import path from 'node:path';
 import { assertFileContains, json, kfc, locate, tmpDir } from '../_harness.mjs';
 
@@ -11,16 +10,41 @@ const { coreDir } = locate(import.meta.url);
 const localHome = tmpDir('kf-remote-local-');
 const sourceHome = tmpDir('kf-remote-source-');
 
-fs.mkdirSync(path.join(sourceHome, 'rewind', 'run-a', 'bundle'), { recursive: true });
-fs.writeFileSync(
-  path.join(sourceHome, 'rewind', 'run-a', 'bundle', 'manifest.json'),
-  JSON.stringify({ schema: 'test-manifest', run_id: 'run-a' }),
+const remoteWork = json(
+  kfc(coreDir, sourceHome, [
+    'work',
+    'create',
+    'Remote source task',
+    '--kind',
+    'agent-run',
+    '--json',
+  ]),
 );
-fs.mkdirSync(path.join(sourceHome, 'work', 'store'), { recursive: true });
-fs.writeFileSync(
-  path.join(sourceHome, 'work', 'store', 'manifest.json'),
-  JSON.stringify({ schema: 'test-work-store' }),
+const remoteWorkId = remoteWork.work_id;
+const remoteRun = json(
+  kfc(coreDir, sourceHome, [
+    'report',
+    'run',
+    'begin',
+    '--work',
+    remoteWorkId,
+    '--provider',
+    'codex',
+    '--run-id',
+    'remote-run-1',
+    '--json',
+  ]),
 );
+kfc(coreDir, sourceHome, [
+  'report',
+  'run',
+  'end',
+  '--run',
+  remoteRun.run_id,
+  '--status',
+  'succeeded',
+  '--json',
+]);
 
 const added = json(
   kfc(coreDir, localHome, [
@@ -45,8 +69,8 @@ if (synced.manifest.sync_state !== 'fresh') {
 
 const mirror = synced.manifest.mirror_runtime;
 assertFileContains(
-  path.join(mirror, 'rewind', 'run-a', 'bundle', 'manifest.json'),
-  'run-a',
+  path.join(mirror, 'rewind', remoteRun.run_id, 'bundle', 'manifest.json'),
+  remoteRun.run_id,
   'mirrored rewind manifest',
 );
 assertFileContains(
@@ -58,6 +82,27 @@ assertFileContains(
 const shown = json(kfc(coreDir, localHome, ['remote', 'show', 'ubuntu', '--json']));
 if (shown.manifest.sync_state !== 'fresh') {
   throw new Error(`show missing fresh manifest: ${JSON.stringify(shown)}`);
+}
+
+const mirroredWork = json(kfc(coreDir, localHome, ['remote', 'work', 'ubuntu', '--json']));
+const item = mirroredWork.items.find((row) => row.work_id === remoteWorkId);
+if (!item) {
+  throw new Error(`remote work projection missing ${remoteWorkId}`);
+}
+if (item.source !== 'remote:ubuntu' || item.sync_state !== 'fresh') {
+  throw new Error(`remote work labels missing: ${JSON.stringify(item)}`);
+}
+if (!item.runs.some((row) => row.run_id === remoteRun.run_id)) {
+  throw new Error(`remote work missing linked run: ${JSON.stringify(item.runs)}`);
+}
+
+const mirroredRuns = json(kfc(coreDir, localHome, ['remote', 'runs', 'ubuntu', '--json']));
+const run = mirroredRuns.runs.find((row) => row.run_id === remoteRun.run_id);
+if (!run) {
+  throw new Error(`remote run projection missing ${remoteRun.run_id}`);
+}
+if (run.source !== 'remote:ubuntu' || run.sync_state !== 'fresh') {
+  throw new Error(`remote run labels missing: ${JSON.stringify(run)}`);
 }
 
 console.log('ok remote sync');

--- a/tests/fixtures/rewind-demo-remote-sync/run.mjs
+++ b/tests/fixtures/rewind-demo-remote-sync/run.mjs
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+// Remote mirror fixture. Proves a source registry entry can mirror a runtime
+// into remotes/<source-id>/runtime with a sync manifest instead of mixing it
+// into the local authoritative runtime.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { assertFileContains, json, kfc, locate, tmpDir } from '../_harness.mjs';
+
+const { coreDir } = locate(import.meta.url);
+const localHome = tmpDir('kf-remote-local-');
+const sourceHome = tmpDir('kf-remote-source-');
+
+fs.mkdirSync(path.join(sourceHome, 'rewind', 'run-a', 'bundle'), { recursive: true });
+fs.writeFileSync(
+  path.join(sourceHome, 'rewind', 'run-a', 'bundle', 'manifest.json'),
+  JSON.stringify({ schema: 'test-manifest', run_id: 'run-a' }),
+);
+fs.mkdirSync(path.join(sourceHome, 'work', 'store'), { recursive: true });
+fs.writeFileSync(
+  path.join(sourceHome, 'work', 'store', 'manifest.json'),
+  JSON.stringify({ schema: 'test-work-store' }),
+);
+
+const added = json(
+  kfc(coreDir, localHome, [
+    'remote',
+    'add',
+    'ubuntu',
+    '--host',
+    'localhost',
+    '--home',
+    sourceHome,
+    '--json',
+  ]),
+);
+if (added.source.transport !== 'local') {
+  throw new Error(`expected local transport, got ${added.source.transport}`);
+}
+
+const synced = json(kfc(coreDir, localHome, ['remote', 'sync', 'ubuntu', '--json']));
+if (synced.manifest.sync_state !== 'fresh') {
+  throw new Error(`sync failed: ${JSON.stringify(synced.manifest)}`);
+}
+
+const mirror = synced.manifest.mirror_runtime;
+assertFileContains(
+  path.join(mirror, 'rewind', 'run-a', 'bundle', 'manifest.json'),
+  'run-a',
+  'mirrored rewind manifest',
+);
+assertFileContains(
+  path.join(path.dirname(mirror), 'sync-manifest.json'),
+  'source-scoped',
+  'sync manifest boundary',
+);
+
+const shown = json(kfc(coreDir, localHome, ['remote', 'show', 'ubuntu', '--json']));
+if (shown.manifest.sync_state !== 'fresh') {
+  throw new Error(`show missing fresh manifest: ${JSON.stringify(shown)}`);
+}
+
+console.log('ok remote sync');

--- a/tests/fixtures/rewind-demo-report-bridge/check_report.py
+++ b/tests/fixtures/rewind-demo-report-bridge/check_report.py
@@ -1,0 +1,83 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import sys
+
+import kungfu
+from kungfu.rewind import MSG_APPROVAL_DECISION, MSG_COST_SNAPSHOT
+from kungfu.rewind.fb.ApprovalDecision import ApprovalDecision
+from kungfu.rewind.fb.Attribution import Attribution
+from kungfu.rewind.fb.CostSnapshot import CostSnapshot
+from kungfu.rewind.fb.Decision import Decision
+from kungfu.work import store as work_store
+
+lf = kungfu.__binding__.longfist
+yjj = kungfu.__binding__.yijinjing
+
+home, run_id, work_id = sys.argv[1:4]
+failures = []
+
+
+def check(name, ok, detail=""):
+    if not ok:
+        failures.append(name + (f" ({detail})" if detail else ""))
+
+
+items = work_store.load(home)
+entry = items.get(work_id)
+check("work item exists", entry is not None)
+if entry:
+    linked = [row["run_id"] for row in entry["runs"]]
+    check("reported run linked to work", run_id in linked, str(linked))
+
+loc = yjj.location(
+    lf.enums.mode.LIVE,
+    lf.enums.category.SYSTEM,
+    "rewind",
+    run_id,
+    yjj.locator(home),
+)
+
+
+def frames(msg_type):
+    return [
+        bytes(payload) for _header, payload in yjj.assemble(loc, 0).read_bytes(msg_type)
+    ]
+
+
+cost_frames = frames(MSG_COST_SNAPSHOT)
+check("one CostSnapshot frame", len(cost_frames) == 1, str(len(cost_frames)))
+if cost_frames:
+    cost = CostSnapshot.GetRootAs(cost_frames[0], 0)
+    check("cost run_id", cost.RunId() == run_id.encode())
+    check("cost work_id", cost.WorkId() == work_id.encode())
+    check("cost provider", cost.Provider() == b"codex")
+    check("cost attribution manual", cost.Attribution() == Attribution.ManualEstimate)
+    check("cost usd known", cost.CostUsdKnown())
+    check("cost input tokens", cost.InputTokens() == 123)
+    check("cost output tokens", cost.OutputTokens() == 45)
+    check("manual estimate ambiguous", cost.AmbiguousAttribution())
+
+approval_frames = frames(MSG_APPROVAL_DECISION)
+check(
+    "one ApprovalDecision frame",
+    len(approval_frames) == 1,
+    str(len(approval_frames)),
+)
+if approval_frames:
+    approval = ApprovalDecision.GetRootAs(approval_frames[0], 0)
+    check("approval run_id", approval.RunId() == run_id.encode())
+    check("approval decision", approval.Decision() == Decision.Approve)
+    check("approval request_id", approval.RequestId() == b"req-1")
+    check("approval reason", approval.Reason() == b"human approved")
+
+manifest = os.path.join(home, "rewind", run_id, "bundle", "manifest.json")
+events = os.path.join(home, "rewind", run_id, "bundle", "report-events.jsonl")
+check("manifest exists", os.path.exists(manifest))
+check("reported event file exists", os.path.exists(events))
+
+if failures:
+    print("\n".join(f"- {failure}" for failure in failures), file=sys.stderr)
+    sys.exit(1)
+
+print("ok report bridge")

--- a/tests/fixtures/rewind-demo-report-bridge/run.mjs
+++ b/tests/fixtures/rewind-demo-report-bridge/run.mjs
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: Apache-2.0
+// Fact Bridge report-mode fixture. Proves a non-managed run can report
+// lifecycle, cost, approval, and work linkage facts without changing the
+// provider execution surface.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { assertFileContains, json, kfc, locate, tmpDir, uvPython } from '../_harness.mjs';
+
+const { fixtureDir, coreDir } = locate(import.meta.url);
+const home = tmpDir('kf-report-bridge-');
+
+const work = json(
+  kfc(coreDir, home, [
+    'work',
+    'create',
+    'External Codex run',
+    '--kind',
+    'agent-run',
+    '--json',
+  ]),
+);
+const workId = work.work_id;
+const begin = json(
+  kfc(coreDir, home, [
+    'report',
+    'run',
+    'begin',
+    '--work',
+    workId,
+    '--provider',
+    'codex',
+    '--cwd',
+    fixtureDir,
+    '--run-id',
+    'reported-run-1',
+    '--json',
+  ]),
+);
+const bundleDir = path.dirname(begin.manifest);
+const runtimeDir = path.resolve(bundleDir, '..', '..', '..');
+
+kfc(coreDir, home, [
+  'report',
+  'cost',
+  '--run',
+  begin.run_id,
+  '--work',
+  workId,
+  '--provider',
+  'codex',
+  '--source',
+  'manual_report',
+  '--attribution',
+  'manual_estimate',
+  '--input-tokens',
+  '123',
+  '--output-tokens',
+  '45',
+  '--usd',
+  '0.42',
+  '--json',
+]);
+kfc(coreDir, home, [
+  'report',
+  'approval',
+  '--run',
+  begin.run_id,
+  '--decision',
+  'approve',
+  '--request-id',
+  'req-1',
+  '--decided-by',
+  'user',
+  '--reason',
+  'human approved',
+  '--json',
+]);
+kfc(coreDir, home, [
+  'report',
+  'event',
+  '--run',
+  begin.run_id,
+  '--type',
+  'blocker',
+  '--message',
+  'waiting for PR review',
+  '--severity',
+  'warning',
+  '--json',
+]);
+kfc(coreDir, home, [
+  'report',
+  'run',
+  'end',
+  '--run',
+  begin.run_id,
+  '--status',
+  'blocked',
+  '--exit-code',
+  '1',
+  '--json',
+]);
+
+const shown = json(kfc(coreDir, home, ['work', 'show', workId, '--json']));
+if (!shown.runs.some((row) => row.run_id === begin.run_id)) {
+  throw new Error(`work item did not link reported run: ${JSON.stringify(shown.runs)}`);
+}
+
+const eventFile = path.join(bundleDir, 'report-events.jsonl');
+assertFileContains(eventFile, 'waiting for PR review', 'report event');
+if (!fs.existsSync(path.join(bundleDir, 'manifest.json'))) {
+  throw new Error('missing report manifest');
+}
+
+uvPython(coreDir, [
+  path.join(fixtureDir, 'check_report.py'),
+  runtimeDir,
+  begin.run_id,
+  workId,
+], {
+  env: {
+    PYTHONPATH: [
+      path.join(coreDir, 'src', 'python'),
+      path.join(coreDir, 'dist', 'kungfu'),
+    ].join(path.delimiter),
+  },
+});
+
+console.log('ok report bridge');


### PR DESCRIPTION
## Summary
- add `kungfu report` for external, non-managed run lifecycle, cost, approval, and event facts
- add `kungfu remote` source registry and source-scoped runtime mirror sync for `journal` / `rewind` / `work`
- expose remote mirrored work/runs with `remote:<source-id>`, `sync_state`, `last_synced_at`, and `capture_mode` labels through CLI/API
- wire the remote work projection into the GUI runtime handle and reference TUI summary
- update agent onboarding pack and Rewind API projection for reported approval fields

## Verification
- `./kungfu-code verify --full` (51/51 passed on linear branch)
- `git diff --check`
