### PR TITLE
fix(core): compile durable runtime on current toolchains

### DIFF
--- a/.github/workflows/embedding-membrane-spike.yml
+++ b/.github/workflows/embedding-membrane-spike.yml
@@ -98,6 +98,8 @@ jobs:
       KUNGFU_BUILD_SKIP_PYKUNGFU: "1"
       SHIFU_NATIVE: "1"
       SHIFU_REQUIRE_MSVC: "1"
+      CARGO_HTTP_TIMEOUT: "120"
+      CARGO_NET_RETRY: "5"
       MIRROR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
       MIRROR_REF: refs/heads/dev/v4/v4.0
       MIRROR_URL: http://192.168.100.222:8088/git-mirrors/kungfu.git

--- a/.github/workflows/embedding-membrane-spike.yml
+++ b/.github/workflows/embedding-membrane-spike.yml
@@ -12,6 +12,8 @@ on:
       - "framework/core/src/libkungfu/include/kungfu/native_storage.h"
       - "framework/core/src/libkungfu/src/runtime/embedding.cpp"
       - "framework/core/src/libkungfu/src/runtime/native_storage.cpp"
+      - "framework/core/src/libkungfu/include/kungfu/yijinjing/ownership.h"
+      - "framework/core/src/libkungfu/src/yijinjing/ownership.cpp"
       - "framework/core/slices/shared-embedding-membrane/**"
       - "framework/core/slices/native-storage-closure/**"
       - "framework/core/slices/libwasm-shared-membrane/**"

--- a/.github/workflows/embedding-membrane-spike.yml
+++ b/.github/workflows/embedding-membrane-spike.yml
@@ -12,6 +12,7 @@ on:
       - "framework/core/src/libkungfu/include/kungfu/native_storage.h"
       - "framework/core/src/libkungfu/src/runtime/embedding.cpp"
       - "framework/core/src/libkungfu/src/runtime/native_storage.cpp"
+      - "framework/core/src/libkungfu/include/kungfu/runtime/durable_ingest.h"
       - "framework/core/src/libkungfu/src/runtime/durable_ingest.cpp"
       - "framework/core/src/libkungfu/include/kungfu/yijinjing/ownership.h"
       - "framework/core/src/libkungfu/src/yijinjing/ownership.cpp"

--- a/.github/workflows/embedding-membrane-spike.yml
+++ b/.github/workflows/embedding-membrane-spike.yml
@@ -12,6 +12,7 @@ on:
       - "framework/core/src/libkungfu/include/kungfu/native_storage.h"
       - "framework/core/src/libkungfu/src/runtime/embedding.cpp"
       - "framework/core/src/libkungfu/src/runtime/native_storage.cpp"
+      - "framework/core/src/libkungfu/src/runtime/durable_ingest.cpp"
       - "framework/core/src/libkungfu/include/kungfu/yijinjing/ownership.h"
       - "framework/core/src/libkungfu/src/yijinjing/ownership.cpp"
       - "framework/core/slices/shared-embedding-membrane/**"

--- a/framework/core/src/libkungfu/src/runtime/durable_ingest.cpp
+++ b/framework/core/src/libkungfu/src/runtime/durable_ingest.cpp
@@ -76,7 +76,7 @@ uint64_t read_u64(const std::string &bytes, size_t &offset) {
 }
 
 void append_string(std::string &out, const std::string &value) {
-  if (value.size() > std::numeric_limits<uint32_t>::max()) {
+  if (value.size() > (std::numeric_limits<uint32_t>::max)()) {
     throw std::invalid_argument("durable_string_too_large");
   }
   append_u32(out, static_cast<uint32_t>(value.size()));
@@ -142,7 +142,7 @@ public:
     size_t offset = 0;
     while (offset < bytes.size()) {
 #ifdef _WIN32
-      const auto remaining = std::min<size_t>(bytes.size() - offset, std::numeric_limits<DWORD>::max());
+      const auto remaining = (std::min<size_t>)(bytes.size() - offset, (std::numeric_limits<DWORD>::max)());
       DWORD written = 0;
       if (WriteFile(handle_, bytes.data() + offset, static_cast<DWORD>(remaining), &written, nullptr) == 0 ||
           written == 0) {
@@ -317,7 +317,7 @@ std::string encode_checkpoint(const checkpoint &value) {
   append_string(body, value.writer_fence);
   append_string(body, value.qualification_profile);
   append_string(body, value.durability_profile);
-  if (value.completed_requests.size() > std::numeric_limits<uint32_t>::max()) {
+  if (value.completed_requests.size() > (std::numeric_limits<uint32_t>::max)()) {
     throw std::invalid_argument("durable_completed_request_index_too_large");
   }
   append_u32(body, static_cast<uint32_t>(value.completed_requests.size()));
@@ -407,7 +407,7 @@ std::string segment_header(uint64_t segment_id, uint64_t stream_id, uint64_t epo
 std::string encode_record(const stream_position &position, int32_t carrier_type, const durable_frame_context &frame,
                           const void *payload, size_t payload_size, uint64_t owner_generation,
                           uint64_t writer_generation) {
-  if (payload_size > std::numeric_limits<uint64_t>::max() - RECORD_HEADER_SIZE) {
+  if (payload_size > (std::numeric_limits<uint64_t>::max)() - RECORD_HEADER_SIZE) {
     throw std::invalid_argument("durable_payload_too_large");
   }
   const std::string payload_bytes(static_cast<const char *>(payload), payload_size);
@@ -638,7 +638,7 @@ struct durable_ingest_log::impl {
         continue;
       }
       try {
-        result = std::max(result, std::stoull(name.substr(prefix.size(), name.size() - prefix.size() - 5)));
+        result = (std::max)(result, std::stoull(name.substr(prefix.size(), name.size() - prefix.size() - 5)));
       } catch (...) {
       }
     }
@@ -720,7 +720,7 @@ struct durable_ingest_log::impl {
       current_status.unacknowledged_tail_bytes =
           earlier_segment_bytes(durable_checkpoint.chain_start_segment_id) + checkpoint_or_later_tail;
       if (checkpoint_or_later_tail > 0 || checkpoint_segment.filename().string().starts_with("sealed-")) {
-        create_segment(std::max(max_segment_id, durable_checkpoint.segment_id) + 1);
+        create_segment((std::max)(max_segment_id, durable_checkpoint.segment_id) + 1);
         return;
       }
       active_path = checkpoint_segment;

--- a/framework/core/src/libkungfu/src/runtime/durable_ingest.cpp
+++ b/framework/core/src/libkungfu/src/runtime/durable_ingest.cpp
@@ -638,7 +638,9 @@ struct durable_ingest_log::impl {
         continue;
       }
       try {
-        result = (std::max)(result, std::stoull(name.substr(prefix.size(), name.size() - prefix.size() - 5)));
+        result =
+            (std::max)(result,
+                       static_cast<uint64_t>(std::stoull(name.substr(prefix.size(), name.size() - prefix.size() - 5))));
       } catch (...) {
       }
     }

--- a/framework/core/src/libyijinjing/include/kungfu/yijinjing/ownership.h
+++ b/framework/core/src/libyijinjing/include/kungfu/yijinjing/ownership.h
@@ -51,7 +51,7 @@ public:
 private:
   struct impl;
   explicit lease(std::unique_ptr<impl> impl) noexcept;
-  std::unique_ptr<impl> impl_ = {};
+  std::unique_ptr<impl> impl_;
 };
 
 [[nodiscard]] const char *scope_name(scope value) noexcept;

--- a/framework/core/src/libyijinjing/include/kungfu/yijinjing/ownership.h
+++ b/framework/core/src/libyijinjing/include/kungfu/yijinjing/ownership.h
@@ -34,7 +34,7 @@ public:
 
 class lease {
 public:
-  lease() noexcept = default;
+  lease() noexcept;
   lease(lease &&other) noexcept;
   lease &operator=(lease &&other) noexcept;
   lease(const lease &) = delete;

--- a/framework/core/src/libyijinjing/src/io/ownership.cpp
+++ b/framework/core/src/libyijinjing/src/io/ownership.cpp
@@ -330,6 +330,7 @@ const char *scope_name(scope value) noexcept {
   return "unknown";
 }
 
+lease::lease() noexcept = default;
 lease::lease(std::unique_ptr<impl> impl) noexcept : impl_(std::move(impl)) {}
 lease::lease(lease &&other) noexcept = default;
 lease &lease::operator=(lease &&other) noexcept = default;


### PR DESCRIPTION
## Summary

- complete `ownership::lease` PImpl construction out of line and remove the incomplete-type member initializer
- make durable-ingest `min`/`max` calls immune to the Windows SDK macros
- route both ownership and durable-ingest changes through the hosted GCC 14 / Apple Clang / MSVC membrane matrix

## Validation

- `./shifu check`
- run 29196153424 proved the first patch reached the full hosted matrix and exposed the remaining exact failures:
  - Linux GCC 14: `unique_ptr<lease::impl>` incomplete type from the member initializer
  - Windows MSVC: `windows.h` `max` macro expansion in `durable_ingest.cpp`
