### PR TITLE
feat(core): assembled runtime becomes the Linux product default (ADR-0046 stage 2)

### DIFF
--- a/crates/trunk/src/envs.rs
+++ b/crates/trunk/src/envs.rs
@@ -161,12 +161,21 @@ fn run_uv(uv: &Path, args: &[&str], context: &str) -> Result<(), String> {
 /// load-bearing: a bare version lets uv satisfy the request with a
 /// wrong-arch interpreter already sitting in the shared store (runnable via
 /// Rosetta on macOS), and every wheel install then fails on platform tags.
+/// The trailing segment is the key's libc field: none on macOS/Windows,
+/// gnu on Linux (the product targets glibc) — a `-none` request simply does
+/// not exist for linux and uv refuses it by name.
 fn python_request(pins: &Pins) -> String {
+    let libc = if cfg!(target_os = "linux") {
+        "gnu"
+    } else {
+        "none"
+    };
     format!(
-        "cpython-{}-{}-{}-none",
+        "cpython-{}-{}-{}-{}",
         pins.python_pin,
         env::consts::OS,
-        env::consts::ARCH
+        env::consts::ARCH,
+        libc
     )
 }
 

--- a/framework/core/.gyp/run-freeze.js
+++ b/framework/core/.gyp/run-freeze.js
@@ -40,12 +40,12 @@ function buildType() {
 }
 
 function freezer() {
-  // ADR-0046 stage 2 rolls out platform by platform: macOS ships the
-  // assembled runtime; Linux/Windows keep nuitka until their legs land.
+  // ADR-0046 stage 2 rolls out platform by platform: macOS and Linux ship
+  // the assembled runtime; Windows keeps nuitka until its leg lands.
   // An explicit config value still selects any leg on any platform.
   const explicit = shell.getConfigValue('freezer');
   if (explicit) return explicit;
-  return process.platform === 'darwin' ? 'assemble' : 'nuitka';
+  return process.platform === 'win32' ? 'nuitka' : 'assemble';
 }
 
 // kungfu.spec datas 引用 build/include 与 build/libs（仅 pyinstaller 路径需要）。
@@ -332,7 +332,11 @@ function pbsKey(pin) {
     );
     process.exit(1);
   }
-  return `cpython-${pin}-${osName}-${arch}-none`;
+  // The trailing segment is the key's libc field: none on macOS/Windows,
+  // gnu on Linux (the product targets glibc). Keep identical to the trunk's
+  // python_request (crates/trunk/src/envs.rs).
+  const libc = process.platform === 'linux' ? 'gnu' : 'none';
+  return `cpython-${pin}-${osName}-${arch}-${libc}`;
 }
 
 // PYTHON_PIN comes from the product pins manifest — the same single source the

--- a/framework/core/src/python/kungfu/action_envelope.py
+++ b/framework/core/src/python/kungfu/action_envelope.py
@@ -122,7 +122,10 @@ def decode_action_envelope(
             3: "content-reference",
             4: "opaque",
         }
-        payload["encoding"] = names.get(payload.get("encoding"), "none")
+        encoding = payload.get("encoding")
+        payload["encoding"] = (
+            names.get(encoding, "none") if isinstance(encoding, int) else "none"
+        )
         payload["data"] = bytes(payload.get("data") or b"")
     return envelope
 

--- a/framework/core/src/python/kungfu/cli/commands/query.py
+++ b/framework/core/src/python/kungfu/cli/commands/query.py
@@ -3,7 +3,7 @@
 import json
 import sys
 from pathlib import Path
-from typing import Any
+from typing import Any, NoReturn
 
 import click
 
@@ -18,7 +18,7 @@ def _echo_json(payload: Any, *, err: bool = False) -> None:
     click.echo(json.dumps(payload, indent=2, sort_keys=True), err=err)
 
 
-def _fail(code: str, message: str, *, exit_code: int = 2) -> None:
+def _fail(code: str, message: str, *, exit_code: int = 2) -> NoReturn:
     _echo_json(
         {
             "schema": ERROR_SCHEMA,
@@ -45,11 +45,18 @@ def _load_definition(file_path: str) -> dict[str, Any]:
     return value
 
 
+def _runtime_dir(ctx: click.Context) -> str:
+    # runtime_dir is copied onto the click context dynamically by
+    # pass_ctx_from_parent (commands/__init__), so typed access goes through
+    # the context dict instead of a (nonexistent) declared attribute.
+    return str(ctx.__dict__["runtime_dir"])
+
+
 def _planner_call(ctx: click.Context, action: str, **kwargs: Any) -> dict[str, Any]:
     from kungfu.storage import service
 
     try:
-        return service.query_plan(ctx.runtime_dir, action=action, **kwargs)
+        return service.query_plan(_runtime_dir(ctx), action=action, **kwargs)
     except (RuntimeError, TypeError, ValueError) as error:
         _fail("KF_QUERY_VALIDATION", str(error))
 
@@ -281,7 +288,7 @@ def prove(
         )
     try:
         result = service.fact_query_definition(
-            ctx.runtime_dir, definition, engine=engine
+            _runtime_dir(ctx), definition, engine=engine
         )
     except (RuntimeError, TypeError, ValueError) as error:
         _fail("KF_QUERY_EXECUTION", str(error), exit_code=1)

--- a/product/stdlib-prune.json
+++ b/product/stdlib-prune.json
@@ -27,6 +27,18 @@
       "lib/pkgconfig",
       "bin/python3-config",
       "bin/python3.13-config"
+    ],
+    "linux": [
+      "lib/tcl9.0",
+      "lib/tk9.0",
+      "lib/tcl9",
+      "lib/itcl4.3.5",
+      "lib/thread3.0.4",
+      "lib/libtcl9.0.so",
+      "lib/libtcl9tk9.0.so",
+      "lib/pkgconfig",
+      "bin/python3-config",
+      "bin/python3.13-config"
     ]
   }
 }


### PR DESCRIPTION
ADR-0046 stage 2, Linux leg — the platform default flips (only Windows keeps nuitka now) and the prune manifest gains its linux section, grounded on the real cpython-3.13.14-linux-x86_64-gnu prefix. share/terminfo deliberately stays (curses/readline may consult it at runtime; ADR-0050 semantic-disjoint bar).

Grounding caught a real key bug: both pbs-key sites (run-freeze pbsKey, the trunk's python_request) hardcoded the -none libc segment, which only exists for macOS/Windows — on Linux the request must end in -gnu or uv refuses it by name. Both mappings now derive the libc field per platform.

Evidence on linux-x64 (agent-120):
- verify --full 73/73 green on the assembled form (probes, slices, fixtures, episode qualification, ASan/UBSan replay) at the pre-drift base; post-rebase revalidation on the touched surfaces (mypy repo-green, closure slice green).
- Product chain green: CLI archive kungfu-episodes-cli-linux-x64.tar.gz with interpreter tree + wheel inside, installed-layout smoke passed.
- Startup 0.11-0.12s; tree 93M pruned (104M full); import tkinter and python -m pip both refused in the shipped tree.

Also lands, each in its own commit: the query CLI mypy gate fix (typed runtime_dir access + NoReturn on _fail, extended over the new engine call site), the action-envelope encoding lookup type narrowing, and the closure slice declaring the explicit basis ADR-0048 now requires (pinned built-in declarations — drift without a version bump fails the slice by design).

Note: dev-tip verify --full currently carries 5 unrelated failures on linux from the storage/qualification lines (deterministic, reproduce with the dev-tip python tree, untouched by this diff); recorded for their owning lines.