### PR TITLE
docs(rewind): record action timeline ADR

### DIFF
--- a/docs/MAP.md
+++ b/docs/MAP.md
@@ -35,6 +35,7 @@ and the map routes a question to whichever doc answers it.
 | What does it actually guarantee (layout / replay / compatibility)? | [`contracts.md`](contracts.md) | verify | stable |
 | What KFD-2 release claims can Buildchain audit? | [`contracts.md`](contracts.md) (KFD-2 release claims) + [`kfd-native-sdk-release-gates.md`](kfd-native-sdk-release-gates.md) | verify | draft |
 | What is the event / journal / replay model? | [`event-model.md`](event-model.md) | use | stable |
+| What does Rewind replay, and what must it never silently re-execute? | [ADR-0020](../framework/core/docs/adr/ADR-0020-agent-action-timeline-and-replay-boundary.md) + [`rewind.md`](rewind.md) | why, verify | stable |
 | How does Kungfu persist user facts, sync sources, and maintain storage over time? | [`runtime-storage-service.md`](runtime-storage-service.md) | use, verify | draft |
 | Where are the Python / Node / framework adapter boundaries? | [`adapters.md`](adapters.md) | use | stable |
 | How do I go from source to a binary? | [`buildchain.md`](buildchain.md) (+ [`../CONTRIBUTING.md`](../CONTRIBUTING.md)) | use | stable |
@@ -63,6 +64,10 @@ route to the row that answers them:
 - **determinism / reproducibility / record-and-replay** → *what does it actually
   guarantee* ([`contracts.md`](contracts.md)) and *the event / journal / replay
   model* ([`event-model.md`](event-model.md)).
+- **agent action timeline / causal action chain / forensic replay / mocked
+  replay / external side effects / rewind replay boundary** → *what does Rewind
+  replay, and what must it never silently re-execute*
+  ([ADR-0020](../framework/core/docs/adr/ADR-0020-agent-action-timeline-and-replay-boundary.md)).
 - **accountability / facts before trust / local proof before control** → *why
   does Kungfu start from accountability* ([`facts-before-trust.md`](facts-before-trust.md)).
 - **latency / performance / zero-copy / serialization** → *the membrane*

--- a/docs/event-model.md
+++ b/docs/event-model.md
@@ -8,6 +8,11 @@ makes see [`contracts.md`](contracts.md); for the design rationale see
 
 Every claim below can be verified against the cited source.
 
+The higher-level action-timeline decision is
+[ADR-0020](../framework/core/docs/adr/ADR-0020-agent-action-timeline-and-replay-boundary.md):
+Kungfu records the causal action chain and attached evidence, not a complete
+snapshot of the outside world.
+
 ## The journal
 
 The data plane is a single, append-only log of **frames** — `yijinjing`. A
@@ -66,6 +71,13 @@ as live: there is no separate replay engine. Because the frames carry
 nanosecond `gen_time`, the `trigger_frame_uid` causal links, and a fixed layout,
 a recorded stream reproduces with high precision. The determinism this provides,
 and its boundaries, are stated in [`contracts.md`](contracts.md).
+
+For agent runs, replay is layered. Forensic replay reopens, decodes, verifies,
+and walks the recorded causal tree without re-executing external effects.
+Mocked replay may substitute recorded receipts for external calls. Any replay
+mode that can repeat real-world side effects must be explicit and confirmed.
+This boundary is pinned by
+[ADR-0020](../framework/core/docs/adr/ADR-0020-agent-action-timeline-and-replay-boundary.md).
 
 Source: the replay path in
 [`framework/core/src/libkungfu/src/yijinjing/`](../framework/core/src/libkungfu/src/yijinjing).

--- a/docs/rewind.md
+++ b/docs/rewind.md
@@ -117,6 +117,11 @@ uv run --frozen python .devtools/kfc.py -H <anything> rewind open <file.rewind.z
 `open` refuses quietly wrong data: the archive's record must pass the same
 two-path verification as a local run before anything is shown.
 
+The replay boundary is architectural, not just a CLI behavior:
+[ADR-0020](../framework/core/docs/adr/ADR-0020-agent-action-timeline-and-replay-boundary.md)
+defines Rewind's default mode as forensic replay. It reopens and verifies the
+recorded action timeline; it does not silently repeat real-world side effects.
+
 ## Diagnose in the app
 
 ```sh
@@ -182,7 +187,8 @@ Each runs standalone: `tests/fixtures/<name>/run.sh`.
 - Streaming (SSE) model responses are captured verbatim, not parsed into
   token/usage facts.
 - Replay is forensic (re-open, walk, verify); deterministic re-execution is a
-  later differentiator gate.
+  later differentiator gate. Any mode that can repeat external side effects
+  must be explicit and confirmed.
 - Framework auto-instrumentation ships with a real LangChain adapter (and the
   demo toolkit for the seam shape); further frameworks grow in the same adapter
   table. The LangChain adapter wraps the synchronous `BaseTool.run` funnel,

--- a/framework/core/docs/adr/ADR-0020-agent-action-timeline-and-replay-boundary.md
+++ b/framework/core/docs/adr/ADR-0020-agent-action-timeline-and-replay-boundary.md
@@ -1,0 +1,144 @@
+# ADR-0020: Agent action timeline and rewind/replay boundary
+
+- Status: accepted
+- Date: 2026-07-08
+- Category: (architecture) action fact model — what Kungfu records for agent
+  work, and what rewind/replay can honestly promise
+- Subsystem: journal/event model, Rewind capture, runtime storage service,
+  source sync, payload evidence, and future replay modes.
+- Related: ADR-0018 defines the runtime storage service. ADR-0019 defines
+  Git-like source sync over Kungfu `location` and `channel`.
+  [`docs/event-model.md`](../../../../docs/event-model.md) describes frames,
+  causal links, and replay. [`docs/rewind.md`](../../../../docs/rewind.md)
+  describes the current pre-release record/open/verify workflow.
+
+## Context
+
+Git is a powerful fact-source mechanism when force rewrites are disallowed:
+objects are immutable, refs move by visible history, and a reader can verify a
+file tree at a head. That makes Git a strong source of **file-surface facts**.
+
+Agent work has different pressure:
+
+1. **Coordination latency.** Multi-line agent work through Git requires index
+   locks, branch locks, merge queues, and conflict resolution. That is correct
+   for source files, but too slow and too coarse for runtime action capture.
+2. **Slice shape.** Git slices by file tree, path, commit, and branch. Agent
+   work slices more naturally by observation, decision, tool call, result,
+   retry, span, session, source, and causal parent.
+3. **World-state mismatch.** A Git head records a file-tree state. An agent acts
+   in an open world: provider APIs, local files, windows, shells, repositories,
+   network services, approvals, and human input can all change independently.
+   No file tree can be the complete state of that world.
+
+Kungfu should not become a faster Git clone. It should use its journal-first,
+zero-copy runtime to capture the thing Git is not shaped to capture: the causal
+action timeline of a runtime participant.
+
+## Decision
+
+Kungfu will treat agent work as an **action fact timeline**.
+
+The authoritative record is an ordered causal chain of runtime facts:
+
+- what the participant observed;
+- what intent, plan, or decision was recorded;
+- which model call, tool call, command, channel request, or external operation
+  was attempted;
+- which payloads, receipts, outputs, errors, and verification results were
+  produced;
+- which frame, span, source, location, session, or prior action caused the next
+  action.
+
+Payload blobs are evidence attached to the action chain. They may be large,
+redacted, absent, or missing, but they do not replace the chain. The chain is
+the thing Kungfu can rewind, inspect, export, sync, fsck, and eventually replay.
+
+Kungfu does not claim to store the complete external world state. It stores the
+participant's verified view of the world at action time, plus enough evidence
+to inspect what happened and to replay the Kungfu-visible timeline.
+
+The replay promise is therefore layered:
+
+| Mode | Meaning | External side effects |
+| --- | --- | --- |
+| Forensic replay | Re-open the recorded timeline, decode frames, verify schemas/payloads, walk the causal tree | Never re-executed |
+| Mocked replay | Re-run local logic against recorded model/tool receipts and captured payloads | Replaced by recorded receipts |
+| Confirmed-effects replay | Re-execute selected commands or remote calls with explicit user approval and fresh guards | Allowed only per operation |
+
+The default safe mode is forensic replay. Any mode that can affect the outside
+world must be opt-in, explicit, and auditable.
+
+## Consequences
+
+- The core slice for agent work is a causal segment, not a file path. Useful
+  filters include `source`, `dest`, `initial_source`, `frame_uid`,
+  `trigger_frame_uid`, `stream_id`, session/run id, model span, tool span,
+  location, channel, time range, and accepted watermark.
+- Rewind is not only a debug view. It is the user-facing view of the action fact
+  timeline: which step happened, what caused it, what evidence was attached, and
+  why it failed or succeeded.
+- Storage and sync operate over action facts. ADR-0018 supplies the local
+  persistence contract; ADR-0019 supplies the source/location/channel sync
+  model; this ADR supplies the semantic unit being stored and synced.
+- A blob payload is evidence, not the timeline itself. A missing payload can
+  degrade or block verification, but the causal chain can still report that the
+  payload was expected and why it mattered.
+- Deterministic replay is precise only inside the recorded Kungfu world. For
+  interactions with the real world, Kungfu can replay observations and receipts
+  by default; it cannot silently repeat the external effect.
+- Future GUI and CLI features should label replay mode clearly. A button or
+  command that re-executes a shell command, network request, PR merge, file
+  write, or other real-world effect must not look like ordinary forensic replay.
+
+## First delivery
+
+The current Rewind slice already fits the decision:
+
+- a traced run writes one local journal and a self-describing trace bundle;
+- model calls and tool calls are captured as a causal tree;
+- cross-runtime tool calls nest under their caller;
+- `rewind show` walks the causal tree;
+- `rewind verify` reopens the record and checks that the bundle can decode the
+  facts;
+- export/open carries the record elsewhere and verifies it before display.
+
+The first delivery remains forensic. Deterministic re-execution and confirmed
+external effects are later gates.
+
+## Explicitly out of scope
+
+- Claiming that Kungfu captures the full state of the external world.
+- Silently re-running external side effects during replay.
+- Replacing Git as the source of truth for source-code file trees.
+- Conflict resolution between independently written timelines.
+- Defining provider-specific semantic replay of model nondeterminism.
+
+## Alternatives considered
+
+- **Use Git as the primary fact ledger for agent work.** Rejected. Git is the
+  right ledger for file trees, not for low-latency action capture. It loses the
+  runtime causal shape unless every action is translated into files first, and
+  that creates avoidable locks, delays, and impedance mismatch.
+- **Snapshot the whole world before every action.** Rejected. The world is open
+  and partly outside the user's machine. Complete snapshots are impossible or
+  unsafe for provider APIs, windows, credentials, remote services, and human
+  decisions.
+- **Treat payload blobs as the authoritative record.** Rejected. Payloads are
+  evidence. Without the causal spine, a pile of request/response bodies cannot
+  explain why an action happened, which input triggered it, or how it affected
+  the next step.
+- **Make replay always re-execute.** Rejected. That would confuse inspection
+  with control and would risk repeating writes, network calls, or approvals.
+  Replay must default to inspection and verification.
+
+## Residual risk
+
+- If capture adapters only record large payloads and omit causality, the system
+  regresses into a blob archive. Adapter tests should assert parent/child links
+  and span topology, not just payload presence.
+- If UI copy calls every mode "replay", users may not distinguish safe forensic
+  replay from effectful re-execution. Mode labels and confirmations are part of
+  the contract.
+- External receipts can be incomplete, redacted, or stale. Fsck and export must
+  preserve that state honestly instead of filling gaps with inferred facts.


### PR DESCRIPTION
## Summary
- add ADR-0020 for the agent action timeline and rewind/replay boundary
- link event-model, Rewind docs, and the documentation map to the ADR

## Validation
- ./kungfu-code check