### PR TITLE
feat(query): add resumable changelog views

### DIFF
--- a/.buildchain/kfd/kfd-2/claims/agent-onboarding-pack.json
+++ b/.buildchain/kfd/kfd-2/claims/agent-onboarding-pack.json
@@ -16,7 +16,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "3364562e43c9f03cfe59e44ce89ae6abde196ffbee06ac986408cdd63d1e0e12"
+        "sha256": "1ed627a64f361ab6c408ed31197da14e5bb43bc69bf9a0933e767c6dc5cb44c9"
       },
       "description": "Machine-readable command catalog and mode maturity metadata."
     },
@@ -54,7 +54,7 @@
     "evidenceSha256": [
       {
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "3364562e43c9f03cfe59e44ce89ae6abde196ffbee06ac986408cdd63d1e0e12"
+        "sha256": "1ed627a64f361ab6c408ed31197da14e5bb43bc69bf9a0933e767c6dc5cb44c9"
       },
       {
         "path": "framework/core/src/python/kungfu/agent/mode-selection.md",
@@ -76,7 +76,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "3364562e43c9f03cfe59e44ce89ae6abde196ffbee06ac986408cdd63d1e0e12"
+        "sha256": "1ed627a64f361ab6c408ed31197da14e5bb43bc69bf9a0933e767c6dc5cb44c9"
       }
     ]
   },
@@ -90,7 +90,7 @@
     {
       "name": "agent-command-catalog",
       "path": "framework/core/src/python/kungfu/agent/commands.json",
-      "sha256": "3364562e43c9f03cfe59e44ce89ae6abde196ffbee06ac986408cdd63d1e0e12",
+      "sha256": "1ed627a64f361ab6c408ed31197da14e5bb43bc69bf9a0933e767c6dc5cb44c9",
       "expectedPackagePath": "kungfu/agent/commands.json"
     }
   ],

--- a/.buildchain/kfd/kfd-2/claims/remote-fact-boundary.json
+++ b/.buildchain/kfd/kfd-2/claims/remote-fact-boundary.json
@@ -34,7 +34,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "3364562e43c9f03cfe59e44ce89ae6abde196ffbee06ac986408cdd63d1e0e12"
+        "sha256": "1ed627a64f361ab6c408ed31197da14e5bb43bc69bf9a0933e767c6dc5cb44c9"
       },
       "description": "Remote add/sync command declarations and mode metadata."
     },
@@ -62,7 +62,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "3364562e43c9f03cfe59e44ce89ae6abde196ffbee06ac986408cdd63d1e0e12"
+        "sha256": "1ed627a64f361ab6c408ed31197da14e5bb43bc69bf9a0933e767c6dc5cb44c9"
       },
       {
         "path": "framework/core/src/python/kungfu/cli/commands/agent.py",

--- a/.buildchain/kfd/kfd-2/release-claims.json
+++ b/.buildchain/kfd/kfd-2/release-claims.json
@@ -29,7 +29,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/commands.json",
-            "sha256": "3364562e43c9f03cfe59e44ce89ae6abde196ffbee06ac986408cdd63d1e0e12"
+            "sha256": "1ed627a64f361ab6c408ed31197da14e5bb43bc69bf9a0933e767c6dc5cb44c9"
           },
           "description": "Machine-readable command catalog and mode maturity metadata."
         },
@@ -194,7 +194,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/commands.json",
-            "sha256": "3364562e43c9f03cfe59e44ce89ae6abde196ffbee06ac986408cdd63d1e0e12"
+            "sha256": "1ed627a64f361ab6c408ed31197da14e5bb43bc69bf9a0933e767c6dc5cb44c9"
           },
           "description": "Remote add/sync command declarations and mode metadata."
         },

--- a/.buildchain/kfd/kfd-3/capability-query.json
+++ b/.buildchain/kfd/kfd-3/capability-query.json
@@ -803,6 +803,28 @@
       "residualRisk": []
     },
     {
+      "id": "kungfu.query.changelog",
+      "kind": "cli",
+      "name": "kungfu query changelog --file query.json --json",
+      "state": "declared",
+      "detected": true,
+      "enforced": false,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "kfd1Basis": {
+        "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+        "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+        "digest": "sha256:b90b979fe69191e09e1f2efb15fb4a7f512d41fbb413211f70f4c18da01d03fe"
+      },
+      "kfd2Trust": {
+        "status": "release-passport-required",
+        "trustImpact": "query-release-passport-for-final-trust",
+        "residualRisk": []
+      },
+      "residualRisk": []
+    },
+    {
       "id": "kungfu.query.describe",
       "kind": "cli",
       "name": "kungfu query describe episodes --json",
@@ -882,6 +904,28 @@
         "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
         "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
         "digest": "sha256:24e62f9e1df10e84d3b1af94c9385f9790926de58867edd67c0a73b9f7551ab3"
+      },
+      "kfd2Trust": {
+        "status": "release-passport-required",
+        "trustImpact": "query-release-passport-for-final-trust",
+        "residualRisk": []
+      },
+      "residualRisk": []
+    },
+    {
+      "id": "kungfu.query.saved-view",
+      "kind": "cli",
+      "name": "kungfu query saved-view --file saved-view.json --json",
+      "state": "declared",
+      "detected": true,
+      "enforced": false,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "kfd1Basis": {
+        "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+        "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+        "digest": "sha256:dbd8669bf2b5880a518fbf5680f88468615d7067087ac28fd090c8e2127a59cb"
       },
       "kfd2Trust": {
         "status": "release-passport-required",

--- a/.buildchain/kfd/kfd-3/collaboration-interface.artifact.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.artifact.json
@@ -10,8 +10,8 @@
   "sourceRegistry": {
     "id": "kungfu",
     "path": ".buildchain/kfd/kfd-3/surfaces.json",
-    "sha256": "a6458ae33277c9df79b82770a70e949df8785cd10888c40a5596ee9f579a0ba7",
-    "digest": "sha256:6a8c59dbfec53dd48fa14a95e09dea9d1e27ffc62c9fc536ff6ec43c8a3309d4"
+    "sha256": "ac2ca592b9547109efaa73c17247003d6692cd0c1dc043d33b4167d5897a9fd6",
+    "digest": "sha256:0f29cb763224b47017cd686c3553b3fc65e2b41a84f1e946b3d5d67b71565bb7"
   },
   "upstreamKfd": {
     "aggregatePath": "developer/sdk/kfd/upstream-aggregate.json",
@@ -28,7 +28,7 @@
     },
     "digest": "sha256:a86ddd8755809f5337e11023a8218d513c87d58077265007f1d207ef957f4761"
   },
-  "collaborationInterfaceDigest": "sha256:0f2ca460793f176850c543539e448e21632f18143d4a68c96138de6b46bd591e",
+  "collaborationInterfaceDigest": "sha256:8eef5f9555e161038ca1121014f14c550ab1ec4f044e0b6e17d4ee7a5f5b05f6",
   "exposedSurfaces": [
     {
       "id": "kungfu.agent",
@@ -775,6 +775,26 @@
       }
     },
     {
+      "id": "kungfu.query.changelog",
+      "name": "kungfu query changelog --file query.json --json",
+      "kind": "cli",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
       "id": "kungfu.query.describe",
       "name": "kungfu query describe episodes --json",
       "kind": "cli",
@@ -837,6 +857,26 @@
     {
       "id": "kungfu.query.prove",
       "name": "kungfu query prove --file query.json --json",
+      "kind": "cli",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
+      "id": "kungfu.query.saved-view",
+      "name": "kungfu query saved-view --file saved-view.json --json",
       "kind": "cli",
       "participantProfile": "agent-or-developer",
       "state": "declared",

--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -5,16 +5,16 @@
   "witnessKind": "prebuild",
   "supportLevel": "release",
   "source": {
-    "cwd": "/Users/dkr/Worktrees/kungfu/feature/adr0051-fact-admission",
-    "sourceSha": "cd2e3d95094e3e9a726453aa5a948334d90f4291",
+    "cwd": "/Users/dkr/Worktrees/kungfu/feature/adr0048-q3-changelog-gui",
+    "sourceSha": "716a6c2f16990de852f7fd553aa6fc20f4671559",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
-    "registryDigest": "sha256:6a8c59dbfec53dd48fa14a95e09dea9d1e27ffc62c9fc536ff6ec43c8a3309d4"
+    "registryDigest": "sha256:0f29cb763224b47017cd686c3553b3fc65e2b41a84f1e946b3d5d67b71565bb7"
   },
   "sourceRegistry": {
     "id": "kungfu",
     "path": ".buildchain/kfd/kfd-3/surfaces.json",
-    "sha256": "a6458ae33277c9df79b82770a70e949df8785cd10888c40a5596ee9f579a0ba7",
-    "digest": "sha256:6a8c59dbfec53dd48fa14a95e09dea9d1e27ffc62c9fc536ff6ec43c8a3309d4"
+    "sha256": "ac2ca592b9547109efaa73c17247003d6692cd0c1dc043d33b4167d5897a9fd6",
+    "digest": "sha256:0f29cb763224b47017cd686c3553b3fc65e2b41a84f1e946b3d5d67b71565bb7"
   },
   "upstreamKfd": {
     "aggregatePath": "developer/sdk/kfd/upstream-aggregate.json",
@@ -34,7 +34,7 @@
   "expectedArtifactVerification": {
     "command": "node scripts/buildchain-kfd-evidence.mjs --artifact-witness --json"
   },
-  "collaborationInterfaceDigest": "sha256:0f2ca460793f176850c543539e448e21632f18143d4a68c96138de6b46bd591e",
+  "collaborationInterfaceDigest": "sha256:8eef5f9555e161038ca1121014f14c550ab1ec4f044e0b6e17d4ee7a5f5b05f6",
   "collaborationInterface": {
     "schemaVersion": 1,
     "contract": "kungfu-buildchain-kfd-3-surface-registry",
@@ -805,6 +805,26 @@
         }
       },
       {
+        "id": "kungfu.query.changelog",
+        "name": "kungfu query changelog --file query.json --json",
+        "kind": "cli",
+        "participantProfile": "agent-or-developer",
+        "state": "declared",
+        "availability": "shipped",
+        "visibility": "public",
+        "participantFacing": true,
+        "public": true,
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+        "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+        "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+        "maturity": "experimental",
+        "declaration": {
+          "owner": "kungfu",
+          "source": "scripts/buildchain-kfd-evidence.mjs",
+          "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+        }
+      },
+      {
         "id": "kungfu.query.describe",
         "name": "kungfu query describe episodes --json",
         "kind": "cli",
@@ -867,6 +887,26 @@
       {
         "id": "kungfu.query.prove",
         "name": "kungfu query prove --file query.json --json",
+        "kind": "cli",
+        "participantProfile": "agent-or-developer",
+        "state": "declared",
+        "availability": "shipped",
+        "visibility": "public",
+        "participantFacing": true,
+        "public": true,
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+        "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+        "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+        "maturity": "experimental",
+        "declaration": {
+          "owner": "kungfu",
+          "source": "scripts/buildchain-kfd-evidence.mjs",
+          "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+        }
+      },
+      {
+        "id": "kungfu.query.saved-view",
+        "name": "kungfu query saved-view --file saved-view.json --json",
         "kind": "cli",
         "participantProfile": "agent-or-developer",
         "state": "declared",
@@ -1447,8 +1487,8 @@
     ],
     "audit": {
       "status": "passed",
-      "declared": 68,
-      "artifactPublic": 68,
+      "declared": 70,
+      "artifactPublic": 70,
       "policy": {
         "sourceOfTruth": ".buildchain/kfd/kfd-3/surfaces.json",
         "detectedButUnregistered": "product-specific-audit",
@@ -2205,6 +2245,26 @@
       }
     },
     {
+      "id": "kungfu.query.changelog",
+      "name": "kungfu query changelog --file query.json --json",
+      "kind": "cli",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
       "id": "kungfu.query.describe",
       "name": "kungfu query describe episodes --json",
       "kind": "cli",
@@ -2267,6 +2327,26 @@
     {
       "id": "kungfu.query.prove",
       "name": "kungfu query prove --file query.json --json",
+      "kind": "cli",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
+      "id": "kungfu.query.saved-view",
+      "name": "kungfu query saved-view --file saved-view.json --json",
       "kind": "cli",
       "participantProfile": "agent-or-developer",
       "state": "declared",

--- a/.buildchain/kfd/kfd-3/surfaces.json
+++ b/.buildchain/kfd/kfd-3/surfaces.json
@@ -813,6 +813,26 @@
       }
     },
     {
+      "id": "kungfu.query.changelog",
+      "name": "kungfu query changelog --file query.json --json",
+      "kind": "cli",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
       "id": "kungfu.query.describe",
       "name": "kungfu query describe episodes --json",
       "kind": "cli",
@@ -875,6 +895,26 @@
     {
       "id": "kungfu.query.prove",
       "name": "kungfu query prove --file query.json --json",
+      "kind": "cli",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
+      "id": "kungfu.query.saved-view",
+      "name": "kungfu query saved-view --file saved-view.json --json",
       "kind": "cli",
       "participantProfile": "agent-or-developer",
       "state": "declared",

--- a/developer/sdk/kfd/kfd-2/claims/agent-onboarding-pack.json
+++ b/developer/sdk/kfd/kfd-2/claims/agent-onboarding-pack.json
@@ -16,7 +16,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "3364562e43c9f03cfe59e44ce89ae6abde196ffbee06ac986408cdd63d1e0e12"
+        "sha256": "1ed627a64f361ab6c408ed31197da14e5bb43bc69bf9a0933e767c6dc5cb44c9"
       },
       "description": "Machine-readable command catalog and mode maturity metadata."
     },
@@ -54,7 +54,7 @@
     "evidenceSha256": [
       {
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "3364562e43c9f03cfe59e44ce89ae6abde196ffbee06ac986408cdd63d1e0e12"
+        "sha256": "1ed627a64f361ab6c408ed31197da14e5bb43bc69bf9a0933e767c6dc5cb44c9"
       },
       {
         "path": "framework/core/src/python/kungfu/agent/mode-selection.md",
@@ -76,7 +76,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "3364562e43c9f03cfe59e44ce89ae6abde196ffbee06ac986408cdd63d1e0e12"
+        "sha256": "1ed627a64f361ab6c408ed31197da14e5bb43bc69bf9a0933e767c6dc5cb44c9"
       }
     ]
   },
@@ -90,7 +90,7 @@
     {
       "name": "agent-command-catalog",
       "path": "framework/core/src/python/kungfu/agent/commands.json",
-      "sha256": "3364562e43c9f03cfe59e44ce89ae6abde196ffbee06ac986408cdd63d1e0e12",
+      "sha256": "1ed627a64f361ab6c408ed31197da14e5bb43bc69bf9a0933e767c6dc5cb44c9",
       "expectedPackagePath": "kungfu/agent/commands.json"
     }
   ],

--- a/developer/sdk/kfd/kfd-2/claims/remote-fact-boundary.json
+++ b/developer/sdk/kfd/kfd-2/claims/remote-fact-boundary.json
@@ -34,7 +34,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "3364562e43c9f03cfe59e44ce89ae6abde196ffbee06ac986408cdd63d1e0e12"
+        "sha256": "1ed627a64f361ab6c408ed31197da14e5bb43bc69bf9a0933e767c6dc5cb44c9"
       },
       "description": "Remote add/sync command declarations and mode metadata."
     },
@@ -62,7 +62,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "3364562e43c9f03cfe59e44ce89ae6abde196ffbee06ac986408cdd63d1e0e12"
+        "sha256": "1ed627a64f361ab6c408ed31197da14e5bb43bc69bf9a0933e767c6dc5cb44c9"
       },
       {
         "path": "framework/core/src/python/kungfu/cli/commands/agent.py",

--- a/developer/sdk/kfd/kfd-2/release-claims.json
+++ b/developer/sdk/kfd/kfd-2/release-claims.json
@@ -29,7 +29,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/commands.json",
-            "sha256": "3364562e43c9f03cfe59e44ce89ae6abde196ffbee06ac986408cdd63d1e0e12"
+            "sha256": "1ed627a64f361ab6c408ed31197da14e5bb43bc69bf9a0933e767c6dc5cb44c9"
           },
           "description": "Machine-readable command catalog and mode maturity metadata."
         },
@@ -194,7 +194,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/commands.json",
-            "sha256": "3364562e43c9f03cfe59e44ce89ae6abde196ffbee06ac986408cdd63d1e0e12"
+            "sha256": "1ed627a64f361ab6c408ed31197da14e5bb43bc69bf9a0933e767c6dc5cb44c9"
           },
           "description": "Remote add/sync command declarations and mode metadata."
         },

--- a/developer/sdk/kfd/kfd-3-surfaces.json
+++ b/developer/sdk/kfd/kfd-3-surfaces.json
@@ -813,6 +813,26 @@
       }
     },
     {
+      "id": "kungfu.query.changelog",
+      "name": "kungfu query changelog --file query.json --json",
+      "kind": "cli",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
       "id": "kungfu.query.describe",
       "name": "kungfu query describe episodes --json",
       "kind": "cli",
@@ -875,6 +895,26 @@
     {
       "id": "kungfu.query.prove",
       "name": "kungfu query prove --file query.json --json",
+      "kind": "cli",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
+      "id": "kungfu.query.saved-view",
+      "name": "kungfu query saved-view --file saved-view.json --json",
       "kind": "cli",
       "participantProfile": "agent-or-developer",
       "state": "declared",

--- a/docs/querying-runtime-facts.md
+++ b/docs/querying-runtime-facts.md
@@ -7,9 +7,9 @@ of truth.
 This document describes the target service contract accepted by
 [ADR-0048](../framework/core/docs/adr/ADR-0048-runtime-fact-query-semantics-and-changelog.md).
 The implementation is staged. QueryDefinition planning, proof-bearing Episode
-queries, the agent CLI, a bounded SQL compiler, and journal/SQLite conformance
-ship today. Changelogs, broad SQL, temporal patterns, and visual builders
-remain later slices.
+queries, the agent CLI, a bounded SQL compiler, journal/SQLite conformance, a
+resumable changelog, and table/timeline/diff/causal-graph reference views ship
+today. Broad SQL and temporal patterns remain later slices.
 
 ## The query basis
 
@@ -132,6 +132,15 @@ This allows a GUI, agent, or external consumer to distinguish:
 - the connection resumed successfully;
 - updates were missed and recovery is required.
 
+The current Episode implementation returns deterministic bounded pages. A
+resume token pins the shared QueryDefinition and logical-plan hashes, the
+source and target frontiers (opaque frame UID plus monotonic authority-record
+count), both result hashes, the batch id, and the next message index. Reconnect
+re-runs the exact authority cuts before continuing.
+Message ids are stable within a batch, so replay is idempotent; a consumer that
+cannot reproduce a pinned result receives `Gap` and must request a new full
+snapshot. The token is integrity-hashed and cannot be moved to another query.
+
 NDJSON is the intended CLI stream representation. Bulk tabular results may use
 Apache Arrow, while ADBC or Flight SQL may provide external database adapters.
 None of those representations becomes fact authority.
@@ -149,6 +158,8 @@ kungfu query compile-sql --file basis.json \
 kungfu query validate --file query.json --json
 kungfu query explain --file query.json --json
 kungfu query prove --file query.json --json
+kungfu query changelog --file query.json --max-messages 100 --json
+kungfu query saved-view --file saved-view.json --json
 kungfu storage episode rebuild-projection --json
 kungfu query prove --file query.json --engine sqlite --json
 ```
@@ -178,6 +189,13 @@ Humans can build and save queries through reference components:
 - before/after diffs;
 - causal graphs and evidence drill-down;
 - temporal pattern builders;
+
+The System Status KFX contains the initial table, timeline, diff, and causal
+graph references. It imports the same `kungfu.query.saved-view/v1` JSON that
+the CLI inspects. Only the QueryDefinition and thin ViewSpec are persisted in
+the browser; result rows and proof are rebuilt from the native query
+capability, and missing or unverifiable evidence remains visible in every
+view. The GUI does not open or own a database.
 - metrics backed by inspectable QueryDefinitions.
 
 Presentation is stored separately as a ViewSpec. Changing a chart, visible

--- a/extensions/system/status/src/view/index.tsx
+++ b/extensions/system/status/src/view/index.tsx
@@ -1,6 +1,7 @@
 import type { KfxCapabilities, Shell } from '@kungfu-tech/kfx';
 import { headingStyle, mono, panelStyle } from '@kungfu-tech/kfx';
 import React from 'react';
+import { QueryReferencePanel } from './query-reference';
 
 // System kfx: system status. Runtime facts (master liveness, versions,
 // binding exports, runtime home) plus the core schema type registry — the
@@ -284,6 +285,7 @@ function SystemStatusView({
           {storageResult}
         </pre>
       </section>
+      <QueryReferencePanel caps={caps} />
     </div>
   );
 }

--- a/extensions/system/status/src/view/query-reference.tsx
+++ b/extensions/system/status/src/view/query-reference.tsx
@@ -1,0 +1,387 @@
+import {
+  type KfxCapabilities,
+  type QueryChangelogState,
+  type QueryResumeToken,
+  type QueryViewSpec,
+  type SavedQueryView,
+  applyQueryChangelogPage,
+  emptyQueryChangelogState,
+  headingStyle,
+  mono,
+  panelStyle,
+  parseSavedQueryView,
+  queryRows,
+} from '@kungfu-tech/kfx';
+import React from 'react';
+
+const SAVED_QUERY_KEY = 'kungfu.query.saved-view/v1:system-status';
+
+function cell(value: unknown): string {
+  if (value === null || value === undefined) return '—';
+  return typeof value === 'object' ? JSON.stringify(value) : String(value);
+}
+
+function evidenceLabel(state: QueryChangelogState, key: string): string {
+  const evidence = state.evidence[key];
+  if (!evidence) return 'missing evidence';
+  const status = String(evidence.content_root_status ?? 'unverifiable');
+  const determinism = String(evidence.determinism ?? 'unverifiable');
+  return `${status} · ${determinism}`;
+}
+
+export function QueryTableReference({
+  state,
+  spec,
+}: {
+  state: QueryChangelogState;
+  spec: Extract<QueryViewSpec, { kind: 'table' }>;
+}) {
+  const rows = queryRows(state);
+  return (
+    <table style={{ ...mono, borderCollapse: 'collapse', width: '100%' }}>
+      <thead>
+        <tr>
+          {spec.columns.map((column) => (
+            <th key={column} style={{ textAlign: 'left', padding: 4 }}>
+              {column}
+            </th>
+          ))}
+          <th style={{ textAlign: 'left', padding: 4 }}>evidence</th>
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((row) => {
+          const key = String(row.episode_id ?? 'unknown');
+          return (
+            <tr key={key}>
+              {spec.columns.map((column) => (
+                <td
+                  key={column}
+                  style={{ padding: 4, borderTop: '1px solid #333' }}
+                >
+                  {cell(row[column])}
+                </td>
+              ))}
+              <td
+                style={{
+                  padding: 4,
+                  borderTop: '1px solid #333',
+                  color: '#dcdcaa',
+                }}
+              >
+                {evidenceLabel(state, key)}
+              </td>
+            </tr>
+          );
+        })}
+      </tbody>
+    </table>
+  );
+}
+
+export function QueryTimelineReference({
+  state,
+  spec,
+}: {
+  state: QueryChangelogState;
+  spec: Extract<QueryViewSpec, { kind: 'timeline' }>;
+}) {
+  const rows = queryRows(state).sort((left, right) =>
+    cell(left[spec.timeField]).localeCompare(
+      cell(right[spec.timeField]),
+      undefined,
+      {
+        numeric: true,
+      },
+    ),
+  );
+  return (
+    <ol style={{ ...mono, margin: 0, paddingLeft: 24 }}>
+      {rows.map((row) => {
+        const key = String(row.episode_id ?? 'unknown');
+        return (
+          <li key={key} style={{ padding: '4px 0' }}>
+            <span style={{ color: '#9cdcfe' }}>
+              {cell(row[spec.timeField])}
+            </span>{' '}
+            {spec.laneField ? `${cell(row[spec.laneField])} · ` : ''}
+            {cell(row[spec.labelField])}{' '}
+            <span style={{ color: '#dcdcaa' }}>
+              ({evidenceLabel(state, key)})
+            </span>
+          </li>
+        );
+      })}
+    </ol>
+  );
+}
+
+export function QueryDiffReference({
+  state,
+  spec,
+}: {
+  state: QueryChangelogState;
+  spec: Extract<QueryViewSpec, { kind: 'diff' }>;
+}) {
+  return (
+    <div style={mono}>
+      {Object.entries(state.changes).map(([key, change]) => {
+        return (
+          <div key={key} style={{ padding: 6, borderBottom: '1px solid #333' }}>
+            <strong style={{ color: '#9cdcfe' }}>{key}</strong>
+            {spec.fields.map((field) => (
+              <div key={field}>
+                {field}:{' '}
+                <span style={{ color: '#f48771' }}>
+                  {cell(change.before?.[field])}
+                </span>{' '}
+                →{' '}
+                <span style={{ color: '#4ec9b0' }}>
+                  {cell(change.after?.[field])}
+                </span>
+              </div>
+            ))}
+            <div style={{ color: '#dcdcaa' }}>{evidenceLabel(state, key)}</div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+export function QueryCausalGraphReference({
+  state,
+  spec,
+}: {
+  state: QueryChangelogState;
+  spec: Extract<QueryViewSpec, { kind: 'causal-graph' }>;
+}) {
+  return (
+    <div style={mono}>
+      {queryRows(state).map((row) => {
+        const key = String(row[spec.idField] ?? 'unknown');
+        const parent = row[spec.parentField];
+        return (
+          <div key={key} style={{ padding: '4px 0' }}>
+            <span style={{ color: '#9cdcfe' }}>{key}</span>
+            <span style={{ color: '#858585' }}> ← {cell(parent)}</span> ·{' '}
+            {cell(row[spec.labelField])}{' '}
+            <span style={{ color: '#dcdcaa' }}>
+              ({evidenceLabel(state, key)})
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function referenceView(state: QueryChangelogState, spec: QueryViewSpec) {
+  switch (spec.kind) {
+    case 'table':
+      return <QueryTableReference state={state} spec={spec} />;
+    case 'timeline':
+      return <QueryTimelineReference state={state} spec={spec} />;
+    case 'diff':
+      return <QueryDiffReference state={state} spec={spec} />;
+    case 'causal-graph':
+      return <QueryCausalGraphReference state={state} spec={spec} />;
+  }
+}
+
+const specs: Record<QueryViewSpec['kind'], QueryViewSpec> = {
+  table: {
+    kind: 'table',
+    columns: [
+      'episode_id',
+      'status',
+      'begin_time',
+      'end_time',
+      'content_root_status',
+    ],
+  },
+  timeline: {
+    kind: 'timeline',
+    timeField: 'begin_time',
+    laneField: 'status',
+    labelField: 'episode_id',
+  },
+  diff: {
+    kind: 'diff',
+    keyField: 'episode_id',
+    fields: ['status', 'record_count', 'frame_count', 'content_root_status'],
+  },
+  'causal-graph': {
+    kind: 'causal-graph',
+    idField: 'episode_id',
+    parentField: 'parent_episode_id',
+    labelField: 'status',
+  },
+};
+
+export function QueryReferencePanel({ caps }: { caps: KfxCapabilities }) {
+  const [savedText, setSavedText] = React.useState(
+    () => window.localStorage.getItem(SAVED_QUERY_KEY) ?? '',
+  );
+  const [saved, setSaved] = React.useState<SavedQueryView | null>(null);
+  const [state, setState] = React.useState(emptyQueryChangelogState);
+  const [error, setError] = React.useState('');
+
+  const loadExample = () => {
+    try {
+      const examples = caps.storage.queryExamples() as {
+        examples?: { definition?: SavedQueryView['definition'] }[];
+      };
+      const definition = examples.examples?.[0]?.definition;
+      if (!definition) throw new Error('query example unavailable');
+      const value: SavedQueryView = {
+        schema: 'kungfu.query.saved-view/v1',
+        name: 'episode-head',
+        definition,
+        view: specs.table,
+      };
+      const text = JSON.stringify(value, null, 2);
+      window.localStorage.setItem(SAVED_QUERY_KEY, text);
+      setSavedText(text);
+      setSaved(value);
+      setError('');
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+    }
+  };
+
+  const applyArtifact = () => {
+    try {
+      const value = parseSavedQueryView(JSON.parse(savedText));
+      window.localStorage.setItem(
+        SAVED_QUERY_KEY,
+        JSON.stringify(value, null, 2),
+      );
+      setSaved(value);
+      setError('');
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+    }
+  };
+
+  const selectView = (kind: QueryViewSpec['kind']) => {
+    if (!saved) return;
+    const value = { ...saved, view: specs[kind] } as SavedQueryView;
+    const text = JSON.stringify(value, null, 2);
+    window.localStorage.setItem(SAVED_QUERY_KEY, text);
+    setSaved(value);
+    setSavedText(text);
+  };
+
+  const refresh = () => {
+    if (!saved) return;
+    try {
+      let next = emptyQueryChangelogState();
+      let token: QueryResumeToken | undefined;
+      // The reference intentionally asks the public changelog for a complete
+      // bounded snapshot. Rows stay in memory; only definition + ViewSpec are
+      // persisted in localStorage.
+      for (let pageCount = 0; pageCount < 100; pageCount += 1) {
+        const page = caps.storage.factChangelog(saved.definition, token, 100);
+        next = applyQueryChangelogPage(next, page);
+        if (page.complete) break;
+        token = page.resume_token;
+      }
+      setState(next);
+      setError(next.gap ? `gap: ${next.gap.recovery_hint}` : '');
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+    }
+  };
+
+  return (
+    <section style={{ ...panelStyle, gridColumn: '1 / -1' }}>
+      <h2 style={headingStyle}>Proof query · shared saved artifact</h2>
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'minmax(320px, 0.8fr) 1.2fr',
+          gap: 12,
+        }}
+      >
+        <div>
+          <textarea
+            aria-label="Saved QueryDefinition and ViewSpec"
+            value={savedText}
+            onChange={(event) => setSavedText(event.target.value)}
+            placeholder="Load an example or paste kungfu.query.saved-view/v1 JSON"
+            style={{
+              ...mono,
+              width: '100%',
+              minHeight: 220,
+              background: '#1e1e1e',
+              color: '#cccccc',
+            }}
+          />
+          <div
+            style={{ display: 'flex', flexWrap: 'wrap', gap: 6, marginTop: 6 }}
+          >
+            <button type="button" onClick={loadExample}>
+              Load example
+            </button>
+            <label style={{ ...mono, display: 'inline-block' }}>
+              Import JSON{' '}
+              <input
+                type="file"
+                accept="application/json,.json"
+                onChange={(event) => {
+                  const file = event.target.files?.[0];
+                  if (!file) return;
+                  void file
+                    .text()
+                    .then(setSavedText, (cause) =>
+                      setError(
+                        cause instanceof Error ? cause.message : String(cause),
+                      ),
+                    );
+                }}
+              />
+            </label>
+            <button type="button" onClick={applyArtifact}>
+              Apply artifact
+            </button>
+            <button type="button" onClick={refresh} disabled={!saved}>
+              Run changelog
+            </button>
+          </div>
+          <div
+            style={{
+              ...mono,
+              color: error ? '#f48771' : '#858585',
+              marginTop: 6,
+            }}
+          >
+            {error ||
+              'Persisted locally: QueryDefinition + ViewSpec only; rows and proof are rebuilt.'}
+          </div>
+        </div>
+        <div>
+          <div style={{ display: 'flex', gap: 6, marginBottom: 8 }}>
+            {(Object.keys(specs) as QueryViewSpec['kind'][]).map((kind) => (
+              <button
+                type="button"
+                key={kind}
+                onClick={() => selectView(kind)}
+                disabled={!saved}
+              >
+                {kind}
+              </button>
+            ))}
+          </div>
+          {saved ? (
+            referenceView(state, saved.view)
+          ) : (
+            <span style={{ ...mono, color: '#858585' }}>
+              No saved query loaded.
+            </span>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/framework/api/package.json
+++ b/framework/api/package.json
@@ -19,6 +19,7 @@
   "main": "./src/capability/index.ts",
   "scripts": {
     "build": "tsc --noEmit",
+    "test:query": "node --test tests/query.test.ts",
     "clean": "rimraf build dist"
   },
   "dependencies": {

--- a/framework/api/src/capability/index.ts
+++ b/framework/api/src/capability/index.ts
@@ -12,6 +12,7 @@ export * from './terminal.js';
 export * from './work.js';
 export * from './atlas.js';
 export * from './storage.js';
+export * from './query.js';
 
 // The runtime-plane trust boundary (ADR-0013 / ADR-0014): the OS-sandbox
 // launcher, the child-process relay transport, the Node child-side guest proxy,

--- a/framework/api/src/capability/query.ts
+++ b/framework/api/src/capability/query.ts
@@ -1,0 +1,259 @@
+// ADR-0048 Q3 public query/changelog/view contracts. QueryDefinition remains
+// the semantic owner; ViewSpec only selects a presentation of returned rows.
+
+export type QueryDefinition = {
+  schema: 'kungfu.query.definition/v1';
+  basis: Record<string, unknown>;
+  object: string;
+  limit: number;
+  evidence: string;
+};
+
+export type QueryFrontier =
+  | { kind: 'empty'; record_count: string }
+  | {
+      kind: 'manifest_frame_uid';
+      manifest_frame_uid: string;
+      record_count: string;
+    };
+
+export type QueryResultSchema = {
+  schema: string;
+  fields: { name: string; type: string; nullable: boolean }[];
+};
+
+export type QueryResumeToken = {
+  schema: 'kungfu.query.resume-token/v1';
+  definition: QueryDefinition;
+  query_definition_hash: string;
+  logical_plan_hash: string;
+  from: QueryFrontier;
+  from_result_hash: string;
+  target: QueryFrontier;
+  target_result_hash: string;
+  next_message_index: number;
+  batch_id: string;
+  token_hash: string;
+};
+
+type ChangelogEnvelope = { message_id: string; index: number };
+
+export type QueryChangelogMessage = ChangelogEnvelope &
+  (
+    | {
+        type: 'SnapshotBegin';
+        basis: Record<string, unknown>;
+        result_schema: QueryResultSchema;
+      }
+    | {
+        type: 'RowUpsert';
+        key: string;
+        row: Record<string, unknown>;
+        evidence_ref: Record<string, unknown>;
+      }
+    | {
+        type: 'RowRetract';
+        key: string;
+        before_hash: string;
+        evidence_ref: Record<string, unknown>;
+      }
+    | {
+        type: 'Progress';
+        frontier: QueryFrontier;
+        watermark: Record<string, unknown>;
+      }
+    | {
+        type: 'SchemaChange';
+        old_schema: QueryResultSchema;
+        new_schema: QueryResultSchema;
+        compatibility: string;
+      }
+    | {
+        type: 'SnapshotEnd';
+        result_hash: string;
+        frontier: QueryFrontier;
+      }
+    | {
+        type: 'Gap';
+        expected: Record<string, unknown>;
+        observed: Record<string, unknown>;
+        recovery_hint: string;
+      }
+  );
+
+export type QueryChangelogPage = {
+  schema: 'kungfu.query.changelog/v1';
+  batch_id: string;
+  messages: QueryChangelogMessage[];
+  resume_token: QueryResumeToken;
+  complete: boolean;
+};
+
+export type TableViewSpec = {
+  kind: 'table';
+  columns: string[];
+};
+export type TimelineViewSpec = {
+  kind: 'timeline';
+  timeField: string;
+  laneField?: string;
+  labelField: string;
+};
+export type DiffViewSpec = {
+  kind: 'diff';
+  keyField: string;
+  fields: string[];
+};
+export type CausalGraphViewSpec = {
+  kind: 'causal-graph';
+  idField: string;
+  parentField: string;
+  labelField: string;
+};
+export type QueryViewSpec =
+  | TableViewSpec
+  | TimelineViewSpec
+  | DiffViewSpec
+  | CausalGraphViewSpec;
+
+export type SavedQueryView = {
+  schema: 'kungfu.query.saved-view/v1';
+  name: string;
+  definition: QueryDefinition;
+  view: QueryViewSpec;
+};
+
+export type QueryChangelogState = {
+  rows: Record<string, Record<string, unknown>>;
+  evidence: Record<string, Record<string, unknown>>;
+  changes: Record<
+    string,
+    {
+      before: Record<string, unknown> | null;
+      after: Record<string, unknown> | null;
+    }
+  >;
+  appliedMessageIds: string[];
+  resultSchema: QueryResultSchema | null;
+  frontier: QueryFrontier;
+  resultHash: string;
+  gap: Extract<QueryChangelogMessage, { type: 'Gap' }> | null;
+};
+
+export function emptyQueryChangelogState(): QueryChangelogState {
+  return {
+    rows: {},
+    evidence: {},
+    changes: {},
+    appliedMessageIds: [],
+    resultSchema: null,
+    frontier: { kind: 'empty', record_count: '0' },
+    resultHash: '',
+    gap: null,
+  };
+}
+
+function frontierValue(frontier: QueryFrontier): bigint {
+  return BigInt(frontier.record_count);
+}
+
+export function applyQueryChangelogPage(
+  current: QueryChangelogState,
+  page: QueryChangelogPage,
+): QueryChangelogState {
+  const state: QueryChangelogState = {
+    ...current,
+    rows: { ...current.rows },
+    evidence: { ...current.evidence },
+    changes: { ...current.changes },
+    appliedMessageIds: [...current.appliedMessageIds],
+  };
+  const applied = new Set(state.appliedMessageIds);
+  for (const message of page.messages) {
+    if (applied.has(message.message_id)) continue;
+    if (state.gap) break;
+    switch (message.type) {
+      case 'SnapshotBegin':
+        state.rows = {};
+        state.evidence = {};
+        state.changes = {};
+        state.resultSchema = message.result_schema;
+        state.resultHash = '';
+        break;
+      case 'RowUpsert':
+        state.changes[message.key] = {
+          before: state.rows[message.key] ?? null,
+          after: message.row,
+        };
+        state.rows[message.key] = message.row;
+        state.evidence[message.key] = message.evidence_ref;
+        break;
+      case 'RowRetract':
+        state.changes[message.key] = {
+          before: state.rows[message.key] ?? null,
+          after: null,
+        };
+        delete state.rows[message.key];
+        state.evidence[message.key] = message.evidence_ref;
+        break;
+      case 'SchemaChange':
+        state.resultSchema = message.new_schema;
+        break;
+      case 'SnapshotEnd':
+        if (frontierValue(message.frontier) < frontierValue(state.frontier)) {
+          throw new Error('query changelog frontier regressed');
+        }
+        state.frontier = message.frontier;
+        state.resultHash = message.result_hash;
+        break;
+      case 'Progress':
+        if (frontierValue(message.frontier) < frontierValue(state.frontier)) {
+          throw new Error('query changelog frontier regressed');
+        }
+        state.frontier = message.frontier;
+        break;
+      case 'Gap':
+        state.gap = message;
+        break;
+    }
+    applied.add(message.message_id);
+    state.appliedMessageIds.push(message.message_id);
+  }
+  return state;
+}
+
+export function parseSavedQueryView(value: unknown): SavedQueryView {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('saved query view must be an object');
+  }
+  const saved = value as Partial<SavedQueryView>;
+  if (saved.schema !== 'kungfu.query.saved-view/v1') {
+    throw new Error('unsupported saved query view schema');
+  }
+  if (
+    !saved.definition ||
+    saved.definition.schema !== 'kungfu.query.definition/v1'
+  ) {
+    throw new Error('saved query view requires a QueryDefinition');
+  }
+  if (
+    !saved.view ||
+    !['table', 'timeline', 'diff', 'causal-graph'].includes(saved.view.kind)
+  ) {
+    throw new Error('saved query view requires a supported ViewSpec');
+  }
+  if (typeof saved.name !== 'string' || saved.name.length === 0) {
+    throw new Error('saved query view requires a name');
+  }
+  return saved as SavedQueryView;
+}
+
+export function queryRows(
+  state: QueryChangelogState,
+): Record<string, unknown>[] {
+  return Object.entries(state.rows)
+    .sort(([left], [right]) =>
+      left.localeCompare(right, undefined, { numeric: true }),
+    )
+    .map(([, row]) => row);
+}

--- a/framework/api/src/capability/storage.ts
+++ b/framework/api/src/capability/storage.ts
@@ -2,6 +2,11 @@
 // The native binding owns every semantic operation; this handle only gives
 // higher layers a typed, injected expression of that existing contract.
 
+import type {
+  QueryChangelogPage,
+  QueryDefinition,
+  QueryResumeToken,
+} from './query.js';
 import type { KfLocator, KfNativeBinding } from './types.js';
 import { resolveRuntimeDir } from './types.js';
 
@@ -16,6 +21,13 @@ export type Storage = {
   fsck: () => StorageValue;
   repairPlan: () => StorageValue;
   exportBundle: (sourceId?: string) => StorageValue;
+  queryExamples: () => StorageValue;
+  factQuery: (definition: QueryDefinition) => StorageValue;
+  factChangelog: (
+    definition: QueryDefinition,
+    resumeToken?: QueryResumeToken,
+    maxMessages?: number,
+  ) => QueryChangelogPage;
 };
 
 export type OpenStorageOptions = {
@@ -47,5 +59,13 @@ export function openStorage(options: OpenStorageOptions): Storage {
     repairPlan: () => run('repair_plan', { dryRun: true }),
     exportBundle: (sourceId = '') =>
       run('export_bundle', sourceId ? { sourceId } : {}),
+    queryExamples: () => run('query_plan', { action: 'examples' }),
+    factQuery: (definition) => run('fact_query', { definition }),
+    factChangelog: (definition, resumeToken, maxMessages = 100) =>
+      run('fact_changelog', {
+        definition,
+        max_messages: maxMessages,
+        ...(resumeToken ? { resume_token: resumeToken } : {}),
+      }) as QueryChangelogPage,
   };
 }

--- a/framework/api/tests/query.test.ts
+++ b/framework/api/tests/query.test.ts
@@ -1,0 +1,137 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  type QueryChangelogPage,
+  applyQueryChangelogPage,
+  emptyQueryChangelogState,
+} from '../src/capability/query.ts';
+
+const token = {
+  schema: 'kungfu.query.resume-token/v1' as const,
+  definition: {
+    schema: 'kungfu.query.definition/v1' as const,
+    basis: {},
+    object: 'episodes',
+    limit: 100,
+    evidence: 'proof',
+  },
+  query_definition_hash: 'query',
+  logical_plan_hash: 'plan',
+  from: { kind: 'empty' as const, record_count: '0' },
+  from_result_hash: '',
+  target: {
+    kind: 'manifest_frame_uid' as const,
+    manifest_frame_uid: '20',
+    record_count: '2',
+  },
+  target_result_hash: 'result',
+  next_message_index: 0,
+  batch_id: 'batch',
+  token_hash: 'token',
+};
+
+function page(messages: QueryChangelogPage['messages']): QueryChangelogPage {
+  return {
+    schema: 'kungfu.query.changelog/v1',
+    batch_id: 'batch',
+    messages,
+    resume_token: token,
+    complete: true,
+  };
+}
+
+test('changelog replay is idempotent and evidence stays visible', () => {
+  const snapshot = page([
+    {
+      type: 'SnapshotBegin',
+      message_id: 'begin',
+      index: 0,
+      basis: {},
+      result_schema: { schema: 'rows/v1', fields: [] },
+    },
+    {
+      type: 'RowUpsert',
+      message_id: 'row',
+      index: 1,
+      key: '48',
+      row: { episode_id: '48', status: 'open' },
+      evidence_ref: {
+        content_root_status: 'unverifiable',
+        determinism: 'unverifiable',
+      },
+    },
+    {
+      type: 'SnapshotEnd',
+      message_id: 'end',
+      index: 2,
+      result_hash: 'result',
+      frontier: {
+        kind: 'manifest_frame_uid',
+        manifest_frame_uid: '20',
+        record_count: '2',
+      },
+    },
+  ]);
+  const applied = applyQueryChangelogPage(emptyQueryChangelogState(), snapshot);
+  const replayed = applyQueryChangelogPage(applied, snapshot);
+
+  assert.deepEqual(replayed, applied);
+  assert.equal(replayed.rows['48']?.status, 'open');
+  assert.equal(replayed.evidence['48']?.content_root_status, 'unverifiable');
+});
+
+test('gap halts mutation and frontier regression fails closed', () => {
+  const gap = applyQueryChangelogPage(
+    emptyQueryChangelogState(),
+    page([
+      {
+        type: 'Gap',
+        message_id: 'gap',
+        index: 0,
+        expected: { result_hash: 'old' },
+        observed: { result_hash: 'new' },
+        recovery_hint: 'discard-token-and-request-full-snapshot',
+      },
+      {
+        type: 'RowUpsert',
+        message_id: 'after-gap',
+        index: 1,
+        key: '48',
+        row: { episode_id: '48' },
+        evidence_ref: {},
+      },
+    ]),
+  );
+  assert.equal(gap.gap?.type, 'Gap');
+  assert.deepEqual(gap.rows, {});
+
+  const advanced = {
+    ...emptyQueryChangelogState(),
+    frontier: {
+      kind: 'manifest_frame_uid' as const,
+      manifest_frame_uid: '20',
+      record_count: '2',
+    },
+  };
+  assert.throws(
+    () =>
+      applyQueryChangelogPage(
+        advanced,
+        page([
+          {
+            type: 'Progress',
+            message_id: 'regression',
+            index: 0,
+            frontier: {
+              kind: 'manifest_frame_uid',
+              manifest_frame_uid: '999',
+              record_count: '1',
+            },
+            watermark: {},
+          },
+        ]),
+      ),
+    /frontier regressed/,
+  );
+});

--- a/framework/core/src/libkungfu/include/kungfu/runtime/query/fact_query.h
+++ b/framework/core/src/libkungfu/include/kungfu/runtime/query/fact_query.h
@@ -5,6 +5,7 @@
 
 #include <cstdint>
 #include <string>
+#include <variant>
 #include <vector>
 
 #include <nlohmann/json.hpp>
@@ -19,6 +20,9 @@ inline constexpr const char *QUERY_RESULT_ROW_SCHEMA_V1 = "kungfu.query.episode-
 inline constexpr const char *QUERY_CAPABILITIES_SCHEMA_V1 = "kungfu.query.capabilities/v1";
 inline constexpr const char *QUERY_VALIDATION_SCHEMA_V1 = "kungfu.query.validation/v1";
 inline constexpr const char *QUERY_EXPLAIN_SCHEMA_V1 = "kungfu.query.explain/v1";
+inline constexpr const char *QUERY_CHANGELOG_SCHEMA_V1 = "kungfu.query.changelog/v1";
+inline constexpr const char *QUERY_RESUME_TOKEN_SCHEMA_V1 = "kungfu.query.resume-token/v1";
+inline constexpr const char *QUERY_VIEW_SCHEMA_V1 = "kungfu.query.saved-view/v1";
 
 enum class cut_kind { Head, ManifestFrameUid };
 
@@ -137,6 +141,88 @@ struct query_result {
   std::string result_hash = {};
 };
 
+enum class frontier_kind { Empty, ManifestFrameUid };
+
+struct query_frontier {
+  frontier_kind kind = frontier_kind::Empty;
+  uint64_t manifest_frame_uid = 0;
+  uint64_t record_count = 0;
+};
+
+// A resume token names both ends of one deterministic changelog batch. A
+// reconnect re-runs those exact cuts and verifies their result hashes before
+// continuing at next_message_index; no GUI cache or server-side cursor owns
+// query truth.
+struct query_resume_token {
+  std::string schema = QUERY_RESUME_TOKEN_SCHEMA_V1;
+  query_definition definition = {};
+  std::string query_definition_hash = {};
+  std::string logical_plan_hash = {};
+  query_frontier from = {};
+  std::string from_result_hash = {};
+  query_frontier target = {};
+  std::string target_result_hash = {};
+  uint64_t next_message_index = 0;
+  std::string batch_id = {};
+  std::string token_hash = {};
+};
+
+struct snapshot_begin {
+  query_basis basis = {};
+  result_schema schema = {};
+};
+
+struct row_upsert {
+  std::string key = {};
+  nlohmann::json row = nlohmann::json::object();
+  nlohmann::json evidence_ref = nlohmann::json::object();
+};
+
+struct row_retract {
+  std::string key = {};
+  std::string before_hash = {};
+  nlohmann::json evidence_ref = nlohmann::json::object();
+};
+
+struct progress {
+  query_frontier frontier = {};
+  nlohmann::json watermark = nlohmann::json::object();
+};
+
+struct schema_change {
+  result_schema old_schema = {};
+  result_schema new_schema = {};
+  std::string compatibility = "unknown";
+};
+
+struct snapshot_end {
+  std::string result_hash = {};
+  query_frontier frontier = {};
+};
+
+struct gap {
+  nlohmann::json expected = nlohmann::json::object();
+  nlohmann::json observed = nlohmann::json::object();
+  std::string recovery_hint = "request-full-snapshot";
+};
+
+using changelog_payload =
+    std::variant<snapshot_begin, row_upsert, row_retract, progress, schema_change, snapshot_end, gap>;
+
+struct changelog_message {
+  std::string message_id = {};
+  uint64_t index = 0;
+  changelog_payload payload = snapshot_begin{};
+};
+
+struct changelog_page {
+  std::string schema = QUERY_CHANGELOG_SCHEMA_V1;
+  std::string batch_id = {};
+  std::vector<changelog_message> messages = {};
+  query_resume_token resume_token = {};
+  bool complete = false;
+};
+
 [[nodiscard]] query_definition parse_query_definition(const nlohmann::json &value);
 
 [[nodiscard]] nlohmann::json query_definition_json(const query_definition &definition);
@@ -158,6 +244,16 @@ struct query_result {
 [[nodiscard]] nlohmann::json query_examples_json();
 
 [[nodiscard]] nlohmann::json query_result_json(const query_result &result);
+
+[[nodiscard]] query_resume_token parse_query_resume_token(const nlohmann::json &value);
+
+[[nodiscard]] nlohmann::json query_resume_token_json(const query_resume_token &token);
+
+[[nodiscard]] nlohmann::json changelog_page_json(const changelog_page &page);
+
+[[nodiscard]] changelog_page run_episode_changelog(const std::string &runtime_dir, const logical_plan &plan,
+                                                   const nlohmann::json &resume_token = nlohmann::json::object(),
+                                                   uint64_t max_messages = 100);
 
 [[nodiscard]] query_result run_episode_authority_scan(const std::string &runtime_dir, const logical_plan &plan);
 

--- a/framework/core/src/libkungfu/include/kungfu/runtime/storage/json_edge.h
+++ b/framework/core/src/libkungfu/include/kungfu/runtime/storage/json_edge.h
@@ -29,6 +29,7 @@ enum class storage_operation {
   Query,
   QueryPlan,
   FactQuery,
+  FactChangelog,
   FactContract,
   FactDeclareWorld,
   FactDeclareSurface,

--- a/framework/core/src/libkungfu/src/runtime/query/fact_query.cpp
+++ b/framework/core/src/libkungfu/src/runtime/query/fact_query.cpp
@@ -6,6 +6,7 @@
 #include <cctype>
 #include <charconv>
 #include <initializer_list>
+#include <map>
 #include <regex>
 #include <stdexcept>
 #include <string>
@@ -486,6 +487,15 @@ nlohmann::json query_capabilities_json() {
                                                   {"declaration", episode_fact_surface_declaration_payload()}}})}}},
       {"formats", nlohmann::json::array({"json", "ndjson", "tsv"})},
       {"frontends", nlohmann::json::array({"query-definition", "bounded-sql"})},
+      {"continuous",
+       {{"schema", QUERY_CHANGELOG_SCHEMA_V1},
+        {"resume_token_schema", QUERY_RESUME_TOKEN_SCHEMA_V1},
+        {"messages", nlohmann::json::array({"SnapshotBegin", "RowUpsert", "RowRetract", "Progress", "SchemaChange",
+                                            "SnapshotEnd", "Gap"})},
+        {"ordering", "batch-index"},
+        {"replay", "message-idempotent"},
+        {"backpressure", "bounded-pages"}}},
+      {"saved_view_schema", QUERY_VIEW_SCHEMA_V1},
       {"sql",
        {{"object", "episodes"},
         {"accepted", nlohmann::json::array(
@@ -496,10 +506,10 @@ nlohmann::json query_capabilities_json() {
         {"basis_owner", "QueryDefinition"}}},
       {"execution_engines", nlohmann::json::array({"episode-authority-scan/v1", "episode-sqlite-projection/v1"})},
       {"commands", nlohmann::json::array({"capabilities", "schema", "describe", "examples", "compile-sql", "validate",
-                                          "explain", "prove"})},
+                                          "explain", "prove", "changelog", "saved-view"})},
       {"limits", {{"minimum", 1}, {"maximum", 1000}}},
-      {"error_codes",
-       nlohmann::json::array({"KF_QUERY_INPUT", "KF_QUERY_VALIDATION", "KF_QUERY_EXECUTION", "KF_QUERY_OUTPUT"})},
+      {"error_codes", nlohmann::json::array({"KF_QUERY_INPUT", "KF_QUERY_VALIDATION", "KF_QUERY_EXECUTION",
+                                             "KF_QUERY_OUTPUT", "KF_QUERY_CHANGELOG", "KF_QUERY_VIEW"})},
       {"physical_plan", {{"public", false}, {"reason", "engine-private-and-replaceable"}}}};
 }
 
@@ -644,6 +654,353 @@ nlohmann::json query_result_json(const query_result &result) {
             {"episode_content_roots", roots},
             {"missing_inputs", missing},
             {"unverifiable_inputs", unverifiable}}}};
+}
+
+namespace {
+
+nlohmann::json frontier_json(const query_frontier &frontier) {
+  if (frontier.kind == frontier_kind::Empty) {
+    return {{"kind", "empty"}, {"record_count", "0"}};
+  }
+  return {{"kind", "manifest_frame_uid"},
+          {"manifest_frame_uid", std::to_string(frontier.manifest_frame_uid)},
+          {"record_count", std::to_string(frontier.record_count)}};
+}
+
+query_frontier parse_frontier(const nlohmann::json &value, const char *path) {
+  reject_unknown_fields(value, {"kind", "manifest_frame_uid", "record_count"}, path);
+  const auto kind = optional_text(value, "kind");
+  if (kind == "empty") {
+    if (value.contains("manifest_frame_uid")) {
+      throw std::invalid_argument(std::string(path) + " empty frontier must not carry manifest_frame_uid");
+    }
+    return {};
+  }
+  if (kind == "manifest_frame_uid") {
+    return {frontier_kind::ManifestFrameUid, optional_uint64(value, "manifest_frame_uid"),
+            optional_uint64(value, "record_count")};
+  }
+  throw std::invalid_argument(std::string(path) + " kind must be empty or manifest_frame_uid");
+}
+
+query_frontier result_frontier(const query_result &result) {
+  const auto &resolved = result.proof.cut.at("resolved");
+  const auto kind = optional_text(resolved, "kind");
+  if (kind == "empty") {
+    return {};
+  }
+  if (kind == "manifest_frame_uid") {
+    return {frontier_kind::ManifestFrameUid, optional_uint64(resolved, "manifest_frame_uid"),
+            optional_uint64(result.proof.authority, "record_count")};
+  }
+  throw std::runtime_error("query result has no resumable frontier");
+}
+
+nlohmann::json result_frontier_evidence_json(const query_result &result) {
+  auto value = result.proof.cut.at("resolved");
+  value["record_count"] = std::to_string(optional_uint64(result.proof.authority, "record_count"));
+  return value;
+}
+
+bool same_frontier(const query_frontier &left, const query_frontier &right) {
+  return left.kind == right.kind &&
+         (left.kind == frontier_kind::Empty ||
+          (left.manifest_frame_uid == right.manifest_frame_uid && left.record_count == right.record_count));
+}
+
+bool frontier_regressed(const query_frontier &from, const query_frontier &target) {
+  return target.record_count < from.record_count;
+}
+
+nlohmann::json resume_token_payload_json(const query_resume_token &token) {
+  return {{"schema", token.schema},
+          {"definition", query_definition_json(token.definition)},
+          {"query_definition_hash", token.query_definition_hash},
+          {"logical_plan_hash", token.logical_plan_hash},
+          {"from", frontier_json(token.from)},
+          {"from_result_hash", token.from_result_hash},
+          {"target", frontier_json(token.target)},
+          {"target_result_hash", token.target_result_hash},
+          {"next_message_index", token.next_message_index},
+          {"batch_id", token.batch_id}};
+}
+
+void seal_resume_token(query_resume_token &token) { token.token_hash = json_hash(resume_token_payload_json(token)); }
+
+std::string changelog_batch_id(const logical_plan &plan, const query_frontier &from,
+                               const std::string &from_result_hash, const query_frontier &target,
+                               const std::string &target_result_hash) {
+  return json_hash({{"query_definition_hash", plan.query_definition_hash},
+                    {"logical_plan_hash", plan.logical_plan_hash},
+                    {"from", frontier_json(from)},
+                    {"from_result_hash", from_result_hash},
+                    {"target", frontier_json(target)},
+                    {"target_result_hash", target_result_hash}});
+}
+
+query_result run_at_frontier(const std::string &runtime_dir, const query_definition &definition,
+                             const query_frontier &frontier) {
+  auto bounded = definition;
+  bounded.basis.selected_cut.kind = cut_kind::ManifestFrameUid;
+  bounded.basis.selected_cut.manifest_frame_uid =
+      frontier.kind == frontier_kind::Empty ? 0 : frontier.manifest_frame_uid;
+  return run_episode_authority_scan(runtime_dir, plan_query(bounded));
+}
+
+std::string row_key(const nlohmann::json &row) {
+  if (!row.is_object() || !row.contains("episode_id")) {
+    throw std::runtime_error("episode changelog row has no episode_id key");
+  }
+  const auto &value = row.at("episode_id");
+  if (value.is_string()) {
+    return value.get<std::string>();
+  }
+  if (value.is_number_unsigned()) {
+    return std::to_string(value.get<uint64_t>());
+  }
+  if (value.is_number_integer() && value.get<int64_t>() >= 0) {
+    return std::to_string(value.get<int64_t>());
+  }
+  throw std::runtime_error("episode changelog key must be an unsigned integer");
+}
+
+std::map<std::string, nlohmann::json> rows_by_key(const query_result &result) {
+  std::map<std::string, nlohmann::json> rows;
+  for (const auto &row : result.rows) {
+    const auto key = row_key(row);
+    if (!rows.emplace(key, row).second) {
+      throw std::runtime_error("episode changelog contains duplicate key " + key);
+    }
+  }
+  return rows;
+}
+
+nlohmann::json evidence_reference(const query_result &result, const nlohmann::json &row) {
+  return {{"episode_id", row_key(row)},
+          {"content_root", row.value("content_root", nlohmann::json(nullptr))},
+          {"content_root_status", row.value("content_root_status", "unverifiable")},
+          {"canonical_state", result.proof.canonical_state},
+          {"determinism", result.proof.determinism},
+          {"missing_inputs", result.proof.missing_inputs},
+          {"unverifiable_inputs", result.proof.unverifiable_inputs}};
+}
+
+nlohmann::json changelog_payload_json(const changelog_payload &payload) {
+  return std::visit(
+      [](const auto &message) -> nlohmann::json {
+        using message_type = std::decay_t<decltype(message)>;
+        if constexpr (std::is_same_v<message_type, snapshot_begin>) {
+          return {
+              {"type", "SnapshotBegin"},
+              {"basis", query_definition_json(query_definition{QUERY_DEFINITION_SCHEMA_V1, message.basis})["basis"]},
+              {"result_schema", result_schema_json(message.schema)}};
+        } else if constexpr (std::is_same_v<message_type, row_upsert>) {
+          return {{"type", "RowUpsert"},
+                  {"key", message.key},
+                  {"row", message.row},
+                  {"evidence_ref", message.evidence_ref}};
+        } else if constexpr (std::is_same_v<message_type, row_retract>) {
+          return {{"type", "RowRetract"},
+                  {"key", message.key},
+                  {"before_hash", message.before_hash},
+                  {"evidence_ref", message.evidence_ref}};
+        } else if constexpr (std::is_same_v<message_type, progress>) {
+          return {
+              {"type", "Progress"}, {"frontier", frontier_json(message.frontier)}, {"watermark", message.watermark}};
+        } else if constexpr (std::is_same_v<message_type, schema_change>) {
+          return {{"type", "SchemaChange"},
+                  {"old_schema", result_schema_json(message.old_schema)},
+                  {"new_schema", result_schema_json(message.new_schema)},
+                  {"compatibility", message.compatibility}};
+        } else if constexpr (std::is_same_v<message_type, snapshot_end>) {
+          return {{"type", "SnapshotEnd"},
+                  {"result_hash", message.result_hash},
+                  {"frontier", frontier_json(message.frontier)}};
+        } else {
+          return {{"type", "Gap"},
+                  {"expected", message.expected},
+                  {"observed", message.observed},
+                  {"recovery_hint", message.recovery_hint}};
+        }
+      },
+      payload);
+}
+
+} // namespace
+
+query_resume_token parse_query_resume_token(const nlohmann::json &value) {
+  reject_unknown_fields(value,
+                        {"schema", "definition", "query_definition_hash", "logical_plan_hash", "from",
+                         "from_result_hash", "target", "target_result_hash", "next_message_index", "batch_id",
+                         "token_hash"},
+                        "resume_token");
+  query_resume_token token;
+  token.schema = optional_text(value, "schema");
+  if (token.schema != QUERY_RESUME_TOKEN_SCHEMA_V1) {
+    throw std::invalid_argument("unsupported query resume token schema");
+  }
+  token.definition = parse_query_definition(value.at("definition"));
+  token.query_definition_hash = optional_text(value, "query_definition_hash");
+  token.logical_plan_hash = optional_text(value, "logical_plan_hash");
+  token.from = parse_frontier(value.at("from"), "resume_token.from");
+  token.from_result_hash = optional_text(value, "from_result_hash");
+  token.target = parse_frontier(value.at("target"), "resume_token.target");
+  token.target_result_hash = optional_text(value, "target_result_hash");
+  token.next_message_index = optional_uint64(value, "next_message_index");
+  token.batch_id = optional_text(value, "batch_id");
+  token.token_hash = optional_text(value, "token_hash");
+  if (token.batch_id.empty() || token.token_hash.empty() ||
+      token.token_hash != json_hash(resume_token_payload_json(token))) {
+    throw std::invalid_argument("query resume token integrity check failed");
+  }
+  return token;
+}
+
+nlohmann::json query_resume_token_json(const query_resume_token &token) {
+  auto value = resume_token_payload_json(token);
+  value["token_hash"] = token.token_hash;
+  return value;
+}
+
+nlohmann::json changelog_page_json(const changelog_page &page) {
+  auto messages = nlohmann::json::array();
+  for (const auto &message : page.messages) {
+    auto value = changelog_payload_json(message.payload);
+    value["message_id"] = message.message_id;
+    value["index"] = message.index;
+    messages.push_back(std::move(value));
+  }
+  return {{"schema", page.schema},
+          {"batch_id", page.batch_id},
+          {"messages", std::move(messages)},
+          {"resume_token", query_resume_token_json(page.resume_token)},
+          {"complete", page.complete}};
+}
+
+changelog_page run_episode_changelog(const std::string &runtime_dir, const logical_plan &plan,
+                                     const nlohmann::json &resume_token, uint64_t max_messages) {
+  if (plan.definition.basis.selected_cut.kind != cut_kind::Head) {
+    throw std::invalid_argument("continuous query requires a head cut");
+  }
+  if (max_messages == 0 || max_messages > 10000) {
+    throw std::invalid_argument("max_messages must be between 1 and 10000");
+  }
+
+  const auto current = run_episode_authority_scan(runtime_dir, plan);
+  const auto current_frontier = result_frontier(current);
+  query_resume_token cursor;
+  bool continuing_batch = false;
+  if (resume_token.is_object() && !resume_token.empty()) {
+    cursor = parse_query_resume_token(resume_token);
+    const auto token_plan = plan_query(cursor.definition);
+    if (token_plan.query_definition_hash != plan.query_definition_hash ||
+        token_plan.logical_plan_hash != plan.logical_plan_hash ||
+        query_definition_json(cursor.definition) != query_definition_json(plan.definition)) {
+      throw std::invalid_argument("query resume token belongs to a different QueryDefinition");
+    }
+    continuing_batch = cursor.next_message_index != 0 || !same_frontier(cursor.from, cursor.target) ||
+                       cursor.from_result_hash != cursor.target_result_hash;
+  } else {
+    cursor.definition = plan.definition;
+    cursor.query_definition_hash = plan.query_definition_hash;
+    cursor.logical_plan_hash = plan.logical_plan_hash;
+  }
+
+  const auto from = cursor.from;
+  const auto from_hash = cursor.from_result_hash;
+  const auto target = continuing_batch ? cursor.target : current_frontier;
+  const auto target_hash = continuing_batch ? cursor.target_result_hash : current.result_hash;
+  const auto batch_id = changelog_batch_id(plan, from, from_hash, target, target_hash);
+
+  std::vector<changelog_message> all;
+  auto append = [&](changelog_payload payload) {
+    const auto index = static_cast<uint64_t>(all.size());
+    all.push_back({json_hash({{"batch_id", batch_id}, {"index", index}}), index, std::move(payload)});
+  };
+  auto gap_page = [&](nlohmann::json expected, nlohmann::json observed) {
+    append(gap{std::move(expected), std::move(observed), "discard-token-and-request-full-snapshot"});
+  };
+
+  query_result prior;
+  bool valid = true;
+  if (!from_hash.empty()) {
+    prior = run_at_frontier(runtime_dir, plan.definition, from);
+    if (prior.result_hash != from_hash) {
+      gap_page({{"frontier", frontier_json(from)}, {"result_hash", from_hash}},
+               {{"frontier", result_frontier_evidence_json(prior)}, {"result_hash", prior.result_hash}});
+      valid = false;
+    }
+  } else {
+    prior.definition = plan.definition;
+    prior.plan = plan;
+    prior.row_schema = plan.row_schema;
+    prior.result_hash =
+        json_hash({{"result_schema", result_schema_json(plan.row_schema)}, {"rows", nlohmann::json::array()}});
+  }
+
+  query_result target_result;
+  if (valid) {
+    target_result =
+        same_frontier(target, current_frontier) ? current : run_at_frontier(runtime_dir, plan.definition, target);
+    if (frontier_regressed(from, target) || target_result.result_hash != target_hash) {
+      gap_page(
+          {{"frontier", frontier_json(target)}, {"result_hash", target_hash}},
+          {{"frontier", result_frontier_evidence_json(target_result)}, {"result_hash", target_result.result_hash}});
+      valid = false;
+    }
+  }
+
+  if (valid) {
+    const auto prior_rows = rows_by_key(prior);
+    const auto target_rows = rows_by_key(target_result);
+    if (from_hash.empty()) {
+      append(snapshot_begin{plan.definition.basis, target_result.row_schema});
+    } else if (result_schema_json(prior.row_schema) != result_schema_json(target_result.row_schema)) {
+      append(schema_change{prior.row_schema, target_result.row_schema, "consumer-must-revalidate"});
+    }
+    for (const auto &[key, row] : prior_rows) {
+      if (!target_rows.contains(key)) {
+        append(row_retract{key, json_hash(row), evidence_reference(prior, row)});
+      }
+    }
+    for (const auto &[key, row] : target_rows) {
+      const auto previous = prior_rows.find(key);
+      if (previous == prior_rows.end() || previous->second != row) {
+        append(row_upsert{key, row, evidence_reference(target_result, row)});
+      }
+    }
+    if (from_hash.empty()) {
+      append(snapshot_end{target_result.result_hash, target});
+    } else {
+      append(progress{target, {{"kind", "authority-frontier"}, {"inclusive", true}}});
+    }
+  }
+
+  const auto begin = valid ? std::min<uint64_t>(cursor.next_message_index, all.size()) : 0;
+  const auto end = std::min<uint64_t>(all.size(), begin + max_messages);
+  changelog_page page;
+  page.batch_id = batch_id;
+  page.messages.insert(page.messages.end(), all.begin() + static_cast<std::ptrdiff_t>(begin),
+                       all.begin() + static_cast<std::ptrdiff_t>(end));
+  page.complete = !valid || end == all.size();
+  page.resume_token.definition = plan.definition;
+  page.resume_token.query_definition_hash = plan.query_definition_hash;
+  page.resume_token.logical_plan_hash = plan.logical_plan_hash;
+  page.resume_token.batch_id = batch_id;
+  if (page.complete && valid) {
+    page.resume_token.from = target;
+    page.resume_token.from_result_hash = target_hash;
+    page.resume_token.target = target;
+    page.resume_token.target_result_hash = target_hash;
+  } else {
+    page.resume_token.from = from;
+    page.resume_token.from_result_hash = from_hash;
+    page.resume_token.target = target;
+    page.resume_token.target_result_hash = target_hash;
+    page.resume_token.next_message_index = end;
+  }
+  seal_resume_token(page.resume_token);
+  return page;
 }
 
 static query_result run_episode_fold(const logical_plan &plan, const yy_storage::episode_manifest_fold &fold,

--- a/framework/core/src/libkungfu/src/runtime/storage/service.cpp
+++ b/framework/core/src/libkungfu/src/runtime/storage/service.cpp
@@ -4624,6 +4624,15 @@ public:
     throw std::invalid_argument("query engine must be authority or sqlite");
   }
 
+  [[nodiscard]] nlohmann::json fact_changelog(const storage_service_options &options) const {
+    const auto definition = query::parse_query_definition(options.query_definition);
+    const auto plan = query::plan_query(definition);
+    const auto resume_token = object_or_empty(options.operation_options, "resume_token");
+    const auto max_messages = uint64_or(options.operation_options, "max_messages", 100);
+    return query::changelog_page_json(
+        query::run_episode_changelog(options.runtime_dir, plan, resume_token, max_messages));
+  }
+
   [[nodiscard]] nlohmann::json fact_contract(const storage_service_options &options) const {
     (void)options;
     return facts::fact_contract_json();
@@ -5945,6 +5954,7 @@ std::vector<std::string> storage_operation_names() {
       storage_operation_name(storage_operation::Query),
       storage_operation_name(storage_operation::QueryPlan),
       storage_operation_name(storage_operation::FactQuery),
+      storage_operation_name(storage_operation::FactChangelog),
       storage_operation_name(storage_operation::FactContract),
       storage_operation_name(storage_operation::FactDeclareWorld),
       storage_operation_name(storage_operation::FactDeclareSurface),
@@ -6001,6 +6011,8 @@ std::string storage_operation_name(storage_operation operation) {
     return "query_plan";
   case storage_operation::FactQuery:
     return "fact_query";
+  case storage_operation::FactChangelog:
+    return "fact_changelog";
   case storage_operation::FactContract:
     return "fact_contract";
   case storage_operation::FactDeclareWorld:
@@ -6093,6 +6105,9 @@ storage_operation parse_storage_operation(const std::string &operation) {
   }
   if (operation == "fact_query") {
     return storage_operation::FactQuery;
+  }
+  if (operation == "fact_changelog") {
+    return storage_operation::FactChangelog;
   }
   if (operation == "fact_contract") {
     return storage_operation::FactContract;
@@ -6198,7 +6213,8 @@ nlohmann::json make_storage_service_request(const std::string &operation, const 
     request["query"] = parsed_options.query;
     request["kind"] = parsed_options.kind.empty() ? nlohmann::json(nullptr) : nlohmann::json(parsed_options.kind);
     request["limit"] = parsed_options.limit;
-  } else if (parsed_operation == storage_operation::QueryPlan || parsed_operation == storage_operation::FactQuery) {
+  } else if (parsed_operation == storage_operation::QueryPlan || parsed_operation == storage_operation::FactQuery ||
+             parsed_operation == storage_operation::FactChangelog) {
     request["definition"] = parsed_options.query_definition;
     request["action"] = text_or(parsed_options.operation_options, "action");
   } else if (parsed_operation == storage_operation::Layout) {
@@ -6253,6 +6269,8 @@ nlohmann::json run_storage_service_operation(const std::string &operation, const
     return storage_json_edge_service_instance().query_plan(parsed_options);
   case storage_operation::FactQuery:
     return storage_json_edge_service_instance().fact_query(parsed_options);
+  case storage_operation::FactChangelog:
+    return storage_json_edge_service_instance().fact_changelog(parsed_options);
   case storage_operation::FactContract:
     return storage_json_edge_service_instance().fact_contract(parsed_options);
   case storage_operation::FactDeclareWorld:

--- a/framework/core/src/python/kungfu/agent/commands.json
+++ b/framework/core/src/python/kungfu/agent/commands.json
@@ -266,6 +266,18 @@
       "purpose": "Execute the same planner through the semantic Episode shortcut."
     },
     {
+      "apiId": "kungfu.query.changelog",
+      "name": "kungfu query changelog --file query.json --json",
+      "maturity": "experimental",
+      "purpose": "Read a bounded resumable page of the typed proof-carrying changelog."
+    },
+    {
+      "apiId": "kungfu.query.saved-view",
+      "name": "kungfu query saved-view --file saved-view.json --json",
+      "maturity": "experimental",
+      "purpose": "Inspect the same QueryDefinition and presentation-only ViewSpec artifact used by the GUI."
+    },
+    {
       "apiId": "kungfu.facts.capabilities",
       "name": "kungfu facts capabilities",
       "maturity": "experimental",

--- a/framework/core/src/python/kungfu/agent/kfd3_api.registry.json
+++ b/framework/core/src/python/kungfu/agent/kfd3_api.registry.json
@@ -455,6 +455,26 @@
       "projections": ["commands.json", "agent-pack-doc", "provider-skill"]
     },
     {
+      "id": "kungfu.query.changelog",
+      "surface": "cli",
+      "name": "kungfu query changelog --file query.json --json",
+      "purpose": "Read a bounded resumable page of the typed proof-carrying changelog.",
+      "maturity": "experimental",
+      "visibility": "adjacent-agent",
+      "anchor": { "kind": "catalog" },
+      "projections": ["commands.json", "agent-pack-doc", "provider-skill"]
+    },
+    {
+      "id": "kungfu.query.saved-view",
+      "surface": "cli",
+      "name": "kungfu query saved-view --file saved-view.json --json",
+      "purpose": "Inspect the same QueryDefinition and presentation-only ViewSpec artifact used by the GUI.",
+      "maturity": "experimental",
+      "visibility": "adjacent-agent",
+      "anchor": { "kind": "catalog" },
+      "projections": ["commands.json", "agent-pack-doc", "provider-skill"]
+    },
+    {
       "id": "kungfu.facts.capabilities",
       "surface": "cli",
       "name": "kungfu facts capabilities",

--- a/framework/core/src/python/kungfu/cli/commands/query.py
+++ b/framework/core/src/python/kungfu/cli/commands/query.py
@@ -56,6 +56,33 @@ def _runtime_dir(ctx: click.Context) -> str:
     return str(ctx.__dict__["runtime_dir"])
 
 
+def _load_json_object(file_path: str, label: str) -> dict[str, Any]:
+    value = _load_definition(file_path)
+    if not isinstance(value, dict):
+        _fail("KF_QUERY_INPUT", f"{label} must be a JSON object")
+    return value
+
+
+def _load_saved_view(file_path: str) -> dict[str, Any]:
+    value = _load_json_object(file_path, "saved query view")
+    if value.get("schema") != "kungfu.query.saved-view/v1":
+        _fail("KF_QUERY_VIEW", "unsupported saved query view schema")
+    if not isinstance(value.get("name"), str) or not value["name"]:
+        _fail("KF_QUERY_VIEW", "saved query view requires a name")
+    definition = value.get("definition")
+    view = value.get("view")
+    if not isinstance(definition, dict):
+        _fail("KF_QUERY_VIEW", "saved query view requires a QueryDefinition")
+    if not isinstance(view, dict) or view.get("kind") not in {
+        "table",
+        "timeline",
+        "diff",
+        "causal-graph",
+    }:
+        _fail("KF_QUERY_VIEW", "saved query view requires a supported ViewSpec")
+    return value
+
+
 def _planner_call(ctx: click.Context, action: str, **kwargs: Any) -> dict[str, Any]:
     from kungfu.storage import service
 
@@ -159,6 +186,33 @@ def describe(ctx: click.Context, object_name: str, as_json: bool) -> None:
 def examples(ctx: click.Context, as_json: bool) -> None:
     del as_json
     _echo_json(_planner_call(ctx, "examples"))
+
+
+@query.command(
+    name="saved-view", help="inspect a shared QueryDefinition + ViewSpec artifact"
+)
+@click.option(
+    "--file", "file_path", required=True, help="kungfu.query.saved-view/v1 JSON path"
+)
+@click.option(
+    "--json", "as_json", is_flag=True, help="machine-readable output (default)"
+)
+@query_command_context
+def saved_view(ctx: click.Context, file_path: str, as_json: bool) -> None:
+    del as_json
+    value = _load_saved_view(file_path)
+    validation = _planner_call(ctx, "validate", definition=value["definition"])
+    _echo_json(
+        {
+            "schema": "kungfu.query.saved-view-inspection/v1",
+            "ok": True,
+            "name": value["name"],
+            "definition": validation["definition"],
+            "query_definition_hash": validation["query_definition_hash"],
+            "logical_plan_hash": validation["logical_plan_hash"],
+            "view": value["view"],
+        }
+    )
 
 
 @query.command(help="validate and canonically hash a QueryDefinition")
@@ -302,3 +356,50 @@ def prove(
         _emit_tsv(result)
     else:
         _echo_json(result)
+
+
+@query.command(help="read one resumable page of the proof-carrying changelog")
+@click.option(
+    "--file",
+    "file_path",
+    required=True,
+    help="head-cut QueryDefinition JSON path or - for stdin",
+)
+@click.option(
+    "--resume-file",
+    default=None,
+    help="resume-token JSON path returned by an earlier page",
+)
+@click.option(
+    "--max-messages",
+    type=click.IntRange(min=1, max=10000),
+    default=100,
+    show_default=True,
+)
+@click.option(
+    "--json", "as_json", is_flag=True, help="machine-readable output (default)"
+)
+@query_command_context
+def changelog(
+    ctx: click.Context,
+    file_path: str,
+    resume_file: str | None,
+    max_messages: int,
+    as_json: bool,
+) -> None:
+    from kungfu.storage import service
+
+    del as_json
+    resume_token = (
+        _load_json_object(resume_file, "resume token") if resume_file else None
+    )
+    try:
+        result = service.fact_changelog(
+            _runtime_dir(ctx),
+            _load_definition(file_path),
+            resume_token=resume_token,
+            max_messages=max_messages,
+        )
+    except (RuntimeError, TypeError, ValueError) as error:
+        _fail("KF_QUERY_CHANGELOG", str(error), exit_code=1)
+    _echo_json(result)

--- a/framework/core/src/python/kungfu/storage/service.py
+++ b/framework/core/src/python/kungfu/storage/service.py
@@ -720,6 +720,28 @@ def fact_query(
     )
 
 
+def fact_changelog(
+    runtime_dir: str | Path,
+    definition: dict[str, Any],
+    *,
+    resume_token: dict[str, Any] | None = None,
+    max_messages: int = 100,
+) -> dict[str, Any]:
+    """Read one deterministic page of the ADR-0048 proof changelog."""
+
+    options: dict[str, Any] = {
+        "definition": definition,
+        "max_messages": max_messages,
+    }
+    if resume_token is not None:
+        options["resume_token"] = resume_token
+    return dict(
+        _runtime().run_storage_service_operation(
+            "fact_changelog", str(runtime_dir), options
+        )
+    )
+
+
 def fact_contract(runtime_dir: str | Path = "") -> dict[str, Any]:
     """Return the C++-owned ADR-0051 declaration/admission contract."""
 

--- a/framework/core/tests/python/test_atlas_storage.py
+++ b/framework/core/tests/python/test_atlas_storage.py
@@ -521,6 +521,7 @@ def test_runtime_storage_service_surface_is_bound_from_libkungfu(tmp_path):
         "query",
         "query_plan",
         "fact_query",
+        "fact_changelog",
         "fact_contract",
         "fact_declare_world",
         "fact_declare_surface",
@@ -1414,6 +1415,84 @@ def test_domain_fact_admission_replays_declaration_history_and_observation_lifec
     assert all(event["episode_id"] for event in head["observation_history"])
     assert head["proof"]["schema_owner"] == "flatbuffers"
     assert head["proof"]["schema_root"].startswith("sha256:")
+
+
+def test_fact_changelog_resumes_pages_without_loss_or_duplication(tmp_path):
+    runtime_dir = tmp_path / "runtime"
+    storage_service.episode_begin(
+        runtime_dir, episode_id=8048, title="changelog", begin_time=1000
+    )
+    definition = storage_service.build_fact_query_definition(episode_id=8048)
+
+    first = storage_service.fact_changelog(runtime_dir, definition, max_messages=2)
+    assert first["schema"] == "kungfu.query.changelog/v1"
+    assert first["complete"] is False
+    assert [message["type"] for message in first["messages"]] == [
+        "SnapshotBegin",
+        "RowUpsert",
+    ]
+    assert len({message["message_id"] for message in first["messages"]}) == 2
+    assert int(first["resume_token"]["target"]["record_count"]) >= 1
+
+    tampered = json.loads(json.dumps(first["resume_token"]))
+    tampered["next_message_index"] += 1
+    with pytest.raises((RuntimeError, ValueError), match="integrity check failed"):
+        storage_service.fact_changelog(
+            runtime_dir, definition, resume_token=tampered, max_messages=2
+        )
+
+    second = storage_service.fact_changelog(
+        runtime_dir,
+        definition,
+        resume_token=first["resume_token"],
+        max_messages=2,
+    )
+    assert second["batch_id"] == first["batch_id"]
+    assert second["complete"] is True
+    assert [message["type"] for message in second["messages"]] == ["SnapshotEnd"]
+    assert [message["index"] for message in first["messages"] + second["messages"]] == [
+        0,
+        1,
+        2,
+    ]
+
+    steady = second["resume_token"]
+    unchanged = storage_service.fact_changelog(
+        runtime_dir, definition, resume_token=steady
+    )
+    assert unchanged["complete"] is True
+    assert [message["type"] for message in unchanged["messages"]] == ["Progress"]
+
+    storage_service.episode_end(
+        runtime_dir,
+        episode_id=8048,
+        end_time=1200,
+        reason="done",
+    )
+    changed = storage_service.fact_changelog(
+        runtime_dir, definition, resume_token=steady, max_messages=1
+    )
+    replay = storage_service.fact_changelog(
+        runtime_dir, definition, resume_token=steady, max_messages=1
+    )
+    assert changed == replay
+    assert changed["complete"] is False
+    assert changed["messages"][0]["type"] == "RowUpsert"
+    assert changed["messages"][0]["row"]["status"] == "ended"
+    assert changed["messages"][0]["evidence_ref"]["content_root_status"] in {
+        "verified",
+        "undefined",
+    }
+
+    finished = storage_service.fact_changelog(
+        runtime_dir,
+        definition,
+        resume_token=changed["resume_token"],
+        max_messages=10,
+    )
+    assert finished["complete"] is True
+    assert [message["type"] for message in finished["messages"]] == ["Progress"]
+    assert finished["messages"][0]["frontier"]["kind"] == "manifest_frame_uid"
 
 
 def test_query_planner_normalizes_defaults_and_exposes_one_semantic_root(tmp_path):

--- a/framework/core/tests/python/test_query_cli.py
+++ b/framework/core/tests/python/test_query_cli.py
@@ -156,6 +156,69 @@ def test_query_cli_returns_stable_validation_error_code(tmp_path):
     assert error["error"]["code"] == "KF_QUERY_VALIDATION"
 
 
+def test_query_cli_shares_saved_view_and_resumes_changelog(tmp_path):
+    home = tmp_path / "home"
+    runtime_dir = home / "runtime"
+    storage_service.episode_begin(runtime_dir, episode_id=48, begin_time=1000)
+    definition = storage_service.build_fact_query_definition(episode_id=48)
+    definition_path = tmp_path / "query.json"
+    definition_path.write_text(json.dumps(definition), encoding="utf-8")
+    saved_path = tmp_path / "saved-view.json"
+    saved_path.write_text(
+        json.dumps(
+            {
+                "schema": "kungfu.query.saved-view/v1",
+                "name": "episode-48",
+                "definition": definition,
+                "view": {
+                    "kind": "table",
+                    "columns": ["episode_id", "status", "content_root_status"],
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    runner = CliRunner()
+
+    inspected = _invoke(runner, home, "saved-view", "--file", str(saved_path), "--json")
+    first = _invoke(
+        runner,
+        home,
+        "changelog",
+        "--file",
+        str(definition_path),
+        "--max-messages",
+        "2",
+        "--json",
+    )
+
+    assert inspected.exit_code == 0, inspected.output
+    assert first.exit_code == 0, first.output
+    inspected_value = json.loads(inspected.output)
+    first_value = json.loads(first.output)
+    assert inspected_value["definition"] == definition
+    assert inspected_value["view"]["kind"] == "table"
+    assert first_value["complete"] is False
+    resume_path = tmp_path / "resume.json"
+    resume_path.write_text(json.dumps(first_value["resume_token"]), encoding="utf-8")
+
+    resumed = _invoke(
+        runner,
+        home,
+        "changelog",
+        "--file",
+        str(definition_path),
+        "--resume-file",
+        str(resume_path),
+        "--json",
+    )
+    assert resumed.exit_code == 0, resumed.output
+    resumed_value = json.loads(resumed.output)
+    assert resumed_value["batch_id"] == first_value["batch_id"]
+    assert resumed_value["complete"] is True
+    assert [message["type"] for message in resumed_value["messages"]] == ["SnapshotEnd"]
+
+
 def test_query_cli_compiles_bounded_sql_and_runs_sqlite_engine(tmp_path):
     home = tmp_path / "home"
     runtime_dir = home / "runtime"

--- a/framework/kfx/src/index.ts
+++ b/framework/kfx/src/index.ts
@@ -37,6 +37,21 @@ export type {
   TerminalSession,
   TerminalSpawnOptions,
   TerminalStatus,
+  QueryChangelogMessage,
+  QueryChangelogPage,
+  QueryChangelogState,
+  QueryDefinition,
+  QueryFrontier,
+  QueryResumeToken,
+  QueryResultSchema,
+  QueryViewSpec,
+  SavedQueryView,
+} from '@kungfu-tech/api/capability';
+export {
+  applyQueryChangelogPage,
+  emptyQueryChangelogState,
+  parseSavedQueryView,
+  queryRows,
 } from '@kungfu-tech/api/capability';
 
 // ── capability surface ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary\n- add a native typed kungfu.query.changelog/v1 stream with integrity-checked resume tokens and reproducible authority cuts\n- expose changelog paging through storage, Python CLI, TypeScript/KFX contracts, and saved-view JSON\n- add System Status table, timeline, diff, and causal-graph reference views with visible evidence and Gap handling\n- document the Q3 contract and extend native, Python, CLI, and TypeScript coverage\n\n## Correctness properties\n- resume tokens pin the query definition, logical plan, authority frontiers, result hashes, batch, and next message index\n- opaque frame UIDs locate exact cuts; authority record counts establish monotonic advancement\n- replay is deterministic and idempotent, with bounded paging and explicit Gap on unreproducible state\n- GUI state is reconstructed from the native changelog; saved views persist only QueryDefinition and ViewSpec\n\n## Validation\n- ./shifu check\n- ./shifu --filter @kungfu-tech/core compile\n- targeted native/Python storage tests\n- query CLI tests\n- TypeScript query tests\n- API and KFX tsc --noEmit\n- System Status KFX bundle build\n\nSigned-off-by: Keren Dong <dkr@kungfu-trader.com>