### PR TITLE
docs(vocabulary): center public language on Episode

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ alone: bind it to a verifiable source, artifact, manifest, or runtime receipt.
 ([KFD](https://kfd.libkungfu.dev/); [Design Philosophy](docs/design-philosophy.md);
 [Facts Before Trust](docs/facts-before-trust.md).)
 
+Real-world work happens in **Episodes**: bounded causal units whose Facts,
+Artifacts, Receipts, dependencies, and verification roots can be inspected,
+sealed, exported, recovered, and used to support Decisions. Read
+[The Episode](docs/the-episode.md) for the public vocabulary that connects
+execution, evidence, trust, and action.
+
 Public entrypoints:
 
 - Product home: <https://kungfu.tech>
@@ -97,6 +103,9 @@ needs to capture, share, and faithfully replay high-frequency event streams.
 
 ## Core ideas
 
+- **Episode-first work model** — a run is an execution coordinate; an Episode
+  is the stable semantic object for bounded causal work, verification,
+  portability, replay, and recovery.
 - **Journal-first data plane** — one append-only event log
   ([`yijinjing`](framework/core)) and two declared schema substrates: the
   `kungfu/yijinjing/schema` Hana closed set for kernel facts, and `.fbs` for
@@ -190,8 +199,16 @@ right document, and is readable by both people and agents.
 - [Product Layers](docs/product-layers.md) — inspect the independent
   product contracts and qualification boundaries behind that choice.
 - [Documentation Map](docs/MAP.md) — the question-indexed map of all documentation.
-- [Concepts](docs/concepts.md) — the vocabulary in one place
-  (`kungfu`/`kfx`/`sdk`, `libkungfu`, `yijinjing`, journal, schema, …).
+- [The Episode](docs/the-episode.md) — the flagship object and layered public
+  vocabulary for real-world agent work: Facts, Artifacts, Receipts, Cuts,
+  Watermarks, Projections, Timelines, Claims, Proof, TrustReports, and
+  Decisions.
+- [Vocabulary Reference](docs/vocabulary.md) — canonical definitions,
+  boundaries, operations, and the separation between Kungfu Core and domain
+  profile terms.
+- [Concepts](docs/concepts.md) — product names, implementation components, and
+  runtime terms (`kungfu`/`kfx`/`sdk`, `libkungfu`, `yijinjing`, journal,
+  schema, …).
 - [Design Philosophy](docs/design-philosophy.md) — the two first
   principles the whole design follows from, and how the architecture falls out
   of them.

--- a/docs/MAP.md
+++ b/docs/MAP.md
@@ -23,6 +23,7 @@ and the map routes a question to whichever doc answers it.
 | Your question | Document | Plane | Status |
 |---|---|---|---|
 | What is kungfu, in one idea? | [`../README.md`](../README.md) | — | stable |
+| Why is Episode the flagship object for real-world execution, and how do Facts, Receipts, Cuts, Claims, and Decisions fit around it? | [`the-episode.md`](the-episode.md) + [`vocabulary.md`](vocabulary.md) | why, use | current · vocabulary contract; guarantees remain maturity-scoped |
 | Do I need the whole Kungfu App, or which smaller product should I start with? | [`choose-your-kungfu.md`](choose-your-kungfu.md) | use | draft · adoption contract accepted; artifacts qualify independently in stages |
 | What do the terms mean (`kungfu` / `yijinjing` / journal / schema …)? | [`concepts.md`](concepts.md) | use | stable |
 | Why is it built this way? What is load-bearing? | [`design-philosophy.md`](design-philosophy.md) | why | stable |

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -5,6 +5,12 @@ the coined names share the `kf` prefix, which simply stands for *kungfu*. For ho
 these pieces are layered see [`architecture.md`](architecture.md); for the
 principles behind them see [`design-philosophy.md`](design-philosophy.md).
 
+This page indexes product names, implementation components, and runtime terms.
+For the public execution language centered on Episode — Fact, Artifact,
+Receipt, Cut, Watermark, Projection, Timeline, Claim, Proof, TrustReport,
+Decision, Replay, and Rewind — start with [**The Episode**](the-episode.md) and
+use the [**Vocabulary Reference**](vocabulary.md) for canonical definitions.
+
 ## The `kf*` command family
 
 | Name | What it is |

--- a/docs/the-episode.md
+++ b/docs/the-episode.md
@@ -1,0 +1,255 @@
+# The Episode
+
+## A vocabulary for real-world agent work
+
+An agent can call tools, change files, spend tokens, produce artifacts, and
+report that it is done. But the report leaves the important questions open:
+
+```text
+What actually happened?
+Which facts and artifacts belong to the work?
+What did the runtime acknowledge?
+What survived a crash?
+What evidence supports completion?
+What may safely happen next?
+```
+
+Logs show activity. Traces show calls. Workflows describe intended steps. A
+chat session preserves a conversation. None of them, by itself, is the durable
+object that real-world work needs.
+
+**That object is an Episode.**
+
+> An Episode is a bounded causal unit of actual work. Its facts, artifacts,
+> dependencies, receipts, and verification roots can be inspected, sealed,
+> exported, recovered, and used to support decisions.
+
+This is the central object in Kungfu. Other concepts exist to state what an
+Episode contains, where its guarantees stand, how it can be understood, and
+which decisions its evidence can support.
+
+```text
+Real-world work happens in Episodes.
+Episodes preserve Facts and Artifacts.
+Receipts and Watermarks state what the runtime has actually established.
+Claims require Proof before they support Decisions.
+```
+
+## Why the session is no longer enough
+
+A session is an execution coordinate. It may end when a process exits, a
+terminal disconnects, or a context window expires. Real work does not respect
+those boundaries. One responsibility may span several runs; one run may
+produce evidence used by several later decisions; an interrupted run may still
+contain verified work worth preserving.
+
+An Episode gives that work a stable semantic boundary. It is not defined by a
+window, process, file, provider, or user interface.
+
+```text
+An Episode is not a chat session.
+An Episode is not a process.
+An Episode is not a bag of logs.
+```
+
+A conforming Episode has a stable identity, declared causal and external
+dependencies, an authoritative manifest, inspectable facts and artifacts, and
+an explicit lifecycle. It can be opened, appended to, sealed, inspected,
+verified, exported, imported, rewound, and recovered without making a GUI or a
+mutable database its authority.
+
+## The language around an Episode
+
+The vocabulary is layered deliberately. Episode is the flagship object; the
+surrounding terms answer different questions about it.
+
+### 1. What belongs to the work?
+
+**Fact** — a typed statement preserved by the runtime under a declared fact
+contract. An observation may be recorded without being admitted into canonical
+fact state, and an admitted fact is not automatically trusted for every claim.
+
+```text
+recorded != admitted != trusted
+```
+
+**Artifact** — durable material produced, consumed, or validated by an Episode.
+Artifacts may be content-addressed and referenced without forcing large bodies
+onto the journal hot path.
+
+**Manifest** — the authoritative declaration of an Episode's included frames,
+facts, artifacts, schemas, dependencies, source provenance, and verification
+roots. A JSON rendering or SQLite row may describe a manifest; it does not
+replace the journal-backed authority.
+
+**Receipt** — a typed acknowledgement of a specific position and guarantee. A
+receipt says exactly what the runtime established, and no more. A successful
+call is not a durability promise unless the returned receipt names and proves
+that durability profile.
+
+```text
+write returned != visible
+visible != durable
+durable != projected
+```
+
+### 2. Where does the answer stand?
+
+**Source** — the provenance identity from which facts or Episodes were
+observed, imported, or accepted. Transporting a fact does not erase its source
+authority.
+
+**Observer** — the declared perspective from which accepted facts are viewed.
+Kungfu does not pretend that a mixed-source history comes from an absolute
+view from nowhere.
+
+**Cut** — the exact fact boundary at which a query, proof, or assessment is
+answered. A cut makes a historical answer reproducible instead of silently
+consulting whatever happens to be current later.
+
+**Watermark** — the position through which one named guarantee holds. Visible,
+durable, projected, and eventually replicated guarantees advance
+independently; they are not one generic progress number.
+
+```text
+visible watermark
+durable watermark
+projection watermark
+replicated watermark
+```
+
+### 3. How does an Episode become understandable?
+
+**Projection** — a rebuildable interpretation of authoritative facts. SQLite
+indexes, folded state, query rows, and GUI models can make Episodes useful, but
+they cannot become a second fact authority.
+
+```text
+Facts are authoritative.
+Projections are rebuildable.
+```
+
+**Timeline** — a deterministic projection of accepted facts under a declared
+observer, causal constraints, source-local order, and ordering policy. Known
+causality dominates presentation policy; concurrent facts may be ordered for a
+stable view without being misrepresented as universal time.
+
+```text
+Timeline != universal clock
+```
+
+**Replay** — reconstruction of recorded facts and derived state under the same
+declared runtime semantics used by live work.
+
+**Rewind** — the product action of reopening an Episode for causal inspection,
+verification, proof, and recovery. Rewind does not silently repeat real-world
+side effects.
+
+```text
+Rewind an Episode.
+Replay its Facts.
+Never re-execute side effects implicitly.
+```
+
+### 4. How do facts support trust and action?
+
+**Claim** — a statement that a participant asks others to rely on: the work is
+complete, an artifact is valid, a handoff is safe, or a system may resume.
+
+**Proof** — the evidence and derivation that bind a result or Claim to fact
+declarations, accepted sources, Episodes, Artifacts, a Cut, and verification
+results. Proof also names missing, conflicted, redacted, or unverifiable input.
+
+**Purpose** — the decision for which a Claim is being assessed. Evidence that
+is sufficient for internal review may be insufficient for release, external
+commitment, or recovery of authority.
+
+**TrustReport** — a purpose-bound assessment of a Claim over pinned facts and
+Proof. It reports fitness, evidence, responsibility, freshness, gaps, and
+residual risk instead of attaching a universal `trusted=true` label.
+
+```text
+Claim + Purpose + Cut + Proof -> TrustReport
+```
+
+**Decision** — the recorded choice of an authorized participant: continue,
+adjust, stop, approve, request evidence, hand off, archive, recover, or reopen.
+Agent self-report may trigger an assessment; it cannot authorize its own Claim
+without independent admitted evidence and the applicable authority.
+
+## The distinctions that matter
+
+The vocabulary is useful because it prevents categories with different
+guarantees from collapsing into one status field.
+
+```text
+Episode != session
+Fact != log line
+recorded != admitted
+Claim != Proof
+claimed complete != fit for purpose
+visible != durable != projected
+Projection != authority
+Timeline != universal clock
+Rewind != re-execution
+restart != recovery
+```
+
+These are operational boundaries, not rhetorical distinctions. They determine
+what an API may acknowledge, what a query may infer, what a GUI may display,
+and what recovery may claim after failure.
+
+## One core, multiple domain profiles
+
+Kungfu Core does not dictate what the work is about. It provides the common
+runtime-fact language; a domain profile supplies the objects and policies that
+give those facts local meaning.
+
+| Profile | Domain vocabulary examples | Shared Kungfu language |
+| --- | --- | --- |
+| accountable agent work | delegated work, responsibility, cost, completion, handoff | Episode, Fact, Artifact, Receipt, Claim, Proof, Cut, TrustReport, Decision |
+| quantitative trading | order, execution, position, account, settlement | Episode, Fact, Receipt, Watermark, Projection, Replay |
+| games and virtual worlds | input, rule outcome, world change, entity state, checkpoint | Episode, Fact, Artifact, Timeline, Cut, Replay |
+| future industrial or device profiles | command, observation, interlock, maintenance action, operator decision | Episode, Fact, Receipt, Claim, Proof, Recovery |
+
+The current Agent Work profile uses **Mission**, **Go**, Responsibility State,
+and Cost/State/Proof to test long-running delegated work. Those are profile
+terms, not prerequisites for using Kungfu and not vocabulary owners of the
+domain-neutral core. Their names may evolve as product validation improves;
+an Episode remains the stable object beneath them.
+
+## The Kungfu contract
+
+Kungfu aims to turn real-world execution from an expendable stream of activity
+into a locally owned, verifiable object. The product is successful when a human
+or agent can answer:
+
+```text
+Which Episode contains the work?
+Which Facts and Artifacts does it preserve?
+What did its Receipts establish?
+At which Cut and Watermark is this answer valid?
+Which Projection or Timeline am I viewing?
+What does the Proof support?
+Which Decision may safely follow?
+```
+
+This vocabulary names the target contract. Individual guarantees remain scoped
+by the current implementation, platform, durability profile, and retained
+qualification evidence. Read [Known Limits](known-limits.md) before treating a
+design target as a released guarantee.
+
+## Go deeper
+
+- [Vocabulary Reference](vocabulary.md) gives canonical definitions and
+  relationships for the terms introduced here.
+- [Episode Object Model](episode-object-model.md) defines Episode invariants,
+  lifecycle, manifest authority, and implementation maturity.
+- [Bringing domain facts into Kungfu](fact-surface-admission.md) defines the
+  recorded/admitted/trusted boundary.
+- [Querying runtime facts](querying-runtime-facts.md) defines Cuts,
+  proof-carrying queries, projections, and changelogs.
+- [Strong durability and crash recovery](durability-and-crash-recovery.md)
+  defines Receipts, Watermarks, recovery, and current non-claims.
+- [Domain Horizons](domain-horizons.md) explains how trading, agent work, and
+  future virtual-world profiles share one neutral core.

--- a/docs/vocabulary.md
+++ b/docs/vocabulary.md
@@ -1,0 +1,323 @@
+# Kungfu Vocabulary Reference
+
+This reference defines the public language Kungfu uses for real-world
+execution. Start with [The Episode](the-episode.md) for the narrative and return
+here when an API, document, extension, or product surface needs the precise
+term.
+
+The hierarchy is intentional:
+
+```text
+flagship object
+  Episode
+
+core evidence and commitment
+  Fact / Artifact / Manifest / Receipt
+
+coordinates and perspective
+  Source / Observer / Cut / Watermark
+
+derivation, trust, and action
+  Projection / Timeline / Claim / Proof / Purpose / TrustReport / Decision
+
+operations
+  Replay / Rewind / Recovery
+
+domain profiles
+  Agent Work / Trading / Games and Virtual Worlds / future profiles
+```
+
+## Flagship object
+
+### Episode
+
+**Definition:** A first-class, bounded causal segment of actual work in the
+Kungfu fact ledger.
+
+**Owns:** The inspectable closure of journal facts, artifacts and payload
+commitments, source provenance, schemas, receipts, dependencies, and
+verification roots required to reason about one unit of work.
+
+**Is not:** A chat session, process, terminal, journal page, source, mutable
+status row, or unstructured collection of logs.
+
+**Lifecycle:** `open -> append -> seal`, followed by non-destructive inspect,
+query, verify, export, import, replay, rewind, and recovery operations.
+Tombstone, repair, compaction, and garbage collection are explicit maintenance
+operations and must not silently rewrite retained evidence.
+
+**Authority:** The journal-backed Episode manifest and referenced fact evidence;
+not a GUI model, SQLite projection, or exported JSON rendering.
+
+See [Episode Object Model](episode-object-model.md).
+
+## Core evidence and commitment
+
+### Fact
+
+**Definition:** A typed statement preserved by Kungfu under a declared schema
+and fact contract.
+
+**Boundary:** An observation can be recorded but not admitted. An admitted fact
+can enter a canonical fold but is not universally trusted. Trust applies to a
+Claim for a Purpose over pinned evidence.
+
+**Relationship to Episode:** Facts are recorded in or referenced by Episodes;
+their identity, provenance, causal position, and schema commitments remain
+inspectable.
+
+### Artifact
+
+**Definition:** Durable material produced, consumed, or validated by work and
+bound to an Episode through an inspectable reference or commitment.
+
+**Boundary:** An Artifact is not required to live inline in the journal.
+Content-addressed bodies and explicit absent, missing, or redacted states keep
+large material off the hot path without weakening the evidence boundary.
+
+### Manifest
+
+**Definition:** The authoritative folded declaration of an Episode's contents,
+dependencies, provenance, schema and artifact inventory, lifecycle, and
+verification roots.
+
+**Boundary:** JSON, SQLite, and GUI representations are edge views or rebuildable
+projections. They are not the local manifest authority.
+
+### Receipt
+
+**Definition:** A typed acknowledgement that binds an operation to a specific
+stream position, Episode coordinate, policy, and established guarantee.
+
+**Boundary:** A generic success response, completed function call, mapped write,
+or visible frame is not a stronger Receipt. Unknown outcomes and unsupported
+profiles fail explicitly.
+
+**Relationship to Watermark:** A durability Receipt may claim only a position at
+or below the applicable qualified Watermark.
+
+## Coordinates and perspective
+
+### Source
+
+**Definition:** A logical provenance and synchronization identity that can
+enumerate or supply facts, Artifacts, or Episodes.
+
+**Boundary:** Location and Channel describe runtime identity and transport. They
+do not replace Source provenance or fact authority.
+
+### Observer
+
+**Definition:** The declared participant or location whose accepted fact set
+and perspective govern a view.
+
+**Boundary:** An Observer does not create facts by viewing them. It declares the
+basis from which a Timeline or mixed-source answer is produced.
+
+### Cut
+
+**Definition:** An exact, reproducible boundary of accepted authority at which a
+query, Proof, Projection, or assessment is evaluated.
+
+**Boundary:** A Cut is not merely a displayed timestamp. It may be expressed by
+an Episode root, exact system-time boundary, stream position, or another
+declared authority coordinate supported by the queried object.
+
+### Watermark
+
+**Definition:** The stream position through which one named guarantee is known
+to hold.
+
+**Named forms:**
+
+- `visible_watermark` — live readers may consume complete published facts
+  through this position;
+- `durable_watermark` — the selected qualified local durability contract holds
+  through this position;
+- `projection_watermark` — derived query state incorporates facts through this
+  position;
+- `replicated_watermark` — reserved for a separately qualified future
+  replication profile.
+
+**Boundary:** Watermarks are not interchangeable. Projection progress cannot
+upgrade visibility into durability, and process residency cannot establish a
+durable Watermark.
+
+## Derivation, trust, and action
+
+### Projection
+
+**Definition:** A deterministic, rebuildable interpretation or index derived
+from authoritative Facts and Episode manifests under a declared policy and
+Cut.
+
+**Examples:** SQLite query state, folded current state, a table, causal graph,
+or responsibility view.
+
+**Boundary:** Losing a Projection must not erase authoritative Facts. Rebuilding
+it must not silently reinterpret history under a newer declaration.
+
+### Timeline
+
+**Definition:** A Projection that orders accepted Facts from one or more Sources
+under a declared Observer, causal constraints, source-local order, projection
+policy, and deterministic tie-breakers.
+
+**Boundary:** A Timeline is not an assertion of a universal global clock. Known
+causality must not be inverted for presentation convenience, and missing
+evidence produces a degraded view rather than an invented order.
+
+### Claim
+
+**Definition:** A statement made by a participant that asks another participant
+or system to rely on a conclusion.
+
+**Examples:** Work is complete; an Artifact is valid; a handoff is safe; a
+release may proceed; a recovered ledger may resume authority.
+
+**Boundary:** A Claim is recorded as a statement, not promoted to truth by the
+identity or confidence of its author.
+
+### Proof
+
+**Definition:** The evidence and derivation envelope that binds an answer or
+Claim to declarations, Sources, accepted ranges, Episodes, Artifacts, a Cut,
+query and policy identities, result hashes, and known gaps.
+
+**Boundary:** An execution plan explains how an answer will be computed. Proof
+states which authority and evidence support the answer.
+
+### Purpose
+
+**Definition:** The intended decision or use for which a Claim is assessed.
+
+**Examples:** Internal review, handoff, continued delegation, release,
+institutional adoption, external commitment, or recovery of authority.
+
+**Boundary:** Fitness is Purpose-dependent. Evidence sufficient for one Purpose
+does not silently qualify another.
+
+### TrustReport
+
+**Definition:** A durable, purpose-bound assessment of one Claim over pinned
+Facts and Proof at a declared Cut.
+
+**Carries:** Fitness, supporting evidence, responsibility, freshness, evidence
+gaps, conflicts, residual risk, validation state, and applicable next actions.
+
+**Boundary:** A TrustReport is not a universal boolean property of a Fact,
+Episode, participant, extension, or product.
+
+### Decision
+
+**Definition:** A recorded choice by an authorized participant about what may or
+should happen next on the basis of available facts, Proof, constraints, and
+Purpose.
+
+**Examples:** Continue, adjust, stop, approve, request evidence, hand off,
+archive, recover, or reopen.
+
+**Boundary:** Recommendation and authorization remain distinct. Agent prose
+cannot create Facts, expand authority, or silently execute a Decision.
+
+## Operations
+
+### Replay
+
+**Definition:** Reconstruction of recorded Facts and derived state under the
+same declared runtime semantics used by live work.
+
+**Boundary:** Replay fidelity is limited by the declared capture boundary and
+available evidence. It does not imply complete recording of outside-world
+state.
+
+### Rewind
+
+**Definition:** The user-facing operation of reopening an Episode to inspect
+its causal chain, verify its evidence, understand failure, or resume recovery.
+
+**Boundary:** Rewind defaults to forensic inspection. It never silently repeats
+external side effects.
+
+### Recovery
+
+**Definition:** The deterministic process of validating retained authority,
+identifying the last proven frontier, classifying any uncertain tail,
+rebuilding Projections, qualifying interrupted Episodes, and reporting which
+capabilities remain safe.
+
+**Boundary:** A process restart is not proof of Recovery. Recovery completes
+only when the applicable facts, Watermarks, repairs, quarantine, loss, and
+capability contractions are reported under the selected profile.
+
+## Domain profiles
+
+Domain profiles add vocabulary and policies above the core without redefining
+Episode identity, fact authority, Cuts, Receipts, Proof, or Recovery.
+
+### Agent Work profile
+
+Current profile terms include Mission, Go, Responsibility State,
+Cost/State/Proof, Completion Claim, Handoff, and Agent Work Inbox. They model a
+specific product experience for long-running delegated work. They are not
+required core objects, and their naming remains subject to domain validation.
+
+### Quantitative trading profile
+
+Trading profiles may define orders, executions, positions, accounts,
+settlement, and exchange-specific authority while using the same Episode,
+Fact, Receipt, Projection, Cut, and Replay contracts.
+
+### Games and virtual worlds profile
+
+Game profiles may define inputs, entity state, rule outcomes, world changes,
+random commitments, and checkpoints while using Episodes, Facts, Artifacts,
+Timelines, Cuts, and Replay as the neutral substrate.
+
+### Future profiles
+
+Industrial, device, research, operations, and other profiles may introduce
+their own domain objects only when they preserve the core authority and
+verification boundaries. A domain term belongs in Kungfu Core only after its
+neutral invariant is clear and demonstrated beyond one profile.
+
+## Canonical relationship
+
+The compact relationship among the core terms is:
+
+```text
+Facts and Artifacts
+  -> bounded by an Episode and its Manifest
+  -> acknowledged by Receipts
+  -> established through named Watermarks
+  -> selected at a Cut from a declared Observer
+  -> rendered as Projections and Timelines
+  -> used as Proof for a Claim and Purpose
+  -> assessed in a TrustReport
+  -> considered by an authorized Decision
+  -> reopened through Replay, Rewind, and Recovery
+```
+
+## Naming discipline
+
+- Use **Episode** for the semantic unit of bounded causal work; use `run`,
+  `process`, `session`, `page`, and `source` only for their narrower meanings.
+- Use **Fact** only with its declaration, provenance, and admission boundary;
+  use `observation` when canonical admission has not occurred.
+- Use **Receipt** only when the acknowledged guarantee and position are named.
+- Use **Cut** for a reproducible fact boundary and **Watermark** for the advance
+  of one guarantee.
+- Use **Projection** for rebuildable derived state; never call a GUI or SQLite
+  cache the authority.
+- Use **Claim**, **Proof**, **Purpose**, and **TrustReport** as distinct objects;
+  do not compress them into `trusted=true` or `done=true`.
+- Use **Rewind** for forensic reopening and reserve re-execution for an
+  explicit mode with side-effect boundaries.
+
+## Maturity and guarantees
+
+This reference defines Kungfu's vocabulary and target semantic boundaries. It
+does not imply that every operation or durability profile is fully implemented
+or qualified on every platform. Current guarantees and staged work are stated
+in [Contracts](contracts.md), [Known Limits](known-limits.md), and
+[Strong durability and crash recovery](durability-and-crash-recovery.md).


### PR DESCRIPTION
## Summary

- establish Episode as the flagship object for real-world execution
- publish a layered narrative around Facts, Receipts, Cuts, Watermarks, Claims, Proof, and Decisions
- add a canonical vocabulary reference that separates Kungfu Core terms from domain profile vocabulary
- route README, Concepts, and the documentation map to the new public entrypoints

## Validation

- `./shifu check`
- `./shifu check:staged`
- `git diff --check`

## Boundaries

- documentation only; no runtime, schema, CLI, or release-contract behavior changes
- Mission and Go remain Agent Work profile terms whose naming may evolve
- maturity and platform guarantees continue to defer to Contracts, Known Limits, and qualification evidence