### PR TITLE
fix(journal): harden mmap ownership and page publication

### DIFF
--- a/framework/core/CMakeLists.txt
+++ b/framework/core/CMakeLists.txt
@@ -57,6 +57,10 @@ option(NNG_TOOLS "" OFF)
 option(NNG_ENABLE_NNGCAT "" OFF)
 option(KUNGFU_WITH_DEBUG_EXAMPLE "" OFF)
 option(KUNGFU_WITH_SLICES "build the capability slices (minimal standalone proofs, see slices/README.md)" OFF)
+option(KUNGFU_WITH_CORE_TESTS "build native yijinjing correctness tests" ON)
+if(KUNGFU_WITH_CORE_TESTS)
+  enable_testing()
+endif()
 
 ##########################################################################
 
@@ -84,6 +88,7 @@ endif()
 ##########################################################################
 
 # journal core static library; libkungfu links it, minimal tools can link it alone
+set(YIJINJING_BUILD_TESTS ${KUNGFU_WITH_CORE_TESTS})
 add_subdirectory(src/libyijinjing)
 
 if (NOT DEFINED ENV{KUNGFU_BUILD_SKIP_LIBKUNGFU} OR NOT $ENV{KUNGFU_BUILD_SKIP_LIBKUNGFU})

--- a/framework/core/docs/adr/ADR-0001-yijinjing-publish-barrier.md
+++ b/framework/core/docs/adr/ADR-0001-yijinjing-publish-barrier.md
@@ -1,9 +1,9 @@
-# ADR-0001: yijinjing journal frame-publish protocol → `atomic_ref` release/acquire
+# ADR-0001: yijinjing journal frame/page publish protocol → `atomic_ref` release/acquire
 
 - Status: accepted (implemented on this line; ARM adversarial stress test + in-tree compile both pass — see "Gate outcome")
 - Date: 2026-06-23
 - Category: (b) improvement + latent bug (concurrency correctness)
-- Subsystem: yijinjing journal — single-writer / multi-reader, mmap `MAP_SHARED` cross-process frame bus
+- Subsystem: yijinjing journal — single-writer / multi-reader, mmap `MAP_SHARED` cross-process page/frame bus
 - Related: independent of schema ownership (historical ADR-0002, current
   ADR-0047); this change touches only publish synchronization, not schema or
   on-disk layout
@@ -20,6 +20,12 @@ ordinary reads/writes" to **`std::atomic_ref` release/acquire**:
 - Reader side: read `length` with `memory_order_acquire` as the "is there a new
   frame" gate (`frame::acquire_length` → `frame::has_data`); only after the gate
   holds may it read payload / gen_time / frame_uid.
+- Page initialization uses the same one-token rule. The initializer writes the
+  immutable `page_header` facts and initial status first, then stores
+  `page_header::last_frame_position` with release. Existing-only readers map
+  without create/grow authority, acquire that token before reading the other
+  header fields, and reject mismatched lengths, page size, or out-of-range
+  offsets before payload access. `status` transitions also use release/acquire.
 
 ## Context
 
@@ -77,6 +83,9 @@ stale frame**.
 - **Binary / on-disk format unchanged**: `length` is still the same offset, same
   width uint32; dropping `volatile` does not change size or alignment. The byte
   contract for cross-language / cross-process readers is unchanged.
+- `page_header::last_frame_position` remains a `uint64_t` at offset 24 and is
+  now the page-initialization publication token. No page or frame field is
+  added, removed, widened, or reordered.
 - **Alignment verified**: on non-Windows targets `KF_DEFINE_PACK_TYPE` lands on
   `__attribute__((aligned(8)))` (not byte-packed); `length` is the first field
   (offset 0), and the frame start address is always 8-byte aligned
@@ -149,3 +158,5 @@ prevent lapping):
 - `framework/core/src/libkungfu/include/kungfu/yijinjing schema/types.h` (frame_header: drop volatile)
 - `framework/core/src/libyijinjing/include/kungfu/yijinjing/journal/frame.h` (acquire/publish/copy)
 - `framework/core/src/libyijinjing/src/journal/writer.cpp` (close_frame_lock_free / copy_frame)
+- `framework/core/src/libyijinjing/src/journal/page.cpp` (page initialization/status publication and bounds validation)
+- `framework/core/src/libyijinjing/src/util/mmap.cpp` (move-only mapping ownership and existing-only reader mapping)

--- a/framework/core/docs/adr/README.md
+++ b/framework/core/docs/adr/README.md
@@ -19,7 +19,7 @@ A record's **Status** says where it stands:
 
 | ADR | Status | Title |
 |---|---|---|
-| [0001](ADR-0001-yijinjing-publish-barrier.md) | accepted | yijinjing journal publish protocol → `atomic_ref` release/acquire |
+| [0001](ADR-0001-yijinjing-publish-barrier.md) | accepted | yijinjing journal frame/page publish protocol → `atomic_ref` release/acquire |
 | [0002](ADR-0002-yijinjing-schema-runtime-layout.md) | superseded | historical FlatBuffers-over-POD runtime-schema decision; schema scope replaced by ADR-0047 |
 | [0003](ADR-0003-control-axis-python-coroutine-integration.md) | proposed | control axis — the Python coroutine integration layer (continue / redesign / drop) |
 | [0004](ADR-0004-control-axis-node-watcher-snapshot-model.md) | proposed | control axis — the Node watcher snapshot model |

--- a/framework/core/src/libyijinjing/CMakeLists.txt
+++ b/framework/core/src/libyijinjing/CMakeLists.txt
@@ -60,6 +60,14 @@ target_link_libraries(yijinjing PUBLIC
   nlohmann_json::nlohmann_json
   xxHash::xxhash)
 
+option(YIJINJING_BUILD_TESTS "build yijinjing native correctness tests" OFF)
+if(YIJINJING_BUILD_TESTS)
+  add_executable(yijinjing_mmap_tests tests/mmap_tests.cpp)
+  target_link_libraries(yijinjing_mmap_tests PRIVATE yijinjing)
+  target_compile_features(yijinjing_mmap_tests PRIVATE cxx_std_23)
+  add_test(NAME yijinjing_mmap_tests COMMAND yijinjing_mmap_tests)
+endif()
+
 if(DEFINED COMPILER_OPTIMIZE_ON_OPTIONS AND NOT "${COMPILER_OPTIMIZE_ON_OPTIONS}" STREQUAL "")
   target_compile_options(yijinjing PRIVATE "$<$<CONFIG:Release>:${COMPILER_OPTIMIZE_ON_OPTIONS}>")
 endif()

--- a/framework/core/src/libyijinjing/include/kungfu/yijinjing/journal/page.h
+++ b/framework/core/src/libyijinjing/include/kungfu/yijinjing/journal/page.h
@@ -5,7 +5,10 @@
 
 #include <kungfu/yijinjing/journal/common.h>
 #include <kungfu/yijinjing/journal/frame.h>
+#include <kungfu/yijinjing/platform/mmap.h>
 #include <kungfu/yijinjing/schema/core.h>
+
+#include <atomic>
 
 namespace kungfu::yijinjing::journal {
 
@@ -30,28 +33,24 @@ public:
     return reinterpret_cast<yijinjing::types::frame_header *>(first_frame_address())->gen_time;
   }
 
-  [[nodiscard]] int64_t end_time() const {
-    return reinterpret_cast<yijinjing::types::frame_header *>(last_frame_address())->gen_time;
-  }
+  [[nodiscard]] int64_t end_time() const;
 
-  [[nodiscard]] uintptr_t address() const { return reinterpret_cast<uintptr_t>(header_); }
+  [[nodiscard]] uintptr_t address() const { return region_.address(); }
 
-  [[nodiscard]] uintptr_t address_border() const {
-    return address() + header_->page_size - sizeof(yijinjing::types::frame_header);
-  }
+  [[nodiscard]] uintptr_t address_border() const;
 
-  [[nodiscard]] uint64_t get_body_size() const { return size_ - header_->page_header_length; }
+  [[nodiscard]] uint64_t get_body_size() const;
 
-  [[nodiscard]] uintptr_t first_frame_address() const { return address() + header_->page_header_length; }
+  [[nodiscard]] uintptr_t first_frame_address() const;
 
-  [[nodiscard]] uintptr_t last_frame_address() const { return address() + header_->last_frame_position; }
+  [[nodiscard]] uintptr_t last_frame_address() const;
 
   [[nodiscard]] bool is_full() const {
     return last_frame_address() + reinterpret_cast<yijinjing::types::frame_header *>(last_frame_address())->length >
            address_border();
   }
 
-  [[nodiscard]] bool is_pre_open() const { return header_->status == yijinjing::enums::PageStatus::PreOpen; };
+  [[nodiscard]] bool is_pre_open() const { return acquire_status() == yijinjing::enums::PageStatus::PreOpen; };
 
   /**
    * update page header when new frame added
@@ -61,7 +60,7 @@ public:
   void enable_page();
 
   static page_ptr load(const data::location_ptr &location, uint32_t dest_id, uint64_t page_size, uint32_t page_id,
-                       bool is_writing, bool lazy, bool pre_open = false);
+                       bool is_writing, bool lazy, bool pre_open = false, bool allow_create = false);
 
   static page_ptr load_header_and_1st_frame_header(const data::location_ptr &location, uint32_t dest_id,
                                                    uint32_t page_id, bool is_writing, bool lazy);
@@ -77,16 +76,22 @@ public:
   static bool check_page_existed(const data::location_ptr &location, uint32_t dest_id, uint32_t page_id);
 
 protected:
+  platform::mapped_region region_;
   const data::location_ptr location_;
   const uint32_t dest_id_;
   const uint32_t page_id_;
-  const bool lazy_;
   const bool is_writing_;
   const size_t size_;
   const yijinjing::types::page_header *header_;
 
   page(data::location_ptr location, uint32_t dest_id, uint32_t page_id, size_t size, bool lazy, bool is_writing,
-       uintptr_t address);
+       platform::mapped_region region);
+
+  [[nodiscard]] uint64_t acquire_last_frame_position() const;
+  [[nodiscard]] yijinjing::enums::PageStatus acquire_status() const;
+  void publish_status(yijinjing::enums::PageStatus status);
+  static std::string resolve_page_path(const data::location_ptr &location, uint32_t dest_id, uint32_t page_id,
+                                       bool create_not_exist);
 
   friend class journal;
 

--- a/framework/core/src/libyijinjing/include/kungfu/yijinjing/platform/mmap.h
+++ b/framework/core/src/libyijinjing/include/kungfu/yijinjing/platform/mmap.h
@@ -3,9 +3,56 @@
 #ifndef KUNGFU_YIJINJING_PLATFORM_MMAP_H
 #define KUNGFU_YIJINJING_PLATFORM_MMAP_H
 
+#include <cstddef>
+#include <cstdint>
 #include <string>
 
 namespace kungfu::yijinjing::platform {
+
+/**
+ * Move-only ownership for one file-backed mapping.
+ *
+ * The mapped address remains stable for the lifetime of this object. Moving
+ * transfers ownership; destruction always attempts to release the mapping and
+ * never throws. File creation is deliberately separated from existing-only
+ * mapping so read paths cannot silently create or stretch journal pages.
+ */
+class mapped_region {
+public:
+  mapped_region() noexcept = default;
+  ~mapped_region() noexcept;
+
+  mapped_region(const mapped_region &) = delete;
+  mapped_region &operator=(const mapped_region &) = delete;
+
+  mapped_region(mapped_region &&other) noexcept;
+  mapped_region &operator=(mapped_region &&other) noexcept;
+
+  static mapped_region map_existing(const std::string &path, size_t size, bool writable = false, bool lazy = true);
+  static mapped_region map_writable(const std::string &path, size_t size, bool lazy = true);
+
+  [[nodiscard]] uintptr_t address() const noexcept { return address_; }
+  [[nodiscard]] size_t size() const noexcept { return size_; }
+  [[nodiscard]] bool writable() const noexcept { return writable_; }
+  [[nodiscard]] bool locked() const noexcept { return locked_; }
+  [[nodiscard]] explicit operator bool() const noexcept { return address_ != 0; }
+
+  [[nodiscard]] bool flush() const noexcept;
+  [[nodiscard]] bool reset() noexcept;
+
+  /** Transfer the raw mapping to the legacy uintptr_t API. */
+  [[nodiscard]] uintptr_t release() noexcept;
+
+private:
+  mapped_region(uintptr_t address, size_t size, bool writable, bool locked) noexcept
+      : address_(address), size_(size), writable_(writable), locked_(locked) {}
+
+  uintptr_t address_ = 0;
+  size_t size_ = 0;
+  bool writable_ = false;
+  bool locked_ = false;
+};
+
 /**
  * load mmap buffer, return address of the file-mapped memory
  * whether to write has to be specified in "is_writing"

--- a/framework/core/src/libyijinjing/src/journal/journal.cpp
+++ b/framework/core/src/libyijinjing/src/journal/journal.cpp
@@ -111,7 +111,7 @@ void journal::preload_next_page() {
   std::lock_guard<std::recursive_mutex> lk(load_page_mtx_);
   if ((not low_latency_ or not page_) or                                                   //
       (preload_page_ and preload_page_->get_page_id() == page_->get_page_id() + 1) or      //
-      (page_->header_->status == yijinjing::enums::PageStatus::PreOpen) or                 //
+      page_->is_pre_open() or                                                              //
       (not page::check_page_existed(location_, page_->dest_id_, page_->get_page_id() + 1)) //
   ) {
     return;
@@ -130,7 +130,7 @@ void journal::try_load_next_extra_page() {
     return;
   }
   pre_create_page_ =
-      page::load(location_, dest_id_, page_->get_page_size(), page_->get_page_id() + 1, false, lazy_, true);
+      page::load(location_, dest_id_, page_->get_page_size(), page_->get_page_id() + 1, false, lazy_, true, true);
 }
 
 void journal::release_page() {

--- a/framework/core/src/libyijinjing/src/journal/page.cpp
+++ b/framework/core/src/libyijinjing/src/journal/page.cpp
@@ -5,85 +5,153 @@
 #include <kungfu/yijinjing/platform/mmap.h>
 #include <kungfu/yijinjing/time.h>
 
+#include <atomic>
+#include <cstddef>
+#include <filesystem>
+#include <thread>
+
 namespace kungfu::yijinjing::journal {
 
 namespace {
 constexpr uint64_t MIN_PAGE_SIZE_MB = 2;
 constexpr uint64_t DEFAULT_PAGE_SIZE_MB = 16;
+static_assert(offsetof(yijinjing::types::page_header, last_frame_position) %
+                      std::atomic_ref<uint64_t>::required_alignment ==
+                  0,
+              "page publication token must satisfy atomic_ref alignment");
+static_assert(std::atomic_ref<uint64_t>::is_always_lock_free,
+              "cross-process page publication requires lock-free uint64 atomics");
+static_assert(offsetof(yijinjing::types::page_header, status) %
+                      std::atomic_ref<yijinjing::enums::PageStatus>::required_alignment ==
+                  0,
+              "page status must satisfy atomic_ref alignment");
+static_assert(std::atomic_ref<yijinjing::enums::PageStatus>::is_always_lock_free,
+              "cross-process page status requires lock-free atomics");
 } // namespace
 using namespace yijinjing::types;
 
 page::page(data::location_ptr location, uint32_t dest_id, uint32_t page_id, size_t size, bool lazy, bool is_writing,
-           uintptr_t address)
-    : location_(std::move(location)), dest_id_(dest_id), page_id_(page_id), lazy_(lazy), size_(size),
-      is_writing_(is_writing), header_(reinterpret_cast<page_header *>(address)) {
-  assert(address > 0);
+           platform::mapped_region region)
+    : region_(std::move(region)), location_(std::move(location)), dest_id_(dest_id), page_id_(page_id),
+      is_writing_(is_writing), size_(size), header_(reinterpret_cast<page_header *>(region_.address())) {
+  (void)lazy;
+  assert(region_);
 }
 
 page::~page() {
   SPDLOG_TRACE("release page {}/{:08x}.{}.journal, is_writing_ {}", location_->uname, dest_id_, page_id_, is_writing_);
-  if (not platform::release_mmap_buffer(address(), size_, lazy_)) {
+  if (not region_.reset()) {
     SPDLOG_ERROR("can not release page {}/{:08x}.{}.journal", location_->uname, dest_id_, page_id_);
   }
 }
 
 void page::flush() {
   SPDLOG_TRACE("flush page {}/{:08x}.{}.journal", location_->uname, dest_id_, page_id_);
-  if (not platform::flush_mmap_buffer(address(), size_, lazy_)) {
+  if (not region_.flush()) {
     SPDLOG_ERROR("can not flush page {}/{:08x}.{}.journal", location_->uname, dest_id_, page_id_);
   }
 }
 
 void page::set_last_frame_position(uint64_t position) {
-  const_cast<page_header *>(header_)->last_frame_position = position;
+  std::atomic_ref<uint64_t>(const_cast<page_header *>(header_)->last_frame_position)
+      .store(position, std::memory_order_release);
 }
 
 void page::enable_page() {
   if (is_writing_) {
-    const_cast<page_header *>(header_)->status = yijinjing::enums::PageStatus::Normal;
+    publish_status(yijinjing::enums::PageStatus::Normal);
   }
 }
 
+uint64_t page::acquire_last_frame_position() const {
+  return std::atomic_ref<uint64_t>(const_cast<page_header *>(header_)->last_frame_position)
+      .load(std::memory_order_acquire);
+}
+
+yijinjing::enums::PageStatus page::acquire_status() const {
+  return std::atomic_ref<yijinjing::enums::PageStatus>(const_cast<page_header *>(header_)->status)
+      .load(std::memory_order_acquire);
+}
+
+void page::publish_status(yijinjing::enums::PageStatus status) {
+  std::atomic_ref<yijinjing::enums::PageStatus>(const_cast<page_header *>(header_)->status)
+      .store(status, std::memory_order_release);
+}
+
+uintptr_t page::address_border() const {
+  if (header_->page_size < sizeof(frame_header) || header_->page_size > size_) {
+    throw journal_error("page border exceeds mapped region for " +
+                        resolve_page_path(location_, dest_id_, page_id_, false));
+  }
+  return address() + header_->page_size - sizeof(frame_header);
+}
+
+uint64_t page::get_body_size() const {
+  if (header_->page_header_length > size_) {
+    throw journal_error("page header exceeds mapped region for " +
+                        resolve_page_path(location_, dest_id_, page_id_, false));
+  }
+  return size_ - header_->page_header_length;
+}
+
+uintptr_t page::first_frame_address() const {
+  if (header_->page_header_length > size_ || size_ - header_->page_header_length < sizeof(frame_header)) {
+    throw journal_error("first frame exceeds mapped region for " +
+                        resolve_page_path(location_, dest_id_, page_id_, false));
+  }
+  return address() + header_->page_header_length;
+}
+
+uintptr_t page::last_frame_address() const {
+  const auto position = acquire_last_frame_position();
+  if (position > size_ || size_ - position < sizeof(frame_header)) {
+    throw journal_error("last frame exceeds mapped region for " +
+                        resolve_page_path(location_, dest_id_, page_id_, false));
+  }
+  return address() + position;
+}
+
+int64_t page::end_time() const {
+  return reinterpret_cast<yijinjing::types::frame_header *>(last_frame_address())->gen_time;
+}
+
 page_ptr page::load(const data::location_ptr &location, uint32_t dest_id, uint64_t page_size, uint32_t page_id,
-                    bool is_writing, bool lazy, bool pre_open) {
-  std::string path = get_page_path(location, dest_id, page_id);
-  uintptr_t address = platform::load_mmap_buffer(path, page_size, is_writing, lazy);
-
-  if (address == 0) {
-    throw journal_error("unable to load page for " + path);
+                    bool is_writing, bool lazy, bool pre_open, bool allow_create) {
+  if (page_size < sizeof(page_header) + 2 * sizeof(frame_header)) {
+    throw journal_error("page size is too small for page and frame publication headers");
   }
+  const bool may_initialize = is_writing || allow_create;
+  std::string path = resolve_page_path(location, dest_id, page_id, may_initialize);
+  auto region = may_initialize ? platform::mapped_region::map_writable(path, page_size, lazy)
+                               : platform::mapped_region::map_existing(path, page_size, false, lazy);
 
-  if (pre_open and not is_writing and lazy) {
-    return std::shared_ptr<page>(new page(location, dest_id, page_id, page_size, lazy, is_writing, address));
-  }
-
-  auto header = reinterpret_cast<page_header *>(address);
-  bool is_virgin_page = header->last_frame_position == 0;
+  auto header = reinterpret_cast<page_header *>(region.address());
+  auto loaded_page =
+      std::shared_ptr<page>(new page(location, dest_id, page_id, page_size, lazy, is_writing, std::move(region)));
+  bool is_virgin_page = loaded_page->acquire_last_frame_position() == 0;
   SPDLOG_TRACE("load page {}/{:08x}.{}.journal lazy {} size {} is_writing {} is_virgin_page {}", location->uname,
                dest_id, page_id, lazy, page_size, is_writing, is_virgin_page);
 
-  if (is_writing or not lazy) {
+  if (may_initialize) {
     if (is_virgin_page) {
       header->version = __JOURNAL_VERSION__;
       header->page_header_length = sizeof(page_header);
       header->page_size = page_size;
       header->frame_header_length = sizeof(frame_header);
-      header->last_frame_position = header->page_header_length;
-    }
-
-    if (pre_open && is_virgin_page) {
-      header->status = yijinjing::enums::PageStatus::PreOpen;
+      loaded_page->publish_status(pre_open ? yijinjing::enums::PageStatus::PreOpen
+                                           : yijinjing::enums::PageStatus::Normal);
+      loaded_page->set_last_frame_position(header->page_header_length);
     } else if (not pre_open) {
-      header->status = yijinjing::enums::PageStatus::Normal;
+      loaded_page->publish_status(yijinjing::enums::PageStatus::Normal);
     }
   }
 
   int64_t nano = time::now_in_nano();
-  while (header->version != __JOURNAL_VERSION__ or header->page_header_length != sizeof(page_header) or
-         header->page_size != page_size) {
+  while (loaded_page->acquire_last_frame_position() == 0) {
     if (time::now_in_nano() - nano > 10 * time_unit::NANOSECONDS_PER_SECOND) {
-      break;
+      throw journal_error("timed out waiting for page initialization: " + path);
     }
+    std::this_thread::yield();
   }
 
   if (header->version != __JOURNAL_VERSION__) {
@@ -94,6 +162,11 @@ page_ptr page::load(const data::location_ptr &location, uint32_t dest_id, uint64
     uint32_t l = header->page_header_length;
     throw journal_error(fmt::format("{} header length mismatch, required {}, found {}", path, sizeof(page_header), l));
   }
+  if (header->frame_header_length != sizeof(frame_header)) {
+    uint32_t l = header->frame_header_length;
+    throw journal_error(
+        fmt::format("{} frame header length mismatch, required {}, found {}", path, sizeof(frame_header), l));
+  }
   if (header->page_size != page_size) {
     uint64_t s = header->page_size;
     throw journal_error(fmt::format(
@@ -101,11 +174,17 @@ page_ptr page::load(const data::location_ptr &location, uint32_t dest_id, uint64
         page_size, s, location->uname, path, dest_id, page_id, is_writing));
   }
 
-  if (header->status != yijinjing::enums::PageStatus::Normal && !pre_open) {
+  const auto last_frame_position = loaded_page->acquire_last_frame_position();
+  if (last_frame_position < header->page_header_length || last_frame_position > page_size - sizeof(frame_header)) {
+    throw journal_error(fmt::format("{} invalid last frame position {}, page header {}, page size {}", path,
+                                    last_frame_position, header->page_header_length, page_size));
+  }
+
+  if (loaded_page->acquire_status() != yijinjing::enums::PageStatus::Normal && !pre_open) {
     SPDLOG_WARN("page is still preopen status");
   }
 
-  return std::shared_ptr<page>(new page(location, dest_id, page_id, page_size, lazy, is_writing, address));
+  return loaded_page;
 }
 
 page_ptr page::load_header_and_1st_frame_header(const data::location_ptr &location, uint32_t dest_id, uint32_t page_id,
@@ -113,24 +192,36 @@ page_ptr page::load_header_and_1st_frame_header(const data::location_ptr &locati
   uint32_t page_header_size = sizeof(page_header);
   uint32_t frame_header_size = sizeof(frame_header);
   uint32_t sliced_page_size = page_header_size + frame_header_size;
-  std::string path = get_page_path(location, dest_id, page_id);
-  uintptr_t address = platform::load_mmap_buffer(path, sliced_page_size, is_writing, lazy);
+  std::string path = resolve_page_path(location, dest_id, page_id, is_writing);
+  auto region = is_writing ? platform::mapped_region::map_writable(path, sliced_page_size, lazy)
+                           : platform::mapped_region::map_existing(path, sliced_page_size, false, lazy);
 
-  if (address == 0) {
-    throw journal_error("unable to load page for " + path);
-  }
-
-  auto header = reinterpret_cast<page_header *>(address);
-  if (header->last_frame_position == 0) {
+  auto header = reinterpret_cast<page_header *>(region.address());
+  auto loaded_page = std::shared_ptr<page>(
+      new page(location, dest_id, page_id, sliced_page_size, lazy, is_writing, std::move(region)));
+  if (loaded_page->acquire_last_frame_position() == 0) {
     SPDLOG_WARN("open a page never loaded : {}", path);
   }
 
-  return std::shared_ptr<page>(new page(location, dest_id, page_id, sliced_page_size, lazy, is_writing, address));
+  if (header->page_header_length != sizeof(page_header) || header->frame_header_length != sizeof(frame_header) ||
+      header->page_size < sliced_page_size) {
+    throw journal_error("invalid sliced page header for " + path);
+  }
+
+  return loaded_page;
 }
 
 std::string page::get_page_path(const data::location_ptr &location, uint32_t dest_id, uint32_t page_id) {
+  return resolve_page_path(location, dest_id, page_id, true);
+}
+
+std::string page::resolve_page_path(const data::location_ptr &location, uint32_t dest_id, uint32_t page_id,
+                                    bool create_not_exist) {
   auto page_name = fmt::format("{:08x}.{}", dest_id, page_id);
-  return location->locator->layout_file(location, yijinjing::enums::layout::JOURNAL, page_name);
+  auto dir = location->locator->layout_dir(location, yijinjing::enums::layout::JOURNAL, create_not_exist);
+  return (std::filesystem::path(dir) /
+          fmt::format("{}.{}", page_name, yijinjing::enums::get_layout_name(yijinjing::enums::layout::JOURNAL)))
+      .string();
 }
 
 uint32_t page::find_page_id(const data::location_ptr &location, uint32_t dest_id, int64_t time) {
@@ -143,9 +234,9 @@ uint32_t page::find_page_id(const data::location_ptr &location, uint32_t dest_id
   }
   for (int i = static_cast<int>(page_ids.size()) - 1; i >= 0; i--) {
     auto loaded_page = page::load_header_and_1st_frame_header(location, dest_id, page_ids[i], false, true);
-    const auto &loaded_page_header = loaded_page->header_;
-    if (loaded_page_header->last_frame_position != 0 &&
-        loaded_page_header->status != yijinjing::enums::PageStatus::PreOpen &&
+    const auto *loaded_page_header = loaded_page->header_;
+    if (loaded_page->acquire_last_frame_position() != 0 &&
+        loaded_page->acquire_status() != yijinjing::enums::PageStatus::PreOpen &&
         loaded_page_header->version == __JOURNAL_VERSION__ && loaded_page->begin_time() < time) {
       return page_ids[i];
     }

--- a/framework/core/src/libyijinjing/src/journal/reader.cpp
+++ b/framework/core/src/libyijinjing/src/journal/reader.cpp
@@ -159,7 +159,7 @@ uint64_t reader::find_page_size(const data::location_ptr &location, uint32_t des
   auto page_size = page->get_page_size();
   if (page_size == 0) {
     const std::string msg = fmt::format("open a page never init page_header for {}", location->uname,
-                                        page::get_page_path(location, dest_id, page_id));
+                                        page::resolve_page_path(location, dest_id, page_id, false));
     SPDLOG_ERROR(msg);
     throw journal_error(msg);
   }

--- a/framework/core/src/libyijinjing/src/util/mmap.cpp
+++ b/framework/core/src/libyijinjing/src/util/mmap.cpp
@@ -13,6 +13,7 @@
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <unistd.h>
 
 #endif // _WINDOWS
 
@@ -20,87 +21,263 @@
 #include <kungfu/yijinjing/journal/common.h>
 #include <kungfu/yijinjing/platform/mmap.h>
 
+#include <limits>
+
 using namespace kungfu::yijinjing::journal;
 
 namespace kungfu::yijinjing::platform {
 
-uintptr_t load_mmap_buffer(const std::string &path, size_t size, bool is_writing, bool lazy) {
+namespace {
+
+struct native_mapping {
+  uintptr_t address;
+  bool locked;
+};
+
 #ifdef _WINDOWS
-  bool has_write_access = is_writing || !lazy;
-  HANDLE dumpFileDescriptor =
-      CreateFileA(path.c_str(), (has_write_access) ? (GENERIC_READ | GENERIC_WRITE) : GENERIC_READ,
-                  FILE_SHARE_READ | FILE_SHARE_WRITE, NULL, (has_write_access) ? OPEN_ALWAYS : OPEN_EXISTING,
-                  FILE_ATTRIBUTE_NORMAL, NULL);
-  if (dumpFileDescriptor == INVALID_HANDLE_VALUE) {
-    throw journal_error("unable to mmap for page " + path);
+[[noreturn]] void throw_mapping_error(const std::string &operation, const std::string &path, int code) {
+  throw journal_error(operation + " for page " + path + ", error: " + std::to_string(code));
+}
+
+class unique_handle {
+public:
+  explicit unique_handle(HANDLE value = INVALID_HANDLE_VALUE) noexcept : value_(value) {}
+  ~unique_handle() noexcept { reset(); }
+  unique_handle(const unique_handle &) = delete;
+  unique_handle &operator=(const unique_handle &) = delete;
+  unique_handle(unique_handle &&other) noexcept : value_(other.release()) {}
+  unique_handle &operator=(unique_handle &&other) noexcept {
+    if (this != &other) {
+      reset();
+      value_ = other.release();
+    }
+    return *this;
+  }
+  [[nodiscard]] HANDLE get() const noexcept { return value_; }
+  [[nodiscard]] explicit operator bool() const noexcept { return value_ != nullptr && value_ != INVALID_HANDLE_VALUE; }
+  [[nodiscard]] HANDLE release() noexcept {
+    HANDLE value = value_;
+    value_ = INVALID_HANDLE_VALUE;
+    return value;
+  }
+  void reset() noexcept {
+    if (*this) {
+      CloseHandle(value_);
+    }
+    value_ = INVALID_HANDLE_VALUE;
   }
 
-  // https://learn.microsoft.com/zh-cn/windows/win32/memory/creating-a-file-mapping-object?redirectedfrom=MSDN
-  // max journal size is 2GB in Windows
-  HANDLE fileMappingObject =
-      CreateFileMapping(dumpFileDescriptor, NULL, (has_write_access) ? PAGE_READWRITE : PAGE_READONLY, 0, size, NULL);
+private:
+  HANDLE value_;
+};
 
-  if (fileMappingObject == NULL) {
-    int nRet = GetLastError();
-    SPDLOG_ERROR("{} CreateFileMapping Error = {}, {}\n", has_write_access ? "writer" : "reader", nRet, path);
-    throw journal_error("unable to mmap for page " + path);
+native_mapping map_file(const std::string &path, size_t size, bool writable, bool create_and_grow, bool lazy) {
+  if (size == 0) {
+    throw journal_error("refusing to mmap zero bytes for page " + path);
+  }
+  if (size > static_cast<uint64_t>(std::numeric_limits<LONGLONG>::max())) {
+    throw journal_error("requested mapping is too large for page " + path);
   }
 
-  void *buffer = MapViewOfFile(fileMappingObject, (has_write_access) ? FILE_MAP_ALL_ACCESS : FILE_MAP_READ, 0, 0, size);
+  unique_handle file(CreateFileA(path.c_str(), writable ? (GENERIC_READ | GENERIC_WRITE) : GENERIC_READ,
+                                 FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr,
+                                 create_and_grow ? OPEN_ALWAYS : OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr));
+  if (!file) {
+    throw_mapping_error("failed to open file", path, static_cast<int>(GetLastError()));
+  }
 
+  LARGE_INTEGER file_size{};
+  if (!GetFileSizeEx(file.get(), &file_size)) {
+    throw_mapping_error("failed to inspect file size", path, static_cast<int>(GetLastError()));
+  }
+  if (file_size.QuadPart < 0 || static_cast<uint64_t>(file_size.QuadPart) < size) {
+    if (!create_and_grow) {
+      throw journal_error("page file is smaller than requested mapping: " + path + ", required " +
+                          std::to_string(size) + ", found " + std::to_string(file_size.QuadPart));
+    }
+    LARGE_INTEGER target{};
+    target.QuadPart = static_cast<LONGLONG>(size);
+    if (!SetFilePointerEx(file.get(), target, nullptr, FILE_BEGIN) || !SetEndOfFile(file.get())) {
+      throw_mapping_error("failed to stretch file", path, static_cast<int>(GetLastError()));
+    }
+  }
+
+  const auto size64 = static_cast<uint64_t>(size);
+  unique_handle mapping(CreateFileMappingA(file.get(), nullptr, writable ? PAGE_READWRITE : PAGE_READONLY,
+                                           static_cast<DWORD>(size64 >> 32u), static_cast<DWORD>(size64), nullptr));
+  if (!mapping) {
+    throw_mapping_error("failed to create file mapping", path, static_cast<int>(GetLastError()));
+  }
+
+  void *buffer = MapViewOfFile(mapping.get(), writable ? FILE_MAP_ALL_ACCESS : FILE_MAP_READ, 0, 0, size);
   if (buffer == nullptr) {
-    int nRet = GetLastError();
-    throw journal_error("failed to load page " + path + ", MapViewOfFile Error " + std::to_string(nRet));
+    throw_mapping_error("failed to map view", path, static_cast<int>(GetLastError()));
   }
-  CloseHandle(fileMappingObject);
-  CloseHandle(dumpFileDescriptor);
+  (void)lazy;
+  return {reinterpret_cast<uintptr_t>(buffer), false};
+}
+
 #else
-  bool has_write_access = is_writing || !lazy;
-  int fd = open(path.c_str(), (has_write_access ? O_RDWR : O_RDONLY) | O_CREAT, (mode_t)0600);
+
+native_mapping map_file(const std::string &path, size_t size, bool writable, bool create_and_grow, bool lazy) {
+  if (size == 0) {
+    throw journal_error("refusing to mmap zero bytes for page " + path);
+  }
+  if (size > static_cast<uint64_t>(std::numeric_limits<off_t>::max())) {
+    throw journal_error("requested mapping is too large for page " + path);
+  }
+
+  int flags = writable ? O_RDWR : O_RDONLY;
+  if (create_and_grow) {
+    flags |= O_CREAT;
+  }
+  int fd = open(path.c_str(), flags, static_cast<mode_t>(0600));
   if (fd < 0) {
     throw journal_error("failed to open file for page " + path + ", errno: " + strerror(errno));
   }
 
-  if (has_write_access) {
-    if (lseek(fd, size - 1, SEEK_SET) == -1) {
+  struct stat file_stat{};
+  if (fstat(fd, &file_stat) != 0) {
+    const int code = errno;
+    close(fd);
+    throw journal_error("failed to inspect file size for page " + path + ", errno: " + strerror(code));
+  }
+  if (file_stat.st_size < 0 || static_cast<uint64_t>(file_stat.st_size) < size) {
+    if (!create_and_grow) {
+      const auto found = file_stat.st_size;
       close(fd);
-      throw journal_error("failed to stretch for page " + path + ", errno: " + strerror(errno));
+      throw journal_error("page file is smaller than requested mapping: " + path + ", required " +
+                          std::to_string(size) + ", found " + std::to_string(found));
     }
-    if (write(fd, "", 1) == -1) {
+    if (ftruncate(fd, static_cast<off_t>(size)) != 0) {
+      const int code = errno;
       close(fd);
-      throw journal_error("unable to write for page " + path + ", errno: " + strerror(errno));
+      throw journal_error("failed to stretch file for page " + path + ", errno: " + strerror(code));
     }
   }
 
-  /**
-   * MAP_FIXED is dup2 for memory mappings, and it's useful in exactly the same situations where dup2 is useful for file
-   * descriptors: when you want to perform a replace operation that atomically reassigns a resource identifier (memory
-   * range in the case of MAP_FIXED, or fd in the case of dup2) to refer to a new resource without the possibility of
-   * races where it might get reassigned to something else if you first released the old resource then attempted to
-   * regain it for the new resource.
-   */
-  void *buffer = mmap(0, size, has_write_access ? (PROT_READ | PROT_WRITE) : PROT_READ, MAP_SHARED, fd, 0);
-
+  void *buffer = mmap(nullptr, size, writable ? (PROT_READ | PROT_WRITE) : PROT_READ, MAP_SHARED, fd, 0);
   if (buffer == MAP_FAILED) {
+    const int code = errno;
     close(fd);
-    throw journal_error("Error mapping file to buffer: " + path);
+    throw journal_error("failed to map file for page " + path + ", errno: " + strerror(code));
   }
 
-  if (!lazy && madvise(buffer, size, MADV_RANDOM) != 0 && mlock(buffer, size) != 0) {
-    munmap(buffer, size);
-    close(fd);
-    throw journal_error("failed to lock memory for page " + path);
+  bool locked = false;
+  if (!lazy && madvise(buffer, size, MADV_RANDOM) != 0) {
+    if (mlock(buffer, size) != 0) {
+      const int code = errno;
+      munmap(buffer, size);
+      close(fd);
+      throw journal_error("failed to prepare resident mapping for page " + path + ", errno: " + strerror(code));
+    }
+    locked = true;
   }
 
   close(fd);
-#endif // _WINDOWS
-  return reinterpret_cast<uintptr_t>(buffer);
+  return {reinterpret_cast<uintptr_t>(buffer), locked};
+}
+
+#endif
+
+} // namespace
+
+mapped_region::~mapped_region() noexcept { (void)reset(); }
+
+mapped_region::mapped_region(mapped_region &&other) noexcept
+    : address_(other.address_), size_(other.size_), writable_(other.writable_), locked_(other.locked_) {
+  other.address_ = 0;
+  other.size_ = 0;
+  other.writable_ = false;
+  other.locked_ = false;
+}
+
+mapped_region &mapped_region::operator=(mapped_region &&other) noexcept {
+  if (this != &other) {
+    (void)reset();
+    address_ = other.address_;
+    size_ = other.size_;
+    writable_ = other.writable_;
+    locked_ = other.locked_;
+    other.address_ = 0;
+    other.size_ = 0;
+    other.writable_ = false;
+    other.locked_ = false;
+  }
+  return *this;
+}
+
+mapped_region mapped_region::map_existing(const std::string &path, size_t size, bool writable, bool lazy) {
+  const auto native = map_file(path, size, writable, false, lazy);
+  return mapped_region(native.address, size, writable, native.locked);
+}
+
+mapped_region mapped_region::map_writable(const std::string &path, size_t size, bool lazy) {
+  const auto native = map_file(path, size, true, true, lazy);
+  return mapped_region(native.address, size, true, native.locked);
+}
+
+bool mapped_region::flush() const noexcept {
+  if (address_ == 0 || !writable_) {
+    return true;
+  }
+  void *buffer = reinterpret_cast<void *>(address_);
+#ifdef _WINDOWS
+  return FlushViewOfFile(buffer, size_) != 0;
+#else
+  return msync(buffer, size_, MS_SYNC) == 0;
+#endif
+}
+
+bool mapped_region::reset() noexcept {
+  if (address_ == 0) {
+    return true;
+  }
+  void *buffer = reinterpret_cast<void *>(address_);
+  bool ok = true;
+#ifdef _WINDOWS
+  if (writable_ && FlushViewOfFile(buffer, size_) == 0) {
+    ok = false;
+  }
+  if (UnmapViewOfFile(buffer) == 0) {
+    ok = false;
+  }
+#else
+  if (locked_ && munlock(buffer, size_) != 0) {
+    ok = false;
+  }
+  if (munmap(buffer, size_) != 0) {
+    ok = false;
+  }
+#endif
+  address_ = 0;
+  size_ = 0;
+  writable_ = false;
+  locked_ = false;
+  return ok;
+}
+
+uintptr_t mapped_region::release() noexcept {
+  const uintptr_t address = address_;
+  address_ = 0;
+  size_ = 0;
+  writable_ = false;
+  locked_ = false;
+  return address;
+}
+
+uintptr_t load_mmap_buffer(const std::string &path, size_t size, bool is_writing, bool lazy) {
+  auto region =
+      is_writing ? mapped_region::map_writable(path, size, lazy) : mapped_region::map_existing(path, size, false, lazy);
+  return region.release();
 }
 
 bool flush_mmap_buffer(uintptr_t address, size_t size, bool lazy) {
   void *buffer = reinterpret_cast<void *>(address);
 #ifdef _WINDOWS
-  FlushViewOfFile(buffer, 0);
+  if (FlushViewOfFile(buffer, size) == 0) {
+    return false;
+  }
 #else
   if (msync(buffer, size, MS_SYNC) != 0) {
     return false;
@@ -112,19 +289,14 @@ bool flush_mmap_buffer(uintptr_t address, size_t size, bool lazy) {
 bool release_mmap_buffer(uintptr_t address, size_t size, bool lazy) {
   void *buffer = reinterpret_cast<void *>(address);
 #ifdef _WINDOWS
-  FlushViewOfFile(buffer, 0);
-  UnmapViewOfFile(buffer);
+  const bool flushed = FlushViewOfFile(buffer, size) != 0;
+  const bool unmapped = UnmapViewOfFile(buffer) != 0;
+  return flushed && unmapped;
 #else
-  // unlock and unmap
-  if (!lazy && munlock(buffer, size) != 0) {
-    return false;
-  }
-
-  if (munmap(buffer, size) != 0) {
-    return false;
-  }
+  const bool unlocked = lazy || munlock(buffer, size) == 0;
+  const bool unmapped = munmap(buffer, size) == 0;
+  return unlocked && unmapped;
 #endif // _WINDOWS
-  return true;
 }
 
 } // namespace kungfu::yijinjing::platform

--- a/framework/core/src/libyijinjing/tests/mmap_tests.cpp
+++ b/framework/core/src/libyijinjing/tests/mmap_tests.cpp
@@ -1,0 +1,249 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#include <kungfu/yijinjing/common.h>
+#include <kungfu/yijinjing/journal/page.h>
+#include <kungfu/yijinjing/platform/mmap.h>
+#include <kungfu/yijinjing/schema/core.h>
+
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <functional>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <type_traits>
+
+#ifndef _WINDOWS
+#include <sys/wait.h>
+#include <unistd.h>
+#endif
+
+namespace fs = std::filesystem;
+using kungfu::yijinjing::data::location;
+using kungfu::yijinjing::data::locator;
+using kungfu::yijinjing::enums::location_role;
+using kungfu::yijinjing::enums::mode;
+using kungfu::yijinjing::journal::page;
+using kungfu::yijinjing::platform::mapped_region;
+using kungfu::yijinjing::types::frame_header;
+using kungfu::yijinjing::types::page_header;
+
+namespace {
+
+constexpr size_t TEST_PAGE_SIZE = 2 * kungfu::yijinjing::MB;
+
+class temp_tree {
+public:
+  temp_tree() {
+    const auto nonce = std::chrono::steady_clock::now().time_since_epoch().count();
+    root_ = fs::temp_directory_path() / ("kungfu-mmap-test-" + std::to_string(nonce));
+    fs::create_directories(root_);
+  }
+  ~temp_tree() {
+    std::error_code ignored;
+    fs::remove_all(root_, ignored);
+  }
+  [[nodiscard]] const fs::path &root() const { return root_; }
+
+private:
+  fs::path root_;
+};
+
+void require(bool condition, const std::string &message) {
+  if (!condition) {
+    throw std::runtime_error(message);
+  }
+}
+
+void require_throws(const std::function<void()> &fn, const std::string &message) {
+  try {
+    fn();
+  } catch (const std::exception &) {
+    return;
+  }
+  throw std::runtime_error(message);
+}
+
+auto make_location(const fs::path &root) {
+  auto page_locator = std::make_shared<locator>(root.string());
+  return location::make_shared(mode::LIVE, location_role::SYSTEM, "mmap_test", "writer", page_locator);
+}
+
+std::string create_page_path(const kungfu::yijinjing::data::location_ptr &loc) {
+  (void)loc->locator->layout_dir(loc, kungfu::yijinjing::enums::layout::JOURNAL, true);
+  return page::get_page_path(loc, location::PUBLIC, 1);
+}
+
+void test_wire_layout_invariants() {
+  static_assert(sizeof(page_header) == 32, "wire-v1 page_header size changed");
+  static_assert(sizeof(frame_header) == 72, "wire-v1 frame_header size changed");
+  static_assert(offsetof(page_header, last_frame_position) == 24, "wire-v1 page publication token offset changed");
+  static_assert(offsetof(frame_header, length) == 0, "frame publication token offset changed");
+  static_assert(std::is_move_constructible_v<mapped_region>);
+  static_assert(!std::is_copy_constructible_v<mapped_region>);
+}
+
+void test_existing_mapping_never_creates_or_grows() {
+  temp_tree tree;
+  const auto missing = tree.root() / "missing.journal";
+  require_throws([&] { (void)mapped_region::map_existing(missing.string(), 4096); },
+                 "existing-only mapping accepted a missing file");
+  require(!fs::exists(missing), "existing-only mapping created a missing file");
+
+  const auto truncated = tree.root() / "truncated.journal";
+  {
+    std::ofstream stream(truncated, std::ios::binary);
+    stream << "short";
+  }
+  const auto before = fs::file_size(truncated);
+  require_throws([&] { (void)mapped_region::map_existing(truncated.string(), 4096); },
+                 "existing-only mapping accepted a truncated file");
+  require(fs::file_size(truncated) == before, "existing-only mapping changed a truncated file size");
+  require_throws([&] { (void)mapped_region::map_existing(truncated.string(), 0); }, "zero-length mapping was accepted");
+}
+
+void test_mapped_region_move_ownership() {
+  temp_tree tree;
+  const auto path = tree.root() / "owned.journal";
+  auto first = mapped_region::map_writable(path.string(), 4096);
+  require(first && first.writable() && first.size() == 4096, "writable mapping facts are incorrect");
+  *reinterpret_cast<uint64_t *>(first.address()) = UINT64_C(0x1020304050607080);
+
+  mapped_region second(std::move(first));
+  require(!first && second, "move construction did not transfer mapping ownership");
+  require(second.flush(), "writable mapping flush failed");
+  require(second.reset(), "writable mapping release failed");
+  require(!second, "released mapping retained an address");
+  require(fs::file_size(path) == 4096, "writable mapping did not size the file exactly once");
+
+  auto reader = mapped_region::map_existing(path.string(), 4096);
+  require(!reader.writable(), "read mapping unexpectedly has write access");
+  require(*reinterpret_cast<const uint64_t *>(reader.address()) == UINT64_C(0x1020304050607080),
+          "mapped payload changed across release/reopen");
+}
+
+void test_page_reader_does_not_create_layout() {
+  temp_tree tree;
+  auto loc = make_location(tree.root());
+  const auto journal_dir = loc->locator->layout_dir(loc, kungfu::yijinjing::enums::layout::JOURNAL, false);
+  require(!fs::exists(journal_dir), "test journal directory unexpectedly exists");
+  require_throws([&] { (void)page::load(loc, location::PUBLIC, TEST_PAGE_SIZE, 1, false, true); },
+                 "reader opened a missing journal page");
+  require(!fs::exists(journal_dir), "reader created the journal directory for a missing page");
+}
+
+void test_corrupt_page_offsets_fail_before_payload_access() {
+  temp_tree tree;
+  auto loc = make_location(tree.root());
+  const auto path = create_page_path(loc);
+  auto region = mapped_region::map_writable(path, TEST_PAGE_SIZE);
+  auto *header = reinterpret_cast<page_header *>(region.address());
+  header->version = __JOURNAL_VERSION__;
+  header->page_header_length = sizeof(page_header);
+  header->page_size = TEST_PAGE_SIZE;
+  header->frame_header_length = sizeof(frame_header);
+  header->status = kungfu::yijinjing::enums::PageStatus::Normal;
+  header->last_frame_position = TEST_PAGE_SIZE;
+  require(region.reset(), "failed to release corrupt-page fixture mapping");
+
+  require_throws([&] { (void)page::load(loc, location::PUBLIC, TEST_PAGE_SIZE, 1, false, true); },
+                 "page accepted a last-frame offset outside the mapped payload");
+}
+
+void test_corrupt_page_header_facts_are_rejected() {
+  struct corrupt_case {
+    const char *name;
+    std::function<void(page_header &)> corrupt;
+  };
+  const corrupt_case cases[] = {
+      {"page header length", [](page_header &header) { header.page_header_length = sizeof(page_header) + 8; }},
+      {"frame header length", [](page_header &header) { header.frame_header_length = sizeof(frame_header) - 8; }},
+      {"page size", [](page_header &header) { header.page_size = TEST_PAGE_SIZE + 4096; }},
+  };
+
+  for (const auto &test_case : cases) {
+    temp_tree tree;
+    auto loc = make_location(tree.root());
+    const auto path = create_page_path(loc);
+    auto region = mapped_region::map_writable(path, TEST_PAGE_SIZE);
+    auto *header = reinterpret_cast<page_header *>(region.address());
+    header->version = __JOURNAL_VERSION__;
+    header->page_header_length = sizeof(page_header);
+    header->page_size = TEST_PAGE_SIZE;
+    header->frame_header_length = sizeof(frame_header);
+    header->status = kungfu::yijinjing::enums::PageStatus::Normal;
+    header->last_frame_position = sizeof(page_header);
+    test_case.corrupt(*header);
+    require(region.reset(), std::string("failed to release ") + test_case.name + " fixture");
+
+    require_throws([&] { (void)page::load(loc, location::PUBLIC, TEST_PAGE_SIZE, 1, false, true); },
+                   std::string("page accepted corrupt ") + test_case.name);
+  }
+}
+
+void test_page_header_publication() {
+  temp_tree tree;
+  auto loc = make_location(tree.root());
+  const auto path = create_page_path(loc);
+  auto empty = mapped_region::map_writable(path, TEST_PAGE_SIZE);
+  require(empty.reset(), "failed to release empty page fixture mapping");
+
+#ifdef _WINDOWS
+  std::thread initializer([loc] {
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    (void)page::load(loc, location::PUBLIC, TEST_PAGE_SIZE, 1, true, true);
+  });
+  auto reader = page::load(loc, location::PUBLIC, TEST_PAGE_SIZE, 1, false, true);
+  initializer.join();
+#else
+  const pid_t child = fork();
+  require(child >= 0, "fork failed for page publication test");
+  if (child == 0) {
+    try {
+      std::this_thread::sleep_for(std::chrono::milliseconds(20));
+      (void)page::load(loc, location::PUBLIC, TEST_PAGE_SIZE, 1, true, true);
+      _exit(0);
+    } catch (...) {
+      _exit(2);
+    }
+  }
+  auto reader = page::load(loc, location::PUBLIC, TEST_PAGE_SIZE, 1, false, true);
+  int status = 0;
+  require(waitpid(child, &status, 0) == child && WIFEXITED(status) && WEXITSTATUS(status) == 0,
+          "initializer process failed");
+#endif
+
+  require(reader->get_version() == __JOURNAL_VERSION__, "reader observed an unpublished page version");
+  require(reader->get_page_size() == TEST_PAGE_SIZE, "reader observed an unpublished page size");
+  require(reader->first_frame_address() > reader->address(), "reader observed an invalid first-frame address");
+}
+
+} // namespace
+
+int main() {
+  const std::pair<const char *, void (*)()> tests[] = {
+      {"wire layout invariants", test_wire_layout_invariants},
+      {"existing mapping never creates or grows", test_existing_mapping_never_creates_or_grows},
+      {"mapped region move ownership", test_mapped_region_move_ownership},
+      {"page reader does not create layout", test_page_reader_does_not_create_layout},
+      {"corrupt page offsets fail before payload access", test_corrupt_page_offsets_fail_before_payload_access},
+      {"corrupt page header facts are rejected", test_corrupt_page_header_facts_are_rejected},
+      {"page header publication", test_page_header_publication},
+  };
+
+  int failed = 0;
+  for (const auto &[name, test] : tests) {
+    try {
+      test();
+      std::cout << "ok - " << name << '\n';
+    } catch (const std::exception &error) {
+      ++failed;
+      std::cerr << "not ok - " << name << ": " << error.what() << '\n';
+    }
+  }
+  return failed == 0 ? 0 : 1;
+}

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "kfd2:claims": "node scripts/require-shifu.mjs kfd2:claims && buildchain kfd 2 product-claims write",
     "kfd2:claims:check": "node scripts/require-shifu.mjs kfd2:claims:check && buildchain kfd 2 product-claims check",
     "check:types": "node scripts/require-shifu.mjs check:types && tsc -p tsconfig.tools.json",
+    "test:mmap": "node scripts/require-shifu.mjs test:mmap && node scripts/run-mmap-tests.mjs",
     "version": "node scripts/sync-shifu-version.mjs && git add crates/shifu/Cargo.toml crates/Cargo.lock",
     "prepare": "node scripts/install-hooks.mjs",
     "hooks:install": "node scripts/require-shifu.mjs hooks:install && node scripts/install-hooks.mjs --force"

--- a/scripts/run-mmap-tests.mjs
+++ b/scripts/run-mmap-tests.mjs
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+
+const root = process.cwd();
+const executable =
+  process.platform === 'win32'
+    ? 'yijinjing_mmap_tests.exe'
+    : 'yijinjing_mmap_tests';
+const candidates = [
+  path.join(root, 'framework', 'core', 'build', 'Release', executable),
+  path.join(root, 'framework', 'core', 'build', executable),
+];
+const testBinary = candidates.find((candidate) => fs.existsSync(candidate));
+
+if (!testBinary) {
+  console.error(
+    '[mmap-test] native test binary not found; run ./shifu build first',
+  );
+  process.exit(2);
+}
+
+const result = spawnSync(testBinary, [], { cwd: root, stdio: 'inherit' });
+if (result.error) {
+  console.error(
+    `[mmap-test] failed to start ${testBinary}: ${result.error.message}`,
+  );
+  process.exit(1);
+}
+process.exit(result.status ?? 1);


### PR DESCRIPTION
## What changed

- introduce move-only `mapped_region` ownership for POSIX and Windows mappings
- separate existing-only mappings from explicit create/grow authority
- make `page_header::last_frame_position` the release/acquire page publication token
- validate page/header/frame sizes and offsets before payload access
- keep journal wire-v1 and the public three-argument Python `get_page_path` API unchanged
- extend ADR-0001 and add native mmap correctness tests wired through Shifu and CTest

## Why

Reader mappings could create or stretch files, raw mapping ownership leaked resources on error paths, and page initialization relied on ordinary cross-process field polling. The new boundary makes ownership and mutation authority explicit while preserving the existing single-writer, zero-copy journal contract.

## Validation

- `./shifu build:core` — passed on Mac arm64 after rebasing onto current `dev/v4/v4.0`; includes Node, Electron, Python, Wasmer and Wasmtime targets
- `./shifu test:mmap` — passed
- `ctest --test-dir framework/core/build -R '^yijinjing_mmap_tests$' --output-on-failure` — passed
- `./shifu check` — passed
- commit pre-checks including clang-format 20.1.8 — passed

CI is currently unavailable and is not used as the merge gate for this change; the requested gate is the Mac build and tests above.
