### PR TITLE
feat(storage): make episodes first-class storage slices

### DIFF
--- a/docs/episode-object-model.md
+++ b/docs/episode-object-model.md
@@ -304,7 +304,10 @@ for the Episode object.
 Episode is now an accepted architecture direction with a v1 manifest journal.
 Existing source/range storage commands still operate on sources, manifests,
 scopes, and ranges. Episode operations exist as the first C++ storage-service
-surface and can be called through Python/Node bindings and the CLI. The next
+surface and can be called through Python/Node bindings and the CLI. Episode is
+also addressable through the generic storage service as `scope=episode` for
+fsck/export and through storage query tables such as `episodes`,
+`episode_frames`, `episode_refs`, and `episode_records`. The next
 implementation work is to make the action recorder automatically open/current/
 seal Episodes and move writer/provider surfaces toward Episode-aware
-allocation and fsck.
+allocation.

--- a/docs/runtime-storage-service.md
+++ b/docs/runtime-storage-service.md
@@ -468,6 +468,12 @@ kungfu storage compact --scope all --dry-run --json
 kungfu storage verify-sync --source <source-id> --json
 kungfu storage query --table entries --scope source --source <source-id> \
   --kind goal --since 20d --json
+kungfu storage query --table episodes --scope episode --json
+kungfu storage query --table episode_frames --scope episode \
+  --episode-id <episode-id> --json
+kungfu storage fsck --scope episode --episode-id <episode-id> --json
+kungfu storage export --scope episode --episode-id <episode-id> \
+  --format bundle-json --out episode.kfbundle.json --json
 ```
 
 `kungfu source add/list/sync/fsck` uses the same source registry path. Atlas
@@ -481,6 +487,26 @@ construction, accepted ranges, payload inventory, source-scoped fsck,
 range-limited export, bundle creation, and bundle import. It deliberately does
 not implement remote channel transport, conflict policy, destructive GC,
 compaction, repair, or a SQLite/RocksDB provider.
+
+### Episode-Owned Storage Slice V1
+
+Episode-owned storage v1 makes the yijinjing Episode manifest journal a normal
+selector in the runtime storage service:
+
+- `storage fsck --scope episode --episode-id <id>` verifies one Episode through
+  the same `libkungfu` service surface as source/all fsck.
+- `storage query --table episodes|episode_records|episode_frames|episode_refs`
+  reads the yijinjing-backed Episode manifest journal through the service
+  rather than treating SQLite as authority.
+- `storage export --scope episode --episode-id <id> --format bundle-json`
+  emits `kungfu.storage.episode-bundle/v1`, a folded export/debug bundle with
+  the Episode manifest summary, manifest records, frame attachments, refs, and
+  declared Episode dependencies.
+
+This slice still does not move event mmap pages into Episode-owned physical
+directories. Frame membership is authoritative through
+`EpisodeFrameAttached` records in the manifest journal. The physical allocation
+domain can change later without changing the product-facing Episode selector.
 
 ### Maintenance And Sync-Readiness Slice
 

--- a/framework/core/docs/adr/ADR-0033-episode-causal-segment-object.md
+++ b/framework/core/docs/adr/ADR-0033-episode-causal-segment-object.md
@@ -129,7 +129,10 @@ This ADR started as a design commitment and now has a v1 implementation slice:
   core surface;
 - Python, Node, and CLI surfaces call the C++ service instead of owning
   separate Episode logic;
-- `storage fsck` includes basic Episode manifest consistency checks.
+- `storage fsck` includes basic Episode manifest consistency checks;
+- `storage fsck --scope episode`, `storage query --table episodes` and
+  `storage export --scope episode` make Episode an addressable storage-service
+  selector without requiring the physical mmap layout to move first.
 
 No full physical journal re-layout is claimed by this ADR. V1 associates
 current frames to Episodes through append-only `EpisodeFrameAttached` manifest

--- a/framework/core/docs/adr/ADR-0034-yijinjing-episode-manifest-journal.md
+++ b/framework/core/docs/adr/ADR-0034-yijinjing-episode-manifest-journal.md
@@ -140,8 +140,18 @@ episode_list
 episode_inspect
 ```
 
-Python, Node, and CLI use this C++ service path. They may render JSON folded
-views, but they do not own the manifest authority.
+Python, Node, and CLI use this C++ service path. The generic storage service
+also accepts Episode as a first-class selector for fsck, query, and
+bundle export:
+
+```text
+storage fsck --scope episode
+storage query --table episodes|episode_records|episode_frames|episode_refs
+storage export --scope episode --format bundle-json
+```
+
+These commands render folded JSON views, but they do not own the manifest
+authority.
 
 V1 intentionally associates frames to Episodes by appending
 `EpisodeFrameAttached` records. It does not add fields to `frame_header` or

--- a/framework/core/src/libkungfu/include/kungfu/runtime/storage/service.h
+++ b/framework/core/src/libkungfu/include/kungfu/runtime/storage/service.h
@@ -48,6 +48,7 @@ struct storage_service_options {
   nlohmann::json operation_options = nlohmann::json::object();
   std::string query = {};
   std::string kind = {};
+  uint64_t episode_id = 0;
   uint64_t limit = 100;
 };
 

--- a/framework/core/src/libkungfu/src/runtime/storage/service.cpp
+++ b/framework/core/src/libkungfu/src/runtime/storage/service.cpp
@@ -1227,6 +1227,62 @@ nlohmann::json sqlite_projection_json(const std::string &runtime_dir, const std:
 
 nlohmann::json query_sqlite_projection(const storage_service_options &options) {
   const auto query = options.query.empty() ? std::string("entries") : options.query;
+  if (query == "episodes" || query == "episode_records" || query == "episode_frames" || query == "episode_refs") {
+    nlohmann::json rows = nlohmann::json::array();
+    if (query == "episodes") {
+      if (options.episode_id == 0) {
+        rows = episode_store(options).list(0, options.limit).value("episodes", nlohmann::json::array());
+      } else {
+        const auto inspected = episode_store(options).inspect(options.episode_id);
+        if (inspected.value("ok", false)) {
+          rows.push_back(inspected.at("episode"));
+        }
+      }
+    } else {
+      if (options.episode_id == 0) {
+        throw std::invalid_argument("episode_id is required for " + query);
+      }
+      const auto inspected = episode_store(options).inspect(options.episode_id);
+      if (!inspected.value("ok", false)) {
+        return {{"ok", false},
+                {"scope", "episode"},
+                {"episode_id", options.episode_id},
+                {"projection",
+                 {{"name", "episode-manifest"},
+                  {"schema", yy_storage::EPISODE_MANIFEST_SCHEMA_V1},
+                  {"authority", "yijinjing-journal"},
+                  {"rebuildable", false}}},
+                {"query", query},
+                {"limit", options.limit},
+                {"rows", nlohmann::json::array()},
+                {"row_count", 0},
+                {"errors", inspected.value("errors", nlohmann::json::array())}};
+      }
+      const auto field = query == "episode_records"
+                             ? std::string("records")
+                             : (query == "episode_frames" ? std::string("frames") : std::string("refs"));
+      rows = inspected.value(field, nlohmann::json::array());
+      if (options.limit != 0 && rows.is_array() && rows.size() > options.limit) {
+        nlohmann::json limited = nlohmann::json::array();
+        for (size_t index = 0; index < std::min<size_t>(rows.size(), options.limit); ++index) {
+          limited.push_back(rows.at(index));
+        }
+        rows = limited;
+      }
+    }
+    return {{"ok", true},
+            {"scope", "episode"},
+            {"episode_id", options.episode_id == 0 ? nlohmann::json(nullptr) : nlohmann::json(options.episode_id)},
+            {"projection",
+             {{"name", "episode-manifest"},
+              {"schema", yy_storage::EPISODE_MANIFEST_SCHEMA_V1},
+              {"authority", "yijinjing-journal"},
+              {"rebuildable", false}}},
+            {"query", query},
+            {"limit", options.limit},
+            {"rows", rows},
+            {"row_count", rows.size()}};
+  }
   const auto path = sqlite_projection_path(options.runtime_dir);
   nlohmann::json result = {
       {"ok", true},
@@ -1262,6 +1318,70 @@ nlohmann::json query_sqlite_projection(const storage_service_options &options) {
   }
   result["row_count"] = result.at("rows").size();
   return result;
+}
+
+nlohmann::json episode_fsck_impl(const storage_service_options &options) {
+  const auto episode_report = episode_store(options).fsck(options.episode_id);
+  const auto checked = object_or_empty(episode_report, "checked");
+  nlohmann::json report = {
+      {"ok", episode_report.value("ok", false)},
+      {"status", episode_report.value("ok", false) ? "ok" : "failed"},
+      {"scope", "episode"},
+      {"episode_id", options.episode_id == 0 ? nlohmann::json(nullptr) : nlohmann::json(options.episode_id)},
+      {"errors", episode_report.value("errors", nlohmann::json::array())},
+      {"warnings", episode_report.value("warnings", nlohmann::json::array())},
+      {"checked",
+       {{"sources", 0},
+        {"manifests", 0},
+        {"payloads", 0},
+        {"schemas", 0},
+        {"accepted_ranges", 0},
+        {"source_records", 0},
+        {"projection_indexes", 1},
+        {"sqlite_projection_rows", 0},
+        {"orphan_payloads", 0},
+        {"episode_manifest_records", checked.value("episode_manifest_records", 0)},
+        {"episodes", checked.value("episodes", 0)}}},
+      {"episode_manifest", episode_report},
+      {"projections", nlohmann::json::array({{{"name", "episode-manifest"},
+                                              {"schema", yy_storage::EPISODE_MANIFEST_SCHEMA_V1},
+                                              {"authority", "yijinjing-journal"},
+                                              {"path", "journal/system/storage/episode-manifest/live/*.journal"},
+                                              {"rebuildable", false}}})}};
+  return report;
+}
+
+nlohmann::json episode_export_bundle_impl(const storage_service_options &options) {
+  if (options.episode_id == 0) {
+    throw std::invalid_argument("episode_id is required for episode export");
+  }
+  const auto inspected = episode_store(options).inspect(options.episode_id);
+  if (!inspected.value("ok", false)) {
+    throw std::runtime_error("episode not found: " + std::to_string(options.episode_id));
+  }
+  const auto episode = object_or_empty(inspected, "episode");
+  const auto records = inspected.value("records", nlohmann::json::array());
+  const auto frames = inspected.value("frames", nlohmann::json::array());
+  const auto refs = inspected.value("refs", nlohmann::json::array());
+  nlohmann::json dependencies = nlohmann::json::array();
+  for (const auto &ref : refs) {
+    if (text_or(ref, "ref_kind") == "episode") {
+      dependencies.push_back(ref);
+    }
+  }
+  return {{"schema", "kungfu.storage.episode-bundle/v1"},
+          {"bundle_id", "episode:" + std::to_string(options.episode_id)},
+          {"scope", "episode"},
+          {"episode_id", options.episode_id},
+          {"authority", "yijinjing-journal"},
+          {"manifest", episode},
+          {"records", records},
+          {"frames", frames},
+          {"refs", refs},
+          {"dependencies", dependencies},
+          {"record_count", records.size()},
+          {"frame_count", frames.size()},
+          {"ref_count", refs.size()}};
 }
 
 nlohmann::json replace_string_subtree(nlohmann::json value, const std::string &needle, const std::string &replacement) {
@@ -1537,6 +1657,9 @@ nlohmann::json fsck_error_report(const storage_service_options &options, const s
 }
 
 nlohmann::json fsck_impl(const storage_service_options &options) {
+  if (options.scope == "episode") {
+    return episode_fsck_impl(options);
+  }
   const auto provider = make_provider(options);
   nlohmann::json registry;
   try {
@@ -1909,6 +2032,9 @@ public:
   }
 
   [[nodiscard]] nlohmann::json export_bundle(const storage_service_options &options) const override {
+    if (options.scope == "episode") {
+      return episode_export_bundle_impl(options);
+    }
     const auto provider = make_provider(options);
     const auto manifest = load_latest_manifest_impl(*provider, options.source_id);
     if (manifest.is_null()) {
@@ -2255,6 +2381,7 @@ storage_service_options parse_storage_service_options(const std::string &runtime
   parsed.operation_options = options;
   parsed.query = text_or(options, "query", "entries");
   parsed.kind = text_or(options, "kind");
+  parsed.episode_id = uint64_or(options, "episode_id");
   parsed.limit = uint64_or(options, "limit", 100);
   return parsed;
 }
@@ -2268,6 +2395,9 @@ nlohmann::json make_storage_service_request(const std::string &operation, const 
     request["query"] = parsed_options.query;
     request["kind"] = parsed_options.kind.empty() ? nlohmann::json(nullptr) : nlohmann::json(parsed_options.kind);
     request["limit"] = parsed_options.limit;
+  }
+  if (parsed_options.episode_id != 0) {
+    request["episode_id"] = parsed_options.episode_id;
   }
   if (parsed_operation == storage_operation::EpisodeList) {
     request["location_uid"] = uint64_or(options, "location_uid");
@@ -2425,6 +2555,8 @@ nlohmann::json storage_service_capabilities() {
              {"schema", yy_storage::EPISODE_MANIFEST_SCHEMA_V1},
              {"authority", "yijinjing-journal"},
              {"path", "journal/system/storage/episode-manifest/live/*.journal"},
+             {"query_tables", nlohmann::json::array({"episodes", "episode_records", "episode_frames", "episode_refs"})},
+             {"export_schema", "kungfu.storage.episode-bundle/v1"},
              {"rebuildable", false}}})},
       {"notes",
        nlohmann::json::array({

--- a/framework/core/src/libyijinjing/include/kungfu/yijinjing/storage/episode_manifest.h
+++ b/framework/core/src/libyijinjing/include/kungfu/yijinjing/storage/episode_manifest.h
@@ -14,7 +14,7 @@
 namespace kungfu::yijinjing::storage {
 
 inline constexpr const char *EPISODE_MANIFEST_SCHEMA_V1 = "kungfu.episode.manifest/v1";
-inline constexpr const char *EPISODE_MANIFEST_GROUP = "storage";
+inline constexpr const char *EPISODE_MANIFEST_NAMESPACE = "storage";
 inline constexpr const char *EPISODE_MANIFEST_NAME = "episode-manifest";
 
 struct episode_begin_options {

--- a/framework/core/src/libyijinjing/src/storage/episode_manifest.cpp
+++ b/framework/core/src/libyijinjing/src/storage/episode_manifest.cpp
@@ -66,7 +66,7 @@ const char *ref_kind_name(EpisodeRefKind kind) {
 
 location_ptr manifest_location(const std::string &runtime_dir) {
   auto locator = std::make_shared<kungfu::yijinjing::data::locator>(runtime_dir, mode::LIVE);
-  return location::make_shared(mode::LIVE, location_role::SYSTEM, EPISODE_MANIFEST_GROUP, EPISODE_MANIFEST_NAME,
+  return location::make_shared(mode::LIVE, location_role::SYSTEM, EPISODE_MANIFEST_NAMESPACE, EPISODE_MANIFEST_NAME,
                                locator);
 }
 

--- a/framework/core/src/python/kungfu/cli/commands/storage.py
+++ b/framework/core/src/python/kungfu/cli/commands/storage.py
@@ -73,11 +73,14 @@ def status(ctx, scope, storage_source_id, as_json):
 
 
 @storage.command(help="verify runtime storage integrity for a scope")
-@click.option("--scope", type=click.Choice(["atlas", "source", "all"]), required=True)
+@click.option(
+    "--scope", type=click.Choice(["atlas", "source", "episode", "all"]), required=True
+)
 @click.option("--source", "storage_source_id", type=str, default=None)
+@click.option("--episode-id", type=int, default=0)
 @click.option("--json", "as_json", is_flag=True, help="machine-readable output")
 @storage_command_context
-def fsck(ctx, scope, storage_source_id, as_json):
+def fsck(ctx, scope, storage_source_id, episode_id, as_json):
     if scope == "atlas":
         from kungfu.atlas import store
 
@@ -85,9 +88,15 @@ def fsck(ctx, scope, storage_source_id, as_json):
     else:
         from kungfu.storage import service
 
+        if scope == "episode" and not episode_id:
+            click.echo(
+                "[storage] --episode-id is required for --scope episode", err=True
+            )
+            sys.exit(2)
         result = service.fsck(
             ctx.runtime_dir,
             source_id=storage_source_id if scope == "source" else None,
+            episode_id=episode_id if scope == "episode" else None,
         )
     if as_json:
         _echo_json(result)
@@ -102,8 +111,11 @@ def fsck(ctx, scope, storage_source_id, as_json):
 
 
 @storage.command(help="export a storage scope")
-@click.option("--scope", type=click.Choice(["atlas", "source"]), required=True)
+@click.option(
+    "--scope", type=click.Choice(["atlas", "source", "episode"]), required=True
+)
 @click.option("--source", "storage_source_id", type=str, default=None)
+@click.option("--episode-id", type=int, default=0)
 @click.option("--since", type=str, default=None, help="relative window such as 3d/12h")
 @click.option(
     "--from", "from_time", type=str, default=None, help="inclusive start time"
@@ -123,6 +135,7 @@ def export(
     ctx,
     scope,
     storage_source_id,
+    episode_id,
     since,
     from_time,
     until,
@@ -132,6 +145,11 @@ def export(
 ):
     if scope == "atlas" and format_ != "jsonl":
         click.echo("[storage] --scope atlas supports only --format jsonl", err=True)
+        sys.exit(1)
+    if scope == "episode" and format_ != "bundle-json":
+        click.echo(
+            "[storage] --scope episode supports only --format bundle-json", err=True
+        )
         sys.exit(1)
     try:
         if scope == "atlas":
@@ -146,8 +164,21 @@ def export(
         else:
             from kungfu.storage import service
 
-            _require_source(storage_source_id)
-            if format_ == "bundle-json":
+            if scope == "episode":
+                if not episode_id:
+                    click.echo(
+                        "[storage] --episode-id is required for --scope episode",
+                        err=True,
+                    )
+                    sys.exit(2)
+                result = service.export_bundle_json(
+                    ctx.runtime_dir,
+                    out_path,
+                    episode_id=episode_id,
+                    range_filter=_range_filter(since, from_time, until),
+                )
+            elif format_ == "bundle-json":
+                _require_source(storage_source_id)
                 result = service.export_bundle_json(
                     ctx.runtime_dir,
                     out_path,
@@ -155,6 +186,7 @@ def export(
                     range_filter=_range_filter(since, from_time, until),
                 )
             else:
+                _require_source(storage_source_id)
                 result = service.export_jsonl(
                     ctx.runtime_dir,
                     out_path,
@@ -246,12 +278,23 @@ def rebuild_index(ctx, scope, storage_source_id, dry_run, as_json):
 @click.option(
     "--table",
     "query_table",
-    type=click.Choice(["sources", "manifests", "entries"]),
+    type=click.Choice(
+        [
+            "sources",
+            "manifests",
+            "entries",
+            "episodes",
+            "episode_records",
+            "episode_frames",
+            "episode_refs",
+        ]
+    ),
     default="entries",
     show_default=True,
 )
-@click.option("--scope", type=click.Choice(["source", "all"]), default="all")
+@click.option("--scope", type=click.Choice(["source", "episode", "all"]), default="all")
 @click.option("--source", "storage_source_id", type=str, default=None)
+@click.option("--episode-id", type=int, default=0)
 @click.option("--kind", type=str, default=None, help="filter entry rows by kind")
 @click.option("--since", type=str, default=None, help="relative window such as 3d/12h")
 @click.option(
@@ -266,6 +309,7 @@ def query(
     query_table,
     scope,
     storage_source_id,
+    episode_id,
     kind,
     since,
     from_time,
@@ -277,10 +321,17 @@ def query(
 
     if scope == "source":
         _require_source(storage_source_id)
+    if scope == "episode" and query_table != "episodes" and not episode_id:
+        click.echo(
+            f"[storage] --episode-id is required for --table {query_table}",
+            err=True,
+        )
+        sys.exit(2)
     result = service.query_projection(
         ctx.runtime_dir,
         query=query_table,
         source_id=storage_source_id if scope == "source" else None,
+        episode_id=episode_id if scope == "episode" else None,
         kind=kind,
         range_filter=_range_filter(since, from_time, until),
         limit=limit,

--- a/framework/core/src/python/kungfu/storage/service.py
+++ b/framework/core/src/python/kungfu/storage/service.py
@@ -346,14 +346,17 @@ def fsck(
     runtime_dir: str | Path,
     *,
     source_id: str | None = None,
+    episode_id: int | None = None,
 ) -> dict[str, Any]:
+    scope = "episode" if episode_id else ("source" if source_id else "all")
     return dict(
         _runtime().run_storage_service_operation(
             "fsck",
             str(runtime_dir),
             {
-                "scope": "source" if source_id else "all",
+                "scope": scope,
                 "source_id": source_id,
+                "episode_id": episode_id or 0,
             },
         )
     )
@@ -440,17 +443,20 @@ def query_projection(
     *,
     query: str = "entries",
     source_id: str | None = None,
+    episode_id: int | None = None,
     kind: str | None = None,
     range_filter: dict[str, Any] | None = None,
     limit: int = 100,
 ) -> dict[str, Any]:
+    scope = "episode" if episode_id else ("source" if source_id else "all")
     return dict(
         _runtime().run_storage_service_operation(
             "query",
             str(runtime_dir),
             {
-                "scope": "source" if source_id else "all",
+                "scope": scope,
                 "source_id": source_id,
+                "episode_id": episode_id or 0,
                 "query": query,
                 "kind": kind,
                 "range": range_filter or {},
@@ -720,17 +726,23 @@ def export_bundle_json(
     runtime_dir: str | Path,
     out_path: str | Path,
     *,
-    source_id: str,
+    source_id: str | None = None,
+    episode_id: int | None = None,
     range_filter: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     bundle = build_export_bundle(
-        runtime_dir, source_id=source_id, range_filter=range_filter
+        runtime_dir,
+        source_id=source_id,
+        episode_id=episode_id,
+        range_filter=range_filter,
     )
     _write_json(Path(out_path), bundle)
+    scope = "episode" if episode_id else "source"
     return {
         "ok": True,
-        "scope": "source",
+        "scope": scope,
         "source_id": source_id,
+        "episode_id": episode_id,
         "range": range_filter,
         "sync_root": bundle.get("manifest", {}).get("sync_root"),
         "format": "bundle-json",
@@ -742,16 +754,19 @@ def export_bundle_json(
 def build_export_bundle(
     runtime_dir: str | Path,
     *,
-    source_id: str,
+    source_id: str | None = None,
+    episode_id: int | None = None,
     range_filter: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
+    scope = "episode" if episode_id else "source"
     return dict(
         _runtime().run_storage_service_operation(
             "export_bundle",
             str(runtime_dir),
             {
-                "scope": "source",
+                "scope": scope,
                 "source_id": source_id,
+                "episode_id": episode_id or 0,
                 "range": range_filter or {},
             },
         )

--- a/framework/core/tests/python/test_atlas_storage.py
+++ b/framework/core/tests/python/test_atlas_storage.py
@@ -509,6 +509,39 @@ def test_episode_manifest_v1_is_yijinjing_backed_and_fscked(tmp_path):
     assert fsck["checked"]["episodes"] == 1
     assert fsck["episode_manifest"]["authority"] == "yijinjing-journal"
 
+    episode_fsck = storage_service.fsck(runtime_dir, episode_id=42)
+    assert episode_fsck["ok"]
+    assert episode_fsck["scope"] == "episode"
+    assert episode_fsck["episode_id"] == 42
+    assert episode_fsck["checked"]["episodes"] == 1
+
+    episode_rows = storage_service.query_projection(
+        runtime_dir,
+        query="episodes",
+        episode_id=42,
+    )
+    assert episode_rows["ok"]
+    assert episode_rows["projection"]["authority"] == "yijinjing-journal"
+    assert episode_rows["row_count"] == 1
+    assert episode_rows["rows"][0]["episode_id"] == 42
+
+    frame_rows = storage_service.query_projection(
+        runtime_dir,
+        query="episode_frames",
+        episode_id=42,
+    )
+    assert frame_rows["ok"]
+    assert frame_rows["row_count"] == 1
+    assert frame_rows["rows"][0]["frame_uid"] == 100
+
+    bundle = storage_service.build_export_bundle(runtime_dir, episode_id=42)
+    assert bundle["schema"] == "kungfu.storage.episode-bundle/v1"
+    assert bundle["scope"] == "episode"
+    assert bundle["episode_id"] == 42
+    assert bundle["manifest"]["episode_id"] == 42
+    assert bundle["record_count"] == 3
+    assert bundle["frame_count"] == 1
+
 
 def test_payload_fsck_verifies_versioned_frame_checksums(tmp_path):
     repo = tmp_path / "atlas"


### PR DESCRIPTION
Implements Episode-owned storage slice v1: generic storage scope=episode fsck/query/export surfaces backed by yijinjing Episode manifests, plus CLI/Python wiring, docs, and storage tests.