### PR TITLE
feat(gui): add integrated window chrome

### DIFF
--- a/framework/gui/src/main/index.ts
+++ b/framework/gui/src/main/index.ts
@@ -22,6 +22,9 @@ import {
   HIDE_CHANNEL,
   SET_BOUNDS_CHANNEL,
   SHOW_CHANNEL,
+  WINDOW_CHROME_CONTROL_CHANNEL,
+  WINDOW_CHROME_GET_CHANNEL,
+  WINDOW_CHROME_STATE_CHANNEL,
 } from '../sandbox/channels';
 import {
   firstPartyManifestPath,
@@ -57,6 +60,61 @@ const bindingPath = path.join(kungfuDir, 'kungfu_electron.node');
 const firstPartySourceRoot =
   process.env.KF_FIRST_PARTY_SOURCE_ROOT ||
   path.join(__dirname, '..', '..', '..', '..', 'extensions');
+
+type WindowChromePlatform = 'darwin' | 'win32' | 'linux' | 'other';
+type WindowChromeMode = 'native' | 'integrated' | 'custom';
+type WindowChromeControl = 'minimize' | 'toggle-maximize' | 'close';
+
+type WindowChromeConfig = {
+  platform: WindowChromePlatform;
+  mode: WindowChromeMode;
+  customControls: boolean;
+  draggable: boolean;
+  trafficLightInset: number;
+  controlInset: number;
+};
+
+function windowChromePlatform(): WindowChromePlatform {
+  if (process.platform === 'darwin') return 'darwin';
+  if (process.platform === 'win32') return 'win32';
+  if (process.platform === 'linux') return 'linux';
+  return 'other';
+}
+
+function windowChromeConfig(): WindowChromeConfig {
+  const platform = windowChromePlatform();
+  if (platform === 'darwin') {
+    return {
+      platform,
+      mode: 'integrated',
+      customControls: false,
+      draggable: true,
+      trafficLightInset: 84,
+      controlInset: 12,
+    };
+  }
+  if (platform === 'win32') {
+    return {
+      platform,
+      mode: 'custom',
+      customControls: true,
+      draggable: true,
+      trafficLightInset: 0,
+      controlInset: 138,
+    };
+  }
+  return {
+    platform,
+    mode: 'native',
+    customControls: false,
+    draggable: false,
+    trafficLightInset: 0,
+    controlInset: 0,
+  };
+}
+
+const windowChrome = windowChromeConfig();
+process.env.KF_WINDOW_CHROME = JSON.stringify(windowChrome);
 
 // Export before the renderer process is created so both processes inherit them.
 // The default runtime home must be writable: userData when packaged (never
@@ -202,6 +260,41 @@ ipcMain.on(DESTROY_CHANNEL, (_event, payload) => {
   manager?.destroyView((payload as { id: string }).id);
 });
 
+function publishWindowChromeState(win: BrowserWindow) {
+  win.webContents.send(WINDOW_CHROME_STATE_CHANNEL, {
+    maximized: win.isMaximized(),
+    fullscreen: win.isFullScreen(),
+  });
+}
+
+ipcMain.handle(WINDOW_CHROME_GET_CHANNEL, (event) => {
+  const win = BrowserWindow.fromWebContents(event.sender);
+  return {
+    ...windowChrome,
+    maximized: win?.isMaximized() ?? false,
+    fullscreen: win?.isFullScreen() ?? false,
+  };
+});
+
+ipcMain.handle(WINDOW_CHROME_CONTROL_CHANNEL, (event, payload) => {
+  const win = BrowserWindow.fromWebContents(event.sender);
+  if (!win) return { ok: false };
+  const control = (payload as { control?: WindowChromeControl }).control;
+  if (control === 'minimize') {
+    win.minimize();
+  } else if (control === 'toggle-maximize') {
+    if (win.isMaximized()) win.unmaximize();
+    else win.maximize();
+  } else if (control === 'close') {
+    win.close();
+  }
+  return {
+    ok: true,
+    maximized: win.isMaximized(),
+    fullscreen: win.isFullScreen(),
+  };
+});
+
 // Application menu with the VS Code-style "Install 'kungfu' Command in PATH"
 // action, so a real user who installed Kungfu.app can use `kungfu` in a shell.
 function buildMenu() {
@@ -275,6 +368,11 @@ function createWindow() {
     width: 1280,
     height: 800,
     show: false,
+    frame: windowChrome.mode !== 'custom',
+    titleBarStyle:
+      windowChrome.mode === 'integrated' ? 'hiddenInset' : 'default',
+    trafficLightPosition:
+      windowChrome.platform === 'darwin' ? { x: 14, y: 14 } : undefined,
     backgroundColor: '#1e1e1e',
     webPreferences: {
       // Moat: in-process zero-copy access to journal/state requires
@@ -285,6 +383,11 @@ function createWindow() {
     },
   });
   shellWindow = win;
+
+  win.on('maximize', () => publishWindowChromeState(win));
+  win.on('unmaximize', () => publishWindowChromeState(win));
+  win.on('enter-full-screen', () => publishWindowChromeState(win));
+  win.on('leave-full-screen', () => publishWindowChromeState(win));
 
   // The trusted renderer holds the real capabilities and runs the capability
   // host; this manager embeds sandboxed views and relays their invokes to it.

--- a/framework/gui/src/renderer/src/main.tsx
+++ b/framework/gui/src/renderer/src/main.tsx
@@ -32,6 +32,9 @@ import {
   SESSION_WINDOW_OPEN_CHANNEL,
   SESSION_WINDOW_RESTORE_CHANNEL,
   SESSION_WINDOW_SNAPSHOT_CHANNEL,
+  WINDOW_CHROME_CONTROL_CHANNEL,
+  WINDOW_CHROME_GET_CHANNEL,
+  WINDOW_CHROME_STATE_CHANNEL,
 } from '../../sandbox/channels';
 import {
   loadKungfuConfig,
@@ -214,6 +217,290 @@ function notificationId(): string {
   );
 }
 
+type WindowChromeControl = 'minimize' | 'toggle-maximize' | 'close';
+type WindowChromeConfig = {
+  platform: 'darwin' | 'win32' | 'linux' | 'other';
+  mode: 'native' | 'integrated' | 'custom';
+  customControls: boolean;
+  draggable: boolean;
+  trafficLightInset: number;
+  controlInset: number;
+  maximized: boolean;
+  fullscreen: boolean;
+};
+type ElectronChromeStyle = React.CSSProperties & {
+  WebkitAppRegion?: 'drag' | 'no-drag';
+};
+
+const defaultWindowChrome: WindowChromeConfig = {
+  platform: 'other',
+  mode: 'native',
+  customControls: false,
+  draggable: false,
+  trafficLightInset: 0,
+  controlInset: 0,
+  maximized: false,
+  fullscreen: false,
+};
+
+function readWindowChromeEnv(): WindowChromeConfig {
+  try {
+    const raw = window.process?.env?.KF_WINDOW_CHROME;
+    if (!raw) return defaultWindowChrome;
+    return { ...defaultWindowChrome, ...JSON.parse(raw) };
+  } catch {
+    return defaultWindowChrome;
+  }
+}
+
+function useWindowChrome(): [
+  WindowChromeConfig,
+  (control: WindowChromeControl) => void,
+] {
+  const [chrome, setChrome] =
+    React.useState<WindowChromeConfig>(readWindowChromeEnv);
+  React.useEffect(() => {
+    type ChromeIpc = {
+      invoke: (channel: string, payload?: unknown) => Promise<unknown>;
+      on: (
+        channel: string,
+        listener: (event: unknown, payload: unknown) => void,
+      ) => void;
+      removeListener: (
+        channel: string,
+        listener: (event: unknown, payload: unknown) => void,
+      ) => void;
+    };
+    let ipc: ChromeIpc | null = null;
+    try {
+      ipc = (window.require('electron') as { ipcRenderer: ChromeIpc })
+        .ipcRenderer;
+    } catch {
+      ipc = null;
+    }
+    if (!ipc) return;
+    void ipc.invoke(WINDOW_CHROME_GET_CHANNEL).then((next) => {
+      setChrome((current) => ({ ...current, ...(next as object) }));
+    });
+    const handler = (_event: unknown, payload: unknown) => {
+      setChrome((current) => ({ ...current, ...(payload as object) }));
+    };
+    ipc.on(WINDOW_CHROME_STATE_CHANNEL, handler);
+    return () => ipc?.removeListener(WINDOW_CHROME_STATE_CHANNEL, handler);
+  }, []);
+
+  const control = React.useCallback((next: WindowChromeControl) => {
+    try {
+      const ipc = (
+        window.require('electron') as {
+          ipcRenderer: {
+            invoke: (channel: string, payload: unknown) => Promise<unknown>;
+          };
+        }
+      ).ipcRenderer;
+      void ipc
+        .invoke(WINDOW_CHROME_CONTROL_CHANNEL, { control: next })
+        .then((state) =>
+          setChrome((current) => ({ ...current, ...(state as object) })),
+        );
+    } catch {
+      // Browser previews have no Electron window to control.
+    }
+  }, []);
+
+  return [chrome, control];
+}
+
+function ShellTitleBar({
+  chrome,
+  activeTitle,
+  commandText,
+  commandOptions,
+  settingsOpen,
+  onCommandChange,
+  onCommandSubmit,
+  onOpenSettings,
+  onWindowControl,
+}: {
+  chrome: WindowChromeConfig;
+  activeTitle: string;
+  commandText: string;
+  commandOptions: { id: string; title: string }[];
+  settingsOpen: boolean;
+  onCommandChange: (value: string) => void;
+  onCommandSubmit: () => void;
+  onOpenSettings: () => void;
+  onWindowControl: (control: WindowChromeControl) => void;
+}) {
+  const dragRegion: ElectronChromeStyle = {
+    WebkitAppRegion: chrome.draggable ? 'drag' : undefined,
+  };
+  const interactiveRegion: ElectronChromeStyle = {
+    WebkitAppRegion: 'no-drag',
+  };
+  const leftInset =
+    chrome.mode === 'integrated' ? Math.max(84, chrome.trafficLightInset) : 12;
+  const rightInset = chrome.customControls
+    ? Math.max(138, chrome.controlInset)
+    : 12;
+  const controlButton = (
+    control: WindowChromeControl,
+    label: string,
+    ariaLabel: string,
+    danger = false,
+  ) => (
+    <button
+      type="button"
+      aria-label={ariaLabel}
+      onClick={() => onWindowControl(control)}
+      style={{
+        ...interactiveRegion,
+        width: 46,
+        height: 34,
+        border: 'none',
+        borderRadius: 0,
+        cursor: 'pointer',
+        background: 'transparent',
+        color: danger ? '#ffffff' : '#cccccc',
+        fontSize: 14,
+      }}
+      onMouseEnter={(event) => {
+        event.currentTarget.style.background = danger ? '#c42b1c' : '#343434';
+      }}
+      onMouseLeave={(event) => {
+        event.currentTarget.style.background = 'transparent';
+      }}
+    >
+      {label}
+    </button>
+  );
+
+  return (
+    <header
+      style={{
+        ...dragRegion,
+        height: 42,
+        flexShrink: 0,
+        display: 'grid',
+        gridTemplateColumns: `${leftInset}px minmax(160px, 1fr) auto ${rightInset}px`,
+        alignItems: 'center',
+        background: '#1e1e1e',
+        borderBottom: '1px solid #2d2d2d',
+        userSelect: 'none',
+      }}
+    >
+      <div />
+      <div
+        style={{
+          minWidth: 0,
+          display: 'grid',
+          gridTemplateColumns: 'minmax(120px, 220px) minmax(180px, 520px)',
+          alignItems: 'center',
+          gap: 12,
+        }}
+      >
+        <div
+          title={activeTitle}
+          style={{
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+            fontSize: 12,
+            color: '#9cdcfe',
+            fontWeight: 600,
+          }}
+        >
+          Kungfu
+        </div>
+        <form
+          onSubmit={(event) => {
+            event.preventDefault();
+            onCommandSubmit();
+          }}
+          style={{
+            ...interactiveRegion,
+            minWidth: 0,
+            display: 'flex',
+            alignItems: 'center',
+          }}
+        >
+          <input
+            aria-label="Search views"
+            list="kf-shell-command-options"
+            value={commandText}
+            onChange={(event) => onCommandChange(event.target.value)}
+            placeholder="Search"
+            style={{
+              width: '100%',
+              height: 26,
+              border: '1px solid #3c3c3c',
+              borderRadius: 6,
+              boxSizing: 'border-box',
+              background: '#252526',
+              color: '#cccccc',
+              padding: '0 10px',
+              outline: 'none',
+              fontSize: 12,
+            }}
+          />
+          <datalist id="kf-shell-command-options">
+            {commandOptions.map((option) => (
+              <option key={option.id} value={option.title} />
+            ))}
+          </datalist>
+        </form>
+      </div>
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'flex-end',
+          gap: 6,
+          paddingRight: 8,
+        }}
+      >
+        <button
+          type="button"
+          aria-label="Open settings"
+          onClick={onOpenSettings}
+          style={{
+            ...interactiveRegion,
+            ...mono,
+            width: 30,
+            height: 28,
+            border: '1px solid #3c3c3c',
+            borderRadius: 6,
+            cursor: 'pointer',
+            background: settingsOpen ? '#04395e' : '#252526',
+            color: settingsOpen ? '#9cdcfe' : '#cccccc',
+            fontSize: 16,
+            lineHeight: '24px',
+          }}
+        >
+          ⚙
+        </button>
+      </div>
+      <div
+        style={{
+          ...interactiveRegion,
+          height: '100%',
+          display: chrome.customControls ? 'flex' : 'none',
+          alignItems: 'stretch',
+          justifyContent: 'flex-end',
+        }}
+      >
+        {controlButton('minimize', '—', 'Minimize window')}
+        {controlButton(
+          'toggle-maximize',
+          chrome.maximized ? '❐' : '□',
+          chrome.maximized ? 'Restore window' : 'Maximize window',
+        )}
+        {controlButton('close', '×', 'Close window', true)}
+      </div>
+    </header>
+  );
+}
+
 function App() {
   const [runtime] = React.useState(bootRuntime);
   const [loaded] = React.useState<KfxLoadResult>(() =>
@@ -235,6 +522,8 @@ function App() {
   );
   const [params, setParams] = React.useState<Record<string, string>>({});
   const [settingsOpen, setSettingsOpen] = React.useState(false);
+  const [commandText, setCommandText] = React.useState('');
+  const [windowChrome, controlWindow] = useWindowChrome();
   const [config, setConfig] = React.useState<KungfuResolvedConfig | null>(null);
   const [configError, setConfigError] = React.useState('');
   const [masterLive, setMasterLive] = React.useState(
@@ -578,6 +867,29 @@ function App() {
     group.push(entry);
     suiteGroups.set(entry.suite, group);
   }
+  const commandOptions = enabled.map((entry) => ({
+    id: entry.id,
+    title: entry.title,
+  }));
+  const submitCommand = React.useCallback(() => {
+    const query = commandText.trim().toLowerCase();
+    if (!query) return;
+    const match =
+      enabled.find((entry) => entry.title.toLowerCase() === query) ??
+      enabled.find((entry) => entry.id.toLowerCase() === query) ??
+      enabled.find((entry) => entry.title.toLowerCase().includes(query)) ??
+      enabled.find((entry) => entry.id.toLowerCase().includes(query));
+    if (!match) {
+      showNotification({
+        level: 'info',
+        title: 'No matching view',
+        message: commandText,
+      });
+      return;
+    }
+    openKfx(match.id);
+    setCommandText('');
+  }, [commandText, enabled, openKfx, showNotification]);
 
   const systemStatusItems: StatusBarItem[] = [
     {
@@ -949,7 +1261,7 @@ function App() {
   const chromeBodyStyle = {
     flex: 1,
     minHeight: 0,
-    padding: '16px 16px 12px',
+    padding: '14px 16px 12px',
     boxSizing: 'border-box',
     display: 'flex',
     flexDirection: 'column',
@@ -959,39 +1271,18 @@ function App() {
 
   return (
     <div style={appStyle}>
+      <ShellTitleBar
+        chrome={windowChrome}
+        activeTitle={activeKfx?.title ?? 'Kungfu'}
+        commandText={commandText}
+        commandOptions={commandOptions}
+        settingsOpen={settingsOpen}
+        onCommandChange={setCommandText}
+        onCommandSubmit={submitCommand}
+        onOpenSettings={() => setSettingsOpen(true)}
+        onWindowControl={controlWindow}
+      />
       <div style={chromeBodyStyle}>
-        <header
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: 16,
-            flexShrink: 0,
-          }}
-        >
-          <h1 style={{ fontSize: 16, fontWeight: 600, margin: 0 }}>
-            Kungfu v4 reference app
-          </h1>
-          <button
-            type="button"
-            aria-label="Open settings"
-            onClick={() => setSettingsOpen(true)}
-            style={{
-              ...mono,
-              marginLeft: 'auto',
-              width: 30,
-              height: 30,
-              border: '1px solid #3c3c3c',
-              borderRadius: 6,
-              cursor: 'pointer',
-              background: settingsOpen ? '#04395e' : '#252526',
-              color: settingsOpen ? '#9cdcfe' : '#cccccc',
-              fontSize: 16,
-              lineHeight: '26px',
-            }}
-          >
-            ⚙
-          </button>
-        </header>
         {runtime.ok ? (
           <div
             style={{

--- a/framework/gui/src/sandbox/channels.ts
+++ b/framework/gui/src/sandbox/channels.ts
@@ -32,3 +32,9 @@ export const SESSION_WINDOW_OPEN_CHANNEL = 'kf-session-window:open';
 export const SESSION_WINDOW_RESTORE_CHANNEL = 'kf-session-window:restore';
 export const SESSION_WINDOW_CLOSE_CHANNEL = 'kf-session-window:close';
 export const SESSION_WINDOW_SNAPSHOT_CHANNEL = 'kf-session-window:snapshot';
+
+// shell renderer <-> main: narrow window chrome bridge. The renderer owns the
+// custom titlebar UI; main owns native BrowserWindow state and controls.
+export const WINDOW_CHROME_GET_CHANNEL = 'kf-window-chrome:get';
+export const WINDOW_CHROME_CONTROL_CHANNEL = 'kf-window-chrome:control';
+export const WINDOW_CHROME_STATE_CHANNEL = 'kf-window-chrome:state';


### PR DESCRIPTION
## Summary
- add a shared renderer titlebar for Electron GUI shell chrome
- use macOS hidden inset titlebar with traffic-light safe area
- use Windows custom frame controls and keep Linux on conservative native chrome
- add a command/search entry that opens enabled KFX views by id or title

## Validation
- ./kungfu-code --filter @kungfu-tech/gui run build
- ./kungfu-code check
- ./kungfu-code build
- ./kungfu-code product gui dev (macOS visual smoke confirmed)

## Notes
- Windows and Linux behavior is implemented by platform branches but only build-validated from macOS in this pass.