### PR TITLE
ci: grant buildchain build issue permission

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,7 @@ on:
 permissions:
   contents: read
   pull-requests: read
+  issues: write
   id-token: write
 
 jobs:


### PR DESCRIPTION
## Summary
- grant the Buildchain reusable build workflow the issue permission it requests
- unblock alpha release-candidate build startup while keeping publish/release options disabled in Buildchain config

## Validation
- actionlint .github/workflows/build.yml .github/workflows/release-verify.yml .github/workflows/release-new-version.yml .github/workflows/buildchain-validate.yml
- git diff --check

## Build policy
- This PR targets dev/v4/v4.0, so it should only run signoff/validate and must not run the product Build workflow.