### PR TITLE
fix(slices): retarget capability slices to the yijinjing journal core

### DIFF
--- a/framework/core/slices/fact-ledger/export.cpp
+++ b/framework/core/slices/fact-ledger/export.cpp
@@ -31,7 +31,7 @@
 #include <string>
 #include <vector>
 
-using namespace kungfu::runtime;
+using namespace kungfu::yijinjing;
 namespace schema = kungfu::yijinjing;
 using kungfu::slices::sha256;
 
@@ -139,7 +139,7 @@ int main(int argc, char **argv) {
         {"trigger_frame_uid", trigger_frame_uid},
         {"gen_time", frame->gen_time()},
         {"trigger_time", frame->trigger_time()},
-        {"msg_type", frame->msg_type()},
+        {"msg_type", frame->carrier_type()},
         {"source", frame->source()},
         {"initial_source", frame->initial_source()},
         {"dest", frame->dest()},

--- a/framework/core/slices/fact-ledger/host.cpp
+++ b/framework/core/slices/fact-ledger/host.cpp
@@ -28,7 +28,7 @@
 #include <string>
 #include <vector>
 
-using namespace kungfu::runtime;
+using namespace kungfu::yijinjing;
 namespace schema = kungfu::yijinjing;
 using schema::enums::FrameDataType;
 

--- a/framework/core/slices/schema-registry/decoder.cpp
+++ b/framework/core/slices/schema-registry/decoder.cpp
@@ -30,7 +30,7 @@
 #include <map>
 #include <string>
 
-using namespace kungfu::runtime;
+using namespace kungfu::yijinjing;
 using kungfu::slices::sha256;
 namespace schema = kungfu::yijinjing;
 
@@ -100,9 +100,9 @@ int main(int argc, char **argv) {
   uint64_t last_uid = 0;
   while (reader.data_available()) {
     auto frame = reader.current_frame();
-    const auto it = bindings.find(frame->msg_type());
+    const auto it = bindings.find(frame->carrier_type());
     if (it == bindings.end()) {
-      std::cerr << "FAIL: no schema binding for msg_type " << frame->msg_type() << "\n";
+      std::cerr << "FAIL: no schema binding for msg_type " << frame->carrier_type() << "\n";
       return 1;
     }
     const Binding &b = it->second;
@@ -140,7 +140,7 @@ int main(int argc, char **argv) {
 
     nlohmann::json line = {
         {"seq", count},
-        {"msg_type", frame->msg_type()},
+        {"msg_type", frame->carrier_type()},
         {"type_name", b.name},
         {"schema_kind", b.kind},
         {"schema_version", b.version},

--- a/framework/core/slices/schema-registry/producer.cpp
+++ b/framework/core/slices/schema-registry/producer.cpp
@@ -29,7 +29,7 @@
 #include <iostream>
 #include <string>
 
-using namespace kungfu::runtime;
+using namespace kungfu::yijinjing;
 using kungfu::slices::sha256;
 namespace schema = kungfu::yijinjing;
 using schema::enums::FrameDataType;


### PR DESCRIPTION
The schema-registry and fact-ledger capability slices link only the yijinjing
static library, but four sources still opened with `using namespace
kungfu::runtime;` left over from the runtime/storage public-API split (only the
embedding slice was verified there). Those runtime data/journal/time aliases
come from <kungfu/runtime/common.h>, which the slices do not include, so the
names stopped resolving against their <kungfu/yijinjing/*> includes and
`cmake --build … -DKUNGFU_WITH_SLICES=ON` failed.

This retargets producer.cpp, decoder.cpp, host.cpp and export.cpp to
kungfu::yijinjing (matching their includes, link library, and the embedding
slice), and follows the frame `msg_type` -> `carrier_type` rename on the read
path. The emitted `msg_type` bundle field is unchanged.

Verified (KUNGFU_WITH_SLICES=ON): built all four targets; `node
slices/schema-registry/run.mjs build` passes; `fact_ledger_host` +
`fact_ledger_export` verified end-to-end (segment checksum + causal chain).