### PR TITLE
feat(core): separate hash integrity surfaces

### DIFF
--- a/docs/event-model.md
+++ b/docs/event-model.md
@@ -75,10 +75,16 @@ while the payload names the domain action through `action_type` and
 per-language causality logic (see [`contracts.md`](contracts.md)).
 
 Current `frame_header` does not contain an in-frame checksum. New
-`action_recorder` receipts carry `integrity_version`, `payload_checksum`, and
-`frame_checksum`; fsck can persist and verify those receipt fields by reopening
-the recorded frame. A full frame trailer or chain root is a future journal
-format surface, not something older journals can be assumed to contain.
+`action_recorder` receipts carry `integrity_version`, `checksum_algorithm`,
+`payload_checksum`, and `frame_checksum`; fsck can persist and verify those
+receipt fields by reopening the recorded frame. The current checksum algorithm
+is `fnv1a64`: a fast corruption detector, not a cryptographic authenticity
+proof. Content payloads and manifests use explicit content hashes such as
+`sha256`; internal yijinjing uid helpers use `fast_hash_*` / `murmur3` and must
+not be treated as content hashes. The taxonomy is pinned in
+[ADR-0028](../framework/core/docs/adr/ADR-0028-hash-taxonomy-and-integrity-algorithms.md).
+A full frame trailer or chain root is a future journal format surface, not
+something older journals can be assumed to contain.
 
 ## Routing: source and dest
 

--- a/docs/runtime-storage-service.md
+++ b/docs/runtime-storage-service.md
@@ -190,6 +190,11 @@ It should check:
 - source manifests, channel cursors, and accepted ranges are internally
   consistent.
 
+Hash verification follows the ADR-0028 taxonomy: storage payloads and manifests
+use explicit content-hash algorithms such as `sha256`; frame receipts use the
+recorded checksum algorithm such as `fnv1a64`; yijinjing `fast_hash_*` ids are
+not valid payload or manifest hashes.
+
 Example target:
 
 ```sh
@@ -328,7 +333,7 @@ Acceptance covered by that slice:
 - large Atlas JSON bodies are stored outside mmap frames as hash-addressed
   payloads;
 - import writes a manifest with source head, object count, payload inventory,
-  and projection watermark;
+  hash algorithm, frame checksum algorithm, and projection watermark;
 - `fsck` detects missing payloads, hash mismatches, malformed payload JSON, and
   projection drift against the current Atlas projection;
 - `storage export` emits a canonical JSONL record per imported Atlas payload;

--- a/framework/core/docs/adr/ADR-0023-frame-integrity-and-msg-type-allocation-gates.md
+++ b/framework/core/docs/adr/ADR-0023-frame-integrity-and-msg-type-allocation-gates.md
@@ -43,13 +43,15 @@ Frame integrity begins in the C++ action-recorder membrane:
 
 - `action_recorder` computes a fast payload checksum and frame checksum when it
   writes a frame.
-- The receipt exposes `integrity_version`, `payload_checksum`, and
-  `frame_checksum` through C++, Python, and Node.
+- The receipt exposes `integrity_version`, `checksum_algorithm`,
+  `payload_checksum`, and `frame_checksum` through C++, Python, and Node.
 - Higher layers that persist receipts, such as the Atlas import manifest, can
   run fsck by reopening journal frames and recomputing those checksums.
 
 The first checksum algorithm is a fast non-keyed 64-bit FNV-1a implementation.
 This is a corruption detector, not a cryptographic authenticity proof.
+ADR-0028 names this algorithm `fnv1a64` and separates it from content hashes
+such as `sha256` and internal yijinjing `fast_hash_*` ids.
 
 ## Trailer and hash-chain direction
 

--- a/framework/core/docs/adr/ADR-0028-hash-taxonomy-and-integrity-algorithms.md
+++ b/framework/core/docs/adr/ADR-0028-hash-taxonomy-and-integrity-algorithms.md
@@ -1,0 +1,95 @@
+# ADR-0028: hash taxonomy separates internal ids, frame checksums, and content hashes
+
+- Status: accepted
+- Date: 2026-07-08
+- Category: (architecture) storage integrity and runtime identity
+- Subsystem: yijinjing hash helpers, runtime action recorder, storage manifests,
+  fsck/export, Python/Node bindings.
+- Related: ADR-0001 defines the publish barrier. ADR-0018 defines runtime
+  storage. ADR-0022 defines the C++ action recorder membrane. ADR-0023 defines
+  receipt-based frame integrity.
+
+## Context
+
+Kungfu historically used MurmurHash3 through generic names such as `hash_32`
+and `hash_str_32`. That was acceptable for low-latency internal ids, but the v4
+runtime now also stores agent facts, import/export manifests, payload
+inventories, fsck reports, and future remote-sync receipts.
+
+Those surfaces need different hash semantics:
+
+- internal ids and hash-map keys must be fast and deterministic;
+- frame receipts need a cheap corruption detector;
+- content-addressed payloads and manifests need stable algorithm-tagged content
+  hashes;
+- future trust proofs need chain/root semantics, not a bare non-keyed checksum.
+
+Using one generic "hash" vocabulary for all of those would make it too easy for
+new code to use MurmurHash3 as a content-addressing or tamper-evidence
+primitive.
+
+## Decision
+
+Kungfu treats hashes as four separate surfaces:
+
+1. **Fast internal hash**: yijinjing exposes `fast_hash_*` APIs. The current
+   implementation is MurmurHash3 and the algorithm label is `murmur3`. This is
+   only for internal ids, location uid derivation, in-process keys, and
+   deterministic bucketing. It is not a content hash and not a security proof.
+2. **Frame checksum**: the first action-recorder receipt integrity slice uses
+   non-keyed 64-bit FNV-1a, labelled `fnv1a64`. It detects accidental
+   corruption or uncoordinated mutation in the writer/fsck path. It is not a
+   cryptographic authenticity proof.
+3. **Content hash**: storage manifests, payload references, schema inventories,
+   and import/export payload bodies use explicit content hash algorithms.
+   `sha256` is the default v4 portable baseline; `blake3` is reserved as a
+   future supported option when the dependency and cross-language bindings are
+   deliberately added.
+4. **Trust proof / sync root**: future tamper evidence must bind frame or
+   payload hashes into a stream/session/page/manifest root. That is a separate
+   journal or remote-sync compatibility surface, not a reason to overload the
+   fast hash or receipt checksum APIs.
+
+The repository enforces the naming boundary:
+
+- C++ internal runtime code uses `fast_hash_*`, not generic `hash_*` names.
+- Python keeps `hash_32` / `hash_str_32` as compatibility aliases, while new
+  internal Python runtime code uses `fast_hash_str_32`.
+- Storage code must not use MurmurHash3 or `fast_hash_*` for content hashes.
+- The runtime greenfield gate blocks reintroducing ambiguous C++ hash names in
+  changed core files.
+
+## Consequences
+
+- A future reader can tell from the function name whether a hash is safe for
+  internal ids only or suitable for storage content identity.
+- Existing Python user scripts are not broken immediately, but new code has the
+  explicit `fast_hash_*` API available.
+- Fsck/export manifests can record both checksum values and the checksum
+  algorithm, so a later algorithm change can be detected instead of silently
+  recomputed with the wrong function.
+- MurmurHash3 remains available for the job it is good at; it is no longer the
+  implied answer to every hash-shaped problem.
+
+## Alternatives considered
+
+- **Replace MurmurHash3 with BLAKE3 everywhere.** Rejected. Internal uid and
+  hash-map use does not need a cryptographic hash, and changing uid derivation
+  is a compatibility decision separate from storage integrity.
+- **Use SHA-256 for frame receipts immediately.** Rejected for the first
+  receipt slice. The current writer/fsck path needs a cheap corruption detector;
+  cryptographic trust belongs to a chain/root design.
+- **Keep `hash_*` as the public C++ vocabulary.** Rejected. The name is too
+  broad and encourages content-hash misuse.
+- **Add BLAKE3 now.** Deferred. It is a good future content-hash option, but it
+  should arrive with intentional dependency, binding, and manifest negotiation
+  work rather than as a hidden runtime dependency.
+
+## Residual risk
+
+- Python compatibility aliases still exist. They should be treated as stable
+  compatibility surface, not the recommended internal API.
+- `fnv1a64` is a receipt checksum, not a security claim. Documentation and fsck
+  output must continue to avoid describing it as tamper-proof.
+- Full tamper evidence still requires a chain/root design and journal-format or
+  remote-sync compatibility work.

--- a/framework/core/docs/adr/README.md
+++ b/framework/core/docs/adr/README.md
@@ -43,6 +43,7 @@ A record's **Status** says where it stands:
 | [0025](ADR-0025-carrier-type-and-action-envelope-semantics.md) | accepted | carrier type is transport metadata and business semantics live in action envelopes |
 | [0026](ADR-0026-runtime-greenfield-core-surface.md) | accepted | runtime exposes a greenfield core surface, not trading typed helpers |
 | [0027](ADR-0027-python-yijinjing-public-core-types.md) | accepted | Python yijinjing schema exposes only core public runtime types |
+| [0028](ADR-0028-hash-taxonomy-and-integrity-algorithms.md) | accepted | hash taxonomy separates internal ids, frame checksums, and content hashes |
 
 ## Reading by theme
 
@@ -100,7 +101,10 @@ A record's **Status** says where it stands:
   [0027](ADR-0027-python-yijinjing-public-core-types.md) (the matching rule that
   Python `pykungfu.yijinjing.types` only exposes core public runtime structs,
   while the full compiled schema registry stays internal to runtime decode
-  paths).
+  paths), and
+  [0028](ADR-0028-hash-taxonomy-and-integrity-algorithms.md) (the rule that
+  fast internal hashes, frame checksums, content hashes, and future trust roots
+  are separate algorithm surfaces).
 - **Cross-cutting principle** — [0009](ADR-0009-load-bearing-self-bootstrap.md)
   (load-bearing self-bootstrap), which also names the general law that
   [`docs/architecture.md` § The build dogfoods the SDK](../../../../docs/architecture.md)

--- a/framework/core/src/bindings/node/binding/action_recorder.cpp
+++ b/framework/core/src/bindings/node/binding/action_recorder.cpp
@@ -88,6 +88,7 @@ Napi::Object to_receipt_object(Napi::Env env, const record_receipt &receipt) {
   object.Set("dataLength", Napi::Number::New(env, receipt.data_length));
   object.Set("dataType", Napi::Number::New(env, receipt.data_type));
   object.Set("integrityVersion", Napi::Number::New(env, receipt.integrity_version));
+  object.Set("checksumAlgorithm", Napi::String::New(env, runtime::action::FRAME_CHECKSUM_ALGORITHM_FNV1A64));
   object.Set("payloadChecksum", Napi::BigInt::New(env, receipt.payload_checksum));
   object.Set("frameChecksum", Napi::BigInt::New(env, receipt.frame_checksum));
   return object;
@@ -158,6 +159,8 @@ void ActionRecorder::Init(Napi::Env env, Napi::Object exports) {
   constructor = Napi::Persistent(func);
   constructor.SuppressDestruct();
   exports.Set("ActionRecorder", func);
+  exports.Set("FRAME_CHECKSUM_ALGORITHM_FNV1A64",
+              Napi::String::New(env, runtime::action::FRAME_CHECKSUM_ALGORITHM_FNV1A64));
 }
 
 } // namespace kungfu::node

--- a/framework/core/src/bindings/node/binding/kungfu_node.cpp
+++ b/framework/core/src/bindings/node/binding/kungfu_node.cpp
@@ -71,7 +71,7 @@ namespace kungfu::node {
 uint32_t Hash32(const Napi::CallbackInfo &info) {
   if (IsValid(info, 0, &Napi::Value::IsString)) {
     auto arg = info[0].ToString().Utf8Value();
-    return hash_32(reinterpret_cast<const unsigned char *>(arg.c_str()), arg.length());
+    return fast_hash_32(reinterpret_cast<const unsigned char *>(arg.c_str()), arg.length());
   }
 
   if (IsValid(info, 0, &Napi::Value::IsNumber)) {

--- a/framework/core/src/bindings/python/binding/py-runtime.cpp
+++ b/framework/core/src/bindings/python/binding/py-runtime.cpp
@@ -177,8 +177,13 @@ void bind(pybind11::module &&m) {
   m.def("in_color_terminal", &runtime::util::in_color_terminal);
   m.def("color_print", &runtime::util::color_print);
 
-  m.def("hash_32", &yijinjing::hash_32, py::arg("key"), py::arg("length"), py::arg("seed") = KUNGFU_HASH_SEED);
-  m.def("hash_str_32", &yijinjing::hash_str_32, py::arg("key"), py::arg("seed") = KUNGFU_HASH_SEED);
+  m.def("fast_hash_32", &yijinjing::fast_hash_32, py::arg("key"), py::arg("length"),
+        py::arg("seed") = KUNGFU_HASH_SEED);
+  m.def("fast_hash_str_32", &yijinjing::fast_hash_str_32, py::arg("key"), py::arg("seed") = KUNGFU_HASH_SEED);
+  m.def("hash_32", &yijinjing::fast_hash_32, py::arg("key"), py::arg("length"), py::arg("seed") = KUNGFU_HASH_SEED);
+  m.def("hash_str_32", &yijinjing::fast_hash_str_32, py::arg("key"), py::arg("seed") = KUNGFU_HASH_SEED);
+  m.attr("FAST_HASH_ALGORITHM") = yijinjing::FAST_HASH_ALGORITHM;
+  m.attr("FRAME_CHECKSUM_ALGORITHM_FNV1A64") = action::FRAME_CHECKSUM_ALGORITHM_FNV1A64;
 
   m.def("setup_log", &yijinjing::log::setup_log);
   m.def("emit_log", &yijinjing::log::emit_log);

--- a/framework/core/src/libkungfu/include/kungfu/runtime/action_recorder.h
+++ b/framework/core/src/libkungfu/include/kungfu/runtime/action_recorder.h
@@ -13,6 +13,9 @@
 
 namespace kungfu::runtime::action {
 
+inline constexpr uint32_t FRAME_INTEGRITY_VERSION_V1 = 1;
+inline constexpr const char *FRAME_CHECKSUM_ALGORITHM_FNV1A64 = "fnv1a64";
+
 struct record_options {
   int64_t gen_time = 0;
   int64_t trigger_time = 0;

--- a/framework/core/src/libkungfu/src/runtime/action_recorder.cpp
+++ b/framework/core/src/libkungfu/src/runtime/action_recorder.cpp
@@ -14,7 +14,6 @@ using namespace kungfu::runtime::journal;
 namespace kungfu::runtime::action {
 
 namespace {
-constexpr uint32_t FRAME_INTEGRITY_VERSION = 1;
 constexpr uint64_t FNV1A64_OFFSET = 14695981039346656037ull;
 constexpr uint64_t FNV1A64_PRIME = 1099511628211ull;
 
@@ -135,7 +134,7 @@ record_receipt action_recorder::record_payload(int32_t carrier_type, const uint8
   receipt.dest = dest_id_;
   receipt.data_length = payload_length;
   receipt.data_type = static_cast<int8_t>(options.data_type);
-  receipt.integrity_version = FRAME_INTEGRITY_VERSION;
+  receipt.integrity_version = FRAME_INTEGRITY_VERSION_V1;
   receipt.payload_checksum = payload_checksum;
   receipt.frame_checksum = frame_checksum;
   last_frame_uid_ = receipt.frame_uid;

--- a/framework/core/src/libyijinjing/include/kungfu/common.h
+++ b/framework/core/src/libyijinjing/include/kungfu/common.h
@@ -111,7 +111,7 @@ using namespace boost::hana::literals;
   DECLARE_PTR(X) /** forward defile smart ptr */
 
 namespace kungfu {
-uint32_t hash_32(const unsigned char *key, int32_t length);
+uint32_t fast_hash_32(const unsigned char *key, int32_t length);
 
 template <typename V, size_t N, typename = void> struct array_to_string;
 
@@ -297,7 +297,9 @@ template <typename T> struct hash<T, std::enable_if_t<std::is_integral_v<T> and 
 };
 
 template <typename T> struct hash<T, std::enable_if_t<std::is_pointer_v<T>>> {
-  uint64_t operator()(const T &value) { return hash_32(reinterpret_cast<const unsigned char *>(value), sizeof(value)); }
+  uint64_t operator()(const T &value) {
+    return fast_hash_32(reinterpret_cast<const unsigned char *>(value), sizeof(value));
+  }
 };
 
 template <typename T> struct hash<T, std::enable_if_t<is_enum_class_v<T>>> {
@@ -306,19 +308,19 @@ template <typename T> struct hash<T, std::enable_if_t<is_enum_class_v<T>>> {
 
 template <> struct hash<std::string> {
   uint64_t operator()(const std::string &value) {
-    return hash_32(reinterpret_cast<const unsigned char *>(value.c_str()), value.length());
+    return fast_hash_32(reinterpret_cast<const unsigned char *>(value.c_str()), value.length());
   }
 };
 
 template <size_t N> struct hash<array<char, N>> {
   uint64_t operator()(const array<char, N> &value) {
-    return hash_32(reinterpret_cast<const unsigned char *>(value.value), strlen(value));
+    return fast_hash_32(reinterpret_cast<const unsigned char *>(value.value), strlen(value));
   }
 };
 
 template <typename T, size_t N> struct hash<array<T, N>> {
   uint64_t operator()(const array<T, N> &value) {
-    return hash_32(reinterpret_cast<const unsigned char *>(value.value), sizeof(value));
+    return fast_hash_32(reinterpret_cast<const unsigned char *>(value.value), sizeof(value));
   }
 };
 

--- a/framework/core/src/libyijinjing/include/kungfu/yijinjing/common.h
+++ b/framework/core/src/libyijinjing/include/kungfu/yijinjing/common.h
@@ -193,7 +193,7 @@ struct location : public std::enable_shared_from_this<location>, public yijinjin
 namespace std {
 template <> struct hash<kungfu::yijinjing::data::location> {
   std::size_t operator()(const kungfu::yijinjing::data::location &l) const {
-    return (static_cast<uint64_t>(kungfu::yijinjing::hash_str_32(l.locator->get_root())) << 32) ^
+    return (static_cast<uint64_t>(kungfu::yijinjing::fast_hash_str_32(l.locator->get_root())) << 32) ^
            static_cast<uint32_t>(l.uid);
   }
 };

--- a/framework/core/src/libyijinjing/include/kungfu/yijinjing/hash.h
+++ b/framework/core/src/libyijinjing/include/kungfu/yijinjing/hash.h
@@ -9,25 +9,33 @@
 
 namespace kungfu::yijinjing {
 /**
- * Murmur Hash 2
+ * Fast deterministic non-cryptographic hash for internal ids and in-process
+ * keys.
+ *
+ * The current implementation is MurmurHash3. Do not use this API for content
+ * addressing, tamper evidence, manifests, or security boundaries; those must
+ * use an explicit content-hash algorithm such as sha256/blake3.
+ *
  * @param key content to be hashed
  * @param len length of key
  * @param seed
  * @return hash result
  */
-uint32_t hash_32(const unsigned char *key, int32_t length, uint32_t seed = KUNGFU_HASH_SEED);
+inline constexpr const char *FAST_HASH_ALGORITHM = "murmur3";
 
-uint64_t hash_64(const unsigned char *key, int32_t length, uint32_t seed = KUNGFU_HASH_SEED);
+uint32_t fast_hash_32(const unsigned char *key, int32_t length, uint32_t seed = KUNGFU_HASH_SEED);
 
-uint32_t hash_str_32(const std::string &key, uint32_t seed = KUNGFU_HASH_SEED);
+uint64_t fast_hash_64(const unsigned char *key, int32_t length, uint32_t seed = KUNGFU_HASH_SEED);
 
-uint64_t hash_str_64(const std::string &key, uint32_t seed = KUNGFU_HASH_SEED);
+uint32_t fast_hash_str_32(const std::string &key, uint32_t seed = KUNGFU_HASH_SEED);
 
-std::string hash_string_32(const std::string &key, uint32_t seed = KUNGFU_HASH_SEED);
+uint64_t fast_hash_str_64(const std::string &key, uint32_t seed = KUNGFU_HASH_SEED);
 
-std::string hash_string_64(const std::string &key, uint32_t seed = KUNGFU_HASH_SEED);
+std::string fast_hash_string_32(const std::string &key, uint32_t seed = KUNGFU_HASH_SEED);
 
-std::string hash_string_128(const std::string &key, uint32_t seed = KUNGFU_HASH_SEED);
+std::string fast_hash_string_64(const std::string &key, uint32_t seed = KUNGFU_HASH_SEED);
+
+std::string fast_hash_string_128(const std::string &key, uint32_t seed = KUNGFU_HASH_SEED);
 } // namespace kungfu::yijinjing
 
 #endif // KUNGFU_YIJINJING_HASH_H

--- a/framework/core/src/libyijinjing/include/kungfu/yijinjing/storage/common.h
+++ b/framework/core/src/libyijinjing/include/kungfu/yijinjing/storage/common.h
@@ -10,6 +10,9 @@
 
 namespace kungfu::yijinjing::storage {
 
+inline constexpr const char *CONTENT_HASH_ALGORITHM_SHA256 = "sha256";
+inline constexpr const char *CONTENT_HASH_ALGORITHM_BLAKE3 = "blake3";
+
 enum class payload_state : uint8_t { Present, Redacted, Absent, Missing };
 
 enum class verification_status : uint8_t { Ok, Degraded, Failed };
@@ -21,7 +24,7 @@ enum class source_kind : uint8_t { Local, ImportedBundle, KungfuRuntime, Adapter
 enum class channel_request_kind : uint8_t { Fetch, Import, Export, Repair };
 
 struct content_hash {
-  std::string algorithm = "sha256";
+  std::string algorithm = CONTENT_HASH_ALGORITHM_SHA256;
   std::string value = {};
 
   [[nodiscard]] bool empty() const { return value.empty(); }

--- a/framework/core/src/libyijinjing/include/kungfu/yijinjing/storage/range.h
+++ b/framework/core/src/libyijinjing/include/kungfu/yijinjing/storage/range.h
@@ -29,7 +29,7 @@ struct hash_inventory_entry {
 };
 
 struct hash_inventory {
-  std::string algorithm = "sha256";
+  std::string algorithm = CONTENT_HASH_ALGORITHM_SHA256;
   std::vector<hash_inventory_entry> entries = {};
 };
 

--- a/framework/core/src/libyijinjing/src/io/locator.cpp
+++ b/framework/core/src/libyijinjing/src/io/locator.cpp
@@ -66,7 +66,8 @@ std::string get_root_dir(es::mode m, const std::vector<std::string> &tags) {
   }
 }
 
-locator::locator(const std::string &root, es::mode m) : root_(root), dir_mode_(m), locator_uid(hash_str_32(root)) {}
+locator::locator(const std::string &root, es::mode m)
+    : root_(root), dir_mode_(m), locator_uid(fast_hash_str_32(root)) {}
 
 locator::locator(const std::string &root) : locator(root, es::mode::LIVE) {}
 
@@ -221,13 +222,13 @@ location::location(yijinjing::enums::mode m, yijinjing::enums::location_role c, 
                    locator_ptr l, uint32_t default_seed)
     : locator(std::move(l)), uname(fmt::format("{}/{}/{}/{}", yijinjing::enums::get_location_role_name(c), g, n,
                                                yijinjing::enums::get_mode_name(m))) {
-  uid64 = hash_str_64(uname);
+  uid64 = fast_hash_str_64(uname);
   role = c;
   group = std::move(g);
   name = std::move(n);
   mode = m;
   seed = default_seed == 0 ? KUNGFU_HASH_SEED : default_seed;
-  uid = hash_str_32(uname, seed);
+  uid = fast_hash_str_32(uname, seed);
   location_uid = uid;
   verify_location_uid();
 }
@@ -271,7 +272,7 @@ std::string location::get_master_kv(const std::string &key) {
 
 void location::update_seed(uint32_t s) {
   seed = s;
-  uid = hash_str_32(uname, seed);
+  uid = fast_hash_str_32(uname, seed);
   location_uid = uid;
   SPDLOG_TRACE("{}", this->to_string());
 }

--- a/framework/core/src/libyijinjing/src/util/hash.cpp
+++ b/framework/core/src/libyijinjing/src/util/hash.cpp
@@ -10,43 +10,43 @@
 #include <kungfu/yijinjing/hash.h>
 
 namespace kungfu {
-uint32_t hash_32(const unsigned char *key, int32_t length) { return kungfu::yijinjing::hash_32(key, length); }
+uint32_t fast_hash_32(const unsigned char *key, int32_t length) { return kungfu::yijinjing::fast_hash_32(key, length); }
 } // namespace kungfu
 
 namespace kungfu::yijinjing {
-uint32_t hash_32(const unsigned char *key, int32_t length, uint32_t seed) {
+uint32_t fast_hash_32(const unsigned char *key, int32_t length, uint32_t seed) {
   uint32_t h;
   MurmurHash3_x86_32(key, length, seed, &h);
   return h;
 }
 
-uint64_t hash_64(const unsigned char *key, int32_t length, uint32_t seed) {
+uint64_t fast_hash_64(const unsigned char *key, int32_t length, uint32_t seed) {
   uint64_t h[2];
   MurmurHash3_x64_128(key, length, seed, &h);
   return h[0];
 }
 
-uint32_t hash_str_32(const std::string &key, uint32_t seed) {
-  return hash_32(reinterpret_cast<const unsigned char *>(key.c_str()), key.length(), seed);
+uint32_t fast_hash_str_32(const std::string &key, uint32_t seed) {
+  return fast_hash_32(reinterpret_cast<const unsigned char *>(key.c_str()), key.length(), seed);
 }
 
-uint64_t hash_str_64(const std::string &key, uint32_t seed) {
-  return hash_64(reinterpret_cast<const unsigned char *>(key.c_str()), key.length(), seed);
+uint64_t fast_hash_str_64(const std::string &key, uint32_t seed) {
+  return fast_hash_64(reinterpret_cast<const unsigned char *>(key.c_str()), key.length(), seed);
 }
 
-std::string hash_string_32(const std::string &key, uint32_t seed) {
+std::string fast_hash_string_32(const std::string &key, uint32_t seed) {
   char h[32] = {0};
   MurmurHash3_x86_32(key.c_str(), key.length(), seed, &h);
   return std::string{h, 32};
 }
 
-std::string hash_string_64(const std::string &key, uint32_t seed) {
+std::string fast_hash_string_64(const std::string &key, uint32_t seed) {
   char h[128] = {0};
   MurmurHash3_x64_128(key.c_str(), key.length(), seed, &h);
   return std::string{h, 64};
 }
 
-std::string hash_string_128(const std::string &key, uint32_t seed) {
+std::string fast_hash_string_128(const std::string &key, uint32_t seed) {
   char h[128] = {0};
   MurmurHash3_x86_128(key.c_str(), key.length(), seed, &h);
   return std::string{h, 128};

--- a/framework/core/src/libyijinjing/src/util/time.cpp
+++ b/framework/core/src/libyijinjing/src/util/time.cpp
@@ -44,7 +44,7 @@ int64_t time::now_in_nano() {
 }
 
 uint32_t time::nano_hashed(int64_t nano_time) {
-  return kungfu::hash_32((const unsigned char *)&nano_time, sizeof(nano_time));
+  return kungfu::fast_hash_32((const unsigned char *)&nano_time, sizeof(nano_time));
 }
 
 int64_t time::next_minute(int64_t nanotime) {

--- a/framework/core/src/python/kungfu/action_envelope.py
+++ b/framework/core/src/python/kungfu/action_envelope.py
@@ -12,6 +12,7 @@ ACTION_ENVELOPE_SCHEMA = "kungfu.action-envelope/v1"
 PAYLOAD_ENCODING_FLATBUFFERS = "flatbuffers"
 PAYLOAD_ENCODING_JSON = "json"
 CONTENT_TRANSFER_BASE64 = "base64"
+CONTENT_HASH_ALGORITHM_SHA256 = "sha256"
 
 
 def canonical_json_bytes(value: Any) -> bytes:

--- a/framework/core/src/python/kungfu/atlas/payloads.py
+++ b/framework/core/src/python/kungfu/atlas/payloads.py
@@ -6,6 +6,7 @@ from typing import Any, cast
 
 from kungfu.action_envelope import (
     ACTION_ENVELOPE_SCHEMA,
+    CONTENT_HASH_ALGORITHM_SHA256,
     build_action_envelope as build_common_action_envelope,
     canonical_json_bytes,
     payload_hash,
@@ -17,6 +18,7 @@ from kungfu.atlas import (
 )
 
 CONTENT_TYPE_JSON = "application/json"
+FRAME_CHECKSUM_ALGORITHM_FNV1A64 = "fnv1a64"
 PAYLOAD_STATE_PRESENT = "present"
 
 ACTION_SCHEMA_REFS = {
@@ -135,7 +137,7 @@ def _action_envelope(
         },
         payload={
             "content_type": entry.get("content_type", CONTENT_TYPE_JSON),
-            "hash_algorithm": "sha256",
+            "hash_algorithm": CONTENT_HASH_ALGORITHM_SHA256,
             "hash": entry.get("payload_hash"),
             "byte_len": entry.get("byte_len"),
             "state": entry.get("payload_state", PAYLOAD_STATE_PRESENT),
@@ -221,7 +223,7 @@ def write_import_payloads(
         "repo_head": repo_head,
         "source_head": repo_head,
         "range": _serialize_range(range_filter),
-        "hash_algorithm": "sha256",
+        "hash_algorithm": CONTENT_HASH_ALGORITHM_SHA256,
         "counts": counts,
         "entries": sorted(
             entries,
@@ -408,6 +410,21 @@ def _check_action_frame(
                 expected=journal.get("journal_payload_hash"),
                 actual=actual_hash,
             )
+        checksum_algorithm = journal.get("checksum_algorithm")
+        if (
+            checksum_algorithm
+            and checksum_algorithm != FRAME_CHECKSUM_ALGORITHM_FNV1A64
+        ):
+            _append_action_error(
+                report,
+                "action_frame_mismatch",
+                entry,
+                field="checksum_algorithm",
+                frame_uid=frame_uid,
+                expected=FRAME_CHECKSUM_ALGORITHM_FNV1A64,
+                actual=checksum_algorithm,
+            )
+            return
         payload_checksum = journal.get("payload_checksum")
         if isinstance(payload_checksum, int) and payload_checksum:
             checksum_for = frame.get("_payload_checksum_for")

--- a/framework/core/src/python/kungfu/atlas/store.py
+++ b/framework/core/src/python/kungfu/atlas/store.py
@@ -90,6 +90,11 @@ class ImportStore:
             "data_length": receipt.data_length,
             "data_type": receipt.data_type,
             "integrity_version": _receipt_value(receipt, "integrity_version", 0),
+            "checksum_algorithm": getattr(
+                yjj,
+                "FRAME_CHECKSUM_ALGORITHM_FNV1A64",
+                payloads.FRAME_CHECKSUM_ALGORITHM_FNV1A64,
+            ),
             "payload_checksum": _receipt_value(receipt, "payload_checksum", 0),
             "frame_checksum": _receipt_value(receipt, "frame_checksum", 0),
             "journal_payload_hash": payloads.payload_hash(data),
@@ -143,7 +148,7 @@ class ImportStore:
                         "content_type": entry.get(
                             "content_type", payloads.CONTENT_TYPE_JSON
                         ),
-                        "hash_algorithm": "sha256",
+                        "hash_algorithm": payloads.CONTENT_HASH_ALGORITHM_SHA256,
                         "hash": entry.get("payload_hash"),
                         "byte_len": entry.get("byte_len"),
                         "state": entry.get(
@@ -217,7 +222,7 @@ class ImportStore:
                 "name": ATLAS_NAME,
                 "dest": PUBLIC_DEST,
             },
-            "hash_algorithm": "sha256",
+            "hash_algorithm": payloads.CONTENT_HASH_ALGORITHM_SHA256,
             "schema_bindings": {
                 str(carrier_type): {
                     "schema_kind": "json",

--- a/framework/core/src/python/kungfu/rewind/bundle.py
+++ b/framework/core/src/python/kungfu/rewind/bundle.py
@@ -12,6 +12,7 @@ import json
 import os
 from typing import Any
 
+from kungfu.action_envelope import CONTENT_HASH_ALGORITHM_SHA256
 from kungfu.rewind import ACTION_TYPE_NAMES, SCHEMA_VERSION
 
 _BFBS_FILE = __import__("kungfu").schema_data_path(__file__, "rewind_events.bfbs")
@@ -56,7 +57,7 @@ def emit(
     manifest = {
         "spec_version": "0.1",
         "source": {"root": journal_root, **source},
-        "hash_algorithm": "sha256",
+        "hash_algorithm": CONTENT_HASH_ALGORITHM_SHA256,
         "schema_bindings": bindings,
         "capture_boundary": "schema bindings cover this run's Rewind capture "
         "events only; frames of other action types in the same journal are out "

--- a/framework/core/src/python/kungfu/rewind/schema_registry.py
+++ b/framework/core/src/python/kungfu/rewind/schema_registry.py
@@ -12,6 +12,7 @@ import hashlib
 import json
 import os
 
+from kungfu.action_envelope import CONTENT_HASH_ALGORITHM_SHA256
 from kungfu.rewind import reflection_fb
 
 _RESERVED_ACTION_PREFIXES = ("rewind.", "work.", "atlas.", "kungfu.")
@@ -76,7 +77,7 @@ def register_user_schema(
     else:
         manifest = {
             "spec_version": "0.1",
-            "hash_algorithm": "sha256",
+            "hash_algorithm": CONTENT_HASH_ALGORITHM_SHA256,
             "schema_bindings": {},
         }
     bindings = manifest.setdefault("schema_bindings", {})

--- a/framework/core/src/python/kungfu/runtime/journal.py
+++ b/framework/core/src/python/kungfu/runtime/journal.py
@@ -36,7 +36,7 @@ def collect_journal_locations(ctx):
             dest = match.group(5)
             page_id = match.group(6)
             uname = "{}/{}/{}/{}".format(role, group, name, mode)
-            uid = yjj.hash_str_32(uname)
+            uid = yjj.fast_hash_str_32(uname)
             if uid in locations:
                 if dest in locations[uid]["readers"]:
                     locations[uid]["readers"][dest].append(page_id)
@@ -49,7 +49,7 @@ def collect_journal_locations(ctx):
                     "name": name,
                     "mode": mode,
                     "uname": uname,
-                    "uid": yjj.hash_str_32(uname),
+                    "uid": yjj.fast_hash_str_32(uname),
                     "readers": {dest: [page_id]},
                 }
             ctx.logger.debug(
@@ -127,7 +127,7 @@ def read_session(ctx, session_id, io_type):
     uname = "{}/{}/{}/{}".format(
         session["role"], session["group"], session["name"], session["mode"]
     )
-    uid = yjj.hash_str_32(uname)
+    uid = yjj.fast_hash_str_32(uname)
     ctx.role = "*"
     ctx.group = "*"
     ctx.name = "*"

--- a/framework/core/src/python/kungfu/work/store.py
+++ b/framework/core/src/python/kungfu/work/store.py
@@ -21,6 +21,7 @@ from typing import Any, cast
 
 import kungfu
 
+from kungfu.action_envelope import CONTENT_HASH_ALGORITHM_SHA256
 from kungfu.work import (
     ACTION_ARTIFACT_RECORDED,
     ACTION_CHECKPOINT_RECORDED,
@@ -181,7 +182,7 @@ class WorkStore:
                 "name": WORK_NAME,
                 "dest": PUBLIC_DEST,
             },
-            "hash_algorithm": "sha256",
+            "hash_algorithm": CONTENT_HASH_ALGORITHM_SHA256,
             "schema_bindings": {
                 action_type: {
                     "schema_kind": "flatbuffers",

--- a/framework/core/stubs/pykungfu/runtime.pyi
+++ b/framework/core/stubs/pykungfu/runtime.pyi
@@ -2,7 +2,7 @@ from __future__ import annotations
 import pykungfu.yijinjing.enums
 import pykungfu.yijinjing.types
 import typing
-__all__: list[str] = ['PUBLISH', 'PULL', 'PUSH', 'REPLY', 'REQUEST', 'SUBSCRIBE', 'action_record_options', 'action_record_receipt', 'action_recorder', 'apprentice', 'assemble', 'bus', 'calendar_day_start', 'color_print', 'compile_schema', 'copy_sink', 'emit_log', 'event', 'frame', 'get_page_path', 'hash_32', 'hash_str_32', 'history_window_start', 'in_color_terminal', 'io_device', 'location', 'locator', 'master', 'nano_hashed', 'next_minute', 'next_session_boundary', 'noop_publisher', 'now_in_nano', 'null_sink', 'observer', 'profile', 'protocol', 'publisher', 'reader', 'session_builder', 'session_finder', 'session_window_start', 'setup_log', 'sink', 'socket', 'strfnow', 'strftime', 'strptime', 'thread_id', 'today_start', 'writer']
+__all__: list[str] = ['FAST_HASH_ALGORITHM', 'FRAME_CHECKSUM_ALGORITHM_FNV1A64', 'PUBLISH', 'PULL', 'PUSH', 'REPLY', 'REQUEST', 'SUBSCRIBE', 'action_record_options', 'action_record_receipt', 'action_recorder', 'apprentice', 'assemble', 'bus', 'calendar_day_start', 'color_print', 'compile_schema', 'copy_sink', 'emit_log', 'event', 'fast_hash_32', 'fast_hash_str_32', 'frame', 'get_page_path', 'hash_32', 'hash_str_32', 'history_window_start', 'in_color_terminal', 'io_device', 'location', 'locator', 'master', 'nano_hashed', 'next_minute', 'next_session_boundary', 'noop_publisher', 'now_in_nano', 'null_sink', 'observer', 'profile', 'protocol', 'publisher', 'reader', 'session_builder', 'session_finder', 'session_window_start', 'setup_log', 'sink', 'socket', 'strfnow', 'strftime', 'strptime', 'thread_id', 'today_start', 'writer']
 class action_record_options:
     chain_to_last: bool
     data_type: pykungfu.yijinjing.enums.FrameDataType
@@ -538,6 +538,10 @@ def compile_schema(fbs_text: str, sandboxed: bool = False) -> tuple:
     ...
 def emit_log(arg0: str, arg1: int, arg2: str, arg3: str, arg4: int, arg5: str) -> None:
     ...
+def fast_hash_32(key: int, length: int, seed: int = 42) -> int:
+    ...
+def fast_hash_str_32(key: str, seed: int = 42) -> int:
+    ...
 def get_page_path(arg0: ..., arg1: int, arg2: int) -> str:
     ...
 def hash_32(key: int, length: int, seed: int = 42) -> int:
@@ -570,6 +574,8 @@ def thread_id() -> int:
     ...
 def today_start() -> int:
     ...
+FAST_HASH_ALGORITHM: str = 'murmur3'
+FRAME_CHECKSUM_ALGORITHM_FNV1A64: str = 'fnv1a64'
 PUBLISH: protocol  # value = <protocol.PUBLISH: 4>
 PULL: protocol  # value = <protocol.PULL: 3>
 PUSH: protocol  # value = <protocol.PUSH: 2>

--- a/scripts/check-runtime-greenfield.mjs
+++ b/scripts/check-runtime-greenfield.mjs
@@ -81,6 +81,8 @@ const CORE_PUBLIC_REGISTRIES = [
 ];
 const LEGACY_REGISTRY_RE =
   /\b(LegacyCompiledTypes|LegacyCompiledDataTypes|LegacyCompiledTypeTags)\b/g;
+const AMBIGUOUS_HASH_API_RE =
+  /\b(hash_32|hash_64|hash_str_32|hash_str_64|hash_string_32|hash_string_64|hash_string_128)\b/g;
 
 const RULES = [
   {
@@ -195,6 +197,27 @@ const RULES = [
     re: /\bfeed_trading_data\b/g,
     message:
       'Closed-set trading feed helpers must not live in the v4 cache API.',
+  },
+  {
+    name: 'ambiguous fast hash api',
+    files: [
+      /^framework\/core\/src\/libyijinjing\//,
+      /^framework\/core\/src\/libkungfu\//,
+      /^framework\/core\/src\/bindings\//,
+    ],
+    re: AMBIGUOUS_HASH_API_RE,
+    message:
+      'Use fast_hash_* for internal non-cryptographic ids; content integrity must use tagged content hashes.',
+  },
+  {
+    name: 'storage content hash misuse',
+    files: [
+      /^framework\/core\/src\/libyijinjing\/include\/kungfu\/yijinjing\/storage\//,
+      /^framework\/core\/src\/libyijinjing\/src\/storage\//,
+    ],
+    re: /\b(fast_hash_|FAST_HASH_ALGORITHM|MurmurHash3)\b/g,
+    message:
+      'Storage content hashes must be explicit content hashes such as sha256/blake3, not fast internal ids.',
   },
 ];
 
@@ -371,6 +394,12 @@ function directLegacyRegistryNameHits(rel, text) {
 }
 
 function isAllowedRuleSelfReference(rel, rule) {
+  if (
+    rule.name === 'ambiguous fast hash api' &&
+    rel === 'framework/core/src/bindings/python/binding/py-runtime.cpp'
+  ) {
+    return true;
+  }
   return (
     rule.name === 'legacy compiled registry names' &&
     rel === 'framework/core/src/libyijinjing/check-deps.mjs'


### PR DESCRIPTION
## Summary
- rename C++ internal hash helpers to fast_hash_* and document MurmurHash3 as internal-only
- expose checksum/content hash algorithm constants through C++, Python, and Node surfaces
- add ADR-0028 plus runtime greenfield gates to prevent future hash taxonomy drift

## Verification
- ./kungfu-code check
- ./kungfu-code build
- node scripts/check-runtime-greenfield.mjs --all
- git diff --check