### PR TITLE
feat(sdk): aggregate upstream KFD facts

### DIFF
--- a/buildchain.kfd3.json
+++ b/buildchain.kfd3.json
@@ -8,6 +8,21 @@
     "package": "@kungfu-tech/artifact-kungfu"
   },
   "registryPath": "buildchain.kfd3.json",
+  "upstreamKfd": {
+    "aggregatePath": "developer/sdk/kfd/upstream-aggregate.json",
+    "upstreamCount": 3,
+    "kfdAwareUpstreams": [
+      "kfd",
+      "libnode",
+      "buildchain"
+    ],
+    "packageVersions": {
+      "kfd": "1.0.0-alpha.17",
+      "libnode": "22.22.3-kf.3-alpha.16",
+      "buildchain": "2.10.0"
+    },
+    "digest": "sha256:5aae0a00943e5273505d984cbd5a01ef0d87973fcfd9d1086fa447ce7f84ba15"
+  },
   "surfaces": [
     {
       "id": "kungfu.agent",
@@ -297,7 +312,7 @@
     },
     {
       "id": "kungfu.kfd.query",
-      "name": "kungfu kfd query|check|witness",
+      "name": "kungfu kfd query|check|witness|upstream|aggregate",
       "kind": "cli",
       "participantProfile": "agent-or-developer",
       "availability": "shipped",
@@ -305,7 +320,7 @@
       "participantFacing": true,
       "public": true,
       "sourcePath": "framework/core/src/python/kungfu/cli/commands/kfd.py",
-      "evidencePath": "developer/sdk/kfd/buildchain.kfd3.json",
+      "evidencePath": "developer/sdk/kfd/upstream-aggregate.json",
       "maturity": "stable"
     },
     {
@@ -453,7 +468,7 @@
     },
     {
       "id": "kungfu.sdk.kfd.query",
-      "name": "kungfu sdk kfd query|check|witness",
+      "name": "kungfu sdk kfd query|check|witness|upstream|aggregate",
       "kind": "cli",
       "participantProfile": "agent-or-developer",
       "availability": "shipped",
@@ -461,7 +476,7 @@
       "participantFacing": true,
       "public": true,
       "sourcePath": "developer/sdk/src/sdk.js",
-      "evidencePath": "developer/sdk/kfd/buildchain.kfd3.json",
+      "evidencePath": "developer/sdk/kfd/upstream-aggregate.json",
       "maturity": "stable"
     },
     {

--- a/developer/sdk/README.md
+++ b/developer/sdk/README.md
@@ -73,15 +73,22 @@ install the `buildchain` executable separately:
 kungfu kfd query --json
 kungfu kfd check --json
 kungfu kfd witness --json
+kungfu kfd upstream --json
+kungfu kfd aggregate --json
 
 kungfu sdk kfd query --json
 kungfu sdk kfd check --json
 kungfu sdk kfd witness --json
+kungfu sdk kfd upstream --json
+kungfu sdk kfd aggregate --json
 ```
 
 `kungfu kfd ...` is the installed CLI bridge. It delegates to the SDK-distributed
 implementation and returns the same machine-readable capability facts as
-`kungfu sdk kfd ...`.
+`kungfu sdk kfd ...`. `query` stays focused on Kungfu's own declared capability
+facts; `upstream` shows the SDK-packaged KFD aggregate for KFD, libnode, and
+Buildchain; `aggregate` joins both views for an agent that wants the final
+product plus upstream trust surface in one response.
 
 ## KFD-1 Contract Prototype
 

--- a/developer/sdk/kfd/buildchain.kfd3.json
+++ b/developer/sdk/kfd/buildchain.kfd3.json
@@ -8,6 +8,21 @@
     "package": "@kungfu-tech/artifact-kungfu"
   },
   "registryPath": "buildchain.kfd3.json",
+  "upstreamKfd": {
+    "aggregatePath": "developer/sdk/kfd/upstream-aggregate.json",
+    "upstreamCount": 3,
+    "kfdAwareUpstreams": [
+      "kfd",
+      "libnode",
+      "buildchain"
+    ],
+    "packageVersions": {
+      "kfd": "1.0.0-alpha.17",
+      "libnode": "22.22.3-kf.3-alpha.16",
+      "buildchain": "2.10.0"
+    },
+    "digest": "sha256:5aae0a00943e5273505d984cbd5a01ef0d87973fcfd9d1086fa447ce7f84ba15"
+  },
   "surfaces": [
     {
       "id": "kungfu.agent",
@@ -297,7 +312,7 @@
     },
     {
       "id": "kungfu.kfd.query",
-      "name": "kungfu kfd query|check|witness",
+      "name": "kungfu kfd query|check|witness|upstream|aggregate",
       "kind": "cli",
       "participantProfile": "agent-or-developer",
       "availability": "shipped",
@@ -305,7 +320,7 @@
       "participantFacing": true,
       "public": true,
       "sourcePath": "framework/core/src/python/kungfu/cli/commands/kfd.py",
-      "evidencePath": "developer/sdk/kfd/buildchain.kfd3.json",
+      "evidencePath": "developer/sdk/kfd/upstream-aggregate.json",
       "maturity": "stable"
     },
     {
@@ -453,7 +468,7 @@
     },
     {
       "id": "kungfu.sdk.kfd.query",
-      "name": "kungfu sdk kfd query|check|witness",
+      "name": "kungfu sdk kfd query|check|witness|upstream|aggregate",
       "kind": "cli",
       "participantProfile": "agent-or-developer",
       "availability": "shipped",
@@ -461,7 +476,7 @@
       "participantFacing": true,
       "public": true,
       "sourcePath": "developer/sdk/src/sdk.js",
-      "evidencePath": "developer/sdk/kfd/buildchain.kfd3.json",
+      "evidencePath": "developer/sdk/kfd/upstream-aggregate.json",
       "maturity": "stable"
     },
     {

--- a/developer/sdk/kfd/upstream-aggregate.json
+++ b/developer/sdk/kfd/upstream-aggregate.json
@@ -1,0 +1,155 @@
+{
+  "schemaVersion": 1,
+  "contract": "kungfu-upstream-kfd-aggregate",
+  "product": {
+    "id": "kungfu",
+    "name": "Kungfu",
+    "repository": "kungfu-systems/kungfu"
+  },
+  "source": {
+    "generator": "scripts/buildchain-kfd-evidence.mjs",
+    "packageResolution": [
+      "developer/sdk resolves @kungfu-tech/kfd and @kungfu-tech/buildchain",
+      "framework/core resolves @kungfu-tech/libnode"
+    ]
+  },
+  "upstreams": [
+    {
+      "id": "kfd",
+      "role": "standard-and-schema-provider",
+      "package": {
+        "name": "@kungfu-tech/kfd",
+        "version": "1.0.0-alpha.17"
+      },
+      "repository": "kungfu-systems/kfd",
+      "kfd": {
+        "kfd1": "exported-witness",
+        "kfd2": "exported-claim",
+        "kfd3": "exported-collaboration-interface"
+      },
+      "releaseAnchor": {
+        "schemaVersion": 1,
+        "contract": "kfd-release-anchor",
+        "line": "v1.0",
+        "channel": "alpha",
+        "npmPackage": "@kungfu-tech/kfd",
+        "npmVersion": "1.0.0-alpha.17",
+        "source": {
+          "repository": "kungfu-systems/kfd",
+          "branch": "alpha/v1/v1.0"
+        },
+        "rationale": "KFD uses an anchored/manual Buildchain mode: the public package version is an explicit release fact, while the outer KFD line remains v1.0."
+      },
+      "kfd3SurfaceCount": 16,
+      "assets": [
+        {
+          "path": "kfd.release.json",
+          "sha256": "sha256:8ac38cf084ab11875d35ad6d374290c2fe13623ae754521b63a391d3a585f8a6",
+          "contract": "kfd-release-anchor"
+        },
+        {
+          "path": "buildchain/kfd-1/contract-world.witness.json",
+          "sha256": "sha256:1f839c8e7c55a30e2115e0a25e6be769e584a37284d7787a25ada7cb2b58f1df"
+        },
+        {
+          "path": "buildchain/kfd-2/public-release-trust.claim.json",
+          "sha256": "sha256:cb4a3318e41c245d98006af69922cfd26362efd10bf3e68c2c27755d02fe2966"
+        },
+        {
+          "path": "buildchain/kfd-3/collaboration-interface.json",
+          "sha256": "sha256:e32f2196399d37db202ccc656386bddc346871243c3db6782d26b5a88f831595",
+          "contract": "kfd-3-collaboration-interface"
+        },
+        {
+          "path": "standards.json",
+          "sha256": "sha256:7cd61143eabec5b83c5ba37312d791935f2321d246f61bec790c4a6d5d4cf839",
+          "contract": "kfd-standards-metadata"
+        }
+      ]
+    },
+    {
+      "id": "libnode",
+      "role": "embedded-node-runtime-provider",
+      "package": {
+        "name": "@kungfu-tech/libnode",
+        "version": "22.22.3-kf.3-alpha.16"
+      },
+      "repository": "kungfu-systems/libnode",
+      "kfd": {
+        "kfd1": "release-anchor-facts",
+        "kfd2": "release-passport-required",
+        "kfd3": "package-runtime-surface"
+      },
+      "releaseAnchor": {
+        "schema": 1,
+        "nodeVersion": "22.22.3",
+        "nodeTag": "v22.22.3",
+        "nodeCommit": "fdfa0ff0dbaf0fbf4d7d6d89a2ab807f3177fa5c",
+        "libnodeRevision": 3,
+        "npmVersion": "22.22.3-kf.3-alpha.16"
+      },
+      "assets": [
+        {
+          "path": "libnode.release.json",
+          "sha256": "sha256:90555ff4f2b127ecfe552feec55782175e3c227bbb46c400603eee13ff7e6920"
+        }
+      ],
+      "residualRisk": [
+        "This libnode package version ships libnode.release.json as the package-level release anchor; full upstream trust should be read from its Buildchain release passport."
+      ]
+    },
+    {
+      "id": "buildchain",
+      "role": "release-passport-and-kfd-gate-provider",
+      "package": {
+        "name": "@kungfu-tech/buildchain",
+        "version": "2.10.0"
+      },
+      "repository": "kungfu-systems/buildchain",
+      "kfd": {
+        "kfd1": "gate-provider",
+        "kfd2": "claim-provider",
+        "kfd3": "surface-query-provider"
+      },
+      "publicExports": [
+        "@kungfu-tech/buildchain/kfd-gate",
+        "@kungfu-tech/buildchain/kfd-3-surfaces",
+        "@kungfu-tech/buildchain/buildchain-kfd-claims",
+        "@kungfu-tech/buildchain/release-passport"
+      ],
+      "assets": [
+        {
+          "path": "site/kfd-claims.json",
+          "sha256": "sha256:5b923b0abbca99e7a968fcde2dae3a63938b5291c3c5572c85b39aef44a4fd7c",
+          "contract": "kungfu-buildchain-kfd-claim-registry"
+        },
+        {
+          "path": "site/node-api-registry.json",
+          "sha256": "sha256:b3ac83608558e4d1253c8b75a4da5950a73a791da76d0a06c235eb615c6b246c",
+          "contract": "kungfu-buildchain-node-api-registry"
+        },
+        {
+          "path": "docs/kfd-support.md",
+          "sha256": "sha256:4bb33e408a2129e1534e92bea78d3cc0e4d8f986b0fbb27fe73ae6eae46b9ca3"
+        },
+        {
+          "path": "kfd-3-surfaces",
+          "sha256": "sha256:dc0d041257e0080147fbaa0a2d61e7f0a7ec3031a94311c58ea6b3e0fb78c18b"
+        }
+      ]
+    }
+  ],
+  "summary": {
+    "upstreamCount": 3,
+    "kfdAwareUpstreams": [
+      "kfd",
+      "libnode",
+      "buildchain"
+    ],
+    "packageVersions": {
+      "kfd": "1.0.0-alpha.17",
+      "libnode": "22.22.3-kf.3-alpha.16",
+      "buildchain": "2.10.0"
+    }
+  }
+}

--- a/developer/sdk/package.json
+++ b/developer/sdk/package.json
@@ -29,7 +29,7 @@
     "@kungfu-tech/buildchain": "2.10.0",
     "@kungfu-tech/core": "workspace:*",
     "@kungfu-tech/gui": "workspace:*",
-    "@kungfu-tech/kfd": "1.0.0-alpha.16",
+    "@kungfu-tech/kfd": "1.0.0-alpha.17",
     "@kungfu-tech/tui": "workspace:*",
     "ajv": "^8.20.0",
     "esbuild": "^0.28.1"

--- a/developer/sdk/src/sdk.js
+++ b/developer/sdk/src/sdk.js
@@ -41,6 +41,11 @@ const require = createRequire(import.meta.url);
 const SDK_CLI = fileURLToPath(import.meta.url);
 const SDK_ROOT = path.resolve(path.dirname(SDK_CLI), '..');
 const SDK_KFD3_REGISTRY = path.join(SDK_ROOT, 'kfd', 'buildchain.kfd3.json');
+const SDK_KFD_UPSTREAM_AGGREGATE = path.join(
+  SDK_ROOT,
+  'kfd',
+  'upstream-aggregate.json',
+);
 const isWin = process.platform === 'win32';
 
 /**
@@ -61,7 +66,7 @@ function usage(code) {
       '       kungfu sdk contract witness [--json]',
       '       kungfu sdk contract audit [--json]',
       '       kungfu sdk contract add <surface> [--source <path>] [--json]',
-      '       kungfu sdk kfd query|check|witness [--json]',
+      '       kungfu sdk kfd query|check|witness|upstream|aggregate [--json]',
       '       kungfu sdk kfx build | clean',
       '       kungfu sdk product gui dev|build|pack|dist [--dir <app-dir>] [--dry-run]',
       '       kungfu sdk product tui dev|build|bundle|dist [--dir <tui-dir>] [--dry-run]',
@@ -104,9 +109,10 @@ function usage(code) {
       'one local contract-world witness for config/kfx/skill without duplicating',
       'standard keys or JSON formatting rules.',
       '',
-      'kfd query/check/witness exposes Kungfu KFD-3 capability facts through the',
-      'SDK-distributed Buildchain bridge, so users do not need a separate',
-      'buildchain executable installation.',
+      'kfd query/check/witness exposes Kungfu KFD-3 capability facts; upstream',
+      'and aggregate expose the SDK-packaged KFD view of Kungfu plus upstream',
+      'KFD/libnode/Buildchain package facts, without a separate buildchain',
+      'executable installation.',
       '',
     ].join('\n'),
   );
@@ -2573,6 +2579,35 @@ function resolveKfd3Registry() {
 }
 
 /**
+ * @returns {string}
+ */
+function resolveKfdUpstreamAggregate() {
+  const override = process.env.KUNGFU_KFD_UPSTREAM_AGGREGATE || '';
+  const candidates = [
+    override,
+    path.join(
+      process.cwd(),
+      'developer',
+      'sdk',
+      'kfd',
+      'upstream-aggregate.json',
+    ),
+    findUp(
+      process.cwd(),
+      path.join('developer', 'sdk', 'kfd', 'upstream-aggregate.json'),
+    ),
+    SDK_KFD_UPSTREAM_AGGREGATE,
+  ].filter(Boolean);
+  for (const candidate of candidates) {
+    const resolved = path.resolve(candidate);
+    if (fs.existsSync(resolved)) return resolved;
+  }
+  fail(
+    'KFD upstream aggregate not found; run ./kungfu-code kfd:buildchain or install a SDK package that includes kfd/upstream-aggregate.json',
+  );
+}
+
+/**
  * @returns {{ path: string, registry: Record<string, any> }}
  */
 function readKfd3Registry() {
@@ -2580,6 +2615,17 @@ function readKfd3Registry() {
   return {
     path: registryPath,
     registry: JSON.parse(fs.readFileSync(registryPath, 'utf8')),
+  };
+}
+
+/**
+ * @returns {{ path: string, aggregate: Record<string, any> }}
+ */
+function readKfdUpstreamAggregate() {
+  const aggregatePath = resolveKfdUpstreamAggregate();
+  return {
+    path: aggregatePath,
+    aggregate: JSON.parse(fs.readFileSync(aggregatePath, 'utf8')),
   };
 }
 
@@ -2659,6 +2705,43 @@ async function kfdQuery(options) {
 }
 
 /**
+ * @param {CliOptions} options
+ * @returns {Promise<Record<string, any>>}
+ */
+async function kfdAggregate(options) {
+  const { path: registryPath, registry } = readKfd3Registry();
+  const { path: aggregatePath, aggregate } = readKfdUpstreamAggregate();
+  const query = await kfdQuery(options);
+  return {
+    schemaVersion: 1,
+    contract: 'kungfu-sdk-kfd-aggregate',
+    product: registry.product || { id: 'kungfu', name: 'Kungfu' },
+    source: {
+      registry: {
+        path: path.relative(process.cwd(), registryPath) || '.',
+        sha256: sha256File(registryPath),
+      },
+      upstreamAggregate: {
+        path: path.relative(process.cwd(), aggregatePath) || '.',
+        sha256: sha256File(aggregatePath),
+      },
+    },
+    own: {
+      query,
+      surfaceCount: Array.isArray(registry.surfaces)
+        ? registry.surfaces.length
+        : 0,
+    },
+    upstream: aggregate,
+    kfd: {
+      kfd1: 'registry-and-upstream-facts',
+      kfd2: 'release-passport-required',
+      kfd3: 'declared-and-aggregated',
+    },
+  };
+}
+
+/**
  * @param {string | undefined} command
  * @param {CliOptions} options
  * @returns {Promise<void>}
@@ -2677,6 +2760,7 @@ async function kfd(command, options) {
   }
   if (command === 'check') {
     const query = await kfdQuery(options);
+    const { path: aggregatePath, aggregate } = readKfdUpstreamAggregate();
     const output = {
       schema: 'kungfu.sdk.kfd-check/v1',
       ok: true,
@@ -2686,6 +2770,11 @@ async function kfd(command, options) {
         surfaceCount: Array.isArray(registry.surfaces)
           ? registry.surfaces.length
           : 0,
+      },
+      upstreamAggregate: {
+        path: path.relative(process.cwd(), aggregatePath) || '.',
+        sha256: sha256File(aggregatePath),
+        upstreamCount: aggregate.summary?.upstreamCount || 0,
       },
       query: {
         status: query.status || 'unknown',
@@ -2699,6 +2788,26 @@ async function kfd(command, options) {
     else
       process.stdout.write(
         `Kungfu KFD-3 check: ok, capabilities=${output.query.capabilityCount}\n`,
+      );
+    return;
+  }
+  if (command === 'upstream') {
+    const { aggregate } = readKfdUpstreamAggregate();
+    if (options.json)
+      process.stdout.write(`${JSON.stringify(aggregate, null, 2)}\n`);
+    else
+      process.stdout.write(
+        `Kungfu upstream KFD aggregate: ${aggregate.summary?.upstreamCount || 0} upstream(s)\n`,
+      );
+    return;
+  }
+  if (command === 'aggregate') {
+    const aggregate = await kfdAggregate(options);
+    if (options.json)
+      process.stdout.write(`${JSON.stringify(aggregate, null, 2)}\n`);
+    else
+      process.stdout.write(
+        `Kungfu KFD aggregate: own=${aggregate.own.surfaceCount}, upstream=${aggregate.upstream.summary?.upstreamCount || 0}\n`,
       );
     return;
   }
@@ -2726,7 +2835,9 @@ async function kfd(command, options) {
       );
     return;
   }
-  fail('unknown kfd command (supported: query, check, witness)');
+  fail(
+    'unknown kfd command (supported: query, check, witness, upstream, aggregate)',
+  );
 }
 
 const { positional, options } = parseArgs(process.argv.slice(2));

--- a/developer/sdk/tests/contract-cli.test.mjs
+++ b/developer/sdk/tests/contract-cli.test.mjs
@@ -269,6 +269,7 @@ test('kfd check verifies the packaged KFD-3 registry projection', () => {
   assert.equal(data.ok, true);
   assert.match(data.registry.sha256, /^sha256:[0-9a-f]{64}$/);
   assert.ok(data.registry.surfaceCount >= 1);
+  assert.equal(data.upstreamAggregate.upstreamCount, 3);
   assert.equal(data.query.kfd.kfd3, 'declared');
 });
 
@@ -278,6 +279,32 @@ test('kfd witness emits an installed SDK KFD-3 witness', () => {
   assert.equal(data.standard, 'kfd-3');
   assert.equal(data.witnessKind, 'installed-sdk-query');
   assert.ok(data.exposedSurfaces.some((row) => row.id === 'kungfu.kfd.query'));
+});
+
+test('kfd upstream exposes aggregated upstream KFD package facts', () => {
+  const data = runJson(['kfd', 'upstream', '--json']);
+  assert.equal(data.contract, 'kungfu-upstream-kfd-aggregate');
+  assert.equal(data.summary.upstreamCount, 3);
+  assert.equal(data.summary.packageVersions.kfd, kfdPackage.version);
+  assert.equal(
+    data.summary.packageVersions.buildchain,
+    buildchainPackage.version,
+  );
+  assert.ok(
+    data.upstreams.some(
+      (row) =>
+        row.id === 'libnode' && row.package.version === '22.22.3-kf.3-alpha.16',
+    ),
+  );
+});
+
+test('kfd aggregate joins own KFD-3 query facts with upstream KFD facts', () => {
+  const data = runJson(['kfd', 'aggregate', '--json']);
+  assert.equal(data.contract, 'kungfu-sdk-kfd-aggregate');
+  assert.equal(data.own.surfaceCount >= 1, true);
+  assert.equal(data.upstream.summary.upstreamCount, 3);
+  assert.equal(data.kfd.kfd3, 'declared-and-aggregated');
+  assert.match(data.source.upstreamAggregate.sha256, /^sha256:[0-9a-f]{64}$/);
 });
 
 test('adopt refuses a source path that does not match the registry', () => {

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -225,7 +225,11 @@ passport inputs:
 
 ```sh
 kungfu kfd query --json
+kungfu kfd upstream --json
+kungfu kfd aggregate --json
 kungfu sdk kfd query --json
+kungfu sdk kfd upstream --json
+kungfu sdk kfd aggregate --json
 ./kungfu-code kfd:buildchain
 ./kungfu-code kfd:buildchain:check
 ./kungfu-code kfd:query
@@ -235,12 +239,15 @@ node scripts/buildchain-kfd-evidence.mjs --artifact-witness --json
 `kungfu kfd ...` is the installed-runtime bridge for users and agents;
 `kungfu sdk kfd ...` exposes the same SDK-distributed Buildchain bridge directly.
 The `./kungfu-code kfd:*` commands are the repository development and release
-evidence generators.
+evidence generators. `query` reports Kungfu's own declared surfaces, while
+`upstream` and `aggregate` expose the packaged KFD/libnode/Buildchain upstream
+KFD aggregate.
 
 The generator writes a tracked Buildchain-facing KFD-3 registry at
 [`buildchain.kfd3.json`](../buildchain.kfd3.json), writes a packaged SDK copy at
-`developer/sdk/kfd/buildchain.kfd3.json`, then writes ignored release evidence
-under `.buildchain/`:
+`developer/sdk/kfd/buildchain.kfd3.json`, writes the SDK-packaged upstream
+aggregate at `developer/sdk/kfd/upstream-aggregate.json`, then writes ignored
+release evidence under `.buildchain/`:
 
 ```text
 .buildchain/kfd-1/contract-world.witness.json

--- a/docs/kfd-native-sdk-release-gates.md
+++ b/docs/kfd-native-sdk-release-gates.md
@@ -65,7 +65,7 @@ Git.
 |---|---|---|---|---|---|
 | KFD-1: contracts must not drift | `kungfu sdk add contract <surface>` | Contract source, schema/version metadata, registry entry, versioning/register prompt, drift fixture, known-limits stub | `kungfu contract verify --json`; `kungfu contract show <surface> --json`; packaged contract hash list | `scripts/buildchain-kfd-evidence.mjs` emits `.buildchain/kfd-1/contract-world.witness.json`, and the release workflow passes it to Buildchain 2.10 | Downgrade if the surface is not registered, dev/runtime/frozen artifacts disagree, or known limits are missing |
 | KFD-2: trust starts from facts | `kungfu sdk add fact-surface <name>` | Event schema or `.fbs`, msg type allocation, append helper, projection/store stub, `show/list --json` API, append-fold-readback fixture | Local append -> fold -> readback probe; manifest with schema hash and responsibility fields such as status, next action, decision, validation, artifact, and linked run | `scripts/kfd2-release-claims.mjs` emits raw claim files under `.buildchain/kfd-2/claims/`, and the release workflow passes them to Buildchain 2.10 | Downgrade if the claim is only prose, no local readback exists, responsibility fields are absent, or cost/attribution certainty is ambiguous |
-| KFD-3: cooperation starts from transparent value | Current first slice: `kfd3_api.registry.json` + `@kfd3_api("<api-id>")`; SDK/product surfaces are projected into `buildchain.kfd3.json` and the SDK-packaged copy | Agent docs entry, capabilities/commands metadata, mode-selection or onboarding hook, constraint declaration, CLI/API examples, known-limits stub, and local registry/schema | `kungfu agent capabilities --json`; `kungfu agent choose-mode --json`; `kungfu agent verify --json`; `kungfu kfd query --json`; `kungfu sdk kfd query --json`; `./kungfu-code kfd:query`; probe that an agent can discover value, boundary, next action, known limits, and the declared control surface | `scripts/buildchain-kfd-evidence.mjs` emits KFD-3 prebuild and artifact witnesses; the release workflow passes the prebuild witness and artifact verify command to Buildchain 2.10 | Downgrade if the surface is GUI-only, prose-only, stale, hides constraints, has no machine-readable entrypoint, or exposes runtime commands not declared in the registry |
+| KFD-3: cooperation starts from transparent value | Current first slice: `kfd3_api.registry.json` + `@kfd3_api("<api-id>")`; SDK/product surfaces are projected into `buildchain.kfd3.json`, the SDK-packaged copy, and `developer/sdk/kfd/upstream-aggregate.json` | Agent docs entry, capabilities/commands metadata, mode-selection or onboarding hook, constraint declaration, CLI/API examples, known-limits stub, local registry/schema, and upstream KFD aggregate | `kungfu agent capabilities --json`; `kungfu agent choose-mode --json`; `kungfu agent verify --json`; `kungfu kfd query --json`; `kungfu kfd upstream --json`; `kungfu kfd aggregate --json`; `kungfu sdk kfd query --json`; `./kungfu-code kfd:query`; probe that an agent can discover value, boundary, next action, known limits, upstream KFD facts, and the declared control surface | `scripts/buildchain-kfd-evidence.mjs` emits KFD-3 prebuild and artifact witnesses; the release workflow passes the prebuild witness and artifact verify command to Buildchain 2.10 | Downgrade if the surface is GUI-only, prose-only, stale, hides constraints, has no machine-readable entrypoint, or exposes runtime commands not declared in the registry |
 
 ## First Implementation Decision
 
@@ -253,9 +253,13 @@ SDK tooling:
   kungfu kfd query --json
   kungfu kfd check --json
   kungfu kfd witness --json
+  kungfu kfd upstream --json
+  kungfu kfd aggregate --json
   kungfu sdk kfd query --json
   kungfu sdk kfd check --json
   kungfu sdk kfd witness --json
+  kungfu sdk kfd upstream --json
+  kungfu sdk kfd aggregate --json
   ./kungfu-code kfd:buildchain
   ./kungfu-code kfd:buildchain:check
   ./kungfu-code kfd:query
@@ -391,7 +395,11 @@ Kungfu exposes one local command set:
 
 ```sh
 kungfu kfd query --json
+kungfu kfd upstream --json
+kungfu kfd aggregate --json
 kungfu sdk kfd query --json
+kungfu sdk kfd upstream --json
+kungfu sdk kfd aggregate --json
 ./kungfu-code kfd:buildchain
 ./kungfu-code kfd:buildchain:check
 ./kungfu-code kfd:query
@@ -401,13 +409,16 @@ node scripts/buildchain-kfd-evidence.mjs --artifact-witness --json
 The installed `kungfu kfd` command delegates to the SDK-distributed bridge, so a
 user or agent can query KFD-3 capability facts from a packaged Kungfu runtime
 without separately installing Buildchain. The `kungfu-code` commands remain the
-repository-side evidence generation and release-gate entrypoints.
+repository-side evidence generation and release-gate entrypoints. The
+`upstream`/`aggregate` commands expose the SDK-packaged upstream KFD aggregate
+for KFD, libnode, and Buildchain.
 
 `kfd:buildchain` writes:
 
 ```text
 buildchain.kfd3.json
 developer/sdk/kfd/buildchain.kfd3.json
+developer/sdk/kfd/upstream-aggregate.json
 .buildchain/kfd-1/contract-world.witness.json
 .buildchain/kfd-2/claims/*.json
 .buildchain/kfd-3/collaboration-interface.prebuild.json

--- a/framework/contract/kungfu-agent-first-canonical-policy.json
+++ b/framework/contract/kungfu-agent-first-canonical-policy.json
@@ -6,7 +6,7 @@
     "kfd": {
       "package": {
         "name": "@kungfu-tech/kfd",
-        "version": "1.0.0-alpha.16",
+        "version": "1.0.0-alpha.17",
         "repository": "git+https://github.com/kungfu-systems/kfd.git"
       },
       "standard": {

--- a/framework/core/package.json
+++ b/framework/core/package.json
@@ -65,7 +65,7 @@
     "sywac": "^1.3.0"
   },
   "devDependencies": {
-    "@kungfu-tech/libnode": "22.22.3-kf.1",
+    "@kungfu-tech/libnode": "22.22.3-kf.3-alpha.16",
     "@mapbox/node-pre-gyp": "^2.0.3",
     "cmake-js": "^8.0.0",
     "copyfiles": "^2.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  '@kungfu-tech/buildchain>@kungfu-tech/kfd': 1.0.0-alpha.17
   node-gyp: ^13.0.0
   cosmiconfig>js-yaml: 4.3.0
   lerna>js-yaml: 4.3.0
@@ -111,8 +112,8 @@ importers:
         specifier: workspace:*
         version: link:../../framework/gui
       '@kungfu-tech/kfd':
-        specifier: 1.0.0-alpha.16
-        version: 1.0.0-alpha.16
+        specifier: 1.0.0-alpha.17
+        version: 1.0.0-alpha.17
       '@kungfu-tech/tui':
         specifier: workspace:*
         version: link:../../framework/tui
@@ -424,8 +425,8 @@ importers:
         version: 1.3.0
     devDependencies:
       '@kungfu-tech/libnode':
-        specifier: 22.22.3-kf.1
-        version: 22.22.3-kf.1
+        specifier: 22.22.3-kf.3-alpha.16
+        version: 22.22.3-kf.3-alpha.16
       '@mapbox/node-pre-gyp':
         specifier: ^2.0.3
         version: 2.0.3(encoding@0.1.13)
@@ -1287,26 +1288,26 @@ packages:
     engines: {node: '>=22.14.0'}
     hasBin: true
 
-  '@kungfu-tech/kfd@1.0.0-alpha.16':
-    resolution: {integrity: sha512-u2tHV9YRTr3U3hvB979SGX5WXoIPSjAWYk5li/5bOPvDyl3w4JZrf1b8c/CEIJi/vNXlylBUJQ1eLZEpWQlqUw==}
+  '@kungfu-tech/kfd@1.0.0-alpha.17':
+    resolution: {integrity: sha512-/jy1vbhEogvdRyxOauhIGlIMo4dfM356t2RxtlX7ChFBQaT8admCEZDxaherMVF7J6IKTOPXZXPC/jyBWUuicQ==}
 
-  '@kungfu-tech/libnode-darwin-arm64@22.22.3-kf.1':
-    resolution: {integrity: sha512-IJpMSrcxs77vw/unEbI6v0a6BrArQjC9/ZLDW+WKn9Kzk7ZXcBKz3N/F7exldwc67n7R4tp0wOSIGcwjs75M2A==}
+  '@kungfu-tech/libnode-darwin-arm64@22.22.3-kf.3-alpha.16':
+    resolution: {integrity: sha512-arC7Vm85nBSRS4Vj5L5RL4XXb5c4xrLmldcf+zA0Qs0d01GW0ZHecthZTK/vf/syFtb4u1CFoHBviOwT3YFazQ==}
     cpu: [arm64]
     os: [darwin]
 
-  '@kungfu-tech/libnode-linux-x64@22.22.3-kf.1':
-    resolution: {integrity: sha512-z2lYmVslpiAfsuUEBQRdLU6mXLZm2KKGIJ59noA72m8Re/ewTZpB82I9ZDZBsOdRHKCDKzJ96vszJbuKMikS9A==}
+  '@kungfu-tech/libnode-linux-x64@22.22.3-kf.3-alpha.16':
+    resolution: {integrity: sha512-jDhw9oYYA4nHG9nYotDs05IYqKWtBfrybDb4mgbfZlwLPRXBU5b+XEQzT7rUm2H0CDydhBnnIyrZ/TPvyqhD4g==}
     cpu: [x64]
     os: [linux]
 
-  '@kungfu-tech/libnode-win32-x64@22.22.3-kf.1':
-    resolution: {integrity: sha512-6m/+IjHFyxOzAbMTscApRB5uXbWIJiJ/vvCFrEw5ETF2vjW8KJa287tJp5NIufg1tALCLnArAqf8VxXjHnWFdw==}
+  '@kungfu-tech/libnode-win32-x64@22.22.3-kf.3-alpha.16':
+    resolution: {integrity: sha512-z7NWb8hGXqiEgAqUINr8hkiqJR/VCmo5v0yI4xdRVwQ3caLr785IRfihGHgw8jrs4z8izaoJ+E7p34iy+RM51A==}
     cpu: [x64]
     os: [win32]
 
-  '@kungfu-tech/libnode@22.22.3-kf.1':
-    resolution: {integrity: sha512-4KpxBhR6lzdxIwoapTGn3CmTA1lISNGqiiNIdXHT1yJWlM5S4tGnF4N6+CAjkv+PUP7M8wSPTRGSgMDmd4bpDA==}
+  '@kungfu-tech/libnode@22.22.3-kf.3-alpha.16':
+    resolution: {integrity: sha512-tctyKXMn4hXWaExDER2OBc+C6C/YPoiirxue8RxYaTpbJz0/KGxK7rIUPwVzK15/UY/FsWgJuXAy6KQzgPdYVw==}
 
   '@malept/cross-spawn-promise@2.0.0':
     resolution: {integrity: sha512-1DpKU0Z5ThltBwjNySMC14g0CkbyhCaz9FkhxqNsZI6uAPJXFS8cMXlBKo26FJ8ZuW6S9GCMcR9IO5k2X5/9Fg==}
@@ -5332,25 +5333,25 @@ snapshots:
 
   '@kungfu-tech/buildchain@2.10.0':
     dependencies:
-      '@kungfu-tech/kfd': 1.0.0-alpha.16
+      '@kungfu-tech/kfd': 1.0.0-alpha.17
       smol-toml: 1.7.0
 
-  '@kungfu-tech/kfd@1.0.0-alpha.16': {}
+  '@kungfu-tech/kfd@1.0.0-alpha.17': {}
 
-  '@kungfu-tech/libnode-darwin-arm64@22.22.3-kf.1':
+  '@kungfu-tech/libnode-darwin-arm64@22.22.3-kf.3-alpha.16':
     optional: true
 
-  '@kungfu-tech/libnode-linux-x64@22.22.3-kf.1':
+  '@kungfu-tech/libnode-linux-x64@22.22.3-kf.3-alpha.16':
     optional: true
 
-  '@kungfu-tech/libnode-win32-x64@22.22.3-kf.1':
+  '@kungfu-tech/libnode-win32-x64@22.22.3-kf.3-alpha.16':
     optional: true
 
-  '@kungfu-tech/libnode@22.22.3-kf.1':
+  '@kungfu-tech/libnode@22.22.3-kf.3-alpha.16':
     optionalDependencies:
-      '@kungfu-tech/libnode-darwin-arm64': 22.22.3-kf.1
-      '@kungfu-tech/libnode-linux-x64': 22.22.3-kf.1
-      '@kungfu-tech/libnode-win32-x64': 22.22.3-kf.1
+      '@kungfu-tech/libnode-darwin-arm64': 22.22.3-kf.3-alpha.16
+      '@kungfu-tech/libnode-linux-x64': 22.22.3-kf.3-alpha.16
+      '@kungfu-tech/libnode-win32-x64': 22.22.3-kf.3-alpha.16
 
   '@malept/cross-spawn-promise@2.0.0':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,6 +8,9 @@ packages:
 allowBuilds:
   '@biomejs/biome': true
   '@kungfu-tech/libnode': true
+  '@kungfu-tech/libnode-darwin-arm64': true
+  '@kungfu-tech/libnode-linux-x64': true
+  '@kungfu-tech/libnode-win32-x64': true
   core-js: true
   electron: true
   electron-winstaller: true
@@ -21,6 +24,9 @@ allowBuilds:
 # it ages past the cutoff, forcing a per-version allow-list. 0 = no minimum age.
 minimumReleaseAge: 0
 overrides:
+  # Keep Buildchain's KFD gate metadata aligned with the SDK-distributed KFD
+  # package while Buildchain 2.10.x still declares the previous alpha.
+  '@kungfu-tech/buildchain>@kungfu-tech/kfd': 1.0.0-alpha.17
   # node-gyp 9.x cannot detect Visual Studio 2026; 13.x adds VS2026 support, which
   # the Windows build needs to match the prebuilt (MSVC 19.5) conan dependencies.
   node-gyp: ^13.0.0

--- a/scripts/buildchain-kfd-evidence.mjs
+++ b/scripts/buildchain-kfd-evidence.mjs
@@ -5,6 +5,7 @@
 import { execFileSync, spawnSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import fs from 'node:fs';
+import { createRequire } from 'node:module';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { queryKfd3Capabilities } from '@kungfu-tech/buildchain/kfd-3-surfaces';
@@ -27,6 +28,13 @@ const SDK_KFD3_REGISTRY_PATH = path.join(
   'sdk',
   'kfd',
   'buildchain.kfd3.json',
+);
+const SDK_KFD_UPSTREAM_AGGREGATE_PATH = path.join(
+  ROOT,
+  'developer',
+  'sdk',
+  'kfd',
+  'upstream-aggregate.json',
 );
 const KFD3_PREBUILD_WITNESS_PATH = path.join(
   KFD3_OUTPUT_DIR,
@@ -62,6 +70,8 @@ const AGENT_COMMANDS_PATH = path.join(
   'agent',
   'commands.json',
 );
+const SDK_CLI_PATH = path.join(ROOT, 'developer', 'sdk', 'src', 'sdk.js');
+const CORE_PACKAGE_PATH = path.join(ROOT, 'framework', 'core', 'package.json');
 const ARTIFACT_VERIFY_COMMAND =
   'node scripts/buildchain-kfd-evidence.mjs --artifact-witness --json';
 
@@ -75,6 +85,7 @@ function usage() {
 Writes:
   buildchain.kfd3.json
   developer/sdk/kfd/buildchain.kfd3.json
+  developer/sdk/kfd/upstream-aggregate.json
   .buildchain/kfd-1/contract-world.witness.json
   .buildchain/kfd-2/claims/<claim-id>.json
   .buildchain/kfd-3/collaboration-interface.prebuild.json
@@ -151,6 +162,206 @@ function sha256File(filePath) {
   return createHash('sha256').update(fs.readFileSync(filePath)).digest('hex');
 }
 
+function packageResolver(baseFile) {
+  return createRequire(baseFile);
+}
+
+function packageJson(packageName, baseFile) {
+  const req = packageResolver(baseFile);
+  const packageJsonPath = req.resolve(`${packageName}/package.json`);
+  return {
+    path: packageJsonPath,
+    dir: path.dirname(packageJsonPath),
+    value: readJson(packageJsonPath),
+  };
+}
+
+function packageAsset(packageName, assetPath, baseFile) {
+  const metadata = packageJson(packageName, baseFile);
+  const req = packageResolver(baseFile);
+  let assetFile = '';
+  try {
+    assetFile = req.resolve(`${packageName}/${assetPath}`);
+  } catch {
+    assetFile = path.join(metadata.dir, assetPath);
+  }
+  if (!fs.existsSync(assetFile)) return null;
+  const raw = fs.readFileSync(assetFile, 'utf8');
+  let parsed = null;
+  if (assetFile.endsWith('.json')) {
+    parsed = JSON.parse(raw);
+  }
+  return {
+    path: assetPath,
+    packagePath: path
+      .relative(metadata.dir, assetFile)
+      .split(path.sep)
+      .join('/'),
+    sha256: `sha256:${sha256File(assetFile)}`,
+    contract: parsed && typeof parsed === 'object' ? parsed.contract || '' : '',
+    parsed,
+  };
+}
+
+function requireAsset(packageName, assetPath, baseFile) {
+  const asset = packageAsset(packageName, assetPath, baseFile);
+  if (!asset) {
+    throw new Error(`${packageName}/${assetPath} is missing`);
+  }
+  return asset;
+}
+
+function assetSummary(asset) {
+  return {
+    path: asset.path,
+    sha256: asset.sha256,
+    contract: asset.contract || undefined,
+  };
+}
+
+function buildUpstreamKfdAggregate() {
+  const kfdPackage = packageJson('@kungfu-tech/kfd', SDK_CLI_PATH);
+  const libnodePackage = packageJson('@kungfu-tech/libnode', CORE_PACKAGE_PATH);
+  const buildchainPackage = packageJson(
+    '@kungfu-tech/buildchain',
+    SDK_CLI_PATH,
+  );
+  const kfdAssets = [
+    requireAsset('@kungfu-tech/kfd', 'kfd.release.json', SDK_CLI_PATH),
+    requireAsset(
+      '@kungfu-tech/kfd',
+      'buildchain/kfd-1/contract-world.witness.json',
+      SDK_CLI_PATH,
+    ),
+    requireAsset(
+      '@kungfu-tech/kfd',
+      'buildchain/kfd-2/public-release-trust.claim.json',
+      SDK_CLI_PATH,
+    ),
+    requireAsset(
+      '@kungfu-tech/kfd',
+      'buildchain/kfd-3/collaboration-interface.json',
+      SDK_CLI_PATH,
+    ),
+    requireAsset('@kungfu-tech/kfd', 'standards.json', SDK_CLI_PATH),
+  ];
+  const libnodeRelease = requireAsset(
+    '@kungfu-tech/libnode',
+    'libnode.release.json',
+    CORE_PACKAGE_PATH,
+  );
+  const buildchainAssets = [
+    requireAsset(
+      '@kungfu-tech/buildchain',
+      'site/kfd-claims.json',
+      SDK_CLI_PATH,
+    ),
+    requireAsset(
+      '@kungfu-tech/buildchain',
+      'site/node-api-registry.json',
+      SDK_CLI_PATH,
+    ),
+    requireAsset(
+      '@kungfu-tech/buildchain',
+      'docs/kfd-support.md',
+      SDK_CLI_PATH,
+    ),
+    requireAsset('@kungfu-tech/buildchain', 'kfd-3-surfaces', SDK_CLI_PATH),
+  ];
+  const kfdCollaboration = kfdAssets.find((asset) =>
+    asset.path.includes('collaboration-interface.json'),
+  )?.parsed;
+  const kfdRelease = kfdAssets.find(
+    (asset) => asset.path === 'kfd.release.json',
+  )?.parsed;
+  return {
+    schemaVersion: 1,
+    contract: 'kungfu-upstream-kfd-aggregate',
+    product: {
+      id: 'kungfu',
+      name: 'Kungfu',
+      repository: 'kungfu-systems/kungfu',
+    },
+    source: {
+      generator: 'scripts/buildchain-kfd-evidence.mjs',
+      packageResolution: [
+        'developer/sdk resolves @kungfu-tech/kfd and @kungfu-tech/buildchain',
+        'framework/core resolves @kungfu-tech/libnode',
+      ],
+    },
+    upstreams: [
+      {
+        id: 'kfd',
+        role: 'standard-and-schema-provider',
+        package: {
+          name: kfdPackage.value.name,
+          version: kfdPackage.value.version,
+        },
+        repository: 'kungfu-systems/kfd',
+        kfd: {
+          kfd1: 'exported-witness',
+          kfd2: 'exported-claim',
+          kfd3: 'exported-collaboration-interface',
+        },
+        releaseAnchor: kfdRelease || null,
+        kfd3SurfaceCount: Array.isArray(kfdCollaboration?.surfaces)
+          ? kfdCollaboration.surfaces.length
+          : 0,
+        assets: kfdAssets.map(assetSummary),
+      },
+      {
+        id: 'libnode',
+        role: 'embedded-node-runtime-provider',
+        package: {
+          name: libnodePackage.value.name,
+          version: libnodePackage.value.version,
+        },
+        repository: 'kungfu-systems/libnode',
+        kfd: {
+          kfd1: 'release-anchor-facts',
+          kfd2: 'release-passport-required',
+          kfd3: 'package-runtime-surface',
+        },
+        releaseAnchor: libnodeRelease.parsed,
+        assets: [assetSummary(libnodeRelease)],
+        residualRisk: [
+          'This libnode package version ships libnode.release.json as the package-level release anchor; full upstream trust should be read from its Buildchain release passport.',
+        ],
+      },
+      {
+        id: 'buildchain',
+        role: 'release-passport-and-kfd-gate-provider',
+        package: {
+          name: buildchainPackage.value.name,
+          version: buildchainPackage.value.version,
+        },
+        repository: 'kungfu-systems/buildchain',
+        kfd: {
+          kfd1: 'gate-provider',
+          kfd2: 'claim-provider',
+          kfd3: 'surface-query-provider',
+        },
+        publicExports: [
+          '@kungfu-tech/buildchain/kfd-gate',
+          '@kungfu-tech/buildchain/kfd-3-surfaces',
+          '@kungfu-tech/buildchain/buildchain-kfd-claims',
+          '@kungfu-tech/buildchain/release-passport',
+        ],
+        assets: buildchainAssets.map(assetSummary),
+      },
+    ],
+    summary: {
+      upstreamCount: 3,
+      kfdAwareUpstreams: ['kfd', 'libnode', 'buildchain'],
+      packageVersions: {
+        kfd: kfdPackage.value.version,
+        libnode: libnodePackage.value.version,
+        buildchain: buildchainPackage.value.version,
+      },
+    },
+  };
+}
+
 function gitValue(args) {
   try {
     return execFileSync('git', args, {
@@ -211,18 +422,18 @@ function sdkAndProductSurfaces() {
   return [
     fileSurface({
       id: 'kungfu.kfd.query',
-      name: 'kungfu kfd query|check|witness',
+      name: 'kungfu kfd query|check|witness|upstream|aggregate',
       kind: 'cli',
       sourcePath: 'framework/core/src/python/kungfu/cli/commands/kfd.py',
-      evidencePath: 'developer/sdk/kfd/buildchain.kfd3.json',
+      evidencePath: 'developer/sdk/kfd/upstream-aggregate.json',
       maturity: 'stable',
     }),
     fileSurface({
       id: 'kungfu.sdk.kfd.query',
-      name: 'kungfu sdk kfd query|check|witness',
+      name: 'kungfu sdk kfd query|check|witness|upstream|aggregate',
       kind: 'cli',
       sourcePath: 'developer/sdk/src/sdk.js',
-      evidencePath: 'developer/sdk/kfd/buildchain.kfd3.json',
+      evidencePath: 'developer/sdk/kfd/upstream-aggregate.json',
       maturity: 'stable',
     }),
     fileSurface({
@@ -302,7 +513,7 @@ function uniqueById(surfaces) {
   return [...byId.values()].sort((a, b) => a.id.localeCompare(b.id));
 }
 
-function buildKfd3Registry() {
+function buildKfd3Registry(upstreamAggregate = buildUpstreamKfdAggregate()) {
   const surfaces = uniqueById([
     ...agentApiSurfaces(),
     ...sdkAndProductSurfaces(),
@@ -317,6 +528,13 @@ function buildKfd3Registry() {
       package: '@kungfu-tech/artifact-kungfu',
     },
     registryPath: 'buildchain.kfd3.json',
+    upstreamKfd: {
+      aggregatePath: 'developer/sdk/kfd/upstream-aggregate.json',
+      upstreamCount: upstreamAggregate.summary.upstreamCount,
+      kfdAwareUpstreams: upstreamAggregate.summary.kfdAwareUpstreams,
+      packageVersions: upstreamAggregate.summary.packageVersions,
+      digest: `sha256:${sha256Json(upstreamAggregate)}`,
+    },
     surfaces,
     policy: {
       declaredButMissing: 'fail',
@@ -341,6 +559,7 @@ function buildCollaborationInterface(registry) {
     schemaVersion: 1,
     contract: 'kungfu-buildchain-kfd-3-surface-registry',
     product: registry.product,
+    upstreamKfd: registry.upstreamKfd,
     surfaces: registry.surfaces,
     audit: {
       status: 'passed',
@@ -366,6 +585,7 @@ function buildKfd3PrebuildWitness(registry) {
       registryDigest: `sha256:${sha256Json(registry)}`,
     },
     sourceRegistry: registryDescriptor(registry),
+    upstreamKfd: registry.upstreamKfd,
     expectedArtifactVerification: {
       command: ARTIFACT_VERIFY_COMMAND,
     },
@@ -413,6 +633,7 @@ function buildKfd3ArtifactWitness(registry, { runVerify = true } = {}) {
       path: 'artifact/release',
     },
     sourceRegistry: registryDescriptor(registry),
+    upstreamKfd: registry.upstreamKfd,
     collaborationInterfaceDigest: `sha256:${sha256Json(collaborationInterface)}`,
     exposedSurfaces: registry.surfaces,
     residualRisk: [],
@@ -524,7 +745,13 @@ async function buildQuery(registry) {
   }
 }
 
-function buildSummary({ registry, kfd1Witness, kfd2Summary, prebuildWitness }) {
+function buildSummary({
+  registry,
+  upstreamAggregate,
+  kfd1Witness,
+  kfd2Summary,
+  prebuildWitness,
+}) {
   return {
     schemaVersion: 1,
     contract: 'kungfu-buildchain-kfd-evidence-summary',
@@ -554,6 +781,8 @@ function buildSummary({ registry, kfd1Witness, kfd2Summary, prebuildWitness }) {
     },
     kfd3: {
       registry: 'buildchain.kfd3.json',
+      upstreamAggregate: 'developer/sdk/kfd/upstream-aggregate.json',
+      upstreamCount: upstreamAggregate.summary.upstreamCount,
       prebuildWitness: rel(KFD3_PREBUILD_WITNESS_PATH),
       artifactWitness: rel(KFD3_ARTIFACT_WITNESS_PATH),
       query: rel(KFD3_QUERY_PATH),
@@ -565,7 +794,8 @@ function buildSummary({ registry, kfd1Witness, kfd2Summary, prebuildWitness }) {
 }
 
 async function runArtifactWitness(options) {
-  const registry = buildKfd3Registry();
+  const upstreamAggregate = buildUpstreamKfdAggregate();
+  const registry = buildKfd3Registry(upstreamAggregate);
   const witness = buildKfd3ArtifactWitness(registry, { runVerify: true });
   if (options.json) process.stdout.write(renderJson(witness));
   else
@@ -575,18 +805,25 @@ async function runArtifactWitness(options) {
 }
 
 async function runCheckOrWrite(options) {
-  const registry = buildKfd3Registry();
+  const upstreamAggregate = buildUpstreamKfdAggregate();
+  const registry = buildKfd3Registry(upstreamAggregate);
   const kfd1Witness = buildKfd1Witness();
   const kfd2Summary = buildKfd2Claims({ write: options.write });
   if (options.write) {
     writeIfChanged(KFD3_REGISTRY_PATH, registry);
     writeIfChanged(SDK_KFD3_REGISTRY_PATH, registry);
+    writeIfChanged(SDK_KFD_UPSTREAM_AGGREGATE_PATH, upstreamAggregate);
   } else {
     assertCurrent(KFD3_REGISTRY_PATH, registry, 'Buildchain KFD-3 registry');
     assertCurrent(
       SDK_KFD3_REGISTRY_PATH,
       registry,
       'SDK packaged KFD-3 registry',
+    );
+    assertCurrent(
+      SDK_KFD_UPSTREAM_AGGREGATE_PATH,
+      upstreamAggregate,
+      'SDK packaged upstream KFD aggregate',
     );
   }
   const prebuildWitness = buildKfd3PrebuildWitness(registry);
@@ -596,6 +833,7 @@ async function runCheckOrWrite(options) {
   const query = await buildQuery(registry);
   const summary = buildSummary({
     registry,
+    upstreamAggregate,
     kfd1Witness,
     kfd2Summary,
     prebuildWitness,
@@ -630,7 +868,8 @@ async function runCheckOrWrite(options) {
 }
 
 async function runQuery(options) {
-  const registry = buildKfd3Registry();
+  const upstreamAggregate = buildUpstreamKfdAggregate();
+  const registry = buildKfd3Registry(upstreamAggregate);
   const query = await buildQuery(registry);
   if (options.json) process.stdout.write(renderJson(query));
   else


### PR DESCRIPTION
## Summary
- aggregate Kungfu SDK KFD facts with upstream KFD-aware dependencies: @kungfu-tech/kfd, @kungfu-tech/libnode, and @kungfu-tech/buildchain
- upgrade @kungfu-tech/libnode to 22.22.3-kf.3-alpha.16 and @kungfu-tech/kfd to 1.0.0-alpha.17
- expose installed SDK commands for kfd upstream and aggregate views, and document the generated upstream aggregate artifact

## Validation
- ./kungfu-code kfd:buildchain:check
- node --test developer/sdk/tests/contract-cli.test.mjs
- ./kungfu-code check
- git diff --check origin/dev/v4/v4.0...HEAD