### PR TITLE
ci: carry no-optional through artifact dist

### DIFF
--- a/artifact/scripts/dist.mjs
+++ b/artifact/scripts/dist.mjs
@@ -50,6 +50,14 @@ function runPnpm(label, args, options = {}) {
   run(label, 'pnpm', args, options);
 }
 
+function installArgs() {
+  const args = ['install', '--frozen-lockfile'];
+  if (process.env.KUNGFU_BUILDCHAIN_NO_OPTIONAL === '1') {
+    args.push('--no-optional');
+  }
+  return args;
+}
+
 function readJson(file) {
   return JSON.parse(fs.readFileSync(file, 'utf8'));
 }
@@ -185,7 +193,7 @@ function main() {
   const kfxPackages = listKfxPackages();
   assertDeclaredKfx(kfxPackages);
 
-  runPnpm('sync dependencies', ['install', '--frozen-lockfile']);
+  runPnpm('sync dependencies', installArgs());
   runPnpm('rebuild core', ['--filter', '@kungfu-tech/core', 'run', 'rebuild']);
   runPnpm('freeze core runtime', [
     '--filter',

--- a/scripts/buildchain-run-kungfu-code.mjs
+++ b/scripts/buildchain-run-kungfu-code.mjs
@@ -42,12 +42,14 @@ function createPnpmShimDir() {
 }
 
 const env = withPathPrefix(process.env, createPnpmShimDir());
+env.KUNGFU_BUILDCHAIN_NO_OPTIONAL = '1';
 const result =
   process.platform === 'win32'
     ? spawnSync('corepack.cmd', ['pnpm', ...argv], {
         cwd: repoRoot,
         env,
         stdio: 'inherit',
+        shell: true,
       })
     : spawnSync(path.join(repoRoot, 'kungfu-code'), argv, {
         cwd: repoRoot,


### PR DESCRIPTION
## Summary
- pass a Buildchain-only no-optional marker through lifecycle commands
- let artifact dist reuse --no-optional for its internal dependency sync
- run Windows corepack.cmd through a shell so .cmd execution works

## Validation
- node --check scripts/buildchain-run-kungfu-code.mjs
- node --check artifact/scripts/dist.mjs
- pnpm exec biome check scripts/buildchain-run-kungfu-code.mjs artifact/scripts/dist.mjs
- pnpm run check:types
- node scripts/buildchain-run-kungfu-code.mjs exec node -e "console.log(process.env.KUNGFU_BUILDCHAIN_NO_OPTIONAL)"
- node scripts/buildchain-run-kungfu-code.mjs install --frozen-lockfile --no-optional
- git diff --check