### PR TITLE
shifu: source-fresh dev cache + self-update

### DIFF
--- a/crates/shifu-core/src/bootstrap.rs
+++ b/crates/shifu-core/src/bootstrap.rs
@@ -448,14 +448,20 @@ pub fn fetch(spec: &FetchSpec) -> Result<PathBuf, BootstrapError> {
     if let Some(expected) = &spec.sha256 {
         verify_checksum(spec, expected, &archive)?;
     }
-    extract(&archive, &work).map_err(|detail| spec.error(BootstrapErrorKind::Io { detail }))?;
 
+    // Archives are unpacked and searched for the binary; a raw asset (no
+    // archive suffix — release binaries like shifu's ship raw) IS the binary.
     let binary_name = spec.binary_name();
-    let extracted = find_file(&work, &binary_name, 3).ok_or_else(|| {
-        spec.error(BootstrapErrorKind::Io {
-            detail: format!("{binary_name} not found inside {}", archive.display()),
-        })
-    })?;
+    let extracted = if is_archive_name(&archive) {
+        extract(&archive, &work).map_err(|detail| spec.error(BootstrapErrorKind::Io { detail }))?;
+        find_file(&work, &binary_name, 3).ok_or_else(|| {
+            spec.error(BootstrapErrorKind::Io {
+                detail: format!("{binary_name} not found inside {}", archive.display()),
+            })
+        })?
+    } else {
+        archive.clone()
+    };
 
     #[cfg(unix)]
     {
@@ -478,6 +484,19 @@ pub fn fetch(spec: &FetchSpec) -> Result<PathBuf, BootstrapError> {
     }
     let _ = fs::remove_dir_all(&work);
     Ok(target)
+}
+
+fn is_archive_name(path: &Path) -> bool {
+    let name = path.to_string_lossy().to_lowercase();
+    name.ends_with(".tar.gz") || name.ends_with(".tgz") || name.ends_with(".zip")
+}
+
+/// Download one file with the host's own tools (curl, PowerShell fallback on
+/// Windows) — the same zero-dependency engine `fetch` uses, exposed for
+/// consumers that need a sidecar file (e.g. a release's SHA256SUMS) rather
+/// than a cached tool.
+pub fn download_file(url: &str, dest: &Path) -> Result<(), String> {
+    download(url, dest)
 }
 
 fn download(url: &str, dest: &Path) -> Result<(), String> {

--- a/crates/shifu-core/tests/bootstrap_roundtrip.rs
+++ b/crates/shifu-core/tests/bootstrap_roundtrip.rs
@@ -118,5 +118,23 @@ fn pinned_fetch_roundtrip_cache_hit_and_checksum_gate() {
         "a failed verification must not populate the cache"
     );
 
+    // Raw (non-archive) asset: release binaries like shifu's own ship as
+    // bare files — the verified download IS the binary.
+    let payload: &[u8] = b"raw-binary-bytes";
+    let raw = scratch.join("rawtool-macos-arm64");
+    fs::write(&raw, payload).expect("write raw fixture");
+    let digest = sha256_file(&raw).expect("digest raw fixture");
+    let raw_spec = FetchSpec {
+        tool: "rawtool".to_string(),
+        version: "2.0.0".to_string(),
+        url: file_url(&raw),
+        sha256: Some(digest),
+        mirror_env: None,
+        binary: None,
+    };
+    let cached = fetch(&raw_spec).expect("raw asset fetch");
+    assert_eq!(cached, raw_spec.cached_binary());
+    assert_eq!(fs::read(&cached).expect("read cached raw"), payload);
+
     let _ = fs::remove_dir_all(&scratch);
 }

--- a/crates/shifu/src/main.rs
+++ b/crates/shifu/src/main.rs
@@ -39,6 +39,7 @@ mod doctor;
 mod envfile;
 #[cfg(windows)]
 mod msvc;
+mod self_update;
 mod tools;
 mod util;
 
@@ -84,6 +85,11 @@ fn print_usage() {
     );
     println!("  shifu --version | -v | -V  launcher version and build identity");
     println!("  shifu self-version         this binary's version, machine readable");
+    println!("  shifu self-update          refresh this installed binary in place");
+    println!(
+        "                             {}",
+        style::dim("(from checkout source, or --version <v> for a release)")
+    );
     println!("  shifu help                 pnpm's own help (tasks are pnpm scripts)");
     println!();
     println!(
@@ -121,18 +127,28 @@ fn main() {
 
     let is_version = matches!(first, Some("--version") | Some("-v") | Some("-V"));
     let is_doctor = first == Some("doctor");
+    let is_self_update = first == Some("self-update");
 
-    let root = find_repo_root(is_version || is_doctor);
+    let root = find_repo_root(is_version || is_doctor || is_self_update);
 
     if is_version {
         println!("{}", version_line(root.as_deref()));
     }
     if let Some(root) = root.as_deref() {
         envfile::load(root);
+        // self-update answers for THIS binary (never delegated): delegation
+        // would replace the process with the checkout's launcher, while the
+        // update must act on the binary the user invoked.
+        if is_self_update {
+            self_update::run(Some(root), &args[1..]);
+        }
         maybe_delegate_to_repo_entrypoint(root, &args);
     }
     if is_version {
         exit(0);
+    }
+    if is_self_update {
+        self_update::run(None, &args[1..]);
     }
     if is_doctor {
         doctor::run(root.as_deref());

--- a/crates/shifu/src/self_update.rs
+++ b/crates/shifu/src/self_update.rs
@@ -1,0 +1,241 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// `shifu self-update` — refresh an installed shifu binary in place.
+//
+// Answered before repo delegation on purpose (like self-version): delegation
+// replaces the process with the checkout's launcher, and an update must act
+// on the binary the user actually invoked. Inside a checkout the freshest
+// truth is the checkout itself — build from source when cargo is present,
+// else fetch the release asset the checkout pins. Outside a checkout an
+// explicit `--version <v>` is required: guessing "latest" across a shared
+// release namespace is how updaters install the wrong thing.
+//
+// Shim-cache copies are refused: the repo shim owns their lifecycle (slots
+// are content-addressed against the launcher source and retired
+// automatically), so updating one in place would only be overwritten.
+//
+// The replacement is a rename dance — stage next to the target, move the old
+// binary aside, move the new one in, restore on failure — so a failed update
+// never leaves the machine without a working shifu (the helper of last
+// resort must not be breakable by its own maintenance).
+
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use shifu_core::bootstrap::{self, FetchSpec};
+use shifu_core::{host, style};
+
+use crate::util;
+
+const DIST_BASE: &str = "https://github.com/kungfu-systems/kungfu/releases/download";
+
+pub fn run(root: Option<&Path>, args: &[String]) -> ! {
+    let mut version_arg: Option<String> = None;
+    let mut iter = args.iter();
+    while let Some(arg) = iter.next() {
+        match arg.as_str() {
+            "--version" => match iter.next() {
+                Some(v) => version_arg = Some(v.clone()),
+                None => util::die("usage: shifu self-update [--version <version>]"),
+            },
+            _ => util::die("usage: shifu self-update [--version <version>]"),
+        }
+    }
+
+    let exe = env::current_exe()
+        .and_then(|p| p.canonicalize())
+        .unwrap_or_else(|e| util::die(&format!("cannot locate this binary: {e}")));
+
+    let shim_cache = host::kungfu_cache_dir().join("shifu");
+    if exe.starts_with(&shim_cache) {
+        util::die(&format!(
+            "this copy is a repo-shim cache slot ({}) — the shim refreshes it automatically; \
+             to force a refresh remove the slot: rm -rf {}",
+            exe.display(),
+            exe.parent().unwrap_or(&shim_cache).display()
+        ));
+    }
+
+    // Decide the replacement. An explicit --version always means the release
+    // asset (also the escape hatch when a checkout's source cannot build).
+    let source_root = match version_arg {
+        None => root.filter(|_| cargo_path().is_some()),
+        Some(_) => None,
+    };
+    let new_binary = if let Some(root) = source_root {
+        build_from_source(root)
+    } else {
+        let version = version_arg
+            .or_else(|| root.and_then(pinned_version))
+            .unwrap_or_else(|| {
+                util::die(
+                    "outside a kungfu checkout the target must be explicit: \
+                     shifu self-update --version <version>",
+                )
+            });
+        fetch_release(&version)
+    };
+
+    replace_binary(&exe, &new_binary);
+    eprintln!(
+        "\u{2705} {} {}",
+        style::green("updated"),
+        style::bold(&exe.display().to_string())
+    );
+    eprintln!("   {}", style::dim("verify with: shifu --version"));
+    std::process::exit(0)
+}
+
+fn cargo_path() -> Option<PathBuf> {
+    host::find_on_path("cargo")
+}
+
+/// The launcher release pin of a checkout (crates/shifu/Cargo.toml).
+fn pinned_version(root: &Path) -> Option<String> {
+    let toml = fs::read_to_string(root.join("crates/shifu/Cargo.toml")).ok()?;
+    toml.lines()
+        .find_map(|line| line.strip_prefix("version = \""))
+        .and_then(|rest| rest.strip_suffix('"'))
+        .map(str::to_string)
+}
+
+/// Build the launcher from the checkout source. The cargo target dir lives in
+/// the user cache so read-only-locked checkouts build too.
+fn build_from_source(root: &Path) -> PathBuf {
+    let cargo = cargo_path().expect("checked by caller");
+    let target_dir = host::kungfu_cache_dir()
+        .join("shifu")
+        .join("cargo-target")
+        .join("self-update");
+    if let Err(e) = fs::create_dir_all(&target_dir) {
+        util::die(&format!("cannot create {}: {e}", target_dir.display()));
+    }
+    eprintln!(
+        "shifu: building from source at {}",
+        style::bold(&root.display().to_string())
+    );
+    let status = Command::new(cargo)
+        .args(["build", "--release", "--locked", "--manifest-path"])
+        .arg(root.join("crates/Cargo.toml"))
+        .args(["-p", "shifu"])
+        .env("CARGO_TARGET_DIR", &target_dir)
+        .current_dir(root)
+        .status();
+    match status {
+        Ok(s) if s.success() => {}
+        Ok(s) => util::die(&format!(
+            "source build failed (exit {:?}); to update from a release instead: \
+             shifu self-update --version <version>",
+            s.code()
+        )),
+        Err(e) => util::die(&format!("failed to run cargo: {e}")),
+    }
+    let name = if cfg!(windows) { "shifu.exe" } else { "shifu" };
+    target_dir.join("release").join(name)
+}
+
+/// Release asset name for the current platform (mirrors release-shifu.yml).
+fn release_asset() -> String {
+    let (os, arch) = (env::consts::OS, env::consts::ARCH);
+    match (os, arch) {
+        ("macos", "aarch64") => "shifu-macos-arm64".to_string(),
+        ("macos", "x86_64") => "shifu-macos-x64".to_string(),
+        ("linux", "x86_64") => "shifu-linux-x64".to_string(),
+        ("linux", "aarch64") => "shifu-linux-arm64".to_string(),
+        ("windows", "x86_64") => "shifu-windows-x64.exe".to_string(),
+        _ => util::die(&format!("no prebuilt shifu release for {os}/{arch}")),
+    }
+}
+
+/// Fetch the pinned release binary, verified against the release's
+/// SHA256SUMS, through shifu-core's fetch engine (cached user-globally, so
+/// repeating an update needs no second download).
+fn fetch_release(version: &str) -> PathBuf {
+    let asset = release_asset();
+    let base = env::var("SHIFU_DIST_MIRROR").unwrap_or_else(|_| DIST_BASE.to_string());
+    let dir = format!("{}/shifu-v{version}", base.trim_end_matches('/'));
+
+    let work = host::unique_temp_dir("shifu-self-update")
+        .unwrap_or_else(|e| util::die(&format!("cannot create temp dir: {e}")));
+    let sums_path = work.join("SHA256SUMS");
+    let sums_url = format!("{dir}/SHA256SUMS");
+    if let Err(e) = bootstrap::download_file(&sums_url, &sums_path) {
+        util::die(&format!(
+            "cannot fetch the release checksum manifest: {e}\n  url: {sums_url}\n  \
+             set SHIFU_DIST_MIRROR to a reachable mirror to route around it"
+        ));
+    }
+    let sums = fs::read_to_string(&sums_path)
+        .unwrap_or_else(|e| util::die(&format!("cannot read {}: {e}", sums_path.display())));
+    let expected = sums
+        .lines()
+        .filter_map(|line| {
+            let mut fields = line.split_whitespace();
+            Some((fields.next()?, fields.next()?))
+        })
+        .find_map(|(digest, name)| {
+            (name.trim_start_matches('*') == asset).then(|| digest.to_lowercase())
+        })
+        .unwrap_or_else(|| {
+            util::die(&format!(
+                "release shifu-v{version} has no checksum entry for {asset} in SHA256SUMS"
+            ))
+        });
+    let _ = fs::remove_dir_all(&work);
+
+    let spec = FetchSpec {
+        tool: "shifu".to_string(),
+        version: version.to_string(),
+        url: format!("{dir}/{asset}"),
+        sha256: Some(expected),
+        mirror_env: Some("SHIFU_DIST_MIRROR".to_string()),
+        binary: None,
+    };
+    eprintln!("shifu: fetching release {}", style::bold(version));
+    bootstrap::fetch(&spec).unwrap_or_else(|err| util::die(&err.to_string()))
+}
+
+/// Rename-dance replacement: never a moment without a runnable binary at the
+/// target path, and the old binary is restored if the swap fails.
+fn replace_binary(exe: &Path, new_binary: &Path) {
+    let dir = exe
+        .parent()
+        .unwrap_or_else(|| util::die("cannot resolve the install directory"));
+    let staged = dir.join(format!(".shifu-update-{}", std::process::id()));
+    if let Err(e) = fs::copy(new_binary, &staged) {
+        util::die(&format!(
+            "cannot stage the new binary next to {}: {e}\n  \
+             (is the install directory writable?)",
+            exe.display()
+        ));
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = fs::set_permissions(&staged, fs::Permissions::from_mode(0o755));
+    }
+    // Windows cannot delete a running exe but can rename it; Unix does not
+    // care either way. Move the old one aside, the new one in.
+    let backup = dir.join(".shifu-update-old");
+    let _ = fs::remove_file(&backup);
+    if let Err(e) = fs::rename(exe, &backup) {
+        let _ = fs::remove_file(&staged);
+        util::die(&format!("cannot move the old binary aside: {e}"));
+    }
+    if let Err(e) = fs::rename(&staged, exe) {
+        let _ = fs::rename(&backup, exe);
+        util::die(&format!("swap failed, old binary restored: {e}"));
+    }
+    if fs::remove_file(&backup).is_err() {
+        // Expected on Windows while the old image is still running.
+        eprintln!(
+            "   {}",
+            style::dim(&format!(
+                "old binary left at {} (removable after this process exits)",
+                backup.display()
+            ))
+        );
+    }
+}

--- a/docs/rust-adoption.md
+++ b/docs/rust-adoption.md
@@ -104,6 +104,20 @@ The paved road for mode 1, as implemented for the launcher:
   configurable per environment through the user-global `build-local.env`
   (`SHIFU_DIST_MIRROR`, and `KUNGFU_FNM_DIST_MIRROR` /
   `KUNGFU_UV_DIST_MIRROR` for the launcher's own tool bootstrap).
+- **Source freshness (dev machines)** — the release pin only moves when a
+  release is cut, so on machines with cargo + git the shims content-address
+  the cache slot by the last commit touching the launcher source
+  (`<version>-<src-sha>`, built out-of-tree so read-only checkouts work) and
+  rebuild whenever it moves; a dirty launcher tree rebuilds on every call. A
+  checkout therefore always runs its own launcher code, never the last
+  release. Machines without cargo keep the release-pinned path untouched.
+- **Self-update** — `shifu self-update` refreshes an installed binary in
+  place (answered before delegation, so it acts on the copy you invoked):
+  inside a checkout it rebuilds from source (or fetches the pinned release
+  when cargo is absent), outside one it requires an explicit
+  `--version <v>`; release downloads are verified against the release's
+  `SHA256SUMS` and the swap is a rename dance that restores the old binary
+  on failure. Shim-cache slots refuse it — the shim owns their lifecycle.
 - **Fallback** — when no release asset is reachable, the shims build from
   source if cargo is present, then fall back to the legacy in-script path, so
   no machine class is stranded.

--- a/shifu
+++ b/shifu
@@ -21,10 +21,15 @@
 # This script is a thin shim in front of the native launcher (crates/shifu, a
 # self-contained Rust binary — see docs/rust-adoption.md). Resolution order:
 #   1. SHIFU_BIN            explicit binary override
-#   2. user-global cached binary  ${XDG_CACHE_HOME:-~/.cache}/kungfu/shifu/<version>/
-#   3. fnm + uv already installed -> proven in-script bootstrap below (no new network deps);
+#   2. dev machines (cargo + git) -> source-fresh cache slot
+#                                    .../kungfu/shifu/<version>-<launcher-src-sha>/,
+#                                    rebuilt whenever the launcher source moves (dirty
+#                                    trees rebuild every call), so a checkout always
+#                                    runs its own code, not the last release
+#   3. user-global cached binary  ${XDG_CACHE_HOME:-~/.cache}/kungfu/shifu/<version>/
+#   4. fnm + uv already installed -> proven in-script bootstrap below (no new network deps);
 #                                    force the native path instead with SHIFU_NATIVE=1
-#   4. fresh machine              -> download the prebuilt binary pinned by crates/shifu/Cargo.toml
+#   5. fresh machine              -> download the prebuilt binary pinned by crates/shifu/Cargo.toml
 #                                    (SHIFU_DIST_MIRROR overrides the base URL), or
 #                                    `cargo build` when a Rust toolchain is present
 #
@@ -83,6 +88,41 @@ kungfu_native_binname() {
   esac
 }
 
+# Paths (relative to the repo root) whose history keys the source-fresh cache
+# slot: the launcher binary is built from exactly these.
+KUNGFU_LAUNCHER_SRC="crates/shifu crates/shifu-core crates/Cargo.toml crates/Cargo.lock"
+
+# Last commit touching the launcher source (plus a -dirty marker for local
+# edits), or empty when cargo/git cannot answer — the caller then falls back
+# to the release-pinned slot.
+kungfu_src_fingerprint() {
+  command -v cargo >/dev/null 2>&1 || return 0
+  command -v git >/dev/null 2>&1 || return 0
+  # shellcheck disable=SC2086
+  _sha="$(git log -1 --format=%h -- $KUNGFU_LAUNCHER_SRC 2>/dev/null || true)"
+  [ -n "$_sha" ] || return 0
+  # shellcheck disable=SC2086
+  if [ -n "$(git status --porcelain -- $KUNGFU_LAUNCHER_SRC 2>/dev/null)" ]; then
+    _sha="${_sha}-dirty"
+  fi
+  echo "$_sha"
+}
+
+# Build the launcher from the checkout source into $1. The cargo target dir
+# lives in the user cache, keyed per checkout, so read-only-locked checkouts
+# (and worktrees sharing a cache) build without touching the repo tree.
+kungfu_native_build() {
+  _dest="$1"
+  _tgt="${XDG_CACHE_HOME:-$HOME/.cache}/kungfu/shifu/cargo-target/$(printf %s "$PWD" | cksum | cut -d' ' -f1)"
+  mkdir -p "$(dirname "$_dest")" "$_tgt"
+  if CARGO_TARGET_DIR="$_tgt" cargo build --release --locked --manifest-path crates/Cargo.toml -p shifu >&2; then
+    _built="$_tgt/release/$(kungfu_native_binname "$(kungfu_native_platform)")"
+    cp "$_built" "${_dest}.tmp" && chmod +x "${_dest}.tmp" && mv "${_dest}.tmp" "$_dest" && return 0
+    rm -f "${_dest}.tmp"
+  fi
+  return 1
+}
+
 # Try to place the native launcher at $1 (version $2). Best-effort: returns
 # non-zero on failure so the caller can fall back to the in-script bootstrap.
 kungfu_native_acquire() {
@@ -123,7 +163,34 @@ if [ "${SHIFU_NATIVE:-}" != "0" ]; then
     exec "${SHIFU_BIN}" "$@"
   fi
   kungfu_ver="$(kungfu_native_version)"
-  kungfu_bin="${XDG_CACHE_HOME:-$HOME/.cache}/kungfu/shifu/${kungfu_ver}/$(kungfu_native_binname "$(kungfu_native_platform)")"
+  kungfu_cache_root="${XDG_CACHE_HOME:-$HOME/.cache}/kungfu/shifu"
+  kungfu_binname="$(kungfu_native_binname "$(kungfu_native_platform)")"
+
+  # Source freshness (dev machines): with cargo + git present the cache slot
+  # is content-addressed by the last commit touching the launcher source, so
+  # the checkout's current code — not the last release, whose pin does not
+  # move between releases — answers. A dirty launcher tree rebuilds on every
+  # call (cargo's own freshness check keeps repeats fast). Machines without
+  # cargo keep the release-pinned path below unchanged.
+  kungfu_src="$(kungfu_src_fingerprint)"
+  if [ -n "$kungfu_src" ] && [ -n "$kungfu_ver" ]; then
+    kungfu_dev_dir="${kungfu_cache_root}/${kungfu_ver}-${kungfu_src}"
+    kungfu_dev_bin="${kungfu_dev_dir}/${kungfu_binname}"
+    case "$kungfu_src" in
+      *-dirty) ;; # local edits: always rebuild
+      *) if [ -x "$kungfu_dev_bin" ]; then exec "$kungfu_dev_bin" "$@"; fi ;;
+    esac
+    if kungfu_native_build "$kungfu_dev_bin"; then
+      # Retire older source-keyed slots; the release-pinned slot stays.
+      for _slot in "${kungfu_cache_root}/${kungfu_ver}-"*; do
+        [ -d "$_slot" ] && [ "$_slot" != "$kungfu_dev_dir" ] && rm -rf "$_slot"
+      done
+      exec "$kungfu_dev_bin" "$@"
+    fi
+    echo "shifu: source build failed; falling back to the release-pinned launcher" >&2
+  fi
+
+  kungfu_bin="${kungfu_cache_root}/${kungfu_ver}/${kungfu_binname}"
   if [ -x "$kungfu_bin" ]; then
     exec "$kungfu_bin" "$@"
   fi

--- a/shifu.cmd
+++ b/shifu.cmd
@@ -20,10 +20,14 @@ rem
 rem This script is a thin shim in front of the native launcher (crates\shifu,
 rem a self-contained Rust binary -- see docs/rust-adoption.md). Resolution order:
 rem   1. SHIFU_BIN            explicit binary override
-rem   2. user-global cached binary  %USERPROFILE%\.cache\kungfu\shifu\<version>\
-rem   3. fnm + uv already installed -> proven in-script bootstrap below
+rem   2. dev machines (cargo + git) -> source-fresh cache slot
+rem                                    ...\kungfu\shifu\<version>-<launcher-src-sha>\,
+rem                                    rebuilt whenever the launcher source moves, so a
+rem                                    checkout always runs its own code, not the last release
+rem   3. user-global cached binary  %USERPROFILE%\.cache\kungfu\shifu\<version>\
+rem   4. fnm + uv already installed -> proven in-script bootstrap below
 rem                                    (force native instead with SHIFU_NATIVE=1)
-rem   4. fresh machine              -> download the prebuilt binary pinned by
+rem   5. fresh machine              -> download the prebuilt binary pinned by
 rem                                    crates\shifu\Cargo.toml (SHIFU_DIST_MIRROR
 rem                                    overrides the base URL), or cargo build from source
 rem The native launcher bootstraps fnm + uv itself when missing (prebuilt binaries),
@@ -64,6 +68,50 @@ set "_KFC_CACHE=%USERPROFILE%\.cache"
 if defined XDG_CACHE_HOME set "_KFC_CACHE=%XDG_CACHE_HOME%"
 set "_KFC_BIN=%_KFC_CACHE%\kungfu\shifu\%_KFC_VER%\shifu.exe"
 
+rem Source freshness (dev machines): with cargo + git the cache slot is
+rem content-addressed by the last commit touching the launcher source, so the
+rem checkout's current code - not the last release, whose pin does not move
+rem between releases - answers. Dirty launcher trees rebuild on every call
+rem (cargo's own freshness check keeps repeats fast). Machines without cargo
+rem keep the release-pinned path below unchanged.
+where cargo >nul 2>nul || goto pinslot
+where git >nul 2>nul || goto pinslot
+if not defined _KFC_VER goto pinslot
+set "_KFC_SRC="
+for /f "usebackq" %%s in (`git log -1 --format=%%h -- crates/shifu crates/shifu-core crates/Cargo.toml crates/Cargo.lock 2^>nul`) do set "_KFC_SRC=%%s"
+if not defined _KFC_SRC goto pinslot
+set "_KFC_DIRTY="
+for /f "usebackq delims=" %%s in (`git status --porcelain -- crates/shifu crates/shifu-core crates/Cargo.toml crates/Cargo.lock 2^>nul`) do set "_KFC_DIRTY=1"
+if defined _KFC_DIRTY set "_KFC_SRC=%_KFC_SRC%-dirty"
+set "_KFC_DEVDIR=%_KFC_CACHE%\kungfu\shifu\%_KFC_VER%-%_KFC_SRC%"
+set "_KFC_DEVBIN=%_KFC_DEVDIR%\shifu.exe"
+if not defined _KFC_DIRTY if exist "%_KFC_DEVBIN%" (
+  "%_KFC_DEVBIN%" %*
+  exit /b !errorlevel!
+)
+rem Build with an out-of-repo target dir (keyed per checkout) so read-only
+rem checkouts build too.
+set "_KFC_TGTKEY=%CD:\=_%"
+set "_KFC_TGTKEY=%_KFC_TGTKEY::=%"
+set "_KFC_TGT=%_KFC_CACHE%\kungfu\shifu\cargo-target\%_KFC_TGTKEY%"
+echo shifu: building launcher from source ^(cargo build --release^) 1>&2
+set "CARGO_TARGET_DIR=%_KFC_TGT%"
+cargo build --release --locked --manifest-path crates\Cargo.toml -p shifu 1>&2 && (
+  set "CARGO_TARGET_DIR="
+  if not exist "%_KFC_DEVDIR%" mkdir "%_KFC_DEVDIR%" >nul 2>nul
+  copy /y "%_KFC_TGT%\release\shifu.exe" "%_KFC_DEVBIN%" >nul && (
+    rem Retire older source-keyed slots; the release-pinned slot stays.
+    for /d %%d in ("%_KFC_CACHE%\kungfu\shifu\%_KFC_VER%-*") do (
+      if /i not "%%~fd"=="%_KFC_DEVDIR%" rd /s /q "%%~fd" >nul 2>nul
+    )
+    "%_KFC_DEVBIN%" %*
+    exit /b !errorlevel!
+  )
+)
+set "CARGO_TARGET_DIR="
+echo shifu: source build failed; falling back to the release-pinned launcher 1>&2
+
+:pinslot
 if exist "%_KFC_BIN%" (
   "%_KFC_BIN%" %*
   exit /b !errorlevel!


### PR DESCRIPTION
The shim cache was keyed by the release pin, which only moves at release time — dev machines structurally ran a stale launcher (new doctor probes could never reach the user). Content-address the cache slot by the last commit touching launcher source when cargo+git are present (dirty trees rebuild every call, out-of-repo target dir so locked checkouts build); machines without cargo keep the existing path byte for byte. Add shifu self-update to refresh an installed binary in place: in-checkout source rebuild (or pinned release without cargo), explicit --version outside; downloads verified against SHA256SUMS through shifu-core's fetch engine (which learns raw non-archive assets); rename-dance swap restores the old binary on failure; shim-cache slots refuse the verb. Verified end to end incl. file:// mirror fixture.