### PR TITLE
fix(build): isolate RxCpp GCC 14 compatibility patch

### DIFF
--- a/framework/core/CMakeLists.txt
+++ b/framework/core/CMakeLists.txt
@@ -26,6 +26,16 @@ find_package(xxHash REQUIRED)
 find_package(tabulate REQUIRED)
 find_package(pybind11 REQUIRED)
 
+# RxCpp 4.1.1 assigns to a const error_ptr in rx-notification.hpp. Conan's
+# generated compatibility copy deletes that impossible assignment operator so
+# clean GCC builds do not depend on a mutated shared package cache.
+if(NOT DEFINED KUNGFU_RXCPP_COMPAT_INCLUDE_DIR OR
+   NOT EXISTS "${KUNGFU_RXCPP_COMPAT_INCLUDE_DIR}/rxcpp/rx-notification.hpp")
+  message(FATAL_ERROR "missing generated RxCpp compatibility include tree")
+endif()
+target_include_directories(rxcpp::rxcpp BEFORE INTERFACE
+  "${KUNGFU_RXCPP_COMPAT_INCLUDE_DIR}")
+
 set(CONAN_LIBS
     fmt::fmt-header-only
     spdlog::spdlog_header_only

--- a/framework/core/conanfile.py
+++ b/framework/core/conanfile.py
@@ -23,8 +23,48 @@ from conan.tools.build import build_jobs
 from conan.tools.cmake import CMakeToolchain, CMakeDeps
 from conan.tools.files import copy
 
-with open(path.join("package.json"), "r") as package_json_file:
+_CONANFILE_DIR = path.dirname(path.realpath(__file__))
+
+with open(path.join(_CONANFILE_DIR, "package.json"), "r") as package_json_file:
     package_json = json.load(package_json_file)
+
+
+_RXCPP_INVALID_ASSIGNMENT = (
+    "on_error_notification& operator=(on_error_notification o) "
+    "{ ep = std::move(o.ep); return *this; }"
+)
+_RXCPP_DELETED_ASSIGNMENT = (
+    "on_error_notification& operator=(on_error_notification) = delete;"
+)
+
+
+def _prepare_rxcpp_compat(source_include_dir, destination_include_dir):
+    """Copy RxCpp and remove its invalid assignment to a const error_ptr.
+
+    RxCpp 4.1.1 and upstream main still declare ``ep`` const while assigning to
+    it in a non-template-dependent operator body. GCC rejects the header during
+    a clean build. Keep Conan's package immutable and patch a generated include
+    overlay instead; fail closed if the pinned upstream source changes.
+    """
+    source_rxcpp_dir = path.join(source_include_dir, "rxcpp")
+    destination_rxcpp_dir = path.join(destination_include_dir, "rxcpp")
+    if path.exists(destination_rxcpp_dir):
+        shutil.rmtree(destination_rxcpp_dir)
+    shutil.copytree(source_rxcpp_dir, destination_rxcpp_dir)
+
+    notification_header = path.join(destination_rxcpp_dir, "rx-notification.hpp")
+    with open(notification_header, "r", encoding="utf-8") as source_file:
+        source = source_file.read()
+    if source.count(_RXCPP_INVALID_ASSIGNMENT) != 1:
+        raise RuntimeError(
+            "RxCpp compatibility patch no longer matches exactly once: "
+            f"{notification_header}"
+        )
+    with open(notification_header, "w", encoding="utf-8") as destination_file:
+        destination_file.write(
+            source.replace(_RXCPP_INVALID_ASSIGNMENT, _RXCPP_DELETED_ASSIGNMENT)
+        )
+    return destination_include_dir
 
 
 def _detected_os():
@@ -107,7 +147,7 @@ class KungfuCoreConan(ConanFile):
         ".deps/*",
         "dist/*",
     )
-    conanfile_dir = path.dirname(path.realpath(__file__))
+    conanfile_dir = _CONANFILE_DIR
     build_info_file = "kungfubuildinfo.json"
     build_dir = path.join(conanfile_dir, "build")
     dist_dir = path.join(conanfile_dir, "dist")
@@ -124,11 +164,19 @@ class KungfuCoreConan(ConanFile):
             pass
 
     def generate(self):
+        rxcpp_package_folder = self.dependencies["rxcpp"].package_folder
+        if rxcpp_package_folder is None:
+            raise RuntimeError("RxCpp dependency has no Conan package folder")
+        rxcpp_compat_include_dir = _prepare_rxcpp_compat(
+            path.join(rxcpp_package_folder, "include"),
+            path.join(self.build_folder, "compat", "rxcpp-4.1.1"),
+        )
         deps = CMakeDeps(self)
         deps.generate()
         tc = CMakeToolchain(self, generator="Ninja")
         # 把自身 options 透传给 CMake（主 CMakeLists 用 ${CONAN_LIBS} 桥接 + SPDLOG 等级）。
         tc.variables["SPDLOG_LOG_LEVEL_COMPILE"] = self.__spdlog_level()
+        tc.variables["KUNGFU_RXCPP_COMPAT_INCLUDE_DIR"] = rxcpp_compat_include_dir
         tc.generate()
         if self.gyp_call:
             self.__touch_lockfile()

--- a/framework/core/conanfile.py
+++ b/framework/core/conanfile.py
@@ -38,6 +38,11 @@ _RXCPP_DELETED_ASSIGNMENT = (
 )
 
 
+def _cmake_path(value):
+    """Return a path safe to embed in a generated CMake string literal."""
+    return str(value).replace("\\", "/")
+
+
 def _prepare_rxcpp_compat(source_include_dir, destination_include_dir):
     """Copy RxCpp and remove its invalid assignment to a const error_ptr.
 
@@ -176,7 +181,9 @@ class KungfuCoreConan(ConanFile):
         tc = CMakeToolchain(self, generator="Ninja")
         # 把自身 options 透传给 CMake（主 CMakeLists 用 ${CONAN_LIBS} 桥接 + SPDLOG 等级）。
         tc.variables["SPDLOG_LOG_LEVEL_COMPILE"] = self.__spdlog_level()
-        tc.variables["KUNGFU_RXCPP_COMPAT_INCLUDE_DIR"] = rxcpp_compat_include_dir
+        tc.variables["KUNGFU_RXCPP_COMPAT_INCLUDE_DIR"] = _cmake_path(
+            rxcpp_compat_include_dir
+        )
         tc.generate()
         if self.gyp_call:
             self.__touch_lockfile()

--- a/framework/core/tests/python/test_conan_rxcpp_compat.py
+++ b/framework/core/tests/python/test_conan_rxcpp_compat.py
@@ -1,0 +1,57 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+CORE_DIR = Path(__file__).resolve().parents[2]
+CONANFILE_PATH = CORE_DIR / "conanfile.py"
+
+
+def _load_conanfile():
+    spec = importlib.util.spec_from_file_location(
+        "kungfu_core_conanfile", CONANFILE_PATH
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_prepare_rxcpp_compat_patches_copy_without_mutating_source(tmp_path):
+    conanfile = _load_conanfile()
+    source_include = tmp_path / "source" / "include"
+    source_rxcpp = source_include / "rxcpp"
+    source_rxcpp.mkdir(parents=True)
+    source_header = source_rxcpp / "rx-notification.hpp"
+    source_header.write_text(
+        f"before\n{conanfile._RXCPP_INVALID_ASSIGNMENT}\nafter\n",
+        encoding="utf-8",
+    )
+
+    destination_include = tmp_path / "build" / "compat"
+    conanfile._prepare_rxcpp_compat(source_include, destination_include)
+
+    assert conanfile._RXCPP_INVALID_ASSIGNMENT in source_header.read_text(
+        encoding="utf-8"
+    )
+    generated = (destination_include / "rxcpp" / "rx-notification.hpp").read_text(
+        encoding="utf-8"
+    )
+    assert conanfile._RXCPP_INVALID_ASSIGNMENT not in generated
+    assert conanfile._RXCPP_DELETED_ASSIGNMENT in generated
+
+
+def test_prepare_rxcpp_compat_fails_closed_on_upstream_drift(tmp_path):
+    conanfile = _load_conanfile()
+    source_rxcpp = tmp_path / "source" / "include" / "rxcpp"
+    source_rxcpp.mkdir(parents=True)
+    (source_rxcpp / "rx-notification.hpp").write_text(
+        "upstream changed\n", encoding="utf-8"
+    )
+
+    with pytest.raises(RuntimeError, match="no longer matches exactly once"):
+        conanfile._prepare_rxcpp_compat(
+            tmp_path / "source" / "include", tmp_path / "build" / "compat"
+        )

--- a/framework/core/tests/python/test_conan_rxcpp_compat.py
+++ b/framework/core/tests/python/test_conan_rxcpp_compat.py
@@ -55,3 +55,11 @@ def test_prepare_rxcpp_compat_fails_closed_on_upstream_drift(tmp_path):
         conanfile._prepare_rxcpp_compat(
             tmp_path / "source" / "include", tmp_path / "build" / "compat"
         )
+
+
+def test_cmake_path_normalizes_windows_separators():
+    conanfile = _load_conanfile()
+    assert (
+        conanfile._cmake_path(r"D:\a\kungfu\framework\core\build\compat")
+        == "D:/a/kungfu/framework/core/build/compat"
+    )


### PR DESCRIPTION
## Summary

- generate a private RxCpp 4.1.1 compatibility include overlay in the core build directory
- keep the shared Conan package cache immutable
- fail closed if the pinned upstream header no longer matches the expected source
- normalize the generated overlay path before embedding it in CMake toolchain files on Windows
- add regression tests for source immutability, patched output, upstream drift, and Windows path normalization

## Evidence

- `framework/core/.venv/bin/python -m pytest -q framework/core/tests/python/test_conan_rxcpp_compat.py`
- `./shifu check`
- Linux GCC 14 failure: Build run 29183724257, job 86626077111
- Windows CMake path failure: membrane run 29184252232, job 86627407081

Closes #622