### PR TITLE
feat(storage): add first-class content store contract with file backend

### DIFF
--- a/framework/core/slices/CMakeLists.txt
+++ b/framework/core/slices/CMakeLists.txt
@@ -5,6 +5,7 @@
 # all; each slice is a self-contained subdirectory with its own probe
 # statement, sources and one-command run script.
 
+add_subdirectory(content-store)
 add_subdirectory(fact-ledger)
 add_subdirectory(schema-registry)
 add_subdirectory(view-encapsulation)

--- a/framework/core/slices/content-store/CMakeLists.txt
+++ b/framework/core/slices/content-store/CMakeLists.txt
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# content-store slice: standalone probe of the ADR-0040 immutable
+# content-addressed store contract and its dependency-free file backend.
+# Links only the yijinjing journal core -- the cut-proof in run.mjs asserts
+# no other dynamic dependency, which is the point: the kernel content store
+# stands with zero engine dependencies.
+
+project(content_store_slice)
+
+find_package(Threads REQUIRED)
+
+add_executable(content_store_probe probe.cpp)
+target_link_libraries(content_store_probe yijinjing Threads::Threads)

--- a/framework/core/slices/content-store/README.md
+++ b/framework/core/slices/content-store/README.md
@@ -1,0 +1,38 @@
+# content-store slice
+
+Probe statement: the yijinjing kernel offers one first-class immutable
+content-addressed store (ADR-0040) whose dependency-free file backend proves
+its contract obligations on this machine, standalone, with no engine
+dependency.
+
+What the probe proves:
+
+- **Atomic publish (put-if-absent)**: bytes are staged under `tmp/` and
+  renamed onto their content digest; a first put publishes, a repeated put is
+  a dedup hit, and publish leaves no temp residue.
+- **Hash mismatch rejection**: a put whose bytes do not hash to the caller's
+  declared digest is rejected and stores nothing; verify of an absent digest
+  is `not_found`.
+- **Crash-safe visibility**: a torn final object (crashed non-atomic writer)
+  fails `verify` and never comes back from `get`; same-length tampering is
+  caught on every read path; temp residue is invisible to lookups.
+- **Verified reads**: `get` returns bytes only after they re-hash to the
+  digest.
+- **Declared semantics**: capability discovery (profile, algorithm, limits,
+  durability, visibility, concurrency), size-limit rejection, and the declared
+  error taxonomy instead of engine-specific failures.
+- **Single-node concurrency**: in-process threads and separate writer
+  processes proposing the same content end with exactly one stored copy and
+  zero torn state; distinct contents land under distinct keys.
+
+The run also executes the yijinjing dependency-direction guard
+(`src/libyijinjing/check-deps.mjs`) plus its seeded self-test, proving the
+ADR-0040 boundary gate catches engine includes, symbols, and CMake links.
+
+Run:
+
+```bash
+cmake -S framework/core -B framework/core/build -DKUNGFU_WITH_SLICES=ON
+cmake --build framework/core/build --target content_store_probe
+node framework/core/slices/content-store/run.mjs
+```

--- a/framework/core/slices/content-store/probe.cpp
+++ b/framework/core/slices/content-store/probe.cpp
@@ -1,0 +1,257 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// content-store slice probe (ADR-0040): drives the dependency-free file
+// backend through the contract's four obligations -- atomic publish
+// (put-if-absent), hash mismatch rejection, crash-safe visibility (a torn
+// write is invisible or detectable, never a verified read), verified reads --
+// plus the single-node concurrency proof: concurrent writers proposing the
+// same content store it once, different content lands under distinct keys.
+//
+// Usage: content_store_probe <workdir>              full fixture suite
+//        content_store_probe --writer <root> <n>    multi-process writer leg
+//          (run.mjs spawns several writer processes against one root and
+//           asserts single-copy dedup on the filesystem afterwards)
+
+#include <atomic>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <kungfu/yijinjing/storage/content_hash.h>
+#include <kungfu/yijinjing/storage/content_store.h>
+
+using namespace kungfu::yijinjing::storage;
+namespace fs = std::filesystem;
+
+namespace {
+
+int failures = 0;
+
+void check(bool ok, const std::string &label) {
+  std::printf("  %s: %s\n", ok ? "ok" : "FAIL", label.c_str());
+  if (!ok) {
+    ++failures;
+  }
+}
+
+// Objects on disk for one namespace, ignoring the tmp/ staging dir; temp
+// residue is counted separately because it must never look like an object.
+size_t count_objects(const std::string &root, const std::string &content_namespace) {
+  const auto dir = fs::path(root) / content_namespace;
+  if (!fs::exists(dir)) {
+    return 0;
+  }
+  size_t count = 0;
+  for (const auto &entry : fs::recursive_directory_iterator(dir)) {
+    if (entry.is_regular_file() && entry.path().parent_path().filename() != "tmp") {
+      ++count;
+    }
+  }
+  return count;
+}
+
+size_t count_temp_residue(const std::string &root, const std::string &content_namespace) {
+  const auto dir = fs::path(root) / content_namespace / "tmp";
+  if (!fs::exists(dir)) {
+    return 0;
+  }
+  size_t count = 0;
+  for (const auto &entry : fs::directory_iterator(dir)) {
+    if (entry.is_regular_file()) {
+      ++count;
+    }
+  }
+  return count;
+}
+
+content_hash digest_of(const std::string &bytes) { return make_content_hash(compute_content_hash_value(bytes)); }
+
+int run_suite(const std::string &root) {
+  file_content_store store(root);
+
+  std::printf("== capability discovery\n");
+  const auto caps = store.capabilities();
+  check(caps.profile == "yijinjing-file/v1", "backend declares its profile");
+  check(caps.hash_algorithm == std::string(CONTENT_HASH_ALGORITHM_SHA256), "backend declares its hash algorithm");
+  check(caps.atomic_put_if_absent, "backend declares atomic put-if-absent");
+  check(caps.verified_reads, "backend declares verified reads");
+  check(!caps.durability.empty() && !caps.visibility.empty() && !caps.concurrency.empty(),
+        "durability/visibility/concurrency are declared, not implied");
+
+  std::printf("== obligation: atomic publish + verified read\n");
+  const std::string bytes = "content-store v1 first obligation payload";
+  const auto put = store.put_if_absent("payloads", bytes);
+  check(put.ok() && !put.existed, "first put publishes");
+  check(put.hash.value == compute_content_hash_value(bytes), "identity is the hash of the bytes");
+  check(put.byte_length == bytes.size(), "result reports the object length");
+  const auto got = store.get("payloads", put.hash);
+  check(got.ok() && got.bytes == bytes, "verified get returns the exact bytes");
+  check(store.has("payloads", put.hash), "has sees the published object");
+  const auto verified = store.verify("payloads", put.hash);
+  check(verified.ok() && verified.byte_length == bytes.size(), "verify re-hashes the stored bytes");
+  check(count_temp_residue(root, "payloads") == 0, "publish leaves no temp residue");
+
+  std::printf("== dedup: same content is stored once\n");
+  const auto again = store.put_if_absent("payloads", bytes);
+  check(again.ok() && again.existed, "second put is a dedup hit");
+  check(count_objects(root, "payloads") == 1, "exactly one object on disk");
+
+  std::printf("== obligation: hash mismatch rejection\n");
+  const std::string other = "different payload that will be rejected";
+  const auto wrong = make_content_hash(std::string(64, '0'));
+  const auto rejected = store.put_if_absent("mismatch", other, wrong);
+  check(rejected.error == content_store_error::HashMismatch, "put with a wrong declared digest is rejected");
+  check(count_objects(root, "mismatch") == 0, "rejected put stores nothing");
+  const auto accepted = store.put_if_absent("mismatch", other, digest_of(other));
+  check(accepted.ok(), "put with the correct declared digest is accepted");
+  const auto absent = store.verify("mismatch", wrong);
+  check(absent.error == content_store_error::NotFound, "verify of an absent digest reports not_found");
+
+  std::printf("== obligation: crash-safe visibility\n");
+  // a torn final object, as a crashed non-atomic legacy writer would leave it
+  const std::string torn_body = "torn object body: the second half of this never reached disk";
+  const auto torn_hash = digest_of(torn_body);
+  const fs::path torn_path = store.object_path("torn", torn_hash);
+  fs::create_directories(torn_path.parent_path());
+  std::ofstream(torn_path, std::ios::binary) << torn_body.substr(0, torn_body.size() / 2);
+  check(store.verify("torn", torn_hash).error == content_store_error::CorruptObject, "torn object fails verify");
+  check(store.get("torn", torn_hash).error == content_store_error::CorruptObject,
+        "torn object never comes back from get");
+  check(store.put_if_absent("torn", torn_body).error == content_store_error::CorruptObject,
+        "put onto a torn object reports corruption instead of trusting it");
+  // same-length tampering passes the dedup fast path (declared: presence plus
+  // length) but can never reach a caller through the verified read path
+  const std::string true_body = "authentic bytes for the tamper case, same length as fake";
+  std::string fake_body = true_body;
+  fake_body[0] = 'X';
+  const auto true_hash = digest_of(true_body);
+  const fs::path tamper_path = store.object_path("tamper", true_hash);
+  fs::create_directories(tamper_path.parent_path());
+  std::ofstream(tamper_path, std::ios::binary) << fake_body;
+  check(store.put_if_absent("tamper", true_body).existed, "same-length tamper passes the dedup fast path by design");
+  check(store.verify("tamper", true_hash).error == content_store_error::CorruptObject, "verify detects the tamper");
+  check(store.get("tamper", true_hash).error == content_store_error::CorruptObject, "get never returns tampered bytes");
+  // a crash between temp write and publish leaves residue only under tmp/,
+  // where no digest lookup can ever address it
+  const std::string junk = "temp residue from a crashed writer";
+  const fs::path residue = fs::path(root) / "payloads" / "tmp" / "deadbeef.99999.1";
+  fs::create_directories(residue.parent_path());
+  std::ofstream(residue, std::ios::binary) << junk;
+  check(!store.has("payloads", digest_of(junk)), "temp residue is invisible to lookups");
+  check(count_objects(root, "payloads") == 1, "temp residue is not an object");
+
+  std::printf("== size limit semantics\n");
+  file_content_store_options bounded_options{};
+  bounded_options.max_object_size = 8;
+  file_content_store bounded(root + "-bounded", bounded_options);
+  check(bounded.capabilities().max_object_size == 8, "the limit is declared through capabilities");
+  check(bounded.put_if_absent("payloads", std::string("123456789")).error == content_store_error::SizeLimitExceeded,
+        "an oversized put is rejected");
+  check(bounded.put_if_absent("payloads", std::string("12345678")).ok(), "a put at the limit is accepted");
+
+  std::printf("== declared error categories\n");
+  check(store.put_if_absent("Bad/Namespace", bytes).error == content_store_error::InvalidArgument,
+        "an invalid namespace is invalid_argument");
+  content_hash malformed{};
+  malformed.value = "zz";
+  check(store.get("payloads", malformed).error == content_store_error::InvalidArgument,
+        "a malformed digest is invalid_argument");
+  content_hash foreign{};
+  foreign.algorithm = "md5";
+  foreign.value = std::string(64, 'a');
+  check(store.verify("payloads", foreign).error == content_store_error::InvalidArgument,
+        "an unsupported algorithm is invalid_argument, not a crash");
+
+  std::printf("== concurrency: same content from many threads is stored once\n");
+  const std::string shared = "fleet-shared content every writer proposes";
+  const int thread_count = 8;
+  const int rounds = 32;
+  std::atomic<int> put_errors{0};
+  {
+    std::vector<std::thread> writers;
+    writers.reserve(thread_count);
+    for (int t = 0; t < thread_count; ++t) {
+      writers.emplace_back([&store, &shared, &put_errors]() {
+        for (int i = 0; i < rounds; ++i) {
+          if (!store.put_if_absent("conc-shared", shared).ok()) {
+            put_errors.fetch_add(1, std::memory_order_relaxed);
+          }
+        }
+      });
+    }
+    for (auto &writer : writers) {
+      writer.join();
+    }
+  }
+  check(put_errors.load() == 0, "every concurrent put succeeds");
+  check(count_objects(root, "conc-shared") == 1, "one stored copy after the race");
+  check(count_temp_residue(root, "conc-shared") == 0, "no torn state after the race");
+  check(store.verify("conc-shared", digest_of(shared)).ok(), "the surviving copy verifies");
+
+  std::printf("== concurrency: distinct content lands under distinct keys\n");
+  std::atomic<int> distinct_errors{0};
+  {
+    std::vector<std::thread> writers;
+    writers.reserve(thread_count);
+    for (int t = 0; t < thread_count; ++t) {
+      writers.emplace_back([&store, &distinct_errors, t]() {
+        const std::string body = "writer-" + std::to_string(t) + " private content";
+        const auto put = store.put_if_absent("conc-distinct", body);
+        if (!put.ok() || put.existed || !store.verify("conc-distinct", put.hash).ok()) {
+          distinct_errors.fetch_add(1, std::memory_order_relaxed);
+        }
+      });
+    }
+    for (auto &writer : writers) {
+      writer.join();
+    }
+  }
+  check(distinct_errors.load() == 0, "every distinct put publishes and verifies");
+  check(count_objects(root, "conc-distinct") == static_cast<size_t>(thread_count),
+        "distinct contents are distinct keys");
+
+  if (failures > 0) {
+    std::printf("FAIL: %d content-store obligations violated\n", failures);
+    return 1;
+  }
+  std::printf("OK: content-store obligations and single-node concurrency proof hold\n");
+  return 0;
+}
+
+// One writer leg of the multi-process proof: publish the same deterministic
+// content set as every other writer, verifying each object after the put.
+int run_writer(const std::string &root, int count) {
+  file_content_store store(root);
+  for (int i = 0; i < count; ++i) {
+    const std::string body = "multi-process shared content #" + std::to_string(i);
+    const auto put = store.put_if_absent("payloads", body);
+    if (!put.ok()) {
+      std::fprintf(stderr, "writer: put %d failed: %s\n", i, put.message.c_str());
+      return 1;
+    }
+    if (!store.verify("payloads", put.hash).ok()) {
+      std::fprintf(stderr, "writer: verify %d failed\n", i);
+      return 1;
+    }
+  }
+  std::printf("writer: %d contents published and verified\n", count);
+  return 0;
+}
+
+} // namespace
+
+int main(int argc, char **argv) {
+  if (argc >= 4 && std::strcmp(argv[1], "--writer") == 0) {
+    return run_writer(argv[2], std::atoi(argv[3]));
+  }
+  if (argc < 2) {
+    std::fprintf(stderr, "usage: content_store_probe <workdir> | content_store_probe --writer <root> <count>\n");
+    return 2;
+  }
+  return run_suite(argv[1]);
+}

--- a/framework/core/slices/content-store/run.mjs
+++ b/framework/core/slices/content-store/run.mjs
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Drive the content-store slice end to end (ADR-0040):
+//   1. assert the probe links only the yijinjing static core (cut-proof)
+//   2. run the fixture suite: four contract obligations, declared error
+//      categories, size-limit semantics, in-process concurrent dedup
+//   3. run the dependency-direction guard and its seeded self-test -- the
+//      kernel must reference no concrete engine, and the gate must be able
+//      to fail
+//   4. multi-process concurrency proof: several writer processes publish the
+//      same content set against one store root; the filesystem must end with
+//      exactly one object per content and zero temp residue
+//
+// Usage: node run.mjs [build-dir]
+
+import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import {
+  assertNoExtraDylibs,
+  fail,
+  findBin,
+  locate,
+  run,
+  tmpDir,
+} from '../_harness.mjs';
+
+const { coreDir, buildDir } = locate(import.meta.url);
+
+const probe = findBin(buildDir, 'content_store_probe', 'slices/content-store');
+if (!probe) {
+  fail(
+    `content_store_probe not found under ${buildDir}\n` +
+      `build first, e.g.:\n  cmake --build ${buildDir} --target content_store_probe`,
+  );
+}
+
+console.log('== step 0: assert zero extra dynamic dependencies (cut-proof)');
+assertNoExtraDylibs(probe);
+
+const work = tmpDir('content-store-slice-');
+
+console.log('\n== step 1: contract obligations + in-process concurrency');
+run(probe, [path.join(work, 'store')], { inherit: true });
+
+console.log('\n== step 2: dependency-direction guard + seeded self-test');
+const guard = path.join(coreDir, 'src', 'libyijinjing', 'check-deps.mjs');
+run(process.execPath, [guard], { inherit: true });
+run(process.execPath, [guard, '--self-test'], { inherit: true });
+
+console.log('\n== step 3: multi-process concurrent dedup');
+const writers = 6;
+const contents = 16;
+const mpRoot = path.join(work, 'mp-store');
+const exits = await Promise.all(
+  Array.from(
+    { length: writers },
+    () =>
+      new Promise((resolve) => {
+        const child = spawn(probe, ['--writer', mpRoot, String(contents)], {
+          stdio: 'inherit',
+        });
+        child.on('error', () => resolve(-1));
+        child.on('exit', (code) => resolve(code));
+      }),
+  ),
+);
+if (exits.some((code) => code !== 0))
+  fail(`writer exit codes: ${exits.join(', ')}`);
+
+let objects = 0;
+let residue = 0;
+const namespaceDir = path.join(mpRoot, 'payloads');
+for (const entry of fs.readdirSync(namespaceDir, {
+  recursive: true,
+  withFileTypes: true,
+})) {
+  if (!entry.isFile()) continue;
+  if (path.basename(entry.parentPath ?? entry.path) === 'tmp') residue += 1;
+  else objects += 1;
+}
+if (objects !== contents)
+  fail(`expected ${contents} unique objects, found ${objects}`);
+if (residue !== 0) fail(`expected zero temp residue, found ${residue}`);
+
+console.log(
+  `\nOK: ${writers} concurrent writer processes x ${contents} shared contents -> ${objects} objects, no torn state.`,
+);

--- a/framework/core/src/libyijinjing/check-deps.mjs
+++ b/framework/core/src/libyijinjing/check-deps.mjs
@@ -7,28 +7,46 @@
 // (kungfu/yijinjing/schema/core.h). It may define storage semantic
 // contracts under kungfu/yijinjing/storage, but it must never include runtime,
 // transport or storage-engine headers, the full runtime registry, or any trading
-// type.
+// type. Per ADR-0040 the kernel owns the content-store contract and must not
+// reference a concrete storage engine by include, symbol, or link; engine
+// implementations live in the runtime/provider layer and are injected through
+// the interface.
 //
 // Include lines are matched instead of bare words so that comments explaining
 // a seam (e.g. "mirrors NNG_FLAG_NONBLOCK") do not trip the guard; trading
-// types and the registry are matched as symbols since no comment should need
-// them either.
+// types, the registry and engine APIs are matched as code-level symbols since
+// no comment should need those either. CMake link lines are matched with
+// comments stripped, so prose about engines stays legal while a real link
+// does not.
 //
 // Pure Node (no grep/bash), so the guard runs on every platform.
 //
-// Usage: node src/libyijinjing/check-deps.mjs   (from anywhere)
+// Usage: node src/libyijinjing/check-deps.mjs               (guard the real tree)
+//        node src/libyijinjing/check-deps.mjs --self-test   (prove the guard
+//          itself fails on seeded violations and passes a clean tree)
 
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 
 const forbiddenIncludes =
-  /^\s*#\s*include\s*[<"](nng\/|rxcpp\/|sqlite|rocksdb\/|kungfu\/runtime\/|kungfu\/longfist\/|kungfu\/yijinjing\/schema\/registry\.h|kungfu\/yijinjing\/practice\/|kungfu\/yijinjing\/cache\/|kungfu\/yijinjing\/index\/|kungfu\/yijinjing\/nanomsg\/|kungfu\/yijinjing\/socket\/|kungfu\/yijinjing\/io\.h|kungfu\/yijinjing\/rx\.h|kungfu\/yijinjing\/util\/|kungfu\/wingchun\/)/;
+  /^\s*#\s*include\s*[<"](nng\/|rxcpp\/|sqlite|rocksdb\/|leveldb\/|lmdb|duckdb|kungfu\/runtime\/|kungfu\/longfist\/|kungfu\/yijinjing\/schema\/registry\.h|kungfu\/yijinjing\/practice\/|kungfu\/yijinjing\/cache\/|kungfu\/yijinjing\/index\/|kungfu\/yijinjing\/nanomsg\/|kungfu\/yijinjing\/socket\/|kungfu\/yijinjing\/io\.h|kungfu\/yijinjing\/rx\.h|kungfu\/yijinjing\/util\/|kungfu\/wingchun\/)/;
 
 const forbiddenSymbols =
   /yijinjing::types::(Order|Trade|Position)|types::(Order|Trade|Position)[A-Za-z]*\b|LegacyCompiledTypes\b|LegacyCompiledDataTypes\b|LegacyCompiledTypeTags\b|wingchun/;
+
+// ADR-0040 boundary: concrete-engine APIs referenced as code, not as prose --
+// a namespace-qualified type or a C API call cannot appear in a legitimate
+// kernel comment, while "RocksDB" as a word can.
+const forbiddenEngineSymbols =
+  /rocksdb::|\bsqlite3_[a-z]|leveldb::|\bmdb_(env|txn|dbi)_|\bduckdb_[a-z]/;
+
+// Engine names on a live CMake line (comments stripped) mean a link/dependency
+// declaration; the kernel must not carry one.
+const forbiddenLinkTokens = /rocksdb|sqlite|leveldb|lmdb|duckdb/i;
 
 function* walk(dir) {
   if (!fs.existsSync(dir)) return;
@@ -39,9 +57,9 @@ function* walk(dir) {
   }
 }
 
-function scan(re) {
+function scan(re, dirs) {
   const hits = [];
-  for (const dir of [path.join(here, 'include'), path.join(here, 'src')]) {
+  for (const dir of dirs) {
     for (const file of walk(dir)) {
       let lines;
       try {
@@ -57,29 +75,140 @@ function scan(re) {
   return hits;
 }
 
-console.log(`yijinjing core dependency guard: ${here}`);
-
-let failed = false;
-
-const includeHits = scan(forbiddenIncludes);
-if (includeHits.length) {
-  console.log(includeHits.join('\n'));
-  console.error(
-    'FAIL: forbidden include found (runtime/transport/storage-engine/full registry)',
-  );
-  failed = true;
+function scanLinks(root) {
+  const hits = [];
+  for (const file of walk(root)) {
+    const base = path.basename(file);
+    if (base !== 'CMakeLists.txt' && !base.endsWith('.cmake')) continue;
+    let lines;
+    try {
+      lines = fs.readFileSync(file, 'utf8').split('\n');
+    } catch {
+      continue;
+    }
+    lines.forEach((line, i) => {
+      const code = line.replace(/#.*$/, '');
+      if (forbiddenLinkTokens.test(code)) hits.push(`${file}:${i + 1}:${line}`);
+    });
+  }
+  return hits;
 }
 
-const symbolHits = scan(forbiddenSymbols);
-if (symbolHits.length) {
-  console.log(symbolHits.join('\n'));
-  console.error(
-    'FAIL: forbidden symbol found (trading types / full runtime registry)',
-  );
-  failed = true;
+function runChecks(root) {
+  const dirs = [path.join(root, 'include'), path.join(root, 'src')];
+  return {
+    includeHits: scan(forbiddenIncludes, dirs),
+    symbolHits: scan(forbiddenSymbols, dirs),
+    engineSymbolHits: scan(forbiddenEngineSymbols, dirs),
+    linkHits: scanLinks(root),
+  };
 }
 
-if (failed) process.exit(1);
-console.log(
-  'OK: core includes only the schema leaf, storage contracts, hash, mmap and base utilities.',
-);
+function report(checks) {
+  let failed = false;
+  const cases = [
+    [
+      checks.includeHits,
+      'FAIL: forbidden include found (runtime/transport/storage-engine/full registry)',
+    ],
+    [
+      checks.symbolHits,
+      'FAIL: forbidden symbol found (trading types / full runtime registry)',
+    ],
+    [
+      checks.engineSymbolHits,
+      'FAIL: concrete storage-engine symbol found (ADR-0040: engines live in the provider layer)',
+    ],
+    [
+      checks.linkHits,
+      'FAIL: concrete storage-engine on a live CMake line (ADR-0040: the kernel links no engine)',
+    ],
+  ];
+  for (const [hits, message] of cases) {
+    if (hits.length) {
+      console.log(hits.join('\n'));
+      console.error(message);
+      failed = true;
+    }
+  }
+  return failed;
+}
+
+// Prove the guard itself: seed one violation per category into a synthetic
+// tree and require the corresponding check to catch it; require a clean tree
+// to pass. A guard that cannot fail is not a guarantee.
+function selfTest() {
+  const tmp = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'yjj-check-deps-selftest-'),
+  );
+  const write = (rel, text) => {
+    const p = path.join(tmp, rel);
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+    fs.writeFileSync(p, text);
+  };
+  const problems = [];
+  const expect = (label, ok) => {
+    console.log(`  ${ok ? 'ok' : 'MISS'}: ${label}`);
+    if (!ok) problems.push(label);
+  };
+  try {
+    write(
+      'include/kungfu/clean.h',
+      '#include <string>\n// prose may say rocksdb and sqlite\n',
+    );
+    write('src/clean.cpp', 'int clean = 0;\n');
+    write(
+      'CMakeLists.txt',
+      'add_library(yijinjing STATIC src/clean.cpp)\n' +
+        'target_link_libraries(yijinjing PUBLIC fmt::fmt) # never rocksdb or sqlite\n',
+    );
+    const clean = runChecks(tmp);
+    expect(
+      'clean tree passes (prose mentions of engines stay legal)',
+      !clean.includeHits.length &&
+        !clean.symbolHits.length &&
+        !clean.engineSymbolHits.length &&
+        !clean.linkHits.length,
+    );
+
+    write('include/kungfu/bad_include.h', '#include <rocksdb/db.h>\n');
+    write(
+      'src/bad_engine.cpp',
+      'rocksdb::DB *db = nullptr;\nint rc = sqlite3_open("f", &h);\n',
+    );
+    write('src/bad_trading.cpp', 'auto order = yijinjing::types::Order{};\n');
+    write(
+      'CMakeLists.txt',
+      'add_library(yijinjing STATIC src/bad_engine.cpp)\n' +
+        'target_link_libraries(yijinjing PUBLIC RocksDB::rocksdb)\n',
+    );
+    const seeded = runChecks(tmp);
+    expect('seeded engine include is caught', seeded.includeHits.length > 0);
+    expect(
+      'seeded engine symbols are caught',
+      seeded.engineSymbolHits.length >= 2,
+    );
+    expect('seeded trading symbol is caught', seeded.symbolHits.length > 0);
+    expect('seeded engine link is caught', seeded.linkHits.length > 0);
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+  if (problems.length) {
+    console.error(`FAIL: guard self-test missed: ${problems.join('; ')}`);
+    process.exit(1);
+  }
+  console.log(
+    'OK: guard self-test -- seeded violations fail, clean tree passes.',
+  );
+}
+
+if (process.argv.includes('--self-test')) {
+  console.log('yijinjing core dependency guard self-test');
+  selfTest();
+} else {
+  console.log(`yijinjing core dependency guard: ${here}`);
+  if (report(runChecks(here))) process.exit(1);
+  console.log(
+    'OK: core includes only the schema leaf, storage contracts, hash, mmap and base utilities.',
+  );
+}

--- a/framework/core/src/libyijinjing/include/kungfu/yijinjing/storage/content_store.h
+++ b/framework/core/src/libyijinjing/include/kungfu/yijinjing/storage/content_store.h
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef KUNGFU_YIJINJING_STORAGE_CONTENT_STORE_H
+#define KUNGFU_YIJINJING_STORAGE_CONTENT_STORE_H
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+
+#include <kungfu/yijinjing/storage/common.h>
+
+namespace kungfu::yijinjing::storage {
+
+// ADR-0040: the immutable content-addressed store is a runtime fact-ledger
+// primitive. This is the one first-class contract for write-once bodies
+// addressed by content hash -- manifests, snapshots, artifacts, arbitrary
+// blobs are uses of this store plus the journal, never bespoke per-scenario
+// stores. The interface belongs to yijinjing; concrete engine backends live
+// in the runtime/provider layer above and are injected through it, so callers
+// never program against a concrete engine. The kernel ships one
+// dependency-free default backend (file_content_store below).
+//
+// Content identity: the key of an object is the hash of its bytes under the
+// store's declared algorithm. Two writers proposing the same hash must
+// propose identical bytes, so put-if-absent has no logical overwrite
+// conflict; the backend still owns atomic publication, durability and
+// visibility, which it declares through content_store_capabilities.
+
+// Declared error categories. Every operation reports exactly one of these;
+// a backend must map its internal failures into this taxonomy instead of
+// leaking engine-specific errors through the contract.
+enum class content_store_error : uint8_t {
+  Ok = 0,
+  InvalidArgument,   // malformed namespace or digest, unsupported algorithm
+  HashMismatch,      // bytes do not hash to the digest the caller declared
+  NotFound,          // no object under this digest in the namespace
+  CorruptObject,     // stored bytes fail verification (torn or tampered)
+  SizeLimitExceeded, // object larger than the backend's declared limit
+  IoError,           // backend I/O failure (open/write/publish/read)
+};
+
+const char *content_store_error_name(content_store_error error);
+
+// Capability discovery (ADR-0040 decisions 3 and 7): a backend declares its
+// profile honestly so embedded and service-fronted implementations can differ
+// without smuggling local assumptions through the shared vocabulary. Callers
+// that need a guarantee check it here instead of assuming it.
+struct content_store_capabilities {
+  std::string profile = {}; // backend identity, e.g. "yijinjing-file/v1"
+  std::string hash_algorithm = CONTENT_HASH_ALGORITHM_SHA256;
+  uint64_t max_object_size = 0; // declared put limit in bytes; 0 = unbounded
+  bool atomic_put_if_absent = false;
+  bool verified_reads = false;  // get() re-hashes bytes before returning them
+  std::string durability = {};  // e.g. "fsync-on-publish", "os-buffered"
+  std::string visibility = {};  // e.g. "publish-then-visible"
+  std::string concurrency = {}; // e.g. "multi-writer-single-node"
+};
+
+struct content_store_result {
+  content_store_error error = content_store_error::Ok;
+  content_hash hash = {};   // the content identity, set on success
+  uint64_t byte_length = 0; // size of the object the result refers to
+  bool existed = false;     // put_if_absent: the object was already present
+  std::string message = {}; // human-readable diagnostic, edge only
+
+  [[nodiscard]] bool ok() const { return error == content_store_error::Ok; }
+};
+
+struct content_get_result {
+  content_store_error error = content_store_error::Ok;
+  content_hash hash = {};
+  std::string bytes = {}; // filled only when error == Ok
+  std::string message = {};
+
+  [[nodiscard]] bool ok() const { return error == content_store_error::Ok; }
+};
+
+// Namespaces partition one store into independent object families (payloads,
+// snapshots, ...) without changing content identity inside each family.
+// A valid namespace is 1..64 chars of [a-z0-9_-].
+[[nodiscard]] bool is_valid_content_namespace(const std::string &content_namespace);
+
+class content_store {
+public:
+  virtual ~content_store() = default;
+
+  [[nodiscard]] virtual content_store_capabilities capabilities() const = 0;
+
+  // Publish bytes under their content hash if no object with that identity
+  // exists yet. When `expected` is non-empty the bytes must hash to it or the
+  // put is rejected with HashMismatch and nothing is stored. When the object
+  // already exists the put succeeds with existed=true; presence plus length
+  // is the dedup fast path, full byte verification is what verify() is for.
+  [[nodiscard]] virtual content_store_result put_if_absent(const std::string &content_namespace, const void *data,
+                                                           size_t size, const content_hash &expected = {}) = 0;
+
+  [[nodiscard]] content_store_result put_if_absent(const std::string &content_namespace, const std::string &bytes,
+                                                   const content_hash &expected = {}) {
+    return put_if_absent(content_namespace, bytes.data(), bytes.size(), expected);
+  }
+
+  [[nodiscard]] virtual bool has(const std::string &content_namespace, const content_hash &hash) const = 0;
+
+  // Re-hash the stored bytes and compare against the digest. A torn or
+  // tampered object reports CorruptObject and never verifies.
+  [[nodiscard]] virtual content_store_result verify(const std::string &content_namespace,
+                                                    const content_hash &hash) const = 0;
+
+  // Verified read: bytes are returned only after they re-hash to the digest,
+  // so a caller can never observe corrupt content through get().
+  [[nodiscard]] virtual content_get_result get(const std::string &content_namespace,
+                                               const content_hash &hash) const = 0;
+};
+
+struct file_content_store_options {
+  std::string hash_algorithm = CONTENT_HASH_ALGORITHM_SHA256;
+  uint64_t max_object_size = 0; // 0 = no declared limit
+  bool fsync_on_publish = true; // fsync object bytes (and dir, POSIX) before publish
+};
+
+// The dependency-free default backend: a file-based content-addressed store
+// over std::filesystem, so the yijinjing content store works standalone with
+// zero heavy dependencies. Layout per namespace follows the ADR-0037 payload
+// layout -- <root>/<namespace>/<digest[0:2]>/<digest>, bare lowercase hex,
+// no extension -- so with root <runtime>/storage and namespace "payloads" it
+// is byte-compatible with the existing payload tree.
+//
+// Atomic publish: bytes are written to a temp file under
+// <root>/<namespace>/tmp/ and renamed onto the final path, so a torn write is
+// never visible under a content digest; a crash leaves only temp residue that
+// lookups can never observe. Concurrent writers of the same content race on
+// the rename at worst, and every rename publishes identical verified bytes.
+class file_content_store : public content_store {
+public:
+  explicit file_content_store(std::string root_dir, file_content_store_options options = {});
+
+  [[nodiscard]] std::string root_dir() const { return root_dir_; }
+
+  [[nodiscard]] content_store_capabilities capabilities() const override;
+
+  [[nodiscard]] content_store_result put_if_absent(const std::string &content_namespace, const void *data, size_t size,
+                                                   const content_hash &expected = {}) override;
+  using content_store::put_if_absent;
+
+  [[nodiscard]] bool has(const std::string &content_namespace, const content_hash &hash) const override;
+
+  [[nodiscard]] content_store_result verify(const std::string &content_namespace,
+                                            const content_hash &hash) const override;
+
+  [[nodiscard]] content_get_result get(const std::string &content_namespace, const content_hash &hash) const override;
+
+  // The final path an object with this identity lives at; for tooling and
+  // fixtures, not a read path (get() is the read path).
+  [[nodiscard]] std::string object_path(const std::string &content_namespace, const content_hash &hash) const;
+
+private:
+  std::string root_dir_;
+  file_content_store_options options_;
+};
+
+} // namespace kungfu::yijinjing::storage
+
+#endif // KUNGFU_YIJINJING_STORAGE_CONTENT_STORE_H

--- a/framework/core/src/libyijinjing/src/storage/content_store.cpp
+++ b/framework/core/src/libyijinjing/src/storage/content_store.cpp
@@ -1,0 +1,382 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#include <kungfu/yijinjing/storage/content_store.h>
+
+#include <atomic>
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <stdexcept>
+#include <system_error>
+#include <utility>
+
+#include <kungfu/yijinjing/storage/content_hash.h>
+
+#ifdef _WINDOWS
+#include <io.h>
+#include <process.h>
+#else
+#include <fcntl.h>
+#include <unistd.h>
+#endif
+
+namespace kungfu::yijinjing::storage {
+
+namespace {
+
+namespace fs = std::filesystem;
+
+constexpr const char *FILE_STORE_PROFILE = "yijinjing-file/v1";
+constexpr const char *TEMP_DIR_NAME = "tmp";
+constexpr size_t SHA256_HEX_LENGTH = 64;
+constexpr size_t DIGEST_PREFIX_LENGTH = 2;
+constexpr size_t MAX_NAMESPACE_LENGTH = 64;
+
+bool is_lower_hex(const std::string &value) {
+  for (const char c : value) {
+    if ((c < '0' || c > '9') && (c < 'a' || c > 'f')) {
+      return false;
+    }
+  }
+  return !value.empty();
+}
+
+int current_pid() {
+#ifdef _WINDOWS
+  return _getpid();
+#else
+  return static_cast<int>(::getpid());
+#endif
+}
+
+uint64_t next_temp_sequence() {
+  static std::atomic<uint64_t> sequence{0};
+  return sequence.fetch_add(1, std::memory_order_relaxed) + 1;
+}
+
+bool flush_to_disk(std::FILE *file) {
+  if (std::fflush(file) != 0) {
+    return false;
+  }
+#ifdef _WINDOWS
+  return _commit(_fileno(file)) == 0;
+#else
+  return ::fsync(fileno(file)) == 0;
+#endif
+}
+
+// Publication is only durable once the directory entry is too; best-effort on
+// platforms without directory fsync.
+void sync_directory(const fs::path &dir) {
+#ifndef _WINDOWS
+  const int fd = ::open(dir.c_str(), O_RDONLY);
+  if (fd >= 0) {
+    ::fsync(fd);
+    ::close(fd);
+  }
+#else
+  (void)dir;
+#endif
+}
+
+// Validate a caller-supplied digest against the store's algorithm without
+// throwing across the contract; failures land in the declared error taxonomy.
+content_store_error check_digest(const content_hash &hash, const std::string &store_algorithm, std::string &message) {
+  std::string normalized;
+  try {
+    normalized = normalize_content_hash_algorithm(hash.algorithm);
+  } catch (const std::invalid_argument &e) {
+    message = e.what();
+    return content_store_error::InvalidArgument;
+  }
+  if (normalized != store_algorithm) {
+    message = "digest algorithm " + normalized + " does not match store algorithm " + store_algorithm;
+    return content_store_error::InvalidArgument;
+  }
+  if (hash.value.size() != SHA256_HEX_LENGTH || !is_lower_hex(hash.value)) {
+    message = "digest value must be " + std::to_string(SHA256_HEX_LENGTH) + " lowercase hex chars";
+    return content_store_error::InvalidArgument;
+  }
+  return content_store_error::Ok;
+}
+
+content_store_error read_file_bytes(const fs::path &path, std::string &bytes, std::string &message) {
+  std::error_code ec;
+  if (!fs::exists(path, ec)) {
+    message = "no object at " + path.string();
+    return content_store_error::NotFound;
+  }
+  std::ifstream stream(path, std::ios::binary);
+  if (!stream) {
+    message = "cannot open " + path.string();
+    return content_store_error::IoError;
+  }
+  std::ostringstream buffer;
+  buffer << stream.rdbuf();
+  if (stream.bad()) {
+    message = "read failed for " + path.string();
+    return content_store_error::IoError;
+  }
+  bytes = buffer.str();
+  return content_store_error::Ok;
+}
+
+} // namespace
+
+const char *content_store_error_name(content_store_error error) {
+  switch (error) {
+  case content_store_error::Ok:
+    return "ok";
+  case content_store_error::InvalidArgument:
+    return "invalid_argument";
+  case content_store_error::HashMismatch:
+    return "hash_mismatch";
+  case content_store_error::NotFound:
+    return "not_found";
+  case content_store_error::CorruptObject:
+    return "corrupt_object";
+  case content_store_error::SizeLimitExceeded:
+    return "size_limit_exceeded";
+  case content_store_error::IoError:
+    return "io_error";
+  }
+  return "unknown";
+}
+
+bool is_valid_content_namespace(const std::string &content_namespace) {
+  if (content_namespace.empty() || content_namespace.size() > MAX_NAMESPACE_LENGTH) {
+    return false;
+  }
+  for (const char c : content_namespace) {
+    const bool ok = (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '_' || c == '-';
+    if (!ok) {
+      return false;
+    }
+  }
+  return true;
+}
+
+file_content_store::file_content_store(std::string root_dir, file_content_store_options options)
+    : root_dir_(std::move(root_dir)), options_(std::move(options)) {
+  if (root_dir_.empty()) {
+    throw std::invalid_argument("file_content_store: root_dir is empty");
+  }
+  // fail fast at construction instead of per operation
+  options_.hash_algorithm = normalize_content_hash_algorithm(options_.hash_algorithm);
+}
+
+content_store_capabilities file_content_store::capabilities() const {
+  content_store_capabilities caps{};
+  caps.profile = FILE_STORE_PROFILE;
+  caps.hash_algorithm = options_.hash_algorithm;
+  caps.max_object_size = options_.max_object_size;
+  caps.atomic_put_if_absent = true;
+  caps.verified_reads = true;
+  caps.durability = options_.fsync_on_publish ? "fsync-on-publish" : "os-buffered";
+  caps.visibility = "publish-then-visible";
+  caps.concurrency = "multi-writer-single-node";
+  return caps;
+}
+
+std::string file_content_store::object_path(const std::string &content_namespace, const content_hash &hash) const {
+  if (!is_valid_content_namespace(content_namespace)) {
+    throw std::invalid_argument("invalid content namespace: " + content_namespace);
+  }
+  std::string message;
+  if (check_digest(hash, options_.hash_algorithm, message) != content_store_error::Ok) {
+    throw std::invalid_argument(message);
+  }
+  const auto path = fs::path(root_dir_) / content_namespace / hash.value.substr(0, DIGEST_PREFIX_LENGTH) / hash.value;
+  return path.string();
+}
+
+content_store_result file_content_store::put_if_absent(const std::string &content_namespace, const void *data,
+                                                       size_t size, const content_hash &expected) {
+  content_store_result result{};
+  if (!is_valid_content_namespace(content_namespace)) {
+    result.error = content_store_error::InvalidArgument;
+    result.message = "invalid content namespace: " + content_namespace;
+    return result;
+  }
+  if (size > 0 && data == nullptr) {
+    result.error = content_store_error::InvalidArgument;
+    result.message = "null data with non-zero size";
+    return result;
+  }
+  if (options_.max_object_size > 0 && size > options_.max_object_size) {
+    result.error = content_store_error::SizeLimitExceeded;
+    result.message = "object of " + std::to_string(size) + " bytes exceeds declared limit of " +
+                     std::to_string(options_.max_object_size);
+    return result;
+  }
+  const auto digest = compute_content_hash(data, size, options_.hash_algorithm);
+  if (!expected.empty()) {
+    result.error = check_digest(expected, options_.hash_algorithm, result.message);
+    if (result.error != content_store_error::Ok) {
+      return result;
+    }
+    if (expected.value != digest.value) {
+      result.error = content_store_error::HashMismatch;
+      result.message = "bytes hash to " + digest.value + ", caller declared " + expected.value;
+      return result;
+    }
+  }
+  result.hash = digest;
+  result.byte_length = size;
+
+  const fs::path final_path = object_path(content_namespace, digest);
+  std::error_code ec;
+  if (fs::exists(final_path, ec)) {
+    const auto stored_size = fs::file_size(final_path, ec);
+    if (ec) {
+      result.error = content_store_error::IoError;
+      result.message = "cannot stat existing object: " + ec.message();
+      return result;
+    }
+    if (stored_size != size) {
+      result.error = content_store_error::CorruptObject;
+      result.message = "existing object holds " + std::to_string(stored_size) + " bytes, content is " +
+                       std::to_string(size) + " bytes; run verify";
+      return result;
+    }
+    result.existed = true;
+    return result;
+  }
+
+  const fs::path temp_dir = fs::path(root_dir_) / content_namespace / TEMP_DIR_NAME;
+  fs::create_directories(temp_dir, ec);
+  if (ec) {
+    result.error = content_store_error::IoError;
+    result.message = "cannot create temp dir: " + ec.message();
+    return result;
+  }
+  fs::create_directories(final_path.parent_path(), ec);
+  if (ec) {
+    result.error = content_store_error::IoError;
+    result.message = "cannot create object dir: " + ec.message();
+    return result;
+  }
+
+  const auto temp_name =
+      digest.value.substr(0, 16) + "." + std::to_string(current_pid()) + "." + std::to_string(next_temp_sequence());
+  const fs::path temp_path = temp_dir / temp_name;
+  const auto discard_temp = [&temp_path]() {
+    std::error_code ignored;
+    fs::remove(temp_path, ignored);
+  };
+
+  std::FILE *file = std::fopen(temp_path.string().c_str(), "wb");
+  if (file == nullptr) {
+    result.error = content_store_error::IoError;
+    result.message = "cannot open temp file " + temp_path.string();
+    return result;
+  }
+  if (size > 0 && std::fwrite(data, 1, size, file) != size) {
+    std::fclose(file);
+    discard_temp();
+    result.error = content_store_error::IoError;
+    result.message = "short write to temp file";
+    return result;
+  }
+  if (options_.fsync_on_publish && !flush_to_disk(file)) {
+    std::fclose(file);
+    discard_temp();
+    result.error = content_store_error::IoError;
+    result.message = "cannot flush temp file to disk";
+    return result;
+  }
+  if (std::fclose(file) != 0) {
+    discard_temp();
+    result.error = content_store_error::IoError;
+    result.message = "cannot close temp file";
+    return result;
+  }
+
+  fs::rename(temp_path, final_path, ec);
+  if (ec) {
+    // Windows refuses to rename onto an existing file: a concurrent writer
+    // published the identical bytes first, which under content identity is
+    // this put succeeding as a dedup hit.
+    std::error_code probe;
+    if (fs::exists(final_path, probe)) {
+      discard_temp();
+      result.existed = true;
+      return result;
+    }
+    discard_temp();
+    result.error = content_store_error::IoError;
+    result.message = "cannot publish object: " + ec.message();
+    return result;
+  }
+  if (options_.fsync_on_publish) {
+    sync_directory(final_path.parent_path());
+  }
+  return result;
+}
+
+bool file_content_store::has(const std::string &content_namespace, const content_hash &hash) const {
+  if (!is_valid_content_namespace(content_namespace)) {
+    return false;
+  }
+  std::string message;
+  if (check_digest(hash, options_.hash_algorithm, message) != content_store_error::Ok) {
+    return false;
+  }
+  std::error_code ec;
+  return fs::exists(object_path(content_namespace, hash), ec);
+}
+
+content_store_result file_content_store::verify(const std::string &content_namespace, const content_hash &hash) const {
+  content_store_result result{};
+  if (!is_valid_content_namespace(content_namespace)) {
+    result.error = content_store_error::InvalidArgument;
+    result.message = "invalid content namespace: " + content_namespace;
+    return result;
+  }
+  result.error = check_digest(hash, options_.hash_algorithm, result.message);
+  if (result.error != content_store_error::Ok) {
+    return result;
+  }
+  result.hash = make_content_hash(hash.value, options_.hash_algorithm);
+  std::string bytes;
+  result.error = read_file_bytes(object_path(content_namespace, result.hash), bytes, result.message);
+  if (result.error != content_store_error::Ok) {
+    return result;
+  }
+  result.byte_length = bytes.size();
+  if (!verify_content_hash(bytes, result.hash)) {
+    result.error = content_store_error::CorruptObject;
+    result.message = "stored bytes do not hash to " + result.hash.value;
+    return result;
+  }
+  return result;
+}
+
+content_get_result file_content_store::get(const std::string &content_namespace, const content_hash &hash) const {
+  content_get_result result{};
+  if (!is_valid_content_namespace(content_namespace)) {
+    result.error = content_store_error::InvalidArgument;
+    result.message = "invalid content namespace: " + content_namespace;
+    return result;
+  }
+  result.error = check_digest(hash, options_.hash_algorithm, result.message);
+  if (result.error != content_store_error::Ok) {
+    return result;
+  }
+  result.hash = make_content_hash(hash.value, options_.hash_algorithm);
+  std::string bytes;
+  result.error = read_file_bytes(object_path(content_namespace, result.hash), bytes, result.message);
+  if (result.error != content_store_error::Ok) {
+    return result;
+  }
+  if (!verify_content_hash(bytes, result.hash)) {
+    result.error = content_store_error::CorruptObject;
+    result.message = "stored bytes do not hash to " + result.hash.value;
+    return result;
+  }
+  result.bytes = std::move(bytes);
+  return result;
+}
+
+} // namespace kungfu::yijinjing::storage

--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -721,6 +721,19 @@ function main() {
       if (guard.status === 0) pass('yijinjing dependency guard', 'check-deps');
       else fail('yijinjing dependency guard', tail3(guard));
 
+      // ADR-0040: the guard itself must demonstrably fail on a seeded
+      // engine include/symbol/link; a guard that cannot fail is not a gate.
+      const guardSelfTest = spawnSync(
+        process.execPath,
+        [guardMjs, '--self-test'],
+        {
+          encoding: 'utf8',
+        },
+      );
+      if (guardSelfTest.status === 0)
+        pass('yijinjing dependency guard self-test', 'seeded violations fail');
+      else fail('yijinjing dependency guard self-test', tail3(guardSelfTest));
+
       // ADR-0039: all FlatBuffers/reflection access is confined to kungfu::view.
       const viewGuardMjs = path.join(
         core,


### PR DESCRIPTION
ADR-0040 first delivery, kernel side: immutable content_store contract in libyijinjing (put-if-absent / get / has / verify, error taxonomy, size-limit semantics, capability discovery) with a dependency-free file backend (atomic tmp+rename publish, ADR-0037 payload layout), extended dependency guard (engine symbols, CMake links, seeded --self-test) wired into verify stage 5, and a content-store capability slice proving the four obligations plus single-node concurrent dedup across threads and processes.