### PR TITLE
ci: run windows pnpm with pinned node

### DIFF
--- a/scripts/buildchain-run-kungfu-code.mjs
+++ b/scripts/buildchain-run-kungfu-code.mjs
@@ -429,7 +429,27 @@ function resolveWindowsPinnedNode(env) {
   return nodeExe && fs.existsSync(nodeExe) ? nodeExe : '';
 }
 
-function runWindowsPnpm(args, env) {
+function corepackJsForNode(nodeExe) {
+  const corepackJs = path.join(
+    path.dirname(nodeExe),
+    'node_modules',
+    'corepack',
+    'dist',
+    'corepack.js',
+  );
+  return fs.existsSync(corepackJs) ? corepackJs : '';
+}
+
+function runWindowsPnpm(args, env, pinnedNode) {
+  const corepackJs = pinnedNode ? corepackJsForNode(pinnedNode) : '';
+  if (corepackJs) {
+    return spawnSync(pinnedNode, [corepackJs, 'pnpm', ...args], {
+      cwd: repoRoot,
+      env,
+      stdio: 'inherit',
+    });
+  }
+
   if (commandAvailable('fnm', ['--version'], env)) {
     spawnSync('fnm', ['install'], {
       cwd: repoRoot,
@@ -478,7 +498,7 @@ env.KUNGFU_BUILDCHAIN_NO_OPTIONAL = '1';
 env.KUNGFU_BUILDCHAIN_SOURCE_BUILD = '1';
 const result =
   process.platform === 'win32'
-    ? runWindowsPnpm(argv, env)
+    ? runWindowsPnpm(argv, env, pinnedWindowsNode)
     : spawnSync(path.join(repoRoot, 'kungfu-code'), argv, {
         cwd: repoRoot,
         env,


### PR DESCRIPTION
## Summary\n- run Windows pnpm through the Corepack JS owned by the fnm-pinned Node installation\n- keep the temporary node.cmd shim so pnpm lifecycle scripts also resolve node to the pinned runtime\n- avoid Actions setup-node 24 leaking into process.execPath for artifact packaging\n\n## Validation\n- node --check scripts/buildchain-run-kungfu-code.mjs\n- ./kungfu-code exec biome check scripts/buildchain-run-kungfu-code.mjs\n- ./kungfu-code run check:types\n- git diff --check\n- DARKHERO mechanism smoke: pinned node runs Corepack JS and pnpm lifecycle script process.execPath resolves to v22.22.3