### PR TITLE
feat(master): route data roots through supervisor

### DIFF
--- a/docs/master-service.md
+++ b/docs/master-service.md
@@ -37,6 +37,7 @@ surface is:
 
 ```sh
 kungfu master status --json
+kungfu master ensure --json
 kungfu master start --json
 kungfu master stop --json
 kungfu master restart --json
@@ -87,13 +88,6 @@ data root:
 <kungfu-data-root>/runtime/master/
 ```
 
-In the current implementation slice the combined service state may still appear
-under:
-
-```text
-<KF_RUNTIME_DIR>/service/master/
-```
-
 Files in these runtime-state directories include:
 
 - `supervisor.pid`
@@ -111,9 +105,10 @@ must not be treated as the source of truth.
 `kungfu master service plan --json` prints the platform-specific file that
 would be installed:
 
-- macOS: `~/Library/LaunchAgents/tech.kungfu.master.plist`
-- Linux: `~/.config/systemd/user/kungfu-master.service`
-- Windows: the current user's Startup folder command file
+- macOS: `~/Library/LaunchAgents/tech.kungfu.supervisor.plist`
+- Linux: `~/.config/systemd/user/kungfu-supervisor.service`
+- Windows: the current user's Startup folder `kungfu-supervisor.cmd` command
+  file
 
 The generated service starts the supervisor loop and lets the supervisor keep
 workspace masters alive as needed. Loading/enabling the service manager is
@@ -125,9 +120,10 @@ intentionally left as an explicit user operation after the file is installed.
   supervisor or a still-active workspace master.
 - Quitting the GUI should exit Electron. If the service is installed and
   running, active workspace masters may remain alive.
-- `kungfu master stop` stops the current implementation's supervisor and child
-  master. In the target topology, stop semantics should distinguish stopping a
-  selected data-root master from stopping the per-user supervisor.
+- `kungfu master ensure` registers the current data root in the supervisor
+  route registry and starts or reuses the corresponding workspace master.
+- `kungfu master stop` stops the per-user supervisor and its supervised
+  workspace masters.
 - `kungfu master service uninstall --execute` removes the user service file; it
   does not delete runtime journals or other user data.
 - When a workspace master has no active leases and the idle grace period has

--- a/framework/config/kungfu-config.contract.json
+++ b/framework/config/kungfu-config.contract.json
@@ -154,7 +154,7 @@
   "resolution": {
     "configHomeEnv": "KF_CONFIG_HOME",
     "runtimeHomeEnv": "KF_HOME",
-    "defaultConfigHome": "~/.kungfu",
+    "defaultConfigHome": "~/.kungfu-config",
     "defaultRuntimeHome": {
       "darwin": "~/Library/Application Support/kungfu/home",
       "win32": "${APPDATA}/kungfu/home",

--- a/framework/contract/kungfu-agent-first-canonical-policy.json
+++ b/framework/contract/kungfu-agent-first-canonical-policy.json
@@ -95,13 +95,13 @@
       },
       "source": {
         "path": "framework/config/kungfu-config.contract.json",
-        "sha256": "sha256:ad21f1f270f47436d7131f2c26524eb882dd67d2c92197aec4c839a7bdac6ecb",
-        "renderedSha256": "sha256:ad21f1f270f47436d7131f2c26524eb882dd67d2c92197aec4c839a7bdac6ecb",
+        "sha256": "sha256:9398832cf89bc8f7f96555ac4be23a3d93bac2e5e392b9eaa3b4917a9526bbea",
+        "renderedSha256": "sha256:9398832cf89bc8f7f96555ac4be23a3d93bac2e5e392b9eaa3b4917a9526bbea",
         "byteForByte": true
       },
       "artifact": {
         "path": "config/kungfu-config.contract.json",
-        "expectedSha256": "sha256:ad21f1f270f47436d7131f2c26524eb882dd67d2c92197aec4c839a7bdac6ecb"
+        "expectedSha256": "sha256:9398832cf89bc8f7f96555ac4be23a3d93bac2e5e392b9eaa3b4917a9526bbea"
       }
     },
     {

--- a/framework/core/src/python/kungfu/cli/commands/__init__.py
+++ b/framework/core/src/python/kungfu/cli/commands/__init__.py
@@ -7,7 +7,7 @@ import os
 import typing
 from click.globals import get_current_context
 from functools import update_wrapper
-from kungfu.config import default_runtime_home
+from kungfu.config import default_config_home, default_runtime_home
 
 # click 8.1.7+ 移除了私有 TypeVar F；CLI 仅用于装饰器类型标注，改本地定义不依赖 click 内部符号。
 CLI = typing.TypeVar("CLI", bound=typing.Callable[..., typing.Any])
@@ -91,6 +91,7 @@ class PrioritizedCommandGroup(click.Group):
 
                 for key in [
                     "name",
+                    "config_home",
                     "home",
                     "extension_path",
                     "log_level",
@@ -155,8 +156,10 @@ def kfc(ctx, home, extension_path, log_level, name, stage, env_verify_location):
 
     runtime_dir_override = os.environ.get("KF_RUNTIME_DIR") if not home else None
     home = default_runtime_home() if not home else home
+    config_home = default_config_home()
     ctx.extension_path = extension_path
 
+    os.environ["KF_CONFIG_HOME"] = ctx.config_home = config_home
     os.environ["KF_HOME"] = ctx.home = home
     os.environ["KF_LOG_LEVEL"] = ctx.log_level = log_level
 

--- a/framework/core/src/python/kungfu/cli/commands/master.py
+++ b/framework/core/src/python/kungfu/cli/commands/master.py
@@ -19,17 +19,20 @@ def _json(payload):
 
 def _plain_status(payload):
     click.echo(f"status: {payload['status']}")
+    click.echo(f"config: {payload['configHome']}")
+    click.echo(f"data root: {payload['dataRoot']}")
     click.echo(f"runtime: {payload['runtimeDir']}")
     click.echo(
         "supervisor: "
         f"{payload['supervisor']['pid'] or '-'} "
         f"({'running' if payload['supervisor']['running'] else 'stopped'})"
     )
-    click.echo(
-        "master: "
-        f"{payload['master']['pid'] or '-'} "
-        f"({'running' if payload['master']['running'] else 'stopped'})"
-    )
+    if "master" in payload:
+        click.echo(
+            "master: "
+            f"{payload['master']['pid'] or '-'} "
+            f"({'running' if payload['master']['running'] else 'stopped'})"
+        )
 
 
 @kfc.group(
@@ -47,18 +50,39 @@ def master(ctx):
 @click.option("--json", "as_json", is_flag=True, help="machine-readable output")
 @master_command_context
 def master_status(ctx, as_json):
-    payload = master_service.status(ctx.home, ctx.runtime_dir)
+    payload = master_service.route_status(ctx.home, ctx.runtime_dir, ctx.config_home)
     if as_json:
         _json(payload)
         return
     _plain_status(payload)
 
 
+@master.command(help="ensure the current data-root master via the user supervisor")
+@click.option("--json", "as_json", is_flag=True, help="machine-readable output")
+@master_command_context
+def ensure(ctx, as_json):
+    payload = master_service.ensure_master(
+        ctx.home,
+        ctx.runtime_dir,
+        ctx.log_level,
+        ctx.config_home,
+    )
+    if as_json:
+        _json(payload)
+        return
+    click.echo("started" if payload.get("changed") else "already running")
+
+
 @master.command(help="start the resident master supervisor")
 @click.option("--json", "as_json", is_flag=True, help="machine-readable output")
 @master_command_context
 def start(ctx, as_json):
-    payload = master_service.start_supervisor(ctx.home, ctx.runtime_dir, ctx.log_level)
+    payload = master_service.ensure_master(
+        ctx.home,
+        ctx.runtime_dir,
+        ctx.log_level,
+        ctx.config_home,
+    )
     if as_json:
         _json(payload)
         return
@@ -69,7 +93,7 @@ def start(ctx, as_json):
 @click.option("--json", "as_json", is_flag=True, help="machine-readable output")
 @master_command_context
 def stop(ctx, as_json):
-    payload = master_service.stop_supervisor(ctx.home, ctx.runtime_dir)
+    payload = master_service.stop_supervisor(ctx.config_home)
     if as_json:
         _json(payload)
         return
@@ -82,10 +106,15 @@ def stop(ctx, as_json):
 @click.option("--json", "as_json", is_flag=True, help="machine-readable output")
 @master_command_context
 def restart(ctx, as_json):
-    stopped = master_service.stop_supervisor(ctx.home, ctx.runtime_dir)
+    stopped = master_service.stop_supervisor(ctx.config_home)
     if stopped.get("error"):
         raise click.ClickException(str(stopped["error"]))
-    started = master_service.start_supervisor(ctx.home, ctx.runtime_dir, ctx.log_level)
+    started = master_service.ensure_master(
+        ctx.home,
+        ctx.runtime_dir,
+        ctx.log_level,
+        ctx.config_home,
+    )
     payload = {
         "schema": "kungfu.master-service.restart/v1",
         "stop": stopped,
@@ -120,25 +149,32 @@ def run(runtime_home, runtime_dir, low_latency):
 @click.option(
     "--home",
     "runtime_home",
-    required=True,
+    required=False,
     hidden=True,
     help="runtime home passed by the service manager",
 )
 @click.option(
     "--runtime-dir",
-    required=True,
+    required=False,
     hidden=True,
     help="runtime directory passed by the service manager",
 )
+@click.option(
+    "--config-home",
+    required=False,
+    hidden=True,
+    help="config home passed by the service manager",
+)
 @click.option("--foreground", is_flag=True, hidden=True)
-def supervise(runtime_home, runtime_dir, foreground):
+def supervise(runtime_home, runtime_dir, config_home, foreground):
     callable(foreground)
     root = click.get_current_context().parent.parent
     sys.exit(
         master_service.run_supervisor(
-            runtime_home,
-            runtime_dir,
             getattr(root, "log_level", "warning"),
+            config_home=config_home,
+            home=runtime_home,
+            runtime_dir=runtime_dir,
         )
     )
 
@@ -158,7 +194,7 @@ def service(ctx):
 @master_command_context
 def plan(ctx, as_json):
     payload = master_service.service_plan(
-        ctx.home, ctx.runtime_dir, ctx.log_level
+        ctx.home, ctx.runtime_dir, ctx.log_level, ctx.config_home
     ).as_dict()
     if as_json:
         _json(payload)
@@ -171,7 +207,12 @@ def plan(ctx, as_json):
 @click.option("--json", "as_json", is_flag=True, help="machine-readable output")
 @master_command_context
 def service_status(ctx, as_json):
-    payload = master_service.service_status(ctx.home, ctx.runtime_dir, ctx.log_level)
+    payload = master_service.service_status(
+        ctx.home,
+        ctx.runtime_dir,
+        ctx.log_level,
+        ctx.config_home,
+    )
     if as_json:
         _json(payload)
         return
@@ -193,7 +234,10 @@ def service_status(ctx, as_json):
 def install(ctx, execute, as_json):
     if execute:
         payload = master_service.install_service(
-            ctx.home, ctx.runtime_dir, ctx.log_level
+            ctx.home,
+            ctx.runtime_dir,
+            ctx.log_level,
+            ctx.config_home,
         )
     else:
         payload = {
@@ -202,7 +246,10 @@ def install(ctx, execute, as_json):
             "changed": False,
             "dryRun": True,
             "plan": master_service.service_plan(
-                ctx.home, ctx.runtime_dir, ctx.log_level
+                ctx.home,
+                ctx.runtime_dir,
+                ctx.log_level,
+                ctx.config_home,
             ).as_dict(),
         }
     if as_json:
@@ -223,7 +270,10 @@ def install(ctx, execute, as_json):
 def uninstall(ctx, execute, as_json):
     if execute:
         payload = master_service.uninstall_service(
-            ctx.home, ctx.runtime_dir, ctx.log_level
+            ctx.home,
+            ctx.runtime_dir,
+            ctx.log_level,
+            ctx.config_home,
         )
     else:
         payload = {
@@ -232,7 +282,10 @@ def uninstall(ctx, execute, as_json):
             "changed": False,
             "dryRun": True,
             "plan": master_service.service_plan(
-                ctx.home, ctx.runtime_dir, ctx.log_level
+                ctx.home,
+                ctx.runtime_dir,
+                ctx.log_level,
+                ctx.config_home,
             ).as_dict(),
         }
     if as_json:

--- a/framework/core/src/python/kungfu/master_service.py
+++ b/framework/core/src/python/kungfu/master_service.py
@@ -10,6 +10,7 @@ import subprocess
 import sys
 import time
 from dataclasses import dataclass
+from hashlib import sha256
 from pathlib import Path
 from typing import Any
 from xml.sax.saxutils import escape as xml_escape
@@ -23,8 +24,9 @@ yjj = kungfu.__binding__.runtime
 SCHEMA_STATUS = "kungfu.master-service.status/v1"
 SCHEMA_PLAN = "kungfu.master-service.plan/v1"
 SCHEMA_RESULT = "kungfu.master-service.result/v1"
-SERVICE_ID = "tech.kungfu.master"
-SERVICE_NAME = "Kungfu Master"
+SCHEMA_ROUTES = "kungfu.master-service.routes/v1"
+SERVICE_ID = "tech.kungfu.supervisor"
+SERVICE_NAME = "Kungfu Supervisor"
 
 
 def _now() -> float:
@@ -90,12 +92,56 @@ def _systemd_env_line(key: str, value: str) -> str:
     return f'Environment="{key}={escaped}"'
 
 
+def _canonical_path(value: str) -> str:
+    return str(Path(value).expanduser().resolve())
+
+
+def resolve_config_home(config_home: str | None = None) -> str:
+    return _canonical_path(
+        config_home or os.environ.get("KF_CONFIG_HOME") or "~/.kungfu-config"
+    )
+
+
+def resolve_runtime_home(home: str) -> str:
+    return _canonical_path(home)
+
+
+def resolve_runtime_dir(home: str, runtime_dir: str | None = None) -> str:
+    return _canonical_path(runtime_dir or str(Path(home).expanduser() / "runtime"))
+
+
+def route_id(home: str, runtime_dir: str) -> str:
+    digest = sha256(
+        f"{resolve_runtime_home(home)}\0{resolve_runtime_dir(home, runtime_dir)}".encode(
+            "utf-8"
+        )
+    ).hexdigest()
+    return digest[:16]
+
+
+def route_record(home: str, runtime_dir: str) -> dict[str, Any]:
+    home = resolve_runtime_home(home)
+    runtime_dir = resolve_runtime_dir(home, runtime_dir)
+    return {
+        "routeId": route_id(home, runtime_dir),
+        "dataRoot": home,
+        "home": home,
+        "runtimeDir": runtime_dir,
+        "desired": True,
+        "updatedAt": _now(),
+    }
+
+
+def supervisor_state_dir(config_home: str | None = None) -> Path:
+    return Path(resolve_config_home(config_home)) / "runtime" / "supervisor"
+
+
 def state_dir(runtime_dir: str) -> Path:
-    return Path(runtime_dir).expanduser().resolve() / "service" / "master"
+    return Path(runtime_dir).expanduser().resolve() / "master"
 
 
-def supervisor_pid_path(runtime_dir: str) -> Path:
-    return state_dir(runtime_dir) / "supervisor.pid"
+def supervisor_pid_path(config_home: str | None = None) -> Path:
+    return supervisor_state_dir(config_home) / "supervisor.pid"
 
 
 def master_pid_path(runtime_dir: str) -> Path:
@@ -106,8 +152,16 @@ def state_path(runtime_dir: str) -> Path:
     return state_dir(runtime_dir) / "state.json"
 
 
-def supervisor_log_path(runtime_dir: str) -> Path:
-    return state_dir(runtime_dir) / "supervisor.log"
+def supervisor_state_path(config_home: str | None = None) -> Path:
+    return supervisor_state_dir(config_home) / "state.json"
+
+
+def routes_path(config_home: str | None = None) -> Path:
+    return supervisor_state_dir(config_home) / "routes.json"
+
+
+def supervisor_log_path(config_home: str | None = None) -> Path:
+    return supervisor_state_dir(config_home) / "supervisor.log"
 
 
 def master_log_path(runtime_dir: str) -> Path:
@@ -140,10 +194,16 @@ def entry_command() -> list[str]:
     return [sys.executable, "-m", "kungfu"]
 
 
-def command_env(home: str, runtime_dir: str, log_level: str) -> dict[str, str]:
+def command_env(
+    home: str,
+    runtime_dir: str,
+    log_level: str,
+    config_home: str | None = None,
+) -> dict[str, str]:
     env = dict(os.environ)
     env["KF_HOME"] = home
     env["KF_RUNTIME_DIR"] = runtime_dir
+    env["KF_CONFIG_HOME"] = resolve_config_home(config_home)
     env["KF_LOG_LEVEL"] = log_level
     return env
 
@@ -163,7 +223,12 @@ def master_run_command(home: str, runtime_dir: str, log_level: str) -> list[str]
 
 
 def supervisor_command(
-    home: str, runtime_dir: str, log_level: str, *, foreground: bool = True
+    config_home: str | None,
+    log_level: str,
+    *,
+    home: str | None = None,
+    runtime_dir: str | None = None,
+    foreground: bool = True,
 ) -> list[str]:
     command = [
         *entry_command(),
@@ -171,14 +236,46 @@ def supervisor_command(
         log_level,
         "master",
         "supervise",
-        "--runtime-dir",
-        runtime_dir,
-        "--home",
-        home,
+        "--config-home",
+        resolve_config_home(config_home),
     ]
+    if home:
+        command.extend(["--home", resolve_runtime_home(home)])
+    if runtime_dir:
+        command.extend(["--runtime-dir", resolve_runtime_dir(home or "", runtime_dir)])
     if foreground:
         command.append("--foreground")
     return command
+
+
+def _empty_routes() -> dict[str, Any]:
+    return {"schema": SCHEMA_ROUTES, "routes": {}}
+
+
+def read_routes(config_home: str | None = None) -> dict[str, Any]:
+    payload = _json_read(routes_path(config_home))
+    if payload.get("schema") != SCHEMA_ROUTES or not isinstance(
+        payload.get("routes"), dict
+    ):
+        return _empty_routes()
+    return payload
+
+
+def write_routes(config_home: str | None, payload: dict[str, Any]) -> None:
+    payload.setdefault("schema", SCHEMA_ROUTES)
+    payload.setdefault("routes", {})
+    payload["updatedAt"] = _now()
+    _json_write(routes_path(config_home), payload)
+
+
+def upsert_route(
+    config_home: str | None, home: str, runtime_dir: str
+) -> dict[str, Any]:
+    route = route_record(home, runtime_dir)
+    payload = read_routes(config_home)
+    payload["routes"][route["routeId"]] = route
+    write_routes(config_home, payload)
+    return route
 
 
 class Master(yjj.master):
@@ -206,6 +303,8 @@ class Master(yjj.master):
 
 
 def run_master(home: str, runtime_dir: str, low_latency: bool = False) -> int:
+    home = resolve_runtime_home(home)
+    runtime_dir = resolve_runtime_dir(home, runtime_dir)
     service_state_dir = state_dir(runtime_dir)
     service_state_dir.mkdir(parents=True, exist_ok=True)
     write_pid(master_pid_path(runtime_dir), os.getpid())
@@ -229,25 +328,48 @@ def run_master(home: str, runtime_dir: str, low_latency: bool = False) -> int:
 
 
 def status(home: str, runtime_dir: str) -> dict[str, Any]:
-    supervisor_pid = read_pid(supervisor_pid_path(runtime_dir))
+    return route_status(home, runtime_dir)
+
+
+def route_status(
+    home: str,
+    runtime_dir: str,
+    config_home: str | None = None,
+) -> dict[str, Any]:
+    config_home = resolve_config_home(config_home)
+    home = resolve_runtime_home(home)
+    runtime_dir = resolve_runtime_dir(home, runtime_dir)
+    route = route_record(home, runtime_dir)
+    supervisor_pid = read_pid(supervisor_pid_path(config_home))
     master_pid = read_pid(master_pid_path(runtime_dir))
     state = _json_read(state_path(runtime_dir))
+    supervisor_state = _json_read(supervisor_state_path(config_home))
+    routes = read_routes(config_home)
     supervisor_running = _is_pid_running(supervisor_pid)
     master_running = _is_pid_running(master_pid)
     status_name = "running" if supervisor_running else "stopped"
     if master_running and not supervisor_running:
         status_name = "orphan-master"
+    elif supervisor_running and not master_running:
+        status_name = "supervisor-running"
     return {
         "schema": SCHEMA_STATUS,
         "status": status_name,
+        "configHome": config_home,
+        "dataRoot": home,
         "home": home,
         "runtimeDir": runtime_dir,
+        "supervisorStateDir": str(supervisor_state_dir(config_home)),
         "stateDir": str(state_dir(runtime_dir)),
+        "route": {
+            **route,
+            "registered": route["routeId"] in routes["routes"],
+        },
         "supervisor": {
             "pid": supervisor_pid,
             "running": supervisor_running,
-            "pidFile": str(supervisor_pid_path(runtime_dir)),
-            "log": str(supervisor_log_path(runtime_dir)),
+            "pidFile": str(supervisor_pid_path(config_home)),
+            "log": str(supervisor_log_path(config_home)),
         },
         "master": {
             "pid": master_pid,
@@ -255,28 +377,38 @@ def status(home: str, runtime_dir: str) -> dict[str, Any]:
             "pidFile": str(master_pid_path(runtime_dir)),
             "log": str(master_log_path(runtime_dir)),
         },
+        "routes": {
+            "path": str(routes_path(config_home)),
+            "count": len(routes["routes"]),
+        },
+        "lastSupervisorState": supervisor_state,
         "lastState": state,
     }
 
 
 def run_supervisor(
-    home: str,
-    runtime_dir: str,
     log_level: str,
     *,
+    config_home: str | None = None,
+    home: str | None = None,
+    runtime_dir: str | None = None,
     restart_delay: float = 2.0,
 ) -> int:
-    service_state_dir = state_dir(runtime_dir)
+    config_home = resolve_config_home(config_home)
+    service_state_dir = supervisor_state_dir(config_home)
     service_state_dir.mkdir(parents=True, exist_ok=True)
-    write_pid(supervisor_pid_path(runtime_dir), os.getpid())
+    write_pid(supervisor_pid_path(config_home), os.getpid())
+    if home and runtime_dir:
+        upsert_route(config_home, home, runtime_dir)
     stopping = False
-    child: subprocess.Popen[Any] | None = None
+    children: dict[str, subprocess.Popen[Any]] = {}
 
     def request_stop(signum: int, frame: Any) -> None:
         nonlocal stopping
         stopping = True
-        if child and child.poll() is None:
-            child.terminate()
+        for child in children.values():
+            if child.poll() is None:
+                child.terminate()
 
     signal.signal(signal.SIGTERM, request_stop)
     if platform.system() != "Windows":
@@ -284,77 +416,117 @@ def run_supervisor(
 
     try:
         while not stopping:
-            command = master_run_command(home, runtime_dir, log_level)
-            with master_log_path(runtime_dir).open("ab") as log:
-                child = subprocess.Popen(
-                    command,
-                    env=command_env(home, runtime_dir, log_level),
-                    stdout=log,
-                    stderr=log,
+            routes = read_routes(config_home)
+            desired_routes = {
+                route_id_: route
+                for route_id_, route in routes["routes"].items()
+                if isinstance(route, dict) and route.get("desired") is True
+            }
+            for route_id_, child in list(children.items()):
+                if child.poll() is not None or route_id_ not in desired_routes:
+                    route = desired_routes.get(route_id_)
+                    if route:
+                        unlink_if_exists(master_pid_path(str(route["runtimeDir"])))
+                    if route_id_ not in desired_routes and child.poll() is None:
+                        child.terminate()
+                    children.pop(route_id_, None)
+            for route_id_, route in desired_routes.items():
+                child = children.get(route_id_)
+                if child and child.poll() is None:
+                    continue
+                route_home = str(route["home"])
+                route_runtime_dir = str(route["runtimeDir"])
+                command = master_run_command(route_home, route_runtime_dir, log_level)
+                master_log_path(route_runtime_dir).parent.mkdir(
+                    parents=True, exist_ok=True
                 )
-            write_pid(master_pid_path(runtime_dir), child.pid)
+                with master_log_path(route_runtime_dir).open("ab") as log:
+                    child = subprocess.Popen(
+                        command,
+                        env=command_env(
+                            route_home,
+                            route_runtime_dir,
+                            log_level,
+                            config_home,
+                        ),
+                        stdout=log,
+                        stderr=log,
+                    )
+                children[route_id_] = child
+                write_pid(master_pid_path(route_runtime_dir), child.pid)
             _json_write(
-                state_path(runtime_dir),
+                supervisor_state_path(config_home),
                 {
                     "schema": SCHEMA_STATUS,
                     "status": "running",
-                    "home": home,
-                    "runtimeDir": runtime_dir,
+                    "configHome": config_home,
                     "supervisorPid": os.getpid(),
-                    "masterPid": child.pid,
-                    "masterCommand": command,
+                    "routes": {
+                        route_id_: {
+                            "home": route["home"],
+                            "runtimeDir": route["runtimeDir"],
+                            "masterPid": children[route_id_].pid
+                            if route_id_ in children
+                            else None,
+                        }
+                        for route_id_, route in desired_routes.items()
+                    },
                     "updatedAt": _now(),
                 },
             )
-            while not stopping and child.poll() is None:
-                time.sleep(0.5)
-            return_code = child.poll()
-            unlink_if_exists(master_pid_path(runtime_dir))
-            _json_write(
-                state_path(runtime_dir),
-                {
-                    "schema": SCHEMA_STATUS,
-                    "status": "stopping" if stopping else "restarting",
-                    "home": home,
-                    "runtimeDir": runtime_dir,
-                    "supervisorPid": os.getpid(),
-                    "lastMasterReturnCode": return_code,
-                    "updatedAt": _now(),
-                },
-            )
-            if not stopping:
-                time.sleep(restart_delay)
+            time.sleep(restart_delay)
         return 0
     finally:
-        if child and child.poll() is None:
+        for route_id_, child in list(children.items()):
+            if child.poll() is None:
+                child.terminate()
+        for route_id_, child in list(children.items()):
             child.terminate()
             try:
                 child.wait(timeout=5)
             except subprocess.TimeoutExpired:
                 child.kill()
-        unlink_if_exists(supervisor_pid_path(runtime_dir))
-        unlink_if_exists(master_pid_path(runtime_dir))
+        for route in read_routes(config_home)["routes"].values():
+            if isinstance(route, dict) and route.get("runtimeDir"):
+                unlink_if_exists(master_pid_path(str(route["runtimeDir"])))
+        unlink_if_exists(supervisor_pid_path(config_home))
         _json_write(
-            state_path(runtime_dir),
+            supervisor_state_path(config_home),
             {
                 "schema": SCHEMA_STATUS,
                 "status": "stopped",
-                "home": home,
-                "runtimeDir": runtime_dir,
+                "configHome": config_home,
                 "updatedAt": _now(),
             },
         )
 
 
-def start_supervisor(home: str, runtime_dir: str, log_level: str) -> dict[str, Any]:
-    current = status(home, runtime_dir)
+def ensure_master(
+    home: str,
+    runtime_dir: str,
+    log_level: str,
+    config_home: str | None = None,
+) -> dict[str, Any]:
+    config_home = resolve_config_home(config_home)
+    home = resolve_runtime_home(home)
+    runtime_dir = resolve_runtime_dir(home, runtime_dir)
+    route = upsert_route(config_home, home, runtime_dir)
+    current = route_status(home, runtime_dir, config_home)
     if current["supervisor"]["running"]:
-        return {**current, "changed": False}
-    state_dir(runtime_dir).mkdir(parents=True, exist_ok=True)
-    command = supervisor_command(home, runtime_dir, log_level, foreground=True)
-    with supervisor_log_path(runtime_dir).open("ab") as log:
+        return _wait_for_master(
+            home, runtime_dir, config_home, changed=False, route=route
+        )
+    supervisor_state_dir(config_home).mkdir(parents=True, exist_ok=True)
+    command = supervisor_command(
+        config_home,
+        log_level,
+        home=home,
+        runtime_dir=runtime_dir,
+        foreground=True,
+    )
+    with supervisor_log_path(config_home).open("ab") as log:
         kwargs: dict[str, Any] = {
-            "env": command_env(home, runtime_dir, log_level),
+            "env": command_env(home, runtime_dir, log_level, config_home),
             "stdout": log,
             "stderr": log,
         }
@@ -367,30 +539,84 @@ def start_supervisor(home: str, runtime_dir: str, log_level: str) -> dict[str, A
         else:
             kwargs["start_new_session"] = True
         subprocess.Popen(command, **kwargs)
+    return _wait_for_master(
+        home,
+        runtime_dir,
+        config_home,
+        changed=True,
+        command=command,
+        route=route,
+    )
+
+
+def _wait_for_master(
+    home: str,
+    runtime_dir: str,
+    config_home: str,
+    *,
+    changed: bool,
+    route: dict[str, Any],
+    command: list[str] | None = None,
+) -> dict[str, Any]:
     deadline = time.time() + 5
     while time.time() < deadline:
-        current = status(home, runtime_dir)
-        if current["supervisor"]["running"]:
-            return {**current, "changed": True, "command": command}
+        current = route_status(home, runtime_dir, config_home)
+        if current["supervisor"]["running"] and current["master"]["running"]:
+            payload = {**current, "changed": changed, "route": route}
+            if command:
+                payload["command"] = command
+            return payload
         time.sleep(0.2)
-    return {**status(home, runtime_dir), "changed": False, "command": command}
+    payload = {
+        **route_status(home, runtime_dir, config_home),
+        "changed": changed,
+        "route": route,
+    }
+    if command:
+        payload["command"] = command
+    return payload
 
 
 def stop_supervisor(
-    home: str, runtime_dir: str, timeout: float = 10.0
+    config_home: str | None = None, timeout: float = 10.0
 ) -> dict[str, Any]:
-    current = status(home, runtime_dir)
+    config_home = resolve_config_home(config_home)
+    current = supervisor_status(config_home)
     pid = current["supervisor"]["pid"]
     if not current["supervisor"]["running"] or not pid:
         return {**current, "changed": False}
     _terminate_pid(pid)
     deadline = time.time() + timeout
     while time.time() < deadline:
-        current = status(home, runtime_dir)
+        current = supervisor_status(config_home)
         if not current["supervisor"]["running"]:
             return {**current, "changed": True}
         time.sleep(0.2)
-    return {**status(home, runtime_dir), "changed": False, "error": "timeout"}
+    return {**supervisor_status(config_home), "changed": False, "error": "timeout"}
+
+
+def supervisor_status(config_home: str | None = None) -> dict[str, Any]:
+    config_home = resolve_config_home(config_home)
+    supervisor_pid = read_pid(supervisor_pid_path(config_home))
+    routes = read_routes(config_home)
+    return {
+        "schema": SCHEMA_STATUS,
+        "status": "running" if _is_pid_running(supervisor_pid) else "stopped",
+        "configHome": config_home,
+        "supervisorStateDir": str(supervisor_state_dir(config_home)),
+        "supervisor": {
+            "pid": supervisor_pid,
+            "running": _is_pid_running(supervisor_pid),
+            "pidFile": str(supervisor_pid_path(config_home)),
+            "log": str(supervisor_log_path(config_home)),
+        },
+        "routes": {
+            "path": str(routes_path(config_home)),
+            "count": len(routes["routes"]),
+            "items": list(routes["routes"].values()),
+        },
+        "lastSupervisorState": _json_read(supervisor_state_path(config_home)),
+    }
 
 
 @dataclass(frozen=True)
@@ -412,10 +638,24 @@ class ServicePlan:
         }
 
 
-def service_plan(home: str, runtime_dir: str, log_level: str) -> ServicePlan:
+def service_plan(
+    home: str,
+    runtime_dir: str,
+    log_level: str,
+    config_home: str | None = None,
+) -> ServicePlan:
+    config_home = resolve_config_home(config_home)
+    home = resolve_runtime_home(home)
+    runtime_dir = resolve_runtime_dir(home, runtime_dir)
     system = platform.system()
-    command = supervisor_command(home, runtime_dir, log_level, foreground=True)
-    env = command_env(home, runtime_dir, log_level)
+    command = supervisor_command(
+        config_home,
+        log_level,
+        home=home,
+        runtime_dir=runtime_dir,
+        foreground=True,
+    )
+    env = command_env(home, runtime_dir, log_level, config_home)
     if system == "Darwin":
         path = Path.home() / "Library" / "LaunchAgents" / f"{SERVICE_ID}.plist"
         args = "\n".join(f"    <string>{xml_escape(arg)}</string>" for arg in command)
@@ -433,6 +673,8 @@ def service_plan(home: str, runtime_dir: str, log_level: str) -> ServicePlan:
   <dict>
     <key>KF_HOME</key>
     <string>{xml_escape(home)}</string>
+    <key>KF_CONFIG_HOME</key>
+    <string>{xml_escape(config_home)}</string>
     <key>KF_RUNTIME_DIR</key>
     <string>{xml_escape(runtime_dir)}</string>
     <key>KF_LOG_LEVEL</key>
@@ -443,9 +685,9 @@ def service_plan(home: str, runtime_dir: str, log_level: str) -> ServicePlan:
   <key>KeepAlive</key>
   <true/>
   <key>StandardOutPath</key>
-  <string>{xml_escape(str(supervisor_log_path(runtime_dir)))}</string>
+  <string>{xml_escape(str(supervisor_log_path(config_home)))}</string>
   <key>StandardErrorPath</key>
-  <string>{xml_escape(str(supervisor_log_path(runtime_dir)))}</string>
+  <string>{xml_escape(str(supervisor_log_path(config_home)))}</string>
 </dict>
 </plist>
 """
@@ -457,7 +699,9 @@ def service_plan(home: str, runtime_dir: str, log_level: str) -> ServicePlan:
             f"run: launchctl bootout gui/$(id -u) {shlex_quote(str(path))}; then remove {path}",
         )
     if system == "Linux":
-        path = Path.home() / ".config" / "systemd" / "user" / "kungfu-master.service"
+        path = (
+            Path.home() / ".config" / "systemd" / "user" / "kungfu-supervisor.service"
+        )
         content = f"""[Unit]
 Description={SERVICE_NAME}
 After=default.target
@@ -465,6 +709,7 @@ After=default.target
 [Service]
 Type=simple
 {_systemd_env_line("KF_HOME", home)}
+{_systemd_env_line("KF_CONFIG_HOME", config_home)}
 {_systemd_env_line("KF_RUNTIME_DIR", runtime_dir)}
 {_systemd_env_line("KF_LOG_LEVEL", log_level)}
 ExecStart={_shell_join(command)}
@@ -478,8 +723,8 @@ WantedBy=default.target
             system,
             path,
             content,
-            "write the unit; then run: systemctl --user daemon-reload && systemctl --user enable --now kungfu-master.service",
-            "run: systemctl --user disable --now kungfu-master.service; then remove the unit",
+            "write the unit; then run: systemctl --user daemon-reload && systemctl --user enable --now kungfu-supervisor.service",
+            "run: systemctl --user disable --now kungfu-supervisor.service; then remove the unit",
         )
     startup = (
         Path(os.environ.get("APPDATA", str(Path.home())))
@@ -488,11 +733,12 @@ WantedBy=default.target
         / "Start Menu"
         / "Programs"
         / "Startup"
-        / "kungfu-master.cmd"
+        / "kungfu-supervisor.cmd"
     )
     lines = [
         "@echo off",
         f'set "KF_HOME={env["KF_HOME"]}"',
+        f'set "KF_CONFIG_HOME={env["KF_CONFIG_HOME"]}"',
         f'set "KF_RUNTIME_DIR={env["KF_RUNTIME_DIR"]}"',
         f'set "KF_LOG_LEVEL={env["KF_LOG_LEVEL"]}"',
         _shell_join(command),
@@ -507,8 +753,13 @@ WantedBy=default.target
     )
 
 
-def install_service(home: str, runtime_dir: str, log_level: str) -> dict[str, Any]:
-    plan = service_plan(home, runtime_dir, log_level)
+def install_service(
+    home: str,
+    runtime_dir: str,
+    log_level: str,
+    config_home: str | None = None,
+) -> dict[str, Any]:
+    plan = service_plan(home, runtime_dir, log_level, config_home)
     plan.path.parent.mkdir(parents=True, exist_ok=True)
     plan.path.write_text(plan.content, "utf-8")
     return {
@@ -519,8 +770,13 @@ def install_service(home: str, runtime_dir: str, log_level: str) -> dict[str, An
     }
 
 
-def uninstall_service(home: str, runtime_dir: str, log_level: str) -> dict[str, Any]:
-    plan = service_plan(home, runtime_dir, log_level)
+def uninstall_service(
+    home: str,
+    runtime_dir: str,
+    log_level: str,
+    config_home: str | None = None,
+) -> dict[str, Any]:
+    plan = service_plan(home, runtime_dir, log_level, config_home)
     existed = plan.path.exists()
     if existed:
         plan.path.unlink()
@@ -532,8 +788,16 @@ def uninstall_service(home: str, runtime_dir: str, log_level: str) -> dict[str, 
     }
 
 
-def service_status(home: str, runtime_dir: str, log_level: str) -> dict[str, Any]:
-    plan = service_plan(home, runtime_dir, log_level)
+def service_status(
+    home: str,
+    runtime_dir: str,
+    log_level: str,
+    config_home: str | None = None,
+) -> dict[str, Any]:
+    config_home = resolve_config_home(config_home)
+    home = resolve_runtime_home(home)
+    runtime_dir = resolve_runtime_dir(home, runtime_dir)
+    plan = service_plan(home, runtime_dir, log_level, config_home)
     installed = plan.path.exists()
     actual = ""
     if installed:
@@ -543,6 +807,7 @@ def service_status(home: str, runtime_dir: str, log_level: str) -> dict[str, Any
             actual = ""
     return {
         "schema": SCHEMA_STATUS,
+        "configHome": config_home,
         "home": home,
         "runtimeDir": runtime_dir,
         "service": {
@@ -552,5 +817,5 @@ def service_status(home: str, runtime_dir: str, log_level: str) -> dict[str, Any
             "installed": installed,
             "matchesPlan": installed and actual == plan.content,
         },
-        "supervisor": status(home, runtime_dir),
+        "supervisor": route_status(home, runtime_dir, config_home),
     }

--- a/framework/core/tests/python/test_master_service.py
+++ b/framework/core/tests/python/test_master_service.py
@@ -42,41 +42,91 @@ from kungfu import master_service  # noqa: E402
 
 
 def test_master_status_reports_runtime_state(tmp_path):
+    config_home = tmp_path / "config"
+    home = tmp_path / "home"
     runtime_dir = tmp_path / "runtime"
 
-    payload = master_service.status(str(tmp_path / "home"), str(runtime_dir))
+    payload = master_service.route_status(
+        str(home),
+        str(runtime_dir),
+        str(config_home),
+    )
 
     assert payload["schema"] == "kungfu.master-service.status/v1"
     assert payload["status"] == "stopped"
-    assert payload["runtimeDir"] == str(runtime_dir)
+    assert payload["configHome"] == str(config_home.resolve())
+    assert payload["dataRoot"] == str(home.resolve())
+    assert payload["runtimeDir"] == str(runtime_dir.resolve())
+    assert payload["supervisorStateDir"] == str(
+        config_home.resolve() / "runtime" / "supervisor"
+    )
+    assert payload["stateDir"] == str(runtime_dir.resolve() / "master")
     assert payload["supervisor"]["running"] is False
     assert payload["master"]["running"] is False
+    assert payload["route"]["registered"] is False
 
 
 def test_master_status_detects_live_recorded_pid(tmp_path):
+    config_home = tmp_path / "config"
     runtime_dir = tmp_path / "runtime"
-    service_dir = master_service.state_dir(str(runtime_dir))
-    service_dir.mkdir(parents=True)
+    master_service.supervisor_state_dir(str(config_home)).mkdir(parents=True)
+    master_service.state_dir(str(runtime_dir)).mkdir(parents=True)
     master_service.write_pid(
-        master_service.supervisor_pid_path(str(runtime_dir)), os.getpid()
+        master_service.supervisor_pid_path(str(config_home)), os.getpid()
+    )
+    master_service.write_pid(
+        master_service.master_pid_path(str(runtime_dir)), os.getpid()
     )
 
-    payload = master_service.status(str(tmp_path / "home"), str(runtime_dir))
+    payload = master_service.route_status(
+        str(tmp_path / "home"),
+        str(runtime_dir),
+        str(config_home),
+    )
 
     assert payload["status"] == "running"
     assert payload["supervisor"]["pid"] == os.getpid()
     assert payload["supervisor"]["running"] is True
+    assert payload["master"]["pid"] == os.getpid()
+    assert payload["master"]["running"] is True
+
+
+def test_upsert_route_registers_data_root_under_user_supervisor(tmp_path):
+    config_home = tmp_path / "config"
+    home = tmp_path / "workspace" / ".kungfu"
+    runtime_dir = home / "runtime"
+
+    route = master_service.upsert_route(
+        str(config_home),
+        str(home),
+        str(runtime_dir),
+    )
+    routes = master_service.read_routes(str(config_home))
+    payload = master_service.route_status(
+        str(home),
+        str(runtime_dir),
+        str(config_home),
+    )
+
+    assert routes["schema"] == "kungfu.master-service.routes/v1"
+    assert route["routeId"] in routes["routes"]
+    assert routes["routes"][route["routeId"]]["dataRoot"] == str(home.resolve())
+    assert payload["route"]["registered"] is True
+    assert payload["routes"]["count"] == 1
 
 
 def test_service_plan_is_dry_run_material(tmp_path):
+    config_home = tmp_path / "config"
     plan = master_service.service_plan(
         str(tmp_path / "home"),
         str(tmp_path / "runtime"),
         "warning",
+        str(config_home),
     ).as_dict()
 
     assert plan["schema"] == "kungfu.master-service.plan/v1"
-    assert "master" in plan["content"]
+    assert "supervisor" in plan["content"]
+    assert "KF_CONFIG_HOME" in plan["content"]
     assert "supervise" in plan["content"]
     assert plan["path"]
     assert plan["installNote"]

--- a/product/scripts/product.mjs
+++ b/product/scripts/product.mjs
@@ -95,7 +95,9 @@ function defaultInstanceRoot(env = process.env) {
 }
 
 function defaultConfigHome() {
-  return path.resolve(expandHomePath(path.join(os.homedir(), '.kungfu')));
+  return path.resolve(
+    expandHomePath(path.join(os.homedir(), '.kungfu-config')),
+  );
 }
 
 function instanceConfigPath(instanceHome) {


### PR DESCRIPTION
## Summary
- add `kungfu master ensure` to register the current data root and start/reuse the per-user supervisor
- move supervisor runtime state to `KF_CONFIG_HOME/runtime/supervisor` and workspace master state to `<data-root>/runtime/master`
- teach the supervisor loop to poll a route registry and manage per-data-root master children
- align config defaults with `~/.kungfu-config` and refresh KFD-1 canonical policy

## Validation
- PYTHONPATH=framework/core/src/python python3 direct harness for `framework/core/tests/python/test_master_service.py`
- python3 -m py_compile framework/core/src/python/kungfu/master_service.py framework/core/src/python/kungfu/cli/commands/master.py framework/core/src/python/kungfu/cli/commands/__init__.py framework/core/tests/python/test_master_service.py
- git diff --check
- ./kungfu-code check

## Notes
- V1 uses a file-backed supervisor route registry. It intentionally does not make closed-data storage operations depend on a live master.