### PR TITLE
ci: fix buildchain install lifecycle

### DIFF
--- a/buildchain.toml
+++ b/buildchain.toml
@@ -23,7 +23,7 @@ key = "version"
 # build workflow) and the runner preset that provides the fnm/uv/conan
 # prerequisites are wired in a later stage.
 [lifecycle.install]
-command = "node scripts/buildchain-run-kungfu-code.mjs sync"
+command = "node scripts/buildchain-run-kungfu-code.mjs install --frozen-lockfile --no-optional"
 
 [lifecycle.build]
 command = "node scripts/buildchain-run-kungfu-code.mjs dist"

--- a/scripts/buildchain-run-kungfu-code.mjs
+++ b/scripts/buildchain-run-kungfu-code.mjs
@@ -18,9 +18,9 @@ const result =
         process.env.ComSpec || 'cmd.exe',
         [
           '/d',
-          '/s',
           '/c',
           [
+            'call',
             quoteCmdArg(path.join(repoRoot, 'kungfu-code.cmd')),
             ...argv.map(quoteCmdArg),
           ].join(' '),


### PR DESCRIPTION
## Summary
- skip optional platform packages during the Buildchain install lifecycle
- invoke kungfu-code.cmd through cmd call on Windows runners

## Validation
- node --check scripts/buildchain-run-kungfu-code.mjs
- pnpm exec biome check scripts/buildchain-run-kungfu-code.mjs
- pnpm run check:types
- node scripts/buildchain-run-kungfu-code.mjs install --frozen-lockfile --no-optional
- pnpm exec buildchain validate --require-version-state --require-lifecycle-stages install,build,verify
- git diff --check