### PR TITLE
chore(ci): drop dead source-mode mirror config and orphan checks.json

### DIFF
--- a/.github/workflows/embedding-membrane-spike.yml
+++ b/.github/workflows/embedding-membrane-spike.yml
@@ -102,8 +102,6 @@ jobs:
       CARGO_HTTP_TIMEOUT: "120"
       CARGO_NET_RETRY: "5"
       MIRROR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
-      MIRROR_REF: refs/heads/dev/v4/v4.0
-      MIRROR_URL: http://192.168.100.222:8088/git-mirrors/kungfu.git
       SOURCE_MODE: ${{ matrix.source_mode }}
       SOURCE_ROOT: source-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
@@ -140,11 +138,6 @@ jobs:
         shell: bash
         run: |
           git init "$SOURCE_ROOT"
-          if [ "$SOURCE_MODE" = "mirror" ]; then
-            git -C "$SOURCE_ROOT" remote add mirror "$MIRROR_URL"
-            git -C "$SOURCE_ROOT" fetch --no-tags mirror \
-              "+${MIRROR_REF}:refs/embedding/base"
-          fi
           if [ "$SOURCE_MODE" = "github" ] || \
             ! git -C "$SOURCE_ROOT" cat-file -e \
               "${MIRROR_BASE_SHA}^{commit}" 2>/dev/null; then

--- a/checks.json
+++ b/checks.json
@@ -1,1 +1,0 @@
-{"enabled":true,"categories":{}}


### PR DESCRIPTION
<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Dead-config cleanup: removes an unreachable CI source-mode mirror branch and an orphan root config file; no architecture contract or runtime behavior change."
}
-->

Dead-config cleanup (zero behavior change), from a dead-code survey.

- **`embedding-membrane-spike.yml`**: the matrix only ever sets
  `source_mode: github`, so the `if [ "$SOURCE_MODE" = "mirror" ]` reconstruct
  branch never runs and its `MIRROR_REF` / `MIRROR_URL` env are unreachable —
  removed. The live github reconstruct path and `MIRROR_BASE_SHA` (still used)
  are unchanged; the full native matrix on this PR revalidates the step.
- **`checks.json`** (repo root, `{"enabled":true,"categories":{}}`, dated 2023):
  no reference anywhere in the repo — removed.

Scope is intentionally minimal: the vestigial always-true `source_mode == 'github'`
guards are left in place (a larger simplification is tracked separately), and
all code-level dead-code candidates are deferred to a review card.