### PR TITLE
fix(ci): align libwasm Rust toolchain pins

### DIFF
--- a/crates/libwasm-spike/rust-toolchain.toml
+++ b/crates/libwasm-spike/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.95.0"
+channel = "1.96.0"
 profile = "minimal"

--- a/crates/libwasm/rust-toolchain.toml
+++ b/crates/libwasm/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.95.0"
+channel = "1.96.0"
 profile = "minimal"

--- a/framework/core/slices/libwasm-shared-membrane/README.md
+++ b/framework/core/slices/libwasm-shared-membrane/README.md
@@ -60,7 +60,7 @@ registry mirror. Leaving it empty uses the official Cargo source; CI may set a
 reviewed mirror URL while Cargo still verifies the checksums pinned in each
 adapter's lockfile.
 
-The standalone spike pins Rust 1.95.0 with a minimal profile in its own
+The standalone spike pins Rust 1.96.0 with a minimal profile in its own
 directory. Wasmtime 46.0.1 requires Rust 1.94 and Wasmer 7.2.0 requires Rust
 1.93; the local pin keeps older self-hosted runner defaults from silently
 selecting an unsupported compiler without changing the root workspace policy.


### PR DESCRIPTION
Fixes #604.

Align both libwasm toolchain pins with the Rust 1.96.0 version provisioned by the self-hosted Buildchain runner contract. This prevents parallel Wasmer/Wasmtime targets from racing two implicit rustup installs of the old 1.95.0 toolchain.

Evidence:
- exact race captured in alpha r2 Linux run 29157376683
- `./shifu check` passed
- staged pre-commit gate passed

A replacement alpha candidate will rerun all three product legs after merge.