### PR TITLE
ci(build): expose trusted Buildchain train override

### DIFF
--- a/.buildchain/kfd/kfd-1/contract-world.witness.json
+++ b/.buildchain/kfd/kfd-1/contract-world.witness.json
@@ -35,7 +35,7 @@
   "sourceVerificationRequired": false,
   "canonicalPolicy": {
     "path": "framework/contract/kungfu-agent-first-canonical-policy.json",
-    "sha256": "d55da341f85d159ab417d5c7b7f8658103fc1d0fa0adfb3c6ecca4d38cca2699"
+    "sha256": "6ac1e00e42d8f079d7a90a51bedf50d0bb82637c4ee880a9a4a2c0152a5fe89c"
   },
   "registry": {
     "path": "framework/contract/kungfu-contracts.registry.json",

--- a/.buildchain/kfd/kfd-1/release-gate.json
+++ b/.buildchain/kfd/kfd-1/release-gate.json
@@ -54,7 +54,7 @@
       "standard": "KFD-1",
       "standardKey": "kfd-1",
       "result": "passed",
-      "preBuildWitnessSha256": "1d3ff601bb7b3040eb55282a978b9ddf187b1e3069779395cb65c42c731bf3ac",
+      "preBuildWitnessSha256": "e27ca9952a3ef9ee9e7a93014f563f2fe13c794bede1bb6509be609e4fdeb284",
       "sourceHashes": {
         "sha256": "899bb7f3cace01b484f61d7f81ac1a2b90543d39613b2fc482bebcd28135a075",
         "surfaceCount": 3
@@ -100,7 +100,7 @@
         "sourceVerificationRequired": true,
         "canonicalPolicy": {
           "path": "framework/contract/kungfu-agent-first-canonical-policy.json",
-          "sha256": "d55da341f85d159ab417d5c7b7f8658103fc1d0fa0adfb3c6ecca4d38cca2699"
+          "sha256": "6ac1e00e42d8f079d7a90a51bedf50d0bb82637c4ee880a9a4a2c0152a5fe89c"
         },
         "registry": {
           "path": "framework/contract/kungfu-contracts.registry.json",

--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -5,8 +5,8 @@
   "witnessKind": "prebuild",
   "supportLevel": "release",
   "source": {
-    "cwd": "/Users/dkr/Worktrees/kungfu/feature/kfd2-product-claims-migration",
-    "sourceSha": "1946346530db0053af8a28e6612e5d108af44969",
+    "cwd": "/Users/dkr/Worktrees/kungfu/fix/buildchain-train-validation",
+    "sourceSha": "155c1c726a688a5dccae517d44adbe993247fafd",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
     "registryDigest": "sha256:75b842671319953a3dd7543cc21afd2c46a494bc0a09897981b1e5bf76a4e017"
   },

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,11 @@ on:
   # Manual runs validate lifecycle changes (e.g. the ./shifu entrypoint
   # switch) on the full platform matrix without waiting for an alpha PR.
   workflow_dispatch:
+    inputs:
+      buildchain-ref:
+        description: "Temporary Buildchain train or exact SHA for trusted manual validation"
+        required: false
+        default: ""
 
 permissions:
   contents: read
@@ -23,6 +28,7 @@ jobs:
     uses: kungfu-systems/buildchain/.github/workflows/.build.yml@v2
     secrets: inherit
     with:
+      buildchain-ref: ${{ inputs.buildchain-ref || '' }}
       runner-preset: kungfu-v4-self-hosted
       artifact-name: kungfu
       artifact-paths: |

--- a/developer/sdk/kfd/kfd-1/contract-world.witness.json
+++ b/developer/sdk/kfd/kfd-1/contract-world.witness.json
@@ -35,7 +35,7 @@
   "sourceVerificationRequired": false,
   "canonicalPolicy": {
     "path": "framework/contract/kungfu-agent-first-canonical-policy.json",
-    "sha256": "d55da341f85d159ab417d5c7b7f8658103fc1d0fa0adfb3c6ecca4d38cca2699"
+    "sha256": "6ac1e00e42d8f079d7a90a51bedf50d0bb82637c4ee880a9a4a2c0152a5fe89c"
   },
   "registry": {
     "path": "framework/contract/kungfu-contracts.registry.json",

--- a/developer/sdk/kfd/kfd-1/release-gate.json
+++ b/developer/sdk/kfd/kfd-1/release-gate.json
@@ -54,7 +54,7 @@
       "standard": "KFD-1",
       "standardKey": "kfd-1",
       "result": "passed",
-      "preBuildWitnessSha256": "1d3ff601bb7b3040eb55282a978b9ddf187b1e3069779395cb65c42c731bf3ac",
+      "preBuildWitnessSha256": "e27ca9952a3ef9ee9e7a93014f563f2fe13c794bede1bb6509be609e4fdeb284",
       "sourceHashes": {
         "sha256": "899bb7f3cace01b484f61d7f81ac1a2b90543d39613b2fc482bebcd28135a075",
         "surfaceCount": 3
@@ -100,7 +100,7 @@
         "sourceVerificationRequired": true,
         "canonicalPolicy": {
           "path": "framework/contract/kungfu-agent-first-canonical-policy.json",
-          "sha256": "d55da341f85d159ab417d5c7b7f8658103fc1d0fa0adfb3c6ecca4d38cca2699"
+          "sha256": "6ac1e00e42d8f079d7a90a51bedf50d0bb82637c4ee880a9a4a2c0152a5fe89c"
         },
         "registry": {
           "path": "framework/contract/kungfu-contracts.registry.json",


### PR DESCRIPTION
## Summary

- expose the documented trusted `workflow_dispatch` `buildchain-ref` pass-through while keeping the committed reusable workflow pinned to `@v2`
- preserve normal build behavior when the input is empty
- refresh the already-stale KFD-1/KFD-3 projections required by the repository commit gate

## Validation

- `./shifu check`
- `actionlint .github/workflows/build.yml`
- DCO and repository pre-commit gate
- exact train run: https://github.com/kungfu-systems/kungfu/actions/runs/29099884183

This provides the consumer evidence path for Buildchain issue #1043 without committing a temporary Buildchain train ref.