### PR TITLE
perf(core): drop scientific stack from the frozen runtime

### DIFF
--- a/framework/core/src/python/kungfu/cli/commands/journal.py
+++ b/framework/core/src/python/kungfu/cli/commands/journal.py
@@ -88,22 +88,25 @@ def journal(ctx, mode, category, group, name):
 )
 @journal_command_context
 def sessions(ctx, sortby, ascending, tablefmt):
-    all_sessions = kfj.find_sessions(ctx).sort_values(by=sortby, ascending=ascending)
-    all_sessions["begin_time"] = all_sessions["begin_time"].apply(
-        lambda t: kft.strftime(t, kft.SESSION_DATETIME_FORMAT)
+    all_sessions = sorted(
+        kfj.find_sessions(ctx), key=lambda row: row[sortby], reverse=not ascending
     )
-    all_sessions["update_time"] = all_sessions["update_time"].apply(
-        lambda t: kft.strftime(abs(t), kft.SESSION_DATETIME_FORMAT)
-    )
-    all_sessions["end_time"] = all_sessions["end_time"].apply(
-        lambda t: kft.strftime(abs(t), kft.SESSION_DATETIME_FORMAT)
-    )
-    all_sessions["duration"] = all_sessions["duration"].apply(
-        lambda t: kft.strftime(t - kft.DURATION_TZ_ADJUST, kft.DURATION_FORMAT)
-    )
+    for row in all_sessions:
+        row["begin_time"] = kft.strftime(row["begin_time"], kft.SESSION_DATETIME_FORMAT)
+        row["update_time"] = kft.strftime(
+            abs(row["update_time"]), kft.SESSION_DATETIME_FORMAT
+        )
+        row["end_time"] = kft.strftime(
+            abs(row["end_time"]), kft.SESSION_DATETIME_FORMAT
+        )
+        row["duration"] = kft.strftime(
+            row["duration"] - kft.DURATION_TZ_ADJUST, kft.DURATION_FORMAT
+        )
 
     table = tabulate(
-        all_sessions.values, headers=all_sessions.columns, tablefmt=tablefmt
+        [[row[col] for col in kfj.SESSION_COLUMNS] for row in all_sessions],
+        headers=kfj.SESSION_COLUMNS,
+        tablefmt=tablefmt,
     )
 
     (term_width, term_height) = shutil.get_terminal_size()

--- a/framework/core/src/python/kungfu/yijinjing/journal.py
+++ b/framework/core/src/python/kungfu/yijinjing/journal.py
@@ -62,51 +62,54 @@ def collect_journal_locations(ctx):
     return locations
 
 
+SESSION_COLUMNS = [
+    "id",
+    "mode",
+    "category",
+    "group",
+    "name",
+    "begin_time",
+    "update_time",
+    "end_time",
+    "closed",
+    "duration",
+]
+
+
 def find_sessions(ctx):
     io_device = yjj.io_device(ctx.console_location)
     session_finder = yjj.session_finder(io_device)
     ctx.session_count = 1
-    import pandas
-
-    sessions_df = pandas.DataFrame(
-        columns=[
-            "id",
-            "mode",
-            "category",
-            "group",
-            "name",
-            "begin_time",
-            "update_time",
-            "end_time",
-            "closed",
-            "duration",
-        ]
-    )
     for_app = "app_location" in dir(ctx)
     sessions = (
         session_finder.find_sessions_for(ctx.app_location)
         if for_app
         else session_finder.find_sessions()
     )
+    rows = []
     for session in sessions:
-        sessions_df.loc[len(sessions_df)] = [
-            len(sessions_df) + 1,
-            lf.enums.get_mode_name(session.mode),
-            lf.enums.get_category_name(session.category),
-            session.group,
-            session.name,
-            session.begin_time,
-            session.update_time,
-            session.end_time,
-            session.end_time != 0,
-            abs(session.update_time) - session.begin_time,
-        ]
-    return sessions_df
+        rows.append(
+            {
+                "id": len(rows) + 1,
+                "mode": lf.enums.get_mode_name(session.mode),
+                "category": lf.enums.get_category_name(session.category),
+                "group": session.group,
+                "name": session.name,
+                "begin_time": session.begin_time,
+                "update_time": session.update_time,
+                "end_time": session.end_time,
+                "closed": session.end_time != 0,
+                "duration": abs(session.update_time) - session.begin_time,
+            }
+        )
+    return rows
 
 
 def find_session(ctx, session_id):
-    all_sessions = find_sessions(ctx)
-    return all_sessions[all_sessions["id"] == session_id].iloc[0]
+    for session in find_sessions(ctx):
+        if session["id"] == session_id:
+            return session
+    raise IndexError(f"session {session_id} not found")
 
 
 def make_location_from_dict(ctx, location):

--- a/framework/core/src/python/kungfu_cli.py
+++ b/framework/core/src/python/kungfu_cli.py
@@ -13,9 +13,17 @@
 # nuitka-project: --warn-unusual-code
 # nuitka-project: --warn-implicit-exceptions
 #
-# nuitka-project: --include-package=numpy
-# nuitka-project: --include-package=pandas
-# nuitka-project: --include-package=plotly
+# 科学计算栈不进冻结核心：plotly / scipy / statsmodels / botocore / boto3 全仓零 import（量化遗留声明），
+# numpy / pandas 此前仅 journal.py find_sessions 用来渲染 sessions 表，已改为纯 stdlib（dict + tabulate）实现，
+# 核心运行时不再依赖。这些包被 --include-package 强行编入使冻结主二进制膨胀 ~235M、散落 C 扩展再占 ~110M；
+# 移除后按需能力应由 kfx（developer/sdk python-AOT）自带，核心只提供 python runtime。
+# nuitka-project: --nofollow-import-to=numpy
+# nuitka-project: --nofollow-import-to=pandas
+# nuitka-project: --nofollow-import-to=scipy
+# nuitka-project: --nofollow-import-to=statsmodels
+# nuitka-project: --nofollow-import-to=plotly
+# nuitka-project: --nofollow-import-to=botocore
+# nuitka-project: --nofollow-import-to=boto3
 #
 # nuitka-project: --nofollow-import-to=*.distutils
 # nuitka-project: --nofollow-import-to=*.tests


### PR DESCRIPTION
## What

Stop force-including the scientific stack in the frozen `kungfu` runtime.

`kungfu_cli.py` force-included `numpy`/`pandas`/`plotly`, and Nuitka
additionally pulled in `scipy`/`statsmodels`/`botocore`/`boto3` as
transitive weight. None of these are used on the core runtime path:

- `plotly`, `scipy`, `statsmodels`, `botocore`, `boto3` — zero imports across the tree (legacy quant declarations).
- `numpy`/`pandas` — only used by `journal sessions` to render a table.

`find_sessions` is rewritten to return plain dicts and the table is
rendered with the existing `tabulate` dependency, so the six packages
can move from `--include-package` to `--nofollow-import-to`.

## Size (macOS arm64, freeze + package:app, C++ core unchanged)

| | before | after | saved |
|---|--:|--:|--:|
| frozen main binary | 257M | 22M | -235M |
| `dist/kungfu` | 709M | 378M | -331M |
| `Kungfu.app` | 993M | 699M | **-294M (-30%)** |

## Validation

Freeze + `package:app` rebuilt on top of an unchanged native core.
Runtime smoke tests green: `journal sessions` (now stdlib-only),
`journal sessions -s duration -a`, `kfx contract`, `config show`,
`skill`, `--version`.

## Follow-up

On-demand heavy dependencies should ship with the kfx that needs them
(`developer/sdk` python-AOT), keeping the core a lean python runtime.