### PR TITLE
feat(storage): rebuildable SQLite projection for source-registry (ADR-0037 slice 2)

### DIFF
--- a/framework/core/docs/adr/ADR-0037-storage-records-hana-core-kernel-metadata.md
+++ b/framework/core/docs/adr/ADR-0037-storage-records-hana-core-kernel-metadata.md
@@ -167,17 +167,27 @@ or a sibling catalog-plane journal, not diverge into two incompatible layouts.
   `source_record_accepted_range` / `source_list` / `source_inspect` /
   `source_registry_fsck`).
 - Project it to SQLite via the Hana → SQLite path; store any body as
-  content-addressed bytes. **(pending, slice 2)** — the source-registry slice
-  folds directly from the journal (as the Episode manifest slice does); the
-  SQLite projection and content-addressed payload bodies are the next sub-slice
-  and reuse the existing Hana → SQLite path, not new machinery.
+  content-addressed bytes. **(SQLite projection done, slice 2)** — the
+  source-registry records project to a rebuildable SQLite cache through
+  `cache::make_storage_ptr` over `SourceRegistryDataTypes` (the same compile-time
+  Hana closed-set → SQLite column path the profile / session / state caches use,
+  not the hand-written raw-SQL projection that serves the JSON manifest layer and
+  not the `.bfbs` reflection projector). `source_registry_rebuild` replays the
+  journal into the typed tables; the journal stays the authority and the
+  projection is fully rebuildable. **Content-addressed payload bodies remain
+  deferred**: source-registry records carry no large payload bodies, so the
+  `.json`-envelope → raw-bytes change belongs with the payload / import-manifest
+  slice, not here.
 - Keep `storage status` / `storage export` as the JSON edge projection over the
-  record; `fsck` verifies journal + payload + projection. **(done, slice 1 for
+  record; `fsck` verifies journal + payload + projection. **(done, slice 1–2 for
   the source registry)** — `source_list` / `source_inspect` return JSON edge
-  projections labelled `authority: yijinjing-journal`, and `source_registry_fsck`
+  projections labelled `authority: yijinjing-journal`; `source_registry_fsck`
   reopens journal frames to check fold consistency (missing / duplicate
-  registration, dangling head). Payload/projection verification arrives with
-  slice 2.
+  registration, dangling head) **and now also verifies the SQLite projection
+  against the journal fold** — projection drift is reported as `degraded` (the
+  journal is intact, the derived cache just needs a rebuild), a missing
+  projection as a distinct honest state. Payload verification arrives with the
+  payload slice.
 - Then migrate the remaining storage-service records and retire the
   JSON-as-contract path and the unconsumed heap structs / `provider.h`.
   **(later)** — import manifest, export bundle, and channel cursor still use the

--- a/framework/core/src/libkungfu/include/kungfu/runtime/cache/backend.h
+++ b/framework/core/src/libkungfu/include/kungfu/runtime/cache/backend.h
@@ -80,6 +80,7 @@ constexpr auto make_storage_ptr = [](const std::string &db_file, const auto &typ
 using ProfileStoragePtr = decltype(make_storage_ptr(std::string(), yijinjing::ProfileDataTypes));
 using SessionStoragePtr = decltype(make_storage_ptr(std::string(), yijinjing::SessionDataTypes));
 using StateStoragePtr = decltype(make_storage_ptr(std::string(), yijinjing::StateDataTypes));
+using SourceRegistryStoragePtr = decltype(make_storage_ptr(std::string(), yijinjing::SourceRegistryDataTypes));
 
 template <typename, typename = void, bool = true> struct time_spec;
 

--- a/framework/core/src/libkungfu/include/kungfu/runtime/storage/service.h
+++ b/framework/core/src/libkungfu/include/kungfu/runtime/storage/service.h
@@ -41,6 +41,7 @@ enum class storage_operation {
   SourceList,
   SourceInspect,
   SourceRegistryFsck,
+  SourceRegistryRebuild,
 };
 
 struct storage_service_options {
@@ -119,6 +120,8 @@ public:
   [[nodiscard]] virtual nlohmann::json source_inspect(const storage_service_options &options) const = 0;
 
   [[nodiscard]] virtual nlohmann::json source_registry_fsck(const storage_service_options &options) const = 0;
+
+  [[nodiscard]] virtual nlohmann::json source_registry_rebuild(const storage_service_options &options) const = 0;
 };
 
 [[nodiscard]] std::vector<std::string> storage_operation_names();

--- a/framework/core/src/libkungfu/include/kungfu/runtime/storage/source_registry_projection.h
+++ b/framework/core/src/libkungfu/include/kungfu/runtime/storage/source_registry_projection.h
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef KUNGFU_RUNTIME_STORAGE_SOURCE_REGISTRY_PROJECTION_H
+#define KUNGFU_RUNTIME_STORAGE_SOURCE_REGISTRY_PROJECTION_H
+
+#include <string>
+
+#include <nlohmann/json.hpp>
+
+namespace kungfu::runtime::storage_service_api {
+
+inline constexpr const char *SOURCE_REGISTRY_PROJECTION_SCHEMA_V1 = "kungfu.storage.source-registry-projection/v1";
+
+// ADR-0037: rebuildable SQLite projection of the source-registry kernel journal.
+// It reuses the compile-time Hana closed-set -> SQLite column path
+// (cache::make_storage_ptr over SourceRegistryDataTypes), the same path the
+// profile / session / state caches use, not the hand-written raw-SQL projection
+// that serves the JSON manifest layer, and not the .bfbs reflection projector
+// (which serves the FlatBuffers open layer). The journal remains the authority;
+// this projection is derived and can be rebuilt at any time.
+class source_registry_projection {
+public:
+  explicit source_registry_projection(std::string runtime_dir);
+
+  [[nodiscard]] std::string sqlite_path() const;
+
+  [[nodiscard]] bool exists() const;
+
+  // Rebuild the SQLite projection from the journal: sync schema, clear tables,
+  // replace every journal record. Returns per-table row counts.
+  [[nodiscard]] nlohmann::json rebuild() const;
+
+  // Verify the projection against the journal fold. Reports drift (projection
+  // row counts diverging from journal record counts) as degraded, missing
+  // projection as a distinct honest state, not silently ok.
+  [[nodiscard]] nlohmann::json verify() const;
+
+private:
+  std::string runtime_dir_;
+};
+
+} // namespace kungfu::runtime::storage_service_api
+
+#endif // KUNGFU_RUNTIME_STORAGE_SOURCE_REGISTRY_PROJECTION_H

--- a/framework/core/src/libkungfu/src/runtime/storage/service.cpp
+++ b/framework/core/src/libkungfu/src/runtime/storage/service.cpp
@@ -15,6 +15,7 @@
 #include <utility>
 #include <vector>
 
+#include <kungfu/runtime/storage/source_registry_projection.h>
 #include <kungfu/yijinjing/storage/content_hash.h>
 #include <kungfu/yijinjing/storage/episode_manifest.h>
 #include <kungfu/yijinjing/storage/generic_service.h>
@@ -3117,7 +3118,26 @@ public:
   }
 
   [[nodiscard]] nlohmann::json source_registry_fsck(const storage_service_options &options) const override {
-    return source_registry_store(options).fsck(text_or(options.operation_options, "source_id", options.source_id));
+    const auto source_id = text_or(options.operation_options, "source_id", options.source_id);
+    auto report = source_registry_store(options).fsck(source_id);
+    // ADR-0037: fsck verifies journal + projection. The journal is the
+    // authority; a rebuildable projection that has drifted from it is degraded,
+    // not failed.
+    auto projection = source_registry_projection(options.runtime_dir).verify();
+    report["projection"] = projection;
+    const bool journal_ok = report.value("ok", false);
+    const bool projection_degraded = projection.value("status", std::string("ok")) == "degraded";
+    report["ok"] = journal_ok && !projection_degraded;
+    if (!journal_ok) {
+      report["status"] = "failed";
+    } else if (projection_degraded) {
+      report["status"] = "degraded";
+    }
+    return report;
+  }
+
+  [[nodiscard]] nlohmann::json source_registry_rebuild(const storage_service_options &options) const override {
+    return source_registry_projection(options.runtime_dir).rebuild();
   }
 };
 
@@ -3174,6 +3194,7 @@ std::vector<std::string> storage_operation_names() {
       storage_operation_name(storage_operation::SourceList),
       storage_operation_name(storage_operation::SourceInspect),
       storage_operation_name(storage_operation::SourceRegistryFsck),
+      storage_operation_name(storage_operation::SourceRegistryRebuild),
   };
 }
 
@@ -3233,6 +3254,8 @@ std::string storage_operation_name(storage_operation operation) {
     return "source_inspect";
   case storage_operation::SourceRegistryFsck:
     return "source_registry_fsck";
+  case storage_operation::SourceRegistryRebuild:
+    return "source_registry_rebuild";
   }
   throw std::invalid_argument("unknown storage operation");
 }
@@ -3318,6 +3341,9 @@ storage_operation parse_storage_operation(const std::string &operation) {
   }
   if (operation == "source_registry_fsck") {
     return storage_operation::SourceRegistryFsck;
+  }
+  if (operation == "source_registry_rebuild") {
+    return storage_operation::SourceRegistryRebuild;
   }
   throw std::invalid_argument("unsupported storage operation: " + operation);
 }
@@ -3431,6 +3457,8 @@ nlohmann::json run_storage_service_operation(const std::string &operation, const
     return storage_service_instance().source_inspect(parsed_options);
   case storage_operation::SourceRegistryFsck:
     return storage_service_instance().source_registry_fsck(parsed_options);
+  case storage_operation::SourceRegistryRebuild:
+    return storage_service_instance().source_registry_rebuild(parsed_options);
   }
   throw std::invalid_argument("unknown storage operation");
 }

--- a/framework/core/src/libkungfu/src/runtime/storage/source_registry_projection.cpp
+++ b/framework/core/src/libkungfu/src/runtime/storage/source_registry_projection.cpp
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#include <kungfu/runtime/storage/source_registry_projection.h>
+
+#include <filesystem>
+#include <set>
+#include <utility>
+
+#include <kungfu/runtime/cache/backend.h>
+#include <kungfu/yijinjing/schema/registry.h>
+#include <kungfu/yijinjing/storage/source_registry.h>
+
+namespace fs = std::filesystem;
+
+namespace kungfu::runtime::storage_service_api {
+
+namespace {
+
+fs::path projection_path(const std::string &runtime_dir) {
+  return fs::path(runtime_dir) / "storage" / "projections" / "source-registry.sqlite";
+}
+
+// Distinct-primary-key journal counts. The SQLite tables upsert by primary key
+// (SourceRegistered by source_uid; SourceHeadUpdated by source_uid+update_time;
+// AcceptedRangeRecorded by source_uid+manifest_uid), so the honest expected row
+// count is the distinct-PK count, not the raw append count.
+struct distinct_counts {
+  size_t registered = 0;
+  size_t head_updates = 0;
+  size_t accepted_ranges = 0;
+};
+
+distinct_counts distinct_pk_counts(const yijinjing::storage::source_registry_journal_records &records) {
+  std::set<uint64_t> registered_uids;
+  for (const auto &record : records.registered) {
+    registered_uids.insert(record.source_uid);
+  }
+  std::set<std::pair<uint64_t, int64_t>> head_keys;
+  for (const auto &record : records.head_updates) {
+    head_keys.emplace(record.source_uid, record.update_time);
+  }
+  std::set<std::pair<uint64_t, uint64_t>> accepted_keys;
+  for (const auto &record : records.accepted_ranges) {
+    accepted_keys.emplace(record.source_uid, record.manifest_uid);
+  }
+  return {registered_uids.size(), head_keys.size(), accepted_keys.size()};
+}
+
+} // namespace
+
+source_registry_projection::source_registry_projection(std::string runtime_dir)
+    : runtime_dir_(std::move(runtime_dir)) {}
+
+std::string source_registry_projection::sqlite_path() const { return projection_path(runtime_dir_).string(); }
+
+bool source_registry_projection::exists() const { return fs::exists(projection_path(runtime_dir_)); }
+
+nlohmann::json source_registry_projection::rebuild() const {
+  const auto path = projection_path(runtime_dir_);
+  fs::create_directories(path.parent_path());
+
+  auto storage = cache::make_storage_ptr(path.string(), yijinjing::SourceRegistryDataTypes);
+  storage->pragma.journal_mode(sqlite_orm::journal_mode::WAL);
+  storage->pragma.synchronous(0);
+  storage->sync_schema();
+
+  // The journal is the authority; the projection is a full rebuild over it.
+  storage->remove_all<yijinjing::types::SourceRegistered>();
+  storage->remove_all<yijinjing::types::SourceHeadUpdated>();
+  storage->remove_all<yijinjing::types::AcceptedRangeRecorded>();
+
+  const auto records = yijinjing::storage::source_registry_store(runtime_dir_).read_typed_records();
+  for (const auto &record : records.registered) {
+    storage->replace(record);
+  }
+  for (const auto &record : records.head_updates) {
+    storage->replace(record);
+  }
+  for (const auto &record : records.accepted_ranges) {
+    storage->replace(record);
+  }
+
+  return {
+      {"ok", true},
+      {"schema", SOURCE_REGISTRY_PROJECTION_SCHEMA_V1},
+      {"runtime_dir", runtime_dir_},
+      {"authority", "yijinjing-journal"},
+      {"projection", "sqlite"},
+      {"sqlite_path", path.string()},
+      {"rows",
+       {{"source_registered", storage->count<yijinjing::types::SourceRegistered>()},
+        {"source_head_updated", storage->count<yijinjing::types::SourceHeadUpdated>()},
+        {"accepted_range_recorded", storage->count<yijinjing::types::AcceptedRangeRecorded>()}}},
+      {"journal_records",
+       {{"source_registered", records.registered.size()},
+        {"source_head_updated", records.head_updates.size()},
+        {"accepted_range_recorded", records.accepted_ranges.size()}}},
+  };
+}
+
+nlohmann::json source_registry_projection::verify() const {
+  const auto path = projection_path(runtime_dir_);
+  const auto records = yijinjing::storage::source_registry_store(runtime_dir_).read_typed_records();
+  const auto expected = distinct_pk_counts(records);
+  const bool has_records =
+      !records.registered.empty() || !records.head_updates.empty() || !records.accepted_ranges.empty();
+
+  if (!fs::exists(path)) {
+    // Missing projection is a distinct honest state, not a silent ok: if the
+    // journal has records, the projection needs a rebuild before SQL queries.
+    return {
+        {"ok", true},
+        {"status", has_records ? "absent" : "ok"},
+        {"schema", SOURCE_REGISTRY_PROJECTION_SCHEMA_V1},
+        {"runtime_dir", runtime_dir_},
+        {"authority", "yijinjing-journal"},
+        {"projection_present", false},
+        {"note", has_records ? "projection not built; run source_registry_rebuild to enable SQL queries"
+                             : "no source-registry records; projection not needed"},
+    };
+  }
+
+  auto storage = cache::make_storage_ptr(path.string(), yijinjing::SourceRegistryDataTypes);
+  storage->on_open = [](sqlite3 *db) { sqlite3_busy_timeout(db, 5000); };
+  storage->sync_schema();
+
+  const size_t projected_registered = storage->count<yijinjing::types::SourceRegistered>();
+  const size_t projected_head = storage->count<yijinjing::types::SourceHeadUpdated>();
+  const size_t projected_accepted = storage->count<yijinjing::types::AcceptedRangeRecorded>();
+
+  nlohmann::json drift = nlohmann::json::array();
+  const auto check = [&](const char *table, size_t projected, size_t journal_expected) {
+    if (projected != journal_expected) {
+      drift.push_back({{"table", table}, {"projection_rows", projected}, {"journal_distinct", journal_expected}});
+    }
+  };
+  check("source_registered", projected_registered, expected.registered);
+  check("source_head_updated", projected_head, expected.head_updates);
+  check("accepted_range_recorded", projected_accepted, expected.accepted_ranges);
+
+  const bool degraded = !drift.empty();
+  return {
+      {"ok", !degraded},
+      {"status", degraded ? "degraded" : "ok"},
+      {"schema", SOURCE_REGISTRY_PROJECTION_SCHEMA_V1},
+      {"runtime_dir", runtime_dir_},
+      {"authority", "yijinjing-journal"},
+      {"projection_present", true},
+      {"degraded", degraded},
+      {"drift", drift},
+      {"rows",
+       {{"source_registered", projected_registered},
+        {"source_head_updated", projected_head},
+        {"accepted_range_recorded", projected_accepted}}},
+      {"journal_distinct",
+       {{"source_registered", expected.registered},
+        {"source_head_updated", expected.head_updates},
+        {"accepted_range_recorded", expected.accepted_ranges}}},
+  };
+}
+
+} // namespace kungfu::runtime::storage_service_api

--- a/framework/core/src/libyijinjing/include/kungfu/yijinjing/schema/registry.h
+++ b/framework/core/src/libyijinjing/include/kungfu/yijinjing/schema/registry.h
@@ -165,6 +165,16 @@ constexpr auto StateDataTypes = boost::hana::make_map( //
     TYPE_PAIR(TimeKeyValue)                            // 10602
 );
 
+// ADR-0037: the source-registry kernel records project to SQLite through the
+// same compile-time Hana closed-set -> SQLite column path (make_storage_ptr)
+// used by the profile / session / state caches, not the hand-written raw-SQL
+// projection that serves the JSON manifest layer.
+constexpr auto SourceRegistryDataTypes = boost::hana::make_map( //
+    TYPE_PAIR(SourceRegistered),                                // 10901
+    TYPE_PAIR(SourceHeadUpdated),                               // 10902
+    TYPE_PAIR(AcceptedRangeRecorded)                            // 10903
+);
+
 constexpr auto StaticDataTypes = boost::hana::make_map();
 constexpr auto StatisticDataTypes = boost::hana::make_map();
 

--- a/framework/core/src/libyijinjing/include/kungfu/yijinjing/storage/source_registry.h
+++ b/framework/core/src/libyijinjing/include/kungfu/yijinjing/storage/source_registry.h
@@ -5,6 +5,7 @@
 
 #include <cstdint>
 #include <string>
+#include <vector>
 
 #include <nlohmann/json.hpp>
 
@@ -58,11 +59,24 @@ struct accepted_range_options {
   yijinjing::enums::SourceVerificationStatus status = yijinjing::enums::SourceVerificationStatus::Ok;
 };
 
+// Typed POD records folded off the journal, in append order. The store stays
+// the journal authority: higher layers (e.g. the libkungfu SQLite projection)
+// read POD records through here rather than re-opening the journal themselves.
+struct source_registry_journal_records {
+  std::vector<yijinjing::types::SourceRegistered> registered = {};
+  std::vector<yijinjing::types::SourceHeadUpdated> head_updates = {};
+  std::vector<yijinjing::types::AcceptedRangeRecorded> accepted_ranges = {};
+};
+
 class source_registry_store {
 public:
   explicit source_registry_store(std::string runtime_dir);
 
   [[nodiscard]] std::string runtime_dir() const { return runtime_dir_; }
+
+  // Read the journal back as typed POD records (append order). Authority for
+  // rebuildable projections such as the SQLite cache.
+  [[nodiscard]] source_registry_journal_records read_typed_records() const;
 
   // Append-only writers. Each writes one POD record to the journal and returns
   // its JSON edge projection.

--- a/framework/core/src/libyijinjing/src/storage/source_registry.cpp
+++ b/framework/core/src/libyijinjing/src/storage/source_registry.cpp
@@ -217,6 +217,34 @@ std::map<uint64_t, source_fold> fold_records(const std::vector<nlohmann::json> &
 
 source_registry_store::source_registry_store(std::string runtime_dir) : runtime_dir_(std::move(runtime_dir)) {}
 
+source_registry_journal_records source_registry_store::read_typed_records() const {
+  source_registry_journal_records records;
+  const auto location = registry_location(runtime_dir_);
+  if (location->locator->list_page_id(location, location::PUBLIC).empty()) {
+    return records;
+  }
+  auto reader = std::make_shared<kungfu::yijinjing::journal::reader>(true, false, std::make_shared<bus>(false));
+  reader->join(location, location::PUBLIC, 0);
+  while (reader->data_available()) {
+    const auto frame = reader->current_frame();
+    switch (frame->carrier_type()) {
+    case SourceRegistered::tag:
+      records.registered.push_back(frame->data<SourceRegistered>());
+      break;
+    case SourceHeadUpdated::tag:
+      records.head_updates.push_back(frame->data<SourceHeadUpdated>());
+      break;
+    case AcceptedRangeRecorded::tag:
+      records.accepted_ranges.push_back(frame->data<AcceptedRangeRecorded>());
+      break;
+    default:
+      break;
+    }
+    reader->next();
+  }
+  return records;
+}
+
 nlohmann::json source_registry_store::register_source(const source_register_options &options) const {
   if (options.source_id.empty()) {
     throw std::invalid_argument("source_id is required");

--- a/framework/core/tests/python/test_atlas_storage.py
+++ b/framework/core/tests/python/test_atlas_storage.py
@@ -389,6 +389,7 @@ def test_runtime_storage_service_surface_is_bound_from_libkungfu(tmp_path):
         "source_list",
         "source_inspect",
         "source_registry_fsck",
+        "source_registry_rebuild",
     }
 
     request = runtime.make_storage_service_request(
@@ -1532,3 +1533,120 @@ def test_source_registry_fsck_flags_dangling_head_without_registration(tmp_path)
     assert fsck["ok"] is False
     assert fsck["status"] == "failed"
     assert any(err["code"] == "source_registration_missing" for err in fsck["errors"])
+
+
+def test_source_registry_sqlite_projection_rebuilds_from_journal(tmp_path):
+    # ADR-0037 slice 2: the source-registry journal projects to a rebuildable
+    # SQLite cache via the compile-time Hana -> SQLite path. The journal stays
+    # the authority; the projection is derived and fsck verifies it against the
+    # journal fold.
+    runtime = kungfu.__binding__.runtime
+    runtime_dir = str(tmp_path)
+
+    runtime.run_storage_service_operation(
+        "source_register",
+        runtime_dir,
+        {"source_id": "atlas-local", "kind": "adapter", "register_time": 1000},
+    )
+    runtime.run_storage_service_operation(
+        "source_register",
+        runtime_dir,
+        {"source_id": "runtime-b", "kind": "kungfu_runtime", "register_time": 1001},
+    )
+    runtime.run_storage_service_operation(
+        "source_update_head",
+        runtime_dir,
+        {"source_id": "atlas-local", "head": "h1", "update_time": 2000},
+    )
+    runtime.run_storage_service_operation(
+        "source_record_accepted_range",
+        runtime_dir,
+        {"source_id": "atlas-local", "manifest_id": "m1", "accept_time": 3000},
+    )
+
+    projection_db = tmp_path / "storage" / "projections" / "source-registry.sqlite"
+
+    # Before any rebuild, fsck honestly reports the projection is absent (records
+    # exist but no projection is built) without failing the journal check.
+    pre = runtime.run_storage_service_operation("source_registry_fsck", runtime_dir, {})
+    assert pre["ok"]
+    assert pre["projection"]["projection_present"] is False
+    assert pre["projection"]["status"] == "absent"
+    assert not projection_db.exists()
+
+    rebuilt = runtime.run_storage_service_operation(
+        "source_registry_rebuild", runtime_dir, {}
+    )
+    assert rebuilt["ok"]
+    assert rebuilt["authority"] == "yijinjing-journal"
+    assert rebuilt["rows"] == {
+        "source_registered": 2,
+        "source_head_updated": 1,
+        "accepted_range_recorded": 1,
+    }
+    assert projection_db.exists()
+
+    # The projection is a real, query-able SQLite database with typed tables
+    # derived straight from the POD records. The kind column holds the POD enum
+    # value (SourceKind::Adapter == 4, KungfuRuntime == 3), not the JSON edge
+    # name — the projection mirrors the kernel record, the same way the profile /
+    # session / state caches store their enums as integers.
+    with sqlite3.connect(projection_db) as conn:
+        registered = conn.execute(
+            "SELECT source_id, kind FROM SourceRegistered ORDER BY source_id"
+        ).fetchall()
+    assert registered == [("atlas-local", 4), ("runtime-b", 3)]
+
+    post = runtime.run_storage_service_operation(
+        "source_registry_fsck", runtime_dir, {}
+    )
+    assert post["ok"]
+    assert post["status"] == "ok"
+    assert post["projection"]["projection_present"] is True
+    assert post["projection"]["status"] == "ok"
+    assert post["projection"]["rows"] == {
+        "source_registered": 2,
+        "source_head_updated": 1,
+        "accepted_range_recorded": 1,
+    }
+
+
+def test_source_registry_projection_fsck_detects_drift(tmp_path):
+    # A projection that has fallen behind the journal is degraded, not failed:
+    # the journal is intact, the derived cache just needs a rebuild.
+    runtime = kungfu.__binding__.runtime
+    runtime_dir = str(tmp_path)
+
+    runtime.run_storage_service_operation(
+        "source_register",
+        runtime_dir,
+        {"source_id": "s1", "register_time": 1000},
+    )
+    runtime.run_storage_service_operation("source_registry_rebuild", runtime_dir, {})
+
+    # New journal record after the rebuild: projection now lags the journal.
+    runtime.run_storage_service_operation(
+        "source_register",
+        runtime_dir,
+        {"source_id": "s2", "register_time": 1001},
+    )
+
+    fsck = runtime.run_storage_service_operation(
+        "source_registry_fsck", runtime_dir, {}
+    )
+    assert fsck["ok"] is False
+    assert fsck["status"] == "degraded"
+    projection = fsck["projection"]
+    assert projection["status"] == "degraded"
+    assert projection["degraded"] is True
+    drift = {row["table"]: row for row in projection["drift"]}
+    assert drift["source_registered"]["projection_rows"] == 1
+    assert drift["source_registered"]["journal_distinct"] == 2
+
+    # Rebuilding reconciles the projection back to the journal.
+    runtime.run_storage_service_operation("source_registry_rebuild", runtime_dir, {})
+    healed = runtime.run_storage_service_operation(
+        "source_registry_fsck", runtime_dir, {}
+    )
+    assert healed["ok"]
+    assert healed["projection"]["status"] == "ok"


### PR DESCRIPTION
Slice 2 of ADR-0037: project the source-registry kernel journal to a rebuildable SQLite cache via the compile-time Hana closed-set to SQLite path (make_storage_ptr over SourceRegistryDataTypes). Adds source_registry_rebuild; source_registry_fsck now verifies journal + projection, treating drift as degraded. Content-addressed payload bodies stay deferred to the payload/import slice. 24/24 storage tests pass.