### PR TITLE
feat(query): drive Mission Control from saved profiles

### DIFF
--- a/docs/mission-control-workspaces.md
+++ b/docs/mission-control-workspaces.md
@@ -46,8 +46,8 @@ Episodes, queries, assessments, and decisions.
 | Default GUI view | `work-dashboard` is already the default profile view | It renders Mission/Goal lists and large inline forms before the responsibility questions |
 | Workspace data resolution | ADR-0035 and dev launchers resolve nearest or Git-root `.kungfu` | Packaged Desktop has no Open Workspace or recent-workspace session and defaults to Electron `userData/runtime` |
 | Lazy creation | Dev path discovery can return a nonexistent Git-root `.kungfu` without creating it | GUI boot eagerly joins a runtime and writes runtime support files; no uninitialized workspace state exists |
-| Mission Control | Atlas import, native Mission/Go, completion claims, ADR-0048 state, ADR-0052 TrustReport, Cost/State/Proof, and bundles exist | These capabilities are exposed as tooling panels, not one Mission Home operating loop |
-| Saved Query Catalog | Journal-backed QueryDefinition + ViewSpec revisions, GUI save/delete/run, Node/Python/native parity | It is currently presented under Status/Query Reference and is not composed into Mission Home profiles |
+| Mission Control | Atlas import, native Mission/Go, completion claims, ADR-0048 state, ADR-0052 TrustReport, Cost/State/Proof, and bundles exist | Mission Home now renders the five resolved query-profile answers; decision recording and cross-cut drift remain later slices |
+| Saved Query Catalog | Journal-backed QueryDefinition + ViewSpec revisions, GUI save/delete/run, Node/Python/native parity | Five built-in Mission Control views now share this catalog; override/fork/restore policy still needs a dedicated manager flow |
 | Shell state | Profile and sidebar state persist in the selected runtime ConfigStore | Last/recent workspace must exist before a workspace runtime and therefore needs global config-home state |
 
 The mechanisms are substantially present. The missing work is composition,

--- a/docs/mission-control.md
+++ b/docs/mission-control.md
@@ -1,3 +1,21 @@
+---
+status: draft
+period: 2026-07-12
+theme: kungfu-mission-control
+doc_type: product-design
+source_level: local-files-and-user-consensus
+confidence: high
+sensitivity: public
+evidence_grade: B
+review_state: unreviewed
+last_reviewed: 2026-07-12
+ai_provenance:
+  model_family: GPT-5
+  product: Codex
+  generated_at: 2026-07-12
+  unavailable_details: exact model checkpoint and hidden runtime parameters
+---
+
 # Kungfu Mission Control
 
 Kungfu Mission Control is the local-first responsibility layer that connects a
@@ -178,6 +196,24 @@ now runs the same ADR-0048 `fact-state` QueryDefinition at head or an exact
 system-time cut, then persists an ADR-0052 `mission-progress-is-reasonable`
 assessment. `kungfu atlas assess-mission` and the Work Dashboard consume the
 same report identity and proof root.
+
+The TrustReport also resolves five versioned `kungfu.mission-control` saved
+views over that same QueryDefinition. Their ViewSpec selects one of the five
+Mission Home questions; `kungfu.mission-control.reducer/v1` owns the
+purpose-bound answer and never moves query semantics into React. The resolved
+views are journal-backed in the selected workspace Saved Query Catalog, so an
+agent can inspect, run, export, or fork them with `kungfu query saved ...` and
+the GUI can manage the same revisions. Rows, proof, and resume tokens remain
+rebuildable runtime state rather than portable authority.
+
+Mission Home now resumes the fact-state changelog with stable logical fact
+keys and a system-time frontier. A correction to one source claim is therefore
+an upsert of that claim, not a retract plus an unrelated identity. The desktop
+refresh bus advances the stream and re-runs the purpose-bound assessment so
+newly admitted Mission/Go subjects are discovered. A stream `Gap`, schema
+failure, or interrupted resume remains visible and falls back to the bounded
+assessment snapshot; it does not blank the renderer or silently claim live
+freshness.
 
 That report now embeds the first `Cost/State/Proof` profile projection. Cost
 comes from linked Rewind `CostSnapshot` journal facts, responsibility state is

--- a/extensions/fact-manager/src/view/index.tsx
+++ b/extensions/fact-manager/src/view/index.tsx
@@ -56,7 +56,13 @@ function downloadJson(name: string, value: StorageValue) {
   URL.revokeObjectURL(url);
 }
 
-function FactManagerView({ caps }: { caps: KfxCapabilities; shell: Shell }) {
+function FactManagerView({
+  caps,
+  shell,
+}: {
+  caps: KfxCapabilities;
+  shell: Shell;
+}) {
   const { storage } = caps;
   const [types, setTypes] = React.useState<FactTypeRow[]>([]);
   const [selectedTypeKey, setSelectedTypeKey] = React.useState('');
@@ -131,6 +137,7 @@ function FactManagerView({ caps }: { caps: KfxCapabilities; shell: Shell }) {
   }, [selectedTypeKey, storage]);
 
   React.useEffect(() => refresh(), [refresh]);
+  React.useEffect(() => shell.onRefresh(refresh), [shell, refresh]);
 
   const createType = () => {
     try {

--- a/extensions/rewind-inspector/src/view/index.tsx
+++ b/extensions/rewind-inspector/src/view/index.tsx
@@ -10,9 +10,9 @@ import {
   type RewindSpan,
   RunStatus,
 } from '@kungfu-tech/api/capability';
-import React from 'react';
 import type { KfxCapabilities, Shell } from '@kungfu-tech/kfx';
 import { headingStyle, mono, panelStyle } from '@kungfu-tech/kfx';
+import React from 'react';
 
 const COLOR = {
   ok: '#4ec9b0',
@@ -300,6 +300,8 @@ function RewindInspectorView({
   React.useEffect(() => {
     refresh();
   }, [refresh]);
+
+  React.useEffect(() => shell.onRefresh(refresh), [shell, refresh]);
 
   const run = React.useMemo(() => {
     if (!selectedRun) return null;

--- a/extensions/system/status/src/view/query-reference.tsx
+++ b/extensions/system/status/src/view/query-reference.tsx
@@ -228,6 +228,19 @@ function referenceView(state: QueryChangelogState, spec: QueryViewSpec) {
       return <QueryCausalGraphReference state={state} spec={spec} />;
     case 'attention':
       return <QueryAttentionReference state={state} spec={spec} />;
+    case 'mission-control':
+      return (
+        <div style={{ ...mono, color: '#cccccc' }}>
+          <div style={{ color: '#9cdcfe', marginBottom: 6 }}>
+            {spec.questionId} · {spec.reducer}
+          </div>
+          <div>
+            {queryRows(state).length} canonical fact row(s) are available. The
+            purpose-bound answer is resolved with the TrustReport in Mission
+            Control; this catalog view does not invent a second reducer.
+          </div>
+        </div>
+      );
   }
 }
 
@@ -266,6 +279,13 @@ const specs: Record<QueryViewSpec['kind'], QueryViewSpec> = {
     elapsedField: 'elapsed_ns',
     attributionField: 'attribution_counts',
     evidenceField: 'matched_episode_ids',
+  },
+  'mission-control': {
+    kind: 'mission-control',
+    profileId: 'kungfu.mission-control',
+    profileVersion: '1',
+    questionId: 'observed-progress',
+    reducer: 'kungfu.mission-control.reducer/v1',
   },
 };
 

--- a/extensions/work-dashboard/package.json
+++ b/extensions/work-dashboard/package.json
@@ -46,6 +46,7 @@
           "ledger",
           "work",
           "atlas",
+          "storage",
           "workspace"
         ]
       }

--- a/extensions/work-dashboard/src/view/index.tsx
+++ b/extensions/work-dashboard/src/view/index.tsx
@@ -10,6 +10,9 @@ import type {
   AtlasImportInfo,
   AtlasMission,
   AtlasMissionControlReport,
+  QueryChangelogState,
+  QueryResumeToken,
+  Storage,
   WorkItem,
   WorkspaceActionPreview,
   WorkspaceActionReceipt,
@@ -20,7 +23,11 @@ import type {
   WorkspaceGuidanceInspection,
   WorkspaceGuidanceIntent,
 } from '@kungfu-tech/api/capability';
-import { WORK_STATUS_NAMES } from '@kungfu-tech/api/capability';
+import {
+  WORK_STATUS_NAMES,
+  applyQueryChangelogPage,
+  emptyQueryChangelogState,
+} from '@kungfu-tech/api/capability';
 import type { KfxCapabilities, Shell } from '@kungfu-tech/kfx';
 import { headingStyle, mono, panelStyle } from '@kungfu-tech/kfx';
 import React from 'react';
@@ -310,9 +317,11 @@ function AtlasUnavailableView() {
 function AtlasProjectionView({
   atlas,
   shell,
+  storage,
 }: {
   atlas: Atlas;
   shell: Shell;
+  storage: Storage;
 }) {
   const [repoRoot, setRepoRoot] = React.useState(atlas.defaultRepoRoot);
   const [missions, setMissions] = React.useState<AtlasMission[]>(() =>
@@ -334,6 +343,17 @@ function AtlasProjectionView({
   const [completionReport, setCompletionReport] =
     React.useState<AtlasMissionControlReport | null>(null);
   const [completionError, setCompletionError] = React.useState<string>('');
+  const [queryStream, setQueryStream] = React.useState<QueryChangelogState>(
+    emptyQueryChangelogState,
+  );
+  const [queryStreamError, setQueryStreamError] = React.useState('');
+  const queryStreamState = React.useRef<QueryChangelogState>(
+    emptyQueryChangelogState(),
+  );
+  const queryStreamDefinitionRoot = React.useRef('');
+  const queryStreamResume = React.useRef<QueryResumeToken | undefined>(
+    undefined,
+  );
   const [newMissionId, setNewMissionId] = React.useState('');
   const [newMissionTitle, setNewMissionTitle] = React.useState('');
   const [newMissionIntent, setNewMissionIntent] = React.useState('');
@@ -369,28 +389,74 @@ function AtlasProjectionView({
     reload();
   }, [reload]);
 
-  React.useEffect(() => shell.onRefresh(reload), [shell, reload]);
+  const advanceQueryStream = React.useCallback(
+    (report: AtlasMissionControlReport) => {
+      const definition = report.query_profile.views[0]?.saved_view.definition;
+      if (!definition)
+        throw new Error('Mission Control query profile has no view');
+      let state = queryStreamState.current;
+      if (queryStreamDefinitionRoot.current !== report.query_definition_root) {
+        state = emptyQueryChangelogState();
+        queryStreamDefinitionRoot.current = report.query_definition_root;
+        queryStreamResume.current = undefined;
+      }
+      let complete = false;
+      for (let pageCount = 0; pageCount < 8 && !complete; pageCount += 1) {
+        const page = storage.factChangelog(
+          definition,
+          queryStreamResume.current,
+          100,
+        );
+        state = applyQueryChangelogPage(state, page);
+        queryStreamResume.current = page.resume_token;
+        complete = page.complete;
+        if (state.gap) break;
+      }
+      queryStreamState.current = state;
+      setQueryStream(state);
+      setQueryStreamError(complete ? '' : 'query stream is catching up');
+    },
+    [storage],
+  );
 
-  React.useEffect(() => {
+  const refreshAssessment = React.useCallback(() => {
     if (selectedMission === 'all') {
       setTrustReport(null);
       setTrustError('');
       setCompletionReport(null);
       setCompletionError('');
+      setQueryStreamError('');
       return;
     }
     try {
-      setTrustReport(
-        atlas.assessMission(selectedMission, {
-          source: selectedMissionSource,
-        }),
-      );
+      const report = atlas.assessMission(selectedMission, {
+        source: selectedMissionSource,
+      });
+      setTrustReport(report);
       setTrustError('');
+      try {
+        advanceQueryStream(report);
+      } catch (error) {
+        setQueryStreamError(
+          `degraded snapshot fallback · ${(error as Error).message}`,
+        );
+      }
     } catch (error) {
       setTrustReport(null);
       setTrustError((error as Error).message);
     }
-  }, [atlas, selectedMission, selectedMissionSource]);
+  }, [atlas, selectedMission, selectedMissionSource, advanceQueryStream]);
+
+  React.useEffect(() => {
+    refreshAssessment();
+  }, [refreshAssessment]);
+
+  const refreshAll = React.useCallback(() => {
+    reload();
+    refreshAssessment();
+  }, [reload, refreshAssessment]);
+
+  React.useEffect(() => shell.onRefresh(refreshAll), [shell, refreshAll]);
 
   const importNow = () => {
     if (!repoRoot.trim()) {
@@ -548,8 +614,6 @@ function AtlasProjectionView({
     visibleGoals.find((goal) => goal.goal_id === selectedGoal) ??
     allGoals.find((goal) => goal.goal_id === selectedGoal) ??
     null;
-  const currentMission =
-    missions.find((mission) => mission.mission_id === selectedMission) ?? null;
   const missionGoals = allGoals.filter(
     (goal) => goal.mission_id === selectedMission,
   );
@@ -558,44 +622,7 @@ function AtlasProjectionView({
     const status = goal.status ?? 'unknown';
     missionGoalCounts.set(status, (missionGoalCounts.get(status) ?? 0) + 1);
   }
-  const statusSummary = [...missionGoalCounts.entries()]
-    .map(([status, count]) => `${status}=${count}`)
-    .join(' · ');
-  const fiveAnswers = [
-    {
-      question: 'What are we trying to achieve?',
-      answer: currentMission
-        ? `${currentMission.title ?? currentMission.mission_id} — ${currentMission.intent ?? 'intent not declared'}${currentMission.stage_name ? ` · stage ${currentMission.stage_name}` : ''}`
-        : 'Not yet declared. Create or import a Mission.',
-    },
-    {
-      question: 'What actually happened?',
-      answer: missionGoals.length
-        ? `${missionGoals.length} Go(s) at this cut${statusSummary ? ` · ${statusSummary}` : ''}`
-        : 'No admitted Go activity is visible at this cut.',
-    },
-    {
-      question: 'What does the evidence establish at this cut?',
-      answer: trustReport
-        ? `${trustReport.state.canonical_state ? 'canonical' : 'degraded'} cut · ${trustReport.findings.length} finding(s) · proof ${trustReport.query_proof_root.slice(-12)}`
-        : trustError || 'No purpose-bound assessment is available yet.',
-    },
-    {
-      question: 'Is delegated work still fit for purpose?',
-      answer: trustReport
-        ? `${trustReport.fitness} · assessment ${trustReport.assessment.state} · residual limits ${trustReport.known_limits.length}`
-        : 'insufficient — select a Mission and assess the current cut.',
-    },
-    {
-      question: 'Who should act next?',
-      answer:
-        currentGoal?.next_action ??
-        currentMission?.next_action ??
-        (trustReport?.fitness === 'fit'
-          ? 'Continue under the current purpose and evidence boundary.'
-          : 'User or agent should adjust, supply evidence, or record a decision.'),
-    },
-  ];
+  const fiveAnswers = trustReport?.query_profile.answers ?? [];
 
   return (
     <div
@@ -633,7 +660,7 @@ function AtlasProjectionView({
           <SmallButton onClick={() => setActionPanel('bundle')}>
             Bundle
           </SmallButton>
-          <SmallButton onClick={reload}>refresh</SmallButton>
+          <SmallButton onClick={refreshAll}>refresh</SmallButton>
           {info && (
             <span style={{ ...mono, color: '#858585' }}>
               {info.missions}M · {info.goals}G · {info.markers} markers
@@ -651,6 +678,33 @@ function AtlasProjectionView({
         <main style={{ flex: 1, minWidth: 0, overflow: 'auto' }}>
           <section style={{ ...panelStyle, marginBottom: 8 }}>
             <h2 style={headingStyle}>Mission Home · current cut</h2>
+            {trustReport && (
+              <div style={{ ...mono, color: '#858585', marginBottom: 5 }}>
+                profile {trustReport.query_profile.profile.version} ·{' '}
+                {trustReport.query_profile.views.length} saved views · proof{' '}
+                {trustReport.query_profile.query_proof_root.slice(-12)}
+              </div>
+            )}
+            {trustReport && (
+              <div
+                style={{
+                  ...mono,
+                  color:
+                    queryStream.gap || queryStreamError ? '#dcdcaa' : '#4ec9b0',
+                  marginBottom: 5,
+                }}
+              >
+                stream {queryStream.frontier.kind} ·{' '}
+                {queryStream.frontier.record_count} rows
+                {queryStream.gap ? ' · gap: recovery required' : ''}
+                {queryStreamError ? ` · ${queryStreamError}` : ''}
+              </div>
+            )}
+            {!trustReport && (
+              <div style={{ ...mono, color: '#858585' }}>
+                {trustError || 'Select a Mission to resolve its query profile.'}
+              </div>
+            )}
             {fiveAnswers.map((row) => (
               <div
                 key={row.question}
@@ -662,7 +716,10 @@ function AtlasProjectionView({
                 <div style={{ ...mono, color: '#9cdcfe', marginBottom: 3 }}>
                   {row.question}
                 </div>
-                <div style={{ ...mono, color: '#cccccc' }}>{row.answer}</div>
+                <div style={{ ...mono, color: '#cccccc' }}>{row.summary}</div>
+                <div style={{ ...mono, color: '#858585', marginTop: 2 }}>
+                  {row.status} · {row.question_id}
+                </div>
               </div>
             ))}
           </section>
@@ -1314,7 +1371,11 @@ function WorkDashboardView({
           </SmallButton>
         </div>
         {atlas ? (
-          <AtlasProjectionView atlas={atlas} shell={shell} />
+          <AtlasProjectionView
+            atlas={atlas}
+            shell={shell}
+            storage={caps.storage}
+          />
         ) : (
           <AtlasUnavailableView />
         )}

--- a/extensions/work-dashboard/src/view/index.tsx
+++ b/extensions/work-dashboard/src/view/index.tsx
@@ -307,7 +307,13 @@ function AtlasUnavailableView() {
   );
 }
 
-function AtlasProjectionView({ atlas }: { atlas: Atlas }) {
+function AtlasProjectionView({
+  atlas,
+  shell,
+}: {
+  atlas: Atlas;
+  shell: Shell;
+}) {
   const [repoRoot, setRepoRoot] = React.useState(atlas.defaultRepoRoot);
   const [missions, setMissions] = React.useState<AtlasMission[]>(() =>
     atlas.missions(),
@@ -362,6 +368,8 @@ function AtlasProjectionView({ atlas }: { atlas: Atlas }) {
   React.useEffect(() => {
     reload();
   }, [reload]);
+
+  React.useEffect(() => shell.onRefresh(reload), [shell, reload]);
 
   React.useEffect(() => {
     if (selectedMission === 'all') {
@@ -1306,7 +1314,7 @@ function WorkDashboardView({
           </SmallButton>
         </div>
         {atlas ? (
-          <AtlasProjectionView atlas={atlas} />
+          <AtlasProjectionView atlas={atlas} shell={shell} />
         ) : (
           <AtlasUnavailableView />
         )}

--- a/extensions/work-dashboard/src/view/index.tsx
+++ b/extensions/work-dashboard/src/view/index.tsx
@@ -391,7 +391,7 @@ function AtlasProjectionView({
 
   const advanceQueryStream = React.useCallback(
     (report: AtlasMissionControlReport) => {
-      const definition = report.query_profile.views[0]?.saved_view.definition;
+      const definition = report.query_profile?.views[0]?.saved_view.definition;
       if (!definition)
         throw new Error('Mission Control query profile has no view');
       let state = queryStreamState.current;
@@ -622,7 +622,7 @@ function AtlasProjectionView({
     const status = goal.status ?? 'unknown';
     missionGoalCounts.set(status, (missionGoalCounts.get(status) ?? 0) + 1);
   }
-  const fiveAnswers = trustReport?.query_profile.answers ?? [];
+  const fiveAnswers = trustReport?.query_profile?.answers ?? [];
 
   return (
     <div
@@ -678,7 +678,7 @@ function AtlasProjectionView({
         <main style={{ flex: 1, minWidth: 0, overflow: 'auto' }}>
           <section style={{ ...panelStyle, marginBottom: 8 }}>
             <h2 style={headingStyle}>Mission Home · current cut</h2>
-            {trustReport && (
+            {trustReport?.query_profile && (
               <div style={{ ...mono, color: '#858585', marginBottom: 5 }}>
                 profile {trustReport.query_profile.profile.version} ·{' '}
                 {trustReport.query_profile.views.length} saved views · proof{' '}

--- a/framework/api/src/capability/atlas.ts
+++ b/framework/api/src/capability/atlas.ts
@@ -92,7 +92,7 @@ export type AtlasMissionControlReport = {
   report_hash?: string;
   query_definition_root: string;
   query_proof_root: string;
-  query_profile: {
+  query_profile?: {
     schema: 'kungfu.mission-control.query-profile/v1';
     profile_hash: string;
     profile: {

--- a/framework/api/src/capability/atlas.ts
+++ b/framework/api/src/capability/atlas.ts
@@ -1,3 +1,5 @@
+import type { SavedQueryView } from './query';
+
 // Mission Control capability handle over the `kungfu atlas` pre-release CLI.
 // Atlas remains authority for imported facts; native Mission/Go/claim writes
 // and portable bundle operations enter the same local Fact Library.
@@ -90,6 +92,33 @@ export type AtlasMissionControlReport = {
   report_hash?: string;
   query_definition_root: string;
   query_proof_root: string;
+  query_profile: {
+    schema: 'kungfu.mission-control.query-profile/v1';
+    profile_hash: string;
+    profile: {
+      id: 'kungfu.mission-control';
+      version: '1';
+      reducer: 'kungfu.mission-control.reducer/v1';
+    };
+    mission_subject: string;
+    query_definition_root: string;
+    query_proof_root: string;
+    result_hash: string;
+    views: Array<{
+      question_id: string;
+      query_id: string;
+      revision: number;
+      saved_view_hash: string;
+      saved_view: SavedQueryView;
+    }>;
+    answers: Array<{
+      question_id: string;
+      question: string;
+      status: string;
+      summary: string;
+      data: Record<string, unknown>;
+    }>;
+  };
   assessment: {
     state: string;
     reused?: boolean;

--- a/framework/api/src/capability/query.ts
+++ b/framework/api/src/capability/query.ts
@@ -33,6 +33,11 @@ export type QueryFrontier =
       kind: 'manifest_frame_uid';
       manifest_frame_uid: string;
       record_count: string;
+    }
+  | {
+      kind: 'system_time';
+      system_time: string;
+      record_count: string;
     };
 
 export type QueryResultSchema = {
@@ -136,12 +141,25 @@ export type AttentionViewSpec = {
   attributionField: string;
   evidenceField: string;
 };
+export type MissionControlViewSpec = {
+  kind: 'mission-control';
+  profileId: 'kungfu.mission-control';
+  profileVersion: '1';
+  questionId:
+    | 'mission-intent'
+    | 'observed-progress'
+    | 'evidence-at-cut'
+    | 'fitness-for-purpose'
+    | 'next-responsibility';
+  reducer: 'kungfu.mission-control.reducer/v1';
+};
 export type QueryViewSpec =
   | TableViewSpec
   | TimelineViewSpec
   | DiffViewSpec
   | CausalGraphViewSpec
-  | AttentionViewSpec;
+  | AttentionViewSpec
+  | MissionControlViewSpec;
 
 export type SavedQueryView = {
   schema: 'kungfu.query.saved-view/v1';
@@ -285,9 +303,14 @@ export function parseSavedQueryView(value: unknown): SavedQueryView {
   }
   if (
     !saved.view ||
-    !['table', 'timeline', 'diff', 'causal-graph', 'attention'].includes(
-      saved.view.kind,
-    )
+    ![
+      'table',
+      'timeline',
+      'diff',
+      'causal-graph',
+      'attention',
+      'mission-control',
+    ].includes(saved.view.kind)
   ) {
     throw new Error('saved query view requires a supported ViewSpec');
   }

--- a/framework/api/tests/query.test.ts
+++ b/framework/api/tests/query.test.ts
@@ -174,3 +174,28 @@ test('attention saved view remains presentation-only', () => {
     definition.temporal_pattern,
   );
 });
+
+test('saved Mission Control view preserves query ownership', () => {
+  const saved = parseSavedQueryView({
+    schema: 'kungfu.query.saved-view/v1',
+    name: 'What actually happened?',
+    definition: {
+      schema: 'kungfu.query.definition/v1',
+      basis: { cut: { kind: 'head' } },
+      object: 'fact-state',
+      subject_keys: ['atlas:mission-a'],
+      limit: 1,
+      evidence: 'proof',
+    },
+    view: {
+      kind: 'mission-control',
+      profileId: 'kungfu.mission-control',
+      profileVersion: '1',
+      questionId: 'observed-progress',
+      reducer: 'kungfu.mission-control.reducer/v1',
+    },
+  });
+
+  assert.equal(saved.view.kind, 'mission-control');
+  assert.equal(saved.definition.object, 'fact-state');
+});

--- a/framework/core/src/libkungfu/include/kungfu/runtime/query/fact_query.h
+++ b/framework/core/src/libkungfu/include/kungfu/runtime/query/fact_query.h
@@ -171,11 +171,12 @@ struct query_result {
   std::string result_hash = {};
 };
 
-enum class frontier_kind { Empty, ManifestFrameUid };
+enum class frontier_kind { Empty, ManifestFrameUid, SystemTime };
 
 struct query_frontier {
   frontier_kind kind = frontier_kind::Empty;
   uint64_t manifest_frame_uid = 0;
+  int64_t system_time = 0;
   uint64_t record_count = 0;
 };
 
@@ -284,6 +285,9 @@ struct changelog_page {
 [[nodiscard]] changelog_page run_episode_changelog(const std::string &runtime_dir, const logical_plan &plan,
                                                    const nlohmann::json &resume_token = nlohmann::json::object(),
                                                    uint64_t max_messages = 100);
+[[nodiscard]] changelog_page run_query_changelog(const std::string &runtime_dir, const logical_plan &plan,
+                                                 const nlohmann::json &resume_token = nlohmann::json::object(),
+                                                 uint64_t max_messages = 100);
 
 [[nodiscard]] query_result run_episode_authority_scan(const std::string &runtime_dir, const logical_plan &plan);
 

--- a/framework/core/src/libkungfu/src/runtime/query/fact_query.cpp
+++ b/framework/core/src/libkungfu/src/runtime/query/fact_query.cpp
@@ -1056,36 +1056,54 @@ nlohmann::json frontier_json(const query_frontier &frontier) {
   if (frontier.kind == frontier_kind::Empty) {
     return {{"kind", "empty"}, {"record_count", "0"}};
   }
+  if (frontier.kind == frontier_kind::SystemTime) {
+    return {{"kind", "system_time"},
+            {"system_time", std::to_string(frontier.system_time)},
+            {"record_count", std::to_string(frontier.record_count)}};
+  }
   return {{"kind", "manifest_frame_uid"},
           {"manifest_frame_uid", std::to_string(frontier.manifest_frame_uid)},
           {"record_count", std::to_string(frontier.record_count)}};
 }
 
 query_frontier parse_frontier(const nlohmann::json &value, const char *path) {
-  reject_unknown_fields(value, {"kind", "manifest_frame_uid", "record_count"}, path);
+  reject_unknown_fields(value, {"kind", "manifest_frame_uid", "system_time", "record_count"}, path);
   const auto kind = optional_text(value, "kind");
   if (kind == "empty") {
-    if (value.contains("manifest_frame_uid")) {
-      throw std::invalid_argument(std::string(path) + " empty frontier must not carry manifest_frame_uid");
+    if (value.contains("manifest_frame_uid") || value.contains("system_time")) {
+      throw std::invalid_argument(std::string(path) + " empty frontier must not carry a position");
     }
     return {};
   }
   if (kind == "manifest_frame_uid") {
-    return {frontier_kind::ManifestFrameUid, optional_uint64(value, "manifest_frame_uid"),
+    return {frontier_kind::ManifestFrameUid, optional_uint64(value, "manifest_frame_uid"), 0,
             optional_uint64(value, "record_count")};
   }
-  throw std::invalid_argument(std::string(path) + " kind must be empty or manifest_frame_uid");
+  if (kind == "system_time") {
+    const auto system_time = int64_value(value.at("system_time"), "frontier.system_time");
+    if (system_time <= 0) {
+      throw std::invalid_argument(std::string(path) + " system_time must be positive");
+    }
+    return {frontier_kind::SystemTime, 0, system_time, optional_uint64(value, "record_count")};
+  }
+  throw std::invalid_argument(std::string(path) + " kind must be empty, manifest_frame_uid, or system_time");
 }
 
 query_frontier result_frontier(const query_result &result) {
   const auto &resolved = result.proof.cut.at("resolved");
+  const auto record_count = optional_uint64(result.proof.authority, "record_count");
+  if (record_count == 0) {
+    return {};
+  }
+  if (result.definition.object == "fact-state") {
+    return {frontier_kind::SystemTime, 0, int64_value(resolved.at("system_time"), "cut.system_time"), record_count};
+  }
   const auto kind = optional_text(resolved, "kind");
   if (kind == "empty") {
     return {};
   }
   if (kind == "manifest_frame_uid") {
-    return {frontier_kind::ManifestFrameUid, optional_uint64(resolved, "manifest_frame_uid"),
-            optional_uint64(result.proof.authority, "record_count")};
+    return {frontier_kind::ManifestFrameUid, optional_uint64(resolved, "manifest_frame_uid"), 0, record_count};
   }
   throw std::runtime_error("query result has no resumable frontier");
 }
@@ -1099,11 +1117,21 @@ nlohmann::json result_frontier_evidence_json(const query_result &result) {
 bool same_frontier(const query_frontier &left, const query_frontier &right) {
   return left.kind == right.kind &&
          (left.kind == frontier_kind::Empty ||
-          (left.manifest_frame_uid == right.manifest_frame_uid && left.record_count == right.record_count));
+          (left.manifest_frame_uid == right.manifest_frame_uid && left.system_time == right.system_time &&
+           left.record_count == right.record_count));
 }
 
 bool frontier_regressed(const query_frontier &from, const query_frontier &target) {
-  return target.record_count < from.record_count;
+  if (target.record_count < from.record_count) {
+    return true;
+  }
+  // frame_uid is an opaque manifest identity, not an ordinal. Append order is
+  // proved by the fold's record_count; comparing uid numerically can report a
+  // false regression when a later frame happens to have a smaller hash-like id.
+  if (from.kind == frontier_kind::SystemTime && target.kind == frontier_kind::SystemTime) {
+    return target.system_time < from.system_time;
+  }
+  return false;
 }
 
 nlohmann::json resume_token_payload_json(const query_resume_token &token) {
@@ -1134,10 +1162,29 @@ std::string changelog_batch_id(const logical_plan &plan, const query_frontier &f
 
 query_result run_at_frontier(const std::string &runtime_dir, const query_definition &definition,
                              const query_frontier &frontier) {
+  if (frontier.kind == frontier_kind::Empty) {
+    query_result empty;
+    empty.definition = definition;
+    empty.plan = plan_query(definition);
+    empty.row_schema = empty.plan.row_schema;
+    empty.result_hash =
+        json_hash({{"result_schema", result_schema_json(empty.row_schema)}, {"rows", nlohmann::json::array()}});
+    return empty;
+  }
   auto bounded = definition;
+  if (definition.object == "fact-state") {
+    if (frontier.kind != frontier_kind::SystemTime) {
+      throw std::runtime_error("fact-state changelog frontier must use system_time");
+    }
+    bounded.basis.selected_cut.kind = cut_kind::SystemTime;
+    bounded.basis.selected_cut.system_time = frontier.system_time;
+    return run_fact_state_authority_scan(runtime_dir, plan_query(bounded));
+  }
+  if (frontier.kind != frontier_kind::ManifestFrameUid) {
+    throw std::runtime_error("episode changelog frontier must use manifest_frame_uid");
+  }
   bounded.basis.selected_cut.kind = cut_kind::ManifestFrameUid;
-  bounded.basis.selected_cut.manifest_frame_uid =
-      frontier.kind == frontier_kind::Empty ? 0 : frontier.manifest_frame_uid;
+  bounded.basis.selected_cut.manifest_frame_uid = frontier.manifest_frame_uid;
   return run_episode_authority_scan(runtime_dir, plan_query(bounded));
 }
 
@@ -1147,6 +1194,12 @@ std::string row_key(const nlohmann::json &row) {
   }
   if (row.contains("match_id") && row.at("match_id").is_string()) {
     return row.at("match_id").get<std::string>();
+  }
+  if (row.contains("fact_surface_id") && row.contains("subject_key") && row.contains("source_id")) {
+    return json_hash({{"contract_world_id", row.value("contract_world_id", "")},
+                      {"fact_surface_id", row.at("fact_surface_id")},
+                      {"subject_key", row.at("subject_key")},
+                      {"source_id", row.at("source_id")}});
   }
   if (!row.contains("episode_id")) {
     throw std::runtime_error("query changelog row has neither match_id nor episode_id key");
@@ -1185,6 +1238,11 @@ nlohmann::json evidence_reference(const query_result &result, const nlohmann::js
   if (row.contains("episode_id")) {
     // Preserve the Q3 evidence edge: uint64 identities are rendered as text.
     reference["episode_id"] = row_key(row);
+    if (row.contains("fact_surface_id")) {
+      reference["episode_id"] = row.at("episode_id");
+      reference["payload_hash"] = row.value("payload_hash", "");
+      reference["payload_ref"] = row.value("payload_ref", "");
+    }
   }
   if (row.contains("match_id")) {
     reference["row_key"] = row_key(row);
@@ -1286,8 +1344,8 @@ nlohmann::json changelog_page_json(const changelog_page &page) {
           {"complete", page.complete}};
 }
 
-changelog_page run_episode_changelog(const std::string &runtime_dir, const logical_plan &plan,
-                                     const nlohmann::json &resume_token, uint64_t max_messages) {
+changelog_page run_query_changelog(const std::string &runtime_dir, const logical_plan &plan,
+                                   const nlohmann::json &resume_token, uint64_t max_messages) {
   if (plan.definition.basis.selected_cut.kind != cut_kind::Head) {
     throw std::invalid_argument("continuous query requires a head cut");
   }
@@ -1295,7 +1353,8 @@ changelog_page run_episode_changelog(const std::string &runtime_dir, const logic
     throw std::invalid_argument("max_messages must be between 1 and 10000");
   }
 
-  const auto current = run_episode_authority_scan(runtime_dir, plan);
+  const auto current = plan.definition.object == "fact-state" ? run_fact_state_authority_scan(runtime_dir, plan)
+                                                              : run_episode_authority_scan(runtime_dir, plan);
   const auto current_frontier = result_frontier(current);
   query_resume_token cursor;
   bool continuing_batch = false;
@@ -1410,6 +1469,14 @@ changelog_page run_episode_changelog(const std::string &runtime_dir, const logic
   }
   seal_resume_token(page.resume_token);
   return page;
+}
+
+changelog_page run_episode_changelog(const std::string &runtime_dir, const logical_plan &plan,
+                                     const nlohmann::json &resume_token, uint64_t max_messages) {
+  if (plan.definition.object != "episodes") {
+    throw std::invalid_argument("episode changelog requires object=episodes");
+  }
+  return run_query_changelog(runtime_dir, plan, resume_token, max_messages);
 }
 
 namespace {

--- a/framework/core/src/libkungfu/src/runtime/query/saved_query_catalog.cpp
+++ b/framework/core/src/libkungfu/src/runtime/query/saved_query_catalog.cpp
@@ -106,7 +106,7 @@ nlohmann::json normalize_saved_view(const nlohmann::json &input) {
   }
   const auto view_kind = text_or(input.at("view"), "kind");
   if (view_kind != "table" && view_kind != "timeline" && view_kind != "diff" && view_kind != "causal-graph" &&
-      view_kind != "attention") {
+      view_kind != "attention" && view_kind != "mission-control") {
     throw std::invalid_argument("saved query requires a supported ViewSpec");
   }
   const auto definition = parse_query_definition(input.at("definition"));

--- a/framework/core/src/libkungfu/src/runtime/storage/service.cpp
+++ b/framework/core/src/libkungfu/src/runtime/storage/service.cpp
@@ -4746,14 +4746,11 @@ public:
 
   [[nodiscard]] nlohmann::json fact_changelog(const storage_service_options &options) const {
     const auto definition = query::parse_query_definition(options.query_definition);
-    if (definition.object != "episodes") {
-      throw std::invalid_argument("fact-state changelog is not implemented; request a proof snapshot");
-    }
     const auto plan = query::plan_query(definition);
     const auto resume_token = object_or_empty(options.operation_options, "resume_token");
     const auto max_messages = uint64_or(options.operation_options, "max_messages", 100);
     return query::changelog_page_json(
-        query::run_episode_changelog(options.runtime_dir, plan, resume_token, max_messages));
+        query::run_query_changelog(options.runtime_dir, plan, resume_token, max_messages));
   }
 
   [[nodiscard]] nlohmann::json saved_query_catalog(const storage_service_options &options) const {

--- a/framework/core/src/python/kungfu/atlas/mission_control.py
+++ b/framework/core/src/python/kungfu/atlas/mission_control.py
@@ -36,6 +36,22 @@ PROGRESS_CLAIM = "mission-progress-is-reasonable"
 PROGRESS_PURPOSE = "operator-review"
 COST_STATE_PROOF_PROFILE_ID = "kungfu.profile.delegated-work-cost-state-proof"
 COST_STATE_PROOF_PROFILE_VERSION = "1"
+MISSION_CONTROL_PROFILE_ID = "kungfu.mission-control"
+MISSION_CONTROL_PROFILE_VERSION = "1"
+MISSION_CONTROL_REDUCER = "kungfu.mission-control.reducer/v1"
+MISSION_CONTROL_QUESTIONS = (
+    ("mission-intent", "What are we trying to achieve?"),
+    ("observed-progress", "What actually happened?"),
+    ("evidence-at-cut", "What does the evidence establish at this cut?"),
+    (
+        "fitness-for-purpose",
+        "Is the delegated work still fit for the purpose that matters?",
+    ),
+    (
+        "next-responsibility",
+        "Who should continue, adjust, stop, approve, or supply evidence next?",
+    ),
+)
 ATTRIBUTION_NAMES = {
     0: "exact-run",
     1: "exact-session",
@@ -1344,6 +1360,211 @@ def build_cost_state_proof_profile(
     return profile
 
 
+def _mission_control_answers(
+    state: dict[str, Any],
+    *,
+    fitness: str,
+    assessment_state: str,
+    findings: list[str],
+    known_limits: list[str],
+) -> list[dict[str, Any]]:
+    mission = (state.get("mission") or {}).get("payload", {}).get("record", {})
+    goals = [row.get("payload", {}).get("record", {}) for row in state.get("goals", [])]
+    statuses: dict[str, int] = {}
+    for goal in goals:
+        status = str(goal.get("status") or "unknown")
+        statuses[status] = statuses.get(status, 0) + 1
+    status_summary = " · ".join(
+        f"{status}={statuses[status]}" for status in sorted(statuses)
+    )
+
+    intent = "Not yet declared. Create or import a Mission."
+    if mission:
+        identity = str(mission.get("title") or mission.get("mission_id") or "Mission")
+        intent = f"{identity} — {mission.get('intent') or 'intent not declared'}"
+        if mission.get("stage_name"):
+            intent += f" · stage {mission['stage_name']}"
+
+    actual = "No admitted Go activity is visible at this cut."
+    if goals:
+        actual = f"{len(goals)} Go(s) at this cut"
+        if status_summary:
+            actual += f" · {status_summary}"
+
+    declared_actions = []
+    for goal in goals:
+        if str(goal.get("next_action") or "").strip():
+            declared_actions.append(
+                {
+                    "actor": str(goal.get("owner_agent") or goal.get("actor") or ""),
+                    "subject": str(goal.get("goal_id") or ""),
+                    "action": str(goal["next_action"]),
+                    "source": "go.next_action",
+                }
+            )
+    if str(mission.get("next_action") or "").strip():
+        declared_actions.append(
+            {
+                "actor": str(mission.get("owner") or ""),
+                "subject": str(mission.get("mission_id") or ""),
+                "action": str(mission["next_action"]),
+                "source": "mission.next_action",
+            }
+        )
+    if declared_actions:
+        next_summary = " · ".join(
+            f"{item['actor'] or item['subject'] or 'declared actor'}: {item['action']}"
+            for item in declared_actions
+        )
+        responsibility_state = "declared"
+    elif fitness == "fit":
+        next_summary = "No next action or responsible actor is declared at this cut."
+        responsibility_state = "undeclared"
+    else:
+        next_summary = (
+            "A decision or additional evidence is required, but no responsible "
+            "actor is declared at this cut."
+        )
+        responsibility_state = "needs-decision"
+
+    proof_suffix = str(state.get("query_proof_root") or "")[-12:]
+    answers_by_id = {
+        "mission-intent": {
+            "status": "declared" if mission else "missing",
+            "summary": intent,
+            "data": {"mission": mission},
+        },
+        "observed-progress": {
+            "status": "observed" if goals else "missing",
+            "summary": actual,
+            "data": {"goal_count": len(goals), "status_counts": statuses},
+        },
+        "evidence-at-cut": {
+            "status": "established" if state.get("canonical_state") else "degraded",
+            "summary": (
+                f"{'canonical' if state.get('canonical_state') else 'degraded'} cut"
+                f" · {len(findings)} finding(s) · proof {proof_suffix or '-'}"
+            ),
+            "data": {
+                "canonical_state": bool(state.get("canonical_state")),
+                "cut": state.get("cut", {}),
+                "findings": findings,
+                "query_definition_root": state.get("query_definition_root", ""),
+                "query_proof_root": state.get("query_proof_root", ""),
+            },
+        },
+        "fitness-for-purpose": {
+            "status": fitness,
+            "summary": (
+                f"{fitness} · assessment {assessment_state}"
+                f" · residual limits {len(known_limits)}"
+            ),
+            "data": {
+                "fitness": fitness,
+                "assessment_state": assessment_state,
+                "known_limits": known_limits,
+            },
+        },
+        "next-responsibility": {
+            "status": responsibility_state,
+            "summary": next_summary,
+            "data": {"declared_actions": declared_actions},
+        },
+    }
+    return [
+        {"question_id": question_id, "question": question, **answers_by_id[question_id]}
+        for question_id, question in MISSION_CONTROL_QUESTIONS
+    ]
+
+
+def build_mission_control_query_profile(
+    runtime_dir: str,
+    state: dict[str, Any],
+    *,
+    fitness: str,
+    assessment_state: str,
+    findings: list[str],
+    known_limits: list[str],
+) -> dict[str, Any]:
+    """Resolve and persist the five built-in views over one canonical query."""
+
+    definition = _runtime_query_definition(state["definition"])
+    if definition.get("schema") != "kungfu.query.definition/v1":
+        raise RuntimeError(
+            "Mission Control profile requires one portable QueryDefinition"
+        )
+    mission_hash = _sha256_root(state["mission_subject"])[7:19]
+    declared_cut = definition.get("basis", {}).get("cut", {})
+    cut_key = (
+        "head"
+        if declared_cut.get("kind") == "head"
+        else _sha256_root(declared_cut)[7:19]
+    )
+    current = {
+        str(entry.get("query_id") or ""): entry
+        for entry in storage_service.saved_query_catalog(runtime_dir).get("entries", [])
+    }
+    views = []
+    for question_id, question in MISSION_CONTROL_QUESTIONS:
+        query_id = f"mission-control.{question_id}.{mission_hash}.{cut_key}"
+        saved_view = {
+            "schema": "kungfu.query.saved-view/v1",
+            "name": question,
+            "definition": definition,
+            "view": {
+                "kind": "mission-control",
+                "profileId": MISSION_CONTROL_PROFILE_ID,
+                "profileVersion": MISSION_CONTROL_PROFILE_VERSION,
+                "questionId": question_id,
+                "reducer": MISSION_CONTROL_REDUCER,
+            },
+        }
+        entry = current.get(query_id)
+        if entry is None or entry.get("saved_view") != saved_view:
+            entry = storage_service.saved_query_catalog(
+                runtime_dir,
+                "put",
+                query_id=query_id,
+                saved_view=saved_view,
+                **(
+                    {"expected_revision": int(entry["revision"])}
+                    if entry is not None
+                    else {}
+                ),
+            )
+        views.append(
+            {
+                "question_id": question_id,
+                "query_id": query_id,
+                "revision": int(entry["revision"]),
+                "saved_view_hash": str(entry["saved_view_hash"]),
+                "saved_view": entry["saved_view"],
+            }
+        )
+    profile = {
+        "schema": "kungfu.mission-control.query-profile/v1",
+        "profile": {
+            "id": MISSION_CONTROL_PROFILE_ID,
+            "version": MISSION_CONTROL_PROFILE_VERSION,
+            "reducer": MISSION_CONTROL_REDUCER,
+        },
+        "mission_subject": state["mission_subject"],
+        "query_definition_root": state["query_definition_root"],
+        "query_proof_root": state["query_proof_root"],
+        "result_hash": state["result_hash"],
+        "views": views,
+        "answers": _mission_control_answers(
+            state,
+            fitness=fitness,
+            assessment_state=assessment_state,
+            findings=findings,
+            known_limits=known_limits,
+        ),
+    }
+    profile["profile_hash"] = _sha256_root(profile)
+    return profile
+
+
 def _progress_fitness(
     state: dict[str, Any], assessment_state: str
 ) -> tuple[str, list[str]]:
@@ -1444,6 +1665,14 @@ def assess_progress(
     )
     fitness, findings = _progress_fitness(state, assessed["state"])
     report_hash = assessed.get("report", {}).get("report_hash")
+    query_profile = build_mission_control_query_profile(
+        runtime_dir,
+        state,
+        fitness=fitness,
+        assessment_state=assessed["state"],
+        findings=findings,
+        known_limits=request["residual_risks"],
+    )
     return {
         "schema": "kungfu.mission-control.trust-report/v1",
         "claim": {
@@ -1460,6 +1689,7 @@ def assess_progress(
         "report_hash": report_hash,
         "query_definition_root": state["query_definition_root"],
         "query_proof_root": state["query_proof_root"],
+        "query_profile": query_profile,
         "profile": build_cost_state_proof_profile(
             runtime_dir,
             state,

--- a/framework/core/src/python/kungfu/cli/commands/query.py
+++ b/framework/core/src/python/kungfu/cli/commands/query.py
@@ -75,6 +75,7 @@ def _load_saved_view(file_path: str) -> dict[str, Any]:
         "diff",
         "causal-graph",
         "attention",
+        "mission-control",
     }:
         _fail("KF_QUERY_VIEW", "saved query view requires a supported ViewSpec")
     return value

--- a/framework/core/tests/python/test_atlas_storage.py
+++ b/framework/core/tests/python/test_atlas_storage.py
@@ -412,9 +412,41 @@ def test_mission_control_queries_and_assesses_progress_at_pinned_cuts(tmp_path):
     assert profile["cost"]["proof_episodes"][0]["episode_root"].startswith("sha256:")
     assert profile["proof"]["query_proof_root"] == first_state["query_proof_root"]
     assert profile["proof"]["assessment_report_hash"] == first_report["report_hash"]
+    query_profile = first_report["query_profile"]
+    assert query_profile["schema"] == "kungfu.mission-control.query-profile/v1"
+    assert query_profile["profile"]["reducer"] == ("kungfu.mission-control.reducer/v1")
+    assert len(query_profile["views"]) == 5
+    assert len(query_profile["answers"]) == 5
+    assert all(
+        view["saved_view"]["view"]["kind"] == "mission-control"
+        for view in query_profile["views"]
+    )
+    next_answer = next(
+        answer
+        for answer in query_profile["answers"]
+        if answer["question_id"] == "next-responsibility"
+    )
+    assert next_answer["status"] == "declared"
+    assert next_answer["data"]["declared_actions"][0]["action"] == "implement"
+    assert next_answer["data"]["declared_actions"][0]["source"] == ("go.next_action")
+    assert "Continue under" not in next_answer["summary"]
+    catalog = storage_service.saved_query_catalog(runtime_dir)
+    assert len(catalog["entries"]) == 5
+    assert all(
+        entry["saved_view"]["definition"]
+        == query_profile["views"][0]["saved_view"]["definition"]
+        for entry in catalog["entries"]
+    )
     repeated = mission_control.assess_progress(str(runtime_dir), mission_id="mission-a")
     assert repeated["assessment_key"] == first_report["assessment_key"]
     assert repeated["assessment"]["reused"] is True
+    assert [view["revision"] for view in repeated["query_profile"]["views"]] == [
+        1,
+        1,
+        1,
+        1,
+        1,
+    ]
 
     from click.testing import CliRunner
     from kungfu.cli.commands import __registry__  # noqa: F401
@@ -2335,6 +2367,68 @@ def test_fact_changelog_resumes_pages_without_loss_or_duplication(tmp_path):
     assert finished["complete"] is True
     assert [message["type"] for message in finished["messages"]] == ["Progress"]
     assert finished["messages"][0]["frontier"]["kind"] == "manifest_frame_uid"
+
+
+def test_fact_state_changelog_uses_stable_keys_and_system_time_frontiers(tmp_path):
+    repo = tmp_path / "atlas"
+    runtime_dir = tmp_path / "runtime"
+    _atlas_fixture(repo)
+    atlas_store.ImportStore(runtime_dir).run_import(str(repo))
+
+    profile_definition = mission_control.build_state_query(
+        str(runtime_dir), mission_id="mission-a"
+    )
+    definition = mission_control._runtime_query_definition(profile_definition)
+    snapshot = storage_service.fact_changelog(runtime_dir, definition)
+    assert snapshot["complete"] is True
+    assert snapshot["resume_token"]["target"]["kind"] == "system_time"
+    assert [message["type"] for message in snapshot["messages"]] == [
+        "SnapshotBegin",
+        "RowUpsert",
+        "RowUpsert",
+        "SnapshotEnd",
+    ]
+    goal_upsert = next(
+        message
+        for message in snapshot["messages"]
+        if message.get("row", {}).get("subject_key") == "atlas:goal-a"
+    )
+    assert goal_upsert["evidence_ref"]["payload_hash"]
+    assert goal_upsert["evidence_ref"]["episode_id"]
+
+    steady = snapshot["resume_token"]
+    unchanged = storage_service.fact_changelog(
+        runtime_dir, definition, resume_token=steady
+    )
+    assert [message["type"] for message in unchanged["messages"]] == ["Progress"]
+
+    goal_path = repo / "agent-journal/goals/registry/active/goal-a.json"
+    changed = json.loads(goal_path.read_text(encoding="utf-8"))
+    changed["status"] = "ready"
+    changed["updated_at"] = "2026-07-09T00:00:00Z"
+    _write_json(goal_path, changed)
+    atlas_store.ImportStore(runtime_dir).run_import(str(repo))
+
+    correction = storage_service.fact_changelog(
+        runtime_dir, definition, resume_token=steady
+    )
+    replay = storage_service.fact_changelog(
+        runtime_dir, definition, resume_token=steady
+    )
+    assert correction == replay
+    assert [message["type"] for message in correction["messages"]] == [
+        "RowUpsert",
+        "Progress",
+    ]
+    assert correction["messages"][0]["key"] == goal_upsert["key"]
+    assert (
+        correction["messages"][0]["row"]["episode_id"]
+        != goal_upsert["row"]["episode_id"]
+    )
+    assert correction["messages"][1]["frontier"]["kind"] == "system_time"
+    assert int(correction["messages"][1]["frontier"]["system_time"]) > int(
+        steady["target"]["system_time"]
+    )
 
 
 def test_temporal_attention_pattern_is_reproducible_and_retracts_on_late_terminal(

--- a/framework/gui/scripts/before-pack.cjs
+++ b/framework/gui/scripts/before-pack.cjs
@@ -11,12 +11,17 @@ function toEsmEntrypointSpecifier(entryPath, platform = process.platform) {
   return platform === 'win32' ? pathToFileURL(entryPath).href : entryPath;
 }
 
+function esmEntrypointArgs(entryPath) {
+  const specifier = toEsmEntrypointSpecifier(entryPath);
+  return ['--eval', `import(${JSON.stringify(specifier)})`];
+}
+
 exports.default = async function beforePack() {
   const gen = path.join(__dirname, 'gen-first-party-manifest.mjs');
   const tsxLoader = require.resolve('tsx/esm');
   const result = spawnSync(
     process.execPath,
-    ['--import', tsxLoader, toEsmEntrypointSpecifier(gen)],
+    ['--import', tsxLoader, ...esmEntrypointArgs(gen)],
     { stdio: 'inherit' },
   );
   if (result.status !== 0) {
@@ -25,3 +30,4 @@ exports.default = async function beforePack() {
 };
 
 exports.toEsmEntrypointSpecifier = toEsmEntrypointSpecifier;
+exports.esmEntrypointArgs = esmEntrypointArgs;

--- a/framework/gui/src/main/index.ts
+++ b/framework/gui/src/main/index.ts
@@ -53,6 +53,7 @@ import {
   createMainTerminalHost,
 } from './terminal-host';
 import {
+  clearDesktopWorkspaceEnvForRelaunch,
   defaultHomeDesktopWorkspace,
   listRecentDesktopWorkspaces,
   resolveLastDesktopWorkspace,
@@ -95,6 +96,11 @@ function defaultConfigHome(): string {
   );
 }
 
+const desktopWorkspaceIsRegistryManaged =
+  !process.env.KF_INSTANCE_HOME &&
+  !process.env.KF_HOME &&
+  !process.env.KF_RUNTIME_DIR;
+
 // A product launcher may set KF_INSTANCE_HOME to make a second Kungfu process
 // independent from the default user-global homes. Keep the same mental model as
 // the default install: config and runtime home are separate directories.
@@ -123,11 +129,7 @@ if (process.env.KF_INSTANCE_HOME) {
   process.env.KF_RUNTIME_DIR = path.join(process.env.KF_HOME, 'runtime');
 }
 
-if (
-  !process.env.KF_INSTANCE_HOME &&
-  !process.env.KF_HOME &&
-  !process.env.KF_RUNTIME_DIR
-) {
+if (desktopWorkspaceIsRegistryManaged) {
   const configHome = defaultConfigHome();
   process.env.KF_CONFIG_HOME = configHome;
   const selected =
@@ -731,6 +733,9 @@ function relaunchWithWorkspaceSelection(args: string[]) {
     timeout: 10000,
   });
   const selected = JSON.parse(out.toString());
+  if (desktopWorkspaceIsRegistryManaged) {
+    clearDesktopWorkspaceEnvForRelaunch(process.env);
+  }
   setImmediate(() => {
     app.relaunch();
     app.exit(0);

--- a/framework/gui/src/main/index.ts
+++ b/framework/gui/src/main/index.ts
@@ -24,6 +24,7 @@ import {
   HIDE_CHANNEL,
   RUNTIME_STATUS_GET_CHANNEL,
   SET_BOUNDS_CHANNEL,
+  SHELL_REFRESH_CHANNEL,
   SHOW_CHANNEL,
   WINDOW_CHROME_CONTROL_CHANNEL,
   WINDOW_CHROME_GET_CHANNEL,
@@ -896,7 +897,28 @@ function buildMenu() {
     ...(process.platform === 'darwin' ? [{ role: 'appMenu' as const }] : []),
     { label: 'kungfu', submenu: cliSubmenu },
     { role: 'editMenu' },
-    { role: 'viewMenu' },
+    {
+      label: 'View',
+      submenu: [
+        {
+          label: 'Refresh Product Data',
+          accelerator: 'CmdOrCtrl+R',
+          click: () => {
+            if (shellWindow && !shellWindow.isDestroyed()) {
+              shellWindow.webContents.send(SHELL_REFRESH_CHANNEL);
+            }
+          },
+        },
+        { type: 'separator' },
+        { role: 'resetZoom' },
+        { role: 'zoomIn' },
+        { role: 'zoomOut' },
+        { type: 'separator' },
+        { role: 'toggleDevTools' },
+        { type: 'separator' },
+        { role: 'togglefullscreen' },
+      ],
+    },
     { role: 'windowMenu' },
   ];
 

--- a/framework/gui/src/main/workspace-selection.test.ts
+++ b/framework/gui/src/main/workspace-selection.test.ts
@@ -5,11 +5,35 @@ import path from 'node:path';
 import test from 'node:test';
 
 import {
+  clearDesktopWorkspaceEnvForRelaunch,
   defaultHomeDesktopWorkspace,
   listRecentDesktopWorkspaces,
   resolveLastDesktopWorkspace,
   workspaceRegistryPath,
 } from './workspace-selection.ts';
+
+test('desktop relaunch clears derived workspace env but preserves config home', () => {
+  const env = {
+    KF_CONFIG_HOME: '/tmp/config',
+    KF_HOME: '/tmp/old-home',
+    KF_RUNTIME_DIR: '/tmp/old-runtime',
+    KF_WORKSPACE_ID: 'home',
+    KF_WORKSPACE_KIND: 'home',
+    KF_WORKSPACE_ROOT: '',
+    KF_WORKSPACE_DISPLAY_PATH: 'Home Workspace',
+    KF_WORKSPACE_RESOLUTION_REASON: 'home-fallback',
+    KF_WORKSPACE_STATE: 'selected-uninitialized',
+    KF_WORKSPACE_DIAGNOSIS: '',
+    KUNGFU_VERSION: '4.0.0',
+  };
+
+  clearDesktopWorkspaceEnvForRelaunch(env);
+
+  assert.deepEqual(env, {
+    KF_CONFIG_HOME: '/tmp/config',
+    KUNGFU_VERSION: '4.0.0',
+  });
+});
 
 function fixture(name: string): string {
   const root = path.join(tmpdir(), `kungfu-workspace-selection-${name}`);

--- a/framework/gui/src/main/workspace-selection.ts
+++ b/framework/gui/src/main/workspace-selection.ts
@@ -5,6 +5,18 @@ import path from 'node:path';
 
 const REGISTRY_SCHEMA = 'kungfu.workspace.registry/v1';
 
+const DESKTOP_WORKSPACE_ENV_KEYS = [
+  'KF_HOME',
+  'KF_RUNTIME_DIR',
+  'KF_WORKSPACE_ID',
+  'KF_WORKSPACE_KIND',
+  'KF_WORKSPACE_ROOT',
+  'KF_WORKSPACE_DISPLAY_PATH',
+  'KF_WORKSPACE_RESOLUTION_REASON',
+  'KF_WORKSPACE_STATE',
+  'KF_WORKSPACE_DIAGNOSIS',
+] as const;
+
 export type RegistryWorkspace = {
   workspace_id?: string;
   workspace_kind?: 'home' | 'project';
@@ -33,6 +45,12 @@ export type DesktopWorkspaceSelection = {
 
 export function workspaceRegistryPath(configHome: string): string {
   return path.join(configHome, 'gui', 'workspaces.json');
+}
+
+export function clearDesktopWorkspaceEnvForRelaunch(
+  env: Record<string, string | undefined>,
+): void {
+  for (const key of DESKTOP_WORKSPACE_ENV_KEYS) delete env[key];
 }
 
 export function resolveLastDesktopWorkspace(

--- a/framework/gui/src/renderer/src/main.tsx
+++ b/framework/gui/src/renderer/src/main.tsx
@@ -33,6 +33,7 @@ import {
   SESSION_WINDOW_OPEN_CHANNEL,
   SESSION_WINDOW_RESTORE_CHANNEL,
   SESSION_WINDOW_SNAPSHOT_CHANNEL,
+  SHELL_REFRESH_CHANNEL,
   WINDOW_CHROME_CONTROL_CHANNEL,
   WINDOW_CHROME_GET_CHANNEL,
   WINDOW_CHROME_STATE_CHANNEL,
@@ -42,6 +43,7 @@ import {
   WORKSPACE_SELECT_HOME_CHANNEL,
   WORKSPACE_SELECT_RECENT_CHANNEL,
 } from '../../sandbox/channels';
+import { publishRefresh } from '../../sandbox/refresh';
 import {
   loadKungfuConfig,
   normalizedUiConfig,
@@ -852,12 +854,32 @@ function App() {
 
   // shared refresh bus: one shell-owned timer, kfx subscribe
   const subscribers = React.useRef(new Set<() => void>());
-  React.useEffect(() => {
-    const timer = setInterval(() => {
-      for (const fn of subscribers.current) fn();
-    }, 5000);
-    return () => clearInterval(timer);
+  const refreshProductData = React.useCallback(() => {
+    publishRefresh(subscribers.current, (error) => {
+      console.error('[shell] product data refresh failed', error);
+    });
   }, []);
+  React.useEffect(() => {
+    const timer = setInterval(refreshProductData, 5000);
+    return () => clearInterval(timer);
+  }, [refreshProductData]);
+
+  React.useEffect(() => {
+    type RefreshIpc = {
+      on: (channel: string, handler: () => void) => void;
+      removeListener: (channel: string, handler: () => void) => void;
+    };
+    let ipc: RefreshIpc | null = null;
+    try {
+      ipc = (window.require('electron') as { ipcRenderer: RefreshIpc })
+        .ipcRenderer;
+    } catch {
+      ipc = null;
+    }
+    if (!ipc) return;
+    ipc.on(SHELL_REFRESH_CHANNEL, refreshProductData);
+    return () => ipc?.removeListener(SHELL_REFRESH_CHANNEL, refreshProductData);
+  }, [refreshProductData]);
 
   React.useEffect(() => {
     const refresh = () =>

--- a/framework/gui/src/sandbox/channels.ts
+++ b/framework/gui/src/sandbox/channels.ts
@@ -41,6 +41,11 @@ export const WINDOW_CHROME_STATE_CHANNEL = 'kf-window-chrome:state';
 
 export const RUNTIME_STATUS_GET_CHANNEL = 'kf-runtime-status:get';
 
+// main -> shell renderer: refresh product data without reloading the renderer.
+// The renderer owns native runtime handles, so Electron's page reload is not a
+// safe refresh mechanism.
+export const SHELL_REFRESH_CHANNEL = 'kf-shell:refresh';
+
 // renderer <-> main: Desktop Workspace chooser/switcher. Selection is a
 // global-config convenience record; fact-bearing data remains in the selected
 // Home or project workspace and switching relaunches the single-workspace app.

--- a/framework/gui/src/sandbox/refresh.test.ts
+++ b/framework/gui/src/sandbox/refresh.test.ts
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { publishRefresh } from './refresh.ts';
+
+test('refresh bus isolates subscribers and continues after a failure', () => {
+  const calls: string[] = [];
+  const errors: unknown[] = [];
+
+  publishRefresh(
+    new Set([
+      () => calls.push('first'),
+      () => {
+        throw new Error('broken view');
+      },
+      () => calls.push('last'),
+    ]),
+    (error) => errors.push(error),
+  );
+
+  assert.deepEqual(calls, ['first', 'last']);
+  assert.equal(errors.length, 1);
+  assert.match(String(errors[0]), /broken view/);
+});

--- a/framework/gui/src/sandbox/refresh.ts
+++ b/framework/gui/src/sandbox/refresh.ts
@@ -1,0 +1,14 @@
+export type RefreshSubscriber = () => void;
+
+export function publishRefresh(
+  subscribers: Iterable<RefreshSubscriber>,
+  onError: (error: unknown) => void = console.error,
+): void {
+  for (const subscriber of [...subscribers]) {
+    try {
+      subscriber();
+    } catch (error) {
+      onError(error);
+    }
+  }
+}

--- a/product/scripts/dist.test.mjs
+++ b/product/scripts/dist.test.mjs
@@ -7,6 +7,7 @@ import { cliArchiveBase, verifyProductObservabilityEvents } from './dist.mjs';
 
 const require = createRequire(import.meta.url);
 const {
+  esmEntrypointArgs,
   toEsmEntrypointSpecifier,
 } = require('../../framework/gui/scripts/before-pack.cjs');
 
@@ -68,4 +69,16 @@ test('electron before-pack uses a file URL only on Windows', () => {
       .protocol,
     'file:',
   );
+});
+
+test('electron before-pack imports its ESM entrypoint through eval', () => {
+  const entryPath = new URL(
+    '../../framework/gui/scripts/gen-first-party-manifest.mjs',
+    import.meta.url,
+  ).pathname;
+  const specifier = toEsmEntrypointSpecifier(entryPath);
+  assert.deepEqual(esmEntrypointArgs(entryPath), [
+    '--eval',
+    `import(${JSON.stringify(specifier)})`,
+  ]);
 });

--- a/product/scripts/dist.test.mjs
+++ b/product/scripts/dist.test.mjs
@@ -6,6 +6,7 @@ import { test } from 'node:test';
 import { cliArchiveBase, verifyProductObservabilityEvents } from './dist.mjs';
 
 const require = createRequire(import.meta.url);
+const workDashboardPackage = require('../../extensions/work-dashboard/package.json');
 const {
   esmEntrypointArgs,
   toEsmEntrypointSpecifier,
@@ -81,4 +82,12 @@ test('electron before-pack imports its ESM entrypoint through eval', () => {
     '--eval',
     `import(${JSON.stringify(specifier)})`,
   ]);
+});
+
+test('work dashboard declares the storage handle used by its query stream', () => {
+  assert.ok(
+    workDashboardPackage.kungfuConfig.config.view.capabilities.includes(
+      'storage',
+    ),
+  );
 });


### PR DESCRIPTION
## Summary
- project the five Mission Control answers from versioned Saved Query profiles
- drive Work Dashboard refresh from proof-bearing fact changelog state
- preserve workspace selection and live refresh compatibility
- repair electron beforePack ESM entrypoint and dashboard storage capability declaration

## Validation
- targeted Python query, changelog, Atlas and Saved Query tests
- API TypeScript build and query tests
- Status and Work Dashboard KFX builds
- product unit tests
- full native/Python/Node rebuild and freeze
- unpacked macOS product build, Shifu registration/promote, and real Atlas GUI dogfood

## Known limits
- CI is currently known broken; this PR does not wait for CI
- existing headless Atlas fixture has independent sync_root_mismatch debt

Signed-off-by: Keren Dong <keren.dong@kungfu.link>