### PR TITLE
ci: align core optional lockfile specifiers

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -434,6 +434,16 @@ importers:
       node-addon-api:
         specifier: ^8.0.0
         version: 8.9.0
+    optionalDependencies:
+      '@kungfu-tech/core-darwin-arm64':
+        specifier: 4.0.0-alpha.0
+        version: 4.0.0-alpha.0
+      '@kungfu-tech/core-linux-x64':
+        specifier: 4.0.0-alpha.0
+        version: 4.0.0-alpha.0
+      '@kungfu-tech/core-win32-x64':
+        specifier: 4.0.0-alpha.0
+        version: 4.0.0-alpha.0
 
   framework/gui:
     dependencies:


### PR DESCRIPTION
## Summary
- add the framework/core optional platform-package specifiers to the lockfile importer so Buildchain no-optional frozen installs validate on clean runners

## Validation
- CI=true pnpm install --frozen-lockfile --no-optional --lockfile-only
- node scripts/buildchain-run-kungfu-code.mjs install --frozen-lockfile --no-optional
- git diff --check