### PR TITLE
feat(storage): attach episodes to runtime lifecycles

### DIFF
--- a/docs/episode-object-model.md
+++ b/docs/episode-object-model.md
@@ -239,6 +239,22 @@ pages byte-compatible while establishing Episode as the durable semantic object.
 Future physical-layout work can move from manifest association to Episode-aware
 allocation domains without changing the product-facing API.
 
+The first runtime lifecycle slice wires real Rewind actions into this manifest
+authority:
+
+- `kungfu trace` opens one Episode for the traced run, records all run frames
+  through the C++ action recorder, attaches the returned frame receipts, records
+  bundle payload refs, and ends or aborts the Episode with the process result.
+- `kungfu managed-run` uses the same lifecycle helper around provider-managed
+  runs after provider discovery succeeds.
+- `kungfu report run begin/end` supports the lower-fidelity reported workflow by
+  reopening the open Episode by `source=rewind:<run_id>` across separate CLI
+  invocations, then closing it on `run end`.
+
+The helper is intentionally thin. Python owns command orchestration and process
+flow; the load-bearing facts remain the C++ `action_recorder` receipts and the
+C++ runtime storage service's yijinjing Episode manifest operations.
+
 ## Core Operations
 
 Episode-native storage should expose these operations through the C++ core

--- a/framework/core/src/libkungfu/src/runtime/storage/service.cpp
+++ b/framework/core/src/libkungfu/src/runtime/storage/service.cpp
@@ -3,6 +3,7 @@
 #include <kungfu/runtime/storage/service.h>
 
 #include <algorithm>
+#include <charconv>
 #include <cstdlib>
 #include <filesystem>
 #include <fstream>
@@ -109,6 +110,16 @@ uint64_t uint64_or(const nlohmann::json &object, const std::string &field, uint6
   }
   if (value.is_number_integer()) {
     return static_cast<uint64_t>(value.get<int64_t>());
+  }
+  if (value.is_string()) {
+    const auto text = value.get<std::string>();
+    uint64_t parsed = 0;
+    const auto *begin = text.data();
+    const auto *end = begin + text.size();
+    const auto [ptr, error] = std::from_chars(begin, end, parsed);
+    if (error == std::errc{} && ptr == end) {
+      return parsed;
+    }
   }
   return fallback;
 }

--- a/framework/core/src/python/kungfu/rewind/managed_cli.py
+++ b/framework/core/src/python/kungfu/rewind/managed_cli.py
@@ -30,9 +30,9 @@ from kungfu.rewind import (
     events,
     managed_run,
 )
-from kungfu.rewind.wire import wrap_event
 from kungfu.rewind.cost import confidence_for, discover_provider
 from kungfu.rewind.fb.RunStatus import RunStatus
+from kungfu.storage.episode_lifecycle import RuntimeEpisodeLifecycle
 from kungfu.skill import (
     build_skill_context,
     context_file_from_env,
@@ -45,9 +45,6 @@ from kungfu.skill import (
     write_audit_document,
 )
 
-lf = kungfu.__binding__.yijinjing
-yjj = kungfu.__binding__.runtime
-
 
 @dataclass
 class ManagedRunCliReport:
@@ -59,16 +56,6 @@ class ManagedRunCliReport:
     response_doc: dict[str, Any]
     skill_audit_path: str | None
     skill_audit_doc: dict[str, Any] | None
-
-
-def _open_journal(runtime_dir: str, run_id: str) -> Any:
-    loc = yjj.locator(runtime_dir)
-    location = yjj.location(
-        lf.enums.mode.LIVE, lf.enums.location_role.SYSTEM, "rewind", run_id, loc
-    )
-    pub = yjj.noop_publisher()
-    bus = yjj.bus(False)
-    return yjj.writer(location, 0, True, pub, False, bus, 0)
 
 
 def _rule(label: str = "") -> str:
@@ -155,36 +142,44 @@ def run_and_report(
             )
         print("  running the provider under management …\n")
 
-    writer = _open_journal(runtime_dir, run_id)
+    episode = RuntimeEpisodeLifecycle(
+        runtime_dir=runtime_dir,
+        namespace="rewind",
+        name=run_id,
+        title=f"managed run {run_id}",
+        actor=provider,
+        source=f"rewind:{run_id}",
+    )
 
     def emit(action_type: str, data: bytes) -> None:
-        carrier_type, envelope = wrap_event(action_type, data, run_id=run_id)
-        writer.write_bytes(0, carrier_type, list(envelope), len(envelope))
+        episode.record_event(action_type, data, run_id=run_id)
 
-    emit(
-        ACTION_RUN_BEGIN,
-        events.run_begin(
+    try:
+        emit(
+            ACTION_RUN_BEGIN,
+            events.run_begin(
+                run_id=run_id,
+                command=f"{provider} managed-run",
+                runtime=sys.platform,
+                supervisor_version=kungfu.__version__,
+                schema_version=SCHEMA_VERSION,
+            ),
+        )
+
+        result = managed_run.run_managed(
+            provider,
+            disc.path,
+            prompt_for_provider,
+            emit=emit,
             run_id=run_id,
-            command=f"{provider} managed-run",
-            runtime=sys.platform,
-            supervisor_version=kungfu.__version__,
-            schema_version=SCHEMA_VERSION,
-        ),
-    )
+            work_id=work_id,
+        )
 
-    result = managed_run.run_managed(
-        provider,
-        disc.path,
-        prompt_for_provider,
-        emit=emit,
-        run_id=run_id,
-        work_id=work_id,
-    )
-
-    status = RunStatus.Succeeded if result.exit_code == 0 else RunStatus.Failed
-    emit(ACTION_RUN_END, events.run_end(run_id, status, result.exit_code))
-    # frames are written straight to the memory-mapped journal page, so they
-    # persist without an explicit flush; the writer releases at function end.
+        status = RunStatus.Succeeded if result.exit_code == 0 else RunStatus.Failed
+        emit(ACTION_RUN_END, events.run_end(run_id, status, result.exit_code))
+    except Exception as exc:
+        episode.close(ok=False, reason=f"managed-run exception: {exc}")
+        raise
 
     bundle_dir = os.path.join(runtime_dir, "rewind", run_id, "bundle")
     os.makedirs(bundle_dir, exist_ok=True)
@@ -203,6 +198,7 @@ def run_and_report(
         f.write("\n")
     with open(response_path, "rb") as rf:
         response_hash = compute_content_hash_value(rf.read())
+    episode.attach_payload_ref(response_path, content_hash=response_hash)
     skill_audit_doc = None
     skill_audit_path = None
     skill_audit_hash = None
@@ -244,6 +240,11 @@ def run_and_report(
             "dest": 0,
         },
         extra=extra,
+    )
+    episode.attach_payload_ref(manifest)
+    episode.close(
+        ok=status == RunStatus.Succeeded,
+        reason=f"managed-run exit_code={result.exit_code}",
     )
     report = ManagedRunCliReport(
         provider=provider,

--- a/framework/core/src/python/kungfu/rewind/reporting.py
+++ b/framework/core/src/python/kungfu/rewind/reporting.py
@@ -21,14 +21,11 @@ from kungfu.rewind import (
     cost_wire,
     events,
 )
-from kungfu.rewind.wire import wrap_event
 from kungfu.rewind.cost.model import AttributionLevel, CostSnapshot, TokenUsage
 from kungfu.rewind.fb.CaptureLayer import CaptureLayer
 from kungfu.rewind.fb.Decision import Decision
 from kungfu.rewind.fb.RunStatus import RunStatus
-
-lf = kungfu.__binding__.yijinjing
-yjj = kungfu.__binding__.runtime
+from kungfu.storage.episode_lifecycle import RuntimeEpisodeLifecycle
 
 DECISION_BY_NAME = {
     "approve": Decision.Approve,
@@ -50,16 +47,6 @@ ATTRIBUTION_BY_NAME = {level.value: level for level in AttributionLevel}
 
 def new_run_id() -> str:
     return uuid.uuid4().hex[:12]
-
-
-def _open_journal(runtime_dir: str, run_id: str) -> Any:
-    loc = yjj.locator(runtime_dir)
-    location = yjj.location(
-        lf.enums.mode.LIVE, lf.enums.location_role.SYSTEM, "rewind", run_id, loc
-    )
-    pub = yjj.noop_publisher()
-    bus = yjj.bus(False)
-    return yjj.writer(location, 0, True, pub, False, bus, 0)
 
 
 def _source(run_id: str, runtime_dir: str) -> dict[str, Any]:
@@ -99,10 +86,21 @@ def emit_manifest(
     )
 
 
+def _episode(
+    runtime_dir: str, run_id: str, *, actor: str = "report"
+) -> RuntimeEpisodeLifecycle:
+    return RuntimeEpisodeLifecycle.resume_or_begin(
+        runtime_dir,
+        namespace="rewind",
+        name=run_id,
+        title=f"reported run {run_id}",
+        actor=actor,
+        source=f"rewind:{run_id}",
+    )
+
+
 def emit_event(runtime_dir: str, run_id: str, action_type: str, payload: bytes) -> None:
-    writer = _open_journal(runtime_dir, run_id)
-    carrier_type, envelope = wrap_event(action_type, payload, run_id=run_id)
-    writer.write_bytes(0, carrier_type, list(envelope), len(envelope))
+    _episode(runtime_dir, run_id).record_event(action_type, payload, run_id=run_id)
 
 
 def begin_run(
@@ -116,9 +114,8 @@ def begin_run(
 ) -> str:
     command_text = command or f"{provider} reported-run"
     runtime = f"reported:{cwd}" if cwd else "reported"
-    emit_event(
-        runtime_dir,
-        run_id,
+    episode = _episode(runtime_dir, run_id, actor=provider)
+    episode.record_event(
         ACTION_RUN_BEGIN,
         events.run_begin(
             run_id=run_id,
@@ -127,22 +124,28 @@ def begin_run(
             supervisor_version=kungfu.__version__,
             schema_version=SCHEMA_VERSION,
         ),
+        run_id=run_id,
     )
-    return emit_manifest(
+    manifest = emit_manifest(
         runtime_dir,
         run_id,
         extra={"provider": provider, "work_id": work_id, "cwd": cwd},
     )
+    episode.attach_payload_ref(manifest)
+    return manifest
 
 
 def end_run(runtime_dir: str, *, run_id: str, status: str, exit_code: int) -> str:
-    emit_event(
-        runtime_dir,
-        run_id,
+    episode = _episode(runtime_dir, run_id)
+    episode.record_event(
         ACTION_RUN_END,
         events.run_end(run_id, RUN_STATUS_BY_NAME[status], exit_code),
+        run_id=run_id,
     )
-    return emit_manifest(runtime_dir, run_id, extra={"status": status})
+    manifest = emit_manifest(runtime_dir, run_id, extra={"status": status})
+    episode.attach_payload_ref(manifest)
+    episode.close(ok=status == "succeeded", reason=f"reported-run {status}")
+    return manifest
 
 
 def report_cost(

--- a/framework/core/src/python/kungfu/rewind/supervisor.py
+++ b/framework/core/src/python/kungfu/rewind/supervisor.py
@@ -40,15 +40,12 @@ from kungfu.rewind import adapters, bundle, events
 from kungfu.rewind.fb.RunStatus import RunStatus
 from kungfu.rewind.ingest import IngestServer
 from kungfu.rewind.schema_registry import register_user_schema
-from kungfu.rewind.wire import wrap_event
 from kungfu.rewind.proxy import (
     DEFAULT_ANTHROPIC_UPSTREAM,
     DEFAULT_OPENAI_UPSTREAM,
     ModelWireProxy,
 )
-
-lf = kungfu.__binding__.yijinjing
-yjj = kungfu.__binding__.runtime
+from kungfu.storage.episode_lifecycle import RuntimeEpisodeLifecycle
 
 ENV_RUN_ID = "KUNGFU_REWIND_RUN_ID"
 ENV_INGEST = "KUNGFU_REWIND_INGEST"
@@ -71,21 +68,13 @@ class Supervisor:
         self.runtime_dir = runtime_dir
         self.command = list(command)
         self.run_id = run_id or uuid.uuid4().hex
-        self.locator = yjj.locator(runtime_dir)
-        self.location = yjj.location(
-            lf.enums.mode.LIVE,
-            lf.enums.location_role.SYSTEM,
-            "rewind",
-            self.run_id,
-            self.locator,
-        )
-        # standalone single-writer journal, same shape as the C++ slices:
-        # no master, no-op publisher, private bus. Keep every piece alive on
-        # self — the writer borrows them without owning their lifetime.
-        self.publisher = yjj.noop_publisher()
-        self.bus = yjj.bus(False)
-        self.writer = yjj.writer(
-            self.location, PUBLIC_DEST, True, self.publisher, False, self.bus, 0
+        self.episode = RuntimeEpisodeLifecycle(
+            runtime_dir=runtime_dir,
+            namespace="rewind",
+            name=self.run_id,
+            title=f"rewind trace {self.run_id}",
+            actor="kungfu trace",
+            source=f"rewind:{self.run_id}",
         )
         self.events: queue.SimpleQueue[Any] = queue.SimpleQueue()
         self.proxy = ModelWireProxy(
@@ -125,9 +114,7 @@ class Supervisor:
             if item is _STOP:
                 return
             action_type, data = item
-            carrier_type, envelope = wrap_event(action_type, data, run_id=self.run_id)
-            # the binding takes the payload as a byte sequence (list[int])
-            self.writer.write_bytes(0, carrier_type, list(envelope), len(envelope))
+            self.episode.record_event(action_type, data, run_id=self.run_id)
 
     def child_env(self) -> dict[str, str]:
         env = dict(os.environ)
@@ -236,4 +223,9 @@ class Supervisor:
                     )
                 except ValueError:
                     continue
+            self.episode.attach_payload_ref(manifest_path)
+            self.episode.close(
+                ok=status == RunStatus.Succeeded,
+                reason=f"trace exit_code={exit_code}",
+            )
         return exit_code, status, manifest_path

--- a/framework/core/src/python/kungfu/storage/episode_lifecycle.py
+++ b/framework/core/src/python/kungfu/storage/episode_lifecycle.py
@@ -1,0 +1,154 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+from typing import Any
+
+import kungfu
+from kungfu.rewind.wire import wrap_event
+from kungfu.storage import service
+
+lf = kungfu.__binding__.yijinjing
+yjj = kungfu.__binding__.runtime
+
+PUBLIC_DEST = 0
+
+
+def _location_uid(runtime_dir: str, namespace: str, name: str) -> int:
+    locator = yjj.locator(runtime_dir)
+    location = yjj.location(
+        lf.enums.mode.LIVE,
+        lf.enums.location_role.SYSTEM,
+        namespace,
+        name,
+        locator,
+    )
+    return int(location.uid)
+
+
+def _relative_ref(runtime_dir: str, path: str) -> str:
+    try:
+        return os.path.relpath(path, runtime_dir)
+    except ValueError:
+        return path
+
+
+def find_open_episode_id(runtime_dir: str, *, source: str) -> int | None:
+    listed = service.episode_list(runtime_dir, limit=0)
+    matches = [
+        int(row["episode_id"])
+        for row in listed.get("episodes", [])
+        if row.get("source") == source and row.get("status") == "open"
+    ]
+    return matches[-1] if matches else None
+
+
+@dataclass
+class RuntimeEpisodeLifecycle:
+    runtime_dir: str
+    namespace: str
+    name: str
+    title: str
+    actor: str
+    source: str
+    episode_id: int = 0
+    begin: bool = True
+
+    def __post_init__(self) -> None:
+        self.location_uid = _location_uid(self.runtime_dir, self.namespace, self.name)
+        self.recorder = yjj.action_recorder(
+            self.runtime_dir, self.namespace, self.name, PUBLIC_DEST, 0
+        )
+        self.frame_count = 0
+        self.closed = False
+        if self.begin:
+            begun = service.episode_begin(
+                self.runtime_dir,
+                episode_id=self.episode_id,
+                title=self.title,
+                actor=self.actor,
+                source=self.source,
+                location_uid=self.location_uid,
+            )
+            self.episode_id = int(begun["episode_id"])
+        elif self.episode_id == 0:
+            raise ValueError("episode_id is required when begin=False")
+        else:
+            inspected = service.episode_inspect(
+                self.runtime_dir, episode_id=self.episode_id
+            )
+            self.frame_count = len(inspected.get("frames", []))
+
+    @classmethod
+    def resume_or_begin(
+        cls,
+        runtime_dir: str,
+        *,
+        namespace: str,
+        name: str,
+        title: str,
+        actor: str,
+        source: str,
+    ) -> "RuntimeEpisodeLifecycle":
+        episode_id = find_open_episode_id(runtime_dir, source=source)
+        return cls(
+            runtime_dir=runtime_dir,
+            namespace=namespace,
+            name=name,
+            title=title,
+            actor=actor,
+            source=source,
+            episode_id=episode_id or 0,
+            begin=episode_id is None,
+        )
+
+    def record_event(self, action_type: str, payload: bytes, *, run_id: str) -> Any:
+        carrier_type, envelope = wrap_event(action_type, payload, run_id=run_id)
+        receipt = self.recorder.record_bytes(carrier_type, bytes(envelope))
+        self.frame_count += 1
+        service.episode_attach_frame(
+            self.runtime_dir,
+            episode_id=self.episode_id,
+            location_uid=self.location_uid,
+            frame_uid=int(receipt.frame_uid),
+            trigger_frame_uid=int(receipt.trigger_frame_uid),
+            stream_id=int(receipt.stream_id),
+            gen_time=int(receipt.gen_time),
+            trigger_time=int(receipt.trigger_time),
+            carrier_type=int(receipt.carrier_type),
+            source=int(receipt.source),
+            dest=int(receipt.dest),
+            data_length=int(receipt.data_length),
+            integrity_version=int(receipt.integrity_version),
+            payload_checksum=int(receipt.payload_checksum),
+            frame_checksum=int(receipt.frame_checksum),
+        )
+        return receipt
+
+    def attach_payload_ref(
+        self, path: str, *, content_hash: str = "", ref_id: str | None = None
+    ) -> None:
+        service.episode_attach_ref(
+            self.runtime_dir,
+            episode_id=self.episode_id,
+            location_uid=self.location_uid,
+            ref_kind="payload",
+            ref_id=ref_id or _relative_ref(self.runtime_dir, path),
+            ref_hash=content_hash,
+        )
+
+    def close(self, *, ok: bool, reason: str = "") -> None:
+        if self.closed:
+            return
+        close = service.episode_end if ok else service.episode_abort
+        close(
+            self.runtime_dir,
+            episode_id=self.episode_id,
+            location_uid=self.location_uid,
+            last_frame_uid=int(self.recorder.last_frame_uid),
+            frame_count=self.frame_count,
+            reason=reason,
+        )
+        self.closed = True

--- a/framework/core/src/python/kungfu/storage/service.py
+++ b/framework/core/src/python/kungfu/storage/service.py
@@ -22,6 +22,10 @@ def _runtime():
     return kungfu.__binding__.runtime
 
 
+def _u64(value: int | None) -> str:
+    return str(value or 0)
+
+
 def service_capabilities() -> dict[str, Any]:
     return dict(_runtime().storage_service_capabilities())
 
@@ -377,7 +381,7 @@ def fsck(
             {
                 "scope": scope,
                 "source_id": source_id,
-                "episode_id": episode_id or 0,
+                "episode_id": _u64(episode_id),
             },
         )
     )
@@ -477,7 +481,7 @@ def query_projection(
             {
                 "scope": scope,
                 "source_id": source_id,
-                "episode_id": episode_id or 0,
+                "episode_id": _u64(episode_id),
                 "query": query,
                 "kind": kind,
                 "range": range_filter or {},
@@ -504,9 +508,9 @@ def episode_begin(
             "episode_begin",
             str(runtime_dir),
             {
-                "episode_id": episode_id,
-                "parent_episode_id": parent_episode_id,
-                "root_trigger_frame_uid": root_trigger_frame_uid,
+                "episode_id": _u64(episode_id),
+                "parent_episode_id": _u64(parent_episode_id),
+                "root_trigger_frame_uid": _u64(root_trigger_frame_uid),
                 "location_uid": location_uid,
                 "begin_time": begin_time,
                 "title": title,
@@ -532,11 +536,11 @@ def episode_heartbeat(
             "episode_heartbeat",
             str(runtime_dir),
             {
-                "episode_id": episode_id,
+                "episode_id": _u64(episode_id),
                 "location_uid": location_uid,
                 "update_time": update_time,
-                "last_frame_uid": last_frame_uid,
-                "frame_count": frame_count,
+                "last_frame_uid": _u64(last_frame_uid),
+                "frame_count": _u64(frame_count),
                 "note": note,
             },
         )
@@ -566,11 +570,11 @@ def episode_attach_frame(
             "episode_attach_frame",
             str(runtime_dir),
             {
-                "episode_id": episode_id,
+                "episode_id": _u64(episode_id),
                 "location_uid": location_uid,
-                "frame_uid": frame_uid,
-                "trigger_frame_uid": trigger_frame_uid,
-                "stream_id": stream_id,
+                "frame_uid": _u64(frame_uid),
+                "trigger_frame_uid": _u64(trigger_frame_uid),
+                "stream_id": _u64(stream_id),
                 "gen_time": gen_time,
                 "trigger_time": trigger_time,
                 "carrier_type": carrier_type,
@@ -578,8 +582,8 @@ def episode_attach_frame(
                 "dest": dest,
                 "data_length": data_length,
                 "integrity_version": integrity_version,
-                "payload_checksum": payload_checksum,
-                "frame_checksum": frame_checksum,
+                "payload_checksum": _u64(payload_checksum),
+                "frame_checksum": _u64(frame_checksum),
             },
         )
     )
@@ -601,10 +605,10 @@ def episode_attach_ref(
             "episode_attach_ref",
             str(runtime_dir),
             {
-                "episode_id": episode_id,
+                "episode_id": _u64(episode_id),
                 "location_uid": location_uid,
                 "ref_kind": ref_kind,
-                "ref_uid": ref_uid,
+                "ref_uid": _u64(ref_uid),
                 "ref_id": ref_id,
                 "ref_hash": ref_hash,
                 "update_time": update_time,
@@ -628,11 +632,11 @@ def episode_end(
             "episode_end",
             str(runtime_dir),
             {
-                "episode_id": episode_id,
+                "episode_id": _u64(episode_id),
                 "location_uid": location_uid,
                 "end_time": end_time,
-                "last_frame_uid": last_frame_uid,
-                "frame_count": frame_count,
+                "last_frame_uid": _u64(last_frame_uid),
+                "frame_count": _u64(frame_count),
                 "reason": reason,
             },
         )
@@ -654,11 +658,11 @@ def episode_abort(
             "episode_abort",
             str(runtime_dir),
             {
-                "episode_id": episode_id,
+                "episode_id": _u64(episode_id),
                 "location_uid": location_uid,
                 "end_time": end_time,
-                "last_frame_uid": last_frame_uid,
-                "frame_count": frame_count,
+                "last_frame_uid": _u64(last_frame_uid),
+                "frame_count": _u64(frame_count),
                 "reason": reason,
             },
         )
@@ -685,7 +689,7 @@ def episode_inspect(runtime_dir: str | Path, *, episode_id: int) -> dict[str, An
         _runtime().run_storage_service_operation(
             "episode_inspect",
             str(runtime_dir),
-            {"episode_id": episode_id},
+            {"episode_id": _u64(episode_id)},
         )
     )
 
@@ -787,7 +791,7 @@ def build_export_bundle(
             {
                 "scope": scope,
                 "source_id": source_id,
-                "episode_id": episode_id or 0,
+                "episode_id": _u64(episode_id),
                 "range": range_filter or {},
             },
         )

--- a/framework/core/stubs/pykungfu/yijinjing/types.pyi
+++ b/framework/core/stubs/pykungfu/yijinjing/types.pyi
@@ -152,7 +152,7 @@ class EpisodeClosed:
     frame_count: int
     last_frame_uid: int
     location_uid: int
-    reason: str
+    reason: String[str[64]]
     schema_version: int
     status: pykungfu.yijinjing.enums.EpisodeStatus
     def __eq__(self, arg0: EpisodeClosed) -> bool:
@@ -214,7 +214,7 @@ class EpisodeHeartbeat:
     frame_count: int
     last_frame_uid: int
     location_uid: int
-    note: str
+    note: String[str[64]]
     schema_version: int
     update_time: int
     def __eq__(self, arg0: EpisodeHeartbeat) -> bool:
@@ -237,15 +237,15 @@ class EpisodeHeartbeat:
 class EpisodeOpen:
     __has_data__: typing.ClassVar[bool] = True
     __tag__: typing.ClassVar[int] = 10801
-    actor: str
+    actor: String[str[64]]
     begin_time: int
     episode_id: int
     location_uid: int
     parent_episode_id: int
     root_trigger_frame_uid: int
     schema_version: int
-    source: str
-    title: str
+    source: String[str[64]]
+    title: String[str[64]]
     def __eq__(self, arg0: EpisodeOpen) -> bool:
         ...
     def __hash__(self) -> int:
@@ -268,8 +268,8 @@ class EpisodeRefAttached:
     __tag__: typing.ClassVar[int] = 10804
     episode_id: int
     location_uid: int
-    ref_hash: str
-    ref_id: str
+    ref_hash: String[str[128]]
+    ref_id: String[str[128]]
     ref_kind: pykungfu.yijinjing.enums.EpisodeRefKind
     ref_uid: int
     schema_version: int

--- a/tests/fixtures/rewind-demo-happy/check_capture.py
+++ b/tests/fixtures/rewind-demo-happy/check_capture.py
@@ -43,6 +43,7 @@ from kungfu.rewind.fb.RunBegin import RunBegin
 from kungfu.rewind.fb.RunEnd import RunEnd
 from kungfu.rewind.fb.ToolCall import ToolCall
 from kungfu.rewind.fb.ToolResult import ToolResult
+from kungfu.storage import service as storage_service
 
 schema = kungfu.__binding__.yijinjing
 yjj = kungfu.__binding__.runtime
@@ -209,6 +210,46 @@ if os.path.exists(manifest_path):
                     "schema blob content-addressed",
                     hashlib.sha256(f.read()).hexdigest() == schema_hash,
                 )
+
+episodes = storage_service.episode_list(runtime_dir, limit=0)
+matching_episodes = [
+    row
+    for row in episodes.get("episodes", [])
+    if row.get("source") == f"rewind:{run_id}"
+]
+check("Episode created for traced run", len(matching_episodes) == 1)
+if matching_episodes:
+    episode = matching_episodes[0]
+    check("Episode status ended", episode.get("status") == "ended", str(episode))
+    check("Episode actor is trace", episode.get("actor") == "kungfu trace")
+    inspected = storage_service.episode_inspect(
+        runtime_dir, episode_id=int(episode["episode_id"])
+    )
+    attached_uids = {row.get("frame_uid") for row in inspected.get("frames", [])}
+    expected_uids = {
+        row[0].frame_uid
+        for rows in (
+            begin_frames,
+            req_frames,
+            resp_frames,
+            call_frames,
+            result_frames,
+            retry_frames,
+            end_frames,
+        )
+        for row in rows
+    }
+    check("Episode attached every run frame", attached_uids == expected_uids)
+    check("Episode has payload refs", len(inspected.get("refs", [])) >= 1)
+    fsck = storage_service.fsck(runtime_dir, episode_id=int(episode["episode_id"]))
+    check("Episode fsck ok", fsck.get("ok") is True, str(fsck.get("errors", [])))
+    exported = storage_service.build_export_bundle(
+        runtime_dir, episode_id=int(episode["episode_id"])
+    )
+    check("Episode export bundle ok", exported.get("scope") == "episode")
+    check(
+        "Episode export has frames", exported.get("frame_count") == len(expected_uids)
+    )
 
 if failures:
     print(f"capture check failed: {failures}")


### PR DESCRIPTION
## Summary
- wrap rewind trace, managed-run, and reported run paths in runtime Episode lifecycles
- attach action recorder frame receipts and payload refs to Episode manifests
- validate Episode list/inspect/fsck/export through the rewind demo fixture

## Validation
- ./kungfu-code build
- ./kungfu-code check
- cd framework/core && DYLD_FALLBACK_LIBRARY_PATH=dist/kungfu PYTHONPATH=src/python:dist/kungfu uv run --frozen pytest tests/python/test_atlas_storage.py -q
- node tests/fixtures/rewind-demo-happy/run.mjs