### PR TITLE
feat(kfd): expose standard coverage in sdk

### DIFF
--- a/.buildchain/buildchain.toml
+++ b/.buildchain/buildchain.toml
@@ -40,5 +40,6 @@ kfd_standards = "developer/sdk/node_modules/@kungfu-tech/kfd/standards.json"
 kfd_1 = "declared"
 kfd_2 = "declared"
 kfd_3 = "declared"
+kfd_4 = "declared"
 platforms = ["macOS", "Linux", "Windows"]
 workflows = ["buildchain-validate.yml", "dco.yml"]

--- a/.buildchain/kfd/kfd-3-surfaces.json
+++ b/.buildchain/kfd/kfd-3-surfaces.json
@@ -49,11 +49,11 @@
       "buildchain"
     ],
     "packageVersions": {
-      "kfd": "1.0.0-alpha.17",
+      "kfd": "1.0.0-alpha.21",
       "libnode": "22.22.3-kf.3-alpha.16",
-      "buildchain": "2.10.7"
+      "buildchain": "2.10.8"
     },
-    "digest": "sha256:4267ac49182534d034aadcbdea6f809e0b402c236c28830f23932856029dc9a1"
+    "digest": "sha256:ff46f99bd15d4495f7890d04577ba91cd8bcb95605fa921313dcd272490182d4"
   },
   "surfaces": [
     {
@@ -498,7 +498,7 @@
     },
     {
       "id": "kungfu.kfd.query",
-      "name": "kungfu kfd query|check|witness|upstream|aggregate",
+      "name": "kungfu kfd status|schema|1|2|4|query|check|witness|upstream|aggregate",
       "kind": "cli",
       "participantProfile": "agent-or-developer",
       "state": "declared",
@@ -738,7 +738,7 @@
     },
     {
       "id": "kungfu.sdk.kfd.query",
-      "name": "kungfu sdk kfd query|check|witness|upstream|aggregate",
+      "name": "kungfu sdk kfd status|schema|1|2|4|query|check|witness|upstream|aggregate",
       "kind": "cli",
       "participantProfile": "agent-or-developer",
       "state": "declared",

--- a/artifact/package.json
+++ b/artifact/package.json
@@ -48,6 +48,6 @@
     "url": "https://github.com/kungfu-systems/kungfu.git"
   },
   "devDependencies": {
-    "@kungfu-tech/buildchain": "2.10.7"
+    "@kungfu-tech/buildchain": "2.10.8"
   }
 }

--- a/developer/sdk/README.md
+++ b/developer/sdk/README.md
@@ -65,17 +65,27 @@ bundle with the kungfu runtime under `Resources/kungfu`.
 
 ## KFD Capability Queries
 
-The SDK also carries Kungfu's Buildchain-facing KFD-3 registry projection, so an
-installed runtime can answer capability questions without asking users to
-install the `buildchain` executable separately:
+The SDK carries Kungfu's Buildchain-facing KFD facts, so an installed runtime can
+answer standard and capability questions without asking users to install the
+`buildchain` executable separately:
 
 ```sh
+kungfu kfd status --json
+kungfu kfd schema kfd-4 --json
+kungfu kfd 1 witness --json
+kungfu kfd 2 claims --json
+kungfu kfd 4 schema --json
 kungfu kfd query --json
 kungfu kfd check --json
 kungfu kfd witness --json
 kungfu kfd upstream --json
 kungfu kfd aggregate --json
 
+kungfu sdk kfd status --json
+kungfu sdk kfd schema kfd-4 --json
+kungfu sdk kfd 1 witness --json
+kungfu sdk kfd 2 claims --json
+kungfu sdk kfd 4 schema --json
 kungfu sdk kfd query --json
 kungfu sdk kfd check --json
 kungfu sdk kfd witness --json
@@ -85,10 +95,13 @@ kungfu sdk kfd aggregate --json
 
 `kungfu kfd ...` is the installed CLI bridge. It delegates to the SDK-distributed
 implementation and returns the same machine-readable capability facts as
-`kungfu sdk kfd ...`. `query` stays focused on Kungfu's own declared capability
-facts; `upstream` shows the SDK-packaged KFD aggregate for KFD, libnode, and
-Buildchain; `aggregate` joins both views for an agent that wants the final
-product plus upstream trust surface in one response.
+`kungfu sdk kfd ...`. `status` summarizes Kungfu's KFD-1 contract-world,
+KFD-2 release-claim, KFD-3 capability, and KFD-4 schema-only support. `query`
+stays focused on Kungfu's own declared KFD-3 capability facts; `upstream` shows
+the SDK-packaged KFD aggregate for Kungfu plus KFD, libnode, and Buildchain;
+`aggregate` joins both views for an agent that wants the final product plus
+upstream trust surface in one response. KFD-4 is intentionally reported as
+schema-only until Buildchain/KFD defines a release verification protocol for it.
 
 ## KFD-1 Contract Prototype
 

--- a/developer/sdk/kfd/kfd-3-surfaces.json
+++ b/developer/sdk/kfd/kfd-3-surfaces.json
@@ -49,11 +49,11 @@
       "buildchain"
     ],
     "packageVersions": {
-      "kfd": "1.0.0-alpha.17",
+      "kfd": "1.0.0-alpha.21",
       "libnode": "22.22.3-kf.3-alpha.16",
-      "buildchain": "2.10.7"
+      "buildchain": "2.10.8"
     },
-    "digest": "sha256:4267ac49182534d034aadcbdea6f809e0b402c236c28830f23932856029dc9a1"
+    "digest": "sha256:ff46f99bd15d4495f7890d04577ba91cd8bcb95605fa921313dcd272490182d4"
   },
   "surfaces": [
     {
@@ -498,7 +498,7 @@
     },
     {
       "id": "kungfu.kfd.query",
-      "name": "kungfu kfd query|check|witness|upstream|aggregate",
+      "name": "kungfu kfd status|schema|1|2|4|query|check|witness|upstream|aggregate",
       "kind": "cli",
       "participantProfile": "agent-or-developer",
       "state": "declared",
@@ -738,7 +738,7 @@
     },
     {
       "id": "kungfu.sdk.kfd.query",
-      "name": "kungfu sdk kfd query|check|witness|upstream|aggregate",
+      "name": "kungfu sdk kfd status|schema|1|2|4|query|check|witness|upstream|aggregate",
       "kind": "cli",
       "participantProfile": "agent-or-developer",
       "state": "declared",

--- a/developer/sdk/kfd/upstream-aggregate.json
+++ b/developer/sdk/kfd/upstream-aggregate.json
@@ -19,13 +19,14 @@
       "role": "standard-and-schema-provider",
       "package": {
         "name": "@kungfu-tech/kfd",
-        "version": "1.0.0-alpha.17"
+        "version": "1.0.0-alpha.21"
       },
       "repository": "kungfu-systems/kfd",
       "kfd": {
         "kfd1": "exported-witness",
         "kfd2": "exported-claim",
-        "kfd3": "exported-collaboration-interface"
+        "kfd3": "exported-collaboration-interface",
+        "kfd4": "schema-metadata"
       },
       "releaseAnchor": {
         "schemaVersion": 1,
@@ -33,36 +34,36 @@
         "line": "v1.0",
         "channel": "alpha",
         "npmPackage": "@kungfu-tech/kfd",
-        "npmVersion": "1.0.0-alpha.17",
+        "npmVersion": "1.0.0-alpha.21",
         "source": {
           "repository": "kungfu-systems/kfd",
           "branch": "alpha/v1/v1.0"
         },
         "rationale": "KFD uses an anchored/manual Buildchain mode: the public package version is an explicit release fact, while the outer KFD line remains v1.0."
       },
-      "kfd3SurfaceCount": 16,
+      "kfd3SurfaceCount": 18,
       "assets": [
         {
           "path": "kfd.release.json",
-          "sha256": "sha256:8ac38cf084ab11875d35ad6d374290c2fe13623ae754521b63a391d3a585f8a6",
+          "sha256": "sha256:bfb302c839b6cb45204d541b5af5b1c211568efb16fb3eebbb04dc65f7de83d2",
           "contract": "kfd-release-anchor"
         },
         {
           "path": "buildchain/kfd-1/contract-world.witness.json",
-          "sha256": "sha256:1f839c8e7c55a30e2115e0a25e6be769e584a37284d7787a25ada7cb2b58f1df"
+          "sha256": "sha256:542fe5b730f2e4782655d096ec04a5dd82a88d4fc9e8701ee235eb111a06dab6"
         },
         {
           "path": "buildchain/kfd-2/public-release-trust.claim.json",
-          "sha256": "sha256:cb4a3318e41c245d98006af69922cfd26362efd10bf3e68c2c27755d02fe2966"
+          "sha256": "sha256:3780b47472762b5ce9575250da73ee800af71dd194a9b0a3f61a063569311237"
         },
         {
           "path": "buildchain/kfd-3/collaboration-interface.json",
-          "sha256": "sha256:e32f2196399d37db202ccc656386bddc346871243c3db6782d26b5a88f831595",
+          "sha256": "sha256:fa41128be4ee57a4a40b76d4d7a063c01d7c2e5c53aec2b9c6db819c7a27b22b",
           "contract": "kfd-3-collaboration-interface"
         },
         {
           "path": "standards.json",
-          "sha256": "sha256:7cd61143eabec5b83c5ba37312d791935f2321d246f61bec790c4a6d5d4cf839",
+          "sha256": "sha256:4ee9e5fc732eef1b43c75a146125496e0dbd859ef5a11d0c637c41e9091c677f",
           "contract": "kfd-standards-metadata"
         }
       ]
@@ -78,7 +79,8 @@
       "kfd": {
         "kfd1": "release-anchor-facts",
         "kfd2": "release-passport-required",
-        "kfd3": "package-runtime-surface"
+        "kfd3": "package-runtime-surface",
+        "kfd4": "not-declared"
       },
       "releaseAnchor": {
         "schema": 1,
@@ -103,13 +105,14 @@
       "role": "release-passport-and-kfd-gate-provider",
       "package": {
         "name": "@kungfu-tech/buildchain",
-        "version": "2.10.7"
+        "version": "2.10.8"
       },
       "repository": "kungfu-systems/buildchain",
       "kfd": {
         "kfd1": "gate-provider",
         "kfd2": "claim-provider",
-        "kfd3": "surface-query-provider"
+        "kfd3": "surface-query-provider",
+        "kfd4": "schema-provider"
       },
       "publicExports": [
         "@kungfu-tech/buildchain/kfd-gate",
@@ -120,25 +123,61 @@
       "assets": [
         {
           "path": "site/kfd-claims.json",
-          "sha256": "sha256:39815c50902a335f730d725baf4cd5b0a51b17f6f02d4513491d42197723dd43",
+          "sha256": "sha256:a314e2b26474a273430c0b0a3743712ca4de5e47596bf4714360f83a46d1bfb7",
           "contract": "kungfu-buildchain-kfd-claim-registry"
         },
         {
           "path": "site/node-api-registry.json",
-          "sha256": "sha256:1d012a0a8f04a4c91abb0a6546103031584247fff028c4066e491ace8afab49d",
+          "sha256": "sha256:46c5938144888f76be429af2c10a16ead94c046c8c6f35965e4d8db647e3c08c",
           "contract": "kungfu-buildchain-node-api-registry"
         },
         {
           "path": "docs/kfd-support.md",
-          "sha256": "sha256:704efbf7be24d641d8b119737eb33b3e98fea8c55cf434f7f475160809f4e3a4"
+          "sha256": "sha256:d1fdec0890884340e4e8108c17b62866c08dc95771075e3e285532b5a7b0ee5a"
         },
         {
           "path": "kfd",
-          "sha256": "sha256:908a171399090cf3d2f43a1e01fa312a1a47861dfc9874d32f5e8a9d4ac53899"
+          "sha256": "sha256:e9170c1e56d2729cf530f953df9ade21963faa9a756ba5fbd0cdd03d8b781cb3"
         }
       ]
     }
   ],
+  "ownKfd": {
+    "kfd1": {
+      "status": "supported",
+      "mode": "contract-world",
+      "source": "framework/contract/kungfu-contracts.registry.json",
+      "sha256": "sha256:19c8d64633b14b805bebb7f7028ddfb69062564b939dd97cd22fe86b5e93422d",
+      "contractCount": 3,
+      "witnessCommand": "kungfu sdk contract witness --json",
+      "releasePassportInput": "--kfd-1-witness-json"
+    },
+    "kfd2": {
+      "status": "supported",
+      "mode": "release-claims",
+      "source": "framework/release/kfd-2/kungfu-release-claims.registry.json",
+      "sha256": "sha256:ebf949f99ed5f0d01e9ba22fbc340848144f12f8e126dba586f16bbc786f5952",
+      "claimCount": 3,
+      "claimsCommand": "kungfu sdk kfd 2 claims --json",
+      "releasePassportInput": "--kfd-2-claim-json"
+    },
+    "kfd3": {
+      "status": "supported",
+      "mode": "strict-buildchain-managed-registry",
+      "source": ".buildchain/kfd/kfd-3-surfaces.json",
+      "queryCommand": "kungfu sdk kfd query --json"
+    },
+    "kfd4": {
+      "status": "schema-only",
+      "mode": "schema-only",
+      "source": "@kungfu-tech/kfd/standards.json",
+      "schemaCount": 2,
+      "schemaCommand": "kungfu sdk kfd 4 schema --json",
+      "residualRisk": [
+        "Buildchain 2.10.8 exposes KFD-4 as schema-only; no release verification protocol is claimed."
+      ]
+    }
+  },
   "summary": {
     "upstreamCount": 3,
     "kfdAwareUpstreams": [
@@ -147,9 +186,9 @@
       "buildchain"
     ],
     "packageVersions": {
-      "kfd": "1.0.0-alpha.17",
+      "kfd": "1.0.0-alpha.21",
       "libnode": "22.22.3-kf.3-alpha.16",
-      "buildchain": "2.10.7"
+      "buildchain": "2.10.8"
     }
   }
 }

--- a/developer/sdk/package.json
+++ b/developer/sdk/package.json
@@ -26,10 +26,10 @@
     "build": "node --check src/sdk.js && node --test tests/*.test.mjs"
   },
   "dependencies": {
-    "@kungfu-tech/buildchain": "2.10.7",
+    "@kungfu-tech/buildchain": "2.10.8",
     "@kungfu-tech/core": "workspace:*",
     "@kungfu-tech/gui": "workspace:*",
-    "@kungfu-tech/kfd": "1.0.0-alpha.17",
+    "@kungfu-tech/kfd": "1.0.0-alpha.21",
     "@kungfu-tech/tui": "workspace:*",
     "ajv": "^8.20.0",
     "esbuild": "^0.28.1"

--- a/developer/sdk/src/sdk.js
+++ b/developer/sdk/src/sdk.js
@@ -15,7 +15,14 @@ import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { BUILDCHAIN_KFD3_SURFACE_REGISTRY_PATH } from '@kungfu-tech/buildchain/buildchain-layout';
-import { kfd3 } from '@kungfu-tech/buildchain/kfd';
+import {
+  collectKfdStatus,
+  kfd1,
+  kfd2,
+  kfd3,
+  kfd4,
+  schemas as kfdSchemas,
+} from '@kungfu-tech/buildchain/kfd';
 import {
   BUILDCHAIN_JSON_FORMATTING_POLICY,
   createKfd1ReleaseGateEvidence,
@@ -72,6 +79,11 @@ function usage(code) {
       '       kungfu sdk contract witness [--json]',
       '       kungfu sdk contract audit [--json]',
       '       kungfu sdk contract add <surface> [--source <path>] [--json]',
+      '       kungfu sdk kfd status [--json]',
+      '       kungfu sdk kfd schema <kfd-1|kfd-2|kfd-3|kfd-4> [--schema <name>] [--json]',
+      '       kungfu sdk kfd 1 status|schema|witness [--json]',
+      '       kungfu sdk kfd 2 status|schema|claims|trust-claims|trust-assessment [--json]',
+      '       kungfu sdk kfd 4 status|schema [--json]',
       '       kungfu sdk kfd query|check|witness|upstream|aggregate [--json]',
       '       kungfu sdk kfx build | clean',
       '       kungfu sdk product gui dev|build|pack|dist [--dir <app-dir>] [--dry-run]',
@@ -115,10 +127,12 @@ function usage(code) {
       'one local contract-world witness for config/kfx/skill without duplicating',
       'standard keys or JSON formatting rules.',
       '',
-      'kfd query/check/witness exposes Kungfu KFD-3 capability facts; upstream',
-      'and aggregate expose the SDK-packaged KFD view of Kungfu plus upstream',
-      'KFD/libnode/Buildchain package facts, without a separate buildchain',
-      'executable installation.',
+      'kfd status/schema and kfd 1/2/4 expose Kungfu KFD-1 contract-world,',
+      'KFD-2 release-claim, KFD-3 capability, and KFD-4 schema-only facts.',
+      'query/check/witness keep the existing KFD-3 capability query behavior;',
+      'upstream and aggregate expose the SDK-packaged KFD view of Kungfu plus',
+      'upstream KFD/libnode/Buildchain package facts, without a separate',
+      'buildchain executable installation.',
       '',
     ].join('\n'),
   );
@@ -145,7 +159,7 @@ function errorMessage(error) {
 
 /**
  * Parsed CLI options shared by SDK verbs.
- * @typedef {{ workspace: boolean, name: string, source: string, dir: string, check: boolean, write: boolean, json: boolean, dryRun: boolean }} CliOptions
+ * @typedef {{ workspace: boolean, name: string, source: string, dir: string, schema: string, check: boolean, write: boolean, json: boolean, dryRun: boolean }} CliOptions
  */
 
 /**
@@ -160,6 +174,7 @@ function parseArgs(argv) {
     name: '',
     source: '',
     dir: '',
+    schema: '',
     check: false,
     write: false,
     json: false,
@@ -177,6 +192,9 @@ function parseArgs(argv) {
     } else if (arg === '--dir') {
       i += 1;
       options.dir = argv[i] || '';
+    } else if (arg === '--schema') {
+      i += 1;
+      options.schema = argv[i] || '';
     } else if (arg === '--check') {
       options.check = true;
     } else if (arg === '--write') {
@@ -777,6 +795,7 @@ function kfxProductEnv(cwd) {
           name: '',
           source: '',
           dir: '',
+          schema: '',
           check: false,
           write: false,
           json: false,
@@ -1702,6 +1721,7 @@ function contractPolicySurface(entry) {
     name: '',
     source: '',
     dir: '',
+    schema: '',
     check: false,
     write: false,
     json: true,
@@ -2654,6 +2674,249 @@ function readKfdUpstreamAggregate() {
 }
 
 /**
+ * @param {string} packageName
+ * @returns {string}
+ */
+function packageVersion(packageName) {
+  try {
+    return String(require(`${packageName}/package.json`).version || '');
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * @param {string} value
+ * @returns {string}
+ */
+function normalizeKfdStandard(value) {
+  const raw = String(value || '')
+    .trim()
+    .toLowerCase();
+  const match = raw.match(/^(?:kfd[-\s]?)?([1-9][0-9]*)$/);
+  if (!match) fail(`unsupported KFD standard: ${value || '<empty>'}`);
+  return `kfd-${match[1]}`;
+}
+
+/**
+ * @param {string} standard
+ * @param {string} [schemaName]
+ * @returns {Record<string, any>}
+ */
+function readKfdSchemaDocument(standard, schemaName = '') {
+  return kfdSchemas.read({
+    standard: normalizeKfdStandard(standard),
+    schema: schemaName,
+  });
+}
+
+/**
+ * @returns {Record<string, any>}
+ */
+function kfdSchemaSummary() {
+  const schemaList = kfdSchemas.list();
+  /** @type {Record<string, Array<{ name: string, schemaId: string, schemaPath: string }>>} */
+  const byStandard = {};
+  for (const entry of schemaList.schemas || []) {
+    byStandard[entry.standard] ||= [];
+    byStandard[entry.standard].push({
+      name: entry.name,
+      schemaId: entry.schemaId,
+      schemaPath: entry.schemaPath,
+    });
+  }
+  return {
+    package: schemaList.package,
+    standards: byStandard,
+  };
+}
+
+/**
+ * @param {Record<string, any>} registry
+ * @param {string} registryPath
+ * @param {Record<string, any>} aggregate
+ * @returns {Record<string, any>}
+ */
+function buildKfdStandardsStatus(registry, registryPath, aggregate) {
+  const ownKfd = aggregate.ownKfd || {};
+  const schemas = kfdSchemaSummary();
+  return {
+    schemaVersion: 1,
+    contract: 'kungfu-sdk-kfd-standards-status',
+    product: registry.product || { id: 'kungfu', name: 'Kungfu' },
+    packages: {
+      kfd: packageVersion('@kungfu-tech/kfd'),
+      buildchain: packageVersion('@kungfu-tech/buildchain'),
+    },
+    source: {
+      registry: {
+        path: path.relative(process.cwd(), registryPath) || '.',
+        sha256: sha256File(registryPath),
+      },
+      upstreamAggregate: {
+        path:
+          path.relative(process.cwd(), resolveKfdUpstreamAggregate()) || '.',
+        sha256: sha256File(resolveKfdUpstreamAggregate()),
+      },
+    },
+    standards: {
+      'kfd-1': {
+        status: 'supported',
+        mode: 'contract-world',
+        commands: [
+          'kungfu sdk contract witness --json',
+          'kungfu sdk contract audit --json',
+          'kungfu sdk kfd 1 witness --json',
+        ],
+        schemaCount: schemas.standards['kfd-1']?.length || 0,
+        source: ownKfd.kfd1 || {
+          note: 'KFD-1 facts are provided by the SDK contract registry and packaged KFD-3 surface registry.',
+        },
+      },
+      'kfd-2': {
+        status: 'supported',
+        mode: 'release-claims',
+        commands: [
+          'kungfu sdk kfd 2 claims --json',
+          'kungfu sdk kfd 2 trust-claims --json',
+          'kungfu sdk kfd 2 trust-assessment --json',
+        ],
+        schemaCount: schemas.standards['kfd-2']?.length || 0,
+        source: ownKfd.kfd2 || {
+          note: 'KFD-2 release trust is finalized by the Buildchain release passport.',
+        },
+      },
+      'kfd-3': {
+        status: 'supported',
+        mode: registry.buildchain?.kfd3?.mode || 'declared-registry',
+        commands: [
+          'kungfu sdk kfd query --json',
+          'kungfu sdk kfd check --json',
+          'kungfu sdk kfd witness --json',
+        ],
+        schemaCount: schemas.standards['kfd-3']?.length || 0,
+        surfaceCount: Array.isArray(registry.surfaces)
+          ? registry.surfaces.length
+          : 0,
+        source: {
+          registryPath:
+            registry.registryPath || BUILDCHAIN_KFD3_SURFACE_REGISTRY_PATH,
+          sourceOfTruth: registry.policy?.sourceOfTruth || '',
+        },
+      },
+      'kfd-4': {
+        status: kfd4.status || 'schema-only',
+        mode: 'schema-only',
+        commands: [
+          'kungfu sdk kfd 4 schema --json',
+          'kungfu sdk kfd schema kfd-4 --json',
+        ],
+        schemaCount: schemas.standards['kfd-4']?.length || 0,
+        source: ownKfd.kfd4 || {
+          note: 'Buildchain 2.10.8 exposes KFD-4 as schema-only; Kungfu declares schema visibility, not a verification pass.',
+        },
+      },
+    },
+    support: {
+      'kfd-1': ['status', 'schema', 'witness'],
+      'kfd-2': [
+        'status',
+        'schema',
+        'claims',
+        'trust-claims',
+        'trust-assessment',
+      ],
+      'kfd-3': ['query', 'check', 'witness', 'aggregate'],
+      'kfd-4': ['status', 'schema'],
+    },
+    buildchainStatus: collectKfdStatus({ cwd: process.cwd() }),
+  };
+}
+
+/**
+ * @param {Record<string, any>} registry
+ * @param {string} registryPath
+ * @param {Record<string, any>} aggregate
+ * @returns {Record<string, any>}
+ */
+function kfd1SupportWitness(registry, registryPath, aggregate) {
+  return {
+    schemaVersion: 1,
+    contract: 'kungfu-sdk-kfd-1-support-witness',
+    standard: 'kfd-1',
+    witnessKind: 'installed-sdk-contract-world-summary',
+    metadata: kfd1.resolveMetadata(),
+    product: registry.product || { id: 'kungfu', name: 'Kungfu' },
+    sourceRegistry: {
+      path: path.relative(process.cwd(), registryPath) || '.',
+      sha256: sha256File(registryPath),
+    },
+    contractWorld: aggregate.ownKfd?.kfd1 || null,
+    surfaces: (registry.surfaces || []).map(
+      (/** @type {Record<string, any>} */ surface) => ({
+        id: surface.id,
+        kind: surface.kind,
+        sourcePath: surface.sourcePath,
+        artifactPath: surface.artifactPath || surface.evidencePath,
+        digest: `sha256:${sha256KfdJson(surface)}`,
+      }),
+    ),
+    releaseGate: {
+      passportInput: '--kfd-1-witness-json',
+      finalTrust: 'query-buildchain-release-passport',
+    },
+  };
+}
+
+/**
+ * @param {Record<string, any>} aggregate
+ * @returns {Record<string, any>}
+ */
+function kfd2ClaimSummary(aggregate) {
+  return {
+    schemaVersion: 1,
+    contract: 'kungfu-sdk-kfd-2-release-claims',
+    standard: 'kfd-2',
+    metadata: kfd2.resolveMetadata(),
+    product: aggregate.product || {
+      id: 'kungfu',
+      name: 'Kungfu',
+      repository: 'kungfu-systems/kungfu',
+    },
+    source: aggregate.ownKfd?.kfd2 || null,
+    releaseGate: {
+      passportInput: '--kfd-2-claim-json',
+      finalTrust: 'query-buildchain-release-passport',
+    },
+    residualRisk: [
+      'Installed SDK claim summaries are packaged facts; release trust depends on the Buildchain release passport for the exact artifact.',
+    ],
+  };
+}
+
+/**
+ * @param {Record<string, any>} document
+ * @param {string} source
+ * @returns {Record<string, any>}
+ */
+function kfd2ValidationDocument(document, source) {
+  const validation =
+    document?.contract === 'kfd-2-trust-claims'
+      ? kfd2.validateTrustClaims(document)
+      : kfd2.validateTrustAssessment(document);
+  return {
+    schemaVersion: 1,
+    contract:
+      document?.contract === 'kfd-2-trust-claims'
+        ? 'kungfu-sdk-kfd-2-trust-claims'
+        : 'kungfu-sdk-kfd-2-trust-assessment',
+    source,
+    document,
+    validation,
+  };
+}
+
+/**
  * @param {Record<string, any>} registry
  * @param {string} registryPath
  * @param {string} [warning]
@@ -2700,6 +2963,7 @@ function registryCapabilityQuery(registry, registryPath, warning = '') {
       kfd1: 'registry-facts',
       kfd2: 'release-passport-required',
       kfd3: 'declared',
+      kfd4: 'schema-only',
     },
   };
 }
@@ -2763,17 +3027,148 @@ async function kfdAggregate(options) {
       kfd1: 'registry-and-upstream-facts',
       kfd2: 'release-passport-required',
       kfd3: 'declared-and-aggregated',
+      kfd4: 'schema-only',
     },
   };
 }
 
 /**
  * @param {string | undefined} command
+ * @param {string[]} args
  * @param {CliOptions} options
  * @returns {Promise<void>}
  */
-async function kfd(command, options) {
+async function kfd(command, args, options) {
   const { path: registryPath, registry } = readKfd3Registry();
+  if (command === 'status') {
+    const { aggregate } = readKfdUpstreamAggregate();
+    const status = buildKfdStandardsStatus(registry, registryPath, aggregate);
+    if (options.json)
+      process.stdout.write(`${JSON.stringify(status, null, 2)}\n`);
+    else
+      process.stdout.write(
+        `Kungfu KFD: kfd-1=${status.standards['kfd-1'].status}, kfd-2=${status.standards['kfd-2'].status}, kfd-3=${status.standards['kfd-3'].status}, kfd-4=${status.standards['kfd-4'].status}\n`,
+      );
+    return;
+  }
+  if (command === 'schema') {
+    const standard = args[0] || '';
+    if (!standard) fail('kfd schema requires <kfd-1|kfd-2|kfd-3|kfd-4>');
+    const schema = readKfdSchemaDocument(standard, options.schema || args[1]);
+    if (options.json)
+      process.stdout.write(`${JSON.stringify(schema, null, 2)}\n`);
+    else process.stdout.write(`${JSON.stringify(schema.schema, null, 2)}\n`);
+    return;
+  }
+  if (['1', 'kfd-1'].includes(String(command || '').toLowerCase())) {
+    const action = args[0] || 'status';
+    if (action === 'status') {
+      const { aggregate } = readKfdUpstreamAggregate();
+      const status = buildKfdStandardsStatus(registry, registryPath, aggregate)
+        .standards['kfd-1'];
+      if (options.json)
+        process.stdout.write(`${JSON.stringify(status, null, 2)}\n`);
+      else process.stdout.write(`Kungfu KFD-1: ${status.status}\n`);
+      return;
+    }
+    if (action === 'schema') {
+      const schema = readKfdSchemaDocument('kfd-1', options.schema || args[1]);
+      if (options.json)
+        process.stdout.write(`${JSON.stringify(schema, null, 2)}\n`);
+      else process.stdout.write(`${JSON.stringify(schema.schema, null, 2)}\n`);
+      return;
+    }
+    if (action === 'witness') {
+      const { aggregate } = readKfdUpstreamAggregate();
+      const witness = kfd1SupportWitness(registry, registryPath, aggregate);
+      if (options.json)
+        process.stdout.write(`${JSON.stringify(witness, null, 2)}\n`);
+      else
+        process.stdout.write(
+          `Kungfu KFD-1 witness: ${witness.surfaces.length} surface(s)\n`,
+        );
+      return;
+    }
+    fail('unknown kfd 1 command (supported: status, schema, witness)');
+  }
+  if (['2', 'kfd-2'].includes(String(command || '').toLowerCase())) {
+    const action = args[0] || 'status';
+    if (action === 'status') {
+      const { aggregate } = readKfdUpstreamAggregate();
+      const status = buildKfdStandardsStatus(registry, registryPath, aggregate)
+        .standards['kfd-2'];
+      if (options.json)
+        process.stdout.write(`${JSON.stringify(status, null, 2)}\n`);
+      else process.stdout.write(`Kungfu KFD-2: ${status.status}\n`);
+      return;
+    }
+    if (action === 'schema') {
+      const schema = readKfdSchemaDocument('kfd-2', options.schema || args[1]);
+      if (options.json)
+        process.stdout.write(`${JSON.stringify(schema, null, 2)}\n`);
+      else process.stdout.write(`${JSON.stringify(schema.schema, null, 2)}\n`);
+      return;
+    }
+    if (action === 'claims') {
+      const { aggregate } = readKfdUpstreamAggregate();
+      const claims = kfd2ClaimSummary(aggregate);
+      if (options.json)
+        process.stdout.write(`${JSON.stringify(claims, null, 2)}\n`);
+      else process.stdout.write('Kungfu KFD-2 claims: packaged\n');
+      return;
+    }
+    if (action === 'trust-claims') {
+      const result = kfd2ValidationDocument(
+        kfd2.readFoundationTrustClaims(),
+        '@kungfu-tech/kfd foundation trust claims',
+      );
+      if (options.json)
+        process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+      else
+        process.stdout.write(
+          `Kungfu KFD-2 trust-claims: ${result.validation.ok ? 'ok' : 'failed'}\n`,
+        );
+      if (!result.validation.ok) process.exitCode = 1;
+      return;
+    }
+    if (action === 'trust-assessment') {
+      const result = kfd2ValidationDocument(
+        kfd2.readFoundationTrustAssessment(),
+        '@kungfu-tech/kfd foundation trust assessment',
+      );
+      if (options.json)
+        process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+      else
+        process.stdout.write(
+          `Kungfu KFD-2 trust-assessment: ${result.validation.ok ? 'ok' : 'failed'}\n`,
+        );
+      if (!result.validation.ok) process.exitCode = 1;
+      return;
+    }
+    fail(
+      'unknown kfd 2 command (supported: status, schema, claims, trust-claims, trust-assessment)',
+    );
+  }
+  if (['4', 'kfd-4'].includes(String(command || '').toLowerCase())) {
+    const action = args[0] || 'status';
+    if (action === 'status') {
+      const { aggregate } = readKfdUpstreamAggregate();
+      const status = buildKfdStandardsStatus(registry, registryPath, aggregate)
+        .standards['kfd-4'];
+      if (options.json)
+        process.stdout.write(`${JSON.stringify(status, null, 2)}\n`);
+      else process.stdout.write(`Kungfu KFD-4: ${status.status}\n`);
+      return;
+    }
+    if (action === 'schema') {
+      const schema = readKfdSchemaDocument('kfd-4', options.schema || args[1]);
+      if (options.json)
+        process.stdout.write(`${JSON.stringify(schema, null, 2)}\n`);
+      else process.stdout.write(`${JSON.stringify(schema.schema, null, 2)}\n`);
+      return;
+    }
+    fail('unknown kfd 4 command (supported: status, schema)');
+  }
   if (command === 'query') {
     const query = await kfdQuery(options);
     if (options.json)
@@ -2814,6 +3209,8 @@ async function kfd(command, options) {
         kfd: query.kfd || {},
         warning: query.warning || '',
       },
+      standards: buildKfdStandardsStatus(registry, registryPath, aggregate)
+        .standards,
     };
     if (options.json)
       process.stdout.write(`${JSON.stringify(output, null, 2)}\n`);
@@ -2868,12 +3265,13 @@ async function kfd(command, options) {
     return;
   }
   fail(
-    'unknown kfd command (supported: query, check, witness, upstream, aggregate)',
+    'unknown kfd command (supported: status, schema, 1, 2, 4, query, check, witness, upstream, aggregate)',
   );
 }
 
 const { positional, options } = parseArgs(process.argv.slice(2));
-const [command, kind, directory] = positional;
+const [command, kind, ...rest] = positional;
+const directory = rest[0];
 
 if (!command) usage(1);
 if (command === 'create') {
@@ -2888,7 +3286,7 @@ if (command === 'create') {
 } else if (command === 'product') {
   await product(kind, directory, options);
 } else if (command === 'kfd') {
-  await kfd(kind, options);
+  await kfd(kind, rest, options);
 } else if (command === 'contract') {
   if (kind === 'adopt') contractAdopt(directory, options);
   else if (kind === 'render') contractRender(directory, options);

--- a/developer/sdk/tests/contract-cli.test.mjs
+++ b/developer/sdk/tests/contract-cli.test.mjs
@@ -284,6 +284,40 @@ test('kfd check verifies the packaged KFD-3 registry projection', () => {
   );
   assert.equal(data.upstreamAggregate.upstreamCount, 3);
   assert.equal(data.query.kfd.kfd3, 'declared');
+  assert.equal(data.query.kfd.kfd4, 'schema-only');
+  assert.equal(data.standards['kfd-1'].status, 'supported');
+  assert.equal(data.standards['kfd-2'].status, 'supported');
+  assert.equal(data.standards['kfd-4'].status, 'schema-only');
+});
+
+test('kfd status exposes KFD-1/2/3/4 support facts', () => {
+  const data = runJson(['kfd', 'status', '--json']);
+  assert.equal(data.contract, 'kungfu-sdk-kfd-standards-status');
+  assert.equal(data.packages.kfd, kfdPackage.version);
+  assert.equal(data.packages.buildchain, buildchainPackage.version);
+  assert.equal(data.standards['kfd-1'].status, 'supported');
+  assert.equal(data.standards['kfd-2'].mode, 'release-claims');
+  assert.equal(data.standards['kfd-3'].status, 'supported');
+  assert.equal(data.standards['kfd-4'].status, 'schema-only');
+  assert.ok(data.standards['kfd-4'].schemaCount >= 1);
+});
+
+test('kfd standard commands expose KFD-1, KFD-2, and KFD-4 facts', () => {
+  const kfd1 = runJson(['kfd', '1', 'witness', '--json']);
+  assert.equal(kfd1.contract, 'kungfu-sdk-kfd-1-support-witness');
+  assert.equal(kfd1.standard, 'kfd-1');
+  assert.ok(kfd1.surfaces.length >= 1);
+
+  const kfd2 = runJson(['kfd', '2', 'claims', '--json']);
+  assert.equal(kfd2.contract, 'kungfu-sdk-kfd-2-release-claims');
+  assert.equal(kfd2.standard, 'kfd-2');
+  assert.equal(kfd2.source.claimCount, 3);
+  assert.equal(kfd2.releaseGate.passportInput, '--kfd-2-claim-json');
+
+  const kfd4 = runJson(['kfd', '4', 'schema', '--json']);
+  assert.equal(kfd4.contract, 'kungfu-buildchain-kfd-schema');
+  assert.equal(kfd4.standard, 'kfd-4');
+  assert.equal(typeof kfd4.schema, 'object');
 });
 
 test('kfd witness emits an installed SDK KFD-3 witness', () => {
@@ -309,6 +343,9 @@ test('kfd upstream exposes aggregated upstream KFD package facts', () => {
         row.id === 'libnode' && row.package.version === '22.22.3-kf.3-alpha.16',
     ),
   );
+  assert.equal(data.ownKfd.kfd1.status, 'supported');
+  assert.equal(data.ownKfd.kfd2.claimCount, 3);
+  assert.equal(data.ownKfd.kfd4.status, 'schema-only');
 });
 
 test('kfd aggregate joins own KFD-3 query facts with upstream KFD facts', () => {
@@ -317,6 +354,7 @@ test('kfd aggregate joins own KFD-3 query facts with upstream KFD facts', () => 
   assert.equal(data.own.surfaceCount >= 1, true);
   assert.equal(data.upstream.summary.upstreamCount, 3);
   assert.equal(data.kfd.kfd3, 'declared-and-aggregated');
+  assert.equal(data.kfd.kfd4, 'schema-only');
   assert.match(data.source.upstreamAggregate.sha256, /^sha256:[0-9a-f]{64}$/);
 });
 

--- a/framework/contract/kungfu-agent-first-canonical-policy.json
+++ b/framework/contract/kungfu-agent-first-canonical-policy.json
@@ -6,7 +6,7 @@
     "kfd": {
       "package": {
         "name": "@kungfu-tech/kfd",
-        "version": "1.0.0-alpha.17",
+        "version": "1.0.0-alpha.21",
         "repository": "git+https://github.com/kungfu-systems/kfd.git"
       },
       "standard": {
@@ -31,7 +31,7 @@
     "buildchain": {
       "package": {
         "name": "@kungfu-tech/buildchain",
-        "version": "2.10.7"
+        "version": "2.10.8"
       },
       "formatting": {
         "name": "buildchain-release-evidence-json-v1",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "1.9.4",
-    "@kungfu-tech/buildchain": "2.10.7",
+    "@kungfu-tech/buildchain": "2.10.8",
     "@types/fs-extra": "^11.0.4",
     "@types/node": "^22.0.0",
     "@types/npmlog": "^7.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@kungfu-tech/buildchain>@kungfu-tech/kfd': 1.0.0-alpha.17
+  '@kungfu-tech/buildchain>@kungfu-tech/kfd': 1.0.0-alpha.21
   node-gyp: ^13.0.0
   cosmiconfig>js-yaml: 4.3.0
   lerna>js-yaml: 4.3.0
@@ -33,8 +33,8 @@ importers:
         specifier: 1.9.4
         version: 1.9.4
       '@kungfu-tech/buildchain':
-        specifier: 2.10.7
-        version: 2.10.7
+        specifier: 2.10.8
+        version: 2.10.8
       '@types/fs-extra':
         specifier: ^11.0.4
         version: 11.0.4
@@ -97,14 +97,14 @@ importers:
         version: link:../framework/tui
     devDependencies:
       '@kungfu-tech/buildchain':
-        specifier: 2.10.7
-        version: 2.10.7
+        specifier: 2.10.8
+        version: 2.10.8
 
   developer/sdk:
     dependencies:
       '@kungfu-tech/buildchain':
-        specifier: 2.10.7
-        version: 2.10.7
+        specifier: 2.10.8
+        version: 2.10.8
       '@kungfu-tech/core':
         specifier: workspace:*
         version: link:../../framework/core
@@ -112,8 +112,8 @@ importers:
         specifier: workspace:*
         version: link:../../framework/gui
       '@kungfu-tech/kfd':
-        specifier: 1.0.0-alpha.17
-        version: 1.0.0-alpha.17
+        specifier: 1.0.0-alpha.21
+        version: 1.0.0-alpha.21
       '@kungfu-tech/tui':
         specifier: workspace:*
         version: link:../../framework/tui
@@ -1283,13 +1283,13 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@kungfu-tech/buildchain@2.10.7':
-    resolution: {integrity: sha512-7cLW6kaTaVm9dneZiSMiVT0fl066mZqfZ2XxxAw40CO4HUNPZbO2M56Ei2Urtj2FH4aclfg2d+LjKnlnaqCitg==}
+  '@kungfu-tech/buildchain@2.10.8':
+    resolution: {integrity: sha512-0fPYGJDDCBUJGtxTYHERncPFJCG/DFn8ePJ2bZmgzzqAyKPJ8BwvEXSdioXJ1lmi6MuCFQbnYI7588b72By1xw==}
     engines: {node: '>=22.14.0'}
     hasBin: true
 
-  '@kungfu-tech/kfd@1.0.0-alpha.17':
-    resolution: {integrity: sha512-/jy1vbhEogvdRyxOauhIGlIMo4dfM356t2RxtlX7ChFBQaT8admCEZDxaherMVF7J6IKTOPXZXPC/jyBWUuicQ==}
+  '@kungfu-tech/kfd@1.0.0-alpha.21':
+    resolution: {integrity: sha512-lsr3aJ93pUaO9gxnGBsrTJkTkvpIHPHp9Rxug7WvdS4Zkte3AdFvyCl1DgwQN+/38FAXf8fBozyGkHxxXaN7Dg==}
 
   '@kungfu-tech/libnode-darwin-arm64@22.22.3-kf.3-alpha.16':
     resolution: {integrity: sha512-arC7Vm85nBSRS4Vj5L5RL4XXb5c4xrLmldcf+zA0Qs0d01GW0ZHecthZTK/vf/syFtb4u1CFoHBviOwT3YFazQ==}
@@ -5331,12 +5331,12 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@kungfu-tech/buildchain@2.10.7':
+  '@kungfu-tech/buildchain@2.10.8':
     dependencies:
-      '@kungfu-tech/kfd': 1.0.0-alpha.17
+      '@kungfu-tech/kfd': 1.0.0-alpha.21
       smol-toml: 1.7.0
 
-  '@kungfu-tech/kfd@1.0.0-alpha.17': {}
+  '@kungfu-tech/kfd@1.0.0-alpha.21': {}
 
   '@kungfu-tech/libnode-darwin-arm64@22.22.3-kf.3-alpha.16':
     optional: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -25,8 +25,8 @@ allowBuilds:
 minimumReleaseAge: 0
 overrides:
   # Keep Buildchain's KFD gate metadata aligned with the SDK-distributed KFD
-  # package while Buildchain 2.10.x still declares the previous alpha.
-  '@kungfu-tech/buildchain>@kungfu-tech/kfd': 1.0.0-alpha.17
+  # package so KFD-4 schema metadata is available to downstream Kungfu CLI users.
+  '@kungfu-tech/buildchain>@kungfu-tech/kfd': 1.0.0-alpha.21
   # node-gyp 9.x cannot detect Visual Studio 2026; 13.x adds VS2026 support, which
   # the Windows build needs to match the prebuilt (MSVC 19.5) conan dependencies.
   node-gyp: ^13.0.0

--- a/scripts/buildchain-kfd-evidence.mjs
+++ b/scripts/buildchain-kfd-evidence.mjs
@@ -79,6 +79,19 @@ const AGENT_COMMANDS_PATH = path.join(
   'commands.json',
 );
 const SDK_CLI_PATH = path.join(ROOT, 'developer', 'sdk', 'src', 'sdk.js');
+const CONTRACT_REGISTRY_PATH = path.join(
+  ROOT,
+  'framework',
+  'contract',
+  'kungfu-contracts.registry.json',
+);
+const KFD2_REGISTRY_PATH = path.join(
+  ROOT,
+  'framework',
+  'release',
+  'kfd-2',
+  'kungfu-release-claims.registry.json',
+);
 const CORE_PACKAGE_PATH = path.join(ROOT, 'framework', 'core', 'package.json');
 const ARTIFACT_VERIFY_COMMAND =
   'node scripts/buildchain-kfd-evidence.mjs --artifact-witness --json';
@@ -228,6 +241,65 @@ function assetSummary(asset) {
   };
 }
 
+function readOptionalJson(filePath) {
+  if (!fs.existsSync(filePath)) return null;
+  return readJson(filePath);
+}
+
+function buildOwnKfdFacts() {
+  const contractRegistry = readOptionalJson(CONTRACT_REGISTRY_PATH);
+  const kfd2Registry = readOptionalJson(KFD2_REGISTRY_PATH);
+  const kfd4Schemas = packageAsset(
+    '@kungfu-tech/kfd',
+    'standards.json',
+    SDK_CLI_PATH,
+  )?.parsed?.standards?.['kfd-4'];
+  return {
+    kfd1: {
+      status: 'supported',
+      mode: 'contract-world',
+      source: rel(CONTRACT_REGISTRY_PATH),
+      sha256: fs.existsSync(CONTRACT_REGISTRY_PATH)
+        ? `sha256:${sha256File(CONTRACT_REGISTRY_PATH)}`
+        : '',
+      contractCount: Array.isArray(contractRegistry?.contracts)
+        ? contractRegistry.contracts.length
+        : 0,
+      witnessCommand: 'kungfu sdk contract witness --json',
+      releasePassportInput: '--kfd-1-witness-json',
+    },
+    kfd2: {
+      status: 'supported',
+      mode: 'release-claims',
+      source: rel(KFD2_REGISTRY_PATH),
+      sha256: fs.existsSync(KFD2_REGISTRY_PATH)
+        ? `sha256:${sha256File(KFD2_REGISTRY_PATH)}`
+        : '',
+      claimCount: Array.isArray(kfd2Registry?.claims)
+        ? kfd2Registry.claims.length
+        : 0,
+      claimsCommand: 'kungfu sdk kfd 2 claims --json',
+      releasePassportInput: '--kfd-2-claim-json',
+    },
+    kfd3: {
+      status: 'supported',
+      mode: STRICT_KFD3_MODE,
+      source: KFD3_DEFAULT_REGISTRY_PATH,
+      queryCommand: 'kungfu sdk kfd query --json',
+    },
+    kfd4: {
+      status: 'schema-only',
+      mode: 'schema-only',
+      source: '@kungfu-tech/kfd/standards.json',
+      schemaCount: Object.keys(kfd4Schemas?.schemaPaths || {}).length,
+      schemaCommand: 'kungfu sdk kfd 4 schema --json',
+      residualRisk: [
+        'Buildchain 2.10.8 exposes KFD-4 as schema-only; no release verification protocol is claimed.',
+      ],
+    },
+  };
+}
+
 function buildUpstreamKfdAggregate() {
   const kfdPackage = packageJson('@kungfu-tech/kfd', SDK_CLI_PATH);
   const libnodePackage = packageJson('@kungfu-tech/libnode', CORE_PACKAGE_PATH);
@@ -311,6 +383,7 @@ function buildUpstreamKfdAggregate() {
           kfd1: 'exported-witness',
           kfd2: 'exported-claim',
           kfd3: 'exported-collaboration-interface',
+          kfd4: 'schema-metadata',
         },
         releaseAnchor: kfdRelease || null,
         kfd3SurfaceCount: Array.isArray(kfdCollaboration?.surfaces)
@@ -330,6 +403,7 @@ function buildUpstreamKfdAggregate() {
           kfd1: 'release-anchor-facts',
           kfd2: 'release-passport-required',
           kfd3: 'package-runtime-surface',
+          kfd4: 'not-declared',
         },
         releaseAnchor: libnodeRelease.parsed,
         assets: [assetSummary(libnodeRelease)],
@@ -349,6 +423,7 @@ function buildUpstreamKfdAggregate() {
           kfd1: 'gate-provider',
           kfd2: 'claim-provider',
           kfd3: 'surface-query-provider',
+          kfd4: 'schema-provider',
         },
         publicExports: [
           '@kungfu-tech/buildchain/kfd-gate',
@@ -359,6 +434,7 @@ function buildUpstreamKfdAggregate() {
         assets: buildchainAssets.map(assetSummary),
       },
     ],
+    ownKfd: buildOwnKfdFacts(),
     summary: {
       upstreamCount: 3,
       kfdAwareUpstreams: ['kfd', 'libnode', 'buildchain'],
@@ -438,7 +514,7 @@ function sdkAndProductSurfaces() {
   return [
     fileSurface({
       id: 'kungfu.kfd.query',
-      name: 'kungfu kfd query|check|witness|upstream|aggregate',
+      name: 'kungfu kfd status|schema|1|2|4|query|check|witness|upstream|aggregate',
       kind: 'cli',
       sourcePath: 'framework/core/src/python/kungfu/cli/commands/kfd.py',
       evidencePath: 'developer/sdk/kfd/upstream-aggregate.json',
@@ -446,7 +522,7 @@ function sdkAndProductSurfaces() {
     }),
     fileSurface({
       id: 'kungfu.sdk.kfd.query',
-      name: 'kungfu sdk kfd query|check|witness|upstream|aggregate',
+      name: 'kungfu sdk kfd status|schema|1|2|4|query|check|witness|upstream|aggregate',
       kind: 'cli',
       sourcePath: 'developer/sdk/src/sdk.js',
       evidencePath: 'developer/sdk/kfd/upstream-aggregate.json',
@@ -900,11 +976,12 @@ function buildSummary({
     contract: 'kungfu-buildchain-kfd-evidence-summary',
     product: registry.product,
     buildchain: {
-      minimumVersion: '2.10.7',
+      minimumVersion: '2.10.8',
       releasePassportInputs: {
         kfd1WitnessJsons: [rel(KFD1_WITNESS_PATH)],
         kfd2ClaimJsons: (kfd2Summary.buildchainProjection?.claims || []).map(
-          (claim) => claim.path,
+          (claim) =>
+            claim.path || `${rel(KFD2_OUTPUT_DIR)}/claims/${claim.id}.json`,
         ),
         kfd3PrebuildWitnessJsons: [rel(KFD3_PREBUILD_WITNESS_PATH)],
         kfd3ArtifactVerifyCommand: ARTIFACT_VERIFY_COMMAND,
@@ -938,6 +1015,13 @@ function buildSummary({
       surfaceCount: registry.surfaces.length,
       collaborationInterfaceDigest:
         prebuildWitness.collaborationInterfaceDigest,
+    },
+    kfd4: {
+      status: 'schema-only',
+      source: '@kungfu-tech/kfd/standards.json',
+      schemaCommand: 'kungfu sdk kfd 4 schema --json',
+      residualRisk:
+        'Buildchain 2.10.8 exposes KFD-4 as schema-only; no release verification protocol is claimed.',
     },
   };
 }


### PR DESCRIPTION
## Summary
- upgrade Buildchain consumers to 2.10.8 and align the KFD metadata package to alpha.21 for KFD-4 schemas
- add SDK/installed CLI KFD standard entrypoints for KFD-1, KFD-2, and KFD-4 while preserving the existing KFD-3 query behavior
- regenerate Buildchain KFD evidence and SDK aggregate facts so packaged Kungfu exposes KFD-1/2/3/4 support

## Validation
- ./kungfu-code sync
- ./kungfu-code kfd:buildchain -- --json
- ./kungfu-code kfd:buildchain:check -- --json
- ./kungfu-code exec buildchain kfd status --json
- ./kungfu-code exec buildchain kfd 4 schema --json
- node --test developer/sdk/tests/contract-cli.test.mjs
- node --test artifact/scripts/product.test.mjs
- ./kungfu-code check