### PR TITLE
fix(gui): add Mission Control situation view

### DIFF
--- a/extensions/work-dashboard/src/view/index.tsx
+++ b/extensions/work-dashboard/src/view/index.tsx
@@ -33,6 +33,12 @@ import type { KfxCapabilities, Shell } from '@kungfu-tech/kfx';
 import { headingStyle, mono, panelStyle } from '@kungfu-tech/kfx';
 import React from 'react';
 import { createLatestRefresh } from './latest-refresh';
+import {
+  GoalCardField,
+  GoalDetailDrawer,
+  MissionSituationOverview,
+} from './mission-visual';
+import { deriveTrustVisual } from './mission-visual-model';
 
 const STATUS_ORDER = ['active', 'blocked', 'waiting', 'ready', 'done'] as const;
 const ATLAS_GOAL_STATUSES = [
@@ -351,12 +357,18 @@ function AtlasProjectionView({
   const assessmentRequest = React.useRef(0);
   const [statusFilter, setStatusFilter] = React.useState<string>('all');
   const [selectedGoal, setSelectedGoal] = React.useState<string | null>(null);
+  const [displayMode, setDisplayMode] = React.useState<'visual' | 'audit'>(
+    'visual',
+  );
   const [message, setMessage] = React.useState<string>('');
   const [trustReport, setTrustReport] =
     React.useState<AtlasMissionControlReport | null>(null);
   const [trustError, setTrustError] = React.useState<string>('');
   const [completionReport, setCompletionReport] =
     React.useState<AtlasMissionControlReport | null>(null);
+  const [completionGoalId, setCompletionGoalId] = React.useState<string | null>(
+    null,
+  );
   const [completionError, setCompletionError] = React.useState<string>('');
   const [queryStream, setQueryStream] = React.useState<QueryChangelogState>(
     emptyQueryChangelogState,
@@ -640,11 +652,13 @@ function AtlasProjectionView({
       );
       if (!mounted.current) return;
       setCompletionReport(report);
+      setCompletionGoalId(selectedGoal);
       setCompletionError('');
       dashboardRefresh.request();
       void refreshAssessment();
     } catch (error) {
       setCompletionReport(null);
+      setCompletionGoalId(null);
       setCompletionError((error as Error).message);
     }
   };
@@ -667,6 +681,17 @@ function AtlasProjectionView({
   const missionGoals = allGoals.filter(
     (goal) => goal.mission_id === selectedMission,
   );
+  const currentMission =
+    missions.find((mission) => mission.mission_id === selectedMission) ?? null;
+  const goalTrustById = React.useMemo(
+    () =>
+      completionGoalId && completionReport
+        ? {
+            [completionGoalId]: deriveTrustVisual(completionReport).state,
+          }
+        : {},
+    [completionGoalId, completionReport],
+  );
   const missionGoalCounts = new Map<string, number>();
   for (const goal of missionGoals) {
     const status = goal.status ?? 'unknown';
@@ -686,13 +711,21 @@ function AtlasProjectionView({
       }}
     >
       <section style={{ ...panelStyle, flexShrink: 0 }}>
-        <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+        <div
+          style={{
+            display: 'flex',
+            flexWrap: 'wrap',
+            gap: 6,
+            alignItems: 'center',
+          }}
+        >
           <select
             aria-label="Mission"
             value={selectedMission}
             onChange={(event) => {
               autoSelectMission.current = false;
               setSelectedMission(event.target.value);
+              setSelectedGoal(null);
             }}
             style={{ ...mono, minWidth: 240, padding: '4px 6px' }}
           >
@@ -703,6 +736,18 @@ function AtlasProjectionView({
               </option>
             ))}
           </select>
+          <SmallButton
+            active={displayMode === 'visual'}
+            onClick={() => setDisplayMode('visual')}
+          >
+            situation
+          </SmallButton>
+          <SmallButton
+            active={displayMode === 'audit'}
+            onClick={() => setDisplayMode('audit')}
+          >
+            audit
+          </SmallButton>
           <SmallButton onClick={() => setActionPanel('mission')}>
             + Mission
           </SmallButton>
@@ -741,156 +786,174 @@ function AtlasProjectionView({
         )}
       </section>
 
-      <div style={{ display: 'flex', gap: 8, flex: 1, minHeight: 0 }}>
-        <main style={{ flex: 1, minWidth: 0, overflow: 'auto' }}>
-          <section style={{ ...panelStyle, marginBottom: 8 }}>
-            <h2 style={headingStyle}>Mission Home · current cut</h2>
-            {trustReport?.query_profile && (
-              <div style={{ ...mono, color: '#858585', marginBottom: 5 }}>
-                profile {trustReport.query_profile.profile.version} ·{' '}
-                {trustReport.query_profile.views.length} saved views · proof{' '}
-                {trustReport.query_profile.query_proof_root.slice(-12)}
-              </div>
-            )}
-            {trustReport && (
-              <div
-                style={{
-                  ...mono,
-                  color:
-                    queryStream.gap || queryStreamError ? '#dcdcaa' : '#4ec9b0',
-                  marginBottom: 5,
-                }}
-              >
-                stream {queryStream.frontier.kind} ·{' '}
-                {queryStream.frontier.record_count} rows
-                {queryStream.gap ? ' · gap: recovery required' : ''}
-                {queryStreamError ? ` · ${queryStreamError}` : ''}
-              </div>
-            )}
-            {!trustReport && (
-              <div style={{ ...mono, color: '#858585' }}>
-                {trustError || 'Select a Mission to resolve its query profile.'}
-              </div>
-            )}
-            {fiveAnswers.map((row) => (
-              <div
-                key={row.question}
-                style={{
-                  padding: '8px 0',
-                  borderBottom: '1px solid #333333',
-                }}
-              >
-                <div style={{ ...mono, color: '#9cdcfe', marginBottom: 3 }}>
-                  {row.question}
-                </div>
-                <div style={{ ...mono, color: '#cccccc' }}>{row.summary}</div>
-                <div style={{ ...mono, color: '#858585', marginTop: 2 }}>
-                  {row.status} · {row.question_id}
-                </div>
-              </div>
-            ))}
-          </section>
-          <MissionTrustPanel report={trustReport} error={trustError} />
-          {(completionReport || completionError) && (
-            <MissionTrustPanel
-              title="Completion TrustReport"
-              report={completionReport}
-              error={completionError}
-            />
-          )}
-        </main>
-
-        <aside
+      {displayMode === 'visual' ? (
+        <main
           style={{
-            ...panelStyle,
-            width: 360,
-            flexShrink: 0,
+            flex: 1,
+            minHeight: 0,
             overflow: 'auto',
+            padding: '0 2px 12px',
           }}
         >
-          <h2 style={headingStyle}>Go summary · {visibleGoals.length}</h2>
-          <div
+          <MissionSituationOverview
+            mission={currentMission}
+            report={trustReport}
+            error={trustError}
+            dashboardCut={dashboardCut}
+            refreshing={dashboardRefreshing}
+          />
+          <div style={{ marginTop: 14 }}>
+            <GoalCardField
+              goals={missionGoals}
+              selectedGoalId={selectedGoal}
+              trustByGoal={goalTrustById}
+              onSelectGoal={setSelectedGoal}
+            />
+          </div>
+        </main>
+      ) : (
+        <div style={{ display: 'flex', gap: 8, flex: 1, minHeight: 0 }}>
+          <main style={{ flex: 1, minWidth: 0, overflow: 'auto' }}>
+            <section style={{ ...panelStyle, marginBottom: 8 }}>
+              <h2 style={headingStyle}>Mission query audit · current cut</h2>
+              {trustReport?.query_profile && (
+                <div style={{ ...mono, color: '#858585', marginBottom: 5 }}>
+                  profile {trustReport.query_profile.profile.version} ·{' '}
+                  {trustReport.query_profile.views.length} saved views · proof{' '}
+                  {trustReport.query_profile.query_proof_root.slice(-12)}
+                </div>
+              )}
+              {trustReport && (
+                <div
+                  style={{
+                    ...mono,
+                    color:
+                      queryStream.gap || queryStreamError
+                        ? '#dcdcaa'
+                        : '#4ec9b0',
+                    marginBottom: 5,
+                  }}
+                >
+                  stream {queryStream.frontier.kind} ·{' '}
+                  {queryStream.frontier.record_count} rows
+                  {queryStream.gap ? ' · gap: recovery required' : ''}
+                  {queryStreamError ? ` · ${queryStreamError}` : ''}
+                </div>
+              )}
+              {!trustReport && (
+                <div style={{ ...mono, color: '#858585' }}>
+                  {trustError ||
+                    'Select a Mission to resolve its query profile.'}
+                </div>
+              )}
+              {fiveAnswers.map((row) => (
+                <div
+                  key={row.question_id}
+                  style={{
+                    padding: '8px 0',
+                    borderBottom: '1px solid #333333',
+                  }}
+                >
+                  <div style={{ ...mono, color: '#9cdcfe', marginBottom: 3 }}>
+                    {row.question}
+                  </div>
+                  <div style={{ ...mono, color: '#cccccc' }}>{row.summary}</div>
+                  <div style={{ ...mono, color: '#858585', marginTop: 2 }}>
+                    {row.status} · {row.question_id}
+                  </div>
+                </div>
+              ))}
+            </section>
+            <MissionTrustPanel report={trustReport} error={trustError} />
+            {(completionReport || completionError) && (
+              <MissionTrustPanel
+                title="Completion TrustReport"
+                report={completionReport}
+                error={completionError}
+              />
+            )}
+          </main>
+
+          <aside
             style={{
-              display: 'flex',
-              flexWrap: 'wrap',
-              gap: 4,
-              marginBottom: 8,
+              ...panelStyle,
+              width: 360,
+              flexShrink: 0,
+              overflow: 'auto',
             }}
           >
-            <SmallButton
-              active={statusFilter === 'all'}
-              onClick={() => setStatusFilter('all')}
-            >
-              all {missionGoals.length}
-            </SmallButton>
-            {ATLAS_GOAL_STATUSES.map((status) => (
-              <SmallButton
-                key={status}
-                active={statusFilter === status}
-                onClick={() => setStatusFilter(status)}
-              >
-                {status} {missionGoalCounts.get(status) ?? 0}
-              </SmallButton>
-            ))}
-          </div>
-          {visibleGoals.map((goal) => (
-            <button
-              key={goal.goal_id}
-              type="button"
-              onClick={() => setSelectedGoal(goal.goal_id)}
+            <h2 style={headingStyle}>Go audit · {visibleGoals.length}</h2>
+            <div
               style={{
-                ...mono,
-                display: 'block',
-                width: '100%',
-                padding: '5px 7px',
-                border: 'none',
-                borderRadius: 4,
-                background:
-                  selectedGoal === goal.goal_id ? '#04395e' : 'transparent',
-                color: '#cccccc',
-                textAlign: 'left',
-                cursor: 'pointer',
+                display: 'flex',
+                flexWrap: 'wrap',
+                gap: 4,
+                marginBottom: 8,
               }}
             >
-              [{goal.status ?? 'unknown'}] {goal.title ?? goal.goal_id}
-            </button>
-          ))}
-          {currentGoal && (
-            <div style={{ marginTop: 8 }}>
-              <AtlasGoalDetail goal={currentGoal} />
-              <SmallButton onClick={() => setActionPanel('claim')}>
-                claim completion
+              <SmallButton
+                active={statusFilter === 'all'}
+                onClick={() => setStatusFilter('all')}
+              >
+                all {missionGoals.length}
               </SmallButton>
+              {ATLAS_GOAL_STATUSES.map((status) => (
+                <SmallButton
+                  key={status}
+                  active={statusFilter === status}
+                  onClick={() => setStatusFilter(status)}
+                >
+                  {status} {missionGoalCounts.get(status) ?? 0}
+                </SmallButton>
+              ))}
             </div>
-          )}
-          <details style={{ marginTop: 12 }}>
-            <summary style={{ ...mono, color: '#858585', cursor: 'pointer' }}>
-              Mission directory · {missions.length}
-            </summary>
-            {missions.map((mission) => (
+            {visibleGoals.map((goal) => (
               <button
-                key={mission.mission_id}
+                key={goal.goal_id}
                 type="button"
-                onClick={() => {
-                  autoSelectMission.current = false;
-                  setSelectedMission(mission.mission_id);
-                }}
+                onClick={() => setSelectedGoal(goal.goal_id)}
                 style={{
                   ...mono,
                   display: 'block',
+                  width: '100%',
+                  padding: '5px 7px',
                   border: 'none',
-                  background: 'transparent',
+                  borderRadius: 4,
+                  background:
+                    selectedGoal === goal.goal_id ? '#04395e' : 'transparent',
                   color: '#cccccc',
-                  padding: '4px 0',
+                  textAlign: 'left',
                   cursor: 'pointer',
                 }}
               >
-                {mission.title ?? mission.mission_id}
+                [{goal.status ?? 'unknown'}] {goal.title ?? goal.goal_id}
               </button>
             ))}
-          </details>
-        </aside>
-      </div>
+            {currentGoal && (
+              <div style={{ marginTop: 8 }}>
+                <AtlasGoalDetail goal={currentGoal} />
+                <SmallButton onClick={() => setActionPanel('claim')}>
+                  claim completion
+                </SmallButton>
+              </div>
+            )}
+          </aside>
+        </div>
+      )}
+
+      {displayMode === 'visual' && currentGoal && (
+        <GoalDetailDrawer
+          goal={currentGoal}
+          mission={currentMission}
+          trust={
+            completionGoalId === currentGoal.goal_id
+              ? deriveTrustVisual(completionReport, completionError)
+              : deriveTrustVisual(null)
+          }
+          onClose={() => setSelectedGoal(null)}
+          onClaimCompletion={() => setActionPanel('claim')}
+        />
+      )}
 
       {actionPanel && (
         <section
@@ -899,7 +962,7 @@ function AtlasProjectionView({
             position: 'absolute',
             top: 48,
             right: 0,
-            zIndex: 20,
+            zIndex: 40,
             width: 380,
             display: 'grid',
             gap: 6,

--- a/extensions/work-dashboard/src/view/mission-visual-model.ts
+++ b/extensions/work-dashboard/src/view/mission-visual-model.ts
@@ -1,0 +1,333 @@
+import type {
+  AtlasGoal,
+  AtlasMission,
+  AtlasMissionControlReport,
+} from '@kungfu-tech/api/capability';
+
+export const MISSION_CONTROL_VISUAL_SPEC = {
+  schema: 'kungfu.mission-control.visual-spec/v1',
+  semanticOwner: 'kungfu.mission-control.query-profile/v1',
+  defaultMode: 'situation',
+  trajectory: {
+    undeclaredFuture: 'visible',
+    syntheticMilestones: 'forbidden',
+    percentageWithoutDenominator: 'forbidden',
+  },
+  goals: {
+    layout: 'responsive-card-field',
+    hierarchy: 'mission-parent-goal-cluster',
+    criticalChildPropagation: true,
+  },
+  trust: {
+    source: 'purpose-bound-kfd-2-report',
+    scalarScore: 'forbidden',
+    missionInheritanceForGo: 'forbidden',
+  },
+  disclosure: {
+    questions: 'internal-only',
+    summary: 'visible',
+    explanation: 'tooltip-or-drawer',
+    audit: 'explicit-mode',
+  },
+} as const;
+
+export type VisualTrustState =
+  | 'established'
+  | 'partial'
+  | 'attention'
+  | 'stale'
+  | 'unknown';
+
+export type TrustFacet = {
+  id: 'claim' | 'assessment' | 'evidence' | 'freshness';
+  state: VisualTrustState;
+  detail: string;
+};
+
+export type TrustVisual = {
+  state: VisualTrustState;
+  label: string;
+  glyph: string;
+  facets: TrustFacet[];
+  detail: string;
+};
+
+const TRUST_LABELS: Record<VisualTrustState, string> = {
+  established: 'Established',
+  partial: 'Partial',
+  attention: 'Attention',
+  stale: 'Stale',
+  unknown: 'Unknown',
+};
+
+const TRUST_GLYPHS: Record<VisualTrustState, string> = {
+  established: '◆',
+  partial: '◒',
+  attention: '!',
+  stale: '↻',
+  unknown: '?',
+};
+
+function trustFacet(
+  id: TrustFacet['id'],
+  state: VisualTrustState,
+  detail: string,
+): TrustFacet {
+  return { id, state, detail };
+}
+
+export function deriveTrustVisual(
+  report: AtlasMissionControlReport | null,
+  error = '',
+): TrustVisual {
+  if (error) {
+    return {
+      state: 'attention',
+      label: TRUST_LABELS.attention,
+      glyph: TRUST_GLYPHS.attention,
+      facets: [
+        trustFacet('claim', 'unknown', 'Claim binding unavailable'),
+        trustFacet('assessment', 'attention', error),
+        trustFacet('evidence', 'unknown', 'Evidence was not resolved'),
+        trustFacet('freshness', 'unknown', 'No assessment cut is available'),
+      ],
+      detail: error,
+    };
+  }
+  if (!report) {
+    return {
+      state: 'unknown',
+      label: TRUST_LABELS.unknown,
+      glyph: TRUST_GLYPHS.unknown,
+      facets: [
+        trustFacet('claim', 'unknown', 'No purpose-bound report is loaded'),
+        trustFacet('assessment', 'unknown', 'No assessment is loaded'),
+        trustFacet('evidence', 'unknown', 'Evidence has not been evaluated'),
+        trustFacet('freshness', 'unknown', 'No assessment cut is available'),
+      ],
+      detail: 'No purpose-bound KFD-2 TrustReport is loaded.',
+    };
+  }
+
+  const assessmentState = String(report.assessment.state || 'unknown');
+  const stale = /stale|invalidated|expired/i.test(assessmentState);
+  const conflicts = report.profile.proof.conflicts.length;
+  const unverifiable = report.profile.proof.unverifiable_inputs.length;
+  const canonical =
+    report.state.canonical_state && report.profile.proof.canonical_state;
+  let state: VisualTrustState;
+  if (stale) state = 'stale';
+  else if (!canonical || conflicts > 0 || unverifiable > 0) state = 'attention';
+  else if (report.fitness === 'fit') state = 'established';
+  else if (report.fitness === 'warning') state = 'partial';
+  else state = 'attention';
+
+  const detail = [
+    `fitness ${report.fitness}`,
+    `assessment ${assessmentState}`,
+    canonical ? 'canonical cut' : 'degraded cut',
+    conflicts ? `${conflicts} conflict(s)` : '',
+    unverifiable ? `${unverifiable} unverifiable input(s)` : '',
+  ]
+    .filter(Boolean)
+    .join(' · ');
+
+  return {
+    state,
+    label: TRUST_LABELS[state],
+    glyph: TRUST_GLYPHS[state],
+    facets: [
+      trustFacet(
+        'claim',
+        'established',
+        `Bound claim ${report.assessment_key}`,
+      ),
+      trustFacet(
+        'assessment',
+        stale ? 'stale' : state === 'attention' ? 'attention' : 'established',
+        assessmentState,
+      ),
+      trustFacet(
+        'evidence',
+        canonical && conflicts === 0 && unverifiable === 0
+          ? 'established'
+          : 'attention',
+        canonical
+          ? `${report.findings.length} finding(s) at a canonical cut`
+          : 'The query cut is degraded',
+      ),
+      trustFacet(
+        'freshness',
+        stale ? 'stale' : 'established',
+        stale ? assessmentState : 'The report is bound to its recorded cut',
+      ),
+    ],
+    detail,
+  };
+}
+
+export type ResponsibilityAction = {
+  actor: string;
+  subject: string;
+  action: string;
+  source: string;
+};
+
+export function responsibilityActions(
+  report: AtlasMissionControlReport | null,
+): ResponsibilityAction[] {
+  const answer = report?.query_profile?.answers.find(
+    (row) => row.question_id === 'next-responsibility',
+  );
+  const values = answer?.data.declared_actions;
+  if (!Array.isArray(values)) return [];
+  return values
+    .filter(
+      (value): value is Record<string, unknown> =>
+        typeof value === 'object' && value !== null,
+    )
+    .map((value) => ({
+      actor: String(value.actor ?? ''),
+      subject: String(value.subject ?? ''),
+      action: String(value.action ?? ''),
+      source: String(value.source ?? ''),
+    }))
+    .filter((value) => value.action);
+}
+
+export type GoalSection = 'attention' | 'in-motion' | 'delegated' | 'closed';
+
+export type GoalClusterMember = {
+  goal: AtlasGoal;
+  depth: number;
+};
+
+export type GoalCluster = {
+  key: string;
+  parent: AtlasGoal;
+  members: GoalClusterMember[];
+  section: GoalSection;
+};
+
+const CLOSED_STATUSES = new Set(['completed', 'done', 'merged', 'archived']);
+const MOTION_STATUSES = new Set([
+  'active',
+  'stage-ready',
+  'ready',
+  'reviewing',
+]);
+const DELEGATED_STATUSES = new Set([
+  'paused',
+  'waiting',
+  'waiting-for-decision',
+  'proposed',
+]);
+
+export function classifyGoalCluster(
+  members: GoalClusterMember[],
+  trustByGoal: Readonly<Record<string, VisualTrustState>> = {},
+): GoalSection {
+  const statuses = members.map(({ goal }) =>
+    goal.archived ? 'archived' : (goal.status ?? 'unknown'),
+  );
+  const trustStates = members.map(
+    ({ goal }) => trustByGoal[goal.goal_id] ?? 'unknown',
+  );
+  if (
+    statuses.includes('blocked') ||
+    trustStates.includes('attention') ||
+    trustStates.includes('stale')
+  ) {
+    return 'attention';
+  }
+  if (statuses.some((status) => MOTION_STATUSES.has(status)))
+    return 'in-motion';
+  if (
+    statuses.length > 0 &&
+    statuses.every((status) => CLOSED_STATUSES.has(status))
+  ) {
+    return 'closed';
+  }
+  if (statuses.some((status) => DELEGATED_STATUSES.has(status)))
+    return 'delegated';
+  return 'delegated';
+}
+
+export function buildGoalClusters(
+  goals: AtlasGoal[],
+  trustByGoal: Readonly<Record<string, VisualTrustState>> = {},
+): GoalCluster[] {
+  const byId = new Map(goals.map((goal) => [goal.goal_id, goal]));
+  const children = new Map<string, AtlasGoal[]>();
+  for (const goal of goals) {
+    const parent = goal.mission_parent_goal;
+    if (!parent || !byId.has(parent) || parent === goal.goal_id) continue;
+    const rows = children.get(parent) ?? [];
+    rows.push(goal);
+    children.set(parent, rows);
+  }
+  for (const rows of children.values()) {
+    rows.sort((left, right) => left.goal_id.localeCompare(right.goal_id));
+  }
+
+  const roots = goals
+    .filter((goal) => {
+      const parent = goal.mission_parent_goal;
+      return !parent || !byId.has(parent) || parent === goal.goal_id;
+    })
+    .sort((left, right) => left.goal_id.localeCompare(right.goal_id));
+  const visited = new Set<string>();
+  const clusters: GoalCluster[] = [];
+
+  const collect = (
+    goal: AtlasGoal,
+    depth: number,
+    members: GoalClusterMember[],
+  ) => {
+    if (visited.has(goal.goal_id)) return;
+    visited.add(goal.goal_id);
+    members.push({ goal, depth });
+    for (const child of children.get(goal.goal_id) ?? []) {
+      collect(child, depth + 1, members);
+    }
+  };
+
+  const appendCluster = (parent: AtlasGoal) => {
+    const members: GoalClusterMember[] = [];
+    collect(parent, 0, members);
+    clusters.push({
+      key: parent.goal_id,
+      parent,
+      members,
+      section: classifyGoalCluster(members, trustByGoal),
+    });
+  };
+  roots.forEach(appendCluster);
+  goals
+    .filter((goal) => !visited.has(goal.goal_id))
+    .sort((left, right) => left.goal_id.localeCompare(right.goal_id))
+    .forEach(appendCluster);
+  return clusters;
+}
+
+export function missionIntent(mission: AtlasMission | null): string {
+  if (!mission) return '';
+  return (
+    mission.north_star ||
+    mission.intent ||
+    mission.why_it_matters ||
+    ''
+  ).trim();
+}
+
+export function missionStage(mission: AtlasMission | null): string {
+  return mission?.stage_name?.trim() || 'Undeclared stage';
+}
+
+export function goalStatusGlyph(status = 'unknown'): string {
+  if (status === 'blocked') return '!';
+  if (CLOSED_STATUSES.has(status)) return '✓';
+  if (MOTION_STATUSES.has(status)) return '●';
+  if (DELEGATED_STATUSES.has(status)) return '◐';
+  return '○';
+}

--- a/extensions/work-dashboard/src/view/mission-visual.tsx
+++ b/extensions/work-dashboard/src/view/mission-visual.tsx
@@ -1,0 +1,963 @@
+import type {
+  AtlasGoal,
+  AtlasMission,
+  AtlasMissionControlReport,
+} from '@kungfu-tech/api/capability';
+import { mono, panelStyle } from '@kungfu-tech/kfx';
+import React from 'react';
+import {
+  type GoalCluster,
+  type GoalSection,
+  MISSION_CONTROL_VISUAL_SPEC,
+  type TrustVisual,
+  type VisualTrustState,
+  buildGoalClusters,
+  deriveTrustVisual,
+  goalStatusGlyph,
+  missionIntent,
+  missionStage,
+  responsibilityActions,
+} from './mission-visual-model';
+
+const COLORS = {
+  canvas: '#11161d',
+  panel: '#171d26',
+  elevated: '#1d2632',
+  border: '#313b49',
+  subtleBorder: '#252e3a',
+  text: '#e5e9ef',
+  muted: '#8c98a8',
+  cyan: '#59c9d8',
+  blue: '#75a7ff',
+  green: '#55c6a9',
+  amber: '#e2b65b',
+  red: '#ed7b72',
+  violet: '#b59cff',
+};
+
+const TRUST_COLORS: Record<VisualTrustState, string> = {
+  established: COLORS.green,
+  partial: COLORS.amber,
+  attention: COLORS.red,
+  stale: COLORS.violet,
+  unknown: COLORS.muted,
+};
+
+const SECTION_META: Record<
+  GoalSection,
+  { label: string; glyph: string; color: string }
+> = {
+  attention: { label: 'Attention', glyph: '!', color: COLORS.red },
+  'in-motion': { label: 'In motion', glyph: '●', color: COLORS.green },
+  delegated: { label: 'Delegated', glyph: '◐', color: COLORS.amber },
+  closed: { label: 'Closed', glyph: '✓', color: COLORS.muted },
+};
+
+const compactButton = (active = false): React.CSSProperties => ({
+  ...mono,
+  border: `1px solid ${active ? COLORS.cyan : COLORS.border}`,
+  borderRadius: 6,
+  padding: '4px 8px',
+  color: active ? COLORS.cyan : COLORS.muted,
+  background: active ? '#15313b' : 'transparent',
+  cursor: 'pointer',
+});
+
+export function TrustGlyph({
+  visual,
+  compact = false,
+}: {
+  visual: TrustVisual;
+  compact?: boolean;
+}) {
+  const size = compact ? 30 : 58;
+  const facetSize = compact ? 5 : 9;
+  return (
+    <button
+      type="button"
+      aria-label={`KFD-2 trust ${visual.label}. ${visual.detail}`}
+      title={`KFD-2 ${visual.label}\n${visual.detail}`}
+      style={{
+        width: size,
+        height: size,
+        borderRadius: '50%',
+        border: `2px solid ${TRUST_COLORS[visual.state]}`,
+        display: 'grid',
+        placeItems: 'center',
+        position: 'relative',
+        flexShrink: 0,
+        background: '#111821',
+        color: TRUST_COLORS[visual.state],
+        outlineOffset: 3,
+        padding: 0,
+        cursor: 'help',
+      }}
+    >
+      <span
+        aria-hidden="true"
+        style={{
+          ...mono,
+          fontSize: compact ? 12 : 20,
+          lineHeight: 1,
+          fontWeight: 700,
+        }}
+      >
+        {visual.glyph}
+      </span>
+      <span
+        aria-hidden="true"
+        style={{
+          position: 'absolute',
+          inset: compact ? 3 : 5,
+          display: 'grid',
+          gridTemplateColumns: '1fr 1fr',
+          gridTemplateRows: '1fr 1fr',
+          pointerEvents: 'none',
+        }}
+      >
+        {visual.facets.map((facet, index) => (
+          <i
+            key={facet.id}
+            title={`${facet.id}: ${facet.detail}`}
+            style={{
+              width: facetSize,
+              height: facetSize,
+              borderRadius: index % 2 ? '0 50% 50% 0' : '50% 0 0 50%',
+              background: TRUST_COLORS[facet.state],
+              opacity: facet.state === 'unknown' ? 0.35 : 0.9,
+              justifySelf: index % 2 ? 'end' : 'start',
+              alignSelf: index > 1 ? 'end' : 'start',
+            }}
+          />
+        ))}
+      </span>
+    </button>
+  );
+}
+
+function StageTrajectory({
+  mission,
+  trust,
+}: {
+  mission: AtlasMission;
+  trust: TrustVisual;
+}) {
+  const stage = missionStage(mission);
+  const paused = ['paused', 'waiting', 'reviewing'].includes(
+    mission.status ?? '',
+  );
+  const attention = ['attention', 'stale'].includes(trust.state);
+  const node = (glyph: string, label: string, color: string, title: string) => (
+    <button
+      type="button"
+      title={title}
+      aria-label={`${label}. ${title}`}
+      style={{
+        minWidth: 86,
+        textAlign: 'center',
+        outlineOffset: 3,
+        border: 0,
+        padding: 0,
+        background: 'transparent',
+        cursor: 'help',
+      }}
+    >
+      <div
+        aria-hidden="true"
+        style={{ ...mono, color, fontSize: 22, lineHeight: 1.1 }}
+      >
+        {glyph}
+      </div>
+      <div
+        style={{
+          ...mono,
+          marginTop: 5,
+          color,
+          fontSize: 10,
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {label}
+      </div>
+    </button>
+  );
+  return (
+    <div style={{ minWidth: 0 }}>
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'flex-start',
+          minWidth: 0,
+          padding: '8px 2px 2px',
+        }}
+      >
+        {node('◆', 'Declared', COLORS.green, 'Mission declaration is present')}
+        <div
+          aria-hidden="true"
+          style={{
+            height: 2,
+            flex: 1,
+            minWidth: 30,
+            marginTop: 10,
+            background: `linear-gradient(90deg, ${COLORS.green}, ${
+              attention ? COLORS.red : COLORS.cyan
+            })`,
+          }}
+        />
+        {node(
+          paused ? 'Ⅱ' : '◉',
+          stage,
+          attention ? COLORS.red : paused ? COLORS.amber : COLORS.cyan,
+          mission.stage_summary || `Current declared stage: ${stage}`,
+        )}
+        <div
+          aria-hidden="true"
+          style={{
+            height: 0,
+            flex: 1,
+            minWidth: 30,
+            marginTop: 10,
+            borderTop: `2px dashed ${COLORS.border}`,
+          }}
+        />
+        {node(
+          '◇',
+          'Open future',
+          COLORS.muted,
+          'No later Mission milestone is declared; the UI does not invent one',
+        )}
+      </div>
+      {attention && (
+        <button
+          type="button"
+          title={trust.detail}
+          style={{
+            ...mono,
+            color: TRUST_COLORS[trust.state],
+            fontSize: 11,
+            marginLeft: '47%',
+            marginTop: -2,
+            border: 0,
+            padding: 0,
+            background: 'transparent',
+            cursor: 'help',
+          }}
+        >
+          ↘ {trust.glyph}
+        </button>
+      )}
+    </div>
+  );
+}
+
+export function MissionSituationOverview({
+  mission,
+  report,
+  error,
+  dashboardCut,
+  refreshing,
+}: {
+  mission: AtlasMission | null;
+  report: AtlasMissionControlReport | null;
+  error: string;
+  dashboardCut: string;
+  refreshing: boolean;
+}) {
+  if (!mission) {
+    return (
+      <section
+        style={{
+          ...panelStyle,
+          minHeight: 190,
+          display: 'grid',
+          placeItems: 'center',
+          background: COLORS.canvas,
+          border: `1px dashed ${COLORS.border}`,
+        }}
+      >
+        <div style={{ ...mono, color: COLORS.muted }}>
+          Select a Mission to resolve its situation.
+        </div>
+      </section>
+    );
+  }
+  const trust = deriveTrustVisual(report, error);
+  const actions = responsibilityActions(report);
+  const proofCount =
+    report?.profile.proof.verified_fact_episode_roots?.length ?? 0;
+  const intent = missionIntent(mission);
+  return (
+    <section
+      data-visual-spec={MISSION_CONTROL_VISUAL_SPEC.schema}
+      style={{
+        ...panelStyle,
+        padding: 18,
+        background:
+          'radial-gradient(circle at 82% 0%, rgba(89,201,216,0.13), transparent 36%), linear-gradient(145deg, #171d26, #11161d)',
+        border: `1px solid ${COLORS.border}`,
+        borderRadius: 12,
+        boxShadow: '0 14px 34px rgba(0,0,0,0.22)',
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          gap: 14,
+          alignItems: 'flex-start',
+        }}
+      >
+        <div style={{ minWidth: 0 }}>
+          <div
+            style={{
+              ...mono,
+              fontSize: 20,
+              fontWeight: 700,
+              color: COLORS.text,
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {mission.title || mission.mission_id}
+          </div>
+          {intent && (
+            <div
+              style={{
+                color: '#bac4d1',
+                fontSize: 13,
+                lineHeight: 1.45,
+                marginTop: 5,
+                maxWidth: 760,
+              }}
+            >
+              {intent}
+            </div>
+          )}
+        </div>
+        <div style={{ display: 'flex', gap: 6, flexShrink: 0 }}>
+          <span
+            title="Mission lifecycle state"
+            style={{
+              ...mono,
+              color: mission.status === 'active' ? COLORS.green : COLORS.amber,
+              border: `1px solid ${COLORS.border}`,
+              borderRadius: 999,
+              padding: '4px 8px',
+            }}
+          >
+            ● {mission.status || 'unknown'}
+          </span>
+          {mission.active_lens && (
+            <span
+              title="Current Mission lens"
+              style={{
+                ...mono,
+                color: COLORS.blue,
+                border: `1px solid ${COLORS.border}`,
+                borderRadius: 999,
+                padding: '4px 8px',
+              }}
+            >
+              ◇ {mission.active_lens}
+            </span>
+          )}
+        </div>
+      </div>
+
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns:
+            'repeat(auto-fit, minmax(min(100%, 320px), 1fr))',
+          gap: 18,
+          alignItems: 'center',
+          marginTop: 16,
+        }}
+      >
+        <StageTrajectory mission={mission} trust={trust} />
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: 'auto 1fr',
+            gap: 12,
+            alignItems: 'center',
+            padding: 12,
+            border: `1px solid ${COLORS.subtleBorder}`,
+            borderRadius: 10,
+            background: 'rgba(12,17,23,0.56)',
+          }}
+        >
+          <TrustGlyph visual={trust} />
+          <div style={{ display: 'grid', gap: 6, minWidth: 0 }}>
+            <div style={{ ...mono, color: TRUST_COLORS[trust.state] }}>
+              KFD-2 · {trust.label}
+            </div>
+            <div style={{ ...mono, color: COLORS.muted, fontSize: 10 }}>
+              ▱ {proofCount} proof Episode root{proofCount === 1 ? '' : 's'}
+              {' · '}
+              {refreshing
+                ? '↻ refreshing'
+                : `cut ${dashboardCut.slice(-10) || '—'}`}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 7,
+          marginTop: 15,
+          paddingTop: 12,
+          borderTop: `1px solid ${COLORS.subtleBorder}`,
+          overflowX: 'auto',
+        }}
+      >
+        {actions.length ? (
+          actions.slice(0, 6).map((action, index) => (
+            <button
+              key={`${action.subject}-${action.action}`}
+              type="button"
+              title={`${action.action}\n${action.source}`}
+              aria-label={`${index === 0 ? 'Next actor' : 'Declared actor'} ${
+                action.actor || action.subject
+              }: ${action.action}`}
+              style={{
+                ...mono,
+                border: `1px solid ${index === 0 ? COLORS.cyan : COLORS.border}`,
+                borderRadius: 999,
+                background: index === 0 ? '#16323c' : COLORS.panel,
+                color: index === 0 ? COLORS.cyan : COLORS.muted,
+                padding: index === 0 ? '7px 11px' : '5px 9px',
+                cursor: 'help',
+                whiteSpace: 'nowrap',
+              }}
+            >
+              {index === 0 ? '◎' : '○'}{' '}
+              {action.actor || action.subject || 'Unassigned'}
+              {index === 0 ? ' ↗' : ''}
+            </button>
+          ))
+        ) : (
+          <span
+            title="No responsible actor or next action is declared at this cut"
+            style={{ ...mono, color: COLORS.muted }}
+          >
+            ○ Unassigned responsibility
+          </span>
+        )}
+      </div>
+    </section>
+  );
+}
+
+function GoalTrustMark({ state }: { state: VisualTrustState }) {
+  return (
+    <span
+      title={`Go-level KFD-2: ${state}. Mission trust is not inherited.`}
+      aria-label={`Go-level KFD-2 ${state}`}
+      style={{
+        ...mono,
+        color: TRUST_COLORS[state],
+        border: `1px solid ${TRUST_COLORS[state]}`,
+        borderRadius: 999,
+        padding: '2px 6px',
+        fontSize: 9,
+      }}
+    >
+      K2 {state === 'established' ? '◆' : state === 'unknown' ? '?' : '!'}
+    </span>
+  );
+}
+
+function GoalCard({
+  cluster,
+  expanded,
+  selectedGoalId,
+  trustByGoal,
+  onToggle,
+  onSelectGoal,
+}: {
+  cluster: GoalCluster;
+  expanded: boolean;
+  selectedGoalId: string | null;
+  trustByGoal: Readonly<Record<string, VisualTrustState>>;
+  onToggle: () => void;
+  onSelectGoal: (goalId: string) => void;
+}) {
+  const parent = cluster.parent;
+  const children = cluster.members.slice(1);
+  const meta = SECTION_META[cluster.section];
+  const parentTrust = trustByGoal[parent.goal_id] ?? 'unknown';
+  const completed = cluster.members.filter(({ goal }) =>
+    ['completed', 'done', 'merged', 'archived'].includes(goal.status ?? ''),
+  ).length;
+  return (
+    <article
+      style={{
+        minWidth: 0,
+        border: `1px solid ${
+          selectedGoalId === parent.goal_id ? COLORS.cyan : COLORS.border
+        }`,
+        borderRadius: 11,
+        background: `linear-gradient(145deg, ${COLORS.elevated}, ${COLORS.panel})`,
+        boxShadow: '0 8px 22px rgba(0,0,0,0.2)',
+        overflow: 'hidden',
+      }}
+    >
+      <button
+        type="button"
+        onClick={() => onSelectGoal(parent.goal_id)}
+        style={{
+          display: 'block',
+          width: '100%',
+          border: 0,
+          background: 'transparent',
+          color: COLORS.text,
+          textAlign: 'left',
+          padding: 13,
+          cursor: 'pointer',
+        }}
+      >
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            gap: 8,
+          }}
+        >
+          <span style={{ ...mono, color: meta.color, fontSize: 11 }}>
+            {goalStatusGlyph(parent.status)} {parent.status || 'unknown'}
+          </span>
+          <GoalTrustMark state={parentTrust} />
+        </div>
+        <div
+          style={{
+            marginTop: 9,
+            fontSize: 14,
+            lineHeight: 1.3,
+            fontWeight: 650,
+            color: COLORS.text,
+          }}
+        >
+          {parent.title || parent.goal_id}
+        </div>
+        {(parent.mission_why_matters || parent.summary) && (
+          <div
+            style={{
+              marginTop: 6,
+              color: '#aeb8c5',
+              fontSize: 11,
+              lineHeight: 1.4,
+              display: '-webkit-box',
+              WebkitLineClamp: 2,
+              WebkitBoxOrient: 'vertical',
+              overflow: 'hidden',
+            }}
+          >
+            {parent.mission_why_matters || parent.summary}
+          </div>
+        )}
+        <div
+          style={{
+            ...mono,
+            display: 'flex',
+            gap: 7,
+            flexWrap: 'wrap',
+            color: COLORS.muted,
+            fontSize: 9,
+            marginTop: 10,
+          }}
+        >
+          {parent.mission_stage && <span>◉ {parent.mission_stage}</span>}
+          {parent.mission_role && <span>◇ {parent.mission_role}</span>}
+          {parent.owner_agent && <span>◎ {parent.owner_agent}</span>}
+        </div>
+        {parent.next_action && (
+          <div
+            style={{
+              ...mono,
+              marginTop: 10,
+              paddingTop: 8,
+              borderTop: `1px solid ${COLORS.subtleBorder}`,
+              color: COLORS.amber,
+              fontSize: 10,
+              whiteSpace: 'nowrap',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+            }}
+          >
+            ↗ {parent.next_action}
+          </div>
+        )}
+      </button>
+      {children.length > 0 && (
+        <div style={{ borderTop: `1px solid ${COLORS.subtleBorder}` }}>
+          <button
+            type="button"
+            onClick={onToggle}
+            aria-expanded={expanded}
+            style={{
+              ...mono,
+              width: '100%',
+              border: 0,
+              background: '#151b23',
+              color: COLORS.muted,
+              padding: '7px 12px',
+              textAlign: 'left',
+              cursor: 'pointer',
+            }}
+          >
+            {expanded ? '▾' : '▸'} {children.length} child Go
+            {children.length === 1 ? '' : 's'} · {completed}/
+            {cluster.members.length} closed
+          </button>
+          {expanded && (
+            <div style={{ padding: '5px 8px 8px', background: '#121820' }}>
+              {children.map(({ goal, depth }) => (
+                <button
+                  key={goal.goal_id}
+                  type="button"
+                  onClick={() => onSelectGoal(goal.goal_id)}
+                  style={{
+                    ...mono,
+                    display: 'grid',
+                    gridTemplateColumns: '18px minmax(0,1fr) auto',
+                    alignItems: 'center',
+                    gap: 5,
+                    width: '100%',
+                    border: 0,
+                    borderRadius: 6,
+                    background:
+                      selectedGoalId === goal.goal_id
+                        ? '#17313a'
+                        : 'transparent',
+                    color: COLORS.text,
+                    padding: `6px 7px 6px ${7 + Math.min(depth - 1, 3) * 12}px`,
+                    textAlign: 'left',
+                    cursor: 'pointer',
+                  }}
+                >
+                  <span style={{ color: SECTION_META[cluster.section].color }}>
+                    {goalStatusGlyph(goal.status)}
+                  </span>
+                  <span
+                    style={{
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap',
+                    }}
+                  >
+                    {goal.title || goal.goal_id}
+                  </span>
+                  <GoalTrustMark
+                    state={trustByGoal[goal.goal_id] ?? 'unknown'}
+                  />
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </article>
+  );
+}
+
+export function GoalCardField({
+  goals,
+  selectedGoalId,
+  trustByGoal,
+  onSelectGoal,
+}: {
+  goals: AtlasGoal[];
+  selectedGoalId: string | null;
+  trustByGoal: Readonly<Record<string, VisualTrustState>>;
+  onSelectGoal: (goalId: string) => void;
+}) {
+  const [expanded, setExpanded] = React.useState<Set<string>>(() => new Set());
+  const clusters = React.useMemo(
+    () => buildGoalClusters(goals, trustByGoal),
+    [goals, trustByGoal],
+  );
+  const toggle = (key: string) => {
+    setExpanded((current) => {
+      const next = new Set(current);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  };
+  if (!goals.length) {
+    return (
+      <section style={{ ...panelStyle, border: `1px dashed ${COLORS.border}` }}>
+        <div style={{ ...mono, color: COLORS.muted }}>
+          No admitted Go is attached to this Mission.
+        </div>
+      </section>
+    );
+  }
+  return (
+    <div style={{ display: 'grid', gap: 14 }}>
+      {(Object.keys(SECTION_META) as GoalSection[]).map((section) => {
+        const rows = clusters.filter((cluster) => cluster.section === section);
+        if (!rows.length) return null;
+        const meta = SECTION_META[section];
+        return (
+          <section key={section} aria-label={`${meta.label} Go cards`}>
+            <div
+              style={{
+                ...mono,
+                display: 'flex',
+                alignItems: 'center',
+                gap: 7,
+                color: meta.color,
+                margin: '1px 2px 7px',
+                fontSize: 11,
+                letterSpacing: '0.04em',
+                textTransform: 'uppercase',
+              }}
+            >
+              <span aria-hidden="true">{meta.glyph}</span>
+              {meta.label}
+              <span style={{ color: COLORS.muted }}>{rows.length}</span>
+            </div>
+            <div
+              style={{
+                display: 'grid',
+                gridTemplateColumns: 'repeat(auto-fit, minmax(270px, 1fr))',
+                gap: 10,
+                alignItems: 'start',
+              }}
+            >
+              {rows.map((cluster) => (
+                <GoalCard
+                  key={cluster.key}
+                  cluster={cluster}
+                  expanded={expanded.has(cluster.key)}
+                  selectedGoalId={selectedGoalId}
+                  trustByGoal={trustByGoal}
+                  onToggle={() => toggle(cluster.key)}
+                  onSelectGoal={onSelectGoal}
+                />
+              ))}
+            </div>
+          </section>
+        );
+      })}
+    </div>
+  );
+}
+
+type DetailTab = 'summary' | 'timeline' | 'trust' | 'evidence' | 'relations';
+
+export function GoalDetailDrawer({
+  goal,
+  mission,
+  trust,
+  onClose,
+  onClaimCompletion,
+}: {
+  goal: AtlasGoal;
+  mission: AtlasMission | null;
+  trust: TrustVisual;
+  onClose: () => void;
+  onClaimCompletion: () => void;
+}) {
+  const [tab, setTab] = React.useState<DetailTab>('summary');
+  const row = (label: string, value?: string | boolean) =>
+    value === undefined || value === '' ? null : (
+      <div
+        key={label}
+        style={{
+          display: 'grid',
+          gridTemplateColumns: '105px minmax(0,1fr)',
+          gap: 8,
+          marginBottom: 8,
+        }}
+      >
+        <span style={{ ...mono, color: COLORS.muted, fontSize: 10 }}>
+          {label}
+        </span>
+        <span
+          style={{
+            ...mono,
+            color: COLORS.text,
+            fontSize: 10,
+            overflowWrap: 'anywhere',
+          }}
+        >
+          {String(value)}
+        </span>
+      </div>
+    );
+  return (
+    <aside
+      aria-label={`Go details: ${goal.title || goal.goal_id}`}
+      style={{
+        position: 'absolute',
+        zIndex: 30,
+        top: 0,
+        right: 0,
+        bottom: 0,
+        width: 'min(460px, 92vw)',
+        display: 'flex',
+        flexDirection: 'column',
+        background: '#151b23',
+        borderLeft: `1px solid ${COLORS.border}`,
+        boxShadow: '-20px 0 50px rgba(0,0,0,0.48)',
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'flex-start',
+          gap: 12,
+          padding: 16,
+          borderBottom: `1px solid ${COLORS.border}`,
+        }}
+      >
+        <div style={{ minWidth: 0 }}>
+          <div style={{ ...mono, color: COLORS.muted, fontSize: 10 }}>
+            {goalStatusGlyph(goal.status)} {goal.status || 'unknown'}
+          </div>
+          <div
+            style={{
+              marginTop: 5,
+              color: COLORS.text,
+              fontSize: 16,
+              fontWeight: 650,
+              lineHeight: 1.35,
+            }}
+          >
+            {goal.title || goal.goal_id}
+          </div>
+        </div>
+        <button type="button" onClick={onClose} style={compactButton()}>
+          close
+        </button>
+      </div>
+      <div
+        role="tablist"
+        aria-label="Go detail sections"
+        style={{
+          display: 'flex',
+          flexWrap: 'wrap',
+          gap: 4,
+          padding: '9px 12px',
+          borderBottom: `1px solid ${COLORS.subtleBorder}`,
+        }}
+      >
+        {(
+          [
+            'summary',
+            'timeline',
+            'trust',
+            'evidence',
+            'relations',
+          ] as DetailTab[]
+        ).map((name) => (
+          <button
+            key={name}
+            type="button"
+            role="tab"
+            aria-selected={tab === name}
+            onClick={() => setTab(name)}
+            style={compactButton(tab === name)}
+          >
+            {name}
+          </button>
+        ))}
+      </div>
+      <div style={{ padding: 16, overflow: 'auto', flex: 1 }}>
+        {tab === 'summary' && (
+          <>
+            {(goal.mission_why_matters || goal.summary) && (
+              <div
+                style={{ color: '#bac4d1', lineHeight: 1.5, marginBottom: 16 }}
+              >
+                {goal.mission_why_matters || goal.summary}
+              </div>
+            )}
+            {goal.next_action && (
+              <div
+                style={{
+                  ...mono,
+                  color: COLORS.amber,
+                  background: '#241f16',
+                  border: '1px solid #4b4028',
+                  borderRadius: 8,
+                  padding: 10,
+                  marginBottom: 14,
+                }}
+              >
+                ↗ {goal.next_action}
+              </div>
+            )}
+            {row('goal id', goal.goal_id)}
+            {row('stage', goal.mission_stage)}
+            {row('role', goal.mission_role)}
+            {row('importance', goal.mission_importance)}
+            {row('track', goal.mission_track)}
+          </>
+        )}
+        {tab === 'timeline' && (
+          <>
+            <div style={{ ...mono, color: COLORS.muted, marginBottom: 12 }}>
+              Projection coordinates at the current cut
+            </div>
+            {row('updated', goal.updated_at || 'not projected')}
+            {row('status', goal.status)}
+            {row('source branch', goal.source_branch)}
+            {row('latest marker', goal.latest_marker)}
+          </>
+        )}
+        {tab === 'trust' && (
+          <div style={{ display: 'grid', justifyItems: 'start', gap: 12 }}>
+            <TrustGlyph visual={trust} />
+            <div style={{ ...mono, color: TRUST_COLORS[trust.state] }}>
+              KFD-2 {trust.label}
+            </div>
+            <div style={{ color: COLORS.muted, lineHeight: 1.45 }}>
+              {trust.detail}
+            </div>
+            <button
+              type="button"
+              onClick={onClaimCompletion}
+              style={compactButton()}
+            >
+              claim completion + assess
+            </button>
+          </div>
+        )}
+        {tab === 'evidence' && (
+          <>
+            {row('external ref', goal.external_ready_ref)}
+            {row('external head', goal.external_head)}
+            {row('latest marker', goal.latest_marker)}
+            {row('worktree', goal.worktree_path)}
+            {!goal.external_ready_ref && !goal.latest_marker && (
+              <div style={{ ...mono, color: COLORS.muted }}>
+                No Go-level proof pointer is projected at this cut.
+              </div>
+            )}
+          </>
+        )}
+        {tab === 'relations' && (
+          <>
+            {row('mission', mission?.title || goal.mission_id)}
+            {row('parent Go', goal.mission_parent_goal)}
+            {row('owner', goal.owner_agent)}
+            {row('lens', goal.lens)}
+            {row('track', goal.mission_track)}
+          </>
+        )}
+      </div>
+    </aside>
+  );
+}

--- a/extensions/work-dashboard/tests/mission-visual-model.test.ts
+++ b/extensions/work-dashboard/tests/mission-visual-model.test.ts
@@ -1,0 +1,190 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import type {
+  AtlasGoal,
+  AtlasMissionControlReport,
+} from '@kungfu-tech/api/capability';
+import {
+  MISSION_CONTROL_VISUAL_SPEC,
+  buildGoalClusters,
+  deriveTrustVisual,
+  responsibilityActions,
+} from '../src/view/mission-visual-model.ts';
+
+const goal = (goalId: string, fields: Partial<AtlasGoal> = {}): AtlasGoal => ({
+  goal_id: goalId,
+  mission_id: 'mission-a',
+  status: 'active',
+  ...fields,
+});
+
+const report = (fields: Partial<AtlasMissionControlReport> = {}) =>
+  ({
+    schema: 'kungfu.mission-control.trust-report/v1',
+    fitness: 'fit',
+    findings: ['progress is supported'],
+    known_limits: [],
+    assessment_key: 'assessment-a',
+    query_definition_root: 'sha256:definition',
+    query_proof_root: 'sha256:proof',
+    assessment: { state: 'completed' },
+    profile: {
+      schema: 'kungfu.profile.delegated-work-cost-state-proof/v1',
+      profile_hash: 'sha256:profile',
+      profile: { id: 'profile', version: '1' },
+      mission_subject: 'atlas:mission-a',
+      cost: {
+        status: 'missing',
+        observation_count: 0,
+        linked_run_count: 0,
+        tokens: {
+          input_tokens: 0,
+          output_tokens: 0,
+          cached_input_tokens: 0,
+          cache_creation_input_tokens: 0,
+          reasoning_tokens: 0,
+        },
+        cost_usd_known: false,
+        attribution: { best: 'unknown', worst: 'unknown', ambiguous: false },
+        proof_episodes: [],
+        missing: {
+          unsealed_runs: [],
+          unreadable_runs: [],
+          no_linked_cost_fact: true,
+        },
+      },
+      state: {
+        value: 'active',
+        source_statuses: ['active'],
+        mapping_policy: 'mission-control',
+        go_subjects: [],
+      },
+      proof: {
+        canonical_state: true,
+        query_definition_root: 'sha256:definition',
+        query_proof_root: 'sha256:proof',
+        query_result_hash: 'sha256:result',
+        verified_fact_episode_roots: ['sha256:episode'],
+        cost_episode_roots: [],
+        assessment_state: 'completed',
+        conflicts: [],
+        unverifiable_inputs: [],
+      },
+    },
+    state: {
+      mission_subject: 'atlas:mission-a',
+      canonical_state: true,
+      cut: {},
+      mission: null,
+      goals: [],
+    },
+    ...fields,
+  }) as AtlasMissionControlReport;
+
+test('visual spec keeps the five questions internal and forbids synthetic truth', () => {
+  assert.equal(
+    MISSION_CONTROL_VISUAL_SPEC.schema,
+    'kungfu.mission-control.visual-spec/v1',
+  );
+  assert.equal(
+    MISSION_CONTROL_VISUAL_SPEC.disclosure.questions,
+    'internal-only',
+  );
+  assert.equal(MISSION_CONTROL_VISUAL_SPEC.trust.scalarScore, 'forbidden');
+  assert.equal(
+    MISSION_CONTROL_VISUAL_SPEC.trajectory.syntheticMilestones,
+    'forbidden',
+  );
+});
+
+test('parent and descendants occupy one cluster and a blocked child propagates attention', () => {
+  const clusters = buildGoalClusters([
+    goal('parent'),
+    goal('child-a', { mission_parent_goal: 'parent', status: 'completed' }),
+    goal('child-b', { mission_parent_goal: 'parent', status: 'blocked' }),
+    goal('grandchild', { mission_parent_goal: 'child-b', status: 'active' }),
+  ]);
+
+  assert.equal(clusters.length, 1);
+  assert.equal(clusters[0].parent.goal_id, 'parent');
+  assert.deepEqual(
+    clusters[0].members.map(({ goal: row, depth }) => [row.goal_id, depth]),
+    [
+      ['parent', 0],
+      ['child-a', 1],
+      ['child-b', 1],
+      ['grandchild', 2],
+    ],
+  );
+  assert.equal(clusters[0].section, 'attention');
+});
+
+test('trust remains unknown without a purpose-bound report and maps explicit report state', () => {
+  assert.equal(deriveTrustVisual(null).state, 'unknown');
+  assert.equal(deriveTrustVisual(report()).state, 'established');
+  assert.equal(
+    deriveTrustVisual(
+      report({
+        fitness: 'warning',
+        profile: {
+          ...report().profile,
+          proof: { ...report().profile.proof, canonical_state: false },
+        },
+      }),
+    ).state,
+    'attention',
+  );
+  assert.equal(
+    deriveTrustVisual(report({ assessment: { state: 'invalidated' } })).state,
+    'stale',
+  );
+});
+
+test('next actor is projected from the query answer rather than component inference', () => {
+  const actions = responsibilityActions(
+    report({
+      query_profile: {
+        schema: 'kungfu.mission-control.query-profile/v1',
+        profile_hash: 'sha256:profile',
+        profile: {
+          id: 'kungfu.mission-control',
+          version: '1',
+          reducer: 'kungfu.mission-control.reducer/v1',
+        },
+        mission_subject: 'atlas:mission-a',
+        query_definition_root: 'sha256:definition',
+        query_proof_root: 'sha256:proof',
+        result_hash: 'sha256:result',
+        views: [],
+        answers: [
+          {
+            question_id: 'next-responsibility',
+            question: 'internal question',
+            status: 'declared',
+            summary: 'Agent A continues',
+            data: {
+              declared_actions: [
+                {
+                  actor: 'Agent A',
+                  subject: 'goal-a',
+                  action: 'Run the visual dogfood',
+                  source: 'go.next_action',
+                },
+              ],
+            },
+          },
+        ],
+      },
+    }),
+  );
+
+  assert.deepEqual(actions, [
+    {
+      actor: 'Agent A',
+      subject: 'goal-a',
+      action: 'Run the visual dogfood',
+      source: 'go.next_action',
+    },
+  ]);
+});

--- a/framework/api/src/capability/atlas.ts
+++ b/framework/api/src/capability/atlas.ts
@@ -8,6 +8,8 @@ export type AtlasMission = {
   mission_id: string;
   title?: string;
   intent?: string;
+  north_star?: string;
+  why_it_matters?: string;
   status?: string;
   horizon?: string;
   owner?: string;
@@ -16,8 +18,10 @@ export type AtlasMission = {
   authority_mode?: string;
   active_lens?: string;
   stage_name?: string;
+  stage_summary?: string;
   next_review?: string;
   next_action?: string;
+  updated_at?: string;
 };
 
 export type AtlasGoal = {
@@ -28,6 +32,11 @@ export type AtlasGoal = {
   mission_id?: string;
   lens?: string;
   mission_stage?: string;
+  mission_role?: string;
+  mission_importance?: string;
+  mission_track?: string;
+  mission_parent_goal?: string;
+  mission_why_matters?: string;
   source_branch?: string;
   worktree_path?: string;
   external_repo_path?: string;
@@ -37,6 +46,7 @@ export type AtlasGoal = {
   latest_marker?: string;
   summary?: string;
   next_action?: string;
+  updated_at?: string;
   archived?: boolean;
 };
 
@@ -185,6 +195,7 @@ export type AtlasMissionControlReport = {
       query_definition_root: string;
       query_proof_root: string;
       query_result_hash: string;
+      verified_fact_episode_roots?: string[];
       cost_episode_roots: Array<{
         run_id: string;
         episode_id: string;

--- a/framework/core/src/python/kungfu/atlas/importer.py
+++ b/framework/core/src/python/kungfu/atlas/importer.py
@@ -199,11 +199,18 @@ def read_missions(repo_root, warnings):
                 {
                     "mission_id": _text(card.get("mission_id")),
                     "title": _text(card.get("title")),
+                    "intent": _text(card.get("intent")),
+                    "north_star": _text(card.get("north_star")),
+                    "why_it_matters": _text(card.get("why_it_matters")),
                     "status": _text(card.get("status")),
+                    "horizon": _text(card.get("horizon")),
+                    "owner": _text(card.get("owner")),
                     "active_lens": _text(card.get("active_lens")),
                     "stage_name": _text(stage.get("name")),
+                    "stage_summary": _text(stage.get("summary")),
                     "next_review": _text(stage.get("next_review")),
                     "next_action": _text(card.get("next_action")),
+                    "updated_at": _text(card.get("updated_at")),
                 }
             )
     return [card for card in missions if card["mission_id"]]
@@ -250,6 +257,11 @@ def read_goals(repo_root, warnings):
                     "mission_id": _text(card.get("mission_id")),
                     "lens": _text(card.get("lens")),
                     "mission_stage": _text(card.get("mission_stage")),
+                    "mission_role": _text(card.get("mission_role")),
+                    "mission_importance": _text(card.get("mission_importance")),
+                    "mission_track": _text(card.get("mission_track")),
+                    "mission_parent_goal": _text(card.get("mission_parent_goal")),
+                    "mission_why_matters": _text(card.get("mission_why_matters")),
                     "source_branch": _text(card.get("source_branch")),
                     "worktree_path": _text(card.get("worktree_path")),
                     "external_repo_path": _text(card.get("external_repo_path")),
@@ -259,6 +271,7 @@ def read_goals(repo_root, warnings):
                     "latest_marker": _text(card.get("latest_marker")),
                     "summary": _text(card.get("summary")),
                     "next_action": _text(card.get("next_action")),
+                    "updated_at": _text(card.get("updated_at")),
                     "archived": bool(card.get("archived", archived)),
                 }
             )

--- a/framework/core/src/python/kungfu/atlas/store.py
+++ b/framework/core/src/python/kungfu/atlas/store.py
@@ -542,11 +542,18 @@ def _mission_card(payload):
     return {
         "mission_id": _text(payload.get("mission_id")),
         "title": _text(payload.get("title")),
+        "intent": _text(payload.get("intent")),
+        "north_star": _text(payload.get("north_star")),
+        "why_it_matters": _text(payload.get("why_it_matters")),
         "status": _text(payload.get("status")),
+        "horizon": _text(payload.get("horizon")),
+        "owner": _text(payload.get("owner")),
         "active_lens": _text(payload.get("active_lens")),
         "stage_name": _text(stage.get("name")),
+        "stage_summary": _text(stage.get("summary")),
         "next_review": _text(stage.get("next_review")),
         "next_action": _text(payload.get("next_action")),
+        "updated_at": _text(payload.get("updated_at")),
     }
 
 
@@ -559,6 +566,11 @@ def _goal_card(payload):
         "mission_id": _text(payload.get("mission_id")),
         "lens": _text(payload.get("lens")),
         "mission_stage": _text(payload.get("mission_stage")),
+        "mission_role": _text(payload.get("mission_role")),
+        "mission_importance": _text(payload.get("mission_importance")),
+        "mission_track": _text(payload.get("mission_track")),
+        "mission_parent_goal": _text(payload.get("mission_parent_goal")),
+        "mission_why_matters": _text(payload.get("mission_why_matters")),
         "source_branch": _text(payload.get("source_branch")),
         "worktree_path": _text(payload.get("worktree_path")),
         "external_repo_path": _text(payload.get("external_repo_path")),
@@ -568,6 +580,7 @@ def _goal_card(payload):
         "latest_marker": _text(payload.get("latest_marker")),
         "summary": _text(payload.get("summary")),
         "next_action": _text(payload.get("next_action")),
+        "updated_at": _text(payload.get("updated_at")),
         "archived": bool(payload.get("archived")),
     }
 

--- a/framework/core/tests/python/test_atlas_storage.py
+++ b/framework/core/tests/python/test_atlas_storage.py
@@ -109,6 +109,11 @@ def _atlas_fixture(root):
             "updated_at": "2026-07-08T01:00:00Z",
             "title": "Goal A",
             "mission_id": "mission-a",
+            "mission_parent_goal": "goal-parent",
+            "mission_role": "supporting",
+            "mission_importance": "high",
+            "mission_track": "mission-control",
+            "mission_why_matters": "Make the Mission legible",
             "next_action": "implement",
             "large_body": ["full", "goal", "payload"],
         },
@@ -223,6 +228,12 @@ def test_atlas_source_records_keep_full_payloads(tmp_path):
     assert warnings == []
     assert [card["mission_id"] for card in missions] == ["mission-a"]
     assert [card["goal_id"] for card in goals] == ["goal-a"]
+    assert goals[0]["mission_parent_goal"] == "goal-parent"
+    assert goals[0]["mission_role"] == "supporting"
+    assert goals[0]["mission_importance"] == "high"
+    assert goals[0]["mission_track"] == "mission-control"
+    assert goals[0]["mission_why_matters"] == "Make the Mission legible"
+    assert goals[0]["updated_at"] == "2026-07-08T01:00:00Z"
     assert [card["branch"] for card in markers] == ["ai/codex/goal-a"]
     assert {(row["kind"], row["source_id"]) for row in source_records} == {
         ("mission", "mission-a"),
@@ -298,6 +309,12 @@ def test_atlas_import_admits_mission_and_go_into_shared_fact_state(tmp_path):
     goal_body = next(body for body in bodies if body["source"]["kind"] == "goal")
     assert goal_body["links"] == {"mission_id": "atlas:mission-a"}
     assert goal_body["record"]["goal_id"] == "goal-a"
+    assert goal_body["record"]["mission_parent_goal"] == "goal-parent"
+    assert goal_body["record"]["mission_role"] == "supporting"
+    assert goal_body["record"]["mission_importance"] == "high"
+    assert goal_body["record"]["mission_track"] == "mission-control"
+    assert goal_body["record"]["mission_why_matters"] == ("Make the Mission legible")
+    assert goal_body["record"]["updated_at"] == "2026-07-08T01:00:00Z"
 
     second = atlas_store.ImportStore(runtime_dir).run_import(str(repo))
     assert second["mission_control"]["status"] == "admitted"


### PR DESCRIPTION
## Summary
- replace the default five-question/table presentation with a visual Mission situation view
- group parent and child Gos into progressive-disclosure cluster cards
- expose purpose-bound KFD-2 glyphs, evidence freshness, next actor, and a detail drawer
- preserve the five-question query output in explicit audit mode
- project the Atlas hierarchy and Mission context fields needed by the visual model

## Verification
- ./shifu check
- ./shifu foreach:extensions test (6/6)
- ./shifu foreach test:query (7/7)
- focused Atlas projection pytest (2/2)
- ./shifu build
- ./shifu dist --product desktop --dir
- real Atlas workspace dogfood: visual spec present, five questions hidden by default, audit questions preserved, drawer tabs work, parent/child cluster detected, 760px viewport has no body overflow

## Product
- promoted Shifu build 20260712T133420Z-be00e1336
- CI is currently not treated as a merge gate per operator instruction