### PR TITLE
chore: merge applicable feature backlog

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,4 @@
+self-hosted-runner:
+  labels:
+    - kungfu-build-v4
+    - kungfu-build-v4-linux-x64

--- a/.github/workflows/runner-three-host-smoke.yml
+++ b/.github/workflows/runner-three-host-smoke.yml
@@ -23,8 +23,6 @@ jobs:
       - kungfu-build-v4-macos-arm64
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
-
       - name: Verify runner route
         shell: bash
         run: |
@@ -58,7 +56,6 @@ jobs:
           test -d /Users/gha-runner/actions-runner/kungfu-systems/_work
           test -d /Users/gha-runner/Worktrees/kungfu
           test -d /Users/gha-runner/.cache/kungfu
-          test -f ./kungfu-code || test -x ./kungfu-code
           df -Pk /Users/gha-runner | awk 'NR==2 { if ($4 < 120*1024*1024) exit 1; print }'
 
       - name: Write smoke summary
@@ -86,8 +83,6 @@ jobs:
       - kungfu-build-v4-windows-x64
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
-
       - name: Verify runner route
         shell: pwsh
         run: |
@@ -125,7 +120,6 @@ jobs:
           )) {
             if (-not (Test-Path -LiteralPath $path -PathType Container)) { throw "missing path $path" }
           }
-          if (-not (Test-Path -LiteralPath ".\kungfu-code.cmd" -PathType Leaf)) { throw "missing kungfu-code.cmd" }
           $free = (Get-CimInstance Win32_LogicalDisk -Filter "DeviceID='C:'").FreeSpace
           if ($free -lt 107374182400) { throw "low disk free bytes=$free" }
           $free
@@ -153,8 +147,6 @@ jobs:
       - kungfu-build
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
-
       - name: Verify runner route
         shell: pwsh
         run: |
@@ -192,7 +184,6 @@ jobs:
           )) {
             if (-not (Test-Path -LiteralPath $path -PathType Container)) { throw "missing path $path" }
           }
-          if (-not (Test-Path -LiteralPath ".\kungfu-code.cmd" -PathType Leaf)) { throw "missing kungfu-code.cmd" }
           $free = (Get-CimInstance Win32_LogicalDisk -Filter "DeviceID='C:'").FreeSpace
           if ($free -lt 107374182400) { throw "low disk free bytes=$free" }
           $free

--- a/.github/workflows/runner-three-host-smoke.yml
+++ b/.github/workflows/runner-three-host-smoke.yml
@@ -4,6 +4,9 @@ name: Runner - Three Host Smoke
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - feature/runner-smoke-three-hosts
 
 permissions:
   contents: read

--- a/.github/workflows/runner-three-host-smoke.yml
+++ b/.github/workflows/runner-three-host-smoke.yml
@@ -1,0 +1,207 @@
+# SPDX-License-Identifier: Apache-2.0
+
+name: Runner - Three Host Smoke
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  mac-studio:
+    name: mac-studio smoke
+    runs-on:
+      - self-hosted
+      - macOS
+      - ARM64
+      - mac-studio
+      - kungfu-build
+      - kungfu-build-v4-macos-arm64
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Verify runner route
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "${RUNNER_NAME}" = "mac-studio-kungfu-systems"
+          test "${RUNNER_OS}" = "macOS"
+          test "${RUNNER_ARCH}" = "ARM64"
+          whoami
+          pwd
+
+      - name: Verify toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          go version | grep -E '^go version go1\.26\.'
+          actionlint -version | grep -E '^1\.7\.'
+          fnm --version
+          node --version | grep -E '^v24\.'
+          yarn --version | grep -E '^1\.2[23]\.'
+          python3 --version
+          uv --version
+          conan --version | grep -E '^Conan version 2\.29\.'
+          cmake --version | head -n 1
+          ninja --version
+          xcode-select -p
+
+      - name: Verify paths and entrypoint
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -d /Users/gha-runner/actions-runner/kungfu-systems/_work
+          test -d /Users/gha-runner/Worktrees/kungfu
+          test -d /Users/gha-runner/.cache/kungfu
+          test -f ./kungfu-code || test -x ./kungfu-code
+          df -Pk /Users/gha-runner | awk 'NR==2 { if ($4 < 120*1024*1024) exit 1; print }'
+
+      - name: Write smoke summary
+        shell: bash
+        run: |
+          {
+            echo "runner=${RUNNER_NAME}"
+            echo "os=${RUNNER_OS}"
+            echo "arch=${RUNNER_ARCH}"
+            go version
+            actionlint -version
+            conan --version
+            node --version
+            python3 --version
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+  darkhero:
+    name: darkhero smoke
+    runs-on:
+      - self-hosted
+      - Windows
+      - X64
+      - darkhero
+      - kungfu-build
+      - kungfu-build-v4-windows-x64
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Verify runner route
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          if ($env:RUNNER_NAME -ne "darkhero-kungfu-systems") { throw "unexpected runner $env:RUNNER_NAME" }
+          if ($env:RUNNER_OS -ne "Windows") { throw "unexpected os $env:RUNNER_OS" }
+          if ($env:RUNNER_ARCH -ne "X64") { throw "unexpected arch $env:RUNNER_ARCH" }
+          whoami
+          Get-Location
+
+      - name: Verify toolchain
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          go version | Select-String '^go version go1\.26\.'
+          actionlint -version | Select-String '^1\.7\.'
+          fnm --version
+          node --version | Select-String '^v24\.'
+          yarn --version | Select-String '^1\.2[23]\.'
+          python --version
+          uv --version
+          conan --version | Select-String '^Conan version 2\.29\.'
+          cmake --version | Select-Object -First 1
+          ninja --version
+
+      - name: Verify paths and entrypoint
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          foreach ($path in @(
+            "C:\actions-runner\kungfu-systems\_work",
+            "C:\Users\gha-runner\Worktrees\kungfu",
+            "C:\kungfu-cache",
+            "C:\tmp"
+          )) {
+            if (-not (Test-Path -LiteralPath $path -PathType Container)) { throw "missing path $path" }
+          }
+          if (-not (Test-Path -LiteralPath ".\kungfu-code.cmd" -PathType Leaf)) { throw "missing kungfu-code.cmd" }
+          $free = (Get-CimInstance Win32_LogicalDisk -Filter "DeviceID='C:'").FreeSpace
+          if ($free -lt 107374182400) { throw "low disk free bytes=$free" }
+          $free
+
+      - name: Write smoke summary
+        shell: pwsh
+        run: |
+          "runner=$env:RUNNER_NAME" >> $env:GITHUB_STEP_SUMMARY
+          "os=$env:RUNNER_OS" >> $env:GITHUB_STEP_SUMMARY
+          "arch=$env:RUNNER_ARCH" >> $env:GITHUB_STEP_SUMMARY
+          go version >> $env:GITHUB_STEP_SUMMARY
+          actionlint -version >> $env:GITHUB_STEP_SUMMARY
+          conan --version >> $env:GITHUB_STEP_SUMMARY
+          node --version >> $env:GITHUB_STEP_SUMMARY
+          python --version >> $env:GITHUB_STEP_SUMMARY
+
+  server-101:
+    name: server-101 smoke
+    runs-on:
+      - self-hosted
+      - Windows
+      - X64
+      - server-101
+      - windows-x64
+      - kungfu-build
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Verify runner route
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          if ($env:RUNNER_NAME -ne "server-101-kungfu-systems") { throw "unexpected runner $env:RUNNER_NAME" }
+          if ($env:RUNNER_OS -ne "Windows") { throw "unexpected os $env:RUNNER_OS" }
+          if ($env:RUNNER_ARCH -ne "X64") { throw "unexpected arch $env:RUNNER_ARCH" }
+          whoami
+          Get-Location
+
+      - name: Verify toolchain
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          go version | Select-String '^go version go1\.26\.'
+          actionlint -version | Select-String '^1\.7\.'
+          fnm --version
+          node --version | Select-String '^v24\.'
+          yarn --version | Select-String '^1\.2[23]\.'
+          python --version
+          uv --version
+          conan --version | Select-String '^Conan version 2\.29\.'
+          cmake --version | Select-Object -First 1
+          ninja --version
+
+      - name: Verify paths and entrypoint
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          foreach ($path in @(
+            "C:\actions-runner\kungfu-systems\_work",
+            "C:\Users\gha-runner\Worktrees\kungfu",
+            "C:\kungfu-cache",
+            "C:\tmp"
+          )) {
+            if (-not (Test-Path -LiteralPath $path -PathType Container)) { throw "missing path $path" }
+          }
+          if (-not (Test-Path -LiteralPath ".\kungfu-code.cmd" -PathType Leaf)) { throw "missing kungfu-code.cmd" }
+          $free = (Get-CimInstance Win32_LogicalDisk -Filter "DeviceID='C:'").FreeSpace
+          if ($free -lt 107374182400) { throw "low disk free bytes=$free" }
+          $free
+
+      - name: Write smoke summary
+        shell: pwsh
+        run: |
+          "runner=$env:RUNNER_NAME" >> $env:GITHUB_STEP_SUMMARY
+          "os=$env:RUNNER_OS" >> $env:GITHUB_STEP_SUMMARY
+          "arch=$env:RUNNER_ARCH" >> $env:GITHUB_STEP_SUMMARY
+          go version >> $env:GITHUB_STEP_SUMMARY
+          actionlint -version >> $env:GITHUB_STEP_SUMMARY
+          conan --version >> $env:GITHUB_STEP_SUMMARY
+          node --version >> $env:GITHUB_STEP_SUMMARY
+          python --version >> $env:GITHUB_STEP_SUMMARY

--- a/.github/workflows/runner-v4-label-smoke.yml
+++ b/.github/workflows/runner-v4-label-smoke.yml
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: Apache-2.0
+
+name: Runner - V4 Label Smoke
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - feature/runner-v4-label-smoke
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    name: agent-120 v4 labels
+    runs-on:
+      - self-hosted
+      - Linux
+      - X64
+      - kungfu-build-v4
+      - kungfu-build-v4-linux-x64
+    timeout-minutes: 10
+    steps:
+      - name: Verify runner route
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "${RUNNER_NAME}" = "agent-120-kungfu-systems"
+          test "${RUNNER_OS}" = "Linux"
+          test "${RUNNER_ARCH}" = "X64"
+
+      - name: Verify toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          go version | grep -E '^go version go1\.26\.'
+          actionlint -version | grep -E '^1\.7\.'
+          fnm --version | grep -E '^fnm 1\.39\.'
+          conan --version | grep -E '^Conan version 2\.29\.'
+          /usr/bin/python3.13 --version | grep -E '^Python 3\.13\.'
+
+      - name: Write smoke summary
+        shell: bash
+        run: |
+          {
+            echo "runner=${RUNNER_NAME}"
+            echo "os=${RUNNER_OS}"
+            echo "arch=${RUNNER_ARCH}"
+            go version
+            actionlint -version
+            fnm --version
+            conan --version
+            /usr/bin/python3.13 --version
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ build/
 build-*/
 cmake-build-debug/
 dist/
+.buildchain/
 
 # Debug related
 debug-example/

--- a/docs/MAP.md
+++ b/docs/MAP.md
@@ -33,6 +33,7 @@ and the map routes a question to whichever doc answers it.
 | What are the known limits / what is *not* yet guaranteed? | [`known-limits.md`](known-limits.md) | verify | stable |
 | How do C++ / Python / Node share data zero-copy (the membrane)? | [`architecture.md`](architecture.md) (membrane diagram) | verify | stable |
 | What does it actually guarantee (layout / replay / compatibility)? | [`contracts.md`](contracts.md) | verify | stable |
+| What KFD-2 release claims can Buildchain audit? | [`contracts.md`](contracts.md) (KFD-2 release claims) + [`kfd-native-sdk-release-gates.md`](kfd-native-sdk-release-gates.md) | verify | draft |
 | What is the event / journal / replay model? | [`event-model.md`](event-model.md) | use | stable |
 | Where are the Python / Node / framework adapter boundaries? | [`adapters.md`](adapters.md) | use | stable |
 | How do I go from source to a binary? | [`buildchain.md`](buildchain.md) (+ [`../CONTRIBUTING.md`](../CONTRIBUTING.md)) | use | stable |

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -190,6 +190,34 @@ currently named `kfd-1`.
 contracts. The registry/tooling path is intended to be the stable KFD-1
 infrastructure before third-party contract surfaces are published.
 
+## KFD-2 release claims are generated from a product-owned registry
+
+**Guarantee.** Public KFD-2 release trust claims are declared in one tracked
+registry:
+[`kungfu-release-claims.registry.json`](../framework/release/kfd-2/kungfu-release-claims.registry.json).
+The registry binds each claim to source files, machine-readable evidence,
+artifact coordinates, a local verification command, audit boundary,
+responsibility state, and residual risk. Generated files under `.buildchain/`
+are projections for release collection, not the source of truth.
+
+**Verify.** Run:
+
+```sh
+node scripts/kfd2-release-claims.mjs --check
+node scripts/kfd2-release-claims.mjs --write
+```
+
+`--check` validates the registry without writing generated files. `--write`
+emits the KFD canonical wrapper at `.buildchain/kfd-2/release-claims.json` and
+Buildchain v2.8-compatible raw claim files under `.buildchain/kfd-2/claims/`.
+Release collection can pass those raw claim files with Buildchain's
+`--kfd-2-claim-json` input.
+
+**Maturity.** `draft`. The first claim set covers the agent onboarding pack,
+Codex report receipts, and the remote fact boundary. Workflow enforcement is
+not yet enabled; release maintainers can run the generator manually before
+Buildchain release-passport collection.
+
 ## The Skill contract is a single source of truth
 
 **Guarantee.** Kungfu Skill source metadata, compact catalogs, context

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -218,6 +218,61 @@ Codex report receipts, and the remote fact boundary. Workflow enforcement is
 not yet enabled; release maintainers can run the generator manually before
 Buildchain release-passport collection.
 
+## The agent-first bridge is Kungfu's current KFD-3 profile
+
+**Guarantee.** The installed runtime carries a local Agent Onboarding Pack and
+machine-readable commands that let an agent start from a minimal artifact-local
+entrypoint instead of guessing from external notes:
+
+```sh
+kungfu agent brief
+kungfu agent capabilities --json
+kungfu agent choose-mode --json
+```
+
+This is Kungfu's current concrete profile of KFD-3: cooperation starts from
+transparent value and constraints. KFD-3 itself is not agent-only; the general
+participant-facing schema belongs in the KFD repository as a collaboration
+interface. Kungfu's first profile is agent-first because agents are the current
+non-human collaborators that need local discovery, mode choice, safety
+boundaries, and receipt/closeout instructions.
+
+The target implementation is a closed participant-facing API surface:
+
+- one Kungfu-owned registry declares public-agent, public-human, experimental,
+  deprecated, internal, and unsupported entrypoints;
+- CLI/help/docs/skills/JSON command catalogs are generated from that registry
+  or explicitly anchored to it in implementation code;
+- Markdown operation manuals are generated or linted against the same registry;
+- reverse audit enumerates the shipped command tree and fails if a reachable
+  entrypoint is not classified;
+- `kungfu agent verify --json` proves the installed artifact can expose the
+  same first-party facts it asks agents to use.
+
+In other words, KFD-3 is not satisfied by "there is documentation." It requires
+proof that the artifact's participant-facing API is discoverable, constraint
+transparent, and closed against hidden usable APIs.
+
+**Verify today.** Run:
+
+```sh
+kungfu agent brief
+kungfu agent capabilities --json
+kungfu agent choose-mode --json
+node scripts/verify-agent-pack.mjs
+```
+
+`verify-agent-pack` is the current packaging gate: it checks the installed pack
+files, command catalog, provider skills, package data, and GUI/TUI pointers.
+The planned KFD-3 closure gate should extend this into registry/code-anchor
+verification, Markdown reference linting, and Buildchain witness generation.
+
+**Maturity.** `draft`. The installed pack and packaging check exist. The
+single-source registry, CLI anchors, reverse command-tree audit,
+`kungfu agent verify --json`, docs projection checks, and Buildchain KFD-3
+witness remain future implementation work. See
+[`kfd-native-sdk-release-gates.md`](kfd-native-sdk-release-gates.md).
+
 ## The Skill contract is a single source of truth
 
 **Guarantee.** Kungfu Skill source metadata, compact catalogs, context

--- a/docs/kfd-native-sdk-release-gates.md
+++ b/docs/kfd-native-sdk-release-gates.md
@@ -146,11 +146,59 @@ This still does not change Kungfu release policy by itself. It gives the
 build/release workflow declarative pre-build input that Buildchain can freeze
 and independently compare against post-build artifact bytes.
 
-### Phase 2: KFD-2 Fact Surface Scaffold
+### Phase 2: KFD-2 Release Claims And Fact Surface Scaffold
 
-Add `kungfu sdk add fact-surface <name>` after the evidence vocabulary is
-settled. The scaffold should produce an append-first event schema, projection,
-JSON read API, and append-fold-readback probe following the work/Rewind model.
+The first KFD-2 implementation slice is release-claim projection, not a full
+fact-surface scaffold. Kungfu owns the claim registry:
+
+```text
+framework/release/kfd-2/kungfu-release-claims.registry.json
+```
+
+The registry is the product fact source. Generated files under `.buildchain/`
+are release-time projections and should not become a second source of truth.
+
+Local commands:
+
+```sh
+node scripts/kfd2-release-claims.mjs --check
+node scripts/kfd2-release-claims.mjs --write
+```
+
+`--check` validates the registry, source paths, machine-readable evidence,
+audit boundaries, responsibility state, residual risk arrays, and the
+Buildchain-compatible projection without writing generated files. `--write`
+emits:
+
+```text
+.buildchain/kfd-2/release-claims.json
+.buildchain/kfd-2/claims/<claim-id>.json
+.buildchain/kfd-2/buildchain-claim-args.txt
+```
+
+The first file follows KFD's canonical `kfd-2-release-claims` wrapper. The
+per-claim files are the current Buildchain v2.8 input shape for
+`--kfd-2-claim-json`, because Buildchain accepts one raw claim object per input
+file.
+
+Manual release-passport collection can pass the generated claim files:
+
+```sh
+node scripts/kfd2-release-claims.mjs --write
+buildchain collect github-release \
+  --kfd-2-claim-json .buildchain/kfd-2/claims/agent-onboarding-pack.json \
+  --kfd-2-claim-json .buildchain/kfd-2/claims/codex-report-receipts.json \
+  --kfd-2-claim-json .buildchain/kfd-2/claims/remote-fact-boundary.json
+```
+
+This slice intentionally does not change release policy or workflow wiring.
+Enforcing KFD-2 in every release workflow remains a separate release-policy
+task after the claim vocabulary proves useful.
+
+After this, add `kungfu sdk add fact-surface <name>` once the scaffold
+vocabulary is settled. The scaffold should produce an append-first event
+schema, projection, JSON read API, and append-fold-readback probe following the
+work/Rewind model.
 
 ### Phase 3: KFD-3 Agent Interface Scaffold
 
@@ -175,6 +223,21 @@ Buildchain owns the passport key, formatting policy, pre-build witness digest,
 and post-build artifact byte checks. Kungfu owns only its registry, source
 contracts, policy file, and generated witness. Enforcing this in every release
 workflow remains a separate release-policy task.
+
+Buildchain v2.8 also consumes explicit KFD-2 release claims. Kungfu should
+generate those from its registry, then pass the generated raw-claim projection:
+
+```sh
+node scripts/kfd2-release-claims.mjs --write
+buildchain collect github-release \
+  --kfd-2-claim-json .buildchain/kfd-2/claims/agent-onboarding-pack.json \
+  --kfd-2-claim-json .buildchain/kfd-2/claims/codex-report-receipts.json \
+  --kfd-2-claim-json .buildchain/kfd-2/claims/remote-fact-boundary.json
+```
+
+Buildchain owns the release trust passport audit and pass/downgrade/fail
+classification. Kungfu owns the claim registry, source bindings, evidence
+files, audit boundaries, responsibility state, and residual risk.
 
 ## Non-Goals
 

--- a/docs/kfd-native-sdk-release-gates.md
+++ b/docs/kfd-native-sdk-release-gates.md
@@ -28,7 +28,8 @@ The first implementation should build on surfaces that already exist:
   registered contracts.
 - The work store and Rewind surfaces already provide append-first local facts.
 - The installed agent pack already exposes agent-readable docs, capabilities,
-  commands, and mode selection.
+  commands, and mode selection. It is Kungfu's current agent-first profile of a
+  more general KFD-3 collaboration interface.
 
 This means the SDK should not invent a second source of truth. It should
 generate files that join the existing contract, fact, and agent surfaces.
@@ -45,6 +46,15 @@ generate files that join the existing contract, fact, and agent surfaces.
   `experimental`, or `stable`, paired with known limits.
 - **Downgrade**: the release claim is lowered when evidence is missing or
   inconsistent.
+- **Participant**: a collaborator that needs to understand value, choices, and
+  constraints before cooperating. A participant can be a human, agent, operator,
+  extension author, API consumer, or service user.
+- **Collaboration interface**: the declared participant-facing interface for a
+  product surface. It includes minimal entrypoints, commands, docs, schemas,
+  choices, constraints, maturity labels, and known limits.
+- **Closure**: every reachable participant-facing entrypoint is classified in
+  the collaboration interface. An unclassified reachable entrypoint is a
+  build-time failure, not an undocumented public API.
 
 ## Design Map
 
@@ -200,11 +210,164 @@ vocabulary is settled. The scaffold should produce an append-first event
 schema, projection, JSON read API, and append-fold-readback probe following the
 work/Rewind model.
 
-### Phase 3: KFD-3 Agent Interface Scaffold
+### Phase 3: KFD-3 Collaboration Interface
 
-Add `kungfu sdk add agent-interface <surface>` after the agent evidence
-vocabulary is settled. The scaffold should produce agent-readable docs,
-capabilities metadata, command maturity, constraints, and a discovery probe.
+KFD-3 is about the cooperation relationship, not only about agents. Kungfu's
+first concrete profile is agent-first because the installed runtime already has
+non-human collaborators that need a minimal local entrypoint, machine-readable
+mode choice, and closeout/receipt rules. The implementation should still use
+participant-neutral terms internally where possible so the same mechanism can
+later cover human operators, extension authors, API consumers, hosted-service
+users, and other collaborators.
+
+The target shape is:
+
+```text
+KFD-owned schema:
+  kfd-3 collaboration-interface + witness
+
+Kungfu-owned fact source:
+  framework/agent/kungfu-agent-api.registry.json
+  framework/agent/kungfu-agent-api.schema.json
+
+Core runtime anchors:
+  @kfd3_api("<api-id>")
+  api_help("<api-id>")
+  kungfu agent verify --json
+
+Generated / checked projections:
+  framework/core/src/python/kungfu/agent/commands.json
+  framework/core/src/python/kungfu/agent/brief.md
+  framework/core/src/python/kungfu/agent/mode-selection.md
+  framework/core/src/python/kungfu/agent/safety.md
+  provider SKILL.md files
+  docs/MAP.md and operation-manual command references
+
+SDK tooling:
+  kungfu sdk collaboration-interface add ...
+  kungfu sdk collaboration-interface render --check --json
+  kungfu sdk collaboration-interface docs-lint --json
+  kungfu sdk collaboration-interface audit --json
+  kungfu sdk collaboration-interface witness --json
+```
+
+The registry is the single fact source for participant-facing Kungfu APIs. It
+should classify every shipped entrypoint that a participant can call or depend
+on:
+
+```json
+{
+  "id": "kungfu.agent.capabilities",
+  "kind": "cli-command",
+  "command": "kungfu agent capabilities --json",
+  "audience": "public-agent",
+  "maturity": "stable",
+  "purpose": "Print machine-readable local Kungfu capabilities for agents.",
+  "constraints": ["read-only", "local-facts"],
+  "jsonSchema": "kungfu.agent-capabilities/v1"
+}
+```
+
+Allowed audience/support classifications should include:
+
+- `public-agent`: safe for an agent to discover and use from the minimal entry.
+- `public-human`: human-facing and visible, but not an agent automation default.
+- `experimental`: visible with maturity and limits.
+- `deprecated`: visible with a migration path.
+- `internal`: implementation detail; not a supported participant API.
+- `unsupported`: reachable only for compatibility or diagnostics, not a public
+  cooperation surface.
+
+Any installed entrypoint reachable from `kungfu` must either be generated from
+the registry or be explicitly anchored to it in implementation code. A future
+core decorator should live in the runtime/CLI layer, not only in
+`developer/sdk`, because packaged `kungfu` must carry the anchor:
+
+```python
+@kfd3_api("kungfu.agent.capabilities")
+@agent.command(help=api_help("kungfu.agent.capabilities"))
+def capabilities(...):
+    ...
+```
+
+Build verification should enumerate the real Click command tree and fail when:
+
+- a reachable CLI command has no registry entry or `@kfd3_api` anchor;
+- the registry declares a command that no longer exists;
+- generated help/docs/commands drift from the registry;
+- a `public-agent` entry lacks purpose, maturity, constraints, next action, or
+  JSON schema when it emits JSON;
+- an `internal` or `unsupported` entry is recommended by the agent pack;
+- an unclassified reachable API exists.
+
+Markdown operating manuals are part of the KFD-3 surface because agents and
+humans share them. Operation-manual content should either be generated from the
+registry or use checked generated blocks:
+
+```md
+<!-- kungfu-agent-api:start commands audience=public-agent -->
+...
+<!-- kungfu-agent-api:end commands -->
+```
+
+The docs linter should scan Markdown command literals, API ids, mode names,
+schema ids, and maturity labels. A command reference that cannot be resolved to
+the registry should fail the build unless it is explicitly marked as historical
+or unsupported.
+
+The local runtime proof should be:
+
+```sh
+kungfu agent capabilities --json
+kungfu agent choose-mode --json
+kungfu agent verify --json
+kungfu sdk collaboration-interface audit --json
+kungfu sdk collaboration-interface docs-lint --json
+```
+
+The audit output should prove two properties:
+
+```json
+{
+  "schema": "kungfu.collaboration-interface-audit/v1",
+  "ok": true,
+  "discoverability": "passed",
+  "closure": "passed",
+  "unclassifiedEntrypoints": [],
+  "staleRegistryEntries": [],
+  "docDrift": [],
+  "hiddenUsableApis": []
+}
+```
+
+The Buildchain witness should be generated only after KFD publishes general
+KFD-3 collaboration-interface schema ids:
+
+```sh
+kungfu sdk collaboration-interface witness --json \
+  > .buildchain/kfd-3/collaboration-interface.witness.json
+```
+
+That witness should record registry hashes, generated artifact hashes, command
+tree hash, docs projection hashes, participant profiles, minimal entrypoints,
+and the audit result. Buildchain should freeze the witness and verify packaged
+artifact bytes, but Kungfu remains the source of truth for its concrete
+registry and CLI anchors.
+
+The first implementation should be a narrow agent-first slice:
+
+1. Create the Kungfu registry and schema for current `kungfu agent` commands.
+2. Add runtime anchors for the `agent` command group.
+3. Generate `commands.json` from the registry or check it byte-for-byte.
+4. Add reverse audit for the Click command tree.
+5. Add Markdown docs-lint for operation-manual command references.
+6. Add `kungfu agent verify --json`.
+7. Extend `scripts/verify-agent-pack.mjs` into the KFD-3 closure gate.
+8. Generate a draft witness once KFD exposes general KFD-3 schema ids.
+
+This phase must not make developers manually update many documents for one new
+command. Adding a participant-facing command should either go through SDK
+scaffolding or fail verification until it is registered and anchored.
 
 ### Phase 4: Buildchain Release Evidence
 
@@ -252,12 +415,14 @@ files, audit boundaries, responsibility state, and residual risk.
 
 - Should SDK scaffolds mutate existing files directly, or emit a reviewable
   patch plan first?
-- Where should the eventual KFD capability evidence manifest live in the
-  repository?
-- Should the maturity vocabulary be shared with `docs/MAP.md`, or should it live
-  in a dedicated contract?
+- Should the KFD-3 source registry live under `framework/agent/` or beside the
+  installed pack under `framework/core/src/python/kungfu/agent/`?
+- Should the maturity vocabulary be shared with `docs/MAP.md`, the agent pack,
+  and KFD-3 witness schema, or should it live in a dedicated contract?
 - How should Buildchain represent a downgrade without making Buildchain the
   source of truth?
+- Which non-agent participant profiles should the first non-agent KFD-3 slice
+  cover: human operator, extension author, API consumer, or hosted service user?
 
 ## Future Acceptance Criteria
 

--- a/framework/core/src/python/kungfu/yijinjing/journal.py
+++ b/framework/core/src/python/kungfu/yijinjing/journal.py
@@ -106,8 +106,10 @@ def find_sessions(ctx):
 
 
 def find_session(ctx, session_id):
-    all_sessions = find_sessions(ctx)
-    return next(session for session in all_sessions if session["id"] == session_id)
+    for session in find_sessions(ctx):
+        if session["id"] == session_id:
+            return session
+    raise IndexError(f"session {session_id} not found")
 
 
 def make_location_from_dict(ctx, location):

--- a/framework/core/src/python/kungfu_cli.py
+++ b/framework/core/src/python/kungfu_cli.py
@@ -23,6 +23,7 @@
 # nuitka-project: --nofollow-import-to=statsmodels
 # nuitka-project: --nofollow-import-to=plotly
 # nuitka-project: --nofollow-import-to=botocore
+# nuitka-project: --nofollow-import-to=boto3
 #
 # nuitka-project: --nofollow-import-to=*.distutils
 # nuitka-project: --nofollow-import-to=*.tests

--- a/framework/release/kfd-2/kungfu-release-claims.registry.json
+++ b/framework/release/kfd-2/kungfu-release-claims.registry.json
@@ -1,0 +1,225 @@
+{
+  "schema": "kungfu.kfd-2-release-claims.registry/v1",
+  "description": "Kungfu-owned source registry for public KFD-2 release trust claims. Generated release claim files are projections of this registry, not the source of truth.",
+  "product": {
+    "name": "Kungfu",
+    "repository": "kungfu-systems/kungfu",
+    "package": "@kungfu-tech/artifact-kungfu"
+  },
+  "releaseDefaults": {
+    "channel": "dev/v4/v4.0",
+    "tagPrefix": "v"
+  },
+  "kfd": {
+    "standard": "kfd-2",
+    "contract": "kfd-2-release-claims",
+    "schemaId": "https://kfd.libkungfu.dev/schemas/kfd-2/release-claims.schema.json",
+    "interfaceVersion": 1
+  },
+  "buildchain": {
+    "minimumVersion": "2.8.0",
+    "claimInput": "--kfd-2-claim-json",
+    "projection": "one raw claim object per file under .buildchain/kfd-2/claims/"
+  },
+  "claims": [
+    {
+      "id": "agent-onboarding-pack",
+      "category": "kfd-2",
+      "statement": "Kungfu releases declare an installed agent onboarding pack with machine-readable command and mode metadata, safety boundaries, examples, and verifier coverage.",
+      "source": {
+        "kind": "file",
+        "path": "framework/core/src/python/kungfu/agent/index.json"
+      },
+      "evidence": [
+        {
+          "type": "file",
+          "path": "framework/core/src/python/kungfu/agent/commands.json",
+          "description": "Machine-readable command catalog and mode maturity metadata."
+        },
+        {
+          "type": "file",
+          "path": "framework/core/src/python/kungfu/agent/mode-selection.md",
+          "description": "Human and agent-readable mode selection rules."
+        },
+        {
+          "type": "file",
+          "path": "framework/core/src/python/kungfu/agent/safety.md",
+          "description": "Fact labels and safety boundaries for observed, reported, imported, and remote evidence."
+        },
+        {
+          "type": "file",
+          "path": "scripts/verify-agent-pack.mjs",
+          "description": "Read-only verifier for installed agent pack completeness and command/doc consistency."
+        }
+      ],
+      "artifacts": [
+        {
+          "name": "agent-pack-index",
+          "path": "framework/core/src/python/kungfu/agent/index.json",
+          "expectedPackagePath": "kungfu/agent/index.json"
+        },
+        {
+          "name": "agent-command-catalog",
+          "path": "framework/core/src/python/kungfu/agent/commands.json",
+          "expectedPackagePath": "kungfu/agent/commands.json"
+        }
+      ],
+      "verification": {
+        "command": "node scripts/verify-agent-pack.mjs && node scripts/kfd2-release-claims.mjs --check",
+        "expectedResult": "pass"
+      },
+      "auditBoundary": {
+        "scope": "The committed agent onboarding pack files listed in this claim and the verifier checks that enumerate required docs, skills, command catalog entries, safety labels, package data, GUI hint, and TUI hint.",
+        "enumerability": "closed-world",
+        "exclusions": [
+          "Provider CLI behavior outside Kungfu",
+          "User-specific bootstrap policy files under local home directories",
+          "Runtime data and receipts produced after installation"
+        ]
+      },
+      "residualRisk": [],
+      "responsibility": {
+        "sourceOwner": "kungfu",
+        "verificationOwner": "kungfu verify",
+        "releaseDecisionOwner": "kungfu release maintainer",
+        "escalation": "Downgrade the claim if the pack verifier fails or a new public agent command is added without command catalog coverage."
+      },
+      "status": "audited"
+    },
+    {
+      "id": "codex-report-receipts",
+      "category": "kfd-2",
+      "statement": "Kungfu report mode exposes a native Codex goal adapter with a verifiable receipt path, and token-only or unknown cost is represented as unknown rather than fabricated zero-dollar cost.",
+      "source": {
+        "kind": "file",
+        "path": "framework/core/src/python/kungfu/cli/commands/codex.py"
+      },
+      "evidence": [
+        {
+          "type": "file",
+          "path": "framework/core/src/python/kungfu/cli/commands/codex.py",
+          "description": "Codex goal report adapter and receipt verifier CLI implementation."
+        },
+        {
+          "type": "file",
+          "path": "framework/core/src/python/kungfu/rewind/cost/codex.py",
+          "description": "Codex cost adapter: tokens are reported, dollar cost remains unknown when not provided by the provider."
+        },
+        {
+          "type": "file",
+          "path": "framework/core/src/python/kungfu/rewind/cost_wire.py",
+          "description": "Cost wire model preserving known/unknown cost distinction."
+        },
+        {
+          "type": "file",
+          "path": "framework/core/src/python/kungfu/agent/examples/report-mode.md",
+          "description": "Report-mode user and agent procedure including Codex receipt verification."
+        },
+        {
+          "type": "file",
+          "path": "framework/core/src/python/kungfu/agent/skills/codex/SKILL.md",
+          "description": "Codex-side report closeout gate instructions shipped in the agent pack."
+        }
+      ],
+      "artifacts": [
+        {
+          "name": "codex-cli-command",
+          "path": "framework/core/src/python/kungfu/cli/commands/codex.py",
+          "expectedPackagePath": "kungfu/cli/commands/codex.py"
+        },
+        {
+          "name": "codex-agent-skill",
+          "path": "framework/core/src/python/kungfu/agent/skills/codex/SKILL.md",
+          "expectedPackagePath": "kungfu/agent/skills/codex/SKILL.md"
+        }
+      ],
+      "verification": {
+        "command": "node scripts/verify-agent-pack.mjs && node scripts/kfd2-release-claims.mjs --check",
+        "expectedResult": "pass"
+      },
+      "auditBoundary": {
+        "scope": "The committed Codex report adapter, receipt verifier, cost wire model, report-mode docs, and shipped Codex skill instructions listed in this claim.",
+        "enumerability": "closed-world",
+        "exclusions": [
+          "Provider-side billing pages or private sessions",
+          "Future Codex API fields not emitted to the user or agent",
+          "Human-entered cost overrides outside the receipt verifier"
+        ]
+      },
+      "residualRisk": [],
+      "responsibility": {
+        "sourceOwner": "kungfu",
+        "verificationOwner": "kungfu verify",
+        "releaseDecisionOwner": "kungfu release maintainer",
+        "escalation": "Downgrade the claim if receipt verification stops binding the run id, work id, goal id, status, and reported usage fields."
+      },
+      "status": "audited"
+    },
+    {
+      "id": "remote-fact-boundary",
+      "category": "kfd-2",
+      "statement": "Kungfu distinguishes local observed facts from reported, imported, and remote facts in the agent pack and remote-sync command surface instead of silently promoting remote evidence into local truth.",
+      "source": {
+        "kind": "file",
+        "path": "framework/core/src/python/kungfu/agent/safety.md"
+      },
+      "evidence": [
+        {
+          "type": "file",
+          "path": "framework/core/src/python/kungfu/agent/safety.md",
+          "description": "Fact labels for observed, reported, imported, and remote evidence."
+        },
+        {
+          "type": "file",
+          "path": "framework/core/src/python/kungfu/agent/mode-selection.md",
+          "description": "Remote-sync mode rule requiring source-scoped import."
+        },
+        {
+          "type": "file",
+          "path": "framework/core/src/python/kungfu/agent/commands.json",
+          "description": "Remote add/sync command declarations and mode metadata."
+        },
+        {
+          "type": "file",
+          "path": "framework/core/src/python/kungfu/cli/commands/agent.py",
+          "description": "Agent command surface including mode selection and bootstrap status."
+        }
+      ],
+      "artifacts": [
+        {
+          "name": "agent-safety-doc",
+          "path": "framework/core/src/python/kungfu/agent/safety.md",
+          "expectedPackagePath": "kungfu/agent/safety.md"
+        },
+        {
+          "name": "agent-mode-selection-doc",
+          "path": "framework/core/src/python/kungfu/agent/mode-selection.md",
+          "expectedPackagePath": "kungfu/agent/mode-selection.md"
+        }
+      ],
+      "verification": {
+        "command": "node scripts/verify-agent-pack.mjs && node scripts/kfd2-release-claims.mjs --check",
+        "expectedResult": "pass"
+      },
+      "auditBoundary": {
+        "scope": "The committed agent safety and mode-selection documents, machine-readable commands catalog, and agent CLI command implementation listed in this claim.",
+        "enumerability": "declared-open",
+        "exclusions": [
+          "Actual network transport availability",
+          "Remote host identity outside locally recorded source metadata",
+          "User decisions to manually promote imported evidence"
+        ]
+      },
+      "residualRisk": [
+        "Remote evidence freshness and identity depend on the configured source runtime and must remain source-scoped until a later command explicitly promotes it."
+      ],
+      "responsibility": {
+        "sourceOwner": "kungfu",
+        "verificationOwner": "kungfu verify",
+        "releaseDecisionOwner": "kungfu release maintainer",
+        "escalation": "Keep this claim downgraded or human-reviewed while remote-sync remains an experimental surface."
+      },
+      "status": "audited"
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -53,6 +53,8 @@
     "dist:dir": "pnpm --filter @kungfu-tech/artifact-kungfu run package",
     "package:app": "pnpm --filter @kungfu-tech/artifact-kungfu run package",
     "verify": "node scripts/verify.mjs",
+    "kfd2:claims": "node scripts/kfd2-release-claims.mjs --write",
+    "kfd2:claims:check": "node scripts/kfd2-release-claims.mjs --check",
     "check:types": "tsc -p tsconfig.tools.json",
     "prepare": "node scripts/install-hooks.mjs",
     "hooks:install": "node scripts/install-hooks.mjs --force"

--- a/scripts/kfd2-release-claims.mjs
+++ b/scripts/kfd2-release-claims.mjs
@@ -1,0 +1,500 @@
+// SPDX-License-Identifier: Apache-2.0
+// @ts-check
+
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const ROOT = path.resolve(__dirname, '..');
+const REGISTRY_PATH = path.join(
+  ROOT,
+  'framework',
+  'release',
+  'kfd-2',
+  'kungfu-release-claims.registry.json',
+);
+const DEFAULT_OUTPUT_DIR = path.join(ROOT, '.buildchain', 'kfd-2');
+const CLAIM_ID_RE = /^[a-z0-9]+(-[a-z0-9]+)*$/;
+const CANONICAL_STATUSES = new Set([
+  'declared',
+  'audited',
+  'enforced',
+  'not-applicable',
+]);
+const ENUMERABILITY = new Set([
+  'closed-world',
+  'declared-open',
+  'sampled',
+  'manual',
+]);
+
+function usage() {
+  return `Usage:
+  node scripts/kfd2-release-claims.mjs --check [--json] [--channel <channel>] [--tag <tag>] [--source-sha <sha>]
+  node scripts/kfd2-release-claims.mjs --write [--output-dir <dir>] [--json] [--channel <channel>] [--tag <tag>] [--source-sha <sha>]
+
+Writes:
+  <output-dir>/release-claims.json
+  <output-dir>/claims/<claim-id>.json
+  <output-dir>/buildchain-claim-args.txt
+`;
+}
+
+function parseArgs(argv) {
+  const options = {
+    check: false,
+    write: false,
+    json: false,
+    outputDir: DEFAULT_OUTPUT_DIR,
+    channel: '',
+    tag: '',
+    sourceSha: '',
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--check') options.check = true;
+    else if (arg === '--write') options.write = true;
+    else if (arg === '--json') options.json = true;
+    else if (arg === '--help' || arg === '-h') {
+      process.stdout.write(usage());
+      process.exit(0);
+    } else if (arg === '--output-dir' || arg === '--out-dir') {
+      i += 1;
+      options.outputDir = path.resolve(ROOT, argv[i] || '');
+    } else if (arg === '--channel') {
+      i += 1;
+      options.channel = argv[i] || '';
+    } else if (arg === '--tag') {
+      i += 1;
+      options.tag = argv[i] || '';
+    } else if (arg === '--source-sha') {
+      i += 1;
+      options.sourceSha = argv[i] || '';
+    } else {
+      throw new Error(`unknown argument: ${arg}`);
+    }
+  }
+  if (!options.check && !options.write) options.check = true;
+  if (options.check && options.write) {
+    throw new Error('choose either --check or --write, not both');
+  }
+  return options;
+}
+
+function readJson(file) {
+  return JSON.parse(fs.readFileSync(file, 'utf8'));
+}
+
+function renderJson(value) {
+  return `${JSON.stringify(value, null, 2)}\n`;
+}
+
+function sha256Buffer(buffer) {
+  return createHash('sha256').update(buffer).digest('hex');
+}
+
+function sha256File(file) {
+  return sha256Buffer(fs.readFileSync(file));
+}
+
+function rel(file) {
+  const resolved = path.resolve(file);
+  if (!resolved.startsWith(`${ROOT}${path.sep}`) && resolved !== ROOT) {
+    return resolved.split(path.sep).join('/');
+  }
+  return path.relative(ROOT, resolved).split(path.sep).join('/');
+}
+
+function resolveRepoPath(relativePath) {
+  if (!relativePath || typeof relativePath !== 'string') {
+    throw new Error('expected a repository-relative path');
+  }
+  const resolved = path.resolve(ROOT, relativePath);
+  if (!resolved.startsWith(`${ROOT}${path.sep}`) && resolved !== ROOT) {
+    throw new Error(`path escapes repository root: ${relativePath}`);
+  }
+  return resolved;
+}
+
+function filePointer(input) {
+  const file = resolveRepoPath(input.path);
+  if (!fs.existsSync(file)) {
+    throw new Error(`missing evidence path: ${input.path}`);
+  }
+  const pointer = {
+    kind: input.kind || 'file',
+    path: rel(file),
+    sha256: sha256File(file),
+  };
+  if (input.schemaId) pointer.schemaId = input.schemaId;
+  if (input.digest) pointer.digest = input.digest;
+  if (input.specifier) pointer.specifier = input.specifier;
+  return pointer;
+}
+
+function gitValue(args) {
+  try {
+    return execFileSync('git', args, {
+      cwd: ROOT,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+  } catch {
+    return '';
+  }
+}
+
+function sourceSha(options) {
+  return options.sourceSha || gitValue(['rev-parse', 'HEAD']) || 'unknown';
+}
+
+function version() {
+  return String(readJson(path.join(ROOT, 'lerna.json')).version || '');
+}
+
+function registrySha() {
+  return sha256File(REGISTRY_PATH);
+}
+
+function validateRegistry(registry) {
+  const errors = [];
+  if (registry?.schema !== 'kungfu.kfd-2-release-claims.registry/v1') {
+    errors.push(
+      'registry schema must be kungfu.kfd-2-release-claims.registry/v1',
+    );
+  }
+  if (registry?.kfd?.standard !== 'kfd-2') {
+    errors.push('registry.kfd.standard must be kfd-2');
+  }
+  if (registry?.kfd?.contract !== 'kfd-2-release-claims') {
+    errors.push('registry.kfd.contract must be kfd-2-release-claims');
+  }
+  if (!Array.isArray(registry?.claims) || registry.claims.length === 0) {
+    errors.push('registry.claims must be a non-empty array');
+  }
+  const ids = new Set();
+  for (const [index, claim] of (registry.claims || []).entries()) {
+    const label = `claims[${index}]`;
+    if (!CLAIM_ID_RE.test(String(claim.id || ''))) {
+      errors.push(`${label}.id must match ${CLAIM_ID_RE}`);
+    } else if (ids.has(claim.id)) {
+      errors.push(`${label}.id duplicates ${claim.id}`);
+    }
+    ids.add(claim.id);
+    if (!claim.statement) errors.push(`${label}.statement is required`);
+    if (!claim.source?.path) errors.push(`${label}.source.path is required`);
+    if (!Array.isArray(claim.evidence) || claim.evidence.length === 0) {
+      errors.push(`${label}.evidence must be non-empty`);
+    }
+    if (!Array.isArray(claim.artifacts) || claim.artifacts.length === 0) {
+      errors.push(`${label}.artifacts must be non-empty`);
+    }
+    if (!claim.auditBoundary?.scope)
+      errors.push(`${label}.auditBoundary.scope is required`);
+    if (!ENUMERABILITY.has(String(claim.auditBoundary?.enumerability || ''))) {
+      errors.push(`${label}.auditBoundary.enumerability is invalid`);
+    }
+    if (!Array.isArray(claim.residualRisk)) {
+      errors.push(`${label}.residualRisk must be an array, even when empty`);
+    }
+    for (const key of [
+      'sourceOwner',
+      'verificationOwner',
+      'releaseDecisionOwner',
+    ]) {
+      if (!claim.responsibility?.[key])
+        errors.push(`${label}.responsibility.${key} is required`);
+    }
+    if (!CANONICAL_STATUSES.has(String(claim.status || ''))) {
+      errors.push(`${label}.status must be a KFD release claim status`);
+    }
+  }
+  return errors;
+}
+
+function canonicalClaim(claim) {
+  const source = filePointer(claim.source);
+  return {
+    id: claim.id,
+    statement: claim.statement,
+    category: claim.category || 'kfd-2',
+    source,
+    evidence: claim.evidence.map((entry) => ({
+      type: entry.type || 'file',
+      pointer: filePointer({ ...entry, kind: entry.kind || 'file' }),
+      description: entry.description || '',
+    })),
+    verification: {
+      command:
+        claim.verification?.command ||
+        'node scripts/kfd2-release-claims.mjs --check',
+      expectedResult: claim.verification?.expectedResult || 'pass',
+    },
+    auditBoundary: {
+      scope: claim.auditBoundary.scope,
+      enumerability: claim.auditBoundary.enumerability,
+      exclusions: claim.auditBoundary.exclusions || [],
+    },
+    residualRisk: claim.residualRisk,
+    responsibility: claim.responsibility,
+    status: claim.status,
+  };
+}
+
+function buildCanonicalReleaseClaims(registry, options) {
+  const releaseVersion = version();
+  return {
+    schemaVersion: 1,
+    contract: registry.kfd.contract,
+    standard: registry.kfd.standard,
+    product: registry.product,
+    release: {
+      version: releaseVersion,
+      channel: options.channel || registry.releaseDefaults?.channel || 'local',
+      tag:
+        options.tag ||
+        `${registry.releaseDefaults?.tagPrefix || 'v'}${releaseVersion}`,
+      sourceSha: sourceSha(options),
+    },
+    claims: registry.claims.map((claim) => canonicalClaim(claim)),
+    schemaEvolution: {
+      interfaceVersion: registry.kfd.interfaceVersion || 1,
+      compatibilityRule:
+        'Compatible additions may keep schemaVersion 1; required-field or semantic changes require a new KFD-owned interface version.',
+    },
+  };
+}
+
+function buildBuildchainClaimProjection(claim) {
+  const source = filePointer(claim.source);
+  const evidence = claim.evidence.map((entry) => ({
+    type: entry.type || 'file',
+    pointer: filePointer({ ...entry, kind: entry.kind || 'file' }),
+    description: entry.description || '',
+  }));
+  const artifactCoordinates = claim.artifacts.map((artifact) => {
+    const pointer = filePointer({ kind: 'file', path: artifact.path });
+    return {
+      name: artifact.name || path.basename(artifact.path),
+      path: pointer.path,
+      sha256: pointer.sha256,
+      expectedPackagePath: artifact.expectedPackagePath || '',
+    };
+  });
+  return {
+    id: claim.id,
+    public: true,
+    claim: claim.statement,
+    sourceBindings: [
+      {
+        role: 'claim-source',
+        kind: source.kind,
+        path: source.path,
+        sha256: source.sha256,
+      },
+    ],
+    machineEvidence: evidence,
+    hashes: {
+      registrySha256: registrySha(),
+      sourceSha256: source.sha256,
+      evidenceSha256: evidence.map((entry) => ({
+        path: entry.pointer.path,
+        sha256: entry.pointer.sha256,
+      })),
+      artifactSha256: artifactCoordinates.map((entry) => ({
+        path: entry.path,
+        sha256: entry.sha256,
+      })),
+    },
+    artifacts: artifactCoordinates,
+    verification: {
+      result:
+        claim.residualRisk.length === 0
+          ? 'passed'
+          : 'passed-with-residual-risk',
+      command:
+        claim.verification?.command ||
+        'node scripts/kfd2-release-claims.mjs --check',
+      expectedResult: claim.verification?.expectedResult || 'pass',
+    },
+    auditBoundary: {
+      scope: claim.auditBoundary.scope,
+      enumerability: claim.auditBoundary.enumerability,
+      exclusions: claim.auditBoundary.exclusions || [],
+    },
+    responsibility: claim.responsibility,
+    residualRisk: claim.residualRisk,
+    canonicalStatus: claim.status,
+  };
+}
+
+function validateCanonical(document) {
+  const errors = [];
+  if (document.schemaVersion !== 1) errors.push('schemaVersion must be 1');
+  if (document.contract !== 'kfd-2-release-claims') {
+    errors.push('contract must be kfd-2-release-claims');
+  }
+  if (document.standard !== 'kfd-2') errors.push('standard must be kfd-2');
+  if (!document.product?.name) errors.push('product.name is required');
+  if (!document.release?.version) errors.push('release.version is required');
+  if (!document.release?.channel) errors.push('release.channel is required');
+  if (!Array.isArray(document.claims) || document.claims.length === 0) {
+    errors.push('claims must be non-empty');
+  }
+  for (const [index, claim] of (document.claims || []).entries()) {
+    const label = `claims[${index}]`;
+    if (!CLAIM_ID_RE.test(claim.id)) errors.push(`${label}.id is invalid`);
+    if (!claim.statement) errors.push(`${label}.statement is required`);
+    if (!claim.source?.kind) errors.push(`${label}.source.kind is required`);
+    if (!Array.isArray(claim.evidence) || claim.evidence.length === 0) {
+      errors.push(`${label}.evidence must be non-empty`);
+    }
+    if (!claim.auditBoundary?.scope)
+      errors.push(`${label}.auditBoundary.scope is required`);
+    if (!claim.responsibility?.sourceOwner) {
+      errors.push(`${label}.responsibility.sourceOwner is required`);
+    }
+    if (!CANONICAL_STATUSES.has(claim.status))
+      errors.push(`${label}.status is invalid`);
+  }
+  return errors;
+}
+
+function validateProjection(claim) {
+  const missing = [];
+  if (!Array.isArray(claim.sourceBindings) || claim.sourceBindings.length === 0)
+    missing.push('declared-sources');
+  if (
+    !Array.isArray(claim.machineEvidence) ||
+    claim.machineEvidence.length === 0
+  )
+    missing.push('machine-readable-evidence');
+  if (!claim.hashes || Object.keys(claim.hashes).length === 0)
+    missing.push('hashes');
+  if (!Array.isArray(claim.artifacts) || claim.artifacts.length === 0)
+    missing.push('artifact-coordinates');
+  if (!claim.verification?.result) missing.push('verification-result');
+  if (!claim.auditBoundary || Object.keys(claim.auditBoundary).length === 0)
+    missing.push('audit-boundary');
+  if (!claim.responsibility?.sourceOwner) missing.push('responsibility-state');
+  if (!Array.isArray(claim.residualRisk)) missing.push('residual-risk');
+  return missing;
+}
+
+function buildAll(options) {
+  const registry = readJson(REGISTRY_PATH);
+  const registryErrors = validateRegistry(registry);
+  if (registryErrors.length) {
+    throw new Error(
+      `registry invalid:\n${registryErrors.map((e) => `- ${e}`).join('\n')}`,
+    );
+  }
+  const canonical = buildCanonicalReleaseClaims(registry, options);
+  const canonicalErrors = validateCanonical(canonical);
+  if (canonicalErrors.length) {
+    throw new Error(
+      `canonical release claims invalid:\n${canonicalErrors.map((e) => `- ${e}`).join('\n')}`,
+    );
+  }
+  const buildchainClaims = registry.claims.map((claim) =>
+    buildBuildchainClaimProjection(claim),
+  );
+  const projectionErrors = [];
+  for (const claim of buildchainClaims) {
+    const missing = validateProjection(claim);
+    if (missing.length > 0) {
+      projectionErrors.push(`${claim.id}: missing ${missing.join(', ')}`);
+    }
+  }
+  if (projectionErrors.length) {
+    throw new Error(
+      `Buildchain projection invalid:\n${projectionErrors.map((e) => `- ${e}`).join('\n')}`,
+    );
+  }
+  return { registry, canonical, buildchainClaims };
+}
+
+function writeOutput(outputDir, canonical, buildchainClaims) {
+  const claimsDir = path.join(outputDir, 'claims');
+  fs.mkdirSync(claimsDir, { recursive: true });
+  const canonicalPath = path.join(outputDir, 'release-claims.json');
+  fs.writeFileSync(canonicalPath, renderJson(canonical));
+  const claimPaths = [];
+  for (const claim of buildchainClaims) {
+    const claimPath = path.join(claimsDir, `${claim.id}.json`);
+    fs.writeFileSync(claimPath, renderJson(claim));
+    claimPaths.push(claimPath);
+  }
+  const argText = claimPaths
+    .map((claimPath) => `--kfd-2-claim-json ${rel(claimPath)}`)
+    .join('\n');
+  fs.writeFileSync(
+    path.join(outputDir, 'buildchain-claim-args.txt'),
+    `${argText}\n`,
+  );
+  return { canonicalPath, claimPaths };
+}
+
+function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const { canonical, buildchainClaims } = buildAll(options);
+  const summary = {
+    ok: true,
+    registry: rel(REGISTRY_PATH),
+    registrySha256: registrySha(),
+    releaseClaims: {
+      contract: canonical.contract,
+      standard: canonical.standard,
+      version: canonical.release.version,
+      channel: canonical.release.channel,
+      tag: canonical.release.tag,
+      sourceSha: canonical.release.sourceSha,
+      claimCount: canonical.claims.length,
+      sha256: sha256Buffer(Buffer.from(renderJson(canonical))),
+    },
+    buildchainProjection: {
+      claimInput: '--kfd-2-claim-json',
+      claimCount: buildchainClaims.length,
+      claims: buildchainClaims.map((claim) => ({
+        id: claim.id,
+        status: claim.residualRisk.length === 0 ? 'passed' : 'downgraded',
+        residualRisk: claim.residualRisk.length,
+      })),
+    },
+  };
+  if (options.write) {
+    const written = writeOutput(options.outputDir, canonical, buildchainClaims);
+    summary.outputDir = rel(options.outputDir);
+    summary.releaseClaims.path = rel(written.canonicalPath);
+    summary.buildchainProjection.claims = written.claimPaths.map(
+      (claimPath, index) => ({
+        ...summary.buildchainProjection.claims[index],
+        path: rel(claimPath),
+      }),
+    );
+  }
+  if (options.json) {
+    process.stdout.write(renderJson(summary));
+  } else if (options.write) {
+    console.log(
+      `[kfd2] wrote ${summary.releaseClaims.path} and ${buildchainClaims.length} Buildchain claim projection(s)`,
+    );
+  } else {
+    console.log(
+      `[kfd2] ok: ${canonical.claims.length} claim(s), registry sha256:${summary.registrySha256}`,
+    );
+  }
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(
+    `[kfd2] ${error instanceof Error ? error.message : String(error)}`,
+  );
+  process.exit(1);
+}

--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -216,6 +216,25 @@ function main() {
         `verify-agent-pack exited ${agentPack.status}`,
     );
 
+  // ── Stage 0d: KFD-2 release claims registry ──────────────────────
+  // The release claims are product-owned facts. The verifier checks the source
+  // registry and Buildchain projection without writing generated .buildchain
+  // files.
+  console.log('\n[verify] stage 0d: KFD-2 release claims registry');
+  const kfd2Claims = spawnSync(
+    process.execPath,
+    [path.join(__dirname, 'kfd2-release-claims.mjs'), '--check'],
+    { encoding: 'utf8' },
+  );
+  if (kfd2Claims.status === 0)
+    pass('KFD-2 release claims registry', (kfd2Claims.stdout || '').trim());
+  else
+    fail(
+      'KFD-2 release claims registry',
+      `${kfd2Claims.stdout || ''}${kfd2Claims.stderr || ''}`.trim() ||
+        `kfd2-release-claims exited ${kfd2Claims.status}`,
+    );
+
   // ── Stage 0: toolchain preflight (read-only) ──────────────────────
   console.log('\n[verify] stage 0: toolchain preflight');
   const uv = spawnSync('uv', ['--version'], { encoding: 'utf8', shell: isWin });


### PR DESCRIPTION
## Summary
- add the KFD-2 release claims registry and generator
- carry forward the KFD-3 collaboration-interface design docs
- add runner smoke workflows for the three self-hosted hosts and v4 labels
- keep boto3 out of the frozen runtime exclusion path

## Notes
- older agent onboarding, fact bridge, and kfx distribution feature branches are already covered by the current dev/v4 implementation, so their stale patches were not reapplied
- v2.4 release-verify runner patches were not applied because dev/v4 delegates product builds to the Buildchain workflow preset

## Verification
- node scripts/kfd2-release-claims.mjs --check
- node --check scripts/kfd2-release-claims.mjs
- node --check scripts/verify.mjs
- node --check scripts/no-bash-guard.mjs
- python3 -m py_compile framework/core/src/python/kungfu/yijinjing/journal.py framework/core/src/python/kungfu_cli.py
- ./kungfu-code check