### PR TITLE
fix(product): stabilize cross-platform release gates

### DIFF
--- a/framework/core/.gyp/run-freeze.js
+++ b/framework/core/.gyp/run-freeze.js
@@ -567,8 +567,9 @@ function generateHelpManifest(pythonExe, distKfc) {
     fs.writeFileSync(out, text);
     console.log('[freeze] assemble: staged help-manifest.txt');
   } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
     console.error(
-      `[freeze] assemble: help manifest generation failed; the trunk will fall back to python --help: ${e.message}`,
+      `[freeze] assemble: help manifest generation failed; the trunk will fall back to python --help: ${message}`,
     );
   }
 }

--- a/framework/gui/scripts/before-pack.cjs
+++ b/framework/gui/scripts/before-pack.cjs
@@ -5,14 +5,23 @@
 // build, so the extension view bundles are present to pin.
 const { spawnSync } = require('node:child_process');
 const path = require('node:path');
+const { pathToFileURL } = require('node:url');
+
+function toEsmEntrypointSpecifier(entryPath) {
+  return pathToFileURL(entryPath).href;
+}
 
 exports.default = async function beforePack() {
   const gen = path.join(__dirname, 'gen-first-party-manifest.mjs');
   const tsxLoader = require.resolve('tsx/esm');
-  const result = spawnSync(process.execPath, ['--import', tsxLoader, gen], {
-    stdio: 'inherit',
-  });
+  const result = spawnSync(
+    process.execPath,
+    ['--import', tsxLoader, toEsmEntrypointSpecifier(gen)],
+    { stdio: 'inherit' },
+  );
   if (result.status !== 0) {
     throw new Error('failed to bake the first-party manifest before pack');
   }
 };
+
+exports.toEsmEntrypointSpecifier = toEsmEntrypointSpecifier;

--- a/product/scripts/dist.mjs
+++ b/product/scripts/dist.mjs
@@ -14,6 +14,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
   createBuildchainLogger,
+  readBuildchainLogEvents,
   verifyBuildchainLogEvents,
 } from '@kungfu-tech/buildchain/logging';
 import { extractTarGz, extractZip, writeTarGz, writeZip } from './archive.mjs';
@@ -1346,10 +1347,7 @@ function main() {
   );
 }
 
-function verifyObservability() {
-  if (!buildchainLogger.path) {
-    return;
-  }
+export function verifyProductObservabilityEvents(events, target = 'all') {
   const requiredEvents = [
     'product.dist.start',
     'product.kfx.dependencies.declared',
@@ -1358,15 +1356,15 @@ function verifyObservability() {
     'product.core.freeze.start',
     'product.dist.end',
   ];
-  if (wantsDesktop()) {
+  if (target === 'all' || target === 'desktop') {
     requiredEvents.push('product.desktop.electron-builder.start');
   }
-  if (wantsCli()) {
+  if (target === 'all' || target === 'cli') {
     requiredEvents.push('product.cli.archive.start');
     requiredEvents.push('product.cli.smoke.start');
   }
-  const report = verifyBuildchainLogEvents({
-    path: buildchainLogger.path,
+  return verifyBuildchainLogEvents({
+    events: events.filter((event) => event.component === 'kungfu-product'),
     minEvents: 12,
     requireComponents: ['kungfu-product'],
     requirePhases: [
@@ -1379,6 +1377,16 @@ function verifyObservability() {
     ],
     requireEvents: requiredEvents,
   });
+}
+
+function verifyObservability() {
+  if (!buildchainLogger.path) {
+    return;
+  }
+  const report = verifyProductObservabilityEvents(
+    readBuildchainLogEvents(buildchainLogger.path),
+    productTarget,
+  );
   if (!report.ok) {
     throw new Error(
       `Buildchain observability verification failed: ${report.issues

--- a/product/scripts/dist.test.mjs
+++ b/product/scripts/dist.test.mjs
@@ -1,8 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
 import { test } from 'node:test';
-import { cliArchiveBase } from './dist.mjs';
+import { cliArchiveBase, verifyProductObservabilityEvents } from './dist.mjs';
+
+const require = createRequire(import.meta.url);
+const {
+  toEsmEntrypointSpecifier,
+} = require('../../framework/gui/scripts/before-pack.cjs');
 
 test('CLI product archive name uses the Kungfu Episodes product prefix', () => {
   assert.equal(
@@ -11,4 +17,51 @@ test('CLI product archive name uses the Kungfu Episodes product prefix', () => {
   );
   assert.equal(cliArchiveBase('linux-x64'), 'kungfu-episodes-cli-linux-x64');
   assert.equal(cliArchiveBase('win32-x64'), 'kungfu-episodes-cli-win32-x64');
+});
+
+test('product observability ignores errors from sibling components', () => {
+  const names = [
+    ['product.dist.start', 'prepare'],
+    ['product.kfx.dependencies.declared', 'dependencies'],
+    ['product.dependencies.sync.start', 'dependencies'],
+    ['product.core.rebuild.start', 'core'],
+    ['product.core.freeze.start', 'core'],
+    ['product.extensions.build.start', 'extensions'],
+    ['product.ui.bundle.start', 'ui'],
+    ['product.desktop.electron-builder.start', 'package'],
+    ['product.cli.archive.start', 'package'],
+    ['product.cli.smoke.start', 'package'],
+    ['product.cli.smoke.end', 'package'],
+    ['product.dist.end', 'package'],
+  ];
+  const events = names.map(([event, phase]) => ({
+    contract: 'kungfu-buildchain-log-event',
+    timestamp: '2026-07-12T00:00:00.000Z',
+    level: 'info',
+    source: 'user',
+    component: 'kungfu-product',
+    event,
+    phase,
+  }));
+  events.push({
+    ...events[0],
+    level: 'error',
+    component: 'buildchain-lifecycle',
+    event: 'unrelated.error',
+  });
+
+  const report = verifyProductObservabilityEvents(events);
+  assert.equal(report.ok, true);
+  assert.equal(report.summary.errorCount, 0);
+  assert.equal(report.summary.eventCount, names.length);
+});
+
+test('electron before-pack uses a file URL for its ESM entrypoint', () => {
+  const specifier = toEsmEntrypointSpecifier(
+    new URL(
+      '../../framework/gui/scripts/gen-first-party-manifest.mjs',
+      import.meta.url,
+    ).pathname,
+  );
+  assert.equal(new URL(specifier).protocol, 'file:');
 });


### PR DESCRIPTION
## Summary

- scope product observability verification to `kungfu-product` events so unrelated Buildchain lifecycle errors do not poison a successful product assembly
- launch the first-party manifest ESM entrypoint through a `file://` URL on Windows
- normalize unknown help-manifest generation errors introduced on current dev
- add regression coverage for observability isolation and the ESM entrypoint specifier

## Validation

- `./shifu fix`
- `./shifu check`
- product/tooling tests: 10 passed, including both new regressions

Fixes #613.