### PR TITLE
docs(config): define workspace-local data home

### DIFF
--- a/docs/MAP.md
+++ b/docs/MAP.md
@@ -100,8 +100,12 @@ route to the row that answers them:
   capability relay / sandboxed view / OS sandbox / service facet / planKfx** →
   *kfx topology* ([`kfx-topology.md`](kfx-topology.md)) and *extensions*
   ([`extensions.md`](extensions.md)).
-- **config / `~/.kungfu` / `KF_CONFIG_HOME` / `KF_HOME` / UI font / UI scale /
+- **config / `.kungfu` / `~/.kungfu-config` / `KF_CONFIG_HOME` / `KF_HOME` / UI font / UI scale /
   shortcuts / agent entrypoint** → *Kungfu config* ([`config.md`](config.md)).
+- **workspace data home / `.kungfu/` / data root / Git worktree data /
+  machine fallback / config home rename** → *Kungfu config*
+  ([`config.md`](config.md)) and
+  [ADR-0035](../framework/core/docs/adr/ADR-0035-workspace-local-kungfu-data-home.md).
 - **SKILL.md / agent skill / skill catalog / context injection / Node manager /
   Python manager / skill audit / skill-manager view / kfx dependency binding** →
   *agent-facing Kungfu Skill* ([`skills.md`](skills.md)).

--- a/docs/config.md
+++ b/docs/config.md
@@ -1,19 +1,23 @@
 # Kungfu Config
 
-Kungfu has two separate local homes:
+Kungfu separates local state into workspace data, user config, and machine data
+fallback. The architecture decision is
+[ADR-0035](../framework/core/docs/adr/ADR-0035-workspace-local-kungfu-data-home.md).
 
-- `KF_HOME` is the runtime data home. It stores journals, runtime databases,
-  archives, datasets, and other state produced by Kungfu itself. Its default is
-  platform-native: `~/Library/Application Support/kungfu/home` on macOS,
-  `${XDG_CONFIG_HOME:-~/.config}/kungfu/home` on Linux, and
-  `%APPDATA%/kungfu/home` on Windows.
+- Workspace `.kungfu/` is the default fact-ledger home when a workspace boundary
+  exists. It stores Episodes, the Episode manifest journal, payload bodies,
+  projections, source registry, and workspace-local runtime facts.
 - `KF_CONFIG_HOME` is the agent-facing global configuration home. Its default is
-  `~/.kungfu`. The first user override file is
-  `~/.kungfu/config.json`.
+  `~/.kungfu-config`; the first user override file is
+  `~/.kungfu-config/config.json`.
+- `KF_HOME` remains the explicit or machine-level runtime data fallback when no
+  workspace `.kungfu/` applies. It stores machine-level runtime state, global
+  catalog/cache/service state, and non-workspace facts.
 
-The split is intentional. Runtime data can be large and stateful; global config
-is small, agent-maintained, and safe to inspect without reading journals or
-provider credentials.
+The split is intentional. Runtime data can be large and stateful; workspace
+facts should live near the project they describe; global config is small,
+agent-maintained, and safe to inspect without reading journals or provider
+credentials.
 
 ## Contract, defaults, and overrides
 
@@ -30,7 +34,7 @@ That contract contains:
 - the JSON Schema for valid config;
 - the default config values;
 - resolution rules such as `KF_CONFIG_HOME`, `KF_HOME`, `config.json`,
-  placeholder expansion, and merge behavior.
+  placeholder expansion, workspace data home discovery, and merge behavior.
 
 Python, Node, and the frozen product load the same contract. The frozen product
 ships it at:
@@ -45,7 +49,7 @@ that the runtime-reported contract hash is the same. Defaults, resolution rules,
 and schema must not be redefined in Python, Node, GUI, or other feature
 modules.
 
-A user config file is optional. If `~/.kungfu/config.json` does not exist,
+A user config file is optional. If `~/.kungfu-config/config.json` does not exist,
 config resolution still succeeds and no file is created as a side effect.
 
 The user file is a JSON object that overrides only the keys it needs:
@@ -74,7 +78,8 @@ validated as a complete config against the same contract schema.
 
 The first config slice includes:
 
-- paths: config home, runtime home, skill roots, and kfx roots;
+- paths: workspace data home, machine data home, config home, skill roots, and
+  kfx roots;
 - agent entrypoint: `kungfu agent context --json`;
 - managed-run behavior flags;
 - GUI font family, font size, and whole-UI scale;
@@ -134,21 +139,18 @@ For the GUI, Electron `userData` also moves under `<path>/userData`, so caches
 and app-window state do not collide with the default instance. The same option
 works with `product tui ...` commands.
 
-When `product gui dev` or `product tui dev` runs from a linked Git worktree and
-no explicit home environment or option is already set, Kungfu chooses an
-instance root automatically under:
-
-```text
-~/.kungfu/instances/worktrees/<worktree-name>-<hash>
-```
-
-Use `--no-instance-home` to disable this auto-selection for a dev launch.
+When `product gui dev` or `product tui dev` runs from a workspace and no
+explicit home environment or option is already set, the accepted target is to
+prefer the workspace `.kungfu/` data home. If a Git root exists, the default
+workspace home is `<git-root>/.kungfu/`; otherwise an existing ancestor
+`.kungfu/` wins before falling back to machine-level `KF_HOME`. Use
+`--no-instance-home` to disable dev-launch instance selection where supported.
 
 On the first real launch for an instance root, if
 `<path>/config/config.json` does not exist and the machine default
-`~/.kungfu/config.json` exists, the launcher copies that default config file
-into the instance config home. Later launches never overwrite the instance copy,
-so tests can change config without changing the machine default.
+`~/.kungfu-config/config.json` exists, the launcher can copy that default config
+file into the instance config home. Later launches never overwrite the instance
+copy, so tests can change config without changing the machine default.
 
 `kungfu config set <dotted-key> <json-value>` writes a user override to
 `configPath`, validates it against the same contract, and returns the resolved

--- a/framework/core/docs/adr/ADR-0035-workspace-local-kungfu-data-home.md
+++ b/framework/core/docs/adr/ADR-0035-workspace-local-kungfu-data-home.md
@@ -1,0 +1,143 @@
+# ADR-0035: Workspace-local `.kungfu` is the default fact ledger home
+
+- Status: accepted
+- Date: 2026-07-09
+- Category: (architecture) local data ownership, configuration homes, and
+  workspace discovery
+- Subsystem: runtime storage service, Episode store, manifest journal, config
+  contract, product launchers, CLI, GUI, and agent workflows.
+- Related: ADR-0018 defines the runtime storage service. ADR-0033 defines
+  Episode as the first-class causal segment object. ADR-0034 defines the
+  yijinjing-backed Episode manifest journal. [`docs/config.md`](../../../../docs/config.md)
+  documents the user-facing home layout.
+
+## Context
+
+Kungfu originally treated `KF_HOME` as the runtime data home. If users did not
+override it, the product effectively had one machine-level data home. That is
+simple for a single installed application, but it is not the best default for
+agent work.
+
+Agents usually act inside a workspace: a Git repository, a worktree, a project
+directory, or another local task root. The files, Markdown memory, source
+history, and review artifacts already live there. With Episodes as first-class
+objects, Kungfu data becomes closer to Git data than to a generic application
+cache: it records the causal action history of that workspace.
+
+The useful analogy is:
+
+```text
+workspace files  = current file-world state
+.git             = file history and branch metadata
+.kungfu          = workspace action facts, Episodes, manifest journal, payloads
+```
+
+Kungfu should not require Git, but when a Git root exists it can provide a
+natural workspace boundary and useful metadata for Episode provenance.
+
+At the same time, user-level product configuration should not live in the same
+directory as runtime data. The old default `~/.kungfu` for config is ambiguous:
+it sounds like the global data home and conflicts with the new `.kungfu/`
+workspace convention. Kungfu is still pre-release, so this is the right time to
+hard-cut the config path instead of carrying migration compatibility.
+
+## Decision
+
+Kungfu separates local state into three roles:
+
+| Role | Default / selector | Contents |
+| --- | --- | --- |
+| Workspace data home | nearest `.kungfu/`, or `<git-root>/.kungfu/` when a Git root exists | Episode store, Episode manifest journal, payload bodies, projections, source registry, workspace-local runtime facts |
+| User config home | `KF_CONFIG_HOME`, default `~/.kungfu-config` | GUI settings, global trust policy, installed kfx/skills, user preferences, config overrides |
+| Machine data fallback | explicit `KF_HOME`, or platform product fallback when no workspace data home applies | machine-level runtime state, global catalog/cache/service state, non-workspace facts |
+
+The default data-root resolution order is:
+
+1. an explicit runtime/home option supplied by the caller;
+2. explicit `KF_HOME`;
+3. nearest ancestor `.kungfu/`;
+4. if inside a Git worktree and no ancestor `.kungfu/` exists, `<git-root>/.kungfu/`;
+5. machine-level `KF_HOME` fallback.
+
+Git is an integration point, not a hard dependency. In a non-Git directory,
+Kungfu can still discover an ancestor `.kungfu/` or use the machine fallback.
+When Git exists, Kungfu may record repository root, worktree identity, commit
+refs, and branch metadata as Episode/source metadata.
+
+`~/.kungfu` is no longer a default config directory. The new default config home
+is `~/.kungfu-config`. Because Kungfu has not shipped as a stable product, this
+is a hard cut:
+
+- do not silently read `~/.kungfu/config.json` as a compatibility default;
+- do not auto-migrate from `~/.kungfu` to `~/.kungfu-config`;
+- an explicit `KF_CONFIG_HOME=~/.kungfu` is still honored because explicit
+  caller input wins, but it is not the product default.
+
+Workspace `.kungfu/` data should normally be ignored by Git. Commands that
+initialize workspace storage may offer or perform `.gitignore` integration, but
+read-only commands must not modify `.gitignore` as a side effect. Portable
+exports or selected evidence bundles can be committed deliberately by the user;
+raw workspace `.kungfu/` storage is not committed by default.
+
+## Consequences
+
+- Episode facts sit near the workspace whose actions they describe. This keeps
+  project A and project B from silently sharing one machine-wide action ledger.
+- Multiple Git worktrees get independent `.kungfu/` homes by default, reducing
+  collisions between dev runs, GUI state, journals, and projections.
+- `KF_HOME` remains useful. It is the explicit/machine-level runtime data
+  fallback, not the only world.
+- `KF_CONFIG_HOME` has a clearer default and no longer competes with data
+  storage terminology.
+- Git-aware behavior becomes additive: better default placement, `.gitignore`
+  support, and provenance metadata. Kungfu still works in non-Git directories.
+- Implementation must update config contracts, launchers, `kungfu config path`,
+  GUI/TUI dev launch, and docs together so agents can discover the same layout
+  from C++, Python, Node, and CLI surfaces.
+
+## First delivery
+
+This ADR records the architecture decision and updates documentation.
+
+Implementation work remains separate:
+
+- update `config-contract` defaults from `~/.kungfu` to `~/.kungfu-config`;
+- add workspace data-home discovery;
+- teach `kungfu config path --json` and agent context output to report
+  `workspaceDataHome`, `configHome`, and `machineDataHome`;
+- add `.kungfu/` ignore support to explicit init/setup flows;
+- make product dev launchers prefer workspace-local data homes unless an
+  explicit instance home or `KF_HOME` is supplied.
+
+## Explicitly out of scope
+
+- Committing raw `.kungfu/` storage to Git by default.
+- Requiring Git for Kungfu data.
+- Removing `KF_HOME`.
+- Automatically migrating old local dogfood directories.
+- Solving remote sync policy or Episode conflict resolution.
+
+## Alternatives considered
+
+- **Keep one machine-wide `KF_HOME` as the default data world.** Rejected. It
+  makes independent projects and worktrees collide and hides the natural
+  boundary of agent action facts.
+- **Require Git and always place `.kungfu/` next to `.git/`.** Rejected. Git is
+  a useful integration point, but Kungfu should work for non-Git workspaces and
+  local runtime data.
+- **Keep `~/.kungfu` as config home for compatibility.** Rejected. Kungfu is
+  pre-release, so a hard cut avoids permanent ambiguity between user config,
+  machine data, and workspace `.kungfu/`.
+- **Rename `KF_HOME` immediately.** Rejected. `KF_HOME` remains a useful and
+  already-known explicit runtime data override. The architectural problem is the
+  default scope, not the existence of the variable.
+
+## Residual risk
+
+- Auto-creating `.kungfu/` on read-only commands would surprise users and dirty
+  workspaces. Creation must be tied to write/init operations.
+- Tooling must be careful in nested repositories and submodules. The nearest
+  existing `.kungfu/` should win before creating a new Git-root `.kungfu/`.
+- If docs move faster than implementation, `kungfu config show --json` may
+  temporarily report the old defaults. The implementation slice should follow
+  this ADR quickly.

--- a/framework/core/docs/adr/README.md
+++ b/framework/core/docs/adr/README.md
@@ -50,6 +50,7 @@ A record's **Status** says where it stands:
 | [0032](ADR-0032-generic-source-service-v1.md) | accepted | generic source service v1 |
 | [0033](ADR-0033-episode-causal-segment-object.md) | accepted | Episode is the first-class causal segment object |
 | [0034](ADR-0034-yijinjing-episode-manifest-journal.md) | accepted | Episode manifest records live in the yijinjing journal format |
+| [0035](ADR-0035-workspace-local-kungfu-data-home.md) | accepted | Workspace-local `.kungfu` is the default fact ledger home |
 
 ## Reading by theme
 
@@ -124,7 +125,10 @@ A record's **Status** says where it stands:
   projection), and
   [0034](ADR-0034-yijinjing-episode-manifest-journal.md) (Episode manifest
   records as yijinjing first-class data structures in a manifest journal, with
-  JSON only as export/debug/folded view).
+  JSON only as export/debug/folded view), and
+  [0035](ADR-0035-workspace-local-kungfu-data-home.md) (workspace-local
+  `.kungfu/` as the default Episode/fact ledger home, with `~/.kungfu-config`
+  as the user config home and `KF_HOME` retained as machine fallback).
 - **Cross-cutting principle** — [0009](ADR-0009-load-bearing-self-bootstrap.md)
   (load-bearing self-bootstrap), which also names the general law that
   [`docs/architecture.md` § The build dogfoods the SDK](../../../../docs/architecture.md)


### PR DESCRIPTION
## Summary

- accept workspace-local `.kungfu/` as the default Episode/fact ledger home
- hard-cut the user config default from `~/.kungfu` to `~/.kungfu-config`
- retain `KF_HOME` as the explicit and machine-level data fallback
- update config docs, documentation map, and ADR index

## Validation

- git diff --check
- ./kungfu-code check

## Governance checklist

- [x] No credentials, tokens, secrets, or private logs
- [x] No provider API, billing, quota, or usage-attribution changes
- [x] No hosted-service, brand, package, or release identity changes
- [x] No release evidence or publishing surface changes
