### PR TITLE
ci(buildchain): enable locked checkout cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,11 @@ jobs:
       release-candidate: true
       artifact-transfer-mode: s3-to-github-artifacts
       artifact-retention-days: 14
+      checkout-cache-mode: auto
+      checkout-cache-mirror-url-template: ${{ vars.BUILDCHAIN_CHECKOUT_CACHE_MIRROR_URL_TEMPLATE }}
+      checkout-cache-reference-repository-template: ${{ vars.BUILDCHAIN_CHECKOUT_CACHE_REFERENCE_REPOSITORY_TEMPLATE }}
+      checkout-cache-fallback: github
+      checkout-cache-timeout-seconds: 60
       buildchain-contract-lock-path: buildchain.contract-lock.json
       buildchain-contract-compatibility-policy: major-compatible
       buildchain-contract-drift-issue-mode: compatible-and-breaking

--- a/docs/buildchain.md
+++ b/docs/buildchain.md
@@ -42,6 +42,21 @@ shipped frozen. A tag is bound to its binaries atomically — *tag exists ⇒ th
 matching binaries exist* — which is the trust property the release mechanism
 exists to hold.
 
+## CI source checkout cache
+
+The release-candidate build uses Buildchain's locked source checkout cache in
+`auto` mode. Self-hosted runners first try the trusted local/LAN Git object cache
+declared by repository or organization variables, then fall back to GitHub if the
+cache is unavailable:
+
+- `BUILDCHAIN_CHECKOUT_CACHE_MIRROR_URL_TEMPLATE`
+- `BUILDCHAIN_CHECKOUT_CACHE_REFERENCE_REPOSITORY_TEMPLATE`
+
+These values are intentionally not checked into this repository. They describe
+private runner or local-network topology. Buildchain still resolves and verifies
+the immutable source commit and tree before running lifecycle commands, and it
+writes sanitized `source-checkout.json` diagnostics into the platform artifacts.
+
 ## Maturity
 
 The local build path (`./kungfu-code sync && ./kungfu-code build`) is real and is


### PR DESCRIPTION
## Summary
- pass Buildchain locked source checkout cache inputs to the release-candidate build workflow
- use repo/org variables for the private local/LAN Git cache template
- document the private config boundary and sanitized source-checkout diagnostics

## Private config
- configured kungfu-systems/kungfu repo variable BUILDCHAIN_CHECKOUT_CACHE_MIRROR_URL_TEMPLATE from the matching libnode variable
- variable value is intentionally not written to repository files

## Validation
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/build.yml")'
- git diff --check origin/dev/v4/v4.0...HEAD
- ./kungfu-code check