### PR TITLE
feat(gui): add global appearance config

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -95,6 +95,9 @@ kungfu config contract --json
 kungfu config schema --json
 kungfu config defaults --json
 kungfu config show --json
+kungfu config set ui.fontSize 16 --json
+kungfu config set ui.scale 1.1 --json
+kungfu config unset ui.scale --json
 kungfu agent context --json
 ```
 
@@ -106,6 +109,13 @@ kungfu agent context --json
 defaults, optional user overrides, contract metadata, source metadata,
 `configHome`, `configPath`, and `runtimeHome`. The `contract.hash` field makes
 the exact contract world inspectable by users, agents, and release gates.
+
+`kungfu config set <dotted-key> <json-value>` writes a user override to
+`configPath`, validates it against the same contract, and returns the resolved
+config with `--json`. Plain values that are not JSON decode as strings, so
+`kungfu config set ui.fontFamily system` and
+`kungfu config set ui.fontFamily '"SF Pro Text, system-ui, sans-serif"'` are
+both valid.
 
 `kungfu agent context --json` is the canonical local discovery entrypoint for
 agents. Managed-run envelopes point to this command instead of carrying config,

--- a/extensions/system/settings/src/view/index.tsx
+++ b/extensions/system/settings/src/view/index.tsx
@@ -10,10 +10,11 @@ import {
 } from '@kungfu-tech/kfx';
 import React from 'react';
 
-const tabs = ['profile', 'kfx', 'paths', 'advanced'] as const;
+const tabs = ['appearance', 'profile', 'kfx', 'paths', 'advanced'] as const;
 type SettingsTab = (typeof tabs)[number];
 
 const tabLabels: Record<SettingsTab, string> = {
+  appearance: 'Appearance',
   profile: 'Profile',
   kfx: 'KFX',
   paths: 'Paths',
@@ -34,13 +35,57 @@ const rowStyle: React.CSSProperties = {
   padding: '6px 0',
 };
 
+const customFontValue = '__custom__';
+
+const fontFamilyOptions = [
+  { label: 'System UI', value: 'system' },
+  {
+    label: 'System Mono',
+    value:
+      'ui-monospace, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace',
+  },
+  {
+    label: 'Common Sans',
+    value:
+      'Arial, Helvetica, "Liberation Sans", "Noto Sans", system-ui, sans-serif',
+  },
+  {
+    label: 'Common Serif',
+    value:
+      'Georgia, "Times New Roman", "Liberation Serif", "Noto Serif", serif',
+  },
+  {
+    label: 'Common Mono',
+    value: 'Consolas, "Liberation Mono", Menlo, "SF Mono", Monaco, monospace',
+  },
+] as const;
+
 function shellEnv(key: string): string {
   return window.process.env[key] || '—';
 }
 
 function SettingsView({ shell }: KfxViewProps) {
   const [drafts, setDrafts] = React.useState<Record<string, string>>({});
-  const [activeTab, setActiveTab] = React.useState<SettingsTab>('profile');
+  const [activeTab, setActiveTab] = React.useState<SettingsTab>('appearance');
+  const ui = shell.config?.config.ui ?? {
+    fontFamily: 'system',
+    fontSize: 14,
+    scale: 1,
+  };
+  const [uiDraft, setUiDraft] = React.useState({
+    fontFamily: ui.fontFamily,
+    fontSize: String(ui.fontSize),
+    scale: String(ui.scale),
+  });
+  const [uiError, setUiError] = React.useState('');
+
+  React.useEffect(() => {
+    setUiDraft({
+      fontFamily: ui.fontFamily,
+      fontSize: String(ui.fontSize),
+      scale: String(ui.scale),
+    });
+  }, [ui.fontFamily, ui.fontSize, ui.scale]);
 
   const declared = shell.registry.flatMap((entry) =>
     entry.settings.map((decl) => ({ owner: entry.title, decl })),
@@ -60,6 +105,163 @@ function SettingsView({ shell }: KfxViewProps) {
   const profile =
     shell.profiles.find((p) => p.id === shell.state.profileId) ??
     shell.profiles[0];
+
+  const saveAppearance = () => {
+    const fontSize = Number(uiDraft.fontSize);
+    const scale = Number(uiDraft.scale);
+    if (!Number.isFinite(fontSize) || fontSize < 8 || fontSize > 48) {
+      setUiError('font size must be between 8 and 48');
+      return;
+    }
+    if (!Number.isFinite(scale) || scale < 0.5 || scale > 3) {
+      setUiError('zoom must be between 50% and 300%');
+      return;
+    }
+    const fontFamily = uiDraft.fontFamily.trim() || 'system';
+    try {
+      shell.setConfigValue('ui.fontFamily', fontFamily);
+      shell.setConfigValue('ui.fontSize', fontSize);
+      shell.setConfigValue('ui.scale', scale);
+      setUiError('');
+    } catch (e) {
+      setUiError((e as Error).message);
+    }
+  };
+
+  const resetAppearance = () => {
+    try {
+      shell.unsetConfigValue('ui.fontFamily');
+      shell.unsetConfigValue('ui.fontSize');
+      shell.unsetConfigValue('ui.scale');
+      shell.reloadConfig();
+      setUiError('');
+    } catch (e) {
+      setUiError((e as Error).message);
+    }
+  };
+
+  const renderAppearance = () => (
+    <section style={sectionStyle}>
+      <h2 style={headingStyle}>Global appearance</h2>
+      {shell.configError && (
+        <div style={{ ...mono, color: '#f48771', marginBottom: 10 }}>
+          {shell.configError}
+        </div>
+      )}
+      <div style={{ display: 'grid', gap: 10, maxWidth: 560 }}>
+        <label style={rowStyle}>
+          <span style={{ color: '#858585' }}>font family</span>
+          <div style={{ display: 'grid', gap: 8 }}>
+            <select
+              style={{ ...inputStyle, width: '100%' }}
+              value={
+                fontFamilyOptions.some(
+                  (option) => option.value === uiDraft.fontFamily,
+                )
+                  ? uiDraft.fontFamily
+                  : customFontValue
+              }
+              onChange={(event) => {
+                const value = event.target.value;
+                setUiDraft((current) => ({
+                  ...current,
+                  fontFamily: value === customFontValue ? '' : value,
+                }));
+              }}
+            >
+              {fontFamilyOptions.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+              <option value={customFontValue}>Custom</option>
+            </select>
+            {!fontFamilyOptions.some(
+              (option) => option.value === uiDraft.fontFamily,
+            ) && (
+              <input
+                style={{ ...inputStyle, width: '100%' }}
+                value={uiDraft.fontFamily}
+                onChange={(event) =>
+                  setUiDraft((current) => ({
+                    ...current,
+                    fontFamily: event.target.value,
+                  }))
+                }
+                placeholder="Inter, system-ui, sans-serif"
+              />
+            )}
+          </div>
+        </label>
+        <label style={rowStyle}>
+          <span style={{ color: '#858585' }}>font size</span>
+          <input
+            type="number"
+            min={8}
+            max={48}
+            step={1}
+            style={{ ...inputStyle, width: 120 }}
+            value={uiDraft.fontSize}
+            onChange={(event) =>
+              setUiDraft((current) => ({
+                ...current,
+                fontSize: event.target.value,
+              }))
+            }
+          />
+        </label>
+        <label style={rowStyle}>
+          <span style={{ color: '#858585' }}>
+            zoom · {Math.round(Number(uiDraft.scale || 1) * 100)}%
+          </span>
+          <input
+            type="range"
+            min={0.5}
+            max={3}
+            step={0.05}
+            value={uiDraft.scale}
+            onChange={(event) =>
+              setUiDraft((current) => ({
+                ...current,
+                scale: event.target.value,
+              }))
+            }
+          />
+        </label>
+        <div style={{ ...mono, color: '#6a6a6a' }}>
+          config: {shell.config?.configPath ?? 'unavailable'}
+        </div>
+        {(uiError || shell.configError) && (
+          <div style={{ ...mono, color: '#f48771' }}>
+            {uiError || shell.configError}
+          </div>
+        )}
+        <div style={{ display: 'flex', gap: 8 }}>
+          <button
+            type="button"
+            onClick={saveAppearance}
+            style={{ ...mono, padding: '6px 12px' }}
+          >
+            Apply
+          </button>
+          <button
+            type="button"
+            onClick={resetAppearance}
+            style={{ ...mono, padding: '6px 12px' }}
+          >
+            Reset
+          </button>
+          <button
+            type="button"
+            onClick={shell.reloadConfig}
+            style={{ ...mono, padding: '6px 12px' }}
+          >
+            Reload
+          </button>
+        </div>
+      </div>
+    </section>
+  );
 
   const renderProfile = () => (
     <section style={sectionStyle}>
@@ -181,6 +383,7 @@ function SettingsView({ shell }: KfxViewProps) {
   );
 
   const renderActive = () => {
+    if (activeTab === 'appearance') return renderAppearance();
     if (activeTab === 'profile') return renderProfile();
     if (activeTab === 'kfx') return renderKfx();
     if (activeTab === 'paths') return renderPaths();

--- a/framework/core/src/python/kungfu/cli/commands/config.py
+++ b/framework/core/src/python/kungfu/cli/commands/config.py
@@ -10,7 +10,10 @@ from kungfu.config import (
     config_schema,
     default_config,
     load_contract,
+    parse_config_value,
     resolve_config,
+    set_user_config_value,
+    unset_user_config_value,
     user_config_path,
 )
 
@@ -108,6 +111,40 @@ def show(ctx, as_json):
         _json(data)
         return
     click.echo(json.dumps(data, indent=2, sort_keys=True))
+
+
+@config.command(name="set", help="set a user config override by dotted key")
+@click.argument("key")
+@click.argument("value")
+@click.option("--json", "as_json", is_flag=True, help="machine-readable output")
+@config_command_context
+def set_value(ctx, key, value, as_json):
+    try:
+        parsed = parse_config_value(value)
+        data = set_user_config_value(key, parsed, runtime_home=ctx.home)
+    except (OSError, ValueError, json.JSONDecodeError) as e:
+        click.echo(f"[config] failed to set {key}: {e}", err=True)
+        sys.exit(1)
+    if as_json:
+        _json(data)
+        return
+    click.echo(f"{key} = {json.dumps(parsed, sort_keys=True)}")
+
+
+@config.command(name="unset", help="remove a user config override by dotted key")
+@click.argument("key")
+@click.option("--json", "as_json", is_flag=True, help="machine-readable output")
+@config_command_context
+def unset_value(ctx, key, as_json):
+    try:
+        data = unset_user_config_value(key, runtime_home=ctx.home)
+    except (OSError, ValueError, json.JSONDecodeError) as e:
+        click.echo(f"[config] failed to unset {key}: {e}", err=True)
+        sys.exit(1)
+    if as_json:
+        _json(data)
+        return
+    click.echo(f"{key} unset")
 
 
 def _default_config(ctx):

--- a/framework/core/src/python/kungfu/config.py
+++ b/framework/core/src/python/kungfu/config.py
@@ -122,6 +122,48 @@ def load_user_config(
     return data
 
 
+def parse_config_value(value: str) -> Any:
+    try:
+        return json.loads(value)
+    except json.JSONDecodeError:
+        return value
+
+
+def set_user_config_value(
+    key: str,
+    value: Any,
+    *,
+    config_home: str | None = None,
+    runtime_home: str | None = None,
+) -> dict[str, Any]:
+    contract = load_contract()
+    config_home = default_config_home() if config_home is None else config_home
+    config_path = user_config_path(config_home)
+    override = load_user_config(config_path, contract=contract)
+    override.setdefault("schema", contract["resolution"]["overrideSchema"])
+    _set_dotted(override, key, value)
+    validate_config(override, contract=contract, partial=True)
+    _write_user_config(config_path, override)
+    return resolve_config(runtime_home=runtime_home, config_home=config_home)
+
+
+def unset_user_config_value(
+    key: str,
+    *,
+    config_home: str | None = None,
+    runtime_home: str | None = None,
+) -> dict[str, Any]:
+    contract = load_contract()
+    config_home = default_config_home() if config_home is None else config_home
+    config_path = user_config_path(config_home)
+    override = load_user_config(config_path, contract=contract)
+    override.setdefault("schema", contract["resolution"]["overrideSchema"])
+    _unset_dotted(override, key)
+    validate_config(override, contract=contract, partial=True)
+    _write_user_config(config_path, override)
+    return resolve_config(runtime_home=runtime_home, config_home=config_home)
+
+
 def resolve_config(
     *,
     runtime_home: str | None = None,
@@ -239,6 +281,51 @@ def _deep_merge(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any
         else:
             result[key] = copy.deepcopy(value)
     return result
+
+
+def _dotted_parts(key: str) -> list[str]:
+    parts = [part for part in key.split(".") if part]
+    if not parts or len(parts) != len(key.split(".")):
+        raise ValueError(f"invalid config key: {key!r}")
+    return parts
+
+
+def _set_dotted(target: dict[str, Any], key: str, value: Any) -> None:
+    parts = _dotted_parts(key)
+    current = target
+    for part in parts[:-1]:
+        existing = current.get(part)
+        if existing is None:
+            existing = {}
+            current[part] = existing
+        if not isinstance(existing, dict):
+            raise ValueError(f"cannot set nested config under scalar key: {part}")
+        current = existing
+    current[parts[-1]] = value
+
+
+def _unset_dotted(target: dict[str, Any], key: str) -> None:
+    parts = _dotted_parts(key)
+    stack: list[tuple[dict[str, Any], str]] = []
+    current = target
+    for part in parts[:-1]:
+        existing = current.get(part)
+        if not isinstance(existing, dict):
+            return
+        stack.append((current, part))
+        current = existing
+    current.pop(parts[-1], None)
+    for parent, part in reversed(stack):
+        child = parent.get(part)
+        if isinstance(child, dict) and not child:
+            parent.pop(part, None)
+
+
+def _write_user_config(config_path: str, data: dict[str, Any]) -> None:
+    os.makedirs(os.path.dirname(config_path), exist_ok=True)
+    with open(config_path, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2, sort_keys=True)
+        f.write("\n")
 
 
 def _expand_placeholders(

--- a/framework/core/tests/python/test_skill.py
+++ b/framework/core/tests/python/test_skill.py
@@ -3,7 +3,13 @@
 from pathlib import Path
 import json
 
-from kungfu.config import contract_hash, load_contract, resolve_config
+from kungfu.config import (
+    contract_hash,
+    load_contract,
+    resolve_config,
+    set_user_config_value,
+    unset_user_config_value,
+)
 from kungfu.skill import (
     append_audit_event,
     build_skill_dependency_binding,
@@ -198,6 +204,57 @@ def test_resolved_config_merges_user_override(tmp_path):
     assert config["config"]["ui"]["fontFamily"] == "system"
     assert config["config"]["shortcuts"]["commandPalette"] == "Ctrl+K"
     assert config["config"]["shortcuts"]["quickOpen"] == "Mod+P"
+
+
+def test_user_config_set_and_unset_dotted_values(tmp_path):
+    runtime_home = tmp_path / "runtime-home"
+    config_home = tmp_path / "config-home"
+
+    set_result = set_user_config_value(
+        "ui.fontSize",
+        18,
+        runtime_home=str(runtime_home),
+        config_home=str(config_home),
+    )
+    set_user_config_value(
+        "ui.scale",
+        1.25,
+        runtime_home=str(runtime_home),
+        config_home=str(config_home),
+    )
+
+    config_path = config_home / "config.json"
+    saved = json.loads(config_path.read_text(encoding="utf-8"))
+    assert saved["schema"] == "kungfu.config.override/v1"
+    assert saved["ui"]["fontSize"] == 18
+    assert saved["ui"]["scale"] == 1.25
+    assert set_result["config"]["ui"]["fontSize"] == 18
+
+    unset_result = unset_user_config_value(
+        "ui.fontSize",
+        runtime_home=str(runtime_home),
+        config_home=str(config_home),
+    )
+
+    saved = json.loads(config_path.read_text(encoding="utf-8"))
+    assert "fontSize" not in saved["ui"]
+    assert saved["ui"]["scale"] == 1.25
+    assert unset_result["config"]["ui"]["fontSize"] == 14
+    assert unset_result["config"]["ui"]["scale"] == 1.25
+
+
+def test_user_config_set_rejects_invalid_contract_value(tmp_path):
+    try:
+        set_user_config_value(
+            "ui.scale",
+            9,
+            runtime_home=str(tmp_path / "runtime-home"),
+            config_home=str(tmp_path / "config-home"),
+        )
+    except ValueError as e:
+        assert "greater than the maximum" in str(e)
+    else:
+        raise AssertionError("expected invalid ui.scale to fail")
 
 
 def test_resolved_config_rejects_unknown_override_keys(tmp_path):

--- a/framework/gui/src/renderer/sandbox-view-harness/harness.ts
+++ b/framework/gui/src/renderer/sandbox-view-harness/harness.ts
@@ -65,6 +65,10 @@ const shell: Shell = {
   setting: () => '',
   updateState: () => {},
   state: { profileId: '', disabledKfx: [], disabledSuites: [], settings: {} },
+  config: null,
+  reloadConfig: () => {},
+  setConfigValue: () => {},
+  unsetConfigValue: () => {},
   info: {
     ok: true,
     message: 'sandboxed',

--- a/framework/gui/src/renderer/src/gui-config.ts
+++ b/framework/gui/src/renderer/src/gui-config.ts
@@ -1,0 +1,101 @@
+import type {
+  KungfuConfigValue,
+  KungfuResolvedConfig,
+  KungfuUiConfig,
+} from '@kungfu-tech/kfx';
+
+const SYSTEM_UI_FONT =
+  'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif';
+const SYSTEM_MONO_FONT = 'SF Mono, Menlo, Monaco, Consolas, monospace';
+const DEFAULT_UI: KungfuUiConfig = {
+  fontFamily: 'system',
+  fontSize: 14,
+  scale: 1,
+};
+
+type ExecFileSync = (
+  file: string,
+  args: string[],
+  options: { encoding: 'utf8'; env: NodeJS.ProcessEnv },
+) => string;
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+function binName(): string {
+  return window.process.platform === 'win32' ? 'kungfu.exe' : 'kungfu';
+}
+
+function kungfuExecutable(): string {
+  const fs = window.require('node:fs') as typeof import('node:fs');
+  const path = window.require('node:path') as typeof import('node:path');
+  const candidates: string[] = [];
+  const kfePath = window.process.env.KFE_PATH;
+  if (kfePath) candidates.push(path.join(path.dirname(kfePath), binName()));
+  try {
+    const core = window.require('@kungfu-tech/core') as {
+      executable?: { kfc?: string };
+    };
+    if (core.executable?.kfc) candidates.push(core.executable.kfc);
+  } catch {
+    // packaged builds do not resolve the workspace package; KFE_PATH covers them
+  }
+  const found = candidates.find((candidate) => fs.existsSync(candidate));
+  if (!found) {
+    throw new Error('cannot locate kungfu CLI for config operations');
+  }
+  return found;
+}
+
+function runConfig(args: string[]): KungfuResolvedConfig {
+  const childProcess = window.require('node:child_process') as {
+    execFileSync: ExecFileSync;
+  };
+  const output = childProcess.execFileSync(
+    kungfuExecutable(),
+    ['config', ...args],
+    {
+      encoding: 'utf8',
+      env: { ...window.process.env },
+    },
+  );
+  return JSON.parse(output) as KungfuResolvedConfig;
+}
+
+export function loadKungfuConfig(): KungfuResolvedConfig {
+  return runConfig(['show', '--json']);
+}
+
+export function setKungfuConfigValue(
+  key: string,
+  value: KungfuConfigValue,
+): KungfuResolvedConfig {
+  return runConfig(['set', key, JSON.stringify(value), '--json']);
+}
+
+export function unsetKungfuConfigValue(key: string): KungfuResolvedConfig {
+  return runConfig(['unset', key, '--json']);
+}
+
+export function normalizedUiConfig(
+  config: KungfuResolvedConfig | null,
+): KungfuUiConfig {
+  const ui = config?.config.ui ?? DEFAULT_UI;
+  return {
+    fontFamily:
+      typeof ui.fontFamily === 'string' && ui.fontFamily.trim()
+        ? ui.fontFamily.trim()
+        : DEFAULT_UI.fontFamily,
+    fontSize: clamp(Number(ui.fontSize) || DEFAULT_UI.fontSize, 8, 48),
+    scale: clamp(Number(ui.scale) || DEFAULT_UI.scale, 0.5, 3),
+  };
+}
+
+export function resolvedUiFontFamily(fontFamily: string): string {
+  return fontFamily === 'system' ? SYSTEM_UI_FONT : fontFamily;
+}
+
+export function resolvedMonoFontFamily(fontFamily: string): string {
+  return fontFamily === 'system' ? SYSTEM_MONO_FONT : fontFamily;
+}

--- a/framework/gui/src/renderer/src/main.tsx
+++ b/framework/gui/src/renderer/src/main.tsx
@@ -12,6 +12,8 @@ import * as capability from '@kungfu-tech/api/capability';
 import type {
   KfxCapabilities,
   KfxEntry,
+  KungfuConfigValue,
+  KungfuResolvedConfig,
   SessionWindowRecord,
   Shell,
   ShellState,
@@ -26,6 +28,14 @@ import {
   SESSION_WINDOW_RESTORE_CHANNEL,
   SESSION_WINDOW_SNAPSHOT_CHANNEL,
 } from '../../sandbox/channels';
+import {
+  loadKungfuConfig,
+  normalizedUiConfig,
+  resolvedMonoFontFamily,
+  resolvedUiFontFamily,
+  setKungfuConfigValue,
+  unsetKungfuConfigValue,
+} from './gui-config';
 import { type KfxLoadResult, loadKfx } from './kfx-loader';
 import { type Runtime, bootRuntime } from './runtime';
 import { sandboxClient } from './sandbox-client';
@@ -198,6 +208,8 @@ function App() {
   );
   const [params, setParams] = React.useState<Record<string, string>>({});
   const [settingsOpen, setSettingsOpen] = React.useState(false);
+  const [config, setConfig] = React.useState<KungfuResolvedConfig | null>(null);
+  const [configError, setConfigError] = React.useState('');
 
   // shared refresh bus: one shell-owned timer, kfx subscribe
   const subscribers = React.useRef(new Set<() => void>());
@@ -218,6 +230,56 @@ function App() {
     },
     [runtime.domain],
   );
+
+  const reloadConfig = React.useCallback(() => {
+    try {
+      setConfig(loadKungfuConfig());
+      setConfigError('');
+    } catch (e) {
+      setConfig(null);
+      setConfigError((e as Error).message);
+    }
+  }, []);
+
+  React.useEffect(() => {
+    reloadConfig();
+  }, [reloadConfig]);
+
+  const updateConfigValue = React.useCallback(
+    (key: string, value: KungfuConfigValue) => {
+      try {
+        setConfig(setKungfuConfigValue(key, value));
+        setConfigError('');
+      } catch (e) {
+        setConfigError((e as Error).message);
+        throw e;
+      }
+    },
+    [],
+  );
+
+  const removeConfigValue = React.useCallback((key: string) => {
+    try {
+      setConfig(unsetKungfuConfigValue(key));
+      setConfigError('');
+    } catch (e) {
+      setConfigError((e as Error).message);
+      throw e;
+    }
+  }, []);
+
+  const uiConfig = normalizedUiConfig(config);
+
+  React.useEffect(() => {
+    try {
+      const electron = window.require('electron') as {
+        webFrame?: { setZoomFactor: (factor: number) => void };
+      };
+      electron.webFrame?.setZoomFactor(uiConfig.scale);
+    } catch {
+      // non-electron tests or previews keep CSS sizing without webFrame zoom
+    }
+  }, [uiConfig.scale]);
 
   const settingFallbacks: Record<string, string> = Object.fromEntries(
     loaded.entries.flatMap((entry) =>
@@ -318,6 +380,11 @@ function App() {
     setting: (key) => state.settings[key] ?? settingFallbacks[key] ?? '',
     updateState,
     state,
+    config,
+    configError,
+    reloadConfig,
+    setConfigValue: updateConfigValue,
+    unsetConfigValue: removeConfigValue,
     info: {
       ok: runtime.ok,
       message: runtime.message,
@@ -472,21 +539,25 @@ function App() {
     </div>
   ) : null;
 
+  const appStyle = {
+    '--kf-ui-font-family': resolvedUiFontFamily(uiConfig.fontFamily),
+    '--kf-mono-font-family': resolvedMonoFontFamily(uiConfig.fontFamily),
+    '--kf-font-size': `${uiConfig.fontSize}px`,
+    fontFamily: 'var(--kf-ui-font-family)',
+    fontSize: 'var(--kf-font-size)',
+    color: '#cccccc',
+    background: '#1e1e1e',
+    height: '100vh',
+    margin: 0,
+    padding: 16,
+    boxSizing: 'border-box',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 12,
+  } as React.CSSProperties;
+
   return (
-    <div
-      style={{
-        fontFamily: 'system-ui, sans-serif',
-        color: '#cccccc',
-        background: '#1e1e1e',
-        height: '100vh',
-        margin: 0,
-        padding: 16,
-        boxSizing: 'border-box',
-        display: 'flex',
-        flexDirection: 'column',
-        gap: 12,
-      }}
-    >
+    <div style={appStyle}>
       <header style={{ display: 'flex', alignItems: 'center', gap: 16 }}>
         <h1 style={{ fontSize: 16, fontWeight: 600, margin: 0 }}>
           Kungfu v4 reference app

--- a/framework/kfx/src/index.ts
+++ b/framework/kfx/src/index.ts
@@ -720,6 +720,38 @@ export type ShellRuntimeInfo = {
   longfistTypes: { name: string; fields: string[] }[];
 };
 
+export type KungfuUiConfig = {
+  fontFamily: string;
+  fontSize: number;
+  scale: number;
+};
+
+export type KungfuResolvedConfig = {
+  schema: 'kungfu.config.resolved/v1';
+  configHome: string;
+  configPath: string;
+  runtimeHome: string;
+  config: {
+    ui: KungfuUiConfig;
+    [key: string]: unknown;
+  };
+  sources: {
+    type: string;
+    path?: string;
+    exists?: boolean;
+    [key: string]: unknown;
+  }[];
+  contract: Record<string, unknown>;
+};
+
+export type KungfuConfigValue =
+  | string
+  | number
+  | boolean
+  | null
+  | Record<string, unknown>
+  | unknown[];
+
 // One loaded view as the GUI shell sees it: a load-plan entry (manifest data +
 // the trust/tier decision) with this renderer's landing added — the mounted
 // `View`. A node-integrated view carries a View evaluated in the shared
@@ -758,6 +790,12 @@ export type Shell = {
   // persist shell state changes; the shell owns the ConfigStore write
   updateState: (patch: Partial<ShellState>) => void;
   state: ShellState;
+  // global Kungfu config, read/written through `kungfu config`
+  config: KungfuResolvedConfig | null;
+  configError?: string;
+  reloadConfig: () => void;
+  setConfigValue: (key: string, value: KungfuConfigValue) => void;
+  unsetConfigValue: (key: string) => void;
   // runtime facts for system views
   info: ShellRuntimeInfo;
   // every loaded kfx (for the manager and settings views)
@@ -809,7 +847,7 @@ export const panelStyle: React.CSSProperties = {
 };
 
 export const headingStyle: React.CSSProperties = {
-  fontSize: 11,
+  fontSize: 'calc(var(--kf-font-size, 14px) - 3px)',
   fontWeight: 600,
   textTransform: 'uppercase',
   letterSpacing: 1,
@@ -818,8 +856,8 @@ export const headingStyle: React.CSSProperties = {
 };
 
 export const mono: React.CSSProperties = {
-  fontFamily: 'SF Mono, Menlo, monospace',
-  fontSize: 12,
+  fontFamily: 'var(--kf-mono-font-family, SF Mono, Menlo, monospace)',
+  fontSize: 'calc(var(--kf-font-size, 14px) - 2px)',
 };
 
 export const inputStyle: React.CSSProperties = {


### PR DESCRIPTION
## Summary
- add `kungfu config set` and `kungfu config unset` for contract-validated user overrides
- wire GUI global font family, font size, and zoom through the Kungfu config mechanism
- add an Appearance tab with cross-platform font presets and Custom font-family input

## Verification
- `./kungfu-code check`
- `./kungfu-code build`
- `./kungfu-code verify`

## Version impact
- minor: adds user-facing global appearance settings