### PR TITLE
feat(storage): add maintenance sync ops

### DIFF
--- a/.buildchain/kfd-2/claims/agent-onboarding-pack.json
+++ b/.buildchain/kfd-2/claims/agent-onboarding-pack.json
@@ -16,7 +16,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "0fadbb02d0e2b49f6bd982a744f9c58448794e7606b9edeb6f2457c28c8404ab"
+        "sha256": "b9f4440a15a2de73b0fcb478686f1e1a8f4a5bec10e47bdfaa0e0c157e29faea"
       },
       "description": "Machine-readable command catalog and mode maturity metadata."
     },
@@ -54,7 +54,7 @@
     "evidenceSha256": [
       {
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "0fadbb02d0e2b49f6bd982a744f9c58448794e7606b9edeb6f2457c28c8404ab"
+        "sha256": "b9f4440a15a2de73b0fcb478686f1e1a8f4a5bec10e47bdfaa0e0c157e29faea"
       },
       {
         "path": "framework/core/src/python/kungfu/agent/mode-selection.md",
@@ -76,7 +76,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "0fadbb02d0e2b49f6bd982a744f9c58448794e7606b9edeb6f2457c28c8404ab"
+        "sha256": "b9f4440a15a2de73b0fcb478686f1e1a8f4a5bec10e47bdfaa0e0c157e29faea"
       }
     ]
   },
@@ -90,7 +90,7 @@
     {
       "name": "agent-command-catalog",
       "path": "framework/core/src/python/kungfu/agent/commands.json",
-      "sha256": "0fadbb02d0e2b49f6bd982a744f9c58448794e7606b9edeb6f2457c28c8404ab",
+      "sha256": "b9f4440a15a2de73b0fcb478686f1e1a8f4a5bec10e47bdfaa0e0c157e29faea",
       "expectedPackagePath": "kungfu/agent/commands.json"
     }
   ],

--- a/.buildchain/kfd-2/claims/codex-report-receipts.json
+++ b/.buildchain/kfd-2/claims/codex-report-receipts.json
@@ -52,7 +52,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/skills/codex/SKILL.md",
-        "sha256": "5de3db86c56124d952b6732133c9c1c0411951f0c9df4685f629edaee1269d07"
+        "sha256": "5b5f2e7640a0e7edd52c28fea4cd8cb4d6f2db66140bd44327cc84fe10c6897c"
       },
       "description": "Codex-side report closeout gate instructions shipped in the agent pack."
     }
@@ -79,7 +79,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/skills/codex/SKILL.md",
-        "sha256": "5de3db86c56124d952b6732133c9c1c0411951f0c9df4685f629edaee1269d07"
+        "sha256": "5b5f2e7640a0e7edd52c28fea4cd8cb4d6f2db66140bd44327cc84fe10c6897c"
       }
     ],
     "artifactSha256": [
@@ -89,7 +89,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/skills/codex/SKILL.md",
-        "sha256": "5de3db86c56124d952b6732133c9c1c0411951f0c9df4685f629edaee1269d07"
+        "sha256": "5b5f2e7640a0e7edd52c28fea4cd8cb4d6f2db66140bd44327cc84fe10c6897c"
       }
     ]
   },
@@ -103,7 +103,7 @@
     {
       "name": "codex-agent-skill",
       "path": "framework/core/src/python/kungfu/agent/skills/codex/SKILL.md",
-      "sha256": "5de3db86c56124d952b6732133c9c1c0411951f0c9df4685f629edaee1269d07",
+      "sha256": "5b5f2e7640a0e7edd52c28fea4cd8cb4d6f2db66140bd44327cc84fe10c6897c",
       "expectedPackagePath": "kungfu/agent/skills/codex/SKILL.md"
     }
   ],

--- a/.buildchain/kfd-2/claims/remote-fact-boundary.json
+++ b/.buildchain/kfd-2/claims/remote-fact-boundary.json
@@ -34,7 +34,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "0fadbb02d0e2b49f6bd982a744f9c58448794e7606b9edeb6f2457c28c8404ab"
+        "sha256": "b9f4440a15a2de73b0fcb478686f1e1a8f4a5bec10e47bdfaa0e0c157e29faea"
       },
       "description": "Remote add/sync command declarations and mode metadata."
     },
@@ -62,7 +62,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "0fadbb02d0e2b49f6bd982a744f9c58448794e7606b9edeb6f2457c28c8404ab"
+        "sha256": "b9f4440a15a2de73b0fcb478686f1e1a8f4a5bec10e47bdfaa0e0c157e29faea"
       },
       {
         "path": "framework/core/src/python/kungfu/cli/commands/agent.py",

--- a/.buildchain/kfd-2/release-claims.json
+++ b/.buildchain/kfd-2/release-claims.json
@@ -29,7 +29,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/commands.json",
-            "sha256": "0fadbb02d0e2b49f6bd982a744f9c58448794e7606b9edeb6f2457c28c8404ab"
+            "sha256": "b9f4440a15a2de73b0fcb478686f1e1a8f4a5bec10e47bdfaa0e0c157e29faea"
           },
           "description": "Machine-readable command catalog and mode maturity metadata."
         },
@@ -134,7 +134,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/skills/codex/SKILL.md",
-            "sha256": "5de3db86c56124d952b6732133c9c1c0411951f0c9df4685f629edaee1269d07"
+            "sha256": "5b5f2e7640a0e7edd52c28fea4cd8cb4d6f2db66140bd44327cc84fe10c6897c"
           },
           "description": "Codex-side report closeout gate instructions shipped in the agent pack."
         }
@@ -194,7 +194,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/commands.json",
-            "sha256": "0fadbb02d0e2b49f6bd982a744f9c58448794e7606b9edeb6f2457c28c8404ab"
+            "sha256": "b9f4440a15a2de73b0fcb478686f1e1a8f4a5bec10e47bdfaa0e0c157e29faea"
           },
           "description": "Remote add/sync command declarations and mode metadata."
         },

--- a/.buildchain/kfd/kfd-3-surfaces.json
+++ b/.buildchain/kfd/kfd-3-surfaces.json
@@ -857,6 +857,126 @@
       }
     },
     {
+      "id": "kungfu.storage.compact",
+      "name": "kungfu storage compact --scope all --dry-run --json",
+      "kind": "cli",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "stable",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
+      "id": "kungfu.storage.fsck",
+      "name": "kungfu storage fsck --scope all --json",
+      "kind": "cli",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "stable",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
+      "id": "kungfu.storage.gc",
+      "name": "kungfu storage gc --scope all --dry-run --json",
+      "kind": "cli",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "stable",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
+      "id": "kungfu.storage.rebuild-index",
+      "name": "kungfu storage rebuild-index --scope all --dry-run --json",
+      "kind": "cli",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "stable",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
+      "id": "kungfu.storage.status",
+      "name": "kungfu storage status --scope all --json",
+      "kind": "cli",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "stable",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
+      "id": "kungfu.storage.verify-sync",
+      "name": "kungfu storage verify-sync --source <source-id> --json",
+      "kind": "cli",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "stable",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
       "id": "kungfu.trace.capture",
       "name": "kungfu trace -- <command>",
       "kind": "cli",

--- a/developer/sdk/kfd/kfd-2/claims/agent-onboarding-pack.json
+++ b/developer/sdk/kfd/kfd-2/claims/agent-onboarding-pack.json
@@ -16,7 +16,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "0fadbb02d0e2b49f6bd982a744f9c58448794e7606b9edeb6f2457c28c8404ab"
+        "sha256": "b9f4440a15a2de73b0fcb478686f1e1a8f4a5bec10e47bdfaa0e0c157e29faea"
       },
       "description": "Machine-readable command catalog and mode maturity metadata."
     },
@@ -54,7 +54,7 @@
     "evidenceSha256": [
       {
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "0fadbb02d0e2b49f6bd982a744f9c58448794e7606b9edeb6f2457c28c8404ab"
+        "sha256": "b9f4440a15a2de73b0fcb478686f1e1a8f4a5bec10e47bdfaa0e0c157e29faea"
       },
       {
         "path": "framework/core/src/python/kungfu/agent/mode-selection.md",
@@ -76,7 +76,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "0fadbb02d0e2b49f6bd982a744f9c58448794e7606b9edeb6f2457c28c8404ab"
+        "sha256": "b9f4440a15a2de73b0fcb478686f1e1a8f4a5bec10e47bdfaa0e0c157e29faea"
       }
     ]
   },
@@ -90,7 +90,7 @@
     {
       "name": "agent-command-catalog",
       "path": "framework/core/src/python/kungfu/agent/commands.json",
-      "sha256": "0fadbb02d0e2b49f6bd982a744f9c58448794e7606b9edeb6f2457c28c8404ab",
+      "sha256": "b9f4440a15a2de73b0fcb478686f1e1a8f4a5bec10e47bdfaa0e0c157e29faea",
       "expectedPackagePath": "kungfu/agent/commands.json"
     }
   ],

--- a/developer/sdk/kfd/kfd-2/claims/codex-report-receipts.json
+++ b/developer/sdk/kfd/kfd-2/claims/codex-report-receipts.json
@@ -52,7 +52,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/skills/codex/SKILL.md",
-        "sha256": "5de3db86c56124d952b6732133c9c1c0411951f0c9df4685f629edaee1269d07"
+        "sha256": "5b5f2e7640a0e7edd52c28fea4cd8cb4d6f2db66140bd44327cc84fe10c6897c"
       },
       "description": "Codex-side report closeout gate instructions shipped in the agent pack."
     }
@@ -79,7 +79,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/skills/codex/SKILL.md",
-        "sha256": "5de3db86c56124d952b6732133c9c1c0411951f0c9df4685f629edaee1269d07"
+        "sha256": "5b5f2e7640a0e7edd52c28fea4cd8cb4d6f2db66140bd44327cc84fe10c6897c"
       }
     ],
     "artifactSha256": [
@@ -89,7 +89,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/skills/codex/SKILL.md",
-        "sha256": "5de3db86c56124d952b6732133c9c1c0411951f0c9df4685f629edaee1269d07"
+        "sha256": "5b5f2e7640a0e7edd52c28fea4cd8cb4d6f2db66140bd44327cc84fe10c6897c"
       }
     ]
   },
@@ -103,7 +103,7 @@
     {
       "name": "codex-agent-skill",
       "path": "framework/core/src/python/kungfu/agent/skills/codex/SKILL.md",
-      "sha256": "5de3db86c56124d952b6732133c9c1c0411951f0c9df4685f629edaee1269d07",
+      "sha256": "5b5f2e7640a0e7edd52c28fea4cd8cb4d6f2db66140bd44327cc84fe10c6897c",
       "expectedPackagePath": "kungfu/agent/skills/codex/SKILL.md"
     }
   ],

--- a/developer/sdk/kfd/kfd-2/claims/remote-fact-boundary.json
+++ b/developer/sdk/kfd/kfd-2/claims/remote-fact-boundary.json
@@ -34,7 +34,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "0fadbb02d0e2b49f6bd982a744f9c58448794e7606b9edeb6f2457c28c8404ab"
+        "sha256": "b9f4440a15a2de73b0fcb478686f1e1a8f4a5bec10e47bdfaa0e0c157e29faea"
       },
       "description": "Remote add/sync command declarations and mode metadata."
     },
@@ -62,7 +62,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "0fadbb02d0e2b49f6bd982a744f9c58448794e7606b9edeb6f2457c28c8404ab"
+        "sha256": "b9f4440a15a2de73b0fcb478686f1e1a8f4a5bec10e47bdfaa0e0c157e29faea"
       },
       {
         "path": "framework/core/src/python/kungfu/cli/commands/agent.py",

--- a/developer/sdk/kfd/kfd-2/release-claims.json
+++ b/developer/sdk/kfd/kfd-2/release-claims.json
@@ -29,7 +29,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/commands.json",
-            "sha256": "0fadbb02d0e2b49f6bd982a744f9c58448794e7606b9edeb6f2457c28c8404ab"
+            "sha256": "b9f4440a15a2de73b0fcb478686f1e1a8f4a5bec10e47bdfaa0e0c157e29faea"
           },
           "description": "Machine-readable command catalog and mode maturity metadata."
         },
@@ -134,7 +134,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/skills/codex/SKILL.md",
-            "sha256": "5de3db86c56124d952b6732133c9c1c0411951f0c9df4685f629edaee1269d07"
+            "sha256": "5b5f2e7640a0e7edd52c28fea4cd8cb4d6f2db66140bd44327cc84fe10c6897c"
           },
           "description": "Codex-side report closeout gate instructions shipped in the agent pack."
         }
@@ -194,7 +194,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/commands.json",
-            "sha256": "0fadbb02d0e2b49f6bd982a744f9c58448794e7606b9edeb6f2457c28c8404ab"
+            "sha256": "b9f4440a15a2de73b0fcb478686f1e1a8f4a5bec10e47bdfaa0e0c157e29faea"
           },
           "description": "Remote add/sync command declarations and mode metadata."
         },

--- a/developer/sdk/kfd/kfd-3-surfaces.json
+++ b/developer/sdk/kfd/kfd-3-surfaces.json
@@ -857,6 +857,126 @@
       }
     },
     {
+      "id": "kungfu.storage.compact",
+      "name": "kungfu storage compact --scope all --dry-run --json",
+      "kind": "cli",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "stable",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
+      "id": "kungfu.storage.fsck",
+      "name": "kungfu storage fsck --scope all --json",
+      "kind": "cli",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "stable",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
+      "id": "kungfu.storage.gc",
+      "name": "kungfu storage gc --scope all --dry-run --json",
+      "kind": "cli",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "stable",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
+      "id": "kungfu.storage.rebuild-index",
+      "name": "kungfu storage rebuild-index --scope all --dry-run --json",
+      "kind": "cli",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "stable",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
+      "id": "kungfu.storage.status",
+      "name": "kungfu storage status --scope all --json",
+      "kind": "cli",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "stable",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
+      "id": "kungfu.storage.verify-sync",
+      "name": "kungfu storage verify-sync --source <source-id> --json",
+      "kind": "cli",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "stable",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
       "id": "kungfu.trace.capture",
       "name": "kungfu trace -- <command>",
       "kind": "cli",

--- a/docs/runtime-storage-service.md
+++ b/docs/runtime-storage-service.md
@@ -390,6 +390,11 @@ kungfu storage export --scope source --source <source-id> \
 kungfu storage export --scope source --source <source-id> \
   --format bundle-json --out source.kfbundle.json --json
 kungfu storage import --from source.kfbundle.json --json
+kungfu storage rebuild-index --scope all --json
+kungfu storage rebuild-index --scope source --source <source-id> --json
+kungfu storage gc --scope all --dry-run --json
+kungfu storage compact --scope all --dry-run --json
+kungfu storage verify-sync --source <source-id> --json
 ```
 
 `kungfu source add/list/sync/fsck` uses the same source registry path. Atlas
@@ -403,6 +408,38 @@ construction, accepted ranges, payload inventory, source-scoped fsck,
 range-limited export, bundle creation, and bundle import. It deliberately does
 not implement remote channel transport, conflict policy, destructive GC,
 compaction, repair, or a SQLite/RocksDB provider.
+
+### Maintenance And Sync-Readiness Slice
+
+The first maintenance slice keeps destructive operations out of scope while
+making storage health and sync readiness inspectable:
+
+- `storage status --scope all|source` now reports each source's latest manifest,
+  accepted ranges, manifest sync root, payload/schema inventory counts, and a
+  cursor-like accepted head for future channel fetch.
+- `storage fsck --scope all|source` checks the generic source registry, latest
+  manifests, source-record drift, accepted ranges, sync roots, payload
+  presence/hash/length, payload inventory counts, schema inventory counts, and
+  all-scope orphan payload candidates.
+- `storage rebuild-index` rebuilds the derived
+  `runtime/storage/sources.json` source registry from accepted latest manifests.
+  This command may write only that derived registry unless `--dry-run` is used.
+- `storage gc --dry-run` scans payload files and reports unreachable candidates.
+  All-scope candidates are unreferenced by retained storage manifests. Source
+  scope is informational only because the interim payload store is shared.
+- `storage compact --dry-run` composes a reviewable plan: retained manifests,
+  rebuild-index preview, gc preview, and unsupported backend/history actions.
+  It does not archive, delete, vacuum, compact, or rewrite any facts.
+- `storage verify-sync --source <source-id>` exports a manifest-backed bundle,
+  imports it into a temporary local runtime, runs fsck there, and compares sync
+  roots. This simulates the proof path future remote sync will use without a
+  real remote.
+
+The current generic store still has no generic SQLite/RocksDB projection.
+Therefore `rebuild-index` explicitly reports SQLite as unsupported rather than
+pretending to rebuild a projection that does not exist. Atlas's user-facing
+cards remain a journal-folded projection; this slice does not add a standalone
+Atlas SQLite projection.
 
 ## Safety Boundaries
 

--- a/framework/core/src/python/kungfu/agent/brief.md
+++ b/framework/core/src/python/kungfu/agent/brief.md
@@ -47,6 +47,8 @@ snapshot it and verify the projection with:
 
 ```sh
 kungfu atlas import --repo <atlas-repo> --json
+kungfu storage fsck --scope all --json
+kungfu storage verify-sync --source <source-id> --json
 kungfu atlas show import --json
 kungfu atlas show missions --json
 kungfu atlas show goals --json

--- a/framework/core/src/python/kungfu/agent/commands.json
+++ b/framework/core/src/python/kungfu/agent/commands.json
@@ -158,6 +158,42 @@
       "purpose": "List imported Atlas worktree-status markers from the latest projection."
     },
     {
+      "apiId": "kungfu.storage.status",
+      "name": "kungfu storage status --scope all --json",
+      "maturity": "stable",
+      "purpose": "Inspect source manifests, accepted cursors, sync roots, and storage projection status."
+    },
+    {
+      "apiId": "kungfu.storage.fsck",
+      "name": "kungfu storage fsck --scope all --json",
+      "maturity": "stable",
+      "purpose": "Verify generic storage manifests, payload hashes, source registry drift, and orphan payload candidates."
+    },
+    {
+      "apiId": "kungfu.storage.rebuild-index",
+      "name": "kungfu storage rebuild-index --scope all --dry-run --json",
+      "maturity": "stable",
+      "purpose": "Preview or rebuild the derived source registry from accepted latest manifests."
+    },
+    {
+      "apiId": "kungfu.storage.gc",
+      "name": "kungfu storage gc --scope all --dry-run --json",
+      "maturity": "stable",
+      "purpose": "Plan unreachable payload garbage collection without deleting payloads."
+    },
+    {
+      "apiId": "kungfu.storage.compact",
+      "name": "kungfu storage compact --scope all --dry-run --json",
+      "maturity": "stable",
+      "purpose": "Plan fact-ledger compaction without archiving, deleting, vacuuming, or rewriting facts."
+    },
+    {
+      "apiId": "kungfu.storage.verify-sync",
+      "name": "kungfu storage verify-sync --source <source-id> --json",
+      "maturity": "stable",
+      "purpose": "Simulate manifest-backed local export/import/fsck and compare sync roots."
+    },
+    {
       "apiId": "kungfu.remote.add",
       "name": "kungfu remote add <source-id> --host <host> --home <kf-home> --json",
       "maturity": "experimental",
@@ -201,7 +237,7 @@
     },
     "atlas-projection": {
       "maturity": "stable",
-      "next": "kungfu atlas import --repo <atlas-repo> --json; kungfu atlas show import --json; kungfu atlas show missions --json; kungfu atlas show goals --json",
+      "next": "kungfu atlas import --repo <atlas-repo> --json; kungfu storage fsck --scope all --json; kungfu storage verify-sync --source <source-id> --json; kungfu atlas show missions --json; kungfu atlas show goals --json",
       "when": "The user asks to sync, import, inspect, or visualize an Atlas-style mission/goal/worktree control-plane repo inside Kungfu."
     },
     "trace": {

--- a/framework/core/src/python/kungfu/agent/kfd3_api.registry.json
+++ b/framework/core/src/python/kungfu/agent/kfd3_api.registry.json
@@ -284,6 +284,66 @@
       "projections": ["commands.json", "agent-pack-doc", "provider-skill"]
     },
     {
+      "id": "kungfu.storage.status",
+      "surface": "cli",
+      "name": "kungfu storage status --scope all --json",
+      "purpose": "Inspect source manifests, accepted cursors, sync roots, and storage projection status.",
+      "maturity": "stable",
+      "visibility": "adjacent-agent",
+      "anchor": { "kind": "catalog" },
+      "projections": ["commands.json", "agent-pack-doc", "provider-skill"]
+    },
+    {
+      "id": "kungfu.storage.fsck",
+      "surface": "cli",
+      "name": "kungfu storage fsck --scope all --json",
+      "purpose": "Verify generic storage manifests, payload hashes, source registry drift, and orphan payload candidates.",
+      "maturity": "stable",
+      "visibility": "adjacent-agent",
+      "anchor": { "kind": "catalog" },
+      "projections": ["commands.json", "agent-pack-doc", "provider-skill"]
+    },
+    {
+      "id": "kungfu.storage.rebuild-index",
+      "surface": "cli",
+      "name": "kungfu storage rebuild-index --scope all --dry-run --json",
+      "purpose": "Preview or rebuild the derived source registry from accepted latest manifests.",
+      "maturity": "stable",
+      "visibility": "adjacent-agent",
+      "anchor": { "kind": "catalog" },
+      "projections": ["commands.json", "agent-pack-doc", "provider-skill"]
+    },
+    {
+      "id": "kungfu.storage.gc",
+      "surface": "cli",
+      "name": "kungfu storage gc --scope all --dry-run --json",
+      "purpose": "Plan unreachable payload garbage collection without deleting payloads.",
+      "maturity": "stable",
+      "visibility": "adjacent-agent",
+      "anchor": { "kind": "catalog" },
+      "projections": ["commands.json", "agent-pack-doc", "provider-skill"]
+    },
+    {
+      "id": "kungfu.storage.compact",
+      "surface": "cli",
+      "name": "kungfu storage compact --scope all --dry-run --json",
+      "purpose": "Plan fact-ledger compaction without archiving, deleting, vacuuming, or rewriting facts.",
+      "maturity": "stable",
+      "visibility": "adjacent-agent",
+      "anchor": { "kind": "catalog" },
+      "projections": ["commands.json", "agent-pack-doc", "provider-skill"]
+    },
+    {
+      "id": "kungfu.storage.verify-sync",
+      "surface": "cli",
+      "name": "kungfu storage verify-sync --source <source-id> --json",
+      "purpose": "Simulate manifest-backed local export/import/fsck and compare sync roots.",
+      "maturity": "stable",
+      "visibility": "adjacent-agent",
+      "anchor": { "kind": "catalog" },
+      "projections": ["commands.json", "agent-pack-doc", "provider-skill"]
+    },
+    {
       "id": "kungfu.remote.add",
       "surface": "cli",
       "name": "kungfu remote add <source-id> --host <host> --home <kf-home> --json",

--- a/framework/core/src/python/kungfu/agent/skills/claude/SKILL.md
+++ b/framework/core/src/python/kungfu/agent/skills/claude/SKILL.md
@@ -46,6 +46,8 @@ For Atlas projection, the source repo remains authoritative. Import and verify:
 
 ```sh
 kungfu atlas import --repo <atlas-repo> --json
+kungfu storage fsck --scope all --json
+kungfu storage verify-sync --source <source-id> --json
 kungfu atlas show import --json
 kungfu atlas show missions --json
 kungfu atlas show goals --json

--- a/framework/core/src/python/kungfu/agent/skills/codex/SKILL.md
+++ b/framework/core/src/python/kungfu/agent/skills/codex/SKILL.md
@@ -46,6 +46,8 @@ For Atlas projection, the source repo remains authoritative. Import and verify:
 
 ```sh
 kungfu atlas import --repo <atlas-repo> --json
+kungfu storage fsck --scope all --json
+kungfu storage verify-sync --source <source-id> --json
 kungfu atlas show import --json
 kungfu atlas show missions --json
 kungfu atlas show goals --json

--- a/framework/core/src/python/kungfu/cli/commands/storage.py
+++ b/framework/core/src/python/kungfu/cli/commands/storage.py
@@ -30,6 +30,13 @@ def _range_filter(since, from_time, until):
         sys.exit(2)
 
 
+def _source_for_scope(scope, storage_source_id):
+    if scope == "source":
+        _require_source(storage_source_id)
+        return storage_source_id
+    return None
+
+
 @kfc.group(
     cls=PrioritizedCommandGroup,
     help_priority=2,
@@ -186,3 +193,146 @@ def import_cmd(ctx, from_path, no_verify, as_json):
     click.echo(
         f"[storage] imported {result['records']} records for {result['source_id']}"
     )
+
+
+@storage.command(name="rebuild-index", help="rebuild derived storage indexes")
+@click.option("--scope", type=click.Choice(["atlas", "source", "all"]), required=True)
+@click.option("--source", "storage_source_id", type=str, default=None)
+@click.option(
+    "--dry-run",
+    "dry_run",
+    is_flag=True,
+    help="show registry changes without writing the derived index",
+)
+@click.option("--json", "as_json", is_flag=True, help="machine-readable output")
+@storage_command_context
+def rebuild_index(ctx, scope, storage_source_id, dry_run, as_json):
+    from kungfu.storage import service
+
+    if scope == "atlas":
+        result = {
+            "ok": True,
+            "scope": "atlas",
+            "dry_run": True,
+            "projection": {
+                "name": "atlas-journal-fold",
+                "rebuildable": False,
+                "reason": (
+                    "Atlas cards are folded from journal frames at read time; "
+                    "there is no standalone SQLite projection to rebuild."
+                ),
+            },
+        }
+    else:
+        result = service.rebuild_index(
+            ctx.runtime_dir,
+            source_id=_source_for_scope(scope, storage_source_id),
+            dry_run=dry_run,
+        )
+    if as_json:
+        _echo_json(result)
+        return
+    click.echo(
+        f"[storage] rebuild-index {scope}: "
+        f"{'would write' if result.get('would_write') else 'up to date'}"
+    )
+    for error in result.get("errors", []):
+        click.echo(f"  error: {error}", err=True)
+    if not result["ok"]:
+        sys.exit(1)
+
+
+@storage.command(help="plan unreachable payload garbage collection")
+@click.option("--scope", type=click.Choice(["source", "all"]), required=True)
+@click.option("--source", "storage_source_id", type=str, default=None)
+@click.option(
+    "--dry-run",
+    "dry_run",
+    is_flag=True,
+    help="required; no payloads are deleted",
+)
+@click.option("--json", "as_json", is_flag=True, help="machine-readable output")
+@storage_command_context
+def gc(ctx, scope, storage_source_id, dry_run, as_json):
+    from kungfu.storage import service
+
+    if not dry_run:
+        click.echo("[storage] gc requires --dry-run in this release", err=True)
+        sys.exit(2)
+    try:
+        result = service.gc_plan(
+            ctx.runtime_dir,
+            source_id=_source_for_scope(scope, storage_source_id),
+            dry_run=True,
+        )
+    except ValueError as e:
+        click.echo(f"[storage] {e}", err=True)
+        sys.exit(2)
+    if as_json:
+        _echo_json(result)
+        return
+    click.echo(
+        f"[storage] gc dry-run {scope}: {result['candidate_count']} candidates, "
+        f"{result['candidate_bytes']} bytes"
+    )
+
+
+@storage.command(help="plan fact-ledger compaction without rewriting storage")
+@click.option("--scope", type=click.Choice(["source", "all"]), required=True)
+@click.option("--source", "storage_source_id", type=str, default=None)
+@click.option(
+    "--dry-run",
+    "dry_run",
+    is_flag=True,
+    help="required; no storage files are rewritten",
+)
+@click.option("--json", "as_json", is_flag=True, help="machine-readable output")
+@storage_command_context
+def compact(ctx, scope, storage_source_id, dry_run, as_json):
+    from kungfu.storage import service
+
+    if not dry_run:
+        click.echo("[storage] compact requires --dry-run in this release", err=True)
+        sys.exit(2)
+    try:
+        result = service.compact_plan(
+            ctx.runtime_dir,
+            source_id=_source_for_scope(scope, storage_source_id),
+            dry_run=True,
+        )
+    except ValueError as e:
+        click.echo(f"[storage] {e}", err=True)
+        sys.exit(2)
+    if as_json:
+        _echo_json(result)
+        return
+    click.echo(
+        f"[storage] compact dry-run {scope}: "
+        f"{len(result['retained_manifests'])} retained manifests, "
+        f"{result['gc']['candidate_count']} gc candidates"
+    )
+    if not result["ok"]:
+        sys.exit(1)
+
+
+@storage.command(name="verify-sync", help="simulate local bundle export/import/fsck")
+@click.option("--source", "storage_source_id", type=str, required=True)
+@click.option("--json", "as_json", is_flag=True, help="machine-readable output")
+@storage_command_context
+def verify_sync(ctx, storage_source_id, as_json):
+    from kungfu.storage import service
+
+    try:
+        result = service.verify_local_sync(ctx.runtime_dir, source_id=storage_source_id)
+    except (FileNotFoundError, ValueError) as e:
+        click.echo(f"[storage] {e}", err=True)
+        sys.exit(1)
+    if as_json:
+        _echo_json(result)
+    else:
+        click.echo(
+            f"[storage] verify-sync {storage_source_id} "
+            f"{'ok' if result['ok'] else 'failed'}"
+        )
+    if not result["ok"]:
+        sys.exit(1)

--- a/framework/core/src/python/kungfu/storage/service.py
+++ b/framework/core/src/python/kungfu/storage/service.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
+import tempfile
 from pathlib import Path
 from typing import Any
 
@@ -11,6 +12,10 @@ from kungfu.content_hash import CONTENT_HASH_ALGORITHM_SHA256
 
 PAYLOAD_STATE_PRESENT = "present"
 CONTENT_TYPE_JSON = "application/json"
+SOURCE_REGISTRY_SCHEMA = "kungfu.storage.source-registry/v1"
+PROJECTION_SOURCE_REGISTRY = "source-registry"
+PROJECTION_SQLITE = "sqlite"
+PROJECTION_ATLAS_JOURNAL_FOLD = "atlas-journal-fold"
 
 
 def _runtime():
@@ -27,6 +32,10 @@ def registry_path(runtime_dir: str | Path) -> Path:
 
 def payload_path(runtime_dir: str | Path, digest: str) -> Path:
     return root_dir(runtime_dir) / "payloads" / digest[:2] / f"{digest}.json"
+
+
+def _payload_root(runtime_dir: str | Path) -> Path:
+    return root_dir(runtime_dir) / "payloads"
 
 
 def write_payload_bytes(runtime_dir: str | Path, digest: str, raw: bytes) -> Path:
@@ -48,14 +57,60 @@ def manifest_path(runtime_dir: str | Path, source_id: str, manifest_id: str) -> 
     return source_manifest_dir(runtime_dir, source_id) / f"{manifest_id}.json"
 
 
+def _read_json(path: Path) -> dict[str, Any] | None:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    return data if isinstance(data, dict) else None
+
+
+def _manifest_paths(
+    runtime_dir: str | Path, source_id: str | None = None
+) -> list[Path]:
+    base = root_dir(runtime_dir) / "sources"
+    if source_id:
+        roots = [base / source_id / "manifests"]
+    else:
+        roots = (
+            sorted(path / "manifests" for path in base.iterdir())
+            if base.exists()
+            else []
+        )
+    paths: list[Path] = []
+    for manifest_dir in roots:
+        if manifest_dir.exists():
+            paths.extend(sorted(manifest_dir.glob("*.json")))
+    return paths
+
+
+def _latest_manifest_paths(
+    runtime_dir: str | Path, source_id: str | None = None
+) -> list[Path]:
+    base = root_dir(runtime_dir) / "sources"
+    if source_id:
+        paths = [base / source_id / "manifests" / "latest.json"]
+    else:
+        paths = sorted(base.glob("*/manifests/latest.json")) if base.exists() else []
+    return [path for path in paths if path.exists()]
+
+
+def _all_payload_paths(runtime_dir: str | Path) -> list[Path]:
+    payload_root = _payload_root(runtime_dir)
+    if not payload_root.exists():
+        return []
+    return sorted(path for path in payload_root.glob("*/*.json") if path.is_file())
+
+
+def _payload_digest_from_path(path: Path) -> str:
+    return path.stem
+
+
 def load_registry(runtime_dir: str | Path) -> dict[str, Any]:
     path = registry_path(runtime_dir)
     if not path.exists():
-        return {"schema": "kungfu.storage.source-registry/v1", "sources": {}}
+        return {"schema": SOURCE_REGISTRY_SCHEMA, "sources": {}}
     data = json.loads(path.read_text(encoding="utf-8"))
     if not isinstance(data, dict) or not isinstance(data.get("sources"), dict):
         raise ValueError(f"invalid storage source registry: {path}")
-    data.setdefault("schema", "kungfu.storage.source-registry/v1")
+    data.setdefault("schema", SOURCE_REGISTRY_SCHEMA)
     return data
 
 
@@ -118,6 +173,101 @@ def load_latest_manifest(
     return data if isinstance(data, dict) else None
 
 
+def _referenced_payload_hashes(
+    runtime_dir: str | Path, source_id: str | None = None
+) -> set[str]:
+    hashes: set[str] = set()
+    seen_manifests: set[tuple[str, str]] = set()
+    for path in _manifest_paths(runtime_dir, source_id):
+        try:
+            manifest = _read_json(path)
+        except (OSError, json.JSONDecodeError):
+            continue
+        if not manifest:
+            continue
+        key = (
+            str(manifest.get("source_id") or ""),
+            str(manifest.get("manifest_id") or path.name),
+        )
+        if key in seen_manifests:
+            continue
+        seen_manifests.add(key)
+        for entry in _entries_for_manifest(manifest):
+            digest = str(entry.get("payload_hash") or "")
+            if digest:
+                hashes.add(digest)
+    return hashes
+
+
+def _source_projection_from_manifest(manifest: dict[str, Any]) -> dict[str, Any]:
+    source = manifest.get("source")
+    if isinstance(source, dict):
+        return source
+    return build_source_record(
+        {
+            "source_id": manifest.get("source_id"),
+            "source_type": manifest.get("source_type"),
+            "source_head": manifest.get("source_head"),
+            "range": manifest.get("range"),
+            "manifest_id": manifest.get("manifest_id"),
+            "sync_root": manifest.get("sync_root"),
+            "accepted_ranges": manifest.get("accepted_ranges", []),
+        }
+    )
+
+
+def _accepted_cursor(manifest: dict[str, Any]) -> dict[str, Any]:
+    accepted_ranges = manifest.get("accepted_ranges", [])
+    last_range = accepted_ranges[-1] if accepted_ranges else {}
+    last_range = last_range if isinstance(last_range, dict) else {}
+    return {
+        "schema": "kungfu.storage.channel-cursor/v1",
+        "source_id": manifest.get("source_id"),
+        "manifest_id": manifest.get("manifest_id"),
+        "source_head": manifest.get("source_head") or last_range.get("source_head"),
+        "range": manifest.get("range") or last_range.get("range") or {},
+        "sync_root": manifest.get("sync_root") or last_range.get("sync_root"),
+        "entry_count": len(_entries_for_manifest(manifest)),
+    }
+
+
+def _source_manifest_status(
+    runtime_dir: str | Path, source: dict[str, Any]
+) -> dict[str, Any]:
+    source_id = str(source.get("source_id") or "")
+    manifest = load_latest_manifest(runtime_dir, source_id)
+    if manifest is None:
+        return {
+            "source_id": source_id,
+            "ok": False,
+            "projection": PROJECTION_SOURCE_REGISTRY,
+            "reason": "manifest_missing",
+            "source": source,
+        }
+    entries = _entries_for_manifest(manifest)
+    payload_inventory = manifest.get("payload_inventory", {})
+    schema_inventory = manifest.get("schema_inventory", {})
+    return {
+        "source_id": source_id,
+        "ok": True,
+        "projection": PROJECTION_SOURCE_REGISTRY,
+        "manifest_id": manifest.get("manifest_id"),
+        "source_type": manifest.get("source_type"),
+        "source_head": manifest.get("source_head"),
+        "accepted_ranges": manifest.get("accepted_ranges", []),
+        "accepted_cursor": _accepted_cursor(manifest),
+        "sync_root": manifest.get("sync_root"),
+        "entries": len(entries),
+        "payload_inventory": len(payload_inventory.get("entries", []))
+        if isinstance(payload_inventory, dict)
+        else 0,
+        "schema_inventory": len(schema_inventory.get("entries", []))
+        if isinstance(schema_inventory, dict)
+        else 0,
+        "source_record": source,
+    }
+
+
 def list_sources(runtime_dir: str | Path) -> list[dict[str, Any]]:
     registry = load_registry(runtime_dir)
     return sorted(
@@ -136,12 +286,19 @@ def status(
         for source in list_sources(runtime_dir)
         if source_id is None or source.get("source_id") == source_id
     ]
+    source_status = [_source_manifest_status(runtime_dir, source) for source in sources]
     return {
         "ok": bool(sources) if source_id else True,
         "scope": "source" if source_id else "all",
         "source_id": source_id,
         "sources": sources,
         "source_count": len(sources),
+        "projection": {
+            "name": PROJECTION_SOURCE_REGISTRY,
+            "path": str(registry_path(runtime_dir)),
+            "rebuildable": True,
+        },
+        "source_status": source_status,
     }
 
 
@@ -187,7 +344,30 @@ def fsck(
     *,
     source_id: str | None = None,
 ) -> dict[str, Any]:
-    sources = list_sources(runtime_dir)
+    try:
+        registry = load_registry(runtime_dir)
+    except (OSError, json.JSONDecodeError, ValueError) as e:
+        return {
+            "ok": False,
+            "scope": "source" if source_id else "all",
+            "source_id": source_id,
+            "errors": [{"code": "source_registry_invalid", "error": str(e)}],
+            "warnings": [],
+            "checked": {
+                "sources": 0,
+                "manifests": 0,
+                "payloads": 0,
+                "schemas": 0,
+                "accepted_ranges": 0,
+                "source_records": 0,
+                "projection_indexes": 0,
+                "orphan_payloads": 0,
+            },
+        }
+    sources = sorted(
+        registry["sources"].values(),
+        key=lambda source: str(source.get("source_id") or ""),
+    )
     if source_id:
         sources = [source for source in sources if source.get("source_id") == source_id]
     report: dict[str, Any] = {
@@ -202,6 +382,9 @@ def fsck(
             "payloads": 0,
             "schemas": 0,
             "accepted_ranges": 0,
+            "source_records": 0,
+            "projection_indexes": 1,
+            "orphan_payloads": 0,
         },
     }
     if source_id and not sources:
@@ -218,6 +401,18 @@ def fsck(
             )
             continue
         report["checked"]["manifests"] += 1
+        report["checked"]["source_records"] += 1
+        projected_source = _source_projection_from_manifest(manifest)
+        if projected_source != source:
+            report["ok"] = False
+            report["errors"].append(
+                {
+                    "code": "source_registry_drift",
+                    "source_id": current_source_id,
+                    "expected": projected_source,
+                    "actual": source,
+                }
+            )
         for issue in verify_import_manifest(manifest):
             row = dict(issue)
             row["source_id"] = current_source_id
@@ -230,6 +425,20 @@ def fsck(
         report["checked"]["schemas"] += len(
             manifest.get("schema_inventory", {}).get("entries", [])
         )
+        payload_inventory = manifest.get("payload_inventory", {})
+        if isinstance(payload_inventory, dict):
+            inventory_count = len(payload_inventory.get("entries", []))
+            entry_count = len(_entries_for_manifest(manifest))
+            if inventory_count != entry_count:
+                report["ok"] = False
+                report["errors"].append(
+                    {
+                        "code": "payload_inventory_mismatch",
+                        "source_id": current_source_id,
+                        "expected": entry_count,
+                        "actual": inventory_count,
+                    }
+                )
         for entry in _entries_for_manifest(manifest):
             report["checked"]["payloads"] += 1
             if entry.get("payload_state") != PAYLOAD_STATE_PRESENT:
@@ -254,7 +463,238 @@ def fsck(
                         "payload_hash": entry.get("payload_hash"),
                     }
                 )
+    if source_id is None:
+        referenced = _referenced_payload_hashes(runtime_dir)
+        for path in _all_payload_paths(runtime_dir):
+            if _payload_digest_from_path(path) not in referenced:
+                report["checked"]["orphan_payloads"] += 1
+                report["warnings"].append(
+                    {
+                        "code": "orphan_payload",
+                        "path": str(path),
+                        "payload_hash": _payload_digest_from_path(path),
+                    }
+                )
     return report
+
+
+def rebuild_index(
+    runtime_dir: str | Path,
+    *,
+    source_id: str | None = None,
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    """Rebuild the source registry projection from accepted manifests."""
+
+    try:
+        old_registry = load_registry(runtime_dir)
+    except (OSError, json.JSONDecodeError, ValueError):
+        old_registry = {"schema": SOURCE_REGISTRY_SCHEMA, "sources": {}}
+
+    old_sources = old_registry.get("sources", {})
+    old_sources = old_sources if isinstance(old_sources, dict) else {}
+    if source_id:
+        new_sources = dict(old_sources)
+    else:
+        new_sources = {}
+
+    changes = []
+    errors = []
+    rebuilt = 0
+    for path in _latest_manifest_paths(runtime_dir, source_id):
+        try:
+            manifest = _read_json(path)
+        except (OSError, json.JSONDecodeError) as e:
+            errors.append(
+                {"code": "manifest_read_error", "path": str(path), "error": str(e)}
+            )
+            continue
+        if not manifest:
+            errors.append({"code": "manifest_invalid", "path": str(path)})
+            continue
+        current_source_id = str(manifest.get("source_id") or "")
+        if not current_source_id:
+            errors.append({"code": "source_id_missing", "path": str(path)})
+            continue
+        projected = _source_projection_from_manifest(manifest)
+        previous = old_sources.get(current_source_id)
+        if previous != projected:
+            changes.append(
+                {
+                    "source_id": current_source_id,
+                    "action": "update" if previous is not None else "add",
+                    "manifest_id": manifest.get("manifest_id"),
+                }
+            )
+        new_sources[current_source_id] = projected
+        rebuilt += 1
+
+    if source_id and rebuilt == 0:
+        errors.append({"code": "source_manifest_missing", "source_id": source_id})
+
+    new_registry = {"schema": SOURCE_REGISTRY_SCHEMA, "sources": new_sources}
+    would_write = old_registry != new_registry
+    if would_write and not dry_run:
+        save_registry(runtime_dir, new_registry)
+
+    return {
+        "ok": not errors,
+        "scope": "source" if source_id else "all",
+        "source_id": source_id,
+        "projection": {
+            "name": PROJECTION_SOURCE_REGISTRY,
+            "path": str(registry_path(runtime_dir)),
+            "rebuilt_from": "accepted latest manifests",
+        },
+        "dry_run": dry_run,
+        "would_write": would_write,
+        "written": would_write and not dry_run,
+        "sources_rebuilt": rebuilt,
+        "changes": changes,
+        "errors": errors,
+        "unsupported": [
+            {
+                "name": PROJECTION_SQLITE,
+                "reason": "no generic SQLite projection exists in this storage slice",
+            }
+        ],
+    }
+
+
+def gc_plan(
+    runtime_dir: str | Path,
+    *,
+    source_id: str | None = None,
+    dry_run: bool = True,
+) -> dict[str, Any]:
+    if not dry_run:
+        raise ValueError("storage_gc_requires_dry_run")
+    referenced = _referenced_payload_hashes(runtime_dir, source_id)
+    payloads = _all_payload_paths(runtime_dir)
+    candidates = []
+    for path in payloads:
+        digest = _payload_digest_from_path(path)
+        if digest in referenced:
+            continue
+        candidates.append(
+            {
+                "payload_hash": digest,
+                "path": str(path),
+                "bytes": path.stat().st_size,
+                "safe_to_delete": source_id is None,
+            }
+        )
+    return {
+        "ok": True,
+        "scope": "source" if source_id else "all",
+        "source_id": source_id,
+        "dry_run": True,
+        "payloads_scanned": len(payloads),
+        "referenced_payloads": len(referenced),
+        "candidate_count": len(candidates),
+        "candidate_bytes": sum(row["bytes"] for row in candidates),
+        "candidates": candidates,
+        "notes": [
+            "No payloads were deleted.",
+            (
+                "Source scope candidates are not globally safe to delete because "
+                "the interim payload store is shared."
+            )
+            if source_id
+            else "All-scope candidates are unreferenced by retained storage manifests.",
+        ],
+    }
+
+
+def compact_plan(
+    runtime_dir: str | Path,
+    *,
+    source_id: str | None = None,
+    dry_run: bool = True,
+) -> dict[str, Any]:
+    if not dry_run:
+        raise ValueError("storage_compact_requires_dry_run")
+    rebuild = rebuild_index(runtime_dir, source_id=source_id, dry_run=True)
+    garbage = gc_plan(runtime_dir, source_id=source_id, dry_run=True)
+    manifests = []
+    for path in _manifest_paths(runtime_dir, source_id):
+        try:
+            manifest = _read_json(path)
+        except (OSError, json.JSONDecodeError):
+            continue
+        if manifest:
+            manifests.append(
+                {
+                    "source_id": manifest.get("source_id"),
+                    "manifest_id": manifest.get("manifest_id"),
+                    "path": str(path),
+                    "entries": len(_entries_for_manifest(manifest)),
+                    "sync_root": manifest.get("sync_root"),
+                }
+            )
+    return {
+        "ok": rebuild["ok"] and garbage["ok"],
+        "scope": "source" if source_id else "all",
+        "source_id": source_id,
+        "dry_run": True,
+        "retained_manifests": manifests,
+        "rebuild_index": rebuild,
+        "gc": garbage,
+        "unsupported": [
+            {
+                "name": "history-archive",
+                "reason": "archive bundles are not implemented in this slice",
+            },
+            {
+                "name": PROJECTION_SQLITE,
+                "reason": "no generic SQLite projection exists in this storage slice",
+            },
+            {
+                "name": "backend-compact",
+                "reason": "the interim backend is content-addressed files",
+            },
+        ],
+        "notes": [
+            "No manifests, payloads, journal frames, or projections were rewritten.",
+            "This is a reviewable compaction plan, not destructive compaction.",
+        ],
+    }
+
+
+def verify_local_sync(
+    runtime_dir: str | Path,
+    *,
+    source_id: str,
+) -> dict[str, Any]:
+    source_report = fsck(runtime_dir, source_id=source_id)
+    if not source_report["ok"]:
+        return {
+            "ok": False,
+            "scope": "source",
+            "source_id": source_id,
+            "errors": [{"code": "source_fsck_failed", "fsck": source_report}],
+        }
+    bundle = build_export_bundle(runtime_dir, source_id=source_id)
+    with tempfile.TemporaryDirectory(prefix="kungfu-storage-sync-") as temp_dir:
+        import_result = import_bundle(temp_dir, bundle)
+        imported_report = fsck(temp_dir, source_id=source_id)
+        imported_manifest = load_latest_manifest(temp_dir, source_id)
+    local_manifest = load_latest_manifest(runtime_dir, source_id)
+    local_root = local_manifest.get("sync_root") if local_manifest else None
+    imported_root = imported_manifest.get("sync_root") if imported_manifest else None
+    roots_match = local_root == imported_root
+    return {
+        "ok": imported_report["ok"] and roots_match,
+        "scope": "source",
+        "source_id": source_id,
+        "exported_records": len(bundle.get("records", [])),
+        "import": import_result,
+        "local_sync_root": local_root,
+        "imported_sync_root": imported_root,
+        "sync_roots_match": roots_match,
+        "source_fsck": source_report,
+        "imported_fsck": imported_report,
+    }
 
 
 def write_jsonl(records: list[dict[str, Any]], out_path: str | Path) -> None:

--- a/framework/core/tests/python/test_atlas_storage.py
+++ b/framework/core/tests/python/test_atlas_storage.py
@@ -574,6 +574,64 @@ def test_generic_storage_service_handles_non_atlas_source_bundle(tmp_path):
     assert storage_service.fsck(imported_range_runtime, source_id="local-synth")["ok"]
 
 
+def test_storage_maintenance_rebuild_gc_compact_and_sync_check(tmp_path):
+    runtime_dir = tmp_path / "runtime"
+    accepted = storage_service.write_synthetic_source(
+        runtime_dir,
+        source_id="local-synth",
+        manifest_id="imp-synth",
+        source_head="head-1",
+        records=[
+            {
+                "kind": "note",
+                "source_id": "note-a",
+                "source_path": "notes/a.json",
+                "source_time": "2026-07-08T00:00:00Z",
+                "payload": {"title": "A", "body": "alpha"},
+            }
+        ],
+    )
+    status = storage_service.status(runtime_dir, source_id="local-synth")
+    assert status["source_status"][0]["accepted_cursor"]["source_head"] == "head-1"
+    assert status["source_status"][0]["sync_root"] == accepted["sync_root"]
+
+    storage_service.registry_path(runtime_dir).unlink()
+    dry_rebuild = storage_service.rebuild_index(
+        runtime_dir, source_id="local-synth", dry_run=True
+    )
+    assert dry_rebuild["ok"]
+    assert dry_rebuild["would_write"]
+    assert not storage_service.registry_path(runtime_dir).exists()
+
+    rebuild = storage_service.rebuild_index(runtime_dir, source_id="local-synth")
+    assert rebuild["ok"]
+    assert rebuild["written"]
+    assert storage_service.status(runtime_dir, source_id="local-synth")["ok"]
+
+    orphan_hash = "0" * 64
+    storage_service.write_payload_bytes(runtime_dir, orphan_hash, b'{"orphan":true}')
+    gc = storage_service.gc_plan(runtime_dir, dry_run=True)
+    assert gc["candidate_count"] == 1
+    assert gc["candidates"][0]["payload_hash"] == orphan_hash
+    assert gc["candidates"][0]["safe_to_delete"] is True
+    assert storage_service.payload_path(runtime_dir, orphan_hash).exists()
+
+    compact = storage_service.compact_plan(runtime_dir, dry_run=True)
+    assert compact["ok"]
+    assert compact["gc"]["candidate_count"] == 1
+    assert any(row["name"] == "backend-compact" for row in compact["unsupported"])
+
+    fsck = storage_service.fsck(runtime_dir)
+    assert fsck["ok"]
+    assert fsck["checked"]["orphan_payloads"] == 1
+    assert any(warning["code"] == "orphan_payload" for warning in fsck["warnings"])
+
+    sync_check = storage_service.verify_local_sync(runtime_dir, source_id="local-synth")
+    assert sync_check["ok"]
+    assert sync_check["sync_roots_match"]
+    assert sync_check["exported_records"] == 1
+
+
 def test_atlas_import_persists_generic_source_manifest(tmp_path):
     repo = tmp_path / "atlas"
     runtime_dir = tmp_path / "runtime"


### PR DESCRIPTION
## Summary
- add storage maintenance operations for the generic source service: status/fsck expansion, projection rebuild, dry-run gc/compact planning, and local sync verification
- expose the maintenance surface through `kungfu storage ...` CLI commands and KFD-3 adjacent-agent command metadata
- document the first safe maintenance/sync-readiness slice in `docs/runtime-storage-service.md`

## Validation
- `./kungfu-code check`
- `./kungfu-code build`
- `./kungfu-code --dir framework/core exec env PYTHONPATH=build/Release:src/python uv run --frozen pytest tests/python/test_atlas_storage.py` (`13 passed`)
- frozen CLI smoke using `/Users/dkr/Code/atlas` as an Atlas source with `--since 3d`: sync/status/fsck/gc/compact/rebuild-index/verify-sync all passed; sync roots matched
- `./kungfu-code kfd:buildchain` (`48 KFD-3 surface(s)`)
