### PR TITLE
ci: lock conan for buildchain source builds

### DIFF
--- a/framework/core/pyproject.toml
+++ b/framework/core/pyproject.toml
@@ -24,6 +24,9 @@ dependencies = [
     # (==) because a version bump changes C++ formatting output; an exact pin keeps
     # the result byte-identical across machines instead of the ambient system one.
     "clang-format==20.1.8",
+    # Native build orchestrator. run-conan.js invokes `uv run --frozen conan`;
+    # keep Conan in the locked uv environment instead of relying on runner-global tools.
+    "conan>=2.22,<3.0.0",
     # Regenerate the native pykungfu .pyi stubs as a build step (.gyp/gen-stubs.js
     # after the addon compiles + libnode colocates) so committed stubs/ track the
     # C++ binding instead of drifting. Type-check env uses the committed text stubs.

--- a/framework/core/uv.lock
+++ b/framework/core/uv.lock
@@ -222,6 +222,26 @@ wheels = [
 ]
 
 [[package]]
+name = "conan"
+version = "2.30.0"
+source = { registry = "http://192.168.100.222:3141/root/pypi/+simple/" }
+dependencies = [
+    { name = "colorama" },
+    { name = "distro", marker = "platform_system == 'FreeBSD' or sys_platform == 'linux'" },
+    { name = "fasteners" },
+    { name = "jinja2" },
+    { name = "patch-ng" },
+    { name = "python-dateutil" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "http://192.168.100.222:3141/root/pypi/+f/8ce/e363744b164fc/conan-2.30.0.tar.gz", hash = "sha256:8cee363744b164fc043d0b9bef8db856bd6b27a3c971d9c494441d2aa92794fa" }
+wheels = [
+    { url = "http://192.168.100.222:3141/root/pypi/+f/67a/2e9a6fdc338c9/conan-2.30.0-py3-none-any.whl", hash = "sha256:67a2e9a6fdc338c9bb464a247057a9c259cff3b6cd53d38cd5a3a7ee7c3e4bb6" },
+]
+
+[[package]]
 name = "cryptography"
 version = "48.0.1"
 source = { registry = "http://192.168.100.222:3141/root/pypi/+simple/" }
@@ -276,12 +296,30 @@ wheels = [
 ]
 
 [[package]]
+name = "distro"
+version = "1.9.0"
+source = { registry = "http://192.168.100.222:3141/root/pypi/+simple/" }
+sdist = { url = "http://192.168.100.222:3141/root/pypi/+f/2fa/77c6fd8940f11/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed" }
+wheels = [
+    { url = "http://192.168.100.222:3141/root/pypi/+f/7bf/fd925d65168f8/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2" },
+]
+
+[[package]]
 name = "et-xmlfile"
 version = "2.0.0"
 source = { registry = "http://192.168.100.222:3141/root/pypi/+simple/" }
 sdist = { url = "http://192.168.100.222:3141/root/pypi/+f/dab/3f4764309081c/et_xmlfile-2.0.0.tar.gz", hash = "sha256:dab3f4764309081ce75662649be815c4c9081e88f0837825f90fd28317d4da54" }
 wheels = [
     { url = "http://192.168.100.222:3141/root/pypi/+f/7a9/1720bc7568435/et_xmlfile-2.0.0-py3-none-any.whl", hash = "sha256:7a91720bc756843502c3b7504c77b8fe44217c85c537d85037f0f536151b2caa" },
+]
+
+[[package]]
+name = "fasteners"
+version = "0.20"
+source = { registry = "http://192.168.100.222:3141/root/pypi/+simple/" }
+sdist = { url = "http://192.168.100.222:3141/root/pypi/+f/55d/ce8792a41b56f/fasteners-0.20.tar.gz", hash = "sha256:55dce8792a41b56f727ba6e123fcaee77fd87e638a6863cec00007bfea84c8d8" }
+wheels = [
+    { url = "http://192.168.100.222:3141/root/pypi/+f/942/2c40d1e350e42/fasteners-0.20-py3-none-any.whl", hash = "sha256:9422c40d1e350e4259f509fb2e608d6bc43c0136f79a00db1b49046029d0b3b7" },
 ]
 
 [[package]]
@@ -470,6 +508,18 @@ wheels = [
 ]
 
 [[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "http://192.168.100.222:3141/root/pypi/+simple/" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "http://192.168.100.222:3141/root/pypi/+f/013/7fb05990d35f1/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d" }
+wheels = [
+    { url = "http://192.168.100.222:3141/root/pypi/+f/85e/ce4451f492d0c/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67" },
+]
+
+[[package]]
 name = "jmespath"
 version = "1.1.0"
 source = { registry = "http://192.168.100.222:3141/root/pypi/+simple/" }
@@ -536,6 +586,7 @@ dependencies = [
     { name = "clang-format" },
     { name = "click" },
     { name = "colorama", marker = "os_name == 'nt'" },
+    { name = "conan" },
     { name = "cryptography", marker = "sys_platform == 'linux'" },
     { name = "filelock" },
     { name = "flatbuffers" },
@@ -599,6 +650,7 @@ requires-dist = [
     { name = "clang-format", specifier = "==20.1.8" },
     { name = "click", specifier = "~=8.1.7" },
     { name = "colorama", marker = "os_name == 'nt'", specifier = "==0.4.6" },
+    { name = "conan", specifier = ">=2.22,<3.0.0" },
     { name = "cryptography", marker = "sys_platform == 'linux'", specifier = ">=48.0.1,<49.0.0" },
     { name = "filelock" },
     { name = "flatbuffers", specifier = ">=25.2,<26" },
@@ -693,6 +745,36 @@ dependencies = [
 sdist = { url = "http://192.168.100.222:3141/root/pypi/+f/04a/21681d6fbb623/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49" }
 wheels = [
     { url = "http://192.168.100.222:3141/root/pypi/+f/9f7/ebbcd14fe5949/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "http://192.168.100.222:3141/root/pypi/+simple/" }
+sdist = { url = "http://192.168.100.222:3141/root/pypi/+f/722/695808f4b6457/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698" }
+wheels = [
+    { url = "http://192.168.100.222:3141/root/pypi/+f/e1c/f1972137e83c5/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795" },
+    { url = "http://192.168.100.222:3141/root/pypi/+f/116/bb52f642a37c1/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219" },
+    { url = "http://192.168.100.222:3141/root/pypi/+f/133/a43e73a802c55/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6" },
+    { url = "http://192.168.100.222:3141/root/pypi/+f/ccf/cd093f13f0f0b/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676" },
+    { url = "http://192.168.100.222:3141/root/pypi/+f/509/fa21c6deb7a7a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9" },
+    { url = "http://192.168.100.222:3141/root/pypi/+f/a4a/fe79fb3de0b70/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1" },
+    { url = "http://192.168.100.222:3141/root/pypi/+f/795/e7751525cae07/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc" },
+    { url = "http://192.168.100.222:3141/root/pypi/+f/848/5f406a96febb5/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12" },
+    { url = "http://192.168.100.222:3141/root/pypi/+f/bdd/37121970bfd8b/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed" },
+    { url = "http://192.168.100.222:3141/root/pypi/+f/9a1/abfdc021a1648/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5" },
+    { url = "http://192.168.100.222:3141/root/pypi/+f/7e6/8f88e5b8799aa/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485" },
+    { url = "http://192.168.100.222:3141/root/pypi/+f/218/551f6df4868a8/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73" },
+    { url = "http://192.168.100.222:3141/root/pypi/+f/352/4b778fe5cfb34/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37" },
+    { url = "http://192.168.100.222:3141/root/pypi/+f/4e8/85a3d1efa2ead/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19" },
+    { url = "http://192.168.100.222:3141/root/pypi/+f/870/9b08f4a89aa75/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025" },
+    { url = "http://192.168.100.222:3141/root/pypi/+f/b85/12a91625c9b3d/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6" },
+    { url = "http://192.168.100.222:3141/root/pypi/+f/9b7/9b7a16f7fedff/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f" },
+    { url = "http://192.168.100.222:3141/root/pypi/+f/12c/63dfb4a98206f/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb" },
+    { url = "http://192.168.100.222:3141/root/pypi/+f/8f7/1bc33915be518/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009" },
+    { url = "http://192.168.100.222:3141/root/pypi/+f/69c/0b73548bc525c/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354" },
+    { url = "http://192.168.100.222:3141/root/pypi/+f/1b4/b79e8ebf6b553/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218" },
+    { url = "http://192.168.100.222:3141/root/pypi/+f/ad2/cf8aa28b8c020/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287" },
 ]
 
 [[package]]
@@ -861,6 +943,15 @@ wheels = [
     { url = "http://192.168.100.222:3141/root/pypi/+f/1db/71525a1538b30/pandas-2.2.3-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1db71525a1538b30142094edb9adc10be3f3e176748cd7acc2240c2f2e5aa3a4" },
     { url = "http://192.168.100.222:3141/root/pypi/+f/15c/0e1e02e931161/pandas-2.2.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:15c0e1e02e93116177d29ff83e8b1619c93ddc9c49083f237d4312337a61165d" },
     { url = "http://192.168.100.222:3141/root/pypi/+f/ad5/b65698ab28ed8/pandas-2.2.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:ad5b65698ab28ed8d7f18790a0dc58005c7629f227be9ecc1072aa74c0c1d43a" },
+]
+
+[[package]]
+name = "patch-ng"
+version = "1.19.1"
+source = { registry = "http://192.168.100.222:3141/root/pypi/+simple/" }
+sdist = { url = "http://192.168.100.222:3141/root/pypi/+f/036/a3cc00134ec53/patch_ng-1.19.1.tar.gz", hash = "sha256:036a3cc00134ec53f37e92333958ee75e117f2e62a5ec2b85c7122e5e815c29e" }
+wheels = [
+    { url = "http://192.168.100.222:3141/root/pypi/+f/d45/fd47b3f74b48c/patch_ng-1.19.1-py3-none-any.whl", hash = "sha256:d45fd47b3f74b48c3e336690341876bb26244a077a06f5f7e6e47c19c15c1ca4" },
 ]
 
 [[package]]
@@ -1137,6 +1228,24 @@ source = { registry = "http://192.168.100.222:3141/root/pypi/+simple/" }
 sdist = { url = "http://192.168.100.222:3141/root/pypi/+f/d16/2dc04946d7045/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755" }
 wheels = [
     { url = "http://192.168.100.222:3141/root/pypi/+f/8a1/513379d709975/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "http://192.168.100.222:3141/root/pypi/+simple/" }
+sdist = { url = "http://192.168.100.222:3141/root/pypi/+f/d76/623373421df22/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f" }
+wheels = [
+    { url = "http://192.168.100.222:3141/root/pypi/+f/8da/9669d359f02c0/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8" },
+    { url = "http://192.168.100.222:3141/root/pypi/+f/228/3a07e2c21a2aa/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1" },
+    { url = "http://192.168.100.222:3141/root/pypi/+f/ee2/922902c45ae8c/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c" },
+    { url = "http://192.168.100.222:3141/root/pypi/+f/a33/284e20b78bd4a/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5" },
+    { url = "http://192.168.100.222:3141/root/pypi/+f/0f2/9edc409a63924/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6" },
+    { url = "http://192.168.100.222:3141/root/pypi/+f/f70/57c9a337546ed/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6" },
+    { url = "http://192.168.100.222:3141/root/pypi/+f/eda/16858a3cab07b/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be" },
+    { url = "http://192.168.100.222:3141/root/pypi/+f/d0e/ae10f8159e8fd/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26" },
+    { url = "http://192.168.100.222:3141/root/pypi/+f/790/05a0d97d5ddab/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c" },
+    { url = "http://192.168.100.222:3141/root/pypi/+f/549/8cd1645aa724a/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add Conan 2 to the locked framework/core uv project
- make `uv run --frozen conan ...` reproducible on self-hosted runners instead of relying on runner-global tools

## Validation
- `cd framework/core && uv lock --check`
- `cd framework/core && uv run --frozen conan --version`
- `tmp_conan_home="$(mktemp -d /tmp/kungfu-conan-home.XXXXXX)" && cd framework/core && CONAN_HOME="$tmp_conan_home" uv run --frozen conan profile detect --force`
- `node --check scripts/buildchain-run-kungfu-code.mjs && node --check framework/core/.gyp/run-conan.js`
- `./kungfu-code exec biome check framework/core/pyproject.toml scripts/buildchain-run-kungfu-code.mjs framework/core/.gyp/run-conan.js`
- `./kungfu-code run check:types`

## Alpha build note
PR #338 was closed after its single allowed Build run failed on Windows before native compilation: `uv run --frozen conan profile detect --force` could not find `conan`. This PR fixes forward through dev before opening a fresh alpha PR.