### PR TITLE
fix(product): select ESM entrypoint specifiers by platform

### DIFF
--- a/framework/gui/scripts/before-pack.cjs
+++ b/framework/gui/scripts/before-pack.cjs
@@ -7,8 +7,8 @@ const { spawnSync } = require('node:child_process');
 const path = require('node:path');
 const { pathToFileURL } = require('node:url');
 
-function toEsmEntrypointSpecifier(entryPath) {
-  return pathToFileURL(entryPath).href;
+function toEsmEntrypointSpecifier(entryPath, platform = process.platform) {
+  return platform === 'win32' ? pathToFileURL(entryPath).href : entryPath;
 }
 
 exports.default = async function beforePack() {

--- a/product/scripts/dist.test.mjs
+++ b/product/scripts/dist.test.mjs
@@ -56,12 +56,16 @@ test('product observability ignores errors from sibling components', () => {
   assert.equal(report.summary.eventCount, names.length);
 });
 
-test('electron before-pack uses a file URL for its ESM entrypoint', () => {
-  const specifier = toEsmEntrypointSpecifier(
-    new URL(
-      '../../framework/gui/scripts/gen-first-party-manifest.mjs',
-      import.meta.url,
-    ).pathname,
+test('electron before-pack uses a file URL only on Windows', () => {
+  const entryPath = new URL(
+    '../../framework/gui/scripts/gen-first-party-manifest.mjs',
+    import.meta.url,
+  ).pathname;
+  assert.equal(toEsmEntrypointSpecifier(entryPath, 'linux'), entryPath);
+  assert.equal(toEsmEntrypointSpecifier(entryPath, 'darwin'), entryPath);
+  assert.equal(
+    new URL(toEsmEntrypointSpecifier('C:\\kungfu\\manifest.mjs', 'win32'))
+      .protocol,
+    'file:',
   );
-  assert.equal(new URL(specifier).protocol, 'file:');
 });


### PR DESCRIPTION
## Summary

- keep absolute filesystem paths for POSIX first-party manifest generation
- use a `file://` URL only on Windows, where drive-letter paths require it
- cover Linux, macOS, and Windows specifier selection

## Validation

- `./shifu install`
- `node --test product/scripts/dist.test.mjs`

Fixes the Linux product failure in #629.