### PR TITLE
feat(episode): add qualification harness

### DIFF
--- a/docs/episode-atomicity-qualification.md
+++ b/docs/episode-atomicity-qualification.md
@@ -255,7 +255,10 @@ run remains a manual qualification until measured duration and memory usage make
 it suitable for a recurring gate. At each checkpoint the harness records:
 
 - open and terminal-append throughput plus p50/p95/p99 latency;
-- `episode_list(limit=100)` latency and total count;
+- `episode_list(limit=100)` latency, plus an explicit unbounded-list count for
+  the current v1 API whose bounded result does not carry a separate total;
+- semantic Episode record totals derived from the listed per-Episode views,
+  while journal page/control frames remain a separate physical observation;
 - inspect latency and exact readback for the first, middle, last, and
   seed-selected Episodes;
 - Episode-scoped and full fsck latency and verdict;

--- a/docs/episode-atomicity-qualification.md
+++ b/docs/episode-atomicity-qualification.md
@@ -184,6 +184,172 @@ Episode bodies may be compact in metadata-scale runs. Separate payload-volume
 profiles must exercise realistic bytes, dedup, cold material, and I/O pressure so
 metadata throughput is not misreported as full-ledger throughput.
 
+## Executable v0 slice
+
+The first harness intentionally implements only the two independent axes needed
+to establish an MVP baseline. It does not attempt the full fault matrix or claim
+fleet-scale capacity.
+
+```text
+accumulation: one writer, increasing retained Episode population
+contention:   fixed total work, 1 / 2 / 5 / 10 physical workers
+```
+
+Keeping these axes separate makes a regression attributable. The accumulation
+run does not increase concurrency, and the contention run does not increase the
+total Episode population as worker count rises.
+
+### Repository layout and entrypoint
+
+The v0 implementation lives under the existing core test tree:
+
+```text
+framework/core/tests/qualification/episode/
+  README.md
+  run.mjs
+  episode_workload.py
+  profiles/
+    mvp-smoke-v1.json
+    mvp-baseline-v1.json
+  schemas/
+    trust-report-v1.schema.json
+```
+
+`run.mjs` is the cross-platform entrypoint and process/report coordinator.
+`episode_workload.py` drives the shipped Python facade backed by the real C++
+Episode implementation; it is not a second manifest parser or Episode engine.
+All load uses `kungfu.storage.service` operations. The harness never creates or
+edits journal bytes directly.
+
+The repository command is:
+
+```sh
+./kungfu-code episode:qualify -- --profile mvp-smoke-v1
+./kungfu-code episode:qualify -- --profile mvp-baseline-v1
+```
+
+Generated runtime homes and reports default to an operating-system temporary
+directory and are not checked in. `--report <path>` selects a Trust Report
+destination, and `--keep-runtime` retains the generated runtime home for
+diagnosis. CI may upload the report as an evidence artifact.
+
+### Deterministic metadata workload
+
+The first population profile is explicitly `metadata-only`. Every generated
+Episode is independent and terminal:
+
+```text
+EpisodeOpen -> EpisodeClosed(Ended|Aborted)
+```
+
+Episode ids and bounded title/actor/source content are derived from the profile,
+mode, seed, worker id, and sequence number. They never depend on wall-clock time.
+The expected record count and every sampled Episode are therefore reproducible.
+The initial profile attaches no event frames, payloads, schemas, or dependency
+edges; later payload/DAG profiles must not reuse its throughput as full-ledger
+evidence.
+
+The accumulation mode accepts a parameterized Episode count and records
+checkpoints. The initial checkpoints are `10^3`, `10^4`, and `10^5`; a `10^6`
+run remains a manual qualification until measured duration and memory usage make
+it suitable for a recurring gate. At each checkpoint the harness records:
+
+- open and terminal-append throughput plus p50/p95/p99 latency;
+- `episode_list(limit=100)` latency and total count;
+- inspect latency and exact readback for the first, middle, last, and
+  seed-selected Episodes;
+- Episode-scoped and full fsck latency and verdict;
+- clean recovery (`episode_recover` must recover zero Episodes after a clean
+  run);
+- a fresh-process list/inspect/fsck probe after the writer process exits;
+- runtime bytes, journal file count, RSS high-water mark, and file-descriptor
+  observations where the platform exposes them.
+
+The current implementation folds the whole manifest for list, inspect, and
+fsck. The v0 curve is expected to expose that cost. It must report the curve
+honestly rather than hiding it behind a smaller sampled data set.
+
+### Bounded writer contention
+
+The contention mode runs `1`, `2`, `5`, and `10` worker processes against one
+data root while keeping the total number of Episodes fixed. Every worker writes
+a disjoint deterministic Episode-id range through the same public Episode
+surface.
+
+The current manifest contract is acquire-or-fail. A competing operation may
+return `manifest_writer_busy`; this is an expected explicit contention result,
+not a successful append and not manifest corruption. The v0 client applies a
+bounded exponential backoff with seed-derived jitter only to that exact error.
+The profile records the initial delay, cap, retry limit, and progress deadline.
+Every other exception is immediately unexpected.
+
+The Trust Report separates at least:
+
+```text
+successful_appends
+manifest_writer_busy
+retry_count
+retry_exhausted
+unexpected_errors
+longest_no_progress_interval
+```
+
+A passing contention run requires every expected Episode to reach exactly one
+terminal state, zero exhausted retries, zero unexpected errors, no deadlock or
+progress timeout, clean full fsck, and identical fresh-process readback. The
+bounded claim is that the declared single-node profile preserved Episode
+authority under ten-worker contention and completed under the recorded retry
+policy. It is not evidence for ten thousand workers or a distributed service.
+
+### Versioned initial profiles
+
+`mvp-smoke-v1` is the Episode/manifest PR gate:
+
+```text
+seed: fixed and recorded
+accumulation: 1,000 Episodes
+contention: 1 / 2 / 5 / 10 workers, 1,000 total Episodes per run
+payload profile: metadata-only
+```
+
+`mvp-baseline-v1` is the MVP-candidate/manual baseline:
+
+```text
+seeds: at least three fixed and recorded seeds
+accumulation checkpoints: 1,000 / 10,000 / 100,000 Episodes
+contention: 1 / 2 / 5 / 10 workers, 10,000 total Episodes per run
+payload profile: metadata-only
+```
+
+The baseline may be split into separate invocations when runtime is long, but
+each report must retain the exact profile, seed, source revision, and completed
+scenario list.
+
+### v0 correctness and progress gates
+
+The following conditions fail the profile regardless of throughput:
+
+- expected, listed, folded, inspected, or fsck Episode counts disagree;
+- an Episode has a missing/duplicate open or terminal record, an unexpected
+  status, or mismatched deterministic metadata;
+- full fsck fails or emits a warning not declared by the profile;
+- recovery finds an open Episode after a clean workload;
+- fresh-process readback differs from the writer-process result;
+- a worker crashes, deadlocks, exhausts retries, exceeds the no-progress
+  deadline, or reports an exception other than the declared busy result;
+- the emitted Trust Report does not validate against its versioned schema.
+
+The first baseline records performance observations without inventing an
+absolute throughput or latency SLO. OOM, timeout, or loss of forward progress is
+an availability failure. After repeatable baselines exist, numerical SLOs may be
+added to a new profile version without changing ADR-0042.
+
+The v0 report sets the Episode query profile to
+`episode-manifest-direct`. The current Episode query path reads the manifest
+fold directly; source-registry SQLite rebuild is not an Episode projection
+rebuild and must not be reported as one. Until an Episode projection exists,
+projection-rebuild coverage remains an explicit gap.
+
 ## Metrics
 
 ### Correctness gates

--- a/docs/episode-atomicity-qualification.md
+++ b/docs/episode-atomicity-qualification.md
@@ -481,6 +481,56 @@ best throughput number.
 6. Emit Trust Report v1 and run the first single-node baseline without treating
    its numbers as a support promise.
 
+## First development baseline (2026-07-10)
+
+The first v0 run exercised source revision
+`b6961891731bf55da589fae9377b5af6039b3232` on `darwin/arm64`, Node
+`v22.22.3`, 20 logical CPUs, and 128 GiB RAM. All three reports validated as
+`kungfu.episode.trust-report/v1` and were generated from a clean source tree.
+This is development evidence, not an adopted SLO or supported-capacity promise.
+
+The complete `mvp-smoke-v1` run passed all five scenarios in 8.4 seconds:
+1,000-Episode accumulation plus 1/2/5/10-worker contention at 1,000 Episodes
+per worker-count scenario. The ten-worker scenario observed 1,013 explicit
+`manifest_writer_busy` results, exhausted none, and finished with zero count,
+readback, fsck, recovery, unexpected-error, or progress-timeout violations.
+
+One seed (`42042`) then exercised the accumulation envelope:
+
+| Retained Episodes | Added-batch ingest | Full list | Full fsck | Inspect p95 | Probe RSS |
+| ---: | ---: | ---: | ---: | ---: | ---: |
+| 1,000 | 1,670 Episodes/s | 40 ms | 9 ms | 1.1 ms | 54 MB |
+| 10,000 | 937 Episodes/s | 444 ms | 82 ms | 11.0 ms | 115 MB |
+| 100,000 | 316 Episodes/s | 4.20 s | 804 ms | 87.5 ms | 698 MB |
+
+At 100,000 Episodes, all 100,000 objects and 200,000 semantic Episode records
+matched exactly after fresh-process readback. The physical manifest contained
+200,002 frames across three journal pages; the additional two frames were page
+control records and are reported separately rather than misclassified as
+Episode corruption. Clean recovery found zero interrupted Episodes.
+
+The profile also ran 10,000 Episodes at each declared worker count:
+
+| Workers | Aggregate ingest | Busy/retry results | Exhausted | Correctness violations |
+| ---: | ---: | ---: | ---: | ---: |
+| 1 | 1,230 Episodes/s | 0 | 0 | 0 |
+| 2 | 1,205 Episodes/s | 1,091 | 0 | 0 |
+| 5 | 1,143 Episodes/s | 4,343 | 0 | 0 |
+| 10 | 1,169 Episodes/s | 8,252 | 0 | 0 |
+
+The bounded conclusion is two-sided:
+
+- the current single-node manifest path preserved Episode authority and made
+  forward progress under ten physical writers with the declared retry policy;
+- writer throughput did not scale with worker count, and retained-population
+  cost is visible in both append and whole-manifest read paths. A long-lived
+  writer/request queue plus bounded/indexed Episode reads are implementation
+  priorities before adopting a materially larger support envelope.
+
+Only one of the baseline profile's three declared seeds was run for the 100k and
+10k-contention tables. Repeating all seeds, payload-volume profiles, dependency
+DAGs, faults, and soak remains required before a broader qualification claim.
+
 ## Open questions
 
 - What is the smallest stable capability vocabulary for v1?

--- a/framework/core/tests/qualification/episode/README.md
+++ b/framework/core/tests/qualification/episode/README.md
@@ -1,0 +1,57 @@
+# Episode Qualification Harness
+
+This directory implements the executable v0 slice of
+[`docs/episode-atomicity-qualification.md`](../../../../../docs/episode-atomicity-qualification.md).
+It exercises the shipped Python facade backed by the C++ Episode manifest
+implementation; it does not parse or mutate journal bytes itself.
+
+Build the core first so `framework/core/dist/kungfu` contains the native binding,
+then run:
+
+```sh
+./kungfu-code episode:qualify -- --profile mvp-smoke-v1
+./kungfu-code episode:qualify -- --profile mvp-baseline-v1
+```
+
+Useful scoped runs:
+
+```sh
+./kungfu-code episode:qualify -- \
+  --profile mvp-smoke-v1 \
+  --mode accumulation \
+  --accumulation-checkpoints 1000,10000 \
+  --seed 42042
+
+./kungfu-code episode:qualify -- \
+  --profile mvp-smoke-v1 \
+  --mode contention \
+  --contention-episodes 2000 \
+  --workers 1,2,5,10 \
+  --report /tmp/episode-trust-report.json
+```
+
+The default report path is a retained temporary directory printed at the end of
+the run. Runtime homes are removed after their fresh-process probes unless
+`--keep-runtime` is supplied.
+
+## Result boundary
+
+The v0 profiles are metadata-only: each independent Episode contains exactly
+one open and one terminal record. They qualify manifest population, fold/fsck
+readback, writer contention, retry progress, and cold-process stability. They
+do not qualify realistic payload bytes, dependency DAGs, projection rebuild,
+distributed writers, or fleet-scale capacity. Those gaps remain explicit in
+every Trust Report.
+
+`manifest_writer_busy` is the only retryable error. The worker records every
+busy result and applies the profile's bounded backoff. An exhausted retry,
+unexpected exception, count mismatch, fsck failure, recovery of an unexpected
+open Episode, or fresh-process mismatch fails the scenario.
+
+## Files
+
+- `run.mjs` owns profiles, worker processes, timeouts, aggregation, and reports.
+- `episode_workload.py` performs writes and readback through
+  `kungfu.storage.service`.
+- `profiles/*.json` are versioned workload and progress policies.
+- `schemas/trust-report-v1.schema.json` validates every emitted report.

--- a/framework/core/tests/qualification/episode/episode_workload.py
+++ b/framework/core/tests/qualification/episode/episode_workload.py
@@ -1,0 +1,639 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Real-surface worker for the Episode qualification harness.
+
+The Node coordinator owns profiles, processes, timeouts, and the final Trust
+Report. This module owns only two product-facing actions:
+
+* write a deterministic range of metadata-only Episodes;
+* probe a completed runtime through list/inspect/fsck/recovery.
+
+All Episode work goes through ``kungfu.storage.service``. Journal bytes are
+never parsed or mutated here.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import os
+from pathlib import Path
+import random
+import sys
+import time
+from typing import Any, Callable
+
+
+CORE_DIR = Path(__file__).resolve().parents[3]
+
+
+def _load_service() -> Any:
+    sys.path.insert(0, str(CORE_DIR / "src" / "python"))
+    sys.path.insert(0, str(CORE_DIR / "dist" / "kungfu"))
+    from kungfu.storage import service
+
+    return service
+
+
+def _write_json(path: str | Path, value: dict[str, Any]) -> None:
+    target = Path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    temporary = target.with_suffix(target.suffix + ".tmp")
+    temporary.write_text(
+        json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    os.replace(temporary, target)
+
+
+def _quantile(sorted_values: list[float], q: float) -> float:
+    if not sorted_values:
+        return 0.0
+    index = max(0, math.ceil(q * len(sorted_values)) - 1)
+    return sorted_values[index]
+
+
+def _distribution(values: list[float]) -> dict[str, float | int]:
+    ordered = sorted(values)
+    return {
+        "count": len(ordered),
+        "min": ordered[0] if ordered else 0.0,
+        "mean": sum(ordered) / len(ordered) if ordered else 0.0,
+        "p50": _quantile(ordered, 0.50),
+        "p95": _quantile(ordered, 0.95),
+        "p99": _quantile(ordered, 0.99),
+        "max": ordered[-1] if ordered else 0.0,
+    }
+
+
+def _process_resources() -> tuple[int, int | None]:
+    try:
+        import psutil
+
+        process = psutil.Process()
+        rss = int(process.memory_info().rss)
+        if hasattr(process, "num_fds"):
+            descriptors = int(process.num_fds())
+        elif hasattr(process, "num_handles"):
+            descriptors = int(process.num_handles())
+        else:
+            descriptors = None
+        return rss, descriptors
+    except Exception:
+        return 0, None
+
+
+def _disk_observation(runtime_dir: Path) -> dict[str, int]:
+    total_bytes = 0
+    file_count = 0
+    journal_files = 0
+    for path in runtime_dir.rglob("*") if runtime_dir.exists() else []:
+        if not path.is_file():
+            continue
+        file_count += 1
+        try:
+            total_bytes += path.stat().st_size
+        except OSError:
+            continue
+        if path.suffix == ".journal":
+            journal_files += 1
+    return {
+        "runtime_bytes": total_bytes,
+        "runtime_files": file_count,
+        "journal_files": journal_files,
+    }
+
+
+def _episode_id(seed: int, index: int) -> int:
+    # Keep the generated id non-zero, stable, and comfortably inside uint64.
+    return ((seed & 0x7FFFFFFF) << 32) | (index + 1)
+
+
+def _episode_expected(
+    *,
+    seed: int,
+    index: int,
+    mode: str,
+    logical_agents: int,
+    abort_every: int,
+) -> dict[str, Any]:
+    ordinal = index + 1
+    aborted = abort_every > 0 and ordinal % abort_every == 0
+    token = hashlib.blake2b(f"{seed}:{index}".encode(), digest_size=8).hexdigest()
+    return {
+        "episode_id": _episode_id(seed, index),
+        "title": f"qualification-{token}",
+        "actor": f"agent-{index % logical_agents}",
+        "source": f"qualification/{mode}/v1",
+        "status": "aborted" if aborted else "ended",
+        "begin_time": 1_000_000_000_000 + (seed % 1_000_000) * 1_000_000 + index * 2,
+        "end_time": 1_000_000_000_001 + (seed % 1_000_000) * 1_000_000 + index * 2,
+    }
+
+
+class WriteState:
+    def __init__(self, args: argparse.Namespace) -> None:
+        self.args = args
+        self.rng = random.Random(args.seed ^ (args.worker_id << 16))
+        self.successful_appends = 0
+        self.busy = 0
+        self.retry_count = 0
+        self.retry_exhausted = 0
+        self.unexpected_errors: list[dict[str, Any]] = []
+        self.progress_timeouts = 0
+        self.open_latency_ms: list[float] = []
+        self.close_latency_ms: list[float] = []
+        self.last_progress = time.perf_counter()
+        self.longest_no_progress_ms = 0.0
+        self.max_rss_bytes = 0
+        self.max_descriptors: int | None = None
+
+    def sample_resources(self) -> None:
+        rss, descriptors = _process_resources()
+        self.max_rss_bytes = max(self.max_rss_bytes, rss)
+        if descriptors is not None:
+            self.max_descriptors = max(self.max_descriptors or 0, descriptors)
+
+    def mark_progress(self) -> None:
+        now = time.perf_counter()
+        self.longest_no_progress_ms = max(
+            self.longest_no_progress_ms, (now - self.last_progress) * 1000
+        )
+        self.last_progress = now
+        self.successful_appends += 1
+
+    def call(
+        self,
+        *,
+        operation: str,
+        episode_id: int,
+        invoke: Callable[[], Any],
+        latencies: list[float],
+    ) -> bool:
+        attempt = 0
+        while True:
+            started = time.perf_counter()
+            try:
+                invoke()
+                latencies.append((time.perf_counter() - started) * 1000)
+                self.mark_progress()
+                return True
+            except RuntimeError as error:
+                message = str(error)
+                if "manifest_writer_busy" not in message:
+                    self.unexpected_errors.append(
+                        {
+                            "operation": operation,
+                            "episode_id": episode_id,
+                            "error": message[:500],
+                        }
+                    )
+                    return False
+                self.busy += 1
+                if attempt >= self.args.max_attempts:
+                    self.retry_exhausted += 1
+                    return False
+                no_progress_ms = (time.perf_counter() - self.last_progress) * 1000
+                if no_progress_ms > self.args.progress_timeout_ms:
+                    self.progress_timeouts += 1
+                    return False
+                self.retry_count += 1
+                exponent = min(attempt, 20)
+                delay_ms = min(
+                    self.args.max_delay_ms,
+                    self.args.initial_delay_ms * (2**exponent),
+                )
+                jittered_ms = delay_ms * (0.5 + self.rng.random())
+                time.sleep(jittered_ms / 1000)
+                attempt += 1
+            except Exception as error:
+                self.unexpected_errors.append(
+                    {
+                        "operation": operation,
+                        "episode_id": episode_id,
+                        "error": f"{type(error).__name__}: {error}"[:500],
+                    }
+                )
+                return False
+
+
+def _wait_for_start(start_at_ms: int) -> None:
+    while True:
+        remaining = start_at_ms / 1000 - time.time()
+        if remaining <= 0:
+            return
+        time.sleep(min(remaining, 0.01))
+
+
+def run_write(args: argparse.Namespace) -> dict[str, Any]:
+    service = _load_service()
+    state = WriteState(args)
+    runtime_dir = Path(args.runtime_dir)
+    runtime_dir.mkdir(parents=True, exist_ok=True)
+    if args.start_at_ms:
+        _wait_for_start(args.start_at_ms)
+
+    started = time.perf_counter()
+    completed = 0
+    state.sample_resources()
+    for offset in range(args.count):
+        index = args.start_index + offset
+        expected = _episode_expected(
+            seed=args.seed,
+            index=index,
+            mode=args.mode,
+            logical_agents=args.logical_agents,
+            abort_every=args.abort_every,
+        )
+        episode_id = int(expected["episode_id"])
+        location_uid = args.worker_id + 1
+        opened = state.call(
+            operation="episode_begin",
+            episode_id=episode_id,
+            latencies=state.open_latency_ms,
+            invoke=lambda expected=expected, location_uid=location_uid: (
+                service.episode_begin(
+                    runtime_dir,
+                    episode_id=int(expected["episode_id"]),
+                    title=str(expected["title"]),
+                    actor=str(expected["actor"]),
+                    source=str(expected["source"]),
+                    location_uid=location_uid,
+                    begin_time=int(expected["begin_time"]),
+                )
+            ),
+        )
+        if not opened:
+            break
+        close = (
+            service.episode_abort
+            if expected["status"] == "aborted"
+            else service.episode_end
+        )
+        closed = state.call(
+            operation="episode_close",
+            episode_id=episode_id,
+            latencies=state.close_latency_ms,
+            invoke=lambda close=close, expected=expected, location_uid=location_uid: (
+                close(
+                    runtime_dir,
+                    episode_id=int(expected["episode_id"]),
+                    location_uid=location_uid,
+                    end_time=int(expected["end_time"]),
+                    last_frame_uid=0,
+                    frame_count=0,
+                    reason="qualification-abort"
+                    if expected["status"] == "aborted"
+                    else "",
+                )
+            ),
+        )
+        if not closed:
+            break
+        completed += 1
+        if completed % 64 == 0:
+            state.sample_resources()
+
+    state.sample_resources()
+    duration = time.perf_counter() - started
+    ok = (
+        completed == args.count
+        and state.retry_exhausted == 0
+        and state.progress_timeouts == 0
+        and not state.unexpected_errors
+    )
+    return {
+        "ok": ok,
+        "kind": "writer",
+        "mode": args.mode,
+        "worker_id": args.worker_id,
+        "logical_agents": args.logical_agents,
+        "start_index": args.start_index,
+        "episodes_requested": args.count,
+        "episodes_completed": completed,
+        "duration_seconds": duration,
+        "throughput_episodes_per_second": completed / duration if duration else 0.0,
+        "operations": {
+            "successful_appends": state.successful_appends,
+            "manifest_writer_busy": state.busy,
+            "retry_count": state.retry_count,
+            "retry_exhausted": state.retry_exhausted,
+            "unexpected_errors": len(state.unexpected_errors),
+            "progress_timeouts": state.progress_timeouts,
+            "longest_no_progress_interval_ms": state.longest_no_progress_ms,
+        },
+        "latency_ms": {
+            "episode_open": _distribution(state.open_latency_ms),
+            "episode_close": _distribution(state.close_latency_ms),
+        },
+        "resources": {
+            "max_rss_bytes": state.max_rss_bytes,
+            "max_descriptors": state.max_descriptors,
+        },
+        "errors": state.unexpected_errors,
+    }
+
+
+def _timed(invoke: Callable[[], Any]) -> tuple[Any, float]:
+    started = time.perf_counter()
+    value = invoke()
+    return value, (time.perf_counter() - started) * 1000
+
+
+def _sample_indices(seed: int, count: int, requested: int) -> list[int]:
+    if count <= 0:
+        return []
+    selected = {0, count // 2, count - 1}
+    rng = random.Random(seed ^ count)
+    while len(selected) < min(requested, count):
+        selected.add(rng.randrange(count))
+    return sorted(selected)
+
+
+def _issue(code: str, **detail: Any) -> dict[str, Any]:
+    return {"code": code, **detail}
+
+
+def run_probe(args: argparse.Namespace) -> dict[str, Any]:
+    service = _load_service()
+    runtime_dir = Path(args.runtime_dir)
+    errors: list[dict[str, Any]] = []
+    sample_indices = _sample_indices(args.seed, args.expected_count, args.sample_count)
+
+    page, list_page_ms = _timed(
+        lambda: service.episode_list(runtime_dir, limit=args.list_limit)
+    )
+    expected_page_count = min(args.list_limit, args.expected_count)
+    if int(page.get("episode_count", -1)) != expected_page_count:
+        errors.append(
+            _issue(
+                "list_page_count_mismatch",
+                expected=expected_page_count,
+                actual=page.get("episode_count"),
+            )
+        )
+
+    all_episodes, list_all_ms = _timed(
+        lambda: service.episode_list(runtime_dir, limit=0)
+    )
+    actual_count = int(all_episodes.get("episode_count", -1))
+    if actual_count != args.expected_count:
+        errors.append(
+            _issue(
+                "episode_count_mismatch",
+                expected=args.expected_count,
+                actual=actual_count,
+            )
+        )
+    semantic_record_count = sum(
+        int(row.get("record_count", 0)) for row in all_episodes.get("episodes", [])
+    )
+    expected_records = args.expected_count * 2
+    if semantic_record_count != expected_records:
+        errors.append(
+            _issue(
+                "episode_semantic_record_count_mismatch",
+                expected=expected_records,
+                actual=semantic_record_count,
+            )
+        )
+    del all_episodes
+
+    inspect_latency: list[float] = []
+    episode_fsck_latency: list[float] = []
+    readback_count = 0
+    for index in sample_indices:
+        expected = _episode_expected(
+            seed=args.seed,
+            index=index,
+            mode=args.mode,
+            logical_agents=args.logical_agents,
+            abort_every=args.abort_every,
+        )
+        inspected, latency = _timed(
+            lambda expected=expected: service.episode_inspect(
+                runtime_dir, episode_id=int(expected["episode_id"])
+            )
+        )
+        inspect_latency.append(latency)
+        episode = inspected.get("episode", {})
+        expected_subset = {
+            "episode_id": expected["episode_id"],
+            "title": expected["title"],
+            "actor": expected["actor"],
+            "source": expected["source"],
+            "status": expected["status"],
+            "opened": True,
+            "closed": True,
+            "record_count": 2,
+            "frame_count": 0,
+            "ref_count": 0,
+        }
+        mismatched = {
+            key: {"expected": value, "actual": episode.get(key)}
+            for key, value in expected_subset.items()
+            if episode.get(key) != value
+        }
+        record_kinds = [row.get("record_kind") for row in inspected.get("records", [])]
+        if record_kinds != ["episode_open", "episode_closed"]:
+            mismatched["record_kinds"] = {
+                "expected": ["episode_open", "episode_closed"],
+                "actual": record_kinds,
+            }
+        if mismatched:
+            errors.append(
+                _issue(
+                    "episode_readback_mismatch",
+                    episode_id=expected["episode_id"],
+                    mismatched=mismatched,
+                )
+            )
+        else:
+            readback_count += 1
+
+        episode_fsck, latency = _timed(
+            lambda expected=expected: service.fsck(
+                runtime_dir, episode_id=int(expected["episode_id"])
+            )
+        )
+        episode_fsck_latency.append(latency)
+        if not episode_fsck.get("ok") or episode_fsck.get("warnings"):
+            errors.append(
+                _issue(
+                    "episode_fsck_failed",
+                    episode_id=expected["episode_id"],
+                    status=episode_fsck.get("status"),
+                    errors=episode_fsck.get("errors", []),
+                    warnings=episode_fsck.get("warnings", []),
+                )
+            )
+
+    full_fsck, full_fsck_ms = _timed(lambda: service.fsck(runtime_dir))
+    checked = full_fsck.get("checked", {})
+    if int(checked.get("episodes", -1)) != args.expected_count:
+        errors.append(
+            _issue(
+                "fsck_episode_count_mismatch",
+                expected=args.expected_count,
+                actual=checked.get("episodes"),
+            )
+        )
+    manifest_frame_count = int(checked.get("episode_manifest_records", -1))
+    if manifest_frame_count < expected_records:
+        errors.append(
+            _issue(
+                "fsck_manifest_frame_count_too_small",
+                minimum=expected_records,
+                actual=manifest_frame_count,
+            )
+        )
+    warning_codes = sorted(
+        str(row.get("code")) for row in full_fsck.get("warnings", [])
+    )
+    unexpected_warnings = sorted(set(warning_codes) - set(args.allowed_warning))
+    if not full_fsck.get("ok") or unexpected_warnings:
+        errors.append(
+            _issue(
+                "full_fsck_failed",
+                status=full_fsck.get("status"),
+                errors=full_fsck.get("errors", []),
+                unexpected_warnings=unexpected_warnings,
+            )
+        )
+
+    recovery, recovery_ms = _timed(lambda: service.episode_recover(runtime_dir))
+    if int(recovery.get("recovered_count", -1)) != 0:
+        errors.append(
+            _issue(
+                "unexpected_recovery",
+                expected=0,
+                actual=recovery.get("recovered_count"),
+                recovered=recovery.get("recovered", []),
+            )
+        )
+
+    rss, descriptors = _process_resources()
+    return {
+        "ok": not errors,
+        "kind": "probe",
+        "mode": args.mode,
+        "expected_episodes": args.expected_count,
+        "listed_episodes": actual_count,
+        "expected_semantic_records": expected_records,
+        "listed_semantic_records": semantic_record_count,
+        "observed_manifest_frames": manifest_frame_count,
+        "manifest_control_frames": max(0, manifest_frame_count - semantic_record_count),
+        "sample_indices": sample_indices,
+        "sampled_readback_ok": readback_count,
+        "metrics": {
+            "list_page_ms": list_page_ms,
+            "list_all_ms": list_all_ms,
+            "inspect_ms": _distribution(inspect_latency),
+            "episode_fsck_ms": _distribution(episode_fsck_latency),
+            "full_fsck_ms": full_fsck_ms,
+            "clean_recovery_ms": recovery_ms,
+        },
+        "fsck": {
+            "ok": bool(full_fsck.get("ok")),
+            "status": full_fsck.get("status"),
+            "checked": checked,
+            "warning_codes": warning_codes,
+        },
+        "recovery": {
+            "recovered_count": recovery.get("recovered_count"),
+            "skipped_count": recovery.get("skipped_count"),
+        },
+        "resources": {
+            **_disk_observation(runtime_dir),
+            "probe_rss_bytes": rss,
+            "probe_descriptors": descriptors,
+        },
+        "errors": errors,
+    }
+
+
+def validate_report(args: argparse.Namespace) -> dict[str, Any]:
+    import jsonschema
+
+    report = json.loads(Path(args.report).read_text(encoding="utf-8"))
+    schema = json.loads(Path(args.schema).read_text(encoding="utf-8"))
+    jsonschema.validate(report, schema)
+    return {"ok": True, "schema": report.get("schema"), "report": args.report}
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    write = subparsers.add_parser("write", help="write one deterministic Episode range")
+    write.add_argument("--result", required=True)
+    write.add_argument("--runtime-dir", required=True)
+    write.add_argument("--mode", choices=("accumulation", "contention"), required=True)
+    write.add_argument("--seed", type=int, required=True)
+    write.add_argument("--start-index", type=int, required=True)
+    write.add_argument("--count", type=int, required=True)
+    write.add_argument("--logical-agents", type=int, required=True)
+    write.add_argument("--worker-id", type=int, required=True)
+    write.add_argument("--abort-every", type=int, default=0)
+    write.add_argument("--initial-delay-ms", type=float, required=True)
+    write.add_argument("--max-delay-ms", type=float, required=True)
+    write.add_argument("--max-attempts", type=int, required=True)
+    write.add_argument("--progress-timeout-ms", type=float, required=True)
+    write.add_argument("--start-at-ms", type=int, default=0)
+
+    probe = subparsers.add_parser("probe", help="fresh-process readback and fsck")
+    probe.add_argument("--result", required=True)
+    probe.add_argument("--runtime-dir", required=True)
+    probe.add_argument("--mode", choices=("accumulation", "contention"), required=True)
+    probe.add_argument("--seed", type=int, required=True)
+    probe.add_argument("--expected-count", type=int, required=True)
+    probe.add_argument("--logical-agents", type=int, required=True)
+    probe.add_argument("--abort-every", type=int, default=0)
+    probe.add_argument("--sample-count", type=int, required=True)
+    probe.add_argument("--list-limit", type=int, required=True)
+    probe.add_argument("--allowed-warning", action="append", default=[])
+
+    validate = subparsers.add_parser(
+        "validate-report", help="validate Trust Report JSON"
+    )
+    validate.add_argument("--report", required=True)
+    validate.add_argument("--schema", required=True)
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    try:
+        if args.command == "write":
+            result = run_write(args)
+            _write_json(args.result, result)
+            return 0 if result["ok"] else 1
+        if args.command == "probe":
+            result = run_probe(args)
+            _write_json(args.result, result)
+            return 0 if result["ok"] else 1
+        result = validate_report(args)
+        print(json.dumps(result, sort_keys=True))
+        return 0
+    except Exception as error:
+        failure = {
+            "ok": False,
+            "kind": args.command,
+            "errors": [
+                {
+                    "code": "worker_exception",
+                    "error": f"{type(error).__name__}: {error}"[:1000],
+                }
+            ],
+        }
+        result_path = getattr(args, "result", "")
+        if result_path:
+            _write_json(result_path, failure)
+        else:
+            print(json.dumps(failure, sort_keys=True), file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/framework/core/tests/qualification/episode/profiles/mvp-baseline-v1.json
+++ b/framework/core/tests/qualification/episode/profiles/mvp-baseline-v1.json
@@ -1,0 +1,29 @@
+{
+  "schema": "kungfu.episode.qualification-profile/v1",
+  "name": "mvp-baseline-v1",
+  "description": "Manual MVP-candidate metadata baseline; observations are not a fleet capacity promise.",
+  "seeds": [42042, 73129, 99017],
+  "payload_profile": "metadata-only",
+  "query_profile": "episode-manifest-direct",
+  "accumulation": {
+    "checkpoints": [1000, 10000, 100000],
+    "abort_every": 20
+  },
+  "contention": {
+    "workers": [1, 2, 5, 10],
+    "total_episodes": 10000,
+    "abort_every": 20
+  },
+  "retry": {
+    "initial_delay_ms": 0.25,
+    "max_delay_ms": 25,
+    "max_attempts": 2000,
+    "progress_timeout_ms": 60000
+  },
+  "validation": {
+    "sample_count": 7,
+    "list_limit": 100,
+    "allowed_full_fsck_warnings": ["sqlite_projection_missing"]
+  },
+  "scenario_timeout_seconds": 3600
+}

--- a/framework/core/tests/qualification/episode/profiles/mvp-smoke-v1.json
+++ b/framework/core/tests/qualification/episode/profiles/mvp-smoke-v1.json
@@ -1,0 +1,29 @@
+{
+  "schema": "kungfu.episode.qualification-profile/v1",
+  "name": "mvp-smoke-v1",
+  "description": "Fast metadata-only Episode accumulation and bounded writer-contention gate.",
+  "seeds": [42042],
+  "payload_profile": "metadata-only",
+  "query_profile": "episode-manifest-direct",
+  "accumulation": {
+    "checkpoints": [1000],
+    "abort_every": 20
+  },
+  "contention": {
+    "workers": [1, 2, 5, 10],
+    "total_episodes": 1000,
+    "abort_every": 20
+  },
+  "retry": {
+    "initial_delay_ms": 0.25,
+    "max_delay_ms": 20,
+    "max_attempts": 1000,
+    "progress_timeout_ms": 30000
+  },
+  "validation": {
+    "sample_count": 5,
+    "list_limit": 100,
+    "allowed_full_fsck_warnings": ["sqlite_projection_missing"]
+  },
+  "scenario_timeout_seconds": 180
+}

--- a/framework/core/tests/qualification/episode/run.mjs
+++ b/framework/core/tests/qualification/episode/run.mjs
@@ -1,0 +1,785 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Cross-platform coordinator for the Episode Qualification Harness v0.
+// Profiles, process isolation, timeouts, aggregation, and the Trust Report live
+// here. Python workers call the real C++-backed Episode surface and write one
+// private result file each; workers never contend on the report itself.
+// @ts-check
+
+import { spawn, spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const harnessDir = path.dirname(__filename);
+const coreDir = path.resolve(harnessDir, '..', '..', '..');
+const rootDir = path.resolve(coreDir, '..', '..');
+const workerPath = path.join(harnessDir, 'episode_workload.py');
+const schemaPath = path.join(
+  harnessDir,
+  'schemas',
+  'trust-report-v1.schema.json',
+);
+
+function usage() {
+  console.log(`Episode Qualification Harness v0
+
+Usage:
+  ./kungfu-code episode:qualify -- [options]
+
+Options:
+  --profile NAME                     mvp-smoke-v1 (default) or mvp-baseline-v1
+  --mode all|accumulation|contention selected scenario family (default: all)
+  --seed N                           override profile seeds with one seed
+  --accumulation-checkpoints A,B     override accumulation checkpoints
+  --contention-episodes N            override fixed contention Episode count
+  --workers A,B                      override contention worker counts
+  --report PATH                      Trust Report destination
+  --keep-runtime                     retain generated runtime homes
+  -h, --help                         show this help
+`);
+}
+
+function fail(message) {
+  console.error(`episode qualification: ${message}`);
+  process.exit(2);
+}
+
+function parseInteger(value, label) {
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isSafeInteger(parsed) || parsed < 0) {
+    fail(`${label} must be a non-negative safe integer, got '${value}'`);
+  }
+  return parsed;
+}
+
+function parseIntegerList(value, label, allowZero = false) {
+  const values = value
+    .split(',')
+    .filter(Boolean)
+    .map((item) => parseInteger(item, label));
+  if (
+    values.length === 0 ||
+    (!allowZero && values.some((item) => item === 0))
+  ) {
+    fail(`${label} must contain positive comma-separated integers`);
+  }
+  return values;
+}
+
+function parseArgs(argv) {
+  const options = {
+    profile: 'mvp-smoke-v1',
+    mode: 'all',
+    seed: null,
+    accumulationCheckpoints: null,
+    contentionEpisodes: null,
+    workers: null,
+    report: null,
+    keepRuntime: false,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--') continue;
+    const next = () => {
+      index += 1;
+      if (index >= argv.length) fail(`${arg} requires a value`);
+      return argv[index];
+    };
+    if (arg === '--profile') options.profile = next();
+    else if (arg === '--mode') options.mode = next();
+    else if (arg === '--seed') options.seed = parseInteger(next(), '--seed');
+    else if (arg === '--accumulation-checkpoints') {
+      options.accumulationCheckpoints = parseIntegerList(
+        next(),
+        '--accumulation-checkpoints',
+      );
+    } else if (arg === '--contention-episodes') {
+      options.contentionEpisodes = parseInteger(
+        next(),
+        '--contention-episodes',
+      );
+      if (options.contentionEpisodes === 0) {
+        fail('--contention-episodes must be positive');
+      }
+    } else if (arg === '--workers') {
+      options.workers = parseIntegerList(next(), '--workers');
+    } else if (arg === '--report') options.report = path.resolve(next());
+    else if (arg === '--keep-runtime') options.keepRuntime = true;
+    else if (arg === '--help' || arg === '-h') {
+      usage();
+      process.exit(0);
+    } else fail(`unknown argument '${arg}'`);
+  }
+  if (!['all', 'accumulation', 'contention'].includes(options.mode)) {
+    fail(
+      `--mode must be all, accumulation, or contention, got '${options.mode}'`,
+    );
+  }
+  if (!/^[a-z0-9][a-z0-9-]*$/.test(options.profile)) {
+    fail(`invalid profile name '${options.profile}'`);
+  }
+  return options;
+}
+
+function loadProfile(options) {
+  const profilePath = path.join(
+    harnessDir,
+    'profiles',
+    `${options.profile}.json`,
+  );
+  if (!fs.existsSync(profilePath)) fail(`profile not found: ${profilePath}`);
+  const profile = JSON.parse(fs.readFileSync(profilePath, 'utf8'));
+  if (profile.schema !== 'kungfu.episode.qualification-profile/v1') {
+    fail(`unsupported profile schema '${profile.schema}'`);
+  }
+  if (profile.name !== options.profile) {
+    fail(`profile name '${profile.name}' does not match ${options.profile}`);
+  }
+  if (options.seed != null) profile.seeds = [options.seed];
+  if (options.accumulationCheckpoints) {
+    profile.accumulation.checkpoints = options.accumulationCheckpoints;
+  }
+  if (options.contentionEpisodes != null) {
+    profile.contention.total_episodes = options.contentionEpisodes;
+  }
+  if (options.workers) profile.contention.workers = options.workers;
+  for (const key of ['seeds']) {
+    if (!Array.isArray(profile[key]) || profile[key].length === 0) {
+      fail(`profile ${key} must be a non-empty array`);
+    }
+  }
+  return profile;
+}
+
+function runtimeEnv() {
+  const dist = path.join(coreDir, 'dist', 'kungfu');
+  const env = { ...process.env };
+  const key =
+    process.platform === 'darwin'
+      ? 'DYLD_FALLBACK_LIBRARY_PATH'
+      : process.platform === 'win32'
+        ? 'PATH'
+        : 'LD_LIBRARY_PATH';
+  env[key] = env[key] ? `${dist}${path.delimiter}${env[key]}` : dist;
+  return env;
+}
+
+function assertNativeBinding() {
+  const dist = path.join(coreDir, 'dist', 'kungfu');
+  let entries = [];
+  try {
+    entries = fs.readdirSync(dist);
+  } catch {
+    // handled below
+  }
+  if (!entries.some((name) => /^pykungfu.*\.(so|pyd)$/.test(name))) {
+    fail(
+      `native binding not found under ${dist}; run './kungfu-code build:core' first`,
+    );
+  }
+}
+
+function gitText(args) {
+  const result = spawnSync('git', args, {
+    cwd: rootDir,
+    encoding: 'utf8',
+  });
+  if (result.status !== 0) fail(`git ${args.join(' ')} failed`);
+  return (result.stdout || '').trim();
+}
+
+function readResult(resultPath, fallback) {
+  try {
+    return JSON.parse(fs.readFileSync(resultPath, 'utf8'));
+  } catch (error) {
+    return {
+      ok: false,
+      kind: fallback.kind,
+      errors: [
+        {
+          code: 'worker_result_missing',
+          error: `${error}`,
+          process: fallback,
+        },
+      ],
+    };
+  }
+}
+
+function runPython(args, resultPath, timeoutSeconds) {
+  return new Promise((resolve) => {
+    const child = spawn(
+      'uv',
+      ['run', '--frozen', 'python', workerPath, ...args],
+      {
+        cwd: coreDir,
+        env: runtimeEnv(),
+        stdio: ['ignore', 'pipe', 'pipe'],
+      },
+    );
+    let stdout = '';
+    let stderr = '';
+    let timedOut = false;
+    child.stdout.on('data', (chunk) => {
+      stdout = `${stdout}${chunk}`.slice(-20000);
+    });
+    child.stderr.on('data', (chunk) => {
+      stderr = `${stderr}${chunk}`.slice(-20000);
+    });
+    child.on('error', (error) => {
+      stderr = `${stderr}\n${error}`.slice(-20000);
+    });
+    const timer = setTimeout(() => {
+      timedOut = true;
+      child.kill('SIGKILL');
+    }, timeoutSeconds * 1000);
+    child.on('close', (code, signal) => {
+      clearTimeout(timer);
+      const processResult = {
+        kind: args[0],
+        exit_code: code,
+        signal,
+        timed_out: timedOut,
+        stdout_tail: stdout.trim().slice(-2000),
+        stderr_tail: stderr.trim().slice(-4000),
+      };
+      const result = readResult(resultPath, processResult);
+      result.process = processResult;
+      if (timedOut) {
+        result.ok = false;
+        result.errors = [
+          ...(result.errors || []),
+          { code: 'scenario_timeout', timeout_seconds: timeoutSeconds },
+        ];
+      }
+      resolve(result);
+    });
+  });
+}
+
+function retryArgs(profile) {
+  return [
+    '--initial-delay-ms',
+    String(profile.retry.initial_delay_ms),
+    '--max-delay-ms',
+    String(profile.retry.max_delay_ms),
+    '--max-attempts',
+    String(profile.retry.max_attempts),
+    '--progress-timeout-ms',
+    String(profile.retry.progress_timeout_ms),
+  ];
+}
+
+function probeArgs(profile, values) {
+  const args = [
+    'probe',
+    '--result',
+    values.resultPath,
+    '--runtime-dir',
+    values.runtimeDir,
+    '--mode',
+    values.mode,
+    '--seed',
+    String(values.seed),
+    '--expected-count',
+    String(values.expectedCount),
+    '--logical-agents',
+    String(values.logicalAgents),
+    '--abort-every',
+    String(values.abortEvery),
+    '--sample-count',
+    String(profile.validation.sample_count),
+    '--list-limit',
+    String(profile.validation.list_limit),
+  ];
+  for (const warning of profile.validation.allowed_full_fsck_warnings) {
+    args.push('--allowed-warning', warning);
+  }
+  return args;
+}
+
+function removeRuntime(runtimeDir, keepRuntime) {
+  if (!keepRuntime) fs.rmSync(runtimeDir, { recursive: true, force: true });
+}
+
+async function runAccumulation(profile, seed, runRoot, keepRuntime) {
+  const runtimeDir = path.join(runRoot, 'runtime', `accumulation-${seed}`);
+  fs.mkdirSync(runtimeDir, { recursive: true });
+  const scenarios = [];
+  let previous = 0;
+  for (const checkpoint of profile.accumulation.checkpoints) {
+    if (!Number.isSafeInteger(checkpoint) || checkpoint <= previous) {
+      fail('accumulation checkpoints must be positive and strictly increasing');
+    }
+    const resultPath = path.join(
+      runRoot,
+      'results',
+      `accumulation-${seed}-${checkpoint}-write.json`,
+    );
+    const write = await runPython(
+      [
+        'write',
+        '--result',
+        resultPath,
+        '--runtime-dir',
+        runtimeDir,
+        '--mode',
+        'accumulation',
+        '--seed',
+        String(seed),
+        '--start-index',
+        String(previous),
+        '--count',
+        String(checkpoint - previous),
+        '--logical-agents',
+        '1',
+        '--worker-id',
+        '0',
+        '--abort-every',
+        String(profile.accumulation.abort_every),
+        ...retryArgs(profile),
+      ],
+      resultPath,
+      profile.scenario_timeout_seconds,
+    );
+    const probePath = path.join(
+      runRoot,
+      'results',
+      `accumulation-${seed}-${checkpoint}-probe.json`,
+    );
+    const probe = await runPython(
+      probeArgs(profile, {
+        resultPath: probePath,
+        runtimeDir,
+        mode: 'accumulation',
+        seed,
+        expectedCount: checkpoint,
+        logicalAgents: 1,
+        abortEvery: profile.accumulation.abort_every,
+      }),
+      probePath,
+      profile.scenario_timeout_seconds,
+    );
+    scenarios.push({
+      kind: 'accumulation',
+      seed,
+      checkpoint,
+      added_episodes: checkpoint - previous,
+      write,
+      probe,
+      ok: Boolean(write.ok && probe.ok),
+    });
+    previous = checkpoint;
+    if (!write.ok || !probe.ok) break;
+  }
+  removeRuntime(runtimeDir, keepRuntime);
+  return scenarios;
+}
+
+async function runContention(profile, seed, workerCount, runRoot, keepRuntime) {
+  const total = profile.contention.total_episodes;
+  const runtimeDir = path.join(
+    runRoot,
+    'runtime',
+    `contention-${seed}-${workerCount}`,
+  );
+  fs.mkdirSync(runtimeDir, { recursive: true });
+  const startAtMs = Date.now() + 1000;
+  let nextIndex = 0;
+  const promises = [];
+  for (let workerId = 0; workerId < workerCount; workerId += 1) {
+    const base = Math.floor(total / workerCount);
+    const count = base + (workerId < total % workerCount ? 1 : 0);
+    const resultPath = path.join(
+      runRoot,
+      'results',
+      `contention-${seed}-${workerCount}-worker-${workerId}.json`,
+    );
+    promises.push(
+      runPython(
+        [
+          'write',
+          '--result',
+          resultPath,
+          '--runtime-dir',
+          runtimeDir,
+          '--mode',
+          'contention',
+          '--seed',
+          String(seed),
+          '--start-index',
+          String(nextIndex),
+          '--count',
+          String(count),
+          '--logical-agents',
+          String(workerCount),
+          '--worker-id',
+          String(workerId),
+          '--abort-every',
+          String(profile.contention.abort_every),
+          '--start-at-ms',
+          String(startAtMs),
+          ...retryArgs(profile),
+        ],
+        resultPath,
+        profile.scenario_timeout_seconds,
+      ),
+    );
+    nextIndex += count;
+  }
+  const workers = await Promise.all(promises);
+  const probePath = path.join(
+    runRoot,
+    'results',
+    `contention-${seed}-${workerCount}-probe.json`,
+  );
+  const probe = await runPython(
+    probeArgs(profile, {
+      resultPath: probePath,
+      runtimeDir,
+      mode: 'contention',
+      seed,
+      expectedCount: total,
+      logicalAgents: workerCount,
+      abortEvery: profile.contention.abort_every,
+    }),
+    probePath,
+    profile.scenario_timeout_seconds,
+  );
+  const scenario = {
+    kind: 'contention',
+    seed,
+    workers: workerCount,
+    total_episodes: total,
+    writer_results: workers,
+    probe,
+    ok: Boolean(workers.every((result) => result.ok) && probe.ok),
+  };
+  removeRuntime(runtimeDir, keepRuntime);
+  return scenario;
+}
+
+function sumWorkerOperation(scenarios, field) {
+  let total = 0;
+  for (const scenario of scenarios) {
+    const workers = scenario.writer_results || [scenario.write].filter(Boolean);
+    for (const worker of workers) total += worker.operations?.[field] || 0;
+  }
+  return total;
+}
+
+function writerResults(scenario) {
+  return scenario.writer_results || [scenario.write].filter(Boolean);
+}
+
+function aggregateWriters(workers) {
+  const durationSeconds = Math.max(
+    0,
+    ...workers.map((worker) => worker.duration_seconds || 0),
+  );
+  const episodesCompleted = workers.reduce(
+    (total, worker) => total + (worker.episodes_completed || 0),
+    0,
+  );
+  const operations = {};
+  for (const field of [
+    'successful_appends',
+    'manifest_writer_busy',
+    'retry_count',
+    'retry_exhausted',
+    'unexpected_errors',
+    'progress_timeouts',
+  ]) {
+    operations[field] = workers.reduce(
+      (total, worker) => total + (worker.operations?.[field] || 0),
+      0,
+    );
+  }
+  operations.longest_no_progress_interval_ms = Math.max(
+    0,
+    ...workers.map(
+      (worker) => worker.operations?.longest_no_progress_interval_ms || 0,
+    ),
+  );
+  return {
+    episodes_completed: episodesCompleted,
+    duration_seconds: durationSeconds,
+    throughput_episodes_per_second:
+      durationSeconds > 0 ? episodesCompleted / durationSeconds : 0,
+    operations,
+    max_worker_rss_bytes: Math.max(
+      0,
+      ...workers.map((worker) => worker.resources?.max_rss_bytes || 0),
+    ),
+  };
+}
+
+function probeErrors(scenarios) {
+  return scenarios.flatMap((scenario) => scenario.probe?.errors || []);
+}
+
+function countCodes(errors, predicate) {
+  return errors.filter((error) => predicate(String(error.code || ''))).length;
+}
+
+function workloadScenario(scenario) {
+  if (scenario.kind === 'accumulation') {
+    return {
+      kind: scenario.kind,
+      seed: scenario.seed,
+      checkpoint: scenario.checkpoint,
+      added_episodes: scenario.added_episodes,
+      ok: scenario.ok,
+    };
+  }
+  return {
+    kind: scenario.kind,
+    seed: scenario.seed,
+    workers: scenario.workers,
+    total_episodes: scenario.total_episodes,
+    ok: scenario.ok,
+  };
+}
+
+function performanceScenario(scenario) {
+  const workers = writerResults(scenario);
+  return {
+    ...workloadScenario(scenario),
+    aggregate: aggregateWriters(workers),
+    writers: workers.map((worker) => ({
+      worker_id: worker.worker_id,
+      episodes_completed: worker.episodes_completed,
+      duration_seconds: worker.duration_seconds,
+      throughput_episodes_per_second: worker.throughput_episodes_per_second,
+      operations: worker.operations,
+      latency_ms: worker.latency_ms,
+      resources: worker.resources,
+    })),
+    readback: scenario.probe
+      ? {
+          expected_episodes: scenario.probe.expected_episodes,
+          listed_episodes: scenario.probe.listed_episodes,
+          expected_semantic_records: scenario.probe.expected_semantic_records,
+          listed_semantic_records: scenario.probe.listed_semantic_records,
+          observed_manifest_frames: scenario.probe.observed_manifest_frames,
+          manifest_control_frames: scenario.probe.manifest_control_frames,
+          sample_indices: scenario.probe.sample_indices,
+          sampled_readback_ok: scenario.probe.sampled_readback_ok,
+          metrics: scenario.probe.metrics,
+          resources: scenario.probe.resources,
+          fsck: scenario.probe.fsck,
+          recovery: scenario.probe.recovery,
+        }
+      : null,
+    diagnostics: {
+      writer_errors: workers.flatMap((worker) => worker.errors || []),
+      writer_processes: workers.map((worker) => worker.process || null),
+      probe_errors: scenario.probe?.errors || [],
+      probe_process: scenario.probe?.process || null,
+    },
+  };
+}
+
+async function validateReport(reportPath) {
+  const child = spawnSync(
+    'uv',
+    [
+      'run',
+      '--frozen',
+      'python',
+      workerPath,
+      'validate-report',
+      '--report',
+      reportPath,
+      '--schema',
+      schemaPath,
+    ],
+    {
+      cwd: coreDir,
+      env: runtimeEnv(),
+      encoding: 'utf8',
+    },
+  );
+  return {
+    ok: child.status === 0,
+    output: `${child.stdout || ''}${child.stderr || ''}`.trim().slice(-4000),
+  };
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const profile = loadProfile(options);
+  assertNativeBinding();
+
+  const runRoot = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'kf-episode-qualification-'),
+  );
+  fs.mkdirSync(path.join(runRoot, 'results'), { recursive: true });
+  const reportPath =
+    options.report || path.join(runRoot, 'episode-trust-report.json');
+  fs.mkdirSync(path.dirname(reportPath), { recursive: true });
+
+  const sourceRevision = gitText(['rev-parse', 'HEAD']);
+  const sourceDirty = gitText(['status', '--porcelain']).length > 0;
+  const started = Date.now();
+  const scenarios = [];
+
+  console.log(
+    `[episode-qualify] profile=${profile.name} mode=${options.mode} seeds=${profile.seeds.join(',')}`,
+  );
+  for (const seed of profile.seeds) {
+    if (options.mode === 'all' || options.mode === 'accumulation') {
+      console.log(
+        `[episode-qualify] accumulation seed=${seed} checkpoints=${profile.accumulation.checkpoints.join(',')}`,
+      );
+      scenarios.push(
+        ...(await runAccumulation(profile, seed, runRoot, options.keepRuntime)),
+      );
+    }
+    if (options.mode === 'all' || options.mode === 'contention') {
+      for (const workers of profile.contention.workers) {
+        console.log(
+          `[episode-qualify] contention seed=${seed} workers=${workers} episodes=${profile.contention.total_episodes}`,
+        );
+        scenarios.push(
+          await runContention(
+            profile,
+            seed,
+            workers,
+            runRoot,
+            options.keepRuntime,
+          ),
+        );
+      }
+    }
+  }
+
+  const errors = probeErrors(scenarios);
+  const retryExhausted = sumWorkerOperation(scenarios, 'retry_exhausted');
+  const unexpectedErrors = scenarios.reduce((total, scenario) => {
+    let scenarioTotal = 0;
+    for (const worker of writerResults(scenario)) {
+      if (worker.operations) {
+        scenarioTotal += worker.operations.unexpected_errors || 0;
+      } else {
+        scenarioTotal += (worker.errors || []).length;
+      }
+    }
+    return total + scenarioTotal;
+  }, 0);
+  const progressTimeouts =
+    sumWorkerOperation(scenarios, 'progress_timeouts') +
+    countCodes(errors, (code) => code === 'scenario_timeout');
+  const correctness = {
+    silent_invalid: 0,
+    capability_violations: 0,
+    containment_violations: 0,
+    repair_monotonicity_violations: 0,
+    count_mismatches: countCodes(errors, (code) =>
+      code.includes('count_mismatch'),
+    ),
+    readback_mismatches: countCodes(errors, (code) =>
+      code.includes('readback_mismatch'),
+    ),
+    fsck_failures: countCodes(errors, (code) => code.includes('fsck_failed')),
+    recovery_mismatches: countCodes(errors, (code) =>
+      code.includes('recovery'),
+    ),
+    retry_exhausted: retryExhausted,
+    unexpected_errors: unexpectedErrors,
+    progress_timeouts: progressTimeouts,
+  };
+  const allScenariosOk =
+    scenarios.length > 0 && scenarios.every((scenario) => scenario.ok);
+  const contentionScenarios = scenarios.filter(
+    (scenario) => scenario.kind === 'contention' && scenario.workers > 1,
+  );
+  const busyObserved =
+    sumWorkerOperation(scenarios, 'manifest_writer_busy') > 0;
+  const durationSeconds = (Date.now() - started) / 1000;
+  const gaps = [
+    'metadata-only profile; realistic payload bytes and dedup are not exercised',
+    'independent Episodes only; dependency DAG depth and fan-out are not exercised',
+    'Episode query is manifest-direct; Episode projection rebuild is not implemented',
+    'single-node local filesystem only; no service-backed or distributed qualification',
+    'deterministic publication crash and corruption coverage remains in separate fixtures',
+    'no absolute performance SLO is adopted by the v0 profile',
+  ];
+  if (options.mode !== 'all') {
+    gaps.push(`invocation selected only the ${options.mode} scenario family`);
+  }
+  if (sourceDirty) {
+    gaps.push(
+      'source worktree was dirty; commit the exact source before a release claim',
+    );
+  }
+
+  const report = {
+    schema: 'kungfu.episode.trust-report/v1',
+    source_revision: sourceRevision,
+    source_dirty: sourceDirty,
+    episode_contract: 'kungfu.episode.manifest/v1',
+    profile: profile.name,
+    platform: {
+      os: process.platform,
+      arch: process.arch,
+      node: process.version,
+    },
+    hardware: {
+      logical_cpus: os.cpus().length,
+      total_memory_bytes: os.totalmem(),
+    },
+    backend_capabilities: {
+      manifest_authority: 'yijinjing-journal',
+      writer_ownership: 'one-logical-manifest-writer-per-data-root',
+      payload_profile: profile.payload_profile,
+      query_profile: profile.query_profile,
+      retry_policy: profile.retry,
+    },
+    workload: {
+      profile: profile.name,
+      seeds: profile.seeds,
+      duration_seconds: durationSeconds,
+      scenarios: scenarios.map(workloadScenario),
+    },
+    fault_coverage: {
+      writer_contention_exercised: contentionScenarios.length > 0,
+      writer_contention_observed: busyObserved,
+      fresh_process_readback: scenarios.every((scenario) =>
+        Boolean(scenario.probe?.ok),
+      ),
+      clean_recovery: scenarios.every(
+        (scenario) => scenario.probe?.recovery?.recovered_count === 0,
+      ),
+    },
+    correctness,
+    performance: {
+      scenarios: scenarios.map(performanceScenario),
+    },
+    gaps,
+    qualified: allScenariosOk && !sourceDirty,
+  };
+  fs.writeFileSync(reportPath, `${JSON.stringify(report, null, 2)}\n`);
+  const schemaValidation = await validateReport(reportPath);
+  if (!schemaValidation.ok) {
+    console.error(
+      `[episode-qualify] report schema invalid: ${schemaValidation.output}`,
+    );
+  }
+
+  console.log(`[episode-qualify] report=${reportPath}`);
+  console.log(
+    `[episode-qualify] scenarios=${scenarios.length} passed=${scenarios.filter((scenario) => scenario.ok).length} busy=${sumWorkerOperation(scenarios, 'manifest_writer_busy')} qualified=${report.qualified}`,
+  );
+  if (sourceDirty && allScenariosOk) {
+    console.log(
+      '[episode-qualify] scenario gates passed, but release qualification remains false for a dirty source tree',
+    );
+  }
+  process.exitCode = allScenariosOk && schemaValidation.ok ? 0 : 1;
+}
+
+await main();

--- a/framework/core/tests/qualification/episode/schemas/trust-report-v1.schema.json
+++ b/framework/core/tests/qualification/episode/schemas/trust-report-v1.schema.json
@@ -1,0 +1,161 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kungfu.tech/schemas/episode-trust-report-v1.schema.json",
+  "title": "Kungfu Episode Trust Report v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "source_revision",
+    "source_dirty",
+    "episode_contract",
+    "profile",
+    "platform",
+    "hardware",
+    "backend_capabilities",
+    "workload",
+    "fault_coverage",
+    "correctness",
+    "performance",
+    "gaps",
+    "qualified"
+  ],
+  "properties": {
+    "schema": {
+      "const": "kungfu.episode.trust-report/v1"
+    },
+    "source_revision": {
+      "type": "string",
+      "minLength": 7
+    },
+    "source_dirty": {
+      "type": "boolean"
+    },
+    "episode_contract": {
+      "const": "kungfu.episode.manifest/v1"
+    },
+    "profile": {
+      "type": "string",
+      "minLength": 1
+    },
+    "platform": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["os", "arch", "node"],
+      "properties": {
+        "os": { "type": "string" },
+        "arch": { "type": "string" },
+        "node": { "type": "string" }
+      }
+    },
+    "hardware": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["logical_cpus", "total_memory_bytes"],
+      "properties": {
+        "logical_cpus": { "type": "integer", "minimum": 1 },
+        "total_memory_bytes": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "backend_capabilities": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "manifest_authority",
+        "writer_ownership",
+        "payload_profile",
+        "query_profile",
+        "retry_policy"
+      ],
+      "properties": {
+        "manifest_authority": { "const": "yijinjing-journal" },
+        "writer_ownership": { "const": "one-logical-manifest-writer-per-data-root" },
+        "payload_profile": { "type": "string" },
+        "query_profile": { "type": "string" },
+        "retry_policy": { "type": "object" }
+      }
+    },
+    "workload": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["profile", "seeds", "duration_seconds", "scenarios"],
+      "properties": {
+        "profile": { "type": "string" },
+        "seeds": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "integer", "minimum": 0 }
+        },
+        "duration_seconds": { "type": "number", "minimum": 0 },
+        "scenarios": {
+          "type": "array",
+          "items": { "type": "object" }
+        }
+      }
+    },
+    "fault_coverage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "writer_contention_exercised",
+        "writer_contention_observed",
+        "fresh_process_readback",
+        "clean_recovery"
+      ],
+      "properties": {
+        "writer_contention_exercised": { "type": "boolean" },
+        "writer_contention_observed": { "type": "boolean" },
+        "fresh_process_readback": { "type": "boolean" },
+        "clean_recovery": { "type": "boolean" }
+      }
+    },
+    "correctness": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "silent_invalid",
+        "capability_violations",
+        "containment_violations",
+        "repair_monotonicity_violations",
+        "count_mismatches",
+        "readback_mismatches",
+        "fsck_failures",
+        "recovery_mismatches",
+        "retry_exhausted",
+        "unexpected_errors",
+        "progress_timeouts"
+      ],
+      "properties": {
+        "silent_invalid": { "type": "integer", "minimum": 0 },
+        "capability_violations": { "type": "integer", "minimum": 0 },
+        "containment_violations": { "type": "integer", "minimum": 0 },
+        "repair_monotonicity_violations": { "type": "integer", "minimum": 0 },
+        "count_mismatches": { "type": "integer", "minimum": 0 },
+        "readback_mismatches": { "type": "integer", "minimum": 0 },
+        "fsck_failures": { "type": "integer", "minimum": 0 },
+        "recovery_mismatches": { "type": "integer", "minimum": 0 },
+        "retry_exhausted": { "type": "integer", "minimum": 0 },
+        "unexpected_errors": { "type": "integer", "minimum": 0 },
+        "progress_timeouts": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "performance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["scenarios"],
+      "properties": {
+        "scenarios": {
+          "type": "array",
+          "items": { "type": "object" }
+        }
+      }
+    },
+    "gaps": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "qualified": {
+      "type": "boolean"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "dist:dir": "pnpm --filter @kungfu-tech/product-kungfu run package",
     "package:app": "pnpm --filter @kungfu-tech/product-kungfu run package",
     "verify": "node scripts/verify.mjs",
+    "episode:qualify": "node framework/core/tests/qualification/episode/run.mjs",
     "kfd:buildchain": "node scripts/buildchain-kfd-evidence.mjs --write",
     "kfd:buildchain:check": "node scripts/buildchain-kfd-evidence.mjs --check",
     "kfd:query": "node scripts/buildchain-kfd-evidence.mjs --query",


### PR DESCRIPTION
## Summary

- add a versioned Episode Qualification Harness with accumulation and 1/2/5/10-worker contention modes
- validate reports against a Trust Report schema and fail on correctness violations
- document the first clean smoke, 100k accumulation, and 10k contention baselines with explicit claim boundaries

## Validation

- ./kungfu-code check
- ./kungfu-code build:core
- pytest -q framework/core/tests/python/test_episode_manifest_recovery.py
- pytest -q framework/core/tests/python/test_atlas_storage.py -k episode
- ./kungfu-code episode:qualify -- --profile mvp-smoke-v1
- one-seed mvp-baseline-v1 accumulation and contention runs

## Version impact

Patch-level tooling and documentation addition; no runtime API or Episode semantic change.