### PR TITLE
ci: use corepack directly on windows buildchain

### DIFF
--- a/scripts/buildchain-run-kungfu-code.mjs
+++ b/scripts/buildchain-run-kungfu-code.mjs
@@ -44,15 +44,11 @@ function createPnpmShimDir() {
 const env = withPathPrefix(process.env, createPnpmShimDir());
 const result =
   process.platform === 'win32'
-    ? spawnSync(
-        'fnm',
-        ['exec', '--using-file', '--', 'corepack.cmd', 'pnpm', ...argv],
-        {
-          cwd: repoRoot,
-          env,
-          stdio: 'inherit',
-        },
-      )
+    ? spawnSync('corepack.cmd', ['pnpm', ...argv], {
+        cwd: repoRoot,
+        env,
+        stdio: 'inherit',
+      })
     : spawnSync(path.join(repoRoot, 'kungfu-code'), argv, {
         cwd: repoRoot,
         env,


### PR DESCRIPTION
## Summary
- avoid requiring fnm in the Windows Buildchain lifecycle wrapper
- keep the temporary pnpm.cmd shim for nested pnpm calls inside package scripts

## Validation
- node --check scripts/buildchain-run-kungfu-code.mjs
- pnpm exec biome check scripts/buildchain-run-kungfu-code.mjs
- pnpm run check:types
- node scripts/buildchain-run-kungfu-code.mjs exec pnpm --version
- node scripts/buildchain-run-kungfu-code.mjs install --frozen-lockfile --no-optional
- git diff --check