### PR TITLE
fix(ci): provision mirrored Rust and Cargo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,11 +25,16 @@ permissions:
 
 jobs:
   build:
-    uses: kungfu-systems/buildchain/.github/workflows/build.yml@v2
+    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@train/v2/v2.12/cargo-registry-mirror
     secrets: inherit
     with:
       buildchain-ref: ${{ inputs.buildchain-ref || '' }}
       runner-preset: kungfu-v4-self-hosted
+      setup-rust: true
+      rust-toolchain: "1.96.0"
+      rustup-dist-server: https://rsproxy.cn
+      rustup-update-root: https://rsproxy.cn/rustup
+      cargo-registry-index: ${{ vars.BUILDCHAIN_CARGO_REGISTRY_INDEX }}
       artifact-name: kungfu
       artifact-paths: |
         product/release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,6 @@ jobs:
       checkout-cache-reference-repository-template: ${{ vars.BUILDCHAIN_CHECKOUT_CACHE_REFERENCE_REPOSITORY_TEMPLATE }}
       checkout-cache-fallback: github
       checkout-cache-timeout-seconds: 60
-      buildchain-alpha-contract-lock-path: .buildchain/alpha-contract-lock.json
-      buildchain-stable-contract-lock-path: .buildchain/contract-lock.json
+      buildchain-contract-lock-path: .buildchain/contract-lock.json
       buildchain-contract-compatibility-policy: major-compatible
       buildchain-contract-drift-issue-mode: compatible-and-breaking

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ permissions:
 
 jobs:
   build:
-    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@train/v2/v2.12/cargo-registry-mirror
+    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@b0733e799eeb1c44caccd6da92ebae4646a1bde4
     secrets: inherit
     with:
       buildchain-ref: ${{ inputs.buildchain-ref || '' }}


### PR DESCRIPTION
Summary: provision Rust 1.96.0 on the self-hosted native matrix; use mirrored rustup distribution endpoints; pass the Cargo registry index through a repository variable so private LAN topology stays out of public workflow YAML. Validation: ./shifu check passed; full self-hosted workflow run 29156651239 is in progress. Depends on Buildchain #1117 and the stacked Cargo registry input PR. Fixes #579.