### PR TITLE
docs: define single-host performance release gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,9 @@ right document, and is readable by both people and agents.
 - [Single-Host Institutional Trust Profile](docs/single-host-institutional-trust.md)
   — the adoption decision, qualified deployment envelope, evidence, operator
   responsibilities, and non-claims for using Kungfu as a local runtime ledger.
+- [Single-Host End-to-End Performance Qualification](docs/single-host-performance-qualification.md)
+  — the post-correctness release gate, absolute performance evidence contract,
+  and strict boundary for informative Aeron comparisons.
 - [Kungfu Skills](docs/skills.md) — design target for Kungfu Skills:
   `SKILL.md` as the minimal source, compact agent catalog injection,
   Node/Python manage modes, and kfx dependency composition.

--- a/docs/MAP.md
+++ b/docs/MAP.md
@@ -41,6 +41,7 @@ and the map routes a question to whichever doc answers it.
 | Which application domains guide the neutral core without expanding the current roadmap? | [`domain-horizons.md`](domain-horizons.md) | why | draft · agent runtime current; trading evidence; games/virtual worlds horizon |
 | What are the known limits / what is *not* yet guaranteed? | [`known-limits.md`](known-limits.md) | verify | stable |
 | Can my institution use Kungfu as an authoritative local ledger on one host, and what evidence and controls are required? | [`single-host-institutional-trust.md`](single-host-institutional-trust.md) | use, verify | draft · evaluation/shadow use only; strong local durability qualification pending |
+| What end-to-end performance gate must the single-host institutional profile pass, and how may Aeron be used as a comparator? | [`single-host-performance-qualification.md`](single-host-performance-qualification.md) | verify | draft · contract defined; thresholds, harness, and retained reports not implemented |
 | Does Kungfu provide strong durability and crash recovery without giving up mmap latency, and what is implemented today? | [`durability-and-crash-recovery.md`](durability-and-crash-recovery.md) + [ADR-0068](../framework/core/docs/adr/ADR-0068-tiered-durability-and-crash-recovery.md) | why, verify | draft · visibility foundations implemented; end-to-end durable receipts and power-loss qualification designed, not implemented |
 | How do C++ / Python / Node share data zero-copy (the membrane)? | [`architecture.md`](architecture.md) (membrane diagram) | verify | stable |
 | What does it actually guarantee (layout / replay / compatibility)? | [`contracts.md`](contracts.md) | verify | stable |
@@ -151,6 +152,11 @@ route to the row that answers them:
   institution can adopt Kungfu as an authoritative local ledger, what evidence
   is required, and which controls remain operator-owned*
   ([`single-host-institutional-trust.md`](single-host-institutional-trust.md)).
+- **performance qualification / release gate / p99 / p99.9 / throughput /
+  backpressure / soak / Aeron comparison / Aeron-class** → *which absolute
+  performance and regression evidence admits the single-host institutional
+  profile, and why Aeron is informative rather than release authority*
+  ([`single-host-performance-qualification.md`](single-host-performance-qualification.md)).
 - **lightweight / too heavy / minimal install / independent package / libkungfu
   only / CLI without GUI / layer deletion / assembled runtime** → *which
   Kungfu should I start with* ([`choose-your-kungfu.md`](choose-your-kungfu.md)),

--- a/docs/durability-and-crash-recovery.md
+++ b/docs/durability-and-crash-recovery.md
@@ -134,7 +134,8 @@ one Episode must not silently invalidate unrelated Episodes.
 | C. Unified position, watermark, and receipt vocabulary | **implemented (contract-only)** | C++ owns stable stream positions, four typed watermarks, named profiles, receipts/errors, deduplication, and explicit unknown outcomes; Python/Node expose typed edge adapters, while current behavior remains `visible` only and rejects stronger profiles |
 | D. Independent durable ingest and projection services | **designed** | move business-journal consumption out of the coordinator; persist raw facts before projecting them |
 | E. Local strong-durability qualification | **not implemented** | qualify `durable_group` and `durable_sync` across macOS, Linux, and Windows with crash, torn-write, ENOSPC, ordering, and recovery evidence |
-| F. Replication and HA | **future** | add a separate replicated watermark and policy only after local durability is trustworthy |
+| F. Single-host end-to-end performance release gate | **planned** | after correctness passes, qualify absolute latency, throughput, long-tail, resource, replay, recovery, and restore ceilings without weakening semantics |
+| G. Replication and HA | **future** | add a separate replicated watermark and policy only after local durability is trustworthy |
 
 Until Stage E passes for a named platform/filesystem/profile, public product
 language must continue to say that power-loss durability is not claimed.
@@ -156,11 +157,22 @@ durability report must cover, for its declared platform and storage profile:
 Evidence is profile-scoped. Passing one filesystem or host does not silently
 qualify another.
 
+Correctness qualification is necessary but not sufficient for institutional
+release admission. The independent
+[Single-host end-to-end performance qualification](single-host-performance-qualification.md)
+must then prove the declared operational envelope. Its release authority comes
+from Kungfu's frozen absolute thresholds and retained evidence; Aeron IPC and
+Aeron Archive may be reported as reference comparators but do not define the
+pass/fail contract.
+
 ## Detailed records
 
 - [Single-host institutional trust profile](single-host-institutional-trust.md)
   defines the first institutional deployment envelope, adoption gates,
   evidence requirements, operator responsibilities, and non-claims.
+- [Single-host end-to-end performance qualification](single-host-performance-qualification.md)
+  defines the post-correctness release gate and the strict boundary for any
+  Aeron comparison.
 - [ADR-0068](../framework/core/docs/adr/ADR-0068-tiered-durability-and-crash-recovery.md)
   fixes the authority, watermarks, receipts, service boundaries, and staged
   adoption decision.

--- a/docs/known-limits.md
+++ b/docs/known-limits.md
@@ -79,6 +79,20 @@ as the adoption checklist. Until the named durability profile and exact
 platform/filesystem/device envelope have retained passing evidence, the
 institutional status remains evaluation or controlled shadow operation.
 
+## The single-host end-to-end performance release gate is not yet qualified
+
+The existing mmap qualification measures component behavior and prevents
+speculative policy tuning. It does not establish a product-level latency,
+throughput, resource, replay, recovery, or restore SLO for the complete
+single-host institutional profile.
+
+The [Single-host end-to-end performance qualification](single-host-performance-qualification.md)
+now defines that post-correctness release gate. Its versioned absolute
+thresholds, harness, sustained-load tier, retained reports, and product
+capability integration remain to be implemented. Aeron IPC and Aeron Archive
+may be used as declared reference comparators, but Kungfu currently makes no
+`Aeron-class`, equivalence, compatibility, or superiority claim.
+
 ## The GitHub build-and-release path is still being brought up
 
 The release mechanism is designed and has a long tag history, but the current v4

--- a/docs/single-host-institutional-trust.md
+++ b/docs/single-host-institutional-trust.md
@@ -27,6 +27,7 @@ with the operator.
 It is not a certification, procurement promise, or substitute for an
 institution's own risk assessment. Technical details remain authoritative in
 [Strong durability and crash recovery](durability-and-crash-recovery.md),
+[Single-host end-to-end performance qualification](single-host-performance-qualification.md),
 [Known Limits](known-limits.md), and the linked architecture decisions.
 
 ## Current decision
@@ -124,6 +125,9 @@ the exact deployment envelope:
 6. schema/version compatibility and migration evidence for the intended
    retention period;
 7. release provenance for the exact binaries being admitted.
+8. a passing Single-Host Performance Profile report covering absolute
+   latency/throughput/resource thresholds, regression ceilings, long-tail
+   behavior, sustained load, replay, recovery, and restore time.
 
 Missing or stale evidence is a failed adoption gate, not an invitation to infer
 the guarantee from `mmap`, `fsync`, SQLite WAL, process residency, or a
@@ -172,8 +176,8 @@ implied by the local durability design.
 |---|---|---|
 | Engineering evaluation | API, integration, replay, and fault-model review | current limits accepted; no authoritative production claim |
 | Shadow operation | record a copy of work whose authority remains elsewhere | operational monitoring and recovery rehearsal in place |
-| Limited authoritative pilot | bounded institution-selected facts on one qualified host | named durable profile implemented; exact envelope qualified; backup/restore drill passed |
-| Authoritative local ledger | institution-approved production scope | all applicable evidence above retained, independently reviewed, and continuously monitored |
+| Limited authoritative pilot | bounded institution-selected facts on one qualified host | named durable profile implemented; exact correctness envelope qualified; backup/restore drill passed; performance candidate characterized |
+| Authoritative local ledger | institution-approved production scope | correctness and Single-Host Performance Profile release gates passed; all applicable evidence above retained, independently reviewed, and continuously monitored |
 
 The current project state is between engineering evaluation and controlled
 shadow operation. Later implementation work must update this page from retained
@@ -184,6 +188,9 @@ evidence; it must not advance the adoption status from design intent alone.
 - [Strong durability and crash recovery](durability-and-crash-recovery.md) —
   durability profiles, watermarks, service boundaries, recovery contract, and
   implementation stages.
+- [Single-host end-to-end performance qualification](single-host-performance-qualification.md)
+  — absolute release thresholds, end-to-end workloads, retained evidence, and
+  the informative Aeron comparison boundary.
 - [Known Limits](known-limits.md) — current non-guarantees across durability,
   compatibility, release provenance, and product completeness.
 - [Runtime storage service](runtime-storage-service.md) — authoritative records,

--- a/docs/single-host-performance-qualification.md
+++ b/docs/single-host-performance-qualification.md
@@ -1,0 +1,217 @@
+---
+status: draft
+period: 2026-07-12
+theme: single-host-performance-qualification
+doc_type: release-gate-contract
+source_level: local-files + architecture-decisions + public-reference-systems
+confidence: high
+sensitivity: public
+evidence_grade: B
+review_state: self-reviewed
+last_reviewed: 2026-07-12
+ai_provenance:
+  model_family: GPT-5
+  product: Codex
+  generated_at: 2026-07-12
+  invisible_context_boundary: Future implementation results, qualification hardware, retained benchmark evidence, and third-party product changes are unknown
+---
+
+# Single-host end-to-end performance qualification
+
+This page defines the performance release gate for Kungfu's
+`Single-Host Institutional Profile v1`. It prevents an implementation that is
+correct but operationally unusable from being admitted as an institutional
+local runtime ledger, while preventing benchmark pressure from weakening
+durability, recovery, or agent-ledger semantics.
+
+The gate is **planned, not yet passed**. No current release claims an
+end-to-end performance profile for `durable_group` or `durable_sync`.
+
+## Place in the release sequence
+
+Performance qualification begins only after the complete single-host
+durability and crash-recovery implementation series has passed its correctness
+qualification:
+
+```text
+position / receipt contract
+  -> state-service separation
+  -> durable ingest
+  -> projection bootstrap and cutover
+  -> recovery engine
+  -> durability correctness qualification
+  -> product and SDK contract
+  -> single-host end-to-end performance qualification
+  -> release admission
+```
+
+The performance gate is not another functional implementation slice. It is an
+independent post-series release gate. A correct implementation can remain
+unreleased when it misses its declared operational envelope; a fast
+implementation cannot pass when its receipt or recovery semantics are wrong.
+
+## Gate principles
+
+1. **Kungfu owns the contract.** Pass/fail is determined by versioned absolute
+   thresholds, regression ceilings, and retained Kungfu evidence.
+2. **Correctness comes first.** No performance result can override a durability,
+   ordering, recovery, ownership-fencing, or backup/restore failure.
+3. **Compare equivalent semantics.** A visible shared-memory publication is not
+   compared with a synchronous durable acknowledgement, and a typed Episode
+   commit is not presented as equivalent to a raw transport frame.
+4. **Long tails are load-bearing.** Mean throughput or a best-case median cannot
+   hide p99/p99.9 latency, stalls, backpressure, recovery time, or resource
+   saturation.
+5. **The envelope is explicit.** Results apply only to the declared Kungfu
+   version, binary provenance, host, CPU topology, OS, filesystem, device,
+   mount/cache policy, compiler, profile, workload, and process topology.
+6. **Raw evidence is retained.** Summary tables never replace commands,
+   configurations, host facts, histograms, counters, logs, and run identities.
+
+## Surfaces under qualification
+
+| Surface | Completion boundary | Required measurements |
+|---|---|---|
+| `visible` raw frame | a complete frame is visible to the declared local reader set | publication-to-read latency, throughput, backpressure, CPU, faults, page rollover |
+| `visible` typed agent fact | the typed fact is visible through the supported C++/Python/Node surface | end-to-end adapter overhead, allocation/copy count, tail latency, throughput |
+| `durable_group` | the receipt position is at or below the qualified group durable watermark | acknowledgement distribution, batch size/delay, sync cost, durable lag, load behavior |
+| `durable_sync` | required fact data and metadata have crossed the qualified local durability barrier | acknowledgement distribution, device-sync cost, error propagation, sustainable rate |
+| projection catch-up | SQLite projection reaches the declared durable cut | projection lag, catch-up throughput, CPU/RSS, writer interference |
+| replay and bootstrap | a new reader or projection reaches the selected cut | cold/warm replay throughput, time to live, history-size scaling |
+| crash recovery | the whole data root reopens and emits a reconciled recovery report | time to verified frontier, rebuild time, capability restoration, resource peak |
+| backup restore | an empty data root is restored, checked, replayed, and projected | restore throughput, time to usable state, recovered cut/RPO |
+
+Raw transport and agent-semantic costs must both remain visible. Kungfu may
+choose the richer agent path because it provides Episode, manifest,
+cost/state/proof, responsibility, and trust semantics; the report must still
+show the incremental cost rather than hiding it in an incomparable benchmark.
+
+## Workload contract
+
+Each versioned qualification profile freezes its workload before release
+candidate measurement. The initial profile must include:
+
+- fixed-size payload classes covering small control facts, ordinary agent
+  facts, and larger payload references;
+- at least single-producer/single-consumer, single-producer/fan-out readers,
+  burst, sustained-rate, and slow-reader/backpressure topologies;
+- rapid page rollover and long-history seek/replay cases;
+- cold and warm data-root starts;
+- empty, representative, and high-cardinality projection state;
+- representative Episode open, action/receipt append, terminal commit, query,
+  replay, and recovery paths;
+- load combined with the qualified fault and restart boundaries, so load cannot
+  silently change acknowledgement semantics.
+
+Message sizes, rates, batch policy, history length, run duration, warm-up, CPU
+placement, idle strategy, and storage preparation are profile fields, not
+unrecorded operator choices.
+
+## Required metrics
+
+Every latency surface reports p50, p95, p99, p99.9, maximum, sample count, and
+the complete retained histogram. Every throughput surface reports both
+messages/second and bytes/second at the declared latency ceiling.
+
+The report also retains:
+
+- application, state-service, ingest, projection, and total host CPU;
+- per-process RSS and mapped-region count;
+- major/minor page faults and storage I/O counters;
+- visible/durable/projection lag distributions;
+- backpressure duration and rejected/unknown outcomes;
+- page-rollover, checkpoint, sync, projection, and recovery stalls;
+- replay, catch-up, restart, and empty-data-root restore time;
+- thermal, frequency, scheduler, virtualization, and noisy-neighbor facts that
+  materially affect interpretation.
+
+## Threshold and run discipline
+
+The machine-readable performance profile owns the absolute thresholds and
+allowed regression ceilings. They must be reviewed and frozen before the first
+release-candidate run; a failed candidate cannot pass by rewriting its profile.
+
+A passing report requires:
+
+- all prerequisite correctness and recovery evidence to remain passing;
+- the declared absolute latency, throughput, recovery-time, and resource
+  ceilings to pass on every required platform/storage profile;
+- repeated baseline/candidate alternation or equivalent drift control;
+- a sustained/soak tier in addition to short latency and saturation tiers;
+- no unexplained loss, duplicate, reorder, false receipt, unknown-success,
+  deadlock, unbounded lag, or recovery divergence;
+- no selective retry, removed outlier, weakened workload, or undeclared tuning;
+- raw artifacts sealed into the same release-evidence system used by the
+  corresponding Kungfu candidate.
+
+Unsupported or unqualified profiles fail closed and remain explicit
+non-claims. A neutral result is valid evidence; release waits or the declared
+product envelope contracts.
+
+## Aeron as a reference comparator
+
+[Aeron](https://github.com/aeron-io/aeron) is a mature first-tier reference for
+low-latency IPC, stream recording, replay, and operational position semantics.
+Kungfu therefore includes Aeron IPC and Aeron Archive in an optional but
+retained comparison profile.
+
+Aeron is a **reference comparator, not the authority for Kungfu release
+admission**:
+
+- Kungfu's pass/fail thresholds do not move when Aeron releases a new version;
+- the report always names the Aeron edition, version, commit/artifact,
+  configuration, API, idle/threading strategy, sync level, and hardware;
+- `visible` is compared with corresponding Aeron IPC delivery;
+- `durable_group` and `durable_sync` are compared only with explicitly matched
+  Aeron Archive recording/file-sync semantics;
+- Aeron Cluster, Premium kernel-bypass features, replication, and HA are outside
+  the v4.0.0 single-host comparison unless separately declared;
+- Kungfu agent-ledger semantics are reported as their own end-to-end path and
+  are not claimed to be equivalent to raw Aeron transport;
+- the comparison uses the same payloads, topology, offered load, CPU/storage
+  envelope, timing boundaries, duration, and percentile rules wherever the
+  systems permit equivalent semantics.
+
+Before retained results exist, public text must not say `Aeron-class
+performance`, `Aeron-equivalent`, `Aeron-compatible`, or `faster than Aeron`.
+After qualification, public text should state the exact measured result and
+envelope, for example:
+
+> Under Single-Host Performance Profile v1 on the declared host, Kungfu's
+> `visible` path and Aeron IPC were measured with the retained latency and
+> throughput distributions linked below.
+
+Even after a favorable result, the numbers and profile are the claim; a loose
+class label is not.
+
+## Evidence and release decision
+
+The release evidence must expose, in machine-readable form:
+
+- profile schema/version and frozen thresholds;
+- Kungfu and comparator identities and configurations;
+- host/storage/toolchain facts;
+- workload and topology identities;
+- raw run references, histogram digests, violations, and excluded-run reasons;
+- absolute and regression verdicts per surface and platform;
+- comparator results marked `informative`, never `release_authority`;
+- residual risks, unsupported envelopes, and explicit non-claims;
+- final `admitted`, `rejected`, or `unqualified` decision.
+
+The public capability surface may advertise a performance profile only when it
+can resolve to this retained report. Absence, staleness, version drift, or an
+unmatched environment removes the claim rather than substituting a generic
+"high performance" label.
+
+## Related records
+
+- [Single-host institutional trust profile](single-host-institutional-trust.md)
+  defines the adoption decision and operator responsibility boundary.
+- [Strong durability and crash recovery](durability-and-crash-recovery.md)
+  defines the receipt, watermark, service, and recovery semantics that this
+  gate must preserve.
+- [yijinjing mmap performance qualification](../framework/core/docs/qualification/mmap-performance.md)
+  qualifies component-level mmap policies and regressions; it does not replace
+  this product-level end-to-end gate.
+- [Episode atomicity qualification](episode-atomicity-qualification.md)
+  defines the related semantic oracle and fault-containment program.


### PR DESCRIPTION
## Summary\n- define the post-correctness Single-Host End-to-End Performance Qualification release gate\n- make Kungfu absolute thresholds, regression ceilings, and retained evidence authoritative\n- constrain Aeron IPC and Aeron Archive to declared, same-semantics informative comparisons\n- connect the gate to institutional trust, durability stages, known limits, README, and the documentation map\n\n## Validation\n- ./shifu check\n- local Markdown link validation across touched documents\n- git diff --check