### PR TITLE
feat(frame): add crc32c frame checksum receipts

### DIFF
--- a/framework/core/docs/adr/ADR-0023-frame-integrity-and-msg-type-allocation-gates.md
+++ b/framework/core/docs/adr/ADR-0023-frame-integrity-and-msg-type-allocation-gates.md
@@ -48,10 +48,11 @@ Frame integrity begins in the C++ action-recorder membrane:
 - Higher layers that persist receipts, such as the Atlas import manifest, can
   run fsck by reopening journal frames and recomputing those checksums.
 
-The first checksum algorithm is a fast non-keyed 64-bit FNV-1a implementation.
-This is a corruption detector, not a cryptographic authenticity proof.
-ADR-0028 names this algorithm `fnv1a64` and separates it from content hashes
-such as `sha256` and internal yijinjing `fast_hash_*` ids.
+The v1 checksum algorithm is a fast non-keyed 64-bit FNV-1a implementation,
+labelled `fnv1a64`. ADR-0029 moves new receipts to v2 CRC32C, labelled
+`crc32c`. Both are corruption detectors, not cryptographic authenticity proofs.
+ADR-0028 separates these frame checksums from content hashes such as `sha256`
+and internal yijinjing `fast_hash_*` ids.
 
 ## Trailer and hash-chain direction
 
@@ -103,10 +104,10 @@ later stage after the receipt-based slice proves the API and fsck flow.
 
 - Receipt-based integrity is only as durable as the layer that persists the
   receipt. Full journal-native trailer integrity is still future work.
-- The v1 receipt checksum defines an implementation-level scalar order for the
+- The receipt checksum defines an implementation-level scalar order for the
   current writer/fsck path. A future journal-native trailer must freeze a
   portable byte encoding as part of the format contract.
-- FNV-1a is not cryptographic. Do not describe it as security against a capable
-  attacker.
+- FNV-1a and CRC32C are not cryptographic. Do not describe them as security
+  against a capable attacker.
 - Legacy open-layer ranges are still present. The gate prevents new accidental
   allocations but does not migrate old surfaces by itself.

--- a/framework/core/docs/adr/ADR-0028-hash-taxonomy-and-integrity-algorithms.md
+++ b/framework/core/docs/adr/ADR-0028-hash-taxonomy-and-integrity-algorithms.md
@@ -36,10 +36,11 @@ Kungfu treats hashes as four separate surfaces:
    implementation is MurmurHash3 and the algorithm label is `murmur3`. This is
    only for internal ids, location uid derivation, in-process keys, and
    deterministic bucketing. It is not a content hash and not a security proof.
-2. **Frame checksum**: the first action-recorder receipt integrity slice uses
-   non-keyed 64-bit FNV-1a, labelled `fnv1a64`. It detects accidental
-   corruption or uncoordinated mutation in the writer/fsck path. It is not a
-   cryptographic authenticity proof.
+2. **Frame checksum**: action-recorder receipts use versioned non-keyed
+   corruption detectors. V1 is 64-bit FNV-1a, labelled `fnv1a64`; v2 is CRC32C,
+   labelled `crc32c` (ADR-0029). They detect accidental corruption or
+   uncoordinated mutation in the writer/fsck path. They are not cryptographic
+   authenticity proofs.
 3. **Content hash**: storage manifests, payload references, schema inventories,
    and import/export payload bodies use explicit content hash algorithms.
    `sha256` is the default v4 portable baseline; `blake3` is reserved as a
@@ -89,7 +90,8 @@ The repository enforces the naming boundary:
 
 - Python compatibility aliases still exist. They should be treated as stable
   compatibility surface, not the recommended internal API.
-- `fnv1a64` is a receipt checksum, not a security claim. Documentation and fsck
-  output must continue to avoid describing it as tamper-proof.
+- `fnv1a64` and `crc32c` are receipt checksums, not security claims.
+  Documentation and fsck output must continue to avoid describing them as
+  tamper-proof.
 - Full tamper evidence still requires a chain/root design and journal-format or
   remote-sync compatibility work.

--- a/framework/core/docs/adr/ADR-0029-frame-checksum-v2-crc32c.md
+++ b/framework/core/docs/adr/ADR-0029-frame-checksum-v2-crc32c.md
@@ -1,0 +1,91 @@
+# ADR-0029: frame checksum v2 uses CRC32C receipt metadata
+
+- Status: accepted
+- Date: 2026-07-08
+- Category: (architecture) frame integrity and fsck
+- Subsystem: libkungfu action recorder, Python/Node bindings, Atlas import
+  manifests, storage fsck/export.
+- Related: ADR-0023 defines receipt-based frame integrity. ADR-0028 separates
+  fast internal hashes, frame checksums, content hashes, and sync roots.
+
+## Context
+
+ADR-0023 introduced receipt-scoped frame integrity with
+`integrity_version=1` and algorithm label `fnv1a64`. That slice proved the
+writer/fsck path without changing `frame_header` or adding a journal trailer.
+
+After the content-hash API landed, the next checksum version needs a more
+standard accidental-corruption detector while keeping the checksum separate from
+content identity and future tamper-evident sync roots.
+
+The candidate algorithms were:
+
+- **CRC32C**: standardized, portable, low build cost, widely available in other
+  languages, good at detecting common storage and transport corruption.
+- **XXH3_64 / XXH3_128**: very fast and wider than CRC32C, but adds a new
+  dependency or vendored implementation and is less useful as a named fsck
+  baseline unless every binding deliberately carries it.
+- **BLAKE3**: strong and fast for cryptographic hashing, but introduces a real
+  dependency and overlaps with the content-hash/trust-proof vocabulary. It is
+  intentionally reserved rather than smuggled in as a frame checksum.
+
+## Decision
+
+Frame checksum v2 uses CRC32C and is labelled `crc32c`.
+
+New action-recorder receipts are produced with:
+
+```text
+integrity_version = 2
+checksum_algorithm = "crc32c"
+```
+
+The v1 algorithm label remains `fnv1a64`, and fsck verifies old receipts by
+using the algorithm implied by `integrity_version=1`.
+
+The checksum scope remains the receipt boundary used by ADR-0023:
+
+- `payload_checksum` covers the published payload bytes.
+- `frame_checksum` covers the selected scalar frame-header fields plus the same
+  payload bytes.
+- `length` remains the final publish token; no journal header or trailer layout
+  is changed by this ADR.
+
+Fsck must reject ambiguous metadata:
+
+- unknown `integrity_version`;
+- unknown `checksum_algorithm`;
+- a supported algorithm that does not match the recorded integrity version;
+- missing algorithm metadata for v2 receipts.
+
+## Consequences
+
+- Existing v1 receipts remain verifiable.
+- New manifests carry an explicit algorithm label and can fail closed when a
+  future agent or machine sees unsupported metadata.
+- CRC32C is a corruption detector, not an authenticity or tamper-evidence
+  primitive. A writer that can rewrite frame bytes can also rewrite non-keyed
+  checksum metadata.
+- The later sync-root/hash-chain work should bind frame or payload hashes into
+  a stream/session/page/manifest root. It should not reinterpret CRC32C as a
+  trust proof.
+
+## Alternatives considered
+
+- **Keep FNV-1a as the default.** Rejected. It is simple, but v2 should move to
+  a standard checksum with better ecosystem support.
+- **Use XXH3 immediately.** Deferred. It is attractive for a future high-speed
+  receipt mode, but the dependency and cross-language binding cost is not needed
+  for this slice.
+- **Use BLAKE3 for frame receipts.** Rejected for this stage. BLAKE3 belongs in
+  content-hash or trust-proof work once its dependency and manifest negotiation
+  are explicit.
+- **Change `frame_header` or add a trailer now.** Rejected. The current goal is
+  a versioned receipt checksum, not a journal-format migration.
+
+## Residual risk
+
+- CRC32C is 32-bit. It is appropriate for accidental corruption, not malicious
+  collision resistance.
+- The receipt is still only as durable as the manifest/projection layer that
+  persists it. Journal-native trailer integrity remains future work.

--- a/framework/core/docs/adr/README.md
+++ b/framework/core/docs/adr/README.md
@@ -44,6 +44,7 @@ A record's **Status** says where it stands:
 | [0026](ADR-0026-runtime-greenfield-core-surface.md) | accepted | runtime exposes a greenfield core surface, not trading typed helpers |
 | [0027](ADR-0027-python-yijinjing-public-core-types.md) | accepted | Python yijinjing schema exposes only core public runtime types |
 | [0028](ADR-0028-hash-taxonomy-and-integrity-algorithms.md) | accepted | hash taxonomy separates internal ids, frame checksums, and content hashes |
+| [0029](ADR-0029-frame-checksum-v2-crc32c.md) | accepted | frame checksum v2 uses CRC32C receipt metadata |
 
 ## Reading by theme
 
@@ -104,7 +105,9 @@ A record's **Status** says where it stands:
   paths), and
   [0028](ADR-0028-hash-taxonomy-and-integrity-algorithms.md) (the rule that
   fast internal hashes, frame checksums, content hashes, and future trust roots
-  are separate algorithm surfaces).
+  are separate algorithm surfaces), and
+  [0029](ADR-0029-frame-checksum-v2-crc32c.md) (the v2 frame receipt checksum
+  algorithm selection and fsck metadata rules).
 - **Cross-cutting principle** — [0009](ADR-0009-load-bearing-self-bootstrap.md)
   (load-bearing self-bootstrap), which also names the general law that
   [`docs/architecture.md` § The build dogfoods the SDK](../../../../docs/architecture.md)

--- a/framework/core/src/bindings/node/binding/action_recorder.cpp
+++ b/framework/core/src/bindings/node/binding/action_recorder.cpp
@@ -88,7 +88,7 @@ Napi::Object to_receipt_object(Napi::Env env, const record_receipt &receipt) {
   object.Set("dataLength", Napi::Number::New(env, receipt.data_length));
   object.Set("dataType", Napi::Number::New(env, receipt.data_type));
   object.Set("integrityVersion", Napi::Number::New(env, receipt.integrity_version));
-  object.Set("checksumAlgorithm", Napi::String::New(env, runtime::action::FRAME_CHECKSUM_ALGORITHM_FNV1A64));
+  object.Set("checksumAlgorithm", Napi::String::New(env, receipt.checksum_algorithm));
   object.Set("payloadChecksum", Napi::BigInt::New(env, receipt.payload_checksum));
   object.Set("frameChecksum", Napi::BigInt::New(env, receipt.frame_checksum));
   return object;
@@ -159,8 +159,16 @@ void ActionRecorder::Init(Napi::Env env, Napi::Object exports) {
   constructor = Napi::Persistent(func);
   constructor.SuppressDestruct();
   exports.Set("ActionRecorder", func);
+  exports.Set("FRAME_INTEGRITY_VERSION_V1", Napi::Number::New(env, runtime::action::FRAME_INTEGRITY_VERSION_V1));
+  exports.Set("FRAME_INTEGRITY_VERSION_V2", Napi::Number::New(env, runtime::action::FRAME_INTEGRITY_VERSION_V2));
+  exports.Set("DEFAULT_FRAME_INTEGRITY_VERSION",
+              Napi::Number::New(env, runtime::action::DEFAULT_FRAME_INTEGRITY_VERSION));
   exports.Set("FRAME_CHECKSUM_ALGORITHM_FNV1A64",
               Napi::String::New(env, runtime::action::FRAME_CHECKSUM_ALGORITHM_FNV1A64));
+  exports.Set("FRAME_CHECKSUM_ALGORITHM_CRC32C",
+              Napi::String::New(env, runtime::action::FRAME_CHECKSUM_ALGORITHM_CRC32C));
+  exports.Set("DEFAULT_FRAME_CHECKSUM_ALGORITHM",
+              Napi::String::New(env, runtime::action::DEFAULT_FRAME_CHECKSUM_ALGORITHM));
 }
 
 } // namespace kungfu::node

--- a/framework/core/src/bindings/python/binding/py-runtime.cpp
+++ b/framework/core/src/bindings/python/binding/py-runtime.cpp
@@ -184,7 +184,25 @@ void bind(pybind11::module &&m) {
   m.def("hash_32", &yijinjing::fast_hash_32, py::arg("key"), py::arg("length"), py::arg("seed") = KUNGFU_HASH_SEED);
   m.def("hash_str_32", &yijinjing::fast_hash_str_32, py::arg("key"), py::arg("seed") = KUNGFU_HASH_SEED);
   m.attr("FAST_HASH_ALGORITHM") = yijinjing::FAST_HASH_ALGORITHM;
+  m.attr("FRAME_INTEGRITY_VERSION_V1") = action::FRAME_INTEGRITY_VERSION_V1;
+  m.attr("FRAME_INTEGRITY_VERSION_V2") = action::FRAME_INTEGRITY_VERSION_V2;
+  m.attr("DEFAULT_FRAME_INTEGRITY_VERSION") = action::DEFAULT_FRAME_INTEGRITY_VERSION;
   m.attr("FRAME_CHECKSUM_ALGORITHM_FNV1A64") = action::FRAME_CHECKSUM_ALGORITHM_FNV1A64;
+  m.attr("FRAME_CHECKSUM_ALGORITHM_CRC32C") = action::FRAME_CHECKSUM_ALGORITHM_CRC32C;
+  m.attr("DEFAULT_FRAME_CHECKSUM_ALGORITHM") = action::DEFAULT_FRAME_CHECKSUM_ALGORITHM;
+  m.def("is_supported_frame_checksum_algorithm", &action::is_supported_frame_checksum_algorithm, py::arg("algorithm"));
+  m.def("frame_checksum_algorithm_for_integrity_version", &action::frame_checksum_algorithm_for_integrity_version,
+        py::arg("integrity_version"));
+  m.def("frame_integrity_version_for_checksum_algorithm", &action::frame_integrity_version_for_checksum_algorithm,
+        py::arg("algorithm"));
+  m.def(
+      "checksum_payload",
+      [](py::buffer payload, const std::string &algorithm) {
+        const auto view = payload.request();
+        return action::checksum_payload(static_cast<const uint8_t *>(view.ptr),
+                                        static_cast<uint32_t>(view.size * view.itemsize), algorithm);
+      },
+      py::arg("payload"), py::arg("algorithm") = action::DEFAULT_FRAME_CHECKSUM_ALGORITHM);
   m.attr("CONTENT_HASH_ALGORITHM_SHA256") = yijinjing::storage::CONTENT_HASH_ALGORITHM_SHA256;
   m.attr("CONTENT_HASH_ALGORITHM_BLAKE3") = yijinjing::storage::CONTENT_HASH_ALGORITHM_BLAKE3;
   m.def("is_supported_content_hash_algorithm", &yijinjing::storage::is_supported_content_hash_algorithm,
@@ -287,6 +305,7 @@ void bind(pybind11::module &&m) {
       .def_readonly("data_length", &action::record_receipt::data_length)
       .def_readonly("data_type", &action::record_receipt::data_type)
       .def_readonly("integrity_version", &action::record_receipt::integrity_version)
+      .def_readonly("checksum_algorithm", &action::record_receipt::checksum_algorithm)
       .def_readonly("payload_checksum", &action::record_receipt::payload_checksum)
       .def_readonly("frame_checksum", &action::record_receipt::frame_checksum);
 

--- a/framework/core/src/libkungfu/include/kungfu/runtime/action_recorder.h
+++ b/framework/core/src/libkungfu/include/kungfu/runtime/action_recorder.h
@@ -14,7 +14,11 @@
 namespace kungfu::runtime::action {
 
 inline constexpr uint32_t FRAME_INTEGRITY_VERSION_V1 = 1;
+inline constexpr uint32_t FRAME_INTEGRITY_VERSION_V2 = 2;
+inline constexpr uint32_t DEFAULT_FRAME_INTEGRITY_VERSION = FRAME_INTEGRITY_VERSION_V2;
 inline constexpr const char *FRAME_CHECKSUM_ALGORITHM_FNV1A64 = "fnv1a64";
+inline constexpr const char *FRAME_CHECKSUM_ALGORITHM_CRC32C = "crc32c";
+inline constexpr const char *DEFAULT_FRAME_CHECKSUM_ALGORITHM = FRAME_CHECKSUM_ALGORITHM_CRC32C;
 
 struct record_options {
   int64_t gen_time = 0;
@@ -38,14 +42,23 @@ struct record_receipt {
   uint32_t data_length = 0;
   int8_t data_type = 0;
   uint32_t integrity_version = 0;
+  std::string checksum_algorithm = {};
   uint64_t payload_checksum = 0;
   uint64_t frame_checksum = 0;
 };
 
-[[nodiscard]] uint64_t checksum_payload(const uint8_t *payload, uint32_t payload_length);
+[[nodiscard]] bool is_supported_frame_checksum_algorithm(const std::string &algorithm);
+
+[[nodiscard]] std::string frame_checksum_algorithm_for_integrity_version(uint32_t integrity_version);
+
+[[nodiscard]] uint32_t frame_integrity_version_for_checksum_algorithm(const std::string &algorithm);
+
+[[nodiscard]] uint64_t checksum_payload(const uint8_t *payload, uint32_t payload_length,
+                                        const std::string &algorithm = DEFAULT_FRAME_CHECKSUM_ALGORITHM);
 
 [[nodiscard]] uint64_t checksum_frame(const yijinjing::types::frame_header &header, const uint8_t *payload,
-                                      uint32_t payload_length);
+                                      uint32_t payload_length,
+                                      const std::string &algorithm = DEFAULT_FRAME_CHECKSUM_ALGORITHM);
 
 class action_recorder {
 public:

--- a/framework/core/src/libkungfu/src/runtime/action_recorder.cpp
+++ b/framework/core/src/libkungfu/src/runtime/action_recorder.cpp
@@ -4,7 +4,10 @@
 #include <kungfu/runtime/io.h>
 #include <kungfu/yijinjing/time.h>
 
+#include <array>
 #include <cstring>
+#include <stdexcept>
+#include <string>
 #include <type_traits>
 
 using namespace kungfu::yijinjing::enums;
@@ -16,6 +19,9 @@ namespace kungfu::runtime::action {
 namespace {
 constexpr uint64_t FNV1A64_OFFSET = 14695981039346656037ull;
 constexpr uint64_t FNV1A64_PRIME = 1099511628211ull;
+constexpr uint32_t CRC32C_INITIAL = 0xffffffffu;
+constexpr uint32_t CRC32C_XOR_OUT = 0xffffffffu;
+constexpr uint32_t CRC32C_REVERSED_POLY = 0x82f63b78u;
 
 uint32_t align_frame_payload_length(uint32_t length) {
   return static_cast<uint32_t>((length + (sizeof(uintptr_t) - 1)) & ~(sizeof(uintptr_t) - 1));
@@ -40,9 +46,82 @@ template <typename T> void checksum_scalar(uint64_t &state, const T &value) {
     checksum_byte(state, static_cast<uint8_t>((raw >> (i * 8)) & 0xffu));
   }
 }
+
+const std::array<uint32_t, 256> &crc32c_table() {
+  static const auto table = [] {
+    std::array<uint32_t, 256> result{};
+    for (uint32_t i = 0; i < result.size(); ++i) {
+      uint32_t crc = i;
+      for (int bit = 0; bit < 8; ++bit) {
+        crc = (crc >> 1u) ^ ((crc & 1u) != 0u ? CRC32C_REVERSED_POLY : 0u);
+      }
+      result[i] = crc;
+    }
+    return result;
+  }();
+  return table;
+}
+
+void checksum_crc32c_bytes(uint32_t &state, const uint8_t *data, size_t size) {
+  const auto &table = crc32c_table();
+  for (size_t i = 0; i < size; ++i) {
+    state = (state >> 8u) ^ table[(state ^ data[i]) & 0xffu];
+  }
+}
+
+template <typename T> void checksum_crc32c_scalar(uint32_t &state, const T &value) {
+  static_assert(std::is_integral_v<T>);
+  using unsigned_t = std::make_unsigned_t<T>;
+  auto raw = static_cast<unsigned_t>(value);
+  for (size_t i = 0; i < sizeof(T); ++i) {
+    const auto byte = static_cast<uint8_t>((raw >> (i * 8)) & 0xffu);
+    checksum_crc32c_bytes(state, &byte, 1);
+  }
+}
+
+uint64_t finalize_crc32c(uint32_t state) { return static_cast<uint64_t>(state ^ CRC32C_XOR_OUT); }
+
+bool is_fnv1a64(const std::string &algorithm) { return algorithm == FRAME_CHECKSUM_ALGORITHM_FNV1A64; }
+
+bool is_crc32c(const std::string &algorithm) { return algorithm == FRAME_CHECKSUM_ALGORITHM_CRC32C; }
 } // namespace
 
-uint64_t checksum_payload(const uint8_t *payload, uint32_t payload_length) {
+bool is_supported_frame_checksum_algorithm(const std::string &algorithm) {
+  return is_fnv1a64(algorithm) || is_crc32c(algorithm);
+}
+
+std::string frame_checksum_algorithm_for_integrity_version(uint32_t integrity_version) {
+  switch (integrity_version) {
+  case FRAME_INTEGRITY_VERSION_V1:
+    return FRAME_CHECKSUM_ALGORITHM_FNV1A64;
+  case FRAME_INTEGRITY_VERSION_V2:
+    return FRAME_CHECKSUM_ALGORITHM_CRC32C;
+  default:
+    throw std::invalid_argument("unsupported frame integrity version: " + std::to_string(integrity_version));
+  }
+}
+
+uint32_t frame_integrity_version_for_checksum_algorithm(const std::string &algorithm) {
+  if (is_fnv1a64(algorithm)) {
+    return FRAME_INTEGRITY_VERSION_V1;
+  }
+  if (is_crc32c(algorithm)) {
+    return FRAME_INTEGRITY_VERSION_V2;
+  }
+  throw std::invalid_argument("unsupported frame checksum algorithm: " + algorithm);
+}
+
+uint64_t checksum_payload(const uint8_t *payload, uint32_t payload_length, const std::string &algorithm) {
+  if (is_crc32c(algorithm)) {
+    uint32_t state = CRC32C_INITIAL;
+    if (payload != nullptr and payload_length > 0) {
+      checksum_crc32c_bytes(state, payload, payload_length);
+    }
+    return finalize_crc32c(state);
+  }
+  if (!is_fnv1a64(algorithm)) {
+    throw std::invalid_argument("unsupported frame checksum algorithm: " + algorithm);
+  }
   uint64_t state = FNV1A64_OFFSET;
   if (payload != nullptr and payload_length > 0) {
     checksum_bytes(state, payload, payload_length);
@@ -50,7 +129,32 @@ uint64_t checksum_payload(const uint8_t *payload, uint32_t payload_length) {
   return state;
 }
 
-uint64_t checksum_frame(const yijinjing::types::frame_header &header, const uint8_t *payload, uint32_t payload_length) {
+uint64_t checksum_frame(const yijinjing::types::frame_header &header, const uint8_t *payload, uint32_t payload_length,
+                        const std::string &algorithm) {
+  if (is_crc32c(algorithm)) {
+    uint32_t state = CRC32C_INITIAL;
+    checksum_crc32c_scalar(state, header.length);
+    checksum_crc32c_scalar(state, header.header_length);
+    checksum_crc32c_scalar(state, header.gen_time);
+    checksum_crc32c_scalar(state, header.trigger_time);
+    checksum_crc32c_scalar(state, header.carrier_type);
+    checksum_crc32c_scalar(state, header.source);
+    checksum_crc32c_scalar(state, header.dest);
+    const auto data_type = static_cast<int8_t>(header.data_type);
+    checksum_crc32c_scalar(state, data_type);
+    checksum_crc32c_scalar(state, header.initial_source);
+    checksum_crc32c_scalar(state, header.frame_uid);
+    checksum_crc32c_scalar(state, header.trigger_frame_uid);
+    checksum_crc32c_scalar(state, header.stream_id);
+    checksum_crc32c_scalar(state, payload_length);
+    if (payload != nullptr and payload_length > 0) {
+      checksum_crc32c_bytes(state, payload, payload_length);
+    }
+    return finalize_crc32c(state);
+  }
+  if (!is_fnv1a64(algorithm)) {
+    throw std::invalid_argument("unsupported frame checksum algorithm: " + algorithm);
+  }
   uint64_t state = FNV1A64_OFFSET;
   checksum_scalar(state, header.length);
   checksum_scalar(state, header.header_length);
@@ -117,8 +221,9 @@ record_receipt action_recorder::record_payload(int32_t carrier_type, const uint8
   checksum_header.gen_time = gen_time;
   checksum_header.frame_uid = frame_uid;
   checksum_header.trigger_frame_uid = parent_frame_uid;
-  const auto payload_checksum = checksum_payload(payload, payload_length);
-  const auto frame_checksum = checksum_frame(checksum_header, payload, payload_length);
+  const auto checksum_algorithm = frame_checksum_algorithm_for_integrity_version(DEFAULT_FRAME_INTEGRITY_VERSION);
+  const auto payload_checksum = checksum_payload(payload, payload_length, checksum_algorithm);
+  const auto frame_checksum = checksum_frame(checksum_header, payload, payload_length, checksum_algorithm);
   writer_->close_frame(payload_length, gen_time);
   bus::set_trigger_frame_uid(0);
 
@@ -134,7 +239,8 @@ record_receipt action_recorder::record_payload(int32_t carrier_type, const uint8
   receipt.dest = dest_id_;
   receipt.data_length = payload_length;
   receipt.data_type = static_cast<int8_t>(options.data_type);
-  receipt.integrity_version = FRAME_INTEGRITY_VERSION_V1;
+  receipt.integrity_version = DEFAULT_FRAME_INTEGRITY_VERSION;
+  receipt.checksum_algorithm = checksum_algorithm;
   receipt.payload_checksum = payload_checksum;
   receipt.frame_checksum = frame_checksum;
   last_frame_uid_ = receipt.frame_uid;

--- a/framework/core/src/python/kungfu/atlas/payloads.py
+++ b/framework/core/src/python/kungfu/atlas/payloads.py
@@ -6,11 +6,11 @@ from typing import Any, cast
 
 from kungfu.action_envelope import (
     ACTION_ENVELOPE_SCHEMA,
-    CONTENT_HASH_ALGORITHM_SHA256,
     build_action_envelope as build_common_action_envelope,
     canonical_json_bytes,
     payload_hash,
 )
+from kungfu.content_hash import CONTENT_HASH_ALGORITHM_SHA256
 from kungfu.atlas import (
     ACTION_GOAL_SNAPSHOT,
     ACTION_MARKER_SNAPSHOT,
@@ -18,7 +18,17 @@ from kungfu.atlas import (
 )
 
 CONTENT_TYPE_JSON = "application/json"
+FRAME_INTEGRITY_VERSION_V1 = 1
+FRAME_INTEGRITY_VERSION_V2 = 2
+DEFAULT_FRAME_INTEGRITY_VERSION = FRAME_INTEGRITY_VERSION_V2
 FRAME_CHECKSUM_ALGORITHM_FNV1A64 = "fnv1a64"
+FRAME_CHECKSUM_ALGORITHM_CRC32C = "crc32c"
+DEFAULT_FRAME_CHECKSUM_ALGORITHM = FRAME_CHECKSUM_ALGORITHM_CRC32C
+FRAME_CHECKSUM_ALGORITHMS_BY_VERSION = {
+    FRAME_INTEGRITY_VERSION_V1: FRAME_CHECKSUM_ALGORITHM_FNV1A64,
+    FRAME_INTEGRITY_VERSION_V2: FRAME_CHECKSUM_ALGORITHM_CRC32C,
+}
+SUPPORTED_FRAME_CHECKSUM_ALGORITHMS = set(FRAME_CHECKSUM_ALGORITHMS_BY_VERSION.values())
 PAYLOAD_STATE_PRESENT = "present"
 
 ACTION_SCHEMA_REFS = {
@@ -309,6 +319,71 @@ def _append_action_error(
     report["errors"].append(error)
 
 
+def _frame_checksum_algorithm_for_journal(
+    report: dict[str, Any],
+    entry: dict[str, Any],
+    journal: dict[str, Any],
+) -> str | None:
+    integrity_version = journal.get("integrity_version")
+    checksum_algorithm = journal.get("checksum_algorithm")
+    if not integrity_version and not checksum_algorithm:
+        return None
+    if not isinstance(integrity_version, int) or integrity_version <= 0:
+        _append_action_error(
+            report,
+            "action_frame_mismatch",
+            entry,
+            field="integrity_version",
+            expected=sorted(FRAME_CHECKSUM_ALGORITHMS_BY_VERSION),
+            actual=integrity_version,
+        )
+        return None
+    expected_algorithm = FRAME_CHECKSUM_ALGORITHMS_BY_VERSION.get(integrity_version)
+    if expected_algorithm is None:
+        _append_action_error(
+            report,
+            "action_frame_mismatch",
+            entry,
+            field="integrity_version",
+            expected=sorted(FRAME_CHECKSUM_ALGORITHMS_BY_VERSION),
+            actual=integrity_version,
+        )
+        return None
+    if not checksum_algorithm:
+        if integrity_version == FRAME_INTEGRITY_VERSION_V1:
+            return expected_algorithm
+        _append_action_error(
+            report,
+            "action_frame_mismatch",
+            entry,
+            field="checksum_algorithm",
+            expected=expected_algorithm,
+            actual=checksum_algorithm,
+        )
+        return None
+    if checksum_algorithm not in SUPPORTED_FRAME_CHECKSUM_ALGORITHMS:
+        _append_action_error(
+            report,
+            "action_frame_mismatch",
+            entry,
+            field="checksum_algorithm",
+            expected=sorted(SUPPORTED_FRAME_CHECKSUM_ALGORITHMS),
+            actual=checksum_algorithm,
+        )
+        return None
+    if checksum_algorithm != expected_algorithm:
+        _append_action_error(
+            report,
+            "action_frame_mismatch",
+            entry,
+            field="checksum_algorithm",
+            expected=expected_algorithm,
+            actual=checksum_algorithm,
+        )
+        return None
+    return checksum_algorithm
+
+
 def _check_action_payload(
     report: dict[str, Any],
     entry: dict[str, Any],
@@ -410,26 +485,20 @@ def _check_action_frame(
                 expected=journal.get("journal_payload_hash"),
                 actual=actual_hash,
             )
-        checksum_algorithm = journal.get("checksum_algorithm")
+        checksum_algorithm = _frame_checksum_algorithm_for_journal(
+            report, entry, journal
+        )
+        payload_checksum = journal.get("payload_checksum")
         if (
             checksum_algorithm
-            and checksum_algorithm != FRAME_CHECKSUM_ALGORITHM_FNV1A64
+            and isinstance(payload_checksum, int)
+            and payload_checksum
         ):
-            _append_action_error(
-                report,
-                "action_frame_mismatch",
-                entry,
-                field="checksum_algorithm",
-                frame_uid=frame_uid,
-                expected=FRAME_CHECKSUM_ALGORITHM_FNV1A64,
-                actual=checksum_algorithm,
-            )
-            return
-        payload_checksum = journal.get("payload_checksum")
-        if isinstance(payload_checksum, int) and payload_checksum:
             checksum_for = frame.get("_payload_checksum_for")
             actual_checksum = (
-                checksum_for(expected_length) if callable(checksum_for) else None
+                checksum_for(expected_length, checksum_algorithm)
+                if callable(checksum_for)
+                else None
             )
             if actual_checksum != payload_checksum:
                 _append_action_error(
@@ -442,10 +511,12 @@ def _check_action_frame(
                     actual=actual_checksum,
                 )
         frame_checksum = journal.get("frame_checksum")
-        if isinstance(frame_checksum, int) and frame_checksum:
+        if checksum_algorithm and isinstance(frame_checksum, int) and frame_checksum:
             checksum_for = frame.get("_frame_checksum_for")
             actual_checksum = (
-                checksum_for(expected_length) if callable(checksum_for) else None
+                checksum_for(expected_length, checksum_algorithm)
+                if callable(checksum_for)
+                else None
             )
             if actual_checksum != frame_checksum:
                 _append_action_error(

--- a/framework/core/src/python/kungfu/atlas/store.py
+++ b/framework/core/src/python/kungfu/atlas/store.py
@@ -90,10 +90,14 @@ class ImportStore:
             "data_length": receipt.data_length,
             "data_type": receipt.data_type,
             "integrity_version": _receipt_value(receipt, "integrity_version", 0),
-            "checksum_algorithm": getattr(
-                yjj,
-                "FRAME_CHECKSUM_ALGORITHM_FNV1A64",
-                payloads.FRAME_CHECKSUM_ALGORITHM_FNV1A64,
+            "checksum_algorithm": _receipt_value(
+                receipt,
+                "checksum_algorithm",
+                getattr(
+                    yjj,
+                    "DEFAULT_FRAME_CHECKSUM_ALGORITHM",
+                    payloads.DEFAULT_FRAME_CHECKSUM_ALGORITHM,
+                ),
             ),
             "payload_checksum": _receipt_value(receipt, "payload_checksum", 0),
             "frame_checksum": _receipt_value(receipt, "frame_checksum", 0),
@@ -277,7 +281,28 @@ def _fnv1a64_update(state, data):
     return state
 
 
-def _checksum_payload(data):
+def _crc32c_table():
+    table = []
+    for i in range(256):
+        crc = i
+        for _ in range(8):
+            crc = (crc >> 1) ^ (0x82F63B78 if crc & 1 else 0)
+        table.append(crc & 0xFFFFFFFF)
+    return table
+
+
+_CRC32C_TABLE = _crc32c_table()
+
+
+def _crc32c_update(state, data):
+    for value in bytes(data):
+        state = (state >> 8) ^ _CRC32C_TABLE[(state ^ value) & 0xFF]
+    return state & 0xFFFFFFFF
+
+
+def _checksum_payload(data, algorithm=payloads.DEFAULT_FRAME_CHECKSUM_ALGORITHM):
+    if algorithm == payloads.FRAME_CHECKSUM_ALGORITHM_CRC32C:
+        return _crc32c_update(0xFFFFFFFF, data) ^ 0xFFFFFFFF
     return _fnv1a64_update(14695981039346656037, data)
 
 
@@ -285,8 +310,9 @@ def _pack_scalar(fmt, value):
     return struct.pack("<" + fmt, value)
 
 
-def _checksum_frame(header, data, payload_length):
-    state = 14695981039346656037
+def _checksum_frame(
+    header, data, payload_length, algorithm=payloads.DEFAULT_FRAME_CHECKSUM_ALGORITHM
+):
     fields = [
         ("I", int(getattr(header, "length", 0))),
         ("I", int(getattr(header, "header_length", 0))),
@@ -302,6 +328,12 @@ def _checksum_frame(header, data, payload_length):
         ("Q", int(header.stream_id)),
         ("I", int(payload_length)),
     ]
+    if algorithm == payloads.FRAME_CHECKSUM_ALGORITHM_CRC32C:
+        state = 0xFFFFFFFF
+        for fmt, value in fields:
+            state = _crc32c_update(state, _pack_scalar(fmt, value))
+        return _crc32c_update(state, data[:payload_length]) ^ 0xFFFFFFFF
+    state = 14695981039346656037
     for fmt, value in fields:
         state = _fnv1a64_update(state, _pack_scalar(fmt, value))
     return _fnv1a64_update(state, data[:payload_length])
@@ -332,11 +364,11 @@ def read_action_frame_index(runtime_dir):
                 "data_type": _frame_data_type_value(header),
                 "journal_payload_hash": payloads.payload_hash(data),
                 "_payload": data,
-                "_payload_checksum_for": lambda payload_length, d=data: (
-                    _checksum_payload(d[:payload_length])
+                "_payload_checksum_for": lambda payload_length, algorithm=payloads.DEFAULT_FRAME_CHECKSUM_ALGORITHM, d=data: (
+                    _checksum_payload(d[:payload_length], algorithm)
                 ),
-                "_frame_checksum_for": lambda payload_length, h=header, d=data: (
-                    _checksum_frame(h, d, payload_length)
+                "_frame_checksum_for": lambda payload_length, algorithm=payloads.DEFAULT_FRAME_CHECKSUM_ALGORITHM, h=header, d=data: (
+                    _checksum_frame(h, d, payload_length, algorithm)
                 ),
             }
     except (RuntimeError, ValueError, FileNotFoundError):

--- a/framework/core/stubs/pykungfu/runtime.pyi
+++ b/framework/core/stubs/pykungfu/runtime.pyi
@@ -3,7 +3,7 @@ import pykungfu.yijinjing.enums
 import pykungfu.yijinjing.types
 import typing
 import typing_extensions
-__all__: list[str] = ['CONTENT_HASH_ALGORITHM_BLAKE3', 'CONTENT_HASH_ALGORITHM_SHA256', 'FAST_HASH_ALGORITHM', 'FRAME_CHECKSUM_ALGORITHM_FNV1A64', 'PUBLISH', 'PULL', 'PUSH', 'REPLY', 'REQUEST', 'SUBSCRIBE', 'action_record_options', 'action_record_receipt', 'action_recorder', 'apprentice', 'assemble', 'bus', 'calendar_day_start', 'color_print', 'compile_schema', 'compute_content_hash', 'compute_content_hash_value', 'copy_sink', 'emit_log', 'event', 'fast_hash_32', 'fast_hash_str_32', 'format_content_hash', 'frame', 'get_page_path', 'hash_32', 'hash_str_32', 'history_window_start', 'in_color_terminal', 'io_device', 'is_supported_content_hash_algorithm', 'location', 'locator', 'master', 'nano_hashed', 'next_minute', 'next_session_boundary', 'noop_publisher', 'normalize_content_hash_algorithm', 'now_in_nano', 'null_sink', 'observer', 'parse_content_hash', 'profile', 'protocol', 'publisher', 'reader', 'session_builder', 'session_finder', 'session_window_start', 'setup_log', 'sink', 'socket', 'strfnow', 'strftime', 'strptime', 'thread_id', 'today_start', 'verify_content_hash', 'writer']
+__all__: list[str] = ['CONTENT_HASH_ALGORITHM_BLAKE3', 'CONTENT_HASH_ALGORITHM_SHA256', 'DEFAULT_FRAME_CHECKSUM_ALGORITHM', 'DEFAULT_FRAME_INTEGRITY_VERSION', 'FAST_HASH_ALGORITHM', 'FRAME_CHECKSUM_ALGORITHM_CRC32C', 'FRAME_CHECKSUM_ALGORITHM_FNV1A64', 'FRAME_INTEGRITY_VERSION_V1', 'FRAME_INTEGRITY_VERSION_V2', 'PUBLISH', 'PULL', 'PUSH', 'REPLY', 'REQUEST', 'SUBSCRIBE', 'action_record_options', 'action_record_receipt', 'action_recorder', 'apprentice', 'assemble', 'bus', 'calendar_day_start', 'checksum_payload', 'color_print', 'compile_schema', 'compute_content_hash', 'compute_content_hash_value', 'copy_sink', 'emit_log', 'event', 'fast_hash_32', 'fast_hash_str_32', 'format_content_hash', 'frame', 'frame_checksum_algorithm_for_integrity_version', 'frame_integrity_version_for_checksum_algorithm', 'get_page_path', 'hash_32', 'hash_str_32', 'history_window_start', 'in_color_terminal', 'io_device', 'is_supported_content_hash_algorithm', 'is_supported_frame_checksum_algorithm', 'location', 'locator', 'master', 'nano_hashed', 'next_minute', 'next_session_boundary', 'noop_publisher', 'normalize_content_hash_algorithm', 'now_in_nano', 'null_sink', 'observer', 'parse_content_hash', 'profile', 'protocol', 'publisher', 'reader', 'session_builder', 'session_finder', 'session_window_start', 'setup_log', 'sink', 'socket', 'strfnow', 'strftime', 'strptime', 'thread_id', 'today_start', 'verify_content_hash', 'writer']
 class action_record_options:
     chain_to_last: bool
     data_type: pykungfu.yijinjing.enums.FrameDataType
@@ -16,6 +16,9 @@ class action_record_options:
 class action_record_receipt:
     @property
     def carrier_type(self) -> int:
+        ...
+    @property
+    def checksum_algorithm(self) -> str:
         ...
     @property
     def data_length(self) -> int:
@@ -533,6 +536,8 @@ class writer:
         ...
 def calendar_day_start(arg0: int) -> int:
     ...
+def checksum_payload(payload: typing_extensions.Buffer, algorithm: str = 'crc32c') -> int:
+    ...
 def color_print(arg0: str, arg1: str) -> None:
     ...
 def compile_schema(fbs_text: str, sandboxed: bool = False) -> tuple:
@@ -549,6 +554,10 @@ def fast_hash_str_32(key: str, seed: int = 42) -> int:
     ...
 def format_content_hash(algorithm: str, value: str) -> str:
     ...
+def frame_checksum_algorithm_for_integrity_version(integrity_version: int) -> str:
+    ...
+def frame_integrity_version_for_checksum_algorithm(algorithm: str) -> int:
+    ...
 def get_page_path(arg0: ..., arg1: int, arg2: int) -> str:
     ...
 def hash_32(key: int, length: int, seed: int = 42) -> int:
@@ -560,6 +569,8 @@ def history_window_start() -> int:
 def in_color_terminal() -> bool:
     ...
 def is_supported_content_hash_algorithm(algorithm: str) -> bool:
+    ...
+def is_supported_frame_checksum_algorithm(algorithm: str) -> bool:
     ...
 def nano_hashed(arg0: int) -> int:
     ...
@@ -591,8 +602,13 @@ def verify_content_hash(payload: typing_extensions.Buffer, expected: str, algori
     ...
 CONTENT_HASH_ALGORITHM_BLAKE3: str = 'blake3'
 CONTENT_HASH_ALGORITHM_SHA256: str = 'sha256'
+DEFAULT_FRAME_CHECKSUM_ALGORITHM: str = 'crc32c'
+DEFAULT_FRAME_INTEGRITY_VERSION: int = 2
 FAST_HASH_ALGORITHM: str = 'murmur3'
+FRAME_CHECKSUM_ALGORITHM_CRC32C: str = 'crc32c'
 FRAME_CHECKSUM_ALGORITHM_FNV1A64: str = 'fnv1a64'
+FRAME_INTEGRITY_VERSION_V1: int = 1
+FRAME_INTEGRITY_VERSION_V2: int = 2
 PUBLISH: protocol  # value = <protocol.PUBLISH: 4>
 PULL: protocol  # value = <protocol.PULL: 3>
 PUSH: protocol  # value = <protocol.PUSH: 2>

--- a/framework/core/tests/python/test_atlas_storage.py
+++ b/framework/core/tests/python/test_atlas_storage.py
@@ -4,7 +4,7 @@ import json
 from datetime import datetime, timezone
 
 from kungfu.atlas import importer, payloads
-from kungfu.atlas import MSG_ACTION_ENVELOPE
+from kungfu.atlas import CARRIER_ATLAS_ACTION
 from kungfu.sources import store as source_store
 
 
@@ -63,7 +63,7 @@ def _action_receipts(source_records):
             "stream_id": 0,
             "gen_time": 1000 + index,
             "trigger_time": 0,
-            "msg_type": MSG_ACTION_ENVELOPE,
+            "carrier_type": CARRIER_ATLAS_ACTION,
             "source": 101,
             "initial_source": 101,
             "dest": 0,
@@ -87,6 +87,18 @@ def _action_frames_from_manifest(manifest):
                 entry["action"]["journal"]["gen_time"],
             )
         ] = journal
+    return frames
+
+
+def _action_frames_with_checksums(manifest, payload_checksum, frame_checksum):
+    frames = _action_frames_from_manifest(manifest)
+    for frame in frames.values():
+        frame["_payload_checksum_for"] = (
+            lambda _length, _algorithm, checksum=payload_checksum: checksum
+        )
+        frame["_frame_checksum_for"] = (
+            lambda _length, _algorithm, checksum=frame_checksum: checksum
+        )
     return frames
 
 
@@ -213,7 +225,7 @@ def test_payload_manifest_fsck_export_and_verify(tmp_path):
     assert goal["action"]["schema_ref"]["id"] == "kungfu.atlas.GoalSnapshot"
     assert goal["action"]["payload"]["hash"] == goal["payload_hash"]
     assert goal["action"]["journal"]["frame_uid"] > 0
-    assert goal["action"]["journal"]["msg_type"] == MSG_ACTION_ENVELOPE
+    assert goal["action"]["journal"]["carrier_type"] == CARRIER_ATLAS_ACTION
 
     missing_frame = payloads.fsck_import(store, action_frames={})
     assert not missing_frame["ok"]
@@ -230,6 +242,120 @@ def test_payload_manifest_fsck_export_and_verify(tmp_path):
         "extra": [],
         "hash_mismatch": [],
     }
+
+
+def test_payload_fsck_verifies_versioned_frame_checksums(tmp_path):
+    repo = tmp_path / "atlas"
+    store = tmp_path / "store"
+    _atlas_fixture(repo)
+    _, _, _, source_records, _ = importer.read_control_plane_with_sources(str(repo))
+    receipts = _action_receipts(source_records)
+    payload_checksum = 1234
+    frame_checksum = 5678
+    for receipt in receipts.values():
+        receipt.update(
+            {
+                "integrity_version": payloads.FRAME_INTEGRITY_VERSION_V2,
+                "checksum_algorithm": payloads.FRAME_CHECKSUM_ALGORITHM_CRC32C,
+                "payload_checksum": payload_checksum,
+                "frame_checksum": frame_checksum,
+            }
+        )
+    manifest = payloads.write_import_payloads(
+        store,
+        import_id="imp-checksum-v2",
+        repo_root=str(repo),
+        repo_head="abc123",
+        source_records=source_records,
+        counts={"missions": 1, "goals": 1, "markers": 1},
+        action_receipts=receipts,
+    )
+
+    report = payloads.fsck_import(
+        store,
+        action_frames=_action_frames_with_checksums(
+            manifest, payload_checksum, frame_checksum
+        ),
+    )
+    assert report["ok"]
+
+    for receipt in receipts.values():
+        receipt["integrity_version"] = payloads.FRAME_INTEGRITY_VERSION_V1
+        receipt["checksum_algorithm"] = payloads.FRAME_CHECKSUM_ALGORITHM_FNV1A64
+    manifest = payloads.write_import_payloads(
+        store,
+        import_id="imp-checksum-v1",
+        repo_root=str(repo),
+        repo_head="abc123",
+        source_records=source_records,
+        counts={"missions": 1, "goals": 1, "markers": 1},
+        action_receipts=receipts,
+    )
+    report = payloads.fsck_import(
+        store,
+        action_frames=_action_frames_with_checksums(
+            manifest, payload_checksum, frame_checksum
+        ),
+    )
+    assert report["ok"]
+
+
+def test_payload_fsck_rejects_unknown_or_mismatched_frame_checksum_metadata(
+    tmp_path,
+):
+    repo = tmp_path / "atlas"
+    store = tmp_path / "store"
+    _atlas_fixture(repo)
+    _, _, _, source_records, _ = importer.read_control_plane_with_sources(str(repo))
+    receipts = _action_receipts(source_records)
+    for receipt in receipts.values():
+        receipt.update(
+            {
+                "integrity_version": payloads.FRAME_INTEGRITY_VERSION_V2,
+                "checksum_algorithm": payloads.FRAME_CHECKSUM_ALGORITHM_FNV1A64,
+                "payload_checksum": 1234,
+                "frame_checksum": 5678,
+            }
+        )
+    manifest = payloads.write_import_payloads(
+        store,
+        import_id="imp-checksum-mismatch",
+        repo_root=str(repo),
+        repo_head="abc123",
+        source_records=source_records,
+        counts={"missions": 1, "goals": 1, "markers": 1},
+        action_receipts=receipts,
+    )
+    report = payloads.fsck_import(
+        store, action_frames=_action_frames_with_checksums(manifest, 1234, 5678)
+    )
+    assert not report["ok"]
+    assert any(
+        error.get("field") == "checksum_algorithm"
+        and error.get("expected") == payloads.FRAME_CHECKSUM_ALGORITHM_CRC32C
+        for error in report["errors"]
+    )
+
+    for receipt in receipts.values():
+        receipt["checksum_algorithm"] = "mystery64"
+    manifest = payloads.write_import_payloads(
+        store,
+        import_id="imp-checksum-unknown",
+        repo_root=str(repo),
+        repo_head="abc123",
+        source_records=source_records,
+        counts={"missions": 1, "goals": 1, "markers": 1},
+        action_receipts=receipts,
+    )
+    report = payloads.fsck_import(
+        store, action_frames=_action_frames_with_checksums(manifest, 1234, 5678)
+    )
+    assert not report["ok"]
+    assert any(
+        error.get("field") == "checksum_algorithm"
+        and error.get("actual") == "mystery64"
+        for error in report["errors"]
+    )
 
 
 def test_payload_fsck_reports_missing_payload(tmp_path):


### PR DESCRIPTION
Implement versioned frame checksum receipts with integrity_version=2 and crc32c, keep v1 fnv1a64 fsck verification, update Python/Node bindings, Atlas import/fsck tests, and ADR-0029.