### PR TITLE
refactor(yijinjing): make schema tag sets compile-time (ADR-0065)

### DIFF
--- a/framework/core/src/bindings/node/binding/watcher.h
+++ b/framework/core/src/bindings/node/binding/watcher.h
@@ -110,7 +110,7 @@ private:
 
   static constexpr auto is_static_data = []() {
     return rx::filter([&](const event_ptr &event) {
-      return yijinjing::StaticDataTags.find(event->carrier_type()) != yijinjing::StaticDataTags.end();
+      return yijinjing::contains_tag(yijinjing::StaticDataTags, event->carrier_type());
     });
   };
 
@@ -145,7 +145,7 @@ private:
   template <typename DataType> void UpdateLedger(const boost::hana::basic_type<DataType> &type) {
     using DataTypeMap = std::unordered_map<uint64_t, state<DataType>>;
     auto &target_map = const_cast<DataTypeMap &>(data_bank_[type]);
-    auto is_static_data_type = yijinjing::StaticDataTags.find(DataType::tag) != yijinjing::StaticDataTags.end();
+    auto is_static_data_type = yijinjing::contains_tag(yijinjing::StaticDataTags, DataType::tag);
     auto count = 0;
     auto iter = target_map.begin();
     while (iter != target_map.end()) {

--- a/framework/core/src/libkungfu/include/kungfu/runtime/rx.h
+++ b/framework/core/src/libkungfu/include/kungfu/runtime/rx.h
@@ -40,8 +40,7 @@ static constexpr auto instanceof =
     []() { return filter([](const event_ptr &event) { return dynamic_cast<EventType *>(event.get()) != nullptr; }); };
 
 static constexpr auto is_custom_event = [](const event_ptr &event) -> bool {
-  return event->carrier_type() > 0 and
-         yijinjing::AllTypesTags.find(event->carrier_type()) == yijinjing::AllTypesTags.end();
+  return event->carrier_type() > 0 and not yijinjing::contains_tag(yijinjing::AllTypesTags, event->carrier_type());
 };
 
 static constexpr auto is_custom = []() {

--- a/framework/core/src/libyijinjing/include/kungfu/yijinjing/schema/registry.h
+++ b/framework/core/src/libyijinjing/include/kungfu/yijinjing/schema/registry.h
@@ -7,9 +7,10 @@
 #ifndef KUNGFU_YIJINJING_SCHEMA_REGISTRY_H
 #define KUNGFU_YIJINJING_SCHEMA_REGISTRY_H
 
+#include <algorithm>
+#include <array>
 #include <deque>
 #include <kungfu/yijinjing/schema/types.h>
-#include <set>
 
 #define TYPE_PAIR(DataType) boost::hana::make_pair(HANA_STR(#DataType), boost::hana::type_c<types::DataType>)
 
@@ -210,6 +211,9 @@ static_assert(decltype(boost::hana::length(SourceRegistryDataTypes))::value == 3
 static_assert(decltype(boost::hana::length(ManifestCatalogDataTypes))::value == 4);
 static_assert(decltype(boost::hana::length(EpisodeManifestDataTypes))::value == 6);
 
+// ADR-0065: intentionally empty placeholders. No static/statistic data types are
+// registered yet, but the state-cache restore paths (manager.cpp) consume these
+// sets, so they must stay defined rather than be removed.
 constexpr auto StaticDataTypes = boost::hana::make_map();
 constexpr auto StatisticDataTypes = boost::hana::make_map();
 
@@ -217,18 +221,26 @@ template <typename T> constexpr bool is_in_types(auto types) { return boost::han
 
 template <typename DataType> constexpr bool is_profile_data() { return is_in_types<DataType>(ProfileDataTypes); };
 
-const auto build_data_set = [](auto types) {
-  std::set<int32_t> s;
+// ADR-0065: the tag sets are compile-time sorted arrays, not runtime std::set
+// globals -- no static-init cost, and membership is a constexpr binary search.
+template <typename Types> constexpr auto build_tag_set(Types types) {
+  constexpr std::size_t n = decltype(boost::hana::length(types))::value;
+  std::array<int32_t, n> tags{};
+  std::size_t i = 0;
   boost::hana::for_each(types, [&](auto it) {
     using DataType = typename decltype(+boost::hana::second(it))::type;
-    s.emplace(DataType::tag);
+    tags[i++] = DataType::tag;
   });
-  return s;
-};
+  std::sort(tags.begin(), tags.end());
+  return tags;
+}
 
-const auto AllTypesTags = build_data_set(AllTypes);
-const auto ProfileDataTags = build_data_set(ProfileDataTypes);
-const auto StaticDataTags = build_data_set(StaticDataTypes);
+template <std::size_t N> constexpr bool contains_tag(const std::array<int32_t, N> &tags, int32_t tag) {
+  return std::binary_search(tags.begin(), tags.end(), tag);
+}
+
+inline constexpr auto AllTypesTags = build_tag_set(AllTypes);
+inline constexpr auto StaticDataTags = build_tag_set(StaticDataTypes);
 
 constexpr auto build_data_map = [](auto types) {
   auto maps = boost::hana::transform(boost::hana::values(types), [](auto value) {


### PR DESCRIPTION
Replaces the runtime const std::set globals (AllTypesTags/StaticDataTags) with constexpr sorted std::array built by build_tag_set + a constexpr contains_tag binary search -- no static-init cost, cache-friendly per-event membership (reactor is_custom_event). Drops the dead ProfileDataTags. StaticDataTypes/StatisticDataTypes stay (empty but consumed by state-cache restore). Consumers switch to contains_tag.