### PR TITLE
docs(adr): add ADR-0060 journal container epoch and page-sizing design note

### DIFF
--- a/docs/episode-object-model.md
+++ b/docs/episode-object-model.md
@@ -145,6 +145,12 @@ proofs remain unambiguous. The important rule is that every frame can be mapped
 to Episode coordinates and every Episode can name the physical evidence that
 proves it.
 
+[`journal-page-sizing-and-episode-reclamation.md`](journal-page-sizing-and-episode-reclamation.md)
+records the design judgment that constrains this future work: page-size variation
+serves only the max-frame bound at page creation, space efficiency comes from
+segment packing rather than per-Episode variable-length pages, and reclamation is
+tombstone-then-cold-path GC rather than shrinking live pages.
+
 ## Episode Manifest
 
 A sealed Episode manifest is the folded result of append-only manifest journal

--- a/docs/journal-page-sizing-and-episode-reclamation.md
+++ b/docs/journal-page-sizing-and-episode-reclamation.md
@@ -1,0 +1,126 @@
+# Design note: journal page sizing, max-frame, and Episode-aware reclamation
+
+- Status: design judgment (note, not a decision record)
+- Date: 2026-07-11
+- Anchors: [ADR-0033](../framework/core/docs/adr/ADR-0033-episode-causal-segment-object.md)
+  (Episode as causal segment), [ADR-0034](../framework/core/docs/adr/ADR-0034-yijinjing-episode-manifest-journal.md)
+  (append-only manifest journal). Related: [ADR-0001](../framework/core/docs/adr/ADR-0001-yijinjing-publish-barrier.md)
+  (publish barrier), [ADR-0024](../framework/core/docs/adr/ADR-0024-location-role-and-journal-page-policy.md)
+  (page size is storage policy), [ADR-0055](../framework/core/docs/adr/ADR-0055-retire-journal-session-and-separate-runtime-state-from-projection.md)
+  / [ADR-0056](../framework/core/docs/adr/ADR-0056-retire-legacy-journal-cli-lifecycle-tools.md)
+  (journal lifecycle belongs to Storage/Episode), [ADR-0058](../framework/core/docs/adr/ADR-0058-yijinjing-explicit-mapping-policies.md)
+  (mapping / page-open policies), and [`episode-object-model.md`](episode-object-model.md)
+  (whose "Physical Shape" section names the Episode-aware physical layout as
+  future work).
+
+## Why this note exists
+
+`episode-object-model.md` records that "the full Episode-aware physical journal
+layout is still future work," and sketches a target of
+`Episode -> segment allocation domain -> mmap pages -> frames`. That open item
+invites a recurring proposal: make journal pages variable-length (and/or
+per-Episode) so that partly-filled pages do not waste space, with a garbage
+collector to reclaim them.
+
+This note records the judgment that resulted from verifying how Episodes map to
+pages today, so the future layout work does not adopt variable-length live pages
+for the wrong reason. It constrains the design; it does not itself change code.
+
+## Verified current mapping (the facts)
+
+- A journal is a per-`(location, dest_id)` append stream. Pages live at
+  `journal/{role}/{namespace}/{name}/{mode}/{dest_id}.{page_id}.journal`
+  (`locator::layout_directory`, `page::resolve_page_path`). Raw mmap pages are
+  shared append blocks, not Episode-owned objects.
+- An Episode is a bounded causal segment, not a physical page owner. The Episode
+  manifest names the included frames as `frame_ranges` over the shared channel
+  journals (ADR-0033/0034). The physical shape is three parts: shared event
+  journals, one append-only Episode manifest journal, and a content-addressed
+  payload store. Multiple Episodes share a channel's pages; a long Episode spans
+  many pages. There is no per-Episode page or file today.
+- Consequently there is no "last page of an Episode" today. Closing an Episode
+  leaves no partial page: the channel keeps appending the next Episode's frames
+  into the same page. The only partial tails are the live page of each active
+  channel and the final page of a channel that stops being written — bounded by
+  channel count, not Episode count.
+- Those partial tails cost almost no physical space on the primary platforms.
+  Page files are created with `ftruncate` (POSIX) without writing zeros, so the
+  unwritten tail is a sparse hole: `ls` shows the nominal size, `du` shows only
+  the written bytes. Windows uses `SetEndOfFile` without `FSCTL_SET_SPARSE`, so
+  the tail there is not sparse and is the one place the waste is physically real.
+
+## Judgment
+
+1. **Trailing-page waste is not a per-Episode property, and on POSIX it is not a
+   physical-space problem.** It is one sparse partial tail per idle channel. Do
+   not treat it as a live-format problem or size the format around it. The one
+   concrete fix worth doing for space is to mark page files sparse on Windows
+   (`FSCTL_SET_SPARSE`), which is format-preserving.
+
+2. **Live pages stay fixed-capacity and sparse; they are never variable-length
+   or growable under readers.** The lock-free tail-read contract (ADR-0001)
+   depends on a stable mapping and fixed page geometry (`address_border` derives
+   from `page_size`). Resizing a page that readers are concurrently tailing
+   reopens the publication-barrier synchronization that ADR-0001 closed, and a
+   live append page cannot be sized to its final content because the future is
+   unknown.
+
+3. **Variable page size at *creation* is sanctioned only to serve the max-frame
+   bound.** A frame larger than the page body can never be written, so
+   `page_size` is each channel's maximum frame size. When a channel must carry an
+   occasional large frame, the new page created at rollover may be sized
+   `max(policy_default, round_up(incoming_frame))`. This is decided once, at
+   creation, and readers already discover the size from the page header
+   (`reader_policy::peer` / `discover_page_size`), so it does not touch
+   live-mapping stability. This is the only reason to vary page size, and it is
+   orthogonal to space reclamation.
+
+4. **Episode-aware space efficiency is packing, not per-Episode pages.** The
+   Episode model already anticipates and rejects one-page-per-Episode: "small
+   Episodes may share provider blocks if the manifest and fsck proofs remain
+   unambiguous." The future `segment allocation domain` should therefore let many
+   small Episodes share a page's segments (packing), with the manifest naming
+   each Episode's frame/segment range. Per-Episode variable-length pages would
+   fight this share-blocks intent, not serve it.
+
+5. **Reclamation is tombstone then cold-path physical GC, owned by
+   Storage/Episode.** The model already separates a logical tombstone from
+   physical garbage collection. Physical reclamation belongs to the
+   Storage/Episode cold path (ADR-0055/0056), and its unit is a whole
+   page/segment once every Episode referencing it is tombstoned. It is not
+   achieved by shrinking live pages.
+
+6. **Any page-geometry change must preserve manifest coordinates.** The manifest
+   records `frame_ranges` as segment/page coordinates. Variable-at-creation
+   sizing, cold compaction, and any truncate-on-seal must keep those coordinates
+   valid or rewrite them transactionally. In particular, the current exact
+   `header->page_size == requested` check in `page::load` must become
+   reader-discovers-from-header before any sealed page is truncated, so a shrunk
+   page still loads.
+
+## Explicitly rejected
+
+Per-Episode or variable-length **live** pages introduced to reclaim
+trailing-page space. On POSIX the space is already sparse (near-zero physical);
+the approach fights the ADR-0001 stable-mapping contract and the model's
+share-blocks intent; and a live append page cannot be pre-sized to its content.
+Space efficiency is packing plus cold GC; page-size variation is reserved for
+the max-frame bound at creation time.
+
+## Follow-ups
+
+- Confirm the sparse assumption on the actual target filesystems with `du`
+  versus `ls` on a real data home; add the Windows `FSCTL_SET_SPARSE` marking if
+  Windows tails are shown to consume clusters.
+- Decide ADR-0024's fate: implement a real per-`(role, channel)` size policy in
+  `find_page_size` (which currently ignores `location` and `dest_id`), or drop
+  the vestigial parameters so the code stops implying a policy that does not
+  exist.
+- When the `segment allocation domain` is designed, treat this note's judgments
+  2–6 as constraints: packing over per-Episode pages, cold-path GC over live
+  shrink, and transactional manifest-coordinate preservation.
+- The journal *container format* epoch (page/frame header layout) is governed
+  separately from page sizing by
+  [ADR-0062](../framework/core/docs/adr/ADR-0062-journal-container-epoch-and-offline-conversion.md);
+  page size is a per-page allocation parameter and is not part of the format
+  epoch.

--- a/framework/core/docs/adr/ADR-0033-episode-causal-segment-object.md
+++ b/framework/core/docs/adr/ADR-0033-episode-causal-segment-object.md
@@ -11,7 +11,9 @@
   timeline projection. ADR-0032 defines the generic source service v1. ADR-0034
   defines the yijinjing-backed Episode manifest journal.
   [`docs/episode-object-model.md`](../../../../docs/episode-object-model.md)
-  is the companion design document.
+  is the companion design document, and
+  [`docs/journal-page-sizing-and-episode-reclamation.md`](../../../../docs/journal-page-sizing-and-episode-reclamation.md)
+  is the design note constraining page sizing and Episode-aware reclamation.
 
 ## Context
 

--- a/framework/core/docs/adr/ADR-0034-yijinjing-episode-manifest-journal.md
+++ b/framework/core/docs/adr/ADR-0034-yijinjing-episode-manifest-journal.md
@@ -8,9 +8,12 @@
 - Related: ADR-0047 assigns closed kernel records to the Hana POD substrate and
   open/domain facts to FlatBuffers. ADR-0022 defines the C++ core as the
   action-recording membrane.
-  ADR-0033 defines Episode as the first-class causal segment object.
+  ADR-0033 defines Episode as the first-class causal segment object. ADR-0062
+  governs the journal container format epoch, which is separate from page sizing.
   [`docs/episode-object-model.md`](../../../../docs/episode-object-model.md)
-  describes the Episode object model.
+  describes the Episode object model, and
+  [`docs/journal-page-sizing-and-episode-reclamation.md`](../../../../docs/journal-page-sizing-and-episode-reclamation.md)
+  is the design note constraining page sizing and Episode-aware reclamation.
 
 ## Context
 

--- a/framework/core/docs/adr/ADR-0062-journal-container-epoch-and-offline-conversion.md
+++ b/framework/core/docs/adr/ADR-0062-journal-container-epoch-and-offline-conversion.md
@@ -1,0 +1,216 @@
+# ADR-0062: the journal container epoch is derived from its layout, and cross-epoch replay is offline conversion
+
+- Status: accepted; not yet implemented
+- Date: 2026-07-11
+- Category: (b) mechanism / governance — data-format enforcement
+- Subsystem: `libyijinjing` journal (`page_header` / `frame_header`), yijinjing schema
+- Related: [ADR-0008](ADR-0008-yijinjing-schema-layout-baseline.md) (parent policy —
+  released closed-layout compatibility baseline; hot path speaks one epoch, cold
+  path carries explicit migration/decode), [ADR-0001](ADR-0001-yijinjing-publish-barrier.md)
+  (the page/frame publish barrier this format must not disturb),
+  [ADR-0058](ADR-0058-yijinjing-explicit-mapping-policies.md) (the page-open
+  policies that gate who may initialize a page),
+  [ADR-0028](ADR-0028-hash-taxonomy-and-integrity-algorithms.md) (a layout
+  fingerprint is a distinct hash surface, not a frame checksum or content hash),
+  [ADR-0029](ADR-0029-frame-checksum-v2-crc32c.md),
+  [ADR-0047](ADR-0047-authoritative-facts-hana-pod-or-flatbuffers.md)
+
+## Context
+
+The journal *container* — the `page_header` and `frame_header` binary layouts
+that yijinjing mmaps and publishes — carries a single version integer
+`__JOURNAL_VERSION__` (in `journal/common.h`, currently `4`). It is the format
+epoch for the whole container, covering both headers.
+
+The mechanics today:
+
+- A writer stamps `version`, `page_header_length` (`= sizeof(page_header)`),
+  `page_size`, and `frame_header_length` (`= sizeof(frame_header)`) into a page
+  only when it first initializes a *virgin* page (`page::load`).
+- Any process opening an *existing* page runs three hard checks in `page::load`
+  and throws `journal_error` on the first mismatch: `version`,
+  `page_header_length`, `frame_header_length` (and then `page_size`). There is no
+  in-place adaptation and no migration.
+
+This correctly serves the container's primary role — a same-machine mmap IPC
+substrate where all peers come from one binary, one epoch, one `sizeof`. Two
+different-epoch peers sharing one page must never proceed, so a hard refusal is
+the only safe behavior, and ADR-0008 already ratifies this stance at the policy
+level ("hot path speaks one schema layout epoch"). What ADR-0008 does *not*
+specify is the enforcement mechanism, and two gaps exist below its policy:
+
+1. **The epoch is a hand-edited constant and is blind to size-preserving layout
+   changes.** The two `*_length` checks only catch changes that alter
+   `sizeof(page_header)` or `sizeof(frame_header)`. A size-preserving change —
+   reusing a field, an equal-width retype, a reorder that keeps `sizeof` equal —
+   passes all three runtime checks with the epoch unchanged, and old data is then
+   silently misread. `frame_header` is more exposed still: it has no version
+   field of its own and is guarded solely by `frame_header_length`. This directly
+   threatens ADR-0008's "released v4+ data is not silently stranded."
+
+2. **The read path claims a cross-epoch capability it does not have.**
+   `assemble::read_bytes` contains a branch that skips frames from a
+   version-mismatched page and warns. Under the current `page::load` contract
+   that branch is unreachable: the reader's page acquisition
+   (`journal::load_page` → `page::load`) refuses a mismatched page before the
+   assembler can skip it. The code reads as if mixed-epoch replay degrades
+   gracefully; it does not.
+
+## Decision
+
+This ADR operationalizes ADR-0008 for the journal container. It changes no wire
+or POD layout and adds no hot-path adapter.
+
+1. **One closed epoch.** The container format is a single closed epoch. It is
+   deliberately not self-describing and not online-compatible. Mixed-epoch mmap
+   peers are never permitted.
+
+2. **Hard refusal stays the hot-path contract.** A page whose stored epoch
+   differs from the running epoch is refused at load, never adapted in place.
+   This is the existing behavior, ratified here.
+
+3. **The epoch is derived from the layout, not hand-maintained.** The epoch is a
+   compile-time function of a *layout fingerprint* over the `page_header` and
+   `frame_header` field set and layout (folded via `boost::hana::accessors`,
+   mixing each field's name and type token together with `sizeof`/`alignof` of
+   each header). Any edit to either layout necessarily changes the fingerprint,
+   hence the epoch; pages written under the old layout carry the old epoch and
+   are refused by rule 2 automatically. This closes gap (1) by construction,
+   including the size-preserving and `frame_header` cases: an unversioned layout
+   change is not possible, because there is no separate version to forget. The
+   epoch is machine-only — it is never read by a human and carries no ordering or
+   release meaning — so it is intentionally an opaque derived value, not a
+   legible monotonic integer.
+
+   The fingerprint is a build-identity hash and is a separate surface from the
+   frame checksum (ADR-0029) and content hashes (ADR-0028); it is never written
+   into a frame body. Its derivation and a `static_assert` that it is a
+   well-formed compile-time constant live beside the existing container
+   invariants in the anonymous namespace at the top of `page.cpp` (which already
+   `static_assert`s alignment and lock-free atomicity for the publication
+   tokens), so the layout contract is enforced in one place.
+
+4. **Layout is binary layout; a pure semantic reinterpretation must rename.** The
+   fingerprint catches every change to field name, type, order, or size. It
+   cannot catch a change that keeps a field's name and type but redefines its
+   meaning (for example, reinterpreting a timestamp field's unit). No layout
+   hash can. The governing rule is therefore a convention: **a change to a
+   field's meaning must change its name or type**, so that a semantic break
+   becomes a fingerprint break and the epoch advances with it. This bound is
+   stated so the derived epoch is not mistaken for a semantic guarantee.
+
+5. **Cross-epoch replay is offline conversion, exclusively.** Reading historical
+   journals written under an older epoch is served by an explicit offline
+   converter that decodes old-epoch pages and emits current-epoch facts or an
+   export. This is the concrete realization of ADR-0008's "cold-path
+   import/export/replay/fsck can carry explicit migrations or decode paths," and
+   it discharges "released v4+ data is not silently stranded" without smuggling a
+   hidden adapter into the zero-copy hot path (ADR-0008 replacement criterion 6).
+   Online readers never translate across epochs.
+
+6. **The read path is made honest.** The unreachable skip-mismatched-page branch
+   in `assemble::read_bytes` is removed, so hard refusal is the single, truthful
+   read-path semantics. If mixed-epoch cold replay is wanted later, it is built as
+   the offline converter of (5) on an explicit epoch-probing path — not
+   reintroduced as tolerance inside the live assembler.
+
+7. **The offline converter is deferred; the standing contract is
+   archive-and-read-with-its-own-binary.** This ADR sanctions the offline
+   converter as *the* path for cross-epoch replay but does not build it now.
+   Until it exists, the contract is firm: an old-epoch journal is archived as raw
+   bytes and read only by a runtime of its own epoch; a newer-epoch runtime that
+   meets an old-epoch page refuses it (rule 2). The converter's build trigger is
+   concrete: **the first epoch advance that would affect already-released v4
+   journals.** Deferral is valid only while no such advance has shipped;
+   pre-stable-release baseline cleanups that advance the epoch (permitted by
+   ADR-0008) do not trigger it. This keeps the deferral inside ADR-0008's
+   "released v4+ data is not silently stranded" obligation: the recourse (raw
+   archive + own-epoch binary) is declared and non-silent, and the converter
+   becomes required precisely when that recourse stops being enough.
+
+## Rationale
+
+The container is not a persistence format that must be read forever by evolving
+code; it is an IPC substrate plus a short-lived record that is regenerated per
+run and archived raw. Its value comes from being dumb, fixed-width, and
+zero-copy. The failure mode worth engineering against is not "we cannot read old
+data online" — that is intended — but "we changed the layout and did not say so."
+Deriving the epoch from the layout removes the last place a human could fail to
+say so: the machine says it, every time, for free.
+
+Because the epoch has no human reader, it need not be legible or monotonic.
+Trading legibility for a derivation that cannot be forgotten is the right
+exchange here — reliability over cleverness, mechanism over discipline.
+
+## Consequences
+
+- Any change to `page_header` or `frame_header` layout — additive, subtractive,
+  reordering, retyping, or size-preserving reinterpretation — changes the epoch
+  automatically; old-epoch pages are refused without any code edit or reviewer
+  vigilance. A deliberate rename is required to version a pure semantic change
+  (rule 4).
+- The epoch value is an opaque derived number. Anything that wants a
+  human-legible release identifier for the journal format must derive it
+  elsewhere (for example in the release tag), not read the epoch.
+- The fingerprint must be computed from platform-stable inputs so one payload has
+  the same epoch on every target. The container already uses fixed-width fields
+  and `aligned(8)`; enum fields must keep fixed underlying types, and nothing
+  platform-dependent (pointer or `long` sizes) may enter a header or the
+  fingerprint.
+- Historical journals across an epoch boundary are not readable by a new-epoch
+  runtime online. Until the deferred converter is built (rule 7), their data is
+  reached by running their own epoch's binary against the raw archive.
+- `assemble::read_bytes` no longer carries a dead cross-epoch branch; the read
+  path's behavior matches its code.
+- No hot-path cost, no wire/POD layout change, no change to the ADR-0001
+  publication barrier or the ADR-0058 page-open policies. `page_size` remains a
+  per-page allocation parameter and is not part of the epoch.
+
+## Alternatives considered
+
+- **Keep a legible monotonic `__JOURNAL_VERSION__` and pair it with a
+  fingerprint `static_assert`.** A layout change would break the assertion and
+  force the developer to advance both the integer and the checked-in fingerprint.
+  Rejected: it keeps a human in the loop for a value no human consumes, and the
+  assertion-and-remember step is exactly the discipline the derived epoch
+  removes. Legibility has no consumer at the container layer.
+- **Make the reader epoch-tolerant (skip mismatched pages, warn).** Rejected: it
+  puts a hidden translation in the zero-copy hot path (violates ADR-0008
+  criterion 6) and is unsafe for mmap IPC, where a mismatch means two
+  incompatible binaries are sharing memory. Cross-epoch reading belongs off the
+  hot path.
+- **A self-describing / variable-length container header.** Rejected for the
+  container: it imposes decode cost on every page open and invites false
+  confidence that old data is safe online. The evolvable representation already
+  exists one layer up for payloads (`.fbs`/`.bfbs`, ADR-0047); the container
+  stays closed POD.
+- **Give `frame_header` its own version field.** Not adopted: the derived epoch
+  already covers both headers; a second field would add a thing to keep in sync
+  without adding safety.
+
+## Verification
+
+- A build-time check: mutating any `page_header` / `frame_header` field in a
+  scratch build must change the derived epoch (and a paired page written before
+  the change must fail to load after it); an unrelated change must not.
+- Confirm the claim in gap (2) with a small harness (write a page, rewrite its
+  header epoch, drive the reader) so the removal of the `assemble` skip branch is
+  grounded on a demonstrated-unreachable path rather than inspection.
+- Confirm the fingerprint is identical across macOS, Linux, and Windows targets
+  for the same layout.
+- Existing container invariants remain: the `page.cpp` alignment / lock-free
+  `static_assert`s and the `page::load` runtime `*_length` / `page_size` checks
+  are unchanged.
+
+## Replacement Criteria
+
+A replacement design is acceptable only if it preserves:
+
+1. one closed, non-self-describing container epoch on the hot path;
+2. hard refusal (never in-place adaptation) of a mismatched page in the live
+   read/write path;
+3. a compile-time guarantee that a layout change cannot ship without an epoch
+   advance;
+4. cross-epoch reading kept off the zero-copy hot path (offline converter or
+   equivalent explicit cold path);
+5. no dead code that implies a cross-epoch capability the hot path lacks.

--- a/framework/core/docs/adr/README.md
+++ b/framework/core/docs/adr/README.md
@@ -79,6 +79,7 @@ A record's **Status** says where it stands:
 | [0059](ADR-0059-mission-control-mission-go-responsibility-model.md) | accepted | Mission Control composes Mission and Go responsibility over runtime facts; Atlas starts as a bridged authority |
 | [0060](ADR-0060-desktop-workspace-selection-and-lazy-data-home.md) | proposed | Desktop and CLI select Home or a project workspace and create its data home only on qualified write intent |
 | [0061](ADR-0061-agent-mediated-guidance-is-a-first-class-product-interface.md) | proposed | Agent-mediated guidance is a first-class interface over shared advice, preview, authorization, action, and receipt contracts |
+| [0062](ADR-0062-journal-container-epoch-and-offline-conversion.md) | accepted; not yet implemented | the journal container epoch is derived from its layout; cross-epoch replay is deferred offline conversion, not an online adapter |
 
 ## Reading by theme
 
@@ -90,6 +91,10 @@ A record's **Status** says where it stands:
   [0058](ADR-0058-yijinjing-explicit-mapping-policies.md) separates mmap
   authority from residency and durability requests without changing the wire
   or POD layouts.
+  [0062](ADR-0062-journal-container-epoch-and-offline-conversion.md) derives the
+  journal container epoch from the page/frame header layout itself, so an
+  unversioned layout change cannot ship, and keeps cross-epoch replay off the hot
+  path as deferred offline conversion.
   [0002](ADR-0002-yijinjing-schema-runtime-layout.md) is retained as the
   superseded historical decision that preceded this split.
 - **Control / event axis** — [0003](ADR-0003-control-axis-python-coroutine-integration.md)
@@ -236,6 +241,10 @@ A record's **Status** says where it stands:
 - [`docs/episode-object-model.md`](../../../../docs/episode-object-model.md) —
   the Episode object model, causal closure invariant, and storage migration
   direction.
+- [`docs/journal-page-sizing-and-episode-reclamation.md`](../../../../docs/journal-page-sizing-and-episode-reclamation.md) —
+  the design judgment constraining the future Episode-aware physical layout:
+  page-size variation only for max-frame, packing over per-Episode pages, and
+  tombstone-then-cold-path GC (ADR-0033/0034, ADR-0055/0056).
 - [`docs/episode-atomicity-qualification.md`](../../../../docs/episode-atomicity-qualification.md) —
   the evolving semantic oracle, fault matrix, scale tiers, metrics, and Episode
   Trust Report design required by ADR-0042.


### PR DESCRIPTION
Adds ADR-0060 (journal container epoch derived from the page/frame header layout; hard refusal on the hot path; deferred offline cross-epoch conversion) and the journal-page-sizing-and-episode-reclamation design note, wired into the ADR index, data-axis theme, related documents, episode-object-model, and ADR-0033/0034. Documentation only.