### PR TITLE
fix(core): suppress Windows minmax macros in mmap

### DIFF
--- a/framework/core/src/libyijinjing/src/util/mmap.cpp
+++ b/framework/core/src/libyijinjing/src/util/mmap.cpp
@@ -6,6 +6,9 @@
 
 #ifdef _WINDOWS
 #include <fcntl.h>
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
 #include <windows.h>
 #else
 


### PR DESCRIPTION
Fixes #596.

The Windows product gate includes `windows.h` before using `std::numeric_limits<LONGLONG>::max()`. Defining `NOMINMAX` at the include boundary prevents Win32 macro expansion and follows the existing repository convention.

Evidence:
- exact MSVC failure reproduced by run 29156716599
- `./shifu check` passed
- staged pre-commit gate passed

The follow-up self-hosted Windows product build will run together with the Rust/Cargo provisioning candidate.