### PR TITLE
feat(view): verify open-layer frames at the access boundary (spatial safety)

### DIFF
--- a/framework/core/slices/view-encapsulation/probe.cpp
+++ b/framework/core/slices/view-encapsulation/probe.cpp
@@ -104,10 +104,11 @@ int main() {
   auto ins = view::insert_sql(thin, "quote", true);
   sqlite3_stmt *st = nullptr;
   assert(sqlite3_prepare_v2(db, ins.c_str(), -1, &st, nullptr) == SQLITE_OK);
-  int next = h.bind_frame(st, thin, dbuf);
-  sqlite3_bind_int64(st, next, 1000);
-  sqlite3_bind_int64(st, next + 1, 7);
-  sqlite3_bind_int64(st, next + 2, 9);
+  auto next = h.bind_frame(st, thin, dbuf, data.size());
+  assert(next.has_value()); // valid frame verifies + binds
+  sqlite3_bind_int64(st, *next, 1000);
+  sqlite3_bind_int64(st, *next + 1, 7);
+  sqlite3_bind_int64(st, *next + 2, 9);
   assert(sqlite3_step(st) == SQLITE_DONE);
   sqlite3_finalize(st);
   assert(sqlite3_prepare_v2(db, "SELECT id, ts_ns, state, kf_gen_time, kf_frame_uid, kf_stream_id FROM quote", -1, &st,
@@ -126,13 +127,21 @@ int main() {
   assert(sqlite3_exec(db, ddl2.c_str(), nullptr, nullptr, nullptr) == SQLITE_OK);
   auto ins2 = view::insert_sql(full, "quote_full", false);
   assert(sqlite3_prepare_v2(db, ins2.c_str(), -1, &st, nullptr) == SQLITE_OK);
-  h.bind_frame(st, full, dbuf);
+  assert(h.bind_frame(st, full, dbuf, data.size()).has_value());
   assert(sqlite3_step(st) == SQLITE_DONE);
   sqlite3_finalize(st);
   assert(sqlite3_prepare_v2(db, "SELECT price, symbol FROM quote_full", -1, &st, nullptr) == SQLITE_OK);
   assert(sqlite3_step(st) == SQLITE_ROW);
   assert(sqlite3_column_double(st, 0) == 3.5);
   assert(std::string(reinterpret_cast<const char *>(sqlite3_column_text(st, 1))) == "AAPL");
+  sqlite3_finalize(st);
+
+  // spatial safety: a malformed/truncated frame is verified-and-skipped, never
+  // dereferenced — bind_frame returns nullopt and binds nothing.
+  assert(sqlite3_prepare_v2(db, ins.c_str(), -1, &st, nullptr) == SQLITE_OK);
+  assert(!h.bind_frame(st, thin, dbuf, 4).has_value()); // truncated
+  const uint8_t garbage[16] = {0xff, 0xff, 0xff, 0xff, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+  assert(!h.bind_frame(st, thin, garbage, sizeof(garbage)).has_value()); // bad offsets
   sqlite3_finalize(st);
 
   // schema evolution: co-owned bytes swap, re-plan, ALTER picks up the new column

--- a/framework/core/src/libkungfu/include/kungfu/runtime/cache/fb_schema_registry.h
+++ b/framework/core/src/libkungfu/include/kungfu/runtime/cache/fb_schema_registry.h
@@ -21,6 +21,7 @@
 
 #include <cstdint>
 #include <map>
+#include <optional>
 #include <sqlite3.h>
 #include <stdexcept>
 #include <string>
@@ -101,18 +102,25 @@ private:
 
 // 把一帧零拷贝投影入库：经 handle 反射 bind 业务列；thin 模式追加 journal 回环坐标
 // (kf_gen_time/kf_frame_uid/kf_stream_id)，列序与 kungfu::view::insert_sql 一致。
-inline void project_frame(sqlite3 *db, const SchemaRegistry::Entry &e, const uint8_t *buf, int64_t gen_time,
-                          uint64_t frame_uid, uint64_t stream_id) {
+// 把一帧零拷贝投影入库：handle.bind_frame 先按 schema verify 再 bind 业务列，坏帧(verify 失败)
+// 直接跳过、不入库并返回 false；thin 模式追加 journal 回环坐标。返回是否成功投影。
+[[nodiscard]] inline bool project_frame(sqlite3 *db, const SchemaRegistry::Entry &e, const uint8_t *buf, size_t len,
+                                        int64_t gen_time, uint64_t frame_uid, uint64_t stream_id) {
   sqlite3_stmt *ins = nullptr;
   sqlite3_prepare_v2(db, e.insert_sql.c_str(), -1, &ins, nullptr);
-  int next = e.handle.bind_frame(ins, e.cols, buf);
+  const std::optional<int> next = e.handle.bind_frame(ins, e.cols, buf, len);
+  if (!next) { // 坏/截断 buffer：一列都不 bind，跳过该帧
+    sqlite3_finalize(ins);
+    return false;
+  }
   if (e.thin) {
-    sqlite3_bind_int64(ins, next, gen_time);
-    sqlite3_bind_int64(ins, next + 1, static_cast<int64_t>(frame_uid));
-    sqlite3_bind_int64(ins, next + 2, static_cast<int64_t>(stream_id));
+    sqlite3_bind_int64(ins, *next, gen_time);
+    sqlite3_bind_int64(ins, *next + 1, static_cast<int64_t>(frame_uid));
+    sqlite3_bind_int64(ins, *next + 2, static_cast<int64_t>(stream_id));
   }
   sqlite3_step(ins);
   sqlite3_finalize(ins);
+  return true;
 }
 
 } // namespace kungfu::runtime::cache::projector

--- a/framework/core/src/libkungfu/include/kungfu/runtime/cache/open_layer_projector.h
+++ b/framework/core/src/libkungfu/include/kungfu/runtime/cache/open_layer_projector.h
@@ -112,12 +112,24 @@ public:
       const auto *entry = registry_.find(p.carrier_type);
       if (entry == nullptr)
         continue;
-      projector::project_frame(db_, *entry, reinterpret_cast<const uint8_t *>(p.payload.data()), p.gen_time,
-                               p.frame_uid, p.stream_id);
+      // project_frame verifies the frame against its schema before binding; a
+      // malformed/truncated frame is skipped (not inserted) rather than driving
+      // an out-of-bounds reflection read. Count + warn so a bad producer is
+      // observable without aborting the whole batch.
+      const bool ok = projector::project_frame(db_, *entry, reinterpret_cast<const uint8_t *>(p.payload.data()),
+                                               p.payload.size(), p.gen_time, p.frame_uid, p.stream_id);
+      if (!ok) {
+        ++skipped_frames_;
+        SPDLOG_WARN("open-layer projector: skipped malformed frame (carrier_type={}, gen_time={}, {} bytes)",
+                    p.carrier_type, p.gen_time, p.payload.size());
+      }
     }
     sqlite3_exec(db_, "COMMIT", nullptr, nullptr, nullptr);
     return batch.size();
   }
+
+  // 累计因 verify 失败被跳过的坏帧数（诊断用；flush_mtx_ 下累加）。
+  [[nodiscard]] uint64_t skipped_frames() const { return skipped_frames_; }
 
   // 启动后台 flush worker（生产异步模式）。幂等：已启动则忽略。
   void start_worker(int64_t interval_ms = 100) {
@@ -170,6 +182,7 @@ private:
   std::thread worker_;
   std::atomic<bool> worker_running_{false};
   std::atomic<bool> quit_{false};
+  uint64_t skipped_frames_ = 0; // verify 失败被跳过的坏帧数（flush_mtx_ 下累加）
 };
 
 DECLARE_PTR(open_layer_projector)

--- a/framework/core/src/libkungfu/include/kungfu/view/schema.h
+++ b/framework/core/src/libkungfu/include/kungfu/view/schema.h
@@ -26,6 +26,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -83,13 +84,22 @@ public:
   // (pk)/(ts)/(status)-attributed columns (the thin index); full projects all.
   [[nodiscard]] std::vector<col_plan> plan_columns(bool thin) const;
 
-  // Bind one zero-copy frame's projected columns into a prepared statement,
-  // reflecting each field's value by BaseType. `buf` points at the FlatBuffers
-  // table root. Returns the next 1-based placeholder index.
-  int bind_frame(sqlite3_stmt *st, const std::vector<col_plan> &cols, const uint8_t *buf) const;
+  // Verify then bind one frame's projected columns into a prepared statement.
+  // `buf`/`len` delimit the FlatBuffers table buffer; this runs
+  // flatbuffers::Verify against the schema *before* any field access, so a
+  // malformed or truncated frame cannot drive an out-of-bounds reflection read
+  // (spatial safety at the access boundary, not left to the caller). On a
+  // buffer that fails verification returns std::nullopt and binds nothing; on
+  // success reflects each field by BaseType and returns the next 1-based
+  // placeholder index. This is the only way to read a frame through the handle;
+  // there is no unchecked variant (the open-layer projection path is cold, so
+  // per-frame verification is negligible next to the SQLite write).
+  [[nodiscard]] std::optional<int> bind_frame(sqlite3_stmt *st, const std::vector<col_plan> &cols, const uint8_t *buf,
+                                              size_t len) const;
 
-  // Verify a data FlatBuffers table buffer against this schema before access.
-  // For untrusted frame buffers; returns false on any bounds violation.
+  // Verify a data FlatBuffers table buffer against this schema (bounds-check the
+  // whole table graph). bind_frame runs this internally; exposed for callers
+  // that want to validate a buffer without binding.
   [[nodiscard]] bool verify_table(const uint8_t *buf, size_t len) const;
 
 private:

--- a/framework/core/src/libkungfu/src/view/schema.cpp
+++ b/framework/core/src/libkungfu/src/view/schema.cpp
@@ -95,7 +95,12 @@ std::vector<col_plan> schema_handle::plan_columns(bool thin) const {
   return cols;
 }
 
-int schema_handle::bind_frame(sqlite3_stmt *st, const std::vector<col_plan> &cols, const uint8_t *buf) const {
+std::optional<int> schema_handle::bind_frame(sqlite3_stmt *st, const std::vector<col_plan> &cols, const uint8_t *buf,
+                                             size_t len) const {
+  // Bounds-check the whole table graph against the schema before any field
+  // access — a malformed/truncated frame is skipped, never dereferenced.
+  if (!verify_table(buf, len))
+    return std::nullopt;
   const reflection::Schema *s = schema_of(*bfbs_);
   const auto *fields = s->root_table()->fields();
   const flatbuffers::Table *root = flatbuffers::GetAnyRoot(buf);


### PR DESCRIPTION
Second hardening step under ADR-0039 (view-hardening parent). bind_frame now runs flatbuffers::Verify against the schema before any field access, so a malformed/truncated open-layer frame is skipped (returns std::optional nullopt), never dereferenced into an out-of-bounds reflection read. No unchecked variant: the open-layer projection is a cold async/batched path (per-frame verify is negligible next to the SQLite write) and the lock-free hot path (POD frame reads) carries no FlatBuffers and is untouched. project_frame returns bool; flush counts + warns skipped frames. Full core build green, view slice asserts truncated/garbage frames skip.