### PR TITLE
feat(freeze): build product trunk with --features embedding on POSIX (ADR-0046 S3)

### DIFF
--- a/framework/core/.gyp/run-freeze.js
+++ b/framework/core/.gyp/run-freeze.js
@@ -541,7 +541,7 @@ function assembleTree(bt) {
   copyAppNative(bt);
   copyLibwasmRuntime();
   copyConfigContract();
-  stageEntry(distKfc);
+  stageEntry(distKfc, bt);
   generateHelpManifest(layout.python, distKfc);
   console.log(
     '[freeze] ✅ dist/kungfu assembled (interpreter tree + flat natives + ' +
@@ -580,12 +580,29 @@ function generateHelpManifest(pythonExe, distKfc) {
 // yields a runnable assembled dist; dist.mjs stageTrunk later re-stages
 // kungfu-trunk and asserts pins consistency at the product stage — same
 // commit, same profile, same binary.
-/** @param {string} distKfc */
-function stageEntry(distKfc) {
+// ADR-0046 stage 3 productionization: the product trunk links libkungfu and
+// ships the real embedding-backed `doctor` on POSIX (--features embedding).
+// Windows embedding linking is not wired yet (crates/trunk/build.rs panics on
+// windows), so the Windows product trunk stays the coreless stub until that
+// follow-up lands — the trunk's doctor/help/variant paths all fall back
+// gracefully when the core is absent, so keeping Windows featureless is
+// zero-regression. The native dir (framework/core/build/<bt>, already populated
+// with libkungfu.* by the time assemble runs) is passed explicitly so build.rs
+// never has to guess a relative path that could fail canonicalize under CI.
+/** @param {string} distKfc @param {string} bt */
+function stageEntry(distKfc, bt) {
   const crates = path.join(CORE, '..', '..', 'crates');
-  shell.run('cargo', ['build', '--release', '-p', 'kungfu-trunk'], true, {
-    cwd: crates,
-  });
+  const cargoArgs = ['build', '--release', '-p', 'kungfu-trunk'];
+  const runOpts = { cwd: crates };
+  if (!isWin) {
+    cargoArgs.push('--features', 'embedding');
+    runOpts.env = {
+      ...process.env,
+      KF_TRUNK_NATIVE_DIR: path.join(CORE, 'build', bt),
+      KF_TRUNK_BUILD_TYPE: bt,
+    };
+  }
+  shell.run('cargo', cargoArgs, true, runOpts);
   const built = path.join(
     crates,
     'target',

--- a/product/scripts/dist.mjs
+++ b/product/scripts/dist.mjs
@@ -640,16 +640,34 @@ function assertCoreFrozen() {
 // runtime-pins manifest. UV_VERSION in the manifest must equal the repo's
 // .uv-version so the product and the dev launcher pull the same pinned uv.
 function stageTrunk() {
-  run(
-    'build kungfu-trunk',
-    'cargo',
-    ['build', '--release', '-p', 'kungfu-trunk'],
-    {
-      cwd: CRATES_DIR,
-      phase: 'core',
-      event: 'product.core.trunk',
-    },
-  );
+  // ADR-0046 stage 3 productionization: link libkungfu and ship the real
+  // embedding-backed doctor on POSIX. Windows stays featureless (build.rs
+  // panics on windows until the static-link follow-up lands); the trunk falls
+  // back gracefully when the core is absent, so that is zero-regression. The
+  // product core is rebuilt (Release) before this stage, so the native dir is
+  // populated; pass it explicitly so build.rs never guesses.
+  const cargoArgs = ['build', '--release', '-p', 'kungfu-trunk'];
+  const runOpts = {
+    cwd: CRATES_DIR,
+    phase: 'core',
+    event: 'product.core.trunk',
+  };
+  if (!isWin) {
+    const buildType = process.env.KF_TRUNK_BUILD_TYPE || 'Release';
+    cargoArgs.push('--features', 'embedding');
+    runOpts.env = {
+      ...process.env,
+      KF_TRUNK_NATIVE_DIR: path.join(
+        ROOT,
+        'framework',
+        'core',
+        'build',
+        buildType,
+      ),
+      KF_TRUNK_BUILD_TYPE: buildType,
+    };
+  }
+  run('build kungfu-trunk', 'cargo', cargoArgs, runOpts);
   const trunkBin = path.join(
     CRATES_DIR,
     'target',


### PR DESCRIPTION
ADR-0046 stage 3 productionization (Phase A, POSIX). The frozen/assembled product trunk now links libkungfu and ships the real embedding-backed `doctor` on macOS/Linux.

Both trunk build points pass `--features embedding` with an explicit `KF_TRUNK_NATIVE_DIR` / `KF_TRUNK_BUILD_TYPE` (`framework/core/build/<bt>`, populated before assemble) so build.rs never guesses a relative path that could fail canonicalize under CI:
- `framework/core/.gyp/run-freeze.js` `stageEntry`
- `product/scripts/dist.mjs` `stageTrunk`

Windows stays featureless until the static-core link follow-up lands; the trunk's doctor/help/variant paths all fall back gracefully when the core is absent, so this is zero-regression.

Local verification (macOS): product cargo invocation builds a real embedding trunk (links `@rpath/libkungfu.dylib`, `@loader_path` rpath); in a co-located dist layout `doctor` negotiates ABI v1 + reports real capabilities, `KUNGFU_AS_VARIANT=node` dlopens the node host and runs `node::Start`, and `--help` renders from the co-located manifest (falls through when absent).