### PR TITLE
refactor(core): remove watcher legacy data path

### DIFF
--- a/framework/api/src/capability/ledger.ts
+++ b/framework/api/src/capability/ledger.ts
@@ -46,16 +46,7 @@ export function openLedger(options: OpenLedgerOptions): Ledger {
   if (options.join) {
     // Constructing a watcher initializes the runtime home layout; starting
     // it makes it join a live master when one is running.
-    watcher = new binding.Watcher(
-      runtimeDir,
-      options.join.name,
-      true,
-      true,
-      true,
-      false,
-      true,
-      50,
-    );
+    watcher = new binding.Watcher(runtimeDir, options.join.name, true, 50);
     if (!watcher.isStarted()) watcher.start();
     joined = true;
   }

--- a/framework/api/src/capability/types.ts
+++ b/framework/api/src/capability/types.ts
@@ -210,10 +210,6 @@ export type KfNativeBinding = {
     runtimeDir: string,
     name: string,
     bypassRestore: boolean,
-    bypassAccounting: boolean,
-    bypassTradingData: boolean,
-    refreshTradingDataBeforeSync: boolean,
-    bypassRefreshBook: boolean,
     millisecondsSleepAfterStep: number,
   ) => {
     isUsable: () => boolean;

--- a/framework/core/docs/adr/ADR-0026-yijinjing-greenfield-core-surface.md
+++ b/framework/core/docs/adr/ADR-0026-yijinjing-greenfield-core-surface.md
@@ -40,9 +40,9 @@ those internal compiled schemas, but they should not re-create a broad
 business-typed journal API.
 
 Remove unused `TradingDataTypes` / `MarketDataTypes` closed-set registries from
-the v4 `longfist.h` core registry. The remaining `LegacyRefreshDataTypes` name
-is explicit technical debt for the existing Node watcher compatibility path, not
-a v4 product-domain model.
+the v4 `longfist.h` core registry. The Node watcher no longer carries the old
+trading-data refresh path; it maintains only the neutral state cache required by
+the runtime view.
 
 Add `scripts/check-yijinjing-greenfield.mjs` to prevent these specific patterns
 from returning.

--- a/framework/core/lib/kungfu.js
+++ b/framework/core/lib/kungfu.js
@@ -26,7 +26,7 @@ function resolveBindingDir(moduleName) {
   if (descriptor) {
     try {
       const platformPackage = require(descriptor.name);
-      if (platformPackage && platformPackage.bindingDir) {
+      if (platformPackage?.bindingDir) {
         return platformPackage.bindingDir;
       }
     } catch (e) {
@@ -45,7 +45,7 @@ function resolveBindingDir(moduleName) {
  * public factory API this module hands to callers, not the addon internals.
  * @returns {Record<string, any>}
  */
-module.exports = function () {
+module.exports = () => {
   /** @type {any} */
   const binding = (() => {
     try {
@@ -91,52 +91,29 @@ module.exports = function () {
      * @param {string} [name]
      * @returns {any}
      */
-    Assemble: function (
-      arg,
-      mode = '*',
-      category = '*',
-      group = '*',
-      name = '*',
-    ) {
+    Assemble: (arg, mode = '*', category = '*', group = '*', name = '*') => {
       if (Array.isArray(arg)) {
         return new binding.Assemble(arg, mode, category, group, name);
-      } else {
-        return new binding.Assemble([arg], mode, category, group, name);
       }
+      return new binding.Assemble([arg], mode, category, group, name);
     },
 
     /** @param {any} home @returns {any} */
-    History: function (home) {
-      return new binding.History(home);
-    },
+    History: (home) => new binding.History(home),
     /** @param {any} home @returns {any} */
-    ConfigStore: function (home) {
-      return new binding.ConfigStore(home);
-    },
+    ConfigStore: (home) => new binding.ConfigStore(home),
     /** @param {any} home @returns {any} */
-    RiskSettingStore: function (home) {
-      return new binding.RiskSettingStore(home);
-    },
+    RiskSettingStore: (home) => new binding.RiskSettingStore(home),
     /** @param {any} home @returns {any} */
-    CommissionStore: function (home) {
-      return new binding.CommissionStore(home);
-    },
+    CommissionStore: (home) => new binding.CommissionStore(home),
     /** @param {any} home @returns {any} */
-    BasketStore: function (home) {
-      return new binding.BasketStore(home);
-    },
+    BasketStore: (home) => new binding.BasketStore(home),
     /** @param {any} home @returns {any} */
-    BasketInstrumentStore: function (home) {
-      return new binding.BasketInstrumentStore(home);
-    },
+    BasketInstrumentStore: (home) => new binding.BasketInstrumentStore(home),
     /** @param {any} location @param {any} home @returns {any} */
-    SessionStore: function (location, home) {
-      return new binding.SessionStore(location, home);
-    },
+    SessionStore: (location, home) => new binding.SessionStore(location, home),
     /** @param {any} location @param {any} home @returns {any} */
-    IODevice: function (location, home) {
-      return new binding.IODevice(location, home);
-    },
+    IODevice: (location, home) => new binding.IODevice(location, home),
     /**
      * @param {any} location
      * @param {any} home
@@ -146,41 +123,27 @@ module.exports = function () {
      * @param {number} end
      * @returns {any}
      */
-    tracer: function (location, home, read, write, begin, end) {
-      return new binding.Tracer(location, home, read, write, begin, end);
-    },
+    tracer: (location, home, read, write, begin, end) =>
+      new binding.Tracer(location, home, read, write, begin, end),
 
     /**
      * @param {any} home
      * @param {string} name
      * @param {boolean} [bypassRestore]
-     * @param {boolean} [bypassAccounting]
-     * @param {boolean} [bypassTradingData]
-     * @param {boolean} [refreshTradingDataBeforeSync]
-     * @param {boolean} [bypassRefreshBook]
      * @param {number} [millisecondsSleepAfterStep]
      * @returns {any}
      */
-    watcher: function (
+    watcher: (
       home,
       name,
       bypassRestore = false,
-      bypassAccounting = false,
-      bypassTradingData = false,
-      refreshTradingDataBeforeSync = false,
-      bypassRefreshBook = false,
       millisecondsSleepAfterStep = 50,
-    ) {
-      return new binding.Watcher(
+    ) =>
+      new binding.Watcher(
         home,
         name,
         bypassRestore,
-        bypassAccounting,
-        bypassTradingData,
-        refreshTradingDataBeforeSync,
-        bypassRefreshBook,
         millisecondsSleepAfterStep,
-      );
-    },
+      ),
   };
 };

--- a/framework/core/src/bindings/node/binding/operators.cpp
+++ b/framework/core/src/bindings/node/binding/operators.cpp
@@ -27,13 +27,4 @@ void InitStateMap(const Napi::CallbackInfo &info, Napi::ObjectReference &state, 
   state.Value().DefineProperty(Napi::PropertyDescriptor::Value("state_name", Napi::String::New(state.Env(), name)));
 }
 
-void RefreshLegacyDataInStateMap(Napi::ObjectReference &state, const std::string &name) {
-  boost::hana::for_each(longfist::LegacyRefreshDataTypes, [&](auto it) {
-    using DataType = typename decltype(+boost::hana::second(it))::type;
-    auto hana_type = boost::hana::type_c<DataType>;
-    auto type_name = std::string(boost::hana::first(it).c_str());
-    state.Set(type_name, DataTable::NewInstance(state.Value()));
-  });
-}
-
 } // namespace kungfu::node::serialize

--- a/framework/core/src/bindings/node/binding/operators.h
+++ b/framework/core/src/bindings/node/binding/operators.h
@@ -382,8 +382,6 @@ private:
 void InitObjectReference(const Napi::CallbackInfo &info, Napi::ObjectReference &data);
 
 void InitStateMap(const Napi::CallbackInfo &info, Napi::ObjectReference &state, const std::string &name);
-
-void RefreshLegacyDataInStateMap(Napi::ObjectReference &state, const std::string &name);
 } // namespace kungfu::node::serialize
 
 #endif // KUNGFU_NODE_SERIALIZE_H

--- a/framework/core/src/bindings/node/binding/watcher.cpp
+++ b/framework/core/src/bindings/node/binding/watcher.cpp
@@ -23,7 +23,6 @@ using namespace kungfu::yijinjing::data;
 namespace kungfu::node {
 
 constexpr uint32_t STEP_INTERVAL = 10;
-constexpr uint32_t LEGACY_REFRESH_DATA_LIMIT_BY_SYNC = 3000;
 
 inline std::string format(uint32_t uid) { return fmt::format("{:08x}", uid); }
 
@@ -54,10 +53,10 @@ inline bool GetBypassRestore(const Napi::CallbackInfo &info) {
 }
 
 inline int GetMillisecondsSleepAfterStep(const Napi::CallbackInfo &info) {
-  if (not IsValid(info, 7, &Napi::Value::IsNumber)) {
+  if (not IsValid(info, 3, &Napi::Value::IsNumber)) {
     throw Napi::Error::New(info.Env(), "Invalid millisecondsSleepAfterStep argument");
   }
-  return info[7].As<Napi::Number>().Int32Value();
+  return info[3].As<Napi::Number>().Int32Value();
 }
 
 // The function-try-block is deliberate: base-class construction (apprentice
@@ -66,15 +65,9 @@ inline int GetMillisecondsSleepAfterStep(const Napi::CallbackInfo &info) {
 // initializer exceptions. A plain std::exception escaping this napi callback
 // terminates the whole process; convert to a JS-catchable error instead.
 Watcher::Watcher(const Napi::CallbackInfo &info) try
-    : ObjectWrap(info),                                   //
-      apprentice(GetWatcherLocation(info), true),         //
-      bypass_accounting_(GetBool(info, 3)),               //
-      bypass_legacy_data_(GetBool(info, 4)),              //
-      refresh_legacy_data_before_sync_(GetBool(info, 5)), //
-      bypass_refresh_book_(GetBool(info, 6)),             //
-      milliseconds_sleep_after_step_(GetNumber(info, 7)), //
-      legacy_data_reader_(std::make_shared<yijinjing::journal::reader>(
-          true, false, std::make_shared<yijinjing::journal::bus>(false))),                        //
+    : ObjectWrap(info),                                                                           //
+      apprentice(GetWatcherLocation(info), true),                                                 //
+      milliseconds_sleep_after_step_(GetNumber(info, 3)),                                         //
       ledger_ref_(Napi::ObjectReference::New(Napi::Object::New(info.Env()), 1)),                  //
       app_states_ref_(Napi::ObjectReference::New(Napi::Object::New(info.Env()), 1)),              //
       strategy_states_ref_(Napi::ObjectReference::New(Napi::Object::New(info.Env()), 1)),         //
@@ -95,7 +88,7 @@ Watcher::Watcher(const Napi::CallbackInfo &info) try
   SPDLOG_INFO("Watcher created for {}", get_home_uname());
 
   // byPassRestore will be true after ui browserWindow reopen by crashed
-  if (GetBypassRestore(info) or bypass_legacy_data_) {
+  if (GetBypassRestore(info)) {
     return;
   }
 
@@ -180,15 +173,6 @@ Napi::Value Watcher::IsLive(const Napi::CallbackInfo &info) { return Napi::Boole
 
 Napi::Value Watcher::IsStarted(const Napi::CallbackInfo &info) { return Napi::Boolean::New(info.Env(), is_started()); }
 
-Napi::Value Watcher::RequestPosition(const Napi::CallbackInfo &info) {
-  if (not has_writer(ledger_home_location_->uid)) {
-    return Napi::Boolean::New(info.Env(), false);
-  }
-
-  get_writer(ledger_home_location_->uid)->mark(now(), PositionRequest::tag);
-  return Napi::Boolean::New(info.Env(), true);
-}
-
 Napi::Value Watcher::RequestStop(const Napi::CallbackInfo &info) {
   auto app_location = IODevice::ExtractLocation(info, 0, get_locator());
 
@@ -226,28 +210,6 @@ Napi::Value Watcher::IssueCustomData(const Napi::CallbackInfo &info) {
   return InteractWithLocation<TimeKeyValue>(info, info[0].ToObject());
 }
 
-// Legacy command handlers are kept as no-op compatibility shims until the next
-// Watcher rebuild exposes neutral agent-event commands.
-Napi::Value Watcher::IssueBlockMessage(const Napi::CallbackInfo &info) {
-  SPDLOG_INFO("issue block message ignored (legacy command shim)");
-  return Napi::BigInt::New(info.Env(), std::uint64_t(0));
-}
-
-Napi::Value Watcher::IssueOrderTrigger(const Napi::CallbackInfo &info) {
-  SPDLOG_INFO("issue order trigger ignored (legacy command shim)");
-  return Napi::BigInt::New(info.Env(), std::uint64_t(0));
-}
-
-Napi::Value Watcher::IssueOrder(const Napi::CallbackInfo &info) {
-  SPDLOG_INFO("issue order ignored (legacy command shim)");
-  return Napi::BigInt::New(info.Env(), std::uint64_t(0));
-}
-
-Napi::Value Watcher::IssueAlgoOrder(const Napi::CallbackInfo &info) {
-  SPDLOG_INFO("issue algo order ignored (legacy command shim)");
-  return Napi::BigInt::New(info.Env(), std::uint64_t(0));
-}
-
 Napi::Value Watcher::IssueMark(const Napi::CallbackInfo &info) {
   SPDLOG_INFO("issue mark");
   uint32_t tag = GetNumber(info, 0);
@@ -257,26 +219,6 @@ Napi::Value Watcher::IssueMark(const Napi::CallbackInfo &info) {
   }
   get_writer(target_location->location_uid)->mark(yijinjing::time::now_in_nano(), tag);
   return Napi::Boolean::New(info.Env(), true);
-}
-
-Napi::Value Watcher::CancelOrder(const Napi::CallbackInfo &info) {
-  SPDLOG_INFO("cancel order ignored (legacy command shim)");
-  return Napi::BigInt::New(info.Env(), std::uint64_t(0));
-}
-
-Napi::Value Watcher::CancelAlgoOrder(const Napi::CallbackInfo &info) {
-  SPDLOG_INFO("cancel algo order ignored (legacy command shim)");
-  return Napi::BigInt::New(info.Env(), std::uint64_t(0));
-}
-
-Napi::Value Watcher::CancelOrderTrigger(const Napi::CallbackInfo &info) {
-  SPDLOG_INFO("cancel order trigger ignored (legacy command shim)");
-  return Napi::BigInt::New(info.Env(), std::uint64_t(0));
-}
-
-Napi::Value Watcher::ToggleAlgoOrder(const Napi::CallbackInfo &info) {
-  SPDLOG_INFO("toggle algo order ignored (legacy command shim)");
-  return Napi::BigInt::New(info.Env(), std::uint64_t(0));
 }
 
 void Watcher::Init(Napi::Env env, Napi::Object exports) {
@@ -297,16 +239,7 @@ void Watcher::Init(Napi::Env env, Napi::Object exports) {
                       InstanceMethod("publishState", &Watcher::PublishState),                           //
                       InstanceMethod("isReadyToInteract", &Watcher::IsReadyToInteract),                 //
                       InstanceMethod("issueCustomData", &Watcher::IssueCustomData),                     //
-                      InstanceMethod("issueBlockMessage", &Watcher::IssueBlockMessage),                 //
-                      InstanceMethod("issueOrderTrigger", &Watcher::IssueOrderTrigger),                 //
-                      InstanceMethod("issueOrder", &Watcher::IssueOrder),                               //
-                      InstanceMethod("issueAlgoOrder", &Watcher::IssueAlgoOrder),                       //
                       InstanceMethod("issueMark", &Watcher::IssueMark),                                 //
-                      InstanceMethod("cancelOrder", &Watcher::CancelOrder),                             //
-                      InstanceMethod("cancelAlgoOrder", &Watcher::CancelAlgoOrder),                     //
-                      InstanceMethod("cancelOrderTrigger", &Watcher::CancelOrderTrigger),               //
-                      InstanceMethod("toggleAlgoOrder", &Watcher::ToggleAlgoOrder),                     //
-                      InstanceMethod("requestPosition", &Watcher::RequestPosition),                     //
                       InstanceMethod("start", &Watcher::Start),                                         //
                       InstanceMethod("sync", &Watcher::Sync),                                           //
                       InstanceMethod("quit", &Watcher::Quit),                                           //
@@ -326,12 +259,8 @@ void Watcher::on_react() {
 
   events_ | is(Register::tag) | $$(OnRegister(event->gen_time(), event->data<Register>()));
   events_ | is(Deregister::tag) | $$(OnDeregister(event->gen_time(), event->data<Deregister>()));
-  // for receive history data
   auto before_start_events = events_ | take_until(events_ | is(RequestStart::tag));
-  // accept legacy data from cached state, so even if ui reload, history data is able to be shown
-  before_start_events | is_legacy_data() | skip_while(while_is(OrderInput::tag)) |
-      $$(cached::feed_state_data(event, legacy_data_cached_bank_));
-  before_start_events | not_legacy_data() | $$(cached::feed_state_data(event, data_bank_));
+  before_start_events | $$(cached::feed_state_data(event, data_bank_));
 }
 
 bool Watcher::has_writer(uint32_t dest_id) const { return writers_.find(dest_id) != writers_.end(); }
@@ -344,12 +273,7 @@ yijinjing::journal::writer_ptr Watcher::get_writer(uint32_t dest_id) const {
 }
 
 void Watcher::on_start() {
-  // This Watcher only maintains the neutral state cache used by the ledger
-  // view. Legacy domain replay stays isolated until the agent-event Watcher
-  // rebuild lands.
-  if (not bypass_legacy_data_) {
-    events_ | not_legacy_data() | skip_while(while_is(Position::tag)) | $$(cached::feed_state_data(event, data_bank_));
-  }
+  events_ | skip_while(while_is(Position::tag)) | $$(cached::feed_state_data(event, data_bank_));
 
   events_ | is(Channel::tag) | $$(InspectChannel(event->gen_time(), event->data<Channel>()));
   events_ | is(BrokerStateUpdate::tag) |
@@ -381,34 +305,10 @@ void Watcher::Sync(const Napi::CallbackInfo &info) {
   SyncAppStates();
   SyncStrategyStates();
   SyncLedger();
-  TryRefreshLegacyData();
-  SyncLegacyDataFromCached();
-  SyncLegacyData();
-  ResetLegacyDataCount();
 }
 
 void Watcher::SyncLedger() {
-  boost::hana::for_each(StateDataTypes, [&](auto it) {
-    // cause legacy data saved in legacy_data_bank, no need to filter at this point
-    UpdateLedger(+boost::hana::second(it));
-  });
-}
-
-void Watcher::TryRefreshLegacyData() {
-  if (not refresh_legacy_data_before_sync_) {
-    return;
-  }
-
-  serialize::RefreshLegacyDataInStateMap(ledger_ref_, "ledger");
-}
-
-void Watcher::SyncLegacyData() {
-  // Legacy typed data is no longer part of StateDataTypes, so this compatibility
-  // shim intentionally stays a no-op.
-}
-
-void Watcher::SyncLegacyDataFromCached() {
-  // See SyncLegacyData().
+  boost::hana::for_each(StateDataTypes, [&](auto it) { UpdateLedger(+boost::hana::second(it)); });
 }
 
 void Watcher::SyncAppStates() {
@@ -486,30 +386,8 @@ location_ptr Watcher::FindLocation(const Napi::CallbackInfo &info) {
 }
 
 void Watcher::InspectChannel(int64_t trigger_time, const Channel &channel) {
-  if (bypass_legacy_data_) {
-    return;
-  }
-
   if (channel.source_id != get_live_home_uid() and channel.dest_id != get_live_home_uid()) {
     reader_join(channel.source_id, channel.dest_id, trigger_time);
-  }
-
-  if (has_location(channel.source_id) && has_location(channel.dest_id)) {
-    auto source_location = get_location(channel.source_id);
-    auto dest_location = get_location(channel.dest_id);
-
-    if (source_location->role == location_role::SINK) {
-      if (dest_location->group == "node") { // for as soon as possible to get legacy data made by renderer process;
-        legacy_data_reader_->join(source_location, channel.dest_id, get_begin_time(), 0, Priority::High);
-      } else {
-        legacy_data_reader_->join(source_location, channel.dest_id, get_begin_time());
-      }
-    }
-
-    // for order stat
-    if (source_location->uid == ledger_home_location_->uid) {
-      legacy_data_reader_->join(source_location, channel.dest_id, get_begin_time());
-    }
   }
 }
 
@@ -544,10 +422,6 @@ void Watcher::OnRegister(int64_t trigger_time, const Register &register_data) {
 
   if (app_location->role == location_role::SOURCE and app_location->mode == mode::LIVE) {
     MonitorSourceHeartbeat(trigger_time, app_location);
-  }
-
-  if (app_location->role == location_role::SINK) {
-    legacy_data_reader_->join(app_location, location::PUBLIC, get_begin_time());
   }
 }
 
@@ -587,7 +461,6 @@ void Watcher::StartWorker() {
           }
 
           watcher->step(STEP_INTERVAL);
-          watcher->drain_from_legacy_data_reader(STEP_INTERVAL);
         }
       } catch (const std::exception &ex) {
         SPDLOG_ERROR("watcher worker error, backing off: {}", ex.what());
@@ -648,7 +521,6 @@ void Watcher::AfterMasterDown(const Napi::CallbackInfo &info) {
   Napi::HandleScope scope(info.Env());
   //  disjoin(get_master_command_uid());
   reader_->clear();
-  legacy_data_reader_->clear();
   writers_.clear();
   band_writers_.clear();
   serialize::InitObjectReference(info, app_states_ref_);
@@ -667,37 +539,9 @@ bool Watcher::is_reactable(const event_ptr &event) {
     return false;
   }
 
-  // is_started() is supposed to be accpeted LegacyRefreshDataTags from cached
-  if ((bypass_legacy_data_ or (bypass_accounting_ and is_started())) and
-      longfist::LegacyRefreshDataTags.find(event->carrier_type()) != longfist::LegacyRefreshDataTags.end()) {
-    return false;
-  }
-
-  // Legacy broker-owned event routing has been removed from this Watcher.
   return not is_custom_event(event);
 }
 
-void Watcher::drain_from_legacy_data_reader(uint32_t step_limit) {
-  std::size_t step_count = 0;
-  while ((step_limit == 0 || step_count < step_limit) and
-         legacy_data_count_by_step_ < LEGACY_REFRESH_DATA_LIMIT_BY_SYNC and legacy_data_reader_->data_available()) {
-    const yijinjing::journal::frame_ptr frame = legacy_data_reader_->current_frame();
-
-    if (longfist::LegacyRefreshDataTags.find(frame->carrier_type()) != longfist::LegacyRefreshDataTags.end() and
-        frame->carrier_type() != OrderInput::tag) {
-      cached::feed_state_data(frame, legacy_data_bank_);
-      legacy_data_count_by_step_++;
-    }
-    step_count++;
-    legacy_data_reader_->next();
-  }
-}
-
-bool Watcher::is_step_continually() {
-  bool default_reader_available = reader_->data_available();
-  bool legacy_data_reader_available = legacy_data_reader_->data_available();
-  bool is_read_enough = legacy_data_count_by_step_ >= LEGACY_REFRESH_DATA_LIMIT_BY_SYNC;
-  return default_reader_available || (legacy_data_reader_available && not is_read_enough);
-}
+bool Watcher::is_step_continually() { return reader_->data_available(); }
 
 } // namespace kungfu::node

--- a/framework/core/src/bindings/node/binding/watcher.h
+++ b/framework/core/src/bindings/node/binding/watcher.h
@@ -23,7 +23,6 @@ namespace kungfu::node {
 constexpr uint64_t ID_TRANC = 0x00000000FFFFFFFF;
 constexpr uint32_t PAGE_ID_MASK = 0x80000000;
 constexpr uint32_t TRANSFER_STATIC_DATA_LIMIT = 2000;
-constexpr uint32_t TRANSFER_LEGACY_DATA_LIMIT = 2000;
 
 class Watcher : public Napi::ObjectWrap<Watcher>, public practice::apprentice {
 public:
@@ -55,31 +54,13 @@ public:
 
   Napi::Value RequestStop(const Napi::CallbackInfo &info);
 
-  Napi::Value RequestPosition(const Napi::CallbackInfo &info);
-
   Napi::Value PublishState(const Napi::CallbackInfo &info);
 
   Napi::Value IsReadyToInteract(const Napi::CallbackInfo &info);
 
   Napi::Value IssueCustomData(const Napi::CallbackInfo &info);
 
-  Napi::Value IssueBlockMessage(const Napi::CallbackInfo &info);
-
-  Napi::Value IssueOrderTrigger(const Napi::CallbackInfo &info);
-
-  Napi::Value IssueOrder(const Napi::CallbackInfo &info);
-
-  Napi::Value IssueAlgoOrder(const Napi::CallbackInfo &info);
-
   Napi::Value IssueMark(const Napi::CallbackInfo &info);
-
-  Napi::Value CancelOrder(const Napi::CallbackInfo &info);
-
-  Napi::Value CancelAlgoOrder(const Napi::CallbackInfo &info);
-
-  Napi::Value CancelOrderTrigger(const Napi::CallbackInfo &info);
-
-  Napi::Value ToggleAlgoOrder(const Napi::CallbackInfo &info);
 
   Napi::Value Start(const Napi::CallbackInfo &info);
 
@@ -99,15 +80,9 @@ public:
 
   bool is_reactable(const event_ptr &event) override;
 
-  void drain_from_legacy_data_reader(uint32_t step_limit = 0);
-
   bool is_step_continually();
 
 protected:
-  const bool bypass_accounting_;
-  const bool bypass_legacy_data_;
-  const bool refresh_legacy_data_before_sync_;
-  const bool bypass_refresh_book_;
   const int milliseconds_sleep_after_step_;
   std::mutex feed_mutex_;
 
@@ -133,14 +108,9 @@ private:
   serialize::JsUpdateState update_ledger;
   serialize::JsResetCache reset_cache;
   cache::bank data_bank_;
-  cache::bank legacy_data_bank_;
-  cache::deque_bank legacy_data_cached_bank_;
   std::vector<kungfu::state<longfist::types::CacheReset>> reset_cache_states_;
   std::unordered_map<uint32_t, int> broker_states_map_ = {};
   std::unordered_map<uint32_t, longfist::types::StrategyStateUpdate> strategy_states_map_ = {};
-
-  yijinjing::journal::reader_ptr legacy_data_reader_;
-  uint32_t legacy_data_count_by_step_ = 0;
 
   typedef longfist::enums::mode mode;
   typedef longfist::enums::location_role role;
@@ -149,18 +119,6 @@ private:
     return rx::filter([&](const event_ptr &event) {
       return not(app->get_location(event->source())->role == longfist::enums::location_role::SOURCE and
                  event->carrier_type() != longfist::types::Instrument::tag and bypass_quotes);
-    });
-  };
-
-  static constexpr auto is_legacy_data = []() {
-    return rx::filter([&](const event_ptr &event) {
-      return longfist::LegacyRefreshDataTags.find(event->carrier_type()) != longfist::LegacyRefreshDataTags.end();
-    });
-  };
-
-  static constexpr auto not_legacy_data = []() {
-    return rx::filter([&](const event_ptr &event) {
-      return longfist::LegacyRefreshDataTags.find(event->carrier_type()) == longfist::LegacyRefreshDataTags.end();
     });
   };
 
@@ -195,12 +153,6 @@ private:
 
   void SyncLedger();
 
-  void TryRefreshLegacyData();
-
-  void SyncLegacyData();
-
-  void SyncLegacyDataFromCached();
-
   void SyncAppStates();
 
   void SyncStrategyStates();
@@ -212,8 +164,6 @@ private:
   void StartWorker();
 
   void CancelWorker();
-
-  void ResetLegacyDataCount() { legacy_data_count_by_step_ = 0; };
 
   uint64_t MakeInstructionUID(yijinjing::journal::writer_ptr &writer, uint32_t dest, uint32_t client_id = 0) {
     uint64_t id_left = (uint64_t)(client_id xor dest) << 32u;
@@ -237,9 +187,6 @@ private:
       }
     }
   }
-
-  // Legacy typed state refresh is intentionally separated from StateDataTypes.
-  // A future Watcher should rebuild this path on top of neutral agent events.
 
   template <typename Instruction>
   Napi::Value InteractWithLocation(const Napi::CallbackInfo &info, const Napi::Object &instruction_object) {

--- a/framework/core/src/libkungfu/include/kungfu/longfist/longfist.h
+++ b/framework/core/src/libkungfu/include/kungfu/longfist/longfist.h
@@ -272,13 +272,6 @@ constexpr auto StaticDataTypes = boost::hana::make_map( //
 // tracing-foundation Phase 1: OrderStat(交易统计)拆死源,本闭集清空(restore_to 迭代 no-op)。
 constexpr auto StatisticDataTypes = boost::hana::make_map();
 
-constexpr auto LegacyRefreshDataTypes = boost::hana::make_map( //
-    TYPE_PAIR(OrderInput),                                     // 201
-    TYPE_PAIR(Order),                                          // 202
-    TYPE_PAIR(Trade),                                          // 203
-    TYPE_PAIR(OrderStat)                                       // 207
-);
-
 template <typename T> constexpr bool is_in_types(auto types) { return boost::hana::contains(types, T::type_name); }
 
 template <typename DataType> constexpr bool is_profile_data() { return is_in_types<DataType>(ProfileDataTypes); };
@@ -296,7 +289,6 @@ const auto LegacyCompiledTypeTags = build_data_set(LegacyCompiledTypes);
 const auto AllTypesTags = LegacyCompiledTypeTags;
 const auto ProfileDataTags = build_data_set(ProfileDataTypes);
 const auto StaticDataTags = build_data_set(StaticDataTypes);
-const auto LegacyRefreshDataTags = build_data_set(LegacyRefreshDataTypes);
 
 constexpr auto build_data_map = [](auto types) {
   auto maps = boost::hana::transform(boost::hana::values(types), [](auto value) {

--- a/framework/core/tests/bench/dispatch_watcher_bench.js
+++ b/framework/core/tests/bench/dispatch_watcher_bench.js
@@ -12,10 +12,10 @@
 //
 // Usage: node tests/bench/dispatch_watcher_bench.js <kf-home> <seconds>
 
-const path = require('path');
+const path = require('node:path');
 
 const home = process.argv[2];
-const seconds = parseInt(process.argv[3] || '30', 10);
+const seconds = Number.parseInt(process.argv[3] || '30', 10);
 if (!home) {
   console.error('usage: dispatch_watcher_bench.js <kf-home> <seconds>');
   process.exit(2);
@@ -36,10 +36,6 @@ const watcher = new binding.Watcher(
   runtimeDir,
   'dispatch_bench',
   true, // bypassRestore
-  false, // bypassAccounting
-  false, // bypassTradingData
-  true, // refreshTradingDataBeforeSync
-  false, // bypassRefreshBook
   2, // millisecondsSleepAfterStep
 );
 

--- a/framework/gui/public/config/kfConfig.json
+++ b/framework/gui/public/config/kfConfig.json
@@ -1,9 +1,6 @@
 {
   "performance": {
     "rocket": false,
-    "bypassAccounting": false,
-    "bypassTradingData": false,
-    "bypassRefreshBook": false,
     "verifyLocation": false,
     "lowMemory": false
   },


### PR DESCRIPTION
## Summary
- remove Watcher legacy trading-data reader/cache/sync path and old command shim exports
- slim Watcher constructor/config/API to neutral runtime arguments
- drop LegacyRefreshDataTypes/Tags and update ADR plus bench usage

## Validation
- ./kungfu-code check
- ./kungfu-code build
- git diff --check
- node --check framework/core/lib/kungfu.js
- node --check framework/core/tests/bench/dispatch_watcher_bench.js
- rg residual scan for removed legacy watcher symbols/config names