### PR TITLE
fix(runtime): make peer register-handshake timeout deterministic and thread-free

### DIFF
--- a/framework/core/src/libkungfu/include/kungfu/runtime/live/peer.h
+++ b/framework/core/src/libkungfu/include/kungfu/runtime/live/peer.h
@@ -289,6 +289,13 @@ protected:
     };
   }
 
+  // Deterministic, replayable business timeout for use AFTER the peer is live.
+  // It drives off journal Time events from the coordinator, so it is only valid
+  // once the coordinator serves this peer's TimeRequest. It must NOT be used for
+  // the register handshake: during the handshake the peer is not yet live and
+  // coordinator::on_time_request drops its TimeRequest, so the deadline would
+  // never fire. The register handshake uses a wall-clock deadline checked from
+  // on_active instead.
   template <typename Duration, typename Enabled = rx::is_duration<Duration>>
   std::function<rx::observable<event_ptr>(rx::observable<event_ptr>)> timeout(Duration &&d, int32_t timer_id) {
     enable_timer(timer_id);
@@ -334,7 +341,13 @@ protected:
 private:
   resource_manager manager_;
   bool started_ = false;
+  bool registered_ = false;
   int64_t checkin_time_ = INT64_MIN;
+  // Wall-clock deadline (ns) for the LIVE register handshake. The handshake runs
+  // before the peer is live, so the coordinator's journal time service does not
+  // serve it; on_active checks this against wall-clock on the observer
+  // recv_timeout heartbeat instead of a background rx::timeout thread.
+  int64_t register_deadline_ = INT64_MAX;
   int32_t timer_usage_count_{0};
   const std::string arguments_ = {};
   std::unordered_map<int, int64_t> timer_checkpoints_ = {};

--- a/framework/core/src/libkungfu/src/runtime/live/peer.cpp
+++ b/framework/core/src/libkungfu/src/runtime/live/peer.cpp
@@ -123,27 +123,22 @@ void peer::react() {
   }
 
   if (get_io_device()->get_home()->mode == mode::LIVE) {
+    // Deterministic, thread-free register handshake timeout. The peer is not yet
+    // live during the handshake, so the coordinator's journal time service does
+    // not serve it; instead of a background rx::timeout thread we set a
+    // wall-clock deadline that on_active checks on the observer recv_timeout
+    // heartbeat.
+    register_deadline_ =
+        yijinjing::time::now_in_nano() + REGISTER_TIMEOUT_SECONDS * yijinjing::time_unit::NANOSECONDS_PER_SECOND;
+
     auto self_register_event = events_ | skip_until(events_ | is(Register::tag) | filter([&](const event_ptr &event) {
                                                       auto uid = event->data<Register>().location_uid;
                                                       return uid == get_live_home_uid();
                                                     })) |
                                first();
 
-    self_register_event | rx::timeout(seconds(REGISTER_TIMEOUT_SECONDS), observe_on_new_thread()) |
-        $(
-            [&](const event_ptr &event) {
-              // this subscriber will quit when register is done, no worry for performance.
-            },
-            [&](std::exception_ptr e) {
-              try {
-                std::rethrow_exception(e);
-              } catch (const timeout_error &ex) {
-                SPDLOG_ERROR("peer register timeout");
-                reactor::signal_stop();
-              }
-            });
-
     self_register_event | $([&](const event_ptr &event) {
+      registered_ = true;
       auto data = event->data<Register>();
       checkin_time_ = data.checkin_time;
       // in case operation-system time change, begin_time_ mismatch clock of coordinator, keep using event->gen_time()
@@ -185,7 +180,20 @@ void peer::react() {
   }
 }
 
-void peer::on_active() {}
+void peer::on_active() {
+  // Register handshake timeout, checked on the recv_timeout heartbeat: on_active
+  // is driven by produce() even when the coordinator is silent, so this is the
+  // one live path during a stalled handshake. Wall-clock, because the peer has
+  // no trustworthy journal time before it is live.
+  if (registered_ or get_io_device()->get_home()->mode != mode::LIVE) {
+    return;
+  }
+  if (yijinjing::time::now_in_nano() >= register_deadline_) {
+    registered_ = true; // report once and stop checking
+    SPDLOG_ERROR("peer register timeout");
+    reactor::signal_stop();
+  }
+}
 
 void peer::on_frame() {
   // request_write_to the dest which from try_write_to


### PR DESCRIPTION
Register handshake timeout was rx::timeout + observe_on_new_thread (background thread, wall-clock, outside the single-threaded replayable model). Replaced with a wall-clock deadline checked from peer::on_active on the observer recv_timeout heartbeat - the one path alive when the coordinator is silent. Same 60s bound and signal_stop, no extra thread; the peer is not live during the handshake so the coordinator's journal time service cannot serve it. peer::timeout() documented as a post-live business timeout only. Verified via sibling compile_commands -fsyntax-only (compiles, no new warnings, clang-format clean) plus a standalone harness covering on_active's four branches.