### PR TITLE
docs(episode): define atomic safety qualification

### DIFF
--- a/docs/MAP.md
+++ b/docs/MAP.md
@@ -37,7 +37,7 @@ and the map routes a question to whichever doc answers it.
 | What is the event / journal / replay model? | [`event-model.md`](event-model.md) | use | stable |
 | What does Rewind replay, and what must it never silently re-execute? | [ADR-0020](../framework/core/docs/adr/ADR-0020-agent-action-timeline-and-replay-boundary.md) + [`rewind.md`](rewind.md) | why, verify | stable |
 | How does Kungfu persist user facts, sync sources, and maintain storage over time? | [`runtime-storage-service.md`](runtime-storage-service.md) | use, verify | draft |
-| What is an Episode, and why is it the unit of export/import/fsck/timeline slicing? | [`episode-object-model.md`](episode-object-model.md) + [ADR-0033](../framework/core/docs/adr/ADR-0033-episode-causal-segment-object.md) + [ADR-0034](../framework/core/docs/adr/ADR-0034-yijinjing-episode-manifest-journal.md) | why, use, verify | draft |
+| What is an Episode, why is it the atomic trust boundary, and how is that claim qualified under faults and load? | [`episode-object-model.md`](episode-object-model.md) + [`episode-atomicity-qualification.md`](episode-atomicity-qualification.md) + [ADR-0033](../framework/core/docs/adr/ADR-0033-episode-causal-segment-object.md) + [ADR-0034](../framework/core/docs/adr/ADR-0034-yijinjing-episode-manifest-journal.md) + [ADR-0042](../framework/core/docs/adr/ADR-0042-episode-atomic-safety-and-qualification.md) | why, use, verify | draft |
 | What is the supervisor/master topology, and how can the master stay alive after the GUI closes? | [`master-service.md`](master-service.md) + [ADR-0036](../framework/core/docs/adr/ADR-0036-supervisor-and-workspace-master-topology.md) | use, verify | draft |
 | How can a multi-machine timeline stay stable without one global clock? | [ADR-0021](../framework/core/docs/adr/ADR-0021-observer-relative-timeline-projection.md) + [`event-model.md`](event-model.md) | why, verify | stable |
 | Where must action-recording semantics live across C++ / Python / Node? | [ADR-0022](../framework/core/docs/adr/ADR-0022-core-action-recording-surface.md) + [`event-model.md`](event-model.md) | why, use | stable |
@@ -120,10 +120,14 @@ route to the row that answers them:
   store / fsck / compact / garbage collection / range export / projection
   rebuild** → *runtime storage service*
   ([`runtime-storage-service.md`](runtime-storage-service.md)).
-- **episode / causal segment / causal closure / lifecycle unit / run slice /
-  export unit / import unit / tombstone / episode manifest / episode fsck** →
+- **episode / causal segment / causal closure / atomic safety / graceful
+  degradation / capability contraction / qualification / Trust Report /
+  lifecycle unit / run slice / export unit / import unit / tombstone / episode
+  manifest / episode fsck** →
   *Episode object model* ([`episode-object-model.md`](episode-object-model.md))
-  and [ADR-0033](../framework/core/docs/adr/ADR-0033-episode-causal-segment-object.md).
+  plus [`episode-atomicity-qualification.md`](episode-atomicity-qualification.md),
+  [ADR-0033](../framework/core/docs/adr/ADR-0033-episode-causal-segment-object.md),
+  and [ADR-0042](../framework/core/docs/adr/ADR-0042-episode-atomic-safety-and-qualification.md).
 - **episode manifest journal / manifest record / manifest delta / manifest
   authority / yijinjing manifest / Hana manifest / JSON manifest** → *Episode
   object model* ([`episode-object-model.md`](episode-object-model.md)) and

--- a/docs/episode-atomicity-qualification.md
+++ b/docs/episode-atomicity-qualification.md
@@ -1,0 +1,326 @@
+---
+status: draft
+period: ongoing
+theme: episode-atomicity-qualification
+doc_type: verification-design
+source_level: user-consensus + local-files
+confidence: medium-high
+sensitivity: public
+evidence_grade: B
+review_state: self-reviewed
+last_reviewed: 2026-07-10
+ai_provenance:
+  model_family: GPT-5
+  product: Codex
+  generated_at: 2026-07-10
+  visible_context: ADR-0042 design discussion, current Episode v1 implementation/tests, and Kungfu fuzz/verification conventions
+  invisible_context_boundary: No qualification harness or industrial-scale run exists yet; numerical envelopes are planning targets, not measured capacity
+---
+
+# Episode Atomicity Qualification
+
+This document is the living verification design for
+[ADR-0042](../framework/core/docs/adr/ADR-0042-episode-atomic-safety-and-qualification.md).
+It defines how Kungfu should accumulate evidence that Episode is a trustworthy
+atomic safety and fault-containment boundary. ADR-0042 owns the stable semantics;
+this document owns the evolving workload, fault matrix, scale tiers, metrics,
+and report format.
+
+## Qualification claim
+
+A successful run supports only a bounded claim:
+
+> Under the named source revision, platform, hardware, backend profile, workload,
+> duration, and injected-fault set, Kungfu observed no silent Episode-integrity,
+> capability-soundness, recovery-monotonicity, causal-closure, or failure-
+> containment violation, and met the recorded performance objectives.
+
+It does not prove correctness under every hardware failure or establish a
+permanent capacity guarantee. New profiles and larger claims require new runs.
+
+## What is being qualified
+
+The system under test includes the complete Episode trust path:
+
+```text
+writer ownership and publication
+  -> event journal + manifest journal
+  -> content-addressed refs
+  -> typed fold and qualification result
+  -> fsck and capability report
+  -> projection/query
+  -> export/import and repair
+```
+
+Testing only a JSON facade, SQLite projection, or manifest append throughput is
+not Episode qualification.
+
+## Semantic oracle
+
+Build a small executable reference model independent of the production fold. It
+consumes abstract operations and evidence changes rather than mmap bytes:
+
+```text
+open(E)
+append_frame(E, F, trigger)
+attach_ref(E, R)
+seal_or_abort(E)
+lose_or_corrupt(evidence)
+restore(evidence)
+rebuild_projection(E)
+import_or_export(E)
+tombstone(E)
+```
+
+For every generated state it returns:
+
+- lifecycle facts;
+- verified evidence dimensions;
+- structured issues;
+- safe capabilities;
+- dependency impact;
+- permitted repair transitions.
+
+The production typed fold/fsck result is compared with the oracle. A mismatch is
+a correctness failure even when the operation returned success.
+
+### Core properties
+
+| Property | Required observation |
+| --- | --- |
+| Deterministic fold | The same authoritative record/evidence set yields the same typed result, issues, capabilities, and roots. |
+| No partial completion | Interrupted publication is never reported as a fully verified Episode. |
+| Capability soundness | Every advertised capability's evidence preconditions hold. |
+| Useful degradation | Losing evidence disables only capabilities that need it; unaffected safe capabilities remain available. |
+| Honest unknowns | Unknown or missing evidence is not rewritten as intentional absence. |
+| Recovery monotonicity | Ordinary repair preserves verified facts and may add evidence/capabilities; retry is semantically idempotent. |
+| Failure containment | Damage affects another Episode only through a named dependency/shared-evidence relation. |
+| Projection derivation | Deleting and rebuilding projections produces an equivalent derived result without changing authority. |
+| Portable identity | Qualified export/import preserves the Episode identity/root and qualification result under the same contract version. |
+
+Small-state exhaustive enumeration should cover short histories before random
+generation scales them. Every discovered counterexample becomes a minimized,
+checked-in regression fixture.
+
+## Fault matrix
+
+The harness injects one fault and selected combinations at declared durability
+boundaries. Each case records the expected capability contraction and recovery
+path, not just a final pass/fail bit.
+
+| Surface | Fault examples | Required checks |
+| --- | --- | --- |
+| Writer ownership | two writers for one manifest location, stale owner, restart race | one owner or explicit failure; no interleaved silent authority |
+| Publication | kill before/after event append, manifest attach, content publish, seal, fsync/visibility | deterministic recovery; no false complete claim |
+| Journal | truncated page/frame, torn tail, bit flip, duplicate/out-of-order record, unknown version | bounded failure, exact issue, unaffected Episode isolation |
+| Frames | missing frame, wrong receipt/checksum, undeclared external trigger | closure/capability contraction and repair target |
+| Content | missing object, wrong bytes/hash/length, delayed visibility, duplicate put | verified reads, no guessed substitution, idempotent recovery |
+| Schema | absent/unknown/corrupt schema | decode-dependent capabilities close; raw evidence remains inspectable |
+| Dependencies | missing Episode, cycle, deep/fan-out graph, dependency restored later | explicit impact, deterministic traversal, monotonic recovery |
+| Projection | missing database, stale/mutated rows, interrupted rebuild | authority remains journal; rebuild restores equivalence |
+| Export/import | truncated bundle, missing closure material, duplicate import, incompatible version | reject or contract-safe degrade; no partial acceptance |
+| Repair | bad donor, repeated material, partial apply, crash during apply | validation first, append-only receipts, idempotence, fsck after apply |
+| Resource pressure | ENOSPC, descriptor exhaustion, allocation failure, backpressure, process kill | explicit failure/backpressure; verification is not bypassed |
+
+Fault injection should sit at named production boundaries rather than depend only
+on timing races. The harness must also retain stochastic kill/chaos runs to find
+unanticipated interleavings.
+
+## Workload model
+
+Workloads are generated from versioned profiles. Dogfood measurements should
+eventually replace synthetic guesses, but the first harness needs explicit
+distributions for:
+
+- Episode frame count and lifetime;
+- payload count, size, and dedup ratio;
+- schema count and reuse;
+- dependency depth, fan-out, fan-in, and hot ancestors;
+- open/seal/abort ratio;
+- inspect/query/export/import/repair mix;
+- projection rebuild frequency;
+- retained Episode age and hot/cold access distribution.
+
+Use at least these shapes:
+
+- many small independent Episodes;
+- long Episodes with bounded/streamed folds;
+- wide and deep dependency DAGs;
+- shared content with high dedup;
+- sparse large payloads;
+- degraded populations undergoing repair while healthy work continues.
+
+Generated workloads must be reproducible from a profile version and random seed.
+
+## Concurrency model
+
+Keep logical and physical concurrency separate:
+
+- **logical agents** each own their declared writer/journal identity;
+- a multiplexed driver can generate thousands of logical agents without
+  requiring one OS process per agent;
+- real thread and multi-process tiers exercise scheduler, lock, descriptor, mmap,
+  and filesystem behavior that logical multiplexing cannot reproduce;
+- future distributed/service-backed profiles are separate qualifications, not
+  inferred from a single-node run.
+
+The single-node campaign must pressure shared catalog/manifest, content-store,
+projection, query, and descriptor paths even though per-agent journals avoid
+logical write contention.
+
+## Initial scale tiers
+
+These are planning envelopes for harness construction, not product capacity
+claims. Revise them from measured dogfood evidence.
+
+| Tier | Initial envelope | Purpose |
+| --- | --- | --- |
+| PR smoke | `10^3–10^4` Episodes, tens of logical agents, fixed fault corpus | fast semantic regression |
+| Heavy/alpha | `10^5` Episodes, up to `10^3` logical agents, generated faults and projection rebuild | recurring scale and sanitizer gate |
+| Single-node qualification | `10^6+` Episodes, up to `10^4` logical agents, mixed real concurrency, 24–72 hour soak | evidence for an industrial single-node profile |
+| Fleet qualification | multi-node/service-backed workload declared separately | later distributed profile; never inferred from single-node results |
+
+Episode bodies may be compact in metadata-scale runs. Separate payload-volume
+profiles must exercise realistic bytes, dedup, cold material, and I/O pressure so
+metadata throughput is not misreported as full-ledger throughput.
+
+## Metrics
+
+### Correctness gates
+
+The following counts must be zero for a qualified run:
+
+- silently accepted invalid/partial Episodes;
+- over-advertised capabilities;
+- deterministic-fold/root disagreements;
+- undeclared cross-Episode failure propagation;
+- ordinary repair that loses or changes verified facts;
+- projection results treated as authority when they disagree with the journal;
+- fault cases without a deterministic diagnostic or explicit unsupported label.
+
+Coverage evidence includes:
+
+- publication crash points exercised;
+- fault-matrix cells and combinations exercised;
+- property histories and random seeds;
+- minimized regression corpus size;
+- Episode/dependency shapes covered;
+- recovery/idempotence transitions covered.
+
+### Performance observations
+
+Record distributions, not only averages:
+
+- open/append/seal throughput and p50/p95/p99 latency;
+- inspect and capability-evaluation latency;
+- incremental and full fsck throughput;
+- projection rebuild time and peak memory;
+- export/import and repair throughput;
+- memory and descriptor high-water marks;
+- bytes per Episode and storage amplification;
+- content dedup ratio;
+- recovery time after crash;
+- performance as Episode count, Episode size, and dependency depth increase.
+
+Numerical pass/fail SLOs belong to a named profile and can be tightened without
+changing ADR-0042.
+
+## Harness architecture
+
+Prefer five separable components:
+
+1. **Generator** — emits a versioned workload and expected abstract history.
+2. **Driver** — executes the history through the real C++-owned Episode surface.
+3. **Fault controller** — injects deterministic and stochastic failures at named
+   boundaries.
+4. **Oracle/verifier** — compares authority, typed fold, fsck, capabilities,
+   projections, bundles, and recovery with the independent model.
+5. **Reporter** — emits the machine-readable Trust Report and a short human
+   summary.
+
+Python may orchestrate qualification, generation, and reporting, but must not
+become an alternative product Episode engine. Load-bearing parsing, storage, and
+capability decisions remain C++-owned.
+
+Reuse Kungfu's existing sanitizer/libFuzzer tiers for byte-facing boundaries and
+add Episode-specific targets/corpora. Property histories and crash fixtures are
+complementary: fuzzing malformed bytes cannot replace lifecycle/dependency model
+checking, and model checking cannot replace ASan/UBSan coverage.
+
+## Execution schedule
+
+| Event | Required tier |
+| --- | --- |
+| Episode/manifest PR | semantic smoke plus affected deterministic fault fixtures |
+| Alpha/release candidate | heavy tier, sanitizer corpus, bounded generated campaign |
+| Production-profile claim | full named qualification and soak on declared hardware/backend |
+| New backend or publication protocol | rerun relevant full profile; do not inherit evidence automatically |
+| New schema/capability contract | version oracle/profile and rerun compatibility plus qualification |
+
+The first implementation may keep the full qualification manual. Once runtime
+and false-positive rates stabilize, automate it as a release gate. A failed
+correctness gate always blocks the corresponding trust claim; a missed
+performance SLO blocks only the profile whose SLO was missed, unless safety was
+compromised.
+
+## Episode Trust Report
+
+Each run records at least:
+
+```json
+{
+  "schema": "kungfu.episode.trust-report/v1",
+  "source_revision": "<git sha>",
+  "episode_contract": "<version>",
+  "profile": "single-node-qualification/v1",
+  "platform": "<os/arch>",
+  "hardware": {},
+  "backend_capabilities": {},
+  "workload": {
+    "profile": "<name/version>",
+    "seed": "<seed>",
+    "episodes": 0,
+    "logical_agents": 0,
+    "duration_seconds": 0
+  },
+  "fault_coverage": {},
+  "correctness": {
+    "silent_invalid": 0,
+    "capability_violations": 0,
+    "containment_violations": 0,
+    "repair_monotonicity_violations": 0
+  },
+  "performance": {},
+  "gaps": [],
+  "qualified": false
+}
+```
+
+The real schema should use stable field names and normalized hardware/backend
+descriptions. Reports are evidence artifacts, not authority facts inside an
+Episode. A human summary must link the exact report rather than restate only the
+best throughput number.
+
+## First implementation slices
+
+1. Encode the abstract state/capability oracle and exhaust short histories.
+2. Convert current happy/degraded/repair Episode fixtures into oracle comparisons.
+3. Add deterministic publication crash points and a checked-in corruption
+   corpus.
+4. Add generated DAG and recovery properties with reproducible seeds.
+5. Add a metadata-scale driver, then realistic payload and multi-process modes.
+6. Emit Trust Report v1 and run the first single-node baseline without treating
+   its numbers as a support promise.
+
+## Open questions
+
+- What is the smallest stable capability vocabulary for v1?
+- Which capability decisions require fresh full fsck, cached verification, or
+  verification-on-use?
+- Which missing evidence is optional, intentionally absent, recoverable, or
+  required for each operation?
+- How are repair receipts represented without expanding the kernel schema too
+  early?
+- Which real dogfood traces can be anonymized into workload distributions?
+- Which hardware and filesystem profiles should become the first supported
+  single-node qualification targets?

--- a/docs/episode-object-model.md
+++ b/docs/episode-object-model.md
@@ -6,6 +6,11 @@ invariants are accepted by
 [ADR-0034](../framework/core/docs/adr/ADR-0034-yijinjing-episode-manifest-journal.md)
 defines the append-only yijinjing manifest journal. The full Episode-aware
 physical journal layout is still future work.
+[ADR-0042](../framework/core/docs/adr/ADR-0042-episode-atomic-safety-and-qualification.md)
+proposes Episode as the atomic safety and fault-containment unit: degradation
+preserves verified work and contracts only the capabilities that missing or
+unverifiable evidence cannot safely support. Its executable verification design
+lives in [Episode Atomicity Qualification](episode-atomicity-qualification.md).
 
 Kungfu needs a storage object that matches the way users and agents reason about
 work. Raw mmap pages are append blocks. A source is a provenance and sync
@@ -315,6 +320,13 @@ root trigger frame, or missing payload ref produces a warning and a degraded
 status while keeping `ok: true` when the manifest itself is readable. This gives
 repair/sync code a precise target without making the Episode disappear from
 inspection or export.
+
+ADR-0042 tightens the intended interpretation without turning degradation into
+a deletion policy: lifecycle, health, and safe capabilities are separate
+dimensions. A future structured qualification result should state which
+operations remain safe and why; the current `ok` field must be read in its
+documented scope rather than as a claim that every Episode capability is fully
+available.
 
 `kungfu.storage.repair-plan/v1` is the first repair-facing projection over that
 diagnostic set. It maps the Episode warnings to read-only candidates such as

--- a/framework/core/docs/adr/ADR-0041-episode-manifest-first-class-journal-structure.md
+++ b/framework/core/docs/adr/ADR-0041-episode-manifest-first-class-journal-structure.md
@@ -14,8 +14,10 @@
   Episode manifest records in the yijinjing journal format; ADR-0037 makes the
   storage record family Hana-core kernel metadata with JSON as an edge
   projection; ADR-0040 makes the runtime fact ledger's content-addressed store a
-  first-class primitive; ADR-0023 starts frame integrity at the C++ recorder;
-  ADR-0028 separates content hashes from frame checksums.
+  first-class primitive; ADR-0042 defines Episode atomic safety, graceful
+  degradation, fault containment, and qualification under load; ADR-0023 starts
+  frame integrity at the C++ recorder; ADR-0028 separates content hashes from
+  frame checksums.
 
 ## Scope
 
@@ -27,13 +29,13 @@ This ADR is about eliminating the remaining JSON-early implementation, deriving
 one typed current view from those records, and tightening the operations that
 touch it.
 
-It is deliberately narrow. The **complete Episode concept** — the Episode
-identity model and its atomic / independent / operable / pressure-resistant
-guarantees, Episode-aware physical page allocation, and the dependency /
-projection / observer policy — is a **forthcoming Episode ADR**, consistent with
-ADR-0033 deferring physical layout. This ADR only makes the manifest (the trust
-boundary) clear and tight; it does not decide the deep Episode identity or
-composition semantics.
+It is deliberately narrow. ADR-0042 takes the next semantic slice — atomic
+safety, graceful degradation, fault containment, recovery, and qualification
+under pressure. The deep Episode identity and hash-root composition model,
+Episode-aware physical page allocation, and the dependency / projection /
+observer policy remain later decisions, consistent with ADR-0033 deferring
+physical layout. This ADR only makes the manifest (the trust boundary) clear and
+tight; it does not decide those deeper semantics.
 
 ## Context
 
@@ -160,9 +162,9 @@ operations tighten around that separation:
   the source-registry projection pattern while keeping the journal as authority.
 - Causal closure, the ADR-0033 core invariant, becomes a checked property of the
   manifest rather than an assumption.
-- The manifest is ready to serve the forthcoming complete Episode ADR: the deep
-  identity / atomicity / independence / composition model can be defined on top
-  of a manifest that is already POD-native and structurally verified.
+- The manifest is ready to serve ADR-0042's atomic-safety qualification and later
+  identity / composition work: those guarantees can be defined on top of a
+  manifest that is already POD-native and structurally verified.
 
 ## Relation to ADR-0033 / ADR-0034
 
@@ -171,8 +173,9 @@ decides the manifest records live in the yijinjing journal format. Both stand.
 This ADR refines them: the journal is the authority, the typed fold is the one
 canonical in-memory derivation, and fold / fsck / query stop collapsing to JSON early. It does
 not touch the Episode concept, identity model, physical layout, or
-dependency/projection policy — those remain with ADR-0033 and the forthcoming
-Episode ADR.
+dependency/projection policy. ADR-0042 defines the atomic-safety and
+qualification contract; deep identity, layout, and projection policy remain
+later decisions.
 
 ## First delivery (staged)
 
@@ -200,10 +203,10 @@ schema-version ADR rather than silently changing the record set.
 
 ## Explicitly out of scope
 
-- The complete Episode concept ADR: the Episode identity model and its atomic /
-  independent / operable / pressure-resistant guarantees, Episode-aware physical
-  page allocation, and dependency / projection / observer policy. This ADR is the
-  manifest, not the full object model.
+- Episode atomic safety, graceful degradation, fault containment, and
+  pressure-qualification semantics (ADR-0042); this ADR is the manifest, not the
+  full object model. Deep identity, Episode-aware physical page allocation, and
+  dependency / projection / observer policy also remain outside this ADR.
 - Any change to the ADR-0034 Episode record set, Episode carrier_type allocation,
   or the edge JSON shape; this ADR tightens structure and operations, not the
   schema.
@@ -225,7 +228,9 @@ schema-version ADR rather than silently changing the record set.
 - **Expand this ADR to the full Episode object model (identity, atomicity,
   composition).** Rejected for now. The manifest is the core of the Episode and
   can be made first-class on its own; the deep object model is a distinct decision
-  best made on top of a clean manifest, in the forthcoming Episode ADR.
+  best made on top of a clean manifest. ADR-0042 takes the atomic-safety and
+  qualification slice; deeper identity, layout, and composition decisions remain
+  separate.
 
 ## Residual risk
 

--- a/framework/core/docs/adr/ADR-0042-episode-atomic-safety-and-qualification.md
+++ b/framework/core/docs/adr/ADR-0042-episode-atomic-safety-and-qualification.md
@@ -29,7 +29,10 @@ ai_provenance:
   ADR-0034 makes its manifest a yijinjing journal; ADR-0041 makes the POD journal
   plus one typed fold the trust boundary; ADR-0040 defines the immutable content
   store used by Episode references; ADR-0023 and ADR-0028 define frame and hash
-  integrity boundaries. The executable qualification design lives in
+  integrity boundaries. The ADR-0041 field map and writer/crash contract are
+  recorded in
+  [`framework/core/docs/episode-manifest-trust-boundary.md`](../episode-manifest-trust-boundary.md).
+  The executable qualification design lives in
   [`docs/episode-atomicity-qualification.md`](../../../../docs/episode-atomicity-qualification.md).
 
 ## Context

--- a/framework/core/docs/adr/ADR-0042-episode-atomic-safety-and-qualification.md
+++ b/framework/core/docs/adr/ADR-0042-episode-atomic-safety-and-qualification.md
@@ -1,0 +1,313 @@
+---
+status: draft
+period: 2026-07-10
+theme: episode-atomic-safety
+doc_type: architecture-decision
+source_level: user-consensus + local-files
+confidence: high
+sensitivity: public
+evidence_grade: B
+review_state: self-reviewed
+last_reviewed: 2026-07-10
+ai_provenance:
+  model_family: GPT-5
+  product: Codex
+  generated_at: 2026-07-10
+  visible_context: User discussion, ADR-0033, ADR-0034, ADR-0040, ADR-0041, the Episode object model, and current v1 degraded/repair tests
+  invisible_context_boundary: Exact model build and hidden system implementation are unknown
+---
+
+# ADR-0042: Episode is the atomic safety and fault-containment unit, qualified by evidence under load
+
+- Status: proposed
+- Date: 2026-07-10
+- Category: (architecture) Episode trust semantics — atomic safety, graceful
+  degradation, recovery, fault containment, and qualification evidence.
+- Subsystem: Episode identity and manifest semantics, runtime storage service,
+  fsck, query/projection, export/import, repair, replay, and release gates.
+- Related: ADR-0033 defines Episode as the first-class causal segment object;
+  ADR-0034 makes its manifest a yijinjing journal; ADR-0041 makes the POD journal
+  plus one typed fold the trust boundary; ADR-0040 defines the immutable content
+  store used by Episode references; ADR-0023 and ADR-0028 define frame and hash
+  integrity boundaries. The executable qualification design lives in
+  [`docs/episode-atomicity-qualification.md`](../../../../docs/episode-atomicity-qualification.md).
+
+## Context
+
+Episode is intended to become Kungfu's most important semantic object: the unit
+that users and agents inspect, move, verify, replay, repair, hide, and reason
+about. If the rest of the storage design is organized around Episode, users need
+more than a useful API. They need a reason to trust the boundary under crashes,
+missing evidence, corruption, repair, high concurrency, and large retained
+populations.
+
+"Atomic" is easy to misread as either a physical transaction or a binary rule:
+an Episode is completely healthy or it must be deleted. Neither interpretation
+is sufficient.
+
+- Event frames, manifest records, content objects, and projections cross several
+  persistence surfaces. They cannot be made one physical write without replacing
+  the journal architecture.
+- Real work is valuable. Missing a projection, payload, schema, dependency, or
+  remote evidence should not cause Kungfu to discard facts that remain readable
+  and verified.
+- Continuing to work is safe only when Kungfu states honestly which capabilities
+  the available evidence supports. "Degraded" must not mean either "pretend it is
+  healthy" or "delete it by default."
+
+The v1 Episode path already points in the right direction: a readable manifest
+may be degraded, inspected, exported for diagnosis, and passed through an
+auditable repair plan/fetch/apply flow. It does not yet define a complete
+capability contract, and a single `ok` boolean can be confused with a claim that
+every operation is safe.
+
+Scale makes the semantic question sharper. A single machine may retain millions
+of Episodes while thousands of logical agents write independent journals. A
+system that is correct only in small fixtures, or that relaxes verification to
+preserve throughput, cannot claim Episode as its atomic core.
+
+## Decision
+
+### 1. Atomic safety means bounded trust and failure containment
+
+Episode is Kungfu's atomic unit for:
+
+- verification and trust reporting;
+- capability decisions;
+- export/import and repair evidence;
+- failure localization;
+- causal membership and explicit cross-Episode dependency.
+
+Atomic safety does **not** mean that every Episode is always fully available,
+that every Episode is physically one transaction or file, or that damage implies
+deletion. It means that partial failure is contained and made explicit at the
+Episode boundary, and that no operation claims more safety than the evidence can
+support.
+
+For every Episode `E`:
+
+```text
+advertised_capabilities(E) ⊆ evidence_safe_capabilities(E)
+```
+
+An implementation violates the atomic boundary if it silently consumes missing
+or unverifiable evidence, presents a partial Episode as complete, or lets one
+Episode's damage corrupt unrelated Episode facts.
+
+### 2. Lifecycle, health, and capability are separate dimensions
+
+Lifecycle facts (`open`, sealed terminal outcomes, tombstone and later
+maintenance receipts) remain append-only manifest facts. Health labels such as
+`healthy`, `degraded`, or `failed` are derived diagnostics. Neither is by itself
+a complete permission model.
+
+The typed Episode view and its edge projection must be able to report at least:
+
+- authority/manifest integrity;
+- frame and content integrity;
+- dependency and causal-closure status;
+- projection freshness/rebuildability;
+- structured issues and supporting evidence;
+- the capabilities currently safe for the requested operation.
+
+Capabilities are operation-oriented, not one global bit. The vocabulary may
+include inspect, query, project, export, import/accept, replay, depend-on, repair,
+sync, and continue/seal where applicable. The exact public schema is staged, but
+all language bindings must project the same C++ decision rather than inventing
+their own gates.
+
+The existing v1 `ok` and `degraded` fields may remain for compatibility while a
+structured capability report is introduced. `ok: true` must be interpreted in a
+documented scope (for example, "manifest is readable"), never as an implicit
+claim that every capability is safe.
+
+### 3. Degradation preserves safe work
+
+A degraded Episode is not automatically unusable and is not a deletion
+candidate merely because it is degraded. Kungfu preserves all verified evidence
+and keeps every capability whose preconditions remain satisfied.
+
+Examples:
+
+- A missing rebuildable projection does not invalidate the journal authority;
+  projection-backed query can fall back or pause while inspect and rebuild remain
+  safe.
+- A missing optional or remotely recoverable payload may still permit manifest
+  inspection, dependency analysis, evidence export, and repair discovery while
+  disabling operations that require those bytes.
+- A missing dependency may restrict projection, replay, or acceptance that needs
+  that dependency without hiding the Episode or erasing its local facts.
+- Unreadable authority evidence requires stronger isolation, but raw evidence is
+  retained for forensic inspection and recovery whenever possible.
+
+Degradation is therefore a capability contraction backed by explicit issues.
+It must not silently substitute guessed facts or turn an unknown state into an
+intentional absence.
+
+### 4. Recovery is evidence-preserving and monotonic
+
+Repair is preferred over deletion when trusted evidence can be recovered.
+Repair operations must be auditable, validate incoming material before use, and
+append receipts or missing facts through the authoritative path rather than
+rewrite known-good history.
+
+For a repair transition from `E` to `E'`:
+
+```text
+verified_facts(E) ⊆ verified_facts(E')
+```
+
+unless an explicit, separately governed correction contract supersedes a fact.
+Normal repair may add evidence and restore capabilities; it must not remove or
+silently alter facts that already verified. Retrying the same repair should be
+idempotent at the semantic level.
+
+Quarantine, tombstone, and physical purge are progressively stronger controls.
+They remain available for unsafe, intentionally excluded, or unrecoverable
+material, but are not the default response to ordinary degradation. Destructive
+operations retain their dry-run, dependency-impact, archive, and policy gates.
+
+### 5. Cross-Episode influence is explicit and failure does not propagate silently
+
+ADR-0033 causal closure remains the core invariant. Damage to Episode `A` may
+reduce capabilities of Episode `B` only through an explicit dependency or shared
+evidence relation that fsck can name. Unrelated Episodes retain their verified
+facts and safe capabilities.
+
+Deletion, tombstone, repair, and import planning must surface reverse dependency
+impact before mutation. This ADR does not choose one universal cascade policy;
+it requires that any supported policy leave the selected Episode set in an
+explicit, verifiable state rather than create hidden broken dependencies.
+
+### 6. Logical admission is evidence-derived across non-atomic physical writes
+
+Event journals, the Episode manifest journal, content objects, and projections
+do not share one atomic write. The writer/recovery contract must therefore make
+visibility and capability decisions from durable evidence:
+
+- a crash before publication cannot create a silently complete Episode;
+- a terminal manifest record is not sufficient for a healthy claim if attached
+  evidence is missing or unverifiable;
+- recovery deterministically classifies interrupted publication and exposes the
+  exact missing side;
+- projections never become authority merely because they committed before or
+  after a journal record.
+
+The publication state machine and crash fixtures required by ADR-0041 are the
+first implementation of this rule.
+
+### 7. Safety semantics are pressure-invariant
+
+Concurrency and volume may change latency, availability, scheduling, and which
+backend profile is selected. They must not change the meaning of a verified
+fact, causal closure, degradation, or a safe capability.
+
+Thousands of logical agents should normally write independent per-agent
+journals. Shared catalog, manifest, content-store, projection, file-descriptor,
+and query paths remain pressure points and must be tested as such. Backpressure
+or explicit unavailability is safer than accepting unverified facts to preserve
+throughput.
+
+### 8. Production trust claims require an Episode qualification report
+
+Kungfu must not claim Episode as a production-grade atomic core from unit tests
+or benchmark throughput alone. A supported profile requires a reproducible
+qualification run covering:
+
+- model/property tests over lifecycle, dependency, capability, and repair
+  transitions;
+- crash injection at every declared publication boundary;
+- corruption and missing-evidence fixtures;
+- recovery and idempotence checks;
+- cross-Episode failure-containment checks;
+- projection rebuild and export/import round trips;
+- concurrent-writer and ownership tests;
+- scale and soak tests over the declared workload envelope.
+
+The run emits an Episode Trust Report containing the source revision, platform,
+hardware/profile, workload and random seeds, fault coverage, correctness
+violations, performance distributions, and remaining gaps. A profile is
+qualified only when its correctness gates pass; capacity observations do not
+become support promises until explicitly adopted.
+
+The stable requirements live in this ADR. Workload distributions, scale tiers,
+fault matrices, commands, SLOs, and report schema evolve in
+`docs/episode-atomicity-qualification.md` without rewriting this decision.
+
+## Consequences
+
+- Users can continue useful work with degraded Episodes when the required
+  evidence for that operation remains valid.
+- `degraded` becomes a precise contraction with repair paths, not a euphemism for
+  healthy and not a deletion policy.
+- C++ owns the capability decision; Python, Node, CLI, GUI, and export formats
+  expose it consistently.
+- Fsck must report evidence and operation impact, not only aggregate errors.
+- Repair, sync, import, and maintenance gain a common safety oracle.
+- Performance engineering must preserve semantics under pressure rather than
+  benchmark a weakened path.
+- Release language becomes profile- and evidence-scoped: Kungfu can say what was
+  tested and observed without claiming immunity to every possible fault.
+
+## First delivery
+
+1. Define a versioned internal Episode qualification result containing evidence
+   dimensions, issues, and safe capabilities; project it through the existing
+   edge JSON without breaking v1 consumers.
+2. Build an independent, executable reference model for lifecycle, dependency,
+   capability, repair, and interruption states; compare the C++ typed fold/fsck
+   result against it with generated histories.
+3. Add deterministic crash and corruption injection around the ADR-0041
+   publication state machine and the ADR-0040 content-store boundary.
+4. Add the scalable workload harness and machine-readable Trust Report described
+   by the companion qualification document.
+5. Gate production Episode claims on the declared profile's qualification result;
+   keep current unit/E2E tests as the fast inner tier.
+
+These stages may land incrementally. The current ADR-0041 typed-fold work need
+not wait for the whole scale harness, but writer lifecycle, capability reporting,
+repair, and production-readiness claims must converge on this contract.
+
+## Explicitly out of scope
+
+- Selecting the final Episode id or hash-root composition algorithm.
+- Requiring one Episode to map to one mmap file or physical transaction.
+- Defining the final Episode-aware page/segment layout.
+- Choosing a universal retention, tombstone cascade, GC, or purge policy.
+- Fixing permanent numerical SLOs or supported capacity in an ADR.
+- Implementing the distributed fleet storage service or remote consistency model.
+- Guaranteeing that every degraded Episode can be fully repaired; the guarantee
+  is honest capability reporting, evidence preservation, and best-effort recovery.
+
+## Alternatives considered
+
+- **Healthy or delete.** Rejected. It destroys recoverable work and confuses
+  atomic safety with binary availability.
+- **Keep one `ok` boolean as the whole contract.** Rejected. Different operations
+  require different evidence; one bit either over-promises or disables useful
+  work.
+- **Treat degraded as healthy until an operation fails.** Rejected. It moves the
+  trust decision into callers and permits silent partial behavior.
+- **Stop all operations on any degradation.** Rejected. It is safe only in the
+  narrowest sense and violates the requirement to preserve useful user work.
+- **Benchmark throughput without a semantic oracle.** Rejected. A fast system
+  that admits invalid Episodes or misreports capabilities has failed the core
+  requirement.
+- **Put all test parameters in the ADR.** Rejected. Hardware, distributions,
+  scale tiers, and SLOs need to evolve while the safety decision remains stable.
+
+## Residual risk
+
+- A capability vocabulary can become too fine-grained or inconsistent across
+  callers. Keep the first version small, operation-oriented, and C++-owned.
+- The reference model can share assumptions with the implementation and miss the
+  same bug. Keep it structurally independent and add hand-authored adversarial
+  fixtures alongside generation.
+- Logical-agent simulation can hide real process, file-descriptor, scheduler, or
+  filesystem contention. Qualification needs both multiplexed scale and real
+  multi-process tiers.
+- A successful finite campaign cannot prove absence of every fault. Reports must
+  name the tested envelope, seeds, uncovered surfaces, and hardware profile.
+- Repair can become a second mutation language if it bypasses append-only
+  authority. Every repair path needs receipts, idempotence tests, and fsck after
+  application.

--- a/framework/core/docs/adr/README.md
+++ b/framework/core/docs/adr/README.md
@@ -57,6 +57,7 @@ A record's **Status** says where it stands:
 | [0039](ADR-0039-unified-view-interface-encapsulates-flatbuffers.md) | proposed | a single kungfu view interface is the sole FlatBuffers access point; raw FB is not called elsewhere |
 | [0040](ADR-0040-runtime-fact-ledger-content-addressed-kv.md) | proposed | a first-class content-addressed store is a runtime fact-ledger primitive, with mutable KV and fleet topology kept as separate capabilities |
 | [0041](ADR-0041-episode-manifest-first-class-journal-structure.md) | proposed | the Episode manifest is the object's trust boundary — POD journal records, one typed fold, and JSON at the edge |
+| [0042](ADR-0042-episode-atomic-safety-and-qualification.md) | proposed | Episode is the atomic safety and fault-containment unit, qualified by evidence under load |
 
 ## Reading by theme
 
@@ -143,7 +144,10 @@ A record's **Status** says where it stands:
   fsck report, accepted range — are Hana-core kernel metadata like the Episode
   manifest of ADR-0034, journal-backed and delta-append; the current JSON
   service surface and unconsumed heap structs are retired to an edge projection,
-  and payload bodies are opaque content-addressed bytes, not `.json` text).
+  and payload bodies are opaque content-addressed bytes, not `.json` text), and
+  [0042](ADR-0042-episode-atomic-safety-and-qualification.md) (Episode atomic
+  safety as evidence-bounded capability, graceful degradation, monotonic repair,
+  fault containment, and qualification under scale).
 - **Cross-cutting principle** — [0009](ADR-0009-load-bearing-self-bootstrap.md)
   (load-bearing self-bootstrap), which also names the general law that
   [`docs/architecture.md` § The build dogfoods the SDK](../../../../docs/architecture.md)
@@ -164,3 +168,6 @@ A record's **Status** says where it stands:
 - [`docs/episode-object-model.md`](../../../../docs/episode-object-model.md) —
   the Episode object model, causal closure invariant, and storage migration
   direction.
+- [`docs/episode-atomicity-qualification.md`](../../../../docs/episode-atomicity-qualification.md) —
+  the evolving semantic oracle, fault matrix, scale tiers, metrics, and Episode
+  Trust Report design required by ADR-0042.

--- a/framework/core/docs/episode-manifest-trust-boundary.md
+++ b/framework/core/docs/episode-manifest-trust-boundary.md
@@ -38,14 +38,15 @@ Mapping each ADR-0033 trust-boundary claim onto that record set:
 | declared external input frames | `EpisodeRefAttached` with `ref_kind=InputFrame` (`ref_uid` = frame uid); `EpisodeOpen.root_trigger_frame_uid` for the opening trigger | representable |
 | causal closure (ADR-0033 core invariant) | derivable: `EpisodeFrameAttached.trigger_frame_uid` edges must resolve inside the Episode's frame set or be declared as `InputFrame` refs / Episode dependencies. Closure is a checked property of the fold, not a stored field | representable (checked, not stored) |
 | rebuildable projection / query indexes | not stored in the manifest by design — projections are derived from the journal and verified against it (ADR-0041 point 5) | n/a (satisfied structurally) |
-| hash roots / sync roots for fsck/export/import | **not representable in v1.** No record carries an Episode-level inventory hash root. v1 fsck verifies by full enumeration of claims instead of root comparison, which is sufficient for the local trust boundary. A hash-root field is deferred to the forthcoming Episode ADR plus a schema-version ADR; it must not be squeezed into `ref_hash` or `note` by overloading | deferred — explicit gap, no field overloading |
+| hash roots / sync roots for fsck/export/import | **not representable in v1.** No record carries an Episode-level inventory hash root. v1 fsck verifies by full enumeration of claims instead of root comparison, which is sufficient for the local trust boundary. A hash-root field is deferred to a later Episode identity decision plus a schema-version ADR; ADR-0042 qualifies atomic safety without selecting the root algorithm. It must not be squeezed into `ref_hash` or `note` by overloading | deferred — explicit gap, no field overloading |
 
 Conclusion required by ADR-0041: the existing record set is sufficient for
 every claim this slice needs. The single not-representable claim (Episode
 hash/sync roots) is exactly the deep-identity surface ADR-0041 already
-defers to the forthcoming Episode ADR; nothing in stages 1–3 and 5 depends
-on it. Content-ref resolution (stage 4) depends on ADR-0040's immutable
-`content_store` landing first and changes no record layout.
+defers to a later identity/schema decision; ADR-0042 does not select that root,
+and nothing in stages 1–3 and 5 depends on it. Content-ref resolution (stage 4)
+depends on ADR-0040's immutable `content_store` landing first and changes no
+record layout.
 
 ## 2. Deterministic typed fold (stage 1 semantics)
 


### PR DESCRIPTION
Define Episode atomic safety, graceful degradation, evidence-preserving recovery, fault containment, and qualification under load. Add the living qualification plan with semantic oracle, fault matrix, scale tiers, metrics, and Episode Trust Report.