### PR TITLE
docs(agent): expose Atlas projection onboarding

### DIFF
--- a/framework/core/src/python/kungfu/agent/brief.md
+++ b/framework/core/src/python/kungfu/agent/brief.md
@@ -32,6 +32,21 @@ Use the modes this way:
   `kungfu remote` is experimental and does not merge remote facts into local
   authoritative truth.
 
+Atlas projection is a local import workflow, not an operating mode. When the
+user asks to sync an Atlas-style control-plane repo into Kungfu, snapshot it and
+verify the projection with:
+
+```sh
+kungfu atlas import --repo <atlas-repo> --json
+kungfu atlas show import --json
+kungfu atlas show missions --json
+kungfu atlas show goals --json
+kungfu atlas show markers --json
+```
+
+The source repo remains the authority. Kungfu stores a read-only projection for
+inspection in CLI, GUI, and kfx work views.
+
 The pack is included by the Electron artifact, the standalone CLI, npm
 `@kungfu-tech/core`, and the PyPI wheel. Future Homebrew, winget, container, and
 kfx packaging must keep the same pack validation gate before claiming support.

--- a/framework/core/src/python/kungfu/agent/commands.json
+++ b/framework/core/src/python/kungfu/agent/commands.json
@@ -19,7 +19,7 @@
     {
       "name": "kungfu agent choose-mode --json",
       "maturity": "stable",
-      "purpose": "Choose brief, report, trace, managed-run, or remote-sync from explicit flags."
+      "purpose": "Choose brief, report, atlas-projection, trace, managed-run, or remote-sync from explicit flags."
     },
     {
       "name": "kungfu agent status --target codex --json",
@@ -34,7 +34,7 @@
     {
       "name": "kungfu agent mode set --target codex --mode managed-run",
       "maturity": "stable",
-      "purpose": "Switch Codex between report, managed-run, trace, brief, or remote-sync policy modes."
+      "purpose": "Switch Codex between report, atlas-projection, managed-run, trace, brief, or remote-sync policy modes."
     },
     {
       "name": "kungfu agent unbootstrap --target codex",
@@ -97,6 +97,31 @@
       "purpose": "Verify a Codex goal report receipt before closeout."
     },
     {
+      "name": "kungfu atlas import --repo <atlas-repo> --json",
+      "maturity": "stable",
+      "purpose": "Snapshot an Atlas-style control-plane repo into Kungfu's local read-only projection."
+    },
+    {
+      "name": "kungfu atlas show import --json",
+      "maturity": "stable",
+      "purpose": "Show the latest Atlas projection batch metadata and source repo head."
+    },
+    {
+      "name": "kungfu atlas show missions --json",
+      "maturity": "stable",
+      "purpose": "List imported Atlas mission cards from the latest projection."
+    },
+    {
+      "name": "kungfu atlas show goals --json",
+      "maturity": "stable",
+      "purpose": "List imported Atlas goal cards from the latest projection."
+    },
+    {
+      "name": "kungfu atlas show markers --json",
+      "maturity": "stable",
+      "purpose": "List imported Atlas worktree-status markers from the latest projection."
+    },
+    {
       "name": "kungfu remote add <source-id> --host <host> --home <kf-home> --json",
       "maturity": "experimental",
       "purpose": "Register a source runtime for source-scoped evidence sync."
@@ -132,6 +157,11 @@
       "maturity": "stable",
       "next": "kungfu work create <title> --json; for native Codex goals prefer kungfu codex report-goal --goal-id <goal-id> --status <status> --json.",
       "when": "The useful output is structured work state, decisions, checkpoints, artifacts, or reported external run facts."
+    },
+    "atlas-projection": {
+      "maturity": "stable",
+      "next": "kungfu atlas import --repo <atlas-repo> --json; kungfu atlas show import --json; kungfu atlas show missions --json; kungfu atlas show goals --json",
+      "when": "The user asks to sync, import, inspect, or visualize an Atlas-style mission/goal/worktree control-plane repo inside Kungfu."
     },
     "trace": {
       "maturity": "stable",

--- a/framework/core/src/python/kungfu/agent/mode-selection.md
+++ b/framework/core/src/python/kungfu/agent/mode-selection.md
@@ -6,6 +6,7 @@ Choose the smallest mode that preserves evidence.
 |---|---|---|---|
 | brief | You need local facts before acting. | `kungfu agent brief` | stable |
 | report | You need structured work facts, status, decisions, artifacts, or reported external run facts. | `kungfu work create <title> --json` or `kungfu codex report-goal --goal-id <goal-id> --status <status> --json` | stable |
+| atlas-projection | The user asks to sync, import, inspect, or visualize an Atlas-style mission/goal/worktree control-plane repo inside Kungfu. | `kungfu atlas import --repo <atlas-repo> --json` then `kungfu atlas show import --json` | stable |
 | trace | You already have a command or agent process to capture. | `kungfu trace -- <command>` | stable |
 | managed-run | Kungfu should launch the provider CLI and bind skill context. | `kungfu managed-run --provider <provider> --prompt <task>` | experimental |
 | remote-sync | Evidence must cross machines or runtime trust boundaries. | `kungfu remote add <source-id> --host <host> --home <kf-home> --json` then `kungfu remote sync <source-id> --json` | experimental |
@@ -17,6 +18,10 @@ Rules:
   process.
 - Prefer `report` when no process capture is needed and the durable fact is a
   work item, checkpoint, decision, artifact link, or reported external run fact.
+- Prefer `atlas-projection` only for importing an external Atlas-style
+  control-plane snapshot into Kungfu. The source repo remains authoritative;
+  verify with `kungfu atlas show missions --json`,
+  `kungfu atlas show goals --json`, and `kungfu atlas show markers --json`.
 - For native Codex goals, prefer `kungfu codex report-goal` over hand-assembling
   `kungfu report` commands; run `kungfu codex verify-goal-report` on the emitted
   receipt before declaring the goal complete.

--- a/framework/core/src/python/kungfu/agent/resources.py
+++ b/framework/core/src/python/kungfu/agent/resources.py
@@ -55,11 +55,18 @@ def choose_mode(
     needs_supervision=False,
     has_existing_run=False,
     needs_structured_work=False,
+    needs_atlas_projection=False,
     remote_runtime=False,
 ):
     if remote_runtime:
         mode = "remote-sync"
         reason = "Remote/runtime boundary is the primary constraint."
+    elif needs_atlas_projection:
+        mode = "atlas-projection"
+        reason = (
+            "An Atlas-style control-plane repo should be imported as a local "
+            "read-only projection."
+        )
     elif has_existing_run or command:
         mode = "trace"
         reason = "There is an existing command or run to capture without rewriting it."

--- a/framework/core/src/python/kungfu/agent/skills/claude/SKILL.md
+++ b/framework/core/src/python/kungfu/agent/skills/claude/SKILL.md
@@ -1,9 +1,12 @@
 ---
 key: kungfu-agent-onboarding
 title: Kungfu Agent Onboarding
-description: Use the installed Kungfu agent pack before choosing report, trace, managed-run, or remote-sync mode.
+description: Use the installed Kungfu agent pack before choosing report, atlas-projection, trace, managed-run, or remote-sync mode.
 triggers:
   - kungfu
+  - atlas projection
+  - atlas import
+  - sync atlas
   - kfx
   - rewind
   - managed-run
@@ -30,11 +33,23 @@ kungfu agent status --target claude --json
 Use the smallest mode that preserves evidence:
 
 - `report` for structured work facts.
+- `atlas-projection` when importing an Atlas-style mission/goal/worktree repo
+  into Kungfu for CLI, GUI, or kfx inspection.
 - `trace` for an existing command.
 - `managed-run` when Kungfu launches the provider CLI.
 - `remote-sync` only when the task is about crossing runtime or machine
   boundaries; stable publishing commands are planned unless the local pack says
   otherwise.
+
+For Atlas projection, the source repo remains authoritative. Import and verify:
+
+```sh
+kungfu atlas import --repo <atlas-repo> --json
+kungfu atlas show import --json
+kungfu atlas show missions --json
+kungfu atlas show goals --json
+kungfu atlas show markers --json
+```
 
 If the work is delegated to a native Codex goal and report mode is enabled,
 closeout is not complete until the Codex-side receipt is reported and verified:

--- a/framework/core/src/python/kungfu/agent/skills/codex/SKILL.md
+++ b/framework/core/src/python/kungfu/agent/skills/codex/SKILL.md
@@ -1,9 +1,12 @@
 ---
 key: kungfu-agent-onboarding
 title: Kungfu Agent Onboarding
-description: Use the installed Kungfu agent pack before choosing report, trace, managed-run, or remote-sync mode.
+description: Use the installed Kungfu agent pack before choosing report, atlas-projection, trace, managed-run, or remote-sync mode.
 triggers:
   - kungfu
+  - atlas projection
+  - atlas import
+  - sync atlas
   - kfx
   - rewind
   - managed-run
@@ -30,11 +33,23 @@ kungfu agent status --target codex --json
 Use the smallest mode that preserves evidence:
 
 - `report` for structured work facts.
+- `atlas-projection` when importing an Atlas-style mission/goal/worktree repo
+  into Kungfu for CLI, GUI, or kfx inspection.
 - `trace` for an existing command.
 - `managed-run` when Kungfu launches the provider CLI.
 - `remote-sync` only when the task is about crossing runtime or machine
   boundaries; stable publishing commands are planned unless the local pack says
   otherwise.
+
+For Atlas projection, the source repo remains authoritative. Import and verify:
+
+```sh
+kungfu atlas import --repo <atlas-repo> --json
+kungfu atlas show import --json
+kungfu atlas show missions --json
+kungfu atlas show goals --json
+kungfu atlas show markers --json
+```
 
 If report mode is enabled and the work uses a native Codex goal, closeout is not
 complete until both commands succeed:

--- a/framework/core/src/python/kungfu/cli/commands/agent.py
+++ b/framework/core/src/python/kungfu/cli/commands/agent.py
@@ -222,6 +222,11 @@ def capabilities(ctx, as_json):
     help="the useful fact is work state, not process capture",
 )
 @click.option(
+    "--needs-atlas-projection",
+    is_flag=True,
+    help="an Atlas-style control-plane repo should be imported for inspection",
+)
+@click.option(
     "--remote-runtime",
     is_flag=True,
     help="evidence crosses a machine or runtime boundary",
@@ -234,6 +239,7 @@ def choose_mode(
     needs_supervision,
     has_existing_run,
     needs_structured_work,
+    needs_atlas_projection,
     remote_runtime,
     as_json,
 ):
@@ -242,6 +248,7 @@ def choose_mode(
         needs_supervision=needs_supervision,
         has_existing_run=has_existing_run,
         needs_structured_work=needs_structured_work,
+        needs_atlas_projection=needs_atlas_projection,
         remote_runtime=remote_runtime,
     )
     if as_json:
@@ -343,7 +350,9 @@ def status(ctx, target, as_json):
 @click.option(
     "--mode",
     required=True,
-    type=click.Choice(["brief", "report", "trace", "managed-run", "remote-sync"]),
+    type=click.Choice(
+        ["brief", "report", "atlas-projection", "trace", "managed-run", "remote-sync"]
+    ),
     help="initial operating mode",
 )
 @click.option(
@@ -404,7 +413,9 @@ def mode(ctx):
     "--mode",
     "mode_name",
     required=True,
-    type=click.Choice(["brief", "report", "trace", "managed-run", "remote-sync"]),
+    type=click.Choice(
+        ["brief", "report", "atlas-projection", "trace", "managed-run", "remote-sync"]
+    ),
     help="new mode",
 )
 @click.option("--execute", is_flag=True, help="write the mode switch")


### PR DESCRIPTION
Expose Atlas projection import/show commands through the installed Kungfu agent onboarding pack so agents can discover the workflow from Kungfu itself.