### PR TITLE
fix(runtime): fail fast on unsupported nanomsg protocol; clarify intentional reactor warnings

### DIFF
--- a/framework/core/src/libkungfu/src/runtime/live/reactor.cpp
+++ b/framework/core/src/libkungfu/src/runtime/live/reactor.cpp
@@ -396,8 +396,11 @@ bool reactor::check_location_live(uint32_t source_id, uint32_t dest_id) const {
 
 void reactor::add_location(int64_t, const location_ptr &location) {
   location_uid64s_.insert(std::to_string(location->uid64));
-  bool write_rocks = locations_.try_emplace(location->uid, location).second |
-                     location64s_.try_emplace(location->uid64, location).second;
+  // Both maps must be updated unconditionally; evaluate each try_emplace before
+  // combining so the second insert is never short-circuited away.
+  bool inserted_uid = locations_.try_emplace(location->uid, location).second;
+  bool inserted_uid64 = location64s_.try_emplace(location->uid64, location).second;
+  bool write_rocks = inserted_uid || inserted_uid64;
   if (write_rocks) {
     write_location_to_rocksdb(location);
   }
@@ -722,9 +725,10 @@ void reactor::put_peer_kv(const std::string &key, const std::string &value) cons
 }
 
 void reactor::ensure_coordinator_rocksdb() {
-  static const std::string coordinator_db_dir = get_locator()->layout_dir(get_coordinator_home_location(), layout::MAP);
   try {
-    get_coordinator_rocksdb();
+    // Probe only: force-open the coordinator rocksdb and discard the handle.
+    // If it is not yet open this throws, and the catch block opens/clears it.
+    (void)get_coordinator_rocksdb();
   } catch (const std::exception &e) {
     SPDLOG_DEBUG("catch exception: {}", e.what());
     std::lock_guard<std::mutex> lk(coordinator_db_mtx_);

--- a/framework/core/src/libkungfu/src/runtime/util/nanomsg.cpp
+++ b/framework/core/src/libkungfu/src/runtime/util/nanomsg.cpp
@@ -35,7 +35,10 @@ socket::socket(protocol p, int buffer_size) : protocol_(p), buf_size_(buffer_siz
     rc = nng_sub0_open(&sock_);
     break;
   default:
+    // Unsupported protocol must fail deterministically: rc is only assigned in
+    // the cases above, so falling through here would read an uninitialized rc.
     SPDLOG_ERROR("unsupportted protocol {}", int(p));
+    throw nn_exception(NNG_ENOTSUP);
   }
 
   if (rc != 0) {


### PR DESCRIPTION
Verdict-before-fix triage of 3 Tier-1 compiler warnings. BUG1 (nanomsg uninitialized rc on unsupported protocol) was a real UB and is fixed to fail deterministically. BUG2 (bitwise | in add_location) and BUG3 (discarded nodiscard probe in ensure_coordinator_rocksdb) were intentional; rewritten to preserve behavior while silencing the warnings. Verified via sibling compile_commands.json -fsyntax-only: all three target warnings gone, no new warnings.