### PR TITLE
release: promote v4.0 alpha buildchain product

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+
+name: Build
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review]
+    branches:
+      - alpha/v*/v*
+      - release/v*/v*
+  workflow_dispatch:
+    inputs:
+      buildchain-ref:
+        description: Optional trusted Buildchain runtime ref for debugging. Empty uses v2 anti-drift runtime resolution.
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+  pull-requests: read
+  id-token: write
+
+concurrency:
+  group: kungfu-product-build-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
+    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@v2
+    with:
+      buildchain-ref: ${{ github.event_name == 'workflow_dispatch' && inputs.buildchain-ref || '' }}
+      runner-preset: kungfu-v4-self-hosted
+      artifact-name: kungfu
+      artifact-paths: |
+        artifact/dist
+      expected-artifacts-json: >-
+        {"minFiles":1,"minTotalBytes":1}
+      require-install: true
+      require-build: true
+      require-verify: true
+      release-candidate: ${{ github.event_name == 'pull_request' }}
+      publish-channel: ${{ github.event_name == 'pull_request' && startsWith(github.event.pull_request.base.ref, 'alpha/') && 'alpha' || github.event_name == 'pull_request' && startsWith(github.event.pull_request.base.ref, 'release/') && 'release' || 'none' }}
+      artifact-transfer-mode: s3-to-github-artifacts
+      artifact-retention-days: 14

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,28 +8,17 @@ on:
     branches:
       - alpha/v*/v*
       - release/v*/v*
-  workflow_dispatch:
-    inputs:
-      buildchain-ref:
-        description: Optional trusted Buildchain runtime ref for debugging. Empty uses v2 anti-drift runtime resolution.
-        required: false
-        default: ""
 
 permissions:
   contents: read
   pull-requests: read
   id-token: write
 
-concurrency:
-  group: kungfu-product-build-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: false
-
 jobs:
   build:
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     uses: kungfu-systems/buildchain/.github/workflows/.build.yml@v2
+    secrets: inherit
     with:
-      buildchain-ref: ${{ github.event_name == 'workflow_dispatch' && inputs.buildchain-ref || '' }}
       runner-preset: kungfu-v4-self-hosted
       artifact-name: kungfu
       artifact-paths: |
@@ -39,7 +28,6 @@ jobs:
       require-install: true
       require-build: true
       require-verify: true
-      release-candidate: ${{ github.event_name == 'pull_request' }}
-      publish-channel: ${{ github.event_name == 'pull_request' && startsWith(github.event.pull_request.base.ref, 'alpha/') && 'alpha' || github.event_name == 'pull_request' && startsWith(github.event.pull_request.base.ref, 'release/') && 'release' || 'none' }}
+      release-candidate: true
       artifact-transfer-mode: s3-to-github-artifacts
       artifact-retention-days: 14

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,7 @@ on:
 permissions:
   contents: read
   pull-requests: read
+  issues: write
   id-token: write
 
 jobs:

--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -9,42 +9,39 @@ on:
       - alpha/v*/v*
       - release/v*/v*
 
+permissions:
+  contents: write
+  actions: read
+  issues: write
+  id-token: write
+
 jobs:
-  release:
-    uses: kungfu-trader/workflows/.github/workflows/.release-new-version.yml@v1
+  promote:
+    if: ${{ github.event.pull_request.merged == true }}
+    uses: kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@v2
     with:
-      protect-dev-branches: true
-      need-qa-automated: true
-      max-preview-links: 64
+      channel: ${{ startsWith(github.event.pull_request.base.ref, 'alpha/') && 'alpha' || 'release' }}
+      target-ref: ${{ github.event.pull_request.base.ref }}
+      target-sha: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
+      package-manager: custom
+      artifact-name: kungfu
+      release-candidate-workflow-file: build.yml
+      release-candidate-workflow-name: Build
+      artifact-patterns: |
+        kungfu-*
+      required-status-check: Build
+      publish-target: custom
+      publish-artifact-kind: kungfu-product
+      publish-command: node scripts/buildchain-custom-publish-evidence.mjs
+      publish-mode: publish-final-version
+      publish-dist-tag: ${{ startsWith(github.event.pull_request.base.ref, 'alpha/') && 'alpha' || 'latest' }}
+      publish-package-set-order: as-provided
+      trusted-publishing: false
+      runner-preset: kungfu-v4-self-hosted
+      required-artifact-count: 3
+      release-passport: true
+      release-passport-product-name: Kungfu
     secrets:
-      GITHUB_PUSH_TOKEN: ${{ secrets.KUNGFU_GITHUB_TOKEN }}
-      AWS_CI_ACCESS_KEY_ID: ${{ secrets.AWS_CI_ACCESS_KEY_ID }}
-      AWS_CI_SECRET_ACCESS_KEY: ${{ secrets.AWS_CI_SECRET_ACCESS_KEY }}
-      AWS_USER_ACCESS_KEY_ID: ${{ secrets.AWS_USER_ACCESS_KEY_ID }}
-      AWS_USER_SECRET_ACCESS_KEY: ${{ secrets.AWS_USER_SECRET_ACCESS_KEY }}
-      MONDAY_API_KEY: ${{ secrets.MONDAY_API_KEY }}
-      AIRTABLE_API_KEY: ${{ secrets.AIRTABLE_API_KEY }}
-
-  trigger-batch-pr:
-      needs: [release]
-      uses: kungfu-trader/workflows/.github/workflows/.batch-pull-request.yml@dev/v1/v1.2
-      with:
-        repo: group
-        pull-request-title: ${{ github.event.pull_request.title }}
-      secrets:
-        GITHUB_PUSH_TOKEN: ${{ secrets.KUNGFU_GITHUB_TOKEN }}
-
-  sync-release-page:
-    needs: [release]
-    uses: kungfu-trader/workflows/.github/workflows/.sync-release-page.yml@dev/v1/v1.2
-    with:
-      product: artifact-kungfu
-      cloudfront-id: E1FE73MM9VXU2T
-      release-url: https://releases.libkungfu.cc
-      repo: kungfu
-      release-path: artifact-kungfu
-      product-name: kungfu
-      lower-edge: 2.0.0
-    secrets:
-      GITHUB_PUSH_TOKEN: ${{ secrets.KUNGFU_GITHUB_TOKEN }}
-      AIRTABLE_API_KEY: ${{ secrets.AIRTABLE_API_KEY }}
+      BUILDCHAIN_PROMOTION_TOKEN: ${{ secrets.KUNGFU_GITHUB_TOKEN }}
+      BUILDCHAIN_ISSUE_APP_ID: ${{ secrets.BUILDCHAIN_ISSUE_APP_ID }}
+      BUILDCHAIN_ISSUE_APP_PRIVATE_KEY: ${{ secrets.BUILDCHAIN_ISSUE_APP_PRIVATE_KEY }}

--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -29,7 +29,7 @@ jobs:
       release-candidate-workflow-name: Build
       artifact-patterns: |
         kungfu-*
-      required-status-check: Build
+      required-status-check: build
       publish-target: custom
       publish-artifact-kind: kungfu-product
       publish-command: node scripts/buildchain-custom-publish-evidence.mjs

--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -1,40 +1,23 @@
 # SPDX-License-Identifier: Apache-2.0
 
 name: Release - Verify
+
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, reopened, ready_for_review, synchronize]
     branches:
-      - alpha/*/*
-      - release/*/*
+      - alpha/v*/v*
+      - release/v*/v*
       - main
 
-jobs:
-  try:
-    uses: kungfu-trader/workflows/.github/workflows/.release-verify.yml@v1
-    with:
-      build-runner-linux: kungfu-builder-linux
-      build-runner-windows: kungfu-builder-windows
-      build-runner-macos: macos-12-xl
-      builder-container: docker.io/kungfutrader/kungfu-builder-centos:v1.2.2
-      use-pipenv: true
-      build-timeout-minutes: 150
-      max-build-attempts: 3
-      enable-linux: true
-      enable-macos: true
-      enable-windows: true
-      code-signing-windows: true
-      max-preview-links: 64
-    secrets:
-      AWS_CI_ACCESS_KEY_ID: ${{ secrets.AWS_CI_ACCESS_KEY_ID }}
-      AWS_CI_SECRET_ACCESS_KEY: ${{ secrets.AWS_CI_SECRET_ACCESS_KEY }}
-      AWS_USER_ACCESS_KEY_ID: ${{ secrets.AWS_USER_ACCESS_KEY_ID }}
-      AWS_USER_SECRET_ACCESS_KEY: ${{ secrets.AWS_USER_SECRET_ACCESS_KEY }}
-      WINDOWS_CSC_KEY: ${{ secrets.WINDOWS_CSC_KEY }}
+permissions:
+  contents: read
 
+jobs:
   verify:
-    needs: try
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
-      - name: report
-        run: echo verified
+      - name: Buildchain product build handoff
+        run: |
+          echo "Product build verification is owned by .github/workflows/build.yml."
+          echo "This workflow intentionally does not build artifacts."

--- a/buildchain.toml
+++ b/buildchain.toml
@@ -10,6 +10,8 @@ schema = 1
 
 [version]
 required = true
+strategy = "semver"
+next = "auto"
 
 [[version.files]]
 type = "json"
@@ -24,7 +26,10 @@ key = "version"
 command = "./kungfu-code sync"
 
 [lifecycle.build]
-command = "./kungfu-code build"
+command = "./kungfu-code dist"
 
 [lifecycle.verify]
 command = "./kungfu-code verify"
+
+[lifecycle.publish]
+command = "node scripts/buildchain-custom-publish-evidence.mjs"

--- a/buildchain.toml
+++ b/buildchain.toml
@@ -23,13 +23,13 @@ key = "version"
 # build workflow) and the runner preset that provides the fnm/uv/conan
 # prerequisites are wired in a later stage.
 [lifecycle.install]
-command = "./kungfu-code sync"
+command = "node scripts/buildchain-run-kungfu-code.mjs sync"
 
 [lifecycle.build]
-command = "./kungfu-code dist"
+command = "node scripts/buildchain-run-kungfu-code.mjs dist"
 
 [lifecycle.verify]
-command = "./kungfu-code verify"
+command = "node scripts/buildchain-run-kungfu-code.mjs verify"
 
 [lifecycle.publish]
 command = "node scripts/buildchain-custom-publish-evidence.mjs"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -434,6 +434,16 @@ importers:
       node-addon-api:
         specifier: ^8.0.0
         version: 8.9.0
+    optionalDependencies:
+      '@kungfu-tech/core-darwin-arm64':
+        specifier: 4.0.0-alpha.0
+        version: 4.0.0-alpha.0
+      '@kungfu-tech/core-linux-x64':
+        specifier: 4.0.0-alpha.0
+        version: 4.0.0-alpha.0
+      '@kungfu-tech/core-win32-x64':
+        specifier: 4.0.0-alpha.0
+        version: 4.0.0-alpha.0
 
   framework/gui:
     dependencies:

--- a/scripts/buildchain-custom-publish-evidence.mjs
+++ b/scripts/buildchain-custom-publish-evidence.mjs
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+function requireEnv(name) {
+  const value = process.env[name];
+  if (!value || !value.trim()) {
+    throw new Error(`${name} is required`);
+  }
+  return value.trim();
+}
+
+function readJson(filePath, label) {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch (error) {
+    throw new Error(
+      `failed to read ${label} at ${filePath}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
+function normalizeArtifact(artifact, index) {
+  if (!artifact || typeof artifact !== 'object' || Array.isArray(artifact)) {
+    throw new Error(`required artifact ${index} must be an object`);
+  }
+  for (const key of ['kind', 'name', 'digest']) {
+    if (!artifact[key] || typeof artifact[key] !== 'string') {
+      throw new Error(`required artifact ${index}.${key} must be a string`);
+    }
+  }
+  return {
+    ...(artifact.group ? { group: artifact.group } : {}),
+    kind: artifact.kind,
+    name: artifact.name,
+    ...(artifact.ref ? { ref: artifact.ref } : {}),
+    digest: artifact.digest,
+    ...(artifact.role ? { role: artifact.role } : {}),
+  };
+}
+
+function main() {
+  const evidencePath = requireEnv('BUILDCHAIN_PUBLISH_EVIDENCE');
+  const requiredArtifactsPath =
+    process.env.BUILDCHAIN_PUBLISH_REQUIRED_ARTIFACTS_PATH ||
+    path.join(
+      process.cwd(),
+      '.buildchain',
+      'release-candidate',
+      'publish-required-artifacts.json',
+    );
+  const requiredArtifacts = readJson(
+    requiredArtifactsPath,
+    'Buildchain required artifact list',
+  );
+  if (!Array.isArray(requiredArtifacts) || requiredArtifacts.length === 0) {
+    throw new Error(
+      'Buildchain required artifact list must contain at least one artifact',
+    );
+  }
+
+  const evidence = {
+    schema: 1,
+    version: requireEnv('BUILDCHAIN_VERSION'),
+    channel: requireEnv('BUILDCHAIN_CHANNEL'),
+    source_sha: requireEnv('BUILDCHAIN_SOURCE_SHA'),
+    release_sha: requireEnv('BUILDCHAIN_RELEASE_SHA'),
+    target_ref: requireEnv('BUILDCHAIN_TARGET_REF'),
+    release_material_sha: requireEnv('BUILDCHAIN_RELEASE_MATERIAL_SHA'),
+    publish_tooling_sha: requireEnv('BUILDCHAIN_PUBLISH_TOOLING_SHA'),
+    artifacts: requiredArtifacts.map(normalizeArtifact),
+  };
+
+  fs.mkdirSync(path.dirname(evidencePath), { recursive: true });
+  fs.writeFileSync(evidencePath, `${JSON.stringify(evidence, null, 2)}\n`);
+  console.log(
+    `buildchain custom publish evidence wrote ${evidence.artifacts.length} artifacts to ${evidencePath}`,
+  );
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(
+    `buildchain custom publish evidence failed: ${error instanceof Error ? error.message : String(error)}`,
+  );
+  process.exit(1);
+}

--- a/scripts/buildchain-run-kungfu-code.mjs
+++ b/scripts/buildchain-run-kungfu-code.mjs
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: Apache-2.0
+
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+const argv = process.argv.slice(2);
+
+function quoteCmdArg(arg) {
+  return `"${String(arg).replace(/"/g, '""')}"`;
+}
+
+const result =
+  process.platform === 'win32'
+    ? spawnSync(
+        process.env.ComSpec || 'cmd.exe',
+        [
+          '/d',
+          '/s',
+          '/c',
+          [
+            quoteCmdArg(path.join(repoRoot, 'kungfu-code.cmd')),
+            ...argv.map(quoteCmdArg),
+          ].join(' '),
+        ],
+        { cwd: repoRoot, env: process.env, stdio: 'inherit' },
+      )
+    : spawnSync(path.join(repoRoot, 'kungfu-code'), argv, {
+        cwd: repoRoot,
+        env: process.env,
+        stdio: 'inherit',
+      });
+
+if (result.error) {
+  console.error(result.error.message);
+  process.exit(1);
+}
+
+if (result.signal) {
+  console.error(`kungfu-code terminated by signal ${result.signal}`);
+  process.exit(1);
+}
+
+process.exit(result.status ?? 0);


### PR DESCRIPTION
## Summary
- promote the Buildchain product-build integration from dev/v4/v4.0 to alpha/v4/v4.0
- use the Buildchain v2 reusable workflow caller and semver release-candidate promotion flow
- keep npm publish and GitHub Release publishing disabled through buildchain.toml

## One-PR-one-build guard
- This is a fresh alpha release-candidate PR after PR #316's single Build run exposed lifecycle install issues and PR #317 fixed them on dev.
- Build workflow trigger is limited to pull_request opened/reopened/ready_for_review for alpha/release bases.
- If more than one product Build run is scheduled for this PR, stop and do not merge.

## Expected artifact transfer
- Self-hosted runners build Windows x64, macOS ARM64, and Linux x64.
- Build artifacts are relayed via China S3 and then collected into GitHub artifacts by Buildchain.