### PR TITLE
docs(timeline): record observer-relative projection ADR

### DIFF
--- a/docs/MAP.md
+++ b/docs/MAP.md
@@ -37,6 +37,7 @@ and the map routes a question to whichever doc answers it.
 | What is the event / journal / replay model? | [`event-model.md`](event-model.md) | use | stable |
 | What does Rewind replay, and what must it never silently re-execute? | [ADR-0020](../framework/core/docs/adr/ADR-0020-agent-action-timeline-and-replay-boundary.md) + [`rewind.md`](rewind.md) | why, verify | stable |
 | How does Kungfu persist user facts, sync sources, and maintain storage over time? | [`runtime-storage-service.md`](runtime-storage-service.md) | use, verify | draft |
+| How can a multi-machine timeline stay stable without one global clock? | [ADR-0021](../framework/core/docs/adr/ADR-0021-observer-relative-timeline-projection.md) + [`event-model.md`](event-model.md) | why, verify | stable |
 | Where are the Python / Node / framework adapter boundaries? | [`adapters.md`](adapters.md) | use | stable |
 | How do I go from source to a binary? | [`buildchain.md`](buildchain.md) (+ [`../CONTRIBUTING.md`](../CONTRIBUTING.md)) | use | stable |
 | Where does a release binary come from, and how do I verify it? | `provenance.md` | verify | blocked · needs release infra |
@@ -68,6 +69,10 @@ route to the row that answers them:
   replay / external side effects / rewind replay boundary** → *what does Rewind
   replay, and what must it never silently re-execute*
   ([ADR-0020](../framework/core/docs/adr/ADR-0020-agent-action-timeline-and-replay-boundary.md)).
+- **observer-relative timeline / timeline projection / source priority /
+  global clock / multi-machine ordering / perspective / concurrent facts** →
+  *how can a multi-machine timeline stay stable without one global clock*
+  ([ADR-0021](../framework/core/docs/adr/ADR-0021-observer-relative-timeline-projection.md)).
 - **accountability / facts before trust / local proof before control** → *why
   does Kungfu start from accountability* ([`facts-before-trust.md`](facts-before-trust.md)).
 - **latency / performance / zero-copy / serialization** → *the membrane*

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -29,6 +29,7 @@ principles behind them see [`design-philosophy.md`](design-philosophy.md).
 | **channel** | A source/destination communication edge between locations. Channels are used for runtime read/write/request paths; they are transport, not fact authority. |
 | **source** | A logical storage-sync registry entry: a local profile, imported bundle, remote Kungfu runtime, or adapter that can enumerate facts for import. |
 | **manifest** | The trust root for a portable fact-ledger bundle or accepted segment: format version, capture boundary, source metadata, payload inventory, schema bindings, and checksums. |
+| **observer timeline projection** | A deterministic user-visible order over accepted facts from one or more sources, produced from an explicit observer policy rather than a claimed universal clock. Causal links dominate policy; concurrent facts may be ordered by source priority and tie-breakers. |
 | **zero-copy** | The same in-process journal bytes are shared across C++, Python, and Node **without serialization** on the hot path. |
 | **replay** | Re-running recorded journals on the *same* runtime and the *same* semantics as live, so recorded streams reproduce with high precision. |
 

--- a/docs/design-philosophy.md
+++ b/docs/design-philosophy.md
@@ -140,6 +140,13 @@ Every ADR is a decision in service of these two principles. Reading the
 [ADRs](../framework/core/docs/adr) in that light shows the architecture as a
 single, coherent answer rather than a sequence of unrelated calls.
 
+For distributed timelines, the same stance means Kungfu does not pretend to own
+an impossible global clock. It records facts, causality, source provenance, and
+the observer policy used to project concurrent facts into a stable view. The
+load-bearing truth is not "this wall-clock order is reality"; it is "this view
+can be reproduced from declared facts and policy." See
+[ADR-0021](../framework/core/docs/adr/ADR-0021-observer-relative-timeline-projection.md).
+
 ## One move, used everywhere
 
 Step back from the individual decisions and they collapse into a single act. Each

--- a/docs/event-model.md
+++ b/docs/event-model.md
@@ -13,6 +13,12 @@ The higher-level action-timeline decision is
 Kungfu records the causal action chain and attached evidence, not a complete
 snapshot of the outside world.
 
+For multi-machine views, frame time is not treated as a universal clock.
+[ADR-0021](../framework/core/docs/adr/ADR-0021-observer-relative-timeline-projection.md)
+pins the rule: Kungfu stores causal facts, source provenance, accepted ranges,
+and payload evidence; a user-visible mixed-source timeline is a deterministic
+projection from an explicit observer policy. Causal links dominate that policy.
+
 ## The journal
 
 The data plane is a single, append-only log of **frames** — `yijinjing`. A
@@ -71,6 +77,11 @@ as live: there is no separate replay engine. Because the frames carry
 nanosecond `gen_time`, the `trigger_frame_uid` causal links, and a fixed layout,
 a recorded stream reproduces with high precision. The determinism this provides,
 and its boundaries, are stated in [`contracts.md`](contracts.md).
+
+Across sources or machines, replay and inspection should prefer causal links,
+accepted ranges, and observer projection metadata over wall-clock order alone.
+Two observers may keep different stable projections of concurrent facts; the
+view is trustworthy when its policy is explicit and reproducible.
 
 For agent runs, replay is layered. Forensic replay reopens, decodes, verifies,
 and walks the recorded causal tree without re-executing external effects.

--- a/framework/core/docs/adr/ADR-0021-observer-relative-timeline-projection.md
+++ b/framework/core/docs/adr/ADR-0021-observer-relative-timeline-projection.md
@@ -1,0 +1,154 @@
+# ADR-0021: Observer-relative timeline projection over causal facts
+
+- Status: accepted
+- Date: 2026-07-08
+- Category: (architecture) distributed timeline projection — how multi-machine
+  facts become a stable user-visible order without pretending to have one
+  universal clock
+- Subsystem: journal/event model, runtime storage service, source registry,
+  source sync over `location` / `channel`, Rewind, and future multi-agent views.
+- Related: ADR-0018 defines the runtime storage service. ADR-0019 defines
+  Git-like source sync over Kungfu `location` and `channel`. ADR-0020 defines
+  the agent action timeline and replay boundary.
+  [`docs/event-model.md`](../../../../docs/event-model.md) describes frames,
+  causal links, and replay.
+
+## Context
+
+Kungfu records timestamps as numbers in journal frames. On one host, the runtime
+can provide a stable local ordering discipline for frames written through that
+host's journal. Across machines, wall clocks are not a reliable global truth:
+they drift, they can be corrected, and they cannot prove causality between two
+independently written locations.
+
+The product goal is still a trustworthy global view. A user should be able to
+open Kungfu on a main machine, sync facts from other machines, and understand the
+work performed by many agents. As topology grows, the visible timeline must stay
+stable enough for inspection, rewind, fsck, export, and replay.
+
+Pursuing a single universal clock would add heavy coordination cost and false
+precision. It would also conflict with Kungfu's local-first model: any accepted
+node should be able to act as the practical source for later work, subject to
+the current no-conflict operating assumption from ADR-0019.
+
+The useful invariant is smaller and stronger: facts, payload commitments,
+manifests, causal links, accepted ranges, and projection policy must be
+verifiable. The final ordering of concurrent facts can be a deterministic view.
+
+## Decision
+
+Kungfu will treat a multi-machine timeline as an **observer-relative projection
+over causal facts**, not as a claim about one absolute global clock.
+
+Authoritative storage contains facts and evidence:
+
+- journal frames and their local order;
+- `source`, `dest`, `initial_source`, `frame_uid`, `trigger_frame_uid`, and
+  `stream_id`;
+- manifests, accepted ranges, heads, watermarks, and source metadata;
+- payload hashes, schema bindings, and verification results.
+
+A user-visible multi-source timeline is a projection of those facts under an
+explicit observer policy. The policy is small metadata, but it is part of the
+recorded view:
+
+| Field | Meaning |
+| --- | --- |
+| `view_id` | Stable identifier for the projection policy instance |
+| `observer_location` | The location whose perspective is being used |
+| `source_priority` | Deterministic ordering of sources or locations when facts are concurrent |
+| `policy_version` | Versioned sort and acceptance semantics |
+| `accepted_ranges` | Source ranges and watermarks included in the view |
+| `tie_breaker` | Final deterministic key, for example `source_id + frame_uid` |
+
+Causal relationships dominate projection policy. A projection may order two
+concurrent or causally unrelated segments according to the observer's source
+priority, but it must not invert a known causal dependency. If a fact depends on
+another fact through `trigger_frame_uid`, stream topology, manifest ancestry, or
+an accepted segment boundary, the dependency must appear first or the view must
+report that it cannot produce a valid total order.
+
+The stable sort shape is:
+
+1. accepted segment and causal dependency constraints;
+2. observer policy over sources, locations, and ranges;
+3. source-local journal order and frame time;
+4. deterministic tie-breaker.
+
+Different observer locations may keep different policies. Host A may prefer
+facts from B before C; host B may prefer C before A. Both views can be valid if
+each is explicit, versioned, and reproducible from the same accepted facts. This
+is a perspectival model, not a license to invent facts: facts and causality
+remain verifiable, while ordering of concurrent facts is view-relative.
+
+Trust therefore comes from reproducibility under a declared policy, not from
+claiming that Kungfu found the one true global clock.
+
+## Consequences
+
+- A synced fact from another machine becomes local Kungfu data with provenance,
+  as ADR-0019 requires. Its placement in a global timeline is a projection
+  decision, not a separate storage directory.
+- GUI and CLI views should identify the observer view or policy when a timeline
+  mixes sources. If freshness, accepted ranges, or causal dependencies are
+  incomplete, the view should report degraded state instead of silently sorting
+  by wall-clock time.
+- Exported bundles that claim a projected timeline must carry enough policy
+  metadata for another node to reproduce the same order.
+- `fsck` should eventually verify that a projection does not invert known
+  causal edges, that every included range has an accepted watermark, and that
+  policy versions are understood.
+- Topology growth adds sources, locations, channels, accepted ranges, and
+  policies. It does not require a later rewrite from absolute time to
+  perspective; perspective is the base model.
+- Wall-clock fields remain useful for latency, display, diagnostics, and
+  source-local ordering. They must not be the only cross-machine ordering proof.
+
+## First delivery
+
+The first delivery is architectural and documentation-level:
+
+- record this ADR;
+- make the event model and documentation map route timeline-ordering questions
+  to it;
+- keep the existing source import and local Rewind semantics unchanged.
+
+The current implementation can already import a source into local storage,
+retain provenance, verify payload hashes, export records, and walk causal action
+chains. It does not yet implement a first-class `view_id` policy object, a
+multi-source timeline projection command, or projection-level fsck.
+
+## Explicitly out of scope
+
+- Solving clock synchronization with NTP, PTP, hybrid logical clocks, or a
+  distributed consensus clock.
+- Conflict resolution between independently written timelines.
+- Electing one permanent global sequencer for all facts.
+- Proving that one observer's view is the absolute truth.
+- Re-executing external side effects during replay; ADR-0020 controls that
+  boundary.
+
+## Alternatives considered
+
+- **Use wall-clock order as the global truth.** Rejected. It is cheap and
+  intuitive, but it fails under clock drift, VM pauses, offline operation, and
+  independently written machines. It also gives users false confidence.
+- **Require one global sequencer.** Rejected as the default. A sequencer can be
+  useful for a specific deployment, but making it the product invariant would
+  weaken local-first operation and add latency to every node.
+- **Keep remote facts in per-machine directories and sort them at display
+  time.** Rejected. That preserves mirrors without making facts part of the
+  ledger, and it leaves ordering policy invisible and unauditable.
+- **Use arbitrary UI sort order.** Rejected. A view that cannot be reproduced
+  from stored policy is not a trustworthy timeline.
+
+## Residual risk
+
+- If the UI hides the active observer policy, users may mistake a perspective
+  for absolute truth. Mixed-source views need visible provenance and freshness.
+- If adapters fail to preserve causal links, projection can only fall back to
+  weaker source-local order. Fsck should report missing causality as degraded
+  evidence, not repair it by inference.
+- If policy metadata is not versioned early, later nodes may reproduce different
+  timeline orders from the same facts. Projection policy needs fixtures once the
+  first command lands.

--- a/framework/core/docs/adr/README.md
+++ b/framework/core/docs/adr/README.md
@@ -33,6 +33,10 @@ A record's **Status** says where it stands:
 | [0015](ADR-0015-kungfu-skill-agent-context-layer.md) | accepted | Kungfu Skill as the agent context layer above kfx |
 | [0016](ADR-0016-managed-session-host-placement.md) | accepted | managed session host placement — move the durable session host to main so multiple OS windows share it |
 | [0017](ADR-0017-dual-host-kfx-loading-host-agnostic-plan-and-service-facet.md) | proposed | dual-host kfx loading — a host-agnostic load plan shared by GUI and CLI, and the background `service` facet as the first OS-sandbox caller |
+| [0018](ADR-0018-runtime-storage-service-architecture.md) | accepted | runtime storage service as the persistence contract above journal, payloads, and projections |
+| [0019](ADR-0019-git-like-source-sync-over-location-and-channel.md) | accepted | Git-like source sync over Kungfu location and channel |
+| [0020](ADR-0020-agent-action-timeline-and-replay-boundary.md) | accepted | agent action timeline and rewind/replay boundary |
+| [0021](ADR-0021-observer-relative-timeline-projection.md) | accepted | observer-relative timeline projection over causal facts |
 
 ## Reading by theme
 
@@ -64,6 +68,15 @@ A record's **Status** says where it stands:
   (Kungfu Skill as the agent-facing layer above kfx: `SKILL.md` as the minimum
   valid source, compact catalog injection, Node/Python manage modes, and kfx
   dependency composition without bypassing the kfx trust gate).
+- **Runtime facts, storage, sync, and replay** —
+  [0018](ADR-0018-runtime-storage-service-architecture.md) (the storage service
+  above journal, payloads and projections),
+  [0019](ADR-0019-git-like-source-sync-over-location-and-channel.md)
+  (source sync over `location` and `channel`),
+  [0020](ADR-0020-agent-action-timeline-and-replay-boundary.md) (the causal
+  action timeline and replay boundary), and
+  [0021](ADR-0021-observer-relative-timeline-projection.md) (stable
+  observer-relative timeline projection without a universal global clock).
 - **Cross-cutting principle** — [0009](ADR-0009-load-bearing-self-bootstrap.md)
   (load-bearing self-bootstrap), which also names the general law that
   [`docs/architecture.md` § The build dogfoods the SDK](../../../../docs/architecture.md)
@@ -78,3 +91,6 @@ A record's **Status** says where it stands:
   below the tag.
 - [`docs/skills.md`](../../../../docs/skills.md) — the user-facing and
   implementation-facing design for Kungfu Skills.
+- [`docs/runtime-storage-service.md`](../../../../docs/runtime-storage-service.md) —
+  the staged storage command surface, fsck/export path, and source-adapter
+  direction.


### PR DESCRIPTION
## Summary
- add ADR-0021 for observer-relative timeline projection over causal facts
- route multi-machine timeline questions through the docs map, event model, concepts, and ADR index
- clarify that trust comes from reproducible facts plus projection policy, not a universal global clock

## Validation
- git diff --check
- ./kungfu-code check