### PR TITLE
chore(gui): remove unused skill-context builder duplicates

### DIFF
--- a/framework/gui/src/main/skill-context.ts
+++ b/framework/gui/src/main/skill-context.ts
@@ -1,26 +1,7 @@
 import {
-  type SkillContextEnvelope,
-  type SkillManagerView,
-  buildSkillContext,
-  buildSkillManagerView,
   writeSkillContextFile,
   writeSkillManagerViewFile,
 } from '@kungfu-tech/skill';
-
-export function buildGuiSkillContext(options: {
-  home: string;
-  profile?: string;
-  agent?: string;
-  env?: Record<string, string | undefined>;
-}): SkillContextEnvelope {
-  return buildSkillContext(options.home, {
-    source: 'gui',
-    manager: 'node',
-    profile: options.profile,
-    agent: options.agent,
-    env: options.env,
-  });
-}
 
 export function writeGuiSkillContextFile(options: {
   home: string;
@@ -33,15 +14,6 @@ export function writeGuiSkillContextFile(options: {
     manager: 'node',
     profile: options.profile,
     agent: options.agent,
-    env: options.env,
-  });
-}
-
-export function buildGuiSkillManagerView(options: {
-  home: string;
-  env?: Record<string, string | undefined>;
-}): SkillManagerView {
-  return buildSkillManagerView(options.home, {
     env: options.env,
   });
 }


### PR DESCRIPTION
`buildGuiSkillContext` and `buildGuiSkillManagerView` (in `framework/gui/src/main/skill-context.ts`) have **no importer anywhere in the repo**. They are in-memory duplicates of `writeGuiSkillContextFile` / `writeGuiSkillManagerViewFile` — the file-writing variants that `index.ts` actually uses; the GUI only ever writes the files. Removed the two dead functions and their now-unused `@kungfu-tech/skill` imports (28 lines).

No behavior change. From a dead-code survey. The survey's other gui candidates were kept after closer reading: `sandbox-view.ts:createSandboxedView` is a deliberate anti-drift reference (per its own header comment), and `installCli.ts:isKungfuCliInstalled` reads as reserved API — both deferred to owner review rather than removed here.