### PR TITLE
feat(product): isolate dev instance homes for worktrees

### DIFF
--- a/artifact/scripts/product.mjs
+++ b/artifact/scripts/product.mjs
@@ -5,6 +5,9 @@
 // regress to a GUI-only build.
 
 import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { copyFileSync, existsSync, mkdirSync } from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -15,12 +18,17 @@ const isWin = process.platform === 'win32';
 function usage(code) {
   process.stdout.write(
     [
-      'usage: ./kungfu-code product gui dev|build|pack|dist [--dry-run]',
-      '       ./kungfu-code product tui dev|build|bundle|dist [--dry-run]',
+      'usage: ./kungfu-code product gui dev|build|pack|dist [--dry-run] [--instance-home <path>] [--no-instance-home]',
+      '       ./kungfu-code product tui dev|build|bundle|dist [--dry-run] [--instance-home <path>] [--no-instance-home]',
       '',
       'gui build/pack  -> artifact-level unpacked app under artifact/dist',
       'gui dist        -> artifact-level DMG/zip under artifact/dist',
       'tui bundle/dist -> bundled TUI under framework/tui/dist',
+      '',
+      '--instance-home, --home, -H <path>',
+      '  run the product against an isolated Kungfu instance root:',
+      '  KF_HOME=<path>/home, KF_CONFIG_HOME=<path>/config, KF_RUNTIME_DIR=<path>/home/runtime',
+      '  dev commands auto-pick an instance root for linked git worktrees',
       '',
     ].join('\n'),
   );
@@ -38,13 +46,192 @@ function exitLabel(result) {
     : String(result.status);
 }
 
+function expandHomePath(value) {
+  if (!value || !value.trim())
+    fail('--instance-home requires a non-empty path');
+  const raw = value.trim();
+  if (raw === '~') return os.homedir();
+  if (raw.startsWith('~/') || raw.startsWith('~\\')) {
+    return path.join(os.homedir(), raw.slice(2));
+  }
+  return raw;
+}
+
+function resolveInstanceHome(value) {
+  return path.resolve(ROOT, expandHomePath(value));
+}
+
+function sanitizeInstanceName(value) {
+  const name = value
+    .trim()
+    .replace(/[^A-Za-z0-9._-]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return name || 'worktree';
+}
+
+function defaultInstanceRoot(env = process.env) {
+  return path.resolve(
+    expandHomePath(
+      env.KF_AUTO_INSTANCE_ROOT ||
+        path.join(os.homedir(), '.kungfu', 'instances'),
+    ),
+  );
+}
+
+function defaultConfigHome() {
+  return path.resolve(expandHomePath(path.join(os.homedir(), '.kungfu')));
+}
+
+function instanceConfigPath(instanceHome) {
+  return path.join(instanceHome, 'config', 'config.json');
+}
+
+function seedInstanceConfig(instanceHome, options = {}) {
+  const sourceConfigHome = options.sourceConfigHome || defaultConfigHome();
+  const source = path.join(sourceConfigHome, 'config.json');
+  const target = instanceConfigPath(instanceHome);
+  if (existsSync(target)) {
+    return { seeded: false, reason: 'target-exists', source, target };
+  }
+  if (!existsSync(source)) {
+    return { seeded: false, reason: 'source-missing', source, target };
+  }
+  mkdirSync(path.dirname(target), { recursive: true });
+  copyFileSync(source, target);
+  return { seeded: true, source, target };
+}
+
+function instanceHomeForWorktree(worktreeRoot, env = process.env) {
+  const resolvedRoot = path.resolve(worktreeRoot);
+  const name = sanitizeInstanceName(path.basename(resolvedRoot));
+  const hash = createHash('sha256')
+    .update(resolvedRoot)
+    .digest('hex')
+    .slice(0, 10);
+  return path.join(defaultInstanceRoot(env), 'worktrees', `${name}-${hash}`);
+}
+
+function gitOutput(args, cwd = ROOT) {
+  const result = spawnSync('git', args, {
+    cwd,
+    encoding: 'utf8',
+  });
+  if (result.status !== 0) return '';
+  return result.stdout.trim();
+}
+
+function isLinkedGitWorktree(cwd = ROOT) {
+  const gitDir = gitOutput(
+    ['rev-parse', '--path-format=absolute', '--git-dir'],
+    cwd,
+  );
+  const commonDir = gitOutput(
+    ['rev-parse', '--path-format=absolute', '--git-common-dir'],
+    cwd,
+  );
+  return Boolean(
+    gitDir && commonDir && path.resolve(gitDir) !== path.resolve(commonDir),
+  );
+}
+
+function shouldAutoInstanceHome(parsed, surface, verb, env = process.env) {
+  return Boolean(
+    !parsed.noInstanceHome &&
+      !parsed.instanceHome &&
+      !env.KF_INSTANCE_HOME &&
+      !env.KF_HOME &&
+      !env.KF_CONFIG_HOME &&
+      verb === 'dev' &&
+      (surface === 'gui' || surface === 'tui') &&
+      isLinkedGitWorktree(ROOT),
+  );
+}
+
+function instanceEnv(instanceHome, baseEnv = process.env) {
+  if (!instanceHome) return { ...baseEnv };
+  const runtimeHome = path.join(instanceHome, 'home');
+  return {
+    ...baseEnv,
+    KF_INSTANCE_HOME: instanceHome,
+    KF_HOME: runtimeHome,
+    KF_CONFIG_HOME: path.join(instanceHome, 'config'),
+    KF_RUNTIME_DIR: path.join(runtimeHome, 'runtime'),
+  };
+}
+
+function parseArgs(argv) {
+  const parsed = {
+    dryRun: false,
+    instanceHome: '',
+    noInstanceHome: false,
+    positional: [],
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--dry-run') {
+      parsed.dryRun = true;
+    } else if (arg === '--no-instance-home') {
+      parsed.noInstanceHome = true;
+    } else if (arg === '--instance-home' || arg === '--home' || arg === '-H') {
+      i += 1;
+      if (i >= argv.length) fail(`${arg} requires a path`);
+      parsed.instanceHome = resolveInstanceHome(argv[i]);
+    } else if (arg.startsWith('--instance-home=')) {
+      parsed.instanceHome = resolveInstanceHome(
+        arg.slice('--instance-home='.length),
+      );
+    } else if (arg.startsWith('--home=')) {
+      parsed.instanceHome = resolveInstanceHome(arg.slice('--home='.length));
+    } else if (arg.startsWith('-')) {
+      fail(`unknown option: ${arg}`);
+    } else {
+      parsed.positional.push(arg);
+    }
+  }
+  return parsed;
+}
+
+function envDiff(env) {
+  return [
+    ['KF_INSTANCE_HOME', env.KF_INSTANCE_HOME],
+    ['KF_HOME', env.KF_HOME],
+    ['KF_CONFIG_HOME', env.KF_CONFIG_HOME],
+    ['KF_RUNTIME_DIR', env.KF_RUNTIME_DIR],
+  ]
+    .filter(([, value]) => value)
+    .map(([key, value]) => `${key}=${value}`);
+}
+
 function run(label, cmd, args, options = {}) {
   if (options.dryRun) {
+    if (options.autoInstanceHome) {
+      process.stdout.write(
+        `[dry-run] auto-instance-home: ${options.autoInstanceHome}\n`,
+      );
+    }
+    const diff = envDiff(options.env || {});
+    if (diff.length) {
+      process.stdout.write(`[dry-run] env: ${diff.join(' ')}\n`);
+    }
     process.stdout.write(`[dry-run] ${label}: ${[cmd, ...args].join(' ')}\n`);
     return;
   }
+  if (options.instanceHome) {
+    mkdirSync(options.instanceHome, { recursive: true });
+    mkdirSync(path.join(options.instanceHome, 'config'), { recursive: true });
+    mkdirSync(path.join(options.instanceHome, 'home', 'runtime'), {
+      recursive: true,
+    });
+    const seed = seedInstanceConfig(options.instanceHome);
+    if (seed.seeded) {
+      process.stdout.write(
+        `[instance-home] seeded config: ${seed.source} -> ${seed.target}\n`,
+      );
+    }
+  }
   const result = spawnSync(cmd, args, {
     cwd: ROOT,
+    env: options.env || process.env,
     stdio: 'inherit',
     shell: isWin,
   });
@@ -55,52 +242,96 @@ function pnpm(label, args, options) {
   run(label, 'pnpm', args, options);
 }
 
-const args = process.argv.slice(2);
-if (args.includes('--help') || args.includes('-h')) usage(0);
-const dryRun = args.includes('--dry-run');
-const positional = args.filter((arg) => arg !== '--dry-run');
-const [surface, verb] = positional;
+function main(argv = process.argv.slice(2)) {
+  if (argv.includes('--help') || argv.includes('-h')) usage(0);
+  const parsed = parseArgs(argv);
+  const { dryRun, positional } = parsed;
+  const [surface, verb] = positional;
+  const autoInstanceHome = shouldAutoInstanceHome(parsed, surface, verb)
+    ? instanceHomeForWorktree(ROOT)
+    : '';
+  const instanceHome =
+    parsed.instanceHome || process.env.KF_INSTANCE_HOME || autoInstanceHome;
+  const env = instanceEnv(instanceHome);
 
-if (!surface || !verb) usage(1);
+  if (!surface || !verb) usage(1);
 
-if (surface === 'gui') {
-  if (verb === 'dev') {
-    pnpm('gui dev', ['--filter', '@kungfu-tech/gui', 'run', 'dev'], { dryRun });
-  } else if (verb === 'build' || verb === 'pack') {
-    run(
-      'artifact dir build',
-      process.execPath,
-      ['artifact/scripts/dist.mjs', '--dir'],
-      {
+  if (surface === 'gui') {
+    if (verb === 'dev') {
+      pnpm('gui dev', ['--filter', '@kungfu-tech/gui', 'run', 'dev'], {
         dryRun,
-      },
-    );
-  } else if (verb === 'dist') {
-    run(
-      'artifact dist build',
-      process.execPath,
-      ['artifact/scripts/dist.mjs'],
-      {
+        env,
+        instanceHome,
+        autoInstanceHome,
+      });
+    } else if (verb === 'build' || verb === 'pack') {
+      run(
+        'artifact dir build',
+        process.execPath,
+        ['artifact/scripts/dist.mjs', '--dir'],
+        {
+          dryRun,
+          env,
+          instanceHome,
+          autoInstanceHome,
+        },
+      );
+    } else if (verb === 'dist') {
+      run(
+        'artifact dist build',
+        process.execPath,
+        ['artifact/scripts/dist.mjs'],
+        {
+          dryRun,
+          env,
+          instanceHome,
+          autoInstanceHome,
+        },
+      );
+    } else {
+      fail('unknown gui command (supported: dev, build, pack, dist)');
+    }
+  } else if (surface === 'tui') {
+    if (verb === 'dev') {
+      pnpm('tui dev', ['--filter', '@kungfu-tech/tui', 'run', 'dev'], {
         dryRun,
-      },
-    );
+        env,
+        instanceHome,
+        autoInstanceHome,
+      });
+    } else if (verb === 'build') {
+      pnpm('tui build', ['--filter', '@kungfu-tech/tui', 'run', 'build'], {
+        dryRun,
+        env,
+        instanceHome,
+        autoInstanceHome,
+      });
+    } else if (verb === 'bundle' || verb === 'dist') {
+      pnpm('tui bundle', ['--filter', '@kungfu-tech/tui', 'run', 'bundle'], {
+        dryRun,
+        env,
+        instanceHome,
+        autoInstanceHome,
+      });
+    } else {
+      fail('unknown tui command (supported: dev, build, bundle, dist)');
+    }
   } else {
-    fail('unknown gui command (supported: dev, build, pack, dist)');
+    fail('unknown product target (supported: gui, tui)');
   }
-} else if (surface === 'tui') {
-  if (verb === 'dev') {
-    pnpm('tui dev', ['--filter', '@kungfu-tech/tui', 'run', 'dev'], { dryRun });
-  } else if (verb === 'build') {
-    pnpm('tui build', ['--filter', '@kungfu-tech/tui', 'run', 'build'], {
-      dryRun,
-    });
-  } else if (verb === 'bundle' || verb === 'dist') {
-    pnpm('tui bundle', ['--filter', '@kungfu-tech/tui', 'run', 'bundle'], {
-      dryRun,
-    });
-  } else {
-    fail('unknown tui command (supported: dev, build, bundle, dist)');
-  }
-} else {
-  fail('unknown product target (supported: gui, tui)');
 }
+
+if (process.argv[1] && path.resolve(process.argv[1]) === __filename) {
+  main();
+}
+
+export {
+  instanceEnv,
+  instanceHomeForWorktree,
+  isLinkedGitWorktree,
+  main,
+  parseArgs,
+  resolveInstanceHome,
+  seedInstanceConfig,
+  shouldAutoInstanceHome,
+};

--- a/artifact/scripts/product.test.mjs
+++ b/artifact/scripts/product.test.mjs
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { homedir, tmpdir } from 'node:os';
+import path from 'node:path';
+import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+import {
+  instanceEnv,
+  instanceHomeForWorktree,
+  parseArgs,
+  resolveInstanceHome,
+  seedInstanceConfig,
+} from './product.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+
+test('parses an isolated instance home for product commands', () => {
+  const parsed = parseArgs([
+    'gui',
+    'dev',
+    '--instance-home',
+    '~/kungfu-demo',
+    '--dry-run',
+  ]);
+  assert.equal(parsed.dryRun, true);
+  assert.deepEqual(parsed.positional, ['gui', 'dev']);
+  assert.equal(parsed.instanceHome, path.join(homedir(), 'kungfu-demo'));
+  assert.equal(parsed.noInstanceHome, false);
+});
+
+test('parses the dev auto-instance opt-out flag', () => {
+  const parsed = parseArgs(['gui', 'dev', '--no-instance-home']);
+  assert.deepEqual(parsed.positional, ['gui', 'dev']);
+  assert.equal(parsed.noInstanceHome, true);
+});
+
+test('builds a consistent Kungfu instance environment', () => {
+  const home = resolveInstanceHome('relative-kungfu-home');
+  const env = instanceEnv(home, { PATH: '/bin' });
+  assert.equal(env.PATH, '/bin');
+  assert.equal(env.KF_INSTANCE_HOME, home);
+  assert.equal(env.KF_HOME, path.join(home, 'home'));
+  assert.equal(env.KF_CONFIG_HOME, path.join(home, 'config'));
+  assert.equal(env.KF_RUNTIME_DIR, path.join(home, 'home', 'runtime'));
+});
+
+test('derives a stable auto instance root from a worktree path', () => {
+  const root = path.join(tmpdir(), 'kungfu feature spaces', 'demo-worktree');
+  const home = instanceHomeForWorktree(root, {
+    KF_AUTO_INSTANCE_ROOT: path.join(tmpdir(), 'kf-instances'),
+  });
+  assert.match(
+    home,
+    new RegExp(
+      `${escapeRegExp(path.join(tmpdir(), 'kf-instances', 'worktrees'))}${escapeRegExp(path.sep)}demo-worktree-[0-9a-f]{10}$`,
+    ),
+  );
+});
+
+test('seeds default config into a fresh instance without overwriting it', () => {
+  const parent = mkdtempSync(path.join(tmpdir(), 'kungfu-product-seed-'));
+  const sourceHome = path.join(parent, 'default-config');
+  const instanceHome = path.join(parent, 'instance');
+  mkdirSync(sourceHome, { recursive: true });
+  writeFileSync(
+    path.join(sourceHome, 'config.json'),
+    '{"schema":"kungfu.config.override/v1","ui":{"scale":1.1}}\n',
+  );
+  try {
+    const first = seedInstanceConfig(instanceHome, {
+      sourceConfigHome: sourceHome,
+    });
+    const target = path.join(instanceHome, 'config', 'config.json');
+    assert.equal(first.seeded, true);
+    assert.equal(
+      readFileSync(target, 'utf8'),
+      readFileSync(first.source, 'utf8'),
+    );
+
+    writeFileSync(
+      target,
+      '{"schema":"kungfu.config.override/v1","ui":{"scale":2}}\n',
+    );
+    writeFileSync(
+      path.join(sourceHome, 'config.json'),
+      '{"schema":"kungfu.config.override/v1","ui":{"scale":3}}\n',
+    );
+    const second = seedInstanceConfig(instanceHome, {
+      sourceConfigHome: sourceHome,
+    });
+    assert.equal(second.seeded, false);
+    assert.equal(second.reason, 'target-exists');
+    assert.match(readFileSync(target, 'utf8'), /"scale":2/);
+  } finally {
+    rmSync(parent, { recursive: true, force: true });
+  }
+});
+
+test('dry-run shows instance env without creating the home', () => {
+  const parent = mkdtempSync(path.join(tmpdir(), 'kungfu-product-test-'));
+  const home = path.join(parent, 'instance-a');
+  try {
+    const result = spawnSync(
+      process.execPath,
+      [
+        __filename.replace(/\.test\.mjs$/, '.mjs'),
+        'gui',
+        'dev',
+        '-H',
+        home,
+        '--dry-run',
+      ],
+      { encoding: 'utf8' },
+    );
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.match(
+      result.stdout,
+      new RegExp(`KF_HOME=${escapeRegExp(path.join(home, 'home'))}`),
+    );
+    assert.match(
+      result.stdout,
+      new RegExp(`KF_CONFIG_HOME=${escapeRegExp(path.join(home, 'config'))}`),
+    );
+    assert.match(
+      result.stdout,
+      new RegExp(
+        `KF_RUNTIME_DIR=${escapeRegExp(path.join(home, 'home', 'runtime'))}`,
+      ),
+    );
+    assert.match(result.stdout, /pnpm --filter @kungfu-tech\/gui run dev/);
+    assert.equal(existsSync(home), false);
+  } finally {
+    rmSync(parent, { recursive: true, force: true });
+  }
+});
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/docs/config.md
+++ b/docs/config.md
@@ -111,6 +111,45 @@ defaults, optional user overrides, contract metadata, source metadata,
 `configHome`, `configPath`, and `runtimeHome`. The `contract.hash` field makes
 the exact contract world inspectable by users, agents, and release gates.
 
+## Isolated product instances
+
+Use an instance home when you need to run a second local Kungfu app without
+sharing the default homes:
+
+```sh
+./kungfu-code product gui dev --instance-home ~/kungfu-instances/demo
+```
+
+`--instance-home <path>` also accepts `--home <path>` and `-H <path>`. The
+argument is an instance root; the product launcher keeps config and runtime home
+separate under that root:
+
+```text
+KF_CONFIG_HOME=<path>/config
+KF_HOME=<path>/home
+KF_RUNTIME_DIR=<path>/home/runtime
+```
+
+For the GUI, Electron `userData` also moves under `<path>/userData`, so caches
+and app-window state do not collide with the default instance. The same option
+works with `product tui ...` commands.
+
+When `product gui dev` or `product tui dev` runs from a linked Git worktree and
+no explicit home environment or option is already set, Kungfu chooses an
+instance root automatically under:
+
+```text
+~/.kungfu/instances/worktrees/<worktree-name>-<hash>
+```
+
+Use `--no-instance-home` to disable this auto-selection for a dev launch.
+
+On the first real launch for an instance root, if
+`<path>/config/config.json` does not exist and the machine default
+`~/.kungfu/config.json` exists, the launcher copies that default config file
+into the instance config home. Later launches never overwrite the instance copy,
+so tests can change config without changing the machine default.
+
 `kungfu config set <dotted-key> <json-value>` writes a user override to
 `configPath`, validates it against the same contract, and returns the resolved
 config with `--json`. Plain values that are not JSON decode as strings, so

--- a/framework/gui/src/main/index.ts
+++ b/framework/gui/src/main/index.ts
@@ -61,6 +61,36 @@ const firstPartySourceRoot =
   process.env.KF_FIRST_PARTY_SOURCE_ROOT ||
   path.join(__dirname, '..', '..', '..', '..', 'extensions');
 
+function expandHomePath(value: string): string {
+  if (value === '~') return app.getPath('home');
+  if (value.startsWith('~/') || value.startsWith('~\\')) {
+    return path.join(app.getPath('home'), value.slice(2));
+  }
+  return value;
+}
+
+function resolveHomePath(value: string): string {
+  return path.resolve(expandHomePath(value));
+}
+
+// A product launcher may set KF_INSTANCE_HOME to make a second Kungfu process
+// independent from the default user-global homes. Keep the same mental model as
+// the default install: config and runtime home are separate directories.
+if (process.env.KF_INSTANCE_HOME) {
+  const instanceHome = resolveHomePath(process.env.KF_INSTANCE_HOME);
+  const runtimeHome = path.join(instanceHome, 'home');
+  process.env.KF_INSTANCE_HOME = instanceHome;
+  process.env.KF_HOME = runtimeHome;
+  process.env.KF_CONFIG_HOME = path.join(instanceHome, 'config');
+  process.env.KF_RUNTIME_DIR = path.join(runtimeHome, 'runtime');
+  const userDataHome = path.join(instanceHome, 'userData');
+  mkdirSync(userDataHome, { recursive: true });
+  app.setPath('userData', userDataHome);
+} else if (process.env.KF_HOME && !process.env.KF_RUNTIME_DIR) {
+  process.env.KF_HOME = resolveHomePath(process.env.KF_HOME);
+  process.env.KF_RUNTIME_DIR = path.join(process.env.KF_HOME, 'runtime');
+}
+
 type WindowChromePlatform = 'darwin' | 'win32' | 'linux' | 'other';
 type WindowChromeMode = 'native' | 'integrated' | 'custom';
 type WindowChromeControl = 'minimize' | 'toggle-maximize' | 'close';


### PR DESCRIPTION
## Summary
- add product dev instance-home handling for GUI and TUI launches
- auto-select an isolated instance root for linked git worktrees
- seed instance config from the machine default config once without overwriting test changes

## Tests
- node --test artifact/scripts/product.test.mjs
- ./kungfu-code product gui dev --dry-run
- ./kungfu-code product gui dev --no-instance-home --dry-run
- ./kungfu-code product tui dev --dry-run
- ./kungfu-code check
- git diff --check