### PR TITLE
fix(ci): align membrane native toolchain

### DIFF
--- a/.github/workflows/embedding-membrane-spike.yml
+++ b/.github/workflows/embedding-membrane-spike.yml
@@ -77,7 +77,7 @@ jobs:
       matrix:
         include:
           - name: Linux x64
-            runner: '"ubuntu-22.04"'
+            runner: '"ubuntu-24.04"'
             source_mode: github
           - name: macOS ARM64
             runner: '"macos-15"'
@@ -108,6 +108,15 @@ jobs:
         if: ${{ runner.os == 'Windows' }}
         shell: pwsh
         run: '"C:\Program Files\Git\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append'
+
+      - name: Select GCC 14 on Linux
+        if: ${{ runner.os == 'Linux' }}
+        shell: bash
+        run: |
+          command -v gcc-14
+          command -v g++-14
+          echo "CC=gcc-14" >> "$GITHUB_ENV"
+          echo "CXX=g++-14" >> "$GITHUB_ENV"
 
       - name: Download immutable source delta
         uses: actions/download-artifact@v4

--- a/.github/workflows/embedding-membrane-spike.yml
+++ b/.github/workflows/embedding-membrane-spike.yml
@@ -213,7 +213,7 @@ jobs:
             spike_python="$PWD/framework/core/.venv/Scripts/python.exe"
           fi
           # shifu-entry-contract: allow the isolated spike configure is not a product-level Shifu task
-          cmake -S framework/core -B framework/core/build \
+          cmake -G Ninja -S framework/core -B framework/core/build \
             -DCMAKE_TOOLCHAIN_FILE="$PWD/framework/core/build/conan_toolchain.cmake" \
             -DCMAKE_POLICY_DEFAULT_CMP0091=NEW \
             -DCMAKE_BUILD_TYPE=Release \


### PR DESCRIPTION
## Summary
- select Ninja for the explicit membrane consumer CMake configure
- run the Linux qualification lane on Ubuntu 24.04 with GCC 14
- align the spike workflow with the repository native toolchain contract

## Context
The native toolchain contract requires Ninja and GCC 14 or newer. The membrane workflow previously defaulted to Unix Makefiles on Ubuntu 22.04/GCC 11 and failed before exercising consumers.

## Validation
- staged repository gate passed
- `git diff --check`
- Ninja mismatch reproduced in #640 run 29186472119
- GCC mismatch reproduced in this PR run 29186603764