### PR TITLE
build(gui): configure Linux and Windows packaging targets

### DIFF
--- a/framework/gui/electron-builder.yml
+++ b/framework/gui/electron-builder.yml
@@ -39,3 +39,21 @@ mac:
     - dmg
     - zip
   identity: null
+linux:
+  # executableName is required here: on Linux it otherwise defaults to the
+  # package name (@kungfu-tech/gui), whose '@' and '/' are rejected as an
+  # executable file name and break AppImage/snap packaging. dir = the pack
+  # verb's fast unpacked app; AppImage = the dist verb's portable installer.
+  # snap is intentionally not a target — it needs a snapcraft/mksquashfs
+  # toolchain that is not part of this build host.
+  executableName: kungfu
+  category: Finance
+  target:
+    - dir
+    - AppImage
+win:
+  # nsis = the dist verb's Windows installer; dir = the fast unpacked app.
+  # executableName defaults to productName (Kungfu), already a valid file name.
+  target:
+    - dir
+    - nsis


### PR DESCRIPTION
electron-builder.yml only declared mac targets, so gui dist on Linux/Windows fell back to defaults and failed (Linux executableName defaults to the package name @kungfu-tech/gui whose @ and / are rejected). Add explicit linux (dir+AppImage, executableName=kungfu, snap omitted) and win (dir+nsis) targets. Verified on Linux (agent-120): dev+fix produces a 232MB AppImage with executable name kungfu. Windows dist verification to follow.