### PR TITLE
docs(storage): clarify content and episode manifest contracts

### DIFF
--- a/framework/core/docs/adr/ADR-0040-runtime-fact-ledger-content-addressed-kv.md
+++ b/framework/core/docs/adr/ADR-0040-runtime-fact-ledger-content-addressed-kv.md
@@ -1,11 +1,11 @@
-# ADR-0040: a first-class content-addressed KV is a runtime fact-ledger primitive, backend-neutral from an embedded single agent to a fleet-scale sharded/tiered store
+# ADR-0040: a first-class content-addressed store is a runtime fact-ledger primitive, with mutable KV and fleet topology kept as separate capabilities
 
 - Status: proposed
 - Date: 2026-07-10
 - Category: (architecture) storage substrate — the runtime fact ledger's
-  key/value capability, its concurrency and scale envelope, and the backend
-  topology that lets one contract serve a single embedded agent and a fleet of
-  thousands of concurrent cloud agents.
+  immutable content-addressed object capability, the semantic boundary between
+  that capability and mutable key/value metadata, and the backend profiles that
+  may implement those contracts.
 - Subsystem: `libyijinjing` / `libkungfu` runtime storage service, the
   content-addressed payload store, the storage record family (ADR-0037), and the
   Python/Node storage bindings.
@@ -21,20 +21,26 @@
 ## Context
 
 The storage-record migration (ADR-0037) surfaced a requirement that is larger
-than any single record type: **a general key/value capability is not a feature
-of one scenario, it is a foundational primitive the runtime fact ledger must
-provide.** Users — including the runtime itself — store many kinds of things
-through it over time: today an import manifest, tomorrow a snapshot, a
-checkpoint, an agent artifact, an arbitrary blob. Building a bespoke KV per
-scenario (a "manifest KV", then a "something-else KV") fragments the substrate;
-the KV must be one first-class contract.
+than any single record type: **immutable bodies addressed by content hash need
+one first-class storage contract.** Users — including the runtime itself — store
+many kinds of things through it over time: today an import-manifest body,
+tomorrow a snapshot, a checkpoint, an agent artifact, or an arbitrary blob.
+Building a bespoke content store per scenario fragments the substrate.
+
+That does not make every key/value use the same semantic object. Immutable
+content-addressed bodies and mutable metadata have different guarantees:
+content objects are write-once and verified by hash, while mutable metadata may
+need delete, ordered scan, compare-and-set, transactions, or a declared
+consistency model. This ADR makes the immutable content store first-class and
+keeps a general mutable KV as a separate capability rather than hiding both
+behind one ambiguous interface.
 
 The current state is partial and does not meet this bar:
 
 - Payload bodies are already opaque content-addressed bytes (ADR-0037 point 6),
-  but there is no first-class KV surface over them. The Python facade is
+  but there is no first-class content-store surface over them. The Python facade is
   asymmetric — a `write_payload_bytes` method exists, reads go through a path
-  helper — and there is no uniform `get / set / has / delete / scan` contract.
+  helper — and there is no uniform content `put / get / has / verify` contract.
 - The provider abstraction (ADR-0018: content-addressed-file / rocksdb) opens
   and closes a fresh backend handle **per operation**. This is adequate for a
   single agent doing one thing at a time but is not a concurrency or lifecycle
@@ -48,10 +54,11 @@ large and writing at once." That reframes the design around two axes the
 single-agent view hides: **fleet-scale concurrency** and **retention-scale
 volume**.
 
-### Scale envelope (agent-work fact ledger)
+### Scale envelope hypothesis (agent-work fact ledger)
 
 A working agent emits a stream of facts — actions, tool calls, edits,
-decisions, Episode frames, receipts — plus the bodies of those facts. A rough
+decisions, Episode frames, receipts — plus the bodies of those facts. The
+following is a planning hypothesis, not measured capacity evidence. A rough
 per-agent rate is order 1k–10k events/hour at ~0.5–5 KB/body (tool I/O, file
 contents, and command output push the tail higher), i.e. order 10–100 MB/agent/
 hour before dedup:
@@ -64,52 +71,58 @@ hour before dedup:
 
 Two properties dominate the design:
 
-1. **Dedup is the largest lever.** Agent work is highly redundant — a fleet
+1. **Dedup may be a large lever.** Agent work can be highly redundant — a fleet
    re-reads the same repositories and files, runs the same builds, loads the
    same libraries, and produces similar outputs. Content-addressing deduplicates
-   this across the whole fleet, so effective storage tends toward *the union of
+   this across the whole fleet, so effective storage can approach *the union of
    distinct content touched plus unique outputs* rather than a per-agent sum.
-   This can pull a naive PB/year back to TB–hundreds-of-TB.
+   The actual ratio is workload-dependent and must be measured before it is used
+   for retention or capacity commitments.
 2. **Concurrency, not raw volume, is the sharp constraint.** Thousands of agents
    writing at the same instant is what breaks a naive design; the storage
    contract must absorb it by construction.
 
 ## Decision
 
-1. **A first-class content-addressed KV is a runtime fact-ledger primitive.** The
-   ledger exposes one uniform KV contract — `put` / `get` / `has` / `delete` /
-   `scan`, organized by `namespace`, with a content-addressed `put-if-absent`
-   mode — in C++, Python, and Node. Features (import manifest, source registry,
-   snapshots, arbitrary user blobs) are *uses* of this KV plus the journal, never
-   bespoke per-scenario stores. Callers never program against a concrete engine
-   (`rocksdb::DB`, `sqlite3`) directly; the KV contract is the surface, the
-   engine is a replaceable part beneath it. Concretely: building manifest storage
-   means building on the yijinjing KV (`yijinjing.kv.put/get/...`) plus the
-   journal — never on the RocksDB API. RocksDB is never a caller-facing surface.
+1. **A first-class content-addressed store is a runtime fact-ledger primitive.**
+   The ledger exposes an immutable `content_store` contract — content-addressed
+   `put-if-absent`, `get`, `has`, and `verify`, with an explicit hash algorithm
+   and namespace/profile — in C++, Python, and Node. Features such as manifests,
+   snapshots, and arbitrary user blobs are *uses* of this store plus the journal,
+   never bespoke per-scenario content stores. Callers never program against a
+   concrete engine (`rocksdb::DB`, `sqlite3`) directly.
+
+   A general mutable `kv_store` is a separate, optional capability. If introduced,
+   its `put` / `get` / `has` / `delete` / `scan` surface must define ordering,
+   pagination, atomicity, consistency, and failure semantics independently. CAS
+   deletion is not an ordinary caller operation; reachability-based deletion
+   belongs to the later retention/GC contract.
 
 2. **Content-addressing is the concurrency, dedup, and tiering enabler — not
    merely a simplification.** Content-addressed objects are write-once: their key
    is the hash of their bytes, so the bytes at a key can never change. This gives
    three load-bearing properties at fleet scale:
-   - *Lock-free concurrent writes:* two writers writing the same hash write
-     identical bytes (idempotent, no coordination); different hashes are
-     different keys (no conflict). Thousands of concurrent writers need no write
-     lock for the content-addressed bulk of the data.
+   - *Coordination-free logical keys:* two writers proposing the same hash must
+     propose identical bytes; different hashes are different logical keys. The
+     backend must still implement atomic publication, collision/mismatch checks,
+     durability, and visibility. Content addressing removes logical overwrite
+     conflicts; it does not claim the implementation has no locks or coordination.
    - *Fleet-wide dedup:* identical content is stored once regardless of how many
      agents produce it.
    - *Cold tiering:* immutable objects can be moved to cheap/cold storage,
      addressed by hash, without invalidating references.
 
-3. **The KV contract is backend- and transport-neutral, and the dependency
-   direction is one-way: yijinjing owns the contract and depends on no concrete
-   engine.** The KV *interface* is a yijinjing primitive. Concrete engine-backed
+3. **The content-store contract is backend-neutral within a declared capability
+   profile, and the dependency direction is one-way: yijinjing owns the contract
+   and depends on no concrete engine.** The content-store *interface* is a
+   yijinjing primitive. Concrete engine-backed
    implementations (RocksDB, later sharded / distributed / object-store-tiered)
    live in the runtime / provider layer above it and are injected through the
    interface. **`libyijinjing` must not depend on, link, or include RocksDB (or
    any other specific engine); the dependency points from the implementation
    layer down to the yijinjing interface, never the reverse.** yijinjing ships a
    dependency-free default backend (a file-based content-addressed store) so its
-   KV works standalone with zero heavy dependencies; RocksDB is an optional,
+   content store works standalone with zero heavy dependencies; RocksDB is an optional,
    injected, replaceable backend selected at the runtime / deployment layer for
    the scale profile. The same interface then serves a single embedded agent and
    a fleet, differing only in the injected backend:
@@ -117,19 +130,23 @@ Two properties dominate the design:
      RocksDB, no service;
    - fleet scale: the same contract behind a storage service, over a
      content-hash-sharded hot store plus an object-store cold tier.
-   No caller-facing contract change is required to move between these; scale is
-   added by swapping the injected backend, not by rewriting callers and not by
-   giving the kernel a new dependency.
+   Callers retain the same content-addressed vocabulary, but local embedded and
+   remote service profiles are interchangeable only for guarantees declared by
+   the interface: hash identity, atomic put-if-absent, verified reads, durability
+   level, visibility, error categories, size limits, and capability discovery.
+   Transport retries, latency, pagination, and consistency must not be smuggled
+   in as invisible local assumptions.
 
-4. **Per-agent journals give linear write scaling.** Ordered per-agent event
+4. **Per-agent journals remove cross-agent contention on the journal write path.** Ordered per-agent event
    streams follow the yijinjing single-writer-per-location contract: each agent
    is its own writer to its own journal, so N agents are N independent writers
-   with no cross-agent contention. Fleet write throughput scales with fleet size
-   for the journal path.
+   with no cross-agent contention at that logical layer. This does not claim
+   end-to-end linear scaling: catalog metadata, content publication, query, file
+   descriptors, and storage-service coordination remain shared constraints.
 
-5. **RocksDB is the default hot backend *at the runtime layer*, injected through
-   the KV interface; at fleet scale it is a per-shard part, not the whole store.**
-   "Default" here means the recommended production backend for the scale profile,
+5. **RocksDB is a candidate hot backend *at the runtime layer*, injected through
+   the content-store interface; at fleet scale it is a per-shard part, not the whole store.**
+   "Candidate" here means a production backend for the scale profile,
    selected and linked by the runtime / provider layer — not a dependency of the
    yijinjing kernel (see Decision 3). RocksDB is retained because it is
    industrial-grade and the most widely deployed embedded storage engine, is
@@ -143,36 +160,38 @@ Two properties dominate the design:
    (by SQLite/LMDB for small profiles, or a distributed store at the top) without
    touching callers or the kernel.
 
-6. **Sharding is for scale, tiering is for retention; the lock is solved
+6. **Sharding is for scale, tiering is for retention; local lifecycle is solved
    separately.** The per-operation open/close of the current provider is a
    lifecycle artifact, not a RocksDB limit: RocksDB is thread-safe through a
-   single long-lived handle, so within a process the lock is dissolved by holding
-   one handle under the single-writer-per-workspace contract — not by sharding.
+   single long-lived handle, so within a process repeated open/close is removed by
+   holding one handle owned by one runtime/provider instance — not by sharding.
+   Multi-process ownership of one database path is not implied and must be
+   rejected or service-fronted explicitly.
    Sharding (by content-hash prefix, preserving dedup) is reserved for genuine
    scale-out beyond a single instance; cold tiering (immutable objects to an
    object store, addressed by hash) is reserved for retention beyond hot
    capacity. Both are enabled by content-addressing.
 
-7. **Scale target.** Design the content-addressed KV so that a single node
-   comfortably holds single-digit to tens of TB (RocksDB's normal range),
-   the contract shards to hundreds of TB by content-hash, and nothing
-   structurally caps the topology below PB — where PB means a sharded / tiered /
-   distributed backend, explicitly not a single local engine. The near-term
-   effective target after dedup is TB–hundreds-of-TB per deployment.
+7. **Scale target is a validation envelope, not a current guarantee.** Design the
+   content-store contract so a backend can report capabilities and scale without
+   changing content identity. Single-node TB claims, content-hash sharding to
+   hundreds of TB, and PB-tier topology require benchmark and dogfood evidence
+   before they become supported capacity commitments. PB explicitly means a
+   sharded / tiered / distributed backend, never a single local engine.
 
 ## For implementers: the dependency boundary (do not make yijinjing depend on RocksDB)
 
 This is the single most confusable point; read it before writing code.
 
-- **The KV interface belongs to `libyijinjing`.** An abstract `kv_store`
-  interface (`put` / `get` / `has` / `delete` / `scan`, namespace,
-  content-addressed `put-if-absent`) plus a dependency-free default backend
+- **The content-store interface belongs to `libyijinjing`.** An abstract
+  `content_store` interface (`put-if-absent` / `get` / `has` / `verify`, hash
+  algorithm, namespace/profile, and capabilities) plus a dependency-free default backend
   (file-based content-addressed) live in the kernel. `libyijinjing` must build,
   link, and run with **no RocksDB dependency at all**.
-- **The RocksDB-backed `kv_store` lives in the runtime / provider layer**
+- **The RocksDB-backed `content_store` lives in the runtime / provider layer**
   (`libkungfu`), which is the only place allowed to include and link RocksDB. It
   implements the yijinjing interface and is injected into the kernel through that
-  interface at runtime — the kernel receives a `kv_store*`, never a
+  interface at runtime — the kernel receives a `content_store*`, never a
   `rocksdb::DB*`.
 - **Dependency direction is one-way and down:** implementation layer → yijinjing
   interface. Never the reverse. If you find yourself adding `#include
@@ -183,22 +202,22 @@ This is the single most confusable point; read it before writing code.
   (in the spirit of ADR-0039's `check-view-boundary.mjs`) that fails if
   `libyijinjing` references RocksDB (or any concrete engine) by include, symbol,
   or link. A reviewer note is not enough; the gate is the guarantee.
-- Callers (manifest storage, source registry, snapshots, user features) depend
-  only on the yijinjing KV interface. They never see RocksDB, SQLite, LMDB, or a
-  distributed backend; swapping the backend is invisible to them.
+- Callers (manifest storage, snapshots, user features) depend only on the
+  yijinjing content-store interface. They never see RocksDB, SQLite, LMDB, or a
+  distributed backend. Backend changes are invisible only within the declared
+  capability and consistency profile.
 
 ## Consequences
 
-- The KV becomes a stable substrate contract that outlives any one record type;
+- The content store becomes a stable substrate contract that outlives any one record type;
   the storage record family (ADR-0037) and the import-manifest migration build on
   it rather than defining private stores.
 - "Embedded, no extra service" holds for a single agent and small scale; a large
-  concurrent fleet requires a storage service / tier. The contract is designed so
-  this is a backend swap, not a contract change.
-- Content-addressing is load-bearing for correctness under concurrency, not only
-  for dedup: the fleet-scale write path is lock-free *because* objects are
-  write-once.
-- RocksDB earns its place for the large-scale write-heavy envelope and is kept.
+  concurrent fleet requires a storage service / tier. Callers retain content
+  identity, while deployment-specific capabilities remain explicit.
+- Content-addressing removes logical overwrite conflicts and enables dedup; the
+  backend still owns atomic publication, durability, and visibility.
+- RocksDB remains a candidate for the large-scale write-heavy envelope.
   The earlier suggestion (in the ADR-0037 discussion) to consider dropping it was
   scoped to a 3 MB control-plane store; under a fleet-scale fact-ledger
   requirement that suggestion is withdrawn.
@@ -208,27 +227,27 @@ This is the single most confusable point; read it before writing code.
 
 ## First delivery (staged)
 
-- Define the first-class KV interface (`put` / `get` / `has` / `delete` /
-  `scan`, `namespace`, content-addressed `put-if-absent`) as a `kv_store`
-  abstraction in `libyijinjing`, with a dependency-free default backend
-  (file-based content-addressed) so the kernel KV works with no RocksDB
-  dependency. Add a symmetric Python/Node facade, and complete the asymmetric
-  payload facade into this uniform KV surface.
+- Define the first-class immutable `content_store` interface
+  (`put-if-absent` / `get` / `has` / `verify`, hash algorithm,
+  namespace/profile, capabilities) in `libyijinjing`, with a dependency-free
+  file backend. The file backend must prove atomic publish, hash mismatch
+  rejection, crash-safe visibility, and verified reads. Add symmetric
+  Python/Node facades over this surface.
 - Add the boundary gate that fails if `libyijinjing` references RocksDB (or any
   concrete engine) by include, symbol, or link, in the spirit of ADR-0039's
   `check-view-boundary.mjs`.
-- Provide the RocksDB-backed `kv_store` in the runtime / provider layer
-  (`libkungfu`), held as a single long-lived handle under the
-  single-writer-per-workspace contract (retiring per-operation open/close for the
-  hot path), injected into the kernel through the interface.
+- Provide the RocksDB-backed `content_store` in the runtime / provider layer
+  (`libkungfu`), held as a single long-lived handle owned by one provider
+  instance (retiring per-operation open/close for the hot path), injected into
+  the kernel through the interface.
 - Prove content-addressed `put-if-absent` dedup and concurrent-writer safety at
   the single-node level.
 - Then, as separate work: content-hash sharding, the object-store cold tier, the
-  fleet storage service, and the retention/gc policy.
+  fleet storage service, a mutable KV contract, and the retention/gc policy.
 
 ## Explicitly out of scope
 
-- The import-manifest record migration itself (a use of this KV + journal),
+- The import-manifest record migration itself (a use of this store + journal),
   recorded and delivered separately.
 - The distributed / service-fronted backend implementation; this ADR fixes the
   contract and topology direction, not that implementation.
@@ -238,6 +257,8 @@ This is the single most confusable point; read it before writing code.
   subject here.
 - The choice of cold-tier object store and any distributed KV; those are backend
   decisions under this contract, taken when scale-out work begins.
+- A general mutable KV contract, including delete, ordered scan, transactions,
+  compare-and-set, or distributed consistency semantics.
 
 ## Alternatives considered
 
@@ -248,8 +269,8 @@ This is the single most confusable point; read it before writing code.
   belongs in the journal; the entry set belongs in the content-addressed store as
   a sealed object. (ADR-0037 point 3 "sealed roots are immutable" is consistent
   with this.)
-- **A bespoke KV per scenario.** Rejected. It fragments the substrate; the KV
-  must be one first-class contract.
+- **A bespoke content store per scenario.** Rejected. It fragments immutable
+  body storage; content identity needs one first-class contract.
 - **SQLite adapted to KV (`WITHOUT ROWID` table + `INSERT OR IGNORE`).** Viable
   and already in the stack for the projection layer, and a strong fit for a small
   write-once, read-heavy store; but for a general, mutable, fleet-scale KV
@@ -270,10 +291,11 @@ This is the single most confusable point; read it before writing code.
 
 ## Residual risk
 
-- The backend-neutral contract must be defined tightly enough that the embedded
-  and fleet backends are genuinely interchangeable; a contract that leaks
-  embedded assumptions (synchronous local paths, single-process handles) would
-  force a rewrite at scale-out.
+- The backend-neutral contract must define atomic put-if-absent, hash mismatch,
+  durability, visibility, error categories, size limits, and capability
+  discovery tightly enough that embedded and service-backed profiles preserve
+  the same content semantics without pretending they have identical latency or
+  consistency behavior.
 - The kernel-must-not-depend-on-RocksDB boundary erodes silently if left to
   reviewer vigilance; without the mechanical gate (see "For implementers"), a
   future change can quietly link RocksDB into `libyijinjing` and invert the
@@ -287,6 +309,6 @@ This is the single most confusable point; read it before writing code.
   and distributed-query path.
 - Retention at PB scale requires a real gc / tiering policy (ADR-0018 deferred);
   without it the ledger grows monotonically.
-- Fleet-scale correctness ultimately rests on the concurrency contract
-  (single-writer-per-location / per-workspace); relaxing it to concurrent writers
-  on one location must be solved at the contract layer, not by backend choice.
+- Fleet-scale correctness still depends on ownership and concurrency contracts
+  for mutable metadata and catalog journals. Content addressing does not solve
+  those shared-write paths.

--- a/framework/core/docs/adr/ADR-0041-episode-manifest-first-class-journal-structure.md
+++ b/framework/core/docs/adr/ADR-0041-episode-manifest-first-class-journal-structure.md
@@ -1,11 +1,11 @@
-# ADR-0041: the Episode manifest is the object's trust boundary — a POD-native yijinjing journal structure with writer / runtime / fsck / query tightened around it, JSON edge-only
+# ADR-0041: the Episode manifest is the object's trust boundary — POD journal records, one typed fold, and JSON at the edge
 
 - Status: proposed
 - Date: 2026-07-10
-- Category: (architecture) storage record structure — making the Episode manifest
-  (the Episode's trust boundary) a fully first-class, POD-native yijinjing journal
-  structure, and tightening the four operations (writer, runtime, fsck, query)
-  around it.
+- Category: (architecture) storage record structure — keeping the Episode
+  manifest's authoritative records as fixed-layout yijinjing POD frames, deriving
+  one typed current view, and tightening writer, runtime, fsck, and query around
+  that boundary.
 - Subsystem: `libyijinjing` `episode_manifest` store and the Episode manifest
   record family, the `libkungfu` runtime storage service Episode operations,
   storage fsck, and the storage query path; Python/Node storage bindings.
@@ -13,7 +13,7 @@
   names the Episode manifest the object's trust boundary; ADR-0034 puts the
   Episode manifest records in the yijinjing journal format; ADR-0037 makes the
   storage record family Hana-core kernel metadata with JSON as an edge
-  projection; ADR-0040 makes the runtime fact ledger's content-addressed KV a
+  projection; ADR-0040 makes the runtime fact ledger's content-addressed store a
   first-class primitive; ADR-0023 starts frame integrity at the C++ recorder;
   ADR-0028 separates content hashes from frame checksums.
 
@@ -22,8 +22,9 @@
 Episode is the first-class causal segment object and the unit all storage is
 organized around (ADR-0033). Its manifest is **the object's trust boundary** —
 what fsck, export/import, sync, and inspection trust to answer "what is this
-Episode." This ADR is about **that manifest**: making it a clean, POD-native,
-first-class yijinjing journal structure and tightening the four operations that
+Episode." ADR-0034 already made its records first-class yijinjing journal frames.
+This ADR is about eliminating the remaining JSON-early implementation, deriving
+one typed current view from those records, and tightening the operations that
 touch it.
 
 It is deliberately narrow. The **complete Episode concept** — the Episode
@@ -46,9 +47,11 @@ The rest is not yet first-class. In the current `episode_manifest` store,
 `fold_records` folds over JSON; and every operation — `list`, `inspect`, `fsck`,
 and the runtime `query` path — reads and reasons over that JSON. JSON is not the
 edge projection here, it is the internal currency of the fold, the verification,
-and the query. There is no POD-typed current view and no rebuildable projection
-(unlike the source-registry family, which folds POD and has a SQLite
-projection).
+and the query. There is no typed current view and no rebuildable Episode
+projection. The source-registry family provides a useful typed-record reader for
+its SQLite projection, but its list/inspect/fsck fold still converts records to
+JSON; this ADR deliberately goes further by making the typed fold the shared
+internal path.
 
 This is the drift ADR-0037 rejects, one layer up: the authoritative substrate is
 the journal of POD frames, but the working representation settled on JSON by
@@ -70,23 +73,29 @@ Per ADR-0033, the Episode manifest records at least:
 - rebuildable projection / query indexes;
 - hash roots or sync roots needed by fsck / export / import.
 
-This ADR makes these records POD-native and tightens the operations around them.
-It carries identity and hash-root *fields*; the deep semantics of Episode
-identity and hash-root composition are the forthcoming Episode ADR, not this one.
+The stored records remain POD-native; the current view is a typed C++ aggregate
+whose variable-length collections may be streamed or bounded. Before
+implementation, the existing ADR-0034 record family must be mapped explicitly to
+each trust-boundary claim above. If a claim cannot be represented without
+overloading an existing field, a schema-version ADR must precede that change.
+Deep Episode identity and hash-root composition remain the forthcoming Episode
+ADR, not this one.
 
 ## Decision
 
-The Episode manifest is the object's trust boundary, structured as a POD-native
-yijinjing journal. The journal of POD frames is the authority and the working
-representation; JSON appears only at the true edge (CLI, export, binding return
-values). The four operations tighten around it:
+The Episode manifest is the object's trust boundary. The append-only journal of
+POD records is the authority; one deterministic typed fold is the canonical
+in-memory derivation; a rebuildable SQLite projection is a query accelerator;
+and JSON appears only at the true edge (CLI, export, binding return values). The
+operations tighten around that separation:
 
-1. **Structure / fold is POD-native.** Folding an Episode manifest reads POD
-   frames from the journal into a typed current view (a POD/`struct` view of the
-   Episode manifest and its typed frame/ref/dependency collections), not into
-   `nlohmann::json`. JSON is produced only when crossing the edge (a CLI/`--json`
-   response, an export bundle, a binding return). The fold, the current view, and
-   everything internal are typed; JSON is never the internal currency.
+1. **Records are POD; the fold is typed.** Folding an Episode manifest decodes
+   fixed-layout POD frames into a typed current view and typed
+   frame/ref/dependency collections, not into `nlohmann::json`. The current view
+   is not itself required to be POD: variable-length collections may use normal
+   C++ ownership, but they must support streaming or bounded materialization.
+   JSON is produced only when crossing the edge (a CLI/`--json` response, an
+   export bundle, or a binding return).
 
 2. **Writer is one tight contract.** Manifest writes go through a single
    open / heartbeat / attach-frame / attach-ref / seal (end/abort/tombstone)
@@ -95,6 +104,20 @@ values). The four operations tighten around it:
    write. Growth is append-only delta folded into the current view (the ADR-0034
    shape), never in-place mutation. `open` / `sealed` / `tombstoned` are recorded
    states, so a partial Episode is never presented as complete.
+
+   The implementation must name one logical writer owner for the manifest
+   location. Masterless operation does not waive ownership: a process must acquire
+   the same data-root-scoped writer guard or fail rather than append concurrently
+   to an active catalog writer.
+
+   Event frames and manifest records live in different journals and therefore do
+   not form one atomic write. Before lifecycle wiring lands, the implementation
+   must document the publication order and recovery state machine and prove each
+   crash point with fixtures. At minimum, a sealed Episode may be reported healthy
+   only when every attached frame/ref is present and verified; interrupted writes
+   remain open/aborted or degraded, and fsck reports the exact missing side. The
+   typed-fold slice may land before this contract, but automatic writer lifecycle
+   integration may not.
 
 3. **Runtime operations expose the journal-native structure.** The storage
    service Episode operations (begin / heartbeat / attach-frame / attach-ref /
@@ -121,20 +144,20 @@ values). The four operations tighten around it:
    projection uses), never ad-hoc JSON assembly. The projection is a derived view
    verified against the journal by fsck, never a second authority.
 
-6. **Content-addressed references resolve through the KV primitive.** The
+6. **Content-addressed references resolve through the immutable content-store
+   primitive.** The
    payload, schema, and hash-root references the manifest records resolve through
-   the yijinjing content-addressed KV (ADR-0040), not through bespoke per-path
-   logic. The manifest carries the references; the KV holds the bytes.
+   the yijinjing `content_store` (ADR-0040), not through bespoke per-path
+   logic. The manifest carries the references; the content store holds the bytes.
 
 ## Consequences
 
 - The Episode manifest stops treating JSON as internal currency; JSON narrows to
   the edge, matching ADR-0037's discipline one layer up.
-- The trust boundary becomes trustworthy from the journal itself: fsck and query
-  read the same typed fold, so they cannot diverge (fsck cannot check something
-  the query cannot see, and neither depends on a JSON re-derivation).
-- Episode gains what source-registry gained — a rebuildable SQLite projection and
-  a structure-native fsck — with the journal as the one authority.
+- Fsck and query consume the same typed fold, removing duplicate JSON fold logic;
+  the SQLite projection remains independently verifiable and can still drift.
+- Episode gains a typed-record path and rebuildable SQLite projection, extending
+  the source-registry projection pattern while keeping the journal as authority.
 - Causal closure, the ADR-0033 core invariant, becomes a checked property of the
   manifest rather than an assumption.
 - The manifest is ready to serve the forthcoming complete Episode ADR: the deep
@@ -145,27 +168,35 @@ values). The four operations tighten around it:
 
 ADR-0033 defines Episode and names the manifest its trust boundary; ADR-0034
 decides the manifest records live in the yijinjing journal format. Both stand.
-This ADR refines them: the journal is not only the storage format but the working
-representation, and the fold / fsck / query stop collapsing to JSON early. It does
+This ADR refines them: the journal is the authority, the typed fold is the one
+canonical in-memory derivation, and fold / fsck / query stop collapsing to JSON early. It does
 not touch the Episode concept, identity model, physical layout, or
 dependency/projection policy — those remain with ADR-0033 and the forthcoming
 Episode ADR.
 
 ## First delivery (staged)
 
-- Make the `episode_manifest` fold POD-native: read POD frames into a typed
-  current view and typed frame/ref/dependency collections; produce JSON only at
-  the edge.
-- Tighten Episode fsck to verify over the typed structure — status/seal
-  consistency, payload-reference presence, causal closure, and frame integrity
-  (ADR-0023) — reporting the degraded / intentional / failed distinction from the
-  structure.
-- Add a rebuildable Episode SQLite projection over the journal via
-  `cache::make_storage_ptr` (mirroring the source-registry projection) and route
-  Episode query through the folded view and that projection.
-- Resolve the manifest's content-addressed references through the ADR-0040 KV.
-- Keep the ADR-0034 record set and the edge JSON shape stable so consumers are
-  unaffected while the internals move to POD-native.
+1. **Typed fold.** Read POD frames into one typed current view and typed
+   frame/ref/dependency collections; define deterministic fold order, duplicate
+   handling, unknown-version behavior, and bounded/streaming behavior; produce
+   JSON only at the edge. Keep the ADR-0034 record set and edge JSON shape stable.
+2. **Writer/recovery contract.** Name the manifest writer owner, document the
+   event-journal/manifest-journal publication order, and add crash-point fixtures.
+   Do not wire automatic lifecycle appends until this stage is proved.
+3. **Structural fsck.** Verify status/seal consistency, payload-reference claims,
+   causal closure, and frame integrity (ADR-0023) over the typed fold, reporting
+   degraded / intentional / failed from the structure.
+4. **Content resolution.** After ADR-0040's minimal immutable `content_store`
+   contract and default backend land, resolve and verify manifest content refs
+   through that interface. No bespoke path fallback becomes a second contract.
+5. **Projection/query.** Add a rebuildable Episode SQLite projection via
+   `cache::make_storage_ptr`, verify it against the journal fold, and route indexed
+   Episode query through the typed model and projection.
+
+Before stage 1 implementation, publish a field-to-claim mapping for the existing
+ADR-0034 records. If the current schema cannot represent a required hash root,
+reference, or lifecycle state without overloading a field, stop and write a
+schema-version ADR rather than silently changing the record set.
 
 ## Explicitly out of scope
 
@@ -176,7 +207,7 @@ Episode ADR.
 - Any change to the ADR-0034 Episode record set, Episode carrier_type allocation,
   or the edge JSON shape; this ADR tightens structure and operations, not the
   schema.
-- The content-addressed KV substrate implementation (ADR-0040) and the storage
+- The content-addressed store substrate implementation (ADR-0040) and the storage
   record kernel-metadata direction (ADR-0037); this ADR builds on them.
 - The import-manifest record migration; it adopts the same POD-native pattern but
   is delivered separately.
@@ -198,10 +229,10 @@ Episode ADR.
 
 ## Residual risk
 
-- The POD current view for variable-length manifest content (frames, refs,
+- The typed current view for variable-length manifest content (frames, refs,
   dependencies) must follow the append-only delta discipline and stream / bound
-  like the journal it reads; a naive typed view that materializes everything in
-  memory does not scale to long Episodes.
+  like the journal it reads; a naive view that materializes everything in memory
+  does not scale to long Episodes.
 - The SQLite projection must stay a rebuildable derived view (verified against the
   journal by fsck), never a second authority — the same guarantee the
   source-registry projection carries.
@@ -214,3 +245,6 @@ Episode ADR.
 - The manifest records identity and hash-root fields whose deep semantics are
   deferred to the Episode ADR; the field layout chosen here must not foreclose a
   content-addressed identity / hash-root model later.
+- A prose-only writer ownership rule is insufficient. The implementation needs a
+  data-root-scoped guard and crash fixtures before a master and masterless process
+  can safely target the same manifest location.

--- a/framework/core/docs/adr/README.md
+++ b/framework/core/docs/adr/README.md
@@ -55,8 +55,8 @@ A record's **Status** says where it stands:
 | [0037](ADR-0037-storage-records-hana-core-kernel-metadata.md) | accepted | ADR-0018 storage-service records are Hana-core kernel metadata; JSON is an edge projection, not the contract |
 | [0038](ADR-0038-location-namespace-terminology.md) | accepted | Location middle identity segment is namespace |
 | [0039](ADR-0039-unified-view-interface-encapsulates-flatbuffers.md) | proposed | a single kungfu view interface is the sole FlatBuffers access point; raw FB is not called elsewhere |
-| [0040](ADR-0040-runtime-fact-ledger-content-addressed-kv.md) | proposed | a first-class content-addressed KV is a runtime fact-ledger primitive, backend-neutral from an embedded single agent to a fleet-scale sharded/tiered store |
-| [0041](ADR-0041-episode-manifest-first-class-journal-structure.md) | proposed | the Episode manifest is the object's trust boundary — a POD-native yijinjing journal structure with writer/runtime/fsck/query tightened around it, JSON edge-only |
+| [0040](ADR-0040-runtime-fact-ledger-content-addressed-kv.md) | proposed | a first-class content-addressed store is a runtime fact-ledger primitive, with mutable KV and fleet topology kept as separate capabilities |
+| [0041](ADR-0041-episode-manifest-first-class-journal-structure.md) | proposed | the Episode manifest is the object's trust boundary — POD journal records, one typed fold, and JSON at the edge |
 
 ## Reading by theme
 


### PR DESCRIPTION
## Summary

Clarify the two proposed storage ADRs before implementation begins.

## Related issue

None.

## Changes

- narrow ADR-0040 to an immutable content-store contract and keep mutable KV as a separate capability
- define backend capability, durability, visibility, ownership, and scale evidence boundaries
- distinguish POD manifest records from the typed Episode current view in ADR-0041
- add writer ownership, cross-journal crash recovery, schema-mapping, and staged dependency gates
- update the ADR index titles

## Verification

- `git diff --check`
- `./kungfu-code check`
- public-surface scan for private paths or maintenance-authorship signals

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] release evidence, provenance, package publishing, or deployment surfaces
- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed
