### PR TITLE
docs: retire stale spec guidance

### DIFF
--- a/framework/core/docs/adr/README.md
+++ b/framework/core/docs/adr/README.md
@@ -53,7 +53,7 @@ A record's **Status** says where it stands:
 | [0033](ADR-0033-episode-causal-segment-object.md) | accepted | Episode is the first-class causal segment object |
 | [0034](ADR-0034-yijinjing-episode-manifest-journal.md) | accepted | Episode manifest records live in the yijinjing journal format |
 | [0035](ADR-0035-workspace-local-kungfu-data-home.md) | accepted | Workspace-local `.kungfu` is the default fact ledger home |
-| [0036](ADR-0036-supervisor-and-workspace-coordinator-topology.md) | superseded by 0057 | Established the per-user supervisor and per-data-root coordinator topology |
+| [0036](ADR-0036-supervisor-and-workspace-master-topology.md) | superseded by 0057 | Established the per-user supervisor and per-data-root coordinator topology |
 | [0037](ADR-0037-storage-records-hana-core-kernel-metadata.md) | accepted | ADR-0018 storage-service records are Hana-core kernel metadata; JSON is an edge projection, not the contract |
 | [0038](ADR-0038-location-namespace-terminology.md) | accepted | Location middle identity segment is namespace |
 | [0039](ADR-0039-unified-view-interface-encapsulates-flatbuffers.md) | proposed | a single kungfu view interface is the sole FlatBuffers access point; raw FB is not called elsewhere |
@@ -187,7 +187,7 @@ A record's **Status** says where it stands:
   [0035](ADR-0035-workspace-local-kungfu-data-home.md) (workspace-local
   `.kungfu/` as the default Episode/fact ledger home, with `~/.kungfu-config`
   as the user config home and `KF_HOME` retained as machine fallback), and
-  [0036](ADR-0036-supervisor-and-workspace-coordinator-topology.md) (a per-user
+  [0036](ADR-0036-supervisor-and-workspace-master-topology.md) (a per-user
   supervisor routes CLI/GUI/TUI entrypoints to per-data-root masters while
   storage remains daemonless), and
   [0037](ADR-0037-storage-records-hana-core-kernel-metadata.md) (the ADR-0018

--- a/framework/core/src/python/kungfu/rewind/README.md
+++ b/framework/core/src/python/kungfu/rewind/README.md
@@ -21,7 +21,7 @@ writes every event as an open-layer journal frame:
 | action envelope | `CostSnapshot` | normalized token/cost usage with attribution + confidence |
 | action envelope | `ApprovalDecision` | human approve/deny/interrupt/resume decision, linked to run_id |
 
-Allocation is recorded in [`docs/carrier-type-registry.md`](../../../../../../docs/carrier-type-registry.md);
+Allocation is recorded in [`docs/carrier-type-registry.md`](../../../../docs/carrier-type-registry.md);
 the schema surface is registered in [`docs/versioning.md`](../../../../../../docs/versioning.md).
 
 ## How the minimal facts are carried

--- a/framework/spec/CONSUMING.md
+++ b/framework/spec/CONSUMING.md
@@ -4,6 +4,11 @@ This is the **connection contract** between the monorepo and the docs site. The
 site depends on exactly one thing: the **manifest** of this package. It must not
 vendor, submodule, or otherwise reach into the monorepo for spec content.
 
+> **Pre-release contract.** This page defines the intended package boundary; it
+> does not assert that `@kungfu-tech/spec` is currently published or that the
+> bundled Spec 0.1 prose is normative. Test consumers against an exact
+> source-built package until release evidence says otherwise.
+
 ## 1. Pin the package
 
 ```jsonc

--- a/framework/spec/README.md
+++ b/framework/spec/README.md
@@ -8,6 +8,15 @@ deliberately landed first, as a skeleton, so the generating flows (core /
 toolchain / node / python) and the downstream site all agree on one contract
 before any content exists.
 
+> **Pre-release walking skeleton.** The manifest contract and aggregation
+> pipeline are active. The bundled format prose is still the historical 0.1
+> draft and is not the current normative `.kungfu` semantic contract. It
+> predates the Episode-centered object model and is retained as an explicit
+> draft input, not as implementation guidance. Current public semantics live in
+> [`docs/the-episode.md`](../../docs/the-episode.md),
+> [`docs/episode-object-model.md`](../../docs/episode-object-model.md), and
+> [`docs/event-model.md`](../../docs/event-model.md).
+
 ## What this package is
 
 - The **single connection protocol** between the kungfu monorepo (the single
@@ -24,7 +33,7 @@ before any content exists.
 | --- | --- | --- |
 | kungfu software version | `4.0.0-alpha.0` | software release (lerna single source) |
 | this package's version | `4.0.0-alpha.0` | **pickup coordinate** (reproducible pin; tracks lerna) |
-| **spec / format version** | **`1.0`** | **the authoritative contract** (declared in the manifest, independent of the above) |
+| **spec / format version** | **`0.1`** | pre-release draft coordinate declared in the manifest; no stable format compatibility claim yet |
 
 Consumers render and route off `spec_version`, never off the npm package
 version. The format identity (`format_namespace`) is **domain-free** on purpose:
@@ -58,22 +67,21 @@ runtime contract, not as independent Python or Node storage models. Storage
 backends such as the content-addressed file provider or RocksDB provider are
 runtime implementation choices behind that contract.
 
-## Scripts (skeleton placeholders)
+## Build and verify the skeleton
 
-- `pnpm --filter @kungfu-tech/spec run build` → `scripts/aggregate.js`: builds a
-  real, schema-valid bundle into `dist/` (`manifest.json` + the six category
-  payloads + three handbook payloads) from `spec.meta.json`, `package.json`, and
-  `docs/format-spec.md`.
-- `pnpm --filter @kungfu-tech/spec run verify` → `scripts/verify.js`: the
-  **integration drift gate**, active. Fails the build if the produced bundle
-  drifts from the manifest contract (missing/extra fields, domain-embedded
-  `format_namespace`, a referenced payload path that does not exist, or a
-  `spec_version` not routed into `docs_url_base`).
+The repository-level `./shifu build` path invokes `scripts/aggregate.js` to
+produce a schema-valid bundle in `dist/`. The package's `scripts/verify.js` is
+the active integration drift gate: it rejects manifest shape drift, missing
+payloads, a domain-embedded `format_namespace`, or a `spec_version` that does
+not match `docs_url_base`. Contributors should enter through `./shifu`, as
+described in the repository [CONTRIBUTING guide](../../CONTRIBUTING.md), rather
+than invoking the package manager directly.
 
 This is a **walking skeleton**: the pipeline produces and gates a real bundle,
 but with minimal content. Only `categories.format_spec` carries real prose
-(`docs/format-spec.md`); the five machine categories and three handbooks are
-minimal stubs, each tagged in the manifest with its owning package. See
+(`docs/format-spec.md`), but that prose remains a non-normative historical 0.1
+draft. The five machine categories and three handbooks are minimal or staged
+surfaces, each tagged in the manifest with its owning package. See
 [CONSUMING.md](CONSUMING.md) for how `site-libkungfu-dev` consumes the bundle.
 
 ## Not done here (follow-ups)

--- a/framework/spec/docs/format-spec.md
+++ b/framework/spec/docs/format-spec.md
@@ -1,5 +1,16 @@
 # Kungfu Fact-Ledger Format — Spec 0.1 (pre-release draft)
 
+> **Historical walking-skeleton input, not the current normative `.kungfu`
+> contract.** This draft predates the Episode-centered object model and remains
+> bundled only so the manifest/aggregation pipeline has explicit versioned
+> input. Do not implement a reader or make a compatibility claim from this
+> prose. Current semantic authority lives in
+> [`docs/the-episode.md`](../../../docs/the-episode.md),
+> [`docs/episode-object-model.md`](../../../docs/episode-object-model.md), and
+> [`docs/event-model.md`](../../../docs/event-model.md). A future format
+> decision must reconcile and replace this draft before the format is promoted
+> as normative.
+
 - **Format namespace:** `libkungfu:fact-ledger` (stable, domain-free identity)
 - **Spec version:** `0.1`
 - **Status:** pre-release draft. A version below `1.0` is **not a publishable
@@ -111,7 +122,7 @@ These terms are normative at the semantic level:
 | **source** | A logical fact provider: local profile, imported bundle, remote Kungfu runtime, or adapter. |
 | **location** | The runtime address/identity for a source or destination process, profile, or node. |
 | **channel** | The transport edge used to request a range, fetch payloads, export, import, or repair missing material. It is not authority. |
-| **range selector** | A bounded request by event range, wall-clock-like logical time, session, cursor, or hash anchor. |
+| **range selector** | A bounded request by event range, Episode, logical time, cursor, or hash anchor. |
 | **hash inventory** | The list of content commitments that lets a receiver verify payload and schema material before or after transfer. |
 | **manifest** | The accept boundary: source metadata, capture boundary, range, payload inventory, schema inventory, checksums, and projection watermarks. |
 | **accepted segment** | The local record that a manifest-backed range has been verified and admitted into the receiver's fact ledger. |

--- a/framework/spec/docs/handbooks/cli.md
+++ b/framework/spec/docs/handbooks/cli.md
@@ -1,61 +1,45 @@
-# kungfu CLI handbook — `kungfu`
+# Kungfu CLI handbook
 
-> Pre-release (spec 0.1) · minimal recipe. `kungfu` is the kungfu CLI
-> (`@kungfu-tech/core`) and the runtime it invokes. The generated command reference (from the
-> CLI's own definitions) and the agent-first `--json` provenance surface are
-> planned; this page is a hand-written getting-started.
+> **Pre-release source guidance.** Public CLI artifacts are not yet a polished
+> one-command install. Command names below are backed by the current source;
+> availability and release guarantees remain scoped by
+> [Known Limits](../../../../docs/known-limits.md).
 
-`kungfu` is how you capture and inspect fact-ledger records from the command
-line. Everything below produces or reads the same portable bundle described in
-the [format spec](../../spec/).
+The `kungfu` command operates the runtime fact ledger. Episode is the semantic
+object; `trace` and `rewind --run` are current Agent Work profile adapters, not
+the identity of the whole CLI.
 
-## Install
+## Discover the installed surface
 
-`kungfu` ships with `@kungfu-tech/core`:
-
-```bash
-pnpm add @kungfu-tech/core
-# kungfu is now on your PATH inside the workspace
-kungfu --version
+```sh
+kungfu agent brief
+kungfu agent capabilities --json
+kungfu agent choose-mode --json
+kungfu --help
 ```
 
-## Capture a record
+## Inspect Episode authority
 
-`trace` captures an agent run into a local trace store — everything the run
-does is recorded into a fact-ledger you can re-open afterward:
+```sh
+kungfu storage episode list --json
+kungfu storage episode inspect --episode-id <episode-id> --json
+kungfu storage fsck --scope episode --episode-id <episode-id> \
+  --verify-frames --json
+```
 
-```bash
-# capture a run
+## Use the Agent Work capture adapter
+
+```sh
 kungfu trace -- <command>
+kungfu rewind show --run <run-id>
+kungfu rewind verify --run <run-id>
 ```
 
-## Re-open a record
+Rewind is forensic reopening. It never silently repeats external side effects.
+See [Rewind an Episode](../../../../docs/rewind.md) for the distinction between
+Replay, Rewind, Recovery, and explicit re-execution.
 
-`rewind` re-opens recorded runs for forensic replay over the trace journal:
-
-```bash
-kungfu rewind <subcommand>
-```
-
-## All commands
-
-| Command | What it does |
-| --- | --- |
-| `trace` | capture an agent run into a local trace store |
-| `rewind` | re-open recorded runs: forensic replay over the trace journal |
-| `journal` | read the underlying journal (yijinjing) records |
-| `schema` | compile kfx FlatBuffers schemas into open-layer `.bfbs` (in-process, no flatc) |
-| `work` | manage work items: create, drive the lifecycle, and inspect state |
-| `kfx` | install, list and remove kfx packages for this home |
-| `cockpit` | open the cockpit — the terminal operator surface (rendered by the reference TUI, Ink) |
-| `atlas` | Atlas repo integration surface |
-| `engage` | developer tooling (formatting and related helpers) |
-
-Run `kungfu <command> --help` for the full option list.
-
-## Planned
-
-- `kungfu --json` emitting provenance + the authoritative `docs_url` for the
-  installed version, so an agent can fetch the right doc automatically.
-- A generated command reference kept in lock-step with the CLI definitions
-  (drift = build fail).
+The former `kungfu journal` maintenance command is retired. Storage, Episode,
+query, repair-plan, export, and source operations own the current public
+authority boundary. Use `kungfu <command> --help` and the installed agent brief
+instead of an enumerated command list that can drift from the runtime.

--- a/framework/spec/docs/handbooks/node.md
+++ b/framework/spec/docs/handbooks/node.md
@@ -1,57 +1,24 @@
-# Node handbook
+# Node SDK handbook
 
-> Pre-release (spec 0.1) · minimal recipe. The generated API reference (from the
-> TypeScript types) is planned; signatures below are illustrative until it lands
-> — check the reference page for authoritative names.
+> **Staged surface.** The Node `@kungfu-tech/storage` source adapter and shared
+> Episode/query/fsck/export fixture exist, but the package is not yet a
+> published cross-platform release. There is no stable public `ledger()` API,
+> and this handbook deliberately does not invent one.
 
-Embed fact-ledger recording in a Node or TypeScript script. Local-first,
-in-process, no account or network.
+Node is a thin N-API binding over the same versioned `libkungfu` storage
+contract used by the native and Python surfaces. It must not redefine Episode
+identity, causality, Cuts, query meaning, repair semantics, or Proof.
 
-## Install
+Current evidence and adoption boundaries:
 
-```bash
-pnpm add @kungfu-tech/api
-```
+- [Product Layers](../../../../docs/product-layers.md) — ecosystem package
+  qualification and availability.
+- [Adapters](../../../../docs/adapters.md) — the N-API/native membrane.
+- [Episode Object Model](../../../../docs/episode-object-model.md) — semantic
+  authority.
+- [SDK layer qualification](../../../../tests/qualification/layers/README.md) —
+  the shared source and exact-artifact fixtures.
 
-## Import
-
-```js
-const kungfu = require('@kungfu-tech/api');
-```
-
-```ts
-import * as kungfu from '@kungfu-tech/api';
-```
-
-## Produce and read a record (shape of use)
-
-The Node binding writes the same portable bundle described in the
-[format spec](../../spec/): append events with their causal parent, then read
-them back with no runtime dependency.
-
-```js
-const kungfu = require('@kungfu-tech/api');
-
-// open a ledger location (local-first; no account/network)
-const ledger = kungfu.ledger('./runs/session-1');
-
-// append a fact, carrying its causal parent
-const e1 = ledger.append({ kind: 'note', payload: { msg: 'started' } });
-ledger.append({ kind: 'note', payload: { msg: 'step done' }, causedBy: e1 });
-
-// read the ordered, causal record back
-for (const event of ledger.read()) {
-  console.log(event.kind, event.payload);
-}
-```
-
-The exact method names are being finalized against the real binding and will be
-published in the generated reference. What is stable is the *shape*: open a local
-ledger, append facts with a causal parent, read them back verifiably.
-
-## Planned
-
-- Generated API reference from the TypeScript types (authoritative signatures;
-  drift = build fail).
-- `--json` provenance emitting the authoritative `docs_url` for the installed
-  version.
+Until a published artifact and generated API reference exist, use the source
+tree and qualification reports for evaluation. Do not copy illustrative method
+names from older drafts into application code.

--- a/framework/spec/docs/handbooks/python.md
+++ b/framework/spec/docs/handbooks/python.md
@@ -1,53 +1,24 @@
-# Python handbook
+# Python SDK handbook
 
-> Pre-release (spec 0.1) · minimal recipe. The generated API reference (from
-> Python introspection) is planned; this page shows the shape of use, not the
-> full signature surface. Signatures below are illustrative until the generated
-> reference lands — check the reference page for authoritative names.
+> **Staged surface.** The Python `kungfu-storage` source adapter and shared
+> Episode/query/fsck/export fixture exist, but the package is not yet a
+> published cross-platform release. There is no stable public `kungfu.ledger()`
+> API, and this handbook deliberately does not invent one.
 
-Embed fact-ledger recording directly in a Python script. Installing the package
-puts recording in-process — no service, no account, local-first.
+Python is a thin binding over the same versioned `libkungfu` storage contract
+used by the native and Node surfaces. It must not redefine Episode identity,
+causality, Cuts, query meaning, repair semantics, or Proof.
 
-## Install
+Current evidence and adoption boundaries:
 
-```bash
-pip install kungfu
-```
+- [Product Layers](../../../../docs/product-layers.md) — ecosystem package
+  qualification and availability.
+- [Adapters](../../../../docs/adapters.md) — the pybind11/native membrane.
+- [Episode Object Model](../../../../docs/episode-object-model.md) — semantic
+  authority.
+- [SDK layer qualification](../../../../tests/qualification/layers/README.md) —
+  the shared source and exact-artifact fixtures.
 
-## Import
-
-```python
-import kungfu
-```
-
-## Produce and read a record (shape of use)
-
-The Python binding writes the same portable bundle described in the
-[format spec](../../spec/): append events with their causal parent, then read
-them back — in this process or any later one, with no runtime dependency.
-
-```python
-import kungfu
-
-# open a ledger location (local-first; no account/network)
-ledger = kungfu.ledger("./runs/session-1")
-
-# append a fact, carrying its causal parent
-e1 = ledger.append(kind="note", payload={"msg": "started"})
-ledger.append(kind="note", payload={"msg": "step done"}, caused_by=e1)
-
-# read the ordered, causal record back
-for event in ledger.read():
-    print(event.kind, event.payload)
-```
-
-The exact method names are being finalized against the real binding and will be
-published in the generated reference. What is stable is the *shape*: open a
-local ledger, append facts with a causal parent, read them back verifiably.
-
-## Planned
-
-- Generated API reference from Python introspection (authoritative signatures;
-  drift = build fail).
-- `--json` provenance emitting the authoritative `docs_url` for the installed
-  version.
+Until a published artifact and generated API reference exist, use the source
+tree and qualification reports for evaluation. Do not copy illustrative method
+names from older drafts into application code.

--- a/framework/spec/docs/overview.md
+++ b/framework/spec/docs/overview.md
@@ -1,37 +1,44 @@
-# libkungfu
+# libkungfu portable format surface
 
-**An open, portable format for fact ledgers — and the agent-facing surface for
-working with them.**
+This package is the pre-release aggregation surface for a portable Kungfu fact
+artifact. It proves that one versioned manifest can route a consumer to format
+prose, schemas, capabilities, conformance material, and language handbooks.
 
-libkungfu is the open standard behind kungfu's runtime fact ledger: an ordered,
-append-only, causally-linked record of events that can be opened and verified
-**without the runtime that produced it, and without any particular library**.
-The format is the product. Reference libraries are a convenience, not a
-requirement and not a trust root — anyone can write a conforming reader from the
-spec alone.
+> **Walking-skeleton status.** The manifest pipeline is active, but the bundled
+> Spec 0.1 prose predates Kungfu's Episode-centered object model and is not the
+> current normative `.kungfu` contract. The language handbooks are staged and
+> must not invent APIs or availability ahead of their owning packages.
 
-Born in a production, low-latency trading core, its first-class use today is
-giving **agent runtimes** a record they cannot misreport: what an agent read,
-called, and decided, captured as facts you can replay and verify.
+The current public object is the **Episode**: a bounded causal unit whose Facts,
+Artifacts, Manifest, Receipts, dependencies, and verification roots can be
+inspected, sealed, exported, replayed, recovered, and used to support
+Decisions. Portable format work must preserve that authority rather than
+creating a second run-, session-, library-, or website-owned truth.
 
-> **Pre-release (spec 0.1).** This surface is a working draft. The format may
-> change without compatibility guarantees until 1.0.
+## Start with current authority
 
-## Start here
+- [The Episode](../../../docs/the-episode.md) — public execution model.
+- [Episode Object Model](../../../docs/episode-object-model.md) — lifecycle,
+  manifest authority, portability, and maturity.
+- [Event Model](../../../docs/event-model.md) — journal, frames, schemas, and
+  Replay mechanics.
+- [Product Layers](../../../docs/product-layers.md) — the staged `.kungfu`
+  format/spec product boundary.
+- [Known Limits](../../../docs/known-limits.md) — absent release and
+  compatibility guarantees.
 
-- **[Format spec](spec/)** — what a bundle is: the guarantees, the four-part
-  anatomy, how it stays verifiable and portable.
-- **Handbooks** — get an agent working against kungfu, per runtime:
-  - **[kungfu (CLI)](handbooks/cli/)** — produce and inspect ledgers from the
-    command line with `kungfu`.
-  - **[Python](handbooks/python/)** — embed recording in a Python script.
-  - **[Node](handbooks/node/)** — embed recording in a Node/TypeScript script.
-- **Reference** — machine-addressable data: schema registry, error dictionary,
-  capabilities, conformance vectors and map. (Growing; see each page.)
+## Bundle inputs
 
-## Why a format, not a library
+- [Format Spec 0.1 draft](format-spec.md) — retained historical input for the
+  walking skeleton; explicitly non-normative.
+- [Kungfu CLI handbook](handbooks/cli.md) — current source-backed command
+  routes and maturity.
+- [Python SDK handbook](handbooks/python.md) and
+  [Node SDK handbook](handbooks/node.md) — staged ecosystem surfaces without
+  illustrative fictional APIs.
 
-The hard value — open five years from now, verify on another machine, trust the
-bytes without trusting a vendor — lives in the *format*, not in any language
-binding. libkungfu is designed format-first: the write API, read API, CLI, and
-tools are all producers and consumers of one specified, versioned artifact.
+The format remains valuable because portable evidence should outlive a runtime,
+library, UI, or documentation host. That goal does not make the current 0.1
+draft a stable compatibility promise. Promotion requires a dedicated format
+decision, a complete schema and conformance contract, executable readers, and
+retained cross-version evidence.


### PR DESCRIPTION
Merge docs/docs-stale-surface-cleanup into dev/v4/v4.0 (kungfu-systems zone dual-account PR flow).