### PR TITLE
ci: lock buildchain contract

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,3 +32,6 @@ jobs:
       release-candidate: true
       artifact-transfer-mode: s3-to-github-artifacts
       artifact-retention-days: 14
+      buildchain-contract-lock-path: buildchain.contract-lock.json
+      buildchain-contract-compatibility-policy: major-compatible
+      buildchain-contract-drift-issue-mode: compatible-and-breaking

--- a/buildchain.contract-lock.json
+++ b/buildchain.contract-lock.json
@@ -1,0 +1,71 @@
+{
+  "schemaVersion": 1,
+  "contract": "kungfu-buildchain-contract-lock",
+  "buildchain": {
+    "ref": "v2",
+    "resolvedSha": "aa039c39e7d5a5a74d078025a21a47676fadca82",
+    "contract": "kungfu-buildchain-runtime-contract-world",
+    "contractDigest": "sha256:7b2fed2dacdf37234ca03e656904611b9c3dd48a4f229be387c7c1393f57fc5b",
+    "compatibilityDigest": "sha256:36421b592a782decbfe31a7d8d42d70ce1100a56a2c4f4a0ccc21f0617dc72bf",
+    "majorLine": "v2",
+    "compatibilityPolicy": "major-compatible",
+    "acceptedAt": "2026-07-08T01:58:03.118Z",
+    "surfaces": [
+      {
+        "id": "reusable-build",
+        "kind": "workflow",
+        "breakingDigest": "sha256:6303aa2c2cb8c2cef4301ceea95cc3c426c2aa81d98714aa9bdf2471d63faee1"
+      },
+      {
+        "id": "release-candidate-promote",
+        "kind": "workflow",
+        "breakingDigest": "sha256:403d2fcdb0c5eabe749e89102defad69745f70a1556707bec7831fcc2e9fa8f8"
+      },
+      {
+        "id": "promote-buildchain-ref-action",
+        "kind": "action",
+        "breakingDigest": "sha256:347b65aecd38bc671d8f697eabd15254f905b6f745389d7b26d7595a904a720c"
+      },
+      {
+        "id": "report-buildchain-issue-action",
+        "kind": "action",
+        "breakingDigest": "sha256:575a2cb02cdb2e61bb2e84d5bbaaf64b430aa5d7936645660b592de4549d81b0"
+      },
+      {
+        "id": "release-passport-schema",
+        "kind": "schema",
+        "breakingDigest": "sha256:b627e1b2ece9b6049517a942c5139e342e6077cdd3d8962d61cef8481b1f70ad"
+      },
+      {
+        "id": "kfd-1-release-gate",
+        "kind": "schema",
+        "breakingDigest": "sha256:f46c1f67b94957ad956cf70db59a73fd5690bd67c91edf9c2d0eb8f3d1e3cf8d"
+      },
+      {
+        "id": "kfd-2-release-trust-passport-audit",
+        "kind": "schema",
+        "breakingDigest": "sha256:f0b636eb925ddbf45ff1a8872454ab7b4dd98857cac12bb75217830130e62a16"
+      },
+      {
+        "id": "kfd-3-collaboration-interface-release-gate",
+        "kind": "schema",
+        "breakingDigest": "sha256:33654f3444c893754aacc42dde3051f0a371bd17c6ef7c657c579a07159cd7c1"
+      },
+      {
+        "id": "buildchain-cli",
+        "kind": "cli",
+        "breakingDigest": "sha256:097db3e67509bedda8c6548bf1edfbfcf57f7b5510520b6a7b7e078d7ec087c8"
+      },
+      {
+        "id": "agent-manual-registry",
+        "kind": "site-contract",
+        "breakingDigest": "sha256:7d0d2819e3a3e72989d9c57b5efe9d0bc0a79bc0f2c82a0c7b9d6c5a211a91f2"
+      },
+      {
+        "id": "node-api-registry",
+        "kind": "site-contract",
+        "breakingDigest": "sha256:48f925608d3e2131d90936b07dc2a30341204cae3e6e785c0f77d61ad755c945"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add the Buildchain v2 contract lock accepted by Kungfu
- wire the reusable build workflow to validate the lock before matrix builds
- open drift issues for compatible and breaking contract drift

## Validation
- actionlint .github/workflows/build.yml .github/workflows/buildchain-validate.yml
- buildchain-contract-lock.mjs check
- git diff --check
- jq contract-lock shape check
