### PR TITLE
feat(gui): add master tray residency controls

### DIFF
--- a/.buildchain/kfd/kfd-3-surfaces.json
+++ b/.buildchain/kfd/kfd-3-surfaces.json
@@ -35,6 +35,10 @@
           "role": "kungfu-master-service-supervisor-runtime"
         },
         {
+          "path": "framework/gui/src/main/index.ts",
+          "role": "kungfu-gui-master-tray-surface"
+        },
+        {
           "path": "product/scripts/product.mjs",
           "role": "kungfu-product-dev-and-build-entrypoints"
         }
@@ -502,6 +506,26 @@
         "owner": "kungfu",
         "source": "scripts/buildchain-kfd-evidence.mjs",
         "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
+      "id": "kungfu.gui.master-tray",
+      "name": "Kungfu GUI menu-bar/system-tray master residency controls",
+      "kind": "gui",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/gui/src/main/index.ts",
+      "evidencePath": "docs/master-service.md",
+      "artifactPath": "docs/master-service.md",
+      "maturity": "draft",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/gui/src/main/index.ts"
       }
     },
     {

--- a/developer/sdk/kfd/kfd-3-surfaces.json
+++ b/developer/sdk/kfd/kfd-3-surfaces.json
@@ -35,6 +35,10 @@
           "role": "kungfu-master-service-supervisor-runtime"
         },
         {
+          "path": "framework/gui/src/main/index.ts",
+          "role": "kungfu-gui-master-tray-surface"
+        },
+        {
           "path": "product/scripts/product.mjs",
           "role": "kungfu-product-dev-and-build-entrypoints"
         }
@@ -502,6 +506,26 @@
         "owner": "kungfu",
         "source": "scripts/buildchain-kfd-evidence.mjs",
         "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
+      "id": "kungfu.gui.master-tray",
+      "name": "Kungfu GUI menu-bar/system-tray master residency controls",
+      "kind": "gui",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/gui/src/main/index.ts",
+      "evidencePath": "docs/master-service.md",
+      "artifactPath": "docs/master-service.md",
+      "maturity": "draft",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/gui/src/main/index.ts"
       }
     },
     {

--- a/docs/master-service.md
+++ b/docs/master-service.md
@@ -72,3 +72,19 @@ an explicit user operation after the file is installed.
 - `kungfu master stop` stops the supervisor and its child master.
 - `kungfu master service uninstall --execute` removes the user service file; it
   does not delete runtime journals or other user data.
+
+## GUI Tray / Menu-Bar Controls
+
+The reference GUI keeps a resident tray surface after the main window is closed.
+On macOS this appears in the menu bar; on Windows and Linux it appears in the
+system tray when the desktop environment supports Electron tray icons.
+
+The tray menu exposes explicit lifecycle choices:
+
+- `Show Kungfu` / `Hide Window` changes only the GUI window visibility.
+- `Master Status`, `Start Master`, and `Stop Master` call the same
+  `kungfu master ... --json` CLI surface listed above.
+- `Quit GUI` exits Electron without treating window close as intent to stop the
+  resident master.
+- `Stop Master and Quit` first runs `kungfu master stop --json`, then exits the
+  GUI if the stop succeeds.

--- a/framework/gui/electron-builder.yml
+++ b/framework/gui/electron-builder.yml
@@ -29,6 +29,9 @@ extraResources:
   # kungfu's embedded Node (libnode) via `kungfu cockpit`.
   - from: ../tui/dist
     to: tui
+  # Tray/menu-bar icon assets used by the resident GUI control surface.
+  - from: public/logo
+    to: logo
 mac:
   # dir = the pack verb's unpacked app (fast, CI-friendly); dmg + zip = the
   # dist verb's installable artifacts. Unsigned pre-release (identity: null):

--- a/framework/gui/src/main/index.ts
+++ b/framework/gui/src/main/index.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from 'node:child_process';
-import { mkdirSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 // Minimal Electron main process for the kungfu reference app.
 //
@@ -10,10 +10,12 @@ import path from 'node:path';
 import {
   BrowserWindow,
   Menu,
+  Tray,
   WebContentsView,
   app,
   dialog,
   ipcMain,
+  nativeImage,
 } from 'electron';
 
 import {
@@ -263,10 +265,176 @@ let manager: SandboxManager | null = null;
 // The current shell window, tracked so the per-session window host (ADR-0016
 // stage 2) can push layout snapshots back to it for persistence.
 let shellWindow: BrowserWindow | null = null;
+let tray: Tray | null = null;
 
 // Set once the app is quitting; the session-window host reads it so window
 // closes during shutdown do not overwrite the persisted layout restore needs.
 let appQuitting = false;
+
+function kungfuBinPath(): string {
+  const binName = process.platform === 'win32' ? 'kungfu.exe' : 'kungfu';
+  return path.join(path.dirname(process.env.KFE_PATH || bindingPath), binName);
+}
+
+function showShellWindow() {
+  const win = shellWindow && !shellWindow.isDestroyed() ? shellWindow : null;
+  if (!win) {
+    createWindow();
+    return;
+  }
+  if (process.platform === 'darwin') void app.dock?.show();
+  if (win.isMinimized()) win.restore();
+  win.show();
+  win.focus();
+  buildTrayMenu();
+}
+
+function hideShellWindow(win = shellWindow) {
+  if (!win || win.isDestroyed()) return;
+  win.hide();
+  if (process.platform === 'darwin') app.dock?.hide();
+  buildTrayMenu();
+}
+
+async function showCommandResult(
+  title: string,
+  args: string[],
+  successMessage: string,
+) {
+  try {
+    const out = execFileSync(kungfuBinPath(), args, {
+      env: process.env,
+      timeout: 10000,
+    });
+    await dialog.showMessageBox({
+      type: 'info',
+      message: successMessage,
+      detail: out.toString().trim().slice(0, 4000) || successMessage,
+    });
+  } catch (e) {
+    await dialog.showMessageBox({
+      type: 'error',
+      message: title,
+      detail: (e as Error).message,
+    });
+  }
+}
+
+function quitGui() {
+  appQuitting = true;
+  app.quit();
+}
+
+async function stopMasterAndQuit() {
+  try {
+    execFileSync(kungfuBinPath(), ['master', 'stop', '--json'], {
+      env: process.env,
+      timeout: 10000,
+    });
+    quitGui();
+  } catch (e) {
+    await dialog.showMessageBox({
+      type: 'error',
+      message: 'Could not stop Kungfu Master',
+      detail: (e as Error).message,
+    });
+  }
+}
+
+function trayIcon() {
+  const candidates = [
+    path.join(process.resourcesPath || '', 'logo', 'icon.png'),
+    path.join(__dirname, '../renderer/logo/icon.png'),
+    path.join(__dirname, '../../public/logo/icon.png'),
+    path.join(
+      process.resourcesPath || '',
+      'app',
+      'out',
+      'renderer',
+      'logo',
+      'icon.png',
+    ),
+  ];
+  const iconPath = candidates.find((candidate) => existsSync(candidate));
+  const image = iconPath
+    ? nativeImage.createFromPath(iconPath)
+    : nativeImage.createFromNamedImage('NSApplicationIcon');
+  return image.isEmpty()
+    ? nativeImage.createEmpty()
+    : image.resize({ width: 18, height: 18 });
+}
+
+function buildTrayMenu() {
+  if (!tray) return;
+  const visible =
+    shellWindow && !shellWindow.isDestroyed() ? shellWindow.isVisible() : false;
+  tray.setContextMenu(
+    Menu.buildFromTemplate([
+      {
+        label: 'Show Kungfu',
+        enabled: !visible,
+        click: showShellWindow,
+      },
+      {
+        label: 'Hide Window',
+        enabled: visible,
+        click: () => hideShellWindow(),
+      },
+      { type: 'separator' },
+      {
+        label: 'Master Status',
+        click: () =>
+          void showCommandResult(
+            'Could not read Kungfu Master status',
+            ['master', 'status', '--json'],
+            'Kungfu Master Status',
+          ),
+      },
+      {
+        label: 'Start Master',
+        click: () =>
+          void showCommandResult(
+            'Could not start Kungfu Master',
+            ['master', 'start', '--json'],
+            'Kungfu Master started',
+          ),
+      },
+      {
+        label: 'Stop Master',
+        click: () =>
+          void showCommandResult(
+            'Could not stop Kungfu Master',
+            ['master', 'stop', '--json'],
+            'Kungfu Master stopped',
+          ),
+      },
+      { type: 'separator' },
+      {
+        label: 'Quit GUI',
+        click: quitGui,
+      },
+      {
+        label: 'Stop Master and Quit',
+        click: () => void stopMasterAndQuit(),
+      },
+    ]),
+  );
+}
+
+function createTray() {
+  if (tray) return;
+  tray = new Tray(trayIcon());
+  tray.setToolTip('Kungfu');
+  tray.on('click', () => {
+    const visible =
+      shellWindow && !shellWindow.isDestroyed()
+        ? shellWindow.isVisible()
+        : false;
+    if (visible) hideShellWindow();
+    else showShellWindow();
+  });
+  buildTrayMenu();
+}
 
 ipcMain.handle(ENSURE_CHANNEL, (_event, payload) => {
   const { id, bundlePath, declared } = payload as {
@@ -418,6 +586,18 @@ function createWindow() {
   win.on('unmaximize', () => publishWindowChromeState(win));
   win.on('enter-full-screen', () => publishWindowChromeState(win));
   win.on('leave-full-screen', () => publishWindowChromeState(win));
+  win.on('close', (event) => {
+    if (appQuitting) return;
+    event.preventDefault();
+    hideShellWindow(win);
+  });
+  win.on('closed', () => {
+    if (shellWindow === win) {
+      shellWindow = null;
+      manager = null;
+    }
+    buildTrayMenu();
+  });
 
   // The trusted renderer holds the real capabilities and runs the capability
   // host; this manager embeds sandboxed views and relays their invokes to it.
@@ -428,7 +608,11 @@ function createWindow() {
     harnessEntry,
   });
 
-  win.on('ready-to-show', () => win.show());
+  win.on('ready-to-show', () => {
+    win.show();
+    if (process.platform === 'darwin') void app.dock?.show();
+    buildTrayMenu();
+  });
 
   if (process.env.ELECTRON_RENDERER_URL) {
     win.loadURL(process.env.ELECTRON_RENDERER_URL);
@@ -439,6 +623,7 @@ function createWindow() {
 
 app.whenReady().then(() => {
   buildMenu();
+  createTray();
   // ADR-0016 stage 1 (flagged): run the durable session host in main so it
   // outlives windows. The ipcMain handlers are global, so bind once; events are
   // sent back to whichever renderer subscribed. Default keeps the in-renderer
@@ -469,7 +654,8 @@ app.whenReady().then(() => {
 });
 
 app.on('activate', () => {
-  if (BrowserWindow.getAllWindows().length === 0) createWindow();
+  if (shellWindow && !shellWindow.isDestroyed()) showShellWindow();
+  else createWindow();
 });
 
 app.on('before-quit', () => {
@@ -479,5 +665,6 @@ app.on('before-quit', () => {
 });
 
 app.on('window-all-closed', () => {
+  if (!appQuitting && tray) return;
   if (process.platform !== 'darwin') app.quit();
 });

--- a/scripts/buildchain-kfd-evidence.mjs
+++ b/scripts/buildchain-kfd-evidence.mjs
@@ -651,6 +651,14 @@ function sdkAndProductSurfaces() {
       maturity: 'draft',
     }),
     fileSurface({
+      id: 'kungfu.gui.master-tray',
+      name: 'Kungfu GUI menu-bar/system-tray master residency controls',
+      kind: 'gui',
+      sourcePath: 'framework/gui/src/main/index.ts',
+      evidencePath: 'docs/master-service.md',
+      maturity: 'draft',
+    }),
+    fileSurface({
       id: 'kungfu.product.dev-run',
       name: './kungfu-code product',
       kind: 'cli',
@@ -734,6 +742,10 @@ function buildKfd3Registry(upstreamAggregate = buildUpstreamKfdAggregate()) {
           {
             path: rel(MASTER_SERVICE_PATH),
             role: 'kungfu-master-service-supervisor-runtime',
+          },
+          {
+            path: 'framework/gui/src/main/index.ts',
+            role: 'kungfu-gui-master-tray-surface',
           },
           {
             path: 'product/scripts/product.mjs',


### PR DESCRIPTION
## Summary
- keep the Electron GUI resident in a tray/menu-bar surface when the main window is closed
- add explicit tray controls for show/hide, master status/start/stop, Quit GUI, and Stop Master and Quit
- register the GUI tray capability in KFD-3 and document the lifecycle semantics

## Validation
- ./kungfu-code check
- ./kungfu-code check:types
- ./kungfu-code kfd:buildchain:check
- ./kungfu-code build:app
- ./kungfu-code product gui pack --dry-run
- ./kungfu-code product gui dist --dry-run
- ./kungfu-code kfd:query --json | jq -r '.capabilities[] | select(.id=="kungfu.gui.master-tray")'

## Notes
- No service files are installed or removed by this change.
- A live desktop tray smoke was not run in this branch.