### PR TITLE
feat(storage): add episode repair plans

### DIFF
--- a/.buildchain/kfd/kfd-2/claims/agent-onboarding-pack.json
+++ b/.buildchain/kfd/kfd-2/claims/agent-onboarding-pack.json
@@ -16,7 +16,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "26c2fe14d914c168904e6578ec632b117a8d88edb66f1771c521d25dddd82aad"
+        "sha256": "262d5bfaa06735304b810d4c7a6da7d7495a5d499dda47ab0835149a091c92fd"
       },
       "description": "Machine-readable command catalog and mode maturity metadata."
     },
@@ -54,7 +54,7 @@
     "evidenceSha256": [
       {
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "26c2fe14d914c168904e6578ec632b117a8d88edb66f1771c521d25dddd82aad"
+        "sha256": "262d5bfaa06735304b810d4c7a6da7d7495a5d499dda47ab0835149a091c92fd"
       },
       {
         "path": "framework/core/src/python/kungfu/agent/mode-selection.md",
@@ -76,7 +76,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "26c2fe14d914c168904e6578ec632b117a8d88edb66f1771c521d25dddd82aad"
+        "sha256": "262d5bfaa06735304b810d4c7a6da7d7495a5d499dda47ab0835149a091c92fd"
       }
     ]
   },
@@ -90,7 +90,7 @@
     {
       "name": "agent-command-catalog",
       "path": "framework/core/src/python/kungfu/agent/commands.json",
-      "sha256": "26c2fe14d914c168904e6578ec632b117a8d88edb66f1771c521d25dddd82aad",
+      "sha256": "262d5bfaa06735304b810d4c7a6da7d7495a5d499dda47ab0835149a091c92fd",
       "expectedPackagePath": "kungfu/agent/commands.json"
     }
   ],

--- a/.buildchain/kfd/kfd-2/claims/codex-report-receipts.json
+++ b/.buildchain/kfd/kfd-2/claims/codex-report-receipts.json
@@ -52,7 +52,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/skills/codex/SKILL.md",
-        "sha256": "5b5f2e7640a0e7edd52c28fea4cd8cb4d6f2db66140bd44327cc84fe10c6897c"
+        "sha256": "2f5047ca321f21befb77a488d1cc27700a0969d17865e79adeae55621cc9f086"
       },
       "description": "Codex-side report closeout gate instructions shipped in the agent pack."
     }
@@ -79,7 +79,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/skills/codex/SKILL.md",
-        "sha256": "5b5f2e7640a0e7edd52c28fea4cd8cb4d6f2db66140bd44327cc84fe10c6897c"
+        "sha256": "2f5047ca321f21befb77a488d1cc27700a0969d17865e79adeae55621cc9f086"
       }
     ],
     "artifactSha256": [
@@ -89,7 +89,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/skills/codex/SKILL.md",
-        "sha256": "5b5f2e7640a0e7edd52c28fea4cd8cb4d6f2db66140bd44327cc84fe10c6897c"
+        "sha256": "2f5047ca321f21befb77a488d1cc27700a0969d17865e79adeae55621cc9f086"
       }
     ]
   },
@@ -103,7 +103,7 @@
     {
       "name": "codex-agent-skill",
       "path": "framework/core/src/python/kungfu/agent/skills/codex/SKILL.md",
-      "sha256": "5b5f2e7640a0e7edd52c28fea4cd8cb4d6f2db66140bd44327cc84fe10c6897c",
+      "sha256": "2f5047ca321f21befb77a488d1cc27700a0969d17865e79adeae55621cc9f086",
       "expectedPackagePath": "kungfu/agent/skills/codex/SKILL.md"
     }
   ],

--- a/.buildchain/kfd/kfd-2/claims/remote-fact-boundary.json
+++ b/.buildchain/kfd/kfd-2/claims/remote-fact-boundary.json
@@ -34,7 +34,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "26c2fe14d914c168904e6578ec632b117a8d88edb66f1771c521d25dddd82aad"
+        "sha256": "262d5bfaa06735304b810d4c7a6da7d7495a5d499dda47ab0835149a091c92fd"
       },
       "description": "Remote add/sync command declarations and mode metadata."
     },
@@ -62,7 +62,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "26c2fe14d914c168904e6578ec632b117a8d88edb66f1771c521d25dddd82aad"
+        "sha256": "262d5bfaa06735304b810d4c7a6da7d7495a5d499dda47ab0835149a091c92fd"
       },
       {
         "path": "framework/core/src/python/kungfu/cli/commands/agent.py",

--- a/.buildchain/kfd/kfd-2/release-claims.json
+++ b/.buildchain/kfd/kfd-2/release-claims.json
@@ -29,7 +29,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/commands.json",
-            "sha256": "26c2fe14d914c168904e6578ec632b117a8d88edb66f1771c521d25dddd82aad"
+            "sha256": "262d5bfaa06735304b810d4c7a6da7d7495a5d499dda47ab0835149a091c92fd"
           },
           "description": "Machine-readable command catalog and mode maturity metadata."
         },
@@ -134,7 +134,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/skills/codex/SKILL.md",
-            "sha256": "5b5f2e7640a0e7edd52c28fea4cd8cb4d6f2db66140bd44327cc84fe10c6897c"
+            "sha256": "2f5047ca321f21befb77a488d1cc27700a0969d17865e79adeae55621cc9f086"
           },
           "description": "Codex-side report closeout gate instructions shipped in the agent pack."
         }
@@ -194,7 +194,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/commands.json",
-            "sha256": "26c2fe14d914c168904e6578ec632b117a8d88edb66f1771c521d25dddd82aad"
+            "sha256": "262d5bfaa06735304b810d4c7a6da7d7495a5d499dda47ab0835149a091c92fd"
           },
           "description": "Remote add/sync command declarations and mode metadata."
         },

--- a/.buildchain/kfd/kfd-3/capability-query.json
+++ b/.buildchain/kfd/kfd-3/capability-query.json
@@ -1089,6 +1089,28 @@
       "residualRisk": []
     },
     {
+      "id": "kungfu.storage.repair",
+      "kind": "cli",
+      "name": "kungfu storage repair --scope episode --episode-id <id> --plan --dry-run --json",
+      "state": "declared",
+      "detected": true,
+      "enforced": false,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "kfd1Basis": {
+        "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+        "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+        "digest": "sha256:6affebbd277dbdd968cac66e503b9baf2abb549ecae81421d51d2d8ff7a58f6e"
+      },
+      "kfd2Trust": {
+        "status": "release-passport-required",
+        "trustImpact": "query-release-passport-for-final-trust",
+        "residualRisk": []
+      },
+      "residualRisk": []
+    },
+    {
       "id": "kungfu.storage.status",
       "kind": "cli",
       "name": "kungfu storage status --scope all --json",

--- a/.buildchain/kfd/kfd-3/collaboration-interface.artifact.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.artifact.json
@@ -10,8 +10,8 @@
   "sourceRegistry": {
     "id": "kungfu",
     "path": ".buildchain/kfd/kfd-3/surfaces.json",
-    "sha256": "e696672e2ec55508d7b5777dee4f547bcccccdde9bed12d10962fa66c858d095",
-    "digest": "sha256:db19c80c37a6fd3283e8dea4ac8912f0e6b1185cb7813a61b18b44d6538e48fe"
+    "sha256": "2b182dcd56f312201cc2db008eadfa2e452d0e042a82b631acf02535499a0d89",
+    "digest": "sha256:86af49982c7b19d05e5e77de6b1f0869cfb20fe309258a8a4c0c37e5527f89cb"
   },
   "upstreamKfd": {
     "aggregatePath": "developer/sdk/kfd/upstream-aggregate.json",
@@ -28,7 +28,7 @@
     },
     "digest": "sha256:aaa0a429cd6211f6469bf16255172c0fcc26259da290ae7858704ca732d849e0"
   },
-  "collaborationInterfaceDigest": "sha256:e0c157538be41d310e8f812855f734a87102e8bed91e6b698392e7b7f41a11f0",
+  "collaborationInterfaceDigest": "sha256:d09798cf600bc7e6f9b0ae0f714ad9aec00aa27c01af989e145b1814fd4dd132",
   "exposedSurfaces": [
     {
       "id": "kungfu.agent",
@@ -1004,6 +1004,26 @@
       "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
       "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
       "maturity": "stable",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
+      "id": "kungfu.storage.repair",
+      "name": "kungfu storage repair --scope episode --episode-id <id> --plan --dry-run --json",
+      "kind": "cli",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
       "declaration": {
         "owner": "kungfu",
         "source": "scripts/buildchain-kfd-evidence.mjs",

--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -5,16 +5,16 @@
   "witnessKind": "prebuild",
   "supportLevel": "release",
   "source": {
-    "cwd": "/Users/dkr/Worktrees/kungfu/feature/buildchain-kfd-layout-2111",
-    "sourceSha": "62a54d3abef2ea105055ccf2cbd2d96af7dee5dd",
+    "cwd": "/Users/dkr/Worktrees/kungfu/feature/episode-repair-import-v1",
+    "sourceSha": "1151ac1575ac3815fb02fe163dde4fbf16b7a504",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
-    "registryDigest": "sha256:db19c80c37a6fd3283e8dea4ac8912f0e6b1185cb7813a61b18b44d6538e48fe"
+    "registryDigest": "sha256:86af49982c7b19d05e5e77de6b1f0869cfb20fe309258a8a4c0c37e5527f89cb"
   },
   "sourceRegistry": {
     "id": "kungfu",
     "path": ".buildchain/kfd/kfd-3/surfaces.json",
-    "sha256": "e696672e2ec55508d7b5777dee4f547bcccccdde9bed12d10962fa66c858d095",
-    "digest": "sha256:db19c80c37a6fd3283e8dea4ac8912f0e6b1185cb7813a61b18b44d6538e48fe"
+    "sha256": "2b182dcd56f312201cc2db008eadfa2e452d0e042a82b631acf02535499a0d89",
+    "digest": "sha256:86af49982c7b19d05e5e77de6b1f0869cfb20fe309258a8a4c0c37e5527f89cb"
   },
   "upstreamKfd": {
     "aggregatePath": "developer/sdk/kfd/upstream-aggregate.json",
@@ -34,7 +34,7 @@
   "expectedArtifactVerification": {
     "command": "node scripts/buildchain-kfd-evidence.mjs --artifact-witness --json"
   },
-  "collaborationInterfaceDigest": "sha256:e0c157538be41d310e8f812855f734a87102e8bed91e6b698392e7b7f41a11f0",
+  "collaborationInterfaceDigest": "sha256:d09798cf600bc7e6f9b0ae0f714ad9aec00aa27c01af989e145b1814fd4dd132",
   "collaborationInterface": {
     "schemaVersion": 1,
     "contract": "kungfu-buildchain-kfd-3-surface-registry",
@@ -1041,6 +1041,26 @@
         }
       },
       {
+        "id": "kungfu.storage.repair",
+        "name": "kungfu storage repair --scope episode --episode-id <id> --plan --dry-run --json",
+        "kind": "cli",
+        "participantProfile": "agent-or-developer",
+        "state": "declared",
+        "availability": "shipped",
+        "visibility": "public",
+        "participantFacing": true,
+        "public": true,
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+        "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+        "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+        "maturity": "experimental",
+        "declaration": {
+          "owner": "kungfu",
+          "source": "scripts/buildchain-kfd-evidence.mjs",
+          "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+        }
+      },
+      {
         "id": "kungfu.storage.status",
         "name": "kungfu storage status --scope all --json",
         "kind": "cli",
@@ -1123,8 +1143,8 @@
     ],
     "audit": {
       "status": "passed",
-      "declared": 53,
-      "artifactPublic": 53,
+      "declared": 54,
+      "artifactPublic": 54,
       "policy": {
         "sourceOfTruth": ".buildchain/kfd/kfd-3/surfaces.json",
         "detectedButUnregistered": "product-specific-audit",
@@ -2110,6 +2130,26 @@
       "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
       "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
       "maturity": "stable",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
+      "id": "kungfu.storage.repair",
+      "name": "kungfu storage repair --scope episode --episode-id <id> --plan --dry-run --json",
+      "kind": "cli",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
       "declaration": {
         "owner": "kungfu",
         "source": "scripts/buildchain-kfd-evidence.mjs",

--- a/.buildchain/kfd/kfd-3/surfaces.json
+++ b/.buildchain/kfd/kfd-3/surfaces.json
@@ -1049,6 +1049,26 @@
       }
     },
     {
+      "id": "kungfu.storage.repair",
+      "name": "kungfu storage repair --scope episode --episode-id <id> --plan --dry-run --json",
+      "kind": "cli",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
       "id": "kungfu.storage.status",
       "name": "kungfu storage status --scope all --json",
       "kind": "cli",

--- a/developer/sdk/kfd/kfd-2/claims/agent-onboarding-pack.json
+++ b/developer/sdk/kfd/kfd-2/claims/agent-onboarding-pack.json
@@ -16,7 +16,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "26c2fe14d914c168904e6578ec632b117a8d88edb66f1771c521d25dddd82aad"
+        "sha256": "262d5bfaa06735304b810d4c7a6da7d7495a5d499dda47ab0835149a091c92fd"
       },
       "description": "Machine-readable command catalog and mode maturity metadata."
     },
@@ -54,7 +54,7 @@
     "evidenceSha256": [
       {
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "26c2fe14d914c168904e6578ec632b117a8d88edb66f1771c521d25dddd82aad"
+        "sha256": "262d5bfaa06735304b810d4c7a6da7d7495a5d499dda47ab0835149a091c92fd"
       },
       {
         "path": "framework/core/src/python/kungfu/agent/mode-selection.md",
@@ -76,7 +76,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "26c2fe14d914c168904e6578ec632b117a8d88edb66f1771c521d25dddd82aad"
+        "sha256": "262d5bfaa06735304b810d4c7a6da7d7495a5d499dda47ab0835149a091c92fd"
       }
     ]
   },
@@ -90,7 +90,7 @@
     {
       "name": "agent-command-catalog",
       "path": "framework/core/src/python/kungfu/agent/commands.json",
-      "sha256": "26c2fe14d914c168904e6578ec632b117a8d88edb66f1771c521d25dddd82aad",
+      "sha256": "262d5bfaa06735304b810d4c7a6da7d7495a5d499dda47ab0835149a091c92fd",
       "expectedPackagePath": "kungfu/agent/commands.json"
     }
   ],

--- a/developer/sdk/kfd/kfd-2/claims/codex-report-receipts.json
+++ b/developer/sdk/kfd/kfd-2/claims/codex-report-receipts.json
@@ -52,7 +52,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/skills/codex/SKILL.md",
-        "sha256": "5b5f2e7640a0e7edd52c28fea4cd8cb4d6f2db66140bd44327cc84fe10c6897c"
+        "sha256": "2f5047ca321f21befb77a488d1cc27700a0969d17865e79adeae55621cc9f086"
       },
       "description": "Codex-side report closeout gate instructions shipped in the agent pack."
     }
@@ -79,7 +79,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/skills/codex/SKILL.md",
-        "sha256": "5b5f2e7640a0e7edd52c28fea4cd8cb4d6f2db66140bd44327cc84fe10c6897c"
+        "sha256": "2f5047ca321f21befb77a488d1cc27700a0969d17865e79adeae55621cc9f086"
       }
     ],
     "artifactSha256": [
@@ -89,7 +89,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/skills/codex/SKILL.md",
-        "sha256": "5b5f2e7640a0e7edd52c28fea4cd8cb4d6f2db66140bd44327cc84fe10c6897c"
+        "sha256": "2f5047ca321f21befb77a488d1cc27700a0969d17865e79adeae55621cc9f086"
       }
     ]
   },
@@ -103,7 +103,7 @@
     {
       "name": "codex-agent-skill",
       "path": "framework/core/src/python/kungfu/agent/skills/codex/SKILL.md",
-      "sha256": "5b5f2e7640a0e7edd52c28fea4cd8cb4d6f2db66140bd44327cc84fe10c6897c",
+      "sha256": "2f5047ca321f21befb77a488d1cc27700a0969d17865e79adeae55621cc9f086",
       "expectedPackagePath": "kungfu/agent/skills/codex/SKILL.md"
     }
   ],

--- a/developer/sdk/kfd/kfd-2/claims/remote-fact-boundary.json
+++ b/developer/sdk/kfd/kfd-2/claims/remote-fact-boundary.json
@@ -34,7 +34,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "26c2fe14d914c168904e6578ec632b117a8d88edb66f1771c521d25dddd82aad"
+        "sha256": "262d5bfaa06735304b810d4c7a6da7d7495a5d499dda47ab0835149a091c92fd"
       },
       "description": "Remote add/sync command declarations and mode metadata."
     },
@@ -62,7 +62,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "26c2fe14d914c168904e6578ec632b117a8d88edb66f1771c521d25dddd82aad"
+        "sha256": "262d5bfaa06735304b810d4c7a6da7d7495a5d499dda47ab0835149a091c92fd"
       },
       {
         "path": "framework/core/src/python/kungfu/cli/commands/agent.py",

--- a/developer/sdk/kfd/kfd-2/release-claims.json
+++ b/developer/sdk/kfd/kfd-2/release-claims.json
@@ -29,7 +29,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/commands.json",
-            "sha256": "26c2fe14d914c168904e6578ec632b117a8d88edb66f1771c521d25dddd82aad"
+            "sha256": "262d5bfaa06735304b810d4c7a6da7d7495a5d499dda47ab0835149a091c92fd"
           },
           "description": "Machine-readable command catalog and mode maturity metadata."
         },
@@ -134,7 +134,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/skills/codex/SKILL.md",
-            "sha256": "5b5f2e7640a0e7edd52c28fea4cd8cb4d6f2db66140bd44327cc84fe10c6897c"
+            "sha256": "2f5047ca321f21befb77a488d1cc27700a0969d17865e79adeae55621cc9f086"
           },
           "description": "Codex-side report closeout gate instructions shipped in the agent pack."
         }
@@ -194,7 +194,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/commands.json",
-            "sha256": "26c2fe14d914c168904e6578ec632b117a8d88edb66f1771c521d25dddd82aad"
+            "sha256": "262d5bfaa06735304b810d4c7a6da7d7495a5d499dda47ab0835149a091c92fd"
           },
           "description": "Remote add/sync command declarations and mode metadata."
         },

--- a/developer/sdk/kfd/kfd-3-surfaces.json
+++ b/developer/sdk/kfd/kfd-3-surfaces.json
@@ -1049,6 +1049,26 @@
       }
     },
     {
+      "id": "kungfu.storage.repair",
+      "name": "kungfu storage repair --scope episode --episode-id <id> --plan --dry-run --json",
+      "kind": "cli",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
       "id": "kungfu.storage.status",
       "name": "kungfu storage status --scope all --json",
       "kind": "cli",

--- a/docs/episode-object-model.md
+++ b/docs/episode-object-model.md
@@ -316,6 +316,17 @@ status while keeping `ok: true` when the manifest itself is readable. This gives
 repair/sync code a precise target without making the Episode disappear from
 inspection or export.
 
+`kungfu.storage.repair-plan/v1` is the first repair-facing projection over that
+diagnostic set. It maps the Episode warnings to read-only candidates such as
+`repair_episode_dependency`, `repair_episode_trigger_frame`, and
+`repair_episode_payload_ref`. Each candidate carries the original issue code,
+target kind, role, Episode/frame/payload id fields, and a suggested action. The
+plan is not authority and does not mutate storage; authority remains the
+yijinjing Episode manifest journal plus the referenced payload/frame evidence.
+Episode bundle import v1 similarly validates `kungfu.storage.episode-bundle/v1`
+and returns the folded causal graph, dependencies, and degraded evidence without
+materializing missing data into the local manifest journal.
+
 ## Migration Plan
 
 The migration can be staged without pretending the physical layout is already

--- a/docs/runtime-storage-service.md
+++ b/docs/runtime-storage-service.md
@@ -96,8 +96,8 @@ backend choices replaceable: a backend can change without changing the
 The first `libkungfu` provider slice exposes
 `kungfu::runtime::storage_service_api::storage_service` and the
 `kungfu.runtime.storage-service/v1` operation surface for `status`, `fsck`,
-`export_bundle`, `import_bundle`, `rebuild_index`, `gc_plan`, `compact_plan`,
-`verify_sync`, and read-only `query`. The current default backend is a content-addressed file
+`repair_plan`, `export_bundle`, `import_bundle`, `rebuild_index`, `gc_plan`,
+`compact_plan`, `verify_sync`, and read-only `query`. The current default backend is a content-addressed file
 provider implemented in C++ under the runtime service. A second C++ provider
 stores the same source registry, manifests, and payload bodies in RocksDB behind
 the identical service operations. Python storage commands are now compatibility
@@ -267,6 +267,13 @@ kungfu source fsck atlas-local --since 20d --json
 `fsck` reports degraded facts without rewriting them. A missing payload is not
 repaired by pretending it was absent; it is reported as missing until an import,
 repair, or redaction decision changes that state.
+
+`storage repair --plan --dry-run` is the read-only follow-up to fsck. It turns
+known degraded diagnostics into `kungfu.storage.repair-plan/v1` candidates with
+stable issue code, target kind, role, target id/hash fields, and suggested
+action. V1 deliberately does not fetch remote data, delete local data, compact
+providers, or mutate manifests. It only gives a future importer or remote sync
+source precise missing Episode, frame, or payload targets.
 
 ## Import And Export
 
@@ -488,6 +495,8 @@ kungfu storage status --scope all --json
 kungfu storage status --scope source --source <source-id> --json
 kungfu storage fsck --scope all --json
 kungfu storage fsck --scope source --source <source-id> --json
+kungfu storage repair --scope episode --episode-id <episode-id> \
+  --plan --dry-run --json
 kungfu storage export --scope source --source <source-id> \
   --format jsonl --out source.jsonl --json
 kungfu storage export --scope source --source <source-id> \
@@ -518,7 +527,7 @@ This slice includes a non-Atlas synthetic fixture that exercises manifest
 construction, accepted ranges, payload inventory, source-scoped fsck,
 range-limited export, bundle creation, and bundle import. It deliberately does
 not implement remote channel transport, conflict policy, destructive GC,
-compaction, repair, or a SQLite/RocksDB provider.
+automatic repair, or destructive compaction.
 
 ### Episode-Owned Storage Slice V1
 
@@ -534,6 +543,12 @@ selector in the runtime storage service:
   emits `kungfu.storage.episode-bundle/v1`, a folded export/debug bundle with
   the Episode manifest summary, manifest records, frame attachments, refs, and
   declared Episode dependencies.
+- `storage repair --scope episode --episode-id <id> --plan --dry-run --json`
+  maps degraded Episode causal graph warnings to read-only repair candidates.
+- `storage import --from episode.kfbundle.json --json` validates
+  `kungfu.storage.episode-bundle/v1` and preserves its causal graph,
+  dependencies, and degraded evidence in the import result. V1 does not yet
+  materialize that bundle into the local Episode manifest journal.
 
 This slice still does not move event mmap pages into Episode-owned physical
 directories. Frame membership is authoritative through

--- a/framework/core/src/libkungfu/include/kungfu/runtime/storage/service.h
+++ b/framework/core/src/libkungfu/include/kungfu/runtime/storage/service.h
@@ -16,6 +16,7 @@ inline constexpr const char *RUNTIME_STORAGE_SERVICE_OWNER = "libkungfu";
 enum class storage_operation {
   Status,
   Fsck,
+  RepairPlan,
   ExportBundle,
   ImportBundle,
   RebuildIndex,
@@ -60,6 +61,8 @@ public:
   [[nodiscard]] virtual nlohmann::json status(const storage_service_options &options) const = 0;
 
   [[nodiscard]] virtual nlohmann::json fsck(const storage_service_options &options) const = 0;
+
+  [[nodiscard]] virtual nlohmann::json repair_plan(const storage_service_options &options) const = 0;
 
   [[nodiscard]] virtual nlohmann::json export_bundle(const storage_service_options &options) const = 0;
 

--- a/framework/core/src/libkungfu/src/runtime/storage/service.cpp
+++ b/framework/core/src/libkungfu/src/runtime/storage/service.cpp
@@ -1481,6 +1481,130 @@ nlohmann::json episode_export_bundle_impl(const storage_service_options &options
           {"dependency_count", dependencies.size()}};
 }
 
+nlohmann::json fsck_impl(const storage_service_options &options);
+
+nlohmann::json repair_candidate_common(const nlohmann::json &warning, const std::string &code, const std::string &kind,
+                                       const std::string &role, const std::string &action,
+                                       nlohmann::json required_inputs) {
+  nlohmann::json candidate = {
+      {"code", code},           {"issue_code", text_or(warning, "code")},
+      {"kind", kind},           {"role", role},
+      {"action", action},       {"suggested_action", action},
+      {"safe_to_apply", false}, {"requires", std::move(required_inputs)},
+      {"warning", warning},
+  };
+  for (const auto *field : {"episode_id", "dependency_episode_id", "frame_uid", "dependent_frame_uid", "ref_id",
+                            "ref_hash", "source_id", "subject", "state", "path", "payload_hash"}) {
+    if (warning.contains(field) && !warning.at(field).is_null()) {
+      candidate[field] = warning.at(field);
+    }
+  }
+  return candidate;
+}
+
+nlohmann::json repair_candidate_from_warning(const nlohmann::json &warning) {
+  const auto code = text_or(warning, "code");
+  if (code == "episode_dependency_missing") {
+    return repair_candidate_common(warning, "repair_episode_dependency", "episode", text_or(warning, "role", "ref"),
+                                   "fetch_episode", nlohmann::json::array({"source_or_episode_bundle"}));
+  }
+  if (code == "episode_root_trigger_frame_missing") {
+    return repair_candidate_common(warning, "repair_episode_root_trigger_frame", "frame", "root_trigger",
+                                   "fetch_frame_or_declare_external_input",
+                                   nlohmann::json::array({"source_or_episode_bundle"}));
+  }
+  if (code == "episode_trigger_frame_missing") {
+    return repair_candidate_common(warning, "repair_episode_trigger_frame", "frame", "trigger",
+                                   "fetch_frame_or_declare_external_input",
+                                   nlohmann::json::array({"source_or_episode_bundle"}));
+  }
+  if (code == "episode_payload_ref_missing") {
+    return repair_candidate_common(warning, "repair_episode_payload_ref", "payload", "payload_ref",
+                                   "fetch_payload_by_hash", nlohmann::json::array({"payload_store_or_episode_bundle"}));
+  }
+  if (code == "payload_not_present") {
+    if (bool_or(warning, "intentional", true)) {
+      return nullptr;
+    }
+    return repair_candidate_common(warning, "repair_source_payload", "payload", "source_record",
+                                   "fetch_payload_by_hash", nlohmann::json::array({"source_or_bundle"}));
+  }
+  return nullptr;
+}
+
+nlohmann::json repair_plan_impl(const storage_service_options &options) {
+  if (!options.dry_run) {
+    throw std::invalid_argument("storage_repair_requires_dry_run");
+  }
+  const auto report = fsck_impl(options);
+  nlohmann::json candidates = nlohmann::json::array();
+  nlohmann::json unsupported = nlohmann::json::array();
+  for (const auto &warning : array_or_empty(report, "warnings")) {
+    const auto candidate = repair_candidate_from_warning(warning);
+    if (candidate.is_null()) {
+      unsupported.push_back(warning);
+    } else {
+      candidates.push_back(candidate);
+    }
+  }
+  return {{"ok", report.value("ok", false)},
+          {"schema", "kungfu.storage.repair-plan/v1"},
+          {"scope", report.value("scope", options.scope.empty() ? "all" : options.scope)},
+          {"source_id", report.contains("source_id") ? report.at("source_id") : nlohmann::json(nullptr)},
+          {"episode_id", report.contains("episode_id") ? report.at("episode_id") : nlohmann::json(nullptr)},
+          {"dry_run", true},
+          {"plan_only", true},
+          {"status", report.value("status", report.value("ok", false) ? "ok" : "failed")},
+          {"degraded", report.value("degraded", false)},
+          {"candidate_count", candidates.size()},
+          {"candidates", candidates},
+          {"unsupported", unsupported},
+          {"fsck", report},
+          {"notes", nlohmann::json::array({
+                        "Repair plan v1 is read-only and never fetches, deletes, compacts, or mutates storage.",
+                        "Candidates describe missing facts that a future importer or remote sync source may provide.",
+                    })}};
+}
+
+nlohmann::json episode_import_bundle_impl(const storage_service_options &options) {
+  if (!options.bundle.is_object() || text_or(options.bundle, "schema") != "kungfu.storage.episode-bundle/v1") {
+    throw std::invalid_argument("episode_bundle_invalid");
+  }
+  const auto manifest = object_or_empty(options.bundle, "manifest");
+  if (manifest.empty()) {
+    throw std::invalid_argument("episode_bundle_manifest_missing");
+  }
+  const auto causal_graph = object_or_empty(options.bundle, "causal_graph");
+  if (causal_graph.empty()) {
+    throw std::invalid_argument("episode_bundle_causal_graph_missing");
+  }
+  const auto records = array_or_empty(options.bundle, "records");
+  const auto frames = array_or_empty(options.bundle, "frames");
+  const auto refs = array_or_empty(options.bundle, "refs");
+  const auto dependencies = array_or_empty(options.bundle, "dependencies");
+  return {{"ok", true},
+          {"schema", "kungfu.storage.episode-import/v1"},
+          {"scope", "episode"},
+          {"episode_id", uint64_or(options.bundle, "episode_id", uint64_or(manifest, "episode_id"))},
+          {"dry_run", true},
+          {"accepted", false},
+          {"status", "validated"},
+          {"authority", "yijinjing-journal"},
+          {"degraded", bool_or(options.bundle, "degraded", bool_or(causal_graph, "degraded", false))},
+          {"manifest", manifest},
+          {"causal_graph", causal_graph},
+          {"dependencies", dependencies},
+          {"records", records.size()},
+          {"frames", frames.size()},
+          {"refs", refs.size()},
+          {"dependency_count", dependencies.size()},
+          {"notes",
+           nlohmann::json::array({
+               "Episode bundle import v1 validates and preserves causal evidence without writing the local manifest.",
+               "A later repair/import stage may materialize missing frames, payloads, or dependent Episodes.",
+           })}};
+}
+
 nlohmann::json replace_string_subtree(nlohmann::json value, const std::string &needle, const std::string &replacement) {
   if (needle.empty()) {
     return value;
@@ -2131,6 +2255,10 @@ public:
     return fsck_impl(options);
   }
 
+  [[nodiscard]] nlohmann::json repair_plan(const storage_service_options &options) const override {
+    return repair_plan_impl(options);
+  }
+
   [[nodiscard]] nlohmann::json export_bundle(const storage_service_options &options) const override {
     if (options.scope == "episode") {
       return episode_export_bundle_impl(options);
@@ -2178,6 +2306,9 @@ public:
   [[nodiscard]] nlohmann::json import_bundle(const storage_service_options &options) const override {
     if (!options.bundle.is_object()) {
       throw std::invalid_argument("bundle_manifest_missing");
+    }
+    if (options.scope == "episode" || text_or(options.bundle, "schema") == "kungfu.storage.episode-bundle/v1") {
+      return episode_import_bundle_impl(options);
     }
     const auto manifest = object_or_empty(options.bundle, "manifest");
     if (manifest.empty()) {
@@ -2356,6 +2487,7 @@ std::vector<std::string> storage_operation_names() {
   return {
       storage_operation_name(storage_operation::Status),
       storage_operation_name(storage_operation::Fsck),
+      storage_operation_name(storage_operation::RepairPlan),
       storage_operation_name(storage_operation::ExportBundle),
       storage_operation_name(storage_operation::ImportBundle),
       storage_operation_name(storage_operation::RebuildIndex),
@@ -2381,6 +2513,8 @@ std::string storage_operation_name(storage_operation operation) {
     return "status";
   case storage_operation::Fsck:
     return "fsck";
+  case storage_operation::RepairPlan:
+    return "repair_plan";
   case storage_operation::ExportBundle:
     return "export_bundle";
   case storage_operation::ImportBundle:
@@ -2423,6 +2557,9 @@ storage_operation parse_storage_operation(const std::string &operation) {
   }
   if (operation == "fsck") {
     return storage_operation::Fsck;
+  }
+  if (operation == "repair_plan") {
+    return storage_operation::RepairPlan;
   }
   if (operation == "export_bundle") {
     return storage_operation::ExportBundle;
@@ -2534,6 +2671,8 @@ nlohmann::json run_storage_service_operation(const std::string &operation, const
     return storage_service_instance().status(parsed_options);
   case storage_operation::Fsck:
     return storage_service_instance().fsck(parsed_options);
+  case storage_operation::RepairPlan:
+    return storage_service_instance().repair_plan(parsed_options);
   case storage_operation::ExportBundle:
     return storage_service_instance().export_bundle(parsed_options);
   case storage_operation::ImportBundle:

--- a/framework/core/src/python/kungfu/agent/brief.md
+++ b/framework/core/src/python/kungfu/agent/brief.md
@@ -48,6 +48,7 @@ snapshot it and verify the projection with:
 ```sh
 kungfu atlas import --repo <atlas-repo> --json
 kungfu storage fsck --scope all --json
+kungfu storage repair --scope episode --episode-id <id> --plan --dry-run --json
 kungfu storage verify-sync --source <source-id> --json
 kungfu atlas show import --json
 kungfu atlas show missions --json

--- a/framework/core/src/python/kungfu/agent/commands.json
+++ b/framework/core/src/python/kungfu/agent/commands.json
@@ -170,6 +170,12 @@
       "purpose": "Verify generic storage manifests, payload hashes, source registry drift, and orphan payload candidates."
     },
     {
+      "apiId": "kungfu.storage.repair",
+      "name": "kungfu storage repair --scope episode --episode-id <id> --plan --dry-run --json",
+      "maturity": "experimental",
+      "purpose": "Convert degraded storage and Episode fsck diagnostics into machine-readable repair candidates without mutating facts."
+    },
+    {
       "apiId": "kungfu.storage.rebuild-index",
       "name": "kungfu storage rebuild-index --scope all --dry-run --json",
       "maturity": "stable",

--- a/framework/core/src/python/kungfu/agent/kfd3_api.registry.json
+++ b/framework/core/src/python/kungfu/agent/kfd3_api.registry.json
@@ -304,6 +304,16 @@
       "projections": ["commands.json", "agent-pack-doc", "provider-skill"]
     },
     {
+      "id": "kungfu.storage.repair",
+      "surface": "cli",
+      "name": "kungfu storage repair --scope episode --episode-id <id> --plan --dry-run --json",
+      "purpose": "Convert degraded storage and Episode fsck diagnostics into machine-readable repair candidates without mutating facts.",
+      "maturity": "experimental",
+      "visibility": "adjacent-agent",
+      "anchor": { "kind": "catalog" },
+      "projections": ["commands.json", "agent-pack-doc", "provider-skill"]
+    },
+    {
       "id": "kungfu.storage.rebuild-index",
       "surface": "cli",
       "name": "kungfu storage rebuild-index --scope all --dry-run --json",

--- a/framework/core/src/python/kungfu/agent/skills/claude/SKILL.md
+++ b/framework/core/src/python/kungfu/agent/skills/claude/SKILL.md
@@ -47,6 +47,7 @@ For Atlas projection, the source repo remains authoritative. Import and verify:
 ```sh
 kungfu atlas import --repo <atlas-repo> --json
 kungfu storage fsck --scope all --json
+kungfu storage repair --scope episode --episode-id <id> --plan --dry-run --json
 kungfu storage verify-sync --source <source-id> --json
 kungfu atlas show import --json
 kungfu atlas show missions --json

--- a/framework/core/src/python/kungfu/agent/skills/codex/SKILL.md
+++ b/framework/core/src/python/kungfu/agent/skills/codex/SKILL.md
@@ -47,6 +47,7 @@ For Atlas projection, the source repo remains authoritative. Import and verify:
 ```sh
 kungfu atlas import --repo <atlas-repo> --json
 kungfu storage fsck --scope all --json
+kungfu storage repair --scope episode --episode-id <id> --plan --dry-run --json
 kungfu storage verify-sync --source <source-id> --json
 kungfu atlas show import --json
 kungfu atlas show missions --json

--- a/framework/core/src/python/kungfu/cli/commands/storage.py
+++ b/framework/core/src/python/kungfu/cli/commands/storage.py
@@ -136,6 +136,55 @@ def fsck(ctx, scope, storage_source_id, episode_id, as_json):
         sys.exit(1)
 
 
+@storage.command(help="plan read-only repairs for degraded runtime storage")
+@click.option("--scope", type=click.Choice(["source", "episode", "all"]), required=True)
+@click.option("--source", "storage_source_id", type=str, default=None)
+@click.option("--episode-id", type=int, default=0)
+@click.option("--plan", "plan_only", is_flag=True, help="emit a read-only repair plan")
+@click.option(
+    "--dry-run",
+    "dry_run",
+    is_flag=True,
+    help="required in v1; do not fetch, delete, compact, or mutate storage",
+)
+@click.option("--json", "as_json", is_flag=True, help="machine-readable output")
+@storage_command_context
+def repair(ctx, scope, storage_source_id, episode_id, plan_only, dry_run, as_json):
+    from kungfu.storage import service
+
+    if not plan_only:
+        click.echo("[storage] repair v1 requires --plan", err=True)
+        sys.exit(2)
+    if not dry_run:
+        click.echo("[storage] repair v1 requires --dry-run", err=True)
+        sys.exit(2)
+    if scope == "source":
+        _require_source(storage_source_id)
+    if scope == "episode" and not episode_id:
+        click.echo("[storage] --episode-id is required for --scope episode", err=True)
+        sys.exit(2)
+    result = service.repair_plan(
+        ctx.runtime_dir,
+        source_id=storage_source_id if scope == "source" else None,
+        episode_id=episode_id if scope == "episode" else None,
+        dry_run=dry_run,
+    )
+    if as_json:
+        _echo_json(result)
+        return
+    click.echo(
+        f"[storage] repair plan {scope}: "
+        f"{result.get('candidate_count', 0)} candidates, status={result.get('status')}"
+    )
+    for candidate in result.get("candidates", []):
+        click.echo(
+            "  candidate: "
+            f"{candidate.get('code')} -> {candidate.get('suggested_action')}"
+        )
+    if not result["ok"]:
+        sys.exit(1)
+
+
 @storage.command(help="export a storage scope")
 @click.option(
     "--scope", type=click.Choice(["atlas", "source", "episode"]), required=True

--- a/framework/core/src/python/kungfu/storage/service.py
+++ b/framework/core/src/python/kungfu/storage/service.py
@@ -26,6 +26,16 @@ def _u64(value: int | None) -> str:
     return str(value or 0)
 
 
+def _binding_json(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {key: _binding_json(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_binding_json(item) for item in value]
+    if isinstance(value, int) and not isinstance(value, bool) and value > 2**63 - 1:
+        return str(value)
+    return value
+
+
 def service_capabilities() -> dict[str, Any]:
     return dict(_runtime().storage_service_capabilities())
 
@@ -382,6 +392,28 @@ def fsck(
                 "scope": scope,
                 "source_id": source_id,
                 "episode_id": _u64(episode_id),
+            },
+        )
+    )
+
+
+def repair_plan(
+    runtime_dir: str | Path,
+    *,
+    source_id: str | None = None,
+    episode_id: int | None = None,
+    dry_run: bool = True,
+) -> dict[str, Any]:
+    scope = "episode" if episode_id else ("source" if source_id else "all")
+    return dict(
+        _runtime().run_storage_service_operation(
+            "repair_plan",
+            str(runtime_dir),
+            {
+                "scope": scope,
+                "source_id": source_id,
+                "episode_id": _u64(episode_id),
+                "dry_run": dry_run,
             },
         )
     )
@@ -805,15 +837,21 @@ def import_bundle(
     verify: bool = True,
 ) -> dict[str, Any]:
     source_id = str(bundle.get("source_id") or "")
+    scope = (
+        "episode"
+        if bundle.get("schema") == "kungfu.storage.episode-bundle/v1"
+        else "source"
+    )
     return dict(
         _runtime().run_storage_service_operation(
             "import_bundle",
             str(runtime_dir),
             {
-                "scope": "source" if source_id else "all",
+                "scope": scope if source_id or scope == "episode" else "all",
                 "source_id": source_id or None,
+                "episode_id": _u64(bundle.get("episode_id")),
                 "verify": verify,
-                "bundle": bundle,
+                "bundle": _binding_json(bundle),
             },
         )
     )

--- a/framework/core/tests/python/test_atlas_storage.py
+++ b/framework/core/tests/python/test_atlas_storage.py
@@ -364,6 +364,7 @@ def test_runtime_storage_service_surface_is_bound_from_libkungfu(tmp_path):
     assert set(capabilities["operations"]) == {
         "status",
         "fsck",
+        "repair_plan",
         "export_bundle",
         "import_bundle",
         "rebuild_index",
@@ -489,6 +490,7 @@ def test_python_storage_operations_enter_runtime_service_surface(tmp_path, monke
     storage_service.status(runtime_dir, source_id="local-synth")
     storage_service.layout(runtime_dir)
     storage_service.fsck(runtime_dir, source_id="local-synth")
+    storage_service.repair_plan(runtime_dir, source_id="local-synth", dry_run=True)
     storage_service.rebuild_index(runtime_dir, source_id="local-synth", dry_run=True)
     storage_service.rebuild_index(runtime_dir, source_id="local-synth", dry_run=False)
     storage_service.gc_plan(runtime_dir, dry_run=True)
@@ -516,6 +518,7 @@ def test_python_storage_operations_enter_runtime_service_surface(tmp_path, monke
         "status",
         "layout",
         "fsck",
+        "repair_plan",
         "rebuild_index",
         "gc_plan",
         "compact_plan",
@@ -709,6 +712,37 @@ def test_episode_fsck_reports_degraded_causal_dependencies(tmp_path):
     assert bundle["degraded"] is True
     assert bundle["causal_graph"]["degraded"] is True
     assert bundle["dependency_count"] == len(bundle["dependencies"])
+
+    imported = storage_service.import_bundle(tmp_path / "imported-runtime", bundle)
+    assert imported["schema"] == "kungfu.storage.episode-import/v1"
+    assert imported["scope"] == "episode"
+    assert imported["accepted"] is False
+    assert imported["degraded"] is True
+    assert imported["causal_graph"]["degraded"] is True
+    assert imported["dependency_count"] == len(bundle["dependencies"])
+
+    repair = storage_service.repair_plan(runtime_dir, episode_id=7, dry_run=True)
+    assert repair["schema"] == "kungfu.storage.repair-plan/v1"
+    assert repair["scope"] == "episode"
+    assert repair["episode_id"] == 7
+    assert repair["dry_run"] is True
+    assert repair["plan_only"] is True
+    assert repair["status"] == "degraded"
+    assert repair["degraded"] is True
+    assert repair["candidate_count"] >= 4
+    candidate_codes = {candidate["code"] for candidate in repair["candidates"]}
+    assert "repair_episode_dependency" in candidate_codes
+    assert "repair_episode_root_trigger_frame" in candidate_codes
+    assert "repair_episode_trigger_frame" in candidate_codes
+    assert "repair_episode_payload_ref" in candidate_codes
+    assert {candidate["kind"] for candidate in repair["candidates"]} >= {
+        "episode",
+        "frame",
+        "payload",
+    }
+    assert all(
+        candidate["safe_to_apply"] is False for candidate in repair["candidates"]
+    )
 
 
 def test_payload_fsck_verifies_versioned_frame_checksums(tmp_path):
@@ -1200,6 +1234,15 @@ def test_storage_fsck_reports_degraded_status_for_recorded_payload_states(tmp_pa
     }
     assert withheld["note:note-missing"] == ("missing", False)
     assert withheld["note:note-redacted"] == ("redacted", True)
+
+    repair = storage_service.repair_plan(
+        runtime_dir, source_id="degraded-synth", dry_run=True
+    )
+    assert repair["schema"] == "kungfu.storage.repair-plan/v1"
+    assert repair["status"] == "degraded"
+    assert repair["candidate_count"] == 1
+    assert repair["candidates"][0]["code"] == "repair_source_payload"
+    assert repair["candidates"][0]["subject"] == "note:note-missing"
 
     # A fully present source verifies as ok with an ok verdict.
     healthy_dir = tmp_path / "healthy"

--- a/framework/core/tests/storage-node-binding.test.js
+++ b/framework/core/tests/storage-node-binding.test.js
@@ -114,6 +114,11 @@ function selectedNodeResults(runtimeDir) {
       scope: 'source',
       source_id: 'node-synth',
     }),
+    repair: kungfu.runStorageServiceOperation('repair_plan', runtimeDir, {
+      scope: 'source',
+      source_id: 'node-synth',
+      dry_run: true,
+    }),
     exported: kungfu.exportStorageRecords(runtimeDir, 'node-synth', {
       since: '2026-07-09T00:00:00Z',
     }),
@@ -185,6 +190,7 @@ out = {
         config_home=str(Path(runtime_dir).parent / "config"),
     ),
     "fsck": service.fsck(runtime_dir, source_id="node-synth"),
+    "repair": service.repair_plan(runtime_dir, source_id="node-synth", dry_run=True),
     "exported": service.export_records(
         runtime_dir,
         source_id="node-synth",
@@ -311,6 +317,11 @@ for (const providerCase of providerCases) {
               : 'stateless-filesystem',
           );
           assert.equal(nodeResults.fsck.ok, true);
+          assert.equal(
+            nodeResults.repair.schema,
+            'kungfu.storage.repair-plan/v1',
+          );
+          assert.equal(nodeResults.repair.candidate_count, 0);
           assert.equal(nodeResults.bundle.records.length, 2);
           assert.equal(nodeResults.exported.length, 1);
           assert.equal(nodeResults.query.row_count, 2);


### PR DESCRIPTION
## Summary
- add C++ storage repair_plan operation for degraded Episode/source diagnostics
- expose read-only kungfu storage repair --plan --dry-run CLI
- validate Episode bundle import evidence without mutating the manifest journal

## Validation
- ./kungfu-code build
- ./kungfu-code check
- DYLD_FALLBACK_LIBRARY_PATH=dist/kungfu PYTHONPATH=src/python:dist/kungfu uv run --frozen pytest tests/python/test_atlas_storage.py -q
- KUNGFU_DIR=$PWD/dist/kungfu node --test tests/storage-node-binding.test.js
- CLI smoke: kungfu storage repair --scope episode --episode-id 7 --plan --dry-run --json