### PR TITLE
ci: run buildchain windows lifecycle on pinned node

### DIFF
--- a/scripts/buildchain-run-kungfu-code.mjs
+++ b/scripts/buildchain-run-kungfu-code.mjs
@@ -388,6 +388,30 @@ function createPnpmShimDir() {
   return shimDir;
 }
 
+function runWindowsPnpm(args, env) {
+  if (commandAvailable('fnm', ['--version'], env)) {
+    spawnSync('fnm', ['install'], {
+      cwd: repoRoot,
+      env,
+      stdio: 'ignore',
+      shell: true,
+    });
+    return spawnSync('fnm', ['exec', '--', 'corepack.cmd', 'pnpm', ...args], {
+      cwd: repoRoot,
+      env,
+      stdio: 'inherit',
+      shell: true,
+    });
+  }
+
+  return spawnSync('corepack.cmd', ['pnpm', ...args], {
+    cwd: repoRoot,
+    env,
+    stdio: 'inherit',
+    shell: true,
+  });
+}
+
 let env = withPathPrefixes(process.env, [
   createPnpmShimDir(),
   ...windowsToolPathDirs(process.env),
@@ -398,12 +422,7 @@ env.KUNGFU_BUILDCHAIN_NO_OPTIONAL = '1';
 env.KUNGFU_BUILDCHAIN_SOURCE_BUILD = '1';
 const result =
   process.platform === 'win32'
-    ? spawnSync('corepack.cmd', ['pnpm', ...argv], {
-        cwd: repoRoot,
-        env,
-        stdio: 'inherit',
-        shell: true,
-      })
+    ? runWindowsPnpm(argv, env)
     : spawnSync(path.join(repoRoot, 'kungfu-code'), argv, {
         cwd: repoRoot,
         env,


### PR DESCRIPTION
## Summary
- run Windows Buildchain lifecycle pnpm commands through `fnm exec` when available
- keep fallback to `corepack.cmd pnpm` for environments without fnm

## Why
Windows Buildchain was invoking pnpm with the Actions runtime Node, so `scripts/verify.mjs` failed the pinned `.node-version` check even though the artifact build had completed.

## Verification
- `node --check scripts/buildchain-run-kungfu-code.mjs`
- `./kungfu-code exec biome check scripts/buildchain-run-kungfu-code.mjs`
- `./kungfu-code run check:types`
- `git diff --check`
- DARKHERO smoke: `fnm exec -- node -p process.version` -> `v22.22.3`; `fnm exec -- corepack.cmd pnpm --version` -> `11.7.0`
