### PR TITLE
fix(product): scope observability to current run

### DIFF
--- a/framework/api/src/capability/atlas.ts
+++ b/framework/api/src/capability/atlas.ts
@@ -1,4 +1,4 @@
-import type { SavedQueryView } from './query';
+import type { SavedQueryView } from './query.js';
 
 // Mission Control capability handle over the `kungfu atlas` pre-release CLI.
 // Atlas remains authority for imported facts; native Mission/Go/claim writes

--- a/product/scripts/dist.mjs
+++ b/product/scripts/dist.mjs
@@ -57,6 +57,9 @@ const buildchainLogger = createBuildchainLogger({
     package: '@kungfu-tech/product-kungfu',
   },
 });
+const buildchainLogEventStartIndex = buildchainLogger.path
+  ? readBuildchainLogEvents(buildchainLogger.path).length
+  : 0;
 
 const parsedArgs = parseArgs(process.argv.slice(2));
 const builderArgs = parsedArgs.builderArgs;
@@ -1365,7 +1368,11 @@ function main() {
   );
 }
 
-export function verifyProductObservabilityEvents(events, target = 'all') {
+export function verifyProductObservabilityEvents(
+  events,
+  target = 'all',
+  startIndex = 0,
+) {
   const requiredEvents = [
     'product.dist.start',
     'product.kfx.dependencies.declared',
@@ -1382,7 +1389,9 @@ export function verifyProductObservabilityEvents(events, target = 'all') {
     requiredEvents.push('product.cli.smoke.start');
   }
   return verifyBuildchainLogEvents({
-    events: events.filter((event) => event.component === 'kungfu-product'),
+    events: events
+      .slice(startIndex)
+      .filter((event) => event.component === 'kungfu-product'),
     minEvents: 12,
     requireComponents: ['kungfu-product'],
     requirePhases: [
@@ -1404,6 +1413,7 @@ function verifyObservability() {
   const report = verifyProductObservabilityEvents(
     readBuildchainLogEvents(buildchainLogger.path),
     productTarget,
+    buildchainLogEventStartIndex,
   );
   if (!report.ok) {
     throw new Error(

--- a/product/scripts/dist.test.mjs
+++ b/product/scripts/dist.test.mjs
@@ -58,6 +58,47 @@ test('product observability ignores errors from sibling components', () => {
   assert.equal(report.summary.eventCount, names.length);
 });
 
+test('product observability ignores same-component errors from prior runs', () => {
+  const events = [
+    {
+      contract: 'kungfu-buildchain-log-event',
+      timestamp: '2026-07-12T00:00:00.000Z',
+      level: 'error',
+      source: 'user',
+      component: 'kungfu-product',
+      event: 'product.dist.error',
+      phase: 'package',
+    },
+    ...[
+      ['product.dist.start', 'prepare'],
+      ['product.kfx.dependencies.declared', 'dependencies'],
+      ['product.dependencies.sync.start', 'dependencies'],
+      ['product.core.rebuild.start', 'core'],
+      ['product.core.freeze.start', 'core'],
+      ['product.extensions.build.start', 'extensions'],
+      ['product.ui.bundle.start', 'ui'],
+      ['product.desktop.electron-builder.start', 'package'],
+      ['product.cli.archive.start', 'package'],
+      ['product.cli.smoke.start', 'package'],
+      ['product.cli.smoke.end', 'package'],
+      ['product.dist.end', 'package'],
+    ].map(([event, phase]) => ({
+      contract: 'kungfu-buildchain-log-event',
+      timestamp: '2026-07-12T00:01:00.000Z',
+      level: 'info',
+      source: 'user',
+      component: 'kungfu-product',
+      event,
+      phase,
+    })),
+  ];
+
+  const report = verifyProductObservabilityEvents(events, 'all', 1);
+  assert.equal(report.ok, true);
+  assert.equal(report.summary.errorCount, 0);
+  assert.equal(report.summary.eventCount, 12);
+});
+
 test('electron before-pack uses a file URL only on Windows', () => {
   const entryPath = new URL(
     '../../framework/gui/scripts/gen-first-party-manifest.mjs',


### PR DESCRIPTION
## Summary
- verify product Buildchain log events only from the current process window
- ignore stale same-component errors retained by a self-hosted workspace across reruns without deleting the shared JSONL
- fix the NodeNext `.js` extension missing from the newly added Atlas saved-query type import

## Validation
- `./shifu check`
- product observability regression covers prior-run `kungfu-product` errors
- tooling type check covers the NodeNext import

Kungfu r8 direct qualification already proved AppImage creation and the installed CLI layout smoke; it then failed only because 32 error events from prior attempts remained in the append-only log.