### PR TITLE
feat(storage): source-registry records as Hana-core kernel journal (ADR-0037)

### DIFF
--- a/framework/core/docs/adr/ADR-0037-storage-records-hana-core-kernel-metadata.md
+++ b/framework/core/docs/adr/ADR-0037-storage-records-hana-core-kernel-metadata.md
@@ -1,6 +1,7 @@
 # ADR-0037: ADR-0018 storage-service records are Hana-core kernel metadata; JSON is an edge projection, not the contract
 
-- Status: proposed
+- Status: accepted (the decision is validated by the source-registry slice; see
+  "First delivery" below for what has landed vs. what remains staged)
 - Date: 2026-07-09
 - Category: (architecture) storage-service record representation and schema
   ownership — which substrate defines source registry, manifest, and fsck
@@ -155,13 +156,33 @@ or a sibling catalog-plane journal, not diverge into two incompatible layouts.
   define it as a POD Hana-core type with a kernel `carrier_type` id (a core type
   like `Channel`, registered in the closed-set — not a raw business allocation of
   the kind ADR-0023 gates), and write/read it through a storage/catalog-plane
-  journal.
+  journal. **(done, slice 1)** — the source registry landed as three POD records
+  `SourceRegistered` (10901), `SourceHeadUpdated` (10902), `AcceptedRangeRecorded`
+  (10903), registered in the closed-set alongside the Episode manifest family.
+  `source_registry_store` writes them to an append-only yijinjing SYSTEM journal
+  (namespace `storage`, name `source-registry`) and folds frames into the current
+  view; variable-length growth (accepted ranges) is modeled as append-only delta
+  records, not inline arrays. Exposed through the libkungfu runtime storage
+  service (`source_register` / `source_update_head` /
+  `source_record_accepted_range` / `source_list` / `source_inspect` /
+  `source_registry_fsck`).
 - Project it to SQLite via the Hana → SQLite path; store any body as
-  content-addressed bytes.
+  content-addressed bytes. **(pending, slice 2)** — the source-registry slice
+  folds directly from the journal (as the Episode manifest slice does); the
+  SQLite projection and content-addressed payload bodies are the next sub-slice
+  and reuse the existing Hana → SQLite path, not new machinery.
 - Keep `storage status` / `storage export` as the JSON edge projection over the
-  record; `fsck` verifies journal + payload + projection.
+  record; `fsck` verifies journal + payload + projection. **(done, slice 1 for
+  the source registry)** — `source_list` / `source_inspect` return JSON edge
+  projections labelled `authority: yijinjing-journal`, and `source_registry_fsck`
+  reopens journal frames to check fold consistency (missing / duplicate
+  registration, dangling head). Payload/projection verification arrives with
+  slice 2.
 - Then migrate the remaining storage-service records and retire the
   JSON-as-contract path and the unconsumed heap structs / `provider.h`.
+  **(later)** — import manifest, export bundle, and channel cursor still use the
+  `generic_service` JSON path; they are migrated after the source-registry slice
+  proves the pattern.
 
 ## Explicitly out of scope
 

--- a/framework/core/src/libkungfu/include/kungfu/runtime/storage/service.h
+++ b/framework/core/src/libkungfu/include/kungfu/runtime/storage/service.h
@@ -33,6 +33,12 @@ enum class storage_operation {
   EpisodeAttachRef,
   EpisodeList,
   EpisodeInspect,
+  SourceRegister,
+  SourceUpdateHead,
+  SourceRecordAcceptedRange,
+  SourceList,
+  SourceInspect,
+  SourceRegistryFsck,
 };
 
 struct storage_service_options {
@@ -95,6 +101,18 @@ public:
   [[nodiscard]] virtual nlohmann::json episode_list(const storage_service_options &options) const = 0;
 
   [[nodiscard]] virtual nlohmann::json episode_inspect(const storage_service_options &options) const = 0;
+
+  [[nodiscard]] virtual nlohmann::json source_register(const storage_service_options &options) const = 0;
+
+  [[nodiscard]] virtual nlohmann::json source_update_head(const storage_service_options &options) const = 0;
+
+  [[nodiscard]] virtual nlohmann::json source_record_accepted_range(const storage_service_options &options) const = 0;
+
+  [[nodiscard]] virtual nlohmann::json source_list(const storage_service_options &options) const = 0;
+
+  [[nodiscard]] virtual nlohmann::json source_inspect(const storage_service_options &options) const = 0;
+
+  [[nodiscard]] virtual nlohmann::json source_registry_fsck(const storage_service_options &options) const = 0;
 };
 
 [[nodiscard]] std::vector<std::string> storage_operation_names();

--- a/framework/core/src/libkungfu/src/runtime/storage/service.cpp
+++ b/framework/core/src/libkungfu/src/runtime/storage/service.cpp
@@ -18,6 +18,7 @@
 #include <kungfu/yijinjing/storage/content_hash.h>
 #include <kungfu/yijinjing/storage/episode_manifest.h>
 #include <kungfu/yijinjing/storage/generic_service.h>
+#include <kungfu/yijinjing/storage/source_registry.h>
 #include <kungfu/yijinjing/storage/sync_root.h>
 #include <rocksdb/db.h>
 #include <rocksdb/iterator.h>
@@ -251,6 +252,83 @@ yy_storage::episode_ref_attach_options parse_episode_ref_attach_options(const nl
   parsed.update_time = int64_or(value, "update_time");
   parsed.ref_id = text_or(value, "ref_id");
   parsed.ref_hash = text_or(value, "ref_hash");
+  return parsed;
+}
+
+yy_enums::SourceKind source_kind_or(const nlohmann::json &object, const std::string &field,
+                                    yy_enums::SourceKind fallback) {
+  const auto value = text_or(object, field);
+  if (value == "imported_bundle" || value == "ImportedBundle") {
+    return yy_enums::SourceKind::ImportedBundle;
+  }
+  if (value == "kungfu_runtime" || value == "KungfuRuntime") {
+    return yy_enums::SourceKind::KungfuRuntime;
+  }
+  if (value == "adapter" || value == "Adapter") {
+    return yy_enums::SourceKind::Adapter;
+  }
+  if (value == "local" || value == "Local") {
+    return yy_enums::SourceKind::Local;
+  }
+  return fallback;
+}
+
+yy_enums::SourceVerificationStatus source_verification_status_or(const nlohmann::json &object, const std::string &field,
+                                                                 yy_enums::SourceVerificationStatus fallback) {
+  const auto value = text_or(object, field);
+  if (value == "degraded" || value == "Degraded") {
+    return yy_enums::SourceVerificationStatus::Degraded;
+  }
+  if (value == "failed" || value == "Failed") {
+    return yy_enums::SourceVerificationStatus::Failed;
+  }
+  if (value == "ok" || value == "Ok") {
+    return yy_enums::SourceVerificationStatus::Ok;
+  }
+  return fallback;
+}
+
+yy_storage::source_registry_store source_registry_store(const storage_service_options &options) {
+  return yy_storage::source_registry_store(options.runtime_dir);
+}
+
+yy_storage::source_register_options parse_source_register_options(const nlohmann::json &value) {
+  yy_storage::source_register_options parsed{};
+  parsed.source_id = text_or(value, "source_id");
+  parsed.kind = source_kind_or(value, "kind", yy_enums::SourceKind::Local);
+  parsed.coordinate = text_or(value, "coordinate");
+  parsed.head = text_or(value, "head");
+  parsed.location_uid = uint32_or(value, "location_uid");
+  parsed.register_time = int64_or(value, "register_time");
+  return parsed;
+}
+
+yy_storage::source_head_update_options parse_source_head_update_options(const nlohmann::json &value) {
+  yy_storage::source_head_update_options parsed{};
+  parsed.source_id = text_or(value, "source_id");
+  parsed.location_uid = uint32_or(value, "location_uid");
+  parsed.update_time = int64_or(value, "update_time");
+  parsed.first_frame_uid = uint64_or(value, "first_frame_uid");
+  parsed.last_frame_uid = uint64_or(value, "last_frame_uid");
+  parsed.since = int64_or(value, "since");
+  parsed.until = int64_or(value, "until");
+  parsed.head = text_or(value, "head");
+  parsed.inventory_hash_algo = text_or(value, "inventory_hash_algo");
+  parsed.inventory_hash = text_or(value, "inventory_hash");
+  return parsed;
+}
+
+yy_storage::accepted_range_options parse_accepted_range_options(const nlohmann::json &value) {
+  yy_storage::accepted_range_options parsed{};
+  parsed.source_id = text_or(value, "source_id");
+  parsed.manifest_id = text_or(value, "manifest_id");
+  parsed.location_uid = uint32_or(value, "location_uid");
+  parsed.accept_time = int64_or(value, "accept_time");
+  parsed.first_frame_uid = uint64_or(value, "first_frame_uid");
+  parsed.last_frame_uid = uint64_or(value, "last_frame_uid");
+  parsed.since = int64_or(value, "since");
+  parsed.until = int64_or(value, "until");
+  parsed.status = source_verification_status_or(value, "status", yy_enums::SourceVerificationStatus::Ok);
   return parsed;
 }
 
@@ -2457,6 +2535,31 @@ public:
   [[nodiscard]] nlohmann::json episode_inspect(const storage_service_options &options) const override {
     return episode_store(options).inspect(uint64_or(options.operation_options, "episode_id"));
   }
+
+  [[nodiscard]] nlohmann::json source_register(const storage_service_options &options) const override {
+    return source_registry_store(options).register_source(parse_source_register_options(options.operation_options));
+  }
+
+  [[nodiscard]] nlohmann::json source_update_head(const storage_service_options &options) const override {
+    return source_registry_store(options).update_head(parse_source_head_update_options(options.operation_options));
+  }
+
+  [[nodiscard]] nlohmann::json source_record_accepted_range(const storage_service_options &options) const override {
+    return source_registry_store(options).record_accepted_range(
+        parse_accepted_range_options(options.operation_options));
+  }
+
+  [[nodiscard]] nlohmann::json source_list(const storage_service_options &options) const override {
+    return source_registry_store(options).list();
+  }
+
+  [[nodiscard]] nlohmann::json source_inspect(const storage_service_options &options) const override {
+    return source_registry_store(options).inspect(text_or(options.operation_options, "source_id", options.source_id));
+  }
+
+  [[nodiscard]] nlohmann::json source_registry_fsck(const storage_service_options &options) const override {
+    return source_registry_store(options).fsck(text_or(options.operation_options, "source_id", options.source_id));
+  }
 };
 
 const file_storage_service &storage_service_instance() {
@@ -2504,6 +2607,12 @@ std::vector<std::string> storage_operation_names() {
       storage_operation_name(storage_operation::EpisodeAttachRef),
       storage_operation_name(storage_operation::EpisodeList),
       storage_operation_name(storage_operation::EpisodeInspect),
+      storage_operation_name(storage_operation::SourceRegister),
+      storage_operation_name(storage_operation::SourceUpdateHead),
+      storage_operation_name(storage_operation::SourceRecordAcceptedRange),
+      storage_operation_name(storage_operation::SourceList),
+      storage_operation_name(storage_operation::SourceInspect),
+      storage_operation_name(storage_operation::SourceRegistryFsck),
   };
 }
 
@@ -2547,6 +2656,18 @@ std::string storage_operation_name(storage_operation operation) {
     return "episode_list";
   case storage_operation::EpisodeInspect:
     return "episode_inspect";
+  case storage_operation::SourceRegister:
+    return "source_register";
+  case storage_operation::SourceUpdateHead:
+    return "source_update_head";
+  case storage_operation::SourceRecordAcceptedRange:
+    return "source_record_accepted_range";
+  case storage_operation::SourceList:
+    return "source_list";
+  case storage_operation::SourceInspect:
+    return "source_inspect";
+  case storage_operation::SourceRegistryFsck:
+    return "source_registry_fsck";
   }
   throw std::invalid_argument("unknown storage operation");
 }
@@ -2608,6 +2729,24 @@ storage_operation parse_storage_operation(const std::string &operation) {
   }
   if (operation == "episode_inspect") {
     return storage_operation::EpisodeInspect;
+  }
+  if (operation == "source_register") {
+    return storage_operation::SourceRegister;
+  }
+  if (operation == "source_update_head") {
+    return storage_operation::SourceUpdateHead;
+  }
+  if (operation == "source_record_accepted_range") {
+    return storage_operation::SourceRecordAcceptedRange;
+  }
+  if (operation == "source_list") {
+    return storage_operation::SourceList;
+  }
+  if (operation == "source_inspect") {
+    return storage_operation::SourceInspect;
+  }
+  if (operation == "source_registry_fsck") {
+    return storage_operation::SourceRegistryFsck;
   }
   throw std::invalid_argument("unsupported storage operation: " + operation);
 }
@@ -2705,6 +2844,18 @@ nlohmann::json run_storage_service_operation(const std::string &operation, const
     return storage_service_instance().episode_list(parsed_options);
   case storage_operation::EpisodeInspect:
     return storage_service_instance().episode_inspect(parsed_options);
+  case storage_operation::SourceRegister:
+    return storage_service_instance().source_register(parsed_options);
+  case storage_operation::SourceUpdateHead:
+    return storage_service_instance().source_update_head(parsed_options);
+  case storage_operation::SourceRecordAcceptedRange:
+    return storage_service_instance().source_record_accepted_range(parsed_options);
+  case storage_operation::SourceList:
+    return storage_service_instance().source_list(parsed_options);
+  case storage_operation::SourceInspect:
+    return storage_service_instance().source_inspect(parsed_options);
+  case storage_operation::SourceRegistryFsck:
+    return storage_service_instance().source_registry_fsck(parsed_options);
   }
   throw std::invalid_argument("unknown storage operation");
 }

--- a/framework/core/src/libyijinjing/include/kungfu/yijinjing/schema/registry.h
+++ b/framework/core/src/libyijinjing/include/kungfu/yijinjing/schema/registry.h
@@ -59,7 +59,10 @@ constexpr auto AllTypes = boost::hana::make_map( //
     TYPE_PAIR(EpisodeHeartbeat),                 // 10802
     TYPE_PAIR(EpisodeFrameAttached),             // 10803
     TYPE_PAIR(EpisodeRefAttached),               // 10804
-    TYPE_PAIR(EpisodeClosed)                     // 10805
+    TYPE_PAIR(EpisodeClosed),                    // 10805
+    TYPE_PAIR(SourceRegistered),                 // 10901
+    TYPE_PAIR(SourceHeadUpdated),                // 10902
+    TYPE_PAIR(AcceptedRangeRecorded)             // 10903
 );
 
 constexpr auto AllDataTypes = boost::hana::make_map( //
@@ -92,7 +95,10 @@ constexpr auto AllDataTypes = boost::hana::make_map( //
     TYPE_PAIR(EpisodeHeartbeat),                     // 10802
     TYPE_PAIR(EpisodeFrameAttached),                 // 10803
     TYPE_PAIR(EpisodeRefAttached),                   // 10804
-    TYPE_PAIR(EpisodeClosed)                         // 10805
+    TYPE_PAIR(EpisodeClosed),                        // 10805
+    TYPE_PAIR(SourceRegistered),                     // 10901
+    TYPE_PAIR(SourceHeadUpdated),                    // 10902
+    TYPE_PAIR(AcceptedRangeRecorded)                 // 10903
 );
 
 constexpr auto CorePublicDataTypes = boost::hana::make_map( //
@@ -125,7 +131,10 @@ constexpr auto CorePublicDataTypes = boost::hana::make_map( //
     TYPE_PAIR(EpisodeHeartbeat),                            // 10802
     TYPE_PAIR(EpisodeFrameAttached),                        // 10803
     TYPE_PAIR(EpisodeRefAttached),                          // 10804
-    TYPE_PAIR(EpisodeClosed)                                // 10805
+    TYPE_PAIR(EpisodeClosed),                               // 10805
+    TYPE_PAIR(SourceRegistered),                            // 10901
+    TYPE_PAIR(SourceHeadUpdated),                           // 10902
+    TYPE_PAIR(AcceptedRangeRecorded)                        // 10903
 );
 
 constexpr auto CorePublicProfileDataTypes = boost::hana::make_map( //

--- a/framework/core/src/libyijinjing/include/kungfu/yijinjing/schema/types.h
+++ b/framework/core/src/libyijinjing/include/kungfu/yijinjing/schema/types.h
@@ -62,6 +62,27 @@ KF_JSON_SERIALIZE_ENUM(EpisodeRefKind, {
 
 inline std::ostream &operator<<(std::ostream &os, EpisodeRefKind t) { return os << int32_t(t); }
 
+enum class SourceKind : int8_t { Local = 1, ImportedBundle = 2, KungfuRuntime = 3, Adapter = 4 };
+
+KF_JSON_SERIALIZE_ENUM(SourceKind, {
+                                       {SourceKind::Local, "Local"},
+                                       {SourceKind::ImportedBundle, "ImportedBundle"},
+                                       {SourceKind::KungfuRuntime, "KungfuRuntime"},
+                                       {SourceKind::Adapter, "Adapter"},
+                                   })
+
+inline std::ostream &operator<<(std::ostream &os, SourceKind t) { return os << int32_t(t); }
+
+enum class SourceVerificationStatus : int8_t { Ok = 1, Degraded = 2, Failed = 3 };
+
+KF_JSON_SERIALIZE_ENUM(SourceVerificationStatus, {
+                                                     {SourceVerificationStatus::Ok, "Ok"},
+                                                     {SourceVerificationStatus::Degraded, "Degraded"},
+                                                     {SourceVerificationStatus::Failed, "Failed"},
+                                                 })
+
+inline std::ostream &operator<<(std::ostream &os, SourceVerificationStatus t) { return os << int32_t(t); }
+
 } // namespace kungfu::yijinjing::enums
 
 namespace kungfu::yijinjing::types {
@@ -297,6 +318,52 @@ KF_DEFINE_PACK_TYPE(                                           //
     (uint64_t, last_frame_uid),                                //
     (uint64_t, frame_count),                                   //
     (array<char, 64>, reason)                                  //
+);
+
+// Storage source-registry records (ADR-0037): Hana-core kernel metadata for the
+// ADR-0018 storage-service source family, written to an append-only yijinjing
+// journal and folded into a current view. JSON is an edge projection only.
+KF_DEFINE_PACK_TYPE(                                                   //
+    SourceRegistered, 10901, PK(source_uid), TIMESTAMP(register_time), //
+    (uint32_t, schema_version),                                        //
+    (uint64_t, source_uid),                                            //
+    (enums::SourceKind, kind),                                         //
+    (uint32_t, location_uid),                                          //
+    (int64_t, register_time),                                          //
+    (array<char, 128>, source_id),                                     //
+    (array<char, 256>, coordinate),                                    //
+    (array<char, 128>, head)                                           //
+);
+
+KF_DEFINE_PACK_TYPE(                                                               //
+    SourceHeadUpdated, 10902, PK(source_uid, update_time), TIMESTAMP(update_time), //
+    (uint32_t, schema_version),                                                    //
+    (uint64_t, source_uid),                                                        //
+    (uint32_t, location_uid),                                                      //
+    (int64_t, update_time),                                                        //
+    (uint64_t, first_frame_uid),                                                   //
+    (uint64_t, last_frame_uid),                                                    //
+    (int64_t, since),                                                              //
+    (int64_t, until),                                                              //
+    (array<char, 128>, head),                                                      //
+    (array<char, 16>, inventory_hash_algo),                                        //
+    (array<char, 128>, inventory_hash)                                             //
+);
+
+KF_DEFINE_PACK_TYPE(                                                                    //
+    AcceptedRangeRecorded, 10903, PK(source_uid, manifest_uid), TIMESTAMP(accept_time), //
+    (uint32_t, schema_version),                                                         //
+    (uint64_t, source_uid),                                                             //
+    (uint64_t, manifest_uid),                                                           //
+    (uint32_t, location_uid),                                                           //
+    (int64_t, accept_time),                                                             //
+    (uint64_t, first_frame_uid),                                                        //
+    (uint64_t, last_frame_uid),                                                         //
+    (int64_t, since),                                                                   //
+    (int64_t, until),                                                                   //
+    (enums::SourceVerificationStatus, status),                                          //
+    (array<char, 128>, source_id),                                                      //
+    (array<char, 128>, manifest_id)                                                     //
 );
 
 KF_DEFINE_PACK_TYPE(                                                   //

--- a/framework/core/src/libyijinjing/include/kungfu/yijinjing/storage.h
+++ b/framework/core/src/libyijinjing/include/kungfu/yijinjing/storage.h
@@ -14,6 +14,7 @@
 #include <kungfu/yijinjing/storage/provider.h>
 #include <kungfu/yijinjing/storage/range.h>
 #include <kungfu/yijinjing/storage/source.h>
+#include <kungfu/yijinjing/storage/source_registry.h>
 #include <kungfu/yijinjing/storage/sync_root.h>
 
 #endif // KUNGFU_YIJINJING_STORAGE_H

--- a/framework/core/src/libyijinjing/include/kungfu/yijinjing/storage/source_registry.h
+++ b/framework/core/src/libyijinjing/include/kungfu/yijinjing/storage/source_registry.h
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef KUNGFU_YIJINJING_STORAGE_SOURCE_REGISTRY_H
+#define KUNGFU_YIJINJING_STORAGE_SOURCE_REGISTRY_H
+
+#include <cstdint>
+#include <string>
+
+#include <nlohmann/json.hpp>
+
+#include <kungfu/yijinjing/schema/types.h>
+
+namespace kungfu::yijinjing::storage {
+
+// ADR-0037: the ADR-0018 storage-service source-registry record family is
+// Hana-core kernel metadata. The authoritative store is an append-only
+// yijinjing journal of POD records (SourceRegistered / SourceHeadUpdated /
+// AcceptedRangeRecorded) folded into a current view. JSON is an edge
+// projection only, never the contract.
+inline constexpr const char *SOURCE_REGISTRY_SCHEMA_V1 = "kungfu.storage.source-registry/v1";
+inline constexpr const char *SOURCE_REGISTRY_NAMESPACE = "storage";
+inline constexpr const char *SOURCE_REGISTRY_NAME = "source-registry";
+
+// Edge-level input options. These carry std::string for ergonomic callers; the
+// store copies them into fixed-layout POD journal records. They are not the
+// stored record and never become the fact substrate.
+struct source_register_options {
+  std::string source_id = {};
+  yijinjing::enums::SourceKind kind = yijinjing::enums::SourceKind::Local;
+  std::string coordinate = {};
+  std::string head = {};
+  uint32_t location_uid = 0;
+  int64_t register_time = 0;
+};
+
+struct source_head_update_options {
+  std::string source_id = {};
+  uint32_t location_uid = 0;
+  int64_t update_time = 0;
+  uint64_t first_frame_uid = 0;
+  uint64_t last_frame_uid = 0;
+  int64_t since = 0;
+  int64_t until = 0;
+  std::string head = {};
+  std::string inventory_hash_algo = {};
+  std::string inventory_hash = {};
+};
+
+struct accepted_range_options {
+  std::string source_id = {};
+  std::string manifest_id = {};
+  uint32_t location_uid = 0;
+  int64_t accept_time = 0;
+  uint64_t first_frame_uid = 0;
+  uint64_t last_frame_uid = 0;
+  int64_t since = 0;
+  int64_t until = 0;
+  yijinjing::enums::SourceVerificationStatus status = yijinjing::enums::SourceVerificationStatus::Ok;
+};
+
+class source_registry_store {
+public:
+  explicit source_registry_store(std::string runtime_dir);
+
+  [[nodiscard]] std::string runtime_dir() const { return runtime_dir_; }
+
+  // Append-only writers. Each writes one POD record to the journal and returns
+  // its JSON edge projection.
+  [[nodiscard]] nlohmann::json register_source(const source_register_options &options) const;
+
+  [[nodiscard]] nlohmann::json update_head(const source_head_update_options &options) const;
+
+  [[nodiscard]] nlohmann::json record_accepted_range(const accepted_range_options &options) const;
+
+  // Fold the journal into the current source-registry view (JSON edge).
+  [[nodiscard]] nlohmann::json list() const;
+
+  [[nodiscard]] nlohmann::json inspect(const std::string &source_id) const;
+
+  // Verify the journal by reopening frames and checking fold consistency.
+  [[nodiscard]] nlohmann::json fsck(const std::string &source_id = {}) const;
+
+private:
+  std::string runtime_dir_;
+};
+
+} // namespace kungfu::yijinjing::storage
+
+#endif // KUNGFU_YIJINJING_STORAGE_SOURCE_REGISTRY_H

--- a/framework/core/src/libyijinjing/src/storage/source_registry.cpp
+++ b/framework/core/src/libyijinjing/src/storage/source_registry.cpp
@@ -1,0 +1,358 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#include <kungfu/yijinjing/storage/source_registry.h>
+
+#include <map>
+#include <memory>
+#include <utility>
+
+#include <kungfu/yijinjing/common.h>
+#include <kungfu/yijinjing/hash.h>
+#include <kungfu/yijinjing/journal/journal.h>
+#include <kungfu/yijinjing/time.h>
+
+using namespace kungfu::yijinjing::data;
+using namespace kungfu::yijinjing::enums;
+using namespace kungfu::yijinjing::journal;
+using namespace kungfu::yijinjing::types;
+
+namespace kungfu::yijinjing::storage {
+
+namespace {
+
+constexpr uint32_t SOURCE_REGISTRY_SCHEMA_VERSION = 1;
+
+template <size_t N> std::string fixed_string(const kungfu::array<char, N> &value) {
+  size_t length = 0;
+  while (length < N && value.value[length] != '\0') {
+    ++length;
+  }
+  return std::string(value.value, length);
+}
+
+template <size_t N> void set_fixed_string(kungfu::array<char, N> &dest, const std::string &value) {
+  kungfu::copy_string(dest, value.c_str());
+}
+
+const char *source_kind_name(SourceKind kind) {
+  switch (kind) {
+  case SourceKind::Local:
+    return "local";
+  case SourceKind::ImportedBundle:
+    return "imported_bundle";
+  case SourceKind::KungfuRuntime:
+    return "kungfu_runtime";
+  case SourceKind::Adapter:
+    return "adapter";
+  }
+  return "unknown";
+}
+
+const char *verification_status_name(SourceVerificationStatus status) {
+  switch (status) {
+  case SourceVerificationStatus::Ok:
+    return "ok";
+  case SourceVerificationStatus::Degraded:
+    return "degraded";
+  case SourceVerificationStatus::Failed:
+    return "failed";
+  }
+  return "unknown";
+}
+
+location_ptr registry_location(const std::string &runtime_dir) {
+  auto locator = std::make_shared<kungfu::yijinjing::data::locator>(runtime_dir, mode::LIVE);
+  return location::make_shared(mode::LIVE, location_role::SYSTEM, SOURCE_REGISTRY_NAMESPACE, SOURCE_REGISTRY_NAME,
+                               locator);
+}
+
+writer make_writer(const std::string &runtime_dir) {
+  return writer(registry_location(runtime_dir), location::PUBLIC, true, std::make_shared<noop_publisher>(), false,
+                std::make_shared<bus>(false));
+}
+
+uint64_t source_uid_of(const std::string &source_id) { return fast_hash_str_64(source_id); }
+
+nlohmann::json range_json(uint64_t first_frame_uid, uint64_t last_frame_uid, int64_t since, int64_t until) {
+  return {
+      {"first_frame_uid", first_frame_uid},
+      {"last_frame_uid", last_frame_uid},
+      {"since", since},
+      {"until", until},
+  };
+}
+
+nlohmann::json record_json(const SourceRegistered &record) {
+  return {
+      {"schema", SOURCE_REGISTRY_SCHEMA_V1},           {"record_kind", "source_registered"},
+      {"schema_version", record.schema_version},       {"source_uid", record.source_uid},
+      {"source_id", fixed_string(record.source_id)},   {"kind", source_kind_name(record.kind)},
+      {"coordinate", fixed_string(record.coordinate)}, {"head", fixed_string(record.head)},
+      {"location_uid", record.location_uid},           {"register_time", record.register_time},
+  };
+}
+
+nlohmann::json record_json(const SourceHeadUpdated &record) {
+  return {
+      {"schema", SOURCE_REGISTRY_SCHEMA_V1},
+      {"record_kind", "source_head_updated"},
+      {"schema_version", record.schema_version},
+      {"source_uid", record.source_uid},
+      {"location_uid", record.location_uid},
+      {"update_time", record.update_time},
+      {"head", fixed_string(record.head)},
+      {"range", range_json(record.first_frame_uid, record.last_frame_uid, record.since, record.until)},
+      {"inventory_hash",
+       {{"algorithm", fixed_string(record.inventory_hash_algo)}, {"value", fixed_string(record.inventory_hash)}}},
+  };
+}
+
+nlohmann::json record_json(const AcceptedRangeRecorded &record) {
+  return {
+      {"schema", SOURCE_REGISTRY_SCHEMA_V1},
+      {"record_kind", "accepted_range_recorded"},
+      {"schema_version", record.schema_version},
+      {"source_uid", record.source_uid},
+      {"manifest_uid", record.manifest_uid},
+      {"source_id", fixed_string(record.source_id)},
+      {"manifest_id", fixed_string(record.manifest_id)},
+      {"location_uid", record.location_uid},
+      {"accept_time", record.accept_time},
+      {"range", range_json(record.first_frame_uid, record.last_frame_uid, record.since, record.until)},
+      {"status", verification_status_name(record.status)},
+  };
+}
+
+std::vector<nlohmann::json> read_records(const std::string &runtime_dir) {
+  std::vector<nlohmann::json> records;
+  const auto location = registry_location(runtime_dir);
+  if (location->locator->list_page_id(location, location::PUBLIC).empty()) {
+    return records;
+  }
+  auto reader = std::make_shared<kungfu::yijinjing::journal::reader>(true, false, std::make_shared<bus>(false));
+  reader->join(location, location::PUBLIC, 0);
+  while (reader->data_available()) {
+    const auto frame = reader->current_frame();
+    switch (frame->carrier_type()) {
+    case SourceRegistered::tag:
+      records.push_back(record_json(frame->data<SourceRegistered>()));
+      break;
+    case SourceHeadUpdated::tag:
+      records.push_back(record_json(frame->data<SourceHeadUpdated>()));
+      break;
+    case AcceptedRangeRecorded::tag:
+      records.push_back(record_json(frame->data<AcceptedRangeRecorded>()));
+      break;
+    default:
+      records.push_back({{"schema", SOURCE_REGISTRY_SCHEMA_V1},
+                         {"record_kind", "unknown"},
+                         {"carrier_type", frame->carrier_type()},
+                         {"frame_uid", frame->frame_uid()},
+                         {"gen_time", frame->gen_time()}});
+      break;
+    }
+    records.back()["registry_frame_uid"] = frame->frame_uid();
+    records.back()["registry_gen_time"] = frame->gen_time();
+    reader->next();
+  }
+  return records;
+}
+
+struct source_fold {
+  nlohmann::json summary = nlohmann::json::object();
+  nlohmann::json records = nlohmann::json::array();
+  nlohmann::json accepted_ranges = nlohmann::json::array();
+  bool registered = false;
+};
+
+std::map<uint64_t, source_fold> fold_records(const std::vector<nlohmann::json> &records) {
+  std::map<uint64_t, source_fold> folded;
+  for (const auto &record : records) {
+    const auto source_uid = record.value("source_uid", uint64_t{0});
+    if (source_uid == 0) {
+      continue;
+    }
+    auto &source = folded[source_uid];
+    source.records.push_back(record);
+    const auto kind = record.value("record_kind", std::string{});
+    if (kind == "source_registered") {
+      source.registered = true;
+      source.summary["source_uid"] = source_uid;
+      source.summary["source_id"] = record.value("source_id", "");
+      source.summary["kind"] = record.value("kind", "unknown");
+      source.summary["coordinate"] = record.value("coordinate", "");
+      source.summary["head"] = record.value("head", "");
+      source.summary["location_uid"] = record.value("location_uid", uint64_t{0});
+      source.summary["register_time"] = record.value("register_time", int64_t{0});
+    } else if (kind == "source_head_updated") {
+      // Later head updates fold over earlier ones: current view = latest head.
+      if (record.contains("head")) {
+        source.summary["head"] = record.value("head", "");
+      }
+      if (record.contains("range")) {
+        source.summary["current_range"] = record.at("range");
+      }
+      if (record.contains("inventory_hash")) {
+        source.summary["inventory_hash"] = record.at("inventory_hash");
+      }
+      source.summary["update_time"] = record.value("update_time", int64_t{0});
+    } else if (kind == "accepted_range_recorded") {
+      source.accepted_ranges.push_back(record);
+    }
+  }
+  for (auto &[source_uid, source] : folded) {
+    source.summary["schema"] = SOURCE_REGISTRY_SCHEMA_V1;
+    source.summary["source_uid"] = source_uid;
+    source.summary["registered"] = source.registered;
+    source.summary["record_count"] = source.records.size();
+    source.summary["accepted_range_count"] = source.accepted_ranges.size();
+    if (!source.summary.contains("source_id")) {
+      source.summary["source_id"] = "";
+    }
+  }
+  return folded;
+}
+
+} // namespace
+
+source_registry_store::source_registry_store(std::string runtime_dir) : runtime_dir_(std::move(runtime_dir)) {}
+
+nlohmann::json source_registry_store::register_source(const source_register_options &options) const {
+  if (options.source_id.empty()) {
+    throw std::invalid_argument("source_id is required");
+  }
+  SourceRegistered record{};
+  record.schema_version = SOURCE_REGISTRY_SCHEMA_VERSION;
+  record.source_uid = source_uid_of(options.source_id);
+  record.kind = options.kind;
+  record.location_uid = options.location_uid == 0 ? registry_location(runtime_dir_)->uid : options.location_uid;
+  record.register_time = options.register_time == 0 ? time::now_in_nano() : options.register_time;
+  set_fixed_string(record.source_id, options.source_id);
+  set_fixed_string(record.coordinate, options.coordinate);
+  set_fixed_string(record.head, options.head);
+  auto writer = make_writer(runtime_dir_);
+  writer.write_at(record.register_time, 0, record);
+  return record_json(record);
+}
+
+nlohmann::json source_registry_store::update_head(const source_head_update_options &options) const {
+  if (options.source_id.empty()) {
+    throw std::invalid_argument("source_id is required");
+  }
+  SourceHeadUpdated record{};
+  record.schema_version = SOURCE_REGISTRY_SCHEMA_VERSION;
+  record.source_uid = source_uid_of(options.source_id);
+  record.location_uid = options.location_uid == 0 ? registry_location(runtime_dir_)->uid : options.location_uid;
+  record.update_time = options.update_time == 0 ? time::now_in_nano() : options.update_time;
+  record.first_frame_uid = options.first_frame_uid;
+  record.last_frame_uid = options.last_frame_uid;
+  record.since = options.since;
+  record.until = options.until;
+  set_fixed_string(record.head, options.head);
+  set_fixed_string(record.inventory_hash_algo, options.inventory_hash_algo);
+  set_fixed_string(record.inventory_hash, options.inventory_hash);
+  auto writer = make_writer(runtime_dir_);
+  writer.write_at(record.update_time, 0, record);
+  return record_json(record);
+}
+
+nlohmann::json source_registry_store::record_accepted_range(const accepted_range_options &options) const {
+  if (options.source_id.empty()) {
+    throw std::invalid_argument("source_id is required");
+  }
+  AcceptedRangeRecorded record{};
+  record.schema_version = SOURCE_REGISTRY_SCHEMA_VERSION;
+  record.source_uid = source_uid_of(options.source_id);
+  record.manifest_uid = options.manifest_id.empty() ? 0 : fast_hash_str_64(options.manifest_id);
+  record.location_uid = options.location_uid == 0 ? registry_location(runtime_dir_)->uid : options.location_uid;
+  record.accept_time = options.accept_time == 0 ? time::now_in_nano() : options.accept_time;
+  record.first_frame_uid = options.first_frame_uid;
+  record.last_frame_uid = options.last_frame_uid;
+  record.since = options.since;
+  record.until = options.until;
+  record.status = options.status;
+  set_fixed_string(record.source_id, options.source_id);
+  set_fixed_string(record.manifest_id, options.manifest_id);
+  auto writer = make_writer(runtime_dir_);
+  writer.write_at(record.accept_time, 0, record);
+  return record_json(record);
+}
+
+nlohmann::json source_registry_store::list() const {
+  const auto folded = fold_records(read_records(runtime_dir_));
+  nlohmann::json sources = nlohmann::json::array();
+  for (const auto &[source_uid, source] : folded) {
+    sources.push_back(source.summary);
+  }
+  return {{"ok", true},
+          {"schema", SOURCE_REGISTRY_SCHEMA_V1},
+          {"runtime_dir", runtime_dir_},
+          {"authority", "yijinjing-journal"},
+          {"sources", sources},
+          {"source_count", sources.size()}};
+}
+
+nlohmann::json source_registry_store::inspect(const std::string &source_id) const {
+  if (source_id.empty()) {
+    throw std::invalid_argument("source_id is required");
+  }
+  const auto source_uid = source_uid_of(source_id);
+  const auto folded = fold_records(read_records(runtime_dir_));
+  const auto iter = folded.find(source_uid);
+  if (iter == folded.end()) {
+    return {{"ok", false},
+            {"schema", SOURCE_REGISTRY_SCHEMA_V1},
+            {"source_id", source_id},
+            {"errors", nlohmann::json::array({{{"code", "source_missing"}, {"source_id", source_id}}})}};
+  }
+  return {{"ok", true},
+          {"schema", SOURCE_REGISTRY_SCHEMA_V1},
+          {"runtime_dir", runtime_dir_},
+          {"authority", "yijinjing-journal"},
+          {"source", iter->second.summary},
+          {"accepted_ranges", iter->second.accepted_ranges},
+          {"records", iter->second.records}};
+}
+
+nlohmann::json source_registry_store::fsck(const std::string &source_id) const {
+  const auto records = read_records(runtime_dir_);
+  const auto folded = fold_records(records);
+  const auto filter_uid = source_id.empty() ? uint64_t{0} : source_uid_of(source_id);
+  nlohmann::json errors = nlohmann::json::array();
+  nlohmann::json warnings = nlohmann::json::array();
+  size_t checked = 0;
+  for (const auto &[current_source_uid, source] : folded) {
+    if (filter_uid != 0 && current_source_uid != filter_uid) {
+      continue;
+    }
+    ++checked;
+    if (!source.registered) {
+      // Head updates or accepted ranges without a registration are dangling
+      // producer output: honest degradation, recorded, not silently dropped.
+      errors.push_back({{"code", "source_registration_missing"}, {"source_uid", current_source_uid}});
+    }
+    size_t register_count = 0;
+    for (const auto &record : source.records) {
+      if (record.value("record_kind", std::string{}) == "source_registered") {
+        ++register_count;
+      }
+    }
+    if (register_count > 1) {
+      warnings.push_back(
+          {{"code", "source_registered_duplicate"}, {"source_uid", current_source_uid}, {"count", register_count}});
+    }
+  }
+  if (filter_uid != 0 && checked == 0) {
+    errors.push_back({{"code", "source_missing"}, {"source_id", source_id}});
+  }
+  return {{"ok", errors.empty()},
+          {"status", errors.empty() ? "ok" : "failed"},
+          {"schema", SOURCE_REGISTRY_SCHEMA_V1},
+          {"runtime_dir", runtime_dir_},
+          {"authority", "yijinjing-journal"},
+          {"errors", errors},
+          {"warnings", warnings},
+          {"checked", {{"source_registry_records", records.size()}, {"sources", checked}}}};
+}
+
+} // namespace kungfu::yijinjing::storage

--- a/framework/core/tests/python/test_atlas_storage.py
+++ b/framework/core/tests/python/test_atlas_storage.py
@@ -381,6 +381,12 @@ def test_runtime_storage_service_surface_is_bound_from_libkungfu(tmp_path):
         "episode_attach_ref",
         "episode_list",
         "episode_inspect",
+        "source_register",
+        "source_update_head",
+        "source_record_accepted_range",
+        "source_list",
+        "source_inspect",
+        "source_registry_fsck",
     }
 
     request = runtime.make_storage_service_request(
@@ -1262,3 +1268,118 @@ def test_storage_fsck_reports_degraded_status_for_recorded_payload_states(tmp_pa
     healthy = storage_service.fsck(healthy_dir, source_id="healthy-synth")
     assert healthy["ok"]
     assert healthy["status"] == "ok"
+
+
+def test_source_registry_records_round_trip_through_journal(tmp_path):
+    # ADR-0037: source-registry records are Hana-core kernel metadata written to
+    # an append-only yijinjing journal; JSON is only an edge projection. This
+    # drives the runtime service surface end to end and asserts the journal
+    # (not any JSON file) is the authority.
+    runtime = kungfu.__binding__.runtime
+    runtime_dir = str(tmp_path)
+
+    registered = runtime.run_storage_service_operation(
+        "source_register",
+        runtime_dir,
+        {
+            "source_id": "atlas-local",
+            "kind": "adapter",
+            "coordinate": "/repo/atlas",
+            "head": "head-0",
+            "register_time": 1000,
+        },
+    )
+    assert registered["record_kind"] == "source_registered"
+    assert registered["source_id"] == "atlas-local"
+    assert registered["kind"] == "adapter"
+    source_uid = registered["source_uid"]
+    assert source_uid != 0
+
+    # A second, independent source proves per-source folding.
+    runtime.run_storage_service_operation(
+        "source_register",
+        runtime_dir,
+        {"source_id": "runtime-b", "kind": "kungfu_runtime", "register_time": 1001},
+    )
+
+    # Head moves forward via an append-only delta record.
+    updated = runtime.run_storage_service_operation(
+        "source_update_head",
+        runtime_dir,
+        {
+            "source_id": "atlas-local",
+            "head": "head-1",
+            "first_frame_uid": 10,
+            "last_frame_uid": 42,
+            "inventory_hash_algo": "sha256",
+            "inventory_hash": "abc123",
+            "update_time": 2000,
+        },
+    )
+    assert updated["record_kind"] == "source_head_updated"
+    assert updated["head"] == "head-1"
+
+    accepted = runtime.run_storage_service_operation(
+        "source_record_accepted_range",
+        runtime_dir,
+        {
+            "source_id": "atlas-local",
+            "manifest_id": "manifest-1",
+            "first_frame_uid": 10,
+            "last_frame_uid": 42,
+            "status": "ok",
+            "accept_time": 3000,
+        },
+    )
+    assert accepted["record_kind"] == "accepted_range_recorded"
+    assert accepted["manifest_id"] == "manifest-1"
+
+    listed = runtime.run_storage_service_operation("source_list", runtime_dir, {})
+    assert listed["ok"]
+    assert listed["authority"] == "yijinjing-journal"
+    assert listed["source_count"] == 2
+    by_uid = {source["source_uid"]: source for source in listed["sources"]}
+    folded = by_uid[source_uid]
+    # Current view folds the latest head delta over the registration.
+    assert folded["head"] == "head-1"
+    assert folded["registered"] is True
+    assert folded["accepted_range_count"] == 1
+
+    inspected = runtime.run_storage_service_operation(
+        "source_inspect", runtime_dir, {"source_id": "atlas-local"}
+    )
+    assert inspected["ok"]
+    assert inspected["authority"] == "yijinjing-journal"
+    assert len(inspected["accepted_ranges"]) == 1
+    assert inspected["accepted_ranges"][0]["manifest_id"] == "manifest-1"
+
+    fsck = runtime.run_storage_service_operation(
+        "source_registry_fsck", runtime_dir, {}
+    )
+    assert fsck["ok"]
+    assert fsck["status"] == "ok"
+    assert fsck["authority"] == "yijinjing-journal"
+    assert fsck["checked"]["sources"] == 2
+
+    # Authority is the append-only journal, not a JSON registry file. The legacy
+    # JSON registry path (storage/sources.json) is not what these records use.
+    assert not (tmp_path / "storage" / "sources.json").exists()
+
+
+def test_source_registry_fsck_flags_dangling_head_without_registration(tmp_path):
+    # A head update for a source that was never registered is dangling producer
+    # output; fsck must record it honestly rather than silently dropping it.
+    runtime = kungfu.__binding__.runtime
+    runtime_dir = str(tmp_path)
+
+    runtime.run_storage_service_operation(
+        "source_update_head",
+        runtime_dir,
+        {"source_id": "ghost", "head": "h", "update_time": 5000},
+    )
+    fsck = runtime.run_storage_service_operation(
+        "source_registry_fsck", runtime_dir, {}
+    )
+    assert fsck["ok"] is False
+    assert fsck["status"] == "failed"
+    assert any(err["code"] == "source_registration_missing" for err in fsck["errors"])


### PR DESCRIPTION
Move the ADR-0018 storage-service source-registry record family to Hana-core kernel metadata (ADR-0037): fixed-layout POD records written to an append-only yijinjing journal and folded into a current view, with JSON as an edge projection only. Exposed through the runtime storage service; end-to-end tests cover register/update-head/accepted-range round-trip, fsck, and dangling-head detection (22/22 storage tests pass). Accepts ADR-0037, validated by this slice.