### PR TITLE
fix(core): qualify action envelope schema type

### DIFF
--- a/framework/core/src/libkungfu/include/kungfu/view/action_envelope.h
+++ b/framework/core/src/libkungfu/include/kungfu/view/action_envelope.h
@@ -83,7 +83,7 @@ struct payload_view {
 struct envelope {
   uint16_t version = ACTION_ENVELOPE_VERSION;
   std::string action_type = {};
-  schema_ref schema_ref = {};
+  ::kungfu::view::action::schema_ref schema_ref = {};
   std::optional<actor_metadata> actor = {};
   std::optional<session_metadata> session = {};
   std::optional<source_metadata> source = {};


### PR DESCRIPTION
## Summary
- fully qualify the `schema_ref` type used by `action::envelope`
- preserve the existing public member name and serialized contract

## Evidence
- fixes the GCC error: declaration of `envelope::schema_ref` changes meaning of `schema_ref`
- Apple Clang C++23 syntax probe passes
- one-line source change with DCO sign-off