### PR TITLE
fix(core): pin native closure query basis

### DIFF
--- a/framework/core/slices/native-storage-closure/host.cpp
+++ b/framework/core/slices/native-storage-closure/host.cpp
@@ -12,6 +12,11 @@ constexpr uint64_t EPISODE_ID = UINT64_C(42490049);
 constexpr uint64_t EXPECTED_CAPABILITIES = KF_NATIVE_STORAGE_CAP_EPISODE_LIFECYCLE |
                                            KF_NATIVE_STORAGE_CAP_HEAD_AND_HISTORICAL_QUERY |
                                            KF_NATIVE_STORAGE_CAP_FSCK | KF_NATIVE_STORAGE_CAP_EXPORT;
+// This external-style C consumer intentionally pins the built-in declaration
+// roots. Contract-world drift must fail closed until the consumer updates.
+constexpr const char *CONTRACT_WORLD_ROOT = "sha256:99e55c748b2e2b12c994b5e691f6781e66f9d460402e4e6871a48d3628314e9e";
+constexpr const char *EPISODE_FACT_SURFACE_ROOT =
+    "sha256:bfdb3eb73ba4ab88e5da42d3eec7a964260ba8da4a0151213a7ed121252ddc85";
 
 bool contains(const std::string &value, const std::string &needle) { return value.find(needle) != std::string::npos; }
 
@@ -61,8 +66,11 @@ std::string resolved_cut(const std::string &head) {
 std::string fact_query_request(const std::string &cut) {
   const auto selected_cut = cut.empty() ? std::string{"{\"kind\":\"head\"}"}
                                         : "{\"kind\":\"manifest_frame_uid\",\"manifest_frame_uid\":\"" + cut + "\"}";
-  return "{\"definition\":{\"basis\":{\"episode_id\":" + std::to_string(EPISODE_ID) + ",\"cut\":" + selected_cut +
-         "}}}";
+  return "{\"definition\":{\"basis\":{\"contract_world\":{\"id\":\"kungfu.runtime\",\"version\":\"1\",\"root\":\"" +
+         std::string{CONTRACT_WORLD_ROOT} +
+         "\"},\"fact_surfaces\":[{\"id\":\"kungfu.runtime.episode-manifest\",\"version\":\"1\",\"root\":\"" +
+         std::string{EPISODE_FACT_SURFACE_ROOT} + "\"}],\"episode_id\":" + std::to_string(EPISODE_ID) +
+         ",\"cut\":" + selected_cut + "}}}";
 }
 
 bool open_context(const kf_native_storage_api_v1 &api, const char *runtime_dir,


### PR DESCRIPTION
## Summary
- make the native storage C consumer send explicit contract-world and fact-surface declaration references
- intentionally pin the current built-in roots so declaration drift fails closed

## Evidence
- reproduces the latest planner requirement for explicit declarations
- `native_storage_closure_host` builds and its complete lifecycle/query/fsck/export harness passes locally
- no C ABI or storage implementation change