### PR TITLE
fix(build): unblock Windows core build and cross-platform packaging

### DIFF
--- a/framework/core/.gyp/gen-stubs.js
+++ b/framework/core/.gyp/gen-stubs.js
@@ -23,6 +23,25 @@ function main() {
   const buildType = shell.getConfigValue('build_type') || 'Release';
   const buildDir = path.resolve('build', buildType);
 
+  // Windows: the MSVC multi-config generator emits pykungfu.<abi>.pyd into build/
+  // root while libnode.dll lands in build/<build_type>. pybind11-stubgen imports
+  // pykungfu, so the .pyd must be on PYTHONPATH *and* able to load libnode.dll —
+  // and Python 3.8+ resolves an extension's dependent DLLs from the extension's
+  // own directory, not PATH. So colocate the .pyd next to libnode.dll in
+  // build/<build_type>; then PYTHONPATH=build/<build_type> both imports it and
+  // resolves the DLL. Mac/Linux keep the .so in build/<build_type> with rpath, so
+  // this is a no-op there. (run-freeze.js colocates the same way for the frozen
+  // runtime; without it stubgen fails with ModuleNotFoundError: pykungfu.)
+  if (process.platform === 'win32') {
+    const buildRoot = path.resolve('build');
+    const [pyd] = glob.sync('pykungfu*.pyd', { cwd: buildRoot });
+    if (pyd) {
+      fs.copyFileSync(path.join(buildRoot, pyd), path.join(buildDir, pyd));
+    } else {
+      console.error('[gen-stubs] Win: pykungfu*.pyd not found in build/ root');
+    }
+  }
+
   // pybind11-stubgen imports pykungfu from build/<build_type>; pass PYTHONPATH to
   // the child only (not this process). Runs in the uv venv (pybind11-stubgen dep).
   const prev = process.env.PYTHONPATH;

--- a/framework/gui/package.json
+++ b/framework/gui/package.json
@@ -22,8 +22,8 @@
     "gen:first-party-manifest": "node --experimental-transform-types scripts/gen-first-party-manifest.mjs",
     "audit:bundle": "node scripts/bundle-core-audit.cjs",
     "start": "pnpm run ensure-electron && electron-vite preview",
-    "pack": "pnpm --filter @kungfu-tech/tui run bundle && pnpm run ensure-electron && electron-vite build && electron-builder --dir --config.electronDist=$(node -p \"require('path').dirname(require.resolve('electron'))+'/dist'\")",
-    "dist": "pnpm --filter @kungfu-tech/tui run bundle && pnpm run ensure-electron && electron-vite build && electron-builder --config.electronDist=$(node -p \"require('path').dirname(require.resolve('electron'))+'/dist'\")",
+    "pack": "pnpm --filter @kungfu-tech/tui run bundle && pnpm run ensure-electron && electron-vite build && node scripts/run-electron-builder.mjs --dir",
+    "dist": "pnpm --filter @kungfu-tech/tui run bundle && pnpm run ensure-electron && electron-vite build && node scripts/run-electron-builder.mjs",
     "clean": "rimraf out dist node_modules/.vite"
   },
   "dependencies": {

--- a/framework/gui/scripts/run-electron-builder.mjs
+++ b/framework/gui/scripts/run-electron-builder.mjs
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+// Cross-platform electron-builder launcher.
+//
+// electron-builder needs --config.electronDist pointing at the local electron
+// install because pnpm does not hoist electron to a path electron-builder can
+// guess. The pack/dist scripts used to compute it with a POSIX `$(node -p …)`
+// command substitution, which cmd.exe does not understand, so `pnpm run dist`
+// failed on Windows (electron-builder got the literal `$(…)` string). Resolve it
+// in node here and invoke electron-builder's JS bin directly (args as an array,
+// no shell), so pack/dist work identically on macOS, Linux, and Windows.
+//
+// Any extra args (e.g. `--dir` for pack) are forwarded before the computed
+// electronDist override.
+
+import { spawnSync } from 'node:child_process';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+
+const require = createRequire(import.meta.url);
+
+const electronDist = `${dirname(require.resolve('electron'))}/dist`;
+
+const ebPkgPath = require.resolve('electron-builder/package.json');
+const ebPkg = require(ebPkgPath);
+const ebBin = join(dirname(ebPkgPath), ebPkg.bin['electron-builder']);
+
+const args = [
+  ebBin,
+  ...process.argv.slice(2),
+  `--config.electronDist=${electronDist}`,
+];
+
+const result = spawnSync(process.execPath, args, { stdio: 'inherit' });
+process.exit(result.status ?? 1);


### PR DESCRIPTION
Two Windows-portability build fixes surfaced verifying the full package pipeline on Windows: (1) colocate pykungfu.pyd next to libnode.dll for pybind11-stubgen (MSVC multi-config emits the .pyd in build/ root and Python 3.8+ resolves an extension's DLLs from its own dir, so build:core failed with ModuleNotFoundError: pykungfu); (2) resolve --config.electronDist in a node launcher instead of a POSIX $(node -p ...) substitution that cmd.exe cannot run. Both are no-ops / behavior-preserving on macOS and Linux. Verified on Windows: build:core + freeze now pass (Nuitka produces kungfu_cli.exe) and electron-vite build runs; a further packaging-time issue (kfx contract path) is tracked separately.