### PR TITLE
fix(api): use NodeNext query specifier

### DIFF
--- a/framework/api/src/capability/atlas.ts
+++ b/framework/api/src/capability/atlas.ts
@@ -1,4 +1,4 @@
-import type { SavedQueryView } from './query';
+import type { SavedQueryView } from './query.js';
 
 // Mission Control capability handle over the `kungfu atlas` pre-release CLI.
 // Atlas remains authority for imported facts; native Mission/Go/claim writes


### PR DESCRIPTION
Closes #658.

Use an explicit `.js` specifier for the type-only `query` import so the API package remains valid under NodeNext module resolution.

Validation:
- `./shifu check:types`
- `./shifu check`
- `git diff --check`