### PR TITLE
feat(qualification): add ADR-0049 layer harness

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "verify": "node scripts/require-shifu.mjs verify && node scripts/verify.mjs",
     "episode:qualify": "node scripts/require-shifu.mjs episode:qualify && node framework/core/tests/qualification/episode/run.mjs",
     "episode:qualify:release": "node scripts/require-shifu.mjs episode:qualify:release && node framework/core/tests/qualification/episode/release_evidence.mjs",
+    "layers:qualify": "node scripts/require-shifu.mjs layers:qualify && node tests/qualification/layers/run.mjs",
     "kfd:buildchain": "node scripts/require-shifu.mjs kfd:buildchain && node scripts/buildchain-kfd-evidence.mjs --write",
     "kfd:buildchain:check": "node scripts/require-shifu.mjs kfd:buildchain:check && node scripts/buildchain-kfd-evidence.mjs --check",
     "kfd:query": "node scripts/require-shifu.mjs kfd:query && node scripts/buildchain-kfd-evidence.mjs --query",

--- a/scripts/check.mjs
+++ b/scripts/check.mjs
@@ -306,6 +306,16 @@ function testShifuEntryContract() {
   ]);
 }
 
+function checkLayerQualification() {
+  run('ADR-0049 layer qualification harness tests', 'node', [
+    '--test',
+    path.join('tests', 'qualification', 'layers', 'run.test.mjs'),
+  ]);
+  run('ADR-0049 layer qualification harness', 'node', [
+    path.join('tests', 'qualification', 'layers', 'run.mjs'),
+  ]);
+}
+
 function checkCarrierActionEnvelope(scopeArgs = []) {
   run('carrier/action-envelope gate', 'node', [
     path.join('scripts', 'check-carrier-action-envelope.mjs'),
@@ -402,6 +412,7 @@ function checkStaged() {
 
 function checkShared() {
   testShifuEntryContract();
+  checkLayerQualification();
   run('tooling type check', 'pnpm', ['run', 'check:types']);
   run('SDK unit tests', 'pnpm', [
     '--filter',

--- a/tests/qualification/layers/README.md
+++ b/tests/qualification/layers/README.md
@@ -1,0 +1,32 @@
+# ADR-0049 layer qualification harness
+
+This harness turns ADR-0049's qualification matrix into a small, executable
+contract. It deliberately separates two facts:
+
+- the harness can be valid and its fixtures can pass;
+- individual release artifacts can still be `absent`, `staged`, `failing`, or
+  `unverifiable`.
+
+Run it through the pinned toolchain:
+
+```sh
+./shifu layers:qualify
+./shifu layers:qualify -- --report /tmp/kungfu-layer-qualification.json
+```
+
+`artifact-matrix.json` declares every official layer, its closure,
+capabilities, forbidden dependencies, onboarding concepts, and current status.
+The runner records exact Git/platform facts and source-level dependency and
+concept baselines. Installed size, cold start, resident runtimes, and resident
+memory stay `unverifiable` until a later goal supplies an exact installed
+artifact; source-tree size is not silently substituted for installed size.
+
+The first deletion fixture starts from the real workspace manifests, computes
+the CLI/TUI runtime dependency closure, writes that closure into an isolated
+temporary projection with the GUI package omitted, and resolves it again. It
+proves only the source-level dependency boundary: it does not claim that the
+packaged CLI already passes clean-install or runtime qualification.
+
+`./shifu check` runs this harness as a lightweight source gate. Later artifact
+goals can add installed-artifact probes and release evidence without turning
+this directory into another release orchestrator.

--- a/tests/qualification/layers/artifact-matrix.json
+++ b/tests/qualification/layers/artifact-matrix.json
@@ -1,0 +1,135 @@
+{
+  "schema": "kungfu.layer-qualification.matrix/v1",
+  "adr": "framework/core/docs/adr/ADR-0049-layer-complete-products-and-domain-neutral-core.md",
+  "status_vocabulary": [
+    "absent",
+    "staged",
+    "passing",
+    "failing",
+    "unverifiable"
+  ],
+  "budget_dimensions": [
+    "dependency_count",
+    "installed_size_bytes",
+    "cold_start_ms",
+    "resident_runtime_count",
+    "resident_memory_bytes",
+    "onboarding_concept_count"
+  ],
+  "artifacts": [
+    {
+      "id": "format-spec",
+      "layer": ".kungfu format and spec",
+      "artifact_status": "staged",
+      "workspace_package": null,
+      "declared_closure": "Open, inspect, verify, and preserve declared unknowns without a GUI.",
+      "required_capabilities": ["open", "inspect", "verify", "preserve_unknowns"],
+      "forbidden_dependencies": ["@kungfu-tech/gui", "electron"],
+      "onboarding": {
+        "commands": [],
+        "concepts": ["workspace", "fact", "schema", "verification"]
+      }
+    },
+    {
+      "id": "libkungfu",
+      "layer": "libkungfu native core",
+      "artifact_status": "staged",
+      "workspace_package": null,
+      "declared_closure": "Create or open .kungfu, append and seal an Episode, query, fsck, and export without a language host.",
+      "required_capabilities": ["record", "episode", "query", "fsck", "export"],
+      "forbidden_dependencies": ["@kungfu-tech/gui", "electron", "python", "node", "rust-host"],
+      "onboarding": {
+        "commands": [],
+        "concepts": ["workspace", "episode", "query", "verification", "export"]
+      }
+    },
+    {
+      "id": "pypi-sdk",
+      "layer": "PyPI SDK",
+      "artifact_status": "staged",
+      "workspace_package": null,
+      "declared_closure": "Install in a clean Python environment and run the shared semantic fixture without sibling SDKs.",
+      "required_capabilities": ["discover", "record", "query", "verify", "export"],
+      "forbidden_dependencies": ["@kungfu-tech/gui", "@kungfu-tech/tui", "npm-sdk", "cargo-sdk"],
+      "onboarding": {
+        "commands": ["pip install kungfu"],
+        "concepts": ["workspace", "episode", "capability", "verification"]
+      }
+    },
+    {
+      "id": "npm-sdk",
+      "layer": "npm SDK",
+      "artifact_status": "staged",
+      "workspace_package": "@kungfu-tech/api",
+      "declared_closure": "Install in a clean Node environment and run the shared semantic fixture without sibling SDKs.",
+      "required_capabilities": ["discover", "record", "query", "verify", "export"],
+      "forbidden_dependencies": ["@kungfu-tech/gui", "@kungfu-tech/tui", "pypi-sdk", "cargo-sdk"],
+      "onboarding": {
+        "commands": ["npm install @kungfu-tech/api"],
+        "concepts": ["workspace", "episode", "capability", "verification"]
+      }
+    },
+    {
+      "id": "cargo-sdk",
+      "layer": "Cargo SDK",
+      "artifact_status": "absent",
+      "workspace_package": null,
+      "declared_closure": "Install in a clean Rust environment and run the shared semantic fixture without sibling SDKs.",
+      "required_capabilities": ["discover", "record", "query", "verify", "export"],
+      "forbidden_dependencies": ["@kungfu-tech/gui", "@kungfu-tech/tui", "pypi-sdk", "npm-sdk"],
+      "onboarding": {
+        "commands": [],
+        "concepts": ["workspace", "episode", "capability", "verification"]
+      }
+    },
+    {
+      "id": "cli-tui",
+      "layer": "Kungfu CLI and TUI",
+      "artifact_status": "staged",
+      "workspace_package": "@kungfu-tech/tui",
+      "declared_closure": "Install a headless artifact and complete init, record, query, verify, export, and agent discovery without Electron.",
+      "required_capabilities": ["init", "record", "query", "verify", "export", "agent_discovery"],
+      "forbidden_dependencies": ["@kungfu-tech/gui", "electron"],
+      "onboarding": {
+        "commands": ["kungfu agent brief", "kungfu agent choose-mode --json"],
+        "concepts": ["workspace", "episode", "mode", "verification", "export"]
+      }
+    },
+    {
+      "id": "gui",
+      "layer": "Kungfu GUI",
+      "artifact_status": "staged",
+      "workspace_package": "@kungfu-tech/gui",
+      "declared_closure": "Complete human visual workflows through public contracts and uninstall without changing .kungfu authority.",
+      "required_capabilities": ["inspect", "timeline", "query", "repair", "export"],
+      "forbidden_dependencies": [],
+      "onboarding": {
+        "commands": ["open Kungfu Episodes"],
+        "concepts": ["workspace", "episode", "timeline", "query", "verification"]
+      }
+    },
+    {
+      "id": "assembled-distribution",
+      "layer": "assembled distribution",
+      "artifact_status": "staged",
+      "workspace_package": "@kungfu-tech/product-kungfu",
+      "declared_closure": "Install compatible official layers together without replacing any lower-layer qualification.",
+      "required_capabilities": ["install", "compatibility", "cli", "gui", "sdk"],
+      "forbidden_dependencies": [],
+      "onboarding": {
+        "commands": ["install Kungfu", "kungfu agent brief"],
+        "concepts": ["workspace", "episode", "surface", "mode", "verification"]
+      }
+    }
+  ],
+  "deletion_fixtures": [
+    {
+      "id": "remove-gui-preserves-cli-runtime-closure",
+      "root_artifact": "cli-tui",
+      "root_package": "@kungfu-tech/tui",
+      "removed_packages": ["@kungfu-tech/gui"],
+      "forbidden_external_dependencies": ["electron"],
+      "claim_boundary": "The source-level CLI/TUI runtime workspace closure remains resolvable when the GUI workspace package is absent. This does not claim that a packaged CLI artifact already passes clean-install or runtime smoke qualification."
+    }
+  ]
+}

--- a/tests/qualification/layers/run.mjs
+++ b/tests/qualification/layers/run.mjs
@@ -1,0 +1,479 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: Apache-2.0
+// @ts-check
+
+import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HARNESS_DIR = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(HARNESS_DIR, '..', '..', '..');
+const DEFAULT_MATRIX = path.join(HARNESS_DIR, 'artifact-matrix.json');
+const DEFAULT_SCHEMA = path.join(
+  HARNESS_DIR,
+  'schemas',
+  'artifact-matrix-v1.schema.json',
+);
+const EXPECTED_STATUSES = [
+  'absent',
+  'staged',
+  'passing',
+  'failing',
+  'unverifiable',
+];
+const EXPECTED_BUDGETS = [
+  'dependency_count',
+  'installed_size_bytes',
+  'cold_start_ms',
+  'resident_runtime_count',
+  'resident_memory_bytes',
+  'onboarding_concept_count',
+];
+const EXPECTED_ARTIFACTS = [
+  'format-spec',
+  'libkungfu',
+  'pypi-sdk',
+  'npm-sdk',
+  'cargo-sdk',
+  'cli-tui',
+  'gui',
+  'assembled-distribution',
+];
+const WORKSPACE_ROOTS = [
+  'framework',
+  'developer',
+  'extensions',
+  'examples',
+  'product',
+];
+
+function usage() {
+  console.log(`ADR-0049 Layer Qualification Harness
+
+Usage:
+  ./shifu layers:qualify -- [--matrix PATH] [--report PATH]
+
+The command validates the declarative artifact matrix, records source-level
+budget baselines, and runs deletion fixtures. A passing harness does not turn
+staged or absent artifact rows into qualified release claims.`);
+}
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function parseArgs(argv) {
+  const result = { matrix: DEFAULT_MATRIX, report: null };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--') continue;
+    if (arg === '--help' || arg === '-h') {
+      usage();
+      process.exit(0);
+    }
+    if (arg === '--matrix' || arg === '--report') {
+      index += 1;
+      if (index >= argv.length) fail(`${arg} requires a path`);
+      result[arg.slice(2)] = path.resolve(argv[index]);
+      continue;
+    }
+    fail(`unknown argument '${arg}'`);
+  }
+  return result;
+}
+
+function readJson(file) {
+  try {
+    return JSON.parse(fs.readFileSync(file, 'utf8'));
+  } catch (error) {
+    fail(
+      `cannot read JSON ${file}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
+function sha256(file) {
+  return createHash('sha256').update(fs.readFileSync(file)).digest('hex');
+}
+
+function validateSchemaContract(schema) {
+  if (
+    schema.properties?.schema?.const !== 'kungfu.layer-qualification.matrix/v1'
+  ) {
+    fail('artifact matrix schema has an unexpected contract id');
+  }
+  if (
+    JSON.stringify(schema.properties?.status_vocabulary?.const) !==
+    JSON.stringify(EXPECTED_STATUSES)
+  ) {
+    fail('artifact matrix schema status vocabulary drifted from the runner');
+  }
+  if (
+    JSON.stringify(schema.properties?.budget_dimensions?.const) !==
+    JSON.stringify(EXPECTED_BUDGETS)
+  ) {
+    fail('artifact matrix schema budget dimensions drifted from the runner');
+  }
+}
+
+function assertUniqueStrings(value, label, allowEmpty = true) {
+  if (!Array.isArray(value) || (!allowEmpty && value.length === 0)) {
+    fail(`${label} must be ${allowEmpty ? 'an' : 'a non-empty'} array`);
+  }
+  if (value.some((item) => typeof item !== 'string' || item.length === 0)) {
+    fail(`${label} must contain non-empty strings`);
+  }
+  if (new Set(value).size !== value.length) fail(`${label} must be unique`);
+}
+
+function validateMatrix(matrix) {
+  if (matrix.schema !== 'kungfu.layer-qualification.matrix/v1') {
+    fail(`unsupported matrix schema '${matrix.schema}'`);
+  }
+  if (
+    JSON.stringify(matrix.status_vocabulary) !==
+    JSON.stringify(EXPECTED_STATUSES)
+  ) {
+    fail('status_vocabulary must preserve the ADR-0049 five-state order');
+  }
+  if (
+    JSON.stringify(matrix.budget_dimensions) !==
+    JSON.stringify(EXPECTED_BUDGETS)
+  ) {
+    fail('budget_dimensions must preserve the ADR-0049 baseline dimensions');
+  }
+  if (!Array.isArray(matrix.artifacts) || matrix.artifacts.length === 0) {
+    fail('artifacts must be a non-empty array');
+  }
+  const ids = new Set();
+  for (const artifact of matrix.artifacts) {
+    if (!/^[a-z0-9][a-z0-9-]*$/.test(artifact.id || '')) {
+      fail(`invalid artifact id '${artifact.id}'`);
+    }
+    if (ids.has(artifact.id)) fail(`duplicate artifact id '${artifact.id}'`);
+    ids.add(artifact.id);
+    if (!EXPECTED_STATUSES.includes(artifact.artifact_status)) {
+      fail(`${artifact.id}.artifact_status is invalid`);
+    }
+    if (
+      typeof artifact.declared_closure !== 'string' ||
+      !artifact.declared_closure
+    ) {
+      fail(`${artifact.id}.declared_closure is required`);
+    }
+    assertUniqueStrings(
+      artifact.required_capabilities,
+      `${artifact.id}.required_capabilities`,
+    );
+    assertUniqueStrings(
+      artifact.forbidden_dependencies,
+      `${artifact.id}.forbidden_dependencies`,
+    );
+    assertUniqueStrings(
+      artifact.onboarding?.commands,
+      `${artifact.id}.onboarding.commands`,
+    );
+    assertUniqueStrings(
+      artifact.onboarding?.concepts,
+      `${artifact.id}.onboarding.concepts`,
+    );
+  }
+  if (
+    JSON.stringify([...ids].sort()) !==
+    JSON.stringify([...EXPECTED_ARTIFACTS].sort())
+  ) {
+    fail(
+      `artifact ids must exactly match the official ADR-0049 set: ${EXPECTED_ARTIFACTS.join(', ')}`,
+    );
+  }
+  if (
+    !Array.isArray(matrix.deletion_fixtures) ||
+    matrix.deletion_fixtures.length === 0
+  ) {
+    fail('deletion_fixtures must be a non-empty array');
+  }
+  for (const fixture of matrix.deletion_fixtures) {
+    if (!ids.has(fixture.root_artifact)) {
+      fail(`${fixture.id}.root_artifact '${fixture.root_artifact}' is unknown`);
+    }
+    assertUniqueStrings(
+      fixture.removed_packages,
+      `${fixture.id}.removed_packages`,
+      false,
+    );
+    assertUniqueStrings(
+      fixture.forbidden_external_dependencies,
+      `${fixture.id}.forbidden_external_dependencies`,
+    );
+    if (typeof fixture.claim_boundary !== 'string' || !fixture.claim_boundary) {
+      fail(`${fixture.id}.claim_boundary is required`);
+    }
+  }
+}
+
+function walkPackageJson(dir, result) {
+  if (!fs.existsSync(dir)) return;
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (
+      ['node_modules', 'dist', 'build', 'out', 'release'].includes(entry.name)
+    )
+      continue;
+    const target = path.join(dir, entry.name);
+    if (entry.isDirectory()) walkPackageJson(target, result);
+    else if (entry.isFile() && entry.name === 'package.json')
+      result.push(target);
+  }
+}
+
+function loadWorkspaceGraph(root = ROOT) {
+  const files = [];
+  for (const rel of WORKSPACE_ROOTS)
+    walkPackageJson(path.join(root, rel), files);
+  const packages = new Map();
+  for (const file of files) {
+    const manifest = readJson(file);
+    if (!manifest.name) continue;
+    if (packages.has(manifest.name))
+      fail(`duplicate workspace package '${manifest.name}'`);
+    packages.set(manifest.name, {
+      file,
+      manifest,
+      runtimeDependencies: {
+        ...(manifest.dependencies || {}),
+        ...(manifest.optionalDependencies || {}),
+        ...(manifest.peerDependencies || {}),
+      },
+    });
+  }
+  return packages;
+}
+
+function runtimeClosure(graph, rootPackage) {
+  if (!graph.has(rootPackage))
+    fail(`workspace package '${rootPackage}' not found`);
+  const seen = new Set();
+  const external = new Set();
+  const queue = [rootPackage];
+  while (queue.length > 0) {
+    const name = queue.shift();
+    if (seen.has(name)) continue;
+    seen.add(name);
+    const entry = graph.get(name);
+    if (!entry) fail(`workspace package '${name}' disappeared from projection`);
+    for (const dependency of Object.keys(entry.runtimeDependencies).sort()) {
+      if (graph.has(dependency)) queue.push(dependency);
+      else external.add(dependency);
+    }
+  }
+  return {
+    workspacePackages: [...seen].sort(),
+    externalDependencies: [...external].sort(),
+  };
+}
+
+function git(args) {
+  const result = spawnSync('git', args, { cwd: ROOT, encoding: 'utf8' });
+  if (result.status !== 0) fail(`git ${args.join(' ')} failed`);
+  return (result.stdout || '').trim();
+}
+
+function writeProjection(graph, closure, removedPackages) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'kungfu-layer-deletion-'));
+  const manifests = path.join(root, 'framework');
+  fs.mkdirSync(manifests, { recursive: true });
+  for (const name of closure.workspacePackages) {
+    if (removedPackages.includes(name)) continue;
+    const safeName = name.replaceAll('@', '').replaceAll('/', '__');
+    const dir = path.join(manifests, safeName);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, 'package.json'),
+      `${JSON.stringify(graph.get(name).manifest, null, 2)}\n`,
+      'utf8',
+    );
+  }
+  return root;
+}
+
+function runDeletionFixture(graph, fixture) {
+  for (const removed of fixture.removed_packages) {
+    if (!graph.has(removed))
+      fail(
+        `${fixture.id}: removed package '${removed}' is not present in the source graph`,
+      );
+  }
+  const sourceClosure = runtimeClosure(graph, fixture.root_package);
+  const forbiddenWorkspace = sourceClosure.workspacePackages.filter((name) =>
+    fixture.removed_packages.includes(name),
+  );
+  const forbiddenExternal = sourceClosure.externalDependencies.filter((name) =>
+    fixture.forbidden_external_dependencies.includes(name),
+  );
+  if (forbiddenWorkspace.length || forbiddenExternal.length) {
+    fail(
+      `${fixture.id}: source runtime closure reaches forbidden dependencies: ${[
+        ...forbiddenWorkspace,
+        ...forbiddenExternal,
+      ].join(', ')}`,
+    );
+  }
+
+  const projectionRoot = writeProjection(
+    graph,
+    sourceClosure,
+    fixture.removed_packages,
+  );
+  try {
+    const projectedGraph = loadWorkspaceGraph(projectionRoot);
+    const projectedClosure = runtimeClosure(
+      projectedGraph,
+      fixture.root_package,
+    );
+    if (projectedClosure.workspacePackages.includes('@kungfu-tech/gui')) {
+      fail(
+        `${fixture.id}: projected closure unexpectedly contains @kungfu-tech/gui`,
+      );
+    }
+    if (
+      projectedClosure.workspacePackages.length !==
+      sourceClosure.workspacePackages.length
+    ) {
+      fail(
+        `${fixture.id}: deletion projection changed the headless workspace closure`,
+      );
+    }
+    return {
+      id: fixture.id,
+      status: 'passing',
+      root_package: fixture.root_package,
+      removed_packages: fixture.removed_packages,
+      workspace_packages: projectedClosure.workspacePackages,
+      external_dependencies: projectedClosure.externalDependencies,
+      claim_boundary: fixture.claim_boundary,
+    };
+  } finally {
+    fs.rmSync(projectionRoot, { recursive: true, force: true });
+  }
+}
+
+function baselineForArtifact(graph, artifact) {
+  const measurements = {};
+  if (artifact.workspace_package && graph.has(artifact.workspace_package)) {
+    const closure = runtimeClosure(graph, artifact.workspace_package);
+    const forbidden = [
+      ...closure.workspacePackages,
+      ...closure.externalDependencies,
+    ].filter((name) => artifact.forbidden_dependencies.includes(name));
+    if (forbidden.length > 0) {
+      fail(
+        `${artifact.id}: runtime dependency closure reaches forbidden dependencies: ${forbidden.join(', ')}`,
+      );
+    }
+    measurements.dependency_count = {
+      status: 'passing',
+      value:
+        closure.workspacePackages.length + closure.externalDependencies.length,
+      unit: 'runtime dependencies including root package',
+      workspace_packages: closure.workspacePackages,
+      external_dependencies: closure.externalDependencies,
+    };
+  } else {
+    measurements.dependency_count = {
+      status: artifact.artifact_status === 'absent' ? 'absent' : 'unverifiable',
+      value: null,
+      unit: 'runtime dependencies including root package',
+    };
+  }
+  for (const dimension of [
+    'installed_size_bytes',
+    'cold_start_ms',
+    'resident_runtime_count',
+    'resident_memory_bytes',
+  ]) {
+    measurements[dimension] = {
+      status: artifact.artifact_status === 'absent' ? 'absent' : 'unverifiable',
+      value: null,
+      reason:
+        'No exact installed artifact was supplied to this source-level harness run.',
+    };
+  }
+  measurements.onboarding_concept_count = {
+    status: 'passing',
+    value: artifact.onboarding.concepts.length,
+    unit: 'declared concepts',
+    commands: artifact.onboarding.commands,
+    concepts: artifact.onboarding.concepts,
+  };
+  return measurements;
+}
+
+function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const matrix = readJson(options.matrix);
+  validateSchemaContract(readJson(DEFAULT_SCHEMA));
+  validateMatrix(matrix);
+  const graph = loadWorkspaceGraph();
+  const fixtures = matrix.deletion_fixtures.map((fixture) =>
+    runDeletionFixture(graph, fixture),
+  );
+  const artifactReports = matrix.artifacts.map((artifact) => ({
+    id: artifact.id,
+    artifact_status: artifact.artifact_status,
+    declared_closure: artifact.declared_closure,
+    measurements: baselineForArtifact(graph, artifact),
+  }));
+  const statusCounts = Object.fromEntries(
+    EXPECTED_STATUSES.map((status) => [
+      status,
+      artifactReports.filter((artifact) => artifact.artifact_status === status)
+        .length,
+    ]),
+  );
+  const report = {
+    schema: 'kungfu.layer-qualification.report/v1',
+    harness_valid: true,
+    matrix: path.relative(ROOT, options.matrix),
+    matrix_sha256: sha256(options.matrix),
+    matrix_schema: path.relative(ROOT, DEFAULT_SCHEMA),
+    matrix_schema_sha256: sha256(DEFAULT_SCHEMA),
+    source: {
+      commit: git(['rev-parse', 'HEAD']),
+      tree_dirty: git(['status', '--porcelain']).length > 0,
+      platform: process.platform,
+      architecture: process.arch,
+      node: process.versions.node,
+    },
+    artifact_status_counts: statusCounts,
+    artifacts: artifactReports,
+    deletion_fixtures: fixtures,
+    boundary:
+      'harness_valid means the matrix and fixtures executed. It does not promote staged, absent, failing, or unverifiable artifacts to passing.',
+  };
+  if (options.report) {
+    fs.mkdirSync(path.dirname(options.report), { recursive: true });
+    fs.writeFileSync(
+      options.report,
+      `${JSON.stringify(report, null, 2)}\n`,
+      'utf8',
+    );
+  }
+  console.log(
+    `[layers:qualify] matrix=${matrix.artifacts.length} artifacts; ` +
+      `statuses=${EXPECTED_STATUSES.map((status) => `${status}:${statusCounts[status]}`).join(',')}; ` +
+      `deletion=${fixtures.length}/${matrix.deletion_fixtures.length} passing`,
+  );
+  if (options.report) console.log(`[layers:qualify] report=${options.report}`);
+  console.log(`[layers:qualify] ${report.boundary}`);
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(
+    `[layers:qualify] failed: ${error instanceof Error ? error.message : String(error)}`,
+  );
+  process.exit(1);
+}

--- a/tests/qualification/layers/run.test.mjs
+++ b/tests/qualification/layers/run.test.mjs
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const DIR = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(DIR, '..', '..', '..');
+const RUNNER = path.join(DIR, 'run.mjs');
+const MATRIX = path.join(DIR, 'artifact-matrix.json');
+
+function run(args) {
+  return spawnSync(process.execPath, [RUNNER, ...args], {
+    cwd: ROOT,
+    encoding: 'utf8',
+  });
+}
+
+test('emits a bound report and passes the GUI deletion fixture', () => {
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), 'kungfu-layer-test-'));
+  try {
+    const reportPath = path.join(temp, 'report.json');
+    const result = run(['--report', reportPath]);
+    assert.equal(result.status, 0, result.stderr);
+    const report = JSON.parse(fs.readFileSync(reportPath, 'utf8'));
+    assert.equal(report.harness_valid, true);
+    assert.equal(report.artifacts.length, 8);
+    assert.equal(report.deletion_fixtures[0].status, 'passing');
+    assert.ok(report.matrix_sha256);
+    assert.ok(report.matrix_schema_sha256);
+  } finally {
+    fs.rmSync(temp, { recursive: true, force: true });
+  }
+});
+
+test('rejects a matrix that drops an official artifact', () => {
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), 'kungfu-layer-test-'));
+  try {
+    const invalidPath = path.join(temp, 'invalid-matrix.json');
+    const matrix = JSON.parse(fs.readFileSync(MATRIX, 'utf8'));
+    matrix.artifacts = matrix.artifacts.filter(
+      (artifact) => artifact.id !== 'format-spec',
+    );
+    fs.writeFileSync(
+      invalidPath,
+      `${JSON.stringify(matrix, null, 2)}\n`,
+      'utf8',
+    );
+    const result = run(['--matrix', invalidPath]);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /artifact ids must exactly match/);
+  } finally {
+    fs.rmSync(temp, { recursive: true, force: true });
+  }
+});

--- a/tests/qualification/layers/schemas/artifact-matrix-v1.schema.json
+++ b/tests/qualification/layers/schemas/artifact-matrix-v1.schema.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kungfu.tech/schemas/layer-qualification/artifact-matrix-v1.schema.json",
+  "title": "Kungfu layer qualification artifact matrix v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "adr", "status_vocabulary", "budget_dimensions", "artifacts", "deletion_fixtures"],
+  "properties": {
+    "schema": { "const": "kungfu.layer-qualification.matrix/v1" },
+    "adr": { "type": "string", "minLength": 1 },
+    "status_vocabulary": {
+      "type": "array",
+      "const": ["absent", "staged", "passing", "failing", "unverifiable"]
+    },
+    "budget_dimensions": {
+      "type": "array",
+      "const": ["dependency_count", "installed_size_bytes", "cold_start_ms", "resident_runtime_count", "resident_memory_bytes", "onboarding_concept_count"]
+    },
+    "artifacts": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/artifact" }
+    },
+    "deletion_fixtures": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/deletionFixture" }
+    }
+  },
+  "$defs": {
+    "status": { "enum": ["absent", "staged", "passing", "failing", "unverifiable"] },
+    "artifact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "layer", "artifact_status", "workspace_package", "declared_closure", "required_capabilities", "forbidden_dependencies", "onboarding"],
+      "properties": {
+        "id": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]*$" },
+        "layer": { "type": "string", "minLength": 1 },
+        "artifact_status": { "$ref": "#/$defs/status" },
+        "workspace_package": { "type": ["string", "null"] },
+        "declared_closure": { "type": "string", "minLength": 1 },
+        "required_capabilities": { "type": "array", "items": { "type": "string", "minLength": 1 }, "uniqueItems": true },
+        "forbidden_dependencies": { "type": "array", "items": { "type": "string", "minLength": 1 }, "uniqueItems": true },
+        "onboarding": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["commands", "concepts"],
+          "properties": {
+            "commands": { "type": "array", "items": { "type": "string", "minLength": 1 }, "uniqueItems": true },
+            "concepts": { "type": "array", "items": { "type": "string", "minLength": 1 }, "uniqueItems": true }
+          }
+        }
+      }
+    },
+    "deletionFixture": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "root_artifact", "root_package", "removed_packages", "forbidden_external_dependencies", "claim_boundary"],
+      "properties": {
+        "id": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]*$" },
+        "root_artifact": { "type": "string", "minLength": 1 },
+        "root_package": { "type": "string", "minLength": 1 },
+        "removed_packages": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 }, "uniqueItems": true },
+        "forbidden_external_dependencies": { "type": "array", "items": { "type": "string", "minLength": 1 }, "uniqueItems": true },
+        "claim_boundary": { "type": "string", "minLength": 1 }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add the machine-readable ADR-0049 artifact matrix and five-state schema
- add source-bound dependency and onboarding budget baselines
- prove the CLI/TUI workspace closure survives GUI removal
- wire the harness and positive/negative tests into the Shifu check gate

## Validation
- ./shifu layers:qualify -- --report /tmp/kungfu-layer-qualification-final.json
- ./shifu check:staged
- ./shifu check reaches the pre-existing run-freeze.js platform/arch type baseline after all new gates pass