### PR TITLE
feat(storage): add atlas source sync

### DIFF
--- a/framework/core/src/python/kungfu/atlas/importer.py
+++ b/framework/core/src/python/kungfu/atlas/importer.py
@@ -15,6 +15,7 @@
 import json
 import os
 import subprocess
+from datetime import datetime, timezone
 from typing import Any
 
 
@@ -64,6 +65,110 @@ def _text(value):
         return None
     text = str(value).strip()
     return text or None
+
+
+def parse_timestamp(value):
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    if len(text) == 10 and text[4] == "-" and text[7] == "-":
+        text = text + "T00:00:00+00:00"
+    try:
+        stamp = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if stamp.tzinfo is None:
+        stamp = stamp.replace(tzinfo=timezone.utc)
+    return stamp.astimezone(timezone.utc)
+
+
+def _source_time(card):
+    for key in ("updated_at", "created_at", "set_at"):
+        text = _text(card.get(key))
+        if text and parse_timestamp(text) is not None:
+            return text
+    return None
+
+
+def _window_time(value):
+    if isinstance(value, datetime):
+        stamp = value
+        if stamp.tzinfo is None:
+            stamp = stamp.replace(tzinfo=timezone.utc)
+        return stamp.astimezone(timezone.utc)
+    return parse_timestamp(value)
+
+
+def _matches_window(record, window):
+    if not window:
+        return True
+    since = _window_time(window.get("since"))
+    until = _window_time(window.get("until"))
+    if since is None and until is None:
+        return True
+    stamp = parse_timestamp(record.get("source_time"))
+    if stamp is None:
+        return False
+    if since is not None and stamp < since:
+        return False
+    if until is not None and stamp > until:
+        return False
+    return True
+
+
+def _filter_source_records(source_records, window):
+    return [record for record in source_records if _matches_window(record, window)]
+
+
+def _expand_context_records(source_records, selected_records):
+    selected_keys = {
+        (record.get("kind"), str(record.get("source_id") or ""))
+        for record in selected_records
+    }
+    needed_mission_ids = {
+        str(record.get("payload", {}).get("mission_id") or "")
+        for record in selected_records
+        if record.get("kind") == "goal" and isinstance(record.get("payload"), dict)
+    }
+    expanded = list(selected_records)
+    for record in source_records:
+        key = (record.get("kind"), str(record.get("source_id") or ""))
+        if key in selected_keys:
+            continue
+        if (
+            record.get("kind") == "mission"
+            and record.get("source_id") in needed_mission_ids
+        ):
+            expanded.append(record)
+            selected_keys.add(key)
+    return expanded
+
+
+def _filter_projection(missions, goals, markers, source_records):
+    mission_ids = {
+        str(record.get("source_id"))
+        for record in source_records
+        if record.get("kind") == "mission"
+    }
+    goal_ids = {
+        str(record.get("source_id"))
+        for record in source_records
+        if record.get("kind") == "goal"
+    }
+    marker_ids = {
+        str(record.get("source_id"))
+        for record in source_records
+        if record.get("kind") == "marker"
+    }
+    return (
+        [card for card in missions if card.get("mission_id") in mission_ids],
+        [card for card in goals if card.get("goal_id") in goal_ids],
+        [card for card in markers if card.get("branch") in marker_ids],
+    )
 
 
 def repo_head(repo_root):
@@ -121,6 +226,7 @@ def _mission_records(repo_root, warnings):
                         "kind": "mission",
                         "source_id": mission_id,
                         "source_path": source_path,
+                        "source_time": _source_time(card),
                         "schema_version": 1,
                         "payload": card,
                     }
@@ -176,6 +282,7 @@ def _goal_records(repo_root, warnings):
                         "kind": "goal",
                         "source_id": goal_id,
                         "source_path": source_path,
+                        "source_time": _source_time(card),
                         "schema_version": 1,
                         "payload": card,
                     }
@@ -232,6 +339,7 @@ def _marker_records(repo_root, warnings):
                     "kind": "marker",
                     "source_id": branch,
                     "source_path": os.path.relpath(path, repo_root),
+                    "source_time": _source_time(card),
                     "schema_version": 1,
                     "payload": card,
                 }
@@ -252,15 +360,21 @@ def read_control_plane(repo_root):
     return missions, goals, markers, warnings
 
 
-def read_control_plane_with_sources(repo_root):
+def read_control_plane_with_sources(repo_root, window=None):
     """Read projection cards plus complete JSON source records."""
     warnings: list[str] = []
     missions = read_missions(repo_root, warnings)
     goals = read_goals(repo_root, warnings)
     markers = read_markers(repo_root, warnings)
-    source_records = (
+    all_source_records = (
         _mission_records(repo_root, warnings)
         + _goal_records(repo_root, warnings)
         + _marker_records(repo_root, warnings)
     )
+    source_records = _filter_source_records(all_source_records, window)
+    if window:
+        source_records = _expand_context_records(all_source_records, source_records)
+        missions, goals, markers = _filter_projection(
+            missions, goals, markers, source_records
+        )
     return missions, goals, markers, source_records, warnings

--- a/framework/core/src/python/kungfu/atlas/payloads.py
+++ b/framework/core/src/python/kungfu/atlas/payloads.py
@@ -49,6 +49,7 @@ def enrich_source_records(source_records: list[dict[str, Any]]) -> list[dict[str
             "kind": record.get("kind"),
             "source_id": record.get("source_id"),
             "source_path": record.get("source_path"),
+            "source_time": record.get("source_time"),
             "schema_version": record.get("schema_version"),
             "content_type": CONTENT_TYPE_JSON,
             "payload_hash": digest,
@@ -60,6 +61,36 @@ def enrich_source_records(source_records: list[dict[str, Any]]) -> list[dict[str
     return enriched
 
 
+def _serialize_range(range_filter: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not range_filter:
+        return None
+    result = {}
+    for key in ("since", "until", "cursor"):
+        value = range_filter.get(key)
+        if value not in (None, ""):
+            result[key] = str(value)
+    return result or None
+
+
+def _matches_range(entry: dict[str, Any], range_filter: dict[str, Any] | None) -> bool:
+    if not range_filter:
+        return True
+    from kungfu.atlas.importer import parse_timestamp
+
+    since = parse_timestamp(range_filter.get("since"))
+    until = parse_timestamp(range_filter.get("until"))
+    if since is None and until is None:
+        return True
+    stamp = parse_timestamp(entry.get("source_time"))
+    if stamp is None:
+        return False
+    if since is not None and stamp < since:
+        return False
+    if until is not None and stamp > until:
+        return False
+    return True
+
+
 def write_import_payloads(
     store_dir: str | Path,
     *,
@@ -68,6 +99,9 @@ def write_import_payloads(
     repo_head: str | None,
     source_records: list[dict[str, Any]],
     counts: dict[str, int],
+    storage_source_id: str = "atlas",
+    source_type: str = "atlas",
+    range_filter: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     store_dir = Path(store_dir)
     entries = []
@@ -82,8 +116,12 @@ def write_import_payloads(
     manifest = {
         "schema": "kungfu.atlas-import/v1",
         "import_id": import_id,
+        "storage_source_id": storage_source_id,
+        "source_type": source_type,
         "repo_root": repo_root,
         "repo_head": repo_head,
+        "source_head": repo_head,
+        "range": _serialize_range(range_filter),
         "hash_algorithm": "sha256",
         "counts": counts,
         "entries": sorted(
@@ -287,18 +325,28 @@ def fsck_import(
     return report
 
 
-def export_records(store_dir: str | Path) -> list[dict[str, Any]]:
+def export_records(
+    store_dir: str | Path,
+    range_filter: dict[str, Any] | None = None,
+    storage_source_id: str | None = None,
+) -> list[dict[str, Any]]:
     manifest = load_latest_manifest(store_dir)
     if manifest is None:
         raise FileNotFoundError(str(latest_manifest_path(store_dir)))
+    if storage_source_id and manifest.get("storage_source_id") != storage_source_id:
+        raise ValueError(f"source_not_imported: {storage_source_id}")
     records = []
     for entry in manifest.get("entries", []):
+        if not _matches_range(entry, range_filter):
+            continue
         payload, error = _load_payload(store_dir, entry)
         if error:
             raise ValueError(f"{error}: {entry.get('kind')}:{entry.get('source_id')}")
         row = dict(entry)
         row["scope"] = "atlas"
         row["import_id"] = manifest.get("import_id")
+        row["storage_source_id"] = manifest.get("storage_source_id", "atlas")
+        row["source_type"] = manifest.get("source_type", "atlas")
         row["repo_head"] = manifest.get("repo_head")
         row["source_head"] = manifest.get("repo_head")
         row["payload"] = payload
@@ -327,8 +375,12 @@ def write_jsonl(records: list[dict[str, Any]], out_path: str | Path) -> None:
 def verify_against_source(
     store_dir: str | Path,
     source_records: list[dict[str, Any]],
+    storage_source_id: str | None = None,
 ) -> dict[str, Any]:
-    exported = {_entry_key(record): record for record in export_records(store_dir)}
+    exported = {
+        _entry_key(record): record
+        for record in export_records(store_dir, storage_source_id=storage_source_id)
+    }
     source = {
         _entry_key(record): record for record in enrich_source_records(source_records)
     }

--- a/framework/core/src/python/kungfu/atlas/store.py
+++ b/framework/core/src/python/kungfu/atlas/store.py
@@ -77,13 +77,19 @@ class ImportStore:
         # the binding takes the payload as a byte sequence (list[int])
         self.writer.write_bytes(0, msg_type, list(data), len(data))
 
-    def run_import(self, repo_root):
+    def run_import(
+        self,
+        repo_root,
+        *,
+        storage_source_id="atlas",
+        range_filter=None,
+    ):
         """Import one snapshot batch from repo_root. Returns a result dict."""
         repo_root = os.path.abspath(repo_root)
         import_id = "imp" + uuid.uuid4().hex[:8]
         repo_head = importer.repo_head(repo_root)
         missions, goals, markers, source_records, warnings = (
-            importer.read_control_plane_with_sources(repo_root)
+            importer.read_control_plane_with_sources(repo_root, window=range_filter)
         )
         self._append(
             MSG_IMPORT_BEGIN,
@@ -117,12 +123,19 @@ class ImportStore:
                 "goals": len(goals),
                 "markers": len(markers),
             },
+            storage_source_id=storage_source_id,
+            source_type="atlas",
+            range_filter=range_filter,
         )
         self.emit_manifest()
         return {
             "import_id": import_id,
+            "storage_source_id": storage_source_id,
+            "source_type": "atlas",
             "repo_root": repo_root,
             "repo_head": repo_head,
+            "source_head": repo_head,
+            "range": payloads._serialize_range(range_filter),
             "missions": len(missions),
             "goals": len(goals),
             "markers": len(markers),
@@ -289,8 +302,12 @@ def status(runtime_dir):
         "ok": projection is not None,
         "scope": "atlas",
         "import_id": manifest.get("import_id"),
+        "storage_source_id": manifest.get("storage_source_id", "atlas"),
+        "source_type": manifest.get("source_type", "atlas"),
+        "range": manifest.get("range"),
         "repo_root": manifest.get("repo_root"),
         "repo_head": manifest.get("repo_head"),
+        "source_head": manifest.get("source_head", manifest.get("repo_head")),
         "payloads": len(manifest.get("entries", [])),
         "missions": len(projection.get("missions", {})) if projection else 0,
         "goals": len(projection.get("goals", {})) if projection else 0,
@@ -302,25 +319,45 @@ def fsck(runtime_dir):
     return payloads.fsck_import(store_dir(runtime_dir), load(runtime_dir))
 
 
-def export_jsonl(runtime_dir, out_path):
-    records = payloads.export_records(store_dir(runtime_dir))
+def export_jsonl(
+    runtime_dir,
+    out_path,
+    *,
+    range_filter=None,
+    storage_source_id=None,
+):
+    records = payloads.export_records(
+        store_dir(runtime_dir),
+        range_filter=range_filter,
+        storage_source_id=storage_source_id,
+    )
     payloads.write_jsonl(records, out_path)
     return {
         "ok": True,
         "scope": "atlas",
+        "storage_source_id": storage_source_id,
+        "range": payloads._serialize_range(range_filter),
         "format": "jsonl",
         "out": os.path.abspath(out_path),
         "records": len(records),
     }
 
 
-def verify_against_repo(runtime_dir, repo_root):
+def verify_against_repo(
+    runtime_dir, repo_root, *, range_filter=None, storage_source_id=None
+):
     repo_root = os.path.abspath(repo_root)
     _, _, _, source_records, warnings = importer.read_control_plane_with_sources(
-        repo_root
+        repo_root, window=range_filter
     )
-    report = payloads.verify_against_source(store_dir(runtime_dir), source_records)
+    report = payloads.verify_against_source(
+        store_dir(runtime_dir),
+        source_records,
+        storage_source_id=storage_source_id,
+    )
     report["repo_root"] = repo_root
     report["repo_head"] = importer.repo_head(repo_root)
+    report["storage_source_id"] = storage_source_id
+    report["range"] = payloads._serialize_range(range_filter)
     report["warnings"] = warnings
     return report

--- a/framework/core/src/python/kungfu/cli/commands/__registry__.py
+++ b/framework/core/src/python/kungfu/cli/commands/__registry__.py
@@ -15,6 +15,7 @@ from . import schema
 from . import work
 from . import atlas
 from . import storage
+from . import source
 from . import kfx
 from . import skill
 from . import codex
@@ -36,6 +37,7 @@ __all__ = [
     "work",
     "atlas",
     "storage",
+    "source",
     "kfx",
     "skill",
     "codex",

--- a/framework/core/src/python/kungfu/cli/commands/atlas.py
+++ b/framework/core/src/python/kungfu/cli/commands/atlas.py
@@ -41,14 +41,34 @@ def _load(ctx):
     return projection
 
 
+def _range_filter(since, from_time, until):
+    from kungfu.sources.store import build_range_filter
+
+    try:
+        return build_range_filter(since=since, from_time=from_time, until=until)
+    except ValueError as e:
+        click.echo(f"[atlas] {e}", err=True)
+        sys.exit(2)
+
+
 @atlas.command(name="import", help="snapshot a control-plane repo into the journal")
 @click.option("--repo", "repo_root", type=str, required=True, help="repo root path")
+@click.option("--source", "storage_source_id", type=str, default="atlas")
+@click.option("--since", type=str, default=None, help="relative window such as 3d/12h")
+@click.option(
+    "--from", "from_time", type=str, default=None, help="inclusive start time"
+)
+@click.option("--until", type=str, default=None, help="inclusive end time")
 @click.option("--json", "as_json", is_flag=True, help="machine-readable output")
 @atlas_command_context
-def import_cmd(ctx, repo_root, as_json):
+def import_cmd(ctx, repo_root, storage_source_id, since, from_time, until, as_json):
     from kungfu.atlas.store import ImportStore
 
-    result = ImportStore(ctx.runtime_dir).run_import(repo_root)
+    result = ImportStore(ctx.runtime_dir).run_import(
+        repo_root,
+        storage_source_id=storage_source_id,
+        range_filter=_range_filter(since, from_time, until),
+    )
     if as_json:
         _echo_json(result)
         return
@@ -63,12 +83,23 @@ def import_cmd(ctx, repo_root, as_json):
 
 @atlas.command(help="compare the latest Kungfu Atlas import with the source repo")
 @click.option("--repo", "repo_root", type=str, required=True, help="repo root path")
+@click.option("--source", "storage_source_id", type=str, default=None)
+@click.option("--since", type=str, default=None, help="relative window such as 3d/12h")
+@click.option(
+    "--from", "from_time", type=str, default=None, help="inclusive start time"
+)
+@click.option("--until", type=str, default=None, help="inclusive end time")
 @click.option("--json", "as_json", is_flag=True, help="machine-readable output")
 @atlas_command_context
-def verify(ctx, repo_root, as_json):
+def verify(ctx, repo_root, storage_source_id, since, from_time, until, as_json):
     from kungfu.atlas import store
 
-    result = store.verify_against_repo(ctx.runtime_dir, repo_root)
+    result = store.verify_against_repo(
+        ctx.runtime_dir,
+        repo_root,
+        storage_source_id=storage_source_id,
+        range_filter=_range_filter(since, from_time, until),
+    )
     if as_json:
         _echo_json(result)
     else:

--- a/framework/core/src/python/kungfu/cli/commands/source.py
+++ b/framework/core/src/python/kungfu/cli/commands/source.py
@@ -1,0 +1,158 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import sys
+
+import click
+
+from kungfu.cli.commands import PrioritizedCommandGroup, kfc
+
+source_command_context = kfc.pass_context()
+
+
+def _echo_json(payload):
+    click.echo(json.dumps(payload, indent=2, sort_keys=True))
+
+
+def _range_filter(since, from_time, until):
+    from kungfu.sources.store import build_range_filter
+
+    try:
+        return build_range_filter(since=since, from_time=from_time, until=until)
+    except ValueError as e:
+        click.echo(f"[source] {e}", err=True)
+        sys.exit(2)
+
+
+@kfc.group(
+    cls=PrioritizedCommandGroup,
+    help_priority=2,
+    help="manage peer storage sources and one-way sync",
+)
+@click.help_option("-h", "--help")
+@kfc.pass_context()
+def source(ctx):
+    pass
+
+
+@source.command(name="add", help="register or update a read-only storage source")
+@click.argument("source_id", type=str)
+@click.option("--type", "source_type", type=click.Choice(["atlas"]), required=True)
+@click.option("--repo", type=str, required=True, help="source repo root path")
+@click.option("--json", "as_json", is_flag=True, help="machine-readable output")
+@source_command_context
+def add_cmd(ctx, source_id, source_type, repo, as_json):
+    from kungfu.sources.store import add_source
+
+    result = add_source(
+        ctx.runtime_dir,
+        source_id=source_id,
+        source_type=source_type,
+        repo=repo,
+    )
+    if as_json:
+        _echo_json(result)
+        return
+    click.echo(f"[source] registered {source_id} ({source_type}) -> {result['repo']}")
+
+
+@source.command(name="list", help="list registered storage sources")
+@click.option("--json", "as_json", is_flag=True, help="machine-readable output")
+@source_command_context
+def list_cmd(ctx, as_json):
+    from kungfu.sources.store import list_sources
+
+    sources = list_sources(ctx.runtime_dir)
+    if as_json:
+        _echo_json(sources)
+        return
+    for row in sources:
+        click.echo(
+            f"{row['source_id']}  [{row['type']}]  {row['repo']}"
+            f"{'  synced: ' + row['last_synced_at'] if row.get('last_synced_at') else ''}"
+        )
+
+
+@source.command(help="show one registered storage source")
+@click.argument("source_id", type=str)
+@click.option("--json", "as_json", is_flag=True, help="machine-readable output")
+@source_command_context
+def show(ctx, source_id, as_json):
+    from kungfu.sources.store import get_source
+
+    try:
+        result = get_source(ctx.runtime_dir, source_id)
+    except KeyError:
+        click.echo(f"[source] unknown source: {source_id}", err=True)
+        sys.exit(1)
+    if as_json:
+        _echo_json(result)
+        return
+    for key, value in result.items():
+        if value not in (None, ""):
+            click.echo(f"  {key}: {value}")
+
+
+@source.command(help="pull source records into local Kungfu storage")
+@click.argument("source_id", type=str)
+@click.option("--since", type=str, default=None, help="relative window such as 3d/12h")
+@click.option(
+    "--from", "from_time", type=str, default=None, help="inclusive start time"
+)
+@click.option("--until", type=str, default=None, help="inclusive end time")
+@click.option("--json", "as_json", is_flag=True, help="machine-readable output")
+@source_command_context
+def sync(ctx, source_id, since, from_time, until, as_json):
+    from kungfu.sources.store import sync_source
+
+    try:
+        result = sync_source(
+            ctx.runtime_dir,
+            source_id,
+            range_filter=_range_filter(since, from_time, until),
+        )
+    except KeyError:
+        click.echo(f"[source] unknown source: {source_id}", err=True)
+        sys.exit(1)
+    except ValueError as e:
+        click.echo(f"[source] {e}", err=True)
+        sys.exit(1)
+    if as_json:
+        _echo_json(result)
+        return
+    sync_result = result["sync"]
+    click.echo(
+        f"[source] synced {source_id}: {sync_result['missions']} missions, "
+        f"{sync_result['goals']} goals, {sync_result['markers']} markers, "
+        f"{sync_result['payloads']} payloads"
+    )
+    for warning in sync_result["warnings"]:
+        click.echo(f"  warning: {warning}", err=True)
+
+
+@source.command(help="compare the latest synced source with its authority")
+@click.argument("source_id", type=str)
+@click.option("--json", "as_json", is_flag=True, help="machine-readable output")
+@source_command_context
+def fsck(ctx, source_id, as_json):
+    from kungfu.sources.store import fsck_source
+
+    try:
+        result = fsck_source(ctx.runtime_dir, source_id)
+    except KeyError:
+        click.echo(f"[source] unknown source: {source_id}", err=True)
+        sys.exit(1)
+    if as_json:
+        _echo_json(result)
+    else:
+        click.echo(f"[source] {source_id} fsck {'ok' if result['ok'] else 'failed'}")
+        for row in result.get("missing", []):
+            click.echo(f"  missing: {row}", err=True)
+        for row in result.get("extra", []):
+            click.echo(f"  extra: {row}", err=True)
+        for row in result.get("hash_mismatch", []):
+            click.echo(f"  hash_mismatch: {row}", err=True)
+        for row in result.get("errors", []):
+            click.echo(f"  error: {row}", err=True)
+    if not result["ok"]:
+        sys.exit(1)

--- a/framework/core/src/python/kungfu/cli/commands/storage.py
+++ b/framework/core/src/python/kungfu/cli/commands/storage.py
@@ -22,6 +22,16 @@ def _require_atlas(scope):
         sys.exit(1)
 
 
+def _range_filter(since, from_time, until):
+    from kungfu.sources.store import build_range_filter
+
+    try:
+        return build_range_filter(since=since, from_time=from_time, until=until)
+    except ValueError as e:
+        click.echo(f"[storage] {e}", err=True)
+        sys.exit(2)
+
+
 @kfc.group(
     cls=PrioritizedCommandGroup,
     help_priority=2,
@@ -72,18 +82,43 @@ def fsck(ctx, scope, as_json):
 
 @storage.command(help="export a storage scope")
 @click.option("--scope", type=click.Choice(["atlas"]), required=True)
+@click.option("--source", "storage_source_id", type=str, default=None)
+@click.option("--since", type=str, default=None, help="relative window such as 3d/12h")
+@click.option(
+    "--from", "from_time", type=str, default=None, help="inclusive start time"
+)
+@click.option("--until", type=str, default=None, help="inclusive end time")
 @click.option("--format", "format_", type=click.Choice(["jsonl"]), default="jsonl")
 @click.option("--out", "out_path", type=str, required=True, help="output path")
 @click.option("--json", "as_json", is_flag=True, help="machine-readable output")
 @storage_command_context
-def export(ctx, scope, format_, out_path, as_json):
+def export(
+    ctx,
+    scope,
+    storage_source_id,
+    since,
+    from_time,
+    until,
+    format_,
+    out_path,
+    as_json,
+):
     _require_atlas(scope)
     from kungfu.atlas import store
 
     if format_ != "jsonl":
         click.echo("[storage] only --format jsonl is implemented", err=True)
         sys.exit(1)
-    result = store.export_jsonl(ctx.runtime_dir, out_path)
+    try:
+        result = store.export_jsonl(
+            ctx.runtime_dir,
+            out_path,
+            storage_source_id=storage_source_id,
+            range_filter=_range_filter(since, from_time, until),
+        )
+    except ValueError as e:
+        click.echo(f"[storage] {e}", err=True)
+        sys.exit(1)
     if as_json:
         _echo_json(result)
         return

--- a/framework/core/src/python/kungfu/sources/__init__.py
+++ b/framework/core/src/python/kungfu/sources/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+

--- a/framework/core/src/python/kungfu/sources/store.py
+++ b/framework/core/src/python/kungfu/sources/store.py
@@ -1,0 +1,205 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import os
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+
+def now_iso() -> str:
+    return _iso(datetime.now(timezone.utc))
+
+
+def registry_path(runtime_dir: str | os.PathLike[str]) -> Path:
+    return Path(runtime_dir) / "sources" / "sources.json"
+
+
+def load_registry(runtime_dir: str | os.PathLike[str]) -> dict[str, Any]:
+    path = registry_path(runtime_dir)
+    if not path.exists():
+        return {"schema": "kungfu.sources/v1", "sources": {}}
+    with path.open(encoding="utf-8") as f:
+        data = json.load(f)
+    if not isinstance(data, dict) or not isinstance(data.get("sources"), dict):
+        raise ValueError(f"invalid source registry: {path}")
+    data.setdefault("schema", "kungfu.sources/v1")
+    return data
+
+
+def save_registry(
+    runtime_dir: str | os.PathLike[str], registry: dict[str, Any]
+) -> None:
+    path = registry_path(runtime_dir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(registry, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def list_sources(runtime_dir: str | os.PathLike[str]) -> list[dict[str, Any]]:
+    registry = load_registry(runtime_dir)
+    return sorted(
+        registry["sources"].values(),
+        key=lambda source: str(source.get("source_id") or ""),
+    )
+
+
+def get_source(runtime_dir: str | os.PathLike[str], source_id: str) -> dict[str, Any]:
+    registry = load_registry(runtime_dir)
+    source = registry["sources"].get(source_id)
+    if source is None:
+        raise KeyError(source_id)
+    return source
+
+
+def add_source(
+    runtime_dir: str | os.PathLike[str],
+    *,
+    source_id: str,
+    source_type: str,
+    repo: str,
+) -> dict[str, Any]:
+    if source_type != "atlas":
+        raise ValueError(f"unsupported source type: {source_type}")
+    registry = load_registry(runtime_dir)
+    sources = registry["sources"]
+    stamp = now_iso()
+    previous = sources.get(source_id, {})
+    source = {
+        "source_id": source_id,
+        "type": source_type,
+        "repo": os.path.abspath(repo),
+        "created_at": previous.get("created_at", stamp),
+        "updated_at": stamp,
+        "last_synced_at": previous.get("last_synced_at"),
+        "last_import_id": previous.get("last_import_id"),
+        "last_source_head": previous.get("last_source_head"),
+        "last_range": previous.get("last_range"),
+    }
+    sources[source_id] = source
+    save_registry(runtime_dir, registry)
+    return source
+
+
+def _iso(stamp: datetime) -> str:
+    if stamp.tzinfo is None:
+        stamp = stamp.replace(tzinfo=timezone.utc)
+    return stamp.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _parse_relative(value: str, *, now: datetime) -> datetime | None:
+    text = value.strip().lower()
+    if len(text) < 2:
+        return None
+    unit = text[-1]
+    amount_text = text[:-1]
+    if not amount_text.isdigit():
+        return None
+    amount = int(amount_text)
+    if unit == "d":
+        delta = timedelta(days=amount)
+    elif unit == "h":
+        delta = timedelta(hours=amount)
+    elif unit == "m":
+        delta = timedelta(minutes=amount)
+    elif unit == "s":
+        delta = timedelta(seconds=amount)
+    else:
+        return None
+    return now - delta
+
+
+def build_range_filter(
+    *,
+    since: str | None = None,
+    from_time: str | None = None,
+    until: str | None = None,
+    now: datetime | None = None,
+) -> dict[str, Any] | None:
+    if since and from_time:
+        raise ValueError("use either --since or --from, not both")
+    now = now or datetime.now(timezone.utc)
+    result: dict[str, Any] = {}
+    if since:
+        relative = _parse_relative(since, now=now)
+        result["since"] = _iso(relative) if relative is not None else since
+    if from_time:
+        result["since"] = from_time
+    if until:
+        result["until"] = until
+    return result or None
+
+
+def sync_source(
+    runtime_dir: str | os.PathLike[str],
+    source_id: str,
+    *,
+    range_filter: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    from kungfu.atlas.store import ImportStore
+
+    registry = load_registry(runtime_dir)
+    source = registry["sources"].get(source_id)
+    if source is None:
+        raise KeyError(source_id)
+    if source.get("type") != "atlas":
+        raise ValueError(f"unsupported source type: {source.get('type')}")
+
+    result = ImportStore(runtime_dir).run_import(
+        source["repo"],
+        storage_source_id=source_id,
+        range_filter=range_filter,
+    )
+    stamp = now_iso()
+    source.update(
+        {
+            "updated_at": stamp,
+            "last_synced_at": stamp,
+            "last_import_id": result.get("import_id"),
+            "last_source_head": result.get("source_head"),
+            "last_range": result.get("range"),
+        }
+    )
+    save_registry(runtime_dir, registry)
+    return {"ok": True, "source": source, "sync": result}
+
+
+def fsck_source(
+    runtime_dir: str | os.PathLike[str],
+    source_id: str,
+) -> dict[str, Any]:
+    from kungfu.atlas import payloads
+    from kungfu.atlas import store as atlas_store
+
+    source = get_source(runtime_dir, source_id)
+    manifest = payloads.load_latest_manifest(atlas_store.store_dir(runtime_dir))
+    if manifest is None:
+        return {
+            "ok": False,
+            "source": source,
+            "errors": [{"code": "manifest_missing"}],
+            "warnings": [],
+        }
+    if manifest.get("storage_source_id") != source_id:
+        return {
+            "ok": False,
+            "source": source,
+            "errors": [
+                {
+                    "code": "source_not_latest_import",
+                    "expected": source_id,
+                    "actual": manifest.get("storage_source_id"),
+                }
+            ],
+            "warnings": [],
+        }
+    report = atlas_store.verify_against_repo(
+        runtime_dir,
+        source["repo"],
+        range_filter=manifest.get("range"),
+        storage_source_id=source_id,
+    )
+    report["source"] = source
+    return report

--- a/framework/core/tests/python/test_atlas_storage.py
+++ b/framework/core/tests/python/test_atlas_storage.py
@@ -1,8 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
+from datetime import datetime, timezone
 
 from kungfu.atlas import importer, payloads
+from kungfu.sources import store as source_store
 
 
 def _write_json(path, data):
@@ -17,6 +19,7 @@ def _atlas_fixture(root):
             "mission_id": "mission-a",
             "title": "Mission A",
             "status": "active",
+            "updated_at": "2026-07-08T00:00:00Z",
             "active_lens": "principal-engineer",
             "current_stage": {"name": "stage-a", "next_review": "2026-07-08"},
             "large_body": {"kept": "full mission payload"},
@@ -27,6 +30,7 @@ def _atlas_fixture(root):
         {
             "goal_id": "goal-a",
             "status": "active",
+            "updated_at": "2026-07-08T01:00:00Z",
             "title": "Goal A",
             "mission_id": "mission-a",
             "next_action": "implement",
@@ -38,6 +42,7 @@ def _atlas_fixture(root):
         {
             "branch": "ai/codex/goal-a",
             "status": "ready",
+            "updated_at": "2026-07-08T02:00:00Z",
             "ready": True,
             "summary": "ready marker",
             "risk": "",
@@ -67,6 +72,57 @@ def test_atlas_source_records_keep_full_payloads(tmp_path):
     assert mission["source_path"] == (
         "agent-journal/missions/registry/active/mission-a.json"
     )
+    assert mission["source_time"] == "2026-07-08T00:00:00Z"
+
+
+def test_atlas_source_records_filter_by_window(tmp_path):
+    repo = tmp_path / "atlas"
+    _atlas_fixture(repo)
+    _write_json(
+        repo / "agent-journal/goals/registry/archive/goal-old.json",
+        {
+            "goal_id": "goal-old",
+            "status": "done",
+            "updated_at": "2026-06-01T00:00:00Z",
+            "title": "Old Goal",
+        },
+    )
+    _write_json(
+        repo / "agent-journal/missions/registry/archive/mission-b.json",
+        {
+            "mission_id": "mission-b",
+            "title": "Mission B",
+            "status": "active",
+            "updated_at": "2026-06-01T00:00:00Z",
+        },
+    )
+    _write_json(
+        repo / "agent-journal/goals/registry/active/goal-b.json",
+        {
+            "goal_id": "goal-b",
+            "status": "active",
+            "updated_at": "2026-07-08T00:00:00Z",
+            "title": "Goal B",
+            "mission_id": "mission-b",
+        },
+    )
+
+    missions, goals, _, source_records, warnings = (
+        importer.read_control_plane_with_sources(
+            str(repo),
+            window={"since": "2026-07-01T00:00:00Z"},
+        )
+    )
+
+    assert warnings == []
+    assert [card["goal_id"] for card in goals] == ["goal-a", "goal-b"]
+    assert [card["mission_id"] for card in missions] == ["mission-a", "mission-b"]
+    assert ("goal", "goal-old") not in {
+        (record["kind"], record["source_id"]) for record in source_records
+    }
+    assert ("mission", "mission-b") in {
+        (record["kind"], record["source_id"]) for record in source_records
+    }
 
 
 def test_payload_manifest_fsck_export_and_verify(tmp_path):
@@ -88,6 +144,8 @@ def test_payload_manifest_fsck_export_and_verify(tmp_path):
             "goals": len(goals),
             "markers": len(markers),
         },
+        storage_source_id="atlas-local",
+        range_filter={"since": "2026-07-01T00:00:00Z"},
     )
 
     report = payloads.fsck_import(store)
@@ -104,6 +162,8 @@ def test_payload_manifest_fsck_export_and_verify(tmp_path):
     goal = next(row for row in records if row["kind"] == "goal")
     assert goal["payload"]["large_body"] == ["full", "goal", "payload"]
     assert goal["repo_head"] == "abc123"
+    assert goal["storage_source_id"] == "atlas-local"
+    assert goal["source_time"] == "2026-07-08T01:00:00Z"
 
     verify = payloads.verify_against_source(store, source_records)
     assert verify == {
@@ -142,3 +202,12 @@ def test_payload_fsck_reports_missing_payload(tmp_path):
 
     assert not report["ok"]
     assert any(error["code"] == "payload_missing" for error in report["errors"])
+
+
+def test_source_range_builder_supports_relative_since():
+    window = source_store.build_range_filter(
+        since="3d",
+        now=datetime(2026, 7, 8, 12, 0, 0, tzinfo=timezone.utc),
+    )
+
+    assert window == {"since": "2026-07-05T12:00:00Z"}


### PR DESCRIPTION
## Summary
- add `kungfu source` commands for registering and syncing read-only Atlas storage sources
- preserve source id, source type, source head, source time, and range metadata in Atlas payload manifests
- add range-aware Atlas import/verify and storage export compatibility paths
- keep parent mission context when a ranged sync selects recent goals

## Validation
- `PYTHONPATH=/Users/dkr/Worktrees/kungfu/feature/storage-source-adapter/framework/core/src/python pnpm --filter @kungfu-tech/core exec uv run --frozen pytest tests/python/test_atlas_storage.py`
- `./kungfu-code check`
- `./kungfu-code build`
- `pnpm --filter @kungfu-tech/core run freeze`
- real Atlas smoke with `framework/core/dist/kungfu/kungfu source add/sync/fsck`, `storage fsck`, and `storage export --since 3d` against `/Users/dkr/Code/atlas`