### PR TITLE
ci: align buildchain promotion check name

### DIFF
--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -29,7 +29,7 @@ jobs:
       release-candidate-workflow-name: Build
       artifact-patterns: |
         kungfu-*
-      required-status-check: Build
+      required-status-check: build
       publish-target: custom
       publish-artifact-kind: kungfu-product
       publish-command: node scripts/buildchain-custom-publish-evidence.mjs


### PR DESCRIPTION
## Summary
- Align the Buildchain promote required status check fragment with the product build job name (  • electron-builder version=20.39.0).

## Validation
- actionlint .github/workflows/release-new-version.yml