### PR TITLE
fix(cli): propagate backtest runtime context

### DIFF
--- a/framework/core/src/python/kungfu/cli/commands/__init__.py
+++ b/framework/core/src/python/kungfu/cli/commands/__init__.py
@@ -141,6 +141,7 @@ class PrioritizedCommandGroup(click.Group):
                     "log_level",
                     "runtime_dir",
                     "dataset_dir",
+                    "backtest_dir",
                     "inbox_dir",
                     "runtime_locator",
                     "backtest_locator",

--- a/framework/core/tests/python/test_storage_cli.py
+++ b/framework/core/tests/python/test_storage_cli.py
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+
+from click.testing import CliRunner
+
+from kungfu.cli.commands import __registry__  # noqa: F401
+from kungfu.cli.commands import kfc
+
+
+def test_storage_layout_inherits_the_complete_runtime_context(tmp_path):
+    home = tmp_path / "home"
+
+    result = CliRunner().invoke(
+        kfc, ["--home", str(home), "storage", "layout", "--json"]
+    )
+
+    assert result.exit_code == 0, result.output
+    layout = json.loads(result.output)
+    assert layout["runtime_dir"] == str(home / "runtime")


### PR DESCRIPTION
## Summary
- propagate `backtest_dir` through nested Kungfu CLI contexts
- cover the installed `storage layout --json` path with a regression test

## Validation
- `./shifu check`
- `./shifu check:staged`

The direct product gate exposed this after successfully producing the Linux AppImage: the installed CLI smoke failed because the nested `storage` context lacked `backtest_dir`.