### PR TITLE
shifu: promote — the freshest built dev kungfu, one command away

### DIFF
--- a/build-local.env.example
+++ b/build-local.env.example
@@ -51,6 +51,17 @@
 # thumb: jobs ≈ available memory GB / 2. If unset, conan defaults (os.cpu_count).
 # export KUNGFU_BUILD_JOBS="12"
 
+# ── Dev build stash (shifu promote / builds) ────────────────────────────────
+# Successful desktop builds register themselves user-globally
+# (~/.cache/kungfu/product/<os>-<arch>/) so `shifu promote` can install the
+# freshest dev build from any terminal, even after the worktree that built it
+# is cleaned.
+# How many stashed builds to keep (default 2; older slots retire automatically):
+# export KUNGFU_PRODUCT_BUILDS_KEEP="2"
+# Where `shifu promote` installs (default /Applications, falling back to
+# ~/Applications when not writable; linux default ~/.local/bin):
+# export KUNGFU_PRODUCT_INSTALL_DIR="/Applications"
+
 # ── Entries not handled by this file — set via their own user-global config (also absent from this repo) ──
 #  npm package install registry + private @scope registry / token  →  ~/.npmrc
 #    e.g.: registry=http://YOUR-CACHE-HOST:4873/  + @kungfu-tech:registry=...  + _authToken

--- a/crates/shifu-core/src/bootstrap.rs
+++ b/crates/shifu-core/src/bootstrap.rs
@@ -63,7 +63,7 @@ const UV_BASE: &str = "https://github.com/astral-sh/uv/releases/download";
 /// `FetchSpec::cached_binary`): binaries for different targets must never
 /// share a cache slot.
 fn cache_target() -> String {
-    format!("{}-{}", env::consts::OS, env::consts::ARCH)
+    host::os_arch()
 }
 
 /// Everything the fetch engine needs to acquire one pinned tool: an exact

--- a/crates/shifu-core/src/host.rs
+++ b/crates/shifu-core/src/host.rs
@@ -36,6 +36,13 @@ pub fn kungfu_cache_dir() -> PathBuf {
     xdg_dir("XDG_CACHE_HOME", ".cache").join("kungfu")
 }
 
+/// Platform tag naming what this process runs on, `<os>-<arch>` in
+/// std::env::consts vocabulary (e.g. `macos-aarch64`). Cache layouts key on
+/// it so artifacts for different targets never share a slot.
+pub fn os_arch() -> String {
+    format!("{}-{}", env::consts::OS, env::consts::ARCH)
+}
+
 /// Resolve a command name against PATH (honoring PATHEXT on Windows).
 /// Equivalent to `command -v` / `where`, without spawning a process.
 pub fn find_on_path(name: &str) -> Option<PathBuf> {

--- a/crates/shifu/src/envfile.rs
+++ b/crates/shifu/src/envfile.rs
@@ -13,12 +13,17 @@ use std::path::Path;
 
 use crate::util;
 
-pub fn load(repo_root: &Path) {
+/// Load the two-layer config: the user-global file always (rootless verbs
+/// like `promote` and `builds` read configuration too), the repo-root
+/// override only inside a checkout.
+pub fn load(repo_root: Option<&Path>) {
     let user_global = util::xdg_dir("XDG_CONFIG_HOME", ".config")
         .join("kungfu")
         .join("build-local.env");
     apply_file(&user_global);
-    apply_file(&repo_root.join("build-local.env"));
+    if let Some(root) = repo_root {
+        apply_file(&root.join("build-local.env"));
+    }
 }
 
 fn apply_file(path: &Path) {
@@ -32,7 +37,7 @@ fn apply_file(path: &Path) {
     }
 }
 
-fn parse_line(line: &str) -> Option<(&str, &str)> {
+pub(crate) fn parse_line(line: &str) -> Option<(&str, &str)> {
     let s = line.trim_start();
     if s.is_empty() || s.starts_with('#') {
         return None;

--- a/crates/shifu/src/main.rs
+++ b/crates/shifu/src/main.rs
@@ -39,6 +39,7 @@ mod doctor;
 mod envfile;
 #[cfg(windows)]
 mod msvc;
+mod promote;
 mod self_update;
 mod tools;
 mod util;
@@ -90,6 +91,8 @@ fn print_usage() {
         "                             {}",
         style::dim("(from checkout source, or --version <v> for a release)")
     );
+    println!("  shifu promote [--launch]   install the freshest built dev kungfu");
+    println!("  shifu builds               list registered dev builds");
     println!("  shifu help                 pnpm's own help (tasks are pnpm scripts)");
     println!();
     println!(
@@ -128,14 +131,21 @@ fn main() {
     let is_version = matches!(first, Some("--version") | Some("-v") | Some("-V"));
     let is_doctor = first == Some("doctor");
     let is_self_update = first == Some("self-update");
+    // Product-stash verbs work outside a checkout too: the stash is
+    // user-global precisely so a cleaned worktree cannot strand its build.
+    let is_promote = first == Some("promote");
+    let is_builds = first == Some("builds");
+    let lenient = is_version || is_doctor || is_self_update || is_promote || is_builds;
 
-    let root = find_repo_root(is_version || is_doctor || is_self_update);
+    let root = find_repo_root(lenient);
 
     if is_version {
         println!("{}", version_line(root.as_deref()));
     }
+    // User-global config loads unconditionally (rootless verbs read it too);
+    // the repo-root override only exists inside a checkout.
+    envfile::load(root.as_deref());
     if let Some(root) = root.as_deref() {
-        envfile::load(root);
         // self-update answers for THIS binary (never delegated): delegation
         // would replace the process with the checkout's launcher, while the
         // update must act on the binary the user invoked.
@@ -152,6 +162,12 @@ fn main() {
     }
     if is_doctor {
         doctor::run(root.as_deref());
+    }
+    if is_promote {
+        promote::run_promote(&args[1..]);
+    }
+    if is_builds {
+        promote::run_builds();
     }
     let root = root.expect("strict repo discovery cannot return None");
 

--- a/crates/shifu/src/promote.rs
+++ b/crates/shifu/src/promote.rs
@@ -1,0 +1,342 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// `shifu promote` / `shifu builds` — use the freshest built dev kungfu from
+// any terminal.
+//
+// Builds happen in worktrees, and worktrees are temporary: the product
+// pipeline therefore stashes each successful desktop build user-globally
+// (product/scripts/register-build.mjs), and these verbs consume that stash —
+// the directory IS the registry:
+//
+//   ${XDG_CACHE_HOME:-~/.cache}/kungfu/product/<os>-<arch>/<utc-ts>-<sha>/
+//     meta.env      KEY='VALUE' lines (build-local.env shape)
+//     <artifact>    unpacked .app (mac) / nsis installer (win) / AppImage
+//
+// The newest build is the lexicographically greatest slot. `builds` lists
+// the stash; `promote` installs the newest entry — the shifu-jurisdiction
+// sibling of `clone`: clone acquires the repository, promote acquires the
+// product. Configuration rides the existing build-local.env surface:
+// KUNGFU_PRODUCT_INSTALL_DIR (install target) and, on the producer side,
+// KUNGFU_PRODUCT_BUILDS_KEEP (stash retention).
+
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use shifu_core::{host, style};
+
+use crate::{envfile, util};
+
+struct BuildEntry {
+    slot: PathBuf,
+    name: String,
+    sha: String,
+    branch: String,
+    worktree: String,
+    built_at: String,
+    kind: String,
+    artifact: String,
+}
+
+fn registry_dir() -> PathBuf {
+    host::kungfu_cache_dir()
+        .join("product")
+        .join(host::os_arch())
+}
+
+fn read_meta(slot: &Path) -> Option<Vec<(String, String)>> {
+    let text = fs::read_to_string(slot.join("meta.env")).ok()?;
+    Some(
+        text.lines()
+            .filter_map(envfile::parse_line)
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect(),
+    )
+}
+
+fn meta_get(meta: &[(String, String)], key: &str) -> String {
+    meta.iter()
+        .find(|(k, _)| k == key)
+        .map(|(_, v)| v.clone())
+        .unwrap_or_default()
+}
+
+/// All stashed builds, newest first.
+fn entries() -> Vec<BuildEntry> {
+    let dir = registry_dir();
+    let Ok(read) = fs::read_dir(&dir) else {
+        return Vec::new();
+    };
+    let mut names: Vec<String> = read
+        .flatten()
+        .filter(|e| e.path().is_dir())
+        .map(|e| e.file_name().to_string_lossy().to_string())
+        .filter(|name| !name.contains(".tmp-"))
+        .collect();
+    names.sort();
+    names.reverse();
+    names
+        .into_iter()
+        .filter_map(|name| {
+            let slot = dir.join(&name);
+            let meta = read_meta(&slot)?;
+            let artifact = meta_get(&meta, "KUNGFU_BUILD_ARTIFACT");
+            if artifact.is_empty() || !slot.join(&artifact).exists() {
+                return None;
+            }
+            Some(BuildEntry {
+                sha: meta_get(&meta, "KUNGFU_BUILD_SHA"),
+                branch: meta_get(&meta, "KUNGFU_BUILD_BRANCH"),
+                worktree: meta_get(&meta, "KUNGFU_BUILD_WORKTREE"),
+                built_at: meta_get(&meta, "KUNGFU_BUILD_TIME"),
+                kind: meta_get(&meta, "KUNGFU_BUILD_KIND"),
+                artifact,
+                slot,
+                name,
+            })
+        })
+        .collect()
+}
+
+fn no_builds_hint() -> ! {
+    util::die(&format!(
+        "no registered dev builds for {} — run a product build first (./shifu dist, \
+         or ./shifu package for the unpacked app); builds register themselves on success",
+        host::os_arch()
+    ));
+}
+
+pub fn run_builds() -> ! {
+    let entries = entries();
+    if entries.is_empty() {
+        no_builds_hint();
+    }
+    println!(
+        "{}",
+        style::cyan(&format!(
+            "Registered dev builds ({}, newest first):",
+            host::os_arch()
+        ))
+    );
+    for (index, entry) in entries.iter().enumerate() {
+        let worktree_note = if Path::new(&entry.worktree).is_dir() {
+            entry.worktree.clone()
+        } else {
+            format!("{} (worktree cleaned; stash still usable)", entry.worktree)
+        };
+        println!(
+            "  {} {} {} @ {}",
+            style::bold(&format!("[{index}]")),
+            entry.built_at,
+            style::bold(&entry.sha),
+            entry.branch,
+        );
+        println!(
+            "      {}",
+            style::dim(&format!("{} - from {}", entry.artifact, worktree_note))
+        );
+    }
+    println!(
+        "\n{} shifu promote [--launch] installs [0]",
+        style::cyan("Next:")
+    );
+    std::process::exit(0)
+}
+
+pub fn run_promote(args: &[String]) -> ! {
+    let mut launch = false;
+    let mut force = false;
+    for arg in args {
+        match arg.as_str() {
+            "--launch" => launch = true,
+            "--force" => force = true,
+            _ => util::die("usage: shifu promote [--launch] [--force]"),
+        }
+    }
+
+    let entries = entries();
+    let Some(entry) = entries.first() else {
+        no_builds_hint();
+    };
+    eprintln!(
+        "\u{1f94b} {}",
+        style::bold(&format!(
+            "promoting dev build {} ({} @ {})",
+            entry.name, entry.sha, entry.branch
+        ))
+    );
+
+    let installed = match entry.kind.as_str() {
+        "app" => promote_app(entry, force),
+        "installer" => promote_installer(entry),
+        "appimage" => promote_appimage(entry),
+        other => util::die(&format!("unknown artifact kind in stash: {other}")),
+    };
+
+    eprintln!(
+        "\u{2705} {} {}",
+        style::green("promoted"),
+        style::bold(&installed.display().to_string())
+    );
+    if launch {
+        launch_product(&installed);
+    }
+    std::process::exit(0)
+}
+
+/// Install target: KUNGFU_PRODUCT_INSTALL_DIR > platform default (falling
+/// back to a per-user location when the default is not writable).
+fn install_dir(default: PathBuf, user_fallback: PathBuf) -> PathBuf {
+    if let Ok(configured) = env::var("KUNGFU_PRODUCT_INSTALL_DIR") {
+        let configured = configured.trim();
+        if !configured.is_empty() {
+            return PathBuf::from(configured);
+        }
+    }
+    if dir_writable(&default) {
+        return default;
+    }
+    user_fallback
+}
+
+fn dir_writable(dir: &Path) -> bool {
+    if !dir.is_dir() {
+        return false;
+    }
+    let probe = dir.join(format!(".shifu-probe-{}", std::process::id()));
+    match fs::write(&probe, b"") {
+        Ok(()) => {
+            let _ = fs::remove_file(&probe);
+            true
+        }
+        Err(_) => false,
+    }
+}
+
+/// macOS: copy the stashed .app over the installed one (rename dance — the
+/// old app is only removed after the new copy fully landed next to it).
+fn promote_app(entry: &BuildEntry, force: bool) -> PathBuf {
+    let target_dir = install_dir(
+        PathBuf::from("/Applications"),
+        host::home_dir().join("Applications"),
+    );
+    if let Err(e) = fs::create_dir_all(&target_dir) {
+        util::die(&format!("cannot create {}: {e}", target_dir.display()));
+    }
+    let target = target_dir.join(&entry.artifact);
+
+    if product_running(&entry.artifact) {
+        if force {
+            eprintln!(
+                "   {}",
+                style::yellow("app is running; replacing anyway (--force)")
+            );
+        } else {
+            util::die(&format!(
+                "{} is running — quit it first, or pass --force to replace it anyway",
+                entry.artifact
+            ));
+        }
+    }
+
+    let staged = target_dir.join(format!(".{}.new-{}", entry.artifact, std::process::id()));
+    let _ = fs::remove_dir_all(&staged);
+    let status = Command::new("ditto")
+        .arg(entry.slot.join(&entry.artifact))
+        .arg(&staged)
+        .status();
+    match status {
+        Ok(s) if s.success() => {}
+        Ok(s) => util::die(&format!("ditto failed (exit {:?})", s.code())),
+        Err(e) => util::die(&format!("failed to run ditto: {e}")),
+    }
+    if target.exists() {
+        if let Err(e) = fs::remove_dir_all(&target) {
+            let _ = fs::remove_dir_all(&staged);
+            util::die(&format!(
+                "cannot remove the previous {}: {e}",
+                target.display()
+            ));
+        }
+    }
+    if let Err(e) = fs::rename(&staged, &target) {
+        util::die(&format!("cannot place {}: {e}", target.display()));
+    }
+    target
+}
+
+/// Is the product app currently running? (macOS: match the executable path
+/// inside the bundle, the stable signal across renames of the process name.)
+fn product_running(app_name: &str) -> bool {
+    let pattern = format!("{app_name}/Contents/MacOS/");
+    Command::new("pgrep")
+        .args(["-f", &pattern])
+        .output()
+        .map(|out| out.status.success())
+        .unwrap_or(false)
+}
+
+/// Windows: the stashed artifact is the self-contained nsis installer; run it
+/// silently.
+fn promote_installer(entry: &BuildEntry) -> PathBuf {
+    let installer = entry.slot.join(&entry.artifact);
+    eprintln!(
+        "   {}",
+        style::dim("running the nsis installer silently (/S)")
+    );
+    let status = Command::new(&installer).arg("/S").status();
+    match status {
+        Ok(s) if s.success() => installer,
+        Ok(s) => util::die(&format!("installer failed (exit {:?})", s.code())),
+        Err(e) => util::die(&format!("failed to run the installer: {e}")),
+    }
+}
+
+/// Linux: place the AppImage on the user's PATH under a stable name.
+fn promote_appimage(entry: &BuildEntry) -> PathBuf {
+    let target_dir = install_dir(
+        host::home_dir().join(".local").join("bin"),
+        host::home_dir().join(".local").join("bin"),
+    );
+    if let Err(e) = fs::create_dir_all(&target_dir) {
+        util::die(&format!("cannot create {}: {e}", target_dir.display()));
+    }
+    let target = target_dir.join("kungfu-dev.AppImage");
+    if let Err(e) = fs::copy(entry.slot.join(&entry.artifact), &target) {
+        util::die(&format!("cannot place {}: {e}", target.display()));
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = fs::set_permissions(&target, fs::Permissions::from_mode(0o755));
+    }
+    target
+}
+
+#[cfg(windows)]
+fn launch_product(installed: &Path) {
+    // The stashed artifact is the installer, not the installed app; launching
+    // it again would rerun the install.
+    let _ = installed;
+    eprintln!(
+        "   {}",
+        style::dim("installed - launch Kungfu from the Start Menu")
+    );
+}
+
+#[cfg(not(windows))]
+fn launch_product(installed: &Path) {
+    #[cfg(target_os = "macos")]
+    let launched = Command::new("open").arg(installed).status().map(|_| ());
+    #[cfg(not(target_os = "macos"))]
+    // Detached on purpose: promote returns, the product keeps running.
+    let launched = Command::new(installed).spawn().map(|_| ());
+    match launched {
+        Ok(()) => eprintln!("   {}", style::dim("launched")),
+        Err(e) => eprintln!(
+            "   {}",
+            style::yellow(&format!("promoted, but launching failed: {e}"))
+        ),
+    }
+}

--- a/docs/rust-adoption.md
+++ b/docs/rust-adoption.md
@@ -189,7 +189,12 @@ per-platform special-casing) with one binary that:
   (plus the checkout's current branch for the repo role);
 - `shifu clone [path]` fetches the repository itself and `shifu doctor`
   checks the development environment (install pointers for the heavyweight
-  prerequisites it deliberately does not manage). Together with delegation
+  prerequisites it deliberately does not manage); `shifu promote` installs
+  the freshest built dev product from the user-global build stash (successful
+  desktop builds register themselves there, so a cleaned worktree cannot
+  strand its build) and `shifu builds` lists that stash — the jurisdiction
+  siblings of clone: clone acquires the repository, promote acquires the
+  product. Together with delegation
   this makes an installed shifu a self-sufficient bootstrap core: install
   once, clone anywhere, and every capability that can evolve lives in the
   repo — the binary never needs re-installing to pick up new launcher

--- a/product/scripts/dist.mjs
+++ b/product/scripts/dist.mjs
@@ -585,6 +585,23 @@ function stageDesktopRelease() {
   });
 }
 
+// Post-success bookkeeping: stash the unpacked desktop artifact user-globally
+// so `shifu promote` can install the freshest dev build from any terminal,
+// surviving worktree cleanup. Advisory by design — a registration failure
+// must not fail a build that already succeeded.
+function registerDevBuild() {
+  const result = spawnSync(
+    process.execPath,
+    [path.join(PRODUCT_DIR, 'scripts', 'register-build.mjs')],
+    { stdio: 'inherit' },
+  );
+  if (result.status !== 0) {
+    console.warn(
+      '[product] warning: dev build registration failed; shifu promote will not see this build',
+    );
+  }
+}
+
 function assertCoreFrozen() {
   const kungfuBin = path.join(CORE_DIST, isWin ? 'kungfu.exe' : 'kungfu');
   if (!fs.existsSync(kungfuBin)) {
@@ -1067,6 +1084,7 @@ function main() {
           },
         );
         stageDesktopRelease();
+        registerDevBuild();
       }
       if (wantsCli()) {
         buildCliProduct();

--- a/product/scripts/register-build.mjs
+++ b/product/scripts/register-build.mjs
@@ -1,0 +1,179 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: Apache-2.0
+//
+// Register a successful desktop build in the user-global product build stash,
+// so the freshest dev build stays usable after its worktree is cleaned and
+// `shifu promote` can install it from any terminal.
+//
+// The directory IS the registry (no JSON, std-only consumers can read it):
+//
+//   ${XDG_CACHE_HOME:-~/.cache}/kungfu/product/<os>-<arch>/<utc-ts>-<sha>[-dirty]/
+//     meta.env            KEY='VALUE' lines (same shape as build-local.env)
+//     <artifact>          the unpacked .app (mac), nsis installer (win),
+//                         or AppImage (linux)
+//
+// "Newest build" is the lexicographically greatest slot name. Retention is
+// KUNGFU_PRODUCT_BUILDS_KEEP (default 2): older slots are removed after a new
+// one lands. Invoked by dist.mjs after the desktop product is staged; runnable
+// standalone (--dist-dir to point at a build output) for tests.
+// @ts-check
+
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PRODUCT_DIR = path.resolve(__dirname, '..');
+const ROOT = path.resolve(PRODUCT_DIR, '..');
+
+function parseArgs(argv) {
+  const args = { distDir: path.join(PRODUCT_DIR, 'dist', 'desktop') };
+  for (let i = 0; i < argv.length; i += 1) {
+    if (argv[i] === '--dist-dir' && argv[i + 1]) {
+      i += 1;
+      args.distDir = path.resolve(argv[i]);
+    } else {
+      throw new Error(`unknown argument: ${argv[i]}`);
+    }
+  }
+  return args;
+}
+
+// Match the rust side (std::env::consts) so the binary reads what we write.
+function platformTag() {
+  const osName = { darwin: 'macos', win32: 'windows', linux: 'linux' }[
+    process.platform
+  ];
+  const arch = { arm64: 'aarch64', x64: 'x86_64' }[process.arch];
+  if (!osName || !arch) {
+    throw new Error(`unsupported platform ${process.platform}/${process.arch}`);
+  }
+  return `${osName}-${arch}`;
+}
+
+function cacheRoot() {
+  const base =
+    process.env.XDG_CACHE_HOME && process.env.XDG_CACHE_HOME !== ''
+      ? process.env.XDG_CACHE_HOME
+      : path.join(os.homedir(), '.cache');
+  return path.join(base, 'kungfu', 'product', platformTag());
+}
+
+function git(args) {
+  const result = spawnSync('git', args, { cwd: ROOT, encoding: 'utf8' });
+  return result.status === 0 ? result.stdout.trim() : '';
+}
+
+// The artifact to stash, per platform: the unpacked .app needs no installer
+// on mac; the nsis installer is self-contained on windows; the AppImage is
+// the whole product on linux.
+function findArtifact(distDir) {
+  if (process.platform === 'darwin') {
+    const entries = fs
+      .readdirSync(distDir, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory() && entry.name.startsWith('mac'));
+    for (const entry of entries) {
+      const inner = path.join(distDir, entry.name);
+      const app = fs.readdirSync(inner).find((name) => name.endsWith('.app'));
+      if (app) {
+        return { kind: 'app', source: path.join(inner, app), name: app };
+      }
+    }
+    throw new Error(`no unpacked .app under ${distDir}`);
+  }
+  if (process.platform === 'win32') {
+    const exe = fs
+      .readdirSync(distDir)
+      .find((name) => name.toLowerCase().endsWith('.exe'));
+    if (!exe) throw new Error(`no nsis installer under ${distDir}`);
+    return { kind: 'installer', source: path.join(distDir, exe), name: exe };
+  }
+  const image = fs
+    .readdirSync(distDir)
+    .find((name) => name.endsWith('.AppImage'));
+  if (!image) throw new Error(`no AppImage under ${distDir}`);
+  return { kind: 'appimage', source: path.join(distDir, image), name: image };
+}
+
+function copyArtifact(source, target) {
+  if (process.platform === 'darwin') {
+    // ditto preserves the .app faithfully (symlinks, permissions, xattrs).
+    const result = spawnSync('ditto', [source, target], { stdio: 'inherit' });
+    if (result.status !== 0) {
+      throw new Error(`ditto failed copying ${source}`);
+    }
+    return;
+  }
+  fs.cpSync(source, target, { recursive: true });
+}
+
+function quote(value) {
+  return `'${String(value).replace(/'/g, '')}'`;
+}
+
+function keepCount() {
+  const raw = Number.parseInt(process.env.KUNGFU_PRODUCT_BUILDS_KEEP ?? '', 10);
+  return Number.isInteger(raw) && raw >= 1 ? raw : 2;
+}
+
+function main() {
+  const { distDir } = parseArgs(process.argv.slice(2));
+  const artifact = findArtifact(distDir);
+
+  const sha = git(['rev-parse', '--short=9', 'HEAD']) || 'unknown';
+  const dirty = git(['status', '--porcelain', '--untracked-files=no']) !== '';
+  const fingerprint = dirty ? `${sha}-dirty` : sha;
+  const branch = git(['rev-parse', '--abbrev-ref', 'HEAD']) || 'unknown';
+  const builtAt = new Date().toISOString();
+  const stamp = builtAt.replace(/[-:]/g, '').replace(/\..*$/, 'Z');
+
+  const root = cacheRoot();
+  const slot = path.join(root, `${stamp}-${fingerprint}`);
+  const staging = `${slot}.tmp-${process.pid}`;
+  fs.mkdirSync(staging, { recursive: true });
+  copyArtifact(artifact.source, path.join(staging, artifact.name));
+  fs.writeFileSync(
+    path.join(staging, 'meta.env'),
+    [
+      `KUNGFU_BUILD_SHA=${quote(fingerprint)}`,
+      `KUNGFU_BUILD_BRANCH=${quote(branch)}`,
+      `KUNGFU_BUILD_WORKTREE=${quote(ROOT)}`,
+      `KUNGFU_BUILD_TIME=${quote(builtAt)}`,
+      `KUNGFU_BUILD_KIND=${quote(artifact.kind)}`,
+      `KUNGFU_BUILD_ARTIFACT=${quote(artifact.name)}`,
+      '',
+    ].join('\n'),
+  );
+  fs.rmSync(slot, { recursive: true, force: true });
+  fs.renameSync(staging, slot);
+  console.log(`[product] registered dev build -> ${slot}`);
+
+  // Retention: keep the newest KUNGFU_PRODUCT_BUILDS_KEEP slots.
+  const keep = keepCount();
+  const slots = fs
+    .readdirSync(root, { withFileTypes: true })
+    .filter(
+      (entry) =>
+        entry.isDirectory() &&
+        !entry.name.includes('.tmp-') &&
+        fs.existsSync(path.join(root, entry.name, 'meta.env')),
+    )
+    .map((entry) => entry.name)
+    .sort()
+    .reverse();
+  for (const name of slots.slice(keep)) {
+    fs.rmSync(path.join(root, name), { recursive: true, force: true });
+    console.log(`[product] retired dev build ${name} (keep ${keep})`);
+  }
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(
+    `[register-build] failed: ${error instanceof Error ? error.message : String(error)}`,
+  );
+  process.exit(1);
+}


### PR DESCRIPTION
Builds happen in temporary worktrees; using a fresh dev build meant locating the worktree, digging out the dmg, and installing by hand — and a cleaned worktree took its build with it. Desktop builds now register themselves into a user-global stash (directory-as-registry under ~/.cache/kungfu/product, meta.env in build-local.env shape, KUNGFU_PRODUCT_BUILDS_KEEP retention; advisory — cannot fail a successful build). The launcher grows the consuming verbs: shifu builds lists the stash, shifu promote [--launch] installs the newest entry (mac stage-then-swap .app replace with running-app guard; win silent nsis; linux AppImage), both answering outside a checkout. The user-global build-local.env layer now loads unconditionally so rootless verbs read configuration; knobs documented in build-local.env.example.