### PR TITLE
ci(core): rebind Dev Check lock to public PyPI before frozen sync

### DIFF
--- a/.github/workflows/dev-check.yml
+++ b/.github/workflows/dev-check.yml
@@ -55,6 +55,30 @@ jobs:
         with:
           version: ${{ steps.uv.outputs.version }}
 
+      - name: Rebind frozen registry metadata to public PyPI
+        shell: bash
+        # The committed uv.lock pins artifact URLs to the office devpi mirror
+        # (192.168.100.222:3141), a LAN pull-through cache that GitHub-hosted
+        # runners cannot reach, so a raw `uv sync --frozen` fails with a tcp
+        # connect error. Re-resolve the same packages against public PyPI and
+        # assert the fingerprint is unchanged (same names, versions and hashes;
+        # only the index host differs) before the frozen sync. This mirrors the
+        # embedding-membrane spike workflow. The office LAN fast path is
+        # untouched because only this GitHub-hosted CI job rebinds.
+        run: |
+          fingerprint() {
+            {
+              grep -E '^(\[\[package\]\]|name = |version = |source = )' "$1" |
+                sed -E 's#source = \{ registry = "[^"]+" \}#source = { registry = "<registry>" }#'
+              grep -E '^(sdist = |[[:space:]]+\{ url = ).*hash = ' "$1" |
+                sed -E 's#.*hash = "([^"]+)".*#hash = "\1"#'
+            } | git hash-object --stdin
+          }
+          before="$(fingerprint uv.lock)"
+          uv lock --refresh --default-index https://pypi.org/simple
+          after="$(fingerprint uv.lock)"
+          test "$before" = "$after"
+
       - name: Sync Python environment (frozen)
         shell: bash
         run: uv sync --frozen


### PR DESCRIPTION
The committed `framework/core/uv.lock` pins every artifact URL to the office
devpi mirror (`192.168.100.222:3141`), a LAN pull-through PyPI cache that gives
office / self-hosted builds a fast path over the restricted cross-border link.
GitHub-hosted runners cannot reach that private address, so Dev Check's raw
`uv sync --frozen` fails intermittently with a `tcp connect error` whenever a
wheel is not already cached (4 of the last 6 Dev Check failures were this).

**Fix (option A, matches the embedding-membrane spike workflow):** re-resolve
the same packages against public PyPI and assert the lock fingerprint (names,
versions, hashes) is unchanged before the frozen sync. Only this GitHub-hosted
CI job rebinds — the committed lock and the office LAN fast path are untouched,
and a genuinely missing package still fails.