### PR TITLE
style(schema): format manifest layout weld

### DIFF
--- a/framework/core/src/libyijinjing/include/kungfu/yijinjing/schema/registry.h
+++ b/framework/core/src/libyijinjing/include/kungfu/yijinjing/schema/registry.h
@@ -234,10 +234,10 @@ namespace manifest_layout_welds {
 // the coverage guard, so a new versioned record cannot ship unwelded.
 template <typename DataType> struct expected_fingerprint;
 
-#define KF_MANIFEST_LAYOUT_WELD(DataType, Fingerprint)                                                                  \
-  template <> struct expected_fingerprint<types::DataType> {                                                            \
-    static constexpr uint64_t value = (Fingerprint);                                                                    \
-  };                                                                                                                    \
+#define KF_MANIFEST_LAYOUT_WELD(DataType, Fingerprint)                                                                 \
+  template <> struct expected_fingerprint<types::DataType> {                                                           \
+    static constexpr uint64_t value = (Fingerprint);                                                                   \
+  };                                                                                                                   \
   static_assert(journal::layout_fingerprint_detail::layout_fingerprint<types::DataType>() == (Fingerprint),            \
                 #DataType " manifest layout changed without updating its schema_version fingerprint (ADR-0067)")
 


### PR DESCRIPTION
Format the ADR-0067 manifest layout weld macro with the repository-pinned clang-format.

This was exposed by the alpha candidate staged gate, which correctly checks the entire dev projection against the older alpha base. No behavior changes.

Validation:
- `uvx clang-format@20.1.8 -style=file --dry-run -Werror framework/core/src/libyijinjing/include/kungfu/yijinjing/schema/registry.h`
- `./shifu check`
- `git diff --check`