### PR TITLE
docs(master): define supervisor topology

### DIFF
--- a/docs/MAP.md
+++ b/docs/MAP.md
@@ -38,7 +38,7 @@ and the map routes a question to whichever doc answers it.
 | What does Rewind replay, and what must it never silently re-execute? | [ADR-0020](../framework/core/docs/adr/ADR-0020-agent-action-timeline-and-replay-boundary.md) + [`rewind.md`](rewind.md) | why, verify | stable |
 | How does Kungfu persist user facts, sync sources, and maintain storage over time? | [`runtime-storage-service.md`](runtime-storage-service.md) | use, verify | draft |
 | What is an Episode, and why is it the unit of export/import/fsck/timeline slicing? | [`episode-object-model.md`](episode-object-model.md) + [ADR-0033](../framework/core/docs/adr/ADR-0033-episode-causal-segment-object.md) + [ADR-0034](../framework/core/docs/adr/ADR-0034-yijinjing-episode-manifest-journal.md) | why, use, verify | draft |
-| How can the master stay alive after the GUI closes, and how do I manage the user service? | [`master-service.md`](master-service.md) | use, verify | draft |
+| What is the supervisor/master topology, and how can the master stay alive after the GUI closes? | [`master-service.md`](master-service.md) + [ADR-0036](../framework/core/docs/adr/ADR-0036-supervisor-and-workspace-master-topology.md) | use, verify | draft |
 | How can a multi-machine timeline stay stable without one global clock? | [ADR-0021](../framework/core/docs/adr/ADR-0021-observer-relative-timeline-projection.md) + [`event-model.md`](event-model.md) | why, verify | stable |
 | Where must action-recording semantics live across C++ / Python / Node? | [ADR-0022](../framework/core/docs/adr/ADR-0022-core-action-recording-surface.md) + [`event-model.md`](event-model.md) | why, use | stable |
 | What is a location role, and why does it not decide journal page size? | [ADR-0024](../framework/core/docs/adr/ADR-0024-location-role-and-journal-page-policy.md) + [`event-model.md`](event-model.md) | why, use | stable |
@@ -106,6 +106,10 @@ route to the row that answers them:
   machine fallback / config home rename** → *Kungfu config*
   ([`config.md`](config.md)) and
   [ADR-0035](../framework/core/docs/adr/ADR-0035-workspace-local-kungfu-data-home.md).
+- **supervisor / per-user supervisor / workspace master / data-root master /
+  master singleton / live registry / idle shutdown / daemonless storage** →
+  *Kungfu supervisor and master service* ([`master-service.md`](master-service.md))
+  and [ADR-0036](../framework/core/docs/adr/ADR-0036-supervisor-and-workspace-master-topology.md).
 - **SKILL.md / agent skill / skill catalog / context injection / Node manager /
   Python manager / skill audit / skill-manager view / kfx dependency binding** →
   *agent-facing Kungfu Skill* ([`skills.md`](skills.md)).

--- a/docs/config.md
+++ b/docs/config.md
@@ -14,6 +14,13 @@ fallback. The architecture decision is
   workspace `.kungfu/` applies. It stores machine-level runtime state, global
   catalog/cache/service state, and non-workspace facts.
 
+The matching live process topology is
+[ADR-0036](../framework/core/docs/adr/ADR-0036-supervisor-and-workspace-master-topology.md):
+a per-user `supervisor` is a router/process manager, while each resolved
+workspace or fallback data root can have its own `master`. The supervisor may
+keep small routing/runtime state under the user config area; workspace master
+process-control state belongs under the resolved data root.
+
 The split is intentional. Runtime data can be large and stateful; workspace
 facts should live near the project they describe; global config is small,
 agent-maintained, and safe to inspect without reading journals or provider

--- a/docs/master-service.md
+++ b/docs/master-service.md
@@ -1,12 +1,31 @@
-# Kungfu Master Service
+# Kungfu Supervisor and Master Service
 
 Status: draft implementation slice.
 
-Kungfu can keep the runtime master alive independently from the GUI. Closing the
-GUI window should not imply that the master stops; stopping the master is an
-explicit operator action.
+Kungfu can keep live runtime coordination alive independently from the GUI.
+Closing the GUI window should not imply that the runtime stops; stopping it is
+an explicit operator action.
 
-The service layer has two parts:
+The architecture decision is
+[ADR-0036](../framework/core/docs/adr/ADR-0036-supervisor-and-workspace-master-topology.md).
+It defines two live process roles:
+
+- `supervisor` is one per OS user/session. It owns no workspace facts. It
+  starts, discovers, health-checks, and stops workspace masters.
+- `master` is one per resolved Kungfu data root: workspace `.kungfu/` or the
+  machine fallback selected by `KF_HOME`. It owns live location/channel
+  registry, active actor supervision, subscriptions, and live projections for
+  that fact ledger.
+
+Durable facts are not daemon-owned. The source of truth remains the data-root
+storage: yijinjing journals, Episode manifest journal, payload store, and
+rebuildable projections. Local append/seal/fsck/export operations may run
+without a live master when they do not need live discovery or routing.
+
+## Current CLI Surface
+
+The current implementation slice exposes the process manager through
+`kungfu master ...` commands:
 
 - `kungfu master supervise` is the foreground supervisor loop used by a user
   service manager.
@@ -32,15 +51,50 @@ kungfu master service uninstall --execute --json
 `install` and `uninstall` are dry-run by default. They write or remove the
 user-level service file only when `--execute` is supplied.
 
+## Target Topology
+
+The target live command path is:
+
+```text
+CLI / GUI / TUI
+  -> resolve Kungfu data root
+  -> contact per-user supervisor
+  -> supervisor ensure_master(data_root)
+  -> command talks to that data-root master
+```
+
+If the supervisor is not running, a product entrypoint may start it. If a
+command only needs closed-data storage access, it may bypass the live master and
+operate directly on the resolved data-root storage.
+
+The supervisor tracks masters by canonical data-root identity, not by the raw
+current-working-directory string. This prevents a symlinked workspace or nested
+path from accidentally starting duplicate masters for the same `.kungfu/` home.
+
 ## Runtime State
 
-The supervisor writes runtime state under:
+The target supervisor writes user-level runtime state under the user
+config/runtime area:
+
+```text
+<KF_CONFIG_HOME>/runtime/supervisor/
+```
+
+The target workspace master writes process-control state under the resolved
+data root:
+
+```text
+<kungfu-data-root>/runtime/master/
+```
+
+In the current implementation slice the combined service state may still appear
+under:
 
 ```text
 <KF_RUNTIME_DIR>/service/master/
 ```
 
-Files in that directory include:
+Files in these runtime-state directories include:
 
 - `supervisor.pid`
 - `master.pid`
@@ -48,8 +102,9 @@ Files in that directory include:
 - `supervisor.log`
 - `master.log`
 
-The `status --json` command reads those files and verifies whether the recorded
-PIDs are still alive.
+The `status --json` command reads process-control state and verifies whether
+the recorded PIDs are still alive. Runtime-state files are not durable facts and
+must not be treated as the source of truth.
 
 ## Service Plans
 
@@ -61,17 +116,25 @@ would be installed:
 - Windows: the current user's Startup folder command file
 
 The generated service starts the supervisor loop and lets the supervisor keep
-the master alive. Loading/enabling the service manager is intentionally left as
-an explicit user operation after the file is installed.
+workspace masters alive as needed. Loading/enabling the service manager is
+intentionally left as an explicit user operation after the file is installed.
 
 ## Lifecycle Semantics
 
-- Closing or hiding the GUI should not stop the master.
+- Closing or hiding the GUI releases the GUI lease. It should not stop the
+  supervisor or a still-active workspace master.
 - Quitting the GUI should exit Electron. If the service is installed and
-  running, the master remains alive.
-- `kungfu master stop` stops the supervisor and its child master.
+  running, active workspace masters may remain alive.
+- `kungfu master stop` stops the current implementation's supervisor and child
+  master. In the target topology, stop semantics should distinguish stopping a
+  selected data-root master from stopping the per-user supervisor.
 - `kungfu master service uninstall --execute` removes the user service file; it
   does not delete runtime journals or other user data.
+- When a workspace master has no active leases and the idle grace period has
+  elapsed, the supervisor may ask it to shut down gracefully.
+- A graceful shutdown should flush live projections, seal or record the master
+  lifecycle Episode where applicable, close sockets, release locks, and leave
+  journals, manifests, payloads, and projections intact.
 
 ## GUI Tray / Menu-Bar Controls
 

--- a/framework/core/docs/adr/ADR-0036-supervisor-and-workspace-master-topology.md
+++ b/framework/core/docs/adr/ADR-0036-supervisor-and-workspace-master-topology.md
@@ -1,0 +1,201 @@
+# ADR-0036: Per-user supervisor manages per-data-root masters
+
+- Status: accepted
+- Date: 2026-07-09
+- Category: (architecture) live runtime coordination, process topology, and
+  workspace master lifecycle
+- Subsystem: supervisor, master, CLI, GUI, TUI, location registry, channel
+  routing, runtime storage service, and workspace data-root discovery.
+- Related: ADR-0018 defines the runtime storage service. ADR-0019 defines
+  source sync over location and channel. ADR-0033 defines Episode as the
+  first-class causal segment object. ADR-0034 defines the yijinjing-backed
+  Episode manifest journal. ADR-0035 defines workspace-local `.kungfu/` as the
+  default fact-ledger home. [`docs/master-service.md`](../../../../docs/master-service.md)
+  documents the operator-facing service surface.
+
+## Context
+
+Kungfu now treats durable facts as data-root scoped. A workspace `.kungfu/`
+home, or the machine fallback selected by `KF_HOME`, contains the journals,
+Episode manifest journal, payload store, projections, and source registry for
+that fact world.
+
+At the same time, Kungfu has live runtime concepts that are not just files:
+locations, channels, active actors, subscriptions, health, and GUI/TUI/CLI
+routing. Those concepts need a live coordinator when a user wants real-time
+discovery or supervision.
+
+Requiring every user or agent to manually run `kungfu start master` before a
+CLI command is a poor interface. Making one global master own every workspace
+would also be wrong: it would collapse independent `.kungfu/` fact ledgers back
+into one machine-wide world and make Git-worktree dogfood collide.
+
+The architecture therefore needs two layers:
+
+- a user-level process that is easy for CLI/GUI/TUI entrypoints to find; and
+- a data-root-level master that coordinates one Kungfu fact world.
+
+## Decision
+
+Kungfu uses the following terminology:
+
+| Name | Scope | Responsibility |
+| --- | --- | --- |
+| `supervisor` | one per OS user/session | Process manager and router. It owns no workspace facts. It starts, discovers, health-checks, and stops workspace masters. |
+| `master` | one per resolved Kungfu data root | Live coordinator for one fact ledger. It owns location/channel registry, active actor supervision, subscriptions, live projections, and the master lifecycle Episode for that data root. |
+| durable storage | one per resolved Kungfu data root | Source of truth: yijinjing journals, Episode manifest journal, payload store, and rebuildable projections. |
+
+The workspace-level live coordinator keeps the existing Kungfu term `master`.
+The user-level process is called `supervisor`. Do not call the per-user process
+`master`, and do not make a workspace master responsible for unrelated data
+roots.
+
+The normal live command path is:
+
+```text
+CLI / GUI / TUI
+  -> resolve Kungfu data root
+  -> contact per-user supervisor
+  -> supervisor ensure_master(data_root)
+  -> command talks to that data-root master
+```
+
+If the supervisor is not running, a product entrypoint may start it. If a
+command only needs daemonless storage operations, it may bypass live master
+routing and write or inspect the data-root storage directly.
+
+The supervisor tracks masters by canonical data-root identity, not by current
+working directory string. It should normalize symlinks and workspace discovery
+results so repeated commands for the same `.kungfu/` home converge on the same
+master.
+
+## Process and runtime state
+
+Supervisor state belongs under the user config/runtime area, because it is a
+user-level router. The exact platform path can vary, but the logical state is:
+
+```text
+<KF_CONFIG_HOME>/runtime/supervisor/
+```
+
+Workspace master state belongs under the resolved data root, because it is tied
+to that fact ledger:
+
+```text
+<kungfu-data-root>/runtime/master/
+```
+
+The supervisor state may include its lock, pid, socket, log, and a small routing
+cache. A workspace master state directory may include its lock, pid, socket,
+heartbeat, log, and live projection state. Durable facts remain outside those
+process-control files in journals, manifest journals, payload stores, and
+projections.
+
+## Lifecycle semantics
+
+The supervisor keeps a registry of live workspace masters and uses leases to
+decide whether a master is still active. Lease sources include:
+
+- CLI commands;
+- GUI windows;
+- TUI sessions;
+- actor processes;
+- maintenance jobs;
+- subscriptions and watchers.
+
+An active actor count is not enough. A GUI subscription or maintenance export
+can keep a master useful even when no user actor is currently writing frames.
+
+When a master has no active leases and the idle grace period has elapsed, the
+supervisor may ask it to shut down gracefully. A graceful shutdown should:
+
+- flush and close live projections;
+- seal or record the master lifecycle Episode where applicable;
+- close sockets;
+- release locks;
+- leave durable journals, manifests, payloads, and projections intact.
+
+If the supervisor crashes, existing masters may keep running temporarily. A
+restarted supervisor can rediscover healthy masters from their runtime state or
+clear stale pid/socket/lock files after verifying that the recorded process is
+gone.
+
+## Masterless storage mode
+
+Kungfu storage is not daemon-owned. The durable fact ledger is the storage
+itself, not the live master process.
+
+Therefore, a local process may operate without a live master when it only needs
+to:
+
+- append or seal its own Episode records;
+- write payloads through the storage provider;
+- export a range or Episode bundle;
+- run fsck or compact-style maintenance over closed data;
+- rebuild projections offline.
+
+In masterless mode, the process does not get live discovery, real-time channel
+routing, supervised actor registry, subscription fan-out, or cross-process
+health. It is a local storage operation with fewer coordination guarantees.
+
+## Consequences
+
+- CLI usage can remain simple. A command can route through the supervisor and
+  get the correct workspace master without forcing users to start one manually.
+- Multiple workspaces and Git worktrees can have independent masters and
+  independent fact ledgers on the same machine.
+- The per-user supervisor can provide health checks and idle shutdown without
+  becoming the source of truth for any workspace.
+- The master remains a live coordination service, not a storage authority. This
+  keeps import/export/fsck/sync compatible with future distributed storage and
+  Episode bundle workflows.
+- GUI close semantics are clearer: closing a window releases the GUI lease; it
+  does not necessarily stop the workspace master or supervisor.
+
+## First delivery
+
+This ADR records the architecture decision and updates documentation.
+
+Implementation work remains separate:
+
+- introduce a user-level supervisor command/service surface;
+- update the existing `kungfu master ...` surface so it targets the resolved
+  data-root master;
+- add `ensure_master(data_root)` routing between CLI/GUI/TUI and the supervisor;
+- move master runtime files under the resolved data root;
+- add lease and heartbeat records for GUI/TUI/CLI/actor/maintenance users;
+- define stale runtime-state recovery and idle graceful shutdown behavior.
+
+## Explicitly out of scope
+
+- Remote cluster consensus or conflict resolution.
+- A universal global clock.
+- Making the supervisor store or own workspace facts.
+- Requiring a live master for closed-data fsck/export.
+- Removing the `master` term from Kungfu's workspace-level live coordinator.
+
+## Alternatives considered
+
+- **Require users to start a master manually.** Rejected. It makes CLI and
+  agent workflows brittle and turns a runtime detail into daily user overhead.
+- **Use one machine-wide master for every workspace.** Rejected. It conflicts
+  with workspace-local `.kungfu/` fact ledgers and makes independent worktrees
+  collide.
+- **Call the user-level process master and invent a new workspace term.**
+  Rejected. `master` is already the Kungfu term for the live coordinator. The
+  new layer is more accurately a supervisor.
+- **Make all storage writes go through master.** Rejected. It would make
+  closed-data maintenance, import/export, and future distributed bundle
+  workflows depend on a daemon even though the storage layer is already the
+  durable truth.
+
+## Residual risk
+
+- Supervisor routing must canonicalize data roots carefully. Symlinked
+  workspaces, nested repositories, and explicit `KF_HOME` values can otherwise
+  produce duplicate masters.
+- Masterless writes need clear locking and fsck rules so they do not corrupt an
+  active writer's open Episode.
+- The CLI surface currently uses `kungfu master ...` for both service and
+  runtime operations. Implementation should preserve a clean user experience
+  while making the internal split explicit.

--- a/framework/core/docs/adr/README.md
+++ b/framework/core/docs/adr/README.md
@@ -51,6 +51,7 @@ A record's **Status** says where it stands:
 | [0033](ADR-0033-episode-causal-segment-object.md) | accepted | Episode is the first-class causal segment object |
 | [0034](ADR-0034-yijinjing-episode-manifest-journal.md) | accepted | Episode manifest records live in the yijinjing journal format |
 | [0035](ADR-0035-workspace-local-kungfu-data-home.md) | accepted | Workspace-local `.kungfu` is the default fact ledger home |
+| [0036](ADR-0036-supervisor-and-workspace-master-topology.md) | accepted | Per-user supervisor manages per-data-root masters |
 
 ## Reading by theme
 
@@ -128,7 +129,10 @@ A record's **Status** says where it stands:
   JSON only as export/debug/folded view), and
   [0035](ADR-0035-workspace-local-kungfu-data-home.md) (workspace-local
   `.kungfu/` as the default Episode/fact ledger home, with `~/.kungfu-config`
-  as the user config home and `KF_HOME` retained as machine fallback).
+  as the user config home and `KF_HOME` retained as machine fallback), and
+  [0036](ADR-0036-supervisor-and-workspace-master-topology.md) (a per-user
+  supervisor routes CLI/GUI/TUI entrypoints to per-data-root masters while
+  storage remains daemonless).
 - **Cross-cutting principle** — [0009](ADR-0009-load-bearing-self-bootstrap.md)
   (load-bearing self-bootstrap), which also names the general law that
   [`docs/architecture.md` § The build dogfoods the SDK](../../../../docs/architecture.md)


### PR DESCRIPTION
## Summary
- add ADR-0036 for the per-user supervisor and per-data-root workspace master topology
- document that the supervisor routes and manages masters but does not own durable facts
- update master service, config, ADR index, and docs map entry points

## Validation
- git diff --check
- ./kungfu-code check

## Notes
- This is a documentation/architecture decision slice. Implementation work remains separate.