### PR TITLE
fix(terminal): scope the managed tmux socket to the runtime home

### DIFF
--- a/framework/api/src/capability/terminal.ts
+++ b/framework/api/src/capability/terminal.ts
@@ -104,6 +104,25 @@ export function tmuxSessionName(provider: string, runId: string): string {
   return `kf_${sanitizeTmuxToken(provider)}_${sanitizeTmuxToken(runId)}`;
 }
 
+// The managed tmux socket, derived from the runtime home. A tmux server freezes
+// its environment at creation, so a single shared socket lets a server started
+// by one runtime home leak its KF_RUNTIME_DIR / launcher into a managed session
+// created later by a *different* home (the session inherits the server's stale
+// env, and cost/journal facts land in the wrong home). Keying the socket on the
+// home makes each server belong to exactly one home, so its frozen env can only
+// ever be that home's. Deterministic, so a restart with the same home reattaches
+// to the same server. An empty home keeps the legacy name. This module is shared
+// browser/node, so the hash is a dependency-free djb2 rather than node:crypto.
+export function managedTmuxSocket(runtimeDir: string): string {
+  const home = runtimeDir.trim();
+  if (!home) return 'kungfu-managed';
+  let hash = 5381;
+  for (let i = 0; i < home.length; i++) {
+    hash = ((hash << 5) + hash + home.charCodeAt(i)) >>> 0;
+  }
+  return `kungfu-managed-${hash.toString(16).padStart(8, '0')}`;
+}
+
 // `new-session -A`: attach-or-create. When the named session already exists this
 // behaves like attach-session (command is ignored — the running agent is
 // untouched), which is exactly the W3 reattach path. Otherwise it creates the

--- a/framework/gui/src/main/terminal-host.ts
+++ b/framework/gui/src/main/terminal-host.ts
@@ -18,6 +18,7 @@ import {
   type Subscription,
   type Terminal,
   type TmuxBinding,
+  managedTmuxSocket,
   openTerminal,
 } from '@kungfu-tech/api/capability';
 
@@ -50,7 +51,9 @@ function resolveTmuxBinding(): TmuxBinding | null {
         ) => void,
       ) => void;
     };
-    const socket = process.env.KF_TMUX_SOCKET || 'kungfu-managed';
+    const socket =
+      process.env.KF_TMUX_SOCKET ||
+      managedTmuxSocket(process.env.KF_RUNTIME_DIR ?? '');
     const candidates = [
       process.env.KF_TMUX_BIN,
       '/opt/homebrew/bin/tmux',

--- a/framework/gui/src/renderer/src/runtime.ts
+++ b/framework/gui/src/renderer/src/runtime.ts
@@ -12,6 +12,7 @@ import {
   type Terminal,
   type TmuxBinding,
   type Work,
+  managedTmuxSocket,
   openDomainState,
   openLedger,
   openRemoteWork,
@@ -29,11 +30,6 @@ declare global {
 }
 
 export const APP_NAME = 'reference_app';
-
-// Dedicated tmux socket for Kungfu managed sessions. Every managed tmux command
-// carries `-L <socket>`, so it physically cannot touch the user's own
-// default-socket tmux sessions. Overridable for tests/other hosts.
-const TMUX_SOCKET = 'kungfu-managed';
 
 // A non-interactive shell must not rely on a `tmux` shell-function shim, so we
 // resolve an absolute binary. Candidates cover Homebrew (arm64/x86) and system
@@ -57,7 +53,13 @@ function resolveTmuxBinding(win: Window): TmuxBinding | null {
     const { execFile } = win.require('node:child_process') as {
       execFile: ExecFile;
     };
-    const socket = win.process.env.KF_TMUX_SOCKET || TMUX_SOCKET;
+    // Per-home socket (KF_TMUX_SOCKET overrides): a dedicated `-L kungfu-managed-*`
+    // socket that still cannot touch the user's own default-socket tmux, and whose
+    // server belongs to exactly this runtime home so its frozen env never leaks
+    // across homes.
+    const socket =
+      win.process.env.KF_TMUX_SOCKET ||
+      managedTmuxSocket(win.process.env.KF_RUNTIME_DIR ?? '');
     const candidates = [
       win.process.env.KF_TMUX_BIN,
       '/opt/homebrew/bin/tmux',


### PR DESCRIPTION
A tmux server freezes its env at creation; the managed backend used one fixed -L kungfu-managed socket for every runtime home, so a server started by one home could leak its stale KF_RUNTIME_DIR/launcher into a managed session created later by a different home (cost/journal facts then landed in the wrong home). Derive the socket per runtime home (kungfu-managed-<hash>): each server belongs to exactly one home, deterministic so restart reattaches, KF_TMUX_SOCKET still overrides.