### PR TITLE
feat(shifu): styled launcher output and bootstrap-core docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@ One entrypoint runs every task under the pinned toolchain. Do not invoke pnpm,
 node, conan, or cmake directly — go through it:
 
 ```sh
+./shifu doctor    # check the development environment (install pointers)
 ./shifu sync      # install JS dependencies (frozen lockfile)
 ./shifu build     # build all workspaces (C++ core + bindings + app)
 ./shifu rebuild   # clear generated build outputs, then run build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,10 @@ package manager (pnpm via Corepack), and the Python environment (via
 [uv](https://docs.astral.sh/uv/)) — bootstrapped automatically on first run
 when not already installed.
 
+Run `./shifu doctor` to check your environment: it reports every required
+tool with a version line or an install pointer (and exits non-zero when a
+required tool is missing, so it can gate scripts).
+
 ## Repository layout
 
 Kungfu is a pnpm-workspaces monorepo. See [`docs/architecture.md`](docs/architecture.md)

--- a/README.md
+++ b/README.md
@@ -119,11 +119,24 @@ conventions, and the pull request / release flow.
 ```sh
 git clone git@github.com:kungfu-systems/kungfu.git
 cd kungfu
+./shifu doctor            # check your environment (optional but recommended)
 ./shifu sync && ./shifu build
 ```
 
 `./shifu` (`shifu.cmd` on Windows) is the build opener: it bootstraps the
-pinned toolchain on first run — nothing to preinstall beyond `curl`.
+pinned toolchain on first run — nothing to preinstall beyond `curl` (plus a
+C++ toolchain and CMake for the native core; `./shifu doctor` tells you
+exactly what is missing and where to get it).
+
+With shifu installed on your PATH (`cargo install --path crates/shifu --root
+~/.local` from any checkout), it also works as a standalone bootstrap core:
+
+```sh
+shifu clone [path]        # fetch the repository (default: current directory)
+cd <path> && shifu build  # inside a checkout, shifu always delegates to the
+                          # repo's own ./shifu — install once, stay current
+                          # by pulling code, never by re-installing shifu
+```
 
 ## Documentation
 

--- a/crates/shifu/src/doctor.rs
+++ b/crates/shifu/src/doctor.rs
@@ -14,7 +14,7 @@
 use std::path::Path;
 use std::process::Command;
 
-use crate::{tools, util};
+use crate::{style, tools, util};
 
 struct Check {
     label: &'static str,
@@ -24,7 +24,10 @@ struct Check {
 }
 
 pub fn run(root: Option<&Path>) -> ! {
-    println!("shifu doctor - development environment preflight\n");
+    println!(
+        "\u{1f94b} {}\n",
+        style::bold("shifu doctor - development environment preflight")
+    );
 
     #[cfg_attr(not(windows), allow(unused_mut))]
     let mut required = vec![
@@ -41,14 +44,20 @@ pub fn run(root: Option<&Path>) -> ! {
     #[cfg(windows)]
     required.push(msvc_check());
 
-    println!("Required (preinstall these; shifu does not manage them):");
+    println!(
+        "{}",
+        style::cyan("Required (preinstall these; shifu does not manage them):")
+    );
     let mut missing_required = false;
     for check in &required {
         missing_required |= check.required && check.found.is_none();
         print_check(check);
     }
 
-    println!("\nManaged by shifu (bootstrapped automatically when missing):");
+    println!(
+        "\n{}",
+        style::cyan("Managed by shifu (bootstrapped automatically when missing):")
+    );
     for tool in [&tools::FNM, &tools::UV] {
         let found = tools::find_tool(tool, root.unwrap_or(Path::new(".")))
             .and_then(|p| version_of(&p.to_string_lossy(), &["--version"]));
@@ -61,21 +70,24 @@ pub fn run(root: Option<&Path>) -> ! {
             (None, Some(p)) => format!("absent; will bootstrap {p} on first run"),
             (None, None) => "absent; will bootstrap the pinned version on first run".to_string(),
         };
-        println!("  ~ {:<14} {label}", tool.name);
+        println!("  \u{1f9f0} {:<14} {label}", tool.name);
     }
     if let Some(root) = root {
         if let Ok(node) = std::fs::read_to_string(root.join(".node-version")) {
             println!(
-                "  ~ {:<14} pinned {} by .node-version (installed via fnm on first build)",
+                "  \u{1f9f0} {:<14} pinned {} by .node-version (installed via fnm on first build)",
                 "node",
                 node.trim()
             );
         }
     } else {
-        println!("  (run inside a kungfu checkout to see the repo's toolchain pins)");
+        println!(
+            "  {}",
+            style::dim("(run inside a kungfu checkout to see the repo's toolchain pins)")
+        );
     }
 
-    println!("\nOptional:");
+    println!("\n{}", style::cyan("Optional:"));
     print_check(&probe(
         "rustc/cargo",
         &["cargo"],
@@ -84,21 +96,33 @@ pub fn run(root: Option<&Path>) -> ! {
     ));
 
     if missing_required {
-        println!("\nresult: missing required tools - see the install pointers above");
+        println!(
+            "\n\u{26d4} {}",
+            style::red("missing required tools - see the install pointers above")
+        );
         std::process::exit(1);
     }
-    println!("\nresult: all required tools present");
+    println!(
+        "\n\u{1f94b} {}",
+        style::green("all required tools present - ready to train")
+    );
     std::process::exit(0)
 }
 
 fn print_check(check: &Check) {
     match &check.found {
-        Some(version) => println!("  + {:<14} {version}", check.label),
-        None => println!(
-            "  {} {:<14} not found - {}",
-            if check.required { "x" } else { "-" },
+        Some(version) => println!("  \u{2705} {:<14} {}", check.label, style::dim(version)),
+        None if check.required => println!(
+            "  \u{274c} {:<14} {} - {}",
             check.label,
-            check.hint
+            style::red("not found"),
+            style::yellow(check.hint)
+        ),
+        None => println!(
+            "  \u{2796} {:<14} {} - {}",
+            check.label,
+            style::dim("not found"),
+            style::dim(check.hint)
         ),
     }
 }

--- a/crates/shifu/src/main.rs
+++ b/crates/shifu/src/main.rs
@@ -39,6 +39,7 @@ mod doctor;
 mod envfile;
 #[cfg(windows)]
 mod msvc;
+mod style;
 mod tools;
 mod util;
 
@@ -46,25 +47,48 @@ mod util;
 /// mirroring the sh / cmd entrypoints. Everything else goes to corepack pnpm.
 const L2_SUBCOMMANDS: &[&str] = &["build", "rebuild", "proxy", "config"];
 
-const USAGE: &str = "\
-shifu - the kungfu development/build launcher (pinned-toolchain entrypoint)
-
-Usage:
-  shifu <task> [args...]     run any pnpm task under the pinned toolchain
-                             (node via fnm/.node-version, python via uv;
-                             missing prerequisites bootstrap automatically)
-  shifu build | rebuild      bootstrap build (rebuild clears generated outputs)
-  shifu proxy | config ...   manage local mirror/cache config (build-local.env)
-  shifu clone [path]         clone the kungfu repository (default: current dir;
-                             SHIFU_CLONE_URL overrides the source)
-  shifu doctor               check the development environment (install pointers
-                             for anything missing; exits 1 on missing required)
-  shifu --version | -v | -V  launcher version and build identity
-  shifu self-version         this binary's version, machine readable
-  shifu help                 pnpm's own help (tasks are pnpm scripts)
-
-Common tasks: sync, build, check, fix, verify, dist, app
-Docs: AGENTS.md (build), docs/rust-adoption.md (how this launcher works)";
+fn print_usage() {
+    println!(
+        "{} {}",
+        "\u{1f94b}",
+        style::bold("shifu - the kungfu development/build launcher (pinned-toolchain entrypoint)")
+    );
+    println!();
+    println!("{}", style::cyan("Usage:"));
+    println!("  shifu <task> [args...]     run any pnpm task under the pinned toolchain");
+    println!(
+        "                             {}",
+        style::dim("(node via fnm/.node-version, python via uv;")
+    );
+    println!(
+        "                             {}",
+        style::dim("missing prerequisites bootstrap automatically)")
+    );
+    println!("  shifu build | rebuild      bootstrap build (rebuild clears generated outputs)");
+    println!("  shifu proxy | config ...   manage local mirror/cache config (build-local.env)");
+    println!("  shifu clone [path]         clone the kungfu repository (default: current dir;");
+    println!(
+        "                             {}",
+        style::dim("SHIFU_CLONE_URL overrides the source)")
+    );
+    println!("  shifu doctor               check the development environment (install pointers");
+    println!(
+        "                             {}",
+        style::dim("for anything missing; exits 1 on missing required)")
+    );
+    println!("  shifu --version | -v | -V  launcher version and build identity");
+    println!("  shifu self-version         this binary's version, machine readable");
+    println!("  shifu help                 pnpm's own help (tasks are pnpm scripts)");
+    println!();
+    println!(
+        "{} sync, build, check, fix, verify, dist, app",
+        style::cyan("Common tasks:")
+    );
+    println!(
+        "{} AGENTS.md (build), docs/rust-adoption.md (how this launcher works)",
+        style::cyan("Docs:")
+    );
+}
 
 fn main() {
     let args: Vec<String> = env::args().skip(1).collect();
@@ -80,7 +104,7 @@ fn main() {
     // Usage is static and repo-independent: answer before repo discovery so a
     // bare `shifu` outside any checkout is still helpful. Not delegated.
     if args.is_empty() || matches!(first, Some("-h") | Some("--help")) {
-        println!("{USAGE}");
+        print_usage();
         exit(if args.is_empty() { 2 } else { 0 });
     }
 
@@ -141,7 +165,10 @@ fn clone_repo(args: &[String]) -> ! {
             127,
         );
     };
-    eprintln!("shifu: cloning {url} into {dest}");
+    eprintln!(
+        "\u{1f94b} {}",
+        style::bold(&format!("cloning {url} into {dest}"))
+    );
     let status = std::process::Command::new(git)
         .arg("clone")
         .arg(&url)
@@ -154,7 +181,15 @@ fn clone_repo(args: &[String]) -> ! {
             } else {
                 format!("cd {dest} && ")
             };
-            eprintln!("shifu: done - next: {cd_hint}./shifu build   (or ./shifu doctor first)");
+            eprintln!(
+                "\u{2705} {} next: {}",
+                style::green("done -"),
+                style::bold(&format!("{cd_hint}./shifu build")),
+            );
+            eprintln!(
+                "   {}",
+                style::dim("(or ./shifu doctor first to check your environment)")
+            );
             exit(0);
         }
         Ok(s) => exit(s.code().unwrap_or(1)),

--- a/crates/shifu/src/style.rs
+++ b/crates/shifu/src/style.rs
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Minimal ANSI styling for launcher-owned output (usage, doctor, clone).
+// std-only, and honest about where color belongs: enabled only when stdout is
+// a terminal, NO_COLOR is unset, and TERM is not "dumb" — piped output stays
+// plain text so scripts can parse it. Task output is untouched; only the few
+// lines shifu itself speaks get styled.
+
+use std::io::IsTerminal;
+use std::sync::OnceLock;
+
+fn enabled() -> bool {
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| {
+        std::env::var_os("NO_COLOR").is_none()
+            && std::env::var("TERM").map(|t| t != "dumb").unwrap_or(true)
+            && std::io::stdout().is_terminal()
+    })
+}
+
+fn wrap(code: &str, text: &str) -> String {
+    if enabled() {
+        format!("\x1b[{code}m{text}\x1b[0m")
+    } else {
+        text.to_string()
+    }
+}
+
+pub fn bold(text: &str) -> String {
+    wrap("1", text)
+}
+
+pub fn dim(text: &str) -> String {
+    wrap("2", text)
+}
+
+pub fn green(text: &str) -> String {
+    wrap("32", text)
+}
+
+pub fn red(text: &str) -> String {
+    wrap("31", text)
+}
+
+pub fn yellow(text: &str) -> String {
+    wrap("33", text)
+}
+
+pub fn cyan(text: &str) -> String {
+    wrap("36", text)
+}


### PR DESCRIPTION
Styled launcher-owned output (usage / doctor / clone): ANSI color + semantic emoji, TTY-gated (NO_COLOR and TERM=dumb respected; piped output stays plain, doctor's exit code remains the script interface). std-only ~50-line style module.

Docs: README getting-started gains the installed-shifu bootstrap-core path (cargo install once, shifu clone anywhere, stay current by pulling code) and a doctor step; CONTRIBUTING and AGENTS.md point at doctor.