### PR TITLE
feat(core): add frame integrity receipts and msg type gate

### DIFF
--- a/docs/event-model.md
+++ b/docs/event-model.md
@@ -19,6 +19,10 @@ architecture-level recording semantics live in the C++ core. Python and Node may
 wrap the recorder and build payloads, but they must not own independent
 causality, writer, timeline, or receipt logic.
 
+Frame integrity starts at the same C++ boundary. [ADR-0023](../framework/core/docs/adr/ADR-0023-frame-integrity-and-msg-type-allocation-gates.md)
+defines the first receipt-based checksum slice and the rule that new v4 business
+facts must not allocate raw `300xx` / `400xx` `msg_type` numbers.
+
 For multi-machine views, frame time is not treated as a universal clock.
 [ADR-0021](../framework/core/docs/adr/ADR-0021-observer-relative-timeline-projection.md)
 pins the rule: Kungfu stores causal facts, source provenance, accepted ranges,
@@ -62,6 +66,12 @@ envelope carrier: the journal header keeps `msg_type` for filtering and fsck,
 while the payload names the domain action through `action_type` and
 `schema_ref`. The same bytes are read by C++, Python, and Node without inventing
 per-language causality logic (see [`contracts.md`](contracts.md)).
+
+Current `frame_header` does not contain an in-frame checksum. New
+`action_recorder` receipts carry `integrity_version`, `payload_checksum`, and
+`frame_checksum`; fsck can persist and verify those receipt fields by reopening
+the recorded frame. A full frame trailer or chain root is a future journal
+format surface, not something older journals can be assumed to contain.
 
 ## Routing: source and dest
 

--- a/framework/api/src/capability/types.ts
+++ b/framework/api/src/capability/types.ts
@@ -68,6 +68,9 @@ export type LedgerRecord = {
   dest: number;
   dataLength: number;
   dataType: number;
+  integrityVersion?: number;
+  payloadChecksum?: bigint;
+  frameChecksum?: bigint;
 };
 
 export type RecordFilter = {

--- a/framework/core/docs/adr/ADR-0023-frame-integrity-and-msg-type-allocation-gates.md
+++ b/framework/core/docs/adr/ADR-0023-frame-integrity-and-msg-type-allocation-gates.md
@@ -1,0 +1,109 @@
+# ADR-0023: frame integrity starts at the C++ recorder and raw msg_type allocation is gated
+
+- Status: accepted
+- Date: 2026-07-08
+- Category: (architecture) journal integrity and v4 event allocation
+- Subsystem: yijinjing journal writer, libkungfu action recorder, fsck/export,
+  Rewind, Work, KFX schema registration, CI/source-quality gates.
+- Related: ADR-0001 defines the publish barrier. ADR-0018 defines runtime
+  storage as the persistence contract. ADR-0022 defines the C++ action recorder
+  as the polyglot membrane.
+
+## Context
+
+The trading-era journal optimized for low-latency publication. `frame_header`
+contains enough structure to publish, route, filter, and replay frames, but it
+does not contain a per-frame checksum. The `length` field is the publication
+token: it proves a reader does not observe a half-written frame, not that the
+frame was never corrupted or changed after publication.
+
+The v4 agent/runtime use case changes the tradeoff. Agent facts are durable
+evidence. They need low-cost integrity checks even when the full cryptographic
+or multi-machine sync story is staged later.
+
+At the same time, earlier dogfood slices used pre-envelope open-layer msg_type
+allocations (`300xx`, `301xx`, `400xx`). Those ranges remain useful historical
+compatibility material, but copying that pattern into new v4 work would
+re-couple business semantics to raw journal integers.
+
+## Decision
+
+New v4 business facts must not allocate raw business `msg_type` numbers. They
+use the action-envelope carrier (`msg_type=1000`) and put business semantics in
+`action_type` plus `schema_ref`.
+
+The repository enforces this with a source-quality gate. New raw `300xx` /
+`400xx` allocations fail unless the file is in an explicit legacy allowlist.
+The allowlist is for preserving existing Rewind/Work/KFX surfaces, not for
+expanding the model.
+
+Frame integrity begins in the C++ action-recorder membrane:
+
+- `action_recorder` computes a fast payload checksum and frame checksum when it
+  writes a frame.
+- The receipt exposes `integrity_version`, `payload_checksum`, and
+  `frame_checksum` through C++, Python, and Node.
+- Higher layers that persist receipts, such as the Atlas import manifest, can
+  run fsck by reopening journal frames and recomputing those checksums.
+
+The first checksum algorithm is a fast non-keyed 64-bit FNV-1a implementation.
+This is a corruption detector, not a cryptographic authenticity proof.
+
+## Trailer and hash-chain direction
+
+A full journal-format v2 should add a frame trailer or equivalent integrity
+region written before the final `length` release-store. That design must
+preserve ADR-0001: the checksum/trailer is fully written before the frame is
+published, and `length` remains the final visibility token.
+
+A single checksum detects accidental corruption and uncoordinated mutation. It
+does not make the frame tamper-proof, because an attacker who can rewrite the
+frame can also rewrite a non-keyed checksum. Tamper evidence requires a
+chain-level commitment, for example:
+
+- previous frame checksum/hash;
+- current header/payload/trailer checksum;
+- stream/session/page root;
+- exported manifest or remote sync receipt binding that root.
+
+That chain is a separate compatibility surface and should be delivered as a
+later stage after the receipt-based slice proves the API and fsck flow.
+
+## Consequences
+
+- Future agents must add action schemas, not raw `msg_type` constants, for new
+  product/runtime facts.
+- Rewind and Work remain pre-envelope compatibility surfaces until deliberately
+  migrated.
+- KFX dynamic schema examples remain legacy; sandboxed extensions should not
+  treat `40000-49999` as the preferred v4 business event model.
+- fsck can detect changed action-envelope payload/header facts when the receipt
+  has integrity fields.
+- Existing journals remain readable. They simply lack integrity receipt fields
+  unless written by the new recorder.
+
+## Alternatives considered
+
+- **Put checksum fields directly into `frame_header`.** Rejected for the first
+  slice. It changes the binary layout and the publish-size assumptions, so it
+  needs a journal-format migration decision.
+- **Append a trailer immediately.** Deferred. Existing readers calculate
+  `data_length = frame_length - header_length`; a naive trailer would be read as
+  payload by old code unless the header/layout is extended.
+- **Rely only on exported manifest hashes.** Rejected as insufficient. Manifest
+  hashes protect exported artifacts, not the frame as the smallest runtime fact.
+- **Use a cryptographic hash immediately.** Deferred. A faster checksum is
+  enough for the first corruption-detection slice; tamper evidence belongs to a
+  chain/root design.
+
+## Residual risk
+
+- Receipt-based integrity is only as durable as the layer that persists the
+  receipt. Full journal-native trailer integrity is still future work.
+- The v1 receipt checksum defines an implementation-level scalar order for the
+  current writer/fsck path. A future journal-native trailer must freeze a
+  portable byte encoding as part of the format contract.
+- FNV-1a is not cryptographic. Do not describe it as security against a capable
+  attacker.
+- Legacy open-layer ranges are still present. The gate prevents new accidental
+  allocations but does not migrate old surfaces by itself.

--- a/framework/core/docs/adr/README.md
+++ b/framework/core/docs/adr/README.md
@@ -38,6 +38,7 @@ A record's **Status** says where it stands:
 | [0020](ADR-0020-agent-action-timeline-and-replay-boundary.md) | accepted | agent action timeline and rewind/replay boundary |
 | [0021](ADR-0021-observer-relative-timeline-projection.md) | accepted | observer-relative timeline projection over causal facts |
 | [0022](ADR-0022-core-action-recording-surface.md) | accepted | core action-recording surface lives in the C++ polyglot membrane |
+| [0023](ADR-0023-frame-integrity-and-msg-type-allocation-gates.md) | accepted | frame integrity starts at the C++ recorder and raw msg_type allocation is gated |
 
 ## Reading by theme
 
@@ -79,7 +80,10 @@ A record's **Status** says where it stands:
   [0021](ADR-0021-observer-relative-timeline-projection.md) (stable
   observer-relative timeline projection without a universal global clock), and
   [0022](ADR-0022-core-action-recording-surface.md) (the C++ core
-  action-recording surface that Python/Node bindings wrap).
+  action-recording surface that Python/Node bindings wrap), and
+  [0023](ADR-0023-frame-integrity-and-msg-type-allocation-gates.md) (the first
+  frame-integrity receipt slice plus the source gate that prevents new raw
+  business msg_type allocations).
 - **Cross-cutting principle** — [0009](ADR-0009-load-bearing-self-bootstrap.md)
   (load-bearing self-bootstrap), which also names the general law that
   [`docs/architecture.md` § The build dogfoods the SDK](../../../../docs/architecture.md)

--- a/framework/core/docs/msg-type-ranges.md
+++ b/framework/core/docs/msg-type-ranges.md
@@ -52,6 +52,8 @@ Rules:
   name a business action. Add an `action_type` / schema binding instead.
 - `msg_type` may appear in fsck/export/debug output as `journal.msg_type`, but
   GUI/KFX/domain APIs should treat it as implementation metadata.
+- `scripts/check-msg-type-allocations.mjs` enforces this rule by blocking new
+  raw `300xx` / `400xx` allocations outside reviewed legacy paths.
 
 ## Legacy / Migration Context
 

--- a/framework/core/slices/fact-ledger/README.md
+++ b/framework/core/slices/fact-ledger/README.md
@@ -109,9 +109,10 @@ link back correctly, so CI can gate on it.
   `src/libyijinjing/check-deps.sh` guards the dependency direction (no
   practice/wingchun/nng/rxcpp/sqlite/rocksdb, no trading types, no full type
   registry).
-- **No in-frame content hash yet.** Content commitment lives at the manifest
-  layer (checksums over exported payloads), not as a per-frame `payload_hash` in
-  the spine (the external hash-blob store of the full design is future work).
+- **Frame integrity is receipt-scoped in this slice.** The action-recorder smoke
+  verifies the C++ receipt's `payload_checksum` and `frame_checksum`, including
+  a payload-mutation negative check. Full journal-native trailer / hash-chain
+  integrity is still future work.
 - **`msg_type` is a carrier int.** The v4 action-recorder smoke uses the generic
   action-envelope carrier (`1000`); domain semantics are carried by the JSON
   payload's `action_type` / schema fields. No full self-describing schema

--- a/framework/core/slices/fact-ledger/action_recorder.cpp
+++ b/framework/core/slices/fact-ledger/action_recorder.cpp
@@ -46,6 +46,11 @@ std::string payload_hash(const std::vector<uint8_t> &bytes, std::size_t length) 
   return sha256::hex(view);
 }
 
+uint64_t frame_checksum(const longfist::types::frame_header &header, const std::vector<uint8_t> &bytes,
+                        std::size_t length) {
+  return action::checksum_frame(header, bytes.data(), static_cast<uint32_t>(length));
+}
+
 void fail(const std::string &message) { std::cerr << "fact_ledger_action_recorder: " << message << "\n"; }
 } // namespace
 
@@ -96,10 +101,20 @@ int main(int argc, char **argv) {
         receipt.trigger_frame_uid != header.trigger_frame_uid || receipt.trigger_frame_uid != expected_parent ||
         receipt.data_length != payloads[i].size() || bytes.size() < payloads[i].size() ||
         !padding_is_zero(bytes, payloads[i].size()) ||
-        payload_hash(bytes, payloads[i].size()) != payload_hash(payloads[i], payloads[i].size())) {
+        payload_hash(bytes, payloads[i].size()) != payload_hash(payloads[i], payloads[i].size()) ||
+        receipt.integrity_version != 1 ||
+        receipt.payload_checksum != action::checksum_payload(bytes.data(), static_cast<uint32_t>(payloads[i].size())) ||
+        receipt.frame_checksum != frame_checksum(header, bytes, payloads[i].size())) {
       fail("receipt/readback mismatch at step " + std::to_string(i));
       return 1;
     }
+  }
+
+  auto tampered = frames[0].second;
+  tampered[0] ^= 0x01;
+  if (receipts[0].frame_checksum == frame_checksum(frames[0].first, tampered, payloads[0].size())) {
+    fail("frame checksum did not detect payload mutation");
+    return 1;
   }
 
   nlohmann::json out = {
@@ -108,6 +123,7 @@ int main(int argc, char **argv) {
       {"name", name},
       {"event_count", receipts.size()},
       {"causal_chain_verified", true},
+      {"frame_integrity_verified", true},
       {"record_surface", "kungfu::yijinjing::action::action_recorder"},
   };
   std::cout << out.dump(2) << "\n";

--- a/framework/core/slices/fact-ledger/run.mjs
+++ b/framework/core/slices/fact-ledger/run.mjs
@@ -12,14 +12,14 @@
 
 import fs from 'node:fs';
 import {
-  locate,
-  findBin,
+  assertNoExtraDylibs,
   fail,
-  tmpDir,
+  findBin,
+  jsonField,
+  locate,
   run,
   sha256,
-  jsonField,
-  assertNoExtraDylibs,
+  tmpDir,
 } from '../_harness.mjs';
 
 const { buildDir } = locate(import.meta.url);
@@ -27,10 +27,15 @@ const eventCount = process.argv[3] || '5';
 
 const hostBin = findBin(buildDir, 'fact_ledger_host', 'slices/fact-ledger');
 const exportBin = findBin(buildDir, 'fact_ledger_export', 'slices/fact-ledger');
-if (!hostBin || !exportBin) {
+const actionRecorderBin = findBin(
+  buildDir,
+  'fact_ledger_action_recorder',
+  'slices/fact-ledger',
+);
+if (!hostBin || !exportBin || !actionRecorderBin) {
   fail(
-    `fact_ledger_host / fact_ledger_export not found under ${buildDir}\n` +
-      `build first, e.g.:\n  cmake --build ${buildDir} --target fact_ledger_host fact_ledger_export`,
+    `fact_ledger_host / fact_ledger_export / fact_ledger_action_recorder not found under ${buildDir}\n` +
+      `build first, e.g.:\n  cmake --build ${buildDir} --target fact_ledger_host fact_ledger_export fact_ledger_action_recorder`,
   );
 }
 
@@ -45,12 +50,17 @@ console.log(`== journal root: ${work}`);
 console.log(`== step 1: host writes ${eventCount} events, then exits`);
 run(hostBin, [work, eventCount], { inherit: true });
 
-console.log('\n== step 2: independent export tool reopens the directory');
+console.log(
+  '\n== step 2: action recorder writes and verifies receipt checksums',
+);
+run(actionRecorderBin, [work, eventCount], { inherit: true });
+
+console.log('\n== step 3: independent export tool reopens the host directory');
 run(exportBin, [work, 'fact_ledger_slice', 'host', `${work}/export`], {
   inherit: true,
 });
 
-console.log('\n== step 3: verify whole-segment checksum with a pure-Node hash');
+console.log('\n== step 4: verify whole-segment checksum with a pure-Node hash');
 const declared = jsonField(
   `${work}/export.manifest.json`,
   'event_log',

--- a/framework/core/src/bindings/node/binding/action_recorder.cpp
+++ b/framework/core/src/bindings/node/binding/action_recorder.cpp
@@ -87,6 +87,9 @@ Napi::Object to_receipt_object(Napi::Env env, const record_receipt &receipt) {
   object.Set("dest", Napi::Number::New(env, receipt.dest));
   object.Set("dataLength", Napi::Number::New(env, receipt.data_length));
   object.Set("dataType", Napi::Number::New(env, receipt.data_type));
+  object.Set("integrityVersion", Napi::Number::New(env, receipt.integrity_version));
+  object.Set("payloadChecksum", Napi::BigInt::New(env, receipt.payload_checksum));
+  object.Set("frameChecksum", Napi::BigInt::New(env, receipt.frame_checksum));
   return object;
 }
 

--- a/framework/core/src/bindings/python/binding/py-yijinjing.cpp
+++ b/framework/core/src/bindings/python/binding/py-yijinjing.cpp
@@ -239,7 +239,10 @@ void bind(pybind11::module &&m) {
       .def_readonly("initial_source", &action::record_receipt::initial_source)
       .def_readonly("dest", &action::record_receipt::dest)
       .def_readonly("data_length", &action::record_receipt::data_length)
-      .def_readonly("data_type", &action::record_receipt::data_type);
+      .def_readonly("data_type", &action::record_receipt::data_type)
+      .def_readonly("integrity_version", &action::record_receipt::integrity_version)
+      .def_readonly("payload_checksum", &action::record_receipt::payload_checksum)
+      .def_readonly("frame_checksum", &action::record_receipt::frame_checksum);
 
   py::class_<action::action_recorder, action::action_recorder_ptr>(m, "action_recorder")
       .def(py::init<const std::string &, const std::string &, const std::string &, uint32_t, uint64_t>(),

--- a/framework/core/src/libkungfu/include/kungfu/yijinjing/action_recorder.h
+++ b/framework/core/src/libkungfu/include/kungfu/yijinjing/action_recorder.h
@@ -34,7 +34,15 @@ struct record_receipt {
   uint32_t dest = 0;
   uint32_t data_length = 0;
   int8_t data_type = 0;
+  uint32_t integrity_version = 0;
+  uint64_t payload_checksum = 0;
+  uint64_t frame_checksum = 0;
 };
+
+[[nodiscard]] uint64_t checksum_payload(const uint8_t *payload, uint32_t payload_length);
+
+[[nodiscard]] uint64_t checksum_frame(const longfist::types::frame_header &header, const uint8_t *payload,
+                                      uint32_t payload_length);
 
 class action_recorder {
 public:

--- a/framework/core/src/libkungfu/src/yijinjing/action_recorder.cpp
+++ b/framework/core/src/libkungfu/src/yijinjing/action_recorder.cpp
@@ -5,12 +5,73 @@
 #include <kungfu/yijinjing/time.h>
 
 #include <cstring>
+#include <type_traits>
 
 using namespace kungfu::longfist::enums;
 using namespace kungfu::yijinjing::data;
 using namespace kungfu::yijinjing::journal;
 
 namespace kungfu::yijinjing::action {
+
+namespace {
+constexpr uint32_t FRAME_INTEGRITY_VERSION = 1;
+constexpr uint64_t FNV1A64_OFFSET = 14695981039346656037ull;
+constexpr uint64_t FNV1A64_PRIME = 1099511628211ull;
+
+uint32_t align_frame_payload_length(uint32_t length) {
+  return static_cast<uint32_t>((length + (sizeof(uintptr_t) - 1)) & ~(sizeof(uintptr_t) - 1));
+}
+
+void checksum_byte(uint64_t &state, uint8_t value) {
+  state ^= static_cast<uint64_t>(value);
+  state *= FNV1A64_PRIME;
+}
+
+void checksum_bytes(uint64_t &state, const uint8_t *data, size_t size) {
+  for (size_t i = 0; i < size; ++i) {
+    checksum_byte(state, data[i]);
+  }
+}
+
+template <typename T> void checksum_scalar(uint64_t &state, const T &value) {
+  static_assert(std::is_integral_v<T>);
+  using unsigned_t = std::make_unsigned_t<T>;
+  auto raw = static_cast<unsigned_t>(value);
+  for (size_t i = 0; i < sizeof(T); ++i) {
+    checksum_byte(state, static_cast<uint8_t>((raw >> (i * 8)) & 0xffu));
+  }
+}
+} // namespace
+
+uint64_t checksum_payload(const uint8_t *payload, uint32_t payload_length) {
+  uint64_t state = FNV1A64_OFFSET;
+  if (payload != nullptr and payload_length > 0) {
+    checksum_bytes(state, payload, payload_length);
+  }
+  return state;
+}
+
+uint64_t checksum_frame(const longfist::types::frame_header &header, const uint8_t *payload, uint32_t payload_length) {
+  uint64_t state = FNV1A64_OFFSET;
+  checksum_scalar(state, header.length);
+  checksum_scalar(state, header.header_length);
+  checksum_scalar(state, header.gen_time);
+  checksum_scalar(state, header.trigger_time);
+  checksum_scalar(state, header.msg_type);
+  checksum_scalar(state, header.source);
+  checksum_scalar(state, header.dest);
+  const auto data_type = static_cast<int8_t>(header.data_type);
+  checksum_scalar(state, data_type);
+  checksum_scalar(state, header.initial_source);
+  checksum_scalar(state, header.frame_uid);
+  checksum_scalar(state, header.trigger_frame_uid);
+  checksum_scalar(state, header.stream_id);
+  checksum_scalar(state, payload_length);
+  if (payload != nullptr and payload_length > 0) {
+    checksum_bytes(state, payload, payload_length);
+  }
+  return state;
+}
 
 action_recorder::action_recorder(const std::string &runtime_dir, const std::string &group, const std::string &name,
                                  uint32_t dest_id, uint64_t stream_id)
@@ -51,6 +112,13 @@ record_receipt action_recorder::record_payload(int32_t msg_type, const uint8_t *
     std::memcpy(const_cast<void *>(frame->data_address()), payload, payload_length);
   }
   const auto frame_uid = writer_->current_frame_uid();
+  auto checksum_header = *reinterpret_cast<const longfist::types::frame_header *>(frame->address());
+  checksum_header.length = checksum_header.header_length + align_frame_payload_length(payload_length);
+  checksum_header.gen_time = gen_time;
+  checksum_header.frame_uid = frame_uid;
+  checksum_header.trigger_frame_uid = parent_frame_uid;
+  const auto payload_checksum = checksum_payload(payload, payload_length);
+  const auto frame_checksum = checksum_frame(checksum_header, payload, payload_length);
   writer_->close_frame(payload_length, gen_time);
   bus::set_trigger_frame_uid(0);
 
@@ -66,6 +134,9 @@ record_receipt action_recorder::record_payload(int32_t msg_type, const uint8_t *
   receipt.dest = dest_id_;
   receipt.data_length = payload_length;
   receipt.data_type = static_cast<int8_t>(options.data_type);
+  receipt.integrity_version = FRAME_INTEGRITY_VERSION;
+  receipt.payload_checksum = payload_checksum;
+  receipt.frame_checksum = frame_checksum;
   last_frame_uid_ = receipt.frame_uid;
   return receipt;
 }

--- a/framework/core/src/python/kungfu/atlas/payloads.py
+++ b/framework/core/src/python/kungfu/atlas/payloads.py
@@ -3,7 +3,7 @@
 import hashlib
 import json
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from kungfu.atlas import (
     ACTION_GOAL_SNAPSHOT,
@@ -423,6 +423,38 @@ def _check_action_frame(
                 expected=journal.get("journal_payload_hash"),
                 actual=actual_hash,
             )
+        payload_checksum = journal.get("payload_checksum")
+        if isinstance(payload_checksum, int) and payload_checksum:
+            checksum_for = frame.get("_payload_checksum_for")
+            actual_checksum = (
+                checksum_for(expected_length) if callable(checksum_for) else None
+            )
+            if actual_checksum != payload_checksum:
+                _append_action_error(
+                    report,
+                    "action_frame_mismatch",
+                    entry,
+                    field="payload_checksum",
+                    frame_uid=frame_uid,
+                    expected=payload_checksum,
+                    actual=actual_checksum,
+                )
+        frame_checksum = journal.get("frame_checksum")
+        if isinstance(frame_checksum, int) and frame_checksum:
+            checksum_for = frame.get("_frame_checksum_for")
+            actual_checksum = (
+                checksum_for(expected_length) if callable(checksum_for) else None
+            )
+            if actual_checksum != frame_checksum:
+                _append_action_error(
+                    report,
+                    "action_frame_mismatch",
+                    entry,
+                    field="frame_checksum",
+                    frame_uid=frame_uid,
+                    expected=frame_checksum,
+                    actual=actual_checksum,
+                )
 
 
 def _check_action(
@@ -464,7 +496,7 @@ def fsck_import(
     action_frames: dict[Any, dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     manifest = load_latest_manifest(store_dir)
-    report = {
+    report: dict[str, Any] = {
         "ok": True,
         "scope": "atlas",
         "import_id": None,
@@ -496,13 +528,17 @@ def fsck_import(
             report["ok"] = False
             report["errors"].append({"code": "manifest_entry_invalid"})
             continue
-        key = _entry_key(entry)
-        if key in seen:
+        entry_key = _entry_key(entry)
+        if entry_key in seen:
             report["ok"] = False
             report["errors"].append(
-                {"code": "duplicate_source", "kind": key[0], "source_id": key[1]}
+                {
+                    "code": "duplicate_source",
+                    "kind": entry_key[0],
+                    "source_id": entry_key[1],
+                }
             )
-        seen.add(key)
+        seen.add(entry_key)
 
         kind = str(entry.get("kind") or "")
         if kind in ("mission", "goal", "marker"):
@@ -532,17 +568,18 @@ def fsck_import(
             )
         _check_action(report, entry, action_frames)
 
-    counts = manifest.get("counts") if isinstance(manifest.get("counts"), dict) else {}
-    for key in ("missions", "goals", "markers"):
-        expected = counts.get(key)
-        if expected is not None and expected != report["checked"][key]:
+    raw_counts = manifest.get("counts")
+    counts = cast(dict[str, Any], raw_counts) if isinstance(raw_counts, dict) else {}
+    for section in ("missions", "goals", "markers"):
+        expected = counts.get(section)
+        if expected is not None and expected != report["checked"][section]:
             report["ok"] = False
             report["errors"].append(
                 {
                     "code": "manifest_count_mismatch",
-                    "kind": key,
+                    "kind": section,
                     "expected": expected,
-                    "actual": report["checked"][key],
+                    "actual": report["checked"][section],
                 }
             )
 
@@ -559,35 +596,35 @@ def fsck_import(
             "goals": {key for key in seen if key[0] == "goal"},
             "markers": {key for key in seen if key[0] == "marker"},
         }
-        for key in ("missions", "goals", "markers"):
-            actual = len(projection_keys[key])
-            expected = len(manifest_keys[key])
+        for section in ("missions", "goals", "markers"):
+            actual = len(projection_keys[section])
+            expected = len(manifest_keys[section])
             if actual != expected:
                 report["ok"] = False
                 report["errors"].append(
                     {
                         "code": "projection_count_mismatch",
-                        "kind": key,
+                        "kind": section,
                         "expected": expected,
                         "actual": actual,
                     }
                 )
-            if projection_keys[key] != manifest_keys[key]:
+            if projection_keys[section] != manifest_keys[section]:
                 report["ok"] = False
                 report["errors"].append(
                     {
                         "code": "projection_id_mismatch",
-                        "kind": key,
+                        "kind": section,
                         "missing_in_projection": [
                             {"kind": kind, "source_id": source_id}
                             for kind, source_id in sorted(
-                                manifest_keys[key] - projection_keys[key]
+                                manifest_keys[section] - projection_keys[section]
                             )
                         ],
                         "extra_in_projection": [
                             {"kind": kind, "source_id": source_id}
                             for kind, source_id in sorted(
-                                projection_keys[key] - manifest_keys[key]
+                                projection_keys[section] - manifest_keys[section]
                             )
                         ],
                     }

--- a/framework/core/src/python/kungfu/atlas/store.py
+++ b/framework/core/src/python/kungfu/atlas/store.py
@@ -7,6 +7,7 @@
 
 import json
 import os
+import struct
 import uuid
 
 import kungfu
@@ -59,6 +60,10 @@ def _journal_payload(envelope):
     return payloads.canonical_json_bytes(envelope)
 
 
+def _receipt_value(receipt, name, default=None):
+    return getattr(receipt, name, default)
+
+
 class ImportStore:
     """Append side. One instance = one short-lived writer = one batch."""
 
@@ -83,6 +88,9 @@ class ImportStore:
             "dest": receipt.dest,
             "data_length": receipt.data_length,
             "data_type": receipt.data_type,
+            "integrity_version": _receipt_value(receipt, "integrity_version", 0),
+            "payload_checksum": _receipt_value(receipt, "payload_checksum", 0),
+            "frame_checksum": _receipt_value(receipt, "frame_checksum", 0),
             "journal_payload_hash": payloads.payload_hash(data),
         }
 
@@ -267,6 +275,43 @@ def _frame_data_type_value(header):
         return 0 if name == "raw" else str(value)
 
 
+def _fnv1a64_update(state, data):
+    for value in bytes(data):
+        state ^= value
+        state = (state * 1099511628211) & 0xFFFFFFFFFFFFFFFF
+    return state
+
+
+def _checksum_payload(data):
+    return _fnv1a64_update(14695981039346656037, data)
+
+
+def _pack_scalar(fmt, value):
+    return struct.pack("<" + fmt, value)
+
+
+def _checksum_frame(header, data, payload_length):
+    state = 14695981039346656037
+    fields = [
+        ("I", int(getattr(header, "length", 0))),
+        ("I", int(getattr(header, "header_length", 0))),
+        ("q", int(header.gen_time)),
+        ("q", int(header.trigger_time)),
+        ("i", int(header.msg_type)),
+        ("I", int(header.source)),
+        ("I", int(header.dest)),
+        ("b", int(_frame_data_type_value(header))),
+        ("I", int(header.initial_source)),
+        ("Q", int(header.frame_uid)),
+        ("Q", int(header.trigger_frame_uid)),
+        ("Q", int(header.stream_id)),
+        ("I", int(payload_length)),
+    ]
+    for fmt, value in fields:
+        state = _fnv1a64_update(state, _pack_scalar(fmt, value))
+    return _fnv1a64_update(state, data[:payload_length])
+
+
 def read_action_frame_index(runtime_dir):
     """Action frame identity index keyed by (frame_uid, gen_time)."""
     location = _location(runtime_dir)
@@ -286,10 +331,18 @@ def read_action_frame_index(runtime_dir):
                 "source": header.source,
                 "initial_source": header.initial_source,
                 "dest": header.dest,
+                "frame_length": getattr(header, "length", 0),
+                "header_length": getattr(header, "header_length", 0),
                 "data_length": len(data),
                 "data_type": _frame_data_type_value(header),
                 "journal_payload_hash": payloads.payload_hash(data),
                 "_payload": data,
+                "_payload_checksum_for": lambda payload_length, d=data: (
+                    _checksum_payload(d[:payload_length])
+                ),
+                "_frame_checksum_for": lambda payload_length, h=header, d=data: (
+                    _checksum_frame(h, d, payload_length)
+                ),
             }
     except (RuntimeError, ValueError, FileNotFoundError):
         pass

--- a/framework/core/stubs/pykungfu/yijinjing.pyi
+++ b/framework/core/stubs/pykungfu/yijinjing.pyi
@@ -23,6 +23,9 @@ class action_record_receipt:
     def dest(self) -> int:
         ...
     @property
+    def frame_checksum(self) -> int:
+        ...
+    @property
     def frame_uid(self) -> int:
         ...
     @property
@@ -32,7 +35,13 @@ class action_record_receipt:
     def initial_source(self) -> int:
         ...
     @property
+    def integrity_version(self) -> int:
+        ...
+    @property
     def msg_type(self) -> int:
+        ...
+    @property
+    def payload_checksum(self) -> int:
         ...
     @property
     def source(self) -> int:

--- a/scripts/check-msg-type-allocations.mjs
+++ b/scripts/check-msg-type-allocations.mjs
@@ -1,0 +1,207 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: Apache-2.0
+//
+// Guard v4 against copying the pre-envelope open-layer allocation pattern.
+// Existing Rewind/Work/KFX files remain as reviewed legacy surfaces; new v4
+// business facts must use msg_type=1000 plus action_type/schema_ref.
+// @ts-check
+
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+const args = process.argv.slice(2);
+const stagedOnly = args.includes('--staged');
+const allFiles = args.includes('--all');
+
+const SOURCE_EXT = /\.(c|cc|cpp|cxx|h|hh|hpp|hxx|mjs|js|cjs|ts|tsx|py|fbs)$/;
+
+const LEGACY_ALLOWLIST = [
+  'framework/api/src/capability/work.ts',
+  'framework/core/tests/bench/dispatch_load.py',
+  'framework/core/src/python/kungfu/rewind/',
+  'framework/core/src/python/kungfu/work/',
+  'tests/fixtures/rewind-demo-',
+  'tests/fixtures/work-demo-lifecycle/',
+];
+
+const ALLOCATION_PATTERNS = [
+  {
+    name: 'raw constant allocation',
+    re: /\b(?:MSG_[A-Z0-9_]*|[A-Z0-9_]*MSG_TYPE|KFX_MSG_TYPE|WORK_MSG_(?:MIN|MAX))\b\s*(?::[^=\n]+)?=\s*(3\d{4}|4\d{4})\b/g,
+  },
+  {
+    name: 'raw msg_type comment contract',
+    re: /\bmsg_type\b[^\n]{0,40}\b(3\d{4}|4\d{4})\b/g,
+  },
+  {
+    name: 'open-layer range constant',
+    re: /\b(?:OPEN_LAYER_MIN|KFX_MSGTYPE_(?:MIN|MAX))\b\s*(?::[^=\n]+)?=\s*(3\d{4}|4\d{4})\b/g,
+  },
+];
+
+function git(gitArgs) {
+  const result = spawnSync('git', gitArgs, {
+    cwd: ROOT,
+    encoding: 'utf8',
+  });
+  if (result.status !== 0) {
+    throw new Error(
+      `git ${gitArgs.join(' ')} failed: ${(result.stderr || '').trim()}`,
+    );
+  }
+  return result.stdout.trim();
+}
+
+function gitMaybe(gitArgs) {
+  const result = spawnSync('git', gitArgs, {
+    cwd: ROOT,
+    encoding: 'utf8',
+  });
+  return result.status === 0 ? result.stdout.trim() : null;
+}
+
+function splitLines(text) {
+  return text
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+function isFile(rel) {
+  try {
+    return fs.statSync(path.join(ROOT, rel)).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function isGenerated(rel) {
+  if (
+    /(?:^|\/)generated\//.test(rel) ||
+    /\/fb\/[A-Z][^/]*\.py$/.test(rel) ||
+    /_fb\.py$/.test(rel)
+  ) {
+    return true;
+  }
+  try {
+    const head = fs
+      .readFileSync(path.join(ROOT, rel), 'utf8')
+      .split('\n', 3)
+      .join('\n');
+    return /automatically generated|do not (edit|modify)/i.test(head);
+  } catch {
+    return false;
+  }
+}
+
+function mergeBase() {
+  const upstream = gitMaybe([
+    'rev-parse',
+    '--abbrev-ref',
+    '--symbolic-full-name',
+    '@{upstream}',
+  ]);
+  const candidates = [
+    upstream,
+    'origin/HEAD',
+    'origin/dev/v4/v4.0',
+    'dev/v4/v4.0',
+  ].filter(Boolean);
+  for (const ref of candidates) {
+    const base = gitMaybe(['merge-base', String(ref), 'HEAD']);
+    if (base) return base;
+  }
+  return null;
+}
+
+function selectedFiles() {
+  const files = new Set();
+  if (stagedOnly) {
+    for (const file of splitLines(
+      git(['diff', '--cached', '--name-only', '--diff-filter=ACM']),
+    )) {
+      files.add(file);
+    }
+  } else if (allFiles) {
+    for (const file of splitLines(git(['ls-files']))) {
+      files.add(file);
+    }
+  } else {
+    const base = mergeBase();
+    if (base) {
+      for (const file of splitLines(
+        git(['diff', '--name-only', '--diff-filter=ACM', `${base}...HEAD`]),
+      )) {
+        files.add(file);
+      }
+    }
+    for (const mode of [[], ['--cached']]) {
+      for (const file of splitLines(
+        git(['diff', ...mode, '--name-only', '--diff-filter=ACM']),
+      )) {
+        files.add(file);
+      }
+    }
+    for (const file of splitLines(
+      git(['ls-files', '--others', '--exclude-standard']),
+    )) {
+      files.add(file);
+    }
+  }
+  return [...files].filter(
+    (file) => SOURCE_EXT.test(file) && isFile(file) && !isGenerated(file),
+  );
+}
+
+function isLegacyAllowed(rel) {
+  return LEGACY_ALLOWLIST.some((entry) =>
+    entry.endsWith('/') || entry.endsWith('-')
+      ? rel.startsWith(entry)
+      : rel === entry,
+  );
+}
+
+function lineNumber(text, index) {
+  let line = 1;
+  for (let i = 0; i < index; i += 1) {
+    if (text.charCodeAt(i) === 10) line += 1;
+  }
+  return line;
+}
+
+const hits = [];
+for (const rel of selectedFiles()) {
+  if (isLegacyAllowed(rel)) continue;
+  const text = fs.readFileSync(path.join(ROOT, rel), 'utf8');
+  for (const pattern of ALLOCATION_PATTERNS) {
+    pattern.re.lastIndex = 0;
+    for (const match of text.matchAll(pattern.re)) {
+      hits.push({
+        file: rel,
+        line: lineNumber(text, match.index || 0),
+        pattern: pattern.name,
+        text: match[0].trim(),
+      });
+    }
+  }
+}
+
+if (hits.length) {
+  console.error('[msg-type] raw open-layer msg_type allocation is blocked.');
+  console.error(
+    '[msg-type] New v4 facts must use msg_type=1000 with action_type/schema_ref.',
+  );
+  console.error(
+    '[msg-type] Move legacy exceptions into a reviewed allowlist only when preserving an existing surface.',
+  );
+  for (const hit of hits) {
+    console.error(`  ${hit.file}:${hit.line} (${hit.pattern}) ${hit.text}`);
+  }
+  process.exit(1);
+}
+
+console.log('[msg-type] allocation gate passed');

--- a/scripts/check.mjs
+++ b/scripts/check.mjs
@@ -210,8 +210,16 @@ function checkNoBashTree() {
   );
 }
 
+function checkMsgTypeAllocations(scopeArgs = []) {
+  run('msg_type allocation gate', 'node', [
+    path.join('scripts', 'check-msg-type-allocations.mjs'),
+    ...scopeArgs,
+  ]);
+}
+
 function checkStaged() {
   checkNoBashStaged();
+  checkMsgTypeAllocations(['--staged']);
   const files = stagedFiles();
   if (!files.length) {
     log('[check] no staged source files');
@@ -296,6 +304,7 @@ function checkShared() {
 
 function checkChanged() {
   checkNoBashTree();
+  checkMsgTypeAllocations();
   checkBiomeFiles('changed', changedFiles());
   checkShared();
   log('\n[check] changed-scope gate passed');
@@ -303,6 +312,7 @@ function checkChanged() {
 
 function checkAll() {
   checkNoBashTree();
+  checkMsgTypeAllocations(['--all']);
   run('repo lint + format check', 'pnpm', ['run', 'lint']);
   checkShared();
   log('\n[check] whole-tree gate passed');


### PR DESCRIPTION
## Summary
- add a repository gate that blocks new raw 300xx/400xx msg_type allocations outside reviewed legacy surfaces
- add action recorder receipt integrity fields for payload and frame checksums
- verify Atlas import fsck against persisted action frame checksums

## Validation
- ./kungfu-code verify --full
- staged pre-commit gate during commit