### PR TITLE
feat(trunk): run the node variant natively on Windows (ADR-0046 S3 Phase B1)

### DIFF
--- a/crates/trunk/src/variant.rs
+++ b/crates/trunk/src/variant.rs
@@ -27,10 +27,14 @@ const ENV_VARIANT_KEY: &str = "KUNGFU_AS_VARIANT";
 
 /// The standalone node-host library the product ships next to this binary; it
 /// exports the C entry `kungfu_node_run` (a thin wrapper over node::Start).
+/// Note the Windows name has no `lib` prefix: MSVC `add_library(... SHARED)`
+/// produces `kungfu_node_host.dll`, not `libkungfu_node_host.dll`.
 #[cfg(target_os = "macos")]
 const NODE_HOST_LIB: &str = "libkungfu_node_host.dylib";
 #[cfg(all(unix, not(target_os = "macos")))]
 const NODE_HOST_LIB: &str = "libkungfu_node_host.so";
+#[cfg(windows)]
+const NODE_HOST_LIB: &str = "kungfu_node_host.dll";
 
 /// If this process was asked to be a variant the trunk can own natively, run it
 /// to completion and return `Some(exit_code)`. Return `None` to fall through to
@@ -40,6 +44,47 @@ pub fn dispatch() -> Option<i32> {
         Some("node") => run_node(),
         _ => None,
     }
+}
+
+/// The C entry the node-host exports: `int kungfu_node_run(int argc, char **argv)`.
+#[cfg(any(unix, windows))]
+type NodeRunFn = extern "C" fn(std::ffi::c_int, *mut *mut std::ffi::c_char) -> std::ffi::c_int;
+
+/// Build heap-owned, mutable UTF-8 argv copies and hand them to the node-host
+/// entry. node::Start owns the process for its lifetime and may permute argv, so
+/// the copies must be heap-owned (argv[0] = program name, matching sys.argv). The
+/// copies are reclaimed only if node::Start returns rather than exiting the
+/// process itself. Shared by every platform loader so the argv contract lives in
+/// one place.
+#[cfg(any(unix, windows))]
+fn invoke_node(run: NodeRunFn) -> i32 {
+    use std::ffi::{c_char, c_int, CString};
+
+    let mut argv: Vec<*mut c_char> = env::args_os()
+        .map(|arg| {
+            CString::new(os_arg_bytes(&arg))
+                .unwrap_or_default()
+                .into_raw()
+        })
+        .collect();
+    let argc = argv.len() as c_int;
+    let code = run(argc, argv.as_mut_ptr());
+    for ptr in argv {
+        unsafe { drop(CString::from_raw(ptr)) };
+    }
+    code as i32
+}
+
+/// argv bytes for the node-host: raw bytes on unix (exact), lossy UTF-8 on
+/// Windows (args arrive as UTF-16; node itself works in UTF-8 argv).
+#[cfg(unix)]
+fn os_arg_bytes(arg: &std::ffi::OsStr) -> Vec<u8> {
+    use std::os::unix::ffi::OsStrExt;
+    arg.as_bytes().to_vec()
+}
+#[cfg(windows)]
+fn os_arg_bytes(arg: &std::ffi::OsStr) -> Vec<u8> {
+    arg.to_string_lossy().into_owned().into_bytes()
 }
 
 #[cfg(unix)]
@@ -71,30 +116,54 @@ fn run_node() -> Option<i32> {
     if entry.is_null() {
         return None;
     }
-    // int kungfu_node_run(int argc, char **argv)
-    let run: extern "C" fn(c_int, *mut *mut c_char) -> c_int =
-        unsafe { std::mem::transmute(entry) };
-
-    // node::Start owns the process for its lifetime and may permute argv, so hand
-    // it heap-owned, mutable copies (argv[0] = program name, matching sys.argv).
-    let mut argv: Vec<*mut c_char> = env::args_os()
-        .map(|arg| CString::new(arg.as_bytes()).unwrap_or_default().into_raw())
-        .collect();
-    let argc = argv.len() as c_int;
-    let code = run(argc, argv.as_mut_ptr());
-
-    // Reclaim the argv copies (reached only if node::Start returns rather than
-    // exiting the process itself).
-    for ptr in argv {
-        unsafe { drop(CString::from_raw(ptr)) };
-    }
-    Some(code as i32)
+    let run: NodeRunFn = unsafe { std::mem::transmute(entry) };
+    Some(invoke_node(run))
 }
 
-#[cfg(not(unix))]
+#[cfg(windows)]
 fn run_node() -> Option<i32> {
-    // Windows native node-host loading is a follow-up (LoadLibrary/GetProcAddress);
-    // until then fall through to the Python variant path, the current behavior.
+    use std::ffi::{c_char, c_void, CString};
+    use std::os::windows::ffi::OsStrExt;
+
+    // Win32 loader entry points from kernel32; std-only, no crate dependency.
+    // `extern "system"` is the stdcall/x64 ABI these use.
+    extern "system" {
+        fn LoadLibraryW(lp_lib_file_name: *const u16) -> *mut c_void;
+        fn GetProcAddress(h_module: *mut c_void, lp_proc_name: *const c_char) -> *mut c_void;
+    }
+
+    // The host DLL ships next to this binary (dist/kungfu); the exe directory is
+    // on the default DLL search path. If we cannot resolve our own path, fall
+    // through rather than guess.
+    let exe = env::current_exe().ok()?;
+    let lib_path = exe.parent()?.join(NODE_HOST_LIB);
+    // LoadLibraryW wants a NUL-terminated wide string.
+    let wide: Vec<u16> = lib_path
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
+
+    // Absent library → not the product build → fall through to the Python path.
+    let handle = unsafe { LoadLibraryW(wide.as_ptr()) };
+    if handle.is_null() {
+        return None;
+    }
+    let symbol = CString::new("kungfu_node_run").unwrap();
+    let entry = unsafe { GetProcAddress(handle, symbol.as_ptr()) };
+    if entry.is_null() {
+        return None;
+    }
+    let run: NodeRunFn = unsafe { std::mem::transmute(entry) };
+    // Deliberately no FreeLibrary: node::Start owns the process and normally exits
+    // it; on the rare return the process is ending anyway.
+    Some(invoke_node(run))
+}
+
+#[cfg(not(any(unix, windows)))]
+fn run_node() -> Option<i32> {
+    // No native loader for this platform → fall through to the Python variant
+    // path, the current behavior.
     None
 }
 

--- a/framework/core/.gyp/run-freeze.js
+++ b/framework/core/.gyp/run-freeze.js
@@ -252,8 +252,19 @@ function copyPyBindingWin(bt) {
   const dll = fs.existsSync(btDll)
     ? btDll
     : findFileShallow(buildDir, /^libnode\.dll$/i);
+  // Python-free node launcher (ADR-0046 stage 3, Phase B): a plain SHARED lib
+  // (no `.node` suffix). MSVC/cmake-js emits kungfu_node_host.dll at the build
+  // root next to the .node addons and pykungfu.pyd; check the multi-config
+  // build/<bt> subdir first (where libnode.dll lands) for resilience, then the
+  // root. The trunk LoadLibraryW's it next to the exe for KUNGFU_AS_VARIANT=node
+  // (variant.rs); absent → the Python variant path still runs node, so staging is
+  // a fast-path, not a requirement.
+  const btHost = path.join(buildDir, bt, 'kungfu_node_host.dll');
+  const host = fs.existsSync(btHost)
+    ? btHost
+    : findFileShallow(buildDir, /^kungfu_node_host\.dll$/i);
   let n = 0;
-  for (const src of [pyd, dll]) {
+  for (const src of [pyd, dll, host]) {
     if (!src) continue;
     fs.copyFileSync(src, path.join(distKfc, path.basename(src)));
     n++;
@@ -261,8 +272,13 @@ function copyPyBindingWin(bt) {
   // pykungfu.pdb ships the symbols for the python binding + statically-linked
   // core; libnode.dll is third-party and carries no PDB of ours.
   if (pyd) copyPdbSibling(pyd, distKfc);
+  if (host) copyPdbSibling(host, distKfc);
   if (!pyd) console.error('[freeze] Win 警告：build 树未找到 pykungfu*.pyd');
   if (!dll) console.error('[freeze] Win 警告：build 树未找到 libnode.dll');
+  if (!host)
+    console.error(
+      '[freeze] Win 提示：build 树未找到 kungfu_node_host.dll（node 变体将回退 Python 路径）',
+    );
   console.log(`[freeze] Win：补拷 python binding → dist/kungfu：${n} 项`);
 }
 

--- a/framework/core/src/bindings/node/CMakeLists.txt
+++ b/framework/core/src/bindings/node/CMakeLists.txt
@@ -42,9 +42,16 @@ endif ()
 # run the KUNGFU_AS_VARIANT=node variant without booting CPython. Built once, for
 # the node runtime; it links libnode directly and inherits the core's global
 # @loader_path/$ORIGIN rpath (compiler.cmake) to resolve the sibling libnode.
-# Windows loading is a trunk-side follow-up (the trunk only dlopens it on unix
-# today), so the launcher itself is unix-only until then.
-if ("${NODE_RUNTIME}" STREQUAL "node" AND UNIX)
+#
+# Built on unix (.dylib/.so) and Windows (kungfu_node_host.dll — MSVC gives a
+# SHARED lib no `lib` prefix). The host is an embedder, so on Windows it links the
+# real libnode import lib (${LIBNODE}=libnode -> libnode.lib in LIBNODE_LIB_DIR),
+# not a delay-loaded node.exe like the napi addons — no delayimp needed. The C
+# entry is __declspec(dllexport)-ready (host/kungfu_node_host.cpp), the strip is
+# unix-guarded, and CXX_VISIBILITY_PRESET is a no-op under MSVC, so the body is
+# portable as-is. The trunk loads it via LoadLibraryW on Windows (variant.rs); at
+# load time Windows resolves the sibling libnode.dll from the exe directory.
+if ("${NODE_RUNTIME}" STREQUAL "node" AND (UNIX OR WIN32))
   message(STATUS "Configuring for node launcher kungfu_node_host")
   add_library(kungfu_node_host SHARED host/kungfu_node_host.cpp)
   set_target_properties(kungfu_node_host PROPERTIES CXX_VISIBILITY_PRESET hidden)


### PR DESCRIPTION
ADR-0046 stage 3 productionization, Phase B1 (Windows node variant). `KUNGFU_AS_VARIANT=node` now runs natively on Windows without booting CPython, matching macOS/Linux.

- `crates/trunk/src/variant.rs`: Windows arm using `LoadLibraryW`/`GetProcAddress` to load `kungfu_node_host.dll` next to the exe and call `kungfu_node_run` (node::Start). argv build + invocation factored into a shared `invoke_node` (unix keeps raw-byte argv; Windows uses lossy UTF-8).
- `framework/core/src/bindings/node/CMakeLists.txt`: widen the node-host gate to `(UNIX OR WIN32)`. The host is an embedder, so on Windows it links the real libnode import lib (`libnode.lib`, which ships in LIBNODE_LIB_DIR next to libnode.dll) — not a delay-loaded node.exe like the napi addons. Body is already portable (`__declspec(dllexport)`-ready entry, unix-guarded strip, MSVC-ignored visibility preset).
- `framework/core/.gyp/run-freeze.js`: `copyPyBindingWin` stages `kungfu_node_host.dll` (+PDB) into dist/kungfu.

Zero-regression: absent DLL → `variant.rs` returns None and the Python variant path still runs node.

Validated on real Windows (DARKHERO, MSVC + cargo 1.96): standalone `cl` build links `libnode.lib` and exports `kungfu_node_run`; the real Windows trunk build (variant.rs Windows arm) loads the host and runs node end-to-end — `KUNGFU_AS_VARIANT=node kungfu-trunk.exe --version` → `v22.22.3`, `-e "console.log(2+3)"` → `5`.

Windows `doctor`/embedding stays stub (deferred: needs a new single-export embedding DLL; separate evaluation).