### PR TITLE
docs(readme): add project status badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Kungfu
 
+[![Buildchain Validate](https://github.com/kungfu-systems/kungfu/actions/workflows/buildchain-validate.yml/badge.svg?branch=dev%2Fv4%2Fv4.0)](https://github.com/kungfu-systems/kungfu/actions/workflows/buildchain-validate.yml)
+[![DCO](https://github.com/kungfu-systems/kungfu/actions/workflows/dco.yml/badge.svg)](https://github.com/kungfu-systems/kungfu/actions/workflows/dco.yml)
+[![License: Apache-2.0](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
+![Status: Coming soon](https://img.shields.io/badge/status-coming%20soon-orange.svg)
+![Platforms: macOS | Linux | Windows](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows-lightgrey.svg)
+
 Kungfu is the open-source core behind the Kungfu product direction: a
 local-first, journal-first runtime for recording facts, replaying work, and
 building verifiable agent-facing applications.


### PR DESCRIPTION
## Summary

- Add README badges for Buildchain Validate and DCO status.
- Add compact public metadata badges for Apache-2.0 license, coming-soon product status, and supported platforms.

## Checks

- git diff --check
- README public wording scan
- badge URL HTTP checks
- ./kungfu-code check