### PR TITLE
test(episode): add semantic qualification evidence

### DIFF
--- a/docs/episode-atomicity-qualification.md
+++ b/docs/episode-atomicity-qualification.md
@@ -102,6 +102,37 @@ Small-state exhaustive enumeration should cover short histories before random
 generation scales them. Every discovered counterexample becomes a minimized,
 checked-in regression fixture.
 
+### Semantic v1 executable slice
+
+The first executable slice lives under
+`framework/core/tests/qualification/episode/`. Its oracle has no Kungfu import
+and consumes only abstract lifecycle and evidence transitions. The production
+worker separately drives the public Python storage service, then compares
+observable lifecycle, fsck status, issue class, record stability, recovery,
+projection, and portable identity against the oracle.
+
+Each recurring semantic run first exhausts the 48-state Semantic v1 cross-
+product of payload evidence, direct dependency presence, terminal state, and
+repair choice. A model-invariant failure blocks qualification before production
+comparisons can support a claim.
+
+The recurring `mvp-smoke-v1` gate requires these dimensions to pass:
+
+- lifecycle safety;
+- useful degradation;
+- repair monotonicity;
+- direct dependency failure containment;
+- projection derivation and rebuild convergence;
+- interrupted-open publication recovery;
+- content integrity and immutable put-if-absent behavior;
+- export/import preservation of Episode identity and causal counts.
+
+`capability_soundness` is explicitly `not_exercised`: the content-store backend
+declares storage capabilities, but the production Episode fold does not yet emit
+the safe-operation capability report required by ADR-0042. Semantic v1 does not
+invent an edge-layer substitute or count an unexecuted check as zero violations.
+This is a visible remaining implementation stage, not a silent pass.
+
 ## Fault matrix
 
 The harness injects one fault and selected combinations at declared durability
@@ -445,7 +476,7 @@ Each run records at least:
 
 ```json
 {
-  "schema": "kungfu.episode.trust-report/v1",
+  "schema": "kungfu.episode.trust-report/v2",
   "source_revision": "<git sha>",
   "episode_contract": "<version>",
   "profile": "single-node-qualification/v1",
@@ -461,10 +492,28 @@ Each run records at least:
   },
   "fault_coverage": {},
   "correctness": {
-    "silent_invalid": 0,
-    "capability_violations": 0,
-    "containment_violations": 0,
-    "repair_monotonicity_violations": 0
+    "count_mismatches": 0,
+    "readback_mismatches": 0
+  },
+  "semantic_evidence": {
+    "oracle": "kungfu.episode.semantic-oracle/v1",
+    "required_dimensions": [],
+    "dimensions": {
+      "lifecycle_safety": {
+        "status": "passed",
+        "cases_executed": 1,
+        "violations": [],
+        "evidence": ["open-publication-recovery"],
+        "reason": null
+      },
+      "capability_soundness": {
+        "status": "not_exercised",
+        "cases_executed": 0,
+        "violations": [],
+        "evidence": [],
+        "reason": "production Episode safe-capability report is not implemented"
+      }
+    }
   },
   "performance": {},
   "gaps": [],
@@ -477,6 +526,12 @@ descriptions. Reports are evidence artifacts, not authority facts inside an
 Episode. A human summary must link the exact report rather than restate only the
 best throughput number.
 
+Trust Report v2 replaces v1's ambiguous semantic zero counters with evidence
+dimensions. Every dimension is `passed`, `failed`, or `not_exercised`; only
+profile-required `passed` dimensions contribute to `qualified=true`. The v1
+schema remains available for historical baseline reports and is not
+reinterpreted as Semantic v1 evidence.
+
 ## First implementation slices
 
 1. Encode the abstract state/capability oracle and exhaust short histories.
@@ -485,8 +540,8 @@ best throughput number.
    corpus.
 4. Add generated DAG and recovery properties with reproducible seeds.
 5. Add a metadata-scale driver, then realistic payload and multi-process modes.
-6. Emit Trust Report v1 and run the first single-node baseline without treating
-   its numbers as a support promise.
+6. Emit the versioned Trust Report and run the first single-node baseline
+   without treating its numbers as a support promise.
 
 ## First development baseline (2026-07-10)
 

--- a/framework/core/tests/python/test_episode_qualification_semantic_oracle.py
+++ b/framework/core/tests/python/test_episode_qualification_semantic_oracle.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Independent model checks for Episode Qualification Semantic v1."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+import pytest
+
+
+QUALIFICATION_DIR = Path(__file__).resolve().parents[1] / "qualification" / "episode"
+sys.path.insert(0, str(QUALIFICATION_DIR))
+
+from semantic_oracle import (  # noqa: E402
+    EpisodeOracle,
+    Evidence,
+    Lifecycle,
+    exhaust_bounded_histories,
+    repair_is_monotonic,
+)
+
+
+def test_open_missing_content_degrades_and_sealed_missing_content_fails():
+    oracle = EpisodeOracle()
+    oracle.begin()
+    oracle.attach_payload("artifact", Evidence.MISSING)
+    assert oracle.observe().status == "degraded"
+    oracle.end()
+    assert oracle.observe().status == "failed"
+
+
+def test_repair_restores_useful_state_without_changing_episode_lifecycle():
+    oracle = EpisodeOracle()
+    oracle.begin()
+    oracle.attach_payload("artifact", Evidence.MISSING)
+    oracle.end()
+    before = oracle.observe()
+    oracle.restore_payload("artifact")
+    after = oracle.observe()
+    assert before.lifecycle == after.lifecycle == "ended"
+    assert before.status == "failed"
+    assert after.status == "ok"
+    assert repair_is_monotonic(before, after)
+
+
+def test_recovery_is_abort_and_idempotent():
+    oracle = EpisodeOracle()
+    oracle.begin()
+    assert oracle.recover() is True
+    assert oracle.lifecycle is Lifecycle.ABORTED
+    assert oracle.recover() is False
+
+
+def test_projection_is_derived_and_journal_change_marks_it_stale():
+    oracle = EpisodeOracle()
+    oracle.begin()
+    oracle.rebuild_projection()
+    assert oracle.projection == "current"
+    oracle.end()
+    assert oracle.projection == "stale"
+    assert oracle.observe().status == "degraded"
+    oracle.rebuild_projection()
+    assert oracle.observe().status == "ok"
+
+
+def test_bounded_payload_dependency_histories_preserve_core_invariants():
+    assert exhaust_bounded_histories() == 48
+
+
+def test_illegal_transitions_are_rejected_by_the_oracle():
+    oracle = EpisodeOracle()
+    with pytest.raises(ValueError, match="episode_not_open"):
+        oracle.end()
+    oracle.begin()
+    oracle.end()
+    with pytest.raises(ValueError, match="episode_not_open"):
+        oracle.attach_payload("late", Evidence.PRESENT)

--- a/framework/core/tests/qualification/episode/README.md
+++ b/framework/core/tests/qualification/episode/README.md
@@ -1,6 +1,6 @@
 # Episode Qualification Harness
 
-This directory implements the executable v0 slice of
+This directory implements the executable scale v0 and Semantic v1 slices of
 [`docs/episode-atomicity-qualification.md`](../../../../../docs/episode-atomicity-qualification.md).
 It exercises the shipped Python facade backed by the C++ Episode manifest
 implementation; it does not parse or mutate journal bytes itself.
@@ -11,6 +11,7 @@ then run:
 ```sh
 ./kungfu-code episode:qualify -- --profile mvp-smoke-v1
 ./kungfu-code episode:qualify -- --profile mvp-baseline-v1
+./kungfu-code episode:qualify -- --profile mvp-smoke-v1 --mode semantic
 ```
 
 Useful scoped runs:
@@ -46,13 +47,35 @@ hatch; the checked-in Buildchain and alpha/release commands do not use it.
 accumulation and 10k contention workloads explicitly for periodic or
 release-readiness qualification.
 
+## Semantic evidence
+
+The independent `semantic_oracle.py` models externally observable lifecycle,
+evidence, dependency, repair, and projection states without importing Kungfu or
+reading journal bytes. `semantic_workload.py` compares that model with the real
+storage service for:
+
+- interrupted-open recovery and recovery idempotence;
+- useful degradation for missing content and monotonic restoration;
+- content hash rejection and put-if-absent idempotence;
+- direct dependency failure containment;
+- projection absence, drift, and rebuild convergence;
+- export/import preservation of Episode identity and causal counts.
+
+Trust Report v2 records every semantic dimension as `passed`, `failed`, or
+`not_exercised`. A dimension can pass only when a production comparison ran.
+`capability_soundness` remains `not_exercised` until the production Episode
+safe-capability report exists; it is therefore not part of the current MVP
+required-dimension set.
+
 ## Result boundary
 
-The v0 profiles are metadata-only: each independent Episode contains exactly
-one open and one terminal record. They qualify manifest population, fold/fsck
-readback, writer contention, retry progress, and cold-process stability. They
-do not qualify realistic payload bytes, dependency DAGs, projection rebuild,
-distributed writers, or fleet-scale capacity. Those gaps remain explicit in
+The scale v0 profiles are metadata-only: each independent Episode contains
+exactly one open and one terminal record. They qualify manifest population,
+fold/fsck readback, writer contention, retry progress, and cold-process
+stability. They do not qualify realistic payload distributions, deep or wide dependency DAGs,
+distributed writers, or fleet-scale capacity. Semantic v1 adds small
+deterministic payload, direct-dependency, and projection cases; it does not turn
+those bounded cases into a scale or soak claim. Those gaps remain explicit in
 every Trust Report.
 
 `manifest_writer_busy` is the only retryable error. The worker records every
@@ -65,5 +88,8 @@ open Episode, or fresh-process mismatch fails the scenario.
 - `run.mjs` owns profiles, worker processes, timeouts, aggregation, and reports.
 - `episode_workload.py` performs writes and readback through
   `kungfu.storage.service`.
+- `semantic_oracle.py` is the dependency-free abstract model.
+- `semantic_workload.py` performs bounded model-versus-production comparisons.
 - `profiles/*.json` are versioned workload and progress policies.
-- `schemas/trust-report-v1.schema.json` validates every emitted report.
+- `schemas/trust-report-v2.schema.json` validates current reports; v1 remains
+  checked in so historical evidence stays readable.

--- a/framework/core/tests/qualification/episode/profiles/mvp-baseline-v1.json
+++ b/framework/core/tests/qualification/episode/profiles/mvp-baseline-v1.json
@@ -25,5 +25,18 @@
     "list_limit": 100,
     "allowed_full_fsck_warnings": ["sqlite_projection_missing"]
   },
+  "semantic": {
+    "required_dimensions": [
+      "lifecycle_safety",
+      "useful_degradation",
+      "repair_monotonicity",
+      "dependency_containment",
+      "projection_derivation",
+      "publication_recovery",
+      "content_integrity",
+      "portable_identity"
+    ],
+    "timeout_seconds": 120
+  },
   "scenario_timeout_seconds": 3600
 }

--- a/framework/core/tests/qualification/episode/profiles/mvp-smoke-v1.json
+++ b/framework/core/tests/qualification/episode/profiles/mvp-smoke-v1.json
@@ -25,5 +25,18 @@
     "list_limit": 100,
     "allowed_full_fsck_warnings": ["sqlite_projection_missing"]
   },
+  "semantic": {
+    "required_dimensions": [
+      "lifecycle_safety",
+      "useful_degradation",
+      "repair_monotonicity",
+      "dependency_containment",
+      "projection_derivation",
+      "publication_recovery",
+      "content_integrity",
+      "portable_identity"
+    ],
+    "timeout_seconds": 120
+  },
   "scenario_timeout_seconds": 180
 }

--- a/framework/core/tests/qualification/episode/run.mjs
+++ b/framework/core/tests/qualification/episode/run.mjs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// Cross-platform coordinator for the Episode Qualification Harness v0.
+// Cross-platform coordinator for the Episode Qualification Harness.
 // Profiles, process isolation, timeouts, aggregation, and the Trust Report live
 // here. Python workers call the real C++-backed Episode surface and write one
 // private result file each; workers never contend on the report itself.
@@ -17,21 +17,33 @@ const harnessDir = path.dirname(__filename);
 const coreDir = path.resolve(harnessDir, '..', '..', '..');
 const rootDir = path.resolve(coreDir, '..', '..');
 const workerPath = path.join(harnessDir, 'episode_workload.py');
+const semanticWorkerPath = path.join(harnessDir, 'semantic_workload.py');
 const schemaPath = path.join(
   harnessDir,
   'schemas',
-  'trust-report-v1.schema.json',
+  'trust-report-v2.schema.json',
 );
+const semanticDimensionNames = [
+  'lifecycle_safety',
+  'capability_soundness',
+  'useful_degradation',
+  'repair_monotonicity',
+  'dependency_containment',
+  'projection_derivation',
+  'publication_recovery',
+  'content_integrity',
+  'portable_identity',
+];
 
 function usage() {
-  console.log(`Episode Qualification Harness v0
+  console.log(`Episode Qualification Harness
 
 Usage:
   ./kungfu-code episode:qualify -- [options]
 
 Options:
   --profile NAME                     mvp-smoke-v1 (default) or mvp-baseline-v1
-  --mode all|accumulation|contention selected scenario family (default: all)
+  --mode all|accumulation|contention|semantic selected scenario family (default: all)
   --seed N                           override profile seeds with one seed
   --accumulation-checkpoints A,B     override accumulation checkpoints
   --contention-episodes N            override fixed contention Episode count
@@ -113,9 +125,11 @@ function parseArgs(argv) {
       process.exit(0);
     } else fail(`unknown argument '${arg}'`);
   }
-  if (!['all', 'accumulation', 'contention'].includes(options.mode)) {
+  if (
+    !['all', 'accumulation', 'contention', 'semantic'].includes(options.mode)
+  ) {
     fail(
-      `--mode must be all, accumulation, or contention, got '${options.mode}'`,
+      `--mode must be all, accumulation, contention, or semantic, got '${options.mode}'`,
     );
   }
   if (!/^[a-z0-9][a-z0-9-]*$/.test(options.profile)) {
@@ -150,6 +164,25 @@ function loadProfile(options) {
     if (!Array.isArray(profile[key]) || profile[key].length === 0) {
       fail(`profile ${key} must be a non-empty array`);
     }
+  }
+  if (
+    !profile.semantic ||
+    !Array.isArray(profile.semantic.required_dimensions) ||
+    profile.semantic.required_dimensions.length === 0 ||
+    !Number.isSafeInteger(profile.semantic.timeout_seconds) ||
+    profile.semantic.timeout_seconds <= 0
+  ) {
+    fail(
+      'profile semantic policy must declare required_dimensions and timeout_seconds',
+    );
+  }
+  const unknownDimensions = profile.semantic.required_dimensions.filter(
+    (dimension) => !semanticDimensionNames.includes(dimension),
+  );
+  if (unknownDimensions.length > 0) {
+    fail(
+      `profile has unknown semantic dimensions: ${unknownDimensions.join(',')}`,
+    );
   }
   return profile;
 }
@@ -209,11 +242,11 @@ function readResult(resultPath, fallback) {
   }
 }
 
-function runPython(args, resultPath, timeoutSeconds) {
+function runPython(args, resultPath, timeoutSeconds, scriptPath = workerPath) {
   return new Promise((resolve) => {
     const child = spawn(
       'uv',
-      ['run', '--frozen', 'python', workerPath, ...args],
+      ['run', '--frozen', 'python', scriptPath, ...args],
       {
         cwd: coreDir,
         env: runtimeEnv(),
@@ -462,6 +495,20 @@ async function runContention(profile, seed, workerCount, runRoot, keepRuntime) {
   return scenario;
 }
 
+async function runSemantic(profile, runRoot, keepRuntime) {
+  const runtimeRoot = path.join(runRoot, 'runtime', 'semantic-v1');
+  const resultPath = path.join(runRoot, 'results', 'semantic-v1.json');
+  fs.mkdirSync(runtimeRoot, { recursive: true });
+  const result = await runPython(
+    ['--result', resultPath, '--runtime-root', runtimeRoot],
+    resultPath,
+    profile.semantic.timeout_seconds,
+    semanticWorkerPath,
+  );
+  removeRuntime(runtimeRoot, keepRuntime);
+  return result;
+}
+
 function sumWorkerOperation(scenarios, field) {
   let total = 0;
   for (const scenario of scenarios) {
@@ -626,6 +673,7 @@ async function main() {
   const sourceDirty = gitText(['status', '--porcelain']).length > 0;
   const started = Date.now();
   const scenarios = [];
+  let semantic = null;
 
   console.log(
     `[episode-qualify] profile=${profile.name} mode=${options.mode} seeds=${profile.seeds.join(',')}`,
@@ -656,6 +704,10 @@ async function main() {
       }
     }
   }
+  if (options.mode === 'all' || options.mode === 'semantic') {
+    console.log('[episode-qualify] semantic oracle and production comparisons');
+    semantic = await runSemantic(profile, runRoot, options.keepRuntime);
+  }
 
   const errors = probeErrors(scenarios);
   const retryExhausted = sumWorkerOperation(scenarios, 'retry_exhausted');
@@ -674,10 +726,6 @@ async function main() {
     sumWorkerOperation(scenarios, 'progress_timeouts') +
     countCodes(errors, (code) => code === 'scenario_timeout');
   const correctness = {
-    silent_invalid: 0,
-    capability_violations: 0,
-    containment_violations: 0,
-    repair_monotonicity_violations: 0,
     count_mismatches: countCodes(errors, (code) =>
       code.includes('count_mismatch'),
     ),
@@ -692,8 +740,34 @@ async function main() {
     unexpected_errors: unexpectedErrors,
     progress_timeouts: progressTimeouts,
   };
-  const allScenariosOk =
-    scenarios.length > 0 && scenarios.every((scenario) => scenario.ok);
+  const metadataSelected = ['all', 'accumulation', 'contention'].includes(
+    options.mode,
+  );
+  const metadataScenariosOk =
+    !metadataSelected ||
+    (scenarios.length > 0 && scenarios.every((scenario) => scenario.ok));
+  const semanticSelected = ['all', 'semantic'].includes(options.mode);
+  const requiredSemanticDimensions = profile.semantic.required_dimensions;
+  const semanticDimensions =
+    semantic?.dimensions ||
+    Object.fromEntries(
+      semanticDimensionNames.map((dimension) => [
+        dimension,
+        {
+          status: 'not_exercised',
+          cases_executed: 0,
+          violations: [],
+          evidence: [],
+          reason: `invocation selected only the ${options.mode} scenario family`,
+        },
+      ]),
+    );
+  const requiredSemanticPassed = requiredSemanticDimensions.every(
+    (dimension) => semanticDimensions[dimension]?.status === 'passed',
+  );
+  const selectedExecutionOk =
+    metadataScenariosOk &&
+    (!semanticSelected || (Boolean(semantic?.ok) && requiredSemanticPassed));
   const contentionScenarios = scenarios.filter(
     (scenario) => scenario.kind === 'contention' && scenario.workers > 1,
   );
@@ -702,10 +776,11 @@ async function main() {
   const durationSeconds = (Date.now() - started) / 1000;
   const gaps = [
     'metadata-only profile; realistic payload bytes and dedup are not exercised',
-    'independent Episodes only; dependency DAG depth and fan-out are not exercised',
-    'Episode query is manifest-direct; Episode projection rebuild is not implemented',
+    'semantic dependency coverage is bounded to direct dependencies; generated DAG depth and fan-out are not exercised',
+    'Episode projection derivation is exercised, but large projection rebuild cost is not measured',
     'single-node local filesystem only; no service-backed or distributed qualification',
-    'deterministic publication crash and corruption coverage remains in separate fixtures',
+    'publication coverage exercises an interrupted open Episode; torn journal/page crash points remain in deterministic fixtures',
+    'production Episode safe-capability reporting is not implemented, so capability_soundness is not_exercised',
     'no absolute performance SLO is adopted by the v0 profile',
   ];
   if (options.mode !== 'all') {
@@ -718,7 +793,7 @@ async function main() {
   }
 
   const report = {
-    schema: 'kungfu.episode.trust-report/v1',
+    schema: 'kungfu.episode.trust-report/v2',
     source_revision: sourceRevision,
     source_dirty: sourceDirty,
     episode_contract: 'kungfu.episode.manifest/v1',
@@ -748,19 +823,46 @@ async function main() {
     fault_coverage: {
       writer_contention_exercised: contentionScenarios.length > 0,
       writer_contention_observed: busyObserved,
-      fresh_process_readback: scenarios.every((scenario) =>
-        Boolean(scenario.probe?.ok),
-      ),
-      clean_recovery: scenarios.every(
-        (scenario) => scenario.probe?.recovery?.recovered_count === 0,
-      ),
+      fresh_process_readback:
+        scenarios.length > 0 &&
+        scenarios.every((scenario) => Boolean(scenario.probe?.ok)),
+      clean_recovery:
+        scenarios.length > 0 &&
+        scenarios.every(
+          (scenario) => scenario.probe?.recovery?.recovered_count === 0,
+        ),
+      interrupted_open_recovery:
+        semanticDimensions.publication_recovery?.status === 'passed',
+      missing_content_and_hash_rejection:
+        semanticDimensions.content_integrity?.status === 'passed',
+      dependency_failure_containment:
+        semanticDimensions.dependency_containment?.status === 'passed',
+      projection_drift_and_rebuild:
+        semanticDimensions.projection_derivation?.status === 'passed',
     },
     correctness,
+    semantic_evidence: {
+      oracle: semantic?.oracle || 'kungfu.episode.semantic-oracle/v1',
+      oracle_check: semantic?.oracle_check || {
+        status: 'not_exercised',
+        histories_checked: 0,
+        violation: `invocation selected only the ${options.mode} scenario family`,
+      },
+      required_dimensions: requiredSemanticDimensions,
+      dimensions: semanticDimensions,
+      cases: semantic?.cases || [],
+      process: semantic?.process || null,
+    },
     performance: {
       scenarios: scenarios.map(performanceScenario),
     },
     gaps,
-    qualified: allScenariosOk && !sourceDirty,
+    qualified:
+      options.mode === 'all' &&
+      metadataScenariosOk &&
+      Boolean(semantic?.ok) &&
+      requiredSemanticPassed &&
+      !sourceDirty,
   };
   fs.writeFileSync(reportPath, `${JSON.stringify(report, null, 2)}\n`);
   const schemaValidation = await validateReport(reportPath);
@@ -774,12 +876,12 @@ async function main() {
   console.log(
     `[episode-qualify] scenarios=${scenarios.length} passed=${scenarios.filter((scenario) => scenario.ok).length} busy=${sumWorkerOperation(scenarios, 'manifest_writer_busy')} qualified=${report.qualified}`,
   );
-  if (sourceDirty && allScenariosOk) {
+  if (sourceDirty && selectedExecutionOk) {
     console.log(
       '[episode-qualify] scenario gates passed, but release qualification remains false for a dirty source tree',
     );
   }
-  process.exitCode = allScenariosOk && schemaValidation.ok ? 0 : 1;
+  process.exitCode = selectedExecutionOk && schemaValidation.ok ? 0 : 1;
 }
 
 await main();

--- a/framework/core/tests/qualification/episode/schemas/trust-report-v2.schema.json
+++ b/framework/core/tests/qualification/episode/schemas/trust-report-v2.schema.json
@@ -1,0 +1,252 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kungfu.tech/schemas/episode-trust-report-v2.schema.json",
+  "title": "Kungfu Episode Trust Report v2",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "source_revision",
+    "source_dirty",
+    "episode_contract",
+    "profile",
+    "platform",
+    "hardware",
+    "backend_capabilities",
+    "workload",
+    "fault_coverage",
+    "correctness",
+    "semantic_evidence",
+    "performance",
+    "gaps",
+    "qualified"
+  ],
+  "$defs": {
+    "dimension": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "status",
+        "cases_executed",
+        "violations",
+        "evidence",
+        "reason"
+      ],
+      "properties": {
+        "status": {
+          "enum": ["passed", "failed", "not_exercised"]
+        },
+        "cases_executed": { "type": "integer", "minimum": 0 },
+        "violations": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["case", "message"],
+            "properties": {
+              "case": { "type": "string", "minLength": 1 },
+              "message": { "type": "string", "minLength": 1 }
+            }
+          }
+        },
+        "evidence": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "reason": {
+          "type": ["string", "null"]
+        }
+      }
+    }
+  },
+  "properties": {
+    "schema": { "const": "kungfu.episode.trust-report/v2" },
+    "source_revision": { "type": "string", "minLength": 7 },
+    "source_dirty": { "type": "boolean" },
+    "episode_contract": { "const": "kungfu.episode.manifest/v1" },
+    "profile": { "type": "string", "minLength": 1 },
+    "platform": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["os", "arch", "node"],
+      "properties": {
+        "os": { "type": "string" },
+        "arch": { "type": "string" },
+        "node": { "type": "string" }
+      }
+    },
+    "hardware": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["logical_cpus", "total_memory_bytes"],
+      "properties": {
+        "logical_cpus": { "type": "integer", "minimum": 1 },
+        "total_memory_bytes": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "backend_capabilities": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "manifest_authority",
+        "writer_ownership",
+        "payload_profile",
+        "query_profile",
+        "retry_policy"
+      ],
+      "properties": {
+        "manifest_authority": { "const": "yijinjing-journal" },
+        "writer_ownership": { "const": "one-logical-manifest-writer-per-data-root" },
+        "payload_profile": { "type": "string" },
+        "query_profile": { "type": "string" },
+        "retry_policy": { "type": "object" }
+      }
+    },
+    "workload": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["profile", "seeds", "duration_seconds", "scenarios"],
+      "properties": {
+        "profile": { "type": "string" },
+        "seeds": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "integer", "minimum": 0 }
+        },
+        "duration_seconds": { "type": "number", "minimum": 0 },
+        "scenarios": {
+          "type": "array",
+          "items": { "type": "object" }
+        }
+      }
+    },
+    "fault_coverage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "writer_contention_exercised",
+        "writer_contention_observed",
+        "fresh_process_readback",
+        "clean_recovery",
+        "interrupted_open_recovery",
+        "missing_content_and_hash_rejection",
+        "dependency_failure_containment",
+        "projection_drift_and_rebuild"
+      ],
+      "properties": {
+        "writer_contention_exercised": { "type": "boolean" },
+        "writer_contention_observed": { "type": "boolean" },
+        "fresh_process_readback": { "type": "boolean" },
+        "clean_recovery": { "type": "boolean" },
+        "interrupted_open_recovery": { "type": "boolean" },
+        "missing_content_and_hash_rejection": { "type": "boolean" },
+        "dependency_failure_containment": { "type": "boolean" },
+        "projection_drift_and_rebuild": { "type": "boolean" }
+      }
+    },
+    "correctness": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "count_mismatches",
+        "readback_mismatches",
+        "fsck_failures",
+        "recovery_mismatches",
+        "retry_exhausted",
+        "unexpected_errors",
+        "progress_timeouts"
+      ],
+      "properties": {
+        "count_mismatches": { "type": "integer", "minimum": 0 },
+        "readback_mismatches": { "type": "integer", "minimum": 0 },
+        "fsck_failures": { "type": "integer", "minimum": 0 },
+        "recovery_mismatches": { "type": "integer", "minimum": 0 },
+        "retry_exhausted": { "type": "integer", "minimum": 0 },
+        "unexpected_errors": { "type": "integer", "minimum": 0 },
+        "progress_timeouts": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "semantic_evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "oracle",
+        "oracle_check",
+        "required_dimensions",
+        "dimensions",
+        "cases",
+        "process"
+      ],
+      "properties": {
+        "oracle": { "const": "kungfu.episode.semantic-oracle/v1" },
+        "oracle_check": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["status", "histories_checked", "violation"],
+          "properties": {
+            "status": {
+              "enum": ["passed", "failed", "not_exercised"]
+            },
+            "histories_checked": { "type": "integer", "minimum": 0 },
+            "violation": { "type": ["string", "null"] }
+          }
+        },
+        "required_dimensions": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "uniqueItems": true
+        },
+        "dimensions": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "lifecycle_safety",
+            "capability_soundness",
+            "useful_degradation",
+            "repair_monotonicity",
+            "dependency_containment",
+            "projection_derivation",
+            "publication_recovery",
+            "content_integrity",
+            "portable_identity"
+          ],
+          "properties": {
+            "lifecycle_safety": { "$ref": "#/$defs/dimension" },
+            "capability_soundness": { "$ref": "#/$defs/dimension" },
+            "useful_degradation": { "$ref": "#/$defs/dimension" },
+            "repair_monotonicity": { "$ref": "#/$defs/dimension" },
+            "dependency_containment": { "$ref": "#/$defs/dimension" },
+            "projection_derivation": { "$ref": "#/$defs/dimension" },
+            "publication_recovery": { "$ref": "#/$defs/dimension" },
+            "content_integrity": { "$ref": "#/$defs/dimension" },
+            "portable_identity": { "$ref": "#/$defs/dimension" }
+          }
+        },
+        "cases": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["name", "dimensions", "status", "violations", "evidence"]
+          }
+        },
+        "process": { "type": ["object", "null"] }
+      }
+    },
+    "performance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["scenarios"],
+      "properties": {
+        "scenarios": {
+          "type": "array",
+          "items": { "type": "object" }
+        }
+      }
+    },
+    "gaps": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "qualified": { "type": "boolean" }
+  }
+}

--- a/framework/core/tests/qualification/episode/semantic_oracle.py
+++ b/framework/core/tests/qualification/episode/semantic_oracle.py
@@ -1,0 +1,189 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Small independent state oracle for Episode qualification.
+
+This module deliberately has no Kungfu imports.  It models only externally
+observable Episode obligations and never reads journals, calls the production
+fold, or duplicates its serialization rules.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from itertools import product
+
+
+class Lifecycle(str, Enum):
+    ABSENT = "absent"
+    OPEN = "open"
+    ENDED = "ended"
+    ABORTED = "aborted"
+
+
+class Evidence(str, Enum):
+    PRESENT = "present"
+    MISSING = "missing"
+    CORRUPT = "corrupt"
+    UNADDRESSABLE = "unaddressable"
+
+
+@dataclass(frozen=True)
+class Observation:
+    lifecycle: str
+    status: str
+    issue_classes: tuple[str, ...]
+    safe_capabilities: tuple[str, ...]
+    projection: str
+
+
+@dataclass
+class EpisodeOracle:
+    """Reference state for one Episode and its directly required evidence."""
+
+    lifecycle: Lifecycle = Lifecycle.ABSENT
+    payloads: dict[str, Evidence] = field(default_factory=dict)
+    missing_dependencies: set[int] = field(default_factory=set)
+    projection: str = "absent"
+
+    def begin(self) -> None:
+        if self.lifecycle is not Lifecycle.ABSENT:
+            raise ValueError("episode_already_opened")
+        self.lifecycle = Lifecycle.OPEN
+        self._journal_changed()
+
+    def attach_payload(self, ref_id: str, evidence: Evidence) -> None:
+        self._require_open()
+        self.payloads[ref_id] = evidence
+        self._journal_changed()
+
+    def restore_payload(self, ref_id: str) -> None:
+        if ref_id not in self.payloads:
+            raise ValueError("payload_ref_unknown")
+        self.payloads[ref_id] = Evidence.PRESENT
+
+    def require_episode(self, episode_id: int) -> None:
+        self._require_open()
+        self.missing_dependencies.add(episode_id)
+        self._journal_changed()
+
+    def resolve_episode(self, episode_id: int) -> None:
+        self.missing_dependencies.discard(episode_id)
+
+    def end(self) -> None:
+        self._require_open()
+        self.lifecycle = Lifecycle.ENDED
+        self._journal_changed()
+
+    def abort(self) -> None:
+        self._require_open()
+        self.lifecycle = Lifecycle.ABORTED
+        self._journal_changed()
+
+    def recover(self) -> bool:
+        if self.lifecycle is Lifecycle.OPEN:
+            self.abort()
+            return True
+        return False
+
+    def rebuild_projection(self) -> None:
+        self.projection = "current"
+
+    def mark_projection_stale(self) -> None:
+        if self.projection == "current":
+            self.projection = "stale"
+
+    def observe(self) -> Observation:
+        issue_classes: list[str] = []
+        payload_issues = {
+            evidence
+            for evidence in self.payloads.values()
+            if evidence is not Evidence.PRESENT
+        }
+        if payload_issues:
+            issue_classes.extend(
+                f"payload_{item.value}" for item in sorted(payload_issues, key=str)
+            )
+        if self.missing_dependencies:
+            issue_classes.append("episode_dependency_missing")
+        if self.projection == "stale":
+            issue_classes.append("projection_stale")
+
+        sealed = self.lifecycle in (Lifecycle.ENDED, Lifecycle.ABORTED)
+        if sealed and payload_issues:
+            status = "failed"
+        elif issue_classes:
+            status = "degraded"
+        else:
+            status = "ok"
+
+        capabilities = ["inspect", "export_evidence"]
+        if status != "failed":
+            capabilities.append("continue_independent_work")
+        if issue_classes:
+            capabilities.append("plan_repair")
+        if self.lifecycle is Lifecycle.OPEN and status != "failed":
+            capabilities.append("append")
+
+        return Observation(
+            lifecycle=self.lifecycle.value,
+            status=status,
+            issue_classes=tuple(sorted(issue_classes)),
+            safe_capabilities=tuple(sorted(capabilities)),
+            projection=self.projection,
+        )
+
+    def _require_open(self) -> None:
+        if self.lifecycle is not Lifecycle.OPEN:
+            raise ValueError("episode_not_open")
+
+    def _journal_changed(self) -> None:
+        self.mark_projection_stale()
+
+
+STATUS_RANK = {"ok": 0, "degraded": 1, "failed": 2}
+
+
+def repair_is_monotonic(before: Observation, after: Observation) -> bool:
+    """A repair may improve or preserve trust status, never make it worse."""
+
+    return STATUS_RANK[after.status] <= STATUS_RANK[before.status]
+
+
+def exhaust_bounded_histories() -> int:
+    """Check the complete first-order Semantic v1 state cross-product."""
+
+    checked = 0
+    for evidence, dependency_missing, terminal, repair in product(
+        Evidence,
+        (False, True),
+        ("open", "ended", "aborted"),
+        (False, True),
+    ):
+        oracle = EpisodeOracle()
+        oracle.begin()
+        oracle.attach_payload("artifact", evidence)
+        if dependency_missing:
+            oracle.require_episode(77)
+        if terminal == "ended":
+            oracle.end()
+        elif terminal == "aborted":
+            oracle.abort()
+
+        before = oracle.observe()
+        if repair:
+            oracle.restore_payload("artifact")
+            oracle.resolve_episode(77)
+            after = oracle.observe()
+            if not repair_is_monotonic(before, after):
+                raise AssertionError("repair worsened bounded-history trust status")
+            if after.lifecycle != before.lifecycle:
+                raise AssertionError("repair changed bounded-history lifecycle")
+
+        observed = oracle.observe()
+        if observed.lifecycle != terminal:
+            raise AssertionError("bounded-history lifecycle mismatch")
+        if terminal != "open" and evidence is not Evidence.PRESENT and not repair:
+            if observed.status != "failed":
+                raise AssertionError("sealed missing evidence was not failed")
+        checked += 1
+    return checked

--- a/framework/core/tests/qualification/episode/semantic_workload.py
+++ b/framework/core/tests/qualification/episode/semantic_workload.py
@@ -1,0 +1,444 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Production-surface comparisons for Episode Qualification Semantic v1."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import sys
+from typing import Any, Callable
+
+from semantic_oracle import (
+    EpisodeOracle,
+    Evidence,
+    exhaust_bounded_histories,
+    repair_is_monotonic,
+)
+
+
+CORE_DIR = Path(__file__).resolve().parents[3]
+DIMENSIONS = (
+    "lifecycle_safety",
+    "capability_soundness",
+    "useful_degradation",
+    "repair_monotonicity",
+    "dependency_containment",
+    "projection_derivation",
+    "publication_recovery",
+    "content_integrity",
+    "portable_identity",
+)
+
+
+def _load_runtime() -> tuple[Any, Any]:
+    sys.path.insert(0, str(CORE_DIR / "src" / "python"))
+    sys.path.insert(0, str(CORE_DIR / "dist" / "kungfu"))
+    from kungfu.storage import content_store, service
+
+    return service, content_store
+
+
+def _write_json(path: str | Path, value: dict[str, Any]) -> None:
+    target = Path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    temporary = target.with_suffix(target.suffix + ".tmp")
+    temporary.write_text(
+        json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    os.replace(temporary, target)
+
+
+def _expect(actual: Any, expected: Any, label: str) -> None:
+    if actual != expected:
+        raise AssertionError(f"{label}: expected {expected!r}, got {actual!r}")
+
+
+def _begin(service: Any, runtime_dir: Path, episode_id: int, **values: Any) -> None:
+    service.episode_begin(
+        runtime_dir,
+        episode_id=episode_id,
+        title=f"semantic case {episode_id}",
+        actor="qualification",
+        source="qualification/semantic/v1",
+        begin_time=1_000 + episode_id,
+        **values,
+    )
+
+
+def _end(service: Any, runtime_dir: Path, episode_id: int) -> None:
+    service.episode_end(
+        runtime_dir,
+        episode_id=episode_id,
+        end_time=2_000 + episode_id,
+        frame_count=0,
+        reason="semantic qualification",
+    )
+
+
+def _case_lifecycle_recovery(service: Any, _: Any, root: Path) -> dict[str, Any]:
+    runtime_dir = root / "lifecycle-recovery"
+    oracle = EpisodeOracle()
+    oracle.begin()
+    _begin(service, runtime_dir, 101)
+    opened = service.episode_inspect(runtime_dir, episode_id=101)["episode"]
+    _expect(opened["status"], oracle.observe().lifecycle, "open lifecycle")
+    _expect(opened["closed"], False, "open must not be presented as closed")
+
+    _expect(oracle.recover(), True, "oracle first recovery")
+    recovered = service.episode_recover(
+        runtime_dir, episode_id=101, reason="semantic interrupted publication"
+    )
+    _expect(recovered["recovered_count"], 1, "production first recovery")
+    inspected = service.episode_inspect(runtime_dir, episode_id=101)["episode"]
+    _expect(inspected["status"], oracle.observe().lifecycle, "recovered lifecycle")
+    _expect(inspected["closed"], True, "recovered Episode closure")
+
+    _expect(oracle.recover(), False, "oracle repeated recovery")
+    repeated = service.episode_recover(runtime_dir, episode_id=101)
+    _expect(repeated["recovered_count"], 0, "production repeated recovery")
+    return {
+        "open_status": opened["status"],
+        "recovered_status": inspected["status"],
+        "first_recovered_count": recovered["recovered_count"],
+        "second_recovered_count": repeated["recovered_count"],
+    }
+
+
+def _case_content_repair(
+    service: Any, content_store: Any, root: Path
+) -> dict[str, Any]:
+    runtime_dir = root / "content-repair"
+    raw = b"episode semantic qualification payload"
+    digest = hashlib.sha256(raw).hexdigest()
+    ref_hash = f"sha256:{digest}"
+    oracle = EpisodeOracle()
+    oracle.begin()
+    oracle.attach_payload("payload", Evidence.MISSING)
+    _begin(service, runtime_dir, 201)
+    service.episode_attach_ref(
+        runtime_dir,
+        episode_id=201,
+        ref_kind="payload",
+        ref_id="qualification/payload.bin",
+        ref_hash=ref_hash,
+    )
+    before = service.fsck(runtime_dir, episode_id=201)
+    before_oracle = oracle.observe()
+    _expect(before["status"], before_oracle.status, "open missing payload status")
+    _expect(
+        "episode_payload_ref_missing" in {row["code"] for row in before["warnings"]},
+        True,
+        "open missing payload evidence",
+    )
+    records_before = service.episode_inspect(runtime_dir, episode_id=201)["episode"][
+        "record_count"
+    ]
+
+    published = content_store.put_if_absent(
+        runtime_dir, "payloads", raw, expected_hash=ref_hash
+    )
+    _expect(published["ok"], True, "content publication")
+    oracle.restore_payload("payload")
+    after = service.fsck(runtime_dir, episode_id=201)
+    after_oracle = oracle.observe()
+    _expect(after["status"], after_oracle.status, "restored open payload status")
+    _expect(
+        repair_is_monotonic(before_oracle, after_oracle), True, "repair monotonicity"
+    )
+
+    repeated = content_store.put_if_absent(
+        runtime_dir, "payloads", raw, expected_hash=ref_hash
+    )
+    _expect(repeated["ok"], True, "repeated content publication")
+    _expect(repeated["existed"], True, "put-if-absent idempotence")
+    records_after = service.episode_inspect(runtime_dir, episode_id=201)["episode"][
+        "record_count"
+    ]
+    _expect(records_after, records_before, "repair must not rewrite manifest facts")
+
+    rejected = content_store.put_if_absent(
+        runtime_dir,
+        "payloads",
+        b"wrong bytes",
+        expected_hash="sha256:" + "0" * 64,
+    )
+    _expect(rejected["ok"], False, "hash mismatch rejection")
+    _expect(rejected["error"], "hash_mismatch", "hash mismatch classification")
+
+    oracle.end()
+    _end(service, runtime_dir, 201)
+    sealed = service.fsck(runtime_dir, episode_id=201)
+    _expect(sealed["status"], oracle.observe().status, "sealed restored payload status")
+    verified = content_store.verify(runtime_dir, "payloads", ref_hash)
+    _expect(verified["ok"], True, "verified content read")
+    return {
+        "status_path": [before["status"], after["status"], sealed["status"]],
+        "manifest_records_before_repair": records_before,
+        "manifest_records_after_repair": records_after,
+        "put_if_absent_repeated": repeated["existed"],
+        "hash_mismatch_rejected": not rejected["ok"],
+        "content_profile": content_store.capabilities(runtime_dir)["profile"],
+    }
+
+
+def _case_dependency_containment(service: Any, _: Any, root: Path) -> dict[str, Any]:
+    runtime_dir = root / "dependency-containment"
+    dependent = EpisodeOracle()
+    dependent.begin()
+    dependent.require_episode(999)
+    dependent.end()
+    _begin(service, runtime_dir, 301, parent_episode_id=999)
+    _end(service, runtime_dir, 301)
+
+    independent = EpisodeOracle()
+    independent.begin()
+    independent.end()
+    _begin(service, runtime_dir, 302)
+    _end(service, runtime_dir, 302)
+
+    dependent_before = service.fsck(runtime_dir, episode_id=301)
+    independent_before = service.fsck(runtime_dir, episode_id=302)
+    _expect(dependent_before["status"], dependent.observe().status, "dependent status")
+    missing_dependency_observed = "episode_dependency_missing" in {
+        row["code"] for row in dependent_before["warnings"]
+    }
+    _expect(
+        missing_dependency_observed,
+        True,
+        "dependent degradation must name the missing dependency",
+    )
+    _expect(
+        independent_before["status"], independent.observe().status, "independent status"
+    )
+
+    _begin(service, runtime_dir, 999)
+    _end(service, runtime_dir, 999)
+    dependent.resolve_episode(999)
+    dependent_after = service.fsck(runtime_dir, episode_id=301)
+    independent_after = service.fsck(runtime_dir, episode_id=302)
+    _expect(
+        dependent_after["status"], dependent.observe().status, "resolved dependency"
+    )
+    _expect(
+        independent_after["status"],
+        independent_before["status"],
+        "independent Episode containment",
+    )
+    return {
+        "dependent_status_path": [
+            dependent_before["status"],
+            dependent_after["status"],
+        ],
+        "independent_status_path": [
+            independent_before["status"],
+            independent_after["status"],
+        ],
+        "missing_dependency_code_observed": missing_dependency_observed,
+    }
+
+
+def _case_projection(service: Any, _: Any, root: Path) -> dict[str, Any]:
+    runtime_dir = root / "projection"
+    oracle = EpisodeOracle()
+    oracle.begin()
+    oracle.end()
+    _begin(service, runtime_dir, 401)
+    _end(service, runtime_dir, 401)
+    absent = service.fsck(runtime_dir, episode_id=401)["episode_projection"]
+    _expect(absent["status"], oracle.projection, "absent projection")
+
+    rebuilt = service.episode_projection_rebuild(runtime_dir)
+    oracle.rebuild_projection()
+    current = service.fsck(runtime_dir, episode_id=401)["episode_projection"]
+    _expect(current["status"], "ok", "rebuilt projection")
+
+    _begin(service, runtime_dir, 402)
+    _end(service, runtime_dir, 402)
+    oracle.mark_projection_stale()
+    stale_fsck = service.fsck(runtime_dir, episode_id=402)
+    stale = stale_fsck["episode_projection"]
+    _expect(stale["status"], "degraded", "stale projection")
+    _expect(stale_fsck["status"], oracle.observe().status, "stale projection trust")
+
+    service.episode_projection_rebuild(runtime_dir)
+    oracle.rebuild_projection()
+    healed = service.fsck(runtime_dir, episode_id=402)
+    _expect(healed["episode_projection"]["status"], "ok", "healed projection")
+    _expect(healed["status"], oracle.observe().status, "healed projection trust")
+    return {
+        "projection_status_path": [
+            absent["status"],
+            current["status"],
+            stale["status"],
+            healed["episode_projection"]["status"],
+        ],
+        "authority": rebuilt["authority"],
+        "journal_records": rebuilt["journal_records"],
+    }
+
+
+def _case_portable_identity(service: Any, _: Any, root: Path) -> dict[str, Any]:
+    runtime_dir = root / "portable-identity"
+    imported_runtime = root / "portable-identity-import"
+    _begin(service, runtime_dir, 501)
+    _end(service, runtime_dir, 501)
+    bundle = service.build_export_bundle(runtime_dir, episode_id=501)
+    imported = service.import_bundle(imported_runtime, bundle)
+    _expect(imported["episode_id"], 501, "portable Episode id")
+    _expect(imported["records"], bundle["record_count"], "portable record count")
+    _expect(
+        imported["dependency_count"],
+        bundle["dependency_count"],
+        "portable dependency count",
+    )
+    _expect(imported["dry_run"], True, "Episode import v1 is validation-only")
+    _expect(imported["accepted"], False, "Episode import v1 does not materialize")
+    return {
+        "episode_id": imported["episode_id"],
+        "record_count": imported["records"],
+        "dependency_count": imported["dependency_count"],
+        "import_status": imported["status"],
+        "materialized": imported["accepted"],
+    }
+
+
+CASES: tuple[
+    tuple[str, tuple[str, ...], Callable[[Any, Any, Path], dict[str, Any]]], ...
+] = (
+    (
+        "open-publication-recovery",
+        ("lifecycle_safety", "publication_recovery"),
+        _case_lifecycle_recovery,
+    ),
+    (
+        "content-degradation-and-repair",
+        ("useful_degradation", "repair_monotonicity", "content_integrity"),
+        _case_content_repair,
+    ),
+    (
+        "dependency-failure-containment",
+        ("useful_degradation", "dependency_containment"),
+        _case_dependency_containment,
+    ),
+    ("projection-derivation", ("projection_derivation",), _case_projection),
+    ("portable-identity", ("portable_identity",), _case_portable_identity),
+)
+
+
+def run_semantic(runtime_root: Path) -> dict[str, Any]:
+    service, content_store = _load_runtime()
+    try:
+        histories_checked = exhaust_bounded_histories()
+        oracle_check = {
+            "status": "passed",
+            "histories_checked": histories_checked,
+            "violation": None,
+        }
+    except Exception as error:
+        oracle_check = {
+            "status": "failed",
+            "histories_checked": 0,
+            "violation": f"{type(error).__name__}: {error}"[:1000],
+        }
+    cases: list[dict[str, Any]] = []
+    for name, dimensions, invoke in CASES:
+        try:
+            evidence = invoke(service, content_store, runtime_root)
+            cases.append(
+                {
+                    "name": name,
+                    "dimensions": list(dimensions),
+                    "status": "passed",
+                    "violations": [],
+                    "evidence": evidence,
+                }
+            )
+        except Exception as error:
+            cases.append(
+                {
+                    "name": name,
+                    "dimensions": list(dimensions),
+                    "status": "failed",
+                    "violations": [f"{type(error).__name__}: {error}"[:1000]],
+                    "evidence": {},
+                }
+            )
+
+    dimensions: dict[str, dict[str, Any]] = {}
+    for dimension in DIMENSIONS:
+        covered = [case for case in cases if dimension in case["dimensions"]]
+        violations = [
+            {"case": case["name"], "message": message}
+            for case in covered
+            for message in case["violations"]
+        ]
+        if dimension == "capability_soundness":
+            dimensions[dimension] = {
+                "status": "not_exercised",
+                "cases_executed": 0,
+                "violations": [],
+                "evidence": [],
+                "reason": "production Episode safe-capability report is not implemented",
+            }
+        elif not covered:
+            dimensions[dimension] = {
+                "status": "not_exercised",
+                "cases_executed": 0,
+                "violations": [],
+                "evidence": [],
+                "reason": "no production comparison is registered",
+            }
+        else:
+            dimensions[dimension] = {
+                "status": "failed" if violations else "passed",
+                "cases_executed": len(covered),
+                "violations": violations,
+                "evidence": [case["name"] for case in covered],
+                "reason": None,
+            }
+    return {
+        "ok": oracle_check["status"] == "passed"
+        and all(case["status"] == "passed" for case in cases),
+        "kind": "semantic",
+        "oracle": "kungfu.episode.semantic-oracle/v1",
+        "oracle_check": oracle_check,
+        "cases": cases,
+        "dimensions": dimensions,
+        "errors": [
+            {
+                "code": "semantic_case_failed",
+                "case": case["name"],
+                "violations": case["violations"],
+            }
+            for case in cases
+            if case["status"] == "failed"
+        ]
+        + (
+            [
+                {
+                    "code": "semantic_oracle_check_failed",
+                    "violation": oracle_check["violation"],
+                }
+            ]
+            if oracle_check["status"] == "failed"
+            else []
+        ),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--result", required=True)
+    parser.add_argument("--runtime-root", required=True)
+    args = parser.parse_args()
+    result = run_semantic(Path(args.runtime_root))
+    _write_json(args.result, result)
+    return 0 if result["ok"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -207,11 +207,19 @@ function runEpisodeQualificationSmoke() {
     const report = JSON.parse(fs.readFileSync(reportPath, 'utf8'));
     const scenarios = report?.workload?.scenarios || [];
     const scenariosPassed = scenarios.filter((scenario) => scenario.ok).length;
+    const requiredSemanticDimensions =
+      report?.semantic_evidence?.required_dimensions || [];
+    const semanticDimensions = report?.semantic_evidence?.dimensions || {};
+    const semanticPassed = requiredSemanticDimensions.filter(
+      (dimension) => semanticDimensions[dimension]?.status === 'passed',
+    ).length;
     if (
-      report?.schema !== 'kungfu.episode.trust-report/v1' ||
+      report?.schema !== 'kungfu.episode.trust-report/v2' ||
       report?.profile !== 'mvp-smoke-v1' ||
       scenarios.length === 0 ||
-      scenariosPassed !== scenarios.length
+      scenariosPassed !== scenarios.length ||
+      requiredSemanticDimensions.length === 0 ||
+      semanticPassed !== requiredSemanticDimensions.length
     ) {
       fail(
         'Episode qualification smoke',
@@ -235,7 +243,7 @@ function runEpisodeQualificationSmoke() {
       );
     pass(
       'Episode qualification smoke',
-      `${scenariosPassed}/${scenarios.length} scenarios; busy=${busy || 0}; qualified=${String(report.qualified)}`,
+      `${scenariosPassed}/${scenarios.length} scale scenarios; ${semanticPassed}/${requiredSemanticDimensions.length} required semantic dimensions; busy=${busy || 0}; qualified=${String(report.qualified)}`,
     );
     fs.rmSync(runRoot, { recursive: true, force: true });
   } catch (error) {


### PR DESCRIPTION
## Summary

- add a Kungfu-independent Episode Semantic v1 oracle with 48 bounded histories
- replace Trust Report v1 semantic zero placeholders with v2 passed/failed/not_exercised evidence dimensions
- gate recurring smoke on 8 required production comparisons while keeping capability_soundness honestly not_exercised
- cover recovery, useful degradation, monotonic repair, dependency containment, projection rebuild, content integrity, and portable identity

## Validation

- 34 focused Episode tests passed
- ./kungfu-code check
- ./kungfu-code build:core
- ./kungfu-code freeze
- CI=1 ./kungfu-code verify (25/25; 5/5 scale, 8/8 required semantic, qualified=true)