### PR TITLE
feat(storage): expose episode causal graph diagnostics

### DIFF
--- a/docs/episode-object-model.md
+++ b/docs/episode-object-model.md
@@ -232,6 +232,21 @@ episode_inspect
 missing open records, duplicate opens, duplicate closes, and malformed frame
 attachments.
 
+The same folded manifest now exposes a first causal graph projection:
+
+```text
+kungfu.episode.causal-graph/v1
+```
+
+`episode_inspect` and Episode-scoped storage export include this graph plus the
+folded `dependencies` list. V1 records internal frame trigger edges when both
+frames live in the Episode, and records declared or missing external
+dependencies for parent Episodes, referenced Episodes, trigger frames, payloads,
+and schemas. `storage fsck --scope episode` uses the graph to distinguish a
+failed Episode from a degraded Episode: failed means unreadable or structurally
+invalid manifest evidence; degraded means the Episode remains inspectable but
+some dependency, trigger frame, or payload evidence is missing.
+
 V1 deliberately does not add an Episode field to `frame_header`. New writes are
 associated with Episodes by appending `EpisodeFrameAttached` records from the
 C++ service using the action recorder's frame receipt. This keeps current mmap
@@ -283,6 +298,7 @@ Episode fsck should verify at least:
 - every `trigger_frame_uid` or equivalent frame-level causal parent resolves
   inside the Episode;
 - external dependencies are declared as Episode ids;
+- declared external trigger frames are named as compact input-frame refs;
 - payload refs exist or are explicitly marked redacted/absent/missing;
 - present payload hashes and byte lengths match the manifest;
 - required schemas resolve;
@@ -292,6 +308,13 @@ Episode fsck should verify at least:
 
 Fsck must report degraded evidence. It must not invent causality or silently
 repair a missing payload by treating it as absent.
+
+V1 degraded diagnostics are intentionally conservative. A missing parent
+Episode, missing referenced Episode, undeclared external trigger frame, missing
+root trigger frame, or missing payload ref produces a warning and a degraded
+status while keeping `ok: true` when the manifest itself is readable. This gives
+repair/sync code a precise target without making the Episode disappear from
+inspection or export.
 
 ## Migration Plan
 

--- a/framework/core/src/libkungfu/src/runtime/storage/service.cpp
+++ b/framework/core/src/libkungfu/src/runtime/storage/service.cpp
@@ -1422,9 +1422,10 @@ nlohmann::json episode_fsck_impl(const storage_service_options &options) {
   const auto checked = object_or_empty(episode_report, "checked");
   nlohmann::json report = {
       {"ok", episode_report.value("ok", false)},
-      {"status", episode_report.value("ok", false) ? "ok" : "failed"},
+      {"status", episode_report.value("status", episode_report.value("ok", false) ? "ok" : "failed")},
       {"scope", "episode"},
       {"episode_id", options.episode_id == 0 ? nlohmann::json(nullptr) : nlohmann::json(options.episode_id)},
+      {"degraded", episode_report.value("degraded", false)},
       {"errors", episode_report.value("errors", nlohmann::json::array())},
       {"warnings", episode_report.value("warnings", nlohmann::json::array())},
       {"checked",
@@ -1460,25 +1461,24 @@ nlohmann::json episode_export_bundle_impl(const storage_service_options &options
   const auto records = inspected.value("records", nlohmann::json::array());
   const auto frames = inspected.value("frames", nlohmann::json::array());
   const auto refs = inspected.value("refs", nlohmann::json::array());
-  nlohmann::json dependencies = nlohmann::json::array();
-  for (const auto &ref : refs) {
-    if (text_or(ref, "ref_kind") == "episode") {
-      dependencies.push_back(ref);
-    }
-  }
+  const auto dependencies = inspected.value("dependencies", nlohmann::json::array());
+  const auto causal_graph = inspected.value("causal_graph", nlohmann::json::object());
   return {{"schema", "kungfu.storage.episode-bundle/v1"},
           {"bundle_id", "episode:" + std::to_string(options.episode_id)},
           {"scope", "episode"},
           {"episode_id", options.episode_id},
           {"authority", "yijinjing-journal"},
           {"manifest", episode},
+          {"causal_graph", causal_graph},
           {"records", records},
           {"frames", frames},
           {"refs", refs},
           {"dependencies", dependencies},
+          {"degraded", causal_graph.value("degraded", false)},
           {"record_count", records.size()},
           {"frame_count", frames.size()},
-          {"ref_count", refs.size()}};
+          {"ref_count", refs.size()},
+          {"dependency_count", dependencies.size()}};
 }
 
 nlohmann::json replace_string_subtree(nlohmann::json value, const std::string &needle, const std::string &replacement) {
@@ -1898,6 +1898,7 @@ nlohmann::json fsck_impl(const storage_service_options &options) {
   report["checked"]["episode_manifest_records"] = episode_checked.value("episode_manifest_records", 0);
   report["checked"]["episodes"] = episode_checked.value("episodes", 0);
   report["episode_manifest"] = episode_report;
+  report["degraded"] = report.value("degraded", false) || episode_report.value("degraded", false);
   for (const auto &error : array_or_empty(episode_report, "errors")) {
     auto row = error;
     row["projection"] = "episode-manifest";
@@ -1909,6 +1910,7 @@ nlohmann::json fsck_impl(const storage_service_options &options) {
     row["projection"] = "episode-manifest";
     report["warnings"].push_back(row);
   }
+  degraded = degraded || episode_report.value("degraded", false);
 
   const auto sqlite_projection_status = sqlite_projection_json(options.runtime_dir, options.source_id);
   report["projections"] = nlohmann::json::array({{{"name", PROJECTION_SOURCE_REGISTRY},
@@ -1953,6 +1955,7 @@ nlohmann::json fsck_impl(const storage_service_options &options) {
   }
   // Tri-state verdict over the boolean ok: failed (corruption/drift/unreadable)
   // dominates, then degraded (incomplete but not corrupt), else ok.
+  report["degraded"] = degraded;
   report["status"] = !report["ok"].get<bool>() ? "failed" : (degraded ? "degraded" : "ok");
   return report;
 }

--- a/framework/core/src/libyijinjing/src/storage/episode_manifest.cpp
+++ b/framework/core/src/libyijinjing/src/storage/episode_manifest.cpp
@@ -3,6 +3,7 @@
 #include <kungfu/yijinjing/storage/episode_manifest.h>
 
 #include <algorithm>
+#include <filesystem>
 #include <map>
 #include <memory>
 #include <stdexcept>
@@ -21,6 +22,8 @@ using namespace kungfu::yijinjing::types;
 namespace kungfu::yijinjing::storage {
 
 namespace {
+
+namespace fs = std::filesystem;
 
 constexpr uint32_t EPISODE_MANIFEST_SCHEMA_VERSION = 1;
 
@@ -248,6 +251,194 @@ std::map<uint64_t, episode_fold> fold_records(const std::vector<nlohmann::json> 
   return folded;
 }
 
+uint64_t u64_or(const nlohmann::json &object, const std::string &field, uint64_t fallback = 0) {
+  if (!object.is_object() || !object.contains(field)) {
+    return fallback;
+  }
+  const auto &value = object.at(field);
+  if (value.is_number_unsigned()) {
+    return value.get<uint64_t>();
+  }
+  if (value.is_number_integer()) {
+    const auto signed_value = value.get<int64_t>();
+    return signed_value < 0 ? fallback : static_cast<uint64_t>(signed_value);
+  }
+  return fallback;
+}
+
+std::string text_or(const nlohmann::json &object, const std::string &field, const std::string &fallback = {}) {
+  if (!object.is_object() || !object.contains(field) || !object.at(field).is_string()) {
+    return fallback;
+  }
+  return object.at(field).get<std::string>();
+}
+
+bool contains_u64(const std::vector<uint64_t> &values, uint64_t value) {
+  return std::find(values.begin(), values.end(), value) != values.end();
+}
+
+bool payload_ref_exists(const std::string &runtime_dir, const nlohmann::json &ref) {
+  const auto ref_id = text_or(ref, "ref_id");
+  if (ref_id.empty()) {
+    return false;
+  }
+  fs::path path(ref_id);
+  if (path.is_relative()) {
+    path = fs::path(runtime_dir) / path;
+  }
+  return fs::exists(path);
+}
+
+struct episode_graph {
+  nlohmann::json graph = nlohmann::json::object();
+  nlohmann::json dependencies = nlohmann::json::array();
+  nlohmann::json warnings = nlohmann::json::array();
+  bool degraded = false;
+};
+
+episode_graph build_causal_graph(const std::string &runtime_dir, uint64_t episode_id, const episode_fold &episode,
+                                 const std::map<uint64_t, episode_fold> &folded) {
+  std::vector<uint64_t> frame_uids;
+  std::vector<uint64_t> declared_input_frames;
+  nlohmann::json frame_edges = nlohmann::json::array();
+  nlohmann::json dependencies = nlohmann::json::array();
+  nlohmann::json warnings = nlohmann::json::array();
+  bool degraded = false;
+
+  for (const auto &frame : episode.frames) {
+    const auto frame_uid = u64_or(frame, "frame_uid");
+    if (frame_uid != 0) {
+      frame_uids.push_back(frame_uid);
+    }
+  }
+  for (const auto &ref : episode.refs) {
+    if (text_or(ref, "ref_kind") == "input_frame") {
+      const auto ref_uid = u64_or(ref, "ref_uid");
+      if (ref_uid != 0) {
+        declared_input_frames.push_back(ref_uid);
+      }
+    }
+  }
+
+  const auto parent_episode_id = u64_or(episode.summary, "parent_episode_id");
+  if (parent_episode_id != 0) {
+    const bool present = folded.find(parent_episode_id) != folded.end();
+    const auto status = present ? "present" : "missing";
+    dependencies.push_back(
+        {{"kind", "episode"}, {"role", "parent"}, {"episode_id", parent_episode_id}, {"status", status}});
+    if (!present) {
+      degraded = true;
+      warnings.push_back({{"code", "episode_dependency_missing"},
+                          {"episode_id", episode_id},
+                          {"dependency_episode_id", parent_episode_id},
+                          {"role", "parent"}});
+    }
+  }
+
+  const auto root_trigger_frame_uid = u64_or(episode.summary, "root_trigger_frame_uid");
+  if (root_trigger_frame_uid != 0 && !contains_u64(frame_uids, root_trigger_frame_uid)) {
+    const bool declared = contains_u64(declared_input_frames, root_trigger_frame_uid);
+    dependencies.push_back({{"kind", "frame"},
+                            {"role", "root_trigger"},
+                            {"frame_uid", root_trigger_frame_uid},
+                            {"status", declared ? "declared_external" : "missing"}});
+    if (!declared) {
+      degraded = true;
+      warnings.push_back({{"code", "episode_root_trigger_frame_missing"},
+                          {"episode_id", episode_id},
+                          {"frame_uid", root_trigger_frame_uid}});
+    }
+  }
+
+  for (const auto &frame : episode.frames) {
+    const auto frame_uid = u64_or(frame, "frame_uid");
+    const auto trigger_frame_uid = u64_or(frame, "trigger_frame_uid");
+    if (trigger_frame_uid == 0) {
+      continue;
+    }
+    if (contains_u64(frame_uids, trigger_frame_uid)) {
+      frame_edges.push_back({{"kind", "frame_trigger"},
+                             {"scope", "internal"},
+                             {"from_frame_uid", trigger_frame_uid},
+                             {"to_frame_uid", frame_uid}});
+      continue;
+    }
+    const bool declared = contains_u64(declared_input_frames, trigger_frame_uid);
+    dependencies.push_back({{"kind", "frame"},
+                            {"role", "trigger"},
+                            {"frame_uid", trigger_frame_uid},
+                            {"dependent_frame_uid", frame_uid},
+                            {"status", declared ? "declared_external" : "missing"}});
+    if (!declared) {
+      degraded = true;
+      warnings.push_back({{"code", "episode_trigger_frame_missing"},
+                          {"episode_id", episode_id},
+                          {"frame_uid", trigger_frame_uid},
+                          {"dependent_frame_uid", frame_uid}});
+    }
+  }
+
+  for (const auto &ref : episode.refs) {
+    const auto ref_kind = text_or(ref, "ref_kind");
+    if (ref_kind == "episode") {
+      const auto ref_uid = u64_or(ref, "ref_uid");
+      const bool present = ref_uid != 0 && folded.find(ref_uid) != folded.end();
+      const bool declared_external = ref_uid == 0 || !text_or(ref, "ref_id").empty();
+      const auto status = present ? "present" : (declared_external ? "declared_external" : "missing");
+      dependencies.push_back({{"kind", "episode"},
+                              {"role", "ref"},
+                              {"episode_id", ref_uid},
+                              {"ref_id", text_or(ref, "ref_id")},
+                              {"ref_hash", text_or(ref, "ref_hash")},
+                              {"status", status}});
+      if (!present && !declared_external) {
+        degraded = true;
+        warnings.push_back({{"code", "episode_dependency_missing"},
+                            {"episode_id", episode_id},
+                            {"dependency_episode_id", ref_uid},
+                            {"role", "ref"}});
+      }
+    } else if (ref_kind == "payload") {
+      const bool present = payload_ref_exists(runtime_dir, ref);
+      dependencies.push_back({{"kind", "payload"},
+                              {"role", "payload_ref"},
+                              {"ref_uid", u64_or(ref, "ref_uid")},
+                              {"ref_id", text_or(ref, "ref_id")},
+                              {"ref_hash", text_or(ref, "ref_hash")},
+                              {"status", present ? "present" : "missing"}});
+      if (!present) {
+        degraded = true;
+        warnings.push_back({{"code", "episode_payload_ref_missing"},
+                            {"episode_id", episode_id},
+                            {"ref_id", text_or(ref, "ref_id")},
+                            {"ref_hash", text_or(ref, "ref_hash")}});
+      }
+    } else if (ref_kind == "schema") {
+      dependencies.push_back({{"kind", "schema"},
+                              {"role", "schema_ref"},
+                              {"ref_uid", u64_or(ref, "ref_uid")},
+                              {"ref_id", text_or(ref, "ref_id")},
+                              {"ref_hash", text_or(ref, "ref_hash")},
+                              {"status", "declared"}});
+    }
+  }
+
+  return {{{
+               "schema",
+               "kungfu.episode.causal-graph/v1",
+           },
+           {"episode_id", episode_id},
+           {"frame_count", frame_uids.size()},
+           {"edge_count", frame_edges.size()},
+           {"dependency_count", dependencies.size()},
+           {"degraded", degraded},
+           {"edges", frame_edges},
+           {"dependencies", dependencies}},
+          dependencies,
+          warnings,
+          degraded};
+}
+
 } // namespace
 
 episode_manifest_store::episode_manifest_store(std::string runtime_dir) : runtime_dir_(std::move(runtime_dir)) {}
@@ -385,11 +576,14 @@ nlohmann::json episode_manifest_store::inspect(uint64_t episode_id) const {
             {"episode_id", episode_id},
             {"errors", nlohmann::json::array({{{"code", "episode_missing"}, {"episode_id", episode_id}}})}};
   }
+  const auto graph = build_causal_graph(runtime_dir_, episode_id, iter->second, folded);
   return {{"ok", true},
           {"schema", EPISODE_MANIFEST_SCHEMA_V1},
           {"runtime_dir", runtime_dir_},
           {"authority", "yijinjing-journal"},
           {"episode", iter->second.summary},
+          {"causal_graph", graph.graph},
+          {"dependencies", graph.dependencies},
           {"records", iter->second.records},
           {"frames", iter->second.frames},
           {"refs", iter->second.refs}};
@@ -401,6 +595,7 @@ nlohmann::json episode_manifest_store::fsck(uint64_t episode_id) const {
   nlohmann::json errors = nlohmann::json::array();
   nlohmann::json warnings = nlohmann::json::array();
   size_t checked = 0;
+  bool degraded = false;
   for (const auto &[current_episode_id, episode] : folded) {
     if (episode_id != 0 && current_episode_id != episode_id) {
       continue;
@@ -437,14 +632,21 @@ nlohmann::json episode_manifest_store::fsck(uint64_t episode_id) const {
       warnings.push_back(
           {{"code", "episode_closed_duplicate"}, {"episode_id", current_episode_id}, {"count", close_count}});
     }
+    const auto graph = build_causal_graph(runtime_dir_, current_episode_id, episode, folded);
+    degraded = degraded || graph.degraded;
+    for (const auto &warning : graph.warnings) {
+      warnings.push_back(warning);
+    }
   }
   if (episode_id != 0 && checked == 0) {
     errors.push_back({{"code", "episode_missing"}, {"episode_id", episode_id}});
   }
   return {{"ok", errors.empty()},
+          {"status", errors.empty() ? (degraded ? "degraded" : "ok") : "failed"},
           {"schema", EPISODE_MANIFEST_SCHEMA_V1},
           {"runtime_dir", runtime_dir_},
           {"authority", "yijinjing-journal"},
+          {"degraded", degraded},
           {"errors", errors},
           {"warnings", warnings},
           {"checked", {{"episode_manifest_records", records.size()}, {"episodes", checked}}}};

--- a/framework/core/tests/python/test_atlas_storage.py
+++ b/framework/core/tests/python/test_atlas_storage.py
@@ -540,6 +540,16 @@ def test_episode_manifest_v1_is_yijinjing_backed_and_fscked(tmp_path):
     assert episode["record_kind"] == "episode_open"
     assert episode["episode_id"] == 42
 
+    input_ref = storage_service.episode_attach_ref(
+        runtime_dir,
+        episode_id=42,
+        ref_kind="input_frame",
+        ref_uid=99,
+        ref_id="external-frame:99",
+    )
+    assert input_ref["record_kind"] == "episode_ref_attached"
+    assert input_ref["ref_kind"] == "input_frame"
+
     attached = storage_service.episode_attach_frame(
         runtime_dir,
         episode_id=42,
@@ -577,12 +587,17 @@ def test_episode_manifest_v1_is_yijinjing_backed_and_fscked(tmp_path):
     inspected = storage_service.episode_inspect(runtime_dir, episode_id=42)
     assert inspected["ok"]
     assert inspected["episode"]["status"] == "ended"
-    assert len(inspected["records"]) == 3
+    assert len(inspected["records"]) == 4
     assert inspected["frames"][0]["frame_uid"] == 100
+    assert inspected["causal_graph"]["schema"] == "kungfu.episode.causal-graph/v1"
+    assert inspected["causal_graph"]["degraded"] is False
+    assert inspected["dependencies"][0]["kind"] == "frame"
+    assert inspected["dependencies"][0]["status"] == "declared_external"
 
     fsck = storage_service.fsck(runtime_dir)
     assert fsck["ok"]
-    assert fsck["checked"]["episode_manifest_records"] == 3
+    assert fsck["status"] == "ok"
+    assert fsck["checked"]["episode_manifest_records"] == 4
     assert fsck["checked"]["episodes"] == 1
     assert fsck["episode_manifest"]["authority"] == "yijinjing-journal"
 
@@ -616,8 +631,84 @@ def test_episode_manifest_v1_is_yijinjing_backed_and_fscked(tmp_path):
     assert bundle["scope"] == "episode"
     assert bundle["episode_id"] == 42
     assert bundle["manifest"]["episode_id"] == 42
-    assert bundle["record_count"] == 3
+    assert bundle["causal_graph"]["degraded"] is False
+    assert bundle["dependencies"][0]["status"] == "declared_external"
+    assert bundle["record_count"] == 4
     assert bundle["frame_count"] == 1
+
+
+def test_episode_fsck_reports_degraded_causal_dependencies(tmp_path):
+    runtime_dir = tmp_path / "runtime"
+    storage_service.episode_begin(
+        runtime_dir,
+        episode_id=7,
+        parent_episode_id=999,
+        root_trigger_frame_uid=77,
+        title="degraded episode",
+        actor="pytest",
+        source="unit-test",
+        begin_time=1000,
+    )
+    storage_service.episode_attach_frame(
+        runtime_dir,
+        episode_id=7,
+        frame_uid=101,
+        trigger_frame_uid=77,
+        stream_id=7,
+        gen_time=1100,
+        carrier_type=10803,
+        source=1,
+        dest=0,
+        data_length=12,
+        integrity_version=2,
+        payload_checksum=123,
+        frame_checksum=456,
+    )
+    storage_service.episode_attach_ref(
+        runtime_dir,
+        episode_id=7,
+        ref_kind="payload",
+        ref_id="missing/payload.json",
+        ref_hash="sha256:missing",
+    )
+    storage_service.episode_attach_ref(
+        runtime_dir,
+        episode_id=7,
+        ref_kind="episode",
+        ref_uid=998,
+    )
+    storage_service.episode_end(
+        runtime_dir,
+        episode_id=7,
+        end_time=1200,
+        last_frame_uid=101,
+        frame_count=1,
+        reason="done",
+    )
+
+    inspected = storage_service.episode_inspect(runtime_dir, episode_id=7)
+    assert inspected["ok"]
+    assert inspected["causal_graph"]["degraded"] is True
+    assert {dependency["kind"] for dependency in inspected["dependencies"]} >= {
+        "episode",
+        "frame",
+        "payload",
+    }
+
+    fsck = storage_service.fsck(runtime_dir, episode_id=7)
+    assert fsck["ok"]
+    assert fsck["status"] == "degraded"
+    assert fsck["degraded"] is True
+    warning_codes = {warning["code"] for warning in fsck["warnings"]}
+    assert "episode_dependency_missing" in warning_codes
+    assert "episode_root_trigger_frame_missing" in warning_codes
+    assert "episode_trigger_frame_missing" in warning_codes
+    assert "episode_payload_ref_missing" in warning_codes
+
+    bundle = storage_service.build_export_bundle(runtime_dir, episode_id=7)
+    assert bundle["degraded"] is True
+    assert bundle["causal_graph"]["degraded"] is True
+    assert bundle["dependency_count"] == len(bundle["dependencies"])
 
 
 def test_payload_fsck_verifies_versioned_frame_checksums(tmp_path):


### PR DESCRIPTION
## Summary
- add kungfu.episode.causal-graph/v1 projection from the C++ yijinjing Episode manifest fold
- surface dependencies/degraded status through episode inspect, storage export, and fsck
- cover declared external triggers and degraded missing dependency/payload cases

## Validation
- ./kungfu-code build
- DYLD_FALLBACK_LIBRARY_PATH=dist/kungfu PYTHONPATH=src/python:dist/kungfu uv run --frozen pytest tests/python/test_atlas_storage.py -q
- node tests/fixtures/rewind-demo-happy/run.mjs
- ./kungfu-code check