### PR TITLE
refactor(journal): separate mmap mapping policies

### DIFF
--- a/framework/core/docs/adr/ADR-0058-yijinjing-explicit-mapping-policies.md
+++ b/framework/core/docs/adr/ADR-0058-yijinjing-explicit-mapping-policies.md
@@ -1,0 +1,112 @@
+---
+status: accepted
+period: 2026-07-11
+theme: yijinjing-explicit-mapping-policies
+doc_type: architecture-decision
+source_level: local-files + user-decision
+confidence: high
+sensitivity: public
+evidence_grade: A
+review_state: user-reviewed
+last_reviewed: 2026-07-11
+---
+
+# ADR-0058: yijinjing mmap behavior is expressed as explicit policies
+
+- Status: accepted; implemented
+- Date: 2026-07-11
+- Category: journal architecture / mmap / compatibility
+- Related: [ADR-0001](ADR-0001-yijinjing-publish-barrier.md),
+  [ADR-0024](ADR-0024-location-role-and-journal-page-policy.md), and
+  [ADR-0057](ADR-0057-domain-neutral-live-runtime-terminology.md)
+
+## Context
+
+The historical mmap surface combined several independent decisions in
+`is_writing` and `lazy` booleans. Depending on the call site, those booleans
+selected read/write access, file creation, page pre-creation, page-size
+discovery, attempted residency locking, and cleanup behavior. A caller could
+not state which authority or operating property it required, and adding a new
+mode risked changing unrelated behavior hidden behind the same boolean.
+
+The journal wire-v1 layout, closed Hana POD layout, zero-copy frame access, and
+single-writer publication protocol are compatibility invariants. Separating
+mapping policy must not change any of them.
+
+## Decision
+
+File mappings use a `mapping_policy` composed from four orthogonal axes:
+
+| Axis | Values | Meaning |
+|---|---|---|
+| access | `read_only`, `read_write` | memory protection and write authority |
+| creation | `existing_only`, `create_or_grow` | whether the path may create or extend a file |
+| residency | `demand`, `prefault`, `pinned` | requested physical-page residency behavior |
+| durability | `visibility`, `asynchronous`, `durable` | requested writeback contract |
+
+The current qualified truth table is deliberately small:
+
+| Access | Creation | Residency | Durability | Qualified |
+|---|---|---|---|---|
+| read-only | existing-only | demand | visibility | yes |
+| read-write | existing-only | demand | visibility | yes |
+| read-write | create-or-grow | demand | visibility | yes |
+| read-only | create-or-grow | any | any | no: structurally invalid |
+| any | any | prefault or pinned | any | no: not performance-qualified |
+| any | any | any | asynchronous or durable | no: not crash-qualified |
+
+Named but unqualified requests are rejected before the filesystem is mutated.
+They remain enum values so future work must qualify an explicit contract rather
+than reusing a boolean with a new meaning.
+
+`visibility` preserves the existing shared-mapping and explicit-flush behavior.
+It is not a claim of power-loss durability. A future `durable` policy must
+define and test file-data and metadata ordering, platform differences, device
+cache behavior, error propagation, and crash recovery before it is accepted.
+
+## Journal intents
+
+Journal code does not assemble low-level policies ad hoc. It uses explicit
+page intents:
+
+- `reader` and `header_probe` open existing pages read-only;
+- `writer` opens or grows the current writable page;
+- `reader_preload` opens an existing next page read-only;
+- `writer_preload` opens or grows the next writable page;
+- `coordinator_precreate` alone grants coordinator-owned page pre-creation.
+
+Reader construction similarly distinguishes `peer` and `coordinator` policy.
+Page-size discovery and next-page pre-creation follow those policies rather
+than the historical interpretation of `lazy`.
+
+## Compatibility boundary
+
+The typed policy API is canonical for C++, journal/runtime internals, and new
+embedders. Deprecated boolean overloads remain temporarily at source and
+language-binding edges:
+
+- old C++ `is_writing` / `lazy` overloads translate immediately to a typed
+  policy;
+- the existing Python `lazy` argument remains accepted and is translated at
+  binding entry;
+- Node and internal runtime call sites use typed policy directly.
+
+The adapters may be removed after a minor release has published the typed API,
+repository and known external consumers no longer call the old overloads, and
+the normal versioning process approves the source break. They must not gain new
+semantics during that period.
+
+## Invariants and consequences
+
+- Journal wire-v1, Hana POD sizes and offsets, frame addresses, and zero-copy
+  access are unchanged.
+- The ADR-0001 release/acquire publication protocol and single-writer rule are
+  unchanged.
+- Read paths cannot silently create or stretch page files.
+- Coordinator pre-creation is an explicit authority, not a residency or
+  latency side effect.
+- Demand paging remains the only qualified residency policy; the historical
+  best-effort `mlock` path is retired.
+- This is an internal contract refactor with compatibility adapters and has
+  patch-level version impact. Qualifying residency or durability modes later
+  requires new evidence and may have independent version impact.

--- a/framework/core/docs/adr/README.md
+++ b/framework/core/docs/adr/README.md
@@ -75,6 +75,7 @@ A record's **Status** says where it stands:
 | [0055](ADR-0055-retire-journal-session-and-separate-runtime-state-from-projection.md) | accepted | retire journal Session; separate live state from schema projections |
 | [0056](ADR-0056-retire-legacy-journal-cli-lifecycle-tools.md) | accepted | journal lifecycle management belongs to Storage and Episode boundaries |
 | [0057](ADR-0057-domain-neutral-live-runtime-terminology.md) | accepted | live runtime internals use reactor, peer, and coordinator; the public command is `kungfu runtime` |
+| [0058](ADR-0058-yijinjing-explicit-mapping-policies.md) | accepted | yijinjing mmap behavior uses explicit access, creation, residency, and durability policies |
 
 ## Reading by theme
 
@@ -83,6 +84,9 @@ A record's **Status** says where it stands:
   (the closed POD layout as a compatibility invariant), and
   [0047](ADR-0047-authoritative-facts-hana-pod-or-flatbuffers.md) (one schema
   owner per structured fact: Hana POD closed set or FlatBuffers open layer).
+  [0058](ADR-0058-yijinjing-explicit-mapping-policies.md) separates mmap
+  authority from residency and durability requests without changing the wire
+  or POD layouts.
   [0002](ADR-0002-yijinjing-schema-runtime-layout.md) is retained as the
   superseded historical decision that preceded this split.
 - **Control / event axis** — [0003](ADR-0003-control-axis-python-coroutine-integration.md)
@@ -184,7 +188,9 @@ A record's **Status** says where it stands:
   (Episode replaces the retired Session replay anchor), and
   [0056](ADR-0056-retire-legacy-journal-cli-lifecycle-tools.md) (journal
   lifecycle management belongs to Storage/Episode rather than loose-file CLI
-  archive and clean commands), and
+  archive and clean commands),
+  [0058](ADR-0058-yijinjing-explicit-mapping-policies.md) (explicit mapping and
+  page-open policies, with coordinator-only pre-creation), and
   [0042](ADR-0042-episode-atomic-safety-and-qualification.md) (Episode atomic
   safety as evidence-bounded capability, graceful degradation, monotonic repair,
   fault containment, and qualification under scale).

--- a/framework/core/src/bindings/node/binding/io.cpp
+++ b/framework/core/src/bindings/node/binding/io.cpp
@@ -17,8 +17,8 @@ namespace kungfu::node {
 Napi::FunctionReference IODevice::constructor = {};
 
 IODevice::IODevice(const Napi::CallbackInfo &info)
-    : ObjectWrap(info),
-      io_device(ExtractLocation(info, 0, IODevice::ExtractRuntimeLocatorByIndex(info, 1)), false, true) {
+    : ObjectWrap(info), io_device(ExtractLocation(info, 0, IODevice::ExtractRuntimeLocatorByIndex(info, 1)), false,
+                                  io_mapping_policy::peer()) {
   Napi::Env env = info.Env();
   Napi::HandleScope scope(env);
 }

--- a/framework/core/src/bindings/node/binding/journal.cpp
+++ b/framework/core/src/bindings/node/binding/journal.cpp
@@ -124,9 +124,9 @@ Napi::Value Frame::NewInstance(const Napi::Value arg) { return constructor.New({
 bool lossless;
 Napi::FunctionReference Reader::constructor = {};
 Reader::Reader(const Napi::CallbackInfo &info)
-    : ObjectWrap(info), reader(true, false, std::make_shared<bus>(false)),
+    : ObjectWrap(info), reader(reader_policy::peer(), false, std::make_shared<bus>(false)),
       io_device_(std::make_shared<io_device>(IODevice::ExtractLocation(info, 0, IODevice::GetDefaultRuntimeLocator()),
-                                             false, true)) {}
+                                             false, io_mapping_policy::peer())) {}
 
 Napi::Value Reader::ToString(const Napi::CallbackInfo &info) { return Napi::String::New(info.Env(), "Reader.js"); }
 

--- a/framework/core/src/bindings/python/binding/py-runtime.cpp
+++ b/framework/core/src/bindings/python/binding/py-runtime.cpp
@@ -1222,8 +1222,11 @@ void bind(pybind11::module &&m) {
       .def("__rshift__", &assemble::operator>>);
 
   py::class_<io_device, kungfu::runtime::io_device_ptr>(m, "io_device")
-      .def(py::init<location_ptr, bool, bool>(), py::arg("home"), py::arg("low_latency") = false,
-           py::arg("lazy") = true)
+      .def(py::init([](location_ptr home, bool low_latency, bool lazy) {
+             return std::make_shared<io_device>(std::move(home), low_latency,
+                                                kungfu::runtime::io_mapping_policy::from_legacy_lazy(lazy));
+           }),
+           py::arg("home"), py::arg("low_latency") = false, py::arg("lazy") = true)
       .def_property_readonly("publisher", &io_device::get_publisher)
       .def_property_readonly("bus", &io_device::get_bus)
       .def_property_readonly("observer", &io_device::get_observer)

--- a/framework/core/src/libkungfu/include/kungfu/runtime/io.h
+++ b/framework/core/src/libkungfu/include/kungfu/runtime/io.h
@@ -19,6 +19,22 @@ namespace journal {
 void install_typed_frame_dumper();
 } // namespace journal
 
+struct io_mapping_policy {
+  yijinjing::journal::reader_policy reader;
+  bool resource_manager_required;
+  bool legacy_lazy_value;
+
+  [[nodiscard]] static constexpr io_mapping_policy peer() noexcept {
+    return {yijinjing::journal::reader_policy::peer(), true, true};
+  }
+  [[nodiscard]] static constexpr io_mapping_policy coordinator() noexcept {
+    return {yijinjing::journal::reader_policy::coordinator(), false, false};
+  }
+  [[nodiscard]] static constexpr io_mapping_policy from_legacy_lazy(bool lazy) noexcept {
+    return lazy ? peer() : coordinator();
+  }
+};
+
 FORWARD_DECLARE_CLASS_PTR(session)
 
 #define SETUP_TIMEOUT 50
@@ -29,13 +45,16 @@ FORWARD_DECLARE_CLASS_PTR(session)
 
 class io_device : public resource {
 public:
+  io_device(data::location_ptr home, bool low_latency, io_mapping_policy policy);
+
+  [[deprecated("use io_mapping_policy")]]
   io_device(data::location_ptr home, bool low_latency, bool lazy);
 
   ~io_device() override = default;
 
   bool is_usable() override { return publisher_ and observer_ and publisher_->is_usable() and observer_->is_usable(); }
 
-  [[nodiscard]] bool is_lazy() const { return lazy_; }
+  [[nodiscard]] bool is_lazy() const { return mapping_policy_.legacy_lazy_value; }
 
   bool setup() override {
     bool prc = publisher_->setup();
@@ -52,7 +71,8 @@ public:
   [[nodiscard]] bool is_low_latency() const { return low_latency_; }
 
   [[nodiscard]] bool is_resource_manager_required() const {
-    return low_latency_ && lazy_ && home_->mode == kungfu::yijinjing::enums::mode::LIVE;
+    return low_latency_ && mapping_policy_.resource_manager_required &&
+           home_->mode == kungfu::yijinjing::enums::mode::LIVE;
   }
 
   [[nodiscard]] const journal::bus_ptr &get_bus() const { return bus_; }
@@ -86,7 +106,7 @@ protected:
   data::location_ptr home_;
   data::location_ptr live_home_;
   const bool low_latency_;
-  const bool lazy_;
+  const io_mapping_policy mapping_policy_;
   int64_t begin_time_;
   nanomsg::url_factory_ptr url_factory_;
   publisher_ptr publisher_;

--- a/framework/core/src/libkungfu/src/runtime/embedding.cpp
+++ b/framework/core/src/libkungfu/src/runtime/embedding.cpp
@@ -60,7 +60,8 @@ int32_t KF_EMBEDDING_CALL context_open(const kf_embedding_context_config_v1 *con
     result->home = data::location::make_shared(static_cast<enums::mode>(config->mode), enums::location_role::SYSTEM,
                                                config->host_namespace, config->host_name, result->locator);
     const bool low_latency = (config->flags & KF_EMBEDDING_CONTEXT_LOW_LATENCY) != 0;
-    result->io = std::make_shared<kungfu::runtime::io_device>(result->home, low_latency, /*lazy=*/true);
+    result->io = std::make_shared<kungfu::runtime::io_device>(result->home, low_latency,
+                                                              kungfu::runtime::io_mapping_policy::peer());
     *out_context = result.release();
     return KF_EMBEDDING_OK;
   });

--- a/framework/core/src/libkungfu/src/runtime/io/io.cpp
+++ b/framework/core/src/libkungfu/src/runtime/io/io.cpp
@@ -150,10 +150,10 @@ public:
   bool is_usable() override { return socket_.recv(NNG_FLAG_ALLOC) == 0; }
 };
 
-io_device::io_device(data::location_ptr home, const bool low_latency, const bool lazy)
+io_device::io_device(data::location_ptr home, const bool low_latency, io_mapping_policy policy)
     : home_(std::move(home)),
       live_home_(location::make_shared(mode::LIVE, home_->role, home_->namespace_, home_->name, home_->locator)),
-      low_latency_(low_latency), lazy_(lazy), begin_time_(time::now_in_nano()),
+      low_latency_(low_latency), mapping_policy_(policy), begin_time_(time::now_in_nano()),
       bus_(std::make_shared<bus>(is_resource_manager_required())) {
   // keep the guarantees deterministic even when static-library linking drops
   // the seam installers' load-time static initializers
@@ -166,17 +166,22 @@ io_device::io_device(data::location_ptr home, const bool low_latency, const bool
   url_factory_ = std::make_shared<ipc_url_factory>();
 }
 
-reader_ptr io_device::open_reader_to_subscribe() { return std::make_shared<reader>(lazy_, low_latency_, bus_); }
+io_device::io_device(data::location_ptr home, const bool low_latency, const bool lazy)
+    : io_device(std::move(home), low_latency, io_mapping_policy::from_legacy_lazy(lazy)) {}
+
+reader_ptr io_device::open_reader_to_subscribe() {
+  return std::make_shared<reader>(mapping_policy_.reader, low_latency_, bus_);
+}
 
 reader_ptr io_device::open_reader(const data::location_ptr &location, uint32_t dest_id) {
-  auto r = std::make_shared<reader>(lazy_, low_latency_, bus_);
+  auto r = std::make_shared<reader>(mapping_policy_.reader, low_latency_, bus_);
   r->join(location, dest_id, 0);
   return r;
 }
 
 writer_ptr io_device::open_writer(uint32_t dest_id, uint64_t page_size) {
   if (home_->mode != mode::REPLAY) {
-    return std::make_shared<writer>(home_, dest_id, lazy_, publisher_, low_latency_, bus_, page_size);
+    return std::make_shared<writer>(home_, dest_id, publisher_, low_latency_, bus_, page_size);
   } else {
     return std::make_shared<replay_writer>(live_home_, dest_id, std::make_shared<noop_publisher>(),
                                            std::make_shared<bus>(false), page_size, begin_time_);
@@ -185,7 +190,7 @@ writer_ptr io_device::open_writer(uint32_t dest_id, uint64_t page_size) {
 
 writer_ptr io_device::open_writer_at(const data::location_ptr &location, uint32_t dest_id, uint64_t page_size) {
   if (home_->mode != mode::REPLAY) {
-    return std::make_shared<writer>(location, dest_id, lazy_, publisher_, low_latency_, bus_, page_size);
+    return std::make_shared<writer>(location, dest_id, publisher_, low_latency_, bus_, page_size);
   } else {
     return std::make_shared<replay_writer>(location, dest_id, std::make_shared<noop_publisher>(),
                                            std::make_shared<bus>(false), page_size, begin_time_);
@@ -194,7 +199,7 @@ writer_ptr io_device::open_writer_at(const data::location_ptr &location, uint32_
 
 writer_ptr io_device::open_hookable_writer(uint32_t dest_id, const writer_hook_ptr &hook, uint64_t page_size) {
   if (home_->mode != mode::REPLAY) {
-    return std::make_shared<hookable_writer>(home_, dest_id, lazy_, publisher_, low_latency_, bus_, page_size, hook);
+    return std::make_shared<hookable_writer>(home_, dest_id, publisher_, low_latency_, bus_, page_size, hook);
   } else {
     return std::make_shared<replay_writer>(live_home_, dest_id, std::make_shared<noop_publisher>(),
                                            std::make_shared<bus>(false), page_size, begin_time_);
@@ -204,7 +209,7 @@ writer_ptr io_device::open_hookable_writer(uint32_t dest_id, const writer_hook_p
 writer_ptr io_device::open_hookable_writer_at(const data::location_ptr &location, uint32_t dest_id,
                                               const writer_hook_ptr &hook, uint64_t page_size) {
   if (home_->mode != mode::REPLAY) {
-    return std::make_shared<hookable_writer>(location, dest_id, lazy_, publisher_, low_latency_, bus_, page_size, hook);
+    return std::make_shared<hookable_writer>(location, dest_id, publisher_, low_latency_, bus_, page_size, hook);
   } else {
     return std::make_shared<replay_writer>(live_home_, dest_id, std::make_shared<noop_publisher>(),
                                            std::make_shared<bus>(false), page_size, begin_time_);
@@ -212,13 +217,13 @@ writer_ptr io_device::open_hookable_writer_at(const data::location_ptr &location
 }
 
 io_device_coordinator::io_device_coordinator(data::location_ptr home, bool low_latency)
-    : io_device(std::move(home), low_latency, false) {
+    : io_device(std::move(home), low_latency, io_mapping_policy::coordinator()) {
   publisher_ = std::make_shared<nanomsg_publisher_coordinator>(*this, is_low_latency());
   observer_ = std::make_shared<nanomsg_observer_coordinator>(*this, is_low_latency());
 }
 
 io_device_peer::io_device_peer(data::location_ptr home, bool low_latency)
-    : io_device(std::move(home), low_latency, true) {}
+    : io_device(std::move(home), low_latency, io_mapping_policy::peer()) {}
 
 bool io_device_peer::is_usable() {
   nanomsg_publisher_peer publisher(*this, false);

--- a/framework/core/src/libyijinjing/EMBEDDING.md
+++ b/framework/core/src/libyijinjing/EMBEDDING.md
@@ -51,7 +51,12 @@ as-is and performs no `find_package` of its own.
   reference consumers;
 - the core primitives required by that surface: deterministic hash helpers
   (`<kungfu/yijinjing/hash.h>`) and page mmap helpers
-  (`<kungfu/yijinjing/platform/mmap.h>`);
+  (`<kungfu/yijinjing/platform/mmap.h>`). New mmap callers construct an
+  explicit `mapping_policy` from access, creation, residency, and durability
+  intent; the currently qualified factories are `read_existing()`,
+  `write_existing()`, and `write_create_or_grow()`. Unsupported prefault,
+  pinned, asynchronous-writeback, and durable-writeback requests fail before
+  filesystem mutation rather than degrading silently;
 - the storage semantic contracts under `<kungfu/yijinjing/storage...>`:
   payload references, range selectors, source heads, channel requests/cursors,
   manifests, hash/schema inventories, accepted segments, fsck reports, and
@@ -92,3 +97,13 @@ actually true, not before:
 Until then, the static core stays the single supported form, and
 `libkungfu.so/.dylib/.dll` remains the runtime entry point for everything
 user-facing.
+
+## mmap source compatibility
+
+The typed `mapped_region::map(path, size, policy)` API is canonical. Deprecated
+`map_existing`, `map_writable`, and raw-address boolean overloads remain only as
+temporary source adapters for existing embedders; they translate directly to a
+typed policy and do not preserve the former best-effort locking interpretation
+of `lazy`. New integrations must not use those adapters. See
+[ADR-0058](../../docs/adr/ADR-0058-yijinjing-explicit-mapping-policies.md) for
+the qualification table and removal conditions.

--- a/framework/core/src/libyijinjing/include/kungfu/yijinjing/journal/journal.h
+++ b/framework/core/src/libyijinjing/include/kungfu/yijinjing/journal/journal.h
@@ -45,11 +45,44 @@ struct journal_key {
 };
 
 typedef std::map<journal_key, journal_ptr> JournalMap;
+
+enum class page_precreation : uint8_t { disabled, coordinator };
+
+struct journal_open_policy {
+  page_open_policy current_page;
+  page_open_policy preload_page;
+  page_precreation precreation;
+
+  [[nodiscard]] static constexpr journal_open_policy reader() noexcept {
+    return {page_open_policy::reader(), page_open_policy::reader_preload(), page_precreation::disabled};
+  }
+  [[nodiscard]] static constexpr journal_open_policy coordinator_reader() noexcept {
+    return {page_open_policy::reader(), page_open_policy::reader_preload(), page_precreation::coordinator};
+  }
+  [[nodiscard]] static constexpr journal_open_policy writer() noexcept {
+    return {page_open_policy::writer(), page_open_policy::writer_preload(), page_precreation::disabled};
+  }
+};
+
+struct reader_policy {
+  journal_open_policy journal;
+  bool discover_page_size;
+
+  [[nodiscard]] static constexpr reader_policy peer() noexcept { return {journal_open_policy::reader(), true}; }
+  [[nodiscard]] static constexpr reader_policy coordinator() noexcept {
+    return {journal_open_policy::coordinator_reader(), false};
+  }
+};
+
 class journal {
 public:
-  explicit journal(data::location_ptr location, uint32_t dest_id, bool is_writing, bool lazy, bool low_latency,
+  explicit journal(data::location_ptr location, uint32_t dest_id, journal_open_policy policy, bool low_latency,
                    bus_ptr bus, uint64_t page_size,
                    yijinjing::enums::Priority priority = yijinjing::enums::Priority::Medium);
+
+  [[deprecated("use journal_open_policy")]] explicit journal(
+      data::location_ptr location, uint32_t dest_id, bool is_writing, bool lazy, bool low_latency, bus_ptr bus,
+      uint64_t page_size, yijinjing::enums::Priority priority = yijinjing::enums::Priority::Medium);
 
   journal(const journal &other);
 
@@ -91,8 +124,7 @@ protected:
   const data::location_ptr location_;
   const uint64_t page_size_;
   const uint32_t dest_id_;
-  const bool is_writing_;
-  const bool lazy_;
+  const journal_open_policy policy_;
   const bool low_latency_;
   const yijinjing::enums::Priority priority_;
   bus_ptr bus_ = {};
@@ -128,8 +160,11 @@ protected:
 
 class reader {
 public:
-  explicit reader(bool lazy, bool low_latency, bus_ptr bus)
-      : lazy_(lazy), low_latency_(low_latency), bus_(std::move(bus)), current_(nullptr) {}
+  explicit reader(reader_policy policy, bool low_latency, bus_ptr bus)
+      : policy_(policy), low_latency_(low_latency), bus_(std::move(bus)), current_(nullptr) {}
+
+  [[deprecated("use reader_policy")]] explicit reader(bool lazy, bool low_latency, bus_ptr bus)
+      : reader(lazy ? reader_policy::peer() : reader_policy::coordinator(), low_latency, std::move(bus)) {}
 
   reader(const reader &other);
 
@@ -189,7 +224,7 @@ protected:
     bool operator()(const journal_ptr &lhs, const journal_ptr &rhs) const;
   };
 
-  const bool lazy_;
+  const reader_policy policy_;
   const bool low_latency_;
   bus_ptr bus_;
   journal_ptr current_;
@@ -202,15 +237,31 @@ protected:
 
 class writer {
 public:
+  explicit writer(const data::location_ptr &location, uint32_t dest_id, publisher_ptr publisher, bool low_latency,
+                  const bus_ptr &bus);
+
+  explicit writer(const data::location_ptr &location, uint32_t dest_id, publisher_ptr publisher, bool low_latency,
+                  const bus_ptr &bus, uint64_t page_size);
+
+  explicit writer(const data::location_ptr &location, uint32_t dest_id, publisher_ptr publisher, bool low_latency,
+                  const bus_ptr &bus, uint64_t page_size, int64_t begin_time);
+
+  explicit writer(const data::location_ptr &location, uint32_t dest_id, publisher_ptr publisher, bool low_latency,
+                  const bus_ptr &bus, const journal_ptr &journal, int64_t begin_time);
+
+  [[deprecated("writer mapping policy is explicit")]]
   explicit writer(const data::location_ptr &location, uint32_t dest_id, bool lazy, publisher_ptr publisher,
                   bool low_latency, const bus_ptr &bus);
 
+  [[deprecated("writer mapping policy is explicit")]]
   explicit writer(const data::location_ptr &location, uint32_t dest_id, bool lazy, publisher_ptr publisher,
                   bool low_latency, const bus_ptr &bus, uint64_t page_size);
 
+  [[deprecated("writer mapping policy is explicit")]]
   explicit writer(const data::location_ptr &location, uint32_t dest_id, bool lazy, publisher_ptr publisher,
                   bool low_latency, const bus_ptr &bus, uint64_t page_size, int64_t begin_time);
 
+  [[deprecated("writer mapping policy is explicit")]]
   explicit writer(const data::location_ptr &location, uint32_t dest_id, bool lazy, publisher_ptr publisher,
                   bool low_latency, const bus_ptr &bus, const journal_ptr &journal, int64_t begin_time);
 
@@ -350,6 +401,11 @@ public:
 
 class hookable_writer : public writer {
 public:
+  explicit hookable_writer(const data::location_ptr &location, uint32_t dest_id, publisher_ptr publisher,
+                           bool low_latency, const bus_ptr &bus, uint64_t page_size, writer_hook_ptr hook)
+      : writer(location, dest_id, std::move(publisher), low_latency, bus, page_size), hook_(std::move(hook)) {}
+
+  [[deprecated("writer mapping policy is explicit")]]
   explicit hookable_writer(const data::location_ptr &location, uint32_t dest_id, bool lazy, publisher_ptr publisher,
                            bool low_latency, const bus_ptr &bus, uint64_t page_size, writer_hook_ptr hook)
       : writer(location, dest_id, lazy, std::move(publisher), low_latency, bus, page_size), hook_(std::move(hook)) {}

--- a/framework/core/src/libyijinjing/include/kungfu/yijinjing/journal/page.h
+++ b/framework/core/src/libyijinjing/include/kungfu/yijinjing/journal/page.h
@@ -12,6 +12,58 @@
 
 namespace kungfu::yijinjing::journal {
 
+enum class page_open_intent : uint8_t {
+  reader,
+  writer,
+  reader_preload,
+  writer_preload,
+  coordinator_precreate,
+  header_probe
+};
+
+class page_open_policy {
+public:
+  [[nodiscard]] static constexpr page_open_policy reader() noexcept {
+    return page_open_policy(page_open_intent::reader);
+  }
+  [[nodiscard]] static constexpr page_open_policy writer() noexcept {
+    return page_open_policy(page_open_intent::writer);
+  }
+  [[nodiscard]] static constexpr page_open_policy reader_preload() noexcept {
+    return page_open_policy(page_open_intent::reader_preload);
+  }
+  [[nodiscard]] static constexpr page_open_policy writer_preload() noexcept {
+    return page_open_policy(page_open_intent::writer_preload);
+  }
+  [[nodiscard]] static constexpr page_open_policy coordinator_precreate() noexcept {
+    return page_open_policy(page_open_intent::coordinator_precreate);
+  }
+  [[nodiscard]] static constexpr page_open_policy header_probe() noexcept {
+    return page_open_policy(page_open_intent::header_probe);
+  }
+
+  [[nodiscard]] constexpr page_open_intent intent() const noexcept { return intent_; }
+  [[nodiscard]] constexpr bool may_initialize() const noexcept {
+    return intent_ == page_open_intent::writer || intent_ == page_open_intent::writer_preload ||
+           intent_ == page_open_intent::coordinator_precreate;
+  }
+  [[nodiscard]] constexpr bool may_publish_normal() const noexcept {
+    return intent_ == page_open_intent::writer || intent_ == page_open_intent::writer_preload;
+  }
+  [[nodiscard]] constexpr bool opens_preopen() const noexcept {
+    return intent_ == page_open_intent::reader_preload || intent_ == page_open_intent::writer_preload ||
+           intent_ == page_open_intent::coordinator_precreate;
+  }
+  [[nodiscard]] constexpr platform::mapping_policy mapping() const noexcept {
+    return may_initialize() ? platform::mapping_policy::write_create_or_grow()
+                            : platform::mapping_policy::read_existing();
+  }
+
+private:
+  explicit constexpr page_open_policy(page_open_intent intent) noexcept : intent_(intent) {}
+  page_open_intent intent_;
+};
+
 class page {
 
 public:
@@ -60,10 +112,18 @@ public:
   void enable_page();
 
   static page_ptr load(const data::location_ptr &location, uint32_t dest_id, uint64_t page_size, uint32_t page_id,
-                       bool is_writing, bool lazy, bool pre_open = false, bool allow_create = false);
+                       page_open_policy policy);
+
+  [[deprecated("use page::load with an explicit page_open_policy")]] static page_ptr
+  load(const data::location_ptr &location, uint32_t dest_id, uint64_t page_size, uint32_t page_id, bool is_writing,
+       bool lazy, bool pre_open = false, bool allow_create = false);
 
   static page_ptr load_header_and_1st_frame_header(const data::location_ptr &location, uint32_t dest_id,
-                                                   uint32_t page_id, bool is_writing, bool lazy);
+                                                   uint32_t page_id, page_open_policy policy);
+
+  [[deprecated("use an explicit header-probe page_open_policy")]] static page_ptr
+  load_header_and_1st_frame_header(const data::location_ptr &location, uint32_t dest_id, uint32_t page_id,
+                                   bool is_writing, bool lazy);
 
   static std::string get_page_path(const data::location_ptr &location, uint32_t dest_id, uint32_t page_id);
 
@@ -80,11 +140,11 @@ protected:
   const data::location_ptr location_;
   const uint32_t dest_id_;
   const uint32_t page_id_;
-  const bool is_writing_;
+  const page_open_policy policy_;
   const size_t size_;
   const yijinjing::types::page_header *header_;
 
-  page(data::location_ptr location, uint32_t dest_id, uint32_t page_id, size_t size, bool lazy, bool is_writing,
+  page(data::location_ptr location, uint32_t dest_id, uint32_t page_id, size_t size, page_open_policy policy,
        platform::mapped_region region);
 
   [[nodiscard]] uint64_t acquire_last_frame_position() const;

--- a/framework/core/src/libyijinjing/include/kungfu/yijinjing/platform/mmap.h
+++ b/framework/core/src/libyijinjing/include/kungfu/yijinjing/platform/mmap.h
@@ -9,6 +9,49 @@
 
 namespace kungfu::yijinjing::platform {
 
+enum class mapping_access : uint8_t { read_only, read_write };
+enum class mapping_creation : uint8_t { existing_only, create_or_grow };
+enum class mapping_residency : uint8_t { demand, prefault, pinned };
+enum class mapping_durability : uint8_t { visibility, asynchronous, durable };
+
+/**
+ * Orthogonal mapping authorization and operating intent.
+ *
+ * S2 deliberately qualifies demand-paged, visibility-only mappings. Prefault,
+ * pinning, asynchronous flush, and durable flush remain named requests so a
+ * caller cannot smuggle them through a boolean; construction rejects them
+ * until the performance and crash-qualification gates enable them.
+ */
+struct mapping_policy {
+  mapping_access access;
+  mapping_creation creation;
+  mapping_residency residency;
+  mapping_durability durability;
+
+  [[nodiscard]] constexpr bool writable() const noexcept { return access == mapping_access::read_write; }
+  [[nodiscard]] constexpr bool creates_or_grows() const noexcept {
+    return creation == mapping_creation::create_or_grow;
+  }
+  [[nodiscard]] constexpr bool structurally_valid() const noexcept { return writable() || !creates_or_grows(); }
+  [[nodiscard]] constexpr bool qualified() const noexcept {
+    return structurally_valid() && residency == mapping_residency::demand &&
+           durability == mapping_durability::visibility;
+  }
+
+  [[nodiscard]] static constexpr mapping_policy read_existing() noexcept {
+    return {mapping_access::read_only, mapping_creation::existing_only, mapping_residency::demand,
+            mapping_durability::visibility};
+  }
+  [[nodiscard]] static constexpr mapping_policy write_existing() noexcept {
+    return {mapping_access::read_write, mapping_creation::existing_only, mapping_residency::demand,
+            mapping_durability::visibility};
+  }
+  [[nodiscard]] static constexpr mapping_policy write_create_or_grow() noexcept {
+    return {mapping_access::read_write, mapping_creation::create_or_grow, mapping_residency::demand,
+            mapping_durability::visibility};
+  }
+};
+
 /**
  * Move-only ownership for one file-backed mapping.
  *
@@ -28,13 +71,19 @@ public:
   mapped_region(mapped_region &&other) noexcept;
   mapped_region &operator=(mapped_region &&other) noexcept;
 
-  static mapped_region map_existing(const std::string &path, size_t size, bool writable = false, bool lazy = true);
-  static mapped_region map_writable(const std::string &path, size_t size, bool lazy = true);
+  static mapped_region map(const std::string &path, size_t size, mapping_policy policy);
+
+  /** Compatibility adapters; new code must construct a mapping_policy. */
+  [[deprecated("use mapped_region::map with an explicit mapping_policy")]] static mapped_region
+  map_existing(const std::string &path, size_t size, bool writable = false, bool lazy = true);
+  [[deprecated("use mapped_region::map with an explicit mapping_policy")]] static mapped_region
+  map_writable(const std::string &path, size_t size, bool lazy = true);
 
   [[nodiscard]] uintptr_t address() const noexcept { return address_; }
   [[nodiscard]] size_t size() const noexcept { return size_; }
   [[nodiscard]] bool writable() const noexcept { return writable_; }
   [[nodiscard]] bool locked() const noexcept { return locked_; }
+  [[nodiscard]] mapping_policy policy() const noexcept { return policy_; }
   [[nodiscard]] explicit operator bool() const noexcept { return address_ != 0; }
 
   [[nodiscard]] bool flush() const noexcept;
@@ -44,26 +93,26 @@ public:
   [[nodiscard]] uintptr_t release() noexcept;
 
 private:
-  mapped_region(uintptr_t address, size_t size, bool writable, bool locked) noexcept
-      : address_(address), size_(size), writable_(writable), locked_(locked) {}
+  mapped_region(uintptr_t address, size_t size, mapping_policy policy, bool locked) noexcept
+      : address_(address), size_(size), writable_(policy.writable()), locked_(locked), policy_(policy) {}
 
   uintptr_t address_ = 0;
   size_t size_ = 0;
   bool writable_ = false;
   bool locked_ = false;
+  mapping_policy policy_ = mapping_policy::read_existing();
 };
 
-/**
- * load mmap buffer, return address of the file-mapped memory
- * whether to write has to be specified in "is_writing"
- * buffer memory is locked if not lazy
- * @return the address of mapped memory
- */
-uintptr_t load_mmap_buffer(const std::string &path, size_t size, bool is_writing = false, bool lazy = true);
+/** Raw-address compatibility surface for embedders that cannot own mapped_region. */
+uintptr_t load_mmap_buffer(const std::string &path, size_t size, mapping_policy policy);
+bool flush_mmap_buffer(uintptr_t address, size_t size, mapping_durability durability);
+bool release_mmap_buffer(uintptr_t address, size_t size);
 
-bool flush_mmap_buffer(uintptr_t address, size_t size, bool lazy);
-
-bool release_mmap_buffer(uintptr_t address, size_t size, bool lazy);
+[[deprecated("use the mapping_policy overload")]] uintptr_t load_mmap_buffer(const std::string &path, size_t size,
+                                                                             bool is_writing = false, bool lazy = true);
+[[deprecated("use the mapping_durability overload")]] bool flush_mmap_buffer(uintptr_t address, size_t size, bool lazy);
+[[deprecated("release no longer accepts residency through lazy")]] bool release_mmap_buffer(uintptr_t address,
+                                                                                            size_t size, bool lazy);
 } // namespace kungfu::yijinjing::platform
 
 #endif // KUNGFU_YIJINJING_PLATFORM_MMAP_H

--- a/framework/core/src/libyijinjing/src/journal/journal.cpp
+++ b/framework/core/src/libyijinjing/src/journal/journal.cpp
@@ -9,11 +9,11 @@
 
 namespace kungfu::yijinjing::journal {
 
-journal::journal(data::location_ptr location, uint32_t dest_id, bool is_writing, bool lazy, bool low_latency,
+journal::journal(data::location_ptr location, uint32_t dest_id, journal_open_policy policy, bool low_latency,
                  bus_ptr bus, uint64_t page_size, yijinjing::enums::Priority priority)
-    : location_(std::move(location)), dest_id_(dest_id), is_writing_(is_writing), lazy_(lazy),
-      low_latency_(low_latency), bus_(std::move(bus)), frame_(std::shared_ptr<frame>(new frame())), page_frame_nb_(0u),
-      page_size_(page_size), priority_(priority), replica_(false) {
+    : location_(std::move(location)), dest_id_(dest_id), policy_(policy), low_latency_(low_latency),
+      bus_(std::move(bus)), frame_(std::shared_ptr<frame>(new frame())), page_frame_nb_(0u), page_size_(page_size),
+      priority_(priority), replica_(false) {
   keep_page_ = std::getenv("KF_KEEP_PAGE") != nullptr;
   char *pre_create_size = std::getenv("KF_MAX_PRE_CREATE_SIZE");
   try {
@@ -28,10 +28,17 @@ journal::journal(data::location_ptr location, uint32_t dest_id, bool is_writing,
                max_pre_create_size_);
 }
 
+journal::journal(data::location_ptr location, uint32_t dest_id, bool is_writing, bool lazy, bool low_latency,
+                 bus_ptr bus, uint64_t page_size, yijinjing::enums::Priority priority)
+    : journal(std::move(location), dest_id,
+              is_writing ? journal_open_policy::writer()
+                         : (lazy ? journal_open_policy::reader() : journal_open_policy::coordinator_reader()),
+              low_latency, std::move(bus), page_size, priority) {}
+
 journal::journal(const journal &other)
-    : location_(other.location_), dest_id_(other.dest_id_), page_size_(other.page_size_),
-      is_writing_(other.is_writing_), lazy_(other.lazy_), low_latency_(other.low_latency_), bus_(other.bus_),
-      page_frame_nb_(other.page_frame_nb_), priority_(other.priority_) {
+    : location_(other.location_), dest_id_(other.dest_id_), page_size_(other.page_size_), policy_(other.policy_),
+      low_latency_(other.low_latency_), bus_(other.bus_), page_frame_nb_(other.page_frame_nb_),
+      priority_(other.priority_) {
   pre_create_page_ = other.pre_create_page_;
   page_ = other.page_;
   frame_ = std::make_shared<frame>(*other.frame_);
@@ -89,7 +96,7 @@ void journal::load_page(uint32_t page_id) {
         page_ = std::move(preload_page_);
         page_->enable_page();
       } else {
-        page_ = page::load(location_, dest_id_, page_size_, page_id, is_writing_, lazy_);
+        page_ = page::load(location_, dest_id_, page_size_, page_id, policy_.current_page);
       }
     }
     frame_->set_address(page_->first_frame_address());
@@ -116,21 +123,21 @@ void journal::preload_next_page() {
   ) {
     return;
   }
-  preload_page_ = page::load(location_, dest_id_, page_size_, page_->get_page_id() + 1, is_writing_, lazy_, true);
+  preload_page_ = page::load(location_, dest_id_, page_size_, page_->get_page_id() + 1, policy_.preload_page);
   SPDLOG_TRACE("journal: {} ", page::get_page_path(location_, dest_id_, preload_page_->get_page_id()));
 }
 
 // Save page-switch time for other processes. This path is only used by the
 // coordinator reader in low-latency mode.
 void journal::try_load_next_extra_page() {
-  if (lazy_ || is_writing_ || !low_latency_ ||                                        //
+  if (policy_.precreation != page_precreation::coordinator || !low_latency_ ||        //
       page_->is_pre_open() ||                                                         //
       max_pre_create_size_ > 0 and page_->get_page_size() > max_pre_create_size_ * MB //
   ) {
     return;
   }
-  pre_create_page_ =
-      page::load(location_, dest_id_, page_->get_page_size(), page_->get_page_id() + 1, false, lazy_, true, true);
+  pre_create_page_ = page::load(location_, dest_id_, page_->get_page_size(), page_->get_page_id() + 1,
+                                page_open_policy::coordinator_precreate());
 }
 
 void journal::release_page() {

--- a/framework/core/src/libyijinjing/src/journal/page.cpp
+++ b/framework/core/src/libyijinjing/src/journal/page.cpp
@@ -30,16 +30,16 @@ static_assert(std::atomic_ref<yijinjing::enums::PageStatus>::is_always_lock_free
 } // namespace
 using namespace yijinjing::types;
 
-page::page(data::location_ptr location, uint32_t dest_id, uint32_t page_id, size_t size, bool lazy, bool is_writing,
+page::page(data::location_ptr location, uint32_t dest_id, uint32_t page_id, size_t size, page_open_policy policy,
            platform::mapped_region region)
-    : region_(std::move(region)), location_(std::move(location)), dest_id_(dest_id), page_id_(page_id),
-      is_writing_(is_writing), size_(size), header_(reinterpret_cast<page_header *>(region_.address())) {
-  (void)lazy;
+    : region_(std::move(region)), location_(std::move(location)), dest_id_(dest_id), page_id_(page_id), policy_(policy),
+      size_(size), header_(reinterpret_cast<page_header *>(region_.address())) {
   assert(region_);
 }
 
 page::~page() {
-  SPDLOG_TRACE("release page {}/{:08x}.{}.journal, is_writing_ {}", location_->uname, dest_id_, page_id_, is_writing_);
+  SPDLOG_TRACE("release page {}/{:08x}.{}.journal, intent {}", location_->uname, dest_id_, page_id_,
+               static_cast<int>(policy_.intent()));
   if (not region_.reset()) {
     SPDLOG_ERROR("can not release page {}/{:08x}.{}.journal", location_->uname, dest_id_, page_id_);
   }
@@ -58,7 +58,7 @@ void page::set_last_frame_position(uint64_t position) {
 }
 
 void page::enable_page() {
-  if (is_writing_) {
+  if (policy_.may_publish_normal()) {
     publish_status(yijinjing::enums::PageStatus::Normal);
   }
 }
@@ -116,21 +116,19 @@ int64_t page::end_time() const {
 }
 
 page_ptr page::load(const data::location_ptr &location, uint32_t dest_id, uint64_t page_size, uint32_t page_id,
-                    bool is_writing, bool lazy, bool pre_open, bool allow_create) {
+                    page_open_policy policy) {
   if (page_size < sizeof(page_header) + 2 * sizeof(frame_header)) {
     throw journal_error("page size is too small for page and frame publication headers");
   }
-  const bool may_initialize = is_writing || allow_create;
-  std::string path = resolve_page_path(location, dest_id, page_id, may_initialize);
-  auto region = may_initialize ? platform::mapped_region::map_writable(path, page_size, lazy)
-                               : platform::mapped_region::map_existing(path, page_size, false, lazy);
+  const bool may_initialize = policy.may_initialize();
+  std::string path = resolve_page_path(location, dest_id, page_id, policy.mapping().creates_or_grows());
+  auto region = platform::mapped_region::map(path, page_size, policy.mapping());
 
   auto header = reinterpret_cast<page_header *>(region.address());
-  auto loaded_page =
-      std::shared_ptr<page>(new page(location, dest_id, page_id, page_size, lazy, is_writing, std::move(region)));
-  bool is_virgin_page = loaded_page->acquire_last_frame_position() == 0;
-  SPDLOG_TRACE("load page {}/{:08x}.{}.journal lazy {} size {} is_writing {} is_virgin_page {}", location->uname,
-               dest_id, page_id, lazy, page_size, is_writing, is_virgin_page);
+  auto loaded_page = std::shared_ptr<page>(new page(location, dest_id, page_id, page_size, policy, std::move(region)));
+  const bool is_virgin_page = loaded_page->acquire_last_frame_position() == 0;
+  SPDLOG_TRACE("load page {}/{:08x}.{}.journal intent {} size {} is_virgin_page {}", location->uname, dest_id, page_id,
+               static_cast<int>(policy.intent()), page_size, is_virgin_page);
 
   if (may_initialize) {
     if (is_virgin_page) {
@@ -138,10 +136,10 @@ page_ptr page::load(const data::location_ptr &location, uint32_t dest_id, uint64
       header->page_header_length = sizeof(page_header);
       header->page_size = page_size;
       header->frame_header_length = sizeof(frame_header);
-      loaded_page->publish_status(pre_open ? yijinjing::enums::PageStatus::PreOpen
-                                           : yijinjing::enums::PageStatus::Normal);
+      loaded_page->publish_status(policy.opens_preopen() ? yijinjing::enums::PageStatus::PreOpen
+                                                         : yijinjing::enums::PageStatus::Normal);
       loaded_page->set_last_frame_position(header->page_header_length);
-    } else if (not pre_open) {
+    } else if (!policy.opens_preopen()) {
       loaded_page->publish_status(yijinjing::enums::PageStatus::Normal);
     }
   }
@@ -169,9 +167,9 @@ page_ptr page::load(const data::location_ptr &location, uint32_t dest_id, uint64
   }
   if (header->page_size != page_size) {
     uint64_t s = header->page_size;
-    throw journal_error(fmt::format(
-        "page size mismatch, required {}, found {}, location {}, path {}, dest_id {}, page_id {} is_writing {}",
-        page_size, s, location->uname, path, dest_id, page_id, is_writing));
+    throw journal_error(
+        fmt::format("page size mismatch, required {}, found {}, location {}, path {}, dest_id {}, page_id {} intent {}",
+                    page_size, s, location->uname, path, dest_id, page_id, static_cast<int>(policy.intent())));
   }
 
   const auto last_frame_position = loaded_page->acquire_last_frame_position();
@@ -180,25 +178,33 @@ page_ptr page::load(const data::location_ptr &location, uint32_t dest_id, uint64
                                     last_frame_position, header->page_header_length, page_size));
   }
 
-  if (loaded_page->acquire_status() != yijinjing::enums::PageStatus::Normal && !pre_open) {
+  if (loaded_page->acquire_status() != yijinjing::enums::PageStatus::Normal && !policy.opens_preopen()) {
     SPDLOG_WARN("page is still preopen status");
   }
 
   return loaded_page;
 }
 
+page_ptr page::load(const data::location_ptr &location, uint32_t dest_id, uint64_t page_size, uint32_t page_id,
+                    bool is_writing, bool lazy, bool pre_open, bool allow_create) {
+  (void)lazy;
+  const auto policy = allow_create && !is_writing ? page_open_policy::coordinator_precreate()
+                      : is_writing ? (pre_open ? page_open_policy::writer_preload() : page_open_policy::writer())
+                                   : (pre_open ? page_open_policy::reader_preload() : page_open_policy::reader());
+  return load(location, dest_id, page_size, page_id, policy);
+}
+
 page_ptr page::load_header_and_1st_frame_header(const data::location_ptr &location, uint32_t dest_id, uint32_t page_id,
-                                                bool is_writing, bool lazy) {
+                                                page_open_policy policy) {
   uint32_t page_header_size = sizeof(page_header);
   uint32_t frame_header_size = sizeof(frame_header);
   uint32_t sliced_page_size = page_header_size + frame_header_size;
-  std::string path = resolve_page_path(location, dest_id, page_id, is_writing);
-  auto region = is_writing ? platform::mapped_region::map_writable(path, sliced_page_size, lazy)
-                           : platform::mapped_region::map_existing(path, sliced_page_size, false, lazy);
+  std::string path = resolve_page_path(location, dest_id, page_id, policy.mapping().creates_or_grows());
+  auto region = platform::mapped_region::map(path, sliced_page_size, policy.mapping());
 
   auto header = reinterpret_cast<page_header *>(region.address());
-  auto loaded_page = std::shared_ptr<page>(
-      new page(location, dest_id, page_id, sliced_page_size, lazy, is_writing, std::move(region)));
+  auto loaded_page =
+      std::shared_ptr<page>(new page(location, dest_id, page_id, sliced_page_size, policy, std::move(region)));
   if (loaded_page->acquire_last_frame_position() == 0) {
     SPDLOG_WARN("open a page never loaded : {}", path);
   }
@@ -209,6 +215,13 @@ page_ptr page::load_header_and_1st_frame_header(const data::location_ptr &locati
   }
 
   return loaded_page;
+}
+
+page_ptr page::load_header_and_1st_frame_header(const data::location_ptr &location, uint32_t dest_id, uint32_t page_id,
+                                                bool is_writing, bool lazy) {
+  (void)lazy;
+  return load_header_and_1st_frame_header(location, dest_id, page_id,
+                                          is_writing ? page_open_policy::writer() : page_open_policy::header_probe());
 }
 
 std::string page::get_page_path(const data::location_ptr &location, uint32_t dest_id, uint32_t page_id) {
@@ -233,7 +246,8 @@ uint32_t page::find_page_id(const data::location_ptr &location, uint32_t dest_id
     return page_ids.front();
   }
   for (int i = static_cast<int>(page_ids.size()) - 1; i >= 0; i--) {
-    auto loaded_page = page::load_header_and_1st_frame_header(location, dest_id, page_ids[i], false, true);
+    auto loaded_page =
+        page::load_header_and_1st_frame_header(location, dest_id, page_ids[i], page_open_policy::header_probe());
     const auto *loaded_page_header = loaded_page->header_;
     if (loaded_page->acquire_last_frame_position() != 0 &&
         loaded_page->acquire_status() != yijinjing::enums::PageStatus::PreOpen &&

--- a/framework/core/src/libyijinjing/src/journal/reader.cpp
+++ b/framework/core/src/libyijinjing/src/journal/reader.cpp
@@ -16,9 +16,10 @@ void reader::join(const data::location_ptr &location, uint32_t dest_id, const in
                   yijinjing::enums::Priority priority) {
   SPDLOG_TRACE("join location: {}, dest_id: {}, page_size: {} ", location->to_string(), dest_id, page_size);
   auto key = journal_key(location, dest_id);
-  auto size = lazy_ ? find_page_size(location, dest_id) : page::find_page_size(location, dest_id, page_size);
+  auto size = policy_.discover_page_size ? find_page_size(location, dest_id)
+                                         : page::find_page_size(location, dest_id, page_size);
   auto result = journals_.try_emplace(
-      key, std::make_shared<journal>(location, dest_id, false, lazy_, low_latency_, bus_, size, priority));
+      key, std::make_shared<journal>(location, dest_id, policy_.journal, low_latency_, bus_, size, priority));
   if (result.second) {
     journals_.at(key)->seek_to_time(from_time);
   }
@@ -127,7 +128,7 @@ void reader::preload_next_page() {
   }
 }
 
-reader::reader(const reader &other) : lazy_(other.lazy_), low_latency_(other.low_latency_), bus_(other.bus_) {
+reader::reader(const reader &other) : policy_(other.policy_), low_latency_(other.low_latency_), bus_(other.bus_) {
   for (auto &j : other.journals_) {
     journals_.emplace(j.first, j.second);
     if (other.current_->get_source() == j.second->get_source() and other.current_->get_dest() == j.second->get_dest()) {
@@ -155,7 +156,7 @@ uint64_t reader::find_page_size(const data::location_ptr &location, uint32_t des
   }
 
   auto page_id = page_ids.front();
-  auto page = page::load_header_and_1st_frame_header(location, dest_id, page_id, false, true);
+  auto page = page::load_header_and_1st_frame_header(location, dest_id, page_id, page_open_policy::header_probe());
   auto page_size = page->get_page_size();
   if (page_size == 0) {
     const std::string msg = fmt::format("open a page never init page_header for {}", location->uname,

--- a/framework/core/src/libyijinjing/src/journal/writer.cpp
+++ b/framework/core/src/libyijinjing/src/journal/writer.cpp
@@ -15,34 +15,60 @@ inline size_t verify_cpu_word_length(size_t length) {
   return ((length + (sizeof(uintptr_t) - 1)) & ~(sizeof(uintptr_t) - 1));
 }
 
-writer::writer(const data::location_ptr &location, uint32_t dest_id, bool lazy, publisher_ptr publisher,
-               bool low_latency, const bus_ptr &bus, const journal_ptr &journal, int64_t begin_time)
+writer::writer(const data::location_ptr &location, uint32_t dest_id, publisher_ptr publisher, bool low_latency,
+               const bus_ptr &bus, const journal_ptr &journal, int64_t begin_time)
     : frame_id_base_(static_cast<uint64_t>(location->uid xor dest_id) << 32u), journal_(journal),
       publisher_(std::move(publisher)), size_to_write_(0), last_gen_time_(0),
       writer_start_time_32int_(time::nano_hashed(time::now_in_nano())) {
+  (void)low_latency;
+  (void)bus;
   journal_->seek_to_time(begin_time);
+}
+
+writer::writer(const data::location_ptr &location, uint32_t dest_id, publisher_ptr publisher, bool low_latency,
+               const bus_ptr &bus)
+    : writer(location, dest_id, std::move(publisher), low_latency, bus,
+             std::make_shared<journal>(location, dest_id, journal_open_policy::writer(), low_latency, bus,
+                                       page::find_page_size(location, dest_id)),
+             time::now_in_nano()) {}
+
+writer::writer(const data::location_ptr &location, uint32_t dest_id, publisher_ptr publisher, bool low_latency,
+               const bus_ptr &bus, uint64_t page_size)
+    : writer(location, dest_id, std::move(publisher), low_latency, bus,
+             std::make_shared<journal>(location, dest_id, journal_open_policy::writer(), low_latency, bus,
+                                       page::find_page_size(location, dest_id, page_size)),
+             time::now_in_nano()) {}
+
+writer::writer(const data::location_ptr &location, uint32_t dest_id, publisher_ptr publisher, bool low_latency,
+               const bus_ptr &bus, uint64_t page_size, int64_t begin_time)
+    : writer(location, dest_id, std::move(publisher), low_latency, bus,
+             std::make_shared<journal>(location, dest_id, journal_open_policy::writer(), low_latency, bus,
+                                       page::find_page_size(location, dest_id, page_size)),
+             begin_time) {}
+
+writer::writer(const data::location_ptr &location, uint32_t dest_id, bool lazy, publisher_ptr publisher,
+               bool low_latency, const bus_ptr &bus, const journal_ptr &journal, int64_t begin_time)
+    : writer(location, dest_id, std::move(publisher), low_latency, bus, journal, begin_time) {
+  (void)lazy;
 }
 
 writer::writer(const data::location_ptr &location, uint32_t dest_id, bool lazy, publisher_ptr publisher,
                bool low_latency, const bus_ptr &bus)
-    : writer(location, dest_id, lazy, std::move(publisher), low_latency, bus,
-             std::make_shared<journal>(location, dest_id, true, lazy, low_latency, bus,
-                                       page::find_page_size(location, dest_id)),
-             time::now_in_nano()) {}
+    : writer(location, dest_id, std::move(publisher), low_latency, bus) {
+  (void)lazy;
+}
 
 writer::writer(const data::location_ptr &location, uint32_t dest_id, bool lazy, publisher_ptr publisher,
                bool low_latency, const bus_ptr &bus, uint64_t page_size)
-    : writer(location, dest_id, lazy, std::move(publisher), low_latency, bus,
-             std::make_shared<journal>(location, dest_id, true, lazy, low_latency, bus,
-                                       page::find_page_size(location, dest_id, page_size)),
-             time::now_in_nano()) {}
+    : writer(location, dest_id, std::move(publisher), low_latency, bus, page_size) {
+  (void)lazy;
+}
 
 writer::writer(const data::location_ptr &location, uint32_t dest_id, bool lazy, publisher_ptr publisher,
                bool low_latency, const bus_ptr &bus, uint64_t page_size, int64_t begin_time)
-    : writer(location, dest_id, lazy, std::move(publisher), low_latency, bus,
-             std::make_shared<journal>(location, dest_id, true, lazy, low_latency, bus,
-                                       page::find_page_size(location, dest_id, page_size)),
-             begin_time) {}
+    : writer(location, dest_id, std::move(publisher), low_latency, bus, page_size, begin_time) {
+  (void)lazy;
+}
 
 uint64_t writer::current_frame_uid() {
   uint32_t page_part = (journal_->page_->page_id_ << 24u) & PAGE_ID_TRANC;

--- a/framework/core/src/libyijinjing/src/storage/episode_manifest.cpp
+++ b/framework/core/src/libyijinjing/src/storage/episode_manifest.cpp
@@ -84,7 +84,7 @@ location_ptr manifest_location(const std::string &runtime_dir) {
 }
 
 writer make_writer(const std::string &runtime_dir) {
-  return writer(manifest_location(runtime_dir), location::PUBLIC, true, std::make_shared<noop_publisher>(), false,
+  return writer(manifest_location(runtime_dir), location::PUBLIC, std::make_shared<noop_publisher>(), false,
                 std::make_shared<bus>(false));
 }
 

--- a/framework/core/src/libyijinjing/src/storage/manifest_catalog.cpp
+++ b/framework/core/src/libyijinjing/src/storage/manifest_catalog.cpp
@@ -182,7 +182,7 @@ location_ptr catalog_location(const std::string &runtime_dir) {
 }
 
 writer make_writer(const std::string &runtime_dir) {
-  return writer(catalog_location(runtime_dir), location::PUBLIC, true, std::make_shared<noop_publisher>(), false,
+  return writer(catalog_location(runtime_dir), location::PUBLIC, std::make_shared<noop_publisher>(), false,
                 std::make_shared<bus>(false));
 }
 

--- a/framework/core/src/libyijinjing/src/storage/source_registry.cpp
+++ b/framework/core/src/libyijinjing/src/storage/source_registry.cpp
@@ -67,7 +67,7 @@ location_ptr registry_location(const std::string &runtime_dir) {
 }
 
 writer make_writer(const std::string &runtime_dir) {
-  return writer(registry_location(runtime_dir), location::PUBLIC, true, std::make_shared<noop_publisher>(), false,
+  return writer(registry_location(runtime_dir), location::PUBLIC, std::make_shared<noop_publisher>(), false,
                 std::make_shared<bus>(false));
 }
 

--- a/framework/core/src/libyijinjing/src/util/mmap.cpp
+++ b/framework/core/src/libyijinjing/src/util/mmap.cpp
@@ -34,6 +34,18 @@ struct native_mapping {
   bool locked;
 };
 
+void validate_policy(const mapping_policy policy, const std::string &path) {
+  if (!policy.structurally_valid()) {
+    throw journal_error("read-only mapping cannot create or grow page " + path);
+  }
+  if (policy.residency != mapping_residency::demand) {
+    throw journal_error("mapping residency request is not qualified for page " + path);
+  }
+  if (policy.durability != mapping_durability::visibility) {
+    throw journal_error("mapping durability request is not qualified for page " + path);
+  }
+}
+
 #ifdef _WINDOWS
 [[noreturn]] void throw_mapping_error(const std::string &operation, const std::string &path, int code) {
   throw journal_error(operation + " for page " + path + ", error: " + std::to_string(code));
@@ -71,7 +83,8 @@ private:
   HANDLE value_;
 };
 
-native_mapping map_file(const std::string &path, size_t size, bool writable, bool create_and_grow, bool lazy) {
+native_mapping map_file(const std::string &path, size_t size, mapping_policy policy) {
+  validate_policy(policy, path);
   if (size == 0) {
     throw journal_error("refusing to mmap zero bytes for page " + path);
   }
@@ -79,9 +92,10 @@ native_mapping map_file(const std::string &path, size_t size, bool writable, boo
     throw journal_error("requested mapping is too large for page " + path);
   }
 
-  unique_handle file(CreateFileA(path.c_str(), writable ? (GENERIC_READ | GENERIC_WRITE) : GENERIC_READ,
+  unique_handle file(CreateFileA(path.c_str(), policy.writable() ? (GENERIC_READ | GENERIC_WRITE) : GENERIC_READ,
                                  FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr,
-                                 create_and_grow ? OPEN_ALWAYS : OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr));
+                                 policy.creates_or_grows() ? OPEN_ALWAYS : OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL,
+                                 nullptr));
   if (!file) {
     throw_mapping_error("failed to open file", path, static_cast<int>(GetLastError()));
   }
@@ -91,7 +105,7 @@ native_mapping map_file(const std::string &path, size_t size, bool writable, boo
     throw_mapping_error("failed to inspect file size", path, static_cast<int>(GetLastError()));
   }
   if (file_size.QuadPart < 0 || static_cast<uint64_t>(file_size.QuadPart) < size) {
-    if (!create_and_grow) {
+    if (!policy.creates_or_grows()) {
       throw journal_error("page file is smaller than requested mapping: " + path + ", required " +
                           std::to_string(size) + ", found " + std::to_string(file_size.QuadPart));
     }
@@ -103,23 +117,23 @@ native_mapping map_file(const std::string &path, size_t size, bool writable, boo
   }
 
   const auto size64 = static_cast<uint64_t>(size);
-  unique_handle mapping(CreateFileMappingA(file.get(), nullptr, writable ? PAGE_READWRITE : PAGE_READONLY,
+  unique_handle mapping(CreateFileMappingA(file.get(), nullptr, policy.writable() ? PAGE_READWRITE : PAGE_READONLY,
                                            static_cast<DWORD>(size64 >> 32u), static_cast<DWORD>(size64), nullptr));
   if (!mapping) {
     throw_mapping_error("failed to create file mapping", path, static_cast<int>(GetLastError()));
   }
 
-  void *buffer = MapViewOfFile(mapping.get(), writable ? FILE_MAP_ALL_ACCESS : FILE_MAP_READ, 0, 0, size);
+  void *buffer = MapViewOfFile(mapping.get(), policy.writable() ? FILE_MAP_ALL_ACCESS : FILE_MAP_READ, 0, 0, size);
   if (buffer == nullptr) {
     throw_mapping_error("failed to map view", path, static_cast<int>(GetLastError()));
   }
-  (void)lazy;
   return {reinterpret_cast<uintptr_t>(buffer), false};
 }
 
 #else
 
-native_mapping map_file(const std::string &path, size_t size, bool writable, bool create_and_grow, bool lazy) {
+native_mapping map_file(const std::string &path, size_t size, mapping_policy policy) {
+  validate_policy(policy, path);
   if (size == 0) {
     throw journal_error("refusing to mmap zero bytes for page " + path);
   }
@@ -127,8 +141,8 @@ native_mapping map_file(const std::string &path, size_t size, bool writable, boo
     throw journal_error("requested mapping is too large for page " + path);
   }
 
-  int flags = writable ? O_RDWR : O_RDONLY;
-  if (create_and_grow) {
+  int flags = policy.writable() ? O_RDWR : O_RDONLY;
+  if (policy.creates_or_grows()) {
     flags |= O_CREAT;
   }
   int fd = open(path.c_str(), flags, static_cast<mode_t>(0600));
@@ -143,7 +157,7 @@ native_mapping map_file(const std::string &path, size_t size, bool writable, boo
     throw journal_error("failed to inspect file size for page " + path + ", errno: " + strerror(code));
   }
   if (file_stat.st_size < 0 || static_cast<uint64_t>(file_stat.st_size) < size) {
-    if (!create_and_grow) {
+    if (!policy.creates_or_grows()) {
       const auto found = file_stat.st_size;
       close(fd);
       throw journal_error("page file is smaller than requested mapping: " + path + ", required " +
@@ -156,26 +170,15 @@ native_mapping map_file(const std::string &path, size_t size, bool writable, boo
     }
   }
 
-  void *buffer = mmap(nullptr, size, writable ? (PROT_READ | PROT_WRITE) : PROT_READ, MAP_SHARED, fd, 0);
+  void *buffer = mmap(nullptr, size, policy.writable() ? (PROT_READ | PROT_WRITE) : PROT_READ, MAP_SHARED, fd, 0);
   if (buffer == MAP_FAILED) {
     const int code = errno;
     close(fd);
     throw journal_error("failed to map file for page " + path + ", errno: " + strerror(code));
   }
 
-  bool locked = false;
-  if (!lazy && madvise(buffer, size, MADV_RANDOM) != 0) {
-    if (mlock(buffer, size) != 0) {
-      const int code = errno;
-      munmap(buffer, size);
-      close(fd);
-      throw journal_error("failed to prepare resident mapping for page " + path + ", errno: " + strerror(code));
-    }
-    locked = true;
-  }
-
   close(fd);
-  return {reinterpret_cast<uintptr_t>(buffer), locked};
+  return {reinterpret_cast<uintptr_t>(buffer), false};
 }
 
 #endif
@@ -185,11 +188,13 @@ native_mapping map_file(const std::string &path, size_t size, bool writable, boo
 mapped_region::~mapped_region() noexcept { (void)reset(); }
 
 mapped_region::mapped_region(mapped_region &&other) noexcept
-    : address_(other.address_), size_(other.size_), writable_(other.writable_), locked_(other.locked_) {
+    : address_(other.address_), size_(other.size_), writable_(other.writable_), locked_(other.locked_),
+      policy_(other.policy_) {
   other.address_ = 0;
   other.size_ = 0;
   other.writable_ = false;
   other.locked_ = false;
+  other.policy_ = mapping_policy::read_existing();
 }
 
 mapped_region &mapped_region::operator=(mapped_region &&other) noexcept {
@@ -199,22 +204,29 @@ mapped_region &mapped_region::operator=(mapped_region &&other) noexcept {
     size_ = other.size_;
     writable_ = other.writable_;
     locked_ = other.locked_;
+    policy_ = other.policy_;
     other.address_ = 0;
     other.size_ = 0;
     other.writable_ = false;
     other.locked_ = false;
+    other.policy_ = mapping_policy::read_existing();
   }
   return *this;
 }
 
+mapped_region mapped_region::map(const std::string &path, size_t size, mapping_policy policy) {
+  const auto native = map_file(path, size, policy);
+  return mapped_region(native.address, size, policy, native.locked);
+}
+
 mapped_region mapped_region::map_existing(const std::string &path, size_t size, bool writable, bool lazy) {
-  const auto native = map_file(path, size, writable, false, lazy);
-  return mapped_region(native.address, size, writable, native.locked);
+  (void)lazy;
+  return map(path, size, writable ? mapping_policy::write_existing() : mapping_policy::read_existing());
 }
 
 mapped_region mapped_region::map_writable(const std::string &path, size_t size, bool lazy) {
-  const auto native = map_file(path, size, true, true, lazy);
-  return mapped_region(native.address, size, true, native.locked);
+  (void)lazy;
+  return map(path, size, mapping_policy::write_create_or_grow());
 }
 
 bool mapped_region::flush() const noexcept {
@@ -254,6 +266,7 @@ bool mapped_region::reset() noexcept {
   size_ = 0;
   writable_ = false;
   locked_ = false;
+  policy_ = mapping_policy::read_existing();
   return ok;
 }
 
@@ -263,16 +276,19 @@ uintptr_t mapped_region::release() noexcept {
   size_ = 0;
   writable_ = false;
   locked_ = false;
+  policy_ = mapping_policy::read_existing();
   return address;
 }
 
-uintptr_t load_mmap_buffer(const std::string &path, size_t size, bool is_writing, bool lazy) {
-  auto region =
-      is_writing ? mapped_region::map_writable(path, size, lazy) : mapped_region::map_existing(path, size, false, lazy);
+uintptr_t load_mmap_buffer(const std::string &path, size_t size, mapping_policy policy) {
+  auto region = mapped_region::map(path, size, policy);
   return region.release();
 }
 
-bool flush_mmap_buffer(uintptr_t address, size_t size, bool lazy) {
+bool flush_mmap_buffer(uintptr_t address, size_t size, mapping_durability durability) {
+  if (durability != mapping_durability::visibility) {
+    return false;
+  }
   void *buffer = reinterpret_cast<void *>(address);
 #ifdef _WINDOWS
   if (FlushViewOfFile(buffer, size) == 0) {
@@ -286,17 +302,31 @@ bool flush_mmap_buffer(uintptr_t address, size_t size, bool lazy) {
   return true;
 }
 
-bool release_mmap_buffer(uintptr_t address, size_t size, bool lazy) {
+bool release_mmap_buffer(uintptr_t address, size_t size) {
   void *buffer = reinterpret_cast<void *>(address);
 #ifdef _WINDOWS
   const bool flushed = FlushViewOfFile(buffer, size) != 0;
   const bool unmapped = UnmapViewOfFile(buffer) != 0;
   return flushed && unmapped;
 #else
-  const bool unlocked = lazy || munlock(buffer, size) == 0;
-  const bool unmapped = munmap(buffer, size) == 0;
-  return unlocked && unmapped;
+  return munmap(buffer, size) == 0;
 #endif // _WINDOWS
+}
+
+uintptr_t load_mmap_buffer(const std::string &path, size_t size, bool is_writing, bool lazy) {
+  (void)lazy;
+  return load_mmap_buffer(path, size,
+                          is_writing ? mapping_policy::write_create_or_grow() : mapping_policy::read_existing());
+}
+
+bool flush_mmap_buffer(uintptr_t address, size_t size, bool lazy) {
+  (void)lazy;
+  return flush_mmap_buffer(address, size, mapping_durability::visibility);
+}
+
+bool release_mmap_buffer(uintptr_t address, size_t size, bool lazy) {
+  (void)lazy;
+  return release_mmap_buffer(address, size);
 }
 
 } // namespace kungfu::yijinjing::platform

--- a/framework/core/src/libyijinjing/tests/mmap_tests.cpp
+++ b/framework/core/src/libyijinjing/tests/mmap_tests.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <kungfu/yijinjing/common.h>
+#include <kungfu/yijinjing/journal/journal.h>
 #include <kungfu/yijinjing/journal/page.h>
 #include <kungfu/yijinjing/platform/mmap.h>
 #include <kungfu/yijinjing/schema/core.h>
@@ -34,7 +35,15 @@ using kungfu::yijinjing::data::locator;
 using kungfu::yijinjing::enums::location_role;
 using kungfu::yijinjing::enums::mode;
 using kungfu::yijinjing::journal::page;
+using kungfu::yijinjing::journal::page_open_policy;
+using kungfu::yijinjing::journal::page_precreation;
+using kungfu::yijinjing::journal::reader_policy;
 using kungfu::yijinjing::platform::mapped_region;
+using kungfu::yijinjing::platform::mapping_access;
+using kungfu::yijinjing::platform::mapping_creation;
+using kungfu::yijinjing::platform::mapping_durability;
+using kungfu::yijinjing::platform::mapping_policy;
+using kungfu::yijinjing::platform::mapping_residency;
 using kungfu::yijinjing::types::frame_header;
 using kungfu::yijinjing::types::page_header;
 
@@ -104,10 +113,74 @@ void test_wire_layout_invariants() {
   static_assert(!std::is_copy_constructible_v<mapped_region>);
 }
 
+void test_mapping_policy_truth_table() {
+  static_assert(mapping_policy::read_existing().qualified());
+  static_assert(mapping_policy::write_existing().qualified());
+  static_assert(mapping_policy::write_create_or_grow().qualified());
+
+  constexpr mapping_policy read_create{mapping_access::read_only, mapping_creation::create_or_grow,
+                                       mapping_residency::demand, mapping_durability::visibility};
+  constexpr mapping_policy prefault{mapping_access::read_only, mapping_creation::existing_only,
+                                    mapping_residency::prefault, mapping_durability::visibility};
+  constexpr mapping_policy pinned{mapping_access::read_write, mapping_creation::existing_only,
+                                  mapping_residency::pinned, mapping_durability::visibility};
+  constexpr mapping_policy asynchronous{mapping_access::read_write, mapping_creation::existing_only,
+                                        mapping_residency::demand, mapping_durability::asynchronous};
+  constexpr mapping_policy durable{mapping_access::read_write, mapping_creation::existing_only,
+                                   mapping_residency::demand, mapping_durability::durable};
+  static_assert(!read_create.structurally_valid());
+  static_assert(!read_create.qualified());
+  static_assert(!prefault.qualified());
+  static_assert(!pinned.qualified());
+  static_assert(!asynchronous.qualified());
+  static_assert(!durable.qualified());
+
+  temp_tree tree;
+  const auto path = tree.root() / "invalid-policy.journal";
+  for (const auto policy : {read_create, prefault, pinned, asynchronous, durable}) {
+    require_throws([&] { (void)mapped_region::map(path.string(), 4096, policy); },
+                   "unqualified mapping policy was accepted");
+  }
+  require(!fs::exists(path), "invalid policy mutated the filesystem before rejection");
+}
+
+void test_page_open_intent_truth_table() {
+  const auto reader = page_open_policy::reader();
+  require(!reader.may_initialize() && !reader.may_publish_normal() && !reader.mapping().writable() &&
+              !reader.mapping().creates_or_grows(),
+          "reader intent gained mutation authority");
+
+  const auto writer = page_open_policy::writer();
+  require(writer.may_initialize() && writer.may_publish_normal() && writer.mapping().writable() &&
+              writer.mapping().creates_or_grows() && !writer.opens_preopen(),
+          "writer intent lost active-page authority");
+
+  const auto reader_preload = page_open_policy::reader_preload();
+  require(reader_preload.opens_preopen() && !reader_preload.may_initialize() && !reader_preload.mapping().writable(),
+          "reader preloader gained mutation authority");
+
+  const auto writer_preload = page_open_policy::writer_preload();
+  require(writer_preload.opens_preopen() && writer_preload.may_initialize() && writer_preload.may_publish_normal(),
+          "writer preloader cannot activate its page");
+
+  const auto precreator = page_open_policy::coordinator_precreate();
+  require(precreator.opens_preopen() && precreator.may_initialize() && !precreator.may_publish_normal() &&
+              precreator.mapping().writable() && precreator.mapping().creates_or_grows(),
+          "coordinator precreator authority is not isolated");
+
+  const auto peer_reader = reader_policy::peer();
+  require(peer_reader.discover_page_size && peer_reader.journal.precreation == page_precreation::disabled,
+          "peer reader unexpectedly owns precreation");
+  const auto coordinator_reader = reader_policy::coordinator();
+  require(!coordinator_reader.discover_page_size &&
+              coordinator_reader.journal.precreation == page_precreation::coordinator,
+          "coordinator reader did not receive explicit precreation authority");
+}
+
 void test_existing_mapping_never_creates_or_grows() {
   temp_tree tree;
   const auto missing = tree.root() / "missing.journal";
-  require_throws([&] { (void)mapped_region::map_existing(missing.string(), 4096); },
+  require_throws([&] { (void)mapped_region::map(missing.string(), 4096, mapping_policy::read_existing()); },
                  "existing-only mapping accepted a missing file");
   require(!fs::exists(missing), "existing-only mapping created a missing file");
 
@@ -117,16 +190,17 @@ void test_existing_mapping_never_creates_or_grows() {
     stream << "short";
   }
   const auto before = fs::file_size(truncated);
-  require_throws([&] { (void)mapped_region::map_existing(truncated.string(), 4096); },
+  require_throws([&] { (void)mapped_region::map(truncated.string(), 4096, mapping_policy::read_existing()); },
                  "existing-only mapping accepted a truncated file");
   require(fs::file_size(truncated) == before, "existing-only mapping changed a truncated file size");
-  require_throws([&] { (void)mapped_region::map_existing(truncated.string(), 0); }, "zero-length mapping was accepted");
+  require_throws([&] { (void)mapped_region::map(truncated.string(), 0, mapping_policy::read_existing()); },
+                 "zero-length mapping was accepted");
 }
 
 void test_mapped_region_move_ownership() {
   temp_tree tree;
   const auto path = tree.root() / "owned.journal";
-  auto first = mapped_region::map_writable(path.string(), 4096);
+  auto first = mapped_region::map(path.string(), 4096, mapping_policy::write_create_or_grow());
   require(first && first.writable() && first.size() == 4096, "writable mapping facts are incorrect");
   *reinterpret_cast<uint64_t *>(first.address()) = UINT64_C(0x1020304050607080);
 
@@ -137,7 +211,7 @@ void test_mapped_region_move_ownership() {
   require(!second, "released mapping retained an address");
   require(fs::file_size(path) == 4096, "writable mapping did not size the file exactly once");
 
-  auto reader = mapped_region::map_existing(path.string(), 4096);
+  auto reader = mapped_region::map(path.string(), 4096, mapping_policy::read_existing());
   require(!reader.writable(), "read mapping unexpectedly has write access");
   require(*reinterpret_cast<const uint64_t *>(reader.address()) == UINT64_C(0x1020304050607080),
           "mapped payload changed across release/reopen");
@@ -151,18 +225,18 @@ void test_mapping_error_paths_release_resources() {
     stream << "short";
   }
 
-  require_throws([&] { (void)mapped_region::map_existing(truncated.string(), 4096); },
+  require_throws([&] { (void)mapped_region::map(truncated.string(), 4096, mapping_policy::read_existing()); },
                  "resource-count warmup unexpectedly mapped a truncated file");
   const auto before = process_resource_count();
   for (int i = 0; i < 8; ++i) {
-    require_throws([&] { (void)mapped_region::map_existing(truncated.string(), 4096); },
+    require_throws([&] { (void)mapped_region::map(truncated.string(), 4096, mapping_policy::read_existing()); },
                    "repeated truncated mapping unexpectedly succeeded");
   }
   const auto after = process_resource_count();
   require(after <= before + 1, "failing mappings leaked file descriptors or handles");
 
   const auto stale_path = tree.root() / "stale.journal";
-  auto stale = mapped_region::map_writable(stale_path.string(), 4096);
+  auto stale = mapped_region::map(stale_path.string(), 4096, mapping_policy::write_create_or_grow());
 #ifdef _WINDOWS
   require(UnmapViewOfFile(reinterpret_cast<void *>(stale.address())) != 0,
           "failed to inject an already-unmapped Windows view");
@@ -190,7 +264,7 @@ void test_resize_budget_failure_releases_file() {
       _exit(2);
     }
     try {
-      (void)mapped_region::map_writable(path.string(), 4096);
+      (void)mapped_region::map(path.string(), 4096, mapping_policy::write_create_or_grow());
       _exit(3);
     } catch (...) {
       std::error_code error;
@@ -210,7 +284,7 @@ void test_page_reader_does_not_create_layout() {
   auto loc = make_location(tree.root());
   const auto journal_dir = loc->locator->layout_dir(loc, kungfu::yijinjing::enums::layout::JOURNAL, false);
   require(!fs::exists(journal_dir), "test journal directory unexpectedly exists");
-  require_throws([&] { (void)page::load(loc, location::PUBLIC, TEST_PAGE_SIZE, 1, false, true); },
+  require_throws([&] { (void)page::load(loc, location::PUBLIC, TEST_PAGE_SIZE, 1, page_open_policy::reader()); },
                  "reader opened a missing journal page");
   require(!fs::exists(journal_dir), "reader created the journal directory for a missing page");
 }
@@ -219,7 +293,7 @@ void test_corrupt_page_offsets_fail_before_payload_access() {
   temp_tree tree;
   auto loc = make_location(tree.root());
   const auto path = create_page_path(loc);
-  auto region = mapped_region::map_writable(path, TEST_PAGE_SIZE);
+  auto region = mapped_region::map(path, TEST_PAGE_SIZE, mapping_policy::write_create_or_grow());
   auto *header = reinterpret_cast<page_header *>(region.address());
   header->version = __JOURNAL_VERSION__;
   header->page_header_length = sizeof(page_header);
@@ -229,7 +303,7 @@ void test_corrupt_page_offsets_fail_before_payload_access() {
   header->last_frame_position = TEST_PAGE_SIZE;
   require(region.reset(), "failed to release corrupt-page fixture mapping");
 
-  require_throws([&] { (void)page::load(loc, location::PUBLIC, TEST_PAGE_SIZE, 1, false, true); },
+  require_throws([&] { (void)page::load(loc, location::PUBLIC, TEST_PAGE_SIZE, 1, page_open_policy::reader()); },
                  "page accepted a last-frame offset outside the mapped payload");
 }
 
@@ -248,7 +322,7 @@ void test_corrupt_page_header_facts_are_rejected() {
     temp_tree tree;
     auto loc = make_location(tree.root());
     const auto path = create_page_path(loc);
-    auto region = mapped_region::map_writable(path, TEST_PAGE_SIZE);
+    auto region = mapped_region::map(path, TEST_PAGE_SIZE, mapping_policy::write_create_or_grow());
     auto *header = reinterpret_cast<page_header *>(region.address());
     header->version = __JOURNAL_VERSION__;
     header->page_header_length = sizeof(page_header);
@@ -259,7 +333,7 @@ void test_corrupt_page_header_facts_are_rejected() {
     test_case.corrupt(*header);
     require(region.reset(), std::string("failed to release ") + test_case.name + " fixture");
 
-    require_throws([&] { (void)page::load(loc, location::PUBLIC, TEST_PAGE_SIZE, 1, false, true); },
+    require_throws([&] { (void)page::load(loc, location::PUBLIC, TEST_PAGE_SIZE, 1, page_open_policy::reader()); },
                    std::string("page accepted corrupt ") + test_case.name);
   }
 }
@@ -268,15 +342,15 @@ void test_page_header_publication() {
   temp_tree tree;
   auto loc = make_location(tree.root());
   const auto path = create_page_path(loc);
-  auto empty = mapped_region::map_writable(path, TEST_PAGE_SIZE);
+  auto empty = mapped_region::map(path, TEST_PAGE_SIZE, mapping_policy::write_create_or_grow());
   require(empty.reset(), "failed to release empty page fixture mapping");
 
 #ifdef _WINDOWS
   std::thread initializer([loc] {
     std::this_thread::sleep_for(std::chrono::milliseconds(20));
-    (void)page::load(loc, location::PUBLIC, TEST_PAGE_SIZE, 1, true, true);
+    (void)page::load(loc, location::PUBLIC, TEST_PAGE_SIZE, 1, page_open_policy::writer());
   });
-  auto reader = page::load(loc, location::PUBLIC, TEST_PAGE_SIZE, 1, false, true);
+  auto reader = page::load(loc, location::PUBLIC, TEST_PAGE_SIZE, 1, page_open_policy::reader());
   initializer.join();
 #else
   const pid_t child = fork();
@@ -284,13 +358,13 @@ void test_page_header_publication() {
   if (child == 0) {
     try {
       std::this_thread::sleep_for(std::chrono::milliseconds(20));
-      (void)page::load(loc, location::PUBLIC, TEST_PAGE_SIZE, 1, true, true);
+      (void)page::load(loc, location::PUBLIC, TEST_PAGE_SIZE, 1, page_open_policy::writer());
       _exit(0);
     } catch (...) {
       _exit(2);
     }
   }
-  auto reader = page::load(loc, location::PUBLIC, TEST_PAGE_SIZE, 1, false, true);
+  auto reader = page::load(loc, location::PUBLIC, TEST_PAGE_SIZE, 1, page_open_policy::reader());
   int status = 0;
   require(waitpid(child, &status, 0) == child && WIFEXITED(status) && WEXITSTATUS(status) == 0,
           "initializer process failed");
@@ -306,6 +380,8 @@ void test_page_header_publication() {
 int main() {
   const std::pair<const char *, void (*)()> tests[] = {
       {"wire layout invariants", test_wire_layout_invariants},
+      {"mapping policy truth table", test_mapping_policy_truth_table},
+      {"page open intent truth table", test_page_open_intent_truth_table},
       {"existing mapping never creates or grows", test_existing_mapping_never_creates_or_grows},
       {"mapped region move ownership", test_mapped_region_move_ownership},
       {"mapping error paths release resources", test_mapping_error_paths_release_resources},


### PR DESCRIPTION
## Summary

- replace implicit mmap booleans with explicit access, creation, residency, and durability policies
- make page and reader/coordinator intents explicit while preserving wire-v1, POD layout, zero-copy, and compatibility adapters
- document the qualified policy matrix in ADR-0058 and add illegal-combination coverage

## Validation

- ./shifu build:core
- ./shifu test:mmap (11/11)
- ./shifu check