### PR TITLE
ci: make buildchain lifecycle install portable

### DIFF
--- a/buildchain.toml
+++ b/buildchain.toml
@@ -23,13 +23,13 @@ key = "version"
 # build workflow) and the runner preset that provides the fnm/uv/conan
 # prerequisites are wired in a later stage.
 [lifecycle.install]
-command = "./kungfu-code sync"
+command = "node scripts/buildchain-run-kungfu-code.mjs sync"
 
 [lifecycle.build]
-command = "./kungfu-code dist"
+command = "node scripts/buildchain-run-kungfu-code.mjs dist"
 
 [lifecycle.verify]
-command = "./kungfu-code verify"
+command = "node scripts/buildchain-run-kungfu-code.mjs verify"
 
 [lifecycle.publish]
 command = "node scripts/buildchain-custom-publish-evidence.mjs"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -434,6 +434,16 @@ importers:
       node-addon-api:
         specifier: ^8.0.0
         version: 8.9.0
+    optionalDependencies:
+      '@kungfu-tech/core-darwin-arm64':
+        specifier: 4.0.0-alpha.0
+        version: 4.0.0-alpha.0
+      '@kungfu-tech/core-linux-x64':
+        specifier: 4.0.0-alpha.0
+        version: 4.0.0-alpha.0
+      '@kungfu-tech/core-win32-x64':
+        specifier: 4.0.0-alpha.0
+        version: 4.0.0-alpha.0
 
   framework/gui:
     dependencies:

--- a/scripts/buildchain-run-kungfu-code.mjs
+++ b/scripts/buildchain-run-kungfu-code.mjs
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: Apache-2.0
+
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+const argv = process.argv.slice(2);
+
+function quoteCmdArg(arg) {
+  return `"${String(arg).replace(/"/g, '""')}"`;
+}
+
+const result =
+  process.platform === 'win32'
+    ? spawnSync(
+        process.env.ComSpec || 'cmd.exe',
+        [
+          '/d',
+          '/s',
+          '/c',
+          [
+            quoteCmdArg(path.join(repoRoot, 'kungfu-code.cmd')),
+            ...argv.map(quoteCmdArg),
+          ].join(' '),
+        ],
+        { cwd: repoRoot, env: process.env, stdio: 'inherit' },
+      )
+    : spawnSync(path.join(repoRoot, 'kungfu-code'), argv, {
+        cwd: repoRoot,
+        env: process.env,
+        stdio: 'inherit',
+      });
+
+if (result.error) {
+  console.error(result.error.message);
+  process.exit(1);
+}
+
+if (result.signal) {
+  console.error(`kungfu-code terminated by signal ${result.signal}`);
+  process.exit(1);
+}
+
+process.exit(result.status ?? 0);


### PR DESCRIPTION
## Summary
- run Buildchain lifecycle stages through a Node shim that dispatches to kungfu-code on POSIX and kungfu-code.cmd on Windows
- update pnpm-lock.yaml so framework/core optional platform packages match package.json under frozen lockfile checks

## Evidence from failed alpha PR
- PR #316 scheduled exactly one product Build workflow run: https://github.com/kungfu-systems/kungfu/actions/runs/28847079471
- Windows failed because ./kungfu-code sync is not executable under cmd
- macOS/Linux failed frozen lockfile because framework/core optionalDependencies were missing from pnpm-lock.yaml

## Validation
- node --check scripts/buildchain-run-kungfu-code.mjs
- CI=true fnm exec --using-file -- corepack pnpm install --frozen-lockfile --lockfile-only --force
- node scripts/buildchain-run-kungfu-code.mjs sync
- fnm exec --using-file -- corepack pnpm exec buildchain validate --require-version-state --require-lifecycle-stages install,build,verify
- git diff --check

## Build policy
- This PR targets dev/v4/v4.0 and should not run product Build. A fresh alpha PR will be opened after this lands.