### PR TITLE
feat(storage): add Episode Qualification Capability Contract v1

### DIFF
--- a/docs/episode-atomicity-qualification.md
+++ b/docs/episode-atomicity-qualification.md
@@ -119,6 +119,7 @@ comparisons can support a claim.
 The recurring `mvp-smoke-v1` gate requires these dimensions to pass:
 
 - lifecycle safety;
+- capability soundness;
 - useful degradation;
 - repair monotonicity;
 - direct dependency failure containment;
@@ -127,11 +128,43 @@ The recurring `mvp-smoke-v1` gate requires these dimensions to pass:
 - content integrity and immutable put-if-absent behavior;
 - export/import preservation of Episode identity and causal counts.
 
-`capability_soundness` is explicitly `not_exercised`: the content-store backend
-declares storage capabilities, but the production Episode fold does not yet emit
-the safe-operation capability report required by ADR-0042. Semantic v1 does not
-invent an edge-layer substitute or count an unexecuted check as zero violations.
-This is a visible remaining implementation stage, not a silent pass.
+### Capability Contract v1
+
+The production C++ fsck path now emits
+`kungfu.episode.qualification/v1`. The result is derived from the typed Episode
+fold and the current fsck evidence; Python, Node and CLI surfaces return the
+same JSON projection without reconstructing policy. The contract contains:
+
+- lifecycle and overall qualification status;
+- named evidence dimensions with explicit `verified`, `not_applicable`,
+  `not_checked`, `missing`, `degraded`, or `failed` state;
+- structured issues linked back to their evidence dimension;
+- every v1 capability with its evidence requirements and concrete blockers;
+- the exact `safe_capabilities` projection and explicit contractions;
+- repair prerequisites derived from the same issue vocabulary used by the
+  storage repair plan, including dedicated projection-rebuild prerequisites.
+
+The deliberately small v1 vocabulary is `inspect`, `fsck`, `export_evidence`,
+`plan_repair`, `rebuild_projection`, `append`, `replay`, and `depend_on`.
+Forensic and evidence-preserving operations remain safe when an Episode's
+content or causal closure is degraded. `append` additionally requires an open
+lifecycle and valid manifest structure. `replay` and `depend_on` require an
+ended Episode plus verified manifest integrity and causal closure, with content,
+frames, and schemas either verified or not applicable. A present but unchecked
+frame/schema claim therefore contracts consuming capabilities rather than being
+silently treated as verified.
+
+This result is a qualification decision, not proof that every future execution
+endpoint already enforces it. Callers adding a replay, query, import-accept, or
+other consuming endpoint must gate that endpoint on the C++ result rather than
+copy its predicates. Adding a capability or changing a precondition requires a
+new contract version plus oracle/profile compatibility qualification.
+
+Semantic v1 now compares the oracle's exact safe-capability set with production
+across missing, healthy-open, degraded-open, healthy-ended, failed-ended, and
+degraded-aborted states. It also checks that the per-capability rows,
+`safe_capabilities`, and contraction projection agree. Both over-advertising and
+unnecessary contraction fail the required `capability_soundness` dimension.
 
 ## Fault matrix
 
@@ -507,11 +540,11 @@ Each run records at least:
         "reason": null
       },
       "capability_soundness": {
-        "status": "not_exercised",
-        "cases_executed": 0,
+        "status": "passed",
+        "cases_executed": 1,
         "violations": [],
-        "evidence": [],
-        "reason": "production Episode safe-capability report is not implemented"
+        "evidence": ["capability-contract"],
+        "reason": null
       }
     }
   },
@@ -595,7 +628,6 @@ DAGs, faults, and soak remains required before a broader qualification claim.
 
 ## Open questions
 
-- What is the smallest stable capability vocabulary for v1?
 - Which capability decisions require fresh full fsck, cached verification, or
   verification-on-use?
 - Which missing evidence is optional, intentionally absent, recoverable, or

--- a/docs/episode-object-model.md
+++ b/docs/episode-object-model.md
@@ -323,10 +323,10 @@ inspection or export.
 
 ADR-0042 tightens the intended interpretation without turning degradation into
 a deletion policy: lifecycle, health, and safe capabilities are separate
-dimensions. A future structured qualification result should state which
-operations remain safe and why; the current `ok` field must be read in its
-documented scope rather than as a claim that every Episode capability is fully
-available.
+dimensions. `kungfu.episode.qualification/v1` now states which operations remain
+safe, their evidence requirements, their blockers, and repair prerequisites.
+The compatibility `ok` field must still be read in its documented fsck scope;
+it is not a substitute for the capability contract.
 
 `kungfu.storage.repair-plan/v1` is the first repair-facing projection over that
 diagnostic set. It maps the Episode warnings to read-only candidates such as

--- a/framework/core/docs/adr/ADR-0042-episode-atomic-safety-and-qualification.md
+++ b/framework/core/docs/adr/ADR-0042-episode-atomic-safety-and-qualification.md
@@ -256,7 +256,10 @@ fault matrices, commands, SLOs, and report schema evolve in
 
 1. Define a versioned internal Episode qualification result containing evidence
    dimensions, issues, and safe capabilities; project it through the existing
-   edge JSON without breaking v1 consumers.
+   edge JSON without breaking v1 consumers. Delivered as
+   `kungfu.episode.qualification/v1`: one C++-owned typed result projected by
+   scoped fsck and inspect, with capability requirements, contractions and
+   repair prerequisites.
 2. Build an independent, executable reference model for lifecycle, dependency,
    capability, repair, and interruption states; compare the C++ typed fold/fsck
    result against it with generated histories.

--- a/framework/core/src/libkungfu/include/kungfu/runtime/storage/service.h
+++ b/framework/core/src/libkungfu/include/kungfu/runtime/storage/service.h
@@ -12,6 +12,47 @@ namespace kungfu::runtime::storage_service_api {
 
 inline constexpr const char *RUNTIME_STORAGE_SERVICE_SCHEMA_V1 = "kungfu.runtime.storage-service/v1";
 inline constexpr const char *RUNTIME_STORAGE_SERVICE_OWNER = "libkungfu";
+inline constexpr const char *EPISODE_QUALIFICATION_SCHEMA_V1 = "kungfu.episode.qualification/v1";
+
+// ADR-0042 Capability Contract v1.  This is the C++-owned result derived from
+// the typed Episode fold plus fsck evidence.  Language bindings and CLIs only
+// serialize this result; they must not infer their own capability policy.
+struct episode_qualification_evidence {
+  std::string name = {};
+  std::string state = {};
+  std::vector<std::string> issue_codes = {};
+};
+
+struct episode_qualification_issue {
+  std::string severity = {};
+  std::string code = {};
+  std::string evidence = {};
+  nlohmann::json detail = nlohmann::json::object();
+};
+
+struct episode_qualification_capability {
+  std::string name = {};
+  bool safe = false;
+  std::vector<std::string> required_evidence = {};
+  std::vector<std::string> blocked_by = {};
+};
+
+struct episode_repair_prerequisite {
+  std::string issue_code = {};
+  std::string action = {};
+  std::vector<std::string> required_inputs = {};
+  nlohmann::json subject = nlohmann::json::object();
+};
+
+struct episode_qualification_result {
+  uint64_t episode_id = 0;
+  std::string lifecycle = "missing";
+  std::string status = "failed";
+  std::vector<episode_qualification_evidence> evidence = {};
+  std::vector<episode_qualification_issue> issues = {};
+  std::vector<episode_qualification_capability> capabilities = {};
+  std::vector<episode_repair_prerequisite> repair_prerequisites = {};
+};
 
 enum class storage_operation {
   Status,

--- a/framework/core/src/libkungfu/src/runtime/storage/service.cpp
+++ b/framework/core/src/libkungfu/src/runtime/storage/service.cpp
@@ -1903,6 +1903,253 @@ episode_frame_verification verify_episode_frame_claims(const storage_service_opt
   return result;
 }
 
+struct episode_repair_descriptor {
+  std::string action = {};
+  std::vector<std::string> required_inputs = {};
+};
+
+std::optional<episode_repair_descriptor> episode_repair_descriptor_for_issue(const nlohmann::json &issue) {
+  const auto code = text_or(issue, "code");
+  if (code == "episode_dependency_missing") {
+    return episode_repair_descriptor{"fetch_episode", {"source_or_episode_bundle"}};
+  }
+  if (code == "episode_root_trigger_frame_missing" || code == "episode_trigger_frame_missing") {
+    return episode_repair_descriptor{"fetch_frame_or_declare_external_input", {"source_or_episode_bundle"}};
+  }
+  if (code == "episode_payload_ref_missing" || code == "episode_payload_ref_hash_mismatch") {
+    return episode_repair_descriptor{"fetch_payload_by_hash", {"payload_store_or_episode_bundle"}};
+  }
+  if (code == "episode_attached_frame_missing") {
+    return episode_repair_descriptor{"fetch_frame", {"source_or_episode_bundle"}};
+  }
+  if (code == "episode_projection_absent" || code == "episode_projection_drift") {
+    return episode_repair_descriptor{"rebuild_projection", {}};
+  }
+  if (code == "payload_not_present" && !bool_or(issue, "intentional", true)) {
+    return episode_repair_descriptor{"fetch_payload_by_hash", {"source_or_bundle"}};
+  }
+  return std::nullopt;
+}
+
+std::string episode_issue_evidence(const std::string &code) {
+  if (code.rfind("episode_payload_ref_", 0) == 0) {
+    return "content";
+  }
+  if (code.rfind("episode_attached_frame_", 0) == 0 || code == "episode_frame_location_unknown" ||
+      code == "episode_frame_integrity_version_unknown") {
+    return "frames";
+  }
+  if (code == "episode_dependency_missing" || code == "episode_root_trigger_frame_missing" ||
+      code == "episode_trigger_frame_missing") {
+    return "causal_closure";
+  }
+  if (code.rfind("episode_projection_", 0) == 0) {
+    return "projection";
+  }
+  return "manifest_integrity";
+}
+
+void append_unique(std::vector<std::string> &values, const std::string &value) {
+  if (std::find(values.begin(), values.end(), value) == values.end()) {
+    values.push_back(value);
+  }
+}
+
+episode_qualification_evidence *find_episode_evidence(episode_qualification_result &result, const std::string &name) {
+  const auto iter = std::find_if(result.evidence.begin(), result.evidence.end(),
+                                 [&name](const auto &entry) { return entry.name == name; });
+  return iter == result.evidence.end() ? nullptr : &*iter;
+}
+
+const episode_qualification_evidence *find_episode_evidence(const episode_qualification_result &result,
+                                                            const std::string &name) {
+  const auto iter = std::find_if(result.evidence.begin(), result.evidence.end(),
+                                 [&name](const auto &entry) { return entry.name == name; });
+  return iter == result.evidence.end() ? nullptr : &*iter;
+}
+
+episode_qualification_capability make_episode_capability(const std::string &name,
+                                                         std::vector<std::pair<std::string, bool>> requirements) {
+  episode_qualification_capability capability;
+  capability.name = name;
+  capability.safe = true;
+  for (const auto &[requirement, satisfied] : requirements) {
+    capability.required_evidence.push_back(requirement);
+    if (!satisfied) {
+      capability.safe = false;
+      capability.blocked_by.push_back(requirement);
+    }
+  }
+  return capability;
+}
+
+episode_qualification_result make_episode_qualification(const nlohmann::json &report, bool frames_checked) {
+  episode_qualification_result result;
+  result.episode_id = uint64_or(report, "episode_id");
+  result.status = text_or(report, "status", "failed");
+  const auto manifest_report = object_or_empty(report, "episode_manifest");
+  const auto episode = object_or_empty(manifest_report, "episode");
+  const bool exists = !episode.empty();
+  result.lifecycle = exists ? text_or(episode, "status", "dangling") : "missing";
+  const auto frame_count = uint64_or(episode, "frame_count");
+  const auto payload_ref_count = uint64_or(episode, "payload_ref_count");
+  const auto schema_ref_count = uint64_or(episode, "schema_ref_count");
+
+  result.evidence = {
+      {"manifest_records", exists ? "verified" : "failed", {}},
+      {"manifest_integrity", exists ? "verified" : "failed", {}},
+      {"causal_closure", exists ? "verified" : "failed", {}},
+      {"content", payload_ref_count == 0 ? "not_applicable" : "verified", {}},
+      {"frames", frame_count == 0 ? "not_applicable" : (frames_checked ? "verified" : "not_checked"), {}},
+      {"schemas", schema_ref_count == 0 ? "not_applicable" : "not_checked", {}},
+      {"projection", "not_checked", {}},
+  };
+
+  const auto add_issue = [&result](const nlohmann::json &detail, const std::string &severity) {
+    episode_qualification_issue issue;
+    issue.severity = severity;
+    issue.code = text_or(detail, "code", "episode_issue_unknown");
+    issue.evidence = episode_issue_evidence(issue.code);
+    issue.detail = detail;
+    result.issues.push_back(issue);
+    if (auto *evidence = find_episode_evidence(result, issue.evidence); evidence != nullptr) {
+      append_unique(evidence->issue_codes, issue.code);
+      if (severity == "error") {
+        evidence->state = "failed";
+      } else if (severity == "warning" && evidence->state != "failed") {
+        evidence->state = "degraded";
+      }
+    }
+  };
+  for (const auto &error : array_or_empty(report, "errors")) {
+    add_issue(error, "error");
+  }
+  for (const auto &warning : array_or_empty(report, "warnings")) {
+    add_issue(warning, "warning");
+  }
+
+  const auto projection = object_or_empty(report, "episode_projection");
+  const auto projection_status = text_or(projection, "status", "not_checked");
+  if (auto *evidence = find_episode_evidence(result, "projection"); evidence != nullptr) {
+    if (!exists) {
+      evidence->state = "not_applicable";
+    } else if (projection_status == "ok") {
+      evidence->state = "verified";
+    } else if (projection_status == "absent") {
+      evidence->state = "missing";
+      add_issue({{"code", "episode_projection_absent"}, {"status", projection_status}}, "info");
+    } else if (projection_status == "degraded") {
+      evidence->state = "degraded";
+      add_issue({{"code", "episode_projection_drift"},
+                 {"status", projection_status},
+                 {"drift", projection.value("drift", nlohmann::json::array())}},
+                "warning");
+    } else {
+      evidence->state = "failed";
+      add_issue({{"code", "episode_projection_unavailable"}, {"status", projection_status}}, "error");
+    }
+  }
+
+  const auto state = [&result](const std::string &name) {
+    const auto *evidence = find_episode_evidence(result, name);
+    return evidence == nullptr ? std::string("missing") : evidence->state;
+  };
+  const auto verified = [&state](const std::string &name) { return state(name) == "verified"; };
+  const auto verified_or_not_applicable = [&state](const std::string &name) {
+    const auto value = state(name);
+    return value == "verified" || value == "not_applicable";
+  };
+  const bool records_readable = verified("manifest_records");
+  const bool manifest_valid = verified("manifest_integrity");
+  result.capabilities = {
+      make_episode_capability("inspect", {{"manifest_records=verified", records_readable}}),
+      make_episode_capability("fsck", {{"manifest_records=verified", records_readable}}),
+      make_episode_capability("export_evidence", {{"manifest_records=verified", records_readable}}),
+      make_episode_capability("plan_repair", {{"manifest_records=verified", records_readable}}),
+      make_episode_capability("rebuild_projection", {{"manifest_records=verified", records_readable},
+                                                     {"manifest_integrity=verified", manifest_valid}}),
+      make_episode_capability("append", {{"lifecycle=open", result.lifecycle == "open"},
+                                         {"manifest_records=verified", records_readable},
+                                         {"manifest_integrity=verified", manifest_valid}}),
+      make_episode_capability("replay", {{"lifecycle=ended", result.lifecycle == "ended"},
+                                         {"manifest_records=verified", records_readable},
+                                         {"manifest_integrity=verified", manifest_valid},
+                                         {"causal_closure=verified", verified("causal_closure")},
+                                         {"content=verified|not_applicable", verified_or_not_applicable("content")},
+                                         {"frames=verified|not_applicable", verified_or_not_applicable("frames")},
+                                         {"schemas=verified|not_applicable", verified_or_not_applicable("schemas")}}),
+      make_episode_capability("depend_on",
+                              {{"lifecycle=ended", result.lifecycle == "ended"},
+                               {"manifest_records=verified", records_readable},
+                               {"manifest_integrity=verified", manifest_valid},
+                               {"causal_closure=verified", verified("causal_closure")},
+                               {"content=verified|not_applicable", verified_or_not_applicable("content")},
+                               {"frames=verified|not_applicable", verified_or_not_applicable("frames")},
+                               {"schemas=verified|not_applicable", verified_or_not_applicable("schemas")}}),
+  };
+
+  for (const auto &issue : result.issues) {
+    const auto descriptor = episode_repair_descriptor_for_issue(issue.detail);
+    if (!descriptor.has_value()) {
+      continue;
+    }
+    nlohmann::json subject = nlohmann::json::object();
+    for (const auto *field :
+         {"episode_id", "dependency_episode_id", "frame_uid", "dependent_frame_uid", "ref_id", "ref_hash", "role"}) {
+      if (issue.detail.contains(field) && !issue.detail.at(field).is_null()) {
+        subject[field] = issue.detail.at(field);
+      }
+    }
+    result.repair_prerequisites.push_back(
+        {issue.code, descriptor->action, descriptor->required_inputs, std::move(subject)});
+  }
+  return result;
+}
+
+nlohmann::json episode_qualification_json(const episode_qualification_result &result) {
+  nlohmann::json evidence = nlohmann::json::object();
+  for (const auto &entry : result.evidence) {
+    evidence[entry.name] = {{"state", entry.state}, {"issue_codes", entry.issue_codes}};
+  }
+  nlohmann::json issues = nlohmann::json::array();
+  for (const auto &issue : result.issues) {
+    issues.push_back(
+        {{"severity", issue.severity}, {"code", issue.code}, {"evidence", issue.evidence}, {"detail", issue.detail}});
+  }
+  nlohmann::json capabilities = nlohmann::json::array();
+  nlohmann::json safe_capabilities = nlohmann::json::array();
+  nlohmann::json contractions = nlohmann::json::array();
+  for (const auto &capability : result.capabilities) {
+    capabilities.push_back({{"name", capability.name},
+                            {"safe", capability.safe},
+                            {"requires", capability.required_evidence},
+                            {"blocked_by", capability.blocked_by}});
+    if (capability.safe) {
+      safe_capabilities.push_back(capability.name);
+    } else {
+      contractions.push_back({{"capability", capability.name}, {"blocked_by", capability.blocked_by}});
+    }
+  }
+  nlohmann::json repair_prerequisites = nlohmann::json::array();
+  for (const auto &prerequisite : result.repair_prerequisites) {
+    repair_prerequisites.push_back({{"issue_code", prerequisite.issue_code},
+                                    {"action", prerequisite.action},
+                                    {"required_inputs", prerequisite.required_inputs},
+                                    {"subject", prerequisite.subject}});
+  }
+  return {{"schema", EPISODE_QUALIFICATION_SCHEMA_V1},
+          {"policy_source", "cpp-typed-fold-fsck"},
+          {"episode_id", result.episode_id},
+          {"lifecycle", result.lifecycle},
+          {"status", result.status},
+          {"evidence", evidence},
+          {"issues", issues},
+          {"capabilities", capabilities},
+          {"safe_capabilities", safe_capabilities},
+          {"contractions", contractions},
+          {"repair_prerequisites", repair_prerequisites}};
+}
+
 nlohmann::json episode_fsck_impl(const storage_service_options &options) {
   const auto scoped = episode_ref_store(options);
   const auto episode_report = scoped.store.fsck(options.episode_id);
@@ -1961,6 +2208,10 @@ nlohmann::json episode_fsck_impl(const storage_service_options &options) {
     report["ok"] = ok;
     report["degraded"] = degraded;
     report["status"] = ok ? (degraded ? "degraded" : "ok") : "failed";
+  }
+  if (options.episode_id != 0) {
+    report["qualification"] = episode_qualification_json(
+        make_episode_qualification(report, bool_or(options.operation_options, "verify_frames", false)));
   }
   return report;
 }
@@ -2023,32 +2274,40 @@ nlohmann::json repair_candidate_common(const nlohmann::json &warning, const std:
 
 nlohmann::json repair_candidate_from_warning(const nlohmann::json &warning) {
   const auto code = text_or(warning, "code");
+  const auto descriptor = episode_repair_descriptor_for_issue(warning);
+  if (!descriptor.has_value()) {
+    return nullptr;
+  }
+  std::string candidate_code;
+  std::string kind;
+  std::string role;
   if (code == "episode_dependency_missing") {
-    return repair_candidate_common(warning, "repair_episode_dependency", "episode", text_or(warning, "role", "ref"),
-                                   "fetch_episode", nlohmann::json::array({"source_or_episode_bundle"}));
+    candidate_code = "repair_episode_dependency";
+    kind = "episode";
+    role = text_or(warning, "role", "ref");
+  } else if (code == "episode_root_trigger_frame_missing") {
+    candidate_code = "repair_episode_root_trigger_frame";
+    kind = "frame";
+    role = "root_trigger";
+  } else if (code == "episode_trigger_frame_missing") {
+    candidate_code = "repair_episode_trigger_frame";
+    kind = "frame";
+    role = "trigger";
+  } else if (code == "episode_payload_ref_missing" || code == "episode_payload_ref_hash_mismatch") {
+    candidate_code = "repair_episode_payload_ref";
+    kind = "payload";
+    role = "payload_ref";
+  } else if (code == "payload_not_present") {
+    candidate_code = "repair_source_payload";
+    kind = "payload";
+    role = "source_record";
+  } else {
+    // Projection repair is exposed by the qualification contract through the
+    // dedicated rebuild operation, not as a storage repair-plan bundle row.
+    return nullptr;
   }
-  if (code == "episode_root_trigger_frame_missing") {
-    return repair_candidate_common(warning, "repair_episode_root_trigger_frame", "frame", "root_trigger",
-                                   "fetch_frame_or_declare_external_input",
-                                   nlohmann::json::array({"source_or_episode_bundle"}));
-  }
-  if (code == "episode_trigger_frame_missing") {
-    return repair_candidate_common(warning, "repair_episode_trigger_frame", "frame", "trigger",
-                                   "fetch_frame_or_declare_external_input",
-                                   nlohmann::json::array({"source_or_episode_bundle"}));
-  }
-  if (code == "episode_payload_ref_missing" || code == "episode_payload_ref_hash_mismatch") {
-    return repair_candidate_common(warning, "repair_episode_payload_ref", "payload", "payload_ref",
-                                   "fetch_payload_by_hash", nlohmann::json::array({"payload_store_or_episode_bundle"}));
-  }
-  if (code == "payload_not_present") {
-    if (bool_or(warning, "intentional", true)) {
-      return nullptr;
-    }
-    return repair_candidate_common(warning, "repair_source_payload", "payload", "source_record",
-                                   "fetch_payload_by_hash", nlohmann::json::array({"source_or_bundle"}));
-  }
-  return nullptr;
+  return repair_candidate_common(warning, candidate_code, kind, role, descriptor->action,
+                                 nlohmann::json(descriptor->required_inputs));
 }
 
 nlohmann::json repair_plan_impl(const storage_service_options &options) {
@@ -3542,7 +3801,12 @@ public:
   }
 
   [[nodiscard]] nlohmann::json episode_inspect(const storage_service_options &options) const override {
-    return episode_ref_store(options).store.inspect(uint64_or(options.operation_options, "episode_id"));
+    auto inspected = episode_ref_store(options).store.inspect(options.episode_id);
+    auto qualification_options = options;
+    qualification_options.scope = "episode";
+    const auto qualification_report = episode_fsck_impl(qualification_options);
+    inspected["qualification"] = qualification_report.at("qualification");
+    return inspected;
   }
 
   [[nodiscard]] nlohmann::json episode_recover(const storage_service_options &options) const override {

--- a/framework/core/src/libyijinjing/src/storage/episode_manifest.cpp
+++ b/framework/core/src/libyijinjing/src/storage/episode_manifest.cpp
@@ -407,6 +407,15 @@ nlohmann::json summary_json(const episode_current_view &view) {
   summary["record_count"] = view.records.size();
   summary["frame_count"] = view.frame_indices.size();
   summary["ref_count"] = view.ref_indices.size();
+  size_t payload_ref_count = 0;
+  size_t schema_ref_count = 0;
+  for (size_t position = 0; position < view.ref_indices.size(); ++position) {
+    const auto kind = view.ref_at(position).ref_kind;
+    payload_ref_count += kind == EpisodeRefKind::Payload ? 1 : 0;
+    schema_ref_count += kind == EpisodeRefKind::Schema ? 1 : 0;
+  }
+  summary["payload_ref_count"] = payload_ref_count;
+  summary["schema_ref_count"] = schema_ref_count;
   if (!summary.contains("status")) {
     summary["status"] = view.opened ? "open" : "dangling";
   }
@@ -873,11 +882,15 @@ nlohmann::json episode_manifest_store::fsck(uint64_t episode_id) const {
   nlohmann::json warnings = nlohmann::json::array();
   size_t checked = 0;
   bool degraded = false;
+  nlohmann::json scoped_episode = nullptr;
   for (const auto &[current_episode_id, view] : fold.episodes) {
     if (episode_id != 0 && current_episode_id != episode_id) {
       continue;
     }
     ++checked;
+    if (episode_id != 0) {
+      scoped_episode = summary_json(view);
+    }
     if (!view.opened) {
       errors.push_back({{"code", "episode_open_missing"}, {"episode_id", current_episode_id}});
     }
@@ -955,19 +968,23 @@ nlohmann::json episode_manifest_store::fsck(uint64_t episode_id) const {
   if (episode_id != 0 && checked == 0) {
     errors.push_back({{"code", "episode_missing"}, {"episode_id", episode_id}});
   }
-  return {{"ok", errors.empty()},
-          {"status", errors.empty() ? (degraded ? "degraded" : "ok") : "failed"},
-          {"schema", EPISODE_MANIFEST_SCHEMA_V1},
-          {"runtime_dir", runtime_dir_},
-          {"authority", "yijinjing-journal"},
-          {"degraded", degraded},
-          {"errors", errors},
-          {"warnings", warnings},
-          {"checked",
-           {{"episode_manifest_records", fold.total_record_count},
-            {"episodes", checked},
-            {"unknown_records", fold.unknown_record_count},
-            {"unfolded_records", fold.unfolded_record_count}}}};
+  nlohmann::json report = {{"ok", errors.empty()},
+                           {"status", errors.empty() ? (degraded ? "degraded" : "ok") : "failed"},
+                           {"schema", EPISODE_MANIFEST_SCHEMA_V1},
+                           {"runtime_dir", runtime_dir_},
+                           {"authority", "yijinjing-journal"},
+                           {"degraded", degraded},
+                           {"errors", errors},
+                           {"warnings", warnings},
+                           {"checked",
+                            {{"episode_manifest_records", fold.total_record_count},
+                             {"episodes", checked},
+                             {"unknown_records", fold.unknown_record_count},
+                             {"unfolded_records", fold.unfolded_record_count}}}};
+  if (episode_id != 0) {
+    report["episode"] = scoped_episode;
+  }
+  return report;
 }
 
 } // namespace kungfu::yijinjing::storage

--- a/framework/core/tests/python/test_episode_manifest_fsck.py
+++ b/framework/core/tests/python/test_episode_manifest_fsck.py
@@ -15,10 +15,12 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import struct
 from pathlib import Path
 
 import kungfu
+import jsonschema
 
 from kungfu.storage import service
 from kungfu.storage.episode_lifecycle import RuntimeEpisodeLifecycle
@@ -221,12 +223,18 @@ def test_verify_frames_confirms_real_recorded_frames(tmp_path):
     lifecycle.record_event("test.step", b'{"step":2}', run_id="r1")
     lifecycle.close(ok=True)
 
+    unchecked = service.fsck(runtime_dir, episode_id=lifecycle.episode_id)
+    assert unchecked["qualification"]["evidence"]["frames"]["state"] == "not_checked"
+    assert _capability(unchecked["qualification"], "replay")["safe"] is False
+
     fsck = service.fsck(
         runtime_dir, episode_id=lifecycle.episode_id, verify_frames=True
     )
     assert fsck["ok"]
     assert fsck["status"] == "ok"
     assert fsck["checked"]["episode_frames_verified"] == 2
+    assert fsck["qualification"]["evidence"]["frames"]["state"] == "verified"
+    assert _capability(fsck["qualification"], "replay")["safe"] is True
 
 
 def test_verify_frames_fails_sealed_episode_with_missing_journal(tmp_path):
@@ -247,6 +255,14 @@ def test_verify_frames_fails_sealed_episode_with_missing_journal(tmp_path):
     assert fsck["status"] == "failed"
     codes = [e["code"] for e in fsck["errors"]]
     assert "episode_attached_frame_missing" in codes
+    qualification = fsck["qualification"]
+    assert qualification["evidence"]["frames"]["state"] == "failed"
+    assert "inspect" in qualification["safe_capabilities"]
+    assert _capability(qualification, "replay")["safe"] is False
+    assert {
+        (row["issue_code"], row["action"])
+        for row in qualification["repair_prerequisites"]
+    } >= {("episode_attached_frame_missing", "fetch_frame")}
 
 
 def test_verify_frames_degrades_open_episode_with_missing_journal(tmp_path):
@@ -266,6 +282,8 @@ def test_verify_frames_degrades_open_episode_with_missing_journal(tmp_path):
     assert fsck["degraded"] is True
     codes = [w["code"] for w in fsck["warnings"]]
     assert "episode_attached_frame_missing" in codes
+    assert fsck["qualification"]["evidence"]["frames"]["state"] == "degraded"
+    assert "append" in fsck["qualification"]["safe_capabilities"]
 
 
 def test_verify_frames_detects_tampered_payload(tmp_path):
@@ -423,3 +441,121 @@ def test_lifecycle_attach_publishes_into_content_store(tmp_path):
     fsck = service.fsck(runtime_dir, episode_id=lifecycle.episode_id)
     assert fsck["ok"]
     assert fsck["status"] == "ok"
+
+
+# ---- ADR-0042 Capability Contract v1 ----
+
+
+def _capability(qualification: dict, name: str) -> dict:
+    return next(row for row in qualification["capabilities"] if row["name"] == name)
+
+
+def test_healthy_sealed_episode_emits_versioned_safe_capabilities(tmp_path):
+    runtime_dir = tmp_path / "runtime"
+    _begin(runtime_dir, 51)
+    _seal(runtime_dir, 51)
+
+    fsck = service.fsck(runtime_dir, episode_id=51)
+    qualification = fsck["qualification"]
+    assert qualification["schema"] == "kungfu.episode.qualification/v1"
+    assert qualification["policy_source"] == "cpp-typed-fold-fsck"
+    assert qualification["lifecycle"] == "ended"
+    assert qualification["status"] == "ok"
+    assert qualification["evidence"]["manifest_records"]["state"] == "verified"
+    assert qualification["evidence"]["frames"]["state"] == "not_applicable"
+    assert qualification["evidence"]["content"]["state"] == "not_applicable"
+    assert {"inspect", "fsck", "export_evidence", "replay", "depend_on"} <= set(
+        qualification["safe_capabilities"]
+    )
+    assert _capability(qualification, "append")["safe"] is False
+    assert _capability(qualification, "append")["blocked_by"] == ["lifecycle=open"]
+
+    inspected = service.episode_inspect(runtime_dir, episode_id=51)
+    assert inspected["qualification"] == qualification
+
+
+def test_open_degradation_preserves_append_and_evidence_export(tmp_path):
+    runtime_dir = tmp_path / "runtime"
+    _begin(runtime_dir, 52)
+    absent = hashlib.sha256(b"capability missing payload").hexdigest()
+    _attach_payload_ref(runtime_dir, 52, f"sha256:{absent}")
+
+    qualification = service.fsck(runtime_dir, episode_id=52)["qualification"]
+    assert qualification["status"] == "degraded"
+    assert qualification["evidence"]["content"]["state"] == "degraded"
+    assert {"inspect", "export_evidence", "append", "plan_repair"} <= set(
+        qualification["safe_capabilities"]
+    )
+    assert _capability(qualification, "replay")["safe"] is False
+    assert "lifecycle=ended" in _capability(qualification, "replay")["blocked_by"]
+    assert (
+        "content=verified|not_applicable"
+        in _capability(qualification, "replay")["blocked_by"]
+    )
+    assert {
+        (row["issue_code"], row["action"])
+        for row in qualification["repair_prerequisites"]
+    } >= {("episode_payload_ref_missing", "fetch_payload_by_hash")}
+
+
+def test_failed_episode_contracts_consuming_capabilities_not_forensics(tmp_path):
+    runtime_dir = tmp_path / "runtime"
+    _begin(runtime_dir, 53)
+    absent = hashlib.sha256(b"sealed capability missing payload").hexdigest()
+    _attach_payload_ref(runtime_dir, 53, f"sha256:{absent}")
+    _seal(runtime_dir, 53)
+
+    qualification = service.fsck(runtime_dir, episode_id=53)["qualification"]
+    assert qualification["status"] == "failed"
+    assert qualification["evidence"]["content"]["state"] == "failed"
+    assert {"inspect", "fsck", "export_evidence", "plan_repair"} <= set(
+        qualification["safe_capabilities"]
+    )
+    assert _capability(qualification, "replay")["safe"] is False
+    assert _capability(qualification, "depend_on")["safe"] is False
+
+
+def test_unverified_schema_claim_contracts_decode_consumers(tmp_path):
+    runtime_dir = tmp_path / "runtime"
+    _begin(runtime_dir, 55)
+    service.episode_attach_ref(
+        runtime_dir,
+        episode_id=55,
+        ref_kind="schema",
+        ref_id="qualification/schema-v1",
+        ref_hash="sha256:" + "1" * 64,
+    )
+    _seal(runtime_dir, 55)
+
+    qualification = service.fsck(runtime_dir, episode_id=55)["qualification"]
+    assert qualification["status"] == "ok"
+    assert qualification["evidence"]["schemas"]["state"] == "not_checked"
+    assert "export_evidence" in qualification["safe_capabilities"]
+    assert _capability(qualification, "replay")["safe"] is False
+    assert (
+        "schemas=verified|not_applicable"
+        in _capability(qualification, "replay")["blocked_by"]
+    )
+
+
+def test_missing_episode_advertises_no_episode_capability(tmp_path):
+    qualification = service.fsck(tmp_path / "runtime", episode_id=999)["qualification"]
+    assert qualification["lifecycle"] == "missing"
+    assert qualification["status"] == "failed"
+    assert qualification["safe_capabilities"] == []
+
+
+def test_episode_qualification_v1_schema_accepts_production_result(tmp_path):
+    runtime_dir = tmp_path / "runtime"
+    _begin(runtime_dir, 54)
+    _seal(runtime_dir, 54)
+    qualification = service.fsck(runtime_dir, episode_id=54)["qualification"]
+    schema_path = (
+        Path(__file__).resolve().parents[1]
+        / "qualification"
+        / "episode"
+        / "schemas"
+        / "episode-qualification-v1.schema.json"
+    )
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    jsonschema.validate(qualification, schema)

--- a/framework/core/tests/python/test_episode_qualification_semantic_oracle.py
+++ b/framework/core/tests/python/test_episode_qualification_semantic_oracle.py
@@ -64,6 +64,32 @@ def test_projection_is_derived_and_journal_change_marks_it_stale():
     assert oracle.observe().status == "ok"
 
 
+def test_capability_contract_preserves_forensics_and_contracts_consumers():
+    oracle = EpisodeOracle()
+    assert oracle.observe().safe_capabilities == ()
+    oracle.begin()
+    assert "append" in oracle.observe().safe_capabilities
+    assert "replay" not in oracle.observe().safe_capabilities
+    oracle.attach_payload("artifact", Evidence.MISSING)
+    assert {"inspect", "export_evidence", "plan_repair"} <= set(
+        oracle.observe().safe_capabilities
+    )
+    oracle.end()
+    assert oracle.observe().status == "failed"
+    assert "replay" not in oracle.observe().safe_capabilities
+    assert "depend_on" not in oracle.observe().safe_capabilities
+
+
+def test_aborted_episode_does_not_claim_a_content_seal():
+    oracle = EpisodeOracle()
+    oracle.begin()
+    oracle.attach_payload("artifact", Evidence.MISSING)
+    oracle.abort()
+    assert oracle.observe().status == "degraded"
+    assert "append" not in oracle.observe().safe_capabilities
+    assert "replay" not in oracle.observe().safe_capabilities
+
+
 def test_bounded_payload_dependency_histories_preserve_core_invariants():
     assert exhaust_bounded_histories() == 48
 

--- a/framework/core/tests/qualification/episode/README.md
+++ b/framework/core/tests/qualification/episode/README.md
@@ -60,12 +60,13 @@ storage service for:
 - direct dependency failure containment;
 - projection absence, drift, and rebuild convergence;
 - export/import preservation of Episode identity and causal counts.
+- exact safe-capability agreement for missing, open, ended, aborted, degraded,
+  failed, repaired, and projection-derived states.
 
 Trust Report v2 records every semantic dimension as `passed`, `failed`, or
 `not_exercised`. A dimension can pass only when a production comparison ran.
-`capability_soundness` remains `not_exercised` until the production Episode
-safe-capability report exists; it is therefore not part of the current MVP
-required-dimension set.
+`capability_soundness` compares the independent oracle with the C++-owned
+`kungfu.episode.qualification/v1` result and is required by both MVP profiles.
 
 ## Result boundary
 
@@ -91,5 +92,7 @@ open Episode, or fresh-process mismatch fails the scenario.
 - `semantic_oracle.py` is the dependency-free abstract model.
 - `semantic_workload.py` performs bounded model-versus-production comparisons.
 - `profiles/*.json` are versioned workload and progress policies.
+- `schemas/episode-qualification-v1.schema.json` validates the production
+  capability contract.
 - `schemas/trust-report-v2.schema.json` validates current reports; v1 remains
   checked in so historical evidence stays readable.

--- a/framework/core/tests/qualification/episode/profiles/mvp-baseline-v1.json
+++ b/framework/core/tests/qualification/episode/profiles/mvp-baseline-v1.json
@@ -28,6 +28,7 @@
   "semantic": {
     "required_dimensions": [
       "lifecycle_safety",
+      "capability_soundness",
       "useful_degradation",
       "repair_monotonicity",
       "dependency_containment",

--- a/framework/core/tests/qualification/episode/profiles/mvp-smoke-v1.json
+++ b/framework/core/tests/qualification/episode/profiles/mvp-smoke-v1.json
@@ -28,6 +28,7 @@
   "semantic": {
     "required_dimensions": [
       "lifecycle_safety",
+      "capability_soundness",
       "useful_degradation",
       "repair_monotonicity",
       "dependency_containment",

--- a/framework/core/tests/qualification/episode/run.mjs
+++ b/framework/core/tests/qualification/episode/run.mjs
@@ -780,7 +780,6 @@ async function main() {
     'Episode projection derivation is exercised, but large projection rebuild cost is not measured',
     'single-node local filesystem only; no service-backed or distributed qualification',
     'publication coverage exercises an interrupted open Episode; torn journal/page crash points remain in deterministic fixtures',
-    'production Episode safe-capability reporting is not implemented, so capability_soundness is not_exercised',
     'no absolute performance SLO is adopted by the v0 profile',
   ];
   if (options.mode !== 'all') {

--- a/framework/core/tests/qualification/episode/schemas/episode-qualification-v1.schema.json
+++ b/framework/core/tests/qualification/episode/schemas/episode-qualification-v1.schema.json
@@ -1,0 +1,174 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kungfu.tech/schemas/episode-qualification-v1.schema.json",
+  "title": "Kungfu Episode Qualification Capability Contract v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "policy_source",
+    "episode_id",
+    "lifecycle",
+    "status",
+    "evidence",
+    "issues",
+    "capabilities",
+    "safe_capabilities",
+    "contractions",
+    "repair_prerequisites"
+  ],
+  "properties": {
+    "schema": { "const": "kungfu.episode.qualification/v1" },
+    "policy_source": { "const": "cpp-typed-fold-fsck" },
+    "episode_id": { "type": "integer", "minimum": 0 },
+    "lifecycle": {
+      "enum": ["missing", "dangling", "open", "ended", "aborted", "tombstoned"]
+    },
+    "status": { "enum": ["ok", "degraded", "failed"] },
+    "evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "manifest_records",
+        "manifest_integrity",
+        "causal_closure",
+        "content",
+        "frames",
+        "schemas",
+        "projection"
+      ],
+      "properties": {
+        "manifest_records": { "$ref": "#/$defs/evidence" },
+        "manifest_integrity": { "$ref": "#/$defs/evidence" },
+        "causal_closure": { "$ref": "#/$defs/evidence" },
+        "content": { "$ref": "#/$defs/evidence" },
+        "frames": { "$ref": "#/$defs/evidence" },
+        "schemas": { "$ref": "#/$defs/evidence" },
+        "projection": { "$ref": "#/$defs/evidence" }
+      }
+    },
+    "issues": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/issue" }
+    },
+    "capabilities": {
+      "type": "array",
+      "minItems": 8,
+      "items": { "$ref": "#/$defs/capability" }
+    },
+    "safe_capabilities": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": { "$ref": "#/$defs/capabilityName" }
+    },
+    "contractions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["capability", "blocked_by"],
+        "properties": {
+          "capability": { "$ref": "#/$defs/capabilityName" },
+          "blocked_by": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "type": "string", "minLength": 1 }
+          }
+        }
+      }
+    },
+    "repair_prerequisites": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/repairPrerequisite" }
+    }
+  },
+  "$defs": {
+    "evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["state", "issue_codes"],
+      "properties": {
+        "state": {
+          "enum": [
+            "verified",
+            "not_applicable",
+            "not_checked",
+            "missing",
+            "degraded",
+            "failed"
+          ]
+        },
+        "issue_codes": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "issue": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["severity", "code", "evidence", "detail"],
+      "properties": {
+        "severity": { "enum": ["info", "warning", "error"] },
+        "code": { "type": "string", "minLength": 1 },
+        "evidence": {
+          "enum": [
+            "manifest_records",
+            "manifest_integrity",
+            "causal_closure",
+            "content",
+            "frames",
+            "schemas",
+            "projection"
+          ]
+        },
+        "detail": { "type": "object" }
+      }
+    },
+    "capabilityName": {
+      "enum": [
+        "inspect",
+        "fsck",
+        "export_evidence",
+        "plan_repair",
+        "rebuild_projection",
+        "append",
+        "replay",
+        "depend_on"
+      ]
+    },
+    "capability": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "safe", "requires", "blocked_by"],
+      "properties": {
+        "name": { "$ref": "#/$defs/capabilityName" },
+        "safe": { "type": "boolean" },
+        "requires": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "blocked_by": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "repairPrerequisite": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["issue_code", "action", "required_inputs", "subject"],
+      "properties": {
+        "issue_code": { "type": "string", "minLength": 1 },
+        "action": { "type": "string", "minLength": 1 },
+        "required_inputs": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "subject": { "type": "object" }
+      }
+    }
+  }
+}

--- a/framework/core/tests/qualification/episode/semantic_oracle.py
+++ b/framework/core/tests/qualification/episode/semantic_oracle.py
@@ -14,7 +14,7 @@ from itertools import product
 
 
 class Lifecycle(str, Enum):
-    ABSENT = "absent"
+    ABSENT = "missing"
     OPEN = "open"
     ENDED = "ended"
     ABORTED = "aborted"
@@ -93,6 +93,15 @@ class EpisodeOracle:
             self.projection = "stale"
 
     def observe(self) -> Observation:
+        if self.lifecycle is Lifecycle.ABSENT:
+            return Observation(
+                lifecycle=self.lifecycle.value,
+                status="failed",
+                issue_classes=("episode_missing",),
+                safe_capabilities=(),
+                projection=self.projection,
+            )
+
         issue_classes: list[str] = []
         payload_issues = {
             evidence
@@ -108,7 +117,7 @@ class EpisodeOracle:
         if self.projection == "stale":
             issue_classes.append("projection_stale")
 
-        sealed = self.lifecycle in (Lifecycle.ENDED, Lifecycle.ABORTED)
+        sealed = self.lifecycle is Lifecycle.ENDED
         if sealed and payload_issues:
             status = "failed"
         elif issue_classes:
@@ -116,13 +125,18 @@ class EpisodeOracle:
         else:
             status = "ok"
 
-        capabilities = ["inspect", "export_evidence"]
-        if status != "failed":
-            capabilities.append("continue_independent_work")
-        if issue_classes:
-            capabilities.append("plan_repair")
-        if self.lifecycle is Lifecycle.OPEN and status != "failed":
+        capabilities = [
+            "inspect",
+            "fsck",
+            "export_evidence",
+            "plan_repair",
+            "rebuild_projection",
+        ]
+        if self.lifecycle is Lifecycle.OPEN:
             capabilities.append("append")
+        consuming_issues = payload_issues or self.missing_dependencies
+        if self.lifecycle is Lifecycle.ENDED and not consuming_issues:
+            capabilities.extend(("replay", "depend_on"))
 
         return Observation(
             lifecycle=self.lifecycle.value,
@@ -182,7 +196,7 @@ def exhaust_bounded_histories() -> int:
         observed = oracle.observe()
         if observed.lifecycle != terminal:
             raise AssertionError("bounded-history lifecycle mismatch")
-        if terminal != "open" and evidence is not Evidence.PRESENT and not repair:
+        if terminal == "ended" and evidence is not Evidence.PRESENT and not repair:
             if observed.status != "failed":
                 raise AssertionError("sealed missing evidence was not failed")
         checked += 1

--- a/framework/core/tests/qualification/episode/semantic_workload.py
+++ b/framework/core/tests/qualification/episode/semantic_workload.py
@@ -79,6 +79,33 @@ def _end(service: Any, runtime_dir: Path, episode_id: int) -> None:
     )
 
 
+def _expect_capability_contract(
+    oracle: EpisodeOracle, report: dict[str, Any], label: str
+) -> dict[str, Any]:
+    qualification = report["qualification"]
+    expected = oracle.observe()
+    actual_safe = tuple(sorted(qualification["safe_capabilities"]))
+    _expect(qualification["lifecycle"], expected.lifecycle, f"{label} lifecycle")
+    _expect(qualification["status"], expected.status, f"{label} status")
+    _expect(actual_safe, expected.safe_capabilities, f"{label} safe capabilities")
+    rows = {row["name"]: row for row in qualification["capabilities"]}
+    _expect(
+        tuple(sorted(name for name, row in rows.items() if row["safe"])),
+        actual_safe,
+        f"{label} safe row projection",
+    )
+    _expect(
+        tuple(sorted(row["capability"] for row in qualification["contractions"])),
+        tuple(sorted(name for name, row in rows.items() if not row["safe"])),
+        f"{label} contraction projection",
+    )
+    return {
+        "lifecycle": qualification["lifecycle"],
+        "status": qualification["status"],
+        "safe_capabilities": list(actual_safe),
+    }
+
+
 def _case_lifecycle_recovery(service: Any, _: Any, root: Path) -> dict[str, Any]:
     runtime_dir = root / "lifecycle-recovery"
     oracle = EpisodeOracle()
@@ -306,6 +333,98 @@ def _case_portable_identity(service: Any, _: Any, root: Path) -> dict[str, Any]:
     }
 
 
+def _case_capability_contract(
+    service: Any, content_store: Any, root: Path
+) -> dict[str, Any]:
+    runtime_dir = root / "capability-contract"
+    snapshots: dict[str, Any] = {}
+
+    missing = EpisodeOracle()
+    snapshots["missing"] = _expect_capability_contract(
+        missing,
+        service.fsck(runtime_dir, episode_id=699),
+        "missing Episode",
+    )
+
+    raw = b"capability qualification payload"
+    ref_hash = f"sha256:{hashlib.sha256(raw).hexdigest()}"
+    oracle = EpisodeOracle()
+    oracle.begin()
+    _begin(service, runtime_dir, 601)
+    snapshots["open"] = _expect_capability_contract(
+        oracle,
+        service.episode_inspect(runtime_dir, episode_id=601),
+        "healthy open Episode",
+    )
+
+    oracle.attach_payload("payload", Evidence.MISSING)
+    service.episode_attach_ref(
+        runtime_dir,
+        episode_id=601,
+        ref_kind="payload",
+        ref_id="qualification/capability.bin",
+        ref_hash=ref_hash,
+    )
+    degraded = service.fsck(runtime_dir, episode_id=601)
+    snapshots["degraded_open"] = _expect_capability_contract(
+        oracle, degraded, "degraded open Episode"
+    )
+    _expect(
+        "append" in degraded["qualification"]["safe_capabilities"],
+        True,
+        "degradation must preserve append",
+    )
+
+    content_store.put_if_absent(runtime_dir, "payloads", raw, expected_hash=ref_hash)
+    oracle.restore_payload("payload")
+    oracle.end()
+    _end(service, runtime_dir, 601)
+    snapshots["healthy_ended"] = _expect_capability_contract(
+        oracle,
+        service.fsck(runtime_dir, episode_id=601),
+        "healthy ended Episode",
+    )
+
+    failed = EpisodeOracle()
+    failed.begin()
+    failed.attach_payload("payload", Evidence.MISSING)
+    failed.end()
+    _begin(service, runtime_dir, 602)
+    service.episode_attach_ref(
+        runtime_dir,
+        episode_id=602,
+        ref_kind="payload",
+        ref_id="qualification/missing.bin",
+        ref_hash=f"sha256:{hashlib.sha256(b'missing capability payload').hexdigest()}",
+    )
+    _end(service, runtime_dir, 602)
+    snapshots["failed_ended"] = _expect_capability_contract(
+        failed,
+        service.fsck(runtime_dir, episode_id=602),
+        "failed ended Episode",
+    )
+
+    aborted = EpisodeOracle()
+    aborted.begin()
+    aborted.attach_payload("payload", Evidence.MISSING)
+    aborted.abort()
+    _begin(service, runtime_dir, 603)
+    service.episode_attach_ref(
+        runtime_dir,
+        episode_id=603,
+        ref_kind="payload",
+        ref_id="qualification/aborted.bin",
+        ref_hash=f"sha256:{hashlib.sha256(b'aborted missing payload').hexdigest()}",
+    )
+    service.episode_abort(runtime_dir, episode_id=603, reason="qualification")
+    snapshots["degraded_aborted"] = _expect_capability_contract(
+        aborted,
+        service.fsck(runtime_dir, episode_id=603),
+        "degraded aborted Episode",
+    )
+    return {"contract": "kungfu.episode.qualification/v1", "snapshots": snapshots}
+
+
 CASES: tuple[
     tuple[str, tuple[str, ...], Callable[[Any, Any, Path], dict[str, Any]]], ...
 ] = (
@@ -326,6 +445,11 @@ CASES: tuple[
     ),
     ("projection-derivation", ("projection_derivation",), _case_projection),
     ("portable-identity", ("portable_identity",), _case_portable_identity),
+    (
+        "capability-contract",
+        ("capability_soundness",),
+        _case_capability_contract,
+    ),
 )
 
 
@@ -376,15 +500,7 @@ def run_semantic(runtime_root: Path) -> dict[str, Any]:
             for case in covered
             for message in case["violations"]
         ]
-        if dimension == "capability_soundness":
-            dimensions[dimension] = {
-                "status": "not_exercised",
-                "cases_executed": 0,
-                "violations": [],
-                "evidence": [],
-                "reason": "production Episode safe-capability report is not implemented",
-            }
-        elif not covered:
+        if not covered:
             dimensions[dimension] = {
                 "status": "not_exercised",
                 "cases_executed": 0,

--- a/framework/core/tests/storage-node-binding.test.js
+++ b/framework/core/tests/storage-node-binding.test.js
@@ -376,6 +376,61 @@ for (const providerCase of providerCases) {
   );
 }
 
+test(
+  'Node projects the C++ Episode qualification contract without re-derivation',
+  {
+    skip:
+      nativeAvailable || process.env.KUNGFU_REQUIRE_NATIVE === '1'
+        ? false
+        : 'built kungfu_node binding is unavailable',
+  },
+  () => {
+    const runtimeDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'kf-episode-qualification-node-'),
+    );
+    try {
+      kungfu.runStorageServiceOperation('episode_begin', runtimeDir, {
+        episode_id: 901,
+        title: 'node qualification projection',
+        actor: 'node-test',
+        source: 'storage-node-binding',
+        begin_time: 1000,
+      });
+      kungfu.runStorageServiceOperation('episode_end', runtimeDir, {
+        episode_id: 901,
+        end_time: 2000,
+        frame_count: 0,
+        reason: 'done',
+      });
+      const fsck = kungfu.runStorageServiceOperation('fsck', runtimeDir, {
+        scope: 'episode',
+        episode_id: 901,
+      });
+      const inspected = kungfu.runStorageServiceOperation(
+        'episode_inspect',
+        runtimeDir,
+        { episode_id: 901 },
+      );
+      assert.equal(
+        fsck.qualification.schema,
+        'kungfu.episode.qualification/v1',
+      );
+      assert.equal(fsck.qualification.policy_source, 'cpp-typed-fold-fsck');
+      assert.deepEqual(inspected.qualification, fsck.qualification);
+      assert.equal(
+        fsck.qualification.safe_capabilities.includes('replay'),
+        true,
+      );
+      assert.equal(
+        fsck.qualification.safe_capabilities.includes('append'),
+        false,
+      );
+    } finally {
+      fs.rmSync(runtimeDir, { recursive: true, force: true });
+    }
+  },
+);
+
 // ADR-0040 stage B: the content-store facade serves Node with the same
 // vocabulary as C++/Python over both provider profiles.
 for (const provider of ['content-addressed-file', 'rocksdb']) {


### PR DESCRIPTION
## Summary
- add C++-owned kungfu.episode.qualification/v1 with evidence, issues, safe capabilities, contractions, and repair prerequisites
- project the same result through scoped fsck/inspect and Python/Node/CLI edges
- make capability_soundness a required, executable Semantic v1 dimension

## Validation
- ./kungfu-code check
- ./kungfu-code build:core
- ./kungfu-code freeze
- focused Episode Python: 41 passed plus final fsck 22 passed
- native Node binding: 5 passed, 0 skipped
- CI=1 ./kungfu-code verify: 25/25, scale 5/5, semantic 9/9, qualified=true