### PR TITLE
ci: use verbatim cmd args for vcvars

### DIFF
--- a/scripts/buildchain-run-kungfu-code.mjs
+++ b/scripts/buildchain-run-kungfu-code.mjs
@@ -289,12 +289,13 @@ function ensureWindowsMsvcEnv(env) {
   console.error(`[buildchain-run] cl.exe not found; loading ${vcvars}`);
   const result = spawnSync(
     'cmd.exe',
-    ['/d', '/c', `call "${vcvars}" x64 >nul && set`],
+    ['/d', '/s', '/c', `""${vcvars}" x64 >nul && set"`],
     {
       cwd: repoRoot,
       env,
       encoding: 'utf8',
       stdio: ['ignore', 'pipe', 'inherit'],
+      windowsVerbatimArguments: true,
     },
   );
   if (result.status !== 0) {


### PR DESCRIPTION
Fix the second Windows MSVC bootstrap issue seen in alpha PR #351.

PR #350 changed the command to `call "...vcvars64.bat"`, but Node's Windows argument quoting still passed escaped quotes (`\"...\"`) to `cmd.exe` when using the normal args array. This PR uses the tested `cmd.exe /d /s /c ""<vcvars>" x64 >nul && set"` form with `windowsVerbatimArguments: true` so `cmd.exe` receives the batch path quotes correctly.

Validation:
- `node --check scripts/buildchain-run-kungfu-code.mjs`
- `./kungfu-code exec biome check scripts/buildchain-run-kungfu-code.mjs`
- `./kungfu-code run check:types`
- `git diff --check`
- DARKHERO Node smoke with identical `spawnSync` arguments resolves `cl.exe` successfully
