### PR TITLE
fix(ci): align product Rust toolchain pin

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
       buildchain-ref: ${{ inputs.buildchain-ref || '' }}
       runner-preset: kungfu-v4-self-hosted
       setup-rust: true
-      rust-toolchain: "1.95.0"
+      rust-toolchain: "1.96.0"
       rustup-dist-server: https://rsproxy.cn
       rustup-update-root: https://rsproxy.cn/rustup
       cargo-registry-index: ${{ vars.BUILDCHAIN_CARGO_REGISTRY_INDEX }}


### PR DESCRIPTION
## Summary

- align the alpha/release product workflow with the Rust 1.96 pins established by #605
- avoid cross-toolchain rustup installation during the native matrix

## Validation

- `./shifu check`
- staged repository gates

Fixes #608.