### PR TITLE
refactor(yijinjing): remove unreachable cross-epoch branch in assemble (ADR-0062)

### DIFF
--- a/framework/core/src/libyijinjing/src/journal/assemble.cpp
+++ b/framework/core/src/libyijinjing/src/journal/assemble.cpp
@@ -8,7 +8,6 @@
 #include <kungfu/yijinjing/common.h>
 #include <kungfu/yijinjing/journal/assemble.h>
 #include <kungfu/yijinjing/journal/bus.h>
-#include <kungfu/yijinjing/journal/layout_fingerprint.h>
 #include <kungfu/yijinjing/time.h>
 #include <unordered_set>
 
@@ -242,18 +241,16 @@ std::vector<std::pair<yijinjing::types::frame_header, std::vector<uint8_t>>> ass
                                                                                                   int64_t end_time) {
   std::vector<std::pair<yijinjing::types::frame_header, std::vector<uint8_t>>> v{};
   while (data_available() and current_frame()->gen_time() < end_time) {
-    if (carrier_type == 0 or
-        current_frame()->carrier_type() == carrier_type && current_page()->get_version() == journal_format_epoch) {
+    // ADR-0062: page::load refuses any page whose epoch != journal_format_epoch,
+    // so every page a reader observes already matches the running epoch. A
+    // per-frame epoch check here is therefore dead (a mismatched page can never
+    // reach this loop), and cross-epoch replay is offline conversion, not an
+    // online skip.
+    if (carrier_type == 0 or current_frame()->carrier_type() == carrier_type) {
       const frame_header &head = *reinterpret_cast<frame_header *>(current_frame()->address());
       std::vector<uint8_t> bytes{current_frame()->data_as_bytes(),
                                  current_frame()->data_as_bytes() + current_frame()->data_length()};
       v.emplace_back(head, bytes);
-    }
-
-    if (current_page()->get_version() != journal_format_epoch) {
-      SPDLOG_WARN("journal version mismatch, expect {}, got {}, page_id {}, location uid {} location name {}",
-                  journal_format_epoch, current_page()->get_version(), current_page()->get_page_id(),
-                  current_page()->get_location()->uid, current_page()->get_location()->uname);
     }
 
     next();

--- a/framework/core/src/libyijinjing/tests/mmap_tests.cpp
+++ b/framework/core/src/libyijinjing/tests/mmap_tests.cpp
@@ -332,6 +332,7 @@ void test_corrupt_page_header_facts_are_rejected() {
     std::function<void(page_header &)> corrupt;
   };
   const corrupt_case cases[] = {
+      {"version", [](page_header &header) { header.version = journal_format_epoch + 1u; }},
       {"page header length", [](page_header &header) { header.page_header_length = sizeof(page_header) + 8; }},
       {"frame header length", [](page_header &header) { header.frame_header_length = sizeof(frame_header) - 8; }},
       {"page size", [](page_header &header) { header.page_size = TEST_PAGE_SIZE + 4096; }},


### PR DESCRIPTION
Every assignment to a reader's current page goes through page::load, which throws on an epoch mismatch, so a version-mismatched page can never reach assemble::read_bytes -- its skip-and-warn branch and the per-frame epoch check were dead code. Removes them (cross-epoch replay is offline conversion, ADR-0062) and adds a 'version' case to test_corrupt_page_header_facts_are_rejected to lock the load-level guarantee the removal rests on.