### PR TITLE
feat(shifu): apply projected cache profiles

### DIFF
--- a/.buildchain/buildchain.toml
+++ b/.buildchain/buildchain.toml
@@ -34,15 +34,15 @@ SHIFU_REQUIRE_MSVC = "1"
 
 [lifecycle.install]
 shell = "bash"
-command = "./shifu doctor && ./shifu install --frozen-lockfile --no-optional"
+command = "./shifu cache apply -- bash -c './shifu doctor && ./shifu install --frozen-lockfile --no-optional'"
 
 [lifecycle.build]
 shell = "bash"
-command = "./shifu dist"
+command = "./shifu cache apply -- ./shifu dist"
 
 [lifecycle.verify]
 shell = "bash"
-command = "./shifu verify"
+command = "./shifu cache apply -- ./shifu verify"
 
 [lifecycle.publish]
 # shifu-entry-contract: allow Buildchain publish adapter bootstraps before repository lifecycle dispatch

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ permissions:
 
 jobs:
   build:
-    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@b0733e799eeb1c44caccd6da92ebae4646a1bde4
+    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@train/v2/v2.3/shifu-cache-profile-passthrough
     secrets: inherit
     with:
       buildchain-ref: ${{ inputs.buildchain-ref || '' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,8 +60,8 @@ jobs:
       verify-command: >-
         bash -c "KUNGFU_BUILDCHAIN_NO_OPTIONAL=1 KUNGFU_BUILDCHAIN_SOURCE_BUILD=1
         SHIFU_NATIVE=1 SHIFU_REQUIRE_MSVC=1 KUNGFU_FUZZ_SECONDS=90
-        ./shifu verify --fuzz &&
-        ./shifu episode:qualify:release -- --output
+        ./shifu cache apply -- ./shifu verify --fuzz &&
+        ./shifu cache apply -- ./shifu episode:qualify:release -- --output
         product/release/qualification/episode-release-evidence.json"
       release-candidate: true
       publish-channel: ${{ startsWith(github.base_ref, 'release/') && 'release' || 'alpha' }}
@@ -72,6 +72,8 @@ jobs:
       checkout-cache-reference-repository-template: ${{ vars.BUILDCHAIN_CHECKOUT_CACHE_REFERENCE_REPOSITORY_TEMPLATE }}
       checkout-cache-fallback: github
       checkout-cache-timeout-seconds: 60
+      shifu-cache-profile-ref: ${{ vars.SHIFU_CACHE_PROFILE_REF }}
+      shifu-cache-profile-digest: ${{ vars.SHIFU_CACHE_PROFILE_DIGEST }}
       buildchain-contract-lock-path: .buildchain/contract-lock.json
       buildchain-contract-compatibility-policy: major-compatible
       buildchain-contract-drift-issue-mode: compatible-and-breaking

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ permissions:
 
 jobs:
   build:
-    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@train/v2/v2.3/shifu-cache-profile-passthrough
+    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@v2-alpha
     secrets: inherit
     with:
       buildchain-ref: ${{ inputs.buildchain-ref || '' }}

--- a/.github/workflows/dev-verify-patrol.yml
+++ b/.github/workflows/dev-verify-patrol.yml
@@ -47,6 +47,10 @@ jobs:
       platforms-json: >-
         [{"id":"linux-x64","name":"Linux x64",
         "runner":"[\"self-hosted\",\"Linux\",\"X64\",\"kungfu-build-v4-linux-x64\"]"}]
+      # The lifecycle forces native execution after the checkout-owned cache
+      # profile is applied. Build the launcher from this source revision so a
+      # stale release slot cannot reinterpret newer Shifu verbs as pnpm tasks.
+      setup-rust: true
       artifact-name: kungfu-dev-verify
       shifu-cache-profile-ref: ${{ vars.SHIFU_CACHE_PROFILE_REF }}
       shifu-cache-profile-digest: ${{ vars.SHIFU_CACHE_PROFILE_DIGEST }}

--- a/.github/workflows/dev-verify-patrol.yml
+++ b/.github/workflows/dev-verify-patrol.yml
@@ -36,7 +36,7 @@ permissions:
 
 jobs:
   verify:
-    uses: kungfu-systems/buildchain/.github/workflows/build.yml@v2
+    uses: kungfu-systems/buildchain/.github/workflows/build.yml@train/v2/v2.3/shifu-cache-profile-passthrough
     secrets: inherit
     with:
       buildchain-ref: ${{ inputs.buildchain-ref || '' }}

--- a/.github/workflows/dev-verify-patrol.yml
+++ b/.github/workflows/dev-verify-patrol.yml
@@ -36,7 +36,7 @@ permissions:
 
 jobs:
   verify:
-    uses: kungfu-systems/buildchain/.github/workflows/build.yml@train/v2/v2.3/shifu-cache-profile-passthrough
+    uses: kungfu-systems/buildchain/.github/workflows/build.yml@v2-alpha
     secrets: inherit
     with:
       buildchain-ref: ${{ inputs.buildchain-ref || '' }}

--- a/.github/workflows/dev-verify-patrol.yml
+++ b/.github/workflows/dev-verify-patrol.yml
@@ -48,6 +48,8 @@ jobs:
         [{"id":"linux-x64","name":"Linux x64",
         "runner":"[\"self-hosted\",\"Linux\",\"X64\",\"kungfu-build-v4-linux-x64\"]"}]
       artifact-name: kungfu-dev-verify
+      shifu-cache-profile-ref: ${{ vars.SHIFU_CACHE_PROFILE_REF }}
+      shifu-cache-profile-digest: ${{ vars.SHIFU_CACHE_PROFILE_DIGEST }}
       artifact-paths: |
         product/release
       expected-artifacts-json: >-
@@ -68,7 +70,7 @@ jobs:
       # match the .buildchain/buildchain.toml stages.
       verify-command: >-
         bash -c "KUNGFU_BUILDCHAIN_NO_OPTIONAL=1 KUNGFU_BUILDCHAIN_SOURCE_BUILD=1
-        SHIFU_NATIVE=1 ./shifu verify --full"
+        SHIFU_NATIVE=1 ./shifu cache apply -- ./shifu verify --full"
 
   # Keep one tracking issue in sync with the patrol result: open or refresh it
   # when dev is red, close it when dev returns to green. This is the standing

--- a/docs/shifu/README.md
+++ b/docs/shifu/README.md
@@ -39,10 +39,15 @@ package:
 ./shifu cache contract
 ./shifu cache schema profile
 ./shifu cache schema resolution
+./shifu cache validate profile path/to/cache-profile.json
+./shifu cache resolve --profile path/to/cache-profile.json --digest sha256:...
+./shifu cache apply --profile path/to/cache-profile.json --digest sha256:... -- ./shifu check
 ```
 
-The commands print the exact checked-in JSON. Consumers should pin the checkout
-or binary source revision when they use the result as a generation input.
+The contract and schema discovery commands print the exact checked-in JSON.
+Consumers should pin the checkout or binary source revision when they use the
+result as a generation input. Runtime validate/resolve/apply commands consume
+profile instances and never modify the checked-in contract.
 
 ## Boundary
 

--- a/docs/shifu/cache-contract.json
+++ b/docs/shifu/cache-contract.json
@@ -54,6 +54,9 @@
     "contract": "shifu cache contract",
     "profileSchema": "shifu cache schema profile",
     "resolutionSchema": "shifu cache schema resolution",
+    "validateProfile": "shifu cache validate profile FILE",
+    "resolveProfile": "shifu cache resolve --profile REF --digest SHA256",
+    "applyProfile": "shifu cache apply --profile REF --digest SHA256 -- COMMAND",
     "repositoryCheck": "./shifu check"
   }
 }

--- a/docs/shifu/cache-profiles.md
+++ b/docs/shifu/cache-profiles.md
@@ -79,7 +79,7 @@ a new major schema rather than silent reinterpretation. Resolution evidence
 binds the SHA-256 of the exact source profile bytes, avoiding an implicit second
 canonical JSON renderer.
 
-## Local-development consumption before publication
+## Runtime consumption
 
 An inventory controller can pin a local Kungfu checkout or a locally built
 Shifu binary, obtain the schema through `shifu cache schema profile`, validate
@@ -87,7 +87,33 @@ the generated instance, and project it to an approved local configuration
 surface. This makes dogfood independent of npm/alpha publication while keeping
 the exact Shifu source revision auditable.
 
-The current slice establishes discovery, schema, examples, and repository
-conformance. Automatic profile application and provider-specific config writers
-are follow-up execution work; until they exist, existing `build-local.env`
-bindings remain the compatible consumption edge.
+`shifu cache validate profile FILE` runs the Shifu-owned runtime validator.
+`shifu cache resolve` loads a local/file/http(s) reference, verifies the digest
+of the exact bytes, checks platform and scope applicability, and emits a
+schema-versioned redacted receipt. `shifu cache apply -- COMMAND` performs the
+same resolution and supplies supported environment bindings only to that child
+process. Unsupported argument/config bindings, protected environment keys,
+secret-like keys, unsafe URLs, applicability drift, and digest drift fail
+closed.
+
+The default reference and digest come from
+`SHIFU_CACHE_PROFILE_REF` and `SHIFU_CACHE_PROFILE_DIGEST`. They may also be
+passed explicitly:
+
+```sh
+./shifu cache apply \
+  --profile https://cache.example.invalid/profiles/development.json \
+  --digest sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef \
+  -- ./shifu check
+```
+
+Both values must be present together. When both are absent, `cache apply` is a
+transparent pass-through so public clones and forks continue to use normal
+upstreams. A local controller may project the pair into the user-global
+`build-local.env`; Shifu still resolves the profile at execution time and does
+not turn that environment file into another field authority.
+
+For CI, Buildchain accepts only the opaque reference and digest and forwards
+them to lifecycle commands. It does not fetch or parse the profile. The
+consumer lifecycle invokes `shifu cache apply`, so the pinned Shifu checkout
+remains the only component that interprets fields and writes the receipt.

--- a/scripts/check-shifu-cache-contract.mjs
+++ b/scripts/check-shifu-cache-contract.mjs
@@ -62,8 +62,8 @@ export function checkShifuCacheContract(root = ROOT) {
   assert.equal(resolutionSchema.$id, contract.schemaIds.resolution);
 
   const dispatchMarkers = [
-    ['shifu', 'build | rebuild | cache | proxy | config)'],
-    ['shifu.cmd', 'if /i "%~1"=="cache"  goto delegate'],
+    ['shifu', 'if [ "${1:-}" = "cache" ]; then'],
+    ['shifu.cmd', 'if /i "%~1"=="cache" goto delegate'],
     ['crates/shifu/src/main.rs', '"cache", "proxy", "config"'],
   ];
   for (const [source, marker] of dispatchMarkers) {

--- a/scripts/check-shifu-cache-contract.test.mjs
+++ b/scripts/check-shifu-cache-contract.test.mjs
@@ -57,3 +57,46 @@ test('unknown cache schema fails with usage', () => {
   assert.equal(result.status, 2);
   assert.match(result.stderr, /cache schema profile/);
 });
+
+test('shifu validates a profile through its runtime authority', () => {
+  const profile = path.join(
+    ROOT,
+    'docs',
+    'shifu',
+    'examples',
+    'development.cache-profile.json',
+  );
+  const result = spawnSync(
+    process.execPath,
+    [SHIFU_MJS, 'cache', 'validate', 'profile', profile],
+    { cwd: ROOT, encoding: 'utf8' },
+  );
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(JSON.parse(result.stdout).valid, true);
+});
+
+test('cache apply is transparent when no profile projection is configured', () => {
+  const result = spawnSync(
+    process.execPath,
+    [
+      SHIFU_MJS,
+      'cache',
+      'apply',
+      '--',
+      process.execPath,
+      '-e',
+      'process.stdout.write("cache-pass-through")',
+    ],
+    {
+      cwd: ROOT,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        SHIFU_CACHE_PROFILE_REF: '',
+        SHIFU_CACHE_PROFILE_DIGEST: '',
+      },
+    },
+  );
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout, 'cache-pass-through');
+});

--- a/scripts/check-shifu-cache-contract.test.mjs
+++ b/scripts/check-shifu-cache-contract.test.mjs
@@ -11,6 +11,7 @@ import { checkShifuCacheContract } from './check-shifu-cache-contract.mjs';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const SHIFU_MJS = path.join(ROOT, 'shifu.mjs');
+const SHIFU_SH = path.join(ROOT, 'shifu');
 
 test('cache contract schemas accept valid fixtures and reject unsafe policy', () => {
   assert.deepEqual(checkShifuCacheContract(ROOT), {
@@ -100,3 +101,17 @@ test('cache apply is transparent when no profile projection is configured', () =
   assert.equal(result.status, 0, result.stderr);
   assert.equal(result.stdout, 'cache-pass-through');
 });
+
+test(
+  'shell shim keeps cache on L2 when native task execution is forced',
+  { skip: process.platform === 'win32' },
+  () => {
+    const result = spawnSync(SHIFU_SH, ['cache', 'contract'], {
+      cwd: ROOT,
+      encoding: 'utf8',
+      env: { ...process.env, SHIFU_NATIVE: '1' },
+    });
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(JSON.parse(result.stdout).schema, 'shifu.cache-contract/v1');
+  },
+);

--- a/scripts/check.mjs
+++ b/scripts/check.mjs
@@ -341,6 +341,7 @@ function testShifuCacheContract() {
   run('Shifu cache contract tests', 'node', [
     '--test',
     path.join('scripts', 'check-shifu-cache-contract.test.mjs'),
+    path.join('scripts', 'shifu-cache-runtime.test.mjs'),
   ]);
 }
 

--- a/scripts/shifu-cache-runtime.mjs
+++ b/scripts/shifu-cache-runtime.mjs
@@ -1,0 +1,564 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: Apache-2.0
+// Resolve one trusted Shifu cache profile, apply its bindings to one child,
+// and emit a redacted resolution receipt. Pure Node builtins: this path is
+// available before repository dependencies are installed.
+
+import { spawnSync } from 'node:child_process';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const PROFILE_SCHEMA = 'shifu.cache-profile/v1';
+const RECEIPT_SCHEMA = 'shifu.cache-resolution/v1';
+const REDACTION = 'credentials-userinfo-query-fragment';
+const DIGEST_RE = /^sha256:[a-f0-9]{64}$/;
+const ENV_KEY_RE = /^[A-Z][A-Z0-9_]*$/;
+const BLOCKED_ENV_KEYS = new Set([
+  'PATH',
+  'HOME',
+  'USER',
+  'SHELL',
+  'GITHUB_TOKEN',
+  'GH_TOKEN',
+  'NODE_OPTIONS',
+  'SHIFU_CACHE_PROFILE_REF',
+  'SHIFU_CACHE_PROFILE_DIGEST',
+]);
+const SECRET_KEY_RE =
+  /(TOKEN|SECRET|PASSWORD|CREDENTIAL|COOKIE|PRIVATE_KEY|AUTH)/;
+
+export class CacheProfileError extends Error {}
+
+function assert(condition, message) {
+  if (!condition) throw new CacheProfileError(message);
+}
+
+function assertObject(value, label) {
+  assert(
+    value && typeof value === 'object' && !Array.isArray(value),
+    `${label} must be an object`,
+  );
+  return value;
+}
+
+function assertExactKeys(value, allowed, required, label) {
+  const object = assertObject(value, label);
+  for (const key of required)
+    assert(Object.hasOwn(object, key), `${label}.${key} is required`);
+  for (const key of Object.keys(object))
+    assert(allowed.has(key), `${label}.${key} is not supported`);
+}
+
+export function sha256(raw) {
+  return `sha256:${crypto.createHash('sha256').update(raw).digest('hex')}`;
+}
+
+function checkedHttpUrl(value, label) {
+  assert(typeof value === 'string', `${label} must be a string`);
+  let parsed;
+  try {
+    parsed = new URL(value);
+  } catch (error) {
+    throw new CacheProfileError(`${label} is not a URL: ${error.message}`);
+  }
+  assert(
+    parsed.protocol === 'http:' || parsed.protocol === 'https:',
+    `${label} must use http(s)`,
+  );
+  assert(
+    !parsed.username && !parsed.password,
+    `${label} must not contain userinfo`,
+  );
+  assert(
+    !parsed.search && !parsed.hash,
+    `${label} must not contain query or fragment`,
+  );
+  return parsed.toString();
+}
+
+function platformId() {
+  const osName =
+    process.platform === 'darwin'
+      ? 'darwin'
+      : process.platform === 'win32'
+        ? 'windows'
+        : process.platform;
+  const arch =
+    process.arch === 'x64'
+      ? 'x64'
+      : process.arch === 'arm64'
+        ? 'arm64'
+        : process.arch;
+  return `${osName}-${arch}`;
+}
+
+export function inferScope(env = process.env) {
+  if (env.SHIFU_CACHE_SCOPE) return env.SHIFU_CACHE_SCOPE;
+  if (env.RUNNER_ENVIRONMENT === 'self-hosted') return 'self-hosted-runner';
+  if (String(env.CI || '').toLowerCase() === 'true') return 'ci';
+  return 'development';
+}
+
+function expandLocalReference(reference, cwd) {
+  if (reference.startsWith('file://')) return fileURLToPath(reference);
+  if (reference === '~') return os.homedir();
+  if (reference.startsWith('~/') || reference.startsWith('~\\')) {
+    return path.join(os.homedir(), reference.slice(2));
+  }
+  return path.resolve(cwd, reference);
+}
+
+export async function readProfileReference(
+  reference,
+  { cwd = process.cwd(), timeoutMs = 10_000 } = {},
+) {
+  assert(
+    typeof reference === 'string' && reference,
+    'cache profile reference is required',
+  );
+  if (/^https?:\/\//.test(reference)) {
+    const url = checkedHttpUrl(reference, 'cache profile reference');
+    let response;
+    try {
+      response = await fetch(url, { signal: AbortSignal.timeout(timeoutMs) });
+    } catch (error) {
+      throw new CacheProfileError(
+        `cannot fetch cache profile: ${error.message}`,
+      );
+    }
+    assert(response.ok, `cannot fetch cache profile: HTTP ${response.status}`);
+    return Buffer.from(await response.arrayBuffer());
+  }
+  const local = expandLocalReference(reference, cwd);
+  try {
+    return fs.readFileSync(local);
+  } catch (error) {
+    throw new CacheProfileError(
+      `cannot read cache profile ${local}: ${error.message}`,
+    );
+  }
+}
+
+function endpointValue(endpoint, binding) {
+  if (binding.valueFrom === 'endpoint.url') {
+    assert(
+      endpoint.type === 'http',
+      'endpoint.url binding requires an http endpoint',
+    );
+    return endpoint.url;
+  }
+  if (binding.valueFrom === 'endpoint.path') {
+    assert(
+      endpoint.type === 'local-path',
+      'endpoint.path binding requires a local-path endpoint',
+    );
+    return endpoint.path;
+  }
+  throw new CacheProfileError(
+    `unsupported binding valueFrom: ${binding.valueFrom}`,
+  );
+}
+
+function validateBinding(binding, serviceId) {
+  assertExactKeys(
+    binding,
+    new Set(['kind', 'key', 'valueFrom']),
+    ['kind', 'key', 'valueFrom'],
+    `services.${serviceId}.binding`,
+  );
+  assert(
+    ['environment', 'argument', 'config-key'].includes(binding.kind),
+    `services.${serviceId} binding kind is invalid`,
+  );
+  assert(
+    typeof binding.key === 'string' && binding.key,
+    `services.${serviceId} binding key is required`,
+  );
+  assert(
+    ['endpoint.url', 'endpoint.path'].includes(binding.valueFrom),
+    `services.${serviceId} binding valueFrom is invalid`,
+  );
+}
+
+function validateEnvironmentKey(key) {
+  assert(ENV_KEY_RE.test(key), `environment binding key is invalid: ${key}`);
+  assert(
+    !BLOCKED_ENV_KEYS.has(key),
+    `environment binding key is protected: ${key}`,
+  );
+  assert(
+    !SECRET_KEY_RE.test(key),
+    `environment binding key is secret-like: ${key}`,
+  );
+}
+
+function validateEndpoint(endpoint, serviceId) {
+  assertObject(endpoint, `services.${serviceId}.endpoint`);
+  if (endpoint.type === 'http') {
+    assertExactKeys(
+      endpoint,
+      new Set(['type', 'url']),
+      ['type', 'url'],
+      `services.${serviceId}.endpoint`,
+    );
+    return {
+      type: 'http',
+      url: checkedHttpUrl(endpoint.url, `services.${serviceId}.endpoint.url`),
+    };
+  }
+  assert(
+    endpoint.type === 'local-path',
+    `services.${serviceId} endpoint type is invalid`,
+  );
+  assertExactKeys(
+    endpoint,
+    new Set(['type', 'path']),
+    ['type', 'path'],
+    `services.${serviceId}.endpoint`,
+  );
+  assert(
+    typeof endpoint.path === 'string' && endpoint.path,
+    `services.${serviceId}.endpoint.path is required`,
+  );
+  return endpoint;
+}
+
+export function validateProfileBytes(
+  raw,
+  { expectedDigest = '', scope = '', platform = '' } = {},
+) {
+  const digest = sha256(raw);
+  if (expectedDigest) {
+    assert(
+      DIGEST_RE.test(expectedDigest),
+      'expected profile digest must be sha256:<64 lowercase hex>',
+    );
+    assert(
+      digest === expectedDigest,
+      `cache profile digest mismatch: expected ${expectedDigest}, got ${digest}`,
+    );
+  }
+  let profile;
+  try {
+    profile = JSON.parse(raw.toString('utf8'));
+  } catch (error) {
+    throw new CacheProfileError(
+      `cache profile is invalid JSON: ${error.message}`,
+    );
+  }
+  assertExactKeys(
+    profile,
+    new Set([
+      '$schema',
+      'schema',
+      'profileId',
+      'revision',
+      'generatedAt',
+      'authority',
+      'subject',
+      'policy',
+      'services',
+      'evidence',
+    ]),
+    [
+      '$schema',
+      'schema',
+      'profileId',
+      'revision',
+      'generatedAt',
+      'authority',
+      'subject',
+      'policy',
+      'services',
+      'evidence',
+    ],
+    'profile',
+  );
+  assert(
+    profile.schema === PROFILE_SCHEMA,
+    `unsupported cache profile schema: ${profile.schema}`,
+  );
+  assert(
+    typeof profile.profileId === 'string' && profile.profileId,
+    'profileId is required',
+  );
+  assert(
+    Number.isInteger(profile.revision) && profile.revision >= 1,
+    'revision must be >= 1',
+  );
+  assert(
+    !Number.isNaN(Date.parse(profile.generatedAt)),
+    'generatedAt must be a date-time',
+  );
+  assertExactKeys(
+    profile.authority,
+    new Set(['owner', 'sourceRef', 'sourceDigest']),
+    ['owner', 'sourceRef', 'sourceDigest'],
+    'authority',
+  );
+  assert(
+    DIGEST_RE.test(profile.authority.sourceDigest),
+    'authority.sourceDigest is invalid',
+  );
+  assertExactKeys(
+    profile.subject,
+    new Set(['principal', 'host', 'platforms', 'scopes']),
+    ['principal', 'platforms', 'scopes'],
+    'subject',
+  );
+  assert(
+    Array.isArray(profile.subject.platforms) &&
+      profile.subject.platforms.length > 0,
+    'subject.platforms must not be empty',
+  );
+  assert(
+    Array.isArray(profile.subject.scopes) && profile.subject.scopes.length > 0,
+    'subject.scopes must not be empty',
+  );
+  if (platform)
+    assert(
+      profile.subject.platforms.includes(platform),
+      `cache profile does not apply to platform ${platform}`,
+    );
+  if (scope)
+    assert(
+      profile.subject.scopes.includes(scope),
+      `cache profile does not apply to scope ${scope}`,
+    );
+  assertExactKeys(
+    profile.policy,
+    new Set(['mode', 'onUnavailable', 'allowPublicFallback', 'secretPolicy']),
+    ['mode', 'onUnavailable', 'allowPublicFallback', 'secretPolicy'],
+    'policy',
+  );
+  assert(
+    ['off', 'prefer', 'require'].includes(profile.policy.mode),
+    'profile policy mode is invalid',
+  );
+  assert(
+    ['bypass', 'fallback', 'fail'].includes(profile.policy.onUnavailable),
+    'profile onUnavailable is invalid',
+  );
+  assert(
+    profile.policy.secretPolicy === 'references-only',
+    'profile secret policy must be references-only',
+  );
+  if (profile.policy.mode === 'require')
+    assert(
+      profile.policy.onUnavailable === 'fail',
+      'required profile must fail when unavailable',
+    );
+  assertExactKeys(
+    profile.evidence,
+    new Set(['enabled', 'redaction']),
+    ['enabled', 'redaction'],
+    'evidence',
+  );
+  assert(
+    profile.evidence.redaction === REDACTION,
+    'unsupported evidence redaction policy',
+  );
+
+  const services = assertObject(profile.services, 'services');
+  assert(Object.keys(services).length > 0, 'profile must contain services');
+  const bindings = {};
+  const receiptServices = {};
+  for (const [serviceId, service] of Object.entries(services)) {
+    assertExactKeys(
+      service,
+      new Set([
+        'kind',
+        'mode',
+        'endpoint',
+        'bindings',
+        'fallback',
+        'verification',
+      ]),
+      ['kind', 'endpoint', 'bindings', 'fallback', 'verification'],
+      `services.${serviceId}`,
+    );
+    const endpoint = validateEndpoint(service.endpoint, serviceId);
+    assert(
+      Array.isArray(service.bindings) && service.bindings.length > 0,
+      `services.${serviceId}.bindings must not be empty`,
+    );
+    for (const binding of service.bindings) {
+      validateBinding(binding, serviceId);
+      if (binding.kind !== 'environment') {
+        throw new CacheProfileError(
+          `runtime apply does not support ${binding.kind} binding ${serviceId}/${binding.key}`,
+        );
+      }
+      validateEnvironmentKey(binding.key);
+      assert(
+        !Object.hasOwn(bindings, binding.key),
+        `duplicate environment binding: ${binding.key}`,
+      );
+      bindings[binding.key] = endpointValue(endpoint, binding);
+    }
+    assertObject(service.fallback, `services.${serviceId}.fallback`);
+    if (profile.policy.mode === 'require')
+      assert(
+        service.fallback.mode === 'fail',
+        `required service ${serviceId} must fail`,
+      );
+    if (!profile.policy.allowPublicFallback)
+      assert(
+        service.fallback.mode !== 'upstream',
+        `service ${serviceId} cannot use public fallback`,
+      );
+    receiptServices[serviceId] = {
+      outcome: 'hit',
+      selected:
+        endpoint.type === 'http'
+          ? { type: 'http', url: endpoint.url }
+          : {
+              type: 'local-path',
+              pathDigest: sha256(Buffer.from(endpoint.path)),
+            },
+      fallbackUsed: false,
+      verification: 'not-run',
+      durationMs: 0,
+      reason: 'profile binding selected',
+    };
+  }
+  return {
+    profile,
+    digest,
+    platform: platform || platformId(),
+    scope: scope || inferScope(),
+    bindings,
+    receiptServices,
+  };
+}
+
+function receiptFor(resolved) {
+  return {
+    $schema:
+      'https://libkungfu.dev/schemas/shifu/cache-resolution-v1.schema.json',
+    schema: RECEIPT_SCHEMA,
+    profile: {
+      id: resolved.profile.profileId,
+      revision: resolved.profile.revision,
+      digest: resolved.digest,
+    },
+    execution: {
+      id: `run:${crypto.randomUUID()}`,
+      platform: resolved.platform,
+      scope: resolved.scope,
+      resolvedAt: new Date().toISOString(),
+    },
+    services: resolved.receiptServices,
+    redaction: REDACTION,
+  };
+}
+
+/**
+ * @param {{reference?: string, expectedDigest?: string, scope?: string,
+ *   cwd?: string, timeoutMs?: number}} [options]
+ */
+export async function resolveCacheProfile({
+  reference,
+  expectedDigest,
+  scope,
+  cwd = process.cwd(),
+  timeoutMs,
+} = {}) {
+  assert(reference, 'cache profile reference is required');
+  assert(expectedDigest, 'cache profile digest is required');
+  const raw = await readProfileReference(reference, { cwd, timeoutMs });
+  const resolved = validateProfileBytes(raw, {
+    expectedDigest,
+    scope: scope || inferScope(),
+    platform: platformId(),
+  });
+  return { ...resolved, receipt: receiptFor(resolved) };
+}
+
+/** @param {Record<string, unknown>} receipt @param {string} receiptPath */
+export function writeReceipt(receipt, receiptPath) {
+  if (!receiptPath) return;
+  const target = path.resolve(receiptPath);
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  const temporary = `${target}.tmp-${process.pid}-${crypto.randomUUID()}`;
+  fs.writeFileSync(temporary, `${JSON.stringify(receipt, null, 2)}\n`, {
+    mode: 0o600,
+  });
+  fs.renameSync(temporary, target);
+}
+
+function spawnChild(command, args, options) {
+  if (
+    process.platform === 'win32' &&
+    [
+      'shifu',
+      './shifu',
+      '.\\shifu',
+      'shifu.cmd',
+      './shifu.cmd',
+      '.\\shifu.cmd',
+    ].includes(command)
+  ) {
+    const quote = (value) => `"${String(value).replaceAll('"', '""')}"`;
+    const line = [quote('shifu.cmd'), ...args.map(quote)].join(' ');
+    return spawnSync('cmd.exe', ['/d', '/s', '/c', line], options);
+  }
+  return spawnSync(command, args, options);
+}
+
+/**
+ * @param {{reference?: string, expectedDigest?: string, scope?: string,
+ *   receiptPath?: string, command?: string, args?: string[], cwd?: string,
+ *   env?: NodeJS.ProcessEnv}} [options]
+ */
+export async function applyCacheProfile({
+  reference,
+  expectedDigest,
+  scope,
+  receiptPath,
+  command,
+  args = [],
+  cwd = process.cwd(),
+  env = process.env,
+} = {}) {
+  assert(command, 'cache apply requires a command after --');
+  if (!reference && !expectedDigest) {
+    const result = spawnChild(command, args, {
+      cwd,
+      env,
+      stdio: 'inherit',
+      shell: false,
+    });
+    if (result.error)
+      throw new CacheProfileError(
+        `cannot run ${command}: ${result.error.message}`,
+      );
+    return result.status ?? 1;
+  }
+  assert(
+    reference && expectedDigest,
+    'cache profile reference and digest must be supplied together',
+  );
+  const resolved = await resolveCacheProfile({
+    reference,
+    expectedDigest,
+    scope,
+    cwd,
+  });
+  writeReceipt(resolved.receipt, receiptPath);
+  const childEnv = { ...env, ...resolved.bindings, SHIFU_CACHE_ACTIVE: '1' };
+  const result = spawnChild(command, args, {
+    cwd,
+    env: childEnv,
+    stdio: 'inherit',
+    shell: false,
+  });
+  if (result.error)
+    throw new CacheProfileError(
+      `cannot run ${command}: ${result.error.message}`,
+    );
+  return result.status ?? 1;
+}

--- a/scripts/shifu-cache-runtime.test.mjs
+++ b/scripts/shifu-cache-runtime.test.mjs
@@ -1,0 +1,205 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import http from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import Ajv2020 from 'ajv/dist/2020.js';
+
+import {
+  CacheProfileError,
+  applyCacheProfile,
+  resolveCacheProfile,
+  sha256,
+  validateProfileBytes,
+} from './shifu-cache-runtime.mjs';
+
+const platform =
+  process.platform === 'darwin'
+    ? `darwin-${process.arch}`
+    : process.platform === 'win32'
+      ? `windows-${process.arch}`
+      : `${process.platform}-${process.arch}`;
+
+function profile(overrides = {}) {
+  return {
+    $schema: 'https://libkungfu.dev/schemas/shifu/cache-profile-v1.schema.json',
+    schema: 'shifu.cache-profile/v1',
+    profileId: 'test.cache-profile',
+    revision: 1,
+    generatedAt: '2026-07-12T00:00:00Z',
+    authority: {
+      owner: 'test-inventory',
+      sourceRef: 'test/inventory.json@revision-1',
+      sourceDigest: `sha256:${'1'.repeat(64)}`,
+    },
+    subject: {
+      principal: 'test:runner',
+      platforms: [platform],
+      scopes: ['development', 'self-hosted-runner', 'ci'],
+    },
+    policy: {
+      mode: 'require',
+      onUnavailable: 'fail',
+      allowPublicFallback: false,
+      secretPolicy: 'references-only',
+    },
+    services: {
+      'npm-registry': {
+        kind: 'package-registry',
+        mode: 'require',
+        endpoint: { type: 'http', url: 'http://cache.example.invalid/npm/' },
+        bindings: [
+          {
+            kind: 'environment',
+            key: 'COREPACK_NPM_REGISTRY',
+            valueFrom: 'endpoint.url',
+          },
+        ],
+        fallback: { mode: 'fail' },
+        verification: { method: 'tool-native' },
+      },
+    },
+    evidence: {
+      enabled: true,
+      redaction: 'credentials-userinfo-query-fragment',
+    },
+    ...overrides,
+  };
+}
+
+function bytes(value = profile()) {
+  return Buffer.from(`${JSON.stringify(value, null, 2)}\n`);
+}
+
+test('validates exact bytes and applies only environment bindings', () => {
+  const raw = bytes();
+  const digest = sha256(raw);
+  const resolved = validateProfileBytes(raw, {
+    expectedDigest: digest,
+    platform,
+    scope: 'self-hosted-runner',
+  });
+  assert.equal(resolved.digest, digest);
+  assert.deepEqual(resolved.bindings, {
+    COREPACK_NPM_REGISTRY: 'http://cache.example.invalid/npm/',
+  });
+});
+
+test('fails closed on digest mismatch and secret-like environment keys', () => {
+  assert.throws(
+    () =>
+      validateProfileBytes(bytes(), {
+        expectedDigest: `sha256:${'0'.repeat(64)}`,
+      }),
+    /digest mismatch/,
+  );
+  const unsafe = profile();
+  unsafe.services['npm-registry'].bindings[0].key = 'CACHE_AUTH_TOKEN';
+  assert.throws(() => validateProfileBytes(bytes(unsafe)), /secret-like/);
+});
+
+test('rejects endpoint credentials, query strings, and unknown fields', () => {
+  for (const url of [
+    'https://user:pass@cache.example.invalid/npm/',
+    'https://cache.example.invalid/npm/?token=redacted',
+    'https://cache.example.invalid/npm/#fragment',
+  ]) {
+    const unsafe = profile();
+    unsafe.services['npm-registry'].endpoint.url = url;
+    assert.throws(() => validateProfileBytes(bytes(unsafe)), CacheProfileError);
+  }
+  const unknown = profile({ unexpected: true });
+  assert.throws(() => validateProfileBytes(bytes(unknown)), /not supported/);
+});
+
+test('resolves an HTTP reference and emits a redacted schema receipt', async (t) => {
+  const raw = bytes();
+  const server = http.createServer((_request, response) => {
+    response.writeHead(200, { 'content-type': 'application/json' });
+    response.end(raw);
+  });
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  t.after(() => server.close());
+  const address = server.address();
+  const reference = `http://127.0.0.1:${address.port}/profile.json`;
+  const resolved = await resolveCacheProfile({
+    reference,
+    expectedDigest: sha256(raw),
+    scope: 'self-hosted-runner',
+  });
+  assert.equal(resolved.receipt.schema, 'shifu.cache-resolution/v1');
+  assert.equal(
+    resolved.receipt.redaction,
+    'credentials-userinfo-query-fragment',
+  );
+  assert.equal(
+    resolved.receipt.services['npm-registry'].selected.url,
+    'http://cache.example.invalid/npm/',
+  );
+  const schema = JSON.parse(
+    fs.readFileSync(
+      new URL(
+        '../docs/shifu/schema/cache-resolution-v1.schema.json',
+        import.meta.url,
+      ),
+      'utf8',
+    ),
+  );
+  const ajv = new Ajv2020({ strict: false });
+  ajv.addFormat('date-time', (value) => Number.isFinite(Date.parse(value)));
+  ajv.addFormat('uri-reference', () => true);
+  const validate = ajv.compile(schema);
+  assert.equal(
+    validate(resolved.receipt),
+    true,
+    JSON.stringify(validate.errors),
+  );
+});
+
+test('cache apply injects bindings and writes a receipt', async (t) => {
+  const directory = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'shifu-cache-apply-'),
+  );
+  t.after(() => fs.rmSync(directory, { recursive: true, force: true }));
+  const raw = bytes();
+  const profilePath = path.join(directory, 'profile.json');
+  const outputPath = path.join(directory, 'child.json');
+  const receiptPath = path.join(directory, 'receipt.json');
+  fs.writeFileSync(profilePath, raw);
+  const script = `require('node:fs').writeFileSync(${JSON.stringify(outputPath)}, JSON.stringify({value: process.env.COREPACK_NPM_REGISTRY, active: process.env.SHIFU_CACHE_ACTIVE}))`;
+  const status = await applyCacheProfile({
+    reference: profilePath,
+    expectedDigest: sha256(raw),
+    scope: 'development',
+    receiptPath,
+    command: process.execPath,
+    args: ['-e', script],
+  });
+  assert.equal(status, 0);
+  assert.deepEqual(JSON.parse(fs.readFileSync(outputPath, 'utf8')), {
+    value: 'http://cache.example.invalid/npm/',
+    active: '1',
+  });
+  const receipt = JSON.parse(fs.readFileSync(receiptPath, 'utf8'));
+  assert.equal(receipt.profile.digest, sha256(raw));
+  assert.match(receipt.execution.id, /^run:/);
+});
+
+test('cache apply is a transparent pass-through when no profile is configured', async (t) => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'shifu-cache-pass-'));
+  t.after(() => fs.rmSync(directory, { recursive: true, force: true }));
+  const outputPath = path.join(directory, 'ran');
+  const status = await applyCacheProfile({
+    command: process.execPath,
+    args: [
+      '-e',
+      `require('node:fs').writeFileSync(${JSON.stringify(outputPath)}, 'yes')`,
+    ],
+  });
+  assert.equal(status, 0);
+  assert.equal(fs.readFileSync(outputPath, 'utf8'), 'yes');
+});

--- a/shifu
+++ b/shifu
@@ -159,6 +159,23 @@ kungfu_load_proxy
 export SHIFU_FROM_SHIM=1
 export SHIFU_ENTRYPOINT=1
 
+# Cache profiles are a checkout-owned L2 contract. Dispatch them before the
+# native launcher even when SHIFU_NATIVE=1: the outer cache apply must resolve
+# and inject bindings first, while the child `./shifu <task>` remains free to
+# use the native launcher. Without this boundary the native task fallback sees
+# `cache` as a pnpm script and runs `pnpm cache` instead.
+if [ "${1:-}" = "cache" ]; then
+  if command -v fnm >/dev/null 2>&1; then
+    fnm install >/dev/null 2>&1 || true
+    exec fnm exec --using-file -- node ./shifu.mjs "$@"
+  elif command -v node >/dev/null 2>&1; then
+    exec node ./shifu.mjs "$@"
+  else
+    echo "shifu: cache commands need node — install fnm or any system node" >&2
+    exit 127
+  fi
+fi
+
 if [ "${SHIFU_NATIVE:-}" != "0" ]; then
   if [ -n "${SHIFU_BIN:-}" ] && [ -x "${SHIFU_BIN}" ]; then
     exec "${SHIFU_BIN}" "$@"
@@ -233,7 +250,7 @@ esac
 # prefer fnm-managed node when available (the normal path once bootstrap is ready); fall back to system node when fnm is
 # not ready, so a developer can still use L2 config first (e.g. set a mirror to in turn help fnm); error only if neither exists.
 case "${1:-}" in
-  build | rebuild | cache | proxy | config)
+  build | rebuild | proxy | config)
     if command -v fnm >/dev/null 2>&1; then
       fnm install >/dev/null 2>&1 || true
       exec fnm exec --using-file -- node ./shifu.mjs "$@"

--- a/shifu.cmd
+++ b/shifu.cmd
@@ -52,6 +52,10 @@ rem Mark the canonical entrypoint and keep native dispatches from re-delegating 
 set "SHIFU_FROM_SHIM=1"
 set "SHIFU_ENTRYPOINT=1"
 
+rem Cache profiles are checkout-owned L2 contracts. Resolve/apply them before
+rem native dispatch; an inner `shifu <task>` can still select the native path.
+if /i "%~1"=="cache" goto delegate
+
 rem -- Native launcher resolution ------------------------------------------------
 if "%SHIFU_NATIVE%"=="0" goto inscript
 
@@ -181,7 +185,6 @@ exit /b 0
 rem -- Delegate rich subcommands to L2 node (no pnpm, no uv). Prefer fnm node, else system node. --
 if /i "%~1"=="proxy"  goto delegate
 if /i "%~1"=="config" goto delegate
-if /i "%~1"=="cache"  goto delegate
 goto bootstrap
 
 :delegate

--- a/shifu.mjs
+++ b/shifu.mjs
@@ -20,6 +20,12 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
+import {
+  applyCacheProfile,
+  resolveCacheProfile,
+  validateProfileBytes,
+  writeReceipt,
+} from './scripts/shifu-cache-runtime.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -181,13 +187,85 @@ function cacheHelp() {
   cache contract            print the canonical contract manifest
   cache schema profile      print the cache-profile JSON Schema
   cache schema resolution   print the resolution-evidence JSON Schema
+  cache validate profile [FILE|-] [--digest SHA256]
+                            validate one profile through the Shifu runtime
+  cache resolve [OPTIONS]   resolve a trusted profile and print a redacted receipt
+  cache apply [OPTIONS] -- COMMAND [ARGS...]
+                            apply environment bindings to one child execution
 
-The output is the exact checked-in JSON. Private inventories generate profile
-instances; they do not change or get embedded in this contract.`);
+Runtime options:
+  --profile REF             local path, file URL, or secret-free http(s) URL
+  --digest SHA256           required exact sha256:<64 lowercase hex> digest
+  --scope SCOPE             defaults to development, CI, or self-hosted-runner
+  --receipt FILE            write the redacted resolution receipt atomically
+
+SHIFU_CACHE_PROFILE_REF and SHIFU_CACHE_PROFILE_DIGEST provide the default
+reference/digest. When both are absent, cache apply runs the command unchanged;
+supplying only one fails closed.
+
+Contract and schema discovery return the exact checked-in JSON. Private
+inventories generate profile instances; they do not change or get embedded in
+this contract.`);
+}
+
+function defaultReceiptPath() {
+  if (process.env.SHIFU_CACHE_RECEIPT) return process.env.SHIFU_CACHE_RECEIPT;
+  if (fs.existsSync(path.join(__dirname, '.buildchain'))) {
+    return path.join(
+      __dirname,
+      '.buildchain',
+      'diagnostics',
+      'shifu-cache-resolution.json',
+    );
+  }
+  return '';
+}
+
+/**
+ * @typedef {object} CacheRuntimeOptions
+ * @property {string} reference
+ * @property {string} expectedDigest
+ * @property {string} scope
+ * @property {string} receiptPath
+ * @property {string} command
+ * @property {string[]} args
+ */
+
+/** @param {string[]} argv @returns {CacheRuntimeOptions} */
+function parseCacheRuntimeOptions(argv) {
+  /** @type {CacheRuntimeOptions} */
+  const options = {
+    reference: process.env.SHIFU_CACHE_PROFILE_REF || '',
+    expectedDigest: process.env.SHIFU_CACHE_PROFILE_DIGEST || '',
+    scope: process.env.SHIFU_CACHE_SCOPE || '',
+    receiptPath: defaultReceiptPath(),
+    command: '',
+    args: [],
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--') {
+      options.command = argv[i + 1] || '';
+      options.args = argv.slice(i + 2);
+      return options;
+    }
+    const value = () => {
+      i += 1;
+      if (i >= argv.length) throw new Error(`${arg} requires a value`);
+      return argv[i];
+    };
+    if (arg === '--profile' || arg === '--profile-ref')
+      options.reference = value();
+    else if (arg === '--digest') options.expectedDigest = value();
+    else if (arg === '--scope') options.scope = value();
+    else if (arg === '--receipt') options.receiptPath = value();
+    else throw new Error(`unknown cache runtime option: ${arg}`);
+  }
+  return options;
 }
 
 /** @param {string[]} argv */
-function runCacheCommand(argv) {
+async function runCacheCommand(argv) {
   const sub = argv[0] || 'help';
   if (sub === 'contract' && argv.length === 1) {
     process.stdout.write(fs.readFileSync(CACHE_CONTRACT));
@@ -195,6 +273,42 @@ function runCacheCommand(argv) {
   }
   if (sub === 'schema' && argv.length === 2 && CACHE_SCHEMAS[argv[1]]) {
     process.stdout.write(fs.readFileSync(CACHE_SCHEMAS[argv[1]]));
+    return;
+  }
+  if (sub === 'validate' && argv[1] === 'profile') {
+    let profilePath = '-';
+    let expectedDigest = '';
+    for (let i = 2; i < argv.length; i += 1) {
+      if (argv[i] === '--digest') {
+        expectedDigest = argv[i + 1] || '';
+        i += 1;
+      } else if (profilePath === '-') {
+        profilePath = argv[i];
+      } else {
+        throw new Error(`unknown cache validate argument: ${argv[i]}`);
+      }
+    }
+    const raw =
+      profilePath === '-'
+        ? fs.readFileSync(0)
+        : fs.readFileSync(path.resolve(profilePath));
+    const result = validateProfileBytes(raw, { expectedDigest });
+    process.stdout.write(
+      `${JSON.stringify({ schema: result.profile.schema, profileId: result.profile.profileId, digest: result.digest, valid: true }, null, 2)}\n`,
+    );
+    return;
+  }
+  if (sub === 'resolve') {
+    const options = parseCacheRuntimeOptions(argv.slice(1));
+    const resolved = await resolveCacheProfile(options);
+    writeReceipt(resolved.receipt, options.receiptPath);
+    process.stdout.write(`${JSON.stringify(resolved.receipt, null, 2)}\n`);
+    return;
+  }
+  if (sub === 'apply') {
+    const options = parseCacheRuntimeOptions(argv.slice(1));
+    const status = await applyCacheProfile(options);
+    process.exitCode = status;
     return;
   }
   if (sub === 'help' || sub === '-h' || sub === '--help') {
@@ -205,7 +319,7 @@ function runCacheCommand(argv) {
   process.exitCode = 2;
 }
 
-function main() {
+async function main() {
   const argv = process.argv.slice(2);
   const cmd = argv[0];
   if (cmd === 'build' || cmd === 'rebuild') {
@@ -213,7 +327,7 @@ function main() {
     return;
   }
   if (cmd === 'cache') {
-    runCacheCommand(argv.slice(1));
+    await runCacheCommand(argv.slice(1));
     return;
   }
   if (cmd !== 'proxy' && cmd !== 'config') {
@@ -298,4 +412,9 @@ function main() {
   }
 }
 
-if (import.meta.url === pathToFileURL(process.argv[1]).href) main();
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(`shifu: ${error.message}`);
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
## Summary

- implement Shifu-owned cache profile validation, resolution, binding application, and redacted receipts
- wrap lifecycle and verification execution through `shifu cache apply`
- pass only an opaque profile reference and digest through Buildchain
- document the KFD-1 profile runtime and ownership boundary

## Validation

- `./shifu check`
- cache runtime and contract tests: 13 passed
- consumer currently pinned to `train/v2/v2.3/shifu-cache-profile-passthrough` for downstream validation

## Dependency

- kungfu-systems/buildchain#1139 must merge and publish a final ref before this PR replaces the temporary train reference and merges.

## Safety

Profiles and receipts reject URL credentials, query strings, fragments, secret-like environment keys, unsupported bindings, scope drift, and digest drift.