### PR TITLE
Assembled runtime host: neutral seam, assemble packaging leg, trunk entry (ADR-0046 stage 2)

### DIFF
--- a/crates/trunk/src/launch.rs
+++ b/crates/trunk/src/launch.rs
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The launch leg (ADR-0046 stage 2): installed as `kungfu` next to the
+// assembled runtime tree, this binary is the product front door. It stays
+// argv-transparent — beyond recognizing the subtrees the trunk itself
+// implements (env, prewarm), it interprets nothing and execs the assembled
+// interpreter on `-m kungfu`, so the domain CLI remains the single source of
+// truth for its own surface. The assembled interpreter is a real
+// sys.executable; no PYTHON* staging is needed (the tree carries its own
+// kungfu-host.json marker and site-packages wiring).
+
+use std::env;
+use std::path::PathBuf;
+use std::process::Command;
+
+/// Whether this process was invoked under the product entry name rather than
+/// as kungfu-trunk. The same binary ships under both names; the file stem of
+/// argv0 (falling back to the executable path) decides the mode.
+pub fn invoked_as_kungfu() -> bool {
+    let argv0 = env::args().next().map(PathBuf::from);
+    let name = argv0
+        .as_deref()
+        .and_then(|p| p.file_stem())
+        .map(|s| s.to_string_lossy().into_owned())
+        .or_else(|| {
+            env::current_exe()
+                .ok()
+                .and_then(|p| p.file_stem().map(|s| s.to_string_lossy().into_owned()))
+        });
+    name.as_deref() == Some("kungfu")
+}
+
+fn tree_python() -> Result<PathBuf, String> {
+    let exe = env::current_exe()
+        .and_then(|p| p.canonicalize())
+        .map_err(|e| format!("cannot resolve the entry binary path: {e}"))?;
+    let root = exe
+        .parent()
+        .ok_or_else(|| "the entry binary has no parent directory".to_string())?;
+    let python = if cfg!(windows) {
+        root.join("python").join("python.exe")
+    } else {
+        root.join("python").join("bin").join("python3")
+    };
+    if !python.is_file() {
+        return Err(format!(
+            "assembled runtime tree not found at {} — the `kungfu` entry only \
+             runs next to the tree the product ships (dev: use `python -m \
+             kungfu` on the managed interpreter, or kungfu-trunk for env \
+             commands)",
+            python.display()
+        ));
+    }
+    Ok(python)
+}
+
+/// Exec the assembled interpreter on `-m kungfu` with the caller's arguments,
+/// verbatim. Unix replaces the process; Windows waits and mirrors the exit
+/// code (no exec semantics there).
+pub fn launch(args: &[String]) -> Result<(), String> {
+    let python = tree_python()?;
+    let mut command = Command::new(&python);
+    command.arg("-m").arg("kungfu").args(args);
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        let err = command.exec();
+        Err(format!("cannot exec {}: {err}", python.display()))
+    }
+    #[cfg(not(unix))]
+    {
+        let status = command
+            .status()
+            .map_err(|e| format!("cannot run {}: {e}", python.display()))?;
+        std::process::exit(status.code().unwrap_or(1));
+    }
+}

--- a/crates/trunk/src/main.rs
+++ b/crates/trunk/src/main.rs
@@ -9,6 +9,7 @@
 // mirror override to set) — the wrong-runtime spirit applied to downloads.
 
 mod envs;
+mod launch;
 mod pins;
 
 use std::env;
@@ -37,6 +38,22 @@ const DEFAULT_ENV: &str = "default";
 
 fn main() {
     let args: Vec<String> = env::args().skip(1).collect();
+    // Installed as `kungfu`, this binary is the assembled product's front
+    // door: the trunk keeps only the subtrees it implements (env, prewarm)
+    // and execs the assembled interpreter for everything else, verbatim —
+    // argv-transparent per the layering law (ADR-0046 stage 2).
+    if launch::invoked_as_kungfu() {
+        let result = match args.first().map(String::as_str) {
+            Some("env") => dispatch_env(&args[1..]),
+            Some("prewarm") => envs::prewarm(),
+            _ => launch::launch(&args),
+        };
+        if let Err(msg) = result {
+            eprintln!("kungfu: {msg}");
+            exit(1);
+        }
+        return;
+    }
     let result = match args.first().map(String::as_str) {
         Some("env") => dispatch_env(&args[1..]),
         Some("prewarm") => envs::prewarm(),

--- a/framework/core/.gyp/run-freeze.js
+++ b/framework/core/.gyp/run-freeze.js
@@ -388,23 +388,43 @@ function applyStdlibPrune(treeRoot) {
     return;
   }
   const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
-  const entries = Array.isArray(manifest.prune) ? manifest.prune : [];
+  const sections = manifest.prune || {};
+  const entries = [
+    ...(sections.common || []),
+    ...(sections[process.platform] || []),
+  ];
   const root = path.resolve(treeRoot);
   let n = 0;
   for (const rel of entries) {
-    const target = path.resolve(treeRoot, rel);
-    if (!target.startsWith(root + path.sep)) {
-      console.error(`[freeze] assemble: prune entry escapes the tree: ${rel}`);
+    // '*' globs cover version-suffixed names (pip-<ver>.dist-info); a literal
+    // or glob that matches nothing means the manifest no longer describes the
+    // tree it prunes, which stops the build.
+    const matches = rel.includes('*')
+      ? fs.globSync(rel, { cwd: treeRoot })
+      : [rel];
+    if (!matches.length) {
+      console.error(`[freeze] assemble: prune glob matches nothing: ${rel}`);
       process.exit(1);
     }
-    if (!existsLstat(target)) {
-      console.error(`[freeze] assemble: prune entry not in the tree: ${rel}`);
-      process.exit(1);
+    for (const m of matches) {
+      const target = path.resolve(treeRoot, m);
+      if (!target.startsWith(root + path.sep)) {
+        console.error(
+          `[freeze] assemble: prune entry escapes the tree: ${rel}`,
+        );
+        process.exit(1);
+      }
+      if (!existsLstat(target)) {
+        console.error(`[freeze] assemble: prune entry not in the tree: ${rel}`);
+        process.exit(1);
+      }
+      fs.rmSync(target, { recursive: true, force: true });
+      n++;
     }
-    fs.rmSync(target, { recursive: true, force: true });
-    n++;
   }
-  console.log(`[freeze] assemble: pruned ${n}/${entries.length} entries`);
+  console.log(
+    `[freeze] assemble: pruned ${n} paths (${entries.length} entries)`,
+  );
 }
 
 // Natives the frozen leg bundled by following imports (pykungfu and the
@@ -481,12 +501,20 @@ function assembleTree(bt) {
     { cwd: CORE },
   );
 
-  // The kungfu package ships as sources at the dist root (data files — .bfbs
-  // schemas, the agent pack — travel inside the package, where the source
-  // layout already has them). The .pth wires the dist root into the tree.
+  // The kungfu package ships as sources in the tree's site-packages — the
+  // standard home, and the dist root stays free for the product entry named
+  // `kungfu`. Data files (.bfbs schemas, the agent pack) travel inside the
+  // package, where the source layout already has them. The .pth wires the
+  // flat dist root (pykungfu + natives) into the tree.
+  const sitePackages = path.join(
+    treeDest,
+    'lib',
+    `python${feature}`,
+    'site-packages',
+  );
   fs.cpSync(
     path.join(CORE, 'src', 'python', 'kungfu'),
-    path.join(distKfc, 'kungfu'),
+    path.join(sitePackages, 'kungfu'),
     {
       recursive: true,
       filter: (src) => !src.split(path.sep).includes('__pycache__'),
@@ -494,12 +522,6 @@ function assembleTree(bt) {
   );
   fs.copyFileSync(info, path.join(distKfc, 'kungfubuildinfo.json'));
 
-  const sitePackages = path.join(
-    treeDest,
-    'lib',
-    `python${feature}`,
-    'site-packages',
-  );
   // Relative to site-packages: four levels up is the dist root.
   fs.writeFileSync(path.join(sitePackages, 'kungfu-dist.pth'), '../../../..\n');
   fs.writeFileSync(
@@ -514,10 +536,40 @@ function assembleTree(bt) {
   copyRuntimeNative(bt, distKfc);
   copyAppNative(bt);
   copyConfigContract();
+  stageEntry(distKfc);
   console.log(
-    '[freeze] ✅ dist/kungfu assembled (interpreter tree + flat natives; ' +
-      'entry binary lands with the entry-form step)',
+    '[freeze] ✅ dist/kungfu assembled (interpreter tree + flat natives + ' +
+      'trunk entry)',
   );
+}
+
+// The product entry is the trunk binary installed under the name `kungfu`:
+// invoked as `kungfu` it keeps the subtrees it implements (env, prewarm) and
+// execs the assembled interpreter on -m kungfu for everything else, verbatim
+// (crates/trunk/src/launch.rs). Staged here so a bare `pnpm run freeze`
+// yields a runnable assembled dist; dist.mjs stageTrunk later re-stages
+// kungfu-trunk and asserts pins consistency at the product stage — same
+// commit, same profile, same binary.
+/** @param {string} distKfc */
+function stageEntry(distKfc) {
+  const crates = path.join(CORE, '..', '..', 'crates');
+  shell.run('cargo', ['build', '--release', '-p', 'kungfu-trunk'], true, {
+    cwd: crates,
+  });
+  const built = path.join(
+    crates,
+    'target',
+    'release',
+    isWin ? 'kungfu-trunk.exe' : 'kungfu-trunk',
+  );
+  for (const name of ['kungfu-trunk', 'kungfu']) {
+    fs.copyFileSync(built, path.join(distKfc, isWin ? `${name}.exe` : name));
+  }
+  fs.copyFileSync(
+    path.join(CORE, '..', '..', 'product', 'runtime-pins.env'),
+    path.join(distKfc, 'runtime-pins.env'),
+  );
+  console.log('[freeze] assemble: trunk entry staged as kungfu + kungfu-trunk');
 }
 
 // ------------------------------------------------------------- pyinstaller

--- a/framework/core/.gyp/run-freeze.js
+++ b/framework/core/.gyp/run-freeze.js
@@ -18,6 +18,7 @@
 // @ts-check
 
 const fs = require('node:fs');
+const os = require('node:os');
 const path = require('node:path');
 const { shell } = require('../lib');
 const { verifyWindowsSymbols } = require('./verify-windows-symbols');
@@ -297,6 +298,228 @@ function freezeNuitka(bt) {
   console.log('[freeze] ✅ dist/kungfu 就绪（nuitka 扁平产物 + app native）');
 }
 
+// --------------------------------------------------------------- assemble
+//
+// ADR-0046 stage 2: the host runs a complete, exact CPython tree instead of a
+// frozen subset. The assembled dist keeps the flat dist/kungfu root (natives,
+// contract, wheels — identical to the frozen layout) and adds the interpreter
+// tree under dist/kungfu/python. The kungfu package ships as sources at the
+// dist root, wired into the tree through a site-packages .pth (never through
+// PYTHON* environment variables, which would leak into satellite envs). The
+// tree carries a kungfu-host.json marker so kungfu.host detects the assembled
+// form; the product entry binary is wired by the entry-form step.
+
+// uv names python-build-standalone keys with its own os/arch vocabulary; keep
+// the mapping identical to kungfu-trunk's python_request (crates/trunk).
+/** @param {string} pin */
+function pbsKey(pin) {
+  const osName = { darwin: 'macos', win32: 'windows', linux: 'linux' }[
+    process.platform
+  ];
+  const arch = { arm64: 'aarch64', x64: 'x86_64' }[process.arch];
+  if (!osName || !arch) {
+    console.error(
+      `[freeze] assemble: unsupported platform ${process.platform}/${process.arch}`,
+    );
+    process.exit(1);
+  }
+  return `cpython-${pin}-${osName}-${arch}-none`;
+}
+
+// PYTHON_PIN comes from the product pins manifest — the same single source the
+// trunk reads at runtime, so the assembled tree and satellite envs can never
+// drift apart. dist.mjs already asserts the manifest against .uv-version.
+function readRuntimePins() {
+  const pinsPath = path.join(CORE, '..', '..', 'product', 'runtime-pins.env');
+  /** @type {Record<string, string>} */
+  const pins = {};
+  for (const line of fs.readFileSync(pinsPath, 'utf-8').split('\n')) {
+    const m = line.match(/^([A-Z0-9_]+)=(.*)$/);
+    if (m) pins[m[1]] = m[2];
+  }
+  if (!pins.PYTHON_PIN) {
+    console.error(`[freeze] assemble: PYTHON_PIN missing in ${pinsPath}`);
+    process.exit(1);
+  }
+  return pins;
+}
+
+// Materialize the pinned python-build-standalone prefix in the kungfu cache
+// (same layout the trunk uses: UV_PYTHON_INSTALL_DIR under ~/.cache/kungfu),
+// arch-qualified so a foreign-arch install can never satisfy the request.
+/** @param {string} pin */
+function ensureRuntimeTree(pin) {
+  const cache = process.env.XDG_CACHE_HOME || path.join(os.homedir(), '.cache');
+  const installDir = path.join(cache, 'kungfu', 'python');
+  const key = pbsKey(pin);
+  shell.run('uv', ['python', 'install', key], true, {
+    cwd: CORE,
+    env: {
+      ...process.env,
+      UV_PYTHON_INSTALL_DIR: installDir,
+      UV_PYTHON_PREFERENCE: 'only-managed',
+    },
+  });
+  const prefix = path.join(installDir, key);
+  if (!fs.existsSync(prefix)) {
+    console.error(`[freeze] assemble: expected runtime tree at ${prefix}`);
+    process.exit(1);
+  }
+  return prefix;
+}
+
+// The stdlib prune policy is a declarative manifest, not code: a fixed list of
+// prefix-relative paths subtracted from a complete stdlib. New dependencies
+// live in site-packages and never interact with this list, and a stale entry
+// fails safe (ships a few extra MB) — deliberately unlike the nofollow-import
+// surface this stage retires. A pruned entry that is unexpectedly absent stops
+// the build: the manifest must describe the tree it prunes.
+/** @param {string} treeRoot */
+function applyStdlibPrune(treeRoot) {
+  const manifestPath = path.join(
+    CORE,
+    '..',
+    '..',
+    'product',
+    'stdlib-prune.json',
+  );
+  if (!fs.existsSync(manifestPath)) {
+    console.log('[freeze] assemble: no stdlib-prune manifest, full tree ships');
+    return;
+  }
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
+  const entries = Array.isArray(manifest.prune) ? manifest.prune : [];
+  const root = path.resolve(treeRoot);
+  let n = 0;
+  for (const rel of entries) {
+    const target = path.resolve(treeRoot, rel);
+    if (!target.startsWith(root + path.sep)) {
+      console.error(`[freeze] assemble: prune entry escapes the tree: ${rel}`);
+      process.exit(1);
+    }
+    if (!existsLstat(target)) {
+      console.error(`[freeze] assemble: prune entry not in the tree: ${rel}`);
+      process.exit(1);
+    }
+    fs.rmSync(target, { recursive: true, force: true });
+    n++;
+  }
+  console.log(`[freeze] assemble: pruned ${n}/${entries.length} entries`);
+}
+
+// Natives the frozen leg bundled by following imports (pykungfu and the
+// libraries its rpath colocation expects) must be staged explicitly here;
+// the four app-side .node files keep going through copyAppNative.
+/** @param {string} bt @param {string} distKfc */
+function copyRuntimeNative(bt, distKfc) {
+  const rel = path.join(CORE, 'build', bt);
+  const wanted =
+    /^(pykungfu.*\.(so|pyd)|libkungfu.*|libnode.*|libnodebuildinfo\.json)$/i;
+  let n = 0;
+  for (const f of fs.readdirSync(rel)) {
+    if (!wanted.test(f)) continue;
+    fs.copyFileSync(path.join(rel, f), path.join(distKfc, f));
+    n++;
+  }
+  if (!n) {
+    console.error(`[freeze] assemble: no runtime natives under build/${bt}`);
+    process.exit(1);
+  }
+  console.log(`[freeze] assemble: staged ${n} runtime natives`);
+}
+
+/** @param {string} bt */
+function assembleTree(bt) {
+  if (isWin) {
+    console.error(
+      '[freeze] assemble: windows keeps the frozen path until its layout ' +
+        'lands (ADR-0046 stage 2 goes platform by platform)',
+    );
+    process.exit(1);
+  }
+  const pins = readRuntimePins();
+  const pin = pins.PYTHON_PIN;
+  const feature = pin.split('.').slice(0, 2).join('.');
+  const distKfc = path.join(CORE, 'dist', 'kungfu');
+  const info = ensureBuildInfo(bt);
+  const prefix = ensureRuntimeTree(pin);
+
+  console.log(`[freeze] assemble: ${pbsKey(pin)} → dist/kungfu/python`);
+  fs.rmSync(distKfc, { recursive: true, force: true });
+  fs.mkdirSync(distKfc, { recursive: true });
+
+  const treeDest = path.join(distKfc, 'python');
+  fs.cpSync(prefix, treeDest, { recursive: true, verbatimSymlinks: true });
+  applyStdlibPrune(treeDest);
+
+  // Runtime dependencies resolve from the committed lock into the tree's own
+  // site-packages — the host tree is the blessed interpreter, so its deps are
+  // part of the product image, not a satellite env concern.
+  const req = path.join(CORE, 'build', 'assemble-requirements.txt');
+  shell.run(
+    'uv',
+    ['export', '--frozen', '--no-dev', '--no-emit-project', '-o', req],
+    true,
+    { cwd: CORE },
+  );
+  // The tree keeps python-build-standalone's EXTERNALLY-MANAGED marker: in the
+  // product it guards the kungfu-owned install surface (a stray pip into the
+  // host tree gets refused, ADR-0046 violation 5). The build stages the deps
+  // through the one explicit bypass.
+  shell.run(
+    'uv',
+    [
+      'pip',
+      'install',
+      '--python',
+      path.join(treeDest, 'bin', 'python3'),
+      '--break-system-packages',
+      '-r',
+      req,
+    ],
+    true,
+    { cwd: CORE },
+  );
+
+  // The kungfu package ships as sources at the dist root (data files — .bfbs
+  // schemas, the agent pack — travel inside the package, where the source
+  // layout already has them). The .pth wires the dist root into the tree.
+  fs.cpSync(
+    path.join(CORE, 'src', 'python', 'kungfu'),
+    path.join(distKfc, 'kungfu'),
+    {
+      recursive: true,
+      filter: (src) => !src.split(path.sep).includes('__pycache__'),
+    },
+  );
+  fs.copyFileSync(info, path.join(distKfc, 'kungfubuildinfo.json'));
+
+  const sitePackages = path.join(
+    treeDest,
+    'lib',
+    `python${feature}`,
+    'site-packages',
+  );
+  // Relative to site-packages: four levels up is the dist root.
+  fs.writeFileSync(path.join(sitePackages, 'kungfu-dist.pth'), '../../../..\n');
+  fs.writeFileSync(
+    path.join(treeDest, 'kungfu-host.json'),
+    `${JSON.stringify(
+      { schema: 'kungfu.host/v1', form: 'assembled', product_root: '..' },
+      null,
+      2,
+    )}\n`,
+  );
+
+  copyRuntimeNative(bt, distKfc);
+  copyAppNative(bt);
+  copyConfigContract();
+  console.log(
+    '[freeze] ✅ dist/kungfu assembled (interpreter tree + flat natives; ' +
+      'entry binary lands with the entry-form step)',
+  );
+}
+
 // ------------------------------------------------------------- pyinstaller
 
 /** @param {string} bt */
@@ -404,8 +627,12 @@ function main() {
     freezeNuitka(bt);
   } else if (fz === 'pyinstaller') {
     freezePyinstaller(bt);
+  } else if (fz === 'assemble') {
+    assembleTree(bt);
   } else {
-    console.error(`[freeze] 未知 freezer: ${fz}（应为 nuitka 或 pyinstaller）`);
+    console.error(
+      `[freeze] 未知 freezer: ${fz}（应为 nuitka、pyinstaller 或 assemble）`,
+    );
     process.exit(1);
   }
   copyWheel();

--- a/framework/core/src/python/kungfu/__init__.py
+++ b/framework/core/src/python/kungfu/__init__.py
@@ -47,16 +47,19 @@ def _runtime_violation(
     frozen: bool,
     base_prefix: str,
     running_version: str,
+    assembled: bool = False,
 ) -> str | None:
     """Judge interpreter blessedness; None means blessed.
 
     Pure so both verdicts unit-test without staging real interpreters. The
-    frozen host is blessed by construction. A satellite is blessed when its
-    feature version matches the one the binding was built for and it runs
-    from a kungfu-managed python-build-standalone install (whose prefix
-    directory is named cpython-<version>-<platform>).
+    frozen host is blessed by construction, and so is the assembled host —
+    the shipped python-build-standalone tree IS the product runtime
+    (ADR-0046 stage 2). A satellite is blessed when its feature version
+    matches the one the binding was built for and it runs from a
+    kungfu-managed python-build-standalone install (whose prefix directory
+    is named cpython-<version>-<platform>).
     """
-    if frozen:
+    if frozen or assembled:
         return None
     expected_feature = ".".join(python_version.split(".")[:2])
     running_feature = ".".join(running_version.split(".")[:2])
@@ -90,12 +93,15 @@ def _verify_blessed_runtime(binding: Any) -> None:
             python_version = json.load(build_info_file).get("pythonVersion", "")
     except OSError:
         return  # no buildinfo (bare dev build) — nothing to judge against
+    from kungfu import host
+
     running = ".".join(str(v) for v in sys.version_info[:3])
     violation = _runtime_violation(
         python_version,
         frozen="__compiled__" in globals() or bool(getattr(sys, "frozen", False)),
         base_prefix=sys.base_prefix,
         running_version=running,
+        assembled=host.host_form() == host.FORM_ASSEMBLED,
     )
     if violation:
         raise WrongRuntimeError(

--- a/framework/core/src/python/kungfu/agent/resources.py
+++ b/framework/core/src/python/kungfu/agent/resources.py
@@ -5,21 +5,25 @@ import sys
 from importlib import resources
 from pathlib import Path
 
+from kungfu import host
+
 _PACKAGE = "kungfu.agent"
 
 
 def pack_root():
-    frozen = _frozen_pack_root()
-    if frozen is not None:
-        return frozen
+    shipped = _shipped_pack_root()
+    if shipped is not None:
+        return shipped
     return resources.files(_PACKAGE)
 
 
-def _frozen_pack_root():
+def _shipped_pack_root():
+    # A product build ships the pack at the dist root; argv0 stays as a
+    # fallback for entries relocated next to the pack (app Resources).
     candidates = []
-    executable = getattr(sys, "executable", "")
-    if executable:
-        candidates.append(Path(executable).resolve().parent / "agent")
+    root = host.product_root()
+    if root is not None:
+        candidates.append(root / "agent")
     argv0 = sys.argv[0] if sys.argv else ""
     if argv0:
         candidates.append(Path(argv0).resolve().parent / "agent")

--- a/framework/core/src/python/kungfu/cli/commands/env.py
+++ b/framework/core/src/python/kungfu/cli/commands/env.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import click
 
+from kungfu import host
 from kungfu.cli.commands import kfc
 
 
@@ -14,7 +15,7 @@ def _resolve_trunk() -> str | None:
     """Locate the kungfu-trunk binary that owns the env semantics.
 
     Resolution order: explicit override, then the product layout (trunk ships
-    next to the frozen binary in dist/kungfu), then the dev build under
+    at the dist root, next to the product entry), then the dev build under
     crates/target. Deliberately no PATH probing — the env surface must be the
     product's own trunk, not a foreign binary that happens to share the name.
     """
@@ -22,9 +23,11 @@ def _resolve_trunk() -> str | None:
     override = os.environ.get("KUNGFU_TRUNK_BIN")
     if override:
         return override if Path(override).is_file() else None
-    product = Path(sys.executable).parent / exe
-    if product.is_file():
-        return str(product)
+    root = host.product_root()
+    if root is not None:
+        product = root / exe
+        if product.is_file():
+            return str(product)
     for parent in Path(__file__).resolve().parents:
         if (parent / "crates").is_dir():
             for profile in ("release", "debug"):

--- a/framework/core/src/python/kungfu/cli/variants/python.py
+++ b/framework/core/src/python/kungfu/cli/variants/python.py
@@ -7,6 +7,7 @@ import re
 import sys
 import tokenize
 
+from kungfu import host
 from kungfu.cli import bridging
 
 
@@ -153,7 +154,8 @@ def main(argv, **options):
     if argv:
         sys.argv = [sys.executable, *argv[1:]]
         __file__ = str(os.path.abspath(argv[0]))
-        dist_root = str(os.path.dirname(sys.executable))
+        root = host.product_root()
+        dist_root = str(root) if root is not None else os.path.dirname(sys.executable)
         if __file__.startswith(dist_root):
             module_name = (
                 __file__.replace(dist_root, "")

--- a/framework/core/src/python/kungfu/contract.py
+++ b/framework/core/src/python/kungfu/contract.py
@@ -4,13 +4,13 @@ from __future__ import annotations
 
 import json
 import os
-import sys
 from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
 from jsonschema import Draft202012Validator
 
+from kungfu import host
 from kungfu.content_hash import compute_content_hash
 
 
@@ -29,11 +29,11 @@ def resolve_registry_path(
     if explicit:
         return os.path.abspath(os.path.expanduser(explicit))
 
-    executable_candidate = (
-        Path(sys.executable).resolve().parent / "config" / REGISTRY_FILE
-    )
-    if executable_candidate.is_file():
-        return str(executable_candidate)
+    root = host.product_root()
+    if root is not None:
+        product_candidate = root / "config" / REGISTRY_FILE
+        if product_candidate.is_file():
+            return str(product_candidate)
 
     for start in [Path(__file__).resolve(), Path.cwd().resolve()]:
         for directory in [start, *start.parents]:
@@ -93,9 +93,11 @@ def resolve_contract_path(
         return os.path.abspath(os.path.expanduser(explicit))
 
     artifact = Path(str(entry["artifact"]))
-    executable_candidate = Path(sys.executable).resolve().parent / artifact
-    if executable_candidate.is_file():
-        return str(executable_candidate)
+    root = host.product_root()
+    if root is not None:
+        product_candidate = root / artifact
+        if product_candidate.is_file():
+            return str(product_candidate)
 
     source = Path(str(entry["source"]))
     for start in [Path(__file__).resolve(), Path.cwd().resolve()]:

--- a/framework/core/src/python/kungfu/host.py
+++ b/framework/core/src/python/kungfu/host.py
@@ -1,0 +1,103 @@
+#  SPDX-License-Identifier: Apache-2.0
+"""The host-neutral seam (ADR-0046 stage 2).
+
+The product has three host forms, and code that needs "where is the product
+root" or "how does a child re-enter kungfu" must ask this module instead of
+deriving it from sys.executable, which points somewhere different in each:
+
+- frozen    — a Nuitka/PyInstaller binary; sys.executable is the product
+              entry itself, sitting at the dist root.
+- assembled — the shipped python-build-standalone tree; sys.executable is
+              a real interpreter deep inside <dist>/python/bin, and the
+              dist root is where the tree's marker says it is.
+- source    — a dev checkout on a managed interpreter; there is no product
+              root, and each site falls back to its source-checkout scan.
+
+The assembled form is declared by a marker the assembly step writes at the
+tree prefix (next to python-build-standalone's own BUILD file):
+
+    <prefix>/kungfu-host.json
+    {"schema": "kungfu.host/v1", "form": "assembled", "product_root": ".."}
+
+Inventory of host assumptions this seam collects (spike report Part 3.3):
+the self-re-entry family (master_service.entry_command, the nuitka/pdm
+bridges' [sys.executable, -m, kungfu] calls) is correct by construction
+wherever sys.executable is a real interpreter and re-routes through
+entry_command() where it is not; the product-root family (contract
+registry/artifact discovery, the baked first-party manifest, the trunk
+binary next to the entry, variants dist-module detection) resolves through
+product_root(); the argv0 family that only names a process for libnode
+(cockpit/sdk/kfd) keeps argv0 semantics untouched. Signal handlers
+(master_service SIGTERM/SIGINT, apprentice os_signal) and the vendored
+site.py atexit hook stay as they are: in stage 2 CPython still owns the
+process main thread; the forwarding seam is stage 3 work.
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+FORM_FROZEN = "frozen"
+FORM_ASSEMBLED = "assembled"
+FORM_SOURCE = "source"
+
+_MARKER_NAME = "kungfu-host.json"
+_MARKER_SCHEMA = "kungfu.host/v1"
+
+
+def is_frozen() -> bool:
+    # Nuitka injects __compiled__ into every compiled module's globals;
+    # PyInstaller sets sys.frozen. Same judgment the wrong-runtime guard uses.
+    return "__compiled__" in globals() or bool(getattr(sys, "frozen", False))
+
+
+def _assembled_marker() -> dict | None:
+    marker = Path(sys.base_prefix) / _MARKER_NAME
+    try:
+        data = json.loads(marker.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    if not isinstance(data, dict) or data.get("schema") != _MARKER_SCHEMA:
+        return None
+    return data
+
+
+def host_form() -> str:
+    if is_frozen():
+        return FORM_FROZEN
+    if _assembled_marker() is not None:
+        return FORM_ASSEMBLED
+    return FORM_SOURCE
+
+
+def product_root() -> Path | None:
+    """The dist root (the directory the product image unpacks to) in product
+    forms; None in a source checkout, where callers use their source scans."""
+    if is_frozen():
+        return Path(sys.executable).resolve().parent
+    marker = _assembled_marker()
+    if marker is not None:
+        rel = str(marker.get("product_root", ".."))
+        return (Path(sys.base_prefix) / rel).resolve()
+    return None
+
+
+def entry_command() -> list[str]:
+    """The command a child process uses to re-enter kungfu.
+
+    Prefer the invoked entry (the frozen binary, or the launch shim in the
+    assembled form) when it is a real executable; otherwise re-enter through
+    the running interpreter, which is a real python everywhere outside the
+    frozen form.
+    """
+    argv0 = Path(sys.argv[0]) if sys.argv and sys.argv[0] else None
+    if (
+        argv0 is not None
+        and argv0.is_file()
+        and os.access(argv0, os.X_OK)
+        and argv0.suffix != ".py"
+        and not argv0.name.startswith("python")
+    ):
+        return [str(argv0.resolve())]
+    return [sys.executable, "-m", "kungfu"]

--- a/framework/core/src/python/kungfu/master_service.py
+++ b/framework/core/src/python/kungfu/master_service.py
@@ -7,7 +7,6 @@ import os
 import platform
 import signal
 import subprocess
-import sys
 import time
 from dataclasses import dataclass
 from hashlib import sha256
@@ -16,6 +15,7 @@ from typing import Any
 from xml.sax.saxutils import escape as xml_escape
 
 import kungfu
+from kungfu import host
 
 lf = kungfu.__binding__.yijinjing
 yjj = kungfu.__binding__.runtime
@@ -202,10 +202,7 @@ def unlink_if_exists(path: Path) -> None:
 
 
 def entry_command() -> list[str]:
-    argv0 = Path(sys.argv[0])
-    if argv0.exists() and argv0.name not in {"python", "python3"}:
-        return [str(argv0.resolve())]
-    return [sys.executable, "-m", "kungfu"]
+    return host.entry_command()
 
 
 def command_env(

--- a/framework/core/src/python/kungfu/rewind/first_party.py
+++ b/framework/core/src/python/kungfu/rewind/first_party.py
@@ -17,9 +17,8 @@ from __future__ import annotations
 
 import json
 import os
-import sys
 
-from kungfu import kfx_contract
+from kungfu import host, kfx_contract
 
 ENV_FIRST_PARTY_MANIFEST = "KF_FIRST_PARTY_MANIFEST"
 BAKED_MANIFEST_NAME = "first-party.json"
@@ -39,13 +38,12 @@ def _read_keys(path: str | None) -> set[str] | None:
     return set(keys) if isinstance(keys, dict) else None
 
 
-def _baked_manifest_path() -> str:
-    # A frozen build ships the manifest next to the executable (in dist/kungfu,
-    # which the app also ships to Resources/kungfu); a source interpreter has no
-    # such neighbour, so this is None-ish there and the source scan takes over.
-    return os.path.join(
-        os.path.dirname(os.path.abspath(sys.executable)), BAKED_MANIFEST_NAME
-    )
+def _baked_manifest_path() -> str | None:
+    # A product build ships the manifest at the dist root (which the app also
+    # ships to Resources/kungfu); a source interpreter has no product root, so
+    # this is None there and the source scan takes over.
+    root = host.product_root()
+    return None if root is None else str(root / BAKED_MANIFEST_NAME)
 
 
 def _source_extensions_root() -> str | None:

--- a/framework/core/tests/python/test_first_party_baked.py
+++ b/framework/core/tests/python/test_first_party_baked.py
@@ -1,25 +1,35 @@
 #  SPDX-License-Identifier: Apache-2.0
 #
-# A frozen build has no source extensions/ tree; it reads the first-party set
-# from the manifest baked next to its executable (ADR-0013). Resolution order:
-# KF_FIRST_PARTY_MANIFEST, then the baked manifest, then a source scan.
+# A product build has no source extensions/ tree; it reads the first-party set
+# from the manifest baked at the product root (ADR-0013). Resolution order:
+# KF_FIRST_PARTY_MANIFEST, then the baked manifest, then a source scan. The
+# product root comes from the host seam, so the frozen form is staged the way
+# the seam detects it (sys.frozen + sys.executable at the dist root).
 
 import json
+import sys
 
 from kungfu.rewind import first_party
+
+SHA = "a" * 64
 
 
 def _write_manifest(path, keys):
     path.write_text(
-        json.dumps({"version": 1, "keys": {k: {"sha256": "x"} for k in keys}})
+        json.dumps({"version": 1, "keys": {k: {"sha256": SHA} for k in keys}})
     )
 
 
-def test_reads_baked_manifest_next_to_executable(tmp_path, monkeypatch):
+def _stage_frozen(tmp_path, monkeypatch):
     exe = tmp_path / "kungfu"
     exe.write_text("")
+    monkeypatch.setattr(sys, "frozen", True, raising=False)
+    monkeypatch.setattr(sys, "executable", str(exe))
+
+
+def test_reads_baked_manifest_at_the_product_root(tmp_path, monkeypatch):
+    _stage_frozen(tmp_path, monkeypatch)
     _write_manifest(tmp_path / "first-party.json", ["work-dashboard", "rewind"])
-    monkeypatch.setattr("sys.executable", str(exe))
     monkeypatch.delenv("KF_FIRST_PARTY_MANIFEST", raising=False)
     assert first_party.first_party_keys() == {"work-dashboard", "rewind"}
     assert first_party.is_first_party("work-dashboard")
@@ -27,11 +37,9 @@ def test_reads_baked_manifest_next_to_executable(tmp_path, monkeypatch):
 
 
 def test_env_manifest_wins_over_baked(tmp_path, monkeypatch):
-    exe = tmp_path / "kungfu"
-    exe.write_text("")
+    _stage_frozen(tmp_path, monkeypatch)
     _write_manifest(tmp_path / "first-party.json", ["baked-only"])
     env_manifest = tmp_path / "env.json"
     _write_manifest(env_manifest, ["env-only"])
-    monkeypatch.setattr("sys.executable", str(exe))
     monkeypatch.setenv("KF_FIRST_PARTY_MANIFEST", str(env_manifest))
     assert first_party.first_party_keys() == {"env-only"}

--- a/framework/core/tests/python/test_host_seam.py
+++ b/framework/core/tests/python/test_host_seam.py
@@ -1,0 +1,92 @@
+#  SPDX-License-Identifier: Apache-2.0
+"""The host-neutral seam: form detection, product root, re-entry command.
+
+Each host form is staged without real product builds: frozen via sys.frozen,
+assembled via a marker file under a faked sys.base_prefix, source as the live
+test interpreter itself (a uv-managed dev interpreter has no marker and is
+not frozen).
+"""
+
+import json
+import os
+import stat
+import sys
+from pathlib import Path
+
+from kungfu import _runtime_violation, host
+
+
+def _write_marker(prefix, body=None):
+    prefix.mkdir(parents=True, exist_ok=True)
+    marker = prefix / "kungfu-host.json"
+    marker.write_text(
+        json.dumps(
+            {"schema": "kungfu.host/v1", "form": "assembled", "product_root": ".."}
+            if body is None
+            else body
+        ),
+        encoding="utf-8",
+    )
+    return marker
+
+
+def test_source_form_on_the_dev_interpreter():
+    assert host.host_form() == host.FORM_SOURCE
+    assert host.product_root() is None
+
+
+def test_frozen_form_detects_and_roots_at_the_executable(monkeypatch):
+    monkeypatch.setattr(sys, "frozen", True, raising=False)
+    assert host.host_form() == host.FORM_FROZEN
+    assert host.product_root() == Path(sys.executable).resolve().parent
+
+
+def test_assembled_form_detects_marker_and_resolves_root(monkeypatch, tmp_path):
+    prefix = tmp_path / "dist" / "kungfu" / "python"
+    _write_marker(prefix)
+    monkeypatch.setattr(sys, "base_prefix", str(prefix))
+    assert host.host_form() == host.FORM_ASSEMBLED
+    assert host.product_root() == (tmp_path / "dist" / "kungfu").resolve()
+
+
+def test_marker_with_wrong_schema_is_not_assembled(monkeypatch, tmp_path):
+    prefix = tmp_path / "python"
+    _write_marker(prefix, {"schema": "other/v1"})
+    monkeypatch.setattr(sys, "base_prefix", str(prefix))
+    assert host.host_form() == host.FORM_SOURCE
+    assert host.product_root() is None
+
+
+def test_entry_command_prefers_a_real_executable_argv0(monkeypatch, tmp_path):
+    entry = tmp_path / "kungfu"
+    entry.write_text("#!/bin/sh\n", encoding="utf-8")
+    entry.chmod(entry.stat().st_mode | stat.S_IXUSR)
+    monkeypatch.setattr(sys, "argv", [str(entry)])
+    assert host.entry_command() == [str(entry.resolve())]
+
+
+def test_entry_command_reenters_the_interpreter_for_module_runs(monkeypatch):
+    # python -m kungfu leaves argv0 pointing at __main__.py, which is not a
+    # command a child can exec; re-enter through the running interpreter.
+    monkeypatch.setattr(sys, "argv", [os.path.join("kungfu", "__main__.py")])
+    assert host.entry_command() == [sys.executable, "-m", "kungfu"]
+
+
+def test_entry_command_falls_back_when_argv0_is_the_interpreter(monkeypatch):
+    # A bare interpreter argv0 (python, python3, python3.13) is not the
+    # product entry; re-enter with -m so the child gets the CLI, not a REPL.
+    monkeypatch.setattr(sys, "argv", [sys.executable])
+    assert host.entry_command() == [sys.executable, "-m", "kungfu"]
+
+
+def test_assembled_host_is_blessed_unconditionally():
+    assert (
+        _runtime_violation(
+            "3.13.14",
+            frozen=False,
+            base_prefix="/opt/kungfu/python",
+            running_version="3.13.14",
+            assembled=True,
+        )
+        is None
+    )

--- a/product/stdlib-prune.json
+++ b/product/stdlib-prune.json
@@ -1,0 +1,32 @@
+{
+  "schema": "kungfu.stdlib-prune/v1",
+  "note": "Family-level subtraction from the complete python-build-standalone prefix (ADR-0046 stage 2). Entries are prefix-relative; '*' globs cover version-suffixed names. Every entry must match the tree it prunes — a stale entry fails the assemble build instead of failing in the field. New python dependencies live in site-packages and never interact with this list.",
+  "prune": {
+    "common": [
+      "lib/python3.13/idlelib",
+      "lib/python3.13/tkinter",
+      "lib/python3.13/turtledemo",
+      "lib/python3.13/turtle.py",
+      "lib/python3.13/ensurepip",
+      "lib/python3.13/site-packages/pip",
+      "lib/python3.13/site-packages/pip-*.dist-info",
+      "lib/python3.13/lib-dynload/_tkinter*",
+      "bin/idle3*",
+      "bin/pip*",
+      "bin/pydoc3*",
+      "include"
+    ],
+    "darwin": [
+      "lib/tcl9.0",
+      "lib/tk9.0",
+      "lib/tcl9",
+      "lib/itcl4.3.5",
+      "lib/thread3.0.4",
+      "lib/libtcl9.0.dylib",
+      "lib/libtcl9tk9.0.dylib",
+      "lib/pkgconfig",
+      "bin/python3-config",
+      "bin/python3.13-config"
+    ]
+  }
+}


### PR DESCRIPTION
## What

Three steps toward the assembled runtime distribution (ADR-0046 stage 2 — assembly replaces freezing), all behind the existing `freezer` config; defaults are untouched on every platform.

1. **Host-neutral seam** (`kungfu.host`): the python tree stops deriving "where is the product root" and "how does a child re-enter kungfu" from `sys.executable`. Three host forms (frozen / assembled / source); the assembled form is declared by a `kungfu-host.json` marker at the tree prefix. The product-root family (contract discovery, baked first-party manifest, agent pack, trunk lookup, variants dist detection) and the self-re-entry family route through the seam; the wrong-runtime guard learns the assembled host is blessed by construction. Also fixes two latent entry_command defects (interpreter-shaped argv0 like `python3.13` slipping the exclusion set; `python -m` handing children an unexecutable `__main__.py` path) and the baked first-party test fixtures that had gone stale against the tightened sha256 schema.

2. **Assemble packaging leg** (`freezer=assemble`): stages the pinned python-build-standalone prefix under `dist/kungfu/python` (same arch-qualified key and cache the trunk uses, from the same runtime-pins manifest), resolves the runtime dependency closure from the committed lock into the tree's site-packages, and wires the flat dist root through a site-packages `.pth` — never via `PYTHON*` env vars, which would leak into satellite envs. The tree keeps python-build-standalone's `EXTERNALLY-MANAGED` marker as an install-surface guard; the build stages deps through the one explicit bypass. The stdlib prune policy is a declarative manifest (`product/stdlib-prune.json`): a fixed family-level subtraction from a complete stdlib that new dependencies never interact with, whose stale entries fail the build instead of failing in the field — deliberately unlike the nofollow-import surface this stage retires. Windows is refused by name until its layout lands.

3. **Trunk entry**: the trunk binary installs under the product name `kungfu` next to the tree. Invoked as `kungfu` it keeps the subtrees it implements (env, prewarm) and execs the assembled interpreter on `-m kungfu` for everything else, verbatim — argv-transparent per the layering law. The kungfu package ships in the tree's site-packages (its standard home, freeing the dist root for the entry). First prune fill: tcl/tk family, pip/ensurepip (uv is the only install engine), headers, bin auxiliaries — tree 68M full → 56M pruned.

## Validation (macOS arm64)

- `ruff` / `mypy` / `biome` / `cargo fmt+clippy` clean; trunk tests pass.
- Seam tests (8 new) + wrong-runtime guard (8) + baked first-party (2, fixture fixed) all pass; full python suite delta vs baseline is exactly the fixture fix (remaining baseline failures are binding drift against a borrowed sibling build, not touched here).
- Assembled dist smoke through the product entry: `kungfu --version`, `kungfu kfd status --json` (libnode round trip), `kungfu env list` (native), contract registry discovery, `import tkinter` refused, `python -m pip` absent, form/product-root detection correct.

## Not in this PR

macOS default flip + `verify --full` gate migration (next slice, with the full-gate evidence); Linux/Windows assembly; Nuitka disposition ledger.