### PR TITLE
feat(storage): add runtime service API surface

### DIFF
--- a/docs/runtime-storage-service.md
+++ b/docs/runtime-storage-service.md
@@ -76,11 +76,24 @@ Implementation boundary:
 - `libkungfu` owns runtime implementation and adapters on top of that kernel:
   RocksDB-backed providers, SQLite projections, transport/process wiring,
   typed schema dumping, Python/Node bindings, and product command surfaces.
+- Python and Node are command, binding, UI, or adapter layers. They may own
+  file parsing and temporary glue while a backend is being migrated, but the
+  stable storage service surface belongs in `libkungfu` so every language calls
+  the same runtime contract.
 
 This keeps storage facts portable across C++, Python, and Node without making
 Python or JavaScript responsible for their own storage semantics. It also keeps
 backend choices replaceable: a backend can change without changing the
 `yijinjing` contract or the product vocabulary.
+
+The first `libkungfu` slice exposes
+`kungfu::runtime::storage_service_api::storage_service` and the
+`kungfu.runtime.storage-service/v1` operation request surface for `status`,
+`fsck`, `export_bundle`, `import_bundle`, `rebuild_index`, `gc_plan`,
+`compact_plan`, and `verify_sync`. Python storage commands enter that C++
+surface before running the interim content-addressed file backend. The next
+provider slice moves the file backend and maintenance behavior behind the same
+C++ service instead of adding another Python-only contract.
 
 The first C++ contract surface is intentionally header-only vocabulary under
 `<kungfu/yijinjing/storage...>`:

--- a/framework/core/src/bindings/python/binding/py-runtime.cpp
+++ b/framework/core/src/bindings/python/binding/py-runtime.cpp
@@ -15,6 +15,7 @@
 #include <kungfu/runtime/practice/apprentice.h>
 #include <kungfu/runtime/practice/master.h>
 #include <kungfu/runtime/schema/schema_compiler.h>
+#include <kungfu/runtime/storage/service.h>
 #include <kungfu/runtime/util/terminal.h>
 #include <kungfu/yijinjing/hash.h>
 #include <kungfu/yijinjing/journal/assemble.h>
@@ -429,6 +430,15 @@ void bind(pybind11::module &&m) {
         return json_to_py(yijinjing::storage::build_storage_export_bundle(py_to_json(manifest), py_to_json(records)));
       },
       py::arg("manifest"), py::arg("records"));
+  m.def("storage_service_capabilities",
+        []() { return json_to_py(storage_service_api::storage_service_capabilities()); });
+  m.def(
+      "make_storage_service_request",
+      [](const std::string &operation, const std::string &runtime_dir, py::dict options) {
+        return json_to_py(
+            storage_service_api::make_storage_service_request(operation, runtime_dir, py_to_json(options)));
+      },
+      py::arg("operation"), py::arg("runtime_dir"), py::arg("options") = py::dict());
 
   m.def("setup_log", &yijinjing::log::setup_log);
   m.def("emit_log", &yijinjing::log::emit_log);

--- a/framework/core/src/libkungfu/include/kungfu/runtime/storage/service.h
+++ b/framework/core/src/libkungfu/include/kungfu/runtime/storage/service.h
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef KUNGFU_RUNTIME_STORAGE_SERVICE_H
+#define KUNGFU_RUNTIME_STORAGE_SERVICE_H
+
+#include <string>
+#include <vector>
+
+#include <nlohmann/json.hpp>
+
+namespace kungfu::runtime::storage_service_api {
+
+inline constexpr const char *RUNTIME_STORAGE_SERVICE_SCHEMA_V1 = "kungfu.runtime.storage-service/v1";
+inline constexpr const char *RUNTIME_STORAGE_SERVICE_OWNER = "libkungfu";
+
+enum class storage_operation {
+  Status,
+  Fsck,
+  ExportBundle,
+  ImportBundle,
+  RebuildIndex,
+  GcPlan,
+  CompactPlan,
+  VerifySync,
+};
+
+struct storage_service_options {
+  std::string runtime_dir = {};
+  std::string scope = {};
+  std::string source_id = {};
+  bool dry_run = true;
+  bool verify = true;
+  nlohmann::json range = nlohmann::json::object();
+  std::string artifact_uri = {};
+};
+
+class storage_service {
+public:
+  virtual ~storage_service() = default;
+
+  [[nodiscard]] virtual nlohmann::json status(const storage_service_options &options) const = 0;
+
+  [[nodiscard]] virtual nlohmann::json fsck(const storage_service_options &options) const = 0;
+
+  [[nodiscard]] virtual nlohmann::json export_bundle(const storage_service_options &options) const = 0;
+
+  [[nodiscard]] virtual nlohmann::json import_bundle(const storage_service_options &options) const = 0;
+
+  [[nodiscard]] virtual nlohmann::json rebuild_index(const storage_service_options &options) const = 0;
+
+  [[nodiscard]] virtual nlohmann::json gc_plan(const storage_service_options &options) const = 0;
+
+  [[nodiscard]] virtual nlohmann::json compact_plan(const storage_service_options &options) const = 0;
+
+  [[nodiscard]] virtual nlohmann::json verify_sync(const storage_service_options &options) const = 0;
+};
+
+[[nodiscard]] std::vector<std::string> storage_operation_names();
+
+[[nodiscard]] std::string storage_operation_name(storage_operation operation);
+
+[[nodiscard]] storage_operation parse_storage_operation(const std::string &operation);
+
+[[nodiscard]] storage_service_options parse_storage_service_options(const std::string &runtime_dir,
+                                                                    const nlohmann::json &options);
+
+[[nodiscard]] nlohmann::json make_storage_service_request(const std::string &operation, const std::string &runtime_dir,
+                                                          const nlohmann::json &options = nlohmann::json::object());
+
+[[nodiscard]] nlohmann::json storage_service_capabilities();
+
+} // namespace kungfu::runtime::storage_service_api
+
+#endif // KUNGFU_RUNTIME_STORAGE_SERVICE_H

--- a/framework/core/src/libkungfu/src/runtime/storage/service.cpp
+++ b/framework/core/src/libkungfu/src/runtime/storage/service.cpp
@@ -1,0 +1,209 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#include <kungfu/runtime/storage/service.h>
+
+#include <stdexcept>
+#include <utility>
+
+namespace kungfu::runtime::storage_service_api {
+
+namespace {
+
+std::string text_or(const nlohmann::json &object, const std::string &field, const std::string &fallback = {}) {
+  if (!object.is_object() || !object.contains(field)) {
+    return fallback;
+  }
+  const auto &value = object.at(field);
+  if (value.is_string()) {
+    return value.get<std::string>();
+  }
+  if (value.is_null()) {
+    return fallback;
+  }
+  return value.dump(-1, ' ', false);
+}
+
+bool bool_or(const nlohmann::json &object, const std::string &field, bool fallback) {
+  if (!object.is_object() || !object.contains(field)) {
+    return fallback;
+  }
+  const auto &value = object.at(field);
+  return value.is_boolean() ? value.get<bool>() : fallback;
+}
+
+nlohmann::json object_or_empty(const nlohmann::json &object, const std::string &field) {
+  if (!object.is_object() || !object.contains(field) || !object.at(field).is_object()) {
+    return nlohmann::json::object();
+  }
+  return object.at(field);
+}
+
+class request_only_storage_service : public storage_service {
+public:
+  [[nodiscard]] nlohmann::json status(const storage_service_options &options) const override {
+    return make_request(storage_operation::Status, options);
+  }
+
+  [[nodiscard]] nlohmann::json fsck(const storage_service_options &options) const override {
+    return make_request(storage_operation::Fsck, options);
+  }
+
+  [[nodiscard]] nlohmann::json export_bundle(const storage_service_options &options) const override {
+    return make_request(storage_operation::ExportBundle, options);
+  }
+
+  [[nodiscard]] nlohmann::json import_bundle(const storage_service_options &options) const override {
+    return make_request(storage_operation::ImportBundle, options);
+  }
+
+  [[nodiscard]] nlohmann::json rebuild_index(const storage_service_options &options) const override {
+    return make_request(storage_operation::RebuildIndex, options);
+  }
+
+  [[nodiscard]] nlohmann::json gc_plan(const storage_service_options &options) const override {
+    return make_request(storage_operation::GcPlan, options);
+  }
+
+  [[nodiscard]] nlohmann::json compact_plan(const storage_service_options &options) const override {
+    return make_request(storage_operation::CompactPlan, options);
+  }
+
+  [[nodiscard]] nlohmann::json verify_sync(const storage_service_options &options) const override {
+    return make_request(storage_operation::VerifySync, options);
+  }
+
+private:
+  [[nodiscard]] static nlohmann::json make_request(storage_operation operation,
+                                                   const storage_service_options &options) {
+    return {
+        {"schema", RUNTIME_STORAGE_SERVICE_SCHEMA_V1},
+        {"owner", RUNTIME_STORAGE_SERVICE_OWNER},
+        {"operation", storage_operation_name(operation)},
+        {"runtime_dir", options.runtime_dir},
+        {"scope", options.scope},
+        {"source_id", options.source_id},
+        {"dry_run", options.dry_run},
+        {"verify", options.verify},
+        {"range", options.range},
+        {"artifact_uri", options.artifact_uri},
+    };
+  }
+};
+
+const request_only_storage_service &request_service() {
+  static const request_only_storage_service service;
+  return service;
+}
+
+} // namespace
+
+std::vector<std::string> storage_operation_names() {
+  return {
+      storage_operation_name(storage_operation::Status),       storage_operation_name(storage_operation::Fsck),
+      storage_operation_name(storage_operation::ExportBundle), storage_operation_name(storage_operation::ImportBundle),
+      storage_operation_name(storage_operation::RebuildIndex), storage_operation_name(storage_operation::GcPlan),
+      storage_operation_name(storage_operation::CompactPlan),  storage_operation_name(storage_operation::VerifySync),
+  };
+}
+
+std::string storage_operation_name(storage_operation operation) {
+  switch (operation) {
+  case storage_operation::Status:
+    return "status";
+  case storage_operation::Fsck:
+    return "fsck";
+  case storage_operation::ExportBundle:
+    return "export_bundle";
+  case storage_operation::ImportBundle:
+    return "import_bundle";
+  case storage_operation::RebuildIndex:
+    return "rebuild_index";
+  case storage_operation::GcPlan:
+    return "gc_plan";
+  case storage_operation::CompactPlan:
+    return "compact_plan";
+  case storage_operation::VerifySync:
+    return "verify_sync";
+  }
+  throw std::invalid_argument("unknown storage operation");
+}
+
+storage_operation parse_storage_operation(const std::string &operation) {
+  if (operation == "status") {
+    return storage_operation::Status;
+  }
+  if (operation == "fsck") {
+    return storage_operation::Fsck;
+  }
+  if (operation == "export_bundle") {
+    return storage_operation::ExportBundle;
+  }
+  if (operation == "import_bundle") {
+    return storage_operation::ImportBundle;
+  }
+  if (operation == "rebuild_index") {
+    return storage_operation::RebuildIndex;
+  }
+  if (operation == "gc_plan") {
+    return storage_operation::GcPlan;
+  }
+  if (operation == "compact_plan") {
+    return storage_operation::CompactPlan;
+  }
+  if (operation == "verify_sync") {
+    return storage_operation::VerifySync;
+  }
+  throw std::invalid_argument("unsupported storage operation: " + operation);
+}
+
+storage_service_options parse_storage_service_options(const std::string &runtime_dir, const nlohmann::json &options) {
+  storage_service_options parsed;
+  parsed.runtime_dir = runtime_dir;
+  parsed.scope = text_or(options, "scope", "all");
+  parsed.source_id = text_or(options, "source_id");
+  parsed.dry_run = bool_or(options, "dry_run", true);
+  parsed.verify = bool_or(options, "verify", true);
+  parsed.range = object_or_empty(options, "range");
+  parsed.artifact_uri = text_or(options, "artifact_uri");
+  return parsed;
+}
+
+nlohmann::json make_storage_service_request(const std::string &operation, const std::string &runtime_dir,
+                                            const nlohmann::json &options) {
+  const auto parsed_operation = parse_storage_operation(operation);
+  const auto parsed_options = parse_storage_service_options(runtime_dir, options);
+  switch (parsed_operation) {
+  case storage_operation::Status:
+    return request_service().status(parsed_options);
+  case storage_operation::Fsck:
+    return request_service().fsck(parsed_options);
+  case storage_operation::ExportBundle:
+    return request_service().export_bundle(parsed_options);
+  case storage_operation::ImportBundle:
+    return request_service().import_bundle(parsed_options);
+  case storage_operation::RebuildIndex:
+    return request_service().rebuild_index(parsed_options);
+  case storage_operation::GcPlan:
+    return request_service().gc_plan(parsed_options);
+  case storage_operation::CompactPlan:
+    return request_service().compact_plan(parsed_options);
+  case storage_operation::VerifySync:
+    return request_service().verify_sync(parsed_options);
+  }
+  throw std::invalid_argument("unknown storage operation");
+}
+
+nlohmann::json storage_service_capabilities() {
+  return {
+      {"schema", RUNTIME_STORAGE_SERVICE_SCHEMA_V1},
+      {"owner", RUNTIME_STORAGE_SERVICE_OWNER},
+      {"operations", storage_operation_names()},
+      {"backend", "request-only"},
+      {"notes", nlohmann::json::array({
+                    "The public runtime storage service surface is owned by libkungfu.",
+                    "The interim content-addressed file backend remains in the language layer until the provider card.",
+                })},
+  };
+}
+
+} // namespace kungfu::runtime::storage_service_api

--- a/framework/core/src/python/kungfu/storage/service.py
+++ b/framework/core/src/python/kungfu/storage/service.py
@@ -16,10 +16,43 @@ SOURCE_REGISTRY_SCHEMA = "kungfu.storage.source-registry/v1"
 PROJECTION_SOURCE_REGISTRY = "source-registry"
 PROJECTION_SQLITE = "sqlite"
 PROJECTION_ATLAS_JOURNAL_FOLD = "atlas-journal-fold"
+RUNTIME_STORAGE_SERVICE_SCHEMA = "kungfu.runtime.storage-service/v1"
 
 
 def _runtime():
     return kungfu.__binding__.runtime
+
+
+def service_capabilities() -> dict[str, Any]:
+    return dict(_runtime().storage_service_capabilities())
+
+
+def _runtime_service_request(
+    operation: str,
+    runtime_dir: str | Path,
+    *,
+    scope: str = "all",
+    source_id: str | None = None,
+    dry_run: bool = True,
+    verify: bool = True,
+    range_filter: dict[str, Any] | None = None,
+    artifact_uri: str | None = None,
+) -> dict[str, Any]:
+    request = _runtime().make_storage_service_request(
+        operation,
+        str(runtime_dir),
+        {
+            "scope": scope,
+            "source_id": source_id,
+            "dry_run": dry_run,
+            "verify": verify,
+            "range": range_filter or {},
+            "artifact_uri": artifact_uri or "",
+        },
+    )
+    if request.get("schema") != RUNTIME_STORAGE_SERVICE_SCHEMA:
+        raise RuntimeError(f"invalid runtime storage service request: {request}")
+    return dict(request)
 
 
 def root_dir(runtime_dir: str | Path) -> Path:
@@ -281,6 +314,12 @@ def status(
     *,
     source_id: str | None = None,
 ) -> dict[str, Any]:
+    _runtime_service_request(
+        "status",
+        runtime_dir,
+        scope="source" if source_id else "all",
+        source_id=source_id,
+    )
     sources = [
         source
         for source in list_sources(runtime_dir)
@@ -344,6 +383,12 @@ def fsck(
     *,
     source_id: str | None = None,
 ) -> dict[str, Any]:
+    _runtime_service_request(
+        "fsck",
+        runtime_dir,
+        scope="source" if source_id else "all",
+        source_id=source_id,
+    )
     try:
         registry = load_registry(runtime_dir)
     except (OSError, json.JSONDecodeError, ValueError) as e:
@@ -486,6 +531,13 @@ def rebuild_index(
 ) -> dict[str, Any]:
     """Rebuild the source registry projection from accepted manifests."""
 
+    _runtime_service_request(
+        "rebuild_index",
+        runtime_dir,
+        scope="source" if source_id else "all",
+        source_id=source_id,
+        dry_run=dry_run,
+    )
     try:
         old_registry = load_registry(runtime_dir)
     except (OSError, json.JSONDecodeError, ValueError):
@@ -567,6 +619,13 @@ def gc_plan(
     source_id: str | None = None,
     dry_run: bool = True,
 ) -> dict[str, Any]:
+    _runtime_service_request(
+        "gc_plan",
+        runtime_dir,
+        scope="source" if source_id else "all",
+        source_id=source_id,
+        dry_run=dry_run,
+    )
     if not dry_run:
         raise ValueError("storage_gc_requires_dry_run")
     referenced = _referenced_payload_hashes(runtime_dir, source_id)
@@ -612,6 +671,13 @@ def compact_plan(
     source_id: str | None = None,
     dry_run: bool = True,
 ) -> dict[str, Any]:
+    _runtime_service_request(
+        "compact_plan",
+        runtime_dir,
+        scope="source" if source_id else "all",
+        source_id=source_id,
+        dry_run=dry_run,
+    )
     if not dry_run:
         raise ValueError("storage_compact_requires_dry_run")
     rebuild = rebuild_index(runtime_dir, source_id=source_id, dry_run=True)
@@ -666,6 +732,12 @@ def verify_local_sync(
     *,
     source_id: str,
 ) -> dict[str, Any]:
+    _runtime_service_request(
+        "verify_sync",
+        runtime_dir,
+        scope="source",
+        source_id=source_id,
+    )
     source_report = fsck(runtime_dir, source_id=source_id)
     if not source_report["ok"]:
         return {
@@ -795,6 +867,13 @@ def build_export_bundle(
     source_id: str,
     range_filter: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
+    _runtime_service_request(
+        "export_bundle",
+        runtime_dir,
+        scope="source",
+        source_id=source_id,
+        range_filter=range_filter,
+    )
     manifest = load_latest_manifest(runtime_dir, source_id)
     if manifest is None:
         raise FileNotFoundError(str(latest_manifest_path(runtime_dir, source_id)))
@@ -827,6 +906,14 @@ def import_bundle(
     *,
     verify: bool = True,
 ) -> dict[str, Any]:
+    source_id = str(bundle.get("source_id") or "")
+    _runtime_service_request(
+        "import_bundle",
+        runtime_dir,
+        scope="source" if source_id else "all",
+        source_id=source_id or None,
+        verify=verify,
+    )
     manifest = bundle.get("manifest")
     if not isinstance(manifest, dict):
         raise ValueError("bundle_manifest_missing")

--- a/framework/core/stubs/pykungfu/runtime.pyi
+++ b/framework/core/stubs/pykungfu/runtime.pyi
@@ -3,7 +3,7 @@ import pykungfu.yijinjing.enums
 import pykungfu.yijinjing.types
 import typing
 import typing_extensions
-__all__: list[str] = ['CONTENT_HASH_ALGORITHM_BLAKE3', 'CONTENT_HASH_ALGORITHM_SHA256', 'DEFAULT_FRAME_CHECKSUM_ALGORITHM', 'DEFAULT_FRAME_INTEGRITY_VERSION', 'FAST_HASH_ALGORITHM', 'FAST_HASH_ALGORITHM_128', 'FAST_HASH_ALGORITHM_64', 'FRAME_CHECKSUM_ALGORITHM_CRC32C', 'FRAME_CHECKSUM_ALGORITHM_FNV1A64', 'FRAME_INTEGRITY_VERSION_V1', 'FRAME_INTEGRITY_VERSION_V2', 'PUBLISH', 'PULL', 'PUSH', 'REPLY', 'REQUEST', 'SUBSCRIBE', 'action_record_options', 'action_record_receipt', 'action_recorder', 'apprentice', 'assemble', 'build_storage_export_bundle', 'build_storage_import_manifest', 'build_storage_source_record', 'bus', 'calendar_day_start', 'checksum_payload', 'color_print', 'compile_schema', 'compute_content_hash', 'compute_content_hash_value', 'compute_storage_sync_root', 'copy_sink', 'emit_log', 'event', 'fast_hash_32', 'fast_hash_64', 'fast_hash_str_32', 'fast_hash_str_64', 'fast_hash_string_128', 'fast_hash_string_32', 'fast_hash_string_64', 'filter_storage_manifest_entries', 'format_content_hash', 'frame', 'frame_checksum_algorithm_for_integrity_version', 'frame_integrity_version_for_checksum_algorithm', 'get_page_path', 'hash_32', 'hash_str_32', 'history_window_start', 'in_color_terminal', 'io_device', 'is_supported_content_hash_algorithm', 'is_supported_frame_checksum_algorithm', 'location', 'locator', 'master', 'nano_hashed', 'next_minute', 'next_session_boundary', 'noop_publisher', 'normalize_content_hash_algorithm', 'now_in_nano', 'null_sink', 'observer', 'parse_content_hash', 'profile', 'protocol', 'publisher', 'reader', 'session_builder', 'session_finder', 'session_window_start', 'setup_log', 'sink', 'socket', 'storage_sync_root_entry_commitment', 'strfnow', 'strftime', 'strptime', 'thread_id', 'today_start', 'verify_content_hash', 'verify_storage_import_manifest', 'verify_storage_payload', 'verify_storage_sync_root', 'writer']
+__all__: list[str] = ['CONTENT_HASH_ALGORITHM_BLAKE3', 'CONTENT_HASH_ALGORITHM_SHA256', 'DEFAULT_FRAME_CHECKSUM_ALGORITHM', 'DEFAULT_FRAME_INTEGRITY_VERSION', 'FAST_HASH_ALGORITHM', 'FAST_HASH_ALGORITHM_128', 'FAST_HASH_ALGORITHM_64', 'FRAME_CHECKSUM_ALGORITHM_CRC32C', 'FRAME_CHECKSUM_ALGORITHM_FNV1A64', 'FRAME_INTEGRITY_VERSION_V1', 'FRAME_INTEGRITY_VERSION_V2', 'PUBLISH', 'PULL', 'PUSH', 'REPLY', 'REQUEST', 'SUBSCRIBE', 'action_record_options', 'action_record_receipt', 'action_recorder', 'apprentice', 'assemble', 'build_storage_export_bundle', 'build_storage_import_manifest', 'build_storage_source_record', 'bus', 'calendar_day_start', 'checksum_payload', 'color_print', 'compile_schema', 'compute_content_hash', 'compute_content_hash_value', 'compute_storage_sync_root', 'copy_sink', 'emit_log', 'event', 'fast_hash_32', 'fast_hash_64', 'fast_hash_str_32', 'fast_hash_str_64', 'fast_hash_string_128', 'fast_hash_string_32', 'fast_hash_string_64', 'filter_storage_manifest_entries', 'format_content_hash', 'frame', 'frame_checksum_algorithm_for_integrity_version', 'frame_integrity_version_for_checksum_algorithm', 'get_page_path', 'hash_32', 'hash_str_32', 'history_window_start', 'in_color_terminal', 'io_device', 'is_supported_content_hash_algorithm', 'is_supported_frame_checksum_algorithm', 'location', 'locator', 'make_storage_service_request', 'master', 'nano_hashed', 'next_minute', 'next_session_boundary', 'noop_publisher', 'normalize_content_hash_algorithm', 'now_in_nano', 'null_sink', 'observer', 'parse_content_hash', 'profile', 'protocol', 'publisher', 'reader', 'session_builder', 'session_finder', 'session_window_start', 'setup_log', 'sink', 'socket', 'storage_service_capabilities', 'storage_sync_root_entry_commitment', 'strfnow', 'strftime', 'strptime', 'thread_id', 'today_start', 'verify_content_hash', 'verify_storage_import_manifest', 'verify_storage_payload', 'verify_storage_sync_root', 'writer']
 class action_record_options:
     chain_to_last: bool
     data_type: pykungfu.yijinjing.enums.FrameDataType
@@ -592,6 +592,8 @@ def is_supported_content_hash_algorithm(algorithm: str) -> bool:
     ...
 def is_supported_frame_checksum_algorithm(algorithm: str) -> bool:
     ...
+def make_storage_service_request(operation: str, runtime_dir: str, options: dict = {}) -> typing.Any:
+    ...
 def nano_hashed(arg0: int) -> int:
     ...
 def next_minute(arg0: int) -> int:
@@ -607,6 +609,8 @@ def parse_content_hash(formatted: str) -> tuple:
 def session_window_start() -> int:
     ...
 def setup_log(arg0: ..., arg1: str) -> str:
+    ...
+def storage_service_capabilities() -> typing.Any:
     ...
 def storage_sync_root_entry_commitment(entry: dict) -> typing.Any:
     ...

--- a/framework/core/tests/python/test_atlas_storage.py
+++ b/framework/core/tests/python/test_atlas_storage.py
@@ -299,6 +299,103 @@ def test_storage_core_binding_owns_sync_root_and_payload_checks(tmp_path):
     )
 
 
+def test_runtime_storage_service_surface_is_bound_from_libkungfu(tmp_path):
+    runtime = kungfu.__binding__.runtime
+    capabilities = storage_service.service_capabilities()
+
+    assert capabilities["schema"] == "kungfu.runtime.storage-service/v1"
+    assert capabilities["owner"] == "libkungfu"
+    assert set(capabilities["operations"]) == {
+        "status",
+        "fsck",
+        "export_bundle",
+        "import_bundle",
+        "rebuild_index",
+        "gc_plan",
+        "compact_plan",
+        "verify_sync",
+    }
+
+    request = runtime.make_storage_service_request(
+        "status",
+        str(tmp_path),
+        {"scope": "source", "source_id": "local-synth", "dry_run": True},
+    )
+    assert request == {
+        "schema": "kungfu.runtime.storage-service/v1",
+        "owner": "libkungfu",
+        "operation": "status",
+        "runtime_dir": str(tmp_path),
+        "scope": "source",
+        "source_id": "local-synth",
+        "dry_run": True,
+        "verify": True,
+        "range": {},
+        "artifact_uri": "",
+    }
+
+
+def test_python_storage_operations_enter_runtime_service_surface(tmp_path, monkeypatch):
+    runtime_dir = tmp_path / "runtime"
+    accepted = storage_service.write_synthetic_source(
+        runtime_dir,
+        source_id="local-synth",
+        manifest_id="imp-synth",
+        source_head="head-1",
+        records=[
+            {
+                "kind": "note",
+                "source_id": "note-a",
+                "source_path": "notes/a.json",
+                "source_time": "2026-07-08T00:00:00Z",
+                "payload": {"title": "A", "body": "alpha"},
+            }
+        ],
+    )
+    assert accepted["source_id"] == "local-synth"
+
+    calls = []
+
+    def spy_request(operation, runtime_dir_arg, options):
+        calls.append((operation, runtime_dir_arg, dict(options)))
+        return {
+            "schema": "kungfu.runtime.storage-service/v1",
+            "owner": "libkungfu",
+            "operation": operation,
+            "runtime_dir": runtime_dir_arg,
+        }
+
+    monkeypatch.setattr(
+        kungfu.__binding__.runtime,
+        "make_storage_service_request",
+        spy_request,
+    )
+
+    storage_service.status(runtime_dir, source_id="local-synth")
+    storage_service.fsck(runtime_dir, source_id="local-synth")
+    storage_service.rebuild_index(runtime_dir, source_id="local-synth", dry_run=True)
+    storage_service.gc_plan(runtime_dir, dry_run=True)
+    storage_service.compact_plan(runtime_dir, dry_run=True)
+    storage_service.build_export_bundle(runtime_dir, source_id="local-synth")
+    storage_service.import_bundle(
+        tmp_path / "imported-runtime",
+        storage_service.build_export_bundle(runtime_dir, source_id="local-synth"),
+    )
+    storage_service.verify_local_sync(runtime_dir, source_id="local-synth")
+
+    entered = {operation for operation, _, _ in calls}
+    assert {
+        "status",
+        "fsck",
+        "rebuild_index",
+        "gc_plan",
+        "compact_plan",
+        "export_bundle",
+        "import_bundle",
+        "verify_sync",
+    } <= entered
+
+
 def test_payload_fsck_verifies_versioned_frame_checksums(tmp_path):
     repo = tmp_path / "atlas"
     store = tmp_path / "store"


### PR DESCRIPTION
## Summary
- Add the libkungfu runtime storage service request/capabilities surface for status, fsck, export, import, rebuild, gc, compact, and sync verification operations.
- Expose the surface through the Python runtime binding and route the existing Python storage operations through it while preserving the current backend and output schemas.
- Document the storage layering rule and add tests proving Python storage commands enter the C++ service surface.

## Validation
- `./kungfu-code fix`
- `./kungfu-code check`
- `PYTHONPATH="$PWD/src/python:$PWD/build/Release" DYLD_FALLBACK_LIBRARY_PATH="$PWD/build/Release${DYLD_FALLBACK_LIBRARY_PATH:+:$DYLD_FALLBACK_LIBRARY_PATH}" uv run --frozen pytest tests/python/test_atlas_storage.py` from `framework/core` (`15 passed`)
- `./kungfu-code build`
