### PR TITLE
fix(api): tolerate runtime logs before Atlas JSON

### DIFF
--- a/framework/api/package.json
+++ b/framework/api/package.json
@@ -19,7 +19,7 @@
   "main": "./src/capability/index.ts",
   "scripts": {
     "build": "tsc --noEmit",
-    "test:query": "node --test tests/query.test.ts tests/ledger.test.ts",
+    "test:query": "node --test tests/query.test.ts tests/ledger.test.ts tests/atlas.test.ts",
     "clean": "rimraf build dist"
   },
   "dependencies": {

--- a/framework/api/src/capability/atlas.ts
+++ b/framework/api/src/capability/atlas.ts
@@ -331,7 +331,30 @@ export type OpenAtlasOptions = {
 };
 
 function parseJson<T>(text: string): T {
-  return JSON.parse(text) as T;
+  const trimmed = text.trim();
+  try {
+    return JSON.parse(trimmed) as T;
+  } catch (originalError) {
+    // Native runtime diagnostics can precede the CLI's JSON on stdout. Search
+    // backwards for a complete object/array at a line boundary so those
+    // diagnostics do not make GUI capabilities fail, while malformed payloads
+    // still raise the original parse error.
+    for (let index = trimmed.length - 1; index > 0; index -= 1) {
+      const current = trimmed[index];
+      const previous = trimmed[index - 1];
+      if (
+        (current === '{' || current === '[') &&
+        (previous === '\n' || previous === '\r')
+      ) {
+        try {
+          return JSON.parse(trimmed.slice(index)) as T;
+        } catch {
+          // A nested JSON line is not a complete suffix; keep searching.
+        }
+      }
+    }
+    throw originalError;
+  }
 }
 
 function cliEnv(

--- a/framework/api/tests/atlas.test.ts
+++ b/framework/api/tests/atlas.test.ts
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { openAtlas } from '../src/capability/atlas.ts';
+
+function atlasWithOutput(output: string) {
+  return openAtlas({
+    runtimeDir: '/tmp/kungfu-atlas-test',
+    bin: 'kungfu',
+    execFileSync: () => output,
+  });
+}
+
+test('Atlas capability accepts JSON after native stdout diagnostics', () => {
+  const atlas = atlasWithOutput(
+    [
+      '[2026-07-11 22:28:04.508] [error] no page for current journal',
+      '[2026-07-11 22:28:04.508] [critical] no page for current journal',
+      '[',
+      '  {"mission_id":"kungfu-tech","title":"Kungfu Tech"}',
+      ']',
+      '',
+    ].join('\n'),
+  );
+
+  assert.deepEqual(atlas.missions(), [
+    { mission_id: 'kungfu-tech', title: 'Kungfu Tech' },
+  ]);
+});
+
+test('Atlas capability still rejects output without a valid JSON suffix', () => {
+  const atlas = atlasWithOutput('[native diagnostic]\n[not-json]');
+
+  assert.throws(() => atlas.missions(), SyntaxError);
+});


### PR DESCRIPTION
## Summary
- tolerate native runtime diagnostics before Atlas CLI JSON payloads
- keep malformed output fail-closed
- add regression coverage for the exact Work Dashboard failure shape

## Validation
- `./shifu --filter @kungfu-tech/api run test:query` (6/6)
- `./shifu check`
- `./shifu product gui build`
- `./shifu package` registered the fix build as Shifu build `[0]`

## Known unrelated gaps
- the live Atlas demo fixture currently fails earlier on `storage_manifest_invalid: sync_root_mismatch`
- CI is currently unhealthy; this PR is not waiting on CI for local dogfood verification