### PR TITLE
feat(atlas): show imported Atlas work in the GUI

### DIFF
--- a/extensions/work-dashboard/package.json
+++ b/extensions/work-dashboard/package.json
@@ -44,7 +44,8 @@
         "title": "Work dashboard",
         "capabilities": [
           "ledger",
-          "work"
+          "work",
+          "atlas"
         ]
       }
     }

--- a/extensions/work-dashboard/src/view/index.tsx
+++ b/extensions/work-dashboard/src/view/index.tsx
@@ -4,13 +4,28 @@
 // decisions, validations, artifacts, linked runs) and lifecycle history.
 // Linked runs point at the Rewind inspector, which stays the run-level
 // forensic detail view.
-import type { WorkItem } from '@kungfu-tech/api/capability';
+import type {
+  Atlas,
+  AtlasGoal,
+  AtlasImportInfo,
+  AtlasMission,
+  WorkItem,
+} from '@kungfu-tech/api/capability';
 import { WORK_STATUS_NAMES } from '@kungfu-tech/api/capability';
-import React from 'react';
 import type { KfxCapabilities, Shell } from '@kungfu-tech/kfx';
 import { headingStyle, mono, panelStyle } from '@kungfu-tech/kfx';
+import React from 'react';
 
 const STATUS_ORDER = ['active', 'blocked', 'waiting', 'ready', 'done'] as const;
+const ATLAS_GOAL_STATUSES = [
+  'active',
+  'paused',
+  'waiting',
+  'blocked',
+  'stage-ready',
+  'ready',
+  'completed',
+] as const;
 
 const STATUS_COLORS: Record<string, string> = {
   active: '#4ec9b0',
@@ -32,6 +47,34 @@ function StatusBadge({ name }: { name: string }) {
   );
 }
 
+function SmallButton({
+  active = false,
+  children,
+  onClick,
+}: {
+  active?: boolean;
+  children: React.ReactNode;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      style={{
+        ...mono,
+        padding: '3px 8px',
+        border: active ? '1px solid #2d8fcc' : '1px solid #3c3c3c',
+        borderRadius: 4,
+        cursor: 'pointer',
+        background: active ? '#04395e' : 'transparent',
+        color: active ? '#9cdcfe' : '#cccccc',
+      }}
+    >
+      {children}
+    </button>
+  );
+}
+
 type FactRow = { key: string; fields: Record<string, string | undefined> };
 
 function FactRows({ label, rows }: { label: string; rows: FactRow[] }) {
@@ -49,6 +92,278 @@ function FactRows({ label, rows }: { label: string; rows: FactRow[] }) {
             .join(' · ')}
         </div>
       ))}
+    </div>
+  );
+}
+
+function AtlasGoalDetail({ goal }: { goal: AtlasGoal | null }) {
+  if (!goal) {
+    return (
+      <section style={{ ...panelStyle, flex: 1 }}>
+        <div style={{ ...mono, color: '#6a6a6a' }}>
+          select an imported Atlas goal
+        </div>
+      </section>
+    );
+  }
+  const rows: [string, string | boolean | undefined][] = [
+    ['goal_id', goal.goal_id],
+    ['status', goal.status],
+    ['mission_id', goal.mission_id],
+    ['lens', goal.lens],
+    ['owner_agent', goal.owner_agent],
+    ['source_branch', goal.source_branch],
+    ['worktree_path', goal.worktree_path],
+    ['external_repo_path', goal.external_repo_path],
+    ['external_branch', goal.external_branch],
+    ['external_head', goal.external_head],
+    ['external_ready_ref', goal.external_ready_ref],
+    ['latest_marker', goal.latest_marker],
+    ['archived', goal.archived],
+  ];
+  return (
+    <section style={{ ...panelStyle, flex: 1, minWidth: 0 }}>
+      <h2 style={headingStyle}>{goal.goal_id}</h2>
+      <div style={{ ...mono, color: '#cccccc', marginBottom: 6 }}>
+        [{goal.status ?? 'unknown'}] {goal.title ?? ''}
+      </div>
+      {goal.summary && (
+        <div style={{ ...mono, color: '#858585', marginBottom: 8 }}>
+          {goal.summary}
+        </div>
+      )}
+      {goal.next_action && (
+        <div style={{ ...mono, color: '#dcdcaa', marginBottom: 8 }}>
+          next: {goal.next_action}
+        </div>
+      )}
+      <h2 style={headingStyle}>Projection fields</h2>
+      {rows
+        .filter(([, value]) => value !== undefined && value !== '')
+        .map(([key, value]) => (
+          <div
+            key={key}
+            style={{
+              ...mono,
+              color: '#9cdcfe',
+              overflowWrap: 'anywhere',
+              marginBottom: 2,
+            }}
+          >
+            {key}: {String(value)}
+          </div>
+        ))}
+    </section>
+  );
+}
+
+function AtlasUnavailableView() {
+  return (
+    <section style={{ ...panelStyle, height: '100%' }}>
+      <div style={{ ...mono, color: '#c46b6b' }}>
+        atlas capability is not available in this runtime
+      </div>
+    </section>
+  );
+}
+
+function AtlasProjectionView({ atlas }: { atlas: Atlas }) {
+  const [repoRoot, setRepoRoot] = React.useState(atlas.defaultRepoRoot);
+  const [missions, setMissions] = React.useState<AtlasMission[]>(() =>
+    atlas.missions(),
+  );
+  const [goals, setGoals] = React.useState<AtlasGoal[]>(() => atlas.goals());
+  const [info, setInfo] = React.useState<AtlasImportInfo | null>(() =>
+    atlas.importInfo(),
+  );
+  const [selectedMission, setSelectedMission] = React.useState<string>('all');
+  const [statusFilter, setStatusFilter] = React.useState<string>('all');
+  const [selectedGoal, setSelectedGoal] = React.useState<string | null>(null);
+  const [message, setMessage] = React.useState<string>('');
+
+  const reload = React.useCallback(() => {
+    setInfo(atlas.importInfo());
+    setMissions(atlas.missions());
+    setGoals(atlas.goals());
+  }, [atlas]);
+
+  React.useEffect(() => {
+    reload();
+  }, [reload]);
+
+  const importNow = () => {
+    if (!repoRoot.trim()) {
+      setMessage('enter an Atlas repo path before importing');
+      return;
+    }
+    try {
+      const result = atlas.importRepo(repoRoot);
+      setMessage(
+        `imported ${result.missions} missions / ${result.goals} goals / ${result.markers} markers (${result.warnings.length} warning)`,
+      );
+      reload();
+    } catch (e) {
+      setMessage((e as Error).message);
+    }
+  };
+
+  const visibleGoals = goals.filter(
+    (goal) =>
+      (selectedMission === 'all' || goal.mission_id === selectedMission) &&
+      (statusFilter === 'all' || goal.status === statusFilter),
+  );
+  const currentGoal =
+    visibleGoals.find((goal) => goal.goal_id === selectedGoal) ??
+    goals.find((goal) => goal.goal_id === selectedGoal) ??
+    null;
+  const goalCounts = new Map<string, number>();
+  for (const goal of goals) {
+    const status = goal.status ?? 'unknown';
+    goalCounts.set(status, (goalCounts.get(status) ?? 0) + 1);
+  }
+
+  return (
+    <div style={{ display: 'flex', gap: 12, height: '100%', minHeight: 0 }}>
+      <section style={{ ...panelStyle, width: 440, flexShrink: 0 }}>
+        <h2 style={headingStyle}>Atlas projection</h2>
+        <div style={{ ...mono, color: '#858585', marginBottom: 8 }}>
+          source: Atlas files · authority stays in Atlas
+        </div>
+        <div style={{ display: 'flex', gap: 6, marginBottom: 8 }}>
+          <input
+            value={repoRoot}
+            placeholder="Atlas repo path"
+            onChange={(e) => setRepoRoot(e.target.value)}
+            style={{
+              ...mono,
+              flex: 1,
+              minWidth: 0,
+              border: '1px solid #3c3c3c',
+              borderRadius: 4,
+              background: '#1e1e1e',
+              color: '#cccccc',
+              padding: '4px 6px',
+            }}
+          />
+          <SmallButton onClick={importNow}>import</SmallButton>
+          <SmallButton onClick={reload}>refresh</SmallButton>
+        </div>
+        {info && (
+          <div style={{ ...mono, color: '#9cdcfe', marginBottom: 6 }}>
+            {info.missions} missions · {info.goals} goals · {info.markers}{' '}
+            markers
+          </div>
+        )}
+        {message && (
+          <div style={{ ...mono, color: '#dcdcaa', marginBottom: 8 }}>
+            {message}
+          </div>
+        )}
+        <h2 style={headingStyle}>Missions · {missions.length}</h2>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+          <button
+            type="button"
+            onClick={() => setSelectedMission('all')}
+            style={{
+              ...mono,
+              border: 'none',
+              borderRadius: 4,
+              cursor: 'pointer',
+              background: selectedMission === 'all' ? '#04395e' : 'transparent',
+              color: '#cccccc',
+              padding: '4px 8px',
+              textAlign: 'left',
+            }}
+          >
+            all missions
+          </button>
+          {missions.map((mission) => (
+            <button
+              key={mission.mission_id}
+              type="button"
+              onClick={() => setSelectedMission(mission.mission_id)}
+              style={{
+                ...mono,
+                border: 'none',
+                borderRadius: 4,
+                cursor: 'pointer',
+                background:
+                  selectedMission === mission.mission_id
+                    ? '#04395e'
+                    : 'transparent',
+                color: '#cccccc',
+                padding: '4px 8px',
+                textAlign: 'left',
+              }}
+            >
+              <span style={{ color: '#4ec9b0' }}>{mission.mission_id}</span>
+              <div style={{ color: '#858585', fontSize: 11 }}>
+                {mission.title ?? ''} {mission.stage_name ?? ''}
+              </div>
+            </button>
+          ))}
+        </div>
+      </section>
+      <section style={{ ...panelStyle, width: 440, flexShrink: 0 }}>
+        <h2 style={headingStyle}>Goals · {visibleGoals.length}</h2>
+        <div
+          style={{ display: 'flex', flexWrap: 'wrap', gap: 4, marginBottom: 8 }}
+        >
+          <SmallButton
+            active={statusFilter === 'all'}
+            onClick={() => setStatusFilter('all')}
+          >
+            all {goals.length}
+          </SmallButton>
+          {ATLAS_GOAL_STATUSES.map((status) => (
+            <SmallButton
+              key={status}
+              active={statusFilter === status}
+              onClick={() => setStatusFilter(status)}
+            >
+              {status} {goalCounts.get(status) ?? 0}
+            </SmallButton>
+          ))}
+        </div>
+        {visibleGoals.length ? (
+          <ul style={{ listStyle: 'none', margin: 0, padding: 0 }}>
+            {visibleGoals.map((goal) => (
+              <li key={goal.goal_id}>
+                <button
+                  type="button"
+                  onClick={() => setSelectedGoal(goal.goal_id)}
+                  style={{
+                    ...mono,
+                    display: 'block',
+                    width: '100%',
+                    textAlign: 'left',
+                    padding: '4px 8px',
+                    border: 'none',
+                    borderRadius: 4,
+                    cursor: 'pointer',
+                    background:
+                      selectedGoal === goal.goal_id ? '#04395e' : 'transparent',
+                    color: '#cccccc',
+                  }}
+                >
+                  <span style={{ color: '#9cdcfe' }}>
+                    [{goal.status ?? 'unknown'}]
+                  </span>{' '}
+                  {goal.title ?? goal.goal_id}
+                  <div style={{ color: '#858585', fontSize: 11 }}>
+                    {goal.goal_id}
+                  </div>
+                </button>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <div style={{ ...mono, color: '#6a6a6a' }}>
+            no imported goals match this filter
+          </div>
+        )}
+      </section>
+      <AtlasGoalDetail goal={currentGoal} />
     </div>
   );
 }
@@ -170,6 +485,9 @@ function WorkDashboardView({
   caps: KfxCapabilities;
   shell: Shell;
 }) {
+  const [view, setView] = React.useState<'work' | 'atlas'>(
+    shell.params?.view === 'atlas' ? 'atlas' : 'work',
+  );
   const [items, setItems] = React.useState<WorkItem[]>(() => caps.work.items());
   const [filter, setFilter] = React.useState<string>('all');
   const [selected, setSelected] = React.useState<string | null>(null);
@@ -213,81 +531,120 @@ function WorkDashboardView({
     </button>
   );
 
+  if (view === 'atlas') {
+    const atlas = caps.atlas;
+    return (
+      <div style={{ height: '100%', minHeight: 0 }}>
+        <div style={{ display: 'flex', gap: 4, marginBottom: 8 }}>
+          <SmallButton onClick={() => setView('work')}>work</SmallButton>
+          <SmallButton active onClick={() => setView('atlas')}>
+            atlas
+          </SmallButton>
+        </div>
+        {atlas ? (
+          <AtlasProjectionView atlas={atlas} />
+        ) : (
+          <AtlasUnavailableView />
+        )}
+      </div>
+    );
+  }
+
   return (
-    <div style={{ display: 'flex', gap: 12, height: '100%', minHeight: 0 }}>
-      <section style={{ ...panelStyle, width: 380, flexShrink: 0 }}>
-        <h2 style={headingStyle}>Work · {items.length}</h2>
-        <div
-          style={{ display: 'flex', flexWrap: 'wrap', gap: 4, marginBottom: 8 }}
-        >
-          {filterButton('all', items.length)}
-          {STATUS_ORDER.map((name) =>
-            filterButton(name, counts.get(name) ?? 0),
-          )}
-          <button
-            type="button"
-            onClick={reload}
+    <div style={{ height: '100%', minHeight: 0 }}>
+      <div style={{ display: 'flex', gap: 4, marginBottom: 8 }}>
+        <SmallButton active onClick={() => setView('work')}>
+          work
+        </SmallButton>
+        <SmallButton onClick={() => setView('atlas')}>atlas</SmallButton>
+      </div>
+      <div
+        style={{
+          display: 'flex',
+          gap: 12,
+          height: 'calc(100% - 32px)',
+          minHeight: 0,
+        }}
+      >
+        <section style={{ ...panelStyle, width: 380, flexShrink: 0 }}>
+          <h2 style={headingStyle}>Work · {items.length}</h2>
+          <div
             style={{
-              ...mono,
-              padding: '3px 8px',
-              border: '1px solid #3c3c3c',
-              borderRadius: 4,
-              cursor: 'pointer',
-              background: 'transparent',
-              color: '#cccccc',
+              display: 'flex',
+              flexWrap: 'wrap',
+              gap: 4,
+              marginBottom: 8,
             }}
           >
-            refresh
-          </button>
-        </div>
-        {visible.length ? (
-          <ul style={{ listStyle: 'none', margin: 0, padding: 0 }}>
-            {visible.map((item) => (
-              <li key={item.workId}>
-                <button
-                  type="button"
-                  onClick={() => setSelected(item.workId)}
-                  style={{
-                    ...mono,
-                    display: 'block',
-                    width: '100%',
-                    textAlign: 'left',
-                    padding: '4px 8px',
-                    border: 'none',
-                    borderRadius: 4,
-                    cursor: 'pointer',
-                    background:
-                      selected === item.workId ? '#04395e' : 'transparent',
-                    color: '#cccccc',
-                  }}
-                >
-                  <StatusBadge name={statusName(item)} />{' '}
-                  {item.title ?? item.workId}
-                  {item.nextAction && (
-                    <div style={{ color: '#858585', fontSize: 11 }}>
-                      next: {item.nextAction}
-                    </div>
-                  )}
-                </button>
-              </li>
-            ))}
-          </ul>
-        ) : (
-          <div style={{ ...mono, color: '#6a6a6a' }}>
-            no work items — create one with `kungfu work create "..."`
+            {filterButton('all', items.length)}
+            {STATUS_ORDER.map((name) =>
+              filterButton(name, counts.get(name) ?? 0),
+            )}
+            <button
+              type="button"
+              onClick={reload}
+              style={{
+                ...mono,
+                padding: '3px 8px',
+                border: '1px solid #3c3c3c',
+                borderRadius: 4,
+                cursor: 'pointer',
+                background: 'transparent',
+                color: '#cccccc',
+              }}
+            >
+              refresh
+            </button>
           </div>
-        )}
-      </section>
-      {current ? (
-        <DetailView caps={caps} shell={shell} item={current} />
-      ) : (
-        <section style={{ ...panelStyle, flex: 1 }}>
-          <div style={{ ...mono, color: '#6a6a6a' }}>
-            select a work item — its facts, next action, history and linked runs
-            appear here
-          </div>
+          {visible.length ? (
+            <ul style={{ listStyle: 'none', margin: 0, padding: 0 }}>
+              {visible.map((item) => (
+                <li key={item.workId}>
+                  <button
+                    type="button"
+                    onClick={() => setSelected(item.workId)}
+                    style={{
+                      ...mono,
+                      display: 'block',
+                      width: '100%',
+                      textAlign: 'left',
+                      padding: '4px 8px',
+                      border: 'none',
+                      borderRadius: 4,
+                      cursor: 'pointer',
+                      background:
+                        selected === item.workId ? '#04395e' : 'transparent',
+                      color: '#cccccc',
+                    }}
+                  >
+                    <StatusBadge name={statusName(item)} />{' '}
+                    {item.title ?? item.workId}
+                    {item.nextAction && (
+                      <div style={{ color: '#858585', fontSize: 11 }}>
+                        next: {item.nextAction}
+                      </div>
+                    )}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <div style={{ ...mono, color: '#6a6a6a' }}>
+              no work items — create one with `kungfu work create "..."`
+            </div>
+          )}
         </section>
-      )}
+        {current ? (
+          <DetailView caps={caps} shell={shell} item={current} />
+        ) : (
+          <section style={{ ...panelStyle, flex: 1 }}>
+            <div style={{ ...mono, color: '#6a6a6a' }}>
+              select a work item — its facts, next action, history and linked
+              runs appear here
+            </div>
+          </section>
+        )}
+      </div>
     </div>
   );
 }

--- a/framework/api/src/capability/atlas.ts
+++ b/framework/api/src/capability/atlas.ts
@@ -1,0 +1,205 @@
+// Atlas-domain capability handle: call the existing read-only
+// `kungfu atlas` CLI surface and expose its JSON projection to GUI/kfx views.
+// Atlas remains the authority; this handle only imports and reads Kungfu's
+// local projection.
+
+export type AtlasMission = {
+  mission_id: string;
+  title?: string;
+  status?: string;
+  active_lens?: string;
+  stage_name?: string;
+  next_review?: string;
+  next_action?: string;
+};
+
+export type AtlasGoal = {
+  goal_id: string;
+  status?: string;
+  title?: string;
+  owner_agent?: string;
+  mission_id?: string;
+  lens?: string;
+  mission_stage?: string;
+  source_branch?: string;
+  worktree_path?: string;
+  external_repo_path?: string;
+  external_branch?: string;
+  external_head?: string;
+  external_ready_ref?: string;
+  latest_marker?: string;
+  summary?: string;
+  next_action?: string;
+  archived?: boolean;
+};
+
+export type AtlasMarker = {
+  branch: string;
+  status?: string;
+  ready?: boolean;
+  ready_scope?: string;
+  keep_source_worktree?: boolean;
+  worktree_path?: string;
+  summary?: string;
+  risk?: string;
+  marker_path?: string;
+};
+
+export type AtlasImportResult = {
+  import_id: string;
+  repo_root: string;
+  missions: number;
+  goals: number;
+  markers: number;
+  warnings: string[];
+};
+
+export type AtlasImportInfo = {
+  import_id: string;
+  repo_root: string;
+  repo_head?: string;
+  missions: number;
+  goals: number;
+  markers: number;
+};
+
+export type AtlasMissionDetail = {
+  mission: AtlasMission;
+  goals: AtlasGoal[];
+};
+
+export type AtlasGoalFilter = {
+  status?: string;
+  missionId?: string;
+};
+
+export type Atlas = {
+  runtimeDir: string;
+  defaultRepoRoot: string;
+  importRepo: (repoRoot: string) => AtlasImportResult;
+  importInfo: () => AtlasImportInfo | null;
+  missions: () => AtlasMission[];
+  mission: (missionId: string) => AtlasMissionDetail | null;
+  goals: (filter?: AtlasGoalFilter) => AtlasGoal[];
+  goal: (goalId: string) => AtlasGoal | null;
+  markers: () => AtlasMarker[];
+};
+
+export type AtlasExecFileSync = (
+  file: string,
+  args: string[],
+  options: { encoding: 'utf8'; env: Record<string, string | undefined> },
+) => string;
+
+export type OpenAtlasOptions = {
+  runtimeDir: string;
+  execFileSync: AtlasExecFileSync;
+  env?: Record<string, string | undefined>;
+  bin?: string;
+};
+
+function parseJson<T>(text: string): T {
+  return JSON.parse(text) as T;
+}
+
+function cliEnv(
+  base: Record<string, string | undefined>,
+  runtimeDir: string,
+): Record<string, string | undefined> {
+  return {
+    ...base,
+    KF_RUNTIME_DIR: runtimeDir,
+  };
+}
+
+function isNoCompletedImport(error: unknown): boolean {
+  const stderr = String(
+    (error as { stderr?: unknown; message?: unknown }).stderr ??
+      (error as { message?: unknown }).message ??
+      '',
+  );
+  return stderr.includes('no completed import');
+}
+
+export function openAtlas(options: OpenAtlasOptions): Atlas {
+  const env = options.env ?? {};
+  const runtimeDir = options.runtimeDir;
+  const bin = options.bin || env.KUNGFU_CLI_BIN || env.KUNGFU_BIN || 'kungfu';
+  const defaultRepoRoot = env.KUNGFU_ATLAS_REPO || env.ATLAS_REPO || '';
+
+  const runJson = <T>(args: string[]): T => {
+    const out = options.execFileSync(bin, args, {
+      encoding: 'utf8',
+      env: cliEnv(env, runtimeDir),
+    });
+    return parseJson<T>(out);
+  };
+
+  return {
+    runtimeDir,
+    defaultRepoRoot,
+    importRepo: (repoRoot) =>
+      runJson<AtlasImportResult>([
+        'atlas',
+        'import',
+        '--repo',
+        repoRoot,
+        '--json',
+      ]),
+    importInfo: () => {
+      try {
+        return runJson<AtlasImportInfo>(['atlas', 'show', 'import', '--json']);
+      } catch (e) {
+        if (isNoCompletedImport(e)) return null;
+        throw e;
+      }
+    },
+    missions: () => {
+      try {
+        return runJson<AtlasMission[]>(['atlas', 'show', 'missions', '--json']);
+      } catch (e) {
+        if (isNoCompletedImport(e)) return [];
+        throw e;
+      }
+    },
+    mission: (missionId) => {
+      try {
+        return runJson<AtlasMissionDetail>([
+          'atlas',
+          'show',
+          'mission',
+          missionId,
+          '--json',
+        ]);
+      } catch {
+        return null;
+      }
+    },
+    goals: (filter = {}) => {
+      const args = ['atlas', 'show', 'goals', '--json'];
+      if (filter.status) args.push('--status', filter.status);
+      if (filter.missionId) args.push('--mission', filter.missionId);
+      try {
+        return runJson<AtlasGoal[]>(args);
+      } catch (e) {
+        if (isNoCompletedImport(e)) return [];
+        throw e;
+      }
+    },
+    goal: (goalId) => {
+      try {
+        return runJson<AtlasGoal>(['atlas', 'show', 'goal', goalId, '--json']);
+      } catch {
+        return null;
+      }
+    },
+    markers: () => {
+      try {
+        return runJson<AtlasMarker[]>(['atlas', 'show', 'markers', '--json']);
+      } catch (e) {
+        if (isNoCompletedImport(e)) return [];
+        throw e;
+      }
+    },
+  };
+}

--- a/framework/api/src/capability/index.ts
+++ b/framework/api/src/capability/index.ts
@@ -10,6 +10,7 @@ export * from './schema.js';
 export * from './sandbox.js';
 export * from './terminal.js';
 export * from './work.js';
+export * from './atlas.js';
 
 // The runtime-plane trust boundary (ADR-0013 / ADR-0014): the OS-sandbox
 // launcher, the child-process relay transport, the Node child-side guest proxy,

--- a/framework/core/src/python/kungfu/cli/commands/__init__.py
+++ b/framework/core/src/python/kungfu/cli/commands/__init__.py
@@ -153,6 +153,7 @@ def kfc(ctx, home, extension_path, log_level, name, stage, env_verify_location):
     if env_verify_location:
         os.environ["KF_VERIFY_LOCATION"] = "KF_VERIFY_LOCATION"
 
+    runtime_dir_override = os.environ.get("KF_RUNTIME_DIR") if not home else None
     home = default_runtime_home() if not home else home
     ctx.extension_path = extension_path
 
@@ -165,7 +166,13 @@ def kfc(ctx, home, extension_path, log_level, name, stage, env_verify_location):
             os.makedirs(target)
         return target
 
-    ctx.runtime_dir = ensure_dir(ctx, "runtime")
+    if runtime_dir_override:
+        ctx.runtime_dir = os.path.abspath(os.path.expanduser(runtime_dir_override))
+        if not os.path.exists(ctx.runtime_dir):
+            os.makedirs(ctx.runtime_dir)
+    else:
+        ctx.runtime_dir = ensure_dir(ctx, "runtime")
+    os.environ["KF_RUNTIME_DIR"] = ctx.runtime_dir
     ctx.archive_dir = ensure_dir(ctx, "archive")
     ctx.dataset_dir = ensure_dir(ctx, "dataset")
     ctx.backtest_dir = ensure_dir(ctx, "backtest")

--- a/framework/gui/src/renderer/src/main.tsx
+++ b/framework/gui/src/renderer/src/main.tsx
@@ -84,6 +84,7 @@ function subsetCaps(runtime: Runtime, entry: KfxEntry): KfxCapabilities | null {
     rewind: runtime.rewind,
     terminal: runtime.terminal,
     work: runtime.work,
+    atlas: runtime.atlas,
   } as Record<string, unknown>;
   const subset: Record<string, unknown> = {};
   for (const key of entry.capabilities) {
@@ -110,6 +111,7 @@ function sandboxSubset(
     rewind: runtime.rewind,
     terminal: runtime.terminal,
     work: runtime.work,
+    atlas: runtime.atlas,
   };
   const subset: Record<string, Record<string, unknown>> = {};
   for (const key of entry.capabilities) {

--- a/framework/gui/src/renderer/src/runtime.ts
+++ b/framework/gui/src/renderer/src/runtime.ts
@@ -3,6 +3,7 @@
 // (ADR-0011), and hand capability handles to the shell and its kfx. This is
 // the moat: the renderer reaches the runtime directly, no IPC copy.
 import {
+  type Atlas,
   type DomainState,
   type KfNativeBinding,
   type Ledger,
@@ -13,6 +14,7 @@ import {
   type TmuxBinding,
   type Work,
   managedTmuxSocket,
+  openAtlas,
   openDomainState,
   openLedger,
   openRemoteWork,
@@ -119,6 +121,7 @@ export type Runtime = {
   remoteWork: RemoteWork | null;
   terminal: Terminal | null;
   work: Work | null;
+  atlas: Atlas | null;
 };
 
 function readLongfistTypes(
@@ -154,6 +157,7 @@ export function bootRuntime(): Runtime {
     remoteWork: null,
     terminal: null,
     work: null,
+    atlas: null,
   };
   try {
     const bindingPath = env.KFE_PATH;
@@ -161,15 +165,16 @@ export function bootRuntime(): Runtime {
       return { ...base, ok: false, message: 'KFE_PATH not set' };
     }
     const binding = window.require(bindingPath) as KfNativeBinding;
+    const path = window.require('node:path') as {
+      dirname: (p: string) => string;
+      join: (...parts: string[]) => string;
+    };
+    const bindingDir = path.dirname(bindingPath);
     let buildInfo: Record<string, unknown> | null = null;
     try {
       const fs = window.require('node:fs');
-      const path = window.require('node:path');
       buildInfo = JSON.parse(
-        fs.readFileSync(
-          path.join(path.dirname(bindingPath), 'kungfubuildinfo.json'),
-          'utf8',
-        ),
+        fs.readFileSync(path.join(bindingDir, 'kungfubuildinfo.json'), 'utf8'),
       );
     } catch {
       buildInfo = null;
@@ -177,7 +182,6 @@ export function bootRuntime(): Runtime {
     let skillManager: Record<string, unknown> | null = null;
     try {
       const fs = window.require('node:fs');
-      const path = window.require('node:path');
       const managerPaths = [
         env.KF_SKILL_MANAGER_FILE,
         runtimeDir
@@ -211,6 +215,25 @@ export function bootRuntime(): Runtime {
       readDir: (d: string) => rewindFs.readdirSync(d),
     });
     const work = openWork({ binding, locator: { runtimeDir } });
+    const childProcess = window.require('node:child_process') as {
+      execFileSync: (
+        file: string,
+        args: string[],
+        options: { encoding: 'utf8'; env: Record<string, string | undefined> },
+      ) => string;
+    };
+    const atlas = openAtlas({
+      runtimeDir,
+      execFileSync: childProcess.execFileSync,
+      env: window.process.env as Record<string, string | undefined>,
+      bin:
+        env.KUNGFU_CLI_BIN ||
+        env.KUNGFU_BIN ||
+        path.join(
+          bindingDir,
+          process.platform === 'win32' ? 'kungfu.exe' : 'kungfu',
+        ),
+    });
     const remoteWork = openRemoteWork({
       binding,
       locator: { runtimeDir },
@@ -259,6 +282,7 @@ export function bootRuntime(): Runtime {
       remoteWork,
       terminal,
       work,
+      atlas,
     };
   } catch (e) {
     return { ...base, ok: false, message: (e as Error).message };

--- a/framework/kfx/kungfu-kfx.contract.json
+++ b/framework/kfx/kungfu-kfx.contract.json
@@ -121,6 +121,7 @@
     "packageManifestFile": "package.json"
   },
   "knownCapabilities": [
+    "atlas",
     "domain",
     "ledger",
     "rewind",

--- a/framework/kfx/src/index.ts
+++ b/framework/kfx/src/index.ts
@@ -10,6 +10,7 @@
 // managers and installers read them without executing the extension. The
 // code side exports exactly one thing — the View component.
 import type {
+  Atlas,
   DomainState,
   Ledger,
   Rewind,
@@ -45,6 +46,7 @@ export type KfxCapabilities = {
   rewind: Rewind;
   terminal: Terminal;
   work: Work;
+  atlas?: Atlas;
 };
 
 export type KfxCapabilityKey = keyof KfxCapabilities;

--- a/tests/fixtures/atlas-demo-import/run.mjs
+++ b/tests/fixtures/atlas-demo-import/run.mjs
@@ -42,6 +42,27 @@ k(['atlas', 'import', '--repo', sampleRoot]);
 const second = json(k(['atlas', 'import', '--repo', sampleRoot, '--json']));
 const secondId = second.import_id;
 
+const runtimeOverride = path.join(tmpDir('atlas-runtime-dir-'), 'demo-runtime');
+uvPython(
+  coreDir,
+  ['.devtools/kungfu_cli.py', 'atlas', 'import', '--repo', sampleRoot],
+  { env: { KF_RUNTIME_DIR: runtimeOverride } },
+);
+const overrideImport = json(
+  uvPython(
+    coreDir,
+    ['.devtools/kungfu_cli.py', 'atlas', 'import', '--repo', sampleRoot, '--json'],
+    { env: { KF_RUNTIME_DIR: runtimeOverride } },
+  ),
+);
+json(
+  uvPython(
+    coreDir,
+    ['.devtools/kungfu_cli.py', 'atlas', 'show', 'import', '--json'],
+    { env: { KF_RUNTIME_DIR: runtimeOverride } },
+  ),
+);
+
 const after = fingerprint(sampleRoot);
 if (before !== after) fail('source tree was modified');
 
@@ -49,4 +70,9 @@ uvPython(coreDir, [
   path.join(fixtureDir, 'check_import.py'),
   path.join(home, 'runtime'),
   secondId,
+]);
+uvPython(coreDir, [
+  path.join(fixtureDir, 'check_import.py'),
+  runtimeOverride,
+  overrideImport.import_id,
 ]);

--- a/tests/fixtures/kfx-demo-atlas-capability/roundtrip.mjs
+++ b/tests/fixtures/kfx-demo-atlas-capability/roundtrip.mjs
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { openAtlas } from '../../../framework/api/src/capability/atlas.ts';
+import { fail, locate, tmpDir } from '../_harness.mjs';
+
+const { fixtureDir } = locate(import.meta.url);
+const repoDir = path.resolve(fixtureDir, '..', '..', '..');
+const sampleRoot = path.resolve(
+  fixtureDir,
+  '..',
+  'atlas-demo-import',
+  'sample-root',
+);
+const runtimeDir = path.join(tmpDir('atlas-capability-'), 'runtime');
+const bin = path.join(repoDir, 'framework', 'core', 'dist', 'kungfu', 'kungfu');
+
+if (!fs.existsSync(bin)) {
+  fail('kungfu CLI is not frozen (run ./kungfu-code freeze first)');
+}
+
+const atlas = openAtlas({
+  runtimeDir,
+  execFileSync,
+  env: { KUNGFU_ATLAS_REPO: sampleRoot },
+  bin,
+});
+
+function ck(label, ok) {
+  if (!ok) fail(label);
+}
+
+ck('default repo root is exposed', atlas.defaultRepoRoot === sampleRoot);
+
+const imported = atlas.importRepo(sampleRoot);
+ck('import counted one mission', imported.missions === 1);
+ck('import counted two goals', imported.goals === 2);
+ck('import counted one marker', imported.markers === 1);
+ck('import surfaced broken-json warning', imported.warnings.length === 1);
+
+const info = atlas.importInfo();
+ck('import info is readable', info?.import_id === imported.import_id);
+ck('import info counts missions', info?.missions === 1);
+ck('import info counts goals', info?.goals === 2);
+ck('import info counts markers', info?.markers === 1);
+
+const missions = atlas.missions();
+ck('mission list folds latest import', missions.length === 1);
+ck('mission id preserved', missions[0]?.mission_id === 'demo-platform');
+
+const activeGoals = atlas.goals({ status: 'active' });
+ck('active goal filter works', activeGoals.length === 1);
+ck('active goal id preserved', activeGoals[0]?.goal_id === '2026-01-02-demo-importer');
+
+const mission = atlas.mission('demo-platform');
+ck('mission detail is readable', mission?.mission.mission_id === 'demo-platform');
+ck('mission detail links active goal', mission?.goals.length === 1);
+
+const goal = atlas.goal('2026-01-02-demo-importer');
+ck('goal detail is readable', goal?.mission_id === 'demo-platform');
+
+const markers = atlas.markers();
+ck('marker list is readable', markers.length === 1);
+ck('marker branch preserved', markers[0]?.branch === 'ai/demo/importer');
+
+console.log('[kfx-demo-atlas-capability] roundtrip ok');

--- a/tests/fixtures/kfx-demo-atlas-capability/run.mjs
+++ b/tests/fixtures/kfx-demo-atlas-capability/run.mjs
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Gate: the Atlas capability handle drives the real Kungfu CLI against a
+// runtime dir, then reads back the imported Mission/go/worktree projection.
+// Headless — no Electron window; it covers the capability layer the GUI injects.
+//
+// Usage: node tests/fixtures/kfx-demo-atlas-capability/run.mjs
+
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import { locate } from '../_harness.mjs';
+
+const { fixtureDir } = locate(import.meta.url);
+const resolver = path.resolve(
+  fixtureDir,
+  '../../../framework/api/src/capability/guest-harness/ts-resolve.mjs',
+);
+
+const r = spawnSync(
+  process.execPath,
+  [
+    '--import',
+    resolver,
+    '--experimental-transform-types',
+    path.join(fixtureDir, 'roundtrip.mjs'),
+  ],
+  { stdio: 'inherit' },
+);
+process.exit(r.status ?? 1);

--- a/tests/fixtures/kfx-demo-install/check_install.py
+++ b/tests/fixtures/kfx-demo-install/check_install.py
@@ -35,7 +35,7 @@ if os.path.isfile(manifest_path):
     check("key is work-dashboard", config.get("key") == "work-dashboard")
     check(
         "view declares capabilities",
-        view.get("capabilities") == ["ledger", "work"],
+        view.get("capabilities") == ["ledger", "work", "atlas"],
     )
     check(
         "package name is the published one",

--- a/tests/fixtures/kfx-demo-work-dashboard-atlas-live/render-live.mjs
+++ b/tests/fixtures/kfx-demo-work-dashboard-atlas-live/render-live.mjs
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { openAtlas } from '../../../framework/api/src/capability/atlas.ts';
+import { fail, locate, tmpDir } from '../_harness.mjs';
+
+const { fixtureDir } = locate(import.meta.url);
+const repoDir = path.resolve(fixtureDir, '..', '..', '..');
+const sampleRoot = path.resolve(
+  fixtureDir,
+  '..',
+  'atlas-demo-import',
+  'sample-root',
+);
+const runtimeDir = path.join(tmpDir('atlas-view-live-'), 'runtime');
+const bin = path.join(repoDir, 'framework', 'core', 'dist', 'kungfu', 'kungfu');
+const bundlePath = path.join(
+  repoDir,
+  'extensions',
+  'work-dashboard',
+  'dist',
+  'view',
+  'index.js',
+);
+const require = createRequire(
+  path.join(repoDir, 'framework', 'gui', 'package.json'),
+);
+
+if (!fs.existsSync(bin)) {
+  fail('kungfu CLI is not frozen (run ./kungfu-code freeze first)');
+}
+if (!fs.existsSync(bundlePath)) {
+  fail('work-dashboard is not built (run kungfu sdk kfx build first)');
+}
+
+const atlas = openAtlas({
+  runtimeDir,
+  execFileSync,
+  env: { KUNGFU_ATLAS_REPO: sampleRoot },
+  bin,
+});
+const imported = atlas.importRepo(sampleRoot);
+if (imported.missions !== 1 || imported.goals !== 2 || imported.markers !== 1) {
+  fail(`unexpected import counts: ${JSON.stringify(imported)}`);
+}
+
+const React = require('react');
+const ReactDomServer = require('react-dom/server');
+const fakeCaps = {
+  work: {
+    refresh: () => undefined,
+    items: () => [],
+  },
+  ledger: {
+    formatNanos: () => '',
+  },
+  atlas,
+};
+const fakeShell = {
+  params: { view: 'atlas' },
+  open: () => undefined,
+  onRefresh: () => ({ stop: () => undefined }),
+};
+const capabilityModule = {
+  WORK_STATUS_NAMES: ['active', 'blocked', 'waiting', 'ready', 'done'],
+};
+const module = { exports: {} };
+const code = fs.readFileSync(bundlePath, 'utf8');
+const requireShim = (id) => {
+  if (id === 'react') return React;
+  if (id === 'react/jsx-runtime') return require('react/jsx-runtime');
+  if (id === '@kungfu-tech/api/capability') return capabilityModule;
+  return require(id);
+};
+new Function('require', 'module', 'exports', code)(
+  requireShim,
+  module,
+  module.exports,
+);
+
+const { View } = module.exports;
+if (typeof View !== 'function') fail('bundle does not export View');
+
+const html = ReactDomServer.renderToStaticMarkup(
+  React.createElement(View, { caps: fakeCaps, shell: fakeShell }),
+);
+
+for (const needle of [
+  'Atlas projection',
+  'Demo platform stewardship',
+  '2026-01-02-demo-importer',
+  'Demo importer goal',
+  '1 missions',
+  '2 goals',
+  '1 markers',
+]) {
+  if (!html.includes(needle)) fail(`live Atlas tab missing ${needle}`);
+}
+
+console.log('[kfx-demo-work-dashboard-atlas-live] render ok');

--- a/tests/fixtures/kfx-demo-work-dashboard-atlas-live/run.mjs
+++ b/tests/fixtures/kfx-demo-work-dashboard-atlas-live/run.mjs
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Render the work-dashboard Atlas tab with the real Atlas capability handle.
+// The fixture imports the sample Atlas control-plane tree through the real
+// Kungfu CLI, then renders the built kfx view headlessly. This proves the GUI
+// view and CLI-backed projection agree without opening an Electron window.
+//
+// Usage: node tests/fixtures/kfx-demo-work-dashboard-atlas-live/run.mjs
+
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import { locate } from '../_harness.mjs';
+
+const { fixtureDir } = locate(import.meta.url);
+const resolver = path.resolve(
+  fixtureDir,
+  '../../../framework/api/src/capability/guest-harness/ts-resolve.mjs',
+);
+
+const r = spawnSync(
+  process.execPath,
+  [
+    '--import',
+    resolver,
+    '--experimental-transform-types',
+    path.join(fixtureDir, 'render-live.mjs'),
+  ],
+  { stdio: 'inherit' },
+);
+process.exit(r.status ?? 1);

--- a/tests/fixtures/kfx-demo-work-dashboard-atlas-view/run.mjs
+++ b/tests/fixtures/kfx-demo-work-dashboard-atlas-view/run.mjs
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Render-smoke the work-dashboard Atlas tab without opening Electron. The kfx
+// bundle is loaded the same CommonJS-wrapped way the GUI loader consumes it,
+// while this fixture injects React and a fake Atlas capability. It proves the
+// built view can display imported Mission/go projection data when opened with
+// shell.params.view=atlas.
+//
+// Usage: node tests/fixtures/kfx-demo-work-dashboard-atlas-view/run.mjs
+
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoDir = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '..',
+  '..',
+  '..',
+);
+const bundlePath = path.join(
+  repoDir,
+  'extensions',
+  'work-dashboard',
+  'dist',
+  'view',
+  'index.js',
+);
+const require = createRequire(
+  path.join(repoDir, 'framework', 'gui', 'package.json'),
+);
+
+function fail(message) {
+  console.error(`FAIL: ${message}`);
+  process.exit(1);
+}
+
+if (!fs.existsSync(bundlePath)) {
+  fail('work-dashboard is not built (run kungfu sdk kfx build first)');
+}
+
+const React = require('react');
+const ReactDomServer = require('react-dom/server');
+
+const fakeCaps = {
+  work: {
+    refresh: () => undefined,
+    items: () => [],
+  },
+  ledger: {
+    formatNanos: () => '',
+  },
+  atlas: {
+    runtimeDir: '/tmp/kungfu-runtime',
+    defaultRepoRoot: '/tmp/atlas',
+    importInfo: () => ({
+      import_id: 'fixture-import',
+      repo_root: '/tmp/atlas',
+      missions: 1,
+      goals: 2,
+      markers: 3,
+    }),
+    missions: () => [
+      {
+        mission_id: 'mission-fixture',
+        title: 'Fixture Mission',
+        stage_name: 'dogfood',
+      },
+    ],
+    goals: () => [
+      {
+        goal_id: 'goal-fixture-active',
+        status: 'active',
+        title: 'Active fixture goal',
+        mission_id: 'mission-fixture',
+        next_action: 'verify atlas tab',
+      },
+      {
+        goal_id: 'goal-fixture-ready',
+        status: 'ready',
+        title: 'Ready fixture goal',
+        mission_id: 'mission-fixture',
+      },
+    ],
+    importRepo: () => ({
+      import_id: 'fixture-import-2',
+      repo_root: '/tmp/atlas',
+      missions: 1,
+      goals: 2,
+      markers: 3,
+      warnings: [],
+    }),
+    mission: () => null,
+    goal: () => null,
+    markers: () => [],
+  },
+};
+
+const fakeShell = {
+  params: { view: 'atlas' },
+  open: () => undefined,
+  onRefresh: () => ({ stop: () => undefined }),
+};
+
+const capabilityModule = {
+  WORK_STATUS_NAMES: ['active', 'blocked', 'waiting', 'ready', 'done'],
+};
+
+const module = { exports: {} };
+const code = fs.readFileSync(bundlePath, 'utf8');
+const requireShim = (id) => {
+  if (id === 'react') return React;
+  if (id === 'react/jsx-runtime') return require('react/jsx-runtime');
+  if (id === '@kungfu-tech/api/capability') return capabilityModule;
+  return require(id);
+};
+new Function('require', 'module', 'exports', code)(
+  requireShim,
+  module,
+  module.exports,
+);
+
+const { View } = module.exports;
+if (typeof View !== 'function') fail('bundle does not export View');
+
+const html = ReactDomServer.renderToStaticMarkup(
+  React.createElement(View, { caps: fakeCaps, shell: fakeShell }),
+);
+
+for (const needle of [
+  'Atlas projection',
+  'mission-fixture',
+  'Fixture Mission',
+  'goal-fixture-active',
+  'Active fixture goal',
+  '1 missions',
+  '2 goals',
+  '3 markers',
+]) {
+  if (!html.includes(needle)) fail(`rendered Atlas tab missing ${needle}`);
+}
+
+console.log('[kfx-demo-work-dashboard-atlas-view] render ok');


### PR DESCRIPTION
Expose the Atlas Mission/go projection through the GUI Work Dashboard while Atlas remains the authority.\n\nValidation:\n- ./kungfu-code verify --full (57/57 passed)\n- GUI dogfood confirmed\n- Atlas sync helper imported 5 missions / 365 goals / 882 markers