### PR TITLE
feat(atlas): seal each import batch as one Episode

### DIFF
--- a/examples/probe-cpp/cmake/kungfu.cmake
+++ b/examples/probe-cpp/cmake/kungfu.cmake
@@ -14,7 +14,9 @@
 #     -DCMAKE_TOOLCHAIN_FILE=<repo>/framework/core/build/conan_toolchain.cmake
 #   cmake --build build
 
-set(CMAKE_CXX_STANDARD 17)
+# Match the core build (gnu++23): the public yijinjing schema headers use
+# C++20+ features, so extensions cannot compile against them with C++17.
+set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 get_filename_component(KF_CORE_DIR "${CMAKE_CURRENT_LIST_DIR}/../../../framework/core" ABSOLUTE)
@@ -28,6 +30,12 @@ list(PREPEND CMAKE_MODULE_PATH "${KF_CORE_DIR}/build")
 
 find_package(pybind11 REQUIRED)
 find_package(flatbuffers REQUIRED)
+# kungfu/common.h pulls fmt, nlohmann/json, spdlog, and boost::hana into the
+# public header surface, so every consumer of the libkungfu/libyijinjing
+# headers needs the same dependency set the yijinjing target exports.
+find_package(fmt REQUIRED)
+find_package(nlohmann_json REQUIRED)
+find_package(spdlog REQUIRED)
 
 # The built libkungfu shared library.
 find_library(KF_LIBKUNGFU
@@ -46,5 +54,13 @@ macro(kungfu_cpp_extension _target)
   target_include_directories(${_target} PRIVATE
     "${KF_CORE_DIR}/src/libkungfu/include"
     "${KF_CORE_DIR}/src/libyijinjing/include")
-  target_link_libraries(${_target} PRIVATE ${KF_LIBKUNGFU} flatbuffers::flatbuffers)
+  # boost::hana is header-only and vendored next to the core tree (the same
+  # copy the yijinjing target exports PUBLIC).
+  if(EXISTS "${KF_CORE_DIR}/.deps/hana-1.80.0/include")
+    target_include_directories(${_target} PRIVATE "${KF_CORE_DIR}/.deps/hana-1.80.0/include")
+  endif()
+  target_link_libraries(${_target} PRIVATE ${KF_LIBKUNGFU} flatbuffers::flatbuffers
+    $<IF:$<TARGET_EXISTS:fmt::fmt-header-only>,fmt::fmt-header-only,fmt::fmt>
+    $<IF:$<TARGET_EXISTS:spdlog::spdlog_header_only>,spdlog::spdlog_header_only,spdlog::spdlog>
+    nlohmann_json::nlohmann_json)
 endmacro()

--- a/framework/core/slices/fact-ledger/action_recorder.cpp
+++ b/framework/core/slices/fact-ledger/action_recorder.cpp
@@ -47,8 +47,8 @@ std::string payload_hash(const std::vector<uint8_t> &bytes, std::size_t length) 
 }
 
 uint64_t frame_checksum(const schema::types::frame_header &header, const std::vector<uint8_t> &bytes,
-                        std::size_t length) {
-  return action::checksum_frame(header, bytes.data(), static_cast<uint32_t>(length));
+                        std::size_t length, const std::string &algorithm) {
+  return action::checksum_frame(header, bytes.data(), static_cast<uint32_t>(length), algorithm);
 }
 
 void fail(const std::string &message) { std::cerr << "fact_ledger_action_recorder: " << message << "\n"; }
@@ -96,15 +96,16 @@ int main(int argc, char **argv) {
     const auto &bytes = frames[i].second;
     const auto expected_parent = i == 0 ? 0 : receipts[i - 1].frame_uid;
 
-    if (receipt.frame_uid != header.frame_uid || receipt.msg_type != header.msg_type ||
+    if (receipt.frame_uid != header.frame_uid || receipt.carrier_type != header.carrier_type ||
         receipt.gen_time != header.gen_time || receipt.stream_id != header.stream_id ||
         receipt.trigger_frame_uid != header.trigger_frame_uid || receipt.trigger_frame_uid != expected_parent ||
         receipt.data_length != payloads[i].size() || bytes.size() < payloads[i].size() ||
         !padding_is_zero(bytes, payloads[i].size()) ||
         payload_hash(bytes, payloads[i].size()) != payload_hash(payloads[i], payloads[i].size()) ||
-        receipt.integrity_version != 1 ||
-        receipt.payload_checksum != action::checksum_payload(bytes.data(), static_cast<uint32_t>(payloads[i].size())) ||
-        receipt.frame_checksum != frame_checksum(header, bytes, payloads[i].size())) {
+        receipt.integrity_version != action::DEFAULT_FRAME_INTEGRITY_VERSION ||
+        receipt.payload_checksum != action::checksum_payload(bytes.data(), static_cast<uint32_t>(payloads[i].size()),
+                                                             receipt.checksum_algorithm) ||
+        receipt.frame_checksum != frame_checksum(header, bytes, payloads[i].size(), receipt.checksum_algorithm)) {
       fail("receipt/readback mismatch at step " + std::to_string(i));
       return 1;
     }
@@ -112,7 +113,8 @@ int main(int argc, char **argv) {
 
   auto tampered = frames[0].second;
   tampered[0] ^= 0x01;
-  if (receipts[0].frame_checksum == frame_checksum(frames[0].first, tampered, payloads[0].size())) {
+  if (receipts[0].frame_checksum ==
+      frame_checksum(frames[0].first, tampered, payloads[0].size(), receipts[0].checksum_algorithm)) {
     fail("frame checksum did not detect payload mutation");
     return 1;
   }

--- a/framework/core/src/python/kungfu/atlas/payloads.py
+++ b/framework/core/src/python/kungfu/atlas/payloads.py
@@ -376,6 +376,7 @@ def write_import_payloads(
     source_type: str = "atlas",
     range_filter: dict[str, Any] | None = None,
     action_receipts: dict[tuple[str, str], dict[str, Any]] | None = None,
+    episode_id: int = 0,
 ) -> dict[str, Any]:
     store_dir = Path(store_dir)
     entries = []
@@ -408,6 +409,11 @@ def write_import_payloads(
     manifest = {
         "schema": "kungfu.atlas-import/v1",
         "import_id": import_id,
+        # Bidirectional index with the Episode manifest journal: the Episode
+        # source field carries "atlas:<import_id>" and this names the Episode
+        # that sealed the batch. Zero means the batch predates Episode
+        # association.
+        "episode_id": episode_id,
         "storage_source_id": storage_source_id,
         "source_type": source_type,
         "repo_root": repo_root,

--- a/framework/core/src/python/kungfu/atlas/store.py
+++ b/framework/core/src/python/kungfu/atlas/store.py
@@ -119,6 +119,28 @@ class ImportStore:
             "journal_payload_hash": payloads.payload_hash(data),
         }
 
+    def _attach_frame(self, episode_id, location_uid, receipt):
+        # The frame was already written once by this store's recorder; the
+        # Episode manifest only attaches the receipt (ADR-0033 v1 keeps mmap
+        # pages byte-compatible, association lives in EpisodeFrameAttached).
+        storage_service.episode_attach_frame(
+            self.runtime_dir,
+            episode_id=episode_id,
+            location_uid=location_uid,
+            frame_uid=int(receipt["frame_uid"]),
+            trigger_frame_uid=int(receipt["trigger_frame_uid"]),
+            stream_id=int(receipt["stream_id"]),
+            gen_time=int(receipt["gen_time"]),
+            trigger_time=int(receipt["trigger_time"]),
+            carrier_type=int(receipt["carrier_type"]),
+            source=int(receipt["source"]),
+            dest=int(receipt["dest"]),
+            data_length=int(receipt["data_length"]),
+            integrity_version=int(receipt["integrity_version"]),
+            payload_checksum=int(receipt["payload_checksum"]),
+            frame_checksum=int(receipt["frame_checksum"]),
+        )
+
     def run_import(
         self,
         repo_root,
@@ -134,88 +156,160 @@ class ImportStore:
             importer.read_control_plane_with_sources(repo_root, window=range_filter)
         )
         enriched_records = payloads.enrich_source_records(source_records)
-        action_receipts = {}
-        self._append_envelope(
-            payloads.build_action_envelope(
-                import_id=import_id,
-                storage_source_id=storage_source_id,
-                source_type="atlas",
-                action_type=ACTION_IMPORT_BEGIN,
-                batch={
-                    "repo_root": repo_root,
-                    "repo_head": repo_head,
-                    "schema_version": SCHEMA_VERSION,
-                },
-            )
+        # One import batch = one sealed Episode: ImportBegin, every snapshot
+        # frame, and ImportEnd are attached to one Episode so the batch gets a
+        # verifiable boundary (fsck verify_frames) and the qualification
+        # contract applies. No heartbeats: a batch is a short-lived
+        # single-writer burst, and the begin/attach/end records already carry
+        # its progress evidence; EpisodeHeartbeat exists for long-running
+        # lifecycles that need liveness between frames.
+        location_uid = int(_location(self.runtime_dir).uid)
+        begun = storage_service.episode_begin(
+            self.runtime_dir,
+            title=f"atlas import {import_id}",
+            actor=storage_source_id,
+            source=f"atlas:{import_id}",
+            location_uid=location_uid,
         )
-        for entry in enriched_records:
-            action_type = payloads.action_type_for_kind(str(entry.get("kind") or ""))
+        episode_id = int(begun["episode_id"])
+        frame_count = 0
+        last_frame_uid = 0
+        try:
             receipt = self._append_envelope(
                 payloads.build_action_envelope(
                     import_id=import_id,
                     storage_source_id=storage_source_id,
                     source_type="atlas",
-                    action_type=action_type,
-                    source={
-                        "kind": entry.get("kind"),
-                        "source_id": entry.get("source_id"),
-                        "source_path": entry.get("source_path"),
-                        "source_time": entry.get("source_time"),
-                        "schema_version": entry.get("schema_version"),
-                    },
-                    payload={
-                        "content_type": entry.get(
-                            "content_type", payloads.CONTENT_TYPE_JSON
-                        ),
-                        "hash_algorithm": payloads.CONTENT_HASH_ALGORITHM_SHA256,
-                        "hash": entry.get("payload_hash"),
-                        "byte_len": entry.get("byte_len"),
-                        "state": entry.get(
-                            "payload_state", payloads.PAYLOAD_STATE_PRESENT
-                        ),
+                    action_type=ACTION_IMPORT_BEGIN,
+                    batch={
+                        "repo_root": repo_root,
+                        "repo_head": repo_head,
+                        "schema_version": SCHEMA_VERSION,
                     },
                 )
             )
-            action_receipts[
-                (str(entry.get("kind") or ""), str(entry.get("source_id") or ""))
-            ] = receipt
-        self._append_envelope(
-            payloads.build_action_envelope(
+            self._attach_frame(episode_id, location_uid, receipt)
+            frame_count += 1
+            last_frame_uid = int(receipt["frame_uid"])
+            action_receipts = {}
+            for entry in enriched_records:
+                action_type = payloads.action_type_for_kind(
+                    str(entry.get("kind") or "")
+                )
+                receipt = self._append_envelope(
+                    payloads.build_action_envelope(
+                        import_id=import_id,
+                        storage_source_id=storage_source_id,
+                        source_type="atlas",
+                        action_type=action_type,
+                        source={
+                            "kind": entry.get("kind"),
+                            "source_id": entry.get("source_id"),
+                            "source_path": entry.get("source_path"),
+                            "source_time": entry.get("source_time"),
+                            "schema_version": entry.get("schema_version"),
+                        },
+                        payload={
+                            "content_type": entry.get(
+                                "content_type", payloads.CONTENT_TYPE_JSON
+                            ),
+                            "hash_algorithm": payloads.CONTENT_HASH_ALGORITHM_SHA256,
+                            "hash": entry.get("payload_hash"),
+                            "byte_len": entry.get("byte_len"),
+                            "state": entry.get(
+                                "payload_state", payloads.PAYLOAD_STATE_PRESENT
+                            ),
+                        },
+                    )
+                )
+                self._attach_frame(episode_id, location_uid, receipt)
+                frame_count += 1
+                last_frame_uid = int(receipt["frame_uid"])
+                action_receipts[
+                    (str(entry.get("kind") or ""), str(entry.get("source_id") or ""))
+                ] = receipt
+            receipt = self._append_envelope(
+                payloads.build_action_envelope(
+                    import_id=import_id,
+                    storage_source_id=storage_source_id,
+                    source_type="atlas",
+                    action_type=ACTION_IMPORT_END,
+                    batch={
+                        "missions": len(missions),
+                        "goals": len(goals),
+                        "markers": len(markers),
+                        "warnings": len(warnings),
+                    },
+                )
+            )
+            self._attach_frame(episode_id, location_uid, receipt)
+            frame_count += 1
+            last_frame_uid = int(receipt["frame_uid"])
+            manifest = payloads.write_import_payloads(
+                self.store_dir(),
                 import_id=import_id,
-                storage_source_id=storage_source_id,
-                source_type="atlas",
-                action_type=ACTION_IMPORT_END,
-                batch={
+                repo_root=repo_root,
+                repo_head=repo_head,
+                source_records=enriched_records,
+                counts={
                     "missions": len(missions),
                     "goals": len(goals),
                     "markers": len(markers),
-                    "warnings": len(warnings),
                 },
+                storage_source_id=storage_source_id,
+                source_type="atlas",
+                range_filter=range_filter,
+                action_receipts=action_receipts,
+                episode_id=episode_id,
             )
-        )
-        manifest = payloads.write_import_payloads(
-            self.store_dir(),
-            import_id=import_id,
-            repo_root=repo_root,
-            repo_head=repo_head,
-            source_records=enriched_records,
-            counts={
-                "missions": len(missions),
-                "goals": len(goals),
-                "markers": len(markers),
-            },
-            storage_source_id=storage_source_id,
-            source_type="atlas",
-            range_filter=range_filter,
-            action_receipts=action_receipts,
-        )
-        _mirror_generic_payloads(
-            self.runtime_dir, self.store_dir(), manifest.get("entries", [])
-        )
-        storage_service.accept_manifest(self.runtime_dir, manifest["storage_manifest"])
-        self.emit_manifest()
+            _mirror_generic_payloads(
+                self.runtime_dir, self.store_dir(), manifest.get("entries", [])
+            )
+            # ADR-0041 stage 4 order: the mirror above publishes the payload
+            # bytes into the provider content store first, then each ref
+            # claims their identity; episode fsck resolves refs by ref_hash
+            # through that same store. Only present payloads have published
+            # bytes; redacted/absent stay in the import manifest inventory.
+            attached_digests = set()
+            for entry in manifest.get("entries", []):
+                if entry.get("payload_state") != payloads.PAYLOAD_STATE_PRESENT:
+                    continue
+                digest = str(entry.get("payload_hash") or "")
+                if not digest or digest in attached_digests:
+                    continue
+                attached_digests.add(digest)
+                storage_service.episode_attach_ref(
+                    self.runtime_dir,
+                    episode_id=episode_id,
+                    location_uid=location_uid,
+                    ref_kind="payload",
+                    ref_id=str(entry.get("source_path") or digest),
+                    ref_hash=f"{payloads.CONTENT_HASH_ALGORITHM_SHA256}:{digest}",
+                )
+            storage_service.accept_manifest(
+                self.runtime_dir, manifest["storage_manifest"]
+            )
+            self.emit_manifest()
+            storage_service.episode_end(
+                self.runtime_dir,
+                episode_id=episode_id,
+                location_uid=location_uid,
+                last_frame_uid=last_frame_uid,
+                frame_count=frame_count,
+            )
+        except BaseException as error:
+            storage_service.episode_abort(
+                self.runtime_dir,
+                episode_id=episode_id,
+                location_uid=location_uid,
+                last_frame_uid=last_frame_uid,
+                frame_count=frame_count,
+                reason=f"{type(error).__name__}: {error}"[:256],
+            )
+            raise
         return {
             "import_id": import_id,
+            "episode_id": episode_id,
             "storage_source_id": storage_source_id,
             "source_type": "atlas",
             "repo_root": repo_root,
@@ -519,6 +613,7 @@ def status(runtime_dir):
         "ok": projection is not None,
         "scope": "atlas",
         "import_id": manifest.get("import_id"),
+        "episode_id": manifest.get("episode_id", 0),
         "storage_source_id": manifest.get("storage_source_id", "atlas"),
         "source_type": manifest.get("source_type", "atlas"),
         "range": manifest.get("range"),

--- a/framework/core/src/python/kungfu/cli/commands/atlas.py
+++ b/framework/core/src/python/kungfu/cli/commands/atlas.py
@@ -75,7 +75,7 @@ def import_cmd(ctx, repo_root, storage_source_id, since, from_time, until, as_js
     click.echo(
         f"[atlas] imported {result['import_id']}: {result['missions']} missions, "
         f"{result['goals']} goals, {result['markers']} markers "
-        f"({len(result['warnings'])} warning(s))"
+        f"({len(result['warnings'])} warning(s)) episode {result['episode_id']}"
     )
     for warning in result["warnings"]:
         click.echo(f"  warning: {warning}", err=True)

--- a/framework/core/src/python/kungfu/cli/commands/storage.py
+++ b/framework/core/src/python/kungfu/cli/commands/storage.py
@@ -104,9 +104,15 @@ def status(ctx, scope, storage_source_id, as_json):
 )
 @click.option("--source", "storage_source_id", type=str, default=None)
 @click.option("--episode-id", type=int, default=0)
+@click.option(
+    "--verify-frames",
+    is_flag=True,
+    help="episode scope only: re-read claimed event journals and verify each "
+    "attached frame receipt (presence, header, checksums)",
+)
 @click.option("--json", "as_json", is_flag=True, help="machine-readable output")
 @storage_command_context
-def fsck(ctx, scope, storage_source_id, episode_id, as_json):
+def fsck(ctx, scope, storage_source_id, episode_id, verify_frames, as_json):
     if scope == "atlas":
         from kungfu.atlas import store
 
@@ -119,10 +125,14 @@ def fsck(ctx, scope, storage_source_id, episode_id, as_json):
                 "[storage] --episode-id is required for --scope episode", err=True
             )
             sys.exit(2)
+        if verify_frames and scope != "episode":
+            click.echo("[storage] --verify-frames requires --scope episode", err=True)
+            sys.exit(2)
         result = service.fsck(
             ctx.runtime_dir,
             source_id=storage_source_id if scope == "source" else None,
             episode_id=episode_id if scope == "episode" else None,
+            verify_frames=verify_frames,
         )
     if as_json:
         _echo_json(result)

--- a/tests/fixtures/atlas-demo-import/check_import.py
+++ b/tests/fixtures/atlas-demo-import/check_import.py
@@ -5,7 +5,12 @@
 # stays authoritative). Runs inside the dev kfc environment (needs pykungfu).
 #
 # Usage: check_import.py <runtime-dir> <latest-import-id>
+#
+# The episode section is destructive at its end (it deletes the import event
+# journal to prove sealed-episode fsck catches the loss), so it must stay the
+# last section and the fixture must not reuse the runtime afterwards.
 
+import glob
 import hashlib
 import json
 import os
@@ -184,6 +189,100 @@ if os.path.exists(payload_manifest_path):
 
     fsck = store.fsck(runtime_dir)
     check("atlas store fsck passes", fsck.get("ok"), json.dumps(fsck.get("errors")))
+
+# ── episode: one import batch = one sealed Episode ────────────────────────
+from kungfu.storage import service as storage_service  # noqa: E402
+
+listed = storage_service.episode_list(runtime_dir, limit=0).get("episodes", [])
+atlas_episodes = [
+    row for row in listed if str(row.get("source") or "").startswith("atlas:imp")
+]
+check(
+    "one sealed episode per import batch",
+    len(atlas_episodes) == 2
+    and all(row.get("status") == "ended" for row in atlas_episodes),
+    f"got {[(row.get('episode_id'), row.get('status')) for row in atlas_episodes]}",
+)
+
+episode_id = 0
+if os.path.exists(payload_manifest_path):
+    episode_id = int(payload_manifest.get("episode_id") or 0)
+    check("manifest names the sealing episode", episode_id > 0, f"got {episode_id}")
+check(
+    "store status names the sealing episode",
+    store.status(runtime_dir).get("episode_id") == episode_id,
+)
+
+if episode_id:
+    inspected = storage_service.episode_inspect(runtime_dir, episode_id=episode_id)
+    episode = inspected.get("episode", {})
+    check(
+        "episode source names the import",
+        episode.get("source") == f"atlas:{latest_import_id}",
+        f"got {episode.get('source')}",
+    )
+    attached = inspected.get("frames", [])
+    check(
+        "episode frames == batch frames (begin + snapshots + end)",
+        len(attached) == len(entries) + 2,
+        f"got {len(attached)}, want {len(entries) + 2}",
+    )
+    payload_refs = [
+        ref for ref in inspected.get("refs", []) if ref.get("ref_kind") == "payload"
+    ]
+    present_hashes = {
+        entry.get("payload_hash")
+        for entry in entries
+        if entry.get("payload_state") == "present" and entry.get("payload_hash")
+    }
+    check(
+        "episode payload refs cover distinct present payloads",
+        len(payload_refs) == len(present_hashes),
+        f"got {len(payload_refs)}, want {len(present_hashes)}",
+    )
+
+    report = storage_service.fsck(
+        runtime_dir, episode_id=episode_id, verify_frames=True
+    )
+    check(
+        "episode fsck verify_frames green",
+        report.get("ok") is True and report.get("degraded") is False,
+        json.dumps(report.get("errors", []) + report.get("warnings", []))[:300],
+    )
+    check(
+        "every batch frame receipt verified",
+        report.get("checked", {}).get("episode_frames_verified") == len(entries) + 2,
+        f"got {report.get('checked', {}).get('episode_frames_verified')}",
+    )
+    qualification = report.get("qualification", {})
+    check(
+        "sealed batch qualifies for replay/depend_on",
+        "replay" in qualification.get("safe_capabilities", [])
+        and "depend_on" in qualification.get("safe_capabilities", []),
+        f"got {qualification.get('safe_capabilities')}",
+    )
+
+    # ── negative (destructive, keep last): losing the event journal must ──
+    # fail the sealed episode instead of passing silently — the exact P10
+    # blind spot: manifest present, projected journal page gone.
+    pages = glob.glob(
+        os.path.join(
+            runtime_dir, "journal", "**", "atlas", "import", "**", "*.journal"
+        ),
+        recursive=True,
+    )
+    check("import event journal pages found", len(pages) > 0)
+    for page in pages:
+        os.remove(page)
+    report = storage_service.fsck(
+        runtime_dir, episode_id=episode_id, verify_frames=True
+    )
+    codes = {error.get("code") for error in report.get("errors", [])}
+    check(
+        "sealed episode fails fsck after journal loss",
+        report.get("ok") is False and "episode_attached_frame_missing" in codes,
+        f"ok={report.get('ok')} codes={sorted(codes)}",
+    )
 
 print(f"[atlas-demo-import] {len(failures)} failure(s)")
 sys.exit(1 if failures else 0)

--- a/tests/fixtures/rewind-demo-approval/check_approval.py
+++ b/tests/fixtures/rewind-demo-approval/check_approval.py
@@ -19,6 +19,7 @@
 #
 # Usage: check_approval.py <fixture-dir>
 
+import hashlib
 import os
 import sys
 import types
@@ -31,11 +32,24 @@ core_src = os.path.abspath(
 )
 sys.path.insert(0, core_src)
 
+
+def _stub_sha256_value(payload, algorithm="sha256"):
+    # bundle.emit hashes the schema blob through kungfu.content_hash, which
+    # dispatches to the native binding. This fixture runs without pykungfu,
+    # so the stub answers only the sha256 default the binding would compute.
+    if algorithm != "sha256":
+        raise ValueError(f"stub binding only hashes sha256, got {algorithm}")
+    return hashlib.sha256(bytes(payload)).hexdigest()
+
+
 if "kungfu" not in sys.modules:
     _m = types.ModuleType("kungfu")
     _m.__path__ = [os.path.join(core_src, "kungfu")]
     _m.schema_data_path = lambda module_file, name: os.path.join(
         os.path.dirname(module_file), name
+    )
+    _m.__binding__ = types.SimpleNamespace(
+        runtime=types.SimpleNamespace(compute_content_hash_value=_stub_sha256_value)
     )
     sys.modules["kungfu"] = _m
 

--- a/tests/fixtures/rewind-demo-cost-wire/check_cost_wire.py
+++ b/tests/fixtures/rewind-demo-cost-wire/check_cost_wire.py
@@ -42,11 +42,25 @@ sys.path.insert(0, core_src)
 # kungfu.rewind.cost.* and kungfu.rewind.cost_wire still import from disk (none
 # of them touch the native binding). bundle.py calls kungfu.schema_data_path at
 # import time, so the stub provides the source-layout resolver.
+
+
+def _stub_sha256_value(payload, algorithm="sha256"):
+    # bundle.emit hashes the schema blob through kungfu.content_hash, which
+    # dispatches to the native binding. This wire test runs without pykungfu,
+    # so the stub answers only the sha256 default the binding would compute.
+    if algorithm != "sha256":
+        raise ValueError(f"stub binding only hashes sha256, got {algorithm}")
+    return hashlib.sha256(bytes(payload)).hexdigest()
+
+
 if "kungfu" not in sys.modules:
     _m = types.ModuleType("kungfu")
     _m.__path__ = [os.path.join(core_src, "kungfu")]
     _m.schema_data_path = lambda module_file, name: os.path.join(
         os.path.dirname(module_file), name
+    )
+    _m.__binding__ = types.SimpleNamespace(
+        runtime=types.SimpleNamespace(compute_content_hash_value=_stub_sha256_value)
     )
     sys.modules["kungfu"] = _m
 


### PR DESCRIPTION
## Summary

One `kungfu atlas import` batch now becomes one sealed Episode: `episode_begin` wraps ImportBegin, every snapshot frame receipt is attached through `episode_attach_frame`, payload identities are claimed with content-addressed refs after the mirror publishes the bytes, and ImportEnd seals the Episode. Failures abort the Episode with the error summary. This brings the atlas import batch into the Episode boundary, so `storage fsck --scope episode --verify-frames` covers atlas frames and the qualification contract (replay/depend_on) applies automatically.

- The import manifest, import result, and `storage status` name the sealing `episode_id`; the Episode source field carries `atlas:<import_id>` for the reverse index.
- `storage fsck` grows an explicit `--verify-frames` flag (episode scope only).
- No heartbeats: an import batch is a short-lived single-writer burst (~3s against a real control-plane repo); begin/attach/end already carry its progress evidence.
- The atlas-demo-import fixture asserts one sealed Episode per batch, full frame/ref coverage, a green verify_frames fsck, and — destructively, last — that deleting the import event journal fails the sealed Episode with `episode_attached_frame_missing` instead of passing silently.

## Verify-gate repairs

`verify --full` had not run since the schema-surface retirement and exposed three latent regressions, fixed here so the gate passes end to end:

- `fix(examples)`: the cpp probe could no longer compile against the public schema headers (missing fmt/nlohmann/spdlog/hana wiring, C++17 pin).
- `fix(slices)`: the fact-ledger recorder probe still compared the retired `msg_type` field and hardcoded integrity version 1.
- `fix(tests)`: the stub-only rewind fixtures died on the new native content-hash dispatch; their stub now answers the sha256 default only.

## Validation

- `./shifu verify --full`: 71/71 passed.
- Real control-plane repo smoke: import 3.1s, one sealed Episode, 1568 frames attached, 1566 payload refs, `fsck --verify-frames` green in 0.15s, qualification reports all capabilities safe.
- Fixture negative case proves the fsck blind spot is closed (manifest present + journal page lost -> failed, `episode_attached_frame_missing`).