### PR TITLE
fix(ci): qualify membranes on current toolchains

### DIFF
--- a/.github/workflows/embedding-membrane-spike.yml
+++ b/.github/workflows/embedding-membrane-spike.yml
@@ -213,7 +213,7 @@ jobs:
             spike_python="$PWD/framework/core/.venv/Scripts/python.exe"
           fi
           # shifu-entry-contract: allow the isolated spike configure is not a product-level Shifu task
-          cmake -S framework/core -B framework/core/build \
+          cmake -S framework/core -B framework/core/build -G Ninja \
             -DCMAKE_TOOLCHAIN_FILE="$PWD/framework/core/build/conan_toolchain.cmake" \
             -DCMAKE_POLICY_DEFAULT_CMP0091=NEW \
             -DCMAKE_BUILD_TYPE=Release \

--- a/.github/workflows/embedding-membrane-spike.yml
+++ b/.github/workflows/embedding-membrane-spike.yml
@@ -77,7 +77,7 @@ jobs:
       matrix:
         include:
           - name: Linux x64
-            runner: '"ubuntu-22.04"'
+            runner: '"ubuntu-24.04"'
             source_mode: github
           - name: macOS ARM64
             runner: '"macos-15"'
@@ -103,6 +103,15 @@ jobs:
         uses: actions/setup-node@v6.4.0
         with:
           node-version: "24"
+
+      - name: Select Linux qualification compiler
+        if: ${{ runner.os == 'Linux' }}
+        shell: bash
+        run: |
+          gcc-14 --version
+          g++-14 --version
+          echo "CC=gcc-14" >> "$GITHUB_ENV"
+          echo "CXX=g++-14" >> "$GITHUB_ENV"
 
       - name: Expose Git Bash on Windows
         if: ${{ runner.os == 'Windows' }}

--- a/.github/workflows/embedding-membrane-spike.yml
+++ b/.github/workflows/embedding-membrane-spike.yml
@@ -26,7 +26,9 @@ on:
       - "product/scripts/compatibility.mjs"
       - "product/scripts/compatibility.test.mjs"
       - "product/scripts/dist.mjs"
+      - "scripts/qualify-embedding-membranes.mjs"
       - "scripts/verify.mjs"
+      - "package.json"
       - ".github/workflows/embedding-membrane-spike.yml"
 
 permissions:
@@ -213,37 +215,14 @@ jobs:
           Set-Location $env:SOURCE_ROOT
           .\shifu.cmd --filter @kungfu-tech/core configure
 
-      - name: Build and run membrane consumers
+      - name: Build and run membrane consumers (POSIX)
+        if: ${{ runner.os != 'Windows' }}
         shell: bash
+        run: cd "$SOURCE_ROOT" && ./shifu qualify:embedding-membranes
+
+      - name: Build and run membrane consumers (Windows)
+        if: ${{ runner.os == 'Windows' }}
+        shell: pwsh
         run: |
-          cd "$SOURCE_ROOT"
-          spike_python="$PWD/framework/core/.venv/bin/python3"
-          if [ "$RUNNER_OS" = "Windows" ]; then
-            spike_python="$PWD/framework/core/.venv/Scripts/python.exe"
-          fi
-          # shifu-entry-contract: allow the isolated spike configure is not a product-level Shifu task
-          cmake -S framework/core -B framework/core/build -G Ninja \
-            -DCMAKE_TOOLCHAIN_FILE="$PWD/framework/core/build/conan_toolchain.cmake" \
-            -DCMAKE_POLICY_DEFAULT_CMP0091=NEW \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DPYTHON_EXECUTABLE="$spike_python" \
-            -DKUNGFU_WITH_SLICES=ON \
-            -DKF_LIBWASM_CARGO_REGISTRY='sparse+https://rsproxy.cn/index/'
-          # shifu-entry-contract: allow the isolated spike targets are not product-level Shifu tasks
-          cmake --build framework/core/build --config Release --parallel 2 \
-            --target shared_embedding_host shared_embedding_native_kfx \
-              native_storage_closure_host libwasm_shared_membrane_host \
-              kungfu_libwasm_self_test
-          if [ "$RUNNER_OS" = "macOS" ]; then
-            test "$(uname -m)" = "arm64"
-          fi
-          # Keep the latency gate separate from sustained compiler load on the
-          # build runner.  This is one fixed settle, not a benchmark retry.
-          sleep 60
-          # shifu-entry-contract: allow the spike harness must inspect platform-specific binaries directly
-          # shifu-entry-contract: allow the libwasm spike harness must inspect engine cdylibs directly
-          node framework/core/slices/libwasm-shared-membrane/run.mjs framework/core/build
-          # shifu-entry-contract: allow the spike harness must inspect platform-specific binaries directly
-          node framework/core/slices/shared-embedding-membrane/run.mjs framework/core/build
-          # shifu-entry-contract: allow the native closure harness must inspect platform-specific binaries directly
-          node framework/core/slices/native-storage-closure/run.mjs framework/core/build
+          Set-Location $env:SOURCE_ROOT
+          .\shifu.cmd qualify:embedding-membranes

--- a/framework/api/src/capability/atlas.ts
+++ b/framework/api/src/capability/atlas.ts
@@ -1,4 +1,4 @@
-import type { SavedQueryView } from './query';
+import type { SavedQueryView } from './query.js';
 
 // Mission Control capability handle over the `kungfu atlas` pre-release CLI.
 // Atlas remains authority for imported facts; native Mission/Go/claim writes

--- a/framework/core/.conan/recipes/rocksdb/conandata.yml
+++ b/framework/core/.conan/recipes/rocksdb/conandata.yml
@@ -1,0 +1,20 @@
+sources:
+  "6.29.5":
+    url: "https://github.com/facebook/rocksdb.git"
+    tag: "v6.29.5"
+    commit: "da11a59034584ea2d0911268b8136e5249d6b692"
+patches:
+  "6.29.5":
+    - patch_file: "patches/0001-add-include-cstdint-for-gcc-13.patch"
+      patch_description: "include cstdint for GCC 13"
+      patch_type: "portability"
+      patch_source: "https://github.com/facebook/rocksdb/pull/11118"
+    - patch_file: "patches/0002-exclude-thirdparty.patch"
+      patch_description: "do not include vendored third-party configuration"
+      patch_type: "portability"
+    - patch_file: "patches/0003-complete-parallel-compression-before-rep-destruction.patch"
+      patch_description: "instantiate Rep destruction after ParallelCompressionRep is complete"
+      patch_type: "portability"
+    - patch_file: "patches/0004-complete-write-batch-types-before-iterator-destruction.patch"
+      patch_description: "instantiate BaseDeltaIterator destruction after internal iterator types are complete"
+      patch_type: "portability"

--- a/framework/core/.conan/recipes/rocksdb/conanfile.py
+++ b/framework/core/.conan/recipes/rocksdb/conanfile.py
@@ -1,0 +1,195 @@
+# SPDX-License-Identifier: MIT
+
+import glob
+import os
+
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.files import (
+    apply_conandata_patches,
+    collect_libs,
+    copy,
+    rm,
+    rmdir,
+)
+from conan.tools.microsoft import is_msvc, is_msvc_static_runtime
+from conan.tools.scm import Git
+
+
+required_conan_version = ">=2.0"
+
+
+class RocksDBConan(ConanFile):
+    name = "rocksdb"
+    description = "Embeddable persistent key-value store"
+    license = ("GPL-2.0-only", "Apache-2.0")
+    homepage = "https://github.com/facebook/rocksdb"
+    package_type = "library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "lite": [True, False],
+        "with_gflags": [True, False],
+        "with_snappy": [True, False],
+        "with_lz4": [True, False],
+        "with_zlib": [True, False],
+        "with_zstd": [True, False],
+        "with_tbb": [True, False],
+        "with_jemalloc": [True, False],
+        "enable_sse": [False, "sse42", "avx2"],
+        "use_rtti": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "lite": False,
+        "with_gflags": False,
+        "with_snappy": False,
+        "with_lz4": False,
+        "with_zlib": False,
+        "with_zstd": False,
+        "with_tbb": False,
+        "with_jemalloc": False,
+        "enable_sse": False,
+        "use_rtti": False,
+    }
+    exports_sources = "patches/*"
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+        if self.settings.arch != "x86_64":
+            del self.options.with_tbb
+        if self.settings.build_type == "Debug":
+            self.options.use_rtti = True
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def requirements(self):
+        if self.options.with_gflags:
+            self.requires("gflags/2.2.2")
+        if self.options.with_snappy:
+            self.requires("snappy/[>=1.1.10 <2]")
+        if self.options.with_lz4:
+            self.requires("lz4/[>=1.9.4 <2]")
+        if self.options.with_zlib:
+            self.requires("zlib/[>=1.2.11 <2]")
+        if self.options.with_zstd:
+            self.requires("zstd/[~1.5]")
+        if self.options.get_safe("with_tbb"):
+            self.requires("onetbb/2021.10.0")
+        if self.options.with_jemalloc:
+            self.requires("jemalloc/5.3.0")
+
+    def validate(self):
+        check_min_cppstd(self, "11")
+        if self.settings.arch not in ["x86_64", "ppc64le", "ppc64", "mips64", "armv8"]:
+            raise ConanInvalidConfiguration("RocksDB requires 64 bits")
+        if is_msvc(self) and int(str(self.settings.compiler.version)) < 191:
+            raise ConanInvalidConfiguration("RocksDB requires MSVC version >= 191")
+
+    def source(self):
+        source = self.conan_data["sources"][self.version]
+        git = Git(self)
+        git.clone(
+            source["url"],
+            target=".",
+            args=["--depth", "1", "--branch", source["tag"]],
+        )
+        if git.get_commit() != source["commit"]:
+            raise ConanInvalidConfiguration(
+                f"RocksDB source commit does not match {source['commit']}"
+            )
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["FAIL_ON_WARNINGS"] = False
+        tc.variables["WITH_TESTS"] = False
+        tc.variables["WITH_TOOLS"] = False
+        tc.variables["WITH_CORE_TOOLS"] = False
+        tc.variables["WITH_BENCHMARK_TOOLS"] = False
+        tc.variables["WITH_FOLLY_DISTRIBUTED_MUTEX"] = False
+        if is_msvc(self):
+            tc.variables["WITH_MD_LIBRARY"] = not is_msvc_static_runtime(self)
+        tc.variables["ROCKSDB_INSTALL_ON_WINDOWS"] = self.settings.os == "Windows"
+        tc.variables["ROCKSDB_LITE"] = self.options.lite
+        tc.variables["WITH_GFLAGS"] = self.options.with_gflags
+        tc.variables["WITH_SNAPPY"] = self.options.with_snappy
+        tc.variables["WITH_LZ4"] = self.options.with_lz4
+        tc.variables["WITH_ZLIB"] = self.options.with_zlib
+        tc.variables["WITH_ZSTD"] = self.options.with_zstd
+        tc.variables["WITH_TBB"] = self.options.get_safe("with_tbb", False)
+        tc.variables["WITH_JEMALLOC"] = self.options.with_jemalloc
+        tc.variables["ROCKSDB_BUILD_SHARED"] = self.options.shared
+        tc.variables["ROCKSDB_LIBRARY_EXPORTS"] = (
+            self.settings.os == "Windows" and self.options.shared
+        )
+        tc.variables["ROCKSDB_DLL"] = (
+            self.settings.os == "Windows" and self.options.shared
+        )
+        tc.variables["USE_RTTI"] = self.options.use_rtti
+        if not bool(self.options.enable_sse):
+            tc.variables["PORTABLE"] = True
+            tc.variables["FORCE_SSE42"] = False
+        elif self.options.enable_sse == "sse42":
+            tc.variables["PORTABLE"] = True
+            tc.variables["FORCE_SSE42"] = True
+        else:
+            tc.variables["PORTABLE"] = False
+            tc.variables["FORCE_SSE42"] = False
+        tc.variables["WITH_NUMA"] = False
+        tc.generate()
+        CMakeDeps(self).generate()
+
+    def build(self):
+        apply_conandata_patches(self)
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(
+            self,
+            "COPYING",
+            src=self.source_folder,
+            dst=os.path.join(self.package_folder, "licenses"),
+        )
+        copy(
+            self,
+            "LICENSE*",
+            src=self.source_folder,
+            dst=os.path.join(self.package_folder, "licenses"),
+        )
+        cmake = CMake(self)
+        cmake.install()
+        if self.options.shared:
+            rm(self, "rocksdb.lib", os.path.join(self.package_folder, "lib"))
+            for library in glob.glob(os.path.join(self.package_folder, "lib", "*.a")):
+                if not library.endswith(".dll.a"):
+                    os.remove(library)
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+
+    def package_info(self):
+        target = "rocksdb-shared" if self.options.shared else "rocksdb"
+        component = self.cpp_info.components["librocksdb"]
+        self.cpp_info.set_property("cmake_file_name", "RocksDB")
+        self.cpp_info.set_property("cmake_target_name", f"RocksDB::{target}")
+        component.set_property("cmake_target_name", f"RocksDB::{target}")
+        component.libs = collect_libs(self)
+        if self.settings.os == "Windows":
+            component.system_libs = ["shlwapi", "rpcrt4"]
+            if self.options.shared:
+                component.defines = ["ROCKSDB_DLL"]
+        elif self.settings.os in ["Linux", "FreeBSD"]:
+            component.system_libs = ["pthread", "m"]
+        if self.options.lite:
+            component.defines.append("ROCKSDB_LITE")

--- a/framework/core/.conan/recipes/rocksdb/patches/0001-add-include-cstdint-for-gcc-13.patch
+++ b/framework/core/.conan/recipes/rocksdb/patches/0001-add-include-cstdint-for-gcc-13.patch
@@ -1,0 +1,30 @@
+--- a/include/rocksdb/utilities/checkpoint.h
++++ b/include/rocksdb/utilities/checkpoint.h
+@@ -8,6 +8,7 @@
+ #pragma once
+ #ifndef ROCKSDB_LITE
+ 
++#include <cstdint>
+ #include <string>
+ #include <vector>
+ #include "rocksdb/status.h"
+--- a/table/block_based/data_block_hash_index.h
++++ b/table/block_based/data_block_hash_index.h
+@@ -5,6 +5,7 @@
+ 
+ #pragma once
+ 
++#include <cstdint>
+ #include <string>
+ #include <vector>
+ 
+--- a/util/string_util.h
++++ b/util/string_util.h
+@@ -6,6 +6,7 @@
+ 
+ #pragma once
+ 
++#include <cstdint>
+ #include <sstream>
+ #include <string>
+ #include <unordered_map>

--- a/framework/core/.conan/recipes/rocksdb/patches/0002-exclude-thirdparty.patch
+++ b/framework/core/.conan/recipes/rocksdb/patches/0002-exclude-thirdparty.patch
@@ -1,0 +1,16 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ec59d4491..35577c998 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -101 +100,0 @@ if(MSVC)
+-  option(WITH_GFLAGS "build with GFlags" OFF)
+@@ -103,2 +102,2 @@ if(MSVC)
+-  include(${CMAKE_CURRENT_SOURCE_DIR}/thirdparty.inc)
+-else()
++endif()
++
+@@ -117 +116 @@ else()
+-  if(MINGW)
++  if(MINGW OR MSVC)
+@@ -183 +181,0 @@ else()
+-endif()

--- a/framework/core/.conan/recipes/rocksdb/patches/0003-complete-parallel-compression-before-rep-destruction.patch
+++ b/framework/core/.conan/recipes/rocksdb/patches/0003-complete-parallel-compression-before-rep-destruction.patch
@@ -1,0 +1,39 @@
+diff --git a/table/block_based/block_based_table_builder.cc b/table/block_based/block_based_table_builder.cc
+index 8c571aa1c..22024832c 100644
+--- a/table/block_based/block_based_table_builder.cc
++++ b/table/block_based/block_based_table_builder.cc
+@@ -331,7 +331,11 @@ struct BlockBasedTableBuilder::Rep {
+   std::unique_ptr<FlushBlockPolicy> flush_block_policy;
+ 
+   std::vector<std::unique_ptr<IntTblPropCollector>> table_properties_collectors;
+ 
+-  std::unique_ptr<ParallelCompressionRep> pc_rep;
++  struct ParallelCompressionRepDeleter {
++    void operator()(ParallelCompressionRep* value) const;
++  };
++  std::unique_ptr<ParallelCompressionRep, ParallelCompressionRepDeleter>
++      pc_rep;
+ 
+   uint64_t get_offset() { return offset.load(std::memory_order_relaxed); }
+@@ -543,6 +547,7 @@ struct BlockBasedTableBuilder::Rep {
+ 
+   Rep(const Rep&) = delete;
+   Rep& operator=(const Rep&) = delete;
++  ~Rep();
+ 
+  private:
+   // Synchronize status & io_status accesses across threads from main thread,
+@@ -863,6 +868,13 @@ struct BlockBasedTableBuilder::ParallelCompressionRep {
+   }
+ };
+ 
++void BlockBasedTableBuilder::Rep::ParallelCompressionRepDeleter::operator()(
++    BlockBasedTableBuilder::ParallelCompressionRep* value) const {
++  delete value;
++}
++
++BlockBasedTableBuilder::Rep::~Rep() = default;
++
+ BlockBasedTableBuilder::BlockBasedTableBuilder(
+     const BlockBasedTableOptions& table_options, const TableBuilderOptions& tbo,
+     WritableFileWriter* file) {

--- a/framework/core/.conan/recipes/rocksdb/patches/0004-complete-write-batch-types-before-iterator-destruction.patch
+++ b/framework/core/.conan/recipes/rocksdb/patches/0004-complete-write-batch-types-before-iterator-destruction.patch
@@ -1,0 +1,26 @@
+diff --git a/utilities/write_batch_with_index/write_batch_with_index_internal.cc b/utilities/write_batch_with_index/write_batch_with_index_internal.cc
+index 4c841c8ed..86ef5ac3f 100644
+--- a/utilities/write_batch_with_index/write_batch_with_index_internal.cc
++++ b/utilities/write_batch_with_index/write_batch_with_index_internal.cc
+@@ -36,6 +36,8 @@ BaseDeltaIterator::BaseDeltaIterator(ColumnFamilyHandle* column_family,
+   wbwii_.reset(new WriteBatchWithIndexInternal(column_family));
+ }
+ 
++BaseDeltaIterator::~BaseDeltaIterator() = default;
++
+ bool BaseDeltaIterator::Valid() const {
+   return status_.ok() ? (current_at_base_ ? BaseValid() : DeltaValid()) : false;
+ }
+diff --git a/utilities/write_batch_with_index/write_batch_with_index_internal.h b/utilities/write_batch_with_index/write_batch_with_index_internal.h
+index ce0dcb2d6..1c24c85ba 100644
+--- a/utilities/write_batch_with_index/write_batch_with_index_internal.h
++++ b/utilities/write_batch_with_index/write_batch_with_index_internal.h
+@@ -40,7 +40,7 @@ class BaseDeltaIterator : public Iterator {
+                     const Comparator* comparator,
+                     const ReadOptions* read_options = nullptr);
+ 
+-  ~BaseDeltaIterator() override {}
++  ~BaseDeltaIterator() override;
+ 
+   bool Valid() const override;
+   void SeekToFirst() override;

--- a/framework/core/.gyp/run-conan.js
+++ b/framework/core/.gyp/run-conan.js
@@ -38,31 +38,57 @@ function ensureBuildchainConanProfile() {
   );
 }
 
-// GCC 14 correctly rejects two assignment operators in RxCpp 4.1.1 that
-// write through const data members. ConanCenter marks the release unsupported
-// on GCC 14, but Kungfu's production compiler floor is newer than that legacy
-// header. Export our source-patched recipe before resolution so every host and
-// clean cache builds the same audited package revision instead of mutating a
-// shared Conan cache after installation.
+// Export source-patched legacy recipes before resolution so every host and
+// clean cache builds the same audited package revisions instead of mutating a
+// shared Conan cache after installation. RxCpp needs its GCC 14 fix; RocksDB
+// 6.29.5 keeps the persisted-data compatibility contract while receiving the
+// compiler-portability fixes required by current toolchains.
 function ensureKungfuConanRecipes() {
-  const source = path.join(__dirname, '..', '.conan', 'recipes', 'rxcpp');
-  const recipe = fse.mkdtempSync(path.join(os.tmpdir(), 'kungfu-rxcpp-'));
-  try {
-    fse.copySync(source, recipe);
-    for (const relative of [
-      'conanfile.py',
-      'conandata.yml',
-      path.join('patches', '0001-fix-notification-assignment.patch'),
-    ]) {
-      const file = path.join(recipe, relative);
-      fse.writeFileSync(
-        file,
-        fse.readFileSync(file, 'utf8').replace(/\r\n/g, '\n'),
-      );
+  const recipes = [
+    {
+      name: 'rxcpp',
+      version: '4.1.1',
+      files: [
+        'conanfile.py',
+        'conandata.yml',
+        path.join('patches', '0001-fix-notification-assignment.patch'),
+      ],
+    },
+    {
+      name: 'rocksdb',
+      version: '6.29.5',
+      files: [
+        'conanfile.py',
+        'conandata.yml',
+        path.join('patches', '0001-add-include-cstdint-for-gcc-13.patch'),
+        path.join('patches', '0002-exclude-thirdparty.patch'),
+        path.join(
+          'patches',
+          '0003-complete-parallel-compression-before-rep-destruction.patch',
+        ),
+        path.join(
+          'patches',
+          '0004-complete-write-batch-types-before-iterator-destruction.patch',
+        ),
+      ],
+    },
+  ];
+  for (const { name, version, files } of recipes) {
+    const source = path.join(__dirname, '..', '.conan', 'recipes', name);
+    const recipe = fse.mkdtempSync(path.join(os.tmpdir(), `kungfu-${name}-`));
+    try {
+      fse.copySync(source, recipe);
+      for (const file of files) {
+        const absolute = path.join(recipe, file);
+        fse.writeFileSync(
+          absolute,
+          fse.readFileSync(absolute, 'utf8').replace(/\r\n/g, '\n'),
+        );
+      }
+      conan(['export', recipe, '--version', version]);
+    } finally {
+      fse.removeSync(recipe);
     }
-    conan(['export', recipe, '--version', '4.1.1']);
-  } finally {
-    fse.removeSync(recipe);
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "test:runtime-errors": "node scripts/require-shifu.mjs test:runtime-errors && node scripts/run-runtime-error-tests.mjs",
     "qualify:mmap": "node scripts/require-shifu.mjs qualify:mmap && node scripts/run-mmap-qualification.mjs",
     "qualify:cpp-modules": "node scripts/require-shifu.mjs qualify:cpp-modules && node scripts/run-cpp-modules-qualification.mjs",
+    "qualify:embedding-membranes": "node scripts/require-shifu.mjs qualify:embedding-membranes && node scripts/qualify-embedding-membranes.mjs",
     "qualify:libwasm-cache": "node scripts/require-shifu.mjs qualify:libwasm-cache && node scripts/qualify-libwasm-cargo-cache.mjs",
     "version": "node scripts/sync-shifu-version.mjs && git add crates/shifu/Cargo.toml crates/Cargo.lock",
     "prepare": "node scripts/install-hooks.mjs",

--- a/scripts/qualify-embedding-membranes.mjs
+++ b/scripts/qualify-embedding-membranes.mjs
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+// shifu-entry-contract: allow qualification implementation behind ./shifu qualify:embedding-membranes
+
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { setTimeout as delay } from 'node:timers/promises';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const core = path.join(root, 'framework', 'core');
+const build = path.join(core, 'build');
+const python = path.join(
+  core,
+  '.venv',
+  process.platform === 'win32' ? 'Scripts' : 'bin',
+  process.platform === 'win32' ? 'python.exe' : 'python3',
+);
+
+function cmakePath(value) {
+  return value.replaceAll('\\', '/');
+}
+
+function run(command, args) {
+  const result = spawnSync(command, args, {
+    cwd: root,
+    env: process.env,
+    stdio: 'inherit',
+  });
+  if (result.error) {
+    throw new Error(`failed to start ${command}: ${result.error.message}`);
+  }
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+}
+
+if (!fs.existsSync(python)) {
+  throw new Error(`managed Python is not materialized: ${python}`);
+}
+if (process.platform === 'darwin' && process.arch !== 'arm64') {
+  throw new Error(
+    `macOS membrane qualification requires arm64, found ${process.arch}`,
+  );
+}
+
+run('cmake', [
+  '-S',
+  core,
+  '-B',
+  build,
+  '-G',
+  'Ninja',
+  `-DCMAKE_TOOLCHAIN_FILE=${cmakePath(path.join(build, 'conan_toolchain.cmake'))}`,
+  '-DCMAKE_POLICY_DEFAULT_CMP0091=NEW',
+  '-DCMAKE_BUILD_TYPE=Release',
+  `-DPYTHON_EXECUTABLE=${cmakePath(python)}`,
+  '-DKUNGFU_WITH_SLICES=ON',
+  '-DKF_LIBWASM_CARGO_REGISTRY=sparse+https://rsproxy.cn/index/',
+]);
+run('cmake', [
+  '--build',
+  build,
+  '--config',
+  'Release',
+  '--parallel',
+  '2',
+  '--target',
+  'shared_embedding_host',
+  'shared_embedding_native_kfx',
+  'native_storage_closure_host',
+  'libwasm_shared_membrane_host',
+  'kungfu_libwasm_self_test',
+]);
+
+// Keep latency qualification separate from sustained compiler load. This is
+// one fixed settle, not a benchmark retry.
+await delay(60_000);
+
+for (const harness of [
+  'libwasm-shared-membrane',
+  'shared-embedding-membrane',
+  'native-storage-closure',
+]) {
+  run(process.execPath, [path.join(core, 'slices', harness, 'run.mjs'), build]);
+}


### PR DESCRIPTION
## Summary
- run membrane qualification through the pinned Shifu entrypoint on every platform
- select Ubuntu 24.04 with GCC 14 and Ninja, matching the checked-in toolchain contract
- export an audited RocksDB 6.29.5 compatibility recipe with current AppleClang/C++23 fixes while preserving the persisted-data version contract
- let Shifu materialize the MSVC environment on Windows
- include the NodeNext Atlas import fix that currently blocks the repository type gate

## Validation
- `./shifu check`
- prior direct failures reproduced all three gaps: Linux generator/compiler, macOS RocksDB incomplete types, Windows compiler environment
- this PR must pass the three-platform `Embedding membrane spikes` matrix before merge