### PR TITLE
feat(core): add language-neutral action recorder

### DIFF
--- a/docs/MAP.md
+++ b/docs/MAP.md
@@ -38,6 +38,7 @@ and the map routes a question to whichever doc answers it.
 | What does Rewind replay, and what must it never silently re-execute? | [ADR-0020](../framework/core/docs/adr/ADR-0020-agent-action-timeline-and-replay-boundary.md) + [`rewind.md`](rewind.md) | why, verify | stable |
 | How does Kungfu persist user facts, sync sources, and maintain storage over time? | [`runtime-storage-service.md`](runtime-storage-service.md) | use, verify | draft |
 | How can a multi-machine timeline stay stable without one global clock? | [ADR-0021](../framework/core/docs/adr/ADR-0021-observer-relative-timeline-projection.md) + [`event-model.md`](event-model.md) | why, verify | stable |
+| Where must action-recording semantics live across C++ / Python / Node? | [ADR-0022](../framework/core/docs/adr/ADR-0022-core-action-recording-surface.md) + [`event-model.md`](event-model.md) | why, use | stable |
 | Where are the Python / Node / framework adapter boundaries? | [`adapters.md`](adapters.md) | use | stable |
 | How do I go from source to a binary? | [`buildchain.md`](buildchain.md) (+ [`../CONTRIBUTING.md`](../CONTRIBUTING.md)) | use | stable |
 | Where does a release binary come from, and how do I verify it? | `provenance.md` | verify | blocked · needs release infra |
@@ -69,6 +70,10 @@ route to the row that answers them:
   replay / external side effects / rewind replay boundary** → *what does Rewind
   replay, and what must it never silently re-execute*
   ([ADR-0020](../framework/core/docs/adr/ADR-0020-agent-action-timeline-and-replay-boundary.md)).
+- **action recorder / action recording / Python recorder / Node recorder /
+  JS recorder / C++ recorder / polyglot action surface / binding-only logic** →
+  *where must action-recording semantics live across C++ / Python / Node*
+  ([ADR-0022](../framework/core/docs/adr/ADR-0022-core-action-recording-surface.md)).
 - **observer-relative timeline / timeline projection / source priority /
   global clock / multi-machine ordering / perspective / concurrent facts** →
   *how can a multi-machine timeline stay stable without one global clock*

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -25,6 +25,7 @@ principles behind them see [`design-philosophy.md`](design-philosophy.md).
 | **yijinjing** | The append-only **journal runtime** — the event bus that carries the data plane. |
 | **journal** | The append-only **event log**: one shared, strongly-typed stream of frames that every component consumes, rather than each inventing its own format. |
 | **frame** | A single journal record: a fixed-size header (source / destination / nanosecond timestamp / message type) plus a variable-size payload. |
+| **action recorder** | The language-neutral C++ core surface for writing action facts into the journal. Python and Node expose thin bindings over it; they must not implement separate causality, writer, or receipt semantics. See [ADR-0022](../framework/core/docs/adr/ADR-0022-core-action-recording-surface.md). |
 | **location** | A runtime identity/address: category, group, name, mode, locator root, and uid. Locations identify who writes, who reads, and where journals live. |
 | **channel** | A source/destination communication edge between locations. Channels are used for runtime read/write/request paths; they are transport, not fact authority. |
 | **source** | A logical storage-sync registry entry: a local profile, imported bundle, remote Kungfu runtime, or adapter that can enumerate facts for import. |

--- a/docs/event-model.md
+++ b/docs/event-model.md
@@ -13,6 +13,12 @@ The higher-level action-timeline decision is
 Kungfu records the causal action chain and attached evidence, not a complete
 snapshot of the outside world.
 
+The action-recording implementation boundary is
+[ADR-0022](../framework/core/docs/adr/ADR-0022-core-action-recording-surface.md):
+architecture-level recording semantics live in the C++ core. Python and Node may
+wrap the recorder and build payloads, but they must not own independent
+causality, writer, timeline, or receipt logic.
+
 For multi-machine views, frame time is not treated as a universal clock.
 [ADR-0021](../framework/core/docs/adr/ADR-0021-observer-relative-timeline-projection.md)
 pins the rule: Kungfu stores causal facts, source provenance, accepted ranges,

--- a/framework/api/src/capability/guest-harness/fixture-caps.ts
+++ b/framework/api/src/capability/guest-harness/fixture-caps.ts
@@ -1,3 +1,4 @@
+import { type Ledger, openLedger } from '../ledger';
 // The trusted host's real capability surface for the guest-host harness, built
 // from an injected in-memory binding (ADR-0011: the SDK never loads the native
 // binding; the host injects it). This exercises the real ledger capability code
@@ -14,12 +15,29 @@
 // `report` is the harness output sink: a facet delivers its result by calling
 // report.result(obj) in BOTH tiers, so its source never branches on the tier.
 import type { KfNativeBinding } from '../types';
-import { type Ledger, openLedger } from '../ledger';
 
 const FIXTURE_FRAMES = [
-  { genTime: 1_700_000_000_000_000_001n, msgType: 101, source: 11, dest: 21 },
-  { genTime: 1_700_000_000_000_000_002n, msgType: 102, source: 12, dest: 22 },
-  { genTime: 1_700_000_000_000_000_003n, msgType: 103, source: 13, dest: 23 },
+  {
+    genTime: 1_700_000_000_000_000_001n,
+    frameUid: 1n,
+    msgType: 101,
+    source: 11,
+    dest: 21,
+  },
+  {
+    genTime: 1_700_000_000_000_000_002n,
+    frameUid: 2n,
+    msgType: 102,
+    source: 12,
+    dest: 22,
+  },
+  {
+    genTime: 1_700_000_000_000_000_003n,
+    frameUid: 3n,
+    msgType: 103,
+    source: 13,
+    dest: 23,
+  },
 ];
 
 // A minimal KfNativeBinding: only Assemble is exercised (records()); the other
@@ -28,7 +46,9 @@ function fixtureBinding(): KfNativeBinding {
   class Assemble {
     private i = 0;
     private readonly frames = FIXTURE_FRAMES;
-    constructor(_runtimeDirs: string[]) {}
+    constructor(runtimeDirs: string[]) {
+      void runtimeDirs;
+    }
     dataAvailable(): boolean {
       return this.i < this.frames.length;
     }
@@ -40,10 +60,15 @@ function fixtureBinding(): KfNativeBinding {
       return {
         genTime: () => f.genTime,
         triggerTime: () => f.genTime,
+        frameUid: () => f.frameUid,
+        triggerFrameUid: () => f.frameUid - 1n,
+        streamId: () => 0n,
         msgType: () => f.msgType,
         source: () => f.source,
+        initialSource: () => f.source,
         dest: () => f.dest,
         dataLength: () => 0,
+        dataType: () => 0,
         dataBytes: () => new Uint8Array(0),
       };
     }

--- a/framework/api/src/capability/ledger.ts
+++ b/framework/api/src/capability/ledger.ts
@@ -75,10 +75,15 @@ export function openLedger(options: OpenLedgerOptions): Ledger {
         result.push({
           genTime,
           triggerTime: frame.triggerTime(),
+          frameUid: frame.frameUid(),
+          triggerFrameUid: frame.triggerFrameUid(),
+          streamId: frame.streamId(),
           msgType,
           source: frame.source(),
+          initialSource: frame.initialSource(),
           dest: frame.dest(),
           dataLength: frame.dataLength(),
+          dataType: frame.dataType(),
         });
       }
       assemble.next();

--- a/framework/api/src/capability/types.ts
+++ b/framework/api/src/capability/types.ts
@@ -60,9 +60,14 @@ export type LedgerRecord = {
   genTime: bigint;
   triggerTime: bigint;
   msgType: number;
+  frameUid: bigint;
+  triggerFrameUid: bigint;
+  streamId: bigint;
   source: number;
+  initialSource: number;
   dest: number;
   dataLength: number;
+  dataType: number;
 };
 
 export type RecordFilter = {
@@ -100,10 +105,15 @@ export type Subscription = {
 export type KfNativeFrame = {
   genTime: () => bigint;
   triggerTime: () => bigint;
+  frameUid: () => bigint;
+  triggerFrameUid: () => bigint;
+  streamId: () => bigint;
   msgType: () => number;
   source: () => number;
+  initialSource: () => number;
   dest: () => number;
   dataLength: () => number;
+  dataType: () => number;
   // raw payload bytes — the decode path for open-layer frames (e.g. rewind
   // events), whose schemas live outside the compiled longfist registry
   dataBytes: () => Uint8Array;
@@ -119,6 +129,47 @@ export type KfNativeBinding = {
     dataAvailable: () => boolean;
     next: () => void;
     currentFrame: () => KfNativeFrame;
+  };
+  ActionRecorder?: new (
+    runtimeDir: string,
+    group: string,
+    name: string,
+    destId?: number,
+    streamId?: bigint | number,
+  ) => {
+    recordBytes: (
+      msgType: number,
+      payload: Uint8Array,
+      options?: {
+        genTime?: bigint | number;
+        triggerTime?: bigint | number;
+        parentFrameUid?: bigint | number;
+        streamId?: bigint | number;
+        chainToLast?: boolean;
+      },
+    ) => LedgerRecord;
+    recordJson: (
+      msgType: number,
+      jsonPayload: string,
+      options?: {
+        genTime?: bigint | number;
+        triggerTime?: bigint | number;
+        parentFrameUid?: bigint | number;
+        streamId?: bigint | number;
+        chainToLast?: boolean;
+      },
+    ) => LedgerRecord;
+    mark: (
+      msgType: number,
+      options?: {
+        genTime?: bigint | number;
+        triggerTime?: bigint | number;
+        parentFrameUid?: bigint | number;
+        streamId?: bigint | number;
+        chainToLast?: boolean;
+      },
+    ) => LedgerRecord;
+    lastFrameUid: () => bigint;
   };
   SessionStore: new (
     location: Record<string, string>,

--- a/framework/core/docs/adr/ADR-0022-core-action-recording-surface.md
+++ b/framework/core/docs/adr/ADR-0022-core-action-recording-surface.md
@@ -1,0 +1,127 @@
+# ADR-0022: Core action-recording surface lives in the C++ polyglot membrane
+
+- Status: accepted
+- Date: 2026-07-08
+- Category: (architecture) polyglot runtime surface -- where action-recording
+  semantics must live
+- Subsystem: libkungfu, yijinjing journal writer, Python bindings, Node
+  bindings, capability SDK, Rewind, runtime storage service, and future
+  multi-agent action capture.
+- Related: ADR-0009 defines `libkungfu` as the load-bearing polyglot membrane.
+  ADR-0018 defines runtime storage as the persistence contract. ADR-0020
+  defines the action timeline and replay boundary. ADR-0021 defines
+  observer-relative timeline projection.
+
+## Context
+
+Kungfu must record actions from agents and user code written in C++, Python,
+Node/JavaScript, and future language bindings. The action timeline is
+architecture-level state: it decides causal parents, frame identity, stream
+identity, timestamps, payload type, source/dest identity, and the receipt a
+caller can trust after writing.
+
+Early product slices exposed much of this through Python-first paths because
+that was the fastest route to dogfood Rewind and Atlas import. That is useful
+for delivery, but it is the wrong long-term ownership boundary. If Python and
+JavaScript each grow independent writer logic, Kungfu loses the very property
+the journal is meant to provide: one physical fact surface shared by all
+languages.
+
+The load-bearing membrane is C++. `libkungfu` owns the journal layout, writer
+semantics, location identity, publish barrier, and zero-copy cross-language
+runtime. Bindings are adapters over that membrane, not separate products.
+
+## Decision
+
+Architecture-level action-recording semantics live in the C++ core.
+
+The first-class action-recording surface is `yijinjing::action::action_recorder`
+in `libkungfu`. It owns:
+
+- construction of the writer location and channel;
+- selection of `source`, `dest`, `initial_source`, and `stream_id`;
+- parent selection through `trigger_frame_uid`;
+- optional chaining to the last recorded frame;
+- payload data type (`Raw` or `Json`);
+- generation and trigger timestamps;
+- frame publication through the yijinjing writer;
+- the record receipt returned to the caller.
+
+Python and Node expose thin bindings over this C++ surface. They may:
+
+- translate language-native payload containers to bytes or strings;
+- translate option names into the C++ `record_options`;
+- translate the C++ `record_receipt` into language-native objects;
+- build domain payloads above the recorder.
+
+They must not own independent architecture-level writer, causality, timeline,
+or receipt semantics. A feature that changes action recording, replay
+causality, storage sync semantics, or cross-language frame identity must be
+implemented in C++ first and then surfaced through bindings.
+
+Read-side bindings must also expose the complete frame identity needed by the
+timeline model: `frame_uid`, `trigger_frame_uid`, `stream_id`,
+`initial_source`, and `data_type`, not only timestamps and msg type.
+
+## Consequences
+
+- Python/JS APIs remain convenient, but they are wrappers. They cannot drift
+  from C++ causality or receipt rules.
+- Future agents implementing storage, Rewind, sync, fsck, export, or replay
+  should search for the C++ core surface before adding Python or TypeScript
+  logic.
+- Capability SDK types may describe the surface, but they do not define the
+  source of truth. The native binding is the contract executor.
+- Language-specific managers can still build payload schemas, validation, and
+  UI/domain helpers. Those are above the recorder and do not decide causal
+  frame semantics.
+- Tests for new action-recording features should verify at least one binding
+  path, but the core invariant belongs to C++.
+
+## First delivery
+
+The first delivery adds:
+
+- C++ `yijinjing::action::action_recorder`;
+- Python binding classes for `action_recorder`, `action_record_options`, and
+  `action_record_receipt`;
+- Node `ActionRecorder` binding;
+- full frame identity exposure in Python and Node frame/event bindings;
+- capability SDK type updates so higher layers can read the same identity
+  fields.
+
+This is still a narrow write surface. It does not yet define domain-specific
+agent action schemas, storage compaction, multi-source projection policy
+objects, or conflict resolution. Those features should build on this recorder
+rather than reimplementing it per language.
+
+## Explicitly out of scope
+
+- Moving all domain payload construction into C++.
+- Removing Python Rewind or Node UI helpers.
+- Making Python or JavaScript unable to write any payloads.
+- Defining every future action schema in this ADR.
+- Solving multi-writer conflict resolution.
+
+## Alternatives considered
+
+- **Keep Python as the action-recording implementation.** Rejected. It works
+  for the first dogfood loop but fails the polyglot requirement. C++ and Node
+  users would either lose first-class recording or duplicate semantics.
+- **Implement one recorder per language.** Rejected. This would create
+  semantic drift in parent selection, timestamps, payload typing, receipts, and
+  frame identity.
+- **Expose only raw yijinjing writer APIs.** Rejected for product-level action
+  capture. Raw writer access is still useful, but architecture-level action
+  recording needs a stable receipt and causal policy.
+
+## Residual risk
+
+- Existing Python-first Rewind code may still contain action semantics that
+  should migrate down. New work should shrink that surface rather than expand
+  it.
+- If bindings add convenience APIs that silently choose different defaults, the
+  membrane can still drift. Binding tests should assert receipt/header parity.
+- If documentation only names the binding APIs, future agents may miss the C++
+  ownership boundary. Concepts, map, and Atlas mission docs must point back to
+  this ADR.

--- a/framework/core/docs/adr/README.md
+++ b/framework/core/docs/adr/README.md
@@ -37,6 +37,7 @@ A record's **Status** says where it stands:
 | [0019](ADR-0019-git-like-source-sync-over-location-and-channel.md) | accepted | Git-like source sync over Kungfu location and channel |
 | [0020](ADR-0020-agent-action-timeline-and-replay-boundary.md) | accepted | agent action timeline and rewind/replay boundary |
 | [0021](ADR-0021-observer-relative-timeline-projection.md) | accepted | observer-relative timeline projection over causal facts |
+| [0022](ADR-0022-core-action-recording-surface.md) | accepted | core action-recording surface lives in the C++ polyglot membrane |
 
 ## Reading by theme
 
@@ -76,7 +77,9 @@ A record's **Status** says where it stands:
   [0020](ADR-0020-agent-action-timeline-and-replay-boundary.md) (the causal
   action timeline and replay boundary), and
   [0021](ADR-0021-observer-relative-timeline-projection.md) (stable
-  observer-relative timeline projection without a universal global clock).
+  observer-relative timeline projection without a universal global clock), and
+  [0022](ADR-0022-core-action-recording-surface.md) (the C++ core
+  action-recording surface that Python/Node bindings wrap).
 - **Cross-cutting principle** — [0009](ADR-0009-load-bearing-self-bootstrap.md)
   (load-bearing self-bootstrap), which also names the general law that
   [`docs/architecture.md` § The build dogfoods the SDK](../../../../docs/architecture.md)

--- a/framework/core/src/bindings/node/binding/action_recorder.cpp
+++ b/framework/core/src/bindings/node/binding/action_recorder.cpp
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#include "action_recorder.h"
+
+#include <vector>
+
+using kungfu::yijinjing::action::record_options;
+using kungfu::yijinjing::action::record_receipt;
+
+namespace kungfu::node {
+
+Napi::FunctionReference ActionRecorder::constructor = {};
+
+namespace {
+
+uint64_t read_uint64(const Napi::Value &value) {
+  if (value.IsBigInt()) {
+    bool lossless = false;
+    return value.As<Napi::BigInt>().Uint64Value(&lossless);
+  }
+  if (value.IsNumber()) {
+    return static_cast<uint64_t>(value.As<Napi::Number>().Int64Value());
+  }
+  return 0;
+}
+
+record_options read_options(const Napi::CallbackInfo &info, size_t index) {
+  record_options options{};
+  if (info.Length() <= index || info[index].IsEmpty() || info[index].IsUndefined()) {
+    return options;
+  }
+  if (!info[index].IsObject()) {
+    throw Napi::TypeError::New(info.Env(), "ActionRecorder options must be an object");
+  }
+
+  auto object = info[index].As<Napi::Object>();
+  if (object.Has("genTime")) {
+    options.gen_time = static_cast<int64_t>(read_uint64(object.Get("genTime")));
+  }
+  if (object.Has("triggerTime")) {
+    options.trigger_time = static_cast<int64_t>(read_uint64(object.Get("triggerTime")));
+  }
+  if (object.Has("parentFrameUid")) {
+    options.parent_frame_uid = read_uint64(object.Get("parentFrameUid"));
+  }
+  if (object.Has("streamId")) {
+    options.stream_id = read_uint64(object.Get("streamId"));
+  }
+  if (object.Has("chainToLast")) {
+    options.chain_to_last = object.Get("chainToLast").ToBoolean().Value();
+  }
+  return options;
+}
+
+std::vector<uint8_t> read_bytes(const Napi::CallbackInfo &info, size_t index) {
+  if (info.Length() <= index || info[index].IsEmpty() || info[index].IsUndefined()) {
+    throw Napi::TypeError::New(info.Env(), "payload must be a Buffer or Uint8Array");
+  }
+
+  auto value = info[index];
+  if (value.IsBuffer()) {
+    auto buffer = value.As<Napi::Buffer<uint8_t>>();
+    return {buffer.Data(), buffer.Data() + buffer.Length()};
+  }
+  if (value.IsTypedArray()) {
+    auto typed_array = value.As<Napi::TypedArray>();
+    if (typed_array.TypedArrayType() == napi_uint8_array) {
+      auto uint8_array = value.As<Napi::Uint8Array>();
+      auto data = static_cast<uint8_t *>(uint8_array.ArrayBuffer().Data()) + uint8_array.ByteOffset();
+      return {data, data + uint8_array.ByteLength()};
+    }
+  }
+
+  throw Napi::TypeError::New(info.Env(), "payload must be a Buffer or Uint8Array");
+}
+
+Napi::Object to_receipt_object(Napi::Env env, const record_receipt &receipt) {
+  auto object = Napi::Object::New(env);
+  object.Set("frameUid", Napi::BigInt::New(env, receipt.frame_uid));
+  object.Set("triggerFrameUid", Napi::BigInt::New(env, receipt.trigger_frame_uid));
+  object.Set("streamId", Napi::BigInt::New(env, receipt.stream_id));
+  object.Set("genTime", Napi::BigInt::New(env, receipt.gen_time));
+  object.Set("triggerTime", Napi::BigInt::New(env, receipt.trigger_time));
+  object.Set("msgType", Napi::Number::New(env, receipt.msg_type));
+  object.Set("source", Napi::Number::New(env, receipt.source));
+  object.Set("initialSource", Napi::Number::New(env, receipt.initial_source));
+  object.Set("dest", Napi::Number::New(env, receipt.dest));
+  object.Set("dataLength", Napi::Number::New(env, receipt.data_length));
+  object.Set("dataType", Napi::Number::New(env, receipt.data_type));
+  return object;
+}
+
+} // namespace
+
+ActionRecorder::ActionRecorder(const Napi::CallbackInfo &info) : ObjectWrap(info) {
+  if (!IsValid(info, 0, &Napi::Value::IsString) || !IsValid(info, 1, &Napi::Value::IsString) ||
+      !IsValid(info, 2, &Napi::Value::IsString)) {
+    throw Napi::TypeError::New(info.Env(), "ActionRecorder(runtimeDir, group, name, destId?, streamId?)");
+  }
+
+  const auto runtime_dir = info[0].As<Napi::String>().Utf8Value();
+  const auto group = info[1].As<Napi::String>().Utf8Value();
+  const auto name = info[2].As<Napi::String>().Utf8Value();
+  const auto dest_id =
+      IsValid(info, 3) ? static_cast<uint32_t>(read_uint64(info[3])) : yijinjing::data::location::PUBLIC;
+  const auto stream_id = IsValid(info, 4) ? read_uint64(info[4]) : 0;
+  recorder_ = std::make_unique<yijinjing::action::action_recorder>(runtime_dir, group, name, dest_id, stream_id);
+}
+
+Napi::Value ActionRecorder::RecordBytes(const Napi::CallbackInfo &info) {
+  if (!IsValid(info, 0, &Napi::Value::IsNumber)) {
+    throw Napi::TypeError::New(info.Env(), "recordBytes(msgType, payload, options?)");
+  }
+  const auto msg_type = info[0].As<Napi::Number>().Int32Value();
+  const auto payload = read_bytes(info, 1);
+  const auto options = read_options(info, 2);
+  return to_receipt_object(info.Env(), recorder_->record_bytes(msg_type, payload, options));
+}
+
+Napi::Value ActionRecorder::RecordJson(const Napi::CallbackInfo &info) {
+  if (!IsValid(info, 0, &Napi::Value::IsNumber) || !IsValid(info, 1, &Napi::Value::IsString)) {
+    throw Napi::TypeError::New(info.Env(), "recordJson(msgType, jsonPayload, options?)");
+  }
+  const auto msg_type = info[0].As<Napi::Number>().Int32Value();
+  const auto payload = info[1].As<Napi::String>().Utf8Value();
+  const auto options = read_options(info, 2);
+  return to_receipt_object(info.Env(), recorder_->record_json(msg_type, payload, options));
+}
+
+Napi::Value ActionRecorder::Mark(const Napi::CallbackInfo &info) {
+  if (!IsValid(info, 0, &Napi::Value::IsNumber)) {
+    throw Napi::TypeError::New(info.Env(), "mark(msgType, options?)");
+  }
+  const auto msg_type = info[0].As<Napi::Number>().Int32Value();
+  const auto options = read_options(info, 1);
+  return to_receipt_object(info.Env(), recorder_->mark(msg_type, options));
+}
+
+Napi::Value ActionRecorder::LastFrameUid(const Napi::CallbackInfo &info) {
+  return Napi::BigInt::New(info.Env(), recorder_->last_frame_uid());
+}
+
+void ActionRecorder::Init(Napi::Env env, Napi::Object exports) {
+  Napi::HandleScope scope(env);
+  env.AddCleanupHook(cleanup);
+
+  Napi::Function func = DefineClass(env, "ActionRecorder",
+                                    {
+                                        InstanceMethod("recordBytes", &ActionRecorder::RecordBytes),
+                                        InstanceMethod("recordJson", &ActionRecorder::RecordJson),
+                                        InstanceMethod("mark", &ActionRecorder::Mark),
+                                        InstanceMethod("lastFrameUid", &ActionRecorder::LastFrameUid),
+                                    });
+
+  constructor = Napi::Persistent(func);
+  constructor.SuppressDestruct();
+  exports.Set("ActionRecorder", func);
+}
+
+} // namespace kungfu::node

--- a/framework/core/src/bindings/node/binding/action_recorder.h
+++ b/framework/core/src/bindings/node/binding/action_recorder.h
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef KUNGFU_NODE_ACTION_RECORDER_H
+#define KUNGFU_NODE_ACTION_RECORDER_H
+
+#include "common.h"
+
+#include <kungfu/yijinjing/action_recorder.h>
+
+#include <memory>
+
+namespace kungfu::node {
+
+class ActionRecorder : public Napi::ObjectWrap<ActionRecorder> {
+public:
+  explicit ActionRecorder(const Napi::CallbackInfo &info);
+
+  Napi::Value RecordBytes(const Napi::CallbackInfo &info);
+
+  Napi::Value RecordJson(const Napi::CallbackInfo &info);
+
+  Napi::Value Mark(const Napi::CallbackInfo &info);
+
+  Napi::Value LastFrameUid(const Napi::CallbackInfo &info);
+
+  static void Init(Napi::Env env, Napi::Object exports);
+
+private:
+  static Napi::FunctionReference constructor;
+  static void cleanup() {
+    SPDLOG_INFO("ActionRecorder reset");
+    ActionRecorder::constructor.Reset();
+  }
+
+  std::unique_ptr<yijinjing::action::action_recorder> recorder_;
+};
+
+} // namespace kungfu::node
+
+#endif // KUNGFU_NODE_ACTION_RECORDER_H

--- a/framework/core/src/bindings/node/binding/journal.cpp
+++ b/framework/core/src/bindings/node/binding/journal.cpp
@@ -31,6 +31,18 @@ Napi::Value Frame::TriggerTime(const Napi::CallbackInfo &info) {
   return Napi::BigInt::New(info.Env(), frame_->trigger_time());
 }
 
+Napi::Value Frame::FrameUid(const Napi::CallbackInfo &info) {
+  return Napi::BigInt::New(info.Env(), frame_->frame_uid());
+}
+
+Napi::Value Frame::TriggerFrameUid(const Napi::CallbackInfo &info) {
+  return Napi::BigInt::New(info.Env(), frame_->trigger_frame_uid());
+}
+
+Napi::Value Frame::StreamId(const Napi::CallbackInfo &info) {
+  return Napi::BigInt::New(info.Env(), frame_->stream_id());
+}
+
 Napi::Value Frame::MsgType(const Napi::CallbackInfo &info) { return Napi::Number::New(info.Env(), frame_->msg_type()); }
 
 Napi::Value Frame::Source(const Napi::CallbackInfo &info) { return Napi::Number::New(info.Env(), frame_->source()); }
@@ -39,6 +51,10 @@ Napi::Value Frame::Dest(const Napi::CallbackInfo &info) { return Napi::Number::N
 
 Napi::Value Frame::InitialSource(const Napi::CallbackInfo &info) {
   return Napi::Number::New(info.Env(), frame_->initial_source());
+}
+
+Napi::Value Frame::DataType(const Napi::CallbackInfo &info) {
+  return Napi::Number::New(info.Env(), frame_->data_type());
 }
 
 Napi::Value Frame::Data(const Napi::CallbackInfo &info) {
@@ -82,16 +98,20 @@ void Frame::Init(Napi::Env env, Napi::Object exports) {
 
   Napi::Function func = DefineClass(env, "Frame",
                                     {
-                                        InstanceMethod("dataLength", &Frame::DataLength),       //
-                                        InstanceMethod("genTime", &Frame::GenTime),             //
-                                        InstanceMethod("triggerTime", &Frame::TriggerTime),     //
-                                        InstanceMethod("msgType", &Frame::MsgType),             //
-                                        InstanceMethod("source", &Frame::Source),               //
-                                        InstanceMethod("dest", &Frame::Dest),                   //
-                                        InstanceMethod("initialSource", &Frame::InitialSource), //
-                                        InstanceMethod("data", &Frame::Data),                   //
-                                        InstanceMethod("dataAsString", &Frame::DataAsString),   //
-                                        InstanceMethod("dataBytes", &Frame::DataBytes)          //
+                                        InstanceMethod("dataLength", &Frame::DataLength),           //
+                                        InstanceMethod("genTime", &Frame::GenTime),                 //
+                                        InstanceMethod("triggerTime", &Frame::TriggerTime),         //
+                                        InstanceMethod("frameUid", &Frame::FrameUid),               //
+                                        InstanceMethod("triggerFrameUid", &Frame::TriggerFrameUid), //
+                                        InstanceMethod("streamId", &Frame::StreamId),               //
+                                        InstanceMethod("msgType", &Frame::MsgType),                 //
+                                        InstanceMethod("source", &Frame::Source),                   //
+                                        InstanceMethod("dest", &Frame::Dest),                       //
+                                        InstanceMethod("initialSource", &Frame::InitialSource),     //
+                                        InstanceMethod("dataType", &Frame::DataType),               //
+                                        InstanceMethod("data", &Frame::Data),                       //
+                                        InstanceMethod("dataAsString", &Frame::DataAsString),       //
+                                        InstanceMethod("dataBytes", &Frame::DataBytes)              //
                                     });
 
   constructor = Napi::Persistent(func);

--- a/framework/core/src/bindings/node/binding/journal.h
+++ b/framework/core/src/bindings/node/binding/journal.h
@@ -61,6 +61,12 @@ public:
 
   Napi::Value TriggerTime(const Napi::CallbackInfo &info);
 
+  Napi::Value FrameUid(const Napi::CallbackInfo &info);
+
+  Napi::Value TriggerFrameUid(const Napi::CallbackInfo &info);
+
+  Napi::Value StreamId(const Napi::CallbackInfo &info);
+
   Napi::Value MsgType(const Napi::CallbackInfo &info);
 
   Napi::Value Source(const Napi::CallbackInfo &info);
@@ -68,6 +74,8 @@ public:
   Napi::Value Dest(const Napi::CallbackInfo &info);
 
   Napi::Value InitialSource(const Napi::CallbackInfo &info);
+
+  Napi::Value DataType(const Napi::CallbackInfo &info);
 
   Napi::Value Data(const Napi::CallbackInfo &info);
 

--- a/framework/core/src/bindings/node/binding/kungfu_node.cpp
+++ b/framework/core/src/bindings/node/binding/kungfu_node.cpp
@@ -46,6 +46,7 @@ decltype(__pfnDliNotifyHook2) __pfnDliNotifyHook2 = load_exe_hook;
 #include <kungfu/yijinjing/io.h>
 #include <kungfu/yijinjing/util/util.h>
 
+#include "action_recorder.h"
 #include "app_container.h"
 #include "basket_instrument_store.h"
 #include "basket_store.h"
@@ -147,6 +148,7 @@ Napi::Object InitAll(Napi::Env env, Napi::Object exports) {
   Frame::Init(env, exports);
   Reader::Init(env, exports);
   Assemble::Init(env, exports);
+  ActionRecorder::Init(env, exports);
   IODevice::Init(env, exports);
   DataTable::Init(env, exports);
   Watcher::Init(env, exports);

--- a/framework/core/src/bindings/python/binding/py-yijinjing.cpp
+++ b/framework/core/src/bindings/python/binding/py-yijinjing.cpp
@@ -5,6 +5,7 @@
 #include <pybind11/stl.h>
 
 #include <kungfu/longfist/longfist.h>
+#include <kungfu/yijinjing/action_recorder.h>
 #include <kungfu/yijinjing/cache/profile.h>
 #include <kungfu/yijinjing/index/session.h>
 #include <kungfu/yijinjing/io.h>
@@ -195,10 +196,16 @@ void bind(pybind11::module &&m) {
   auto event_class = py::class_<event, PyEvent, std::shared_ptr<event>>(m, "event");
   event_class.def_property_readonly("gen_time", &event::gen_time)
       .def_property_readonly("trigger_time", &event::trigger_time)
+      .def_property_readonly("frame_uid", &event::frame_uid)
+      .def_property_readonly("trigger_frame_uid", &event::trigger_frame_uid)
+      .def_property_readonly("stream_id", &event::stream_id)
       .def_property_readonly("source", &event::source)
+      .def_property_readonly("initial_source", &event::initial_source)
       .def_property_readonly("dest", &event::dest)
       .def_property_readonly("msg_type", &event::msg_type)
       .def_property_readonly("data_length", &event::data_length)
+      .def_property_readonly("data_type", &event::data_type)
+      .def_property_readonly("is_json", &event::is_json)
       .def_property_readonly("data_as_bytes", &event::data_as_bytes)
       .def_property_readonly("data_as_byte_array", &event::data_as_byte_array)
       .def_property_readonly("data_as_string", &event::data_as_string)
@@ -211,6 +218,46 @@ void bind(pybind11::module &&m) {
   py::class_<frame, event, frame_ptr>(m, "frame")
       .def_property_readonly("frame_length", &frame::frame_length)
       .def("has_data", &frame::has_data);
+
+  py::class_<action::record_options>(m, "action_record_options")
+      .def(py::init<>())
+      .def_readwrite("gen_time", &action::record_options::gen_time)
+      .def_readwrite("trigger_time", &action::record_options::trigger_time)
+      .def_readwrite("parent_frame_uid", &action::record_options::parent_frame_uid)
+      .def_readwrite("stream_id", &action::record_options::stream_id)
+      .def_readwrite("chain_to_last", &action::record_options::chain_to_last)
+      .def_readwrite("data_type", &action::record_options::data_type);
+
+  py::class_<action::record_receipt>(m, "action_record_receipt")
+      .def_readonly("frame_uid", &action::record_receipt::frame_uid)
+      .def_readonly("trigger_frame_uid", &action::record_receipt::trigger_frame_uid)
+      .def_readonly("stream_id", &action::record_receipt::stream_id)
+      .def_readonly("gen_time", &action::record_receipt::gen_time)
+      .def_readonly("trigger_time", &action::record_receipt::trigger_time)
+      .def_readonly("msg_type", &action::record_receipt::msg_type)
+      .def_readonly("source", &action::record_receipt::source)
+      .def_readonly("initial_source", &action::record_receipt::initial_source)
+      .def_readonly("dest", &action::record_receipt::dest)
+      .def_readonly("data_length", &action::record_receipt::data_length)
+      .def_readonly("data_type", &action::record_receipt::data_type);
+
+  py::class_<action::action_recorder, action::action_recorder_ptr>(m, "action_recorder")
+      .def(py::init<const std::string &, const std::string &, const std::string &, uint32_t, uint64_t>(),
+           py::arg("runtime_dir"), py::arg("group"), py::arg("name"),
+           py::arg("dest_id") = yijinjing::data::location::PUBLIC, py::arg("stream_id") = 0)
+      .def(
+          "record_bytes",
+          [](action::action_recorder &recorder, int32_t msg_type, py::bytes payload, action::record_options options) {
+            std::string bytes = payload;
+            return recorder.record_bytes(msg_type, std::vector<uint8_t>(bytes.begin(), bytes.end()), options);
+          },
+          py::arg("msg_type"), py::arg("payload"),
+          py::arg_v("options", action::record_options{}, "action_record_options()"))
+      .def("record_json", &action::action_recorder::record_json, py::arg("msg_type"), py::arg("json_payload"),
+           py::arg_v("options", action::record_options{}, "action_record_options()"))
+      .def("mark", &action::action_recorder::mark, py::arg("msg_type"),
+           py::arg_v("options", action::record_options{}, "action_record_options()"))
+      .def_property_readonly("last_frame_uid", &action::action_recorder::last_frame_uid);
 
   auto location_class = py::class_<location, location_ptr>(m, "location");
   location_class

--- a/framework/core/src/libkungfu/include/kungfu/yijinjing/action_recorder.h
+++ b/framework/core/src/libkungfu/include/kungfu/yijinjing/action_recorder.h
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef KUNGFU_YIJINJING_ACTION_RECORDER_H
+#define KUNGFU_YIJINJING_ACTION_RECORDER_H
+
+#include <kungfu/longfist/core.h>
+#include <kungfu/yijinjing/common.h>
+#include <kungfu/yijinjing/journal/journal.h>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace kungfu::yijinjing::action {
+
+struct record_options {
+  int64_t gen_time = 0;
+  int64_t trigger_time = 0;
+  uint64_t parent_frame_uid = 0;
+  uint64_t stream_id = 0;
+  bool chain_to_last = true;
+  longfist::enums::FrameDataType data_type = longfist::enums::FrameDataType::Raw;
+};
+
+struct record_receipt {
+  uint64_t frame_uid = 0;
+  uint64_t trigger_frame_uid = 0;
+  uint64_t stream_id = 0;
+  int64_t gen_time = 0;
+  int64_t trigger_time = 0;
+  int32_t msg_type = 0;
+  uint32_t source = 0;
+  uint32_t initial_source = 0;
+  uint32_t dest = 0;
+  uint32_t data_length = 0;
+  int8_t data_type = 0;
+};
+
+class action_recorder {
+public:
+  action_recorder(const std::string &runtime_dir, const std::string &group, const std::string &name,
+                  uint32_t dest_id = yijinjing::data::location::PUBLIC, uint64_t stream_id = 0);
+
+  record_receipt record_bytes(int32_t msg_type, const std::vector<uint8_t> &payload, record_options options = {});
+
+  record_receipt record_json(int32_t msg_type, const std::string &json_payload, record_options options = {});
+
+  record_receipt mark(int32_t msg_type, record_options options = {});
+
+  [[nodiscard]] uint64_t last_frame_uid() const { return last_frame_uid_; }
+
+  [[nodiscard]] const data::location_ptr &get_location() const { return location_; }
+
+private:
+  record_receipt record_payload(int32_t msg_type, const uint8_t *payload, uint32_t payload_length,
+                                record_options options);
+
+  data::locator_ptr locator_;
+  data::location_ptr location_;
+  publisher_ptr publisher_;
+  journal::bus_ptr bus_;
+  journal::writer_ptr writer_;
+  uint32_t dest_id_;
+  uint64_t default_stream_id_;
+  uint64_t last_frame_uid_ = 0;
+};
+
+DECLARE_PTR(action_recorder)
+
+} // namespace kungfu::yijinjing::action
+
+#endif // KUNGFU_YIJINJING_ACTION_RECORDER_H

--- a/framework/core/src/libkungfu/src/yijinjing/action_recorder.cpp
+++ b/framework/core/src/libkungfu/src/yijinjing/action_recorder.cpp
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#include <kungfu/yijinjing/action_recorder.h>
+#include <kungfu/yijinjing/io.h>
+#include <kungfu/yijinjing/time.h>
+
+#include <cstring>
+
+using namespace kungfu::longfist::enums;
+using namespace kungfu::yijinjing::data;
+using namespace kungfu::yijinjing::journal;
+
+namespace kungfu::yijinjing::action {
+
+action_recorder::action_recorder(const std::string &runtime_dir, const std::string &group, const std::string &name,
+                                 uint32_t dest_id, uint64_t stream_id)
+    : locator_(std::make_shared<locator>(runtime_dir, mode::LIVE)),
+      location_(location::make_shared(mode::LIVE, category::SYSTEM, group, name, locator_)),
+      publisher_(std::make_shared<noop_publisher>()), bus_(std::make_shared<bus>(false)),
+      writer_(std::make_shared<writer>(location_, dest_id, true, publisher_, false, bus_)), dest_id_(dest_id),
+      default_stream_id_(stream_id) {}
+
+record_receipt action_recorder::record_bytes(int32_t msg_type, const std::vector<uint8_t> &payload,
+                                             record_options options) {
+  options.data_type = FrameDataType::Raw;
+  return record_payload(msg_type, payload.data(), static_cast<uint32_t>(payload.size()), options);
+}
+
+record_receipt action_recorder::record_json(int32_t msg_type, const std::string &json_payload, record_options options) {
+  options.data_type = FrameDataType::Json;
+  return record_payload(msg_type, reinterpret_cast<const uint8_t *>(json_payload.data()),
+                        static_cast<uint32_t>(json_payload.size()), options);
+}
+
+record_receipt action_recorder::mark(int32_t msg_type, record_options options) {
+  options.data_type = FrameDataType::Raw;
+  return record_payload(msg_type, nullptr, 0, options);
+}
+
+record_receipt action_recorder::record_payload(int32_t msg_type, const uint8_t *payload, uint32_t payload_length,
+                                               record_options options) {
+  const auto parent_frame_uid =
+      options.parent_frame_uid != 0 ? options.parent_frame_uid : (options.chain_to_last ? last_frame_uid_ : 0);
+  const auto stream_id = options.stream_id != 0 ? options.stream_id : default_stream_id_;
+  const auto gen_time = options.gen_time != 0 ? options.gen_time : time::now_in_nano();
+
+  bus::set_trigger_frame_uid(parent_frame_uid);
+  auto frame = writer_->open_frame(options.trigger_time, msg_type, payload_length, stream_id);
+  frame->set_data_type(options.data_type);
+  if (payload_length > 0) {
+    std::memcpy(const_cast<void *>(frame->data_address()), payload, payload_length);
+  }
+  const auto frame_uid = writer_->current_frame_uid();
+  writer_->close_frame(payload_length, gen_time);
+  bus::set_trigger_frame_uid(0);
+
+  record_receipt receipt{};
+  receipt.frame_uid = frame_uid;
+  receipt.trigger_frame_uid = parent_frame_uid;
+  receipt.stream_id = stream_id;
+  receipt.gen_time = gen_time;
+  receipt.trigger_time = options.trigger_time;
+  receipt.msg_type = msg_type;
+  receipt.source = location_->uid;
+  receipt.initial_source = location_->uid;
+  receipt.dest = dest_id_;
+  receipt.data_length = payload_length;
+  receipt.data_type = static_cast<int8_t>(options.data_type);
+  last_frame_uid_ = receipt.frame_uid;
+  return receipt;
+}
+
+} // namespace kungfu::yijinjing::action

--- a/framework/core/stubs/pykungfu/yijinjing.pyi
+++ b/framework/core/stubs/pykungfu/yijinjing.pyi
@@ -2,7 +2,62 @@ from __future__ import annotations
 import pykungfu.longfist.enums
 import pykungfu.longfist.types
 import typing
-__all__: list[str] = ['PUBLISH', 'PULL', 'PUSH', 'REPLY', 'REQUEST', 'SUBSCRIBE', 'apprentice', 'assemble', 'bus', 'calendar_day_start', 'color_print', 'compile_schema', 'copy_sink', 'emit_log', 'event', 'frame', 'get_page_path', 'hash_32', 'hash_str_32', 'in_color_terminal', 'io_device', 'location', 'locator', 'master', 'nano_hashed', 'next_minute', 'next_trading_day_end', 'noop_publisher', 'now_in_nano', 'null_sink', 'observer', 'profile', 'protocol', 'publisher', 'reader', 'restore_start', 'session_builder', 'session_finder', 'setup_log', 'sink', 'socket', 'strfnow', 'strftime', 'strptime', 'thread_id', 'today_start', 'trading_day_start', 'writer']
+__all__: list[str] = ['PUBLISH', 'PULL', 'PUSH', 'REPLY', 'REQUEST', 'SUBSCRIBE', 'action_record_options', 'action_record_receipt', 'action_recorder', 'apprentice', 'assemble', 'bus', 'calendar_day_start', 'color_print', 'compile_schema', 'copy_sink', 'emit_log', 'event', 'frame', 'get_page_path', 'hash_32', 'hash_str_32', 'in_color_terminal', 'io_device', 'location', 'locator', 'master', 'nano_hashed', 'next_minute', 'next_trading_day_end', 'noop_publisher', 'now_in_nano', 'null_sink', 'observer', 'profile', 'protocol', 'publisher', 'reader', 'restore_start', 'session_builder', 'session_finder', 'setup_log', 'sink', 'socket', 'strfnow', 'strftime', 'strptime', 'thread_id', 'today_start', 'trading_day_start', 'writer']
+class action_record_options:
+    chain_to_last: bool
+    data_type: pykungfu.longfist.enums.FrameDataType
+    gen_time: int
+    parent_frame_uid: int
+    stream_id: int
+    trigger_time: int
+    def __init__(self) -> None:
+        ...
+class action_record_receipt:
+    @property
+    def data_length(self) -> int:
+        ...
+    @property
+    def data_type(self) -> int:
+        ...
+    @property
+    def dest(self) -> int:
+        ...
+    @property
+    def frame_uid(self) -> int:
+        ...
+    @property
+    def gen_time(self) -> int:
+        ...
+    @property
+    def initial_source(self) -> int:
+        ...
+    @property
+    def msg_type(self) -> int:
+        ...
+    @property
+    def source(self) -> int:
+        ...
+    @property
+    def stream_id(self) -> int:
+        ...
+    @property
+    def trigger_frame_uid(self) -> int:
+        ...
+    @property
+    def trigger_time(self) -> int:
+        ...
+class action_recorder:
+    def __init__(self, runtime_dir: str, group: str, name: str, dest_id: int = 0, stream_id: int = 0) -> None:
+        ...
+    def mark(self, msg_type: int, options: action_record_options = ...) -> action_record_receipt:
+        ...
+    def record_bytes(self, msg_type: int, payload: bytes, options: action_record_options = ...) -> action_record_receipt:
+        ...
+    def record_json(self, msg_type: int, json_payload: str, options: action_record_options = ...) -> action_record_receipt:
+        ...
+    @property
+    def last_frame_uid(self) -> int:
+        ...
 class apprentice:
     def __init__(self, home: location, low_latency: bool = False, arguments: str = '{}') -> None:
         ...
@@ -1002,16 +1057,34 @@ class event:
     def data_length(self) -> int:
         ...
     @property
+    def data_type(self) -> int:
+        ...
+    @property
     def dest(self) -> int:
         ...
     @property
+    def frame_uid(self) -> int:
+        ...
+    @property
     def gen_time(self) -> int:
+        ...
+    @property
+    def initial_source(self) -> int:
+        ...
+    @property
+    def is_json(self) -> bool:
         ...
     @property
     def msg_type(self) -> int:
         ...
     @property
     def source(self) -> int:
+        ...
+    @property
+    def stream_id(self) -> int:
+        ...
+    @property
+    def trigger_frame_uid(self) -> int:
         ...
     @property
     def trigger_time(self) -> int:


### PR DESCRIPTION
Add a C++ action-recording surface in libkungfu, expose thin Python/Node bindings, and document the C++ ownership boundary for future polyglot runtime fact-ledger work.