### PR TITLE
fix(sdk): refresh canonical policy baseline

### DIFF
--- a/framework/contract/kungfu-agent-first-canonical-policy.json
+++ b/framework/contract/kungfu-agent-first-canonical-policy.json
@@ -31,7 +31,7 @@
     "buildchain": {
       "package": {
         "name": "@kungfu-tech/buildchain",
-        "version": "2.11.1"
+        "version": "2.11.14-alpha.0"
       },
       "formatting": {
         "name": "buildchain-release-evidence-json-v1",


### PR DESCRIPTION
## Summary
- refresh the frozen canonical-policy Buildchain package version to match the SDK dependency
- restore byte-for-byte equality between the canonical source and SDK renderer

## Validation
- `./shifu check`
- `./shifu exec node developer/sdk/src/sdk.js contract policy --check --json`
- `./shifu exec node developer/sdk/src/sdk.js contract audit --json`

Signed-off-by: Keren Dong <keren.dong+cx@kungfu.link>