### PR TITLE
fix(build): patch rxcpp maybe<T> off deprecated std::aligned_storage

### DIFF
--- a/framework/core/.conan/recipes/rxcpp/conandata.yml
+++ b/framework/core/.conan/recipes/rxcpp/conandata.yml
@@ -7,3 +7,6 @@ patches:
     - patch_file: "patches/0001-fix-notification-assignment.patch"
       patch_description: "make notification values assignable under GCC 14"
       patch_type: "portability"
+    - patch_file: "patches/0002-replace-deprecated-aligned-storage.patch"
+      patch_description: "replace std::aligned_storage (deprecated in C++23) with an alignas byte buffer in maybe<T>"
+      patch_type: "portability"

--- a/framework/core/.conan/recipes/rxcpp/patches/0002-replace-deprecated-aligned-storage.patch
+++ b/framework/core/.conan/recipes/rxcpp/patches/0002-replace-deprecated-aligned-storage.patch
@@ -1,0 +1,12 @@
+--- a/Rx/v2/src/rxcpp/rx-util.hpp
++++ b/Rx/v2/src/rxcpp/rx-util.hpp
+@@ -571,8 +571,7 @@
+ class maybe
+ {
+     bool is_set;
+-    typename std::aligned_storage<sizeof(T), std::alignment_of<T>::value>::type
+-        storage;
++    alignas(T) unsigned char storage[sizeof(T)];
+ public:
+     maybe()
+     : is_set(false)


### PR DESCRIPTION
std::aligned_storage is deprecated in C++23 (P1413R3); rxcpp 4.1.1 uses it in maybe<T>, so under -std=gnu++23 every kungfu rx consumer instantiating maybe<T> emits a deprecation warning -isystem cannot suppress. Conan recipe patch replaces it with an equivalent alignas byte buffer; placement-new access unchanged. Verified: patched package header contains zero std::aligned_storage occurrences.