### PR TITLE
fix(product): rename CLI archive for Kungfu Episodes

### DIFF
--- a/product/scripts/dist.mjs
+++ b/product/scripts/dist.mjs
@@ -34,6 +34,7 @@ const CLI_DIST_DIR = path.join(DIST_DIR, 'cli');
 const RELEASE_DIR = path.join(PRODUCT_DIR, 'release');
 const DESKTOP_RELEASE_DIR = path.join(RELEASE_DIR, 'desktop');
 const CLI_RELEASE_DIR = path.join(RELEASE_DIR, 'cli');
+const CLI_ARCHIVE_PREFIX = 'kungfu-episodes-cli';
 const isWin = process.platform === 'win32';
 const require = createRequire(import.meta.url);
 const buildchainLogger = createBuildchainLogger({
@@ -693,6 +694,10 @@ function writeCliManifest(stageRoot, archiveName) {
   );
 }
 
+export function cliArchiveBase(platform) {
+  return `${CLI_ARCHIVE_PREFIX}-${platform}`;
+}
+
 function assertFile(file, label) {
   if (!fs.existsSync(file) || !fs.statSync(file).isFile()) {
     throw new Error(`${label} not found: ${file}`);
@@ -895,7 +900,7 @@ function buildCliProduct() {
     },
     () => {
       const platform = platformId();
-      const archiveBase = `kungfu-cli-${platform}`;
+      const archiveBase = cliArchiveBase(platform);
       const archiveName = isWin
         ? `${archiveBase}.zip`
         : `${archiveBase}.tar.gz`;
@@ -1072,12 +1077,14 @@ function verifyObservability() {
   );
 }
 
-try {
-  main();
-  verifyObservability();
-} catch (error) {
-  console.error(
-    `[product] failed: ${error instanceof Error ? error.message : String(error)}`,
-  );
-  process.exit(1);
+if (process.argv[1] && path.resolve(process.argv[1]) === __filename) {
+  try {
+    main();
+    verifyObservability();
+  } catch (error) {
+    console.error(
+      `[product] failed: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    process.exit(1);
+  }
 }

--- a/product/scripts/dist.test.mjs
+++ b/product/scripts/dist.test.mjs
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { cliArchiveBase } from './dist.mjs';
+
+test('CLI product archive name uses the Kungfu Episodes product prefix', () => {
+  assert.equal(
+    cliArchiveBase('darwin-arm64'),
+    'kungfu-episodes-cli-darwin-arm64',
+  );
+  assert.equal(cliArchiveBase('linux-x64'), 'kungfu-episodes-cli-linux-x64');
+  assert.equal(cliArchiveBase('win32-x64'), 'kungfu-episodes-cli-win32-x64');
+});


### PR DESCRIPTION
## Summary
- rename the CLI product archive/staging basename to `kungfu-episodes-cli-<platform>`
- add a focused product dist test for the CLI archive basename

## Validation
- `./kungfu-code sync`
- `node --test product/scripts/dist.test.mjs`
- `./kungfu-code check:types`
- `./kungfu-code check`
- `./kungfu-code kfd:buildchain:check`
- `./kungfu-code product cli dist --dry-run`
- `git diff --check`
- `node --check product/scripts/dist.mjs && node --check product/scripts/dist.test.mjs`