### PR TITLE
feat(shifu): manage Cargo and Conan cache bindings

### DIFF
--- a/build-local.env.example
+++ b/build-local.env.example
@@ -81,5 +81,6 @@
 # ── Entries not handled by this file — set via their own user-global config (also absent from this repo) ──
 #  npm package install registry + private @scope registry / token  →  ~/.npmrc
 #    e.g.: registry=http://YOUR-CACHE-HOST:4873/  + @kungfu-tech:registry=...  + _authToken
-#  conan remote (e.g. a LAN ConanCenter transparent cache)         →  ~/.conan2/remotes.json
-#    e.g.: conan remote add <name> http://YOUR-CACHE-HOST:8083/
+#  persistent conan remote outside a managed Shifu execution       →  ~/.conan2/remotes.json
+#    Managed cache profiles instead create a disposable CONAN_HOME for the child;
+#    Shifu does not read or overwrite this persistent fallback surface.

--- a/docs/shifu/adr/SHIFU-ADR-0001-cache-profile-contract-and-ownership.md
+++ b/docs/shifu/adr/SHIFU-ADR-0001-cache-profile-contract-and-ownership.md
@@ -86,6 +86,10 @@ registered KFD-1 version decision process.
   different policy instances.
 - Provider-specific writers and automatic profile application can be added
   later without changing authority ownership.
+- Cargo source replacement uses a child-scoped wrapper with highest-priority
+  command-line config, while Conan remote selection uses a disposable
+  `CONAN_HOME`. Shifu does not read, merge, or overwrite user configuration;
+  the managed aliases and endpoints cannot silently drift from the profile.
 - A future Shifu repository extraction can move this ADR registry and contract
   together without renumbering Kungfu Core ADRs.
 

--- a/docs/shifu/cache-contract.json
+++ b/docs/shifu/cache-contract.json
@@ -44,6 +44,7 @@
     "embeddedSecrets": "forbidden",
     "endpointUserInfo": "forbidden",
     "endpointQueryAndFragment": "forbidden",
+    "persistentToolConfig": "not-read-or-written-by-shifu",
     "evidenceRedaction": "credentials-userinfo-query-fragment"
   },
   "integrity": {

--- a/docs/shifu/cache-profiles.md
+++ b/docs/shifu/cache-profiles.md
@@ -91,10 +91,21 @@ the exact Shifu source revision auditable.
 `shifu cache resolve` loads a local/file/http(s) reference, verifies the digest
 of the exact bytes, checks platform and scope applicability, and emits a
 schema-versioned redacted receipt. `shifu cache apply -- COMMAND` performs the
-same resolution and supplies supported environment bindings only to that child
-process. Unsupported argument/config bindings, protected environment keys,
-secret-like keys, unsafe URLs, applicability drift, and digest drift fail
-closed.
+same resolution and supplies supported bindings only to that child process.
+Environment bindings remain child-only. The reserved
+`cargo.source.crates-io` and `conan.remote.conancenter` config keys create
+child-scoped overlays without modifying persistent Cargo/Conan configuration.
+Cargo is invoked through a temporary PATH wrapper that supplies highest-priority
+`--config` source replacement values; Cargo may still perform its normal
+hierarchical config discovery, but the managed source alias and endpoint are
+overridden by the profile. Conan receives a disposable `CONAN_HOME` containing
+only the managed remote plus an explicitly declared development fallback, if
+any; Kungfu detects a default compiler profile inside that isolated home. Both
+temporary overlays are removed after the child exits, including non-zero exits.
+The nested libwasm Cargo invocation inherits the same wrapper.
+Unsupported argument/config bindings, protected or secret-like environment
+keys, unsafe URLs, applicability drift, and digest drift fail closed. Receipts
+name binding kinds and overlay cleanup without exposing local paths.
 
 The default reference and digest come from
 `SHIFU_CACHE_PROFILE_REF` and `SHIFU_CACHE_PROFILE_DIGEST`. They may also be

--- a/docs/shifu/examples/cache-resolution.json
+++ b/docs/shifu/examples/cache-resolution.json
@@ -22,7 +22,13 @@
       "fallbackUsed": false,
       "verification": "passed",
       "durationMs": 18,
-      "reason": "cache endpoint selected"
+      "reason": "cache endpoint selected",
+      "application": {
+        "bindingKinds": ["environment"],
+        "scope": "child-process",
+        "persistentConfig": "not-read-or-written-by-shifu",
+        "overlayCleanup": "not-applicable"
+      }
     },
     "compiler-cache": {
       "outcome": "miss",
@@ -33,7 +39,13 @@
       "fallbackUsed": false,
       "verification": "not-applicable",
       "durationMs": 2,
-      "reason": "no matching object"
+      "reason": "no matching object",
+      "application": {
+        "bindingKinds": ["environment"],
+        "scope": "child-process",
+        "persistentConfig": "not-read-or-written-by-shifu",
+        "overlayCleanup": "not-applicable"
+      }
     }
   },
   "redaction": "credentials-userinfo-query-fragment"

--- a/docs/shifu/examples/development.cache-profile.json
+++ b/docs/shifu/examples/development.cache-profile.json
@@ -51,14 +51,37 @@
       },
       "bindings": [
         {
-          "kind": "environment",
-          "key": "CARGO_REGISTRIES_CRATES_IO_INDEX",
+          "kind": "config-key",
+          "key": "cargo.source.crates-io",
+          "name": "example-cache",
           "valueFrom": "endpoint.url"
         }
       ],
       "fallback": {
         "mode": "upstream",
         "upstreamUrl": "https://index.crates.io/"
+      },
+      "verification": {
+        "method": "tool-native"
+      }
+    },
+    "conan-registry": {
+      "kind": "package-registry",
+      "endpoint": {
+        "type": "http",
+        "url": "https://cache.example.invalid/conan/"
+      },
+      "bindings": [
+        {
+          "kind": "config-key",
+          "key": "conan.remote.conancenter",
+          "name": "example-cache",
+          "valueFrom": "endpoint.url"
+        }
+      ],
+      "fallback": {
+        "mode": "upstream",
+        "upstreamUrl": "https://center2.conan.io/"
       },
       "verification": {
         "method": "tool-native"

--- a/docs/shifu/examples/self-hosted-runner.cache-profile.json
+++ b/docs/shifu/examples/self-hosted-runner.cache-profile.json
@@ -64,6 +64,50 @@
         "method": "tool-native"
       }
     },
+    "cargo-registry": {
+      "kind": "source-index",
+      "mode": "require",
+      "endpoint": {
+        "type": "http",
+        "url": "https://cache.example.invalid/cargo-index/"
+      },
+      "bindings": [
+        {
+          "kind": "config-key",
+          "key": "cargo.source.crates-io",
+          "name": "example-cache",
+          "valueFrom": "endpoint.url"
+        }
+      ],
+      "fallback": {
+        "mode": "fail"
+      },
+      "verification": {
+        "method": "tool-native"
+      }
+    },
+    "conan-registry": {
+      "kind": "package-registry",
+      "mode": "require",
+      "endpoint": {
+        "type": "http",
+        "url": "https://cache.example.invalid/conan/"
+      },
+      "bindings": [
+        {
+          "kind": "config-key",
+          "key": "conan.remote.conancenter",
+          "name": "example-cache",
+          "valueFrom": "endpoint.url"
+        }
+      ],
+      "fallback": {
+        "mode": "fail"
+      },
+      "verification": {
+        "method": "tool-native"
+      }
+    },
     "buildchain-distribution": {
       "kind": "distribution",
       "mode": "require",

--- a/docs/shifu/schema/cache-profile-v1.schema.json
+++ b/docs/shifu/schema/cache-profile-v1.schema.json
@@ -299,7 +299,7 @@
           "required": ["kind", "key", "valueFrom"],
           "properties": {
             "kind": {
-              "enum": ["argument", "config-key"]
+              "const": "argument"
             },
             "key": {
               "type": "string",
@@ -308,6 +308,31 @@
             },
             "valueFrom": {
               "enum": ["endpoint.url", "endpoint.path"]
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "key", "name", "valueFrom"],
+          "properties": {
+            "kind": {
+              "const": "config-key"
+            },
+            "key": {
+              "enum": [
+                "cargo.source.crates-io",
+                "conan.remote.conancenter"
+              ]
+            },
+            "name": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 128,
+              "pattern": "^[a-z0-9](?:[a-z0-9_-]*[a-z0-9])?$"
+            },
+            "valueFrom": {
+              "const": "endpoint.url"
             }
           }
         }

--- a/docs/shifu/schema/cache-resolution-v1.schema.json
+++ b/docs/shifu/schema/cache-resolution-v1.schema.json
@@ -161,6 +161,35 @@
         "reason": {
           "type": "string",
           "maxLength": 512
+        },
+        "application": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "bindingKinds",
+            "scope",
+            "persistentConfig",
+            "overlayCleanup"
+          ],
+          "properties": {
+            "bindingKinds": {
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": {
+                "enum": ["environment", "config-key"]
+              }
+            },
+            "scope": {
+              "const": "child-process"
+            },
+            "persistentConfig": {
+              "const": "not-read-or-written-by-shifu"
+            },
+            "overlayCleanup": {
+              "enum": ["not-run", "completed", "not-applicable"]
+            }
+          }
         }
       }
     }

--- a/framework/core/.gyp/run-conan.js
+++ b/framework/core/.gyp/run-conan.js
@@ -16,7 +16,10 @@ function conan(cmd) {
 }
 
 function ensureBuildchainConanProfile() {
-  if (process.env.KUNGFU_BUILDCHAIN_SOURCE_BUILD !== '1') {
+  if (
+    process.env.KUNGFU_BUILDCHAIN_SOURCE_BUILD !== '1' &&
+    process.env.SHIFU_CACHE_MANAGED_CONAN !== '1'
+  ) {
     return;
   }
   const env = { NODE_GYP_RUN: 'on', ...process.env };

--- a/scripts/shifu-cache-runtime.mjs
+++ b/scripts/shifu-cache-runtime.mjs
@@ -24,8 +24,20 @@ const BLOCKED_ENV_KEYS = new Set([
   'GITHUB_TOKEN',
   'GH_TOKEN',
   'NODE_OPTIONS',
+  'CARGO_HOME',
+  'CONAN_HOME',
+  'KF_LIBWASM_CARGO_REGISTRY',
+  'SHIFU_CACHE_ACTIVE',
+  'SHIFU_CARGO_ORIGINAL_PATH',
+  'SHIFU_CARGO_REGISTRY',
+  'SHIFU_CARGO_SOURCE_NAME',
+  'SHIFU_CACHE_MANAGED_CONAN',
   'SHIFU_CACHE_PROFILE_REF',
   'SHIFU_CACHE_PROFILE_DIGEST',
+]);
+const CONFIG_KEYS = new Set([
+  'cargo.source.crates-io',
+  'conan.remote.conancenter',
 ]);
 const SECRET_KEY_RE =
   /(TOKEN|SECRET|PASSWORD|CREDENTIAL|COOKIE|PRIVATE_KEY|AUTH)/;
@@ -165,7 +177,7 @@ function endpointValue(endpoint, binding) {
 function validateBinding(binding, serviceId) {
   assertExactKeys(
     binding,
-    new Set(['kind', 'key', 'valueFrom']),
+    new Set(['kind', 'key', 'name', 'valueFrom']),
     ['kind', 'key', 'valueFrom'],
     `services.${serviceId}.binding`,
   );
@@ -181,6 +193,26 @@ function validateBinding(binding, serviceId) {
     ['endpoint.url', 'endpoint.path'].includes(binding.valueFrom),
     `services.${serviceId} binding valueFrom is invalid`,
   );
+  if (binding.kind === 'config-key') {
+    assert(
+      CONFIG_KEYS.has(binding.key),
+      `services.${serviceId} config-key is not supported: ${binding.key}`,
+    );
+    assert(
+      binding.valueFrom === 'endpoint.url',
+      `services.${serviceId} config-key requires endpoint.url`,
+    );
+    assert(
+      typeof binding.name === 'string' &&
+        /^[a-z0-9](?:[a-z0-9_-]*[a-z0-9])?$/.test(binding.name),
+      `services.${serviceId} config-key name is invalid`,
+    );
+  } else {
+    assert(
+      !Object.hasOwn(binding, 'name'),
+      `services.${serviceId} ${binding.kind} binding cannot declare name`,
+    );
+  }
 }
 
 function validateEnvironmentKey(key) {
@@ -365,6 +397,7 @@ export function validateProfileBytes(
   const services = assertObject(profile.services, 'services');
   assert(Object.keys(services).length > 0, 'profile must contain services');
   const bindings = {};
+  const configBindings = [];
   const receiptServices = {};
   for (const [serviceId, service] of Object.entries(services)) {
     assertExactKeys(
@@ -385,19 +418,36 @@ export function validateProfileBytes(
       Array.isArray(service.bindings) && service.bindings.length > 0,
       `services.${serviceId}.bindings must not be empty`,
     );
+    const bindingKinds = new Set();
     for (const binding of service.bindings) {
       validateBinding(binding, serviceId);
-      if (binding.kind !== 'environment') {
+      bindingKinds.add(binding.kind);
+      if (binding.kind === 'argument') {
         throw new CacheProfileError(
           `runtime apply does not support ${binding.kind} binding ${serviceId}/${binding.key}`,
         );
       }
-      validateEnvironmentKey(binding.key);
-      assert(
-        !Object.hasOwn(bindings, binding.key),
-        `duplicate environment binding: ${binding.key}`,
-      );
-      bindings[binding.key] = endpointValue(endpoint, binding);
+      if (binding.kind === 'environment') {
+        validateEnvironmentKey(binding.key);
+        assert(
+          !Object.hasOwn(bindings, binding.key),
+          `duplicate environment binding: ${binding.key}`,
+        );
+        bindings[binding.key] = endpointValue(endpoint, binding);
+      } else {
+        assert(
+          !configBindings.some((item) => item.key === binding.key),
+          `duplicate config-key binding: ${binding.key}`,
+        );
+        configBindings.push({
+          serviceId,
+          serviceKind: service.kind,
+          key: binding.key,
+          name: binding.name,
+          value: endpointValue(endpoint, binding),
+          fallback: service.fallback,
+        });
+      }
     }
     assertObject(service.fallback, `services.${serviceId}.fallback`);
     if (profile.policy.mode === 'require')
@@ -423,6 +473,14 @@ export function validateProfileBytes(
       verification: 'not-run',
       durationMs: 0,
       reason: 'profile binding selected',
+      application: {
+        bindingKinds: [...bindingKinds].sort(),
+        scope: 'child-process',
+        persistentConfig: 'not-read-or-written-by-shifu',
+        overlayCleanup: bindingKinds.has('config-key')
+          ? 'not-run'
+          : 'not-applicable',
+      },
     };
   }
   return {
@@ -431,8 +489,153 @@ export function validateProfileBytes(
     platform: platform || platformId(),
     scope: scope || inferScope(),
     bindings,
+    configBindings,
     receiptServices,
   };
+}
+
+function conanRemotes(binding) {
+  assert(
+    binding.name !== 'conancenter',
+    'managed Conan remote name must not shadow conancenter',
+  );
+  const remotes = [
+    {
+      name: binding.name,
+      url: binding.value,
+      verify_ssl: binding.value.startsWith('https:'),
+    },
+  ];
+  if (binding.fallback?.mode === 'upstream') {
+    const upstream = checkedHttpUrl(
+      binding.fallback.upstreamUrl,
+      `services.${binding.serviceId}.fallback.upstreamUrl`,
+    );
+    remotes.push({
+      name: 'conancenter',
+      url: upstream,
+      verify_ssl: upstream.startsWith('https:'),
+    });
+  }
+  return `${JSON.stringify({ remotes }, null, 1)}\n`;
+}
+
+function cargoWrapperSource() {
+  return `// Generated by Shifu for one child execution; contains no credentials.
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const originalPath = process.env.SHIFU_CARGO_ORIGINAL_PATH || '';
+const sourceName = process.env.SHIFU_CARGO_SOURCE_NAME || '';
+const registry = process.env.SHIFU_CARGO_REGISTRY || '';
+const names = process.platform === 'win32'
+  ? ['cargo.exe', 'cargo.cmd', 'cargo.bat', 'cargo']
+  : ['cargo'];
+let realCargo = '';
+for (const directory of originalPath.split(path.delimiter).filter(Boolean)) {
+  for (const name of names) {
+    const candidate = path.join(directory, name);
+    try {
+      fs.accessSync(candidate, fs.constants.X_OK);
+      realCargo = candidate;
+      break;
+    } catch {}
+  }
+  if (realCargo) break;
+}
+if (!realCargo) {
+  console.error('shifu cache: cargo is not available on the original PATH');
+  process.exit(127);
+}
+const config = [
+  '--config',
+  \`source.crates-io.replace-with=\"\${sourceName}\"\`,
+  '--config',
+  \`source.\${sourceName}.registry=\"sparse+\${registry}\"\`,
+];
+const result = spawnSync(realCargo, [...config, ...process.argv.slice(2)], {
+  env: { ...process.env, PATH: originalPath },
+  stdio: 'inherit',
+  shell: /\\.(?:cmd|bat)$/i.test(realCargo),
+});
+if (result.error) {
+  console.error(\`shifu cache: cannot run cargo: \${result.error.message}\`);
+  process.exit(1);
+}
+process.exit(result.status ?? 1);
+`;
+}
+
+function prepareConfigOverlays(configBindings, baseEnv) {
+  if (configBindings.length === 0) return { env: {}, root: '', cleanup() {} };
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'shifu-cache-overlay-'));
+  fs.chmodSync(root, 0o700);
+  const overlayEnv = {};
+  try {
+    for (const binding of configBindings) {
+      if (binding.key === 'cargo.source.crates-io') {
+        assert(
+          binding.serviceKind === 'source-index',
+          `${binding.key} requires a source-index service`,
+        );
+        assert(
+          binding.name !== 'crates-io',
+          'managed Cargo source name must not be crates-io',
+        );
+        const wrapperDir = path.join(root, 'bin');
+        fs.mkdirSync(wrapperDir, { mode: 0o700 });
+        const wrapperModule = path.join(wrapperDir, 'cargo-wrapper.mjs');
+        fs.writeFileSync(wrapperModule, cargoWrapperSource(), { mode: 0o600 });
+        fs.writeFileSync(
+          path.join(wrapperDir, 'cargo'),
+          "#!/usr/bin/env node\nimport './cargo-wrapper.mjs';\n",
+          { mode: 0o700 },
+        );
+        fs.writeFileSync(
+          path.join(wrapperDir, 'cargo.cmd'),
+          '@node "%~dp0cargo-wrapper.mjs" %*\r\n',
+          { mode: 0o600 },
+        );
+        const originalPath = baseEnv.PATH || '';
+        overlayEnv.PATH = `${wrapperDir}${path.delimiter}${originalPath}`;
+        overlayEnv.SHIFU_CARGO_ORIGINAL_PATH = originalPath;
+        overlayEnv.SHIFU_CARGO_SOURCE_NAME = binding.name;
+        overlayEnv.SHIFU_CARGO_REGISTRY = binding.value;
+      } else if (binding.key === 'conan.remote.conancenter') {
+        assert(
+          binding.serviceKind === 'package-registry',
+          `${binding.key} requires a package-registry service`,
+        );
+        const conanHome = path.join(root, 'conan-home');
+        fs.mkdirSync(conanHome, { mode: 0o700 });
+        fs.writeFileSync(
+          path.join(conanHome, 'remotes.json'),
+          conanRemotes(binding),
+          { mode: 0o600 },
+        );
+        overlayEnv.CONAN_HOME = conanHome;
+        overlayEnv.SHIFU_CACHE_MANAGED_CONAN = '1';
+      }
+    }
+  } catch (error) {
+    fs.rmSync(root, { recursive: true, force: true });
+    throw error;
+  }
+  return {
+    env: overlayEnv,
+    root,
+    cleanup() {
+      fs.rmSync(root, { recursive: true, force: true });
+    },
+  };
+}
+
+function markOverlayCleanup(receipt) {
+  for (const service of Object.values(receipt.services)) {
+    if (service.application.overlayCleanup === 'not-run')
+      service.application.overlayCleanup = 'completed';
+  }
 }
 
 function receiptFor(resolved) {
@@ -548,14 +751,26 @@ export async function applyCacheProfile({
     scope,
     cwd,
   });
-  writeReceipt(resolved.receipt, receiptPath);
-  const childEnv = { ...env, ...resolved.bindings, SHIFU_CACHE_ACTIVE: '1' };
-  const result = spawnChild(command, args, {
-    cwd,
-    env: childEnv,
-    stdio: 'inherit',
-    shell: false,
-  });
+  const overlays = prepareConfigOverlays(resolved.configBindings, env);
+  let result;
+  try {
+    const childEnv = {
+      ...env,
+      ...resolved.bindings,
+      ...overlays.env,
+      SHIFU_CACHE_ACTIVE: '1',
+    };
+    result = spawnChild(command, args, {
+      cwd,
+      env: childEnv,
+      stdio: 'inherit',
+      shell: false,
+    });
+  } finally {
+    overlays.cleanup();
+    markOverlayCleanup(resolved.receipt);
+    writeReceipt(resolved.receipt, receiptPath);
+  }
   if (result.error)
     throw new CacheProfileError(
       `cannot run ${command}: ${result.error.message}`,

--- a/scripts/shifu-cache-runtime.test.mjs
+++ b/scripts/shifu-cache-runtime.test.mjs
@@ -75,6 +75,49 @@ function bytes(value = profile()) {
   return Buffer.from(`${JSON.stringify(value, null, 2)}\n`);
 }
 
+function toolConfigProfile() {
+  return profile({
+    services: {
+      'cargo-registry': {
+        kind: 'source-index',
+        mode: 'require',
+        endpoint: {
+          type: 'http',
+          url: 'http://cache.example.invalid/cargo-index/',
+        },
+        bindings: [
+          {
+            kind: 'config-key',
+            key: 'cargo.source.crates-io',
+            name: 'workhub',
+            valueFrom: 'endpoint.url',
+          },
+        ],
+        fallback: { mode: 'fail' },
+        verification: { method: 'tool-native' },
+      },
+      'conan-registry': {
+        kind: 'package-registry',
+        mode: 'require',
+        endpoint: {
+          type: 'http',
+          url: 'http://cache.example.invalid/conan/',
+        },
+        bindings: [
+          {
+            kind: 'config-key',
+            key: 'conan.remote.conancenter',
+            name: 'workhub-conan',
+            valueFrom: 'endpoint.url',
+          },
+        ],
+        fallback: { mode: 'fail' },
+        verification: { method: 'tool-native' },
+      },
+    },
+  });
+}
+
 test('validates exact bytes and applies only environment bindings', () => {
   const raw = bytes();
   const digest = sha256(raw);
@@ -114,6 +157,19 @@ test('rejects endpoint credentials, query strings, and unknown fields', () => {
   }
   const unknown = profile({ unexpected: true });
   assert.throws(() => validateProfileBytes(bytes(unknown)), /not supported/);
+  const unsupportedConfig = toolConfigProfile();
+  unsupportedConfig.services['cargo-registry'].bindings[0].key =
+    'cargo.credentials';
+  assert.throws(
+    () => validateProfileBytes(bytes(unsupportedConfig)),
+    /config-key is not supported/,
+  );
+  const unsafeAlias = toolConfigProfile();
+  unsafeAlias.services['cargo-registry'].bindings[0].name = 'workhub.bad';
+  assert.throws(
+    () => validateProfileBytes(bytes(unsafeAlias)),
+    /config-key name is invalid/,
+  );
 });
 
 test('resolves an HTTP reference and emits a redacted schema receipt', async (t) => {
@@ -187,6 +243,146 @@ test('cache apply injects bindings and writes a receipt', async (t) => {
   const receipt = JSON.parse(fs.readFileSync(receiptPath, 'utf8'));
   assert.equal(receipt.profile.digest, sha256(raw));
   assert.match(receipt.execution.id, /^run:/);
+});
+
+test('cache apply overrides Cargo and isolates Conan without mutating persistent config', async (t) => {
+  const directory = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'shifu-cache-config-'),
+  );
+  t.after(() => fs.rmSync(directory, { recursive: true, force: true }));
+  const persistentCargo = path.join(directory, 'persistent-cargo');
+  const persistentConan = path.join(directory, 'persistent-conan');
+  fs.mkdirSync(persistentCargo);
+  fs.mkdirSync(persistentConan);
+  const cargoSentinel = '[sentinel]\nvalue = "persistent-cargo"\n';
+  const conanSentinel = '{"sentinel":"persistent-conan"}\n';
+  fs.writeFileSync(path.join(persistentCargo, 'config.toml'), cargoSentinel);
+  fs.writeFileSync(path.join(persistentConan, 'remotes.json'), conanSentinel);
+
+  const raw = bytes(toolConfigProfile());
+  const profilePath = path.join(directory, 'profile.json');
+  const outputPath = path.join(directory, 'child.json');
+  const receiptPath = path.join(directory, 'receipt.json');
+  const fakeCargoArgsPath = path.join(directory, 'fake-cargo-args.json');
+  const fakeBin = path.join(directory, 'fake-bin');
+  fs.mkdirSync(fakeBin);
+  const fakeCargoModule = path.join(fakeBin, 'fake-cargo.mjs');
+  fs.writeFileSync(
+    fakeCargoModule,
+    `import fs from 'node:fs'; fs.writeFileSync(process.env.FAKE_CARGO_ARGS, JSON.stringify(process.argv.slice(2)));\n`,
+  );
+  if (process.platform === 'win32') {
+    fs.writeFileSync(
+      path.join(fakeBin, 'cargo.cmd'),
+      '@node "%~dp0fake-cargo.mjs" %*\r\n',
+    );
+  } else {
+    fs.writeFileSync(
+      path.join(fakeBin, 'cargo'),
+      "#!/usr/bin/env node\nimport './fake-cargo.mjs';\n",
+      { mode: 0o700 },
+    );
+  }
+  fs.writeFileSync(profilePath, raw);
+  const script = [
+    "const cp = require('node:child_process');",
+    "const fs = require('node:fs');",
+    "const path = require('node:path');",
+    "const result = cp.spawnSync('cargo', ['metadata'], {stdio: 'inherit'});",
+    'if (result.status !== 0) process.exit(result.status || 1);',
+    `fs.writeFileSync(${JSON.stringify(outputPath)}, JSON.stringify({`,
+    'cargoHome: process.env.CARGO_HOME,',
+    'conanHome: process.env.CONAN_HOME,',
+    'wrapperDir: process.env.PATH.split(path.delimiter)[0],',
+    "conanRemotes: JSON.parse(fs.readFileSync(path.join(process.env.CONAN_HOME, 'remotes.json'), 'utf8')),",
+    'managedConan: process.env.SHIFU_CACHE_MANAGED_CONAN,',
+    '}));',
+  ].join('');
+  const status = await applyCacheProfile({
+    reference: profilePath,
+    expectedDigest: sha256(raw),
+    scope: 'development',
+    receiptPath,
+    command: process.execPath,
+    args: ['-e', script],
+    env: {
+      ...process.env,
+      CARGO_HOME: persistentCargo,
+      CONAN_HOME: persistentConan,
+      FAKE_CARGO_ARGS: fakeCargoArgsPath,
+      PATH: `${fakeBin}${path.delimiter}${process.env.PATH || ''}`,
+    },
+  });
+  assert.equal(status, 0);
+  const child = JSON.parse(fs.readFileSync(outputPath, 'utf8'));
+  assert.equal(child.cargoHome, persistentCargo);
+  assert.notEqual(child.conanHome, persistentConan);
+  assert.deepEqual(JSON.parse(fs.readFileSync(fakeCargoArgsPath, 'utf8')), [
+    '--config',
+    'source.crates-io.replace-with="workhub"',
+    '--config',
+    'source.workhub.registry="sparse+http://cache.example.invalid/cargo-index/"',
+    'metadata',
+  ]);
+  assert.deepEqual(child.conanRemotes, {
+    remotes: [
+      {
+        name: 'workhub-conan',
+        url: 'http://cache.example.invalid/conan/',
+        verify_ssl: false,
+      },
+    ],
+  });
+  assert.equal(child.managedConan, '1');
+  assert.equal(
+    fs.readFileSync(path.join(persistentCargo, 'config.toml'), 'utf8'),
+    cargoSentinel,
+  );
+  assert.equal(
+    fs.readFileSync(path.join(persistentConan, 'remotes.json'), 'utf8'),
+    conanSentinel,
+  );
+  assert.equal(fs.existsSync(child.wrapperDir), false);
+  assert.equal(fs.existsSync(child.conanHome), false);
+
+  const receipt = JSON.parse(fs.readFileSync(receiptPath, 'utf8'));
+  for (const service of Object.values(receipt.services)) {
+    assert.deepEqual(service.application.bindingKinds, ['config-key']);
+    assert.equal(service.application.scope, 'child-process');
+    assert.equal(
+      service.application.persistentConfig,
+      'not-read-or-written-by-shifu',
+    );
+    assert.equal(service.application.overlayCleanup, 'completed');
+  }
+  assert.doesNotMatch(
+    JSON.stringify(receipt),
+    /persistent-cargo|persistent-conan/,
+  );
+  assert.doesNotMatch(JSON.stringify(receipt), /shifu-cache-overlay-/);
+});
+
+test('cache apply cleans config overlays after a failing child', async (t) => {
+  const directory = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'shifu-cache-failure-'),
+  );
+  t.after(() => fs.rmSync(directory, { recursive: true, force: true }));
+  const raw = bytes(toolConfigProfile());
+  const profilePath = path.join(directory, 'profile.json');
+  const outputPath = path.join(directory, 'child.json');
+  fs.writeFileSync(profilePath, raw);
+  const script = `const path = require('node:path'); require('node:fs').writeFileSync(${JSON.stringify(outputPath)}, JSON.stringify({wrapperDir: process.env.PATH.split(path.delimiter)[0], conanHome: process.env.CONAN_HOME})); process.exit(17)`;
+  const status = await applyCacheProfile({
+    reference: profilePath,
+    expectedDigest: sha256(raw),
+    scope: 'development',
+    command: process.execPath,
+    args: ['-e', script],
+  });
+  assert.equal(status, 17);
+  const child = JSON.parse(fs.readFileSync(outputPath, 'utf8'));
+  assert.equal(fs.existsSync(child.wrapperDir), false);
+  assert.equal(fs.existsSync(child.conanHome), false);
 });
 
 test('cache apply is a transparent pass-through when no profile is configured', async (t) => {


### PR DESCRIPTION
## What changed

- add KFD-1 cache profile bindings for Cargo crates.io source replacement and ConanCenter remotes
- apply Cargo through a temporary wrapper with highest-priority config and Conan through a disposable CONAN_HOME
- emit redacted application and cleanup evidence in cache receipts
- initialize Conan default profiles for Shifu-managed source builds

## Why

Kungfu builds need the Atlas-managed central Cargo and Conan caches without depending on or overwriting persistent host configuration. Buildchain remains limited to opaque profile reference and digest transport.

## Validation

- ./shifu check
- 16 Shifu cache contract/runtime tests
- Mac, Ubuntu, agent-120, and DARKHERO digest-bound dry-run and live Cargo/Conan cache smoke
- persistent Cargo/Conan config hashes unchanged on all four hosts
