### PR TITLE
feat(storage): add projection query API

### DIFF
--- a/.buildchain/kfd-2/claims/agent-onboarding-pack.json
+++ b/.buildchain/kfd-2/claims/agent-onboarding-pack.json
@@ -16,7 +16,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "b9f4440a15a2de73b0fcb478686f1e1a8f4a5bec10e47bdfaa0e0c157e29faea"
+        "sha256": "26c2fe14d914c168904e6578ec632b117a8d88edb66f1771c521d25dddd82aad"
       },
       "description": "Machine-readable command catalog and mode maturity metadata."
     },
@@ -54,7 +54,7 @@
     "evidenceSha256": [
       {
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "b9f4440a15a2de73b0fcb478686f1e1a8f4a5bec10e47bdfaa0e0c157e29faea"
+        "sha256": "26c2fe14d914c168904e6578ec632b117a8d88edb66f1771c521d25dddd82aad"
       },
       {
         "path": "framework/core/src/python/kungfu/agent/mode-selection.md",
@@ -76,7 +76,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "b9f4440a15a2de73b0fcb478686f1e1a8f4a5bec10e47bdfaa0e0c157e29faea"
+        "sha256": "26c2fe14d914c168904e6578ec632b117a8d88edb66f1771c521d25dddd82aad"
       }
     ]
   },
@@ -90,7 +90,7 @@
     {
       "name": "agent-command-catalog",
       "path": "framework/core/src/python/kungfu/agent/commands.json",
-      "sha256": "b9f4440a15a2de73b0fcb478686f1e1a8f4a5bec10e47bdfaa0e0c157e29faea",
+      "sha256": "26c2fe14d914c168904e6578ec632b117a8d88edb66f1771c521d25dddd82aad",
       "expectedPackagePath": "kungfu/agent/commands.json"
     }
   ],

--- a/.buildchain/kfd-2/claims/remote-fact-boundary.json
+++ b/.buildchain/kfd-2/claims/remote-fact-boundary.json
@@ -34,7 +34,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "b9f4440a15a2de73b0fcb478686f1e1a8f4a5bec10e47bdfaa0e0c157e29faea"
+        "sha256": "26c2fe14d914c168904e6578ec632b117a8d88edb66f1771c521d25dddd82aad"
       },
       "description": "Remote add/sync command declarations and mode metadata."
     },
@@ -62,7 +62,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "b9f4440a15a2de73b0fcb478686f1e1a8f4a5bec10e47bdfaa0e0c157e29faea"
+        "sha256": "26c2fe14d914c168904e6578ec632b117a8d88edb66f1771c521d25dddd82aad"
       },
       {
         "path": "framework/core/src/python/kungfu/cli/commands/agent.py",

--- a/.buildchain/kfd-2/release-claims.json
+++ b/.buildchain/kfd-2/release-claims.json
@@ -29,7 +29,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/commands.json",
-            "sha256": "b9f4440a15a2de73b0fcb478686f1e1a8f4a5bec10e47bdfaa0e0c157e29faea"
+            "sha256": "26c2fe14d914c168904e6578ec632b117a8d88edb66f1771c521d25dddd82aad"
           },
           "description": "Machine-readable command catalog and mode maturity metadata."
         },
@@ -194,7 +194,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/commands.json",
-            "sha256": "b9f4440a15a2de73b0fcb478686f1e1a8f4a5bec10e47bdfaa0e0c157e29faea"
+            "sha256": "26c2fe14d914c168904e6578ec632b117a8d88edb66f1771c521d25dddd82aad"
           },
           "description": "Remote add/sync command declarations and mode metadata."
         },

--- a/.buildchain/kfd/kfd-3-surfaces.json
+++ b/.buildchain/kfd/kfd-3-surfaces.json
@@ -957,6 +957,26 @@
       }
     },
     {
+      "id": "kungfu.storage.query",
+      "name": "kungfu storage query --table entries --scope source --source <source-id> --json",
+      "kind": "cli",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "stable",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
       "id": "kungfu.storage.rebuild-index",
       "name": "kungfu storage rebuild-index --scope all --dry-run --json",
       "kind": "cli",

--- a/developer/sdk/kfd/kfd-2/claims/agent-onboarding-pack.json
+++ b/developer/sdk/kfd/kfd-2/claims/agent-onboarding-pack.json
@@ -16,7 +16,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "b9f4440a15a2de73b0fcb478686f1e1a8f4a5bec10e47bdfaa0e0c157e29faea"
+        "sha256": "26c2fe14d914c168904e6578ec632b117a8d88edb66f1771c521d25dddd82aad"
       },
       "description": "Machine-readable command catalog and mode maturity metadata."
     },
@@ -54,7 +54,7 @@
     "evidenceSha256": [
       {
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "b9f4440a15a2de73b0fcb478686f1e1a8f4a5bec10e47bdfaa0e0c157e29faea"
+        "sha256": "26c2fe14d914c168904e6578ec632b117a8d88edb66f1771c521d25dddd82aad"
       },
       {
         "path": "framework/core/src/python/kungfu/agent/mode-selection.md",
@@ -76,7 +76,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "b9f4440a15a2de73b0fcb478686f1e1a8f4a5bec10e47bdfaa0e0c157e29faea"
+        "sha256": "26c2fe14d914c168904e6578ec632b117a8d88edb66f1771c521d25dddd82aad"
       }
     ]
   },
@@ -90,7 +90,7 @@
     {
       "name": "agent-command-catalog",
       "path": "framework/core/src/python/kungfu/agent/commands.json",
-      "sha256": "b9f4440a15a2de73b0fcb478686f1e1a8f4a5bec10e47bdfaa0e0c157e29faea",
+      "sha256": "26c2fe14d914c168904e6578ec632b117a8d88edb66f1771c521d25dddd82aad",
       "expectedPackagePath": "kungfu/agent/commands.json"
     }
   ],

--- a/developer/sdk/kfd/kfd-2/claims/remote-fact-boundary.json
+++ b/developer/sdk/kfd/kfd-2/claims/remote-fact-boundary.json
@@ -34,7 +34,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "b9f4440a15a2de73b0fcb478686f1e1a8f4a5bec10e47bdfaa0e0c157e29faea"
+        "sha256": "26c2fe14d914c168904e6578ec632b117a8d88edb66f1771c521d25dddd82aad"
       },
       "description": "Remote add/sync command declarations and mode metadata."
     },
@@ -62,7 +62,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "b9f4440a15a2de73b0fcb478686f1e1a8f4a5bec10e47bdfaa0e0c157e29faea"
+        "sha256": "26c2fe14d914c168904e6578ec632b117a8d88edb66f1771c521d25dddd82aad"
       },
       {
         "path": "framework/core/src/python/kungfu/cli/commands/agent.py",

--- a/developer/sdk/kfd/kfd-2/release-claims.json
+++ b/developer/sdk/kfd/kfd-2/release-claims.json
@@ -29,7 +29,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/commands.json",
-            "sha256": "b9f4440a15a2de73b0fcb478686f1e1a8f4a5bec10e47bdfaa0e0c157e29faea"
+            "sha256": "26c2fe14d914c168904e6578ec632b117a8d88edb66f1771c521d25dddd82aad"
           },
           "description": "Machine-readable command catalog and mode maturity metadata."
         },
@@ -194,7 +194,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/commands.json",
-            "sha256": "b9f4440a15a2de73b0fcb478686f1e1a8f4a5bec10e47bdfaa0e0c157e29faea"
+            "sha256": "26c2fe14d914c168904e6578ec632b117a8d88edb66f1771c521d25dddd82aad"
           },
           "description": "Remote add/sync command declarations and mode metadata."
         },

--- a/developer/sdk/kfd/kfd-3-surfaces.json
+++ b/developer/sdk/kfd/kfd-3-surfaces.json
@@ -957,6 +957,26 @@
       }
     },
     {
+      "id": "kungfu.storage.query",
+      "name": "kungfu storage query --table entries --scope source --source <source-id> --json",
+      "kind": "cli",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "stable",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
       "id": "kungfu.storage.rebuild-index",
       "name": "kungfu storage rebuild-index --scope all --dry-run --json",
       "kind": "cli",

--- a/docs/runtime-storage-service.md
+++ b/docs/runtime-storage-service.md
@@ -90,7 +90,7 @@ The first `libkungfu` provider slice exposes
 `kungfu::runtime::storage_service_api::storage_service` and the
 `kungfu.runtime.storage-service/v1` operation surface for `status`, `fsck`,
 `export_bundle`, `import_bundle`, `rebuild_index`, `gc_plan`, `compact_plan`,
-and `verify_sync`. The current default backend is a content-addressed file
+`verify_sync`, and read-only `query`. The current default backend is a content-addressed file
 provider implemented in C++ under the runtime service. A second C++ provider
 stores the same source registry, manifests, and payload bodies in RocksDB behind
 the identical service operations. Python storage commands are now compatibility
@@ -420,6 +420,14 @@ authority. `storage fsck` treats a missing projection as a warning and treats a
 present projection whose row counts no longer match latest manifests as
 projection drift.
 
+`storage query` is the first public read-only API over that projection. It still
+enters through `libkungfu` (`kungfu.runtime.storage-service/v1` operation
+`query`) instead of letting Python, Node, CLI, or GUI code read SQLite directly.
+The v1 query surface supports `sources`, `manifests`, and `entries` tables,
+source filtering, entry-kind filtering, ISO time ranges, and a bounded limit.
+It returns JSON rows decoded by the C++ service; the SQLite file remains
+rebuildable cache, not a source of authority.
+
 The user-facing generic commands are:
 
 ```sh
@@ -437,6 +445,8 @@ kungfu storage rebuild-index --scope source --source <source-id> --json
 kungfu storage gc --scope all --dry-run --json
 kungfu storage compact --scope all --dry-run --json
 kungfu storage verify-sync --source <source-id> --json
+kungfu storage query --table entries --scope source --source <source-id> \
+  --kind goal --since 20d --json
 ```
 
 `kungfu source add/list/sync/fsck` uses the same source registry path. Atlas
@@ -467,6 +477,9 @@ making storage health and sync readiness inspectable:
   `runtime/storage/sources.json` source registry and the C++-owned SQLite
   projection from accepted latest manifests. This command writes only derived
   indexes unless `--dry-run` is used.
+- `storage query --table sources|manifests|entries` reads the C++-owned SQLite
+  projection through the runtime storage service. It is read-only and fails with
+  a rebuild hint when the projection is missing.
 - `storage gc --dry-run` scans payload files and reports unreachable candidates.
   All-scope candidates are unreferenced by retained storage manifests. Source
   scope is informational only because the interim payload store is shared.

--- a/framework/core/docs/adr/ADR-0018-runtime-storage-service-architecture.md
+++ b/framework/core/docs/adr/ADR-0018-runtime-storage-service-architecture.md
@@ -128,6 +128,10 @@ execution.
   `storage_manifests`, and `storage_entries` query tables. It is derived and
   disposable: `fsck` reports a missing projection as rebuildable cache loss and
   reports mismatched row counts as projection drift.
+- The read-only query surface over that projection is also a storage service
+  operation (`query`), not a Python, Node, CLI, or GUI SQLite reader. Bindings
+  pass table/filter/limit options into `libkungfu` and receive decoded JSON rows
+  from the C++ service.
 - Large payloads are not stored by making journal frames arbitrarily large. The
   journal carries commitments and metadata; the payload store carries bodies.
 - SQLite is a projection facility, not the authority root. It may be rebuilt

--- a/framework/core/src/libkungfu/include/kungfu/runtime/storage/service.h
+++ b/framework/core/src/libkungfu/include/kungfu/runtime/storage/service.h
@@ -22,6 +22,7 @@ enum class storage_operation {
   GcPlan,
   CompactPlan,
   VerifySync,
+  Query,
 };
 
 struct storage_service_options {
@@ -36,6 +37,9 @@ struct storage_service_options {
   std::string artifact_uri = {};
   nlohmann::json bundle = nlohmann::json::object();
   nlohmann::json manifest = nlohmann::json::object();
+  std::string query = {};
+  std::string kind = {};
+  uint64_t limit = 100;
 };
 
 class storage_service {
@@ -57,6 +61,8 @@ public:
   [[nodiscard]] virtual nlohmann::json compact_plan(const storage_service_options &options) const = 0;
 
   [[nodiscard]] virtual nlohmann::json verify_sync(const storage_service_options &options) const = 0;
+
+  [[nodiscard]] virtual nlohmann::json query(const storage_service_options &options) const = 0;
 };
 
 [[nodiscard]] std::vector<std::string> storage_operation_names();

--- a/framework/core/src/libkungfu/src/runtime/storage/service.cpp
+++ b/framework/core/src/libkungfu/src/runtime/storage/service.cpp
@@ -723,6 +723,13 @@ struct sqlite_projection_counts {
   size_t entries = 0;
 };
 
+std::string limit_clause(uint64_t limit) {
+  if (limit == 0) {
+    return "";
+  }
+  return " LIMIT " + std::to_string(std::min<uint64_t>(limit, 1000));
+}
+
 class sqlite_projection {
 public:
   explicit sqlite_projection(fs::path path, bool writable) : path_(std::move(path)) {
@@ -887,6 +894,83 @@ public:
             count_rows("storage_entries", source_id)};
   }
 
+  [[nodiscard]] nlohmann::json query_sources(const std::string &source_id, uint64_t limit) const {
+    std::vector<std::string> values;
+    auto sql = std::string("SELECT source_json FROM storage_sources");
+    if (!source_id.empty()) {
+      sql += " WHERE source_id = ?";
+      values.emplace_back(source_id);
+    }
+    sql += " ORDER BY source_id" + limit_clause(limit);
+    return query_json_column(sql, values, 0);
+  }
+
+  [[nodiscard]] nlohmann::json query_manifests(const std::string &source_id, uint64_t limit) const {
+    std::vector<std::string> values;
+    auto sql = std::string("SELECT manifest_json FROM storage_manifests");
+    if (!source_id.empty()) {
+      sql += " WHERE source_id = ?";
+      values.emplace_back(source_id);
+    }
+    sql += " ORDER BY source_id, manifest_id" + limit_clause(limit);
+    return query_json_column(sql, values, 0);
+  }
+
+  [[nodiscard]] nlohmann::json query_entries(const storage_service_options &options) const {
+    std::vector<std::string> values;
+    std::vector<std::string> clauses;
+    if (!options.source_id.empty()) {
+      clauses.emplace_back("source_id = ?");
+      values.emplace_back(options.source_id);
+    }
+    if (!options.kind.empty()) {
+      clauses.emplace_back("kind = ?");
+      values.emplace_back(options.kind);
+    }
+    const auto since = text_or(options.range, "since");
+    if (!since.empty()) {
+      clauses.emplace_back("source_time >= ?");
+      values.emplace_back(since);
+    }
+    const auto until = text_or(options.range, "until");
+    if (!until.empty()) {
+      clauses.emplace_back("source_time <= ?");
+      values.emplace_back(until);
+    }
+    auto sql = std::string("SELECT source_id, manifest_id, entry_json FROM storage_entries");
+    if (!clauses.empty()) {
+      sql += " WHERE ";
+      for (size_t index = 0; index < clauses.size(); ++index) {
+        if (index > 0) {
+          sql += " AND ";
+        }
+        sql += clauses.at(index);
+      }
+    }
+    sql += " ORDER BY source_time, kind, entry_source_id, source_path" + limit_clause(options.limit);
+    sqlite3_stmt *raw = nullptr;
+    const auto rc = sqlite3_prepare_v2(db_.get(), sql.c_str(), -1, &raw, nullptr);
+    statement stmt(raw);
+    if (rc != SQLITE_OK) {
+      throw std::runtime_error("sqlite_projection_prepare_failed: " + last_error());
+    }
+    bind_values(stmt.get(), values);
+    nlohmann::json rows = nlohmann::json::array();
+    int step = SQLITE_ROW;
+    while ((step = sqlite3_step(stmt.get())) == SQLITE_ROW) {
+      auto row = parse_json_column(stmt.get(), 2);
+      if (row.is_object()) {
+        row["storage_source_id"] = column_text(stmt.get(), 0);
+        row["manifest_id"] = column_text(stmt.get(), 1);
+      }
+      rows.push_back(row);
+    }
+    if (step != SQLITE_DONE) {
+      throw std::runtime_error("sqlite_projection_query_failed: " + last_error());
+    }
+    return rows;
+  }
+
   void exec(const std::string &sql) {
     char *error = nullptr;
     const auto rc = sqlite3_exec(db_.get(), sql.c_str(), nullptr, nullptr, &error);
@@ -923,6 +1007,45 @@ private:
     if (rc != SQLITE_OK) {
       throw std::runtime_error("sqlite_projection_bind_failed");
     }
+  }
+
+  static std::string column_text(sqlite3_stmt *stmt, int index) {
+    const auto raw = sqlite3_column_text(stmt, index);
+    return raw == nullptr ? std::string() : reinterpret_cast<const char *>(raw);
+  }
+
+  static nlohmann::json parse_json_column(sqlite3_stmt *stmt, int index) {
+    const auto raw = column_text(stmt, index);
+    if (raw.empty()) {
+      return nullptr;
+    }
+    return nlohmann::json::parse(raw);
+  }
+
+  static void bind_values(sqlite3_stmt *stmt, const std::vector<std::string> &values) {
+    for (size_t index = 0; index < values.size(); ++index) {
+      bind_text(stmt, static_cast<int>(index + 1), values.at(index));
+    }
+  }
+
+  [[nodiscard]] nlohmann::json query_json_column(const std::string &sql, const std::vector<std::string> &values,
+                                                 int column) const {
+    sqlite3_stmt *raw = nullptr;
+    const auto rc = sqlite3_prepare_v2(db_.get(), sql.c_str(), -1, &raw, nullptr);
+    statement stmt(raw);
+    if (rc != SQLITE_OK) {
+      throw std::runtime_error("sqlite_projection_prepare_failed: " + last_error());
+    }
+    bind_values(stmt.get(), values);
+    nlohmann::json rows = nlohmann::json::array();
+    int step = SQLITE_ROW;
+    while ((step = sqlite3_step(stmt.get())) == SQLITE_ROW) {
+      rows.push_back(parse_json_column(stmt.get(), column));
+    }
+    if (step != SQLITE_DONE) {
+      throw std::runtime_error("sqlite_projection_query_failed: " + last_error());
+    }
+    return rows;
   }
 
   void exec_bound(const std::string &sql, const std::vector<std::string> &values) {
@@ -964,6 +1087,45 @@ nlohmann::json sqlite_projection_json(const std::string &runtime_dir, const std:
     result["ok"] = false;
     result["error"] = e.what();
   }
+  return result;
+}
+
+nlohmann::json query_sqlite_projection(const storage_service_options &options) {
+  const auto query = options.query.empty() ? std::string("entries") : options.query;
+  const auto path = sqlite_projection_path(options.runtime_dir);
+  nlohmann::json result = {
+      {"ok", true},
+      {"scope", options.source_id.empty() ? "all" : "source"},
+      {"source_id", options.source_id.empty() ? nlohmann::json(nullptr) : nlohmann::json(options.source_id)},
+      {"projection",
+       {{"name", PROJECTION_SQLITE},
+        {"schema", SQLITE_PROJECTION_SCHEMA},
+        {"path", path.string()},
+        {"authority", "derived"},
+        {"rebuildable", true}}},
+      {"query", query},
+      {"kind", options.kind.empty() ? nlohmann::json(nullptr) : nlohmann::json(options.kind)},
+      {"range", options.range},
+      {"limit", options.limit},
+      {"rows", nlohmann::json::array()},
+  };
+  if (!fs::exists(path)) {
+    result["ok"] = false;
+    result["errors"] = nlohmann::json::array(
+        {{{"code", "sqlite_projection_missing"}, {"path", path.string()}, {"hint", "run storage rebuild-index"}}});
+    return result;
+  }
+  const sqlite_projection projection(path, false);
+  if (query == "sources") {
+    result["rows"] = projection.query_sources(options.source_id, options.limit);
+  } else if (query == "manifests") {
+    result["rows"] = projection.query_manifests(options.source_id, options.limit);
+  } else if (query == "entries") {
+    result["rows"] = projection.query_entries(options);
+  } else {
+    throw std::invalid_argument("unsupported storage query: " + query);
+  }
+  result["row_count"] = result.at("rows").size();
   return result;
 }
 
@@ -1721,6 +1883,10 @@ public:
             {"source_fsck", source_report},
             {"imported_fsck", imported_report}};
   }
+
+  [[nodiscard]] nlohmann::json query(const storage_service_options &options) const override {
+    return query_sqlite_projection(options);
+  }
 };
 
 const file_storage_service &storage_service_instance() {
@@ -1753,6 +1919,7 @@ std::vector<std::string> storage_operation_names() {
       storage_operation_name(storage_operation::ExportBundle), storage_operation_name(storage_operation::ImportBundle),
       storage_operation_name(storage_operation::RebuildIndex), storage_operation_name(storage_operation::GcPlan),
       storage_operation_name(storage_operation::CompactPlan),  storage_operation_name(storage_operation::VerifySync),
+      storage_operation_name(storage_operation::Query),
   };
 }
 
@@ -1774,6 +1941,8 @@ std::string storage_operation_name(storage_operation operation) {
     return "compact_plan";
   case storage_operation::VerifySync:
     return "verify_sync";
+  case storage_operation::Query:
+    return "query";
   }
   throw std::invalid_argument("unknown storage operation");
 }
@@ -1803,6 +1972,9 @@ storage_operation parse_storage_operation(const std::string &operation) {
   if (operation == "verify_sync") {
     return storage_operation::VerifySync;
   }
+  if (operation == "query") {
+    return storage_operation::Query;
+  }
   throw std::invalid_argument("unsupported storage operation: " + operation);
 }
 
@@ -1820,12 +1992,23 @@ storage_service_options parse_storage_service_options(const std::string &runtime
   parsed.artifact_uri = text_or(options, "artifact_uri");
   parsed.bundle = object_or_empty(options, "bundle");
   parsed.manifest = object_or_empty(options, "manifest");
+  parsed.query = text_or(options, "query", "entries");
+  parsed.kind = text_or(options, "kind");
+  parsed.limit = uint64_or(options, "limit", 100);
   return parsed;
 }
 
 nlohmann::json make_storage_service_request(const std::string &operation, const std::string &runtime_dir,
                                             const nlohmann::json &options) {
-  return make_request(parse_storage_operation(operation), parse_storage_service_options(runtime_dir, options));
+  const auto parsed_operation = parse_storage_operation(operation);
+  const auto parsed_options = parse_storage_service_options(runtime_dir, options);
+  auto request = make_request(parsed_operation, parsed_options);
+  if (parsed_operation == storage_operation::Query) {
+    request["query"] = parsed_options.query;
+    request["kind"] = parsed_options.kind.empty() ? nlohmann::json(nullptr) : nlohmann::json(parsed_options.kind);
+    request["limit"] = parsed_options.limit;
+  }
+  return request;
 }
 
 nlohmann::json run_storage_service_operation(const std::string &operation, const std::string &runtime_dir,
@@ -1849,6 +2032,8 @@ nlohmann::json run_storage_service_operation(const std::string &operation, const
     return storage_service_instance().compact_plan(parsed_options);
   case storage_operation::VerifySync:
     return storage_service_instance().verify_sync(parsed_options);
+  case storage_operation::Query:
+    return storage_service_instance().query(parsed_options);
   }
   throw std::invalid_argument("unknown storage operation");
 }

--- a/framework/core/src/python/kungfu/agent/commands.json
+++ b/framework/core/src/python/kungfu/agent/commands.json
@@ -194,6 +194,12 @@
       "purpose": "Simulate manifest-backed local export/import/fsck and compare sync roots."
     },
     {
+      "apiId": "kungfu.storage.query",
+      "name": "kungfu storage query --table entries --scope source --source <source-id> --json",
+      "maturity": "stable",
+      "purpose": "Query C++-owned SQLite storage projection rows without reading SQLite directly from bindings."
+    },
+    {
       "apiId": "kungfu.remote.add",
       "name": "kungfu remote add <source-id> --host <host> --home <kf-home> --json",
       "maturity": "experimental",

--- a/framework/core/src/python/kungfu/agent/kfd3_api.registry.json
+++ b/framework/core/src/python/kungfu/agent/kfd3_api.registry.json
@@ -344,6 +344,16 @@
       "projections": ["commands.json", "agent-pack-doc", "provider-skill"]
     },
     {
+      "id": "kungfu.storage.query",
+      "surface": "cli",
+      "name": "kungfu storage query --table entries --scope source --source <source-id> --json",
+      "purpose": "Query C++-owned SQLite storage projection rows without reading SQLite directly from bindings.",
+      "maturity": "stable",
+      "visibility": "adjacent-agent",
+      "anchor": { "kind": "catalog" },
+      "projections": ["commands.json", "agent-pack-doc", "provider-skill"]
+    },
+    {
       "id": "kungfu.remote.add",
       "surface": "cli",
       "name": "kungfu remote add <source-id> --host <host> --home <kf-home> --json",

--- a/framework/core/src/python/kungfu/cli/commands/storage.py
+++ b/framework/core/src/python/kungfu/cli/commands/storage.py
@@ -242,6 +242,64 @@ def rebuild_index(ctx, scope, storage_source_id, dry_run, as_json):
         sys.exit(1)
 
 
+@storage.command(help="query the rebuildable SQLite storage projection")
+@click.option(
+    "--table",
+    "query_table",
+    type=click.Choice(["sources", "manifests", "entries"]),
+    default="entries",
+    show_default=True,
+)
+@click.option("--scope", type=click.Choice(["source", "all"]), default="all")
+@click.option("--source", "storage_source_id", type=str, default=None)
+@click.option("--kind", type=str, default=None, help="filter entry rows by kind")
+@click.option("--since", type=str, default=None, help="relative window such as 3d/12h")
+@click.option(
+    "--from", "from_time", type=str, default=None, help="inclusive start time"
+)
+@click.option("--until", type=str, default=None, help="inclusive end time")
+@click.option("--limit", type=click.IntRange(min=0), default=100, show_default=True)
+@click.option("--json", "as_json", is_flag=True, help="machine-readable output")
+@storage_command_context
+def query(
+    ctx,
+    query_table,
+    scope,
+    storage_source_id,
+    kind,
+    since,
+    from_time,
+    until,
+    limit,
+    as_json,
+):
+    from kungfu.storage import service
+
+    if scope == "source":
+        _require_source(storage_source_id)
+    result = service.query_projection(
+        ctx.runtime_dir,
+        query=query_table,
+        source_id=storage_source_id if scope == "source" else None,
+        kind=kind,
+        range_filter=_range_filter(since, from_time, until),
+        limit=limit,
+    )
+    if as_json:
+        _echo_json(result)
+        return
+    if not result["ok"]:
+        for error in result.get("errors", []):
+            click.echo(f"  error: {error}", err=True)
+        sys.exit(1)
+    click.echo(
+        f"[storage] query {query_table}: {result['row_count']} rows "
+        f"from {result['projection']['path']}"
+    )
+    for row in result["rows"]:
+        click.echo(json.dumps(row, sort_keys=True))
+
+
 @storage.command(help="plan unreachable payload garbage collection")
 @click.option("--scope", type=click.Choice(["source", "all"]), required=True)
 @click.option("--source", "storage_source_id", type=str, default=None)

--- a/framework/core/src/python/kungfu/storage/service.py
+++ b/framework/core/src/python/kungfu/storage/service.py
@@ -435,6 +435,31 @@ def verify_local_sync(
     )
 
 
+def query_projection(
+    runtime_dir: str | Path,
+    *,
+    query: str = "entries",
+    source_id: str | None = None,
+    kind: str | None = None,
+    range_filter: dict[str, Any] | None = None,
+    limit: int = 100,
+) -> dict[str, Any]:
+    return dict(
+        _runtime().run_storage_service_operation(
+            "query",
+            str(runtime_dir),
+            {
+                "scope": "source" if source_id else "all",
+                "source_id": source_id,
+                "query": query,
+                "kind": kind,
+                "range": range_filter or {},
+                "limit": limit,
+            },
+        )
+    )
+
+
 def write_jsonl(records: list[dict[str, Any]], out_path: str | Path) -> None:
     with open(out_path, "w", encoding="utf-8") as f:
         for record in records:

--- a/framework/core/tests/python/test_atlas_storage.py
+++ b/framework/core/tests/python/test_atlas_storage.py
@@ -327,6 +327,7 @@ def test_runtime_storage_service_surface_is_bound_from_libkungfu(tmp_path):
         "gc_plan",
         "compact_plan",
         "verify_sync",
+        "query",
     }
 
     request = runtime.make_storage_service_request(
@@ -405,6 +406,7 @@ def test_python_storage_operations_enter_runtime_service_surface(tmp_path, monke
     storage_service.status(runtime_dir, source_id="local-synth")
     storage_service.fsck(runtime_dir, source_id="local-synth")
     storage_service.rebuild_index(runtime_dir, source_id="local-synth", dry_run=True)
+    storage_service.rebuild_index(runtime_dir, source_id="local-synth", dry_run=False)
     storage_service.gc_plan(runtime_dir, dry_run=True)
     storage_service.compact_plan(runtime_dir, dry_run=True)
     storage_service.build_export_bundle(runtime_dir, source_id="local-synth")
@@ -413,6 +415,17 @@ def test_python_storage_operations_enter_runtime_service_surface(tmp_path, monke
         storage_service.build_export_bundle(runtime_dir, source_id="local-synth"),
     )
     storage_service.verify_local_sync(runtime_dir, source_id="local-synth")
+    query = storage_service.query_projection(
+        runtime_dir,
+        query="entries",
+        source_id="local-synth",
+        kind="note",
+        limit=10,
+    )
+    assert query["ok"]
+    assert query["row_count"] == 1
+    assert query["rows"][0]["kind"] == "note"
+    assert query["rows"][0]["storage_source_id"] == "local-synth"
 
     entered = {operation for operation, _, _ in calls}
     assert {
@@ -424,6 +437,7 @@ def test_python_storage_operations_enter_runtime_service_surface(tmp_path, monke
         "export_bundle",
         "import_bundle",
         "verify_sync",
+        "query",
     } <= entered
 
 

--- a/framework/core/tests/storage-node-binding.test.js
+++ b/framework/core/tests/storage-node-binding.test.js
@@ -116,6 +116,13 @@ function selectedNodeResults(runtimeDir) {
       scope: 'source',
       source_id: 'node-synth',
     }),
+    query: kungfu.runStorageServiceOperation('query', runtimeDir, {
+      scope: 'source',
+      source_id: 'node-synth',
+      query: 'entries',
+      kind: 'note',
+      limit: 10,
+    }),
     verify: kungfu.runStorageServiceOperation('verify_sync', runtimeDir, {
       scope: 'source',
       source_id: 'node-synth',
@@ -174,6 +181,13 @@ out = {
         range_filter={"since": "2026-07-09T00:00:00Z"},
     ),
     "bundle": service.build_export_bundle(runtime_dir, source_id="node-synth"),
+    "query": service.query_projection(
+        runtime_dir,
+        query="entries",
+        source_id="node-synth",
+        kind="note",
+        limit=10,
+    ),
     "verify": service.verify_local_sync(runtime_dir, source_id="node-synth"),
 }
 print(json.dumps(out, sort_keys=True, separators=(",", ":")))
@@ -234,6 +248,12 @@ for (const providerCase of providerCases) {
           const accepted = writeNodeFixture(runtimeDir);
           assert.equal(accepted.schema, 'kungfu.storage.import-manifest/v1');
           assert.equal(accepted.source_id, 'node-synth');
+          const rebuilt = kungfu.runStorageServiceOperation(
+            'rebuild_index',
+            runtimeDir,
+            { scope: 'source', source_id: 'node-synth', dry_run: false },
+          );
+          assert.equal(rebuilt.ok, true);
 
           const nodeResults = selectedNodeResults(runtimeDir);
           const pythonResults = selectedPythonResults(runtimeDir);
@@ -259,6 +279,11 @@ for (const providerCase of providerCases) {
           assert.equal(nodeResults.fsck.ok, true);
           assert.equal(nodeResults.bundle.records.length, 2);
           assert.equal(nodeResults.exported.length, 1);
+          assert.equal(nodeResults.query.row_count, 2);
+          assert.equal(
+            nodeResults.query.rows[0].storage_source_id,
+            'node-synth',
+          );
           assert.equal(nodeResults.verify.sync_roots_match, true);
           assert.equal(
             fs.existsSync(providerCase.expectedPath(runtimeDir)),


### PR DESCRIPTION
## Summary
- add C++-owned `query` storage service operation over the rebuildable SQLite projection
- expose thin Python service and `kungfu storage query` CLI wrappers
- register the new KFD-3 command surface and refresh Buildchain KFD evidence
- extend Python and Node storage parity tests to cover query results

## Validation
- `./kungfu-code build:core`
- `./kungfu-code check`
- `PYTHONPATH="$PWD/src/python:$PWD/dist/kungfu" KUNGFU_DIR="$PWD/dist/kungfu" uv run --frozen python -m pytest tests/python/test_atlas_storage.py`
- `KUNGFU_REQUIRE_NATIVE=1 KUNGFU_DIR="$PWD/framework/core/dist/kungfu" pnpm --filter @kungfu-tech/core run test:storage-binding`
- CLI smoke via `CliRunner`: `kungfu storage query --table entries --scope source --source cli-synth --json`
- `git diff --check`
