### PR TITLE
feat(storage): payload bodies are opaque content-addressed bytes (ADR-0037)

### DIFF
--- a/framework/core/docs/adr/ADR-0037-storage-records-hana-core-kernel-metadata.md
+++ b/framework/core/docs/adr/ADR-0037-storage-records-hana-core-kernel-metadata.md
@@ -174,10 +174,14 @@ or a sibling catalog-plane journal, not diverge into two incompatible layouts.
   not the hand-written raw-SQL projection that serves the JSON manifest layer and
   not the `.bfbs` reflection projector). `source_registry_rebuild` replays the
   journal into the typed tables; the journal stays the authority and the
-  projection is fully rebuildable. **Content-addressed payload bodies remain
-  deferred**: source-registry records carry no large payload bodies, so the
-  `.json`-envelope → raw-bytes change belongs with the payload / import-manifest
-  slice, not here.
+  projection is fully rebuildable. **Content-addressed payload bodies done
+  (payload slice)** — payload bodies are now stored as opaque bytes named by the
+  content hash alone (`storage/payloads/<hash-prefix>/<sha256>`, no
+  format-implying extension), in both the C++ runtime storage service and the
+  Python atlas importer. Body format is orthogonal to the record schema; the
+  manifest entry commits to the body by hash, length, and `content_type`
+  metadata. This decouples and precedes the import-manifest migration, whose
+  entries reference payloads by hash.
 - Keep `storage status` / `storage export` as the JSON edge projection over the
   record; `fsck` verifies journal + payload + projection. **(done, slice 1–2 for
   the source registry)** — `source_list` / `source_inspect` return JSON edge

--- a/framework/core/src/libkungfu/src/runtime/storage/service.cpp
+++ b/framework/core/src/libkungfu/src/runtime/storage/service.cpp
@@ -348,7 +348,11 @@ fs::path sqlite_projection_path(const std::string &runtime_dir) {
 }
 
 fs::path payload_path(const std::string &runtime_dir, const std::string &digest) {
-  return payload_root(runtime_dir) / digest.substr(0, std::min<size_t>(2, digest.size())) / (digest + ".json");
+  // ADR-0037: payload bodies are opaque content-addressed bytes. The file is
+  // named by the content hash alone, with no format-implying extension — the
+  // body format is orthogonal to the record schema, which commits to the body
+  // by hash, length, and payload state (content_type is record metadata).
+  return payload_root(runtime_dir) / digest.substr(0, std::min<size_t>(2, digest.size())) / digest;
 }
 
 fs::path source_manifest_dir(const std::string &runtime_dir, const std::string &source_id) {
@@ -490,7 +494,7 @@ public:
     return {
         {"source_registry", "storage/sources.json"},
         {"source_manifests", "storage/sources/<source-id>/manifests/*.json"},
-        {"payloads", "storage/payloads/<hash-prefix>/<sha256>.json"},
+        {"payloads", "storage/payloads/<hash-prefix>/<sha256>"},
     };
   }
 
@@ -849,7 +853,7 @@ nlohmann::json workspace_episode_layout(const storage_service_options &options, 
   const auto episode_manifest_dir =
       journal_dir / "system" / yy_storage::EPISODE_MANIFEST_NAMESPACE / yy_storage::EPISODE_MANIFEST_NAME / "live";
   const auto source_manifest_pattern = storage_dir / "sources" / "<source-id>" / "manifests" / "*.json";
-  const auto payload_pattern = storage_dir / "payloads" / "<hash-prefix>" / "<sha256>.json";
+  const auto payload_pattern = storage_dir / "payloads" / "<hash-prefix>" / "<sha256>";
 
   return {
       {"schema", "kungfu.workspace.episode-layout/v1"},
@@ -983,7 +987,9 @@ std::vector<fs::path> all_payload_paths(const std::string &runtime_dir) {
       continue;
     }
     for (const auto &entry : fs::directory_iterator(prefix.path())) {
-      if (entry.is_regular_file() && entry.path().extension() == ".json") {
+      // Payload bodies are opaque content-addressed files named by hash, with no
+      // extension (ADR-0037); every regular file under a prefix is a body.
+      if (entry.is_regular_file()) {
         paths.emplace_back(entry.path());
       }
     }
@@ -992,7 +998,11 @@ std::vector<fs::path> all_payload_paths(const std::string &runtime_dir) {
   return paths;
 }
 
-std::string payload_digest_from_path(const fs::path &path) { return path.stem().string(); }
+std::string payload_digest_from_path(const fs::path &path) {
+  // Bodies are named by the full content hash with no extension; the whole
+  // filename is the digest.
+  return path.filename().string();
+}
 
 nlohmann::json source_projection_from_manifest(const nlohmann::json &manifest) {
   if (manifest.contains("source") && manifest.at("source").is_object()) {

--- a/framework/core/src/python/kungfu/atlas/payloads.py
+++ b/framework/core/src/python/kungfu/atlas/payloads.py
@@ -61,8 +61,12 @@ def _runtime():
 
 
 def payload_path(store_dir: str | Path, digest: str) -> Path:
+    # ADR-0037: payload bodies are opaque content-addressed bytes named by the
+    # content hash alone, with no format-implying extension. The body format is
+    # orthogonal to the record schema; content_type / length / hash live on the
+    # manifest entry, not in the file name.
     root = Path(store_dir) / "payloads" / digest[:2]
-    return root / f"{digest}.json"
+    return root / digest
 
 
 def latest_manifest_path(store_dir: str | Path) -> Path:

--- a/framework/core/src/python/kungfu/storage/service.py
+++ b/framework/core/src/python/kungfu/storage/service.py
@@ -77,7 +77,10 @@ def registry_path(runtime_dir: str | Path) -> Path:
 
 
 def payload_path(runtime_dir: str | Path, digest: str) -> Path:
-    return root_dir(runtime_dir) / "payloads" / digest[:2] / f"{digest}.json"
+    # ADR-0037: payload bodies are opaque content-addressed bytes named by the
+    # content hash alone (no format-implying extension). Must match the C++
+    # runtime storage service payload_path.
+    return root_dir(runtime_dir) / "payloads" / digest[:2] / digest
 
 
 def _payload_root(runtime_dir: str | Path) -> Path:

--- a/framework/core/tests/python/test_atlas_storage.py
+++ b/framework/core/tests/python/test_atlas_storage.py
@@ -1650,3 +1650,48 @@ def test_source_registry_projection_fsck_detects_drift(tmp_path):
     )
     assert healed["ok"]
     assert healed["projection"]["status"] == "ok"
+
+
+def test_payload_bodies_are_opaque_content_addressed_bytes(tmp_path):
+    # ADR-0037 point 6: payload bodies are opaque content-addressed bytes with no
+    # format-implying extension. The body format is orthogonal to the record
+    # schema; the manifest entry commits to the body by hash, length, and
+    # content_type metadata, not by the file name.
+    repo = tmp_path / "atlas"
+    store = tmp_path / "store"
+    _atlas_fixture(repo)
+    _, _, _, source_records, _ = importer.read_control_plane_with_sources(str(repo))
+
+    manifest = payloads.write_import_payloads(
+        store,
+        import_id="imp-opaque",
+        repo_root=str(repo),
+        repo_head="abc123",
+        source_records=source_records,
+        counts={"missions": 1, "goals": 1, "markers": 1},
+    )
+
+    entry = manifest["entries"][0]
+    digest = entry["payload_hash"]
+    body_path = store / "payloads" / digest[:2] / digest
+
+    # The body is stored at the hash-addressed path with no extension...
+    assert body_path.exists()
+    assert body_path.suffix == ""
+    # ...and the legacy .json-envelope path is gone.
+    assert not (store / "payloads" / digest[:2] / f"{digest}.json").exists()
+
+    # The stored bytes are exactly the opaque body, content-addressed: the file
+    # name is the sha256 of its contents.
+    raw = body_path.read_bytes()
+    import hashlib
+
+    assert hashlib.sha256(raw).hexdigest() == digest
+    assert len(raw) == entry["byte_len"]
+
+    # Format lives on the record as metadata, not in the file name.
+    assert entry["content_type"] == payloads.CONTENT_TYPE_JSON
+
+    # The runtime still verifies the body by hash + length regardless of naming.
+    runtime = kungfu.__binding__.runtime
+    assert runtime.verify_storage_payload(raw, digest, entry["byte_len"]) == ""


### PR DESCRIPTION
Store payload bodies as opaque content-addressed bytes (storage/payloads/<hash-prefix>/<sha256>, no format-implying extension); the manifest entry commits to the body by hash, length, and content_type metadata. Aligns C++ runtime service and Python importer on the content-addressed path. Decouples and precedes the import-manifest migration. 25/25 storage tests pass.