### PR TITLE
test(core): stabilize libwasm copy evidence

### DIFF
--- a/crates/libwasm-spike/src/lib.rs
+++ b/crates/libwasm-spike/src/lib.rs
@@ -23,6 +23,7 @@ const CAP_READ_JOURNAL_BATCH: u64 = 1 << 0;
 const MAX_BATCH_FRAMES: u32 = 4096;
 
 const LIBWASM_ABI_V1: u32 = 1;
+const COPY_BENCH_REPEATS: u64 = 8;
 const ENGINE_WASMTIME: u32 = 1;
 #[cfg(feature = "wasmer-engine")]
 const ENGINE_WASMER: u32 = 2;
@@ -676,12 +677,22 @@ unsafe fn run(
         return Err(INVARIANT_ERROR);
     }
     let payloads = one_mib.payloads()?;
-    let (value, copy_ns) = timed(|| guest.consume(&payloads))?;
-    if value != ((0x5a_u64 << 32) | 0x5a) || copy_ns == 0 {
+    let ((), copy_total_ns) = timed(|| {
+        for _ in 0..COPY_BENCH_REPEATS {
+            if guest.consume(&payloads)? != ((0x5a_u64 << 32) | 0x5a) {
+                return Err(INVARIANT_ERROR);
+            }
+        }
+        Ok(())
+    })?;
+    if copy_total_ns == 0 {
         return Err(INVARIANT_ERROR);
     }
     let one_mib_bytes = one_mib.raw.payload_bytes;
-    let throughput = ((one_mib_bytes as u128) * 1_000_000_000_u128 / copy_ns as u128) as u64;
+    let measured_copy_bytes = one_mib_bytes * COPY_BENCH_REPEATS;
+    let copy_ns = copy_total_ns / COPY_BENCH_REPEATS;
+    let throughput =
+        ((measured_copy_bytes as u128) * 1_000_000_000_u128 / copy_total_ns as u128) as u64;
     drop(one_mib);
 
     let trap_contained = guest.trap_is_contained();
@@ -698,7 +709,7 @@ unsafe fn run(
     report.batch_calls = config.measured_batches as u64;
     report.frame_count = frame_count;
     report.payload_bytes = payload_bytes;
-    report.host_to_guest_bytes_copied = copied_bytes + one_mib_bytes;
+    report.host_to_guest_bytes_copied = copied_bytes + measured_copy_bytes;
     report.guest_to_host_bytes_copied = 0;
     report.control_p50_ns = percentile(&mut controls.clone(), 50);
     report.control_p99_ns = percentile(&mut controls, 99);

--- a/framework/core/slices/libwasm-shared-membrane/README.md
+++ b/framework/core/slices/libwasm-shared-membrane/README.md
@@ -43,8 +43,11 @@ The same three-trial schema gates both engines against ADR-0045's provisional
 budgets: control p99 at most 10 microseconds, 4 KiB batch p99 at most 50
 microseconds, 1 MiB effective copy throughput at least 1 GiB/s, and idle
 instance resident delta at most 16 MiB excluding the already-loaded engine
-code. Guest traps and a deliberate Rust panic must return as contained status,
-never unwind across C.
+code. Each trial averages eight consecutive 1 MiB guest copies before the
+outer three-trial median, so a single runner scheduling interruption cannot
+decide the throughput verdict; all eight copies remain visible in the byte
+accounting. Guest traps and a deliberate Rust panic must return as contained
+status, never unwind across C.
 
 Run through the repository entrypoint:
 

--- a/framework/core/slices/libwasm-shared-membrane/host.cpp
+++ b/framework/core/slices/libwasm-shared-membrane/host.cpp
@@ -26,6 +26,7 @@ constexpr int32_t MSG_ONE_MIB = 21102;
 constexpr uint32_t BATCH_FRAMES = 16;
 constexpr uint32_t WARMUP_BATCHES = 10;
 constexpr uint32_t MEASURED_BATCHES = 1000;
+constexpr uint64_t COPY_BENCH_REPEATS = 8;
 constexpr uint32_t FIXTURE_FRAMES = BATCH_FRAMES * (WARMUP_BATCHES + MEASURED_BATCHES);
 
 bool seed(const std::string &root) {
@@ -123,7 +124,7 @@ bool run_engine(const dynamic_library &libwasm, const char *library_path, const 
   const auto status = run(&api, &config, &report);
   const uint64_t expected_frames = static_cast<uint64_t>(BATCH_FRAMES) * MEASURED_BATCHES;
   const uint64_t expected_payload = expected_frames * 256U;
-  const uint64_t expected_copied = expected_payload + 1024U * 1024U;
+  const uint64_t expected_copied = expected_payload + 1024U * 1024U * COPY_BENCH_REPEATS;
   if (status != 0 || report.abi_version != KF_LIBWASM_ABI_V1 || report.engine != engine || report.trap_contained != 1 ||
       report.batch_calls != MEASURED_BATCHES || report.frame_count != expected_frames ||
       report.payload_bytes != expected_payload || report.host_to_guest_bytes_copied != expected_copied ||


### PR DESCRIPTION
## Summary

- average eight consecutive 1 MiB guest copies inside each throughput observation
- keep the existing 1 GiB/s gate and outer three-trial median unchanged
- account for every measured host-to-guest byte and document the sampling boundary

## Why

PR #561 merged the libwasm spike before its late-attached embedding matrix completed. The macOS job then exposed that one isolated 1 MiB timing sample could be dominated by runner scheduling: Wasmer measured 1.63 GB/s once and about 0.70 GB/s twice. This patch measures sustained copy throughput instead of a single scheduling interval; it does not lower any acceptance budget.

## Validation

- `./shifu check`
- incremental Release adapter/host build
- local macOS ARM64 libwasm harness PASS with exact byte accounting

Follow-up to #561; supersedes the unmerged fix commit on its now-closed delivery branch.