### PR TITLE
ci: fix windows vcvars bootstrap

### DIFF
--- a/scripts/buildchain-run-kungfu-code.mjs
+++ b/scripts/buildchain-run-kungfu-code.mjs
@@ -268,8 +268,14 @@ function parseWindowsSetOutput(stdout) {
   return env;
 }
 
+function windowsMsvcAvailable(env) {
+  return (
+    process.platform === 'win32' && commandAvailable('where.exe', ['cl'], env)
+  );
+}
+
 function ensureWindowsMsvcEnv(env) {
-  if (process.platform !== 'win32' || commandAvailable('cl', ['/Bv'], env)) {
+  if (process.platform !== 'win32' || windowsMsvcAvailable(env)) {
     return env;
   }
 
@@ -283,7 +289,7 @@ function ensureWindowsMsvcEnv(env) {
   console.error(`[buildchain-run] cl.exe not found; loading ${vcvars}`);
   const result = spawnSync(
     'cmd.exe',
-    ['/d', '/s', '/c', `"${vcvars}" x64 >nul && set`],
+    ['/d', '/c', `call "${vcvars}" x64 >nul && set`],
     {
       cwd: repoRoot,
       env,
@@ -298,7 +304,7 @@ function ensureWindowsMsvcEnv(env) {
   }
 
   const nextEnv = { ...env, ...parseWindowsSetOutput(result.stdout) };
-  if (!commandAvailable('cl', ['/Bv'], nextEnv)) {
+  if (!windowsMsvcAvailable(nextEnv)) {
     throw new Error(
       'MSVC environment bootstrap did not produce cl.exe in PATH',
     );


### PR DESCRIPTION
Fix the Windows Buildchain lifecycle wrapper after PR #348 proved the install lifecycle fails before the build step.

Changes:
- invoke vcvars64.bat through `cmd /d /c call "..." x64 >nul && set` so paths with spaces are handled correctly
- detect MSVC availability with `where.exe cl` instead of `cl /Bv`, because `cl /Bv` can locate the compiler but still exits non-zero without source files

Validation:
- `node --check scripts/buildchain-run-kungfu-code.mjs`
- `./kungfu-code exec biome check scripts/buildchain-run-kungfu-code.mjs`
- `./kungfu-code run check:types`
- `git diff --check`
- DARKHERO read-only Windows smoke: `call vcvars64.bat ... && where cl` resolves cl.exe successfully
