### PR TITLE
test(product): smoke CLI product install layout

### DIFF
--- a/product/scripts/archive.mjs
+++ b/product/scripts/archive.mjs
@@ -13,6 +13,34 @@ function normalizePath(value) {
   return value.split(path.sep).join('/');
 }
 
+function unsafeArchivePath(name) {
+  return (
+    !name ||
+    name.includes('\\') ||
+    path.isAbsolute(name) ||
+    /^[a-zA-Z]:/.test(name) ||
+    name
+      .split('/')
+      .filter(Boolean)
+      .some((part) => part === '..')
+  );
+}
+
+function extractPath(targetDir, name) {
+  if (unsafeArchivePath(name)) {
+    throw new Error(`unsafe archive path: ${name}`);
+  }
+  const resolved = path.resolve(targetDir, ...name.split('/').filter(Boolean));
+  const targetRoot = path.resolve(targetDir);
+  if (
+    resolved !== targetRoot &&
+    !resolved.startsWith(`${targetRoot}${path.sep}`)
+  ) {
+    throw new Error(`archive path escapes target: ${name}`);
+  }
+  return resolved;
+}
+
 function collectFiles(root) {
   const files = [];
   const visit = (dir) => {
@@ -94,6 +122,58 @@ export function writeTarGz({ sourceDir, outputFile }) {
     outputFile,
     zlib.gzipSync(Buffer.concat(chunks), { level: 9 }),
   );
+}
+
+function readTarString(buffer, offset, length) {
+  const end = buffer.indexOf(0, offset);
+  const sliceEnd =
+    end >= offset && end < offset + length ? end : offset + length;
+  return buffer.toString('utf8', offset, sliceEnd).replace(/\0.*$/, '');
+}
+
+function readTarOctal(buffer, offset, length) {
+  const value = readTarString(buffer, offset, length).trim();
+  return value ? Number.parseInt(value, 8) : 0;
+}
+
+function chmodIfPossible(file, mode) {
+  try {
+    fs.chmodSync(file, mode);
+  } catch {
+    // Some filesystems/platforms do not preserve POSIX modes.
+  }
+}
+
+export function extractTarGz({ archiveFile, targetDir }) {
+  const buffer = zlib.gunzipSync(fs.readFileSync(archiveFile));
+  fs.mkdirSync(targetDir, { recursive: true });
+  let offset = 0;
+  while (offset + TAR_BLOCK <= buffer.length) {
+    const header = buffer.subarray(offset, offset + TAR_BLOCK);
+    offset += TAR_BLOCK;
+    if (header.every((byte) => byte === 0)) break;
+
+    const name = readTarString(header, 0, 100);
+    const prefix = readTarString(header, 345, 155);
+    const entryName = prefix ? `${prefix}/${name}` : name;
+    const size = readTarOctal(header, 124, 12);
+    const mode = readTarOctal(header, 100, 8) || 0o644;
+    const type = readTarString(header, 156, 1) || '0';
+    const body = buffer.subarray(offset, offset + size);
+    offset += size + (size % TAR_BLOCK ? TAR_BLOCK - (size % TAR_BLOCK) : 0);
+
+    const target = extractPath(targetDir, entryName);
+    if (type === '5') {
+      fs.mkdirSync(target, { recursive: true });
+      continue;
+    }
+    if (type !== '0') {
+      throw new Error(`unsupported tar entry type ${type} for ${entryName}`);
+    }
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.writeFileSync(target, body);
+    chmodIfPossible(target, mode);
+  }
 }
 
 let crcTable;
@@ -202,4 +282,42 @@ export function writeZip({ sourceDir, outputFile }) {
   footer.writeUInt16LE(0, 20);
   fs.mkdirSync(path.dirname(outputFile), { recursive: true });
   fs.writeFileSync(outputFile, Buffer.concat([...local, ...central, footer]));
+}
+
+export function extractZip({ archiveFile, targetDir }) {
+  const buffer = fs.readFileSync(archiveFile);
+  fs.mkdirSync(targetDir, { recursive: true });
+  let offset = 0;
+  while (offset + 4 <= buffer.length) {
+    const signature = buffer.readUInt32LE(offset);
+    if (signature === 0x02014b50 || signature === 0x06054b50) break;
+    if (signature !== 0x04034b50) {
+      throw new Error(`unsupported zip signature at ${offset}: ${signature}`);
+    }
+    const method = buffer.readUInt16LE(offset + 8);
+    const compressedSize = buffer.readUInt32LE(offset + 18);
+    const uncompressedSize = buffer.readUInt32LE(offset + 22);
+    const nameLength = buffer.readUInt16LE(offset + 26);
+    const extraLength = buffer.readUInt16LE(offset + 28);
+    const nameStart = offset + 30;
+    const name = buffer.toString('utf8', nameStart, nameStart + nameLength);
+    const bodyStart = nameStart + nameLength + extraLength;
+    const bodyEnd = bodyStart + compressedSize;
+    if (method !== 0) {
+      throw new Error(
+        `unsupported zip compression method ${method} for ${name}`,
+      );
+    }
+    if (compressedSize !== uncompressedSize) {
+      throw new Error(`zip entry size mismatch for ${name}`);
+    }
+    const target = extractPath(targetDir, name);
+    if (name.endsWith('/')) {
+      fs.mkdirSync(target, { recursive: true });
+    } else {
+      fs.mkdirSync(path.dirname(target), { recursive: true });
+      fs.writeFileSync(target, buffer.subarray(bodyStart, bodyEnd));
+    }
+    offset = bodyEnd;
+  }
 }

--- a/product/scripts/archive.test.mjs
+++ b/product/scripts/archive.test.mjs
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { test } from 'node:test';
+import { extractTarGz, extractZip, writeTarGz, writeZip } from './archive.mjs';
+
+function makeFixture(parent) {
+  const sourceDir = path.join(parent, 'source');
+  const productRoot = path.join(sourceDir, 'kungfu-cli-test');
+  const bin = path.join(productRoot, 'kungfu', 'kungfu');
+  const longPath = path.join(
+    productRoot,
+    'extensions',
+    'system',
+    'skill-manager',
+    'dist',
+    'view',
+    'index.js',
+  );
+  fs.mkdirSync(path.dirname(bin), { recursive: true });
+  fs.mkdirSync(path.dirname(longPath), { recursive: true });
+  fs.writeFileSync(
+    path.join(productRoot, 'product.json'),
+    '{"schema":"kungfu.product.cli/v1"}\n',
+  );
+  fs.writeFileSync(bin, '#!/usr/bin/env node\n');
+  fs.writeFileSync(longPath, 'export default "ok";\n');
+  fs.chmodSync(bin, 0o755);
+  return { sourceDir, productRoot };
+}
+
+function assertExtracted(targetDir) {
+  const productRoot = path.join(targetDir, 'kungfu-cli-test');
+  assert.equal(
+    fs.readFileSync(path.join(productRoot, 'product.json'), 'utf8'),
+    '{"schema":"kungfu.product.cli/v1"}\n',
+  );
+  assert.equal(
+    fs.readFileSync(
+      path.join(
+        productRoot,
+        'extensions',
+        'system',
+        'skill-manager',
+        'dist',
+        'view',
+        'index.js',
+      ),
+      'utf8',
+    ),
+    'export default "ok";\n',
+  );
+  assert.equal(
+    fs.readFileSync(path.join(productRoot, 'kungfu', 'kungfu'), 'utf8'),
+    '#!/usr/bin/env node\n',
+  );
+}
+
+test('tar.gz archives round-trip the product layout', () => {
+  const parent = fs.mkdtempSync(path.join(os.tmpdir(), 'kungfu-archive-test-'));
+  try {
+    const { sourceDir } = makeFixture(parent);
+    const archiveFile = path.join(parent, 'product.tar.gz');
+    const targetDir = path.join(parent, 'tar-out');
+    writeTarGz({ sourceDir, outputFile: archiveFile });
+    extractTarGz({ archiveFile, targetDir });
+    assertExtracted(targetDir);
+    if (process.platform !== 'win32') {
+      const mode =
+        fs.statSync(path.join(targetDir, 'kungfu-cli-test', 'kungfu', 'kungfu'))
+          .mode & 0o777;
+      assert.equal(mode, 0o755);
+    }
+  } finally {
+    fs.rmSync(parent, { recursive: true, force: true });
+  }
+});
+
+test('zip archives round-trip the product layout', () => {
+  const parent = fs.mkdtempSync(path.join(os.tmpdir(), 'kungfu-archive-test-'));
+  try {
+    const { sourceDir } = makeFixture(parent);
+    const archiveFile = path.join(parent, 'product.zip');
+    const targetDir = path.join(parent, 'zip-out');
+    writeZip({ sourceDir, outputFile: archiveFile });
+    extractZip({ archiveFile, targetDir });
+    assertExtracted(targetDir);
+  } finally {
+    fs.rmSync(parent, { recursive: true, force: true });
+  }
+});

--- a/product/scripts/dist.mjs
+++ b/product/scripts/dist.mjs
@@ -9,13 +9,14 @@
 import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import { createRequire } from 'node:module';
+import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
   createBuildchainLogger,
   verifyBuildchainLogEvents,
 } from '@kungfu-tech/buildchain/logging';
-import { writeTarGz, writeZip } from './archive.mjs';
+import { extractTarGz, extractZip, writeTarGz, writeZip } from './archive.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -364,6 +365,20 @@ function readJson(file) {
   return JSON.parse(fs.readFileSync(file, 'utf8'));
 }
 
+function parseJsonOutput(output, label) {
+  const text = output.trim();
+  try {
+    return JSON.parse(text);
+  } catch {
+    const start = text.indexOf('{');
+    const end = text.lastIndexOf('}');
+    if (start >= 0 && end > start) {
+      return JSON.parse(text.slice(start, end + 1));
+    }
+    throw new Error(`${label} did not produce JSON output`);
+  }
+}
+
 function listKfxPackages() {
   const packages = [];
   const visit = (dir, depth) => {
@@ -629,8 +644,26 @@ function bundleSdkForCli(stageRoot) {
     outfile: sdkOut,
     logLevel: 'silent',
   });
+  fs.writeFileSync(
+    path.join(stageRoot, 'sdk', 'package.json'),
+    `${JSON.stringify({ private: true, type: 'module' }, null, 2)}\n`,
+  );
   copyTree(path.join(SDK_DIR, 'kfd'), path.join(stageRoot, 'kfd'));
   copyTree(path.join(SDK_DIR, 'templates'), path.join(stageRoot, 'templates'));
+  copySdkRuntimePackageForCli(stageRoot, '@kungfu-tech/kfd');
+}
+
+function copySdkRuntimePackageForCli(stageRoot, packageName) {
+  const packageJson = require.resolve(`${packageName}/package.json`, {
+    paths: [SDK_DIR, ROOT],
+  });
+  const source = path.dirname(packageJson);
+  const target = path.join(
+    stageRoot,
+    'node_modules',
+    ...packageName.split('/'),
+  );
+  copyTree(source, target);
 }
 
 function writeCliManifest(stageRoot, archiveName) {
@@ -645,13 +678,208 @@ function writeCliManifest(stageRoot, archiveName) {
         entries: {
           kungfu: isWin ? 'kungfu/kungfu.exe' : 'kungfu/kungfu',
           sdk: 'sdk/sdk.js',
+          sdkPackage: 'sdk/package.json',
+          kfd3Registry: 'kfd/kfd-3-surfaces.json',
+          kfdUpstreamAggregate: 'kfd/upstream-aggregate.json',
+          kfdPackage: 'node_modules/@kungfu-tech/kfd/package.json',
           tui: 'tui/tui.mjs',
           extensions: 'extensions',
+          templates: 'templates',
         },
       },
       null,
       2,
     )}\n`,
+  );
+}
+
+function assertFile(file, label) {
+  if (!fs.existsSync(file) || !fs.statSync(file).isFile()) {
+    throw new Error(`${label} not found: ${file}`);
+  }
+}
+
+function assertDirectory(dir, label) {
+  if (!fs.existsSync(dir) || !fs.statSync(dir).isDirectory()) {
+    throw new Error(`${label} not found: ${dir}`);
+  }
+}
+
+function entryPath(installRoot, entries, key) {
+  const entry = entries?.[key];
+  if (!entry) throw new Error(`CLI product manifest missing entries.${key}`);
+  return path.join(installRoot, ...entry.split('/'));
+}
+
+function listInstalledKfxPackages(extensionsRoot) {
+  const names = new Set();
+  const visit = (dir) => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (!entry.isDirectory() || entry.name === 'node_modules') continue;
+      const pkgPath = path.join(full, 'package.json');
+      if (fs.existsSync(pkgPath)) {
+        const pkg = readJson(pkgPath);
+        if (pkg.name?.startsWith('@kungfu-tech/kfx-')) {
+          names.add(pkg.name);
+        }
+      }
+      visit(full);
+    }
+  };
+  visit(extensionsRoot);
+  return names;
+}
+
+function assertSameSet(label, expected, actual) {
+  const missing = [...expected].filter((name) => !actual.has(name)).sort();
+  const stale = [...actual].filter((name) => !expected.has(name)).sort();
+  if (missing.length || stale.length) {
+    throw new Error(
+      [
+        `${label} mismatch`,
+        missing.length ? `missing: ${missing.join(', ')}` : '',
+        stale.length ? `stale: ${stale.join(', ')}` : '',
+      ]
+        .filter(Boolean)
+        .join('\n'),
+    );
+  }
+}
+
+function runInstalledKungfuKfdSmoke({
+  installRoot,
+  kungfuBin,
+  sdkEntry,
+  kfd3Registry,
+  kfdUpstreamAggregate,
+  extensionsRoot,
+}) {
+  const result = spawnSync(kungfuBin, ['kfd', 'status', '--json'], {
+    cwd: installRoot,
+    env: {
+      ...process.env,
+      KUNGFU_SDK_ENTRY: sdkEntry,
+      KUNGFU_KFD3_REGISTRY: kfd3Registry,
+      KUNGFU_KFD_UPSTREAM_AGGREGATE: kfdUpstreamAggregate,
+      KF_FIRST_PARTY_SOURCE_ROOT: extensionsRoot,
+    },
+    encoding: 'utf8',
+    shell: isWin,
+  });
+  if (result.status !== 0) {
+    throw new Error(
+      [
+        `installed kungfu kfd smoke failed (exit ${exitLabel(result.status, result.signal)})`,
+        result.stdout?.trim() ? `stdout:\n${result.stdout.trim()}` : '',
+        result.stderr?.trim() ? `stderr:\n${result.stderr.trim()}` : '',
+      ]
+        .filter(Boolean)
+        .join('\n'),
+    );
+  }
+  const data = parseJsonOutput(result.stdout || '', 'kungfu kfd status');
+  if (data.contract !== 'kungfu-sdk-kfd-standards-status') {
+    throw new Error(`unexpected kfd status contract: ${data.contract}`);
+  }
+  if (data.standards?.['kfd-3']?.status !== 'supported') {
+    throw new Error('installed kungfu kfd status did not report KFD-3 support');
+  }
+}
+
+function smokeCliProductArchive({ archivePath, archiveBase }) {
+  buildchainLogger.spanSync(
+    'product.cli.smoke',
+    {
+      phase: 'package',
+      attributes: {
+        archive: rel(archivePath),
+      },
+    },
+    () => {
+      const tempRoot = fs.mkdtempSync(
+        path.join(os.tmpdir(), 'kungfu-cli-product-smoke-'),
+      );
+      try {
+        if (archivePath.endsWith('.zip')) {
+          extractZip({ archiveFile: archivePath, targetDir: tempRoot });
+        } else {
+          extractTarGz({ archiveFile: archivePath, targetDir: tempRoot });
+        }
+        const installRoot = path.join(tempRoot, archiveBase);
+        assertDirectory(installRoot, 'extracted CLI product root');
+        const manifestPath = path.join(installRoot, 'product.json');
+        assertFile(manifestPath, 'CLI product manifest');
+        const manifest = readJson(manifestPath);
+        if (manifest.schema !== 'kungfu.product.cli/v1') {
+          throw new Error(`unexpected CLI product schema: ${manifest.schema}`);
+        }
+        if (manifest.product !== 'cli' || manifest.platform !== platformId()) {
+          throw new Error('CLI product manifest does not match this platform');
+        }
+
+        const kungfuBin = entryPath(installRoot, manifest.entries, 'kungfu');
+        const sdkEntry = entryPath(installRoot, manifest.entries, 'sdk');
+        const sdkPackage = entryPath(
+          installRoot,
+          manifest.entries,
+          'sdkPackage',
+        );
+        const kfd3Registry = entryPath(
+          installRoot,
+          manifest.entries,
+          'kfd3Registry',
+        );
+        const kfdUpstreamAggregate = entryPath(
+          installRoot,
+          manifest.entries,
+          'kfdUpstreamAggregate',
+        );
+        const kfdPackage = entryPath(
+          installRoot,
+          manifest.entries,
+          'kfdPackage',
+        );
+        const tuiEntry = entryPath(installRoot, manifest.entries, 'tui');
+        const extensionsRoot = entryPath(
+          installRoot,
+          manifest.entries,
+          'extensions',
+        );
+        const templatesRoot = entryPath(
+          installRoot,
+          manifest.entries,
+          'templates',
+        );
+        assertFile(kungfuBin, 'installed kungfu runtime');
+        assertFile(sdkEntry, 'installed Kungfu SDK entry');
+        assertFile(sdkPackage, 'installed Kungfu SDK package metadata');
+        assertFile(kfd3Registry, 'installed KFD-3 registry');
+        assertFile(kfdUpstreamAggregate, 'installed KFD upstream aggregate');
+        assertFile(kfdPackage, 'installed KFD package metadata');
+        assertFile(tuiEntry, 'installed TUI entry');
+        assertDirectory(extensionsRoot, 'installed kfx extensions');
+        assertDirectory(templatesRoot, 'installed SDK templates');
+
+        assertSameSet(
+          'installed kfx package set',
+          productKfxDependencies(),
+          listInstalledKfxPackages(extensionsRoot),
+        );
+
+        runInstalledKungfuKfdSmoke({
+          installRoot,
+          kungfuBin,
+          sdkEntry,
+          kfd3Registry,
+          kfdUpstreamAggregate,
+          extensionsRoot,
+        });
+        console.log('[product] CLI installed-layout smoke passed');
+      } finally {
+        fs.rmSync(tempRoot, { recursive: true, force: true });
+      }
+    },
   );
 }
 
@@ -692,6 +920,7 @@ function buildCliProduct() {
       } else {
         writeTarGz({ sourceDir: CLI_DIST_DIR, outputFile: archivePath });
       }
+      smokeCliProductArchive({ archivePath, archiveBase });
       console.log(`[product] CLI archive -> ${rel(archivePath)}`);
     },
   );
@@ -815,6 +1044,7 @@ function verifyObservability() {
   }
   if (wantsCli()) {
     requiredEvents.push('product.cli.archive.start');
+    requiredEvents.push('product.cli.smoke.start');
   }
   const report = verifyBuildchainLogEvents({
     path: buildchainLogger.path,


### PR DESCRIPTION
## Summary
- extract generated CLI archives in a temporary install layout after packaging
- validate runtime, SDK/KFD metadata, TUI entry, first-party kfx package set, and `kungfu kfd status --json` from the extracted product
- include the SDK runtime KFD package and module metadata in the CLI product

## Validation
- `./kungfu-code check`
- `node --test product/scripts/archive.test.mjs product/scripts/product.test.mjs`
- `./kungfu-code product cli dist`
- verified `product/release/cli/kungfu-cli-darwin-arm64.tar.gz` contains runtime, SDK, KFD package, TUI, and 11 first-party kfx package manifests
