### PR TITLE
ci: accept the v2-alpha buildchain contract in the consumer lock

### DIFF
--- a/.buildchain/contract-lock.json
+++ b/.buildchain/contract-lock.json
@@ -2,34 +2,39 @@
   "schemaVersion": 1,
   "contract": "kungfu-buildchain-contract-lock",
   "buildchain": {
-    "ref": "v2",
-    "resolvedSha": "1ddb0408433cba98f668410776d8b4bb65eb2452",
+    "ref": "v2-alpha",
+    "resolvedSha": "4cba0848b4dfa5381f3ed9d2256b174fb0fb8502",
     "contract": "kungfu-buildchain-runtime-contract-world",
-    "contractDigest": "sha256:3492a69ad5e95953d78aa3f4418b205c551e75430afcf5f00f8d5da356bc5207",
-    "compatibilityDigest": "sha256:967df7e854fdf582294ddfb6403eff25c00db9518a24051e7d47cbd75527c785",
+    "contractDigest": "sha256:46cccc23015847e18fcc1a88efce2c1b5c10c332551a12fa75ab14d8b70bf1c1",
+    "compatibilityDigest": "sha256:2090784977bc7d54fc647215ef73532b9db26147a0b40ec3f56c31d611d806cc",
     "majorLine": "v2",
     "compatibilityPolicy": "major-compatible",
-    "acceptedAt": "2026-07-09T14:23:53.705Z",
+    "acceptedAt": "2026-07-11T09:49:03.973Z",
     "surfaces": [
       {
         "id": "reusable-build",
         "kind": "workflow",
-        "breakingDigest": "sha256:6303aa2c2cb8c2cef4301ceea95cc3c426c2aa81d98714aa9bdf2471d63faee1"
+        "breakingDigest": "sha256:a6a35370d6b0d0f46e1b2712dcc01961fe53c2febde95409a27a485c10a36650"
+      },
+      {
+        "id": "channel-build-router",
+        "kind": "workflow",
+        "breakingDigest": "sha256:c4597dfa89e1a58f1023905092b849644f5c080abf150aeba9c7e1cd5ed43962"
       },
       {
         "id": "release-candidate-promote",
         "kind": "workflow",
-        "breakingDigest": "sha256:403d2fcdb0c5eabe749e89102defad69745f70a1556707bec7831fcc2e9fa8f8"
+        "breakingDigest": "sha256:6dbae32ce3d7aab3be6957065105af574794581847b7637314dad45f5349c919"
       },
       {
         "id": "web-surface",
         "kind": "workflow",
-        "breakingDigest": "sha256:82ee63cb336e40d832dfff4a1c5e6cbfa221a4fc8b2359990033bc931bffc43a"
+        "breakingDigest": "sha256:da569f90374e878948e3d5160ed9929338ce0572473ca8ee54867b0fe1aaeace"
       },
       {
         "id": "promote-buildchain-ref-action",
         "kind": "action",
-        "breakingDigest": "sha256:0c5896590c8c9a44dfecbe060bcef1b43d3a9556737309dbe7e5f2bf83bfee6c"
+        "breakingDigest": "sha256:a59f0910e6df842e7699139472e5dd69ac2fdd7f7213bf2cb346d1d622556874"
       },
       {
         "id": "report-buildchain-issue-action",


### PR DESCRIPTION
The v2-alpha switch updated workflow references but left the consumer contract lock pinned to the v2 contract world — the trust gate correctly rejected runs as breaking drift. Regenerate the lock against the current v2-alpha runtime (4cba0848) so accepted surfaces match the consumed channel.