### PR TITLE
docs(storage): define episode manifest journal

### DIFF
--- a/docs/MAP.md
+++ b/docs/MAP.md
@@ -37,7 +37,7 @@ and the map routes a question to whichever doc answers it.
 | What is the event / journal / replay model? | [`event-model.md`](event-model.md) | use | stable |
 | What does Rewind replay, and what must it never silently re-execute? | [ADR-0020](../framework/core/docs/adr/ADR-0020-agent-action-timeline-and-replay-boundary.md) + [`rewind.md`](rewind.md) | why, verify | stable |
 | How does Kungfu persist user facts, sync sources, and maintain storage over time? | [`runtime-storage-service.md`](runtime-storage-service.md) | use, verify | draft |
-| What is an Episode, and why is it the unit of export/import/fsck/timeline slicing? | [`episode-object-model.md`](episode-object-model.md) + [ADR-0033](../framework/core/docs/adr/ADR-0033-episode-causal-segment-object.md) | why, use, verify | draft |
+| What is an Episode, and why is it the unit of export/import/fsck/timeline slicing? | [`episode-object-model.md`](episode-object-model.md) + [ADR-0033](../framework/core/docs/adr/ADR-0033-episode-causal-segment-object.md) + [ADR-0034](../framework/core/docs/adr/ADR-0034-yijinjing-episode-manifest-journal.md) | why, use, verify | draft |
 | How can the master stay alive after the GUI closes, and how do I manage the user service? | [`master-service.md`](master-service.md) | use, verify | draft |
 | How can a multi-machine timeline stay stable without one global clock? | [ADR-0021](../framework/core/docs/adr/ADR-0021-observer-relative-timeline-projection.md) + [`event-model.md`](event-model.md) | why, verify | stable |
 | Where must action-recording semantics live across C++ / Python / Node? | [ADR-0022](../framework/core/docs/adr/ADR-0022-core-action-recording-surface.md) + [`event-model.md`](event-model.md) | why, use | stable |
@@ -116,6 +116,10 @@ route to the row that answers them:
   export unit / import unit / tombstone / episode manifest / episode fsck** →
   *Episode object model* ([`episode-object-model.md`](episode-object-model.md))
   and [ADR-0033](../framework/core/docs/adr/ADR-0033-episode-causal-segment-object.md).
+- **episode manifest journal / manifest record / manifest delta / manifest
+  authority / yijinjing manifest / Hana manifest / JSON manifest** → *Episode
+  object model* ([`episode-object-model.md`](episode-object-model.md)) and
+  [ADR-0034](../framework/core/docs/adr/ADR-0034-yijinjing-episode-manifest-journal.md).
 - **signature / checksum / supply chain / SBOM** → *verify a release binary*
   (`provenance.md`, `blocked` — see [`known-limits.md`](known-limits.md)).
 - **KFD / SDK scaffold / release gate evidence / contract scaffold / fact

--- a/docs/episode-object-model.md
+++ b/docs/episode-object-model.md
@@ -99,22 +99,27 @@ data with provenance attached.
 
 ## Physical Shape
 
-The target storage shape is Episode-aware:
+The target storage shape is Episode-aware and journal-backed:
 
 ```text
-episode/<episode_id>/
-  manifest.json
-  segments/
-    <segment_id>/
-      pages...
-  payloads -> content-addressed payload store
-  projections -> rebuildable indexes
+episode manifest journal
+  yijinjing mmap frames for Episode metadata records
+
+event journals
+  yijinjing mmap frames for runtime/action facts
+
+payload store
+  content-addressed payload bodies
+
+projections
+  rebuildable indexes and folded views
 ```
 
-This is a conceptual shape, not a required literal directory layout. Providers
-may store the same object in content-addressed files, RocksDB, or a future
-hybrid layout. The requirement is that the provider can answer Episode
-questions without scanning unrelated history as the normal path.
+The local authority for Episode manifest facts is not a loose JSON file. ADR-0034
+defines manifest records as yijinjing first-class data structures stored in a
+yijinjing-backed append-only manifest journal. Providers may maintain
+content-addressed files, RocksDB indexes, SQLite projections, or exported JSON
+views, but those are not the manifest authority.
 
 The lower journal shape should move toward:
 
@@ -134,8 +139,9 @@ proves it.
 
 ## Episode Manifest
 
-A sealed Episode manifest should carry enough data for fsck, export/import, and
-timeline projection:
+A sealed Episode manifest is the folded result of append-only manifest journal
+records. It should carry enough data for fsck, export/import, and timeline
+projection:
 
 | Field | Meaning |
 | --- | --- |
@@ -154,6 +160,24 @@ timeline projection:
 
 Open Episodes may have provisional ids. A sealed Episode should get a stable id
 derived from its manifest/root so export/import can be idempotent.
+
+The manifest journal records the history that produces this folded view:
+
+```text
+episode_open
+episode_frame_attached
+episode_input_ref_attached
+episode_payload_ref_attached
+episode_schema_ref_attached
+episode_sealed
+episode_tombstoned
+episode_repair_receipt
+episode_purge_receipt
+```
+
+JSON may be emitted as an export/debug/folded view, but Python, Node, CLI, and
+GUI code should treat the C++/yijinjing manifest journal as the local source of
+truth.
 
 ## Core Operations
 
@@ -201,17 +225,19 @@ complete:
 1. **Documentation and contracts** — accept ADR-0033, publish this design, and
    add C++ vocabulary types for Episode ids, manifests, dependencies, and fsck
    issues.
-2. **Logical Episode index** — let current storage manifests and source imports
+2. **Manifest journal records** — add yijinjing first-class Episode manifest
+   record types in C++ before adding Python/Node convenience APIs.
+3. **Logical Episode index** — let current storage manifests and source imports
    name Episodes, even if the frames still live in existing journal pages.
-3. **Episode-aware writer** — make the C++ action recorder/storage writer open,
+4. **Episode-aware writer** — make the C++ action recorder/storage writer open,
    append to, and seal Episodes; expose thin Python/Node bindings.
-4. **Episode-aware providers** — make file/RocksDB providers store and query
+5. **Episode-aware providers** — make file/RocksDB providers store and query
    Episode manifests and frame coordinates as first-class records.
-5. **Episode export/import/fsck** — support `kungfu storage export/import/fsck`
+6. **Episode export/import/fsck** — support `kungfu storage export/import/fsck`
    by Episode selectors and bundles.
-6. **GUI/Rewind** — render Episodes as the primary work slices; timeline views
+7. **GUI/Rewind** — render Episodes as the primary work slices; timeline views
    project selected Episodes rather than raw source/page streams.
-7. **Maintenance** — implement tombstone, gc, compact, archive, and restore
+8. **Maintenance** — implement tombstone, gc, compact, archive, and restore
    around retained Episode sets.
 
 During the migration, source/range/date selectors remain useful compatibility

--- a/docs/runtime-storage-service.md
+++ b/docs/runtime-storage-service.md
@@ -24,6 +24,9 @@ records the first generic source service implementation slice.
 [`ADR-0033`](../framework/core/docs/adr/ADR-0033-episode-causal-segment-object.md)
 defines Episode as the first-class causal segment object that future storage,
 sync, fsck, import/export, and timeline slicing should address directly.
+[`ADR-0034`](../framework/core/docs/adr/ADR-0034-yijinjing-episode-manifest-journal.md)
+defines Episode manifest records as yijinjing-backed append-only journal facts,
+with JSON limited to export, import interchange, diagnostics, and folded views.
 
 ## Existing Ground
 
@@ -135,7 +138,8 @@ The first C++ contract surface is intentionally header-only vocabulary under
 The next storage-contract layer should add Episode vocabulary under the same
 C++ ownership boundary. Episode is not a Python/Node convenience term: it is the
 causal segment object that providers, fsck, export/import, and timeline
-projection must agree on.
+projection must agree on. Its manifest history should be stored as yijinjing
+manifest journal records, not as loose JSON authority.
 
 ## Source, Location, And Channel
 

--- a/framework/core/docs/adr/ADR-0033-episode-causal-segment-object.md
+++ b/framework/core/docs/adr/ADR-0033-episode-causal-segment-object.md
@@ -8,7 +8,8 @@
 - Related: ADR-0018 defines the runtime storage service. ADR-0019 defines
   Git-like source sync over `location` and `channel`. ADR-0020 defines the
   action timeline and replay boundary. ADR-0021 defines observer-relative
-  timeline projection. ADR-0032 defines the generic source service v1.
+  timeline projection. ADR-0032 defines the generic source service v1. ADR-0034
+  defines the yijinjing-backed Episode manifest journal.
   [`docs/episode-object-model.md`](../../../../docs/episode-object-model.md)
   is the companion design document.
 
@@ -113,6 +114,9 @@ retention and archive policy permits."
 - Migration can start logically: manifests and indexes can identify Episodes
   before the mmap writer fully allocates page files by Episode. The target
   architecture still makes Episode the physical organization domain.
+- Manifest facts are append-only yijinjing records, not loose JSON authority.
+  JSON can be exported as a folded view, but the local manifest authority is
+  decided separately in ADR-0034.
 
 ## First delivery
 

--- a/framework/core/docs/adr/ADR-0034-yijinjing-episode-manifest-journal.md
+++ b/framework/core/docs/adr/ADR-0034-yijinjing-episode-manifest-journal.md
@@ -1,0 +1,150 @@
+# ADR-0034: Episode manifest records live in the yijinjing journal format
+
+- Status: accepted
+- Date: 2026-07-09
+- Category: (architecture) Episode manifest storage and schema ownership
+- Subsystem: yijinjing schema, journal mmap, Episode manifests, runtime storage
+  service, Python bindings, Node bindings, Rewind payloads.
+- Related: ADR-0002 defines the FlatBuffers runtime schema over the zero-copy
+  POD layout. ADR-0022 defines the C++ core as the action-recording membrane.
+  ADR-0033 defines Episode as the first-class causal segment object.
+  [`docs/episode-object-model.md`](../../../../docs/episode-object-model.md)
+  describes the Episode object model.
+
+## Context
+
+ADR-0033 defines Episode as a first-class causal segment object. That makes the
+Episode manifest load-bearing: it records Episode open/seal state, frame
+membership, input references, dependencies, payload/schema references,
+tombstones, repairs, and purge receipts.
+
+The first design sketches used `manifest.json` as an understandable folded view.
+That is acceptable as an export/debug representation, but it is the wrong local
+authority implementation. A JSON-file manifest would force every language
+surface to implement its own parsing and update path, weaken zero-copy
+cross-language sharing, and create a second fact system next to yijinjing.
+
+The manifest history is journal-like: append-only records are folded into a
+current Episode view; sealed roots are immutable; tombstone/repair/purge events
+append new receipts rather than modifying the old manifest. Therefore the local
+authority should use the same journal substrate as the rest of Kungfu's core
+facts.
+
+## Decision
+
+Episode manifest records are yijinjing first-class data structures and are
+stored in a yijinjing-backed append-only **Episode manifest journal**.
+
+The authority split is:
+
+```text
+event journal
+  yijinjing frames for runtime events, action facts, and payload commitments
+
+episode manifest journal
+  yijinjing frames for Episode object metadata facts
+
+projection / query cache
+  rebuildable SQLite, RocksDB secondary indexes, or GUI caches
+
+JSON / bundle views
+  export, import interchange, diagnostics, and human-readable folded views
+```
+
+The Episode manifest journal should be written by a stable storage/catalog
+location, not as private metadata hidden inside an agent's short-lived runtime
+journal. It still uses yijinjing mmap and frame semantics, but it belongs to the
+storage/catalog plane so deleting one agent location's journal does not erase
+the Episode object directory.
+
+The manifest record schema belongs to yijinjing's core POD/Hana-style schema
+surface. It is kernel metadata, not domain payload. Python and Node consume the
+same compiled schema/bindings that C++ owns; they must not implement an
+independent JSON manifest authority.
+
+The first record family should be small, append-only, and delta-oriented:
+
+```text
+episode_open
+episode_frame_attached
+episode_input_ref_attached
+episode_payload_ref_attached
+episode_schema_ref_attached
+episode_sealed
+episode_tombstoned
+episode_repair_receipt
+episode_purge_receipt
+```
+
+Large or domain-specific payloads remain outside this core record family.
+Rewind actions, agent action bodies, app facts, and other business payloads
+should use FlatBuffers or other declared payload schemas behind action
+envelopes. The manifest journal records references, hashes, and Episode object
+metadata; it does not become a revived trading-era business schema registry.
+
+## Consequences
+
+- C++, Python, and Node share one authority for Episode manifests through the
+  yijinjing format instead of each parsing loose JSON files.
+- Fsck can use one journal reader model to check event journals and manifest
+  journals, then cross-check them:
+
+  ```text
+  event frame says:      frame F belongs to Episode E
+  manifest record says:  Episode E contains frame F
+  fsck verifies:         checksums, roots, and dependency closure agree
+  ```
+
+- Deleting an agent location journal can degrade Episode evidence without
+  deleting the manifest catalog. Fsck can still report which Episodes are
+  missing frames and which downstream Episodes have unresolved dependencies.
+- Exported JSON or bundle JSON is a folded view of yijinjing manifest records,
+  not the local source of truth.
+- The C++ implementation must define manifest records before binding surfaces.
+  Python and Node APIs should wrap the C++ journal/schema surface.
+- Runtime storage providers can maintain secondary indexes, but those indexes
+  are rebuildable projections over the manifest journal and event journals.
+
+## First delivery
+
+This ADR is a design commitment. The first implementation slice should add C++
+Episode manifest record vocabulary in the yijinjing schema/storage layer before
+adding Python or Node convenience APIs.
+
+Documentation is updated to avoid presenting `manifest.json` as the intended
+local authority. JSON remains valid for export/debug/folded views.
+
+## Explicitly out of scope
+
+- Implementing the full manifest journal writer in this ADR.
+- Replacing Rewind or action-envelope domain payload schemas with Hana records.
+- Making every business data type a yijinjing core type.
+- Removing JSON export or diagnostic output.
+- Solving Episode conflict resolution or remote merge policy.
+
+## Alternatives considered
+
+- **Loose JSON manifest files as local authority.** Rejected. They create a
+  parallel storage implementation, duplicate parsing across languages, and lose
+  yijinjing's cross-language single fact source.
+- **Store all manifest data only in event frame trailers.** Rejected. Frame
+  trailers should carry minimal per-frame membership/integrity data. Episode
+  object graph updates such as open, input refs, seal, tombstone, repair, and
+  purge are object-level facts and may happen without a business event frame.
+- **Use FlatBuffers for Episode manifest records.** Rejected for the core
+  manifest record family. FlatBuffers remains appropriate for domain payloads,
+  but Episode manifest records are storage-kernel metadata that must follow the
+  yijinjing POD/Hana core schema path.
+- **Make SQLite the manifest authority.** Rejected. SQLite is useful for query
+  projection, but it must remain rebuildable from append-only facts.
+
+## Residual risk
+
+- Reintroducing a broad Hana business model would repeat the old trading-era
+  coupling. The yijinjing core schema must stay limited to kernel facts,
+  storage metadata, receipts, and compact references.
+- If the storage/catalog location is stored under the same retention boundary as
+  short-lived agent journals, violent journal deletion can still erase too much.
+  The manifest journal needs a clear catalog-plane home and backup policy.
+- If bindings expose JSON as if it were the authority, higher layers may drift.
+  Binding names and docs should make JSON a view/export format.

--- a/framework/core/docs/adr/README.md
+++ b/framework/core/docs/adr/README.md
@@ -49,6 +49,7 @@ A record's **Status** says where it stands:
 | [0031](ADR-0031-fast-hash-xxh3.md) | accepted | fast internal hashes use XXH3 |
 | [0032](ADR-0032-generic-source-service-v1.md) | accepted | generic source service v1 |
 | [0033](ADR-0033-episode-causal-segment-object.md) | accepted | Episode is the first-class causal segment object |
+| [0034](ADR-0034-yijinjing-episode-manifest-journal.md) | accepted | Episode manifest records live in the yijinjing journal format |
 
 ## Reading by theme
 
@@ -120,7 +121,10 @@ A record's **Status** says where it stands:
   registry, accepted-range, bundle import/export, and fsck service slice), and
   [0033](ADR-0033-episode-causal-segment-object.md) (Episode as the first-class
   causal segment object for storage, sync, fsck, import/export, and timeline
-  projection).
+  projection), and
+  [0034](ADR-0034-yijinjing-episode-manifest-journal.md) (Episode manifest
+  records as yijinjing first-class data structures in a manifest journal, with
+  JSON only as export/debug/folded view).
 - **Cross-cutting principle** — [0009](ADR-0009-load-bearing-self-bootstrap.md)
   (load-bearing self-bootstrap), which also names the general law that
   [`docs/architecture.md` § The build dogfoods the SDK](../../../../docs/architecture.md)


### PR DESCRIPTION
## Summary

- accept the Episode manifest journal as the local authority for Episode metadata
- define Episode manifest records as yijinjing first-class data structures
- clarify that JSON is only an export, diagnostic, or folded view
- update the Episode object model and storage docs to route to ADR-0034

## Validation

- git diff --check
- ./kungfu-code check

## Governance checklist

- [x] No credentials, tokens, secrets, or private logs
- [x] No provider API, billing, quota, or usage-attribution changes
- [x] No hosted-service, brand, package, or release identity changes
- [x] No release evidence or publishing surface changes
