### PR TITLE
feat(yijinjing): derive journal container epoch from header layout (ADR-0062)

### DIFF
--- a/framework/core/src/libyijinjing/include/kungfu/yijinjing/journal/common.h
+++ b/framework/core/src/libyijinjing/include/kungfu/yijinjing/journal/common.h
@@ -9,7 +9,9 @@
 
 #include <kungfu/yijinjing/common.h>
 
-#define __JOURNAL_VERSION__ 4
+// ADR-0062: the journal container format epoch is no longer a hand-maintained
+// integer. It is derived from the page_header/frame_header layout in
+// <kungfu/yijinjing/journal/layout_fingerprint.h> as `journal_format_epoch`.
 
 namespace kungfu::yijinjing::journal {
 

--- a/framework/core/src/libyijinjing/include/kungfu/yijinjing/journal/layout_fingerprint.h
+++ b/framework/core/src/libyijinjing/include/kungfu/yijinjing/journal/layout_fingerprint.h
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef KUNGFU_YIJINJING_JOURNAL_LAYOUT_FINGERPRINT_H
+#define KUNGFU_YIJINJING_JOURNAL_LAYOUT_FINGERPRINT_H
+
+#include <kungfu/yijinjing/schema/core.h>
+
+#include <cstdint>
+#include <type_traits>
+
+// ADR-0062: the journal container format epoch is derived from the page_header
+// and frame_header binary layout, not from a hand-maintained integer. Any change
+// to either layout -- add, remove, reorder, retype, or rename, including
+// size-preserving ones the *_length checks cannot see -- changes the epoch, so an
+// unversioned layout change cannot ship and old-epoch pages are refused by
+// page::load automatically. Cross-epoch replay is offline conversion (deferred).
+//
+// A pure semantic reinterpretation that keeps a field's name and type is out of
+// scope for any layout hash: change the field's name or type to version it.
+namespace kungfu::yijinjing::journal {
+
+namespace layout_fingerprint_detail {
+
+constexpr uint64_t kFnvOffset = 1469598103934665603ull;
+constexpr uint64_t kFnvPrime = 1099511628211ull;
+constexpr uint64_t mix(uint64_t h, uint64_t v) { return (h ^ v) * kFnvPrime; }
+
+// A platform-stable token for one field type: width, alignment, and the
+// signed / enum / floating discriminators. Fixed-width fields keep this equal
+// across macOS, Linux, and Windows.
+template <typename A> constexpr uint64_t field_token() {
+  using T = std::decay_t<A>;
+  uint64_t t = kFnvOffset;
+  t = mix(t, sizeof(T));
+  t = mix(t, alignof(T));
+  t = mix(t, static_cast<uint64_t>(std::is_signed_v<T> ? 1u : 0u));
+  t = mix(t, static_cast<uint64_t>(std::is_enum_v<T> ? 2u : 0u));
+  t = mix(t, static_cast<uint64_t>(std::is_floating_point_v<T> ? 4u : 0u));
+  return t;
+}
+
+// Fold the Hana-reflected field set (field name chars in order + each field's
+// type token) together with the struct's own size and alignment.
+template <typename DataType> constexpr uint64_t layout_fingerprint() {
+  uint64_t base = mix(mix(kFnvOffset, sizeof(DataType)), alignof(DataType));
+  return boost::hana::fold_left(boost::hana::accessors<DataType>(), base, [](uint64_t acc, auto it) {
+    acc = boost::hana::fold_left(boost::hana::first(it), acc, [](uint64_t a, auto ch) {
+      return mix(a, static_cast<uint64_t>(static_cast<unsigned char>(decltype(ch)::value)));
+    });
+    using FieldT = std::decay_t<decltype(boost::hana::second(it)(std::declval<DataType &>()))>;
+    return mix(acc, field_token<FieldT>());
+  });
+}
+
+} // namespace layout_fingerprint_detail
+
+// The container epoch covers both header layouts. It is a machine-only opaque
+// value -- never read by a human, no ordering or release meaning -- stamped into
+// page_header.version and checked by page::load. Non-zero by construction (the
+// low bit is forced set) so it never collides with an uninitialized page.
+inline constexpr uint32_t journal_format_epoch =
+    (static_cast<uint32_t>(
+         layout_fingerprint_detail::mix(
+             layout_fingerprint_detail::layout_fingerprint<::kungfu::yijinjing::types::page_header>(),
+             layout_fingerprint_detail::layout_fingerprint<::kungfu::yijinjing::types::frame_header>()) >>
+         32) |
+     1u);
+
+} // namespace kungfu::yijinjing::journal
+
+#endif // KUNGFU_YIJINJING_JOURNAL_LAYOUT_FINGERPRINT_H

--- a/framework/core/src/libyijinjing/src/journal/assemble.cpp
+++ b/framework/core/src/libyijinjing/src/journal/assemble.cpp
@@ -8,6 +8,7 @@
 #include <kungfu/yijinjing/common.h>
 #include <kungfu/yijinjing/journal/assemble.h>
 #include <kungfu/yijinjing/journal/bus.h>
+#include <kungfu/yijinjing/journal/layout_fingerprint.h>
 #include <kungfu/yijinjing/time.h>
 #include <unordered_set>
 
@@ -242,16 +243,16 @@ std::vector<std::pair<yijinjing::types::frame_header, std::vector<uint8_t>>> ass
   std::vector<std::pair<yijinjing::types::frame_header, std::vector<uint8_t>>> v{};
   while (data_available() and current_frame()->gen_time() < end_time) {
     if (carrier_type == 0 or
-        current_frame()->carrier_type() == carrier_type && current_page()->get_version() == __JOURNAL_VERSION__) {
+        current_frame()->carrier_type() == carrier_type && current_page()->get_version() == journal_format_epoch) {
       const frame_header &head = *reinterpret_cast<frame_header *>(current_frame()->address());
       std::vector<uint8_t> bytes{current_frame()->data_as_bytes(),
                                  current_frame()->data_as_bytes() + current_frame()->data_length()};
       v.emplace_back(head, bytes);
     }
 
-    if (current_page()->get_version() != __JOURNAL_VERSION__) {
+    if (current_page()->get_version() != journal_format_epoch) {
       SPDLOG_WARN("journal version mismatch, expect {}, got {}, page_id {}, location uid {} location name {}",
-                  __JOURNAL_VERSION__, current_page()->get_version(), current_page()->get_page_id(),
+                  journal_format_epoch, current_page()->get_version(), current_page()->get_page_id(),
                   current_page()->get_location()->uid, current_page()->get_location()->uname);
     }
 

--- a/framework/core/src/libyijinjing/src/journal/page.cpp
+++ b/framework/core/src/libyijinjing/src/journal/page.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <kungfu/common.h>
+#include <kungfu/yijinjing/journal/layout_fingerprint.h>
 #include <kungfu/yijinjing/journal/page.h>
 #include <kungfu/yijinjing/platform/mmap.h>
 #include <kungfu/yijinjing/time.h>
@@ -27,6 +28,9 @@ static_assert(offsetof(yijinjing::types::page_header, status) %
               "page status must satisfy atomic_ref alignment");
 static_assert(std::atomic_ref<yijinjing::enums::PageStatus>::is_always_lock_free,
               "cross-process page status requires lock-free atomics");
+// ADR-0062: the container epoch is derived from the header layout at compile
+// time; force its evaluation here so a malformed derivation fails the build.
+static_assert(journal_format_epoch != 0u, "journal format epoch must be a non-zero compile-time constant");
 } // namespace
 using namespace yijinjing::types;
 
@@ -132,7 +136,7 @@ page_ptr page::load(const data::location_ptr &location, uint32_t dest_id, uint64
 
   if (may_initialize) {
     if (is_virgin_page) {
-      header->version = __JOURNAL_VERSION__;
+      header->version = journal_format_epoch;
       header->page_header_length = sizeof(page_header);
       header->page_size = page_size;
       header->frame_header_length = sizeof(frame_header);
@@ -152,9 +156,9 @@ page_ptr page::load(const data::location_ptr &location, uint32_t dest_id, uint64
     std::this_thread::yield();
   }
 
-  if (header->version != __JOURNAL_VERSION__) {
+  if (header->version != journal_format_epoch) {
     uint32_t v = header->version;
-    throw journal_error(fmt::format("{} version mismatch, required {}, found {}", path, __JOURNAL_VERSION__, v));
+    throw journal_error(fmt::format("{} version mismatch, required {}, found {}", path, journal_format_epoch, v));
   }
   if (header->page_header_length != sizeof(page_header)) {
     uint32_t l = header->page_header_length;
@@ -252,7 +256,7 @@ uint32_t page::find_page_id(const data::location_ptr &location, uint32_t dest_id
     const auto *loaded_page_header = loaded_page->header_;
     return loaded_page->acquire_last_frame_position() != 0 &&
            loaded_page->acquire_status() != yijinjing::enums::PageStatus::PreOpen &&
-           loaded_page_header->version == __JOURNAL_VERSION__ && loaded_page->begin_time() < time;
+           loaded_page_header->version == journal_format_epoch && loaded_page->begin_time() < time;
   };
 
   // Most live seeks target the tail. Preserve that one-probe path before using

--- a/framework/core/src/libyijinjing/tests/mmap_tests.cpp
+++ b/framework/core/src/libyijinjing/tests/mmap_tests.cpp
@@ -2,6 +2,7 @@
 
 #include <kungfu/yijinjing/common.h>
 #include <kungfu/yijinjing/journal/journal.h>
+#include <kungfu/yijinjing/journal/layout_fingerprint.h>
 #include <kungfu/yijinjing/journal/page.h>
 #include <kungfu/yijinjing/platform/mmap.h>
 #include <kungfu/yijinjing/schema/core.h>
@@ -34,6 +35,7 @@ using kungfu::yijinjing::data::location;
 using kungfu::yijinjing::data::locator;
 using kungfu::yijinjing::enums::location_role;
 using kungfu::yijinjing::enums::mode;
+using kungfu::yijinjing::journal::journal_format_epoch;
 using kungfu::yijinjing::journal::page;
 using kungfu::yijinjing::journal::page_open_policy;
 using kungfu::yijinjing::journal::page_precreation;
@@ -109,7 +111,7 @@ void create_seek_page(const kungfu::yijinjing::data::location_ptr &loc, uint32_t
   const auto path = page::get_page_path(loc, location::PUBLIC, page_id);
   auto region = mapped_region::map(path, TEST_PAGE_SIZE, mapping_policy::write_create_or_grow());
   auto *header = reinterpret_cast<page_header *>(region.address());
-  header->version = __JOURNAL_VERSION__;
+  header->version = journal_format_epoch;
   header->page_header_length = sizeof(page_header);
   header->page_size = TEST_PAGE_SIZE;
   header->frame_header_length = sizeof(frame_header);
@@ -311,7 +313,7 @@ void test_corrupt_page_offsets_fail_before_payload_access() {
   const auto path = create_page_path(loc);
   auto region = mapped_region::map(path, TEST_PAGE_SIZE, mapping_policy::write_create_or_grow());
   auto *header = reinterpret_cast<page_header *>(region.address());
-  header->version = __JOURNAL_VERSION__;
+  header->version = journal_format_epoch;
   header->page_header_length = sizeof(page_header);
   header->page_size = TEST_PAGE_SIZE;
   header->frame_header_length = sizeof(frame_header);
@@ -340,7 +342,7 @@ void test_corrupt_page_header_facts_are_rejected() {
     const auto path = create_page_path(loc);
     auto region = mapped_region::map(path, TEST_PAGE_SIZE, mapping_policy::write_create_or_grow());
     auto *header = reinterpret_cast<page_header *>(region.address());
-    header->version = __JOURNAL_VERSION__;
+    header->version = journal_format_epoch;
     header->page_header_length = sizeof(page_header);
     header->page_size = TEST_PAGE_SIZE;
     header->frame_header_length = sizeof(frame_header);
@@ -386,7 +388,7 @@ void test_page_header_publication() {
           "initializer process failed");
 #endif
 
-  require(reader->get_version() == __JOURNAL_VERSION__, "reader observed an unpublished page version");
+  require(reader->get_version() == journal_format_epoch, "reader observed an unpublished page version");
   require(reader->get_page_size() == TEST_PAGE_SIZE, "reader observed an unpublished page size");
   require(reader->first_frame_address() > reader->address(), "reader observed an invalid first-frame address");
 }


### PR DESCRIPTION
Replaces the hand-maintained __JOURNAL_VERSION__ integer with journal_format_epoch, a compile-time value derived from the page_header/frame_header layout (Boost.Hana fold over field names + type tokens + sizeof/alignof). Any layout change -- including size-preserving reorder/retype/rename the *_length checks miss -- changes the epoch, so an unversioned layout change cannot ship and old-epoch pages are refused automatically. page::load semantics and the *_length checks are unchanged. Implements ADR-0062 (removing the now-unreachable assemble cross-epoch branch is a separate follow-up).