### PR TITLE
shifu: self-update provenance, generations, and checkout-free upgrade

### DIFF
--- a/.github/workflows/release-shifu.yml
+++ b/.github/workflows/release-shifu.yml
@@ -60,6 +60,10 @@ jobs:
       - name: Build
         run: cargo build --release -p shifu --target "${{ matrix.target }}"
         working-directory: crates
+        env:
+          # Bake the "release" build channel so `shifu --version` can tell a
+          # release asset from a local source build.
+          SHIFU_RELEASE_BUILD: "1"
       - name: Stage asset
         run: |
           mkdir -p dist

--- a/build-local.env.example
+++ b/build-local.env.example
@@ -61,6 +61,9 @@
 # Where `shifu promote` installs (default /Applications, falling back to
 # ~/Applications when not writable; linux default ~/.local/bin):
 # export KUNGFU_PRODUCT_INSTALL_DIR="/Applications"
+# How many replaced shifu binaries `shifu self-update` archives for
+# --rollback (default 3; oldest generations retire automatically):
+# export KUNGFU_SHIFU_GENERATIONS_KEEP="3"
 
 # ── Entries not handled by this file — set via their own user-global config (also absent from this repo) ──
 #  npm package install registry + private @scope registry / token  →  ~/.npmrc

--- a/crates/shifu/build.rs
+++ b/crates/shifu/build.rs
@@ -26,5 +26,16 @@ fn main() {
         "cargo:rustc-env=SHIFU_GIT_SHA={sha}{}",
         if dirty { "-dirty" } else { "" }
     );
+    // Build channel: release binaries (built by release-shifu.yml with
+    // SHIFU_RELEASE_BUILD=1) identify as "release"; every local build — cargo
+    // install, the shim's source-fresh slots, self-update — is "source", so
+    // `shifu --version` always tells which supply chain the binary came from.
+    let channel = if std::env::var_os("SHIFU_RELEASE_BUILD").is_some_and(|v| v == "1") {
+        "release"
+    } else {
+        "source"
+    };
+    println!("cargo:rustc-env=SHIFU_BUILD_CHANNEL={channel}");
+    println!("cargo:rerun-if-env-changed=SHIFU_RELEASE_BUILD");
     println!("cargo:rerun-if-changed=../../.git/HEAD");
 }

--- a/crates/shifu/src/main.rs
+++ b/crates/shifu/src/main.rs
@@ -89,7 +89,11 @@ fn print_usage() {
     println!("  shifu self-update          refresh this installed binary in place");
     println!(
         "                             {}",
-        style::dim("(from checkout source, or --version <v> for a release)")
+        style::dim("(checkout source > local build slot; --version <v> for a")
+    );
+    println!(
+        "                             {}",
+        style::dim("release; --list generations; --rollback one step back)")
     );
     println!("  shifu promote [--launch]   install the freshest built dev kungfu");
     println!("  shifu builds               list registered dev builds");
@@ -258,9 +262,10 @@ fn version_line(root: Option<&Path>) -> String {
         "installed".to_string()
     };
     format!(
-        "shifu {} (git {}, {role})",
+        "shifu {} (git {}, {}, {role})",
         env!("CARGO_PKG_VERSION"),
         env!("SHIFU_GIT_SHA"),
+        env!("SHIFU_BUILD_CHANNEL"),
     )
 }
 

--- a/crates/shifu/src/self_update.rs
+++ b/crates/shifu/src/self_update.rs
@@ -1,47 +1,76 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// `shifu self-update` — refresh an installed shifu binary in place.
+// `shifu self-update` — refresh an installed shifu binary in place, with
+// provenance and a way back.
 //
 // Answered before repo delegation on purpose (like self-version): delegation
 // replaces the process with the checkout's launcher, and an update must act
-// on the binary the user actually invoked. Inside a checkout the freshest
-// truth is the checkout itself — build from source when cargo is present,
-// else fetch the release asset the checkout pins. Outside a checkout an
-// explicit `--version <v>` is required: guessing "latest" across a shared
-// release namespace is how updaters install the wrong thing.
+// on the binary the user actually invoked.
 //
-// Shim-cache copies are refused: the repo shim owns their lifecycle (slots
-// are content-addressed against the launcher source and retired
-// automatically), so updating one in place would only be overwritten.
+// Where the new binary comes from, in order:
 //
-// The replacement is a rename dance — stage next to the target, move the old
-// binary aside, move the new one in, restore on failure — so a failed update
-// never leaves the machine without a working shifu (the helper of last
-// resort must not be breakable by its own maintenance).
+//   1. --version <v>       the release asset, verified against SHA256SUMS —
+//                          also the explicit road back to the official build
+//   2. inside a checkout   built from the checkout's current source (cargo
+//                          present) — fresher than any stash can be
+//   3. local build slot    the newest source-fresh cache slot the repo shim
+//                          built (~/.cache/kungfu/shifu/<slot>/): the binary
+//                          that actually drove the last build, surviving its
+//                          worktree — so upgrading needs no checkout at all;
+//                          its full identity line prints before the swap
+//
+// Every replacement first archives the outgoing binary (this very process, so
+// its identity is compile-time exact) under .../shifu/generations/, keeping
+// KUNGFU_SHIFU_GENERATIONS_KEEP (default 3): `--list` shows the ledger,
+// `--rollback` restores the previous generation (archiving the current one,
+// so a rollback is itself reversible). The helper of last resort must not be
+// breakable by its own maintenance — a failed swap restores the old binary,
+// and a regretted swap is one verb away from undone.
+//
+// Shim-cache copies are refused: the repo shim owns their lifecycle.
 
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use shifu_core::bootstrap::{self, FetchSpec};
 use shifu_core::{host, style};
 
-use crate::util;
+use crate::{envfile, util};
 
 const DIST_BASE: &str = "https://github.com/kungfu-systems/kungfu/releases/download";
+const USAGE: &str = "usage: shifu self-update [--version <version> | --list | --rollback]";
+
+/// The running binary's own identity — exact by construction: these are the
+/// compile-time constants of the process doing the archiving.
+fn own_identity() -> (&'static str, &'static str, &'static str) {
+    (
+        env!("CARGO_PKG_VERSION"),
+        env!("SHIFU_GIT_SHA"),
+        env!("SHIFU_BUILD_CHANNEL"),
+    )
+}
 
 pub fn run(root: Option<&Path>, args: &[String]) -> ! {
     let mut version_arg: Option<String> = None;
+    let mut list = false;
+    let mut rollback = false;
     let mut iter = args.iter();
     while let Some(arg) = iter.next() {
         match arg.as_str() {
             "--version" => match iter.next() {
                 Some(v) => version_arg = Some(v.clone()),
-                None => util::die("usage: shifu self-update [--version <version>]"),
+                None => util::die(USAGE),
             },
-            _ => util::die("usage: shifu self-update [--version <version>]"),
+            "--list" => list = true,
+            "--rollback" => rollback = true,
+            _ => util::die(USAGE),
         }
+    }
+    if (list && rollback) || (version_arg.is_some() && (list || rollback)) {
+        util::die(USAGE);
     }
 
     let exe = env::current_exe()
@@ -51,11 +80,17 @@ pub fn run(root: Option<&Path>, args: &[String]) -> ! {
     let shim_cache = host::kungfu_cache_dir().join("shifu");
     if exe.starts_with(&shim_cache) {
         util::die(&format!(
-            "this copy is a repo-shim cache slot ({}) — the shim refreshes it automatically; \
-             to force a refresh remove the slot: rm -rf {}",
-            exe.display(),
-            exe.parent().unwrap_or(&shim_cache).display()
+            "this copy lives in the shifu cache ({}) — shim slots refresh themselves, and \
+             generations are restored with --rollback from the installed binary",
+            exe.display()
         ));
+    }
+
+    if list {
+        run_list();
+    }
+    if rollback {
+        run_rollback(&exe);
     }
 
     // Decide the replacement. An explicit --version always means the release
@@ -66,18 +101,19 @@ pub fn run(root: Option<&Path>, args: &[String]) -> ! {
     };
     let new_binary = if let Some(root) = source_root {
         build_from_source(root)
-    } else {
-        let version = version_arg
-            .or_else(|| root.and_then(pinned_version))
-            .unwrap_or_else(|| {
-                util::die(
-                    "outside a kungfu checkout the target must be explicit: \
-                     shifu self-update --version <version>",
-                )
-            });
+    } else if let Some(version) = version_arg.or_else(|| root.and_then(pinned_version)) {
         fetch_release(&version)
+    } else if let Some(slot) = newest_build_slot() {
+        announce_slot(&slot);
+        slot
+    } else {
+        util::die(
+            "nothing to update from: no local build slot exists yet — run inside a kungfu \
+             checkout, or pass an explicit release: shifu self-update --version <version>",
+        )
     };
 
+    archive_current(&exe);
     replace_binary(&exe, &new_binary);
     eprintln!(
         "\u{2705} {} {}",
@@ -90,6 +126,14 @@ pub fn run(root: Option<&Path>, args: &[String]) -> ! {
 
 fn cargo_path() -> Option<PathBuf> {
     host::find_on_path("cargo")
+}
+
+fn binary_name() -> &'static str {
+    if cfg!(windows) {
+        "shifu.exe"
+    } else {
+        "shifu"
+    }
 }
 
 /// The launcher release pin of a checkout (crates/shifu/Cargo.toml).
@@ -132,8 +176,7 @@ fn build_from_source(root: &Path) -> PathBuf {
         )),
         Err(e) => util::die(&format!("failed to run cargo: {e}")),
     }
-    let name = if cfg!(windows) { "shifu.exe" } else { "shifu" };
-    target_dir.join("release").join(name)
+    target_dir.join("release").join(binary_name())
 }
 
 /// Release asset name for the current platform (mirrors release-shifu.yml).
@@ -195,6 +238,256 @@ fn fetch_release(version: &str) -> PathBuf {
     };
     eprintln!("shifu: fetching release {}", style::bold(version));
     bootstrap::fetch(&spec).unwrap_or_else(|err| util::die(&err.to_string()))
+}
+
+// ---------------------------------------------------------------------------
+// Local build slots — the shim's source-fresh cache as an upgrade source.
+
+/// The newest binary among the shim's cache slots (release-pin and
+/// source-fresh alike), by binary mtime: the build most recently placed is
+/// the one most recently proven in use. Bookkeeping dirs are excluded.
+fn newest_build_slot() -> Option<PathBuf> {
+    let root = host::kungfu_cache_dir().join("shifu");
+    let entries = fs::read_dir(&root).ok()?;
+    let mut best: Option<(SystemTime, PathBuf)> = None;
+    for entry in entries.flatten() {
+        let dir = entry.path();
+        if !dir.is_dir() {
+            continue;
+        }
+        let name = entry.file_name().to_string_lossy().to_string();
+        if name == "generations" || name == "cargo-target" || name.contains(".tmp") {
+            continue;
+        }
+        let bin = dir.join(binary_name());
+        let Ok(meta) = bin.metadata() else {
+            continue;
+        };
+        let modified = meta.modified().unwrap_or(UNIX_EPOCH);
+        if best.as_ref().is_none_or(|(t, _)| modified > *t) {
+            best = Some((modified, bin));
+        }
+    }
+    best.map(|(_, bin)| bin)
+}
+
+/// A binary's full identity line, by asking it. Spawning is safe: --version
+/// answers before any delegation, and SHIFU_DELEGATED suppresses delegation
+/// entirely.
+fn identity_of(binary: &Path) -> Option<String> {
+    Command::new(binary)
+        .arg("--version")
+        .env("SHIFU_DELEGATED", "1")
+        .output()
+        .ok()
+        .filter(|out| out.status.success())
+        .and_then(|out| {
+            let text = String::from_utf8_lossy(&out.stdout);
+            text.lines().next().map(|line| line.trim().to_string())
+        })
+}
+
+/// Print the slot binary's identity before the swap: the user sees exactly
+/// what they are upgrading to.
+fn announce_slot(slot: &Path) {
+    let identity = identity_of(slot)
+        .unwrap_or_else(|| format!("(unidentifiable binary at {})", slot.display()));
+    eprintln!("shifu: upgrading to the newest local build slot:");
+    eprintln!("   {}", style::bold(&identity));
+}
+
+// ---------------------------------------------------------------------------
+// Generations — the archive of replaced binaries, and the way back.
+
+fn generations_dir() -> PathBuf {
+    host::kungfu_cache_dir().join("shifu").join("generations")
+}
+
+fn generations_keep() -> usize {
+    env::var("KUNGFU_SHIFU_GENERATIONS_KEEP")
+        .ok()
+        .and_then(|v| v.trim().parse::<usize>().ok())
+        .filter(|n| *n >= 1)
+        .unwrap_or(3)
+}
+
+fn epoch_now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+struct Generation {
+    dir: PathBuf,
+    version: String,
+    sha: String,
+    channel: String,
+    archived_at: u64,
+}
+
+/// All archived generations, newest first (slot names sort by zero-padded
+/// epoch seconds).
+fn generations() -> Vec<Generation> {
+    let root = generations_dir();
+    let Ok(entries) = fs::read_dir(&root) else {
+        return Vec::new();
+    };
+    let mut names: Vec<String> = entries
+        .flatten()
+        .filter(|e| e.path().is_dir())
+        .map(|e| e.file_name().to_string_lossy().to_string())
+        .filter(|name| !name.contains(".tmp") && !name.contains(".restoring"))
+        .collect();
+    names.sort();
+    names.reverse();
+    names
+        .into_iter()
+        .filter_map(|name| {
+            let dir = root.join(&name);
+            if !dir.join(binary_name()).is_file() {
+                return None;
+            }
+            let meta = fs::read_to_string(dir.join("meta.env")).ok()?;
+            let get = |key: &str| {
+                meta.lines()
+                    .filter_map(envfile::parse_line)
+                    .find(|(k, _)| *k == key)
+                    .map(|(_, v)| v.to_string())
+                    .unwrap_or_default()
+            };
+            Some(Generation {
+                version: get("KUNGFU_SHIFU_VERSION"),
+                sha: get("KUNGFU_SHIFU_SHA"),
+                channel: get("KUNGFU_SHIFU_CHANNEL"),
+                archived_at: get("KUNGFU_SHIFU_ARCHIVED_AT").parse().unwrap_or(0),
+                dir,
+            })
+        })
+        .collect()
+}
+
+fn age(archived_at: u64) -> String {
+    let secs = epoch_now().saturating_sub(archived_at);
+    if secs < 120 {
+        format!("{secs}s ago")
+    } else if secs < 7200 {
+        format!("{}m ago", secs / 60)
+    } else if secs < 172_800 {
+        format!("{}h ago", secs / 3600)
+    } else {
+        format!("{}d ago", secs / 86_400)
+    }
+}
+
+/// Archive the outgoing binary (this very process) before it is replaced.
+/// Best-effort: an archive failure warns but never blocks the update.
+fn archive_current(exe: &Path) {
+    let (version, sha, channel) = own_identity();
+    let slot = generations_dir().join(format!("{:012}-{sha}", epoch_now()));
+    let staging = slot.with_extension("tmp");
+    let _ = fs::remove_dir_all(&staging);
+    let placed = fs::create_dir_all(&staging).is_ok()
+        && fs::copy(exe, staging.join(binary_name())).is_ok()
+        && fs::write(
+            staging.join("meta.env"),
+            format!(
+                "KUNGFU_SHIFU_VERSION='{version}'\nKUNGFU_SHIFU_SHA='{sha}'\n\
+                 KUNGFU_SHIFU_CHANNEL='{channel}'\nKUNGFU_SHIFU_ARCHIVED_AT='{}'\n\
+                 KUNGFU_SHIFU_FROM='{}'\n",
+                epoch_now(),
+                exe.display()
+            ),
+        )
+        .is_ok()
+        && fs::rename(&staging, &slot).is_ok();
+    if !placed {
+        let _ = fs::remove_dir_all(&staging);
+        eprintln!(
+            "   {}",
+            style::yellow(
+                "warning: could not archive the current binary; --rollback will not reach it"
+            )
+        );
+        return;
+    }
+    // Retention: keep the newest KUNGFU_SHIFU_GENERATIONS_KEEP generations.
+    for stale in generations().into_iter().skip(generations_keep()) {
+        let _ = fs::remove_dir_all(&stale.dir);
+    }
+}
+
+fn run_list() -> ! {
+    let (version, sha, channel) = own_identity();
+    println!(
+        "{} shifu {version} (git {sha}, {channel})",
+        style::cyan("Installed:")
+    );
+    match newest_build_slot() {
+        Some(slot) => {
+            let line = identity_of(&slot).unwrap_or_else(|| slot.display().to_string());
+            println!("{} {line}", style::cyan("Local build slot:"));
+        }
+        None => println!("{} none", style::cyan("Local build slot:")),
+    }
+    let generations = generations();
+    if generations.is_empty() {
+        println!("{} none yet", style::cyan("Generations:"));
+    } else {
+        println!("{}", style::cyan("Generations (newest first):"));
+        for (index, generation) in generations.iter().enumerate() {
+            println!(
+                "  [{index}] shifu {} (git {}, {}) {}",
+                generation.version,
+                generation.sha,
+                generation.channel,
+                style::dim(&age(generation.archived_at)),
+            );
+        }
+        println!(
+            "\n{} shifu self-update --rollback restores [0]",
+            style::cyan("Next:")
+        );
+    }
+    std::process::exit(0)
+}
+
+/// Restore the newest generation. The current binary is archived first, so a
+/// rollback is itself reversible; the restored generation's slot is consumed.
+fn run_rollback(exe: &Path) -> ! {
+    let Some(generation) = generations().into_iter().next() else {
+        util::die(
+            "no generations to roll back to (they accumulate as self-update replaces binaries)",
+        );
+    };
+    eprintln!(
+        "\u{1f94b} {}",
+        style::bold(&format!(
+            "rolling back to shifu {} (git {}, {}, archived {})",
+            generation.version,
+            generation.sha,
+            generation.channel,
+            age(generation.archived_at)
+        ))
+    );
+    // Move the target generation aside first: archiving the current binary
+    // below prunes old generations, and the one being restored must survive
+    // both the prune and the consume-after-install.
+    let staging = generation.dir.with_extension("restoring");
+    let _ = fs::remove_dir_all(&staging);
+    if let Err(e) = fs::rename(&generation.dir, &staging) {
+        util::die(&format!("cannot stage the generation: {e}"));
+    }
+    archive_current(exe);
+    replace_binary(exe, &staging.join(binary_name()));
+    let _ = fs::remove_dir_all(&staging);
+    eprintln!(
+        "\u{2705} {} {}",
+        style::green("rolled back"),
+        style::bold(&exe.display().to_string())
+    );
+    eprintln!("   {}", style::dim("verify with: shifu --version"));
+    std::process::exit(0)
 }
 
 /// Rename-dance replacement: never a moment without a runnable binary at the

--- a/docs/rust-adoption.md
+++ b/docs/rust-adoption.md
@@ -112,12 +112,21 @@ The paved road for mode 1, as implemented for the launcher:
   checkout therefore always runs its own launcher code, never the last
   release. Machines without cargo keep the release-pinned path untouched.
 - **Self-update** — `shifu self-update` refreshes an installed binary in
-  place (answered before delegation, so it acts on the copy you invoked):
-  inside a checkout it rebuilds from source (or fetches the pinned release
-  when cargo is absent), outside one it requires an explicit
-  `--version <v>`; release downloads are verified against the release's
-  `SHA256SUMS` and the swap is a rename dance that restores the old binary
-  on failure. Shim-cache slots refuse it — the shim owns their lifecycle.
+  place (answered before delegation, so it acts on the copy you invoked).
+  Sources, in order: an explicit `--version <v>` fetches that release asset
+  (verified against the release's `SHA256SUMS`) — also the road back to the
+  official build; inside a checkout it rebuilds from the checkout's current
+  source; outside one it takes the newest local build slot the shim produced
+  (the binary that drove the last build, surviving its worktree), printing
+  that binary's full identity line before the swap. Every replacement first
+  archives the outgoing binary under a generations ledger
+  (`KUNGFU_SHIFU_GENERATIONS_KEEP`, default 3): `--list` shows it,
+  `--rollback` restores the previous generation — reversibly, since the
+  current binary is archived in turn. `shifu --version` names each binary's
+  build channel (`release` = CI release asset, `source` = any local build),
+  so which supply chain you are running is never a guess. The swap is a
+  rename dance that restores the old binary on failure; shim-cache slots
+  refuse the verb — the shim owns their lifecycle.
 - **Fallback** — when no release asset is reachable, the shims build from
   source if cargo is present, then fall back to the legacy in-script path, so
   no machine class is stranded.


### PR DESCRIPTION
Once a binary was replaced you could not tell what you were running, could not get back, and going forward required a source checkout. Now: build.rs bakes a build channel (release CI assets vs local source builds) that --version prints; every replacement archives the outgoing binary into a generations ledger (--list to inspect, --rollback to restore reversibly, KUNGFU_SHIFU_GENERATIONS_KEEP deep); and outside a checkout self-update takes the newest local build slot the shim produced — the binary that drove the last build, surviving its worktree — announcing its identity before the swap. Verified end to end with two distinguishable binaries: slot upgrade, ledger, double rollback, retention.