### PR TITLE
feat(storage): fetch local episode repair material

### DIFF
--- a/.buildchain/kfd/kfd-2/claims/agent-onboarding-pack.json
+++ b/.buildchain/kfd/kfd-2/claims/agent-onboarding-pack.json
@@ -16,7 +16,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "ef564727f7c6eed86ef01cbb5d64806012ba137a5cb867d1d32d3cd0d306b263"
+        "sha256": "55efae97c6dfe6d5640ff8fb569dcb20f758a70d6cf50b3f1da5613e510dc6f9"
       },
       "description": "Machine-readable command catalog and mode maturity metadata."
     },
@@ -54,7 +54,7 @@
     "evidenceSha256": [
       {
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "ef564727f7c6eed86ef01cbb5d64806012ba137a5cb867d1d32d3cd0d306b263"
+        "sha256": "55efae97c6dfe6d5640ff8fb569dcb20f758a70d6cf50b3f1da5613e510dc6f9"
       },
       {
         "path": "framework/core/src/python/kungfu/agent/mode-selection.md",
@@ -76,7 +76,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "ef564727f7c6eed86ef01cbb5d64806012ba137a5cb867d1d32d3cd0d306b263"
+        "sha256": "55efae97c6dfe6d5640ff8fb569dcb20f758a70d6cf50b3f1da5613e510dc6f9"
       }
     ]
   },
@@ -90,7 +90,7 @@
     {
       "name": "agent-command-catalog",
       "path": "framework/core/src/python/kungfu/agent/commands.json",
-      "sha256": "ef564727f7c6eed86ef01cbb5d64806012ba137a5cb867d1d32d3cd0d306b263",
+      "sha256": "55efae97c6dfe6d5640ff8fb569dcb20f758a70d6cf50b3f1da5613e510dc6f9",
       "expectedPackagePath": "kungfu/agent/commands.json"
     }
   ],

--- a/.buildchain/kfd/kfd-2/claims/codex-report-receipts.json
+++ b/.buildchain/kfd/kfd-2/claims/codex-report-receipts.json
@@ -52,7 +52,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/skills/codex/SKILL.md",
-        "sha256": "5abf198330bc42bff0ee486b36fd89701f6bd59964422d4e28e7b17b4cfb8576"
+        "sha256": "bab74a980ae981a0d6a7608e507fb5cdb4357c08b114cb8aa84c4e4d19174894"
       },
       "description": "Codex-side report closeout gate instructions shipped in the agent pack."
     }
@@ -79,7 +79,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/skills/codex/SKILL.md",
-        "sha256": "5abf198330bc42bff0ee486b36fd89701f6bd59964422d4e28e7b17b4cfb8576"
+        "sha256": "bab74a980ae981a0d6a7608e507fb5cdb4357c08b114cb8aa84c4e4d19174894"
       }
     ],
     "artifactSha256": [
@@ -89,7 +89,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/skills/codex/SKILL.md",
-        "sha256": "5abf198330bc42bff0ee486b36fd89701f6bd59964422d4e28e7b17b4cfb8576"
+        "sha256": "bab74a980ae981a0d6a7608e507fb5cdb4357c08b114cb8aa84c4e4d19174894"
       }
     ]
   },
@@ -103,7 +103,7 @@
     {
       "name": "codex-agent-skill",
       "path": "framework/core/src/python/kungfu/agent/skills/codex/SKILL.md",
-      "sha256": "5abf198330bc42bff0ee486b36fd89701f6bd59964422d4e28e7b17b4cfb8576",
+      "sha256": "bab74a980ae981a0d6a7608e507fb5cdb4357c08b114cb8aa84c4e4d19174894",
       "expectedPackagePath": "kungfu/agent/skills/codex/SKILL.md"
     }
   ],

--- a/.buildchain/kfd/kfd-2/claims/remote-fact-boundary.json
+++ b/.buildchain/kfd/kfd-2/claims/remote-fact-boundary.json
@@ -34,7 +34,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "ef564727f7c6eed86ef01cbb5d64806012ba137a5cb867d1d32d3cd0d306b263"
+        "sha256": "55efae97c6dfe6d5640ff8fb569dcb20f758a70d6cf50b3f1da5613e510dc6f9"
       },
       "description": "Remote add/sync command declarations and mode metadata."
     },
@@ -62,7 +62,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "ef564727f7c6eed86ef01cbb5d64806012ba137a5cb867d1d32d3cd0d306b263"
+        "sha256": "55efae97c6dfe6d5640ff8fb569dcb20f758a70d6cf50b3f1da5613e510dc6f9"
       },
       {
         "path": "framework/core/src/python/kungfu/cli/commands/agent.py",

--- a/.buildchain/kfd/kfd-2/release-claims.json
+++ b/.buildchain/kfd/kfd-2/release-claims.json
@@ -29,7 +29,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/commands.json",
-            "sha256": "ef564727f7c6eed86ef01cbb5d64806012ba137a5cb867d1d32d3cd0d306b263"
+            "sha256": "55efae97c6dfe6d5640ff8fb569dcb20f758a70d6cf50b3f1da5613e510dc6f9"
           },
           "description": "Machine-readable command catalog and mode maturity metadata."
         },
@@ -134,7 +134,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/skills/codex/SKILL.md",
-            "sha256": "5abf198330bc42bff0ee486b36fd89701f6bd59964422d4e28e7b17b4cfb8576"
+            "sha256": "bab74a980ae981a0d6a7608e507fb5cdb4357c08b114cb8aa84c4e4d19174894"
           },
           "description": "Codex-side report closeout gate instructions shipped in the agent pack."
         }
@@ -194,7 +194,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/commands.json",
-            "sha256": "ef564727f7c6eed86ef01cbb5d64806012ba137a5cb867d1d32d3cd0d306b263"
+            "sha256": "55efae97c6dfe6d5640ff8fb569dcb20f758a70d6cf50b3f1da5613e510dc6f9"
           },
           "description": "Remote add/sync command declarations and mode metadata."
         },

--- a/.buildchain/kfd/kfd-3/capability-query.json
+++ b/.buildchain/kfd/kfd-3/capability-query.json
@@ -1133,6 +1133,28 @@
       "residualRisk": []
     },
     {
+      "id": "kungfu.storage.repair.fetch",
+      "kind": "cli",
+      "name": "kungfu storage repair --scope episode --episode-id <id> --fetch --out repair-material.json --dry-run --json",
+      "state": "declared",
+      "detected": true,
+      "enforced": false,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "kfd1Basis": {
+        "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+        "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+        "digest": "sha256:62efd4eadd21ec5f8423dde21170316f8e597f1325fab0aebcdbf1b0dd4e6d1c"
+      },
+      "kfd2Trust": {
+        "status": "release-passport-required",
+        "trustImpact": "query-release-passport-for-final-trust",
+        "residualRisk": []
+      },
+      "residualRisk": []
+    },
+    {
       "id": "kungfu.storage.status",
       "kind": "cli",
       "name": "kungfu storage status --scope all --json",

--- a/.buildchain/kfd/kfd-3/collaboration-interface.artifact.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.artifact.json
@@ -10,8 +10,8 @@
   "sourceRegistry": {
     "id": "kungfu",
     "path": ".buildchain/kfd/kfd-3/surfaces.json",
-    "sha256": "cb5d10119888907da6f4cc32f9e3a5b3d77f07acff9e8ede2b1a93b7db2109ea",
-    "digest": "sha256:99f3698a746d07e6f9f323efb4e01adbfeb1742d1141c27876df4df7dd32a45f"
+    "sha256": "192bc86ac09d2eb59b10b842571eefbf78ee157458764018670ef6d8b9269e17",
+    "digest": "sha256:cacffca0d9ee7c8a2f67506df944e37067e24f2638d1ae3d3a66ef7fe336de93"
   },
   "upstreamKfd": {
     "aggregatePath": "developer/sdk/kfd/upstream-aggregate.json",
@@ -28,7 +28,7 @@
     },
     "digest": "sha256:aaa0a429cd6211f6469bf16255172c0fcc26259da290ae7858704ca732d849e0"
   },
-  "collaborationInterfaceDigest": "sha256:ecd975ab0e39218014c40b62489972b90c02ee676f9ab6cbc7821eb74f24c627",
+  "collaborationInterfaceDigest": "sha256:390d0b96e93e87f518367fb64f009c0fb301ba4ea46b1639ba32b68d87b37825",
   "exposedSurfaces": [
     {
       "id": "kungfu.agent",
@@ -1033,6 +1033,26 @@
     {
       "id": "kungfu.storage.repair.apply",
       "name": "kungfu storage repair --scope episode --episode-id <id> --apply --from <bundle.json> --dry-run --json",
+      "kind": "cli",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
+      "id": "kungfu.storage.repair.fetch",
+      "name": "kungfu storage repair --scope episode --episode-id <id> --fetch --out repair-material.json --dry-run --json",
       "kind": "cli",
       "participantProfile": "agent-or-developer",
       "state": "declared",

--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -5,16 +5,16 @@
   "witnessKind": "prebuild",
   "supportLevel": "release",
   "source": {
-    "cwd": "/Users/dkr/Worktrees/kungfu/feature/episode-repair-apply-v1",
-    "sourceSha": "02f78ae593a3ed0bef5d7323bec29a11b045d852",
+    "cwd": "/Users/dkr/Worktrees/kungfu/feature/episode-repair-fetch-v1",
+    "sourceSha": "19bc09ffe203d65575419b8d23b13d206bd4f4cc",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
-    "registryDigest": "sha256:99f3698a746d07e6f9f323efb4e01adbfeb1742d1141c27876df4df7dd32a45f"
+    "registryDigest": "sha256:cacffca0d9ee7c8a2f67506df944e37067e24f2638d1ae3d3a66ef7fe336de93"
   },
   "sourceRegistry": {
     "id": "kungfu",
     "path": ".buildchain/kfd/kfd-3/surfaces.json",
-    "sha256": "cb5d10119888907da6f4cc32f9e3a5b3d77f07acff9e8ede2b1a93b7db2109ea",
-    "digest": "sha256:99f3698a746d07e6f9f323efb4e01adbfeb1742d1141c27876df4df7dd32a45f"
+    "sha256": "192bc86ac09d2eb59b10b842571eefbf78ee157458764018670ef6d8b9269e17",
+    "digest": "sha256:cacffca0d9ee7c8a2f67506df944e37067e24f2638d1ae3d3a66ef7fe336de93"
   },
   "upstreamKfd": {
     "aggregatePath": "developer/sdk/kfd/upstream-aggregate.json",
@@ -34,7 +34,7 @@
   "expectedArtifactVerification": {
     "command": "node scripts/buildchain-kfd-evidence.mjs --artifact-witness --json"
   },
-  "collaborationInterfaceDigest": "sha256:ecd975ab0e39218014c40b62489972b90c02ee676f9ab6cbc7821eb74f24c627",
+  "collaborationInterfaceDigest": "sha256:390d0b96e93e87f518367fb64f009c0fb301ba4ea46b1639ba32b68d87b37825",
   "collaborationInterface": {
     "schemaVersion": 1,
     "contract": "kungfu-buildchain-kfd-3-surface-registry",
@@ -1081,6 +1081,26 @@
         }
       },
       {
+        "id": "kungfu.storage.repair.fetch",
+        "name": "kungfu storage repair --scope episode --episode-id <id> --fetch --out repair-material.json --dry-run --json",
+        "kind": "cli",
+        "participantProfile": "agent-or-developer",
+        "state": "declared",
+        "availability": "shipped",
+        "visibility": "public",
+        "participantFacing": true,
+        "public": true,
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+        "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+        "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+        "maturity": "experimental",
+        "declaration": {
+          "owner": "kungfu",
+          "source": "scripts/buildchain-kfd-evidence.mjs",
+          "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+        }
+      },
+      {
         "id": "kungfu.storage.status",
         "name": "kungfu storage status --scope all --json",
         "kind": "cli",
@@ -1163,8 +1183,8 @@
     ],
     "audit": {
       "status": "passed",
-      "declared": 55,
-      "artifactPublic": 55,
+      "declared": 56,
+      "artifactPublic": 56,
       "policy": {
         "sourceOfTruth": ".buildchain/kfd/kfd-3/surfaces.json",
         "detectedButUnregistered": "product-specific-audit",
@@ -2179,6 +2199,26 @@
     {
       "id": "kungfu.storage.repair.apply",
       "name": "kungfu storage repair --scope episode --episode-id <id> --apply --from <bundle.json> --dry-run --json",
+      "kind": "cli",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
+      "id": "kungfu.storage.repair.fetch",
+      "name": "kungfu storage repair --scope episode --episode-id <id> --fetch --out repair-material.json --dry-run --json",
       "kind": "cli",
       "participantProfile": "agent-or-developer",
       "state": "declared",

--- a/.buildchain/kfd/kfd-3/surfaces.json
+++ b/.buildchain/kfd/kfd-3/surfaces.json
@@ -1089,6 +1089,26 @@
       }
     },
     {
+      "id": "kungfu.storage.repair.fetch",
+      "name": "kungfu storage repair --scope episode --episode-id <id> --fetch --out repair-material.json --dry-run --json",
+      "kind": "cli",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
       "id": "kungfu.storage.status",
       "name": "kungfu storage status --scope all --json",
       "kind": "cli",

--- a/developer/sdk/kfd/kfd-2/claims/agent-onboarding-pack.json
+++ b/developer/sdk/kfd/kfd-2/claims/agent-onboarding-pack.json
@@ -16,7 +16,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "ef564727f7c6eed86ef01cbb5d64806012ba137a5cb867d1d32d3cd0d306b263"
+        "sha256": "55efae97c6dfe6d5640ff8fb569dcb20f758a70d6cf50b3f1da5613e510dc6f9"
       },
       "description": "Machine-readable command catalog and mode maturity metadata."
     },
@@ -54,7 +54,7 @@
     "evidenceSha256": [
       {
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "ef564727f7c6eed86ef01cbb5d64806012ba137a5cb867d1d32d3cd0d306b263"
+        "sha256": "55efae97c6dfe6d5640ff8fb569dcb20f758a70d6cf50b3f1da5613e510dc6f9"
       },
       {
         "path": "framework/core/src/python/kungfu/agent/mode-selection.md",
@@ -76,7 +76,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "ef564727f7c6eed86ef01cbb5d64806012ba137a5cb867d1d32d3cd0d306b263"
+        "sha256": "55efae97c6dfe6d5640ff8fb569dcb20f758a70d6cf50b3f1da5613e510dc6f9"
       }
     ]
   },
@@ -90,7 +90,7 @@
     {
       "name": "agent-command-catalog",
       "path": "framework/core/src/python/kungfu/agent/commands.json",
-      "sha256": "ef564727f7c6eed86ef01cbb5d64806012ba137a5cb867d1d32d3cd0d306b263",
+      "sha256": "55efae97c6dfe6d5640ff8fb569dcb20f758a70d6cf50b3f1da5613e510dc6f9",
       "expectedPackagePath": "kungfu/agent/commands.json"
     }
   ],

--- a/developer/sdk/kfd/kfd-2/claims/codex-report-receipts.json
+++ b/developer/sdk/kfd/kfd-2/claims/codex-report-receipts.json
@@ -52,7 +52,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/skills/codex/SKILL.md",
-        "sha256": "5abf198330bc42bff0ee486b36fd89701f6bd59964422d4e28e7b17b4cfb8576"
+        "sha256": "bab74a980ae981a0d6a7608e507fb5cdb4357c08b114cb8aa84c4e4d19174894"
       },
       "description": "Codex-side report closeout gate instructions shipped in the agent pack."
     }
@@ -79,7 +79,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/skills/codex/SKILL.md",
-        "sha256": "5abf198330bc42bff0ee486b36fd89701f6bd59964422d4e28e7b17b4cfb8576"
+        "sha256": "bab74a980ae981a0d6a7608e507fb5cdb4357c08b114cb8aa84c4e4d19174894"
       }
     ],
     "artifactSha256": [
@@ -89,7 +89,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/skills/codex/SKILL.md",
-        "sha256": "5abf198330bc42bff0ee486b36fd89701f6bd59964422d4e28e7b17b4cfb8576"
+        "sha256": "bab74a980ae981a0d6a7608e507fb5cdb4357c08b114cb8aa84c4e4d19174894"
       }
     ]
   },
@@ -103,7 +103,7 @@
     {
       "name": "codex-agent-skill",
       "path": "framework/core/src/python/kungfu/agent/skills/codex/SKILL.md",
-      "sha256": "5abf198330bc42bff0ee486b36fd89701f6bd59964422d4e28e7b17b4cfb8576",
+      "sha256": "bab74a980ae981a0d6a7608e507fb5cdb4357c08b114cb8aa84c4e4d19174894",
       "expectedPackagePath": "kungfu/agent/skills/codex/SKILL.md"
     }
   ],

--- a/developer/sdk/kfd/kfd-2/claims/remote-fact-boundary.json
+++ b/developer/sdk/kfd/kfd-2/claims/remote-fact-boundary.json
@@ -34,7 +34,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "ef564727f7c6eed86ef01cbb5d64806012ba137a5cb867d1d32d3cd0d306b263"
+        "sha256": "55efae97c6dfe6d5640ff8fb569dcb20f758a70d6cf50b3f1da5613e510dc6f9"
       },
       "description": "Remote add/sync command declarations and mode metadata."
     },
@@ -62,7 +62,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "ef564727f7c6eed86ef01cbb5d64806012ba137a5cb867d1d32d3cd0d306b263"
+        "sha256": "55efae97c6dfe6d5640ff8fb569dcb20f758a70d6cf50b3f1da5613e510dc6f9"
       },
       {
         "path": "framework/core/src/python/kungfu/cli/commands/agent.py",

--- a/developer/sdk/kfd/kfd-2/release-claims.json
+++ b/developer/sdk/kfd/kfd-2/release-claims.json
@@ -29,7 +29,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/commands.json",
-            "sha256": "ef564727f7c6eed86ef01cbb5d64806012ba137a5cb867d1d32d3cd0d306b263"
+            "sha256": "55efae97c6dfe6d5640ff8fb569dcb20f758a70d6cf50b3f1da5613e510dc6f9"
           },
           "description": "Machine-readable command catalog and mode maturity metadata."
         },
@@ -134,7 +134,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/skills/codex/SKILL.md",
-            "sha256": "5abf198330bc42bff0ee486b36fd89701f6bd59964422d4e28e7b17b4cfb8576"
+            "sha256": "bab74a980ae981a0d6a7608e507fb5cdb4357c08b114cb8aa84c4e4d19174894"
           },
           "description": "Codex-side report closeout gate instructions shipped in the agent pack."
         }
@@ -194,7 +194,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/commands.json",
-            "sha256": "ef564727f7c6eed86ef01cbb5d64806012ba137a5cb867d1d32d3cd0d306b263"
+            "sha256": "55efae97c6dfe6d5640ff8fb569dcb20f758a70d6cf50b3f1da5613e510dc6f9"
           },
           "description": "Remote add/sync command declarations and mode metadata."
         },

--- a/developer/sdk/kfd/kfd-3-surfaces.json
+++ b/developer/sdk/kfd/kfd-3-surfaces.json
@@ -1089,6 +1089,26 @@
       }
     },
     {
+      "id": "kungfu.storage.repair.fetch",
+      "name": "kungfu storage repair --scope episode --episode-id <id> --fetch --out repair-material.json --dry-run --json",
+      "kind": "cli",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
       "id": "kungfu.storage.status",
       "name": "kungfu storage status --scope all --json",
       "kind": "cli",

--- a/docs/episode-object-model.md
+++ b/docs/episode-object-model.md
@@ -324,6 +324,13 @@ target kind, role, Episode/frame/payload id fields, and a suggested action. The
 plan is not authority and does not mutate storage; authority remains the
 yijinjing Episode manifest journal plus the referenced payload/frame evidence.
 
+`kungfu.storage.repair-fetch/v1` is the read-only material discovery step. It
+consumes the repair plan, checks the local runtime and registered local remote
+mirror runtimes for matching Episode/source evidence, and emits
+`kungfu.storage.repair-material/v1` with Episode bundles and source bundles. It
+may write that material to an explicit output path, but it does not network
+fetch, apply, delete, compact, or mark a candidate repaired.
+
 `kungfu.storage.repair-apply/v1` is the first mutation-capable repair receipt,
 but it is still local-material only. It consumes an already available
 `kungfu.storage.episode-bundle/v1` or source export bundle, validates the

--- a/docs/runtime-storage-service.md
+++ b/docs/runtime-storage-service.md
@@ -96,7 +96,7 @@ backend choices replaceable: a backend can change without changing the
 The first `libkungfu` provider slice exposes
 `kungfu::runtime::storage_service_api::storage_service` and the
 `kungfu.runtime.storage-service/v1` operation surface for `status`, `fsck`,
-`repair_plan`, `export_bundle`, `import_bundle`, `rebuild_index`, `gc_plan`,
+`repair_plan`, `repair_fetch`, `export_bundle`, `import_bundle`, `rebuild_index`, `gc_plan`,
 `compact_plan`, `verify_sync`, and read-only `query`. The current default backend is a content-addressed file
 provider implemented in C++ under the runtime service. A second C++ provider
 stores the same source registry, manifests, and payload bodies in RocksDB behind
@@ -274,6 +274,15 @@ stable issue code, target kind, role, target id/hash fields, and suggested
 action. V1 deliberately does not fetch remote data, delete local data, compact
 providers, or mutate manifests. It only gives a future importer or remote sync
 source precise missing Episode, frame, or payload targets.
+
+`storage repair --fetch --out <json> --dry-run` is the local evidence collection
+step between plan and apply. It consumes the current repair plan, searches the
+current runtime plus already registered local remote mirrors under
+`runtime/remotes/<source-id>/runtime`, and emits
+`kungfu.storage.repair-material/v1` containing Episode bundles or source export
+bundles. Fetch writes a material artifact only when `--out` is explicit. It does
+not perform network sync, apply material, delete facts, compact providers, or
+mark anything repaired.
 
 `storage repair --apply --from <json>` is the explicit local-material follow-up
 to that plan. It consumes a validated `kungfu.storage.episode-bundle/v1` or
@@ -559,6 +568,9 @@ selector in the runtime storage service:
   declared Episode dependencies.
 - `storage repair --scope episode --episode-id <id> --plan --dry-run --json`
   maps degraded Episode causal graph warnings to read-only repair candidates.
+- `storage repair --scope episode --episode-id <id> --fetch --out <material>
+  --dry-run --json` searches only local runtime/mirror evidence and writes a
+  `kungfu.storage.repair-material/v1` artifact for later validation or apply.
 - `storage repair --scope episode --episode-id <id> --apply --from <bundle>
   --dry-run|--execute --json` validates local Episode material and, only with
   `--execute`, appends missing Episode manifest records while skipping records

--- a/framework/core/src/libkungfu/include/kungfu/runtime/storage/service.h
+++ b/framework/core/src/libkungfu/include/kungfu/runtime/storage/service.h
@@ -17,6 +17,7 @@ enum class storage_operation {
   Status,
   Fsck,
   RepairPlan,
+  RepairFetch,
   RepairApply,
   ExportBundle,
   ImportBundle,
@@ -64,6 +65,8 @@ public:
   [[nodiscard]] virtual nlohmann::json fsck(const storage_service_options &options) const = 0;
 
   [[nodiscard]] virtual nlohmann::json repair_plan(const storage_service_options &options) const = 0;
+
+  [[nodiscard]] virtual nlohmann::json repair_fetch(const storage_service_options &options) const = 0;
 
   [[nodiscard]] virtual nlohmann::json repair_apply(const storage_service_options &options) const = 0;
 

--- a/framework/core/src/libkungfu/src/runtime/storage/service.cpp
+++ b/framework/core/src/libkungfu/src/runtime/storage/service.cpp
@@ -1846,6 +1846,276 @@ nlohmann::json repair_apply_impl(const storage_service_options &options) {
                     })}};
 }
 
+struct repair_evidence_runtime {
+  std::string source = {};
+  fs::path runtime_dir = {};
+};
+
+std::string normalized_runtime_key(const fs::path &path) {
+  std::error_code ec;
+  auto normalized = fs::weakly_canonical(path, ec);
+  if (ec) {
+    normalized = fs::absolute(path, ec);
+  }
+  return normalized.lexically_normal().string();
+}
+
+void push_evidence_runtime(std::vector<repair_evidence_runtime> &runtimes, const std::string &source,
+                           const fs::path &runtime_dir) {
+  if (runtime_dir.empty()) {
+    return;
+  }
+  const auto key = normalized_runtime_key(runtime_dir);
+  for (const auto &existing : runtimes) {
+    if (normalized_runtime_key(existing.runtime_dir) == key) {
+      return;
+    }
+  }
+  runtimes.push_back({source, runtime_dir});
+}
+
+std::vector<repair_evidence_runtime> repair_evidence_runtimes(const storage_service_options &options) {
+  std::vector<repair_evidence_runtime> runtimes;
+  push_evidence_runtime(runtimes, "local-runtime", options.runtime_dir);
+  const auto remotes_dir = fs::path(options.runtime_dir) / "remotes";
+  std::error_code ec;
+  if (fs::exists(remotes_dir, ec) && fs::is_directory(remotes_dir, ec)) {
+    for (const auto &entry : fs::directory_iterator(remotes_dir, ec)) {
+      if (ec) {
+        break;
+      }
+      if (!entry.is_directory(ec)) {
+        continue;
+      }
+      const auto runtime_dir = entry.path() / "runtime";
+      if (fs::exists(runtime_dir, ec) && fs::is_directory(runtime_dir, ec)) {
+        push_evidence_runtime(runtimes, "remote-mirror:" + entry.path().filename().string(), runtime_dir);
+      }
+    }
+  }
+  for (const auto &extra : array_or_empty(options.operation_options, "candidate_runtime_dirs")) {
+    if (extra.is_string()) {
+      push_evidence_runtime(runtimes, "explicit-runtime", extra.get<std::string>());
+    }
+  }
+  return runtimes;
+}
+
+bool source_bundle_has_payload(const nlohmann::json &bundle, const std::string &payload_hash) {
+  if (payload_hash.empty()) {
+    return !array_or_empty(bundle, "records").empty();
+  }
+  for (const auto &record : array_or_empty(bundle, "records")) {
+    if (text_or(record, "payload_hash") == payload_hash && record.contains("payload")) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool episode_bundle_has_frame(const nlohmann::json &bundle, uint64_t frame_uid) {
+  if (frame_uid == 0) {
+    return !array_or_empty(bundle, "records").empty();
+  }
+  for (const auto &frame : array_or_empty(bundle, "frames")) {
+    if (uint64_or(frame, "frame_uid") == frame_uid) {
+      return true;
+    }
+  }
+  for (const auto &record : array_or_empty(bundle, "records")) {
+    if (text_or(record, "record_kind") == "episode_frame_attached" && uint64_or(record, "frame_uid") == frame_uid) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool episode_bundle_has_ref_hash(const nlohmann::json &bundle, const std::string &ref_hash) {
+  if (ref_hash.empty()) {
+    return !array_or_empty(bundle, "records").empty();
+  }
+  for (const auto &ref : array_or_empty(bundle, "refs")) {
+    if (text_or(ref, "ref_hash") == ref_hash) {
+      return true;
+    }
+  }
+  for (const auto &record : array_or_empty(bundle, "records")) {
+    if (text_or(record, "record_kind") == "episode_ref_attached" && text_or(record, "ref_hash") == ref_hash) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool episode_bundle_satisfies_candidate(const nlohmann::json &candidate, const nlohmann::json &bundle) {
+  const auto code = text_or(candidate, "code");
+  if (code == "repair_episode_root_trigger_frame" || code == "repair_episode_trigger_frame") {
+    return episode_bundle_has_frame(bundle, uint64_or(candidate, "frame_uid"));
+  }
+  if (code == "repair_episode_payload_ref") {
+    return episode_bundle_has_ref_hash(bundle, text_or(candidate, "ref_hash"));
+  }
+  if (code == "repair_episode_dependency") {
+    const auto dependency_episode_id = uint64_or(candidate, "dependency_episode_id");
+    return dependency_episode_id == 0 || uint64_or(bundle, "episode_id") == dependency_episode_id ||
+           uint64_or(object_or_empty(bundle, "manifest"), "episode_id") == dependency_episode_id;
+  }
+  return false;
+}
+
+void push_unique_bundle(nlohmann::json &bundles, std::vector<std::string> &seen, const nlohmann::json &bundle) {
+  const auto key = text_or(bundle, "schema") + ":" + text_or(bundle, "bundle_id", canonical_json(bundle));
+  if (std::find(seen.begin(), seen.end(), key) != seen.end()) {
+    return;
+  }
+  seen.push_back(key);
+  bundles.push_back(bundle);
+}
+
+nlohmann::json repair_fetch_impl(const storage_service_options &options, const storage_service &service) {
+  if (!options.dry_run) {
+    throw std::invalid_argument("storage_repair_fetch_is_read_only");
+  }
+  auto plan_options = options;
+  plan_options.dry_run = true;
+  const auto plan = repair_plan_impl(plan_options);
+  const auto runtimes = repair_evidence_runtimes(options);
+  nlohmann::json material = {
+      {"schema", "kungfu.storage.repair-material/v1"},
+      {"generated_by", "kungfu.storage.repair-fetch/v1"},
+      {"episode_bundles", nlohmann::json::array()},
+      {"source_bundles", nlohmann::json::array()},
+  };
+  std::vector<std::string> seen_episode_bundles;
+  std::vector<std::string> seen_source_bundles;
+  nlohmann::json matched = nlohmann::json::array();
+  nlohmann::json skipped = nlohmann::json::array();
+  nlohmann::json missing = nlohmann::json::array();
+
+  for (const auto &candidate : array_or_empty(plan, "candidates")) {
+    const auto code = text_or(candidate, "code");
+    bool found = false;
+    if (code == "repair_source_payload") {
+      const auto source_id = text_or(candidate, "source_id", options.source_id);
+      const auto payload_hash = text_or(candidate, "payload_hash");
+      for (const auto &runtime : runtimes) {
+        try {
+          auto candidate_options = options;
+          candidate_options.runtime_dir = runtime.runtime_dir.string();
+          candidate_options.scope = "source";
+          candidate_options.source_id = source_id;
+          const auto bundle = service.export_bundle(candidate_options);
+          if (!source_bundle_has_payload(bundle, payload_hash)) {
+            skipped.push_back({{"candidate", candidate},
+                               {"evidence_source", runtime.source},
+                               {"runtime_dir", runtime.runtime_dir.string()},
+                               {"reason", "payload_not_in_bundle"}});
+            continue;
+          }
+          push_unique_bundle(material["source_bundles"], seen_source_bundles, bundle);
+          matched.push_back({{"candidate", candidate},
+                             {"evidence_source", runtime.source},
+                             {"runtime_dir", runtime.runtime_dir.string()},
+                             {"material", "source_bundle"}});
+          found = true;
+          break;
+        } catch (const std::exception &e) {
+          skipped.push_back({{"candidate", candidate},
+                             {"evidence_source", runtime.source},
+                             {"runtime_dir", runtime.runtime_dir.string()},
+                             {"reason", e.what()}});
+        }
+      }
+    } else if (text_or(candidate, "kind") == "episode" || text_or(candidate, "kind") == "frame" ||
+               code == "repair_episode_payload_ref") {
+      std::vector<uint64_t> episode_ids;
+      const auto requested_episode_id = uint64_or(candidate, "episode_id", options.episode_id);
+      if (requested_episode_id != 0) {
+        episode_ids.push_back(requested_episode_id);
+      }
+      const auto dependency_episode_id = uint64_or(candidate, "dependency_episode_id");
+      if (dependency_episode_id != 0 &&
+          std::find(episode_ids.begin(), episode_ids.end(), dependency_episode_id) == episode_ids.end()) {
+        episode_ids.push_back(dependency_episode_id);
+      }
+      for (const auto &runtime : runtimes) {
+        for (const auto episode_id : episode_ids) {
+          try {
+            auto candidate_options = options;
+            candidate_options.runtime_dir = runtime.runtime_dir.string();
+            candidate_options.scope = "episode";
+            candidate_options.episode_id = episode_id;
+            const auto bundle = service.export_bundle(candidate_options);
+            if (!episode_bundle_satisfies_candidate(candidate, bundle)) {
+              skipped.push_back({{"candidate", candidate},
+                                 {"evidence_source", runtime.source},
+                                 {"runtime_dir", runtime.runtime_dir.string()},
+                                 {"episode_id", episode_id},
+                                 {"reason", "episode_evidence_not_in_bundle"}});
+              continue;
+            }
+            push_unique_bundle(material["episode_bundles"], seen_episode_bundles, bundle);
+            matched.push_back({{"candidate", candidate},
+                               {"evidence_source", runtime.source},
+                               {"runtime_dir", runtime.runtime_dir.string()},
+                               {"episode_id", episode_id},
+                               {"material", "episode_bundle"}});
+            found = true;
+            break;
+          } catch (const std::exception &e) {
+            skipped.push_back({{"candidate", candidate},
+                               {"evidence_source", runtime.source},
+                               {"runtime_dir", runtime.runtime_dir.string()},
+                               {"episode_id", episode_id},
+                               {"reason", e.what()}});
+          }
+        }
+        if (found) {
+          break;
+        }
+      }
+    }
+    if (!found) {
+      missing.push_back(candidate);
+    }
+  }
+
+  const auto written = !options.artifact_uri.empty();
+  if (written) {
+    write_json_file(options.artifact_uri, material);
+  }
+  return {
+      {"ok", missing.empty()},
+      {"schema", "kungfu.storage.repair-fetch/v1"},
+      {"scope", options.scope.empty() ? "all" : options.scope},
+      {"source_id", options.source_id.empty() ? nlohmann::json(nullptr) : nlohmann::json(options.source_id)},
+      {"episode_id", options.episode_id == 0 ? nlohmann::json(nullptr) : nlohmann::json(options.episode_id)},
+      {"dry_run", true},
+      {"read_only", true},
+      {"artifact_uri", options.artifact_uri.empty() ? nlohmann::json(nullptr) : nlohmann::json(options.artifact_uri)},
+      {"written", written},
+      {"plan", plan},
+      {"evidence_runtimes",
+       [&] {
+         nlohmann::json rows = nlohmann::json::array();
+         for (const auto &runtime : runtimes) {
+           rows.push_back({{"source", runtime.source}, {"runtime_dir", runtime.runtime_dir.string()}});
+         }
+         return rows;
+       }()},
+      {"material", material},
+      {"matched", matched},
+      {"matched_count", matched.size()},
+      {"skipped", skipped},
+      {"missing", missing},
+      {"missing_count", missing.size()},
+      {"notes", nlohmann::json::array({
+                    "Repair fetch v1 only searches local runtime evidence and registered remote mirror runtimes.",
+                    "It writes a local material artifact only when artifact_uri/--out is explicitly supplied.",
+                    "It never applies material, deletes, compacts, garbage-collects, or performs network fetch.",
+                })}};
+}
+
 nlohmann::json episode_import_bundle_impl(const storage_service_options &options) {
   if (!options.bundle.is_object() || text_or(options.bundle, "schema") != "kungfu.storage.episode-bundle/v1") {
     throw std::invalid_argument("episode_bundle_invalid");
@@ -2540,6 +2810,10 @@ public:
     return repair_plan_impl(options);
   }
 
+  [[nodiscard]] nlohmann::json repair_fetch(const storage_service_options &options) const override {
+    return repair_fetch_impl(options, *this);
+  }
+
   [[nodiscard]] nlohmann::json repair_apply(const storage_service_options &options) const override {
     return repair_apply_impl(options);
   }
@@ -2773,6 +3047,7 @@ std::vector<std::string> storage_operation_names() {
       storage_operation_name(storage_operation::Status),
       storage_operation_name(storage_operation::Fsck),
       storage_operation_name(storage_operation::RepairPlan),
+      storage_operation_name(storage_operation::RepairFetch),
       storage_operation_name(storage_operation::RepairApply),
       storage_operation_name(storage_operation::ExportBundle),
       storage_operation_name(storage_operation::ImportBundle),
@@ -2801,6 +3076,8 @@ std::string storage_operation_name(storage_operation operation) {
     return "fsck";
   case storage_operation::RepairPlan:
     return "repair_plan";
+  case storage_operation::RepairFetch:
+    return "repair_fetch";
   case storage_operation::RepairApply:
     return "repair_apply";
   case storage_operation::ExportBundle:
@@ -2848,6 +3125,9 @@ storage_operation parse_storage_operation(const std::string &operation) {
   }
   if (operation == "repair_plan") {
     return storage_operation::RepairPlan;
+  }
+  if (operation == "repair_fetch") {
+    return storage_operation::RepairFetch;
   }
   if (operation == "repair_apply") {
     return storage_operation::RepairApply;
@@ -2964,6 +3244,8 @@ nlohmann::json run_storage_service_operation(const std::string &operation, const
     return storage_service_instance().fsck(parsed_options);
   case storage_operation::RepairPlan:
     return storage_service_instance().repair_plan(parsed_options);
+  case storage_operation::RepairFetch:
+    return storage_service_instance().repair_fetch(parsed_options);
   case storage_operation::RepairApply:
     return storage_service_instance().repair_apply(parsed_options);
   case storage_operation::ExportBundle:

--- a/framework/core/src/python/kungfu/agent/brief.md
+++ b/framework/core/src/python/kungfu/agent/brief.md
@@ -49,6 +49,7 @@ snapshot it and verify the projection with:
 kungfu atlas import --repo <atlas-repo> --json
 kungfu storage fsck --scope all --json
 kungfu storage repair --scope episode --episode-id <id> --plan --dry-run --json
+kungfu storage repair --scope episode --episode-id <id> --fetch --out repair-material.json --dry-run --json
 kungfu storage repair --scope episode --episode-id <id> --apply --from <bundle.json> --dry-run --json
 kungfu storage verify-sync --source <source-id> --json
 kungfu atlas show import --json

--- a/framework/core/src/python/kungfu/agent/commands.json
+++ b/framework/core/src/python/kungfu/agent/commands.json
@@ -176,6 +176,12 @@
       "purpose": "Convert degraded storage and Episode fsck diagnostics into machine-readable repair candidates without mutating facts."
     },
     {
+      "apiId": "kungfu.storage.repair.fetch",
+      "name": "kungfu storage repair --scope episode --episode-id <id> --fetch --out repair-material.json --dry-run --json",
+      "maturity": "experimental",
+      "purpose": "Collect local repair material from the runtime and registered remote mirrors into a JSON artifact without applying it."
+    },
+    {
       "apiId": "kungfu.storage.repair.apply",
       "name": "kungfu storage repair --scope episode --episode-id <id> --apply --from <bundle.json> --dry-run --json",
       "maturity": "experimental",

--- a/framework/core/src/python/kungfu/agent/kfd3_api.registry.json
+++ b/framework/core/src/python/kungfu/agent/kfd3_api.registry.json
@@ -314,6 +314,16 @@
       "projections": ["commands.json", "agent-pack-doc", "provider-skill"]
     },
     {
+      "id": "kungfu.storage.repair.fetch",
+      "surface": "cli",
+      "name": "kungfu storage repair --scope episode --episode-id <id> --fetch --out repair-material.json --dry-run --json",
+      "purpose": "Collect local repair material from the runtime and registered remote mirrors into a JSON artifact without applying it.",
+      "maturity": "experimental",
+      "visibility": "adjacent-agent",
+      "anchor": { "kind": "catalog" },
+      "projections": ["commands.json", "agent-pack-doc", "provider-skill"]
+    },
+    {
       "id": "kungfu.storage.repair.apply",
       "surface": "cli",
       "name": "kungfu storage repair --scope episode --episode-id <id> --apply --from <bundle.json> --dry-run --json",

--- a/framework/core/src/python/kungfu/agent/skills/claude/SKILL.md
+++ b/framework/core/src/python/kungfu/agent/skills/claude/SKILL.md
@@ -48,6 +48,7 @@ For Atlas projection, the source repo remains authoritative. Import and verify:
 kungfu atlas import --repo <atlas-repo> --json
 kungfu storage fsck --scope all --json
 kungfu storage repair --scope episode --episode-id <id> --plan --dry-run --json
+kungfu storage repair --scope episode --episode-id <id> --fetch --out repair-material.json --dry-run --json
 kungfu storage repair --scope episode --episode-id <id> --apply --from <bundle.json> --dry-run --json
 kungfu storage verify-sync --source <source-id> --json
 kungfu atlas show import --json

--- a/framework/core/src/python/kungfu/agent/skills/codex/SKILL.md
+++ b/framework/core/src/python/kungfu/agent/skills/codex/SKILL.md
@@ -48,6 +48,7 @@ For Atlas projection, the source repo remains authoritative. Import and verify:
 kungfu atlas import --repo <atlas-repo> --json
 kungfu storage fsck --scope all --json
 kungfu storage repair --scope episode --episode-id <id> --plan --dry-run --json
+kungfu storage repair --scope episode --episode-id <id> --fetch --out repair-material.json --dry-run --json
 kungfu storage repair --scope episode --episode-id <id> --apply --from <bundle.json> --dry-run --json
 kungfu storage verify-sync --source <source-id> --json
 kungfu atlas show import --json

--- a/framework/core/src/python/kungfu/cli/commands/storage.py
+++ b/framework/core/src/python/kungfu/cli/commands/storage.py
@@ -136,11 +136,19 @@ def fsck(ctx, scope, storage_source_id, episode_id, as_json):
         sys.exit(1)
 
 
-@storage.command(help="plan read-only repairs for degraded runtime storage")
+@storage.command(
+    help="plan, fetch, or apply local repairs for degraded runtime storage"
+)
 @click.option("--scope", type=click.Choice(["source", "episode", "all"]), required=True)
 @click.option("--source", "storage_source_id", type=str, default=None)
 @click.option("--episode-id", type=int, default=0)
 @click.option("--plan", "plan_only", is_flag=True, help="emit a read-only repair plan")
+@click.option(
+    "--fetch",
+    "fetch_requested",
+    is_flag=True,
+    help="collect local repair material from runtime mirrors",
+)
 @click.option(
     "--apply",
     "apply_requested",
@@ -149,6 +157,13 @@ def fsck(ctx, scope, storage_source_id, episode_id, as_json):
 )
 @click.option(
     "--from", "from_path", type=str, default=None, help="repair material JSON path"
+)
+@click.option(
+    "--out",
+    "out_path",
+    type=str,
+    default=None,
+    help="write fetched repair material JSON",
 )
 @click.option(
     "--dry-run",
@@ -167,19 +182,22 @@ def repair(
     storage_source_id,
     episode_id,
     plan_only,
+    fetch_requested,
     apply_requested,
     from_path,
+    out_path,
     dry_run,
     execute,
     as_json,
 ):
     from kungfu.storage import service
 
-    if plan_only and apply_requested:
-        click.echo("[storage] choose either --plan or --apply", err=True)
+    selected = sum(1 for item in (plan_only, fetch_requested, apply_requested) if item)
+    if selected > 1:
+        click.echo("[storage] choose only one of --plan, --fetch, or --apply", err=True)
         sys.exit(2)
-    if not plan_only and not apply_requested:
-        click.echo("[storage] repair v1 requires --plan or --apply", err=True)
+    if selected == 0:
+        click.echo("[storage] repair v1 requires --plan, --fetch, or --apply", err=True)
         sys.exit(2)
     if scope == "source":
         _require_source(storage_source_id)
@@ -194,6 +212,23 @@ def repair(
             ctx.runtime_dir,
             source_id=storage_source_id if scope == "source" else None,
             episode_id=episode_id if scope == "episode" else None,
+            dry_run=True,
+        )
+    elif fetch_requested:
+        if execute:
+            click.echo(
+                "[storage] repair fetch is read-only; --execute is not supported",
+                err=True,
+            )
+            sys.exit(2)
+        if not dry_run:
+            click.echo("[storage] repair fetch requires --dry-run", err=True)
+            sys.exit(2)
+        result = service.repair_fetch(
+            ctx.runtime_dir,
+            source_id=storage_source_id if scope == "source" else None,
+            episode_id=episode_id if scope == "episode" else None,
+            out_path=out_path,
             dry_run=True,
         )
     else:
@@ -229,6 +264,13 @@ def repair(
                 "  candidate: "
                 f"{candidate.get('code')} -> {candidate.get('suggested_action')}"
             )
+    elif fetch_requested:
+        out = result.get("artifact_uri") or "<memory>"
+        click.echo(
+            f"[storage] repair fetch {scope}: "
+            f"matched={result.get('matched_count', 0)} "
+            f"missing={result.get('missing_count', 0)} out={out}"
+        )
     else:
         click.echo(
             f"[storage] repair apply {scope}: "

--- a/framework/core/src/python/kungfu/remote/store.py
+++ b/framework/core/src/python/kungfu/remote/store.py
@@ -17,7 +17,7 @@ import tarfile
 from pathlib import Path
 from typing import Any
 
-SYNC_DIRS = ("journal", "rewind", "work")
+SYNC_DIRS = ("journal", "rewind", "work", "storage")
 LOCAL_HOSTS = {"", "local", "localhost", "127.0.0.1", "::1"}
 
 
@@ -301,7 +301,7 @@ def sync_source(runtime_dir: str, source_id: str) -> dict[str, Any]:
         "copied": copied,
         "capture_boundary": (
             "remote facts stay source-scoped under remotes/<source-id>/runtime; "
-            "journal/rewind/work are mirrored but not merged into the local "
+            "journal/rewind/work/storage are mirrored but not merged into the local "
             "authoritative runtime"
         ),
     }

--- a/framework/core/src/python/kungfu/storage/service.py
+++ b/framework/core/src/python/kungfu/storage/service.py
@@ -419,6 +419,30 @@ def repair_plan(
     )
 
 
+def repair_fetch(
+    runtime_dir: str | Path,
+    *,
+    source_id: str | None = None,
+    episode_id: int | None = None,
+    out_path: str | Path | None = None,
+    dry_run: bool = True,
+) -> dict[str, Any]:
+    scope = "episode" if episode_id else ("source" if source_id else "all")
+    return dict(
+        _runtime().run_storage_service_operation(
+            "repair_fetch",
+            str(runtime_dir),
+            {
+                "scope": scope,
+                "source_id": source_id,
+                "episode_id": _u64(episode_id),
+                "dry_run": dry_run,
+                "artifact_uri": str(out_path) if out_path else "",
+            },
+        )
+    )
+
+
 def repair_apply(
     runtime_dir: str | Path,
     repair_input: dict[str, Any],

--- a/framework/core/tests/python/test_atlas_storage.py
+++ b/framework/core/tests/python/test_atlas_storage.py
@@ -365,6 +365,7 @@ def test_runtime_storage_service_surface_is_bound_from_libkungfu(tmp_path):
         "status",
         "fsck",
         "repair_plan",
+        "repair_fetch",
         "repair_apply",
         "export_bundle",
         "import_bundle",
@@ -492,6 +493,7 @@ def test_python_storage_operations_enter_runtime_service_surface(tmp_path, monke
     storage_service.layout(runtime_dir)
     storage_service.fsck(runtime_dir, source_id="local-synth")
     storage_service.repair_plan(runtime_dir, source_id="local-synth", dry_run=True)
+    storage_service.repair_fetch(runtime_dir, source_id="local-synth", dry_run=True)
     storage_service.repair_apply(
         runtime_dir,
         storage_service.build_export_bundle(runtime_dir, source_id="local-synth"),
@@ -526,6 +528,7 @@ def test_python_storage_operations_enter_runtime_service_surface(tmp_path, monke
         "layout",
         "fsck",
         "repair_plan",
+        "repair_fetch",
         "repair_apply",
         "rebuild_index",
         "gc_plan",
@@ -752,7 +755,7 @@ def test_episode_fsck_reports_degraded_causal_dependencies(tmp_path):
         candidate["safe_to_apply"] is False for candidate in repair["candidates"]
     )
 
-    donor_dir = tmp_path / "donor-runtime"
+    donor_dir = runtime_dir / "remotes" / "donor" / "runtime"
     storage_service.episode_begin(
         donor_dir,
         episode_id=7,
@@ -813,10 +816,24 @@ def test_episode_fsck_reports_degraded_causal_dependencies(tmp_path):
         frame_count=2,
         reason="done",
     )
-    repair_bundle = storage_service.build_export_bundle(donor_dir, episode_id=7)
+    fetch_out = tmp_path / "episode-repair-material.json"
+    fetched = storage_service.repair_fetch(
+        runtime_dir, episode_id=7, out_path=fetch_out, dry_run=True
+    )
+    assert fetched["schema"] == "kungfu.storage.repair-fetch/v1"
+    assert fetched["dry_run"] is True
+    assert fetched["read_only"] is True
+    assert fetched["written"] is True
+    assert fetch_out.exists()
+    assert fetched["matched_count"] >= 2
+    assert fetched["material"]["schema"] == "kungfu.storage.repair-material/v1"
+    assert fetched["material"]["episode_bundles"]
+    assert any(
+        row["evidence_source"] == "remote-mirror:donor" for row in fetched["matched"]
+    )
 
     dry_apply = storage_service.repair_apply(
-        runtime_dir, repair_bundle, episode_id=7, dry_run=True
+        runtime_dir, fetched["material"], episode_id=7, dry_run=True
     )
     assert dry_apply["schema"] == "kungfu.storage.repair-apply/v1"
     assert dry_apply["dry_run"] is True
@@ -825,7 +842,7 @@ def test_episode_fsck_reports_degraded_causal_dependencies(tmp_path):
     assert storage_service.fsck(runtime_dir, episode_id=7)["status"] == "degraded"
 
     applied = storage_service.repair_apply(
-        runtime_dir, repair_bundle, episode_id=7, dry_run=False
+        runtime_dir, fetched["material"], episode_id=7, dry_run=False
     )
     assert applied["schema"] == "kungfu.storage.repair-apply/v1"
     assert applied["applied"] is True
@@ -1338,11 +1355,19 @@ def test_storage_fsck_reports_degraded_status_for_recorded_payload_states(tmp_pa
     assert repair["candidates"][0]["subject"] == "note:note-missing"
     assert repair["candidates"][0]["payload_hash"]
 
-    material = storage_service.build_export_bundle(
-        runtime_dir, source_id="degraded-synth"
+    fetch_out = tmp_path / "source-repair-material.json"
+    fetched = storage_service.repair_fetch(
+        runtime_dir, source_id="degraded-synth", out_path=fetch_out, dry_run=True
     )
+    assert fetched["schema"] == "kungfu.storage.repair-fetch/v1"
+    assert fetched["ok"]
+    assert fetched["written"] is True
+    assert fetch_out.exists()
+    assert fetched["matched_count"] == 1
+    assert fetched["material"]["source_bundles"]
+
     dry_apply = storage_service.repair_apply(
-        runtime_dir, material, source_id="degraded-synth", dry_run=True
+        runtime_dir, fetched["material"], source_id="degraded-synth", dry_run=True
     )
     assert dry_apply["schema"] == "kungfu.storage.repair-apply/v1"
     assert dry_apply["dry_run"] is True
@@ -1354,7 +1379,7 @@ def test_storage_fsck_reports_degraded_status_for_recorded_payload_states(tmp_pa
     )
 
     applied = storage_service.repair_apply(
-        runtime_dir, material, source_id="degraded-synth", dry_run=False
+        runtime_dir, fetched["material"], source_id="degraded-synth", dry_run=False
     )
     assert applied["applied"] is True
     assert applied["applied_count"] >= 1

--- a/framework/core/tests/storage-node-binding.test.js
+++ b/framework/core/tests/storage-node-binding.test.js
@@ -127,6 +127,11 @@ function selectedNodeResults(runtimeDir) {
       source_id: 'node-synth',
       dry_run: true,
     }),
+    repairFetch: kungfu.runStorageServiceOperation('repair_fetch', runtimeDir, {
+      scope: 'source',
+      source_id: 'node-synth',
+      dry_run: true,
+    }),
     repairApply: kungfu.runStorageServiceOperation('repair_apply', runtimeDir, {
       scope: 'source',
       source_id: 'node-synth',
@@ -203,6 +208,7 @@ out = {
     ),
     "fsck": service.fsck(runtime_dir, source_id="node-synth"),
     "repair": service.repair_plan(runtime_dir, source_id="node-synth", dry_run=True),
+    "repairFetch": service.repair_fetch(runtime_dir, source_id="node-synth", dry_run=True),
     "repairApply": service.repair_apply(
         runtime_dir,
         bundle,
@@ -340,6 +346,12 @@ for (const providerCase of providerCases) {
             'kungfu.storage.repair-plan/v1',
           );
           assert.equal(nodeResults.repair.candidate_count, 0);
+          assert.equal(
+            nodeResults.repairFetch.schema,
+            'kungfu.storage.repair-fetch/v1',
+          );
+          assert.equal(nodeResults.repairFetch.read_only, true);
+          assert.equal(nodeResults.repairFetch.matched_count, 0);
           assert.equal(
             nodeResults.repairApply.schema,
             'kungfu.storage.repair-apply/v1',


### PR DESCRIPTION
## Summary
- Add C++ storage_service repair_fetch operation that consumes repair_plan output and collects local repair material from the runtime plus registered remote mirrors.
- Expose repair fetch through Python and CLI as storage repair --fetch --out, and include it in agent/KFD discovery surfaces.
- Extend remote mirror sync to include storage evidence and cover source/Episode repair-fetch-to-apply flows in tests.

## Validation
- ./kungfu-code build
- ./kungfu-code check
- PYTHONPATH=src/python:build/Release DYLD_FALLBACK_LIBRARY_PATH=build/Release uv run --frozen pytest tests/python/test_atlas_storage.py -q
- KUNGFU_DIR=/Users/dkr/Worktrees/kungfu/feature/episode-repair-fetch-v1/framework/core/dist/kungfu pnpm --filter @kungfu-tech/core run test:storage-binding
- CLI smoke: plan -> fetch --out -> apply --dry-run -> apply --execute -> fsck ok on /tmp/kungfu-repair-fetch.f7bB5X