### PR TITLE
docs(storage): define episode object model

### DIFF
--- a/docs/MAP.md
+++ b/docs/MAP.md
@@ -37,6 +37,7 @@ and the map routes a question to whichever doc answers it.
 | What is the event / journal / replay model? | [`event-model.md`](event-model.md) | use | stable |
 | What does Rewind replay, and what must it never silently re-execute? | [ADR-0020](../framework/core/docs/adr/ADR-0020-agent-action-timeline-and-replay-boundary.md) + [`rewind.md`](rewind.md) | why, verify | stable |
 | How does Kungfu persist user facts, sync sources, and maintain storage over time? | [`runtime-storage-service.md`](runtime-storage-service.md) | use, verify | draft |
+| What is an Episode, and why is it the unit of export/import/fsck/timeline slicing? | [`episode-object-model.md`](episode-object-model.md) + [ADR-0033](../framework/core/docs/adr/ADR-0033-episode-causal-segment-object.md) | why, use, verify | draft |
 | How can the master stay alive after the GUI closes, and how do I manage the user service? | [`master-service.md`](master-service.md) | use, verify | draft |
 | How can a multi-machine timeline stay stable without one global clock? | [ADR-0021](../framework/core/docs/adr/ADR-0021-observer-relative-timeline-projection.md) + [`event-model.md`](event-model.md) | why, verify | stable |
 | Where must action-recording semantics live across C++ / Python / Node? | [ADR-0022](../framework/core/docs/adr/ADR-0022-core-action-recording-surface.md) + [`event-model.md`](event-model.md) | why, use | stable |
@@ -111,6 +112,10 @@ route to the row that answers them:
   store / fsck / compact / garbage collection / range export / projection
   rebuild** → *runtime storage service*
   ([`runtime-storage-service.md`](runtime-storage-service.md)).
+- **episode / causal segment / causal closure / lifecycle unit / run slice /
+  export unit / import unit / tombstone / episode manifest / episode fsck** →
+  *Episode object model* ([`episode-object-model.md`](episode-object-model.md))
+  and [ADR-0033](../framework/core/docs/adr/ADR-0033-episode-causal-segment-object.md).
 - **signature / checksum / supply chain / SBOM** → *verify a release binary*
   (`provenance.md`, `blocked` — see [`known-limits.md`](known-limits.md)).
 - **KFD / SDK scaffold / release gate evidence / contract scaffold / fact

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -30,6 +30,7 @@ principles behind them see [`design-philosophy.md`](design-philosophy.md).
 | **channel** | A source/destination communication edge between locations. Channels are used for runtime read/write/request paths; they are transport, not fact authority. |
 | **source** | A logical storage-sync registry entry: a local profile, imported bundle, remote Kungfu runtime, or adapter that can enumerate facts for import. |
 | **manifest** | The trust root for a portable fact-ledger bundle or accepted segment: format version, capture boundary, source metadata, payload inventory, schema bindings, and checksums. |
+| **Episode** | A first-class bounded causal segment in the fact ledger. It is the storage/export/import/fsck/timeline-slicing unit: frame-level causality closes inside it, and cross-Episode influence is declared as Episode dependencies. See [ADR-0033](../framework/core/docs/adr/ADR-0033-episode-causal-segment-object.md) and [`episode-object-model.md`](episode-object-model.md). |
 | **observer timeline projection** | A deterministic user-visible order over accepted facts from one or more sources, produced from an explicit observer policy rather than a claimed universal clock. Causal links dominate policy; concurrent facts may be ordered by source priority and tie-breakers. |
 | **zero-copy** | The same in-process journal bytes are shared across C++, Python, and Node **without serialization** on the hot path. |
 | **replay** | Re-running recorded journals on the *same* runtime and the *same* semantics as live, so recorded streams reproduce with high precision. |

--- a/docs/episode-object-model.md
+++ b/docs/episode-object-model.md
@@ -1,0 +1,235 @@
+# Episode Object Model
+
+Status: accepted design direction. The term and invariants are accepted by
+[ADR-0033](../framework/core/docs/adr/ADR-0033-episode-causal-segment-object.md);
+the physical storage layout is not fully implemented yet.
+
+Kungfu needs a storage object that matches the way users and agents reason about
+work. Raw mmap pages are append blocks. A source is a provenance and sync
+identity. A session/run is a product-facing view. None of those is the stable
+unit that can be exported, imported, verified, hidden, merged, compacted, and
+rendered as "the thing that happened."
+
+That object is an **Episode**.
+
+## Definition
+
+An Episode is a first-class, bounded causal segment in the Kungfu fact ledger.
+It contains the journal frames, payload commitments, source provenance, schema
+references, receipts, dependency metadata, and rebuildable projections needed
+to inspect one closed unit of action.
+
+In one sentence:
+
+```text
+Episode = causal-closure container + storage/export/fsck unit + timeline input.
+```
+
+The object is intentionally not named `Lifecycle` or `Execution`:
+
+- `Lifecycle` collides with object/process/component lifecycle terminology.
+- `Execution` sounds like a machine-only action.
+- `Episode` names a distinctive Kungfu object: a bounded segment of the
+  world-facing causal timeline.
+
+## Invariants
+
+An implementation is Episode-compatible only if these rules hold:
+
+| Invariant | Meaning |
+| --- | --- |
+| Causal closure | Frame-level causal links inside an Episode resolve to frames in the same Episode. |
+| Declared external influence | Cross-Episode influence is recorded as Episode dependencies, not an undeclared frame chain crossing the boundary. |
+| Stable projection input | Timeline views select Episodes, then deterministically project their frames under observer policy. |
+| Manifest authority | The Episode manifest names the included frames, payloads, schemas, dependencies, source provenance, and verification roots. |
+| Rebuildable indexes | SQLite and GUI query rows are derived from Episode manifests and frames, not authority roots. |
+| Tombstone before removal | Removing an Episode from normal views is a tombstone/projection decision before any physical garbage collection. |
+
+The causal closure rule is the most important one. It lets Kungfu answer:
+
+- Can this unit be exported by itself?
+- Can another runtime import and fsck it?
+- Can Rewind explain the action chain without silently chasing missing local
+  pages?
+- Can a GUI hide this unit without corrupting another unit's causal tree?
+
+## Relation To Timeline Projection
+
+Kungfu's global timeline is not the raw order of mmap pages. The stable model is:
+
+```text
+Timeline(view) = deterministic projection(
+  selected Episode set,
+  observer policy,
+  dependency constraints,
+  source-local order,
+  tie-breakers
+)
+```
+
+This extends ADR-0021. A machine does not need to prove one universal global
+clock. It needs a declared view that can be reproduced from accepted facts and
+policy.
+
+Episodes make the projection input explicit:
+
+- Importing or accepting an Episode expands the local selected fact set.
+- Tombstoning or hiding an Episode shrinks the default selected fact set.
+- Duplicate frame timestamps remain valid if dependency and merge rules are
+  deterministic.
+- A projection must not invert declared Episode dependencies or known in-Episode
+  causal links.
+
+## Relation To Source Sync
+
+Sources, locations, and channels remain important, but they are not the final
+object boundary:
+
+| Concept | Role |
+| --- | --- |
+| Source | Logical provenance and sync registry entry. |
+| Location | Runtime identity/address that writes, reads, or serves data. |
+| Channel | Transport/request edge between locations. |
+| Episode | Accepted causal object that becomes part of the local fact set. |
+
+A remote runtime should not become a special local `remote-120` storage island.
+It is a source reachable through one or more locations and channels. When local
+Kungfu imports a verified Episode from that source, the Episode becomes local
+data with provenance attached.
+
+## Physical Shape
+
+The target storage shape is Episode-aware:
+
+```text
+episode/<episode_id>/
+  manifest.json
+  segments/
+    <segment_id>/
+      pages...
+  payloads -> content-addressed payload store
+  projections -> rebuildable indexes
+```
+
+This is a conceptual shape, not a required literal directory layout. Providers
+may store the same object in content-addressed files, RocksDB, or a future
+hybrid layout. The requirement is that the provider can answer Episode
+questions without scanning unrelated history as the normal path.
+
+The lower journal shape should move toward:
+
+```text
+Episode
+  -> segment allocation domain
+  -> mmap pages
+  -> frames
+```
+
+That avoids making a semantic object fight the physical substrate. It does not
+mean every Episode must own exactly one file. Long Episodes may span pages or
+segments. Small Episodes may share provider blocks if the manifest and fsck
+proofs remain unambiguous. The important rule is that every frame can be mapped
+to Episode coordinates and every Episode can name the physical evidence that
+proves it.
+
+## Episode Manifest
+
+A sealed Episode manifest should carry enough data for fsck, export/import, and
+timeline projection:
+
+| Field | Meaning |
+| --- | --- |
+| `episode_id` | Stable id, eventually content-addressed from the sealed manifest/root. |
+| `episode_version` | Contract version for manifest semantics. |
+| `status` | `open`, `sealed`, `tombstoned`, or later maintenance states. |
+| `writer_location` | Location that opened or wrote the Episode. |
+| `source_refs` | Sources that contributed facts or payloads. |
+| `frame_ranges` | Frame ranges, frame ids, or segment/page coordinates included. |
+| `payload_inventory` | Payload refs, byte lengths, states, and content hashes. |
+| `schema_inventory` | Schemas required to decode payloads. |
+| `depends_on_episode_ids` | Declared cross-Episode dependencies. |
+| `projection_refs` | Rebuildable projection/index refs and watermarks. |
+| `sync_root` | Hash root for fsck/export/import verification. |
+| `created_at` / `sealed_at` | Diagnostic timestamps, not cross-machine ordering truth. |
+
+Open Episodes may have provisional ids. A sealed Episode should get a stable id
+derived from its manifest/root so export/import can be idempotent.
+
+## Core Operations
+
+Episode-native storage should expose these operations through the C++ core
+surface first, then through Python/Node bindings and CLI/GUI commands:
+
+| Operation | Semantics |
+| --- | --- |
+| `open` | Create an open Episode allocation domain and initial dependency set. |
+| `append` | Write frames and payload commitments into the current Episode. |
+| `seal` | Freeze the manifest, compute roots, and make the Episode import/export ready. |
+| `query` | Read Episode metadata, frame lists, dependencies, and projection rows. |
+| `export` | Produce a portable bundle for selected Episodes. |
+| `import` | Verify and accept Episode bundles into the local fact set. |
+| `fsck` | Verify closure, frames, payloads, schemas, roots, dependencies, and projections. |
+| `tombstone` | Exclude an Episode from default views without rewriting retained evidence. |
+| `gc` | Collect unreachable payloads/pages after tombstone, archive, and retention policy. |
+| `compact` | Archive, rebuild projections, vacuum/compact providers, and report restore paths. |
+
+All destructive or history-reducing operations need dry-run/preview output.
+
+## Fsck Rules
+
+Episode fsck should verify at least:
+
+- every included frame is readable and mapped to the Episode;
+- every `trigger_frame_uid` or equivalent frame-level causal parent resolves
+  inside the Episode;
+- external dependencies are declared as Episode ids;
+- payload refs exist or are explicitly marked redacted/absent/missing;
+- present payload hashes and byte lengths match the manifest;
+- required schemas resolve;
+- projection rows can be rebuilt from the Episode evidence;
+- hash roots/sync roots recompute;
+- tombstoned Episodes are not selected by default projections unless requested.
+
+Fsck must report degraded evidence. It must not invent causality or silently
+repair a missing payload by treating it as absent.
+
+## Migration Plan
+
+The migration can be staged without pretending the physical layout is already
+complete:
+
+1. **Documentation and contracts** — accept ADR-0033, publish this design, and
+   add C++ vocabulary types for Episode ids, manifests, dependencies, and fsck
+   issues.
+2. **Logical Episode index** — let current storage manifests and source imports
+   name Episodes, even if the frames still live in existing journal pages.
+3. **Episode-aware writer** — make the C++ action recorder/storage writer open,
+   append to, and seal Episodes; expose thin Python/Node bindings.
+4. **Episode-aware providers** — make file/RocksDB providers store and query
+   Episode manifests and frame coordinates as first-class records.
+5. **Episode export/import/fsck** — support `kungfu storage export/import/fsck`
+   by Episode selectors and bundles.
+6. **GUI/Rewind** — render Episodes as the primary work slices; timeline views
+   project selected Episodes rather than raw source/page streams.
+7. **Maintenance** — implement tombstone, gc, compact, archive, and restore
+   around retained Episode sets.
+
+During the migration, source/range/date selectors remain useful compatibility
+filters. They should gradually become ways to select Episodes, not substitutes
+for the Episode object.
+
+## Non-goals
+
+- One universal global wall-clock order.
+- Conflict resolution between independently edited Episodes.
+- A guarantee that every Episode maps to one physical mmap file.
+- A user-visible model where mmap page names are the primary object.
+- Replaying real-world side effects without explicit replay mode boundaries.
+
+## Maturity
+
+Episode is currently an accepted architecture direction and documentation
+surface. Existing storage commands still operate on sources, manifests, scopes,
+and ranges. The next implementation work is to add C++ Episode vocabulary and
+logical manifests, then move the writer/provider surfaces toward Episode-aware
+allocation and fsck.

--- a/docs/event-model.md
+++ b/docs/event-model.md
@@ -13,6 +13,12 @@ The higher-level action-timeline decision is
 Kungfu records the causal action chain and attached evidence, not a complete
 snapshot of the outside world.
 
+The first-class storage object for bounded causal work is an Episode:
+[ADR-0033](../framework/core/docs/adr/ADR-0033-episode-causal-segment-object.md)
+defines Episode as the causal-closure container and the future
+export/import/fsck/timeline-slicing unit. Raw mmap pages are append blocks;
+Episodes are the semantic objects projected into user-visible timelines.
+
 The action-recording implementation boundary is
 [ADR-0022](../framework/core/docs/adr/ADR-0022-core-action-recording-surface.md):
 architecture-level recording semantics live in the C++ core. Python and Node may
@@ -114,6 +120,11 @@ Across sources or machines, replay and inspection should prefer causal links,
 accepted ranges, and observer projection metadata over wall-clock order alone.
 Two observers may keep different stable projections of concurrent facts; the
 view is trustworthy when its policy is explicit and reproducible.
+
+As the storage layer becomes Episode-aware, replay and inspection should select
+Episodes first and then walk the closed frame-level causal chains inside them.
+Cross-Episode influence should appear as declared Episode dependencies, not as
+an undeclared frame-level chain that silently leaves the selected object.
 
 For agent runs, replay is layered. Forensic replay reopens, decodes, verifies,
 and walks the recorded causal tree without re-executing external effects.

--- a/docs/runtime-storage-service.md
+++ b/docs/runtime-storage-service.md
@@ -21,6 +21,9 @@ for the local runtime storage service and
 for Git-like source sync over Kungfu `location` and `channel`.
 [`ADR-0032`](../framework/core/docs/adr/ADR-0032-generic-source-service-v1.md)
 records the first generic source service implementation slice.
+[`ADR-0033`](../framework/core/docs/adr/ADR-0033-episode-causal-segment-object.md)
+defines Episode as the first-class causal segment object that future storage,
+sync, fsck, import/export, and timeline slicing should address directly.
 
 ## Existing Ground
 
@@ -61,6 +64,7 @@ Internal roles:
 | SQLite projections | Query/index/cache views | Derived and rebuildable |
 | Manifest/schema registry | Capture boundary, provenance, schemas, versioning | Trust and decode root for bundles |
 | Source registry | Known sources, locations, heads, accepted ranges, watermarks | Local record of what has been accepted |
+| Episode manifest | Bounded causal segment, frame coordinates, dependencies, payload/schema inventories, projection refs, and verification roots | First-class object boundary for export/import/fsck/timeline selection |
 
 The first runtime backend may use RocksDB, content-addressed files, SQLite blob
 tables, or a mix. That choice must remain behind the storage service. Public
@@ -128,6 +132,11 @@ The first C++ contract surface is intentionally header-only vocabulary under
 | `fsck.h` | Read-only verification options, issue taxonomy, and reports. |
 | `provider.h` | Abstract service/provider interfaces implemented above the kernel. |
 
+The next storage-contract layer should add Episode vocabulary under the same
+C++ ownership boundary. Episode is not a Python/Node convenience term: it is the
+causal segment object that providers, fsck, export/import, and timeline
+projection must agree on.
+
 ## Source, Location, And Channel
 
 Runtime storage sync should build on Kungfu's native runtime concepts instead
@@ -183,6 +192,11 @@ causal runtime fact ledger, not a snapshot tree database. The first sync stages
 can assume a single accepted timeline and avoid conflict resolution; if forks,
 authority-root changes, or conflicts appear later, they must become explicit
 accept/reject/rebase policy rather than implicit directory layout.
+
+Episode is the Kungfu analogue of a distributable object, but for causal
+segments instead of filesystem snapshots. A remote fetch should eventually
+accept verified Episodes into the local fact set; the observer timeline then
+projects the selected Episode set under declared policy.
 
 ## Command Surface
 
@@ -262,6 +276,7 @@ Import/export should become the shared mechanism for:
 
 Filters should support at least:
 
+- episode id or Episode selector;
 - source id;
 - scope/profile, such as `atlas`, `work`, `rewind`, or `all`;
 - session or run id;
@@ -271,6 +286,8 @@ Filters should support at least:
 
 The bundle must carry:
 
+- Episode manifest, dependencies, and selected projection policy if the export
+  claims a projected timeline;
 - manifest and capture boundary;
 - event segment;
 - payload inventory with present/redacted/absent/missing state;

--- a/framework/core/docs/adr/ADR-0033-episode-causal-segment-object.md
+++ b/framework/core/docs/adr/ADR-0033-episode-causal-segment-object.md
@@ -1,0 +1,169 @@
+# ADR-0033: Episode is the first-class causal segment object
+
+- Status: accepted
+- Date: 2026-07-09
+- Category: (architecture) storage object model and causal timeline slicing
+- Subsystem: yijinjing journal/storage kernel, runtime storage service,
+  source sync, fsck, export/import, Rewind, and GUI timeline views.
+- Related: ADR-0018 defines the runtime storage service. ADR-0019 defines
+  Git-like source sync over `location` and `channel`. ADR-0020 defines the
+  action timeline and replay boundary. ADR-0021 defines observer-relative
+  timeline projection. ADR-0032 defines the generic source service v1.
+  [`docs/episode-object-model.md`](../../../../docs/episode-object-model.md)
+  is the companion design document.
+
+## Context
+
+Kungfu's lowest journal mechanism is append-only. Writers append frames to
+memory-mapped pages, readers follow those pages, and the global event stream can
+span many files. That is correct for the hot path, but it is not the unit users
+or agents naturally need to reason about.
+
+A meaningful unit of work can start in the middle of one mmap page and finish in
+the middle of another. It may contain frames, payload references, projection
+rows, source metadata, receipts, and later imported evidence. If Kungfu keeps
+only raw page boundaries, it is hard to export, import, verify, delete, compact,
+or visualize "the thing that happened" as one object.
+
+Git and container systems are useful comparisons because they made semantic
+storage objects first-class: commits, trees, packs, image layers, and manifests
+are the units that can be copied, verified, hidden, or merged. Kungfu should not
+copy their filesystem-snapshot model, because Kungfu records causal runtime
+facts rather than filesystem state. It does need an equivalent first-class
+object for a bounded causal segment.
+
+The name matters. `Execution` is too machine-action oriented, and `Lifecycle`
+collides with common software object/process lifecycle terminology. `Episode`
+is distinct enough to become a Kungfu term: a bounded segment of action and
+causality in the ledger.
+
+## Decision
+
+Kungfu defines **Episode** as the first-class causal segment object.
+
+An Episode is a bounded container of causal facts. It is the unit that storage,
+sync, export/import, fsck, GUI inspection, and later maintenance operations
+should be able to address directly.
+
+The core invariants are:
+
+- Episode is a causal-closure container.
+- Frame-level causality must be closed inside one Episode.
+- Cross-Episode influence is represented at the Episode level through declared
+  dependencies, not by an undeclared naked frame-level chain crossing Episode
+  boundaries.
+- A timeline is not raw mmap order. It is a deterministic projection over a
+  selected set of Episodes under an explicit observer policy.
+- Adding an Episode to the selected set expands the local fact projection.
+  Hiding or tombstoning an Episode shrinks the default projection without
+  rewriting older facts.
+
+This does not require "one Episode equals one mmap file." The storage direction
+is:
+
+```text
+Episode
+  -> segment / page allocation domain
+  -> frames
+  -> payload references
+  -> projections
+  -> manifest / hash root / dependency metadata
+```
+
+The journal and mmap pages remain implementation blocks. They should become
+Episode-aware allocation and verification blocks, rather than the user-visible
+fact object. Page headers, segment metadata, manifests, and indexes should carry
+enough Episode coordinates to answer "which Episode owns this frame?" and "which
+physical pages prove this Episode?"
+
+An Episode manifest is the trust boundary for the object. It records at least:
+
+- Episode identity and manifest version;
+- open/sealed/tombstoned status;
+- frame ranges or frame ids included in the Episode;
+- payload inventory and content hashes;
+- schema inventory;
+- source and location provenance;
+- declared dependency Episode ids;
+- projection and query indexes that can be rebuilt;
+- hash roots or sync roots needed by fsck/export/import.
+
+Delete-like operations are tombstone plus garbage collection. The first-class
+operation is not "erase these mmap bytes"; it is "exclude this Episode from the
+default projection, then eventually collect unreachable payloads/pages when the
+retention and archive policy permits."
+
+## Consequences
+
+- The natural unit for future `storage export`, `storage import`, `source sync`,
+  `fsck`, `compact`, and GUI inspection becomes Episode, not session directory,
+  raw mmap file, or arbitrary date range.
+- `Timeline(view)` becomes a projection over selected Episodes. Duplicate frame
+  times are acceptable if the projection policy and Episode merge rules are
+  deterministic and do not invert declared causality.
+- Rewind can present a coherent object: an Episode contains one causal tree or a
+  closed set of causal trees, plus the evidence needed to inspect it.
+- The C++ core must own Episode contracts. Python, Node, GUI, and CLI surfaces
+  may expose and render Episodes, but they must not invent separate Episode
+  identity, causality, export/import, or fsck semantics.
+- Storage providers should be judged by whether they preserve Episode
+  invariants, not by their backend name. Content-addressed files, RocksDB,
+  SQLite projections, and mmap pages are implementation facilities behind the
+  service.
+- Migration can start logically: manifests and indexes can identify Episodes
+  before the mmap writer fully allocates page files by Episode. The target
+  architecture still makes Episode the physical organization domain.
+
+## First delivery
+
+This ADR is a design commitment. The first delivery is documentation-level:
+
+- accept the `Episode` term and invariants;
+- add the companion design document;
+- route docs for storage, event model, and documentation map to the Episode
+  object model.
+
+No on-disk journal layout change is claimed by this ADR. Existing storage
+commands still operate on sources, manifests, scopes, and ranges. Future
+implementation slices should move those surfaces toward Episode-native
+selectors and manifests.
+
+## Explicitly out of scope
+
+- Implementing the new mmap layout immediately.
+- Rewriting existing journal pages or source manifests.
+- Solving conflict resolution between independently edited Episodes.
+- Claiming one absolute global clock or one universal observer view.
+- Re-executing external side effects during Episode replay; ADR-0020 controls
+  that replay boundary.
+
+## Alternatives considered
+
+- **Use session or run as the storage object.** Rejected. A session/run is a
+  useful product view, but it is too tied to one agent/process vocabulary. The
+  object must also cover scripts, imports, remote bundles, and future runtime
+  actions that are not named as agent runs.
+- **Use Lifecycle.** Rejected. It is semantically close, but it collides with
+  common software lifecycle terminology and would be easy to confuse with
+  object, process, or component lifecycle hooks.
+- **Use Execution.** Rejected. It over-centers machine execution and underplays
+  the reality that Kungfu models a causal segment in the world-facing timeline.
+- **Keep mmap/page files as the object.** Rejected. Page boundaries are
+  implementation boundaries. They do not match the causal/user boundary and
+  would make export/import, deletion, GUI inspection, and fsck harder.
+- **Allow frame-level causality to cross Episode boundaries freely.** Rejected.
+  That would make an Episode impossible to move or verify as a closed object.
+  Cross-Episode influence must be explicit at the Episode dependency layer.
+
+## Residual risk
+
+- If implementation only adds Episode indexes above an unchanged physical
+  layout, large maintenance operations may still pay unnecessary page scanning
+  costs. The index-first phase is acceptable, but the target is Episode-aware
+  physical organization.
+- If GUI labels every source import as an Episode without enforcing causal
+  closure, users will trust an object that cannot be independently exported or
+  verified. Fsck must make closure visible.
+- If Episode dependency metadata is not versioned early, different nodes may
+  project the same Episode set differently. Projection and dependency policy
+  must be declared and fixture-tested once implemented.

--- a/framework/core/docs/adr/README.md
+++ b/framework/core/docs/adr/README.md
@@ -48,6 +48,7 @@ A record's **Status** says where it stands:
 | [0030](ADR-0030-manifest-scoped-sync-root-v1.md) | accepted | manifest-scoped sync root v1 |
 | [0031](ADR-0031-fast-hash-xxh3.md) | accepted | fast internal hashes use XXH3 |
 | [0032](ADR-0032-generic-source-service-v1.md) | accepted | generic source service v1 |
+| [0033](ADR-0033-episode-causal-segment-object.md) | accepted | Episode is the first-class causal segment object |
 
 ## Reading by theme
 
@@ -116,7 +117,10 @@ A record's **Status** says where it stands:
   [0031](ADR-0031-fast-hash-xxh3.md) (the v4 greenfield switch of internal
   fast hashes to XXH3_64 / XXH3_128), and
   [0032](ADR-0032-generic-source-service-v1.md) (the first generic source
-  registry, accepted-range, bundle import/export, and fsck service slice).
+  registry, accepted-range, bundle import/export, and fsck service slice), and
+  [0033](ADR-0033-episode-causal-segment-object.md) (Episode as the first-class
+  causal segment object for storage, sync, fsck, import/export, and timeline
+  projection).
 - **Cross-cutting principle** — [0009](ADR-0009-load-bearing-self-bootstrap.md)
   (load-bearing self-bootstrap), which also names the general law that
   [`docs/architecture.md` § The build dogfoods the SDK](../../../../docs/architecture.md)
@@ -133,4 +137,7 @@ A record's **Status** says where it stands:
   implementation-facing design for Kungfu Skills.
 - [`docs/runtime-storage-service.md`](../../../../docs/runtime-storage-service.md) —
   the staged storage command surface, fsck/export path, and source-adapter
+  direction.
+- [`docs/episode-object-model.md`](../../../../docs/episode-object-model.md) —
+  the Episode object model, causal closure invariant, and storage migration
   direction.


### PR DESCRIPTION
## Summary

- accept Episode as the first-class causal segment object
- add the companion Episode object model design document
- route storage, event model, concepts, and ADR index docs to the new model

## Validation

- git diff --check
- ./kungfu-code check

## Governance checklist

- [x] No credentials, tokens, secrets, or private logs
- [x] No provider API, billing, quota, or usage-attribution changes
- [x] No hosted-service, brand, package, or release identity changes
- [x] No release evidence or publishing surface changes
