### PR TITLE
test(episode): gate verify with qualification smoke

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,9 @@ layout, and code style.
 `check` is the source-quality gate for changed files plus shared type/tooling
 tests. `check:all` exists for whole-tree cleanup once the lint baseline is clean.
 `verify` is the runtime/product done-check: it asserts the build artifacts and
-runs a `kungfu` runtime smoke, rather than trusting a "looks built" impression.
+runs a `kungfu` runtime smoke plus the `mvp-smoke-v1` Episode qualification,
+rather than trusting a "looks built" impression. The larger Episode baseline
+remains an explicit periodic/release-readiness command.
 
 ## Proposing changes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,6 +79,11 @@ cd kungfu
 `./kungfu-code <task>` runs `<task>` under the pinned Node toolchain — it is a
 thin wrapper, so any pnpm task works (`./kungfu-code build:core`, etc.).
 
+`./kungfu-code verify` includes the bounded `mvp-smoke-v1` Episode
+qualification by default. Use `./kungfu-code episode:qualify -- --profile
+mvp-baseline-v1` explicitly for the heavier periodic/release-readiness
+baseline; it is not run on every build.
+
 > Node, packages, and Electron binaries are resolved through the standard
 > `FNM_NODE_DIST_MIRROR`, `COREPACK_NPM_REGISTRY`, and `ELECTRON_MIRROR`
 > environment variables; set these to point at a specific mirror if needed.

--- a/docs/episode-atomicity-qualification.md
+++ b/docs/episode-atomicity-qualification.md
@@ -14,7 +14,7 @@ ai_provenance:
   product: Codex
   generated_at: 2026-07-10
   visible_context: ADR-0042 design discussion, current Episode v1 implementation/tests, and Kungfu fuzz/verification conventions
-  invisible_context_boundary: No qualification harness or industrial-scale run exists yet; numerical envelopes are planning targets, not measured capacity
+  invisible_context_boundary: The current harness and first local single-node baselines are visible; no multi-platform CI result, fleet-scale run, payload-volume qualification, or industrial soak is available yet
 ---
 
 # Episode Atomicity Qualification
@@ -327,6 +327,13 @@ payload profile: metadata-only
 The baseline may be split into separate invocations when runtime is long, but
 each report must retain the exact profile, seed, source revision, and completed
 scenario list.
+
+As of 2026-07-10, `./kungfu-code verify` runs `mvp-smoke-v1` by default. The
+declared Buildchain `verify` lifecycle and the alpha/release `verify --fuzz`
+workflow therefore inherit the same Episode correctness gate. The explicit
+`--skip-episode-qualification` option is for local diagnosis; checked-in
+Buildchain commands do not use it. `mvp-baseline-v1` remains an explicit
+periodic or release-readiness qualification rather than a per-build workload.
 
 ### v0 correctness and progress gates
 

--- a/framework/core/tests/qualification/episode/README.md
+++ b/framework/core/tests/qualification/episode/README.md
@@ -34,6 +34,18 @@ The default report path is a retained temporary directory printed at the end of
 the run. Runtime homes are removed after their fresh-process probes unless
 `--keep-runtime` is supplied.
 
+## Build-chain gate
+
+`./kungfu-code verify` runs `mvp-smoke-v1` by default after checking the built
+runtime artifacts. This means both the declared Buildchain `verify` lifecycle
+and the alpha/release `verify --fuzz` workflow fail when the smoke profile
+fails. `--skip-episode-qualification` is an explicit local diagnostic escape
+hatch; the checked-in Buildchain and alpha/release commands do not use it.
+
+`mvp-baseline-v1` is intentionally not a per-build gate. Run its 100k
+accumulation and 10k contention workloads explicitly for periodic or
+release-readiness qualification.
+
 ## Result boundary
 
 The v0 profiles are metadata-only: each independent Episode contains exactly

--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -14,6 +14,9 @@
 //   ./kungfu-code verify --fuzz       add the kungfu::view libFuzzer long-run (ADR-0039 memory safety); needs a
 //                                     libFuzzer-capable clang (brew LLVM on macOS, system clang on Linux). The
 //                                     alpha/release build passes this; a new crash blocks the build.
+//   ./kungfu-code verify --skip-episode-qualification
+//                                     diagnostic-only escape hatch; the default verify path runs the
+//                                     mvp-smoke-v1 Episode qualification profile.
 //   ./kungfu-code verify --help
 //
 // Assertion targets (all grounded in the build scripts, not guessed):
@@ -32,6 +35,7 @@ import { spawnSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import fs from 'node:fs';
 import { createRequire } from 'node:module';
+import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -66,6 +70,7 @@ if (args.includes('--help') || args.includes('-h')) {
 }
 const doFull = args.includes('--full');
 const withApp = args.includes('--with-app');
+const skipEpisodeQualification = args.includes('--skip-episode-qualification');
 // --fuzz adds the libFuzzer long-run tier (needs a libFuzzer-capable clang); the
 // alpha/release build passes it. The lightweight ASan/UBSan corpus replay runs
 // whenever the memory-safety stage runs (full or fuzz).
@@ -156,13 +161,98 @@ function runPnpm(task) {
   }
 }
 
+function runEpisodeQualificationSmoke() {
+  console.log('\n[verify] stage 3b: Episode qualification (mvp-smoke-v1)');
+  if (skipEpisodeQualification) {
+    console.log(
+      '  (skipped: explicitly requested with --skip-episode-qualification; Buildchain and alpha/release do not use this bypass)',
+    );
+    return;
+  }
+
+  const harness = path.join(
+    ROOT,
+    'framework',
+    'core',
+    'tests',
+    'qualification',
+    'episode',
+    'run.mjs',
+  );
+  const runRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'kf-verify-episode-'));
+  const reportPath = path.join(runRoot, 'episode-trust-report.json');
+  const smoke = spawnSync(
+    process.execPath,
+    [harness, '--profile', 'mvp-smoke-v1', '--report', reportPath],
+    {
+      cwd: ROOT,
+      encoding: 'utf8',
+      timeout: 5 * 60 * 1000,
+      maxBuffer: 10 * 1024 * 1024,
+    },
+  );
+  const tail = outputTail(smoke.stdout, smoke.stderr, 8);
+  if (smoke.error || smoke.status !== 0) {
+    const processDetail = smoke.error
+      ? `${smoke.error.code || smoke.error.message}`
+      : `exit ${exitLabel(smoke.status, smoke.signal)}`;
+    fail(
+      'Episode qualification smoke',
+      `${processDetail}; report/runtime retained under ${runRoot}${tail ? `; tail: ${tail}` : ''}`,
+    );
+    return;
+  }
+
+  try {
+    const report = JSON.parse(fs.readFileSync(reportPath, 'utf8'));
+    const scenarios = report?.workload?.scenarios || [];
+    const scenariosPassed = scenarios.filter((scenario) => scenario.ok).length;
+    if (
+      report?.schema !== 'kungfu.episode.trust-report/v1' ||
+      report?.profile !== 'mvp-smoke-v1' ||
+      scenarios.length === 0 ||
+      scenariosPassed !== scenarios.length
+    ) {
+      fail(
+        'Episode qualification smoke',
+        `unexpected Trust Report contract; report retained at ${reportPath}`,
+      );
+      return;
+    }
+    if (process.env.CI && report.qualified !== true) {
+      fail(
+        'Episode qualification smoke',
+        `CI requires a clean-source qualified Trust Report; report retained at ${reportPath}`,
+      );
+      return;
+    }
+    const busy = report.performance?.scenarios
+      ?.flatMap((scenario) => scenario.writers || [])
+      .reduce(
+        (total, writer) =>
+          total + (writer.operations?.manifest_writer_busy || 0),
+        0,
+      );
+    pass(
+      'Episode qualification smoke',
+      `${scenariosPassed}/${scenarios.length} scenarios; busy=${busy || 0}; qualified=${String(report.qualified)}`,
+    );
+    fs.rmSync(runRoot, { recursive: true, force: true });
+  } catch (error) {
+    fail(
+      'Episode qualification smoke',
+      `invalid or missing Trust Report at ${reportPath}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
 function main() {
   const version = expectedVersion();
   console.log(
     `[verify] kungfu build-chain verification — expected version ${version}`,
   );
   console.log(
-    `[verify] mode: ${doFull ? 'full (build first)' : 'quick (assert existing artifacts only)'}${withApp ? ' + app' : ''}`,
+    `[verify] mode: ${doFull ? 'full (build first)' : 'quick (assert existing artifacts only)'}${withApp ? ' + app' : ''}${skipEpisodeQualification ? ' - Episode qualification' : ' + Episode qualification'}`,
   );
 
   // ── Stage 0a: cross-platform script guard (read-only) ─────────────
@@ -628,6 +718,8 @@ function main() {
     fail('kungfu skill contract smoke', 'no kungfu executable, skipped');
     fail('kungfu contract registry smoke', 'no kungfu executable, skipped');
   }
+
+  runEpisodeQualificationSmoke();
 
   // ── Stage 4: (optional) app build artifact ────────────────────────
   if (withApp) {


### PR DESCRIPTION
## Summary

- run the versioned `mvp-smoke-v1` Episode qualification from `verify` by default
- retain failed Trust Reports, enforce clean-source qualification in CI, and expose an explicit local diagnostic skip
- keep the 100k accumulation and 10k contention baseline outside the per-build path

## Validation

- `./kungfu-code check`
- `./kungfu-code build:core`
- `./kungfu-code freeze`
- clean-source `CI=1 ./kungfu-code verify`: Episode qualification 5/5, `qualified=true`
- dirty-source CI negative test: Episode stage blocks as designed
- checked-in Buildchain/workflow commands contain no Episode skip

## Known baseline

The full verify summary remains red on five pre-existing mypy errors in `master_service.py` and `sources/store.py`; the new Episode stage itself passes.

## Version impact

Patch-level verification and documentation change; no Episode runtime contract change.