### PR TITLE
feat(view): route .fbs compile through kungfu::view; flip FB gate strict (ADR-0039 slice 2)

### DIFF
--- a/framework/core/docs/adr/ADR-0039-unified-view-interface-encapsulates-flatbuffers.md
+++ b/framework/core/docs/adr/ADR-0039-unified-view-interface-encapsulates-flatbuffers.md
@@ -117,9 +117,13 @@ Enforcement is a mechanism, not a rule:
    symbol-level) wired into `verify.mjs`; allowlists the view module and fails
    elsewhere. `runtime/schema/schema_compiler.cpp` is temporarily allowlisted.
    A `slices/view-encapsulation` probe proves the roundtrip + boundary.
-5. **Migrate the rest** — `schema_compiler` (behind `kungfu::view::compile_schema`)
-   and the `py-runtime` consumer incrementally, then remove the schema_compiler
-   allowlist to flip the gate strict.
+5. **Migrate the rest** (done, slice 2) — `schema_compiler` now delegates the
+   `.fbs` -> `.bfbs` compile to `kungfu::view::compile_schema` (keeping only its
+   trust-tier policy), and the schema_compiler allowlist is removed so the gate
+   is **strict**: no `flatbuffers::` / `reflection::` appears anywhere outside
+   `kungfu::view`. The `py-runtime` consumer needs no change — it marshals the
+   compiled `.bfbs` bytes across the binding boundary and never holds a bare
+   reflection view.
 
 ## Explicitly out of scope
 

--- a/framework/core/slices/view-encapsulation/probe.cpp
+++ b/framework/core/slices/view-encapsulation/probe.cpp
@@ -66,7 +66,13 @@ static std::string make_data(const char *fbs, const char *json) {
 }
 
 int main() {
-  const std::string bfbs = make_bfbs(FBS);
+  // compile .fbs -> .bfbs through the view chokepoint (the sole FB compile entry)
+  auto compiled = view::compile_schema(FBS, /*allow_includes*/ false);
+  assert(compiled.ok && !compiled.bfbs.empty() && compiled.error.empty());
+  auto bad = view::compile_schema("table Broken { : }", false);
+  assert(!bad.ok && !bad.error.empty() && bad.bfbs.empty()); // never throws on bad input
+  const std::string bfbs = compiled.bfbs;
+
   const std::string data = make_data(FBS, JSON);
   const auto *dbuf = reinterpret_cast<const uint8_t *>(data.data());
 

--- a/framework/core/src/libkungfu/check-view-boundary.mjs
+++ b/framework/core/src/libkungfu/check-view-boundary.mjs
@@ -15,11 +15,9 @@
 // comment outside the view module should need to name `flatbuffers::` /
 // `reflection::`; reword the seam instead.
 //
-// ALLOWLIST (slice-staged):
-//   - the kungfu::view module itself (the sole FB access point);
-//   - runtime/schema/schema_compiler.cpp — the `.fbs` -> `.bfbs` compile path,
-//     migrated in a later slice. Remove this entry when it moves behind
-//     kungfu::view::compile_schema, flipping the gate fully strict.
+// ALLOWLIST: only the kungfu::view module itself (the sole FB access point).
+// The gate is strict — the `.fbs` -> `.bfbs` compile path now goes through
+// kungfu::view::compile_schema, so no other file may name FlatBuffers.
 //
 // Pure Node (no grep/bash), so the guard runs on every platform.
 //
@@ -38,10 +36,9 @@ const allowedPrefixes = [
   'libkungfu/include/kungfu/view/',
   'libkungfu/src/view/',
 ];
-const allowedFiles = [
-  // Deferred to the next migration slice; see ALLOWLIST note above.
-  'libkungfu/src/runtime/schema/schema_compiler.cpp',
-];
+// No exceptions: every `.fbs`/`.bfbs`/reflection path now goes through
+// kungfu::view (schema_compiler delegates to view::compile_schema). Strict.
+const allowedFiles = [];
 
 const cppExt = /\.(h|hh|hpp|hxx|c|cc|cpp|cxx|inl|ipp)$/;
 

--- a/framework/core/src/libkungfu/include/kungfu/view/schema.h
+++ b/framework/core/src/libkungfu/include/kungfu/view/schema.h
@@ -112,6 +112,22 @@ private:
 // not altered here.
 std::vector<std::string> alter_add_missing(sqlite3 *db, const std::vector<col_plan> &cols, std::string_view table);
 
+// Result of compiling `.fbs` schema text to a `.bfbs` reflection binary.
+struct compiled_schema {
+  bool ok = false;
+  std::string bfbs;  // reflection binary bytes on success, empty on failure
+  std::string error; // FlatBuffers parser diagnostic (file:line: message) on failure
+};
+
+// Compile `.fbs` schema text to a `.bfbs` reflection binary in-process (the
+// linked FlatBuffers parser; no flatc, no subprocess) — the sole FB compile
+// entry, so `flatbuffers::Parser` stays inside kungfu::view (ADR-0039). Never
+// throws: a parse failure returns ok=false with the parser diagnostic. This is
+// schema parsing, not code execution. `allow_includes=false` blocks cross-file
+// includes (callers force it off for untrusted input); trust-tier size bounds
+// stay with the caller, not here.
+[[nodiscard]] compiled_schema compile_schema(std::string_view fbs_text, bool allow_includes);
+
 } // namespace kungfu::view
 
 #endif // KUNGFU_VIEW_SCHEMA_H

--- a/framework/core/src/libkungfu/src/runtime/schema/schema_compiler.cpp
+++ b/framework/core/src/libkungfu/src/runtime/schema/schema_compiler.cpp
@@ -2,7 +2,7 @@
 
 #include <kungfu/runtime/schema/schema_compiler.h>
 
-#include <flatbuffers/idl.h>
+#include <kungfu/view/schema.h>
 
 namespace kungfu::runtime::schema {
 
@@ -25,24 +25,15 @@ compile_result compile_fbs(const std::string &fbs_text, const compile_options &o
     return result;
   }
 
-  // In-memory compile against the already-linked FlatBuffers library. No
-  // include directories are provided, so a schema that pulls in other files
-  // fails to resolve — acceptable for the in-process open-layer path and
-  // mandatory for the sandboxed tier.
-  flatbuffers::IDLOptions idl_opts;
-  flatbuffers::Parser parser(idl_opts);
-
-  const char *include_paths[] = {nullptr};
-  if (!parser.Parse(fbs_text.c_str(), allow_includes ? nullptr : include_paths)) {
-    result.error = parser.error_;
+  // The `.fbs` -> `.bfbs` compile itself goes through kungfu::view: FlatBuffers
+  // is reached only through that one module (ADR-0039). This layer keeps just
+  // the trust-tier policy above.
+  auto compiled = kungfu::view::compile_schema(fbs_text, allow_includes);
+  if (!compiled.ok) {
+    result.error = std::move(compiled.error);
     return result;
   }
-
-  // Serialize the parsed schema to its reflection binary (.bfbs).
-  parser.Serialize();
-  const std::uint8_t *buf = parser.builder_.GetBufferPointer();
-  const std::size_t size = parser.builder_.GetSize();
-  result.bfbs.assign(buf, buf + size);
+  result.bfbs.assign(compiled.bfbs.begin(), compiled.bfbs.end());
   result.ok = true;
   return result;
 }

--- a/framework/core/src/libkungfu/src/view/schema.cpp
+++ b/framework/core/src/libkungfu/src/view/schema.cpp
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// kungfu::view regime 2 implementation — the ONLY translation unit in kungfu
-// that names `flatbuffers::` / `reflection::` for the open-layer reflection path
-// (ADR-0039). Everything borrow-heavy about FlatBuffers lives behind this file;
+// kungfu::view implementation — the ONLY translation unit in kungfu that names
+// `flatbuffers::` / `reflection::` (ADR-0039): the open-layer reflection path
+// (regime 2) and the `.fbs` -> `.bfbs` compile entry both live behind this file;
 // the header exposes only reflection-free types.
 #include <kungfu/view/schema.h>
 
+#include <flatbuffers/idl.h> // Parser for the .fbs -> .bfbs compile entry
 #include <flatbuffers/reflection.h>
 #include <flatbuffers/util.h> // LoadFile for the .bfbs import boundary
 #include <sqlite3.h>
@@ -184,6 +185,25 @@ std::vector<std::string> alter_add_missing(sqlite3 *db, const std::vector<col_pl
     }
   }
   return added;
+}
+
+compiled_schema compile_schema(std::string_view fbs_text, bool allow_includes) {
+  compiled_schema out;
+  // In-memory compile against the already-linked FlatBuffers library. With no
+  // include directories provided, a schema that pulls in other files fails to
+  // resolve — the safe default for the in-process open-layer path.
+  flatbuffers::IDLOptions idl_opts;
+  flatbuffers::Parser parser(idl_opts);
+  const char *no_includes[] = {nullptr};
+  if (!parser.Parse(std::string(fbs_text).c_str(), allow_includes ? nullptr : no_includes)) {
+    out.error = parser.error_;
+    return out;
+  }
+  parser.Serialize(); // parsed schema -> reflection binary (.bfbs)
+  const auto *buf = reinterpret_cast<const char *>(parser.builder_.GetBufferPointer());
+  out.bfbs.assign(buf, parser.builder_.GetSize());
+  out.ok = true;
+  return out;
 }
 
 } // namespace kungfu::view


### PR DESCRIPTION
Complete ADR-0039: no flatbuffers::/reflection:: symbol appears outside kungfu::view. Adds view::compile_schema (the sole .fbs->.bfbs compile entry), makes schema_compiler delegate to it (keeping only trust-tier policy), and removes the schema_compiler allowlist so the boundary gate is strict. Full core build green; view-encapsulation probe (now exercising compile_schema) passes under the strict gate; py-runtime unchanged (marshals compiled bytes, holds no reflection view). Validated C++ (standalone harness) and Python (pykungfu.runtime.compile_schema).