### PR TITLE
refactor(core): replace location category with role policy

### DIFF
--- a/docs/MAP.md
+++ b/docs/MAP.md
@@ -39,6 +39,7 @@ and the map routes a question to whichever doc answers it.
 | How does Kungfu persist user facts, sync sources, and maintain storage over time? | [`runtime-storage-service.md`](runtime-storage-service.md) | use, verify | draft |
 | How can a multi-machine timeline stay stable without one global clock? | [ADR-0021](../framework/core/docs/adr/ADR-0021-observer-relative-timeline-projection.md) + [`event-model.md`](event-model.md) | why, verify | stable |
 | Where must action-recording semantics live across C++ / Python / Node? | [ADR-0022](../framework/core/docs/adr/ADR-0022-core-action-recording-surface.md) + [`event-model.md`](event-model.md) | why, use | stable |
+| What is a location role, and why does it not decide journal page size? | [ADR-0024](../framework/core/docs/adr/ADR-0024-location-role-and-journal-page-policy.md) + [`event-model.md`](event-model.md) | why, use | stable |
 | Where are the Python / Node / framework adapter boundaries? | [`adapters.md`](adapters.md) | use | stable |
 | How do I go from source to a binary? | [`buildchain.md`](buildchain.md) (+ [`../CONTRIBUTING.md`](../CONTRIBUTING.md)) | use | stable |
 | Where does a release binary come from, and how do I verify it? | `provenance.md` | verify | blocked · needs release infra |
@@ -74,6 +75,10 @@ route to the row that answers them:
   JS recorder / C++ recorder / polyglot action surface / binding-only logic** →
   *where must action-recording semantics live across C++ / Python / Node*
   ([ADR-0022](../framework/core/docs/adr/ADR-0022-core-action-recording-surface.md)).
+- **location role / source / sink / actor / service / journal page size /
+  mmap size / storage policy** → *what is a location role, and why does it not
+  decide journal page size*
+  ([ADR-0024](../framework/core/docs/adr/ADR-0024-location-role-and-journal-page-policy.md)).
 - **observer-relative timeline / timeline projection / source priority /
   global clock / multi-machine ordering / perspective / concurrent facts** →
   *how can a multi-machine timeline stay stable without one global clock*

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -26,7 +26,7 @@ principles behind them see [`design-philosophy.md`](design-philosophy.md).
 | **journal** | The append-only **event log**: one shared, strongly-typed stream of frames that every component consumes, rather than each inventing its own format. |
 | **frame** | A single journal record: a fixed-size header (source / destination / nanosecond timestamp / message type) plus a variable-size payload. |
 | **action recorder** | The language-neutral C++ core surface for writing action facts into the journal. Python and Node expose thin bindings over it; they must not implement separate causality, writer, or receipt semantics. See [ADR-0022](../framework/core/docs/adr/ADR-0022-core-action-recording-surface.md). |
-| **location** | A runtime identity/address: category, group, name, mode, locator root, and uid. Locations identify who writes, who reads, and where journals live. |
+| **location** | A runtime identity/address: role, group, name, mode, locator root, and uid. Locations identify who writes, who reads, and where journals live. |
 | **channel** | A source/destination communication edge between locations. Channels are used for runtime read/write/request paths; they are transport, not fact authority. |
 | **source** | A logical storage-sync registry entry: a local profile, imported bundle, remote Kungfu runtime, or adapter that can enumerate facts for import. |
 | **manifest** | The trust root for a portable fact-ledger bundle or accepted segment: format version, capture boundary, source metadata, payload inventory, schema bindings, and checksums. |

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -23,7 +23,7 @@ to "what is actually in the journal?" — which you can inspect directly.
 - **Rebuild / update the index** — if `sessions` looks wrong or incomplete, the
   index can be rebuilt from the journal files.
 
-Filters (`--mode`, `--category`, `--group`, `--name`) scope the view to the part
+Filters (`--mode`, `--role`, `--group`, `--name`) scope the view to the part
 of the system you are investigating.
 
 ## Reproduce with replay

--- a/docs/event-model.md
+++ b/docs/event-model.md
@@ -23,6 +23,10 @@ Frame integrity starts at the same C++ boundary. [ADR-0023](../framework/core/do
 defines the first receipt-based checksum slice and the rule that new v4 business
 facts must not allocate raw `300xx` / `400xx` `msg_type` numbers.
 
+Location identity uses neutral roles, not trading categories. [ADR-0024](../framework/core/docs/adr/ADR-0024-location-role-and-journal-page-policy.md)
+defines `source`, `sink`, `actor`, `system`, and `service`, and keeps journal
+page sizing as storage policy rather than role-derived behavior.
+
 For multi-machine views, frame time is not treated as a universal clock.
 [ADR-0021](../framework/core/docs/adr/ADR-0021-observer-relative-timeline-projection.md)
 pins the rule: Kungfu stores causal facts, source provenance, accepted ranges,

--- a/framework/api/src/capability/domain.ts
+++ b/framework/api/src/capability/domain.ts
@@ -6,9 +6,9 @@ import {
   type KfLocation,
   type KfLocator,
   type KfNativeBinding,
-  categoryName,
   modeName,
   resolveRuntimeDir,
+  roleName,
 } from './types.js';
 
 export type ConfigEntry = {
@@ -37,7 +37,7 @@ export function openDomainState(options: OpenDomainStateOptions): DomainState {
   const configs = (): ConfigEntry[] =>
     Object.values(store.getAllConfig()).map((row) => ({
       location: {
-        category: categoryName(row.category as number),
+        role: roleName(row.role as number),
         group: String(row.group),
         name: String(row.name),
         mode: modeName(row.mode as number),
@@ -47,7 +47,7 @@ export function openDomainState(options: OpenDomainStateOptions): DomainState {
 
   const setConfig = (location: KfLocation, value: string): boolean =>
     store.setConfig(
-      String(location.category),
+      String(location.role),
       location.group,
       location.name,
       String(location.mode),
@@ -56,7 +56,7 @@ export function openDomainState(options: OpenDomainStateOptions): DomainState {
 
   const removeConfig = (location: KfLocation): boolean =>
     store.removeConfig(
-      String(location.category),
+      String(location.role),
       location.group,
       location.name,
       String(location.mode),
@@ -64,11 +64,11 @@ export function openDomainState(options: OpenDomainStateOptions): DomainState {
 
   const locations = (): KfLocation[] => {
     const io = new binding.IODevice(
-      { category: 'system', group: 'capability', name: 'domain', mode: 'live' },
+      { role: 'system', group: 'capability', name: 'domain', mode: 'live' },
       runtimeDir,
     );
     return Object.values(io.getAllLocations()).map((row) => ({
-      category: String(row.category),
+      role: String(row.role),
       group: String(row.group),
       name: String(row.name),
       mode: String(row.mode),

--- a/framework/api/src/capability/guest-harness/authz-run.ts
+++ b/framework/api/src/capability/guest-harness/authz-run.ts
@@ -155,7 +155,7 @@ function partB(): void {
 
   // a hostile blob (non-boolean grant fields) is sanitized to default-deny.
   domain.setConfig(
-    { category: 'system', group: 'shell', name: 'service-authz', mode: 'live' },
+    { role: 'system', group: 'shell', name: 'service-authz', mode: 'live' },
     JSON.stringify({ perKfx: { [KEY]: { network: 'yes', write: 1 } } }),
   );
   const dirty = resolveServiceLanding(loadServiceAuthz(domain), KEY, false);

--- a/framework/api/src/capability/ledger.ts
+++ b/framework/api/src/capability/ledger.ts
@@ -9,9 +9,9 @@ import {
   type RecordFilter,
   type ReplayAnchor,
   type Subscription,
-  categoryName,
   modeName,
   resolveRuntimeDir,
+  roleName,
 } from './types.js';
 
 export type OpenLedgerOptions = {
@@ -112,7 +112,7 @@ export function openLedger(options: OpenLedgerOptions): Ledger {
 
   const replayAnchors = (): ReplayAnchor[] => {
     const store = new binding.SessionStore(
-      { category: 'system', group: 'capability', name: 'ledger', mode: 'live' },
+      { role: 'system', group: 'capability', name: 'ledger', mode: 'live' },
       runtimeDir,
     );
     const all = store.getAllSessions();
@@ -121,7 +121,7 @@ export function openLedger(options: OpenLedgerOptions): Ledger {
       const record = row as Record<string, unknown>;
       return {
         location: {
-          category: categoryName(record.category as number),
+          role: roleName(record.role as number),
           group: String(record.group),
           name: String(record.name),
           mode: modeName(record.mode as number),

--- a/framework/api/src/capability/service-authz.ts
+++ b/framework/api/src/capability/service-authz.ts
@@ -99,7 +99,7 @@ export function resolveServiceLanding(
 // the GUI and agent APIs read and write the same authorization — no host holds a
 // private grants file.
 export const SERVICE_AUTHZ_LOCATION = {
-  category: 'system',
+  role: 'system',
   group: 'shell',
   name: 'service-authz',
   mode: 'live',
@@ -125,7 +125,7 @@ export function loadServiceAuthz(domain: DomainState): ServiceAuthz {
       .configs()
       .find(
         (row) =>
-          row.location.category === SERVICE_AUTHZ_LOCATION.category &&
+          row.location.role === SERVICE_AUTHZ_LOCATION.role &&
           row.location.group === SERVICE_AUTHZ_LOCATION.group &&
           row.location.name === SERVICE_AUTHZ_LOCATION.name,
       );

--- a/framework/api/src/capability/types.js
+++ b/framework/api/src/capability/types.js
@@ -2,7 +2,7 @@
 // TypeScript resolves `./types.js` to `types.ts`; Node needs a real JS module.
 export {
   bigintSafe,
-  categoryName,
+  roleName,
   modeName,
   resolveRuntimeDir,
   toSerializable,

--- a/framework/api/src/capability/types.ts
+++ b/framework/api/src/capability/types.ts
@@ -19,14 +19,20 @@ export function resolveRuntimeDir(locator: KfLocator): string {
 // --- enum mapping ------------------------------------------------------
 // Enum-to-name mapping lives in the SDK, not in each consumer (ADR-0011 §4).
 
-export const CATEGORY_NAMES = ['md', 'td', 'strategy', 'system'] as const;
+export const ROLE_NAMES = [
+  'source',
+  'sink',
+  'actor',
+  'system',
+  'service',
+] as const;
 export const MODE_NAMES = ['live', 'data', 'replay', 'backtest'] as const;
 
-export type KfCategory = (typeof CATEGORY_NAMES)[number];
+export type KfRole = (typeof ROLE_NAMES)[number];
 export type KfMode = (typeof MODE_NAMES)[number];
 
-export function categoryName(value: number | string): string {
-  return CATEGORY_NAMES[Number(value)] ?? String(value);
+export function roleName(value: number | string): string {
+  return ROLE_NAMES[Number(value)] ?? String(value);
 }
 
 export function modeName(value: number | string): string {
@@ -34,7 +40,7 @@ export function modeName(value: number | string): string {
 }
 
 export type KfLocation = {
-  category: KfCategory | string;
+  role: KfRole | string;
   group: string;
   name: string;
   mode: KfMode | string;
@@ -182,14 +188,14 @@ export type KfNativeBinding = {
     runtimeDir: string,
   ) => {
     setConfig: (
-      category: string,
+      role: string,
       group: string,
       name: string,
       mode: string,
       value: string,
     ) => boolean;
     removeConfig: (
-      category: string,
+      role: string,
       group: string,
       name: string,
       mode: string,

--- a/framework/core/docs/adr/ADR-0024-location-role-and-journal-page-policy.md
+++ b/framework/core/docs/adr/ADR-0024-location-role-and-journal-page-policy.md
@@ -1,0 +1,104 @@
+# ADR-0024: location role replaces trading category and journal page size is storage policy
+
+- Status: accepted
+- Date: 2026-07-08
+- Category: (architecture) yijinjing location identity and storage policy
+- Subsystem: longfist core schema, yijinjing locator, journal page sizing,
+  Python and Node bindings, capability SDK.
+- Related: ADR-0001 defines the journal publication barrier. ADR-0008 defines
+  longfist schema compatibility surfaces. ADR-0018 defines runtime storage as a
+  service. ADR-0022 defines the C++ core as the polyglot action-recording
+  membrane.
+
+## Context
+
+The legacy trading runtime used `category` values such as `md`, `td`,
+`strategy`, `operator`, and `system` in the location path:
+
+```text
+<layout>/<category>/<group>/<name>/<mode>
+```
+
+That vocabulary encoded trading product roles into the journal identity layer.
+It also leaked into journal page sizing: market-data categories received large
+mmap pages, trading categories received medium pages, and some public/sync paths
+received small pages.
+
+For v4 this is the wrong abstraction. Kungfu is being rebuilt as a runtime fact
+ledger for agents, applications, extensions, and storage sync. No deployed v3
+system is expected to run on v4 journals, so this decision intentionally starts
+from the v4 design instead of preserving trading-era names.
+
+## Decision
+
+`category` is removed from the v4 location contract. The location identity is:
+
+```text
+role / group / name / mode
+```
+
+The core enum is `location_role`:
+
+| Role | Path name | Meaning |
+|---|---|---|
+| `SOURCE` | `source` | A fact-producing endpoint. |
+| `SINK` | `sink` | A fact-consuming or command-facing endpoint. |
+| `ACTOR` | `actor` | An active runtime participant such as an agent or app. |
+| `SYSTEM` | `system` | Kungfu-owned infrastructure endpoints. |
+| `SERVICE` | `service` | Long-lived runtime service endpoints. |
+
+The existing path shape remains stable as:
+
+```text
+<layout>/<role>/<group>/<name>/<mode>
+```
+
+The field name in `Location`, `Register`, `Session`, `Config`,
+`RequestWriteToBand`, capability SDK location objects, Python bindings, and Node
+bindings is `role`.
+
+Journal page size is no longer derived from location role. The default page
+size is a storage policy constant. Callers that need a different page size must
+pass an explicit page size through the existing writer/request APIs.
+
+The first v4 default is:
+
+- explicit `page_size` wins;
+- explicit sizes below 2 MiB are clamped to 2 MiB;
+- default journal page size is 16 MiB.
+
+## Consequences
+
+- New code must not introduce `category` for yijinjing location identity.
+- New code must not use role as a proxy for mmap/page capacity. Storage policy
+  belongs to writer/request configuration or future runtime storage config.
+- Python and Node are binding surfaces over the C++ enum and `Location` fields;
+  they must not maintain independent role vocabularies.
+- Fresh v4 runtime directories use `source`, `sink`, `actor`, `system`, and
+  `service` path segments.
+- Existing v3/trading-era journal directories are not a compatibility target for
+  v4 greenfield startup.
+
+## Alternatives considered
+
+- **Keep `category` and only rename enum values.** Rejected. The old field name
+  would keep inviting new v4 code to copy trading-era semantics.
+- **Preserve old role names as aliases.** Rejected for the greenfield v4 start.
+  Compatibility aliases would make old examples look valid.
+- **Derive page size from role with new names.** Rejected. The root problem is
+  coupling identity to capacity. A source can be tiny; a service can be large.
+- **Move page size immediately into full config.** Deferred. The current writer
+  APIs already accept explicit page size, and a constant default is a smaller
+  first step. A config-backed storage profile can be added later without
+  reintroducing role coupling.
+
+## Residual risk
+
+- Some higher-level runtime paths still carry trading-origin names such as
+  broker or trading-data caches. Those are separate product-domain migrations.
+  They may temporarily map old behavior onto neutral roles, but they must not
+  reintroduce `category` as a storage identity.
+- Existing docs or examples outside the compiled/runtime path may still mention
+  the historical term. They should be cleaned when touched.
+- Changing the field name is a breaking schema/API change. That is intentional
+  for v4 before the first real user data baseline is created.

--- a/framework/core/docs/adr/README.md
+++ b/framework/core/docs/adr/README.md
@@ -39,6 +39,7 @@ A record's **Status** says where it stands:
 | [0021](ADR-0021-observer-relative-timeline-projection.md) | accepted | observer-relative timeline projection over causal facts |
 | [0022](ADR-0022-core-action-recording-surface.md) | accepted | core action-recording surface lives in the C++ polyglot membrane |
 | [0023](ADR-0023-frame-integrity-and-msg-type-allocation-gates.md) | accepted | frame integrity starts at the C++ recorder and raw msg_type allocation is gated |
+| [0024](ADR-0024-location-role-and-journal-page-policy.md) | accepted | location role replaces trading category and journal page size is storage policy |
 
 ## Reading by theme
 
@@ -83,7 +84,10 @@ A record's **Status** says where it stands:
   action-recording surface that Python/Node bindings wrap), and
   [0023](ADR-0023-frame-integrity-and-msg-type-allocation-gates.md) (the first
   frame-integrity receipt slice plus the source gate that prevents new raw
-  business msg_type allocations).
+  business msg_type allocations), and
+  [0024](ADR-0024-location-role-and-journal-page-policy.md) (neutral location
+  roles and the rule that journal page size is storage policy, not role
+  identity).
 - **Cross-cutting principle** — [0009](ADR-0009-load-bearing-self-bootstrap.md)
   (load-bearing self-bootstrap), which also names the general law that
   [`docs/architecture.md` § The build dogfoods the SDK](../../../../docs/architecture.md)

--- a/framework/core/src/bindings/node/binding/history.cpp
+++ b/framework/core/src/bindings/node/binding/history.cpp
@@ -23,8 +23,8 @@ Napi::FunctionReference History::constructor = {};
 
 History::History(const Napi::CallbackInfo &info)
     : ObjectWrap(info), locator_(IODevice::ExtractRuntimeLocatorByIndex(info, 0)),
-      ledger_location_(location::make_shared(mode::LIVE, category::SYSTEM, "service", "ledger", locator_)),
-      renderer_location_(location::make_shared(mode::LIVE, category::SYSTEM, "node", "renderer-app", locator_)),
+      ledger_location_(location::make_shared(mode::LIVE, location_role::SYSTEM, "service", "ledger", locator_)),
+      renderer_location_(location::make_shared(mode::LIVE, location_role::SYSTEM, "node", "renderer-app", locator_)),
       profile_(locator_) {}
 
 Napi::Value History::SelectPeriod(const Napi::CallbackInfo &info) {

--- a/framework/core/src/bindings/node/binding/io.cpp
+++ b/framework/core/src/bindings/node/binding/io.cpp
@@ -54,7 +54,7 @@ Napi::Value IODevice::GetAllLocations(const Napi::CallbackInfo &info) {
   for (auto location : locator->list_locations(".*", ".*", ".*", ".*")) {
     auto uid = fmt::format("{:016x}", location->uid);
     auto locationObj = Napi::Object::New(info.Env());
-    locationObj.Set("category", Napi::String::New(info.Env(), get_category_name(location->category)));
+    locationObj.Set("role", Napi::String::New(info.Env(), get_location_role_name(location->role)));
     locationObj.Set("group", Napi::String::New(info.Env(), location->group));
     locationObj.Set("name", Napi::String::New(info.Env(), location->name));
     locationObj.Set("mode", Napi::String::New(info.Env(), get_mode_name(location->mode)));
@@ -71,12 +71,12 @@ location_ptr IODevice::ExtractLocation(const Napi::CallbackInfo &info, int index
     if (info[index].IsObject()) {
       auto obj = info[index].ToObject();
       return location::make_shared(get_mode_by_name(obj.Get("mode").ToString().Utf8Value()),
-                                   get_category_by_name(obj.Get("category").ToString().Utf8Value()),
+                                   get_location_role_by_name(obj.Get("role").ToString().Utf8Value()),
                                    obj.Get("group").ToString().Utf8Value(), obj.Get("name").ToString().Utf8Value(),
                                    locator);
     } else {
       return location::make_shared(get_mode_by_name(info[index + 3].As<Napi::String>().Utf8Value()),
-                                   get_category_by_name(info[index].As<Napi::String>().Utf8Value()),
+                                   get_location_role_by_name(info[index].As<Napi::String>().Utf8Value()),
                                    info[index + 1].As<Napi::String>().Utf8Value(),
                                    info[index + 2].As<Napi::String>().Utf8Value(), locator);
     }

--- a/framework/core/src/bindings/node/binding/journal.cpp
+++ b/framework/core/src/bindings/node/binding/journal.cpp
@@ -151,14 +151,13 @@ Napi::Value Reader::Next(const Napi::CallbackInfo &info) {
 }
 
 Napi::Value Reader::Join(const Napi::CallbackInfo &info) {
-  auto category = longfist::enums::get_category_by_name(info[0].As<Napi::String>().Utf8Value());
+  auto role = longfist::enums::get_location_role_by_name(info[0].As<Napi::String>().Utf8Value());
   auto group = info[1].As<Napi::String>().Utf8Value();
   auto name = info[2].As<Napi::String>().Utf8Value();
   auto mode = longfist::enums::get_mode_by_name(info[3].As<Napi::String>().Utf8Value());
   uint32_t dest_id = info[4].As<Napi::Number>().Int32Value();
   auto from_time = GetBigInt(info, 5);
-  join(std::make_shared<location>(mode, category, group, name, io_device_->get_live_home()->locator), dest_id,
-       from_time);
+  join(std::make_shared<location>(mode, role, group, name, io_device_->get_live_home()->locator), dest_id, from_time);
   return {};
 }
 

--- a/framework/core/src/bindings/node/binding/risk_setting_store.cpp
+++ b/framework/core/src/bindings/node/binding/risk_setting_store.cpp
@@ -24,7 +24,7 @@ inline RiskSetting getConfigFromJs(const Napi::CallbackInfo &info, const locator
   auto config_location = IODevice::ExtractLocation(info, 0, locator);
   if (config_location) {
     query.location_uid = config_location->uid;
-    query.category = config_location->category;
+    query.role = config_location->role;
     query.group = config_location->group;
     query.name = config_location->name;
     query.mode = config_location->mode;
@@ -71,14 +71,14 @@ Napi::Value RiskSettingStore::SetAllRiskSetting(const Napi::CallbackInfo &info) 
       for (int i = 0; i < args.Length(); i++) {
         auto location =
             location::make_shared(get_mode_by_name(args.Get(i).ToObject().Get("mode").ToString().Utf8Value()),
-                                  get_category_by_name(args.Get(i).ToObject().Get("category").ToString().Utf8Value()),
+                                  get_location_role_by_name(args.Get(i).ToObject().Get("role").ToString().Utf8Value()),
                                   args.Get(i).ToObject().Get("group").ToString().Utf8Value(),
                                   args.Get(i).ToObject().Get("name").ToString().Utf8Value(), locator_);
 
         if (location) {
           RiskSetting risk_setting = {};
           risk_setting.location_uid = location->uid;
-          risk_setting.category = location->category;
+          risk_setting.role = location->role;
           risk_setting.group = location->group;
           risk_setting.name = location->name;
           risk_setting.mode = location->mode;

--- a/framework/core/src/bindings/node/binding/watcher.cpp
+++ b/framework/core/src/bindings/node/binding/watcher.cpp
@@ -40,8 +40,8 @@ inline location_ptr GetWatcherLocation(const Napi::CallbackInfo &info) {
 
   auto runtime_dir = info[0].As<Napi::String>().Utf8Value();
   auto name = info[1].As<Napi::String>().Utf8Value();
-  auto result =
-      std::make_shared<location>(mode::LIVE, category::SYSTEM, "node", name, IODevice::GetRuntimeLocator(runtime_dir));
+  auto result = std::make_shared<location>(mode::LIVE, location_role::SYSTEM, "node", name,
+                                           IODevice::GetRuntimeLocator(runtime_dir));
   yijinjing::log::copy_log_settings(result, result->name);
   return result;
 }
@@ -150,7 +150,7 @@ Napi::Value Watcher::GetLocation(const Napi::CallbackInfo &info) {
     return {};
   }
   auto locationObj = Napi::Object::New(info.Env());
-  locationObj.Set("category", Napi::String::New(info.Env(), get_category_name(location->category)));
+  locationObj.Set("role", Napi::String::New(info.Env(), get_location_role_name(location->role)));
   locationObj.Set("group", Napi::String::New(info.Env(), location->group));
   locationObj.Set("name", Napi::String::New(info.Env(), location->name));
   locationObj.Set("mode", Napi::String::New(info.Env(), get_mode_name(location->mode)));
@@ -193,7 +193,7 @@ Napi::Value Watcher::RequestStop(const Napi::CallbackInfo &info) {
   auto app_location = IODevice::ExtractLocation(info, 0, get_locator());
 
   // stop master
-  if (app_location->category == category::SYSTEM && app_location->group == "master") {
+  if (app_location->role == location_role::SYSTEM && app_location->group == "master") {
     if (not has_writer(get_master_command_uid())) {
       return Napi::Boolean::New(info.Env(), false);
     }
@@ -498,7 +498,7 @@ void Watcher::InspectChannel(int64_t trigger_time, const Channel &channel) {
     auto source_location = get_location(channel.source_id);
     auto dest_location = get_location(channel.dest_id);
 
-    if (source_location->category == category::TD) {
+    if (source_location->role == location_role::SINK) {
       if (dest_location->group == "node") { // for as soon as possible to get trading data made by renderer process;
         trading_data_reader_->join(source_location, channel.dest_id, get_begin_time(), 0, Priority::High);
       } else {
@@ -537,28 +537,28 @@ void Watcher::OnRegister(int64_t trigger_time, const Register &register_data) {
   }
 
   auto app_location = get_location(app_uid);
-  if (app_location->category == category::MD or app_location->category == category::TD or
-      app_location->category == category::OPERATOR) {
+  if (app_location->role == location_role::SOURCE or app_location->role == location_role::SINK or
+      app_location->role == location_role::SERVICE) {
     broker_states_map_.insert_or_assign(app_location->uid, int(BrokerState::Pending));
   }
 
-  if (app_location->category == category::MD and app_location->mode == mode::LIVE) {
+  if (app_location->role == location_role::SOURCE and app_location->mode == mode::LIVE) {
     MonitorMarketData(trigger_time, app_location);
   }
 
-  if (app_location->category == category::TD) {
+  if (app_location->role == location_role::SINK) {
     trading_data_reader_->join(app_location, location::PUBLIC, get_begin_time());
   }
 }
 
 void Watcher::OnDeregister(int64_t trigger_time, const Deregister &deregister_data) {
   auto app_location = location::make_shared(deregister_data, get_locator());
-  if (app_location->category == category::MD or app_location->category == category::TD or
-      app_location->category == category::OPERATOR) {
+  if (app_location->role == location_role::SOURCE or app_location->role == location_role::SINK or
+      app_location->role == location_role::SERVICE) {
     broker_states_map_.insert_or_assign(app_location->uid, int(BrokerState::Pending));
   }
 
-  if (app_location->category == category::SYSTEM and app_location->group == "master" and
+  if (app_location->role == location_role::SYSTEM and app_location->group == "master" and
       app_location->name == "master") {
     CancelWorker();
   }

--- a/framework/core/src/bindings/node/binding/watcher.h
+++ b/framework/core/src/bindings/node/binding/watcher.h
@@ -143,11 +143,11 @@ private:
   uint32_t trading_data_count_by_step_ = 0;
 
   typedef longfist::enums::mode mode;
-  typedef longfist::enums::category category;
+  typedef longfist::enums::location_role role;
 
   static constexpr auto bypass = [](practice::apprentice *app, bool bypass_quotes) {
     return rx::filter([&](const event_ptr &event) {
-      return not(app->get_location(event->source())->category == longfist::enums::category::MD and
+      return not(app->get_location(event->source())->role == longfist::enums::location_role::SOURCE and
                  event->msg_type() != longfist::types::Instrument::tag and bypass_quotes);
     });
   };
@@ -185,8 +185,8 @@ private:
   template <typename DataType>
   void UpdateBrokerOperatorState(uint32_t source_id, uint32_t dest_id, const DataType &state) {
     auto source_location = get_location(state.location_uid);
-    if (source_location->category == category::TD or source_location->category == category::MD or
-        source_location->category == category::OPERATOR) {
+    if (source_location->role == role::SINK or source_location->role == role::SOURCE or
+        source_location->role == role::SERVICE) {
       broker_states_map_.insert_or_assign(source_location->uid, int(state.state));
     }
   };
@@ -246,7 +246,7 @@ private:
     try {
       auto target_location = IODevice::ExtractLocation(info, 1, get_locator());
 
-      if (target_location->category == longfist::enums::category::SYSTEM && target_location->group == "master") {
+      if (target_location->role == longfist::enums::location_role::SYSTEM && target_location->group == "master") {
         target_location = master_cmd_location_;
       }
 

--- a/framework/core/src/bindings/python/binding/py-longfist-enums.cpp
+++ b/framework/core/src/bindings/python/binding/py-longfist-enums.cpp
@@ -22,15 +22,15 @@ void bind_enums(py::module &m) {
   m_enums.def("get_mode_name", &get_mode_name);
   m_enums.def("get_mode_by_name", &get_mode_by_name);
 
-  py::enum_<category>(m_enums, "category", py::arithmetic(), "Kungfu Data Category")
-      .value("MD", category::MD)
-      .value("TD", category::TD)
-      .value("STRATEGY", category::STRATEGY)
-      .value("SYSTEM", category::SYSTEM)
-      .value("OPERATOR", category::OPERATOR)
+  py::enum_<location_role>(m_enums, "location_role", py::arithmetic(), "Kungfu Location Role")
+      .value("SOURCE", location_role::SOURCE)
+      .value("SINK", location_role::SINK)
+      .value("ACTOR", location_role::ACTOR)
+      .value("SYSTEM", location_role::SYSTEM)
+      .value("SERVICE", location_role::SERVICE)
       .export_values();
-  m_enums.def("get_category_name", &get_category_name);
-  m_enums.def("get_category_by_name", &get_category_by_name);
+  m_enums.def("get_location_role_name", &get_location_role_name);
+  m_enums.def("get_location_role_by_name", &get_location_role_by_name);
 
   py::enum_<layout>(m_enums, "layout", py::arithmetic(), "Kungfu Data Layout")
       .value("JOURNAL", layout::JOURNAL)

--- a/framework/core/src/bindings/python/binding/py-yijinjing.cpp
+++ b/framework/core/src/bindings/python/binding/py-yijinjing.cpp
@@ -62,10 +62,10 @@ class PyLocator : public locator {
     PYBIND11_OVERLOAD(std::vector<uint32_t>, locator, list_page_id, location, dest_id);
   }
 
-  [[nodiscard]] std::vector<location_ptr> list_locations(const std::string &category, const std::string &group,
+  [[nodiscard]] std::vector<location_ptr> list_locations(const std::string &role, const std::string &group,
                                                          const std::string &name,
                                                          const std::string &mode) const override {
-    PYBIND11_OVERLOAD(std::vector<location_ptr>, locator, list_locations, category, group, name, mode);
+    PYBIND11_OVERLOAD(std::vector<location_ptr>, locator, list_locations, role, group, name, mode);
   }
 
   [[nodiscard]] std::vector<uint32_t> list_location_dest(const location_ptr &location) const override {
@@ -264,10 +264,11 @@ void bind(pybind11::module &&m) {
 
   auto location_class = py::class_<location, location_ptr>(m, "location");
   location_class
-      .def(py::init<mode, category, const std::string &, const std::string &, locator_ptr, uint32_t>(), py::arg("m"),
-           py::arg("c"), py::arg("g"), py::arg("n"), py::arg("l"), py::arg("default_seed") = KUNGFU_HASH_SEED)
+      .def(py::init<mode, location_role, const std::string &, const std::string &, locator_ptr, uint32_t>(),
+           py::arg("m"), py::arg("c"), py::arg("g"), py::arg("n"), py::arg("l"),
+           py::arg("default_seed") = KUNGFU_HASH_SEED)
       .def_readonly("mode", &location::mode)
-      .def_readonly("category", &location::category)
+      .def_readonly("role", &location::role)
       .def_readonly("group", &location::group)
       .def_readonly("name", &location::name)
       .def_readonly("uname", &location::uname)
@@ -291,7 +292,7 @@ void bind(pybind11::module &&m) {
       .def("layout_file", &locator::layout_file)
       .def("get_root", &locator::get_root)
       .def("list_page_id", &locator::list_page_id)
-      .def("list_locations", &locator::list_locations, py::arg("category") = "*", py::arg("group") = "*",
+      .def("list_locations", &locator::list_locations, py::arg("role") = "*", py::arg("group") = "*",
            py::arg("name") = "*", py::arg("mode") = "*")
       .def("list_location_dest", &locator::list_location_dest);
 
@@ -374,7 +375,7 @@ void bind(pybind11::module &&m) {
   assemble_class
       .def(py::init<const std::vector<yijinjing::data::locator_ptr> &, const std::string &, const std::string &,
                     const std::string &, const std::string &>(),
-           py::arg("locators"), py::arg("mode") = "*", py::arg("category") = "*", py::arg("group") = "*",
+           py::arg("locators"), py::arg("mode") = "*", py::arg("role") = "*", py::arg("group") = "*",
            py::arg("name") = "*")
       .def(py::init<const yijinjing::data::location_ptr &, uint32_t, uint32_t, int64_t>(), py::arg("source_location"),
            py::arg("dest_id"), py::arg("assemble_mode") = longfist::enums::AssembleMode::Channel,

--- a/framework/core/src/libkungfu/include/kungfu/longfist/enums.h
+++ b/framework/core/src/libkungfu/include/kungfu/longfist/enums.h
@@ -17,7 +17,7 @@
 
 namespace kungfu::longfist::enums {
 
-// mode / category / layout moved to the schema leaf kungfu/longfist/core.h
+// mode / role / layout moved to the schema leaf kungfu/longfist/core.h
 // (journal-infrastructure enums shared with the yijinjing core). Included above.
 
 // 权限订阅数据类型

--- a/framework/core/src/libkungfu/include/kungfu/longfist/types.h
+++ b/framework/core/src/libkungfu/include/kungfu/longfist/types.h
@@ -803,7 +803,7 @@ KF_DEFINE_DATA_TYPE(                                          //
     OutputKey, 701, PK(location_uid), TIMESTAMP(update_time), //
     (uint64_t, uid64),                                        //
     (uint32_t, location_uid),                                 //
-    (enums::category, category),                              //
+    (enums::location_role, role),                             //
     (enums::mode, mode),                                      //
     (std::string, group),                                     //
     (std::string, name),                                      //
@@ -814,7 +814,7 @@ KF_DEFINE_DATA_TYPE(                                //
     Register, 10101, PK(location_uid), PERPETUAL(), //
     (uint64_t, uid64),                              //
     (uint32_t, location_uid),                       //
-    (enums::category, category),                    //
+    (enums::location_role, role),                   //
     (enums::mode, mode),                            //
     (std::string, group),                           //
     (std::string, name),                            //
@@ -828,7 +828,7 @@ KF_DEFINE_DATA_TYPE(                                  //
     Deregister, 10102, PK(location_uid), PERPETUAL(), //
     (uint64_t, uid64),                                //
     (uint32_t, location_uid),                         //
-    (enums::category, category),                      //
+    (enums::location_role, role),                     //
     (enums::mode, mode),                              //
     (std::string, group),                             //
     (std::string, name),                              //
@@ -839,7 +839,7 @@ KF_DEFINE_DATA_TYPE(                                                     //
     Session, 10103, PK(location_uid, begin_time), TIMESTAMP(begin_time), //
     (uint64_t, uid64),                                                   //
     (uint32_t, location_uid),                                            //
-    (enums::category, category),                                         //
+    (enums::location_role, role),                                        //
     (enums::mode, mode),                                                 //
     (std::string, group),                                                //
     (std::string, name),                                                 //
@@ -881,7 +881,7 @@ KF_DEFINE_DATA_TYPE(                              //
     Config, 10201, PK(location_uid), PERPETUAL(), //
     (uint64_t, uid64),                            //
     (uint32_t, location_uid),                     //
-    (enums::category, category),                  //
+    (enums::location_role, role),                 //
     (std::string, group),                         //
     (std::string, name),                          //
     (uint32_t, seed),                             //
@@ -893,7 +893,7 @@ KF_DEFINE_DATA_TYPE(                                   //
     RiskSetting, 10202, PK(location_uid), PERPETUAL(), //
     (uint64_t, uid64),                                 //
     (uint32_t, location_uid),                          //
-    (enums::category, category),                       //
+    (enums::location_role, role),                      //
     (std::string, group),                              //
     (std::string, name),                               //
     (uint32_t, seed),                                  //
@@ -1033,7 +1033,7 @@ KF_DEFINE_DATA_TYPE(                                          //
     RequestWriteToBand, 10307, PK(location_uid), PERPETUAL(), //
     (uint64_t, uid64),                                        //
     (uint32_t, location_uid),                                 //
-    (enums::category, category),                              //
+    (enums::location_role, role),                             //
     (enums::mode, mode),                                      //
     (std::string, group),                                     //
     (std::string, name),                                      //

--- a/framework/core/src/libkungfu/include/kungfu/yijinjing/practice/hero.h
+++ b/framework/core/src/libkungfu/include/kungfu/yijinjing/practice/hero.h
@@ -25,8 +25,8 @@ namespace kungfu::practice {
 inline yijinjing::data::location_ptr make_system_location(const std::string &group, const std::string &name,
                                                           const yijinjing::data::locator_ptr &locator,
                                                           uint32_t seed = KUNGFU_HASH_SEED) {
-  return yijinjing::data::location::make_shared(locator->get_dir_mode(), longfist::enums::category::SYSTEM, group, name,
-                                                locator, seed);
+  return yijinjing::data::location::make_shared(locator->get_dir_mode(), longfist::enums::location_role::SYSTEM, group,
+                                                name, locator, seed);
 }
 
 typedef std::unordered_map<uint32_t, yijinjing::journal::writer_ptr> WriterMap;

--- a/framework/core/src/libkungfu/src/yijinjing/action_recorder.cpp
+++ b/framework/core/src/libkungfu/src/yijinjing/action_recorder.cpp
@@ -76,7 +76,7 @@ uint64_t checksum_frame(const longfist::types::frame_header &header, const uint8
 action_recorder::action_recorder(const std::string &runtime_dir, const std::string &group, const std::string &name,
                                  uint32_t dest_id, uint64_t stream_id)
     : locator_(std::make_shared<locator>(runtime_dir, mode::LIVE)),
-      location_(location::make_shared(mode::LIVE, category::SYSTEM, group, name, locator_)),
+      location_(location::make_shared(mode::LIVE, location_role::SYSTEM, group, name, locator_)),
       publisher_(std::make_shared<noop_publisher>()), bus_(std::make_shared<bus>(false)),
       writer_(std::make_shared<writer>(location_, dest_id, true, publisher_, false, bus_)), dest_id_(dest_id),
       default_stream_id_(stream_id) {}

--- a/framework/core/src/libkungfu/src/yijinjing/cache/cached.cpp
+++ b/framework/core/src/libkungfu/src/yijinjing/cache/cached.cpp
@@ -98,16 +98,16 @@ void cached::restore_states(const yijinjing::data::location_ptr &location,
     SPDLOG_ERROR("failed to write cache {} {} {}", location->uid, location->uname, ex.what());
   }
 
-  const bool IS_NODE = location->category == category::SYSTEM and location->group == "node";
+  const bool IS_NODE = location->role == location_role::SYSTEM and location->group == "node";
   const bool IS_LEDGER = location->uid == ledger_home_location_->uid;
-  const bool IS_TD = location->category == category::TD;
-  const bool IS_STRATEGY = location->category == category::STRATEGY;
-  const bool IS_OPERATOR = location->category == category::OPERATOR;
-  const bool IS_SYSTEM = location->category == category::SYSTEM;
+  const bool IS_SINK = location->role == location_role::SINK;
+  const bool IS_ACTOR = location->role == location_role::ACTOR;
+  const bool IS_SERVICE = location->role == location_role::SERVICE;
+  const bool IS_SYSTEM = location->role == location_role::SYSTEM;
 
-  if (IS_TD or IS_STRATEGY) {
+  if (IS_SINK or IS_ACTOR) {
     for (const auto &other_location : location->locator->list_locations("*", "*", "*", "*")) {
-      if (other_location->category == category::SYSTEM) {
+      if (other_location->role == location_role::SYSTEM) {
         continue;
       }
 
@@ -126,41 +126,41 @@ void cached::restore_states(const yijinjing::data::location_ptr &location,
     }
   }
 
-  // static data in td
-  if (IS_STRATEGY or IS_OPERATOR or IS_SYSTEM) {
-    for (const auto &td_location : location->locator->list_locations("td", "*", "*", "live")) {
-      auto dests = location->locator->list_location_dest_by_db(td_location);
+  // static data published by sinks
+  if (IS_ACTOR or IS_SERVICE or IS_SYSTEM) {
+    for (const auto &sink_location : location->locator->list_locations("sink", "*", "*", "live")) {
+      auto dests = location->locator->list_location_dest_by_db(sink_location);
       if (std::find(dests.begin(), dests.end(), location::PUBLIC) != dests.end()) {
         try {
-          if (not check_cached_storage_exists(td_location, location::PUBLIC)) {
+          if (not check_cached_storage_exists(sink_location, location::PUBLIC)) {
             continue;
           }
-          ensure_cached_storage(td_location, location::PUBLIC);
-          app_states_shift_.at(td_location->uid).restore_to(StaticDataTypes, writer, location::PUBLIC);
+          ensure_cached_storage(sink_location, location::PUBLIC);
+          app_states_shift_.at(sink_location->uid).restore_to(StaticDataTypes, writer, location::PUBLIC);
 
           // for trading task starting as quick as possible
-          if (IS_STRATEGY and location->group != "default" and is_otc_) {
+          if (IS_ACTOR and location->group != "default" and is_otc_) {
             break;
           }
         } catch (const std::exception &ex) {
-          SPDLOG_ERROR("failed to write static data {} {} {} for target {}", td_location->uname, location::PUBLIC,
+          SPDLOG_ERROR("failed to write static data {} {} {} for target {}", sink_location->uname, location::PUBLIC,
                        ex.what(), location->uname);
         }
       }
     }
   }
 
-  // restore all trading data from tds, including static data in td
+  // restore all trading data from sinks, including static data
   if (IS_SYSTEM) {
-    for (const auto &td_location : location->locator->list_locations("td", "*", "*", "live")) {
-      for (auto dest : location->locator->list_location_dest_by_db(td_location)) {
+    for (const auto &sink_location : location->locator->list_locations("sink", "*", "*", "live")) {
+      for (auto dest : location->locator->list_location_dest_by_db(sink_location)) {
         try {
-          ensure_cached_storage(td_location, dest);
+          ensure_cached_storage(sink_location, dest);
           // tracing-foundation Phase 1: Order/AlgoOrder(交易)拆出闭集 cache,移除其专属 restore;
           // 保留对非交易 StateDataTypes 的泛型 restore。
-          app_states_shift_.at(td_location->uid).restore_to(writer, dest, RESTORE_LIMIT);
+          app_states_shift_.at(sink_location->uid).restore_to(writer, dest, RESTORE_LIMIT);
         } catch (const std::exception &ex) {
-          SPDLOG_ERROR("failed to write cache {} {} {} for target {}", td_location->uname, dest, ex.what(),
+          SPDLOG_ERROR("failed to write cache {} {} {} for target {}", sink_location->uname, dest, ex.what(),
                        location->uname);
         }
       }

--- a/framework/core/src/libkungfu/src/yijinjing/cache/profile.cpp
+++ b/framework/core/src/libkungfu/src/yijinjing/cache/profile.cpp
@@ -13,7 +13,7 @@ using namespace kungfu::yijinjing::data;
 namespace kungfu::cache {
 
 std::string default_db_file(const locator_ptr &locator) {
-  auto config_location = std::make_shared<location>(mode::LIVE, category::SYSTEM, "etc", "kungfu", locator);
+  auto config_location = std::make_shared<location>(mode::LIVE, location_role::SYSTEM, "etc", "kungfu", locator);
   return locator->layout_file(config_location, enums::layout::SQLITE, "config");
 }
 

--- a/framework/core/src/libkungfu/src/yijinjing/index/session.cpp
+++ b/framework/core/src/libkungfu/src/yijinjing/index/session.cpp
@@ -19,7 +19,7 @@ using namespace kungfu::yijinjing::journal;
 namespace kungfu::index {
 std::string get_index_db_file(const yijinjing::io_device_ptr &io_device) {
   auto locator = io_device->get_locator();
-  auto index_location = location::make_shared(mode::LIVE, category::SYSTEM, "journal", "index", locator);
+  auto index_location = location::make_shared(mode::LIVE, location_role::SYSTEM, "journal", "index", locator);
   return locator->layout_file(index_location, layout::SQLITE, "index");
 }
 
@@ -74,7 +74,7 @@ Session &session_builder::open_session(const location_ptr &source_location, int6
   auto &session = pair.first->second;
   if (pair.second) {
     session.location_uid = source_location->uid;
-    session.category = source_location->category;
+    session.role = source_location->role;
     session.group = source_location->group;
     session.name = source_location->name;
     session.mode = source_location->mode;
@@ -143,11 +143,11 @@ void session_builder::rebuild_index_db() {
   for (const auto &location : locator->list_locations("*", "*", "*", "*")) {
     SPDLOG_TRACE("investigating journal for [{:08x}] {}", location->uid, location->uname);
 
-    if (location->category != category::SYSTEM or location->group != "master") {
+    if (location->role != location_role::SYSTEM or location->group != "master") {
       formatstr_to_locations.emplace(fmt::format("{:08x}", location->uid), location);
     }
 
-    if (location->category == category::SYSTEM and location->group == "master" and location->name == "master") {
+    if (location->role == location_role::SYSTEM and location->group == "master" and location->name == "master") {
       formatstr_to_locations.emplace(location->name, location);
     }
 
@@ -171,9 +171,9 @@ void session_builder::rebuild_index_db() {
         open_session(formatstr_to_locations.at(uid_str), frame->gen_time());
       } else if (frame->msg_type() == SessionEnd::tag) {
         close_session(formatstr_to_locations.at(uid_str), frame->gen_time());
-      } else if (location->category != category::SYSTEM or location->group != "master") {
+      } else if (location->role != location_role::SYSTEM or location->group != "master") {
         update_session(frame);
-      } else if (location->category == category::SYSTEM and location->group == "master" and
+      } else if (location->role == location_role::SYSTEM and location->group == "master" and
                  location->name == "master") {
         update_session(frame);
       }

--- a/framework/core/src/libkungfu/src/yijinjing/io/io.cpp
+++ b/framework/core/src/libkungfu/src/yijinjing/io/io.cpp
@@ -33,8 +33,8 @@ class nanomsg_resource : public resource {
 protected:
   nanomsg_resource(const io_device &io_device, bool low_latency, protocol p)
       : io_device_(io_device), low_latency_(low_latency),
-        location_(std::make_shared<data::location>(mode::LIVE, longfist::enums::category::SYSTEM, "master", "master",
-                                                   io_device_.get_live_home()->locator)),
+        location_(std::make_shared<data::location>(mode::LIVE, longfist::enums::location_role::SYSTEM, "master",
+                                                   "master", io_device_.get_live_home()->locator)),
         listen_path_(io_device_.get_url_factory()->make_path_listen(location_, p)),
         dial_path_(io_device_.get_url_factory()->make_path_dial(location_, p)), socket_(p) {}
 
@@ -150,7 +150,7 @@ public:
 
 io_device::io_device(data::location_ptr home, const bool low_latency, const bool lazy)
     : home_(std::move(home)),
-      live_home_(location::make_shared(mode::LIVE, home_->category, home_->group, home_->name, home_->locator)),
+      live_home_(location::make_shared(mode::LIVE, home_->role, home_->group, home_->name, home_->locator)),
       low_latency_(low_latency), lazy_(lazy), begin_time_(time::now_in_nano()),
       bus_(std::make_shared<bus>(is_resource_manager_required())) {
   // keep the guarantees deterministic even when static-library linking drops

--- a/framework/core/src/libkungfu/src/yijinjing/journal/tracer.cpp
+++ b/framework/core/src/libkungfu/src/yijinjing/journal/tracer.cpp
@@ -16,12 +16,14 @@ tracer::tracer(const location_ptr location, bool in, bool out, int64_t begin, in
     : home_(location), reader_(std::make_shared<reader>(true, false, std::make_shared<bus>(false))),
       reader_for_in_(std::make_shared<reader>(true, false, std::make_shared<bus>(false))), in_(in), out_(out),
       begin_time_(begin), end_time_(end == 0 ? INT64_MAX : end) {
-  auto master_home_location = location::make_shared(mode::LIVE, category::SYSTEM, "master", "master", get_locator());
+  auto master_home_location =
+      location::make_shared(mode::LIVE, location_role::SYSTEM, "master", "master", get_locator());
   auto is_master = master_home_location->uid == home_->uid;
   if (in) {
     if (not is_master) {
       auto uid_str = fmt::format("{:08x}", home_->uid);
-      auto master_cmd_location = location::make_shared(mode::LIVE, category::SYSTEM, "master", uid_str, get_locator());
+      auto master_cmd_location =
+          location::make_shared(mode::LIVE, location_role::SYSTEM, "master", uid_str, get_locator());
       if (page::check_page_existed(master_cmd_location, home_->uid)) {
         reader_->join(master_cmd_location, home_->uid, begin_time_);
         reader_for_in_->join(master_cmd_location, home_->uid, begin_time_);
@@ -31,13 +33,13 @@ tracer::tracer(const location_ptr location, bool in, bool out, int64_t begin, in
       }
     } else {
       for (auto target_location : get_locator()->list_locations("*", "*", "*", "*")) {
-        if (target_location->category == category::SYSTEM and target_location->group == "master") {
+        if (target_location->role == location_role::SYSTEM and target_location->group == "master") {
           continue;
         }
         for (auto dest_id : get_locator()->list_location_dest(target_location)) {
           auto uid_str = fmt::format("{:08x}", target_location->uid);
           auto master_cmd_location =
-              location::make_shared(mode::LIVE, category::SYSTEM, "master", uid_str, get_locator());
+              location::make_shared(mode::LIVE, location_role::SYSTEM, "master", uid_str, get_locator());
           if (dest_id == master_cmd_location->uid) {
             if (page::check_page_existed(target_location, dest_id)) {
               reader_->join(target_location, dest_id, begin_time_);

--- a/framework/core/src/libkungfu/src/yijinjing/practice/apprentice.cpp
+++ b/framework/core/src/libkungfu/src/yijinjing/practice/apprentice.cpp
@@ -70,7 +70,7 @@ void apprentice::request_write_to_band(int64_t trigger_time, const location_ptr 
 uint32_t apprentice::request_band(const std::string &band_name, uint64_t page_size) {
   auto io_device = get_io_device();
   auto home = io_device->get_live_home();
-  auto band_location = location::make_shared(home->mode, home->category, home->group, band_name, get_locator());
+  auto band_location = location::make_shared(home->mode, home->role, home->group, band_name, get_locator());
   request_write_to_band(now(), band_location, page_size);
   return band_location->uid;
 }
@@ -289,7 +289,7 @@ void apprentice::checkin() {
   auto home = get_live_home();
   Register register_data{};
   register_data.mode = home->mode;
-  register_data.category = home->category;
+  register_data.role = home->role;
   register_data.group = home->group;
   register_data.name = home->name;
   register_data.seed = home->seed;

--- a/framework/core/src/libkungfu/src/yijinjing/practice/master.cpp
+++ b/framework/core/src/libkungfu/src/yijinjing/practice/master.cpp
@@ -113,7 +113,7 @@ void master::register_app(const event_ptr &event) {
   auto now = yijinjing::time::now_in_nano();
   auto uid_str = fmt::format("{:08x}", app_location->uid);
   auto master_cmd_location =
-      location::make_shared(mode::LIVE, category::SYSTEM, "master", uid_str, home->locator, app_location->seed);
+      location::make_shared(mode::LIVE, location_role::SYSTEM, "master", uid_str, home->locator, app_location->seed);
   SPDLOG_INFO("registering location {} uname {} uid {}, master_cmd_location {} uid {}", uid_str, app_location->uname,
               app_location->uid, master_cmd_location->uname, master_cmd_location->uid);
   try_add_location(event->gen_time(), master_cmd_location);
@@ -196,7 +196,7 @@ void master::react() {
     auto dest = event->dest();
     if (has_location(dest)) {
       auto dest_location = get_location(dest);
-      if (dest_location->category == category::SYSTEM and dest_location->group == "master") {
+      if (dest_location->role == location_role::SYSTEM and dest_location->group == "master") {
         return true;
       }
     }
@@ -268,12 +268,12 @@ void master::feed(const event_ptr &event) {
     return;
   }
 
-  if (get_location(event->source())->category == category::OPERATOR) {
+  if (get_location(event->source())->role == location_role::SERVICE) {
     return;
   }
 
   if (event->msg_type() != Instrument::tag and event->msg_type() != InstrumentFactor::tag and
-      get_location(event->source())->category == category::MD) {
+      get_location(event->source())->role == location_role::SOURCE) {
     return;
   }
 

--- a/framework/core/src/libkungfu/src/yijinjing/util/rocks.cpp
+++ b/framework/core/src/libkungfu/src/yijinjing/util/rocks.cpp
@@ -147,8 +147,8 @@ void rocks::clear_rocksdb(rocksdb::DB **db) {
 void install_master_kv_provider() {
   data::location::master_kv() = [](const data::location &self, const std::string &key) {
     namespace es = longfist::enums;
-    const std::string rocksdb_dir =
-        self.locator->layout_directory(es::layout::MAP, es::category::SYSTEM, "master", "master", self.mode, false);
+    const std::string rocksdb_dir = self.locator->layout_directory(es::layout::MAP, es::location_role::SYSTEM, "master",
+                                                                   "master", self.mode, false);
     SPDLOG_TRACE("rocksdb_dir: {}", rocksdb_dir);
     std::string value{};
     rocks::get_kv(key, value, rocksdb_dir);

--- a/framework/core/src/libkungfu/src/yijinjing/util/webserver.cpp
+++ b/framework/core/src/libkungfu/src/yijinjing/util/webserver.cpp
@@ -17,7 +17,7 @@ constexpr uint64_t PAGE_SIZE = 256;
 
 stream::stream(nng_stream *s, bool is_server) : stream_id_(generate_stream_id(s, is_server)) {
   const std::string group = is_server ? "webserver" : "webclient";
-  location_ = location::make_shared(mode::LIVE, category::SYSTEM, group, std::to_string(stream_id_),
+  location_ = location::make_shared(mode::LIVE, location_role::SYSTEM, group, std::to_string(stream_id_),
                                     std::make_shared<locator>(mode::LIVE));
   writer_ = std::make_shared<writer>(location_, location::PUBLIC, false, std::make_shared<noop_publisher>(), true,
                                      std::make_shared<bus>(false), PAGE_SIZE);

--- a/framework/core/src/libyijinjing/include/kungfu/longfist/core.h
+++ b/framework/core/src/libyijinjing/include/kungfu/longfist/core.h
@@ -5,8 +5,8 @@
 //
 // Holds the fact-ledger journal schema the yijinjing core needs, and ONLY that:
 //   - frame/page packs: frame_header (tag 0), page_header (tag 1)
-//   - journal enums: FrameDataType, PageStatus, mode, category, layout, Priority
-//   - Location (tag 10205): the journal-endpoint pack (mode/category/group/name)
+//   - journal enums: FrameDataType, PageStatus, mode, role, layout, Priority
+//   - Location (tag 10205): the journal-endpoint pack (mode/role/group/name)
 // All of the above are journal infrastructure. Business/trading types
 // (Order / Trade / Quote / Position / ...) live in types.h / enums.h and are NOT
 // visible here, so a pure journal core includes only this leaf and never pulls
@@ -80,7 +80,7 @@ KF_JSON_SERIALIZE_ENUM(PageStatus, {
                                    })
 
 // Journal-infrastructure enums the yijinjing core (locator / journal) needs.
-// These describe where/how a journal lives (mode / category / layout) and event
+// These describe where/how a journal lives (mode / role / layout) and event
 // scheduling priority -- pure journal schema, NOT trading types. They live here
 // (the leaf) so a pure journal core includes only core.h. Their integer values,
 // json names and helper mappings are moved verbatim from enums.h.
@@ -123,45 +123,45 @@ inline mode get_mode_by_name(const std::string &name) {
   return mode::LIVE;
 }
 
-enum class category : int8_t { MD, TD, STRATEGY, SYSTEM, OPERATOR };
+enum class location_role : int8_t { SOURCE, SINK, ACTOR, SYSTEM, SERVICE };
 
-KF_JSON_SERIALIZE_ENUM(category, {
-                                     {category::MD, "MD"},
-                                     {category::TD, "TD"},
-                                     {category::STRATEGY, "STRATEGY"},
-                                     {category::SYSTEM, "SYSTEM"},
-                                     {category::OPERATOR, "OPERATOR"},
-                                 })
+KF_JSON_SERIALIZE_ENUM(location_role, {
+                                          {location_role::SOURCE, "SOURCE"},
+                                          {location_role::SINK, "SINK"},
+                                          {location_role::ACTOR, "ACTOR"},
+                                          {location_role::SYSTEM, "SYSTEM"},
+                                          {location_role::SERVICE, "SERVICE"},
+                                      })
 
-inline std::ostream &operator<<(std::ostream &os, category t) { return os << int32_t(t); }
+inline std::ostream &operator<<(std::ostream &os, location_role t) { return os << int32_t(t); }
 
-inline std::string get_category_name(category c) {
-  switch (c) {
-  case category::MD:
-    return "md";
-  case category::TD:
-    return "td";
-  case category::STRATEGY:
-    return "strategy";
-  case category::OPERATOR:
-    return "operator";
-  case category::SYSTEM:
+inline std::string get_location_role_name(location_role role) {
+  switch (role) {
+  case location_role::SOURCE:
+    return "source";
+  case location_role::SINK:
+    return "sink";
+  case location_role::ACTOR:
+    return "actor";
+  case location_role::SERVICE:
+    return "service";
+  case location_role::SYSTEM:
   default:
     return "system";
   }
 }
 
-inline category get_category_by_name(const std::string &name) {
-  if (name == "md")
-    return category::MD;
-  else if (name == "td")
-    return category::TD;
-  else if (name == "strategy")
-    return category::STRATEGY;
-  else if (name == "operator")
-    return category::OPERATOR;
+inline location_role get_location_role_by_name(const std::string &name) {
+  if (name == "source")
+    return location_role::SOURCE;
+  else if (name == "sink")
+    return location_role::SINK;
+  else if (name == "actor")
+    return location_role::ACTOR;
+  else if (name == "service")
+    return location_role::SERVICE;
   else
-    return category::SYSTEM;
+    return location_role::SYSTEM;
 }
 
 enum class layout : int8_t { JOURNAL, SQLITE, NANOMSG, LOG, MAP };
@@ -266,7 +266,7 @@ KF_DEFINE_PACK_TYPE(                          //
 // type tag 10051 and stays registered in the full type registry (longfist.h) verbatim.
 KF_DEFINE_MARK_TYPE(PageEnd, 10051);
 
-// Location identifies a journal endpoint (mode/category/group/name). The yijinjing
+// Location identifies a journal endpoint (mode/role/group/name). The yijinjing
 // core's locator/location model it, so it lives in the leaf. It keeps type tag
 // 10205 and stays registered in the full type registry (longfist.h) verbatim -- only its
 // definition moves here, exactly as frame_header/page_header did.
@@ -274,7 +274,7 @@ KF_DEFINE_DATA_TYPE(                         //
     Location, 10205, PK(uid64), PERPETUAL(), //
     (uint64_t, uid64),                       //
     (uint32_t, location_uid),                //
-    (enums::category, category),             //
+    (enums::location_role, role),            //
     (enums::mode, mode),                     //
     (std::string, group),                    //
     (std::string, name),                     //

--- a/framework/core/src/libyijinjing/include/kungfu/yijinjing/common.h
+++ b/framework/core/src/libyijinjing/include/kungfu/yijinjing/common.h
@@ -88,7 +88,7 @@ public:
   [[nodiscard]] virtual std::string layout_dir(const location_ptr &location, longfist::enums::layout layout,
                                                bool create_not_exist = true) const;
 
-  [[nodiscard]] std::string layout_directory(longfist::enums::layout layout, longfist::enums::category c,
+  [[nodiscard]] std::string layout_directory(longfist::enums::layout layout, longfist::enums::location_role c,
                                              const std::string &g, const std::string &n, longfist::enums::mode m,
                                              bool create_not_exist = true) const;
 
@@ -99,7 +99,7 @@ public:
 
   [[nodiscard]] virtual std::vector<uint32_t> list_page_id(const location_ptr &location, uint32_t dest_id) const;
 
-  [[nodiscard]] virtual std::vector<location_ptr> list_locations(const std::string &category, const std::string &group,
+  [[nodiscard]] virtual std::vector<location_ptr> list_locations(const std::string &role, const std::string &group,
                                                                  const std::string &name,
                                                                  const std::string &mode) const;
 
@@ -137,7 +137,7 @@ struct location : public std::enable_shared_from_this<location>, public longfist
   const std::string uname;
   uint32_t uid;
 
-  location(longfist::enums::mode m, longfist::enums::category c, std::string g, std::string n, locator_ptr l,
+  location(longfist::enums::mode m, longfist::enums::location_role c, std::string g, std::string n, locator_ptr l,
            uint32_t default_seed = KUNGFU_HASH_SEED);
 
   bool static is_verify_location();
@@ -155,7 +155,7 @@ struct location : public std::enable_shared_from_this<location>, public longfist
     t.uid64 = uid64;
     t.location_uid = location_uid;
     t.mode = mode;
-    t.category = category;
+    t.role = role;
     t.group = group;
     t.name = name;
     t.seed = seed;
@@ -166,7 +166,7 @@ struct location : public std::enable_shared_from_this<location>, public longfist
     t.uid64 = uid64;
     t.location_uid = location_uid;
     t.mode = mode;
-    t.category = category;
+    t.role = role;
     t.group = group;
     t.name = name;
     t.seed = seed;
@@ -174,17 +174,17 @@ struct location : public std::enable_shared_from_this<location>, public longfist
   }
 
   template <typename T> static inline location_ptr make_shared(T msg, locator_ptr l) {
-    return std::make_shared<location>(msg.mode, msg.category, msg.group, msg.name, l, msg.seed);
+    return std::make_shared<location>(msg.mode, msg.role, msg.group, msg.name, l, msg.seed);
   }
 
-  static inline location_ptr make_shared(longfist::enums::mode m, longfist::enums::category c, const std::string &g,
-                                         const std::string &n, const locator_ptr &l,
+  static inline location_ptr make_shared(longfist::enums::mode m, longfist::enums::location_role c,
+                                         const std::string &g, const std::string &n, const locator_ptr &l,
                                          uint32_t default_seed = KUNGFU_HASH_SEED) {
     return std::make_shared<location>(m, c, g, n, l, default_seed);
   }
   bool operator==(const location &another) const {
-    return locator->get_root() == another.locator->get_root() and category == another.category and
-           group == another.group and name == another.name and mode == another.mode;
+    return locator->get_root() == another.locator->get_root() and role == another.role and group == another.group and
+           name == another.name and mode == another.mode;
   }
 };
 } // namespace data

--- a/framework/core/src/libyijinjing/include/kungfu/yijinjing/journal/assemble.h
+++ b/framework/core/src/libyijinjing/include/kungfu/yijinjing/journal/assemble.h
@@ -51,9 +51,9 @@ private:
 class assemble {
 public:
   explicit assemble(const std::vector<data::locator_ptr> &locators, const std::string &mode = "*",
-                    const std::string &category = "*", const std::string &group = "*", const std::string &name = "*");
+                    const std::string &role = "*", const std::string &group = "*", const std::string &name = "*");
 
-  explicit assemble(const data::locator_ptr &locator, const std::string &mode = "*", const std::string &category = "*",
+  explicit assemble(const data::locator_ptr &locator, const std::string &mode = "*", const std::string &role = "*",
                     const std::string &group = "*", const std::string &name = "*");
 
   explicit assemble(const data::location_ptr &source_location, uint32_t dest_id,
@@ -143,7 +143,7 @@ protected:
 
 private:
   const std::string mode_;
-  const std::string category_;
+  const std::string role_;
   const std::string group_;
   const std::string name_;
   publisher_ptr publisher_;

--- a/framework/core/src/libyijinjing/src/io/locator.cpp
+++ b/framework/core/src/libyijinjing/src/io/locator.cpp
@@ -79,13 +79,14 @@ bool locator::has_env(const std::string &name) const { return std::getenv(name.c
 
 std::string locator::get_env(const std::string &name) const { return std::getenv(name.c_str()); }
 
-std::string locator::layout_directory(longfist::enums::layout layout, longfist::enums::category c, const std::string &g,
-                                      const std::string &n, longfist::enums::mode m, bool create_not_exist) const {
-  auto dir = root_ /                       //
-             es::get_layout_name(layout) / //
-             es::get_category_name(c) /    //
-             g /                           //
-             n /                           //
+std::string locator::layout_directory(longfist::enums::layout layout, longfist::enums::location_role c,
+                                      const std::string &g, const std::string &n, longfist::enums::mode m,
+                                      bool create_not_exist) const {
+  auto dir = root_ /                         //
+             es::get_layout_name(layout) /   //
+             es::get_location_role_name(c) / //
+             g /                             //
+             n /                             //
              es::get_mode_name(m);
   if (create_not_exist && not fs::exists(dir)) {
     fs::create_directories(dir);
@@ -94,8 +95,7 @@ std::string locator::layout_directory(longfist::enums::layout layout, longfist::
 }
 
 std::string locator::layout_dir(const location_ptr &location, es::layout layout, bool create_not_exist) const {
-  return layout_directory(layout, location->category, location->group, location->name, location->mode,
-                          create_not_exist);
+  return layout_directory(layout, location->role, location->group, location->name, location->mode, create_not_exist);
 }
 
 std::string locator::layout_file(const location_ptr &location, es::layout layout, const std::string &name) const {
@@ -107,11 +107,11 @@ std::string locator::default_to_system_db(const location_ptr &location, const st
   auto sqlite_layout = es::layout::SQLITE;
   auto db_file = layout_file(location, sqlite_layout, name);
   if (not fs::exists(db_file)) {
-    auto system_db_file = root_ /                                     //
-                          es::get_layout_name(sqlite_layout) /        //
-                          es::get_category_name(location->category) / //
-                          location->group /                           //
-                          location->name /                            //
+    auto system_db_file = root_ /                                      //
+                          es::get_layout_name(sqlite_layout) /         //
+                          es::get_location_role_name(location->role) / //
+                          location->group /                            //
+                          location->name /                             //
                           es::get_mode_name(location->mode);
     fs::copy(system_db_file, db_file);
   }
@@ -140,9 +140,9 @@ static constexpr auto lambda_w = [](const std::string &pattern) { return pattern
 
 static constexpr auto lambda_g = [](const std::string &pattern) { return fmt::format("({})", lambda_w(pattern)); };
 
-std::vector<location_ptr> locator::list_locations(const std::string &category, const std::string &group,
+std::vector<location_ptr> locator::list_locations(const std::string &role, const std::string &group,
                                                   const std::string &name, const std::string &mode) const {
-  fs::path search_path = root_ / ".*" / lambda_g(category) / lambda_g(group) / lambda_g(name) / lambda_g(mode);
+  fs::path search_path = root_ / ".*" / lambda_g(role) / lambda_g(group) / lambda_g(name) / lambda_g(mode);
   std::string pattern = std::regex_replace(search_path.string(), std::regex("\\\\"), "\\\\");
   std::regex search_regex(pattern);
   std::unordered_map<uint32_t, location_ptr> avoid_repeat_locations = {};
@@ -157,13 +157,13 @@ std::vector<location_ptr> locator::list_locations(const std::string &category, c
       if (mode_local == es::mode::LIVE and mode_name != "live") {
         continue;
       }
-      std::string category_name = match[1].str();
-      auto category_local = es::get_category_by_name(category_name);
-      if (category_local == es::category::SYSTEM and category_name != "system") {
+      std::string role_name = match[1].str();
+      auto role_local = es::get_location_role_by_name(role_name);
+      if (role_local == es::location_role::SYSTEM and role_name != "system") {
         continue;
       }
       auto l = location::make_shared(mode_local,     //
-                                     category_local, //
+                                     role_local,     //
                                      match[2].str(), //
                                      match[3].str(), //
                                      std::make_shared<locator>(root_.string()));
@@ -218,12 +218,12 @@ bool locator::operator==(const locator &another) const {
   return dir_mode_ == another.dir_mode_ and root_.string() == another.root_.string();
 }
 
-location::location(longfist::enums::mode m, longfist::enums::category c, std::string g, std::string n, locator_ptr l,
-                   uint32_t default_seed)
-    : locator(std::move(l)), uname(fmt::format("{}/{}/{}/{}", longfist::enums::get_category_name(c), g, n,
+location::location(longfist::enums::mode m, longfist::enums::location_role c, std::string g, std::string n,
+                   locator_ptr l, uint32_t default_seed)
+    : locator(std::move(l)), uname(fmt::format("{}/{}/{}/{}", longfist::enums::get_location_role_name(c), g, n,
                                                longfist::enums::get_mode_name(m))) {
   uid64 = util::hash_str_64(uname);
-  category = c;
+  role = c;
   group = std::move(g);
   name = std::move(n);
   mode = m;

--- a/framework/core/src/libyijinjing/src/journal/assemble.cpp
+++ b/framework/core/src/libyijinjing/src/journal/assemble.cpp
@@ -39,13 +39,13 @@ void copy_sink::put(const data::location_ptr &location, uint32_t dest_id, const 
   writers.at(dest_id)->copy_frame(frame);
 }
 
-assemble::assemble(const data::locator_ptr &locator, const std::string &mode, const std::string &category,
+assemble::assemble(const data::locator_ptr &locator, const std::string &mode, const std::string &role,
                    const std::string &group, const std::string &name)
-    : mode_(mode), category_(category), group_(group), name_(name), publisher_(std::make_shared<noop_publisher>()) {
+    : mode_(mode), role_(role), group_(group), name_(name), publisher_(std::make_shared<noop_publisher>()) {
   locators_.push_back(locator);
   readers_.push_back(std::make_shared<reader>(true, false, std::make_shared<bus>(false)));
   auto reader = readers_.back();
-  for (auto &location : locator->list_locations(category, group, name, mode)) {
+  for (auto &location : locator->list_locations(role, group, name, mode)) {
     for (auto dest_id : locator->list_location_dest(location)) {
       reader->join(location, dest_id, 0);
     }
@@ -53,14 +53,14 @@ assemble::assemble(const data::locator_ptr &locator, const std::string &mode, co
   sort();
 }
 
-assemble::assemble(const std::vector<data::locator_ptr> &locators, const std::string &mode, const std::string &category,
+assemble::assemble(const std::vector<data::locator_ptr> &locators, const std::string &mode, const std::string &role,
                    const std::string &group, const std::string &name)
-    : mode_(mode), category_(category), group_(group), name_(name), publisher_(std::make_shared<noop_publisher>()) {
+    : mode_(mode), role_(role), group_(group), name_(name), publisher_(std::make_shared<noop_publisher>()) {
   for (auto &locator : locators) {
     locators_.push_back(locator);
     readers_.push_back(std::make_shared<reader>(true, false, std::make_shared<bus>(false)));
     auto reader = readers_.back();
-    for (auto &location : locator->list_locations(category, group, name, mode)) {
+    for (auto &location : locator->list_locations(role, group, name, mode)) {
       for (auto dest_id : locator->list_location_dest(location)) {
         reader->join(location, dest_id, 0);
       }
@@ -71,7 +71,7 @@ assemble::assemble(const std::vector<data::locator_ptr> &locators, const std::st
 
 assemble::assemble(const data::location_ptr &source_location, uint32_t dest_id, uint32_t assemble_mode,
                    int64_t from_time)
-    : mode_("*"), category_("*"), group_("*"), name_("*"), publisher_(std::make_shared<noop_publisher>()) {
+    : mode_("*"), role_("*"), group_("*"), name_("*"), publisher_(std::make_shared<noop_publisher>()) {
   from_time_ = from_time;
   locators_.clear();
   readers_.clear();
@@ -116,15 +116,15 @@ assemble::assemble(const data::location_ptr &source_location, uint32_t dest_id, 
 }
 
 assemble assemble::operator+(assemble &other) {
-  if (mode_ != other.mode_ or category_ != other.category_ or group_ != other.group_ or name_ != other.name_) {
-    auto msg = fmt::format("assemble incompatible: {}/{}/{}/{}, {}/{}/{}/{}", category_, group_, name_, mode_,
-                           other.category_, other.group_, other.name_, other.mode_);
+  if (mode_ != other.mode_ or role_ != other.role_ or group_ != other.group_ or name_ != other.name_) {
+    auto msg = fmt::format("assemble incompatible: {}/{}/{}/{}, {}/{}/{}/{}", role_, group_, name_, mode_, other.role_,
+                           other.group_, other.name_, other.mode_);
     throw assemble_exception(msg);
   }
   std::vector<data::locator_ptr> merged_locators = {};
   merged_locators.insert(merged_locators.end(), locators_.begin(), locators_.end());
   merged_locators.insert(merged_locators.end(), other.locators_.begin(), other.locators_.end());
-  return assemble(merged_locators, mode_, category_, group_, name_);
+  return assemble(merged_locators, mode_, role_, group_, name_);
 }
 
 assemble &assemble::operator+=(const assemble &other) {

--- a/framework/core/src/libyijinjing/src/journal/page.cpp
+++ b/framework/core/src/libyijinjing/src/journal/page.cpp
@@ -6,6 +6,11 @@
 #include <kungfu/yijinjing/util/os.h>
 
 namespace kungfu::yijinjing::journal {
+
+namespace {
+constexpr uint64_t MIN_PAGE_SIZE_MB = 2;
+constexpr uint64_t DEFAULT_PAGE_SIZE_MB = 16;
+} // namespace
 using namespace longfist::types;
 
 page::page(data::location_ptr location, uint32_t dest_id, uint32_t page_id, size_t size, bool lazy, bool is_writing,
@@ -150,28 +155,15 @@ uint32_t page::find_page_id(const data::location_ptr &location, uint32_t dest_id
 
 uint64_t page::find_page_size(const data::location_ptr &location, uint32_t dest_id, uint64_t page_size) {
   if (page_size > 0) {
-    if (page_size < 2) {
-      return 2 * MB;
+    if (page_size < MIN_PAGE_SIZE_MB) {
+      return MIN_PAGE_SIZE_MB * MB;
     }
     return std::min<uint64_t>(page_size * MB, UINT64_MAX / 2);
   }
 
-  if (location->category == longfist::enums::category::MD && dest_id != data::location::SYNC) {
-    return 128 * MB;
-  }
-  if (location->mode == longfist::enums::mode::BACKTEST || location->mode == longfist::enums::mode::DATA) {
-    return 128 * MB;
-  }
-  if (location->category == longfist::enums::category::TD) {
-    return 16 * MB;
-  }
-  if ((location->category == longfist::enums::category::STRATEGY ||
-       location->category == longfist::enums::category::OPERATOR ||
-       location->category == longfist::enums::category::SYSTEM) &&
-      (dest_id != data::location::PUBLIC and dest_id != data::location::SYNC)) {
-    return 16 * MB;
-  }
-  return 2 * MB;
+  (void)location;
+  (void)dest_id;
+  return DEFAULT_PAGE_SIZE_MB * MB;
 }
 
 bool page::check_page_existed(const data::location_ptr &location, uint32_t dest_id) {

--- a/framework/core/src/python/kungfu/atlas/store.py
+++ b/framework/core/src/python/kungfu/atlas/store.py
@@ -37,7 +37,7 @@ def _location(runtime_dir):
     locator = yjj.locator(runtime_dir)
     return yjj.location(
         lf.enums.mode.LIVE,
-        lf.enums.category.SYSTEM,
+        lf.enums.location_role.SYSTEM,
         ATLAS_GROUP,
         ATLAS_NAME,
         locator,
@@ -211,7 +211,7 @@ class ImportStore:
             "source": {
                 "root": self.runtime_dir,
                 "mode": "live",
-                "category": "system",
+                "role": "system",
                 "group": ATLAS_GROUP,
                 "name": ATLAS_NAME,
                 "dest": PUBLIC_DEST,

--- a/framework/core/src/python/kungfu/cli/commands/__init__.py
+++ b/framework/core/src/python/kungfu/cli/commands/__init__.py
@@ -187,21 +187,21 @@ def kfc(ctx, home, extension_path, log_level, name, stage, env_verify_location):
     ctx.backtest_locator = yjj.locator(lf.enums.mode.BACKTEST)
     ctx.config_location = yjj.location(
         lf.enums.mode.LIVE,
-        lf.enums.category.SYSTEM,
+        lf.enums.location_role.SYSTEM,
         "etc",
         "kungfu",
         ctx.runtime_locator,
     )
     ctx.console_location = yjj.location(
         lf.enums.mode.LIVE,
-        lf.enums.category.SYSTEM,
+        lf.enums.location_role.SYSTEM,
         "service",
         "console",
         ctx.runtime_locator,
     )
     ctx.index_location = yjj.location(
         lf.enums.mode.LIVE,
-        lf.enums.category.SYSTEM,
+        lf.enums.location_role.SYSTEM,
         "journal",
         "index",
         ctx.runtime_locator,

--- a/framework/core/src/python/kungfu/cli/commands/journal.py
+++ b/framework/core/src/python/kungfu/cli/commands/journal.py
@@ -42,23 +42,23 @@ journal_command_context = kfc.pass_context(
 )
 @click.option(
     "-c",
-    "--category",
+    "--role",
     default="*",
-    type=click.Choice(list(kfj.CATEGORIES)),
-    help="category",
+    type=click.Choice(list(kfj.ROLES)),
+    help="role",
 )
 @click.option("-g", "--group", type=str, default="*", help="group")
 @click.option("-n", "--name", type=str, default="*", help="name")
 @click.help_option("-h", "--help")
 @kfc.pass_context()
-def journal(ctx, mode, category, group, name):
+def journal(ctx, mode, role, group, name):
     ctx.low_latency = False
     ctx.mode = mode
-    ctx.category = category
+    ctx.role = role
     ctx.group = group
     ctx.name = name
     ctx.location = yjj.location(
-        kfj.MODES[mode], kfj.CATEGORIES[category], group, name, ctx.runtime_locator
+        kfj.MODES[mode], kfj.ROLES[role], group, name, ctx.runtime_locator
     )
     ctx.logger = create_logger("journal", ctx.log_level, ctx.console_location)
 
@@ -72,7 +72,7 @@ def journal(ctx, mode, category, group, name):
     "--sortby",
     default="begin_time",
     type=click.Choice(
-        ["begin_time", "end_time", "duration", "mode", "category", "group", "name"]
+        ["begin_time", "end_time", "duration", "mode", "role", "group", "name"]
     ),
     help="sorting method",
 )
@@ -298,14 +298,12 @@ def export_logs(ctx, src_dir, dst_dir):
     for log_file in glob.glob(search_path):
         match = LOG_PATTERN.match(log_file[len(src_dir) + 1 :])
         if match:
-            category = match.group(1)
+            role = match.group(1)
             group = match.group(2)
             name = match.group(3)
             mode = match.group(4)
             date = match.group(6)
-            archive_path = os.path.join(
-                dst_dir, date, category, group, name, "log", mode
-            )
+            archive_path = os.path.join(dst_dir, date, role, group, name, "log", mode)
             if not os.path.exists(archive_path):
                 os.makedirs(archive_path)
             archive_log = os.path.join(archive_path, os.path.basename(log_file))
@@ -332,7 +330,7 @@ def make_archive(ctx, archive_format, archive_date):
 def update_index_db(ctx):
     index_location = yjj.location(
         lf.enums.mode.LIVE,
-        lf.enums.category.SYSTEM,
+        lf.enums.location_role.SYSTEM,
         "journal",
         "index",
         ctx.runtime_locator,

--- a/framework/core/src/python/kungfu/rewind/bundle.py
+++ b/framework/core/src/python/kungfu/rewind/bundle.py
@@ -30,7 +30,7 @@ def emit(
 ) -> str:
     """Write schemas/<hash>.bfbs and manifest.json under bundle_dir.
 
-    source: dict with mode/category/group/name/dest describing the journal
+    source: dict with mode/role/group/name/dest describing the journal
     location the run was written to. Returns the manifest path.
     """
     blob = read_schema_blob()

--- a/framework/core/src/python/kungfu/rewind/managed_cli.py
+++ b/framework/core/src/python/kungfu/rewind/managed_cli.py
@@ -63,7 +63,7 @@ class ManagedRunCliReport:
 def _open_journal(runtime_dir: str, run_id: str) -> Any:
     loc = yjj.locator(runtime_dir)
     location = yjj.location(
-        lf.enums.mode.LIVE, lf.enums.category.SYSTEM, "rewind", run_id, loc
+        lf.enums.mode.LIVE, lf.enums.location_role.SYSTEM, "rewind", run_id, loc
     )
     pub = yjj.noop_publisher()
     bus = yjj.bus(False)
@@ -236,7 +236,7 @@ def run_and_report(
         runtime_dir,
         {
             "mode": "LIVE",
-            "category": "SYSTEM",
+            "role": "SYSTEM",
             "group": "rewind",
             "name": run_id,
             "dest": 0,

--- a/framework/core/src/python/kungfu/rewind/replay.py
+++ b/framework/core/src/python/kungfu/rewind/replay.py
@@ -64,7 +64,7 @@ def read_frames(runtime_dir: str, run_id: str) -> list[tuple[int, Any, bytes]]:
     """All rewind frames of a run in gen_time order: (msg_type, header, bytes)."""
     locator = yjj.locator(runtime_dir)
     location = yjj.location(
-        lf.enums.mode.LIVE, lf.enums.category.SYSTEM, "rewind", run_id, locator
+        lf.enums.mode.LIVE, lf.enums.location_role.SYSTEM, "rewind", run_id, locator
     )
     frames: list[tuple[int, Any, bytes]] = []
     for msg_type in MSG_TYPE_NAMES:

--- a/framework/core/src/python/kungfu/rewind/reporting.py
+++ b/framework/core/src/python/kungfu/rewind/reporting.py
@@ -55,7 +55,7 @@ def new_run_id() -> str:
 def _open_journal(runtime_dir: str, run_id: str) -> Any:
     loc = yjj.locator(runtime_dir)
     location = yjj.location(
-        lf.enums.mode.LIVE, lf.enums.category.SYSTEM, "rewind", run_id, loc
+        lf.enums.mode.LIVE, lf.enums.location_role.SYSTEM, "rewind", run_id, loc
     )
     pub = yjj.noop_publisher()
     bus = yjj.bus(False)
@@ -65,7 +65,7 @@ def _open_journal(runtime_dir: str, run_id: str) -> Any:
 def _source(run_id: str, runtime_dir: str) -> dict[str, Any]:
     return {
         "mode": "LIVE",
-        "category": "SYSTEM",
+        "role": "SYSTEM",
         "group": "rewind",
         "name": run_id,
         "dest": 0,

--- a/framework/core/src/python/kungfu/rewind/supervisor.py
+++ b/framework/core/src/python/kungfu/rewind/supervisor.py
@@ -73,7 +73,7 @@ class Supervisor:
         self.locator = yjj.locator(runtime_dir)
         self.location = yjj.location(
             lf.enums.mode.LIVE,
-            lf.enums.category.SYSTEM,
+            lf.enums.location_role.SYSTEM,
             "rewind",
             self.run_id,
             self.locator,
@@ -218,7 +218,7 @@ class Supervisor:
                 self.runtime_dir,
                 {
                     "mode": "LIVE",
-                    "category": "SYSTEM",
+                    "role": "SYSTEM",
                     "group": "rewind",
                     "name": self.run_id,
                     "dest": PUBLIC_DEST,

--- a/framework/core/src/python/kungfu/work/store.py
+++ b/framework/core/src/python/kungfu/work/store.py
@@ -78,7 +78,7 @@ def _location(runtime_dir):
     locator = yjj.locator(runtime_dir)
     return yjj.location(
         lf.enums.mode.LIVE,
-        lf.enums.category.SYSTEM,
+        lf.enums.location_role.SYSTEM,
         WORK_GROUP,
         WORK_NAME,
         locator,
@@ -169,7 +169,7 @@ class WorkStore:
             "source": {
                 "root": self.runtime_dir,
                 "mode": "live",
-                "category": "system",
+                "role": "system",
                 "group": WORK_GROUP,
                 "name": WORK_NAME,
                 "dest": PUBLIC_DEST,

--- a/framework/core/src/python/kungfu/yijinjing/__init__.py
+++ b/framework/core/src/python/kungfu/yijinjing/__init__.py
@@ -13,7 +13,7 @@ LAYOUT_LOCATION_REGEX = "{}{}{}{}{}{}{}{}{}{}{}".format(
     r"layout",
     os_sep,  # layout
     r"(.*)",
-    os_sep,  # category
+    os_sep,  # role
     r"(.*)",
     os_sep,  # group
     r"(.*)",
@@ -28,7 +28,7 @@ JOURNAL_LOCATION_REGEX = "{}{}{}{}{}{}{}{}{}".format(
     r"journal",
     os_sep,
     r"(.*)",
-    os_sep,  # category
+    os_sep,  # role
     r"(.*)",
     os_sep,  # group
     r"(.*)",
@@ -41,7 +41,7 @@ JOURNAL_PAGE_REGEX = "{}{}{}{}{}{}{}{}{}{}{}".format(
     r"journal",
     os_sep,  # mode
     r"(.*)",
-    os_sep,  # category
+    os_sep,  # role
     r"(.*)",
     os_sep,  # group
     r"(.*)",
@@ -56,7 +56,7 @@ LOG_REGEX = "{}{}{}{}{}{}{}{}{}{}{}".format(
     r"log",
     os_sep,
     r"(.*)",
-    os_sep,  # category
+    os_sep,  # role
     r"(.*)",
     os_sep,  # group
     r"(.*)",
@@ -78,13 +78,13 @@ MODES = {
     "*": lf.enums.mode.LIVE,
 }
 
-CATEGORIES = {
-    "md": lf.enums.category.MD,
-    "td": lf.enums.category.TD,
-    "strategy": lf.enums.category.STRATEGY,
-    "system": lf.enums.category.SYSTEM,
-    "operator": lf.enums.category.OPERATOR,
-    "*": lf.enums.category.SYSTEM,
+ROLES = {
+    "source": lf.enums.location_role.SOURCE,
+    "sink": lf.enums.location_role.SINK,
+    "actor": lf.enums.location_role.ACTOR,
+    "system": lf.enums.location_role.SYSTEM,
+    "service": lf.enums.location_role.SERVICE,
+    "*": lf.enums.location_role.SYSTEM,
 }
 
 ARCHIVE_PREFIX = "KFA"

--- a/framework/core/src/python/kungfu/yijinjing/data/adapter.py
+++ b/framework/core/src/python/kungfu/yijinjing/data/adapter.py
@@ -53,12 +53,12 @@ class Adapter:
                 if len(name_list) != 4:
                     self.ctx.logger.error(f"invalid csv name {filename}")
                     continue
-                category, group, name, type_name = name_list
-                writer_key = category + group + name
+                role, group, name, type_name = name_list
+                writer_key = role + group + name
                 if writer_key not in writers:
                     home = yjj.location(
                         lf.enums.mode.DATA,
-                        lf.enums.get_category_by_name(category),
+                        lf.enums.get_location_role_by_name(role),
                         group,
                         name,
                         output_locator,

--- a/framework/core/src/python/kungfu/yijinjing/journal.py
+++ b/framework/core/src/python/kungfu/yijinjing/journal.py
@@ -17,7 +17,7 @@ def collect_journal_locations(ctx):
     search_path = os.path.join(
         ctx.runtime_dir,
         "journal",
-        ctx.category,
+        ctx.role,
         ctx.group,
         ctx.name,
         ctx.mode,
@@ -29,13 +29,13 @@ def collect_journal_locations(ctx):
         ctx.logger.debug(f"{journal}")
         match = JOURNAL_PAGE_PATTERN.match(journal[len(ctx.runtime_dir) + 1 :])
         if match:
-            category = match.group(1)
+            role = match.group(1)
             group = match.group(2)
             name = match.group(3)
             mode = match.group(4)
             dest = match.group(5)
             page_id = match.group(6)
-            uname = "{}/{}/{}/{}".format(category, group, name, mode)
+            uname = "{}/{}/{}/{}".format(role, group, name, mode)
             uid = yjj.hash_str_32(uname)
             if uid in locations:
                 if dest in locations[uid]["readers"]:
@@ -44,7 +44,7 @@ def collect_journal_locations(ctx):
                     locations[uid]["readers"][dest] = [page_id]
             else:
                 locations[uid] = {
-                    "category": category,
+                    "role": role,
                     "group": group,
                     "name": name,
                     "mode": mode,
@@ -53,7 +53,7 @@ def collect_journal_locations(ctx):
                     "readers": {dest: [page_id]},
                 }
             ctx.logger.debug(
-                f"found journal {MODES[mode]} {CATEGORIES[category]} {group} {name}"
+                f"found journal {MODES[mode]} {ROLES[role]} {group} {name}"
             )
         else:
             ctx.logger.warn(
@@ -65,7 +65,7 @@ def collect_journal_locations(ctx):
 SESSION_COLUMNS = [
     "id",
     "mode",
-    "category",
+    "role",
     "group",
     "name",
     "begin_time",
@@ -92,7 +92,7 @@ def find_sessions(ctx):
             {
                 "id": len(rows) + 1,
                 "mode": lf.enums.get_mode_name(session.mode),
-                "category": lf.enums.get_category_name(session.category),
+                "role": lf.enums.get_location_role_name(session.role),
                 "group": session.group,
                 "name": session.name,
                 "begin_time": session.begin_time,
@@ -115,7 +115,7 @@ def find_session(ctx, session_id):
 def make_location_from_dict(ctx, location):
     return yjj.location(
         MODES[location["mode"]],
-        CATEGORIES[location["category"]],
+        ROLES[location["role"]],
         location["group"],
         location["name"],
         ctx.runtime_locator,
@@ -125,10 +125,10 @@ def make_location_from_dict(ctx, location):
 def read_session(ctx, session_id, io_type):
     session = find_session(ctx, session_id)
     uname = "{}/{}/{}/{}".format(
-        session["category"], session["group"], session["name"], session["mode"]
+        session["role"], session["group"], session["name"], session["mode"]
     )
     uid = yjj.hash_str_32(uname)
-    ctx.category = "*"
+    ctx.role = "*"
     ctx.group = "*"
     ctx.name = "*"
     ctx.mode = "*"
@@ -138,7 +138,7 @@ def read_session(ctx, session_id, io_type):
     io_device = yjj.io_device_console(home, ctx.console_width, ctx.console_height)
 
     show_in = (io_type == "in" or io_type == "all") and not (
-        io_device.home.category == lf.enums.category.SYSTEM
+        io_device.home.role == lf.enums.location_role.SYSTEM
         and io_device.home.group == "master"
         and io_device.home.name == "master"
     )

--- a/framework/core/src/python/kungfu/yijinjing/practice/apprentice.py
+++ b/framework/core/src/python/kungfu/yijinjing/practice/apprentice.py
@@ -19,7 +19,7 @@ class Apprentice(yjj.apprentice):
             self,
             yjj.location(
                 kfj.MODES[ctx.mode],
-                kfj.CATEGORIES[ctx.category],
+                kfj.ROLES[ctx.role],
                 ctx.group,
                 ctx.name,
                 ctx.runtime_locator,

--- a/framework/core/src/python/kungfu/yijinjing/sinks/archive.py
+++ b/framework/core/src/python/kungfu/yijinjing/sinks/archive.py
@@ -25,7 +25,7 @@ class ArchiveSink(yjj.sink):
             if dest_id not in writers:
                 target_location = yjj.location(
                     location.mode,
-                    location.category,
+                    location.role,
                     location.group,
                     location.name,
                     self.locator,

--- a/framework/core/src/python/kungfu/yijinjing/sinks/csv.py
+++ b/framework/core/src/python/kungfu/yijinjing/sinks/csv.py
@@ -23,7 +23,7 @@ class CsvSink(yjj.sink):
             return
         data_type = self.tagged_types[frame.msg_type]
         header = [m for m in vars(data_type) if not m.startswith("_")]
-        location_part = f"{lf.enums.get_category_name(location.category)}.{location.group}.{location.name}"
+        location_part = f"{lf.enums.get_location_role_name(location.role)}.{location.group}.{location.name}"
         output = os.path.join(
             self.ctx.inbox_dir, f"{location_part}.{data_type.__name__}.csv"
         )

--- a/framework/core/stubs/pykungfu/longfist/enums.pyi
+++ b/framework/core/stubs/pykungfu/longfist/enums.pyi
@@ -1,14 +1,14 @@
 from __future__ import annotations
 import typing
-__all__: list[str] = ['Account', 'AccountType', 'AccountingMethodType', 'AlgoOrderActionFlag', 'All', 'Allow', 'Any', 'Arbitrage', 'AskPriceGreaterEqualStopPrice', 'AskPriceGreaterThanStopPrice', 'AskPriceLesserEqualStopPrice', 'AskPriceLesserThanStopPrice', 'AssembleMode', 'AtAuction', 'AtAuctionLimit', 'BACKTEST', 'BSE', 'BadDebtInterest', 'BasketType', 'BasketVolumeType', 'BidPriceGreaterEqualStopPrice', 'BidPriceGreaterThanStopPrice', 'BidPriceLesserEqualStopPrice', 'BidPriceLesserThanStopPrice', 'Bond', 'BrokerState', 'BsFlag', 'Buy', 'ByAmount', 'ByVolume', 'CEN', 'CFFEX', 'CNH', 'CNY', 'CZCE', 'Cancel', 'Cancelled', 'Cancelling', 'CapitalOccupationFee', 'CapitalRightsCompensation', 'CashBondETF', 'CashRepayMargin', 'CashReplaceFlag', 'Close', 'CloseOut', 'CloseOutFlag', 'CloseToday', 'CloseYesterday', 'CommissionRateMode', 'CommodityETF', 'Connected', 'Continuous', 'ContractType', 'Covered', 'CrdBuyContract', 'CrdBuyInterest', 'CrdSellContract', 'CrdSellFee', 'Credit', 'CrossCountryETF', 'CrossMarketETF', 'Crypto', 'CryptoFuture', 'CryptoUFuture', 'Currency', 'CurrencyETF', 'Custom', 'DATA', 'DCE', 'Default', 'Depth', 'Direction', 'DisConnected', 'Drop', 'ETF', 'ETFStatus', 'ETFType', 'EUR', 'EnReplace', 'EnhancedLimit', 'Entrust', 'Error', 'Exec', 'ExecType', 'Fak', 'FakBest5', 'Filled', 'Fok', 'Forbid', 'ForwardBest', 'FrameDataType', 'Fund', 'Future', 'FutureOption', 'GBP', 'GFA', 'GFD', 'GFS', 'GTC', 'GTD', 'GuaranteeStockBuy', 'GuaranteeStockSell', 'GuaranteeStockTransferIn', 'GuaranteeStockTransferOut', 'HKD', 'HKT', 'Hedge', 'HedgeFlag', 'High', 'HistoryDataType', 'INE', 'IOC', 'Idle', 'Immediately', 'Index', 'InitNotCloseOut', 'InstrumentType', 'Intraday', 'JOURNAL', 'JPY', 'Json', 'LIVE', 'LOG', 'Last', 'LastPriceGreaterEqualStopPrice', 'LastPriceGreaterThanStopPrice', 'LastPriceLesserEqualStopPrice', 'LastPriceLesserThanStopPrice', 'LedgerCategory', 'Limit', 'LocalETF', 'Lock', 'LoggedIn', 'LoginFailed', 'Long', 'Lost', 'Low', 'MD', 'MYR', 'ManagementFee', 'MarginTrade', 'MarketType', 'Medium', 'Merge', 'Min', 'MustReplace', 'NANOMSG', 'Normal', 'NotCloseOut', 'Now', 'OPERATOR', 'OTC', 'Offset', 'Open', 'OperatorState', 'Opposing1', 'Opposing2', 'Opposing3', 'Opposing4', 'Opposing5', 'OrderActionFlag', 'OrderStatus', 'OrderTriggerFlag', 'OrderTriggerType', 'OverdueInterest', 'Own1', 'Own2', 'Own3', 'Own4', 'Own5', 'PageEnd', 'PageStatus', 'ParkedOrder', 'PartialFilledActive', 'PartialFilledNotActive', 'Pending', 'PendingSettlement', 'PhysicalBondETF', 'PreOpen', 'PriceLevel', 'PriceType', 'Priority', 'Proportion', 'Purchase', 'PurchaseOnly', 'Quantity', 'REPLAY', 'Raw', 'Ready', 'Redemption', 'RedemptionOnly', 'RepayMargin', 'RepayStock', 'Repo', 'ResumePolicy', 'ReverseBest', 'SGD', 'SHFE', 'SQLITE', 'SSE', 'STRATEGY', 'SYSTEM', 'SZE', 'Sell', 'ShareRightsCompensation', 'Short', 'ShortSell', 'Side', 'Snapshot', 'Speculation', 'Split', 'Start', 'Stateless', 'Stock', 'StockOption', 'StockRepayStock', 'Stop', 'Strategy', 'StrategyState', 'Submitted', 'SubscribeDataType', 'SubscribeInstrumentType', 'SurplusStockTransfer', 'TD', 'TechStock', 'Tick', 'TimeCondition', 'TotalEnd', 'Touch', 'TouchProfit', 'Trade', 'Transaction', 'Tree', 'TriggerCancel', 'TriggerInsert', 'USD', 'UnHKMustReplace', 'UnHKReplace', 'UnReplace', 'UnSSEMustReplace', 'UnSSEReplace', 'UnSSESZEMustReplace', 'UnSSESZEReplace', 'Unknown', 'Unlock', 'UpperLimitPrice', 'VolumeCondition', 'Warn', 'category', 'get_category_by_name', 'get_category_name', 'get_layout_name', 'get_mode_by_name', 'get_mode_name', 'layout', 'lowerLimitPrice', 'mode']
+__all__: list[str] = ['ACTOR', 'Account', 'AccountType', 'AccountingMethodType', 'AlgoOrderActionFlag', 'All', 'Allow', 'Any', 'Arbitrage', 'AskPriceGreaterEqualStopPrice', 'AskPriceGreaterThanStopPrice', 'AskPriceLesserEqualStopPrice', 'AskPriceLesserThanStopPrice', 'AssembleMode', 'AtAuction', 'AtAuctionLimit', 'BACKTEST', 'BSE', 'BadDebtInterest', 'BasketType', 'BasketVolumeType', 'BidPriceGreaterEqualStopPrice', 'BidPriceGreaterThanStopPrice', 'BidPriceLesserEqualStopPrice', 'BidPriceLesserThanStopPrice', 'Bond', 'BrokerState', 'BsFlag', 'Buy', 'ByAmount', 'ByVolume', 'CEN', 'CFFEX', 'CNH', 'CNY', 'CZCE', 'Cancel', 'Cancelled', 'Cancelling', 'CapitalOccupationFee', 'CapitalRightsCompensation', 'CashBondETF', 'CashRepayMargin', 'CashReplaceFlag', 'Close', 'CloseOut', 'CloseOutFlag', 'CloseToday', 'CloseYesterday', 'CommissionRateMode', 'CommodityETF', 'Connected', 'Continuous', 'ContractType', 'Covered', 'CrdBuyContract', 'CrdBuyInterest', 'CrdSellContract', 'CrdSellFee', 'Credit', 'CrossCountryETF', 'CrossMarketETF', 'Crypto', 'CryptoFuture', 'CryptoUFuture', 'Currency', 'CurrencyETF', 'Custom', 'DATA', 'DCE', 'Default', 'Depth', 'Direction', 'DisConnected', 'Drop', 'ETF', 'ETFStatus', 'ETFType', 'EUR', 'EnReplace', 'EnhancedLimit', 'Entrust', 'Error', 'Exec', 'ExecType', 'Fak', 'FakBest5', 'Filled', 'Fok', 'Forbid', 'ForwardBest', 'FrameDataType', 'Fund', 'Future', 'FutureOption', 'GBP', 'GFA', 'GFD', 'GFS', 'GTC', 'GTD', 'GuaranteeStockBuy', 'GuaranteeStockSell', 'GuaranteeStockTransferIn', 'GuaranteeStockTransferOut', 'HKD', 'HKT', 'Hedge', 'HedgeFlag', 'High', 'HistoryDataType', 'INE', 'IOC', 'Idle', 'Immediately', 'Index', 'InitNotCloseOut', 'InstrumentType', 'Intraday', 'JOURNAL', 'JPY', 'Json', 'LIVE', 'LOG', 'Last', 'LastPriceGreaterEqualStopPrice', 'LastPriceGreaterThanStopPrice', 'LastPriceLesserEqualStopPrice', 'LastPriceLesserThanStopPrice', 'LedgerCategory', 'Limit', 'LocalETF', 'Lock', 'LoggedIn', 'LoginFailed', 'Long', 'Lost', 'Low', 'MYR', 'ManagementFee', 'MarginTrade', 'MarketType', 'Medium', 'Merge', 'Min', 'MustReplace', 'NANOMSG', 'Normal', 'NotCloseOut', 'Now', 'OTC', 'Offset', 'Open', 'OperatorState', 'Opposing1', 'Opposing2', 'Opposing3', 'Opposing4', 'Opposing5', 'OrderActionFlag', 'OrderStatus', 'OrderTriggerFlag', 'OrderTriggerType', 'OverdueInterest', 'Own1', 'Own2', 'Own3', 'Own4', 'Own5', 'PageEnd', 'PageStatus', 'ParkedOrder', 'PartialFilledActive', 'PartialFilledNotActive', 'Pending', 'PendingSettlement', 'PhysicalBondETF', 'PreOpen', 'PriceLevel', 'PriceType', 'Priority', 'Proportion', 'Purchase', 'PurchaseOnly', 'Quantity', 'REPLAY', 'Raw', 'Ready', 'Redemption', 'RedemptionOnly', 'RepayMargin', 'RepayStock', 'Repo', 'ResumePolicy', 'ReverseBest', 'SERVICE', 'SGD', 'SHFE', 'SINK', 'SOURCE', 'SQLITE', 'SSE', 'SYSTEM', 'SZE', 'Sell', 'ShareRightsCompensation', 'Short', 'ShortSell', 'Side', 'Snapshot', 'Speculation', 'Split', 'Start', 'Stateless', 'Stock', 'StockOption', 'StockRepayStock', 'Stop', 'Strategy', 'StrategyState', 'Submitted', 'SubscribeDataType', 'SubscribeInstrumentType', 'SurplusStockTransfer', 'TechStock', 'Tick', 'TimeCondition', 'TotalEnd', 'Touch', 'TouchProfit', 'Trade', 'Transaction', 'Tree', 'TriggerCancel', 'TriggerInsert', 'USD', 'UnHKMustReplace', 'UnHKReplace', 'UnReplace', 'UnSSEMustReplace', 'UnSSEReplace', 'UnSSESZEMustReplace', 'UnSSESZEReplace', 'Unknown', 'Unlock', 'UpperLimitPrice', 'VolumeCondition', 'Warn', 'get_layout_name', 'get_location_role_by_name', 'get_location_role_name', 'get_mode_by_name', 'get_mode_name', 'layout', 'location_role', 'lowerLimitPrice', 'mode']
 class AccountType:
     """
     Members:
-    
+
       Stock
-    
+
       Credit
-    
+
       Future
     """
     Credit: typing.ClassVar[AccountType]  # value = <AccountType.Credit: 1>
@@ -56,9 +56,9 @@ class AccountType:
 class AccountingMethodType:
     """
     Members:
-    
+
       Default
-    
+
       OTC
     """
     Default: typing.ClassVar[AccountingMethodType]  # value = <AccountingMethodType.Default: 0>
@@ -105,11 +105,11 @@ class AccountingMethodType:
 class AlgoOrderActionFlag:
     """
     Members:
-    
+
       Cancel
-    
+
       Start
-    
+
       Stop
     """
     Cancel: typing.ClassVar[AlgoOrderActionFlag]  # value = <AlgoOrderActionFlag.Cancel: 0>
@@ -166,9 +166,9 @@ class AssembleMode:
 class BasketType:
     """
     Members:
-    
+
       Custom
-    
+
       ETF
     """
     Custom: typing.ClassVar[BasketType]  # value = <BasketType.Custom: 0>
@@ -215,11 +215,11 @@ class BasketType:
 class BasketVolumeType:
     """
     Members:
-    
+
       Unknown
-    
+
       Quantity
-    
+
       Proportion
     """
     Proportion: typing.ClassVar[BasketVolumeType]  # value = <BasketVolumeType.Proportion: 2>
@@ -267,19 +267,19 @@ class BasketVolumeType:
 class BrokerState:
     """
     Members:
-    
+
       Pending
-    
+
       Idle
-    
+
       DisConnected
-    
+
       Connected
-    
+
       LoggedIn
-    
+
       LoginFailed
-    
+
       Ready
     """
     Connected: typing.ClassVar[BrokerState]  # value = <BrokerState.Connected: 3>
@@ -331,11 +331,11 @@ class BrokerState:
 class BsFlag:
     """
     Members:
-    
+
       Unknown
-    
+
       Buy
-    
+
       Sell
     """
     Buy: typing.ClassVar[BsFlag]  # value = <BsFlag.Buy: 1>
@@ -383,25 +383,25 @@ class BsFlag:
 class CashReplaceFlag:
     """
     Members:
-    
+
       UnReplace
-    
+
       EnReplace
-    
+
       MustReplace
-    
+
       UnSSEReplace
-    
+
       UnSSEMustReplace
-    
+
       UnSSESZEReplace
-    
+
       UnSSESZEMustReplace
-    
+
       UnHKReplace
-    
+
       UnHKMustReplace
-    
+
       Unknown
     """
     EnReplace: typing.ClassVar[CashReplaceFlag]  # value = <CashReplaceFlag.EnReplace: 1>
@@ -456,11 +456,11 @@ class CashReplaceFlag:
 class CloseOutFlag:
     """
     Members:
-    
+
       NotCloseOut
-    
+
       CloseOut
-    
+
       InitNotCloseOut
     """
     CloseOut: typing.ClassVar[CloseOutFlag]  # value = <CloseOutFlag.CloseOut: 1>
@@ -508,9 +508,9 @@ class CloseOutFlag:
 class CommissionRateMode:
     """
     Members:
-    
+
       ByAmount
-    
+
       ByVolume
     """
     ByAmount: typing.ClassVar[CommissionRateMode]  # value = <CommissionRateMode.ByAmount: 0>
@@ -557,25 +557,25 @@ class CommissionRateMode:
 class ContractType:
     """
     Members:
-    
+
       CrdBuyContract
-    
+
       CrdSellContract
-    
+
       CrdBuyInterest
-    
+
       CrdSellFee
-    
+
       CapitalRightsCompensation
-    
+
       ShareRightsCompensation
-    
+
       OverdueInterest
-    
+
       BadDebtInterest
-    
+
       CapitalOccupationFee
-    
+
       ManagementFee
     """
     BadDebtInterest: typing.ClassVar[ContractType]  # value = <ContractType.BadDebtInterest: 7>
@@ -630,27 +630,27 @@ class ContractType:
 class Currency:
     """
     Members:
-    
+
       Unknown
-    
+
       CNY
-    
+
       HKD
-    
+
       USD
-    
+
       JPY
-    
+
       GBP
-    
+
       EUR
-    
+
       CNH
-    
+
       SGD
-    
+
       MYR
-    
+
       CEN
     """
     CEN: typing.ClassVar[Currency]  # value = <Currency.CEN: 10>
@@ -706,9 +706,9 @@ class Currency:
 class Direction:
     """
     Members:
-    
+
       Long
-    
+
       Short
     """
     Long: typing.ClassVar[Direction]  # value = <Direction.Long: 0>
@@ -755,15 +755,15 @@ class Direction:
 class ETFStatus:
     """
     Members:
-    
+
       Forbid
-    
+
       Allow
-    
+
       PurchaseOnly
-    
+
       RedemptionOnly
-    
+
       Unknown
     """
     Allow: typing.ClassVar[ETFStatus]  # value = <ETFStatus.Allow: 1>
@@ -813,21 +813,21 @@ class ETFStatus:
 class ETFType:
     """
     Members:
-    
+
       LocalETF
-    
+
       CrossCountryETF
-    
+
       CrossMarketETF
-    
+
       CurrencyETF
-    
+
       PhysicalBondETF
-    
+
       CommodityETF
-    
+
       CashBondETF
-    
+
       Unknown
     """
     CashBondETF: typing.ClassVar[ETFType]  # value = <ETFType.CashBondETF: 6>
@@ -880,11 +880,11 @@ class ETFType:
 class ExecType:
     """
     Members:
-    
+
       Unknown
-    
+
       Cancel
-    
+
       Trade
     """
     Cancel: typing.ClassVar[ExecType]  # value = <ExecType.Cancel: 1>
@@ -932,11 +932,11 @@ class ExecType:
 class FrameDataType:
     """
     Members:
-    
+
       Raw
-    
+
       Json
-    
+
       Unknown
     """
     Json: typing.ClassVar[FrameDataType]  # value = <FrameDataType.Json: 1>
@@ -984,13 +984,13 @@ class FrameDataType:
 class HedgeFlag:
     """
     Members:
-    
+
       Speculation
-    
+
       Arbitrage
-    
+
       Hedge
-    
+
       Covered
     """
     Arbitrage: typing.ClassVar[HedgeFlag]  # value = <HedgeFlag.Arbitrage: 1>
@@ -1039,11 +1039,11 @@ class HedgeFlag:
 class HistoryDataType:
     """
     Members:
-    
+
       Normal
-    
+
       PageEnd
-    
+
       TotalEnd
     """
     Normal: typing.ClassVar[HistoryDataType]  # value = <HistoryDataType.Normal: 0>
@@ -1091,29 +1091,29 @@ class HistoryDataType:
 class InstrumentType:
     """
     Members:
-    
+
       Unknown
-    
+
       Stock
-    
+
       Future
-    
+
       Bond
-    
+
       StockOption
-    
+
       TechStock
-    
+
       Fund
-    
+
       Index
-    
+
       Repo
-    
+
       Crypto
-    
+
       CryptoFuture
-    
+
       CryptoUFuture
     """
     Bond: typing.ClassVar[InstrumentType]  # value = <InstrumentType.Bond: 5>
@@ -1170,9 +1170,9 @@ class InstrumentType:
 class LedgerCategory:
     """
     Members:
-    
+
       Account
-    
+
       Strategy
     """
     Account: typing.ClassVar[LedgerCategory]  # value = <LedgerCategory.Account: 0>
@@ -1219,23 +1219,23 @@ class LedgerCategory:
 class MarketType:
     """
     Members:
-    
+
       All
-    
+
       BSE
-    
+
       SHFE
-    
+
       CFFEX
-    
+
       DCE
-    
+
       CZCE
-    
+
       INE
-    
+
       SSE
-    
+
       SZE
     """
     All: typing.ClassVar[MarketType]  # value = <MarketType.All: 0>
@@ -1289,13 +1289,13 @@ class MarketType:
 class Offset:
     """
     Members:
-    
+
       Open
-    
+
       Close
-    
+
       CloseToday
-    
+
       CloseYesterday
     """
     Close: typing.ClassVar[Offset]  # value = <Offset.Close: 1>
@@ -1344,13 +1344,13 @@ class Offset:
 class OperatorState:
     """
     Members:
-    
+
       Pending
-    
+
       DisConnected
-    
+
       Connected
-    
+
       Ready
     """
     Connected: typing.ClassVar[OperatorState]  # value = <OperatorState.Connected: 3>
@@ -1399,9 +1399,9 @@ class OperatorState:
 class OrderActionFlag:
     """
     Members:
-    
+
       Cancel
-    
+
       TriggerCancel
     """
     Cancel: typing.ClassVar[OrderActionFlag]  # value = <OrderActionFlag.Cancel: 0>
@@ -1448,27 +1448,27 @@ class OrderActionFlag:
 class OrderStatus:
     """
     Members:
-    
+
       Unknown
-    
+
       Submitted
-    
+
       Pending
-    
+
       Cancelled
-    
+
       Error
-    
+
       Filled
-    
+
       PartialFilledNotActive
-    
+
       PartialFilledActive
-    
+
       Lost
-    
+
       Cancelling
-    
+
       PendingSettlement
     """
     Cancelled: typing.ClassVar[OrderStatus]  # value = <OrderStatus.Cancelled: 3>
@@ -1524,9 +1524,9 @@ class OrderStatus:
 class OrderTriggerFlag:
     """
     Members:
-    
+
       TriggerInsert
-    
+
       TriggerCancel
     """
     TriggerCancel: typing.ClassVar[OrderTriggerFlag]  # value = <OrderTriggerFlag.TriggerCancel: 1>
@@ -1573,37 +1573,37 @@ class OrderTriggerFlag:
 class OrderTriggerType:
     """
     Members:
-    
+
       Immediately
-    
+
       Touch
-    
+
       TouchProfit
-    
+
       ParkedOrder
-    
+
       LastPriceGreaterThanStopPrice
-    
+
       LastPriceGreaterEqualStopPrice
-    
+
       LastPriceLesserThanStopPrice
-    
+
       LastPriceLesserEqualStopPrice
-    
+
       AskPriceGreaterThanStopPrice
-    
+
       AskPriceGreaterEqualStopPrice
-    
+
       AskPriceLesserThanStopPrice
-    
+
       AskPriceLesserEqualStopPrice
-    
+
       BidPriceGreaterThanStopPrice
-    
+
       BidPriceGreaterEqualStopPrice
-    
+
       BidPriceLesserThanStopPrice
-    
+
       BidPriceLesserEqualStopPrice
     """
     AskPriceGreaterEqualStopPrice: typing.ClassVar[OrderTriggerType]  # value = <OrderTriggerType.AskPriceGreaterEqualStopPrice: 9>
@@ -1664,9 +1664,9 @@ class OrderTriggerType:
 class PageStatus:
     """
     Members:
-    
+
       Normal
-    
+
       PreOpen
     """
     Normal: typing.ClassVar[PageStatus]  # value = <PageStatus.Normal: 0>
@@ -1713,33 +1713,33 @@ class PageStatus:
 class PriceLevel:
     """
     Members:
-    
+
       Last
-    
+
       Opposing5
-    
+
       Opposing4
-    
+
       Opposing3
-    
+
       Opposing2
-    
+
       Opposing1
-    
+
       Own1
-    
+
       Own2
-    
+
       Own3
-    
+
       Own4
-    
+
       Own5
-    
+
       UpperLimitPrice
-    
+
       lowerLimitPrice
-    
+
       Unknown
     """
     Last: typing.ClassVar[PriceLevel]  # value = <PriceLevel.Last: 0>
@@ -1798,27 +1798,27 @@ class PriceLevel:
 class PriceType:
     """
     Members:
-    
+
       Any
-    
+
       FakBest5
-    
+
       Fak
-    
+
       Fok
-    
+
       Limit
-    
+
       ForwardBest
-    
+
       ReverseBest
-    
+
       EnhancedLimit
-    
+
       AtAuctionLimit
-    
+
       AtAuction
-    
+
       Unknown
     """
     Any: typing.ClassVar[PriceType]  # value = <PriceType.Any: 1>
@@ -1874,11 +1874,11 @@ class PriceType:
 class Priority:
     """
     Members:
-    
+
       Low
-    
+
       Medium
-    
+
       High
     """
     High: typing.ClassVar[Priority]  # value = <Priority.High: 2>
@@ -1926,13 +1926,13 @@ class Priority:
 class ResumePolicy:
     """
     Members:
-    
+
       Now
-    
+
       Intraday
-    
+
       Stateless
-    
+
       Continuous
     """
     Continuous: typing.ClassVar[ResumePolicy]  # value = <ResumePolicy.Continuous: 3>
@@ -1981,49 +1981,49 @@ class ResumePolicy:
 class Side:
     """
     Members:
-    
+
       Buy
-    
+
       Sell
-    
+
       Lock
-    
+
       Unlock
-    
+
       Exec
-    
+
       Drop
-    
+
       Purchase
-    
+
       Redemption
-    
+
       Split
-    
+
       Merge
-    
+
       MarginTrade
-    
+
       ShortSell
-    
+
       RepayMargin
-    
+
       RepayStock
-    
+
       CashRepayMargin
-    
+
       StockRepayStock
-    
+
       SurplusStockTransfer
-    
+
       GuaranteeStockTransferIn
-    
+
       GuaranteeStockTransferOut
-    
+
       GuaranteeStockBuy
-    
+
       GuaranteeStockSell
-    
+
       Unknown
     """
     Buy: typing.ClassVar[Side]  # value = <Side.Buy: 0>
@@ -2090,11 +2090,11 @@ class Side:
 class StrategyState:
     """
     Members:
-    
+
       Normal
-    
+
       Warn
-    
+
       Error
     """
     Error: typing.ClassVar[StrategyState]  # value = <StrategyState.Error: 2>
@@ -2142,19 +2142,19 @@ class StrategyState:
 class SubscribeDataType:
     """
     Members:
-    
+
       All
-    
+
       Snapshot
-    
+
       Transaction
-    
+
       Entrust
-    
+
       Tree
-    
+
       Depth
-    
+
       Tick
     """
     All: typing.ClassVar[SubscribeDataType]  # value = <SubscribeDataType.All: 0>
@@ -2208,23 +2208,23 @@ class SubscribeDataType:
 class SubscribeInstrumentType:
     """
     Members:
-    
+
       All
-    
+
       Stock
-    
+
       Future
-    
+
       Bond
-    
+
       StockOption
-    
+
       FutureOption
-    
+
       Fund
-    
+
       Index
-    
+
       HKT
     """
     All: typing.ClassVar[SubscribeInstrumentType]  # value = <SubscribeInstrumentType.All: 0>
@@ -2280,19 +2280,19 @@ class SubscribeInstrumentType:
 class TimeCondition:
     """
     Members:
-    
+
       IOC
-    
+
       GFD
-    
+
       GTC
-    
+
       GFS
-    
+
       GTD
-    
+
       GFA
-    
+
       Unknown
     """
     GFA: typing.ClassVar[TimeCondition]  # value = <TimeCondition.GFA: 5>
@@ -2344,11 +2344,11 @@ class TimeCondition:
 class VolumeCondition:
     """
     Members:
-    
+
       Any
-    
+
       Min
-    
+
       All
     """
     All: typing.ClassVar[VolumeCondition]  # value = <VolumeCondition.All: 2>
@@ -2393,74 +2393,18 @@ class VolumeCondition:
     @property
     def value(self) -> int:
         ...
-class category:
-    """
-    Kungfu Data Category
-    
-    Members:
-    
-      MD
-    
-      TD
-    
-      STRATEGY
-    
-      SYSTEM
-    
-      OPERATOR
-    """
-    MD: typing.ClassVar[category]  # value = <category.MD: 0>
-    OPERATOR: typing.ClassVar[category]  # value = <category.OPERATOR: 4>
-    STRATEGY: typing.ClassVar[category]  # value = <category.STRATEGY: 2>
-    SYSTEM: typing.ClassVar[category]  # value = <category.SYSTEM: 3>
-    TD: typing.ClassVar[category]  # value = <category.TD: 1>
-    __members__: typing.ClassVar[dict[str, category]]  # value = {'MD': <category.MD: 0>, 'TD': <category.TD: 1>, 'STRATEGY': <category.STRATEGY: 2>, 'SYSTEM': <category.SYSTEM: 3>, 'OPERATOR': <category.OPERATOR: 4>}
-    def __eq__(self, other: typing.Any) -> bool:
-        ...
-    def __ge__(self, other: typing.Any) -> bool:
-        ...
-    def __getstate__(self) -> int:
-        ...
-    def __gt__(self, other: typing.Any) -> bool:
-        ...
-    def __hash__(self) -> int:
-        ...
-    def __index__(self) -> int:
-        ...
-    def __init__(self, value: int) -> None:
-        ...
-    def __int__(self) -> int:
-        ...
-    def __le__(self, other: typing.Any) -> bool:
-        ...
-    def __lt__(self, other: typing.Any) -> bool:
-        ...
-    def __ne__(self, other: typing.Any) -> bool:
-        ...
-    def __repr__(self) -> str:
-        ...
-    def __setstate__(self, state: int) -> None:
-        ...
-    def __str__(self) -> str:
-        ...
-    @property
-    def name(self) -> str:
-        ...
-    @property
-    def value(self) -> int:
-        ...
 class layout:
     """
     Kungfu Data Layout
-    
+
     Members:
-    
+
       JOURNAL
-    
+
       SQLITE
-    
+
       NANOMSG
-    
+
       LOG
     """
     JOURNAL: typing.ClassVar[layout]  # value = <layout.JOURNAL: 0>
@@ -2502,18 +2446,74 @@ class layout:
     @property
     def value(self) -> int:
         ...
+class location_role:
+    """
+    Kungfu Location Role
+
+    Members:
+
+      SOURCE
+
+      SINK
+
+      ACTOR
+
+      SYSTEM
+
+      SERVICE
+    """
+    ACTOR: typing.ClassVar[location_role]  # value = <location_role.ACTOR: 2>
+    SERVICE: typing.ClassVar[location_role]  # value = <location_role.SERVICE: 4>
+    SINK: typing.ClassVar[location_role]  # value = <location_role.SINK: 1>
+    SOURCE: typing.ClassVar[location_role]  # value = <location_role.SOURCE: 0>
+    SYSTEM: typing.ClassVar[location_role]  # value = <location_role.SYSTEM: 3>
+    __members__: typing.ClassVar[dict[str, location_role]]  # value = {'SOURCE': <location_role.SOURCE: 0>, 'SINK': <location_role.SINK: 1>, 'ACTOR': <location_role.ACTOR: 2>, 'SYSTEM': <location_role.SYSTEM: 3>, 'SERVICE': <location_role.SERVICE: 4>}
+    def __eq__(self, other: typing.Any) -> bool:
+        ...
+    def __ge__(self, other: typing.Any) -> bool:
+        ...
+    def __getstate__(self) -> int:
+        ...
+    def __gt__(self, other: typing.Any) -> bool:
+        ...
+    def __hash__(self) -> int:
+        ...
+    def __index__(self) -> int:
+        ...
+    def __init__(self, value: int) -> None:
+        ...
+    def __int__(self) -> int:
+        ...
+    def __le__(self, other: typing.Any) -> bool:
+        ...
+    def __lt__(self, other: typing.Any) -> bool:
+        ...
+    def __ne__(self, other: typing.Any) -> bool:
+        ...
+    def __repr__(self) -> str:
+        ...
+    def __setstate__(self, state: int) -> None:
+        ...
+    def __str__(self) -> str:
+        ...
+    @property
+    def name(self) -> str:
+        ...
+    @property
+    def value(self) -> int:
+        ...
 class mode:
     """
     Kungfu Run Mode
-    
+
     Members:
-    
+
       LIVE
-    
+
       DATA
-    
+
       REPLAY
-    
+
       BACKTEST
     """
     BACKTEST: typing.ClassVar[mode]  # value = <mode.BACKTEST: 3>
@@ -2555,16 +2555,17 @@ class mode:
     @property
     def value(self) -> int:
         ...
-def get_category_by_name(arg0: str) -> category:
-    ...
-def get_category_name(arg0: category) -> str:
-    ...
 def get_layout_name(arg0: layout) -> str:
+    ...
+def get_location_role_by_name(arg0: str) -> location_role:
+    ...
+def get_location_role_name(arg0: location_role) -> str:
     ...
 def get_mode_by_name(arg0: str) -> mode:
     ...
 def get_mode_name(arg0: mode) -> str:
     ...
+ACTOR: location_role  # value = <location_role.ACTOR: 2>
 Account: LedgerCategory  # value = <LedgerCategory.Account: 0>
 All: SubscribeInstrumentType  # value = <SubscribeInstrumentType.All: 0>
 Allow: ETFStatus  # value = <ETFStatus.Allow: 1>
@@ -2680,7 +2681,6 @@ LoginFailed: BrokerState  # value = <BrokerState.LoginFailed: 5>
 Long: Direction  # value = <Direction.Long: 0>
 Lost: OrderStatus  # value = <OrderStatus.Lost: 8>
 Low: Priority  # value = <Priority.Low: 0>
-MD: category  # value = <category.MD: 0>
 MYR: Currency  # value = <Currency.MYR: 9>
 ManagementFee: ContractType  # value = <ContractType.ManagementFee: 9>
 MarginTrade: Side  # value = <Side.MarginTrade: 10>
@@ -2692,7 +2692,6 @@ NANOMSG: layout  # value = <layout.NANOMSG: 2>
 Normal: PageStatus  # value = <PageStatus.Normal: 0>
 NotCloseOut: CloseOutFlag  # value = <CloseOutFlag.NotCloseOut: 0>
 Now: ResumePolicy  # value = <ResumePolicy.Now: 0>
-OPERATOR: category  # value = <category.OPERATOR: 4>
 OTC: AccountingMethodType  # value = <AccountingMethodType.OTC: 1>
 Open: Offset  # value = <Offset.Open: 0>
 Opposing1: PriceLevel  # value = <PriceLevel.Opposing1: 5>
@@ -2727,12 +2726,14 @@ RepayMargin: Side  # value = <Side.RepayMargin: 12>
 RepayStock: Side  # value = <Side.RepayStock: 13>
 Repo: InstrumentType  # value = <InstrumentType.Repo: 8>
 ReverseBest: PriceType  # value = <PriceType.ReverseBest: 4>
+SERVICE: location_role  # value = <location_role.SERVICE: 4>
 SGD: Currency  # value = <Currency.SGD: 8>
 SHFE: MarketType  # value = <MarketType.SHFE: 2>
+SINK: location_role  # value = <location_role.SINK: 1>
+SOURCE: location_role  # value = <location_role.SOURCE: 0>
 SQLITE: layout  # value = <layout.SQLITE: 1>
 SSE: MarketType  # value = <MarketType.SSE: 7>
-STRATEGY: category  # value = <category.STRATEGY: 2>
-SYSTEM: category  # value = <category.SYSTEM: 3>
+SYSTEM: location_role  # value = <location_role.SYSTEM: 3>
 SZE: MarketType  # value = <MarketType.SZE: 8>
 Sell: BsFlag  # value = <BsFlag.Sell: 2>
 ShareRightsCompensation: ContractType  # value = <ContractType.ShareRightsCompensation: 5>
@@ -2750,7 +2751,6 @@ Stop: AlgoOrderActionFlag  # value = <AlgoOrderActionFlag.Stop: 2>
 Strategy: LedgerCategory  # value = <LedgerCategory.Strategy: 1>
 Submitted: OrderStatus  # value = <OrderStatus.Submitted: 1>
 SurplusStockTransfer: Side  # value = <Side.SurplusStockTransfer: 16>
-TD: category  # value = <category.TD: 1>
 TechStock: InstrumentType  # value = <InstrumentType.TechStock: 3>
 Tick: SubscribeDataType  # value = <SubscribeDataType.Tick: 22>
 TotalEnd: HistoryDataType  # value = <HistoryDataType.TotalEnd: 2>

--- a/framework/core/stubs/pykungfu/longfist/types.pyi
+++ b/framework/core/stubs/pykungfu/longfist/types.pyi
@@ -427,11 +427,11 @@ class Commission:
 class Config:
     __has_data__: typing.ClassVar[bool] = True
     __tag__: typing.ClassVar[int] = 10201
-    category: pykungfu.longfist.enums.category
     group: str
     location_uid: int
     mode: pykungfu.longfist.enums.mode
     name: str
+    role: pykungfu.longfist.enums.location_role
     seed: int
     uid64: int
     value: str
@@ -514,11 +514,11 @@ class CustomSubscribe:
 class Deregister:
     __has_data__: typing.ClassVar[bool] = True
     __tag__: typing.ClassVar[int] = 10102
-    category: pykungfu.longfist.enums.category
     group: str
     location_uid: int
     mode: pykungfu.longfist.enums.mode
     name: str
+    role: pykungfu.longfist.enums.location_role
     seed: int
     uid64: int
     def __eq__(self, arg0: Deregister) -> bool:
@@ -750,11 +750,11 @@ class InstrumentKey:
 class Location:
     __has_data__: typing.ClassVar[bool] = True
     __tag__: typing.ClassVar[int] = 10205
-    category: pykungfu.longfist.enums.category
     group: str
     location_uid: int
     mode: pykungfu.longfist.enums.mode
     name: str
+    role: pykungfu.longfist.enums.location_role
     seed: int
     uid64: int
     def __eq__(self, arg0: Location) -> bool:
@@ -1101,11 +1101,11 @@ class OrderTriggerInput:
 class OutputKey:
     __has_data__: typing.ClassVar[bool] = True
     __tag__: typing.ClassVar[int] = 701
-    category: pykungfu.longfist.enums.category
     group: str
     location_uid: int
     mode: pykungfu.longfist.enums.mode
     name: str
+    role: pykungfu.longfist.enums.location_role
     seed: int
     uid64: int
     def __eq__(self, arg0: OutputKey) -> bool:
@@ -1244,7 +1244,6 @@ class Quote:
 class Register:
     __has_data__: typing.ClassVar[bool] = True
     __tag__: typing.ClassVar[int] = 10101
-    category: pykungfu.longfist.enums.category
     checkin_time: int
     group: str
     last_active_time: int
@@ -1252,6 +1251,7 @@ class Register:
     mode: pykungfu.longfist.enums.mode
     name: str
     pid: int
+    role: pykungfu.longfist.enums.location_role
     seed: int
     uid64: int
     def __eq__(self, arg0: Register) -> bool:
@@ -1500,12 +1500,12 @@ class RequestWriteTo:
 class RequestWriteToBand:
     __has_data__: typing.ClassVar[bool] = True
     __tag__: typing.ClassVar[int] = 10307
-    category: pykungfu.longfist.enums.category
     group: str
     location_uid: int
     mode: pykungfu.longfist.enums.mode
     name: str
     page_size: int
+    role: pykungfu.longfist.enums.location_role
     seed: int
     uid64: int
     def __eq__(self, arg0: RequestWriteToBand) -> bool:
@@ -1528,13 +1528,13 @@ class RequestWriteToBand:
 class RiskSetting:
     __has_data__: typing.ClassVar[bool] = True
     __tag__: typing.ClassVar[int] = 10202
-    category: pykungfu.longfist.enums.category
     group: str
     location_uid: int
     mode: pykungfu.longfist.enums.mode
     name: str
     risk_check: bool
     risk_name: str
+    role: pykungfu.longfist.enums.location_role
     seed: int
     self_deal_check_type: ...
     uid64: int
@@ -1560,7 +1560,6 @@ class Session:
     __has_data__: typing.ClassVar[bool] = True
     __tag__: typing.ClassVar[int] = 10103
     begin_time: int
-    category: pykungfu.longfist.enums.category
     data_size: int
     end_time: int
     frame_count: int
@@ -1568,6 +1567,7 @@ class Session:
     location_uid: int
     mode: pykungfu.longfist.enums.mode
     name: str
+    role: pykungfu.longfist.enums.location_role
     seed: int
     uid64: int
     update_time: int

--- a/framework/core/stubs/pykungfu/yijinjing.pyi
+++ b/framework/core/stubs/pykungfu/yijinjing.pyi
@@ -115,7 +115,7 @@ class apprentice:
         ...
 class assemble:
     @typing.overload
-    def __init__(self, locators: list[locator], mode: str = '*', category: str = '*', group: str = '*', name: str = '*') -> None:
+    def __init__(self, locators: list[locator], mode: str = '*', role: str = '*', group: str = '*', name: str = '*') -> None:
         ...
     @typing.overload
     def __init__(self, source_location: location, dest_id: int, assemble_mode: int = 1, from_time: int = 0) -> None:
@@ -428,19 +428,19 @@ class assemble:
     def read_bytes(self, data: pykungfu.longfist.types.SyntheticData = {"key":"","tag_a":"","tag_b":"","tag_c":"","update_time":0,"value":""}, end_time: int = 9223372036854775807) -> list[tuple[pykungfu.longfist.types.frame_header, list[int]]]:
         ...
     @typing.overload
-    def read_bytes(self, data: pykungfu.longfist.types.OutputKey = {"category":"MD","group":"","location_uid":0,"mode":"LIVE","name":"","seed":0,"uid64":0}, end_time: int = 9223372036854775807) -> list[tuple[pykungfu.longfist.types.frame_header, list[int]]]:
+    def read_bytes(self, data: pykungfu.longfist.types.OutputKey = {"group":"","location_uid":0,"mode":"LIVE","name":"","role":"SOURCE","seed":0,"uid64":0}, end_time: int = 9223372036854775807) -> list[tuple[pykungfu.longfist.types.frame_header, list[int]]]:
         ...
     @typing.overload
-    def read_bytes(self, data: pykungfu.longfist.types.Register = {"category":"MD","checkin_time":0,"group":"","last_active_time":0,"location_uid":0,"mode":"LIVE","name":"","pid":0,"seed":0,"uid64":0}, end_time: int = 9223372036854775807) -> list[tuple[pykungfu.longfist.types.frame_header, list[int]]]:
+    def read_bytes(self, data: pykungfu.longfist.types.Register = {"checkin_time":0,"group":"","last_active_time":0,"location_uid":0,"mode":"LIVE","name":"","pid":0,"role":"SOURCE","seed":0,"uid64":0}, end_time: int = 9223372036854775807) -> list[tuple[pykungfu.longfist.types.frame_header, list[int]]]:
         ...
     @typing.overload
-    def read_bytes(self, data: pykungfu.longfist.types.Deregister = {"category":"MD","group":"","location_uid":0,"mode":"LIVE","name":"","seed":0,"uid64":0}, end_time: int = 9223372036854775807) -> list[tuple[pykungfu.longfist.types.frame_header, list[int]]]:
+    def read_bytes(self, data: pykungfu.longfist.types.Deregister = {"group":"","location_uid":0,"mode":"LIVE","name":"","role":"SOURCE","seed":0,"uid64":0}, end_time: int = 9223372036854775807) -> list[tuple[pykungfu.longfist.types.frame_header, list[int]]]:
         ...
     @typing.overload
     def read_bytes(self, data: pykungfu.longfist.types.StrategyStateUpdate = {"info_a":"","info_b":"","info_c":"","state":"Normal","update_time":0,"value":""}, end_time: int = 9223372036854775807) -> list[tuple[pykungfu.longfist.types.frame_header, list[int]]]:
         ...
     @typing.overload
-    def read_bytes(self, data: pykungfu.longfist.types.Session = {"begin_time":0,"category":"MD","data_size":0,"end_time":0,"frame_count":0,"group":"","location_uid":0,"mode":"LIVE","name":"","seed":0,"uid64":0,"update_time":0}, end_time: int = 9223372036854775807) -> list[tuple[pykungfu.longfist.types.frame_header, list[int]]]:
+    def read_bytes(self, data: pykungfu.longfist.types.Session = {"begin_time":0,"data_size":0,"end_time":0,"frame_count":0,"group":"","location_uid":0,"mode":"LIVE","name":"","role":"SOURCE","seed":0,"uid64":0,"update_time":0}, end_time: int = 9223372036854775807) -> list[tuple[pykungfu.longfist.types.frame_header, list[int]]]:
         ...
     @typing.overload
     def read_bytes(self, data: pykungfu.longfist.types.OperatorStateUpdate = {"info_a":"","info_b":"","location_uid":0,"state":"Pending","update_time":0,"value":""}, end_time: int = 9223372036854775807) -> list[tuple[pykungfu.longfist.types.frame_header, list[int]]]:
@@ -449,7 +449,7 @@ class assemble:
     def read_bytes(self, data: pykungfu.longfist.types.BrokerStateUpdate = {"location_uid":0,"state":"Pending"}, end_time: int = 9223372036854775807) -> list[tuple[pykungfu.longfist.types.frame_header, list[int]]]:
         ...
     @typing.overload
-    def read_bytes(self, data: pykungfu.longfist.types.Config = {"category":"MD","group":"","location_uid":0,"mode":"LIVE","name":"","seed":0,"uid64":0,"value":""}, end_time: int = 9223372036854775807) -> list[tuple[pykungfu.longfist.types.frame_header, list[int]]]:
+    def read_bytes(self, data: pykungfu.longfist.types.Config = {"group":"","location_uid":0,"mode":"LIVE","name":"","role":"SOURCE","seed":0,"uid64":0,"value":""}, end_time: int = 9223372036854775807) -> list[tuple[pykungfu.longfist.types.frame_header, list[int]]]:
         ...
     @typing.overload
     def read_bytes(self, data: pykungfu.longfist.types.RiskSetting = ..., end_time: int = 9223372036854775807) -> list[tuple[pykungfu.longfist.types.frame_header, list[int]]]:
@@ -461,7 +461,7 @@ class assemble:
     def read_bytes(self, data: pykungfu.longfist.types.Instrument = {"contract_multiplier":0,"create_date":"","currency":"Unknown","delivery_month":0,"delivery_year":0,"exchange_id":"","expire_date":"","instrument_id":"","instrument_type":"Unknown","open_date":"","price_tick":0.0,"product_id":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"quantity_unit":0.0}, end_time: int = 9223372036854775807) -> list[tuple[pykungfu.longfist.types.frame_header, list[int]]]:
         ...
     @typing.overload
-    def read_bytes(self, data: pykungfu.longfist.types.Location = {"category":"MD","group":"","location_uid":0,"mode":"LIVE","name":"","seed":0,"uid64":0}, end_time: int = 9223372036854775807) -> list[tuple[pykungfu.longfist.types.frame_header, list[int]]]:
+    def read_bytes(self, data: pykungfu.longfist.types.Location = {"group":"","location_uid":0,"mode":"LIVE","name":"","role":"SOURCE","seed":0,"uid64":0}, end_time: int = 9223372036854775807) -> list[tuple[pykungfu.longfist.types.frame_header, list[int]]]:
         ...
     @typing.overload
     def read_bytes(self, data: pykungfu.longfist.types.Basket = {"basket_type":"Custom","cash_difference":0.0,"etf_status":"Forbid","etf_type":"LocalETF","etf_value":0.0,"exchange_id":"","id":0,"instrument_id":"","max_cash_ratio":0.0,"max_purchase_volume":0.0,"max_redemption_volume":0.0,"min_volume":0.0,"name":"","net_unit_value":0.0,"total_amount":0.0,"volume_type":"Unknown"}, end_time: int = 9223372036854775807) -> list[tuple[pykungfu.longfist.types.frame_header, list[int]]]:
@@ -494,7 +494,7 @@ class assemble:
     def read_bytes(self, data: pykungfu.longfist.types.ChannelRequest = {"dest_id":0,"source_id":0}, end_time: int = 9223372036854775807) -> list[tuple[pykungfu.longfist.types.frame_header, list[int]]]:
         ...
     @typing.overload
-    def read_bytes(self, data: pykungfu.longfist.types.RequestWriteToBand = {"category":"MD","group":"","location_uid":0,"mode":"LIVE","name":"","page_size":0,"seed":0,"uid64":0}, end_time: int = 9223372036854775807) -> list[tuple[pykungfu.longfist.types.frame_header, list[int]]]:
+    def read_bytes(self, data: pykungfu.longfist.types.RequestWriteToBand = {"group":"","location_uid":0,"mode":"LIVE","name":"","page_size":0,"role":"SOURCE","seed":0,"uid64":0}, end_time: int = 9223372036854775807) -> list[tuple[pykungfu.longfist.types.frame_header, list[int]]]:
         ...
     @typing.overload
     def read_bytes(self, data: pykungfu.longfist.types.Band = {"dest_id":0,"source_id":0}, end_time: int = 9223372036854775807) -> list[tuple[pykungfu.longfist.types.frame_header, list[int]]]:
@@ -821,19 +821,19 @@ class assemble:
     def read_headers(self, data: pykungfu.longfist.types.SyntheticData = {"key":"","tag_a":"","tag_b":"","tag_c":"","update_time":0,"value":""}, end_time: int = 9223372036854775807) -> list[pykungfu.longfist.types.frame_header]:
         ...
     @typing.overload
-    def read_headers(self, data: pykungfu.longfist.types.OutputKey = {"category":"MD","group":"","location_uid":0,"mode":"LIVE","name":"","seed":0,"uid64":0}, end_time: int = 9223372036854775807) -> list[pykungfu.longfist.types.frame_header]:
+    def read_headers(self, data: pykungfu.longfist.types.OutputKey = {"group":"","location_uid":0,"mode":"LIVE","name":"","role":"SOURCE","seed":0,"uid64":0}, end_time: int = 9223372036854775807) -> list[pykungfu.longfist.types.frame_header]:
         ...
     @typing.overload
-    def read_headers(self, data: pykungfu.longfist.types.Register = {"category":"MD","checkin_time":0,"group":"","last_active_time":0,"location_uid":0,"mode":"LIVE","name":"","pid":0,"seed":0,"uid64":0}, end_time: int = 9223372036854775807) -> list[pykungfu.longfist.types.frame_header]:
+    def read_headers(self, data: pykungfu.longfist.types.Register = {"checkin_time":0,"group":"","last_active_time":0,"location_uid":0,"mode":"LIVE","name":"","pid":0,"role":"SOURCE","seed":0,"uid64":0}, end_time: int = 9223372036854775807) -> list[pykungfu.longfist.types.frame_header]:
         ...
     @typing.overload
-    def read_headers(self, data: pykungfu.longfist.types.Deregister = {"category":"MD","group":"","location_uid":0,"mode":"LIVE","name":"","seed":0,"uid64":0}, end_time: int = 9223372036854775807) -> list[pykungfu.longfist.types.frame_header]:
+    def read_headers(self, data: pykungfu.longfist.types.Deregister = {"group":"","location_uid":0,"mode":"LIVE","name":"","role":"SOURCE","seed":0,"uid64":0}, end_time: int = 9223372036854775807) -> list[pykungfu.longfist.types.frame_header]:
         ...
     @typing.overload
     def read_headers(self, data: pykungfu.longfist.types.StrategyStateUpdate = {"info_a":"","info_b":"","info_c":"","state":"Normal","update_time":0,"value":""}, end_time: int = 9223372036854775807) -> list[pykungfu.longfist.types.frame_header]:
         ...
     @typing.overload
-    def read_headers(self, data: pykungfu.longfist.types.Session = {"begin_time":0,"category":"MD","data_size":0,"end_time":0,"frame_count":0,"group":"","location_uid":0,"mode":"LIVE","name":"","seed":0,"uid64":0,"update_time":0}, end_time: int = 9223372036854775807) -> list[pykungfu.longfist.types.frame_header]:
+    def read_headers(self, data: pykungfu.longfist.types.Session = {"begin_time":0,"data_size":0,"end_time":0,"frame_count":0,"group":"","location_uid":0,"mode":"LIVE","name":"","role":"SOURCE","seed":0,"uid64":0,"update_time":0}, end_time: int = 9223372036854775807) -> list[pykungfu.longfist.types.frame_header]:
         ...
     @typing.overload
     def read_headers(self, data: pykungfu.longfist.types.OperatorStateUpdate = {"info_a":"","info_b":"","location_uid":0,"state":"Pending","update_time":0,"value":""}, end_time: int = 9223372036854775807) -> list[pykungfu.longfist.types.frame_header]:
@@ -842,7 +842,7 @@ class assemble:
     def read_headers(self, data: pykungfu.longfist.types.BrokerStateUpdate = {"location_uid":0,"state":"Pending"}, end_time: int = 9223372036854775807) -> list[pykungfu.longfist.types.frame_header]:
         ...
     @typing.overload
-    def read_headers(self, data: pykungfu.longfist.types.Config = {"category":"MD","group":"","location_uid":0,"mode":"LIVE","name":"","seed":0,"uid64":0,"value":""}, end_time: int = 9223372036854775807) -> list[pykungfu.longfist.types.frame_header]:
+    def read_headers(self, data: pykungfu.longfist.types.Config = {"group":"","location_uid":0,"mode":"LIVE","name":"","role":"SOURCE","seed":0,"uid64":0,"value":""}, end_time: int = 9223372036854775807) -> list[pykungfu.longfist.types.frame_header]:
         ...
     @typing.overload
     def read_headers(self, data: pykungfu.longfist.types.RiskSetting = ..., end_time: int = 9223372036854775807) -> list[pykungfu.longfist.types.frame_header]:
@@ -854,7 +854,7 @@ class assemble:
     def read_headers(self, data: pykungfu.longfist.types.Instrument = {"contract_multiplier":0,"create_date":"","currency":"Unknown","delivery_month":0,"delivery_year":0,"exchange_id":"","expire_date":"","instrument_id":"","instrument_type":"Unknown","open_date":"","price_tick":0.0,"product_id":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"quantity_unit":0.0}, end_time: int = 9223372036854775807) -> list[pykungfu.longfist.types.frame_header]:
         ...
     @typing.overload
-    def read_headers(self, data: pykungfu.longfist.types.Location = {"category":"MD","group":"","location_uid":0,"mode":"LIVE","name":"","seed":0,"uid64":0}, end_time: int = 9223372036854775807) -> list[pykungfu.longfist.types.frame_header]:
+    def read_headers(self, data: pykungfu.longfist.types.Location = {"group":"","location_uid":0,"mode":"LIVE","name":"","role":"SOURCE","seed":0,"uid64":0}, end_time: int = 9223372036854775807) -> list[pykungfu.longfist.types.frame_header]:
         ...
     @typing.overload
     def read_headers(self, data: pykungfu.longfist.types.Basket = {"basket_type":"Custom","cash_difference":0.0,"etf_status":"Forbid","etf_type":"LocalETF","etf_value":0.0,"exchange_id":"","id":0,"instrument_id":"","max_cash_ratio":0.0,"max_purchase_volume":0.0,"max_redemption_volume":0.0,"min_volume":0.0,"name":"","net_unit_value":0.0,"total_amount":0.0,"volume_type":"Unknown"}, end_time: int = 9223372036854775807) -> list[pykungfu.longfist.types.frame_header]:
@@ -887,7 +887,7 @@ class assemble:
     def read_headers(self, data: pykungfu.longfist.types.ChannelRequest = {"dest_id":0,"source_id":0}, end_time: int = 9223372036854775807) -> list[pykungfu.longfist.types.frame_header]:
         ...
     @typing.overload
-    def read_headers(self, data: pykungfu.longfist.types.RequestWriteToBand = {"category":"MD","group":"","location_uid":0,"mode":"LIVE","name":"","page_size":0,"seed":0,"uid64":0}, end_time: int = 9223372036854775807) -> list[pykungfu.longfist.types.frame_header]:
+    def read_headers(self, data: pykungfu.longfist.types.RequestWriteToBand = {"group":"","location_uid":0,"mode":"LIVE","name":"","page_size":0,"role":"SOURCE","seed":0,"uid64":0}, end_time: int = 9223372036854775807) -> list[pykungfu.longfist.types.frame_header]:
         ...
     @typing.overload
     def read_headers(self, data: pykungfu.longfist.types.Band = {"dest_id":0,"source_id":0}, end_time: int = 9223372036854775807) -> list[pykungfu.longfist.types.frame_header]:
@@ -1133,7 +1133,7 @@ class io_device:
     def publisher(self) -> publisher:
         ...
 class location:
-    def __init__(self, m: pykungfu.longfist.enums.mode, c: pykungfu.longfist.enums.category, g: str, n: str, l: ..., default_seed: int = 42) -> None:
+    def __init__(self, m: pykungfu.longfist.enums.mode, c: pykungfu.longfist.enums.location_role, g: str, n: str, l: ..., default_seed: int = 42) -> None:
         ...
     def __repr__(self) -> str:
         ...
@@ -1150,9 +1150,6 @@ class location:
     def to(self, arg0: pykungfu.longfist.types.Location) -> pykungfu.longfist.types.Location:
         ...
     @property
-    def category(self) -> pykungfu.longfist.enums.category:
-        ...
-    @property
     def group(self) -> str:
         ...
     @property
@@ -1163,6 +1160,9 @@ class location:
         ...
     @property
     def name(self) -> str:
+        ...
+    @property
+    def role(self) -> pykungfu.longfist.enums.location_role:
         ...
     @property
     def uid(self) -> int:
@@ -1195,7 +1195,7 @@ class locator:
         ...
     def list_location_dest(self, arg0: location) -> list[int]:
         ...
-    def list_locations(self, category: str = '*', group: str = '*', name: str = '*', mode: str = '*') -> list[location]:
+    def list_locations(self, role: str = '*', group: str = '*', name: str = '*', mode: str = '*') -> list[location]:
         ...
     def list_page_id(self, arg0: location, arg1: int) -> list[int]:
         ...


### PR DESCRIPTION
## Summary
- replace trading-era yijinjing location category with neutral location_role / role across C++, Python, Node, SDK, and stubs
- decouple journal page sizing from location role and use a uniform 16 MiB default storage policy
- document the v4 greenfield decision in ADR-0024

## Validation
- ./kungfu-code build
- ./kungfu-code check
- git diff --check
- Python enum smoke for location_role
- kungfu journal --help exposes --role
