### PR TITLE
feat(kfd): expose dev metadata in product runs

### DIFF
--- a/artifact/scripts/product.mjs
+++ b/artifact/scripts/product.mjs
@@ -14,6 +14,15 @@ import { fileURLToPath } from 'node:url';
 const __filename = fileURLToPath(import.meta.url);
 const ROOT = path.resolve(path.dirname(__filename), '..', '..');
 const isWin = process.platform === 'win32';
+const KFD3_REGISTRY = path.join(ROOT, 'buildchain.kfd3.json');
+const KFD_UPSTREAM_AGGREGATE = path.join(
+  ROOT,
+  'developer',
+  'sdk',
+  'kfd',
+  'upstream-aggregate.json',
+);
+const SDK_ENTRY = path.join(ROOT, 'developer', 'sdk', 'src', 'sdk.js');
 
 function usage(code) {
   process.stdout.write(
@@ -159,6 +168,23 @@ function instanceEnv(instanceHome, baseEnv = process.env) {
   };
 }
 
+function devKfdEnv(baseEnv = process.env) {
+  const env = { ...baseEnv };
+  if (!env.KUNGFU_SDK_ENTRY && existsSync(SDK_ENTRY)) {
+    env.KUNGFU_SDK_ENTRY = SDK_ENTRY;
+  }
+  if (!env.KUNGFU_KFD3_REGISTRY && existsSync(KFD3_REGISTRY)) {
+    env.KUNGFU_KFD3_REGISTRY = KFD3_REGISTRY;
+  }
+  if (
+    !env.KUNGFU_KFD_UPSTREAM_AGGREGATE &&
+    existsSync(KFD_UPSTREAM_AGGREGATE)
+  ) {
+    env.KUNGFU_KFD_UPSTREAM_AGGREGATE = KFD_UPSTREAM_AGGREGATE;
+  }
+  return env;
+}
+
 function parseArgs(argv) {
   const parsed = {
     dryRun: false,
@@ -197,6 +223,9 @@ function envDiff(env) {
     ['KF_HOME', env.KF_HOME],
     ['KF_CONFIG_HOME', env.KF_CONFIG_HOME],
     ['KF_RUNTIME_DIR', env.KF_RUNTIME_DIR],
+    ['KUNGFU_SDK_ENTRY', env.KUNGFU_SDK_ENTRY],
+    ['KUNGFU_KFD3_REGISTRY', env.KUNGFU_KFD3_REGISTRY],
+    ['KUNGFU_KFD_UPSTREAM_AGGREGATE', env.KUNGFU_KFD_UPSTREAM_AGGREGATE],
   ]
     .filter(([, value]) => value)
     .map(([key, value]) => `${key}=${value}`);
@@ -252,7 +281,11 @@ function main(argv = process.argv.slice(2)) {
     : '';
   const instanceHome =
     parsed.instanceHome || process.env.KF_INSTANCE_HOME || autoInstanceHome;
-  const env = instanceEnv(instanceHome);
+  const baseEnv = instanceEnv(instanceHome);
+  const env =
+    verb === 'dev' && (surface === 'gui' || surface === 'tui')
+      ? devKfdEnv(baseEnv)
+      : baseEnv;
 
   if (!surface || !verb) usage(1);
 
@@ -326,6 +359,7 @@ if (process.argv[1] && path.resolve(process.argv[1]) === __filename) {
 }
 
 export {
+  devKfdEnv,
   instanceEnv,
   instanceHomeForWorktree,
   isLinkedGitWorktree,

--- a/artifact/scripts/product.test.mjs
+++ b/artifact/scripts/product.test.mjs
@@ -15,6 +15,7 @@ import path from 'node:path';
 import { test } from 'node:test';
 import { fileURLToPath } from 'node:url';
 import {
+  devKfdEnv,
   instanceEnv,
   instanceHomeForWorktree,
   parseArgs,
@@ -23,6 +24,7 @@ import {
 } from './product.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
+const ROOT = path.resolve(path.dirname(__filename), '..', '..');
 
 test('parses an isolated instance home for product commands', () => {
   const parsed = parseArgs([
@@ -142,6 +144,44 @@ test('dry-run shows instance env without creating the home', () => {
   } finally {
     rmSync(parent, { recursive: true, force: true });
   }
+});
+
+test('dev product commands expose local KFD metadata to kungfu kfd', () => {
+  const result = spawnSync(
+    process.execPath,
+    [__filename.replace(/\.test\.mjs$/, '.mjs'), 'gui', 'dev', '--dry-run'],
+    { encoding: 'utf8' },
+  );
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.match(
+    result.stdout,
+    new RegExp(
+      `KUNGFU_SDK_ENTRY=${escapeRegExp(path.join(ROOT, 'developer', 'sdk', 'src', 'sdk.js'))}`,
+    ),
+  );
+  assert.match(
+    result.stdout,
+    new RegExp(
+      `KUNGFU_KFD3_REGISTRY=${escapeRegExp(path.join(ROOT, 'buildchain.kfd3.json'))}`,
+    ),
+  );
+  assert.match(
+    result.stdout,
+    new RegExp(
+      `KUNGFU_KFD_UPSTREAM_AGGREGATE=${escapeRegExp(path.join(ROOT, 'developer', 'sdk', 'kfd', 'upstream-aggregate.json'))}`,
+    ),
+  );
+});
+
+test('dev KFD environment preserves explicit user overrides', () => {
+  const env = devKfdEnv({
+    KUNGFU_SDK_ENTRY: '/custom/sdk.js',
+    KUNGFU_KFD3_REGISTRY: '/custom/kfd3.json',
+    KUNGFU_KFD_UPSTREAM_AGGREGATE: '/custom/upstream.json',
+  });
+  assert.equal(env.KUNGFU_SDK_ENTRY, '/custom/sdk.js');
+  assert.equal(env.KUNGFU_KFD3_REGISTRY, '/custom/kfd3.json');
+  assert.equal(env.KUNGFU_KFD_UPSTREAM_AGGREGATE, '/custom/upstream.json');
 });
 
 function escapeRegExp(value) {

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -243,6 +243,12 @@ evidence generators. `query` reports Kungfu's own declared surfaces, while
 `upstream` and `aggregate` expose the packaged KFD/libnode/Buildchain upstream
 KFD aggregate.
 
+During `./kungfu-code product gui dev` and `./kungfu-code product tui dev`, the
+product wrapper exports `KUNGFU_SDK_ENTRY`, `KUNGFU_KFD3_REGISTRY`, and
+`KUNGFU_KFD_UPSTREAM_AGGREGATE` for the launched dev process. This lets a local
+dev run query the working tree's KFD facts through the normal `kungfu kfd`
+bridge instead of waiting for a packaged release artifact.
+
 The generator writes a tracked Buildchain-facing KFD-3 registry at
 [`buildchain.kfd3.json`](../buildchain.kfd3.json), writes a packaged SDK copy at
 `developer/sdk/kfd/buildchain.kfd3.json`, writes the SDK-packaged upstream

--- a/docs/kfd-native-sdk-release-gates.md
+++ b/docs/kfd-native-sdk-release-gates.md
@@ -413,6 +413,12 @@ repository-side evidence generation and release-gate entrypoints. The
 `upstream`/`aggregate` commands expose the SDK-packaged upstream KFD aggregate
 for KFD, libnode, and Buildchain.
 
+For repository dev runs, `./kungfu-code product gui dev` and `./kungfu-code
+product tui dev` inject `KUNGFU_SDK_ENTRY`, `KUNGFU_KFD3_REGISTRY`, and
+`KUNGFU_KFD_UPSTREAM_AGGREGATE` into the launched process. That makes the same
+`kungfu kfd` bridge resolve the working tree's development KFD facts before a
+release artifact exists.
+
 `kfd:buildchain` writes:
 
 ```text


### PR DESCRIPTION
## Summary
- inject local KFD registry/upstream aggregate/SDK entry env into `./kungfu-code product gui dev` and `tui dev`
- keep explicit `KUNGFU_*` overrides authoritative
- document dev-run KFD bridge behavior

## Validation
- `node --test artifact/scripts/product.test.mjs`
- `KUNGFU_KFD3_REGISTRY=... KUNGFU_KFD_UPSTREAM_AGGREGATE=... node developer/sdk/src/sdk.js kfd aggregate --json`
- `./kungfu-code kfd:buildchain:check`
- `./kungfu-code check:types`
- `./kungfu-code check`