### PR TITLE
ci: prepare buildchain source build prerequisites

### DIFF
--- a/artifact/scripts/dist.mjs
+++ b/artifact/scripts/dist.mjs
@@ -7,6 +7,7 @@
 
 import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
+import { createRequire } from 'node:module';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -19,6 +20,7 @@ const CORE_DIST = path.join(ROOT, 'framework', 'core', 'dist', 'kungfu');
 const EXTENSIONS_ROOT = path.join(ROOT, 'extensions');
 const ASSEMBLED_EXTENSIONS = path.join(ARTIFACT_DIR, 'extensions');
 const isWin = process.platform === 'win32';
+const require = createRequire(import.meta.url);
 
 const builderArgs = process.argv.slice(2);
 
@@ -50,12 +52,88 @@ function runPnpm(label, args, options = {}) {
   run(label, 'pnpm', args, options);
 }
 
+function libnodePlatformPackageName() {
+  const packages = {
+    'darwin-arm64': '@kungfu-tech/libnode-darwin-arm64',
+    'linux-x64': '@kungfu-tech/libnode-linux-x64',
+    'win32-x64': '@kungfu-tech/libnode-win32-x64',
+  };
+  return packages[`${process.platform}-${process.arch}`];
+}
+
 function installArgs() {
   const args = ['install', '--frozen-lockfile'];
   if (process.env.KUNGFU_BUILDCHAIN_NO_OPTIONAL === '1') {
     args.push('--no-optional');
   }
   return args;
+}
+
+function canResolve(packageName) {
+  try {
+    require.resolve(`${packageName}/package.json`);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function buildchainSourceBuildEnv() {
+  if (process.env.KUNGFU_BUILDCHAIN_NO_OPTIONAL !== '1') {
+    return process.env;
+  }
+
+  const packageName = libnodePlatformPackageName();
+  if (!packageName) {
+    throw new Error(
+      `unsupported libnode platform: ${process.platform}-${process.arch}`,
+    );
+  }
+  if (canResolve(packageName)) {
+    return process.env;
+  }
+
+  const corePackage = readJson(
+    path.join(ROOT, 'framework', 'core', 'package.json'),
+  );
+  const libnodeVersion = corePackage.devDependencies?.['@kungfu-tech/libnode'];
+  if (!libnodeVersion) {
+    throw new Error('framework/core must declare @kungfu-tech/libnode');
+  }
+
+  const installRoot = path.join(
+    ROOT,
+    '.buildchain',
+    'libnode-platform',
+    `${process.platform}-${process.arch}`,
+  );
+  const nodePath = path.join(installRoot, 'node_modules');
+  const installedPackageJson = path.join(
+    nodePath,
+    ...packageName.split('/'),
+    'package.json',
+  );
+  if (!fs.existsSync(installedPackageJson)) {
+    fs.rmSync(installRoot, { recursive: true, force: true });
+    fs.mkdirSync(installRoot, { recursive: true });
+    run('install libnode platform package', 'npm', [
+      'install',
+      '--no-save',
+      '--package-lock=false',
+      '--ignore-scripts',
+      '--prefer-offline',
+      '--prefix',
+      installRoot,
+      `${packageName}@${libnodeVersion}`,
+    ]);
+  }
+
+  return {
+    ...process.env,
+    NODE_PATH: [nodePath, process.env.NODE_PATH || '']
+      .filter(Boolean)
+      .join(path.delimiter),
+  };
 }
 
 function readJson(file) {
@@ -193,8 +271,11 @@ function main() {
   const kfxPackages = listKfxPackages();
   assertDeclaredKfx(kfxPackages);
 
+  const buildEnv = buildchainSourceBuildEnv();
   runPnpm('sync dependencies', installArgs());
-  runPnpm('rebuild core', ['--filter', '@kungfu-tech/core', 'run', 'rebuild']);
+  runPnpm('rebuild core', ['--filter', '@kungfu-tech/core', 'run', 'rebuild'], {
+    env: buildEnv,
+  });
   runPnpm('freeze core runtime', [
     '--filter',
     '@kungfu-tech/core',

--- a/framework/core/.gyp/run-conan.js
+++ b/framework/core/.gyp/run-conan.js
@@ -2,7 +2,7 @@
 // @ts-check
 
 const fse = require('fs-extra');
-const path = require('path');
+const path = require('node:path');
 const { shell } = require('../lib');
 
 /** @param {string[]} cmd */
@@ -14,16 +14,40 @@ function conan(cmd) {
   });
 }
 
+function ensureBuildchainConanProfile() {
+  if (process.env.KUNGFU_BUILDCHAIN_SOURCE_BUILD !== '1') {
+    return;
+  }
+  const env = { NODE_GYP_RUN: 'on', ...process.env };
+  const existing = shell.runAndCollect(
+    'uv',
+    ['run', '--frozen', 'conan', 'profile', 'path', 'default'],
+    { env, silent: true },
+  );
+  if (existing.status === 0) {
+    return;
+  }
+  shell.run(
+    'uv',
+    ['run', '--frozen', 'conan', 'profile', 'detect', '--force'],
+    true,
+    {
+      env,
+    },
+  );
+}
+
 function getNodeVersionOptions() {
   const packageJson = fse.readJsonSync(
     path.resolve(path.dirname(__dirname), 'package.json'),
   );
   // electron 从 devDependencies 读并去掉 ^/~ 前缀；node_version 从 config 读
   // (v4 起 @kungfu-tech/libnode 不再列为 devDep，dev 走 npm link，见 docs/conan2-migration.md)。
-  const electronVersion = String(
-    packageJson.devDependencies['electron'],
-  ).replace(/^[\^~]/, '');
-  const nodeVersion = packageJson.config['node_version'];
+  const electronVersion = String(packageJson.devDependencies.electron).replace(
+    /^[\^~]/,
+    '',
+  );
+  const nodeVersion = packageJson.config.node_version;
   return [
     '-o',
     `electron_version=${electronVersion}`,
@@ -41,7 +65,7 @@ function makeConanSetting(name) {
 
 /** @param {string[]} names */
 function makeConanSettings(names) {
-  return names.map(makeConanSetting).flat();
+  return names.flatMap(makeConanSetting);
 }
 
 // Windows 端口固化：conan profile detect 在 MSVC 上把 compiler.cppstd 探成 14，
@@ -60,11 +84,12 @@ function makeConanOption(name) {
 
 /** @param {string[]} names */
 function makeConanOptions(names) {
-  return names.map(makeConanOption).flat().concat(getNodeVersionOptions());
+  return names.flatMap(makeConanOption).concat(getNodeVersionOptions());
 }
 
 // conan2：-if/-bf → --output-folder；arch 是 setting 由 profile 自测，不再作 -o 选项。
 function conanInstall() {
+  ensureBuildchainConanProfile();
   const settings = [
     ...makeConanSettings(['build_type']),
     ...platformConanSettings(),

--- a/scripts/buildchain-run-kungfu-code.mjs
+++ b/scripts/buildchain-run-kungfu-code.mjs
@@ -10,10 +10,35 @@ import { fileURLToPath } from 'node:url';
 const repoRoot = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
 const argv = process.argv.slice(2);
 
-function withPathPrefix(env, dir) {
+function envPathKey(env) {
+  if (process.platform === 'win32' && Object.hasOwn(env, 'Path')) {
+    return 'Path';
+  }
+  return 'PATH';
+}
+
+function existingDirs(dirs) {
+  return dirs.filter((dir) => dir && fs.existsSync(dir));
+}
+
+function windowsToolPathDirs(env) {
+  if (process.platform !== 'win32') {
+    return [];
+  }
+  const home = env.USERPROFILE || env.HOME;
+  const localAppData = env.LOCALAPPDATA;
+  return existingDirs([
+    localAppData && path.join(localAppData, 'Microsoft', 'WinGet', 'Links'),
+    home && path.join(home, '.local', 'bin'),
+    home && path.join(home, '.cargo', 'bin'),
+  ]);
+}
+
+function withPathPrefixes(env, dirs) {
+  const pathKey = envPathKey(env);
   return {
     ...env,
-    PATH: [dir, env.PATH || env.Path || '']
+    [pathKey]: [...dirs, env[pathKey] || env.PATH || env.Path || '']
       .filter(Boolean)
       .join(path.delimiter),
   };
@@ -41,8 +66,12 @@ function createPnpmShimDir() {
   return shimDir;
 }
 
-const env = withPathPrefix(process.env, createPnpmShimDir());
+const env = withPathPrefixes(process.env, [
+  createPnpmShimDir(),
+  ...windowsToolPathDirs(process.env),
+]);
 env.KUNGFU_BUILDCHAIN_NO_OPTIONAL = '1';
+env.KUNGFU_BUILDCHAIN_SOURCE_BUILD = '1';
 const result =
   process.platform === 'win32'
     ? spawnSync('corepack.cmd', ['pnpm', ...argv], {


### PR DESCRIPTION
## Summary
- keep Buildchain no-optional installs while injecting only the current libnode platform package for source rebuilds
- mark Buildchain source builds and auto-detect a Conan default profile when missing
- add common Windows user tool directories to PATH for lifecycle commands

## Validation
- node --check scripts/buildchain-run-kungfu-code.mjs artifact/scripts/dist.mjs framework/core/.gyp/run-conan.js
- pnpm exec biome check scripts/buildchain-run-kungfu-code.mjs artifact/scripts/dist.mjs framework/core/.gyp/run-conan.js
- pnpm run check:types
- node scripts/buildchain-run-kungfu-code.mjs install --frozen-lockfile --no-optional
- libnode NODE_PATH probe with @kungfu-tech/libnode-darwin-arm64@22.22.3-kf.1