### PR TITLE
feat(storage): apply local episode repairs

### DIFF
--- a/.buildchain/kfd/kfd-2/claims/agent-onboarding-pack.json
+++ b/.buildchain/kfd/kfd-2/claims/agent-onboarding-pack.json
@@ -16,7 +16,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "262d5bfaa06735304b810d4c7a6da7d7495a5d499dda47ab0835149a091c92fd"
+        "sha256": "ef564727f7c6eed86ef01cbb5d64806012ba137a5cb867d1d32d3cd0d306b263"
       },
       "description": "Machine-readable command catalog and mode maturity metadata."
     },
@@ -54,7 +54,7 @@
     "evidenceSha256": [
       {
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "262d5bfaa06735304b810d4c7a6da7d7495a5d499dda47ab0835149a091c92fd"
+        "sha256": "ef564727f7c6eed86ef01cbb5d64806012ba137a5cb867d1d32d3cd0d306b263"
       },
       {
         "path": "framework/core/src/python/kungfu/agent/mode-selection.md",
@@ -76,7 +76,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "262d5bfaa06735304b810d4c7a6da7d7495a5d499dda47ab0835149a091c92fd"
+        "sha256": "ef564727f7c6eed86ef01cbb5d64806012ba137a5cb867d1d32d3cd0d306b263"
       }
     ]
   },
@@ -90,7 +90,7 @@
     {
       "name": "agent-command-catalog",
       "path": "framework/core/src/python/kungfu/agent/commands.json",
-      "sha256": "262d5bfaa06735304b810d4c7a6da7d7495a5d499dda47ab0835149a091c92fd",
+      "sha256": "ef564727f7c6eed86ef01cbb5d64806012ba137a5cb867d1d32d3cd0d306b263",
       "expectedPackagePath": "kungfu/agent/commands.json"
     }
   ],

--- a/.buildchain/kfd/kfd-2/claims/codex-report-receipts.json
+++ b/.buildchain/kfd/kfd-2/claims/codex-report-receipts.json
@@ -52,7 +52,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/skills/codex/SKILL.md",
-        "sha256": "2f5047ca321f21befb77a488d1cc27700a0969d17865e79adeae55621cc9f086"
+        "sha256": "5abf198330bc42bff0ee486b36fd89701f6bd59964422d4e28e7b17b4cfb8576"
       },
       "description": "Codex-side report closeout gate instructions shipped in the agent pack."
     }
@@ -79,7 +79,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/skills/codex/SKILL.md",
-        "sha256": "2f5047ca321f21befb77a488d1cc27700a0969d17865e79adeae55621cc9f086"
+        "sha256": "5abf198330bc42bff0ee486b36fd89701f6bd59964422d4e28e7b17b4cfb8576"
       }
     ],
     "artifactSha256": [
@@ -89,7 +89,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/skills/codex/SKILL.md",
-        "sha256": "2f5047ca321f21befb77a488d1cc27700a0969d17865e79adeae55621cc9f086"
+        "sha256": "5abf198330bc42bff0ee486b36fd89701f6bd59964422d4e28e7b17b4cfb8576"
       }
     ]
   },
@@ -103,7 +103,7 @@
     {
       "name": "codex-agent-skill",
       "path": "framework/core/src/python/kungfu/agent/skills/codex/SKILL.md",
-      "sha256": "2f5047ca321f21befb77a488d1cc27700a0969d17865e79adeae55621cc9f086",
+      "sha256": "5abf198330bc42bff0ee486b36fd89701f6bd59964422d4e28e7b17b4cfb8576",
       "expectedPackagePath": "kungfu/agent/skills/codex/SKILL.md"
     }
   ],

--- a/.buildchain/kfd/kfd-2/claims/remote-fact-boundary.json
+++ b/.buildchain/kfd/kfd-2/claims/remote-fact-boundary.json
@@ -34,7 +34,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "262d5bfaa06735304b810d4c7a6da7d7495a5d499dda47ab0835149a091c92fd"
+        "sha256": "ef564727f7c6eed86ef01cbb5d64806012ba137a5cb867d1d32d3cd0d306b263"
       },
       "description": "Remote add/sync command declarations and mode metadata."
     },
@@ -62,7 +62,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "262d5bfaa06735304b810d4c7a6da7d7495a5d499dda47ab0835149a091c92fd"
+        "sha256": "ef564727f7c6eed86ef01cbb5d64806012ba137a5cb867d1d32d3cd0d306b263"
       },
       {
         "path": "framework/core/src/python/kungfu/cli/commands/agent.py",

--- a/.buildchain/kfd/kfd-2/release-claims.json
+++ b/.buildchain/kfd/kfd-2/release-claims.json
@@ -29,7 +29,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/commands.json",
-            "sha256": "262d5bfaa06735304b810d4c7a6da7d7495a5d499dda47ab0835149a091c92fd"
+            "sha256": "ef564727f7c6eed86ef01cbb5d64806012ba137a5cb867d1d32d3cd0d306b263"
           },
           "description": "Machine-readable command catalog and mode maturity metadata."
         },
@@ -134,7 +134,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/skills/codex/SKILL.md",
-            "sha256": "2f5047ca321f21befb77a488d1cc27700a0969d17865e79adeae55621cc9f086"
+            "sha256": "5abf198330bc42bff0ee486b36fd89701f6bd59964422d4e28e7b17b4cfb8576"
           },
           "description": "Codex-side report closeout gate instructions shipped in the agent pack."
         }
@@ -194,7 +194,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/commands.json",
-            "sha256": "262d5bfaa06735304b810d4c7a6da7d7495a5d499dda47ab0835149a091c92fd"
+            "sha256": "ef564727f7c6eed86ef01cbb5d64806012ba137a5cb867d1d32d3cd0d306b263"
           },
           "description": "Remote add/sync command declarations and mode metadata."
         },

--- a/.buildchain/kfd/kfd-3/capability-query.json
+++ b/.buildchain/kfd/kfd-3/capability-query.json
@@ -1111,6 +1111,28 @@
       "residualRisk": []
     },
     {
+      "id": "kungfu.storage.repair.apply",
+      "kind": "cli",
+      "name": "kungfu storage repair --scope episode --episode-id <id> --apply --from <bundle.json> --dry-run --json",
+      "state": "declared",
+      "detected": true,
+      "enforced": false,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "kfd1Basis": {
+        "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+        "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+        "digest": "sha256:50d48d6cc90c14335bca695d93eda2f3c942bf81964fee6600dcafd963631f97"
+      },
+      "kfd2Trust": {
+        "status": "release-passport-required",
+        "trustImpact": "query-release-passport-for-final-trust",
+        "residualRisk": []
+      },
+      "residualRisk": []
+    },
+    {
       "id": "kungfu.storage.status",
       "kind": "cli",
       "name": "kungfu storage status --scope all --json",

--- a/.buildchain/kfd/kfd-3/collaboration-interface.artifact.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.artifact.json
@@ -10,8 +10,8 @@
   "sourceRegistry": {
     "id": "kungfu",
     "path": ".buildchain/kfd/kfd-3/surfaces.json",
-    "sha256": "2b182dcd56f312201cc2db008eadfa2e452d0e042a82b631acf02535499a0d89",
-    "digest": "sha256:86af49982c7b19d05e5e77de6b1f0869cfb20fe309258a8a4c0c37e5527f89cb"
+    "sha256": "cb5d10119888907da6f4cc32f9e3a5b3d77f07acff9e8ede2b1a93b7db2109ea",
+    "digest": "sha256:99f3698a746d07e6f9f323efb4e01adbfeb1742d1141c27876df4df7dd32a45f"
   },
   "upstreamKfd": {
     "aggregatePath": "developer/sdk/kfd/upstream-aggregate.json",
@@ -28,7 +28,7 @@
     },
     "digest": "sha256:aaa0a429cd6211f6469bf16255172c0fcc26259da290ae7858704ca732d849e0"
   },
-  "collaborationInterfaceDigest": "sha256:d09798cf600bc7e6f9b0ae0f714ad9aec00aa27c01af989e145b1814fd4dd132",
+  "collaborationInterfaceDigest": "sha256:ecd975ab0e39218014c40b62489972b90c02ee676f9ab6cbc7821eb74f24c627",
   "exposedSurfaces": [
     {
       "id": "kungfu.agent",
@@ -1013,6 +1013,26 @@
     {
       "id": "kungfu.storage.repair",
       "name": "kungfu storage repair --scope episode --episode-id <id> --plan --dry-run --json",
+      "kind": "cli",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
+      "id": "kungfu.storage.repair.apply",
+      "name": "kungfu storage repair --scope episode --episode-id <id> --apply --from <bundle.json> --dry-run --json",
       "kind": "cli",
       "participantProfile": "agent-or-developer",
       "state": "declared",

--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -5,16 +5,16 @@
   "witnessKind": "prebuild",
   "supportLevel": "release",
   "source": {
-    "cwd": "/Users/dkr/Worktrees/kungfu/feature/episode-repair-import-v1",
-    "sourceSha": "1151ac1575ac3815fb02fe163dde4fbf16b7a504",
+    "cwd": "/Users/dkr/Worktrees/kungfu/feature/episode-repair-apply-v1",
+    "sourceSha": "02f78ae593a3ed0bef5d7323bec29a11b045d852",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
-    "registryDigest": "sha256:86af49982c7b19d05e5e77de6b1f0869cfb20fe309258a8a4c0c37e5527f89cb"
+    "registryDigest": "sha256:99f3698a746d07e6f9f323efb4e01adbfeb1742d1141c27876df4df7dd32a45f"
   },
   "sourceRegistry": {
     "id": "kungfu",
     "path": ".buildchain/kfd/kfd-3/surfaces.json",
-    "sha256": "2b182dcd56f312201cc2db008eadfa2e452d0e042a82b631acf02535499a0d89",
-    "digest": "sha256:86af49982c7b19d05e5e77de6b1f0869cfb20fe309258a8a4c0c37e5527f89cb"
+    "sha256": "cb5d10119888907da6f4cc32f9e3a5b3d77f07acff9e8ede2b1a93b7db2109ea",
+    "digest": "sha256:99f3698a746d07e6f9f323efb4e01adbfeb1742d1141c27876df4df7dd32a45f"
   },
   "upstreamKfd": {
     "aggregatePath": "developer/sdk/kfd/upstream-aggregate.json",
@@ -34,7 +34,7 @@
   "expectedArtifactVerification": {
     "command": "node scripts/buildchain-kfd-evidence.mjs --artifact-witness --json"
   },
-  "collaborationInterfaceDigest": "sha256:d09798cf600bc7e6f9b0ae0f714ad9aec00aa27c01af989e145b1814fd4dd132",
+  "collaborationInterfaceDigest": "sha256:ecd975ab0e39218014c40b62489972b90c02ee676f9ab6cbc7821eb74f24c627",
   "collaborationInterface": {
     "schemaVersion": 1,
     "contract": "kungfu-buildchain-kfd-3-surface-registry",
@@ -1061,6 +1061,26 @@
         }
       },
       {
+        "id": "kungfu.storage.repair.apply",
+        "name": "kungfu storage repair --scope episode --episode-id <id> --apply --from <bundle.json> --dry-run --json",
+        "kind": "cli",
+        "participantProfile": "agent-or-developer",
+        "state": "declared",
+        "availability": "shipped",
+        "visibility": "public",
+        "participantFacing": true,
+        "public": true,
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+        "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+        "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+        "maturity": "experimental",
+        "declaration": {
+          "owner": "kungfu",
+          "source": "scripts/buildchain-kfd-evidence.mjs",
+          "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+        }
+      },
+      {
         "id": "kungfu.storage.status",
         "name": "kungfu storage status --scope all --json",
         "kind": "cli",
@@ -1143,8 +1163,8 @@
     ],
     "audit": {
       "status": "passed",
-      "declared": 54,
-      "artifactPublic": 54,
+      "declared": 55,
+      "artifactPublic": 55,
       "policy": {
         "sourceOfTruth": ".buildchain/kfd/kfd-3/surfaces.json",
         "detectedButUnregistered": "product-specific-audit",
@@ -2139,6 +2159,26 @@
     {
       "id": "kungfu.storage.repair",
       "name": "kungfu storage repair --scope episode --episode-id <id> --plan --dry-run --json",
+      "kind": "cli",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
+      "id": "kungfu.storage.repair.apply",
+      "name": "kungfu storage repair --scope episode --episode-id <id> --apply --from <bundle.json> --dry-run --json",
       "kind": "cli",
       "participantProfile": "agent-or-developer",
       "state": "declared",

--- a/.buildchain/kfd/kfd-3/surfaces.json
+++ b/.buildchain/kfd/kfd-3/surfaces.json
@@ -1069,6 +1069,26 @@
       }
     },
     {
+      "id": "kungfu.storage.repair.apply",
+      "name": "kungfu storage repair --scope episode --episode-id <id> --apply --from <bundle.json> --dry-run --json",
+      "kind": "cli",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
       "id": "kungfu.storage.status",
       "name": "kungfu storage status --scope all --json",
       "kind": "cli",

--- a/developer/sdk/kfd/kfd-2/claims/agent-onboarding-pack.json
+++ b/developer/sdk/kfd/kfd-2/claims/agent-onboarding-pack.json
@@ -16,7 +16,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "262d5bfaa06735304b810d4c7a6da7d7495a5d499dda47ab0835149a091c92fd"
+        "sha256": "ef564727f7c6eed86ef01cbb5d64806012ba137a5cb867d1d32d3cd0d306b263"
       },
       "description": "Machine-readable command catalog and mode maturity metadata."
     },
@@ -54,7 +54,7 @@
     "evidenceSha256": [
       {
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "262d5bfaa06735304b810d4c7a6da7d7495a5d499dda47ab0835149a091c92fd"
+        "sha256": "ef564727f7c6eed86ef01cbb5d64806012ba137a5cb867d1d32d3cd0d306b263"
       },
       {
         "path": "framework/core/src/python/kungfu/agent/mode-selection.md",
@@ -76,7 +76,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "262d5bfaa06735304b810d4c7a6da7d7495a5d499dda47ab0835149a091c92fd"
+        "sha256": "ef564727f7c6eed86ef01cbb5d64806012ba137a5cb867d1d32d3cd0d306b263"
       }
     ]
   },
@@ -90,7 +90,7 @@
     {
       "name": "agent-command-catalog",
       "path": "framework/core/src/python/kungfu/agent/commands.json",
-      "sha256": "262d5bfaa06735304b810d4c7a6da7d7495a5d499dda47ab0835149a091c92fd",
+      "sha256": "ef564727f7c6eed86ef01cbb5d64806012ba137a5cb867d1d32d3cd0d306b263",
       "expectedPackagePath": "kungfu/agent/commands.json"
     }
   ],

--- a/developer/sdk/kfd/kfd-2/claims/codex-report-receipts.json
+++ b/developer/sdk/kfd/kfd-2/claims/codex-report-receipts.json
@@ -52,7 +52,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/skills/codex/SKILL.md",
-        "sha256": "2f5047ca321f21befb77a488d1cc27700a0969d17865e79adeae55621cc9f086"
+        "sha256": "5abf198330bc42bff0ee486b36fd89701f6bd59964422d4e28e7b17b4cfb8576"
       },
       "description": "Codex-side report closeout gate instructions shipped in the agent pack."
     }
@@ -79,7 +79,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/skills/codex/SKILL.md",
-        "sha256": "2f5047ca321f21befb77a488d1cc27700a0969d17865e79adeae55621cc9f086"
+        "sha256": "5abf198330bc42bff0ee486b36fd89701f6bd59964422d4e28e7b17b4cfb8576"
       }
     ],
     "artifactSha256": [
@@ -89,7 +89,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/skills/codex/SKILL.md",
-        "sha256": "2f5047ca321f21befb77a488d1cc27700a0969d17865e79adeae55621cc9f086"
+        "sha256": "5abf198330bc42bff0ee486b36fd89701f6bd59964422d4e28e7b17b4cfb8576"
       }
     ]
   },
@@ -103,7 +103,7 @@
     {
       "name": "codex-agent-skill",
       "path": "framework/core/src/python/kungfu/agent/skills/codex/SKILL.md",
-      "sha256": "2f5047ca321f21befb77a488d1cc27700a0969d17865e79adeae55621cc9f086",
+      "sha256": "5abf198330bc42bff0ee486b36fd89701f6bd59964422d4e28e7b17b4cfb8576",
       "expectedPackagePath": "kungfu/agent/skills/codex/SKILL.md"
     }
   ],

--- a/developer/sdk/kfd/kfd-2/claims/remote-fact-boundary.json
+++ b/developer/sdk/kfd/kfd-2/claims/remote-fact-boundary.json
@@ -34,7 +34,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "262d5bfaa06735304b810d4c7a6da7d7495a5d499dda47ab0835149a091c92fd"
+        "sha256": "ef564727f7c6eed86ef01cbb5d64806012ba137a5cb867d1d32d3cd0d306b263"
       },
       "description": "Remote add/sync command declarations and mode metadata."
     },
@@ -62,7 +62,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "262d5bfaa06735304b810d4c7a6da7d7495a5d499dda47ab0835149a091c92fd"
+        "sha256": "ef564727f7c6eed86ef01cbb5d64806012ba137a5cb867d1d32d3cd0d306b263"
       },
       {
         "path": "framework/core/src/python/kungfu/cli/commands/agent.py",

--- a/developer/sdk/kfd/kfd-2/release-claims.json
+++ b/developer/sdk/kfd/kfd-2/release-claims.json
@@ -29,7 +29,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/commands.json",
-            "sha256": "262d5bfaa06735304b810d4c7a6da7d7495a5d499dda47ab0835149a091c92fd"
+            "sha256": "ef564727f7c6eed86ef01cbb5d64806012ba137a5cb867d1d32d3cd0d306b263"
           },
           "description": "Machine-readable command catalog and mode maturity metadata."
         },
@@ -134,7 +134,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/skills/codex/SKILL.md",
-            "sha256": "2f5047ca321f21befb77a488d1cc27700a0969d17865e79adeae55621cc9f086"
+            "sha256": "5abf198330bc42bff0ee486b36fd89701f6bd59964422d4e28e7b17b4cfb8576"
           },
           "description": "Codex-side report closeout gate instructions shipped in the agent pack."
         }
@@ -194,7 +194,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/commands.json",
-            "sha256": "262d5bfaa06735304b810d4c7a6da7d7495a5d499dda47ab0835149a091c92fd"
+            "sha256": "ef564727f7c6eed86ef01cbb5d64806012ba137a5cb867d1d32d3cd0d306b263"
           },
           "description": "Remote add/sync command declarations and mode metadata."
         },

--- a/developer/sdk/kfd/kfd-3-surfaces.json
+++ b/developer/sdk/kfd/kfd-3-surfaces.json
@@ -1069,6 +1069,26 @@
       }
     },
     {
+      "id": "kungfu.storage.repair.apply",
+      "name": "kungfu storage repair --scope episode --episode-id <id> --apply --from <bundle.json> --dry-run --json",
+      "kind": "cli",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
       "id": "kungfu.storage.status",
       "name": "kungfu storage status --scope all --json",
       "kind": "cli",

--- a/docs/episode-object-model.md
+++ b/docs/episode-object-model.md
@@ -323,9 +323,22 @@ diagnostic set. It maps the Episode warnings to read-only candidates such as
 target kind, role, Episode/frame/payload id fields, and a suggested action. The
 plan is not authority and does not mutate storage; authority remains the
 yijinjing Episode manifest journal plus the referenced payload/frame evidence.
-Episode bundle import v1 similarly validates `kungfu.storage.episode-bundle/v1`
-and returns the folded causal graph, dependencies, and degraded evidence without
-materializing missing data into the local manifest journal.
+
+`kungfu.storage.repair-apply/v1` is the first mutation-capable repair receipt,
+but it is still local-material only. It consumes an already available
+`kungfu.storage.episode-bundle/v1` or source export bundle, validates the
+material, defaults to dry-run, and writes only under `--execute`. For Episodes,
+it appends missing manifest records through the C++ yijinjing manifest store and
+skips already identified open/close/frame/ref records. For source payloads, it
+restores missing payload bodies only when the bytes match the manifest hash and
+length. It does not fetch remote evidence, delete data, compact providers, or
+rewrite intentional redaction/absence decisions.
+
+Episode bundle import v1 validates `kungfu.storage.episode-bundle/v1` and
+returns the folded causal graph, dependencies, and degraded evidence without
+materializing missing data into the local manifest journal. Materialization is a
+separate repair-apply operation so fsck, import, preview, and mutation remain
+auditable steps.
 
 ## Migration Plan
 

--- a/docs/runtime-storage-service.md
+++ b/docs/runtime-storage-service.md
@@ -275,6 +275,16 @@ action. V1 deliberately does not fetch remote data, delete local data, compact
 providers, or mutate manifests. It only gives a future importer or remote sync
 source precise missing Episode, frame, or payload targets.
 
+`storage repair --apply --from <json>` is the explicit local-material follow-up
+to that plan. It consumes a validated `kungfu.storage.episode-bundle/v1` or
+`kungfu.storage.export-bundle/v1` that the caller already has on disk. The
+command defaults to dry-run and reports `kungfu.storage.repair-apply/v1`; only
+`--execute` writes. V1 may append missing Episode manifest records or restore
+missing source payload bodies whose content hash and length match the local
+manifest. It still does not contact remotes, invent missing data, delete facts,
+compact providers, garbage collect payloads, or override intentional
+`redacted`/`absent` states.
+
 ## Import And Export
 
 Import/export should become the shared mechanism for:
@@ -497,6 +507,10 @@ kungfu storage fsck --scope all --json
 kungfu storage fsck --scope source --source <source-id> --json
 kungfu storage repair --scope episode --episode-id <episode-id> \
   --plan --dry-run --json
+kungfu storage repair --scope episode --episode-id <episode-id> \
+  --apply --from episode.kfbundle.json --dry-run --json
+kungfu storage repair --scope episode --episode-id <episode-id> \
+  --apply --from episode.kfbundle.json --execute --json
 kungfu storage export --scope source --source <source-id> \
   --format jsonl --out source.jsonl --json
 kungfu storage export --scope source --source <source-id> \
@@ -545,10 +559,15 @@ selector in the runtime storage service:
   declared Episode dependencies.
 - `storage repair --scope episode --episode-id <id> --plan --dry-run --json`
   maps degraded Episode causal graph warnings to read-only repair candidates.
+- `storage repair --scope episode --episode-id <id> --apply --from <bundle>
+  --dry-run|--execute --json` validates local Episode material and, only with
+  `--execute`, appends missing Episode manifest records while skipping records
+  already identified by the manifest.
 - `storage import --from episode.kfbundle.json --json` validates
   `kungfu.storage.episode-bundle/v1` and preserves its causal graph,
-  dependencies, and degraded evidence in the import result. V1 does not yet
-  materialize that bundle into the local Episode manifest journal.
+  dependencies, and degraded evidence in the import result. Materialization is
+  intentionally routed through the separate repair-apply command so mutation
+  remains explicit and previewable.
 
 This slice still does not move event mmap pages into Episode-owned physical
 directories. Frame membership is authoritative through

--- a/framework/core/src/libkungfu/include/kungfu/runtime/storage/service.h
+++ b/framework/core/src/libkungfu/include/kungfu/runtime/storage/service.h
@@ -17,6 +17,7 @@ enum class storage_operation {
   Status,
   Fsck,
   RepairPlan,
+  RepairApply,
   ExportBundle,
   ImportBundle,
   RebuildIndex,
@@ -63,6 +64,8 @@ public:
   [[nodiscard]] virtual nlohmann::json fsck(const storage_service_options &options) const = 0;
 
   [[nodiscard]] virtual nlohmann::json repair_plan(const storage_service_options &options) const = 0;
+
+  [[nodiscard]] virtual nlohmann::json repair_apply(const storage_service_options &options) const = 0;
 
   [[nodiscard]] virtual nlohmann::json export_bundle(const storage_service_options &options) const = 0;
 

--- a/framework/core/src/libkungfu/src/runtime/storage/service.cpp
+++ b/framework/core/src/libkungfu/src/runtime/storage/service.cpp
@@ -1482,6 +1482,8 @@ nlohmann::json episode_export_bundle_impl(const storage_service_options &options
 }
 
 nlohmann::json fsck_impl(const storage_service_options &options);
+nlohmann::json episode_import_bundle_impl(const storage_service_options &options);
+nlohmann::json load_latest_manifest_impl(const storage_provider &provider, const std::string &source_id);
 
 nlohmann::json repair_candidate_common(const nlohmann::json &warning, const std::string &code, const std::string &kind,
                                        const std::string &role, const std::string &action,
@@ -1563,6 +1565,284 @@ nlohmann::json repair_plan_impl(const storage_service_options &options) {
           {"notes", nlohmann::json::array({
                         "Repair plan v1 is read-only and never fetches, deletes, compacts, or mutates storage.",
                         "Candidates describe missing facts that a future importer or remote sync source may provide.",
+                    })}};
+}
+
+bool episode_record_kind_supported(const std::string &kind) {
+  return kind == "episode_open" || kind == "episode_heartbeat" || kind == "episode_frame_attached" ||
+         kind == "episode_ref_attached" || kind == "episode_closed";
+}
+
+std::string episode_record_identity_key(const nlohmann::json &record) {
+  const auto kind = text_or(record, "record_kind");
+  const auto episode_id = std::to_string(uint64_or(record, "episode_id"));
+  if (kind == "episode_open" || kind == "episode_closed") {
+    return kind + ":" + episode_id;
+  }
+  if (kind == "episode_frame_attached") {
+    return kind + ":" + episode_id + ":" + std::to_string(uint64_or(record, "frame_uid"));
+  }
+  if (kind == "episode_ref_attached") {
+    return kind + ":" + episode_id + ":" + text_or(record, "ref_kind") + ":" +
+           std::to_string(uint64_or(record, "ref_uid")) + ":" + text_or(record, "ref_id") + ":" +
+           text_or(record, "ref_hash");
+  }
+  return canonical_json(record);
+}
+
+nlohmann::json episode_apply_record(const storage_service_options &options, const nlohmann::json &record) {
+  const auto kind = text_or(record, "record_kind");
+  if (kind == "episode_open") {
+    return episode_store(options).begin(parse_episode_begin_options(record));
+  }
+  if (kind == "episode_heartbeat") {
+    return episode_store(options).heartbeat(parse_episode_heartbeat_options(record));
+  }
+  if (kind == "episode_frame_attached") {
+    return episode_store(options).attach_frame(parse_episode_frame_attach_options(record));
+  }
+  if (kind == "episode_ref_attached") {
+    return episode_store(options).attach_ref(parse_episode_ref_attach_options(record));
+  }
+  if (kind == "episode_closed") {
+    return episode_store(options).end(parse_episode_close_options(record, yy_enums::EpisodeStatus::Ended));
+  }
+  return nullptr;
+}
+
+nlohmann::json apply_episode_bundle_material(const storage_service_options &options, const nlohmann::json &bundle,
+                                             bool write) {
+  auto validation_options = options;
+  validation_options.scope = "episode";
+  validation_options.dry_run = true;
+  validation_options.bundle = bundle;
+  const auto validated = episode_import_bundle_impl(validation_options);
+  const auto bundle_episode_id =
+      uint64_or(bundle, "episode_id", uint64_or(object_or_empty(bundle, "manifest"), "episode_id"));
+  nlohmann::json existing_keys = nlohmann::json::array();
+  std::vector<std::string> seen;
+  if (bundle_episode_id != 0) {
+    const auto inspected = episode_store(options).inspect(bundle_episode_id);
+    for (const auto &existing : array_or_empty(inspected, "records")) {
+      const auto key = episode_record_identity_key(existing);
+      seen.push_back(key);
+      existing_keys.push_back(key);
+    }
+  }
+  nlohmann::json applied = nlohmann::json::array();
+  nlohmann::json skipped = nlohmann::json::array();
+  nlohmann::json rejected = nlohmann::json::array();
+  if (write) {
+    for (const auto &record : array_or_empty(bundle, "records")) {
+      const auto kind = text_or(record, "record_kind");
+      if (kind.empty()) {
+        rejected.push_back({{"kind", "episode_record"}, {"reason", "record_kind_missing"}, {"record", record}});
+      } else if (!episode_record_kind_supported(kind)) {
+        rejected.push_back({{"kind", "episode_record"}, {"reason", "unsupported_record_kind"}, {"record_kind", kind}});
+      }
+    }
+    if (!rejected.empty()) {
+      return {{"kind", "episode_bundle"},
+              {"schema", text_or(bundle, "schema")},
+              {"episode_id", bundle_episode_id == 0 ? nlohmann::json(nullptr) : nlohmann::json(bundle_episode_id)},
+              {"validated", validated},
+              {"existing_record_keys", existing_keys},
+              {"applied", applied},
+              {"skipped", skipped},
+              {"rejected", rejected}};
+    }
+  }
+  for (const auto &record : array_or_empty(bundle, "records")) {
+    const auto key = episode_record_identity_key(record);
+    if (std::find(seen.begin(), seen.end(), key) != seen.end()) {
+      skipped.push_back({{"kind", "episode_record"}, {"reason", "already_present"}, {"record", record}});
+      continue;
+    }
+    const auto kind = text_or(record, "record_kind");
+    if (kind.empty()) {
+      rejected.push_back({{"kind", "episode_record"}, {"reason", "record_kind_missing"}, {"record", record}});
+      continue;
+    }
+    if (write) {
+      const auto written = episode_apply_record(options, record);
+      if (written.is_null()) {
+        rejected.push_back({{"kind", "episode_record"}, {"reason", "unsupported_record_kind"}, {"record_kind", kind}});
+        continue;
+      }
+      applied.push_back({{"kind", "episode_record"}, {"record_kind", kind}, {"record", written}});
+    } else {
+      if (!episode_record_kind_supported(kind)) {
+        rejected.push_back({{"kind", "episode_record"}, {"reason", "unsupported_record_kind"}, {"record_kind", kind}});
+        continue;
+      }
+      applied.push_back({{"kind", "episode_record"}, {"record_kind", kind}, {"record", record}, {"dry_run", true}});
+    }
+  }
+  return {{"kind", "episode_bundle"},
+          {"schema", text_or(bundle, "schema")},
+          {"episode_id", bundle_episode_id == 0 ? nlohmann::json(nullptr) : nlohmann::json(bundle_episode_id)},
+          {"validated", validated},
+          {"existing_record_keys", existing_keys},
+          {"applied", applied},
+          {"skipped", skipped},
+          {"rejected", rejected}};
+}
+
+nlohmann::json apply_source_bundle_material(const storage_service_options &options, const nlohmann::json &bundle,
+                                            bool write) {
+  auto source_id = options.source_id.empty() ? text_or(bundle, "source_id") : options.source_id;
+  if (source_id.empty()) {
+    source_id = text_or(object_or_empty(bundle, "manifest"), "source_id");
+  }
+  if (source_id.empty()) {
+    throw std::invalid_argument("repair_apply_source_id_required");
+  }
+  const auto provider = make_provider(options);
+  auto manifest = load_latest_manifest_impl(*provider, source_id);
+  if (manifest.is_null()) {
+    throw std::runtime_error("manifest not found: " + source_id);
+  }
+  auto entries = entries_for_manifest(manifest);
+  nlohmann::json applied = nlohmann::json::array();
+  nlohmann::json skipped = nlohmann::json::array();
+  nlohmann::json rejected = nlohmann::json::array();
+  bool manifest_changed = false;
+  for (const auto &record : array_or_empty(bundle, "records")) {
+    if (!record.is_object() || !record.contains("payload")) {
+      skipped.push_back({{"kind", "payload"}, {"reason", "payload_missing_in_material"}, {"record", record}});
+      continue;
+    }
+    const auto raw = canonical_json(record.at("payload"));
+    auto digest = text_or(record, "payload_hash");
+    if (digest.empty()) {
+      digest = yy_storage::compute_content_hash_value(raw, yy_storage::CONTENT_HASH_ALGORITHM_SHA256);
+    }
+    const auto error =
+        yy_storage::verify_payload_ref(raw, digest, raw.size(), yy_storage::CONTENT_HASH_ALGORITHM_SHA256);
+    if (!error.empty()) {
+      rejected.push_back({{"kind", "payload"}, {"reason", error}, {"payload_hash", digest}});
+      continue;
+    }
+    bool matched = false;
+    for (auto &entry : entries) {
+      if (!entry.is_object() || text_or(entry, "payload_hash") != digest) {
+        continue;
+      }
+      matched = true;
+      if (text_or(entry, "payload_state") == PAYLOAD_STATE_PRESENT && provider->payload_exists(digest)) {
+        skipped.push_back({{"kind", "payload"}, {"reason", "already_present"}, {"payload_hash", digest}});
+        continue;
+      }
+      if (text_or(entry, "payload_state") == PAYLOAD_STATE_REDACTED ||
+          text_or(entry, "payload_state") == PAYLOAD_STATE_ABSENT) {
+        skipped.push_back({{"kind", "payload"}, {"reason", "intentional_non_present_state"}, {"payload_hash", digest}});
+        continue;
+      }
+      if (write) {
+        provider->write_payload(digest, raw);
+      }
+      entry["payload_state"] = PAYLOAD_STATE_PRESENT;
+      entry["byte_len"] = raw.size();
+      if (text_or(entry, "content_type").empty()) {
+        entry["content_type"] = CONTENT_TYPE_JSON;
+      }
+      manifest_changed = true;
+      applied.push_back({{"kind", "payload"},
+                         {"payload_hash", digest},
+                         {"subject", text_or(entry, "kind") + ":" + text_or(entry, "source_id")},
+                         {"dry_run", !write}});
+    }
+    if (!matched) {
+      rejected.push_back({{"kind", "payload"}, {"reason", "manifest_entry_missing"}, {"payload_hash", digest}});
+    }
+  }
+  nlohmann::json accepted = nullptr;
+  if (write && manifest_changed) {
+    auto repaired_input = manifest;
+    repaired_input["entries"] = entries;
+    repaired_input.erase("sync_root");
+    repaired_input.erase("accepted_ranges");
+    repaired_input.erase("payload_inventory");
+    repaired_input["manifest_id"] = text_or(manifest, "manifest_id") + ".repair";
+    accepted = yy_storage::build_storage_import_manifest(repaired_input);
+    provider->write_manifest(source_id, text_or(accepted, "manifest_id"), accepted);
+    provider->write_latest_manifest(source_id, accepted);
+    auto registry = provider->load_registry();
+    registry["sources"][source_id] = accepted.at("source");
+    provider->save_registry(registry);
+  }
+  return {{"kind", "source_bundle"},
+          {"schema", text_or(bundle, "schema")},
+          {"source_id", source_id},
+          {"manifest_changed", manifest_changed},
+          {"accepted_manifest", accepted},
+          {"applied", applied},
+          {"skipped", skipped},
+          {"rejected", rejected}};
+}
+
+nlohmann::json repair_apply_impl(const storage_service_options &options) {
+  const auto write = !options.dry_run;
+  auto plan_options = options;
+  plan_options.dry_run = true;
+  const auto plan = repair_plan_impl(plan_options);
+  auto material = options.bundle;
+  if (material.empty()) {
+    material = object_or_empty(options.operation_options, "repair_input");
+  }
+  if (material.empty()) {
+    material = object_or_empty(options.operation_options, "material");
+  }
+  if (material.empty()) {
+    throw std::invalid_argument("repair_apply_material_required");
+  }
+  nlohmann::json groups = nlohmann::json::array();
+  const auto apply_one = [&](const nlohmann::json &item) {
+    const auto schema = text_or(item, "schema");
+    if (schema == "kungfu.storage.episode-bundle/v1") {
+      return apply_episode_bundle_material(options, item, write);
+    }
+    if (schema == yy_storage::STORAGE_EXPORT_BUNDLE_SCHEMA_V1) {
+      return apply_source_bundle_material(options, item, write);
+    }
+    return nlohmann::json{{"kind", "unknown"},
+                          {"schema", schema},
+                          {"rejected", nlohmann::json::array({{{"reason", "unsupported_material_schema"}}})}};
+  };
+  if (material.contains("episode_bundles") || material.contains("source_bundles")) {
+    for (const auto &bundle : array_or_empty(material, "episode_bundles")) {
+      groups.push_back(apply_one(bundle));
+    }
+    for (const auto &bundle : array_or_empty(material, "source_bundles")) {
+      groups.push_back(apply_one(bundle));
+    }
+  } else {
+    groups.push_back(apply_one(material));
+  }
+  size_t applied_count = 0;
+  size_t skipped_count = 0;
+  size_t rejected_count = 0;
+  for (const auto &group : groups) {
+    applied_count += array_or_empty(group, "applied").size();
+    skipped_count += array_or_empty(group, "skipped").size();
+    rejected_count += array_or_empty(group, "rejected").size();
+  }
+  return {{"ok", rejected_count == 0},
+          {"schema", "kungfu.storage.repair-apply/v1"},
+          {"scope", options.scope.empty() ? "all" : options.scope},
+          {"source_id", options.source_id.empty() ? nlohmann::json(nullptr) : nlohmann::json(options.source_id)},
+          {"episode_id", options.episode_id == 0 ? nlohmann::json(nullptr) : nlohmann::json(options.episode_id)},
+          {"dry_run", options.dry_run},
+          {"applied", write},
+          {"status", rejected_count == 0 ? (write ? "applied" : "validated") : "rejected"},
+          {"plan", plan},
+          {"groups", groups},
+          {"applied_count", applied_count},
+          {"skipped_count", skipped_count},
+          {"rejected_count", rejected_count},
+          {"notes", nlohmann::json::array({
+                        "Repair apply v1 only consumes locally supplied material.",
+                        "It never fetches remote data, deletes, compacts, or garbage-collects storage.",
                     })}};
 }
 
@@ -1990,6 +2270,7 @@ nlohmann::json fsck_impl(const storage_service_options &options) {
         report["warnings"].push_back({{"code", "payload_not_present"},
                                       {"source_id", current_source_id},
                                       {"subject", text_or(entry, "kind") + ":" + text_or(entry, "source_id")},
+                                      {"payload_hash", text_or(entry, "payload_hash")},
                                       {"state", payload_state},
                                       {"intentional", intentional}});
         continue;
@@ -2259,6 +2540,10 @@ public:
     return repair_plan_impl(options);
   }
 
+  [[nodiscard]] nlohmann::json repair_apply(const storage_service_options &options) const override {
+    return repair_apply_impl(options);
+  }
+
   [[nodiscard]] nlohmann::json export_bundle(const storage_service_options &options) const override {
     if (options.scope == "episode") {
       return episode_export_bundle_impl(options);
@@ -2488,6 +2773,7 @@ std::vector<std::string> storage_operation_names() {
       storage_operation_name(storage_operation::Status),
       storage_operation_name(storage_operation::Fsck),
       storage_operation_name(storage_operation::RepairPlan),
+      storage_operation_name(storage_operation::RepairApply),
       storage_operation_name(storage_operation::ExportBundle),
       storage_operation_name(storage_operation::ImportBundle),
       storage_operation_name(storage_operation::RebuildIndex),
@@ -2515,6 +2801,8 @@ std::string storage_operation_name(storage_operation operation) {
     return "fsck";
   case storage_operation::RepairPlan:
     return "repair_plan";
+  case storage_operation::RepairApply:
+    return "repair_apply";
   case storage_operation::ExportBundle:
     return "export_bundle";
   case storage_operation::ImportBundle:
@@ -2560,6 +2848,9 @@ storage_operation parse_storage_operation(const std::string &operation) {
   }
   if (operation == "repair_plan") {
     return storage_operation::RepairPlan;
+  }
+  if (operation == "repair_apply") {
+    return storage_operation::RepairApply;
   }
   if (operation == "export_bundle") {
     return storage_operation::ExportBundle;
@@ -2673,6 +2964,8 @@ nlohmann::json run_storage_service_operation(const std::string &operation, const
     return storage_service_instance().fsck(parsed_options);
   case storage_operation::RepairPlan:
     return storage_service_instance().repair_plan(parsed_options);
+  case storage_operation::RepairApply:
+    return storage_service_instance().repair_apply(parsed_options);
   case storage_operation::ExportBundle:
     return storage_service_instance().export_bundle(parsed_options);
   case storage_operation::ImportBundle:

--- a/framework/core/src/python/kungfu/agent/brief.md
+++ b/framework/core/src/python/kungfu/agent/brief.md
@@ -49,6 +49,7 @@ snapshot it and verify the projection with:
 kungfu atlas import --repo <atlas-repo> --json
 kungfu storage fsck --scope all --json
 kungfu storage repair --scope episode --episode-id <id> --plan --dry-run --json
+kungfu storage repair --scope episode --episode-id <id> --apply --from <bundle.json> --dry-run --json
 kungfu storage verify-sync --source <source-id> --json
 kungfu atlas show import --json
 kungfu atlas show missions --json

--- a/framework/core/src/python/kungfu/agent/commands.json
+++ b/framework/core/src/python/kungfu/agent/commands.json
@@ -176,6 +176,12 @@
       "purpose": "Convert degraded storage and Episode fsck diagnostics into machine-readable repair candidates without mutating facts."
     },
     {
+      "apiId": "kungfu.storage.repair.apply",
+      "name": "kungfu storage repair --scope episode --episode-id <id> --apply --from <bundle.json> --dry-run --json",
+      "maturity": "experimental",
+      "purpose": "Validate local repair material and preview Episode manifest or payload restoration; use --execute only for explicit writes."
+    },
+    {
       "apiId": "kungfu.storage.rebuild-index",
       "name": "kungfu storage rebuild-index --scope all --dry-run --json",
       "maturity": "stable",

--- a/framework/core/src/python/kungfu/agent/kfd3_api.registry.json
+++ b/framework/core/src/python/kungfu/agent/kfd3_api.registry.json
@@ -314,6 +314,16 @@
       "projections": ["commands.json", "agent-pack-doc", "provider-skill"]
     },
     {
+      "id": "kungfu.storage.repair.apply",
+      "surface": "cli",
+      "name": "kungfu storage repair --scope episode --episode-id <id> --apply --from <bundle.json> --dry-run --json",
+      "purpose": "Validate local repair material and preview Episode manifest or payload restoration; use --execute only for explicit writes.",
+      "maturity": "experimental",
+      "visibility": "adjacent-agent",
+      "anchor": { "kind": "catalog" },
+      "projections": ["commands.json", "agent-pack-doc", "provider-skill"]
+    },
+    {
       "id": "kungfu.storage.rebuild-index",
       "surface": "cli",
       "name": "kungfu storage rebuild-index --scope all --dry-run --json",

--- a/framework/core/src/python/kungfu/agent/skills/claude/SKILL.md
+++ b/framework/core/src/python/kungfu/agent/skills/claude/SKILL.md
@@ -48,6 +48,7 @@ For Atlas projection, the source repo remains authoritative. Import and verify:
 kungfu atlas import --repo <atlas-repo> --json
 kungfu storage fsck --scope all --json
 kungfu storage repair --scope episode --episode-id <id> --plan --dry-run --json
+kungfu storage repair --scope episode --episode-id <id> --apply --from <bundle.json> --dry-run --json
 kungfu storage verify-sync --source <source-id> --json
 kungfu atlas show import --json
 kungfu atlas show missions --json

--- a/framework/core/src/python/kungfu/agent/skills/codex/SKILL.md
+++ b/framework/core/src/python/kungfu/agent/skills/codex/SKILL.md
@@ -48,6 +48,7 @@ For Atlas projection, the source repo remains authoritative. Import and verify:
 kungfu atlas import --repo <atlas-repo> --json
 kungfu storage fsck --scope all --json
 kungfu storage repair --scope episode --episode-id <id> --plan --dry-run --json
+kungfu storage repair --scope episode --episode-id <id> --apply --from <bundle.json> --dry-run --json
 kungfu storage verify-sync --source <source-id> --json
 kungfu atlas show import --json
 kungfu atlas show missions --json

--- a/framework/core/src/python/kungfu/cli/commands/storage.py
+++ b/framework/core/src/python/kungfu/cli/commands/storage.py
@@ -142,44 +142,100 @@ def fsck(ctx, scope, storage_source_id, episode_id, as_json):
 @click.option("--episode-id", type=int, default=0)
 @click.option("--plan", "plan_only", is_flag=True, help="emit a read-only repair plan")
 @click.option(
+    "--apply",
+    "apply_requested",
+    is_flag=True,
+    help="validate or apply local repair material",
+)
+@click.option(
+    "--from", "from_path", type=str, default=None, help="repair material JSON path"
+)
+@click.option(
     "--dry-run",
     "dry_run",
     is_flag=True,
-    help="required in v1; do not fetch, delete, compact, or mutate storage",
+    help="do not fetch, delete, compact, or mutate storage",
+)
+@click.option(
+    "--execute", "execute", is_flag=True, help="write validated local repair material"
 )
 @click.option("--json", "as_json", is_flag=True, help="machine-readable output")
 @storage_command_context
-def repair(ctx, scope, storage_source_id, episode_id, plan_only, dry_run, as_json):
+def repair(
+    ctx,
+    scope,
+    storage_source_id,
+    episode_id,
+    plan_only,
+    apply_requested,
+    from_path,
+    dry_run,
+    execute,
+    as_json,
+):
     from kungfu.storage import service
 
-    if not plan_only:
-        click.echo("[storage] repair v1 requires --plan", err=True)
+    if plan_only and apply_requested:
+        click.echo("[storage] choose either --plan or --apply", err=True)
         sys.exit(2)
-    if not dry_run:
-        click.echo("[storage] repair v1 requires --dry-run", err=True)
+    if not plan_only and not apply_requested:
+        click.echo("[storage] repair v1 requires --plan or --apply", err=True)
         sys.exit(2)
     if scope == "source":
         _require_source(storage_source_id)
     if scope == "episode" and not episode_id:
         click.echo("[storage] --episode-id is required for --scope episode", err=True)
         sys.exit(2)
-    result = service.repair_plan(
-        ctx.runtime_dir,
-        source_id=storage_source_id if scope == "source" else None,
-        episode_id=episode_id if scope == "episode" else None,
-        dry_run=dry_run,
-    )
+    if plan_only:
+        if not dry_run:
+            click.echo("[storage] repair plan requires --dry-run", err=True)
+            sys.exit(2)
+        result = service.repair_plan(
+            ctx.runtime_dir,
+            source_id=storage_source_id if scope == "source" else None,
+            episode_id=episode_id if scope == "episode" else None,
+            dry_run=True,
+        )
+    else:
+        if not from_path:
+            click.echo("[storage] repair apply requires --from <json>", err=True)
+            sys.exit(2)
+        if dry_run and execute:
+            click.echo("[storage] choose either --dry-run or --execute", err=True)
+            sys.exit(2)
+        try:
+            with open(from_path, encoding="utf-8") as f:
+                repair_input = json.load(f)
+        except (OSError, ValueError) as e:
+            click.echo(f"[storage] {e}", err=True)
+            sys.exit(1)
+        result = service.repair_apply(
+            ctx.runtime_dir,
+            repair_input,
+            source_id=storage_source_id if scope == "source" else None,
+            episode_id=episode_id if scope == "episode" else None,
+            dry_run=not execute,
+        )
     if as_json:
         _echo_json(result)
         return
-    click.echo(
-        f"[storage] repair plan {scope}: "
-        f"{result.get('candidate_count', 0)} candidates, status={result.get('status')}"
-    )
-    for candidate in result.get("candidates", []):
+    if plan_only:
         click.echo(
-            "  candidate: "
-            f"{candidate.get('code')} -> {candidate.get('suggested_action')}"
+            f"[storage] repair plan {scope}: "
+            f"{result.get('candidate_count', 0)} candidates, status={result.get('status')}"
+        )
+        for candidate in result.get("candidates", []):
+            click.echo(
+                "  candidate: "
+                f"{candidate.get('code')} -> {candidate.get('suggested_action')}"
+            )
+    else:
+        click.echo(
+            f"[storage] repair apply {scope}: "
+            f"applied={result.get('applied_count', 0)} "
+            f"skipped={result.get('skipped_count', 0)} "
+            f"rejected={result.get('rejected_count', 0)} "
+            f"status={result.get('status')}"
         )
     if not result["ok"]:
         sys.exit(1)

--- a/framework/core/src/python/kungfu/storage/service.py
+++ b/framework/core/src/python/kungfu/storage/service.py
@@ -419,6 +419,30 @@ def repair_plan(
     )
 
 
+def repair_apply(
+    runtime_dir: str | Path,
+    repair_input: dict[str, Any],
+    *,
+    source_id: str | None = None,
+    episode_id: int | None = None,
+    dry_run: bool = True,
+) -> dict[str, Any]:
+    scope = "episode" if episode_id else ("source" if source_id else "all")
+    return dict(
+        _runtime().run_storage_service_operation(
+            "repair_apply",
+            str(runtime_dir),
+            {
+                "scope": scope,
+                "source_id": source_id,
+                "episode_id": _u64(episode_id),
+                "dry_run": dry_run,
+                "bundle": _binding_json(repair_input),
+            },
+        )
+    )
+
+
 def rebuild_index(
     runtime_dir: str | Path,
     *,

--- a/framework/core/tests/python/test_atlas_storage.py
+++ b/framework/core/tests/python/test_atlas_storage.py
@@ -365,6 +365,7 @@ def test_runtime_storage_service_surface_is_bound_from_libkungfu(tmp_path):
         "status",
         "fsck",
         "repair_plan",
+        "repair_apply",
         "export_bundle",
         "import_bundle",
         "rebuild_index",
@@ -491,6 +492,12 @@ def test_python_storage_operations_enter_runtime_service_surface(tmp_path, monke
     storage_service.layout(runtime_dir)
     storage_service.fsck(runtime_dir, source_id="local-synth")
     storage_service.repair_plan(runtime_dir, source_id="local-synth", dry_run=True)
+    storage_service.repair_apply(
+        runtime_dir,
+        storage_service.build_export_bundle(runtime_dir, source_id="local-synth"),
+        source_id="local-synth",
+        dry_run=True,
+    )
     storage_service.rebuild_index(runtime_dir, source_id="local-synth", dry_run=True)
     storage_service.rebuild_index(runtime_dir, source_id="local-synth", dry_run=False)
     storage_service.gc_plan(runtime_dir, dry_run=True)
@@ -519,6 +526,7 @@ def test_python_storage_operations_enter_runtime_service_surface(tmp_path, monke
         "layout",
         "fsck",
         "repair_plan",
+        "repair_apply",
         "rebuild_index",
         "gc_plan",
         "compact_plan",
@@ -743,6 +751,91 @@ def test_episode_fsck_reports_degraded_causal_dependencies(tmp_path):
     assert all(
         candidate["safe_to_apply"] is False for candidate in repair["candidates"]
     )
+
+    donor_dir = tmp_path / "donor-runtime"
+    storage_service.episode_begin(
+        donor_dir,
+        episode_id=7,
+        parent_episode_id=999,
+        root_trigger_frame_uid=77,
+        title="degraded episode",
+        actor="pytest",
+        source="unit-test",
+        begin_time=1000,
+    )
+    storage_service.episode_attach_frame(
+        donor_dir,
+        episode_id=7,
+        frame_uid=77,
+        stream_id=7,
+        gen_time=1050,
+        carrier_type=10803,
+        source=1,
+        dest=0,
+        data_length=8,
+        integrity_version=2,
+        payload_checksum=111,
+        frame_checksum=222,
+    )
+    storage_service.episode_attach_frame(
+        donor_dir,
+        episode_id=7,
+        frame_uid=101,
+        trigger_frame_uid=77,
+        stream_id=7,
+        gen_time=1100,
+        carrier_type=10803,
+        source=1,
+        dest=0,
+        data_length=12,
+        integrity_version=2,
+        payload_checksum=123,
+        frame_checksum=456,
+    )
+    storage_service.episode_attach_ref(
+        donor_dir,
+        episode_id=7,
+        ref_kind="payload",
+        ref_id="missing/payload.json",
+        ref_hash="sha256:missing",
+    )
+    storage_service.episode_attach_ref(
+        donor_dir,
+        episode_id=7,
+        ref_kind="episode",
+        ref_uid=998,
+    )
+    storage_service.episode_end(
+        donor_dir,
+        episode_id=7,
+        end_time=1200,
+        last_frame_uid=101,
+        frame_count=2,
+        reason="done",
+    )
+    repair_bundle = storage_service.build_export_bundle(donor_dir, episode_id=7)
+
+    dry_apply = storage_service.repair_apply(
+        runtime_dir, repair_bundle, episode_id=7, dry_run=True
+    )
+    assert dry_apply["schema"] == "kungfu.storage.repair-apply/v1"
+    assert dry_apply["dry_run"] is True
+    assert dry_apply["applied"] is False
+    assert dry_apply["applied_count"] >= 1
+    assert storage_service.fsck(runtime_dir, episode_id=7)["status"] == "degraded"
+
+    applied = storage_service.repair_apply(
+        runtime_dir, repair_bundle, episode_id=7, dry_run=False
+    )
+    assert applied["schema"] == "kungfu.storage.repair-apply/v1"
+    assert applied["applied"] is True
+    assert applied["applied_count"] >= 1
+    repaired_warning_codes = {
+        warning["code"]
+        for warning in storage_service.fsck(runtime_dir, episode_id=7)["warnings"]
+    }
+    assert "episode_root_trigger_frame_missing" not in repaired_warning_codes
+    assert "episode_trigger_frame_missing" not in repaired_warning_codes
 
 
 def test_payload_fsck_verifies_versioned_frame_checksums(tmp_path):
@@ -1243,6 +1336,37 @@ def test_storage_fsck_reports_degraded_status_for_recorded_payload_states(tmp_pa
     assert repair["candidate_count"] == 1
     assert repair["candidates"][0]["code"] == "repair_source_payload"
     assert repair["candidates"][0]["subject"] == "note:note-missing"
+    assert repair["candidates"][0]["payload_hash"]
+
+    material = storage_service.build_export_bundle(
+        runtime_dir, source_id="degraded-synth"
+    )
+    dry_apply = storage_service.repair_apply(
+        runtime_dir, material, source_id="degraded-synth", dry_run=True
+    )
+    assert dry_apply["schema"] == "kungfu.storage.repair-apply/v1"
+    assert dry_apply["dry_run"] is True
+    assert dry_apply["applied"] is False
+    assert dry_apply["applied_count"] >= 1
+    assert (
+        storage_service.fsck(runtime_dir, source_id="degraded-synth")["status"]
+        == "degraded"
+    )
+
+    applied = storage_service.repair_apply(
+        runtime_dir, material, source_id="degraded-synth", dry_run=False
+    )
+    assert applied["applied"] is True
+    assert applied["applied_count"] >= 1
+    repaired = storage_service.fsck(runtime_dir, source_id="degraded-synth")
+    assert repaired["ok"]
+    assert repaired["status"] == "ok"
+    warning_subjects = {
+        warning["subject"]
+        for warning in repaired["warnings"]
+        if warning["code"] == "payload_not_present"
+    }
+    assert "note:note-missing" not in warning_subjects
 
     # A fully present source verifies as ok with an ok verdict.
     healthy_dir = tmp_path / "healthy"

--- a/framework/core/tests/storage-node-binding.test.js
+++ b/framework/core/tests/storage-node-binding.test.js
@@ -91,6 +91,14 @@ function writeNodeFixture(runtimeDir) {
 }
 
 function selectedNodeResults(runtimeDir) {
+  const bundle = kungfu.runStorageServiceOperation(
+    'export_bundle',
+    runtimeDir,
+    {
+      scope: 'source',
+      source_id: 'node-synth',
+    },
+  );
   return {
     capabilities: kungfu.storageServiceCapabilities(),
     optionRequest: kungfu.makeStorageServiceRequest('status', runtimeDir, {
@@ -119,13 +127,16 @@ function selectedNodeResults(runtimeDir) {
       source_id: 'node-synth',
       dry_run: true,
     }),
+    repairApply: kungfu.runStorageServiceOperation('repair_apply', runtimeDir, {
+      scope: 'source',
+      source_id: 'node-synth',
+      dry_run: true,
+      bundle,
+    }),
     exported: kungfu.exportStorageRecords(runtimeDir, 'node-synth', {
       since: '2026-07-09T00:00:00Z',
     }),
-    bundle: kungfu.runStorageServiceOperation('export_bundle', runtimeDir, {
-      scope: 'source',
-      source_id: 'node-synth',
-    }),
+    bundle,
     query: kungfu.runStorageServiceOperation('query', runtimeDir, {
       scope: 'source',
       source_id: 'node-synth',
@@ -171,6 +182,7 @@ sys.path.insert(0, str(core_dir / "dist" / "kungfu"))
 
 from kungfu.storage import service
 
+bundle = service.build_export_bundle(runtime_dir, source_id="node-synth")
 out = {
     "capabilities": service.service_capabilities(),
     "optionRequest": service._runtime().make_storage_service_request(
@@ -191,12 +203,18 @@ out = {
     ),
     "fsck": service.fsck(runtime_dir, source_id="node-synth"),
     "repair": service.repair_plan(runtime_dir, source_id="node-synth", dry_run=True),
+    "repairApply": service.repair_apply(
+        runtime_dir,
+        bundle,
+        source_id="node-synth",
+        dry_run=True,
+    ),
     "exported": service.export_records(
         runtime_dir,
         source_id="node-synth",
         range_filter={"since": "2026-07-09T00:00:00Z"},
     ),
-    "bundle": service.build_export_bundle(runtime_dir, source_id="node-synth"),
+    "bundle": bundle,
     "query": service.query_projection(
         runtime_dir,
         query="entries",
@@ -322,6 +340,11 @@ for (const providerCase of providerCases) {
             'kungfu.storage.repair-plan/v1',
           );
           assert.equal(nodeResults.repair.candidate_count, 0);
+          assert.equal(
+            nodeResults.repairApply.schema,
+            'kungfu.storage.repair-apply/v1',
+          );
+          assert.equal(nodeResults.repairApply.dry_run, true);
           assert.equal(nodeResults.bundle.records.length, 2);
           assert.equal(nodeResults.exported.length, 1);
           assert.equal(nodeResults.query.row_count, 2);


### PR DESCRIPTION
## Summary
- add C++ storage-service repair_apply for local Episode/source repair material
- expose kungfu storage repair --apply --from with dry-run default and --execute mutation
- document repair-apply safety boundaries and refresh KFD evidence

## Validation
- ./kungfu-code build
- ./kungfu-code check
- DYLD_FALLBACK_LIBRARY_PATH=dist/kungfu PYTHONPATH=src/python:dist/kungfu uv run --frozen pytest tests/python/test_atlas_storage.py -q
- KUNGFU_DIR="$PWD/dist/kungfu" node --test tests/storage-node-binding.test.js
- CLI smoke: episode fsck degraded -> repair apply dry-run -> execute -> fsck ok