### PR TITLE
docs: manage README badges with buildchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,17 @@
 # Kungfu
 
-[![Buildchain Validate](https://github.com/kungfu-systems/kungfu/actions/workflows/buildchain-validate.yml/badge.svg?branch=dev%2Fv4%2Fv4.0)](https://github.com/kungfu-systems/kungfu/actions/workflows/buildchain-validate.yml)
+<!-- buildchain:badges:start -->
+[![KFD-1: declared](https://buildchain.libkungfu.dev/badges/v1/kfd-1/declared.svg)](https://github.com/kungfu-systems/kungfu/releases/latest/download/buildchain.release.json)
+[![KFD-2: declared](https://buildchain.libkungfu.dev/badges/v1/kfd-2/declared.svg)](https://github.com/kungfu-systems/kungfu/releases/latest/download/buildchain.release.json)
+[![KFD-3: declared](https://buildchain.libkungfu.dev/badges/v1/kfd-3/declared.svg)](https://github.com/kungfu-systems/kungfu/releases/latest/download/buildchain.release.json)
+[![Buildchain Release Passport: declared](https://buildchain.libkungfu.dev/badges/v1/buildchain-release-passport/declared.svg)](https://github.com/kungfu-systems/kungfu/releases/latest/download/buildchain.release.json)
+[![License: Apache-2.0](https://img.shields.io/badge/license-Apache--2.0-0969da.svg)](https://github.com/kungfu-systems/kungfu/blob/HEAD/LICENSE)
+[![Platform: macOS | Linux | Windows](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows-6e7781.svg)](https://github.com/kungfu-systems/kungfu/releases/latest/download/buildchain.release.json)
+[![Buildchain Validate](https://github.com/kungfu-systems/kungfu/actions/workflows/buildchain-validate.yml/badge.svg)](https://github.com/kungfu-systems/kungfu/actions/workflows/buildchain-validate.yml)
 [![DCO](https://github.com/kungfu-systems/kungfu/actions/workflows/dco.yml/badge.svg)](https://github.com/kungfu-systems/kungfu/actions/workflows/dco.yml)
-[![License: Apache-2.0](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
+<!-- buildchain:badges:end -->
+
 ![Status: Coming soon](https://img.shields.io/badge/status-coming%20soon-orange.svg)
-![Platforms: macOS | Linux | Windows](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows-lightgrey.svg)
 
 Kungfu is the open-source core behind the Kungfu product direction: a
 local-first, journal-first runtime for recording facts, replaying work, and

--- a/artifact/package.json
+++ b/artifact/package.json
@@ -48,6 +48,6 @@
     "url": "https://github.com/kungfu-systems/kungfu.git"
   },
   "devDependencies": {
-    "@kungfu-tech/buildchain": "2.8.8"
+    "@kungfu-tech/buildchain": "2.8.17"
   }
 }

--- a/buildchain.toml
+++ b/buildchain.toml
@@ -33,3 +33,12 @@ command = "node scripts/buildchain-run-kungfu-code.mjs verify"
 
 [lifecycle.publish]
 command = "node scripts/buildchain-custom-publish-evidence.mjs"
+
+[badges]
+release_passport = "https://github.com/kungfu-systems/kungfu/releases/latest/download/buildchain.release.json"
+kfd_standards = "developer/sdk/node_modules/@kungfu-tech/kfd/standards.json"
+kfd_1 = "declared"
+kfd_2 = "declared"
+kfd_3 = "declared"
+platforms = ["macOS", "Linux", "Windows"]
+workflows = ["buildchain-validate.yml", "dco.yml"]

--- a/developer/sdk/package.json
+++ b/developer/sdk/package.json
@@ -25,7 +25,7 @@
     "build": "node --check src/sdk.js && node --test tests/*.test.mjs"
   },
   "dependencies": {
-    "@kungfu-tech/buildchain": "2.8.8",
+    "@kungfu-tech/buildchain": "2.8.17",
     "@kungfu-tech/core": "workspace:*",
     "@kungfu-tech/gui": "workspace:*",
     "@kungfu-tech/kfd": "1.0.0-alpha.16",

--- a/framework/contract/kungfu-agent-first-canonical-policy.json
+++ b/framework/contract/kungfu-agent-first-canonical-policy.json
@@ -31,7 +31,7 @@
     "buildchain": {
       "package": {
         "name": "@kungfu-tech/buildchain",
-        "version": "2.8.8"
+        "version": "2.8.17"
       },
       "formatting": {
         "name": "buildchain-release-evidence-json-v1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,14 +93,14 @@ importers:
         version: link:../framework/tui
     devDependencies:
       '@kungfu-tech/buildchain':
-        specifier: 2.8.8
-        version: 2.8.8
+        specifier: 2.8.17
+        version: 2.8.17
 
   developer/sdk:
     dependencies:
       '@kungfu-tech/buildchain':
-        specifier: 2.8.8
-        version: 2.8.8
+        specifier: 2.8.17
+        version: 2.8.17
       '@kungfu-tech/core':
         specifier: workspace:*
         version: link:../../framework/core
@@ -1279,8 +1279,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@kungfu-tech/buildchain@2.8.8':
-    resolution: {integrity: sha512-YI2/6r43DMG6tgQXrsIRcX0bU7w4epqTVmfX6a7Tqc7dstynqFBLK0PJHDZgeFBvRqZ3y/z4rbz82lqxb/iQBg==}
+  '@kungfu-tech/buildchain@2.8.17':
+    resolution: {integrity: sha512-I2OpuVDKgexWONSV3k1nLWPvR3cR80zBvYC32USBX2sEiHcwc+JqnSCSC3Jqu2RGyVdLBz4Njrs+qNpmbxJocA==}
     engines: {node: '>=22.14.0'}
     hasBin: true
 
@@ -5327,7 +5327,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@kungfu-tech/buildchain@2.8.8':
+  '@kungfu-tech/buildchain@2.8.17':
     dependencies:
       '@kungfu-tech/kfd': 1.0.0-alpha.16
       smol-toml: 1.7.0


### PR DESCRIPTION
## Summary
- replace the hand-maintained README badge set with a Buildchain-managed badge block
- configure Buildchain badge facts for KFD, release passport, license, platform and workflow badges
- update Kungfu to @kungfu-tech/buildchain 2.8.17 and refresh the generated SDK canonical policy

## Validation
- ./kungfu-code check
- buildchain badges readme --cwd . --check --json
- buildchain validate --cwd . --require-version-state --require-lifecycle-stages install,build,verify --json
