### PR TITLE
feat(storage): sealed Episode content root commits identity (ADR-0043)

### DIFF
--- a/framework/core/docs/adr/ADR-0043-episode-identity-sealed-content-root.md
+++ b/framework/core/docs/adr/ADR-0043-episode-identity-sealed-content-root.md
@@ -1,0 +1,286 @@
+# ADR-0043: Episode identity is two layers — a local coordinate plus a sealed content root committed in the manifest
+
+- Status: proposed
+- Date: 2026-07-10
+- Category: (architecture) Episode identity — the relation between the local
+  `episode_id` and content identity, the hash-root composition algorithm over
+  an Episode's owned material, when identity is defined, and how it is
+  recorded and verified at the manifest trust boundary.
+- Subsystem: `libyijinjing` `episode_manifest` record family and store, the
+  `libkungfu` runtime storage service Episode operations, storage fsck,
+  export/import and future sync/dedup semantics.
+- Related: ADR-0033 defines Episode as the first-class causal segment object
+  and requires the manifest to record "hash roots or sync roots needed by
+  fsck/export/import"; ADR-0034 puts the manifest records in the yijinjing
+  journal; ADR-0041 makes the POD journal plus one typed fold the trust
+  boundary and defers "deep Episode identity and hash-root composition" to
+  this ADR; ADR-0042 defines atomic safety and explicitly leaves "selecting
+  the final Episode id or hash-root composition algorithm" out of scope —
+  this ADR closes that deferral. ADR-0040 provides the content-addressed
+  store the root builds on; ADR-0023/0028 define frame checksum and content
+  hash boundaries. The sync-root linear chain
+  (`kungfu.sync-root/v1`) is the composition precedent this ADR follows.
+
+## Context
+
+Every storage decision so far organizes around Episode (ADR-0033), and the
+manifest is the object's trust boundary (ADR-0041): the journal of POD claims
+is what fsck, export/import, and sync trust to answer "what is this Episode."
+What is still undefined is identity itself:
+
+- `episode_id` is a caller-chosen `uint64`, the primary key of every manifest
+  record. It is a **coordinate inside one data root**, not evidence: nothing
+  ties it to the claims it labels, so two stores can disagree about what
+  "Episode 5" is and no verifier can tell.
+- The manifest records per-frame checksums (ADR-0023) and per-ref content
+  hashes (ADR-0040), so each *individual* claim is checkable, but there is no
+  commitment to the *whole* — nothing states "this exact sequence of claims,
+  and nothing else, is Episode 5."
+- Export/import, dedup, and future sync need an equality judgment that
+  survives moving an Episode between runtime dirs. Without a content
+  identity, "same Episode" degenerates to "same local number", which is
+  exactly the kind of unverifiable coordinate ADR-0033 rejects as the user
+  fact object.
+
+The roadmap's framing is a git-commit-like storage object: atomic,
+independently verifiable, addressable by content. This ADR decides the
+identity layer of that framing; it deliberately does not redesign lifecycle,
+layout, retention, or transport.
+
+## Decision
+
+### 1. Identity is two layers: coordinate and content root
+
+- **`episode_id` stays the local lifecycle coordinate.** It is how a live,
+  open Episode is addressed inside one data root (all v1 records key on it;
+  that does not change). It makes no cross-store claim.
+- **The content identity of a sealed Episode is its root: one hash chained
+  over the Episode's owned claim sequence** (composition in decision 3). Two
+  sealed Episodes are the same Episode exactly when their roots are equal
+  (same algorithm). The root is the unit of cross-runtime-dir equality,
+  import idempotence/dedup, and future sync reconciliation.
+- The analogy is git's ref vs commit id: the coordinate names a line of work
+  while it moves; the root names the sealed result wherever it travels.
+
+### 2. Identity is defined at seal, not before
+
+- A hash root is defined **only for sealed Episodes** (terminal
+  `EpisodeClosed`: Ended or Aborted). An open Episode has only its
+  coordinate; its claim sequence is still growing, so any root over it would
+  be a moving target presented as identity.
+- This is the publication contract's last step (fact before claim,
+  trust-boundary §3.2): after the seal verifies its claims and appends
+  `EpisodeClosed`, the writer computes the root over the recorded claim
+  sequence and appends it as the final claim. A crash between seal and root
+  leaves a sealed Episode with an **absent** root — tolerated and reported
+  honestly (decision 5); it never leaves a root without its facts.
+- Rolling / per-segment roots for open Episodes are explicitly not in v1.
+
+### 3. The root is a linear chain over the owned claim records, hashed
+   journal-native
+
+The composition follows the proven sync-root paradigm (linear chain,
+`kungfu.sync-root/v1`) but hashes the records journal-natively — each covered
+record contributes its fixed-layout field bytes in declaration order, with no
+JSON canonicalization inside the trust boundary (ADR-0041's discipline: JSON
+is edge-only).
+
+**Coverage.** For one Episode, in manifest append order, the root covers the
+owned claim records:
+
+- the first `EpisodeOpen` (identity and provenance claims);
+- every `EpisodeFrameAttached` (each carries the frame's uid, times,
+  carrier/source/dest, length, and ADR-0023 checksums — so the root commits
+  transitively to frame content);
+- every `EpisodeRefAttached` (each carries `ref_id` and `ref_hash` — so the
+  root commits transitively to payload bytes through the ADR-0040
+  content-addressed store);
+- the terminal `EpisodeClosed` (outcome, end time, claimed counts).
+
+Duplicates stay in: the journal's append order — including duplicate or
+conflicting claims — is the authority for *what was claimed* (ADR-0041 fold
+semantics), and the root is a commitment to exactly that.
+
+**Exclusions, each for a reason:**
+
+- `EpisodeHeartbeat` records: liveness/watermark telemetry, not claims about
+  owned material. Excluding them keeps identity insensitive to operational
+  noise (an Episode's identity does not depend on how often it pulsed).
+- Manifest frame provenance (`manifest_frame_uid`, `manifest_gen_time`, page
+  placement): storage coordinates of the *manifest journal itself*. They
+  necessarily change when records are re-appended into another store, and
+  identity must survive that (decision 4).
+- Unknown / newer-schema records and the root record itself.
+
+**Per-record commitment and chain.** Each covered record contributes a
+commitment hashed over its field bytes in declaration order — scalar and
+enum fields as their in-memory little-endian bytes, fixed char arrays as
+their full zero-filled extent, `schema_version` included. Struct padding
+never enters the hash, so the commitment does not depend on compiler layout
+or uninitialized bytes. The chain is
+`link_i = H(domain || index || link_{i-1} || commitment_i)` with a fixed
+domain tag (`kungfu.episode-root-link/v1`) and an all-zero initial link, the
+same convention as the sync root. The root is the last link. The exact link
+preimage is pinned by the record's `schema_version` and proved by fixtures;
+changing it is a schema-version change, never a silent edit.
+
+**Local ids are inside the root — deliberately.** `episode_id`,
+`parent_episode_id`, `location_uid`, and frame uids are fields of the covered
+records and therefore part of identity. The root is a commitment to the
+manifest's claims *as recorded*, and those claims are expressed in local
+coordinates. Consequence: identity is invariant under **verbatim migration**
+(export/import that preserves the claim records byte-for-byte yields the same
+root — the invariance sync and dedup need), but **renumbering is a new
+identity** (an import that rewrites `episode_id` produces different claims,
+hence a different root). Store-independent "portable identity" that survives
+renumbering would require hash-based parent/dependency references — a
+content-addressed DAG — which conflicts with v1's lifecycle (children may
+open, and be claimed against, while the parent is still open and has no root
+yet). That revision stays explicitly out of scope; payload-level dedup is
+already store-wide through the content store regardless.
+
+### 4. The root is a recorded claim, verified by fsck
+
+- A new manifest record type commits the root:
+
+  ```text
+  EpisodeRootCommitted (new carrier type, additive to the ADR-0034 family)
+    schema_version        pins layout AND composition semantics
+    episode_id            the sealed Episode this root names
+    location_uid          writer provenance
+    commit_time
+    covered_record_count  claims covered (open + frames + refs + close)
+    algorithm             content-hash algorithm name ("sha256" today)
+    root_value            bare lowercase hex of the root
+  ```
+
+  ADR-0041 required a schema-version ADR before extending the record set;
+  this is that ADR. The addition is additive: no existing record's layout or
+  meaning changes, and readers that predate it preserve it as an unknown
+  record without folding it (the ADR-0041 unknown-record contract).
+- **fsck recomputes and verifies.** For a sealed Episode with a root record,
+  fsck recomputes the chain from the typed fold and compares: mismatch is a
+  manifest-integrity failure (`episode_root_mismatch`, status failed) — the
+  trust boundary itself is lying about identity. When the Episode's fold saw
+  unknown/newer records, fsck reports the root as **unverifiable** instead of
+  guessing (a v1 verifier must not fail a v2 writer's root over records it
+  cannot canonicalize — honest degradation per ADR-0042).
+- **inspect reports identity.** `episode_inspect` exposes the recorded root,
+  the recomputed root, and the match verdict, so identity is inspectable
+  without a monitoring stack.
+
+### 5. Absence is honest, not an error
+
+- Episodes sealed before this ADR, and seals interrupted between
+  `EpisodeClosed` and the root append, have no root record. They remain valid
+  sealed Episodes; inspect/fsck report `root: absent` (with the recomputed
+  value available from the fold), never a failure. Greenfield seals always
+  append the root; there is no backfill obligation in this ADR (an explicit
+  maintenance/repair op may add roots later under ADR-0042's
+  evidence-preserving rules).
+- `advertised_capabilities ⊆ evidence_safe_capabilities` (ADR-0042) applies:
+  operations that *require* committed identity (future sync/dedup admission)
+  treat an absent root as that capability being unavailable, not as license
+  to invent one.
+
+### 6. Algorithm and evolution
+
+- The algorithm is named in the record (`sha256` today; BLAKE3 is already in
+  the supported content-hash vocabulary as a candidate successor). Identity
+  comparisons are `(algorithm, root_value)` pairs; equality across different
+  algorithms is undefined — reconciliation across an algorithm migration
+  recomputes rather than assumes.
+- The composition (coverage, ordering, link preimage) is pinned by the root
+  record's `schema_version`. Any change — adding a covered record type,
+  changing exclusions, changing the chain — increments it and states the
+  migration rule; mixed populations are expected and handled by reading the
+  version from the record.
+
+## Consequences
+
+- A sealed Episode finally *is* something: a verifiable content identity that
+  travels with its records, closing the loop ADR-0033 opened when it named
+  hash roots part of the trust boundary.
+- Export/import gains an equality/idempotence judgment (same root = same
+  Episode; skip or verify on re-import), which the import-manifest migration
+  and future sync/maintenance cards build on instead of inventing.
+- fsck can now catch whole-Episode substitution/reordering, not only
+  per-claim corruption: the root binds the sequence, the checksums bind the
+  parts.
+- The seal path does more work (fold + chain over the Episode's records);
+  seal is rare and the cost is linear in the Episode's claim count.
+- Renumbering imports are a new identity by construction; tools that need
+  cross-store dedup under renumbering must wait for (or motivate) the
+  portable-identity revision, documented above as out of scope.
+
+## First delivery (thin slice)
+
+1. `EpisodeRootCommitted` record type (additive), fold support (root fields
+   on the typed current view), and the chain computation over the typed fold.
+2. Seal path (`end` / `abort` / `recover`) computes and appends the root
+   after `EpisodeClosed`, under the existing writer guard.
+3. `episode_inspect` exposes recorded/recomputed/match; fsck verifies
+   (mismatch → failed; unknown-records → unverifiable; absent → reported).
+4. Fixtures: determinism (re-fold ⇒ same root), sensitivity (any covered
+   claim changes ⇒ root changes; heartbeats do not), crash-shape (sealed
+   without root stays healthy with `root: absent`), and cross-store
+   invariance (re-appending the same claims in a fresh runtime dir ⇒ same
+   root).
+
+## Explicitly out of scope
+
+- Portable identity under renumbering (hash-based parent/dependency
+  references, content-addressed Episode DAG).
+- Rolling or per-segment roots for open Episodes.
+- Root backfill for historical Episodes and any repair/maintenance op that
+  appends roots retroactively.
+- Export/import bundle format changes and the import-manifest record
+  migration (separate card; it consumes this identity).
+- Remote sync transport, fleet reconciliation, retention/GC.
+
+## Alternatives considered
+
+- **Content-addressed `episode_id` (replace the coordinate).** Rejected: an
+  open Episode has no final content, every v1 record keys on the id, and a
+  live workflow needs a stable address before identity exists. Two layers
+  match the object's lifecycle.
+- **Derived-only root (compute on demand, never record).** Rejected: the
+  trust boundary must *record* identity (ADR-0033), otherwise export/import
+  has nothing recorded to verify against and "identity" silently becomes
+  whatever the local verifier computes today.
+- **Reuse `EpisodeRefAttached` with a new ref kind to carry the root.**
+  Rejected: a root is a claim about the Episode itself, not an attached
+  external reference; overloading the ref record is exactly the field
+  overloading ADR-0041 forbids without a schema ADR — and once writing a
+  schema ADR, the honest shape is a first-class record.
+- **JSON-canonicalized commitments (reuse sync-root entry hashing as-is).**
+  Rejected: it would reintroduce JSON as internal currency inside the trust
+  boundary, the drift ADR-0041 exists to eliminate. The chain shape is
+  reused; the commitment is journal-native POD bytes.
+- **Exclude local ids from the root for portability.** Rejected for v1: it
+  requires hash-based parent references (parents may still be open when
+  children claim them) and a canonical renumbering story; the honest v1
+  contract is verbatim-migration invariance with renumbering as new identity.
+- **Include heartbeats.** Rejected: identity would depend on liveness noise;
+  no trust claim is lost by excluding them.
+
+## Residual risk
+
+- Field-byte hashing assumes fixed char arrays are zero-filled past their
+  content (the `copy_string` write path guarantees this) and that scalar
+  endianness stays little-endian across supported platforms; the determinism
+  fixtures must catch drift. Whole-struct raw-byte hashing was rejected during
+  implementation because these records are pack(8), not byte-packed, and their
+  padding is not deterministically initialized.
+- The unknown-record "unverifiable" rule means a v1 verifier cannot catch a
+  malicious root written alongside v2 records; verification strength follows
+  reader schema coverage. This is inherent to forward compatibility and is
+  reported, not hidden.
+- Two commitment paradigms now exist (JSON-entry sync root for import
+  manifests, POD-byte Episode root). They serve different boundaries; the
+  import-manifest migration should converge its commitments toward
+  journal-native records rather than the reverse.
+- Seal-time fold cost grows with Episode size; unacceptable growth would
+  motivate an incremental chain carried in the writer, which the composition
+  already permits (linear chain is prefix-incremental) without a schema
+  change.

--- a/framework/core/docs/episode-manifest-trust-boundary.md
+++ b/framework/core/docs/episode-manifest-trust-boundary.md
@@ -38,15 +38,14 @@ Mapping each ADR-0033 trust-boundary claim onto that record set:
 | declared external input frames | `EpisodeRefAttached` with `ref_kind=InputFrame` (`ref_uid` = frame uid); `EpisodeOpen.root_trigger_frame_uid` for the opening trigger | representable |
 | causal closure (ADR-0033 core invariant) | derivable: `EpisodeFrameAttached.trigger_frame_uid` edges must resolve inside the Episode's frame set or be declared as `InputFrame` refs / Episode dependencies. Closure is a checked property of the fold, not a stored field | representable (checked, not stored) |
 | rebuildable projection / query indexes | not stored in the manifest by design — projections are derived from the journal and verified against it (ADR-0041 point 5) | n/a (satisfied structurally) |
-| hash roots / sync roots for fsck/export/import | **not representable in v1.** No record carries an Episode-level inventory hash root. v1 fsck verifies by full enumeration of claims instead of root comparison, which is sufficient for the local trust boundary. A hash-root field is deferred to a later Episode identity decision plus a schema-version ADR; ADR-0042 qualifies atomic safety without selecting the root algorithm. It must not be squeezed into `ref_hash` or `note` by overloading | deferred — explicit gap, no field overloading |
+| hash roots / sync roots for fsck/export/import | **delivered by ADR-0043**: `EpisodeRootCommitted` (carrier `10806`, additive) records the sealed Episode's content root — a linear chain over the owned claim sequence — appended by the seal path as the final claim. fsck recomputes and verifies it; inspect exposes recorded/computed/match; absence (pre-ADR-0043 data, or a crash between seal and root append) is reported honestly, never failed | representable (ADR-0043) |
 
 Conclusion required by ADR-0041: the existing record set is sufficient for
-every claim this slice needs. The single not-representable claim (Episode
-hash/sync roots) is exactly the deep-identity surface ADR-0041 already
-defers to a later identity/schema decision; ADR-0042 does not select that root,
-and nothing in stages 1–3 and 5 depends on it. Content-ref resolution (stage 4,
-delivered) resolves through ADR-0040's immutable `content_store` and changed
-no record layout.
+every claim this slice needs. The one claim that was not representable in the
+original v1 set (Episode hash/sync roots) has since been closed by ADR-0043's
+additive `EpisodeRootCommitted` record — the schema-version ADR this map
+originally deferred to. Content-ref resolution (stage 4, delivered) resolves
+through ADR-0040's immutable `content_store` and changed no record layout.
 
 ## 2. Deterministic typed fold (stage 1 semantics)
 

--- a/framework/core/src/libkungfu/src/runtime/storage/episode_manifest_projection.cpp
+++ b/framework/core/src/libkungfu/src/runtime/storage/episode_manifest_projection.cpp
@@ -26,14 +26,16 @@ fs::path projection_path(const std::string &runtime_dir) {
 // Distinct-primary-key journal counts. The SQLite tables upsert by primary
 // key (EpisodeOpen by episode_id; EpisodeHeartbeat by episode_id+update_time;
 // EpisodeFrameAttached by episode_id+frame_uid; EpisodeRefAttached by
-// episode_id+ref_kind+ref_uid; EpisodeClosed by episode_id), so the honest
-// expected row count is the distinct-PK count, not the raw append count.
+// episode_id+ref_kind+ref_uid; EpisodeClosed and EpisodeRootCommitted by
+// episode_id), so the honest expected row count is the distinct-PK count,
+// not the raw append count.
 struct distinct_counts {
   size_t opens = 0;
   size_t heartbeats = 0;
   size_t frames = 0;
   size_t refs = 0;
   size_t closes = 0;
+  size_t roots = 0;
 };
 
 distinct_counts distinct_pk_counts(const std::vector<yijinjing::storage::episode_manifest_record> &records) {
@@ -42,6 +44,7 @@ distinct_counts distinct_pk_counts(const std::vector<yijinjing::storage::episode
   std::set<std::pair<uint64_t, uint64_t>> frame_keys;
   std::set<std::tuple<uint64_t, int8_t, uint64_t>> ref_keys;
   std::set<uint64_t> close_keys;
+  std::set<uint64_t> root_keys;
   for (const auto &record : records) {
     std::visit(
         [&](const auto &body) {
@@ -56,11 +59,14 @@ distinct_counts distinct_pk_counts(const std::vector<yijinjing::storage::episode
             ref_keys.emplace(body.episode_id, static_cast<int8_t>(body.ref_kind), body.ref_uid);
           } else if constexpr (std::is_same_v<body_t, yijinjing::types::EpisodeClosed>) {
             close_keys.insert(body.episode_id);
+          } else if constexpr (std::is_same_v<body_t, yijinjing::types::EpisodeRootCommitted>) {
+            root_keys.insert(body.episode_id);
           }
         },
         record.body);
   }
-  return {open_keys.size(), heartbeat_keys.size(), frame_keys.size(), ref_keys.size(), close_keys.size()};
+  return {open_keys.size(), heartbeat_keys.size(), frame_keys.size(),
+          ref_keys.size(),  close_keys.size(),     root_keys.size()};
 }
 
 } // namespace
@@ -87,6 +93,7 @@ nlohmann::json episode_manifest_projection::rebuild() const {
   storage->remove_all<yijinjing::types::EpisodeFrameAttached>();
   storage->remove_all<yijinjing::types::EpisodeRefAttached>();
   storage->remove_all<yijinjing::types::EpisodeClosed>();
+  storage->remove_all<yijinjing::types::EpisodeRootCommitted>();
 
   const auto records = yijinjing::storage::episode_manifest_store(runtime_dir_).read_typed_records();
   std::unordered_set<uint64_t> opened;
@@ -122,7 +129,8 @@ nlohmann::json episode_manifest_projection::rebuild() const {
         {"episode_heartbeat", storage->count<yijinjing::types::EpisodeHeartbeat>()},
         {"episode_frame_attached", storage->count<yijinjing::types::EpisodeFrameAttached>()},
         {"episode_ref_attached", storage->count<yijinjing::types::EpisodeRefAttached>()},
-        {"episode_closed", storage->count<yijinjing::types::EpisodeClosed>()}}},
+        {"episode_closed", storage->count<yijinjing::types::EpisodeClosed>()},
+        {"episode_root_committed", storage->count<yijinjing::types::EpisodeRootCommitted>()}}},
       {"journal_records", records.size()},
   };
 }
@@ -157,6 +165,7 @@ nlohmann::json episode_manifest_projection::verify() const {
   const size_t projected_frames = storage->count<yijinjing::types::EpisodeFrameAttached>();
   const size_t projected_refs = storage->count<yijinjing::types::EpisodeRefAttached>();
   const size_t projected_closes = storage->count<yijinjing::types::EpisodeClosed>();
+  const size_t projected_roots = storage->count<yijinjing::types::EpisodeRootCommitted>();
 
   nlohmann::json drift = nlohmann::json::array();
   const auto check = [&](const char *table, size_t projected, size_t journal_expected) {
@@ -169,6 +178,7 @@ nlohmann::json episode_manifest_projection::verify() const {
   check("episode_frame_attached", projected_frames, expected.frames);
   check("episode_ref_attached", projected_refs, expected.refs);
   check("episode_closed", projected_closes, expected.closes);
+  check("episode_root_committed", projected_roots, expected.roots);
 
   const bool degraded = !drift.empty();
   return {
@@ -185,13 +195,15 @@ nlohmann::json episode_manifest_projection::verify() const {
         {"episode_heartbeat", projected_heartbeats},
         {"episode_frame_attached", projected_frames},
         {"episode_ref_attached", projected_refs},
-        {"episode_closed", projected_closes}}},
+        {"episode_closed", projected_closes},
+        {"episode_root_committed", projected_roots}}},
       {"journal_distinct",
        {{"episode_open", expected.opens},
         {"episode_heartbeat", expected.heartbeats},
         {"episode_frame_attached", expected.frames},
         {"episode_ref_attached", expected.refs},
-        {"episode_closed", expected.closes}}},
+        {"episode_closed", expected.closes},
+        {"episode_root_committed", expected.roots}}},
   };
 }
 

--- a/framework/core/src/libkungfu/src/runtime/storage/service.cpp
+++ b/framework/core/src/libkungfu/src/runtime/storage/service.cpp
@@ -2428,13 +2428,13 @@ nlohmann::json repair_plan_impl(const storage_service_options &options) {
 
 bool episode_record_kind_supported(const std::string &kind) {
   return kind == "episode_open" || kind == "episode_heartbeat" || kind == "episode_frame_attached" ||
-         kind == "episode_ref_attached" || kind == "episode_closed";
+         kind == "episode_ref_attached" || kind == "episode_closed" || kind == "episode_root_committed";
 }
 
 std::string episode_record_identity_key(const nlohmann::json &record) {
   const auto kind = text_or(record, "record_kind");
   const auto episode_id = std::to_string(uint64_or(record, "episode_id"));
-  if (kind == "episode_open" || kind == "episode_closed") {
+  if (kind == "episode_open" || kind == "episode_closed" || kind == "episode_root_committed") {
     return kind + ":" + episode_id;
   }
   if (kind == "episode_frame_attached") {
@@ -2464,6 +2464,16 @@ nlohmann::json episode_apply_record(const storage_service_options &options, cons
   }
   if (kind == "episode_closed") {
     return episode_store(options).end(parse_episode_close_options(record, yy_enums::EpisodeStatus::Ended));
+  }
+  if (kind == "episode_root_committed") {
+    // ADR-0043: the destination's root is committed by its own seal path (the
+    // episode_closed apply above); the bundle's root record is carried through
+    // as the source's identity claim for comparison, never re-appended — a
+    // root must commit to the sequence its own store recorded, and a second
+    // root record would only be a duplicate-root diagnostic.
+    auto row = record;
+    row["applied"] = "source_identity_claim";
+    return row;
   }
   return nullptr;
 }

--- a/framework/core/src/libyijinjing/include/kungfu/yijinjing/schema/registry.h
+++ b/framework/core/src/libyijinjing/include/kungfu/yijinjing/schema/registry.h
@@ -184,7 +184,8 @@ constexpr auto EpisodeManifestDataTypes = boost::hana::make_map( //
     TYPE_PAIR(EpisodeHeartbeat),                                 // 10802
     TYPE_PAIR(EpisodeFrameAttached),                             // 10803
     TYPE_PAIR(EpisodeRefAttached),                               // 10804
-    TYPE_PAIR(EpisodeClosed)                                     // 10805
+    TYPE_PAIR(EpisodeClosed),                                    // 10805
+    TYPE_PAIR(EpisodeRootCommitted)                              // 10806 (ADR-0043)
 );
 
 constexpr auto StaticDataTypes = boost::hana::make_map();

--- a/framework/core/src/libyijinjing/include/kungfu/yijinjing/schema/types.h
+++ b/framework/core/src/libyijinjing/include/kungfu/yijinjing/schema/types.h
@@ -320,6 +320,20 @@ KF_DEFINE_PACK_TYPE(                                           //
     (array<char, 64>, reason)                                  //
 );
 
+// ADR-0043: the sealed Episode's content identity — a hash root chained over
+// the Episode's owned claim sequence, appended as the final claim after the
+// seal. schema_version pins both the record layout and the root composition.
+KF_DEFINE_PACK_TYPE(                                                     //
+    EpisodeRootCommitted, 10806, PK(episode_id), TIMESTAMP(commit_time), //
+    (uint32_t, schema_version),                                          //
+    (uint64_t, episode_id),                                              //
+    (uint32_t, location_uid),                                            //
+    (int64_t, commit_time),                                              //
+    (uint32_t, covered_record_count),                                    //
+    (array<char, 16>, algorithm),                                        //
+    (array<char, 72>, root_value)                                        //
+);
+
 // Storage source-registry records (ADR-0037): Hana-core kernel metadata for the
 // ADR-0018 storage-service source family, written to an append-only yijinjing
 // journal and folded into a current view. JSON is an edge projection only.

--- a/framework/core/src/libyijinjing/include/kungfu/yijinjing/storage/episode_manifest.h
+++ b/framework/core/src/libyijinjing/include/kungfu/yijinjing/storage/episode_manifest.h
@@ -118,7 +118,7 @@ struct episode_manifest_record {
   int64_t manifest_gen_time = 0;
   std::variant<episode_manifest_unknown_record, yijinjing::types::EpisodeOpen, yijinjing::types::EpisodeHeartbeat,
                yijinjing::types::EpisodeFrameAttached, yijinjing::types::EpisodeRefAttached,
-               yijinjing::types::EpisodeClosed>
+               yijinjing::types::EpisodeClosed, yijinjing::types::EpisodeRootCommitted>
       body = episode_manifest_unknown_record{};
 };
 
@@ -145,6 +145,11 @@ struct episode_current_view {
   size_t unique_frame_count = 0;
   yijinjing::types::EpisodeClosed close = {};
   std::vector<yijinjing::enums::EpisodeStatus> close_statuses = {};
+  // ADR-0043: the recorded content-root claim. First-committed-wins (a root
+  // names a sealed identity once); later duplicates are fsck diagnostics.
+  bool root_seen = false;
+  size_t root_count = 0;
+  yijinjing::types::EpisodeRootCommitted root = {};
   std::vector<episode_manifest_record> records = {};
   std::vector<size_t> frame_indices = {};
   std::vector<size_t> ref_indices = {};
@@ -166,6 +171,20 @@ struct episode_manifest_fold {
   size_t unknown_record_count = 0;
   size_t unfolded_record_count = 0;
 };
+
+// ADR-0043: the content root of one Episode's owned claim sequence — a linear
+// hash chain over the covered records in manifest append order (the first
+// EpisodeOpen, every EpisodeFrameAttached / EpisodeRefAttached, and the first
+// terminal EpisodeClosed). Heartbeats, manifest provenance, unknown records,
+// and the root record itself stay outside identity. Each record contributes
+// its hana field bytes in declaration order (padding never enters the hash).
+struct episode_content_root {
+  uint32_t covered_record_count = 0;
+  std::string algorithm = {};
+  std::string value = {};
+};
+
+[[nodiscard]] episode_content_root compute_episode_content_root(const episode_current_view &view);
 
 class content_store;
 

--- a/framework/core/src/libyijinjing/src/storage/episode_manifest.cpp
+++ b/framework/core/src/libyijinjing/src/storage/episode_manifest.cpp
@@ -224,6 +224,15 @@ nlohmann::json record_json(const EpisodeClosed &record) {
   return row;
 }
 
+nlohmann::json record_json(const EpisodeRootCommitted &record) {
+  auto row = base_record_json("episode_root_committed", record);
+  row["commit_time"] = record.commit_time;
+  row["covered_record_count"] = record.covered_record_count;
+  row["algorithm"] = fixed_string(record.algorithm);
+  row["root_value"] = fixed_string(record.root_value);
+  return row;
+}
+
 // Edge projection of one typed record, including its manifest provenance.
 nlohmann::json record_row_json(const episode_manifest_record &record) {
   auto row = std::visit(
@@ -280,6 +289,9 @@ episode_manifest_record decode_record(const frame_ptr &frame) {
     break;
   case EpisodeClosed::tag:
     decoded = decode_v1_record<EpisodeClosed>(frame, record);
+    break;
+  case EpisodeRootCommitted::tag:
+    decoded = decode_v1_record<EpisodeRootCommitted>(frame, record);
     break;
   default:
     break;
@@ -374,6 +386,12 @@ void fold_into(episode_manifest_fold &fold, const episode_manifest_record &recor
           view.claimed_frame_count = body.frame_count;
           view.last_frame_uid_seen = true;
           view.last_frame_uid = body.last_frame_uid;
+        } else if constexpr (std::is_same_v<body_t, EpisodeRootCommitted>) {
+          ++view.root_count;
+          if (!view.root_seen) {
+            view.root_seen = true;
+            view.root = body;
+          }
         }
       },
       record.body);
@@ -416,10 +434,48 @@ nlohmann::json summary_json(const episode_current_view &view) {
   }
   summary["payload_ref_count"] = payload_ref_count;
   summary["schema_ref_count"] = schema_ref_count;
+  if (view.root_seen) {
+    summary["content_root"] = fixed_string(view.root.root_value);
+    summary["content_root_algorithm"] = fixed_string(view.root.algorithm);
+  }
   if (!summary.contains("status")) {
     summary["status"] = view.opened ? "open" : "dangling";
   }
   return summary;
+}
+
+// ADR-0043 edge projection of Episode identity: the recorded root claim, the
+// recomputed root when this reader can derive one, and the verdict. Status
+// vocabulary: undefined (open), absent (sealed, no root), verified, mismatch,
+// unverifiable (unknown records present or unsupported algorithm),
+// root_without_seal (a root claims identity of an unsealed Episode).
+nlohmann::json content_root_json(const episode_current_view &view, size_t unknown_record_count) {
+  nlohmann::json recorded = view.root_seen ? record_json(view.root) : nlohmann::json(nullptr);
+  nlohmann::json computed = nullptr;
+  nlohmann::json match = nullptr;
+  const char *status = "undefined";
+  if (!view.closed) {
+    if (view.root_seen) {
+      status = "root_without_seal";
+    }
+  } else if (unknown_record_count > 0) {
+    status = view.root_seen ? "unverifiable" : "absent";
+  } else {
+    const auto root = compute_episode_content_root(view);
+    computed = {
+        {"algorithm", root.algorithm}, {"value", root.value}, {"covered_record_count", root.covered_record_count}};
+    if (!view.root_seen) {
+      status = "absent";
+    } else if (fixed_string(view.root.algorithm) != root.algorithm) {
+      status = "unverifiable";
+    } else {
+      const bool verified = fixed_string(view.root.root_value) == root.value &&
+                            view.root.covered_record_count == root.covered_record_count;
+      match = verified;
+      status = verified ? "verified" : "mismatch";
+    }
+  }
+  return {{"recorded", recorded}, {"computed", computed}, {"match", match}, {"status", status}};
 }
 
 nlohmann::json rows_json(const episode_current_view &view, const std::vector<size_t> &indices) {
@@ -637,7 +693,76 @@ episode_graph build_causal_graph(const content_store &refs, uint64_t episode_id,
           degraded};
 }
 
+// ADR-0043: per-record commitment for the content root. Each covered record
+// contributes its hana field bytes in declaration order — scalar and enum
+// fields as their in-memory little-endian bytes, fixed char arrays as their
+// full zero-filled extent. Struct padding never enters the hash, so the
+// commitment is deterministic across compilers and write paths.
+template <typename T> std::string episode_record_commitment(const T &record) {
+  std::string bytes;
+  boost::hana::for_each(boost::hana::accessors<T>(), [&bytes, &record](auto accessor) {
+    const auto &member = boost::hana::second(accessor)(record);
+    bytes.append(reinterpret_cast<const char *>(&member), sizeof(member));
+  });
+  return compute_content_hash_value(bytes);
+}
+
+// ADR-0043 v1 chain link preimage, pinned by fixtures: ASCII domain tag,
+// decimal covered-record index, previous link hex, record commitment hex,
+// joined by '|'. The initial link is 64 zero hex digits.
+constexpr const char *EPISODE_ROOT_LINK_DOMAIN = "kungfu.episode-root-link/v1";
+constexpr const char *EPISODE_ROOT_INITIAL_LINK = "0000000000000000000000000000000000000000000000000000000000000000";
+
+std::string episode_root_chain_link(size_t index, const std::string &previous, const std::string &record_commitment) {
+  return compute_content_hash_value(std::string(EPISODE_ROOT_LINK_DOMAIN) + "|" + std::to_string(index) + "|" +
+                                    previous + "|" + record_commitment);
+}
+
 } // namespace
+
+episode_content_root compute_episode_content_root(const episode_current_view &view) {
+  episode_content_root root{};
+  root.algorithm = CONTENT_HASH_ALGORITHM_SHA256;
+  root.value = EPISODE_ROOT_INITIAL_LINK;
+  bool open_covered = false;
+  bool close_covered = false;
+  for (const auto &record : view.records) {
+    const auto commitment = std::visit(
+        [&open_covered, &close_covered](const auto &body) -> std::string {
+          using body_t = std::decay_t<decltype(body)>;
+          if constexpr (std::is_same_v<body_t, EpisodeOpen>) {
+            if (open_covered) {
+              return {};
+            }
+            open_covered = true;
+            return episode_record_commitment(body);
+          } else if constexpr (std::is_same_v<body_t, EpisodeFrameAttached> ||
+                               std::is_same_v<body_t, EpisodeRefAttached>) {
+            return episode_record_commitment(body);
+          } else if constexpr (std::is_same_v<body_t, EpisodeClosed>) {
+            // the first terminal close is the seal and part of identity;
+            // later closes (tombstone path, anomalous duplicates) are
+            // lifecycle facts outside it
+            if (close_covered) {
+              return {};
+            }
+            close_covered = true;
+            return episode_record_commitment(body);
+          } else {
+            // heartbeats, unknown records, and the root record itself stay
+            // outside identity
+            return {};
+          }
+        },
+        record.body);
+    if (commitment.empty()) {
+      continue;
+    }
+    root.value = episode_root_chain_link(root.covered_record_count, root.value, commitment);
+    ++root.covered_record_count;
+  }
+  return root;
+}
 
 std::string episode_manifest_writer_lock_path(const std::string &runtime_dir) {
   const auto location = manifest_location(runtime_dir);
@@ -740,9 +865,33 @@ nlohmann::json episode_manifest_store::end(const episode_close_options &options)
   record.frame_count = options.frame_count;
   set_fixed_string(record.reason, options.reason);
   const auto guard = acquire_writer_guard(runtime_dir_);
+  auto fold = fold_typed_records();
+  const auto folded = fold.episodes.find(record.episode_id);
+  const bool first_close = folded == fold.episodes.end() || !folded->second.closed;
   auto writer = make_writer(runtime_dir_);
   writer.write_at(record.end_time, 0, record);
-  return record_json(record);
+  auto response = record_json(record);
+  // ADR-0043: the first terminal close is the seal — commit the Episode's
+  // content identity as the final claim, under the same writer guard so no
+  // record can interleave between the seal and its root. Later closes
+  // (tombstone path) are lifecycle facts outside identity and get no root.
+  if (first_close) {
+    episode_manifest_record appended{};
+    appended.body = record;
+    fold_into(fold, appended);
+    const auto root = compute_episode_content_root(fold.episodes.at(record.episode_id));
+    EpisodeRootCommitted root_record{};
+    root_record.schema_version = EPISODE_MANIFEST_SCHEMA_VERSION;
+    root_record.episode_id = record.episode_id;
+    root_record.location_uid = record.location_uid;
+    root_record.commit_time = record.end_time;
+    root_record.covered_record_count = root.covered_record_count;
+    set_fixed_string(root_record.algorithm, root.algorithm);
+    set_fixed_string(root_record.root_value, root.value);
+    writer.write_at(root_record.commit_time, 0, root_record);
+    response["content_root"] = record_json(root_record);
+  }
+  return response;
 }
 
 nlohmann::json episode_manifest_store::abort(const episode_close_options &options) const {
@@ -753,7 +902,7 @@ nlohmann::json episode_manifest_store::abort(const episode_close_options &option
 
 nlohmann::json episode_manifest_store::recover(const episode_recover_options &options) const {
   const auto guard = acquire_writer_guard(runtime_dir_);
-  const auto fold = fold_typed_records();
+  auto fold = fold_typed_records();
   const auto end_time = options.end_time == 0 ? time::now_in_nano() : options.end_time;
   const auto reason = options.reason.empty() ? std::string("recovered") : options.reason;
   std::vector<EpisodeClosed> closes;
@@ -786,7 +935,24 @@ nlohmann::json episode_manifest_store::recover(const episode_recover_options &op
     auto writer = make_writer(runtime_dir_);
     for (const auto &record : closes) {
       writer.write_at(record.end_time, 0, record);
-      recovered.push_back(record_json(record));
+      auto row = record_json(record);
+      // ADR-0043: recovery seals were open Episodes, so each close here is
+      // the first close — commit each Episode's content root after its seal.
+      episode_manifest_record appended{};
+      appended.body = record;
+      fold_into(fold, appended);
+      const auto root = compute_episode_content_root(fold.episodes.at(record.episode_id));
+      EpisodeRootCommitted root_record{};
+      root_record.schema_version = EPISODE_MANIFEST_SCHEMA_VERSION;
+      root_record.episode_id = record.episode_id;
+      root_record.location_uid = record.location_uid;
+      root_record.commit_time = record.end_time;
+      root_record.covered_record_count = root.covered_record_count;
+      set_fixed_string(root_record.algorithm, root.algorithm);
+      set_fixed_string(root_record.root_value, root.value);
+      writer.write_at(root_record.commit_time, 0, root_record);
+      row["content_root"] = record_json(root_record);
+      recovered.push_back(row);
     }
   }
   return {{"ok", true},
@@ -867,6 +1033,7 @@ nlohmann::json episode_manifest_store::inspect(uint64_t episode_id) const {
           {"runtime_dir", runtime_dir_},
           {"authority", "yijinjing-journal"},
           {"episode", summary_json(view)},
+          {"content_root", content_root_json(view, fold.unknown_record_count)},
           {"causal_graph", graph.graph},
           {"dependencies", graph.dependencies},
           {"records", records_json(view)},
@@ -947,6 +1114,42 @@ nlohmann::json episode_manifest_store::fsck(uint64_t episode_id) const {
                               {"episode_id", current_episode_id},
                               {"frame_uid", view.close.last_frame_uid}});
           }
+        }
+      }
+    }
+    // ADR-0043: the recorded content root is a claim about the whole covered
+    // sequence; fsck recomputes it from the fold and verifies. Unknown
+    // records make the recomputation unverifiable (this reader cannot
+    // canonicalize records a newer writer may have covered), reported
+    // honestly instead of guessed.
+    if (view.root_seen && !view.closed) {
+      errors.push_back({{"code", "episode_root_without_seal"}, {"episode_id", current_episode_id}});
+    }
+    if (view.root_count > 1) {
+      warnings.push_back(
+          {{"code", "episode_root_duplicate"}, {"episode_id", current_episode_id}, {"count", view.root_count}});
+    }
+    if (view.root_seen && view.closed) {
+      const auto recorded_algorithm = fixed_string(view.root.algorithm);
+      if (fold.unknown_record_count > 0) {
+        warnings.push_back({{"code", "episode_root_unverifiable"},
+                            {"episode_id", current_episode_id},
+                            {"reason", "unknown_records_present"}});
+      } else if (recorded_algorithm != CONTENT_HASH_ALGORITHM_SHA256) {
+        warnings.push_back({{"code", "episode_root_unverifiable"},
+                            {"episode_id", current_episode_id},
+                            {"reason", "unsupported_algorithm"},
+                            {"algorithm", recorded_algorithm}});
+      } else {
+        const auto root = compute_episode_content_root(view);
+        const auto recorded_value = fixed_string(view.root.root_value);
+        if (recorded_value != root.value || view.root.covered_record_count != root.covered_record_count) {
+          errors.push_back({{"code", "episode_root_mismatch"},
+                            {"episode_id", current_episode_id},
+                            {"recorded", recorded_value},
+                            {"computed", root.value},
+                            {"recorded_covered_record_count", view.root.covered_record_count},
+                            {"computed_covered_record_count", root.covered_record_count}});
         }
       }
     }

--- a/framework/core/tests/python/test_atlas_storage.py
+++ b/framework/core/tests/python/test_atlas_storage.py
@@ -609,7 +609,10 @@ def test_episode_manifest_v1_is_yijinjing_backed_and_fscked(tmp_path):
     inspected = storage_service.episode_inspect(runtime_dir, episode_id=42)
     assert inspected["ok"]
     assert inspected["episode"]["status"] == "ended"
-    assert len(inspected["records"]) == 4
+    # open + frame + ref + close, plus the ADR-0043 root committed at seal
+    assert len(inspected["records"]) == 5
+    assert inspected["records"][-1]["record_kind"] == "episode_root_committed"
+    assert inspected["content_root"]["status"] == "verified"
     assert inspected["frames"][0]["frame_uid"] == 100
     assert inspected["causal_graph"]["schema"] == "kungfu.episode.causal-graph/v1"
     assert inspected["causal_graph"]["degraded"] is False
@@ -619,7 +622,7 @@ def test_episode_manifest_v1_is_yijinjing_backed_and_fscked(tmp_path):
     fsck = storage_service.fsck(runtime_dir)
     assert fsck["ok"]
     assert fsck["status"] == "ok"
-    assert fsck["checked"]["episode_manifest_records"] == 4
+    assert fsck["checked"]["episode_manifest_records"] == 5
     assert fsck["checked"]["episodes"] == 1
     assert fsck["episode_manifest"]["authority"] == "yijinjing-journal"
 
@@ -655,7 +658,7 @@ def test_episode_manifest_v1_is_yijinjing_backed_and_fscked(tmp_path):
     assert bundle["manifest"]["episode_id"] == 42
     assert bundle["causal_graph"]["degraded"] is False
     assert bundle["dependencies"][0]["status"] == "declared_external"
-    assert bundle["record_count"] == 4
+    assert bundle["record_count"] == 5
     assert bundle["frame_count"] == 1
 
 

--- a/framework/core/tests/python/test_episode_content_root.py
+++ b/framework/core/tests/python/test_episode_content_root.py
@@ -1,0 +1,266 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# ADR-0043 Episode identity fixtures: the sealed content root.
+#
+# The seal path commits one EpisodeRootCommitted record — a linear hash chain
+# over the Episode's owned claim sequence (first open, every frame/ref attach
+# in append order, the first terminal close). These fixtures prove the four
+# contract properties: determinism (re-fold yields the same root), sensitivity
+# (covered claims change the root, heartbeats do not), honest absence (a
+# sealed Episode whose root append was lost stays healthy with root absent),
+# and cross-store invariance (re-appending identical claims in a fresh runtime
+# dir yields the same root).
+
+from __future__ import annotations
+
+import struct
+from pathlib import Path
+
+from kungfu.storage import service
+
+MANIFEST_SUBDIR = Path("journal/system/storage/episode-manifest/live")
+LOCATION_UID = 777
+
+
+def _manifest_journal(runtime_dir: Path) -> Path:
+    files = sorted((Path(runtime_dir) / MANIFEST_SUBDIR).glob("*.journal"))
+    assert len(files) == 1
+    return files[0]
+
+
+def _walk_frames(data: bytearray) -> list[int]:
+    page_header_length = struct.unpack_from("<I", data, 4)[0]
+    offsets = []
+    offset = page_header_length
+    while offset + 4 <= len(data):
+        frame_length = struct.unpack_from("<I", data, offset)[0]
+        if frame_length == 0:
+            break
+        offsets.append(offset)
+        offset += frame_length
+    return offsets
+
+
+def _drop_last_frame(journal_file: Path) -> None:
+    # Zero the last frame's length header: the reader stops there, exactly the
+    # shape of a crash between the seal and its root append.
+    data = bytearray(journal_file.read_bytes())
+    offsets = _walk_frames(data)
+    assert offsets, "journal has no published frame"
+    struct.pack_into("<I", data, offsets[-1], 0)
+    journal_file.write_bytes(data)
+
+
+def _tamper_recorded_root(journal_file: Path, recorded_hex: str) -> None:
+    data = bytearray(journal_file.read_bytes())
+    needle = recorded_hex.encode()
+    index = data.find(needle)
+    assert index >= 0, "recorded root value not found in manifest journal"
+    original = chr(data[index])
+    data[index] = ord("0" if original != "0" else "1")
+    journal_file.write_bytes(data)
+
+
+def _build_episode(
+    runtime_dir: Path,
+    *,
+    episode_id: int = 7,
+    heartbeats: tuple[int, ...] = (),
+    extra_frame: bool = False,
+    seal: bool = True,
+) -> None:
+    # Every field explicit and deterministic, so replaying this sequence in a
+    # fresh runtime dir records byte-identical claims.
+    service.episode_begin(
+        runtime_dir,
+        episode_id=episode_id,
+        title="identity fixture",
+        actor="pytest",
+        source="content-root",
+        location_uid=LOCATION_UID,
+        begin_time=1000,
+    )
+    service.episode_attach_frame(
+        runtime_dir,
+        episode_id=episode_id,
+        frame_uid=11,
+        location_uid=LOCATION_UID,
+        stream_id=1,
+        gen_time=1100,
+        carrier_type=1000,
+        source=1,
+        dest=0,
+        data_length=16,
+        integrity_version=2,
+        payload_checksum=12345,
+        frame_checksum=67890,
+    )
+    for update_time in heartbeats:
+        service.episode_heartbeat(
+            runtime_dir,
+            episode_id=episode_id,
+            location_uid=LOCATION_UID,
+            update_time=update_time,
+            last_frame_uid=11,
+            frame_count=1,
+        )
+    if extra_frame:
+        service.episode_attach_frame(
+            runtime_dir,
+            episode_id=episode_id,
+            frame_uid=12,
+            location_uid=LOCATION_UID,
+            stream_id=1,
+            gen_time=1150,
+            carrier_type=1000,
+            source=1,
+            dest=0,
+            data_length=16,
+            integrity_version=2,
+            payload_checksum=12346,
+            frame_checksum=67891,
+        )
+    service.episode_attach_ref(
+        runtime_dir,
+        episode_id=episode_id,
+        ref_kind="input_frame",
+        ref_uid=5,
+        ref_id="fixtures/input",
+        ref_hash="",
+        location_uid=LOCATION_UID,
+        update_time=1200,
+    )
+    if seal:
+        service.episode_end(
+            runtime_dir,
+            episode_id=episode_id,
+            location_uid=LOCATION_UID,
+            end_time=2000,
+            last_frame_uid=12 if extra_frame else 11,
+            frame_count=2 if extra_frame else 1,
+            reason="done",
+        )
+
+
+def _root_of(runtime_dir: Path, episode_id: int = 7) -> dict:
+    return service.episode_inspect(runtime_dir, episode_id=episode_id)["content_root"]
+
+
+def test_seal_commits_a_verified_deterministic_root(tmp_path):
+    runtime_dir = tmp_path / "runtime"
+    _build_episode(runtime_dir)
+
+    root = _root_of(runtime_dir)
+    assert root["status"] == "verified"
+    assert root["match"] is True
+    assert root["recorded"]["record_kind"] == "episode_root_committed"
+    assert root["recorded"]["algorithm"] == "sha256"
+    assert root["recorded"]["root_value"] == root["computed"]["value"]
+    # open + frame + ref + close are covered; heartbeats are not claims
+    assert root["recorded"]["covered_record_count"] == 4
+
+    # re-folding the same journal derives the same identity
+    again = _root_of(runtime_dir)
+    assert again["computed"]["value"] == root["computed"]["value"]
+
+    # identity surfaces on the summary for list/inspect/fsck consumers
+    episode = service.episode_inspect(runtime_dir, episode_id=7)["episode"]
+    assert episode["content_root"] == root["recorded"]["root_value"]
+
+    fsck = service.fsck(runtime_dir, episode_id=7)
+    assert fsck["ok"]
+
+
+def test_heartbeats_do_not_change_identity_but_claims_do(tmp_path):
+    quiet = tmp_path / "quiet"
+    noisy = tmp_path / "noisy"
+    heavier = tmp_path / "heavier"
+    _build_episode(quiet)
+    _build_episode(noisy, heartbeats=(1300, 1400, 1500))
+    _build_episode(heavier, extra_frame=True)
+
+    quiet_root = _root_of(quiet)["recorded"]["root_value"]
+    noisy_root = _root_of(noisy)["recorded"]["root_value"]
+    heavier_root = _root_of(heavier)["recorded"]["root_value"]
+
+    assert quiet_root == noisy_root
+    assert heavier_root != quiet_root
+    assert _root_of(heavier)["recorded"]["covered_record_count"] == 5
+
+
+def test_identical_claims_in_a_fresh_store_yield_the_same_root(tmp_path):
+    # ADR-0043 migration invariance: identity survives verbatim re-append
+    # into another runtime dir.
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    _build_episode(first)
+    _build_episode(second)
+    assert (
+        _root_of(first)["recorded"]["root_value"]
+        == _root_of(second)["recorded"]["root_value"]
+    )
+
+
+def test_sealed_episode_with_lost_root_reports_absent(tmp_path):
+    runtime_dir = tmp_path / "runtime"
+    _build_episode(runtime_dir)
+    _drop_last_frame(_manifest_journal(runtime_dir))
+
+    root = _root_of(runtime_dir)
+    assert root["status"] == "absent"
+    assert root["recorded"] is None
+    # the fold can still derive the identity for inspection or later backfill
+    assert root["computed"]["value"]
+
+    # absence is honest, not a failure
+    fsck = service.fsck(runtime_dir, episode_id=7)
+    assert fsck["ok"]
+
+
+def test_tampered_root_fails_fsck(tmp_path):
+    runtime_dir = tmp_path / "runtime"
+    _build_episode(runtime_dir)
+    recorded = _root_of(runtime_dir)["recorded"]["root_value"]
+    _tamper_recorded_root(_manifest_journal(runtime_dir), recorded)
+
+    root = _root_of(runtime_dir)
+    assert root["status"] == "mismatch"
+    assert root["match"] is False
+
+    fsck = service.fsck(runtime_dir, episode_id=7)
+    assert not fsck["ok"]
+    assert fsck["status"] == "failed"
+    codes = [e["code"] for e in fsck["errors"]]
+    assert "episode_root_mismatch" in codes
+
+
+def test_open_episode_has_no_identity_yet(tmp_path):
+    runtime_dir = tmp_path / "runtime"
+    _build_episode(runtime_dir, seal=False)
+
+    root = _root_of(runtime_dir)
+    assert root["status"] == "undefined"
+    assert root["recorded"] is None
+    assert root["computed"] is None
+
+
+def test_abort_seals_identity_too(tmp_path):
+    runtime_dir = tmp_path / "runtime"
+    _build_episode(runtime_dir, seal=False)
+    service.episode_abort(
+        runtime_dir,
+        episode_id=7,
+        location_uid=LOCATION_UID,
+        end_time=2000,
+        reason="interrupted",
+    )
+    root = _root_of(runtime_dir)
+    assert root["status"] == "verified"
+
+
+def test_projection_carries_the_root_record(tmp_path):
+    runtime_dir = tmp_path / "runtime"
+    _build_episode(runtime_dir)
+    rebuilt = service.episode_projection_rebuild(runtime_dir)
+    assert rebuilt["ok"]
+    assert rebuilt["rows"]["episode_root_committed"] == 1

--- a/framework/core/tests/python/test_episode_manifest_projection.py
+++ b/framework/core/tests/python/test_episode_manifest_projection.py
@@ -75,6 +75,7 @@ def test_rebuild_builds_sqlite_at_declared_path(tmp_path):
         "episode_frame_attached": 2,
         "episode_ref_attached": 2,
         "episode_closed": 2,
+        "episode_root_committed": 2,
     }
     assert (runtime_dir / PROJECTION_SUBPATH).exists()
 

--- a/framework/core/tests/python/test_episode_manifest_recovery.py
+++ b/framework/core/tests/python/test_episode_manifest_recovery.py
@@ -204,10 +204,20 @@ def test_c5_torn_manifest_tail_never_presents_a_partial_seal(tmp_path):
 
     journal_files = _journal_files(runtime_dir)
     assert len(journal_files) == 1
-    _zero_last_frame_length(journal_files[0])
 
-    # The torn seal is invisible; the Episode regresses to open instead of
-    # surfacing as a sealed-but-unverified object, and nothing crashes.
+    # ADR-0043 publication order: the seal appends EpisodeClosed, then the
+    # content root. Crash point A — the root append is lost: the Episode
+    # stays honestly sealed with its identity reported absent, never failed.
+    _zero_last_frame_length(journal_files[0])
+    inspected = service.episode_inspect(runtime_dir, episode_id=6)
+    assert inspected["episode"]["status"] == "ended"
+    assert inspected["content_root"]["status"] == "absent"
+    fsck = service.fsck(runtime_dir, episode_id=6)
+    assert fsck["ok"]
+
+    # Crash point B — the seal itself is torn: the Episode regresses to open
+    # instead of surfacing as a sealed-but-unverified object, nothing crashes.
+    _zero_last_frame_length(journal_files[0])
     inspected = service.episode_inspect(runtime_dir, episode_id=6)["episode"]
     assert inspected["status"] == "open"
     assert inspected["closed"] is False

--- a/framework/core/tests/qualification/episode/episode_workload.py
+++ b/framework/core/tests/qualification/episode/episode_workload.py
@@ -389,7 +389,9 @@ def run_probe(args: argparse.Namespace) -> dict[str, Any]:
     semantic_record_count = sum(
         int(row.get("record_count", 0)) for row in all_episodes.get("episodes", [])
     )
-    expected_records = args.expected_count * 2
+    # ADR-0043: every sealed Episode carries open + close + the root
+    # committed at seal
+    expected_records = args.expected_count * 3
     if semantic_record_count != expected_records:
         errors.append(
             _issue(
@@ -426,7 +428,7 @@ def run_probe(args: argparse.Namespace) -> dict[str, Any]:
             "status": expected["status"],
             "opened": True,
             "closed": True,
-            "record_count": 2,
+            "record_count": 3,
             "frame_count": 0,
             "ref_count": 0,
         }
@@ -436,9 +438,10 @@ def run_probe(args: argparse.Namespace) -> dict[str, Any]:
             if episode.get(key) != value
         }
         record_kinds = [row.get("record_kind") for row in inspected.get("records", [])]
-        if record_kinds != ["episode_open", "episode_closed"]:
+        expected_kinds = ["episode_open", "episode_closed", "episode_root_committed"]
+        if record_kinds != expected_kinds:
             mismatched["record_kinds"] = {
-                "expected": ["episode_open", "episode_closed"],
+                "expected": expected_kinds,
                 "actual": record_kinds,
             }
         if mismatched:


### PR DESCRIPTION
ADR-0043: Episode identity is two layers — episode_id stays the local lifecycle coordinate; a sealed Episode's content identity is a hash root chained over its owned claim sequence, committed as EpisodeRootCommitted (carrier 10806, additive) by the seal path and verified by fsck. Covers determinism/sensitivity/crash-shape/cross-store-invariance fixtures, projection support, bundle-apply compatibility, and the qualification reference model update.