### PR TITLE
ci: force windows lifecycle scripts onto pinned node

### DIFF
--- a/scripts/buildchain-run-kungfu-code.mjs
+++ b/scripts/buildchain-run-kungfu-code.mjs
@@ -388,6 +388,47 @@ function createPnpmShimDir() {
   return shimDir;
 }
 
+function createWindowsNodeShimDir(nodeExe) {
+  const shimDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'kungfu-buildchain-node-'),
+  );
+  const escapedNodeExe = nodeExe.replace(/%/g, '%%');
+  fs.writeFileSync(
+    path.join(shimDir, 'node.cmd'),
+    `@echo off\r\n"${escapedNodeExe}" %*\r\n`,
+    'utf8',
+  );
+  return shimDir;
+}
+
+function resolveWindowsPinnedNode(env) {
+  if (
+    process.platform !== 'win32' ||
+    !commandAvailable('fnm', ['--version'], env)
+  ) {
+    return '';
+  }
+
+  spawnSync('fnm', ['install'], {
+    cwd: repoRoot,
+    env,
+    stdio: 'ignore',
+    shell: true,
+  });
+
+  const result = runAndCollect(
+    'fnm',
+    ['exec', '--', 'node', '-p', 'process.execPath'],
+    env,
+  );
+  if (result.status !== 0) {
+    return '';
+  }
+
+  const nodeExe = result.stdout.trim().split(/\r?\n/).pop()?.trim() || '';
+  return nodeExe && fs.existsSync(nodeExe) ? nodeExe : '';
+}
+
 function runWindowsPnpm(args, env) {
   if (commandAvailable('fnm', ['--version'], env)) {
     spawnSync('fnm', ['install'], {
@@ -416,6 +457,21 @@ let env = withPathPrefixes(process.env, [
   createPnpmShimDir(),
   ...windowsToolPathDirs(process.env),
 ]);
+const pinnedWindowsNode = resolveWindowsPinnedNode(env);
+if (pinnedWindowsNode) {
+  console.error(`[buildchain-run] using pinned Node ${pinnedWindowsNode}`);
+  env = withPathPrefixes(
+    {
+      ...env,
+      npm_node_execpath: pinnedWindowsNode,
+      NODE: pinnedWindowsNode,
+    },
+    [
+      createWindowsNodeShimDir(pinnedWindowsNode),
+      path.dirname(pinnedWindowsNode),
+    ],
+  );
+}
 env = ensureWindowsUv(env);
 env = ensureWindowsMsvcEnv(env);
 env.KUNGFU_BUILDCHAIN_NO_OPTIONAL = '1';


### PR DESCRIPTION
## Summary\n- resolve the fnm-pinned Windows node executable before running pnpm\n- prepend a temporary node.cmd shim so pnpm lifecycle scripts inherit Node 22\n- export npm_node_execpath/NODE for child tooling\n\n## Validation\n- node --check scripts/buildchain-run-kungfu-code.mjs\n- ./kungfu-code exec biome check scripts/buildchain-run-kungfu-code.mjs\n- ./kungfu-code run check:types\n- git diff --check\n- DARKHERO targeted smoke: node and corepack.cmd pnpm exec node both report v22.22.3\n- DARKHERO targeted verify: corepack.cmd pnpm run verify passes 22/22 with node version pinned v22.22.3