### PR TITLE
feat(storage): add manifest sync root verification

### DIFF
--- a/docs/runtime-storage-service.md
+++ b/docs/runtime-storage-service.md
@@ -195,6 +195,14 @@ use explicit content-hash algorithms such as `sha256`; frame receipts use the
 recorded checksum algorithm such as `fnv1a64`; yijinjing `fast_hash_*` ids are
 not valid payload or manifest hashes.
 
+The first trust-proof surface is the manifest-scoped sync root from
+[`ADR-0030`](../framework/core/docs/adr/ADR-0030-manifest-scoped-sync-root-v1.md).
+For Atlas imports, `fsck` recomputes `kungfu.sync-root/v1` from the manifest's
+ordered entries and reports missing or mismatched root data as a storage
+failure. This root binds payload references, source coordinates, action
+envelopes, and frame receipt metadata for the accepted segment. It is local
+tamper evidence, not a signature, MAC, or non-repudiation proof.
+
 Example target:
 
 ```sh

--- a/framework/core/docs/adr/ADR-0030-manifest-scoped-sync-root-v1.md
+++ b/framework/core/docs/adr/ADR-0030-manifest-scoped-sync-root-v1.md
@@ -1,0 +1,123 @@
+# ADR-0030: manifest-scoped sync root v1
+
+- Status: accepted
+- Date: 2026-07-08
+- Category: (architecture) storage integrity and source sync
+- Subsystem: Atlas import manifests, storage export, storage fsck, future
+  source sync over location/channel.
+- Related: ADR-0018 defines the runtime storage service. ADR-0019 defines
+  Git-like source sync over `location` and `channel`. ADR-0021 defines
+  observer-relative timeline projection. ADR-0028 separates hash surfaces.
+  ADR-0029 defines CRC32C frame receipt checksums.
+
+## Context
+
+Kungfu now has two lower integrity layers:
+
+- content hashes use algorithm-tagged SHA-256 content identity;
+- frame receipt checksums use versioned non-keyed corruption detectors.
+
+Neither layer is enough to prove that a portable segment has not been
+reordered, had entries removed, or had manifest metadata rewritten. The next
+source-sync step needs a root commitment that binds the payload references,
+source coordinates, action envelope metadata, and frame receipt evidence into
+one verifiable segment.
+
+This must not imply a universal wall clock. ADR-0021 already decides that
+multi-machine ordering is observer-relative: facts and accepted ranges are
+verifiable, while concurrent cross-source ordering is a declared projection
+policy.
+
+## Decision
+
+The first sync-root implementation is manifest-scoped:
+
+```text
+schema = "kungfu.sync-root/v1"
+scope = "atlas.import.manifest"
+proof = "linear-chain-v1"
+algorithm = "sha256"
+```
+
+The root is a linear hash chain over the manifest entries in the existing
+manifest entry order:
+
+```text
+initial = "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+entry_hash[i] = sha256(canonical_json(entry_commitment[i]))
+root[i] = sha256(canonical_json({
+  "schema": "kungfu.sync-chain-link/v1",
+  "index": i,
+  "previous": root[i - 1],
+  "entry": entry_hash[i]
+}))
+```
+
+The entry commitment includes source coordinates, source time, schema version,
+payload hash and byte length, payload state, content type, and the action
+envelope when present. Because the action envelope includes journal receipt
+metadata, the sync root indirectly binds frame uid, carrier type, frame
+checksum metadata, and payload checksum metadata without treating CRC32C as a
+trust primitive.
+
+`storage fsck --scope atlas` recomputes the root from the manifest and fails if
+the `sync_root` object is missing, malformed, or mismatched. `storage export`
+reports the root for the exported segment. Range-limited exports compute a root
+for the exported entry subset, while the full import manifest keeps the root for
+the accepted import segment.
+
+## Observer-relative metadata
+
+The v1 root records only the deterministic local manifest entry ordering policy:
+
+```text
+ordering.policy = "manifest-entry-sort-v1"
+ordering.fields = ["kind", "source_id", "source_path"]
+```
+
+This is sufficient for the first Atlas source-adapter proof. Future
+multi-source sync must add projection policy metadata for observer-relative
+timeline replay:
+
+- `view_id`
+- `observer_location`
+- `source_priority`
+- `policy_version`
+- `accepted_ranges`
+- `tie_breaker`
+
+Those fields belong to the timeline/projection root or accepted-segment
+metadata, not to this narrow Atlas import manifest root.
+
+## Consequences
+
+- Export/import/fsck can verify that a local Atlas import segment still matches
+  its manifest commitment.
+- Missing root data, reordered entries, changed source metadata, changed
+  payload references, or changed action receipt metadata become fsck failures.
+- The implementation remains local and does not require wall-clock consensus,
+  remote transport, conflict resolution, compaction, deletion, signatures, or
+  authentication.
+- The first proof is not journal-native. A future journal trailer or page/root
+  migration can consume this commitment format without forcing this card to
+  change the frame header.
+
+## Alternatives considered
+
+- **Make frame CRC32C the trust proof.** Rejected. CRC32C is a corruption
+  detector; a writer that can rewrite bytes can rewrite a non-keyed checksum.
+- **Add a journal-native trailer now.** Deferred. Trailer layout is a format
+  migration and should be designed separately from the first manifest proof.
+- **Use a Merkle tree immediately.** Deferred. A Merkle tree is useful for
+  partial proofs, but the first dogfood slice needs a simple, deterministic
+  segment root that export/import/fsck can verify locally.
+- **Store a signed root.** Deferred. Signatures and MACs require key management,
+  identity, rotation, and trust policy. This ADR records tamper evidence against
+  uncoordinated mutation, not authenticity or non-repudiation.
+
+## Residual risk
+
+- SHA-256 root commitments are not identity or authorship proofs.
+- Range-limited export roots are segment roots, not authority-root changes.
+- Without remote transport and conflict policy, this remains a local proof
+  surface rather than full multi-machine sync.

--- a/framework/core/docs/adr/README.md
+++ b/framework/core/docs/adr/README.md
@@ -45,6 +45,7 @@ A record's **Status** says where it stands:
 | [0027](ADR-0027-python-yijinjing-public-core-types.md) | accepted | Python yijinjing schema exposes only core public runtime types |
 | [0028](ADR-0028-hash-taxonomy-and-integrity-algorithms.md) | accepted | hash taxonomy separates internal ids, frame checksums, and content hashes |
 | [0029](ADR-0029-frame-checksum-v2-crc32c.md) | accepted | frame checksum v2 uses CRC32C receipt metadata |
+| [0030](ADR-0030-manifest-scoped-sync-root-v1.md) | accepted | manifest-scoped sync root v1 |
 
 ## Reading by theme
 
@@ -107,7 +108,9 @@ A record's **Status** says where it stands:
   fast internal hashes, frame checksums, content hashes, and future trust roots
   are separate algorithm surfaces), and
   [0029](ADR-0029-frame-checksum-v2-crc32c.md) (the v2 frame receipt checksum
-  algorithm selection and fsck metadata rules).
+  algorithm selection and fsck metadata rules), and
+  [0030](ADR-0030-manifest-scoped-sync-root-v1.md) (the first manifest-scoped
+  sync root that binds payload/action/frame receipt evidence for export/fsck).
 - **Cross-cutting principle** — [0009](ADR-0009-load-bearing-self-bootstrap.md)
   (load-bearing self-bootstrap), which also names the general law that
   [`docs/architecture.md` § The build dogfoods the SDK](../../../../docs/architecture.md)

--- a/framework/core/src/python/kungfu/atlas/payloads.py
+++ b/framework/core/src/python/kungfu/atlas/payloads.py
@@ -11,6 +11,7 @@ from kungfu.action_envelope import (
     payload_hash,
 )
 from kungfu.content_hash import CONTENT_HASH_ALGORITHM_SHA256
+from kungfu.content_hash import compute_content_hash
 from kungfu.atlas import (
     ACTION_GOAL_SNAPSHOT,
     ACTION_MARKER_SNAPSHOT,
@@ -30,6 +31,13 @@ FRAME_CHECKSUM_ALGORITHMS_BY_VERSION = {
 }
 SUPPORTED_FRAME_CHECKSUM_ALGORITHMS = set(FRAME_CHECKSUM_ALGORITHMS_BY_VERSION.values())
 PAYLOAD_STATE_PRESENT = "present"
+SYNC_ROOT_SCHEMA = "kungfu.sync-root/v1"
+SYNC_ROOT_SCOPE_ATLAS_IMPORT_MANIFEST = "atlas.import.manifest"
+SYNC_ROOT_CHAIN_LINK_SCHEMA = "kungfu.sync-chain-link/v1"
+SYNC_ROOT_PROOF_LINEAR_CHAIN_V1 = "linear-chain-v1"
+SYNC_ROOT_ORDERING_POLICY_MANIFEST_ENTRY_SORT_V1 = "manifest-entry-sort-v1"
+SYNC_ROOT_INITIAL = f"{CONTENT_HASH_ALGORITHM_SHA256}:{'0' * 64}"
+SYNC_ROOT_ENTRY_ORDER_FIELDS = ["kind", "source_id", "source_path"]
 
 ACTION_SCHEMA_REFS = {
     "atlas.import.begin": {"id": "kungfu.atlas.ImportBegin", "version": 1},
@@ -186,6 +194,122 @@ def _matches_range(entry: dict[str, Any], range_filter: dict[str, Any] | None) -
     return True
 
 
+def _manifest_entry_sort_key(row: dict[str, Any]) -> tuple[str, str, str]:
+    return (
+        str(row.get("kind") or ""),
+        str(row.get("source_id") or ""),
+        str(row.get("source_path") or ""),
+    )
+
+
+def _sync_root_entry_commitment(entry: dict[str, Any]) -> dict[str, Any]:
+    fields = (
+        "kind",
+        "source_id",
+        "source_path",
+        "source_time",
+        "schema_version",
+        "content_type",
+        "payload_hash",
+        "byte_len",
+        "payload_state",
+        "action",
+    )
+    return {field: entry[field] for field in fields if field in entry}
+
+
+def compute_sync_root(entries: list[dict[str, Any]]) -> dict[str, Any]:
+    previous = SYNC_ROOT_INITIAL
+    for index, entry in enumerate(entries):
+        entry_hash = compute_content_hash(
+            canonical_json_bytes(_sync_root_entry_commitment(entry))
+        )
+        previous = compute_content_hash(
+            canonical_json_bytes(
+                {
+                    "schema": SYNC_ROOT_CHAIN_LINK_SCHEMA,
+                    "index": index,
+                    "previous": previous,
+                    "entry": entry_hash,
+                }
+            )
+        )
+    return {
+        "schema": SYNC_ROOT_SCHEMA,
+        "scope": SYNC_ROOT_SCOPE_ATLAS_IMPORT_MANIFEST,
+        "proof": SYNC_ROOT_PROOF_LINEAR_CHAIN_V1,
+        "algorithm": CONTENT_HASH_ALGORITHM_SHA256,
+        "value": previous,
+        "entry_count": len(entries),
+        "initial": SYNC_ROOT_INITIAL,
+        "ordering": {
+            "policy": SYNC_ROOT_ORDERING_POLICY_MANIFEST_ENTRY_SORT_V1,
+            "fields": list(SYNC_ROOT_ENTRY_ORDER_FIELDS),
+        },
+    }
+
+
+def _append_sync_root_error(
+    report: dict[str, Any],
+    code: str,
+    *,
+    field: str | None = None,
+    expected: Any = None,
+    actual: Any = None,
+) -> None:
+    report["ok"] = False
+    error = {"code": code}
+    if field is not None:
+        error["field"] = field
+    if expected is not None:
+        error["expected"] = expected
+    if actual is not None:
+        error["actual"] = actual
+    report["errors"].append(error)
+
+
+def _check_sync_root(
+    report: dict[str, Any], manifest: dict[str, Any], entries: list[dict[str, Any]]
+) -> None:
+    report["checked"]["sync_roots"] += 1
+    actual = manifest.get("sync_root")
+    if actual is None:
+        _append_sync_root_error(report, "sync_root_missing")
+        return
+    if not isinstance(actual, dict):
+        _append_sync_root_error(report, "sync_root_invalid", actual=actual)
+        return
+    expected = compute_sync_root(entries)
+    for field, expected_value in expected.items():
+        actual_value = actual.get(field)
+        if actual_value != expected_value:
+            _append_sync_root_error(
+                report,
+                "sync_root_mismatch",
+                field=field,
+                expected=expected_value,
+                actual=actual_value,
+            )
+
+
+def export_sync_root(
+    store_dir: str | Path,
+    range_filter: dict[str, Any] | None = None,
+    storage_source_id: str | None = None,
+) -> dict[str, Any]:
+    manifest = load_latest_manifest(store_dir)
+    if manifest is None:
+        raise FileNotFoundError(str(latest_manifest_path(store_dir)))
+    if storage_source_id and manifest.get("storage_source_id") != storage_source_id:
+        raise ValueError(f"source_not_imported: {storage_source_id}")
+    entries = [
+        entry
+        for entry in manifest.get("entries", [])
+        if isinstance(entry, dict) and _matches_range(entry, range_filter)
+    ]
+    return compute_sync_root(entries)
+
+
 def write_import_payloads(
     store_dir: str | Path,
     *,
@@ -224,6 +348,7 @@ def write_import_payloads(
             )
         entries.append(entry)
 
+    sorted_entries = sorted(entries, key=_manifest_entry_sort_key)
     manifest = {
         "schema": "kungfu.atlas-import/v1",
         "import_id": import_id,
@@ -235,14 +360,8 @@ def write_import_payloads(
         "range": _serialize_range(range_filter),
         "hash_algorithm": CONTENT_HASH_ALGORITHM_SHA256,
         "counts": counts,
-        "entries": sorted(
-            entries,
-            key=lambda row: (
-                str(row.get("kind") or ""),
-                str(row.get("source_id") or ""),
-                str(row.get("source_path") or ""),
-            ),
-        ),
+        "entries": sorted_entries,
+        "sync_root": compute_sync_root(sorted_entries),
     }
 
     manifest_path = import_manifest_path(store_dir, import_id)
@@ -581,6 +700,7 @@ def fsck_import(
             "goals": 0,
             "markers": 0,
             "actions": 0,
+            "sync_roots": 0,
         },
     }
     if manifest is None:
@@ -594,6 +714,8 @@ def fsck_import(
         report["ok"] = False
         report["errors"].append({"code": "manifest_entries_invalid"})
         return report
+    manifest_entries = [entry for entry in entries if isinstance(entry, dict)]
+    _check_sync_root(report, manifest, manifest_entries)
 
     seen: set[tuple[str, str]] = set()
     for entry in entries:
@@ -741,13 +863,7 @@ def export_records(
         row["source_head"] = manifest.get("repo_head")
         row["payload"] = payload
         records.append(row)
-    records.sort(
-        key=lambda row: (
-            str(row.get("kind") or ""),
-            str(row.get("source_id") or ""),
-            str(row.get("source_path") or ""),
-        )
-    )
+    records.sort(key=_manifest_entry_sort_key)
     return records
 
 

--- a/framework/core/src/python/kungfu/atlas/store.py
+++ b/framework/core/src/python/kungfu/atlas/store.py
@@ -178,7 +178,7 @@ class ImportStore:
                 },
             )
         )
-        payloads.write_import_payloads(
+        manifest = payloads.write_import_payloads(
             self.store_dir(),
             import_id=import_id,
             repo_root=repo_root,
@@ -203,6 +203,7 @@ class ImportStore:
             "repo_head": repo_head,
             "source_head": repo_head,
             "range": payloads._serialize_range(range_filter),
+            "sync_root": manifest.get("sync_root"),
             "missions": len(missions),
             "goals": len(goals),
             "markers": len(markers),
@@ -505,6 +506,7 @@ def status(runtime_dir):
         "repo_root": manifest.get("repo_root"),
         "repo_head": manifest.get("repo_head"),
         "source_head": manifest.get("source_head", manifest.get("repo_head")),
+        "sync_root": manifest.get("sync_root"),
         "payloads": len(manifest.get("entries", [])),
         "missions": len(projection.get("missions", {})) if projection else 0,
         "goals": len(projection.get("goals", {})) if projection else 0,
@@ -538,6 +540,11 @@ def export_jsonl(
         "scope": "atlas",
         "storage_source_id": storage_source_id,
         "range": payloads._serialize_range(range_filter),
+        "sync_root": payloads.export_sync_root(
+            store_dir(runtime_dir),
+            range_filter=range_filter,
+            storage_source_id=storage_source_id,
+        ),
         "format": "jsonl",
         "out": os.path.abspath(out_path),
         "records": len(records),

--- a/framework/core/tests/python/test_atlas_storage.py
+++ b/framework/core/tests/python/test_atlas_storage.py
@@ -211,7 +211,14 @@ def test_payload_manifest_fsck_export_and_verify(tmp_path):
         "goals": 1,
         "markers": 1,
         "actions": 3,
+        "sync_roots": 1,
     }
+    assert manifest["sync_root"] == payloads.compute_sync_root(manifest["entries"])
+    assert manifest["sync_root"]["schema"] == payloads.SYNC_ROOT_SCHEMA
+    assert (
+        manifest["sync_root"]["scope"] == payloads.SYNC_ROOT_SCOPE_ATLAS_IMPORT_MANIFEST
+    )
+    assert manifest["sync_root"]["value"].startswith("sha256:")
 
     records = payloads.export_records(store)
     assert len(records) == 3
@@ -384,6 +391,59 @@ def test_payload_fsck_reports_missing_payload(tmp_path):
 
     assert not report["ok"]
     assert any(error["code"] == "payload_missing" for error in report["errors"])
+
+
+def test_payload_fsck_rejects_missing_sync_root(tmp_path):
+    repo = tmp_path / "atlas"
+    store = tmp_path / "store"
+    _atlas_fixture(repo)
+    _, _, _, source_records, _ = importer.read_control_plane_with_sources(str(repo))
+    manifest = payloads.write_import_payloads(
+        store,
+        import_id="imp-test",
+        repo_root=str(repo),
+        repo_head="abc123",
+        source_records=source_records,
+        counts={"missions": 1, "goals": 1, "markers": 1},
+    )
+    del manifest["sync_root"]
+    payloads.latest_manifest_path(store).write_text(
+        json.dumps(manifest, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+
+    report = payloads.fsck_import(store)
+
+    assert not report["ok"]
+    assert any(error["code"] == "sync_root_missing" for error in report["errors"])
+
+
+def test_payload_fsck_rejects_sync_root_entry_mutation(tmp_path):
+    repo = tmp_path / "atlas"
+    store = tmp_path / "store"
+    _atlas_fixture(repo)
+    _, _, _, source_records, _ = importer.read_control_plane_with_sources(str(repo))
+    manifest = payloads.write_import_payloads(
+        store,
+        import_id="imp-test",
+        repo_root=str(repo),
+        repo_head="abc123",
+        source_records=source_records,
+        counts={"missions": 1, "goals": 1, "markers": 1},
+    )
+    manifest["entries"][0]["source_path"] = "tampered.json"
+    payloads.latest_manifest_path(store).write_text(
+        json.dumps(manifest, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+
+    report = payloads.fsck_import(store)
+
+    assert not report["ok"]
+    assert any(
+        error["code"] == "sync_root_mismatch" and error["field"] == "value"
+        for error in report["errors"]
+    )
 
 
 def test_source_range_builder_supports_relative_since():


### PR DESCRIPTION
## Summary
- add manifest-scoped kungfu.sync-root/v1 commitments for Atlas import manifests
- verify sync roots in storage fsck and expose roots from import/status/export metadata
- document ADR-0030 and storage-service semantics

## Verification
- ./kungfu-code fix
- ./kungfu-code build
- ./kungfu-code check
- PYTHONPATH=framework/core/build/Release:framework/core/src/python uv run --project framework/core pytest framework/core/tests/python/test_atlas_storage.py
- temp Atlas 3d import/fsck/export smoke plus deleted-sync_root failure smoke