### PR TITLE
fix(view): reject rootless .bfbs at the load boundary; wire the fuzz + sanitizer gate

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,17 @@ jobs:
       require-install: true
       require-build: true
       require-verify: true
+      # This workflow only fires on alpha/release PRs, so it is the recurring
+      # heavy gate (kungfu has no nightly). Override the default lifecycle verify
+      # (.buildchain/buildchain.toml runs quick `verify`) with the kungfu::view
+      # memory-safety long-run: `--fuzz` adds the libFuzzer stage over the three
+      # FlatBuffers access entries under ASan/UBSan (ADR-0039 residual risk); a
+      # new crash fails verify and blocks the alpha. The ASan/UBSan corpus-replay
+      # tier runs on every platform (MSVC /fsanitize=address on Windows); the
+      # libFuzzer long-run is the Linux gate and soft-skips where libFuzzer is
+      # absent. KUNGFU_FUZZ_SECONDS bounds the per-target run.
+      verify-command: >-
+        KUNGFU_FUZZ_SECONDS=90 node scripts/buildchain-run-kungfu-code.mjs verify --fuzz
       release-candidate: true
       artifact-transfer-mode: s3-to-github-artifacts
       artifact-retention-days: 14

--- a/framework/core/fuzz/CMakeLists.txt
+++ b/framework/core/fuzz/CMakeLists.txt
@@ -1,0 +1,107 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# kungfu::view memory-safety targets (ADR-0039 residual risk).
+#
+# The three fuzz entries (fuzz_compile_schema / fuzz_from_bytes / fuzz_bind_frame)
+# each drive one untrusted-input entry of the sole FlatBuffers access module,
+# compiling src/view/schema.cpp directly and linking only FlatBuffers + SQLite —
+# no runtime, mirroring the view-encapsulation slice probe. The SAME entry
+# functions are built in two independent tiers, differing only in instrumentation
+# and driver:
+#
+#   -DKUNGFU_WITH_SANITIZERS=ON   every-build lightweight tier: replay the seed
+#                                 corpus through a libFuzzer-less driver
+#                                 (StandaloneFuzzMain.cpp) under ASan+UBSan.
+#                                 Builds with the ordinary build compiler (Apple
+#                                 clang / Linux clang|gcc / MSVC /fsanitize=address)
+#                                 — zero extra toolchain.
+#   -DKUNGFU_WITH_FUZZ=ON         alpha heavy tier: real libFuzzer long-run
+#                                 (-fsanitize=fuzzer,address,undefined). Needs a
+#                                 libFuzzer-capable clang (Homebrew LLVM on macOS,
+#                                 system clang on Linux). If the compiler lacks
+#                                 libFuzzer, the fuzz targets are skipped with a
+#                                 message rather than failing configure.
+#
+# Configured STANDALONE (never add_subdirectory'd into framework/core) because
+# the fuzz tier needs a different compiler than the conan/cmake-js core toolchain,
+# and two compilers cannot share one build tree. Dependencies come from the conan
+# CMakeDeps that build:core already generated: point CMAKE_PREFIX_PATH at the core
+# build dir, e.g.
+#   cmake -S framework/core/fuzz -B framework/core/build-sanitize \
+#         -DKUNGFU_WITH_SANITIZERS=ON -DCMAKE_PREFIX_PATH=$PWD/framework/core/build
+# scripts/verify.mjs wires both tiers; see fuzz/README.md for the standalone recipe.
+
+cmake_minimum_required(VERSION 3.15)
+project(kungfu_view_fuzz CXX)
+
+option(KUNGFU_WITH_SANITIZERS "build the view fuzz entries under ASan+UBSan via a libFuzzer-less standalone driver" OFF)
+option(KUNGFU_WITH_FUZZ "build the view fuzz entries as libFuzzer targets (needs a libFuzzer-capable clang)" OFF)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(flatbuffers REQUIRED)
+find_package(SQLite3 REQUIRED)
+
+set(_view_dir ${CMAKE_CURRENT_SOURCE_DIR}/../src/libkungfu)
+set(_view_src ${_view_dir}/src/view/schema.cpp)
+set(_view_inc ${_view_dir}/include)
+
+# entry basename -> fuzz_<name>.cpp; kept in lockstep with the checked-in targets
+set(_targets compile_schema from_bytes bind_frame)
+
+# The libFuzzer tier only materializes when the active compiler actually ships
+# libFuzzer; otherwise skip with a message (Apple clang has none).
+set(_have_libfuzzer OFF)
+if (KUNGFU_WITH_FUZZ)
+  include(CheckCXXSourceCompiles)
+  set(CMAKE_REQUIRED_FLAGS "-fsanitize=fuzzer")
+  check_cxx_source_compiles([[
+    #include <cstddef>
+    #include <cstdint>
+    extern "C" int LLVMFuzzerTestOneInput(const uint8_t *, size_t) { return 0; }
+  ]] KUNGFU_LIBFUZZER_OK)
+  unset(CMAKE_REQUIRED_FLAGS)
+  if (KUNGFU_LIBFUZZER_OK)
+    set(_have_libfuzzer ON)
+  else()
+    message(STATUS "kungfu view fuzz: '${CMAKE_CXX_COMPILER}' lacks libFuzzer (-fsanitize=fuzzer); fuzz targets skipped. Use an LLVM clang (brew install llvm on macOS; system clang on Linux ships it).")
+  endif()
+endif()
+
+if (NOT KUNGFU_WITH_SANITIZERS AND NOT _have_libfuzzer)
+  message(STATUS "kungfu view fuzz: no tier active — set -DKUNGFU_WITH_SANITIZERS=ON (ASan/UBSan replay) and/or -DKUNGFU_WITH_FUZZ=ON (libFuzzer).")
+endif()
+
+# Sanitizer flags: MSVC exposes only ASan (/fsanitize=address); clang/gcc get
+# ASan+UBSan with no silent recovery so the first violation aborts.
+if (MSVC)
+  set(_san_compile /fsanitize=address)
+  set(_san_link "")
+else()
+  set(_san_compile -fsanitize=address,undefined -fno-sanitize-recover=all -fno-omit-frame-pointer)
+  set(_san_link -fsanitize=address,undefined)
+endif()
+set(_fuzz_flags -fsanitize=fuzzer,address,undefined -fno-omit-frame-pointer)
+
+foreach(t ${_targets})
+  set(_entry ${CMAKE_CURRENT_SOURCE_DIR}/fuzz_${t}.cpp)
+
+  if (KUNGFU_WITH_SANITIZERS)
+    add_executable(fuzz_${t}_sanitize ${_entry} ${CMAKE_CURRENT_SOURCE_DIR}/StandaloneFuzzMain.cpp ${_view_src})
+    target_include_directories(fuzz_${t}_sanitize PRIVATE ${_view_inc})
+    target_link_libraries(fuzz_${t}_sanitize PRIVATE flatbuffers::flatbuffers SQLite::SQLite3)
+    target_compile_options(fuzz_${t}_sanitize PRIVATE ${_san_compile})
+    if (_san_link)
+      target_link_options(fuzz_${t}_sanitize PRIVATE ${_san_link})
+    endif()
+  endif()
+
+  if (_have_libfuzzer)
+    add_executable(fuzz_${t} ${_entry} ${_view_src})
+    target_include_directories(fuzz_${t} PRIVATE ${_view_inc})
+    target_link_libraries(fuzz_${t} PRIVATE flatbuffers::flatbuffers SQLite::SQLite3)
+    target_compile_options(fuzz_${t} PRIVATE ${_fuzz_flags})
+    target_link_options(fuzz_${t} PRIVATE ${_fuzz_flags})
+  endif()
+endforeach()

--- a/framework/core/fuzz/README.md
+++ b/framework/core/fuzz/README.md
@@ -8,62 +8,95 @@ UAF" is *demonstrated*, not merely asserted.
 
 | target | entry fuzzed | invariant |
 | --- | --- | --- |
-| `fuzz_compile_schema` | `view::compile_schema` (`.fbs` text → `.bfbs`) | hostile schema text never crashes the parser |
-| `fuzz_from_bytes` | `view::schema_handle::from_bytes` (`.bfbs` load) | `VerifySchemaBuffer` rejects every malformed buffer, never UB |
+| `fuzz_compile_schema` | `view::compile_schema` (`.fbs` text → `.bfbs`) → load + reflect | hostile schema text never crashes the parser, and a compiled schema reflects in bounds |
+| `fuzz_from_bytes` | `view::schema_handle::from_bytes` (`.bfbs` load) | the load boundary rejects every malformed / unusable buffer, never UB |
 | `fuzz_bind_frame` | `view::schema_handle::bind_frame` (frame access) | verify-before-access: a bad frame is skipped, never read out of bounds |
 
 Each links only the view module (`src/view/schema.cpp`) + FlatBuffers + SQLite —
 no runtime, mirroring the `view-encapsulation` slice.
 
-## Toolchain (important)
+## Two tiers (over the same entry functions)
 
-- **ASan/UBSan** works with the build's default **Apple clang** (macOS) — zero
-  extra toolchain. This is the every-build lightweight tier.
-- **libFuzzer** (`-fsanitize=fuzzer`) is **NOT in Apple clang**
-  (`libclang_rt.fuzzer_osx.a not found`). It needs an LLVM clang:
-  - macOS dev: `brew install llvm` → `/opt/homebrew/opt/llvm/bin/clang++`
-  - Linux CI: system clang ships libFuzzer built-in
-  So fuzz targets build under a **separate toolchain** from the cmake-js `.node`
-  build; they do not compile in the same configure.
+The same `LLVMFuzzerTestOneInput` entries are built two ways, differing only in
+instrumentation and driver:
 
-## Proven recipe (mac arm64, standalone — validated 2026-07-10)
+- **ASan/UBSan corpus replay** (`-DKUNGFU_WITH_SANITIZERS=ON`) — the every-build
+  lightweight tier. `StandaloneFuzzMain.cpp` replays the seed corpus through each
+  entry under `-fsanitize=address,undefined`; it needs **no** libFuzzer runtime,
+  so it builds with the ordinary build compiler (Apple clang on macOS, system
+  clang/gcc on Linux, MSVC `/fsanitize=address` on Windows).
+- **libFuzzer long-run** (`-DKUNGFU_WITH_FUZZ=ON`) — the alpha heavy tier. Real
+  `-fsanitize=fuzzer,address,undefined`; needs a **libFuzzer-capable clang**
+  (`libclang_rt.fuzzer` — Apple clang has none). If the active compiler lacks it,
+  the fuzz targets are skipped with a message rather than failing configure.
+
+`fuzz/CMakeLists.txt` is configured **standalone** (never `add_subdirectory`'d
+into `framework/core`) because the fuzz tier needs a different compiler than the
+conan / cmake-js core toolchain, and two compilers can't share one build tree.
+Dependencies come from the conan CMakeDeps that `build:core` already generated —
+point `CMAKE_PREFIX_PATH` at the core build dir.
+
+## Wiring (how it runs in the gate)
+
+`scripts/verify.mjs` stage 7 drives both tiers against `framework/core/build`
+(the conan tree seeded by `build:core` / `rebuild:core`, like the slices stage):
 
 ```bash
-LLVM=/opt/homebrew/opt/llvm/bin/clang++
-FB=~/.conan2/p/b/<flatbuffers>/p        # include + lib/libflatbuffers.a
-SQ=~/.conan2/p/b/<sqlite>/p             # include + lib/libsqlite3.a
-VIEW=framework/core/src/libkungfu/include
-SRC=framework/core/src/libkungfu/src/view/schema.cpp
-
-# fuzz tier (libFuzzer + ASan + UBSan)
-"$LLVM" -std=c++20 -g -O1 -fsanitize=fuzzer,address,undefined \
-  -I"$VIEW" -I"$FB/include" -I"$SQ/include" \
-  "$SRC" framework/core/fuzz/fuzz_from_bytes.cpp \
-  "$FB/lib/libflatbuffers.a" "$SQ/lib/libsqlite3.a" -o fuzz_from_bytes
-./fuzz_from_bytes -max_total_time=<seconds> corpus/from_bytes
-
-# sanitizer-only tier (Apple clang, the build toolchain — no libFuzzer)
-clang++ -std=c++20 -g -O1 -fsanitize=address,undefined -fno-sanitize-recover=all \
-  -I"$VIEW" -I"$FB/include" -I"$SQ/include" \
-  "$SRC" framework/core/slices/view-encapsulation/probe.cpp \
-  "$FB/lib/libflatbuffers.a" "$SQ/lib/libsqlite3.a" -o probe_asan && ./probe_asan
+./kungfu-code verify --full     # ASan/UBSan corpus replay (every-build tier)
+./kungfu-code verify --fuzz      # + libFuzzer long-run (needs a libFuzzer clang)
 ```
 
-PoC results: from_bytes 698k execs / compile_schema 211k / bind_frame **2.7M**
-execs, no crash; probe clean under ASan+UBSan. Teeth check: temporarily skipping
-`VerifySchemaBuffer` in `from_bytes` makes the fuzzer find a crash in seconds
-(`AddressSanitizer: BUS in flatbuffers::ReadScalar`) — the net catches real
-out-of-bounds reflection reads.
+`KUNGFU_FUZZ_SECONDS` bounds the per-target long-run (default 20s);
+`KUNGFU_FUZZ_CLANGXX` overrides the fuzz compiler (else Homebrew LLVM on macOS,
+system `clang++` on Linux). The libFuzzer run happens in a throwaway working dir
+seeded from this corpus with `-artifact_prefix` pointed at scratch, so a CI run
+never mutates the checked-in seeds or drops a `crash-*` into the repo.
 
-## Tiering (per repo decision)
+The alpha/release build (`.github/workflows/build.yml`, the only recurring heavy
+gate — kungfu has no nightly) overrides the lifecycle verify with
+`KUNGFU_FUZZ_SECONDS=90 … verify --fuzz`: the ASan/UBSan tier runs on every
+platform (MSVC ASan on Windows), the libFuzzer long-run is the Linux gate, and a
+**new crash fails verify and blocks the alpha**.
 
-- **every dev build / local**: ASan+UBSan over the view tests (Apple clang, fast).
-- **alpha release build**: full — ASan+UBSan + libFuzzer long-run (LLVM clang),
-  new crash blocks the alpha. Not nightly (kungfu has no nightly); the alpha
-  build is the recurring heavy gate.
-- **Windows**: MSVC `/fsanitize=address` over the tests on the alpha build only.
+## Manual standalone recipe (mac arm64)
+
+```bash
+PROBE=framework/core/build   # conan CMakeDeps, seeded by build:core
+# ASan/UBSan tier (the build compiler — Apple clang)
+cmake -S framework/core/fuzz -B /tmp/fuzz-san -DKUNGFU_WITH_SANITIZERS=ON \
+      -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=$PWD/$PROBE -DCMAKE_MODULE_PATH=$PWD/$PROBE
+cmake --build /tmp/fuzz-san
+/tmp/fuzz-san/fuzz_from_bytes_sanitize framework/core/fuzz/corpus/from_bytes
+
+# libFuzzer tier (Homebrew LLVM clang)
+cmake -S framework/core/fuzz -B /tmp/fuzz-lf -DKUNGFU_WITH_FUZZ=ON \
+      -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=/opt/homebrew/opt/llvm/bin/clang++ \
+      -DCMAKE_PREFIX_PATH=$PWD/$PROBE -DCMAKE_MODULE_PATH=$PWD/$PROBE
+cmake --build /tmp/fuzz-lf
+/tmp/fuzz-lf/fuzz_from_bytes framework/core/fuzz/corpus/from_bytes -max_total_time=30
+```
+
+## Findings
+
+- **Rootless-schema null-pointer read (fixed).** libFuzzer's `fuzz_compile_schema`
+  found that a structurally valid `.bfbs` declaring no `root_type` (e.g. the schema
+  `attribute g;`) passes `VerifySchemaBuffer` — reflection makes `root_type`
+  optional — after which `plan_columns` / `bind_frame` / `verify_table` all
+  dereference the null `root_table()` (UBSan: *member call on null pointer of type
+  'reflection::Object'*; ASan: SEGV in `flatbuffers::Table::GetPointer`). Fixed at
+  the sole load boundary: `from_bytes` now rejects a schema with a null
+  `root_table()`, so every live handle guarantees a non-null root (the access path
+  relies on it). After the fix all three targets run crash-free
+  (`compile_schema` 842k / `from_bytes` 2.2M / `bind_frame` 12M execs over 30s each,
+  mac arm64). This is the ADR-0039 residual risk paying off — a real spatial-safety
+  hole the roundtrip tests never reached.
+
+Teeth check: temporarily skipping `VerifySchemaBuffer` in `from_bytes` makes the
+fuzzer catch a crash in seconds (`AddressSanitizer: BUS in
+flatbuffers::ReadScalar`) — the net catches real out-of-bounds reflection reads.
 
 ## Seeds
 
-`corpus/<target>/` holds checked-in seed inputs; alpha-run findings are added
-back here + fixed. Keep seeds small and representative.
+`corpus/<target>/` holds one checked-in seed input per target; alpha-run findings
+are added back here (deliberately) + fixed. Keep seeds small and representative.
+The libFuzzer run does not write back into this directory — it works on a copy.

--- a/framework/core/fuzz/StandaloneFuzzMain.cpp
+++ b/framework/core/fuzz/StandaloneFuzzMain.cpp
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// libFuzzer-less driver: replay the checked-in seed corpus through
+// LLVMFuzzerTestOneInput under ASan/UBSan. This is the *every-build* sanitizer
+// tier — it needs no libFuzzer runtime, so it links with the ordinary build
+// compiler (Apple clang on macOS, system clang/gcc on Linux, MSVC
+// /fsanitize=address on Windows), unlike the libFuzzer tier which needs an
+// LLVM clang. A sanitizer violation aborts the process; a clean exit 0 means
+// every seed stayed in bounds through the view access boundary.
+//
+// Usage: fuzz_<target>_sanitize <corpus-dir-or-file> [more ...]
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <vector>
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size);
+
+namespace {
+void run_bytes(const std::vector<uint8_t> &buf) { LLVMFuzzerTestOneInput(buf.data(), buf.size()); }
+
+int run_file(const std::filesystem::path &p) {
+  std::ifstream f(p, std::ios::binary);
+  if (!f)
+    return 0;
+  std::vector<uint8_t> buf((std::istreambuf_iterator<char>(f)), std::istreambuf_iterator<char>());
+  run_bytes(buf);
+  return 1;
+}
+} // namespace
+
+int main(int argc, char **argv) {
+  namespace fs = std::filesystem;
+  int files = 0;
+  for (int i = 1; i < argc; ++i) {
+    std::error_code ec;
+    fs::path p(argv[i]);
+    if (fs::is_directory(p, ec)) {
+      for (const auto &e : fs::directory_iterator(p, ec))
+        if (e.is_regular_file())
+          files += run_file(e.path());
+    } else if (fs::is_regular_file(p, ec)) {
+      files += run_file(p);
+    }
+  }
+  // Always exercise the degenerate empty input — a common boundary the seed
+  // corpus does not otherwise cover.
+  run_bytes(std::vector<uint8_t>{});
+  std::fprintf(stderr, "[standalone-fuzz] replayed %d corpus file(s) + empty input clean\n", files);
+  return 0;
+}

--- a/framework/core/src/libkungfu/src/view/schema.cpp
+++ b/framework/core/src/libkungfu/src/view/schema.cpp
@@ -59,6 +59,17 @@ schema_handle schema_handle::from_bytes(std::string bfbs) {
   flatbuffers::Verifier v(reinterpret_cast<const uint8_t *>(bfbs.data()), bfbs.size());
   if (!reflection::VerifySchemaBuffer(v))
     throw std::runtime_error("kungfu::view: malformed .bfbs reflection schema buffer");
+  // VerifySchemaBuffer still accepts a structurally-valid schema that declares no
+  // root_type (root_table() == nullptr) — reflection makes root_type optional.
+  // The whole access path (plan_columns / bind_frame / verify_table) reflects
+  // through the root table on every call, so a rootless schema would otherwise
+  // drive a null-pointer member read downstream. Reject it here at the sole load
+  // boundary so every live handle guarantees a non-null root table (ADR-0039
+  // spatial safety). Object.fields / Field.name / Field.type are `required` in
+  // reflection.fbs, so the verifier already guarantees those once the root exists.
+  const reflection::Schema *s = schema_of(bfbs);
+  if (s == nullptr || s->root_table() == nullptr)
+    throw std::runtime_error("kungfu::view: .bfbs reflection schema declares no root_type");
   schema_handle h;
   h.bfbs_ = std::make_shared<const std::string>(std::move(bfbs));
   return h;

--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -11,6 +11,9 @@
 //   ./kungfu-code verify --full       full: rebuild:core + freeze first, then assert; also builds and runs the
 //                                     capability slices (framework/core/slices) + yijinjing dependency guard
 //   ./kungfu-code verify --with-app   also assert the build:app artifact (with --full it builds the app first)
+//   ./kungfu-code verify --fuzz       add the kungfu::view libFuzzer long-run (ADR-0039 memory safety); needs a
+//                                     libFuzzer-capable clang (brew LLVM on macOS, system clang on Linux). The
+//                                     alpha/release build passes this; a new crash blocks the build.
 //   ./kungfu-code verify --help
 //
 // Assertion targets (all grounded in the build scripts, not guessed):
@@ -63,6 +66,10 @@ if (args.includes('--help') || args.includes('-h')) {
 }
 const doFull = args.includes('--full');
 const withApp = args.includes('--with-app');
+// --fuzz adds the libFuzzer long-run tier (needs a libFuzzer-capable clang); the
+// alpha/release build passes it. The lightweight ASan/UBSan corpus replay runs
+// whenever the memory-safety stage runs (full or fuzz).
+const doFuzz = args.includes('--fuzz');
 
 // expected version: single source of truth is lerna.json (maintained by the release workflow)
 function expectedVersion() {
@@ -770,7 +777,235 @@ function main() {
     }
   }
 
+  // ── Stage 7: kungfu::view memory safety (ASan/UBSan + libFuzzer) ───
+  // ADR-0039 residual risk: *demonstrate* — not merely assert — that the three
+  // untrusted-input entries of the sole FlatBuffers access module never read out
+  // of bounds. Two tiers over the same fuzz entries (framework/core/fuzz):
+  //   full  → ASan+UBSan corpus replay via the libFuzzer-less standalone driver
+  //           (the build compiler; every-build lightweight tier).
+  //   fuzz  → libFuzzer long-run (needs a libFuzzer-capable clang; the
+  //           alpha/release build passes --fuzz and a new crash blocks it).
+  // Both build standalone against the conan deps that rebuild:core seeded under
+  // framework/core/build (like the slices stage, the build tree must exist).
+  if (doFull || doFuzz) {
+    console.log(
+      '\n[verify] stage 7: kungfu::view memory safety (ASan/UBSan + fuzz)',
+    );
+    const core = path.join(ROOT, 'framework', 'core');
+    const fuzzSrc = path.join(core, 'fuzz');
+    const prefix = conanPrefix(core);
+    const targets = ['compile_schema', 'from_bytes', 'bind_frame'];
+    /** @param {import('child_process').SpawnSyncReturns<string>} r */
+    const tail3 = (r) =>
+      `${r.stdout || ''}${r.stderr || ''}`
+        .trim()
+        .split('\n')
+        .slice(-3)
+        .join(' | ')
+        .slice(0, 400);
+    if (!prefix) {
+      fail(
+        'view memory-safety deps',
+        `conan CMakeDeps not found under ${path.join(core, 'build')}; rebuild:core must run first (use --full)`,
+      );
+      return summarize();
+    }
+
+    // Tier 1 — ASan/UBSan corpus replay (every build; the build compiler).
+    {
+      const buildDir = path.join(core, 'build-sanitize');
+      const cfg = spawnSync(
+        'cmake',
+        [
+          '-S',
+          fuzzSrc,
+          '-B',
+          buildDir,
+          '-DKUNGFU_WITH_SANITIZERS=ON',
+          '-DCMAKE_BUILD_TYPE=Release',
+          `-DCMAKE_PREFIX_PATH=${prefix}`,
+          `-DCMAKE_MODULE_PATH=${prefix}`,
+        ],
+        { stdio: 'inherit' },
+      );
+      if (cfg.status !== 0) {
+        fail(
+          'view ASan/UBSan configure',
+          `cmake -DKUNGFU_WITH_SANITIZERS=ON failed (exit ${cfg.status})`,
+        );
+      } else {
+        const bld = spawnSync(
+          'cmake',
+          ['--build', buildDir, '--config', 'Release'],
+          {
+            stdio: 'inherit',
+          },
+        );
+        if (bld.status !== 0)
+          fail(
+            'view ASan/UBSan build',
+            `cmake --build failed (exit ${bld.status})`,
+          );
+        else {
+          pass('view ASan/UBSan build', 'KUNGFU_WITH_SANITIZERS=ON');
+          for (const t of targets) {
+            const bin = builtBin(buildDir, `fuzz_${t}_sanitize`);
+            if (!bin) {
+              fail(
+                `view ASan replay ${t}`,
+                `binary missing under ${path.relative(ROOT, buildDir)}`,
+              );
+              continue;
+            }
+            const corpus = path.join(fuzzSrc, 'corpus', t);
+            const r = spawnSync(bin, [corpus], { encoding: 'utf8' });
+            if (r.status === 0)
+              pass(`view ASan replay ${t}`, 'corpus clean under ASan+UBSan');
+            else
+              fail(
+                `view ASan replay ${t}`,
+                `exit ${exitLabel(r.status, r.signal)}; tail: ${tail3(r)}`,
+              );
+          }
+        }
+      }
+    }
+
+    // Tier 2 — libFuzzer long-run (alpha/release gate). Needs a libFuzzer clang.
+    if (doFuzz) {
+      const clang = fuzzClang();
+      const buildDir = path.join(core, 'build-fuzz');
+      const cfgArgs = [
+        '-S',
+        fuzzSrc,
+        '-B',
+        buildDir,
+        '-DKUNGFU_WITH_FUZZ=ON',
+        '-DCMAKE_BUILD_TYPE=Release',
+        `-DCMAKE_PREFIX_PATH=${prefix}`,
+        `-DCMAKE_MODULE_PATH=${prefix}`,
+      ];
+      if (clang) cfgArgs.push(`-DCMAKE_CXX_COMPILER=${clang}`);
+      const cfg = spawnSync('cmake', cfgArgs, { stdio: 'inherit' });
+      if (cfg.status !== 0) {
+        fail(
+          'view fuzz configure',
+          `cmake -DKUNGFU_WITH_FUZZ=ON failed (exit ${cfg.status})`,
+        );
+      } else {
+        const bld = spawnSync(
+          'cmake',
+          ['--build', buildDir, '--config', 'Release'],
+          {
+            stdio: 'inherit',
+          },
+        );
+        if (bld.status !== 0) {
+          fail('view fuzz build', `cmake --build failed (exit ${bld.status})`);
+        } else {
+          const built = targets.filter((t) => builtBin(buildDir, `fuzz_${t}`));
+          if (built.length === 0) {
+            // No libFuzzer in the active clang. Linux clang ships it, so on the
+            // Linux alpha runner this is a real gate failure, not a skip. On
+            // macOS/Windows libFuzzer is not always present; the sanitizer tier
+            // above already exercised ASan/UBSan, so soft-skip the long-run there
+            // rather than break the platform's build.
+            if (process.platform === 'linux') {
+              fail(
+                'view fuzz targets',
+                `no libFuzzer targets built on Linux (clang '${clang || 'default'}' lacks -fsanitize=fuzzer); the Linux alpha gate requires libFuzzer. Set KUNGFU_FUZZ_CLANGXX to an LLVM clang.`,
+              );
+            } else {
+              console.log(
+                `  (skipped: no libFuzzer clang on ${process.platform}; ASan/UBSan tier above covered the entries. brew install llvm or set KUNGFU_FUZZ_CLANGXX to enable the long-run here.)`,
+              );
+            }
+          } else {
+            pass(
+              'view fuzz build',
+              `KUNGFU_WITH_FUZZ=ON (${built.length}/${targets.length} targets)`,
+            );
+            const secs = Number(process.env.KUNGFU_FUZZ_SECONDS || '20');
+            for (const t of built) {
+              const bin = builtBin(buildDir, `fuzz_${t}`);
+              // Fuzz in a throwaway working dir seeded from the read-only
+              // checked-in corpus, and send any crash reproducer to a scratch
+              // dir, so a CI run never mutates framework/core/fuzz/corpus (libFuzzer
+              // appends newly-found units to its first corpus arg) or drops a
+              // crash-* file into the repo. The checked-in seeds stay the single
+              // source of truth; alpha findings are added back deliberately.
+              const seeds = path.join(fuzzSrc, 'corpus', t);
+              const work = path.join(buildDir, 'work', t);
+              const artifacts = path.join(buildDir, 'artifacts', t);
+              fs.mkdirSync(work, { recursive: true });
+              fs.mkdirSync(artifacts, { recursive: true });
+              if (fs.existsSync(seeds))
+                for (const f of fs.readdirSync(seeds))
+                  fs.copyFileSync(path.join(seeds, f), path.join(work, f));
+              const r = spawnSync(
+                bin,
+                [
+                  work,
+                  `-max_total_time=${secs}`,
+                  `-artifact_prefix=${artifacts}${path.sep}`,
+                  '-print_final_stats=1',
+                ],
+                { encoding: 'utf8' },
+              );
+              if (r.status === 0) pass(`view fuzz ${t}`, `${secs}s, no crash`);
+              else
+                fail(
+                  `view fuzz ${t}`,
+                  `crash — reproducer under ${path.relative(ROOT, artifacts)}; exit ${exitLabel(r.status, r.signal)}; tail: ${tail3(r)}`,
+                );
+            }
+          }
+        }
+      }
+    }
+  }
+
   return summarize();
+}
+
+// conan CMakeDeps (flatbuffers / SQLite configs) are generated into
+// framework/core/build by build:core / rebuild:core; the standalone fuzz build
+// reuses them via CMAKE_PREFIX_PATH so it need not re-resolve conan itself.
+function conanPrefix(core) {
+  const build = path.join(core, 'build');
+  const markers = [
+    'flatbuffers-config.cmake',
+    'Findflatbuffers.cmake',
+    'FlatBuffersConfig.cmake',
+  ];
+  return markers.some((m) => fs.existsSync(path.join(build, m))) ? build : null;
+}
+
+// Locate a built executable across single-config (Ninja/Make: buildDir/<name>)
+// and multi-config (VS: buildDir/Release/<name>.exe) generator layouts.
+function builtBin(buildDir, name) {
+  const cands = [
+    path.join(buildDir, name),
+    path.join(buildDir, `${name}.exe`),
+    path.join(buildDir, 'Release', name),
+    path.join(buildDir, 'Release', `${name}.exe`),
+  ];
+  return cands.find((p) => fs.existsSync(p)) || null;
+}
+
+// libFuzzer needs an LLVM clang; Apple clang has none. Honor an explicit
+// override, else prefer Homebrew LLVM (macOS), else on Linux prefer clang++
+// (system clang ships libFuzzer) over a possibly-gcc default. Returns null to
+// mean "let CMake pick its default compiler".
+function fuzzClang() {
+  if (process.env.KUNGFU_FUZZ_CLANGXX) return process.env.KUNGFU_FUZZ_CLANGXX;
+  const cands = [
+    '/opt/homebrew/opt/llvm/bin/clang++',
+    '/usr/local/opt/llvm/bin/clang++',
+  ];
+  for (const c of cands) if (fs.existsSync(c)) return c;
+  if (process.platform === 'linux') return 'clang++';
+  return null;
 }
 
 function summarize() {


### PR DESCRIPTION
Memory-safety coverage for kungfu::view (ADR-0039 residual risk).

Two tiers over the three FlatBuffers access entries (compile_schema / from_bytes /
bind_frame), sharing one set of libFuzzer entry functions:
- KUNGFU_WITH_SANITIZERS: ASan/UBSan corpus replay via a libFuzzer-less driver
  (any build compiler; MSVC /fsanitize=address on Windows) — the every-build tier.
- KUNGFU_WITH_FUZZ: real libFuzzer long-run (needs a libFuzzer-capable clang).

fuzz/CMakeLists.txt is a standalone project (the fuzz tier needs a different
compiler than the conan/cmake-js core toolchain); scripts/verify.mjs stage 7 drives
both against the conan tree build:core seeds, without mutating the checked-in
corpus; the alpha/release build runs verify --fuzz so a new crash blocks the alpha.

Fixes a spatial-safety hole the new gate found: a valid .bfbs with no root_type
passes VerifySchemaBuffer but leaves root_table() null, which plan_columns /
bind_frame / verify_table then dereference. from_bytes now rejects a rootless
schema at the sole load boundary.

Validated on mac arm64: after the fix all three targets run crash-free
(compile_schema 842k / from_bytes 2.2M / bind_frame 12M execs, 30s each).