### PR TITLE
feat(atlas): reset v4 msg type envelope

### DIFF
--- a/docs/event-model.md
+++ b/docs/event-model.md
@@ -47,7 +47,7 @@ fields (defined in
 | `header_length` | `uint32` | Header size. |
 | `gen_time` | `int64` | When the frame was generated (nanoseconds). |
 | `trigger_time` | `int64` | Trigger time, for latency statistics. |
-| `msg_type` | `int32` | Message type of the payload. |
+| `msg_type` | `int32` | Wire-level carrier type. In v4 business facts normally use the generic action-envelope carrier and put semantics in `action_type` / `schema_ref`. |
 | `source` | `uint32` | Source of the frame. |
 | `dest` | `uint32` | Destination of the frame. |
 | `data_type` | enum | Payload encoding (raw struct vs json). |
@@ -56,9 +56,12 @@ fields (defined in
 | `trigger_frame_uid` | `uint64` | The reader's current frame when this frame was generated. |
 | `stream_id` | `uint64` | Stream identifier. |
 
-The payload's type is identified by `msg_type` and laid out per the `longfist`
-schema — the same bytes are read by C++, Python, and Node without parsing (see
-[`contracts.md`](contracts.md)).
+Closed longfist/runtime frames may still identify their payload layout directly
+through `msg_type`. New v4 business facts should use the generic action
+envelope carrier: the journal header keeps `msg_type` for filtering and fsck,
+while the payload names the domain action through `action_type` and
+`schema_ref`. The same bytes are read by C++, Python, and Node without inventing
+per-language causality logic (see [`contracts.md`](contracts.md)).
 
 ## Routing: source and dest
 

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -19,7 +19,8 @@ the rule. For what each surface guarantees and how to verify it, see
 | `config-contract` | Kungfu global config contract: schema, defaults, resolution rules, resolved output metadata, and packaged contract hash | integration + cross-time | [`config.md`](config.md), [`../framework/config/kungfu-config.contract.json`](../framework/config/kungfu-config.contract.json) |
 | `kungfu-cli` | kungfu CLI surface (canonical `kungfu` command; commands, journal subcommand output conventions) | integration | [`debugging.md`](debugging.md) |
 | `journal-replayability` | cross-version cold-path decode of recorded journals | cross-time | [ADR-0008](../framework/core/docs/adr/ADR-0008-longfist-schema-evolution-and-minor-maintenance.md) |
-| `rewind-event-schema` | Rewind capture event model (open-layer msg_types 30001-30099, `rewind_events.fbs`; trace bundles bind and outlive runs) | integration + cross-time | [`msg-type-ranges.md`](../framework/core/docs/msg-type-ranges.md), [`kungfu/rewind/README.md`](../framework/core/src/python/kungfu/rewind/README.md) |
+| `v4-action-envelope` | Generic journal carrier for v4 runtime facts (`msg_type=1000`, semantics in `action_type` / `schema_ref`) | integration + cross-time | [`msg-type-ranges.md`](../framework/core/docs/msg-type-ranges.md), [ADR-0022](../framework/core/docs/adr/ADR-0022-core-action-recording-surface.md) |
+| `rewind-event-schema` | Rewind capture event model (pre-envelope open-layer msg_types 30001-30099, `rewind_events.fbs`; trace bundles bind and outlive runs) | integration + cross-time | [`msg-type-ranges.md`](../framework/core/docs/msg-type-ranges.md), [`kungfu/rewind/README.md`](../framework/core/src/python/kungfu/rewind/README.md) |
 
 A surface is registered when consumers bind to it at integration time without
 runtime negotiation, or when its outputs remain depended on after the run.
@@ -33,6 +34,7 @@ registered surface was touched.
 
 | Date | Action | Line | Faces | Class | Rationale | PR |
 |---|---|---|---|---|---|---|
+| 2026-07-08 | register | — | v4-action-envelope | behavioral | Reset v4 business msg_type allocation: new runtime facts use `msg_type=1000` as the action-envelope carrier and put business semantics in `action_type` / `schema_ref`; Atlas import migrates off 30201-30205. Pre-release, no compatibility promise for the pre-envelope Atlas journal profile | — |
 | 2026-07-06 | update | — | config-contract, kfx-contract, skill-contract | additive | Add a shared KFD-1 contract registry/runtime: config, kfx, and skill contracts are registry-addressed, copied into frozen artifacts by one tool, verified by one artifact hash gate, and inspectable through `kungfu contract`. Pre-release, no line open | — |
 | 2026-07-06 | update | — | kfx-contract | additive | Weld the KFX manifest/config mechanism to a single machine-readable contract: package manifest schema, first-party manifest schema, Python/Node validation, frozen artifact hash evidence, and CLI inspection. Pre-release, no line open | — |
 | 2026-07-06 | register | — | config-contract | additive | Register the Kungfu config contract as a KFD-1 welded surface: one source for schema/defaults/resolution rules, with resolved output and frozen artifact hash evidence. Pre-release, no line open | — |

--- a/framework/core/docs/msg-type-ranges.md
+++ b/framework/core/docs/msg-type-ranges.md
@@ -1,33 +1,71 @@
-# Message Type Ranges
+---
+status: draft
+period: 2026-07-08
+theme: kungfu-v4-msg-type-registry
+doc_type: design
+source_level: local-files
+confidence: high
+sensitivity: internal
+evidence_grade: B
+review_state: active
+last_reviewed: 2026-07-08
+ai_provenance:
+  generated_by: Codex
+  product: Codex CLI
+  generated_at: 2026-07-08T10:55:00+08:00
+  visible_context: local Kungfu source tree and current user consensus
+  invisible_context: exact model build and hidden system implementation are unknown
+---
 
-`msg_type` is a wire-level welded surface: the numbers travel inside journal
-frames across processes, languages and years, so allocation needs a single
-source of truth. This file is that source. Adding a type means taking a number
-from the right range here — duplicate registrations are also rejected at
-runtime by the schema registry, but the range discipline is what keeps
-independent lines from colliding in the first place.
+# Message Type Registry
 
-| Range | Owner | Notes |
+`msg_type` remains a wire-level journal header field. It must stay positive for
+published frames and it is still useful for low-level filtering, frame
+validation, and compatibility with the yijinjing reader APIs.
+
+v4 resets the business allocation rule: **new product/runtime facts do not get
+one `msg_type` per business event.** They use a small carrier set at the journal
+layer, and put domain semantics in the payload envelope:
+
+```json
+{
+  "schema": "kungfu.action-envelope/v1",
+  "action_type": "atlas.goal.snapshot",
+  "schema_ref": {"id": "kungfu.atlas.GoalSnapshot", "version": 1}
+}
+```
+
+## v4 Allocations
+
+| Number | Owner | Meaning |
 | --- | --- | --- |
-| `0 – 19999` | longfist closed set | Kernel and trading type registry (`kungfu/longfist`). Currently occupies `0 – 799` and `10051 – 10751`; the whole range is reserved for it. |
-| `20000 – 29999` | capability slices | Demo/probe types used by `slices/*` (see `slices/README.md`). Never consumed by products. |
-| `30000` and above | open layer | Application types registered at runtime with a self-describing schema (`.bfbs`); governed by the schema registry and per-run manifest bindings, not by this repository's compiled registry. |
+| `0` | yijinjing/longfist core | Internal `frame_header`; not a user event. |
+| `1` | yijinjing/longfist core | Internal `page_header`; not a user event. |
+| `1000` | Kungfu v4 action runtime | `kungfu.action-envelope/v1`; business semantics come from `action_type` and `schema_ref`, not from `msg_type`. |
+| `10051 – 10751` | yijinjing runtime service markers | Existing internal service/control tags such as `PageEnd`, `Time`, `Ping`, `Pong`, cache and socket markers. |
 
-Within the capability-slice range:
+Rules:
 
-| Numbers | Slice |
-| --- | --- |
-| `20001` | `slices/embedding` |
-| `20011 – 20013` | `slices/fact-ledger` |
-| `20021 – 20022` | `slices/schema-registry` |
+- New v4 business features should use `1000` unless they can prove a separate
+  carrier type is needed at the journal adapter layer.
+- KFX and first-party features must not allocate a new raw `msg_type` merely to
+  name a business action. Add an `action_type` / schema binding instead.
+- `msg_type` may appear in fsck/export/debug output as `journal.msg_type`, but
+  GUI/KFX/domain APIs should treat it as implementation metadata.
 
-First-party allocations within the open layer (informative — the binding
-authority remains each run's manifest, but first-party products reserve their
-numbers here to avoid colliding with each other):
+## Legacy / Migration Context
 
-| Numbers | Product | Schema |
+The repository still contains compiled longfist trading tags and earlier
+capability-slice demos. They are historical/runtime compatibility material, not
+the v4 business allocation model.
+
+| Legacy range | Status | Notes |
 | --- | --- | --- |
-| `30001 – 30099` | Kungfu Rewind capture events | `src/python/kungfu/rewind/rewind_events.fbs` (30001 RunBegin, 30002 RunEnd, 30003 ModelRequest, 30004 ModelResponse, 30005 ToolCall, 30006 ToolResult, 30007 RetryMarker, 30008 CostSnapshot, 30009 ApprovalDecision) |
-| `30101 – 30199` | Kungfu work items (default work profile) | `src/python/kungfu/work/work_events.fbs` (30101 WorkItemCreated, 30102 WorkStatusChanged, 30103 NextActionSet, 30104 CheckpointRecorded, 30105 DecisionRecorded, 30106 ValidationRecorded, 30107 ArtifactRecorded, 30108 RunLinked) |
-| `30201 – 30299` | Kungfu Atlas import profile (read-only control-plane snapshots) | `src/python/kungfu/atlas/atlas_events.fbs` (30201 ImportBegin, 30202 MissionSnapshot, 30203 GoalSnapshot, 30204 MarkerSnapshot, 30205 ImportEnd) |
-| `40000 – 49999` | Third-party kfx dynamic event schemas | No first-party `.fbs` — a kfx author compiles its own schema at runtime (`kungfu schema compile` / `pykungfu.yijinjing.compile_schema`) and registers the `.bfbs` into a run's manifest under a number in this band. The `sandboxed` trust tier is *constrained* to this band so an untrusted kfx cannot claim a first-party number (e.g. masquerade as `30005 ToolCall`); the `trusted` (node-integrated) tier may use any open-layer number but should still avoid the first-party sub-ranges above. |
+| `101 – 799` | legacy compiled longfist/trading tags | Kept while code exists, not extended for v4 agent facts. |
+| `20000 – 29999` | legacy capability-slice demos | May remain in isolated demos until each slice migrates to the v4 action envelope. |
+| `30000` and above | pre-envelope open layer | Earlier rewind/work/atlas profiles allocated one number per event table. New v4 code should not copy that pattern. |
+
+The Atlas import profile was migrated first: its former `30201 – 30205` event
+numbers are replaced by `msg_type = 1000` plus `action_type` values
+`atlas.import.begin`, `atlas.mission.snapshot`, `atlas.goal.snapshot`,
+`atlas.marker.snapshot`, and `atlas.import.end`.

--- a/framework/core/slices/fact-ledger/README.md
+++ b/framework/core/slices/fact-ledger/README.md
@@ -112,8 +112,10 @@ link back correctly, so CI can gate on it.
 - **No in-frame content hash yet.** Content commitment lives at the manifest
   layer (checksums over exported payloads), not as a per-frame `payload_hash` in
   the spine (the external hash-blob store of the full design is future work).
-- **`msg_type` is an opaque int.** No self-describing schema registry is bundled;
-  decoding still assumes the reader knows the meaning of a type.
+- **`msg_type` is a carrier int.** The v4 action-recorder smoke uses the generic
+  action-envelope carrier (`1000`); domain semantics are carried by the JSON
+  payload's `action_type` / schema fields. No full self-describing schema
+  registry is bundled in this slice yet.
 - **`frame_uid` is stable within a bundle and across re-reads, but not
   reproducible across separate write runs** (per-writer nano-hash low bits;
   ADR-0010 8.2.3 determinism not adopted).

--- a/framework/core/slices/fact-ledger/action_recorder.cpp
+++ b/framework/core/slices/fact-ledger/action_recorder.cpp
@@ -22,12 +22,13 @@ namespace longfist = kungfu::longfist;
 using kungfu::slices::sha256;
 
 namespace {
-constexpr int32_t MSG_ACTION = 20031;
+constexpr int32_t MSG_ACTION_ENVELOPE = 1000;
 constexpr uint64_t STREAM_ID = 7001;
 
 std::vector<uint8_t> bytes_for_step(std::size_t step) {
   nlohmann::json payload = {
       {"schema", "kungfu.fact-ledger-action/v1"},
+      {"msg_schema", "kungfu.action-envelope/v1"},
       {"step", step},
       {"action_type", "slice.fact.record"},
   };
@@ -71,14 +72,14 @@ int main(int argc, char **argv) {
   for (std::size_t i = 0; i < n; ++i) {
     auto payload = bytes_for_step(i);
     payloads.push_back(payload);
-    receipts.push_back(recorder.record_bytes(MSG_ACTION, payload));
+    receipts.push_back(recorder.record_bytes(MSG_ACTION_ENVELOPE, payload));
   }
 
   auto locator = std::make_shared<data::locator>(root);
   auto location =
       data::location::make_shared(longfist::enums::mode::LIVE, longfist::enums::category::SYSTEM, group, name, locator);
   journal::assemble reader(location, data::location::PUBLIC, longfist::enums::AssembleMode::Channel, 0);
-  auto frames = reader.read_bytes(MSG_ACTION);
+  auto frames = reader.read_bytes(MSG_ACTION_ENVELOPE);
   if (frames.size() != receipts.size()) {
     fail("frame count mismatch");
     return 1;

--- a/framework/core/src/python/kungfu/atlas/__init__.py
+++ b/framework/core/src/python/kungfu/atlas/__init__.py
@@ -3,12 +3,8 @@
 # kungfu.atlas — the Atlas control-plane import profile (read-only slice).
 #
 # Layout:
-#   atlas_events.fbs   the event contract (welded surface atlas-import-schema)
-#   atlas_events.bfbs  reflection schema, checked in; regenerate with
-#                      `flatc -b --schema` whenever the .fbs changes
-#   fb/                flatc --python generated accessors/builders (do not edit)
-#   events.py          serializers: python values -> FlatBuffers event bytes
 #   importer.py        read-only reader over an Atlas-style control-plane repo
+#   payloads.py        blob payload store + action envelope helpers
 #   store.py           the import store: journal appends and the projection
 #                      folding the latest completed import batch
 #
@@ -16,21 +12,31 @@
 # truth. This profile imports snapshots into a local journal so Kungfu can
 # display and query them; it never writes back to the source repository.
 
-# Open-layer msg_type allocation — docs/msg-type-ranges.md, 30201-30299.
-MSG_IMPORT_BEGIN = 30201
-MSG_MISSION_SNAPSHOT = 30202
-MSG_GOAL_SNAPSHOT = 30203
-MSG_MARKER_SNAPSHOT = 30204
-MSG_IMPORT_END = 30205
+# v4 msg_type allocation — docs/msg-type-ranges.md.
+#
+# The journal still needs a positive wire-level msg_type, but Atlas business
+# semantics live in the JSON action envelope's action_type/schema metadata.
+# Do not allocate one msg_type per Atlas business event.
+MSG_ACTION_ENVELOPE = 1000
+
+ACTION_IMPORT_BEGIN = "atlas.import.begin"
+ACTION_MISSION_SNAPSHOT = "atlas.mission.snapshot"
+ACTION_GOAL_SNAPSHOT = "atlas.goal.snapshot"
+ACTION_MARKER_SNAPSHOT = "atlas.marker.snapshot"
+ACTION_IMPORT_END = "atlas.import.end"
 
 # Event-model version marker carried in ImportBegin (belt and braces beside
 # the store manifest's schema binding, which remains decode authority).
 SCHEMA_VERSION = 1
 
 MSG_TYPE_NAMES = {
-    MSG_IMPORT_BEGIN: "ImportBegin",
-    MSG_MISSION_SNAPSHOT: "MissionSnapshot",
-    MSG_GOAL_SNAPSHOT: "GoalSnapshot",
-    MSG_MARKER_SNAPSHOT: "MarkerSnapshot",
-    MSG_IMPORT_END: "ImportEnd",
+    MSG_ACTION_ENVELOPE: "ActionEnvelope",
+}
+
+ACTION_TYPE_NAMES = {
+    ACTION_IMPORT_BEGIN: "ImportBegin",
+    ACTION_MISSION_SNAPSHOT: "MissionSnapshot",
+    ACTION_GOAL_SNAPSHOT: "GoalSnapshot",
+    ACTION_MARKER_SNAPSHOT: "MarkerSnapshot",
+    ACTION_IMPORT_END: "ImportEnd",
 }

--- a/framework/core/src/python/kungfu/atlas/atlas_events.fbs
+++ b/framework/core/src/python/kungfu/atlas/atlas_events.fbs
@@ -1,13 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// Atlas control-plane import events — the open-layer event schema for
-// `kungfu atlas import` (the Atlas profile's read-only first slice).
+// Legacy Atlas control-plane import events.
 //
-// Layering: these are application types (msg_type 30201-30299, see
-// docs/msg-type-ranges.md), NOT longfist kernel types. They ride the journal
-// as self-describing open-layer events, pinned by the import store's
-// content-addressed .bfbs manifest — the same mechanism the Rewind bundle
-// and the work store use.
+// v4 no longer writes one journal msg_type per Atlas business event. The active
+// import path writes `kungfu.action-envelope/v1` JSON frames under
+// `MSG_ACTION_ENVELOPE` and uses `action_type` / `schema_ref` for business
+// semantics. This FlatBuffers schema is retained only as pre-envelope history
+// while old generated files remain in-tree.
 //
 // Fact model: one import = one snapshot batch sharing an import_id, bracketed
 // by ImportBegin/ImportEnd. Each mission / goal / worktree-marker card in the
@@ -26,7 +25,7 @@
 
 namespace kungfu.atlas.fb;
 
-// msg_type 30201. Opens an import batch.
+// Legacy: opened an import batch.
 table ImportBegin {
   import_id:string;
   repo_root:string;
@@ -34,7 +33,7 @@ table ImportBegin {
   schema_version:uint;
 }
 
-// msg_type 30202. One mission registry card.
+// Legacy: one mission registry card.
 table MissionSnapshot {
   import_id:string;
   mission_id:string;
@@ -46,7 +45,7 @@ table MissionSnapshot {
   next_action:string;
 }
 
-// msg_type 30203. One goal registry card.
+// Legacy: one goal registry card.
 table GoalSnapshot {
   import_id:string;
   goal_id:string;
@@ -68,7 +67,7 @@ table GoalSnapshot {
   archived:bool;
 }
 
-// msg_type 30204. One worktree-status (ready/stage/merged) marker.
+// Legacy: one worktree-status (ready/stage/merged) marker.
 table MarkerSnapshot {
   import_id:string;
   branch:string;
@@ -82,7 +81,7 @@ table MarkerSnapshot {
   marker_path:string;
 }
 
-// msg_type 30205. Closes an import batch with counts; warnings counts files
+// Legacy: closes an import batch with counts; warnings counts files
 // that were unreadable or shaped unexpectedly (diagnostic, never fatal).
 table ImportEnd {
   import_id:string;

--- a/framework/core/src/python/kungfu/atlas/payloads.py
+++ b/framework/core/src/python/kungfu/atlas/payloads.py
@@ -5,9 +5,29 @@ import json
 from pathlib import Path
 from typing import Any
 
+from kungfu.atlas import (
+    ACTION_GOAL_SNAPSHOT,
+    ACTION_MARKER_SNAPSHOT,
+    ACTION_MISSION_SNAPSHOT,
+)
+
 CONTENT_TYPE_JSON = "application/json"
 PAYLOAD_STATE_PRESENT = "present"
 ACTION_ENVELOPE_SCHEMA = "kungfu.action-envelope/v1"
+
+ACTION_SCHEMA_REFS = {
+    "atlas.import.begin": {"id": "kungfu.atlas.ImportBegin", "version": 1},
+    ACTION_MISSION_SNAPSHOT: {"id": "kungfu.atlas.MissionSnapshot", "version": 1},
+    ACTION_GOAL_SNAPSHOT: {"id": "kungfu.atlas.GoalSnapshot", "version": 1},
+    ACTION_MARKER_SNAPSHOT: {"id": "kungfu.atlas.MarkerSnapshot", "version": 1},
+    "atlas.import.end": {"id": "kungfu.atlas.ImportEnd", "version": 1},
+}
+
+KIND_ACTION_TYPES = {
+    "mission": ACTION_MISSION_SNAPSHOT,
+    "goal": ACTION_GOAL_SNAPSHOT,
+    "marker": ACTION_MARKER_SNAPSHOT,
+}
 
 
 def canonical_json_bytes(value: Any) -> bytes:
@@ -62,8 +82,49 @@ def enrich_source_records(source_records: list[dict[str, Any]]) -> list[dict[str
     return enriched
 
 
-def _action_type(kind: str) -> str:
-    return f"atlas.{kind}.snapshot"
+def action_type_for_kind(kind: str) -> str:
+    return KIND_ACTION_TYPES.get(kind, f"atlas.{kind}.snapshot")
+
+
+def _schema_ref(action_type: str) -> dict[str, Any]:
+    return dict(
+        ACTION_SCHEMA_REFS.get(
+            action_type,
+            {"id": action_type, "version": 1},
+        )
+    )
+
+
+def build_action_envelope(
+    *,
+    import_id: str,
+    storage_source_id: str,
+    source_type: str,
+    action_type: str,
+    source: dict[str, Any] | None = None,
+    payload: dict[str, Any] | None = None,
+    batch: dict[str, Any] | None = None,
+    journal: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    envelope: dict[str, Any] = {
+        "schema": ACTION_ENVELOPE_SCHEMA,
+        "schema_ref": _schema_ref(action_type),
+        "session": {"import_id": import_id},
+        "actor": {
+            "storage_source_id": storage_source_id,
+            "source_type": source_type,
+        },
+        "action_type": action_type,
+    }
+    if source is not None:
+        envelope["source"] = source
+    if payload is not None:
+        envelope["payload"] = payload
+    if batch is not None:
+        envelope["batch"] = batch
+    if journal is not None:
+        envelope["journal"] = dict(journal)
+    return envelope
 
 
 def _action_envelope(
@@ -75,30 +136,27 @@ def _action_envelope(
     receipt: dict[str, Any],
 ) -> dict[str, Any]:
     kind = str(entry.get("kind") or "")
-    return {
-        "schema": ACTION_ENVELOPE_SCHEMA,
-        "session": {"import_id": import_id},
-        "actor": {
-            "storage_source_id": storage_source_id,
-            "source_type": source_type,
-        },
-        "action_type": _action_type(kind),
-        "source": {
+    return build_action_envelope(
+        import_id=import_id,
+        storage_source_id=storage_source_id,
+        source_type=source_type,
+        action_type=action_type_for_kind(kind),
+        source={
             "kind": kind,
             "source_id": entry.get("source_id"),
             "source_path": entry.get("source_path"),
             "source_time": entry.get("source_time"),
             "schema_version": entry.get("schema_version"),
         },
-        "payload": {
+        payload={
             "content_type": entry.get("content_type", CONTENT_TYPE_JSON),
             "hash_algorithm": "sha256",
             "hash": entry.get("payload_hash"),
             "byte_len": entry.get("byte_len"),
             "state": entry.get("payload_state", PAYLOAD_STATE_PRESENT),
         },
-        "journal": dict(receipt),
-    }
+        journal=receipt,
+    )
 
 
 def _serialize_range(range_filter: dict[str, Any] | None) -> dict[str, Any] | None:
@@ -146,7 +204,12 @@ def write_import_payloads(
 ) -> dict[str, Any]:
     store_dir = Path(store_dir)
     entries = []
-    for record in enrich_source_records(source_records):
+    records = (
+        source_records
+        if all("payload_hash" in record for record in source_records)
+        else enrich_source_records(source_records)
+    )
+    for record in records:
         raw = canonical_json_bytes(record["payload"])
         path = payload_path(store_dir, record["payload_hash"])
         path.parent.mkdir(parents=True, exist_ok=True)
@@ -232,6 +295,17 @@ def _load_payload(
     return data, None
 
 
+def load_payload_descriptor(
+    store_dir: str | Path,
+    descriptor: dict[str, Any],
+) -> tuple[dict[str, Any] | None, str | None]:
+    entry = {
+        "payload_hash": descriptor.get("hash"),
+        "byte_len": descriptor.get("byte_len"),
+    }
+    return _load_payload(store_dir, entry)
+
+
 def _append_action_error(
     report: dict[str, Any],
     code: str,
@@ -287,9 +361,11 @@ def _check_action_frame(
     if action_frames is None:
         return
     frame_uid = journal.get("frame_uid")
-    frame = action_frames.get(
-        (frame_uid, journal.get("msg_type"), journal.get("gen_time"))
-    )
+    frame = action_frames.get((frame_uid, journal.get("gen_time")))
+    if frame is None:
+        frame = action_frames.get(
+            (frame_uid, journal.get("msg_type"), journal.get("gen_time"))
+        )
     if frame is None:
         _append_action_error(report, "action_frame_missing", entry, frame_uid=frame_uid)
         return
@@ -370,12 +446,12 @@ def _check_action(
             actual=action.get("schema"),
         )
     kind = str(entry.get("kind") or "")
-    if action.get("action_type") != _action_type(kind):
+    if action.get("action_type") != action_type_for_kind(kind):
         _append_action_error(
             report,
             "action_type_mismatch",
             entry,
-            expected=_action_type(kind),
+            expected=action_type_for_kind(kind),
             actual=action.get("action_type"),
         )
     _check_action_payload(report, entry, action)

--- a/framework/core/src/python/kungfu/atlas/store.py
+++ b/framework/core/src/python/kungfu/atlas/store.py
@@ -5,7 +5,6 @@
 # import. Same construction as the work store — standalone single writer,
 # content-addressed schema manifest, state lives only in the fold.
 
-import hashlib
 import json
 import os
 import uuid
@@ -13,22 +12,17 @@ import uuid
 import kungfu
 
 from kungfu.atlas import (
-    MSG_GOAL_SNAPSHOT,
-    MSG_IMPORT_BEGIN,
-    MSG_IMPORT_END,
-    MSG_MARKER_SNAPSHOT,
-    MSG_MISSION_SNAPSHOT,
+    ACTION_GOAL_SNAPSHOT,
+    ACTION_IMPORT_BEGIN,
+    ACTION_IMPORT_END,
+    ACTION_MARKER_SNAPSHOT,
+    ACTION_MISSION_SNAPSHOT,
+    MSG_ACTION_ENVELOPE,
     MSG_TYPE_NAMES,
     SCHEMA_VERSION,
-    events,
     importer,
     payloads,
 )
-from kungfu.atlas.fb.GoalSnapshot import GoalSnapshot
-from kungfu.atlas.fb.ImportBegin import ImportBegin
-from kungfu.atlas.fb.ImportEnd import ImportEnd
-from kungfu.atlas.fb.MarkerSnapshot import MarkerSnapshot
-from kungfu.atlas.fb.MissionSnapshot import MissionSnapshot
 
 lf = kungfu.__binding__.longfist
 yjj = kungfu.__binding__.yijinjing
@@ -36,8 +30,6 @@ yjj = kungfu.__binding__.yijinjing
 PUBLIC_DEST = 0
 ATLAS_GROUP = "atlas"
 ATLAS_NAME = "import"
-
-_BFBS_FILE = __import__("kungfu").schema_data_path(__file__, "atlas_events.bfbs")
 
 
 def _location(runtime_dir):
@@ -56,7 +48,15 @@ def store_dir(runtime_dir):
 
 
 def _text(value):
-    return value.decode() if value is not None else None
+    if value is None:
+        return None
+    text = value.decode() if isinstance(value, bytes) else str(value)
+    text = text.strip()
+    return text or None
+
+
+def _journal_payload(envelope):
+    return payloads.canonical_json_bytes(envelope)
 
 
 class ImportStore:
@@ -68,8 +68,9 @@ class ImportStore:
             runtime_dir, ATLAS_GROUP, ATLAS_NAME, PUBLIC_DEST, 0
         )
 
-    def _append(self, msg_type, data):
-        receipt = self.recorder.record_bytes(msg_type, data)
+    def _append_envelope(self, envelope):
+        data = _journal_payload(envelope)
+        receipt = self.recorder.record_json(MSG_ACTION_ENVELOPE, data.decode("utf-8"))
         return {
             "frame_uid": receipt.frame_uid,
             "trigger_frame_uid": receipt.trigger_frame_uid,
@@ -99,40 +100,72 @@ class ImportStore:
         missions, goals, markers, source_records, warnings = (
             importer.read_control_plane_with_sources(repo_root, window=range_filter)
         )
+        enriched_records = payloads.enrich_source_records(source_records)
         action_receipts = {}
-        self._append(
-            MSG_IMPORT_BEGIN,
-            events.import_begin(
-                import_id,
-                repo_root,
-                repo_head,
-                SCHEMA_VERSION,
-            ),
+        self._append_envelope(
+            payloads.build_action_envelope(
+                import_id=import_id,
+                storage_source_id=storage_source_id,
+                source_type="atlas",
+                action_type=ACTION_IMPORT_BEGIN,
+                batch={
+                    "repo_root": repo_root,
+                    "repo_head": repo_head,
+                    "schema_version": SCHEMA_VERSION,
+                },
+            )
         )
-        for card in missions:
-            action_receipts[("mission", card["mission_id"])] = self._append(
-                MSG_MISSION_SNAPSHOT, events.mission_snapshot(import_id, card)
+        for entry in enriched_records:
+            action_type = payloads.action_type_for_kind(str(entry.get("kind") or ""))
+            receipt = self._append_envelope(
+                payloads.build_action_envelope(
+                    import_id=import_id,
+                    storage_source_id=storage_source_id,
+                    source_type="atlas",
+                    action_type=action_type,
+                    source={
+                        "kind": entry.get("kind"),
+                        "source_id": entry.get("source_id"),
+                        "source_path": entry.get("source_path"),
+                        "source_time": entry.get("source_time"),
+                        "schema_version": entry.get("schema_version"),
+                    },
+                    payload={
+                        "content_type": entry.get(
+                            "content_type", payloads.CONTENT_TYPE_JSON
+                        ),
+                        "hash_algorithm": "sha256",
+                        "hash": entry.get("payload_hash"),
+                        "byte_len": entry.get("byte_len"),
+                        "state": entry.get(
+                            "payload_state", payloads.PAYLOAD_STATE_PRESENT
+                        ),
+                    },
+                )
             )
-        for card in goals:
-            action_receipts[("goal", card["goal_id"])] = self._append(
-                MSG_GOAL_SNAPSHOT, events.goal_snapshot(import_id, card)
+            action_receipts[
+                (str(entry.get("kind") or ""), str(entry.get("source_id") or ""))
+            ] = receipt
+        self._append_envelope(
+            payloads.build_action_envelope(
+                import_id=import_id,
+                storage_source_id=storage_source_id,
+                source_type="atlas",
+                action_type=ACTION_IMPORT_END,
+                batch={
+                    "missions": len(missions),
+                    "goals": len(goals),
+                    "markers": len(markers),
+                    "warnings": len(warnings),
+                },
             )
-        for card in markers:
-            action_receipts[("marker", card["branch"])] = self._append(
-                MSG_MARKER_SNAPSHOT, events.marker_snapshot(import_id, card)
-            )
-        self._append(
-            MSG_IMPORT_END,
-            events.import_end(
-                import_id, len(missions), len(goals), len(markers), len(warnings)
-            ),
         )
         payloads.write_import_payloads(
             self.store_dir(),
             import_id=import_id,
             repo_root=repo_root,
             repo_head=repo_head,
-            source_records=source_records,
+            source_records=enriched_records,
             counts={
                 "missions": len(missions),
                 "goals": len(goals),
@@ -163,17 +196,7 @@ class ImportStore:
         return store_dir(self.runtime_dir)
 
     def emit_manifest(self):
-        """Pin the store's schema bindings (content-addressed .bfbs + manifest)."""
-        with open(_BFBS_FILE, "rb") as f:
-            blob = f.read()
-        schema_hash = hashlib.sha256(blob).hexdigest()
-
-        schemas_dir = os.path.join(self.store_dir(), "schemas")
-        os.makedirs(schemas_dir, exist_ok=True)
-        blob_path = os.path.join(schemas_dir, schema_hash + ".bfbs")
-        if not os.path.exists(blob_path):
-            with open(blob_path, "wb") as f:
-                f.write(blob)
+        """Pin this store's v4 action-envelope binding."""
 
         manifest = {
             "spec_version": "0.1",
@@ -188,13 +211,15 @@ class ImportStore:
             "hash_algorithm": "sha256",
             "schema_bindings": {
                 str(msg_type): {
-                    "schema_kind": "flatbuffers",
+                    "schema_kind": "json",
                     "name": name,
-                    "schema_version": SCHEMA_VERSION,
-                    "schema_hash": schema_hash,
+                    "schema": payloads.ACTION_ENVELOPE_SCHEMA,
+                    "schema_version": 1,
                 }
                 for msg_type, name in MSG_TYPE_NAMES.items()
             },
+            "msg_type_epoch": "v4",
+            "semantic_dispatch": "action_type",
             "authority_boundary": "this store is a read-only projection of an "
             "external control-plane repository; that repository's files remain "
             "the source of truth",
@@ -205,16 +230,30 @@ class ImportStore:
         return manifest_path
 
 
+def _decode_action_envelope(data):
+    raw = bytes(data).rstrip(b"\0")
+    if not raw:
+        return None
+    try:
+        envelope = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return None
+    return envelope if isinstance(envelope, dict) else None
+
+
 def read_frames(runtime_dir):
-    """All import frames in gen_time order: (gen_time, msg_type, bytes)."""
+    """All import action frames in gen_time order: (gen_time, action_type, envelope)."""
     location = _location(runtime_dir)
     frames = []
-    for msg_type in MSG_TYPE_NAMES:
-        try:
-            for header, payload in yjj.assemble(location, 0).read_bytes(msg_type):
-                frames.append((header.gen_time, msg_type, bytes(payload)))
-        except (RuntimeError, ValueError, FileNotFoundError):
-            continue
+    try:
+        for header, frame_payload in yjj.assemble(location, 0).read_bytes(
+            MSG_ACTION_ENVELOPE
+        ):
+            envelope = _decode_action_envelope(frame_payload)
+            if envelope is not None:
+                frames.append((header.gen_time, envelope.get("action_type"), envelope))
+    except (RuntimeError, ValueError, FileNotFoundError):
+        pass
     frames.sort(key=lambda f: f[0])
     return frames
 
@@ -229,31 +268,82 @@ def _frame_data_type_value(header):
 
 
 def read_action_frame_index(runtime_dir):
-    """Action frame identity index keyed by (frame_uid, msg_type, gen_time)."""
+    """Action frame identity index keyed by (frame_uid, gen_time)."""
     location = _location(runtime_dir)
     index = {}
-    for msg_type in MSG_TYPE_NAMES:
-        try:
-            for header, frame_payload in yjj.assemble(location, 0).read_bytes(msg_type):
-                data = bytes(frame_payload)
-                index[(header.frame_uid, header.msg_type, header.gen_time)] = {
-                    "frame_uid": header.frame_uid,
-                    "trigger_frame_uid": header.trigger_frame_uid,
-                    "stream_id": header.stream_id,
-                    "gen_time": header.gen_time,
-                    "trigger_time": header.trigger_time,
-                    "msg_type": header.msg_type,
-                    "source": header.source,
-                    "initial_source": header.initial_source,
-                    "dest": header.dest,
-                    "data_length": len(data),
-                    "data_type": _frame_data_type_value(header),
-                    "journal_payload_hash": payloads.payload_hash(data),
-                    "_payload": data,
-                }
-        except (RuntimeError, ValueError, FileNotFoundError):
-            continue
+    try:
+        for header, frame_payload in yjj.assemble(location, 0).read_bytes(
+            MSG_ACTION_ENVELOPE
+        ):
+            data = bytes(frame_payload)
+            index[(header.frame_uid, header.gen_time)] = {
+                "frame_uid": header.frame_uid,
+                "trigger_frame_uid": header.trigger_frame_uid,
+                "stream_id": header.stream_id,
+                "gen_time": header.gen_time,
+                "trigger_time": header.trigger_time,
+                "msg_type": header.msg_type,
+                "source": header.source,
+                "initial_source": header.initial_source,
+                "dest": header.dest,
+                "data_length": len(data),
+                "data_type": _frame_data_type_value(header),
+                "journal_payload_hash": payloads.payload_hash(data),
+                "_payload": data,
+            }
+    except (RuntimeError, ValueError, FileNotFoundError):
+        pass
     return index
+
+
+def _mission_card(payload):
+    stage = payload.get("current_stage")
+    stage = stage if isinstance(stage, dict) else {}
+    return {
+        "mission_id": _text(payload.get("mission_id")),
+        "title": _text(payload.get("title")),
+        "status": _text(payload.get("status")),
+        "active_lens": _text(payload.get("active_lens")),
+        "stage_name": _text(stage.get("name")),
+        "next_review": _text(stage.get("next_review")),
+        "next_action": _text(payload.get("next_action")),
+    }
+
+
+def _goal_card(payload):
+    return {
+        "goal_id": _text(payload.get("goal_id")),
+        "status": _text(payload.get("status")),
+        "title": _text(payload.get("title")),
+        "owner_agent": _text(payload.get("owner_agent")),
+        "mission_id": _text(payload.get("mission_id")),
+        "lens": _text(payload.get("lens")),
+        "mission_stage": _text(payload.get("mission_stage")),
+        "source_branch": _text(payload.get("source_branch")),
+        "worktree_path": _text(payload.get("worktree_path")),
+        "external_repo_path": _text(payload.get("external_repo_path")),
+        "external_branch": _text(payload.get("external_branch")),
+        "external_head": _text(payload.get("external_head")),
+        "external_ready_ref": _text(payload.get("external_ready_ref")),
+        "latest_marker": _text(payload.get("latest_marker")),
+        "summary": _text(payload.get("summary")),
+        "next_action": _text(payload.get("next_action")),
+        "archived": bool(payload.get("archived")),
+    }
+
+
+def _marker_card(payload, source):
+    return {
+        "branch": _text(payload.get("branch")),
+        "status": _text(payload.get("status")),
+        "ready": bool(payload.get("ready")),
+        "ready_scope": _text(payload.get("ready_scope")),
+        "keep_source_worktree": bool(payload.get("keep_source_worktree")),
+        "worktree_path": _text(payload.get("worktree_path")),
+        "summary": _text(payload.get("summary")),
+        "risk": _text(payload.get("risk")),
+        "marker_path": _text(source.get("source_path") or payload.get("marker_path")),
+    }
 
 
 def load(runtime_dir):
@@ -264,76 +354,50 @@ def load(runtime_dir):
     """
     batches = {}
     completed = []
-    for gen_time, msg_type, payload in read_frames(runtime_dir):
-        if msg_type == MSG_IMPORT_BEGIN:
-            event = ImportBegin.GetRootAs(payload, 0)
-            import_id = _text(event.ImportId())
+    data_dir = store_dir(runtime_dir)
+    for gen_time, action_type, envelope in read_frames(runtime_dir):
+        session = envelope.get("session")
+        session = session if isinstance(session, dict) else {}
+        batch_info = envelope.get("batch")
+        batch_info = batch_info if isinstance(batch_info, dict) else {}
+        import_id = _text(session.get("import_id"))
+        if action_type == ACTION_IMPORT_BEGIN and import_id:
             batches[import_id] = {
                 "import_id": import_id,
-                "repo_root": _text(event.RepoRoot()),
-                "repo_head": _text(event.RepoHead()),
+                "repo_root": _text(batch_info.get("repo_root")),
+                "repo_head": _text(batch_info.get("repo_head")),
                 "time": gen_time,
                 "missions": {},
                 "goals": {},
                 "markers": {},
             }
-        elif msg_type == MSG_MISSION_SNAPSHOT:
-            event = MissionSnapshot.GetRootAs(payload, 0)
-            batch = batches.get(_text(event.ImportId()))
-            if batch is not None:
-                card = {
-                    "mission_id": _text(event.MissionId()),
-                    "title": _text(event.Title()),
-                    "status": _text(event.Status()),
-                    "active_lens": _text(event.ActiveLens()),
-                    "stage_name": _text(event.StageName()),
-                    "next_review": _text(event.NextReview()),
-                    "next_action": _text(event.NextAction()),
-                }
+        elif action_type == ACTION_MISSION_SNAPSHOT and import_id:
+            batch = batches.get(import_id)
+            descriptor = envelope.get("payload")
+            descriptor = descriptor if isinstance(descriptor, dict) else {}
+            source_payload, _ = payloads.load_payload_descriptor(data_dir, descriptor)
+            if batch is not None and source_payload is not None:
+                card = _mission_card(source_payload)
                 batch["missions"][card["mission_id"]] = card
-        elif msg_type == MSG_GOAL_SNAPSHOT:
-            event = GoalSnapshot.GetRootAs(payload, 0)
-            batch = batches.get(_text(event.ImportId()))
-            if batch is not None:
-                card = {
-                    "goal_id": _text(event.GoalId()),
-                    "status": _text(event.Status()),
-                    "title": _text(event.Title()),
-                    "owner_agent": _text(event.OwnerAgent()),
-                    "mission_id": _text(event.MissionId()),
-                    "lens": _text(event.Lens()),
-                    "mission_stage": _text(event.MissionStage()),
-                    "source_branch": _text(event.SourceBranch()),
-                    "worktree_path": _text(event.WorktreePath()),
-                    "external_repo_path": _text(event.ExternalRepoPath()),
-                    "external_branch": _text(event.ExternalBranch()),
-                    "external_head": _text(event.ExternalHead()),
-                    "external_ready_ref": _text(event.ExternalReadyRef()),
-                    "latest_marker": _text(event.LatestMarker()),
-                    "summary": _text(event.Summary()),
-                    "next_action": _text(event.NextAction()),
-                    "archived": bool(event.Archived()),
-                }
+        elif action_type == ACTION_GOAL_SNAPSHOT and import_id:
+            batch = batches.get(import_id)
+            descriptor = envelope.get("payload")
+            descriptor = descriptor if isinstance(descriptor, dict) else {}
+            source_payload, _ = payloads.load_payload_descriptor(data_dir, descriptor)
+            if batch is not None and source_payload is not None:
+                card = _goal_card(source_payload)
                 batch["goals"][card["goal_id"]] = card
-        elif msg_type == MSG_MARKER_SNAPSHOT:
-            event = MarkerSnapshot.GetRootAs(payload, 0)
-            batch = batches.get(_text(event.ImportId()))
-            if batch is not None:
-                card = {
-                    "branch": _text(event.Branch()),
-                    "status": _text(event.Status()),
-                    "ready": bool(event.Ready()),
-                    "ready_scope": _text(event.ReadyScope()),
-                    "keep_source_worktree": bool(event.KeepSourceWorktree()),
-                    "worktree_path": _text(event.WorktreePath()),
-                    "summary": _text(event.Summary()),
-                    "risk": _text(event.Risk()),
-                    "marker_path": _text(event.MarkerPath()),
-                }
+        elif action_type == ACTION_MARKER_SNAPSHOT and import_id:
+            batch = batches.get(import_id)
+            descriptor = envelope.get("payload")
+            descriptor = descriptor if isinstance(descriptor, dict) else {}
+            source = envelope.get("source")
+            source = source if isinstance(source, dict) else {}
+            source_payload, _ = payloads.load_payload_descriptor(data_dir, descriptor)
+            if batch is not None and source_payload is not None:
+                card = _marker_card(source_payload, source)
                 batch["markers"][card["branch"]] = card
-        elif msg_type == MSG_IMPORT_END:
-            event = ImportEnd.GetRootAs(payload, 0)
-            import_id = _text(event.ImportId())
+        elif action_type == ACTION_IMPORT_END and import_id:
             if import_id in batches:
                 completed.append((gen_time, import_id))
     if not completed:

--- a/framework/core/tests/python/test_atlas_storage.py
+++ b/framework/core/tests/python/test_atlas_storage.py
@@ -4,6 +4,7 @@ import json
 from datetime import datetime, timezone
 
 from kungfu.atlas import importer, payloads
+from kungfu.atlas import MSG_ACTION_ENVELOPE
 from kungfu.sources import store as source_store
 
 
@@ -62,7 +63,7 @@ def _action_receipts(source_records):
             "stream_id": 0,
             "gen_time": 1000 + index,
             "trigger_time": 0,
-            "msg_type": 9000 + index,
+            "msg_type": MSG_ACTION_ENVELOPE,
             "source": 101,
             "initial_source": 101,
             "dest": 0,
@@ -83,7 +84,6 @@ def _action_frames_from_manifest(manifest):
         frames[
             (
                 entry["action"]["journal"]["frame_uid"],
-                entry["action"]["journal"]["msg_type"],
                 entry["action"]["journal"]["gen_time"],
             )
         ] = journal
@@ -210,8 +210,10 @@ def test_payload_manifest_fsck_export_and_verify(tmp_path):
     assert goal["source_time"] == "2026-07-08T01:00:00Z"
     assert goal["action"]["schema"] == payloads.ACTION_ENVELOPE_SCHEMA
     assert goal["action"]["action_type"] == "atlas.goal.snapshot"
+    assert goal["action"]["schema_ref"]["id"] == "kungfu.atlas.GoalSnapshot"
     assert goal["action"]["payload"]["hash"] == goal["payload_hash"]
     assert goal["action"]["journal"]["frame_uid"] > 0
+    assert goal["action"]["journal"]["msg_type"] == MSG_ACTION_ENVELOPE
 
     missing_frame = payloads.fsck_import(store, action_frames={})
     assert not missing_frame["ok"]

--- a/scripts/install-hooks.mjs
+++ b/scripts/install-hooks.mjs
@@ -38,6 +38,14 @@ function log(msg) {
   process.stderr.write(`[install-hooks] ${msg}\n`);
 }
 
+/** @param {unknown} error */
+function errorLabel(error) {
+  if (error && typeof error === 'object' && 'code' in error) {
+    return String(error.code);
+  }
+  return error instanceof Error ? error.message : String(error);
+}
+
 function main() {
   const force = process.argv.includes('--force');
 
@@ -65,7 +73,12 @@ function main() {
   const hooksDir = path.isAbsolute(commonDir)
     ? path.join(commonDir, 'hooks')
     : path.join(process.cwd(), commonDir, 'hooks');
-  fs.mkdirSync(hooksDir, { recursive: true });
+  try {
+    fs.mkdirSync(hooksDir, { recursive: true });
+  } catch (error) {
+    log(`skipped (cannot create hooks dir: ${hooksDir}; ${errorLabel(error)})`);
+    return 0;
+  }
   const dest = path.join(hooksDir, 'pre-commit');
 
   if (fs.existsSync(dest) && !force) {
@@ -78,8 +91,13 @@ function main() {
     }
   }
 
-  fs.copyFileSync(src, dest);
-  fs.chmodSync(dest, 0o755);
+  try {
+    fs.copyFileSync(src, dest);
+    fs.chmodSync(dest, 0o755);
+  } catch (error) {
+    log(`skipped (cannot write pre-commit: ${dest}; ${errorLabel(error)})`);
+    return 0;
+  }
   log(`installed pre-commit -> ${dest}`);
 
   // Informational: if core.hooksPath is redirected, git only runs this standard

--- a/tests/fixtures/atlas-demo-import/check_import.py
+++ b/tests/fixtures/atlas-demo-import/check_import.py
@@ -20,14 +20,15 @@ sys.path.insert(0, os.path.join(_core, "src", "python"))
 sys.path.insert(0, os.path.join(_core, "dist", "kungfu"))
 
 from kungfu.atlas import (  # noqa: E402
-    MSG_GOAL_SNAPSHOT,
-    MSG_IMPORT_BEGIN,
-    MSG_IMPORT_END,
-    MSG_MARKER_SNAPSHOT,
-    MSG_MISSION_SNAPSHOT,
+    ACTION_GOAL_SNAPSHOT,
+    ACTION_IMPORT_BEGIN,
+    ACTION_IMPORT_END,
+    ACTION_MARKER_SNAPSHOT,
+    ACTION_MISSION_SNAPSHOT,
+    ACTION_TYPE_NAMES,
+    MSG_ACTION_ENVELOPE,
 )
 from kungfu.atlas import store  # noqa: E402
-from kungfu.atlas.fb.ImportEnd import ImportEnd  # noqa: E402
 
 runtime_dir, latest_import_id = sys.argv[1], sys.argv[2]
 failures = []
@@ -39,36 +40,36 @@ def check(name, ok, detail=""):
         failures.append(name)
 
 
-# ── journal: two complete batches, counts double the single batch ─────────
+# ── journal: two complete batches, one v4 envelope msg_type ───────────────
 frames = store.read_frames(runtime_dir)
 counts = {}
-for _gen_time, msg_type, _payload in frames:
-    counts[msg_type] = counts.get(msg_type, 0) + 1
+for _gen_time, action_type, _payload in frames:
+    counts[action_type] = counts.get(action_type, 0) + 1
 
 expected = {
-    MSG_IMPORT_BEGIN: 2,
-    MSG_MISSION_SNAPSHOT: 2,  # 1 mission x 2 imports
-    MSG_GOAL_SNAPSHOT: 4,  # 2 goals x 2 imports
-    MSG_MARKER_SNAPSHOT: 2,  # 1 valid marker x 2 imports
-    MSG_IMPORT_END: 2,
+    ACTION_IMPORT_BEGIN: 2,
+    ACTION_MISSION_SNAPSHOT: 2,  # 1 mission x 2 imports
+    ACTION_GOAL_SNAPSHOT: 4,  # 2 goals x 2 imports
+    ACTION_MARKER_SNAPSHOT: 2,  # 1 valid marker x 2 imports
+    ACTION_IMPORT_END: 2,
 }
-for msg_type, want in expected.items():
+for action_type, want in expected.items():
     check(
-        f"{store.MSG_TYPE_NAMES[msg_type]} x{want}",
-        counts.get(msg_type, 0) == want,
-        f"got {counts.get(msg_type, 0)}",
+        f"{ACTION_TYPE_NAMES[action_type]} x{want}",
+        counts.get(action_type, 0) == want,
+        f"got {counts.get(action_type, 0)}",
     )
 
 # warnings are diagnostic and counted: broken.json in the marker dir
 ends = [
-    ImportEnd.GetRootAs(payload, 0)
-    for _gen_time, msg_type, payload in frames
-    if msg_type == MSG_IMPORT_END
+    envelope
+    for _gen_time, action_type, envelope in frames
+    if action_type == ACTION_IMPORT_END
 ]
 check(
     "each batch counted one warning (broken.json)",
-    all(e.Warnings() == 1 for e in ends),
-    f"got {[e.Warnings() for e in ends]}",
+    all(e.get("batch", {}).get("warnings") == 1 for e in ends),
+    f"got {[e.get('batch', {}).get('warnings') for e in ends]}",
 )
 
 # ── projection: the fold picks the LATEST completed batch ─────────────────
@@ -121,23 +122,19 @@ if os.path.exists(manifest_path):
     with open(manifest_path) as f:
         manifest = json.load(f)
     bindings = manifest.get("schema_bindings", {})
-    check("manifest binds all five event types", len(bindings) == 5)
+    check("manifest binds the v4 action envelope", len(bindings) == 1)
+    check(
+        "manifest uses the reset envelope msg_type",
+        str(MSG_ACTION_ENVELOPE) in bindings,
+    )
     check(
         "manifest states the authority boundary",
         "authority_boundary" in manifest,
     )
-    hashes = {binding["schema_hash"] for binding in bindings.values()}
-    if len(hashes) == 1:
-        schema_hash = hashes.pop()
-        blob_path = os.path.join(store_dir, "schemas", schema_hash + ".bfbs")
-        check("schema blob exists", os.path.exists(blob_path))
-        if os.path.exists(blob_path):
-            with open(blob_path, "rb") as f:
-                blob = f.read()
-            check(
-                "schema blob content-addressed",
-                hashlib.sha256(blob).hexdigest() == schema_hash,
-            )
+    check(
+        "manifest dispatches business semantics by action_type",
+        manifest.get("semantic_dispatch") == "action_type",
+    )
 
 # ── payload manifest: every imported source record is an action envelope ──
 payload_manifest_path = os.path.join(store_dir, "imports", "latest.json")
@@ -161,7 +158,6 @@ if os.path.exists(payload_manifest_path):
         frame = frame_index.get(
             (
                 journal.get("frame_uid"),
-                journal.get("msg_type"),
                 journal.get("gen_time"),
             )
         )
@@ -180,6 +176,10 @@ if os.path.exists(payload_manifest_path):
         check(
             f"action payload hash matches {entry.get('kind')}:{entry.get('source_id')}",
             action.get("payload", {}).get("hash") == entry.get("payload_hash"),
+        )
+        check(
+            f"action journal uses envelope msg_type for {entry.get('kind')}:{entry.get('source_id')}",
+            journal.get("msg_type") == MSG_ACTION_ENVELOPE,
         )
 
     fsck = store.fsck(runtime_dir)


### PR DESCRIPTION
## Summary
- reset v4 business facts onto a generic msg_type=1000 action-envelope carrier
- move Atlas import semantics to action_type/schema_ref metadata
- update Atlas import/export/fsck/projection tests and msg_type docs
- make hook installation tolerate locked main-repo .git hooks during worktree builds

## Validation
- python3 -m py_compile framework/core/src/python/kungfu/atlas/__init__.py framework/core/src/python/kungfu/atlas/payloads.py framework/core/src/python/kungfu/atlas/store.py framework/core/tests/python/test_atlas_storage.py tests/fixtures/atlas-demo-import/check_import.py
- cd framework/core && PYTHONPATH=src/python uv run --frozen pytest tests/python/test_atlas_storage.py -q
- ./kungfu-code build
- ./kungfu-code check
- node tests/fixtures/atlas-demo-import/run.mjs
- node tests/fixtures/kfx-demo-work-dashboard-atlas-live/run.mjs
- cmake/build fact_ledger_action_recorder smoke