### PR TITLE
fix(ci): adopt Buildchain dual-channel routing

### DIFF
--- a/.buildchain/alpha-contract-lock.json
+++ b/.buildchain/alpha-contract-lock.json
@@ -2,10 +2,10 @@
   "schemaVersion": 1,
   "contract": "kungfu-buildchain-contract-lock",
   "buildchain": {
-    "ref": "v2",
-    "resolvedSha": "03ec04b384f6ce8d4bc2d569bc2642d91fa56906",
+    "ref": "v2-alpha",
+    "resolvedSha": "4cba0848b4dfa5381f3ed9d2256b174fb0fb8502",
     "contract": "kungfu-buildchain-runtime-contract-world",
-    "contractDigest": "sha256:7baa8a5044e49fea61abba63ef5f7fa3c582cf2c8cde50dd1395d1b1de2f3184",
+    "contractDigest": "sha256:46cccc23015847e18fcc1a88efce2c1b5c10c332551a12fa75ab14d8b70bf1c1",
     "compatibilityDigest": "sha256:2090784977bc7d54fc647215ef73532b9db26147a0b40ec3f56c31d611d806cc",
     "majorLine": "v2",
     "compatibilityPolicy": "major-compatible",

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ permissions:
 
 jobs:
   build:
-    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@v2-alpha
+    uses: kungfu-systems/buildchain/.github/workflows/build.yml@v2
     secrets: inherit
     with:
       buildchain-ref: ${{ inputs.buildchain-ref || '' }}
@@ -59,6 +59,7 @@ jobs:
         ./shifu episode:qualify:release -- --output
         product/release/qualification/episode-release-evidence.json"
       release-candidate: true
+      publish-channel: ${{ startsWith(github.base_ref, 'release/') && 'release' || 'alpha' }}
       artifact-transfer-mode: s3-to-github-artifacts
       artifact-retention-days: 14
       checkout-cache-mode: auto
@@ -66,6 +67,7 @@ jobs:
       checkout-cache-reference-repository-template: ${{ vars.BUILDCHAIN_CHECKOUT_CACHE_REFERENCE_REPOSITORY_TEMPLATE }}
       checkout-cache-fallback: github
       checkout-cache-timeout-seconds: 60
-      buildchain-contract-lock-path: .buildchain/contract-lock.json
+      buildchain-alpha-contract-lock-path: .buildchain/alpha-contract-lock.json
+      buildchain-stable-contract-lock-path: .buildchain/contract-lock.json
       buildchain-contract-compatibility-policy: major-compatible
       buildchain-contract-drift-issue-mode: compatible-and-breaking

--- a/.github/workflows/buildchain-validate.yml
+++ b/.github/workflows/buildchain-validate.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Validate .buildchain/buildchain.toml
-        uses: kungfu-systems/buildchain/actions/validate-config@v2-alpha
+        uses: kungfu-systems/buildchain/actions/validate-config@v2
         with:
           require-version-state: "true"
           require-lifecycle-stages: "install,build,verify"

--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -18,12 +18,13 @@ permissions:
 jobs:
   promote:
     if: ${{ github.event.pull_request.merged == true }}
-    uses: kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@v2-alpha
+    uses: kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@v2
     with:
       channel: ${{ startsWith(github.event.pull_request.base.ref, 'alpha/') && 'alpha' || 'release' }}
+      buildchain-ref: ${{ startsWith(github.event.pull_request.base.ref, 'alpha/') && 'v2-alpha' || 'v2' }}
       target-ref: ${{ github.event.pull_request.base.ref }}
       target-sha: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
-      buildchain-contract-lock-path: .buildchain/contract-lock.json
+      buildchain-contract-lock-path: ${{ startsWith(github.event.pull_request.base.ref, 'alpha/') && '.buildchain/alpha-contract-lock.json' || '.buildchain/contract-lock.json' }}
       buildchain-contract-compatibility-policy: major-compatible
       buildchain-contract-drift-issue-mode: compatible-and-breaking
       package-manager: custom

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ cmake-build-debug/
 dist/
 .buildchain/*
 !.buildchain/buildchain.toml
+!.buildchain/alpha-contract-lock.json
 !.buildchain/contract-lock.json
 !.buildchain/kfd/
 .buildchain/kfd/*


### PR DESCRIPTION
## Summary

- adopt the current Buildchain v2 dual-channel model
- route development/alpha validation through `v2-alpha` and release consumption through `v2`
- add and verify channel-specific consumer contract locks
- update repository checks and machine-readable evidence where applicable

## Validation

- `actionlint` on changed GitHub workflows
- stable and alpha contract locks regenerated and revalidated against exact v2.12 contract worlds
- repository-local lightweight checks passed where available
