### PR TITLE
docs(positioning): define the runtime fact infrastructure layer

### DIFF
--- a/docs/MAP.md
+++ b/docs/MAP.md
@@ -25,6 +25,7 @@ and the map routes a question to whichever doc answers it.
 | What is kungfu, in one idea? | [`../README.md`](../README.md) | — | stable |
 | What do the terms mean (`kungfu` / `yijinjing` / journal / schema …)? | [`concepts.md`](concepts.md) | use | stable |
 | Why is it built this way? What is load-bearing? | [`design-philosophy.md`](design-philosophy.md) | why | stable |
+| Why compare Kungfu to SQLite, Git, and a flight recorder — and why is it neither observability nor blockchain? | [`design-philosophy.md`](design-philosophy.md#the-missing-infrastructure-layer-runtime-facts) | why | stable |
 | Why does Kungfu start from accountability? | [`facts-before-trust.md`](facts-before-trust.md) | why | stable |
 | Why this versioning / release design (don't replace it naively)? | [`version-release-design.md`](version-release-design.md) | why | stable |
 | When must a change open a minor or major (and when must it not)? | [`versioning.md`](versioning.md) (rule: KFD-1, adopted by ADR-0010) | verify | stable |
@@ -89,6 +90,10 @@ route to the row that answers them:
   ([ADR-0021](../framework/core/docs/adr/ADR-0021-observer-relative-timeline-projection.md)).
 - **accountability / facts before trust / local proof before control** → *why
   does Kungfu start from accountability* ([`facts-before-trust.md`](facts-before-trust.md)).
+- **SQLite / Git for runs / flight recorder / runtime fact infrastructure /
+  observability / OpenTelemetry / blockchain / polyglot semantic core** → *why
+  Kungfu occupies a distinct runtime-fact layer*
+  ([`design-philosophy.md`](design-philosophy.md#the-missing-infrastructure-layer-runtime-facts)).
 - **latency / performance / zero-copy / serialization** → *the membrane*
   ([`architecture.md`](architecture.md)) and *the event model*
   ([`event-model.md`](event-model.md)).

--- a/docs/design-philosophy.md
+++ b/docs/design-philosophy.md
@@ -34,6 +34,114 @@ recover a failed workflow — should naturally move through local facts,
 responsibility state, and proof-backed control decisions because that is the
 simplest reliable way the product works.
 
+## The missing infrastructure layer: runtime facts
+
+Kungfu is runtime fact infrastructure for the agent era. Its design target can
+be located with three coordinates:
+
+```text
+shape:     SQLite
+semantics: Git, but for runs rather than source code
+mission:   a flight recorder with a qualification layer
+```
+
+In one sentence: **Kungfu aims to do for what actually happened during a run
+what Git did for source history, while fitting into each language ecosystem the
+way SQLite does.** The comparison describes the product's intended shape and
+responsibility; it is not a shortcut around evidence. Current guarantees and
+maturity remain grounded in [`contracts.md`](contracts.md) and
+[`known-limits.md`](known-limits.md).
+
+### Shaped like SQLite: embedded where the facts happen
+
+SQLite is useful without requiring a database service to be deployed first. It
+travels as a library, speaks through native language bindings, and writes at the
+place where the application already runs. Kungfu follows that shape for runtime
+facts: the fact source should live beside the work, not begin as a remote sample
+sent to a mandatory service.
+
+The intended adoption test is deliberately concrete: each supported ecosystem
+should offer a five-minute `hello Episode` path with no action outside that
+ecosystem. A Python or Node user should encounter a native package and native
+API, not a foreign platform ceremony. Rust may add another native surface when
+it earns its place, but it must not create another definition of causality,
+receipts, manifests, or replay. Native surfaces are the reach; the C++ core and
+declared schema are the semantic weight-bearing layer.
+
+### Git semantics, applied to runs
+
+Source code already has a first-class history object: a Git commit is bounded,
+independently addressable, durable under pressure, and meaningful inside an
+explicit trust boundary. Agent work needs an equivalent unit for execution
+history. In Kungfu that unit is the
+[`Episode`](episode-object-model.md): a bounded causal segment whose facts,
+payload commitments, provenance, dependencies, and verification roots can be
+inspected as one object.
+
+The analogy is semantic, not literal. An Episode is not a commit, and replaying
+a run is not checking out a tree. The useful correspondence is that a run stops
+being an expendable stream of logs and becomes an object that can be named,
+verified, exported, imported, compared, and projected into a reproducible
+timeline under a declared policy. Git also demonstrates the adoption property:
+developers do not change programming languages to use source history. Runtime
+fact semantics should be just as language-neutral.
+
+### A flight recorder, with qualification
+
+A flight recorder preserves the evidence needed to reconstruct and attribute
+what happened. Kungfu adds an active semantic layer: it should also be able to
+qualify whether the declared evidence boundary is intact and which claims that
+evidence can support. Recording, replay, attribution, `fsck`, manifests,
+receipts, and qualification belong to one responsibility chain.
+
+This does not mean recording every bit of machine state or claiming that every
+external side effect can be replayed. The trust boundary must be explicit. If
+required evidence is absent or unverifiable, the honest result is a contracted
+capability or failed qualification, not a confident reconstruction assembled
+from guesses.
+
+### Two deliberate non-identities
+
+The distinctions below are more important than the analogies because they
+prevent the product from collapsing into an already named category.
+
+**Kungfu is not observability.** OpenTelemetry, monitoring systems, and tracing
+services are excellent at answering operational questions from telemetry. They
+may sample, aggregate, or optimize for dashboards and fleet-scale diagnosis.
+Kungfu's ledger has a different duty: preserve the declared, correctness-relevant
+facts as a locally owned and checkable object. Monitoring asks, "How does the
+system appear to be behaving?" A runtime fact ledger asks, "What accepted facts
+show what happened, what can be reproduced, and who or what was responsible?"
+The two can interoperate; one should not be mislabeled as the other.
+
+**Kungfu is not a blockchain.** Both domains use words such as *ledger*,
+*integrity*, and *trust*, but they solve different problems. A blockchain
+coordinates consensus among parties that do not share an authority. Kungfu
+records and verifies agent work for participants who need factual provenance
+and accountability. It needs strict semantics, integrity checks, and explicit
+source boundaries — not a consensus machine, a token, or a globally replicated
+chain.
+
+### Why this layer becomes necessary now
+
+Code has Git. Data has databases. Metrics and traces have observability
+systems. Execution itself rarely became a first-class durable object because a
+traditional program's behavior was largely derived from code plus inputs; logs
+were often enough to investigate the exceptions.
+
+Agent work changes that premise. A run may depend on model behavior, context,
+tool results, permissions, approvals, randomness, external systems, and choices
+made during execution. The source code no longer determines the action history
+by itself. **What actually happened** therefore becomes a first-class object
+that must be recorded, replayed within declared limits, and qualified in its own
+right.
+
+That requirement determines the architecture. Facts must be captured where the
+work happens, under runtime-native semantics, before they are reduced to remote
+telemetry or a model's summary. The ecosystem surface can be polyglot; the
+causal, manifest, receipt, and trust semantics cannot fork by language. This is
+the empty layer Kungfu is built to occupy.
+
 ## Principle 1 — The machine adapts to the person
 
 Kungfu absorbs toolchain and runtime complexity into the product so its users do


### PR DESCRIPTION
## Summary

- position Kungfu through the SQLite shape, Git-for-runs semantics, and flight-recorder-plus-qualification mission
- distinguish the runtime fact ledger from observability and blockchain
- explain why agent work creates a missing first-class runtime-fact layer
- route the positioning question and keywords from the documentation map

## Validation

- `git diff --check`
- public-surface leakage scan
- `./shifu check`