### PR TITLE
feat(atlas): add storage fsck and export

### DIFF
--- a/docs/known-limits.md
+++ b/docs/known-limits.md
@@ -122,24 +122,25 @@ Trading-specific ones from earlier versions are being retired and their coverage
 role moved to neutral replacements that exercise the same paths; during this
 migration both may be present.
 
-## Runtime storage service is designed, not complete
+## Runtime storage service is only partially implemented
 
 The fact-ledger format direction includes an append-only event spine, payload
 content commitments, a blob store, schema registry, and manifest root
 ([`framework/spec/docs/format-spec.md`](../framework/spec/docs/format-spec.md)).
-The fact-ledger slice proves a minimal causal journal export path, but the
-unified user-data storage service is still a design plan
+The fact-ledger slice proves a minimal causal journal export path, and the Atlas
+scope now has a first payload import/fsck/export/verify loop
 ([`runtime-storage-service.md`](runtime-storage-service.md)).
 
 What is **not yet guaranteed**:
 
 - large payload bodies are not yet uniformly stored behind hash-addressed
-  journal references;
-- `kungfu storage fsck` does not yet verify journal, payloads, schemas, and
-  projections as one semantic unit;
+  references across every runtime scope;
+- `kungfu storage fsck` is currently Atlas-scoped, not a complete semantic check
+  for all journal, schema, projection, and payload classes;
 - range/session/hash import-export is not yet the remote sync substrate;
 - compaction is not yet a manifest-backed checkpoint/archive/GC/vacuum process;
 - Atlas import remains a read-only projection, not an authority migration.
 
-Until these land, treat existing journal archive/clean/rebuild primitives as
-maintenance tools, not as the complete persistence-service contract.
+Until these land, treat existing journal archive/clean/rebuild primitives and
+the Atlas storage commands as useful maintenance tools, not as the complete
+persistence-service contract.

--- a/docs/runtime-storage-service.md
+++ b/docs/runtime-storage-service.md
@@ -1,6 +1,6 @@
 # Runtime Storage Service
 
-Status: draft design plan.
+Status: draft design plan with an implemented Atlas first slice.
 
 Kungfu's fact ledger is not only an event capture mechanism. Long term, it is
 also the local persistence service for user facts: runs, work items, imported
@@ -90,9 +90,9 @@ kungfu storage fsck --scope atlas --json
 kungfu storage fsck --scope all --since 20d --json
 ```
 
-`fsck` should report degraded facts without rewriting them. A missing payload is
-not repaired by pretending it was absent; it is reported as missing until an
-import, repair, or redaction decision changes that state.
+`fsck` reports degraded facts without rewriting them. A missing payload is not
+repaired by pretending it was absent; it is reported as missing until an import,
+repair, or redaction decision changes that state.
 
 ## Import And Export
 
@@ -191,25 +191,30 @@ This lets `kungfu atlas import` remain safe and one-way while still exercising
 the same payload, manifest, fsck, and rebuild mechanisms required for future
 remote sync and authority migration.
 
-The first useful slice is:
+The implemented first slice is:
 
 ```sh
 kungfu atlas import --repo <atlas-repo> --json
 kungfu storage status --scope atlas --json
 kungfu storage fsck --scope atlas --json
-kungfu storage rebuild-index --scope atlas --json
+kungfu storage export --scope atlas --format jsonl --out atlas.jsonl --json
+kungfu atlas verify --repo <atlas-repo> --json
 ```
 
-Acceptance for that slice:
+Acceptance covered by that slice:
 
 - large Atlas JSON bodies are stored outside mmap frames as hash-addressed
   payloads;
-- journal events carry payload hash, size, content type, and state;
-- import writes a manifest with source head, object count, event range, payload
-  inventory, and projection watermark;
-- `fsck` detects missing payloads, hash mismatches, missing schemas, and
-  projection drift;
-- `rebuild-index` reconstructs the Atlas projection from journal plus payloads.
+- import writes a manifest with source head, object count, payload inventory,
+  and projection watermark;
+- `fsck` detects missing payloads, hash mismatches, malformed payload JSON, and
+  projection drift against the current Atlas projection;
+- `storage export` emits a canonical JSONL record per imported Atlas payload;
+- `atlas verify` recomputes source hashes from the Atlas repo and compares them
+  with the latest imported payload manifest.
+
+The first slice deliberately does not claim generic storage compaction, range
+sync, schema repair, or a complete rebuild-index command yet.
 
 ## Safety Boundaries
 
@@ -237,6 +242,7 @@ Storage service operations must preserve these boundaries:
 
 ## Maturity
 
-This is a draft design plan. It names the service boundary and phased target. It
-does not yet claim that Kungfu can repair arbitrary journal corruption, safely
-compact user data, or replace Atlas as an authority source.
+This is still a phased storage-service plan. The Atlas scope now has a concrete
+payload import, fsck, export, and source-verify loop; Kungfu still does not
+claim that it can repair arbitrary journal corruption, safely compact user data,
+run range/session/hash remote sync, or replace Atlas as an authority source.

--- a/framework/core/.gyp/run-build.js
+++ b/framework/core/.gyp/run-build.js
@@ -15,6 +15,18 @@ function copyConfigContract() {
   copyContractArtifacts(path.join(CORE, 'dist', 'kungfu'));
 }
 
+/**
+ * @param {string} sourceDir
+ * @param {string} targetDir
+ * @param {Set<string>} staged
+ */
+function copyBuildInfo(sourceDir, targetDir, staged) {
+  const source = path.join(sourceDir, 'kungfubuildinfo.json');
+  if (!fs.existsSync(source) || staged.has('kungfubuildinfo.json')) return;
+  staged.add('kungfubuildinfo.json');
+  fs.copyFileSync(source, path.join(targetDir, 'kungfubuildinfo.json'));
+}
+
 function cpVsDependencies() {
   const isWin = process.platform === 'win32';
   if (!isWin) return;
@@ -53,6 +65,7 @@ function stage() {
   if (process.platform === 'win32') buildDirs.push('build');
   const staged = new Set();
   for (const buildDir of buildDirs) {
+    copyBuildInfo(buildDir, distKungfu, staged);
     for (const pattern of [
       '*.node',
       '*.pyd',

--- a/framework/core/src/python/kungfu/atlas/importer.py
+++ b/framework/core/src/python/kungfu/atlas/importer.py
@@ -45,6 +45,20 @@ def _cards(root, warnings, required=True):
             yield card
 
 
+def _cards_with_path(root, repo_root, warnings, required=True):
+    if not os.path.isdir(root):
+        if required:
+            warnings.append(f"{root}: missing directory")
+        return
+    for name in sorted(os.listdir(root)):
+        if not name.endswith(".json"):
+            continue
+        path = os.path.join(root, name)
+        card = _read_json(path, warnings)
+        if card is not None:
+            yield card, os.path.relpath(path, repo_root)
+
+
 def _text(value):
     if value is None:
         return None
@@ -90,6 +104,30 @@ def read_missions(repo_root, warnings):
     return [card for card in missions if card["mission_id"]]
 
 
+def _mission_records(repo_root, warnings):
+    records = []
+    base = os.path.join(repo_root, "agent-journal", "missions", "registry")
+    for state in ("active", "archive"):
+        for card, source_path in _cards_with_path(
+            os.path.join(base, state),
+            repo_root,
+            warnings,
+            required=state == "active",
+        ):
+            mission_id = _text(card.get("mission_id"))
+            if mission_id:
+                records.append(
+                    {
+                        "kind": "mission",
+                        "source_id": mission_id,
+                        "source_path": source_path,
+                        "schema_version": 1,
+                        "payload": card,
+                    }
+                )
+    return records
+
+
 def read_goals(repo_root, warnings):
     goals = []
     base = os.path.join(repo_root, "agent-journal", "goals", "registry")
@@ -121,6 +159,30 @@ def read_goals(repo_root, warnings):
     return [card for card in goals if card["goal_id"]]
 
 
+def _goal_records(repo_root, warnings):
+    records = []
+    base = os.path.join(repo_root, "agent-journal", "goals", "registry")
+    for state in ("active", "archive"):
+        for card, source_path in _cards_with_path(
+            os.path.join(base, state),
+            repo_root,
+            warnings,
+            required=state == "active",
+        ):
+            goal_id = _text(card.get("goal_id"))
+            if goal_id:
+                records.append(
+                    {
+                        "kind": "goal",
+                        "source_id": goal_id,
+                        "source_path": source_path,
+                        "schema_version": 1,
+                        "payload": card,
+                    }
+                )
+    return records
+
+
 def read_markers(repo_root, warnings):
     markers: list[dict[str, Any]] = []
     base = os.path.join(repo_root, "reviews", "worktree-status")
@@ -150,6 +212,33 @@ def read_markers(repo_root, warnings):
     return [card for card in markers if card["branch"]]
 
 
+def _marker_records(repo_root, warnings):
+    records = []
+    base = os.path.join(repo_root, "reviews", "worktree-status")
+    if not os.path.isdir(base):
+        warnings.append(f"{base}: missing directory")
+        return records
+    for name in sorted(os.listdir(base)):
+        if not name.endswith(".json"):
+            continue
+        path = os.path.join(base, name)
+        card = _read_json(path, warnings)
+        if card is None:
+            continue
+        branch = _text(card.get("branch"))
+        if branch:
+            records.append(
+                {
+                    "kind": "marker",
+                    "source_id": branch,
+                    "source_path": os.path.relpath(path, repo_root),
+                    "schema_version": 1,
+                    "payload": card,
+                }
+            )
+    return records
+
+
 def read_control_plane(repo_root):
     """One defensive pass over the three source surfaces.
 
@@ -161,3 +250,17 @@ def read_control_plane(repo_root):
     goals = read_goals(repo_root, warnings)
     markers = read_markers(repo_root, warnings)
     return missions, goals, markers, warnings
+
+
+def read_control_plane_with_sources(repo_root):
+    """Read projection cards plus complete JSON source records."""
+    warnings: list[str] = []
+    missions = read_missions(repo_root, warnings)
+    goals = read_goals(repo_root, warnings)
+    markers = read_markers(repo_root, warnings)
+    source_records = (
+        _mission_records(repo_root, warnings)
+        + _goal_records(repo_root, warnings)
+        + _marker_records(repo_root, warnings)
+    )
+    return missions, goals, markers, source_records, warnings

--- a/framework/core/src/python/kungfu/atlas/payloads.py
+++ b/framework/core/src/python/kungfu/atlas/payloads.py
@@ -1,0 +1,363 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+CONTENT_TYPE_JSON = "application/json"
+PAYLOAD_STATE_PRESENT = "present"
+
+
+def canonical_json_bytes(value: Any) -> bytes:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+
+def payload_hash(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+def payload_path(store_dir: str | Path, digest: str) -> Path:
+    root = Path(store_dir) / "payloads" / digest[:2]
+    return root / f"{digest}.json"
+
+
+def latest_manifest_path(store_dir: str | Path) -> Path:
+    return Path(store_dir) / "imports" / "latest.json"
+
+
+def import_manifest_path(store_dir: str | Path, import_id: str) -> Path:
+    return Path(store_dir) / "imports" / f"{import_id}.json"
+
+
+def _source_payload(record: dict[str, Any]) -> dict[str, Any]:
+    payload = record.get("payload")
+    return payload if isinstance(payload, dict) else {}
+
+
+def enrich_source_records(source_records: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    enriched = []
+    for record in source_records:
+        raw = canonical_json_bytes(_source_payload(record))
+        digest = payload_hash(raw)
+        row = {
+            "kind": record.get("kind"),
+            "source_id": record.get("source_id"),
+            "source_path": record.get("source_path"),
+            "schema_version": record.get("schema_version"),
+            "content_type": CONTENT_TYPE_JSON,
+            "payload_hash": digest,
+            "byte_len": len(raw),
+            "payload_state": PAYLOAD_STATE_PRESENT,
+            "payload": _source_payload(record),
+        }
+        enriched.append(row)
+    return enriched
+
+
+def write_import_payloads(
+    store_dir: str | Path,
+    *,
+    import_id: str,
+    repo_root: str,
+    repo_head: str | None,
+    source_records: list[dict[str, Any]],
+    counts: dict[str, int],
+) -> dict[str, Any]:
+    store_dir = Path(store_dir)
+    entries = []
+    for record in enrich_source_records(source_records):
+        raw = canonical_json_bytes(record["payload"])
+        path = payload_path(store_dir, record["payload_hash"])
+        path.parent.mkdir(parents=True, exist_ok=True)
+        if not path.exists():
+            path.write_bytes(raw)
+        entries.append({k: v for k, v in record.items() if k != "payload"})
+
+    manifest = {
+        "schema": "kungfu.atlas-import/v1",
+        "import_id": import_id,
+        "repo_root": repo_root,
+        "repo_head": repo_head,
+        "hash_algorithm": "sha256",
+        "counts": counts,
+        "entries": sorted(
+            entries,
+            key=lambda row: (
+                str(row.get("kind") or ""),
+                str(row.get("source_id") or ""),
+                str(row.get("source_path") or ""),
+            ),
+        ),
+    }
+
+    manifest_path = import_manifest_path(store_dir, import_id)
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest_path.write_text(
+        json.dumps(manifest, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    latest_manifest_path(store_dir).write_text(
+        json.dumps(manifest, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return manifest
+
+
+def load_latest_manifest(store_dir: str | Path) -> dict[str, Any] | None:
+    path = latest_manifest_path(store_dir)
+    if not path.exists():
+        return None
+    with path.open(encoding="utf-8") as f:
+        data = json.load(f)
+    return data if isinstance(data, dict) else None
+
+
+def _entry_key(entry: dict[str, Any]) -> tuple[str, str]:
+    return str(entry.get("kind") or ""), str(entry.get("source_id") or "")
+
+
+def _load_payload(
+    store_dir: str | Path, entry: dict[str, Any]
+) -> tuple[dict[str, Any] | None, str | None]:
+    digest = str(entry.get("payload_hash") or "")
+    path = payload_path(store_dir, digest)
+    if not path.exists():
+        return None, "payload_missing"
+    raw = path.read_bytes()
+    if len(raw) != entry.get("byte_len"):
+        return None, "byte_len_mismatch"
+    if payload_hash(raw) != digest:
+        return None, "hash_mismatch"
+    try:
+        data = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return None, "payload_decode_error"
+    if not isinstance(data, dict):
+        return None, "payload_not_object"
+    return data, None
+
+
+def fsck_import(
+    store_dir: str | Path,
+    projection: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    manifest = load_latest_manifest(store_dir)
+    report = {
+        "ok": True,
+        "scope": "atlas",
+        "import_id": None,
+        "errors": [],
+        "warnings": [],
+        "checked": {
+            "payloads": 0,
+            "missions": 0,
+            "goals": 0,
+            "markers": 0,
+        },
+    }
+    if manifest is None:
+        report["ok"] = False
+        report["errors"].append({"code": "manifest_missing"})
+        return report
+
+    report["import_id"] = manifest.get("import_id")
+    entries = manifest.get("entries")
+    if not isinstance(entries, list):
+        report["ok"] = False
+        report["errors"].append({"code": "manifest_entries_invalid"})
+        return report
+
+    seen: set[tuple[str, str]] = set()
+    for entry in entries:
+        if not isinstance(entry, dict):
+            report["ok"] = False
+            report["errors"].append({"code": "manifest_entry_invalid"})
+            continue
+        key = _entry_key(entry)
+        if key in seen:
+            report["ok"] = False
+            report["errors"].append(
+                {"code": "duplicate_source", "kind": key[0], "source_id": key[1]}
+            )
+        seen.add(key)
+
+        kind = str(entry.get("kind") or "")
+        if kind in ("mission", "goal", "marker"):
+            report["checked"][f"{kind}s"] += 1
+        report["checked"]["payloads"] += 1
+
+        if entry.get("payload_state") != PAYLOAD_STATE_PRESENT:
+            report["warnings"].append(
+                {
+                    "code": "payload_not_present",
+                    "kind": kind,
+                    "source_id": entry.get("source_id"),
+                    "state": entry.get("payload_state"),
+                }
+            )
+            continue
+        _, error = _load_payload(store_dir, entry)
+        if error:
+            report["ok"] = False
+            report["errors"].append(
+                {
+                    "code": error,
+                    "kind": kind,
+                    "source_id": entry.get("source_id"),
+                    "payload_hash": entry.get("payload_hash"),
+                }
+            )
+
+    counts = manifest.get("counts") if isinstance(manifest.get("counts"), dict) else {}
+    for key in ("missions", "goals", "markers"):
+        expected = counts.get(key)
+        if expected is not None and expected != report["checked"][key]:
+            report["ok"] = False
+            report["errors"].append(
+                {
+                    "code": "manifest_count_mismatch",
+                    "kind": key,
+                    "expected": expected,
+                    "actual": report["checked"][key],
+                }
+            )
+
+    if projection is not None:
+        projection_keys = {
+            "missions": {
+                ("mission", str(key)) for key in projection.get("missions", {})
+            },
+            "goals": {("goal", str(key)) for key in projection.get("goals", {})},
+            "markers": {("marker", str(key)) for key in projection.get("markers", {})},
+        }
+        manifest_keys = {
+            "missions": {key for key in seen if key[0] == "mission"},
+            "goals": {key for key in seen if key[0] == "goal"},
+            "markers": {key for key in seen if key[0] == "marker"},
+        }
+        for key in ("missions", "goals", "markers"):
+            actual = len(projection_keys[key])
+            expected = len(manifest_keys[key])
+            if actual != expected:
+                report["ok"] = False
+                report["errors"].append(
+                    {
+                        "code": "projection_count_mismatch",
+                        "kind": key,
+                        "expected": expected,
+                        "actual": actual,
+                    }
+                )
+            if projection_keys[key] != manifest_keys[key]:
+                report["ok"] = False
+                report["errors"].append(
+                    {
+                        "code": "projection_id_mismatch",
+                        "kind": key,
+                        "missing_in_projection": [
+                            {"kind": kind, "source_id": source_id}
+                            for kind, source_id in sorted(
+                                manifest_keys[key] - projection_keys[key]
+                            )
+                        ],
+                        "extra_in_projection": [
+                            {"kind": kind, "source_id": source_id}
+                            for kind, source_id in sorted(
+                                projection_keys[key] - manifest_keys[key]
+                            )
+                        ],
+                    }
+                )
+        if projection.get("import_id") != manifest.get("import_id"):
+            report["ok"] = False
+            report["errors"].append(
+                {
+                    "code": "projection_import_mismatch",
+                    "manifest_import_id": manifest.get("import_id"),
+                    "projection_import_id": projection.get("import_id"),
+                }
+            )
+
+    return report
+
+
+def export_records(store_dir: str | Path) -> list[dict[str, Any]]:
+    manifest = load_latest_manifest(store_dir)
+    if manifest is None:
+        raise FileNotFoundError(str(latest_manifest_path(store_dir)))
+    records = []
+    for entry in manifest.get("entries", []):
+        payload, error = _load_payload(store_dir, entry)
+        if error:
+            raise ValueError(f"{error}: {entry.get('kind')}:{entry.get('source_id')}")
+        row = dict(entry)
+        row["scope"] = "atlas"
+        row["import_id"] = manifest.get("import_id")
+        row["repo_head"] = manifest.get("repo_head")
+        row["source_head"] = manifest.get("repo_head")
+        row["payload"] = payload
+        records.append(row)
+    records.sort(
+        key=lambda row: (
+            str(row.get("kind") or ""),
+            str(row.get("source_id") or ""),
+            str(row.get("source_path") or ""),
+        )
+    )
+    return records
+
+
+def write_jsonl(records: list[dict[str, Any]], out_path: str | Path) -> None:
+    with open(out_path, "w", encoding="utf-8") as f:
+        for record in records:
+            f.write(
+                json.dumps(
+                    record, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+                )
+                + "\n"
+            )
+
+
+def verify_against_source(
+    store_dir: str | Path,
+    source_records: list[dict[str, Any]],
+) -> dict[str, Any]:
+    exported = {_entry_key(record): record for record in export_records(store_dir)}
+    source = {
+        _entry_key(record): record for record in enrich_source_records(source_records)
+    }
+    missing = []
+    extra = []
+    mismatched = []
+    for key, row in source.items():
+        current = exported.get(key)
+        if current is None:
+            missing.append({"kind": key[0], "source_id": key[1]})
+            continue
+        if current.get("payload_hash") != row.get("payload_hash"):
+            mismatched.append(
+                {
+                    "kind": key[0],
+                    "source_id": key[1],
+                    "expected": row.get("payload_hash"),
+                    "actual": current.get("payload_hash"),
+                }
+            )
+    for key in exported:
+        if key not in source:
+            extra.append({"kind": key[0], "source_id": key[1]})
+
+    return {
+        "ok": not missing and not extra and not mismatched,
+        "scope": "atlas",
+        "checked": len(source),
+        "missing": missing,
+        "extra": extra,
+        "hash_mismatch": mismatched,
+    }

--- a/framework/core/src/python/kungfu/atlas/store.py
+++ b/framework/core/src/python/kungfu/atlas/store.py
@@ -22,6 +22,7 @@ from kungfu.atlas import (
     SCHEMA_VERSION,
     events,
     importer,
+    payloads,
 )
 from kungfu.atlas.fb.GoalSnapshot import GoalSnapshot
 from kungfu.atlas.fb.ImportBegin import ImportBegin
@@ -50,6 +51,10 @@ def _location(runtime_dir):
     )
 
 
+def store_dir(runtime_dir):
+    return os.path.join(runtime_dir, "atlas", "store")
+
+
 def _text(value):
     return value.decode() if value is not None else None
 
@@ -76,13 +81,16 @@ class ImportStore:
         """Import one snapshot batch from repo_root. Returns a result dict."""
         repo_root = os.path.abspath(repo_root)
         import_id = "imp" + uuid.uuid4().hex[:8]
-        missions, goals, markers, warnings = importer.read_control_plane(repo_root)
+        repo_head = importer.repo_head(repo_root)
+        missions, goals, markers, source_records, warnings = (
+            importer.read_control_plane_with_sources(repo_root)
+        )
         self._append(
             MSG_IMPORT_BEGIN,
             events.import_begin(
                 import_id,
                 repo_root,
-                importer.repo_head(repo_root),
+                repo_head,
                 SCHEMA_VERSION,
             ),
         )
@@ -98,18 +106,32 @@ class ImportStore:
                 import_id, len(missions), len(goals), len(markers), len(warnings)
             ),
         )
+        payloads.write_import_payloads(
+            self.store_dir(),
+            import_id=import_id,
+            repo_root=repo_root,
+            repo_head=repo_head,
+            source_records=source_records,
+            counts={
+                "missions": len(missions),
+                "goals": len(goals),
+                "markers": len(markers),
+            },
+        )
         self.emit_manifest()
         return {
             "import_id": import_id,
             "repo_root": repo_root,
+            "repo_head": repo_head,
             "missions": len(missions),
             "goals": len(goals),
             "markers": len(markers),
+            "payloads": len(source_records),
             "warnings": warnings,
         }
 
     def store_dir(self):
-        return os.path.join(self.runtime_dir, "atlas", "store")
+        return store_dir(self.runtime_dir)
 
     def emit_manifest(self):
         """Pin the store's schema bindings (content-addressed .bfbs + manifest)."""
@@ -252,3 +274,53 @@ def load(runtime_dir):
         return None
     completed.sort(key=lambda entry: entry[0])
     return batches[completed[-1][1]]
+
+
+def status(runtime_dir):
+    projection = load(runtime_dir)
+    manifest = payloads.load_latest_manifest(store_dir(runtime_dir))
+    if manifest is None:
+        return {
+            "ok": False,
+            "scope": "atlas",
+            "reason": "no completed payload manifest",
+        }
+    return {
+        "ok": projection is not None,
+        "scope": "atlas",
+        "import_id": manifest.get("import_id"),
+        "repo_root": manifest.get("repo_root"),
+        "repo_head": manifest.get("repo_head"),
+        "payloads": len(manifest.get("entries", [])),
+        "missions": len(projection.get("missions", {})) if projection else 0,
+        "goals": len(projection.get("goals", {})) if projection else 0,
+        "markers": len(projection.get("markers", {})) if projection else 0,
+    }
+
+
+def fsck(runtime_dir):
+    return payloads.fsck_import(store_dir(runtime_dir), load(runtime_dir))
+
+
+def export_jsonl(runtime_dir, out_path):
+    records = payloads.export_records(store_dir(runtime_dir))
+    payloads.write_jsonl(records, out_path)
+    return {
+        "ok": True,
+        "scope": "atlas",
+        "format": "jsonl",
+        "out": os.path.abspath(out_path),
+        "records": len(records),
+    }
+
+
+def verify_against_repo(runtime_dir, repo_root):
+    repo_root = os.path.abspath(repo_root)
+    _, _, _, source_records, warnings = importer.read_control_plane_with_sources(
+        repo_root
+    )
+    report = payloads.verify_against_source(store_dir(runtime_dir), source_records)
+    report["repo_root"] = repo_root
+    report["repo_head"] = importer.repo_head(repo_root)
+    report["warnings"] = warnings
+    return report

--- a/framework/core/src/python/kungfu/cli/commands/__registry__.py
+++ b/framework/core/src/python/kungfu/cli/commands/__registry__.py
@@ -14,9 +14,9 @@ from . import rewind
 from . import schema
 from . import work
 from . import atlas
+from . import storage
 from . import kfx
 from . import skill
-from . import agent
 from . import codex
 from . import sdk
 
@@ -35,9 +35,9 @@ __all__ = [
     "schema",
     "work",
     "atlas",
+    "storage",
     "kfx",
     "skill",
-    "agent",
     "codex",
     "sdk",
 ]

--- a/framework/core/src/python/kungfu/cli/commands/atlas.py
+++ b/framework/core/src/python/kungfu/cli/commands/atlas.py
@@ -61,6 +61,25 @@ def import_cmd(ctx, repo_root, as_json):
         click.echo(f"  warning: {warning}", err=True)
 
 
+@atlas.command(help="compare the latest Kungfu Atlas import with the source repo")
+@click.option("--repo", "repo_root", type=str, required=True, help="repo root path")
+@click.option("--json", "as_json", is_flag=True, help="machine-readable output")
+@atlas_command_context
+def verify(ctx, repo_root, as_json):
+    from kungfu.atlas import store
+
+    result = store.verify_against_repo(ctx.runtime_dir, repo_root)
+    if as_json:
+        _echo_json(result)
+    else:
+        click.echo(f"[atlas] verify {'ok' if result['ok'] else 'failed'}")
+        for key in ("missing", "extra", "hash_mismatch"):
+            for row in result[key]:
+                click.echo(f"  {key}: {row}", err=True)
+    if not result["ok"]:
+        sys.exit(1)
+
+
 @atlas.group(
     cls=PrioritizedCommandGroup,
     help="render the latest completed import (a projection, not the authority)",

--- a/framework/core/src/python/kungfu/cli/commands/storage.py
+++ b/framework/core/src/python/kungfu/cli/commands/storage.py
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import sys
+
+import click
+
+from kungfu.cli.commands import PrioritizedCommandGroup, kfc
+
+storage_command_context = kfc.pass_context()
+
+
+def _echo_json(payload):
+    click.echo(json.dumps(payload, indent=2, sort_keys=True))
+
+
+def _require_atlas(scope):
+    if scope != "atlas":
+        click.echo(
+            "[storage] only --scope atlas is implemented in this slice", err=True
+        )
+        sys.exit(1)
+
+
+@kfc.group(
+    cls=PrioritizedCommandGroup,
+    help_priority=2,
+    help="inspect and maintain runtime fact storage",
+)
+@click.help_option("-h", "--help")
+@kfc.pass_context()
+def storage(ctx):
+    pass
+
+
+@storage.command(help="summarize a storage scope")
+@click.option("--scope", type=click.Choice(["atlas"]), required=True)
+@click.option("--json", "as_json", is_flag=True, help="machine-readable output")
+@storage_command_context
+def status(ctx, scope, as_json):
+    _require_atlas(scope)
+    from kungfu.atlas import store
+
+    result = store.status(ctx.runtime_dir)
+    if as_json:
+        _echo_json(result)
+        return
+    for key, value in result.items():
+        click.echo(f"  {key}: {value}")
+
+
+@storage.command(help="verify runtime storage integrity for a scope")
+@click.option("--scope", type=click.Choice(["atlas"]), required=True)
+@click.option("--json", "as_json", is_flag=True, help="machine-readable output")
+@storage_command_context
+def fsck(ctx, scope, as_json):
+    _require_atlas(scope)
+    from kungfu.atlas import store
+
+    result = store.fsck(ctx.runtime_dir)
+    if as_json:
+        _echo_json(result)
+    else:
+        click.echo(f"[storage] {scope} fsck {'ok' if result['ok'] else 'failed'}")
+        for error in result["errors"]:
+            click.echo(f"  error: {error}", err=True)
+        for warning in result["warnings"]:
+            click.echo(f"  warning: {warning}", err=True)
+    if not result["ok"]:
+        sys.exit(1)
+
+
+@storage.command(help="export a storage scope")
+@click.option("--scope", type=click.Choice(["atlas"]), required=True)
+@click.option("--format", "format_", type=click.Choice(["jsonl"]), default="jsonl")
+@click.option("--out", "out_path", type=str, required=True, help="output path")
+@click.option("--json", "as_json", is_flag=True, help="machine-readable output")
+@storage_command_context
+def export(ctx, scope, format_, out_path, as_json):
+    _require_atlas(scope)
+    from kungfu.atlas import store
+
+    if format_ != "jsonl":
+        click.echo("[storage] only --format jsonl is implemented", err=True)
+        sys.exit(1)
+    result = store.export_jsonl(ctx.runtime_dir, out_path)
+    if as_json:
+        _echo_json(result)
+        return
+    click.echo(f"[storage] exported {result['records']} {scope} records to {out_path}")

--- a/framework/core/tests/python/test_atlas_storage.py
+++ b/framework/core/tests/python/test_atlas_storage.py
@@ -1,0 +1,144 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+
+from kungfu.atlas import importer, payloads
+
+
+def _write_json(path, data):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2, sort_keys=True), encoding="utf-8")
+
+
+def _atlas_fixture(root):
+    _write_json(
+        root / "agent-journal/missions/registry/active/mission-a.json",
+        {
+            "mission_id": "mission-a",
+            "title": "Mission A",
+            "status": "active",
+            "active_lens": "principal-engineer",
+            "current_stage": {"name": "stage-a", "next_review": "2026-07-08"},
+            "large_body": {"kept": "full mission payload"},
+        },
+    )
+    _write_json(
+        root / "agent-journal/goals/registry/active/goal-a.json",
+        {
+            "goal_id": "goal-a",
+            "status": "active",
+            "title": "Goal A",
+            "mission_id": "mission-a",
+            "next_action": "implement",
+            "large_body": ["full", "goal", "payload"],
+        },
+    )
+    _write_json(
+        root / "reviews/worktree-status/ai__codex__goal-a.json",
+        {
+            "branch": "ai/codex/goal-a",
+            "status": "ready",
+            "ready": True,
+            "summary": "ready marker",
+            "risk": "",
+        },
+    )
+
+
+def test_atlas_source_records_keep_full_payloads(tmp_path):
+    repo = tmp_path / "atlas"
+    _atlas_fixture(repo)
+
+    missions, goals, markers, source_records, warnings = (
+        importer.read_control_plane_with_sources(str(repo))
+    )
+
+    assert warnings == []
+    assert [card["mission_id"] for card in missions] == ["mission-a"]
+    assert [card["goal_id"] for card in goals] == ["goal-a"]
+    assert [card["branch"] for card in markers] == ["ai/codex/goal-a"]
+    assert {(row["kind"], row["source_id"]) for row in source_records} == {
+        ("mission", "mission-a"),
+        ("goal", "goal-a"),
+        ("marker", "ai/codex/goal-a"),
+    }
+    mission = next(row for row in source_records if row["kind"] == "mission")
+    assert mission["payload"]["large_body"] == {"kept": "full mission payload"}
+    assert mission["source_path"] == (
+        "agent-journal/missions/registry/active/mission-a.json"
+    )
+
+
+def test_payload_manifest_fsck_export_and_verify(tmp_path):
+    repo = tmp_path / "atlas"
+    store = tmp_path / "store"
+    _atlas_fixture(repo)
+    missions, goals, markers, source_records, _ = (
+        importer.read_control_plane_with_sources(str(repo))
+    )
+
+    payloads.write_import_payloads(
+        store,
+        import_id="imp-test",
+        repo_root=str(repo),
+        repo_head="abc123",
+        source_records=source_records,
+        counts={
+            "missions": len(missions),
+            "goals": len(goals),
+            "markers": len(markers),
+        },
+    )
+
+    report = payloads.fsck_import(store)
+    assert report["ok"]
+    assert report["checked"] == {
+        "payloads": 3,
+        "missions": 1,
+        "goals": 1,
+        "markers": 1,
+    }
+
+    records = payloads.export_records(store)
+    assert len(records) == 3
+    goal = next(row for row in records if row["kind"] == "goal")
+    assert goal["payload"]["large_body"] == ["full", "goal", "payload"]
+    assert goal["repo_head"] == "abc123"
+
+    verify = payloads.verify_against_source(store, source_records)
+    assert verify == {
+        "ok": True,
+        "scope": "atlas",
+        "checked": 3,
+        "missing": [],
+        "extra": [],
+        "hash_mismatch": [],
+    }
+
+
+def test_payload_fsck_reports_missing_payload(tmp_path):
+    repo = tmp_path / "atlas"
+    store = tmp_path / "store"
+    _atlas_fixture(repo)
+    missions, goals, markers, source_records, _ = (
+        importer.read_control_plane_with_sources(str(repo))
+    )
+    manifest = payloads.write_import_payloads(
+        store,
+        import_id="imp-test",
+        repo_root=str(repo),
+        repo_head="abc123",
+        source_records=source_records,
+        counts={
+            "missions": len(missions),
+            "goals": len(goals),
+            "markers": len(markers),
+        },
+    )
+    first = manifest["entries"][0]
+    payloads.payload_path(store, first["payload_hash"]).unlink()
+
+    report = payloads.fsck_import(store)
+
+    assert not report["ok"]
+    assert any(error["code"] == "payload_missing" for error in report["errors"])


### PR DESCRIPTION
## Summary
- store complete Atlas source JSON payloads as hash-addressed import payloads alongside the existing Atlas journal projection
- add Atlas-scoped storage status/fsck/export commands plus atlas verify against the source repo
- keep build:core dist staging self-contained by copying kungfubuildinfo.json

## Validation
- PYTHONPATH=framework/core/src/python uv run --project framework/core --frozen pytest framework/core/tests/python/test_atlas_storage.py
- uv run --project framework/core --frozen ruff check framework/core/src/python/kungfu/atlas/importer.py framework/core/src/python/kungfu/atlas/store.py framework/core/src/python/kungfu/atlas/payloads.py framework/core/src/python/kungfu/cli/commands/atlas.py framework/core/src/python/kungfu/cli/commands/storage.py framework/core/src/python/kungfu/cli/commands/__registry__.py framework/core/tests/python/test_atlas_storage.py
- uv run --project framework/core --frozen ruff format --check framework/core/src/python/kungfu/atlas/importer.py framework/core/src/python/kungfu/atlas/store.py framework/core/src/python/kungfu/atlas/payloads.py framework/core/src/python/kungfu/cli/commands/atlas.py framework/core/src/python/kungfu/cli/commands/storage.py framework/core/src/python/kungfu/cli/commands/__registry__.py framework/core/tests/python/test_atlas_storage.py
- ./kungfu-code build:core
- ./kungfu-code check
- Atlas dataset smoke with temporary KF_HOME/KF_RUNTIME_DIR: import 5 missions, 371 goals, 895 markers, 1271 payloads; storage fsck ok; export 1271 JSONL records; atlas verify ok
