### PR TITLE
ci: instrument artifact buildchain lifecycle

### DIFF
--- a/artifact/package.json
+++ b/artifact/package.json
@@ -28,6 +28,8 @@
     "clean": "node -e \"fs.rmSync('dist',{recursive:true,force:true});fs.rmSync('extensions',{recursive:true,force:true})\" && pnpm --filter @kungfu-tech/gui run clean"
   },
   "dependencies": {
+    "@kungfu-tech/core": "workspace:*",
+    "@kungfu-tech/gui": "workspace:*",
     "@kungfu-tech/kfx-adapter-langchain": "workspace:*",
     "@kungfu-tech/kfx-suite-system": "workspace:*",
     "@kungfu-tech/kfx-view-config-manager": "workspace:*",
@@ -39,12 +41,13 @@
     "@kungfu-tech/kfx-view-status": "workspace:*",
     "@kungfu-tech/kfx-view-terminal": "workspace:*",
     "@kungfu-tech/kfx-view-work-dashboard": "workspace:*",
-    "@kungfu-tech/gui": "workspace:*",
-    "@kungfu-tech/tui": "workspace:*",
-    "@kungfu-tech/core": "workspace:*",
-    "@kungfu-tech/sdk": "workspace:*"
+    "@kungfu-tech/sdk": "workspace:*",
+    "@kungfu-tech/tui": "workspace:*"
   },
   "repository": {
     "url": "https://github.com/kungfu-systems/kungfu.git"
+  },
+  "devDependencies": {
+    "@kungfu-tech/buildchain": "2.8.7"
   }
 }

--- a/artifact/scripts/dist.mjs
+++ b/artifact/scripts/dist.mjs
@@ -10,6 +10,10 @@ import fs from 'node:fs';
 import { createRequire } from 'node:module';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import {
+  createBuildchainLogger,
+  verifyBuildchainLogEvents,
+} from '@kungfu-tech/buildchain/logging';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -21,6 +25,13 @@ const EXTENSIONS_ROOT = path.join(ROOT, 'extensions');
 const ASSEMBLED_EXTENSIONS = path.join(ARTIFACT_DIR, 'extensions');
 const isWin = process.platform === 'win32';
 const require = createRequire(import.meta.url);
+const buildchainLogger = createBuildchainLogger({
+  source: 'user',
+  component: 'kungfu-artifact',
+  attributes: {
+    package: '@kungfu-tech/artifact-kungfu',
+  },
+});
 
 const builderArgs = process.argv.slice(2);
 
@@ -33,23 +44,48 @@ function exitLabel(status, signal) {
 }
 
 function run(label, cmd, args, options = {}) {
-  console.log(`\n[artifact] ${label}`);
-  console.log(`[artifact] $ ${[cmd, ...args].join(' ')}`);
-  const result = spawnSync(cmd, args, {
-    cwd: options.cwd || ROOT,
-    env: options.env || process.env,
-    stdio: 'inherit',
-    shell: isWin,
-  });
-  if (result.status !== 0) {
-    throw new Error(
-      `${label} failed (exit ${exitLabel(result.status, result.signal)})`,
-    );
-  }
+  const cwd = options.cwd || ROOT;
+  const event = options.event || `artifact.command.${labelSlug(label)}`;
+  return buildchainLogger.spanSync(
+    event,
+    {
+      phase: options.phase || 'build',
+      attributes: {
+        label,
+        command: cmd,
+        cwd: rel(cwd),
+        argCount: args.length,
+        ...options.attributes,
+      },
+    },
+    () => {
+      console.log(`\n[artifact] ${label}`);
+      console.log(`[artifact] $ ${[cmd, ...args].join(' ')}`);
+      const result = spawnSync(cmd, args, {
+        cwd,
+        env: options.env || process.env,
+        stdio: 'inherit',
+        shell: isWin,
+      });
+      if (result.status !== 0) {
+        throw new Error(
+          `${label} failed (exit ${exitLabel(result.status, result.signal)})`,
+        );
+      }
+      return result;
+    },
+  );
 }
 
 function runPnpm(label, args, options = {}) {
   run(label, 'pnpm', args, options);
+}
+
+function labelSlug(label) {
+  return label
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '.')
+    .replace(/^\.+|\.+$/g, '');
 }
 
 function libnodePlatformPackageName() {
@@ -59,6 +95,30 @@ function libnodePlatformPackageName() {
     'win32-x64': '@kungfu-tech/libnode-win32-x64',
   };
   return packages[`${process.platform}-${process.arch}`];
+}
+
+function rollupPlatformPackageName() {
+  const libc = linuxLibc();
+  const packages = {
+    'darwin-arm64': '@rollup/rollup-darwin-arm64',
+    'darwin-x64': '@rollup/rollup-darwin-x64',
+    [`linux-arm64-${libc}`]: `@rollup/rollup-linux-arm64-${libc}`,
+    [`linux-x64-${libc}`]: `@rollup/rollup-linux-x64-${libc}`,
+    'win32-arm64': '@rollup/rollup-win32-arm64-msvc',
+    'win32-ia32': '@rollup/rollup-win32-ia32-msvc',
+    'win32-x64': '@rollup/rollup-win32-x64-msvc',
+  };
+  return packages[
+    `${process.platform}-${process.arch}${libc ? `-${libc}` : ''}`
+  ];
+}
+
+function linuxLibc() {
+  if (process.platform !== 'linux') {
+    return '';
+  }
+  const report = process.report?.getReport?.();
+  return report?.header?.glibcVersionRuntime ? 'gnu' : 'musl';
 }
 
 function installArgs() {
@@ -78,8 +138,107 @@ function canResolve(packageName) {
   }
 }
 
+function canResolveFrom(packageName, paths) {
+  try {
+    require.resolve(`${packageName}/package.json`, { paths });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function packageVersionFrom(packageName, paths) {
+  return readJson(require.resolve(`${packageName}/package.json`, { paths }))
+    .version;
+}
+
+function rollupPackagePathsFromGui() {
+  const vitePackageJson = require.resolve('vite/package.json', {
+    paths: [GUI_DIR],
+  });
+  const viteDir = path.dirname(vitePackageJson);
+  const rollupPackageJson = require.resolve('rollup/package.json', {
+    paths: [viteDir],
+  });
+  return [path.dirname(rollupPackageJson), viteDir];
+}
+
+function rollupVersionFromGui() {
+  return packageVersionFrom('rollup', rollupPackagePathsFromGui());
+}
+
+function packageJsonPath(nodePath, packageName) {
+  return path.join(nodePath, ...packageName.split('/'), 'package.json');
+}
+
+function appendNodePath(env, nodePaths) {
+  const nextNodePath = [...nodePaths, env.NODE_PATH || '']
+    .filter(Boolean)
+    .join(path.delimiter);
+  return nextNodePath ? { ...env, NODE_PATH: nextNodePath } : env;
+}
+
+function ensureNoOptionalPlatformPackage({
+  kind,
+  packageName,
+  version,
+  installRoot,
+}) {
+  const nodePath = path.join(installRoot, 'node_modules');
+  const installedPackageJson = packageJsonPath(nodePath, packageName);
+  if (!fs.existsSync(installedPackageJson)) {
+    fs.rmSync(installRoot, { recursive: true, force: true });
+    fs.mkdirSync(installRoot, { recursive: true });
+    run(
+      `install ${kind} platform package`,
+      'npm',
+      [
+        'install',
+        '--no-save',
+        '--package-lock=false',
+        '--ignore-scripts',
+        '--prefer-offline',
+        '--prefix',
+        installRoot,
+        `${packageName}@${version}`,
+      ],
+      {
+        phase: 'dependencies',
+        event: `artifact.${kind}.platform.install`,
+        attributes: {
+          packageName,
+          version,
+        },
+      },
+    );
+  } else {
+    buildchainLogger.mark(`artifact.${kind}.platform.cached`, {
+      phase: 'dependencies',
+      attributes: {
+        packageName,
+        version,
+      },
+    });
+  }
+
+  buildchainLogger.mark(`artifact.${kind}.platform.ready`, {
+    phase: 'dependencies',
+    attributes: {
+      packageName,
+      version,
+    },
+  });
+  return nodePath;
+}
+
 function buildchainSourceBuildEnv() {
   if (process.env.KUNGFU_BUILDCHAIN_NO_OPTIONAL !== '1') {
+    buildchainLogger.mark('artifact.libnode.platform.optional', {
+      phase: 'dependencies',
+      attributes: {
+        noOptional: false,
+      },
+    });
     return process.env;
   }
 
@@ -89,8 +248,15 @@ function buildchainSourceBuildEnv() {
       `unsupported libnode platform: ${process.platform}-${process.arch}`,
     );
   }
+  const nodePaths = [];
   if (canResolve(packageName)) {
-    return process.env;
+    buildchainLogger.mark('artifact.libnode.platform.resolved', {
+      phase: 'dependencies',
+      attributes: {
+        packageName,
+        source: 'workspace-node-path',
+      },
+    });
   }
 
   const corePackage = readJson(
@@ -107,33 +273,48 @@ function buildchainSourceBuildEnv() {
     'libnode-platform',
     `${process.platform}-${process.arch}`,
   );
-  const nodePath = path.join(installRoot, 'node_modules');
-  const installedPackageJson = path.join(
-    nodePath,
-    ...packageName.split('/'),
-    'package.json',
-  );
-  if (!fs.existsSync(installedPackageJson)) {
-    fs.rmSync(installRoot, { recursive: true, force: true });
-    fs.mkdirSync(installRoot, { recursive: true });
-    run('install libnode platform package', 'npm', [
-      'install',
-      '--no-save',
-      '--package-lock=false',
-      '--ignore-scripts',
-      '--prefer-offline',
-      '--prefix',
-      installRoot,
-      `${packageName}@${libnodeVersion}`,
-    ]);
+  if (!canResolve(packageName)) {
+    nodePaths.push(
+      ensureNoOptionalPlatformPackage({
+        kind: 'libnode',
+        packageName,
+        version: libnodeVersion,
+        installRoot,
+      }),
+    );
   }
 
-  return {
-    ...process.env,
-    NODE_PATH: [nodePath, process.env.NODE_PATH || '']
-      .filter(Boolean)
-      .join(path.delimiter),
-  };
+  const rollupPackageName = rollupPlatformPackageName();
+  if (!rollupPackageName) {
+    throw new Error(
+      `unsupported rollup platform: ${process.platform}-${process.arch}`,
+    );
+  }
+  if (canResolveFrom(rollupPackageName, rollupPackagePathsFromGui())) {
+    buildchainLogger.mark('artifact.rollup.platform.resolved', {
+      phase: 'dependencies',
+      attributes: {
+        packageName: rollupPackageName,
+        source: 'workspace-node-path',
+      },
+    });
+  } else {
+    nodePaths.push(
+      ensureNoOptionalPlatformPackage({
+        kind: 'rollup',
+        packageName: rollupPackageName,
+        version: rollupVersionFromGui(),
+        installRoot: path.join(
+          ROOT,
+          '.buildchain',
+          'rollup-platform',
+          `${process.platform}-${process.arch}`,
+        ),
+      }),
+    );
+  }
+
+  return appendNodePath(process.env, nodePaths);
 }
 
 function readJson(file) {
@@ -192,6 +373,12 @@ function assertDeclaredKfx(packages) {
     );
   }
   console.log(`[artifact] declared kfx dependencies: ${packages.length}`);
+  buildchainLogger.mark('artifact.kfx.dependencies.declared', {
+    phase: 'prepare',
+    attributes: {
+      packageCount: packages.length,
+    },
+  });
 }
 
 function assertSafeGeneratedDir(dir) {
@@ -225,18 +412,30 @@ function copyPackageDir(source, target) {
   });
 }
 
-function buildKfx(packages) {
+function buildKfx(packages, baseEnv = process.env) {
   const env = {
-    ...process.env,
-    PATH: `${CORE_DIST}${path.delimiter}${process.env.PATH || ''}`,
+    ...baseEnv,
+    PATH: `${CORE_DIST}${path.delimiter}${baseEnv.PATH || process.env.PATH || ''}`,
   };
   for (const pkg of packages) {
     if (!pkg.scripts.build) {
       console.log(`[artifact] skip ${pkg.name}: no build script`);
+      buildchainLogger.mark('artifact.kfx.build.skipped', {
+        phase: 'extensions',
+        attributes: {
+          packageName: pkg.name,
+          reason: 'no-build-script',
+        },
+      });
       continue;
     }
     runPnpm(`build kfx ${pkg.name}`, ['--filter', pkg.name, 'run', 'build'], {
       env,
+      phase: 'extensions',
+      event: 'artifact.kfx.build',
+      attributes: {
+        packageName: pkg.name,
+      },
     });
     if (pkg.config?.config?.view) {
       const entry = pkg.config.config.view.entry || 'dist/view/index.js';
@@ -249,14 +448,26 @@ function buildKfx(packages) {
 }
 
 function assembleKfx(packages) {
-  assertSafeGeneratedDir(ASSEMBLED_EXTENSIONS);
-  fs.rmSync(ASSEMBLED_EXTENSIONS, { recursive: true, force: true });
-  fs.mkdirSync(ASSEMBLED_EXTENSIONS, { recursive: true });
-  for (const pkg of packages) {
-    copyPackageDir(pkg.dir, path.join(ASSEMBLED_EXTENSIONS, pkg.relDir));
-  }
-  console.log(
-    `[artifact] assembled kfx packages -> ${rel(ASSEMBLED_EXTENSIONS)}`,
+  buildchainLogger.spanSync(
+    'artifact.kfx.assemble',
+    {
+      phase: 'extensions',
+      attributes: {
+        packageCount: packages.length,
+        output: rel(ASSEMBLED_EXTENSIONS),
+      },
+    },
+    () => {
+      assertSafeGeneratedDir(ASSEMBLED_EXTENSIONS);
+      fs.rmSync(ASSEMBLED_EXTENSIONS, { recursive: true, force: true });
+      fs.mkdirSync(ASSEMBLED_EXTENSIONS, { recursive: true });
+      for (const pkg of packages) {
+        copyPackageDir(pkg.dir, path.join(ASSEMBLED_EXTENSIONS, pkg.relDir));
+      }
+      console.log(
+        `[artifact] assembled kfx packages -> ${rel(ASSEMBLED_EXTENSIONS)}`,
+      );
+    },
   );
 }
 
@@ -268,55 +479,142 @@ function assertCoreFrozen() {
 }
 
 function main() {
-  const kfxPackages = listKfxPackages();
-  assertDeclaredKfx(kfxPackages);
-
-  const buildEnv = buildchainSourceBuildEnv();
-  runPnpm('sync dependencies', installArgs());
-  runPnpm('rebuild core', ['--filter', '@kungfu-tech/core', 'run', 'rebuild'], {
-    env: buildEnv,
-  });
-  runPnpm('freeze core runtime', [
-    '--filter',
-    '@kungfu-tech/core',
-    'run',
-    'freeze',
-  ]);
-  assertCoreFrozen();
-
-  buildKfx(kfxPackages);
-  assembleKfx(kfxPackages);
-
-  runPnpm('bundle tui', ['--filter', '@kungfu-tech/tui', 'run', 'bundle']);
-  runPnpm('ensure electron', [
-    '--filter',
-    '@kungfu-tech/gui',
-    'run',
-    'ensure-electron',
-  ]);
-  runPnpm('build gui', ['--filter', '@kungfu-tech/gui', 'run', 'build']);
-  run(
-    'electron-builder artifact',
-    process.execPath,
-    [
-      path.join(GUI_DIR, 'scripts', 'run-electron-builder.mjs'),
-      `--config=${path.join(ARTIFACT_DIR, 'electron-builder.yml')}`,
-      ...builderArgs,
-    ],
+  buildchainLogger.spanSync(
+    'artifact.dist',
     {
-      cwd: GUI_DIR,
-      env: {
-        ...process.env,
-        KF_FIRST_PARTY_SOURCE_ROOT: ASSEMBLED_EXTENSIONS,
+      phase: 'package',
+      attributes: {
+        platform: process.platform,
+        arch: process.arch,
+        builderArgCount: builderArgs.length,
       },
     },
-  );
+    () => {
+      const kfxPackages = buildchainLogger.spanSync(
+        'artifact.kfx.discover',
+        {
+          phase: 'prepare',
+          attributes: {
+            root: rel(EXTENSIONS_ROOT),
+          },
+        },
+        () => listKfxPackages(),
+      );
+      assertDeclaredKfx(kfxPackages);
 
-  console.log(`\n[artifact] output -> ${rel(path.join(ARTIFACT_DIR, 'dist'))}`);
+      const buildEnv = buildchainSourceBuildEnv();
+      runPnpm('sync dependencies', installArgs(), {
+        phase: 'dependencies',
+        event: 'artifact.dependencies.sync',
+      });
+      runPnpm(
+        'rebuild core',
+        ['--filter', '@kungfu-tech/core', 'run', 'rebuild'],
+        {
+          env: buildEnv,
+          phase: 'core',
+          event: 'artifact.core.rebuild',
+        },
+      );
+      runPnpm(
+        'freeze core runtime',
+        ['--filter', '@kungfu-tech/core', 'run', 'freeze'],
+        {
+          phase: 'core',
+          event: 'artifact.core.freeze',
+        },
+      );
+      assertCoreFrozen();
+
+      buildKfx(kfxPackages, buildEnv);
+      assembleKfx(kfxPackages);
+
+      runPnpm('bundle tui', ['--filter', '@kungfu-tech/tui', 'run', 'bundle'], {
+        env: buildEnv,
+        phase: 'ui',
+        event: 'artifact.tui.bundle',
+      });
+      runPnpm(
+        'ensure electron',
+        ['--filter', '@kungfu-tech/gui', 'run', 'ensure-electron'],
+        {
+          env: buildEnv,
+          phase: 'ui',
+          event: 'artifact.gui.ensure-electron',
+        },
+      );
+      runPnpm('build gui', ['--filter', '@kungfu-tech/gui', 'run', 'build'], {
+        env: buildEnv,
+        phase: 'ui',
+        event: 'artifact.gui.build',
+      });
+      run(
+        'electron-builder artifact',
+        process.execPath,
+        [
+          path.join(GUI_DIR, 'scripts', 'run-electron-builder.mjs'),
+          `--config=${path.join(ARTIFACT_DIR, 'electron-builder.yml')}`,
+          ...builderArgs,
+        ],
+        {
+          cwd: GUI_DIR,
+          env: {
+            ...buildEnv,
+            KF_FIRST_PARTY_SOURCE_ROOT: ASSEMBLED_EXTENSIONS,
+          },
+          phase: 'package',
+          event: 'artifact.electron-builder',
+        },
+      );
+
+      console.log(
+        `\n[artifact] output -> ${rel(path.join(ARTIFACT_DIR, 'dist'))}`,
+      );
+    },
+  );
+}
+
+function verifyObservability() {
+  if (!buildchainLogger.path) {
+    return;
+  }
+  const report = verifyBuildchainLogEvents({
+    path: buildchainLogger.path,
+    minEvents: 12,
+    requireComponents: ['kungfu-artifact'],
+    requirePhases: [
+      'prepare',
+      'dependencies',
+      'core',
+      'extensions',
+      'ui',
+      'package',
+    ],
+    requireEvents: [
+      'artifact.dist.start',
+      'artifact.kfx.dependencies.declared',
+      'artifact.dependencies.sync.start',
+      'artifact.core.rebuild.start',
+      'artifact.core.freeze.start',
+      'artifact.electron-builder.start',
+      'artifact.dist.end',
+    ],
+  });
+  if (!report.ok) {
+    throw new Error(
+      `Buildchain observability verification failed: ${report.issues
+        .map((issue) => issue.message)
+        .join('; ')}`,
+    );
+  }
+  console.log(
+    `[artifact] buildchain observability events: ${report.summary.components['kungfu-artifact']?.count ?? 0}`,
+  );
 }
 
 try {
   main();
+  verifyObservability();
 } catch (error) {
   console.error(
     `[artifact] failed: ${error instanceof Error ? error.message : String(error)}`,

--- a/developer/sdk/package.json
+++ b/developer/sdk/package.json
@@ -25,7 +25,7 @@
     "build": "node --check src/sdk.js && node --test tests/*.test.mjs"
   },
   "dependencies": {
-    "@kungfu-tech/buildchain": "2.8.0",
+    "@kungfu-tech/buildchain": "2.8.7",
     "@kungfu-tech/core": "workspace:*",
     "@kungfu-tech/gui": "workspace:*",
     "@kungfu-tech/kfd": "1.0.0-alpha.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,12 +91,16 @@ importers:
       '@kungfu-tech/tui':
         specifier: workspace:*
         version: link:../framework/tui
+    devDependencies:
+      '@kungfu-tech/buildchain':
+        specifier: 2.8.7
+        version: 2.8.7
 
   developer/sdk:
     dependencies:
       '@kungfu-tech/buildchain':
-        specifier: 2.8.0
-        version: 2.8.0
+        specifier: 2.8.7
+        version: 2.8.7
       '@kungfu-tech/core':
         specifier: workspace:*
         version: link:../../framework/core
@@ -1285,10 +1289,13 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@kungfu-tech/buildchain@2.8.0':
-    resolution: {integrity: sha512-xvukZHbaRQNQF+5Bbayd+AF7QkKH/2kJR9YLsckdMnNBm/x2K1gaLYUmpWZL0T8ftVbPFYS5q8yZxVeTr6jjxA==}
+  '@kungfu-tech/buildchain@2.8.7':
+    resolution: {integrity: sha512-w4lczTGoZUVvU3fQ+ZHi/Akk0DDEt8fn6cI91SDEIn07wNSVWyX9CkLN13TjfNqVx9zMzqcy1fZCoiO4j4/tog==}
     engines: {node: '>=22.14.0'}
     hasBin: true
+
+  '@kungfu-tech/kfd@1.0.0-alpha.16':
+    resolution: {integrity: sha512-u2tHV9YRTr3U3hvB979SGX5WXoIPSjAWYk5li/5bOPvDyl3w4JZrf1b8c/CEIJi/vNXlylBUJQ1eLZEpWQlqUw==}
 
   '@kungfu-tech/kfd@1.0.0-alpha.2':
     resolution: {integrity: sha512-LJ/mBkBrgWI8WqOFiJa6Ppz59zuYP/KZxbkLRhg+IwAYjvu4Wkn7cn1OMmwdSRdPU7N6ROlsRlnEkHRa0knR7g==}
@@ -5333,10 +5340,12 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@kungfu-tech/buildchain@2.8.0':
+  '@kungfu-tech/buildchain@2.8.7':
     dependencies:
-      '@kungfu-tech/kfd': 1.0.0-alpha.2
+      '@kungfu-tech/kfd': 1.0.0-alpha.16
       smol-toml: 1.7.0
+
+  '@kungfu-tech/kfd@1.0.0-alpha.16': {}
 
   '@kungfu-tech/kfd@1.0.0-alpha.2': {}
 

--- a/scripts/buildchain-run-kungfu-code.mjs
+++ b/scripts/buildchain-run-kungfu-code.mjs
@@ -33,10 +33,54 @@ function windowsUserToolPathDirs() {
       const home = path.join(usersRoot, entry.name);
       return [
         path.join(home, 'AppData', 'Local', 'Microsoft', 'WinGet', 'Links'),
+        path.join(home, 'AppData', 'Local', 'Microsoft', 'WinGet', 'Packages'),
         path.join(home, '.local', 'bin'),
         path.join(home, '.cargo', 'bin'),
+        path.join(home, 'scoop', 'shims'),
       ];
     });
+}
+
+function findExecutableDirs(roots, executableNames, options = {}) {
+  const maxDepth = options.maxDepth ?? 4;
+  const maxMatches = options.maxMatches ?? 16;
+  const matches = new Set();
+  const wanted = new Set(executableNames.map((name) => name.toLowerCase()));
+  const skipDirs = new Set([
+    '.git',
+    'node_modules',
+    'Package Cache',
+    'Temp',
+    'tmp',
+  ]);
+  const queue = roots
+    .filter((root) => root && fs.existsSync(root))
+    .map((root) => ({ dir: root, depth: 0 }));
+
+  while (queue.length && matches.size < maxMatches) {
+    const { dir, depth } = queue.shift();
+    let entries = [];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isFile() && wanted.has(entry.name.toLowerCase())) {
+        matches.add(dir);
+        if (matches.size >= maxMatches) break;
+      } else if (
+        entry.isDirectory() &&
+        depth < maxDepth &&
+        !skipDirs.has(entry.name)
+      ) {
+        queue.push({ dir: fullPath, depth: depth + 1 });
+      }
+    }
+  }
+
+  return [...matches];
 }
 
 function windowsToolPathDirs(env) {
@@ -45,12 +89,18 @@ function windowsToolPathDirs(env) {
   }
   const home = env.USERPROFILE || env.HOME;
   const localAppData = env.LOCALAPPDATA;
-  return existingDirs([
+  const candidateDirs = [
     localAppData && path.join(localAppData, 'Microsoft', 'WinGet', 'Links'),
+    localAppData && path.join(localAppData, 'Microsoft', 'WinGet', 'Packages'),
     home && path.join(home, '.local', 'bin'),
     home && path.join(home, '.cargo', 'bin'),
+    home && path.join(home, 'scoop', 'shims'),
     ...windowsUserToolPathDirs(),
-  ]);
+  ];
+  return [
+    ...existingDirs(candidateDirs),
+    ...findExecutableDirs(candidateDirs, ['uv.exe', 'uvx.exe']),
+  ];
 }
 
 function withPathPrefixes(env, dirs) {


### PR DESCRIPTION
## Summary
- upgrade the SDK and artifact build dependency to the latest Buildchain release package, @kungfu-tech/buildchain@2.8.7
- instrument artifact/scripts/dist.mjs with Buildchain toolkit lifecycle spans and event verification
- keep no-optional Buildchain source builds working by installing current-platform libnode and Rollup native packages under .buildchain and exposing them through NODE_PATH
- broaden Windows runner tool discovery for uv/uvx across WinGet package directories and Scoop shims

## Validation
- node --check artifact/scripts/dist.mjs
- node --check scripts/buildchain-run-kungfu-code.mjs
- ./kungfu-code exec biome check artifact/scripts/dist.mjs scripts/buildchain-run-kungfu-code.mjs artifact/package.json developer/sdk/package.json
- ./kungfu-code run check:types
- CI=true ./kungfu-code install --frozen-lockfile --no-optional --lockfile-only
- Buildchain logging smoke with BUILDCHAIN_LOG_PATH
- Rollup platform package resolution smoke

## Alpha PR handling
- Closed #333 after its single allowed Build run failed on Windows and Linux
- Cancelled the remaining queued jobs for run 28854374922 before opening this dev fix PR