### PR TITLE
ci: rename windows frozen cli executable

### DIFF
--- a/framework/core/.gyp/run-freeze.js
+++ b/framework/core/.gyp/run-freeze.js
@@ -285,7 +285,7 @@ function freezeNuitka(bt) {
     const kungfuPath = path.join(distKfc, 'kungfu');
     if (fs.existsSync(binPath)) fs.renameSync(binPath, kungfuPath);
   } else {
-    const exePath = path.join(distKfc, 'kungfu.exe');
+    const exePath = path.join(distKfc, 'kungfu_cli.exe');
     const kungfuExe = path.join(distKfc, 'kungfu.exe');
     if (fs.existsSync(exePath)) fs.renameSync(exePath, kungfuExe);
   }


### PR DESCRIPTION
Fix the Windows artifact build failure seen in alpha PR #354.

Windows Nuitka successfully produced `framework/core/build/kungfu-nuitka/kungfu_cli.dist/kungfu_cli.exe`, but `run-freeze.js` accidentally looked for `kungfu.exe` and renamed it to itself. The artifact build then failed because `framework/core/dist/kungfu/kungfu.exe` was never created.

This PR renames `kungfu_cli.exe` to `kungfu.exe` on Windows, matching the existing comment and the artifact/runtime expectation.

Validation:
- `node --check framework/core/.gyp/run-freeze.js`
- `./kungfu-code exec biome check framework/core/.gyp/run-freeze.js`
- `./kungfu-code run check:types`
- `git diff --check`
