### PR TITLE
feat(agent): add codex goal report bootstrap

### DIFF
--- a/framework/core/src/python/kungfu/agent/brief.md
+++ b/framework/core/src/python/kungfu/agent/brief.md
@@ -9,6 +9,7 @@ Start here:
 kungfu agent brief
 kungfu agent capabilities --json
 kungfu agent choose-mode --json
+kungfu agent status --target codex --json
 ```
 
 Kungfu is journal-first infrastructure for capturing local facts, replaying
@@ -21,10 +22,12 @@ Use the modes this way:
 
 - **brief**: read the local facts; no runtime action.
 - **report**: create or inspect structured work facts with `kungfu work`, and
-  append external run facts with `kungfu report`.
+  append external run facts with `kungfu report`. Native Codex goals should use
+  `kungfu codex report-goal` and verify the receipt before closeout.
 - **trace**: capture an existing command with `kungfu trace -- <command>`.
 - **managed-run**: let Kungfu launch a provider CLI with skill context and run
-  evidence; this surface is experimental.
+  evidence; this surface is experimental. Keep the report closeout gate as a
+  fallback when switching between managed-run and report mode.
 - **remote-sync**: mirror evidence across runtime boundaries with source labels;
   `kungfu remote` is experimental and does not merge remote facts into local
   authoritative truth.
@@ -32,3 +35,16 @@ Use the modes this way:
 The pack is included by the Electron artifact, the standalone CLI, npm
 `@kungfu-tech/core`, and the PyPI wheel. Future Homebrew, winget, container, and
 kfx packaging must keep the same pack validation gate before claiming support.
+
+Bootstrap surfaces are local and explicit:
+
+```sh
+kungfu agent bootstrap --target codex --mode report
+kungfu agent mode set --target codex --mode managed-run
+kungfu agent unbootstrap --target codex
+kungfu agent uninstall --target codex
+```
+
+These commands dry-run by default unless they expose an `--execute` flag. They
+do not read provider credentials and do not delete receipts, work items, or
+Rewind bundles.

--- a/framework/core/src/python/kungfu/agent/commands.json
+++ b/framework/core/src/python/kungfu/agent/commands.json
@@ -22,6 +22,31 @@
       "purpose": "Choose brief, report, trace, managed-run, or remote-sync from explicit flags."
     },
     {
+      "name": "kungfu agent status --target codex --json",
+      "maturity": "stable",
+      "purpose": "Show Codex bootstrap mode, report closeout gate, and local policy path."
+    },
+    {
+      "name": "kungfu agent bootstrap --target codex --mode report",
+      "maturity": "stable",
+      "purpose": "Preview or apply the Codex report bootstrap policy and optional skill install."
+    },
+    {
+      "name": "kungfu agent mode set --target codex --mode managed-run",
+      "maturity": "stable",
+      "purpose": "Switch Codex between report, managed-run, trace, brief, or remote-sync policy modes."
+    },
+    {
+      "name": "kungfu agent unbootstrap --target codex",
+      "maturity": "stable",
+      "purpose": "Disable Codex bootstrap policy without deleting receipts, work items, or copied skills."
+    },
+    {
+      "name": "kungfu agent uninstall --target codex",
+      "maturity": "stable",
+      "purpose": "Show complete Codex uninstall steps; dry-run by default and no data deletion."
+    },
+    {
       "name": "kungfu agent install-skill --target codex",
       "maturity": "stable",
       "purpose": "Preview or explicitly copy the Codex skill file."
@@ -62,6 +87,16 @@
       "purpose": "Close a reported external run and refresh its manifest."
     },
     {
+      "name": "kungfu codex report-goal --goal-id <goal-id> --status <status> --json",
+      "maturity": "stable",
+      "purpose": "Report a native Codex goal into Kungfu work/Rewind facts and emit a receipt."
+    },
+    {
+      "name": "kungfu codex verify-goal-report --receipt <path> --json",
+      "maturity": "stable",
+      "purpose": "Verify a Codex goal report receipt before closeout."
+    },
+    {
       "name": "kungfu remote add <source-id> --host <host> --home <kf-home> --json",
       "maturity": "experimental",
       "purpose": "Register a source runtime for source-scoped evidence sync."
@@ -95,7 +130,7 @@
     },
     "report": {
       "maturity": "stable",
-      "next": "kungfu work create <title> --json; use kungfu report run begin when the fact belongs to an external run.",
+      "next": "kungfu work create <title> --json; for native Codex goals prefer kungfu codex report-goal --goal-id <goal-id> --status <status> --json.",
       "when": "The useful output is structured work state, decisions, checkpoints, artifacts, or reported external run facts."
     },
     "trace": {

--- a/framework/core/src/python/kungfu/agent/examples/report-mode.md
+++ b/framework/core/src/python/kungfu/agent/examples/report-mode.md
@@ -5,7 +5,7 @@ process.
 
 ```sh
 kungfu work create "Inspect failed extension load" --kind investigation --json
-kungfu work checkpoint <work-id> --summary "Reproduced with local bundle" --json
+kungfu work checkpoint <work-id> "Reproduced with local bundle"
 kungfu work ready <work-id> --reason "Evidence attached" --json
 ```
 
@@ -16,6 +16,16 @@ kungfu report run begin --work <work-id> --provider codex --json
 kungfu report cost --run <run-id> --provider codex --model gpt-5 --usd 0.42 --json
 kungfu report run end --run <run-id> --status succeeded --json
 ```
+
+For a native Codex goal, use the adapter so closeout has one receipt to verify:
+
+```sh
+kungfu codex report-goal --goal-id <goal-id> --status succeeded --tokens-used <n> --json
+kungfu codex verify-goal-report --receipt <receipt-path> --json
+```
+
+`tokens-used` is a native observed total. It is recorded as usage evidence. Only
+pass split token fields or `--usd` when that cost attribution is actually known.
 
 Keep facts labeled:
 

--- a/framework/core/src/python/kungfu/agent/mode-selection.md
+++ b/framework/core/src/python/kungfu/agent/mode-selection.md
@@ -5,7 +5,7 @@ Choose the smallest mode that preserves evidence.
 | Mode | Use when | First command | Maturity |
 |---|---|---|---|
 | brief | You need local facts before acting. | `kungfu agent brief` | stable |
-| report | You need structured work facts, status, decisions, artifacts, or reported external run facts. | `kungfu work create <title> --json` or `kungfu report run begin --work <work-id> --provider <provider> --json` | stable |
+| report | You need structured work facts, status, decisions, artifacts, or reported external run facts. | `kungfu work create <title> --json` or `kungfu codex report-goal --goal-id <goal-id> --status <status> --json` | stable |
 | trace | You already have a command or agent process to capture. | `kungfu trace -- <command>` | stable |
 | managed-run | Kungfu should launch the provider CLI and bind skill context. | `kungfu managed-run --provider <provider> --prompt <task>` | experimental |
 | remote-sync | Evidence must cross machines or runtime trust boundaries. | `kungfu remote add <source-id> --host <host> --home <kf-home> --json` then `kungfu remote sync <source-id> --json` | experimental |
@@ -17,6 +17,12 @@ Rules:
   process.
 - Prefer `report` when no process capture is needed and the durable fact is a
   work item, checkpoint, decision, artifact link, or reported external run fact.
+- For native Codex goals, prefer `kungfu codex report-goal` over hand-assembling
+  `kungfu report` commands; run `kungfu codex verify-goal-report` on the emitted
+  receipt before declaring the goal complete.
+- Switching to `managed-run` does not require disabling report mode. Keep the
+  receipt closeout gate available as a fallback for native-goal or interrupted
+  runs.
 - Treat `remote-sync` as source-scoped import: remote facts stay under
   `remotes/<source-id>/runtime` unless a later command explicitly promotes
   them.

--- a/framework/core/src/python/kungfu/agent/skills/claude/SKILL.md
+++ b/framework/core/src/python/kungfu/agent/skills/claude/SKILL.md
@@ -8,9 +8,12 @@ triggers:
   - rewind
   - managed-run
   - trace
+  - report-goal
+  - closeout receipt
 capabilities:
   - local-fact-review
   - mode-selection
+  - receipt-verification
 ---
 
 # Kungfu Agent Onboarding
@@ -21,6 +24,7 @@ Before acting in a Kungfu runtime, read local facts from the installed pack:
 kungfu agent brief
 kungfu agent capabilities --json
 kungfu agent choose-mode --json
+kungfu agent status --target claude --json
 ```
 
 Use the smallest mode that preserves evidence:
@@ -31,5 +35,30 @@ Use the smallest mode that preserves evidence:
 - `remote-sync` only when the task is about crossing runtime or machine
   boundaries; stable publishing commands are planned unless the local pack says
   otherwise.
+
+If the work is delegated to a native Codex goal and report mode is enabled,
+closeout is not complete until the Codex-side receipt is reported and verified:
+
+```sh
+kungfu codex report-goal --goal-id <goal-id> --status <status> --json
+kungfu codex verify-goal-report --receipt <receipt-path> --json
+```
+
+Use native goal usage only as observed usage evidence unless the provider gives
+split token fields or an exact dollar cost. Switching to `managed-run` does not
+require disabling report mode; keep the report receipt gate as the fallback for
+native-goal or interrupted work.
+
+For setup or teardown, preview first:
+
+```sh
+kungfu agent bootstrap --target claude --mode report
+kungfu agent mode set --target claude --mode managed-run
+kungfu agent unbootstrap --target claude
+kungfu agent uninstall --target claude
+```
+
+Do not delete Kungfu receipts, work items, or Rewind bundles unless the user
+explicitly asks to archive or remove Kungfu data.
 
 Keep observed, reported, imported, and remote facts distinct.

--- a/framework/core/src/python/kungfu/agent/skills/codex/SKILL.md
+++ b/framework/core/src/python/kungfu/agent/skills/codex/SKILL.md
@@ -8,9 +8,12 @@ triggers:
   - rewind
   - managed-run
   - trace
+  - report-goal
+  - closeout receipt
 capabilities:
   - local-fact-review
   - mode-selection
+  - receipt-verification
 ---
 
 # Kungfu Agent Onboarding
@@ -21,6 +24,7 @@ Before acting in a Kungfu runtime, read local facts from the installed pack:
 kungfu agent brief
 kungfu agent capabilities --json
 kungfu agent choose-mode --json
+kungfu agent status --target codex --json
 ```
 
 Use the smallest mode that preserves evidence:
@@ -31,5 +35,30 @@ Use the smallest mode that preserves evidence:
 - `remote-sync` only when the task is about crossing runtime or machine
   boundaries; stable publishing commands are planned unless the local pack says
   otherwise.
+
+If report mode is enabled and the work uses a native Codex goal, closeout is not
+complete until both commands succeed:
+
+```sh
+kungfu codex report-goal --goal-id <goal-id> --status <status> --json
+kungfu codex verify-goal-report --receipt <receipt-path> --json
+```
+
+Use native goal usage only as observed usage evidence unless the provider gives
+split token fields or an exact dollar cost. Switching to `managed-run` does not
+require disabling report mode; keep the report receipt gate as the fallback for
+native-goal or interrupted work.
+
+For setup or teardown, preview first:
+
+```sh
+kungfu agent bootstrap --target codex --mode report
+kungfu agent mode set --target codex --mode managed-run
+kungfu agent unbootstrap --target codex
+kungfu agent uninstall --target codex
+```
+
+Do not delete Kungfu receipts, work items, or Rewind bundles unless the user
+explicitly asks to archive or remove Kungfu data.
 
 Keep observed, reported, imported, and remote facts distinct.

--- a/framework/core/src/python/kungfu/cli/commands/__registry__.py
+++ b/framework/core/src/python/kungfu/cli/commands/__registry__.py
@@ -17,6 +17,7 @@ from . import atlas
 from . import kfx
 from . import skill
 from . import agent
+from . import codex
 from . import sdk
 
 __all__ = [
@@ -37,5 +38,6 @@ __all__ = [
     "kfx",
     "skill",
     "agent",
+    "codex",
     "sdk",
 ]

--- a/framework/core/src/python/kungfu/cli/commands/agent.py
+++ b/framework/core/src/python/kungfu/cli/commands/agent.py
@@ -98,6 +98,67 @@ def _json(payload):
     click.echo(json.dumps(payload, indent=2, sort_keys=True))
 
 
+def _policy_dir(ctx):
+    return os.path.join(ctx.runtime_dir, "agent")
+
+
+def _policy_path(ctx, target):
+    return os.path.join(_policy_dir(ctx), f"{target}-policy.json")
+
+
+def _read_policy(ctx, target):
+    path = _policy_path(ctx, target)
+    if not os.path.exists(path):
+        return None
+    try:
+        with open(path, encoding="utf-8") as f:
+            return json.load(f)
+    except (OSError, json.JSONDecodeError) as e:
+        click.echo(f"[agent] failed to read policy {path}: {e}", err=True)
+        sys.exit(1)
+
+
+def _write_policy(ctx, target, policy):
+    os.makedirs(_policy_dir(ctx), exist_ok=True)
+    path = _policy_path(ctx, target)
+    tmp = path + ".tmp"
+    with open(tmp, "w", encoding="utf-8") as f:
+        json.dump(policy, f, indent=2, sort_keys=True)
+        f.write("\n")
+    os.replace(tmp, path)
+    return path
+
+
+def _policy_payload(ctx, target, mode, enabled=True):
+    closeout_gate = enabled and mode in {"report", "managed-run"}
+    return {
+        "schema": "kungfu.agent-policy/v1",
+        "target": target,
+        "mode": mode,
+        "enabled": enabled,
+        "reportCloseoutGate": closeout_gate,
+        "reportAdapter": "kungfu codex report-goal"
+        if target == "codex"
+        else "kungfu report run begin",
+        "receiptVerifier": "kungfu codex verify-goal-report"
+        if target == "codex"
+        else "kungfu report run end",
+        "runtimeDir": ctx.runtime_dir,
+    }
+
+
+def _install_skill_file(target, out_dir, force):
+    src = agent_pack.skill_path(target)
+    dest = os.path.join(out_dir, "SKILL.md")
+    os.makedirs(out_dir, exist_ok=True)
+    if os.path.exists(dest) and not force:
+        click.echo(f"[agent] {dest} exists (use --force to replace)", err=True)
+        sys.exit(1)
+    with open(dest, "wb") as f:
+        f.write(src.read_bytes())
+    return str(src), dest
+
+
 @agent.command(help="print the local onboarding brief")
 @agent_command_context
 def brief(ctx):
@@ -224,12 +285,7 @@ def install_skill(ctx, target, out_dir, execute, force, as_json):
         if not out_dir:
             click.echo("[agent] --execute requires --out <directory>", err=True)
             sys.exit(1)
-        os.makedirs(out_dir, exist_ok=True)
-        if os.path.exists(dest) and not force:
-            click.echo(f"[agent] {dest} exists (use --force to replace)", err=True)
-            sys.exit(1)
-        with open(dest, "wb") as f:
-            f.write(src.read_bytes())
+        _install_skill_file(target, out_dir, force)
         payload["changed"] = True
     if as_json:
         _json(payload)
@@ -240,6 +296,219 @@ def install_skill(ctx, target, out_dir, execute, force, as_json):
     click.echo(f"[agent] destination: {dest or '<choose with --out>'}")
     if not execute:
         click.echo("[agent] no files changed; add --execute --out <directory> to copy")
+
+
+@agent.command(help="show the local agent bootstrap and report gate status")
+@click.option(
+    "--target",
+    required=True,
+    type=click.Choice(["codex", "claude"]),
+    help="provider skill target",
+)
+@click.option("--json", "as_json", is_flag=True, help="machine-readable output")
+@agent_command_context
+def status(ctx, target, as_json):
+    policy = _read_policy(ctx, target)
+    payload = {
+        "schema": "kungfu.agent-status/v1",
+        "target": target,
+        "configured": policy is not None,
+        "policyPath": _policy_path(ctx, target),
+        "policy": policy,
+        "skillSource": str(agent_pack.skill_path(target)),
+        "commands": {
+            "bootstrap": f"kungfu agent bootstrap --target {target} --mode report",
+            "mode": f"kungfu agent mode set --target {target} --mode managed-run",
+            "unbootstrap": f"kungfu agent unbootstrap --target {target}",
+            "uninstall": f"kungfu agent uninstall --target {target}",
+        },
+    }
+    if as_json:
+        _json(payload)
+        return
+    if policy is None:
+        click.echo(f"[agent] {target}: not bootstrapped")
+    else:
+        gate = "on" if policy.get("reportCloseoutGate") else "off"
+        click.echo(f"[agent] {target}: {policy.get('mode')} (report gate: {gate})")
+
+
+@agent.command(help="preview or apply local agent bootstrap policy")
+@click.option(
+    "--target",
+    required=True,
+    type=click.Choice(["codex", "claude"]),
+    help="provider skill target",
+)
+@click.option(
+    "--mode",
+    required=True,
+    type=click.Choice(["brief", "report", "trace", "managed-run", "remote-sync"]),
+    help="initial operating mode",
+)
+@click.option(
+    "--skill-dir",
+    type=click.Path(file_okay=False, dir_okay=True),
+    default=None,
+    help="optional destination for SKILL.md",
+)
+@click.option("--execute", is_flag=True, help="write policy/copy skill")
+@click.option("--force", is_flag=True, help="replace an existing SKILL.md")
+@click.option("--json", "as_json", is_flag=True, help="machine-readable output")
+@agent_command_context
+def bootstrap(ctx, target, mode, skill_dir, execute, force, as_json):
+    policy = _policy_payload(ctx, target, mode, enabled=True)
+    skill_destination = os.path.join(skill_dir, "SKILL.md") if skill_dir else None
+    payload = {
+        "schema": "kungfu.agent-bootstrap/v1",
+        "target": target,
+        "mode": mode,
+        "execute": execute,
+        "changed": False,
+        "policyPath": _policy_path(ctx, target),
+        "policy": policy,
+        "skillSource": str(agent_pack.skill_path(target)),
+        "skillDestination": skill_destination,
+    }
+    if execute:
+        _write_policy(ctx, target, policy)
+        payload["changed"] = True
+        if skill_dir:
+            _install_skill_file(target, skill_dir, force)
+    if as_json:
+        _json(payload)
+        return
+    action = "applied" if execute else "preview"
+    click.echo(f"[agent] bootstrap {action}: {target} mode={mode}")
+    click.echo(f"[agent] policy: {_policy_path(ctx, target)}")
+    if skill_destination:
+        click.echo(f"[agent] skill: {skill_destination}")
+    if not execute:
+        click.echo("[agent] no files changed; add --execute to apply")
+
+
+@agent.group(help="preview or apply an agent mode switch")
+@agent_command_context
+def mode(ctx):
+    pass
+
+
+@mode.command(name="set", help="set the local agent operating mode")
+@click.option(
+    "--target",
+    required=True,
+    type=click.Choice(["codex", "claude"]),
+    help="provider skill target",
+)
+@click.option(
+    "--mode",
+    "mode_name",
+    required=True,
+    type=click.Choice(["brief", "report", "trace", "managed-run", "remote-sync"]),
+    help="new mode",
+)
+@click.option("--execute", is_flag=True, help="write the mode switch")
+@click.option("--json", "as_json", is_flag=True, help="machine-readable output")
+@agent_command_context
+def set_mode(ctx, target, mode_name, execute, as_json):
+    previous = _read_policy(ctx, target)
+    policy = dict(previous or _policy_payload(ctx, target, mode_name, enabled=True))
+    policy.update(_policy_payload(ctx, target, mode_name, enabled=True))
+    payload = {
+        "schema": "kungfu.agent-mode-set/v1",
+        "target": target,
+        "mode": mode_name,
+        "execute": execute,
+        "changed": False,
+        "previous": previous,
+        "policy": policy,
+        "policyPath": _policy_path(ctx, target),
+    }
+    if execute:
+        _write_policy(ctx, target, policy)
+        payload["changed"] = True
+    if as_json:
+        _json(payload)
+        return
+    action = "set" if execute else "preview"
+    click.echo(f"[agent] mode {action}: {target} -> {mode_name}")
+    if not execute:
+        click.echo("[agent] no files changed; add --execute to apply")
+
+
+@agent.command(help="disable local bootstrap policy without deleting user data")
+@click.option(
+    "--target",
+    required=True,
+    type=click.Choice(["codex", "claude"]),
+    help="provider skill target",
+)
+@click.option("--execute", is_flag=True, help="write disabled policy")
+@click.option("--json", "as_json", is_flag=True, help="machine-readable output")
+@agent_command_context
+def unbootstrap(ctx, target, execute, as_json):
+    previous = _read_policy(ctx, target)
+    disabled = _policy_payload(ctx, target, "brief", enabled=False)
+    payload = {
+        "schema": "kungfu.agent-unbootstrap/v1",
+        "target": target,
+        "execute": execute,
+        "changed": False,
+        "previous": previous,
+        "policy": disabled,
+        "policyPath": _policy_path(ctx, target),
+        "note": "Does not delete receipts, work items, rewind bundles, or copied skills.",
+    }
+    if execute:
+        _write_policy(ctx, target, disabled)
+        payload["changed"] = True
+    if as_json:
+        _json(payload)
+        return
+    action = "disabled" if execute else "preview"
+    click.echo(f"[agent] unbootstrap {action}: {target}")
+    click.echo("[agent] no user data or receipts are deleted")
+    if not execute:
+        click.echo("[agent] add --execute to write the disabled policy")
+
+
+@agent.command(help="show complete uninstall steps; defaults to dry-run")
+@click.option(
+    "--target",
+    required=True,
+    type=click.Choice(["codex", "claude"]),
+    help="provider skill target",
+)
+@click.option("--execute", is_flag=True, help="disable local policy")
+@click.option("--json", "as_json", is_flag=True, help="machine-readable output")
+@agent_command_context
+def uninstall(ctx, target, execute, as_json):
+    previous = _read_policy(ctx, target)
+    disabled = _policy_payload(ctx, target, "brief", enabled=False)
+    payload = {
+        "schema": "kungfu.agent-uninstall/v1",
+        "target": target,
+        "execute": execute,
+        "changed": False,
+        "policyPath": _policy_path(ctx, target),
+        "previous": previous,
+        "willDeleteData": False,
+        "steps": [
+            "Run kungfu agent unbootstrap --target <target> --execute.",
+            "Remove any copied SKILL.md from the agent skill root you chose.",
+            "Keep KF_HOME/runtime receipts unless the user explicitly archives or deletes Kungfu data.",
+        ],
+    }
+    if execute:
+        _write_policy(ctx, target, disabled)
+        payload["changed"] = True
+    if as_json:
+        _json(payload)
+        return
+    action = "disabled policy" if execute else "dry-run"
+    click.echo(f"[agent] uninstall {action}: {target}")
+    for step in payload["steps"]:
+        click.echo(f"- {step}")
 
 
 @agent.command(help="print the canonical agent context")

--- a/framework/core/src/python/kungfu/cli/commands/codex.py
+++ b/framework/core/src/python/kungfu/cli/commands/codex.py
@@ -1,0 +1,340 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Codex-specific adapter commands. These wrap the generic report/work facts in
+# a receipt contract so an agent can close a native Codex goal only after Kungfu
+# can verify the reported usage window and run linkage.
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from typing import Any
+
+import click
+
+from kungfu.cli.commands import PrioritizedCommandGroup, kfc
+from kungfu.rewind import reporting
+
+codex_command_context = kfc.pass_context()
+
+
+@kfc.group(
+    cls=PrioritizedCommandGroup,
+    help_priority=3,
+    help="Codex-native adapters for reported goal usage and receipts",
+)
+@click.help_option("-h", "--help")
+@kfc.pass_context()
+def codex(ctx):
+    pass
+
+
+def _json(payload: dict[str, Any]) -> None:
+    click.echo(json.dumps(payload, indent=2, sort_keys=True))
+
+
+def _load_work(runtime_dir: str) -> dict[str, Any]:
+    from kungfu.work import store
+
+    return store.load(runtime_dir)
+
+
+def _require_work(runtime_dir: str, work_id: str) -> dict[str, Any]:
+    items = _load_work(runtime_dir)
+    if work_id not in items:
+        click.echo(f"[codex] unknown work item: {work_id}", err=True)
+        sys.exit(1)
+    return items[work_id]
+
+
+def _write_receipt(runtime_dir: str, run_id: str, receipt: dict[str, Any]) -> str:
+    target = reporting.bundle_dir(runtime_dir, run_id)
+    os.makedirs(target, exist_ok=True)
+    path = os.path.join(target, "codex-goal-receipt.json")
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(receipt, f, indent=2, sort_keys=True)
+        f.write("\n")
+    return path
+
+
+def _read_json_file(path: str) -> dict[str, Any]:
+    try:
+        with open(path, encoding="utf-8") as f:
+            return json.load(f)
+    except (OSError, json.JSONDecodeError) as e:
+        click.echo(f"[codex] failed to read {path}: {e}", err=True)
+        sys.exit(1)
+
+
+def _has_goal_event(bundle_dir: str, run_id: str, goal_id: str) -> bool:
+    event_file = os.path.join(bundle_dir, "report-events.jsonl")
+    try:
+        with open(event_file, encoding="utf-8") as f:
+            for line in f:
+                row = json.loads(line)
+                if row.get("run_id") != run_id:
+                    continue
+                if row.get("type") != "codex_goal_usage_observed":
+                    continue
+                message = row.get("message") or ""
+                if goal_id in message:
+                    return True
+    except (OSError, json.JSONDecodeError):
+        return False
+    return False
+
+
+@codex.command(
+    name="report-goal",
+    help="report a native Codex goal into Kungfu and emit a verifiable receipt",
+)
+@click.option("--work", "work_id", type=str, default=None, help="existing work item id")
+@click.option("--title", type=str, default=None, help="title when creating work")
+@click.option("--goal-id", required=True, type=str, help="Codex native goal id")
+@click.option("--objective", type=str, default=None, help="Codex goal objective")
+@click.option(
+    "--status",
+    required=True,
+    type=click.Choice(["succeeded", "failed", "blocked", "interrupted"]),
+    help="terminal goal status",
+)
+@click.option("--tokens-used", type=int, default=None, help="native total token usage")
+@click.option(
+    "--time-used-seconds", type=int, default=None, help="native elapsed seconds"
+)
+@click.option("--run-id", type=str, default=None, help="stable Kungfu run id")
+@click.option("--provider", type=str, default="codex", help="provider label")
+@click.option("--model", type=str, default=None, help="model name when known")
+@click.option("--session-id", type=str, default=None, help="provider session id")
+@click.option("--input-tokens", type=int, default=None)
+@click.option("--output-tokens", type=int, default=None)
+@click.option("--cached-input-tokens", type=int, default=None)
+@click.option("--reasoning-tokens", type=int, default=None)
+@click.option("--usd", "cost_usd", type=float, default=None)
+@click.option(
+    "--source",
+    type=str,
+    default="codex_native_goal",
+    help="source label for the usage observation",
+)
+@click.option(
+    "--attribution",
+    type=click.Choice(sorted(reporting.ATTRIBUTION_BY_NAME)),
+    default="observed_window",
+    help="cost/usage attribution level",
+)
+@click.option("--cwd", type=str, default=None, help="reported working directory")
+@click.option("--json", "as_json", is_flag=True, help="machine-readable output")
+@codex_command_context
+def report_goal(
+    ctx,
+    work_id,
+    title,
+    goal_id,
+    objective,
+    status,
+    tokens_used,
+    time_used_seconds,
+    run_id,
+    provider,
+    model,
+    session_id,
+    input_tokens,
+    output_tokens,
+    cached_input_tokens,
+    reasoning_tokens,
+    cost_usd,
+    source,
+    attribution,
+    cwd,
+    as_json,
+):
+    from kungfu.work.store import WorkStore
+
+    store = WorkStore(ctx.runtime_dir)
+    created_work = False
+    actual_work_id = work_id
+    if actual_work_id:
+        _require_work(ctx.runtime_dir, actual_work_id)
+    else:
+        actual_work_id = store.create(
+            title or objective or f"Codex goal {goal_id}",
+            "codex-goal",
+            objective or f"Codex native goal {goal_id}",
+        )
+        created_work = True
+
+    actual_run_id = run_id or reporting.new_run_id()
+    command = f"codex native goal {goal_id}"
+    manifest = reporting.begin_run(
+        ctx.runtime_dir,
+        run_id=actual_run_id,
+        provider=provider,
+        cwd=cwd or os.getcwd(),
+        work_id=actual_work_id,
+        command=command,
+    )
+    store.link_run(actual_work_id, actual_run_id)
+
+    usage = {
+        "schema": "kungfu.codex-goal-usage/v1",
+        "goal_id": goal_id,
+        "objective": objective,
+        "status": status,
+        "tokens_used": tokens_used,
+        "time_used_seconds": time_used_seconds,
+        "source": source,
+        "attribution": attribution,
+    }
+    manifest = reporting.report_event(
+        ctx.runtime_dir,
+        run_id=actual_run_id,
+        event_type="codex_goal_usage_observed",
+        message=json.dumps(usage, sort_keys=True),
+        severity="info" if status == "succeeded" else "warning",
+    )
+
+    cost_snapshot_written = any(
+        value is not None
+        for value in (
+            input_tokens,
+            output_tokens,
+            cached_input_tokens,
+            reasoning_tokens,
+            cost_usd,
+        )
+    )
+    if cost_snapshot_written:
+        manifest = reporting.report_cost(
+            ctx.runtime_dir,
+            run_id=actual_run_id,
+            work_id=actual_work_id,
+            provider=provider,
+            surface="codex_native_goal",
+            model=model,
+            session_id=session_id,
+            source=source,
+            attribution=attribution,
+            input_tokens=input_tokens or 0,
+            output_tokens=output_tokens or 0,
+            cached_input_tokens=cached_input_tokens or 0,
+            reasoning_tokens=reasoning_tokens or 0,
+            cost_usd=cost_usd,
+            raw_ref=goal_id,
+        )
+
+    exit_code = 0 if status == "succeeded" else 1
+    manifest = reporting.end_run(
+        ctx.runtime_dir, run_id=actual_run_id, status=status, exit_code=exit_code
+    )
+
+    receipt = {
+        "schema": "kungfu.codex-goal-report/v1",
+        "work_id": actual_work_id,
+        "run_id": actual_run_id,
+        "goal_id": goal_id,
+        "objective": objective,
+        "status": status,
+        "tokens_used": tokens_used,
+        "time_used_seconds": time_used_seconds,
+        "provider": provider,
+        "model": model,
+        "session_id": session_id,
+        "source": source,
+        "attribution": attribution,
+        "cost_snapshot_written": cost_snapshot_written,
+        "cost_usd_known": cost_usd is not None,
+        "runtime_dir": ctx.runtime_dir,
+        "manifest": manifest,
+    }
+    receipt_path = _write_receipt(ctx.runtime_dir, actual_run_id, receipt)
+    manifest = reporting.emit_manifest(
+        ctx.runtime_dir,
+        actual_run_id,
+        extra={
+            "codex_goal_receipt": {
+                "path": "codex-goal-receipt.json",
+                "goal_id": goal_id,
+                "verified_by": "kungfu codex verify-goal-report",
+            }
+        },
+    )
+    receipt["manifest"] = manifest
+    receipt["receipt"] = receipt_path
+    _write_receipt(ctx.runtime_dir, actual_run_id, receipt)
+
+    payload = dict(receipt)
+    payload["created_work"] = created_work
+    if as_json:
+        _json(payload)
+    else:
+        click.echo(
+            f"[codex] goal {goal_id} reported as run {actual_run_id}; "
+            f"receipt: {receipt_path}"
+        )
+
+
+@codex.command(
+    name="verify-goal-report",
+    help="verify a Codex goal report receipt and its local Kungfu facts",
+)
+@click.option("--receipt", type=click.Path(dir_okay=False), required=True)
+@click.option("--json", "as_json", is_flag=True, help="machine-readable output")
+@codex_command_context
+def verify_goal_report(ctx, receipt, as_json):
+    receipt_path = os.path.abspath(receipt)
+    data = _read_json_file(receipt_path)
+    errors = []
+    if data.get("schema") != "kungfu.codex-goal-report/v1":
+        errors.append("receipt schema mismatch")
+
+    runtime_dir = data.get("runtime_dir") or ctx.runtime_dir
+    run_id = data.get("run_id")
+    work_id = data.get("work_id")
+    goal_id = data.get("goal_id")
+    manifest = data.get("manifest")
+    if not run_id:
+        errors.append("receipt missing run_id")
+    if not work_id:
+        errors.append("receipt missing work_id")
+    if not goal_id:
+        errors.append("receipt missing goal_id")
+
+    if manifest and not os.path.exists(manifest):
+        errors.append(f"manifest missing: {manifest}")
+    bundle_dir = reporting.bundle_dir(runtime_dir, run_id) if run_id else ""
+    if run_id and not os.path.isdir(bundle_dir):
+        errors.append(f"bundle missing: {bundle_dir}")
+    if run_id and goal_id and not _has_goal_event(bundle_dir, run_id, goal_id):
+        errors.append("codex_goal_usage_observed event missing")
+
+    try:
+        item = _require_work(runtime_dir, work_id) if work_id else None
+        if item and run_id:
+            linked = any(row.get("run_id") == run_id for row in item.get("runs", []))
+            if not linked:
+                errors.append("work item does not link run_id")
+    except SystemExit:
+        errors.append(f"work item missing: {work_id}")
+
+    payload = {
+        "schema": "kungfu.codex-goal-report-verify/v1",
+        "ok": not errors,
+        "receipt": receipt_path,
+        "run_id": run_id,
+        "work_id": work_id,
+        "goal_id": goal_id,
+        "errors": errors,
+    }
+    if errors:
+        if as_json:
+            _json(payload)
+        else:
+            for error in errors:
+                click.echo(f"[codex] verify failed: {error}", err=True)
+        sys.exit(1)
+    if as_json:
+        _json(payload)
+    else:
+        click.echo(f"[codex] verified goal report receipt: {receipt_path}")

--- a/scripts/verify-agent-pack.mjs
+++ b/scripts/verify-agent-pack.mjs
@@ -101,6 +101,11 @@ if (commands) {
     'kungfu agent docs',
     'kungfu agent capabilities --json',
     'kungfu agent choose-mode --json',
+    'kungfu agent status --target codex --json',
+    'kungfu agent bootstrap --target codex --mode report',
+    'kungfu agent mode set --target codex --mode managed-run',
+    'kungfu agent unbootstrap --target codex',
+    'kungfu agent uninstall --target codex',
     'kungfu agent install-skill --target codex',
     'kungfu agent install-skill --target claude',
     'kungfu trace -- <command>',
@@ -109,6 +114,8 @@ if (commands) {
     'kungfu report run begin --work <work-id> --provider <provider> --json',
     'kungfu report cost --run <run-id> --provider <provider> --json',
     'kungfu report run end --run <run-id> --status <status> --json',
+    'kungfu codex report-goal --goal-id <goal-id> --status <status> --json',
+    'kungfu codex verify-goal-report --receipt <path> --json',
     'kungfu remote add <source-id> --host <host> --home <kf-home> --json',
     'kungfu remote sync <source-id> --json',
     'kungfu skill catalog --json',
@@ -157,6 +164,7 @@ for (const rel of REQUIRED.filter((p) => p.endsWith('.md'))) {
       bare.startsWith('kungfu managed-run') ||
       bare.startsWith('kungfu work') ||
       bare.startsWith('kungfu report') ||
+      bare.startsWith('kungfu codex') ||
       bare.startsWith('kungfu remote') ||
       bare.startsWith('kungfu rewind')
     ) {

--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -666,7 +666,8 @@ function main() {
       // Each fixture under tests/fixtures/rewind-demo-*/ proves a capture
       // gate end to end against the built dist/kungfu (G2 capture, G3 event
       // completeness); tests/fixtures/work-demo-*/ prove the default work
-      // profile the same way (P1 vocabulary, P2 lifecycle), and
+      // profile the same way (P1 vocabulary, P2 lifecycle), agent-demo-*
+      // proves onboarding/bootstrap contracts, and
       // tests/fixtures/atlas-demo-*/ prove the read-only control-plane
       // import profile (P7 dogfood slice). A red fixture means the
       // corresponding journal fact contract regressed.
@@ -674,6 +675,7 @@ function main() {
       const fixturePrefixes = [
         'rewind-demo-',
         'work-demo-',
+        'agent-demo-',
         'atlas-demo-',
         'kfx-demo-',
       ];

--- a/tests/fixtures/agent-demo-bootstrap/run.mjs
+++ b/tests/fixtures/agent-demo-bootstrap/run.mjs
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+// Agent bootstrap fixture. Proves report-mode bootstrap has a stable status
+// surface, can switch to managed-run without dropping the report closeout gate,
+// and exposes dry-run teardown without deleting local receipts/data.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { json, kfc, locate, tmpDir } from '../_harness.mjs';
+
+const { coreDir } = locate(import.meta.url);
+const home = tmpDir('kf-agent-bootstrap-');
+const skillDir = path.join(home, 'codex-skill');
+
+const initial = json(
+  kfc(coreDir, home, ['agent', 'status', '--target', 'codex', '--json']),
+);
+if (initial.configured) throw new Error('fresh home should not be configured');
+
+const preview = json(
+  kfc(coreDir, home, [
+    'agent',
+    'bootstrap',
+    '--target',
+    'codex',
+    '--mode',
+    'report',
+    '--skill-dir',
+    skillDir,
+    '--json',
+  ]),
+);
+if (preview.changed) throw new Error('bootstrap preview changed state');
+if (fs.existsSync(path.join(skillDir, 'SKILL.md'))) {
+  throw new Error('bootstrap preview copied skill');
+}
+
+const applied = json(
+  kfc(coreDir, home, [
+    'agent',
+    'bootstrap',
+    '--target',
+    'codex',
+    '--mode',
+    'report',
+    '--skill-dir',
+    skillDir,
+    '--execute',
+    '--json',
+  ]),
+);
+if (!applied.changed) throw new Error('bootstrap execute did not change state');
+if (!fs.existsSync(path.join(skillDir, 'SKILL.md'))) {
+  throw new Error('bootstrap execute did not copy skill');
+}
+
+const status = json(
+  kfc(coreDir, home, ['agent', 'status', '--target', 'codex', '--json']),
+);
+if (!status.policy?.reportCloseoutGate) {
+  throw new Error(`report gate not enabled: ${JSON.stringify(status)}`);
+}
+
+const switched = json(
+  kfc(coreDir, home, [
+    'agent',
+    'mode',
+    'set',
+    '--target',
+    'codex',
+    '--mode',
+    'managed-run',
+    '--execute',
+    '--json',
+  ]),
+);
+if (!switched.policy?.reportCloseoutGate) {
+  throw new Error('managed-run switch dropped report closeout gate');
+}
+
+const unbootstrapPreview = json(
+  kfc(coreDir, home, ['agent', 'unbootstrap', '--target', 'codex', '--json']),
+);
+if (unbootstrapPreview.changed) throw new Error('unbootstrap preview changed state');
+
+const uninstallPreview = json(
+  kfc(coreDir, home, ['agent', 'uninstall', '--target', 'codex', '--json']),
+);
+if (uninstallPreview.willDeleteData) {
+  throw new Error('uninstall preview should not delete data');
+}
+
+console.log('ok agent bootstrap');

--- a/tests/fixtures/rewind-demo-codex-goal-report/run.mjs
+++ b/tests/fixtures/rewind-demo-codex-goal-report/run.mjs
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+// Codex native-goal report fixture. Proves an agent can close a native Codex
+// goal through one adapter command and one receipt verification command.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { assertFileContains, json, kfc, locate, tmpDir } from '../_harness.mjs';
+
+const { coreDir } = locate(import.meta.url);
+const home = tmpDir('kf-codex-goal-report-');
+
+const report = json(
+  kfc(coreDir, home, [
+    'codex',
+    'report-goal',
+    '--goal-id',
+    'codex-native-goal-1',
+    '--objective',
+    'Prove native Codex goal report receipts',
+    '--status',
+    'succeeded',
+    '--tokens-used',
+    '1234',
+    '--time-used-seconds',
+    '56',
+    '--title',
+    'Native Codex goal receipt',
+    '--json',
+  ]),
+);
+
+if (report.schema !== 'kungfu.codex-goal-report/v1') {
+  throw new Error(`unexpected receipt schema: ${report.schema}`);
+}
+if (!report.created_work || !report.work_id || !report.run_id || !report.receipt) {
+  throw new Error(`incomplete report payload: ${JSON.stringify(report)}`);
+}
+
+const verify = json(
+  kfc(coreDir, home, [
+    'codex',
+    'verify-goal-report',
+    '--receipt',
+    report.receipt,
+    '--json',
+  ]),
+);
+if (!verify.ok) throw new Error(`receipt did not verify: ${JSON.stringify(verify)}`);
+
+const shown = json(kfc(coreDir, home, ['work', 'show', report.work_id, '--json']));
+if (!shown.runs.some((row) => row.run_id === report.run_id)) {
+  throw new Error(`work item did not link run: ${JSON.stringify(shown.runs)}`);
+}
+
+const bundleDir = path.dirname(report.receipt);
+const eventFile = path.join(bundleDir, 'report-events.jsonl');
+assertFileContains(eventFile, 'codex-native-goal-1', 'goal usage event');
+assertFileContains(eventFile, 'tokens_used', 'goal usage event');
+if (!fs.existsSync(path.join(bundleDir, 'manifest.json'))) {
+  throw new Error('missing report manifest');
+}
+
+console.log('ok codex goal report');


### PR DESCRIPTION
## Summary
- add `kungfu codex report-goal` and `verify-goal-report` for native Codex goal receipts
- add agent bootstrap/status/mode/unbootstrap/uninstall policy surfaces with dry-run defaults
- update the agent onboarding pack and skills so report closeout verifies receipts and managed-run keeps report as fallback
- add fixtures for Codex goal receipts and agent bootstrap behavior

## Verification
- `uv run --frozen python -m py_compile src/python/kungfu/cli/commands/agent.py src/python/kungfu/cli/commands/codex.py src/python/kungfu/cli/commands/__registry__.py`
- `node scripts/verify-agent-pack.mjs`
- `node tests/fixtures/rewind-demo-codex-goal-report/run.mjs`
- `node tests/fixtures/agent-demo-bootstrap/run.mjs`
- `./kungfu-code build:core`
- `./kungfu-code freeze`
- `./kungfu-code verify`
- frozen CLI smoke: `kungfu codex report-goal` + `kungfu codex verify-goal-report`

## Notes
- `./kungfu-code --filter @kungfu-tech/core run package` reached binary staging but then failed in an existing package script path handling error (`ERR_INVALID_ARG_TYPE` in `framework/core/.gyp/run-build.js`).
