### PR TITLE
fix(freeze): type child process options

### DIFF
--- a/framework/core/.gyp/run-freeze.js
+++ b/framework/core/.gyp/run-freeze.js
@@ -594,6 +594,7 @@ function generateHelpManifest(pythonExe, distKfc) {
 function stageEntry(distKfc, bt) {
   const crates = path.join(CORE, '..', '..', 'crates');
   const cargoArgs = ['build', '--release', '-p', 'kungfu-trunk'];
+  /** @type {import('child_process').SpawnSyncOptions} */
   const runOpts = { cwd: crates };
   if (!isWin) {
     cargoArgs.push('--features', 'embedding');


### PR DESCRIPTION
## Summary

- declare the `stageEntry` shell options as Node child-process spawn options
- preserve the existing conditional POSIX embedding environment and Windows behavior
- remove the current dev tooling type error without changing runtime arguments

## Evidence

- `./shifu check:types`
- `./shifu check`

Closes #636