### PR TITLE
fix(gui): run first-party manifest with tsx

### DIFF
--- a/framework/gui/package.json
+++ b/framework/gui/package.json
@@ -19,7 +19,7 @@
     "ensure-electron": "node scripts/ensure-electron.mjs",
     "dev": "pnpm run ensure-electron && electron-vite dev",
     "build": "electron-vite build",
-    "gen:first-party-manifest": "node --experimental-transform-types scripts/gen-first-party-manifest.mjs",
+    "gen:first-party-manifest": "tsx scripts/gen-first-party-manifest.mjs",
     "audit:bundle": "node scripts/bundle-core-audit.cjs",
     "start": "pnpm run ensure-electron && electron-vite preview",
     "pack": "pnpm --filter @kungfu-tech/tui run bundle && pnpm run ensure-electron && electron-vite build && node scripts/run-electron-builder.mjs --dir",
@@ -43,6 +43,7 @@
     "electron-builder": "^26.15.3",
     "electron-vite": "^5.0.0",
     "rimraf": "^5.0.0",
+    "tsx": "^4.19.0",
     "typescript": "^5.5.4",
     "vite": "^6.4.3"
   }

--- a/framework/gui/scripts/before-pack.cjs
+++ b/framework/gui/scripts/before-pack.cjs
@@ -8,11 +8,10 @@ const path = require('node:path');
 
 exports.default = async function beforePack() {
   const gen = path.join(__dirname, 'gen-first-party-manifest.mjs');
-  const result = spawnSync(
-    process.execPath,
-    ['--experimental-transform-types', gen],
-    { stdio: 'inherit' },
-  );
+  const tsxLoader = require.resolve('tsx/esm');
+  const result = spawnSync(process.execPath, ['--import', tsxLoader, gen], {
+    stdio: 'inherit',
+  });
   if (result.status !== 0) {
     throw new Error('failed to bake the first-party manifest before pack');
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -455,6 +455,9 @@ importers:
       rimraf:
         specifier: ^5.0.0
         version: 5.0.10
+      tsx:
+        specifier: ^4.19.0
+        version: 4.22.4
       typescript:
         specifier: ^5.5.4
         version: 5.9.3
@@ -4429,6 +4432,7 @@ packages:
   tsx@4.22.4:
     resolution: {integrity: sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==}
     engines: {node: '>=18.0.0'}
+    hasBin: true
 
   tuf-js@4.1.0:
     resolution: {integrity: sha512-50QV99kCKH5P/Vs4E2Gzp7BopNV+KzTXqWeaxrfu5IQJBOULRsTIS9seSsOVT8ZnGXzCyx55nYWAi4qJzpZKEQ==}


### PR DESCRIPTION
## Summary

- execute first-party manifest generation through the project TypeScript runtime
- keep the package script and electron-builder beforePack hook on the same execution path
- preserve the pinned first-party extension manifest in desktop artifacts

## Validation

- `./shifu check`
- `./shifu --filter @kungfu-tech/gui run gen:first-party-manifest`
- full `./shifu product gui dist` completed with ZIP and DMG outputs
- packaged Status extension hash matches the pinned first-party manifest