### PR TITLE
fix(windows): unblock mmap build and RAII qualification

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,4 @@ framework/config/*.contract.json text eol=lf
 framework/kfx/*.contract.json text eol=lf
 framework/skill/*.contract.json text eol=lf
 framework/contract/*.json text eol=lf
+framework/core/stubs/**/*.pyi text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Canonical contract bytes are hashed and compared byte-for-byte. Keep their
+# line endings independent of the checkout platform.
+framework/config/*.contract.json text eol=lf
+framework/kfx/*.contract.json text eol=lf
+framework/skill/*.contract.json text eol=lf
+framework/contract/*.json text eol=lf

--- a/crates/shifu/src/main.rs
+++ b/crates/shifu/src/main.rs
@@ -51,6 +51,11 @@ use shifu_core::style;
 /// mirroring the sh / cmd entrypoints. Everything else goes to corepack pnpm.
 const L2_SUBCOMMANDS: &[&str] = &["build", "rebuild", "proxy", "config"];
 
+#[cfg(any(windows, test))]
+fn command_requires_msvc(command: Option<&str>) -> bool {
+    !matches!(command, Some("proxy" | "config"))
+}
+
 fn print_usage() {
     println!(
         "\u{1f94b} {}",
@@ -176,15 +181,17 @@ fn main() {
     }
     let root = root.expect("strict repo discovery cannot return None");
 
+    // L2 build/rebuild dispatches inherit this process environment, so load
+    // MSVC before selecting the Node path. Proxy/config are intentionally
+    // compiler-free; ordinary pnpm tasks keep the historical MSVC bootstrap.
+    #[cfg(windows)]
+    if command_requires_msvc(first) {
+        msvc::ensure_msvc_env(&root);
+    }
+
     match first {
         Some(cmd) if L2_SUBCOMMANDS.contains(&cmd) => dispatch::delegate_l2(&root, &args),
-        _ => {
-            // Build tasks on Windows need the MSVC environment (cl.exe) for the
-            // C++ core; load vcvars when it is not already present.
-            #[cfg(windows)]
-            msvc::ensure_msvc_env(&root);
-            dispatch::run_pnpm(&root, &args)
-        }
+        _ => dispatch::run_pnpm(&root, &args),
     }
 }
 
@@ -395,5 +402,20 @@ fn find_repo_root(lenient: bool) -> Option<PathBuf> {
                 )
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::command_requires_msvc;
+
+    #[test]
+    fn compiler_environment_precedes_every_build_capable_dispatch() {
+        assert!(command_requires_msvc(Some("build")));
+        assert!(command_requires_msvc(Some("rebuild")));
+        assert!(command_requires_msvc(Some("build:core")));
+        assert!(command_requires_msvc(Some("qualify:mmap")));
+        assert!(!command_requires_msvc(Some("proxy")));
+        assert!(!command_requires_msvc(Some("config")));
     }
 }

--- a/crates/shifu/src/registrar.rs
+++ b/crates/shifu/src/registrar.rs
@@ -301,9 +301,17 @@ fn warn(msg: &str) {
 }
 
 fn git(root: &Path, args: &[&str]) -> String {
+    // Bind provenance to the declared product root. Hooks and nested Git
+    // callers may export repository-local variables that otherwise override
+    // current_dir/-C and silently fingerprint the caller's repository.
     Command::new("git")
+        .arg("-C")
+        .arg(root)
         .args(args)
-        .current_dir(root)
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_WORK_TREE")
+        .env_remove("GIT_COMMON_DIR")
+        .env_remove("GIT_INDEX_FILE")
         .output()
         .ok()
         .filter(|out| out.status.success())

--- a/developer/sdk/tests/contract-cli.test.mjs
+++ b/developer/sdk/tests/contract-cli.test.mjs
@@ -246,10 +246,10 @@ test('product gui dist dry-run supports a product assembly directory', () => {
     join(repoRoot, 'product'),
     '--dry-run',
   ]);
-  assert.match(output, /system\/status/);
+  assert.match(output, /system[\\/]status/);
   assert.match(output, /assemble kfx ->/);
-  assert.match(output, /framework\/tui/);
-  assert.match(output, /framework\/gui/);
+  assert.match(output, /framework[\\/]tui/);
+  assert.match(output, /framework[\\/]gui/);
   assert.match(output, /run-electron-builder\.mjs/);
   assert.match(output, /electron-builder\.yml/);
 });

--- a/framework/core/.cmake/compiler.cmake
+++ b/framework/core/.cmake/compiler.cmake
@@ -65,7 +65,9 @@ if (APPLE)
   set(CONAN_DISABLE_CHECK_COMPILER ON)
 endif ()
 if (MSVC)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP /utf-8 /permissive- /bigobj /W0 /Zc:__cplusplus")
+  # /EHsc is part of the core RAII contract: exception paths must unwind local
+  # owners (file handles, mappings, and other native resources).
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP /utf-8 /permissive- /bigobj /W0 /Zc:__cplusplus /EHsc")
   message(STATUS "CMAKE_CXX_FLAGS set to ${CMAKE_CXX_FLAGS}")
   set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /IGNORE:4199")
   set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} /IGNORE:4199")

--- a/framework/core/.cmake/libnode.cmake
+++ b/framework/core/.cmake/libnode.cmake
@@ -18,12 +18,9 @@ macro(use_node_addon_api)
 
   add_compile_definitions(NAPI_EXPERIMENTAL)
   add_compile_definitions(NAPI_VERSION=8)
+  # Declare the binding's exception contract explicitly; compiler.cmake owns
+  # the matching MSVC /EHsc unwind semantics for every C++ target.
   add_compile_definitions(NODE_ADDON_API_CPP_EXCEPTIONS)
-  if (MSVC)
-    # node-addon-api cannot infer exception support from MSVC unless the
-    # compiler emits standard C++ unwind semantics.
-    add_compile_options(/EHsc)
-  endif ()
 endmacro(use_node_addon_api)
 
 macro(use_libnode)

--- a/framework/core/.cmake/libnode.cmake
+++ b/framework/core/.cmake/libnode.cmake
@@ -18,6 +18,12 @@ macro(use_node_addon_api)
 
   add_compile_definitions(NAPI_EXPERIMENTAL)
   add_compile_definitions(NAPI_VERSION=8)
+  add_compile_definitions(NODE_ADDON_API_CPP_EXCEPTIONS)
+  if (MSVC)
+    # node-addon-api cannot infer exception support from MSVC unless the
+    # compiler emits standard C++ unwind semantics.
+    add_compile_options(/EHsc)
+  endif ()
 endmacro(use_node_addon_api)
 
 macro(use_libnode)

--- a/framework/core/.gyp/gen-stubs.js
+++ b/framework/core/.gyp/gen-stubs.js
@@ -64,10 +64,12 @@ function main() {
 
   // pybind11-stubgen copies C++ parameter names verbatim; `from` is a Python
   // keyword, so `def f(self, from: int)` is invalid Python — rename to `from_`.
+  // It also follows the host newline convention; committed stubs are canonical
+  // LF text so a Windows build must not dirty the worktree by line endings alone.
   for (const rel of glob.sync('**/*.pyi', { cwd: 'stubs/pykungfu' })) {
     const file = path.join('stubs', 'pykungfu', rel);
     const before = fs.readFileSync(file, 'utf8');
-    const after = before.replace(/\bfrom:/g, 'from_:');
+    const after = before.replace(/\r\n?/g, '\n').replace(/\bfrom:/g, 'from_:');
     if (after !== before) fs.writeFileSync(file, after);
   }
 }

--- a/framework/core/.gyp/gen-stubs.js
+++ b/framework/core/.gyp/gen-stubs.js
@@ -69,7 +69,10 @@ function main() {
   for (const rel of glob.sync('**/*.pyi', { cwd: 'stubs/pykungfu' })) {
     const file = path.join('stubs', 'pykungfu', rel);
     const before = fs.readFileSync(file, 'utf8');
-    const after = before.replace(/\r\n?/g, '\n').replace(/\bfrom:/g, 'from_:');
+    const after = before
+      .replace(/\r\n?/g, '\n')
+      .replace(/[ \t]+$/gm, '')
+      .replace(/\bfrom:/g, 'from_:');
     if (after !== before) fs.writeFileSync(file, after);
   }
 }

--- a/framework/core/.gyp/run-freeze.js
+++ b/framework/core/.gyp/run-freeze.js
@@ -133,12 +133,18 @@ function copyPdbSibling(binPath, destDir) {
 
 /** @param {string} bt */
 function copyAppNative(bt) {
-  const rel = path.join(CORE, 'build', bt);
+  const buildDirs = [path.join(CORE, 'build', bt)];
+  // CMake's Ninja layout places Windows addons directly under build/, while
+  // POSIX layouts place them under build/<type>. Keep freeze aligned with the
+  // staging search contract in run-build.js.
+  if (isWin) buildDirs.push(path.join(CORE, 'build'));
   const distKfc = path.join(CORE, 'dist', 'kungfu');
   let n = 0;
   for (const f of APP_NATIVE) {
-    const from = path.join(rel, f);
-    if (!fs.existsSync(from)) continue;
+    const from = buildDirs
+      .map((dir) => path.join(dir, f))
+      .find((candidate) => fs.existsSync(candidate));
+    if (!from) continue;
     fs.copyFileSync(from, path.join(distKfc, f));
     copyPdbSibling(from, distKfc);
     n++;

--- a/framework/core/src/libkungfu/include/kungfu/runtime/os.h
+++ b/framework/core/src/libkungfu/include/kungfu/runtime/os.h
@@ -3,7 +3,7 @@
 #ifndef KUNGFU_RUNTIME_OS_H
 #define KUNGFU_RUNTIME_OS_H
 
-#ifdef _WINDOWS
+#ifdef _WIN32
 #include <process.h>
 #define GETPID _getpid
 #else

--- a/framework/core/src/libkungfu/include/kungfu/runtime/util/stacktrace.h
+++ b/framework/core/src/libkungfu/include/kungfu/runtime/util/stacktrace.h
@@ -5,11 +5,11 @@
 
 #include <kungfu/common.h>
 
-#ifdef _WINDOWS
+#ifdef _WIN32
 #include <Psapi.h>
 #include <Windows.h>
 #include <cstdio>
-#endif // _WINDOWS
+#endif // _WIN32
 
 namespace kungfu::runtime::util {
 void set_error_log_dir(const std::string &path);
@@ -18,7 +18,7 @@ void set_error_log_dir(const std::string &path);
 // signal / SEH handlers are installed, never from inside a handler.
 void prepare_stack_trace();
 
-#ifdef _WINDOWS
+#ifdef _WIN32
 
 DWORD print_stack_trace(EXCEPTION_POINTERS *ep = nullptr);
 
@@ -26,7 +26,7 @@ DWORD print_stack_trace(EXCEPTION_POINTERS *ep = nullptr);
 
 void print_stack_trace(FILE *out = stderr, int signum = 0);
 
-#endif // _WINDOWS
+#endif // _WIN32
 } // namespace kungfu::runtime::util
 
 #endif // KUNGFU_RUNTIME_UTIL_STACKTRACE_H

--- a/framework/core/src/libkungfu/src/runtime/live/reactor.cpp
+++ b/framework/core/src/libkungfu/src/runtime/live/reactor.cpp
@@ -564,7 +564,7 @@ bool reactor::drain(const rx::subscriber<event_ptr> &sb) {
 }
 
 void reactor::delegate_produce(reactor *instance, const rx::subscriber<event_ptr> &subscriber) {
-#ifdef _WINDOWS
+#ifdef _WIN32
   __try {
     instance->produce(subscriber);
   } __except (util::print_stack_trace(GetExceptionInformation())) {

--- a/framework/core/src/libkungfu/src/runtime/util/signal.cpp
+++ b/framework/core/src/libkungfu/src/runtime/util/signal.cpp
@@ -33,7 +33,7 @@ void exit_reactor(int signum) {
 
 void kf_os_signal_handler(int signum) {
   switch (signum) {
-#ifdef _WINDOWS
+#ifdef _WIN32
   case SIGINT:   // interrupt
   case SIGBREAK: // Ctrl-Break sequence
     KF_LOG_INFO("kungfu app interrupted");
@@ -113,7 +113,7 @@ void kf_os_signal_handler(int signum) {
   case SIGSYS: // create core image    non-existent system call invoked
     print_stack_trace(stderr, signum);
     exit_reactor(signum);
-#endif // _WINDOWS
+#endif // _WIN32
 #ifdef __APPLE__
   case SIGINFO: // discard signal       status request from keyboard
     KF_LOG_INFO("kungfu app discard signal {}", signum);
@@ -129,7 +129,7 @@ void kf_os_signal_handler(int signum) {
 
 void disable_os_signals_handler() { signals_handler_enabled = false; }
 
-#ifdef _WINDOWS
+#ifdef _WIN32
 // Process-wide backstop for exceptions raised outside reactor::produce's SEH frame
 // (other threads, or before / after the produce loop). It hands the dumper real
 // EXCEPTION_POINTERS, unlike the contextless CRT signal(SIGSEGV) path.
@@ -137,7 +137,7 @@ static LONG WINAPI kf_top_level_filter(EXCEPTION_POINTERS *ep) {
   print_stack_trace(ep);
   return EXCEPTION_EXECUTE_HANDLER;
 }
-#endif // _WINDOWS
+#endif // _WIN32
 
 void handle_os_signals(void *reactor) {
   if (reactor_instance != nullptr) {
@@ -155,11 +155,11 @@ void handle_os_signals(void *reactor) {
   // path never triggers lazy dynamic-linker / dbghelp initialization.
   prepare_stack_trace();
 
-#ifdef _WINDOWS
+#ifdef _WIN32
   // Install the process-wide backstop after warm-up so the filter path only does
   // symbol lookups, never first-time DbgHelp initialization.
   SetUnhandledExceptionFilter(kf_top_level_filter);
-#endif // _WINDOWS
+#endif // _WIN32
 
   for (int s = 1; s < NSIG; s++) {
     signal(s, kf_os_signal_handler);

--- a/framework/core/src/libkungfu/src/runtime/util/stacktrace.cpp
+++ b/framework/core/src/libkungfu/src/runtime/util/stacktrace.cpp
@@ -7,7 +7,7 @@
 #include <kungfu/common.h>
 #include <time.h>
 
-#ifdef _WINDOWS
+#ifdef _WIN32
 
 #include <kungfu/runtime/util/stacktrace.h>
 
@@ -28,7 +28,7 @@
 #include <fcntl.h>
 #include <unistd.h>
 
-#endif // _WINDOWS
+#endif // _WIN32
 
 namespace kungfu::runtime::util {
 
@@ -44,7 +44,7 @@ static std::string error_log_dir = get_default_error_log_dir();
 
 void set_error_log_dir(const std::string &path) { error_log_dir = path; }
 
-#ifdef _WINDOWS
+#ifdef _WIN32
 
 namespace {
 // Crash-path helpers. On Windows the crash arrives via an SEH __except filter
@@ -476,5 +476,5 @@ void prepare_stack_trace() {
     close(devnull);
   }
 }
-#endif // _WINDOWS
+#endif // _WIN32
 } // namespace kungfu::runtime::util

--- a/framework/core/src/libkungfu/src/runtime/util/terminal.cpp
+++ b/framework/core/src/libkungfu/src/runtime/util/terminal.cpp
@@ -109,7 +109,7 @@ inline size_t _thread_id() noexcept {
 // borrowed from <spdlog/details/os-inl.h> end
 
 // borrowed from <spdlog/sinks/wincolor_sink-inl.h> begin
-#ifdef _WINDOWS
+#ifdef _WIN32
 #include <wincon.h>
 
 class WinColor {

--- a/framework/core/src/libyijinjing/include/kungfu/common.h
+++ b/framework/core/src/libyijinjing/include/kungfu/common.h
@@ -23,7 +23,7 @@
 
 //------------------------------------------------------------------------
 // workaround for using c++20 with hana-1.7.0@conan-center
-#if defined(_WINDOWS) && (_MSVC_LANG > 201704L)
+#if defined(_WIN32) && (_MSVC_LANG > 201704L)
 namespace std {
 template <typename T> struct is_literal_type {};
 } // namespace std
@@ -45,7 +45,7 @@ using namespace boost::hana::literals;
 
 //------------------------------------------------------------------------
 // pack struct for fixing data length in journal
-#ifdef _WINDOWS
+#ifdef _WIN32
 #define KF_PACK_TYPE_BEGIN __pragma(pack(push, 8))
 #define KF_PACK_TYPE_END                                                                                               \
   ;                                                                                                                    \
@@ -137,7 +137,7 @@ template <typename V, size_t N> struct array_to_string<V, N, std::enable_if_t<no
   };
 };
 
-// 安全定长字符串拷贝（跨平台）。替代此前 _WINDOWS 下全局 `#define strcpy/strncpy → _s 安全版`：
+// 安全定长字符串拷贝（跨平台）。替代此前 Windows 下全局 `#define strcpy/strncpy → _s 安全版`：
 // 旧宏会污染随后 include 的系统/三方头里的 strcpy/strncpy（如 <tchar.h> 内联 _strncpy_l），
 // 且对裸指针目标用 sizeof(指针) 取容量会误判。此函数显式传 size，限定在 dest[0,size) 内：
 // 从 src 复制至多 min(count,size) 个非 NUL 字节，余下补 '\0'（与定长字段语义一致，不依赖 NUL 结尾）。

--- a/framework/core/src/libyijinjing/src/io/locator.cpp
+++ b/framework/core/src/libyijinjing/src/io/locator.cpp
@@ -21,7 +21,7 @@ fs::path get_default_root() {
   if (kf_home != nullptr) {
     return fs::path{kf_home};
   }
-#ifdef _WINDOWS
+#ifdef _WIN32
   auto appdata = std::getenv("APPDATA");
   auto root = fs::path(appdata);
 #elif __APPLE__
@@ -30,7 +30,7 @@ fs::path get_default_root() {
 #elif __linux__
   auto user_home = std::getenv("HOME");
   auto root = fs::path(user_home) / ".config";
-#endif // _WINDOWS
+#endif // _WIN32
   return root / "kungfu" / "home";
 }
 

--- a/framework/core/src/libyijinjing/src/storage/content_store.cpp
+++ b/framework/core/src/libyijinjing/src/storage/content_store.cpp
@@ -13,7 +13,7 @@
 
 #include <kungfu/yijinjing/storage/content_hash.h>
 
-#ifdef _WINDOWS
+#ifdef _WIN32
 #include <io.h>
 #include <process.h>
 #else
@@ -43,7 +43,7 @@ bool is_lower_hex(const std::string &value) {
 }
 
 int current_pid() {
-#ifdef _WINDOWS
+#ifdef _WIN32
   return _getpid();
 #else
   return static_cast<int>(::getpid());
@@ -59,7 +59,7 @@ bool flush_to_disk(std::FILE *file) {
   if (std::fflush(file) != 0) {
     return false;
   }
-#ifdef _WINDOWS
+#ifdef _WIN32
   return _commit(_fileno(file)) == 0;
 #else
   return ::fsync(fileno(file)) == 0;
@@ -69,7 +69,7 @@ bool flush_to_disk(std::FILE *file) {
 // Publication is only durable once the directory entry is too; best-effort on
 // platforms without directory fsync.
 void sync_directory(const fs::path &dir) {
-#ifndef _WINDOWS
+#ifndef _WIN32
   const int fd = ::open(dir.c_str(), O_RDONLY);
   if (fd >= 0) {
     ::fsync(fd);

--- a/framework/core/src/libyijinjing/src/storage/episode_manifest.cpp
+++ b/framework/core/src/libyijinjing/src/storage/episode_manifest.cpp
@@ -16,7 +16,7 @@
 #include <kungfu/yijinjing/storage/content_store.h>
 #include <kungfu/yijinjing/time.h>
 
-#ifdef _WINDOWS
+#ifdef _WIN32
 #include <windows.h>
 #else
 #include <fcntl.h>
@@ -97,7 +97,7 @@ writer make_writer(const std::string &runtime_dir) {
 class manifest_writer_guard {
 public:
   explicit manifest_writer_guard(const std::string &lock_path) : lock_path_(lock_path) {
-#ifdef _WINDOWS
+#ifdef _WIN32
     handle_ = CreateFileA(lock_path.c_str(), GENERIC_READ | GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr,
                           OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr);
     if (handle_ == INVALID_HANDLE_VALUE) {
@@ -126,7 +126,7 @@ public:
   manifest_writer_guard &operator=(const manifest_writer_guard &) = delete;
 
   ~manifest_writer_guard() {
-#ifdef _WINDOWS
+#ifdef _WIN32
     if (handle_ != INVALID_HANDLE_VALUE) {
       OVERLAPPED overlapped{};
       UnlockFileEx(handle_, 0, 1, 0, &overlapped);
@@ -142,7 +142,7 @@ public:
 
 private:
   std::string lock_path_;
-#ifdef _WINDOWS
+#ifdef _WIN32
   HANDLE handle_ = INVALID_HANDLE_VALUE;
 #else
   int fd_ = -1;

--- a/framework/core/src/libyijinjing/src/util/mmap.cpp
+++ b/framework/core/src/libyijinjing/src/util/mmap.cpp
@@ -4,7 +4,7 @@
 // Created by Keren Dong on 2019-06-10.
 //
 
-#ifdef _WINDOWS
+#ifdef _WIN32
 #include <fcntl.h>
 #ifndef NOMINMAX
 #define NOMINMAX
@@ -18,7 +18,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 
-#endif // _WINDOWS
+#endif // _WIN32
 
 #include <kungfu/common.h>
 #include <kungfu/yijinjing/journal/common.h>
@@ -49,7 +49,7 @@ void validate_policy(const mapping_policy policy, const std::string &path) {
   }
 }
 
-#ifdef _WINDOWS
+#ifdef _WIN32
 [[noreturn]] void throw_mapping_error(const std::string &operation, const std::string &path, int code) {
   throw journal_error(operation + " for page " + path + ", error: " + std::to_string(code));
 }
@@ -237,7 +237,7 @@ bool mapped_region::flush() const noexcept {
     return true;
   }
   void *buffer = reinterpret_cast<void *>(address_);
-#ifdef _WINDOWS
+#ifdef _WIN32
   return FlushViewOfFile(buffer, size_) != 0;
 #else
   return msync(buffer, size_, MS_SYNC) == 0;
@@ -250,7 +250,7 @@ bool mapped_region::reset() noexcept {
   }
   void *buffer = reinterpret_cast<void *>(address_);
   bool ok = true;
-#ifdef _WINDOWS
+#ifdef _WIN32
   if (writable_ && FlushViewOfFile(buffer, size_) == 0) {
     ok = false;
   }
@@ -293,7 +293,7 @@ bool flush_mmap_buffer(uintptr_t address, size_t size, mapping_durability durabi
     return false;
   }
   void *buffer = reinterpret_cast<void *>(address);
-#ifdef _WINDOWS
+#ifdef _WIN32
   if (FlushViewOfFile(buffer, size) == 0) {
     return false;
   }
@@ -307,13 +307,13 @@ bool flush_mmap_buffer(uintptr_t address, size_t size, mapping_durability durabi
 
 bool release_mmap_buffer(uintptr_t address, size_t size) {
   void *buffer = reinterpret_cast<void *>(address);
-#ifdef _WINDOWS
+#ifdef _WIN32
   const bool flushed = FlushViewOfFile(buffer, size) != 0;
   const bool unmapped = UnmapViewOfFile(buffer) != 0;
   return flushed && unmapped;
 #else
   return munmap(buffer, size) == 0;
-#endif // _WINDOWS
+#endif // _WIN32
 }
 
 uintptr_t load_mmap_buffer(const std::string &path, size_t size, bool is_writing, bool lazy) {

--- a/framework/core/src/libyijinjing/tests/mmap_qualification.cpp
+++ b/framework/core/src/libyijinjing/tests/mmap_qualification.cpp
@@ -26,7 +26,7 @@
 #include <sys/sysctl.h>
 #endif
 
-#ifdef _WINDOWS
+#ifdef _WIN32
 #include <windows.h>
 #else
 #include <sys/resource.h>
@@ -110,7 +110,7 @@ size_t mapped_region_count() {
   // vmmap would perturb the process being measured. Leave this fact explicit
   // rather than substituting a different metric under the same name.
   return 0;
-#elif defined(_WINDOWS)
+#elif defined(_WIN32)
   size_t count = 0;
   MEMORY_BASIC_INFORMATION info{};
   auto *address = static_cast<unsigned char *>(nullptr);
@@ -130,7 +130,7 @@ size_t mapped_region_count() {
 
 resource_sample resources() {
   resource_sample result;
-#ifdef _WINDOWS
+#ifdef _WIN32
   result.mapped_regions = mapped_region_count();
 #else
   rusage usage{};
@@ -192,7 +192,7 @@ json host_facts() {
   json facts = {{"hardware_threads", std::thread::hardware_concurrency()},
                 {"cpp_standard", __cplusplus},
                 {"pointer_bits", sizeof(void *) * 8}};
-#ifdef _WINDOWS
+#ifdef _WIN32
   SYSTEM_INFO info{};
   GetSystemInfo(&info);
   facts["os"] = "windows";

--- a/framework/core/src/libyijinjing/tests/mmap_tests.cpp
+++ b/framework/core/src/libyijinjing/tests/mmap_tests.cpp
@@ -19,7 +19,7 @@
 #include <thread>
 #include <type_traits>
 
-#ifdef _WINDOWS
+#ifdef _WIN32
 #include <windows.h>
 #else
 #include <csignal>
@@ -84,7 +84,7 @@ void require_throws(const std::function<void()> &fn, const std::string &message)
 }
 
 size_t process_resource_count() {
-#ifdef _WINDOWS
+#ifdef _WIN32
   DWORD count = 0;
   require(GetProcessHandleCount(GetCurrentProcess(), &count) != 0, "failed to count process handles");
   return count;
@@ -249,11 +249,12 @@ void test_mapping_error_paths_release_resources() {
                    "repeated truncated mapping unexpectedly succeeded");
   }
   const auto after = process_resource_count();
-  require(after <= before + 1, "failing mappings leaked file descriptors or handles");
+  require(after <= before + 1, "failing mappings leaked file descriptors or handles: before=" + std::to_string(before) +
+                                   ", after=" + std::to_string(after) + ", delta=" + std::to_string(after - before));
 
   const auto stale_path = tree.root() / "stale.journal";
   auto stale = mapped_region::map(stale_path.string(), 4096, mapping_policy::write_create_or_grow());
-#ifdef _WINDOWS
+#ifdef _WIN32
   require(UnmapViewOfFile(reinterpret_cast<void *>(stale.address())) != 0,
           "failed to inject an already-unmapped Windows view");
 #else
@@ -265,7 +266,7 @@ void test_mapping_error_paths_release_resources() {
   require(!stale, "failed cleanup retained stale mapping ownership");
 }
 
-#ifndef _WINDOWS
+#ifndef _WIN32
 void test_resize_budget_failure_releases_file() {
   temp_tree tree;
   const auto path = tree.root() / "limited.journal";
@@ -361,7 +362,7 @@ void test_page_header_publication() {
   auto empty = mapped_region::map(path, TEST_PAGE_SIZE, mapping_policy::write_create_or_grow());
   require(empty.reset(), "failed to release empty page fixture mapping");
 
-#ifdef _WINDOWS
+#ifdef _WIN32
   std::thread initializer([loc] {
     std::this_thread::sleep_for(std::chrono::milliseconds(20));
     (void)page::load(loc, location::PUBLIC, TEST_PAGE_SIZE, 1, page_open_policy::writer());
@@ -416,7 +417,7 @@ int main() {
       {"existing mapping never creates or grows", test_existing_mapping_never_creates_or_grows},
       {"mapped region move ownership", test_mapped_region_move_ownership},
       {"mapping error paths release resources", test_mapping_error_paths_release_resources},
-#ifndef _WINDOWS
+#ifndef _WIN32
       {"resize budget failure releases file", test_resize_budget_failure_releases_file},
 #endif
       {"page reader does not create layout", test_page_reader_does_not_create_layout},

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -158,7 +158,11 @@ function assertCoreRuntime() {
     'config',
     'kungfu-kfx.contract.json',
   );
-  for (const file of [kungfuBin, electronBinding, nodeBinding, kfxContract]) {
+  // Windows deliberately builds the Electron runtime under kungfu_node.node:
+  // the Node-runtime pass skips the addon there, so there is only one ABI
+  // artifact to assert. POSIX builds retain distinct Node/Electron bindings.
+  const bindings = isWin ? [nodeBinding] : [electronBinding, nodeBinding];
+  for (const file of [kungfuBin, ...bindings, kfxContract]) {
     if (!fs.existsSync(file)) {
       throw new Error(`build did not produce ${rel(file)}`);
     }

--- a/scripts/check.mjs
+++ b/scripts/check.mjs
@@ -236,12 +236,11 @@ function checkPythonFiles(label, files) {
 // Rust format + lint check, workspace-scoped whenever any crates/ file is in
 // the given list: the workspace is a few small crates, cargo fmt reads the
 // edition from Cargo.toml, and clippy compiles whole targets by nature — so
-// per-file scoping buys nothing, and running the exact two commands shifu CI
-// runs (fmt --all --check, clippy -D warnings) means the local gate cannot
-// drift from CI. Read-only: fixes live in fix.mjs. A missing cargo warns and
-// skips — rustc is deliberately outside shifu's bootstrap scope (doctor
-// reports it as optional), and CI backstops crates/ edits made without a
-// local Rust toolchain.
+// per-file scoping buys nothing. Formatting, clippy, and workspace unit tests
+// keep source shape, lint, and launcher dispatch behavior in one gate.
+// Read-only: fixes live in fix.mjs. A missing cargo warns and skips — rustc is
+// deliberately outside shifu's bootstrap scope (doctor reports it as
+// optional), and CI backstops crates/ edits made without a local toolchain.
 function checkRustFiles(label, files, { force = false } = {}) {
   const rust = files.filter((file) => file.startsWith('crates/'));
   if (!force && !rust.length) {
@@ -264,6 +263,9 @@ function checkRustFiles(label, files, { force = false } = {}) {
     ['clippy', '--workspace', '--all-targets', '--', '-D', 'warnings'],
     { cwd: crates },
   );
+  run(`${label} Rust unit tests`, 'cargo', ['test', '--workspace'], {
+    cwd: crates,
+  });
 }
 
 function checkNoBashStaged() {
@@ -284,6 +286,29 @@ function checkNoBashTree() {
       .map((hit) => `  ${hit}`)
       .join('\n')}`,
   );
+}
+
+function checkPlatformMacros() {
+  const files = splitLines(git(['ls-files', 'framework/core'])).filter((file) =>
+    /\.(?:c|cc|cpp|cxx|h|hh|hpp|hxx)$/.test(file),
+  );
+  const findings = [];
+  for (const file of files) {
+    const lines = fs.readFileSync(path.join(ROOT, file), 'utf8').split(/\r?\n/);
+    for (let index = 0; index < lines.length; index += 1) {
+      if (/\b_WINDOWS\b/.test(lines[index])) {
+        findings.push(
+          `${file}:${index + 1}: use the compiler-standard _WIN32 macro`,
+        );
+      }
+    }
+  }
+  if (findings.length) {
+    throw new Error(
+      `non-standard Windows platform macros:\n${findings.join('\n')}`,
+    );
+  }
+  log('[check] Windows platform macros use _WIN32');
 }
 
 function checkShifuVersionSync() {
@@ -428,6 +453,7 @@ function checkBuildchainKfdEvidence(files = [], { force = false } = {}) {
 
 function checkStaged() {
   checkNoBashStaged();
+  checkPlatformMacros();
   checkShifuVersionSync();
   checkShifuEntryContract();
   checkCarrierActionEnvelope(['--staged']);
@@ -507,6 +533,7 @@ function checkShared() {
 
 function checkChanged() {
   checkNoBashTree();
+  checkPlatformMacros();
   checkShifuVersionSync();
   checkShifuEntryContract();
   checkCarrierActionEnvelope();
@@ -525,6 +552,7 @@ function checkChanged() {
 
 function checkAll() {
   checkNoBashTree();
+  checkPlatformMacros();
   checkShifuVersionSync();
   checkShifuEntryContract();
   checkCarrierActionEnvelope(['--all']);


### PR DESCRIPTION
## Summary

- replace non-standard `_WINDOWS` guards with compiler-standard `_WIN32` and enforce the boundary in `shifu check`
- load the MSVC environment before Shifu L2 build dispatch, with Rust unit coverage
- enable global MSVC `/EHsc` so exception paths unwind mmap RAII handles
- close Windows build/freeze/SDK path and canonical-text gaps exposed by the clean build

## Validation

- DARKHERO Windows: default `shifu.cmd build` passed without manual vcvars or compile flags
- DARKHERO Windows: `shifu.cmd test:mmap` passed, including repeated failing-map handle regression (previously +8 handles)
- DARKHERO Windows: clean baseline qualification bound to `a3ba855105f61aa46471b1b2d8e2921a8b85567e`, MSVC 19.51, `git_dirty=false`
- macOS arm64: full `./shifu build`, `./shifu check`, and `./shifu test:mmap` passed
- agent-120 Linux: `./shifu sync`, full `./shifu build`, `./shifu test:mmap`, and `./shifu check` passed

CI is currently unavailable; this PR is qualified by the explicit three-host local matrix above.