### PR TITLE
docs(mission-control): design workspace product flow

### DIFF
--- a/docs/MAP.md
+++ b/docs/MAP.md
@@ -30,6 +30,7 @@ and the map routes a question to whichever doc answers it.
 | Why does Kungfu start from accountability? | [`facts-before-trust.md`](facts-before-trust.md) | why | stable |
 | How do Missions, delegated Go work, runtime facts, proof, and decisions become one product? | [`mission-control.md`](mission-control.md) + [`mission-control-workspaces.md`](mission-control-workspaces.md) + [ADR-0059](../framework/core/docs/adr/ADR-0059-mission-control-mission-go-responsibility-model.md) | why, use, verify | draft · mechanisms implemented; workspace product composition and five-question Mission Home designed |
 | How does Desktop open and remember a workspace without creating `.kungfu` on read? | [`mission-control-workspaces.md`](mission-control-workspaces.md) + [ADR-0060](../framework/core/docs/adr/ADR-0060-desktop-workspace-selection-and-lazy-data-home.md) | why, use, verify | proposed · product design complete; implementation sliced |
+| How can a first-time user manage agent work without a repository or predeclared Mission? | [`mission-control-workspaces.md`](mission-control-workspaces.md) + [ADR-0060](../framework/core/docs/adr/ADR-0060-desktop-workspace-selection-and-lazy-data-home.md) | why, use, verify | proposed · Personal Agent Workspace and unassigned inbox designed |
 | Why does the commercial product lead with Cost/State/Proof, and what does that profile guarantee? | [`cost-state-proof-profile.md`](cost-state-proof-profile.md) | why, use, verify | draft · first progress and completion qualification implemented |
 | Why this versioning / release design (don't replace it naively)? | [`version-release-design.md`](version-release-design.md) | why | stable |
 | When must a change open a minor or major (and when must it not)? | [`versioning.md`](versioning.md) (rule: KFD-1, adopted by ADR-0010) | verify | stable |
@@ -149,8 +150,9 @@ route to the row that answers them:
 - **config / `.kungfu` / `~/.kungfu-config` / `KF_CONFIG_HOME` / `KF_HOME` / UI font / UI scale /
   shortcuts / agent entrypoint** → *Kungfu config* ([`config.md`](config.md)).
 - **workspace data home / `.kungfu/` / data root / Git worktree data /
-  machine fallback / config home rename / Open Workspace / recent workspace /
-  lazy initialization** → *Kungfu config and Desktop workspace product*
+  machine fallback / Personal Agent Workspace / Agent Work Inbox / config home
+  rename / Open Workspace / recent workspace / lazy initialization** → *Kungfu
+  config and Desktop workspace product*
   ([`config.md`](config.md)) and
   [`mission-control-workspaces.md`](mission-control-workspaces.md),
   [ADR-0035](../framework/core/docs/adr/ADR-0035-workspace-local-kungfu-data-home.md),

--- a/docs/MAP.md
+++ b/docs/MAP.md
@@ -30,7 +30,8 @@ and the map routes a question to whichever doc answers it.
 | Why does Kungfu start from accountability? | [`facts-before-trust.md`](facts-before-trust.md) | why | stable |
 | How do Missions, delegated Go work, runtime facts, proof, and decisions become one product? | [`mission-control.md`](mission-control.md) + [`mission-control-workspaces.md`](mission-control-workspaces.md) + [ADR-0059](../framework/core/docs/adr/ADR-0059-mission-control-mission-go-responsibility-model.md) | why, use, verify | draft · mechanisms implemented; workspace product composition and five-question Mission Home designed |
 | How does Desktop open and remember a workspace without creating `.kungfu` on read? | [`mission-control-workspaces.md`](mission-control-workspaces.md) + [ADR-0060](../framework/core/docs/adr/ADR-0060-desktop-workspace-selection-and-lazy-data-home.md) | why, use, verify | proposed · product design complete; implementation sliced |
-| How can a first-time user manage agent work without a repository or predeclared Mission? | [`mission-control-workspaces.md`](mission-control-workspaces.md) + [ADR-0060](../framework/core/docs/adr/ADR-0060-desktop-workspace-selection-and-lazy-data-home.md) | why, use, verify | proposed · Personal Agent Workspace and unassigned inbox designed |
+| How can a first-time user manage agent work without a repository or predeclared Mission? | [`mission-control-workspaces.md`](mission-control-workspaces.md) + [ADR-0060](../framework/core/docs/adr/ADR-0060-desktop-workspace-selection-and-lazy-data-home.md) | why, use, verify | proposed · Home Workspace and unassigned inbox designed |
+| Why is agent-mediated guidance a first-class product interface rather than a later CLI integration? | [ADR-0061](../framework/core/docs/adr/ADR-0061-agent-mediated-guidance-is-a-first-class-product-interface.md) + [`mission-control-workspaces.md`](mission-control-workspaces.md) | why, use, verify | proposed · dual-first advice/action/receipt contract designed |
 | Why does the commercial product lead with Cost/State/Proof, and what does that profile guarantee? | [`cost-state-proof-profile.md`](cost-state-proof-profile.md) | why, use, verify | draft · first progress and completion qualification implemented |
 | Why this versioning / release design (don't replace it naively)? | [`version-release-design.md`](version-release-design.md) | why | stable |
 | When must a change open a minor or major (and when must it not)? | [`versioning.md`](versioning.md) (rule: KFD-1, adopted by ADR-0010) | verify | stable |
@@ -150,13 +151,17 @@ route to the row that answers them:
 - **config / `.kungfu` / `~/.kungfu-config` / `KF_CONFIG_HOME` / `KF_HOME` / UI font / UI scale /
   shortcuts / agent entrypoint** → *Kungfu config* ([`config.md`](config.md)).
 - **workspace data home / `.kungfu/` / data root / Git worktree data /
-  machine fallback / Personal Agent Workspace / Agent Work Inbox / config home
+  machine fallback / Home Workspace / Agent Work Inbox / config home
   rename / Open Workspace / recent workspace / lazy initialization** → *Kungfu
   config and Desktop workspace product*
   ([`config.md`](config.md)) and
   [`mission-control-workspaces.md`](mission-control-workspaces.md),
   [ADR-0035](../framework/core/docs/adr/ADR-0035-workspace-local-kungfu-data-home.md),
   and [ADR-0060](../framework/core/docs/adr/ADR-0060-desktop-workspace-selection-and-lazy-data-home.md).
+- **agent-mediated guidance / dual-first UX / advice / impact preview /
+  authorization / execution receipt / stale advice / agent-operable product** →
+  *Mission Control workspace product* ([`mission-control-workspaces.md`](mission-control-workspaces.md))
+  and [ADR-0061](../framework/core/docs/adr/ADR-0061-agent-mediated-guidance-is-a-first-class-product-interface.md).
 - **supervisor / per-user supervisor / workspace coordinator / data-root coordinator /
   coordinator singleton / live registry / idle shutdown / daemonless storage** →
   *Kungfu supervisor and coordinator service* ([`runtime-service.md`](runtime-service.md))

--- a/docs/MAP.md
+++ b/docs/MAP.md
@@ -28,7 +28,8 @@ and the map routes a question to whichever doc answers it.
 | Why is it built this way? What is load-bearing? | [`design-philosophy.md`](design-philosophy.md) | why | stable |
 | Why compare Kungfu to SQLite, Git, and a flight recorder — and why is it neither observability nor blockchain? | [`design-philosophy.md`](design-philosophy.md#the-missing-infrastructure-layer-runtime-facts) | why | stable |
 | Why does Kungfu start from accountability? | [`facts-before-trust.md`](facts-before-trust.md) | why | stable |
-| How do Missions, delegated Go work, runtime facts, proof, and decisions become one product? | [`mission-control.md`](mission-control.md) + [ADR-0059](../framework/core/docs/adr/ADR-0059-mission-control-mission-go-responsibility-model.md) | why, use, verify | draft · Atlas bridge, native Go, completion claim, proof/assessment, and dashboard dogfood slice implemented |
+| How do Missions, delegated Go work, runtime facts, proof, and decisions become one product? | [`mission-control.md`](mission-control.md) + [`mission-control-workspaces.md`](mission-control-workspaces.md) + [ADR-0059](../framework/core/docs/adr/ADR-0059-mission-control-mission-go-responsibility-model.md) | why, use, verify | draft · mechanisms implemented; workspace product composition and five-question Mission Home designed |
+| How does Desktop open and remember a workspace without creating `.kungfu` on read? | [`mission-control-workspaces.md`](mission-control-workspaces.md) + [ADR-0060](../framework/core/docs/adr/ADR-0060-desktop-workspace-selection-and-lazy-data-home.md) | why, use, verify | proposed · product design complete; implementation sliced |
 | Why does the commercial product lead with Cost/State/Proof, and what does that profile guarantee? | [`cost-state-proof-profile.md`](cost-state-proof-profile.md) | why, use, verify | draft · first progress and completion qualification implemented |
 | Why this versioning / release design (don't replace it naively)? | [`version-release-design.md`](version-release-design.md) | why | stable |
 | When must a change open a minor or major (and when must it not)? | [`versioning.md`](versioning.md) (rule: KFD-1, adopted by ADR-0010) | verify | stable |
@@ -104,7 +105,8 @@ route to the row that answers them:
 - **Mission Control / Mission / Go / delegated responsibility / progress drift /
   completion claim / Atlas bridge / Cost State Proof / cost management profile**
   → *how Missions and delegated work become one proof-backed product*
-  ([`mission-control.md`](mission-control.md)), then *what the first commercial
+  ([`mission-control.md`](mission-control.md)), *how the workspace product and
+  five-question Mission Home behave* ([`mission-control-workspaces.md`](mission-control-workspaces.md)), then *what the first commercial
   profile packages* ([`cost-state-proof-profile.md`](cost-state-proof-profile.md))
   and [ADR-0059](../framework/core/docs/adr/ADR-0059-mission-control-mission-go-responsibility-model.md).
 - **SQLite / Git for runs / flight recorder / runtime fact infrastructure /
@@ -147,9 +149,12 @@ route to the row that answers them:
 - **config / `.kungfu` / `~/.kungfu-config` / `KF_CONFIG_HOME` / `KF_HOME` / UI font / UI scale /
   shortcuts / agent entrypoint** → *Kungfu config* ([`config.md`](config.md)).
 - **workspace data home / `.kungfu/` / data root / Git worktree data /
-  machine fallback / config home rename** → *Kungfu config*
+  machine fallback / config home rename / Open Workspace / recent workspace /
+  lazy initialization** → *Kungfu config and Desktop workspace product*
   ([`config.md`](config.md)) and
-  [ADR-0035](../framework/core/docs/adr/ADR-0035-workspace-local-kungfu-data-home.md).
+  [`mission-control-workspaces.md`](mission-control-workspaces.md),
+  [ADR-0035](../framework/core/docs/adr/ADR-0035-workspace-local-kungfu-data-home.md),
+  and [ADR-0060](../framework/core/docs/adr/ADR-0060-desktop-workspace-selection-and-lazy-data-home.md).
 - **supervisor / per-user supervisor / workspace coordinator / data-root coordinator /
   coordinator singleton / live registry / idle shutdown / daemonless storage** →
   *Kungfu supervisor and coordinator service* ([`runtime-service.md`](runtime-service.md))

--- a/docs/mission-control-workspaces.md
+++ b/docs/mission-control-workspaces.md
@@ -22,9 +22,9 @@ ai_provenance:
 ## Product outcome
 
 Kungfu Desktop opens one explicit fact world and turns its admitted facts into
-one responsibility-oriented home screen. That fact world may be a Personal
-Agent Workspace for someone who has no project repository, or a project
-workspace such as `~/Code/atlas`. In both cases the home should answer five
+one responsibility-oriented home screen. That fact world may be the user's
+Home Workspace when no project repository exists, or a project workspace such
+as `~/Code/atlas`. In both cases the home should answer five
 questions before it offers a generic list:
 
 ```text
@@ -60,7 +60,7 @@ flowchart TD
   C -- "no" --> D["First-run choices; no fact world"]
   D --> P["Start managing agent work"]
   D --> O["Open existing project"]
-  P --> Q["Select Personal Agent Workspace candidate"]
+  P --> Q["Select logical Home Workspace"]
   O --> E
   C -- "yes" --> E["Select workspace root"]
   Q --> F{"data home exists?"}
@@ -81,7 +81,7 @@ flowchart TD
    boot.
 3. On first install, show **Start managing agent work** as the recommended
    path, plus **Open existing project** and bounded recents. The recommended
-   path selects the Personal Agent Workspace candidate; it does not require a
+   path selects Home; it does not require a
    repository, Markdown files, Git, or prior Mission vocabulary.
 4. If an existing last workspace is missing or inaccessible, show the same
    choices with diagnosis; do not choose a different fact world silently.
@@ -89,16 +89,18 @@ flowchart TD
    title/header.
 
 Installing or launching Kungfu creates neither `~/.kungfu` nor a project
-`.kungfu`. Choosing the personal path establishes the user's intended fact
+`.kungfu`. Choosing Home establishes the user's intended fact
 world. Its first managed agent run, Mission/Go creation, import, saved query, or
 other fact-bearing write passes through the same lazy initialization gate.
 
-### Personal Agent Workspace
+### Home Workspace
 
-The Personal Agent Workspace is the first-class path for users who want Kungfu
-to manage agent work alongside arbitrary projects without preparing a local
-knowledge repository. Its stable data home is `~/.kungfu`, selected explicitly
-and recorded in the global workspace registry with kind `personal`.
+Every user has one logical Home Workspace with stable identity `home`, display
+name **Home**, and data home `~/.kungfu`. It is the first-class path for users
+who want Kungfu to manage agent work alongside arbitrary projects without
+preparing a local knowledge repository. The identity exists before the
+directory; installation, launch, and selection remain read-only until the first
+fact-bearing write lazily materializes it.
 
 It may contain personal or cross-project Missions, unassigned agent work,
 Episodes, facts, proof, assessments, decisions, and saved queries. Project
@@ -106,7 +108,7 @@ directories and files can later be attached as sources or evidence; their mere
 presence does not make them authority and Kungfu does not copy their contents
 automatically.
 
-Personal does not mean globally merged. Opening a project workspace selects a
+Home does not mean globally merged. Opening a project workspace selects a
 different fact world. Moving a Mission or Episode between them requires an
 explicit full or thin bundle export/import, with missing material and authority
 degradation reported rather than hidden dual writes.
@@ -129,9 +131,9 @@ relaunch in version 1. The reopened window goes directly to Mission Home.
 
 | State | Home behavior | Allowed actions |
 | --- | --- | --- |
-| `none-selected` | First-run/Workspace chooser | start personal, open/recent/inspect only |
+| `none-selected` | First-run/Workspace chooser | start Home, open/recent/inspect only |
 | `selected-uninitialized` | Empty Mission Home or Agent Work Inbox with detected source hints | start managed run, create Mission, import, materialize bundle; first write initializes the selected data home |
-| `ready-empty` | Initialized fact world with no Mission; Personal may show unassigned work | start managed run, create/import Mission, attach inbox work |
+| `ready-empty` | Initialized fact world with no Mission; Home may show unassigned work | start managed run, create/import Mission, attach inbox work |
 | `ready` | Five-question Mission Home | all admitted read/write actions |
 | `unavailable` | Path/permission diagnosis; never fall through | locate, forget, retry |
 | `degraded` | Existing data with fsck/migration/missing-evidence warnings | inspect/export/repair actions allowed by diagnosis |
@@ -183,7 +185,7 @@ does not label ordinary list changes as Mission drift.
   exists; otherwise rank Missions needing a decision, showing drift, or lacking
   evidence before offering the full directory.
 - No Mission: show the five-question skeleton with honest empty answers and the
-  top-bar Create/Import actions. In a Personal Agent Workspace, also show an
+  top-bar Create/Import actions. In Home, also show an
   **Agent Work Inbox** for captured work not yet attached to a Mission.
 
 ### Agent Work Inbox before Mission
@@ -215,6 +217,90 @@ time.
 “Sidecar management” is therefore a product integration contract, not magical
 passive observation of every agent. Degraded attribution remains useful, but it
 must remain visible and cannot be promoted by UI wording.
+
+### Home is the default capture target, not a global fallback
+
+An independent CLI resolves its target as follows:
+
+```text
+explicit --workspace / --home
+  -> explicit process environment
+  -> nearest discovered project workspace
+  -> command-specific no-project behavior
+  -> fail with target diagnosis
+```
+
+The CLI never inherits the Desktop's last workspace implicitly. When no project
+workspace exists, capture-only operations such as Episode import or a managed
+agent run may materialize Home and write to its Agent Work Inbox. The receipt
+must report:
+
+```text
+workspace_id=home
+workspace_kind=home
+data_home=~/.kungfu
+resolution_reason=no-project-workspace
+association=unassigned
+source_working_directory=<captured cwd>
+```
+
+This establishes capture, not project membership or Mission purpose. Bundle
+validation may remain workspace-free. Non-interactive semantic writes,
+assessment, correction, repair, migration, and destructive operations require
+an explicit or discovered target; they do not use Home as a silent catch-all.
+
+### Progressive project and Git guidance
+
+Home is a real workspace, not a temporary error state. Kungfu recommends a
+project workspace only when admitted evidence shows project gravity:
+
+- repeated unassigned Episodes from one source root;
+- an existing Git repository;
+- a Mission with stable project coordinates;
+- a collaboration, transfer, long-term drift, or recovery requirement.
+
+The recommendation shows the triggering facts and offers **Create project
+workspace**, **Keep in Home**, and **Do not ask again for this source**. Before
+execution it previews which Episodes will be related or materialized, which
+material remains in Home, and which filesystem or Git effects are excluded.
+
+Kungfu strongly recommends a project workspace at the root of an existing Git
+repository for long-lived software or document work, but it does not require
+Git and never runs `git init`, edits `.gitignore`, stages, commits, creates a
+remote, or pushes as an implied part of workspace creation.
+
+A Git-backed workspace does not mean the whole `.kungfu` directory belongs in
+Git. Git is suited to low-frequency, reviewable declarations, policy/schema/kfx
+pins, portable query definitions, and other declared contract inputs. Kungfu's
+high-frequency Episode journals, payloads, runtime facts, coordinator state,
+and rebuildable projections remain in the fact ledger and move through
+explicit bundles or a future declared sync contract. The exact tracked contract
+layout must be qualified before any automatic Git integration ships.
+
+An **All Workspaces** view may join Home and project attention as a read-only
+projection. It is not another fact world and cannot accept writes.
+
+### Agent-mediated guidance
+
+Users may ask an agent to operate Kungfu instead of navigating every mechanical
+flow. Under ADR-0061, Kungfu produces the evidence-backed advice, impact preview,
+authorization requirement, and execution receipt; the agent explains the
+choice, asks for the bounded decision, and invokes the intent-level operation.
+
+For example, Kungfu may report seven unassigned Episodes from one Git root and
+recommend a project workspace. The agent can explain why, compare **Keep in
+Home**, and execute the selected plan. It cannot infer project authority,
+expand approval into Git mutation, or substitute its prose for a receipt.
+
+The reusable interaction contract is:
+
+```text
+inspect -> advise -> preview -> authorize -> execute -> receipt -> verify
+```
+
+The GUI renders the same advice and decision identities, so guidance remains
+visible and recoverable even when the conversation ends or another agent takes
+over.
 
 ## Atlas dogfood behavior
 
@@ -286,19 +372,19 @@ workspace pin, enablement/grant, declaration, and receipt. Updating a globally
 installed package cannot retroactively change the contract world of an older
 cut.
 
-### Machine fallback and Personal `~/.kungfu`
+### Machine fallback and Home `~/.kungfu`
 
 The platform fallback supports the no-workspace shell, caches, services, and
 explicitly machine-scoped facts. It is not a hidden aggregate Mission world.
 
-`~/.kungfu` is the explicit Personal Agent Workspace data home. It is created
-only after the user chooses the personal path and performs the first tracking
+`~/.kungfu` is the Home Workspace data home. It is created
+only after the user chooses Home and performs the first tracking
 or fact-world write. It is not config, a machine cache, or an implicit merge
 point. Nothing is copied from or into an opened project workspace implicitly.
 
 ## Saved Query Catalog decision
 
-Saved Query Catalog belongs to the selected fact world—Personal `~/.kungfu` or
+Saved Query Catalog belongs to the selected fact world—Home `~/.kungfu` or
 project `<workspace>/.kungfu`—and its current storage choice is correct:
 
 - a saved query pins a QueryDefinition and ViewSpec for one declared fact world;
@@ -322,7 +408,10 @@ kungfu workspace inspect <path> --json
 kungfu workspace list --json
 kungfu workspace current --json
 kungfu workspace select <path> --json
-kungfu workspace select-personal --json
+kungfu workspace select-home --json
+kungfu workspace advise --json
+kungfu workspace preview <advice-id> --json
+kungfu workspace apply <preview-id> --json
 
 kungfu atlas create-mission ... --workspace <path> --json
 kungfu atlas create-go ... --workspace <path> --json
@@ -335,46 +424,58 @@ canonical workspace, data home, initialization state, source authority, and
 created fact/Episode/assessment identity. A GUI-only database or hidden current
 workspace is forbidden.
 
+Exact subcommand names may change during implementation, but inspect, advice,
+preview, authorized execution, receipt, and verification are required semantic
+surfaces. Prompt text or an installed skill may teach an agent to use them; it
+is not the enforcement boundary.
+
 ## Delivery slices
 
 | Slice | Deliverable | Falsifiable gate |
 | --- | --- | --- |
-| 1. Workspace registry | versioned config-home registry with `personal`/`project` kind, inspect/list/current/select CLI, path canonicalization | selecting either fresh candidate changes only the registry; no data home exists |
-| 2. First-run and Personal workspace | onboarding choices, Personal selection, Agent Work Inbox, restart restore | a user with no repo records one managed run and reopens it without learning Git or editing JSON |
+| 1. Workspace registry | versioned config-home registry with `home`/`project` kind, inspect/list/current/select CLI, path canonicalization | selecting either fresh candidate changes only the registry; no data home exists |
+| 2. First-run and Home Workspace | onboarding choices, Home selection, Agent Work Inbox, restart restore | a user with no repo records one managed run and reopens it without learning Git or editing JSON |
 | 3. Desktop project workspace shell | Open Workspace, recents, unavailable state, header/switcher | restart reopens the same root; missing root never falls through silently |
 | 4. Lazy data-home lifecycle | uninitialized runtime state, ensure gate, initialization receipt, coordinator attach | install/open is filesystem-neutral; first tracking/Mission/import/query write creates exactly one root |
 | 5. Agent capture contract | managed-run receipts, CLI/API integration receipts, degraded external import | unintegrated external activity cannot be presented as exact attribution |
-| 6. Mission Home read model | one application service composing Mission fold, inbox, delta, proof, TrustReport, responsibility decision surface | GUI/CLI return the same five answer identities and cut/proof roots |
-| 7. Mission Home UX | five-question canvas, compact action bar, modal/drawer authoring, progressive disclosure | default screenshot contains no expanded create/import/bundle forms and no all-Mission list wall |
-| 8. Atlas dogfood | real Atlas import freshness, focus selection, drift between accepted cuts, decision inbox | opening imported Atlas answers all five questions for one real Mission |
-| 9. Saved Query and transfer | custom views stored per fact world, explicit Personal-to-project bundle transfer | personal query/Mission is absent in project until imported; identities and missing material remain explicit |
-| 10. Qualification | cross-platform filesystem, restart, switch, migration, deletion, GUI/CLI parity fixtures | release evidence proves no read-side creation and no cross-workspace leakage |
+| 6. Advice/action protocol | typed inspect/advice/preview/authorization/action/receipt services shared by GUI and agents | stale advice cannot execute; GUI and CLI expose the same reason and receipt identities |
+| 7. Project promotion and Git boundary | project-gravity advice, Home-to-project preview, suppression, separate Git effects | keep-in-Home works; workspace creation changes no Git state without separate authorization |
+| 8. Mission Home read model | one application service composing Mission fold, inbox, delta, proof, TrustReport, responsibility decision surface | GUI/CLI return the same five answer identities and cut/proof roots |
+| 9. Mission Home UX | five-question canvas, compact action bar, modal/drawer authoring, progressive disclosure | default screenshot contains no expanded create/import/bundle forms and no all-Mission list wall |
+| 10. Atlas dogfood | real Atlas import freshness, focus selection, drift between accepted cuts, decision inbox | opening imported Atlas answers all five questions for one real Mission |
+| 11. Saved Query and transfer | custom views stored per fact world, explicit Home-to-project bundle transfer | Home query/Mission is absent in project until imported; identities and missing material remain explicit |
+| 12. Qualification | cross-platform filesystem, restart, switch, migration, deletion, GUI/CLI parity and stale-agent fixtures | release evidence proves no read-side creation, cross-workspace leakage, or authority expansion through agent prose |
 
 ## Product acceptance journey
 
 1. Install and start Desktop with no registry: see **Start managing agent
    work** and **Open existing project**; neither `~/.kungfu` nor a project data
    home is created.
-2. Choose the personal path and start one managed agent run: `~/.kungfu`
+2. Choose Home and start one managed agent run: `~/.kungfu`
    initializes with a receipt; the run appears in Agent Work Inbox without an
    invented Mission, and fitness reports insufficient until purpose exists.
 3. Attach that Episode to a new Mission: its original identity and capture time
-   remain unchanged. Restart Desktop and the Personal workspace reopens.
-4. Open `~/Code/atlas` without `.kungfu`: path is remembered, Mission Home is
+   remain unchanged. Restart Desktop and Home reopens.
+4. Run an Episode import outside a project: the receipt targets Home Inbox,
+   records the source directory, and reports `association=unassigned`.
+5. After repeated Episodes from one Git root, inspect the shared GUI/agent
+   advice, keep them in Home once, then preview project promotion. Creating the
+   workspace performs no Git mutation.
+6. Open `~/Code/atlas` without `.kungfu`: path is remembered, Mission Home is
    honestly empty, filesystem is unchanged.
-5. Import Atlas or create a Mission: exactly `~/Code/atlas/.kungfu` initializes
+7. Import Atlas or create a Mission: exactly `~/Code/atlas/.kungfu` initializes
    and the receipt names the trigger.
-6. Restart Desktop: Atlas reopens and existing Mission/Go/query/assessment data
+8. Restart Desktop: Atlas reopens and existing Mission/Go/query/assessment data
    appears without re-import.
-7. Select one Mission: the home answers the five questions at `head` and can
+9. Select one Mission: the home answers the five questions at `head` and can
    switch to the latest accepted decision cut.
-8. Create a Go from the top action bar: a drawer collects the bounded intent;
+10. Create a Go from the top action bar: a drawer collects the bounded intent;
    after admission the responsibility and next-action sections update.
-9. Save a custom evidence view: it appears in Atlas's Saved Query Catalog but
+11. Save a custom evidence view: it appears in Atlas's Saved Query Catalog but
    not another workspace.
-10. Export a Personal Mission as a full bundle and import it into Atlas: the
+12. Export a Home Mission as a full bundle and import it into Atlas: the
    declared roots persist, while no global/project shared authority is created.
-11. Switch workspace: the old coordinator lease and runtime handles are gone;
+13. Switch workspace: the old coordinator lease and runtime handles are gone;
    no old Mission is visible.
 
 ## Explicit non-goals for the first release

--- a/docs/mission-control-workspaces.md
+++ b/docs/mission-control-workspaces.md
@@ -21,9 +21,11 @@ ai_provenance:
 
 ## Product outcome
 
-Kungfu Desktop opens a real project workspace and turns its admitted facts into
-one responsibility-oriented home screen. For Atlas dogfood, opening
-`~/Code/atlas` should answer five questions before it offers a generic list:
+Kungfu Desktop opens one explicit fact world and turns its admitted facts into
+one responsibility-oriented home screen. That fact world may be a Personal
+Agent Workspace for someone who has no project repository, or a project
+workspace such as `~/Code/atlas`. In both cases the home should answer five
+questions before it offers a generic list:
 
 ```text
 What are we trying to achieve?
@@ -55,13 +57,18 @@ workspace lifecycle, and information architecture.
 flowchart TD
   A["Desktop starts"] --> B["Read global workspace registry"]
   B --> C{"Last workspace available?"}
-  C -- "no" --> D["Workspace chooser; no fact world"]
+  C -- "no" --> D["First-run choices; no fact world"]
+  D --> P["Start managing agent work"]
+  D --> O["Open existing project"]
+  P --> Q["Select Personal Agent Workspace candidate"]
+  O --> E
   C -- "yes" --> E["Select workspace root"]
-  E --> F{"workspace/.kungfu exists?"}
+  Q --> F{"data home exists?"}
+  E --> F
   F -- "yes" --> G["Attach workspace coordinator and load Mission Home"]
   F -- "no" --> H["Read-only uninitialized Mission Home"]
-  H --> I{"First fact-world write intent"}
-  I -- "yes" --> J["Initialize workspace/.kungfu with receipt"]
+  H --> I{"First tracking or fact-world write intent"}
+  I -- "yes" --> J["Initialize selected data home with receipt"]
   J --> G
 ```
 
@@ -72,9 +79,37 @@ flowchart TD
 1. Read `<KF_CONFIG_HOME>/gui/workspaces.json`.
 2. If the last workspace exists and is accessible, select it before runtime
    boot.
-3. If it is missing or inaccessible, show **Open Workspace** plus bounded
-   recents; do not choose a machine fact world silently.
-4. Display the canonical workspace path and data-home state in the title/header.
+3. On first install, show **Start managing agent work** as the recommended
+   path, plus **Open existing project** and bounded recents. The recommended
+   path selects the Personal Agent Workspace candidate; it does not require a
+   repository, Markdown files, Git, or prior Mission vocabulary.
+4. If an existing last workspace is missing or inaccessible, show the same
+   choices with diagnosis; do not choose a different fact world silently.
+5. Display the canonical workspace identity and data-home state in the
+   title/header.
+
+Installing or launching Kungfu creates neither `~/.kungfu` nor a project
+`.kungfu`. Choosing the personal path establishes the user's intended fact
+world. Its first managed agent run, Mission/Go creation, import, saved query, or
+other fact-bearing write passes through the same lazy initialization gate.
+
+### Personal Agent Workspace
+
+The Personal Agent Workspace is the first-class path for users who want Kungfu
+to manage agent work alongside arbitrary projects without preparing a local
+knowledge repository. Its stable data home is `~/.kungfu`, selected explicitly
+and recorded in the global workspace registry with kind `personal`.
+
+It may contain personal or cross-project Missions, unassigned agent work,
+Episodes, facts, proof, assessments, decisions, and saved queries. Project
+directories and files can later be attached as sources or evidence; their mere
+presence does not make them authority and Kungfu does not copy their contents
+automatically.
+
+Personal does not mean globally merged. Opening a project workspace selects a
+different fact world. Moving a Mission or Episode between them requires an
+explicit full or thin bundle export/import, with missing material and authority
+degradation reported rather than hidden dual writes.
 
 ### Open Workspace
 
@@ -94,9 +129,9 @@ relaunch in version 1. The reopened window goes directly to Mission Home.
 
 | State | Home behavior | Allowed actions |
 | --- | --- | --- |
-| `none-selected` | Workspace chooser | open/recent/inspect only |
-| `selected-uninitialized` | Empty Mission Home with detected source hints | create Mission, import, materialize bundle; first write initializes `.kungfu` |
-| `ready-empty` | Initialized fact world with no Mission | create/import Mission |
+| `none-selected` | First-run/Workspace chooser | start personal, open/recent/inspect only |
+| `selected-uninitialized` | Empty Mission Home or Agent Work Inbox with detected source hints | start managed run, create Mission, import, materialize bundle; first write initializes the selected data home |
+| `ready-empty` | Initialized fact world with no Mission; Personal may show unassigned work | start managed run, create/import Mission, attach inbox work |
 | `ready` | Five-question Mission Home | all admitted read/write actions |
 | `unavailable` | Path/permission diagnosis; never fall through | locate, forget, retry |
 | `degraded` | Existing data with fsck/migration/missing-evidence warnings | inspect/export/repair actions allowed by diagnosis |
@@ -148,7 +183,38 @@ does not label ordinary list changes as Mission drift.
   exists; otherwise rank Missions needing a decision, showing drift, or lacking
   evidence before offering the full directory.
 - No Mission: show the five-question skeleton with honest empty answers and the
-  top-bar Create/Import actions.
+  top-bar Create/Import actions. In a Personal Agent Workspace, also show an
+  **Agent Work Inbox** for captured work not yet attached to a Mission.
+
+### Agent Work Inbox before Mission
+
+A new user may start an agent run before they can articulate a Mission. Kungfu
+must preserve that work without inventing purpose:
+
+- **What are we trying to achieve?** Not yet declared; offer Create Mission or
+  Ask agent to propose one.
+- **What actually happened?** Show the admitted run/Episode events.
+- **What does the evidence establish?** Show receipts, proof coverage, and
+  attribution quality.
+- **Is it fit for purpose?** `insufficient`: no purpose has been declared.
+- **Who should act next?** Ask the user or agent to attach/clarify purpose or
+  supply missing evidence.
+
+Attaching an inbox Episode to a later Mission/Go adds an admitted relationship;
+it does not rewrite the Episode identity or pretend the purpose existed at run
+time.
+
+### Capture and attribution modes
+
+| Agent path | What Kungfu can establish | Required presentation |
+| --- | --- | --- |
+| Kungfu launches a managed run | supervisor/run/Episode identity and bounded runtime facts | exact attribution where receipts and frame checks pass |
+| Agent uses Kungfu CLI/API/skill | explicit action and evidence receipts from that integration | sourced attribution with declared capture boundary |
+| External agent is imported after the fact | only the observed files/traces/material supplied | observed or ambiguous; never exact causality by inference |
+
+“Sidecar management” is therefore a product integration contract, not magical
+passive observation of every agent. Degraded attribution remains useful, but it
+must remain visible and cannot be promoted by UI wording.
 
 ## Atlas dogfood behavior
 
@@ -220,19 +286,20 @@ workspace pin, enablement/grant, declaration, and receipt. Updating a globally
 installed package cannot retroactively change the contract world of an older
 cut.
 
-### Machine fallback and `~/.kungfu`
+### Machine fallback and Personal `~/.kungfu`
 
 The platform fallback supports the no-workspace shell, caches, services, and
 explicitly machine-scoped facts. It is not a hidden aggregate Mission world.
 
-`~/.kungfu` is not a default config or data merge point. It may later be opened
-explicitly as a Personal Workspace, but nothing is copied from or into an
-opened project workspace implicitly.
+`~/.kungfu` is the explicit Personal Agent Workspace data home. It is created
+only after the user chooses the personal path and performs the first tracking
+or fact-world write. It is not config, a machine cache, or an implicit merge
+point. Nothing is copied from or into an opened project workspace implicitly.
 
 ## Saved Query Catalog decision
 
-Saved Query Catalog is related to workspace `.kungfu` and its current storage
-choice is correct:
+Saved Query Catalog belongs to the selected fact world—Personal `~/.kungfu` or
+project `<workspace>/.kungfu`—and its current storage choice is correct:
 
 - a saved query pins a QueryDefinition and ViewSpec for one declared fact world;
 - rows, proof, and changelog state are rebuilt rather than stored as GUI truth;
@@ -255,6 +322,7 @@ kungfu workspace inspect <path> --json
 kungfu workspace list --json
 kungfu workspace current --json
 kungfu workspace select <path> --json
+kungfu workspace select-personal --json
 
 kungfu atlas create-mission ... --workspace <path> --json
 kungfu atlas create-go ... --workspace <path> --json
@@ -271,38 +339,50 @@ workspace is forbidden.
 
 | Slice | Deliverable | Falsifiable gate |
 | --- | --- | --- |
-| 1. Workspace registry | versioned config-home registry, inspect/list/current/select CLI, path canonicalization | selecting a fresh repo changes only the registry; `.kungfu` remains absent |
-| 2. Desktop workspace shell | Open Workspace, recents, cold-start restore, unavailable state, header/switcher | restart reopens the same root; missing root never falls through silently |
-| 3. Lazy data-home lifecycle | uninitialized runtime state, ensure gate, initialization receipt, coordinator attach | first read is filesystem-neutral; first Mission/import/saved-query write creates one root |
-| 4. Mission Home read model | one application service composing Mission fold, delta, proof, TrustReport, responsibility decision surface | GUI/CLI return the same five answer identities and cut/proof roots |
-| 5. Mission Home UX | five-question canvas, compact action bar, modal/drawer authoring, progressive disclosure | default screenshot contains no expanded create/import/bundle forms and no all-Mission list wall |
-| 6. Atlas dogfood | real Atlas import freshness, focus selection, drift between accepted cuts, decision inbox | opening imported Atlas answers all five questions for one real Mission |
-| 7. Saved Query composition | custom Mission views stored in workspace catalog, explicit transfer | query saved in workspace A is absent in B until imported; rebuilt result preserves definition identity |
-| 8. Qualification | cross-platform filesystem, restart, switch, migration, deletion, GUI/CLI parity fixtures | release evidence proves no read-side creation and no cross-workspace leakage |
+| 1. Workspace registry | versioned config-home registry with `personal`/`project` kind, inspect/list/current/select CLI, path canonicalization | selecting either fresh candidate changes only the registry; no data home exists |
+| 2. First-run and Personal workspace | onboarding choices, Personal selection, Agent Work Inbox, restart restore | a user with no repo records one managed run and reopens it without learning Git or editing JSON |
+| 3. Desktop project workspace shell | Open Workspace, recents, unavailable state, header/switcher | restart reopens the same root; missing root never falls through silently |
+| 4. Lazy data-home lifecycle | uninitialized runtime state, ensure gate, initialization receipt, coordinator attach | install/open is filesystem-neutral; first tracking/Mission/import/query write creates exactly one root |
+| 5. Agent capture contract | managed-run receipts, CLI/API integration receipts, degraded external import | unintegrated external activity cannot be presented as exact attribution |
+| 6. Mission Home read model | one application service composing Mission fold, inbox, delta, proof, TrustReport, responsibility decision surface | GUI/CLI return the same five answer identities and cut/proof roots |
+| 7. Mission Home UX | five-question canvas, compact action bar, modal/drawer authoring, progressive disclosure | default screenshot contains no expanded create/import/bundle forms and no all-Mission list wall |
+| 8. Atlas dogfood | real Atlas import freshness, focus selection, drift between accepted cuts, decision inbox | opening imported Atlas answers all five questions for one real Mission |
+| 9. Saved Query and transfer | custom views stored per fact world, explicit Personal-to-project bundle transfer | personal query/Mission is absent in project until imported; identities and missing material remain explicit |
+| 10. Qualification | cross-platform filesystem, restart, switch, migration, deletion, GUI/CLI parity fixtures | release evidence proves no read-side creation and no cross-workspace leakage |
 
 ## Product acceptance journey
 
-1. Start Desktop with no registry: see Open Workspace; no workspace data is
-   created.
-2. Open `~/Code/atlas` without `.kungfu`: path is remembered, Mission Home is
+1. Install and start Desktop with no registry: see **Start managing agent
+   work** and **Open existing project**; neither `~/.kungfu` nor a project data
+   home is created.
+2. Choose the personal path and start one managed agent run: `~/.kungfu`
+   initializes with a receipt; the run appears in Agent Work Inbox without an
+   invented Mission, and fitness reports insufficient until purpose exists.
+3. Attach that Episode to a new Mission: its original identity and capture time
+   remain unchanged. Restart Desktop and the Personal workspace reopens.
+4. Open `~/Code/atlas` without `.kungfu`: path is remembered, Mission Home is
    honestly empty, filesystem is unchanged.
-3. Import Atlas or create a Mission: exactly `~/Code/atlas/.kungfu` initializes
+5. Import Atlas or create a Mission: exactly `~/Code/atlas/.kungfu` initializes
    and the receipt names the trigger.
-4. Restart Desktop: Atlas reopens and existing Mission/Go/query/assessment data
+6. Restart Desktop: Atlas reopens and existing Mission/Go/query/assessment data
    appears without re-import.
-5. Select one Mission: the home answers the five questions at `head` and can
+7. Select one Mission: the home answers the five questions at `head` and can
    switch to the latest accepted decision cut.
-6. Create a Go from the top action bar: a drawer collects the bounded intent;
+8. Create a Go from the top action bar: a drawer collects the bounded intent;
    after admission the responsibility and next-action sections update.
-7. Save a custom evidence view: it appears in Atlas's Saved Query Catalog but
+9. Save a custom evidence view: it appears in Atlas's Saved Query Catalog but
    not another workspace.
-8. Switch workspace: the old coordinator lease and runtime handles are gone;
+10. Export a Personal Mission as a full bundle and import it into Atlas: the
+   declared roots persist, while no global/project shared authority is created.
+11. Switch workspace: the old coordinator lease and runtime handles are gone;
    no old Mission is visible.
 
 ## Explicit non-goals for the first release
 
 - several live workspaces inside one Desktop process;
 - automatic Atlas import merely because a directory looks compatible;
+- claiming passive, exact observation of an agent that emitted no Kungfu
+  integration receipt or importable evidence;
 - a universal ontology or generic workflow designer;
 - storing Mission truth in React state, Electron `userData`, or global config;
 - silently editing `.gitignore`;

--- a/docs/mission-control-workspaces.md
+++ b/docs/mission-control-workspaces.md
@@ -1,0 +1,320 @@
+---
+status: draft
+period: 2026-07-11
+theme: kungfu-mission-control-workspaces
+doc_type: product-design
+source_level: user-consensus-and-local-files
+confidence: high
+sensitivity: public
+evidence_grade: B
+review_state: unreviewed
+last_reviewed: 2026-07-11
+ai_provenance:
+  model_family: GPT-5
+  product: Codex
+  generated_at: 2026-07-11
+  visible_context: User product requirements, Atlas Mission working model, ADR-0035, ADR-0048, ADR-0051, ADR-0052, ADR-0059, Work Dashboard source, config and product launcher code, Saved Query Catalog source
+  invisible_context_boundary: Did not inspect private Atlas document bodies, provider payloads, credentials, or hidden model state
+---
+
+# Mission Control Workspace Product Design
+
+## Product outcome
+
+Kungfu Desktop opens a real project workspace and turns its admitted facts into
+one responsibility-oriented home screen. For Atlas dogfood, opening
+`~/Code/atlas` should answer five questions before it offers a generic list:
+
+```text
+What are we trying to achieve?
+What actually happened?
+What does the evidence establish at this cut?
+Is the delegated work still fit for the purpose that matters?
+Who should continue, adjust, stop, approve, or supply evidence next?
+```
+
+Mission and Go are not the dashboard's content model by themselves. They are
+the responsibility coordinates used to answer those questions over facts,
+Episodes, queries, assessments, and decisions.
+
+## Current product evidence
+
+| Surface | What exists now | Product gap |
+| --- | --- | --- |
+| Default GUI view | `work-dashboard` is already the default profile view | It renders Mission/Goal lists and large inline forms before the responsibility questions |
+| Workspace data resolution | ADR-0035 and dev launchers resolve nearest or Git-root `.kungfu` | Packaged Desktop has no Open Workspace or recent-workspace session and defaults to Electron `userData/runtime` |
+| Lazy creation | Dev path discovery can return a nonexistent Git-root `.kungfu` without creating it | GUI boot eagerly joins a runtime and writes runtime support files; no uninitialized workspace state exists |
+| Mission Control | Atlas import, native Mission/Go, completion claims, ADR-0048 state, ADR-0052 TrustReport, Cost/State/Proof, and bundles exist | These capabilities are exposed as tooling panels, not one Mission Home operating loop |
+| Saved Query Catalog | Journal-backed QueryDefinition + ViewSpec revisions, GUI save/delete/run, Node/Python/native parity | It is currently presented under Status/Query Reference and is not composed into Mission Home profiles |
+| Shell state | Profile and sidebar state persist in the selected runtime ConfigStore | Last/recent workspace must exist before a workspace runtime and therefore needs global config-home state |
+
+The mechanisms are substantially present. The missing work is composition,
+workspace lifecycle, and information architecture.
+
+```mermaid
+flowchart TD
+  A["Desktop starts"] --> B["Read global workspace registry"]
+  B --> C{"Last workspace available?"}
+  C -- "no" --> D["Workspace chooser; no fact world"]
+  C -- "yes" --> E["Select workspace root"]
+  E --> F{"workspace/.kungfu exists?"}
+  F -- "yes" --> G["Attach workspace coordinator and load Mission Home"]
+  F -- "no" --> H["Read-only uninitialized Mission Home"]
+  H --> I{"First fact-world write intent"}
+  I -- "yes" --> J["Initialize workspace/.kungfu with receipt"]
+  J --> G
+```
+
+## Workspace experience
+
+### Cold start
+
+1. Read `<KF_CONFIG_HOME>/gui/workspaces.json`.
+2. If the last workspace exists and is accessible, select it before runtime
+   boot.
+3. If it is missing or inaccessible, show **Open Workspace** plus bounded
+   recents; do not choose a machine fact world silently.
+4. Display the canonical workspace path and data-home state in the title/header.
+
+### Open Workspace
+
+`File -> Open Workspace…`, the empty-state button, and the command palette use
+the same directory-picker action. Selecting a directory:
+
+- canonicalizes and remembers the root;
+- detects Git and adapter eligibility;
+- checks whether `<root>/.kungfu` exists;
+- does not create `.kungfu`, start a coordinator, import Atlas, or modify
+  `.gitignore`.
+
+Switching from a live workspace releases its lease and performs a controlled
+relaunch in version 1. The reopened window goes directly to Mission Home.
+
+### Workspace states
+
+| State | Home behavior | Allowed actions |
+| --- | --- | --- |
+| `none-selected` | Workspace chooser | open/recent/inspect only |
+| `selected-uninitialized` | Empty Mission Home with detected source hints | create Mission, import, materialize bundle; first write initializes `.kungfu` |
+| `ready-empty` | Initialized fact world with no Mission | create/import Mission |
+| `ready` | Five-question Mission Home | all admitted read/write actions |
+| `unavailable` | Path/permission diagnosis; never fall through | locate, forget, retry |
+| `degraded` | Existing data with fsck/migration/missing-evidence warnings | inspect/export/repair actions allowed by diagnosis |
+
+## Mission Home information architecture
+
+### Header and action bar
+
+The fixed top bar contains:
+
+```text
+[workspace / switcher] [Mission switcher] [cut: head | historical]
+[+ Mission] [+ Go] [Import/Refresh] [Assess] [Export] [...]
+```
+
+`+ Mission` and `+ Go` open a modal or right-side drawer. They are never
+expanded forms in the default dashboard. `+ Go` inherits the selected Mission
+and remains disabled until one is selected. Advanced bundle and claim forms
+move under contextual actions.
+
+### The five-question canvas
+
+| Question | Primary content | Authority / evidence | Primary action |
+| --- | --- | --- | --- |
+| What are we trying to achieve? | selected Mission intent, why it matters, current stage, constraints, last accepted decision | Mission fact fold at selected cut | clarify Mission, select another Mission |
+| What actually happened? | material Go/Episode changes since the previous accepted assessment or review cut; blocked/waiting/completed transitions | Episode and admitted fact delta, not latest mutable rows | inspect timeline, attach or correct evidence |
+| What does the evidence establish at this cut? | current state, proof coverage, missing/conflicting/stale evidence, declaration and query roots | ADR-0048 result/proof and linked sealed Episodes | inspect proof, change cut, request evidence |
+| Is delegated work still fit for purpose? | purpose, fitness, assessment state, residual risk, freshness | ADR-0052 TrustReport for the explicit purpose | reassess, change purpose, adjust delegation |
+| Who should act next? | current responsibility, decision inbox, suggested continue/adjust/stop/approve/request-evidence/handoff actions | admitted responsibility facts plus assessment suggestions; human authority remains explicit | record decision or delegate next action |
+
+The dashboard compares two explicit cuts when it says **drift**: normally the
+current cut and the cut pinned by the latest accepted assessment/decision. It
+does not label ordinary list changes as Mission drift.
+
+### Secondary views
+
+- **Go Board** is reached from the Mission Home Go summary and groups work by
+  responsibility state.
+- **Mission/Go directory** remains available through switchers and search, not
+  as the home screen's dominant content.
+- **Observer Timeline**, **Fact Manager**, **Saved Query Catalog**, and **Trust
+  Inspector** are progressive-disclosure destinations linked from each answer.
+- Raw source material remains last-mile evidence, never the default home view.
+
+### Selection defaults
+
+- One active Mission: select it.
+- Several Missions: restore the workspace-local last focus when it still
+  exists; otherwise rank Missions needing a decision, showing drift, or lacking
+  evidence before offering the full directory.
+- No Mission: show the five-question skeleton with honest empty answers and the
+  top-bar Create/Import actions.
+
+## Atlas dogfood behavior
+
+Opening `~/Code/atlas` sets the workspace root and candidate data home to
+`~/Code/atlas/.kungfu`.
+
+- If a completed Atlas import already exists in that `.kungfu`, Mission Home
+  loads it immediately. It shows import source/head/time and the bridge-authority
+  badge; it does not ask for another import.
+- If `.kungfu` exists but the import is stale, show **Refresh Atlas facts** and
+  the source delta. Refresh creates a new sealed import Episode and cannot
+  reinterpret an old cut.
+- If no import exists, detect the Atlas adapter and offer **Import Atlas facts**.
+  This is explicit and initializes `.kungfu` if necessary.
+- Imported Missions/Goals remain Atlas-authority observations. Kungfu-native Go,
+  claim, assessment, and decision facts identify their own source authority and
+  never masquerade as Atlas write-back.
+
+The first dogfood dashboard should default to one real Atlas Mission and show:
+
+- its north star/current operating line;
+- Go and worktree facts since the prior decision cut;
+- the current proof/degraded state;
+- fitness for `continue-delegation` or another selected purpose;
+- concrete responsibility for the next decision/evidence/action.
+
+## Storage contract
+
+### Workspace `.kungfu`
+
+Authoritative or evidence-bearing workspace state:
+
+- KFD declarations and admission receipts;
+- Mission, Go, claim, decision, correction, and source observations;
+- Episodes, manifest journals, payloads, content roots, source registry;
+- assessment requests, Assessment Episodes, TrustReports;
+- observer/cut metadata needed to reproduce a state;
+- Saved Query Catalog revisions: QueryDefinition + ViewSpec;
+- imported Atlas snapshot Episodes and source coordinates.
+
+Workspace policy pins also live here: the exact fact type, schema, kfx/skill
+version, capability grant, or trust-policy revision that participated in this
+fact world. They are not mutable references to whichever package is installed
+globally today.
+
+Rebuildable workspace-local state:
+
+- SQLite/index projections and query caches;
+- coordinator process state and live routing files;
+- workspace-specific shell focus/layout that does not claim domain authority.
+
+Deleting a projection may change performance or temporary availability; it
+must not delete Mission, proof, assessment, or saved-query authority.
+
+### Global `~/.kungfu-config`
+
+- config contract override and user UI preferences;
+- recent/last workspace registry;
+- installed kfx/skill metadata and global policy;
+- user-level supervisor routing/process state;
+- global shortcuts and appearance.
+
+It must not contain workspace Mission/Go bodies, proof, imported Atlas content,
+or Saved Query Catalog revisions.
+
+Global installation and workspace use are separate. The config home may own an
+installed package/cache and user-level default policy; `.kungfu` owns the exact
+workspace pin, enablement/grant, declaration, and receipt. Updating a globally
+installed package cannot retroactively change the contract world of an older
+cut.
+
+### Machine fallback and `~/.kungfu`
+
+The platform fallback supports the no-workspace shell, caches, services, and
+explicitly machine-scoped facts. It is not a hidden aggregate Mission world.
+
+`~/.kungfu` is not a default config or data merge point. It may later be opened
+explicitly as a Personal Workspace, but nothing is copied from or into an
+opened project workspace implicitly.
+
+## Saved Query Catalog decision
+
+Saved Query Catalog is related to workspace `.kungfu` and its current storage
+choice is correct:
+
+- a saved query pins a QueryDefinition and ViewSpec for one declared fact world;
+- rows, proof, and changelog state are rebuilt rather than stored as GUI truth;
+- the Mission Home's built-in five-question profile is shipped product logic,
+  not a mutable saved query;
+- user-customized Mission views may be saved into that workspace's catalog;
+- moving a saved view uses explicit JSON export/import or a containing portable
+  bundle, never a global catalog that silently follows every workspace.
+
+Built-in examples and presentation defaults may be global/read-only. Once a
+definition is saved or revised against workspace facts, its revision is
+workspace state.
+
+## Agent and CLI parity
+
+Agents need intent-level operations, not instructions to edit local JSON:
+
+```text
+kungfu workspace inspect <path> --json
+kungfu workspace list --json
+kungfu workspace current --json
+kungfu workspace select <path> --json
+
+kungfu atlas create-mission ... --workspace <path> --json
+kungfu atlas create-go ... --workspace <path> --json
+kungfu atlas import --repo <path> --workspace <path> --json
+kungfu atlas assess-mission ... --workspace <path> --json
+```
+
+GUI actions call the same application service. Every write receipt reports the
+canonical workspace, data home, initialization state, source authority, and
+created fact/Episode/assessment identity. A GUI-only database or hidden current
+workspace is forbidden.
+
+## Delivery slices
+
+| Slice | Deliverable | Falsifiable gate |
+| --- | --- | --- |
+| 1. Workspace registry | versioned config-home registry, inspect/list/current/select CLI, path canonicalization | selecting a fresh repo changes only the registry; `.kungfu` remains absent |
+| 2. Desktop workspace shell | Open Workspace, recents, cold-start restore, unavailable state, header/switcher | restart reopens the same root; missing root never falls through silently |
+| 3. Lazy data-home lifecycle | uninitialized runtime state, ensure gate, initialization receipt, coordinator attach | first read is filesystem-neutral; first Mission/import/saved-query write creates one root |
+| 4. Mission Home read model | one application service composing Mission fold, delta, proof, TrustReport, responsibility decision surface | GUI/CLI return the same five answer identities and cut/proof roots |
+| 5. Mission Home UX | five-question canvas, compact action bar, modal/drawer authoring, progressive disclosure | default screenshot contains no expanded create/import/bundle forms and no all-Mission list wall |
+| 6. Atlas dogfood | real Atlas import freshness, focus selection, drift between accepted cuts, decision inbox | opening imported Atlas answers all five questions for one real Mission |
+| 7. Saved Query composition | custom Mission views stored in workspace catalog, explicit transfer | query saved in workspace A is absent in B until imported; rebuilt result preserves definition identity |
+| 8. Qualification | cross-platform filesystem, restart, switch, migration, deletion, GUI/CLI parity fixtures | release evidence proves no read-side creation and no cross-workspace leakage |
+
+## Product acceptance journey
+
+1. Start Desktop with no registry: see Open Workspace; no workspace data is
+   created.
+2. Open `~/Code/atlas` without `.kungfu`: path is remembered, Mission Home is
+   honestly empty, filesystem is unchanged.
+3. Import Atlas or create a Mission: exactly `~/Code/atlas/.kungfu` initializes
+   and the receipt names the trigger.
+4. Restart Desktop: Atlas reopens and existing Mission/Go/query/assessment data
+   appears without re-import.
+5. Select one Mission: the home answers the five questions at `head` and can
+   switch to the latest accepted decision cut.
+6. Create a Go from the top action bar: a drawer collects the bounded intent;
+   after admission the responsibility and next-action sections update.
+7. Save a custom evidence view: it appears in Atlas's Saved Query Catalog but
+   not another workspace.
+8. Switch workspace: the old coordinator lease and runtime handles are gone;
+   no old Mission is visible.
+
+## Explicit non-goals for the first release
+
+- several live workspaces inside one Desktop process;
+- automatic Atlas import merely because a directory looks compatible;
+- a universal ontology or generic workflow designer;
+- storing Mission truth in React state, Electron `userData`, or global config;
+- silently editing `.gitignore`;
+- making KFD-2 decide whether the Mission itself is valuable.
+
+## Product risks
+
+- A five-question dashboard can still become five decorative summaries. Every
+  answer must expose its cut, proof, degraded state, and next action.
+- Automatic Mission ranking must remain an attention projection, not hidden
+  authority over human priority.
+- Recent workspace paths are sensitive local metadata and must not enter
+  portable bundles or telemetry.
+- Workspace initialization is a cross-layer side effect. Qualification must
+  test before/after filesystem state rather than trusting UI text.

--- a/docs/mission-control.md
+++ b/docs/mission-control.md
@@ -142,9 +142,17 @@ assessment, or close work without hand-authoring low-level declarations. GUI
 and agent surfaces consume the same domain objects, QueryDefinitions, and
 assessment contracts; no GUI-private database owns Mission state.
 
+Agent-mediated use is a first-class product path, not an integration added
+after GUI design. Kungfu owns typed inspection, evidence-backed advice, impact
+preview, authorization, execution, receipt, and verification semantics. The
+agent explains the options and may execute an authorized intent; its prose
+cannot create facts or expand authority. A minimal direct GUI remains available
+for the same decisions and recovery path. This product principle is fixed by
+[ADR-0061](../framework/core/docs/adr/ADR-0061-agent-mediated-guidance-is-a-first-class-product-interface.md).
+
 A first-time user does not need an Atlas-style Markdown repository or a fully
-formed Mission. **Start managing agent work** explicitly selects a Personal
-Agent Workspace at `~/.kungfu`; its first managed run lazily initializes the
+formed Mission. **Start managing agent work** selects the logical Home Workspace
+at `~/.kungfu`; its first managed run lazily initializes the
 fact world and appears in an unassigned Agent Work Inbox. Kungfu can establish
 exact attribution only for managed or explicitly integrated runs. Imported
 external traces remain observed or ambiguous, and purpose-bound fitness stays
@@ -216,7 +224,7 @@ export consumer. Long-lived dual writes with two authorities are forbidden.
 ## Storage and portability
 
 Project workspace state lives under its resolved `<project>/.kungfu/`; the
-explicit Personal Agent Workspace lives at `~/.kungfu`. Machine fallback and
+Home Workspace lives at `~/.kungfu`. Machine fallback and
 `~/.kungfu-config` remain separate service/config homes. Journal records,
 Episodes, schemas, payloads, saved queries, assessment Episodes, TrustReports,
 and observer metadata belong to the selected fact-world authority.

--- a/docs/mission-control.md
+++ b/docs/mission-control.md
@@ -142,6 +142,14 @@ assessment, or close work without hand-authoring low-level declarations. GUI
 and agent surfaces consume the same domain objects, QueryDefinitions, and
 assessment contracts; no GUI-private database owns Mission state.
 
+A first-time user does not need an Atlas-style Markdown repository or a fully
+formed Mission. **Start managing agent work** explicitly selects a Personal
+Agent Workspace at `~/.kungfu`; its first managed run lazily initializes the
+fact world and appears in an unassigned Agent Work Inbox. Kungfu can establish
+exact attribution only for managed or explicitly integrated runs. Imported
+external traces remain observed or ambiguous, and purpose-bound fitness stays
+insufficient until the work is attached to a declared purpose.
+
 ## Authority and Atlas dogfood
 
 Kungfu already ships a read-only Atlas import profile. It records content-
@@ -207,10 +215,11 @@ export consumer. Long-lived dual writes with two authorities are forbidden.
 
 ## Storage and portability
 
-Workspace state lives under the resolved workspace `.kungfu/`; personal or
-machine state uses the resolved runtime home. Journal records, Episodes,
-schemas, payloads, saved queries, assessment Episodes, TrustReports, and
-observer metadata share that authority.
+Project workspace state lives under its resolved `<project>/.kungfu/`; the
+explicit Personal Agent Workspace lives at `~/.kungfu`. Machine fallback and
+`~/.kungfu-config` remain separate service/config homes. Journal records,
+Episodes, schemas, payloads, saved queries, assessment Episodes, TrustReports,
+and observer metadata belong to the selected fact-world authority.
 
 Desktop remembers the last selected workspace under `KF_CONFIG_HOME`, but that
 registry is only global GUI session state. Opening a directory remains

--- a/docs/mission-control.md
+++ b/docs/mission-control.md
@@ -121,8 +121,12 @@ it evaluates declared criteria against available facts.
 
 The GUI follows progressive disclosure:
 
-1. **Mission Home** — intent, stage, progress assessment, active Go work,
-   decisions required, drift, and next responsibility.
+1. **Mission Home** — the five-question workspace home: intent, material events,
+   evidence at the selected cut, purpose-bound fitness, and next responsibility.
+   Mission/Go creation lives in compact top-bar actions and modal/drawer flows,
+   not expanded forms on the default canvas. The complete workspace product
+   behavior is defined in
+   [Mission Control Workspace Product Design](mission-control-workspaces.md).
 2. **Go Board** — delegated work grouped by responsibility state, not a generic
    kanban status string.
 3. **Observer Timeline** — accepted sources, cut/frontier, causal order,
@@ -207,6 +211,13 @@ Workspace state lives under the resolved workspace `.kungfu/`; personal or
 machine state uses the resolved runtime home. Journal records, Episodes,
 schemas, payloads, saved queries, assessment Episodes, TrustReports, and
 observer metadata share that authority.
+
+Desktop remembers the last selected workspace under `KF_CONFIG_HOME`, but that
+registry is only global GUI session state. Opening a directory remains
+read-only; `.kungfu` initializes on the first operation that changes the
+workspace fact world. [ADR-0060](../framework/core/docs/adr/ADR-0060-desktop-workspace-selection-and-lazy-data-home.md)
+defines the lifecycle and prevents recent-workspace convenience from becoming
+Mission authority.
 
 A full bundle carries the bounded content closure needed for offline replay and
 proof. A thin bundle carries declared roots and references and reports missing

--- a/framework/core/docs/adr/ADR-0060-desktop-workspace-selection-and-lazy-data-home.md
+++ b/framework/core/docs/adr/ADR-0060-desktop-workspace-selection-and-lazy-data-home.md
@@ -1,0 +1,230 @@
+---
+status: draft
+period: 2026-07-11
+theme: kungfu-workspace-product
+doc_type: decision
+source_level: user-consensus-and-local-files
+confidence: high
+sensitivity: public
+evidence_grade: B
+review_state: unreviewed
+last_reviewed: 2026-07-11
+ai_provenance:
+  model_family: GPT-5
+  product: Codex
+  generated_at: 2026-07-11
+  visible_context: User workspace and Mission Control requirements, ADR-0035, ADR-0059, current GUI boot/runtime code, Saved Query Catalog implementation, Atlas dogfood behavior
+  invisible_context_boundary: Did not inspect private Atlas bodies, credentials, provider payloads, or hidden model state
+---
+
+# ADR-0060: Desktop selects one workspace and initializes its `.kungfu` data home lazily
+
+- Status: proposed
+- Date: 2026-07-11
+- Category: product architecture, workspace lifecycle, local data ownership
+- Subsystem: Desktop shell, GUI main/renderer processes, config contract,
+  workspace coordinator, Mission Control, Saved Query Catalog, CLI/agent surface
+- Related: ADR-0035 defines workspace-local `.kungfu`; ADR-0057 defines the
+  per-user supervisor and per-data-root coordinator; ADR-0059 defines Mission
+  Control responsibility and authority.
+
+## Context
+
+The source and dev launchers can already derive a workspace `.kungfu` data home,
+but the installed Desktop product cannot choose a project directory, remember
+the last choice, or switch the selected fact world. A packaged launch therefore
+falls back to Electron `userData/runtime`, while Work Dashboard immediately
+renders Mission/Go lists and authoring forms against whichever runtime home was
+inherited.
+
+This breaks the intended product model. A user should be able to open a real
+workspace such as `~/Code/atlas`, return to it on the next launch, and see the
+Mission Control view backed by that workspace's `.kungfu`. Opening a directory
+must remain read-only: it must not create `.kungfu`, journals, runtime files, or
+Git ignore changes merely because the user inspected a project.
+
+Saved Query Catalog makes the boundary load-bearing. Its QueryDefinition and
+ViewSpec revisions are already journal-backed in the selected runtime data
+root. They describe one fact world and therefore cannot be moved into a global
+GUI preference file without losing their declaration, cut, and schema context.
+
+## Decision
+
+### 1. Workspace root and data home are distinct identities
+
+Desktop selects a canonical **workspace root**. Its candidate Kungfu data home
+is `<workspace-root>/.kungfu`. Symlinks are resolved for identity, while the
+user-facing path may retain the path the user selected.
+
+The product exports both identities before creating a renderer:
+
+```text
+KF_WORKSPACE_ROOT=<canonical workspace root>
+KF_HOME=<workspace root>/.kungfu
+KF_RUNTIME_DIR=<workspace root>/.kungfu/runtime
+```
+
+`KF_WORKSPACE_ROOT` is a product/session selector. `KF_HOME` remains the data
+home selector. Callers must not pass a project root to `-H` and hope every layer
+appends `.kungfu` independently.
+
+### 2. Opening is read-only; initialization is write-intent-bound
+
+Selecting or reopening a workspace performs only path validation, capability
+discovery, and inspection of whether `.kungfu` already exists. It does not
+create the data home.
+
+When `.kungfu` is absent, Desktop enters `selected-uninitialized` state. It
+must not call runtime joins, generate skill/runtime files, ensure a coordinator,
+or construct a storage handle against the candidate path. The first operation
+that would change the workspace fact world passes through one
+`ensureWorkspaceDataHome(reason)` gate. Examples include:
+
+- create or clarify a Mission;
+- create a Go, claim completion, or record a decision;
+- import Atlas or materialize a Mission/Episode/fact bundle;
+- save a QueryDefinition/ViewSpec revision;
+- record an Episode, fact material, source, or assessment.
+
+Read-only Mission/Go inspection, workspace probing, config inspection, bundle
+validation, and query planning do not initialize the workspace.
+
+The ensure gate creates the minimum `.kungfu` layout, returns a receipt naming
+the triggering intent, and then starts or attaches to the data-root
+coordinator. Git ignore integration is an explicit follow-up action, not a
+silent side effect of opening or initialization.
+
+### 3. One Desktop process owns one selected workspace
+
+Version 1 binds one Desktop process to one workspace candidate before runtime
+handles are created. If the data home already exists, runtime boot is eager. If
+it does not, runtime boot is deferred until the ensure gate succeeds; the
+process already carries the candidate environment, so initialization does not
+need to reinterpret the path.
+
+Switching to another workspace disposes the current workspace lease and uses a
+controlled application relaunch in the first delivery. This preserves the
+in-process native capability boundary and prevents live handles, subprocess
+environment, terminal hosts, and coordinator leases from spanning two fact
+worlds. A later multi-workspace process model requires a separate ADR.
+
+### 4. The last workspace is global product state, not a workspace fact
+
+Desktop persists a versioned registry at:
+
+```text
+<KF_CONFIG_HOME>/gui/workspaces.json
+```
+
+The registry contains the last selected canonical root, bounded recent roots,
+display paths, and non-authoritative availability metadata. It contains no
+Mission bodies, Go state, facts, proofs, or imported Atlas payloads. A missing
+or inaccessible last workspace degrades to the workspace chooser; it never
+falls through to a different fact world silently.
+
+Dynamic recent paths do not belong in the declarative `config.json` preference
+override. They are user-level GUI session state under the same config home.
+
+### 5. Local state has three standard homes
+
+| Home | Owns | Must not own |
+| --- | --- | --- |
+| `<workspace>/.kungfu` | declarations, admitted facts, Episodes, payloads, source registry, Mission/Go/claim/decision facts, assessments, TrustReports, saved queries, observer metadata, rebuildable workspace projections and coordinator state | global recent workspaces, installed-product preferences |
+| `~/.kungfu-config` (or `KF_CONFIG_HOME`) | user preferences, global trust/extension/skill policy, installed kfx/skill metadata, recent/last workspace registry, per-user supervisor routing state | workspace Mission/Go facts, saved query revisions, proof or imported Atlas bodies |
+| platform machine fallback selected by `KF_HOME` | no-workspace runtime support, caches, service state, explicitly machine-scoped facts | an implicit merged Mission world for all projects |
+
+`~/.kungfu` has no implicit default role. It is not a config compatibility path
+and Desktop does not silently merge it with an opened workspace. A future
+explicit **Personal Workspace** may select `~/.kungfu` as its data root, but it
+must be created and opened deliberately like any other workspace.
+
+Global installation and workspace participation remain distinct. The config
+home may contain an installed kfx/skill package and user default policy; the
+workspace pins the exact version, enablement/grant, declaration, and receipt
+that participated in its fact world. A global update cannot reinterpret an
+older workspace cut.
+
+### 6. Existing workspace data loads without re-import
+
+When the selected `.kungfu` exists, Desktop opens that data root and rebuilds
+projections as needed. A completed Atlas import, native Mission, Go, assessment,
+or Saved Query Catalog entry is immediately available from the same authority.
+Opening does not re-import Atlas and does not mutate source authority.
+
+If the selected root looks Atlas-compatible but no completed import exists,
+Mission Home may offer **Import Atlas facts**. The action is explicit and is a
+write intent, so it passes through lazy initialization. Import freshness and
+source coordinates remain visible after completion.
+
+### 7. GUI and agents use the same workspace contract
+
+The installed CLI/API must expose machine-readable workspace selection and
+inspection, including at least:
+
+```text
+kungfu workspace inspect <path> --json
+kungfu workspace list --json
+kungfu workspace current --json
+kungfu workspace select <path> --json
+```
+
+Intent-level write commands accept an explicit workspace root or use ordinary
+workspace discovery. Selecting a GUI workspace does not force every independent
+agent command to use that global choice. Receipts disclose workspace root, data
+home, whether initialization occurred, and the resulting fact/episode identity.
+
+## Consequences
+
+- The installed product can dogfood real repositories without a special dev
+  launcher or manual environment variables.
+- Reopening Desktop returns to the last workspace and the same Mission Control
+  fact world.
+- Read-only inspection cannot dirty a repository.
+- Global GUI convenience state is separated from workspace authority.
+- Saved Query Catalog remains correctly workspace-scoped; transfer uses its
+  JSON artifact or a larger Mission/Episode bundle, not implicit global reuse.
+- The first implementation must split current eager runtime boot into selected,
+  selected-uninitialized, ready, unavailable, and degraded states.
+- Controlled relaunch on workspace switch is a visible implementation cost but
+  avoids cross-root native handle leakage in the first delivery.
+
+## Rejected alternatives
+
+- **Use Electron `userData/runtime` for every Mission.** Rejected because it
+  silently merges unrelated projects and makes workspace transfer unclear.
+- **Create `.kungfu` whenever a directory is opened.** Rejected because reading
+  a project must not change it.
+- **Store recent workspaces in `.kungfu`.** Rejected because the chooser must
+  work before any workspace is opened and recent paths are not workspace facts.
+- **Store Saved Query Catalog globally.** Rejected because a saved definition
+  and view are bound to one declared fact world even when their JSON shape is
+  portable.
+- **Hot-swap runtime roots inside existing handles.** Rejected for version 1;
+  native handles, coordinator leases, subprocess environment, and terminal
+  hosts would otherwise risk crossing authority boundaries.
+- **Restore `~/.kungfu` as an ambiguous global default.** Rejected because it
+  collapses config, personal facts, machine state, and project facts again.
+
+## Acceptance gates
+
+- Opening a Git workspace with no `.kungfu` leaves the filesystem unchanged.
+- The first Mission/Go/import/saved-query write creates exactly that
+  workspace's data home and returns an initialization receipt.
+- Restarting Desktop reopens the last valid workspace and loads existing facts.
+- Switching workspace cannot expose the prior workspace's Mission, query, or
+  runtime handles.
+- Removing `~/.kungfu-config/gui/workspaces.json` forgets recents but does not
+  delete or change any workspace fact.
+- Deleting rebuildable projections does not delete Missions, assessments, or
+  saved-query revisions.
+- GUI and CLI report the same canonical workspace root and data home.
+
+## Residual risk
+
+- Nested repositories and symlinked paths need one canonical identity policy.
+- A write-intent gate that misses an eager runtime side effect would violate the
+  read-only open promise; product qualification needs filesystem before/after
+  assertions.
+- Controlled relaunch needs clear unsaved-dialog handling and lease release.
+- Recent workspace paths can be sensitive metadata; the registry remains local,
+  bounded, and outside portable Mission bundles.

--- a/framework/core/docs/adr/ADR-0060-desktop-workspace-selection-and-lazy-data-home.md
+++ b/framework/core/docs/adr/ADR-0060-desktop-workspace-selection-and-lazy-data-home.md
@@ -17,7 +17,7 @@ ai_provenance:
   invisible_context_boundary: Did not inspect private Atlas bodies, credentials, provider payloads, or hidden model state
 ---
 
-# ADR-0060: Desktop selects one workspace and initializes its `.kungfu` data home lazily
+# ADR-0060: Desktop selects one explicit workspace and initializes its data home lazily
 
 - Status: proposed
 - Date: 2026-07-11
@@ -37,11 +37,13 @@ falls back to Electron `userData/runtime`, while Work Dashboard immediately
 renders Mission/Go lists and authoring forms against whichever runtime home was
 inherited.
 
-This breaks the intended product model. A user should be able to open a real
-workspace such as `~/Code/atlas`, return to it on the next launch, and see the
-Mission Control view backed by that workspace's `.kungfu`. Opening a directory
-must remain read-only: it must not create `.kungfu`, journals, runtime files, or
-Git ignore changes merely because the user inspected a project.
+This breaks the intended product model in two directions. A user should be able
+to open a real workspace such as `~/Code/atlas`, return to it on the next
+launch, and see the Mission Control view backed by that workspace's `.kungfu`.
+A first-time user with no repository must also be able to start managing agent
+work without preparing Markdown, Git, or a Mission hierarchy first. Opening a
+directory or merely launching the product must remain read-only: neither action
+may create a fact world merely because it was inspected.
 
 Saved Query Catalog makes the boundary load-bearing. Its QueryDefinition and
 ViewSpec revisions are already journal-backed in the selected runtime data
@@ -52,9 +54,11 @@ GUI preference file without losing their declaration, cut, and schema context.
 
 ### 1. Workspace root and data home are distinct identities
 
-Desktop selects a canonical **workspace root**. Its candidate Kungfu data home
-is `<workspace-root>/.kungfu`. Symlinks are resolved for identity, while the
-user-facing path may retain the path the user selected.
+Desktop selects one explicit workspace identity with kind `project` or
+`personal`. A project has a canonical **workspace root** and candidate data
+home `<workspace-root>/.kungfu`. The Personal Agent Workspace has no project
+root and uses the canonical data home `~/.kungfu`. Symlinks are resolved for
+identity, while the user-facing path may retain the path the user selected.
 
 The product exports both identities before creating a renderer:
 
@@ -63,6 +67,10 @@ KF_WORKSPACE_ROOT=<canonical workspace root>
 KF_HOME=<workspace root>/.kungfu
 KF_RUNTIME_DIR=<workspace root>/.kungfu/runtime
 ```
+
+For the Personal Agent Workspace, `KF_HOME=~/.kungfu` and
+`KF_RUNTIME_DIR=~/.kungfu/runtime`; `KF_WORKSPACE_ROOT` is absent and the
+registry-provided workspace kind supplies the product identity.
 
 `KF_WORKSPACE_ROOT` is a product/session selector. `KF_HOME` remains the data
 home selector. Callers must not pass a project root to `-H` and hope every layer
@@ -74,7 +82,8 @@ Selecting or reopening a workspace performs only path validation, capability
 discovery, and inspection of whether `.kungfu` already exists. It does not
 create the data home.
 
-When `.kungfu` is absent, Desktop enters `selected-uninitialized` state. It
+When the selected data home is absent, Desktop enters
+`selected-uninitialized` state. It
 must not call runtime joins, generate skill/runtime files, ensure a coordinator,
 or construct a storage handle against the candidate path. The first operation
 that would change the workspace fact world passes through one
@@ -85,6 +94,8 @@ that would change the workspace fact world passes through one
 - import Atlas or materialize a Mission/Episode/fact bundle;
 - save a QueryDefinition/ViewSpec revision;
 - record an Episode, fact material, source, or assessment.
+- start a Kungfu-managed agent run whose receipts will enter the Personal Agent
+  Workspace inbox.
 
 Read-only Mission/Go inspection, workspace probing, config inspection, bundle
 validation, and query planning do not initialize the workspace.
@@ -108,7 +119,27 @@ in-process native capability boundary and prevents live handles, subprocess
 environment, terminal hosts, and coordinator leases from spanning two fact
 worlds. A later multi-workspace process model requires a separate ADR.
 
-### 4. The last workspace is global product state, not a workspace fact
+### 4. First install offers an explicit Personal Agent Workspace
+
+When no registry exists, Desktop offers **Start managing agent work** as the
+recommended path and **Open existing project** as the project path. The first
+choice selects the Personal Agent Workspace candidate; installation, launch,
+and selection alone do not create `~/.kungfu`. Its first managed run or other
+fact-bearing write passes through `ensureWorkspaceDataHome(reason)`.
+
+The Personal workspace may begin with an Agent Work Inbox and no Mission. In
+that state Kungfu records what happened and what the evidence establishes, but
+reports purpose-bound fitness as insufficient until a Mission/Go or explicit
+purpose is attached. Attaching purpose later adds a relationship without
+rewriting the original Episode identity or capture time.
+
+Agent attribution remains bounded by integration evidence: a Kungfu-managed
+run may establish exact supervisor/run identity; CLI/API/skill use establishes
+explicit sourced receipts; after-the-fact external imports remain observed or
+ambiguous. The product must not infer exact causality from unrelated files or
+process presence.
+
+### 5. The last workspace is global product state, not a workspace fact
 
 Desktop persists a versioned registry at:
 
@@ -117,7 +148,8 @@ Desktop persists a versioned registry at:
 ```
 
 The registry contains the last selected canonical root, bounded recent roots,
-display paths, and non-authoritative availability metadata. It contains no
+display paths, workspace kind (`personal` or `project`), and non-authoritative
+availability metadata. It contains no
 Mission bodies, Go state, facts, proofs, or imported Atlas payloads. A missing
 or inaccessible last workspace degrades to the workspace chooser; it never
 falls through to a different fact world silently.
@@ -125,18 +157,20 @@ falls through to a different fact world silently.
 Dynamic recent paths do not belong in the declarative `config.json` preference
 override. They are user-level GUI session state under the same config home.
 
-### 5. Local state has three standard homes
+### 6. Local state has four standard homes
 
 | Home | Owns | Must not own |
 | --- | --- | --- |
-| `<workspace>/.kungfu` | declarations, admitted facts, Episodes, payloads, source registry, Mission/Go/claim/decision facts, assessments, TrustReports, saved queries, observer metadata, rebuildable workspace projections and coordinator state | global recent workspaces, installed-product preferences |
+| `~/.kungfu` Personal Agent Workspace | explicitly personal/cross-project Missions, unassigned Agent Work Inbox Episodes, admitted facts, proof, assessments, decisions, saved queries, projections and coordinator state | global preferences, implicit project facts, machine caches |
+| `<project>/.kungfu` | project declarations, admitted facts, Episodes, payloads, source registry, Mission/Go/claim/decision facts, assessments, TrustReports, saved queries, observer metadata, rebuildable projections and coordinator state | global recent workspaces, installed-product preferences, implicit Personal facts |
 | `~/.kungfu-config` (or `KF_CONFIG_HOME`) | user preferences, global trust/extension/skill policy, installed kfx/skill metadata, recent/last workspace registry, per-user supervisor routing state | workspace Mission/Go facts, saved query revisions, proof or imported Atlas bodies |
 | platform machine fallback selected by `KF_HOME` | no-workspace runtime support, caches, service state, explicitly machine-scoped facts | an implicit merged Mission world for all projects |
 
-`~/.kungfu` has no implicit default role. It is not a config compatibility path
-and Desktop does not silently merge it with an opened workspace. A future
-explicit **Personal Workspace** may select `~/.kungfu` as its data root, but it
-must be created and opened deliberately like any other workspace.
+`~/.kungfu` has one precise role: the explicitly selected Personal Agent
+Workspace. It is not a config compatibility path or machine fallback, and
+Desktop never silently merges it with an opened project workspace. Missions,
+Episodes, or saved queries move between fact worlds only through explicit full
+or thin bundle export/import; no dual write is introduced.
 
 Global installation and workspace participation remain distinct. The config
 home may contain an installed kfx/skill package and user default policy; the
@@ -144,7 +178,7 @@ workspace pins the exact version, enablement/grant, declaration, and receipt
 that participated in its fact world. A global update cannot reinterpret an
 older workspace cut.
 
-### 6. Existing workspace data loads without re-import
+### 7. Existing workspace data loads without re-import
 
 When the selected `.kungfu` exists, Desktop opens that data root and rebuilds
 projections as needed. A completed Atlas import, native Mission, Go, assessment,
@@ -156,7 +190,7 @@ Mission Home may offer **Import Atlas facts**. The action is explicit and is a
 write intent, so it passes through lazy initialization. Import freshness and
 source coordinates remain visible after completion.
 
-### 7. GUI and agents use the same workspace contract
+### 8. GUI and agents use the same workspace contract
 
 The installed CLI/API must expose machine-readable workspace selection and
 inspection, including at least:
@@ -166,6 +200,7 @@ kungfu workspace inspect <path> --json
 kungfu workspace list --json
 kungfu workspace current --json
 kungfu workspace select <path> --json
+kungfu workspace select-personal --json
 ```
 
 Intent-level write commands accept an explicit workspace root or use ordinary
@@ -177,6 +212,8 @@ home, whether initialization occurred, and the resulting fact/episode identity.
 
 - The installed product can dogfood real repositories without a special dev
   launcher or manual environment variables.
+- A first-time user can capture and manage agent work before owning a repository
+  or fully articulating a Mission, without the product inventing purpose.
 - Reopening Desktop returns to the last workspace and the same Mission Control
   fact world.
 - Read-only inspection cannot dirty a repository.
@@ -203,10 +240,25 @@ home, whether initialization occurred, and the resulting fact/episode identity.
   native handles, coordinator leases, subprocess environment, and terminal
   hosts would otherwise risk crossing authority boundaries.
 - **Restore `~/.kungfu` as an ambiguous global default.** Rejected because it
-  collapses config, personal facts, machine state, and project facts again.
+  collapses config, personal facts, machine state, and project facts again. The
+  accepted Personal Agent Workspace gives this path one explicit role instead.
+- **Require a repository or Mission before tracking agent work.** Rejected
+  because sidecar adoption must precede project formalization; the inbox can
+  preserve evidence while fitness remains honestly insufficient.
+- **Passively claim exact attribution for any local agent.** Rejected because
+  process/file proximity does not establish causal responsibility.
 
 ## Acceptance gates
 
+- Installing and launching Desktop with no registry creates neither
+  `~/.kungfu` nor a project `.kungfu`.
+- Choosing **Start managing agent work** and performing the first managed run
+  initializes only `~/.kungfu`, returns a receipt, and shows the Episode in an
+  unassigned inbox without inventing a Mission.
+- Attaching that Episode to a later Mission preserves its identity and original
+  capture boundary.
+- External activity without a Kungfu integration receipt cannot be presented
+  as exact attribution.
 - Opening a Git workspace with no `.kungfu` leaves the filesystem unchanged.
 - The first Mission/Go/import/saved-query write creates exactly that
   workspace's data home and returns an initialization receipt.
@@ -218,6 +270,8 @@ home, whether initialization occurred, and the resulting fact/episode identity.
 - Deleting rebuildable projections does not delete Missions, assessments, or
   saved-query revisions.
 - GUI and CLI report the same canonical workspace root and data home.
+- A full Personal-to-project bundle transfer preserves declared roots without
+  creating shared or dual-write authority.
 
 ## Residual risk
 
@@ -228,3 +282,6 @@ home, whether initialization occurred, and the resulting fact/episode identity.
 - Controlled relaunch needs clear unsaved-dialog handling and lease release.
 - Recent workspace paths can be sensitive metadata; the registry remains local,
   bounded, and outside portable Mission bundles.
+- A personal inbox can become a dumping ground unless retention, assignment,
+  and degraded-evidence states remain visible; those policies require product
+  qualification rather than silent cleanup.

--- a/framework/core/docs/adr/ADR-0060-desktop-workspace-selection-and-lazy-data-home.md
+++ b/framework/core/docs/adr/ADR-0060-desktop-workspace-selection-and-lazy-data-home.md
@@ -26,7 +26,8 @@ ai_provenance:
   workspace coordinator, Mission Control, Saved Query Catalog, CLI/agent surface
 - Related: ADR-0035 defines workspace-local `.kungfu`; ADR-0057 defines the
   per-user supervisor and per-data-root coordinator; ADR-0059 defines Mission
-  Control responsibility and authority.
+  Control responsibility and authority; ADR-0061 makes agent-mediated advice
+  and execution a first-class product interface.
 
 ## Context
 
@@ -54,11 +55,12 @@ GUI preference file without losing their declaration, cut, and schema context.
 
 ### 1. Workspace root and data home are distinct identities
 
-Desktop selects one explicit workspace identity with kind `project` or
-`personal`. A project has a canonical **workspace root** and candidate data
-home `<workspace-root>/.kungfu`. The Personal Agent Workspace has no project
-root and uses the canonical data home `~/.kungfu`. Symlinks are resolved for
-identity, while the user-facing path may retain the path the user selected.
+Desktop selects one explicit workspace identity with kind `project` or `home`.
+A project has a canonical **workspace root** and candidate data home
+`<workspace-root>/.kungfu`. Every user has one logical **Home Workspace** with
+stable identity `home`, display name **Home**, no project root, and canonical
+data home `~/.kungfu`. Symlinks are resolved for identity, while the user-facing
+path may retain the path the user selected.
 
 The product exports both identities before creating a renderer:
 
@@ -68,7 +70,7 @@ KF_HOME=<workspace root>/.kungfu
 KF_RUNTIME_DIR=<workspace root>/.kungfu/runtime
 ```
 
-For the Personal Agent Workspace, `KF_HOME=~/.kungfu` and
+For the Home Workspace, `KF_HOME=~/.kungfu` and
 `KF_RUNTIME_DIR=~/.kungfu/runtime`; `KF_WORKSPACE_ROOT` is absent and the
 registry-provided workspace kind supplies the product identity.
 
@@ -94,8 +96,8 @@ that would change the workspace fact world passes through one
 - import Atlas or materialize a Mission/Episode/fact bundle;
 - save a QueryDefinition/ViewSpec revision;
 - record an Episode, fact material, source, or assessment.
-- start a Kungfu-managed agent run whose receipts will enter the Personal Agent
-  Workspace inbox.
+- start a Kungfu-managed agent run whose receipts will enter the Home Workspace
+  inbox.
 
 Read-only Mission/Go inspection, workspace probing, config inspection, bundle
 validation, and query planning do not initialize the workspace.
@@ -119,15 +121,15 @@ in-process native capability boundary and prevents live handles, subprocess
 environment, terminal hosts, and coordinator leases from spanning two fact
 worlds. A later multi-workspace process model requires a separate ADR.
 
-### 4. First install offers an explicit Personal Agent Workspace
+### 4. First install offers the logical Home Workspace
 
 When no registry exists, Desktop offers **Start managing agent work** as the
 recommended path and **Open existing project** as the project path. The first
-choice selects the Personal Agent Workspace candidate; installation, launch,
-and selection alone do not create `~/.kungfu`. Its first managed run or other
-fact-bearing write passes through `ensureWorkspaceDataHome(reason)`.
+choice selects Home; installation, launch, and selection alone do not create
+`~/.kungfu`. Its first managed run or other fact-bearing write passes through
+`ensureWorkspaceDataHome(reason)`.
 
-The Personal workspace may begin with an Agent Work Inbox and no Mission. In
+Home may begin with an Agent Work Inbox and no Mission. In
 that state Kungfu records what happened and what the evidence establishes, but
 reports purpose-bound fitness as insufficient until a Mission/Go or explicit
 purpose is attached. Attaching purpose later adds a relationship without
@@ -148,7 +150,7 @@ Desktop persists a versioned registry at:
 ```
 
 The registry contains the last selected canonical root, bounded recent roots,
-display paths, workspace kind (`personal` or `project`), and non-authoritative
+display paths, workspace kind (`home` or `project`), and non-authoritative
 availability metadata. It contains no
 Mission bodies, Go state, facts, proofs, or imported Atlas payloads. A missing
 or inaccessible last workspace degrades to the workspace chooser; it never
@@ -161,13 +163,13 @@ override. They are user-level GUI session state under the same config home.
 
 | Home | Owns | Must not own |
 | --- | --- | --- |
-| `~/.kungfu` Personal Agent Workspace | explicitly personal/cross-project Missions, unassigned Agent Work Inbox Episodes, admitted facts, proof, assessments, decisions, saved queries, projections and coordinator state | global preferences, implicit project facts, machine caches |
-| `<project>/.kungfu` | project declarations, admitted facts, Episodes, payloads, source registry, Mission/Go/claim/decision facts, assessments, TrustReports, saved queries, observer metadata, rebuildable projections and coordinator state | global recent workspaces, installed-product preferences, implicit Personal facts |
+| `~/.kungfu` Home Workspace | personal/cross-project Missions, unassigned Agent Work Inbox Episodes, admitted facts, proof, assessments, decisions, saved queries, projections and coordinator state | global preferences, implicit project facts, machine caches |
+| `<project>/.kungfu` | project declarations, admitted facts, Episodes, payloads, source registry, Mission/Go/claim/decision facts, assessments, TrustReports, saved queries, observer metadata, rebuildable projections and coordinator state | global recent workspaces, installed-product preferences, implicit Home facts |
 | `~/.kungfu-config` (or `KF_CONFIG_HOME`) | user preferences, global trust/extension/skill policy, installed kfx/skill metadata, recent/last workspace registry, per-user supervisor routing state | workspace Mission/Go facts, saved query revisions, proof or imported Atlas bodies |
 | platform machine fallback selected by `KF_HOME` | no-workspace runtime support, caches, service state, explicitly machine-scoped facts | an implicit merged Mission world for all projects |
 
-`~/.kungfu` has one precise role: the explicitly selected Personal Agent
-Workspace. It is not a config compatibility path or machine fallback, and
+`~/.kungfu` has one precise role: the user's Home Workspace. It is not a config
+compatibility path or machine fallback, and
 Desktop never silently merges it with an opened project workspace. Missions,
 Episodes, or saved queries move between fact worlds only through explicit full
 or thin bundle export/import; no dual write is introduced.
@@ -190,7 +192,32 @@ Mission Home may offer **Import Atlas facts**. The action is explicit and is a
 write intent, so it passes through lazy initialization. Import freshness and
 source coordinates remain visible after completion.
 
-### 8. GUI and agents use the same workspace contract
+### 8. CLI target resolution is explicit and command-sensitive
+
+An independent CLI process does not inherit the Desktop's last selected
+workspace. It resolves a target in this order:
+
+```text
+1. explicit --workspace <path> or --home
+2. explicit workspace environment for this process
+3. nearest discovered project workspace for the current directory
+4. command-specific no-project behavior
+5. fail with a machine-readable target diagnosis
+```
+
+Capture-only operations such as importing an Episode or recording a managed
+agent run may use Home when no project workspace is discovered. They enter the
+Home Agent Work Inbox as `unassigned`, record the source working directory and
+resolution reason, and establish no project or Mission association.
+
+Read-only validation may operate without a workspace. Semantic writes such as
+Mission/Go creation may offer Home interactively, but non-interactive/JSON use
+must name `--home` or `--workspace` unless the command is explicitly classified
+as capture-only. Assessment, correction, repair, migration, and destructive
+operations require an explicit or discovered target and never fall back to
+Home silently.
+
+### 9. GUI and agents use the same workspace contract
 
 The installed CLI/API must expose machine-readable workspace selection and
 inspection, including at least:
@@ -200,13 +227,32 @@ kungfu workspace inspect <path> --json
 kungfu workspace list --json
 kungfu workspace current --json
 kungfu workspace select <path> --json
-kungfu workspace select-personal --json
+kungfu workspace select-home --json
 ```
 
 Intent-level write commands accept an explicit workspace root or use ordinary
 workspace discovery. Selecting a GUI workspace does not force every independent
 agent command to use that global choice. Receipts disclose workspace root, data
-home, whether initialization occurred, and the resulting fact/episode identity.
+home, resolution reason, association state, whether initialization occurred,
+and the resulting fact/episode identity.
+
+### 10. Home-to-project promotion is explicit
+
+Kungfu may advise creation of a project workspace when evidence shows project
+gravity: repeated unassigned Episodes from one source root, an existing Git
+repository, a long-lived Mission, or a portability/collaboration request. The
+advice follows ADR-0061 and offers **keep in Home** plus durable suppression.
+
+Creating `<project>/.kungfu`, attaching Home Episodes, modifying `.gitignore`,
+initializing Git, staging, committing, and pushing are separate effects and
+authorization classes. A project workspace may live at a Git repository root
+without making its entire high-frequency ledger Git-tracked. Git is appropriate
+for low-frequency, reviewable contract sources and pins; Episode journals,
+payloads, runtime state, and rebuildable projections remain Kungfu data unless
+an explicit portable bundle or later declared Git contract says otherwise.
+
+An **All Workspaces** surface may aggregate read-only attention across Home and
+projects. It is never a fact world or write target.
 
 ## Consequences
 
@@ -220,6 +266,8 @@ home, whether initialization occurred, and the resulting fact/episode identity.
 - Global GUI convenience state is separated from workspace authority.
 - Saved Query Catalog remains correctly workspace-scoped; transfer uses its
   JSON artifact or a larger Mission/Episode bundle, not implicit global reuse.
+- Evidence-backed agent advice can progressively recommend a project or
+  Git-backed contract without turning Home into an inferior temporary store.
 - The first implementation must split current eager runtime boot into selected,
   selected-uninitialized, ready, unavailable, and degraded states.
 - Controlled relaunch on workspace switch is a visible implementation cost but
@@ -239,9 +287,9 @@ home, whether initialization occurred, and the resulting fact/episode identity.
 - **Hot-swap runtime roots inside existing handles.** Rejected for version 1;
   native handles, coordinator leases, subprocess environment, and terminal
   hosts would otherwise risk crossing authority boundaries.
-- **Restore `~/.kungfu` as an ambiguous global default.** Rejected because it
+- **Restore `~/.kungfu` as an ambiguous global fallback.** Rejected because it
   collapses config, personal facts, machine state, and project facts again. The
-  accepted Personal Agent Workspace gives this path one explicit role instead.
+  accepted Home Workspace gives this path one explicit role instead.
 - **Require a repository or Mission before tracking agent work.** Rejected
   because sidecar adoption must precede project formalization; the inbox can
   preserve evidence while fitness remains honestly insufficient.
@@ -255,6 +303,11 @@ home, whether initialization occurred, and the resulting fact/episode identity.
 - Choosing **Start managing agent work** and performing the first managed run
   initializes only `~/.kungfu`, returns a receipt, and shows the Episode in an
   unassigned inbox without inventing a Mission.
+- Importing an Episode outside any project workspace resolves to Home Inbox and
+  reports `workspace_id=home`, the source directory, resolution reason, and
+  `association=unassigned`.
+- An independent CLI process never targets the Desktop's last project merely
+  because it was last open in the GUI.
 - Attaching that Episode to a later Mission preserves its identity and original
   capture boundary.
 - External activity without a Kungfu integration receipt cannot be presented
@@ -270,8 +323,10 @@ home, whether initialization occurred, and the resulting fact/episode identity.
 - Deleting rebuildable projections does not delete Missions, assessments, or
   saved-query revisions.
 - GUI and CLI report the same canonical workspace root and data home.
-- A full Personal-to-project bundle transfer preserves declared roots without
+- A full Home-to-project bundle transfer preserves declared roots without
   creating shared or dual-write authority.
+- Workspace creation authorization cannot silently edit Git state, and an All
+  Workspaces view cannot accept writes.
 
 ## Residual risk
 
@@ -282,6 +337,6 @@ home, whether initialization occurred, and the resulting fact/episode identity.
 - Controlled relaunch needs clear unsaved-dialog handling and lease release.
 - Recent workspace paths can be sensitive metadata; the registry remains local,
   bounded, and outside portable Mission bundles.
-- A personal inbox can become a dumping ground unless retention, assignment,
+- A Home inbox can become a dumping ground unless retention, assignment,
   and degraded-evidence states remain visible; those policies require product
   qualification rather than silent cleanup.

--- a/framework/core/docs/adr/ADR-0061-agent-mediated-guidance-is-a-first-class-product-interface.md
+++ b/framework/core/docs/adr/ADR-0061-agent-mediated-guidance-is-a-first-class-product-interface.md
@@ -1,0 +1,221 @@
+---
+status: draft
+period: 2026-07-11
+theme: kungfu-agent-mediated-product
+doc_type: decision
+source_level: user-consensus-and-local-files
+confidence: high
+sensitivity: public
+evidence_grade: B
+review_state: unreviewed
+last_reviewed: 2026-07-11
+ai_provenance:
+  model_family: GPT-5
+  product: Codex
+  generated_at: 2026-07-11
+  visible_context: User product principle, Mission Control workspace design, Shifu delegation protocol, KFD-3, and current GUI/CLI parity contracts
+  invisible_context_boundary: Did not inspect private provider sessions, credentials, hidden prompts, or hidden model state
+---
+
+# ADR-0061: Agent-mediated guidance is a first-class product interface
+
+- Status: proposed
+- Date: 2026-07-11
+- Category: product architecture, dual-first interaction, agent interface
+- Subsystem: application services, CLI/API, GUI, advice, authorization,
+  receipts, agent brief
+- Related: ADR-0044 defines Shifu delegation; ADR-0049 requires independently
+  complete product layers; ADR-0059 defines Mission Control responsibility;
+  ADR-0060 defines Home and project workspace selection.
+
+## Context
+
+Many Kungfu users will not operate every command or configuration surface
+themselves. They will ask an agent to inspect Kungfu, explain the current state,
+recommend a better workspace or evidence structure, preview the consequences,
+and perform an authorized operation through the installed CLI/API.
+
+Treating this as an edge case would force Kungfu to duplicate mechanical
+onboarding and low-frequency workflows across GUI forms while still leaving
+agents to infer product semantics from prose. Treating a free-form agent as the
+product authority would be worse: model quality, loaded context, and prompt
+interpretation vary, and an agent suggestion cannot establish facts,
+authorization, or effects.
+
+Kungfu is dual-first under KFD-3. People and agents must participate through the
+same declared fact world, choices, constraints, and receipts. The product can
+therefore use agents as an explanation and interaction layer, but only after
+Kungfu exposes the deterministic contracts that make their help reliable.
+
+## Decision
+
+### 1. Agent-mediated use is a primary qualification path
+
+Every material product capability is designed for two clients from the start:
+
+- a human using the GUI directly; and
+- an agent using machine-readable CLI/API operations on the person's behalf.
+
+Agent operability is not satisfied by documenting internal files or asking an
+agent to synthesize shell commands. The capability must expose intent-level
+inspection, action, and receipt contracts. The GUI calls the same application
+service rather than owning a private behavior or database.
+
+This principle reduces mechanical GUI workflow, not product responsibility. A
+usable minimal GUI remains required for workspace selection, advice review,
+impact preview, authorization, status, and recovery when no agent is present.
+
+### 2. Kungfu owns semantics; the agent owns explanation
+
+Kungfu produces bounded, typed advice from admitted facts and explicit product
+policy. An advice object includes at least:
+
+```text
+advice_id
+advice_kind and state
+workspace identity and selected cut
+reason codes and evidence references
+recommended intent
+proposed effects and skipped effects
+risk / authorization class
+preview operation or next command
+freshness / invalidation coordinates
+suppression key
+```
+
+An agent may translate that object into language appropriate for the user,
+compare options, and recommend a choice. It may not invent hidden evidence,
+upgrade an uncertain observation, remove an authorization requirement, or turn
+its explanation into an admitted fact automatically.
+
+Advice is a decision aid, not a command. It remains inspectable in the GUI and
+must report `insufficient`, `ambiguous`, `stale`, or no recommendation when its
+inputs do not justify a stronger result.
+
+### 3. Material workflows follow one interaction protocol
+
+The reusable product sequence is:
+
+```text
+inspect -> advise -> preview -> authorize -> execute -> receipt -> verify
+```
+
+- **inspect** returns current identities, facts, policy, and degraded state;
+- **advise** returns evidence-backed options without changing state;
+- **preview** resolves exact target, effects, skips, and required authority;
+- **authorize** records the user decision or checks an existing bounded policy;
+- **execute** performs one idempotent intent-level operation;
+- **receipt** names the target, inputs, effects, created identities, and skips;
+- **verify** reads the resulting state rather than trusting a success string.
+
+GUI confirmation cards and agent CLI calls use the same advice identity,
+preview identity, authorization decision, and execution receipt. Recomputing
+after relevant facts change invalidates or supersedes stale advice; it does not
+silently reuse the old recommendation.
+
+### 4. Authorization cannot expand through conversational delegation
+
+Agents may perform read-only inspection and advice without another approval.
+Low-risk capture into an already authorized Home Inbox may run under an
+explicit standing policy. Consequential or scope-changing operations require a
+recorded decision or a policy that names that exact class.
+
+Creating a project workspace, attaching or materializing Home material, and
+changing source authority are separate actions. Git initialization,
+`.gitignore` modification, staging, commit, push, remote creation, credentials,
+and network publication are separate authorization classes. Approval for one
+does not imply another, and an agent cannot infer authority from the user's use
+of a natural-language shortcut.
+
+### 5. Agent guidance is discoverable, not prompt folklore
+
+The installed agent brief and command discovery surface publish the protocol,
+available intents, current workspace resolution, authorization boundaries, and
+JSON schemas needed to act safely. Agents should be able to discover bounded
+operations such as:
+
+```text
+kungfu workspace inspect ... --json
+kungfu workspace advise ... --json
+kungfu workspace preview ... --json
+kungfu workspace apply ... --json
+```
+
+Exact command names may be refined during implementation, but the four
+semantic surfaces and shared identities are required. A prompt or skill may
+teach an agent how to use them; it is not the only enforcement mechanism.
+
+### 6. Guidance is progressive and suppressible
+
+Kungfu should recommend formalization when facts justify it—for example,
+repeated unassigned Episodes from one source root, an existing Git repository,
+a long-lived Mission, or a portability/collaboration request. It must disclose
+the triggering facts, allow **keep in Home**, and support a durable suppression
+choice for a source or advice class.
+
+The product does not maximize project-workspace or Git adoption as a vanity
+metric. It recommends the smallest structure that improves responsibility,
+evidence, recovery, or transfer for the user's actual work.
+
+## Consequences
+
+- Kungfu can support sophisticated workflows without turning every branch into
+  a permanent GUI wizard.
+- Agents can help users make better choices because recommendations originate
+  in inspectable product facts rather than model intuition alone.
+- GUI and CLI behavior converge around application services and stable JSON
+  identities.
+- Feature work carries an additional qualification cost: advice, preview,
+  receipts, stale-state behavior, and agent parity must be designed early.
+- The product remains usable without an agent, and weaker or outdated agents
+  fail closed at the service boundary.
+- Natural-language quality may vary without changing the underlying decision
+  or execution semantics.
+
+## Rejected alternatives
+
+- **Build GUI workflows first and add agent commands later.** Rejected because
+  it creates duplicated semantics and makes agent use permanently second-class.
+- **Let agents infer recommendations from documentation and filesystem state.**
+  Rejected because prose and proximity do not establish facts, freshness, or
+  authorization.
+- **Make Kungfu agent-only.** Rejected because people still need direct
+  visibility, consent, recovery, and a usable path when an agent is absent.
+- **Use generic chatbot suggestions without advice identities or evidence.**
+  Rejected because they cannot be reproduced, suppressed, invalidated, or
+  connected to an execution receipt.
+- **Treat prompt instructions as the authorization system.** Rejected because
+  conversational context is not a durable capability grant.
+
+## Acceptance gates
+
+- The same current facts produce the same advice identity and reason codes in
+  GUI and CLI/API.
+- An agent can inspect a workspace recommendation, present its evidence and
+  exact effects, obtain the required decision, execute it, and return a receipt
+  without editing Kungfu internals.
+- A user without an agent can complete the same bounded workflow in the GUI.
+- Changing relevant facts or workspace selection makes stale advice
+  non-executable until it is recomputed.
+- Advice with insufficient or ambiguous evidence cannot present a confident
+  single-path recommendation.
+- Authorization for project workspace creation cannot authorize Git mutation,
+  commit, push, or publication implicitly.
+- Every material execution receipt discloses target workspace, resolution
+  reason, initialization, applied effects, skipped effects, and resulting
+  identities.
+- Product qualification includes at least one weaker/stale-agent fixture whose
+  invalid or over-broad request is rejected by the application service.
+
+## Residual risk
+
+- An advice framework can become a generic rule engine; implementations should
+  begin with bounded typed advice for real product decisions.
+- Too many recommendations can become notification noise; suppression,
+  freshness, ranking, and decision-oriented presentation are part of the
+  contract.
+- An eloquent agent explanation may still overstate the underlying advice;
+  GUI cards and receipts must keep reason codes, evidence, and uncertainty
+  visible.
+- Standing authorization policies need their own inspectable lifecycle and
+  revocation path before broad automation is enabled.

--- a/framework/core/docs/adr/README.md
+++ b/framework/core/docs/adr/README.md
@@ -77,7 +77,8 @@ A record's **Status** says where it stands:
 | [0057](ADR-0057-domain-neutral-live-runtime-terminology.md) | accepted | live runtime internals use reactor, peer, and coordinator; the public command is `kungfu runtime` |
 | [0058](ADR-0058-yijinjing-explicit-mapping-policies.md) | accepted | yijinjing mmap behavior uses explicit access, creation, residency, and durability policies |
 | [0059](ADR-0059-mission-control-mission-go-responsibility-model.md) | accepted | Mission Control composes Mission and Go responsibility over runtime facts; Atlas starts as a bridged authority |
-| [0060](ADR-0060-desktop-workspace-selection-and-lazy-data-home.md) | proposed | Desktop selects a Personal or project workspace and creates its data home only on write intent |
+| [0060](ADR-0060-desktop-workspace-selection-and-lazy-data-home.md) | proposed | Desktop and CLI select Home or a project workspace and create its data home only on qualified write intent |
+| [0061](ADR-0061-agent-mediated-guidance-is-a-first-class-product-interface.md) | proposed | Agent-mediated guidance is a first-class interface over shared advice, preview, authorization, action, and receipt contracts |
 
 ## Reading by theme
 
@@ -190,9 +191,10 @@ A record's **Status** says where it stands:
   Mission/Go responsibility domain, Atlas bridge authority, and Cost/State/Proof
   profile composition),
   [0060](ADR-0060-desktop-workspace-selection-and-lazy-data-home.md) (Desktop
-  Personal/project workspace selection, global recent-workspace state,
+  Home/project workspace selection, global recent-workspace state,
   first-run Agent Work Inbox, and write-intent-bound data-home initialization),
-  and
+  [0061](ADR-0061-agent-mediated-guidance-is-a-first-class-product-interface.md)
+  (the dual-first inspect/advice/preview/authorize/action/receipt protocol), and
   [0055](ADR-0055-retire-journal-session-and-separate-runtime-state-from-projection.md)
   (Episode replaces the retired Session replay anchor), and
   [0056](ADR-0056-retire-legacy-journal-cli-lifecycle-tools.md) (journal

--- a/framework/core/docs/adr/README.md
+++ b/framework/core/docs/adr/README.md
@@ -77,6 +77,7 @@ A record's **Status** says where it stands:
 | [0057](ADR-0057-domain-neutral-live-runtime-terminology.md) | accepted | live runtime internals use reactor, peer, and coordinator; the public command is `kungfu runtime` |
 | [0058](ADR-0058-yijinjing-explicit-mapping-policies.md) | accepted | yijinjing mmap behavior uses explicit access, creation, residency, and durability policies |
 | [0059](ADR-0059-mission-control-mission-go-responsibility-model.md) | accepted | Mission Control composes Mission and Go responsibility over runtime facts; Atlas starts as a bridged authority |
+| [0060](ADR-0060-desktop-workspace-selection-and-lazy-data-home.md) | proposed | Desktop selects and remembers one workspace while creating its `.kungfu` data home only on write intent |
 
 ## Reading by theme
 
@@ -187,7 +188,10 @@ A record's **Status** says where it stands:
   equivalent process/thread executors), and
   [0059](ADR-0059-mission-control-mission-go-responsibility-model.md) (the
   Mission/Go responsibility domain, Atlas bridge authority, and Cost/State/Proof
-  profile composition), and
+  profile composition),
+  [0060](ADR-0060-desktop-workspace-selection-and-lazy-data-home.md) (Desktop
+  workspace selection, global recent-workspace state, and write-intent-bound
+  `.kungfu` initialization), and
   [0055](ADR-0055-retire-journal-session-and-separate-runtime-state-from-projection.md)
   (Episode replaces the retired Session replay anchor), and
   [0056](ADR-0056-retire-legacy-journal-cli-lifecycle-tools.md) (journal

--- a/framework/core/docs/adr/README.md
+++ b/framework/core/docs/adr/README.md
@@ -77,7 +77,7 @@ A record's **Status** says where it stands:
 | [0057](ADR-0057-domain-neutral-live-runtime-terminology.md) | accepted | live runtime internals use reactor, peer, and coordinator; the public command is `kungfu runtime` |
 | [0058](ADR-0058-yijinjing-explicit-mapping-policies.md) | accepted | yijinjing mmap behavior uses explicit access, creation, residency, and durability policies |
 | [0059](ADR-0059-mission-control-mission-go-responsibility-model.md) | accepted | Mission Control composes Mission and Go responsibility over runtime facts; Atlas starts as a bridged authority |
-| [0060](ADR-0060-desktop-workspace-selection-and-lazy-data-home.md) | proposed | Desktop selects and remembers one workspace while creating its `.kungfu` data home only on write intent |
+| [0060](ADR-0060-desktop-workspace-selection-and-lazy-data-home.md) | proposed | Desktop selects a Personal or project workspace and creates its data home only on write intent |
 
 ## Reading by theme
 
@@ -190,8 +190,9 @@ A record's **Status** says where it stands:
   Mission/Go responsibility domain, Atlas bridge authority, and Cost/State/Proof
   profile composition),
   [0060](ADR-0060-desktop-workspace-selection-and-lazy-data-home.md) (Desktop
-  workspace selection, global recent-workspace state, and write-intent-bound
-  `.kungfu` initialization), and
+  Personal/project workspace selection, global recent-workspace state,
+  first-run Agent Work Inbox, and write-intent-bound data-home initialization),
+  and
   [0055](ADR-0055-retire-journal-session-and-separate-runtime-state-from-projection.md)
   (Episode replaces the retired Session replay anchor), and
   [0056](ADR-0056-retire-legacy-journal-cli-lifecycle-tools.md) (journal


### PR DESCRIPTION
## Summary
- define Desktop Open Workspace, recents, cold-start restore, and lazy `.kungfu` initialization
- separate workspace facts, global config/session state, machine fallback, and explicit personal workspace semantics
- redesign Work Dashboard as a five-question Mission Home with compact authoring actions
- confirm Saved Query Catalog remains workspace-scoped and define Atlas dogfood behavior
- add ADR-0060 plus eight implementation slices and falsifiable product gates

## Validation
- `git diff --check`
- `./shifu check`
- ADR identity/index gate passed

## Scope
Design and architecture only. This PR does not claim that Open Workspace or the redesigned Mission Home is implemented.