### PR TITLE
refactor(core): fence node longfist public registry

### DIFF
--- a/extensions/system/status/src/view/index.tsx
+++ b/extensions/system/status/src/view/index.tsx
@@ -1,10 +1,11 @@
-// System kfx: system status. Runtime facts (master liveness, versions,
-// binding exports, runtime home) plus the live longfist type registry — the
-// diagnostics face of the shell. The future storage health story
-// (fsck/export overview) mounts here.
-import React from 'react';
 import type { KfxCapabilities, Shell } from '@kungfu-tech/kfx';
 import { headingStyle, mono, panelStyle } from '@kungfu-tech/kfx';
+import React from 'react';
+
+// System kfx: system status. Runtime facts (master liveness, versions,
+// binding exports, runtime home) plus the core longfist type registry — the
+// diagnostics face of the shell. The future storage health story
+// (fsck/export overview) mounts here.
 
 function SystemStatusView({
   caps,
@@ -65,7 +66,7 @@ function SystemStatusView({
         </ul>
       </section>
       <section style={panelStyle}>
-        <h2 style={headingStyle}>Longfist type registry · {registry.length}</h2>
+        <h2 style={headingStyle}>Core longfist registry · {registry.length}</h2>
         <div style={{ display: 'flex', gap: 12 }}>
           <ul
             style={{ listStyle: 'none', margin: 0, padding: 0, minWidth: 180 }}
@@ -105,7 +106,7 @@ function SystemStatusView({
               </>
             ) : (
               <span style={{ color: '#6a6a6a' }}>
-                select a type — fields come from the live C++ type registry
+                select a type — fields come from the public C++ core registry
               </span>
             )}
           </div>

--- a/framework/core/src/bindings/node/binding/longfist.cpp
+++ b/framework/core/src/bindings/node/binding/longfist.cpp
@@ -43,7 +43,7 @@ void Longfist::Init(Napi::Env env, Napi::Object exports) {
 Napi::Value Longfist::GetCarrierTypes(const Napi::CallbackInfo &info) { return carrier_types_ref_.Value(); }
 
 void Longfist::InitCarrierTypes(const Napi::CallbackInfo &info) {
-  boost::hana::for_each(AllTypes, [&](auto it) {
+  boost::hana::for_each(CorePublicDataTypes, [&](auto it) {
     using DataType = typename decltype(+boost::hana::second(it))::type;
     carrier_types_ref_.Set(int(DataType::tag), Napi::String::New(info.Env(), DataType::type_name.c_str()));
   });
@@ -52,7 +52,7 @@ void Longfist::InitCarrierTypes(const Napi::CallbackInfo &info) {
 Napi::Value Longfist::GetTypes(const Napi::CallbackInfo &info) { return types_ref_.Value(); }
 
 void Longfist::InitTypes(const Napi::CallbackInfo &info) {
-  boost::hana::for_each(StateDataTypes, [&](auto it) {
+  boost::hana::for_each(CorePublicDataTypes, [&](auto it) {
     auto name = boost::hana::first(it);
     using DataType = typename decltype(+boost::hana::second(it))::type;
     static const auto make = serialize::JsMake<DataType>(name.c_str());

--- a/framework/core/src/libkungfu/include/kungfu/longfist/longfist.h
+++ b/framework/core/src/libkungfu/include/kungfu/longfist/longfist.h
@@ -180,10 +180,10 @@ constexpr auto AllDataTypes = boost::hana::make_map( //
     TYPE_PAIR(TimeKeyValue)                          // 10602
 );
 
-// Public Python longfist types are limited to v4 runtime/core schemas. The
-// broader AllTypes/AllDataTypes registries are legacy compiled schema sets used
-// by diagnostics, raw journal decoding, and staged compatibility paths; they
-// are not the language-neutral action-recording surface.
+// Public language bindings are limited to v4 runtime/core schemas. The broader
+// AllTypes/AllDataTypes registries are legacy compiled schema sets used by
+// diagnostics, raw journal decoding, and staged compatibility paths; they are
+// not the language-neutral action-recording surface.
 constexpr auto CorePublicDataTypes = boost::hana::make_map( //
     TYPE_PAIR(frame_header),                                // 0
     TYPE_PAIR(page_header),                                 // 1

--- a/scripts/check-yijinjing-greenfield.mjs
+++ b/scripts/check-yijinjing-greenfield.mjs
@@ -20,6 +20,63 @@ const allFiles = args.includes('--all');
 const SOURCE_EXT = /\.(c|cc|cpp|cxx|h|hh|hpp|hxx|mjs|js|cjs|ts|tsx|py|pyi)$/;
 const LEGACY_PY_LONGFIST_TYPES =
   /\b(AlgoOrder|AlgoOrderAction|AlgoOrderActionError|AlgoOrderInput|Asset|Basket|BasketInstrument|BlockMessage|Commission|Contract|CustomSubscribe|Entrust|HistoryOrder|HistoryTrade|Instrument|InstrumentFactor|InstrumentKey|Order|OrderAction|OrderActionError|OrderInput|OrderStat|OrderTrigger|OrderTriggerAction|OrderTriggerActionError|OrderTriggerInput|Position|PositionEnd|Quote|RequestHistoryOrder|RequestHistoryOrderError|RequestHistoryTrade|RequestHistoryTradeError|RiskSetting|Trade|TradingDay|Transaction|Tree)\b/g;
+const LEGACY_CORE_PUBLIC_TYPES = [
+  'AlgoOrder',
+  'AlgoOrderAction',
+  'AlgoOrderActionError',
+  'AlgoOrderInput',
+  'Asset',
+  'AssetRequest',
+  'AssetSync',
+  'Basket',
+  'BasketInstrument',
+  'BlockMessage',
+  'Commission',
+  'Contract',
+  'ContractRequest',
+  'CustomSubscribe',
+  'Depth',
+  'Entrust',
+  'HistoryOrder',
+  'HistoryTrade',
+  'Instrument',
+  'InstrumentFactor',
+  'InstrumentKey',
+  'KeepPositionsRequest',
+  'MirrorPositionsRequest',
+  'Order',
+  'OrderAction',
+  'OrderActionError',
+  'OrderInput',
+  'OrderStat',
+  'OrderTrigger',
+  'OrderTriggerAction',
+  'OrderTriggerActionError',
+  'OrderTriggerInput',
+  'OrderTriggerRequest',
+  'Position',
+  'PositionEnd',
+  'PositionRequest',
+  'PositionSync',
+  'Quote',
+  'RebuildPositionsRequest',
+  'RequestHistoryOrder',
+  'RequestHistoryOrderError',
+  'RequestHistoryTrade',
+  'RequestHistoryTradeError',
+  'ResetBookRequest',
+  'RiskSetting',
+  'Tick',
+  'Trade',
+  'TradingDay',
+  'Transaction',
+  'Tree',
+];
+const CORE_PUBLIC_REGISTRIES = [
+  'CorePublicDataTypes',
+  'CorePublicStateDataTypes',
+  'CorePublicProfileDataTypes',
+];
 
 const RULES = [
   {
@@ -48,6 +105,13 @@ const RULES = [
     re: /\bProfileDataTypes\b|boost::hana::for_each\(longfist::ProfileDataTypes/g,
     message:
       'Python yijinjing profile must bind CorePublicProfileDataTypes, not the internal profile schema set.',
+  },
+  {
+    name: 'node longfist public internal registry binding',
+    files: [/^framework\/core\/src\/bindings\/node\/binding\/longfist\.cpp$/],
+    re: /\b(AllTypes|AllDataTypes|StateDataTypes|ProfileDataTypes)\b|boost::hana::for_each\((AllTypes|AllDataTypes|StateDataTypes|ProfileDataTypes)/g,
+    message:
+      'Node longfist public types/carrierTypes must bind CorePublic*DataTypes, not the legacy internal schema sets.',
   },
   {
     name: 'python longfist public trading stubs',
@@ -201,6 +265,46 @@ function lineNumber(text, index) {
   return line;
 }
 
+function corePublicRegistryHits(rel, text) {
+  if (
+    rel !== 'framework/core/src/libkungfu/include/kungfu/longfist/longfist.h'
+  ) {
+    return [];
+  }
+  const hits = [];
+  for (const registry of CORE_PUBLIC_REGISTRIES) {
+    const blockRe = new RegExp(
+      `constexpr auto ${registry} = boost::hana::make_map\\([\\s\\S]*?\\n\\);`,
+      'm',
+    );
+    const block = blockRe.exec(text);
+    if (!block) {
+      hits.push({
+        file: rel,
+        line: 1,
+        rule: `${registry} exists`,
+        message: `${registry} must stay explicit so public binding checks can audit it.`,
+        text: registry,
+      });
+      continue;
+    }
+    for (const typeName of LEGACY_CORE_PUBLIC_TYPES) {
+      const typeRe = new RegExp(`\\bTYPE_PAIR\\(${typeName}\\)\\b`);
+      const typeMatch = typeRe.exec(block[0]);
+      if (!typeMatch) continue;
+      hits.push({
+        file: rel,
+        line: lineNumber(text, block.index + typeMatch.index),
+        rule: `${registry} legacy type`,
+        message:
+          'CorePublic*DataTypes must stay runtime/core-only; legacy trading/profile schemas belong to internal compatibility registries.',
+        text: typeName,
+      });
+    }
+  }
+  return hits;
+}
+
 const hits = [];
 for (const rel of selectedFiles()) {
   const rules = RULES.filter((rule) => rule.files.some((re) => re.test(rel)));
@@ -218,6 +322,7 @@ for (const rel of selectedFiles()) {
       });
     }
   }
+  hits.push(...corePublicRegistryHits(rel, text));
 }
 
 if (hits.length) {


### PR DESCRIPTION
## Summary
- bind Node Longfist public `types` and `carrierTypes` to `CorePublicDataTypes`
- update the status view wording to show the core registry rather than the legacy compiled registry
- extend the yijinjing greenfield guard to block public Node binding and CorePublic* registry regressions

## Validation
- ./kungfu-code build
- ./kungfu-code check
- node scripts/check-yijinjing-greenfield.mjs --all
- node scripts/check-carrier-action-envelope.mjs --all
- node framework/core/src/libyijinjing/check-deps.mjs
- git diff --check
- runtime probe: Longfist public types/carrierTypes expose 27 core entries and no legacy trading/profile entries