### PR TITLE
fix(storage): preserve Atlas range export context

### DIFF
--- a/docs/runtime-storage-service.md
+++ b/docs/runtime-storage-service.md
@@ -392,6 +392,16 @@ kungfu storage export --scope atlas --format jsonl --out atlas.jsonl --json
 kungfu atlas verify --repo <atlas-repo> --json
 ```
 
+Range-limited Atlas imports preserve the control-plane context needed to make
+the selected records meaningful. For example, if a goal updated inside
+`--from` references a mission whose own card was last updated before that
+window, the import includes that mission as context. `storage export --scope
+atlas` applies the same closure rule: a range export keeps those context
+records instead of re-filtering them away. To export the exact latest imported
+batch, omit range flags; to export a subrange from the latest import, pass
+`--since` / `--from` / `--until` and expect a JSONL stream containing the
+selected records plus required context records.
+
 Acceptance covered by that slice:
 
 - large Atlas JSON bodies are stored outside mmap frames as hash-addressed

--- a/framework/core/src/python/kungfu/atlas/payloads.py
+++ b/framework/core/src/python/kungfu/atlas/payloads.py
@@ -78,6 +78,22 @@ def _source_payload(record: dict[str, Any]) -> dict[str, Any]:
     return payload if isinstance(payload, dict) else {}
 
 
+def _source_refs(record: dict[str, Any]) -> list[dict[str, str]]:
+    payload = _source_payload(record)
+    refs: list[dict[str, str]] = []
+    if record.get("kind") == "goal":
+        mission_id = str(payload.get("mission_id") or "").strip()
+        if mission_id:
+            refs.append(
+                {
+                    "kind": "mission",
+                    "source_id": mission_id,
+                    "role": "context",
+                }
+            )
+    return refs
+
+
 def enrich_source_records(source_records: list[dict[str, Any]]) -> list[dict[str, Any]]:
     enriched = []
     for record in source_records:
@@ -95,6 +111,9 @@ def enrich_source_records(source_records: list[dict[str, Any]]) -> list[dict[str
             "payload_state": PAYLOAD_STATE_PRESENT,
             "payload": _source_payload(record),
         }
+        refs = _source_refs(record)
+        if refs:
+            row["source_refs"] = refs
         enriched.append(row)
     return enriched
 
@@ -187,6 +206,60 @@ def _matches_range(entry: dict[str, Any], range_filter: dict[str, Any] | None) -
     return bool(_runtime().filter_storage_manifest_entries([entry], range_filter))
 
 
+def _context_keys_from_entry(
+    store_dir: str | Path,
+    entry: dict[str, Any],
+) -> set[tuple[str, str]]:
+    keys: set[tuple[str, str]] = set()
+    refs = entry.get("source_refs")
+    if isinstance(refs, list):
+        for ref in refs:
+            if not isinstance(ref, dict):
+                continue
+            kind = str(ref.get("kind") or "").strip()
+            source_id = str(ref.get("source_id") or "").strip()
+            if kind and source_id:
+                keys.add((kind, source_id))
+    if keys or entry.get("kind") != "goal":
+        return keys
+
+    payload, error = _load_payload(store_dir, entry)
+    if error or payload is None:
+        return keys
+    mission_id = str(payload.get("mission_id") or "").strip()
+    if mission_id:
+        keys.add(("mission", mission_id))
+    return keys
+
+
+def _entries_for_range(
+    store_dir: str | Path,
+    entries: list[Any],
+    range_filter: dict[str, Any] | None,
+) -> list[dict[str, Any]]:
+    manifest_entries = [entry for entry in entries if isinstance(entry, dict)]
+    if not range_filter:
+        return manifest_entries
+
+    selected = [
+        entry for entry in manifest_entries if _matches_range(entry, range_filter)
+    ]
+    selected_keys = {_entry_key(entry) for entry in selected}
+    context_keys: set[tuple[str, str]] = set()
+    for entry in selected:
+        context_keys.update(_context_keys_from_entry(store_dir, entry))
+
+    expanded = list(selected)
+    for entry in manifest_entries:
+        key = _entry_key(entry)
+        if key in selected_keys:
+            continue
+        if key in context_keys:
+            expanded.append(entry)
+            selected_keys.add(key)
+    return sorted(expanded, key=_manifest_entry_sort_key)
+
+
 def _manifest_entry_sort_key(row: dict[str, Any]) -> tuple[str, str, str]:
     return (
         str(row.get("kind") or ""),
@@ -254,11 +327,7 @@ def export_sync_root(
         raise FileNotFoundError(str(latest_manifest_path(store_dir)))
     if storage_source_id and manifest.get("storage_source_id") != storage_source_id:
         raise ValueError(f"source_not_imported: {storage_source_id}")
-    entries = [
-        entry
-        for entry in manifest.get("entries", [])
-        if isinstance(entry, dict) and _matches_range(entry, range_filter)
-    ]
+    entries = _entries_for_range(store_dir, manifest.get("entries", []), range_filter)
     return compute_sync_root(entries)
 
 
@@ -837,9 +906,9 @@ def export_records(
     if storage_source_id and manifest.get("storage_source_id") != storage_source_id:
         raise ValueError(f"source_not_imported: {storage_source_id}")
     records = []
-    for entry in manifest.get("entries", []):
-        if not _matches_range(entry, range_filter):
-            continue
+    for entry in _entries_for_range(
+        store_dir, manifest.get("entries", []), range_filter
+    ):
         payload, error = _load_payload(store_dir, entry)
         if error:
             raise ValueError(f"{error}: {entry.get('kind')}:{entry.get('source_id')}")

--- a/framework/core/tests/python/test_atlas_storage.py
+++ b/framework/core/tests/python/test_atlas_storage.py
@@ -55,6 +55,37 @@ def _atlas_fixture(root):
     )
 
 
+def _atlas_window_context_fixture(root):
+    _write_json(
+        root / "agent-journal/goals/registry/archive/goal-old.json",
+        {
+            "goal_id": "goal-old",
+            "status": "done",
+            "updated_at": "2026-06-01T00:00:00Z",
+            "title": "Old Goal",
+        },
+    )
+    _write_json(
+        root / "agent-journal/missions/registry/archive/mission-b.json",
+        {
+            "mission_id": "mission-b",
+            "title": "Mission B",
+            "status": "active",
+            "updated_at": "2026-06-01T00:00:00Z",
+        },
+    )
+    _write_json(
+        root / "agent-journal/goals/registry/active/goal-b.json",
+        {
+            "goal_id": "goal-b",
+            "status": "active",
+            "updated_at": "2026-07-08T00:00:00Z",
+            "title": "Goal B",
+            "mission_id": "mission-b",
+        },
+    )
+
+
 def _action_receipts(source_records):
     receipts = {}
     for index, record in enumerate(
@@ -134,34 +165,7 @@ def test_atlas_source_records_keep_full_payloads(tmp_path):
 def test_atlas_source_records_filter_by_window(tmp_path):
     repo = tmp_path / "atlas"
     _atlas_fixture(repo)
-    _write_json(
-        repo / "agent-journal/goals/registry/archive/goal-old.json",
-        {
-            "goal_id": "goal-old",
-            "status": "done",
-            "updated_at": "2026-06-01T00:00:00Z",
-            "title": "Old Goal",
-        },
-    )
-    _write_json(
-        repo / "agent-journal/missions/registry/archive/mission-b.json",
-        {
-            "mission_id": "mission-b",
-            "title": "Mission B",
-            "status": "active",
-            "updated_at": "2026-06-01T00:00:00Z",
-        },
-    )
-    _write_json(
-        repo / "agent-journal/goals/registry/active/goal-b.json",
-        {
-            "goal_id": "goal-b",
-            "status": "active",
-            "updated_at": "2026-07-08T00:00:00Z",
-            "title": "Goal B",
-            "mission_id": "mission-b",
-        },
-    )
+    _atlas_window_context_fixture(repo)
 
     missions, goals, _, source_records, warnings = (
         importer.read_control_plane_with_sources(
@@ -179,6 +183,45 @@ def test_atlas_source_records_filter_by_window(tmp_path):
     assert ("mission", "mission-b") in {
         (record["kind"], record["source_id"]) for record in source_records
     }
+
+
+def test_atlas_range_export_preserves_context_closure(tmp_path):
+    repo = tmp_path / "atlas"
+    store = tmp_path / "store"
+    window = {"since": "2026-07-01T00:00:00Z"}
+    _atlas_fixture(repo)
+    _atlas_window_context_fixture(repo)
+
+    missions, goals, markers, source_records, warnings = (
+        importer.read_control_plane_with_sources(str(repo), window=window)
+    )
+    assert warnings == []
+
+    manifest = payloads.write_import_payloads(
+        store,
+        import_id="imp-range-closure",
+        repo_root=str(repo),
+        repo_head="abc123",
+        source_records=source_records,
+        counts={
+            "missions": len(missions),
+            "goals": len(goals),
+            "markers": len(markers),
+        },
+        range_filter=window,
+        action_receipts=_action_receipts(source_records),
+    )
+
+    exported = payloads.export_records(store, range_filter=window)
+    exported_keys = {(row["kind"], row["source_id"]) for row in exported}
+    source_keys = {(row["kind"], row["source_id"]) for row in source_records}
+
+    assert exported_keys == source_keys
+    assert ("mission", "mission-b") in exported_keys
+    assert (
+        payloads.export_sync_root(store, range_filter=window) == manifest["sync_root"]
+    )
+    assert payloads.verify_against_source(store, source_records)["ok"]
 
 
 def test_payload_manifest_fsck_export_and_verify(tmp_path):


### PR DESCRIPTION
## Summary
- preserve Atlas range exports as context-closed slices
- record goal-to-mission source refs in Atlas manifest entries, with fallback for older manifests
- document Atlas JSONL range export semantics

## Validation
- ./kungfu-code build
- PYTHONPATH="$PWD/framework/core/src/python:$PWD/framework/core/build/Release" uv run --project framework/core python -m pytest framework/core/tests/python/test_atlas_storage.py -q
- ./kungfu-code check
- CLI smoke: import/export/verify /Users/dkr/Code/atlas from 2026-06-29T00:00:00Z, 739 records, matching sync root, verify ok