### PR TITLE
refactor(core): name legacy compiled longfist registry

### DIFF
--- a/framework/core/src/bindings/node/binding/journal.cpp
+++ b/framework/core/src/bindings/node/binding/journal.cpp
@@ -61,8 +61,8 @@ Napi::Value Frame::DataType(const Napi::CallbackInfo &info) {
 
 Napi::Value Frame::Data(const Napi::CallbackInfo &info) {
   auto result = Napi::Object::New(info.Env());
-  // have to be AllDataTypes, for data size is not 0
-  boost::hana::for_each(longfist::AllDataTypes, [&](auto it) {
+  // Legacy compiled payload decoder; open-layer frames should use dataBytes().
+  boost::hana::for_each(longfist::LegacyCompiledDataTypes, [&](auto it) {
     using DataType = typename decltype(+boost::hana::second(it))::type;
     if (frame_->carrier_type() == DataType::tag) {
       serialize::JsSet{}(frame_->data<DataType>(), result);
@@ -77,8 +77,8 @@ Napi::Value Frame::Data(const Napi::CallbackInfo &info) {
 
 Napi::Value Frame::DataAsString(const Napi::CallbackInfo &info) {
   std::string result = "";
-  // have to be AllDataTypes, for data size is not 0
-  boost::hana::for_each(longfist::AllDataTypes, [&](auto it) {
+  // Legacy compiled payload decoder; open-layer frames should use dataBytes().
+  boost::hana::for_each(longfist::LegacyCompiledDataTypes, [&](auto it) {
     using DataType = typename decltype(+boost::hana::second(it))::type;
     if (frame_->carrier_type() == DataType::tag) {
       result = frame_->data<DataType>().to_string();

--- a/framework/core/src/libkungfu/include/kungfu/longfist/longfist.h
+++ b/framework/core/src/libkungfu/include/kungfu/longfist/longfist.h
@@ -181,9 +181,12 @@ constexpr auto AllDataTypes = boost::hana::make_map( //
 );
 
 // Public language bindings are limited to v4 runtime/core schemas. The broader
-// AllTypes/AllDataTypes registries are legacy compiled schema sets used by
-// diagnostics, raw journal decoding, and staged compatibility paths; they are
-// not the language-neutral action-recording surface.
+// AllTypes/AllDataTypes names are retained for compatibility; internal code
+// should use the explicit LegacyCompiled* names below whenever it intentionally
+// decodes historical compiled longfist payloads.
+constexpr auto LegacyCompiledTypes = AllTypes;
+constexpr auto LegacyCompiledDataTypes = AllDataTypes;
+
 constexpr auto CorePublicDataTypes = boost::hana::make_map( //
     TYPE_PAIR(frame_header),                                // 0
     TYPE_PAIR(page_header),                                 // 1
@@ -289,7 +292,8 @@ const auto build_data_set = [](auto types) {
   return s;
 };
 
-const auto AllTypesTags = build_data_set(AllTypes);
+const auto LegacyCompiledTypeTags = build_data_set(LegacyCompiledTypes);
+const auto AllTypesTags = LegacyCompiledTypeTags;
 const auto ProfileDataTags = build_data_set(ProfileDataTypes);
 const auto StaticDataTags = build_data_set(StaticDataTypes);
 const auto LegacyRefreshDataTags = build_data_set(LegacyRefreshDataTypes);

--- a/framework/core/src/libkungfu/include/kungfu/yijinjing/rx.h
+++ b/framework/core/src/libkungfu/include/kungfu/yijinjing/rx.h
@@ -39,7 +39,7 @@ static constexpr auto instanceof =
 
 static constexpr auto is_custom_event = [](const event_ptr &event) -> bool {
   return event->carrier_type() > 0 and
-         longfist::AllTypesTags.find(event->carrier_type()) == longfist::AllTypesTags.end();
+         longfist::LegacyCompiledTypeTags.find(event->carrier_type()) == longfist::LegacyCompiledTypeTags.end();
 };
 
 static constexpr auto is_custom = []() {

--- a/framework/core/src/libkungfu/src/yijinjing/io/console.cpp
+++ b/framework/core/src/libkungfu/src/yijinjing/io/console.cpp
@@ -110,7 +110,7 @@ void io_device_console::trace(int64_t begin_time, int64_t end_time, bool in, boo
                      : location::SYNC                  ? "sync"
                                                        : locations.at(frame->dest())->uname;
     bool type_found = false;
-    boost::hana::for_each(AllTypes, [&](auto type) {
+    boost::hana::for_each(LegacyCompiledTypes, [&](auto type) {
       using DataType = typename decltype(+boost::hana::second(type))::type;
       if (frame->carrier_type() == DataType::tag) {
         table.add_row({
@@ -174,7 +174,7 @@ void io_device_console::show(int64_t begin_time, int64_t end_time, bool in, bool
                      : location::SYNC                  ? "sync"
                                                        : locations.at(frame->dest())->uname;
     bool type_found = false;
-    boost::hana::for_each(AllTypes, [&](auto type) {
+    boost::hana::for_each(LegacyCompiledTypes, [&](auto type) {
       using DataType = typename decltype(+boost::hana::second(type))::type;
       if (frame->carrier_type() == DataType::tag) {
         table.add_row({

--- a/framework/core/src/libkungfu/src/yijinjing/journal/replay_writer.cpp
+++ b/framework/core/src/libkungfu/src/yijinjing/journal/replay_writer.cpp
@@ -59,7 +59,7 @@ void replay_writer::close_frame(size_t data_length, int64_t gen_time) {
 uint64_t replay_writer::current_frame_uid() {
   uint64_t uid = 0;
   auto frame = reader_for_write_->current_frame();
-  boost::hana::for_each(longfist::AllDataTypes, [&](auto it) {
+  boost::hana::for_each(longfist::LegacyCompiledDataTypes, [&](auto it) {
     using DataType = typename decltype(+boost::hana::second(it))::type;
     if (frame->carrier_type() == DataType::tag) {
       uid = frame->data<DataType>().uid();

--- a/framework/core/src/libkungfu/src/yijinjing/typed_frame_dump.cpp
+++ b/framework/core/src/libkungfu/src/yijinjing/typed_frame_dump.cpp
@@ -2,10 +2,11 @@
 
 // Runtime side of the frame typed-dump seam: the yijinjing core renders only
 // header + json payloads in frame::to_string(); this installs a dumper that
-// resolves raw payloads against the full longfist type registry, restoring the
-// typed output every runtime consumer expects. Installed on load (static init)
-// and again explicitly from the io_device constructor, so static-library
-// builds that drop unreferenced objects still get it before any runtime dump.
+// resolves raw payloads against the legacy compiled longfist registry,
+// restoring the typed output every runtime consumer expects. Installed on load
+// (static init) and again explicitly from the io_device constructor, so
+// static-library builds that drop unreferenced objects still get it before any
+// runtime dump.
 
 #include <kungfu/longfist/longfist.h>
 #include <kungfu/yijinjing/journal/frame.h>
@@ -14,7 +15,7 @@ namespace kungfu::yijinjing::journal {
 
 void install_typed_frame_dumper() {
   frame::type_dumper() = [](const frame &self, nlohmann::json &j) {
-    hana::for_each(longfist::AllTypes, [&](auto pair) {
+    hana::for_each(longfist::LegacyCompiledTypes, [&](auto pair) {
       using DataType = typename decltype(+hana::second(pair))::type;
       if (DataType::tag == self.carrier_type()) {
         j["data"] = self.data<DataType>().to_string();

--- a/framework/core/src/libyijinjing/check-deps.mjs
+++ b/framework/core/src/libyijinjing/check-deps.mjs
@@ -26,7 +26,7 @@ const forbiddenIncludes =
   /^\s*#\s*include\s*[<"](nng\/|rxcpp\/|sqlite|rocksdb\/|kungfu\/longfist\/longfist\.h|kungfu\/longfist\/types\.h|kungfu\/longfist\/enums\.h|kungfu\/longfist\/sqlite|kungfu\/yijinjing\/practice\/|kungfu\/yijinjing\/cache\/|kungfu\/yijinjing\/index\/|kungfu\/yijinjing\/nanomsg\/|kungfu\/yijinjing\/socket\/|kungfu\/yijinjing\/io\.h|kungfu\/yijinjing\/rx\.h|kungfu\/yijinjing\/util\/rocks\.h|kungfu\/wingchun\/)/;
 
 const forbiddenSymbols =
-  /longfist::types::(Order|Trade|Position)|types::(Order|Trade|Position)[A-Za-z]*\b|AllTypes\b|AllDataTypes\b|AllTypesTags\b|wingchun/;
+  /longfist::types::(Order|Trade|Position)|types::(Order|Trade|Position)[A-Za-z]*\b|AllTypes\b|AllDataTypes\b|AllTypesTags\b|LegacyCompiledTypes\b|LegacyCompiledDataTypes\b|LegacyCompiledTypeTags\b|wingchun/;
 
 function* walk(dir) {
   if (!fs.existsSync(dir)) return;

--- a/scripts/check-yijinjing-greenfield.mjs
+++ b/scripts/check-yijinjing-greenfield.mjs
@@ -77,6 +77,9 @@ const CORE_PUBLIC_REGISTRIES = [
   'CorePublicStateDataTypes',
   'CorePublicProfileDataTypes',
 ];
+const INTERNAL_LEGACY_REGISTRY_RE =
+  /\b(AllTypes|AllDataTypes|AllTypesTags|LegacyCompiledTypes|LegacyCompiledDataTypes|LegacyCompiledTypeTags)\b/g;
+const DIRECT_LEGACY_REGISTRY_RE = /\b(AllTypes|AllDataTypes|AllTypesTags)\b/g;
 
 const RULES = [
   {
@@ -84,7 +87,7 @@ const RULES = [
     files: [
       /^framework\/core\/src\/bindings\/python\/binding\/py-yijinjing\.cpp$/,
     ],
-    re: /\bAllDataTypes\b|boost::hana::for_each\(AllDataTypes/g,
+    re: INTERNAL_LEGACY_REGISTRY_RE,
     message:
       'Python yijinjing must expose neutral raw/envelope APIs, not generated business typed helpers.',
   },
@@ -93,7 +96,7 @@ const RULES = [
     files: [
       /^framework\/core\/src\/bindings\/python\/binding\/py-longfist-types\.cpp$/,
     ],
-    re: /\b(AllDataTypes|StateDataTypes)\b|boost::hana::for_each\((AllDataTypes|StateDataTypes)/g,
+    re: /\b(AllDataTypes|StateDataTypes|LegacyCompiledTypes|LegacyCompiledDataTypes|LegacyCompiledTypeTags)\b|boost::hana::for_each\((AllDataTypes|StateDataTypes|LegacyCompiledTypes|LegacyCompiledDataTypes)/g,
     message:
       'Python longfist public types/state must bind CorePublic*DataTypes, not the legacy internal schema sets.',
   },
@@ -109,7 +112,7 @@ const RULES = [
   {
     name: 'node longfist public internal registry binding',
     files: [/^framework\/core\/src\/bindings\/node\/binding\/longfist\.cpp$/],
-    re: /\b(AllTypes|AllDataTypes|StateDataTypes|ProfileDataTypes)\b|boost::hana::for_each\((AllTypes|AllDataTypes|StateDataTypes|ProfileDataTypes)/g,
+    re: /\b(AllTypes|AllDataTypes|StateDataTypes|ProfileDataTypes|LegacyCompiledTypes|LegacyCompiledDataTypes|LegacyCompiledTypeTags)\b|boost::hana::for_each\((AllTypes|AllDataTypes|StateDataTypes|ProfileDataTypes|LegacyCompiledTypes|LegacyCompiledDataTypes)/g,
     message:
       'Node longfist public types/carrierTypes must bind CorePublic*DataTypes, not the legacy internal schema sets.',
   },
@@ -305,6 +308,33 @@ function corePublicRegistryHits(rel, text) {
   return hits;
 }
 
+function directLegacyRegistryNameHits(rel, text) {
+  if (
+    rel === 'framework/core/src/libkungfu/include/kungfu/longfist/longfist.h' ||
+    rel === 'framework/core/src/libkungfu/include/kungfu/longfist/types.h' ||
+    rel === 'framework/core/src/libyijinjing/check-deps.mjs' ||
+    rel === 'scripts/check-yijinjing-greenfield.mjs'
+  ) {
+    return [];
+  }
+  if (!/^framework\/core\/src\/(bindings|libkungfu|libyijinjing)\//.test(rel)) {
+    return [];
+  }
+  const hits = [];
+  DIRECT_LEGACY_REGISTRY_RE.lastIndex = 0;
+  for (const match of text.matchAll(DIRECT_LEGACY_REGISTRY_RE)) {
+    hits.push({
+      file: rel,
+      line: lineNumber(text, match.index || 0),
+      rule: 'direct legacy registry compatibility alias',
+      message:
+        'Use LegacyCompiled* names for internal compiled-schema compatibility paths; keep AllTypes/AllDataTypes as compatibility aliases only.',
+      text: match[0],
+    });
+  }
+  return hits;
+}
+
 const hits = [];
 for (const rel of selectedFiles()) {
   const rules = RULES.filter((rule) => rule.files.some((re) => re.test(rel)));
@@ -323,6 +353,7 @@ for (const rel of selectedFiles()) {
     }
   }
   hits.push(...corePublicRegistryHits(rel, text));
+  hits.push(...directLegacyRegistryNameHits(rel, text));
 }
 
 if (hits.length) {


### PR DESCRIPTION
## Summary
- add explicit LegacyCompiled* registry names for internal compiled longfist compatibility decode paths
- move journal replay, console, typed dump, rx custom-event detection, and Node Frame typed decode away from direct AllTypes/AllDataTypes names
- extend greenfield/dependency guards so public bindings and future yijinjing code cannot reintroduce legacy registry coupling

## Validation
- ./kungfu-code build
- ./kungfu-code check
- node scripts/check-carrier-action-envelope.mjs --all
- node scripts/check-yijinjing-greenfield.mjs --all
- node framework/core/src/libyijinjing/check-deps.mjs
- git diff --check