### PR TITLE
feat(storage): process-level provider cache retires per-call lifecycle

### DIFF
--- a/framework/core/docs/storage-provider-lifecycle.md
+++ b/framework/core/docs/storage-provider-lifecycle.md
@@ -1,0 +1,83 @@
+# Storage provider lifecycle: the process-level provider cache
+
+Status: delivered (ADR-0040 decision 6 closure)
+
+ADR-0040 decision 6 states that the per-operation open/close of the storage
+provider was a lifecycle artifact, not an engine limit: RocksDB is thread-safe
+through a single long-lived handle, so within a process repeated open/close is
+removed by holding one handle owned by one provider instance. This document
+records how the runtime storage service implements that, and the semantics a
+caller may rely on. The implementation lives in
+`src/libkungfu/src/runtime/storage/service.cpp` (`provider_cache`).
+
+## What is cached, and under which key
+
+- One `storage_provider` instance per **(provider name, canonical runtime
+  dir)** within a process. The runtime dir is canonicalized
+  (`fs::absolute(...).lexically_normal()`) before it becomes part of the key,
+  so different spellings of the same directory share one instance and one
+  engine handle, and distinct runtime dirs never share a handle.
+- Every service entry point uses the cache: the operations routed through
+  `run_storage_service_operation`, the manifest/payload helpers
+  (`accept_storage_manifest`, `load_storage_latest_manifest`,
+  `export_storage_records`, `write_storage_payload_bytes`), and the five
+  content-store facade functions (`put_if_absent` / `has` / `verify` / `get` /
+  `capabilities`). No hot path constructs a provider per call.
+
+## Close and eviction semantics
+
+- **Entries live until process exit.** There is no eviction, no LRU, no
+  explicit close operation, and no background maintenance thread. Rationale:
+  the set of (runtime dir, provider) pairs a process touches is small; an
+  evicted-then-reopened engine handle would reintroduce exactly the open/close
+  races the cache removes; and a maintenance thread is out of scope by design.
+- **The cache is intentionally leaked at exit** (its destructor never runs):
+  destroying a RocksDB handle during static teardown aborts the process once
+  the engine's lock infrastructure is torn down first. Exit-without-close is
+  safe under the declared contract — publication is WAL-ordered, so it is
+  exactly the crash-safety case the backend already commits to.
+- Consequently the RocksDB write handle, once opened, **holds the engine lock
+  for the rest of the process lifetime**. This is intentional: ADR-0040
+  decision 6 requires multi-process ownership of one database path to be
+  rejected or explicitly service-fronted. A second process opening the same
+  database for write fails with the engine's own lock error — that rejection
+  is the contract, not an accident.
+
+## Handle semantics inside the cached RocksDB provider
+
+- The engine handle opens lazily and is shared: operations borrow a
+  `shared_ptr` to the handle, so a concurrent readonly-to-readwrite upgrade
+  swaps in a fresh handle while in-flight readers finish safely on the old one
+  (a readonly open holds no engine lock).
+- **Readonly operations never create the database; writes do.** This preserves
+  the pre-cache behavior: `fsck`/`status` on an empty runtime dir do not
+  materialize an engine directory, while the first write creates it
+  (`create_if_missing` only on write opens).
+- RocksDB is thread-safe through the shared handle, so N threads calling
+  `put_if_absent` concurrently against one runtime dir all succeed with
+  exactly one stored copy; identical-bytes races on the same key are benign
+  under content identity.
+- The file provider is stateless per operation (atomic tmp+rename publishes);
+  caching it unifies lifecycle observability without changing its semantics.
+
+## Not the same database as the location metadata engine
+
+`hero`'s master/app RocksDB (location metadata) lives under the locator's
+`layout::MAP` directory (`<root>/map/<role>/<namespace>/<name>/<mode>`); the
+storage provider's engine lives under `<runtime_dir>/storage/rocksdb`. The
+paths are disjoint by construction, so no database path ever has two in-process
+owners. If a future change makes these paths overlap, the overlapping engine
+must be unified into the provider cache — two handles on one path within a
+process is a defect, not a tuning choice.
+
+## Observability
+
+- `provider.runtime()` reports `instance_lifecycle: "process-cached"` plus the
+  live handle state (`closed` / `open-readonly` / `open-readwrite`).
+- The `status` and `layout` operations report `provider_cache`
+  (`lifecycle` / `entries` / `hits` / `misses`), so cache behavior is
+  inspectable without a monitoring stack.
+- The Python facade releases the GIL around the C++ call, so Python threads
+  genuinely exercise the shared handle; the concurrency fixtures in
+  `tests/python/test_content_store_facade.py` prove the dedup guarantee
+  through both providers.

--- a/framework/core/src/bindings/python/binding/py-runtime.cpp
+++ b/framework/core/src/bindings/python/binding/py-runtime.cpp
@@ -465,10 +465,15 @@ void bind(pybind11::module &&m) {
             storage_service_api::export_storage_records(runtime_dir, source_id, py_to_json(range_filter)));
       },
       py::arg("runtime_dir"), py::arg("source_id"), py::arg("range_filter") = py::dict());
+  // The content-store facade releases the GIL around the C++ call so Python
+  // threads genuinely share the process-cached provider (the concurrency the
+  // service-level lifecycle guarantees); conversions between Python and C++
+  // values stay under the GIL on both sides of the release window.
   m.def(
       "write_storage_payload_bytes",
       [](const std::string &runtime_dir, const std::string &digest, py::bytes payload) {
         const std::string raw = payload;
+        py::gil_scoped_release release;
         return storage_service_api::write_storage_payload_bytes(runtime_dir, digest, raw);
       },
       py::arg("runtime_dir"), py::arg("digest"), py::arg("payload"));
@@ -477,28 +482,47 @@ void bind(pybind11::module &&m) {
       [](const std::string &runtime_dir, const std::string &content_namespace, py::bytes payload,
          const std::string &expected_hash) {
         const std::string raw = payload;
-        return json_to_py(
-            storage_service_api::content_store_put_if_absent(runtime_dir, content_namespace, raw, expected_hash));
+        nlohmann::json result;
+        {
+          py::gil_scoped_release release;
+          result = storage_service_api::content_store_put_if_absent(runtime_dir, content_namespace, raw, expected_hash);
+        }
+        return json_to_py(result);
       },
       py::arg("runtime_dir"), py::arg("content_namespace"), py::arg("payload"), py::arg("expected_hash") = "");
-  m.def("content_store_has", &storage_service_api::content_store_has, py::arg("runtime_dir"),
-        py::arg("content_namespace"), py::arg("content_hash"));
+  m.def("content_store_has", &storage_service_api::content_store_has, py::call_guard<py::gil_scoped_release>(),
+        py::arg("runtime_dir"), py::arg("content_namespace"), py::arg("content_hash"));
   m.def(
       "content_store_verify",
       [](const std::string &runtime_dir, const std::string &content_namespace, const std::string &content_hash) {
-        return json_to_py(storage_service_api::content_store_verify(runtime_dir, content_namespace, content_hash));
+        nlohmann::json result;
+        {
+          py::gil_scoped_release release;
+          result = storage_service_api::content_store_verify(runtime_dir, content_namespace, content_hash);
+        }
+        return json_to_py(result);
       },
       py::arg("runtime_dir"), py::arg("content_namespace"), py::arg("content_hash"));
   m.def(
       "content_store_get",
       [](const std::string &runtime_dir, const std::string &content_namespace, const std::string &content_hash) {
-        return py::bytes(storage_service_api::content_store_get(runtime_dir, content_namespace, content_hash));
+        std::string bytes;
+        {
+          py::gil_scoped_release release;
+          bytes = storage_service_api::content_store_get(runtime_dir, content_namespace, content_hash);
+        }
+        return py::bytes(bytes);
       },
       py::arg("runtime_dir"), py::arg("content_namespace"), py::arg("content_hash"));
   m.def(
       "content_store_capabilities",
       [](const std::string &runtime_dir) {
-        return json_to_py(storage_service_api::content_store_capabilities(runtime_dir));
+        nlohmann::json result;
+        {
+          py::gil_scoped_release release;
+          result = storage_service_api::content_store_capabilities(runtime_dir);
+        }
+        return json_to_py(result);
       },
       py::arg("runtime_dir"));
 

--- a/framework/core/src/libkungfu/src/runtime/storage/service.cpp
+++ b/framework/core/src/libkungfu/src/runtime/storage/service.cpp
@@ -3,12 +3,14 @@
 #include <kungfu/runtime/storage/service.h>
 
 #include <algorithm>
+#include <atomic>
 #include <charconv>
 #include <cstdlib>
 #include <filesystem>
 #include <fstream>
 #include <functional>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <random>
 #include <stdexcept>
@@ -519,9 +521,8 @@ public:
 
   [[nodiscard]] nlohmann::json runtime() const override {
     return {
-        {"lifecycle", "stateless-filesystem"},
-        {"handle", "per filesystem operation"},
-        {"readonly_open_creates_backend", false},
+        {"lifecycle", "stateless-filesystem"},  {"instance_lifecycle", "process-cached"},
+        {"handle", "per filesystem operation"}, {"readonly_open_creates_backend", false},
         {"write_open_creates_backend", true},
     };
   }
@@ -645,7 +646,9 @@ private:
 // races on the same key are benign under content identity.
 class rocksdb_content_store : public yy_storage::content_store {
 public:
-  using engine_opener = std::function<rocksdb::DB *(bool write)>;
+  // Returns a shared handle so an in-flight operation keeps its engine alive
+  // across a concurrent readonly-to-readwrite upgrade in the provider.
+  using engine_opener = std::function<std::shared_ptr<rocksdb::DB>(bool write)>;
 
   explicit rocksdb_content_store(engine_opener open) : open_(std::move(open)) {}
 
@@ -690,8 +693,8 @@ public:
     }
     result.hash = digest;
     result.byte_length = size;
-    auto *db = open_(true);
-    if (db == nullptr) {
+    auto db = open_(true);
+    if (!db) {
       result.error = yy_storage::content_store_error::IoError;
       result.message = "cannot open storage engine for write";
       return result;
@@ -734,8 +737,8 @@ public:
         yy_storage::content_store_error::Ok) {
       return false;
     }
-    auto *db = open_(false);
-    if (db == nullptr) {
+    auto db = open_(false);
+    if (!db) {
       return false;
     }
     std::string existing;
@@ -794,8 +797,8 @@ private:
     if (digest_error != yy_storage::content_store_error::Ok) {
       return digest_error;
     }
-    auto *db = open_(false);
-    if (db == nullptr) {
+    auto db = open_(false);
+    if (!db) {
       message = "no storage engine at this runtime dir";
       return yy_storage::content_store_error::NotFound;
     }
@@ -837,8 +840,10 @@ public:
   }
 
   [[nodiscard]] nlohmann::json runtime() const override {
+    std::lock_guard<std::mutex> lock(db_mutex_);
     return {
         {"lifecycle", "provider-instance-owned"},
+        {"instance_lifecycle", "process-cached"},
         {"handle", db_ ? (db_writable_ ? "open-readwrite" : "open-readonly") : "closed"},
         {"readonly_open_creates_backend", false},
         {"write_open_creates_backend", true},
@@ -973,10 +978,16 @@ private:
     return "manifest/" + source_id + "/latest";
   }
 
-  [[nodiscard]] rocksdb::DB *open(bool write) const {
+  // Lazily opens the engine and hands back a shared handle. RocksDB is
+  // thread-safe through one handle, so concurrent operations share it; the
+  // readonly-to-readwrite upgrade swaps in a fresh handle while in-flight
+  // readers finish on the old one (a readonly open holds no engine lock).
+  // Readonly opens still never create the database; only writes do.
+  [[nodiscard]] std::shared_ptr<rocksdb::DB> open(bool write) const {
+    std::lock_guard<std::mutex> lock(db_mutex_);
     if (db_) {
       if (!write || db_writable_) {
-        return db_.get();
+        return db_;
       }
       db_.reset();
       db_writable_ = false;
@@ -998,9 +1009,9 @@ private:
     if (!status.ok()) {
       throw std::runtime_error("rocksdb_open_failed: " + status.ToString());
     }
-    db_.reset(raw);
+    db_ = std::shared_ptr<rocksdb::DB>(raw);
     db_writable_ = write;
-    return db_.get();
+    return db_;
   }
 
   [[nodiscard]] bool get(const std::string &key, std::string &value) const {
@@ -1046,7 +1057,8 @@ private:
 
   std::string runtime_dir_;
   mutable rocksdb_content_store content_store_;
-  mutable std::unique_ptr<rocksdb::DB> db_ = {};
+  mutable std::mutex db_mutex_;
+  mutable std::shared_ptr<rocksdb::DB> db_ = {};
   mutable bool db_writable_ = false;
   rocksdb::ReadOptions read_options_ = [] {
     rocksdb::ReadOptions options;
@@ -1056,30 +1068,89 @@ private:
   rocksdb::WriteOptions write_options_ = {};
 };
 
-std::unique_ptr<storage_provider> make_provider(const storage_service_options &options) {
-  const auto provider = select_provider(options.provider);
-  if (provider.name == PROVIDER_ROCKSDB) {
-    return std::make_unique<rocksdb_storage_provider>(options.runtime_dir);
+std::unique_ptr<storage_provider> make_provider(const std::string &provider_name, const std::string &runtime_dir) {
+  if (provider_name == PROVIDER_ROCKSDB) {
+    return std::make_unique<rocksdb_storage_provider>(runtime_dir);
   }
-  return std::make_unique<file_storage_provider>(options.runtime_dir);
+  return std::make_unique<file_storage_provider>(runtime_dir);
 }
 
-std::unique_ptr<storage_provider> make_provider(const std::string &runtime_dir) {
+// ADR-0040 decision 6: the per-operation provider open/close was a lifecycle
+// artifact, not an engine limit. One long-lived provider per (canonical
+// runtime dir, provider) is shared by every operation in this process, so
+// concurrent facade/service calls share one engine handle instead of racing
+// for the engine lock. Entries live until process exit: the touched
+// (runtime dir, provider) set is small, an evicted-then-reused handle would
+// reintroduce the open/close races this cache removes, and a background
+// eviction thread is out of scope by design. The engine's own lock keeps
+// rejecting a second process on the same database path — holding the write
+// handle for the process lifetime is that decision made visible, and hero's
+// location-metadata engine lives under layout::MAP, a disjoint path from
+// this provider's storage/rocksdb, so no path ever has two in-process owners.
+class provider_cache {
+public:
+  static provider_cache &instance() {
+    // Intentionally leaked: cached engine handles must not run destructors
+    // during static teardown (RocksDB aborts once its lock infrastructure is
+    // torn down first). Never closing on exit loses nothing under the
+    // declared contract — publication is WAL-ordered, so exit-without-close
+    // is exactly the crash-safety case the backend already commits to.
+    static auto *cache = new provider_cache();
+    return *cache;
+  }
+
+  [[nodiscard]] std::shared_ptr<storage_provider> acquire(const storage_service_options &options) {
+    const auto selection = select_provider(options.provider);
+    const auto runtime_dir = absolute_normalized(options.runtime_dir).string();
+    const auto key = selection.name + "|" + runtime_dir;
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (const auto it = providers_.find(key); it != providers_.end()) {
+      hits_.fetch_add(1, std::memory_order_relaxed);
+      return it->second;
+    }
+    misses_.fetch_add(1, std::memory_order_relaxed);
+    return providers_.emplace(key, make_provider(selection.name, runtime_dir)).first->second;
+  }
+
+  [[nodiscard]] nlohmann::json stats() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return {
+        {"lifecycle", "process"},
+        {"entries", providers_.size()},
+        {"hits", hits_.load(std::memory_order_relaxed)},
+        {"misses", misses_.load(std::memory_order_relaxed)},
+    };
+  }
+
+private:
+  provider_cache() = default;
+
+  mutable std::mutex mutex_;
+  std::unordered_map<std::string, std::shared_ptr<storage_provider>> providers_;
+  std::atomic<uint64_t> hits_{0};
+  std::atomic<uint64_t> misses_{0};
+};
+
+std::shared_ptr<storage_provider> shared_provider(const storage_service_options &options) {
+  return provider_cache::instance().acquire(options);
+}
+
+std::shared_ptr<storage_provider> shared_provider(const std::string &runtime_dir) {
   storage_service_options options;
   options.runtime_dir = runtime_dir;
-  return make_provider(options);
+  return shared_provider(options);
 }
 
 // Bundle a provider with an episode store wired to its content store, so
 // payload-ref resolution reads the same backend that published the bytes
 // (ADR-0040); the provider member keeps the injected store alive.
 struct episode_store_with_provider {
-  std::unique_ptr<storage_provider> provider;
+  std::shared_ptr<storage_provider> provider;
   yy_storage::episode_manifest_store store;
 };
 
 episode_store_with_provider episode_ref_store(const storage_service_options &options) {
-  auto provider = make_provider(options);
+  auto provider = shared_provider(options);
   auto store = yy_storage::episode_manifest_store(options.runtime_dir);
   store.set_content_store(&provider->content_store());
   return {std::move(provider), std::move(store)};
@@ -1107,6 +1178,8 @@ nlohmann::json workspace_episode_layout(const storage_service_options &options, 
       {"config_home", optional_absolute_path(options.operation_options, "config_home")},
       {"provider", provider.name()},
       {"provider_layout", provider.layout()},
+      {"provider_runtime", provider.runtime()},
+      {"provider_cache", provider_cache::instance().stats()},
       {"paths",
        {{"data_home", home.string()},
         {"runtime_dir", runtime.string()},
@@ -2224,7 +2297,7 @@ nlohmann::json apply_source_bundle_material(const storage_service_options &optio
   if (source_id.empty()) {
     throw std::invalid_argument("repair_apply_source_id_required");
   }
-  const auto provider = make_provider(options);
+  const auto provider = shared_provider(options);
   auto manifest = load_latest_manifest_impl(*provider, source_id);
   if (manifest.is_null()) {
     throw std::runtime_error("manifest not found: " + source_id);
@@ -2876,7 +2949,7 @@ nlohmann::json list_sources_impl(const storage_provider &provider) {
 }
 
 nlohmann::json status_impl(const storage_service_options &options) {
-  const auto provider = make_provider(options);
+  const auto provider = shared_provider(options);
   auto sources = nlohmann::json::array();
   for (const auto &source : list_sources_impl(*provider)) {
     if (options.source_id.empty() || text_or(source, "source_id") == options.source_id) {
@@ -2893,6 +2966,7 @@ nlohmann::json status_impl(const storage_service_options &options) {
       {"provider", provider->name()},
       {"provider_config_source", options.provider_config_source},
       {"provider_runtime", provider->runtime()},
+      {"provider_cache", provider_cache::instance().stats()},
       {"scope", options.source_id.empty() ? "all" : "source"},
       {"source_id", options.source_id.empty() ? nlohmann::json(nullptr) : nlohmann::json(options.source_id)},
       {"sources", sources},
@@ -2958,7 +3032,7 @@ nlohmann::json fsck_impl(const storage_service_options &options) {
   if (options.scope == "episode") {
     return episode_fsck_impl(options);
   }
-  const auto provider = make_provider(options);
+  const auto provider = shared_provider(options);
   nlohmann::json registry;
   try {
     registry = provider->load_registry();
@@ -3164,7 +3238,7 @@ nlohmann::json fsck_impl(const storage_service_options &options) {
 }
 
 nlohmann::json rebuild_index_impl(const storage_service_options &options) {
-  const auto provider = make_provider(options);
+  const auto provider = shared_provider(options);
   nlohmann::json old_registry;
   try {
     old_registry = provider->load_registry();
@@ -3241,7 +3315,7 @@ nlohmann::json gc_plan_impl(const storage_service_options &options) {
   if (!options.dry_run) {
     throw std::invalid_argument("storage_gc_requires_dry_run");
   }
-  const auto provider = make_provider(options);
+  const auto provider = shared_provider(options);
   const auto referenced = referenced_payload_hashes(*provider, options.source_id);
   const auto payloads = provider->all_payloads();
   nlohmann::json candidates = nlohmann::json::array();
@@ -3284,7 +3358,7 @@ nlohmann::json compact_plan_impl(const storage_service_options &options) {
   rebuild_options.dry_run = true;
   const auto rebuild = rebuild_index_impl(rebuild_options);
   const auto garbage = gc_plan_impl(rebuild_options);
-  const auto provider = make_provider(options);
+  const auto provider = shared_provider(options);
   nlohmann::json manifests = nlohmann::json::array();
   for (const auto &record : provider->manifest_records(options.source_id)) {
     if (!record.value.is_object()) {
@@ -3350,7 +3424,7 @@ public:
     if (options.scope == "episode") {
       return episode_export_bundle_impl(options);
     }
-    const auto provider = make_provider(options);
+    const auto provider = shared_provider(options);
     const auto manifest = load_latest_manifest_impl(*provider, options.source_id);
     if (manifest.is_null()) {
       throw std::runtime_error("manifest not found: " + options.source_id);
@@ -3409,7 +3483,7 @@ public:
         }
       }
     }
-    const auto provider = make_provider(options);
+    const auto provider = shared_provider(options);
     for (const auto &record : records) {
       if (!record.is_object() || !record.contains("payload")) {
         continue;
@@ -3474,14 +3548,14 @@ public:
       import_result = import_bundle(import_options);
       imported_report = fsck_impl(import_options);
       imported_report = replace_string_subtree(imported_report, temp_root.string(), "<sync-runtime>");
-      const auto import_provider = make_provider(import_options);
+      const auto import_provider = shared_provider(import_options);
       imported_manifest = load_latest_manifest_impl(*import_provider, options.source_id);
       fs::remove_all(temp_root);
     } catch (...) {
       fs::remove_all(temp_root);
       throw;
     }
-    const auto provider = make_provider(options);
+    const auto provider = shared_provider(options);
     const auto local_manifest = load_latest_manifest_impl(*provider, options.source_id);
     const auto local_root = local_manifest.is_object() && local_manifest.contains("sync_root")
                                 ? local_manifest.at("sync_root")
@@ -3507,7 +3581,7 @@ public:
   }
 
   [[nodiscard]] nlohmann::json layout(const storage_service_options &options) const override {
-    const auto provider = make_provider(options);
+    const auto provider = shared_provider(options);
     return workspace_episode_layout(options, *provider);
   }
 
@@ -3935,7 +4009,7 @@ nlohmann::json run_storage_service_operation(const std::string &operation, const
 }
 
 nlohmann::json accept_storage_manifest(const std::string &runtime_dir, const nlohmann::json &manifest) {
-  const auto provider = make_provider(runtime_dir);
+  const auto provider = shared_provider(runtime_dir);
   const auto generic = yy_storage::build_storage_import_manifest(manifest);
   for (const auto &issue : yy_storage::verify_storage_import_manifest(generic)) {
     if (issue.severity != "warning") {
@@ -3954,13 +4028,13 @@ nlohmann::json accept_storage_manifest(const std::string &runtime_dir, const nlo
 }
 
 nlohmann::json load_storage_latest_manifest(const std::string &runtime_dir, const std::string &source_id) {
-  const auto provider = make_provider(runtime_dir);
+  const auto provider = shared_provider(runtime_dir);
   return load_latest_manifest_impl(*provider, source_id);
 }
 
 nlohmann::json export_storage_records(const std::string &runtime_dir, const std::string &source_id,
                                       const nlohmann::json &range) {
-  const auto provider = make_provider(runtime_dir);
+  const auto provider = shared_provider(runtime_dir);
   const auto manifest = load_latest_manifest_impl(*provider, source_id);
   if (manifest.is_null()) {
     throw std::runtime_error("manifest not found: " + source_id);
@@ -3993,7 +4067,7 @@ std::string write_storage_payload_bytes(const std::string &runtime_dir, const st
   if (!error.empty()) {
     throw std::invalid_argument("storage_payload_invalid: " + error);
   }
-  const auto provider = make_provider(runtime_dir);
+  const auto provider = shared_provider(runtime_dir);
   provider->write_payload(digest, raw);
   return provider->name() == PROVIDER_ROCKSDB ? storage_uri(PROVIDER_ROCKSDB, runtime_dir, "payloads/" + digest)
                                               : payload_path(runtime_dir, digest).string();
@@ -4043,7 +4117,7 @@ nlohmann::json content_store_put_if_absent(const std::string &runtime_dir, const
       return invalid_content_hash_json(message);
     }
   }
-  const auto provider = make_provider(runtime_dir);
+  const auto provider = shared_provider(runtime_dir);
   return content_result_json(provider->content_store().put_if_absent(content_namespace, raw, expected));
 }
 
@@ -4054,7 +4128,7 @@ bool content_store_has(const std::string &runtime_dir, const std::string &conten
   if (!parse_content_hash_text(content_hash_text, hash, message)) {
     return false;
   }
-  const auto provider = make_provider(runtime_dir);
+  const auto provider = shared_provider(runtime_dir);
   return provider->content_store().has(content_namespace, hash);
 }
 
@@ -4065,7 +4139,7 @@ nlohmann::json content_store_verify(const std::string &runtime_dir, const std::s
   if (!parse_content_hash_text(content_hash_text, hash, message)) {
     return invalid_content_hash_json(message);
   }
-  const auto provider = make_provider(runtime_dir);
+  const auto provider = shared_provider(runtime_dir);
   return content_result_json(provider->content_store().verify(content_namespace, hash));
 }
 
@@ -4076,7 +4150,7 @@ std::string content_store_get(const std::string &runtime_dir, const std::string 
   if (!parse_content_hash_text(content_hash_text, hash, message)) {
     throw std::invalid_argument("content_store_get: " + message);
   }
-  const auto provider = make_provider(runtime_dir);
+  const auto provider = shared_provider(runtime_dir);
   auto result = provider->content_store().get(content_namespace, hash);
   if (!result.ok()) {
     throw std::runtime_error(std::string("content_store_get_failed: ") +
@@ -4087,7 +4161,7 @@ std::string content_store_get(const std::string &runtime_dir, const std::string 
 }
 
 nlohmann::json content_store_capabilities(const std::string &runtime_dir) {
-  const auto provider = make_provider(runtime_dir);
+  const auto provider = shared_provider(runtime_dir);
   const auto caps = provider->content_store().capabilities();
   return {{"provider", provider->name()},
           {"profile", caps.profile},

--- a/framework/core/tests/python/test_content_store_facade.py
+++ b/framework/core/tests/python/test_content_store_facade.py
@@ -12,6 +12,7 @@
 from __future__ import annotations
 
 import hashlib
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import pytest
@@ -133,6 +134,67 @@ def test_fsck_resolves_refs_through_the_selected_backend(tmp_path, provider):
         assert not object_path.exists()
     else:
         assert object_path.exists()
+
+
+def test_concurrent_put_if_absent_shares_one_provider(tmp_path, provider):
+    # ADR-0040 decision 6: facade calls share one process-cached provider per
+    # (runtime dir, provider), so N threads publishing the same bytes must all
+    # succeed with exactly one stored copy and zero engine-lock errors. Before
+    # the provider cache this deadlocked rocksdb on its own LOCK file.
+    runtime_dir = tmp_path / "runtime"
+    raw = f"concurrent dedup via {provider}".encode()
+    digest = _digest(raw)
+    threads, attempts = 8, 32
+
+    with ThreadPoolExecutor(max_workers=threads) as pool:
+        results = list(
+            pool.map(
+                lambda _: content_store.put_if_absent(runtime_dir, "payloads", raw),
+                range(attempts),
+            )
+        )
+
+    assert all(r["ok"] for r in results)
+    assert all(r["error"] == "ok" for r in results)
+    assert all(r["hash"]["value"] == digest for r in results)
+    # at least one attempt performed the initial publication; racing
+    # publishers of identical bytes are benign under content identity
+    assert any(not r["existed"] for r in results)
+
+    assert content_store.get(runtime_dir, "payloads", digest) == raw
+    assert content_store.verify(runtime_dir, "payloads", digest)["ok"]
+    if provider == "content-addressed-file":
+        object_dir = Path(runtime_dir) / "storage" / "payloads" / digest[:2]
+        assert [p.name for p in object_dir.iterdir()] == [digest]
+
+
+def test_concurrent_readers_and_writers_stay_consistent(tmp_path, provider):
+    runtime_dir = tmp_path / "runtime"
+    payloads = [f"object {i} via {provider}".encode() for i in range(16)]
+
+    def publish_and_read(raw: bytes) -> None:
+        digest = _digest(raw)
+        put = content_store.put_if_absent(runtime_dir, "payloads", raw)
+        assert put["ok"], put
+        assert content_store.has(runtime_dir, "payloads", digest)
+        assert content_store.get(runtime_dir, "payloads", digest) == raw
+        assert content_store.verify(runtime_dir, "payloads", digest)["ok"]
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        list(pool.map(publish_and_read, payloads * 4))
+
+
+def test_status_reports_the_cached_provider(tmp_path, provider):
+    runtime_dir = tmp_path / "runtime"
+    assert content_store.put_if_absent(runtime_dir, "payloads", b"observable")["ok"]
+
+    status = service.status(runtime_dir)
+    cache = status["provider_cache"]
+    assert cache["lifecycle"] == "process"
+    assert cache["entries"] >= 1
+    # the facade call above seeded the cache, so status reuses that provider
+    assert cache["hits"] >= 1
+    assert status["provider_runtime"]["instance_lifecycle"] == "process-cached"
 
 
 def test_sealed_missing_ref_fails_under_both_backends(tmp_path, provider):

--- a/framework/core/tests/storage-node-binding.test.js
+++ b/framework/core/tests/storage-node-binding.test.js
@@ -297,7 +297,33 @@ for (const providerCase of providerCases) {
 
           const nodeResults = selectedNodeResults(runtimeDir);
           const pythonResults = selectedPythonResults(runtimeDir);
-          assert.deepEqual(nodeResults, pythonResults);
+          // the provider cache and its live handle state are process-local
+          // observability (each runtime is its own process with its own
+          // cache), so they are asserted per-process and excluded from the
+          // cross-runtime equality contract
+          assert.equal(
+            nodeResults.status.provider_runtime.instance_lifecycle,
+            'process-cached',
+          );
+          assert.equal(nodeResults.status.provider_cache.lifecycle, 'process');
+          assert.ok(nodeResults.status.provider_cache.entries >= 1);
+          assert.ok(nodeResults.status.provider_cache.hits >= 1);
+          const stripProcessLocal = (results) => {
+            const strip = ({
+              provider_runtime: _runtime,
+              provider_cache: _cache,
+              ...rest
+            }) => rest;
+            return {
+              ...results,
+              status: strip(results.status),
+              layout: strip(results.layout),
+            };
+          };
+          assert.deepEqual(
+            stripProcessLocal(nodeResults),
+            stripProcessLocal(pythonResults),
+          );
           assert.equal(
             nodeResults.status.provider,
             providerCase.expectedProvider,


### PR DESCRIPTION
Close ADR-0040 decision 6: one process-cached provider per (provider, canonical runtime dir); thread-safe shared rocksdb handle; GIL released around the content-store facade; concurrency dedup fixtures for both providers; cache observability in status/layout; lifecycle doc.