### PR TITLE
fix(view): bounds-check bind_frame field_index; generalize the fuzz harness

### DIFF
--- a/framework/core/fuzz/CMakeLists.txt
+++ b/framework/core/fuzz/CMakeLists.txt
@@ -43,12 +43,11 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 find_package(flatbuffers REQUIRED)
 find_package(SQLite3 REQUIRED)
 
-set(_view_dir ${CMAKE_CURRENT_SOURCE_DIR}/../src/libkungfu)
-set(_view_src ${_view_dir}/src/view/schema.cpp)
-set(_view_inc ${_view_dir}/include)
-
-# entry basename -> fuzz_<name>.cpp; kept in lockstep with the checked-in targets
-set(_targets compile_schema from_bytes bind_frame)
+# Whole libkungfu public include — covers kungfu::view today and any other core
+# module a future fuzz target drives (e.g. a storage/episode import surface).
+set(_lk_dir ${CMAKE_CURRENT_SOURCE_DIR}/../src/libkungfu)
+set(_lk_inc ${_lk_dir}/include)
+set(_view_src ${_lk_dir}/src/view/schema.cpp)
 
 # The libFuzzer tier only materializes when the active compiler actually ships
 # libFuzzer; otherwise skip with a message (Apple clang has none).
@@ -84,24 +83,42 @@ else()
 endif()
 set(_fuzz_flags -fsanitize=fuzzer,address,undefined -fno-omit-frame-pointer)
 
-foreach(t ${_targets})
-  set(_entry ${CMAKE_CURRENT_SOURCE_DIR}/fuzz_${t}.cpp)
+# kungfu_add_fuzz(<name> <module .cpp under test> [more .cpp ...])
+#   Builds fuzz/fuzz_<name>.cpp + the module source(s) two ways:
+#     KUNGFU_WITH_SANITIZERS -> fuzz_<name>_sanitize  (StandaloneFuzzMain corpus
+#                                                      replay under ASan/UBSan, any compiler)
+#     KUNGFU_WITH_FUZZ       -> fuzz_<name>           (libFuzzer, when available)
+#   Adding a new untrusted-input surface is one row here + a fuzz_<name>.cpp entry +
+#   a corpus/<name>/ seed dir; scripts/verify.mjs discovers targets from fuzz_*.cpp,
+#   so no wiring change is needed beyond this file.
+function(kungfu_add_fuzz _name)
+  set(_entry ${CMAKE_CURRENT_SOURCE_DIR}/fuzz_${_name}.cpp)
+  set(_mod_srcs ${ARGN})
 
   if (KUNGFU_WITH_SANITIZERS)
-    add_executable(fuzz_${t}_sanitize ${_entry} ${CMAKE_CURRENT_SOURCE_DIR}/StandaloneFuzzMain.cpp ${_view_src})
-    target_include_directories(fuzz_${t}_sanitize PRIVATE ${_view_inc})
-    target_link_libraries(fuzz_${t}_sanitize PRIVATE flatbuffers::flatbuffers SQLite::SQLite3)
-    target_compile_options(fuzz_${t}_sanitize PRIVATE ${_san_compile})
+    add_executable(fuzz_${_name}_sanitize ${_entry} ${CMAKE_CURRENT_SOURCE_DIR}/StandaloneFuzzMain.cpp ${_mod_srcs})
+    target_include_directories(fuzz_${_name}_sanitize PRIVATE ${_lk_inc})
+    target_link_libraries(fuzz_${_name}_sanitize PRIVATE flatbuffers::flatbuffers SQLite::SQLite3)
+    target_compile_options(fuzz_${_name}_sanitize PRIVATE ${_san_compile})
     if (_san_link)
-      target_link_options(fuzz_${t}_sanitize PRIVATE ${_san_link})
+      target_link_options(fuzz_${_name}_sanitize PRIVATE ${_san_link})
     endif()
   endif()
 
   if (_have_libfuzzer)
-    add_executable(fuzz_${t} ${_entry} ${_view_src})
-    target_include_directories(fuzz_${t} PRIVATE ${_view_inc})
-    target_link_libraries(fuzz_${t} PRIVATE flatbuffers::flatbuffers SQLite::SQLite3)
-    target_compile_options(fuzz_${t} PRIVATE ${_fuzz_flags})
-    target_link_options(fuzz_${t} PRIVATE ${_fuzz_flags})
+    add_executable(fuzz_${_name} ${_entry} ${_mod_srcs})
+    target_include_directories(fuzz_${_name} PRIVATE ${_lk_inc})
+    target_link_libraries(fuzz_${_name} PRIVATE flatbuffers::flatbuffers SQLite::SQLite3)
+    target_compile_options(fuzz_${_name} PRIVATE ${_fuzz_flags})
+    target_link_options(fuzz_${_name} PRIVATE ${_fuzz_flags})
   endif()
-endforeach()
+endfunction()
+
+# ── Registered fuzz targets ─────────────────────────────────────────
+# kungfu::view — the sole FlatBuffers access module (ADR-0039): the three
+# untrusted-input entries each compile the view TU directly (no runtime).
+kungfu_add_fuzz(compile_schema ${_view_src})
+kungfu_add_fuzz(from_bytes     ${_view_src})
+kungfu_add_fuzz(bind_frame     ${_view_src})
+# Future untrusted-input surfaces plug in with one row, e.g.:
+#   kungfu_add_fuzz(episode_import ${_lk_dir}/src/storage/episode/import.cpp)

--- a/framework/core/slices/view-encapsulation/probe.cpp
+++ b/framework/core/slices/view-encapsulation/probe.cpp
@@ -151,6 +151,21 @@ int main() {
   auto added = view::alter_add_missing(db, full2, "quote_full");
   assert(added.size() == 1 && added[0] == "volume");
 
+  // spatial safety (stale plan): a col_plan referencing a field beyond the schema
+  // it is bound against — e.g. a 6-field plan applied to a 5-field schema — must
+  // bounds-check field_index, never issue an out-of-range fields->Get. bind_frame
+  // skips such a frame (nullopt) instead of an OOB reflection read.
+  {
+    auto big6 = view::schema_handle::from_bytes(make_bfbs(FBS2)).plan_columns(false);
+    assert(big6.size() == 6);                                      // field indices 0..5
+    auto small5 = view::schema_handle::from_bytes(make_bfbs(FBS)); // 5 fields, indices 0..4
+    const std::string sd = make_data(FBS, JSON);
+    sqlite3_stmt *stf = nullptr;
+    assert(sqlite3_prepare_v2(db, "SELECT ?,?,?,?,?,?", -1, &stf, nullptr) == SQLITE_OK);
+    assert(!small5.bind_frame(stf, big6, reinterpret_cast<const uint8_t *>(sd.data()), sd.size()).has_value());
+    sqlite3_finalize(stf);
+  }
+
   sqlite3_close(db);
   std::printf("OK: kungfu::view projection roundtrip (thin+full+evolve+verify) holds; no runtime linked\n");
   return 0;

--- a/framework/core/src/libkungfu/src/view/schema.cpp
+++ b/framework/core/src/libkungfu/src/view/schema.cpp
@@ -117,6 +117,14 @@ std::optional<int> schema_handle::bind_frame(sqlite3_stmt *st, const std::vector
   const flatbuffers::Table *root = flatbuffers::GetAnyRoot(buf);
   int idx = 1;
   for (const auto &c : cols) {
+    // Spatial safety: a col_plan cached against a larger/older schema (e.g. one
+    // planned before an evolve() shrank the field set) can carry a field_index
+    // past the current schema's fields. Bounds-check before fields->Get so the
+    // sole FB access path never issues an unchecked out-of-range reflection read
+    // (ADR-0039). A stale plan can't bind this frame correctly, so skip it whole,
+    // like a failed verify.
+    if (c.field_index >= fields->size())
+      return std::nullopt;
     const reflection::Field *f = fields->Get(c.field_index);
     switch (c.kind) {
     case bind_kind::as_text: {
@@ -140,7 +148,8 @@ bool schema_handle::verify_table(const uint8_t *buf, size_t len) const {
   if (!bfbs_ || buf == nullptr)
     return false;
   const reflection::Schema *s = schema_of(*bfbs_);
-  flatbuffers::Verifier v(buf, len);
+  // reflection Verify constructs its own Verifier over (buf, len); no separate
+  // flatbuffers::Verifier needed here.
   return flatbuffers::Verify(*s, *s->root_table(), buf, len);
 }
 
@@ -185,8 +194,13 @@ std::vector<std::string> alter_add_missing(sqlite3 *db, const std::vector<col_pl
   std::vector<std::string> existing;
   sqlite3_stmt *st = nullptr;
   sqlite3_prepare_v2(db, ("PRAGMA table_info(" + tbl + ")").c_str(), -1, &st, nullptr);
-  while (sqlite3_step(st) == SQLITE_ROW)
-    existing.push_back(reinterpret_cast<const char *>(sqlite3_column_text(st, 1)));
+  while (sqlite3_step(st) == SQLITE_ROW) {
+    // PRAGMA table_info.name is never NULL in practice, but guard the cast so a
+    // NULL text column can never construct std::string(nullptr) (UB).
+    const auto *name = sqlite3_column_text(st, 1);
+    if (name != nullptr)
+      existing.push_back(reinterpret_cast<const char *>(name));
+  }
   sqlite3_finalize(st);
   std::vector<std::string> added;
   for (const auto &c : cols) {

--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -794,7 +794,17 @@ function main() {
     const core = path.join(ROOT, 'framework', 'core');
     const fuzzSrc = path.join(core, 'fuzz');
     const prefix = conanPrefix(core);
-    const targets = ['compile_schema', 'from_bytes', 'bind_frame'];
+    // Discover fuzz targets from fuzz_<name>.cpp so a new untrusted-input surface
+    // (registered via kungfu_add_fuzz in fuzz/CMakeLists.txt + a corpus/<name>/)
+    // is picked up here with no edit. StandaloneFuzzMain.cpp is not a fuzz_*.cpp.
+    const targets = fs.existsSync(fuzzSrc)
+      ? fs
+          .readdirSync(fuzzSrc)
+          .map((f) => /^fuzz_(.+)\.cpp$/.exec(f))
+          .filter((m) => m)
+          .map((m) => m[1])
+          .sort()
+      : [];
     /** @param {import('child_process').SpawnSyncReturns<string>} r */
     const tail3 = (r) =>
       `${r.stdout || ''}${r.stderr || ''}`


### PR DESCRIPTION
Unsafe-region audit of the sole FlatBuffers access module (kungfu::view, ADR-0039 parent closeout) found a spatial-safety-by-discipline residue plus two minor items, and generalizes the fuzz harness for future untrusted-input surfaces.

- bind_frame now bounds-checks the col_plan field_index before fields->Get, so a stale plan (e.g. one cached against a larger schema, then bound against a smaller one after evolve()) skips the frame instead of an out-of-range reflection read. Regression-tested in the view-encapsulation probe (teeth-checked against the unpatched module).
- verify_table drops an unused Verifier; alter_add_missing null-guards sqlite3_column_text.
- fuzz/CMakeLists.txt exposes kungfu_add_fuzz(name, sources) and verify.mjs discovers targets from fuzz_<name>.cpp, so a new fuzz surface (e.g. episode import) is one CMake row + an entry cpp + a corpus dir.

Validated mac arm64: both fuzz tiers build via the generalized harness; view fuzz clean; probe passes under ASan+UBSan.