### PR TITLE
ci: bootstrap uv for buildchain windows

### DIFF
--- a/artifact/package.json
+++ b/artifact/package.json
@@ -48,6 +48,6 @@
     "url": "https://github.com/kungfu-systems/kungfu.git"
   },
   "devDependencies": {
-    "@kungfu-tech/buildchain": "2.8.7"
+    "@kungfu-tech/buildchain": "2.8.8"
   }
 }

--- a/developer/sdk/package.json
+++ b/developer/sdk/package.json
@@ -25,7 +25,7 @@
     "build": "node --check src/sdk.js && node --test tests/*.test.mjs"
   },
   "dependencies": {
-    "@kungfu-tech/buildchain": "2.8.7",
+    "@kungfu-tech/buildchain": "2.8.8",
     "@kungfu-tech/core": "workspace:*",
     "@kungfu-tech/gui": "workspace:*",
     "@kungfu-tech/kfd": "1.0.0-alpha.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,14 +93,14 @@ importers:
         version: link:../framework/tui
     devDependencies:
       '@kungfu-tech/buildchain':
-        specifier: 2.8.7
-        version: 2.8.7
+        specifier: 2.8.8
+        version: 2.8.8
 
   developer/sdk:
     dependencies:
       '@kungfu-tech/buildchain':
-        specifier: 2.8.7
-        version: 2.8.7
+        specifier: 2.8.8
+        version: 2.8.8
       '@kungfu-tech/core':
         specifier: workspace:*
         version: link:../../framework/core
@@ -1289,8 +1289,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@kungfu-tech/buildchain@2.8.7':
-    resolution: {integrity: sha512-w4lczTGoZUVvU3fQ+ZHi/Akk0DDEt8fn6cI91SDEIn07wNSVWyX9CkLN13TjfNqVx9zMzqcy1fZCoiO4j4/tog==}
+  '@kungfu-tech/buildchain@2.8.8':
+    resolution: {integrity: sha512-YI2/6r43DMG6tgQXrsIRcX0bU7w4epqTVmfX6a7Tqc7dstynqFBLK0PJHDZgeFBvRqZ3y/z4rbz82lqxb/iQBg==}
     engines: {node: '>=22.14.0'}
     hasBin: true
 
@@ -5340,7 +5340,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@kungfu-tech/buildchain@2.8.7':
+  '@kungfu-tech/buildchain@2.8.8':
     dependencies:
       '@kungfu-tech/kfd': 1.0.0-alpha.16
       smol-toml: 1.7.0

--- a/scripts/buildchain-run-kungfu-code.mjs
+++ b/scripts/buildchain-run-kungfu-code.mjs
@@ -113,6 +113,88 @@ function withPathPrefixes(env, dirs) {
   };
 }
 
+function commandAvailable(command, args, env) {
+  const result = spawnSync(command, args, {
+    cwd: repoRoot,
+    env,
+    stdio: 'ignore',
+    shell: process.platform === 'win32',
+  });
+  return result.status === 0;
+}
+
+function powershellCommand() {
+  for (const command of ['pwsh.exe', 'powershell.exe']) {
+    if (
+      commandAvailable(
+        command,
+        ['-NoProfile', '-Command', '$PSVersionTable.PSVersion.ToString()'],
+        process.env,
+      )
+    ) {
+      return command;
+    }
+  }
+  return '';
+}
+
+function psSingleQuoted(value) {
+  return `'${value.replace(/'/g, "''")}'`;
+}
+
+function ensureWindowsUv(env) {
+  if (
+    process.platform !== 'win32' ||
+    commandAvailable('uv', ['--version'], env)
+  ) {
+    return env;
+  }
+
+  const installDir = path.join(repoRoot, '.buildchain', 'uv');
+  fs.mkdirSync(installDir, { recursive: true });
+  const ps = powershellCommand();
+  if (!ps) {
+    throw new Error(
+      'uv not found and PowerShell is unavailable to bootstrap it',
+    );
+  }
+
+  console.error(`[buildchain-run] uv not found; installing to ${installDir}`);
+  const result = spawnSync(
+    ps,
+    [
+      '-NoProfile',
+      '-ExecutionPolicy',
+      'Bypass',
+      '-Command',
+      [
+        "$ErrorActionPreference = 'Stop'",
+        `$env:UV_INSTALL_DIR = ${psSingleQuoted(installDir)}`,
+        "$env:UV_UNMANAGED_INSTALL = '1'",
+        'irm https://astral.sh/uv/install.ps1 | iex',
+      ].join('; '),
+    ],
+    {
+      cwd: repoRoot,
+      env,
+      stdio: 'inherit',
+    },
+  );
+  if (result.status !== 0) {
+    throw new Error(
+      `uv bootstrap failed with exit ${result.status ?? 'signal'}`,
+    );
+  }
+
+  const nextEnv = withPathPrefixes(env, [installDir]);
+  if (!commandAvailable('uv', ['--version'], nextEnv)) {
+    throw new Error(
+      `uv bootstrap did not produce a runnable uv in ${installDir}`,
+    );
+  }
+  return nextEnv;
+}
+
 function createPnpmShimDir() {
   const shimDir = fs.mkdtempSync(
     path.join(os.tmpdir(), 'kungfu-buildchain-pnpm-'),
@@ -135,10 +217,11 @@ function createPnpmShimDir() {
   return shimDir;
 }
 
-const env = withPathPrefixes(process.env, [
+let env = withPathPrefixes(process.env, [
   createPnpmShimDir(),
   ...windowsToolPathDirs(process.env),
 ]);
+env = ensureWindowsUv(env);
 env.KUNGFU_BUILDCHAIN_NO_OPTIONAL = '1';
 env.KUNGFU_BUILDCHAIN_SOURCE_BUILD = '1';
 const result =

--- a/scripts/no-bash-guard.mjs
+++ b/scripts/no-bash-guard.mjs
@@ -19,6 +19,7 @@ import { fileURLToPath } from 'node:url';
 const SKIP_DIRS = new Set([
   'node_modules',
   '.git',
+  '.buildchain',
   '.venv',
   'build',
   'dist',


### PR DESCRIPTION
## Summary
- upgrade @kungfu-tech/buildchain to the current latest release package, 2.8.8
- bootstrap uv into .buildchain/uv on Windows only when uv is not already available
- keep the bootstrap scoped to the lifecycle wrapper instead of mutating runner-global state
- exclude generated .buildchain runtime files from the no-bash guard used by verify

## Evidence from alpha #336
- Windows now installs libnode and Rollup platform packages but still fails because uv is unavailable on the runner
- Linux builds the AppImage and reports Buildchain observability events, then fails verify because .buildchain/runtime/scripts/check-workflows.sh is generated by Buildchain runtime and should not be scanned as repo source

## Validation
- node --check scripts/buildchain-run-kungfu-code.mjs
- node --check scripts/no-bash-guard.mjs
- node scripts/no-bash-guard.mjs
- ./kungfu-code exec biome check scripts/buildchain-run-kungfu-code.mjs scripts/no-bash-guard.mjs artifact/package.json developer/sdk/package.json
- ./kungfu-code run check:types
- CI=true ./kungfu-code install --frozen-lockfile --no-optional --lockfile-only