### PR TITLE
feat(master): add supervisor route lifecycle leases

### DIFF
--- a/docs/master-service.md
+++ b/docs/master-service.md
@@ -100,6 +100,28 @@ The `status --json` command reads process-control state and verifies whether
 the recorded PIDs are still alive. Runtime-state files are not durable facts and
 must not be treated as the source of truth.
 
+The route registry also carries a narrow v1 lifecycle lease for each workspace
+master route:
+
+- `leaseTtlSeconds` is the freshness window for the route heartbeat.
+- `leaseUpdatedAt` is refreshed when a route is registered or re-registered.
+- `heartbeatAt`, `supervisorPid`, and `masterPid` are refreshed by the live
+  supervisor loop while it actively owns that route.
+- `status --json` reports `lifecycle.state`, `lifecycle.healthy`,
+  `lifecycle.warnings`, `route.freshness`, `route.stale`, and
+  `routes.staleCount`.
+
+The lifecycle state is deterministic from the route lease and pid probes:
+
+- `running`: supervisor and workspace master are both live and the route is
+  fresh.
+- `degraded`: the supervisor is live but the workspace master is not yet live.
+- `stale-route`: the route heartbeat is older than its lease TTL.
+- `orphan-master`: the workspace master is live without a live supervisor.
+- `dead`: at least one recorded pid file points to a dead process.
+- `registered`: the route is registered but not currently live.
+- `stopped`: no live supervisor or master is recorded.
+
 ## Service Plans
 
 `kungfu master service plan --json` prints the platform-specific file that
@@ -122,6 +144,11 @@ intentionally left as an explicit user operation after the file is installed.
   running, active workspace masters may remain alive.
 - `kungfu master ensure` registers the current data root in the supervisor
   route registry and starts or reuses the corresponding workspace master.
+- Before starting or reusing a master, `kungfu master ensure` performs a narrow
+  repair pass: dead pid files are removed, stale routes are refreshed, and an
+  orphan workspace master is terminated before the supervisor is started so the
+  supervisor does not duplicate it. The JSON result includes a `repairs` array
+  when this pass changed or attempted to repair local process-control state.
 - `kungfu master stop` stops the per-user supervisor and its supervised
   workspace masters.
 - `kungfu master service uninstall --execute` removes the user service file; it
@@ -157,4 +184,6 @@ The shell bottom status bar and the System Status view read the same
 `kungfu master status --json` payload through the Electron main process. They
 surface supervisor liveness, workspace master liveness, config home, data root,
 runtime directory, and route registration without introducing a second process
-control path.
+control path. Lifecycle health comes from the core status payload, not from GUI
+pid or route reimplementation, so stale and degraded states stay consistent
+between CLI, tray, status bar, and the System Status view.

--- a/extensions/system/status/src/view/index.tsx
+++ b/extensions/system/status/src/view/index.tsx
@@ -33,10 +33,20 @@ function SystemStatusView({
         configHome?: string;
         dataRoot?: string;
         runtimeDir?: string;
+        lifecycle?: {
+          state?: string;
+          healthy?: boolean;
+          warnings?: string[];
+        };
         supervisor?: { running?: boolean; pid?: number | null };
         master?: { running?: boolean; pid?: number | null };
-        route?: { routeId?: string; registered?: boolean };
-        routes?: { count?: number };
+        route?: {
+          routeId?: string;
+          registered?: boolean;
+          stale?: boolean;
+          freshness?: { ageSeconds?: number | null; ttlSeconds?: number };
+        };
+        routes?: { count?: number; staleCount?: number };
       }
     | null
     | undefined;
@@ -61,6 +71,22 @@ function SystemStatusView({
             </span>
           </div>
           <div>service status: {masterPayload?.status ?? 'unknown'}</div>
+          <div>
+            lifecycle:{' '}
+            <span
+              style={{
+                color: masterPayload?.lifecycle?.healthy
+                  ? '#4ec9b0'
+                  : '#dcdcaa',
+              }}
+            >
+              {masterPayload?.lifecycle?.state ?? 'unknown'}
+            </span>
+          </div>
+          <div>
+            lifecycle warnings:{' '}
+            {masterPayload?.lifecycle?.warnings?.join(', ') || '-'}
+          </div>
           <div>core: {String(info.buildInfo?.version ?? 'unknown')}</div>
           <div>kungfu: {info.kungfuVersion || 'unavailable'}</div>
           <div>
@@ -74,8 +100,18 @@ function SystemStatusView({
           <div>
             route: {masterPayload?.route?.routeId ?? 'unknown'} ·{' '}
             {masterPayload?.route?.registered ? 'registered' : 'not registered'}
+            {masterPayload?.route?.stale ? ' · stale' : ''}
           </div>
-          <div>routes: {String(masterPayload?.routes?.count ?? 'unknown')}</div>
+          <div>
+            route lease age:{' '}
+            {masterPayload?.route?.freshness?.ageSeconds == null
+              ? 'unknown'
+              : `${masterPayload.route.freshness.ageSeconds.toFixed(1)}s`}
+          </div>
+          <div>
+            routes: {String(masterPayload?.routes?.count ?? 'unknown')} · stale:{' '}
+            {String(masterPayload?.routes?.staleCount ?? 0)}
+          </div>
           <div style={{ color: info.ok ? '#4ec9b0' : '#f48771' }}>
             binding: {info.message}
           </div>

--- a/framework/core/src/python/kungfu/cli/commands/master.py
+++ b/framework/core/src/python/kungfu/cli/commands/master.py
@@ -19,6 +19,7 @@ def _json(payload):
 
 def _plain_status(payload):
     click.echo(f"status: {payload['status']}")
+    click.echo(f"lifecycle: {payload.get('lifecycle', {}).get('state', '-')}")
     click.echo(f"config: {payload['configHome']}")
     click.echo(f"data root: {payload['dataRoot']}")
     click.echo(f"runtime: {payload['runtimeDir']}")
@@ -33,6 +34,9 @@ def _plain_status(payload):
             f"{payload['master']['pid'] or '-'} "
             f"({'running' if payload['master']['running'] else 'stopped'})"
         )
+    warnings = payload.get("lifecycle", {}).get("warnings") or []
+    if warnings:
+        click.echo(f"warnings: {', '.join(warnings)}")
 
 
 @kfc.group(

--- a/framework/core/src/python/kungfu/master_service.py
+++ b/framework/core/src/python/kungfu/master_service.py
@@ -27,6 +27,7 @@ SCHEMA_RESULT = "kungfu.master-service.result/v1"
 SCHEMA_ROUTES = "kungfu.master-service.routes/v1"
 SERVICE_ID = "tech.kungfu.supervisor"
 SERVICE_NAME = "Kungfu Supervisor"
+ROUTE_LEASE_TTL_SECONDS = 30.0
 
 
 def _now() -> float:
@@ -57,6 +58,12 @@ def _is_pid_running(pid: int | None) -> bool:
         return True
     except OSError:
         return False
+
+
+def _pid_state(pid: int | None) -> str:
+    if not pid or pid <= 0:
+        return "missing"
+    return "running" if _is_pid_running(pid) else "dead"
 
 
 def _signal_pid(pid: int, sig: int) -> None:
@@ -122,13 +129,20 @@ def route_id(home: str, runtime_dir: str) -> str:
 def route_record(home: str, runtime_dir: str) -> dict[str, Any]:
     home = resolve_runtime_home(home)
     runtime_dir = resolve_runtime_dir(home, runtime_dir)
+    now = _now()
     return {
         "routeId": route_id(home, runtime_dir),
         "dataRoot": home,
         "home": home,
         "runtimeDir": runtime_dir,
         "desired": True,
-        "updatedAt": _now(),
+        "leaseTtlSeconds": ROUTE_LEASE_TTL_SECONDS,
+        "leaseUpdatedAt": now,
+        "heartbeatAt": None,
+        "supervisorPid": None,
+        "masterPid": None,
+        "createdAt": now,
+        "updatedAt": now,
     }
 
 
@@ -273,9 +287,153 @@ def upsert_route(
 ) -> dict[str, Any]:
     route = route_record(home, runtime_dir)
     payload = read_routes(config_home)
+    previous = payload["routes"].get(route["routeId"])
+    if isinstance(previous, dict):
+        route["createdAt"] = previous.get("createdAt", route["createdAt"])
     payload["routes"][route["routeId"]] = route
     write_routes(config_home, payload)
     return route
+
+
+def touch_route_heartbeat(
+    config_home: str | None,
+    route_id_: str,
+    *,
+    supervisor_pid: int | None,
+    master_pid: int | None,
+) -> dict[str, Any] | None:
+    payload = read_routes(config_home)
+    route = payload["routes"].get(route_id_)
+    if not isinstance(route, dict):
+        return None
+    now = _now()
+    route["heartbeatAt"] = now
+    route["leaseTtlSeconds"] = route.get("leaseTtlSeconds", ROUTE_LEASE_TTL_SECONDS)
+    route["supervisorPid"] = supervisor_pid
+    route["masterPid"] = master_pid
+    route["updatedAt"] = now
+    payload["routes"][route_id_] = route
+    write_routes(config_home, payload)
+    return route
+
+
+def _route_freshness(
+    route: dict[str, Any] | None,
+    *,
+    registered: bool,
+    now: float,
+) -> dict[str, Any]:
+    if not registered or not isinstance(route, dict):
+        return {
+            "state": "unregistered",
+            "stale": False,
+            "ageSeconds": None,
+            "expiresAt": None,
+            "ttlSeconds": ROUTE_LEASE_TTL_SECONDS,
+        }
+    ttl = float(route.get("leaseTtlSeconds") or ROUTE_LEASE_TTL_SECONDS)
+    heartbeat = route.get("heartbeatAt")
+    lease_updated = route.get("leaseUpdatedAt")
+    anchor = heartbeat if isinstance(heartbeat, (int, float)) else lease_updated
+    if not isinstance(anchor, (int, float)):
+        return {
+            "state": "pending",
+            "stale": False,
+            "ageSeconds": None,
+            "expiresAt": None,
+            "ttlSeconds": ttl,
+        }
+    age = max(0.0, now - float(anchor))
+    stale = age > ttl
+    return {
+        "state": "stale" if stale else "fresh",
+        "stale": stale,
+        "ageSeconds": age,
+        "expiresAt": float(anchor) + ttl,
+        "ttlSeconds": ttl,
+    }
+
+
+def _lifecycle_status(
+    *,
+    registered: bool,
+    route_freshness: dict[str, Any],
+    supervisor_pid: int | None,
+    supervisor_running: bool,
+    master_pid: int | None,
+    master_running: bool,
+) -> dict[str, Any]:
+    warnings: list[str] = []
+    supervisor_state = _pid_state(supervisor_pid)
+    master_state = _pid_state(master_pid)
+    route_stale = bool(route_freshness.get("stale"))
+    if route_stale:
+        warnings.append("route-stale")
+    if supervisor_state == "dead":
+        warnings.append("supervisor-dead-pid")
+    if master_state == "dead":
+        warnings.append("master-dead-pid")
+
+    state = "stopped"
+    if route_stale:
+        state = "stale-route"
+    elif master_running and not supervisor_running:
+        state = "orphan-master"
+        warnings.append("orphan-master")
+    elif supervisor_running and master_running:
+        state = "running"
+    elif supervisor_running and not master_running:
+        state = "degraded"
+        warnings.append("master-not-running")
+    elif supervisor_state == "dead" or master_state == "dead":
+        state = "dead"
+    elif registered:
+        state = "registered"
+
+    healthy = state == "running"
+    return {
+        "state": state,
+        "healthy": healthy,
+        "warnings": warnings,
+        "supervisorProcess": supervisor_state,
+        "masterProcess": master_state,
+        "routeFreshness": route_freshness,
+    }
+
+
+def _terminate_and_wait(pid: int, timeout: float = 2.0) -> bool:
+    _terminate_pid(pid)
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if not _is_pid_running(pid):
+            return True
+        time.sleep(0.1)
+    return not _is_pid_running(pid)
+
+
+def repair_route_state(
+    home: str,
+    runtime_dir: str,
+    config_home: str | None = None,
+) -> list[str]:
+    current = route_status(home, runtime_dir, config_home)
+    repairs: list[str] = []
+    master_pid = current["master"]["pid"]
+    if current["lifecycle"]["supervisorProcess"] == "dead":
+        unlink_if_exists(supervisor_pid_path(config_home))
+        repairs.append("removed-dead-supervisor-pid")
+    if current["lifecycle"]["masterProcess"] == "dead":
+        unlink_if_exists(master_pid_path(runtime_dir))
+        repairs.append("removed-dead-master-pid")
+    if current["lifecycle"]["state"] == "orphan-master" and master_pid:
+        if _terminate_and_wait(master_pid):
+            unlink_if_exists(master_pid_path(runtime_dir))
+            repairs.append("terminated-orphan-master")
+        else:
+            repairs.append("orphan-master-still-running")
+    if current["route"].get("freshness", {}).get("stale"):
+        repairs.append("refreshed-stale-route")
+    return repairs
 
 
 class Master(yjj.master):
@@ -345,16 +503,28 @@ def route_status(
     state = _json_read(state_path(runtime_dir))
     supervisor_state = _json_read(supervisor_state_path(config_home))
     routes = read_routes(config_home)
+    registered_route = routes["routes"].get(route["routeId"])
+    registered = isinstance(registered_route, dict)
     supervisor_running = _is_pid_running(supervisor_pid)
     master_running = _is_pid_running(master_pid)
-    status_name = "running" if supervisor_running else "stopped"
-    if master_running and not supervisor_running:
-        status_name = "orphan-master"
-    elif supervisor_running and not master_running:
-        status_name = "supervisor-running"
+    now = _now()
+    route_freshness = _route_freshness(
+        registered_route if registered else None,
+        registered=registered,
+        now=now,
+    )
+    lifecycle = _lifecycle_status(
+        registered=registered,
+        route_freshness=route_freshness,
+        supervisor_pid=supervisor_pid,
+        supervisor_running=supervisor_running,
+        master_pid=master_pid,
+        master_running=master_running,
+    )
+    route_payload = registered_route if registered else route
     return {
         "schema": SCHEMA_STATUS,
-        "status": status_name,
+        "status": lifecycle["state"],
         "configHome": config_home,
         "dataRoot": home,
         "home": home,
@@ -362,24 +532,38 @@ def route_status(
         "supervisorStateDir": str(supervisor_state_dir(config_home)),
         "stateDir": str(state_dir(runtime_dir)),
         "route": {
-            **route,
-            "registered": route["routeId"] in routes["routes"],
+            **route_payload,
+            "registered": registered,
+            "freshness": route_freshness,
+            "stale": route_freshness["stale"],
         },
+        "lifecycle": lifecycle,
         "supervisor": {
             "pid": supervisor_pid,
             "running": supervisor_running,
+            "processState": lifecycle["supervisorProcess"],
             "pidFile": str(supervisor_pid_path(config_home)),
             "log": str(supervisor_log_path(config_home)),
         },
         "master": {
             "pid": master_pid,
             "running": master_running,
+            "processState": lifecycle["masterProcess"],
             "pidFile": str(master_pid_path(runtime_dir)),
             "log": str(master_log_path(runtime_dir)),
         },
         "routes": {
             "path": str(routes_path(config_home)),
             "count": len(routes["routes"]),
+            "staleCount": sum(
+                1
+                for item in routes["routes"].values()
+                if _route_freshness(
+                    item if isinstance(item, dict) else None,
+                    registered=isinstance(item, dict),
+                    now=now,
+                )["stale"]
+            ),
         },
         "lastSupervisorState": supervisor_state,
         "lastState": state,
@@ -433,6 +617,12 @@ def run_supervisor(
             for route_id_, route in desired_routes.items():
                 child = children.get(route_id_)
                 if child and child.poll() is None:
+                    touch_route_heartbeat(
+                        config_home,
+                        route_id_,
+                        supervisor_pid=os.getpid(),
+                        master_pid=child.pid,
+                    )
                     continue
                 route_home = str(route["home"])
                 route_runtime_dir = str(route["runtimeDir"])
@@ -454,6 +644,12 @@ def run_supervisor(
                     )
                 children[route_id_] = child
                 write_pid(master_pid_path(route_runtime_dir), child.pid)
+                touch_route_heartbeat(
+                    config_home,
+                    route_id_,
+                    supervisor_pid=os.getpid(),
+                    master_pid=child.pid,
+                )
             _json_write(
                 supervisor_state_path(config_home),
                 {
@@ -510,11 +706,12 @@ def ensure_master(
     config_home = resolve_config_home(config_home)
     home = resolve_runtime_home(home)
     runtime_dir = resolve_runtime_dir(home, runtime_dir)
+    repairs = repair_route_state(home, runtime_dir, config_home)
     route = upsert_route(config_home, home, runtime_dir)
     current = route_status(home, runtime_dir, config_home)
     if current["supervisor"]["running"]:
         return _wait_for_master(
-            home, runtime_dir, config_home, changed=False, route=route
+            home, runtime_dir, config_home, changed=False, route=route, repairs=repairs
         )
     supervisor_state_dir(config_home).mkdir(parents=True, exist_ok=True)
     command = supervisor_command(
@@ -546,6 +743,7 @@ def ensure_master(
         changed=True,
         command=command,
         route=route,
+        repairs=repairs,
     )
 
 
@@ -556,13 +754,20 @@ def _wait_for_master(
     *,
     changed: bool,
     route: dict[str, Any],
+    repairs: list[str] | None = None,
     command: list[str] | None = None,
 ) -> dict[str, Any]:
     deadline = time.time() + 5
     while time.time() < deadline:
         current = route_status(home, runtime_dir, config_home)
         if current["supervisor"]["running"] and current["master"]["running"]:
-            payload = {**current, "changed": changed, "route": route}
+            payload = {
+                **current,
+                "changed": changed,
+                "route": {**route, **current.get("route", {})},
+            }
+            if repairs is not None:
+                payload["repairs"] = repairs
             if command:
                 payload["command"] = command
             return payload
@@ -570,8 +775,10 @@ def _wait_for_master(
     payload = {
         **route_status(home, runtime_dir, config_home),
         "changed": changed,
-        "route": route,
     }
+    payload["route"] = {**route, **payload.get("route", {})}
+    if repairs is not None:
+        payload["repairs"] = repairs
     if command:
         payload["command"] = command
     return payload

--- a/framework/core/tests/python/test_master_service.py
+++ b/framework/core/tests/python/test_master_service.py
@@ -64,6 +64,8 @@ def test_master_status_reports_runtime_state(tmp_path):
     assert payload["supervisor"]["running"] is False
     assert payload["master"]["running"] is False
     assert payload["route"]["registered"] is False
+    assert payload["lifecycle"]["state"] == "stopped"
+    assert payload["lifecycle"]["healthy"] is False
 
 
 def test_master_status_detects_live_recorded_pid(tmp_path):
@@ -89,6 +91,8 @@ def test_master_status_detects_live_recorded_pid(tmp_path):
     assert payload["supervisor"]["running"] is True
     assert payload["master"]["pid"] == os.getpid()
     assert payload["master"]["running"] is True
+    assert payload["lifecycle"]["state"] == "running"
+    assert payload["lifecycle"]["healthy"] is True
 
 
 def test_upsert_route_registers_data_root_under_user_supervisor(tmp_path):
@@ -112,7 +116,130 @@ def test_upsert_route_registers_data_root_under_user_supervisor(tmp_path):
     assert route["routeId"] in routes["routes"]
     assert routes["routes"][route["routeId"]]["dataRoot"] == str(home.resolve())
     assert payload["route"]["registered"] is True
+    assert payload["route"]["freshness"]["state"] == "fresh"
     assert payload["routes"]["count"] == 1
+
+
+def test_master_status_detects_stale_route_lease(tmp_path, monkeypatch):
+    config_home = tmp_path / "config"
+    home = tmp_path / "workspace" / ".kungfu"
+    runtime_dir = home / "runtime"
+
+    monkeypatch.setattr(master_service, "_now", lambda: 1000.0)
+    master_service.upsert_route(str(config_home), str(home), str(runtime_dir))
+    monkeypatch.setattr(master_service, "_now", lambda: 1035.0)
+
+    payload = master_service.route_status(
+        str(home),
+        str(runtime_dir),
+        str(config_home),
+    )
+
+    assert payload["status"] == "stale-route"
+    assert payload["route"]["stale"] is True
+    assert payload["route"]["freshness"]["ageSeconds"] == 35.0
+    assert payload["routes"]["staleCount"] == 1
+    assert "route-stale" in payload["lifecycle"]["warnings"]
+
+
+def test_repair_route_state_removes_dead_pid_files(tmp_path, monkeypatch):
+    config_home = tmp_path / "config"
+    home = tmp_path / "workspace" / ".kungfu"
+    runtime_dir = home / "runtime"
+    master_service.supervisor_state_dir(str(config_home)).mkdir(parents=True)
+    master_service.state_dir(str(runtime_dir)).mkdir(parents=True)
+    master_service.write_pid(master_service.supervisor_pid_path(str(config_home)), 123)
+    master_service.write_pid(master_service.master_pid_path(str(runtime_dir)), 456)
+    monkeypatch.setattr(master_service, "_is_pid_running", lambda pid: False)
+
+    repairs = master_service.repair_route_state(
+        str(home),
+        str(runtime_dir),
+        str(config_home),
+    )
+
+    assert repairs == ["removed-dead-supervisor-pid", "removed-dead-master-pid"]
+    assert (
+        master_service.read_pid(master_service.supervisor_pid_path(str(config_home)))
+        is None
+    )
+    assert (
+        master_service.read_pid(master_service.master_pid_path(str(runtime_dir)))
+        is None
+    )
+
+
+def test_ensure_master_reports_repairs(tmp_path, monkeypatch):
+    config_home = tmp_path / "config"
+    home = tmp_path / "workspace" / ".kungfu"
+    runtime_dir = home / "runtime"
+    master_service.state_dir(str(runtime_dir)).mkdir(parents=True)
+    master_service.write_pid(master_service.master_pid_path(str(runtime_dir)), 456)
+    monkeypatch.setattr(master_service, "_is_pid_running", lambda pid: False)
+
+    class _FakeProcess:
+        pid = 789
+
+    monkeypatch.setattr(
+        master_service.subprocess, "Popen", lambda *a, **k: _FakeProcess()
+    )
+
+    def _fake_wait(
+        home, runtime_dir, config_home, *, changed, route, repairs, command=None
+    ):
+        return {
+            "schema": master_service.SCHEMA_STATUS,
+            "changed": changed,
+            "route": route,
+            "repairs": repairs,
+            "command": command,
+        }
+
+    monkeypatch.setattr(master_service, "_wait_for_master", _fake_wait)
+
+    payload = master_service.ensure_master(
+        str(home),
+        str(runtime_dir),
+        "warning",
+        str(config_home),
+    )
+
+    assert payload["changed"] is True
+    assert payload["repairs"] == ["removed-dead-master-pid"]
+
+
+def test_wait_for_master_preserves_enriched_route_status(tmp_path, monkeypatch):
+    route = master_service.route_record(
+        str(tmp_path / "home"),
+        str(tmp_path / "runtime"),
+    )
+
+    def _fake_status(home, runtime_dir, config_home):
+        return {
+            "schema": master_service.SCHEMA_STATUS,
+            "status": "running",
+            "supervisor": {"running": True},
+            "master": {"running": True},
+            "route": {
+                **route,
+                "registered": True,
+                "freshness": {"state": "fresh", "stale": False},
+                "stale": False,
+            },
+        }
+
+    monkeypatch.setattr(master_service, "route_status", _fake_status)
+
+    payload = master_service._wait_for_master(
+        str(tmp_path / "home"),
+        str(tmp_path / "runtime"),
+        str(tmp_path / "config"),
+        changed=False,
+        route=route,
+    )
+
+    assert payload["route"]["registered"] is True
+    assert payload["route"]["freshness"]["state"] == "fresh"
 
 
 def test_service_plan_is_dry_run_material(tmp_path):

--- a/framework/gui/src/main/index.ts
+++ b/framework/gui/src/main/index.ts
@@ -283,10 +283,15 @@ type MasterStatusPayload = {
   configHome?: string;
   dataRoot?: string;
   runtimeDir?: string;
+  lifecycle?: {
+    state?: string;
+    healthy?: boolean;
+    warnings?: string[];
+  };
   supervisor?: { pid?: number | null; running?: boolean };
   master?: { pid?: number | null; running?: boolean };
-  route?: { routeId?: string; registered?: boolean };
-  routes?: { count?: number };
+  route?: { routeId?: string; registered?: boolean; stale?: boolean };
+  routes?: { count?: number; staleCount?: number };
 };
 
 type MasterStatusResult = {
@@ -347,6 +352,11 @@ function ensureMasterForGuiStartup() {
 
 function masterStatusLabel(result = lastMasterStatus ?? readMasterStatus()) {
   if (!result.ok || !result.payload) return 'Master: unavailable';
+  const lifecycle = result.payload.lifecycle?.state || result.payload.status;
+  if (lifecycle === 'stale-route') return 'Master: stale route';
+  if (lifecycle === 'degraded') return 'Master: degraded';
+  if (lifecycle === 'dead') return 'Master: dead pid';
+  if (lifecycle === 'orphan-master') return 'Master: orphan';
   const supervisor = result.payload.supervisor?.running;
   const master = result.payload.master?.running;
   if (supervisor && master) return 'Master: running';
@@ -451,7 +461,9 @@ function buildTrayMenu() {
   const payload = status.payload;
   const statusDetail =
     status.ok && payload
-      ? `Data root: ${payload.dataRoot || '-'}`
+      ? `Lifecycle: ${payload.lifecycle?.state || payload.status || '-'} · Data root: ${
+          payload.dataRoot || '-'
+        }`
       : status.error || 'Status unavailable';
   tray.setContextMenu(
     Menu.buildFromTemplate([

--- a/framework/gui/src/renderer/src/main.tsx
+++ b/framework/gui/src/renderer/src/main.tsx
@@ -209,10 +209,15 @@ type MasterStatusPayload = {
   configHome?: string;
   dataRoot?: string;
   runtimeDir?: string;
+  lifecycle?: {
+    state?: string;
+    healthy?: boolean;
+    warnings?: string[];
+  };
   supervisor?: { pid?: number | null; running?: boolean };
   master?: { pid?: number | null; running?: boolean };
-  route?: { routeId?: string; registered?: boolean };
-  routes?: { count?: number };
+  route?: { routeId?: string; registered?: boolean; stale?: boolean };
+  routes?: { count?: number; staleCount?: number };
 };
 
 type MasterStatusResult = {
@@ -225,6 +230,11 @@ type MasterStatusResult = {
 function masterStatusText(status: MasterStatusResult | null): string {
   if (!status) return 'master checking';
   if (!status.ok || !status.payload) return 'master unavailable';
+  const lifecycle = status.payload.lifecycle?.state || status.payload.status;
+  if (lifecycle === 'stale-route') return 'master stale route';
+  if (lifecycle === 'degraded') return 'master degraded';
+  if (lifecycle === 'dead') return 'master dead pid';
+  if (lifecycle === 'orphan-master') return 'master orphan';
   const supervisor = status.payload.supervisor?.running;
   const master = status.payload.master?.running;
   if (supervisor && master) return 'master live';
@@ -236,6 +246,9 @@ function masterStatusText(status: MasterStatusResult | null): string {
 function supervisorStatusText(status: MasterStatusResult | null): string {
   if (!status) return 'supervisor checking';
   if (!status.ok || !status.payload) return 'supervisor unavailable';
+  const lifecycle = status.payload.lifecycle?.state || status.payload.status;
+  if (lifecycle === 'dead') return 'supervisor dead pid';
+  if (lifecycle === 'stale-route') return 'supervisor stale route';
   return status.payload.supervisor?.running
     ? 'supervisor live'
     : 'supervisor stopped';
@@ -248,12 +261,15 @@ function statusTooltip(status: MasterStatusResult | null): string {
   const payload = status.payload;
   return [
     `Status: ${payload.status || '-'}`,
+    `Lifecycle: ${payload.lifecycle?.state || '-'}`,
+    `Warnings: ${payload.lifecycle?.warnings?.join(', ') || '-'}`,
     `Config: ${payload.configHome || '-'}`,
     `Data root: ${payload.dataRoot || '-'}`,
     `Runtime: ${payload.runtimeDir || '-'}`,
     `Route: ${payload.route?.routeId || '-'}${
       payload.route?.registered ? ' registered' : ' not registered'
-    }`,
+    }${payload.route?.stale ? ' stale' : ''}`,
+    `Stale routes: ${String(payload.routes?.staleCount ?? 0)}`,
   ].join('\n');
 }
 
@@ -994,9 +1010,17 @@ function App() {
   const masterRunning =
     masterStatus?.payload?.master?.running === true ||
     (!masterStatus?.ok && masterLive);
-  const masterSeverity: StatusBarSeverity = masterRunning
+  const lifecycleState =
+    masterStatus?.payload?.lifecycle?.state || masterStatus?.payload?.status;
+  const lifecycleHealthy = masterStatus?.payload?.lifecycle?.healthy === true;
+  const lifecycleDegraded =
+    lifecycleState === 'stale-route' ||
+    lifecycleState === 'degraded' ||
+    lifecycleState === 'dead' ||
+    lifecycleState === 'orphan-master';
+  const masterSeverity: StatusBarSeverity = lifecycleHealthy
     ? 'ok'
-    : supervisorRunning
+    : lifecycleDegraded || supervisorRunning
       ? 'warning'
       : 'error';
   const systemStatusItems: StatusBarItem[] = [
@@ -1004,7 +1028,12 @@ function App() {
       id: 'system.supervisor',
       text: supervisorStatusText(masterStatus),
       icon: supervisorRunning ? '●' : '○',
-      severity: supervisorRunning ? 'ok' : 'warning',
+      severity:
+        lifecycleState === 'dead'
+          ? 'error'
+          : supervisorRunning
+            ? 'ok'
+            : 'warning',
       side: 'left',
       priority: -110,
       tooltip: statusTooltip(masterStatus),


### PR DESCRIPTION
Adds supervisor route heartbeat leases, deterministic lifecycle health states, ensure-time repair for unsafe route state, and GUI status/tray lifecycle surfacing.\n\nValidation:\n- ./kungfu-code check\n- pnpm --filter @kungfu-tech/gui run build\n- ./kungfu-code build\n- built CLI master status/ensure/status/stop smoke with temporary KF_HOME/KF_CONFIG_HOME