### PR TITLE
feat(core): assembled runtime becomes the macOS product form (ADR-0046 stage 2)

### DIFF
--- a/docs/MAP.md
+++ b/docs/MAP.md
@@ -50,6 +50,7 @@ and the map routes a question to whichever doc answers it.
 | Where are the Python / Node / framework adapter boundaries? | [`adapters.md`](adapters.md) | use | stable |
 | How do I install Python packages (pandas/torch-class) into Kungfu's runtime? | [`python-environments.md`](python-environments.md) + [ADR-0046](../framework/core/docs/adr/ADR-0046-rust-host-trunk-and-assembled-runtime.md) | use | stable |
 | How do I go from source to a binary? | [`buildchain.md`](buildchain.md) (+ [`../CONTRIBUTING.md`](../CONTRIBUTING.md)) | use | stable |
+| What Python runtime ships inside the product, and what was pruned from it? | [ADR-0050](../framework/core/docs/adr/ADR-0050-assembled-runtime-stdlib-pruning-policy.md) + [`buildchain.md`](buildchain.md) | why, verify | stable |
 | When (and when not) does a component get written in Rust, and how is one added? | [`rust-adoption.md`](rust-adoption.md) | why, use | stable |
 | What must never change about the `shifu` entrypoints (and why)? | [ADR-0044](../framework/core/docs/adr/ADR-0044-shifu-delegation-protocol.md) | why, verify | stable |
 | Where does a release binary come from, and how do I verify it? | `provenance.md` | verify | blocked · needs release infra |

--- a/docs/buildchain.md
+++ b/docs/buildchain.md
@@ -28,9 +28,27 @@ under those pinned tools.
 | `libkungfu` (C++ core: yijinjing schema + journal) | `framework/core/src` | CMake + Conan 2; build orchestration in `framework/core/.gyp/` |
 | Python binding (`py_kungfu`) | `framework/core/src/bindings/python` | pybind11, built under the pinned CPython |
 | Node addon (`kungfu_node.node`) | `framework/core/src/bindings/node` | N-API via the `.gyp` build |
-| `kungfu` (the frozen runtime) | the above + embedded Python/Node runtimes | `./shifu freeze` |
-| distributable products | frozen runtime + GUI/TUI/CLI + all product-declared first-party kfx | `./shifu dist` |
+| `kungfu` (the product runtime) | the above + the Python/Node runtimes | `./shifu freeze` — on macOS this assembles the complete pinned CPython tree next to the entry (ADR-0046 stage 2); on Linux/Windows it still Nuitka-freezes until those platform legs land |
+| distributable products | product runtime + GUI/TUI/CLI + all product-declared first-party kfx | `./shifu dist` |
 | product loops | SDK-distributed GUI/TUI/CLI dev/build verbs | single kfx: `kungfu sdk product gui dev`; product assembly: `kungfu sdk product gui dist`; repo dogfood via `./shifu product ...` |
+
+## Freeze retirement ledger (macOS exited 2026-07-11)
+
+ADR-0046 stage 2 retires freezing platform by platform. What remains of the
+freeze machinery, and why, while the window is open:
+
+| Leg | Status | Retires when |
+|---|---|---|
+| `run-freeze.js` nuitka leg + the `nuitka-project` header in `kungfu_cli.py` (the `nofollow-import` list) | **kept** — Linux/Windows still freeze | the last frozen platform exits |
+| `run-freeze.js` pyinstaller fallback leg | **kept but off every default**; no platform selects it | with the nuitka leg — retire both together |
+| `conanfile.py` legacy freeze path (its `freezer` option + PyInstaller import) | **dead code** — freeze left conan in the conan2 migration; the option is no longer passed by the build chain | first conanfile cleanup touching that section |
+| `engage nuitka` / `engage pdm` bridges | **kept, deliberately** — their consumer is the Python-AOT kfx build contract (`kungfu sdk kfx build` for py extensions), not the freeze chain; retirement follows the ADR-0045 execution-profile line, not this ledger |
+| Nuitka / PyInstaller pins in `uv.lock` dev deps | **kept** — the frozen platforms and the engage bridge still resolve them | with their last consumer above |
+
+The assembled form's own policy record is
+[ADR-0050](../framework/core/docs/adr/ADR-0050-assembled-runtime-stdlib-pruning-policy.md)
+(stdlib pruning); the target architecture is
+[ADR-0046](../framework/core/docs/adr/ADR-0046-rust-host-trunk-and-assembled-runtime.md).
 
 ## Where the prebuilt binaries come from
 

--- a/framework/core/.gyp/run-build.js
+++ b/framework/core/.gyp/run-build.js
@@ -104,6 +104,13 @@ function build() {
   // With libnode colocated above, pykungfu imports — regenerate its .pyi stubs
   // from the fresh binding so committed stubs/ track the C++ (see gen-stubs.js).
   require('./gen-stubs').main();
+  // The pykungfu wheel ships in dist/kungfu/wheels — the product install
+  // surface (`kungfu env`) resolves it from there. Build it with the binding
+  // so every build/rebuild leaves a wheel matching the fresh natives; before
+  // this only the gyp kfc chain built it, and the product dist chain shipped
+  // without wheels (run-freeze copyWheel warned but could not fail).
+  // run-wheel.js ends with process.exit, so spawn it instead of requiring.
+  shell.run(process.execPath, [path.join(__dirname, 'run-wheel.js')], true);
   stage();
   cpVsDependencies();
 }

--- a/framework/core/.gyp/run-conan.js
+++ b/framework/core/.gyp/run-conan.js
@@ -88,13 +88,16 @@ function makeConanOptions(names) {
 }
 
 // conan2：-if/-bf → --output-folder；arch 是 setting 由 profile 自测，不再作 -o 选项。
+// freezer 不再透传给 conan：freeze 已迁出 conan（Stage C → run-freeze.js），
+// conanfile 的 freezer option 只喂 conan2 下不可达的遗留 package() 路径；产品
+// 形态选择（含 macOS 平台默认 assemble）完全由 run-freeze.js 决定。
 function conanInstall() {
   ensureBuildchainConanProfile();
   const settings = [
     ...makeConanSettings(['build_type']),
     ...platformConanSettings(),
   ];
-  const options = makeConanOptions(['log_level', 'freezer']);
+  const options = makeConanOptions(['log_level']);
   conan([
     'install',
     '.',
@@ -111,7 +114,7 @@ function conanBuild() {
     ...makeConanSettings(['build_type']),
     ...platformConanSettings(),
   ];
-  const options = makeConanOptions(['log_level', 'freezer']);
+  const options = makeConanOptions(['log_level']);
   conan(['build', '.', '--output-folder', 'build', ...settings, ...options]);
 }
 
@@ -124,7 +127,7 @@ function conanPackage() {
     ...makeConanSettings(['build_type']),
     ...platformConanSettings(),
   ];
-  const options = makeConanOptions(['log_level', 'freezer']);
+  const options = makeConanOptions(['log_level']);
   conan(['build', '.', '--output-folder', 'build', ...settings, ...options]);
 }
 

--- a/framework/core/.gyp/run-freeze.js
+++ b/framework/core/.gyp/run-freeze.js
@@ -4,10 +4,12 @@
 //
 // 背景：conan2 移除了独立 `conan package` 本地命令，原 `freeze`→run-conan.js package
 // 只触发 `conan build`（占位，不跑 freezer）。本脚本把 freeze 做成 `./shifu freeze`
-// 一步可复现，并据 `config.freezer` 选择 Nuitka（默认）或 PyInstaller（fallback）。
+// 一步可复现，并据 `config.freezer` 选择产物腿；缺省按平台：macOS=assemble
+// （ADR-0046 stage 2，组装完整 CPython 树），Linux/Windows=nuitka（各自平台腿
+// 落地前维持冻结）。
 //
-// 两条 freezer 路径（可人 2026-06-17 决策 Nuitka 2.x，不行回退 PyInstaller；
-// .v4 线 Nuitka 三平台已跑通，见 docs/conan2-migration.md §4c）：
+// 三条产物腿（nuitka/pyinstaller 见 docs/conan2-migration.md §4c；assemble 见
+// ADR-0046 与本文件 assemble 段注释）：
 //
 // - nuitka（默认）：编译成 C，产物 kungfu_cli.dist 本就扁平（无 _internal），移到 dist/kungfu 即可，
 //   不需要 promote。kungfu_cli.py 内嵌 nuitka-project 选项（--standalone 等）。Nuitka 只跟随
@@ -38,7 +40,12 @@ function buildType() {
 }
 
 function freezer() {
-  return shell.getConfigValue('freezer') || 'nuitka';
+  // ADR-0046 stage 2 rolls out platform by platform: macOS ships the
+  // assembled runtime; Linux/Windows keep nuitka until their legs land.
+  // An explicit config value still selects any leg on any platform.
+  const explicit = shell.getConfigValue('freezer');
+  if (explicit) return explicit;
+  return process.platform === 'darwin' ? 'assemble' : 'nuitka';
 }
 
 // kungfu.spec datas 引用 build/include 与 build/libs（仅 pyinstaller 路径需要）。

--- a/framework/core/.gyp/run-freeze.js
+++ b/framework/core/.gyp/run-freeze.js
@@ -8,8 +8,8 @@
 // （ADR-0046 stage 2，组装完整 CPython 树），Linux/Windows=nuitka（各自平台腿
 // 落地前维持冻结）。
 //
-// 三条产物腿（nuitka/pyinstaller 见 docs/conan2-migration.md §4c；assemble 见
-// ADR-0046 与本文件 assemble 段注释）：
+// 三条产物腿（assemble 见 ADR-0046 与本文件 assemble 段注释；冻结腿去留记账见
+// docs/buildchain.md「Freeze retirement ledger」）：
 //
 // - nuitka（默认）：编译成 C，产物 kungfu_cli.dist 本就扁平（无 _internal），移到 dist/kungfu 即可，
 //   不需要 promote。kungfu_cli.py 内嵌 nuitka-project 选项（--standalone 等）。Nuitka 只跟随

--- a/framework/core/docs/adr/ADR-0046-rust-host-trunk-and-assembled-runtime.md
+++ b/framework/core/docs/adr/ADR-0046-rust-host-trunk-and-assembled-runtime.md
@@ -17,7 +17,9 @@
   delegation; the trunk is its runtime sibling);
   [ADR-0045](ADR-0045-kfx-execution-profiles-native-rust-wasm.md) (extension
   execution profiles; both ADRs draw on the same Rust line, at different
-  layers: 0045 places extensions, this ADR places the host).
+  layers: 0045 places extensions, this ADR places the host);
+  [ADR-0050](ADR-0050-assembled-runtime-stdlib-pruning-policy.md) (the
+  stage-2 stdlib pruning policy, the own record stage 2 calls for).
 
 ## Question
 

--- a/framework/core/docs/adr/ADR-0050-assembled-runtime-stdlib-pruning-policy.md
+++ b/framework/core/docs/adr/ADR-0050-assembled-runtime-stdlib-pruning-policy.md
@@ -1,0 +1,129 @@
+# ADR-0050: Stdlib pruning policy for the assembled runtime
+
+- Status: accepted
+- Date: 2026-07-11
+- Category: distribution — product image content policy
+- Subsystem: the assembled runtime distribution (the `assemble` leg of
+  `framework/core/.gyp/run-freeze.js`, the interpreter tree under
+  `dist/kungfu/python`)
+- Related: [ADR-0046](ADR-0046-rust-host-trunk-and-assembled-runtime.md)
+  (stage 2 requires this policy "decided here, in its own record"; this is
+  that record)
+
+## Question
+
+The assembled distribution ships a complete python-build-standalone prefix
+instead of a frozen subset. Complete is the point — but the full prefix
+carries families the product has no path to (tk GUIs, an in-tree pip, C
+headers). What may be removed from the shipped tree, by what mechanism, and
+under what maintenance discipline — given that the freezer's hand-maintained
+`nofollow-import` exclusion surface is precisely the disease ADR-0046 stage 2
+retires, and this policy must not grow back into it?
+
+## Drivers
+
+1. **The nofollow disease, named.** The frozen leg's exclusion list grows
+   with development activity — every new Python dependency can demand a new
+   entry — and a miss fails at runtime in the field (missing module) or
+   silently bloats the binary. Any pruning policy whose maintenance scales
+   with dependency count, or whose failure mode is a field incident,
+   recreates what this stage exists to retire.
+2. **The install-surface contract.** The tree ships with pip inside it
+   otherwise: a resolvable `python -m pip` inside the product tree is a
+   standing silent bypass of the kungfu-owned install surface —
+   ADR-0046 violation criterion 5 in shipped form.
+3. **Size is secondary, not zero.** Measured on macOS arm64 (CPython
+   3.13.14 install_only prefix): full tree 68M, pruned 56M. Worth taking
+   when the mechanism is sound; never worth a maintenance surface that
+   grows.
+
+## Decision
+
+### 1. Family-level subtraction only
+
+The policy removes **whole families that have no intersection with product
+semantics**, never individual modules chased along an import graph. First
+fill (the manifest is the authority; this list is its rationale):
+
+- the tcl/tk family — `tkinter`, `idlelib`, `turtle`, the tcl/tk runtime
+  libraries (no kungfu path opens a tk window);
+- `pip` + `ensurepip` — a contract action as much as a size one: removing
+  the in-tree pip closes the silent-bypass door, leaving uv as the only
+  install engine (the tree's `EXTERNALLY-MANAGED` marker refuses a stray
+  host-python pip even before this — pruning removes the engine itself);
+- C headers (`include/`) and `bin/` auxiliaries (`idle3`, `pip3`,
+  `pydoc3`, `python3-config`) — build-time surfaces, not runtime ones.
+
+The subtraction is from a **fixed** stdlib: new product dependencies land in
+site-packages and never interact with this list. The manifest does not grow
+with development activity, by construction.
+
+### 2. Declarative manifest, fail-closed on staleness
+
+The policy lives in `product/stdlib-prune.json`
+(schema `kungfu.stdlib-prune/v1`): prefix-relative paths under a `common`
+section plus per-platform sections, `*` globs covering version-suffixed
+names. The assemble leg enforces two properties at build time:
+
+- **an entry that matches nothing stops the build** — the manifest must
+  describe the tree it prunes, so pbs layout drift surfaces at build time,
+  not as silent shipping of a family believed pruned;
+- **an entry that escapes the tree root stops the build**.
+
+An absent manifest means the full tree ships — the mechanism defaults to
+completeness, not to pruning.
+
+### 3. Failure direction: fail-safe
+
+The two lists fail in opposite directions, and this is the load-bearing
+difference rather than a nicety: a missed `nofollow` entry ships a broken
+runtime to the field; a missed prune entry ships a few extra megabytes. A
+*wrong* prune entry (a family the product actually needs) is caught where
+everything else is: `verify --full` dogfoods the assembled tree through the
+real probe chain, and the wrong-runtime guard plus product smoke run on the
+pruned tree, not the full one.
+
+### 4. Maintenance discipline
+
+A manifest change is one data edit plus the build's own assertions — no
+code. Adding a family requires the same argument this record makes for the
+first fill: the family must be semantically disjoint from the product, not
+merely unused today. Per-platform sections carry platform layout differences
+(the macOS section holds the tcl/tk runtime library paths of the darwin
+prefix); a platform leg landing later (Linux, Windows) extends its own
+section against its own tree, gated by the same fail-closed assertions.
+
+## Alternatives considered
+
+- **No pruning (ship the full 68M prefix).** Zero manifest, zero mechanism —
+  legitimate if the ~12M and the list are judged not worth each other. It
+  loses the contract action, though: the in-tree pip stays a resolvable
+  bypass engine. Rejected for the pip door more than for the megabytes.
+- **Import-graph pruning (cut the 24M stdlib to the observed closure).**
+  Recreates the nofollow disease exactly: the list grows with code, a miss
+  fails at runtime in the field. Rejected against this record's own driver 1;
+  taking it would be self-refuting.
+
+## Consequences
+
+- The macOS assembled tree ships 56M instead of 68M; net dist growth against
+  the retired frozen form stays where ADR-0046 accounted it.
+- `import tkinter` and `python -m pip` inside the product tree fail by
+  construction — the first is out-of-scope surface, the second is the
+  install-surface contract holding by mechanism.
+- pbs layout drift (a renamed tcl directory, a repathed pip) breaks the
+  assemble build loudly at the manifest assertion, which is the designed
+  place to notice it.
+
+## Violation criteria
+
+Record against this ADR any change that:
+
+1. adds a prune entry to chase an individual module or to resolve a
+   dependency conflict (import-graph creep — the disease returning);
+2. makes pruning a step that must be revisited when a Python dependency is
+   added (maintenance coupling to development activity);
+3. weakens the fail-closed assertions (a non-matching entry that warns
+   instead of stopping the build);
+4. restores an install engine inside the product tree, or removes the
+   `EXTERNALLY-MANAGED` refusal, without an explicit named bypass decision.

--- a/framework/core/docs/adr/README.md
+++ b/framework/core/docs/adr/README.md
@@ -67,6 +67,7 @@ A record's **Status** says where it stands:
 | [0047](ADR-0047-authoritative-facts-hana-pod-or-flatbuffers.md) | accepted; staged | authoritative structured facts have one schema owner — Hana POD or FlatBuffers |
 | [0048](ADR-0048-runtime-fact-query-semantics-and-changelog.md) | accepted; staged | runtime fact queries use explicit bases, one logical plan, and a proof-carrying changelog |
 | [0049](ADR-0049-layer-complete-products-and-domain-neutral-core.md) | accepted; staged | every product layer is independently complete and the core remains domain-neutral |
+| [0050](ADR-0050-assembled-runtime-stdlib-pruning-policy.md) | accepted | stdlib pruning policy for the assembled runtime — family-level subtraction, declarative fail-closed manifest |
 
 ## Reading by theme
 

--- a/framework/core/package.json
+++ b/framework/core/package.json
@@ -27,8 +27,7 @@
     "build_type": "Release",
     "log_level": "trace",
     "python_version": "3.13",
-    "node_version": "22.22.3",
-    "freezer": "nuitka"
+    "node_version": "22.22.3"
   },
   "binary": {
     "module_name": "kungfu_node",

--- a/product/scripts/dist.mjs
+++ b/product/scripts/dist.mjs
@@ -621,6 +621,18 @@ function assertCoreFrozen() {
       }
     }
   }
+  // The product install surface (`kungfu env`) resolves the pykungfu wheel
+  // from dist/kungfu/wheels. A bare dev freeze only warns when the wheel is
+  // missing; the product chain must not ship without it.
+  const wheels = path.join(CORE_DIST, 'wheels');
+  const hasWheel =
+    fs.existsSync(wheels) &&
+    fs.readdirSync(wheels).some((f) => f.endsWith('.whl'));
+  if (!hasWheel) {
+    throw new Error(
+      `no pykungfu wheel under ${rel(wheels)}; the install surface would ship unusable`,
+    );
+  }
 }
 
 // ADR-0046 stage 1: kungfu-trunk (the product trunk carrying the kungfu-owned

--- a/product/scripts/dist.mjs
+++ b/product/scripts/dist.mjs
@@ -607,6 +607,20 @@ function assertCoreFrozen() {
   if (!fs.existsSync(kungfuBin)) {
     throw new Error(`freeze did not produce ${rel(kungfuBin)}`);
   }
+  // Assembled form (ADR-0046 stage 2): when the dist carries the interpreter
+  // tree, it must be well-formed — the host marker declares the form and the
+  // tree's python3 is the real sys.executable the entry execs.
+  const tree = path.join(CORE_DIST, 'python');
+  if (fs.existsSync(tree)) {
+    for (const required of [
+      path.join(tree, 'kungfu-host.json'),
+      path.join(tree, 'bin', 'python3'),
+    ]) {
+      if (!fs.existsSync(required)) {
+        throw new Error(`assembled runtime tree incomplete: ${rel(required)}`);
+      }
+    }
+  }
 }
 
 // ADR-0046 stage 1: kungfu-trunk (the product trunk carrying the kungfu-owned

--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -20,9 +20,9 @@
 //   ./shifu verify --help
 //
 // Assertion targets (all grounded in the build scripts, not guessed):
-//   - framework/core/dist/kungfu/                     freeze artifact directory (run-freeze.js renameSync target)
+//   - framework/core/dist/kungfu/                     product core dist (run-freeze.js target; frozen or assembled form)
 //   - framework/core/dist/kungfu/kungfu[.exe]           kungfu executable (path resolved by lib/executable.js)
-//   - `kungfu --version` exits 0 and output contains the expected version   frozen Python runtime runs end to end (runtime smoke)
+//   - `kungfu --version` exits 0 and output contains the expected version   product Python runtime runs end to end (runtime smoke)
 //   - framework/gui/out/                           (--with-app) build:app electron-vite artifact
 //
 // Exit codes: all green 0; any failed assertion 1 (fail-fast prints copy-pastable troubleshooting info).
@@ -418,10 +418,10 @@ function main() {
     try {
       runPnpm('rebuild:core'); // clean + build:conan C++/wheel/native
       // Freeze before the dogfood probes: the extension build they run is
-      // `kungfu sdk kfx build`, which launches the frozen kungfu runtime — so
+      // `kungfu sdk kfx build`, which launches the product kungfu runtime — so
       // dist/kungfu must exist first. (Before the kfs→`kungfu sdk` move the
       // probe used a plain-node bin and could run pre-freeze; it can't now.)
-      runPnpm('freeze'); // nuitka → framework/core/dist/kungfu
+      runPnpm('freeze'); // platform leg (macOS assemble / others nuitka) → framework/core/dist/kungfu
       // C++ dogfood probe: compile the reference cpp kfx against the freshly
       // built libkungfu (headers + shared lib + FlatBuffers) into a native
       // module. If a core capability regresses, this build breaks here.
@@ -506,6 +506,29 @@ function main() {
         `not found ${path.relative(ROOT, kungfuBin)} (freeze first)`,
       );
       kungfuBin = null;
+    }
+    // Assembled form (ADR-0046 stage 2): when the dist carries the
+    // interpreter tree, it must be well-formed — the host marker declares
+    // the form and the tree's python3 is the real sys.executable the entry
+    // execs. A frozen dist has no python/ tree and skips this assertion.
+    const assembledTree = path.join(distDir, 'python');
+    if (fs.existsSync(assembledTree)) {
+      const required = [
+        path.join(assembledTree, 'kungfu-host.json'),
+        path.join(assembledTree, 'bin', 'python3'),
+      ];
+      const missing = required.filter((p) => !fs.existsSync(p));
+      if (!missing.length) {
+        pass(
+          'assembled runtime tree well-formed',
+          path.relative(ROOT, assembledTree),
+        );
+      } else {
+        fail(
+          'assembled runtime tree well-formed',
+          `missing ${missing.map((p) => path.relative(ROOT, p)).join(', ')}`,
+        );
+      }
     }
   } else {
     fail(


### PR DESCRIPTION
ADR-0046 stage 2, macOS leg — the freezer config default is now platform-conditional (assemble on macOS, nuitka elsewhere), the conan chain stops threading the retired freezer option, and both product gates (dist.mjs, verify) assert the assembled tree is well-formed.

Evidence on macOS arm64:
- verify --full passes 71/71 on the assembled form (probes, slices, fixtures, episode qualification, ASan/UBSan replay).
- Product chain green end to end: CLI archive (interpreter tree + wheels inside, installed-layout smoke) and desktop app (assembled tree with symlinks intact under Resources, single-runtime audit, zip+dmg).
- Startup parity: assembled kungfu --version 0.17-0.19s vs frozen 0.19s baseline; native env subtree at ms-class.
- Tree ships 56M pruned (68M full); total dist 209M, net flat against the frozen form.

Also lands, each in its own commit:
- ADR-0048: the stdlib pruning policy record stage 2 calls for, plus the freeze retirement ledger in docs/buildchain.md.
- Drift fixes the full gate surfaced: the cpp probe closes over the core's public header surface (fmt/spdlog/nlohmann/hana, C++23), the fact-ledger slice follows carrier_type/integrity-v2, the binding-less rewind fixtures stub kungfu.content_hash.
- The product chain builds the pykungfu wheel on every build and hard-fails a wheel-less dist (the first assembled product build shipped without the install surface and only warned).

Linux/Windows keep the frozen path until their platform legs land.