### PR TITLE
feat(episode): resolve payload refs through the content store

### DIFF
--- a/framework/core/docs/episode-manifest-trust-boundary.md
+++ b/framework/core/docs/episode-manifest-trust-boundary.md
@@ -31,7 +31,7 @@ Mapping each ADR-0033 trust-boundary claim onto that record set:
 | Manifest version | `schema_version` (u32) present on every record; store-level constant `kungfu.episode.manifest/v1` | representable |
 | open / sealed / tombstoned status | presence of `EpisodeOpen` = open; `EpisodeClosed.status` ∈ {Ended, Aborted, Tombstoned}. Tombstone is a later `EpisodeClosed` append with `status=Tombstoned`, never an in-place edit | representable (fold rule §2.3) |
 | frame membership | one `EpisodeFrameAttached` per frame, id-level (`frame_uid`), carrying the frame receipt (checksums, integrity version, stream, times). Range-compressed membership is a future optimization, not required for the claim | representable |
-| payload inventory + content hashes | `EpisodeRefAttached` with `ref_kind=Payload`; `ref_id` is the payload address (today a runtime-dir-relative path, later a content-store key), `ref_hash` the content hash. Convention: `ref_hash` is `<algo>:<hex>` (e.g. `sha256:...`), consistent with current producers (`episode_lifecycle.attach_payload_ref`). Per-frame payload checksums additionally live on `EpisodeFrameAttached.payload_checksum` | representable; hash-algo prefix is a producer convention, not a schema change |
+| payload inventory + content hashes | `EpisodeRefAttached` with `ref_kind=Payload`; `ref_hash` is the content identity and the resolution key: fsck resolves the ref through the ADR-0040 immutable `content_store` (namespace `payloads`) by this hash; `ref_id` is an edge label recording the bytes' runtime-relative origin, with no resolution role. Canonical `ref_hash` form is `<algo>:<hex>` (e.g. `sha256:...`, written by `episode_lifecycle.attach_payload_ref`); bare hex from earlier producers is accepted as the store's default algorithm. Per-frame payload checksums additionally live on `EpisodeFrameAttached.payload_checksum` | representable; hash-algo prefix is a producer convention, not a schema change |
 | schema inventory | `EpisodeRefAttached` with `ref_kind=Schema` (`ref_id` = schema id, `ref_hash` = `.bfbs` content hash) | representable |
 | source and location provenance | `EpisodeOpen.source` / `actor` / `title`; `location_uid` on every record | representable |
 | declared dependency Episode ids | `EpisodeOpen.parent_episode_id` plus `EpisodeRefAttached` with `ref_kind=Episode` (`ref_uid` = episode id, optional `ref_id`/`ref_hash` for externally-held Episodes) | representable |
@@ -44,9 +44,9 @@ Conclusion required by ADR-0041: the existing record set is sufficient for
 every claim this slice needs. The single not-representable claim (Episode
 hash/sync roots) is exactly the deep-identity surface ADR-0041 already
 defers to a later identity/schema decision; ADR-0042 does not select that root,
-and nothing in stages 1–3 and 5 depends on it. Content-ref resolution (stage 4)
-depends on ADR-0040's immutable `content_store` landing first and changes no
-record layout.
+and nothing in stages 1–3 and 5 depends on it. Content-ref resolution (stage 4,
+delivered) resolves through ADR-0040's immutable `content_store` and changed
+no record layout.
 
 ## 2. Deterministic typed fold (stage 1 semantics)
 
@@ -169,8 +169,9 @@ one atomic write. The contract orders them so a crash can only ever leave a
 record event      1) append event frame (event journal, durable receipt)
                   2) append EpisodeFrameAttached (manifest journal)
 
-attach payload    1) publish payload bytes (stage 4: content_store
-                     put-if-absent; today: provider payload write)
+attach payload    1) publish payload bytes through the content store
+                     (put-if-absent; the file provider's payload write is
+                     this publish)
                   2) append EpisodeRefAttached claiming id + hash
 
 seal              1) verify every claim this writer made is durable
@@ -239,8 +240,14 @@ C4. Episodes owned by other locations are reported, never mutated.
    fields, recomputed payload/frame checksums (ADR-0023/0028) — failing a
    sealed Episode and degrading an open one, with the exact missing side
    reported.
-4. **Content resolution** — blocked on ADR-0040 `content_store` (interface +
-   file backend); replaces the bespoke `payload_ref_exists` path probe.
+4. **Content resolution** (delivered) — payload refs resolve through the
+   ADR-0040 immutable `content_store` by `ref_hash` (verified read, full
+   error taxonomy: missing / hash-mismatch / unaddressable / io), replacing
+   the bespoke `payload_ref_exists` path probe. An unverified payload ref
+   fails a sealed Episode and degrades an open one, mirroring the frame
+   verification severity; producers publish bytes via content-store
+   put-if-absent before appending the ref. Schema refs stay declared-only
+   until schemas live in the store.
 5. **Projection/query** (delivered) — rebuildable Episode SQLite projection
    (`storage/projections/episode-manifest.sqlite`) over the typed record
    stream via `cache::make_storage_ptr` on `EpisodeManifestDataTypes`, the

--- a/framework/core/src/libkungfu/src/runtime/storage/service.cpp
+++ b/framework/core/src/libkungfu/src/runtime/storage/service.cpp
@@ -21,6 +21,7 @@
 #include <kungfu/runtime/storage/episode_manifest_projection.h>
 #include <kungfu/runtime/storage/source_registry_projection.h>
 #include <kungfu/yijinjing/storage/content_hash.h>
+#include <kungfu/yijinjing/storage/content_store.h>
 #include <kungfu/yijinjing/storage/episode_manifest.h>
 #include <kungfu/yijinjing/storage/generic_service.h>
 #include <kungfu/yijinjing/storage/source_registry.h>
@@ -603,7 +604,16 @@ public:
   }
 
   void write_payload(const std::string &digest, const std::string &raw) const override {
-    write_bytes(payload_path(runtime_dir_, digest), raw);
+    // ADR-0040: publish through the immutable content store (atomic
+    // tmp+rename, digest checked against the bytes) instead of a bare file
+    // write; the store's layout is byte-compatible with payload_path.
+    yy_storage::file_content_store store(root_dir(runtime_dir_).string());
+    const auto result = store.put_if_absent("payloads", raw, yy_storage::make_content_hash(digest));
+    if (!result.ok()) {
+      throw std::runtime_error("failed to publish payload " + digest + ": " +
+                               yy_storage::content_store_error_name(result.error) +
+                               (result.message.empty() ? "" : " (" + result.message + ")"));
+    }
   }
 
   [[nodiscard]] std::vector<stored_payload> all_payloads() const override {
@@ -1806,7 +1816,7 @@ nlohmann::json repair_candidate_from_warning(const nlohmann::json &warning) {
                                    "fetch_frame_or_declare_external_input",
                                    nlohmann::json::array({"source_or_episode_bundle"}));
   }
-  if (code == "episode_payload_ref_missing") {
+  if (code == "episode_payload_ref_missing" || code == "episode_payload_ref_hash_mismatch") {
     return repair_candidate_common(warning, "repair_episode_payload_ref", "payload", "payload_ref",
                                    "fetch_payload_by_hash", nlohmann::json::array({"payload_store_or_episode_bundle"}));
   }
@@ -1832,6 +1842,15 @@ nlohmann::json repair_plan_impl(const storage_service_options &options) {
     if (candidate.is_null()) {
       unsupported.push_back(warning);
     } else {
+      candidates.push_back(candidate);
+    }
+  }
+  // Sealed-Episode payload-ref issues are errors (the seal is falsified), and
+  // they are exactly the issues repair material can satisfy; other error
+  // codes are structural manifest defects, not fetchable facts.
+  for (const auto &error : array_or_empty(report, "errors")) {
+    const auto candidate = repair_candidate_from_warning(error);
+    if (!candidate.is_null()) {
       candidates.push_back(candidate);
     }
   }

--- a/framework/core/src/libyijinjing/src/storage/episode_manifest.cpp
+++ b/framework/core/src/libyijinjing/src/storage/episode_manifest.cpp
@@ -11,6 +11,8 @@
 #include <kungfu/yijinjing/common.h>
 #include <kungfu/yijinjing/hash.h>
 #include <kungfu/yijinjing/journal/journal.h>
+#include <kungfu/yijinjing/storage/content_hash.h>
+#include <kungfu/yijinjing/storage/content_store.h>
 #include <kungfu/yijinjing/time.h>
 
 #ifdef _WINDOWS
@@ -431,22 +433,45 @@ bool contains_u64(const std::vector<uint64_t> &values, uint64_t value) {
   return std::find(values.begin(), values.end(), value) != values.end();
 }
 
-// Stage 4 (ADR-0041) replaces this path probe with resolution through the
-// ADR-0040 immutable content_store once that primitive lands.
-bool payload_ref_exists(const std::string &runtime_dir, const std::string &ref_id) {
-  if (ref_id.empty()) {
-    return false;
+// ADR-0041 stage 4: a payload ref resolves through the ADR-0040 immutable
+// content_store by its content identity (ref_hash); ref_id is an edge label
+// with no resolution role. The verified read maps the store's declared error
+// taxonomy onto manifest diagnostics -- there is no path fallback.
+struct payload_ref_resolution {
+  const char *status = "missing"; // dependency status for the causal graph
+  const char *code = nullptr;     // issue code when the ref is not verified
+  std::string detail = {};
+};
+
+payload_ref_resolution resolve_payload_ref(const std::string &runtime_dir, const std::string &ref_hash) {
+  content_hash hash{};
+  try {
+    // canonical form is "<algo>:<hex>"; bare hex from earlier producers is
+    // accepted as the store's default algorithm
+    hash = ref_hash.find(':') != std::string::npos ? parse_content_hash(ref_hash) : make_content_hash(ref_hash);
+  } catch (const std::exception &e) {
+    return {"unaddressable", "episode_payload_ref_hash_invalid", e.what()};
   }
-  fs::path path(ref_id);
-  if (path.is_relative()) {
-    path = fs::path(runtime_dir) / path;
+  file_content_store store((fs::path(runtime_dir) / "storage").string());
+  const auto verified = store.verify("payloads", hash);
+  switch (verified.error) {
+  case content_store_error::Ok:
+    return {"present", nullptr, {}};
+  case content_store_error::NotFound:
+    return {"missing", "episode_payload_ref_missing", verified.message};
+  case content_store_error::CorruptObject:
+    return {"hash_mismatch", "episode_payload_ref_hash_mismatch", verified.message};
+  case content_store_error::InvalidArgument:
+    return {"unaddressable", "episode_payload_ref_hash_invalid", verified.message};
+  default:
+    return {"unreadable", "episode_payload_ref_io_error", verified.message};
   }
-  return fs::exists(path);
 }
 
 struct episode_graph {
   nlohmann::json graph = nlohmann::json::object();
   nlohmann::json dependencies = nlohmann::json::array();
+  nlohmann::json errors = nlohmann::json::array();
   nlohmann::json warnings = nlohmann::json::array();
   bool degraded = false;
 };
@@ -457,8 +482,10 @@ episode_graph build_causal_graph(const std::string &runtime_dir, uint64_t episod
   std::vector<uint64_t> declared_input_frames;
   nlohmann::json frame_edges = nlohmann::json::array();
   nlohmann::json dependencies = nlohmann::json::array();
+  nlohmann::json errors = nlohmann::json::array();
   nlohmann::json warnings = nlohmann::json::array();
   bool degraded = false;
+  const bool sealed = view.closed && view.close.status == EpisodeStatus::Ended;
 
   for (size_t position = 0; position < view.frame_indices.size(); ++position) {
     const auto frame_uid = view.frame_at(position).frame_uid;
@@ -552,19 +579,28 @@ episode_graph build_causal_graph(const std::string &runtime_dir, uint64_t episod
                             {"role", "ref"}});
       }
     } else if (ref.ref_kind == EpisodeRefKind::Payload) {
-      const bool present = payload_ref_exists(runtime_dir, ref_id);
+      const auto resolved = resolve_payload_ref(runtime_dir, ref_hash);
       dependencies.push_back({{"kind", "payload"},
                               {"role", "payload_ref"},
                               {"ref_uid", ref.ref_uid},
                               {"ref_id", ref_id},
                               {"ref_hash", ref_hash},
-                              {"status", present ? "present" : "missing"}});
-      if (!present) {
-        degraded = true;
-        warnings.push_back({{"code", "episode_payload_ref_missing"},
-                            {"episode_id", episode_id},
-                            {"ref_id", ref_id},
-                            {"ref_hash", ref_hash}});
+                              {"status", resolved.status}});
+      if (resolved.code != nullptr) {
+        nlohmann::json issue = {
+            {"code", resolved.code}, {"episode_id", episode_id}, {"ref_id", ref_id}, {"ref_hash", ref_hash}};
+        if (!resolved.detail.empty()) {
+          issue["detail"] = resolved.detail;
+        }
+        // A seal claims the Episode's material is complete and intact; an
+        // unverified payload ref falsifies a sealed Episode and only
+        // degrades an open one (trust-boundary contract §3.2).
+        if (sealed) {
+          errors.push_back(std::move(issue));
+        } else {
+          degraded = true;
+          warnings.push_back(std::move(issue));
+        }
       }
     } else if (ref.ref_kind == EpisodeRefKind::Schema) {
       dependencies.push_back({{"kind", "schema"},
@@ -588,6 +624,7 @@ episode_graph build_causal_graph(const std::string &runtime_dir, uint64_t episod
            {"edges", frame_edges},
            {"dependencies", dependencies}},
           dependencies,
+          errors,
           warnings,
           degraded};
 }
@@ -899,6 +936,9 @@ nlohmann::json episode_manifest_store::fsck(uint64_t episode_id) const {
     }
     const auto graph = build_causal_graph(runtime_dir_, current_episode_id, view, fold.episodes);
     degraded = degraded || graph.degraded;
+    for (const auto &error : graph.errors) {
+      errors.push_back(error);
+    }
     for (const auto &warning : graph.warnings) {
       warnings.push_back(warning);
     }

--- a/framework/core/src/python/kungfu/storage/episode_lifecycle.py
+++ b/framework/core/src/python/kungfu/storage/episode_lifecycle.py
@@ -130,13 +130,30 @@ class RuntimeEpisodeLifecycle:
     def attach_payload_ref(
         self, path: str, *, content_hash: str = "", ref_id: str | None = None
     ) -> None:
+        # ADR-0041 stage 4: publish the payload bytes into the content store
+        # first, then append the ref claiming their identity; fsck resolves
+        # the ref through the store by ref_hash, not by path. ref_id stays an
+        # edge label (the runtime-relative origin of the bytes).
+        from kungfu.content_hash import compute_content_hash_value
+
+        with open(path, "rb") as payload_file:
+            raw = payload_file.read()
+        digest = compute_content_hash_value(raw)
+        if content_hash:
+            declared = content_hash.split(":", 1)[-1]
+            if declared != digest:
+                raise ValueError(
+                    f"attach_payload_ref: declared hash {content_hash} does not "
+                    f"match the bytes at {path} (sha256:{digest})"
+                )
+        service.write_payload_bytes(self.runtime_dir, digest, raw)
         service.episode_attach_ref(
             self.runtime_dir,
             episode_id=self.episode_id,
             location_uid=self.location_uid,
             ref_kind="payload",
             ref_id=ref_id or _relative_ref(self.runtime_dir, path),
-            ref_hash=content_hash,
+            ref_hash=f"sha256:{digest}",
         )
 
     def close(self, *, ok: bool, reason: str = "") -> None:

--- a/framework/core/tests/python/test_atlas_storage.py
+++ b/framework/core/tests/python/test_atlas_storage.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
+import hashlib
 import json
 import sqlite3
 from datetime import datetime, timezone
@@ -658,6 +659,12 @@ def test_episode_manifest_v1_is_yijinjing_backed_and_fscked(tmp_path):
     assert bundle["frame_count"] == 1
 
 
+# A well-formed digest whose bytes were never published: stage 4 resolves
+# payload refs through the content store by hash, so "absent" must still be
+# addressable to count as missing (a malformed hash is unaddressable instead).
+_ABSENT_PAYLOAD_HASH = "sha256:" + hashlib.sha256(b"absent-payload").hexdigest()
+
+
 def test_episode_fsck_reports_degraded_causal_dependencies(tmp_path):
     runtime_dir = tmp_path / "runtime"
     storage_service.episode_begin(
@@ -690,7 +697,7 @@ def test_episode_fsck_reports_degraded_causal_dependencies(tmp_path):
         episode_id=7,
         ref_kind="payload",
         ref_id="missing/payload.json",
-        ref_hash="sha256:missing",
+        ref_hash=_ABSENT_PAYLOAD_HASH,
     )
     storage_service.episode_attach_ref(
         runtime_dir,
@@ -717,14 +724,17 @@ def test_episode_fsck_reports_degraded_causal_dependencies(tmp_path):
     }
 
     fsck = storage_service.fsck(runtime_dir, episode_id=7)
-    assert fsck["ok"]
-    assert fsck["status"] == "degraded"
+    # stage 4: the episode is sealed, so an unresolved payload ref falsifies
+    # the seal (error/failed) instead of merely degrading it
+    assert not fsck["ok"]
+    assert fsck["status"] == "failed"
     assert fsck["degraded"] is True
     warning_codes = {warning["code"] for warning in fsck["warnings"]}
     assert "episode_dependency_missing" in warning_codes
     assert "episode_root_trigger_frame_missing" in warning_codes
     assert "episode_trigger_frame_missing" in warning_codes
-    assert "episode_payload_ref_missing" in warning_codes
+    error_codes = {error["code"] for error in fsck["errors"]}
+    assert "episode_payload_ref_missing" in error_codes
 
     bundle = storage_service.build_export_bundle(runtime_dir, episode_id=7)
     assert bundle["degraded"] is True
@@ -745,7 +755,7 @@ def test_episode_fsck_reports_degraded_causal_dependencies(tmp_path):
     assert repair["episode_id"] == 7
     assert repair["dry_run"] is True
     assert repair["plan_only"] is True
-    assert repair["status"] == "degraded"
+    assert repair["status"] == "failed"
     assert repair["degraded"] is True
     assert repair["candidate_count"] >= 4
     candidate_codes = {candidate["code"] for candidate in repair["candidates"]}
@@ -807,7 +817,7 @@ def test_episode_fsck_reports_degraded_causal_dependencies(tmp_path):
         episode_id=7,
         ref_kind="payload",
         ref_id="missing/payload.json",
-        ref_hash="sha256:missing",
+        ref_hash=_ABSENT_PAYLOAD_HASH,
     )
     storage_service.episode_attach_ref(
         donor_dir,
@@ -846,7 +856,9 @@ def test_episode_fsck_reports_degraded_causal_dependencies(tmp_path):
     assert dry_apply["dry_run"] is True
     assert dry_apply["applied"] is False
     assert dry_apply["applied_count"] >= 1
-    assert storage_service.fsck(runtime_dir, episode_id=7)["status"] == "degraded"
+    # still failed: the sealed episode's payload bytes are not in the store
+    # (bundles carry manifest records, not payload bodies)
+    assert storage_service.fsck(runtime_dir, episode_id=7)["status"] == "failed"
 
     applied = storage_service.repair_apply(
         runtime_dir, fetched["material"], episode_id=7, dry_run=False

--- a/framework/core/tests/python/test_episode_manifest_fsck.py
+++ b/framework/core/tests/python/test_episode_manifest_fsck.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import struct
 from pathlib import Path
 
@@ -21,7 +22,6 @@ import kungfu
 
 from kungfu.storage import service
 from kungfu.storage.episode_lifecycle import RuntimeEpisodeLifecycle
-
 
 MANIFEST_SUBDIR = Path("journal/system/storage/episode-manifest/live")
 
@@ -285,3 +285,141 @@ def test_verify_frames_detects_tampered_payload(tmp_path):
     assert fsck["status"] == "failed"
     codes = [e["code"] for e in fsck["errors"]]
     assert "episode_attached_frame_checksum_mismatch" in codes
+
+
+# ---- stage 4: payload refs resolve through the ADR-0040 content store ----
+#
+# ref_hash is the resolution key (verified read through the immutable
+# content store, namespace "payloads"); ref_id is an edge label. A sealed
+# Episode with a missing / mismatched / unaddressable payload ref fails;
+# an open Episode is degraded.
+
+
+def _publish_payload(runtime_dir: Path, raw: bytes) -> str:
+    digest = hashlib.sha256(raw).hexdigest()
+    service.write_payload_bytes(runtime_dir, digest, raw)
+    return digest
+
+
+def _attach_payload_ref(runtime_dir: Path, episode_id: int, ref_hash: str) -> None:
+    service.episode_attach_ref(
+        runtime_dir,
+        episode_id=episode_id,
+        ref_kind="payload",
+        ref_id="fixtures/payload.bin",
+        ref_hash=ref_hash,
+    )
+
+
+def _seal(runtime_dir: Path, episode_id: int) -> None:
+    service.episode_end(
+        runtime_dir,
+        episode_id=episode_id,
+        end_time=2000,
+        frame_count=0,
+        reason="done",
+    )
+
+
+def _payload_object(runtime_dir: Path, digest: str) -> Path:
+    return Path(runtime_dir) / "storage" / "payloads" / digest[:2] / digest
+
+
+def test_published_payload_ref_verifies_through_content_store(tmp_path):
+    runtime_dir = tmp_path / "runtime"
+    _begin(runtime_dir, 41)
+    digest = _publish_payload(runtime_dir, b"stage-4 payload body")
+    _attach_payload_ref(runtime_dir, 41, f"sha256:{digest}")
+    _seal(runtime_dir, 41)
+
+    fsck = service.fsck(runtime_dir, episode_id=41)
+    assert fsck["ok"]
+    assert fsck["status"] == "ok"
+
+    inspected = service.episode_inspect(runtime_dir, episode_id=41)
+    payload_deps = [
+        dep for dep in inspected["dependencies"] if dep["kind"] == "payload"
+    ]
+    assert payload_deps and payload_deps[0]["status"] == "present"
+
+
+def test_bare_hex_ref_hash_is_accepted(tmp_path):
+    runtime_dir = tmp_path / "runtime"
+    _begin(runtime_dir, 42)
+    digest = _publish_payload(runtime_dir, b"bare hex producer compat")
+    _attach_payload_ref(runtime_dir, 42, digest)
+    _seal(runtime_dir, 42)
+
+    fsck = service.fsck(runtime_dir, episode_id=42)
+    assert fsck["ok"]
+    assert fsck["status"] == "ok"
+
+
+def test_sealed_missing_payload_ref_fails_fsck(tmp_path):
+    runtime_dir = tmp_path / "runtime"
+    _begin(runtime_dir, 43)
+    absent = hashlib.sha256(b"never published").hexdigest()
+    _attach_payload_ref(runtime_dir, 43, f"sha256:{absent}")
+    _seal(runtime_dir, 43)
+
+    fsck = service.fsck(runtime_dir, episode_id=43)
+    assert not fsck["ok"]
+    assert fsck["status"] == "failed"
+    assert "episode_payload_ref_missing" in [e["code"] for e in fsck["errors"]]
+
+
+def test_open_missing_payload_ref_degrades_fsck(tmp_path):
+    runtime_dir = tmp_path / "runtime"
+    _begin(runtime_dir, 44)
+    absent = hashlib.sha256(b"never published either").hexdigest()
+    _attach_payload_ref(runtime_dir, 44, f"sha256:{absent}")
+
+    fsck = service.fsck(runtime_dir, episode_id=44)
+    assert fsck["ok"]
+    assert fsck["status"] == "degraded"
+    assert "episode_payload_ref_missing" in [w["code"] for w in fsck["warnings"]]
+
+
+def test_sealed_tampered_payload_fails_fsck(tmp_path):
+    runtime_dir = tmp_path / "runtime"
+    _begin(runtime_dir, 45)
+    raw = b"authentic payload bytes"
+    digest = _publish_payload(runtime_dir, raw)
+    _attach_payload_ref(runtime_dir, 45, f"sha256:{digest}")
+    _seal(runtime_dir, 45)
+
+    # same-length corruption: presence and length survive, content does not
+    tampered = b"Xuthentic payload bytes"
+    _payload_object(runtime_dir, digest).write_bytes(tampered)
+
+    fsck = service.fsck(runtime_dir, episode_id=45)
+    assert not fsck["ok"]
+    assert fsck["status"] == "failed"
+    assert "episode_payload_ref_hash_mismatch" in [e["code"] for e in fsck["errors"]]
+
+
+def test_unaddressable_ref_hash_is_reported(tmp_path):
+    runtime_dir = tmp_path / "runtime"
+    _begin(runtime_dir, 46)
+    _attach_payload_ref(runtime_dir, 46, "sha256:not-a-digest")
+
+    fsck = service.fsck(runtime_dir, episode_id=46)
+    assert fsck["ok"]
+    assert fsck["status"] == "degraded"
+    assert "episode_payload_ref_hash_invalid" in [w["code"] for w in fsck["warnings"]]
+
+
+def test_lifecycle_attach_publishes_into_content_store(tmp_path):
+    runtime_dir = tmp_path / "runtime"
+    lifecycle = _lifecycle(runtime_dir, "worker-payload")
+    payload_file = tmp_path / "artifact.json"
+    payload_file.write_text('{"result": "ok"}', encoding="utf-8")
+    lifecycle.attach_payload_ref(str(payload_file))
+    lifecycle.close(ok=True)
+
+    digest = hashlib.sha256(payload_file.read_bytes()).hexdigest()
+    assert _payload_object(runtime_dir, digest).exists()
+
+    fsck = service.fsck(runtime_dir, episode_id=lifecycle.episode_id)
+    assert fsck["ok"]
+    assert fsck["status"] == "ok"

--- a/framework/core/tests/python/test_episode_manifest_projection.py
+++ b/framework/core/tests/python/test_episode_manifest_projection.py
@@ -9,6 +9,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import sqlite3
 from pathlib import Path
 
@@ -41,15 +42,15 @@ def _seed_episode(runtime_dir: Path, episode_id: int) -> None:
         payload_checksum=0,
         frame_checksum=0,
     )
-    payload = Path(runtime_dir) / "payloads" / f"{episode_id}.bin"
-    payload.parent.mkdir(parents=True, exist_ok=True)
-    payload.write_bytes(b"payload")
+    # stage 4: payload bytes live in the content store, addressed by ref_hash
+    payload_digest = hashlib.sha256(b"payload").hexdigest()
+    service.write_payload_bytes(runtime_dir, payload_digest, b"payload")
     service.episode_attach_ref(
         runtime_dir,
         episode_id=episode_id,
         ref_kind="payload",
         ref_id=f"payloads/{episode_id}.bin",
-        ref_hash="sha256:test",
+        ref_hash=f"sha256:{payload_digest}",
     )
     service.episode_end(
         runtime_dir,


### PR DESCRIPTION
ADR-0041 stage 4: Episode payload refs resolve through the ADR-0040 immutable content_store by content identity (ref_hash); ref_id stays an edge label. Verified reads map the store's error taxonomy onto manifest diagnostics (missing / hash-mismatch / unaddressable / io); an unverified payload ref fails a sealed Episode and degrades an open one; repair planning also scans fsck errors so sealed payload issues remain fetchable. Producers publish bytes before claiming them, and the file provider's payload write now publishes via content-store put-if-absent. Validation: full core build; episode suites 28/28 incl. 7 new stage-4 fixtures; full python 108 passed with only the 2 pre-existing first-party-baked baseline failures (reproduced on clean dev); node binding consistent with baseline.