### PR TITLE
feat(runtime): add shadow projection bootstrap

### DIFF
--- a/docs/durability-and-crash-recovery.md
+++ b/docs/durability-and-crash-recovery.md
@@ -69,6 +69,16 @@ position, carrier, and payload after reopen.
 It accepts success receipts only under `test/*` qualification fixtures; this
 is implementation evidence, not a production durability claim.
 
+A test-only projection bootstrap substrate now consumes only those verified,
+checkpoint-covered KFDL records. It writes a versioned binary snapshot through
+logical position `T`, verifies its SHA-256 integrity and projection schema after
+restart, and replays strictly after `T`. Required peers fail closed when the
+snapshot/cut is absent or invalid; optional peers report degraded state; peers
+declaring no state dependency remain independent. Projection corruption or a
+failed rebuild does not advance its watermark and does not block durable ingest.
+This is shadow/cutover evidence: the production coordinator compatibility
+restore remains active and public durable profiles remain disabled.
+
 Do not interpret `MAP_SHARED`, `msync`, `FlushViewOfFile`, SQLite WAL, process
 residency, or a successful write call as a power-loss guarantee. A guarantee is
 made only by a named profile with retained qualification evidence.
@@ -150,9 +160,10 @@ one Episode must not silently invalidate unrelated Episodes.
 | C. Unified position, watermark, and receipt vocabulary | **implemented (contract-only)** | C++ owns stable stream positions, four typed watermarks, named profiles, receipts/errors, deduplication, and explicit unknown outcomes; Python/Node expose typed edge adapters, while current behavior remains `visible` only and rejects stronger profiles |
 | D. State-service separation and durable ingest | **partially implemented** | coordinator no longer owns the projection store directly; the in-process state-service boundary has independent lifecycle, shadow comparison, and single-host owner/writer fencing. Moving business-journal ingestion out of coordinator and persisting raw facts before projection remain pending |
 | E. Independent KFDL segment/checkpoint backend | **implemented (test-only shadow)** | append-only binary records, SHA-256 coverage, rollover, dual-slot atomic checkpoint, explicit data/checkpoint/directory barriers, persisted request deduplication, cooperative deadline/unknown handling, typed service-unavailable, fenced generations, fail-stop unknown append sessions, and retained tails; production profiles remain disabled |
-| F. Local strong-durability qualification | **not implemented** | qualify `durable_group` and `durable_sync` across macOS, Linux, and Windows with crash, torn-write, ENOSPC, ordering, recovery, and profile-registry evidence |
-| G. Single-host end-to-end performance release gate | **planned** | after correctness passes, qualify absolute latency, throughput, long-tail, resource, replay, recovery, and restore ceilings without weakening semantics |
-| H. Replication and HA | **future** | add a separate replicated watermark and policy only after local durability is trustworthy |
+| F. Snapshot-through-T projection bootstrap | **implemented (test-only shadow)** | versioned binary snapshot, integrity/schema/cut verification, strict replay-after-T, typed required/optional/none outcomes, deterministic rebuild, independent projection watermark, and state-service ownership; production bootstrap cutover remains pending |
+| G. Local strong-durability qualification | **not implemented** | qualify `durable_group` and `durable_sync` across macOS, Linux, and Windows with crash, torn-write, ENOSPC, ordering, recovery, and profile-registry evidence |
+| H. Single-host end-to-end performance release gate | **planned** | after correctness passes, qualify absolute latency, throughput, long-tail, resource, replay, recovery, and restore ceilings without weakening semantics |
+| I. Replication and HA | **future** | add a separate replicated watermark and policy only after local durability is trustworthy |
 
 Until Stage F passes for a named platform/filesystem/profile, public product
 language must continue to say that power-loss durability is not claimed.

--- a/docs/known-limits.md
+++ b/docs/known-limits.md
@@ -75,6 +75,14 @@ compaction for that growing index are not yet qualified; this is deliberately
 kept behind the test-only boundary rather than weakened to last-request-only
 deduplication.
 
+A state-service-owned snapshot-through-T plus replay-after-T implementation now
+exists for checkpoint-covered KFDL records in tests. Its binary integrity,
+schema/cut checks, required/optional/none peer outcomes, deterministic rebuild,
+and projection-failure isolation are implementation evidence only. The actual
+production state schemas still use the coordinator-triggered compatibility
+restore; business joins/restore cutover and public projection capability remain
+pending.
+
 SQLite WAL, a mapped-region flush, or a resident process is not a substitute for
 that evidence. See [Strong durability and crash recovery](durability-and-crash-recovery.md)
 for the current status and [ADR-0068](../framework/core/docs/adr/ADR-0068-tiered-durability-and-crash-recovery.md)

--- a/framework/core/docs/strong-durability-and-crash-recovery-design.md
+++ b/framework/core/docs/strong-durability-and-crash-recovery-design.md
@@ -56,7 +56,7 @@ Non-goals for the first implementation:
 | frame integrity | CRC32C receipt metadata and container-epoch contracts exist | detects classes of corruption; does not create durability |
 | content objects | immutable store can request sync-on-publish | useful backend primitive, not a journal-wide guarantee |
 | projections | source, manifest, Episode, and state SQLite stores use WAL and are rebuildable; several use synchronous mode off | query accelerator, never durability authority |
-| live topology | coordinator owns `state_cache`, joins business streams, stores/restores state | compatibility implementation to be split |
+| live topology | coordinator calls an in-process state-service boundary that owns `state_cache`; coordinator still triggers compatibility restore and joins business streams | ownership split implemented; bootstrap/business-join cutover remains |
 | Episode | typed manifests, qualification/capability/repair slices and fault matrix exist | semantic recovery boundary is staged, not fully durability-qualified |
 
 The migration begins from this behavior. It does not relabel existing success as
@@ -352,6 +352,30 @@ Duplicate boundary delivery must be harmless and tested. Peers declare:
 - `required`: do not start active work without a qualified snapshot/cut;
 - `optional`: start with explicit degraded/lag status;
 - `none`: no state bootstrap.
+
+### Current shadow snapshot/replay substrate
+
+The first implementation is a state-service-owned, test-only binary projection
+snapshot. It is intentionally separate from SQLite and from the mmap hot path.
+The snapshot binds projection name/schema, source qualification profile, stream id, container epoch,
+`through_position T`, deterministically ordered key/value state, and a SHA-256
+over the complete encoded body. It is atomically replaced only after the new
+body is complete; a failed projector leaves the previous readable snapshot in
+place.
+
+Bootstrap validates the snapshot integrity, schema, stream epoch, and that `T`
+is present in the checkpoint-covered KFDL chain. It restores state through `T`
+and applies records strictly after `T`, rejecting any gap. Repeated bootstrap
+is idempotent. The resulting status reports the durable and projection
+watermarks, lag, rebuild state, and typed error. Deleting a projection makes a
+required peer refuse startup until the same durable chain deterministically
+rebuilds it; an optional peer reports degraded rather than silently starting
+with current-state claims.
+
+This slice proves the new boundary and its restart/failure semantics but does
+not yet replace the production coordinator-triggered compatibility restore.
+That switch remains gated on a typed projector for the actual state schemas,
+shadow equality, rollback evidence, and the later qualified durable profile.
 
 ## 8. Failure behavior
 

--- a/framework/core/src/libkungfu/CMakeLists.txt
+++ b/framework/core/src/libkungfu/CMakeLists.txt
@@ -97,6 +97,11 @@ if(KUNGFU_WITH_CORE_TESTS)
   target_link_libraries(kungfu_durable_ingest_tests PRIVATE ${LIBKUNGFU_NAME} Threads::Threads)
   target_compile_features(kungfu_durable_ingest_tests PRIVATE cxx_std_20)
   add_test(NAME kungfu_durable_ingest_tests COMMAND kungfu_durable_ingest_tests)
+
+  add_executable(kungfu_projection_bootstrap_tests tests/projection_bootstrap_tests.cpp)
+  target_link_libraries(kungfu_projection_bootstrap_tests PRIVATE ${LIBKUNGFU_NAME} Threads::Threads)
+  target_compile_features(kungfu_projection_bootstrap_tests PRIVATE cxx_std_20)
+  add_test(NAME kungfu_projection_bootstrap_tests COMMAND kungfu_projection_bootstrap_tests)
 endif()
 
 # Windows AppContainer guest launcher (ADR-0014) lives in the runtime sandbox

--- a/framework/core/src/libkungfu/include/kungfu/runtime/projection_bootstrap.h
+++ b/framework/core/src/libkungfu/include/kungfu/runtime/projection_bootstrap.h
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef KUNGFU_RUNTIME_PROJECTION_BOOTSTRAP_H
+#define KUNGFU_RUNTIME_PROJECTION_BOOTSTRAP_H
+
+#include <functional>
+#include <map>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include <kungfu/runtime/durable_ingest.h>
+
+namespace kungfu::runtime::state_service {
+
+inline constexpr const char *PROJECTION_SNAPSHOT_SCHEMA_V1 = "kungfu.projection-snapshot/v1";
+
+enum class peer_state_requirement : uint8_t { Required, Optional, None };
+enum class bootstrap_outcome : uint8_t { Ready, Degraded, Refused };
+enum class projection_error : uint8_t {
+  None,
+  InvalidArgument,
+  ServiceUnavailable,
+  SnapshotMissing,
+  SnapshotCorrupt,
+  SchemaMismatch,
+  PositionMismatch,
+  PositionGap,
+  ProjectorFailed,
+  IoError,
+};
+
+struct projection_mutation {
+  std::string key = {};
+  std::string value = {};
+  bool erase = false;
+};
+
+using durable_projector = std::function<std::optional<projection_mutation>(const durability::durable_record &)>;
+
+struct projection_options {
+  std::string data_root = {};
+  uint64_t stream_id = 0;
+  uint64_t container_epoch = 0;
+  std::string projection_name = {};
+  std::string projection_schema = {};
+  std::string source_qualification_profile = {};
+};
+
+struct projection_snapshot {
+  std::string schema = PROJECTION_SNAPSHOT_SCHEMA_V1;
+  std::string projection_name = {};
+  std::string projection_schema = {};
+  std::string source_qualification_profile = {};
+  durability::stream_position through_position = {};
+  std::map<std::string, std::string> state = {};
+  std::string integrity_sha256 = {};
+};
+
+struct projection_status {
+  bool available = true;
+  bool snapshot_present = false;
+  bool shadow = true;
+  std::string rebuild_state = "not_started";
+  std::optional<durability::stream_position> durable_watermark = std::nullopt;
+  std::optional<durability::stream_position> projection_watermark = std::nullopt;
+  uint64_t lag_records = 0;
+  projection_error last_error = projection_error::None;
+  std::string last_error_message = {};
+};
+
+struct bootstrap_result {
+  bootstrap_outcome outcome = bootstrap_outcome::Refused;
+  projection_error error = projection_error::None;
+  std::string message = {};
+  projection_status status = {};
+  std::map<std::string, std::string> state = {};
+  std::optional<durability::stream_position> snapshot_through = std::nullopt;
+  std::optional<durability::stream_position> replay_through = std::nullopt;
+  uint64_t replayed_records = 0;
+};
+
+// A derived, rebuildable projection snapshot over checkpoint-covered durable
+// records. The snapshot is never a fact authority: its integrity and cut are
+// verified before replay, and deletion is repaired by rebuilding from KFDL.
+class projection_bootstrap_store {
+public:
+  projection_bootstrap_store(projection_options options, durable_projector projector);
+  ~projection_bootstrap_store();
+  projection_bootstrap_store(const projection_bootstrap_store &) = delete;
+  projection_bootstrap_store &operator=(const projection_bootstrap_store &) = delete;
+
+  [[nodiscard]] projection_snapshot rebuild(const std::vector<durability::durable_record> &records,
+                                            std::optional<durability::stream_position> through = std::nullopt);
+  [[nodiscard]] projection_snapshot load_snapshot() const;
+  [[nodiscard]] bootstrap_result bootstrap(const std::vector<durability::durable_record> &records,
+                                           peer_state_requirement requirement);
+  [[nodiscard]] projection_status status() const;
+  [[nodiscard]] std::string snapshot_path() const;
+
+private:
+  struct impl;
+  std::unique_ptr<impl> impl_;
+};
+
+[[nodiscard]] const char *projection_error_name(projection_error error) noexcept;
+[[nodiscard]] const char *bootstrap_outcome_name(bootstrap_outcome outcome) noexcept;
+
+} // namespace kungfu::runtime::state_service
+
+#endif // KUNGFU_RUNTIME_PROJECTION_BOOTSTRAP_H

--- a/framework/core/src/libkungfu/include/kungfu/runtime/state_service.h
+++ b/framework/core/src/libkungfu/include/kungfu/runtime/state_service.h
@@ -9,6 +9,7 @@
 #include <kungfu/runtime/common.h>
 #include <kungfu/runtime/durable_ingest.h>
 #include <kungfu/runtime/io.h>
+#include <kungfu/runtime/projection_bootstrap.h>
 #include <kungfu/yijinjing/ownership.h>
 #include <kungfu/yijinjing/schema/core.h>
 
@@ -52,6 +53,16 @@ public:
                                                                   durability::durability_profile profile,
                                                                   durability::barrier_options options = {});
   [[nodiscard]] durability::ingest_status durable_shadow_status(uint64_t stream_id, uint64_t container_epoch) const;
+
+  void open_projection_shadow(projection_options options, durable_projector projector);
+  [[nodiscard]] projection_snapshot
+  rebuild_projection_shadow(uint64_t stream_id, uint64_t container_epoch, const std::string &projection_name,
+                            std::optional<durability::stream_position> through = std::nullopt);
+  [[nodiscard]] bootstrap_result bootstrap_projection_shadow(uint64_t stream_id, uint64_t container_epoch,
+                                                             const std::string &projection_name,
+                                                             peer_state_requirement requirement);
+  [[nodiscard]] projection_status projection_shadow_status(uint64_t stream_id, uint64_t container_epoch,
+                                                           const std::string &projection_name) const;
 
 private:
   struct impl;

--- a/framework/core/src/libkungfu/src/runtime/projection_bootstrap.cpp
+++ b/framework/core/src/libkungfu/src/runtime/projection_bootstrap.cpp
@@ -1,0 +1,453 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#include <kungfu/runtime/projection_bootstrap.h>
+
+#include <algorithm>
+#include <array>
+#include <filesystem>
+#include <fstream>
+#include <limits>
+#include <mutex>
+#include <stdexcept>
+#include <utility>
+
+#include <kungfu/yijinjing/storage/content_hash.h>
+
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
+namespace kungfu::runtime::state_service {
+namespace {
+
+namespace fs = std::filesystem;
+using durability::compare_positions;
+using durability::durable_record;
+using durability::position_order;
+using durability::stream_position;
+using yijinjing::storage::compute_content_hash_value;
+
+constexpr std::array<char, 8> SNAPSHOT_MAGIC{'K', 'F', 'P', 'R', 'O', 'J', '0', '1'};
+constexpr uint32_t FORMAT_VERSION = 1;
+
+void append_u32(std::string &out, uint32_t value) {
+  for (unsigned shift = 0; shift < 32; shift += 8) {
+    out.push_back(static_cast<char>((value >> shift) & 0xffU));
+  }
+}
+
+void append_u64(std::string &out, uint64_t value) {
+  for (unsigned shift = 0; shift < 64; shift += 8) {
+    out.push_back(static_cast<char>((value >> shift) & 0xffU));
+  }
+}
+
+uint32_t read_u32(const std::string &bytes, size_t &offset) {
+  if (offset + 4 > bytes.size()) {
+    throw std::runtime_error("projection_snapshot_truncated");
+  }
+  uint32_t value = 0;
+  for (unsigned shift = 0; shift < 32; shift += 8) {
+    value |= static_cast<uint32_t>(static_cast<unsigned char>(bytes[offset++])) << shift;
+  }
+  return value;
+}
+
+uint64_t read_u64(const std::string &bytes, size_t &offset) {
+  if (offset + 8 > bytes.size()) {
+    throw std::runtime_error("projection_snapshot_truncated");
+  }
+  uint64_t value = 0;
+  for (unsigned shift = 0; shift < 64; shift += 8) {
+    value |= static_cast<uint64_t>(static_cast<unsigned char>(bytes[offset++])) << shift;
+  }
+  return value;
+}
+
+void append_string(std::string &out, const std::string &value) {
+  if (value.size() > std::numeric_limits<uint32_t>::max()) {
+    throw std::invalid_argument("projection_snapshot_string_too_large");
+  }
+  append_u32(out, static_cast<uint32_t>(value.size()));
+  out.append(value);
+}
+
+std::string read_string(const std::string &bytes, size_t &offset) {
+  const auto size = read_u32(bytes, offset);
+  if (offset + size > bytes.size()) {
+    throw std::runtime_error("projection_snapshot_truncated");
+  }
+  auto result = bytes.substr(offset, size);
+  offset += size;
+  return result;
+}
+
+std::string normalized_component(const std::string &value, const char *name) {
+  if (value.empty() || value == "." || value == ".." || value.find('/') != std::string::npos ||
+      value.find('\\') != std::string::npos) {
+    throw std::invalid_argument(std::string("invalid_") + name);
+  }
+  return value;
+}
+
+std::string encode_snapshot_body(const projection_snapshot &snapshot) {
+  std::string body;
+  body.append(SNAPSHOT_MAGIC.data(), SNAPSHOT_MAGIC.size());
+  append_u32(body, FORMAT_VERSION);
+  append_string(body, snapshot.schema);
+  append_string(body, snapshot.projection_name);
+  append_string(body, snapshot.projection_schema);
+  append_string(body, snapshot.source_qualification_profile);
+  append_u64(body, snapshot.through_position.stream_id);
+  append_u64(body, snapshot.through_position.container_epoch);
+  append_u64(body, snapshot.through_position.sequence);
+  append_u64(body, snapshot.through_position.frame_uid);
+  append_u64(body, snapshot.state.size());
+  for (const auto &[key, value] : snapshot.state) {
+    append_string(body, key);
+    append_string(body, value);
+  }
+  return body;
+}
+
+projection_snapshot decode_snapshot(const std::string &bytes) {
+  if (bytes.size() < SNAPSHOT_MAGIC.size() + 4 + 64 ||
+      !std::equal(SNAPSHOT_MAGIC.begin(), SNAPSHOT_MAGIC.end(), bytes.begin())) {
+    throw std::runtime_error("projection_snapshot_magic_mismatch");
+  }
+  const auto body_size = bytes.size() - 64;
+  const auto body = bytes.substr(0, body_size);
+  const auto stored_hash = bytes.substr(body_size);
+  if (compute_content_hash_value(body) != stored_hash) {
+    throw std::runtime_error("projection_snapshot_integrity_mismatch");
+  }
+  size_t offset = SNAPSHOT_MAGIC.size();
+  if (read_u32(body, offset) != FORMAT_VERSION) {
+    throw std::runtime_error("projection_snapshot_version_mismatch");
+  }
+  projection_snapshot snapshot;
+  snapshot.schema = read_string(body, offset);
+  snapshot.projection_name = read_string(body, offset);
+  snapshot.projection_schema = read_string(body, offset);
+  snapshot.source_qualification_profile = read_string(body, offset);
+  snapshot.through_position.stream_id = read_u64(body, offset);
+  snapshot.through_position.container_epoch = read_u64(body, offset);
+  snapshot.through_position.sequence = read_u64(body, offset);
+  snapshot.through_position.frame_uid = read_u64(body, offset);
+  const auto state_size = read_u64(body, offset);
+  for (uint64_t index = 0; index < state_size; ++index) {
+    auto key = read_string(body, offset);
+    auto value = read_string(body, offset);
+    if (!snapshot.state.emplace(std::move(key), std::move(value)).second) {
+      throw std::runtime_error("projection_snapshot_duplicate_key");
+    }
+  }
+  if (offset != body.size()) {
+    throw std::runtime_error("projection_snapshot_trailing_bytes");
+  }
+  snapshot.integrity_sha256 = stored_hash;
+  return snapshot;
+}
+
+void validate_record_chain(const std::vector<durable_record> &records, uint64_t stream_id, uint64_t epoch) {
+  std::optional<stream_position> previous;
+  for (const auto &record : records) {
+    const auto &position = record.position;
+    if (position.stream_id != stream_id || position.container_epoch != epoch) {
+      throw std::invalid_argument("projection_record_stream_epoch_mismatch");
+    }
+    if (previous.has_value()) {
+      if (position.sequence != previous->sequence + 1) {
+        throw std::invalid_argument("projection_record_position_gap");
+      }
+      if (compare_positions(*previous, position) != position_order::Before) {
+        throw std::invalid_argument("projection_record_order_mismatch");
+      }
+    }
+    previous = position;
+  }
+}
+
+void replace_snapshot(const fs::path &temp_path, const fs::path &target_path) {
+#ifdef _WIN32
+  if (MoveFileExW(temp_path.wstring().c_str(), target_path.wstring().c_str(),
+                  MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH) == 0) {
+    throw std::system_error(static_cast<int>(GetLastError()), std::system_category(), "replace projection snapshot");
+  }
+#else
+  std::error_code error;
+  fs::rename(temp_path, target_path, error);
+  if (error) {
+    throw std::system_error(error, "replace projection snapshot");
+  }
+#endif
+}
+
+projection_error classify_snapshot_error(const std::string &message) {
+  if (message == "projection_record_stream_epoch_mismatch" || message == "projection_snapshot_position_mismatch" ||
+      message == "projection_snapshot_cut_not_in_durable_chain") {
+    return projection_error::PositionMismatch;
+  }
+  if (message == "projection_record_position_gap" || message == "projection_record_order_mismatch" ||
+      message == "projection_replay_position_gap") {
+    return projection_error::PositionGap;
+  }
+  if (message == "projection_projector_failed") {
+    return projection_error::ProjectorFailed;
+  }
+  if (message == "projection_snapshot_missing" || message == "projection_durable_chain_missing") {
+    return projection_error::SnapshotMissing;
+  }
+  if (message == "projection_snapshot_schema_mismatch" || message == "projection_snapshot_version_mismatch") {
+    return projection_error::SchemaMismatch;
+  }
+  return projection_error::SnapshotCorrupt;
+}
+
+} // namespace
+
+struct projection_bootstrap_store::impl {
+  impl(projection_options options, durable_projector projector)
+      : options(std::move(options)), projector(std::move(projector)) {
+    if (this->options.data_root.empty() || this->options.stream_id == 0 || this->options.container_epoch == 0 ||
+        this->options.source_qualification_profile.empty() || !this->projector) {
+      throw std::invalid_argument("invalid_projection_bootstrap_options");
+    }
+    this->options.data_root = fs::absolute(this->options.data_root).lexically_normal().string();
+    this->options.projection_name = normalized_component(this->options.projection_name, "projection_name");
+    this->options.projection_schema = normalized_component(this->options.projection_schema, "projection_schema");
+  }
+
+  fs::path path() const {
+    return fs::path(options.data_root) / ".kungfu" / "durability" / "projections" /
+           (options.projection_name + "-s" + std::to_string(options.stream_id) + "-e" +
+            std::to_string(options.container_epoch) + ".kfproj");
+  }
+
+  void apply(std::map<std::string, std::string> &state, const durable_record &record) const {
+    const auto mutation = projector(record);
+    if (!mutation.has_value()) {
+      return;
+    }
+    if (mutation->key.empty()) {
+      throw std::invalid_argument("projection_mutation_key_empty");
+    }
+    if (mutation->erase) {
+      state.erase(mutation->key);
+    } else {
+      state.insert_or_assign(mutation->key, mutation->value);
+    }
+  }
+
+  projection_snapshot load_unlocked() const {
+    std::ifstream input(path(), std::ios::binary);
+    if (!input) {
+      throw std::runtime_error("projection_snapshot_missing");
+    }
+    const std::string bytes((std::istreambuf_iterator<char>(input)), std::istreambuf_iterator<char>());
+    auto snapshot = decode_snapshot(bytes);
+    if (snapshot.schema != PROJECTION_SNAPSHOT_SCHEMA_V1 || snapshot.projection_name != options.projection_name ||
+        snapshot.projection_schema != options.projection_schema ||
+        snapshot.source_qualification_profile != options.source_qualification_profile) {
+      throw std::runtime_error("projection_snapshot_schema_mismatch");
+    }
+    if (snapshot.through_position.stream_id != options.stream_id ||
+        snapshot.through_position.container_epoch != options.container_epoch) {
+      throw std::runtime_error("projection_snapshot_position_mismatch");
+    }
+    return snapshot;
+  }
+
+  projection_options options;
+  durable_projector projector;
+  mutable std::mutex mutex;
+  projection_status current_status;
+};
+
+projection_bootstrap_store::projection_bootstrap_store(projection_options options, durable_projector projector)
+    : impl_(std::make_unique<impl>(std::move(options), std::move(projector))) {}
+
+projection_bootstrap_store::~projection_bootstrap_store() = default;
+
+projection_snapshot projection_bootstrap_store::rebuild(const std::vector<durable_record> &records,
+                                                        std::optional<stream_position> through) {
+  std::lock_guard lock(impl_->mutex);
+  validate_record_chain(records, impl_->options.stream_id, impl_->options.container_epoch);
+  if (records.empty()) {
+    throw std::invalid_argument("projection_rebuild_requires_durable_records");
+  }
+  const auto target = through.value_or(records.back().position);
+  if (target.stream_id != impl_->options.stream_id || target.container_epoch != impl_->options.container_epoch) {
+    throw std::invalid_argument("projection_rebuild_cut_mismatch");
+  }
+  projection_snapshot snapshot;
+  snapshot.projection_name = impl_->options.projection_name;
+  snapshot.projection_schema = impl_->options.projection_schema;
+  snapshot.source_qualification_profile = impl_->options.source_qualification_profile;
+  bool found_target = false;
+  try {
+    for (const auto &record : records) {
+      const auto order = compare_positions(record.position, target);
+      if (order == position_order::Unordered) {
+        throw std::invalid_argument("projection_rebuild_cut_unordered");
+      }
+      if (order == position_order::After) {
+        break;
+      }
+      impl_->apply(snapshot.state, record);
+      snapshot.through_position = record.position;
+      found_target = order == position_order::Equal;
+    }
+  } catch (...) {
+    impl_->current_status.rebuild_state = "failed";
+    impl_->current_status.last_error = projection_error::ProjectorFailed;
+    impl_->current_status.last_error_message = "projection_projector_failed";
+    throw;
+  }
+  if (!found_target) {
+    throw std::invalid_argument("projection_rebuild_cut_not_in_durable_chain");
+  }
+  const auto body = encode_snapshot_body(snapshot);
+  snapshot.integrity_sha256 = compute_content_hash_value(body);
+  const auto target_path = impl_->path();
+  fs::create_directories(target_path.parent_path());
+  const auto temp_path = target_path.string() + ".tmp";
+  {
+    std::ofstream output(temp_path, std::ios::binary | std::ios::trunc);
+    if (!output) {
+      throw std::runtime_error("projection_snapshot_temp_open_failed");
+    }
+    output.write(body.data(), static_cast<std::streamsize>(body.size()));
+    output.write(snapshot.integrity_sha256.data(), static_cast<std::streamsize>(snapshot.integrity_sha256.size()));
+    output.flush();
+    if (!output) {
+      throw std::runtime_error("projection_snapshot_write_failed");
+    }
+  }
+  replace_snapshot(temp_path, target_path);
+  impl_->current_status.available = true;
+  impl_->current_status.snapshot_present = true;
+  impl_->current_status.rebuild_state = "complete";
+  impl_->current_status.durable_watermark = records.back().position;
+  impl_->current_status.projection_watermark = target;
+  impl_->current_status.lag_records = records.back().position.sequence - target.sequence;
+  impl_->current_status.last_error = projection_error::None;
+  impl_->current_status.last_error_message.clear();
+  return snapshot;
+}
+
+projection_snapshot projection_bootstrap_store::load_snapshot() const {
+  std::lock_guard lock(impl_->mutex);
+  return impl_->load_unlocked();
+}
+
+bootstrap_result projection_bootstrap_store::bootstrap(const std::vector<durable_record> &records,
+                                                       peer_state_requirement requirement) {
+  std::lock_guard lock(impl_->mutex);
+  bootstrap_result result;
+  if (requirement == peer_state_requirement::None) {
+    result.outcome = bootstrap_outcome::Ready;
+    result.message = "peer_declares_no_state_requirement";
+    result.status = impl_->current_status;
+    return result;
+  }
+  try {
+    validate_record_chain(records, impl_->options.stream_id, impl_->options.container_epoch);
+    auto snapshot = impl_->load_unlocked();
+    if (records.empty()) {
+      throw std::runtime_error("projection_durable_chain_missing");
+    }
+    const auto snapshot_it = std::find_if(records.begin(), records.end(), [&](const auto &record) {
+      return record.position == snapshot.through_position;
+    });
+    if (snapshot_it == records.end()) {
+      throw std::runtime_error("projection_snapshot_cut_not_in_durable_chain");
+    }
+    result.state = snapshot.state;
+    result.snapshot_through = snapshot.through_position;
+    auto previous = snapshot.through_position;
+    for (auto iterator = std::next(snapshot_it); iterator != records.end(); ++iterator) {
+      if (iterator->position.sequence != previous.sequence + 1) {
+        throw std::runtime_error("projection_replay_position_gap");
+      }
+      try {
+        impl_->apply(result.state, *iterator);
+      } catch (...) {
+        throw std::runtime_error("projection_projector_failed");
+      }
+      previous = iterator->position;
+      result.replay_through = iterator->position;
+      ++result.replayed_records;
+    }
+    const auto projection_watermark = result.replay_through.value_or(snapshot.through_position);
+    result.outcome = bootstrap_outcome::Ready;
+    result.message = "snapshot_through_t_plus_replay_after_t";
+    impl_->current_status.snapshot_present = true;
+    impl_->current_status.available = true;
+    impl_->current_status.rebuild_state = "ready";
+    impl_->current_status.durable_watermark = records.back().position;
+    impl_->current_status.projection_watermark = projection_watermark;
+    impl_->current_status.lag_records = records.back().position.sequence - projection_watermark.sequence;
+    impl_->current_status.last_error = projection_error::None;
+    impl_->current_status.last_error_message.clear();
+  } catch (const std::exception &error) {
+    impl_->current_status.snapshot_present = fs::exists(impl_->path());
+    impl_->current_status.available = false;
+    impl_->current_status.rebuild_state = "unavailable";
+    impl_->current_status.last_error = classify_snapshot_error(error.what());
+    impl_->current_status.last_error_message = error.what();
+    result.outcome =
+        requirement == peer_state_requirement::Required ? bootstrap_outcome::Refused : bootstrap_outcome::Degraded;
+    result.error = impl_->current_status.last_error;
+    result.message = error.what();
+  }
+  result.status = impl_->current_status;
+  return result;
+}
+
+projection_status projection_bootstrap_store::status() const {
+  std::lock_guard lock(impl_->mutex);
+  return impl_->current_status;
+}
+
+std::string projection_bootstrap_store::snapshot_path() const { return impl_->path().string(); }
+
+const char *projection_error_name(projection_error error) noexcept {
+  switch (error) {
+  case projection_error::None:
+    return "none";
+  case projection_error::InvalidArgument:
+    return "invalid_argument";
+  case projection_error::ServiceUnavailable:
+    return "service_unavailable";
+  case projection_error::SnapshotMissing:
+    return "snapshot_missing";
+  case projection_error::SnapshotCorrupt:
+    return "snapshot_corrupt";
+  case projection_error::SchemaMismatch:
+    return "schema_mismatch";
+  case projection_error::PositionMismatch:
+    return "position_mismatch";
+  case projection_error::PositionGap:
+    return "position_gap";
+  case projection_error::ProjectorFailed:
+    return "projector_failed";
+  case projection_error::IoError:
+    return "io_error";
+  }
+  return "unknown";
+}
+
+const char *bootstrap_outcome_name(bootstrap_outcome outcome) noexcept {
+  switch (outcome) {
+  case bootstrap_outcome::Ready:
+    return "ready";
+  case bootstrap_outcome::Degraded:
+    return "degraded";
+  case bootstrap_outcome::Refused:
+    return "refused";
+  }
+  return "unknown";
+}
+
+} // namespace kungfu::runtime::state_service

--- a/framework/core/src/libkungfu/src/runtime/state_service.cpp
+++ b/framework/core/src/libkungfu/src/runtime/state_service.cpp
@@ -6,6 +6,7 @@
 #include <map>
 #include <mutex>
 #include <stdexcept>
+#include <tuple>
 #include <utility>
 
 #include <kungfu/runtime/state_cache/manager.h>
@@ -29,6 +30,25 @@ durability::barrier_result unavailable_barrier(uint64_t request_id, durability::
   return result;
 }
 
+bootstrap_result unavailable_bootstrap(const std::string &message, peer_state_requirement requirement) {
+  bootstrap_result result;
+  if (requirement == peer_state_requirement::None) {
+    result.outcome = bootstrap_outcome::Ready;
+    result.message = "peer_declares_no_state_requirement";
+    result.status.available = true;
+    return result;
+  }
+  result.outcome =
+      requirement == peer_state_requirement::Required ? bootstrap_outcome::Refused : bootstrap_outcome::Degraded;
+  result.error = projection_error::ServiceUnavailable;
+  result.message = message;
+  result.status.available = false;
+  result.status.rebuild_state = "unavailable";
+  result.status.last_error = projection_error::ServiceUnavailable;
+  result.status.last_error_message = message;
+  return result;
+}
+
 } // namespace
 
 struct service::impl {
@@ -48,6 +68,7 @@ struct service::impl {
   yijinjing::ownership::lease ownership;
   state_cache::manager manager;
   std::map<std::pair<uint64_t, uint64_t>, std::unique_ptr<durability::durable_ingest_log>> durable_shadows;
+  std::map<std::tuple<uint64_t, uint64_t, std::string>, std::unique_ptr<projection_bootstrap_store>> projection_shadows;
   mutable std::mutex durable_shadows_mutex;
 };
 
@@ -147,6 +168,64 @@ durability::ingest_status service::durable_shadow_status(uint64_t stream_id, uin
   const auto found = impl_->durable_shadows.find({stream_id, container_epoch});
   if (found == impl_->durable_shadows.end()) {
     throw std::logic_error("durable shadow stream epoch is not open");
+  }
+  return found->second->status();
+}
+
+void service::open_projection_shadow(projection_options options, durable_projector projector) {
+  impl_->require_write_authority();
+  if (std::filesystem::absolute(options.data_root).lexically_normal() !=
+      std::filesystem::absolute(impl_->ownership.status().data_root).lexically_normal()) {
+    throw std::invalid_argument("projection shadow data root does not match state service ownership");
+  }
+  std::lock_guard lock(impl_->durable_shadows_mutex);
+  const auto durable = impl_->durable_shadows.find({options.stream_id, options.container_epoch});
+  if (durable == impl_->durable_shadows.end()) {
+    throw std::logic_error("projection shadow requires an open durable shadow");
+  }
+  options.source_qualification_profile = durable->second->status().qualification_profile;
+  const auto key = std::make_tuple(options.stream_id, options.container_epoch, options.projection_name);
+  if (impl_->projection_shadows.contains(key)) {
+    throw std::logic_error("projection shadow is already open");
+  }
+  impl_->projection_shadows.emplace(
+      key, std::make_unique<projection_bootstrap_store>(std::move(options), std::move(projector)));
+}
+
+projection_snapshot service::rebuild_projection_shadow(uint64_t stream_id, uint64_t container_epoch,
+                                                       const std::string &projection_name,
+                                                       std::optional<durability::stream_position> through) {
+  impl_->require_write_authority();
+  std::lock_guard lock(impl_->durable_shadows_mutex);
+  const auto durable = impl_->durable_shadows.find({stream_id, container_epoch});
+  const auto projection = impl_->projection_shadows.find({stream_id, container_epoch, projection_name});
+  if (durable == impl_->durable_shadows.end() || projection == impl_->projection_shadows.end()) {
+    throw std::logic_error("projection shadow or durable shadow is not open");
+  }
+  return projection->second->rebuild(durable->second->read_durable_records(), through);
+}
+
+bootstrap_result service::bootstrap_projection_shadow(uint64_t stream_id, uint64_t container_epoch,
+                                                      const std::string &projection_name,
+                                                      peer_state_requirement requirement) {
+  if (!impl_->ownership.owns() || !impl_->manager.running()) {
+    return unavailable_bootstrap("state_service_not_running_or_fenced", requirement);
+  }
+  std::lock_guard lock(impl_->durable_shadows_mutex);
+  const auto durable = impl_->durable_shadows.find({stream_id, container_epoch});
+  const auto projection = impl_->projection_shadows.find({stream_id, container_epoch, projection_name});
+  if (durable == impl_->durable_shadows.end() || projection == impl_->projection_shadows.end()) {
+    return unavailable_bootstrap("projection_shadow_or_durable_shadow_not_open", requirement);
+  }
+  return projection->second->bootstrap(durable->second->read_durable_records(), requirement);
+}
+
+projection_status service::projection_shadow_status(uint64_t stream_id, uint64_t container_epoch,
+                                                    const std::string &projection_name) const {
+  std::lock_guard lock(impl_->durable_shadows_mutex);
+  const auto found = impl_->projection_shadows.find({stream_id, container_epoch, projection_name});
+  if (found == impl_->projection_shadows.end()) {
+    throw std::logic_error("projection shadow is not open");
   }
   return found->second->status();
 }

--- a/framework/core/src/libkungfu/tests/projection_bootstrap_tests.cpp
+++ b/framework/core/src/libkungfu/tests/projection_bootstrap_tests.cpp
@@ -1,0 +1,298 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#include <kungfu/runtime/io.h>
+#include <kungfu/runtime/projection_bootstrap.h>
+#include <kungfu/runtime/state_service.h>
+#include <kungfu/yijinjing/ownership.h>
+
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace fs = std::filesystem;
+using kungfu::runtime::durability::durability_profile;
+using kungfu::runtime::durability::durable_record;
+using kungfu::runtime::durability::ingest_options;
+using kungfu::runtime::durability::receipt_status;
+using kungfu::runtime::durability::stream_position;
+using kungfu::runtime::state_service::bootstrap_outcome;
+using kungfu::runtime::state_service::peer_state_requirement;
+using kungfu::runtime::state_service::projection_bootstrap_store;
+using kungfu::runtime::state_service::projection_error;
+using kungfu::runtime::state_service::projection_mutation;
+using kungfu::runtime::state_service::projection_options;
+using kungfu::runtime::state_service::service;
+using kungfu::yijinjing::data::location;
+using kungfu::yijinjing::data::locator;
+using kungfu::yijinjing::enums::location_role;
+using kungfu::yijinjing::enums::mode;
+using kungfu::yijinjing::ownership::lease;
+
+namespace {
+
+void require(bool condition, const std::string &message) {
+  if (!condition) {
+    throw std::runtime_error(message);
+  }
+}
+
+class temp_tree {
+public:
+  temp_tree() {
+    const auto nonce = std::chrono::steady_clock::now().time_since_epoch().count();
+    root_ = fs::temp_directory_path() / ("kungfu-projection-bootstrap-test-" + std::to_string(nonce));
+    fs::create_directories(root_);
+  }
+  ~temp_tree() {
+    std::error_code ignored;
+    fs::remove_all(root_, ignored);
+  }
+  [[nodiscard]] const fs::path &root() const { return root_; }
+
+private:
+  fs::path root_;
+};
+
+durable_record record(uint64_t sequence, std::string payload) {
+  durable_record value;
+  value.position = {71, 5, sequence, 1000 + sequence};
+  value.carrier_type = 9001;
+  value.payload = std::move(payload);
+  return value;
+}
+
+std::vector<durable_record> records() {
+  return {record(1, "alpha=one"), record(2, "alpha=two"), record(3, "beta=three")};
+}
+
+std::optional<projection_mutation> key_value_projector(const durable_record &input) {
+  const auto separator = input.payload.find('=');
+  if (separator == std::string::npos) {
+    throw std::invalid_argument("test_payload_missing_separator");
+  }
+  return projection_mutation{input.payload.substr(0, separator), input.payload.substr(separator + 1), false};
+}
+
+projection_options options(const fs::path &root, std::string schema = "test-state-v1",
+                           std::string qualification_profile = "test/macos-apfs-projection-bootstrap") {
+  return {root.string(), 71, 5, "test-state", std::move(schema), std::move(qualification_profile)};
+}
+
+void test_snapshot_through_t_replays_strictly_after_t() {
+  temp_tree tree;
+  projection_bootstrap_store store(options(tree.root()), key_value_projector);
+  const auto all = records();
+  const auto snapshot = store.rebuild(all, all[1].position);
+  require(snapshot.through_position == all[1].position, "snapshot cut did not stop at T");
+  require(snapshot.state.at("alpha") == "two" && !snapshot.state.contains("beta"),
+          "snapshot state included a record after T");
+
+  const auto first = store.bootstrap(all, peer_state_requirement::Required);
+  require(first.outcome == bootstrap_outcome::Ready, "required bootstrap did not become ready");
+  require(first.replayed_records == 1 && first.replay_through == all[2].position,
+          "replay did not use the strict after-T boundary");
+  require(first.state.at("alpha") == "two" && first.state.at("beta") == "three",
+          "snapshot plus replay produced the wrong state");
+
+  const auto repeated = store.bootstrap(all, peer_state_requirement::Required);
+  require(repeated.state == first.state && repeated.replayed_records == first.replayed_records,
+          "repeated bootstrap was not idempotent");
+  require(repeated.status.projection_watermark == all.back().position && repeated.status.lag_records == 0,
+          "projection watermark did not reach the durable cut");
+}
+
+void test_restart_loads_verified_snapshot_and_replays() {
+  temp_tree tree;
+  const auto all = records();
+  {
+    projection_bootstrap_store first(options(tree.root()), key_value_projector);
+    (void)first.rebuild(all, all[1].position);
+  }
+  projection_bootstrap_store reopened(options(tree.root()), key_value_projector);
+  const auto result = reopened.bootstrap(all, peer_state_requirement::Required);
+  require(result.outcome == bootstrap_outcome::Ready && result.replayed_records == 1,
+          "restart did not recover snapshot-through-T plus replay-after-T");
+}
+
+void test_missing_snapshot_honors_peer_requirement() {
+  temp_tree tree;
+  projection_bootstrap_store store(options(tree.root()), key_value_projector);
+  const auto all = records();
+  const auto required = store.bootstrap(all, peer_state_requirement::Required);
+  require(required.outcome == bootstrap_outcome::Refused && required.error == projection_error::SnapshotMissing,
+          "required peer did not fail closed on a missing snapshot");
+  const auto optional = store.bootstrap(all, peer_state_requirement::Optional);
+  require(optional.outcome == bootstrap_outcome::Degraded && optional.state.empty(),
+          "optional peer did not report an explicit degraded state");
+  const auto none = store.bootstrap(all, peer_state_requirement::None);
+  require(none.outcome == bootstrap_outcome::Ready && none.state.empty(),
+          "no-state peer unexpectedly depended on a snapshot");
+}
+
+void test_corrupt_or_wrong_schema_snapshot_fails_closed() {
+  temp_tree tree;
+  const auto all = records();
+  projection_bootstrap_store store(options(tree.root()), key_value_projector);
+  (void)store.rebuild(all, all[1].position);
+  {
+    std::ofstream output(store.snapshot_path(), std::ios::binary | std::ios::app);
+    output << "corrupt";
+  }
+  const auto corrupt = store.bootstrap(all, peer_state_requirement::Required);
+  require(corrupt.outcome == bootstrap_outcome::Refused && corrupt.error == projection_error::SnapshotCorrupt,
+          "corrupt snapshot was accepted");
+
+  temp_tree schema_tree;
+  projection_bootstrap_store v1(options(schema_tree.root()), key_value_projector);
+  (void)v1.rebuild(all, all[1].position);
+  projection_bootstrap_store v2(options(schema_tree.root(), "test-state-v2"), key_value_projector);
+  const auto mismatch = v2.bootstrap(all, peer_state_requirement::Required);
+  require(mismatch.outcome == bootstrap_outcome::Refused && mismatch.error == projection_error::SchemaMismatch,
+          "wrong projection schema inherited an older snapshot");
+
+  temp_tree profile_tree;
+  projection_bootstrap_store qualified(options(profile_tree.root()), key_value_projector);
+  (void)qualified.rebuild(all, all[1].position);
+  projection_bootstrap_store other_profile(
+      options(profile_tree.root(), "test-state-v1", "test/linux-ext4-projection-bootstrap"), key_value_projector);
+  const auto profile_mismatch = other_profile.bootstrap(all, peer_state_requirement::Required);
+  require(profile_mismatch.outcome == bootstrap_outcome::Refused &&
+              profile_mismatch.error == projection_error::SchemaMismatch,
+          "snapshot inherited qualification evidence from another storage profile");
+}
+
+void test_deleted_projection_rebuilds_deterministically_from_durable_records() {
+  temp_tree tree;
+  const auto all = records();
+  projection_bootstrap_store store(options(tree.root()), key_value_projector);
+  const auto first = store.rebuild(all);
+  fs::remove(store.snapshot_path());
+  require(store.bootstrap(all, peer_state_requirement::Required).outcome == bootstrap_outcome::Refused,
+          "deleted projection remained authoritative");
+  const auto rebuilt = store.rebuild(all);
+  require(rebuilt.state == first.state && rebuilt.integrity_sha256 == first.integrity_sha256,
+          "durable rebuild was not deterministic");
+}
+
+void test_gap_never_becomes_a_projection_watermark() {
+  temp_tree tree;
+  projection_bootstrap_store store(options(tree.root()), key_value_projector);
+  auto gapped = records();
+  gapped.erase(gapped.begin() + 1);
+  bool refused = false;
+  try {
+    (void)store.rebuild(gapped);
+  } catch (const std::invalid_argument &) {
+    refused = true;
+  }
+  require(refused, "gapped durable input produced a snapshot");
+  require(!store.status().projection_watermark.has_value(), "failed rebuild advanced projection watermark");
+}
+
+void test_failed_rebuild_preserves_previous_readable_snapshot() {
+  temp_tree tree;
+  const auto all = records();
+  projection_bootstrap_store good(options(tree.root()), key_value_projector);
+  const auto previous = good.rebuild(all, all[1].position);
+  projection_bootstrap_store failing(options(tree.root()), [](const durable_record &input) {
+    if (input.position.sequence == 3) {
+      throw std::runtime_error("injected_projection_failure");
+    }
+    return key_value_projector(input);
+  });
+  bool failed = false;
+  try {
+    (void)failing.rebuild(all);
+  } catch (const std::runtime_error &) {
+    failed = true;
+  }
+  require(failed, "projector failure was hidden");
+  const auto retained = good.load_snapshot();
+  require(retained.integrity_sha256 == previous.integrity_sha256 && retained.state == previous.state,
+          "failed rebuild destroyed the previous readable snapshot");
+}
+
+void test_state_service_owns_projection_shadow_and_stopped_service_is_unavailable() {
+  temp_tree tree;
+  auto page_locator = std::make_shared<locator>(tree.root().string());
+  auto home = location::make_shared(mode::LIVE, location_role::SYSTEM, "service", "projection", page_locator);
+  auto io_device = std::make_shared<kungfu::runtime::io_device_coordinator>(home, false);
+  service state_service(io_device);
+  state_service.start();
+
+  auto writer = lease::acquire_stream_writer(tree.root().string(), "projection-test-writer");
+  ingest_options ingest;
+  ingest.data_root = tree.root().string();
+  ingest.stream_id = 71;
+  ingest.container_epoch = 5;
+  ingest.writer_resource_id = "projection-test-writer";
+  ingest.qualification_profile = "test/macos-apfs-projection-bootstrap";
+  ingest.qualification_passed = true;
+  state_service.open_durable_shadow(ingest);
+  state_service.append_durable_shadow({71, 5, 1, 1001}, 9001, "alpha=one", writer.status());
+  state_service.append_durable_shadow({71, 5, 2, 1002}, 9001, "alpha=two", writer.status());
+  const auto first_barrier = state_service.barrier_durable_shadow(71, 5, 1, durability_profile::DurableGroup);
+  require(first_barrier.receipt.status == receipt_status::Succeeded, "fixture durable barrier failed");
+
+  state_service.open_projection_shadow(options(tree.root()), key_value_projector);
+  const auto snapshot = state_service.rebuild_projection_shadow(71, 5, "test-state", stream_position{71, 5, 1, 1001});
+  require(snapshot.state.at("alpha") == "one", "state service rebuilt the wrong cut");
+  const auto ready = state_service.bootstrap_projection_shadow(71, 5, "test-state", peer_state_requirement::Required);
+  require(ready.outcome == bootstrap_outcome::Ready && ready.state.at("alpha") == "two" && ready.replayed_records == 1,
+          "state service did not bootstrap from its durable shadow");
+
+  const auto snapshot_path = tree.root() / ".kungfu" / "durability" / "projections" / "test-state-s71-e5.kfproj";
+  {
+    std::ofstream output(snapshot_path, std::ios::binary | std::ios::app);
+    output << "corrupt";
+  }
+  const auto refused = state_service.bootstrap_projection_shadow(71, 5, "test-state", peer_state_requirement::Required);
+  require(refused.outcome == bootstrap_outcome::Refused, "corrupt projection did not fail closed");
+  state_service.append_durable_shadow({71, 5, 3, 1003}, 9001, "beta=three", writer.status());
+  const auto second_barrier = state_service.barrier_durable_shadow(71, 5, 2, durability_profile::DurableGroup);
+  require(second_barrier.receipt.status == receipt_status::Succeeded,
+          "projection failure blocked independent durable ingest progress");
+
+  state_service.stop();
+  const auto stopped = state_service.bootstrap_projection_shadow(71, 5, "test-state", peer_state_requirement::Required);
+  require(stopped.outcome == bootstrap_outcome::Refused && stopped.error == projection_error::ServiceUnavailable,
+          "stopped state service returned projection success");
+  const auto stopped_none =
+      state_service.bootstrap_projection_shadow(71, 5, "test-state", peer_state_requirement::None);
+  require(stopped_none.outcome == bootstrap_outcome::Ready,
+          "peer with no state requirement depended on a stopped projection service");
+}
+
+int run_tests() {
+  const std::pair<const char *, void (*)()> tests[] = {
+      {"snapshot through T replays strictly after T", test_snapshot_through_t_replays_strictly_after_t},
+      {"restart loads verified snapshot and replays", test_restart_loads_verified_snapshot_and_replays},
+      {"missing snapshot honors peer requirement", test_missing_snapshot_honors_peer_requirement},
+      {"corrupt and wrong-schema snapshots fail closed", test_corrupt_or_wrong_schema_snapshot_fails_closed},
+      {"deleted projection rebuilds deterministically",
+       test_deleted_projection_rebuilds_deterministically_from_durable_records},
+      {"gapped durable input never advances projection", test_gap_never_becomes_a_projection_watermark},
+      {"failed rebuild preserves the previous snapshot", test_failed_rebuild_preserves_previous_readable_snapshot},
+      {"state service owns projection shadow and fails closed when stopped",
+       test_state_service_owns_projection_shadow_and_stopped_service_is_unavailable},
+  };
+  int failures = 0;
+  for (const auto &[name, test] : tests) {
+    try {
+      test();
+      std::cout << "ok - " << name << '\n';
+    } catch (const std::exception &error) {
+      ++failures;
+      std::cerr << "not ok - " << name << ": " << error.what() << '\n';
+    }
+  }
+  return failures == 0 ? 0 : 1;
+}
+
+} // namespace
+
+int main() { return run_tests(); }

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "test:durability-contract": "node scripts/require-shifu.mjs test:durability-contract && node scripts/run-durability-contract-tests.mjs",
     "test:state-service": "node scripts/require-shifu.mjs test:state-service && node scripts/run-state-service-tests.mjs",
     "test:durable-ingest": "node scripts/require-shifu.mjs test:durable-ingest && node scripts/run-durable-ingest-tests.mjs",
+    "test:projection-bootstrap": "node scripts/require-shifu.mjs test:projection-bootstrap && node scripts/run-projection-bootstrap-tests.mjs",
     "test:runtime-errors": "node scripts/require-shifu.mjs test:runtime-errors && node scripts/run-runtime-error-tests.mjs",
     "qualify:mmap": "node scripts/require-shifu.mjs qualify:mmap && node scripts/run-mmap-qualification.mjs",
     "qualify:cpp-modules": "node scripts/require-shifu.mjs qualify:cpp-modules && node scripts/run-cpp-modules-qualification.mjs",

--- a/scripts/run-projection-bootstrap-tests.mjs
+++ b/scripts/run-projection-bootstrap-tests.mjs
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+
+const buildDir = path.join(process.cwd(), 'framework', 'core', 'build');
+const build = spawnSync(
+  'cmake',
+  [
+    '--build',
+    buildDir,
+    '--config',
+    'Release',
+    '--target',
+    'kungfu_projection_bootstrap_tests',
+  ],
+  { cwd: process.cwd(), stdio: 'inherit' },
+);
+if (build.error || build.status !== 0) {
+  if (build.error)
+    console.error(`[projection-bootstrap-test] build: ${build.error.message}`);
+  console.error(
+    '[projection-bootstrap-test] target build failed; run ./shifu build:core to configure the core tree',
+  );
+  process.exit(build.status ?? 2);
+}
+
+const executable =
+  process.platform === 'win32'
+    ? 'kungfu_projection_bootstrap_tests.exe'
+    : 'kungfu_projection_bootstrap_tests';
+const candidates = [
+  path.join(process.cwd(), 'framework', 'core', 'build', 'Release', executable),
+  path.join(process.cwd(), 'framework', 'core', 'build', executable),
+];
+const testBinary = candidates.find((candidate) => fs.existsSync(candidate));
+if (!testBinary) {
+  console.error(
+    '[projection-bootstrap-test] binary not found; run ./shifu build:core first',
+  );
+  process.exit(2);
+}
+
+const sources = [
+  'framework/core/src/libkungfu/include/kungfu/runtime/projection_bootstrap.h',
+  'framework/core/src/libkungfu/src/runtime/projection_bootstrap.cpp',
+  'framework/core/src/libkungfu/include/kungfu/runtime/state_service.h',
+  'framework/core/src/libkungfu/src/runtime/state_service.cpp',
+  'framework/core/src/libkungfu/tests/projection_bootstrap_tests.cpp',
+].map((source) => path.join(process.cwd(), source));
+const binaryMtime = fs.statSync(testBinary).mtimeMs;
+const newerSource = sources.find(
+  (source) => fs.statSync(source).mtimeMs > binaryMtime,
+);
+if (newerSource) {
+  console.error(
+    `[projection-bootstrap-test] refusing stale binary; newer source: ${path.relative(process.cwd(), newerSource)}`,
+  );
+  process.exit(2);
+}
+
+console.log(`[projection-bootstrap-test] running ${testBinary}`);
+const result = spawnSync(testBinary, [], {
+  cwd: process.cwd(),
+  stdio: 'inherit',
+});
+if (result.error || result.status !== 0) {
+  if (result.error)
+    console.error(`[projection-bootstrap-test] ${result.error.message}`);
+  process.exit(result.status ?? 1);
+}
+
+for (const source of [
+  'framework/core/src/libkungfu/src/runtime/live/coordinator.cpp',
+  'framework/core/src/libyijinjing/src/journal/writer.cpp',
+]) {
+  const content = fs.readFileSync(path.join(process.cwd(), source), 'utf8');
+  if (
+    content.includes('projection_bootstrap_store') ||
+    content.includes('rebuild_projection_shadow')
+  ) {
+    console.error(
+      `[projection-bootstrap-test] shadow bootstrap leaked into the production hot path: ${source}`,
+    );
+    process.exit(1);
+  }
+}
+
+console.log('[projection-bootstrap-test] snapshot/replay contracts passed');

--- a/scripts/run-state-service-tests.mjs
+++ b/scripts/run-state-service-tests.mjs
@@ -7,6 +7,29 @@ import path from 'node:path';
 import process from 'node:process';
 import { setTimeout as delay } from 'node:timers/promises';
 
+const buildDir = path.join(process.cwd(), 'framework', 'core', 'build');
+// shifu-entry-contract: build the exact native target instead of trusting a stale binary
+const build = spawnSync(
+  'cmake',
+  [
+    '--build',
+    buildDir,
+    '--config',
+    'Release',
+    '--target',
+    'kungfu_state_service_contract_tests',
+  ],
+  { cwd: process.cwd(), stdio: 'inherit' },
+);
+if (build.error || build.status !== 0) {
+  if (build.error)
+    console.error(`[state-service-test] build: ${build.error.message}`);
+  console.error(
+    '[state-service-test] target build failed; run ./shifu build:core to configure the core tree',
+  );
+  process.exit(build.status ?? 2);
+}
+
 const executable =
   process.platform === 'win32'
     ? 'kungfu_state_service_contract_tests.exe'
@@ -19,6 +42,22 @@ const testBinary = candidates.find((candidate) => fs.existsSync(candidate));
 if (!testBinary) {
   console.error(
     '[state-service-test] binary not found; run ./shifu build:core first',
+  );
+  process.exit(2);
+}
+
+const nativeSources = [
+  'framework/core/src/libkungfu/include/kungfu/runtime/state_service.h',
+  'framework/core/src/libkungfu/src/runtime/state_service.cpp',
+  'framework/core/src/libkungfu/tests/state_service_contract_tests.cpp',
+].map((source) => path.join(process.cwd(), source));
+const binaryMtime = fs.statSync(testBinary).mtimeMs;
+const newerSource = nativeSources.find(
+  (source) => fs.statSync(source).mtimeMs > binaryMtime,
+);
+if (newerSource) {
+  console.error(
+    `[state-service-test] refusing stale binary; newer source: ${path.relative(process.cwd(), newerSource)}`,
   );
   process.exit(2);
 }


### PR DESCRIPTION
## Summary

- add a state-service-owned binary snapshot-through-T and replay-after-T substrate over checkpoint-covered KFDL records
- bind snapshots to logical cut, projection schema, source qualification profile, and SHA-256 integrity
- provide typed required/optional/none bootstrap outcomes, deterministic rebuild, lag/watermark status, and fail-closed corruption handling
- keep the production coordinator compatibility restore unchanged; this PR is shadow evidence, not a public durability claim

## Validation

- ./shifu build:core
- ./shifu test:projection-bootstrap
- ./shifu test:durable-ingest
- ./shifu test:state-service
- ./shifu test:durability-contract
- ./shifu test:runtime-errors
- ./shifu test:mmap
- ./shifu check

## Remaining boundary

Production state-schema projection, shadow equality/cutover, coordinator business-join removal, real power-loss qualification, and public durable profiles remain disabled.