### PR TITLE
feat(query): add proof-carrying episode authority scan

### DIFF
--- a/framework/core/src/libkungfu/include/kungfu/runtime/query/fact_query.h
+++ b/framework/core/src/libkungfu/include/kungfu/runtime/query/fact_query.h
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef KUNGFU_RUNTIME_QUERY_FACT_QUERY_H
+#define KUNGFU_RUNTIME_QUERY_FACT_QUERY_H
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include <nlohmann/json.hpp>
+
+namespace kungfu::runtime::query {
+
+inline constexpr const char *QUERY_DEFINITION_SCHEMA_V1 = "kungfu.query.definition/v1";
+inline constexpr const char *QUERY_RESULT_SCHEMA_V1 = "kungfu.query.result/v1";
+inline constexpr const char *QUERY_LINEAGE_SCHEMA_V1 = "kungfu.query.lineage/v1";
+inline constexpr const char *QUERY_RESULT_ROW_SCHEMA_V1 = "kungfu.query.episode-row/v1";
+
+enum class cut_kind { Head, ManifestFrameUid };
+
+struct cut {
+  cut_kind kind = cut_kind::Head;
+  uint64_t manifest_frame_uid = 0;
+};
+
+struct query_policy {
+  std::string fold = "episode-manifest-fold/v1";
+  std::string schema = "kungfu.episode.manifest/v1";
+  std::string engine = "episode-authority-scan/v1";
+  std::string conflict = "preserve-source-claims/v1";
+  std::string redaction = "report-missing-evidence/v1";
+};
+
+// ADR-0048 Q0: the result is unique only under this declared basis. These are
+// C++-owned semantic fields; bindings translate edge JSON but do not infer a
+// second basis.
+struct query_basis {
+  std::string scope = "episode-manifest";
+  uint64_t episode_id = 0;
+  std::string perspective = "manifest-append-order";
+  cut selected_cut = {};
+  query_policy policy = {};
+  std::string valid_time = "not-projected";
+  std::string system_time = "manifest-gen-time";
+  std::string causal_time = "manifest-order-and-episode-refs";
+};
+
+struct query_definition {
+  std::string schema = QUERY_DEFINITION_SCHEMA_V1;
+  query_basis basis = {};
+  std::string object = "episodes";
+  uint64_t limit = 100;
+  std::string evidence = "proof";
+};
+
+struct result_field {
+  std::string name = {};
+  std::string type = {};
+  bool nullable = false;
+};
+
+struct result_schema {
+  std::string schema = QUERY_RESULT_ROW_SCHEMA_V1;
+  std::vector<result_field> fields = {};
+};
+
+struct lineage {
+  std::string schema = QUERY_LINEAGE_SCHEMA_V1;
+  nlohmann::json authority = nlohmann::json::object();
+  nlohmann::json cut = nlohmann::json::object();
+  nlohmann::json policy_versions = nlohmann::json::object();
+  nlohmann::json time_basis = nlohmann::json::object();
+  std::string determinism = "deterministic";
+  std::vector<nlohmann::json> episode_content_roots = {};
+  std::vector<nlohmann::json> missing_inputs = {};
+  std::vector<nlohmann::json> unverifiable_inputs = {};
+  std::string query_definition_hash = {};
+};
+
+struct query_result {
+  std::string schema = QUERY_RESULT_SCHEMA_V1;
+  query_definition definition = {};
+  result_schema row_schema = {};
+  std::vector<nlohmann::json> rows = {};
+  lineage proof = {};
+  std::string result_hash = {};
+};
+
+[[nodiscard]] query_definition parse_query_definition(const nlohmann::json &value);
+
+[[nodiscard]] nlohmann::json query_definition_json(const query_definition &definition);
+
+[[nodiscard]] nlohmann::json query_result_json(const query_result &result);
+
+[[nodiscard]] query_result run_episode_authority_scan(const std::string &runtime_dir,
+                                                      const query_definition &definition);
+
+} // namespace kungfu::runtime::query
+
+#endif // KUNGFU_RUNTIME_QUERY_FACT_QUERY_H

--- a/framework/core/src/libkungfu/include/kungfu/runtime/storage/service.h
+++ b/framework/core/src/libkungfu/include/kungfu/runtime/storage/service.h
@@ -8,6 +8,8 @@
 
 #include <nlohmann/json.hpp>
 
+#include <kungfu/runtime/query/fact_query.h>
+
 namespace kungfu::runtime::storage_service_api {
 
 inline constexpr const char *RUNTIME_STORAGE_SERVICE_SCHEMA_V1 = "kungfu.runtime.storage-service/v1";
@@ -67,6 +69,7 @@ enum class storage_operation {
   CompactPlan,
   VerifySync,
   Query,
+  FactQuery,
   Layout,
   EpisodeBegin,
   EpisodeHeartbeat,
@@ -100,6 +103,7 @@ struct storage_service_options {
   nlohmann::json bundle = nlohmann::json::object();
   nlohmann::json manifest = nlohmann::json::object();
   nlohmann::json operation_options = nlohmann::json::object();
+  nlohmann::json query_definition = nlohmann::json::object();
   std::string query = {};
   std::string kind = {};
   uint64_t episode_id = 0;
@@ -133,6 +137,8 @@ public:
   [[nodiscard]] virtual nlohmann::json verify_sync(const storage_service_options &options) const = 0;
 
   [[nodiscard]] virtual nlohmann::json query(const storage_service_options &options) const = 0;
+
+  [[nodiscard]] virtual nlohmann::json fact_query(const storage_service_options &options) const = 0;
 
   [[nodiscard]] virtual nlohmann::json layout(const storage_service_options &options) const = 0;
 

--- a/framework/core/src/libkungfu/src/runtime/query/fact_query.cpp
+++ b/framework/core/src/libkungfu/src/runtime/query/fact_query.cpp
@@ -1,0 +1,299 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#include <kungfu/runtime/query/fact_query.h>
+
+#include <algorithm>
+#include <charconv>
+#include <stdexcept>
+#include <string>
+
+#include <kungfu/yijinjing/storage/content_hash.h>
+#include <kungfu/yijinjing/storage/episode_manifest.h>
+
+namespace kungfu::runtime::query {
+
+namespace yy_storage = kungfu::yijinjing::storage;
+
+namespace {
+
+uint64_t uint64_value(const nlohmann::json &value, const char *field) {
+  if (value.is_number_unsigned()) {
+    return value.get<uint64_t>();
+  }
+  if (value.is_number_integer()) {
+    const auto signed_value = value.get<int64_t>();
+    if (signed_value >= 0) {
+      return static_cast<uint64_t>(signed_value);
+    }
+  }
+  if (value.is_string()) {
+    const auto text = value.get<std::string>();
+    uint64_t parsed = 0;
+    const auto [end, error] = std::from_chars(text.data(), text.data() + text.size(), parsed);
+    if (error == std::errc{} && end == text.data() + text.size()) {
+      return parsed;
+    }
+  }
+  throw std::invalid_argument(std::string("invalid unsigned query field: ") + field);
+}
+
+uint64_t optional_uint64(const nlohmann::json &object, const char *field, uint64_t fallback = 0) {
+  if (!object.is_object() || !object.contains(field) || object.at(field).is_null()) {
+    return fallback;
+  }
+  return uint64_value(object.at(field), field);
+}
+
+std::string optional_text(const nlohmann::json &object, const char *field, const std::string &fallback = {}) {
+  if (!object.is_object() || !object.contains(field) || object.at(field).is_null()) {
+    return fallback;
+  }
+  if (!object.at(field).is_string()) {
+    throw std::invalid_argument(std::string("invalid text query field: ") + field);
+  }
+  return object.at(field).get<std::string>();
+}
+
+nlohmann::json cut_json(const cut &value) {
+  if (value.kind == cut_kind::Head) {
+    return {{"kind", "head"}};
+  }
+  return {{"kind", "manifest_frame_uid"}, {"manifest_frame_uid", std::to_string(value.manifest_frame_uid)}};
+}
+
+nlohmann::json policy_json(const query_policy &policy) {
+  return {{"fold", policy.fold},
+          {"schema", policy.schema},
+          {"engine", policy.engine},
+          {"conflict", policy.conflict},
+          {"redaction", policy.redaction}};
+}
+
+nlohmann::json result_schema_json(const result_schema &schema) {
+  auto fields = nlohmann::json::array();
+  for (const auto &field : schema.fields) {
+    fields.push_back({{"name", field.name}, {"type", field.type}, {"nullable", field.nullable}});
+  }
+  return {{"schema", schema.schema}, {"fields", fields}};
+}
+
+std::string json_hash(const nlohmann::json &value) {
+  return yy_storage::format_content_hash(yy_storage::compute_content_hash(value.dump(-1, ' ', false)));
+}
+
+result_schema episode_result_schema() {
+  return {QUERY_RESULT_ROW_SCHEMA_V1,
+          {{"episode_id", "uint64", false},
+           {"status", "string", false},
+           {"opened", "boolean", false},
+           {"closed", "boolean", false},
+           {"begin_time", "int64", true},
+           {"end_time", "int64", true},
+           {"record_count", "uint64", false},
+           {"frame_count", "uint64", false},
+           {"ref_count", "uint64", false},
+           {"content_root", "string", true},
+           {"content_root_status", "string", false}}};
+}
+
+nlohmann::json resolved_cut_json(const yy_storage::episode_manifest_fold &fold) {
+  if (fold.total_record_count == 0) {
+    return {{"kind", "empty"}};
+  }
+  return {{"kind", "manifest_frame_uid"}, {"manifest_frame_uid", std::to_string(fold.last_manifest_frame_uid)}};
+}
+
+} // namespace
+
+query_definition parse_query_definition(const nlohmann::json &value) {
+  if (!value.is_object()) {
+    throw std::invalid_argument("query definition must be an object");
+  }
+  query_definition definition;
+  definition.schema = optional_text(value, "schema", QUERY_DEFINITION_SCHEMA_V1);
+  if (definition.schema != QUERY_DEFINITION_SCHEMA_V1) {
+    throw std::invalid_argument("unsupported query definition schema: " + definition.schema);
+  }
+  definition.object = optional_text(value, "object", "episodes");
+  if (definition.object != "episodes") {
+    throw std::invalid_argument("ADR-0048 Q0 supports only object=episodes");
+  }
+  definition.limit = optional_uint64(value, "limit", 100);
+  if (definition.limit == 0 || definition.limit > 1000) {
+    throw std::invalid_argument("ADR-0048 Q0 requires 1 <= limit <= 1000");
+  }
+  definition.evidence = optional_text(value, "evidence", "proof");
+
+  const auto basis = value.value("basis", nlohmann::json::object());
+  definition.basis.scope = optional_text(basis, "scope", "episode-manifest");
+  if (definition.basis.scope != "episode-manifest") {
+    throw std::invalid_argument("ADR-0048 Q0 supports only scope=episode-manifest");
+  }
+  definition.basis.episode_id = optional_uint64(basis, "episode_id");
+  definition.basis.perspective = optional_text(basis, "perspective", "manifest-append-order");
+  if (definition.basis.perspective != "manifest-append-order") {
+    throw std::invalid_argument("ADR-0048 Q0 supports only perspective=manifest-append-order");
+  }
+
+  const auto selected_cut = basis.value("cut", nlohmann::json{{"kind", "head"}});
+  const auto cut_name = optional_text(selected_cut, "kind", "head");
+  if (cut_name == "head") {
+    definition.basis.selected_cut.kind = cut_kind::Head;
+  } else if (cut_name == "manifest_frame_uid") {
+    definition.basis.selected_cut.kind = cut_kind::ManifestFrameUid;
+    definition.basis.selected_cut.manifest_frame_uid = optional_uint64(selected_cut, "manifest_frame_uid");
+    if (definition.basis.selected_cut.manifest_frame_uid == 0) {
+      throw std::invalid_argument("manifest_frame_uid cut requires a non-zero token");
+    }
+  } else {
+    throw std::invalid_argument("unsupported query cut: " + cut_name);
+  }
+
+  const auto policy = basis.value("policy", nlohmann::json::object());
+  definition.basis.policy.fold = optional_text(policy, "fold", definition.basis.policy.fold);
+  definition.basis.policy.schema = optional_text(policy, "schema", definition.basis.policy.schema);
+  definition.basis.policy.engine = optional_text(policy, "engine", definition.basis.policy.engine);
+  definition.basis.policy.conflict = optional_text(policy, "conflict", definition.basis.policy.conflict);
+  definition.basis.policy.redaction = optional_text(policy, "redaction", definition.basis.policy.redaction);
+  const auto time_basis = basis.value("time_basis", nlohmann::json::object());
+  definition.basis.valid_time = optional_text(time_basis, "valid_time", definition.basis.valid_time);
+  definition.basis.system_time = optional_text(time_basis, "system_time", definition.basis.system_time);
+  definition.basis.causal_time = optional_text(time_basis, "causal_time", definition.basis.causal_time);
+  const query_policy supported_policy{};
+  if (definition.basis.policy.fold != supported_policy.fold ||
+      definition.basis.policy.schema != supported_policy.schema ||
+      definition.basis.policy.engine != supported_policy.engine ||
+      definition.basis.policy.conflict != supported_policy.conflict ||
+      definition.basis.policy.redaction != supported_policy.redaction) {
+    throw std::invalid_argument("unsupported ADR-0048 Q0 policy version");
+  }
+  const query_basis supported_basis{};
+  if (definition.basis.valid_time != supported_basis.valid_time ||
+      definition.basis.system_time != supported_basis.system_time ||
+      definition.basis.causal_time != supported_basis.causal_time) {
+    throw std::invalid_argument("unsupported ADR-0048 Q0 time basis");
+  }
+  return definition;
+}
+
+nlohmann::json query_definition_json(const query_definition &definition) {
+  return {{"schema", definition.schema},
+          {"basis",
+           {{"scope", definition.basis.scope},
+            {"episode_id", std::to_string(definition.basis.episode_id)},
+            {"perspective", definition.basis.perspective},
+            {"cut", cut_json(definition.basis.selected_cut)},
+            {"policy", policy_json(definition.basis.policy)},
+            {"time_basis",
+             {{"valid_time", definition.basis.valid_time},
+              {"system_time", definition.basis.system_time},
+              {"causal_time", definition.basis.causal_time}}}}},
+          {"object", definition.object},
+          {"limit", definition.limit},
+          {"evidence", definition.evidence}};
+}
+
+nlohmann::json query_result_json(const query_result &result) {
+  auto rows = nlohmann::json::array();
+  for (const auto &row : result.rows) {
+    rows.push_back(row);
+  }
+  auto roots = nlohmann::json::array();
+  for (const auto &root : result.proof.episode_content_roots) {
+    roots.push_back(root);
+  }
+  auto missing = nlohmann::json::array();
+  for (const auto &item : result.proof.missing_inputs) {
+    missing.push_back(item);
+  }
+  auto unverifiable = nlohmann::json::array();
+  for (const auto &item : result.proof.unverifiable_inputs) {
+    unverifiable.push_back(item);
+  }
+  return {{"schema", result.schema},
+          {"definition", query_definition_json(result.definition)},
+          {"result_schema", result_schema_json(result.row_schema)},
+          {"rows", rows},
+          {"row_count", rows.size()},
+          {"result_hash", result.result_hash},
+          {"lineage",
+           {{"schema", result.proof.schema},
+            {"query_definition_hash", result.proof.query_definition_hash},
+            {"authority", result.proof.authority},
+            {"cut", result.proof.cut},
+            {"policy_versions", result.proof.policy_versions},
+            {"time_basis", result.proof.time_basis},
+            {"determinism", result.proof.determinism},
+            {"episode_content_roots", roots},
+            {"missing_inputs", missing},
+            {"unverifiable_inputs", unverifiable}}}};
+}
+
+query_result run_episode_authority_scan(const std::string &runtime_dir, const query_definition &definition) {
+  yy_storage::episode_manifest_store store(runtime_dir);
+  const auto fold = definition.basis.selected_cut.kind == cut_kind::Head
+                        ? store.fold_typed_records()
+                        : store.fold_typed_records_until(definition.basis.selected_cut.manifest_frame_uid);
+
+  query_result result;
+  result.definition = definition;
+  result.row_schema = episode_result_schema();
+  result.proof.query_definition_hash = json_hash(query_definition_json(definition));
+  result.proof.authority = {{"kind", "yijinjing-journal"},
+                            {"schema", yy_storage::EPISODE_MANIFEST_SCHEMA_V1},
+                            {"first_manifest_frame_uid", std::to_string(fold.first_manifest_frame_uid)},
+                            {"last_manifest_frame_uid", std::to_string(fold.last_manifest_frame_uid)},
+                            {"record_count", fold.total_record_count},
+                            {"unknown_record_count", fold.unknown_record_count},
+                            {"unfolded_record_count", fold.unfolded_record_count}};
+  result.proof.cut = {{"declared", cut_json(definition.basis.selected_cut)},
+                      {"resolved", fold.cut_found ? resolved_cut_json(fold) : nlohmann::json{{"kind", "unresolved"}}},
+                      {"inclusive", true}};
+  result.proof.policy_versions = policy_json(definition.basis.policy);
+  result.proof.time_basis = {{"valid_time", definition.basis.valid_time},
+                             {"system_time", definition.basis.system_time},
+                             {"causal_time", definition.basis.causal_time}};
+
+  if (!fold.cut_found) {
+    result.proof.missing_inputs.push_back(
+        {{"kind", "manifest_cut"},
+         {"manifest_frame_uid", std::to_string(definition.basis.selected_cut.manifest_frame_uid)}});
+    result.proof.determinism = "unverifiable";
+  }
+  if (fold.unknown_record_count != 0) {
+    result.proof.unverifiable_inputs.push_back(
+        {{"kind", "manifest_unknown_records"}, {"count", fold.unknown_record_count}});
+    result.proof.determinism = "unverifiable";
+  }
+
+  if (fold.cut_found) {
+    for (const auto &[episode_id, view] : fold.episodes) {
+      if (definition.basis.episode_id != 0 && episode_id != definition.basis.episode_id) {
+        continue;
+      }
+      auto row = yy_storage::episode_summary_json(view);
+      const auto content_root = yy_storage::episode_content_root_json(view, fold.unknown_record_count);
+      row["content_root_status"] = content_root.at("status");
+      if (!row.contains("content_root")) {
+        row["content_root"] = nullptr;
+      }
+      result.rows.push_back(row);
+      result.proof.episode_content_roots.push_back({{"episode_id", std::to_string(episode_id)},
+                                                    {"status", content_root.at("status")},
+                                                    {"recorded", content_root.at("recorded")},
+                                                    {"computed", content_root.at("computed")}});
+      if (definition.limit != 0 && result.rows.size() >= definition.limit) {
+        break;
+      }
+    }
+  }
+  if (definition.basis.episode_id != 0 && result.rows.empty() && fold.cut_found) {
+    result.proof.missing_inputs.push_back(
+        {{"kind", "episode"}, {"episode_id", std::to_string(definition.basis.episode_id)}});
+  }
+
+  result.result_hash = json_hash({{"result_schema", result_schema_json(result.row_schema)}, {"rows", result.rows}});
+  return result;
+}
+
+} // namespace kungfu::runtime::query

--- a/framework/core/src/libkungfu/src/runtime/storage/service.cpp
+++ b/framework/core/src/libkungfu/src/runtime/storage/service.cpp
@@ -21,6 +21,7 @@
 #include <vector>
 
 #include <kungfu/runtime/action_recorder.h>
+#include <kungfu/runtime/query/fact_query.h>
 #include <kungfu/runtime/storage/episode_manifest_projection.h>
 #include <kungfu/runtime/storage/manifest_catalog_projection.h>
 #include <kungfu/runtime/storage/source_registry_projection.h>
@@ -3269,6 +3270,11 @@ public:
     return query_sqlite_projection(options);
   }
 
+  [[nodiscard]] nlohmann::json fact_query(const storage_service_options &options) const override {
+    const auto definition = query::parse_query_definition(options.query_definition);
+    return query::query_result_json(query::run_episode_authority_scan(options.runtime_dir, definition));
+  }
+
   [[nodiscard]] nlohmann::json layout(const storage_service_options &options) const override {
     const auto provider = shared_provider(options);
     return workspace_episode_layout(options, *provider);
@@ -3404,6 +3410,7 @@ std::vector<std::string> storage_operation_names() {
       storage_operation_name(storage_operation::CompactPlan),
       storage_operation_name(storage_operation::VerifySync),
       storage_operation_name(storage_operation::Query),
+      storage_operation_name(storage_operation::FactQuery),
       storage_operation_name(storage_operation::Layout),
       storage_operation_name(storage_operation::EpisodeBegin),
       storage_operation_name(storage_operation::EpisodeHeartbeat),
@@ -3449,6 +3456,8 @@ std::string storage_operation_name(storage_operation operation) {
     return "verify_sync";
   case storage_operation::Query:
     return "query";
+  case storage_operation::FactQuery:
+    return "fact_query";
   case storage_operation::Layout:
     return "layout";
   case storage_operation::EpisodeBegin:
@@ -3526,6 +3535,9 @@ storage_operation parse_storage_operation(const std::string &operation) {
   if (operation == "query") {
     return storage_operation::Query;
   }
+  if (operation == "fact_query") {
+    return storage_operation::FactQuery;
+  }
   if (operation == "layout") {
     return storage_operation::Layout;
   }
@@ -3598,6 +3610,7 @@ storage_service_options parse_storage_service_options(const std::string &runtime
   parsed.bundle = object_or_empty(options, "bundle");
   parsed.manifest = object_or_empty(options, "manifest");
   parsed.operation_options = options;
+  parsed.query_definition = object_or_empty(options, "definition");
   parsed.query = text_or(options, "query", "entries");
   parsed.kind = text_or(options, "kind");
   parsed.episode_id = uint64_or(options, "episode_id");
@@ -3614,6 +3627,8 @@ nlohmann::json make_storage_service_request(const std::string &operation, const 
     request["query"] = parsed_options.query;
     request["kind"] = parsed_options.kind.empty() ? nlohmann::json(nullptr) : nlohmann::json(parsed_options.kind);
     request["limit"] = parsed_options.limit;
+  } else if (parsed_operation == storage_operation::FactQuery) {
+    request["definition"] = parsed_options.query_definition;
   } else if (parsed_operation == storage_operation::Layout) {
     request["runtime_home"] = runtime_home_path(parsed_options).string();
     request["runtime_home_source"] = runtime_home_source(parsed_options);
@@ -3662,6 +3677,8 @@ nlohmann::json run_storage_service_operation(const std::string &operation, const
     return storage_service_instance().verify_sync(parsed_options);
   case storage_operation::Query:
     return storage_service_instance().query(parsed_options);
+  case storage_operation::FactQuery:
+    return storage_service_instance().fact_query(parsed_options);
   case storage_operation::Layout:
     return storage_service_instance().layout(parsed_options);
   case storage_operation::EpisodeBegin:

--- a/framework/core/src/libyijinjing/include/kungfu/yijinjing/storage/episode_manifest.h
+++ b/framework/core/src/libyijinjing/include/kungfu/yijinjing/storage/episode_manifest.h
@@ -170,7 +170,18 @@ struct episode_manifest_fold {
   size_t total_record_count = 0;
   size_t unknown_record_count = 0;
   size_t unfolded_record_count = 0;
+  uint64_t first_manifest_frame_uid = 0;
+  uint64_t last_manifest_frame_uid = 0;
+  int64_t last_manifest_gen_time = 0;
+  bool cut_found = true;
 };
+
+// Stable edge projections of one typed folded view. Query/reference paths use
+// these helpers so list/inspect and authority-scan cannot silently derive
+// different Episode row or content-root semantics.
+[[nodiscard]] nlohmann::json episode_summary_json(const episode_current_view &view);
+
+[[nodiscard]] nlohmann::json episode_content_root_json(const episode_current_view &view, size_t unknown_record_count);
 
 // ADR-0043: the content root of one Episode's owned claim sequence — a linear
 // hash chain over the covered records in manifest append order (the first
@@ -231,6 +242,11 @@ public:
   // Fold the journal into the typed current views (the canonical in-memory
   // derivation shared by list/inspect/fsck and future projection/query).
   [[nodiscard]] episode_manifest_fold fold_typed_records() const;
+
+  // Historical reference fold: admit records in manifest append order through
+  // the exact frame uid (inclusive). The uid is a stable token, not a sortable
+  // time value. cut_found is false when the requested token is absent.
+  [[nodiscard]] episode_manifest_fold fold_typed_records_until(uint64_t manifest_frame_uid) const;
 
   // Edge projections over the typed fold. JSON is produced here and only here.
   [[nodiscard]] nlohmann::json list(uint64_t location_uid = 0, uint64_t limit = 100) const;

--- a/framework/core/src/libyijinjing/src/storage/episode_manifest.cpp
+++ b/framework/core/src/libyijinjing/src/storage/episode_manifest.cpp
@@ -328,6 +328,11 @@ uint64_t record_episode_id(const episode_manifest_record &record) {
 // first-open-wins; watermarks are last-writer-wins; collections keep append
 // order including duplicates.
 void fold_into(episode_manifest_fold &fold, const episode_manifest_record &record) {
+  if (fold.total_record_count == 0) {
+    fold.first_manifest_frame_uid = record.manifest_frame_uid;
+  }
+  fold.last_manifest_frame_uid = record.manifest_frame_uid;
+  fold.last_manifest_gen_time = record.manifest_gen_time;
   ++fold.total_record_count;
   if (std::holds_alternative<episode_manifest_unknown_record>(record.body)) {
     ++fold.unknown_record_count;
@@ -720,6 +725,12 @@ std::string episode_root_chain_link(size_t index, const std::string &previous, c
 
 } // namespace
 
+nlohmann::json episode_summary_json(const episode_current_view &view) { return summary_json(view); }
+
+nlohmann::json episode_content_root_json(const episode_current_view &view, size_t unknown_record_count) {
+  return content_root_json(view, unknown_record_count);
+}
+
 episode_content_root compute_episode_content_root(const episode_current_view &view) {
   episode_content_root root{};
   root.algorithm = CONTENT_HASH_ALGORITHM_SHA256;
@@ -993,6 +1004,23 @@ std::vector<episode_manifest_record> episode_manifest_store::read_typed_records(
 episode_manifest_fold episode_manifest_store::fold_typed_records() const {
   episode_manifest_fold fold;
   for_each_typed_record([&fold](const episode_manifest_record &record) { fold_into(fold, record); });
+  return fold;
+}
+
+episode_manifest_fold episode_manifest_store::fold_typed_records_until(uint64_t manifest_frame_uid) const {
+  episode_manifest_fold fold;
+  fold.cut_found = false;
+  bool complete = false;
+  for_each_typed_record([&](const episode_manifest_record &record) {
+    if (complete) {
+      return;
+    }
+    fold_into(fold, record);
+    if (record.manifest_frame_uid == manifest_frame_uid) {
+      fold.cut_found = true;
+      complete = true;
+    }
+  });
   return fold;
 }
 

--- a/framework/core/src/python/kungfu/storage/service.py
+++ b/framework/core/src/python/kungfu/storage/service.py
@@ -613,6 +613,46 @@ def episode_inspect(runtime_dir: str | Path, *, episode_id: int) -> dict[str, An
     )
 
 
+def fact_query(
+    runtime_dir: str | Path,
+    *,
+    episode_id: int = 0,
+    cut: dict[str, Any] | None = None,
+    limit: int = 100,
+) -> dict[str, Any]:
+    """Run the ADR-0048 Q0 Episode authority-scan reference query."""
+
+    definition = {
+        "schema": "kungfu.query.definition/v1",
+        "basis": {
+            "scope": "episode-manifest",
+            "episode_id": _u64(episode_id),
+            "perspective": "manifest-append-order",
+            "cut": cut or {"kind": "head"},
+            "policy": {
+                "fold": "episode-manifest-fold/v1",
+                "schema": "kungfu.episode.manifest/v1",
+                "engine": "episode-authority-scan/v1",
+                "conflict": "preserve-source-claims/v1",
+                "redaction": "report-missing-evidence/v1",
+            },
+            "time_basis": {
+                "valid_time": "not-projected",
+                "system_time": "manifest-gen-time",
+                "causal_time": "manifest-order-and-episode-refs",
+            },
+        },
+        "object": "episodes",
+        "limit": limit,
+        "evidence": "proof",
+    }
+    return dict(
+        _runtime().run_storage_service_operation(
+            "fact_query", str(runtime_dir), {"definition": definition}
+        )
+    )
+
+
 def episode_recover(
     runtime_dir: str | Path,
     *,

--- a/framework/core/tests/python/test_atlas_storage.py
+++ b/framework/core/tests/python/test_atlas_storage.py
@@ -375,6 +375,7 @@ def test_runtime_storage_service_surface_is_bound_from_libkungfu(tmp_path):
         "compact_plan",
         "verify_sync",
         "query",
+        "fact_query",
         "layout",
         "episode_begin",
         "episode_heartbeat",
@@ -669,6 +670,107 @@ def test_episode_manifest_v1_is_yijinjing_backed_and_fscked(tmp_path):
     assert bundle["dependencies"][0]["status"] == "declared_external"
     assert bundle["record_count"] == 5
     assert bundle["frame_count"] == 1
+
+
+def test_fact_query_reproduces_head_and_historical_episode_cuts(tmp_path):
+    runtime_dir = tmp_path / "runtime"
+    opened = storage_service.episode_begin(
+        runtime_dir,
+        episode_id=1048,
+        title="query basis proof",
+        actor="pytest",
+        source="adr-0048-q0",
+        begin_time=1000,
+    )
+    attached = storage_service.episode_attach_frame(
+        runtime_dir,
+        episode_id=1048,
+        frame_uid=2001,
+        trigger_frame_uid=0,
+        stream_id=48,
+        gen_time=1100,
+        carrier_type=10803,
+        source=1,
+        dest=0,
+        data_length=12,
+        integrity_version=2,
+        payload_checksum=123,
+        frame_checksum=456,
+    )
+    storage_service.episode_end(
+        runtime_dir,
+        episode_id=1048,
+        end_time=1200,
+        last_frame_uid=2001,
+        frame_count=1,
+        reason="done",
+    )
+
+    records = storage_service.episode_inspect(runtime_dir, episode_id=1048)["records"]
+    attached_record = next(
+        record
+        for record in records
+        if record["record_kind"] == "episode_frame_attached"
+    )
+    historical_cut = {
+        "kind": "manifest_frame_uid",
+        "manifest_frame_uid": str(attached_record["manifest_frame_uid"]),
+    }
+    historical = storage_service.fact_query(
+        runtime_dir, episode_id=1048, cut=historical_cut
+    )
+    repeated = storage_service.fact_query(
+        runtime_dir, episode_id=1048, cut=historical_cut
+    )
+    head = storage_service.fact_query(runtime_dir, episode_id=1048)
+
+    assert opened["episode_id"] == attached["episode_id"]
+    assert historical == repeated
+    assert historical["schema"] == "kungfu.query.result/v1"
+    assert historical["definition"]["schema"] == "kungfu.query.definition/v1"
+    assert historical["definition"]["basis"]["cut"] == historical_cut
+    assert historical["rows"][0]["status"] == "open"
+    assert historical["rows"][0]["content_root_status"] == "undefined"
+    assert historical["lineage"]["authority"]["kind"] == "yijinjing-journal"
+    assert historical["lineage"]["authority"]["record_count"] == 2
+    assert historical["lineage"]["cut"]["resolved"] == historical_cut
+    assert historical["lineage"]["determinism"] == "deterministic"
+    assert historical["lineage"]["missing_inputs"] == []
+    assert set(historical["lineage"]["time_basis"]) == {
+        "valid_time",
+        "system_time",
+        "causal_time",
+    }
+    assert historical["lineage"]["time_basis"]["valid_time"] == "not-projected"
+    assert (
+        historical["lineage"]["policy_versions"]["engine"]
+        == "episode-authority-scan/v1"
+    )
+
+    assert head["definition"]["basis"]["cut"] == {"kind": "head"}
+    assert head["rows"][0]["status"] == "ended"
+    assert head["rows"][0]["content_root_status"] == "verified"
+    assert head["result_hash"] != historical["result_hash"]
+    assert head["lineage"]["cut"]["resolved"]["kind"] == "manifest_frame_uid"
+    assert head["lineage"]["episode_content_roots"][0]["status"] == "verified"
+
+    missing = storage_service.fact_query(
+        runtime_dir,
+        episode_id=1048,
+        cut={
+            "kind": "manifest_frame_uid",
+            "manifest_frame_uid": "18446744073709551615",
+        },
+    )
+    assert missing["rows"] == []
+    assert missing["lineage"]["determinism"] == "unverifiable"
+    assert missing["lineage"]["cut"]["resolved"] == {"kind": "unresolved"}
+    assert missing["lineage"]["missing_inputs"] == [
+        {
+            "kind": "manifest_cut",
+            "manifest_frame_uid": "18446744073709551615",
+        }
+    ]
 
 
 # A well-formed digest whose bytes were never published: stage 4 resolves

--- a/framework/core/tests/storage-node-binding.test.js
+++ b/framework/core/tests/storage-node-binding.test.js
@@ -437,6 +437,23 @@ test(
         runtimeDir,
         { episode_id: 901 },
       );
+      const factQuery = kungfu.runStorageServiceOperation(
+        'fact_query',
+        runtimeDir,
+        {
+          definition: {
+            schema: 'kungfu.query.definition/v1',
+            basis: {
+              scope: 'episode-manifest',
+              episode_id: '901',
+              perspective: 'manifest-append-order',
+              cut: { kind: 'head' },
+            },
+            object: 'episodes',
+            evidence: 'proof',
+          },
+        },
+      );
       assert.equal(
         fsck.qualification.schema,
         'kungfu.episode.qualification/v1',
@@ -451,6 +468,10 @@ test(
         fsck.qualification.safe_capabilities.includes('append'),
         false,
       );
+      assert.equal(factQuery.schema, 'kungfu.query.result/v1');
+      assert.equal(factQuery.rows[0].status, 'ended');
+      assert.equal(factQuery.lineage.authority.kind, 'yijinjing-journal');
+      assert.equal(factQuery.lineage.determinism, 'deterministic');
     } finally {
       fs.rmSync(runtimeDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- add typed ADR-0048 Q0 query basis, cut, result schema, and lineage contracts
- implement deterministic Episode authority scans for head and exact historical manifest cuts
- expose thin Python and Node service probes with reproducibility and missing-cut coverage

## Validation
- ./shifu build:core
- Python storage suite: 28 passed
- ./shifu foreach test:storage-binding: 5 passed
- staged quality gate passed

## Known baseline
- ./shifu check reaches the unchanged run-freeze.js TypeScript platform-key baseline and exits 1