### PR TITLE
feat(core): single-export embedding DLL — doctor works on Windows (ADR-0046 S3 Phase B2)

### DIFF
--- a/crates/trunk/build.rs
+++ b/crates/trunk/build.rs
@@ -10,11 +10,20 @@
 // feature off and link nothing, so the rlib-only members and the frozen-host
 // launch surface still build with no core in reach.
 //
-// Native dir resolution (POSIX): KF_TRUNK_NATIVE_DIR if set, else the product
-// build's own output at framework/core/build/<type>. The product ships libkungfu
-// next to the trunk binary in dist/kungfu, so an origin-relative rpath resolves
-// it at runtime; the native-dir rpath additionally lets an in-place dev or
-// verification build load a sibling core directly.
+// Native dir resolution: KF_TRUNK_NATIVE_DIR if set, else the product build's own
+// output. On POSIX that is framework/core/build/<type> (where libkungfu.* lands);
+// on Windows it is the build root framework/core/build (where kungfu_embedding.lib
+// and the static kungfu.lib/yijinjing.lib land — MSVC archives colocate at the
+// root, not under a <type> subdir).
+//
+// What the trunk links differs by platform (ADR-0046 stage 3):
+//   POSIX   — the SHARED libkungfu exports kungfu_embedding_get_api directly, so
+//             link `dylib=kungfu`; the product ships libkungfu next to the trunk
+//             binary in dist/kungfu, resolved by an origin-relative rpath.
+//   Windows — the core is STATIC and unexported (COFF 65K export limit), so link
+//             the single-export import lib `kungfu_embedding` (Phase B2); the
+//             product ships kungfu_embedding.dll next to the exe, resolved from
+//             the exe directory (Windows' default DLL search — no rpath).
 
 use std::env;
 use std::path::PathBuf;
@@ -28,37 +37,44 @@ fn main() {
     }
 
     let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
-    if target_os == "windows" {
-        // The core is static on Windows (COFF 65K export limit); the product build
-        // links the static libkungfu and re-exports the single C entry (RFC D2
-        // Windows note). Wiring that static link + import lib is a product-build
-        // follow-up; the feature is POSIX-only until then.
-        panic!(
-            "kungfu-trunk[embedding]: Windows static-core linking is not wired yet \
-             (RFC D2 Windows note); build the embedding feature on macOS/Linux, or \
-             land the Windows static-link follow-up first"
-        );
-    }
+    let is_windows = target_os == "windows";
 
     let manifest = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
     let build_type = env::var("KF_TRUNK_BUILD_TYPE").unwrap_or_else(|_| "Release".to_string());
     let native_dir = env::var_os("KF_TRUNK_NATIVE_DIR")
         .map(PathBuf::from)
         .unwrap_or_else(|| {
-            manifest
-                .join("../../framework/core/build")
-                .join(&build_type)
+            let build = manifest.join("../../framework/core/build");
+            // Windows archives sit at the build root; POSIX under build/<type>.
+            if is_windows {
+                build
+            } else {
+                build.join(&build_type)
+            }
         });
     let native_dir = native_dir.canonicalize().unwrap_or_else(|_| {
+        let lib = if is_windows {
+            "kungfu_embedding.lib"
+        } else {
+            "libkungfu"
+        };
         panic!(
             "kungfu-trunk[embedding]: native dir {} not found; build framework/core \
-             or set KF_TRUNK_NATIVE_DIR to a dir holding libkungfu",
+             or set KF_TRUNK_NATIVE_DIR to a dir holding {lib}",
             native_dir.display()
         )
     });
 
     let native_dir = native_dir.display().to_string();
     println!("cargo:rustc-link-search=native={native_dir}");
+
+    if is_windows {
+        // The single-export DLL's import lib; kungfu_embedding.dll ships next to the
+        // exe and is found via the default DLL search path, so no rpath.
+        println!("cargo:rustc-link-lib=dylib=kungfu_embedding");
+        return;
+    }
+
     println!("cargo:rustc-link-lib=dylib=kungfu");
 
     // Runtime resolution: dist/kungfu ships libkungfu next to the trunk binary, so

--- a/framework/core/.gyp/run-freeze.js
+++ b/framework/core/.gyp/run-freeze.js
@@ -263,8 +263,17 @@ function copyPyBindingWin(bt) {
   const host = fs.existsSync(btHost)
     ? btHost
     : findFileShallow(buildDir, /^kungfu_node_host\.dll$/i);
+  // Single-export embedding membrane DLL (ADR-0046 stage 3, Phase B2): a SHARED
+  // lib that exports only kungfu_embedding_get_api, which the product trunk links
+  // (import lib) so `doctor` works on Windows where the core is STATIC. MSVC emits
+  // kungfu_embedding.dll at the build root (ARCHIVE/RUNTIME_OUTPUT_DIRECTORY =
+  // KUNGFU_BUILD_DIR); check build/<bt> first for resilience, then the root.
+  const btEmb = path.join(buildDir, bt, 'kungfu_embedding.dll');
+  const emb = fs.existsSync(btEmb)
+    ? btEmb
+    : findFileShallow(buildDir, /^kungfu_embedding\.dll$/i);
   let n = 0;
-  for (const src of [pyd, dll, host]) {
+  for (const src of [pyd, dll, host, emb]) {
     if (!src) continue;
     fs.copyFileSync(src, path.join(distKfc, path.basename(src)));
     n++;
@@ -273,11 +282,16 @@ function copyPyBindingWin(bt) {
   // core; libnode.dll is third-party and carries no PDB of ours.
   if (pyd) copyPdbSibling(pyd, distKfc);
   if (host) copyPdbSibling(host, distKfc);
+  if (emb) copyPdbSibling(emb, distKfc);
   if (!pyd) console.error('[freeze] Win 警告：build 树未找到 pykungfu*.pyd');
   if (!dll) console.error('[freeze] Win 警告：build 树未找到 libnode.dll');
   if (!host)
     console.error(
       '[freeze] Win 提示：build 树未找到 kungfu_node_host.dll（node 变体将回退 Python 路径）',
+    );
+  if (!emb)
+    console.error(
+      '[freeze] Win 警告：build 树未找到 kungfu_embedding.dll（doctor 将回退 stub）',
     );
   console.log(`[freeze] Win：补拷 python binding → dist/kungfu：${n} 项`);
 }
@@ -597,28 +611,35 @@ function generateHelpManifest(pythonExe, distKfc) {
 // yields a runnable assembled dist; dist.mjs stageTrunk later re-stages
 // kungfu-trunk and asserts pins consistency at the product stage — same
 // commit, same profile, same binary.
-// ADR-0046 stage 3 productionization: the product trunk links libkungfu and
-// ships the real embedding-backed `doctor` on POSIX (--features embedding).
-// Windows embedding linking is not wired yet (crates/trunk/build.rs panics on
-// windows), so the Windows product trunk stays the coreless stub until that
-// follow-up lands — the trunk's doctor/help/variant paths all fall back
-// gracefully when the core is absent, so keeping Windows featureless is
-// zero-regression. The native dir (framework/core/build/<bt>, already populated
-// with libkungfu.* by the time assemble runs) is passed explicitly so build.rs
-// never has to guess a relative path that could fail canonicalize under CI.
+// ADR-0046 stage 3 productionization: the product trunk links the embedding
+// membrane and ships the real embedding-backed `doctor` on every platform
+// (--features embedding). POSIX links the SHARED libkungfu directly from
+// build/<bt>; Windows links the single-export kungfu_embedding.dll import lib
+// (Phase B2) from the build root, where MSVC archives colocate. The native dir is
+// passed explicitly so build.rs never has to guess a relative path that could
+// fail canonicalize under CI.
 /** @param {string} distKfc @param {string} bt */
 function stageEntry(distKfc, bt) {
   const crates = path.join(CORE, '..', '..', 'crates');
-  const cargoArgs = ['build', '--release', '-p', 'kungfu-trunk'];
-  const runOpts = { cwd: crates, env: process.env };
-  if (!isWin) {
-    cargoArgs.push('--features', 'embedding');
-    runOpts.env = {
+  const cargoArgs = [
+    'build',
+    '--release',
+    '-p',
+    'kungfu-trunk',
+    '--features',
+    'embedding',
+  ];
+  const runOpts = {
+    cwd: crates,
+    env: {
       ...process.env,
-      KF_TRUNK_NATIVE_DIR: path.join(CORE, 'build', bt),
+      // Windows: kungfu_embedding.lib at the build root; POSIX: libkungfu.* under build/<bt>.
+      KF_TRUNK_NATIVE_DIR: isWin
+        ? path.join(CORE, 'build')
+        : path.join(CORE, 'build', bt),
       KF_TRUNK_BUILD_TYPE: bt,
-    };
-  }
+    },
+  };
   shell.run('cargo', cargoArgs, true, runOpts);
   const built = path.join(
     crates,

--- a/framework/core/CMakeLists.txt
+++ b/framework/core/CMakeLists.txt
@@ -92,6 +92,14 @@ if (TARGET ${LIBKUNGFU_NAME})
   add_subdirectory(src/libwasm)
 endif()
 
+# ADR-0046 stage 3 (Phase B2): Windows-only single-export embedding DLL so the
+# trunk can link the embedding membrane where the core is STATIC/unexported. On
+# POSIX the trunk links the SHARED libkungfu directly, so this is Windows-only.
+if (WIN32 AND TARGET ${LIBKUNGFU_NAME})
+  message(STATUS "Enabled kungfu_embedding (Windows single-export membrane DLL)")
+  add_subdirectory(src/libembedding)
+endif()
+
 if (NOT DEFINED ENV{KUNGFU_BUILD_SKIP_KUNGFU_NODE} OR NOT $ENV{KUNGFU_BUILD_SKIP_KUNGFU_NODE})
   message(STATUS "Enabled kungfu_node")
   add_subdirectory(src/bindings/node)

--- a/framework/core/src/libembedding/CMakeLists.txt
+++ b/framework/core/src/libembedding/CMakeLists.txt
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# ADR-0046 stage 3 (Phase B2): a Windows-only SHARED library that exports exactly
+# one C symbol — kungfu_embedding_get_api — so the Rust trunk can link the
+# embedding membrane on Windows. On Windows the core is built STATIC and does not
+# export the embedding entry (a SHARED core blows the COFF 65535-export limit,
+# LNK1189, because of the rocksdb/boost/sqlite_orm template closure — see
+# ../libkungfu/CMakeLists.txt). Exporting a single symbol from a dedicated DLL
+# dodges that limit while still handing the trunk something to link against.
+#
+# This target is deliberately NOT under src/libkungfu/, so it does not inherit
+# that directory's enable_windows_export_all_symbols() — export-all over the whole
+# core closure is exactly what LNK1189 rejects. The single dllexport comes solely
+# from the header's KF_EMBEDDING_BUILD_SHARED path.
+#
+# Windows-only: on POSIX the trunk links libkungfu directly (the SHARED core
+# already exports the entry via visibility, Phase A), so this DLL is never built
+# there and POSIX is untouched.
+#
+# It compiles its own copy of embedding.cpp; the copy already inside kungfu.lib
+# (matched by the src/*.cpp GLOB) stays dormant because nothing references it, so
+# there is no duplicate-definition conflict. embedding.cpp must NOT be removed
+# from the core GLOB — the POSIX libkungfu exports the entry from it.
+
+add_library(kungfu_embedding SHARED
+  ${CMAKE_CURRENT_SOURCE_DIR}/../libkungfu/src/runtime/embedding.cpp)
+
+# The single dllexport; every other embedding function is anonymous-namespace
+# static reached through the kf_embedding_api_v1 table, so nothing else exports.
+target_compile_definitions(kungfu_embedding PRIVATE KF_EMBEDDING_BUILD_SHARED)
+
+# embedding.cpp includes <kungfu/embedding.h> + <kungfu/runtime/io.h>; the rest of
+# the include closure (yijinjing, generated flatbuffers, vendored headers) arrives
+# transitively from the linked core targets' PUBLIC include dirs.
+target_include_directories(kungfu_embedding PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}/../libkungfu/include)
+
+# Whole-core static closure: ${LIBKUNGFU_NAME} (STATIC on Windows) PUBLIC-
+# propagates yijinjing + ${CONAN_LIBS} + userenv/advapi32/user32/ole32. This is
+# pykungfu's link line minus ${LIBNODE} (embedding never touches node). The
+# linker pulls the referenced objects from kungfu.lib/yijinjing.lib on demand.
+target_link_libraries(kungfu_embedding PRIVATE
+  ${LIBKUNGFU_NAME} kungfu_compile_contract ${CONAN_LIBS})
+
+set_target_properties(kungfu_embedding PROPERTIES
+  # Belt-and-suspenders against LNK1189: never auto-export the closure.
+  WINDOWS_EXPORT_ALL_SYMBOLS OFF
+  # kungfu_embedding.lib (import) + kungfu_embedding.dll land next to kungfu.lib
+  # at the build root, where the trunk build points KF_TRUNK_NATIVE_DIR on Windows.
+  ARCHIVE_OUTPUT_DIRECTORY ${KUNGFU_BUILD_DIR}
+  RUNTIME_OUTPUT_DIRECTORY ${KUNGFU_BUILD_DIR})
+
+kungfu_strip_release_local_symbols(kungfu_embedding)

--- a/product/scripts/dist.mjs
+++ b/product/scripts/dist.mjs
@@ -641,33 +641,33 @@ function assertCoreFrozen() {
 // runtime-pins manifest. UV_VERSION in the manifest must equal the repo's
 // .uv-version so the product and the dev launcher pull the same pinned uv.
 function stageTrunk() {
-  // ADR-0046 stage 3 productionization: link libkungfu and ship the real
-  // embedding-backed doctor on POSIX. Windows stays featureless (build.rs
-  // panics on windows until the static-link follow-up lands); the trunk falls
-  // back gracefully when the core is absent, so that is zero-regression. The
-  // product core is rebuilt (Release) before this stage, so the native dir is
-  // populated; pass it explicitly so build.rs never guesses.
-  const cargoArgs = ['build', '--release', '-p', 'kungfu-trunk'];
+  // ADR-0046 stage 3 productionization: link the embedding membrane and ship the
+  // real embedding-backed doctor on every platform. POSIX links the SHARED
+  // libkungfu from build/<type>; Windows links the single-export
+  // kungfu_embedding.dll import lib (Phase B2) from the build root, where MSVC
+  // archives colocate. The product core is rebuilt (Release) before this stage,
+  // so the native dir is populated; pass it explicitly so build.rs never guesses.
+  const buildType = process.env.KF_TRUNK_BUILD_TYPE || 'Release';
+  const coreBuild = path.join(ROOT, 'framework', 'core', 'build');
+  const cargoArgs = [
+    'build',
+    '--release',
+    '-p',
+    'kungfu-trunk',
+    '--features',
+    'embedding',
+  ];
   const runOpts = {
     cwd: CRATES_DIR,
     phase: 'core',
     event: 'product.core.trunk',
-  };
-  if (!isWin) {
-    const buildType = process.env.KF_TRUNK_BUILD_TYPE || 'Release';
-    cargoArgs.push('--features', 'embedding');
-    runOpts.env = {
+    env: {
       ...process.env,
-      KF_TRUNK_NATIVE_DIR: path.join(
-        ROOT,
-        'framework',
-        'core',
-        'build',
-        buildType,
-      ),
+      // Windows: kungfu_embedding.lib at the build root; POSIX: libkungfu.* under build/<type>.
+      KF_TRUNK_NATIVE_DIR: isWin ? coreBuild : path.join(coreBuild, buildType),
       KF_TRUNK_BUILD_TYPE: buildType,
-    };
-  }
+    },
+  };
   run('build kungfu-trunk', 'cargo', cargoArgs, runOpts);
   const trunkBin = path.join(
     CRATES_DIR,


### PR DESCRIPTION
ADR-0046 stage 3, Phase B2. Makes `doctor`/the embedding membrane real on Windows.

On Windows the core is built STATIC and does not export `kungfu_embedding_get_api` (a SHARED core blows the COFF 65535-export limit, LNK1189), so the trunk had nothing to link. Add a **Windows-only** SHARED target `kungfu_embedding` (in its own `src/libembedding/`, so it doesn't inherit libkungfu's `enable_windows_export_all_symbols()`) that exports exactly `kungfu_embedding_get_api` and internally static-links the whole core closure (`kungfu` + `kungfu_compile_contract` + `CONAN_LIBS` — pykungfu's line minus libnode). One dllexport dodges LNK1189. POSIX is untouched (the SHARED libkungfu still exports the entry).

- `framework/core/src/libembedding/CMakeLists.txt` (new) + core CMakeLists `if(WIN32 AND TARGET kungfu)` wiring.
- `crates/trunk/build.rs`: drop the Windows panic; on Windows emit `rustc-link-lib=dylib=kungfu_embedding` from the build root (no rpath). POSIX unchanged.
- `run-freeze.js` / `dist.mjs`: extend `--features embedding` to Windows (build-root native dir); `copyPyBindingWin` stages `kungfu_embedding.dll`.

Validated end-to-end on real Windows (DARKHERO, MSVC + cargo 1.96):
- `kungfu_embedding.dll` links the full core closure cleanly (`[26/26] Linking`, exit 0); `dumpbin /exports` shows **exactly one** symbol, `kungfu_embedding_get_api` (LNK1189 avoided); the DLL is self-contained (only system/MSVC-runtime deps).
- The trunk built `--features embedding` links `kungfu_embedding.lib`; `doctor` → real embedding membrane, ABI v1, real capabilities `(0x3)` (not the stub).
- POSIX `--features embedding` verified regression-free (still links `@rpath/libkungfu`).