### PR TITLE
feat(kfd): complete buildchain kfd 1 2 support

### DIFF
--- a/.buildchain/kfd-1/contract-world.witness.json
+++ b/.buildchain/kfd-1/contract-world.witness.json
@@ -1,0 +1,87 @@
+{
+  "schemaVersion": 1,
+  "contract": "kungfu-buildchain-kfd-1-witness-set",
+  "id": "kungfu-contracts",
+  "standard": "kfd-1",
+  "standardLabel": "KFD-1",
+  "source": {
+    "repo": "kungfu-systems/kungfu",
+    "registry": "framework/contract/kungfu-contracts.registry.json",
+    "policy": "framework/contract/kungfu-agent-first-canonical-policy.json"
+  },
+  "contractWorld": {
+    "schemaId": "https://kfd.libkungfu.dev/schemas/kfd-1/contract-world.schema.json",
+    "digest": "sha256:3aa7446953e91f366d250331e4feb7d6a3608f56e8c5bc12fa01b2fd597ea05d"
+  },
+  "standardContract": {
+    "id": "",
+    "schemaId": "https://kfd.libkungfu.dev/schemas/kfd-1/contract-world.schema.json",
+    "path": "",
+    "sha256": "",
+    "digest": "sha256:3aa7446953e91f366d250331e4feb7d6a3608f56e8c5bc12fa01b2fd597ea05d"
+  },
+  "selfHostingBoundary": {
+    "mode": "external-contract-world",
+    "sourceScope": "KFD source standard metadata, schemas, package exports, and site-consumption entrypoints",
+    "artifactScope": "packaged public artifact surfaces",
+    "boundary": "source-to-artifact byte equality for declared standard-contract surfaces",
+    "residualRisk": []
+  },
+  "responsibility": {
+    "sourceContractOwner": "product",
+    "artifactVerificationOwner": "buildchain-release-passport",
+    "releasePassportProofOwner": "buildchain"
+  },
+  "sourceVerificationRequired": false,
+  "canonicalPolicy": {
+    "path": "framework/contract/kungfu-agent-first-canonical-policy.json",
+    "sha256": "3431fb0df826dae69101258cce785c07ff8902430838f612bee2b628ddd6a0b7"
+  },
+  "registry": {
+    "path": "framework/contract/kungfu-contracts.registry.json",
+    "sha256": "19c8d64633b14b805bebb7f7028ddfb69062564b939dd97cd22fe86b5e93422d"
+  },
+  "surfaces": [
+    {
+      "name": "kungfu-config",
+      "sourcePath": "framework/config/kungfu-config.contract.json",
+      "sourceSha256": "ad21f1f270f47436d7131f2c26524eb882dd67d2c92197aec4c839a7bdac6ecb",
+      "artifactPath": "config/kungfu-config.contract.json",
+      "expectedSha256": "ad21f1f270f47436d7131f2c26524eb882dd67d2c92197aec4c839a7bdac6ecb",
+      "byteForByte": true
+    },
+    {
+      "name": "kungfu-kfx",
+      "sourcePath": "framework/kfx/kungfu-kfx.contract.json",
+      "sourceSha256": "0a585a0557c37a962a58f5ab5bcf8bd97dde8ca531701179cc7433a4a5df8c98",
+      "artifactPath": "config/kungfu-kfx.contract.json",
+      "expectedSha256": "0a585a0557c37a962a58f5ab5bcf8bd97dde8ca531701179cc7433a4a5df8c98",
+      "byteForByte": true
+    },
+    {
+      "name": "kungfu-skill",
+      "sourcePath": "framework/skill/kungfu-skill.contract.json",
+      "sourceSha256": "fb6fbc59557ac8448226f5ed8b97fd71fcf202742e896bb06e2831abeedc2a52",
+      "artifactPath": "config/kungfu-skill.contract.json",
+      "expectedSha256": "fb6fbc59557ac8448226f5ed8b97fd71fcf202742e896bb06e2831abeedc2a52",
+      "byteForByte": true
+    }
+  ],
+  "metadata": {
+    "kfdPackage": {
+      "name": "@kungfu-tech/kfd",
+      "version": "1.0.0-alpha.21",
+      "repository": "git+https://github.com/kungfu-systems/kfd.git"
+    },
+    "schemaIds": {
+      "metadata": "https://kfd.libkungfu.dev/schemas/kfd-standards.schema.json",
+      "contractWorld": "https://kfd.libkungfu.dev/schemas/kfd-1/contract-world.schema.json",
+      "witness": "https://kfd.libkungfu.dev/schemas/kfd-1/witness.schema.json"
+    },
+    "schemaPaths": {
+      "metadata": "schemas/kfd-standards.schema.json",
+      "contractWorld": "schemas/kfd-1/contract-world.schema.json",
+      "witness": "schemas/kfd-1/witness.schema.json"
+    }
+  }
+}

--- a/.buildchain/kfd-1/release-gate.json
+++ b/.buildchain/kfd-1/release-gate.json
@@ -1,0 +1,244 @@
+{
+  "schemaVersion": 1,
+  "contract": "kungfu-buildchain-kfd-1-release-gate",
+  "status": "passed",
+  "selfContractVerification": {
+    "result": "pass",
+    "contractWorldCount": 1,
+    "selfHosted": true,
+    "responsibility": {
+      "proofOwner": "buildchain-release-passport"
+    }
+  },
+  "metadata": {
+    "standard": {
+      "key": "kfd-1",
+      "id": "KFD-1",
+      "label": "KFD-1",
+      "title": "Facts must not drift: contract worlds need one fact source",
+      "revision": 1,
+      "status": "active"
+    },
+    "schemas": {
+      "ids": {
+        "metadata": "https://kfd.libkungfu.dev/schemas/kfd-standards.schema.json",
+        "contractWorld": "https://kfd.libkungfu.dev/schemas/kfd-1/contract-world.schema.json",
+        "witness": "https://kfd.libkungfu.dev/schemas/kfd-1/witness.schema.json"
+      },
+      "paths": {
+        "metadata": "schemas/kfd-standards.schema.json",
+        "contractWorld": "schemas/kfd-1/contract-world.schema.json",
+        "witness": "schemas/kfd-1/witness.schema.json"
+      },
+      "metadata": {
+        "id": "https://kfd.libkungfu.dev/schemas/kfd-standards.schema.json",
+        "path": "schemas/kfd-standards.schema.json",
+        "version": "1"
+      }
+    },
+    "package": {
+      "name": "@kungfu-tech/kfd",
+      "version": "1.0.0-alpha.21",
+      "repository": "git+https://github.com/kungfu-systems/kfd.git"
+    }
+  },
+  "formatting": {
+    "name": "buildchain-release-evidence-json-v1",
+    "indentation": 2,
+    "trailingNewline": true,
+    "canonicalDigest": "stable-json-sha256-v1"
+  },
+  "contractWorlds": [
+    {
+      "id": "kungfu-contracts",
+      "standard": "KFD-1",
+      "standardKey": "kfd-1",
+      "result": "passed",
+      "preBuildWitnessSha256": "662d5e8c8c58483e8171e4b1cf0d7a6de27367dba360afe6c2ca953fc07162fa",
+      "sourceHashes": {
+        "sha256": "c4d6910390b238fcf81c3f510c629cc0da82fed2e1ada08b10910f4fd1d15ca2",
+        "surfaceCount": 3
+      },
+      "artifactHashes": {
+        "sha256": "f06816adc9306ed3c68ff80fa15631ade6fd3d6aa56b4d451b498e3d0894122d",
+        "surfaceCount": 3
+      },
+      "witness": {
+        "schemaVersion": 1,
+        "contract": "kungfu-buildchain-kfd-1-witness-set",
+        "id": "kungfu-contracts",
+        "standard": "kfd-1",
+        "standardLabel": "KFD-1",
+        "source": {
+          "repo": "kungfu-systems/kungfu",
+          "registry": "framework/contract/kungfu-contracts.registry.json",
+          "policy": "framework/contract/kungfu-agent-first-canonical-policy.json"
+        },
+        "contractWorld": {
+          "schemaId": "https://kfd.libkungfu.dev/schemas/kfd-1/contract-world.schema.json",
+          "digest": "sha256:3aa7446953e91f366d250331e4feb7d6a3608f56e8c5bc12fa01b2fd597ea05d"
+        },
+        "standardContract": {
+          "id": "",
+          "schemaId": "https://kfd.libkungfu.dev/schemas/kfd-1/contract-world.schema.json",
+          "path": "",
+          "sha256": "",
+          "digest": "sha256:3aa7446953e91f366d250331e4feb7d6a3608f56e8c5bc12fa01b2fd597ea05d"
+        },
+        "selfHostingBoundary": {
+          "mode": "external-contract-world",
+          "sourceScope": "KFD source standard metadata, schemas, package exports, and site-consumption entrypoints",
+          "artifactScope": "packaged public artifact surfaces",
+          "boundary": "source-to-artifact byte equality for declared standard-contract surfaces",
+          "residualRisk": []
+        },
+        "responsibility": {
+          "sourceContractOwner": "product",
+          "artifactVerificationOwner": "buildchain-release-passport",
+          "releasePassportProofOwner": "buildchain"
+        },
+        "sourceVerificationRequired": true,
+        "canonicalPolicy": {
+          "path": "framework/contract/kungfu-agent-first-canonical-policy.json",
+          "sha256": "3431fb0df826dae69101258cce785c07ff8902430838f612bee2b628ddd6a0b7"
+        },
+        "registry": {
+          "path": "framework/contract/kungfu-contracts.registry.json",
+          "sha256": "19c8d64633b14b805bebb7f7028ddfb69062564b939dd97cd22fe86b5e93422d"
+        },
+        "surfaces": [
+          {
+            "name": "kungfu-config",
+            "sourcePath": "framework/config/kungfu-config.contract.json",
+            "sourceSha256": "ad21f1f270f47436d7131f2c26524eb882dd67d2c92197aec4c839a7bdac6ecb",
+            "artifactPath": "config/kungfu-config.contract.json",
+            "expectedSha256": "ad21f1f270f47436d7131f2c26524eb882dd67d2c92197aec4c839a7bdac6ecb",
+            "byteForByte": true
+          },
+          {
+            "name": "kungfu-kfx",
+            "sourcePath": "framework/kfx/kungfu-kfx.contract.json",
+            "sourceSha256": "0a585a0557c37a962a58f5ab5bcf8bd97dde8ca531701179cc7433a4a5df8c98",
+            "artifactPath": "config/kungfu-kfx.contract.json",
+            "expectedSha256": "0a585a0557c37a962a58f5ab5bcf8bd97dde8ca531701179cc7433a4a5df8c98",
+            "byteForByte": true
+          },
+          {
+            "name": "kungfu-skill",
+            "sourcePath": "framework/skill/kungfu-skill.contract.json",
+            "sourceSha256": "fb6fbc59557ac8448226f5ed8b97fd71fcf202742e896bb06e2831abeedc2a52",
+            "artifactPath": "config/kungfu-skill.contract.json",
+            "expectedSha256": "fb6fbc59557ac8448226f5ed8b97fd71fcf202742e896bb06e2831abeedc2a52",
+            "byteForByte": true
+          }
+        ],
+        "metadata": {
+          "kfdPackage": {
+            "name": "@kungfu-tech/kfd",
+            "version": "1.0.0-alpha.21",
+            "repository": "git+https://github.com/kungfu-systems/kfd.git"
+          },
+          "schemaIds": {
+            "metadata": "https://kfd.libkungfu.dev/schemas/kfd-standards.schema.json",
+            "contractWorld": "https://kfd.libkungfu.dev/schemas/kfd-1/contract-world.schema.json",
+            "witness": "https://kfd.libkungfu.dev/schemas/kfd-1/witness.schema.json"
+          },
+          "schemaPaths": {
+            "metadata": "schemas/kfd-standards.schema.json",
+            "contractWorld": "schemas/kfd-1/contract-world.schema.json",
+            "witness": "schemas/kfd-1/witness.schema.json"
+          }
+        }
+      },
+      "standardContract": {
+        "id": "",
+        "schemaId": "https://kfd.libkungfu.dev/schemas/kfd-1/contract-world.schema.json",
+        "path": "",
+        "sha256": "",
+        "digest": "sha256:3aa7446953e91f366d250331e4feb7d6a3608f56e8c5bc12fa01b2fd597ea05d"
+      },
+      "selfHostingBoundary": {
+        "mode": "external-contract-world",
+        "sourceScope": "KFD source standard metadata, schemas, package exports, and site-consumption entrypoints",
+        "artifactScope": "packaged public artifact surfaces",
+        "boundary": "source-to-artifact byte equality for declared standard-contract surfaces",
+        "residualRisk": []
+      },
+      "responsibility": {
+        "sourceContractOwner": "product",
+        "artifactVerificationOwner": "buildchain-release-passport",
+        "releasePassportProofOwner": "buildchain"
+      },
+      "sourceVerification": {
+        "status": "passed",
+        "verifiedAt": "1970-01-01T00:00:00.000Z",
+        "required": true,
+        "surfaces": [
+          {
+            "name": "kungfu-config",
+            "sourcePath": "framework/config/kungfu-config.contract.json",
+            "expectedSha256": "ad21f1f270f47436d7131f2c26524eb882dd67d2c92197aec4c839a7bdac6ecb",
+            "actualSha256": "ad21f1f270f47436d7131f2c26524eb882dd67d2c92197aec4c839a7bdac6ecb",
+            "status": "passed",
+            "reason": ""
+          },
+          {
+            "name": "kungfu-kfx",
+            "sourcePath": "framework/kfx/kungfu-kfx.contract.json",
+            "expectedSha256": "0a585a0557c37a962a58f5ab5bcf8bd97dde8ca531701179cc7433a4a5df8c98",
+            "actualSha256": "0a585a0557c37a962a58f5ab5bcf8bd97dde8ca531701179cc7433a4a5df8c98",
+            "status": "passed",
+            "reason": ""
+          },
+          {
+            "name": "kungfu-skill",
+            "sourcePath": "framework/skill/kungfu-skill.contract.json",
+            "expectedSha256": "fb6fbc59557ac8448226f5ed8b97fd71fcf202742e896bb06e2831abeedc2a52",
+            "actualSha256": "fb6fbc59557ac8448226f5ed8b97fd71fcf202742e896bb06e2831abeedc2a52",
+            "status": "passed",
+            "reason": ""
+          }
+        ]
+      },
+      "artifactVerification": {
+        "status": "passed",
+        "verifiedAt": "1970-01-01T00:00:00.000Z",
+        "surfaces": [
+          {
+            "name": "kungfu-config",
+            "sourcePath": "framework/config/kungfu-config.contract.json",
+            "sourceSha256": "ad21f1f270f47436d7131f2c26524eb882dd67d2c92197aec4c839a7bdac6ecb",
+            "artifactPath": "config/kungfu-config.contract.json",
+            "expectedSha256": "ad21f1f270f47436d7131f2c26524eb882dd67d2c92197aec4c839a7bdac6ecb",
+            "actualSha256": "ad21f1f270f47436d7131f2c26524eb882dd67d2c92197aec4c839a7bdac6ecb",
+            "byteForByte": true,
+            "status": "passed",
+            "reason": ""
+          },
+          {
+            "name": "kungfu-kfx",
+            "sourcePath": "framework/kfx/kungfu-kfx.contract.json",
+            "sourceSha256": "0a585a0557c37a962a58f5ab5bcf8bd97dde8ca531701179cc7433a4a5df8c98",
+            "artifactPath": "config/kungfu-kfx.contract.json",
+            "expectedSha256": "0a585a0557c37a962a58f5ab5bcf8bd97dde8ca531701179cc7433a4a5df8c98",
+            "actualSha256": "0a585a0557c37a962a58f5ab5bcf8bd97dde8ca531701179cc7433a4a5df8c98",
+            "byteForByte": true,
+            "status": "passed",
+            "reason": ""
+          },
+          {
+            "name": "kungfu-skill",
+            "sourcePath": "framework/skill/kungfu-skill.contract.json",
+            "sourceSha256": "fb6fbc59557ac8448226f5ed8b97fd71fcf202742e896bb06e2831abeedc2a52",
+            "artifactPath": "config/kungfu-skill.contract.json",
+            "expectedSha256": "fb6fbc59557ac8448226f5ed8b97fd71fcf202742e896bb06e2831abeedc2a52",
+            "actualSha256": "fb6fbc59557ac8448226f5ed8b97fd71fcf202742e896bb06e2831abeedc2a52",
+            "byteForByte": true,
+            "status": "passed",
+            "reason": ""
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/.buildchain/kfd-1/verify-result.json
+++ b/.buildchain/kfd-1/verify-result.json
@@ -1,0 +1,6 @@
+{
+  "schemaVersion": 1,
+  "contract": "kungfu-buildchain-kfd-1-verify-result",
+  "ok": true,
+  "issues": []
+}

--- a/.buildchain/kfd-2/buildchain-claim-args.txt
+++ b/.buildchain/kfd-2/buildchain-claim-args.txt
@@ -1,0 +1,3 @@
+--kfd-2-claim-json .buildchain/kfd-2/claims/agent-onboarding-pack.json
+--kfd-2-claim-json .buildchain/kfd-2/claims/codex-report-receipts.json
+--kfd-2-claim-json .buildchain/kfd-2/claims/remote-fact-boundary.json

--- a/.buildchain/kfd-2/claims/agent-onboarding-pack.json
+++ b/.buildchain/kfd-2/claims/agent-onboarding-pack.json
@@ -1,0 +1,119 @@
+{
+  "id": "agent-onboarding-pack",
+  "public": true,
+  "claim": "Kungfu releases declare an installed agent onboarding pack with machine-readable command and mode metadata, safety boundaries, examples, and verifier coverage.",
+  "sourceBindings": [
+    {
+      "role": "claim-source",
+      "kind": "file",
+      "path": "framework/core/src/python/kungfu/agent/index.json",
+      "sha256": "c6ba4dd9b1c3e97bd6e7853555e4534ed5cdcfdea8fda0d3798a7a545331c62c"
+    }
+  ],
+  "machineEvidence": [
+    {
+      "type": "file",
+      "pointer": {
+        "kind": "file",
+        "path": "framework/core/src/python/kungfu/agent/commands.json",
+        "sha256": "0fadbb02d0e2b49f6bd982a744f9c58448794e7606b9edeb6f2457c28c8404ab"
+      },
+      "description": "Machine-readable command catalog and mode maturity metadata."
+    },
+    {
+      "type": "file",
+      "pointer": {
+        "kind": "file",
+        "path": "framework/core/src/python/kungfu/agent/mode-selection.md",
+        "sha256": "51f32b7c4b5e1eb49cf05a4386b1134c8f019aca984c6a7842b8bec5f972bee2"
+      },
+      "description": "Human and agent-readable mode selection rules."
+    },
+    {
+      "type": "file",
+      "pointer": {
+        "kind": "file",
+        "path": "framework/core/src/python/kungfu/agent/safety.md",
+        "sha256": "7d79f580d229ff16821568b5200746cc17abd68fa7ec533ca8ff2c49b7e7e8c7"
+      },
+      "description": "Fact labels and safety boundaries for observed, reported, imported, and remote evidence."
+    },
+    {
+      "type": "file",
+      "pointer": {
+        "kind": "file",
+        "path": "scripts/verify-agent-pack.mjs",
+        "sha256": "5939f9bc8a6c37c9712db5d31c84b08cbf60416e0a1c5437460629000d3aa4c0"
+      },
+      "description": "Read-only verifier for installed agent pack completeness and command/doc consistency."
+    }
+  ],
+  "hashes": {
+    "registrySha256": "ebf949f99ed5f0d01e9ba22fbc340848144f12f8e126dba586f16bbc786f5952",
+    "sourceSha256": "c6ba4dd9b1c3e97bd6e7853555e4534ed5cdcfdea8fda0d3798a7a545331c62c",
+    "evidenceSha256": [
+      {
+        "path": "framework/core/src/python/kungfu/agent/commands.json",
+        "sha256": "0fadbb02d0e2b49f6bd982a744f9c58448794e7606b9edeb6f2457c28c8404ab"
+      },
+      {
+        "path": "framework/core/src/python/kungfu/agent/mode-selection.md",
+        "sha256": "51f32b7c4b5e1eb49cf05a4386b1134c8f019aca984c6a7842b8bec5f972bee2"
+      },
+      {
+        "path": "framework/core/src/python/kungfu/agent/safety.md",
+        "sha256": "7d79f580d229ff16821568b5200746cc17abd68fa7ec533ca8ff2c49b7e7e8c7"
+      },
+      {
+        "path": "scripts/verify-agent-pack.mjs",
+        "sha256": "5939f9bc8a6c37c9712db5d31c84b08cbf60416e0a1c5437460629000d3aa4c0"
+      }
+    ],
+    "artifactSha256": [
+      {
+        "path": "framework/core/src/python/kungfu/agent/index.json",
+        "sha256": "c6ba4dd9b1c3e97bd6e7853555e4534ed5cdcfdea8fda0d3798a7a545331c62c"
+      },
+      {
+        "path": "framework/core/src/python/kungfu/agent/commands.json",
+        "sha256": "0fadbb02d0e2b49f6bd982a744f9c58448794e7606b9edeb6f2457c28c8404ab"
+      }
+    ]
+  },
+  "artifacts": [
+    {
+      "name": "agent-pack-index",
+      "path": "framework/core/src/python/kungfu/agent/index.json",
+      "sha256": "c6ba4dd9b1c3e97bd6e7853555e4534ed5cdcfdea8fda0d3798a7a545331c62c",
+      "expectedPackagePath": "kungfu/agent/index.json"
+    },
+    {
+      "name": "agent-command-catalog",
+      "path": "framework/core/src/python/kungfu/agent/commands.json",
+      "sha256": "0fadbb02d0e2b49f6bd982a744f9c58448794e7606b9edeb6f2457c28c8404ab",
+      "expectedPackagePath": "kungfu/agent/commands.json"
+    }
+  ],
+  "verification": {
+    "result": "passed",
+    "command": "node scripts/verify-agent-pack.mjs && node scripts/kfd2-release-claims.mjs --check",
+    "expectedResult": "pass"
+  },
+  "auditBoundary": {
+    "scope": "The committed agent onboarding pack files listed in this claim and the verifier checks that enumerate required docs, skills, command catalog entries, safety labels, package data, GUI hint, and TUI hint.",
+    "enumerability": "closed-world",
+    "exclusions": [
+      "Provider CLI behavior outside Kungfu",
+      "User-specific bootstrap policy files under local home directories",
+      "Runtime data and receipts produced after installation"
+    ]
+  },
+  "responsibility": {
+    "sourceOwner": "kungfu",
+    "verificationOwner": "kungfu verify",
+    "releaseDecisionOwner": "kungfu release maintainer",
+    "escalation": "Downgrade the claim if the pack verifier fails or a new public agent command is added without command catalog coverage."
+  },
+  "residualRisk": [],
+  "canonicalStatus": "audited"
+}

--- a/.buildchain/kfd-2/claims/codex-report-receipts.json
+++ b/.buildchain/kfd-2/claims/codex-report-receipts.json
@@ -1,0 +1,132 @@
+{
+  "id": "codex-report-receipts",
+  "public": true,
+  "claim": "Kungfu report mode exposes a native Codex goal adapter with a verifiable receipt path, and token-only or unknown cost is represented as unknown rather than fabricated zero-dollar cost.",
+  "sourceBindings": [
+    {
+      "role": "claim-source",
+      "kind": "file",
+      "path": "framework/core/src/python/kungfu/cli/commands/codex.py",
+      "sha256": "54dc1ae6436427df7a15551c897c3111a88b529c610f1dd0f16673199e2dec14"
+    }
+  ],
+  "machineEvidence": [
+    {
+      "type": "file",
+      "pointer": {
+        "kind": "file",
+        "path": "framework/core/src/python/kungfu/cli/commands/codex.py",
+        "sha256": "54dc1ae6436427df7a15551c897c3111a88b529c610f1dd0f16673199e2dec14"
+      },
+      "description": "Codex goal report adapter and receipt verifier CLI implementation."
+    },
+    {
+      "type": "file",
+      "pointer": {
+        "kind": "file",
+        "path": "framework/core/src/python/kungfu/rewind/cost/codex.py",
+        "sha256": "859526f1e21f9596d064388b365019858436026aad9628706cabd1d6fe078699"
+      },
+      "description": "Codex cost adapter: tokens are reported, dollar cost remains unknown when not provided by the provider."
+    },
+    {
+      "type": "file",
+      "pointer": {
+        "kind": "file",
+        "path": "framework/core/src/python/kungfu/rewind/cost_wire.py",
+        "sha256": "76887d0ba61675be4fd9e7f11cabce1d1be952f07370a156095b0423d01aba2c"
+      },
+      "description": "Cost wire model preserving known/unknown cost distinction."
+    },
+    {
+      "type": "file",
+      "pointer": {
+        "kind": "file",
+        "path": "framework/core/src/python/kungfu/agent/examples/report-mode.md",
+        "sha256": "ef62de93bb8c9b29e50c18429a6d5c006b19a57bd730768d4d5768a175a5d70c"
+      },
+      "description": "Report-mode user and agent procedure including Codex receipt verification."
+    },
+    {
+      "type": "file",
+      "pointer": {
+        "kind": "file",
+        "path": "framework/core/src/python/kungfu/agent/skills/codex/SKILL.md",
+        "sha256": "5de3db86c56124d952b6732133c9c1c0411951f0c9df4685f629edaee1269d07"
+      },
+      "description": "Codex-side report closeout gate instructions shipped in the agent pack."
+    }
+  ],
+  "hashes": {
+    "registrySha256": "ebf949f99ed5f0d01e9ba22fbc340848144f12f8e126dba586f16bbc786f5952",
+    "sourceSha256": "54dc1ae6436427df7a15551c897c3111a88b529c610f1dd0f16673199e2dec14",
+    "evidenceSha256": [
+      {
+        "path": "framework/core/src/python/kungfu/cli/commands/codex.py",
+        "sha256": "54dc1ae6436427df7a15551c897c3111a88b529c610f1dd0f16673199e2dec14"
+      },
+      {
+        "path": "framework/core/src/python/kungfu/rewind/cost/codex.py",
+        "sha256": "859526f1e21f9596d064388b365019858436026aad9628706cabd1d6fe078699"
+      },
+      {
+        "path": "framework/core/src/python/kungfu/rewind/cost_wire.py",
+        "sha256": "76887d0ba61675be4fd9e7f11cabce1d1be952f07370a156095b0423d01aba2c"
+      },
+      {
+        "path": "framework/core/src/python/kungfu/agent/examples/report-mode.md",
+        "sha256": "ef62de93bb8c9b29e50c18429a6d5c006b19a57bd730768d4d5768a175a5d70c"
+      },
+      {
+        "path": "framework/core/src/python/kungfu/agent/skills/codex/SKILL.md",
+        "sha256": "5de3db86c56124d952b6732133c9c1c0411951f0c9df4685f629edaee1269d07"
+      }
+    ],
+    "artifactSha256": [
+      {
+        "path": "framework/core/src/python/kungfu/cli/commands/codex.py",
+        "sha256": "54dc1ae6436427df7a15551c897c3111a88b529c610f1dd0f16673199e2dec14"
+      },
+      {
+        "path": "framework/core/src/python/kungfu/agent/skills/codex/SKILL.md",
+        "sha256": "5de3db86c56124d952b6732133c9c1c0411951f0c9df4685f629edaee1269d07"
+      }
+    ]
+  },
+  "artifacts": [
+    {
+      "name": "codex-cli-command",
+      "path": "framework/core/src/python/kungfu/cli/commands/codex.py",
+      "sha256": "54dc1ae6436427df7a15551c897c3111a88b529c610f1dd0f16673199e2dec14",
+      "expectedPackagePath": "kungfu/cli/commands/codex.py"
+    },
+    {
+      "name": "codex-agent-skill",
+      "path": "framework/core/src/python/kungfu/agent/skills/codex/SKILL.md",
+      "sha256": "5de3db86c56124d952b6732133c9c1c0411951f0c9df4685f629edaee1269d07",
+      "expectedPackagePath": "kungfu/agent/skills/codex/SKILL.md"
+    }
+  ],
+  "verification": {
+    "result": "passed",
+    "command": "node scripts/verify-agent-pack.mjs && node scripts/kfd2-release-claims.mjs --check",
+    "expectedResult": "pass"
+  },
+  "auditBoundary": {
+    "scope": "The committed Codex report adapter, receipt verifier, cost wire model, report-mode docs, and shipped Codex skill instructions listed in this claim.",
+    "enumerability": "closed-world",
+    "exclusions": [
+      "Provider-side billing pages or private sessions",
+      "Future Codex API fields not emitted to the user or agent",
+      "Human-entered cost overrides outside the receipt verifier"
+    ]
+  },
+  "responsibility": {
+    "sourceOwner": "kungfu",
+    "verificationOwner": "kungfu verify",
+    "releaseDecisionOwner": "kungfu release maintainer",
+    "escalation": "Downgrade the claim if receipt verification stops binding the run id, work id, goal id, status, and reported usage fields."
+  },
+  "residualRisk": [],
+  "canonicalStatus": "audited"
+}

--- a/.buildchain/kfd-2/claims/remote-fact-boundary.json
+++ b/.buildchain/kfd-2/claims/remote-fact-boundary.json
@@ -1,0 +1,121 @@
+{
+  "id": "remote-fact-boundary",
+  "public": true,
+  "claim": "Kungfu distinguishes local observed facts from reported, imported, and remote facts in the agent pack and remote-sync command surface instead of silently promoting remote evidence into local truth.",
+  "sourceBindings": [
+    {
+      "role": "claim-source",
+      "kind": "file",
+      "path": "framework/core/src/python/kungfu/agent/safety.md",
+      "sha256": "7d79f580d229ff16821568b5200746cc17abd68fa7ec533ca8ff2c49b7e7e8c7"
+    }
+  ],
+  "machineEvidence": [
+    {
+      "type": "file",
+      "pointer": {
+        "kind": "file",
+        "path": "framework/core/src/python/kungfu/agent/safety.md",
+        "sha256": "7d79f580d229ff16821568b5200746cc17abd68fa7ec533ca8ff2c49b7e7e8c7"
+      },
+      "description": "Fact labels for observed, reported, imported, and remote evidence."
+    },
+    {
+      "type": "file",
+      "pointer": {
+        "kind": "file",
+        "path": "framework/core/src/python/kungfu/agent/mode-selection.md",
+        "sha256": "51f32b7c4b5e1eb49cf05a4386b1134c8f019aca984c6a7842b8bec5f972bee2"
+      },
+      "description": "Remote-sync mode rule requiring source-scoped import."
+    },
+    {
+      "type": "file",
+      "pointer": {
+        "kind": "file",
+        "path": "framework/core/src/python/kungfu/agent/commands.json",
+        "sha256": "0fadbb02d0e2b49f6bd982a744f9c58448794e7606b9edeb6f2457c28c8404ab"
+      },
+      "description": "Remote add/sync command declarations and mode metadata."
+    },
+    {
+      "type": "file",
+      "pointer": {
+        "kind": "file",
+        "path": "framework/core/src/python/kungfu/cli/commands/agent.py",
+        "sha256": "d8c195502f678bc34be690769f29c1c8b223fe5ae65ad142fa656e9b3c849b16"
+      },
+      "description": "Agent command surface including mode selection and bootstrap status."
+    }
+  ],
+  "hashes": {
+    "registrySha256": "ebf949f99ed5f0d01e9ba22fbc340848144f12f8e126dba586f16bbc786f5952",
+    "sourceSha256": "7d79f580d229ff16821568b5200746cc17abd68fa7ec533ca8ff2c49b7e7e8c7",
+    "evidenceSha256": [
+      {
+        "path": "framework/core/src/python/kungfu/agent/safety.md",
+        "sha256": "7d79f580d229ff16821568b5200746cc17abd68fa7ec533ca8ff2c49b7e7e8c7"
+      },
+      {
+        "path": "framework/core/src/python/kungfu/agent/mode-selection.md",
+        "sha256": "51f32b7c4b5e1eb49cf05a4386b1134c8f019aca984c6a7842b8bec5f972bee2"
+      },
+      {
+        "path": "framework/core/src/python/kungfu/agent/commands.json",
+        "sha256": "0fadbb02d0e2b49f6bd982a744f9c58448794e7606b9edeb6f2457c28c8404ab"
+      },
+      {
+        "path": "framework/core/src/python/kungfu/cli/commands/agent.py",
+        "sha256": "d8c195502f678bc34be690769f29c1c8b223fe5ae65ad142fa656e9b3c849b16"
+      }
+    ],
+    "artifactSha256": [
+      {
+        "path": "framework/core/src/python/kungfu/agent/safety.md",
+        "sha256": "7d79f580d229ff16821568b5200746cc17abd68fa7ec533ca8ff2c49b7e7e8c7"
+      },
+      {
+        "path": "framework/core/src/python/kungfu/agent/mode-selection.md",
+        "sha256": "51f32b7c4b5e1eb49cf05a4386b1134c8f019aca984c6a7842b8bec5f972bee2"
+      }
+    ]
+  },
+  "artifacts": [
+    {
+      "name": "agent-safety-doc",
+      "path": "framework/core/src/python/kungfu/agent/safety.md",
+      "sha256": "7d79f580d229ff16821568b5200746cc17abd68fa7ec533ca8ff2c49b7e7e8c7",
+      "expectedPackagePath": "kungfu/agent/safety.md"
+    },
+    {
+      "name": "agent-mode-selection-doc",
+      "path": "framework/core/src/python/kungfu/agent/mode-selection.md",
+      "sha256": "51f32b7c4b5e1eb49cf05a4386b1134c8f019aca984c6a7842b8bec5f972bee2",
+      "expectedPackagePath": "kungfu/agent/mode-selection.md"
+    }
+  ],
+  "verification": {
+    "result": "passed-with-residual-risk",
+    "command": "node scripts/verify-agent-pack.mjs && node scripts/kfd2-release-claims.mjs --check",
+    "expectedResult": "pass"
+  },
+  "auditBoundary": {
+    "scope": "The committed agent safety and mode-selection documents, machine-readable commands catalog, and agent CLI command implementation listed in this claim.",
+    "enumerability": "declared-open",
+    "exclusions": [
+      "Actual network transport availability",
+      "Remote host identity outside locally recorded source metadata",
+      "User decisions to manually promote imported evidence"
+    ]
+  },
+  "responsibility": {
+    "sourceOwner": "kungfu",
+    "verificationOwner": "kungfu verify",
+    "releaseDecisionOwner": "kungfu release maintainer",
+    "escalation": "Keep this claim downgraded or human-reviewed while remote-sync remains an experimental surface."
+  },
+  "residualRisk": [
+    "Remote evidence freshness and identity depend on the configured source runtime and must remain source-scoped until a later command explicitly promotes it."
+  ],
+  "canonicalStatus": "audited"
+}

--- a/.buildchain/kfd-2/release-claims.json
+++ b/.buildchain/kfd-2/release-claims.json
@@ -1,0 +1,240 @@
+{
+  "schemaVersion": 1,
+  "contract": "kfd-2-release-claims",
+  "standard": "kfd-2",
+  "product": {
+    "name": "Kungfu",
+    "repository": "kungfu-systems/kungfu",
+    "package": "@kungfu-tech/artifact-kungfu"
+  },
+  "release": {
+    "version": "4.0.0-alpha.0",
+    "channel": "dev/v4/v4.0",
+    "tag": "v4.0.0-alpha.0",
+    "sourceSha": "local-dev-snapshot"
+  },
+  "claims": [
+    {
+      "id": "agent-onboarding-pack",
+      "statement": "Kungfu releases declare an installed agent onboarding pack with machine-readable command and mode metadata, safety boundaries, examples, and verifier coverage.",
+      "category": "kfd-2",
+      "source": {
+        "kind": "file",
+        "path": "framework/core/src/python/kungfu/agent/index.json",
+        "sha256": "c6ba4dd9b1c3e97bd6e7853555e4534ed5cdcfdea8fda0d3798a7a545331c62c"
+      },
+      "evidence": [
+        {
+          "type": "file",
+          "pointer": {
+            "kind": "file",
+            "path": "framework/core/src/python/kungfu/agent/commands.json",
+            "sha256": "0fadbb02d0e2b49f6bd982a744f9c58448794e7606b9edeb6f2457c28c8404ab"
+          },
+          "description": "Machine-readable command catalog and mode maturity metadata."
+        },
+        {
+          "type": "file",
+          "pointer": {
+            "kind": "file",
+            "path": "framework/core/src/python/kungfu/agent/mode-selection.md",
+            "sha256": "51f32b7c4b5e1eb49cf05a4386b1134c8f019aca984c6a7842b8bec5f972bee2"
+          },
+          "description": "Human and agent-readable mode selection rules."
+        },
+        {
+          "type": "file",
+          "pointer": {
+            "kind": "file",
+            "path": "framework/core/src/python/kungfu/agent/safety.md",
+            "sha256": "7d79f580d229ff16821568b5200746cc17abd68fa7ec533ca8ff2c49b7e7e8c7"
+          },
+          "description": "Fact labels and safety boundaries for observed, reported, imported, and remote evidence."
+        },
+        {
+          "type": "file",
+          "pointer": {
+            "kind": "file",
+            "path": "scripts/verify-agent-pack.mjs",
+            "sha256": "5939f9bc8a6c37c9712db5d31c84b08cbf60416e0a1c5437460629000d3aa4c0"
+          },
+          "description": "Read-only verifier for installed agent pack completeness and command/doc consistency."
+        }
+      ],
+      "verification": {
+        "command": "node scripts/verify-agent-pack.mjs && node scripts/kfd2-release-claims.mjs --check",
+        "expectedResult": "pass"
+      },
+      "auditBoundary": {
+        "scope": "The committed agent onboarding pack files listed in this claim and the verifier checks that enumerate required docs, skills, command catalog entries, safety labels, package data, GUI hint, and TUI hint.",
+        "enumerability": "closed-world",
+        "exclusions": [
+          "Provider CLI behavior outside Kungfu",
+          "User-specific bootstrap policy files under local home directories",
+          "Runtime data and receipts produced after installation"
+        ]
+      },
+      "residualRisk": [],
+      "responsibility": {
+        "sourceOwner": "kungfu",
+        "verificationOwner": "kungfu verify",
+        "releaseDecisionOwner": "kungfu release maintainer",
+        "escalation": "Downgrade the claim if the pack verifier fails or a new public agent command is added without command catalog coverage."
+      },
+      "status": "audited"
+    },
+    {
+      "id": "codex-report-receipts",
+      "statement": "Kungfu report mode exposes a native Codex goal adapter with a verifiable receipt path, and token-only or unknown cost is represented as unknown rather than fabricated zero-dollar cost.",
+      "category": "kfd-2",
+      "source": {
+        "kind": "file",
+        "path": "framework/core/src/python/kungfu/cli/commands/codex.py",
+        "sha256": "54dc1ae6436427df7a15551c897c3111a88b529c610f1dd0f16673199e2dec14"
+      },
+      "evidence": [
+        {
+          "type": "file",
+          "pointer": {
+            "kind": "file",
+            "path": "framework/core/src/python/kungfu/cli/commands/codex.py",
+            "sha256": "54dc1ae6436427df7a15551c897c3111a88b529c610f1dd0f16673199e2dec14"
+          },
+          "description": "Codex goal report adapter and receipt verifier CLI implementation."
+        },
+        {
+          "type": "file",
+          "pointer": {
+            "kind": "file",
+            "path": "framework/core/src/python/kungfu/rewind/cost/codex.py",
+            "sha256": "859526f1e21f9596d064388b365019858436026aad9628706cabd1d6fe078699"
+          },
+          "description": "Codex cost adapter: tokens are reported, dollar cost remains unknown when not provided by the provider."
+        },
+        {
+          "type": "file",
+          "pointer": {
+            "kind": "file",
+            "path": "framework/core/src/python/kungfu/rewind/cost_wire.py",
+            "sha256": "76887d0ba61675be4fd9e7f11cabce1d1be952f07370a156095b0423d01aba2c"
+          },
+          "description": "Cost wire model preserving known/unknown cost distinction."
+        },
+        {
+          "type": "file",
+          "pointer": {
+            "kind": "file",
+            "path": "framework/core/src/python/kungfu/agent/examples/report-mode.md",
+            "sha256": "ef62de93bb8c9b29e50c18429a6d5c006b19a57bd730768d4d5768a175a5d70c"
+          },
+          "description": "Report-mode user and agent procedure including Codex receipt verification."
+        },
+        {
+          "type": "file",
+          "pointer": {
+            "kind": "file",
+            "path": "framework/core/src/python/kungfu/agent/skills/codex/SKILL.md",
+            "sha256": "5de3db86c56124d952b6732133c9c1c0411951f0c9df4685f629edaee1269d07"
+          },
+          "description": "Codex-side report closeout gate instructions shipped in the agent pack."
+        }
+      ],
+      "verification": {
+        "command": "node scripts/verify-agent-pack.mjs && node scripts/kfd2-release-claims.mjs --check",
+        "expectedResult": "pass"
+      },
+      "auditBoundary": {
+        "scope": "The committed Codex report adapter, receipt verifier, cost wire model, report-mode docs, and shipped Codex skill instructions listed in this claim.",
+        "enumerability": "closed-world",
+        "exclusions": [
+          "Provider-side billing pages or private sessions",
+          "Future Codex API fields not emitted to the user or agent",
+          "Human-entered cost overrides outside the receipt verifier"
+        ]
+      },
+      "residualRisk": [],
+      "responsibility": {
+        "sourceOwner": "kungfu",
+        "verificationOwner": "kungfu verify",
+        "releaseDecisionOwner": "kungfu release maintainer",
+        "escalation": "Downgrade the claim if receipt verification stops binding the run id, work id, goal id, status, and reported usage fields."
+      },
+      "status": "audited"
+    },
+    {
+      "id": "remote-fact-boundary",
+      "statement": "Kungfu distinguishes local observed facts from reported, imported, and remote facts in the agent pack and remote-sync command surface instead of silently promoting remote evidence into local truth.",
+      "category": "kfd-2",
+      "source": {
+        "kind": "file",
+        "path": "framework/core/src/python/kungfu/agent/safety.md",
+        "sha256": "7d79f580d229ff16821568b5200746cc17abd68fa7ec533ca8ff2c49b7e7e8c7"
+      },
+      "evidence": [
+        {
+          "type": "file",
+          "pointer": {
+            "kind": "file",
+            "path": "framework/core/src/python/kungfu/agent/safety.md",
+            "sha256": "7d79f580d229ff16821568b5200746cc17abd68fa7ec533ca8ff2c49b7e7e8c7"
+          },
+          "description": "Fact labels for observed, reported, imported, and remote evidence."
+        },
+        {
+          "type": "file",
+          "pointer": {
+            "kind": "file",
+            "path": "framework/core/src/python/kungfu/agent/mode-selection.md",
+            "sha256": "51f32b7c4b5e1eb49cf05a4386b1134c8f019aca984c6a7842b8bec5f972bee2"
+          },
+          "description": "Remote-sync mode rule requiring source-scoped import."
+        },
+        {
+          "type": "file",
+          "pointer": {
+            "kind": "file",
+            "path": "framework/core/src/python/kungfu/agent/commands.json",
+            "sha256": "0fadbb02d0e2b49f6bd982a744f9c58448794e7606b9edeb6f2457c28c8404ab"
+          },
+          "description": "Remote add/sync command declarations and mode metadata."
+        },
+        {
+          "type": "file",
+          "pointer": {
+            "kind": "file",
+            "path": "framework/core/src/python/kungfu/cli/commands/agent.py",
+            "sha256": "d8c195502f678bc34be690769f29c1c8b223fe5ae65ad142fa656e9b3c849b16"
+          },
+          "description": "Agent command surface including mode selection and bootstrap status."
+        }
+      ],
+      "verification": {
+        "command": "node scripts/verify-agent-pack.mjs && node scripts/kfd2-release-claims.mjs --check",
+        "expectedResult": "pass"
+      },
+      "auditBoundary": {
+        "scope": "The committed agent safety and mode-selection documents, machine-readable commands catalog, and agent CLI command implementation listed in this claim.",
+        "enumerability": "declared-open",
+        "exclusions": [
+          "Actual network transport availability",
+          "Remote host identity outside locally recorded source metadata",
+          "User decisions to manually promote imported evidence"
+        ]
+      },
+      "residualRisk": [
+        "Remote evidence freshness and identity depend on the configured source runtime and must remain source-scoped until a later command explicitly promotes it."
+      ],
+      "responsibility": {
+        "sourceOwner": "kungfu",
+        "verificationOwner": "kungfu verify",
+        "releaseDecisionOwner": "kungfu release maintainer",
+        "escalation": "Keep this claim downgraded or human-reviewed while remote-sync remains an experimental surface."
+      },
+      "status": "audited"
+    }
+  ],
+  "schemaEvolution": {
+    "interfaceVersion": 1,
+    "compatibilityRule": "Compatible additions may keep schemaVersion 1; required-field or semantic changes require a new KFD-owned interface version."
+  }
+}

--- a/.buildchain/kfd/kfd-3-surfaces.json
+++ b/.buildchain/kfd/kfd-3-surfaces.json
@@ -53,7 +53,7 @@
       "libnode": "22.22.3-kf.3-alpha.16",
       "buildchain": "2.10.8"
     },
-    "digest": "sha256:ff46f99bd15d4495f7890d04577ba91cd8bcb95605fa921313dcd272490182d4"
+    "digest": "sha256:f0eb882f9f2e011f7dd89b5fb41a30f62883560480822c3e71c633b60e43fe2e"
   },
   "surfaces": [
     {

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,10 @@ dist/
 .buildchain/*
 !.buildchain/buildchain.toml
 !.buildchain/contract-lock.json
+!.buildchain/kfd-1/
+!.buildchain/kfd-1/**
+!.buildchain/kfd-2/
+!.buildchain/kfd-2/**
 !.buildchain/kfd/
 .buildchain/kfd/*
 !.buildchain/kfd/kfd-3-surfaces.json

--- a/developer/sdk/README.md
+++ b/developer/sdk/README.md
@@ -73,6 +73,8 @@ answer standard and capability questions without asking users to install the
 kungfu kfd status --json
 kungfu kfd schema kfd-4 --json
 kungfu kfd 1 witness --json
+kungfu kfd 1 gate --json
+kungfu kfd 1 verify --json
 kungfu kfd 2 claims --json
 kungfu kfd 4 schema --json
 kungfu kfd query --json
@@ -84,6 +86,8 @@ kungfu kfd aggregate --json
 kungfu sdk kfd status --json
 kungfu sdk kfd schema kfd-4 --json
 kungfu sdk kfd 1 witness --json
+kungfu sdk kfd 1 gate --json
+kungfu sdk kfd 1 verify --json
 kungfu sdk kfd 2 claims --json
 kungfu sdk kfd 4 schema --json
 kungfu sdk kfd query --json
@@ -102,6 +106,10 @@ the SDK-packaged KFD aggregate for Kungfu plus KFD, libnode, and Buildchain;
 `aggregate` joins both views for an agent that wants the final product plus
 upstream trust surface in one response. KFD-4 is intentionally reported as
 schema-only until Buildchain/KFD defines a release verification protocol for it.
+KFD-1 is exposed as the actual Buildchain contract-world witness, release gate,
+and verify result. KFD-2 `claims` returns the packaged canonical
+`release-claims.json` plus the per-claim Buildchain projection files that feed
+the release passport through `--kfd-2-claim-json`.
 
 ## KFD-1 Contract Prototype
 

--- a/developer/sdk/kfd/kfd-1/contract-world.witness.json
+++ b/developer/sdk/kfd/kfd-1/contract-world.witness.json
@@ -1,0 +1,87 @@
+{
+  "schemaVersion": 1,
+  "contract": "kungfu-buildchain-kfd-1-witness-set",
+  "id": "kungfu-contracts",
+  "standard": "kfd-1",
+  "standardLabel": "KFD-1",
+  "source": {
+    "repo": "kungfu-systems/kungfu",
+    "registry": "framework/contract/kungfu-contracts.registry.json",
+    "policy": "framework/contract/kungfu-agent-first-canonical-policy.json"
+  },
+  "contractWorld": {
+    "schemaId": "https://kfd.libkungfu.dev/schemas/kfd-1/contract-world.schema.json",
+    "digest": "sha256:3aa7446953e91f366d250331e4feb7d6a3608f56e8c5bc12fa01b2fd597ea05d"
+  },
+  "standardContract": {
+    "id": "",
+    "schemaId": "https://kfd.libkungfu.dev/schemas/kfd-1/contract-world.schema.json",
+    "path": "",
+    "sha256": "",
+    "digest": "sha256:3aa7446953e91f366d250331e4feb7d6a3608f56e8c5bc12fa01b2fd597ea05d"
+  },
+  "selfHostingBoundary": {
+    "mode": "external-contract-world",
+    "sourceScope": "KFD source standard metadata, schemas, package exports, and site-consumption entrypoints",
+    "artifactScope": "packaged public artifact surfaces",
+    "boundary": "source-to-artifact byte equality for declared standard-contract surfaces",
+    "residualRisk": []
+  },
+  "responsibility": {
+    "sourceContractOwner": "product",
+    "artifactVerificationOwner": "buildchain-release-passport",
+    "releasePassportProofOwner": "buildchain"
+  },
+  "sourceVerificationRequired": false,
+  "canonicalPolicy": {
+    "path": "framework/contract/kungfu-agent-first-canonical-policy.json",
+    "sha256": "3431fb0df826dae69101258cce785c07ff8902430838f612bee2b628ddd6a0b7"
+  },
+  "registry": {
+    "path": "framework/contract/kungfu-contracts.registry.json",
+    "sha256": "19c8d64633b14b805bebb7f7028ddfb69062564b939dd97cd22fe86b5e93422d"
+  },
+  "surfaces": [
+    {
+      "name": "kungfu-config",
+      "sourcePath": "framework/config/kungfu-config.contract.json",
+      "sourceSha256": "ad21f1f270f47436d7131f2c26524eb882dd67d2c92197aec4c839a7bdac6ecb",
+      "artifactPath": "config/kungfu-config.contract.json",
+      "expectedSha256": "ad21f1f270f47436d7131f2c26524eb882dd67d2c92197aec4c839a7bdac6ecb",
+      "byteForByte": true
+    },
+    {
+      "name": "kungfu-kfx",
+      "sourcePath": "framework/kfx/kungfu-kfx.contract.json",
+      "sourceSha256": "0a585a0557c37a962a58f5ab5bcf8bd97dde8ca531701179cc7433a4a5df8c98",
+      "artifactPath": "config/kungfu-kfx.contract.json",
+      "expectedSha256": "0a585a0557c37a962a58f5ab5bcf8bd97dde8ca531701179cc7433a4a5df8c98",
+      "byteForByte": true
+    },
+    {
+      "name": "kungfu-skill",
+      "sourcePath": "framework/skill/kungfu-skill.contract.json",
+      "sourceSha256": "fb6fbc59557ac8448226f5ed8b97fd71fcf202742e896bb06e2831abeedc2a52",
+      "artifactPath": "config/kungfu-skill.contract.json",
+      "expectedSha256": "fb6fbc59557ac8448226f5ed8b97fd71fcf202742e896bb06e2831abeedc2a52",
+      "byteForByte": true
+    }
+  ],
+  "metadata": {
+    "kfdPackage": {
+      "name": "@kungfu-tech/kfd",
+      "version": "1.0.0-alpha.21",
+      "repository": "git+https://github.com/kungfu-systems/kfd.git"
+    },
+    "schemaIds": {
+      "metadata": "https://kfd.libkungfu.dev/schemas/kfd-standards.schema.json",
+      "contractWorld": "https://kfd.libkungfu.dev/schemas/kfd-1/contract-world.schema.json",
+      "witness": "https://kfd.libkungfu.dev/schemas/kfd-1/witness.schema.json"
+    },
+    "schemaPaths": {
+      "metadata": "schemas/kfd-standards.schema.json",
+      "contractWorld": "schemas/kfd-1/contract-world.schema.json",
+      "witness": "schemas/kfd-1/witness.schema.json"
+    }
+  }
+}

--- a/developer/sdk/kfd/kfd-1/release-gate.json
+++ b/developer/sdk/kfd/kfd-1/release-gate.json
@@ -1,0 +1,244 @@
+{
+  "schemaVersion": 1,
+  "contract": "kungfu-buildchain-kfd-1-release-gate",
+  "status": "passed",
+  "selfContractVerification": {
+    "result": "pass",
+    "contractWorldCount": 1,
+    "selfHosted": true,
+    "responsibility": {
+      "proofOwner": "buildchain-release-passport"
+    }
+  },
+  "metadata": {
+    "standard": {
+      "key": "kfd-1",
+      "id": "KFD-1",
+      "label": "KFD-1",
+      "title": "Facts must not drift: contract worlds need one fact source",
+      "revision": 1,
+      "status": "active"
+    },
+    "schemas": {
+      "ids": {
+        "metadata": "https://kfd.libkungfu.dev/schemas/kfd-standards.schema.json",
+        "contractWorld": "https://kfd.libkungfu.dev/schemas/kfd-1/contract-world.schema.json",
+        "witness": "https://kfd.libkungfu.dev/schemas/kfd-1/witness.schema.json"
+      },
+      "paths": {
+        "metadata": "schemas/kfd-standards.schema.json",
+        "contractWorld": "schemas/kfd-1/contract-world.schema.json",
+        "witness": "schemas/kfd-1/witness.schema.json"
+      },
+      "metadata": {
+        "id": "https://kfd.libkungfu.dev/schemas/kfd-standards.schema.json",
+        "path": "schemas/kfd-standards.schema.json",
+        "version": "1"
+      }
+    },
+    "package": {
+      "name": "@kungfu-tech/kfd",
+      "version": "1.0.0-alpha.21",
+      "repository": "git+https://github.com/kungfu-systems/kfd.git"
+    }
+  },
+  "formatting": {
+    "name": "buildchain-release-evidence-json-v1",
+    "indentation": 2,
+    "trailingNewline": true,
+    "canonicalDigest": "stable-json-sha256-v1"
+  },
+  "contractWorlds": [
+    {
+      "id": "kungfu-contracts",
+      "standard": "KFD-1",
+      "standardKey": "kfd-1",
+      "result": "passed",
+      "preBuildWitnessSha256": "662d5e8c8c58483e8171e4b1cf0d7a6de27367dba360afe6c2ca953fc07162fa",
+      "sourceHashes": {
+        "sha256": "c4d6910390b238fcf81c3f510c629cc0da82fed2e1ada08b10910f4fd1d15ca2",
+        "surfaceCount": 3
+      },
+      "artifactHashes": {
+        "sha256": "f06816adc9306ed3c68ff80fa15631ade6fd3d6aa56b4d451b498e3d0894122d",
+        "surfaceCount": 3
+      },
+      "witness": {
+        "schemaVersion": 1,
+        "contract": "kungfu-buildchain-kfd-1-witness-set",
+        "id": "kungfu-contracts",
+        "standard": "kfd-1",
+        "standardLabel": "KFD-1",
+        "source": {
+          "repo": "kungfu-systems/kungfu",
+          "registry": "framework/contract/kungfu-contracts.registry.json",
+          "policy": "framework/contract/kungfu-agent-first-canonical-policy.json"
+        },
+        "contractWorld": {
+          "schemaId": "https://kfd.libkungfu.dev/schemas/kfd-1/contract-world.schema.json",
+          "digest": "sha256:3aa7446953e91f366d250331e4feb7d6a3608f56e8c5bc12fa01b2fd597ea05d"
+        },
+        "standardContract": {
+          "id": "",
+          "schemaId": "https://kfd.libkungfu.dev/schemas/kfd-1/contract-world.schema.json",
+          "path": "",
+          "sha256": "",
+          "digest": "sha256:3aa7446953e91f366d250331e4feb7d6a3608f56e8c5bc12fa01b2fd597ea05d"
+        },
+        "selfHostingBoundary": {
+          "mode": "external-contract-world",
+          "sourceScope": "KFD source standard metadata, schemas, package exports, and site-consumption entrypoints",
+          "artifactScope": "packaged public artifact surfaces",
+          "boundary": "source-to-artifact byte equality for declared standard-contract surfaces",
+          "residualRisk": []
+        },
+        "responsibility": {
+          "sourceContractOwner": "product",
+          "artifactVerificationOwner": "buildchain-release-passport",
+          "releasePassportProofOwner": "buildchain"
+        },
+        "sourceVerificationRequired": true,
+        "canonicalPolicy": {
+          "path": "framework/contract/kungfu-agent-first-canonical-policy.json",
+          "sha256": "3431fb0df826dae69101258cce785c07ff8902430838f612bee2b628ddd6a0b7"
+        },
+        "registry": {
+          "path": "framework/contract/kungfu-contracts.registry.json",
+          "sha256": "19c8d64633b14b805bebb7f7028ddfb69062564b939dd97cd22fe86b5e93422d"
+        },
+        "surfaces": [
+          {
+            "name": "kungfu-config",
+            "sourcePath": "framework/config/kungfu-config.contract.json",
+            "sourceSha256": "ad21f1f270f47436d7131f2c26524eb882dd67d2c92197aec4c839a7bdac6ecb",
+            "artifactPath": "config/kungfu-config.contract.json",
+            "expectedSha256": "ad21f1f270f47436d7131f2c26524eb882dd67d2c92197aec4c839a7bdac6ecb",
+            "byteForByte": true
+          },
+          {
+            "name": "kungfu-kfx",
+            "sourcePath": "framework/kfx/kungfu-kfx.contract.json",
+            "sourceSha256": "0a585a0557c37a962a58f5ab5bcf8bd97dde8ca531701179cc7433a4a5df8c98",
+            "artifactPath": "config/kungfu-kfx.contract.json",
+            "expectedSha256": "0a585a0557c37a962a58f5ab5bcf8bd97dde8ca531701179cc7433a4a5df8c98",
+            "byteForByte": true
+          },
+          {
+            "name": "kungfu-skill",
+            "sourcePath": "framework/skill/kungfu-skill.contract.json",
+            "sourceSha256": "fb6fbc59557ac8448226f5ed8b97fd71fcf202742e896bb06e2831abeedc2a52",
+            "artifactPath": "config/kungfu-skill.contract.json",
+            "expectedSha256": "fb6fbc59557ac8448226f5ed8b97fd71fcf202742e896bb06e2831abeedc2a52",
+            "byteForByte": true
+          }
+        ],
+        "metadata": {
+          "kfdPackage": {
+            "name": "@kungfu-tech/kfd",
+            "version": "1.0.0-alpha.21",
+            "repository": "git+https://github.com/kungfu-systems/kfd.git"
+          },
+          "schemaIds": {
+            "metadata": "https://kfd.libkungfu.dev/schemas/kfd-standards.schema.json",
+            "contractWorld": "https://kfd.libkungfu.dev/schemas/kfd-1/contract-world.schema.json",
+            "witness": "https://kfd.libkungfu.dev/schemas/kfd-1/witness.schema.json"
+          },
+          "schemaPaths": {
+            "metadata": "schemas/kfd-standards.schema.json",
+            "contractWorld": "schemas/kfd-1/contract-world.schema.json",
+            "witness": "schemas/kfd-1/witness.schema.json"
+          }
+        }
+      },
+      "standardContract": {
+        "id": "",
+        "schemaId": "https://kfd.libkungfu.dev/schemas/kfd-1/contract-world.schema.json",
+        "path": "",
+        "sha256": "",
+        "digest": "sha256:3aa7446953e91f366d250331e4feb7d6a3608f56e8c5bc12fa01b2fd597ea05d"
+      },
+      "selfHostingBoundary": {
+        "mode": "external-contract-world",
+        "sourceScope": "KFD source standard metadata, schemas, package exports, and site-consumption entrypoints",
+        "artifactScope": "packaged public artifact surfaces",
+        "boundary": "source-to-artifact byte equality for declared standard-contract surfaces",
+        "residualRisk": []
+      },
+      "responsibility": {
+        "sourceContractOwner": "product",
+        "artifactVerificationOwner": "buildchain-release-passport",
+        "releasePassportProofOwner": "buildchain"
+      },
+      "sourceVerification": {
+        "status": "passed",
+        "verifiedAt": "1970-01-01T00:00:00.000Z",
+        "required": true,
+        "surfaces": [
+          {
+            "name": "kungfu-config",
+            "sourcePath": "framework/config/kungfu-config.contract.json",
+            "expectedSha256": "ad21f1f270f47436d7131f2c26524eb882dd67d2c92197aec4c839a7bdac6ecb",
+            "actualSha256": "ad21f1f270f47436d7131f2c26524eb882dd67d2c92197aec4c839a7bdac6ecb",
+            "status": "passed",
+            "reason": ""
+          },
+          {
+            "name": "kungfu-kfx",
+            "sourcePath": "framework/kfx/kungfu-kfx.contract.json",
+            "expectedSha256": "0a585a0557c37a962a58f5ab5bcf8bd97dde8ca531701179cc7433a4a5df8c98",
+            "actualSha256": "0a585a0557c37a962a58f5ab5bcf8bd97dde8ca531701179cc7433a4a5df8c98",
+            "status": "passed",
+            "reason": ""
+          },
+          {
+            "name": "kungfu-skill",
+            "sourcePath": "framework/skill/kungfu-skill.contract.json",
+            "expectedSha256": "fb6fbc59557ac8448226f5ed8b97fd71fcf202742e896bb06e2831abeedc2a52",
+            "actualSha256": "fb6fbc59557ac8448226f5ed8b97fd71fcf202742e896bb06e2831abeedc2a52",
+            "status": "passed",
+            "reason": ""
+          }
+        ]
+      },
+      "artifactVerification": {
+        "status": "passed",
+        "verifiedAt": "1970-01-01T00:00:00.000Z",
+        "surfaces": [
+          {
+            "name": "kungfu-config",
+            "sourcePath": "framework/config/kungfu-config.contract.json",
+            "sourceSha256": "ad21f1f270f47436d7131f2c26524eb882dd67d2c92197aec4c839a7bdac6ecb",
+            "artifactPath": "config/kungfu-config.contract.json",
+            "expectedSha256": "ad21f1f270f47436d7131f2c26524eb882dd67d2c92197aec4c839a7bdac6ecb",
+            "actualSha256": "ad21f1f270f47436d7131f2c26524eb882dd67d2c92197aec4c839a7bdac6ecb",
+            "byteForByte": true,
+            "status": "passed",
+            "reason": ""
+          },
+          {
+            "name": "kungfu-kfx",
+            "sourcePath": "framework/kfx/kungfu-kfx.contract.json",
+            "sourceSha256": "0a585a0557c37a962a58f5ab5bcf8bd97dde8ca531701179cc7433a4a5df8c98",
+            "artifactPath": "config/kungfu-kfx.contract.json",
+            "expectedSha256": "0a585a0557c37a962a58f5ab5bcf8bd97dde8ca531701179cc7433a4a5df8c98",
+            "actualSha256": "0a585a0557c37a962a58f5ab5bcf8bd97dde8ca531701179cc7433a4a5df8c98",
+            "byteForByte": true,
+            "status": "passed",
+            "reason": ""
+          },
+          {
+            "name": "kungfu-skill",
+            "sourcePath": "framework/skill/kungfu-skill.contract.json",
+            "sourceSha256": "fb6fbc59557ac8448226f5ed8b97fd71fcf202742e896bb06e2831abeedc2a52",
+            "artifactPath": "config/kungfu-skill.contract.json",
+            "expectedSha256": "fb6fbc59557ac8448226f5ed8b97fd71fcf202742e896bb06e2831abeedc2a52",
+            "actualSha256": "fb6fbc59557ac8448226f5ed8b97fd71fcf202742e896bb06e2831abeedc2a52",
+            "byteForByte": true,
+            "status": "passed",
+            "reason": ""
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/developer/sdk/kfd/kfd-1/verify-result.json
+++ b/developer/sdk/kfd/kfd-1/verify-result.json
@@ -1,0 +1,6 @@
+{
+  "schemaVersion": 1,
+  "contract": "kungfu-buildchain-kfd-1-verify-result",
+  "ok": true,
+  "issues": []
+}

--- a/developer/sdk/kfd/kfd-2/buildchain-claim-args.txt
+++ b/developer/sdk/kfd/kfd-2/buildchain-claim-args.txt
@@ -1,0 +1,3 @@
+--kfd-2-claim-json developer/sdk/kfd/kfd-2/claims/agent-onboarding-pack.json
+--kfd-2-claim-json developer/sdk/kfd/kfd-2/claims/codex-report-receipts.json
+--kfd-2-claim-json developer/sdk/kfd/kfd-2/claims/remote-fact-boundary.json

--- a/developer/sdk/kfd/kfd-2/claims/agent-onboarding-pack.json
+++ b/developer/sdk/kfd/kfd-2/claims/agent-onboarding-pack.json
@@ -1,0 +1,119 @@
+{
+  "id": "agent-onboarding-pack",
+  "public": true,
+  "claim": "Kungfu releases declare an installed agent onboarding pack with machine-readable command and mode metadata, safety boundaries, examples, and verifier coverage.",
+  "sourceBindings": [
+    {
+      "role": "claim-source",
+      "kind": "file",
+      "path": "framework/core/src/python/kungfu/agent/index.json",
+      "sha256": "c6ba4dd9b1c3e97bd6e7853555e4534ed5cdcfdea8fda0d3798a7a545331c62c"
+    }
+  ],
+  "machineEvidence": [
+    {
+      "type": "file",
+      "pointer": {
+        "kind": "file",
+        "path": "framework/core/src/python/kungfu/agent/commands.json",
+        "sha256": "0fadbb02d0e2b49f6bd982a744f9c58448794e7606b9edeb6f2457c28c8404ab"
+      },
+      "description": "Machine-readable command catalog and mode maturity metadata."
+    },
+    {
+      "type": "file",
+      "pointer": {
+        "kind": "file",
+        "path": "framework/core/src/python/kungfu/agent/mode-selection.md",
+        "sha256": "51f32b7c4b5e1eb49cf05a4386b1134c8f019aca984c6a7842b8bec5f972bee2"
+      },
+      "description": "Human and agent-readable mode selection rules."
+    },
+    {
+      "type": "file",
+      "pointer": {
+        "kind": "file",
+        "path": "framework/core/src/python/kungfu/agent/safety.md",
+        "sha256": "7d79f580d229ff16821568b5200746cc17abd68fa7ec533ca8ff2c49b7e7e8c7"
+      },
+      "description": "Fact labels and safety boundaries for observed, reported, imported, and remote evidence."
+    },
+    {
+      "type": "file",
+      "pointer": {
+        "kind": "file",
+        "path": "scripts/verify-agent-pack.mjs",
+        "sha256": "5939f9bc8a6c37c9712db5d31c84b08cbf60416e0a1c5437460629000d3aa4c0"
+      },
+      "description": "Read-only verifier for installed agent pack completeness and command/doc consistency."
+    }
+  ],
+  "hashes": {
+    "registrySha256": "ebf949f99ed5f0d01e9ba22fbc340848144f12f8e126dba586f16bbc786f5952",
+    "sourceSha256": "c6ba4dd9b1c3e97bd6e7853555e4534ed5cdcfdea8fda0d3798a7a545331c62c",
+    "evidenceSha256": [
+      {
+        "path": "framework/core/src/python/kungfu/agent/commands.json",
+        "sha256": "0fadbb02d0e2b49f6bd982a744f9c58448794e7606b9edeb6f2457c28c8404ab"
+      },
+      {
+        "path": "framework/core/src/python/kungfu/agent/mode-selection.md",
+        "sha256": "51f32b7c4b5e1eb49cf05a4386b1134c8f019aca984c6a7842b8bec5f972bee2"
+      },
+      {
+        "path": "framework/core/src/python/kungfu/agent/safety.md",
+        "sha256": "7d79f580d229ff16821568b5200746cc17abd68fa7ec533ca8ff2c49b7e7e8c7"
+      },
+      {
+        "path": "scripts/verify-agent-pack.mjs",
+        "sha256": "5939f9bc8a6c37c9712db5d31c84b08cbf60416e0a1c5437460629000d3aa4c0"
+      }
+    ],
+    "artifactSha256": [
+      {
+        "path": "framework/core/src/python/kungfu/agent/index.json",
+        "sha256": "c6ba4dd9b1c3e97bd6e7853555e4534ed5cdcfdea8fda0d3798a7a545331c62c"
+      },
+      {
+        "path": "framework/core/src/python/kungfu/agent/commands.json",
+        "sha256": "0fadbb02d0e2b49f6bd982a744f9c58448794e7606b9edeb6f2457c28c8404ab"
+      }
+    ]
+  },
+  "artifacts": [
+    {
+      "name": "agent-pack-index",
+      "path": "framework/core/src/python/kungfu/agent/index.json",
+      "sha256": "c6ba4dd9b1c3e97bd6e7853555e4534ed5cdcfdea8fda0d3798a7a545331c62c",
+      "expectedPackagePath": "kungfu/agent/index.json"
+    },
+    {
+      "name": "agent-command-catalog",
+      "path": "framework/core/src/python/kungfu/agent/commands.json",
+      "sha256": "0fadbb02d0e2b49f6bd982a744f9c58448794e7606b9edeb6f2457c28c8404ab",
+      "expectedPackagePath": "kungfu/agent/commands.json"
+    }
+  ],
+  "verification": {
+    "result": "passed",
+    "command": "node scripts/verify-agent-pack.mjs && node scripts/kfd2-release-claims.mjs --check",
+    "expectedResult": "pass"
+  },
+  "auditBoundary": {
+    "scope": "The committed agent onboarding pack files listed in this claim and the verifier checks that enumerate required docs, skills, command catalog entries, safety labels, package data, GUI hint, and TUI hint.",
+    "enumerability": "closed-world",
+    "exclusions": [
+      "Provider CLI behavior outside Kungfu",
+      "User-specific bootstrap policy files under local home directories",
+      "Runtime data and receipts produced after installation"
+    ]
+  },
+  "responsibility": {
+    "sourceOwner": "kungfu",
+    "verificationOwner": "kungfu verify",
+    "releaseDecisionOwner": "kungfu release maintainer",
+    "escalation": "Downgrade the claim if the pack verifier fails or a new public agent command is added without command catalog coverage."
+  },
+  "residualRisk": [],
+  "canonicalStatus": "audited"
+}

--- a/developer/sdk/kfd/kfd-2/claims/codex-report-receipts.json
+++ b/developer/sdk/kfd/kfd-2/claims/codex-report-receipts.json
@@ -1,0 +1,132 @@
+{
+  "id": "codex-report-receipts",
+  "public": true,
+  "claim": "Kungfu report mode exposes a native Codex goal adapter with a verifiable receipt path, and token-only or unknown cost is represented as unknown rather than fabricated zero-dollar cost.",
+  "sourceBindings": [
+    {
+      "role": "claim-source",
+      "kind": "file",
+      "path": "framework/core/src/python/kungfu/cli/commands/codex.py",
+      "sha256": "54dc1ae6436427df7a15551c897c3111a88b529c610f1dd0f16673199e2dec14"
+    }
+  ],
+  "machineEvidence": [
+    {
+      "type": "file",
+      "pointer": {
+        "kind": "file",
+        "path": "framework/core/src/python/kungfu/cli/commands/codex.py",
+        "sha256": "54dc1ae6436427df7a15551c897c3111a88b529c610f1dd0f16673199e2dec14"
+      },
+      "description": "Codex goal report adapter and receipt verifier CLI implementation."
+    },
+    {
+      "type": "file",
+      "pointer": {
+        "kind": "file",
+        "path": "framework/core/src/python/kungfu/rewind/cost/codex.py",
+        "sha256": "859526f1e21f9596d064388b365019858436026aad9628706cabd1d6fe078699"
+      },
+      "description": "Codex cost adapter: tokens are reported, dollar cost remains unknown when not provided by the provider."
+    },
+    {
+      "type": "file",
+      "pointer": {
+        "kind": "file",
+        "path": "framework/core/src/python/kungfu/rewind/cost_wire.py",
+        "sha256": "76887d0ba61675be4fd9e7f11cabce1d1be952f07370a156095b0423d01aba2c"
+      },
+      "description": "Cost wire model preserving known/unknown cost distinction."
+    },
+    {
+      "type": "file",
+      "pointer": {
+        "kind": "file",
+        "path": "framework/core/src/python/kungfu/agent/examples/report-mode.md",
+        "sha256": "ef62de93bb8c9b29e50c18429a6d5c006b19a57bd730768d4d5768a175a5d70c"
+      },
+      "description": "Report-mode user and agent procedure including Codex receipt verification."
+    },
+    {
+      "type": "file",
+      "pointer": {
+        "kind": "file",
+        "path": "framework/core/src/python/kungfu/agent/skills/codex/SKILL.md",
+        "sha256": "5de3db86c56124d952b6732133c9c1c0411951f0c9df4685f629edaee1269d07"
+      },
+      "description": "Codex-side report closeout gate instructions shipped in the agent pack."
+    }
+  ],
+  "hashes": {
+    "registrySha256": "ebf949f99ed5f0d01e9ba22fbc340848144f12f8e126dba586f16bbc786f5952",
+    "sourceSha256": "54dc1ae6436427df7a15551c897c3111a88b529c610f1dd0f16673199e2dec14",
+    "evidenceSha256": [
+      {
+        "path": "framework/core/src/python/kungfu/cli/commands/codex.py",
+        "sha256": "54dc1ae6436427df7a15551c897c3111a88b529c610f1dd0f16673199e2dec14"
+      },
+      {
+        "path": "framework/core/src/python/kungfu/rewind/cost/codex.py",
+        "sha256": "859526f1e21f9596d064388b365019858436026aad9628706cabd1d6fe078699"
+      },
+      {
+        "path": "framework/core/src/python/kungfu/rewind/cost_wire.py",
+        "sha256": "76887d0ba61675be4fd9e7f11cabce1d1be952f07370a156095b0423d01aba2c"
+      },
+      {
+        "path": "framework/core/src/python/kungfu/agent/examples/report-mode.md",
+        "sha256": "ef62de93bb8c9b29e50c18429a6d5c006b19a57bd730768d4d5768a175a5d70c"
+      },
+      {
+        "path": "framework/core/src/python/kungfu/agent/skills/codex/SKILL.md",
+        "sha256": "5de3db86c56124d952b6732133c9c1c0411951f0c9df4685f629edaee1269d07"
+      }
+    ],
+    "artifactSha256": [
+      {
+        "path": "framework/core/src/python/kungfu/cli/commands/codex.py",
+        "sha256": "54dc1ae6436427df7a15551c897c3111a88b529c610f1dd0f16673199e2dec14"
+      },
+      {
+        "path": "framework/core/src/python/kungfu/agent/skills/codex/SKILL.md",
+        "sha256": "5de3db86c56124d952b6732133c9c1c0411951f0c9df4685f629edaee1269d07"
+      }
+    ]
+  },
+  "artifacts": [
+    {
+      "name": "codex-cli-command",
+      "path": "framework/core/src/python/kungfu/cli/commands/codex.py",
+      "sha256": "54dc1ae6436427df7a15551c897c3111a88b529c610f1dd0f16673199e2dec14",
+      "expectedPackagePath": "kungfu/cli/commands/codex.py"
+    },
+    {
+      "name": "codex-agent-skill",
+      "path": "framework/core/src/python/kungfu/agent/skills/codex/SKILL.md",
+      "sha256": "5de3db86c56124d952b6732133c9c1c0411951f0c9df4685f629edaee1269d07",
+      "expectedPackagePath": "kungfu/agent/skills/codex/SKILL.md"
+    }
+  ],
+  "verification": {
+    "result": "passed",
+    "command": "node scripts/verify-agent-pack.mjs && node scripts/kfd2-release-claims.mjs --check",
+    "expectedResult": "pass"
+  },
+  "auditBoundary": {
+    "scope": "The committed Codex report adapter, receipt verifier, cost wire model, report-mode docs, and shipped Codex skill instructions listed in this claim.",
+    "enumerability": "closed-world",
+    "exclusions": [
+      "Provider-side billing pages or private sessions",
+      "Future Codex API fields not emitted to the user or agent",
+      "Human-entered cost overrides outside the receipt verifier"
+    ]
+  },
+  "responsibility": {
+    "sourceOwner": "kungfu",
+    "verificationOwner": "kungfu verify",
+    "releaseDecisionOwner": "kungfu release maintainer",
+    "escalation": "Downgrade the claim if receipt verification stops binding the run id, work id, goal id, status, and reported usage fields."
+  },
+  "residualRisk": [],
+  "canonicalStatus": "audited"
+}

--- a/developer/sdk/kfd/kfd-2/claims/remote-fact-boundary.json
+++ b/developer/sdk/kfd/kfd-2/claims/remote-fact-boundary.json
@@ -1,0 +1,121 @@
+{
+  "id": "remote-fact-boundary",
+  "public": true,
+  "claim": "Kungfu distinguishes local observed facts from reported, imported, and remote facts in the agent pack and remote-sync command surface instead of silently promoting remote evidence into local truth.",
+  "sourceBindings": [
+    {
+      "role": "claim-source",
+      "kind": "file",
+      "path": "framework/core/src/python/kungfu/agent/safety.md",
+      "sha256": "7d79f580d229ff16821568b5200746cc17abd68fa7ec533ca8ff2c49b7e7e8c7"
+    }
+  ],
+  "machineEvidence": [
+    {
+      "type": "file",
+      "pointer": {
+        "kind": "file",
+        "path": "framework/core/src/python/kungfu/agent/safety.md",
+        "sha256": "7d79f580d229ff16821568b5200746cc17abd68fa7ec533ca8ff2c49b7e7e8c7"
+      },
+      "description": "Fact labels for observed, reported, imported, and remote evidence."
+    },
+    {
+      "type": "file",
+      "pointer": {
+        "kind": "file",
+        "path": "framework/core/src/python/kungfu/agent/mode-selection.md",
+        "sha256": "51f32b7c4b5e1eb49cf05a4386b1134c8f019aca984c6a7842b8bec5f972bee2"
+      },
+      "description": "Remote-sync mode rule requiring source-scoped import."
+    },
+    {
+      "type": "file",
+      "pointer": {
+        "kind": "file",
+        "path": "framework/core/src/python/kungfu/agent/commands.json",
+        "sha256": "0fadbb02d0e2b49f6bd982a744f9c58448794e7606b9edeb6f2457c28c8404ab"
+      },
+      "description": "Remote add/sync command declarations and mode metadata."
+    },
+    {
+      "type": "file",
+      "pointer": {
+        "kind": "file",
+        "path": "framework/core/src/python/kungfu/cli/commands/agent.py",
+        "sha256": "d8c195502f678bc34be690769f29c1c8b223fe5ae65ad142fa656e9b3c849b16"
+      },
+      "description": "Agent command surface including mode selection and bootstrap status."
+    }
+  ],
+  "hashes": {
+    "registrySha256": "ebf949f99ed5f0d01e9ba22fbc340848144f12f8e126dba586f16bbc786f5952",
+    "sourceSha256": "7d79f580d229ff16821568b5200746cc17abd68fa7ec533ca8ff2c49b7e7e8c7",
+    "evidenceSha256": [
+      {
+        "path": "framework/core/src/python/kungfu/agent/safety.md",
+        "sha256": "7d79f580d229ff16821568b5200746cc17abd68fa7ec533ca8ff2c49b7e7e8c7"
+      },
+      {
+        "path": "framework/core/src/python/kungfu/agent/mode-selection.md",
+        "sha256": "51f32b7c4b5e1eb49cf05a4386b1134c8f019aca984c6a7842b8bec5f972bee2"
+      },
+      {
+        "path": "framework/core/src/python/kungfu/agent/commands.json",
+        "sha256": "0fadbb02d0e2b49f6bd982a744f9c58448794e7606b9edeb6f2457c28c8404ab"
+      },
+      {
+        "path": "framework/core/src/python/kungfu/cli/commands/agent.py",
+        "sha256": "d8c195502f678bc34be690769f29c1c8b223fe5ae65ad142fa656e9b3c849b16"
+      }
+    ],
+    "artifactSha256": [
+      {
+        "path": "framework/core/src/python/kungfu/agent/safety.md",
+        "sha256": "7d79f580d229ff16821568b5200746cc17abd68fa7ec533ca8ff2c49b7e7e8c7"
+      },
+      {
+        "path": "framework/core/src/python/kungfu/agent/mode-selection.md",
+        "sha256": "51f32b7c4b5e1eb49cf05a4386b1134c8f019aca984c6a7842b8bec5f972bee2"
+      }
+    ]
+  },
+  "artifacts": [
+    {
+      "name": "agent-safety-doc",
+      "path": "framework/core/src/python/kungfu/agent/safety.md",
+      "sha256": "7d79f580d229ff16821568b5200746cc17abd68fa7ec533ca8ff2c49b7e7e8c7",
+      "expectedPackagePath": "kungfu/agent/safety.md"
+    },
+    {
+      "name": "agent-mode-selection-doc",
+      "path": "framework/core/src/python/kungfu/agent/mode-selection.md",
+      "sha256": "51f32b7c4b5e1eb49cf05a4386b1134c8f019aca984c6a7842b8bec5f972bee2",
+      "expectedPackagePath": "kungfu/agent/mode-selection.md"
+    }
+  ],
+  "verification": {
+    "result": "passed-with-residual-risk",
+    "command": "node scripts/verify-agent-pack.mjs && node scripts/kfd2-release-claims.mjs --check",
+    "expectedResult": "pass"
+  },
+  "auditBoundary": {
+    "scope": "The committed agent safety and mode-selection documents, machine-readable commands catalog, and agent CLI command implementation listed in this claim.",
+    "enumerability": "declared-open",
+    "exclusions": [
+      "Actual network transport availability",
+      "Remote host identity outside locally recorded source metadata",
+      "User decisions to manually promote imported evidence"
+    ]
+  },
+  "responsibility": {
+    "sourceOwner": "kungfu",
+    "verificationOwner": "kungfu verify",
+    "releaseDecisionOwner": "kungfu release maintainer",
+    "escalation": "Keep this claim downgraded or human-reviewed while remote-sync remains an experimental surface."
+  },
+  "residualRisk": [
+    "Remote evidence freshness and identity depend on the configured source runtime and must remain source-scoped until a later command explicitly promotes it."
+  ],
+  "canonicalStatus": "audited"
+}

--- a/developer/sdk/kfd/kfd-2/release-claims.json
+++ b/developer/sdk/kfd/kfd-2/release-claims.json
@@ -1,0 +1,240 @@
+{
+  "schemaVersion": 1,
+  "contract": "kfd-2-release-claims",
+  "standard": "kfd-2",
+  "product": {
+    "name": "Kungfu",
+    "repository": "kungfu-systems/kungfu",
+    "package": "@kungfu-tech/artifact-kungfu"
+  },
+  "release": {
+    "version": "4.0.0-alpha.0",
+    "channel": "dev/v4/v4.0",
+    "tag": "v4.0.0-alpha.0",
+    "sourceSha": "local-dev-snapshot"
+  },
+  "claims": [
+    {
+      "id": "agent-onboarding-pack",
+      "statement": "Kungfu releases declare an installed agent onboarding pack with machine-readable command and mode metadata, safety boundaries, examples, and verifier coverage.",
+      "category": "kfd-2",
+      "source": {
+        "kind": "file",
+        "path": "framework/core/src/python/kungfu/agent/index.json",
+        "sha256": "c6ba4dd9b1c3e97bd6e7853555e4534ed5cdcfdea8fda0d3798a7a545331c62c"
+      },
+      "evidence": [
+        {
+          "type": "file",
+          "pointer": {
+            "kind": "file",
+            "path": "framework/core/src/python/kungfu/agent/commands.json",
+            "sha256": "0fadbb02d0e2b49f6bd982a744f9c58448794e7606b9edeb6f2457c28c8404ab"
+          },
+          "description": "Machine-readable command catalog and mode maturity metadata."
+        },
+        {
+          "type": "file",
+          "pointer": {
+            "kind": "file",
+            "path": "framework/core/src/python/kungfu/agent/mode-selection.md",
+            "sha256": "51f32b7c4b5e1eb49cf05a4386b1134c8f019aca984c6a7842b8bec5f972bee2"
+          },
+          "description": "Human and agent-readable mode selection rules."
+        },
+        {
+          "type": "file",
+          "pointer": {
+            "kind": "file",
+            "path": "framework/core/src/python/kungfu/agent/safety.md",
+            "sha256": "7d79f580d229ff16821568b5200746cc17abd68fa7ec533ca8ff2c49b7e7e8c7"
+          },
+          "description": "Fact labels and safety boundaries for observed, reported, imported, and remote evidence."
+        },
+        {
+          "type": "file",
+          "pointer": {
+            "kind": "file",
+            "path": "scripts/verify-agent-pack.mjs",
+            "sha256": "5939f9bc8a6c37c9712db5d31c84b08cbf60416e0a1c5437460629000d3aa4c0"
+          },
+          "description": "Read-only verifier for installed agent pack completeness and command/doc consistency."
+        }
+      ],
+      "verification": {
+        "command": "node scripts/verify-agent-pack.mjs && node scripts/kfd2-release-claims.mjs --check",
+        "expectedResult": "pass"
+      },
+      "auditBoundary": {
+        "scope": "The committed agent onboarding pack files listed in this claim and the verifier checks that enumerate required docs, skills, command catalog entries, safety labels, package data, GUI hint, and TUI hint.",
+        "enumerability": "closed-world",
+        "exclusions": [
+          "Provider CLI behavior outside Kungfu",
+          "User-specific bootstrap policy files under local home directories",
+          "Runtime data and receipts produced after installation"
+        ]
+      },
+      "residualRisk": [],
+      "responsibility": {
+        "sourceOwner": "kungfu",
+        "verificationOwner": "kungfu verify",
+        "releaseDecisionOwner": "kungfu release maintainer",
+        "escalation": "Downgrade the claim if the pack verifier fails or a new public agent command is added without command catalog coverage."
+      },
+      "status": "audited"
+    },
+    {
+      "id": "codex-report-receipts",
+      "statement": "Kungfu report mode exposes a native Codex goal adapter with a verifiable receipt path, and token-only or unknown cost is represented as unknown rather than fabricated zero-dollar cost.",
+      "category": "kfd-2",
+      "source": {
+        "kind": "file",
+        "path": "framework/core/src/python/kungfu/cli/commands/codex.py",
+        "sha256": "54dc1ae6436427df7a15551c897c3111a88b529c610f1dd0f16673199e2dec14"
+      },
+      "evidence": [
+        {
+          "type": "file",
+          "pointer": {
+            "kind": "file",
+            "path": "framework/core/src/python/kungfu/cli/commands/codex.py",
+            "sha256": "54dc1ae6436427df7a15551c897c3111a88b529c610f1dd0f16673199e2dec14"
+          },
+          "description": "Codex goal report adapter and receipt verifier CLI implementation."
+        },
+        {
+          "type": "file",
+          "pointer": {
+            "kind": "file",
+            "path": "framework/core/src/python/kungfu/rewind/cost/codex.py",
+            "sha256": "859526f1e21f9596d064388b365019858436026aad9628706cabd1d6fe078699"
+          },
+          "description": "Codex cost adapter: tokens are reported, dollar cost remains unknown when not provided by the provider."
+        },
+        {
+          "type": "file",
+          "pointer": {
+            "kind": "file",
+            "path": "framework/core/src/python/kungfu/rewind/cost_wire.py",
+            "sha256": "76887d0ba61675be4fd9e7f11cabce1d1be952f07370a156095b0423d01aba2c"
+          },
+          "description": "Cost wire model preserving known/unknown cost distinction."
+        },
+        {
+          "type": "file",
+          "pointer": {
+            "kind": "file",
+            "path": "framework/core/src/python/kungfu/agent/examples/report-mode.md",
+            "sha256": "ef62de93bb8c9b29e50c18429a6d5c006b19a57bd730768d4d5768a175a5d70c"
+          },
+          "description": "Report-mode user and agent procedure including Codex receipt verification."
+        },
+        {
+          "type": "file",
+          "pointer": {
+            "kind": "file",
+            "path": "framework/core/src/python/kungfu/agent/skills/codex/SKILL.md",
+            "sha256": "5de3db86c56124d952b6732133c9c1c0411951f0c9df4685f629edaee1269d07"
+          },
+          "description": "Codex-side report closeout gate instructions shipped in the agent pack."
+        }
+      ],
+      "verification": {
+        "command": "node scripts/verify-agent-pack.mjs && node scripts/kfd2-release-claims.mjs --check",
+        "expectedResult": "pass"
+      },
+      "auditBoundary": {
+        "scope": "The committed Codex report adapter, receipt verifier, cost wire model, report-mode docs, and shipped Codex skill instructions listed in this claim.",
+        "enumerability": "closed-world",
+        "exclusions": [
+          "Provider-side billing pages or private sessions",
+          "Future Codex API fields not emitted to the user or agent",
+          "Human-entered cost overrides outside the receipt verifier"
+        ]
+      },
+      "residualRisk": [],
+      "responsibility": {
+        "sourceOwner": "kungfu",
+        "verificationOwner": "kungfu verify",
+        "releaseDecisionOwner": "kungfu release maintainer",
+        "escalation": "Downgrade the claim if receipt verification stops binding the run id, work id, goal id, status, and reported usage fields."
+      },
+      "status": "audited"
+    },
+    {
+      "id": "remote-fact-boundary",
+      "statement": "Kungfu distinguishes local observed facts from reported, imported, and remote facts in the agent pack and remote-sync command surface instead of silently promoting remote evidence into local truth.",
+      "category": "kfd-2",
+      "source": {
+        "kind": "file",
+        "path": "framework/core/src/python/kungfu/agent/safety.md",
+        "sha256": "7d79f580d229ff16821568b5200746cc17abd68fa7ec533ca8ff2c49b7e7e8c7"
+      },
+      "evidence": [
+        {
+          "type": "file",
+          "pointer": {
+            "kind": "file",
+            "path": "framework/core/src/python/kungfu/agent/safety.md",
+            "sha256": "7d79f580d229ff16821568b5200746cc17abd68fa7ec533ca8ff2c49b7e7e8c7"
+          },
+          "description": "Fact labels for observed, reported, imported, and remote evidence."
+        },
+        {
+          "type": "file",
+          "pointer": {
+            "kind": "file",
+            "path": "framework/core/src/python/kungfu/agent/mode-selection.md",
+            "sha256": "51f32b7c4b5e1eb49cf05a4386b1134c8f019aca984c6a7842b8bec5f972bee2"
+          },
+          "description": "Remote-sync mode rule requiring source-scoped import."
+        },
+        {
+          "type": "file",
+          "pointer": {
+            "kind": "file",
+            "path": "framework/core/src/python/kungfu/agent/commands.json",
+            "sha256": "0fadbb02d0e2b49f6bd982a744f9c58448794e7606b9edeb6f2457c28c8404ab"
+          },
+          "description": "Remote add/sync command declarations and mode metadata."
+        },
+        {
+          "type": "file",
+          "pointer": {
+            "kind": "file",
+            "path": "framework/core/src/python/kungfu/cli/commands/agent.py",
+            "sha256": "d8c195502f678bc34be690769f29c1c8b223fe5ae65ad142fa656e9b3c849b16"
+          },
+          "description": "Agent command surface including mode selection and bootstrap status."
+        }
+      ],
+      "verification": {
+        "command": "node scripts/verify-agent-pack.mjs && node scripts/kfd2-release-claims.mjs --check",
+        "expectedResult": "pass"
+      },
+      "auditBoundary": {
+        "scope": "The committed agent safety and mode-selection documents, machine-readable commands catalog, and agent CLI command implementation listed in this claim.",
+        "enumerability": "declared-open",
+        "exclusions": [
+          "Actual network transport availability",
+          "Remote host identity outside locally recorded source metadata",
+          "User decisions to manually promote imported evidence"
+        ]
+      },
+      "residualRisk": [
+        "Remote evidence freshness and identity depend on the configured source runtime and must remain source-scoped until a later command explicitly promotes it."
+      ],
+      "responsibility": {
+        "sourceOwner": "kungfu",
+        "verificationOwner": "kungfu verify",
+        "releaseDecisionOwner": "kungfu release maintainer",
+        "escalation": "Keep this claim downgraded or human-reviewed while remote-sync remains an experimental surface."
+      },
+      "status": "audited"
+    }
+  ],
+  "schemaEvolution": {
+    "interfaceVersion": 1,
+    "compatibilityRule": "Compatible additions may keep schemaVersion 1; required-field or semantic changes require a new KFD-owned interface version."
+  }
+}

--- a/developer/sdk/kfd/kfd-3-surfaces.json
+++ b/developer/sdk/kfd/kfd-3-surfaces.json
@@ -53,7 +53,7 @@
       "libnode": "22.22.3-kf.3-alpha.16",
       "buildchain": "2.10.8"
     },
-    "digest": "sha256:ff46f99bd15d4495f7890d04577ba91cd8bcb95605fa921313dcd272490182d4"
+    "digest": "sha256:f0eb882f9f2e011f7dd89b5fb41a30f62883560480822c3e71c633b60e43fe2e"
   },
   "surfaces": [
     {

--- a/developer/sdk/kfd/upstream-aggregate.json
+++ b/developer/sdk/kfd/upstream-aggregate.json
@@ -150,7 +150,11 @@
       "sha256": "sha256:19c8d64633b14b805bebb7f7028ddfb69062564b939dd97cd22fe86b5e93422d",
       "contractCount": 3,
       "witnessCommand": "kungfu sdk contract witness --json",
-      "releasePassportInput": "--kfd-1-witness-json"
+      "gateCommand": "kungfu sdk kfd 1 gate --json",
+      "verifyCommand": "kungfu sdk kfd 1 verify --json",
+      "releasePassportInput": "--kfd-1-witness-json",
+      "releaseGate": "developer/sdk/kfd/kfd-1/release-gate.json",
+      "verifyResult": "developer/sdk/kfd/kfd-1/verify-result.json"
     },
     "kfd2": {
       "status": "supported",
@@ -159,7 +163,9 @@
       "sha256": "sha256:ebf949f99ed5f0d01e9ba22fbc340848144f12f8e126dba586f16bbc786f5952",
       "claimCount": 3,
       "claimsCommand": "kungfu sdk kfd 2 claims --json",
-      "releasePassportInput": "--kfd-2-claim-json"
+      "releasePassportInput": "--kfd-2-claim-json",
+      "releaseClaims": "developer/sdk/kfd/kfd-2/release-claims.json",
+      "buildchainClaimArgs": "developer/sdk/kfd/kfd-2/buildchain-claim-args.txt"
     },
     "kfd3": {
       "status": "supported",

--- a/developer/sdk/src/sdk.js
+++ b/developer/sdk/src/sdk.js
@@ -59,6 +59,37 @@ const SDK_KFD_UPSTREAM_AGGREGATE = path.join(
   'kfd',
   'upstream-aggregate.json',
 );
+const SDK_KFD1_WITNESS = path.join(
+  SDK_ROOT,
+  'kfd',
+  'kfd-1',
+  'contract-world.witness.json',
+);
+const SDK_KFD1_RELEASE_GATE = path.join(
+  SDK_ROOT,
+  'kfd',
+  'kfd-1',
+  'release-gate.json',
+);
+const SDK_KFD1_VERIFY_RESULT = path.join(
+  SDK_ROOT,
+  'kfd',
+  'kfd-1',
+  'verify-result.json',
+);
+const SDK_KFD2_RELEASE_CLAIMS = path.join(
+  SDK_ROOT,
+  'kfd',
+  'kfd-2',
+  'release-claims.json',
+);
+const SDK_KFD2_CLAIMS_DIR = path.join(SDK_ROOT, 'kfd', 'kfd-2', 'claims');
+const SDK_KFD2_CLAIM_ARGS = path.join(
+  SDK_ROOT,
+  'kfd',
+  'kfd-2',
+  'buildchain-claim-args.txt',
+);
 const isWin = process.platform === 'win32';
 
 /**
@@ -81,7 +112,7 @@ function usage(code) {
       '       kungfu sdk contract add <surface> [--source <path>] [--json]',
       '       kungfu sdk kfd status [--json]',
       '       kungfu sdk kfd schema <kfd-1|kfd-2|kfd-3|kfd-4> [--schema <name>] [--json]',
-      '       kungfu sdk kfd 1 status|schema|witness [--json]',
+      '       kungfu sdk kfd 1 status|schema|witness|gate|verify [--json]',
       '       kungfu sdk kfd 2 status|schema|claims|trust-claims|trust-assessment [--json]',
       '       kungfu sdk kfd 4 status|schema [--json]',
       '       kungfu sdk kfd query|check|witness|upstream|aggregate [--json]',
@@ -2732,6 +2763,151 @@ function kfdSchemaSummary() {
 }
 
 /**
+ * @returns {string}
+ */
+function resolvePackagedKfd1Witness() {
+  if (fs.existsSync(SDK_KFD1_WITNESS)) return SDK_KFD1_WITNESS;
+  fail(
+    'SDK packaged KFD-1 witness not found; run ./kungfu-code kfd:buildchain in the Kungfu checkout before packaging',
+  );
+}
+
+/**
+ * @returns {string}
+ */
+function resolvePackagedKfd1ReleaseGate() {
+  if (fs.existsSync(SDK_KFD1_RELEASE_GATE)) return SDK_KFD1_RELEASE_GATE;
+  fail(
+    'SDK packaged KFD-1 release gate not found; run ./kungfu-code kfd:buildchain in the Kungfu checkout before packaging',
+  );
+}
+
+/**
+ * @returns {string}
+ */
+function resolvePackagedKfd1VerifyResult() {
+  if (fs.existsSync(SDK_KFD1_VERIFY_RESULT)) return SDK_KFD1_VERIFY_RESULT;
+  fail(
+    'SDK packaged KFD-1 verify result not found; run ./kungfu-code kfd:buildchain in the Kungfu checkout before packaging',
+  );
+}
+
+/**
+ * @returns {Record<string, any>}
+ */
+function readKfd1Witness() {
+  try {
+    return buildContractWorldWitness(locateRepoRoot(process.cwd()));
+  } catch {
+    return /** @type {Record<string, any>} */ (
+      readJson(resolvePackagedKfd1Witness())
+    );
+  }
+}
+
+/**
+ * @param {Record<string, any>} witness
+ * @returns {Record<string, any>}
+ */
+function buildKfd1ReleaseGate(witness) {
+  const repoRoot = (() => {
+    try {
+      return locateRepoRoot(process.cwd());
+    } catch {
+      return '';
+    }
+  })();
+  if (!repoRoot) {
+    return /** @type {Record<string, any>} */ (
+      readJson(resolvePackagedKfd1ReleaseGate())
+    );
+  }
+  const gate = createKfd1ReleaseGateEvidence({
+    cwd: repoRoot,
+    artifacts: Array.isArray(witness.surfaces)
+      ? witness.surfaces.map((surface) => ({
+          name: surface.artifactPath,
+          sourcePath: path.resolve(repoRoot, surface.sourcePath),
+        }))
+      : [],
+    witnesses: [witness],
+    verifiedAt: '1970-01-01T00:00:00.000Z',
+  })?.passportSection;
+  if (!gate) fail('KFD-1 release gate could not be created from the witness');
+  return gate;
+}
+
+/**
+ * @param {Record<string, any>} releaseGate
+ * @returns {Record<string, any>}
+ */
+function buildKfd1VerifyResult(releaseGate) {
+  const issues = validateKfd1ReleaseGateEvidence(releaseGate);
+  return {
+    schemaVersion: 1,
+    contract: 'kungfu-buildchain-kfd-1-verify-result',
+    ok: issues.length === 0,
+    issues,
+  };
+}
+
+/**
+ * @returns {Record<string, any>}
+ */
+function readKfd2ClaimsDocument() {
+  if (!fs.existsSync(SDK_KFD2_RELEASE_CLAIMS)) {
+    fail(
+      'SDK packaged KFD-2 release claims not found; run ./kungfu-code kfd:buildchain in the Kungfu checkout before packaging',
+    );
+  }
+  const releaseClaims = /** @type {Record<string, any>} */ (
+    readJson(SDK_KFD2_RELEASE_CLAIMS)
+  );
+  const claims = fs.existsSync(SDK_KFD2_CLAIMS_DIR)
+    ? fs
+        .readdirSync(SDK_KFD2_CLAIMS_DIR)
+        .filter((name) => name.endsWith('.json'))
+        .sort()
+        .map((name) => {
+          const file = path.join(SDK_KFD2_CLAIMS_DIR, name);
+          return {
+            path: path.relative(process.cwd(), file) || '.',
+            sha256: sha256File(file),
+            document: readJson(file),
+          };
+        })
+    : [];
+  return {
+    schemaVersion: 1,
+    contract: 'kungfu-sdk-kfd-2-release-claims',
+    standard: 'kfd-2',
+    metadata: kfd2.resolveMetadata(),
+    source: {
+      releaseClaims: {
+        path: path.relative(process.cwd(), SDK_KFD2_RELEASE_CLAIMS) || '.',
+        sha256: sha256File(SDK_KFD2_RELEASE_CLAIMS),
+      },
+      buildchainClaimArgs: fs.existsSync(SDK_KFD2_CLAIM_ARGS)
+        ? {
+            path: path.relative(process.cwd(), SDK_KFD2_CLAIM_ARGS) || '.',
+            sha256: sha256File(SDK_KFD2_CLAIM_ARGS),
+          }
+        : null,
+    },
+    releaseClaims,
+    buildchainProjection: {
+      claimInput: '--kfd-2-claim-json',
+      claimCount: claims.length,
+      claims,
+    },
+    releaseGate: {
+      passportInput: '--kfd-2-claim-json',
+      finalTrust: 'query-buildchain-release-passport',
+    },
+  };
+}
+
+/**
  * @param {Record<string, any>} registry
  * @param {string} registryPath
  * @param {Record<string, any>} aggregate
@@ -2767,6 +2943,8 @@ function buildKfdStandardsStatus(registry, registryPath, aggregate) {
           'kungfu sdk contract witness --json',
           'kungfu sdk contract audit --json',
           'kungfu sdk kfd 1 witness --json',
+          'kungfu sdk kfd 1 gate --json',
+          'kungfu sdk kfd 1 verify --json',
         ],
         schemaCount: schemas.standards['kfd-1']?.length || 0,
         source: ownKfd.kfd1 || {
@@ -2818,7 +2996,7 @@ function buildKfdStandardsStatus(registry, registryPath, aggregate) {
       },
     },
     support: {
-      'kfd-1': ['status', 'schema', 'witness'],
+      'kfd-1': ['status', 'schema', 'witness', 'gate', 'verify'],
       'kfd-2': [
         'status',
         'schema',
@@ -3079,17 +3257,38 @@ async function kfd(command, args, options) {
       return;
     }
     if (action === 'witness') {
-      const { aggregate } = readKfdUpstreamAggregate();
-      const witness = kfd1SupportWitness(registry, registryPath, aggregate);
+      const witness = readKfd1Witness();
       if (options.json)
         process.stdout.write(`${JSON.stringify(witness, null, 2)}\n`);
       else
         process.stdout.write(
-          `Kungfu KFD-1 witness: ${witness.surfaces.length} surface(s)\n`,
+          `Kungfu KFD-1 witness: ${witness.surfaces?.length || 0} surface(s)\n`,
         );
       return;
     }
-    fail('unknown kfd 1 command (supported: status, schema, witness)');
+    if (action === 'gate') {
+      const gate = buildKfd1ReleaseGate(readKfd1Witness());
+      if (options.json)
+        process.stdout.write(`${JSON.stringify(gate, null, 2)}\n`);
+      else process.stdout.write(`Kungfu KFD-1 gate: ${gate.status}\n`);
+      return;
+    }
+    if (action === 'verify') {
+      const result = buildKfd1VerifyResult(
+        buildKfd1ReleaseGate(readKfd1Witness()),
+      );
+      if (options.json)
+        process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+      else
+        process.stdout.write(
+          `Kungfu KFD-1 verify: ${result.ok ? 'ok' : 'failed'}\n`,
+        );
+      if (!result.ok) process.exitCode = 1;
+      return;
+    }
+    fail(
+      'unknown kfd 1 command (supported: status, schema, witness, gate, verify)',
+    );
   }
   if (['2', 'kfd-2'].includes(String(command || '').toLowerCase())) {
     const action = args[0] || 'status';
@@ -3110,11 +3309,13 @@ async function kfd(command, args, options) {
       return;
     }
     if (action === 'claims') {
-      const { aggregate } = readKfdUpstreamAggregate();
-      const claims = kfd2ClaimSummary(aggregate);
+      const claims = readKfd2ClaimsDocument();
       if (options.json)
         process.stdout.write(`${JSON.stringify(claims, null, 2)}\n`);
-      else process.stdout.write('Kungfu KFD-2 claims: packaged\n');
+      else
+        process.stdout.write(
+          `Kungfu KFD-2 claims: ${claims.buildchainProjection.claimCount} packaged claim(s)\n`,
+        );
       return;
     }
     if (action === 'trust-claims') {

--- a/developer/sdk/tests/contract-cli.test.mjs
+++ b/developer/sdk/tests/contract-cli.test.mjs
@@ -304,14 +304,27 @@ test('kfd status exposes KFD-1/2/3/4 support facts', () => {
 
 test('kfd standard commands expose KFD-1, KFD-2, and KFD-4 facts', () => {
   const kfd1 = runJson(['kfd', '1', 'witness', '--json']);
-  assert.equal(kfd1.contract, 'kungfu-sdk-kfd-1-support-witness');
+  assert.equal(kfd1.contract, 'kungfu-buildchain-kfd-1-witness-set');
   assert.equal(kfd1.standard, 'kfd-1');
   assert.ok(kfd1.surfaces.length >= 1);
+
+  const kfd1Gate = runJson(['kfd', '1', 'gate', '--json']);
+  assert.equal(kfd1Gate.contract, 'kungfu-buildchain-kfd-1-release-gate');
+  assert.equal(kfd1Gate.status, 'passed');
+  assert.equal(kfd1Gate.contractWorlds.length, 1);
+
+  const kfd1Verify = runJson(['kfd', '1', 'verify', '--json']);
+  assert.equal(kfd1Verify.contract, 'kungfu-buildchain-kfd-1-verify-result');
+  assert.equal(kfd1Verify.ok, true);
+  assert.deepEqual(kfd1Verify.issues, []);
 
   const kfd2 = runJson(['kfd', '2', 'claims', '--json']);
   assert.equal(kfd2.contract, 'kungfu-sdk-kfd-2-release-claims');
   assert.equal(kfd2.standard, 'kfd-2');
-  assert.equal(kfd2.source.claimCount, 3);
+  assert.equal(kfd2.releaseClaims.contract, 'kfd-2-release-claims');
+  assert.equal(kfd2.releaseClaims.claims.length, 3);
+  assert.equal(kfd2.buildchainProjection.claimCount, 3);
+  assert.equal(kfd2.buildchainProjection.claims.length, 3);
   assert.equal(kfd2.releaseGate.passportInput, '--kfd-2-claim-json');
 
   const kfd4 = runJson(['kfd', '4', 'schema', '--json']);

--- a/scripts/buildchain-kfd-evidence.mjs
+++ b/scripts/buildchain-kfd-evidence.mjs
@@ -6,10 +6,11 @@ import { execFileSync, spawnSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import fs from 'node:fs';
 import { createRequire } from 'node:module';
+import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { BUILDCHAIN_KFD3_SURFACE_REGISTRY_PATH as KFD3_DEFAULT_REGISTRY_PATH } from '@kungfu-tech/buildchain/buildchain-layout';
-import { kfd3 } from '@kungfu-tech/buildchain/kfd';
+import { kfd1, kfd3 } from '@kungfu-tech/buildchain/kfd';
 
 const KFD3_SURFACE_REGISTRY_CONTRACT =
   'kungfu-buildchain-kfd-3-surface-registry';
@@ -26,6 +27,16 @@ const KFD1_WITNESS_PATH = path.join(
   BUILDCHAIN_DIR,
   'kfd-1',
   'contract-world.witness.json',
+);
+const KFD1_RELEASE_GATE_PATH = path.join(
+  BUILDCHAIN_DIR,
+  'kfd-1',
+  'release-gate.json',
+);
+const KFD1_VERIFY_RESULT_PATH = path.join(
+  BUILDCHAIN_DIR,
+  'kfd-1',
+  'verify-result.json',
 );
 const KFD2_OUTPUT_DIR = path.join(BUILDCHAIN_DIR, 'kfd-2');
 const KFD3_OUTPUT_DIR = path.join(BUILDCHAIN_DIR, 'kfd-3');
@@ -44,6 +55,20 @@ const SDK_KFD_UPSTREAM_AGGREGATE_PATH = path.join(
   'kfd',
   'upstream-aggregate.json',
 );
+const SDK_KFD1_OUTPUT_DIR = path.join(ROOT, 'developer', 'sdk', 'kfd', 'kfd-1');
+const SDK_KFD1_WITNESS_PATH = path.join(
+  SDK_KFD1_OUTPUT_DIR,
+  'contract-world.witness.json',
+);
+const SDK_KFD1_RELEASE_GATE_PATH = path.join(
+  SDK_KFD1_OUTPUT_DIR,
+  'release-gate.json',
+);
+const SDK_KFD1_VERIFY_RESULT_PATH = path.join(
+  SDK_KFD1_OUTPUT_DIR,
+  'verify-result.json',
+);
+const SDK_KFD2_OUTPUT_DIR = path.join(ROOT, 'developer', 'sdk', 'kfd', 'kfd-2');
 const KFD3_PREBUILD_WITNESS_PATH = path.join(
   KFD3_OUTPUT_DIR,
   'collaboration-interface.prebuild.json',
@@ -96,6 +121,8 @@ const CORE_PACKAGE_PATH = path.join(ROOT, 'framework', 'core', 'package.json');
 const ARTIFACT_VERIFY_COMMAND =
   'node scripts/buildchain-kfd-evidence.mjs --artifact-witness --json';
 const STRICT_KFD3_MODE = 'strict-buildchain-managed-registry';
+const KFD_EVIDENCE_SOURCE_SHA =
+  process.env.KUNGFU_KFD_SOURCE_SHA || 'local-dev-snapshot';
 
 function usage() {
   return `Usage:
@@ -109,7 +136,15 @@ Writes:
   developer/sdk/kfd/kfd-3-surfaces.json
   developer/sdk/kfd/upstream-aggregate.json
   .buildchain/kfd-1/contract-world.witness.json
+  .buildchain/kfd-1/release-gate.json
+  .buildchain/kfd-1/verify-result.json
   .buildchain/kfd-2/claims/<claim-id>.json
+  .buildchain/kfd-2/release-claims.json
+  developer/sdk/kfd/kfd-1/contract-world.witness.json
+  developer/sdk/kfd/kfd-1/release-gate.json
+  developer/sdk/kfd/kfd-1/verify-result.json
+  developer/sdk/kfd/kfd-2/release-claims.json
+  developer/sdk/kfd/kfd-2/claims/<claim-id>.json
   .buildchain/kfd-3/collaboration-interface.prebuild.json
   .buildchain/kfd-3/collaboration-interface.artifact.json
   .buildchain/kfd-3/capability-query.json
@@ -182,6 +217,10 @@ function sha256Json(value) {
 
 function sha256File(filePath) {
   return createHash('sha256').update(fs.readFileSync(filePath)).digest('hex');
+}
+
+function sha256RenderedJson(value) {
+  return sha256Text(renderJson(value));
 }
 
 function packageResolver(baseFile) {
@@ -266,7 +305,11 @@ function buildOwnKfdFacts() {
         ? contractRegistry.contracts.length
         : 0,
       witnessCommand: 'kungfu sdk contract witness --json',
+      gateCommand: 'kungfu sdk kfd 1 gate --json',
+      verifyCommand: 'kungfu sdk kfd 1 verify --json',
       releasePassportInput: '--kfd-1-witness-json',
+      releaseGate: rel(SDK_KFD1_RELEASE_GATE_PATH),
+      verifyResult: rel(SDK_KFD1_VERIFY_RESULT_PATH),
     },
     kfd2: {
       status: 'supported',
@@ -280,6 +323,8 @@ function buildOwnKfdFacts() {
         : 0,
       claimsCommand: 'kungfu sdk kfd 2 claims --json',
       releasePassportInput: '--kfd-2-claim-json',
+      releaseClaims: `${rel(SDK_KFD2_OUTPUT_DIR)}/release-claims.json`,
+      buildchainClaimArgs: `${rel(SDK_KFD2_OUTPUT_DIR)}/buildchain-claim-args.txt`,
     },
     kfd3: {
       status: 'supported',
@@ -882,6 +927,17 @@ function assertCurrent(filePath, value, label) {
   }
 }
 
+function assertSameFile(expectedPath, actualPath, label) {
+  if (!fs.existsSync(actualPath)) {
+    throw new Error(`${label} is missing: ${rel(actualPath)}`);
+  }
+  const expected = fs.readFileSync(expectedPath, 'utf8');
+  const actual = fs.readFileSync(actualPath, 'utf8');
+  if (expected !== actual) {
+    throw new Error(`${label} is stale: ${rel(actualPath)}`);
+  }
+}
+
 function buildKfd1Witness() {
   return runNodeScript([
     'developer/sdk/src/sdk.js',
@@ -891,12 +947,98 @@ function buildKfd1Witness() {
   ]);
 }
 
-function buildKfd2Claims({ write }) {
+function buildKfd1ReleaseGate(kfd1Witness) {
+  return kfd1.createReleaseGateEvidence({
+    cwd: ROOT,
+    artifacts: (kfd1Witness.surfaces || []).map((surface) => ({
+      name: surface.artifactPath,
+      sourcePath: path.resolve(ROOT, surface.sourcePath),
+    })),
+    witnesses: [kfd1Witness],
+    verifiedAt: '1970-01-01T00:00:00.000Z',
+  })?.passportSection;
+}
+
+function buildKfd1VerifyResult(kfd1Gate) {
+  const issues = kfd1.validateReleaseGateEvidence(kfd1Gate);
+  return {
+    schemaVersion: 1,
+    contract: 'kungfu-buildchain-kfd-1-verify-result',
+    ok: issues.length === 0,
+    issues,
+  };
+}
+
+function buildKfd2Claims({ write, outputDir = KFD2_OUTPUT_DIR }) {
   return runNodeScript([
     'scripts/kfd2-release-claims.mjs',
     write ? '--write' : '--check',
+    '--output-dir',
+    outputDir,
+    '--source-sha',
+    KFD_EVIDENCE_SOURCE_SHA,
     '--json',
   ]);
+}
+
+function writeKfd2PackagedOutputs(outputDir) {
+  return buildKfd2Claims({ write: true, outputDir });
+}
+
+function assertCurrentKfd2Output(outputDir, label) {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kungfu-kfd2-check-'));
+  try {
+    const expected = writeKfd2PackagedOutputs(tmpDir);
+    const releaseClaimsPath = path.join(outputDir, 'release-claims.json');
+    assertSameFile(
+      path.join(tmpDir, 'release-claims.json'),
+      releaseClaimsPath,
+      `${label} release claims`,
+    );
+    for (const claim of expected.buildchainProjection?.claims || []) {
+      const fileName = `${claim.id}.json`;
+      assertSameFile(
+        path.join(tmpDir, 'claims', fileName),
+        path.join(outputDir, 'claims', fileName),
+        `${label} claim ${claim.id}`,
+      );
+    }
+    const expectedArgs = (expected.buildchainProjection?.claims || [])
+      .map(
+        (claim) =>
+          `--kfd-2-claim-json ${rel(path.join(outputDir, 'claims', `${claim.id}.json`))}`,
+      )
+      .join('\n');
+    const actualArgsPath = path.join(outputDir, 'buildchain-claim-args.txt');
+    if (!fs.existsSync(actualArgsPath)) {
+      throw new Error(
+        `${label} Buildchain claim args is missing: ${rel(actualArgsPath)}`,
+      );
+    }
+    const actualArgs = fs.readFileSync(actualArgsPath, 'utf8').trimEnd();
+    if (actualArgs !== expectedArgs) {
+      throw new Error(
+        `${label} Buildchain claim args is stale: ${rel(actualArgsPath)}`,
+      );
+    }
+    return {
+      ...expected,
+      outputDir: rel(outputDir),
+      releaseClaims: {
+        ...expected.releaseClaims,
+        path: rel(releaseClaimsPath),
+      },
+      buildchainProjection: {
+        ...expected.buildchainProjection,
+        claims: (expected.buildchainProjection?.claims || []).map((claim) => ({
+          ...claim,
+          path: `${rel(outputDir)}/claims/${claim.id}.json`,
+        })),
+      },
+    };
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
 }
 
 function registryCapabilityQuery(registry, { warning = '' } = {}) {
@@ -967,6 +1109,8 @@ function buildSummary({
   registry,
   upstreamAggregate,
   kfd1Witness,
+  kfd1Gate,
+  kfd1VerifyResult,
   kfd2Summary,
   prebuildWitness,
   strictAudit,
@@ -979,9 +1123,12 @@ function buildSummary({
       minimumVersion: '2.10.8',
       releasePassportInputs: {
         kfd1WitnessJsons: [rel(KFD1_WITNESS_PATH)],
+        kfd1ReleaseGate: rel(KFD1_RELEASE_GATE_PATH),
         kfd2ClaimJsons: (kfd2Summary.buildchainProjection?.claims || []).map(
           (claim) =>
-            claim.path || `${rel(KFD2_OUTPUT_DIR)}/claims/${claim.id}.json`,
+            claim.path
+              ? rel(claim.path)
+              : `${rel(KFD2_OUTPUT_DIR)}/claims/${claim.id}.json`,
         ),
         kfd3PrebuildWitnessJsons: [rel(KFD3_PREBUILD_WITNESS_PATH)],
         kfd3ArtifactVerifyCommand: ARTIFACT_VERIFY_COMMAND,
@@ -989,15 +1136,27 @@ function buildSummary({
     },
     kfd1: {
       witness: rel(KFD1_WITNESS_PATH),
+      packagedWitness: rel(SDK_KFD1_WITNESS_PATH),
+      releaseGate: rel(KFD1_RELEASE_GATE_PATH),
+      packagedReleaseGate: rel(SDK_KFD1_RELEASE_GATE_PATH),
+      verifyResult: rel(KFD1_VERIFY_RESULT_PATH),
+      packagedVerifyResult: rel(SDK_KFD1_VERIFY_RESULT_PATH),
       id: kfd1Witness.id,
       standard: kfd1Witness.standard,
+      status: kfd1Gate.status,
+      verifyOk: kfd1VerifyResult.ok,
+      releaseGateSha256: `sha256:${sha256RenderedJson(kfd1Gate)}`,
       surfaces: Array.isArray(kfd1Witness.surfaces)
         ? kfd1Witness.surfaces.length
         : 0,
     },
     kfd2: {
       outputDir: rel(KFD2_OUTPUT_DIR),
+      packagedOutputDir: rel(SDK_KFD2_OUTPUT_DIR),
+      releaseClaims: `${rel(KFD2_OUTPUT_DIR)}/release-claims.json`,
+      packagedReleaseClaims: `${rel(SDK_KFD2_OUTPUT_DIR)}/release-claims.json`,
       claimCount: kfd2Summary.buildchainProjection?.claimCount || 0,
+      releaseClaimsSha256: `sha256:${kfd2Summary.releaseClaims?.sha256 || ''}`,
     },
     kfd3: {
       registry: KFD3_DEFAULT_REGISTRY_PATH,
@@ -1043,11 +1202,26 @@ async function runCheckOrWrite(options) {
   const upstreamAggregate = buildUpstreamKfdAggregate();
   const registry = buildKfd3Registry(upstreamAggregate);
   const kfd1Witness = buildKfd1Witness();
-  const kfd2Summary = buildKfd2Claims({ write: options.write });
+  const kfd1Gate = buildKfd1ReleaseGate(kfd1Witness);
+  const kfd1VerifyResult = buildKfd1VerifyResult(kfd1Gate);
+  if (!kfd1VerifyResult.ok) {
+    throw new Error(
+      `KFD-1 release gate verification failed:\n${kfd1VerifyResult.issues
+        .map((issue) => `- ${issue.code || 'kfd-1'}: ${issue.message || issue}`)
+        .join('\n')}`,
+    );
+  }
+  const kfd2Summary = options.write
+    ? writeKfd2PackagedOutputs(KFD2_OUTPUT_DIR)
+    : assertCurrentKfd2Output(KFD2_OUTPUT_DIR, 'Buildchain KFD-2 output');
   if (options.write) {
     writeIfChanged(KFD3_REGISTRY_PATH, registry);
     writeIfChanged(SDK_KFD3_CANONICAL_REGISTRY_PATH, registry);
     writeIfChanged(SDK_KFD_UPSTREAM_AGGREGATE_PATH, upstreamAggregate);
+    writeJson(SDK_KFD1_WITNESS_PATH, kfd1Witness);
+    writeJson(SDK_KFD1_RELEASE_GATE_PATH, kfd1Gate);
+    writeJson(SDK_KFD1_VERIFY_RESULT_PATH, kfd1VerifyResult);
+    writeKfd2PackagedOutputs(SDK_KFD2_OUTPUT_DIR);
   } else {
     assertCurrent(KFD3_REGISTRY_PATH, registry, 'Buildchain KFD-3 registry');
     assertCurrent(
@@ -1060,6 +1234,33 @@ async function runCheckOrWrite(options) {
       upstreamAggregate,
       'SDK packaged upstream KFD aggregate',
     );
+    assertCurrent(KFD1_WITNESS_PATH, kfd1Witness, 'Buildchain KFD-1 witness');
+    assertCurrent(
+      KFD1_RELEASE_GATE_PATH,
+      kfd1Gate,
+      'Buildchain KFD-1 release gate',
+    );
+    assertCurrent(
+      KFD1_VERIFY_RESULT_PATH,
+      kfd1VerifyResult,
+      'Buildchain KFD-1 verify result',
+    );
+    assertCurrent(
+      SDK_KFD1_WITNESS_PATH,
+      kfd1Witness,
+      'SDK packaged KFD-1 witness',
+    );
+    assertCurrent(
+      SDK_KFD1_RELEASE_GATE_PATH,
+      kfd1Gate,
+      'SDK packaged KFD-1 release gate',
+    );
+    assertCurrent(
+      SDK_KFD1_VERIFY_RESULT_PATH,
+      kfd1VerifyResult,
+      'SDK packaged KFD-1 verify result',
+    );
+    assertCurrentKfd2Output(SDK_KFD2_OUTPUT_DIR, 'SDK packaged KFD-2 output');
   }
   const strictAudit = buildStrictBuildchainAudit(registry);
   assertStrictBuildchainAudit(strictAudit);
@@ -1072,6 +1273,8 @@ async function runCheckOrWrite(options) {
     registry,
     upstreamAggregate,
     kfd1Witness,
+    kfd1Gate,
+    kfd1VerifyResult,
     kfd2Summary,
     prebuildWitness,
     strictAudit,
@@ -1079,6 +1282,8 @@ async function runCheckOrWrite(options) {
 
   if (options.write) {
     writeJson(KFD1_WITNESS_PATH, kfd1Witness);
+    writeJson(KFD1_RELEASE_GATE_PATH, kfd1Gate);
+    writeJson(KFD1_VERIFY_RESULT_PATH, kfd1VerifyResult);
     writeJson(KFD3_PREBUILD_WITNESS_PATH, prebuildWitness);
     writeJson(KFD3_ARTIFACT_WITNESS_PATH, artifactWitness);
     writeJson(KFD3_QUERY_PATH, query);

--- a/scripts/check.mjs
+++ b/scripts/check.mjs
@@ -228,6 +228,10 @@ function touchesBuildchainKfdEvidence(files) {
   return files.some(
     (file) =>
       file === '.buildchain/kfd/kfd-3-surfaces.json' ||
+      file.startsWith('.buildchain/kfd-1/') ||
+      file.startsWith('.buildchain/kfd-2/') ||
+      file.startsWith('developer/sdk/kfd/kfd-1/') ||
+      file.startsWith('developer/sdk/kfd/kfd-2/') ||
       file === 'developer/sdk/kfd/kfd-3-surfaces.json' ||
       file === 'developer/sdk/kfd/upstream-aggregate.json' ||
       file === 'developer/sdk/src/sdk.js' ||


### PR DESCRIPTION
## Summary
- persist Buildchain KFD-1 witness, release gate, and verify result into .buildchain and the SDK package
- persist KFD-2 canonical release claims plus per-claim Buildchain projections into .buildchain and the SDK package
- expose kungfu sdk kfd 1 gate/verify and make kfd 2 claims return the packaged release-claim documents
- extend KFD evidence checks to cover the new KFD-1/2 files

## Validation
- ./kungfu-code kfd:buildchain -- --json
- ./kungfu-code kfd:buildchain:check -- --json
- node --test developer/sdk/tests/contract-cli.test.mjs
- ./kungfu-code check