### PR TITLE
perf(yijinjing): qualify and optimize mmap page lookup

### DIFF
--- a/framework/core/docs/adr/ADR-0058-yijinjing-explicit-mapping-policies.md
+++ b/framework/core/docs/adr/ADR-0058-yijinjing-explicit-mapping-policies.md
@@ -19,6 +19,7 @@ last_reviewed: 2026-07-11
 - Related: [ADR-0001](ADR-0001-yijinjing-publish-barrier.md),
   [ADR-0024](ADR-0024-location-role-and-journal-page-policy.md), and
   [ADR-0057](ADR-0057-domain-neutral-live-runtime-terminology.md)
+- Qualification: [mmap performance](../qualification/mmap-performance.md)
 
 ## Context
 
@@ -107,6 +108,8 @@ semantics during that period.
   latency side effect.
 - Demand paging remains the only qualified residency policy; the historical
   best-effort `mlock` path is retired.
+- The qualification harness measures the existing demand/visibility baseline
+  without granting unqualified policy requests or changing production defaults.
 - This is an internal contract refactor with compatibility adapters and has
   patch-level version impact. Qualifying residency or durability modes later
   requires new evidence and may have independent version impact.

--- a/framework/core/docs/qualification/mmap-linux-x86_64-285158703-candidate-01.json
+++ b/framework/core/docs/qualification/mmap-linux-x86_64-285158703-candidate-01.json
@@ -1,0 +1,483 @@
+{
+  "fixture": {
+    "journal_page_size_bytes": 2097152,
+    "payload_bytes": 4096,
+    "primitive_bytes": 67108864,
+    "seek_page_counts": [
+      8,
+      32,
+      128
+    ],
+    "temporary_root": true
+  },
+  "host": {
+    "compiler": "gcc",
+    "compiler_version": "13.3.0",
+    "cpp_standard": 202100,
+    "hardware_threads": 32,
+    "machine": "x86_64",
+    "os": "Linux",
+    "os_page_size": 4096,
+    "os_release": "6.8.0-134-generic",
+    "pointer_bits": 64
+  },
+  "journal": [
+    {
+      "frames_written": 3585,
+      "page_count": 8,
+      "seek": {
+        "iterations_per_position": 80,
+        "page_count": 8,
+        "positions": {
+          "early": {
+            "latency": {
+              "count": 80,
+              "max_ns": 119166,
+              "mean_ns": 38852,
+              "min_ns": 37070,
+              "p50_ns": 37699,
+              "p95_ns": 39146,
+              "p99_ns": 119166
+            },
+            "resources": {
+              "available": true,
+              "major_faults": 0,
+              "mapped_region_count_available": true,
+              "mapped_regions_after": 40,
+              "mapped_regions_before": 40,
+              "max_rss_kib_after": 73216,
+              "max_rss_kib_before": 73216,
+              "minor_faults": 481,
+              "system_us": 1925,
+              "user_us": 1969
+            },
+            "target_page": 1
+          },
+          "late": {
+            "latency": {
+              "count": 80,
+              "max_ns": 40867,
+              "mean_ns": 23171,
+              "min_ns": 22366,
+              "p50_ns": 22662,
+              "p95_ns": 25184,
+              "p99_ns": 40867
+            },
+            "resources": {
+              "available": true,
+              "major_faults": 0,
+              "mapped_region_count_available": true,
+              "mapped_regions_after": 40,
+              "mapped_regions_before": 40,
+              "max_rss_kib_after": 73216,
+              "max_rss_kib_before": 73216,
+              "minor_faults": 242,
+              "system_us": 1133,
+              "user_us": 1030
+            },
+            "target_page": 8
+          },
+          "middle": {
+            "latency": {
+              "count": 80,
+              "max_ns": 40908,
+              "mean_ns": 37906,
+              "min_ns": 36997,
+              "p50_ns": 37672,
+              "p95_ns": 39192,
+              "p99_ns": 40908
+            },
+            "resources": {
+              "available": true,
+              "major_faults": 0,
+              "mapped_region_count_available": true,
+              "mapped_regions_after": 40,
+              "mapped_regions_before": 40,
+              "max_rss_kib_after": 73216,
+              "max_rss_kib_before": 73216,
+              "minor_faults": 480,
+              "system_us": 1432,
+              "user_us": 1916
+            },
+            "target_page": 4
+          }
+        }
+      },
+      "sequential_read": {
+        "data_frames_observed": 3585,
+        "estimated_payload_mib_per_second": 4054.668980850797,
+        "frames_observed": 3592,
+        "page_switch": {
+          "count": 7,
+          "max_ns": 140859,
+          "mean_ns": 131910,
+          "min_ns": 124961,
+          "p50_ns": 132981,
+          "p95_ns": 140859,
+          "p99_ns": 140859
+        },
+        "payload_bytes_observed": 14684160,
+        "resources": {
+          "available": true,
+          "major_faults": 0,
+          "mapped_region_count_available": true,
+          "mapped_regions_after": 41,
+          "mapped_regions_before": 40,
+          "max_rss_kib_after": 73216,
+          "max_rss_kib_before": 73216,
+          "minor_faults": 232,
+          "system_us": 1032,
+          "user_us": 3026
+        },
+        "total_ns": 3453773
+      },
+      "write_page_switch": {
+        "count": 7,
+        "max_ns": 344397,
+        "mean_ns": 194611,
+        "min_ns": 73809,
+        "p50_ns": 205320,
+        "p95_ns": 344397,
+        "p99_ns": 344397
+      },
+      "write_payload_mib_per_second": 726.6470075267933,
+      "write_resources": {
+        "available": true,
+        "major_faults": 7,
+        "mapped_region_count_available": true,
+        "mapped_regions_after": 41,
+        "mapped_regions_before": 41,
+        "max_rss_kib_after": 73216,
+        "max_rss_kib_before": 73216,
+        "minor_faults": 3651,
+        "system_us": 17898,
+        "user_us": 2131
+      }
+    },
+    {
+      "frames_written": 15657,
+      "page_count": 32,
+      "seek": {
+        "iterations_per_position": 80,
+        "page_count": 32,
+        "positions": {
+          "early": {
+            "latency": {
+              "count": 80,
+              "max_ns": 204210,
+              "mean_ns": 103188,
+              "min_ns": 65623,
+              "p50_ns": 91156,
+              "p95_ns": 168673,
+              "p99_ns": 204210
+            },
+            "resources": {
+              "available": true,
+              "major_faults": 0,
+              "mapped_region_count_available": true,
+              "mapped_regions_after": 40,
+              "mapped_regions_before": 40,
+              "max_rss_kib_after": 73216,
+              "max_rss_kib_before": 73216,
+              "minor_faults": 640,
+              "system_us": 869,
+              "user_us": 8011
+            },
+            "target_page": 1
+          },
+          "late": {
+            "latency": {
+              "count": 80,
+              "max_ns": 101460,
+              "mean_ns": 42450,
+              "min_ns": 40651,
+              "p50_ns": 41632,
+              "p95_ns": 42689,
+              "p99_ns": 101460
+            },
+            "resources": {
+              "available": true,
+              "major_faults": 0,
+              "mapped_region_count_available": true,
+              "mapped_regions_after": 40,
+              "mapped_regions_before": 40,
+              "max_rss_kib_after": 73216,
+              "max_rss_kib_before": 73216,
+              "minor_faults": 241,
+              "system_us": 0,
+              "user_us": 3660
+            },
+            "target_page": 32
+          },
+          "middle": {
+            "latency": {
+              "count": 80,
+              "max_ns": 121606,
+              "mean_ns": 67632,
+              "min_ns": 65344,
+              "p50_ns": 66424,
+              "p95_ns": 68886,
+              "p99_ns": 121606
+            },
+            "resources": {
+              "available": true,
+              "major_faults": 0,
+              "mapped_region_count_available": true,
+              "mapped_regions_after": 40,
+              "mapped_regions_before": 40,
+              "max_rss_kib_after": 73216,
+              "max_rss_kib_before": 73216,
+              "minor_faults": 640,
+              "system_us": 727,
+              "user_us": 4957
+            },
+            "target_page": 16
+          }
+        }
+      },
+      "sequential_read": {
+        "data_frames_observed": 15657,
+        "estimated_payload_mib_per_second": 4716.231873765087,
+        "frames_observed": 15688,
+        "page_switch": {
+          "count": 31,
+          "max_ns": 143017,
+          "mean_ns": 112325,
+          "min_ns": 73183,
+          "p50_ns": 115535,
+          "p95_ns": 137164,
+          "p99_ns": 143017
+        },
+        "payload_bytes_observed": 64131072,
+        "resources": {
+          "available": true,
+          "major_faults": 0,
+          "mapped_region_count_available": true,
+          "mapped_regions_after": 41,
+          "mapped_regions_before": 40,
+          "max_rss_kib_after": 73216,
+          "max_rss_kib_before": 73216,
+          "minor_faults": 998,
+          "system_us": 8646,
+          "user_us": 4938
+        },
+        "total_ns": 12968013
+      },
+      "write_page_switch": {
+        "count": 31,
+        "max_ns": 144079,
+        "mean_ns": 64785,
+        "min_ns": 55303,
+        "p50_ns": 57183,
+        "p95_ns": 108955,
+        "p99_ns": 144079
+      },
+      "write_payload_mib_per_second": 2167.8414812146702,
+      "write_resources": {
+        "available": true,
+        "major_faults": 31,
+        "mapped_region_count_available": true,
+        "mapped_regions_after": 41,
+        "mapped_regions_before": 41,
+        "max_rss_kib_after": 73216,
+        "max_rss_kib_before": 73216,
+        "minor_faults": 15939,
+        "system_us": 20344,
+        "user_us": 7907
+      }
+    },
+    {
+      "frames_written": 63945,
+      "page_count": 128,
+      "seek": {
+        "iterations_per_position": 80,
+        "page_count": 128,
+        "positions": {
+          "early": {
+            "latency": {
+              "count": 80,
+              "max_ns": 189907,
+              "mean_ns": 155473,
+              "min_ns": 150374,
+              "p50_ns": 154384,
+              "p95_ns": 161370,
+              "p99_ns": 189907
+            },
+            "resources": {
+              "available": true,
+              "major_faults": 0,
+              "mapped_region_count_available": true,
+              "mapped_regions_after": 40,
+              "mapped_regions_before": 40,
+              "max_rss_kib_after": 73216,
+              "max_rss_kib_before": 73216,
+              "minor_faults": 800,
+              "system_us": 2882,
+              "user_us": 9835
+            },
+            "target_page": 1
+          },
+          "late": {
+            "latency": {
+              "count": 80,
+              "max_ns": 167694,
+              "mean_ns": 120698,
+              "min_ns": 116526,
+              "p50_ns": 118963,
+              "p95_ns": 124586,
+              "p99_ns": 167694
+            },
+            "resources": {
+              "available": true,
+              "major_faults": 0,
+              "mapped_region_count_available": true,
+              "mapped_regions_after": 40,
+              "mapped_regions_before": 40,
+              "max_rss_kib_after": 73216,
+              "max_rss_kib_before": 73216,
+              "minor_faults": 241,
+              "system_us": 0,
+              "user_us": 9886
+            },
+            "target_page": 128
+          },
+          "middle": {
+            "latency": {
+              "count": 80,
+              "max_ns": 189522,
+              "mean_ns": 155063,
+              "min_ns": 151604,
+              "p50_ns": 153464,
+              "p95_ns": 159146,
+              "p99_ns": 189522
+            },
+            "resources": {
+              "available": true,
+              "major_faults": 0,
+              "mapped_region_count_available": true,
+              "mapped_regions_after": 40,
+              "mapped_regions_before": 40,
+              "max_rss_kib_after": 73216,
+              "max_rss_kib_before": 73216,
+              "minor_faults": 800,
+              "system_us": 3821,
+              "user_us": 8817
+            },
+            "target_page": 64
+          }
+        }
+      },
+      "sequential_read": {
+        "data_frames_observed": 63945,
+        "estimated_payload_mib_per_second": 9575.402138078987,
+        "frames_observed": 64072,
+        "page_switch": {
+          "count": 127,
+          "max_ns": 144249,
+          "mean_ns": 47825,
+          "min_ns": 24554,
+          "p50_ns": 30748,
+          "p95_ns": 130152,
+          "p99_ns": 133857
+        },
+        "payload_bytes_observed": 261918720,
+        "resources": {
+          "available": true,
+          "major_faults": 0,
+          "mapped_region_count_available": true,
+          "mapped_regions_after": 41,
+          "mapped_regions_before": 40,
+          "max_rss_kib_after": 73216,
+          "max_rss_kib_before": 73216,
+          "minor_faults": 4071,
+          "system_us": 14493,
+          "user_us": 12166
+        },
+        "total_ns": 26086127
+      },
+      "write_page_switch": {
+        "count": 127,
+        "max_ns": 145087,
+        "mean_ns": 66108,
+        "min_ns": 55291,
+        "p50_ns": 58297,
+        "p95_ns": 101861,
+        "p99_ns": 140716
+      },
+      "write_payload_mib_per_second": 2191.4528003026735,
+      "write_resources": {
+        "available": true,
+        "major_faults": 127,
+        "mapped_region_count_available": true,
+        "mapped_regions_after": 41,
+        "mapped_regions_before": 41,
+        "max_rss_kib_after": 73216,
+        "max_rss_kib_before": 73216,
+        "minor_faults": 65089,
+        "system_us": 92988,
+        "user_us": 21114
+      }
+    }
+  ],
+  "primitive_mapping": {
+    "fixture_bytes": 67108864,
+    "full_mapping_visibility_flush_ns": 391086023,
+    "iterations": 80,
+    "mapping_open": {
+      "count": 80,
+      "max_ns": 52789,
+      "mean_ns": 3762,
+      "min_ns": 2421,
+      "p50_ns": 2981,
+      "p95_ns": 4781,
+      "p99_ns": 52789
+    },
+    "mapping_read_resources": {
+      "available": true,
+      "major_faults": 0,
+      "mapped_region_count_available": true,
+      "mapped_regions_after": 40,
+      "mapped_regions_before": 40,
+      "max_rss_kib_after": 73216,
+      "max_rss_kib_before": 72960,
+      "minor_faults": 81924,
+      "system_us": 118171,
+      "user_us": 28215
+    },
+    "os_page_cache_cold": "not_measured",
+    "process_first_touch": {
+      "count": 80,
+      "max_ns": 3642324,
+      "mean_ns": 1361611,
+      "min_ns": 1300733,
+      "p50_ns": 1326620,
+      "p95_ns": 1390835,
+      "p99_ns": 3642324
+    },
+    "sequential_write_mib_per_second": 4232.462724568521,
+    "sequential_write_ns": 15121220,
+    "write_and_flush_resources": {
+      "available": true,
+      "major_faults": 0,
+      "mapped_region_count_available": true,
+      "mapped_regions_after": 41,
+      "mapped_regions_before": 41,
+      "max_rss_kib_after": 73216,
+      "max_rss_kib_before": 73216,
+      "minor_faults": 16384,
+      "system_us": 43749,
+      "user_us": 1913
+    }
+  },
+  "profile": "baseline",
+  "schema": "kungfu.mmap-qualification.v1",
+  "semantic_limits": {
+    "mapping_policy": "demand+visibility",
+    "os_page_cache_cold": "not_measured",
+    "power_loss_durability": "not_claimed"
+  },
+  "source": {
+    "git_dirty": "false",
+    "git_head": "285158703c4494f8a998a6181ad6f3dbbb1b2d35"
+  }
+}

--- a/framework/core/docs/qualification/mmap-linux-x86_64-bc3dcb7d2-baseline-01.json
+++ b/framework/core/docs/qualification/mmap-linux-x86_64-bc3dcb7d2-baseline-01.json
@@ -1,0 +1,483 @@
+{
+  "fixture": {
+    "journal_page_size_bytes": 2097152,
+    "payload_bytes": 4096,
+    "primitive_bytes": 67108864,
+    "seek_page_counts": [
+      8,
+      32,
+      128
+    ],
+    "temporary_root": true
+  },
+  "host": {
+    "compiler": "gcc",
+    "compiler_version": "13.3.0",
+    "cpp_standard": 202100,
+    "hardware_threads": 32,
+    "machine": "x86_64",
+    "os": "Linux",
+    "os_page_size": 4096,
+    "os_release": "6.8.0-134-generic",
+    "pointer_bits": 64
+  },
+  "journal": [
+    {
+      "frames_written": 3585,
+      "page_count": 8,
+      "seek": {
+        "iterations_per_position": 80,
+        "page_count": 8,
+        "positions": {
+          "early": {
+            "latency": {
+              "count": 80,
+              "max_ns": 70428,
+              "mean_ns": 60823,
+              "min_ns": 59231,
+              "p50_ns": 60503,
+              "p95_ns": 63040,
+              "p99_ns": 70428
+            },
+            "resources": {
+              "available": true,
+              "major_faults": 0,
+              "mapped_region_count_available": true,
+              "mapped_regions_after": 40,
+              "mapped_regions_before": 40,
+              "max_rss_kib_after": 72888,
+              "max_rss_kib_before": 72888,
+              "minor_faults": 801,
+              "system_us": 1192,
+              "user_us": 3999
+            },
+            "target_page": 1
+          },
+          "late": {
+            "latency": {
+              "count": 80,
+              "max_ns": 165093,
+              "mean_ns": 25686,
+              "min_ns": 23508,
+              "p50_ns": 23825,
+              "p95_ns": 24564,
+              "p99_ns": 165093
+            },
+            "resources": {
+              "available": true,
+              "major_faults": 0,
+              "mapped_region_count_available": true,
+              "mapped_regions_after": 40,
+              "mapped_regions_before": 40,
+              "max_rss_kib_after": 72888,
+              "max_rss_kib_before": 72888,
+              "minor_faults": 242,
+              "system_us": 408,
+              "user_us": 1847
+            },
+            "target_page": 8
+          },
+          "middle": {
+            "latency": {
+              "count": 80,
+              "max_ns": 48797,
+              "mean_ns": 44829,
+              "min_ns": 43666,
+              "p50_ns": 44674,
+              "p95_ns": 47128,
+              "p99_ns": 48797
+            },
+            "resources": {
+              "available": true,
+              "major_faults": 0,
+              "mapped_region_count_available": true,
+              "mapped_regions_after": 40,
+              "mapped_regions_before": 40,
+              "max_rss_kib_after": 72888,
+              "max_rss_kib_before": 72888,
+              "minor_faults": 560,
+              "system_us": 1937,
+              "user_us": 1971
+            },
+            "target_page": 4
+          }
+        }
+      },
+      "sequential_read": {
+        "data_frames_observed": 3585,
+        "estimated_payload_mib_per_second": 12299.945587922715,
+        "frames_observed": 3592,
+        "page_switch": {
+          "count": 7,
+          "max_ns": 29734,
+          "mean_ns": 26369,
+          "min_ns": 25032,
+          "p50_ns": 25859,
+          "p95_ns": 29734,
+          "p99_ns": 29734
+        },
+        "payload_bytes_observed": 14684160,
+        "resources": {
+          "available": true,
+          "major_faults": 0,
+          "mapped_region_count_available": true,
+          "mapped_regions_after": 41,
+          "mapped_regions_before": 40,
+          "max_rss_kib_after": 72888,
+          "max_rss_kib_before": 72888,
+          "minor_faults": 232,
+          "system_us": 605,
+          "user_us": 652
+        },
+        "total_ns": 1138534
+      },
+      "write_page_switch": {
+        "count": 7,
+        "max_ns": 74135,
+        "mean_ns": 67789,
+        "min_ns": 63441,
+        "p50_ns": 67621,
+        "p95_ns": 74135,
+        "p99_ns": 74135
+      },
+      "write_payload_mib_per_second": 2199.7356105555973,
+      "write_resources": {
+        "available": true,
+        "major_faults": 7,
+        "mapped_region_count_available": true,
+        "mapped_regions_after": 41,
+        "mapped_regions_before": 41,
+        "max_rss_kib_after": 72888,
+        "max_rss_kib_before": 72888,
+        "minor_faults": 3652,
+        "system_us": 4669,
+        "user_us": 1924
+      }
+    },
+    {
+      "frames_written": 15657,
+      "page_count": 32,
+      "seek": {
+        "iterations_per_position": 80,
+        "page_count": 32,
+        "positions": {
+          "early": {
+            "latency": {
+              "count": 80,
+              "max_ns": 470745,
+              "mean_ns": 212399,
+              "min_ns": 203260,
+              "p50_ns": 206236,
+              "p95_ns": 222658,
+              "p99_ns": 470745
+            },
+            "resources": {
+              "available": true,
+              "major_faults": 0,
+              "mapped_region_count_available": true,
+              "mapped_regions_after": 40,
+              "mapped_regions_before": 40,
+              "max_rss_kib_after": 72888,
+              "max_rss_kib_before": 72888,
+              "minor_faults": 2720,
+              "system_us": 1491,
+              "user_us": 15662
+            },
+            "target_page": 1
+          },
+          "late": {
+            "latency": {
+              "count": 80,
+              "max_ns": 62623,
+              "mean_ns": 46910,
+              "min_ns": 43148,
+              "p50_ns": 44599,
+              "p95_ns": 58089,
+              "p99_ns": 62623
+            },
+            "resources": {
+              "available": true,
+              "major_faults": 0,
+              "mapped_region_count_available": true,
+              "mapped_regions_after": 40,
+              "mapped_regions_before": 40,
+              "max_rss_kib_after": 72888,
+              "max_rss_kib_before": 72888,
+              "minor_faults": 241,
+              "system_us": 2079,
+              "user_us": 2016
+            },
+            "target_page": 32
+          },
+          "middle": {
+            "latency": {
+              "count": 80,
+              "max_ns": 232256,
+              "mean_ns": 135515,
+              "min_ns": 125895,
+              "p50_ns": 127812,
+              "p95_ns": 162764,
+              "p99_ns": 232256
+            },
+            "resources": {
+              "available": true,
+              "major_faults": 0,
+              "mapped_region_count_available": true,
+              "mapped_regions_after": 40,
+              "mapped_regions_before": 40,
+              "max_rss_kib_after": 72888,
+              "max_rss_kib_before": 72888,
+              "minor_faults": 1520,
+              "system_us": 7100,
+              "user_us": 4019
+            },
+            "target_page": 16
+          }
+        }
+      },
+      "sequential_read": {
+        "data_frames_observed": 15657,
+        "estimated_payload_mib_per_second": 11321.652633110529,
+        "frames_observed": 15688,
+        "page_switch": {
+          "count": 31,
+          "max_ns": 28331,
+          "mean_ns": 26365,
+          "min_ns": 24410,
+          "p50_ns": 26357,
+          "p95_ns": 27842,
+          "p99_ns": 28331
+        },
+        "payload_bytes_observed": 64131072,
+        "resources": {
+          "available": true,
+          "major_faults": 0,
+          "mapped_region_count_available": true,
+          "mapped_regions_after": 41,
+          "mapped_regions_before": 40,
+          "max_rss_kib_after": 72888,
+          "max_rss_kib_before": 72888,
+          "minor_faults": 998,
+          "system_us": 2856,
+          "user_us": 2665
+        },
+        "total_ns": 5402052
+      },
+      "write_page_switch": {
+        "count": 31,
+        "max_ns": 155157,
+        "mean_ns": 69101,
+        "min_ns": 63274,
+        "p50_ns": 66116,
+        "p95_ns": 70619,
+        "p99_ns": 155157
+      },
+      "write_payload_mib_per_second": 2200.6417484564963,
+      "write_resources": {
+        "available": true,
+        "major_faults": 31,
+        "mapped_region_count_available": true,
+        "mapped_regions_after": 41,
+        "mapped_regions_before": 41,
+        "max_rss_kib_after": 72888,
+        "max_rss_kib_before": 72888,
+        "minor_faults": 15939,
+        "system_us": 15950,
+        "user_us": 11904
+      }
+    },
+    {
+      "frames_written": 63945,
+      "page_count": 128,
+      "seek": {
+        "iterations_per_position": 80,
+        "page_count": 128,
+        "positions": {
+          "early": {
+            "latency": {
+              "count": 80,
+              "max_ns": 1004383,
+              "mean_ns": 808649,
+              "min_ns": 779304,
+              "p50_ns": 787612,
+              "p95_ns": 903506,
+              "p99_ns": 1004383
+            },
+            "resources": {
+              "available": true,
+              "major_faults": 0,
+              "mapped_region_count_available": true,
+              "mapped_regions_after": 40,
+              "mapped_regions_before": 40,
+              "max_rss_kib_after": 72888,
+              "max_rss_kib_before": 72888,
+              "minor_faults": 10401,
+              "system_us": 27237,
+              "user_us": 36505
+            },
+            "target_page": 1
+          },
+          "late": {
+            "latency": {
+              "count": 80,
+              "max_ns": 169476,
+              "mean_ns": 128525,
+              "min_ns": 121882,
+              "p50_ns": 126649,
+              "p95_ns": 137520,
+              "p99_ns": 169476
+            },
+            "resources": {
+              "available": true,
+              "major_faults": 0,
+              "mapped_region_count_available": true,
+              "mapped_regions_after": 40,
+              "mapped_regions_before": 40,
+              "max_rss_kib_after": 72888,
+              "max_rss_kib_before": 72888,
+              "minor_faults": 241,
+              "system_us": 0,
+              "user_us": 10621
+            },
+            "target_page": 128
+          },
+          "middle": {
+            "latency": {
+              "count": 80,
+              "max_ns": 664214,
+              "mean_ns": 468804,
+              "min_ns": 453364,
+              "p50_ns": 459683,
+              "p95_ns": 508350,
+              "p99_ns": 664214
+            },
+            "resources": {
+              "available": true,
+              "major_faults": 0,
+              "mapped_region_count_available": true,
+              "mapped_regions_after": 40,
+              "mapped_regions_before": 40,
+              "max_rss_kib_after": 72888,
+              "max_rss_kib_before": 72888,
+              "minor_faults": 5362,
+              "system_us": 10796,
+              "user_us": 26726
+            },
+            "target_page": 64
+          }
+        }
+      },
+      "sequential_read": {
+        "data_frames_observed": 63945,
+        "estimated_payload_mib_per_second": 16041.04415357496,
+        "frames_observed": 64072,
+        "page_switch": {
+          "count": 127,
+          "max_ns": 30742,
+          "mean_ns": 25935,
+          "min_ns": 24679,
+          "p50_ns": 25871,
+          "p95_ns": 27019,
+          "p99_ns": 28375
+        },
+        "payload_bytes_observed": 261918720,
+        "resources": {
+          "available": true,
+          "major_faults": 0,
+          "mapped_region_count_available": true,
+          "mapped_regions_after": 41,
+          "mapped_regions_before": 40,
+          "max_rss_kib_after": 72888,
+          "max_rss_kib_before": 72888,
+          "minor_faults": 4070,
+          "system_us": 10770,
+          "user_us": 4912
+        },
+        "total_ns": 15571627
+      },
+      "write_page_switch": {
+        "count": 127,
+        "max_ns": 141999,
+        "mean_ns": 71522,
+        "min_ns": 57667,
+        "p50_ns": 65816,
+        "p95_ns": 108106,
+        "p99_ns": 119619
+      },
+      "write_payload_mib_per_second": 2146.7829512649078,
+      "write_resources": {
+        "available": true,
+        "major_faults": 127,
+        "mapped_region_count_available": true,
+        "mapped_regions_after": 41,
+        "mapped_regions_before": 41,
+        "max_rss_kib_after": 72888,
+        "max_rss_kib_before": 72888,
+        "minor_faults": 65089,
+        "system_us": 90921,
+        "user_us": 25671
+      }
+    }
+  ],
+  "primitive_mapping": {
+    "fixture_bytes": 67108864,
+    "full_mapping_visibility_flush_ns": 408348007,
+    "iterations": 80,
+    "mapping_open": {
+      "count": 80,
+      "max_ns": 14857,
+      "mean_ns": 2902,
+      "min_ns": 1944,
+      "p50_ns": 2396,
+      "p95_ns": 3654,
+      "p99_ns": 14857
+    },
+    "mapping_read_resources": {
+      "available": true,
+      "major_faults": 0,
+      "mapped_region_count_available": true,
+      "mapped_regions_after": 40,
+      "mapped_regions_before": 40,
+      "max_rss_kib_after": 72888,
+      "max_rss_kib_before": 72704,
+      "minor_faults": 81924,
+      "system_us": 112104,
+      "user_us": 24978
+    },
+    "os_page_cache_cold": "not_measured",
+    "process_first_touch": {
+      "count": 80,
+      "max_ns": 1600199,
+      "mean_ns": 1306444,
+      "min_ns": 1264158,
+      "p50_ns": 1295585,
+      "p95_ns": 1371508,
+      "p99_ns": 1600199
+    },
+    "sequential_write_mib_per_second": 3954.629279766232,
+    "sequential_write_ns": 16183565,
+    "write_and_flush_resources": {
+      "available": true,
+      "major_faults": 0,
+      "mapped_region_count_available": true,
+      "mapped_regions_after": 41,
+      "mapped_regions_before": 41,
+      "max_rss_kib_after": 72888,
+      "max_rss_kib_before": 72888,
+      "minor_faults": 16384,
+      "system_us": 21886,
+      "user_us": 2796
+    }
+  },
+  "profile": "baseline",
+  "schema": "kungfu.mmap-qualification.v1",
+  "semantic_limits": {
+    "mapping_policy": "demand+visibility",
+    "os_page_cache_cold": "not_measured",
+    "power_loss_durability": "not_claimed"
+  },
+  "source": {
+    "git_dirty": "false",
+    "git_head": "bc3dcb7d2976dadb9651b9e4ad115257720d9d75"
+  }
+}

--- a/framework/core/docs/qualification/mmap-macos-arm64-4a36ae5ea-candidate-01.json
+++ b/framework/core/docs/qualification/mmap-macos-arm64-4a36ae5ea-candidate-01.json
@@ -1,0 +1,484 @@
+{
+  "fixture": {
+    "journal_page_size_bytes": 2097152,
+    "payload_bytes": 4096,
+    "primitive_bytes": 67108864,
+    "seek_page_counts": [
+      8,
+      32,
+      128
+    ],
+    "temporary_root": true
+  },
+  "host": {
+    "compiler": "clang",
+    "compiler_version": "21.0.0 (clang-2100.1.1.101)",
+    "cpp_standard": 202302,
+    "hardware_model": "Mac13,2",
+    "hardware_threads": 20,
+    "machine": "arm64",
+    "os": "Darwin",
+    "os_page_size": 16384,
+    "os_release": "25.5.0",
+    "pointer_bits": 64
+  },
+  "journal": [
+    {
+      "frames_written": 3585,
+      "page_count": 8,
+      "seek": {
+        "iterations_per_position": 80,
+        "page_count": 8,
+        "positions": {
+          "early": {
+            "latency": {
+              "count": 80,
+              "max_ns": 340209,
+              "mean_ns": 159898,
+              "min_ns": 126125,
+              "p50_ns": 153000,
+              "p95_ns": 210125,
+              "p99_ns": 340209
+            },
+            "resources": {
+              "available": true,
+              "major_faults": 0,
+              "mapped_region_count_available": false,
+              "mapped_regions_after": 0,
+              "mapped_regions_before": 0,
+              "max_rss_kib_after": 70496,
+              "max_rss_kib_before": 70496,
+              "minor_faults": 490,
+              "system_us": 11593,
+              "user_us": 1716
+            },
+            "target_page": 1
+          },
+          "late": {
+            "latency": {
+              "count": 80,
+              "max_ns": 96167,
+              "mean_ns": 76735,
+              "min_ns": 66125,
+              "p50_ns": 76917,
+              "p95_ns": 87584,
+              "p99_ns": 96167
+            },
+            "resources": {
+              "available": true,
+              "major_faults": 0,
+              "mapped_region_count_available": false,
+              "mapped_regions_after": 0,
+              "mapped_regions_before": 0,
+              "max_rss_kib_after": 70496,
+              "max_rss_kib_before": 70496,
+              "minor_faults": 240,
+              "system_us": 5708,
+              "user_us": 925
+            },
+            "target_page": 8
+          },
+          "middle": {
+            "latency": {
+              "count": 80,
+              "max_ns": 335000,
+              "mean_ns": 161258,
+              "min_ns": 134458,
+              "p50_ns": 151167,
+              "p95_ns": 207250,
+              "p99_ns": 335000
+            },
+            "resources": {
+              "available": true,
+              "major_faults": 0,
+              "mapped_region_count_available": false,
+              "mapped_regions_after": 0,
+              "mapped_regions_before": 0,
+              "max_rss_kib_after": 70496,
+              "max_rss_kib_before": 70496,
+              "minor_faults": 480,
+              "system_us": 11667,
+              "user_us": 1693
+            },
+            "target_page": 4
+          }
+        }
+      },
+      "sequential_read": {
+        "data_frames_observed": 3585,
+        "estimated_payload_mib_per_second": 7178.574778859048,
+        "frames_observed": 3592,
+        "page_switch": {
+          "count": 7,
+          "max_ns": 69209,
+          "mean_ns": 46429,
+          "min_ns": 35709,
+          "p50_ns": 43042,
+          "p95_ns": 69209,
+          "p99_ns": 69209
+        },
+        "payload_bytes_observed": 14684160,
+        "resources": {
+          "available": true,
+          "major_faults": 0,
+          "mapped_region_count_available": false,
+          "mapped_regions_after": 0,
+          "mapped_regions_before": 0,
+          "max_rss_kib_after": 70496,
+          "max_rss_kib_before": 70496,
+          "minor_faults": 918,
+          "system_us": 1064,
+          "user_us": 878
+        },
+        "total_ns": 1950792
+      },
+      "write_page_switch": {
+        "count": 7,
+        "max_ns": 405958,
+        "mean_ns": 228500,
+        "min_ns": 157792,
+        "p50_ns": 169375,
+        "p95_ns": 405958,
+        "p99_ns": 405958
+      },
+      "write_payload_mib_per_second": 2998.374103415052,
+      "write_resources": {
+        "available": true,
+        "major_faults": 912,
+        "mapped_region_count_available": false,
+        "mapped_regions_after": 0,
+        "mapped_regions_before": 0,
+        "max_rss_kib_after": 70496,
+        "max_rss_kib_before": 70496,
+        "minor_faults": 9,
+        "system_us": 3356,
+        "user_us": 1301
+      }
+    },
+    {
+      "frames_written": 15657,
+      "page_count": 32,
+      "seek": {
+        "iterations_per_position": 80,
+        "page_count": 32,
+        "positions": {
+          "early": {
+            "latency": {
+              "count": 80,
+              "max_ns": 425292,
+              "mean_ns": 237048,
+              "min_ns": 191000,
+              "p50_ns": 231375,
+              "p95_ns": 304000,
+              "p99_ns": 425292
+            },
+            "resources": {
+              "available": true,
+              "major_faults": 0,
+              "mapped_region_count_available": false,
+              "mapped_regions_after": 0,
+              "mapped_regions_before": 0,
+              "max_rss_kib_after": 70496,
+              "max_rss_kib_before": 70496,
+              "minor_faults": 641,
+              "system_us": 16538,
+              "user_us": 2973
+            },
+            "target_page": 1
+          },
+          "late": {
+            "latency": {
+              "count": 80,
+              "max_ns": 114834,
+              "mean_ns": 89592,
+              "min_ns": 82416,
+              "p50_ns": 88125,
+              "p95_ns": 99958,
+              "p99_ns": 114834
+            },
+            "resources": {
+              "available": true,
+              "major_faults": 0,
+              "mapped_region_count_available": false,
+              "mapped_regions_after": 0,
+              "mapped_regions_before": 0,
+              "max_rss_kib_after": 70496,
+              "max_rss_kib_before": 70496,
+              "minor_faults": 242,
+              "system_us": 5916,
+              "user_us": 1749
+            },
+            "target_page": 32
+          },
+          "middle": {
+            "latency": {
+              "count": 80,
+              "max_ns": 1165792,
+              "mean_ns": 235623,
+              "min_ns": 178625,
+              "p50_ns": 213334,
+              "p95_ns": 378792,
+              "p99_ns": 1165792
+            },
+            "resources": {
+              "available": true,
+              "major_faults": 0,
+              "mapped_region_count_available": false,
+              "mapped_regions_after": 0,
+              "mapped_regions_before": 0,
+              "max_rss_kib_after": 70496,
+              "max_rss_kib_before": 70496,
+              "minor_faults": 640,
+              "system_us": 15606,
+              "user_us": 2780
+            },
+            "target_page": 16
+          }
+        }
+      },
+      "sequential_read": {
+        "data_frames_observed": 15657,
+        "estimated_payload_mib_per_second": 8206.800684345595,
+        "frames_observed": 15688,
+        "page_switch": {
+          "count": 31,
+          "max_ns": 114084,
+          "mean_ns": 38826,
+          "min_ns": 30916,
+          "p50_ns": 36000,
+          "p95_ns": 58291,
+          "p99_ns": 114084
+        },
+        "payload_bytes_observed": 64131072,
+        "resources": {
+          "available": true,
+          "major_faults": 0,
+          "mapped_region_count_available": false,
+          "mapped_regions_after": 0,
+          "mapped_regions_before": 0,
+          "max_rss_kib_after": 70496,
+          "max_rss_kib_before": 70496,
+          "minor_faults": 3985,
+          "system_us": 3693,
+          "user_us": 3732
+        },
+        "total_ns": 7452375
+      },
+      "write_page_switch": {
+        "count": 31,
+        "max_ns": 929584,
+        "mean_ns": 242891,
+        "min_ns": 146791,
+        "p50_ns": 208709,
+        "p95_ns": 343208,
+        "p99_ns": 929584
+      },
+      "write_payload_mib_per_second": 3028.6113535496092,
+      "write_resources": {
+        "available": true,
+        "major_faults": 3984,
+        "mapped_region_count_available": false,
+        "mapped_regions_after": 0,
+        "mapped_regions_before": 0,
+        "max_rss_kib_after": 70496,
+        "max_rss_kib_before": 70496,
+        "minor_faults": 31,
+        "system_us": 13724,
+        "user_us": 5656
+      }
+    },
+    {
+      "frames_written": 63945,
+      "page_count": 128,
+      "seek": {
+        "iterations_per_position": 80,
+        "page_count": 128,
+        "positions": {
+          "early": {
+            "latency": {
+              "count": 80,
+              "max_ns": 743167,
+              "mean_ns": 464381,
+              "min_ns": 351333,
+              "p50_ns": 456458,
+              "p95_ns": 618792,
+              "p99_ns": 743167
+            },
+            "resources": {
+              "available": true,
+              "major_faults": 0,
+              "mapped_region_count_available": false,
+              "mapped_regions_after": 0,
+              "mapped_regions_before": 0,
+              "max_rss_kib_after": 70496,
+              "max_rss_kib_before": 70496,
+              "minor_faults": 802,
+              "system_us": 30219,
+              "user_us": 7151
+            },
+            "target_page": 1
+          },
+          "late": {
+            "latency": {
+              "count": 80,
+              "max_ns": 883541,
+              "mean_ns": 270718,
+              "min_ns": 169666,
+              "p50_ns": 241333,
+              "p95_ns": 416791,
+              "p99_ns": 883541
+            },
+            "resources": {
+              "available": true,
+              "major_faults": 0,
+              "mapped_region_count_available": false,
+              "mapped_regions_after": 0,
+              "mapped_regions_before": 0,
+              "max_rss_kib_after": 70496,
+              "max_rss_kib_before": 70496,
+              "minor_faults": 240,
+              "system_us": 15455,
+              "user_us": 5638
+            },
+            "target_page": 128
+          },
+          "middle": {
+            "latency": {
+              "count": 80,
+              "max_ns": 1576791,
+              "mean_ns": 463306,
+              "min_ns": 335458,
+              "p50_ns": 427167,
+              "p95_ns": 624875,
+              "p99_ns": 1576791
+            },
+            "resources": {
+              "available": true,
+              "major_faults": 0,
+              "mapped_region_count_available": false,
+              "mapped_regions_after": 0,
+              "mapped_regions_before": 0,
+              "max_rss_kib_after": 70496,
+              "max_rss_kib_before": 70496,
+              "minor_faults": 800,
+              "system_us": 29555,
+              "user_us": 7150
+            },
+            "target_page": 64
+          }
+        }
+      },
+      "sequential_read": {
+        "data_frames_observed": 63945,
+        "estimated_payload_mib_per_second": 6280.506298480067,
+        "frames_observed": 64072,
+        "page_switch": {
+          "count": 127,
+          "max_ns": 200625,
+          "mean_ns": 51815,
+          "min_ns": 33792,
+          "p50_ns": 42417,
+          "p95_ns": 126459,
+          "p99_ns": 160084
+        },
+        "payload_bytes_observed": 261918720,
+        "resources": {
+          "available": true,
+          "major_faults": 0,
+          "mapped_region_count_available": false,
+          "mapped_regions_after": 0,
+          "mapped_regions_before": 0,
+          "max_rss_kib_after": 70496,
+          "max_rss_kib_before": 70496,
+          "minor_faults": 16276,
+          "system_us": 23058,
+          "user_us": 16032
+        },
+        "total_ns": 39771500
+      },
+      "write_page_switch": {
+        "count": 127,
+        "max_ns": 1050708,
+        "mean_ns": 212824,
+        "min_ns": 136000,
+        "p50_ns": 184625,
+        "p95_ns": 372708,
+        "p99_ns": 599500
+      },
+      "write_payload_mib_per_second": 3147.429960639037,
+      "write_resources": {
+        "available": true,
+        "major_faults": 16272,
+        "mapped_region_count_available": false,
+        "mapped_regions_after": 0,
+        "mapped_regions_before": 0,
+        "max_rss_kib_after": 70496,
+        "max_rss_kib_before": 70496,
+        "minor_faults": 128,
+        "system_us": 54646,
+        "user_us": 23028
+      }
+    }
+  ],
+  "primitive_mapping": {
+    "fixture_bytes": 67108864,
+    "full_mapping_visibility_flush_ns": 19099833,
+    "iterations": 80,
+    "mapping_open": {
+      "count": 80,
+      "max_ns": 124166,
+      "mean_ns": 57661,
+      "min_ns": 26334,
+      "p50_ns": 56708,
+      "p95_ns": 82667,
+      "p99_ns": 124166
+    },
+    "mapping_read_resources": {
+      "available": true,
+      "major_faults": 0,
+      "mapped_region_count_available": false,
+      "mapped_regions_after": 0,
+      "mapped_regions_before": 0,
+      "max_rss_kib_after": 70496,
+      "max_rss_kib_before": 70448,
+      "minor_faults": 327683,
+      "system_us": 195357,
+      "user_us": 77298
+    },
+    "os_page_cache_cold": "not_measured",
+    "process_first_touch": {
+      "count": 80,
+      "max_ns": 3821416,
+      "mean_ns": 3014187,
+      "min_ns": 2114708,
+      "p50_ns": 3046208,
+      "p95_ns": 3488542,
+      "p99_ns": 3821416
+    },
+    "sequential_write_mib_per_second": 18189.140344280637,
+    "sequential_write_ns": 3518583,
+    "write_and_flush_resources": {
+      "available": true,
+      "major_faults": 0,
+      "mapped_region_count_available": false,
+      "mapped_regions_after": 0,
+      "mapped_regions_before": 0,
+      "max_rss_kib_after": 70496,
+      "max_rss_kib_before": 70496,
+      "minor_faults": 4096,
+      "system_us": 11063,
+      "user_us": 1303
+    }
+  },
+  "profile": "baseline",
+  "schema": "kungfu.mmap-qualification.v1",
+  "semantic_limits": {
+    "mapping_policy": "demand+visibility",
+    "os_page_cache_cold": "not_measured",
+    "power_loss_durability": "not_claimed"
+  },
+  "source": {
+    "git_dirty": "false",
+    "git_head": "4a36ae5ea4662ed78be500530e2335e35d8644e0"
+  }
+}

--- a/framework/core/docs/qualification/mmap-macos-arm64-f857fa162-baseline-01.json
+++ b/framework/core/docs/qualification/mmap-macos-arm64-f857fa162-baseline-01.json
@@ -1,0 +1,484 @@
+{
+  "fixture": {
+    "journal_page_size_bytes": 2097152,
+    "payload_bytes": 4096,
+    "primitive_bytes": 67108864,
+    "seek_page_counts": [
+      8,
+      32,
+      128
+    ],
+    "temporary_root": true
+  },
+  "host": {
+    "compiler": "clang",
+    "compiler_version": "21.0.0 (clang-2100.1.1.101)",
+    "cpp_standard": 202302,
+    "hardware_model": "Mac13,2",
+    "hardware_threads": 20,
+    "machine": "arm64",
+    "os": "Darwin",
+    "os_page_size": 16384,
+    "os_release": "25.5.0",
+    "pointer_bits": 64
+  },
+  "journal": [
+    {
+      "frames_written": 3585,
+      "page_count": 8,
+      "seek": {
+        "iterations_per_position": 80,
+        "page_count": 8,
+        "positions": {
+          "early": {
+            "latency": {
+              "count": 80,
+              "max_ns": 457125,
+              "mean_ns": 260333,
+              "min_ns": 208000,
+              "p50_ns": 244250,
+              "p95_ns": 357625,
+              "p99_ns": 457125
+            },
+            "resources": {
+              "available": true,
+              "major_faults": 0,
+              "mapped_region_count_available": false,
+              "mapped_regions_after": 0,
+              "mapped_regions_before": 0,
+              "max_rss_kib_after": 70480,
+              "max_rss_kib_before": 70480,
+              "minor_faults": 805,
+              "system_us": 18671,
+              "user_us": 2508
+            },
+            "target_page": 1
+          },
+          "late": {
+            "latency": {
+              "count": 80,
+              "max_ns": 164958,
+              "mean_ns": 93683,
+              "min_ns": 71041,
+              "p50_ns": 88291,
+              "p95_ns": 125000,
+              "p99_ns": 164958
+            },
+            "resources": {
+              "available": true,
+              "major_faults": 0,
+              "mapped_region_count_available": false,
+              "mapped_regions_after": 0,
+              "mapped_regions_before": 0,
+              "max_rss_kib_after": 70480,
+              "max_rss_kib_before": 70480,
+              "minor_faults": 240,
+              "system_us": 6727,
+              "user_us": 1094
+            },
+            "target_page": 8
+          },
+          "middle": {
+            "latency": {
+              "count": 80,
+              "max_ns": 258292,
+              "mean_ns": 177331,
+              "min_ns": 146500,
+              "p50_ns": 166708,
+              "p95_ns": 237167,
+              "p99_ns": 258292
+            },
+            "resources": {
+              "available": true,
+              "major_faults": 0,
+              "mapped_region_count_available": false,
+              "mapped_regions_after": 0,
+              "mapped_regions_before": 0,
+              "max_rss_kib_after": 70480,
+              "max_rss_kib_before": 70480,
+              "minor_faults": 561,
+              "system_us": 12693,
+              "user_us": 1853
+            },
+            "target_page": 4
+          }
+        }
+      },
+      "sequential_read": {
+        "data_frames_observed": 3585,
+        "estimated_payload_mib_per_second": 7723.271972508409,
+        "frames_observed": 3592,
+        "page_switch": {
+          "count": 7,
+          "max_ns": 40834,
+          "mean_ns": 38607,
+          "min_ns": 34375,
+          "p50_ns": 39334,
+          "p95_ns": 40834,
+          "p99_ns": 40834
+        },
+        "payload_bytes_observed": 14684160,
+        "resources": {
+          "available": true,
+          "major_faults": 0,
+          "mapped_region_count_available": false,
+          "mapped_regions_after": 0,
+          "mapped_regions_before": 0,
+          "max_rss_kib_after": 70480,
+          "max_rss_kib_before": 70480,
+          "minor_faults": 919,
+          "system_us": 926,
+          "user_us": 873
+        },
+        "total_ns": 1813209
+      },
+      "write_page_switch": {
+        "count": 7,
+        "max_ns": 332666,
+        "mean_ns": 239113,
+        "min_ns": 171583,
+        "p50_ns": 198958,
+        "p95_ns": 332666,
+        "p99_ns": 332666
+      },
+      "write_payload_mib_per_second": 2946.1749855362123,
+      "write_resources": {
+        "available": true,
+        "major_faults": 912,
+        "mapped_region_count_available": false,
+        "mapped_regions_after": 0,
+        "mapped_regions_before": 0,
+        "max_rss_kib_after": 70480,
+        "max_rss_kib_before": 70480,
+        "minor_faults": 11,
+        "system_us": 3408,
+        "user_us": 1354
+      }
+    },
+    {
+      "frames_written": 15657,
+      "page_count": 32,
+      "seek": {
+        "iterations_per_position": 80,
+        "page_count": 32,
+        "positions": {
+          "early": {
+            "latency": {
+              "count": 80,
+              "max_ns": 1306333,
+              "mean_ns": 940523,
+              "min_ns": 749291,
+              "p50_ns": 931166,
+              "p95_ns": 1145334,
+              "p99_ns": 1306333
+            },
+            "resources": {
+              "available": true,
+              "major_faults": 0,
+              "mapped_region_count_available": false,
+              "mapped_regions_after": 0,
+              "mapped_regions_before": 0,
+              "max_rss_kib_after": 70480,
+              "max_rss_kib_before": 70480,
+              "minor_faults": 2722,
+              "system_us": 66920,
+              "user_us": 8366
+            },
+            "target_page": 1
+          },
+          "late": {
+            "latency": {
+              "count": 80,
+              "max_ns": 338250,
+              "mean_ns": 115153,
+              "min_ns": 87667,
+              "p50_ns": 105375,
+              "p95_ns": 154542,
+              "p99_ns": 338250
+            },
+            "resources": {
+              "available": true,
+              "major_faults": 0,
+              "mapped_region_count_available": false,
+              "mapped_regions_after": 0,
+              "mapped_regions_before": 0,
+              "max_rss_kib_after": 70480,
+              "max_rss_kib_before": 70480,
+              "minor_faults": 240,
+              "system_us": 7427,
+              "user_us": 1917
+            },
+            "target_page": 32
+          },
+          "middle": {
+            "latency": {
+              "count": 80,
+              "max_ns": 1490917,
+              "mean_ns": 639754,
+              "min_ns": 396667,
+              "p50_ns": 592084,
+              "p95_ns": 925125,
+              "p99_ns": 1490917
+            },
+            "resources": {
+              "available": true,
+              "major_faults": 0,
+              "mapped_region_count_available": false,
+              "mapped_regions_after": 0,
+              "mapped_regions_before": 0,
+              "max_rss_kib_after": 70480,
+              "max_rss_kib_before": 70480,
+              "minor_faults": 1521,
+              "system_us": 45612,
+              "user_us": 5152
+            },
+            "target_page": 16
+          }
+        }
+      },
+      "sequential_read": {
+        "data_frames_observed": 15657,
+        "estimated_payload_mib_per_second": 7534.938784938785,
+        "frames_observed": 15688,
+        "page_switch": {
+          "count": 31,
+          "max_ns": 78875,
+          "mean_ns": 44782,
+          "min_ns": 34166,
+          "p50_ns": 42333,
+          "p95_ns": 66750,
+          "p99_ns": 78875
+        },
+        "payload_bytes_observed": 64131072,
+        "resources": {
+          "available": true,
+          "major_faults": 0,
+          "mapped_region_count_available": false,
+          "mapped_regions_after": 0,
+          "mapped_regions_before": 0,
+          "max_rss_kib_after": 70480,
+          "max_rss_kib_before": 70480,
+          "minor_faults": 3985,
+          "system_us": 4270,
+          "user_us": 3790
+        },
+        "total_ns": 8116875
+      },
+      "write_page_switch": {
+        "count": 31,
+        "max_ns": 405167,
+        "mean_ns": 221755,
+        "min_ns": 158833,
+        "p50_ns": 198917,
+        "p95_ns": 387333,
+        "p99_ns": 405167
+      },
+      "write_payload_mib_per_second": 3116.758714263874,
+      "write_resources": {
+        "available": true,
+        "major_faults": 3984,
+        "mapped_region_count_available": false,
+        "mapped_regions_after": 0,
+        "mapped_regions_before": 0,
+        "max_rss_kib_after": 70480,
+        "max_rss_kib_before": 70480,
+        "minor_faults": 32,
+        "system_us": 14009,
+        "user_us": 5489
+      }
+    },
+    {
+      "frames_written": 63945,
+      "page_count": 128,
+      "seek": {
+        "iterations_per_position": 80,
+        "page_count": 128,
+        "positions": {
+          "early": {
+            "latency": {
+              "count": 80,
+              "max_ns": 13861959,
+              "mean_ns": 6491399,
+              "min_ns": 3823041,
+              "p50_ns": 6371375,
+              "p95_ns": 9121000,
+              "p99_ns": 13861959
+            },
+            "resources": {
+              "available": true,
+              "major_faults": 0,
+              "mapped_region_count_available": false,
+              "mapped_regions_after": 0,
+              "mapped_regions_before": 0,
+              "max_rss_kib_after": 70480,
+              "max_rss_kib_before": 70480,
+              "minor_faults": 10403,
+              "system_us": 468644,
+              "user_us": 36735
+            },
+            "target_page": 1
+          },
+          "late": {
+            "latency": {
+              "count": 80,
+              "max_ns": 462417,
+              "mean_ns": 273803,
+              "min_ns": 170750,
+              "p50_ns": 248875,
+              "p95_ns": 416791,
+              "p99_ns": 462417
+            },
+            "resources": {
+              "available": true,
+              "major_faults": 0,
+              "mapped_region_count_available": false,
+              "mapped_regions_after": 0,
+              "mapped_regions_before": 0,
+              "max_rss_kib_after": 70480,
+              "max_rss_kib_before": 70480,
+              "minor_faults": 240,
+              "system_us": 15729,
+              "user_us": 5607
+            },
+            "target_page": 128
+          },
+          "middle": {
+            "latency": {
+              "count": 80,
+              "max_ns": 9392334,
+              "mean_ns": 3058161,
+              "min_ns": 1544250,
+              "p50_ns": 3152125,
+              "p95_ns": 3636667,
+              "p99_ns": 9392334
+            },
+            "resources": {
+              "available": true,
+              "major_faults": 0,
+              "mapped_region_count_available": false,
+              "mapped_regions_after": 0,
+              "mapped_regions_before": 0,
+              "max_rss_kib_after": 70480,
+              "max_rss_kib_before": 70480,
+              "minor_faults": 5360,
+              "system_us": 214432,
+              "user_us": 19454
+            },
+            "target_page": 64
+          }
+        }
+      },
+      "sequential_read": {
+        "data_frames_observed": 63945,
+        "estimated_payload_mib_per_second": 7244.57683791451,
+        "frames_observed": 64072,
+        "page_switch": {
+          "count": 127,
+          "max_ns": 212541,
+          "mean_ns": 61302,
+          "min_ns": 43500,
+          "p50_ns": 55583,
+          "p95_ns": 94167,
+          "p99_ns": 164875
+        },
+        "payload_bytes_observed": 261918720,
+        "resources": {
+          "available": true,
+          "major_faults": 0,
+          "mapped_region_count_available": false,
+          "mapped_regions_after": 0,
+          "mapped_regions_before": 0,
+          "max_rss_kib_after": 70480,
+          "max_rss_kib_before": 70480,
+          "minor_faults": 16274,
+          "system_us": 19284,
+          "user_us": 15075
+        },
+        "total_ns": 34478916
+      },
+      "write_page_switch": {
+        "count": 127,
+        "max_ns": 9376792,
+        "mean_ns": 323029,
+        "min_ns": 133000,
+        "p50_ns": 173917,
+        "p95_ns": 392584,
+        "p99_ns": 3391209
+      },
+      "write_payload_mib_per_second": 2538.370298388019,
+      "write_resources": {
+        "available": true,
+        "major_faults": 16272,
+        "mapped_region_count_available": false,
+        "mapped_regions_after": 0,
+        "mapped_regions_before": 0,
+        "max_rss_kib_after": 70480,
+        "max_rss_kib_before": 70480,
+        "minor_faults": 127,
+        "system_us": 54008,
+        "user_us": 22505
+      }
+    }
+  ],
+  "primitive_mapping": {
+    "fixture_bytes": 67108864,
+    "full_mapping_visibility_flush_ns": 22686042,
+    "iterations": 80,
+    "mapping_open": {
+      "count": 80,
+      "max_ns": 265209,
+      "mean_ns": 75102,
+      "min_ns": 36208,
+      "p50_ns": 68625,
+      "p95_ns": 147333,
+      "p99_ns": 265209
+    },
+    "mapping_read_resources": {
+      "available": true,
+      "major_faults": 0,
+      "mapped_region_count_available": false,
+      "mapped_regions_after": 0,
+      "mapped_regions_before": 0,
+      "max_rss_kib_after": 70480,
+      "max_rss_kib_before": 70432,
+      "minor_faults": 327683,
+      "system_us": 171462,
+      "user_us": 69837
+    },
+    "os_page_cache_cold": "not_measured",
+    "process_first_touch": {
+      "count": 80,
+      "max_ns": 3448416,
+      "mean_ns": 2668406,
+      "min_ns": 2137084,
+      "p50_ns": 2594750,
+      "p95_ns": 3286250,
+      "p99_ns": 3448416
+    },
+    "sequential_write_mib_per_second": 14873.776254248613,
+    "sequential_write_ns": 4302875,
+    "write_and_flush_resources": {
+      "available": true,
+      "major_faults": 0,
+      "mapped_region_count_available": false,
+      "mapped_regions_after": 0,
+      "mapped_regions_before": 0,
+      "max_rss_kib_after": 70480,
+      "max_rss_kib_before": 70480,
+      "minor_faults": 4096,
+      "system_us": 10872,
+      "user_us": 1419
+    }
+  },
+  "profile": "baseline",
+  "schema": "kungfu.mmap-qualification.v1",
+  "semantic_limits": {
+    "mapping_policy": "demand+visibility",
+    "os_page_cache_cold": "not_measured",
+    "power_loss_durability": "not_claimed"
+  },
+  "source": {
+    "git_dirty": "false",
+    "git_head": "f857fa162b0cf21fbe157ceb38bc81a674aebc94"
+  }
+}

--- a/framework/core/docs/qualification/mmap-performance.md
+++ b/framework/core/docs/qualification/mmap-performance.md
@@ -156,3 +156,45 @@ Linux reproduces the same direction as macOS: seeking old history grows with
 page count and is much slower than seeking near the tail. Absolute timings are
 not compared across hosts. The cross-platform shape raises page lookup from a
 single-host suspicion to the first controlled production candidate.
+
+### Ordered page lookup candidate
+
+- Candidate: tail fast path plus binary upper-bound probes over append-ordered
+  page begin times.
+- Candidate head: `4a36ae5ea4662ed78be500530e2335e35d8644e0`.
+- Retained evidence: [`mmap-macos-arm64-4a36ae5ea-candidate-01.json`](mmap-macos-arm64-4a36ae5ea-candidate-01.json).
+- Rollback: revert `4a36ae5ea` and `60a3d5cf2`; no journal bytes, page names,
+  persisted metadata, or public API changed.
+
+Three baseline/candidate alternations on the same Mac produced these 128-page
+seek ranges (minimum to maximum p50 across the three runs):
+
+| Position | Linear baseline p50 | Ordered candidate p50 | Decision signal |
+|---|---:|---:|---|
+| early | 3.131-3.505 ms | 0.298-0.517 ms | 6.1-11.8x faster |
+| middle | 1.825-1.953 ms | 0.293-0.454 ms | 4.0-6.7x faster |
+| late | 0.186-0.234 ms | 0.162-0.221 ms | tail fast path removes the first candidate's regression |
+
+The candidate reduces early-seek minor faults by an order of magnitude because
+it maps a bounded number of sliced headers. Write and sequential-read code is
+unchanged; their noisy p99 samples are retained as opposite-path evidence and
+are not claimed as candidate improvements. Final acceptance still requires the
+same direction on Linux.
+
+### Independent policy decisions
+
+| Candidate | Classification | Evidence and boundary |
+|---|---|---|
+| ordered page lookup | pending Linux reproduction | Cross-platform baselines identify the same linear shape; Mac alternations clear the performance and rollback gates. |
+| exact file sizing | keep current | Writer creation grows each page once to its declared fixed size; no redundant resize was found. |
+| extra preallocation | defer | The harness does not isolate allocation guarantees from page-cache and filesystem effects; no default changes. |
+| `MADV_RANDOM` | reject as default | Journal traffic mixes sequential traversal with sparse header probes, so global random advice contradicts the representative sequential path. |
+| sequential / will-need advice | defer | Page-cache-cold behavior is intentionally not measured, so the present evidence cannot support an OS advice default. |
+| prefault | reject as default | It only displaces first-touch faults into startup without evidence of better journal page-switch tails; the mapping policy remains unqualified. |
+| bounded pinning | reject as default | It consumes process and system lock budgets and has no representative end-to-end win; unlimited pinning remains out of scope. |
+| committed-range flush | defer | Current visibility flush is whole-range and the mapping layer has no independently qualified committed-range authority; narrowing it could silently omit published bytes. |
+| release queue polling | defer | No representative cross-thread shared-page ownership workload exists yet; replacing the bounded one-microsecond wait would be speculative. |
+
+These are separate verdicts. Deferrals do not authorize hidden experimental
+branches or weaken the policy truth table: `prefault`, `pinned`, asynchronous,
+and durable mappings remain rejected by production mapping policy.

--- a/framework/core/docs/qualification/mmap-performance.md
+++ b/framework/core/docs/qualification/mmap-performance.md
@@ -102,3 +102,35 @@ The first run records the untouched `demand + visibility` implementation from
 ADR-0058. Candidate decisions remain `defer` until both macOS and Linux
 baselines are retained. Windows is a recorded coverage gap unless a suitable
 runner is available.
+
+### macOS baseline 01
+
+- Evidence: [`mmap-macos-arm64-f857fa162-baseline-01.json`](mmap-macos-arm64-f857fa162-baseline-01.json)
+- Git head: `f857fa162b0cf21fbe157ceb38bc81a674aebc94`
+- Command: `./shifu qualify:mmap -- --profile baseline --output
+  framework/core/docs/qualification/mmap-macos-arm64-f857fa162-baseline-01.json`
+- Host: Darwin 25.5.0, arm64 `Mac13,2`, 20 hardware threads, 16 KiB OS
+  pages, Apple Clang 21, C++23.
+- Integrity: all written data frames were read back at 8, 32, and 128 journal
+  pages; no major read faults were observed.
+
+| Pages | Write switch p50 / p99 | Read switch p50 / p99 | Seek early p50 / p99 | Seek middle p50 | Seek late p50 |
+|---:|---:|---:|---:|---:|---:|
+| 8 | 0.199 / 0.333 ms | 0.039 / 0.041 ms | 0.244 / 0.457 ms | 0.167 ms | 0.088 ms |
+| 32 | 0.199 / 0.405 ms | 0.042 / 0.079 ms | 0.931 / 1.306 ms | 0.592 ms | 0.105 ms |
+| 128 | 0.174 / 3.391 ms | 0.056 / 0.165 ms | 6.371 / 13.862 ms | 3.152 ms | 0.249 ms |
+
+The position-dependent seek curve is consistent with the current reverse
+linear header scan: old targets inspect many page headers while a late target
+usually stops near the tail. This is a candidate-selection signal, not yet an
+optimization verdict. The 128-page write-switch p99 spike also needs repeated
+baseline/candidate alternation before it can justify preallocation, advice, or
+residency changes.
+
+Current classification:
+
+- page metadata/indexing: `defer`, highest-priority controlled candidate after
+  Linux baseline because the scaling signal is representative and structural;
+- file sizing/preallocation, advice, prefault/pinning, committed-range flush,
+  and release queue: `defer`, insufficient isolated evidence;
+- production policy/default changes: none.

--- a/framework/core/docs/qualification/mmap-performance.md
+++ b/framework/core/docs/qualification/mmap-performance.md
@@ -1,0 +1,104 @@
+---
+status: draft
+period: 2026-07-11
+theme: yijinjing-mmap-performance-qualification
+doc_type: qualification-contract
+source_level: local-files + user-decision
+confidence: high
+sensitivity: public
+evidence_grade: B
+review_state: self-reviewed
+last_reviewed: 2026-07-11
+ai_provenance:
+  model_family: GPT-5
+  product: Codex
+  generated_at: 2026-07-11
+  invisible_context_boundary: No credentials, private journals, or hidden provider state were read
+---
+
+# yijinjing mmap performance qualification
+
+This contract decides whether an mmap optimization is safe and useful enough
+to enter production. It does not turn a microbenchmark into a product SLO.
+
+## Run contract
+
+Configure/build through Shifu, then run the native evidence tool through
+Shifu. `qualify:mmap` incrementally builds only its evidence executable from
+the configured core tree before running it:
+
+```sh
+./shifu build
+./shifu qualify:mmap -- --profile smoke
+./shifu qualify:mmap -- --profile baseline --output mmap-baseline.json
+```
+
+The tool creates and removes its own directory under the operating system's
+temporary root. It never accepts a user journal path and refuses to overwrite
+an existing evidence file. JSON is an evidence-edge format; production journal
+and mapping APIs remain typed C++ structures.
+
+The `smoke` profile proves that the harness and invariants run. The `baseline`
+profile is the minimum decision input. A result is identified by its Git head,
+host facts, compiler/toolchain, profile, fixture sizes, and raw JSON output.
+The Git head and exact Shifu command must accompany retained evidence.
+
+## Measurements and meanings
+
+| Measurement | Meaning | Explicit non-claim |
+|---|---|---|
+| mapping open | open, inspect, and map an existing file | not disk cold-start |
+| process first touch | touch one byte per 4 KiB after each new mapping | not guaranteed OS page-cache cold |
+| sequential read/write | bounded fixture traversal or mutation | not application end-to-end throughput |
+| page switch | operation crossing a journal page boundary | not summarized by mean alone |
+| seek early/middle/late | fresh journal seek at growing page counts | not a stable complexity claim from one host |
+| visibility flush | full mapped-range `MS_SYNC` / `FlushViewOfFile` cost | not power-loss durability |
+| resource delta | user/system CPU, RSS high-water mark, major/minor faults, and mapped-region count where available | unavailable fields remain explicit |
+
+Clearing the host's global page cache is forbidden by this qualification.
+Therefore `os_page_cache_cold` is `not_measured`. A future cold-storage study
+must use an isolated disposable host or volume and a separate safety review.
+
+## Decision gate
+
+Every candidate is isolated and classified `accept`, `reject`, or `defer`.
+Acceptance requires all of the following:
+
+1. The benchmark command, fixture, host facts, raw baseline, and raw candidate
+   result are retained.
+2. The representative scenario improves p50 and/or p99 materially across at
+   least three baseline/candidate alternations; a mean-only win is insufficient.
+3. CPU, RSS, major/minor faults, mapped-region count, startup, sequential
+   throughput, and the opposite latency tail show no unexplained regression.
+4. The result holds for the relevant rapid-rollover or long-history fixture,
+   not only a primitive mapping loop.
+5. `./shifu test:mmap`, historic-wire checks, `./shifu check`, and the Mac build
+   pass. Linux must reproduce the direction before a POSIX default changes.
+6. The candidate has an explicit rollback and does not weaken wire-v1, Hana POD
+   layout, zero-copy access, single-writer publication, mapping authority, or
+   error propagation.
+
+Noise below 5% is treated as neutral unless its confidence interval and tail
+distribution show otherwise. Host-to-host absolute numbers are not compared;
+only controlled baseline/candidate runs on the same host support a decision.
+
+## Candidate boundaries
+
+- File sizing/preallocation, OS advice, prefault, bounded pinning,
+  committed-range flush, seek metadata/indexing, and release-queue behavior are
+  separate experiments and separate commits.
+- `prefault` or `pinned` cannot become a default merely because the primitive
+  first-touch scenario improves. RSS, fault displacement, startup, limits, and
+  journal page-switch tails are load-bearing evidence.
+- `asynchronous` is a visibility/writeback policy, not durability.
+  `durable` remains blocked until file-data and metadata ordering, device cache,
+  error propagation, and crash recovery are qualified separately.
+- Unlimited pinning, huge-page defaults, global kernel tuning, and real user
+  journal fixtures are outside this contract.
+
+## Initial evidence status
+
+The first run records the untouched `demand + visibility` implementation from
+ADR-0058. Candidate decisions remain `defer` until both macOS and Linux
+baselines are retained. Windows is a recorded coverage gap unless a suitable
+runner is available.

--- a/framework/core/docs/qualification/mmap-performance.md
+++ b/framework/core/docs/qualification/mmap-performance.md
@@ -98,10 +98,9 @@ only controlled baseline/candidate runs on the same host support a decision.
 
 ## Initial evidence status
 
-The first run records the untouched `demand + visibility` implementation from
-ADR-0058. Candidate decisions remain `defer` until both macOS and Linux
-baselines are retained. Windows is a recorded coverage gap unless a suitable
-runner is available.
+The first runs record the untouched `demand + visibility` implementation from
+ADR-0058. macOS and Linux baselines are retained below. Windows remains a
+recorded coverage gap unless a suitable runner is available.
 
 ### macOS baseline 01
 
@@ -134,3 +133,26 @@ Current classification:
 - file sizing/preallocation, advice, prefault/pinning, committed-range flush,
   and release queue: `defer`, insufficient isolated evidence;
 - production policy/default changes: none.
+
+### Linux baseline 01
+
+- Evidence: [`mmap-linux-x86_64-bc3dcb7d2-baseline-01.json`](mmap-linux-x86_64-bc3dcb7d2-baseline-01.json)
+- Git head: `bc3dcb7d2976dadb9651b9e4ad115257720d9d75`
+- Command: `./shifu qualify:mmap -- --profile baseline --output
+  /tmp/mmap-linux-x86_64-bc3dcb7d2-baseline-01.json`
+- Host: Linux 6.8.0-134-generic, x86_64 `agent-120`, 32 hardware threads,
+  4 KiB OS pages, GCC 13.3, C++23.
+- Integrity: all written data frames were read back at 8, 32, and 128 journal
+  pages. Read/seek observed no major faults; journal creation observed one
+  major fault per page on this run.
+
+| Pages | Write switch p50 / p99 | Read switch p50 / p99 | Seek early p50 / p99 | Seek middle p50 | Seek late p50 |
+|---:|---:|---:|---:|---:|---:|
+| 8 | 0.068 / 0.074 ms | 0.026 / 0.030 ms | 0.061 / 0.070 ms | 0.045 ms | 0.024 ms |
+| 32 | 0.066 / 0.155 ms | 0.026 / 0.028 ms | 0.206 / 0.471 ms | 0.128 ms | 0.045 ms |
+| 128 | 0.066 / 0.120 ms | 0.026 / 0.028 ms | 0.788 / 1.004 ms | 0.460 ms | 0.127 ms |
+
+Linux reproduces the same direction as macOS: seeking old history grows with
+page count and is much slower than seeking near the tail. Absolute timings are
+not compared across hosts. The cross-platform shape raises page lookup from a
+single-host suspicion to the first controlled production candidate.

--- a/framework/core/docs/qualification/mmap-performance.md
+++ b/framework/core/docs/qualification/mmap-performance.md
@@ -178,14 +178,27 @@ seek ranges (minimum to maximum p50 across the three runs):
 The candidate reduces early-seek minor faults by an order of magnitude because
 it maps a bounded number of sliced headers. Write and sequential-read code is
 unchanged; their noisy p99 samples are retained as opposite-path evidence and
-are not claimed as candidate improvements. Final acceptance still requires the
-same direction on Linux.
+are not claimed as candidate improvements.
+
+Linux reproduced the result in three baseline/candidate alternations at 128
+pages:
+
+| Position | Linear baseline p50 | Ordered candidate p50 | Decision signal |
+|---|---:|---:|---|
+| early | 0.750-0.782 ms | 0.153-0.155 ms | 4.8-5.1x faster |
+| middle | 0.431-0.454 ms | 0.152-0.154 ms | 2.8-3.0x faster |
+| late | 0.120-0.127 ms | 0.117-0.119 ms | no regression |
+
+Retained Linux candidate evidence:
+[`mmap-linux-x86_64-285158703-candidate-01.json`](mmap-linux-x86_64-285158703-candidate-01.json).
+The full agent-120 product rebuild also completed with both production libwasm
+engines using the repository-pinned rustup 1.95.0 toolchain.
 
 ### Independent policy decisions
 
 | Candidate | Classification | Evidence and boundary |
 |---|---|---|
-| ordered page lookup | pending Linux reproduction | Cross-platform baselines identify the same linear shape; Mac alternations clear the performance and rollback gates. |
+| ordered page lookup | accept | Mac and Linux three-round alternations improve old-history seek, preserve the tail fast path, and leave wire/API/durability semantics unchanged. |
 | exact file sizing | keep current | Writer creation grows each page once to its declared fixed size; no redundant resize was found. |
 | extra preallocation | defer | The harness does not isolate allocation guarantees from page-cache and filesystem effects; no default changes. |
 | `MADV_RANDOM` | reject as default | Journal traffic mixes sequential traversal with sparse header probes, so global random advice contradicts the representative sequential path. |

--- a/framework/core/src/libyijinjing/CMakeLists.txt
+++ b/framework/core/src/libyijinjing/CMakeLists.txt
@@ -66,6 +66,12 @@ if(YIJINJING_BUILD_TESTS)
   target_link_libraries(yijinjing_mmap_tests PRIVATE yijinjing)
   target_compile_features(yijinjing_mmap_tests PRIVATE cxx_std_23)
   add_test(NAME yijinjing_mmap_tests COMMAND yijinjing_mmap_tests)
+
+  # Evidence tool only: this executable exercises the qualified production
+  # surface but is not linked into or shipped with the runtime.
+  add_executable(yijinjing_mmap_qualification tests/mmap_qualification.cpp)
+  target_link_libraries(yijinjing_mmap_qualification PRIVATE yijinjing)
+  target_compile_features(yijinjing_mmap_qualification PRIVATE cxx_std_23)
 endif()
 
 if(DEFINED COMPILER_OPTIMIZE_ON_OPTIONS AND NOT "${COMPILER_OPTIMIZE_ON_OPTIONS}" STREQUAL "")

--- a/framework/core/src/libyijinjing/src/journal/page.cpp
+++ b/framework/core/src/libyijinjing/src/journal/page.cpp
@@ -245,17 +245,29 @@ uint32_t page::find_page_id(const data::location_ptr &location, uint32_t dest_id
   if (time == 0) {
     return page_ids.front();
   }
-  for (int i = static_cast<int>(page_ids.size()) - 1; i >= 0; i--) {
+
+  // Page begin times are append-only and therefore ordered with page ids.
+  // Probe the upper bound instead of mapping every newer page header. Pre-open
+  // pages form an ineligible suffix and naturally move the bound left.
+  size_t lower = 0;
+  size_t upper = page_ids.size();
+  uint32_t candidate = page_ids.front();
+  while (lower < upper) {
+    const size_t middle = lower + (upper - lower) / 2;
     auto loaded_page =
-        page::load_header_and_1st_frame_header(location, dest_id, page_ids[i], page_open_policy::header_probe());
+        page::load_header_and_1st_frame_header(location, dest_id, page_ids[middle], page_open_policy::header_probe());
     const auto *loaded_page_header = loaded_page->header_;
-    if (loaded_page->acquire_last_frame_position() != 0 &&
-        loaded_page->acquire_status() != yijinjing::enums::PageStatus::PreOpen &&
-        loaded_page_header->version == __JOURNAL_VERSION__ && loaded_page->begin_time() < time) {
-      return page_ids[i];
+    const bool eligible = loaded_page->acquire_last_frame_position() != 0 &&
+                          loaded_page->acquire_status() != yijinjing::enums::PageStatus::PreOpen &&
+                          loaded_page_header->version == __JOURNAL_VERSION__ && loaded_page->begin_time() < time;
+    if (eligible) {
+      candidate = page_ids[middle];
+      lower = middle + 1;
+    } else {
+      upper = middle;
     }
   }
-  return page_ids.front();
+  return candidate;
 }
 
 uint64_t page::find_page_size(const data::location_ptr &location, uint32_t dest_id, uint64_t page_size) {

--- a/framework/core/src/libyijinjing/src/journal/page.cpp
+++ b/framework/core/src/libyijinjing/src/journal/page.cpp
@@ -246,21 +246,30 @@ uint32_t page::find_page_id(const data::location_ptr &location, uint32_t dest_id
     return page_ids.front();
   }
 
+  const auto is_before_target = [&](size_t index) {
+    auto loaded_page =
+        page::load_header_and_1st_frame_header(location, dest_id, page_ids[index], page_open_policy::header_probe());
+    const auto *loaded_page_header = loaded_page->header_;
+    return loaded_page->acquire_last_frame_position() != 0 &&
+           loaded_page->acquire_status() != yijinjing::enums::PageStatus::PreOpen &&
+           loaded_page_header->version == __JOURNAL_VERSION__ && loaded_page->begin_time() < time;
+  };
+
+  // Most live seeks target the tail. Preserve that one-probe path before using
+  // ordered lookup for older history.
+  if (is_before_target(page_ids.size() - 1)) {
+    return page_ids.back();
+  }
+
   // Page begin times are append-only and therefore ordered with page ids.
   // Probe the upper bound instead of mapping every newer page header. Pre-open
   // pages form an ineligible suffix and naturally move the bound left.
   size_t lower = 0;
-  size_t upper = page_ids.size();
+  size_t upper = page_ids.size() - 1;
   uint32_t candidate = page_ids.front();
   while (lower < upper) {
     const size_t middle = lower + (upper - lower) / 2;
-    auto loaded_page =
-        page::load_header_and_1st_frame_header(location, dest_id, page_ids[middle], page_open_policy::header_probe());
-    const auto *loaded_page_header = loaded_page->header_;
-    const bool eligible = loaded_page->acquire_last_frame_position() != 0 &&
-                          loaded_page->acquire_status() != yijinjing::enums::PageStatus::PreOpen &&
-                          loaded_page_header->version == __JOURNAL_VERSION__ && loaded_page->begin_time() < time;
-    if (eligible) {
+    if (is_before_target(middle)) {
       candidate = page_ids[middle];
       lower = middle + 1;
     } else {

--- a/framework/core/src/libyijinjing/tests/mmap_qualification.cpp
+++ b/framework/core/src/libyijinjing/tests/mmap_qualification.cpp
@@ -1,0 +1,497 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#include <kungfu/yijinjing/common.h>
+#include <kungfu/yijinjing/journal/journal.h>
+#include <kungfu/yijinjing/platform/mmap.h>
+
+#include <nlohmann/json.hpp>
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <iterator>
+#include <numeric>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <vector>
+
+#ifdef __APPLE__
+#include <sys/sysctl.h>
+#endif
+
+#ifdef _WINDOWS
+#include <windows.h>
+#else
+#include <sys/resource.h>
+#include <sys/utsname.h>
+#include <unistd.h>
+#endif
+
+namespace fs = std::filesystem;
+using json = nlohmann::json;
+using clock_type = std::chrono::steady_clock;
+using kungfu::yijinjing::MB;
+using kungfu::yijinjing::data::location;
+using kungfu::yijinjing::data::locator;
+using kungfu::yijinjing::enums::location_role;
+using kungfu::yijinjing::enums::mode;
+using kungfu::yijinjing::journal::bus;
+using kungfu::yijinjing::journal::journal;
+using kungfu::yijinjing::journal::journal_open_policy;
+using kungfu::yijinjing::journal::noop_publisher;
+using kungfu::yijinjing::journal::writer;
+using kungfu::yijinjing::platform::mapped_region;
+using kungfu::yijinjing::platform::mapping_policy;
+
+namespace {
+
+constexpr uint32_t DEST_ID = location::PUBLIC;
+constexpr int32_t CARRIER_TYPE = 10001;
+constexpr size_t PAYLOAD_SIZE = 4096;
+volatile uint64_t read_sink = 0;
+
+struct profile {
+  std::string name;
+  size_t primitive_size;
+  size_t primitive_iterations;
+  uint64_t journal_page_size_mb;
+  std::vector<uint32_t> seek_page_counts;
+  size_t seek_iterations;
+};
+
+struct run_options {
+  profile config;
+  fs::path output;
+};
+
+struct resource_sample {
+  int64_t user_us = 0;
+  int64_t system_us = 0;
+  int64_t minor_faults = 0;
+  int64_t major_faults = 0;
+  int64_t max_rss_kib = 0;
+  size_t mapped_regions = 0;
+  bool available = false;
+};
+
+class temp_tree {
+public:
+  temp_tree() {
+    const auto nonce = clock_type::now().time_since_epoch().count();
+    root_ = fs::temp_directory_path() / ("kungfu-mmap-qualification-" + std::to_string(nonce));
+    fs::create_directories(root_);
+  }
+  ~temp_tree() {
+    std::error_code ignored;
+    fs::remove_all(root_, ignored);
+  }
+  [[nodiscard]] const fs::path &root() const { return root_; }
+
+private:
+  fs::path root_;
+};
+
+uint64_t elapsed_ns(const clock_type::time_point start) {
+  return static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::nanoseconds>(clock_type::now() - start).count());
+}
+
+size_t mapped_region_count() {
+#ifdef __linux__
+  std::ifstream maps("/proc/self/maps");
+  return static_cast<size_t>(std::count(std::istreambuf_iterator<char>(maps), std::istreambuf_iterator<char>(), '\n'));
+#elif defined(__APPLE__)
+  // vmmap would perturb the process being measured. Leave this fact explicit
+  // rather than substituting a different metric under the same name.
+  return 0;
+#elif defined(_WINDOWS)
+  size_t count = 0;
+  MEMORY_BASIC_INFORMATION info{};
+  auto *address = static_cast<unsigned char *>(nullptr);
+  while (VirtualQuery(address, &info, sizeof(info)) == sizeof(info)) {
+    ++count;
+    if (info.RegionSize == 0 ||
+        reinterpret_cast<uintptr_t>(address) + info.RegionSize < reinterpret_cast<uintptr_t>(address)) {
+      break;
+    }
+    address += info.RegionSize;
+  }
+  return count;
+#else
+  return 0;
+#endif
+}
+
+resource_sample resources() {
+  resource_sample result;
+#ifdef _WINDOWS
+  result.mapped_regions = mapped_region_count();
+#else
+  rusage usage{};
+  if (getrusage(RUSAGE_SELF, &usage) != 0) {
+    return result;
+  }
+  result.user_us = usage.ru_utime.tv_sec * 1000000LL + usage.ru_utime.tv_usec;
+  result.system_us = usage.ru_stime.tv_sec * 1000000LL + usage.ru_stime.tv_usec;
+  result.minor_faults = usage.ru_minflt;
+  result.major_faults = usage.ru_majflt;
+#ifdef __APPLE__
+  result.max_rss_kib = usage.ru_maxrss / 1024;
+#else
+  result.max_rss_kib = usage.ru_maxrss;
+#endif
+  result.mapped_regions = mapped_region_count();
+  result.available = true;
+#endif
+  return result;
+}
+
+json resource_delta(const resource_sample &before, const resource_sample &after) {
+  return {{"available", before.available && after.available},
+          {"user_us", after.user_us - before.user_us},
+          {"system_us", after.system_us - before.system_us},
+          {"minor_faults", after.minor_faults - before.minor_faults},
+          {"major_faults", after.major_faults - before.major_faults},
+          {"max_rss_kib_before", before.max_rss_kib},
+          {"max_rss_kib_after", after.max_rss_kib},
+          {"mapped_regions_before", before.mapped_regions},
+          {"mapped_regions_after", after.mapped_regions},
+          {"mapped_region_count_available", before.mapped_regions != 0 || after.mapped_regions != 0}};
+}
+
+uint64_t percentile(const std::vector<uint64_t> &sorted, double quantile) {
+  if (sorted.empty()) {
+    return 0;
+  }
+  const auto index = static_cast<size_t>(std::ceil(quantile * static_cast<double>(sorted.size())) - 1.0);
+  return sorted[std::min(index, sorted.size() - 1)];
+}
+
+json distribution(std::vector<uint64_t> samples) {
+  if (samples.empty()) {
+    return {{"count", 0}};
+  }
+  std::sort(samples.begin(), samples.end());
+  const auto total = std::accumulate(samples.begin(), samples.end(), uint64_t{0});
+  return {{"count", samples.size()},
+          {"min_ns", samples.front()},
+          {"p50_ns", percentile(samples, 0.50)},
+          {"p95_ns", percentile(samples, 0.95)},
+          {"p99_ns", percentile(samples, 0.99)},
+          {"max_ns", samples.back()},
+          {"mean_ns", total / samples.size()}};
+}
+
+json host_facts() {
+  json facts = {{"hardware_threads", std::thread::hardware_concurrency()},
+                {"cpp_standard", __cplusplus},
+                {"pointer_bits", sizeof(void *) * 8}};
+#ifdef _WINDOWS
+  SYSTEM_INFO info{};
+  GetSystemInfo(&info);
+  facts["os"] = "windows";
+  facts["os_page_size"] = info.dwPageSize;
+#else
+  utsname name{};
+  if (uname(&name) == 0) {
+    facts["os"] = name.sysname;
+    facts["os_release"] = name.release;
+    facts["machine"] = name.machine;
+  }
+  facts["os_page_size"] = sysconf(_SC_PAGESIZE);
+#ifdef __APPLE__
+  size_t model_size = 0;
+  if (sysctlbyname("hw.model", nullptr, &model_size, nullptr, 0) == 0 && model_size > 1) {
+    std::string model(model_size, '\0');
+    if (sysctlbyname("hw.model", model.data(), &model_size, nullptr, 0) == 0) {
+      model.resize(std::strlen(model.c_str()));
+      facts["hardware_model"] = model;
+    }
+  }
+#endif
+#endif
+#if defined(__clang__)
+  facts["compiler"] = "clang";
+  facts["compiler_version"] = __clang_version__;
+#elif defined(__GNUC__)
+  facts["compiler"] = "gcc";
+  facts["compiler_version"] = __VERSION__;
+#elif defined(_MSC_VER)
+  facts["compiler"] = "msvc";
+  facts["compiler_version"] = _MSC_VER;
+#endif
+  return facts;
+}
+
+void touch_read(const mapped_region &region) {
+  const auto *bytes = reinterpret_cast<const unsigned char *>(region.address());
+  const size_t stride = 4096;
+  uint64_t sum = 0;
+  for (size_t offset = 0; offset < region.size(); offset += stride) {
+    sum += bytes[offset];
+  }
+  read_sink = read_sink + sum;
+}
+
+json primitive_mapping(const temp_tree &tree, const profile &config) {
+  const auto path = tree.root() / "primitive.journal";
+  {
+    auto seed = mapped_region::map(path.string(), config.primitive_size, mapping_policy::write_create_or_grow());
+    std::memset(reinterpret_cast<void *>(seed.address()), 0x5a, seed.size());
+    if (!seed.flush()) {
+      throw std::runtime_error("failed to flush primitive fixture");
+    }
+  }
+
+  std::vector<uint64_t> open_samples;
+  std::vector<uint64_t> first_touch_samples;
+  open_samples.reserve(config.primitive_iterations);
+  first_touch_samples.reserve(config.primitive_iterations);
+  const auto before = resources();
+  for (size_t i = 0; i < config.primitive_iterations; ++i) {
+    const auto open_start = clock_type::now();
+    auto region = mapped_region::map(path.string(), config.primitive_size, mapping_policy::read_existing());
+    open_samples.push_back(elapsed_ns(open_start));
+    const auto touch_start = clock_type::now();
+    touch_read(region);
+    first_touch_samples.push_back(elapsed_ns(touch_start));
+  }
+  const auto after = resources();
+
+  auto region = mapped_region::map(path.string(), config.primitive_size, mapping_policy::write_existing());
+  const auto write_before = resources();
+  const auto write_start = clock_type::now();
+  std::memset(reinterpret_cast<void *>(region.address()), 0xa5, region.size());
+  const auto write_ns = elapsed_ns(write_start);
+  const auto flush_start = clock_type::now();
+  if (!region.flush()) {
+    throw std::runtime_error("failed to flush primitive measurement");
+  }
+  const auto flush_ns = elapsed_ns(flush_start);
+  const auto write_after = resources();
+
+  return {{"fixture_bytes", config.primitive_size},
+          {"iterations", config.primitive_iterations},
+          {"mapping_open", distribution(std::move(open_samples))},
+          {"process_first_touch", distribution(std::move(first_touch_samples))},
+          {"mapping_read_resources", resource_delta(before, after)},
+          {"sequential_write_ns", write_ns},
+          {"sequential_write_mib_per_second",
+           static_cast<double>(config.primitive_size) * 1e9 / static_cast<double>(write_ns) / (1024.0 * 1024.0)},
+          {"full_mapping_visibility_flush_ns", flush_ns},
+          {"write_and_flush_resources", resource_delta(write_before, write_after)},
+          {"os_page_cache_cold", "not_measured"}};
+}
+
+auto make_location(const fs::path &root, const std::string &group) {
+  auto page_locator = std::make_shared<locator>(root.string());
+  return location::make_shared(mode::LIVE, location_role::SYSTEM, group, "qualification", page_locator);
+}
+
+struct journal_fixture {
+  kungfu::yijinjing::data::location_ptr location;
+  std::vector<int64_t> first_time_by_page;
+  size_t frames = 0;
+  json write_switches;
+  json write_resources;
+  double write_mib_per_second = 0;
+};
+
+journal_fixture build_journal_fixture(const temp_tree &tree, uint32_t page_count, const profile &config) {
+  auto loc = make_location(tree.root(), "pages_" + std::to_string(page_count));
+  auto publisher = std::make_shared<noop_publisher>();
+  auto page_bus = std::make_shared<bus>(false);
+  writer output(loc, DEST_ID, publisher, false, page_bus, config.journal_page_size_mb, 0);
+  std::vector<unsigned char> payload(PAYLOAD_SIZE, 0x3c);
+  std::vector<uint64_t> switches;
+  std::vector<int64_t> first_time(page_count + 1, 0);
+  uint32_t frames_on_final_page = 0;
+  int64_t gen_time = 1'000'000;
+  size_t frames = 0;
+  const auto before = resources();
+  const auto total_start = clock_type::now();
+  while (output.get_current_page()->get_page_id() < page_count || frames_on_final_page < 64) {
+    const auto before_page = output.get_current_page()->get_page_id();
+    if (before_page <= page_count && first_time[before_page] == 0) {
+      first_time[before_page] = gen_time;
+    }
+    const auto start = clock_type::now();
+    output.write_raw_at_as(gen_time, gen_time, loc->uid, DEST_ID, CARRIER_TYPE,
+                           reinterpret_cast<uintptr_t>(payload.data()), static_cast<uint32_t>(payload.size()));
+    const auto duration = elapsed_ns(start);
+    const auto after_page = output.get_current_page()->get_page_id();
+    if (after_page != before_page) {
+      switches.push_back(duration);
+    }
+    if (after_page == page_count) {
+      ++frames_on_final_page;
+    }
+    ++frames;
+    gen_time += 1'000;
+  }
+  const auto total_ns = elapsed_ns(total_start);
+  output.get_current_page()->flush();
+  const auto after = resources();
+  const auto bytes = static_cast<double>(frames * PAYLOAD_SIZE);
+  return {loc,
+          std::move(first_time),
+          frames,
+          distribution(std::move(switches)),
+          resource_delta(before, after),
+          bytes * 1e9 / static_cast<double>(total_ns) / (1024.0 * 1024.0)};
+}
+
+json read_journal(const journal_fixture &fixture, const profile &config) {
+  auto page_bus = std::make_shared<bus>(false);
+  journal input(fixture.location, DEST_ID, journal_open_policy::reader(), false, page_bus,
+                config.journal_page_size_mb * MB);
+  const auto before = resources();
+  const auto start = clock_type::now();
+  input.seek_to_time(0);
+  std::vector<uint64_t> switches;
+  size_t frames = 0;
+  size_t data_frames = 0;
+  uint64_t payload_bytes = 0;
+  auto previous_page = input.current_page_id();
+  while (input.current_frame()->has_data()) {
+    const auto data_length = input.current_frame()->data_length();
+    read_sink = read_sink + data_length;
+    if (data_length > 0) {
+      ++data_frames;
+      payload_bytes += data_length;
+    }
+    const auto next_start = clock_type::now();
+    input.next();
+    const auto next_ns = elapsed_ns(next_start);
+    const auto current_page = input.current_page_id();
+    if (current_page != previous_page) {
+      switches.push_back(next_ns);
+      previous_page = current_page;
+    }
+    ++frames;
+  }
+  const auto total_ns = elapsed_ns(start);
+  const auto after = resources();
+  const auto bytes = static_cast<double>(payload_bytes);
+  return {{"frames_observed", frames},
+          {"data_frames_observed", data_frames},
+          {"payload_bytes_observed", payload_bytes},
+          {"total_ns", total_ns},
+          {"estimated_payload_mib_per_second", bytes * 1e9 / static_cast<double>(total_ns) / (1024.0 * 1024.0)},
+          {"page_switch", distribution(std::move(switches))},
+          {"resources", resource_delta(before, after)}};
+}
+
+json seek_journal(const journal_fixture &fixture, uint32_t page_count, const profile &config) {
+  json positions = json::object();
+  const std::pair<const char *, uint32_t> targets[] = {
+      {"early", 1}, {"middle", std::max<uint32_t>(1, page_count / 2)}, {"late", page_count}};
+  for (const auto &[name, page_id] : targets) {
+    std::vector<uint64_t> samples;
+    const auto before = resources();
+    for (size_t i = 0; i < config.seek_iterations; ++i) {
+      auto page_bus = std::make_shared<bus>(false);
+      journal input(fixture.location, DEST_ID, journal_open_policy::reader(), false, page_bus,
+                    config.journal_page_size_mb * MB);
+      const auto start = clock_type::now();
+      input.seek_to_time(fixture.first_time_by_page.at(page_id) + 1);
+      samples.push_back(elapsed_ns(start));
+    }
+    const auto after = resources();
+    positions[name] = {{"target_page", page_id},
+                       {"latency", distribution(std::move(samples))},
+                       {"resources", resource_delta(before, after)}};
+  }
+  return {{"page_count", page_count}, {"iterations_per_position", config.seek_iterations}, {"positions", positions}};
+}
+
+run_options parse_options(int argc, char **argv) {
+  std::string requested = "smoke";
+  fs::path output;
+  for (int i = 1; i < argc; ++i) {
+    const std::string arg(argv[i]);
+    if (arg == "--profile" && i + 1 < argc) {
+      requested = argv[++i];
+    } else if (arg == "--output" && i + 1 < argc) {
+      output = argv[++i];
+    } else {
+      throw std::runtime_error(
+          "usage: yijinjing_mmap_qualification [--profile smoke|baseline] [--output new-file.json]");
+    }
+  }
+  if (requested == "smoke") {
+    return {{requested, 8 * MB, 12, 2, {4, 16}, 12}, output};
+  }
+  if (requested == "baseline") {
+    return {{requested, 64 * MB, 80, 2, {8, 32, 128}, 80}, output};
+  }
+  throw std::runtime_error("unknown profile: " + requested);
+}
+
+} // namespace
+
+int main(int argc, char **argv) {
+  try {
+    const auto options = parse_options(argc, argv);
+    const auto &config = options.config;
+    if (!options.output.empty() && fs::exists(options.output)) {
+      throw std::runtime_error("refusing to overwrite evidence file: " + options.output.string());
+    }
+    temp_tree tree;
+    json report = {{"schema", "kungfu.mmap-qualification.v1"},
+                   {"profile", config.name},
+                   {"source",
+                    {{"git_head", std::getenv("KUNGFU_QUALIFICATION_GIT_HEAD") != nullptr
+                                      ? std::getenv("KUNGFU_QUALIFICATION_GIT_HEAD")
+                                      : "unknown"},
+                     {"git_dirty", std::getenv("KUNGFU_QUALIFICATION_GIT_DIRTY") != nullptr
+                                       ? std::getenv("KUNGFU_QUALIFICATION_GIT_DIRTY")
+                                       : "unknown"}}},
+                   {"host", host_facts()},
+                   {"fixture",
+                    {{"temporary_root", true},
+                     {"primitive_bytes", config.primitive_size},
+                     {"journal_page_size_bytes", config.journal_page_size_mb * MB},
+                     {"payload_bytes", PAYLOAD_SIZE},
+                     {"seek_page_counts", config.seek_page_counts}}},
+                   {"semantic_limits",
+                    {{"mapping_policy", "demand+visibility"},
+                     {"os_page_cache_cold", "not_measured"},
+                     {"power_loss_durability", "not_claimed"}}}};
+    report["primitive_mapping"] = primitive_mapping(tree, config);
+    report["journal"] = json::array();
+    for (const auto page_count : config.seek_page_counts) {
+      const auto fixture = build_journal_fixture(tree, page_count, config);
+      report["journal"].push_back({{"page_count", page_count},
+                                   {"frames_written", fixture.frames},
+                                   {"write_payload_mib_per_second", fixture.write_mib_per_second},
+                                   {"write_page_switch", fixture.write_switches},
+                                   {"write_resources", fixture.write_resources},
+                                   {"sequential_read", read_journal(fixture, config)},
+                                   {"seek", seek_journal(fixture, page_count, config)}});
+    }
+    if (options.output.empty()) {
+      std::cout << report.dump(2) << '\n';
+    } else {
+      std::ofstream stream(options.output);
+      if (!stream) {
+        throw std::runtime_error("cannot open evidence output: " + options.output.string());
+      }
+      stream << report.dump(2) << '\n';
+      if (!stream) {
+        throw std::runtime_error("cannot write evidence output: " + options.output.string());
+      }
+      std::cout << "mmap qualification evidence: " << options.output << '\n';
+    }
+    return 0;
+  } catch (const std::exception &error) {
+    std::cerr << "mmap qualification failed: " << error.what() << '\n';
+    return 1;
+  }
+}

--- a/framework/core/src/libyijinjing/tests/mmap_tests.cpp
+++ b/framework/core/src/libyijinjing/tests/mmap_tests.cpp
@@ -104,6 +104,22 @@ std::string create_page_path(const kungfu::yijinjing::data::location_ptr &loc) {
   return page::get_page_path(loc, location::PUBLIC, 1);
 }
 
+void create_seek_page(const kungfu::yijinjing::data::location_ptr &loc, uint32_t page_id, int64_t begin_time,
+                      kungfu::yijinjing::enums::PageStatus status = kungfu::yijinjing::enums::PageStatus::Normal) {
+  const auto path = page::get_page_path(loc, location::PUBLIC, page_id);
+  auto region = mapped_region::map(path, TEST_PAGE_SIZE, mapping_policy::write_create_or_grow());
+  auto *header = reinterpret_cast<page_header *>(region.address());
+  header->version = __JOURNAL_VERSION__;
+  header->page_header_length = sizeof(page_header);
+  header->page_size = TEST_PAGE_SIZE;
+  header->frame_header_length = sizeof(frame_header);
+  header->status = status;
+  header->last_frame_position = sizeof(page_header);
+  auto *first_frame = reinterpret_cast<frame_header *>(region.address() + sizeof(page_header));
+  first_frame->gen_time = begin_time;
+  require(region.reset(), "failed to release seek-page fixture mapping");
+}
+
 void test_wire_layout_invariants() {
   static_assert(sizeof(page_header) == 32, "wire-v1 page_header size changed");
   static_assert(sizeof(frame_header) == 72, "wire-v1 frame_header size changed");
@@ -375,6 +391,21 @@ void test_page_header_publication() {
   require(reader->first_frame_address() > reader->address(), "reader observed an invalid first-frame address");
 }
 
+void test_page_lookup_uses_ordered_begin_times() {
+  temp_tree tree;
+  auto loc = make_location(tree.root());
+  for (uint32_t page_id = 1; page_id <= 4; ++page_id) {
+    create_seek_page(loc, page_id, static_cast<int64_t>(page_id) * 100);
+  }
+  create_seek_page(loc, 5, 500, kungfu::yijinjing::enums::PageStatus::PreOpen);
+
+  require(page::find_page_id(loc, location::PUBLIC, 0) == 1, "zero-time lookup did not select the first page");
+  require(page::find_page_id(loc, location::PUBLIC, 100) == 1,
+          "lookup at the first begin time did not preserve first-page fallback");
+  require(page::find_page_id(loc, location::PUBLIC, 201) == 2, "lookup did not select the latest earlier page");
+  require(page::find_page_id(loc, location::PUBLIC, 1'000) == 4, "lookup selected a pre-open tail page");
+}
+
 } // namespace
 
 int main() {
@@ -392,6 +423,7 @@ int main() {
       {"corrupt page offsets fail before payload access", test_corrupt_page_offsets_fail_before_payload_access},
       {"corrupt page header facts are rejected", test_corrupt_page_header_facts_are_rejected},
       {"page header publication", test_page_header_publication},
+      {"page lookup uses ordered begin times", test_page_lookup_uses_ordered_begin_times},
   };
 
   int failed = 0;

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "kfd2:claims:check": "node scripts/require-shifu.mjs kfd2:claims:check && buildchain kfd 2 product-claims check",
     "check:types": "node scripts/require-shifu.mjs check:types && tsc -p tsconfig.tools.json",
     "test:mmap": "node scripts/require-shifu.mjs test:mmap && node scripts/run-mmap-tests.mjs",
+    "qualify:mmap": "node scripts/require-shifu.mjs qualify:mmap && node scripts/run-mmap-qualification.mjs",
     "version": "node scripts/sync-shifu-version.mjs && git add crates/shifu/Cargo.toml crates/Cargo.lock",
     "prepare": "node scripts/install-hooks.mjs",
     "hooks:install": "node scripts/require-shifu.mjs hooks:install && node scripts/install-hooks.mjs --force"

--- a/scripts/run-mmap-qualification.mjs
+++ b/scripts/run-mmap-qualification.mjs
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+
+const root = process.cwd();
+const buildDir = path.join(root, 'framework', 'core', 'build');
+const executable =
+  process.platform === 'win32'
+    ? 'yijinjing_mmap_qualification.exe'
+    : 'yijinjing_mmap_qualification';
+const candidates = [
+  path.join(root, 'framework', 'core', 'build', 'Release', executable),
+  path.join(root, 'framework', 'core', 'build', executable),
+];
+if (!fs.existsSync(path.join(buildDir, 'CMakeCache.txt'))) {
+  console.error(
+    '[mmap-qualification] configured core build not found; run ./shifu build first',
+  );
+  process.exit(2);
+}
+// This script is itself entered through ./shifu qualify:mmap. Building one
+// evidence-only target avoids making unrelated product adapters part of the
+// qualification loop after the normal core configure step.
+const build = spawnSync(
+  'cmake',
+  [
+    '--build',
+    buildDir,
+    '--config',
+    'Release',
+    '--target',
+    'yijinjing_mmap_qualification',
+    'yijinjing_mmap_tests',
+  ],
+  { cwd: root, stdio: 'inherit' },
+);
+if (build.error || build.status !== 0) {
+  console.error('[mmap-qualification] failed to build native evidence tool');
+  process.exit(build.status ?? 1);
+}
+const qualificationBinary = candidates.find((candidate) =>
+  fs.existsSync(candidate),
+);
+if (!qualificationBinary) {
+  console.error('[mmap-qualification] build completed without the native tool');
+  process.exit(2);
+}
+
+const forwardedArgs = process.argv.slice(2);
+if (forwardedArgs[0] === '--') forwardedArgs.shift();
+const gitHead = spawnSync('git', ['rev-parse', 'HEAD'], {
+  cwd: root,
+  encoding: 'utf8',
+});
+const gitStatus = spawnSync('git', ['status', '--porcelain'], {
+  cwd: root,
+  encoding: 'utf8',
+});
+const result = spawnSync(qualificationBinary, forwardedArgs, {
+  cwd: root,
+  env: {
+    ...process.env,
+    KUNGFU_QUALIFICATION_GIT_HEAD:
+      gitHead.status === 0 ? gitHead.stdout.trim() : 'unknown',
+    KUNGFU_QUALIFICATION_GIT_DIRTY:
+      gitStatus.status === 0 && gitStatus.stdout.trim() === ''
+        ? 'false'
+        : 'true',
+  },
+  stdio: 'inherit',
+});
+if (result.error) {
+  console.error(
+    `[mmap-qualification] failed to start ${qualificationBinary}: ${result.error.message}`,
+  );
+  process.exit(1);
+}
+process.exit(result.status ?? 1);


### PR DESCRIPTION
## Summary

- add a reproducible native mmap qualification harness and retain macOS/Linux evidence
- replace reverse-linear page-header lookup with a tail fast path plus ordered binary probes
- record independent accept/reject/defer decisions for sizing, advice, residency, flush range, and release polling

## Evidence

- Mac three-round A/B at 128 pages: early seek p50 3.131-3.505 ms -> 0.298-0.517 ms; middle 1.825-1.953 ms -> 0.293-0.454 ms; late unchanged
- Linux three-round A/B: early 0.750-0.782 ms -> 0.153-0.155 ms; middle 0.431-0.454 ms -> 0.152-0.154 ms; late unchanged
- `./shifu rebuild` passed on macOS arm64 and agent-120 Linux x86_64
- `./shifu test:mmap` passed on both hosts
- `./shifu check` passed on macOS

## Compatibility

No wire bytes, Hana POD layout, public API, mapping authority, or durability semantics change. Rollback is a normal revert of the two lookup commits.