### PR TITLE
feat(atlas): record imports as action envelopes

### DIFF
--- a/framework/core/slices/fact-ledger/CMakeLists.txt
+++ b/framework/core/slices/fact-ledger/CMakeLists.txt
@@ -1,13 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 #
-# Minimal fact-ledger slice: two standalone executables that embed the journal
+# Minimal fact-ledger slice: standalone executables that embed the journal
 # spine without starting the trading runtime.
 #
-#   fact_ledger_host    write path  -- appends a causal chain of Json events
-#   fact_ledger_export  read path   -- reopens the directory, emits JSONL + manifest
+#   fact_ledger_host             write path -- appends a causal chain of Json events
+#   fact_ledger_export           read path  -- reopens the directory, emits JSONL + manifest
+#   fact_ledger_action_recorder  C++ action_recorder write/readback smoke
 #
-# Both link ONLY the yijinjing journal core -- this is the cut-proof for the
-# static-core boundary: the tools embed the journal spine without libkungfu.
+# host/export link only the yijinjing journal core. action_recorder links
+# libkungfu because that is the polyglot core action-recording surface.
 
 project(fact_ledger_slice)
 
@@ -16,3 +17,6 @@ target_link_libraries(fact_ledger_host yijinjing)
 
 add_executable(fact_ledger_export export.cpp)
 target_link_libraries(fact_ledger_export yijinjing)
+
+add_executable(fact_ledger_action_recorder action_recorder.cpp)
+target_link_libraries(fact_ledger_action_recorder ${LIBKUNGFU_NAME})

--- a/framework/core/slices/fact-ledger/action_recorder.cpp
+++ b/framework/core/slices/fact-ledger/action_recorder.cpp
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// C++ action_recorder smoke: record a causal chain through the core recorder,
+// reopen it with assemble, and verify receipts against the journal bytes.
+
+#include <kungfu/yijinjing/action_recorder.h>
+#include <kungfu/yijinjing/common.h>
+#include <kungfu/yijinjing/journal/assemble.h>
+
+#include <nlohmann/json.hpp>
+
+#include "../common/sha256.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <iostream>
+#include <string>
+#include <vector>
+
+using namespace kungfu::yijinjing;
+namespace longfist = kungfu::longfist;
+using kungfu::slices::sha256;
+
+namespace {
+constexpr int32_t MSG_ACTION = 20031;
+constexpr uint64_t STREAM_ID = 7001;
+
+std::vector<uint8_t> bytes_for_step(std::size_t step) {
+  nlohmann::json payload = {
+      {"schema", "kungfu.fact-ledger-action/v1"},
+      {"step", step},
+      {"action_type", "slice.fact.record"},
+  };
+  const std::string text = payload.dump();
+  return {text.begin(), text.end()};
+}
+
+bool padding_is_zero(const std::vector<uint8_t> &bytes, std::size_t from) {
+  return std::all_of(bytes.begin() + static_cast<std::ptrdiff_t>(from), bytes.end(),
+                     [](uint8_t value) { return value == 0; });
+}
+
+std::string payload_hash(const std::vector<uint8_t> &bytes, std::size_t length) {
+  const std::string view{reinterpret_cast<const char *>(bytes.data()), length};
+  return sha256::hex(view);
+}
+
+void fail(const std::string &message) { std::cerr << "fact_ledger_action_recorder: " << message << "\n"; }
+} // namespace
+
+int main(int argc, char **argv) {
+  if (argc < 2) {
+    std::cerr << "usage: fact_ledger_action_recorder <journal-root-dir> [event-count]\n";
+    return 2;
+  }
+
+  const std::string root = argv[1];
+  const std::size_t n = argc >= 3 ? static_cast<std::size_t>(std::stoul(argv[2])) : 4;
+  if (n < 2) {
+    fail("event-count must be >= 2");
+    return 2;
+  }
+
+  const std::string group = "fact_ledger_slice";
+  const std::string name = "action_recorder";
+
+  action::action_recorder recorder(root, group, name, data::location::PUBLIC, STREAM_ID);
+  std::vector<action::record_receipt> receipts;
+  std::vector<std::vector<uint8_t>> payloads;
+
+  for (std::size_t i = 0; i < n; ++i) {
+    auto payload = bytes_for_step(i);
+    payloads.push_back(payload);
+    receipts.push_back(recorder.record_bytes(MSG_ACTION, payload));
+  }
+
+  auto locator = std::make_shared<data::locator>(root);
+  auto location =
+      data::location::make_shared(longfist::enums::mode::LIVE, longfist::enums::category::SYSTEM, group, name, locator);
+  journal::assemble reader(location, data::location::PUBLIC, longfist::enums::AssembleMode::Channel, 0);
+  auto frames = reader.read_bytes(MSG_ACTION);
+  if (frames.size() != receipts.size()) {
+    fail("frame count mismatch");
+    return 1;
+  }
+
+  for (std::size_t i = 0; i < receipts.size(); ++i) {
+    const auto &receipt = receipts[i];
+    const auto &header = frames[i].first;
+    const auto &bytes = frames[i].second;
+    const auto expected_parent = i == 0 ? 0 : receipts[i - 1].frame_uid;
+
+    if (receipt.frame_uid != header.frame_uid || receipt.msg_type != header.msg_type ||
+        receipt.gen_time != header.gen_time || receipt.stream_id != header.stream_id ||
+        receipt.trigger_frame_uid != header.trigger_frame_uid || receipt.trigger_frame_uid != expected_parent ||
+        receipt.data_length != payloads[i].size() || bytes.size() < payloads[i].size() ||
+        !padding_is_zero(bytes, payloads[i].size()) ||
+        payload_hash(bytes, payloads[i].size()) != payload_hash(payloads[i], payloads[i].size())) {
+      fail("receipt/readback mismatch at step " + std::to_string(i));
+      return 1;
+    }
+  }
+
+  nlohmann::json out = {
+      {"root", root},
+      {"group", group},
+      {"name", name},
+      {"event_count", receipts.size()},
+      {"causal_chain_verified", true},
+      {"record_surface", "kungfu::yijinjing::action::action_recorder"},
+  };
+  std::cout << out.dump(2) << "\n";
+  return 0;
+}

--- a/framework/core/src/python/kungfu/atlas/importer.py
+++ b/framework/core/src/python/kungfu/atlas/importer.py
@@ -377,4 +377,4 @@ def read_control_plane_with_sources(repo_root, window=None):
         missions, goals, markers = _filter_projection(
             missions, goals, markers, source_records
         )
-    return missions, goals, markers, source_records, warnings
+    return missions, goals, markers, source_records, list(dict.fromkeys(warnings))

--- a/framework/core/src/python/kungfu/atlas/payloads.py
+++ b/framework/core/src/python/kungfu/atlas/payloads.py
@@ -7,6 +7,7 @@ from typing import Any
 
 CONTENT_TYPE_JSON = "application/json"
 PAYLOAD_STATE_PRESENT = "present"
+ACTION_ENVELOPE_SCHEMA = "kungfu.action-envelope/v1"
 
 
 def canonical_json_bytes(value: Any) -> bytes:
@@ -61,6 +62,45 @@ def enrich_source_records(source_records: list[dict[str, Any]]) -> list[dict[str
     return enriched
 
 
+def _action_type(kind: str) -> str:
+    return f"atlas.{kind}.snapshot"
+
+
+def _action_envelope(
+    *,
+    import_id: str,
+    storage_source_id: str,
+    source_type: str,
+    entry: dict[str, Any],
+    receipt: dict[str, Any],
+) -> dict[str, Any]:
+    kind = str(entry.get("kind") or "")
+    return {
+        "schema": ACTION_ENVELOPE_SCHEMA,
+        "session": {"import_id": import_id},
+        "actor": {
+            "storage_source_id": storage_source_id,
+            "source_type": source_type,
+        },
+        "action_type": _action_type(kind),
+        "source": {
+            "kind": kind,
+            "source_id": entry.get("source_id"),
+            "source_path": entry.get("source_path"),
+            "source_time": entry.get("source_time"),
+            "schema_version": entry.get("schema_version"),
+        },
+        "payload": {
+            "content_type": entry.get("content_type", CONTENT_TYPE_JSON),
+            "hash_algorithm": "sha256",
+            "hash": entry.get("payload_hash"),
+            "byte_len": entry.get("byte_len"),
+            "state": entry.get("payload_state", PAYLOAD_STATE_PRESENT),
+        },
+        "journal": dict(receipt),
+    }
+
+
 def _serialize_range(range_filter: dict[str, Any] | None) -> dict[str, Any] | None:
     if not range_filter:
         return None
@@ -102,6 +142,7 @@ def write_import_payloads(
     storage_source_id: str = "atlas",
     source_type: str = "atlas",
     range_filter: dict[str, Any] | None = None,
+    action_receipts: dict[tuple[str, str], dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     store_dir = Path(store_dir)
     entries = []
@@ -111,7 +152,17 @@ def write_import_payloads(
         path.parent.mkdir(parents=True, exist_ok=True)
         if not path.exists():
             path.write_bytes(raw)
-        entries.append({k: v for k, v in record.items() if k != "payload"})
+        entry = {k: v for k, v in record.items() if k != "payload"}
+        receipt = (action_receipts or {}).get(_entry_key(entry))
+        if receipt is not None:
+            entry["action"] = _action_envelope(
+                import_id=import_id,
+                storage_source_id=storage_source_id,
+                source_type=source_type,
+                entry=entry,
+                receipt=receipt,
+            )
+        entries.append(entry)
 
     manifest = {
         "schema": "kungfu.atlas-import/v1",
@@ -181,9 +232,160 @@ def _load_payload(
     return data, None
 
 
+def _append_action_error(
+    report: dict[str, Any],
+    code: str,
+    entry: dict[str, Any],
+    **extra: Any,
+) -> None:
+    report["ok"] = False
+    error = {
+        "code": code,
+        "kind": entry.get("kind"),
+        "source_id": entry.get("source_id"),
+    }
+    error.update(extra)
+    report["errors"].append(error)
+
+
+def _check_action_payload(
+    report: dict[str, Any],
+    entry: dict[str, Any],
+    action: dict[str, Any],
+) -> None:
+    payload = action.get("payload")
+    if not isinstance(payload, dict):
+        _append_action_error(report, "action_payload_invalid", entry)
+        return
+    expectations = {
+        "hash": entry.get("payload_hash"),
+        "byte_len": entry.get("byte_len"),
+        "state": entry.get("payload_state"),
+    }
+    for field, expected in expectations.items():
+        if payload.get(field) != expected:
+            _append_action_error(
+                report,
+                "action_payload_mismatch",
+                entry,
+                field=field,
+                expected=expected,
+                actual=payload.get(field),
+            )
+
+
+def _check_action_frame(
+    report: dict[str, Any],
+    entry: dict[str, Any],
+    action: dict[str, Any],
+    action_frames: dict[Any, dict[str, Any]] | None,
+) -> None:
+    journal = action.get("journal")
+    if not isinstance(journal, dict):
+        _append_action_error(report, "action_journal_invalid", entry)
+        return
+    if action_frames is None:
+        return
+    frame_uid = journal.get("frame_uid")
+    frame = action_frames.get(
+        (frame_uid, journal.get("msg_type"), journal.get("gen_time"))
+    )
+    if frame is None:
+        _append_action_error(report, "action_frame_missing", entry, frame_uid=frame_uid)
+        return
+    for field in (
+        "trigger_frame_uid",
+        "stream_id",
+        "gen_time",
+        "trigger_time",
+        "msg_type",
+        "source",
+        "initial_source",
+        "dest",
+        "data_type",
+    ):
+        if frame.get(field) != journal.get(field):
+            _append_action_error(
+                report,
+                "action_frame_mismatch",
+                entry,
+                field=field,
+                frame_uid=frame_uid,
+                expected=journal.get(field),
+                actual=frame.get(field),
+            )
+    payload = frame.get("_payload")
+    expected_length = journal.get("data_length")
+    if isinstance(payload, bytes) and isinstance(expected_length, int):
+        if len(payload) < expected_length:
+            _append_action_error(
+                report,
+                "action_frame_mismatch",
+                entry,
+                field="data_length",
+                frame_uid=frame_uid,
+                expected=expected_length,
+                actual=len(payload),
+            )
+        elif any(payload[expected_length:]):
+            _append_action_error(
+                report,
+                "action_frame_nonzero_padding",
+                entry,
+                frame_uid=frame_uid,
+                expected=expected_length,
+                actual=len(payload),
+            )
+        actual_hash = payload_hash(payload[:expected_length])
+        if actual_hash != journal.get("journal_payload_hash"):
+            _append_action_error(
+                report,
+                "action_frame_mismatch",
+                entry,
+                field="journal_payload_hash",
+                frame_uid=frame_uid,
+                expected=journal.get("journal_payload_hash"),
+                actual=actual_hash,
+            )
+
+
+def _check_action(
+    report: dict[str, Any],
+    entry: dict[str, Any],
+    action_frames: dict[Any, dict[str, Any]] | None,
+) -> None:
+    action = entry.get("action")
+    if action is None:
+        return
+    report["checked"]["actions"] += 1
+    if not isinstance(action, dict):
+        _append_action_error(report, "action_invalid", entry)
+        return
+    if action.get("schema") != ACTION_ENVELOPE_SCHEMA:
+        _append_action_error(
+            report,
+            "action_schema_mismatch",
+            entry,
+            expected=ACTION_ENVELOPE_SCHEMA,
+            actual=action.get("schema"),
+        )
+    kind = str(entry.get("kind") or "")
+    if action.get("action_type") != _action_type(kind):
+        _append_action_error(
+            report,
+            "action_type_mismatch",
+            entry,
+            expected=_action_type(kind),
+            actual=action.get("action_type"),
+        )
+    _check_action_payload(report, entry, action)
+    _check_action_frame(report, entry, action, action_frames)
+
+
 def fsck_import(
     store_dir: str | Path,
     projection: dict[str, Any] | None = None,
+    action_frames: dict[Any, dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     manifest = load_latest_manifest(store_dir)
     report = {
@@ -197,6 +399,7 @@ def fsck_import(
             "missions": 0,
             "goals": 0,
             "markers": 0,
+            "actions": 0,
         },
     }
     if manifest is None:
@@ -251,6 +454,7 @@ def fsck_import(
                     "payload_hash": entry.get("payload_hash"),
                 }
             )
+        _check_action(report, entry, action_frames)
 
     counts = manifest.get("counts") if isinstance(manifest.get("counts"), dict) else {}
     for key in ("missions", "goals", "markers"):

--- a/framework/core/src/python/kungfu/atlas/store.py
+++ b/framework/core/src/python/kungfu/atlas/store.py
@@ -64,18 +64,26 @@ class ImportStore:
 
     def __init__(self, runtime_dir):
         self.runtime_dir = runtime_dir
-        self.location = _location(runtime_dir)
-        # keep every piece alive on self — the writer borrows them without
-        # owning their lifetime (same as the work store)
-        self.publisher = yjj.noop_publisher()
-        self.bus = yjj.bus(False)
-        self.writer = yjj.writer(
-            self.location, PUBLIC_DEST, True, self.publisher, False, self.bus, 0
+        self.recorder = yjj.action_recorder(
+            runtime_dir, ATLAS_GROUP, ATLAS_NAME, PUBLIC_DEST, 0
         )
 
     def _append(self, msg_type, data):
-        # the binding takes the payload as a byte sequence (list[int])
-        self.writer.write_bytes(0, msg_type, list(data), len(data))
+        receipt = self.recorder.record_bytes(msg_type, data)
+        return {
+            "frame_uid": receipt.frame_uid,
+            "trigger_frame_uid": receipt.trigger_frame_uid,
+            "stream_id": receipt.stream_id,
+            "gen_time": receipt.gen_time,
+            "trigger_time": receipt.trigger_time,
+            "msg_type": receipt.msg_type,
+            "source": receipt.source,
+            "initial_source": receipt.initial_source,
+            "dest": receipt.dest,
+            "data_length": receipt.data_length,
+            "data_type": receipt.data_type,
+            "journal_payload_hash": payloads.payload_hash(data),
+        }
 
     def run_import(
         self,
@@ -91,6 +99,7 @@ class ImportStore:
         missions, goals, markers, source_records, warnings = (
             importer.read_control_plane_with_sources(repo_root, window=range_filter)
         )
+        action_receipts = {}
         self._append(
             MSG_IMPORT_BEGIN,
             events.import_begin(
@@ -101,11 +110,17 @@ class ImportStore:
             ),
         )
         for card in missions:
-            self._append(MSG_MISSION_SNAPSHOT, events.mission_snapshot(import_id, card))
+            action_receipts[("mission", card["mission_id"])] = self._append(
+                MSG_MISSION_SNAPSHOT, events.mission_snapshot(import_id, card)
+            )
         for card in goals:
-            self._append(MSG_GOAL_SNAPSHOT, events.goal_snapshot(import_id, card))
+            action_receipts[("goal", card["goal_id"])] = self._append(
+                MSG_GOAL_SNAPSHOT, events.goal_snapshot(import_id, card)
+            )
         for card in markers:
-            self._append(MSG_MARKER_SNAPSHOT, events.marker_snapshot(import_id, card))
+            action_receipts[("marker", card["branch"])] = self._append(
+                MSG_MARKER_SNAPSHOT, events.marker_snapshot(import_id, card)
+            )
         self._append(
             MSG_IMPORT_END,
             events.import_end(
@@ -126,6 +141,7 @@ class ImportStore:
             storage_source_id=storage_source_id,
             source_type="atlas",
             range_filter=range_filter,
+            action_receipts=action_receipts,
         )
         self.emit_manifest()
         return {
@@ -201,6 +217,43 @@ def read_frames(runtime_dir):
             continue
     frames.sort(key=lambda f: f[0])
     return frames
+
+
+def _frame_data_type_value(header):
+    value = getattr(header, "data_type", 0)
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        name = str(value).split(".")[-1].lower()
+        return 0 if name == "raw" else str(value)
+
+
+def read_action_frame_index(runtime_dir):
+    """Action frame identity index keyed by (frame_uid, msg_type, gen_time)."""
+    location = _location(runtime_dir)
+    index = {}
+    for msg_type in MSG_TYPE_NAMES:
+        try:
+            for header, frame_payload in yjj.assemble(location, 0).read_bytes(msg_type):
+                data = bytes(frame_payload)
+                index[(header.frame_uid, header.msg_type, header.gen_time)] = {
+                    "frame_uid": header.frame_uid,
+                    "trigger_frame_uid": header.trigger_frame_uid,
+                    "stream_id": header.stream_id,
+                    "gen_time": header.gen_time,
+                    "trigger_time": header.trigger_time,
+                    "msg_type": header.msg_type,
+                    "source": header.source,
+                    "initial_source": header.initial_source,
+                    "dest": header.dest,
+                    "data_length": len(data),
+                    "data_type": _frame_data_type_value(header),
+                    "journal_payload_hash": payloads.payload_hash(data),
+                    "_payload": data,
+                }
+        except (RuntimeError, ValueError, FileNotFoundError):
+            continue
+    return index
 
 
 def load(runtime_dir):
@@ -316,7 +369,11 @@ def status(runtime_dir):
 
 
 def fsck(runtime_dir):
-    return payloads.fsck_import(store_dir(runtime_dir), load(runtime_dir))
+    return payloads.fsck_import(
+        store_dir(runtime_dir),
+        load(runtime_dir),
+        action_frames=read_action_frame_index(runtime_dir),
+    )
 
 
 def export_jsonl(

--- a/framework/core/tests/python/test_atlas_storage.py
+++ b/framework/core/tests/python/test_atlas_storage.py
@@ -50,6 +50,46 @@ def _atlas_fixture(root):
     )
 
 
+def _action_receipts(source_records):
+    receipts = {}
+    for index, record in enumerate(
+        payloads.enrich_source_records(source_records), start=1
+    ):
+        journal_payload = f"journal-payload-{index}".encode("utf-8")
+        receipts[(record["kind"], record["source_id"])] = {
+            "frame_uid": index,
+            "trigger_frame_uid": index - 1,
+            "stream_id": 0,
+            "gen_time": 1000 + index,
+            "trigger_time": 0,
+            "msg_type": 9000 + index,
+            "source": 101,
+            "initial_source": 101,
+            "dest": 0,
+            "data_length": len(journal_payload),
+            "data_type": 0,
+            "journal_payload_hash": payloads.payload_hash(journal_payload),
+        }
+    return receipts
+
+
+def _action_frames_from_manifest(manifest):
+    frames = {}
+    for entry in manifest["entries"]:
+        if "action" not in entry:
+            continue
+        journal = dict(entry["action"]["journal"])
+        journal["_payload"] = f"journal-payload-{journal['frame_uid']}".encode("utf-8")
+        frames[
+            (
+                entry["action"]["journal"]["frame_uid"],
+                entry["action"]["journal"]["msg_type"],
+                entry["action"]["journal"]["gen_time"],
+            )
+        ] = journal
+    return frames
+
+
 def test_atlas_source_records_keep_full_payloads(tmp_path):
     repo = tmp_path / "atlas"
     _atlas_fixture(repo)
@@ -133,7 +173,7 @@ def test_payload_manifest_fsck_export_and_verify(tmp_path):
         importer.read_control_plane_with_sources(str(repo))
     )
 
-    payloads.write_import_payloads(
+    manifest = payloads.write_import_payloads(
         store,
         import_id="imp-test",
         repo_root=str(repo),
@@ -146,15 +186,19 @@ def test_payload_manifest_fsck_export_and_verify(tmp_path):
         },
         storage_source_id="atlas-local",
         range_filter={"since": "2026-07-01T00:00:00Z"},
+        action_receipts=_action_receipts(source_records),
     )
 
-    report = payloads.fsck_import(store)
+    report = payloads.fsck_import(
+        store, action_frames=_action_frames_from_manifest(manifest)
+    )
     assert report["ok"]
     assert report["checked"] == {
         "payloads": 3,
         "missions": 1,
         "goals": 1,
         "markers": 1,
+        "actions": 3,
     }
 
     records = payloads.export_records(store)
@@ -164,6 +208,16 @@ def test_payload_manifest_fsck_export_and_verify(tmp_path):
     assert goal["repo_head"] == "abc123"
     assert goal["storage_source_id"] == "atlas-local"
     assert goal["source_time"] == "2026-07-08T01:00:00Z"
+    assert goal["action"]["schema"] == payloads.ACTION_ENVELOPE_SCHEMA
+    assert goal["action"]["action_type"] == "atlas.goal.snapshot"
+    assert goal["action"]["payload"]["hash"] == goal["payload_hash"]
+    assert goal["action"]["journal"]["frame_uid"] > 0
+
+    missing_frame = payloads.fsck_import(store, action_frames={})
+    assert not missing_frame["ok"]
+    assert any(
+        error["code"] == "action_frame_missing" for error in missing_frame["errors"]
+    )
 
     verify = payloads.verify_against_source(store, source_records)
     assert verify == {

--- a/tests/fixtures/atlas-demo-import/check_import.py
+++ b/tests/fixtures/atlas-demo-import/check_import.py
@@ -139,5 +139,51 @@ if os.path.exists(manifest_path):
                 hashlib.sha256(blob).hexdigest() == schema_hash,
             )
 
+# ── payload manifest: every imported source record is an action envelope ──
+payload_manifest_path = os.path.join(store_dir, "imports", "latest.json")
+check("payload manifest exists", os.path.exists(payload_manifest_path))
+if os.path.exists(payload_manifest_path):
+    with open(payload_manifest_path) as f:
+        payload_manifest = json.load(f)
+    entries = payload_manifest.get("entries", [])
+    action_entries = [
+        entry for entry in entries if isinstance(entry.get("action"), dict)
+    ]
+    check(
+        "all source records have action envelopes", len(action_entries) == len(entries)
+    )
+
+    frame_index = store.read_action_frame_index(runtime_dir)
+    check("journal action frame index is populated", len(frame_index) >= len(entries))
+    for entry in action_entries:
+        action = entry["action"]
+        journal = action.get("journal", {})
+        frame = frame_index.get(
+            (
+                journal.get("frame_uid"),
+                journal.get("msg_type"),
+                journal.get("gen_time"),
+            )
+        )
+        check(
+            f"action frame exists for {entry.get('kind')}:{entry.get('source_id')}",
+            frame is not None,
+        )
+        if frame is not None:
+            payload = frame.get("_payload", b"")
+            payload = payload[: journal.get("data_length", len(payload))]
+            check(
+                f"action frame hash matches {entry.get('kind')}:{entry.get('source_id')}",
+                hashlib.sha256(payload).hexdigest()
+                == journal.get("journal_payload_hash"),
+            )
+        check(
+            f"action payload hash matches {entry.get('kind')}:{entry.get('source_id')}",
+            action.get("payload", {}).get("hash") == entry.get("payload_hash"),
+        )
+
+    fsck = store.fsck(runtime_dir)
+    check("atlas store fsck passes", fsck.get("ok"), json.dumps(fsck.get("errors")))
+
 print(f"[atlas-demo-import] {len(failures)} failure(s)")
 sys.exit(1 if failures else 0)


### PR DESCRIPTION
## Summary
- route Atlas import snapshot writes through the C++ action_recorder binding
- add action envelopes to Atlas import manifests and fsck journal-frame validation
- add C++ action_recorder readback smoke plus Atlas import/export/GUI fixture coverage

## Verification
- PYTHONPATH=src/python uv run --frozen pytest tests/python/test_atlas_storage.py -q
- node tests/fixtures/atlas-demo-import/run.mjs
- cmake -S . -B build -DKUNGFU_WITH_SLICES=ON && cmake --build build --config Release --target fact_ledger_action_recorder --parallel 8
- ./framework/core/build/Release/fact_ledger_action_recorder /tmp/kf-action-recorder.A19XMO 5
- ./kungfu-code build
- node tests/fixtures/kfx-demo-work-dashboard-atlas-live/run.mjs
- ./kungfu-code check