### PR TITLE
docs(storage): record storage architecture ADRs

### DIFF
--- a/docs/runtime-storage-service.md
+++ b/docs/runtime-storage-service.md
@@ -13,6 +13,12 @@ journal maintenance commands, Atlas import, source sync, remote sync, and the
 missing storage operations such as `fsck`, import/export, garbage collection,
 and compaction.
 
+The architectural decisions are recorded in
+[`ADR-0018`](../framework/core/docs/adr/ADR-0018-runtime-storage-service-architecture.md)
+for the local runtime storage service and
+[`ADR-0019`](../framework/core/docs/adr/ADR-0019-git-like-source-sync-over-location-and-channel.md)
+for Git-like source sync over Kungfu `location` and `channel`.
+
 ## Existing Ground
 
 The lower-level contract already exists in pieces:

--- a/framework/core/docs/adr/ADR-0018-runtime-storage-service-architecture.md
+++ b/framework/core/docs/adr/ADR-0018-runtime-storage-service-architecture.md
@@ -1,0 +1,154 @@
+# ADR-0018: Runtime storage service as the persistence contract above journal, payloads, and projections
+
+- Status: accepted
+- Date: 2026-07-08
+- Category: (architecture) persistence contract — how Kungfu stores user facts
+  without exposing storage-engine choices as product semantics
+- Subsystem: `framework/core` journal runtime, fact-ledger format direction,
+  Atlas import storage slice, payload/blob storage, SQLite projections, and the
+  user-facing `kungfu storage` command surface.
+- Related: ADR-0001 pins the journal publish barrier; ADR-0002 pins the
+  longfist runtime schema; ADR-0011 pins the capability SDK contract.
+  [`docs/runtime-storage-service.md`](../../../../docs/runtime-storage-service.md)
+  is the companion reference page for the staged command surface, fsck/export,
+  compaction, and source adapter path. ADR-0019 separately decides the
+  multi-machine source sync model above this storage contract.
+
+## Context
+
+Kungfu already has the lower layers needed for a local fact ledger:
+
+- an append-only journal with frame provenance, order, and causal routing;
+- stable typed schemas and a portable fact-ledger format direction;
+- large-payload content commitments and a blob-store direction;
+- SQLite projections that are useful for query and UI state but must remain
+  rebuildable;
+- a first Atlas import slice that stores large JSON payloads outside mmap
+  frames, writes manifests, runs `fsck`, exports JSONL, and verifies source
+  hashes against the Atlas repository.
+
+Those pieces are not yet one product contract. Without such a contract, callers
+would need to know whether a fact lives in journal mmap, content-addressed
+files, RocksDB, SQLite, or a temporary adapter directory. That leaks backend
+choices into the API and makes long-term maintenance operations hard to define.
+
+The user-facing need is broader than event capture. Kungfu must become the
+local persistence service for runs, work items, imported profiles, payload
+bodies, source mirrors, projections, and audit bundles. It must also be able to
+prove and maintain that storage through read-only checks, rebuilds, exports,
+garbage collection, and eventual compaction.
+
+## Decision
+
+Kungfu will expose a **runtime storage service** above the raw storage engines.
+The public contract talks about facts, payload references, manifests, schemas,
+projections, watermarks, source metadata, and verification results; it does not
+promise a specific backend such as RocksDB, SQLite, mmap frames, or files.
+
+The architecture has these roles:
+
+| Part | Role | Authority |
+| --- | --- | --- |
+| Journal | Event spine, ordering, causality, payload commitments | Authoritative for topology and content commitment |
+| Payload/blob store | Large bodies addressed by hash | Authoritative body when present and hash-verified |
+| SQLite projections | Query/index/cache views | Derived and rebuildable |
+| Manifest/schema registry | Capture boundary, provenance, schemas, versioning | Trust and decode root for bundles |
+| Source registry | Known sources, accepted ranges, heads, and watermarks | Local record of what has been accepted |
+
+The storage service owns the semantic operations:
+
+- `kungfu storage status` reports scope, manifest, projection, and payload
+  state.
+- `kungfu storage fsck` verifies journal readability, event topology, payload
+  presence, hashes, schemas, projection watermarks, and manifest consistency.
+- `kungfu storage export` produces a portable, verifiable bundle or stream.
+- `kungfu storage import` verifies and accepts a bundle into local storage.
+- `kungfu storage rebuild-index` rebuilds derived projections from authoritative
+  facts.
+- `kungfu storage gc` removes only unreachable payload bodies.
+- `kungfu storage compact` composes checkpointing, archive bundle creation,
+  payload GC, projection vacuum/rebuild, and backend compaction where available.
+
+All agent-facing commands must support `--json`. Any operation that deletes,
+archives, rewrites, or compacts facts must have a preview or dry-run mode before
+execution.
+
+## Consequences
+
+- Backend choices stay replaceable. RocksDB, content-addressed files, SQLite
+  blob tables, mmap frames, or hybrids can be adopted per slice without changing
+  the product vocabulary.
+- Large payloads are not stored by making journal frames arbitrarily large. The
+  journal carries commitments and metadata; the payload store carries bodies.
+- SQLite is a projection facility, not the authority root. It may be rebuilt
+  from journal, payloads, manifests, and schemas.
+- `fsck` is a first-class storage operation. It reports corruption, drift,
+  missing payloads, malformed payload JSON, and projection mismatch without
+  silently repairing or rewriting facts.
+- Import/export becomes a verification path as well as a portability path.
+  Exported data must carry enough manifest, schema, payload inventory, and
+  watermark information for verification to be recomputed.
+- Compaction is not a destructive history rewrite. It is a reported maintenance
+  operation over retained ranges, archived ranges, payload reachability, and
+  projections.
+
+## First delivery
+
+The accepted first delivery is the Atlas-scoped proof surface:
+
+```sh
+kungfu atlas import --repo <atlas-repo> --json
+kungfu storage status --scope atlas --json
+kungfu storage fsck --scope atlas --json
+kungfu storage export --scope atlas --format jsonl --out atlas.jsonl --json
+kungfu atlas verify --repo <atlas-repo> --json
+```
+
+That slice proves the direction without claiming the whole service is complete:
+
+- Atlas large JSON bodies are stored outside mmap frames as hash-addressed
+  payloads.
+- Import writes a manifest with source head, object count, payload inventory,
+  and projection watermark.
+- `fsck` detects missing payloads, hash mismatches, malformed payload JSON, and
+  projection drift.
+- `storage export` emits canonical JSONL records for imported Atlas payloads.
+- `atlas verify` recomputes hashes from the Atlas repo and compares them with
+  the imported payload manifest.
+
+## Explicitly out of scope
+
+- Choosing RocksDB, SQLite blob tables, files, or another backend as the final
+  large-payload store.
+- Repairing arbitrary journal corruption.
+- Declaring Atlas or any imported source no longer authoritative.
+- Defining cross-machine fetch/pull semantics, channel protocol, conflict
+  handling, or source authority transfer. Those are ADR-0019 concerns.
+- Shipping destructive `gc` or `compact` before the reporting and rollback
+  contract is implemented.
+
+## Alternatives considered
+
+- **Store every large object directly in the journal.** Rejected. It bloats mmap
+  frames, weakens hot-path replay properties, and makes payload-level fsck and
+  repair awkward. The journal should commit to payloads; it should not be the
+  only payload body store.
+- **Make SQLite the single source of truth.** Rejected. SQLite is excellent for
+  projection and query, and Kungfu can use it heavily, but it should remain
+  rebuildable from the fact ledger and payload commitments.
+- **Expose RocksDB or another KV store as the product API.** Rejected. Engine
+  names are implementation details. The stable contract is about facts,
+  manifests, payloads, verification, and projections.
+- **Keep import/export as Atlas-specific commands.** Rejected. Atlas is the
+  first high-value adapter, not a special storage architecture. The mechanism
+  should generalize to other sources and later to remote Kungfu runtimes.
+
+## Residual risk
+
+- The storage contract can drift if early commands remain Atlas-scoped for too
+  long. Shared storage schemas, fixtures, and non-Atlas smoke tests should land
+  as soon as a second source exists.
+- `compact` is easy to overclaim. It must stay staged until the archive,
+  reachability, dry-run, and rollback report are all boring.
+- Projection rebuilds may hide payload or schema corruption if they are used as
+  repair instead of verification. `fsck` must verify authoritative inputs first.

--- a/framework/core/docs/adr/ADR-0019-git-like-source-sync-over-location-and-channel.md
+++ b/framework/core/docs/adr/ADR-0019-git-like-source-sync-over-location-and-channel.md
@@ -1,0 +1,166 @@
+# ADR-0019: Git-like source sync over Kungfu location and channel
+
+- Status: accepted
+- Date: 2026-07-08
+- Category: (architecture) distributed fact-ledger sync — how local and remote
+  sources become part of one Kungfu storage model
+- Subsystem: runtime storage service, source registry, manifest-backed import
+  and export, `location` / `channel` runtime concepts, Atlas source adapter, and
+  future remote Kungfu sync.
+- Related: ADR-0018 decides the local runtime storage service contract.
+  [`docs/runtime-storage-service.md`](../../../../docs/runtime-storage-service.md)
+  is the companion reference page. The existing journal/event model documents
+  frame `source`, `dest`, `initial_source`, `frame_uid`, and stream routing.
+
+## Context
+
+Kungfu is local-first, but the user model is not single-machine. A user may run
+Kungfu on multiple machines, pull facts from another machine, inspect work that
+originated elsewhere, and later use any node as the practical source for future
+work. That requires a distributed storage model.
+
+The early Atlas migration also exposes the same shape. Atlas is currently an
+external source of facts. Kungfu imports Atlas facts one way, keeps Atlas as the
+authority, and verifies local payloads against Atlas. This is intentionally
+conservative, but it is also a useful rehearsal for future multi-machine sync:
+enumerate a source, fetch a range, verify payloads and manifests, accept facts
+locally, rebuild projections, and prove equivalence by export/fsck.
+
+The wrong model would be to copy a remote machine into a separate local
+directory such as `remote-120` and leave it there forever. That preserves bytes
+but does not make the facts part of Kungfu's fact ledger. It also makes every
+consumer reason about physical directories instead of accepted facts,
+provenance, and watermarks.
+
+Kungfu already has native runtime concepts that should be used instead of
+inventing a second addressing layer:
+
+- `location` identifies runtime participants, locator roots, and who writes or
+  reads.
+- `channel` is the communication edge between source and destination locations.
+- journal frames already carry source/destination and initial-source metadata.
+
+## Decision
+
+Kungfu will model distributed storage as **source sync over location and
+channel**, not as copied remote directories.
+
+A source is a logical registry entry: a local profile, imported bundle, Atlas
+adapter, remote Kungfu runtime, or any adapter that can enumerate facts. A
+location is the runtime identity/address that owns or exposes a storage view. A
+channel is the transport edge used to request ranges, read from a source, write
+to a destination, subscribe, or repair missing payloads. A manifest is the
+accept boundary.
+
+The target workflow is Git-like:
+
+```text
+source + location
+  -> channel request/fetch
+  -> manifest-backed event segment
+  -> payload/hash/schema inventory
+  -> local acceptance into the unified fact ledger
+  -> rebuildable projection
+```
+
+The analogy is intentionally limited:
+
+| Git-like concept | Kungfu storage concept |
+| --- | --- |
+| remote | source + location |
+| fetch/pull | channel request + import |
+| object | payload/blob by hash |
+| pack/bundle | fact-ledger bundle |
+| accepted point | manifest-backed accepted segment |
+| ref/head | source head, accepted frame uid, or watermark |
+| fsck | causal/hash/schema/projection verification |
+
+Kungfu will not copy Git's commit/tree/branch model. Kungfu is an ordered,
+causal runtime fact ledger. The accepted unit is an event segment plus manifest,
+payload inventory, schema registry entries, source metadata, and watermarks.
+
+When a local runtime imports verified facts from another source, those accepted
+facts become part of the local Kungfu data. They are not merely stored in a
+remote-specific directory. Their original source and location provenance remain
+attached so a user can answer where a fact came from and how it was accepted.
+
+`channel` is transport, not authority. Authority is the accepted journal spine
+plus manifest root plus payload/schema verification result.
+
+## Consequences
+
+- A machine such as `120` is not modeled as a permanent local folder. It is a
+  source with one or more locations and channel-reachable ranges. Imported,
+  verified facts enter the local ledger with provenance.
+- Atlas import is the first source-adapter proof, not a one-off migration path.
+  It should exercise the same manifest, payload, fsck, export, and verification
+  mechanics used later by remote Kungfu sync.
+- Import/export must support range-limited operation: by session/run, time
+  window, cursor, event range, source id, and hash inventory.
+- `source fsck` and `storage fsck` must verify source metadata, channel cursors,
+  accepted ranges, `source` / `dest` / `initial_source`, payload presence,
+  payload hashes, schemas, and projection watermarks.
+- Multi-machine sync starts without conflict resolution. The initial product
+  assumption is a single accepted timeline and careful user operation. If forks,
+  authority-root changes, or conflicting writes appear later, they must become
+  explicit accept/reject/rebase policy rather than implicit directory layout.
+
+## First delivery
+
+The first delivery remains one-way:
+
+```text
+Atlas source -> Kungfu local storage
+```
+
+Atlas remains the source of truth. Kungfu imports Atlas facts, stores large
+payloads behind hash-addressed references, writes a manifest, runs fsck, exports
+canonical JSONL, and verifies imported hashes against the Atlas repository.
+
+This proves:
+
+- source enumeration by stable coordinates;
+- payload hashing and manifest inventory;
+- local acceptance into Kungfu storage;
+- export for equivalence checking;
+- fsck/verify loops that can detect drift.
+
+It does not yet claim remote Kungfu-to-Kungfu sync, conflict handling, or
+authority migration.
+
+## Explicitly out of scope
+
+- Conflict resolution between two independently written timelines.
+- Automatically changing the authority root from an external source to Kungfu.
+- Peer discovery, authentication, encryption, transport security, or hosted
+  relay design.
+- A final wire protocol for channel requests.
+- Directory-level mirror semantics as the product contract.
+
+## Alternatives considered
+
+- **Keep each remote machine in a separate local directory.** Rejected. It
+  preserves a mirror but does not make accepted facts first-class local facts,
+  and it forces consumers to reason about physical layout instead of manifests
+  and provenance.
+- **Declare one machine the permanent primary.** Rejected. It does not match the
+  local-first model. A user should be able to continue from any node whose facts
+  have been accepted and verified, subject to the current no-conflict operating
+  assumption.
+- **Invent a sync address model separate from location/channel.** Rejected. The
+  runtime already has location and channel concepts. Reusing them keeps storage
+  sync aligned with the rest of the multi-process runtime.
+- **Adopt Git's object and branch model directly.** Rejected. The analogy is
+  useful for fetch, object identity, bundle verification, and fsck, but Kungfu's
+  data model is an ordered causal ledger, not a tree snapshot database.
+
+## Residual risk
+
+- Without conflict policy, the system depends on careful user operation. That is
+  acceptable for the first dogfood stage but must remain explicit in the UI and
+  docs.
+- Source provenance can become noisy if every adapter invents its own metadata.
+  The source registry and manifest schema need shared fixtures early.
+- A channel implementation that only copies directories would satisfy early
+  tests while violating the decision. Acceptance must be manifest-backed and
+  ledger-visible.


### PR DESCRIPTION
## Summary
- add ADR-0018 for the runtime storage service architecture
- add ADR-0019 for Git-like source sync over location/channel
- link the runtime storage service reference page to both ADRs

## Validation
- ./kungfu-code check