### PR TITLE
perf(libwasm): share stable per-engine Cargo caches

### DIFF
--- a/build-local.env.example
+++ b/build-local.env.example
@@ -56,6 +56,12 @@
 # thumb: jobs ≈ available memory GB / 2. If unset, conan defaults (os.cpu_count).
 # export KUNGFU_BUILD_JOBS="12"
 
+# Optional libwasm Cargo target-cache root. By default every checkout uses a
+# deterministic per-engine slot below ${XDG_CACHE_HOME:-$HOME/.cache}/kungfu,
+# shared by all of that checkout's CMake build trees. Set this only when a
+# managed runner wants the cache on a dedicated local volume.
+# export KF_LIBWASM_CARGO_TARGET_ROOT="/path/to/local-cache/kungfu/libwasm/cargo-target"
+
 # ── Dev build stash (shifu promote / builds) ────────────────────────────────
 # Successful desktop builds register themselves user-globally
 # (~/.cache/kungfu/product/<os>-<arch>/) so `shifu promote` can install the

--- a/docs/cpp-toolchain.md
+++ b/docs/cpp-toolchain.md
@@ -66,6 +66,28 @@ without changing Cargo package identity. For example:
 KF_LIBWASM_CARGO_REGISTRY=sparse+https://rsproxy.cn/index/ ./shifu build:core
 ```
 
+Cargo downloads remain shared through `CARGO_HOME`, but Wasmtime and Wasmer
+keep independent workspaces, lockfiles, and target directories. Their target
+directories live under
+`${KF_LIBWASM_CARGO_TARGET_ROOT:-${XDG_CACHE_HOME:-~/.cache}/kungfu/libwasm/cargo-target}`
+and are keyed by the source checkout, actual Cargo/rustc identity and target,
+release profile, and engine lockfile. Consequently, separate CMake build trees
+from the same checkout reuse compiled dependencies, while separate worktrees,
+engines, toolchains, targets, profiles, or lockfiles cannot collide. Each CMake
+tree receives its own staged copy of the adapter library. The two heavy engine
+builds are serialized inside one CMake graph; Cargo's target-directory lock is
+the cross-graph concurrency boundary.
+
+Shifu loads `KF_LIBWASM_CARGO_TARGET_ROOT` from `build-local.env` when a managed
+machine or Buildchain runner needs a dedicated local cache volume. It is a
+transport/performance override only: package identity and correctness never
+depend on the internal registry or on a pre-existing target cache.
+
+Run `./shifu qualify:libwasm-cache` to build both production adapters twice,
+verify that the warm pass compiles no crates, and compare the two CMake-style
+staged artifact hashes. The command prints the resolved per-engine keys and
+target directories as machine-readable JSON.
+
 The build exports Kungfu's pinned RxCpp 4.1.1 Conan recipe before dependency
 resolution. Its single portability patch makes the notification payloads
 assignable, matching their declared assignment operators and allowing the

--- a/framework/core/.cmake/libwasm-cargo-cache.cmake
+++ b/framework/core/.cmake/libwasm-cargo-cache.cmake
@@ -1,0 +1,128 @@
+# SPDX-License-Identifier: Apache-2.0
+
+include_guard(GLOBAL)
+
+function(kungfu_libwasm_default_cargo_target_root OUTPUT)
+  if(DEFINED ENV{KF_LIBWASM_CARGO_TARGET_ROOT} AND
+     NOT "$ENV{KF_LIBWASM_CARGO_TARGET_ROOT}" STREQUAL "")
+    set(ROOT "$ENV{KF_LIBWASM_CARGO_TARGET_ROOT}")
+  elseif(DEFINED ENV{XDG_CACHE_HOME} AND NOT "$ENV{XDG_CACHE_HOME}" STREQUAL "")
+    set(ROOT "$ENV{XDG_CACHE_HOME}/kungfu/libwasm/cargo-target")
+  elseif(WIN32 AND DEFINED ENV{LOCALAPPDATA} AND NOT "$ENV{LOCALAPPDATA}" STREQUAL "")
+    set(ROOT "$ENV{LOCALAPPDATA}/kungfu/libwasm/cargo-target")
+  elseif(DEFINED ENV{HOME} AND NOT "$ENV{HOME}" STREQUAL "")
+    set(ROOT "$ENV{HOME}/.cache/kungfu/libwasm/cargo-target")
+  elseif(DEFINED ENV{USERPROFILE} AND NOT "$ENV{USERPROFILE}" STREQUAL "")
+    set(ROOT "$ENV{USERPROFILE}/.cache/kungfu/libwasm/cargo-target")
+  else()
+    set(ROOT "${CMAKE_BINARY_DIR}/.kungfu-cache/libwasm/cargo-target")
+  endif()
+  cmake_path(ABSOLUTE_PATH ROOT NORMALIZE OUTPUT_VARIABLE ROOT)
+  set(${OUTPUT} "${ROOT}" PARENT_SCOPE)
+endfunction()
+
+# Resolve one isolated Cargo target directory. The source-root fingerprint keeps
+# independent Git worktrees from racing on the same primary crate artifacts,
+# while all CMake build trees created from one checkout reuse the same cache.
+# The actual Cargo/Rust compiler identity, target, profile, and lockfile hash
+# make invalidation explicit and keep Wasmtime/Wasmer dependency worlds apart.
+function(kungfu_resolve_libwasm_cargo_target OUTPUT_DIR OUTPUT_KEY)
+  set(ONE_VALUE_ARGS
+      NAME
+      MANIFEST_DIR
+      LOCKFILE
+      SOURCE_ROOT
+      PROFILE
+      CARGO
+      RUSTC
+      CACHE_ROOT
+      TARGET
+      TOOLCHAIN_FINGERPRINT)
+  cmake_parse_arguments(KF "" "${ONE_VALUE_ARGS}" "" ${ARGN})
+
+  foreach(REQUIRED_ARG NAME MANIFEST_DIR LOCKFILE SOURCE_ROOT PROFILE)
+    if(NOT KF_${REQUIRED_ARG})
+      message(FATAL_ERROR "kungfu_resolve_libwasm_cargo_target requires ${REQUIRED_ARG}")
+    endif()
+  endforeach()
+  if(NOT KF_NAME MATCHES "^[A-Za-z0-9._-]+$" OR
+     NOT KF_PROFILE MATCHES "^[A-Za-z0-9._-]+$")
+    message(FATAL_ERROR "libwasm Cargo cache name/profile must be path-safe")
+  endif()
+  if(NOT EXISTS "${KF_LOCKFILE}")
+    message(FATAL_ERROR "libwasm Cargo lockfile not found: ${KF_LOCKFILE}")
+  endif()
+
+  file(REAL_PATH "${KF_SOURCE_ROOT}" SOURCE_ROOT_REAL)
+  file(SHA256 "${KF_LOCKFILE}" LOCK_HASH)
+  string(SHA256 SOURCE_HASH "${SOURCE_ROOT_REAL}")
+
+  if(KF_TOOLCHAIN_FINGERPRINT)
+    set(TOOLCHAIN_FINGERPRINT "${KF_TOOLCHAIN_FINGERPRINT}")
+  else()
+    if(NOT KF_CARGO)
+      message(FATAL_ERROR "libwasm Cargo cache resolution requires CARGO")
+    endif()
+    execute_process(
+      COMMAND "${KF_CARGO}" -Vv
+      WORKING_DIRECTORY "${KF_MANIFEST_DIR}"
+      OUTPUT_VARIABLE CARGO_VERSION
+      ERROR_VARIABLE CARGO_VERSION_ERROR
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+      RESULT_VARIABLE CARGO_VERSION_RESULT)
+    if(NOT CARGO_VERSION_RESULT EQUAL 0)
+      message(FATAL_ERROR
+        "Failed to identify Cargo for libwasm cache: ${CARGO_VERSION_ERROR}")
+    endif()
+
+    if(KF_RUSTC)
+      set(RUSTC "${KF_RUSTC}")
+    else()
+      get_filename_component(CARGO_DIRECTORY "${KF_CARGO}" DIRECTORY)
+      find_program(RUSTC NAMES rustc HINTS "${CARGO_DIRECTORY}" NO_DEFAULT_PATH)
+      if(NOT RUSTC)
+        find_program(RUSTC NAMES rustc REQUIRED)
+      endif()
+    endif()
+    execute_process(
+      COMMAND "${RUSTC}" -vV
+      WORKING_DIRECTORY "${KF_MANIFEST_DIR}"
+      OUTPUT_VARIABLE RUSTC_VERSION
+      ERROR_VARIABLE RUSTC_VERSION_ERROR
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+      RESULT_VARIABLE RUSTC_VERSION_RESULT)
+    if(NOT RUSTC_VERSION_RESULT EQUAL 0)
+      message(FATAL_ERROR
+        "Failed to identify rustc for libwasm cache: ${RUSTC_VERSION_ERROR}")
+    endif()
+    set(TOOLCHAIN_FINGERPRINT "cargo=${CARGO_VERSION}\nrustc=${RUSTC_VERSION}")
+  endif()
+
+  if(KF_TARGET)
+    set(CARGO_TARGET "${KF_TARGET}")
+  elseif(DEFINED ENV{CARGO_BUILD_TARGET} AND NOT "$ENV{CARGO_BUILD_TARGET}" STREQUAL "")
+    set(CARGO_TARGET "$ENV{CARGO_BUILD_TARGET}")
+  else()
+    set(CARGO_TARGET "host")
+  endif()
+
+  string(SHA256 TOOLCHAIN_HASH "${TOOLCHAIN_FINGERPRINT}")
+  string(SHA256 TARGET_HASH "${KF_NAME}|${KF_PROFILE}|${CARGO_TARGET}")
+  string(SUBSTRING "${SOURCE_HASH}" 0 12 SOURCE_KEY)
+  string(SUBSTRING "${TOOLCHAIN_HASH}" 0 12 TOOLCHAIN_KEY)
+  string(SUBSTRING "${TARGET_HASH}" 0 8 TARGET_KEY)
+  string(SUBSTRING "${LOCK_HASH}" 0 12 LOCK_KEY)
+  set(CACHE_KEY
+      "v1-${SOURCE_KEY}-${TOOLCHAIN_KEY}-${TARGET_KEY}-${LOCK_KEY}")
+
+  if(KF_CACHE_ROOT)
+    set(CACHE_ROOT "${KF_CACHE_ROOT}")
+    cmake_path(ABSOLUTE_PATH CACHE_ROOT NORMALIZE OUTPUT_VARIABLE CACHE_ROOT)
+  else()
+    kungfu_libwasm_default_cargo_target_root(CACHE_ROOT)
+  endif()
+  set(TARGET_DIR "${CACHE_ROOT}/${KF_NAME}/${KF_PROFILE}/${CACHE_KEY}")
+
+  set(${OUTPUT_DIR} "${TARGET_DIR}" PARENT_SCOPE)
+  set(${OUTPUT_KEY} "${CACHE_KEY}" PARENT_SCOPE)
+endfunction()

--- a/framework/core/CMakeLists.txt
+++ b/framework/core/CMakeLists.txt
@@ -9,6 +9,7 @@ include(${PROJECT_SOURCE_DIR}/.cmake/editor.cmake)
 include(${PROJECT_SOURCE_DIR}/.cmake/compiler.cmake)
 include(${PROJECT_SOURCE_DIR}/.cmake/toolchain-contract.cmake)
 include(${PROJECT_SOURCE_DIR}/.cmake/libnode.cmake)
+include(${PROJECT_SOURCE_DIR}/.cmake/libwasm-cargo-cache.cmake)
 
 ##########################################################################
 # conan 2：依赖经 CMakeToolchain(工具链) + CMakeDeps(find_package 目标) 提供，

--- a/framework/core/slices/libwasm-shared-membrane/CMakeLists.txt
+++ b/framework/core/slices/libwasm-shared-membrane/CMakeLists.txt
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 find_program(KF_LIBWASM_CARGO cargo REQUIRED)
+include("${CMAKE_CURRENT_LIST_DIR}/../../.cmake/libwasm-cargo-cache.cmake")
 set(KF_LIBWASM_CARGO_REGISTRY "" CACHE STRING
   "Optional sparse Cargo registry mirror, for example sparse+https://rsproxy.cn/index/")
 set(KF_LIBWASM_CARGO_SOURCE_ARGS)
@@ -12,19 +13,42 @@ endif()
 set(KF_LIBWASM_CRATE_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/../../../../crates/libwasm-spike")
 set(KF_LIBWASM_WASMTIME_DIR "${KF_LIBWASM_CRATE_ROOT}/wasmtime")
 set(KF_LIBWASM_WASMER_DIR "${KF_LIBWASM_CRATE_ROOT}/wasmer")
-set(KF_LIBWASM_WASMTIME_TARGET_DIR "${CMAKE_CURRENT_BINARY_DIR}/cargo-target-wasmtime")
-set(KF_LIBWASM_WASMER_TARGET_DIR "${CMAKE_CURRENT_BINARY_DIR}/cargo-target-wasmer")
+set(KF_LIBWASM_CARGO_TARGET_ROOT "" CACHE PATH
+  "Optional root for stable per-engine libwasm Cargo target caches")
+kungfu_resolve_libwasm_cargo_target(
+  KF_LIBWASM_WASMTIME_TARGET_DIR KF_LIBWASM_WASMTIME_CACHE_KEY
+  NAME wasmtime-spike
+  MANIFEST_DIR "${KF_LIBWASM_WASMTIME_DIR}"
+  LOCKFILE "${KF_LIBWASM_WASMTIME_DIR}/Cargo.lock"
+  SOURCE_ROOT "${KF_LIBWASM_CRATE_ROOT}/../.."
+  PROFILE release
+  CARGO "${KF_LIBWASM_CARGO}"
+  CACHE_ROOT "${KF_LIBWASM_CARGO_TARGET_ROOT}")
+kungfu_resolve_libwasm_cargo_target(
+  KF_LIBWASM_WASMER_TARGET_DIR KF_LIBWASM_WASMER_CACHE_KEY
+  NAME wasmer-spike
+  MANIFEST_DIR "${KF_LIBWASM_WASMER_DIR}"
+  LOCKFILE "${KF_LIBWASM_WASMER_DIR}/Cargo.lock"
+  SOURCE_ROOT "${KF_LIBWASM_CRATE_ROOT}/../.."
+  PROFILE release
+  CARGO "${KF_LIBWASM_CARGO}"
+  CACHE_ROOT "${KF_LIBWASM_CARGO_TARGET_ROOT}")
+set(KF_LIBWASM_STAGE_DIR "${CMAKE_CURRENT_BINARY_DIR}/cargo-stage")
 
 if(WIN32)
-  set(KF_LIBWASM_WASMTIME_LIBRARY "${KF_LIBWASM_WASMTIME_TARGET_DIR}/release/kf_libwasm_wasmtime_spike.dll")
-  set(KF_LIBWASM_WASMER_LIBRARY "${KF_LIBWASM_WASMER_TARGET_DIR}/release/kf_libwasm_wasmer_spike.dll")
+  set(KF_LIBWASM_WASMTIME_CACHED_LIBRARY "${KF_LIBWASM_WASMTIME_TARGET_DIR}/release/kf_libwasm_wasmtime_spike.dll")
+  set(KF_LIBWASM_WASMER_CACHED_LIBRARY "${KF_LIBWASM_WASMER_TARGET_DIR}/release/kf_libwasm_wasmer_spike.dll")
 elseif(APPLE)
-  set(KF_LIBWASM_WASMTIME_LIBRARY "${KF_LIBWASM_WASMTIME_TARGET_DIR}/release/libkf_libwasm_wasmtime_spike.dylib")
-  set(KF_LIBWASM_WASMER_LIBRARY "${KF_LIBWASM_WASMER_TARGET_DIR}/release/libkf_libwasm_wasmer_spike.dylib")
+  set(KF_LIBWASM_WASMTIME_CACHED_LIBRARY "${KF_LIBWASM_WASMTIME_TARGET_DIR}/release/libkf_libwasm_wasmtime_spike.dylib")
+  set(KF_LIBWASM_WASMER_CACHED_LIBRARY "${KF_LIBWASM_WASMER_TARGET_DIR}/release/libkf_libwasm_wasmer_spike.dylib")
 else()
-  set(KF_LIBWASM_WASMTIME_LIBRARY "${KF_LIBWASM_WASMTIME_TARGET_DIR}/release/libkf_libwasm_wasmtime_spike.so")
-  set(KF_LIBWASM_WASMER_LIBRARY "${KF_LIBWASM_WASMER_TARGET_DIR}/release/libkf_libwasm_wasmer_spike.so")
+  set(KF_LIBWASM_WASMTIME_CACHED_LIBRARY "${KF_LIBWASM_WASMTIME_TARGET_DIR}/release/libkf_libwasm_wasmtime_spike.so")
+  set(KF_LIBWASM_WASMER_CACHED_LIBRARY "${KF_LIBWASM_WASMER_TARGET_DIR}/release/libkf_libwasm_wasmer_spike.so")
 endif()
+get_filename_component(KF_LIBWASM_WASMTIME_FILENAME "${KF_LIBWASM_WASMTIME_CACHED_LIBRARY}" NAME)
+get_filename_component(KF_LIBWASM_WASMER_FILENAME "${KF_LIBWASM_WASMER_CACHED_LIBRARY}" NAME)
+set(KF_LIBWASM_WASMTIME_LIBRARY "${KF_LIBWASM_STAGE_DIR}/${KF_LIBWASM_WASMTIME_FILENAME}")
+set(KF_LIBWASM_WASMER_LIBRARY "${KF_LIBWASM_STAGE_DIR}/${KF_LIBWASM_WASMER_FILENAME}")
 
 add_custom_command(
   OUTPUT "${KF_LIBWASM_WASMTIME_LIBRARY}"
@@ -32,9 +56,13 @@ add_custom_command(
           "CARGO_TARGET_DIR=${KF_LIBWASM_WASMTIME_TARGET_DIR}"
           "${KF_LIBWASM_CARGO}" ${KF_LIBWASM_CARGO_SOURCE_ARGS} build --release --locked
           --manifest-path "${KF_LIBWASM_WASMTIME_DIR}/Cargo.toml"
+  COMMAND ${CMAKE_COMMAND} -E make_directory "${KF_LIBWASM_STAGE_DIR}"
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different
+          "${KF_LIBWASM_WASMTIME_CACHED_LIBRARY}" "${KF_LIBWASM_WASMTIME_LIBRARY}"
   DEPENDS
     "${KF_LIBWASM_WASMTIME_DIR}/Cargo.toml"
     "${KF_LIBWASM_WASMTIME_DIR}/Cargo.lock"
+    "${KF_LIBWASM_CRATE_ROOT}/rust-toolchain.toml"
     "${KF_LIBWASM_CRATE_ROOT}/src/lib.rs"
   WORKING_DIRECTORY "${KF_LIBWASM_WASMTIME_DIR}"
   COMMENT "Building bounded Wasmtime libwasm adapter"
@@ -46,16 +74,25 @@ add_custom_command(
           "CARGO_TARGET_DIR=${KF_LIBWASM_WASMER_TARGET_DIR}"
           "${KF_LIBWASM_CARGO}" ${KF_LIBWASM_CARGO_SOURCE_ARGS} build --release --locked
           --manifest-path "${KF_LIBWASM_WASMER_DIR}/Cargo.toml"
+  COMMAND ${CMAKE_COMMAND} -E make_directory "${KF_LIBWASM_STAGE_DIR}"
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different
+          "${KF_LIBWASM_WASMER_CACHED_LIBRARY}" "${KF_LIBWASM_WASMER_LIBRARY}"
   DEPENDS
     "${KF_LIBWASM_WASMER_DIR}/Cargo.toml"
     "${KF_LIBWASM_WASMER_DIR}/Cargo.lock"
+    "${KF_LIBWASM_CRATE_ROOT}/rust-toolchain.toml"
     "${KF_LIBWASM_CRATE_ROOT}/src/lib.rs"
   WORKING_DIRECTORY "${KF_LIBWASM_WASMER_DIR}"
   COMMENT "Building bounded Wasmer libwasm adapter"
   VERBATIM)
 
-add_custom_target(libwasm_spike_cdylibs ALL
-  DEPENDS "${KF_LIBWASM_WASMTIME_LIBRARY}" "${KF_LIBWASM_WASMER_LIBRARY}")
+add_custom_target(libwasm_spike_wasmtime_cdylib
+  DEPENDS "${KF_LIBWASM_WASMTIME_LIBRARY}")
+add_custom_target(libwasm_spike_wasmer_cdylib
+  DEPENDS "${KF_LIBWASM_WASMER_LIBRARY}")
+add_dependencies(libwasm_spike_wasmer_cdylib libwasm_spike_wasmtime_cdylib)
+add_custom_target(libwasm_spike_cdylibs ALL)
+add_dependencies(libwasm_spike_cdylibs libwasm_spike_wasmer_cdylib)
 
 add_executable(libwasm_shared_membrane_host host.cpp)
 add_dependencies(libwasm_shared_membrane_host libwasm_spike_cdylibs)

--- a/framework/core/slices/libwasm-shared-membrane/README.md
+++ b/framework/core/slices/libwasm-shared-membrane/README.md
@@ -60,6 +60,10 @@ registry mirror. Leaving it empty uses the official Cargo source; CI may set a
 reviewed mirror URL while Cargo still verifies the checksums pinned in each
 adapter's lockfile.
 
+The slice uses the same stable, per-engine Cargo target-cache contract as the
+production adapters. Its staged libraries remain inside the slice build tree,
+so qualification never depends on an external-cache path after compilation.
+
 The standalone spike pins Rust 1.96.0 with a minimal profile in its own
 directory. Wasmtime 46.0.1 requires Rust 1.94 and Wasmer 7.2.0 requires Rust
 1.93; the local pin keeps older self-hosted runner defaults from silently

--- a/framework/core/slices/libwasm-shared-membrane/run.mjs
+++ b/framework/core/slices/libwasm-shared-membrane/run.mjs
@@ -48,8 +48,7 @@ const adapter = (engine) =>
     buildDir,
     'slices',
     'libwasm-shared-membrane',
-    `cargo-target-${engine}`,
-    'release',
+    'cargo-stage',
     `${prefix}kf_libwasm_${engine}_spike${suffix}`,
   );
 const wasmtime = adapter('wasmtime');

--- a/framework/core/src/libwasm/CMakeLists.txt
+++ b/framework/core/src/libwasm/CMakeLists.txt
@@ -15,28 +15,60 @@ if(KF_LIBWASM_CARGO_REGISTRY)
 endif()
 
 set(KF_LIBWASM_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/../../../../crates/libwasm")
-set(KF_LIBWASM_WASMTIME_TARGET "${CMAKE_CURRENT_BINARY_DIR}/cargo-target-wasmtime")
-set(KF_LIBWASM_WASMER_TARGET "${CMAKE_CURRENT_BINARY_DIR}/cargo-target-wasmer")
+set(KF_LIBWASM_CARGO_TARGET_ROOT "" CACHE PATH
+  "Optional root for stable per-engine libwasm Cargo target caches")
+kungfu_resolve_libwasm_cargo_target(
+  KF_LIBWASM_WASMTIME_TARGET KF_LIBWASM_WASMTIME_CACHE_KEY
+  NAME wasmtime
+  MANIFEST_DIR "${KF_LIBWASM_ROOT}/wasmtime"
+  LOCKFILE "${KF_LIBWASM_ROOT}/wasmtime/Cargo.lock"
+  SOURCE_ROOT "${KF_LIBWASM_ROOT}/../.."
+  PROFILE release
+  CARGO "${KF_LIBWASM_CARGO}"
+  CACHE_ROOT "${KF_LIBWASM_CARGO_TARGET_ROOT}")
+kungfu_resolve_libwasm_cargo_target(
+  KF_LIBWASM_WASMER_TARGET KF_LIBWASM_WASMER_CACHE_KEY
+  NAME wasmer
+  MANIFEST_DIR "${KF_LIBWASM_ROOT}/wasmer"
+  LOCKFILE "${KF_LIBWASM_ROOT}/wasmer/Cargo.lock"
+  SOURCE_ROOT "${KF_LIBWASM_ROOT}/../.."
+  PROFILE release
+  CARGO "${KF_LIBWASM_CARGO}"
+  CACHE_ROOT "${KF_LIBWASM_CARGO_TARGET_ROOT}")
+set(KF_LIBWASM_STAGE_DIR "${CMAKE_CURRENT_BINARY_DIR}/cargo-stage")
 
 if(WIN32)
-  set(KF_LIBWASM_WASMTIME_LIBRARY "${KF_LIBWASM_WASMTIME_TARGET}/release/kungfu_libwasm_wasmtime.dll")
-  set(KF_LIBWASM_WASMER_LIBRARY "${KF_LIBWASM_WASMER_TARGET}/release/kungfu_libwasm_wasmer.dll")
+  set(KF_LIBWASM_WASMTIME_CACHED_LIBRARY "${KF_LIBWASM_WASMTIME_TARGET}/release/kungfu_libwasm_wasmtime.dll")
+  set(KF_LIBWASM_WASMER_CACHED_LIBRARY "${KF_LIBWASM_WASMER_TARGET}/release/kungfu_libwasm_wasmer.dll")
 elseif(APPLE)
-  set(KF_LIBWASM_WASMTIME_LIBRARY "${KF_LIBWASM_WASMTIME_TARGET}/release/libkungfu_libwasm_wasmtime.dylib")
-  set(KF_LIBWASM_WASMER_LIBRARY "${KF_LIBWASM_WASMER_TARGET}/release/libkungfu_libwasm_wasmer.dylib")
+  set(KF_LIBWASM_WASMTIME_CACHED_LIBRARY "${KF_LIBWASM_WASMTIME_TARGET}/release/libkungfu_libwasm_wasmtime.dylib")
+  set(KF_LIBWASM_WASMER_CACHED_LIBRARY "${KF_LIBWASM_WASMER_TARGET}/release/libkungfu_libwasm_wasmer.dylib")
 else()
-  set(KF_LIBWASM_WASMTIME_LIBRARY "${KF_LIBWASM_WASMTIME_TARGET}/release/libkungfu_libwasm_wasmtime.so")
-  set(KF_LIBWASM_WASMER_LIBRARY "${KF_LIBWASM_WASMER_TARGET}/release/libkungfu_libwasm_wasmer.so")
+  set(KF_LIBWASM_WASMTIME_CACHED_LIBRARY "${KF_LIBWASM_WASMTIME_TARGET}/release/libkungfu_libwasm_wasmtime.so")
+  set(KF_LIBWASM_WASMER_CACHED_LIBRARY "${KF_LIBWASM_WASMER_TARGET}/release/libkungfu_libwasm_wasmer.so")
 endif()
+get_filename_component(KF_LIBWASM_WASMTIME_FILENAME "${KF_LIBWASM_WASMTIME_CACHED_LIBRARY}" NAME)
+get_filename_component(KF_LIBWASM_WASMER_FILENAME "${KF_LIBWASM_WASMER_CACHED_LIBRARY}" NAME)
+set(KF_LIBWASM_WASMTIME_LIBRARY "${KF_LIBWASM_STAGE_DIR}/${KF_LIBWASM_WASMTIME_FILENAME}")
+set(KF_LIBWASM_WASMER_LIBRARY "${KF_LIBWASM_STAGE_DIR}/${KF_LIBWASM_WASMER_FILENAME}")
+
+message(STATUS
+  "libwasm Cargo cache: wasmtime=${KF_LIBWASM_WASMTIME_CACHE_KEY} "
+  "(${KF_LIBWASM_WASMTIME_TARGET}), wasmer=${KF_LIBWASM_WASMER_CACHE_KEY} "
+  "(${KF_LIBWASM_WASMER_TARGET})")
 
 add_custom_command(
   OUTPUT "${KF_LIBWASM_WASMTIME_LIBRARY}"
   COMMAND ${CMAKE_COMMAND} -E env "CARGO_TARGET_DIR=${KF_LIBWASM_WASMTIME_TARGET}"
           "${KF_LIBWASM_CARGO}" ${KF_LIBWASM_CARGO_SOURCE_ARGS} build --release --locked
           --manifest-path "${KF_LIBWASM_ROOT}/wasmtime/Cargo.toml"
+  COMMAND ${CMAKE_COMMAND} -E make_directory "${KF_LIBWASM_STAGE_DIR}"
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different
+          "${KF_LIBWASM_WASMTIME_CACHED_LIBRARY}" "${KF_LIBWASM_WASMTIME_LIBRARY}"
   DEPENDS
     "${KF_LIBWASM_ROOT}/wasmtime/Cargo.toml"
     "${KF_LIBWASM_ROOT}/wasmtime/Cargo.lock"
+    "${KF_LIBWASM_ROOT}/rust-toolchain.toml"
     "${KF_LIBWASM_ROOT}/src/lib.rs"
     "${KF_LIBWASM_ROOT}/src/production.rs"
     "${KF_LIBWASM_ROOT}/../libwasm-spike/src/lib.rs"
@@ -49,9 +81,13 @@ add_custom_command(
   COMMAND ${CMAKE_COMMAND} -E env "CARGO_TARGET_DIR=${KF_LIBWASM_WASMER_TARGET}"
           "${KF_LIBWASM_CARGO}" ${KF_LIBWASM_CARGO_SOURCE_ARGS} build --release --locked
           --manifest-path "${KF_LIBWASM_ROOT}/wasmer/Cargo.toml"
+  COMMAND ${CMAKE_COMMAND} -E make_directory "${KF_LIBWASM_STAGE_DIR}"
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different
+          "${KF_LIBWASM_WASMER_CACHED_LIBRARY}" "${KF_LIBWASM_WASMER_LIBRARY}"
   DEPENDS
     "${KF_LIBWASM_ROOT}/wasmer/Cargo.toml"
     "${KF_LIBWASM_ROOT}/wasmer/Cargo.lock"
+    "${KF_LIBWASM_ROOT}/rust-toolchain.toml"
     "${KF_LIBWASM_ROOT}/src/lib.rs"
     "${KF_LIBWASM_ROOT}/src/production.rs"
     "${KF_LIBWASM_ROOT}/../libwasm-spike/src/lib.rs"
@@ -59,8 +95,16 @@ add_custom_command(
   COMMENT "Building production Wasmer libwasm adapter"
   VERBATIM)
 
-add_custom_target(kungfu_libwasm_cdylibs ALL
-  DEPENDS "${KF_LIBWASM_WASMTIME_LIBRARY}" "${KF_LIBWASM_WASMER_LIBRARY}")
+add_custom_target(kungfu_libwasm_wasmtime_cdylib
+  DEPENDS "${KF_LIBWASM_WASMTIME_LIBRARY}")
+add_custom_target(kungfu_libwasm_wasmer_cdylib
+  DEPENDS "${KF_LIBWASM_WASMER_LIBRARY}")
+# Both adapters are heavy Rust release builds and share CARGO_HOME. Serialize
+# them within one CMake graph; Cargo's own target-dir lock covers two separate
+# CMake graphs that resolve to the same per-engine cache key.
+add_dependencies(kungfu_libwasm_wasmer_cdylib kungfu_libwasm_wasmtime_cdylib)
+add_custom_target(kungfu_libwasm_cdylibs ALL)
+add_dependencies(kungfu_libwasm_cdylibs kungfu_libwasm_wasmer_cdylib)
 
 add_executable(kungfu_wasm_host host.cpp)
 set_target_properties(kungfu_wasm_host PROPERTIES OUTPUT_NAME "kungfu-wasm-host")

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "test:mmap": "node scripts/require-shifu.mjs test:mmap && node scripts/run-mmap-tests.mjs",
     "qualify:mmap": "node scripts/require-shifu.mjs qualify:mmap && node scripts/run-mmap-qualification.mjs",
     "qualify:cpp-modules": "node scripts/require-shifu.mjs qualify:cpp-modules && node scripts/run-cpp-modules-qualification.mjs",
+    "qualify:libwasm-cache": "node scripts/require-shifu.mjs qualify:libwasm-cache && node scripts/qualify-libwasm-cargo-cache.mjs",
     "version": "node scripts/sync-shifu-version.mjs && git add crates/shifu/Cargo.toml crates/Cargo.lock",
     "prepare": "node scripts/install-hooks.mjs",
     "hooks:install": "node scripts/require-shifu.mjs hooks:install && node scripts/install-hooks.mjs --force"

--- a/scripts/check.mjs
+++ b/scripts/check.mjs
@@ -451,6 +451,22 @@ function checkBuildchainKfdEvidence(files = [], { force = false } = {}) {
   ]);
 }
 
+function checkLibwasmCargoCache(files = [], { force = false } = {}) {
+  const touched = files.some(
+    (file) =>
+      file === 'framework/core/.cmake/libwasm-cargo-cache.cmake' ||
+      file === 'scripts/libwasm-cargo-cache.test.mjs' ||
+      file === 'scripts/qualify-libwasm-cargo-cache.mjs' ||
+      file.endsWith('/libwasm/CMakeLists.txt') ||
+      file.includes('/libwasm-shared-membrane/'),
+  );
+  if (!force && !touched) return;
+  run('libwasm Cargo cache contract tests', 'node', [
+    '--test',
+    path.join('scripts', 'libwasm-cargo-cache.test.mjs'),
+  ]);
+}
+
 function checkStaged() {
   checkNoBashStaged();
   checkPlatformMacros();
@@ -499,6 +515,7 @@ function checkStaged() {
   checkBiomeFiles('staged', files);
   checkRustFiles('staged', files);
   checkBuildchainKfdEvidence(files);
+  checkLibwasmCargoCache(files);
 
   log('\n[check] staged gate passed');
 }
@@ -546,6 +563,7 @@ function checkChanged() {
   checkBiomeFiles('changed', files);
   checkRustFiles('changed', files);
   checkBuildchainKfdEvidence(files);
+  checkLibwasmCargoCache(files);
   checkShared();
   log('\n[check] changed-scope gate passed');
 }
@@ -563,6 +581,7 @@ function checkAll() {
   run('repo lint + format check', 'pnpm', ['run', 'lint']);
   checkRustFiles('all', [], { force: true });
   checkBuildchainKfdEvidence([], { force: true });
+  checkLibwasmCargoCache([], { force: true });
   checkShared();
   log('\n[check] whole-tree gate passed');
 }

--- a/scripts/libwasm-cargo-cache.test.mjs
+++ b/scripts/libwasm-cargo-cache.test.mjs
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const modulePath = path.join(
+  root,
+  'framework',
+  'core',
+  '.cmake',
+  'libwasm-cargo-cache.cmake',
+);
+
+function cmakePath(value) {
+  return value.replaceAll('\\', '/').replaceAll('"', '\\"');
+}
+
+function resolveCache({
+  source,
+  lock,
+  name = 'wasmtime',
+  toolchain = 'rust-1',
+}) {
+  const work = fs.mkdtempSync(path.join(os.tmpdir(), 'kungfu-libwasm-cache-'));
+  const cacheRoot = path.join(work, 'cache');
+  const script = path.join(work, 'resolve.cmake');
+  fs.writeFileSync(
+    script,
+    `include("${cmakePath(modulePath)}")
+kungfu_resolve_libwasm_cargo_target(OUT_DIR OUT_KEY
+  NAME "${name}"
+  MANIFEST_DIR "${cmakePath(source)}"
+  LOCKFILE "${cmakePath(lock)}"
+  SOURCE_ROOT "${cmakePath(source)}"
+  PROFILE release
+  CACHE_ROOT "${cmakePath(cacheRoot)}"
+  TOOLCHAIN_FINGERPRINT "${toolchain}"
+  TARGET "test-target")
+message("RESULT|\${OUT_KEY}|\${OUT_DIR}")
+`,
+  );
+  const result = spawnSync('cmake', ['-P', script], { encoding: 'utf8' });
+  assert.equal(result.status, 0, result.stderr);
+  const match = `${result.stdout}${result.stderr}`.match(
+    /RESULT\|([^|]+)\|(.+)/,
+  );
+  assert.ok(match, `${result.stdout}\n${result.stderr}`);
+  return { key: match[1], dir: match[2].trim(), cacheRoot };
+}
+
+test('libwasm Cargo cache key is stable and isolates invalidation axes', () => {
+  const fixture = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'kungfu-libwasm-fixture-'),
+  );
+  const sourceA = path.join(fixture, 'source-a');
+  const sourceB = path.join(fixture, 'source-b');
+  fs.mkdirSync(sourceA);
+  fs.mkdirSync(sourceB);
+  const lockA = path.join(sourceA, 'Cargo.lock');
+  const lockB = path.join(sourceB, 'Cargo.lock');
+  fs.writeFileSync(lockA, 'version = 4\n');
+  fs.writeFileSync(lockB, 'version = 4\n');
+
+  const first = resolveCache({ source: sourceA, lock: lockA });
+  const repeat = resolveCache({ source: sourceA, lock: lockA });
+  assert.equal(first.key, repeat.key);
+  assert.match(first.dir, /[/\\]wasmtime[/\\]release[/\\]v1-/);
+  assert.ok(first.dir.startsWith(first.cacheRoot));
+
+  fs.writeFileSync(lockA, 'version = 4\n# changed\n');
+  assert.notEqual(
+    first.key,
+    resolveCache({ source: sourceA, lock: lockA }).key,
+  );
+  assert.notEqual(
+    first.key,
+    resolveCache({ source: sourceB, lock: lockB }).key,
+  );
+  assert.notEqual(
+    first.key,
+    resolveCache({ source: sourceA, lock: lockB, name: 'wasmer' }).key,
+  );
+  assert.notEqual(
+    first.key,
+    resolveCache({ source: sourceA, lock: lockB, toolchain: 'rust-2' }).key,
+  );
+});

--- a/scripts/qualify-libwasm-cargo-cache.mjs
+++ b/scripts/qualify-libwasm-cargo-cache.mjs
@@ -100,6 +100,7 @@ try {
   const results = [];
   for (const engine of ['wasmtime', 'wasmer']) {
     const manifest = path.join(crateRoot, engine, 'Cargo.toml');
+    const manifestDir = path.dirname(manifest);
     const artifact = path.join(
       caches.get(engine).directory,
       'release',
@@ -109,11 +110,16 @@ try {
       ...process.env,
       CARGO_TARGET_DIR: caches.get(engine).directory,
     };
+    const cargoIdentity = run(cargo, ['-Vv'], {
+      capture: true,
+      cwd: manifestDir,
+    }).stdout.split(/\r?\n/)[0];
     const first = run(
       cargo,
       ['build', '--release', '--locked', '--manifest-path', manifest],
       {
         capture: true,
+        cwd: manifestDir,
         env,
       },
     );
@@ -126,6 +132,7 @@ try {
       ['build', '--release', '--locked', '--manifest-path', manifest],
       {
         capture: true,
+        cwd: manifestDir,
         env,
       },
     );
@@ -144,6 +151,7 @@ try {
     );
     results.push({
       engine,
+      cargo: cargoIdentity,
       cache_key: caches.get(engine).key,
       cache_dir: caches.get(engine).directory,
       first_ms: Math.round(first.elapsedMs),

--- a/scripts/qualify-libwasm-cargo-cache.mjs
+++ b/scripts/qualify-libwasm-cargo-cache.mjs
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const modulePath = path.join(
+  root,
+  'framework',
+  'core',
+  '.cmake',
+  'libwasm-cargo-cache.cmake',
+);
+const crateRoot = path.join(root, 'crates', 'libwasm');
+
+function cmakePath(value) {
+  return value.replaceAll('\\', '/').replaceAll('"', '\\"');
+}
+
+function run(command, args, options = {}) {
+  const started = process.hrtime.bigint();
+  const result = spawnSync(command, args, {
+    cwd: root,
+    encoding: 'utf8',
+    stdio: options.capture ? 'pipe' : 'inherit',
+    ...options,
+  });
+  const elapsedMs = Number(process.hrtime.bigint() - started) / 1e6;
+  assert.equal(
+    result.status,
+    0,
+    `${command} ${args.join(' ')} failed\n${result.stdout || ''}${result.stderr || ''}`,
+  );
+  return { ...result, elapsedMs };
+}
+
+function commandPath(name) {
+  const finder = process.platform === 'win32' ? 'where.exe' : 'which';
+  const result = run(finder, [name], { capture: true });
+  return result.stdout.trim().split(/\r?\n/)[0];
+}
+
+function sha256(file) {
+  return crypto
+    .createHash('sha256')
+    .update(fs.readFileSync(file))
+    .digest('hex');
+}
+
+const work = fs.mkdtempSync(path.join(os.tmpdir(), 'kungfu-libwasm-qualify-'));
+try {
+  const cargo = commandPath('cargo');
+  const script = path.join(work, 'resolve.cmake');
+  const cacheRoot = process.env.KF_LIBWASM_CARGO_TARGET_ROOT || '';
+  const lines = [`include("${cmakePath(modulePath)}")`];
+  for (const engine of ['wasmtime', 'wasmer']) {
+    const manifestDir = path.join(crateRoot, engine);
+    lines.push(`kungfu_resolve_libwasm_cargo_target(${engine.toUpperCase()}_DIR ${engine.toUpperCase()}_KEY
+  NAME "${engine}"
+  MANIFEST_DIR "${cmakePath(manifestDir)}"
+  LOCKFILE "${cmakePath(path.join(manifestDir, 'Cargo.lock'))}"
+  SOURCE_ROOT "${cmakePath(root)}"
+  PROFILE release
+  CARGO "${cmakePath(cargo)}"
+  CACHE_ROOT "${cmakePath(cacheRoot)}")`);
+    lines.push(
+      `message("CACHE|${engine}|\${${engine.toUpperCase()}_KEY}|\${${engine.toUpperCase()}_DIR}")`,
+    );
+  }
+  fs.writeFileSync(script, `${lines.join('\n')}\n`);
+  const resolved = run(commandPath('cmake'), ['-P', script], { capture: true });
+  const cacheLines = `${resolved.stdout}${resolved.stderr}`
+    .split(/\r?\n/)
+    .filter((line) => line.startsWith('CACHE|'));
+  assert.equal(cacheLines.length, 2, `${resolved.stdout}\n${resolved.stderr}`);
+
+  const caches = new Map(
+    cacheLines.map((line) => {
+      const [, engine, key, directory] = line.split('|');
+      return [engine, { key, directory }];
+    }),
+  );
+  assert.notEqual(
+    caches.get('wasmtime').directory,
+    caches.get('wasmer').directory,
+  );
+
+  const suffix =
+    process.platform === 'win32'
+      ? '.dll'
+      : process.platform === 'darwin'
+        ? '.dylib'
+        : '.so';
+  const prefix = process.platform === 'win32' ? '' : 'lib';
+  const results = [];
+  for (const engine of ['wasmtime', 'wasmer']) {
+    const manifest = path.join(crateRoot, engine, 'Cargo.toml');
+    const artifact = path.join(
+      caches.get(engine).directory,
+      'release',
+      `${prefix}kungfu_libwasm_${engine}${suffix}`,
+    );
+    const env = {
+      ...process.env,
+      CARGO_TARGET_DIR: caches.get(engine).directory,
+    };
+    const first = run(
+      cargo,
+      ['build', '--release', '--locked', '--manifest-path', manifest],
+      {
+        capture: true,
+        env,
+      },
+    );
+    const firstStage = path.join(work, 'build-a', 'cargo-stage');
+    fs.mkdirSync(firstStage, { recursive: true });
+    fs.copyFileSync(artifact, path.join(firstStage, path.basename(artifact)));
+
+    const second = run(
+      cargo,
+      ['build', '--release', '--locked', '--manifest-path', manifest],
+      {
+        capture: true,
+        env,
+      },
+    );
+    assert.doesNotMatch(
+      `${second.stdout}${second.stderr}`,
+      /^\s*Compiling /m,
+      `${engine} warm build unexpectedly compiled crates`,
+    );
+    const secondStage = path.join(work, 'build-b', 'cargo-stage');
+    fs.mkdirSync(secondStage, { recursive: true });
+    const secondArtifact = path.join(secondStage, path.basename(artifact));
+    fs.copyFileSync(artifact, secondArtifact);
+    assert.equal(
+      sha256(path.join(firstStage, path.basename(artifact))),
+      sha256(secondArtifact),
+    );
+    results.push({
+      engine,
+      cache_key: caches.get(engine).key,
+      cache_dir: caches.get(engine).directory,
+      first_ms: Math.round(first.elapsedMs),
+      warm_ms: Math.round(second.elapsedMs),
+      staged_sha256: sha256(secondArtifact),
+    });
+  }
+
+  console.log(JSON.stringify({ status: 'pass', results }, null, 2));
+} finally {
+  fs.rmSync(work, { recursive: true, force: true });
+}


### PR DESCRIPTION
## What changed

- move production Wasmtime and Wasmer Cargo target directories out of each
  CMake build tree into stable per-engine user-cache slots;
- key each slot by source checkout, actual Cargo/rustc identity and target,
  profile, engine, and lockfile;
- stage each adapter back into its consuming CMake tree so build artifacts do
  not depend on an external-cache path;
- serialize the two heavy Cargo builds inside one CMake graph while retaining
  Cargo's per-target lock as the cross-graph boundary;
- apply the same contract to the shared-membrane qualification slice;
- add a deterministic CMake contract test and
  `./shifu qualify:libwasm-cache` for cold/warm cross-platform evidence.

## Why

The two engine workspaces intentionally remain separate because their Cranelift
dependency lines are incompatible. The previous integration also placed both
target directories under `CMAKE_CURRENT_BINARY_DIR`, so every distinct CMake
tree paid another full Rust dependency build. This change preserves the strict
engine/workspace boundary while making target reuse stable and explicit.

## Impact

Separate CMake trees from one checkout now reuse compiled Rust dependencies.
Different worktrees, engines, toolchains, targets, profiles, or lockfiles cannot
collide. `CARGO_HOME` still owns shared registry downloads; the optional Cargo
mirror remains a transport-only override.

## Validation

- macOS arm64:
  - qualification (Cargo 1.95): Wasmtime `319 ms -> 89 ms`, Wasmer
    `327 ms -> 132 ms` on the corrected warm run;
  - full `./shifu build:core` passed in `117.50 s`; production CMake adapter
    steps reused the cache in `0.45 s` and `0.66 s`.
- agent-120 Linux x64 (Cargo 1.96): Wasmtime `80.2 s -> 78 ms`, Wasmer
  `76.7 s -> 91 ms`.
- DARKHERO Windows x64 (Cargo 1.96): Wasmtime `159.3 s -> 112 ms`, Wasmer
  `164.7 s -> 202 ms`.
- Commit hooks: staged source/format/contract gates passed on both commits.
- `./shifu check`: all changed-file and cache-contract gates passed; the shared
  tooling phase remains blocked by the pre-existing unchanged
  `framework/core/.gyp/run-freeze.js:600` TypeScript inference error.
- CI was not used for this change; the three requested native hosts supplied
  the build evidence.
