### PR TITLE
feat(master): add resident service supervisor

### DIFF
--- a/.buildchain/kfd/kfd-3-surfaces.json
+++ b/.buildchain/kfd/kfd-3-surfaces.json
@@ -27,6 +27,14 @@
           "role": "kungfu-sdk-product-entrypoints"
         },
         {
+          "path": "framework/core/src/python/kungfu/cli/commands/master.py",
+          "role": "kungfu-master-service-entrypoints"
+        },
+        {
+          "path": "framework/core/src/python/kungfu/master_service.py",
+          "role": "kungfu-master-service-supervisor-runtime"
+        },
+        {
           "path": "product/scripts/product.mjs",
           "role": "kungfu-product-dev-and-build-entrypoints"
         }
@@ -554,6 +562,26 @@
         "owner": "kungfu",
         "source": "scripts/buildchain-kfd-evidence.mjs",
         "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
+      "id": "kungfu.master.service",
+      "name": "kungfu master status|start|stop|restart|service plan|install|uninstall|status",
+      "kind": "cli",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/cli/commands/master.py",
+      "evidencePath": "framework/core/src/python/kungfu/master_service.py",
+      "artifactPath": "framework/core/src/python/kungfu/master_service.py",
+      "maturity": "draft",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/cli/commands/master.py"
       }
     },
     {

--- a/developer/sdk/kfd/kfd-3-surfaces.json
+++ b/developer/sdk/kfd/kfd-3-surfaces.json
@@ -27,6 +27,14 @@
           "role": "kungfu-sdk-product-entrypoints"
         },
         {
+          "path": "framework/core/src/python/kungfu/cli/commands/master.py",
+          "role": "kungfu-master-service-entrypoints"
+        },
+        {
+          "path": "framework/core/src/python/kungfu/master_service.py",
+          "role": "kungfu-master-service-supervisor-runtime"
+        },
+        {
           "path": "product/scripts/product.mjs",
           "role": "kungfu-product-dev-and-build-entrypoints"
         }
@@ -554,6 +562,26 @@
         "owner": "kungfu",
         "source": "scripts/buildchain-kfd-evidence.mjs",
         "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
+      "id": "kungfu.master.service",
+      "name": "kungfu master status|start|stop|restart|service plan|install|uninstall|status",
+      "kind": "cli",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/cli/commands/master.py",
+      "evidencePath": "framework/core/src/python/kungfu/master_service.py",
+      "artifactPath": "framework/core/src/python/kungfu/master_service.py",
+      "maturity": "draft",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/cli/commands/master.py"
       }
     },
     {

--- a/docs/MAP.md
+++ b/docs/MAP.md
@@ -37,6 +37,7 @@ and the map routes a question to whichever doc answers it.
 | What is the event / journal / replay model? | [`event-model.md`](event-model.md) | use | stable |
 | What does Rewind replay, and what must it never silently re-execute? | [ADR-0020](../framework/core/docs/adr/ADR-0020-agent-action-timeline-and-replay-boundary.md) + [`rewind.md`](rewind.md) | why, verify | stable |
 | How does Kungfu persist user facts, sync sources, and maintain storage over time? | [`runtime-storage-service.md`](runtime-storage-service.md) | use, verify | draft |
+| How can the master stay alive after the GUI closes, and how do I manage the user service? | [`master-service.md`](master-service.md) | use, verify | draft |
 | How can a multi-machine timeline stay stable without one global clock? | [ADR-0021](../framework/core/docs/adr/ADR-0021-observer-relative-timeline-projection.md) + [`event-model.md`](event-model.md) | why, verify | stable |
 | Where must action-recording semantics live across C++ / Python / Node? | [ADR-0022](../framework/core/docs/adr/ADR-0022-core-action-recording-surface.md) + [`event-model.md`](event-model.md) | why, use | stable |
 | What is a location role, and why does it not decide journal page size? | [ADR-0024](../framework/core/docs/adr/ADR-0024-location-role-and-journal-page-policy.md) + [`event-model.md`](event-model.md) | why, use | stable |

--- a/docs/master-service.md
+++ b/docs/master-service.md
@@ -1,0 +1,74 @@
+# Kungfu Master Service
+
+Status: draft implementation slice.
+
+Kungfu can keep the runtime master alive independently from the GUI. Closing the
+GUI window should not imply that the master stops; stopping the master is an
+explicit operator action.
+
+The service layer has two parts:
+
+- `kungfu master supervise` is the foreground supervisor loop used by a user
+  service manager.
+- `kungfu master run` is the foreground master runtime process supervised by
+  that loop.
+
+Users normally do not call those two commands directly. The public operator
+surface is:
+
+```sh
+kungfu master status --json
+kungfu master start --json
+kungfu master stop --json
+kungfu master restart --json
+kungfu master service status --json
+kungfu master service plan --json
+kungfu master service install --json
+kungfu master service install --execute --json
+kungfu master service uninstall --json
+kungfu master service uninstall --execute --json
+```
+
+`install` and `uninstall` are dry-run by default. They write or remove the
+user-level service file only when `--execute` is supplied.
+
+## Runtime State
+
+The supervisor writes runtime state under:
+
+```text
+<KF_RUNTIME_DIR>/service/master/
+```
+
+Files in that directory include:
+
+- `supervisor.pid`
+- `master.pid`
+- `state.json`
+- `supervisor.log`
+- `master.log`
+
+The `status --json` command reads those files and verifies whether the recorded
+PIDs are still alive.
+
+## Service Plans
+
+`kungfu master service plan --json` prints the platform-specific file that
+would be installed:
+
+- macOS: `~/Library/LaunchAgents/tech.kungfu.master.plist`
+- Linux: `~/.config/systemd/user/kungfu-master.service`
+- Windows: the current user's Startup folder command file
+
+The generated service starts the supervisor loop and lets the supervisor keep
+the master alive. Loading/enabling the service manager is intentionally left as
+an explicit user operation after the file is installed.
+
+## Lifecycle Semantics
+
+- Closing or hiding the GUI should not stop the master.
+- Quitting the GUI should exit Electron. If the service is installed and
+  running, the master remains alive.
+- `kungfu master stop` stops the supervisor and its child master.
+- `kungfu master service uninstall --execute` removes the user service file; it
+  does not delete runtime journals or other user data.

--- a/framework/core/src/python/kungfu/cli/commands/__registry__.py
+++ b/framework/core/src/python/kungfu/cli/commands/__registry__.py
@@ -21,6 +21,7 @@ from . import skill
 from . import codex
 from . import sdk
 from . import kfd
+from . import master
 
 __all__ = [
     "engage",
@@ -44,4 +45,5 @@ __all__ = [
     "codex",
     "sdk",
     "kfd",
+    "master",
 ]

--- a/framework/core/src/python/kungfu/cli/commands/master.py
+++ b/framework/core/src/python/kungfu/cli/commands/master.py
@@ -1,0 +1,242 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+import sys
+
+import click
+
+from kungfu import master_service
+from kungfu.cli.commands import PrioritizedCommandGroup, kfc
+
+master_command_context = kfc.pass_context()
+
+
+def _json(payload):
+    click.echo(json.dumps(payload, indent=2, sort_keys=True))
+
+
+def _plain_status(payload):
+    click.echo(f"status: {payload['status']}")
+    click.echo(f"runtime: {payload['runtimeDir']}")
+    click.echo(
+        "supervisor: "
+        f"{payload['supervisor']['pid'] or '-'} "
+        f"({'running' if payload['supervisor']['running'] else 'stopped'})"
+    )
+    click.echo(
+        "master: "
+        f"{payload['master']['pid'] or '-'} "
+        f"({'running' if payload['master']['running'] else 'stopped'})"
+    )
+
+
+@kfc.group(
+    cls=PrioritizedCommandGroup,
+    help_priority=2,
+    help="manage the resident Kungfu master supervisor",
+)
+@click.help_option("-h", "--help")
+@kfc.pass_context()
+def master(ctx):
+    pass
+
+
+@master.command(name="status", help="print resident master supervisor status")
+@click.option("--json", "as_json", is_flag=True, help="machine-readable output")
+@master_command_context
+def master_status(ctx, as_json):
+    payload = master_service.status(ctx.home, ctx.runtime_dir)
+    if as_json:
+        _json(payload)
+        return
+    _plain_status(payload)
+
+
+@master.command(help="start the resident master supervisor")
+@click.option("--json", "as_json", is_flag=True, help="machine-readable output")
+@master_command_context
+def start(ctx, as_json):
+    payload = master_service.start_supervisor(ctx.home, ctx.runtime_dir, ctx.log_level)
+    if as_json:
+        _json(payload)
+        return
+    click.echo("started" if payload.get("changed") else "already running")
+
+
+@master.command(help="stop the resident master supervisor")
+@click.option("--json", "as_json", is_flag=True, help="machine-readable output")
+@master_command_context
+def stop(ctx, as_json):
+    payload = master_service.stop_supervisor(ctx.home, ctx.runtime_dir)
+    if as_json:
+        _json(payload)
+        return
+    if payload.get("error"):
+        raise click.ClickException(str(payload["error"]))
+    click.echo("stopped" if payload.get("changed") else "already stopped")
+
+
+@master.command(help="restart the resident master supervisor")
+@click.option("--json", "as_json", is_flag=True, help="machine-readable output")
+@master_command_context
+def restart(ctx, as_json):
+    stopped = master_service.stop_supervisor(ctx.home, ctx.runtime_dir)
+    if stopped.get("error"):
+        raise click.ClickException(str(stopped["error"]))
+    started = master_service.start_supervisor(ctx.home, ctx.runtime_dir, ctx.log_level)
+    payload = {
+        "schema": "kungfu.master-service.restart/v1",
+        "stop": stopped,
+        "start": started,
+    }
+    if as_json:
+        _json(payload)
+        return
+    click.echo("restarted")
+
+
+@master.command(help="run one foreground master process")
+@click.option(
+    "--home",
+    "runtime_home",
+    required=True,
+    hidden=True,
+    help="runtime home passed by the supervisor",
+)
+@click.option(
+    "--runtime-dir",
+    required=True,
+    hidden=True,
+    help="runtime directory passed by the supervisor",
+)
+@click.option("--low-latency", is_flag=True, hidden=True)
+def run(runtime_home, runtime_dir, low_latency):
+    sys.exit(master_service.run_master(runtime_home, runtime_dir, low_latency))
+
+
+@master.command(help="run the foreground master supervisor service loop")
+@click.option(
+    "--home",
+    "runtime_home",
+    required=True,
+    hidden=True,
+    help="runtime home passed by the service manager",
+)
+@click.option(
+    "--runtime-dir",
+    required=True,
+    hidden=True,
+    help="runtime directory passed by the service manager",
+)
+@click.option("--foreground", is_flag=True, hidden=True)
+def supervise(runtime_home, runtime_dir, foreground):
+    callable(foreground)
+    root = click.get_current_context().parent.parent
+    sys.exit(
+        master_service.run_supervisor(
+            runtime_home,
+            runtime_dir,
+            getattr(root, "log_level", "warning"),
+        )
+    )
+
+
+@master.group(
+    cls=PrioritizedCommandGroup,
+    help="install, remove, and inspect the user-level master service plan",
+)
+@click.help_option("-h", "--help")
+@master_command_context
+def service(ctx):
+    pass
+
+
+@service.command(help="print the platform service plan without writing files")
+@click.option("--json", "as_json", is_flag=True, help="machine-readable output")
+@master_command_context
+def plan(ctx, as_json):
+    payload = master_service.service_plan(
+        ctx.home, ctx.runtime_dir, ctx.log_level
+    ).as_dict()
+    if as_json:
+        _json(payload)
+        return
+    click.echo(f"path: {payload['path']}")
+    click.echo(payload["content"], nl=False)
+
+
+@service.command(name="status", help="print user-level service installation status")
+@click.option("--json", "as_json", is_flag=True, help="machine-readable output")
+@master_command_context
+def service_status(ctx, as_json):
+    payload = master_service.service_status(ctx.home, ctx.runtime_dir, ctx.log_level)
+    if as_json:
+        _json(payload)
+        return
+    service_payload = payload["service"]
+    click.echo(f"service: {service_payload['id']}")
+    click.echo(f"path: {service_payload['path']}")
+    click.echo(f"installed: {'yes' if service_payload['installed'] else 'no'}")
+    click.echo(f"matches plan: {'yes' if service_payload['matchesPlan'] else 'no'}")
+
+
+@service.command(help="install the user-level service file")
+@click.option(
+    "--execute",
+    is_flag=True,
+    help="write the service file; default is a dry-run preview",
+)
+@click.option("--json", "as_json", is_flag=True, help="machine-readable output")
+@master_command_context
+def install(ctx, execute, as_json):
+    if execute:
+        payload = master_service.install_service(
+            ctx.home, ctx.runtime_dir, ctx.log_level
+        )
+    else:
+        payload = {
+            "schema": "kungfu.master-service.result/v1",
+            "action": "install",
+            "changed": False,
+            "dryRun": True,
+            "plan": master_service.service_plan(
+                ctx.home, ctx.runtime_dir, ctx.log_level
+            ).as_dict(),
+        }
+    if as_json:
+        _json(payload)
+        return
+    click.echo("[dry-run] install preview" if not execute else "installed")
+    click.echo(payload["plan"]["installNote"])
+
+
+@service.command(help="uninstall the user-level service file")
+@click.option(
+    "--execute",
+    is_flag=True,
+    help="remove the service file; default is a dry-run preview",
+)
+@click.option("--json", "as_json", is_flag=True, help="machine-readable output")
+@master_command_context
+def uninstall(ctx, execute, as_json):
+    if execute:
+        payload = master_service.uninstall_service(
+            ctx.home, ctx.runtime_dir, ctx.log_level
+        )
+    else:
+        payload = {
+            "schema": "kungfu.master-service.result/v1",
+            "action": "uninstall",
+            "changed": False,
+            "dryRun": True,
+            "plan": master_service.service_plan(
+                ctx.home, ctx.runtime_dir, ctx.log_level
+            ).as_dict(),
+        }
+    if as_json:
+        _json(payload)
+        return
+    click.echo("[dry-run] uninstall preview" if not execute else "uninstalled")
+    click.echo(payload["plan"]["uninstallNote"])

--- a/framework/core/src/python/kungfu/master_service.py
+++ b/framework/core/src/python/kungfu/master_service.py
@@ -1,0 +1,556 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+import os
+import platform
+import signal
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from xml.sax.saxutils import escape as xml_escape
+
+import kungfu
+
+lf = kungfu.__binding__.yijinjing
+yjj = kungfu.__binding__.runtime
+
+
+SCHEMA_STATUS = "kungfu.master-service.status/v1"
+SCHEMA_PLAN = "kungfu.master-service.plan/v1"
+SCHEMA_RESULT = "kungfu.master-service.result/v1"
+SERVICE_ID = "tech.kungfu.master"
+SERVICE_NAME = "Kungfu Master"
+
+
+def _now() -> float:
+    return time.time()
+
+
+def _json_write(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", "utf-8")
+    os.replace(tmp, path)
+
+
+def _json_read(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text("utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def _is_pid_running(pid: int | None) -> bool:
+    if not pid or pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+        return True
+    except OSError:
+        return False
+
+
+def _signal_pid(pid: int, sig: int) -> None:
+    os.kill(pid, sig)
+
+
+def _terminate_pid(pid: int) -> None:
+    if platform.system() == "Windows":
+        _signal_pid(pid, signal.SIGTERM)
+        return
+    _signal_pid(pid, signal.SIGTERM)
+
+
+def _shell_join(argv: list[str]) -> str:
+    return (
+        subprocess.list2cmdline(argv)
+        if platform.system() == "Windows"
+        else " ".join(shlex_quote(arg) for arg in argv)
+    )
+
+
+def shlex_quote(value: str) -> str:
+    if not value:
+        return "''"
+    safe = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_@%+=:,./-"
+    if all(ch in safe for ch in value):
+        return value
+    return "'" + value.replace("'", "'\"'\"'") + "'"
+
+
+def _systemd_env_line(key: str, value: str) -> str:
+    escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+    return f'Environment="{key}={escaped}"'
+
+
+def state_dir(runtime_dir: str) -> Path:
+    return Path(runtime_dir).expanduser().resolve() / "service" / "master"
+
+
+def supervisor_pid_path(runtime_dir: str) -> Path:
+    return state_dir(runtime_dir) / "supervisor.pid"
+
+
+def master_pid_path(runtime_dir: str) -> Path:
+    return state_dir(runtime_dir) / "master.pid"
+
+
+def state_path(runtime_dir: str) -> Path:
+    return state_dir(runtime_dir) / "state.json"
+
+
+def supervisor_log_path(runtime_dir: str) -> Path:
+    return state_dir(runtime_dir) / "supervisor.log"
+
+
+def master_log_path(runtime_dir: str) -> Path:
+    return state_dir(runtime_dir) / "master.log"
+
+
+def read_pid(path: Path) -> int | None:
+    try:
+        return int(path.read_text("utf-8").strip())
+    except (OSError, ValueError):
+        return None
+
+
+def write_pid(path: Path, pid: int) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(f"{pid}\n", "utf-8")
+
+
+def unlink_if_exists(path: Path) -> None:
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        pass
+
+
+def entry_command() -> list[str]:
+    argv0 = Path(sys.argv[0])
+    if argv0.exists() and argv0.name not in {"python", "python3"}:
+        return [str(argv0.resolve())]
+    return [sys.executable, "-m", "kungfu"]
+
+
+def command_env(home: str, runtime_dir: str, log_level: str) -> dict[str, str]:
+    env = dict(os.environ)
+    env["KF_HOME"] = home
+    env["KF_RUNTIME_DIR"] = runtime_dir
+    env["KF_LOG_LEVEL"] = log_level
+    return env
+
+
+def master_run_command(home: str, runtime_dir: str, log_level: str) -> list[str]:
+    return [
+        *entry_command(),
+        "--log_level",
+        log_level,
+        "master",
+        "run",
+        "--runtime-dir",
+        runtime_dir,
+        "--home",
+        home,
+    ]
+
+
+def supervisor_command(
+    home: str, runtime_dir: str, log_level: str, *, foreground: bool = True
+) -> list[str]:
+    command = [
+        *entry_command(),
+        "--log_level",
+        log_level,
+        "master",
+        "supervise",
+        "--runtime-dir",
+        runtime_dir,
+        "--home",
+        home,
+    ]
+    if foreground:
+        command.append("--foreground")
+    return command
+
+
+class Master(yjj.master):
+    def __init__(self, home: str, runtime_dir: str, low_latency: bool = False) -> None:
+        locator = yjj.locator(runtime_dir)
+        location = yjj.location(
+            lf.enums.mode.LIVE,
+            lf.enums.location_role.SYSTEM,
+            "master",
+            "master",
+            locator,
+        )
+        super().__init__(location, low_latency)
+        self.home_dir = home
+        self.runtime_dir = runtime_dir
+
+    def on_register(self, gen_time: int, register_data: Any) -> None:
+        return None
+
+    def check_register(self, gen_time: int, register_data: Any) -> bool:
+        return True
+
+    def on_interval_check(self, nanotime: int) -> None:
+        return None
+
+
+def run_master(home: str, runtime_dir: str, low_latency: bool = False) -> int:
+    service_state_dir = state_dir(runtime_dir)
+    service_state_dir.mkdir(parents=True, exist_ok=True)
+    write_pid(master_pid_path(runtime_dir), os.getpid())
+    _json_write(
+        state_path(runtime_dir),
+        {
+            "schema": SCHEMA_STATUS,
+            "status": "master-running",
+            "home": home,
+            "runtimeDir": runtime_dir,
+            "masterPid": os.getpid(),
+            "updatedAt": _now(),
+        },
+    )
+    try:
+        master = Master(home, runtime_dir, low_latency=low_latency)
+        master.run()
+        return 0
+    finally:
+        unlink_if_exists(master_pid_path(runtime_dir))
+
+
+def status(home: str, runtime_dir: str) -> dict[str, Any]:
+    supervisor_pid = read_pid(supervisor_pid_path(runtime_dir))
+    master_pid = read_pid(master_pid_path(runtime_dir))
+    state = _json_read(state_path(runtime_dir))
+    supervisor_running = _is_pid_running(supervisor_pid)
+    master_running = _is_pid_running(master_pid)
+    status_name = "running" if supervisor_running else "stopped"
+    if master_running and not supervisor_running:
+        status_name = "orphan-master"
+    return {
+        "schema": SCHEMA_STATUS,
+        "status": status_name,
+        "home": home,
+        "runtimeDir": runtime_dir,
+        "stateDir": str(state_dir(runtime_dir)),
+        "supervisor": {
+            "pid": supervisor_pid,
+            "running": supervisor_running,
+            "pidFile": str(supervisor_pid_path(runtime_dir)),
+            "log": str(supervisor_log_path(runtime_dir)),
+        },
+        "master": {
+            "pid": master_pid,
+            "running": master_running,
+            "pidFile": str(master_pid_path(runtime_dir)),
+            "log": str(master_log_path(runtime_dir)),
+        },
+        "lastState": state,
+    }
+
+
+def run_supervisor(
+    home: str,
+    runtime_dir: str,
+    log_level: str,
+    *,
+    restart_delay: float = 2.0,
+) -> int:
+    service_state_dir = state_dir(runtime_dir)
+    service_state_dir.mkdir(parents=True, exist_ok=True)
+    write_pid(supervisor_pid_path(runtime_dir), os.getpid())
+    stopping = False
+    child: subprocess.Popen[Any] | None = None
+
+    def request_stop(signum: int, frame: Any) -> None:
+        nonlocal stopping
+        stopping = True
+        if child and child.poll() is None:
+            child.terminate()
+
+    signal.signal(signal.SIGTERM, request_stop)
+    if platform.system() != "Windows":
+        signal.signal(signal.SIGINT, request_stop)
+
+    try:
+        while not stopping:
+            command = master_run_command(home, runtime_dir, log_level)
+            with master_log_path(runtime_dir).open("ab") as log:
+                child = subprocess.Popen(
+                    command,
+                    env=command_env(home, runtime_dir, log_level),
+                    stdout=log,
+                    stderr=log,
+                )
+            write_pid(master_pid_path(runtime_dir), child.pid)
+            _json_write(
+                state_path(runtime_dir),
+                {
+                    "schema": SCHEMA_STATUS,
+                    "status": "running",
+                    "home": home,
+                    "runtimeDir": runtime_dir,
+                    "supervisorPid": os.getpid(),
+                    "masterPid": child.pid,
+                    "masterCommand": command,
+                    "updatedAt": _now(),
+                },
+            )
+            while not stopping and child.poll() is None:
+                time.sleep(0.5)
+            return_code = child.poll()
+            unlink_if_exists(master_pid_path(runtime_dir))
+            _json_write(
+                state_path(runtime_dir),
+                {
+                    "schema": SCHEMA_STATUS,
+                    "status": "stopping" if stopping else "restarting",
+                    "home": home,
+                    "runtimeDir": runtime_dir,
+                    "supervisorPid": os.getpid(),
+                    "lastMasterReturnCode": return_code,
+                    "updatedAt": _now(),
+                },
+            )
+            if not stopping:
+                time.sleep(restart_delay)
+        return 0
+    finally:
+        if child and child.poll() is None:
+            child.terminate()
+            try:
+                child.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                child.kill()
+        unlink_if_exists(supervisor_pid_path(runtime_dir))
+        unlink_if_exists(master_pid_path(runtime_dir))
+        _json_write(
+            state_path(runtime_dir),
+            {
+                "schema": SCHEMA_STATUS,
+                "status": "stopped",
+                "home": home,
+                "runtimeDir": runtime_dir,
+                "updatedAt": _now(),
+            },
+        )
+
+
+def start_supervisor(home: str, runtime_dir: str, log_level: str) -> dict[str, Any]:
+    current = status(home, runtime_dir)
+    if current["supervisor"]["running"]:
+        return {**current, "changed": False}
+    state_dir(runtime_dir).mkdir(parents=True, exist_ok=True)
+    command = supervisor_command(home, runtime_dir, log_level, foreground=True)
+    with supervisor_log_path(runtime_dir).open("ab") as log:
+        kwargs: dict[str, Any] = {
+            "env": command_env(home, runtime_dir, log_level),
+            "stdout": log,
+            "stderr": log,
+        }
+        if platform.system() == "Windows":
+            detached_process = getattr(subprocess, "DETACHED_PROCESS", 0x00000008)
+            new_process_group = getattr(
+                subprocess, "CREATE_NEW_PROCESS_GROUP", 0x00000200
+            )
+            kwargs["creationflags"] = detached_process | new_process_group
+        else:
+            kwargs["start_new_session"] = True
+        subprocess.Popen(command, **kwargs)
+    deadline = time.time() + 5
+    while time.time() < deadline:
+        current = status(home, runtime_dir)
+        if current["supervisor"]["running"]:
+            return {**current, "changed": True, "command": command}
+        time.sleep(0.2)
+    return {**status(home, runtime_dir), "changed": False, "command": command}
+
+
+def stop_supervisor(
+    home: str, runtime_dir: str, timeout: float = 10.0
+) -> dict[str, Any]:
+    current = status(home, runtime_dir)
+    pid = current["supervisor"]["pid"]
+    if not current["supervisor"]["running"] or not pid:
+        return {**current, "changed": False}
+    _terminate_pid(pid)
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        current = status(home, runtime_dir)
+        if not current["supervisor"]["running"]:
+            return {**current, "changed": True}
+        time.sleep(0.2)
+    return {**status(home, runtime_dir), "changed": False, "error": "timeout"}
+
+
+@dataclass(frozen=True)
+class ServicePlan:
+    platform: str
+    path: Path
+    content: str
+    install_note: str
+    uninstall_note: str
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "schema": SCHEMA_PLAN,
+            "platform": self.platform,
+            "path": str(self.path),
+            "content": self.content,
+            "installNote": self.install_note,
+            "uninstallNote": self.uninstall_note,
+        }
+
+
+def service_plan(home: str, runtime_dir: str, log_level: str) -> ServicePlan:
+    system = platform.system()
+    command = supervisor_command(home, runtime_dir, log_level, foreground=True)
+    env = command_env(home, runtime_dir, log_level)
+    if system == "Darwin":
+        path = Path.home() / "Library" / "LaunchAgents" / f"{SERVICE_ID}.plist"
+        args = "\n".join(f"    <string>{xml_escape(arg)}</string>" for arg in command)
+        content = f"""<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">
+<plist version=\"1.0\">
+<dict>
+  <key>Label</key>
+  <string>{xml_escape(SERVICE_ID)}</string>
+  <key>ProgramArguments</key>
+  <array>
+{args}
+  </array>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>KF_HOME</key>
+    <string>{xml_escape(home)}</string>
+    <key>KF_RUNTIME_DIR</key>
+    <string>{xml_escape(runtime_dir)}</string>
+    <key>KF_LOG_LEVEL</key>
+    <string>{xml_escape(log_level)}</string>
+  </dict>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>StandardOutPath</key>
+  <string>{xml_escape(str(supervisor_log_path(runtime_dir)))}</string>
+  <key>StandardErrorPath</key>
+  <string>{xml_escape(str(supervisor_log_path(runtime_dir)))}</string>
+</dict>
+</plist>
+"""
+        return ServicePlan(
+            system,
+            path,
+            content,
+            f"write {path}; then run: launchctl bootstrap gui/$(id -u) {shlex_quote(str(path))}",
+            f"run: launchctl bootout gui/$(id -u) {shlex_quote(str(path))}; then remove {path}",
+        )
+    if system == "Linux":
+        path = Path.home() / ".config" / "systemd" / "user" / "kungfu-master.service"
+        content = f"""[Unit]
+Description={SERVICE_NAME}
+After=default.target
+
+[Service]
+Type=simple
+{_systemd_env_line("KF_HOME", home)}
+{_systemd_env_line("KF_RUNTIME_DIR", runtime_dir)}
+{_systemd_env_line("KF_LOG_LEVEL", log_level)}
+ExecStart={_shell_join(command)}
+Restart=always
+RestartSec=2
+
+[Install]
+WantedBy=default.target
+"""
+        return ServicePlan(
+            system,
+            path,
+            content,
+            "write the unit; then run: systemctl --user daemon-reload && systemctl --user enable --now kungfu-master.service",
+            "run: systemctl --user disable --now kungfu-master.service; then remove the unit",
+        )
+    startup = (
+        Path(os.environ.get("APPDATA", str(Path.home())))
+        / "Microsoft"
+        / "Windows"
+        / "Start Menu"
+        / "Programs"
+        / "Startup"
+        / "kungfu-master.cmd"
+    )
+    lines = [
+        "@echo off",
+        f'set "KF_HOME={env["KF_HOME"]}"',
+        f'set "KF_RUNTIME_DIR={env["KF_RUNTIME_DIR"]}"',
+        f'set "KF_LOG_LEVEL={env["KF_LOG_LEVEL"]}"',
+        _shell_join(command),
+        "",
+    ]
+    return ServicePlan(
+        system,
+        startup,
+        "\r\n".join(lines),
+        f"write {startup}; it will start at the next user logon",
+        f"remove {startup}",
+    )
+
+
+def install_service(home: str, runtime_dir: str, log_level: str) -> dict[str, Any]:
+    plan = service_plan(home, runtime_dir, log_level)
+    plan.path.parent.mkdir(parents=True, exist_ok=True)
+    plan.path.write_text(plan.content, "utf-8")
+    return {
+        "schema": SCHEMA_RESULT,
+        "action": "install",
+        "changed": True,
+        "plan": plan.as_dict(),
+    }
+
+
+def uninstall_service(home: str, runtime_dir: str, log_level: str) -> dict[str, Any]:
+    plan = service_plan(home, runtime_dir, log_level)
+    existed = plan.path.exists()
+    if existed:
+        plan.path.unlink()
+    return {
+        "schema": SCHEMA_RESULT,
+        "action": "uninstall",
+        "changed": existed,
+        "plan": plan.as_dict(),
+    }
+
+
+def service_status(home: str, runtime_dir: str, log_level: str) -> dict[str, Any]:
+    plan = service_plan(home, runtime_dir, log_level)
+    installed = plan.path.exists()
+    actual = ""
+    if installed:
+        try:
+            actual = plan.path.read_text("utf-8")
+        except OSError:
+            actual = ""
+    return {
+        "schema": SCHEMA_STATUS,
+        "home": home,
+        "runtimeDir": runtime_dir,
+        "service": {
+            "id": SERVICE_ID,
+            "platform": plan.platform,
+            "path": str(plan.path),
+            "installed": installed,
+            "matchesPlan": installed and actual == plan.content,
+        },
+        "supervisor": status(home, runtime_dir),
+    }

--- a/framework/core/tests/python/test_master_service.py
+++ b/framework/core/tests/python/test_master_service.py
@@ -1,0 +1,83 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import sys
+import types
+
+
+class _FakeMaster:
+    def __init__(self, location, low_latency=False):
+        self.location = location
+        self.low_latency = low_latency
+
+    def run(self):
+        return None
+
+
+def _install_fake_pykungfu():
+    fake = types.ModuleType("pykungfu")
+    fake.yijinjing = types.SimpleNamespace(
+        enums=types.SimpleNamespace(
+            mode=types.SimpleNamespace(LIVE="LIVE"),
+            location_role=types.SimpleNamespace(SYSTEM="SYSTEM"),
+        )
+    )
+    fake.runtime = types.SimpleNamespace(
+        master=_FakeMaster,
+        locator=lambda runtime_dir: {"runtime_dir": runtime_dir},
+        location=lambda mode, role, group, name, locator: {
+            "mode": mode,
+            "role": role,
+            "group": group,
+            "name": name,
+            "locator": locator,
+        },
+    )
+    sys.modules.setdefault("pykungfu", fake)
+
+
+_install_fake_pykungfu()
+
+from kungfu import master_service  # noqa: E402
+
+
+def test_master_status_reports_runtime_state(tmp_path):
+    runtime_dir = tmp_path / "runtime"
+
+    payload = master_service.status(str(tmp_path / "home"), str(runtime_dir))
+
+    assert payload["schema"] == "kungfu.master-service.status/v1"
+    assert payload["status"] == "stopped"
+    assert payload["runtimeDir"] == str(runtime_dir)
+    assert payload["supervisor"]["running"] is False
+    assert payload["master"]["running"] is False
+
+
+def test_master_status_detects_live_recorded_pid(tmp_path):
+    runtime_dir = tmp_path / "runtime"
+    service_dir = master_service.state_dir(str(runtime_dir))
+    service_dir.mkdir(parents=True)
+    master_service.write_pid(
+        master_service.supervisor_pid_path(str(runtime_dir)), os.getpid()
+    )
+
+    payload = master_service.status(str(tmp_path / "home"), str(runtime_dir))
+
+    assert payload["status"] == "running"
+    assert payload["supervisor"]["pid"] == os.getpid()
+    assert payload["supervisor"]["running"] is True
+
+
+def test_service_plan_is_dry_run_material(tmp_path):
+    plan = master_service.service_plan(
+        str(tmp_path / "home"),
+        str(tmp_path / "runtime"),
+        "warning",
+    ).as_dict()
+
+    assert plan["schema"] == "kungfu.master-service.plan/v1"
+    assert "master" in plan["content"]
+    assert "supervise" in plan["content"]
+    assert plan["path"]
+    assert plan["installNote"]
+    assert plan["uninstallNote"]

--- a/scripts/buildchain-kfd-evidence.mjs
+++ b/scripts/buildchain-kfd-evidence.mjs
@@ -104,6 +104,26 @@ const AGENT_COMMANDS_PATH = path.join(
   'commands.json',
 );
 const SDK_CLI_PATH = path.join(ROOT, 'developer', 'sdk', 'src', 'sdk.js');
+const MASTER_CLI_PATH = path.join(
+  ROOT,
+  'framework',
+  'core',
+  'src',
+  'python',
+  'kungfu',
+  'cli',
+  'commands',
+  'master.py',
+);
+const MASTER_SERVICE_PATH = path.join(
+  ROOT,
+  'framework',
+  'core',
+  'src',
+  'python',
+  'kungfu',
+  'master_service.py',
+);
 const CONTRACT_REGISTRY_PATH = path.join(
   ROOT,
   'framework',
@@ -623,6 +643,14 @@ function sdkAndProductSurfaces() {
       maturity: 'stable',
     }),
     fileSurface({
+      id: 'kungfu.master.service',
+      name: 'kungfu master status|start|stop|restart|service plan|install|uninstall|status',
+      kind: 'cli',
+      sourcePath: rel(MASTER_CLI_PATH),
+      evidencePath: rel(MASTER_SERVICE_PATH),
+      maturity: 'draft',
+    }),
+    fileSurface({
       id: 'kungfu.product.dev-run',
       name: './kungfu-code product',
       kind: 'cli',
@@ -698,6 +726,14 @@ function buildKfd3Registry(upstreamAggregate = buildUpstreamKfdAggregate()) {
           {
             path: rel(SDK_CLI_PATH),
             role: 'kungfu-sdk-product-entrypoints',
+          },
+          {
+            path: rel(MASTER_CLI_PATH),
+            role: 'kungfu-master-service-entrypoints',
+          },
+          {
+            path: rel(MASTER_SERVICE_PATH),
+            role: 'kungfu-master-service-supervisor-runtime',
           },
           {
             path: 'product/scripts/product.mjs',


### PR DESCRIPTION
## Summary
- add `kungfu master` commands for resident master supervisor status/start/stop/restart
- add dry-run-by-default user service plan/install/uninstall commands for macOS, Linux, and Windows
- register the public CLI surface in Buildchain-managed KFD-3 and document the lifecycle contract

## Verification
- `./kungfu-code check`
- `./kungfu-code check:types`
- `./kungfu-code kfd:buildchain:check`
- `PYTHONPATH=src/python uv run --frozen pytest tests/python/test_master_service.py`
- `uv run --frozen mypy src/python/kungfu/master_service.py src/python/kungfu/cli/commands/master.py`
