### PR TITLE
feat(storage): expose workspace episode layout

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -125,6 +125,11 @@ defaults, optional user overrides, contract metadata, source metadata,
 a compact `kungfu.config.path/v1` payload. The `contract.hash` field makes the
 exact contract world inspectable by users, agents, and release gates.
 
+Use `kungfu storage layout --json` when the question is not "which config wins"
+but "where do workspace Episode journals, payloads, provider state, and
+projections live under the resolved data home". That layout is reported by the
+C++ storage service and keeps `KF_CONFIG_HOME` separate from workspace data.
+
 ## Isolated product instances
 
 Use an instance home when you need to run a second local Kungfu app without

--- a/docs/episode-object-model.md
+++ b/docs/episode-object-model.md
@@ -190,6 +190,19 @@ Episode manifest v1 is implemented as a system catalog journal at:
 journal/system/storage/episode-manifest/live/*.journal
 ```
 
+In the workspace data-home layout this resolves to:
+
+```text
+.kungfu/runtime/journal/system/storage/episode-manifest/live/*.journal
+```
+
+Use `kungfu storage layout --json` to inspect the fully resolved absolute path
+for the current process. That command reports the workspace data home, runtime
+dir, storage provider paths, SQLite projection path, and Episode manifest
+journal path through the C++ storage service. The JSON output is intentionally
+only an inspection view; the append-only yijinjing manifest journal remains the
+Episode authority.
+
 The authority records are yijinjing Hana/POD schema records:
 
 | Record | Tag | Purpose |

--- a/docs/runtime-storage-service.md
+++ b/docs/runtime-storage-service.md
@@ -442,6 +442,27 @@ runtime/storage/payloads/<prefix>/<sha256>.json
 runtime/storage/projections/storage.sqlite
 ```
 
+When the resolved data home is a workspace `.kungfu/`, those paths live under
+the workspace root as:
+
+```text
+.kungfu/runtime/journal/system/storage/episode-manifest/live/*.journal
+.kungfu/runtime/storage/sources.json
+.kungfu/runtime/storage/sources/<source_id>/manifests/*.json
+.kungfu/runtime/storage/payloads/<prefix>/<sha256>.json
+.kungfu/runtime/storage/rocksdb/
+.kungfu/runtime/storage/projections/storage.sqlite
+```
+
+`kungfu storage layout --json` is the v1 inspection surface for this resolved
+layout. It enters through the C++ `kungfu.runtime.storage-service/v1` operation
+`layout`, so Python, Node, CLI, and GUI code can inspect the same paths without
+redefining path rules. The returned JSON is an inspection contract, not a fact
+source: Episode authority remains the yijinjing manifest journal, source
+authority remains accepted manifests plus content-addressed payloads, and
+SQLite/RocksDB remain provider/projection implementation details behind the
+storage service API.
+
 `runtime/storage/projections/storage.sqlite` is the first generic SQLite
 projection. It is owned by the C++ storage service, rebuilt by
 `storage rebuild-index`, and contains query tables for accepted source records,
@@ -462,6 +483,7 @@ rebuildable cache, not a source of authority.
 The user-facing generic commands are:
 
 ```sh
+kungfu storage layout --json
 kungfu storage status --scope all --json
 kungfu storage status --scope source --source <source-id> --json
 kungfu storage fsck --scope all --json

--- a/framework/core/src/libkungfu/include/kungfu/runtime/storage/service.h
+++ b/framework/core/src/libkungfu/include/kungfu/runtime/storage/service.h
@@ -23,6 +23,7 @@ enum class storage_operation {
   CompactPlan,
   VerifySync,
   Query,
+  Layout,
   EpisodeBegin,
   EpisodeHeartbeat,
   EpisodeEnd,
@@ -73,6 +74,8 @@ public:
   [[nodiscard]] virtual nlohmann::json verify_sync(const storage_service_options &options) const = 0;
 
   [[nodiscard]] virtual nlohmann::json query(const storage_service_options &options) const = 0;
+
+  [[nodiscard]] virtual nlohmann::json layout(const storage_service_options &options) const = 0;
 
   [[nodiscard]] virtual nlohmann::json episode_begin(const storage_service_options &options) const = 0;
 

--- a/framework/core/src/libkungfu/src/runtime/storage/service.cpp
+++ b/framework/core/src/libkungfu/src/runtime/storage/service.cpp
@@ -273,6 +273,26 @@ fs::path manifest_path(const std::string &runtime_dir, const std::string &source
   return source_manifest_dir(runtime_dir, source_id) / (manifest_id + ".json");
 }
 
+fs::path absolute_normalized(fs::path path) { return fs::absolute(std::move(path)).lexically_normal(); }
+
+fs::path runtime_home_path(const storage_service_options &options) {
+  const auto explicit_runtime_home = text_or(options.operation_options, "runtime_home");
+  if (!explicit_runtime_home.empty()) {
+    return absolute_normalized(explicit_runtime_home);
+  }
+  const auto runtime = absolute_normalized(options.runtime_dir);
+  return runtime.filename() == "runtime" ? runtime.parent_path() : runtime;
+}
+
+std::string runtime_home_source(const storage_service_options &options) {
+  return text_or(options.operation_options, "runtime_home").empty() ? "inferred-from-runtime-dir" : "option";
+}
+
+std::string optional_absolute_path(const nlohmann::json &object, const std::string &field) {
+  const auto value = text_or(object, field);
+  return value.empty() ? std::string{} : absolute_normalized(value).string();
+}
+
 std::vector<fs::path> manifest_paths(const std::string &runtime_dir, const std::string &source_id = {});
 std::vector<fs::path> latest_manifest_paths(const std::string &runtime_dir, const std::string &source_id = {});
 std::vector<fs::path> all_payload_paths(const std::string &runtime_dir);
@@ -729,6 +749,72 @@ std::unique_ptr<storage_provider> make_provider(const std::string &runtime_dir) 
   storage_service_options options;
   options.runtime_dir = runtime_dir;
   return make_provider(options);
+}
+
+nlohmann::json workspace_episode_layout(const storage_service_options &options, const storage_provider &provider) {
+  const auto runtime = absolute_normalized(options.runtime_dir);
+  const auto home = runtime_home_path(options);
+  const auto journal_dir = runtime / "journal";
+  const auto storage_dir = runtime / "storage";
+  const auto episode_manifest_dir =
+      journal_dir / "system" / yy_storage::EPISODE_MANIFEST_NAMESPACE / yy_storage::EPISODE_MANIFEST_NAME / "live";
+  const auto source_manifest_pattern = storage_dir / "sources" / "<source-id>" / "manifests" / "*.json";
+  const auto payload_pattern = storage_dir / "payloads" / "<hash-prefix>" / "<sha256>.json";
+
+  return {
+      {"schema", "kungfu.workspace.episode-layout/v1"},
+      {"owner", RUNTIME_STORAGE_SERVICE_OWNER},
+      {"layout_version", 1},
+      {"runtime_home", home.string()},
+      {"workspace_data_home", home.string()},
+      {"runtime_home_source", runtime_home_source(options)},
+      {"runtime_dir", runtime.string()},
+      {"runtime_dir_is_standard_child", runtime.filename() == "runtime"},
+      {"config_home", optional_absolute_path(options.operation_options, "config_home")},
+      {"provider", provider.name()},
+      {"provider_layout", provider.layout()},
+      {"paths",
+       {{"data_home", home.string()},
+        {"runtime_dir", runtime.string()},
+        {"archive_dir", (home / "archive").string()},
+        {"dataset_dir", (home / "dataset").string()},
+        {"inbox_dir", (home / "inbox").string()},
+        {"journal_dir", journal_dir.string()},
+        {"storage_dir", storage_dir.string()},
+        {"source_registry", registry_path(runtime.string()).string()},
+        {"source_manifests", source_manifest_pattern.string()},
+        {"payloads", payload_pattern.string()},
+        {"rocksdb", rocksdb_root(runtime.string()).string()},
+        {"sqlite_projection", sqlite_projection_path(runtime.string()).string()},
+        {"episode_manifest_journal_dir", episode_manifest_dir.string()},
+        {"episode_manifest_journal", (episode_manifest_dir / "*.journal").string()},
+        {"master_state", (runtime / "master").string()},
+        {"remote_mirrors", (runtime / "remotes" / "<source-id>" / "runtime").string()},
+        {"atlas_store", (runtime / "atlas" / "store").string()}}},
+      {"episodes",
+       {{"authority", "yijinjing-journal"},
+        {"schema", yy_storage::EPISODE_MANIFEST_SCHEMA_V1},
+        {"manifest_namespace", yy_storage::EPISODE_MANIFEST_NAMESPACE},
+        {"manifest_name", yy_storage::EPISODE_MANIFEST_NAME},
+        {"manifest_journal", (episode_manifest_dir / "*.journal").string()},
+        {"query_tables", nlohmann::json::array({"episodes", "episode_records", "episode_frames", "episode_refs"})},
+        {"export_schema", "kungfu.storage.episode-bundle/v1"}}},
+      {"ownership",
+       {{"journal_dir", "append-only yijinjing frames owned by the resolved runtime"},
+        {"episode_manifest_journal", "append-only yijinjing manifest records; not loose JSON authority"},
+        {"storage_dir", "runtime storage service area for manifests, payloads, provider databases, and projections"},
+        {"source_registry", "derived source catalog that can be rebuilt from accepted manifests"},
+        {"payloads", "provider-owned content-addressed payload bodies"},
+        {"sqlite_projection", "derived rebuildable query projection"},
+        {"rocksdb", "optional provider-owned large-payload/key-value backend"},
+        {"config_home", "user config home; intentionally outside workspace data"}}},
+      {"notes", nlohmann::json::array({
+                    "This layout describes the resolved local data root; it is an inspection contract, not a second "
+                    "fact source.",
+                    "Episode authority remains the yijinjing manifest journal under the runtime journal tree.",
+                    "Provider-specific paths are implementation details behind the runtime storage service API.",
+                })},
+  };
 }
 
 nlohmann::json entries_for_manifest(const nlohmann::json &manifest, const nlohmann::json &range_filter = {}) {
@@ -2188,6 +2274,11 @@ public:
     return query_sqlite_projection(options);
   }
 
+  [[nodiscard]] nlohmann::json layout(const storage_service_options &options) const override {
+    const auto provider = make_provider(options);
+    return workspace_episode_layout(options, *provider);
+  }
+
   [[nodiscard]] nlohmann::json episode_begin(const storage_service_options &options) const override {
     return episode_store(options).begin(parse_episode_begin_options(options.operation_options));
   }
@@ -2258,6 +2349,7 @@ std::vector<std::string> storage_operation_names() {
       storage_operation_name(storage_operation::CompactPlan),
       storage_operation_name(storage_operation::VerifySync),
       storage_operation_name(storage_operation::Query),
+      storage_operation_name(storage_operation::Layout),
       storage_operation_name(storage_operation::EpisodeBegin),
       storage_operation_name(storage_operation::EpisodeHeartbeat),
       storage_operation_name(storage_operation::EpisodeEnd),
@@ -2289,6 +2381,8 @@ std::string storage_operation_name(storage_operation operation) {
     return "verify_sync";
   case storage_operation::Query:
     return "query";
+  case storage_operation::Layout:
+    return "layout";
   case storage_operation::EpisodeBegin:
     return "episode_begin";
   case storage_operation::EpisodeHeartbeat:
@@ -2336,6 +2430,9 @@ storage_operation parse_storage_operation(const std::string &operation) {
   }
   if (operation == "query") {
     return storage_operation::Query;
+  }
+  if (operation == "layout") {
+    return storage_operation::Layout;
   }
   if (operation == "episode_begin") {
     return storage_operation::EpisodeBegin;
@@ -2395,6 +2492,10 @@ nlohmann::json make_storage_service_request(const std::string &operation, const 
     request["query"] = parsed_options.query;
     request["kind"] = parsed_options.kind.empty() ? nlohmann::json(nullptr) : nlohmann::json(parsed_options.kind);
     request["limit"] = parsed_options.limit;
+  } else if (parsed_operation == storage_operation::Layout) {
+    request["runtime_home"] = runtime_home_path(parsed_options).string();
+    request["runtime_home_source"] = runtime_home_source(parsed_options);
+    request["config_home"] = optional_absolute_path(parsed_options.operation_options, "config_home");
   }
   if (parsed_options.episode_id != 0) {
     request["episode_id"] = parsed_options.episode_id;
@@ -2433,6 +2534,8 @@ nlohmann::json run_storage_service_operation(const std::string &operation, const
     return storage_service_instance().verify_sync(parsed_options);
   case storage_operation::Query:
     return storage_service_instance().query(parsed_options);
+  case storage_operation::Layout:
+    return storage_service_instance().layout(parsed_options);
   case storage_operation::EpisodeBegin:
     return storage_service_instance().episode_begin(parsed_options);
   case storage_operation::EpisodeHeartbeat:

--- a/framework/core/src/python/kungfu/cli/commands/storage.py
+++ b/framework/core/src/python/kungfu/cli/commands/storage.py
@@ -48,6 +48,32 @@ def storage(ctx):
     pass
 
 
+@storage.command(help="show the resolved workspace Episode storage layout")
+@click.option(
+    "--provider", type=click.Choice(["content-addressed-file", "rocksdb"]), default=None
+)
+@click.option("--json", "as_json", is_flag=True, help="machine-readable output")
+@storage_command_context
+def layout(ctx, provider, as_json):
+    from kungfu.storage import service
+
+    result = service.layout(
+        ctx.runtime_dir,
+        runtime_home=ctx.home,
+        config_home=ctx.config_home,
+        provider=provider,
+    )
+    if as_json:
+        _echo_json(result)
+        return
+    click.echo(f"[storage] data home: {result['workspace_data_home']}")
+    click.echo(f"[storage] runtime dir: {result['runtime_dir']}")
+    click.echo(
+        f"[storage] episode manifest: {result['paths']['episode_manifest_journal']}"
+    )
+    click.echo(f"[storage] provider: {result['provider']}")
+
+
 @storage.command(help="summarize a storage scope")
 @click.option("--scope", type=click.Choice(["atlas", "source", "all"]), required=True)
 @click.option("--source", "storage_source_id", type=str, default=None)

--- a/framework/core/src/python/kungfu/storage/service.py
+++ b/framework/core/src/python/kungfu/storage/service.py
@@ -305,6 +305,27 @@ def status(
     )
 
 
+def layout(
+    runtime_dir: str | Path,
+    *,
+    runtime_home: str | Path | None = None,
+    config_home: str | Path | None = None,
+    provider: str | None = None,
+) -> dict[str, Any]:
+    return dict(
+        _runtime().run_storage_service_operation(
+            "layout",
+            str(runtime_dir),
+            {
+                "scope": "all",
+                "runtime_home": str(runtime_home) if runtime_home is not None else None,
+                "config_home": str(config_home) if config_home is not None else None,
+                "provider": provider,
+            },
+        )
+    )
+
+
 def _entries_for_manifest(
     manifest: dict[str, Any], range_filter: dict[str, Any] | None = None
 ) -> list[dict[str, Any]]:

--- a/framework/core/tests/python/test_atlas_storage.py
+++ b/framework/core/tests/python/test_atlas_storage.py
@@ -371,6 +371,7 @@ def test_runtime_storage_service_surface_is_bound_from_libkungfu(tmp_path):
         "compact_plan",
         "verify_sync",
         "query",
+        "layout",
         "episode_begin",
         "episode_heartbeat",
         "episode_end",
@@ -420,6 +421,37 @@ def test_runtime_storage_service_surface_is_bound_from_libkungfu(tmp_path):
     assert request["provider"] == "rocksdb"
     assert request["provider_config_source"] == "option"
 
+    workspace_home = tmp_path / ".kungfu"
+    runtime_dir = workspace_home / "runtime"
+    config_home = tmp_path / ".kungfu-config"
+    layout = storage_service.layout(
+        runtime_dir,
+        runtime_home=workspace_home,
+        config_home=config_home,
+    )
+    assert layout["schema"] == "kungfu.workspace.episode-layout/v1"
+    assert layout["owner"] == "libkungfu"
+    assert layout["workspace_data_home"] == str(workspace_home)
+    assert layout["runtime_home"] == str(workspace_home)
+    assert layout["runtime_home_source"] == "option"
+    assert layout["runtime_dir"] == str(runtime_dir)
+    assert layout["config_home"] == str(config_home)
+    assert layout["paths"]["data_home"] == str(workspace_home)
+    assert layout["paths"]["storage_dir"] == str(runtime_dir / "storage")
+    assert layout["paths"]["sqlite_projection"] == str(
+        runtime_dir / "storage/projections/storage.sqlite"
+    )
+    assert layout["paths"]["episode_manifest_journal"] == str(
+        runtime_dir / "journal/system/storage/episode-manifest/live/*.journal"
+    )
+    assert layout["episodes"]["authority"] == "yijinjing-journal"
+    assert layout["episodes"]["query_tables"] == [
+        "episodes",
+        "episode_records",
+        "episode_frames",
+        "episode_refs",
+    ]
+
 
 def test_python_storage_operations_enter_runtime_service_surface(tmp_path, monkeypatch):
     runtime_dir = tmp_path / "runtime"
@@ -455,6 +487,7 @@ def test_python_storage_operations_enter_runtime_service_surface(tmp_path, monke
     )
 
     storage_service.status(runtime_dir, source_id="local-synth")
+    storage_service.layout(runtime_dir)
     storage_service.fsck(runtime_dir, source_id="local-synth")
     storage_service.rebuild_index(runtime_dir, source_id="local-synth", dry_run=True)
     storage_service.rebuild_index(runtime_dir, source_id="local-synth", dry_run=False)
@@ -481,6 +514,7 @@ def test_python_storage_operations_enter_runtime_service_surface(tmp_path, monke
     entered = {operation for operation, _, _ in calls}
     assert {
         "status",
+        "layout",
         "fsck",
         "rebuild_index",
         "gc_plan",

--- a/framework/core/tests/storage-node-binding.test.js
+++ b/framework/core/tests/storage-node-binding.test.js
@@ -105,6 +105,11 @@ function selectedNodeResults(runtimeDir) {
       scope: 'source',
       source_id: 'node-synth',
     }),
+    layout: kungfu.runStorageServiceOperation('layout', runtimeDir, {
+      scope: 'all',
+      runtime_home: path.dirname(runtimeDir),
+      config_home: path.join(path.dirname(runtimeDir), 'config'),
+    }),
     fsck: kungfu.runStorageServiceOperation('fsck', runtimeDir, {
       scope: 'source',
       source_id: 'node-synth',
@@ -174,6 +179,11 @@ out = {
         {"scope": "source", "source_id": "node-synth"},
     ),
     "status": service.status(runtime_dir, source_id="node-synth"),
+    "layout": service.layout(
+        runtime_dir,
+        runtime_home=str(Path(runtime_dir).parent),
+        config_home=str(Path(runtime_dir).parent / "config"),
+    ),
     "fsck": service.fsck(runtime_dir, source_id="node-synth"),
     "exported": service.export_records(
         runtime_dir,
@@ -261,6 +271,30 @@ for (const providerCase of providerCases) {
           assert.equal(
             nodeResults.status.provider,
             providerCase.expectedProvider,
+          );
+          assert.equal(
+            nodeResults.layout.schema,
+            'kungfu.workspace.episode-layout/v1',
+          );
+          assert.equal(
+            nodeResults.layout.paths.storage_dir,
+            path.join(runtimeDir, 'storage'),
+          );
+          assert.equal(
+            nodeResults.layout.paths.episode_manifest_journal,
+            path.join(
+              runtimeDir,
+              'journal',
+              'system',
+              'storage',
+              'episode-manifest',
+              'live',
+              '*.journal',
+            ),
+          );
+          assert.equal(
+            nodeResults.layout.config_home,
+            path.join(path.dirname(runtimeDir), 'config'),
           );
           assert.equal(
             nodeResults.optionRequest.provider,


### PR DESCRIPTION
## Summary
- add a C++ storage service layout operation for workspace Episode storage paths
- expose `kungfu storage layout --json` through the Python CLI
- document the `.kungfu/runtime` Episode layout and verify Python/Node storage bindings

## Validation
- ./kungfu-code build
- ./kungfu-code check
- PYTHONPATH="$PWD/src/python:$PWD/dist/kungfu" DYLD_FALLBACK_LIBRARY_PATH="$PWD/dist/kungfu:${DYLD_FALLBACK_LIBRARY_PATH:-}" uv run --frozen pytest tests/python/test_atlas_storage.py::test_runtime_storage_service_surface_is_bound_from_libkungfu tests/python/test_atlas_storage.py::test_python_storage_operations_enter_runtime_service_surface tests/python/test_atlas_storage.py::test_episode_manifest_v1_is_yijinjing_backed_and_fscked -q
- KUNGFU_DIR="$PWD/dist/kungfu" DYLD_FALLBACK_LIBRARY_PATH="$PWD/dist/kungfu:${DYLD_FALLBACK_LIBRARY_PATH:-}" pnpm run test:storage-binding
- frozen CLI `kungfu storage layout --json` smoke