### PR TITLE
feat(storage): fsck distinguishes redacted/absent from missing payloads

### DIFF
--- a/framework/core/src/libkungfu/src/runtime/storage/service.cpp
+++ b/framework/core/src/libkungfu/src/runtime/storage/service.cpp
@@ -29,6 +29,9 @@ namespace yy_storage = kungfu::yijinjing::storage;
 namespace {
 
 inline constexpr const char *PAYLOAD_STATE_PRESENT = "present";
+inline constexpr const char *PAYLOAD_STATE_REDACTED = "redacted";
+inline constexpr const char *PAYLOAD_STATE_ABSENT = "absent";
+inline constexpr const char *PAYLOAD_STATE_MISSING = "missing";
 inline constexpr const char *CONTENT_TYPE_JSON = "application/json";
 inline constexpr const char *SOURCE_REGISTRY_SCHEMA = "kungfu.storage.source-registry/v1";
 inline constexpr const char *PROJECTION_SOURCE_REGISTRY = "source-registry";
@@ -1437,6 +1440,12 @@ nlohmann::json fsck_impl(const storage_service_options &options) {
            {"orphan_payloads", 0},
        }},
   };
+  // Degraded means facts are incomplete but not corrupt: a payload is recorded
+  // missing (data loss), as opposed to intentionally redacted/absent. Corruption
+  // and drift set ok=false (failed); degradation keeps ok=true but is surfaced
+  // through the tri-state `status` field so a missing payload no longer hides
+  // under ok=true.
+  bool degraded = false;
   if (!options.source_id.empty() && sources.empty()) {
     report["ok"] = false;
     report["errors"].push_back({{"code", "source_missing"}, {"source_id", options.source_id}});
@@ -1489,11 +1498,20 @@ nlohmann::json fsck_impl(const storage_service_options &options) {
     }
     for (const auto &entry : entries_for_manifest(manifest)) {
       report["checked"]["payloads"] = report["checked"]["payloads"].get<size_t>() + 1;
-      if (text_or(entry, "payload_state") != PAYLOAD_STATE_PRESENT) {
+      const auto payload_state = text_or(entry, "payload_state");
+      if (payload_state != PAYLOAD_STATE_PRESENT) {
+        // Redacted/absent are intentional (a sensitive body deliberately withheld
+        // or known not to exist) and stay ok; any other non-present state, such as
+        // a recorded-missing body, is a real gap and degrades the verdict.
+        const bool intentional = payload_state == PAYLOAD_STATE_REDACTED || payload_state == PAYLOAD_STATE_ABSENT;
+        if (!intentional) {
+          degraded = true;
+        }
         report["warnings"].push_back({{"code", "payload_not_present"},
                                       {"source_id", current_source_id},
                                       {"subject", text_or(entry, "kind") + ":" + text_or(entry, "source_id")},
-                                      {"state", text_or(entry, "payload_state")}});
+                                      {"state", payload_state},
+                                      {"intentional", intentional}});
         continue;
       }
       const auto [_, error] = load_payload_impl(*provider, entry);
@@ -1560,6 +1578,9 @@ nlohmann::json fsck_impl(const storage_service_options &options) {
            {"actual", counts}});
     }
   }
+  // Tri-state verdict over the boolean ok: failed (corruption/drift/unreadable)
+  // dominates, then degraded (incomplete but not corrupt), else ok.
+  report["status"] = !report["ok"].get<bool>() ? "failed" : (degraded ? "degraded" : "ok");
   return report;
 }
 

--- a/framework/core/src/python/kungfu/storage/service.py
+++ b/framework/core/src/python/kungfu/storage/service.py
@@ -603,7 +603,9 @@ def write_synthetic_source(
                 "content_type": CONTENT_TYPE_JSON,
                 "payload_hash": digest,
                 "byte_len": len(raw),
-                "payload_state": PAYLOAD_STATE_PRESENT,
+                "payload_state": str(
+                    record.get("payload_state") or PAYLOAD_STATE_PRESENT
+                ),
             }
         )
     manifest = build_import_manifest(

--- a/framework/core/tests/python/test_atlas_storage.py
+++ b/framework/core/tests/python/test_atlas_storage.py
@@ -881,3 +881,71 @@ def test_atlas_import_persists_generic_source_manifest(tmp_path):
     source_fsck = source_store.fsck_source(runtime_dir, "atlas-local")
     assert source_fsck["ok"]
     assert source_fsck["storage"]["ok"]
+
+
+def test_storage_fsck_reports_degraded_status_for_recorded_payload_states(tmp_path):
+    runtime_dir = tmp_path / "runtime"
+    storage_service.write_synthetic_source(
+        runtime_dir,
+        source_id="degraded-synth",
+        manifest_id="imp-degraded",
+        source_head="head-1",
+        records=[
+            {
+                "kind": "note",
+                "source_id": "note-present",
+                "source_path": "notes/p.json",
+                "source_time": "2026-07-07T00:00:00Z",
+                "payload": {"body": "present"},
+            },
+            {
+                "kind": "note",
+                "source_id": "note-missing",
+                "source_path": "notes/m.json",
+                "source_time": "2026-07-08T00:00:00Z",
+                "payload": {"body": "lost"},
+                "payload_state": "missing",
+            },
+            {
+                "kind": "note",
+                "source_id": "note-redacted",
+                "source_path": "notes/r.json",
+                "source_time": "2026-07-09T00:00:00Z",
+                "payload": {"body": "sensitive"},
+                "payload_state": "redacted",
+            },
+        ],
+    )
+
+    report = storage_service.fsck(runtime_dir, source_id="degraded-synth")
+    # A recorded-missing payload is incomplete, not corrupt: ok stays true, but the
+    # tri-state verdict degrades so the loss is not hidden under ok=true. A redacted
+    # body is an intentional withholding and does not degrade the verdict.
+    assert report["ok"]
+    assert report["status"] == "degraded"
+    withheld = {
+        warning["subject"]: (warning["state"], warning["intentional"])
+        for warning in report["warnings"]
+        if warning["code"] == "payload_not_present"
+    }
+    assert withheld["note:note-missing"] == ("missing", False)
+    assert withheld["note:note-redacted"] == ("redacted", True)
+
+    # A fully present source verifies as ok with an ok verdict.
+    healthy_dir = tmp_path / "healthy"
+    storage_service.write_synthetic_source(
+        healthy_dir,
+        source_id="healthy-synth",
+        records=[
+            {
+                "kind": "note",
+                "source_id": "note-a",
+                "source_path": "notes/a.json",
+                "source_time": "2026-07-09T00:00:00Z",
+                "payload": {"body": "a"},
+            }
+        ],
+    )
+    healthy = storage_service.fsck(healthy_dir, source_id="healthy-synth")
+    assert healthy["ok"]
+    assert healthy["status"] == "ok"


### PR DESCRIPTION
Merge feature/storage-fsck-payload-status into dev/v4/v4.0 (kungfu-systems zone dual-account PR flow).