### PR TITLE
fix(gui): find the kfx contract on Windows when baking the manifest

### DIFF
--- a/framework/gui/src/main/first-party-manifest.ts
+++ b/framework/gui/src/main/first-party-manifest.ts
@@ -61,7 +61,12 @@ export function generateFirstPartyManifest(
     path: nodePath,
     crypto: nodeCrypto as unknown as KfxPlanDeps['crypto'],
   };
-  const contract = loadKfxContract(process.env, deps);
+  // Pass cwd explicitly: the contract resolver walks ancestors of options.cwd /
+  // env.PWD to find framework/kfx/kungfu-kfx.contract.json, but cmd.exe does not
+  // set PWD, so on Windows the ancestor search would be empty and the (present)
+  // contract would not be found. process.cwd() (framework/gui at pack time) has
+  // the repo root as an ancestor, matching the POSIX env.PWD behavior.
+  const contract = loadKfxContract(process.env, deps, { cwd: process.cwd() });
   const keys: Record<string, FirstPartyPin> = {};
   for (const dir of packageDirs(firstPartyRoot)) {
     let manifest: ViewManifest;


### PR DESCRIPTION
The electron-builder beforePack manifest bake called loadKfxContract without a cwd, so the contract resolver walked ancestors of env.PWD only; cmd.exe does not set PWD, so on Windows the committed framework/kfx/kungfu-kfx.contract.json was reported not found and dist failed. Pass cwd: process.cwd() to match POSIX behavior. With this the full Windows package pipeline completes: verified on DARKHERO producing a 162MB 'Kungfu Setup 4.0.0-alpha.0.exe' nsis installer. No change on macOS/Linux.