### PR TITLE
ci: consume buildchain through the v2-alpha floating channel

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ permissions:
 
 jobs:
   build:
-    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@v2
+    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@v2-alpha
     secrets: inherit
     with:
       buildchain-ref: ${{ inputs.buildchain-ref || '' }}

--- a/.github/workflows/buildchain-validate.yml
+++ b/.github/workflows/buildchain-validate.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Validate .buildchain/buildchain.toml
-        uses: kungfu-systems/buildchain/actions/validate-config@v2
+        uses: kungfu-systems/buildchain/actions/validate-config@v2-alpha
         with:
           require-version-state: "true"
           require-lifecycle-stages: "install,build,verify"

--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   promote:
     if: ${{ github.event.pull_request.merged == true }}
-    uses: kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@v2
+    uses: kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@v2-alpha
     with:
       channel: ${{ startsWith(github.event.pull_request.base.ref, 'alpha/') && 'alpha' || 'release' }}
       target-ref: ${{ github.event.pull_request.base.ref }}


### PR DESCRIPTION
Switch the three buildchain references from @v2 to @v2-alpha to pick up the lifecycle override inheritance and bounded checkout fallback fixes (buildchain#1040, #1043) ahead of the stable channel — unblocking the native shifu lifecycle validation on the self-hosted matrix.