### PR TITLE
fix(ci): honor the libwasm Rust pin

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
       buildchain-ref: ${{ inputs.buildchain-ref || '' }}
       runner-preset: kungfu-v4-self-hosted
       setup-rust: true
-      rust-toolchain: "1.96.0"
+      rust-toolchain: "1.95.0"
       rustup-dist-server: https://rsproxy.cn
       rustup-update-root: https://rsproxy.cn/rustup
       cargo-registry-index: ${{ vars.BUILDCHAIN_CARGO_REGISTRY_INDEX }}


### PR DESCRIPTION
Summary: align the self-hosted CI bootstrap with the authoritative Rust 1.95.0 pins in `crates/libwasm/rust-toolchain.toml` and `crates/libwasm-spike/rust-toolchain.toml`, so the native build does not attempt a second rustup install inside the build lifecycle. This is the follow-up to #590 discovered by real matrix validation. Validation: `actionlint .github/workflows/build.yml` and `./shifu check` pass. The final self-hosted proof run is 29157505924. Related to #579.