### PR TITLE
ci: discover uv from windows runner users

### DIFF
--- a/scripts/buildchain-run-kungfu-code.mjs
+++ b/scripts/buildchain-run-kungfu-code.mjs
@@ -21,6 +21,24 @@ function existingDirs(dirs) {
   return dirs.filter((dir) => dir && fs.existsSync(dir));
 }
 
+function windowsUserToolPathDirs() {
+  const usersRoot = 'C:\\Users';
+  if (!fs.existsSync(usersRoot)) {
+    return [];
+  }
+  return fs
+    .readdirSync(usersRoot, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .flatMap((entry) => {
+      const home = path.join(usersRoot, entry.name);
+      return [
+        path.join(home, 'AppData', 'Local', 'Microsoft', 'WinGet', 'Links'),
+        path.join(home, '.local', 'bin'),
+        path.join(home, '.cargo', 'bin'),
+      ];
+    });
+}
+
 function windowsToolPathDirs(env) {
   if (process.platform !== 'win32') {
     return [];
@@ -31,6 +49,7 @@ function windowsToolPathDirs(env) {
     localAppData && path.join(localAppData, 'Microsoft', 'WinGet', 'Links'),
     home && path.join(home, '.local', 'bin'),
     home && path.join(home, '.cargo', 'bin'),
+    ...windowsUserToolPathDirs(),
   ]);
 }
 


### PR DESCRIPTION
## Summary
- add Windows user tool directories from C:\Users\* to the Buildchain wrapper PATH so self-hosted runner jobs can find an existing uv.exe during source rebuilds
- keep this scoped to Windows Buildchain lifecycle execution; no tool installation is performed

## Validation
- node --check scripts/buildchain-run-kungfu-code.mjs
- pnpm exec biome check scripts/buildchain-run-kungfu-code.mjs
- node scripts/buildchain-run-kungfu-code.mjs exec node -e "console.log(process.env.KUNGFU_BUILDCHAIN_NO_OPTIONAL, process.env.KUNGFU_BUILDCHAIN_SOURCE_BUILD)"
- git diff --check