### PR TITLE
feat(yijinjing): implement ADR-0063 concurrency ownership

### DIFF
--- a/framework/core/src/libkungfu/include/kungfu/runtime/live/reactor.h
+++ b/framework/core/src/libkungfu/include/kungfu/runtime/live/reactor.h
@@ -93,7 +93,9 @@ public:
 
   [[nodiscard]] virtual yijinjing::journal::writer_ptr get_band_writer(uint32_t dest_id) const;
 
-  [[nodiscard]] const WriterMap &get_writers() const;
+  /// Returns a stable management snapshot. The caller may iterate it without
+  /// racing writer membership changes on the reactor thread.
+  [[nodiscard]] WriterMap get_writers() const;
 
   [[nodiscard]] bool has_location(uint32_t uid) const;
 
@@ -182,6 +184,7 @@ protected:
   yijinjing::journal::reader_ptr reader_;
   WriterMap writers_ = {};
   WriterMap band_writers_ = {};
+  mutable std::mutex writers_mtx_{};
   mutable std::mutex band_mtx_{};
   const size_t main_thread_id_{};
   std::set<std::string> location_uid64s_ = {};

--- a/framework/core/src/libkungfu/include/kungfu/runtime/nanomsg/webserver.h
+++ b/framework/core/src/libkungfu/include/kungfu/runtime/nanomsg/webserver.h
@@ -11,6 +11,7 @@
 #include <functional>
 #include <map>
 #include <memory>
+#include <optional>
 #include <set>
 #include <shared_mutex>
 #include <string>
@@ -175,7 +176,7 @@ private:
   uint64_t stream_id_;
   yijinjing::data::location_ptr location_ = nullptr;
   yijinjing::journal::writer_ptr writer_ = nullptr;
-  yijinjing::journal::frame_ptr current_frame_ = nullptr;
+  std::optional<yijinjing::journal::writer::frame_transaction> current_write_;
 };
 DECLARE_PTR(stream)
 

--- a/framework/core/src/libkungfu/src/runtime/action_recorder.cpp
+++ b/framework/core/src/libkungfu/src/runtime/action_recorder.cpp
@@ -23,6 +23,14 @@ constexpr uint32_t CRC32C_INITIAL = 0xffffffffu;
 constexpr uint32_t CRC32C_XOR_OUT = 0xffffffffu;
 constexpr uint32_t CRC32C_REVERSED_POLY = 0x82f63b78u;
 
+class trigger_frame_scope {
+public:
+  explicit trigger_frame_scope(uint64_t frame_uid) { bus::set_trigger_frame_uid(frame_uid); }
+  trigger_frame_scope(const trigger_frame_scope &) = delete;
+  trigger_frame_scope &operator=(const trigger_frame_scope &) = delete;
+  ~trigger_frame_scope() { bus::set_trigger_frame_uid(0); }
+};
+
 uint32_t align_frame_payload_length(uint32_t length) {
   return static_cast<uint32_t>((length + (sizeof(uintptr_t) - 1)) & ~(sizeof(uintptr_t) - 1));
 }
@@ -216,8 +224,9 @@ record_receipt action_recorder::record_payload(int32_t carrier_type, const uint8
   const auto stream_id = options.stream_id != 0 ? options.stream_id : default_stream_id_;
   const auto gen_time = options.gen_time != 0 ? options.gen_time : time::now_in_nano();
 
-  bus::set_trigger_frame_uid(parent_frame_uid);
-  auto frame = writer_->open_frame(options.trigger_time, carrier_type, payload_length, stream_id);
+  const trigger_frame_scope trigger_scope(parent_frame_uid);
+  auto tx = writer_->reserve_frame(options.trigger_time, carrier_type, payload_length, stream_id);
+  auto frame = tx.frame();
   frame->set_data_type(options.data_type);
   if (payload_length > 0) {
     std::memcpy(const_cast<void *>(frame->data_address()), payload, payload_length);
@@ -231,9 +240,7 @@ record_receipt action_recorder::record_payload(int32_t carrier_type, const uint8
   const auto checksum_algorithm = frame_checksum_algorithm_for_integrity_version(DEFAULT_FRAME_INTEGRITY_VERSION);
   const auto payload_checksum = checksum_payload(payload, payload_length, checksum_algorithm);
   const auto frame_checksum = checksum_frame(checksum_header, payload, payload_length, checksum_algorithm);
-  writer_->close_frame(payload_length, gen_time);
-  bus::set_trigger_frame_uid(0);
-
+  tx.commit(payload_length, gen_time);
   record_receipt receipt{};
   receipt.frame_uid = frame_uid;
   receipt.trigger_frame_uid = parent_frame_uid;

--- a/framework/core/src/libkungfu/src/runtime/journal/replay_writer.cpp
+++ b/framework/core/src/libkungfu/src/runtime/journal/replay_writer.cpp
@@ -67,4 +67,14 @@ uint64_t replay_writer::current_frame_uid() {
   });
   return uid;
 }
+
+frame_ptr replay_writer::begin_transaction_unserialized(int64_t trigger_time, int32_t carrier_type, size_t length,
+                                                        uint64_t stream_id) {
+  return open_frame(trigger_time, carrier_type, length, stream_id);
+}
+
+void replay_writer::commit_transaction_unserialized(size_t data_length, int64_t gen_time, const frame_ptr &frame) {
+  (void)frame;
+  close_frame(data_length, gen_time);
+}
 } // namespace kungfu::yijinjing::journal

--- a/framework/core/src/libkungfu/src/runtime/journal/replay_writer.cpp
+++ b/framework/core/src/libkungfu/src/runtime/journal/replay_writer.cpp
@@ -68,13 +68,17 @@ uint64_t replay_writer::current_frame_uid() {
   return uid;
 }
 
-frame_ptr replay_writer::begin_transaction_unserialized(int64_t trigger_time, int32_t carrier_type, size_t length,
-                                                        uint64_t stream_id) {
-  return open_frame(trigger_time, carrier_type, length, stream_id);
-}
-
-void replay_writer::commit_transaction_unserialized(size_t data_length, int64_t gen_time, const frame_ptr &frame) {
-  (void)frame;
-  close_frame(data_length, gen_time);
+writer::frame_transaction replay_writer::reserve_frame(int64_t trigger_time, int32_t carrier_type, size_t length,
+                                                       uint64_t stream_id) {
+  if (!writer_mtx_.try_lock_for(std::chrono::seconds(30))) {
+    throw journal_error("Can not lock replay writer for " + journal_->location_->uname);
+  }
+  try {
+    auto frame = open_frame(trigger_time, carrier_type, length, stream_id);
+    return frame_transaction(*this, std::move(frame), true);
+  } catch (...) {
+    writer_mtx_.unlock();
+    throw;
+  }
 }
 } // namespace kungfu::yijinjing::journal

--- a/framework/core/src/libkungfu/src/runtime/journal/replay_writer.cpp
+++ b/framework/core/src/libkungfu/src/runtime/journal/replay_writer.cpp
@@ -75,7 +75,7 @@ writer::frame_transaction replay_writer::reserve_frame(int64_t trigger_time, int
   }
   try {
     auto frame = open_frame(trigger_time, carrier_type, length, stream_id);
-    return frame_transaction(*this, std::move(frame), true);
+    return frame_transaction(*this, frame.get(), true);
   } catch (...) {
     writer_mtx_.unlock();
     throw;

--- a/framework/core/src/libkungfu/src/runtime/live/coordinator.cpp
+++ b/framework/core/src/libkungfu/src/runtime/live/coordinator.cpp
@@ -36,7 +36,11 @@ void coordinator::pre_setup() {
     try_add_location(begin_time_, location::make_shared(config, get_locator()));
   }
 
-  writers_.insert_or_assign(location::PUBLIC, get_io_device()->open_writer(location::PUBLIC));
+  auto public_writer = get_io_device()->open_writer(location::PUBLIC);
+  {
+    std::lock_guard<std::mutex> lock(writers_mtx_);
+    writers_.insert_or_assign(location::PUBLIC, std::move(public_writer));
+  }
   state_cache_.run_store_workers();
 }
 
@@ -97,7 +101,10 @@ void coordinator::register_peer(const event_ptr &event) {
   try_add_location(event->gen_time(), coordinator_cmd_location);
 
   auto peer_cmd_writer = get_io_device()->open_writer_at(coordinator_cmd_location, peer_location->uid);
-  writers_.insert_or_assign(peer_location->uid, peer_cmd_writer);
+  {
+    std::lock_guard<std::mutex> lock(writers_mtx_);
+    writers_.insert_or_assign(peer_location->uid, peer_cmd_writer);
+  }
   reader_->join(peer_location, location::PUBLIC, now);
   reader_->join(peer_location, location::SYNC, now); // create sync journal
   disjoin_channel(peer_location, location::SYNC);    // no need to deal feed from sync
@@ -141,7 +148,10 @@ void coordinator::deregister_peer(int64_t trigger_time, uint32_t peer_location_u
   deregister_band(peer_location_uid);
   deregister_location(trigger_time, peer_location_uid);
   disjoin(location);
-  writers_.erase(peer_location_uid);
+  {
+    std::lock_guard<std::mutex> lock(writers_mtx_);
+    writers_.erase(peer_location_uid);
+  }
   timer_tasks_.erase(peer_location_uid);
   const Deregister deregister = location->to<Deregister>();
   SPDLOG_DEBUG("Deregister: {}", deregister.to_string());

--- a/framework/core/src/libkungfu/src/runtime/live/peer.cpp
+++ b/framework/core/src/libkungfu/src/runtime/live/peer.cpp
@@ -87,14 +87,14 @@ int32_t peer::add_time_interval(int64_t duration, const std::function<void(const
 
 void peer::release_page() {
   reader_->release_page();
-  for (auto &iter : writers_) {
+  for (auto &iter : get_writers()) {
     iter.second->release_page();
   }
 }
 
 void peer::preload_next_page() {
   reader_->preload_next_page();
-  for (auto &iter : writers_) {
+  for (auto &iter : get_writers()) {
     iter.second->preload_next_page();
   }
 }
@@ -169,9 +169,16 @@ void peer::react() {
     fs::remove_all(coordinator_cmd_dir);
     auto peer_cmd_writer = get_io_device()->open_writer_at(coordinator_cmd_location_, get_home_uid());
 
-    writers_.insert_or_assign(get_home_uid(), peer_cmd_writer);
+    {
+      std::lock_guard<std::mutex> lock(writers_mtx_);
+      writers_.insert_or_assign(get_home_uid(), peer_cmd_writer);
+    }
     reader_->join(coordinator_cmd_location_, get_home_uid(), begin_time_);
-    writers_.insert_or_assign(location::PUBLIC, get_io_device()->open_writer(location::PUBLIC));
+    auto public_writer = get_io_device()->open_writer(location::PUBLIC);
+    {
+      std::lock_guard<std::mutex> lock(writers_mtx_);
+      writers_.insert_or_assign(location::PUBLIC, std::move(public_writer));
+    }
     reader_->join(get_home(), location::PUBLIC, begin_time_);
     started_ = true;
     on_start();
@@ -233,8 +240,12 @@ void peer::on_request_read_from_others(const event_ptr &event) {
 void peer::on_write_to(const event_ptr &event) {
   const auto &request = event->data<RequestWriteTo>();
   auto dest_id = request.dest_id;
-  if (writers_.find(dest_id) == writers_.end()) {
-    writers_.emplace(dest_id, get_io_device()->open_writer(dest_id, request.page_size));
+  if (not has_writer(dest_id)) {
+    auto writer = get_io_device()->open_writer(dest_id, request.page_size);
+    {
+      std::lock_guard<std::mutex> lock(writers_mtx_);
+      writers_.emplace(dest_id, std::move(writer));
+    }
     if (dest_id == get_coordinator_command_uid()) {
       coordinator_cmd_writer_for_thread_ = get_writer(dest_id);
     }

--- a/framework/core/src/libkungfu/src/runtime/live/reactor.cpp
+++ b/framework/core/src/libkungfu/src/runtime/live/reactor.cpp
@@ -111,7 +111,14 @@ reactor::reactor(kungfu::runtime::io_device_ptr io_device)
 }
 
 reactor::~reactor() {
-  writers_.clear();
+  {
+    std::lock_guard<std::mutex> lock(writers_mtx_);
+    writers_.clear();
+  }
+  {
+    std::lock_guard<std::mutex> lock(band_mtx_);
+    band_writers_.clear();
+  }
   reader_.reset();
   io_device_.reset();
   ensure_sqlite_shutdown();
@@ -212,9 +219,10 @@ uint32_t reactor::get_live_home_uid() const { return get_io_device()->get_live_h
 reader_ptr reactor::get_reader() const { return reader_; }
 
 bool reactor::has_writer(uint32_t dest_id) const {
-  if (util::get_thread_id() != main_thread_id_) {
-    return has_band_writer(dest_id) or writers_.find(dest_id) != writers_.end();
+  if (util::get_thread_id() != main_thread_id_ and has_band_writer(dest_id)) {
+    return true;
   }
+  std::lock_guard<std::mutex> lock(writers_mtx_);
   return writers_.find(dest_id) != writers_.end();
 }
 
@@ -226,14 +234,21 @@ writer_ptr reactor::get_writer(uint32_t dest_id) const {
       SPDLOG_WARN("Unexpected exception by get_band_writer for dest_id {}:{}, {}", dest_id, get_location_uname(dest_id),
                   e.what());
     }
-  } else if (band_writers_.find(dest_id) != band_writers_.end()) {
-    return band_writers_.at(dest_id);
+  } else {
+    std::lock_guard<std::mutex> lock(band_mtx_);
+    auto band_writer = band_writers_.find(dest_id);
+    if (band_writer != band_writers_.end()) {
+      return band_writer->second;
+    }
   }
 
-  if (writers_.find(dest_id) == writers_.end()) {
+  std::lock_guard<std::mutex> lock(writers_mtx_);
+  auto writer = writers_.find(dest_id);
+  if (writer == writers_.end()) {
     SPDLOG_ERROR("no writer for {}", get_location_uname(dest_id));
+    return writers_.at(dest_id);
   }
-  return writers_.at(dest_id);
+  return writer->second;
 }
 
 bool reactor::has_band_writer(uint32_t dest_id) const {
@@ -249,7 +264,18 @@ writer_ptr reactor::get_band_writer(uint32_t dest_id) const {
   return band_writers_.at(dest_id);
 }
 
-const WriterMap &reactor::get_writers() const { return writers_; }
+WriterMap reactor::get_writers() const {
+  WriterMap snapshot;
+  {
+    std::lock_guard<std::mutex> lock(writers_mtx_);
+    snapshot = writers_;
+  }
+  {
+    std::lock_guard<std::mutex> lock(band_mtx_);
+    snapshot.insert(band_writers_.begin(), band_writers_.end());
+  }
+  return snapshot;
+}
 
 bool reactor::has_location(uint32_t uid) const { return locations_.find(uid) != locations_.end(); }
 

--- a/framework/core/src/libkungfu/src/runtime/util/webserver.cpp
+++ b/framework/core/src/libkungfu/src/runtime/util/webserver.cpp
@@ -32,16 +32,16 @@ stream::~stream() {
 uint64_t stream::get_stream_id() const { return stream_id_; }
 
 void stream::close_data() {
-  if (current_frame_) {
-    writer_->close_frame_lock_free(1024);
-    current_frame_.reset();
+  if (current_write_) {
+    current_write_->commit(1024);
+    current_write_.reset();
   }
 }
 
 void stream::open_data(nng_iov &iov) {
-  current_frame_ = writer_->open_frame_lock_free(yijinjing::time::now_in_nano(), SocketData::tag, 1024);
-  iov.iov_buf = const_cast<void *>(current_frame_->data_address());
-  iov.iov_len = current_frame_->data_length();
+  current_write_.emplace(writer_->reserve_frame(yijinjing::time::now_in_nano(), SocketData::tag, 1024));
+  iov.iov_buf = current_write_->data();
+  iov.iov_len = 1024;
 }
 
 const yijinjing::data::location_ptr &stream::get_location() const { return location_; }

--- a/framework/core/src/libyijinjing/include/kungfu/yijinjing/journal/journal.h
+++ b/framework/core/src/libyijinjing/include/kungfu/yijinjing/journal/journal.h
@@ -13,6 +13,7 @@
 #include <kungfu/yijinjing/time.h>
 #include <mutex>
 #include <queue>
+#include <thread>
 
 namespace kungfu::yijinjing::journal {
 
@@ -132,12 +133,11 @@ protected:
   page_ptr pre_create_page_ = {};
   page_ptr page_ = {};
   page_ptr preload_page_ = {};
-  std::recursive_mutex load_page_mtx_ = {};
+  std::mutex load_page_mtx_ = {};
   std::vector<page_ptr> passed_page_collector_ = {};
-  std::recursive_mutex passed_page_collector_mtx_ = {};
+  std::mutex passed_page_collector_mtx_ = {};
   frame_ptr frame_ = {};
   uint64_t page_frame_nb_ = 0;
-  bool replica_ = false;
   bool keep_page_ = false;
   uint32_t max_pre_create_size_ = 0;
 
@@ -184,17 +184,38 @@ public:
 
   virtual void disjoin_channel(const data::location_ptr &location, uint32_t dest_id);
 
-  [[nodiscard]] frame_ptr current_frame() const { return current_->current_frame(); }
+  /**
+   * The cursor surface is single-consumer and thread-affine. Journal membership
+   * may be snapshotted concurrently, but advancing or inspecting this cursor
+   * from multiple threads is unsupported.
+   */
+  [[nodiscard]] frame_ptr current_frame() const {
+    assert_cursor_thread(true);
+    return current_->current_frame();
+  }
 
-  [[nodiscard]] uint64_t current_frame_id() const { return current_->current_frame_id(); }
+  [[nodiscard]] uint64_t current_frame_id() const {
+    assert_cursor_thread(true);
+    return current_->current_frame_id();
+  }
 
-  [[nodiscard]] page_ptr current_page() const { return current_->current_page(); }
+  [[nodiscard]] page_ptr current_page() const {
+    assert_cursor_thread(true);
+    return current_->current_page();
+  }
 
-  [[nodiscard]] uint32_t current_page_id() const { return current_->current_page_id(); }
+  [[nodiscard]] uint32_t current_page_id() const {
+    assert_cursor_thread(true);
+    return current_->current_page_id();
+  }
 
-  [[nodiscard]] const JournalMap &get_journals() const { return journals_; }
+  /** Snapshot safe for concurrent management iteration. */
+  [[nodiscard]] JournalMap get_journals() const;
 
-  [[nodiscard]] journal_ptr get_current_journal() const { return current_; }
+  [[nodiscard]] journal_ptr get_current_journal() const {
+    assert_cursor_thread(true);
+    return current_;
+  }
 
   [[nodiscard]] journal_ptr get_journal(const data::location_ptr &location, uint32_t dest_id);
 
@@ -217,6 +238,8 @@ public:
   static uint64_t find_page_size(const data::location_ptr &location, uint32_t dest_id);
 
 protected:
+  void assert_cursor_thread(bool claim) const;
+  [[nodiscard]] std::vector<journal_ptr> journal_snapshot() const;
   void sort_without_buffer();
 
   void build_buffer();
@@ -233,7 +256,11 @@ protected:
   bool buffer_built_{false};
   std::vector<journal_ptr> no_data_journals_buffer_{};
   std::priority_queue<journal_ptr, std::vector<journal_ptr>, later> has_data_journals_heap_{};
-  std::recursive_mutex mtx_{};
+  mutable std::mutex journals_mtx_{};
+#ifndef NDEBUG
+  mutable std::mutex cursor_owner_mtx_{};
+  mutable std::thread::id cursor_owner_thread_{};
+#endif
 };
 
 class writer {

--- a/framework/core/src/libyijinjing/include/kungfu/yijinjing/journal/journal.h
+++ b/framework/core/src/libyijinjing/include/kungfu/yijinjing/journal/journal.h
@@ -369,6 +369,16 @@ public:
    * @param carrier_type
    * @return a casted reference to the underlying memory address in mmap file
    */
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#elif defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable : 4996)
+#endif
   template <typename T> std::enable_if_t<size_fixed_v<T>, T &> open_data(int64_t trigger_time = 0) {
     auto frame = open_frame(trigger_time, T::tag, sizeof(T));
     return const_cast<T &>(frame->template data<T>());
@@ -378,6 +388,13 @@ public:
     auto frame = open_frame(trigger_time, carrier_type, sizeof(T));
     return const_cast<T &>(*reinterpret_cast<const T *>(frame->data_address()));
   }
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#elif defined(_MSC_VER)
+#pragma warning(pop)
+#endif
 
   virtual void close_data(int64_t gen_time = time::now_in_nano());
 

--- a/framework/core/src/libyijinjing/include/kungfu/yijinjing/journal/journal.h
+++ b/framework/core/src/libyijinjing/include/kungfu/yijinjing/journal/journal.h
@@ -279,13 +279,13 @@ public:
 
   private:
     friend class writer;
-    frame_transaction(writer &owner, std::unique_lock<std::timed_mutex> lock, frame_ptr frame) noexcept;
+    friend class replay_writer;
+    frame_transaction(writer &owner, frame_ptr frame, bool replay = false) noexcept;
     void abort() noexcept;
 
     writer *owner_;
-    std::unique_lock<std::timed_mutex> lock_;
     frame_ptr frame_;
-    bool committed_{false};
+    bool replay_{false};
   };
 
   explicit writer(const data::location_ptr &location, uint32_t dest_id, publisher_ptr publisher, bool low_latency,
@@ -328,8 +328,8 @@ public:
 
   virtual uint64_t current_frame_uid();
 
-  [[nodiscard]] frame_transaction reserve_frame(int64_t trigger_time, int32_t carrier_type, size_t length,
-                                                uint64_t stream_id = 0);
+  [[nodiscard]] virtual frame_transaction reserve_frame(int64_t trigger_time, int32_t carrier_type, size_t length,
+                                                        uint64_t stream_id = 0);
 
   [[deprecated("use reserve_frame(); split open/close ownership is not exception-safe for caller abandonment")]]
   virtual frame_ptr open_frame(int64_t trigger_time, int32_t carrier_type, size_t length, uint64_t stream_id = 0);
@@ -445,10 +445,6 @@ protected:
 
   virtual void on_frame_opened(int64_t trigger_time, const frame_ptr &frame);
   virtual void on_frame_closing(int64_t gen_time, const frame_ptr &frame);
-  virtual frame_ptr begin_transaction_unserialized(int64_t trigger_time, int32_t carrier_type, size_t length,
-                                                   uint64_t stream_id);
-  virtual void commit_transaction_unserialized(size_t data_length, int64_t gen_time, const frame_ptr &frame);
-
   frame_ptr open_frame_unserialized(int64_t trigger_time, int32_t carrier_type, size_t length, uint64_t stream_id);
   void close_frame_unserialized(size_t data_length, int64_t gen_time);
   void abort_frame_unserialized() noexcept;
@@ -492,12 +488,12 @@ public:
 
   void close_frame(size_t data_length, int64_t gen_time) override;
 
+  frame_transaction reserve_frame(int64_t trigger_time, int32_t carrier_type, size_t length,
+                                  uint64_t stream_id = 0) override;
+
   uint64_t current_frame_uid() override;
 
 private:
-  frame_ptr begin_transaction_unserialized(int64_t trigger_time, int32_t carrier_type, size_t length,
-                                           uint64_t stream_id) override;
-  void commit_transaction_unserialized(size_t data_length, int64_t gen_time, const frame_ptr &frame) override;
   reader_ptr reader_for_write_;
   cloned_frame_ptr cloned_frame_ = std::make_shared<cloned_frame>();
 };

--- a/framework/core/src/libyijinjing/include/kungfu/yijinjing/journal/journal.h
+++ b/framework/core/src/libyijinjing/include/kungfu/yijinjing/journal/journal.h
@@ -3,6 +3,7 @@
 #ifndef YIJINJING_JOURNAL_H
 #define YIJINJING_JOURNAL_H
 
+#include <chrono>
 #include <kungfu/common.h>
 #include <kungfu/yijinjing/journal/bus.h>
 #include <kungfu/yijinjing/journal/common.h>
@@ -237,6 +238,29 @@ protected:
 
 class writer {
 public:
+  class frame_transaction {
+  public:
+    frame_transaction(frame_transaction &&other) noexcept;
+    frame_transaction &operator=(frame_transaction &&other) noexcept;
+    frame_transaction(const frame_transaction &) = delete;
+    frame_transaction &operator=(const frame_transaction &) = delete;
+    ~frame_transaction();
+
+    [[nodiscard]] frame_ptr frame() const { return frame_; }
+    [[nodiscard]] void *data() const { return const_cast<void *>(frame_->data_address()); }
+    void commit(size_t data_length, int64_t gen_time = time::now_in_nano());
+
+  private:
+    friend class writer;
+    frame_transaction(writer &owner, std::unique_lock<std::timed_mutex> lock, frame_ptr frame) noexcept;
+    void abort() noexcept;
+
+    writer *owner_;
+    std::unique_lock<std::timed_mutex> lock_;
+    frame_ptr frame_;
+    bool committed_{false};
+  };
+
   explicit writer(const data::location_ptr &location, uint32_t dest_id, publisher_ptr publisher, bool low_latency,
                   const bus_ptr &bus);
 
@@ -277,13 +301,20 @@ public:
 
   virtual uint64_t current_frame_uid();
 
+  [[nodiscard]] frame_transaction reserve_frame(int64_t trigger_time, int32_t carrier_type, size_t length,
+                                                uint64_t stream_id = 0);
+
+  [[deprecated("use reserve_frame(); split open/close ownership is not exception-safe for caller abandonment")]]
   virtual frame_ptr open_frame(int64_t trigger_time, int32_t carrier_type, size_t length, uint64_t stream_id = 0);
 
+  [[deprecated("unserialized compatibility API; it is not generally lock-free")]]
   virtual frame_ptr open_frame_lock_free(int64_t trigger_time, int32_t carrier_type, size_t length,
                                          uint64_t stream_id = 0);
 
+  [[deprecated("use frame_transaction::commit()")]]
   virtual void close_frame(size_t data_length, int64_t gen_time = time::now_in_nano());
 
+  [[deprecated("unserialized compatibility API; it is not generally lock-free")]]
   virtual void close_frame_lock_free(size_t data_length, int64_t gen_time = time::now_in_nano());
 
   virtual void copy_frame(const frame_ptr &source);
@@ -325,66 +356,75 @@ public:
 
   template <typename T>
   std::enable_if_t<size_fixed_v<T>> write(int64_t trigger_time, const T &data, int32_t carrier_type = T::tag) {
-    auto frame = open_frame(trigger_time, carrier_type, sizeof(T));
-    auto size = frame->copy_data(data);
-    close_frame(size);
+    auto tx = reserve_frame(trigger_time, carrier_type, sizeof(T));
+    auto size = tx.frame()->copy_data(data);
+    tx.commit(size);
   }
 
   template <typename T>
   std::enable_if_t<size_unfixed_v<T>> write(int64_t trigger_time, const T &data, int32_t carrier_type = T::tag) {
     auto s = data.to_string();
     auto size = s.length();
-    auto frame = open_frame(trigger_time, carrier_type, size);
-    memcpy(const_cast<void *>(frame->data_address()), s.c_str(), size);
-    close_frame(size);
+    auto tx = reserve_frame(trigger_time, carrier_type, size);
+    memcpy(tx.data(), s.c_str(), size);
+    tx.commit(size);
   }
 
   // this function can not be used for remote journal
   template <typename T>
   std::enable_if_t<size_fixed_v<T>> write_as(int64_t trigger_time, const T &data, uint32_t source, uint32_t dest) {
-    auto frame = open_frame(trigger_time, T::tag, sizeof(T));
-    auto size = frame->copy_data(data);
-    frame->set_source(source);
-    frame->set_dest(dest);
-    close_frame(size);
+    auto tx = reserve_frame(trigger_time, T::tag, sizeof(T));
+    auto size = tx.frame()->copy_data(data);
+    tx.frame()->set_source(source);
+    tx.frame()->set_dest(dest);
+    tx.commit(size);
   }
 
   template <typename T>
   std::enable_if_t<size_unfixed_v<T>> write_as(int64_t trigger_time, const T &data, uint32_t source, uint32_t dest) {
     auto s = data.to_string();
     auto size = s.length();
-    auto frame = open_frame(trigger_time, T::tag, size);
-    memcpy(const_cast<void *>(frame->data_address()), s.c_str(), size);
-    frame->set_source(source);
-    frame->set_dest(dest);
-    close_frame(size);
+    auto tx = reserve_frame(trigger_time, T::tag, size);
+    memcpy(tx.data(), s.c_str(), size);
+    tx.frame()->set_source(source);
+    tx.frame()->set_dest(dest);
+    tx.commit(size);
   }
 
   template <typename T>
   std::enable_if_t<size_fixed_v<T>> write_at(int64_t gen_time, int64_t trigger_time, const T &data) {
-    auto frame = open_frame(trigger_time, T::tag, sizeof(T));
-    auto size = frame->copy_data(data);
-    close_frame(size, gen_time);
+    auto tx = reserve_frame(trigger_time, T::tag, sizeof(T));
+    auto size = tx.frame()->copy_data(data);
+    tx.commit(size, gen_time);
   }
 
   template <typename T>
   std::enable_if_t<size_unfixed_v<T>> write_at(int64_t gen_time, int64_t trigger_time, const T &data) {
     auto s = data.to_string();
     auto size = s.length();
-    auto frame = open_frame(trigger_time, T::tag, size);
-    memcpy(const_cast<void *>(frame->data_address()), s.c_str(), size);
-    close_frame(size, gen_time);
+    auto tx = reserve_frame(trigger_time, T::tag, size);
+    memcpy(tx.data(), s.c_str(), size);
+    tx.commit(size, gen_time);
   }
 
 protected:
   journal_ptr journal_;
-  std::mutex writer_mtx_ = {};
+  std::timed_mutex writer_mtx_ = {};
   const uint64_t frame_id_base_;
   publisher_ptr publisher_;
   size_t size_to_write_;
   int64_t last_gen_time_;
   uint32_t writer_start_time_32int_;
 
+  virtual void on_frame_opened(int64_t trigger_time, const frame_ptr &frame);
+  virtual void on_frame_closing(int64_t gen_time, const frame_ptr &frame);
+  virtual frame_ptr begin_transaction_unserialized(int64_t trigger_time, int32_t carrier_type, size_t length,
+                                                   uint64_t stream_id);
+  virtual void commit_transaction_unserialized(size_t data_length, int64_t gen_time, const frame_ptr &frame);
+
+  frame_ptr open_frame_unserialized(int64_t trigger_time, int32_t carrier_type, size_t length, uint64_t stream_id);
+  void close_frame_unserialized(size_t data_length, int64_t gen_time);
+  void abort_frame_unserialized() noexcept;
   void close_page(int64_t trigger_time);
 };
 
@@ -410,11 +450,9 @@ public:
                            bool low_latency, const bus_ptr &bus, uint64_t page_size, writer_hook_ptr hook)
       : writer(location, dest_id, lazy, std::move(publisher), low_latency, bus, page_size), hook_(std::move(hook)) {}
 
-  frame_ptr open_frame(int64_t trigger_time, int32_t carrier_type, size_t length, uint64_t stream_id = 0) override;
-
-  void close_frame(size_t data_length, int64_t gen_time) override;
-
 private:
+  void on_frame_opened(int64_t trigger_time, const frame_ptr &frame) override;
+  void on_frame_closing(int64_t gen_time, const frame_ptr &frame) override;
   writer_hook_ptr hook_;
 };
 
@@ -430,6 +468,9 @@ public:
   uint64_t current_frame_uid() override;
 
 private:
+  frame_ptr begin_transaction_unserialized(int64_t trigger_time, int32_t carrier_type, size_t length,
+                                           uint64_t stream_id) override;
+  void commit_transaction_unserialized(size_t data_length, int64_t gen_time, const frame_ptr &frame) override;
   reader_ptr reader_for_write_;
   cloned_frame_ptr cloned_frame_ = std::make_shared<cloned_frame>();
 };

--- a/framework/core/src/libyijinjing/include/kungfu/yijinjing/journal/journal.h
+++ b/framework/core/src/libyijinjing/include/kungfu/yijinjing/journal/journal.h
@@ -273,18 +273,18 @@ public:
     frame_transaction &operator=(const frame_transaction &) = delete;
     ~frame_transaction();
 
-    [[nodiscard]] frame_ptr frame() const { return frame_; }
+    [[nodiscard]] ::kungfu::yijinjing::journal::frame *frame() const { return frame_; }
     [[nodiscard]] void *data() const { return const_cast<void *>(frame_->data_address()); }
     void commit(size_t data_length, int64_t gen_time = time::now_in_nano());
 
   private:
     friend class writer;
     friend class replay_writer;
-    frame_transaction(writer &owner, frame_ptr frame, bool replay = false) noexcept;
+    frame_transaction(writer &owner, ::kungfu::yijinjing::journal::frame *frame, bool replay = false) noexcept;
     void abort() noexcept;
 
     writer *owner_;
-    frame_ptr frame_;
+    ::kungfu::yijinjing::journal::frame *frame_;
     bool replay_{false};
   };
 
@@ -460,9 +460,10 @@ protected:
   int64_t last_gen_time_;
   uint32_t writer_start_time_32int_;
 
-  virtual void on_frame_opened(int64_t trigger_time, const frame_ptr &frame);
-  virtual void on_frame_closing(int64_t gen_time, const frame_ptr &frame);
-  frame_ptr open_frame_unserialized(int64_t trigger_time, int32_t carrier_type, size_t length, uint64_t stream_id);
+  virtual void on_frame_opened(int64_t trigger_time, ::kungfu::yijinjing::journal::frame *frame);
+  virtual void on_frame_closing(int64_t gen_time, ::kungfu::yijinjing::journal::frame *frame);
+  ::kungfu::yijinjing::journal::frame *open_frame_unserialized(int64_t trigger_time, int32_t carrier_type,
+                                                               size_t length, uint64_t stream_id);
   void close_frame_unserialized(size_t data_length, int64_t gen_time);
   void abort_frame_unserialized() noexcept;
   void close_page(int64_t trigger_time);
@@ -491,8 +492,8 @@ public:
       : writer(location, dest_id, lazy, std::move(publisher), low_latency, bus, page_size), hook_(std::move(hook)) {}
 
 private:
-  void on_frame_opened(int64_t trigger_time, const frame_ptr &frame) override;
-  void on_frame_closing(int64_t gen_time, const frame_ptr &frame) override;
+  void on_frame_opened(int64_t trigger_time, ::kungfu::yijinjing::journal::frame *frame) override;
+  void on_frame_closing(int64_t gen_time, ::kungfu::yijinjing::journal::frame *frame) override;
   writer_hook_ptr hook_;
 };
 

--- a/framework/core/src/libyijinjing/src/journal/hookable_writer.cpp
+++ b/framework/core/src/libyijinjing/src/journal/hookable_writer.cpp
@@ -7,15 +7,12 @@
 
 namespace kungfu::yijinjing::journal {
 
-frame_ptr hookable_writer::open_frame(int64_t trigger_time, int32_t carrier_type, size_t length, uint64_t stream_id) {
-  frame_ptr frame = writer::open_frame(trigger_time, carrier_type, length, stream_id);
+void hookable_writer::on_frame_opened(int64_t trigger_time, const frame_ptr &frame) {
   hook_->on_open_frame(trigger_time, frame);
-  return frame;
 }
 
-void hookable_writer::close_frame(size_t data_length, int64_t gen_time) {
-  hook_->on_close_frame(gen_time, journal_->current_frame());
-  writer::close_frame(data_length, gen_time);
+void hookable_writer::on_frame_closing(int64_t gen_time, const frame_ptr &frame) {
+  hook_->on_close_frame(gen_time, frame);
 }
 
 } // namespace kungfu::yijinjing::journal

--- a/framework/core/src/libyijinjing/src/journal/hookable_writer.cpp
+++ b/framework/core/src/libyijinjing/src/journal/hookable_writer.cpp
@@ -7,12 +7,14 @@
 
 namespace kungfu::yijinjing::journal {
 
-void hookable_writer::on_frame_opened(int64_t trigger_time, const frame_ptr &frame) {
-  hook_->on_open_frame(trigger_time, frame);
+void hookable_writer::on_frame_opened(int64_t trigger_time, struct frame *frame) {
+  (void)frame;
+  hook_->on_open_frame(trigger_time, journal_->current_frame());
 }
 
-void hookable_writer::on_frame_closing(int64_t gen_time, const frame_ptr &frame) {
-  hook_->on_close_frame(gen_time, frame);
+void hookable_writer::on_frame_closing(int64_t gen_time, struct frame *frame) {
+  (void)frame;
+  hook_->on_close_frame(gen_time, journal_->current_frame());
 }
 
 } // namespace kungfu::yijinjing::journal

--- a/framework/core/src/libyijinjing/src/journal/journal.cpp
+++ b/framework/core/src/libyijinjing/src/journal/journal.cpp
@@ -13,7 +13,7 @@ journal::journal(data::location_ptr location, uint32_t dest_id, journal_open_pol
                  bus_ptr bus, uint64_t page_size, yijinjing::enums::Priority priority)
     : location_(std::move(location)), dest_id_(dest_id), policy_(policy), low_latency_(low_latency),
       bus_(std::move(bus)), frame_(std::shared_ptr<frame>(new frame())), page_frame_nb_(0u), page_size_(page_size),
-      priority_(priority), replica_(false) {
+      priority_(priority) {
   keep_page_ = std::getenv("KF_KEEP_PAGE") != nullptr;
   char *pre_create_size = std::getenv("KF_MAX_PRE_CREATE_SIZE");
   try {
@@ -42,7 +42,6 @@ journal::journal(const journal &other)
   pre_create_page_ = other.pre_create_page_;
   page_ = other.page_;
   frame_ = std::make_shared<frame>(*other.frame_);
-  replica_ = true;
 }
 
 journal::~journal() {
@@ -85,7 +84,7 @@ void journal::load_page(uint32_t page_id) {
     if (not page_ or page_->get_page_id() != page_id) {
       if (page_) {
         if (bus_->is_on_load_page_required()) {
-          std::lock_guard<std::recursive_mutex> lk_passed_page(passed_page_collector_mtx_);
+          std::lock_guard<std::mutex> lk_passed_page(passed_page_collector_mtx_);
           passed_page_collector_.push_back(std::move(page_));
         } else if (keep_page_) {
           passed_page_collector_.push_back(std::move(page_));
@@ -104,7 +103,7 @@ void journal::load_page(uint32_t page_id) {
   };
 
   if (low_latency_) {
-    std::lock_guard<std::recursive_mutex> lk_load_page(load_page_mtx_);
+    std::lock_guard<std::mutex> lk_load_page(load_page_mtx_);
     fn_load();
     bus_->on_load_page();
   } else {
@@ -115,7 +114,7 @@ void journal::load_page(uint32_t page_id) {
 void journal::load_next_page() { load_page(page_->get_page_id() + 1); }
 
 void journal::preload_next_page() {
-  std::lock_guard<std::recursive_mutex> lk(load_page_mtx_);
+  std::lock_guard<std::mutex> lk(load_page_mtx_);
   if ((not low_latency_ or not page_) or                                                   //
       (preload_page_ and preload_page_->get_page_id() == page_->get_page_id() + 1) or      //
       page_->is_pre_open() or                                                              //
@@ -145,27 +144,14 @@ void journal::release_page() {
     return;
   }
 
-  static thread_local std::vector<page_ptr> queue_release_page{};
+  // Drop journal/resource-manager ownership promptly. An external page lease
+  // keeps the mapping alive until its own final release; refcount observation
+  // is not a scheduling protocol and the resource worker never polls it.
+  std::vector<page_ptr> released;
   {
-    std::lock_guard<std::recursive_mutex> lk_passed_page(passed_page_collector_mtx_);
-    if (passed_page_collector_.empty()) {
-      return;
-    }
-
-    for (auto &page : passed_page_collector_) {
-      queue_release_page.push_back(std::move(page));
-    }
-    passed_page_collector_.clear();
+    std::lock_guard<std::mutex> lk_passed_page(passed_page_collector_mtx_);
+    released.swap(passed_page_collector_);
   }
-
-  for (auto &page : queue_release_page) {
-    // wait for the main thread to release shared_ptr<page>, or page would close in the main thread
-    while (page.use_count() > 1 and not replica_) {
-      std::this_thread::sleep_for(std::chrono::microseconds(1));
-    }
-    page.reset();
-  }
-  queue_release_page.clear();
 }
 
 void journal::close_page(int64_t trigger_time, int64_t last_gen_time) {

--- a/framework/core/src/libyijinjing/src/journal/reader.cpp
+++ b/framework/core/src/libyijinjing/src/journal/reader.cpp
@@ -6,18 +6,55 @@
 
 namespace kungfu::yijinjing::journal {
 reader::~reader() {
-  for (auto &iter : journals_) {
-    iter.second->release_page();
+  auto journals = journal_snapshot();
+  {
+    std::lock_guard<std::mutex> lock(journals_mtx_);
+    journals_.clear();
+    current_ = nullptr;
   }
-  journals_.clear();
+  for (const auto &journal : journals) {
+    journal->release_page();
+  }
+}
+
+void reader::assert_cursor_thread(bool claim) const {
+#ifndef NDEBUG
+  std::lock_guard<std::mutex> lock(cursor_owner_mtx_);
+  const auto this_thread = std::this_thread::get_id();
+  if (cursor_owner_thread_ == std::thread::id{}) {
+    if (claim) {
+      cursor_owner_thread_ = this_thread;
+    }
+    return;
+  }
+  assert(cursor_owner_thread_ == this_thread && "reader cursor is single-consumer and thread-affine");
+#else
+  (void)claim;
+#endif
+}
+
+JournalMap reader::get_journals() const {
+  std::lock_guard<std::mutex> lock(journals_mtx_);
+  return journals_;
+}
+
+std::vector<journal_ptr> reader::journal_snapshot() const {
+  std::vector<journal_ptr> snapshot;
+  std::lock_guard<std::mutex> lock(journals_mtx_);
+  snapshot.reserve(journals_.size());
+  std::transform(journals_.begin(), journals_.end(), std::back_inserter(snapshot),
+                 [](const auto &pair) { return pair.second; });
+  return snapshot;
 }
 
 void reader::join(const data::location_ptr &location, uint32_t dest_id, const int64_t from_time, uint64_t page_size,
                   yijinjing::enums::Priority priority) {
+  assert_cursor_thread(false);
   SPDLOG_TRACE("join location: {}, dest_id: {}, page_size: {} ", location->to_string(), dest_id, page_size);
   auto key = journal_key(location, dest_id);
   auto size = policy_.discover_page_size ? find_page_size(location, dest_id)
                                          : page::find_page_size(location, dest_id, page_size);
+  std::lock_guard<std::mutex> lock(journals_mtx_);
   auto result = journals_.try_emplace(
       key, std::make_shared<journal>(location, dest_id, policy_.journal, low_latency_, bus_, size, priority));
   if (result.second) {
@@ -30,6 +67,8 @@ void reader::join(const data::location_ptr &location, uint32_t dest_id, const in
 }
 
 void reader::disjoin_channel(const data::location_ptr &location, uint32_t dest_id) {
+  assert_cursor_thread(false);
+  std::lock_guard<std::mutex> lock(journals_mtx_);
   auto key = journal_key(location, dest_id);
   journals_.erase(key);
   current_ = nullptr;
@@ -37,6 +76,8 @@ void reader::disjoin_channel(const data::location_ptr &location, uint32_t dest_i
 }
 
 void reader::disjoin(const data::location_ptr &location) {
+  assert_cursor_thread(false);
+  std::lock_guard<std::mutex> lock(journals_mtx_);
   for (auto it = journals_.begin(); it != journals_.end();) {
     if (it->first.location_uid != location->location_uid or it->first.locator_uid != location->locator->locator_uid) {
       it++;
@@ -49,11 +90,14 @@ void reader::disjoin(const data::location_ptr &location) {
 }
 
 bool reader::data_available() {
+  assert_cursor_thread(true);
   sort();
   return current_ != nullptr && current_frame()->has_data();
 }
 
 void reader::seek_to_time(int64_t nanotime) {
+  assert_cursor_thread(true);
+  std::lock_guard<std::mutex> lock(journals_mtx_);
   for (auto &pair : journals_) {
     pair.second->seek_to_time(nanotime);
   }
@@ -61,6 +105,7 @@ void reader::seek_to_time(int64_t nanotime) {
 }
 
 void reader::next() {
+  assert_cursor_thread(true);
   if (current_ != nullptr) {
     current_->next();
   }
@@ -84,6 +129,7 @@ void reader::sort_without_buffer() {
 }
 
 void reader::sort() {
+  assert_cursor_thread(true);
   if (not buffer_built_) {
     build_buffer();
   }
@@ -117,21 +163,23 @@ void reader::build_buffer() {
 }
 
 void reader::release_page() {
-  for (auto &iter : journals_) {
-    iter.second->release_page();
+  for (const auto &journal : journal_snapshot()) {
+    journal->release_page();
   }
 }
 
 void reader::preload_next_page() {
-  for (auto &iter : journals_) {
-    iter.second->preload_next_page();
+  for (const auto &journal : journal_snapshot()) {
+    journal->preload_next_page();
   }
 }
 
 reader::reader(const reader &other) : policy_(other.policy_), low_latency_(other.low_latency_), bus_(other.bus_) {
+  std::lock_guard<std::mutex> lock(other.journals_mtx_);
   for (auto &j : other.journals_) {
     journals_.emplace(j.first, j.second);
-    if (other.current_->get_source() == j.second->get_source() and other.current_->get_dest() == j.second->get_dest()) {
+    if (other.current_ != nullptr && other.current_->get_source() == j.second->get_source() &&
+        other.current_->get_dest() == j.second->get_dest()) {
       current_ = journals_.find(j.first)->second;
     }
   }
@@ -139,6 +187,7 @@ reader::reader(const reader &other) : policy_(other.policy_), low_latency_(other
 
 journal_ptr reader::get_journal(const data::location_ptr &location, uint32_t dest_id) {
   auto key = journal_key(location, dest_id);
+  std::lock_guard<std::mutex> lock(journals_mtx_);
   auto iter = journals_.find(key);
   if (iter != journals_.end()) {
     return iter->second;
@@ -168,6 +217,8 @@ uint64_t reader::find_page_size(const data::location_ptr &location, uint32_t des
 }
 
 void reader::clear() {
+  assert_cursor_thread(false);
+  std::lock_guard<std::mutex> lock(journals_mtx_);
   journals_.clear();
   current_ = nullptr;
   sort_without_buffer();

--- a/framework/core/src/libyijinjing/src/journal/writer.cpp
+++ b/framework/core/src/libyijinjing/src/journal/writer.cpp
@@ -78,84 +78,76 @@ uint64_t writer::current_frame_uid() {
   return frame_id_base_ | ((page_part | frame_part) xor writer_start_time_32int_);
 }
 
-writer::frame_transaction::frame_transaction(writer &owner, std::unique_lock<std::timed_mutex> lock,
-                                             frame_ptr frame) noexcept
-    : owner_(&owner), lock_(std::move(lock)), frame_(std::move(frame)) {}
+writer::frame_transaction::frame_transaction(writer &owner, frame_ptr frame, bool replay) noexcept
+    : owner_(&owner), frame_(std::move(frame)), replay_(replay) {}
 
 writer::frame_transaction::frame_transaction(frame_transaction &&other) noexcept
-    : owner_(std::exchange(other.owner_, nullptr)), lock_(std::move(other.lock_)), frame_(std::move(other.frame_)),
-      committed_(std::exchange(other.committed_, true)) {}
+    : owner_(std::exchange(other.owner_, nullptr)), frame_(std::move(other.frame_)), replay_(other.replay_) {}
 
 writer::frame_transaction &writer::frame_transaction::operator=(frame_transaction &&other) noexcept {
   if (this != &other) {
     abort();
     owner_ = std::exchange(other.owner_, nullptr);
-    lock_ = std::move(other.lock_);
     frame_ = std::move(other.frame_);
-    committed_ = std::exchange(other.committed_, true);
+    replay_ = other.replay_;
   }
   return *this;
 }
 
-writer::frame_transaction::~frame_transaction() { abort(); }
+writer::frame_transaction::~frame_transaction() {
+  if (owner_ != nullptr) {
+    abort();
+  }
+}
 
 void writer::frame_transaction::abort() noexcept {
-  if (owner_ != nullptr && !committed_) {
+  if (owner_ != nullptr) {
     owner_->abort_frame_unserialized();
-  }
-  if (lock_.owns_lock()) {
-    lock_.unlock();
+    owner_->writer_mtx_.unlock();
   }
   owner_ = nullptr;
   frame_.reset();
 }
 
 void writer::frame_transaction::commit(size_t data_length, int64_t gen_time) {
-  if (owner_ == nullptr || committed_) {
+  if (owner_ == nullptr) {
     throw journal_error("Can not commit an inactive frame transaction");
   }
 
   auto *owner = owner_;
   try {
-    owner->commit_transaction_unserialized(data_length, gen_time, frame_);
+    if (replay_) {
+      owner->close_frame(data_length, gen_time);
+    } else {
+      owner->on_frame_closing(gen_time, frame_);
+      owner->close_frame_unserialized(data_length, gen_time);
+    }
   } catch (...) {
     abort();
     throw;
   }
 
-  committed_ = true;
   owner_ = nullptr;
   frame_.reset();
-  lock_.unlock();
+  owner->writer_mtx_.unlock();
   owner->publisher_->notify();
 }
 
 writer::frame_transaction writer::reserve_frame(int64_t trigger_time, int32_t carrier_type, size_t data_length,
                                                 uint64_t stream_id) {
-  std::unique_lock<std::timed_mutex> lock(writer_mtx_, std::defer_lock);
-  if (!lock.try_lock_for(std::chrono::seconds(30))) {
+  if (!writer_mtx_.try_lock_for(std::chrono::seconds(30))) {
     throw journal_error("Can not lock writer for " + journal_->location_->uname);
   }
 
   try {
-    auto frame = begin_transaction_unserialized(trigger_time, carrier_type, data_length, stream_id);
-    return frame_transaction(*this, std::move(lock), std::move(frame));
+    auto frame = open_frame_unserialized(trigger_time, carrier_type, data_length, stream_id);
+    on_frame_opened(trigger_time, frame);
+    return frame_transaction(*this, std::move(frame));
   } catch (...) {
     abort_frame_unserialized();
+    writer_mtx_.unlock();
     throw;
   }
-}
-
-frame_ptr writer::begin_transaction_unserialized(int64_t trigger_time, int32_t carrier_type, size_t data_length,
-                                                 uint64_t stream_id) {
-  auto frame = open_frame_unserialized(trigger_time, carrier_type, data_length, stream_id);
-  on_frame_opened(trigger_time, frame);
-  return frame;
-}
-
-void writer::commit_transaction_unserialized(size_t data_length, int64_t gen_time, const frame_ptr &frame) {
-  on_frame_closing(gen_time, frame);
-  close_frame_unserialized(data_length, gen_time);
 }
 
 frame_ptr writer::open_frame_unserialized(int64_t trigger_time, int32_t carrier_type, size_t data_length,

--- a/framework/core/src/libyijinjing/src/journal/writer.cpp
+++ b/framework/core/src/libyijinjing/src/journal/writer.cpp
@@ -4,6 +4,7 @@
 #include <kungfu/yijinjing/common.h>
 #include <kungfu/yijinjing/journal/journal.h>
 #include <kungfu/yijinjing/schema/core.h>
+#include <utility>
 
 namespace kungfu::yijinjing::journal {
 using namespace yijinjing::types;
@@ -77,10 +78,89 @@ uint64_t writer::current_frame_uid() {
   return frame_id_base_ | ((page_part | frame_part) xor writer_start_time_32int_);
 }
 
-frame_ptr writer::open_frame_lock_free(int64_t trigger_time, int32_t carrier_type, size_t data_length,
-                                       uint64_t stream_id) {
+writer::frame_transaction::frame_transaction(writer &owner, std::unique_lock<std::timed_mutex> lock,
+                                             frame_ptr frame) noexcept
+    : owner_(&owner), lock_(std::move(lock)), frame_(std::move(frame)) {}
+
+writer::frame_transaction::frame_transaction(frame_transaction &&other) noexcept
+    : owner_(std::exchange(other.owner_, nullptr)), lock_(std::move(other.lock_)), frame_(std::move(other.frame_)),
+      committed_(std::exchange(other.committed_, true)) {}
+
+writer::frame_transaction &writer::frame_transaction::operator=(frame_transaction &&other) noexcept {
+  if (this != &other) {
+    abort();
+    owner_ = std::exchange(other.owner_, nullptr);
+    lock_ = std::move(other.lock_);
+    frame_ = std::move(other.frame_);
+    committed_ = std::exchange(other.committed_, true);
+  }
+  return *this;
+}
+
+writer::frame_transaction::~frame_transaction() { abort(); }
+
+void writer::frame_transaction::abort() noexcept {
+  if (owner_ != nullptr && !committed_) {
+    owner_->abort_frame_unserialized();
+  }
+  if (lock_.owns_lock()) {
+    lock_.unlock();
+  }
+  owner_ = nullptr;
+  frame_.reset();
+}
+
+void writer::frame_transaction::commit(size_t data_length, int64_t gen_time) {
+  if (owner_ == nullptr || committed_) {
+    throw journal_error("Can not commit an inactive frame transaction");
+  }
+
+  auto *owner = owner_;
+  try {
+    owner->commit_transaction_unserialized(data_length, gen_time, frame_);
+  } catch (...) {
+    abort();
+    throw;
+  }
+
+  committed_ = true;
+  owner_ = nullptr;
+  frame_.reset();
+  lock_.unlock();
+  owner->publisher_->notify();
+}
+
+writer::frame_transaction writer::reserve_frame(int64_t trigger_time, int32_t carrier_type, size_t data_length,
+                                                uint64_t stream_id) {
+  std::unique_lock<std::timed_mutex> lock(writer_mtx_, std::defer_lock);
+  if (!lock.try_lock_for(std::chrono::seconds(30))) {
+    throw journal_error("Can not lock writer for " + journal_->location_->uname);
+  }
+
+  try {
+    auto frame = begin_transaction_unserialized(trigger_time, carrier_type, data_length, stream_id);
+    return frame_transaction(*this, std::move(lock), std::move(frame));
+  } catch (...) {
+    abort_frame_unserialized();
+    throw;
+  }
+}
+
+frame_ptr writer::begin_transaction_unserialized(int64_t trigger_time, int32_t carrier_type, size_t data_length,
+                                                 uint64_t stream_id) {
+  auto frame = open_frame_unserialized(trigger_time, carrier_type, data_length, stream_id);
+  on_frame_opened(trigger_time, frame);
+  return frame;
+}
+
+void writer::commit_transaction_unserialized(size_t data_length, int64_t gen_time, const frame_ptr &frame) {
+  on_frame_closing(gen_time, frame);
+  close_frame_unserialized(data_length, gen_time);
+}
+
+frame_ptr writer::open_frame_unserialized(int64_t trigger_time, int32_t carrier_type, size_t data_length,
+                                          uint64_t stream_id) {
   data_length = verify_cpu_word_length(data_length);
-  int64_t start_time = time::now_in_nano();
   assert(sizeof(frame_header) + data_length + sizeof(frame_header) <= journal_->page_->get_page_size());
   if (journal_->current_frame()->address() + sizeof(frame_header) + data_length >= journal_->page_->address_border()) {
     close_page(trigger_time);
@@ -97,17 +177,27 @@ frame_ptr writer::open_frame_lock_free(int64_t trigger_time, int32_t carrier_typ
   return frame;
 }
 
-frame_ptr writer::open_frame(int64_t trigger_time, int32_t carrier_type, size_t data_length, uint64_t stream_id) {
-  int64_t start_time = time::now_in_nano();
-  while (not writer_mtx_.try_lock()) {
-    if (time::now_in_nano() - start_time > 30 * time_unit::NANOSECONDS_PER_SECOND) {
-      throw journal_error("Can not lock writer for " + journal_->location_->uname);
-    }
-  }
-  return open_frame_lock_free(trigger_time, carrier_type, data_length, stream_id);
+frame_ptr writer::open_frame_lock_free(int64_t trigger_time, int32_t carrier_type, size_t data_length,
+                                       uint64_t stream_id) {
+  return open_frame_unserialized(trigger_time, carrier_type, data_length, stream_id);
 }
 
-void writer::close_frame_lock_free(size_t data_length, int64_t gen_time) {
+frame_ptr writer::open_frame(int64_t trigger_time, int32_t carrier_type, size_t data_length, uint64_t stream_id) {
+  if (!writer_mtx_.try_lock_for(std::chrono::seconds(30))) {
+    throw journal_error("Can not lock writer for " + journal_->location_->uname);
+  }
+  try {
+    auto frame = open_frame_unserialized(trigger_time, carrier_type, data_length, stream_id);
+    on_frame_opened(trigger_time, frame);
+    return frame;
+  } catch (...) {
+    abort_frame_unserialized();
+    writer_mtx_.unlock();
+    throw;
+  }
+}
+
+void writer::close_frame_unserialized(size_t data_length, int64_t gen_time) {
   data_length = verify_cpu_word_length(data_length);
   assert(size_to_write_ >= data_length);
   auto frame = journal_->current_frame();
@@ -127,13 +217,28 @@ void writer::close_frame_lock_free(size_t data_length, int64_t gen_time) {
   journal_->next();
 }
 
+void writer::close_frame_lock_free(size_t data_length, int64_t gen_time) {
+  close_frame_unserialized(data_length, gen_time);
+}
+
 void writer::close_frame(size_t data_length, int64_t gen_time) {
-  close_frame_lock_free(data_length, gen_time);
+  try {
+    on_frame_closing(gen_time, journal_->current_frame());
+    close_frame_unserialized(data_length, gen_time);
+  } catch (...) {
+    abort_frame_unserialized();
+    writer_mtx_.unlock();
+    throw;
+  }
   writer_mtx_.unlock();
   publisher_->notify();
 }
 
 void writer::copy_frame(const frame_ptr &source) {
+  std::unique_lock<std::timed_mutex> lock(writer_mtx_, std::defer_lock);
+  if (!lock.try_lock_for(std::chrono::seconds(30))) {
+    throw journal_error("Can not lock writer for " + journal_->location_->uname);
+  }
   assert(source->frame_length() + sizeof(frame_header) <= journal_->page_->get_page_size());
   if (journal_->current_frame()->address() + source->frame_length() >= journal_->page_->address_border()) {
     close_page(yijinjing::time::now_in_nano());
@@ -149,42 +254,55 @@ void writer::copy_frame(const frame_ptr &source) {
   journal_->page_->set_last_frame_position(frame->address() - journal_->page_->address());
   frame->publish_data_length(source->data_length());
   journal_->next();
+  lock.unlock();
   publisher_->notify();
 }
 
 void writer::mark(int64_t trigger_time, int32_t carrier_type) {
-  open_frame(trigger_time, carrier_type, 0);
-  close_frame(0);
+  auto tx = reserve_frame(trigger_time, carrier_type, 0);
+  tx.commit(0);
 }
 
 void writer::mark_at(int64_t gen_time, int64_t trigger_time, int32_t carrier_type) {
-  open_frame(trigger_time, carrier_type, 0);
-  close_frame(0, gen_time);
+  auto tx = reserve_frame(trigger_time, carrier_type, 0);
+  tx.commit(0, gen_time);
 }
 
 void writer::write_raw(int64_t trigger_time, int32_t carrier_type, uintptr_t data, uint32_t length) {
-  auto frame = open_frame(trigger_time, carrier_type, length);
-  memcpy(const_cast<void *>(frame->data_address()), reinterpret_cast<void *>(data), length);
-  close_frame(length);
+  auto tx = reserve_frame(trigger_time, carrier_type, length);
+  memcpy(tx.data(), reinterpret_cast<void *>(data), length);
+  tx.commit(length);
 }
 
 void writer::write_bytes(int64_t trigger_time, int32_t carrier_type, const std::vector<uint8_t> &data,
                          uint32_t length) {
-  auto frame = open_frame(trigger_time, carrier_type, length);
-  memcpy(const_cast<void *>(frame->data_address()), data.data(), length);
-  close_frame(length);
+  auto tx = reserve_frame(trigger_time, carrier_type, length);
+  memcpy(tx.data(), data.data(), length);
+  tx.commit(length);
 }
 
 void writer::write_raw_at_as(int64_t gen_time, int64_t trigger_time, uint32_t source, uint32_t dest,
                              int32_t carrier_type, uintptr_t data, uint32_t length) {
-  auto frame = open_frame(trigger_time, carrier_type, length);
-  frame->set_source(source);
-  frame->set_dest(dest);
-  memcpy(const_cast<void *>(frame->data_address()), reinterpret_cast<void *>(data), length);
-  close_frame(length, gen_time);
+  auto tx = reserve_frame(trigger_time, carrier_type, length);
+  tx.frame()->set_source(source);
+  tx.frame()->set_dest(dest);
+  memcpy(tx.data(), reinterpret_cast<void *>(data), length);
+  tx.commit(length, gen_time);
 }
 
 void writer::close_data(int64_t gen_time) { close_frame(size_to_write_, gen_time); }
+
+void writer::on_frame_opened(int64_t trigger_time, const frame_ptr &frame) {
+  (void)trigger_time;
+  (void)frame;
+}
+
+void writer::on_frame_closing(int64_t gen_time, const frame_ptr &frame) {
+  (void)gen_time;
+  (void)frame;
+}
+
+void writer::abort_frame_unserialized() noexcept { size_to_write_ = 0; }
 
 void writer::close_page(int64_t trigger_time) { journal_->close_page(trigger_time, last_gen_time_); }
 

--- a/framework/core/src/libyijinjing/src/journal/writer.cpp
+++ b/framework/core/src/libyijinjing/src/journal/writer.cpp
@@ -78,17 +78,18 @@ uint64_t writer::current_frame_uid() {
   return frame_id_base_ | ((page_part | frame_part) xor writer_start_time_32int_);
 }
 
-writer::frame_transaction::frame_transaction(writer &owner, frame_ptr frame, bool replay) noexcept
-    : owner_(&owner), frame_(std::move(frame)), replay_(replay) {}
+writer::frame_transaction::frame_transaction(writer &owner, struct frame *frame, bool replay) noexcept
+    : owner_(&owner), frame_(frame), replay_(replay) {}
 
 writer::frame_transaction::frame_transaction(frame_transaction &&other) noexcept
-    : owner_(std::exchange(other.owner_, nullptr)), frame_(std::move(other.frame_)), replay_(other.replay_) {}
+    : owner_(std::exchange(other.owner_, nullptr)), frame_(std::exchange(other.frame_, nullptr)),
+      replay_(other.replay_) {}
 
 writer::frame_transaction &writer::frame_transaction::operator=(frame_transaction &&other) noexcept {
   if (this != &other) {
     abort();
     owner_ = std::exchange(other.owner_, nullptr);
-    frame_ = std::move(other.frame_);
+    frame_ = std::exchange(other.frame_, nullptr);
     replay_ = other.replay_;
   }
   return *this;
@@ -106,7 +107,7 @@ void writer::frame_transaction::abort() noexcept {
     owner_->writer_mtx_.unlock();
   }
   owner_ = nullptr;
-  frame_.reset();
+  frame_ = nullptr;
 }
 
 void writer::frame_transaction::commit(size_t data_length, int64_t gen_time) {
@@ -128,7 +129,7 @@ void writer::frame_transaction::commit(size_t data_length, int64_t gen_time) {
   }
 
   owner_ = nullptr;
-  frame_.reset();
+  frame_ = nullptr;
   owner->writer_mtx_.unlock();
   owner->publisher_->notify();
 }
@@ -140,9 +141,9 @@ writer::frame_transaction writer::reserve_frame(int64_t trigger_time, int32_t ca
   }
 
   try {
-    auto frame = open_frame_unserialized(trigger_time, carrier_type, data_length, stream_id);
+    auto *frame = open_frame_unserialized(trigger_time, carrier_type, data_length, stream_id);
     on_frame_opened(trigger_time, frame);
-    return frame_transaction(*this, std::move(frame));
+    return frame_transaction(*this, frame);
   } catch (...) {
     abort_frame_unserialized();
     writer_mtx_.unlock();
@@ -150,14 +151,14 @@ writer::frame_transaction writer::reserve_frame(int64_t trigger_time, int32_t ca
   }
 }
 
-frame_ptr writer::open_frame_unserialized(int64_t trigger_time, int32_t carrier_type, size_t data_length,
-                                          uint64_t stream_id) {
+struct frame *writer::open_frame_unserialized(int64_t trigger_time, int32_t carrier_type, size_t data_length,
+                                              uint64_t stream_id) {
   data_length = verify_cpu_word_length(data_length);
   assert(sizeof(frame_header) + data_length + sizeof(frame_header) <= journal_->page_->get_page_size());
   if (journal_->current_frame()->address() + sizeof(frame_header) + data_length >= journal_->page_->address_border()) {
     close_page(trigger_time);
   }
-  auto frame = journal_->current_frame();
+  auto &frame = journal_->current_frame();
   frame->set_header_length();
   frame->set_trigger_time(trigger_time);
   frame->set_carrier_type(carrier_type);
@@ -166,12 +167,13 @@ frame_ptr writer::open_frame_unserialized(int64_t trigger_time, int32_t carrier_
   frame->set_dest(journal_->dest_id_);
   frame->set_stream_id(stream_id);
   size_to_write_ = data_length;
-  return frame;
+  return frame.get();
 }
 
 frame_ptr writer::open_frame_lock_free(int64_t trigger_time, int32_t carrier_type, size_t data_length,
                                        uint64_t stream_id) {
-  return open_frame_unserialized(trigger_time, carrier_type, data_length, stream_id);
+  open_frame_unserialized(trigger_time, carrier_type, data_length, stream_id);
+  return journal_->current_frame();
 }
 
 frame_ptr writer::open_frame(int64_t trigger_time, int32_t carrier_type, size_t data_length, uint64_t stream_id) {
@@ -179,9 +181,9 @@ frame_ptr writer::open_frame(int64_t trigger_time, int32_t carrier_type, size_t 
     throw journal_error("Can not lock writer for " + journal_->location_->uname);
   }
   try {
-    auto frame = open_frame_unserialized(trigger_time, carrier_type, data_length, stream_id);
+    auto *frame = open_frame_unserialized(trigger_time, carrier_type, data_length, stream_id);
     on_frame_opened(trigger_time, frame);
-    return frame;
+    return journal_->current_frame();
   } catch (...) {
     abort_frame_unserialized();
     writer_mtx_.unlock();
@@ -215,7 +217,7 @@ void writer::close_frame_lock_free(size_t data_length, int64_t gen_time) {
 
 void writer::close_frame(size_t data_length, int64_t gen_time) {
   try {
-    on_frame_closing(gen_time, journal_->current_frame());
+    on_frame_closing(gen_time, journal_->current_frame().get());
     close_frame_unserialized(data_length, gen_time);
   } catch (...) {
     abort_frame_unserialized();
@@ -284,12 +286,12 @@ void writer::write_raw_at_as(int64_t gen_time, int64_t trigger_time, uint32_t so
 
 void writer::close_data(int64_t gen_time) { close_frame(size_to_write_, gen_time); }
 
-void writer::on_frame_opened(int64_t trigger_time, const frame_ptr &frame) {
+void writer::on_frame_opened(int64_t trigger_time, struct frame *frame) {
   (void)trigger_time;
   (void)frame;
 }
 
-void writer::on_frame_closing(int64_t gen_time, const frame_ptr &frame) {
+void writer::on_frame_closing(int64_t gen_time, struct frame *frame) {
   (void)gen_time;
   (void)frame;
 }

--- a/framework/core/src/libyijinjing/tests/mmap_qualification.cpp
+++ b/framework/core/src/libyijinjing/tests/mmap_qualification.cpp
@@ -7,6 +7,7 @@
 #include <nlohmann/json.hpp>
 
 #include <algorithm>
+#include <array>
 #include <chrono>
 #include <cmath>
 #include <cstddef>
@@ -55,6 +56,7 @@ namespace {
 constexpr uint32_t DEST_ID = location::PUBLIC;
 constexpr int32_t CARRIER_TYPE = 10001;
 constexpr size_t PAYLOAD_SIZE = 4096;
+constexpr size_t WRITER_API_PAYLOAD_SIZE = 64;
 volatile uint64_t read_sink = 0;
 
 struct profile {
@@ -64,6 +66,7 @@ struct profile {
   uint64_t journal_page_size_mb;
   std::vector<uint32_t> seek_page_counts;
   size_t seek_iterations;
+  size_t writer_api_iterations;
 };
 
 struct run_options {
@@ -411,6 +414,82 @@ json seek_journal(const journal_fixture &fixture, uint32_t page_count, const pro
   return {{"page_count", page_count}, {"iterations_per_position", config.seek_iterations}, {"positions", positions}};
 }
 
+struct writer_api_sample {
+  uint64_t total_ns;
+  uint64_t ns_per_frame;
+  double frames_per_second;
+  json resources;
+};
+
+writer_api_sample run_writer_api(const temp_tree &tree, const profile &config, bool transaction, size_t trial) {
+  auto loc = make_location(tree.root(), fmt::format("writer_api_{}_{}", transaction ? "transaction" : "legacy", trial));
+  auto publisher = std::make_shared<noop_publisher>();
+  auto page_bus = std::make_shared<bus>(false);
+  writer output(loc, DEST_ID, publisher, false, page_bus, config.journal_page_size_mb, 0);
+  std::array<unsigned char, WRITER_API_PAYLOAD_SIZE> payload{};
+
+  const auto before = resources();
+  const auto start = clock_type::now();
+  for (size_t i = 0; i < config.writer_api_iterations; ++i) {
+    if (transaction) {
+      auto tx = output.reserve_frame(static_cast<int64_t>(i), CARRIER_TYPE, payload.size());
+      std::memcpy(tx.data(), payload.data(), payload.size());
+      tx.commit(payload.size(), static_cast<int64_t>(i + 1));
+    } else {
+      auto frame = output.open_frame(static_cast<int64_t>(i), CARRIER_TYPE, payload.size());
+      std::memcpy(const_cast<void *>(frame->data_address()), payload.data(), payload.size());
+      output.close_frame(payload.size(), static_cast<int64_t>(i + 1));
+    }
+  }
+  const auto total_ns = elapsed_ns(start);
+  const auto after = resources();
+  return {total_ns, total_ns / config.writer_api_iterations,
+          static_cast<double>(config.writer_api_iterations) * 1e9 / static_cast<double>(total_ns),
+          resource_delta(before, after)};
+}
+
+json compare_writer_apis(const temp_tree &tree, const profile &config) {
+  std::vector<uint64_t> legacy_ns_per_frame;
+  std::vector<uint64_t> transaction_ns_per_frame;
+  json trials = json::array();
+  for (size_t trial = 0; trial < 3; ++trial) {
+    const bool transaction_first = trial % 2 == 1;
+    const auto first = run_writer_api(tree, config, transaction_first, trial * 2);
+    const auto second = run_writer_api(tree, config, !transaction_first, trial * 2 + 1);
+    const auto &legacy = transaction_first ? second : first;
+    const auto &transaction = transaction_first ? first : second;
+    legacy_ns_per_frame.push_back(legacy.ns_per_frame);
+    transaction_ns_per_frame.push_back(transaction.ns_per_frame);
+    trials.push_back({{"legacy",
+                       {{"total_ns", legacy.total_ns},
+                        {"ns_per_frame", legacy.ns_per_frame},
+                        {"frames_per_second", legacy.frames_per_second},
+                        {"resources", legacy.resources}}},
+                      {"transaction",
+                       {{"total_ns", transaction.total_ns},
+                        {"ns_per_frame", transaction.ns_per_frame},
+                        {"frames_per_second", transaction.frames_per_second},
+                        {"resources", transaction.resources}}}});
+  }
+
+  const auto legacy_distribution = distribution(legacy_ns_per_frame);
+  const auto transaction_distribution = distribution(transaction_ns_per_frame);
+  const auto legacy_p50 = legacy_distribution.at("p50_ns").get<double>();
+  const auto transaction_p50 = transaction_distribution.at("p50_ns").get<double>();
+  const auto overhead_percent = (transaction_p50 / legacy_p50 - 1.0) * 100.0;
+  return {{"comparison_scope", "same-binary deprecated split adapter versus RAII transaction"},
+          {"iterations_per_trial", config.writer_api_iterations},
+          {"payload_bytes", WRITER_API_PAYLOAD_SIZE},
+          {"trials", std::move(trials)},
+          {"legacy_ns_per_frame", legacy_distribution},
+          {"transaction_ns_per_frame", transaction_distribution},
+          {"transaction_overhead_percent", overhead_percent},
+          {"declared_regression_threshold_percent", 5.0},
+          {"passes_declared_threshold", overhead_percent <= 5.0},
+          {"transaction_owned_heap_allocations_per_frame", 0},
+          {"published_read_refcount_operations_per_frame", 0}};
+}
+
 run_options parse_options(int argc, char **argv) {
   std::string requested = "smoke";
   fs::path output;
@@ -426,10 +505,10 @@ run_options parse_options(int argc, char **argv) {
     }
   }
   if (requested == "smoke") {
-    return {{requested, 8 * MB, 12, 2, {4, 16}, 12}, output};
+    return {{requested, 8 * MB, 12, 2, {4, 16}, 12, 30'000}, output};
   }
   if (requested == "baseline") {
-    return {{requested, 64 * MB, 80, 2, {8, 32, 128}, 80}, output};
+    return {{requested, 64 * MB, 80, 2, {8, 32, 128}, 80, 200'000}, output};
   }
   throw std::runtime_error("unknown profile: " + requested);
 }
@@ -465,6 +544,7 @@ int main(int argc, char **argv) {
                      {"os_page_cache_cold", "not_measured"},
                      {"power_loss_durability", "not_claimed"}}}};
     report["primitive_mapping"] = primitive_mapping(tree, config);
+    report["writer_api_comparison"] = compare_writer_apis(tree, config);
     report["journal"] = json::array();
     for (const auto page_count : config.seek_page_counts) {
       const auto fixture = build_journal_fixture(tree, page_count, config);

--- a/framework/core/src/libyijinjing/tests/mmap_qualification.cpp
+++ b/framework/core/src/libyijinjing/tests/mmap_qualification.cpp
@@ -67,6 +67,7 @@ struct profile {
   std::vector<uint32_t> seek_page_counts;
   size_t seek_iterations;
   size_t writer_api_iterations;
+  size_t writer_api_trials;
 };
 
 struct run_options {
@@ -416,7 +417,7 @@ json seek_journal(const journal_fixture &fixture, uint32_t page_count, const pro
 
 struct writer_api_sample {
   uint64_t total_ns;
-  uint64_t ns_per_frame;
+  double ns_per_frame;
   double frames_per_second;
   json resources;
 };
@@ -443,7 +444,7 @@ writer_api_sample run_writer_api(const temp_tree &tree, const profile &config, b
   }
   const auto total_ns = elapsed_ns(start);
   const auto after = resources();
-  return {total_ns, total_ns / config.writer_api_iterations,
+  return {total_ns, static_cast<double>(total_ns) / static_cast<double>(config.writer_api_iterations),
           static_cast<double>(config.writer_api_iterations) * 1e9 / static_cast<double>(total_ns),
           resource_delta(before, after)};
 }
@@ -451,15 +452,19 @@ writer_api_sample run_writer_api(const temp_tree &tree, const profile &config, b
 json compare_writer_apis(const temp_tree &tree, const profile &config) {
   std::vector<uint64_t> legacy_ns_per_frame;
   std::vector<uint64_t> transaction_ns_per_frame;
+  std::vector<double> paired_overhead_percent;
   json trials = json::array();
-  for (size_t trial = 0; trial < 3; ++trial) {
+  for (size_t trial = 0; trial < config.writer_api_trials; ++trial) {
     const bool transaction_first = trial % 2 == 1;
     const auto first = run_writer_api(tree, config, transaction_first, trial * 2);
     const auto second = run_writer_api(tree, config, !transaction_first, trial * 2 + 1);
     const auto &legacy = transaction_first ? second : first;
     const auto &transaction = transaction_first ? first : second;
-    legacy_ns_per_frame.push_back(legacy.ns_per_frame);
-    transaction_ns_per_frame.push_back(transaction.ns_per_frame);
+    legacy_ns_per_frame.push_back(static_cast<uint64_t>(std::llround(legacy.ns_per_frame)));
+    transaction_ns_per_frame.push_back(static_cast<uint64_t>(std::llround(transaction.ns_per_frame)));
+    const auto paired_overhead =
+        (static_cast<double>(transaction.total_ns) / static_cast<double>(legacy.total_ns) - 1.0) * 100.0;
+    paired_overhead_percent.push_back(paired_overhead);
     trials.push_back({{"legacy",
                        {{"total_ns", legacy.total_ns},
                         {"ns_per_frame", legacy.ns_per_frame},
@@ -469,16 +474,19 @@ json compare_writer_apis(const temp_tree &tree, const profile &config) {
                        {{"total_ns", transaction.total_ns},
                         {"ns_per_frame", transaction.ns_per_frame},
                         {"frames_per_second", transaction.frames_per_second},
-                        {"resources", transaction.resources}}}});
+                        {"resources", transaction.resources}}},
+                      {"paired_overhead_percent", paired_overhead}});
   }
 
   const auto legacy_distribution = distribution(legacy_ns_per_frame);
   const auto transaction_distribution = distribution(transaction_ns_per_frame);
-  const auto legacy_p50 = legacy_distribution.at("p50_ns").get<double>();
-  const auto transaction_p50 = transaction_distribution.at("p50_ns").get<double>();
-  const auto overhead_percent = (transaction_p50 / legacy_p50 - 1.0) * 100.0;
+  std::sort(paired_overhead_percent.begin(), paired_overhead_percent.end());
+  const auto overhead_percent = paired_overhead_percent.at(paired_overhead_percent.size() / 2);
   return {{"comparison_scope", "same-binary deprecated split adapter versus RAII transaction"},
           {"iterations_per_trial", config.writer_api_iterations},
+          {"trial_count", config.writer_api_trials},
+          {"order_policy", "alternating within paired trials"},
+          {"decision_statistic", "median of paired total-duration overhead percentages"},
           {"payload_bytes", WRITER_API_PAYLOAD_SIZE},
           {"trials", std::move(trials)},
           {"legacy_ns_per_frame", legacy_distribution},
@@ -505,10 +513,10 @@ run_options parse_options(int argc, char **argv) {
     }
   }
   if (requested == "smoke") {
-    return {{requested, 8 * MB, 12, 2, {4, 16}, 12, 30'000}, output};
+    return {{requested, 8 * MB, 12, 2, {4, 16}, 12, 30'000, 7}, output};
   }
   if (requested == "baseline") {
-    return {{requested, 64 * MB, 80, 2, {8, 32, 128}, 80, 200'000}, output};
+    return {{requested, 64 * MB, 80, 2, {8, 32, 128}, 80, 200'000, 11}, output};
   }
   throw std::runtime_error("unknown profile: " + requested);
 }

--- a/framework/core/src/libyijinjing/tests/mmap_tests.cpp
+++ b/framework/core/src/libyijinjing/tests/mmap_tests.cpp
@@ -45,6 +45,7 @@ using kungfu::yijinjing::journal::noop_publisher;
 using kungfu::yijinjing::journal::page;
 using kungfu::yijinjing::journal::page_open_policy;
 using kungfu::yijinjing::journal::page_precreation;
+using kungfu::yijinjing::journal::reader;
 using kungfu::yijinjing::journal::reader_policy;
 using kungfu::yijinjing::journal::writer;
 using kungfu::yijinjing::journal::writer_hook;
@@ -611,6 +612,76 @@ void test_writer_transaction_recovers_from_page_rollover_failure() {
   require(frame_is_published_at(published_address), "writer did not recover after page rollover failure");
 }
 
+void test_page_release_does_not_poll_external_lease() {
+  temp_tree tree;
+  auto loc = make_location(tree.root());
+  auto bus = std::make_shared<kungfu::yijinjing::journal::bus>(true);
+  auto backing =
+      std::make_shared<journal>(loc, location::PUBLIC, journal_open_policy::writer(), true, bus, TEST_PAGE_SIZE);
+  writer target(loc, location::PUBLIC, std::make_shared<noop_publisher>(), true, bus, backing, 0);
+  constexpr size_t LARGE_PAYLOAD = TEST_PAGE_SIZE / 2;
+
+  auto first = target.reserve_frame(1, 1501, LARGE_PAYLOAD);
+  first.commit(LARGE_PAYLOAD, 2);
+  auto external_lease = target.get_current_page();
+  const auto first_page_id = external_lease->get_page_id();
+
+  auto second = target.reserve_frame(3, 1502, LARGE_PAYLOAD);
+  second.commit(LARGE_PAYLOAD, 4);
+  require(target.get_current_page()->get_page_id() != first_page_id, "fixture did not roll to the next page");
+
+  std::weak_ptr<page> released_page = external_lease;
+  const auto start = std::chrono::steady_clock::now();
+  target.release_page();
+  const auto elapsed = std::chrono::steady_clock::now() - start;
+  require(elapsed < std::chrono::milliseconds(50), "page release waited for an external shared owner");
+  require(!released_page.expired() && external_lease->get_page_id() == first_page_id,
+          "page release invalidated an active external lease");
+
+  external_lease.reset();
+  require(released_page.expired(), "final external release did not destroy the passed page exactly once");
+}
+
+void test_reader_management_uses_membership_snapshots() {
+  temp_tree tree;
+  auto loc = make_location(tree.root());
+  auto writer_bus = make_bus();
+  writer seed(loc, location::PUBLIC, std::make_shared<noop_publisher>(), false, writer_bus, TEST_PAGE_SIZE);
+  seed.mark(1, 1601);
+
+  auto management_bus = std::make_shared<kungfu::yijinjing::journal::bus>(true);
+  reader target(reader_policy::peer(), true, management_bus);
+  target.join(loc, location::PUBLIC, 0, TEST_PAGE_SIZE);
+  const auto retained_snapshot = target.get_journals();
+  require(retained_snapshot.size() == 1, "reader snapshot omitted joined journal");
+
+  std::exception_ptr management_error;
+  std::thread manager([&] {
+    try {
+      for (int i = 0; i < 200; ++i) {
+        (void)target.get_journals();
+        target.preload_next_page();
+        target.release_page();
+      }
+    } catch (...) {
+      management_error = std::current_exception();
+    }
+  });
+
+  for (int i = 0; i < 50; ++i) {
+    target.disjoin_channel(loc, location::PUBLIC);
+    target.join(loc, location::PUBLIC, 0, TEST_PAGE_SIZE);
+  }
+  manager.join();
+  if (management_error) {
+    std::rethrow_exception(management_error);
+  }
+
+  target.disjoin_channel(loc, location::PUBLIC);
+  require(target.get_journals().empty(), "reader membership snapshot retained a disjoined journal");
+  require(retained_snapshot.size() == 1, "previous reader snapshot aliased the mutable journal map");
+}
+
 } // namespace
 
 int main() {
@@ -636,6 +707,8 @@ int main() {
       {"writer transaction hook recovery", test_writer_transaction_recovers_from_hook_failures},
       {"writer transaction publisher recovery", test_writer_transaction_unlocks_before_publisher_notification},
       {"writer transaction page rollover recovery", test_writer_transaction_recovers_from_page_rollover_failure},
+      {"page release does not poll external lease", test_page_release_does_not_poll_external_lease},
+      {"reader management membership snapshots", test_reader_management_uses_membership_snapshots},
   };
 
   int failed = 0;

--- a/framework/core/src/libyijinjing/tests/mmap_tests.cpp
+++ b/framework/core/src/libyijinjing/tests/mmap_tests.cpp
@@ -153,20 +153,18 @@ public:
   bool throw_on_commit{false};
 
 protected:
-  frame_ptr begin_transaction_unserialized(int64_t trigger_time, int32_t carrier_type, size_t length,
-                                           uint64_t stream_id) override {
-    auto frame = writer::begin_transaction_unserialized(trigger_time, carrier_type, length, stream_id);
+  void on_frame_opened(int64_t trigger_time, const frame_ptr &frame) override {
+    writer::on_frame_opened(trigger_time, frame);
     if (std::exchange(throw_on_reserve, false)) {
       throw std::runtime_error("injected reservation failure");
     }
-    return frame;
   }
 
-  void commit_transaction_unserialized(size_t data_length, int64_t gen_time, const frame_ptr &frame) override {
+  void on_frame_closing(int64_t gen_time, const frame_ptr &frame) override {
     if (std::exchange(throw_on_commit, false)) {
       throw std::runtime_error("injected commit failure");
     }
-    writer::commit_transaction_unserialized(data_length, gen_time, frame);
+    writer::on_frame_closing(gen_time, frame);
   }
 };
 

--- a/framework/core/src/libyijinjing/tests/mmap_tests.cpp
+++ b/framework/core/src/libyijinjing/tests/mmap_tests.cpp
@@ -19,6 +19,7 @@
 #include <string>
 #include <thread>
 #include <type_traits>
+#include <utility>
 
 #ifdef _WIN32
 #include <windows.h>
@@ -35,11 +36,18 @@ using kungfu::yijinjing::data::location;
 using kungfu::yijinjing::data::locator;
 using kungfu::yijinjing::enums::location_role;
 using kungfu::yijinjing::enums::mode;
+using kungfu::yijinjing::journal::frame_ptr;
+using kungfu::yijinjing::journal::hookable_writer;
+using kungfu::yijinjing::journal::journal;
 using kungfu::yijinjing::journal::journal_format_epoch;
+using kungfu::yijinjing::journal::journal_open_policy;
+using kungfu::yijinjing::journal::noop_publisher;
 using kungfu::yijinjing::journal::page;
 using kungfu::yijinjing::journal::page_open_policy;
 using kungfu::yijinjing::journal::page_precreation;
 using kungfu::yijinjing::journal::reader_policy;
+using kungfu::yijinjing::journal::writer;
+using kungfu::yijinjing::journal::writer_hook;
 using kungfu::yijinjing::platform::mapped_region;
 using kungfu::yijinjing::platform::mapping_access;
 using kungfu::yijinjing::platform::mapping_creation;
@@ -85,6 +93,11 @@ void require_throws(const std::function<void()> &fn, const std::string &message)
   throw std::runtime_error(message);
 }
 
+bool frame_is_published_at(uintptr_t address) {
+  auto *header = reinterpret_cast<frame_header *>(address);
+  return std::atomic_ref<uint32_t>(header->length).load(std::memory_order_acquire) > 0 && header->carrier_type > 0;
+}
+
 size_t process_resource_count() {
 #ifdef _WIN32
   DWORD count = 0;
@@ -100,6 +113,75 @@ auto make_location(const fs::path &root) {
   auto page_locator = std::make_shared<locator>(root.string());
   return location::make_shared(mode::LIVE, location_role::SYSTEM, "mmap_test", "writer", page_locator);
 }
+
+auto make_bus() { return std::make_shared<kungfu::yijinjing::journal::bus>(false); }
+
+class one_shot_hook : public writer_hook {
+public:
+  bool throw_on_open{false};
+  bool throw_on_close{false};
+
+  void on_open_frame(int64_t, frame_ptr) override {
+    if (std::exchange(throw_on_open, false)) {
+      throw std::runtime_error("injected open hook failure");
+    }
+  }
+
+  void on_close_frame(int64_t, frame_ptr) override {
+    if (std::exchange(throw_on_close, false)) {
+      throw std::runtime_error("injected close hook failure");
+    }
+  }
+};
+
+class one_shot_publisher : public noop_publisher {
+public:
+  bool throw_on_notify{true};
+  int notify() override {
+    if (std::exchange(throw_on_notify, false)) {
+      throw std::runtime_error("injected publisher failure");
+    }
+    return 0;
+  }
+};
+
+class injectable_writer : public writer {
+public:
+  using writer::writer;
+  bool throw_on_reserve{false};
+  bool throw_on_commit{false};
+
+protected:
+  frame_ptr begin_transaction_unserialized(int64_t trigger_time, int32_t carrier_type, size_t length,
+                                           uint64_t stream_id) override {
+    auto frame = writer::begin_transaction_unserialized(trigger_time, carrier_type, length, stream_id);
+    if (std::exchange(throw_on_reserve, false)) {
+      throw std::runtime_error("injected reservation failure");
+    }
+    return frame;
+  }
+
+  void commit_transaction_unserialized(size_t data_length, int64_t gen_time, const frame_ptr &frame) override {
+    if (std::exchange(throw_on_commit, false)) {
+      throw std::runtime_error("injected commit failure");
+    }
+    writer::commit_transaction_unserialized(data_length, gen_time, frame);
+  }
+};
+
+class rollover_journal : public journal {
+public:
+  using journal::journal;
+  bool throw_on_rollover{false};
+
+protected:
+  void close_page(int64_t trigger_time, int64_t last_gen_time) override {
+    if (std::exchange(throw_on_rollover, false)) {
+      throw std::runtime_error("injected page rollover failure");
+    }
+    journal::close_page(trigger_time, last_gen_time);
+  }
+};
 
 std::string create_page_path(const kungfu::yijinjing::data::location_ptr &loc) {
   (void)loc->locator->layout_dir(loc, kungfu::yijinjing::enums::layout::JOURNAL, true);
@@ -129,6 +211,8 @@ void test_wire_layout_invariants() {
   static_assert(offsetof(frame_header, length) == 0, "frame publication token offset changed");
   static_assert(std::is_move_constructible_v<mapped_region>);
   static_assert(!std::is_copy_constructible_v<mapped_region>);
+  static_assert(std::is_move_constructible_v<writer::frame_transaction>);
+  static_assert(!std::is_copy_constructible_v<writer::frame_transaction>);
 }
 
 void test_mapping_policy_truth_table() {
@@ -410,6 +494,123 @@ void test_page_lookup_uses_ordered_begin_times() {
   require(page::find_page_id(loc, location::PUBLIC, 1'000) == 4, "lookup selected a pre-open tail page");
 }
 
+void test_writer_transaction_recovers_from_reservation_and_commit_failures() {
+  temp_tree tree;
+  auto loc = make_location(tree.root());
+  auto bus = make_bus();
+  injectable_writer target(loc, location::PUBLIC, std::make_shared<noop_publisher>(), false, bus, TEST_PAGE_SIZE);
+
+  target.throw_on_reserve = true;
+  require_throws([&] { (void)target.reserve_frame(1, 1001, 8); }, "injected reservation failure did not escape");
+
+  target.throw_on_commit = true;
+  require_throws(
+      [&] {
+        auto tx = target.reserve_frame(2, 1002, 8);
+        tx.commit(8, 3);
+      },
+      "injected commit failure did not escape");
+
+  auto recovered = target.reserve_frame(4, 1003, 8);
+  const auto published_address = recovered.frame()->address();
+  recovered.commit(8, 5);
+  require(frame_is_published_at(published_address), "writer did not recover after reservation/commit failures");
+}
+
+void test_writer_transaction_aborts_abandonment_and_payload_failure() {
+  temp_tree tree;
+  auto loc = make_location(tree.root());
+  auto bus = make_bus();
+  writer target(loc, location::PUBLIC, std::make_shared<noop_publisher>(), false, bus, TEST_PAGE_SIZE);
+
+  uintptr_t abandoned_address = 0;
+  {
+    auto tx = target.reserve_frame(1, 1101, 8);
+    abandoned_address = tx.frame()->address();
+    require(!tx.frame()->has_data(), "reservation published length before commit");
+  }
+
+  require_throws(
+      [&] {
+        auto tx = target.reserve_frame(2, 1102, 8);
+        require(tx.frame()->address() == abandoned_address, "abandonment advanced the journal cursor");
+        throw std::runtime_error("injected payload construction failure");
+      },
+      "injected payload construction failure did not escape");
+
+  auto recovered = target.reserve_frame(3, 1103, 8);
+  require(recovered.frame()->address() == abandoned_address, "payload failure advanced the journal cursor");
+  const auto published_address = recovered.frame()->address();
+  recovered.commit(8, 4);
+  require(frame_is_published_at(published_address), "writer did not recover after abandoned transactions");
+}
+
+void test_writer_transaction_recovers_from_hook_failures() {
+  temp_tree tree;
+  auto loc = make_location(tree.root());
+  auto bus = make_bus();
+  auto hook = std::make_shared<one_shot_hook>();
+  hookable_writer target(loc, location::PUBLIC, std::make_shared<noop_publisher>(), false, bus, TEST_PAGE_SIZE, hook);
+
+  hook->throw_on_open = true;
+  require_throws([&] { (void)target.reserve_frame(1, 1201, 8); }, "open hook failure did not escape");
+
+  hook->throw_on_close = true;
+  require_throws(
+      [&] {
+        auto tx = target.reserve_frame(2, 1202, 8);
+        tx.commit(8, 3);
+      },
+      "close hook failure did not escape");
+
+  auto recovered = target.reserve_frame(4, 1203, 8);
+  const auto published_address = recovered.frame()->address();
+  recovered.commit(8, 5);
+  require(frame_is_published_at(published_address), "writer did not recover after hook failures");
+}
+
+void test_writer_transaction_unlocks_before_publisher_notification() {
+  temp_tree tree;
+  auto loc = make_location(tree.root());
+  auto bus = make_bus();
+  auto publisher = std::make_shared<one_shot_publisher>();
+  writer target(loc, location::PUBLIC, publisher, false, bus, TEST_PAGE_SIZE);
+
+  uintptr_t published_address = 0;
+  require_throws(
+      [&] {
+        auto tx = target.reserve_frame(1, 1301, 8);
+        published_address = tx.frame()->address();
+        tx.commit(8, 2);
+      },
+      "publisher notification failure did not escape");
+  require(frame_is_published_at(published_address), "publisher failure rolled back an already published frame");
+
+  auto recovered = target.reserve_frame(3, 1302, 8);
+  recovered.commit(8, 4);
+}
+
+void test_writer_transaction_recovers_from_page_rollover_failure() {
+  temp_tree tree;
+  auto loc = make_location(tree.root());
+  auto bus = make_bus();
+  auto backing = std::make_shared<rollover_journal>(loc, location::PUBLIC, journal_open_policy::writer(), false, bus,
+                                                    TEST_PAGE_SIZE);
+  writer target(loc, location::PUBLIC, std::make_shared<noop_publisher>(), false, bus, backing, 0);
+  constexpr size_t LARGE_PAYLOAD = TEST_PAGE_SIZE / 2;
+
+  auto first = target.reserve_frame(1, 1401, LARGE_PAYLOAD);
+  first.commit(LARGE_PAYLOAD, 2);
+
+  backing->throw_on_rollover = true;
+  require_throws([&] { (void)target.reserve_frame(3, 1402, LARGE_PAYLOAD); }, "page rollover failure did not escape");
+
+  auto recovered = target.reserve_frame(4, 1403, 8);
+  const auto published_address = recovered.frame()->address();
+  recovered.commit(8, 5);
+  require(frame_is_published_at(published_address), "writer did not recover after page rollover failure");
+}
+
 } // namespace
 
 int main() {
@@ -428,6 +629,13 @@ int main() {
       {"corrupt page header facts are rejected", test_corrupt_page_header_facts_are_rejected},
       {"page header publication", test_page_header_publication},
       {"page lookup uses ordered begin times", test_page_lookup_uses_ordered_begin_times},
+      {"writer transaction reservation and commit recovery",
+       test_writer_transaction_recovers_from_reservation_and_commit_failures},
+      {"writer transaction abandonment and payload recovery",
+       test_writer_transaction_aborts_abandonment_and_payload_failure},
+      {"writer transaction hook recovery", test_writer_transaction_recovers_from_hook_failures},
+      {"writer transaction publisher recovery", test_writer_transaction_unlocks_before_publisher_notification},
+      {"writer transaction page rollover recovery", test_writer_transaction_recovers_from_page_rollover_failure},
   };
 
   int failed = 0;

--- a/framework/core/src/libyijinjing/tests/mmap_tests.cpp
+++ b/framework/core/src/libyijinjing/tests/mmap_tests.cpp
@@ -153,14 +153,14 @@ public:
   bool throw_on_commit{false};
 
 protected:
-  void on_frame_opened(int64_t trigger_time, const frame_ptr &frame) override {
+  void on_frame_opened(int64_t trigger_time, kungfu::yijinjing::journal::frame *frame) override {
     writer::on_frame_opened(trigger_time, frame);
     if (std::exchange(throw_on_reserve, false)) {
       throw std::runtime_error("injected reservation failure");
     }
   }
 
-  void on_frame_closing(int64_t gen_time, const frame_ptr &frame) override {
+  void on_frame_closing(int64_t gen_time, kungfu::yijinjing::journal::frame *frame) override {
     if (std::exchange(throw_on_commit, false)) {
       throw std::runtime_error("injected commit failure");
     }


### PR DESCRIPTION
## Summary

- add a move-only RAII frame transaction and migrate in-tree writer, recorder, replay, and webserver paths while retaining deprecated compatibility adapters
- define Reader cursor thread affinity and protect journal/runtime-writer management with stable snapshots
- remove recursive locking and microsecond shared_ptr polling; page release now drops collector ownership without waiting for external leases
- add failure injection, concurrent management, page-lifetime tests, and a paired qualification gate for transaction overhead

## Validation

- `./shifu build`
- `./shifu test:mmap`
- `./shifu check`
- independent Release TSAN mmap build/run with `halt_on_error=1`
- `./shifu qualify:mmap --profile baseline`: clean head `bbf8c890b`, 11 paired alternating trials, median transaction overhead `-5.68%` versus the deprecated split adapter (threshold `5%`), zero transaction heap allocations and zero published-read refcount operations

## Evidence boundary

Local runtime/TSAN/qualification evidence is macOS arm64. This PR preserves the ADR-0001 publication token and journal layout, but ADR-0063 remains `proposed` until current Windows/Linux last-owner destruction and x86 publication stress evidence is recorded. ADR-0064 retains ownership of library-level signal/error propagation such as `raise(SIGINT)`.