### PR TITLE
docs(adr): define yijinjing concurrency and error ownership

### DIFF
--- a/docs/MAP.md
+++ b/docs/MAP.md
@@ -82,7 +82,14 @@ route to the row that answers them:
   actually guarantee* ([`contracts.md`](contracts.md)) and *why was a decision
   made* ([ADR-0001](../framework/core/docs/adr/ADR-0001-yijinjing-publish-barrier.md)).
 - **thread-safety / concurrency / single-writer multi-reader / lock-free** →
-  *what does it actually guarantee* ([`contracts.md`](contracts.md)).
+  *what does it actually guarantee* ([`contracts.md`](contracts.md)) and *where
+  should writer, reader-cursor, and page-lifetime ownership end*
+  ([ADR-0063](../framework/core/docs/adr/ADR-0063-yijinjing-concurrency-and-lifetime-contract.md),
+  proposed).
+- **SIGINT / replay exhaustion / subscriber error / loop stop / embedding error**
+  → *who owns error propagation and process lifetime*
+  ([ADR-0064](../framework/core/docs/adr/ADR-0064-runtime-error-propagation-and-stop-ownership.md),
+  proposed).
 - **determinism / reproducibility / record-and-replay** → *what does it actually
   guarantee* ([`contracts.md`](contracts.md)) and *the event / journal / replay
   model* ([`event-model.md`](event-model.md)).

--- a/framework/core/docs/adr/ADR-0063-yijinjing-concurrency-and-lifetime-contract.md
+++ b/framework/core/docs/adr/ADR-0063-yijinjing-concurrency-and-lifetime-contract.md
@@ -1,0 +1,203 @@
+# ADR-0063: yijinjing separates lock-free publication from cursor, write, and page-lifetime ownership
+
+- Status: proposed
+- Date: 2026-07-12
+- Category: (b) correctness + contract clarification
+- Subsystem: `libyijinjing` journal writer, reader cursor, page resource management
+- Related: [ADR-0001](ADR-0001-yijinjing-publish-barrier.md),
+  [ADR-0058](ADR-0058-yijinjing-explicit-mapping-policies.md),
+  [ADR-0062](ADR-0062-journal-container-epoch-and-offline-conversion.md),
+  [ADR-0064](ADR-0064-runtime-error-propagation-and-stop-ownership.md)
+
+## Context
+
+ADR-0001 gives yijinjing a correct release/acquire publication protocol: one
+writer publishes a frame by storing its `length` token last, and readers acquire
+that token before inspecting the frame. That decision makes frame visibility
+tear-free and lets many processes poll a published tail without a coordinating
+mutex. It does not make every operation on `writer`, `reader`, `journal`, or
+`page` lock-free or generally thread-safe.
+
+The current object model blurs those boundaries:
+
+- `writer::open_frame()` acquires `writer_mtx_` manually and
+  `writer::close_frame()` releases it. Exceptions during page rollover, hooks,
+  payload construction, or commit can strand the lock. A caller that never
+  closes an opened frame has the same effect. The `*_lock_free` variants expose
+  mutable writer/journal state without serialization and may still map pages,
+  allocate, take other locks, or perform file operations.
+- `reader` owns a mutable journal map, current cursor, and sort buffers. It
+  declares a recursive mutex but does not use it. The live resource-management
+  worker concurrently calls `preload_next_page()` and `release_page()` while the
+  pump thread can join, disjoin, or advance journals, so unsynchronised map
+  iteration is a real execution path rather than a hypothetical API misuse.
+- Passed pages are retained in shared ownership and released by polling
+  `shared_ptr::use_count()` every microsecond until one owner remains. A held
+  page can block the resource worker indefinitely, and reference-count
+  observation has become an implicit scheduling protocol.
+- `recursive_mutex` hides ownership and re-entry questions in paths whose
+  current call graph does not require recursive locking.
+
+These are separate from the on-disk layout and publication barrier. Fixing them
+must not put a contended lock or refcount increment into the cross-process frame
+publication/read hot path.
+
+## Proposed decision
+
+### 1. Preserve the single-logical-writer, multi-reader publication model
+
+One logical writer owns a journal append cursor. Many readers may observe
+published frames through the ADR-0001 acquire gate. "Lock-free" is reserved for
+that publication/tail-read protocol and for operations whose complete call path
+is demonstrably lock-free.
+
+The writer object itself, page rollover, mapping, discovery, reader membership,
+and page reclamation are not claimed to be lock-free.
+
+### 2. Make a frame write an RAII transaction
+
+The primary writer API returns a move-only write transaction that owns the
+writer serialization token from reservation until commit or abort:
+
+```cpp
+auto tx = writer.reserve_frame(trigger_time, carrier_type, length, stream_id);
+std::memcpy(tx.data(), payload, length);
+tx.commit(length, gen_time);
+```
+
+- `commit()` completes header/payload writes, publishes `length` last with the
+  ADR-0001 release store, advances the cursor, releases serialization, and only
+  then notifies the publisher.
+- Destruction before commit aborts the reservation: the frame remains
+  unpublished, transient writer state is cleared, and serialization is
+  released. Abort does not advance the journal cursor.
+- Hook failures and page-rollover failures follow the same abort path.
+- High-level `write`, `mark`, recorder, replay, and binding surfaces migrate to
+  the transaction API so ordinary callers cannot accidentally split ownership
+  across two unrelated calls.
+
+The existing `open_frame()` / `close_frame()` pair remains temporarily as a
+deprecated compatibility adapter. The existing `open_frame_lock_free()` /
+`close_frame_lock_free()` names are deprecated; any necessary internal
+single-owner primitive is private and named `*_unserialized`, not lock-free.
+
+### 3. Define reader as a single-consumer cursor with a concurrent management boundary
+
+The current `reader` cursor is thread-affine:
+
+- `data_available()`, `current_frame()`, `next()`, sorting, and seeking are
+  driven by one consumer thread.
+- A returned frame view is valid only under its documented page lease and must
+  not imply that the mutable cursor can be advanced concurrently.
+- Debug builds record/assert the cursor owner thread so accidental cross-thread
+  consumption fails close during development.
+
+Management operations are made safe without locking the read hot path:
+
+- journal membership and the map are protected by a non-recursive mutex;
+- the resource worker obtains a snapshot of `shared_ptr<journal>` values under
+  that mutex, releases the mutex, then preloads or releases pages from the
+  snapshot;
+- `get_journals()` no longer exposes a reference to the mutable internal map;
+  callers receive a snapshot or a bounded visitation API;
+- joins/disjoins that must change cursor order are applied on the cursor owner
+  thread or through an explicit command handoff, rather than racing `next()`.
+
+This ADR does not promise a generally multi-consumer reader. A future
+`synchronized_reader` may provide that surface with immutable frame/page leases,
+but it must be a separate type so the zero-copy single-consumer cost remains
+visible.
+
+### 4. Reclaim pages by ownership completion, not refcount polling
+
+`release_page()` drops the journal/resource-manager ownership promptly and does
+not wait for external page leases.
+
+If unmapping must occur on a designated resource thread, page allocation uses a
+custom deleter backed by a `page_reclaimer` queue:
+
+- the final shared owner enqueues the page for destruction;
+- a condition-variable-driven worker performs destruction/unmap;
+- shutdown stops admission, drains the queue, and joins the worker;
+- a deleter that outlives the reclaimer has an explicit safe fallback rather
+  than dereferencing destroyed queue state.
+
+If qualification proves that unmapping on the final owner's thread is safe and
+cheap on every supported host, the smaller implementation is allowed: rely on
+ordinary `shared_ptr` last-owner destruction and remove the reclaimer entirely.
+Both valid implementations eliminate `use_count()` polling; the qualification
+decides whether designated-thread unmapping is necessary.
+
+### 5. Use non-recursive locks and explicit locked/unlocked helpers
+
+Reader membership, page-load coordination, and passed-page collection use
+`std::mutex` unless a reviewed call graph demonstrates unavoidable re-entry.
+Nested operations are expressed as private `*_locked` / `*_unlocked` helpers
+instead of selecting `recursive_mutex` as insurance.
+
+## Compatibility and migration
+
+- No page/frame field, alignment, epoch, publication token, or mmap format
+  changes.
+- The first implementation slice adds the RAII transaction and migrates
+  in-tree callers while retaining deprecated compatibility methods.
+- The second slice establishes the reader management snapshot and thread-affine
+  cursor contract.
+- The third slice qualifies and replaces page reclamation, then removes
+  recursive locking and stale compatibility names.
+- Python and Node bindings keep their current high-level write/read behavior;
+  they surface the safer C++ ownership model rather than exposing a raw
+  transaction unless a consumer requirement justifies it.
+
+Removal of deprecated methods requires a separately declared compatibility
+window and a repository-wide consumer scan.
+
+## Alternatives considered
+
+- **Add a coarse recursive mutex to every reader method.** Rejected: it hides
+  cursor ownership, does not make returned mutable frame pointers safe after the
+  lock is released, and taxes the common single-consumer path.
+- **Store a `unique_lock` inside `writer` between open and close.** Rejected as
+  the primary model: it still leaves transaction ownership implicit and cannot
+  reliably distinguish caller abandonment from an active reservation.
+- **Keep microsecond polling but add a timeout/backoff.** Rejected: it bounds
+  one symptom while retaining refcount observation as a scheduling protocol.
+- **Adopt hazard pointers or epoch-based reclamation immediately.** Deferred:
+  page rollover is not yet shown to need that complexity. A custom deleter or
+  ordinary last-owner destruction is easier to audit and sufficient unless
+  benchmarks falsify it.
+- **Rename only the lock-free methods.** Rejected as incomplete: terminology is
+  one symptom of missing ownership and thread-affinity contracts.
+
+## Acceptance and verification gates
+
+Before this ADR can become accepted/implemented:
+
+1. Exception-injection tests cover reservation, page rollover, open/close hooks,
+   payload construction, commit, and publisher notification; a subsequent write
+   must succeed after every injected failure.
+2. ThreadSanitizer stress covers pump-thread cursor use concurrent with resource
+   snapshots, join/disjoin handoff, preload, release, and shutdown.
+3. A held page lease must not make `release_page()` busy-wait or block the
+   resource worker; final release must unmap exactly once.
+4. Reclaimer shutdown/drain and late-deleter fallback are deterministic and
+   leak-free on macOS, Linux, and Windows, or qualification chooses ordinary
+   last-owner destruction instead.
+5. ARM and x86 publication stress from ADR-0001 remains tear-free.
+6. Before/after benchmarks report append throughput, tail-read throughput,
+   page-rollover latency, CPU time, and allocation/refcount cost. The transaction
+   wrapper must not add synchronization to published-frame reads.
+7. Public docs and API names describe single-writer, reader cursor affinity,
+   and the exact lock-free boundary consistently.
+
+## Consequences
+
+- Failure paths become recoverable without deadlocking a writer or resource
+  worker.
+- Thread safety is stated as a composable contract instead of inferred from a
+  mutex member or `shared_ptr` use.
+- The page lifecycle gains an explicit owner and shutdown protocol.
+- Migration adds temporary API surface and tests, but the compatibility period
+  is bounded and observable.
+- The lock-free claim becomes narrower and stronger: publication and tail reads
+  retain their proof; unrelated operations stop borrowing that label.

--- a/framework/core/docs/adr/ADR-0064-runtime-error-propagation-and-stop-ownership.md
+++ b/framework/core/docs/adr/ADR-0064-runtime-error-propagation-and-stop-ownership.md
@@ -1,0 +1,161 @@
+# ADR-0064: runtime libraries propagate structured errors; loop owners decide how execution stops
+
+- Status: proposed
+- Date: 2026-07-12
+- Category: (b) correctness + embedding boundary
+- Subsystem: replay writer, Rx subscription errors, reactor/peer loop ownership, Python and Node hosts
+- Related: [ADR-0003](ADR-0003-control-axis-python-coroutine-integration.md),
+  [ADR-0004](ADR-0004-control-axis-node-watcher-snapshot-model.md),
+  [ADR-0005](ADR-0005-control-event-axis-modernization-assessment.md),
+  [ADR-0020](ADR-0020-agent-action-timeline-and-replay-boundary.md),
+  [ADR-0063](ADR-0063-yijinjing-concurrency-and-lifetime-contract.md)
+
+## Context
+
+Two library-level error paths can currently interrupt an entire process:
+
+- `replay_writer::open_frame()` calls `raise(SIGINT)` when it cannot find more
+  replay data for a carrier type, then continues constructing a cloned frame if
+  a signal handler returns.
+- The default Rx `loop_interrupter()` also calls `raise(SIGINT)`. A reactor
+  replaces it with a callback that calls `signal_stop()`, but the callback is a
+  mutable process-wide static `std::function` that captures one reactor. Multiple
+  reactors can overwrite one another, and destruction does not establish an
+  explicit lifetime boundary for the captured object.
+
+A library cannot know whether its host is a CLI, Python interpreter, Node
+process, desktop application, test runner, embedded runtime, or another service.
+Sending a process signal from the middle of replay or subscription dispatch
+bypasses that host's error, cleanup, and policy boundaries.
+
+ADR-0005 froze the v4 Rx routing algebra, synchronous fan-out model, and
+performance work because measurement showed no bottleneck. This proposal does
+not reopen that decision. Error ownership and callback lifetime are correctness
+boundaries around the loop, not a replacement or optimization of Rx routing.
+
+## Proposed decision
+
+### 1. Libraries report errors; application boundaries choose process behavior
+
+Code below the CLI/application host does not raise `SIGINT`, call `exit`, or
+otherwise terminate the process as an error-reporting mechanism.
+
+- Synchronous library operations return a typed result or throw a documented
+  typed exception.
+- Asynchronous loop/subscription errors are delivered to an owner-provided error
+  sink associated with that loop instance.
+- Only a top-level CLI or explicit process supervisor may convert an error or
+  user interrupt into a process signal or exit code.
+
+### 2. Replay exhaustion is a typed outcome
+
+Reaching the end of replay or failing to find the requested carrier is reported
+as `replay_exhausted` (or an equivalent typed `replay_error` result). It does not
+manufacture a writable frame after signalling an error.
+
+The caller decides whether exhaustion means normal EOF, a failed deterministic
+replay contract, or a request to stop the owning runtime. Python and Node map
+the outcome to their ordinary exception/EOF mechanisms; a CLI may map it to a
+documented non-zero exit status.
+
+### 3. Every event loop owns its stop and error state
+
+Each reactor/loop instance owns an error state containing at least:
+
+- the first `std::exception_ptr` (or typed error);
+- an idempotent stop request;
+- a lifetime-safe callback/token used by subscriptions;
+- a way for the host boundary to inspect, return, or rethrow the error after the
+  pump unwinds.
+
+Subscription error handling records the first error and requests that same
+loop to stop. It does not mutate a process-global callback, target another
+reactor, or retain an unscoped raw `this` capture.
+
+The owner may implement the stop request with `std::stop_source`, a weakly owned
+loop state, or an equivalent explicit token. The semantic requirement is
+per-loop identity and lifetime, not a specific C++ class.
+
+### 4. Unwinding and host translation happen at a stable boundary
+
+The pump completes its current failure path, releases subscriptions/resources,
+and returns control to its owner. The owner then translates the recorded error:
+
+- C++ run loop: return a typed status or rethrow at the documented `run`/`step`
+  boundary;
+- Python: raise through the binding/coroutine boundary with the original cause;
+- Node: reject/report through the watcher/event-loop boundary;
+- GUI/service: report failure and apply its own restart/stop policy;
+- CLI: render a diagnostic and choose an exit code.
+
+User-originated `SIGINT` remains a valid top-level control input. This ADR only
+forbids a library from synthesizing it as an internal error channel.
+
+### 5. Preserve the frozen Rx execution model
+
+No routing operator, filter-chain declaration, `holdon` step primitive,
+synchronous fan-out rule, or dispatch indexing changes under this ADR. The
+change is limited to error-sink injection, stop ownership, lifetime cleanup, and
+host propagation.
+
+Performance optimization of the reactive layer remains governed by ADR-0005's
+measured reopening conditions.
+
+## Compatibility and migration
+
+1. Introduce typed replay errors and migrate in-tree replay callers/bindings.
+2. Add a per-loop error/stop owner and inject it into subscription construction.
+3. Keep a temporary compatibility adapter for Rx use outside a reactor, but its
+   default records/throws a structured error; it never raises a process signal.
+4. Remove the process-global mutable interrupter after repository-wide caller
+   migration.
+5. Update public contracts and known limits so "loop stopped" and "process
+   interrupted" are never used as synonyms.
+
+No journal layout, frame publication, replay data, or routing declaration
+changes.
+
+## Alternatives considered
+
+- **Keep `raise(SIGINT)` for fail-loud behavior.** Rejected: it is loud at the
+  wrong ownership layer and can terminate unrelated embedded work.
+- **Install a signal handler in every host.** Rejected: handlers are
+  process-global, platform-sensitive, and still lose loop identity and the
+  original exception.
+- **Retain one global callback but guard it with a mutex.** Rejected: a mutex
+  prevents data races but cannot make one callback belong to multiple reactors
+  or solve captured-object lifetime.
+- **Swallow subscriber errors and continue.** Rejected: routing chains are
+  load-bearing; a silently dead chain is worse than a cleanly stopped loop with
+  a preserved cause.
+- **Replace RxCpp while touching error handling.** Rejected by scope and by
+  ADR-0005's measured freeze decision.
+
+## Acceptance and verification gates
+
+Before this ADR can become accepted/implemented:
+
+1. Replay exhaustion tests prove no signal is emitted and no synthetic frame is
+   returned after exhaustion.
+2. Subscriber exceptions preserve type/message/cause through C++, Python, and
+   Node owner boundaries.
+3. Two reactors running concurrently receive only their own errors and stop
+   independently.
+4. Destroying a reactor/host before or after subscription teardown leaves no
+   callback capable of dereferencing it.
+5. Repeated errors record the first cause and request stop idempotently.
+6. Existing explicit user `SIGINT` handling and CLI exit-code tests remain
+   intact.
+7. The ADR-0005 dispatch benchmark shows no material regression; routing and
+   step-mode qualification remain unchanged.
+
+## Consequences
+
+- Embedding hosts regain authority over cleanup, diagnostics, restart, and
+  process lifetime.
+- Errors retain their original cause instead of being flattened into SIGINT.
+- Per-loop state removes cross-reactor callback interference and dangling
+  captures.
+- The implementation touches a load-bearing boundary and therefore requires
+  multi-host qualification even though it deliberately leaves Rx routing
+  unchanged.

--- a/framework/core/docs/adr/README.md
+++ b/framework/core/docs/adr/README.md
@@ -80,6 +80,8 @@ A record's **Status** says where it stands:
 | [0060](ADR-0060-desktop-workspace-selection-and-lazy-data-home.md) | proposed | Desktop and CLI select Home or a project workspace and create its data home only on qualified write intent |
 | [0061](ADR-0061-agent-mediated-guidance-is-a-first-class-product-interface.md) | proposed | Agent-mediated guidance is a first-class interface over shared advice, preview, authorization, action, and receipt contracts |
 | [0062](ADR-0062-journal-container-epoch-and-offline-conversion.md) | accepted; implemented | the journal container epoch is derived from its layout; cross-epoch replay is deferred offline conversion, not an online adapter |
+| [0063](ADR-0063-yijinjing-concurrency-and-lifetime-contract.md) | proposed | yijinjing separates lock-free publication from cursor, write, and page-lifetime ownership |
+| [0064](ADR-0064-runtime-error-propagation-and-stop-ownership.md) | proposed | runtime libraries propagate structured errors; loop owners decide how execution stops |
 
 ## Reading by theme
 
@@ -95,12 +97,20 @@ A record's **Status** says where it stands:
   journal container epoch from the page/frame header layout itself, so an
   unversioned layout change cannot ship, and keeps cross-epoch replay off the hot
   path as deferred offline conversion.
+  [0063](ADR-0063-yijinjing-concurrency-and-lifetime-contract.md) narrows the
+  lock-free claim to publication/tail reads and proposes explicit writer
+  transactions, a thread-affine reader cursor, and ownership-driven page
+  reclamation.
   [0002](ADR-0002-yijinjing-schema-runtime-layout.md) is retained as the
   superseded historical decision that preceded this split.
 - **Control / event axis** — [0003](ADR-0003-control-axis-python-coroutine-integration.md)
   (Python coroutine integration), [0004](ADR-0004-control-axis-node-watcher-snapshot-model.md)
   (Node watcher snapshot model), with [0005](ADR-0005-control-event-axis-modernization-assessment.md)
   the meta-assessment of whether v4 should touch this axis at all.
+  [0064](ADR-0064-runtime-error-propagation-and-stop-ownership.md) proposes the
+  narrower correctness boundary that libraries propagate structured errors and
+  each loop owner controls stopping, without reopening ADR-0005's frozen Rx
+  routing/fan-out decision.
 - **Frontend platform** — [0006](ADR-0006-v4-frontend-platform-architecture.md)
   (platform + reference app), [0007](ADR-0007-v4-tui-platform-reference-surface.md)
   (the TUI reference surface).


### PR DESCRIPTION
Merge docs/yijinjing-concurrency-contracts into dev/v4/v4.0 (kungfu-systems zone dual-account PR flow).