### PR TITLE
docs(metadata): enforce typed document frontmatter

### DIFF
--- a/.buildchain/kfd/kfd-1/contract-world.witness.json
+++ b/.buildchain/kfd/kfd-1/contract-world.witness.json
@@ -35,7 +35,7 @@
   "sourceVerificationRequired": false,
   "canonicalPolicy": {
     "path": "framework/contract/kungfu-agent-first-canonical-policy.json",
-    "sha256": "4f7ba18746ef3e54627c1edaf39cbd74312b2ad2cb97e31240b1c58bb053a782"
+    "sha256": "43c88bdf780ddbc2f9007ec166fba5aea3520a2d3a44667782aa564a9cd55a33"
   },
   "registry": {
     "path": "framework/contract/kungfu-contracts.registry.json",
@@ -53,9 +53,9 @@
     {
       "name": "kungfu-kfx",
       "sourcePath": "framework/kfx/kungfu-kfx.contract.json",
-      "sourceSha256": "ad1a493d02e732283ea94958deac2c998ccf0bfb32251815a462188bd15dbb7c",
+      "sourceSha256": "238b2fcd1fe881dc9c476e818df7161e7caddbd6a9ca5cf3737672383a877ca4",
       "artifactPath": "config/kungfu-kfx.contract.json",
-      "expectedSha256": "ad1a493d02e732283ea94958deac2c998ccf0bfb32251815a462188bd15dbb7c",
+      "expectedSha256": "238b2fcd1fe881dc9c476e818df7161e7caddbd6a9ca5cf3737672383a877ca4",
       "byteForByte": true
     },
     {

--- a/.buildchain/kfd/kfd-1/release-gate.json
+++ b/.buildchain/kfd/kfd-1/release-gate.json
@@ -54,13 +54,13 @@
       "standard": "KFD-1",
       "standardKey": "kfd-1",
       "result": "passed",
-      "preBuildWitnessSha256": "81b636b5cd292c29506e9154c79c9383cf8f507547dd0932551a6200ff13adcb",
+      "preBuildWitnessSha256": "96ed167f14be7f8724bf93e26868a2615ee841e8a58f971c218915f2cc558a82",
       "sourceHashes": {
-        "sha256": "39abc5202a68141a814b51a21aa59bf2b709ac5d050aab0c7cd2306370e63f80",
+        "sha256": "49b05398fa09ef3106953ca54b33c42b1ac72c6016437f6f8b43e10f94edf968",
         "surfaceCount": 3
       },
       "artifactHashes": {
-        "sha256": "231f66c206d903bf38ad4f1b1bd098751039fe4eae029339bc3bbefb3366ee23",
+        "sha256": "6756ccd7727792f89b97a6ad732a5635f296b8f255f5fcd70c07f4ff3154edbc",
         "surfaceCount": 3
       },
       "witness": {
@@ -100,7 +100,7 @@
         "sourceVerificationRequired": true,
         "canonicalPolicy": {
           "path": "framework/contract/kungfu-agent-first-canonical-policy.json",
-          "sha256": "4f7ba18746ef3e54627c1edaf39cbd74312b2ad2cb97e31240b1c58bb053a782"
+          "sha256": "43c88bdf780ddbc2f9007ec166fba5aea3520a2d3a44667782aa564a9cd55a33"
         },
         "registry": {
           "path": "framework/contract/kungfu-contracts.registry.json",
@@ -118,9 +118,9 @@
           {
             "name": "kungfu-kfx",
             "sourcePath": "framework/kfx/kungfu-kfx.contract.json",
-            "sourceSha256": "ad1a493d02e732283ea94958deac2c998ccf0bfb32251815a462188bd15dbb7c",
+            "sourceSha256": "238b2fcd1fe881dc9c476e818df7161e7caddbd6a9ca5cf3737672383a877ca4",
             "artifactPath": "config/kungfu-kfx.contract.json",
-            "expectedSha256": "ad1a493d02e732283ea94958deac2c998ccf0bfb32251815a462188bd15dbb7c",
+            "expectedSha256": "238b2fcd1fe881dc9c476e818df7161e7caddbd6a9ca5cf3737672383a877ca4",
             "byteForByte": true
           },
           {
@@ -185,8 +185,8 @@
           {
             "name": "kungfu-kfx",
             "sourcePath": "framework/kfx/kungfu-kfx.contract.json",
-            "expectedSha256": "ad1a493d02e732283ea94958deac2c998ccf0bfb32251815a462188bd15dbb7c",
-            "actualSha256": "ad1a493d02e732283ea94958deac2c998ccf0bfb32251815a462188bd15dbb7c",
+            "expectedSha256": "238b2fcd1fe881dc9c476e818df7161e7caddbd6a9ca5cf3737672383a877ca4",
+            "actualSha256": "238b2fcd1fe881dc9c476e818df7161e7caddbd6a9ca5cf3737672383a877ca4",
             "status": "passed",
             "reason": ""
           },
@@ -218,10 +218,10 @@
           {
             "name": "kungfu-kfx",
             "sourcePath": "framework/kfx/kungfu-kfx.contract.json",
-            "sourceSha256": "ad1a493d02e732283ea94958deac2c998ccf0bfb32251815a462188bd15dbb7c",
+            "sourceSha256": "238b2fcd1fe881dc9c476e818df7161e7caddbd6a9ca5cf3737672383a877ca4",
             "artifactPath": "config/kungfu-kfx.contract.json",
-            "expectedSha256": "ad1a493d02e732283ea94958deac2c998ccf0bfb32251815a462188bd15dbb7c",
-            "actualSha256": "ad1a493d02e732283ea94958deac2c998ccf0bfb32251815a462188bd15dbb7c",
+            "expectedSha256": "238b2fcd1fe881dc9c476e818df7161e7caddbd6a9ca5cf3737672383a877ca4",
+            "actualSha256": "238b2fcd1fe881dc9c476e818df7161e7caddbd6a9ca5cf3737672383a877ca4",
             "byteForByte": true,
             "status": "passed",
             "reason": ""

--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -5,8 +5,8 @@
   "witnessKind": "prebuild",
   "supportLevel": "release",
   "source": {
-    "cwd": "/Users/dkr/Worktrees/kungfu/feature/home-workspace-agent-guidance",
-    "sourceSha": "caa70020c244e327fa9ce61b5f892d41429d5f15",
+    "cwd": "/Users/dkr/Worktrees/kungfu/feature/document-metadata-contract",
+    "sourceSha": "3d45ed9b89349bdfde4f52c663108186b5402122",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
     "registryDigest": "sha256:710a7f091e6f42a2059d2b617a417650fc7894e6ba80e3c456530460b755fd02"
   },

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,11 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+document_status: active
+doc_type: public-document
+review_state: unreviewed
+sensitivity: public
+---
+
 # AGENTS.md
 
 This file orients coding agents (and people) working with this repository. It is

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,11 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+document_status: active
+doc_type: public-document
+review_state: unreviewed
+sensitivity: public
+---
+
 # Contributing to Kungfu
 
 Thanks for your interest in Kungfu. This guide covers how to build the project,
@@ -168,7 +176,12 @@ whole Markdown graph so deleting or renaming a target cannot evade a
 changed-file filter. The intentionally small Markdownlint rule baseline lives
 in `.markdownlint-cli2.mjs`; do not enable a style rule by rewriting unrelated
 documents. `docs.contract.json` owns only required documents and navigation
-pointers. [`docs/vocabulary.registry.json`](docs/vocabulary.registry.json) is
+pointers. [`docs/document-metadata.contract.json`](docs/document-metadata.contract.json)
+owns typed frontmatter profiles and makes ADR body/index status checked
+projections of ADR metadata; see
+[`docs/document-metadata.md`](docs/document-metadata.md). GitHub issue templates
+and Kungfu Skills retain their independently consumed frontmatter schemas.
+[`docs/vocabulary.registry.json`](docs/vocabulary.registry.json) is
 the executable source for canonical term spelling and layers, governed public
 files, retired wording, preferred terminology, and load-bearing claim guards.
 The deterministic check verifies that its core terms remain aligned with

--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+document_status: active
+doc_type: public-document
+review_state: unreviewed
+sensitivity: public
+---
+
 # Kungfu
 
 <!-- buildchain:badges:start -->

--- a/crates/host-spike/README.md
+++ b/crates/host-spike/README.md
@@ -1,13 +1,14 @@
 ---
-status: draft
+metadata_schema: kungfu.document-metadata/v1
+document_status: draft
+doc_type: analysis
+review_state: unreviewed
+sensitivity: internal
+sources: [local-files]
 period: 2026-07-10
 theme: rust-host-spike
-doc_type: analysis
-source_level: local-files
 confidence: medium
-sensitivity: internal
 evidence_grade: B
-review_state: unreviewed
 last_reviewed: 2026-07-10
 ai_provenance:
   model_family: GPT-5

--- a/developer/sdk/kfd/kfd-1/contract-world.witness.json
+++ b/developer/sdk/kfd/kfd-1/contract-world.witness.json
@@ -35,7 +35,7 @@
   "sourceVerificationRequired": false,
   "canonicalPolicy": {
     "path": "framework/contract/kungfu-agent-first-canonical-policy.json",
-    "sha256": "4f7ba18746ef3e54627c1edaf39cbd74312b2ad2cb97e31240b1c58bb053a782"
+    "sha256": "43c88bdf780ddbc2f9007ec166fba5aea3520a2d3a44667782aa564a9cd55a33"
   },
   "registry": {
     "path": "framework/contract/kungfu-contracts.registry.json",
@@ -53,9 +53,9 @@
     {
       "name": "kungfu-kfx",
       "sourcePath": "framework/kfx/kungfu-kfx.contract.json",
-      "sourceSha256": "ad1a493d02e732283ea94958deac2c998ccf0bfb32251815a462188bd15dbb7c",
+      "sourceSha256": "238b2fcd1fe881dc9c476e818df7161e7caddbd6a9ca5cf3737672383a877ca4",
       "artifactPath": "config/kungfu-kfx.contract.json",
-      "expectedSha256": "ad1a493d02e732283ea94958deac2c998ccf0bfb32251815a462188bd15dbb7c",
+      "expectedSha256": "238b2fcd1fe881dc9c476e818df7161e7caddbd6a9ca5cf3737672383a877ca4",
       "byteForByte": true
     },
     {

--- a/developer/sdk/kfd/kfd-1/release-gate.json
+++ b/developer/sdk/kfd/kfd-1/release-gate.json
@@ -54,13 +54,13 @@
       "standard": "KFD-1",
       "standardKey": "kfd-1",
       "result": "passed",
-      "preBuildWitnessSha256": "81b636b5cd292c29506e9154c79c9383cf8f507547dd0932551a6200ff13adcb",
+      "preBuildWitnessSha256": "96ed167f14be7f8724bf93e26868a2615ee841e8a58f971c218915f2cc558a82",
       "sourceHashes": {
-        "sha256": "39abc5202a68141a814b51a21aa59bf2b709ac5d050aab0c7cd2306370e63f80",
+        "sha256": "49b05398fa09ef3106953ca54b33c42b1ac72c6016437f6f8b43e10f94edf968",
         "surfaceCount": 3
       },
       "artifactHashes": {
-        "sha256": "231f66c206d903bf38ad4f1b1bd098751039fe4eae029339bc3bbefb3366ee23",
+        "sha256": "6756ccd7727792f89b97a6ad732a5635f296b8f255f5fcd70c07f4ff3154edbc",
         "surfaceCount": 3
       },
       "witness": {
@@ -100,7 +100,7 @@
         "sourceVerificationRequired": true,
         "canonicalPolicy": {
           "path": "framework/contract/kungfu-agent-first-canonical-policy.json",
-          "sha256": "4f7ba18746ef3e54627c1edaf39cbd74312b2ad2cb97e31240b1c58bb053a782"
+          "sha256": "43c88bdf780ddbc2f9007ec166fba5aea3520a2d3a44667782aa564a9cd55a33"
         },
         "registry": {
           "path": "framework/contract/kungfu-contracts.registry.json",
@@ -118,9 +118,9 @@
           {
             "name": "kungfu-kfx",
             "sourcePath": "framework/kfx/kungfu-kfx.contract.json",
-            "sourceSha256": "ad1a493d02e732283ea94958deac2c998ccf0bfb32251815a462188bd15dbb7c",
+            "sourceSha256": "238b2fcd1fe881dc9c476e818df7161e7caddbd6a9ca5cf3737672383a877ca4",
             "artifactPath": "config/kungfu-kfx.contract.json",
-            "expectedSha256": "ad1a493d02e732283ea94958deac2c998ccf0bfb32251815a462188bd15dbb7c",
+            "expectedSha256": "238b2fcd1fe881dc9c476e818df7161e7caddbd6a9ca5cf3737672383a877ca4",
             "byteForByte": true
           },
           {
@@ -185,8 +185,8 @@
           {
             "name": "kungfu-kfx",
             "sourcePath": "framework/kfx/kungfu-kfx.contract.json",
-            "expectedSha256": "ad1a493d02e732283ea94958deac2c998ccf0bfb32251815a462188bd15dbb7c",
-            "actualSha256": "ad1a493d02e732283ea94958deac2c998ccf0bfb32251815a462188bd15dbb7c",
+            "expectedSha256": "238b2fcd1fe881dc9c476e818df7161e7caddbd6a9ca5cf3737672383a877ca4",
+            "actualSha256": "238b2fcd1fe881dc9c476e818df7161e7caddbd6a9ca5cf3737672383a877ca4",
             "status": "passed",
             "reason": ""
           },
@@ -218,10 +218,10 @@
           {
             "name": "kungfu-kfx",
             "sourcePath": "framework/kfx/kungfu-kfx.contract.json",
-            "sourceSha256": "ad1a493d02e732283ea94958deac2c998ccf0bfb32251815a462188bd15dbb7c",
+            "sourceSha256": "238b2fcd1fe881dc9c476e818df7161e7caddbd6a9ca5cf3737672383a877ca4",
             "artifactPath": "config/kungfu-kfx.contract.json",
-            "expectedSha256": "ad1a493d02e732283ea94958deac2c998ccf0bfb32251815a462188bd15dbb7c",
-            "actualSha256": "ad1a493d02e732283ea94958deac2c998ccf0bfb32251815a462188bd15dbb7c",
+            "expectedSha256": "238b2fcd1fe881dc9c476e818df7161e7caddbd6a9ca5cf3737672383a877ca4",
+            "actualSha256": "238b2fcd1fe881dc9c476e818df7161e7caddbd6a9ca5cf3737672383a877ca4",
             "byteForByte": true,
             "status": "passed",
             "reason": ""

--- a/docs/MAP.md
+++ b/docs/MAP.md
@@ -1,3 +1,11 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+document_status: active
+doc_type: public-document
+review_state: unreviewed
+sensitivity: public
+---
+
 # Documentation Map
 
 This is Kungfu's exhaustive question and evidence index. It is optimized for a
@@ -41,6 +49,7 @@ and the map routes a question to whichever doc answers it.
 | Why this versioning / release design (don't replace it naively)? | [`version-release-design.md`](version-release-design.md) | why | stable |
 | When must a change open a minor or major (and when must it not)? | [`versioning.md`](versioning.md) (rule: KFD-1, adopted by ADR-0010) | verify | stable |
 | Why was a past decision made? | [`../framework/core/docs/adr/`](../framework/core/docs/adr) | why | stable |
+| Which frontmatter fields are authoritative, and how are ADR status projections checked? | [`document-metadata.md`](document-metadata.md) | use, verify | stable · executable contract |
 | How is the repository layered? | [`architecture.md`](architecture.md) | use | stable |
 | Which Kungfu layer can I adopt independently, and what does each product promise? | [`product-layers.md`](product-layers.md) + [ADR-0049](../framework/core/docs/adr/ADR-0049-layer-complete-products-and-domain-neutral-core.md) | why, use, verify | draft · principle accepted; qualifications staged |
 | Which application domains guide the neutral core without expanding the current roadmap? | [`domain-horizons.md`](domain-horizons.md) | why | draft · agent runtime current; trading evidence; games/virtual worlds horizon |

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,11 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+document_status: active
+doc_type: public-document
+review_state: unreviewed
+sensitivity: public
+---
+
 # Kungfu Documentation
 
 Kungfu is execution infrastructure for real-world agent work. Its flagship
@@ -94,6 +102,8 @@ design target into a production guarantee.
   channel intent, and release mechanics.
 - [Shifu Documentation](shifu/README.md) — development/build execution and
   versioned cache contracts.
+- [Document Metadata Contract](document-metadata.md) — typed frontmatter,
+  lifecycle axes, ADR projections, and schema exemptions.
 - [Core ADRs](../framework/core/docs/adr/) — load-bearing decisions.
 - [Documentation Map](MAP.md) — the complete question and keyword index.
 
@@ -146,7 +156,9 @@ Vocabulary reference and its machine-readable registry. Run
 retired positioning, preferred terms, and load-bearing guarantee language.
 Objective prose errors block pull requests through `docs:prose:required`;
 warning-level policy remains advisory until its false-positive behavior is
-qualified. `docs.contract.json` owns document topology, while
+qualified. `docs.contract.json` owns document topology,
+[`document-metadata.contract.json`](document-metadata.contract.json) owns typed
+frontmatter and ADR projections, while
 [`vocabulary.registry.json`](vocabulary.registry.json) owns executable language
 policy; generated Vale files are disposable projections of that registry.
 External URL health is deliberately separate because remote availability is

--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -1,3 +1,11 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+document_status: active
+doc_type: public-document
+review_state: unreviewed
+sensitivity: public
+---
+
 # Adapters — language and framework boundaries
 
 Where the boundaries are between the C++ core and the languages that consume it,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,3 +1,11 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+document_status: active
+doc_type: public-document
+review_state: unreviewed
+sensitivity: public
+---
+
 # Architecture
 
 How the Kungfu repository is layered, and the principle that shapes it. For the

--- a/docs/buildchain.md
+++ b/docs/buildchain.md
@@ -1,3 +1,11 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+document_status: active
+doc_type: public-document
+review_state: unreviewed
+sensitivity: public
+---
+
 # Buildchain — from source to binary
 
 How source becomes the binaries you run, and where each binary comes from. This

--- a/docs/choose-your-kungfu.md
+++ b/docs/choose-your-kungfu.md
@@ -1,3 +1,11 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+document_status: active
+doc_type: public-document
+review_state: unreviewed
+sensitivity: public
+---
+
 # Choose Your Kungfu
 
 Use only the layer you need.

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -1,3 +1,11 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+document_status: active
+doc_type: public-document
+review_state: unreviewed
+sensitivity: public
+---
+
 # Implementation Concepts
 
 The product names, repository components, and runtime terms used across Kungfu's

--- a/docs/config.md
+++ b/docs/config.md
@@ -1,3 +1,11 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+document_status: active
+doc_type: public-document
+review_state: unreviewed
+sensitivity: public
+---
+
 # Kungfu Config
 
 Kungfu separates local state into workspace data, user config, and machine data

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -1,3 +1,11 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+document_status: active
+doc_type: public-document
+review_state: unreviewed
+sensitivity: public
+---
+
 # Contracts — what kungfu actually guarantees
 
 What you can rely on, stated as contracts you can verify, with each one's current

--- a/docs/cost-state-proof-profile.md
+++ b/docs/cost-state-proof-profile.md
@@ -1,3 +1,11 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+document_status: active
+doc_type: public-document
+review_state: unreviewed
+sensitivity: public
+---
+
 # Cost/State/Proof profile
 
 Cost/State/Proof is the first commercial profile of Kungfu Mission Control. It

--- a/docs/cpp-toolchain.md
+++ b/docs/cpp-toolchain.md
@@ -1,13 +1,14 @@
 ---
-status: active
+metadata_schema: kungfu.document-metadata/v1
+document_status: active
+doc_type: reference
+review_state: self-reviewed
+sensitivity: public
+sources: [local-files]
 period: ongoing
 theme: kungfu-cpp-toolchain
-doc_type: reference
-source_level: local-files
 confidence: high
-sensitivity: public
 evidence_grade: A
-review_state: self-reviewed
 last_reviewed: 2026-07-12
 ai_provenance:
   model_family: GPT-5

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -1,3 +1,11 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+document_status: active
+doc_type: public-document
+review_state: unreviewed
+sensitivity: public
+---
+
 # Debugging kungfu
 
 If kungfu itself misbehaves — a frame that looks wrong, a component that does not

--- a/docs/design-philosophy.md
+++ b/docs/design-philosophy.md
@@ -1,3 +1,11 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+document_status: active
+doc_type: public-document
+review_state: unreviewed
+sensitivity: public
+---
+
 # Design Philosophy
 
 Two choices in this repository look wrong at first glance, and both are

--- a/docs/document-metadata.contract.json
+++ b/docs/document-metadata.contract.json
@@ -1,0 +1,143 @@
+{
+  "schemaVersion": 1,
+  "metadataSchema": "kungfu.document-metadata/v1",
+  "sourceKinds": [
+    "architecture-decisions",
+    "executable-probe",
+    "local-files",
+    "official-upstream",
+    "public-reference-systems",
+    "user-consensus",
+    "user-decision"
+  ],
+  "externalFrontmatterSchemas": [
+    {
+      "id": "github-issue-template",
+      "patterns": ["^\\.github/ISSUE_TEMPLATE/.*\\.md$"]
+    },
+    {
+      "id": "kungfu-skill",
+      "patterns": ["(^|/)SKILL\\.md$"]
+    }
+  ],
+  "profiles": [
+    {
+      "id": "architecture-decision",
+      "patterns": [
+        "^framework/core/docs/adr/ADR-[0-9]{4}-.*\\.md$",
+        "^docs/shifu/adr/SHIFU-ADR-[0-9]{4}-.*\\.md$"
+      ],
+      "frontmatterRequired": true,
+      "required": [
+        "metadata_schema",
+        "doc_type",
+        "adr_id",
+        "decision_status",
+        "implementation_status",
+        "review_state",
+        "sensitivity"
+      ],
+      "constants": {
+        "metadata_schema": "kungfu.document-metadata/v1",
+        "doc_type": "architecture-decision",
+        "sensitivity": "public"
+      },
+      "enums": {
+        "decision_status": ["proposed", "accepted", "superseded"],
+        "implementation_status": [
+          "not-started",
+          "partial",
+          "staged",
+          "implemented",
+          "not-applicable",
+          "unknown"
+        ],
+        "review_state": [
+          "legacy-unreviewed",
+          "unreviewed",
+          "self-reviewed",
+          "maintainer-reviewed"
+        ]
+      },
+      "forbidden": ["status", "document_status", "source_level"]
+    },
+    {
+      "id": "adr-index",
+      "files": [
+        "framework/core/docs/adr/README.md",
+        "docs/shifu/adr/README.md"
+      ],
+      "frontmatterRequired": true,
+      "required": [
+        "metadata_schema",
+        "doc_type",
+        "document_status",
+        "review_state",
+        "sensitivity"
+      ],
+      "constants": {
+        "metadata_schema": "kungfu.document-metadata/v1",
+        "doc_type": "adr-index",
+        "document_status": "active",
+        "sensitivity": "public"
+      },
+      "enums": {
+        "review_state": ["unreviewed", "self-reviewed", "maintainer-reviewed"]
+      },
+      "forbidden": ["status", "decision_status", "source_level"]
+    },
+    {
+      "id": "public-document",
+      "files": ["README.md", "AGENTS.md", "CONTRIBUTING.md"],
+      "patterns": ["^docs/.*\\.md$", "^framework/spec/.*\\.md$"],
+      "frontmatterRequired": true,
+      "required": [
+        "metadata_schema",
+        "doc_type",
+        "document_status",
+        "review_state",
+        "sensitivity"
+      ],
+      "constants": {
+        "metadata_schema": "kungfu.document-metadata/v1",
+        "sensitivity": "public"
+      },
+      "enums": {
+        "document_status": ["draft", "active", "stable", "deprecated", "archived"],
+        "review_state": ["unreviewed", "self-reviewed", "maintainer-reviewed"]
+      },
+      "forbidden": ["status", "decision_status", "source_level"]
+    },
+    {
+      "id": "repository-document",
+      "patterns": [".*"],
+      "frontmatterRequired": false,
+      "required": [
+        "metadata_schema",
+        "doc_type",
+        "document_status",
+        "review_state",
+        "sensitivity"
+      ],
+      "constants": {
+        "metadata_schema": "kungfu.document-metadata/v1"
+      },
+      "enums": {
+        "document_status": ["draft", "active", "stable", "deprecated", "archived"],
+        "review_state": ["unreviewed", "self-reviewed", "maintainer-reviewed"],
+        "sensitivity": ["public", "internal"]
+      },
+      "forbidden": ["status", "decision_status", "source_level"]
+    }
+  ],
+  "adrRegistries": [
+    {
+      "index": "framework/core/docs/adr/README.md",
+      "recordPattern": "^framework/core/docs/adr/(ADR-[0-9]{4})-.*\\.md$"
+    },
+    {
+      "index": "docs/shifu/adr/README.md",
+      "recordPattern": "^docs/shifu/adr/(SHIFU-ADR-[0-9]{4})-.*\\.md$"
+    }
+  ]
+}

--- a/docs/document-metadata.md
+++ b/docs/document-metadata.md
@@ -1,0 +1,88 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+document_status: active
+doc_type: reference
+review_state: maintainer-reviewed
+sensitivity: public
+sources: [local-files, user-consensus]
+last_reviewed: 2026-07-13
+---
+
+# Document Metadata Contract
+
+Kungfu treats documentation metadata as an executable product contract. The
+frontmatter identifies what kind of document a file is, which lifecycle axes
+apply to it, and which fields tools may trust. It is not decorative YAML.
+
+The machine authority is
+[`document-metadata.contract.json`](document-metadata.contract.json). The
+deterministic `./shifu docs:check` gate validates the contract, all governed
+frontmatter, ADR body projections, and ADR registry rows.
+
+## Profiles
+
+| Profile | Coverage | Required authority |
+| --- | --- | --- |
+| public document | repository entry documents, `docs/`, and `framework/spec/` | document lifecycle, type, review state, and public sensitivity |
+| architecture decision | Core and Shifu ADR records | ADR id, decision status, implementation status, review state, and public sensitivity |
+| ADR index | Core and Shifu ADR registries | active index identity and review state; every row must match record metadata |
+| repository document | other tracked Markdown that already declares Kungfu metadata | the base document lifecycle profile |
+| external schema | issue templates and Kungfu Skills | the schema owned by their consumer, not this contract |
+
+The contract intentionally does not require frontmatter on every nested package
+README. A repository document may remain headerless until it needs governed
+metadata. Once it declares Kungfu metadata, it must use the current schema.
+
+## Separate lifecycle axes
+
+Do not use a generic `status` field. It previously meant document maturity in
+some files and decision state in others.
+
+- `document_status` describes a non-ADR document: `draft`, `active`, `stable`,
+  `deprecated`, or `archived`.
+- `decision_status` describes an ADR decision: `proposed`, `accepted`, or
+  `superseded`.
+- `implementation_status` describes the implementation separately:
+  `not-started`, `partial`, `staged`, `implemented`, `not-applicable`, or
+  `unknown`.
+- `review_state` records review evidence. `legacy-unreviewed` is allowed only
+  for migrated ADRs whose historical review cannot be reconstructed honestly.
+
+`unknown` and `legacy-unreviewed` are deliberate evidence boundaries. Do not
+invent implementation completion, review, dates, sources, or AI provenance to
+make an older file look complete.
+
+## Sources and provenance
+
+Use the structured inline `sources` list and only the values declared by the
+contract. Do not concatenate source names into a free-form `source_level`
+string. `ai_provenance` remains conditional: include it when an AI materially
+generated or rewrote the document and the visible generation context is known;
+do not fabricate it for historical records.
+
+## ADR projection rule
+
+ADR frontmatter is the machine authority. The visible body status and registry
+table remain useful to readers, but they are checked projections:
+
+```yaml
+metadata_schema: kungfu.document-metadata/v1
+doc_type: architecture-decision
+adr_id: ADR-0069
+decision_status: accepted
+implementation_status: staged
+review_state: self-reviewed
+sensitivity: public
+```
+
+The body must visibly project the same decision status. The ADR registry must
+contain the record and show the same canonical decision status. Implementation
+detail belongs in `implementation_status` and the ADR body, not in a compound
+registry status cell.
+
+## Changing the contract
+
+Change the JSON contract, validator, fixtures, affected documents, and this
+reference together. Add a negative fixture for every new failure mode. Prefer
+extending an existing profile over adding one; create a new profile only when a
+different consumer or lifecycle semantics make the distinction load-bearing.

--- a/docs/domain-horizons.md
+++ b/docs/domain-horizons.md
@@ -1,3 +1,11 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+document_status: active
+doc_type: public-document
+review_state: unreviewed
+sensitivity: public
+---
+
 # Domain horizons for the runtime-fact core
 
 Kungfu's current product focus is accountable agent runtime. Its native core is

--- a/docs/durability-and-crash-recovery.md
+++ b/docs/durability-and-crash-recovery.md
@@ -1,13 +1,14 @@
 ---
-status: draft
+metadata_schema: kungfu.document-metadata/v1
+document_status: draft
+doc_type: capability-overview
+review_state: self-reviewed
+sensitivity: public
+sources: [architecture-decisions, local-files]
 period: 2026-07-12
 theme: strong-durability-and-crash-recovery
-doc_type: capability-overview
-source_level: local-files + architecture-decisions
 confidence: high
-sensitivity: public
 evidence_grade: B
-review_state: self-reviewed
 last_reviewed: 2026-07-12
 ai_provenance:
   model_family: GPT-5

--- a/docs/episode-atomicity-qualification.md
+++ b/docs/episode-atomicity-qualification.md
@@ -1,13 +1,14 @@
 ---
-status: draft
+metadata_schema: kungfu.document-metadata/v1
+document_status: draft
+doc_type: verification-design
+review_state: self-reviewed
+sensitivity: public
+sources: [local-files, user-consensus]
 period: ongoing
 theme: episode-atomicity-qualification
-doc_type: verification-design
-source_level: user-consensus + local-files
 confidence: medium-high
-sensitivity: public
 evidence_grade: B
-review_state: self-reviewed
 last_reviewed: 2026-07-10
 ai_provenance:
   model_family: GPT-5

--- a/docs/episode-object-model.md
+++ b/docs/episode-object-model.md
@@ -1,3 +1,11 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+document_status: active
+doc_type: public-document
+review_state: unreviewed
+sensitivity: public
+---
+
 # Episode Object Model
 
 Status: accepted design direction with v1 implementation. The term and

--- a/docs/event-model.md
+++ b/docs/event-model.md
@@ -1,3 +1,11 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+document_status: active
+doc_type: public-document
+review_state: unreviewed
+sensitivity: public
+---
+
 # Event Model — journal, frame, replay
 
 How kungfu represents and moves data. This is the *use* reference for the data

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -1,3 +1,11 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+document_status: active
+doc_type: public-document
+review_state: unreviewed
+sensitivity: public
+---
+
 # Extensions (kfx)
 
 How to write, build and install a kungfu extension. This is the

--- a/docs/fact-surface-admission.md
+++ b/docs/fact-surface-admission.md
@@ -1,3 +1,11 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+document_status: active
+doc_type: public-document
+review_state: unreviewed
+sensitivity: public
+---
+
 # Bringing domain facts into Kungfu
 
 Kungfu can preserve and query facts from a product, user, extension, or domain

--- a/docs/facts-before-trust.md
+++ b/docs/facts-before-trust.md
@@ -1,3 +1,11 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+document_status: active
+doc_type: public-document
+review_state: unreviewed
+sensitivity: public
+---
+
 # Facts Before Trust
 
 Kungfu starts from the rule KFD makes explicit:

--- a/docs/journal-page-sizing-and-episode-reclamation.md
+++ b/docs/journal-page-sizing-and-episode-reclamation.md
@@ -1,3 +1,11 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+document_status: active
+doc_type: public-document
+review_state: unreviewed
+sensitivity: public
+---
+
 # Design note: journal page sizing, max-frame, and Episode-aware reclamation
 
 - Status: design judgment (note, not a decision record)

--- a/docs/kfd-native-sdk-release-gates.md
+++ b/docs/kfd-native-sdk-release-gates.md
@@ -1,3 +1,11 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+document_status: active
+doc_type: public-document
+review_state: unreviewed
+sensitivity: public
+---
+
 # KFD-Native SDK And Release Gates
 
 This records how KFD-1/2/3 are native to Kungfu developer workflows and

--- a/docs/kfd2-trust-assessment.md
+++ b/docs/kfd2-trust-assessment.md
@@ -1,3 +1,11 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+document_status: active
+doc_type: public-document
+review_state: unreviewed
+sensitivity: public
+---
+
 # KFD-2 trust assessment in a live workspace
 
 Kungfu records work continuously, but it does not run a full trust analysis

--- a/docs/kfx-topology.md
+++ b/docs/kfx-topology.md
@@ -1,3 +1,11 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+document_status: active
+doc_type: public-document
+review_state: unreviewed
+sensitivity: public
+---
+
 # kfx topology — how a kfx is loaded, trusted, confined, and connected
 
 This page is the mental model behind [`extensions.md`](extensions.md). That page

--- a/docs/known-limits.md
+++ b/docs/known-limits.md
@@ -1,3 +1,11 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+document_status: active
+doc_type: public-document
+review_state: unreviewed
+sensitivity: public
+---
+
 # Known Limits
 
 What kungfu does *not* yet guarantee, stated plainly. This is part of answering

--- a/docs/libkungfu-embedding-membrane-spike.md
+++ b/docs/libkungfu-embedding-membrane-spike.md
@@ -1,13 +1,14 @@
 ---
-status: active
+metadata_schema: kungfu.document-metadata/v1
+document_status: active
+doc_type: analysis
+review_state: self-reviewed
+sensitivity: public
+sources: [local-files]
 period: 2026-07-10
 theme: libkungfu-shared-embedding-membrane
-doc_type: analysis
-source_level: local-files
 confidence: high
-sensitivity: internal
 evidence_grade: A
-review_state: self-reviewed
 last_reviewed: 2026-07-11
 ai_provenance:
   model_family: GPT-5

--- a/docs/libwasm-embedding-membrane-spike.md
+++ b/docs/libwasm-embedding-membrane-spike.md
@@ -1,13 +1,14 @@
 ---
-status: draft
+metadata_schema: kungfu.document-metadata/v1
+document_status: draft
+doc_type: analysis
+review_state: unreviewed
+sensitivity: public
+sources: [executable-probe, local-files, official-upstream]
 period: 2026-07-11
 theme: libwasm-shared-embedding-membrane
-doc_type: analysis
-source_level: local-files + official-upstream + executable-probe
 confidence: high
-sensitivity: public
 evidence_grade: B
-review_state: unreviewed
 last_reviewed: 2026-07-11
 ai_provenance:
   model_family: GPT-5

--- a/docs/mission-control-workspaces.md
+++ b/docs/mission-control-workspaces.md
@@ -1,13 +1,14 @@
 ---
-status: draft
+metadata_schema: kungfu.document-metadata/v1
+document_status: draft
+doc_type: product-design
+review_state: unreviewed
+sensitivity: public
+sources: [local-files, user-consensus]
 period: 2026-07-11
 theme: kungfu-mission-control-workspaces
-doc_type: product-design
-source_level: user-consensus-and-local-files
 confidence: high
-sensitivity: public
 evidence_grade: B
-review_state: unreviewed
 last_reviewed: 2026-07-11
 ai_provenance:
   model_family: GPT-5

--- a/docs/mission-control.md
+++ b/docs/mission-control.md
@@ -1,13 +1,14 @@
 ---
-status: draft
+metadata_schema: kungfu.document-metadata/v1
+document_status: draft
+doc_type: product-design
+review_state: unreviewed
+sensitivity: public
+sources: [local-files, user-consensus]
 period: 2026-07-12
 theme: kungfu-mission-control
-doc_type: product-design
-source_level: local-files-and-user-consensus
 confidence: high
-sensitivity: public
 evidence_grade: B
-review_state: unreviewed
 last_reviewed: 2026-07-12
 ai_provenance:
   model_family: GPT-5

--- a/docs/product-layers.md
+++ b/docs/product-layers.md
@@ -1,3 +1,11 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+document_status: active
+doc_type: public-document
+review_state: unreviewed
+sensitivity: public
+---
+
 # Product Layers
 
 Independent adoption from the App to the format.

--- a/docs/python-environments.md
+++ b/docs/python-environments.md
@@ -1,3 +1,11 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+document_status: active
+doc_type: public-document
+review_state: unreviewed
+sensitivity: public
+---
+
 # Python environments — `kungfu env`
 
 How to use the full Python package ecosystem (PyTorch-class included) with

--- a/docs/querying-runtime-facts.md
+++ b/docs/querying-runtime-facts.md
@@ -1,3 +1,11 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+document_status: active
+doc_type: public-document
+review_state: unreviewed
+sensitivity: public
+---
+
 # Querying runtime facts
 
 Kungfu's runtime fact ledger is designed to answer both current-state and

--- a/docs/rewind.md
+++ b/docs/rewind.md
@@ -1,3 +1,11 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+document_status: active
+doc_type: public-document
+review_state: unreviewed
+sensitivity: public
+---
+
 # Rewind an Episode
 
 Rewind is the user-facing operation of reopening an **Episode** for causal

--- a/docs/runtime-service.md
+++ b/docs/runtime-service.md
@@ -1,3 +1,11 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+document_status: active
+doc_type: public-document
+review_state: unreviewed
+sensitivity: public
+---
+
 # Kungfu Runtime Service
 
 Status: draft implementation slice.

--- a/docs/runtime-storage-service.md
+++ b/docs/runtime-storage-service.md
@@ -1,3 +1,11 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+document_status: active
+doc_type: public-document
+review_state: unreviewed
+sensitivity: public
+---
+
 # Runtime Storage Service
 
 Status: draft design plan with implemented Atlas and generic source first

--- a/docs/rust-adoption.md
+++ b/docs/rust-adoption.md
@@ -1,3 +1,11 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+document_status: active
+doc_type: public-document
+review_state: unreviewed
+sensitivity: public
+---
+
 # Rust adoption paradigm
 
 Kungfu treats Rust as a **first-class option**, not a migration target: the

--- a/docs/rust-host-spike.md
+++ b/docs/rust-host-spike.md
@@ -1,13 +1,14 @@
 ---
-status: draft
+metadata_schema: kungfu.document-metadata/v1
+document_status: draft
+doc_type: analysis
+review_state: unreviewed
+sensitivity: public
+sources: [local-files]
 period: 2026-07-10
 theme: rust-host-spike
-doc_type: analysis
-source_level: local-files
 confidence: medium
-sensitivity: internal
 evidence_grade: B
-review_state: unreviewed
 last_reviewed: 2026-07-10
 ai_provenance:
   model_family: GPT-5

--- a/docs/shifu/README.md
+++ b/docs/shifu/README.md
@@ -1,13 +1,14 @@
 ---
-status: draft
+metadata_schema: kungfu.document-metadata/v1
+document_status: draft
+doc_type: documentation-map
+review_state: unreviewed
+sensitivity: public
+sources: [local-files]
 period: ongoing
 theme: shifu
-doc_type: documentation-map
-source_level: local-files
 confidence: high
-sensitivity: public
 evidence_grade: B
-review_state: unreviewed
 last_reviewed: 2026-07-12
 ---
 

--- a/docs/shifu/adr/README.md
+++ b/docs/shifu/adr/README.md
@@ -1,13 +1,14 @@
 ---
-status: active
+metadata_schema: kungfu.document-metadata/v1
+document_status: active
+doc_type: adr-index
+review_state: self-reviewed
+sensitivity: public
+sources: [local-files]
 period: ongoing
 theme: shifu-architecture-decisions
-doc_type: adr-index
-source_level: local-files
 confidence: high
-sensitivity: public
 evidence_grade: B
-review_state: self-reviewed
 last_reviewed: 2026-07-12
 ---
 
@@ -20,9 +21,13 @@ if the tool later becomes a separate project.
 Records are append-only. A changed decision is superseded by a new record; the
 old record stays as evidence.
 
+Frontmatter is the machine authority. Body and registry status are checked
+projections under the [Document Metadata Contract](../../document-metadata.md),
+with decision and implementation state kept on separate axes.
+
 | ADR | Status | Decision |
 |---|---|---|
-| [SHIFU-ADR-0001](SHIFU-ADR-0001-cache-profile-contract-and-ownership.md) | accepted; development implementation | Cache profiles are Shifu-owned contracts; inventories project instances, Buildchain owns process |
+| [SHIFU-ADR-0001](SHIFU-ADR-0001-cache-profile-contract-and-ownership.md) | accepted | Cache profiles are Shifu-owned contracts; inventories project instances, Buildchain owns process |
 
 Kungfu Core decisions that constrain Shifu remain in the Core ADR registry.
 In particular, [ADR-0044](../../../framework/core/docs/adr/ADR-0044-shifu-delegation-protocol.md)

--- a/docs/shifu/adr/SHIFU-ADR-0001-cache-profile-contract-and-ownership.md
+++ b/docs/shifu/adr/SHIFU-ADR-0001-cache-profile-contract-and-ownership.md
@@ -1,13 +1,16 @@
 ---
-status: accepted
+metadata_schema: kungfu.document-metadata/v1
+doc_type: architecture-decision
+adr_id: SHIFU-ADR-0001
+decision_status: accepted
+implementation_status: partial
+review_state: unreviewed
+sensitivity: public
+sources: [local-files, user-consensus]
 period: ongoing
 theme: shifu-cache-profile-contract
-doc_type: architecture-decision-record
-source_level: user-consensus + local-files
 confidence: high
-sensitivity: public
 evidence_grade: B
-review_state: unreviewed
 last_reviewed: 2026-07-12
 ---
 

--- a/docs/shifu/cache-profiles.md
+++ b/docs/shifu/cache-profiles.md
@@ -1,13 +1,14 @@
 ---
-status: draft
+metadata_schema: kungfu.document-metadata/v1
+document_status: draft
+doc_type: design-reference
+review_state: unreviewed
+sensitivity: public
+sources: [local-files]
 period: ongoing
 theme: shifu-cache-profiles
-doc_type: design-reference
-source_level: local-files
 confidence: high
-sensitivity: public
 evidence_grade: B
-review_state: unreviewed
 last_reviewed: 2026-07-12
 ---
 

--- a/docs/single-host-institutional-trust.md
+++ b/docs/single-host-institutional-trust.md
@@ -1,13 +1,14 @@
 ---
-status: draft
+metadata_schema: kungfu.document-metadata/v1
+document_status: draft
+doc_type: adoption-contract
+review_state: self-reviewed
+sensitivity: public
+sources: [architecture-decisions, local-files]
 period: 2026-07-12
 theme: single-host-institutional-trust
-doc_type: adoption-contract
-source_level: local-files + architecture-decisions
 confidence: high
-sensitivity: public
 evidence_grade: B
-review_state: self-reviewed
 last_reviewed: 2026-07-12
 ai_provenance:
   model_family: GPT-5

--- a/docs/single-host-performance-qualification.md
+++ b/docs/single-host-performance-qualification.md
@@ -1,13 +1,14 @@
 ---
-status: draft
+metadata_schema: kungfu.document-metadata/v1
+document_status: draft
+doc_type: release-gate-contract
+review_state: self-reviewed
+sensitivity: public
+sources: [architecture-decisions, local-files, public-reference-systems]
 period: 2026-07-12
 theme: single-host-performance-qualification
-doc_type: release-gate-contract
-source_level: local-files + architecture-decisions + public-reference-systems
 confidence: high
-sensitivity: public
 evidence_grade: B
-review_state: self-reviewed
 last_reviewed: 2026-07-12
 ai_provenance:
   model_family: GPT-5

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -1,3 +1,11 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+document_status: active
+doc_type: public-document
+review_state: unreviewed
+sensitivity: public
+---
+
 # Kungfu Skills
 
 Kungfu Skills are the agent-facing capability layer above kfx. A skill teaches

--- a/docs/the-episode.md
+++ b/docs/the-episode.md
@@ -1,3 +1,11 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+document_status: active
+doc_type: public-document
+review_state: unreviewed
+sensitivity: public
+---
+
 # The Episode
 
 ## A vocabulary for real-world agent work

--- a/docs/version-release-design.md
+++ b/docs/version-release-design.md
@@ -1,3 +1,11 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+document_status: active
+doc_type: public-document
+review_state: unreviewed
+sensitivity: public
+---
+
 # Version & Release Mechanism — Design Rationale
 
 > Audience: maintainers evaluating, extending, or considering replacing

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -1,3 +1,11 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+document_status: active
+doc_type: public-document
+review_state: unreviewed
+sensitivity: public
+---
+
 # Versioning — welded surfaces and the decision log
 
 How this repository decides patch, minor, and major. The rule is

--- a/docs/vocabulary.md
+++ b/docs/vocabulary.md
@@ -1,3 +1,11 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+document_status: active
+doc_type: public-document
+review_state: unreviewed
+sensitivity: public
+---
+
 # Kungfu Vocabulary Reference
 
 This reference defines the public language Kungfu uses for real-world

--- a/framework/core/docs/adr/ADR-0001-yijinjing-publish-barrier.md
+++ b/framework/core/docs/adr/ADR-0001-yijinjing-publish-barrier.md
@@ -1,3 +1,13 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+doc_type: architecture-decision
+adr_id: ADR-0001
+decision_status: accepted
+implementation_status: implemented
+review_state: legacy-unreviewed
+sensitivity: public
+---
+
 # ADR-0001: yijinjing journal frame/page publish protocol → `atomic_ref` release/acquire
 
 - Status: accepted (implemented on this line; ARM adversarial stress test + in-tree compile both pass — see "Gate outcome")

--- a/framework/core/docs/adr/ADR-0002-yijinjing-schema-runtime-layout.md
+++ b/framework/core/docs/adr/ADR-0002-yijinjing-schema-runtime-layout.md
@@ -1,3 +1,13 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+doc_type: architecture-decision
+adr_id: ADR-0002
+decision_status: superseded
+implementation_status: not-applicable
+review_state: legacy-unreviewed
+sensitivity: public
+---
+
 # ADR-0002: yijinjing schema serialization — a FlatBuffers runtime schema over the zero-copy POD layout
 
 - Status: superseded in schema scope by

--- a/framework/core/docs/adr/ADR-0003-control-axis-python-coroutine-integration.md
+++ b/framework/core/docs/adr/ADR-0003-control-axis-python-coroutine-integration.md
@@ -1,3 +1,13 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+doc_type: architecture-decision
+adr_id: ADR-0003
+decision_status: proposed
+implementation_status: not-started
+review_state: legacy-unreviewed
+sensitivity: public
+---
+
 # ADR-0003: control axis — the Python coroutine integration layer (continue / redesign / drop)
 
 - Status: proposed (open design question; under evaluation, not scheduled)

--- a/framework/core/docs/adr/ADR-0004-control-axis-node-watcher-snapshot-model.md
+++ b/framework/core/docs/adr/ADR-0004-control-axis-node-watcher-snapshot-model.md
@@ -1,3 +1,13 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+doc_type: architecture-decision
+adr_id: ADR-0004
+decision_status: proposed
+implementation_status: not-started
+review_state: legacy-unreviewed
+sensitivity: public
+---
+
 # ADR-0004: control axis — the Node watcher snapshot model
 
 - Status: proposed (open design question; triggered by state scale, not current)

--- a/framework/core/docs/adr/ADR-0005-control-event-axis-modernization-assessment.md
+++ b/framework/core/docs/adr/ADR-0005-control-event-axis-modernization-assessment.md
@@ -1,6 +1,16 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+doc_type: architecture-decision
+adr_id: ADR-0005
+decision_status: proposed
+implementation_status: partial
+review_state: legacy-unreviewed
+sensitivity: public
+---
+
 # ADR-0005: control / event axis modernization — a meta-assessment
 
-- Status: partially decided (2026-07-03: the reactive event layer is **frozen
+- Status: proposed; partially decided (2026-07-03: the reactive event layer is **frozen
   for v4** — see the decision below; ADR-0003 and ADR-0004 remain open)
 - Date: 2026-06-30
 - Category: (b) improvement — meta design question for v4 scope

--- a/framework/core/docs/adr/ADR-0006-v4-frontend-platform-architecture.md
+++ b/framework/core/docs/adr/ADR-0006-v4-frontend-platform-architecture.md
@@ -1,3 +1,13 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+doc_type: architecture-decision
+adr_id: ADR-0006
+decision_status: accepted
+implementation_status: partial
+review_state: legacy-unreviewed
+sensitivity: public
+---
+
 # ADR-0006: v4 frontend = platform (capability SDK + loose kfx contract) + minimal reference app
 
 - Status: accepted (foundation phase; coexistence empirically validated, see "Gate outcome")

--- a/framework/core/docs/adr/ADR-0007-v4-tui-platform-reference-surface.md
+++ b/framework/core/docs/adr/ADR-0007-v4-tui-platform-reference-surface.md
@@ -1,3 +1,13 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+doc_type: architecture-decision
+adr_id: ADR-0007
+decision_status: accepted
+implementation_status: not-started
+review_state: legacy-unreviewed
+sensitivity: public
+---
+
 # ADR-0007: v4 TUI = the platform's second reference surface (shell-native, zero-copy, React/Ink)
 
 - Status: accepted (decision 2026-06-29: Ink / React stack). Implementation pending; coexistence

--- a/framework/core/docs/adr/ADR-0008-yijinjing-schema-layout-baseline.md
+++ b/framework/core/docs/adr/ADR-0008-yijinjing-schema-layout-baseline.md
@@ -1,3 +1,13 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+doc_type: architecture-decision
+adr_id: ADR-0008
+decision_status: accepted
+implementation_status: unknown
+review_state: legacy-unreviewed
+sensitivity: public
+---
+
 # ADR-0008: yijinjing schema layout is the v4 greenfield fact contract
 
 - Status: accepted

--- a/framework/core/docs/adr/ADR-0009-load-bearing-self-bootstrap.md
+++ b/framework/core/docs/adr/ADR-0009-load-bearing-self-bootstrap.md
@@ -1,3 +1,13 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+doc_type: architecture-decision
+adr_id: ADR-0009
+decision_status: accepted
+implementation_status: implemented
+review_state: legacy-unreviewed
+sensitivity: public
+---
+
 # ADR-0009: Load-bearing self-bootstrap — the adoption path is the validation path
 
 - Status: accepted (the principle; it names a structure the repository already

--- a/framework/core/docs/adr/ADR-0010-adopt-kfd-1-release-versioning.md
+++ b/framework/core/docs/adr/ADR-0010-adopt-kfd-1-release-versioning.md
@@ -1,3 +1,13 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+doc_type: architecture-decision
+adr_id: ADR-0010
+decision_status: accepted
+implementation_status: unknown
+review_state: legacy-unreviewed
+sensitivity: public
+---
+
 # ADR-0010: adopt KFD-1 — welded-surface registers decide patch, minor, and major
 
 - Status: accepted

--- a/framework/core/docs/adr/ADR-0011-v4-capability-sdk-contract.md
+++ b/framework/core/docs/adr/ADR-0011-v4-capability-sdk-contract.md
@@ -1,3 +1,13 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+doc_type: architecture-decision
+adr_id: ADR-0011
+decision_status: accepted
+implementation_status: implemented
+review_state: legacy-unreviewed
+sensitivity: public
+---
+
 # ADR-0011: v4 capability SDK contract — first cut
 
 - Status: accepted (contract ratified and implemented 2026-07-02: the

--- a/framework/core/docs/adr/ADR-0013-cli-runtime-extension-isolation-trusted-channel.md
+++ b/framework/core/docs/adr/ADR-0013-cli-runtime-extension-isolation-trusted-channel.md
@@ -1,3 +1,13 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+doc_type: architecture-decision
+adr_id: ADR-0013
+decision_status: proposed
+implementation_status: not-started
+review_state: legacy-unreviewed
+sensitivity: public
+---
+
 # ADR-0013: extension isolation and the trusted channel on the runtime plane
 
 - Status: proposed (design accepted 2026-07-04; implementation deferred to a

--- a/framework/core/docs/adr/ADR-0014-extension-execution-contract-uniform-capability-surface.md
+++ b/framework/core/docs/adr/ADR-0014-extension-execution-contract-uniform-capability-surface.md
@@ -1,3 +1,13 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+doc_type: architecture-decision
+adr_id: ADR-0014
+decision_status: accepted
+implementation_status: unknown
+review_state: legacy-unreviewed
+sensitivity: public
+---
+
 # ADR-0014: the extension execution contract — a uniform capability surface across trust tiers
 
 - Status: accepted

--- a/framework/core/docs/adr/ADR-0015-kungfu-skill-agent-context-layer.md
+++ b/framework/core/docs/adr/ADR-0015-kungfu-skill-agent-context-layer.md
@@ -1,3 +1,13 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+doc_type: architecture-decision
+adr_id: ADR-0015
+decision_status: accepted
+implementation_status: unknown
+review_state: legacy-unreviewed
+sensitivity: public
+---
+
 # ADR-0015: Kungfu Skill as the agent context layer above kfx
 
 - Status: accepted

--- a/framework/core/docs/adr/ADR-0016-managed-session-host-placement.md
+++ b/framework/core/docs/adr/ADR-0016-managed-session-host-placement.md
@@ -1,3 +1,13 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+doc_type: architecture-decision
+adr_id: ADR-0016
+decision_status: accepted
+implementation_status: unknown
+review_state: legacy-unreviewed
+sensitivity: public
+---
+
 # ADR-0016: managed session host placement — a shared durable host for multi-window session workspaces
 
 - Status: accepted

--- a/framework/core/docs/adr/ADR-0017-dual-host-kfx-loading-host-agnostic-plan-and-service-facet.md
+++ b/framework/core/docs/adr/ADR-0017-dual-host-kfx-loading-host-agnostic-plan-and-service-facet.md
@@ -1,3 +1,13 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+doc_type: architecture-decision
+adr_id: ADR-0017
+decision_status: proposed
+implementation_status: not-started
+review_state: legacy-unreviewed
+sensitivity: public
+---
+
 # ADR-0017: dual-host kfx loading — a host-agnostic load plan and the background service facet on the OS-sandbox plane
 
 - Status: proposed

--- a/framework/core/docs/adr/ADR-0018-runtime-storage-service-architecture.md
+++ b/framework/core/docs/adr/ADR-0018-runtime-storage-service-architecture.md
@@ -1,3 +1,13 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+doc_type: architecture-decision
+adr_id: ADR-0018
+decision_status: accepted
+implementation_status: unknown
+review_state: legacy-unreviewed
+sensitivity: public
+---
+
 # ADR-0018: Runtime storage service as the persistence contract above journal, payloads, and projections
 
 - Status: accepted

--- a/framework/core/docs/adr/ADR-0019-git-like-source-sync-over-location-and-channel.md
+++ b/framework/core/docs/adr/ADR-0019-git-like-source-sync-over-location-and-channel.md
@@ -1,3 +1,13 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+doc_type: architecture-decision
+adr_id: ADR-0019
+decision_status: accepted
+implementation_status: unknown
+review_state: legacy-unreviewed
+sensitivity: public
+---
+
 # ADR-0019: Git-like source sync over Kungfu location and channel
 
 - Status: accepted

--- a/framework/core/docs/adr/ADR-0020-agent-action-timeline-and-replay-boundary.md
+++ b/framework/core/docs/adr/ADR-0020-agent-action-timeline-and-replay-boundary.md
@@ -1,3 +1,13 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+doc_type: architecture-decision
+adr_id: ADR-0020
+decision_status: accepted
+implementation_status: unknown
+review_state: legacy-unreviewed
+sensitivity: public
+---
+
 # ADR-0020: Agent action timeline and rewind/replay boundary
 
 - Status: accepted

--- a/framework/core/docs/adr/ADR-0021-observer-relative-timeline-projection.md
+++ b/framework/core/docs/adr/ADR-0021-observer-relative-timeline-projection.md
@@ -1,3 +1,13 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+doc_type: architecture-decision
+adr_id: ADR-0021
+decision_status: accepted
+implementation_status: unknown
+review_state: legacy-unreviewed
+sensitivity: public
+---
+
 # ADR-0021: Observer-relative timeline projection over causal facts
 
 - Status: accepted

--- a/framework/core/docs/adr/ADR-0022-core-action-recording-surface.md
+++ b/framework/core/docs/adr/ADR-0022-core-action-recording-surface.md
@@ -1,3 +1,13 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+doc_type: architecture-decision
+adr_id: ADR-0022
+decision_status: accepted
+implementation_status: unknown
+review_state: legacy-unreviewed
+sensitivity: public
+---
+
 # ADR-0022: Core action-recording surface lives in the C++ polyglot membrane
 
 - Status: accepted

--- a/framework/core/docs/adr/ADR-0023-frame-integrity-and-msg-type-allocation-gates.md
+++ b/framework/core/docs/adr/ADR-0023-frame-integrity-and-msg-type-allocation-gates.md
@@ -1,3 +1,13 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+doc_type: architecture-decision
+adr_id: ADR-0023
+decision_status: accepted
+implementation_status: unknown
+review_state: legacy-unreviewed
+sensitivity: public
+---
+
 # ADR-0023: frame integrity starts at the C++ recorder and raw carrier_type allocation is gated
 
 - Status: accepted

--- a/framework/core/docs/adr/ADR-0024-location-role-and-journal-page-policy.md
+++ b/framework/core/docs/adr/ADR-0024-location-role-and-journal-page-policy.md
@@ -1,3 +1,13 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+doc_type: architecture-decision
+adr_id: ADR-0024
+decision_status: accepted
+implementation_status: unknown
+review_state: legacy-unreviewed
+sensitivity: public
+---
+
 # ADR-0024: location role replaces trading category and journal page size is storage policy
 
 - Status: accepted

--- a/framework/core/docs/adr/ADR-0025-carrier-type-and-action-envelope-semantics.md
+++ b/framework/core/docs/adr/ADR-0025-carrier-type-and-action-envelope-semantics.md
@@ -1,3 +1,13 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+doc_type: architecture-decision
+adr_id: ADR-0025
+decision_status: accepted
+implementation_status: unknown
+review_state: legacy-unreviewed
+sensitivity: public
+---
+
 # ADR-0025: carrier type is transport metadata and business semantics live in action envelopes
 
 ## Status

--- a/framework/core/docs/adr/ADR-0026-runtime-greenfield-core-surface.md
+++ b/framework/core/docs/adr/ADR-0026-runtime-greenfield-core-surface.md
@@ -1,3 +1,13 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+doc_type: architecture-decision
+adr_id: ADR-0026
+decision_status: accepted
+implementation_status: unknown
+review_state: legacy-unreviewed
+sensitivity: public
+---
+
 # ADR-0026: runtime exposes a greenfield core surface, not trading typed helpers
 
 ## Status

--- a/framework/core/docs/adr/ADR-0027-python-yijinjing-public-core-types.md
+++ b/framework/core/docs/adr/ADR-0027-python-yijinjing-public-core-types.md
@@ -1,3 +1,13 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+doc_type: architecture-decision
+adr_id: ADR-0027
+decision_status: accepted
+implementation_status: unknown
+review_state: legacy-unreviewed
+sensitivity: public
+---
+
 # ADR-0027: Python yijinjing schema exposes only core public runtime types
 
 ## Status

--- a/framework/core/docs/adr/ADR-0028-hash-taxonomy-and-integrity-algorithms.md
+++ b/framework/core/docs/adr/ADR-0028-hash-taxonomy-and-integrity-algorithms.md
@@ -1,3 +1,13 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+doc_type: architecture-decision
+adr_id: ADR-0028
+decision_status: accepted
+implementation_status: unknown
+review_state: legacy-unreviewed
+sensitivity: public
+---
+
 # ADR-0028: hash taxonomy separates internal ids, frame checksums, and content hashes
 
 - Status: accepted

--- a/framework/core/docs/adr/ADR-0029-frame-checksum-v2-crc32c.md
+++ b/framework/core/docs/adr/ADR-0029-frame-checksum-v2-crc32c.md
@@ -1,3 +1,13 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+doc_type: architecture-decision
+adr_id: ADR-0029
+decision_status: accepted
+implementation_status: unknown
+review_state: legacy-unreviewed
+sensitivity: public
+---
+
 # ADR-0029: frame checksum v2 uses CRC32C receipt metadata
 
 - Status: accepted

--- a/framework/core/docs/adr/ADR-0030-manifest-scoped-sync-root-v1.md
+++ b/framework/core/docs/adr/ADR-0030-manifest-scoped-sync-root-v1.md
@@ -1,3 +1,13 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+doc_type: architecture-decision
+adr_id: ADR-0030
+decision_status: accepted
+implementation_status: unknown
+review_state: legacy-unreviewed
+sensitivity: public
+---
+
 # ADR-0030: manifest-scoped sync root v1
 
 - Status: accepted

--- a/framework/core/docs/adr/ADR-0031-fast-hash-xxh3.md
+++ b/framework/core/docs/adr/ADR-0031-fast-hash-xxh3.md
@@ -1,3 +1,13 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+doc_type: architecture-decision
+adr_id: ADR-0031
+decision_status: accepted
+implementation_status: unknown
+review_state: legacy-unreviewed
+sensitivity: public
+---
+
 # ADR-0031: fast internal hashes use XXH3
 
 - Status: accepted

--- a/framework/core/docs/adr/ADR-0032-generic-source-service-v1.md
+++ b/framework/core/docs/adr/ADR-0032-generic-source-service-v1.md
@@ -1,3 +1,13 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+doc_type: architecture-decision
+adr_id: ADR-0032
+decision_status: accepted
+implementation_status: unknown
+review_state: legacy-unreviewed
+sensitivity: public
+---
+
 # ADR-0032: generic source service v1
 
 - Status: accepted

--- a/framework/core/docs/adr/ADR-0033-episode-causal-segment-object.md
+++ b/framework/core/docs/adr/ADR-0033-episode-causal-segment-object.md
@@ -1,3 +1,13 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+doc_type: architecture-decision
+adr_id: ADR-0033
+decision_status: accepted
+implementation_status: unknown
+review_state: legacy-unreviewed
+sensitivity: public
+---
+
 # ADR-0033: Episode is the first-class causal segment object
 
 - Status: accepted

--- a/framework/core/docs/adr/ADR-0034-yijinjing-episode-manifest-journal.md
+++ b/framework/core/docs/adr/ADR-0034-yijinjing-episode-manifest-journal.md
@@ -1,3 +1,13 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+doc_type: architecture-decision
+adr_id: ADR-0034
+decision_status: accepted
+implementation_status: unknown
+review_state: legacy-unreviewed
+sensitivity: public
+---
+
 # ADR-0034: Episode manifest records live in the yijinjing journal format
 
 - Status: accepted

--- a/framework/core/docs/adr/ADR-0035-workspace-local-kungfu-data-home.md
+++ b/framework/core/docs/adr/ADR-0035-workspace-local-kungfu-data-home.md
@@ -1,3 +1,13 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+doc_type: architecture-decision
+adr_id: ADR-0035
+decision_status: accepted
+implementation_status: unknown
+review_state: legacy-unreviewed
+sensitivity: public
+---
+
 # ADR-0035: Workspace-local `.kungfu` is the default fact ledger home
 
 - Status: accepted

--- a/framework/core/docs/adr/ADR-0036-supervisor-and-workspace-master-topology.md
+++ b/framework/core/docs/adr/ADR-0036-supervisor-and-workspace-master-topology.md
@@ -1,3 +1,13 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+doc_type: architecture-decision
+adr_id: ADR-0036
+decision_status: superseded
+implementation_status: not-applicable
+review_state: legacy-unreviewed
+sensitivity: public
+---
+
 # ADR-0036: Per-user supervisor manages per-data-root masters
 
 - Status: superseded by [ADR-0057](ADR-0057-domain-neutral-live-runtime-terminology.md)

--- a/framework/core/docs/adr/ADR-0037-storage-records-hana-core-kernel-metadata.md
+++ b/framework/core/docs/adr/ADR-0037-storage-records-hana-core-kernel-metadata.md
@@ -1,3 +1,13 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+doc_type: architecture-decision
+adr_id: ADR-0037
+decision_status: accepted
+implementation_status: implemented
+review_state: legacy-unreviewed
+sensitivity: public
+---
+
 # ADR-0037: ADR-0018 storage-service records are Hana-core kernel metadata; JSON is an edge projection, not the contract
 
 - Status: accepted; record/journal/projection and typed service migration delivered

--- a/framework/core/docs/adr/ADR-0038-location-namespace-terminology.md
+++ b/framework/core/docs/adr/ADR-0038-location-namespace-terminology.md
@@ -1,3 +1,13 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+doc_type: architecture-decision
+adr_id: ADR-0038
+decision_status: accepted
+implementation_status: unknown
+review_state: legacy-unreviewed
+sensitivity: public
+---
+
 # ADR-0038: location middle identity segment is namespace
 
 - Status: accepted

--- a/framework/core/docs/adr/ADR-0039-unified-view-interface-encapsulates-flatbuffers.md
+++ b/framework/core/docs/adr/ADR-0039-unified-view-interface-encapsulates-flatbuffers.md
@@ -1,3 +1,13 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+doc_type: architecture-decision
+adr_id: ADR-0039
+decision_status: accepted
+implementation_status: unknown
+review_state: legacy-unreviewed
+sensitivity: public
+---
+
 # ADR-0039: a single kungfu view interface is the sole FlatBuffers access point; raw FB is not called elsewhere
 
 - Status: accepted

--- a/framework/core/docs/adr/ADR-0040-runtime-fact-ledger-content-addressed-kv.md
+++ b/framework/core/docs/adr/ADR-0040-runtime-fact-ledger-content-addressed-kv.md
@@ -1,3 +1,13 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+doc_type: architecture-decision
+adr_id: ADR-0040
+decision_status: proposed
+implementation_status: not-started
+review_state: legacy-unreviewed
+sensitivity: public
+---
+
 # ADR-0040: a first-class content-addressed store is a runtime fact-ledger primitive, with mutable KV and fleet topology kept as separate capabilities
 
 - Status: proposed

--- a/framework/core/docs/adr/ADR-0041-episode-manifest-first-class-journal-structure.md
+++ b/framework/core/docs/adr/ADR-0041-episode-manifest-first-class-journal-structure.md
@@ -1,3 +1,13 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+doc_type: architecture-decision
+adr_id: ADR-0041
+decision_status: proposed
+implementation_status: not-started
+review_state: legacy-unreviewed
+sensitivity: public
+---
+
 # ADR-0041: the Episode manifest is the object's trust boundary — POD journal records, one typed fold, and JSON at the edge
 
 - Status: proposed

--- a/framework/core/docs/adr/ADR-0042-episode-atomic-safety-and-qualification.md
+++ b/framework/core/docs/adr/ADR-0042-episode-atomic-safety-and-qualification.md
@@ -1,13 +1,16 @@
 ---
-status: draft
+metadata_schema: kungfu.document-metadata/v1
+doc_type: architecture-decision
+adr_id: ADR-0042
+decision_status: proposed
+implementation_status: not-started
+review_state: self-reviewed
+sensitivity: public
+sources: [local-files, user-consensus]
 period: 2026-07-10
 theme: episode-atomic-safety
-doc_type: architecture-decision
-source_level: user-consensus + local-files
 confidence: high
-sensitivity: public
 evidence_grade: B
-review_state: self-reviewed
 last_reviewed: 2026-07-10
 ai_provenance:
   model_family: GPT-5

--- a/framework/core/docs/adr/ADR-0043-episode-identity-sealed-content-root.md
+++ b/framework/core/docs/adr/ADR-0043-episode-identity-sealed-content-root.md
@@ -1,3 +1,13 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+doc_type: architecture-decision
+adr_id: ADR-0043
+decision_status: proposed
+implementation_status: not-started
+review_state: legacy-unreviewed
+sensitivity: public
+---
+
 # ADR-0043: Episode identity is two layers — a local coordinate plus a sealed content root committed in the manifest
 
 - Status: proposed

--- a/framework/core/docs/adr/ADR-0044-shifu-delegation-protocol.md
+++ b/framework/core/docs/adr/ADR-0044-shifu-delegation-protocol.md
@@ -1,3 +1,13 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+doc_type: architecture-decision
+adr_id: ADR-0044
+decision_status: accepted
+implementation_status: unknown
+review_state: legacy-unreviewed
+sensitivity: public
+---
+
 # ADR-0044: The shifu delegation protocol — what installed binaries bake in forever
 
 - Status: accepted

--- a/framework/core/docs/adr/ADR-0045-kfx-execution-profiles-native-rust-wasm.md
+++ b/framework/core/docs/adr/ADR-0045-kfx-execution-profiles-native-rust-wasm.md
@@ -1,13 +1,16 @@
 ---
-status: accepted
+metadata_schema: kungfu.document-metadata/v1
+doc_type: architecture-decision
+adr_id: ADR-0045
+decision_status: accepted
+implementation_status: implemented
+review_state: maintainer-reviewed
+sensitivity: public
+sources: [local-files, official-upstream]
 period: 2026-07-10
 theme: kfx-execution-profiles
-doc_type: architecture-decision
-source_level: local-files + official-upstream
 confidence: high
-sensitivity: public
 evidence_grade: B
-review_state: user-reviewed
 last_reviewed: 2026-07-11
 ---
 

--- a/framework/core/docs/adr/ADR-0046-rust-host-trunk-and-assembled-runtime.md
+++ b/framework/core/docs/adr/ADR-0046-rust-host-trunk-and-assembled-runtime.md
@@ -1,3 +1,13 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+doc_type: architecture-decision
+adr_id: ADR-0046
+decision_status: accepted
+implementation_status: staged
+review_state: legacy-unreviewed
+sensitivity: public
+---
+
 # ADR-0046: Rust host trunk, layered CLI, and the assembled runtime distribution
 
 - Status: accepted (target architecture; adoption is staged — see "Adoption

--- a/framework/core/docs/adr/ADR-0047-authoritative-facts-hana-pod-or-flatbuffers.md
+++ b/framework/core/docs/adr/ADR-0047-authoritative-facts-hana-pod-or-flatbuffers.md
@@ -1,3 +1,13 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+doc_type: architecture-decision
+adr_id: ADR-0047
+decision_status: accepted
+implementation_status: implemented
+review_state: legacy-unreviewed
+sensitivity: public
+---
+
 # ADR-0047: authoritative structured facts have one schema owner — Hana POD or FlatBuffers
 
 - Status: accepted; implemented and enforced

--- a/framework/core/docs/adr/ADR-0048-runtime-fact-query-semantics-and-changelog.md
+++ b/framework/core/docs/adr/ADR-0048-runtime-fact-query-semantics-and-changelog.md
@@ -1,3 +1,13 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+doc_type: architecture-decision
+adr_id: ADR-0048
+decision_status: accepted
+implementation_status: staged
+review_state: legacy-unreviewed
+sensitivity: public
+---
+
 # ADR-0048: runtime fact queries use explicit bases, one logical plan, and a proof-carrying changelog
 
 - Status: accepted; implementation staged

--- a/framework/core/docs/adr/ADR-0049-layer-complete-products-and-domain-neutral-core.md
+++ b/framework/core/docs/adr/ADR-0049-layer-complete-products-and-domain-neutral-core.md
@@ -1,3 +1,13 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+doc_type: architecture-decision
+adr_id: ADR-0049
+decision_status: accepted
+implementation_status: staged
+review_state: legacy-unreviewed
+sensitivity: public
+---
+
 # ADR-0049: every product layer is independently complete and the core remains domain-neutral
 
 - Status: accepted; qualification staged

--- a/framework/core/docs/adr/ADR-0050-assembled-runtime-stdlib-pruning-policy.md
+++ b/framework/core/docs/adr/ADR-0050-assembled-runtime-stdlib-pruning-policy.md
@@ -1,3 +1,13 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+doc_type: architecture-decision
+adr_id: ADR-0050
+decision_status: accepted
+implementation_status: unknown
+review_state: legacy-unreviewed
+sensitivity: public
+---
+
 # ADR-0050: Stdlib pruning policy for the assembled runtime
 
 - Status: accepted

--- a/framework/core/docs/adr/ADR-0051-kfd-contract-world-fact-admission-and-trust.md
+++ b/framework/core/docs/adr/ADR-0051-kfd-contract-world-fact-admission-and-trust.md
@@ -1,3 +1,13 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+doc_type: architecture-decision
+adr_id: ADR-0051
+decision_status: accepted
+implementation_status: implemented
+review_state: legacy-unreviewed
+sensitivity: public
+---
+
 # ADR-0051: KFD contract worlds govern fact admission, historical interpretation, and trust assessment
 
 - Status: accepted; initial fact-admission and trust runtime implemented

--- a/framework/core/docs/adr/ADR-0052-kfd2-assessment-lifecycle-and-executors.md
+++ b/framework/core/docs/adr/ADR-0052-kfd2-assessment-lifecycle-and-executors.md
@@ -1,3 +1,13 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+doc_type: architecture-decision
+adr_id: ADR-0052
+decision_status: accepted
+implementation_status: implemented
+review_state: legacy-unreviewed
+sensitivity: public
+---
+
 # ADR-0052: KFD-2 assessments are claim-triggered jobs coordinated by the workspace coordinator
 
 - Status: accepted; initial runtime implemented

--- a/framework/core/docs/adr/ADR-0053-self-contained-episode-bundles.md
+++ b/framework/core/docs/adr/ADR-0053-self-contained-episode-bundles.md
@@ -1,3 +1,13 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+doc_type: architecture-decision
+adr_id: ADR-0053
+decision_status: proposed
+implementation_status: not-started
+review_state: legacy-unreviewed
+sensitivity: public
+---
+
 # ADR-0053: Episode bundles carry their owned bytes, and import materializes them
 
 - Status: proposed

--- a/framework/core/docs/adr/ADR-0054-libwasm-production-runtime-and-release.md
+++ b/framework/core/docs/adr/ADR-0054-libwasm-production-runtime-and-release.md
@@ -1,13 +1,16 @@
 ---
-status: accepted
+metadata_schema: kungfu.document-metadata/v1
+doc_type: architecture-decision
+adr_id: ADR-0054
+decision_status: accepted
+implementation_status: unknown
+review_state: maintainer-reviewed
+sensitivity: public
+sources: [executable-probe, local-files, official-upstream]
 period: 2026-07-11
 theme: libwasm-production-runtime
-doc_type: architecture-decision
-source_level: local-files + executable-probe + official-upstream
 confidence: high
-sensitivity: public
 evidence_grade: B
-review_state: user-reviewed
 last_reviewed: 2026-07-11
 ai_provenance:
   model_family: GPT-5

--- a/framework/core/docs/adr/ADR-0055-retire-journal-session-and-separate-runtime-state-from-projection.md
+++ b/framework/core/docs/adr/ADR-0055-retire-journal-session-and-separate-runtime-state-from-projection.md
@@ -1,3 +1,13 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+doc_type: architecture-decision
+adr_id: ADR-0055
+decision_status: accepted
+implementation_status: implemented
+review_state: legacy-unreviewed
+sensitivity: public
+---
+
 # ADR-0055: retire journal Session and separate live state from schema projections
 
 - Status: accepted; implemented

--- a/framework/core/docs/adr/ADR-0056-retire-legacy-journal-cli-lifecycle-tools.md
+++ b/framework/core/docs/adr/ADR-0056-retire-legacy-journal-cli-lifecycle-tools.md
@@ -1,13 +1,16 @@
 ---
-status: accepted
+metadata_schema: kungfu.document-metadata/v1
+doc_type: architecture-decision
+adr_id: ADR-0056
+decision_status: accepted
+implementation_status: implemented
+review_state: maintainer-reviewed
+sensitivity: public
+sources: [local-files, user-decision]
 period: 2026-07-11
 theme: legacy-journal-cli-retirement
-doc_type: architecture-decision
-source_level: local-files + user-decision
 confidence: high
-sensitivity: public
 evidence_grade: A
-review_state: user-reviewed
 last_reviewed: 2026-07-11
 ---
 

--- a/framework/core/docs/adr/ADR-0057-domain-neutral-live-runtime-terminology.md
+++ b/framework/core/docs/adr/ADR-0057-domain-neutral-live-runtime-terminology.md
@@ -1,13 +1,16 @@
 ---
-status: accepted
+metadata_schema: kungfu.document-metadata/v1
+doc_type: architecture-decision
+adr_id: ADR-0057
+decision_status: accepted
+implementation_status: implemented
+review_state: maintainer-reviewed
+sensitivity: public
+sources: [local-files, user-decision]
 period: 2026-07-11
 theme: domain-neutral-live-runtime-terminology
-doc_type: architecture-decision
-source_level: local-files + user-decision
 confidence: high
-sensitivity: public
 evidence_grade: A
-review_state: user-reviewed
 last_reviewed: 2026-07-11
 ---
 

--- a/framework/core/docs/adr/ADR-0058-yijinjing-explicit-mapping-policies.md
+++ b/framework/core/docs/adr/ADR-0058-yijinjing-explicit-mapping-policies.md
@@ -1,13 +1,16 @@
 ---
-status: accepted
+metadata_schema: kungfu.document-metadata/v1
+doc_type: architecture-decision
+adr_id: ADR-0058
+decision_status: accepted
+implementation_status: implemented
+review_state: maintainer-reviewed
+sensitivity: public
+sources: [local-files, user-decision]
 period: 2026-07-11
 theme: yijinjing-explicit-mapping-policies
-doc_type: architecture-decision
-source_level: local-files + user-decision
 confidence: high
-sensitivity: public
 evidence_grade: A
-review_state: user-reviewed
 last_reviewed: 2026-07-11
 ---
 

--- a/framework/core/docs/adr/ADR-0059-mission-control-mission-go-responsibility-model.md
+++ b/framework/core/docs/adr/ADR-0059-mission-control-mission-go-responsibility-model.md
@@ -1,3 +1,13 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+doc_type: architecture-decision
+adr_id: ADR-0059
+decision_status: accepted
+implementation_status: implemented
+review_state: legacy-unreviewed
+sensitivity: public
+---
+
 # ADR-0059: Mission Control composes Mission and Go responsibility over runtime facts
 
 - Status: accepted; initial Atlas Mission/Go admission implemented; query and

--- a/framework/core/docs/adr/ADR-0060-desktop-workspace-selection-and-lazy-data-home.md
+++ b/framework/core/docs/adr/ADR-0060-desktop-workspace-selection-and-lazy-data-home.md
@@ -1,13 +1,16 @@
 ---
-status: draft
+metadata_schema: kungfu.document-metadata/v1
+doc_type: architecture-decision
+adr_id: ADR-0060
+decision_status: proposed
+implementation_status: not-started
+review_state: unreviewed
+sensitivity: public
+sources: [local-files, user-consensus]
 period: 2026-07-11
 theme: kungfu-workspace-product
-doc_type: decision
-source_level: user-consensus-and-local-files
 confidence: high
-sensitivity: public
 evidence_grade: B
-review_state: unreviewed
 last_reviewed: 2026-07-11
 ai_provenance:
   model_family: GPT-5

--- a/framework/core/docs/adr/ADR-0061-agent-mediated-guidance-is-a-first-class-product-interface.md
+++ b/framework/core/docs/adr/ADR-0061-agent-mediated-guidance-is-a-first-class-product-interface.md
@@ -1,13 +1,16 @@
 ---
-status: draft
+metadata_schema: kungfu.document-metadata/v1
+doc_type: architecture-decision
+adr_id: ADR-0061
+decision_status: proposed
+implementation_status: not-started
+review_state: unreviewed
+sensitivity: public
+sources: [local-files, user-consensus]
 period: 2026-07-11
 theme: kungfu-agent-mediated-product
-doc_type: decision
-source_level: user-consensus-and-local-files
 confidence: high
-sensitivity: public
 evidence_grade: B
-review_state: unreviewed
 last_reviewed: 2026-07-11
 ai_provenance:
   model_family: GPT-5

--- a/framework/core/docs/adr/ADR-0062-journal-container-epoch-and-offline-conversion.md
+++ b/framework/core/docs/adr/ADR-0062-journal-container-epoch-and-offline-conversion.md
@@ -1,3 +1,13 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+doc_type: architecture-decision
+adr_id: ADR-0062
+decision_status: accepted
+implementation_status: implemented
+review_state: legacy-unreviewed
+sensitivity: public
+---
+
 # ADR-0062: the journal container epoch is derived from its layout, and cross-epoch replay is offline conversion
 
 - Status: accepted; implemented

--- a/framework/core/docs/adr/ADR-0063-yijinjing-concurrency-and-lifetime-contract.md
+++ b/framework/core/docs/adr/ADR-0063-yijinjing-concurrency-and-lifetime-contract.md
@@ -1,3 +1,13 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+doc_type: architecture-decision
+adr_id: ADR-0063
+decision_status: proposed
+implementation_status: not-started
+review_state: legacy-unreviewed
+sensitivity: public
+---
+
 # ADR-0063: yijinjing separates lock-free publication from cursor, write, and page-lifetime ownership
 
 - Status: proposed

--- a/framework/core/docs/adr/ADR-0064-runtime-error-propagation-and-stop-ownership.md
+++ b/framework/core/docs/adr/ADR-0064-runtime-error-propagation-and-stop-ownership.md
@@ -1,3 +1,13 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+doc_type: architecture-decision
+adr_id: ADR-0064
+decision_status: proposed
+implementation_status: not-started
+review_state: legacy-unreviewed
+sensitivity: public
+---
+
 # ADR-0064: runtime libraries propagate structured errors; loop owners decide how execution stops
 
 - Status: proposed

--- a/framework/core/docs/adr/ADR-0065-schema-registry-consolidation.md
+++ b/framework/core/docs/adr/ADR-0065-schema-registry-consolidation.md
@@ -1,3 +1,13 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+doc_type: architecture-decision
+adr_id: ADR-0065
+decision_status: proposed
+implementation_status: not-started
+review_state: legacy-unreviewed
+sensitivity: public
+---
+
 # ADR-0065: the schema type registry has one authoritative set and trait-derived subsets
 
 - Status: proposed

--- a/framework/core/docs/adr/ADR-0066-native-cpp-toolchain-contract-and-modules-hold.md
+++ b/framework/core/docs/adr/ADR-0066-native-cpp-toolchain-contract-and-modules-hold.md
@@ -1,13 +1,16 @@
 ---
-status: accepted
+metadata_schema: kungfu.document-metadata/v1
+doc_type: architecture-decision
+adr_id: ADR-0066
+decision_status: accepted
+implementation_status: unknown
+review_state: self-reviewed
+sensitivity: public
+sources: [local-files]
 period: ongoing
 theme: kungfu-cpp-modernization
-doc_type: decision
-source_level: local-files
 confidence: high
-sensitivity: public
 evidence_grade: A
-review_state: self-reviewed
 last_reviewed: 2026-07-12
 ai_provenance:
   model_family: GPT-5

--- a/framework/core/docs/adr/ADR-0067-schema-registry-compile-time-contract-welds.md
+++ b/framework/core/docs/adr/ADR-0067-schema-registry-compile-time-contract-welds.md
@@ -1,3 +1,13 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+doc_type: architecture-decision
+adr_id: ADR-0067
+decision_status: accepted
+implementation_status: not-started
+review_state: legacy-unreviewed
+sensitivity: public
+---
+
 # ADR-0067: schema-registry contract invariants are welded at compile time — tag uniqueness and payload layout↔version binding
 
 - Status: accepted; not yet implemented

--- a/framework/core/docs/adr/ADR-0068-tiered-durability-and-crash-recovery.md
+++ b/framework/core/docs/adr/ADR-0068-tiered-durability-and-crash-recovery.md
@@ -1,13 +1,16 @@
 ---
-status: accepted
+metadata_schema: kungfu.document-metadata/v1
+doc_type: architecture-decision
+adr_id: ADR-0068
+decision_status: accepted
+implementation_status: staged
+review_state: self-reviewed
+sensitivity: public
+sources: [local-files, user-consensus]
 period: 2026-07-12
 theme: tiered-durability-and-crash-recovery
-doc_type: architecture-decision
-source_level: user-consensus + local-files
 confidence: high
-sensitivity: public
 evidence_grade: B
-review_state: self-reviewed
 last_reviewed: 2026-07-12
 ai_provenance:
   model_family: GPT-5

--- a/framework/core/docs/adr/ADR-0069-agent-first-kfx-profile-suite-runtime.md
+++ b/framework/core/docs/adr/ADR-0069-agent-first-kfx-profile-suite-runtime.md
@@ -1,13 +1,16 @@
 ---
-status: accepted
+metadata_schema: kungfu.document-metadata/v1
+doc_type: architecture-decision
+adr_id: ADR-0069
+decision_status: accepted
+implementation_status: staged
+review_state: self-reviewed
+sensitivity: public
+sources: [local-files, user-consensus]
 period: 2026-07-13
 theme: agent-first-kfx-profile-suite-runtime
-doc_type: architecture-decision
-source_level: user-consensus + local-files
 confidence: high
-sensitivity: public
 evidence_grade: B
-review_state: self-reviewed
 last_reviewed: 2026-07-13
 ai_provenance:
   model_family: GPT-5

--- a/framework/core/docs/adr/README.md
+++ b/framework/core/docs/adr/README.md
@@ -1,3 +1,11 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+document_status: active
+doc_type: adr-index
+review_state: unreviewed
+sensitivity: public
+---
+
 # Architecture Decision Records
 
 This directory records the significant architecture and design decisions behind
@@ -15,6 +23,12 @@ A record's **Status** says where it stands:
 - **superseded** — retained as historical decision evidence, but replaced for
   current design by the ADR it names.
 
+ADR frontmatter is the machine authority. The body status and this index are
+human-readable projections checked by `./shifu docs:check`. Decision state,
+implementation state, and review state are separate fields; see the
+[Document Metadata Contract](../../../../docs/document-metadata.md). Do not add
+compound implementation notes to the index Status column.
+
 ## Index
 
 | ADR | Status | Title |
@@ -26,12 +40,12 @@ A record's **Status** says where it stands:
 | [0005](ADR-0005-control-event-axis-modernization-assessment.md) | proposed | control / event axis modernization — a meta-assessment |
 | [0006](ADR-0006-v4-frontend-platform-architecture.md) | accepted | v4 frontend = platform (capability SDK + loose kfx contract) + minimal reference app |
 | [0007](ADR-0007-v4-tui-platform-reference-surface.md) | accepted | v4 TUI = the platform's second reference surface |
-| [0008](ADR-0008-yijinjing-schema-layout-baseline.md) | proposed | yijinjing schema binary layout as the true compatibility invariant; schema-evolution policy |
+| [0008](ADR-0008-yijinjing-schema-layout-baseline.md) | accepted | yijinjing schema binary layout as the true compatibility invariant; schema-evolution policy |
 | [0009](ADR-0009-load-bearing-self-bootstrap.md) | accepted | load-bearing self-bootstrap — the adoption path is the validation path |
 | [0010](ADR-0010-adopt-kfd-1-release-versioning.md) | accepted | adopt KFD-1 — welded-surface registers decide patch, minor, and major |
 | [0011](ADR-0011-v4-capability-sdk-contract.md) | accepted | v4 capability SDK contract — two vocabulary domains, runtime-tier declaration, five consumer-driven handles |
 | [0013](ADR-0013-cli-runtime-extension-isolation-trusted-channel.md) | proposed | extension isolation and the trusted channel on the runtime plane — trust by verifiable origin, default-deny OS sandbox, zero-copy only for the trusted channel |
-| [0014](ADR-0014-extension-execution-contract-uniform-capability-surface.md) | proposed | the extension execution contract — one uniform capability surface across trust tiers, restriction as transparent interception, a binding-less guest host |
+| [0014](ADR-0014-extension-execution-contract-uniform-capability-surface.md) | accepted | the extension execution contract — one uniform capability surface across trust tiers, restriction as transparent interception, a binding-less guest host |
 | [0015](ADR-0015-kungfu-skill-agent-context-layer.md) | accepted | Kungfu Skill as the agent context layer above kfx |
 | [0016](ADR-0016-managed-session-host-placement.md) | accepted | managed session host placement — move the durable session host to main so multiple OS windows share it |
 | [0017](ADR-0017-dual-host-kfx-loading-host-agnostic-plan-and-service-facet.md) | proposed | dual-host kfx loading — a host-agnostic load plan shared by GUI and CLI, and the background `service` facet as the first OS-sandbox caller |
@@ -53,10 +67,10 @@ A record's **Status** says where it stands:
 | [0033](ADR-0033-episode-causal-segment-object.md) | accepted | Episode is the first-class causal segment object |
 | [0034](ADR-0034-yijinjing-episode-manifest-journal.md) | accepted | Episode manifest records live in the yijinjing journal format |
 | [0035](ADR-0035-workspace-local-kungfu-data-home.md) | accepted | Workspace-local `.kungfu` is the default fact ledger home |
-| [0036](ADR-0036-supervisor-and-workspace-master-topology.md) | superseded by 0057 | Established the per-user supervisor and per-data-root coordinator topology |
+| [0036](ADR-0036-supervisor-and-workspace-master-topology.md) | superseded | Established the per-user supervisor and per-data-root coordinator topology |
 | [0037](ADR-0037-storage-records-hana-core-kernel-metadata.md) | accepted | ADR-0018 storage-service records are Hana-core kernel metadata; JSON is an edge projection, not the contract |
 | [0038](ADR-0038-location-namespace-terminology.md) | accepted | Location middle identity segment is namespace |
-| [0039](ADR-0039-unified-view-interface-encapsulates-flatbuffers.md) | proposed | a single kungfu view interface is the sole FlatBuffers access point; raw FB is not called elsewhere |
+| [0039](ADR-0039-unified-view-interface-encapsulates-flatbuffers.md) | accepted | a single kungfu view interface is the sole FlatBuffers access point; raw FB is not called elsewhere |
 | [0040](ADR-0040-runtime-fact-ledger-content-addressed-kv.md) | proposed | a first-class content-addressed store is a runtime fact-ledger primitive, with mutable KV and fleet topology kept as separate capabilities |
 | [0041](ADR-0041-episode-manifest-first-class-journal-structure.md) | proposed | the Episode manifest is the object's trust boundary — POD journal records, one typed fold, and JSON at the edge |
 | [0042](ADR-0042-episode-atomic-safety-and-qualification.md) | proposed | Episode is the atomic safety and fault-containment unit, qualified by evidence under load |
@@ -64,12 +78,12 @@ A record's **Status** says where it stands:
 | [0044](ADR-0044-shifu-delegation-protocol.md) | accepted | The shifu delegation protocol — what installed binaries bake in forever |
 | [0045](ADR-0045-kfx-execution-profiles-native-rust-wasm.md) | accepted | KFX execution profiles — Rust-primary native, WebAssembly components, managed runtimes, and subprocesses |
 | [0046](ADR-0046-rust-host-trunk-and-assembled-runtime.md) | accepted | Rust host trunk, layered CLI, and the assembled runtime distribution |
-| [0047](ADR-0047-authoritative-facts-hana-pod-or-flatbuffers.md) | accepted; staged | authoritative structured facts have one schema owner — Hana POD or FlatBuffers |
-| [0048](ADR-0048-runtime-fact-query-semantics-and-changelog.md) | accepted; staged | runtime fact queries use explicit bases, one logical plan, and a proof-carrying changelog |
-| [0049](ADR-0049-layer-complete-products-and-domain-neutral-core.md) | accepted; staged | every product layer is independently complete and the core remains domain-neutral |
+| [0047](ADR-0047-authoritative-facts-hana-pod-or-flatbuffers.md) | accepted | authoritative structured facts have one schema owner — Hana POD or FlatBuffers |
+| [0048](ADR-0048-runtime-fact-query-semantics-and-changelog.md) | accepted | runtime fact queries use explicit bases, one logical plan, and a proof-carrying changelog |
+| [0049](ADR-0049-layer-complete-products-and-domain-neutral-core.md) | accepted | every product layer is independently complete and the core remains domain-neutral |
 | [0050](ADR-0050-assembled-runtime-stdlib-pruning-policy.md) | accepted | stdlib pruning policy for the assembled runtime — family-level subtraction, declarative fail-closed manifest |
-| [0051](ADR-0051-kfd-contract-world-fact-admission-and-trust.md) | accepted; staged | KFD contract worlds govern fact admission, historical interpretation, and trust assessment |
-| [0052](ADR-0052-kfd2-assessment-lifecycle-and-executors.md) | accepted; staged | KFD-2 assessments are claim-triggered jobs coordinated by the workspace coordinator |
+| [0051](ADR-0051-kfd-contract-world-fact-admission-and-trust.md) | accepted | KFD contract worlds govern fact admission, historical interpretation, and trust assessment |
+| [0052](ADR-0052-kfd2-assessment-lifecycle-and-executors.md) | accepted | KFD-2 assessments are claim-triggered jobs coordinated by the workspace coordinator |
 | [0053](ADR-0053-self-contained-episode-bundles.md) | proposed | Episode bundles carry their owned bytes, and import materializes them |
 | [0054](ADR-0054-libwasm-production-runtime-and-release.md) | accepted | libwasm is a governed product runtime, not a copied spike library |
 | [0055](ADR-0055-retire-journal-session-and-separate-runtime-state-from-projection.md) | accepted | retire journal Session; separate live state from schema projections |
@@ -79,14 +93,14 @@ A record's **Status** says where it stands:
 | [0059](ADR-0059-mission-control-mission-go-responsibility-model.md) | accepted | Mission Control composes Mission and Go responsibility over runtime facts; Atlas starts as a bridged authority |
 | [0060](ADR-0060-desktop-workspace-selection-and-lazy-data-home.md) | proposed | Desktop and CLI select Home or a project workspace and create its data home only on qualified write intent |
 | [0061](ADR-0061-agent-mediated-guidance-is-a-first-class-product-interface.md) | proposed | Agent-mediated guidance is a first-class interface over shared advice, preview, authorization, action, and receipt contracts |
-| [0062](ADR-0062-journal-container-epoch-and-offline-conversion.md) | accepted; implemented | the journal container epoch is derived from its layout; cross-epoch replay is deferred offline conversion, not an online adapter |
+| [0062](ADR-0062-journal-container-epoch-and-offline-conversion.md) | accepted | the journal container epoch is derived from its layout; cross-epoch replay is deferred offline conversion, not an online adapter |
 | [0063](ADR-0063-yijinjing-concurrency-and-lifetime-contract.md) | proposed | yijinjing separates lock-free publication from cursor, write, and page-lifetime ownership |
 | [0064](ADR-0064-runtime-error-propagation-and-stop-ownership.md) | proposed | runtime libraries propagate structured errors; loop owners decide how execution stops |
 | [0065](ADR-0065-schema-registry-consolidation.md) | proposed | the schema type registry has one authoritative set and trait-derived subsets; numeric tag comments retired; `msg_type` vocabulary finished except the frozen v1 embedding ABI |
 | [0066](ADR-0066-native-cpp-toolchain-contract-and-modules-hold.md) | accepted | native compilers share one C++ contract; modules remain qualification-only |
-| [0067](ADR-0067-schema-registry-compile-time-contract-welds.md) | accepted; not yet implemented | schema contract invariants welded at compile time — `carrier_type` tag uniqueness and payload layout↔`schema_version` binding (reusing the ADR-0062 fingerprint) |
-| [0068](ADR-0068-tiered-durability-and-crash-recovery.md) | accepted; staged | tiered durability separates hot mmap visibility, durable fact admission, rebuildable projections, and later replication |
-| [0069](ADR-0069-agent-first-kfx-profile-suite-runtime.md) | accepted; staged | Agent-first KFX Profile Suites carry domain semantics over a domain-neutral Core |
+| [0067](ADR-0067-schema-registry-compile-time-contract-welds.md) | accepted | schema contract invariants welded at compile time — `carrier_type` tag uniqueness and payload layout↔`schema_version` binding (reusing the ADR-0062 fingerprint) |
+| [0068](ADR-0068-tiered-durability-and-crash-recovery.md) | accepted | tiered durability separates hot mmap visibility, durable fact admission, rebuildable projections, and later replication |
+| [0069](ADR-0069-agent-first-kfx-profile-suite-runtime.md) | accepted | Agent-first KFX Profile Suites carry domain semantics over a domain-neutral Core |
 
 ## Reading by theme
 

--- a/framework/core/docs/carrier-type-registry.md
+++ b/framework/core/docs/carrier-type-registry.md
@@ -1,13 +1,14 @@
 ---
-status: draft
+metadata_schema: kungfu.document-metadata/v1
+document_status: draft
+doc_type: design
+review_state: unreviewed
+sensitivity: internal
+sources: [local-files]
 period: 2026-07-08
 theme: kungfu-v4-carrier-type-registry
-doc_type: design
-source_level: local-files
 confidence: high
-sensitivity: internal
 evidence_grade: B
-review_state: active
 last_reviewed: 2026-07-11
 ai_provenance:
   generated_by: Codex

--- a/framework/core/docs/qualification/mmap-performance.md
+++ b/framework/core/docs/qualification/mmap-performance.md
@@ -1,13 +1,14 @@
 ---
-status: draft
+metadata_schema: kungfu.document-metadata/v1
+document_status: draft
+doc_type: qualification-contract
+review_state: self-reviewed
+sensitivity: public
+sources: [local-files, user-decision]
 period: 2026-07-11
 theme: yijinjing-mmap-performance-qualification
-doc_type: qualification-contract
-source_level: local-files + user-decision
 confidence: high
-sensitivity: public
 evidence_grade: B
-review_state: self-reviewed
 last_reviewed: 2026-07-11
 ai_provenance:
   model_family: GPT-5

--- a/framework/core/docs/strong-durability-and-crash-recovery-design.md
+++ b/framework/core/docs/strong-durability-and-crash-recovery-design.md
@@ -1,13 +1,14 @@
 ---
-status: draft
+metadata_schema: kungfu.document-metadata/v1
+document_status: draft
+doc_type: design
+review_state: self-reviewed
+sensitivity: public
+sources: [local-files, user-consensus]
 period: 2026-07-12
 theme: strong-durability-and-crash-recovery
-doc_type: design
-source_level: user-consensus + local-files
 confidence: high
-sensitivity: public
 evidence_grade: B
-review_state: self-reviewed
 last_reviewed: 2026-07-12
 ai_provenance:
   model_family: GPT-5

--- a/framework/core/slices/libwasm-shared-membrane/README.md
+++ b/framework/core/slices/libwasm-shared-membrane/README.md
@@ -1,13 +1,14 @@
 ---
-status: draft
+metadata_schema: kungfu.document-metadata/v1
+document_status: draft
+doc_type: analysis
+review_state: unreviewed
+sensitivity: public
+sources: [executable-probe, local-files]
 period: 2026-07-11
 theme: libwasm-shared-embedding-membrane
-doc_type: analysis
-source_level: local-files + executable-probe
 confidence: high
-sensitivity: public
 evidence_grade: B
-review_state: unreviewed
 last_reviewed: 2026-07-11
 ai_provenance:
   model_family: GPT-5

--- a/framework/core/slices/native-storage-closure/README.md
+++ b/framework/core/slices/native-storage-closure/README.md
@@ -1,13 +1,14 @@
 ---
-status: active
+metadata_schema: kungfu.document-metadata/v1
+document_status: active
+doc_type: analysis
+review_state: self-reviewed
+sensitivity: internal
+sources: [local-files]
 period: 2026-07-11
 theme: adr-0049-native-storage-closure
-doc_type: analysis
-source_level: local-files
 confidence: high
-sensitivity: internal
 evidence_grade: A
-review_state: self-reviewed
 last_reviewed: 2026-07-11
 ai_provenance:
   model_family: GPT-5

--- a/framework/core/slices/shared-embedding-membrane/README.md
+++ b/framework/core/slices/shared-embedding-membrane/README.md
@@ -1,13 +1,14 @@
 ---
-status: active
+metadata_schema: kungfu.document-metadata/v1
+document_status: active
+doc_type: analysis
+review_state: self-reviewed
+sensitivity: internal
+sources: [local-files]
 period: 2026-07-10
 theme: libkungfu-shared-embedding-membrane
-doc_type: analysis
-source_level: local-files
 confidence: high
-sensitivity: internal
 evidence_grade: A
-review_state: self-reviewed
 last_reviewed: 2026-07-11
 ai_provenance:
   model_family: GPT-5

--- a/framework/spec/CONSUMING.md
+++ b/framework/spec/CONSUMING.md
@@ -1,3 +1,11 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+document_status: active
+doc_type: public-document
+review_state: unreviewed
+sensitivity: public
+---
+
 # Consuming `@kungfu-tech/spec` (for `site-libkungfu-dev`)
 
 This is the **connection contract** between the monorepo and the docs site. The

--- a/framework/spec/README.md
+++ b/framework/spec/README.md
@@ -1,3 +1,11 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+document_status: active
+doc_type: public-document
+review_state: unreviewed
+sensitivity: public
+---
+
 # @kungfu-tech/spec
 
 The portable fact-ledger **format spec** bundle for kungfu, and the **manifest

--- a/framework/spec/docs/format-spec.md
+++ b/framework/spec/docs/format-spec.md
@@ -1,3 +1,11 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+document_status: active
+doc_type: public-document
+review_state: unreviewed
+sensitivity: public
+---
+
 # Kungfu Fact-Ledger Format — Spec 0.1 (pre-release draft)
 
 > **Historical walking-skeleton input, not the current normative `.kungfu`

--- a/framework/spec/docs/handbooks/cli.md
+++ b/framework/spec/docs/handbooks/cli.md
@@ -1,3 +1,11 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+document_status: active
+doc_type: public-document
+review_state: unreviewed
+sensitivity: public
+---
+
 # Kungfu CLI handbook
 
 > **Pre-release source guidance.** Public CLI artifacts are not yet a polished

--- a/framework/spec/docs/handbooks/node.md
+++ b/framework/spec/docs/handbooks/node.md
@@ -1,3 +1,11 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+document_status: active
+doc_type: public-document
+review_state: unreviewed
+sensitivity: public
+---
+
 # Node SDK handbook
 
 > **Staged surface.** The Node `@kungfu-tech/storage` source adapter and shared

--- a/framework/spec/docs/handbooks/python.md
+++ b/framework/spec/docs/handbooks/python.md
@@ -1,3 +1,11 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+document_status: active
+doc_type: public-document
+review_state: unreviewed
+sensitivity: public
+---
+
 # Python SDK handbook
 
 > **Staged surface.** The Python `kungfu-storage` source adapter and shared

--- a/framework/spec/docs/overview.md
+++ b/framework/spec/docs/overview.md
@@ -1,3 +1,11 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+document_status: active
+doc_type: public-document
+review_state: unreviewed
+sensitivity: public
+---
+
 # libkungfu portable format surface
 
 This package is the pre-release aggregation surface for a portable Kungfu fact

--- a/scripts/check-docs.mjs
+++ b/scripts/check-docs.mjs
@@ -8,6 +8,7 @@ import { createRequire } from 'node:module';
 import path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
+import { validateDocumentMetadata } from './document-metadata-contract.mjs';
 import { validateVocabularyContract } from './vocabulary-contract.mjs';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
@@ -211,7 +212,7 @@ function hasExactCase(root, absolute) {
 }
 
 /**
- * @param {{root?: string, files?: string[], contract?: DocsContract, vocabularyRegistry?: object | false}} options
+ * @param {{root?: string, files?: string[], contract?: DocsContract, vocabularyRegistry?: object | false, metadataContract?: object | false}} options
  * @returns {Finding[]}
  */
 export function checkDocs(options = {}) {
@@ -228,6 +229,16 @@ export function checkDocs(options = {}) {
           root,
           registry: /** @type {any} */ (options.vocabularyRegistry),
         });
+
+  if (options.metadataContract !== false) {
+    findings.push(
+      ...validateDocumentMetadata({
+        root,
+        files,
+        contract: /** @type {any} */ (options.metadataContract),
+      }),
+    );
+  }
 
   for (const rel of files) {
     const text = fs.readFileSync(path.join(root, rel), 'utf8');

--- a/scripts/check-docs.test.mjs
+++ b/scripts/check-docs.test.mjs
@@ -46,6 +46,7 @@ function run(files) {
       .sort(),
     contract,
     vocabularyRegistry: false,
+    metadataContract: false,
   });
 }
 
@@ -134,6 +135,7 @@ test('rejects undeclared executable examples', () => {
     files: ['README.md', 'docs/guide.md'],
     contract,
     vocabularyRegistry: false,
+    metadataContract: false,
   });
   assert.ok(
     findings.some(
@@ -161,6 +163,7 @@ test('rejects declared executable examples outside the safe argv allowlist', () 
     files: ['README.md', 'docs/guide.md'],
     contract: unsafe,
     vocabularyRegistry: false,
+    metadataContract: false,
   });
   assert.ok(
     findings.some((finding) => finding.code === 'executable-example-unsafe'),

--- a/scripts/document-metadata-contract.mjs
+++ b/scripts/document-metadata-contract.mjs
@@ -1,0 +1,331 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: Apache-2.0
+// @ts-check
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const DEFAULT_CONTRACT = 'docs/document-metadata.contract.json';
+
+/** @typedef {{code: string, file: string, line: number, message: string}} Finding */
+/**
+ * @typedef {{
+ *   id: string,
+ *   files?: string[],
+ *   patterns?: string[],
+ *   frontmatterRequired: boolean,
+ *   required: string[],
+ *   constants?: Record<string, string>,
+ *   enums?: Record<string, string[]>,
+ *   forbidden?: string[]
+ * }} MetadataProfile
+ */
+/**
+ * @typedef {{
+ *   schemaVersion: number,
+ *   metadataSchema: string,
+ *   sourceKinds?: string[],
+ *   externalFrontmatterSchemas: {id: string, patterns: string[]}[],
+ *   profiles: MetadataProfile[],
+ *   adrRegistries: {index: string, recordPattern: string}[]
+ * }} MetadataContract
+ */
+
+/** @param {string} value */
+function parseScalar(value) {
+  const trimmed = value.trim();
+  if (
+    (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+    (trimmed.startsWith("'") && trimmed.endsWith("'"))
+  ) {
+    return trimmed.slice(1, -1);
+  }
+  if (trimmed.startsWith('[') && trimmed.endsWith(']')) {
+    const body = trimmed.slice(1, -1).trim();
+    return body ? body.split(',').map((item) => parseScalar(item)) : [];
+  }
+  return trimmed;
+}
+
+/** @param {string} text */
+export function parseFrontmatter(text) {
+  const lines = text.split(/\r?\n/);
+  if (lines[0] !== '---') return null;
+  const end = lines.indexOf('---', 1);
+  if (end < 0) return { fields: new Map(), endLine: 1, malformed: true };
+  const fields = new Map();
+  const duplicates = [];
+  for (let index = 1; index < end; index += 1) {
+    const line = lines[index];
+    if (!line || /^\s/.test(line) || line.trimStart().startsWith('#')) continue;
+    const match = /^([a-z][a-z0-9_]*)\s*:\s*(.*)$/.exec(line);
+    if (!match) continue;
+    if (fields.has(match[1]))
+      duplicates.push({ key: match[1], line: index + 1 });
+    else
+      fields.set(match[1], { value: parseScalar(match[2]), line: index + 1 });
+  }
+  return { fields, duplicates, endLine: end + 1, malformed: false };
+}
+
+/** @param {string} root @param {string} contractPath */
+export function readMetadataContract(
+  root = ROOT,
+  contractPath = DEFAULT_CONTRACT,
+) {
+  const contract = JSON.parse(
+    fs.readFileSync(path.join(root, contractPath), 'utf8'),
+  );
+  if (contract.schemaVersion !== 1) {
+    throw new Error(
+      `${contractPath}: unsupported schemaVersion ${String(contract.schemaVersion)}`,
+    );
+  }
+  return /** @type {MetadataContract} */ (contract);
+}
+
+/** @param {string} rel @param {{files?: string[], patterns?: string[]}} rule */
+function matches(rel, rule) {
+  return (
+    (rule.files || []).includes(rel) ||
+    (rule.patterns || []).some((pattern) => new RegExp(pattern).test(rel))
+  );
+}
+
+/** @param {string} value */
+function canonicalDecisionStatus(value) {
+  const match = /^(accepted|proposed|superseded)\b/i.exec(value.trim());
+  return match?.[1].toLowerCase() || null;
+}
+
+/** @param {string} text */
+function visibleDecisionStatus(text) {
+  const bullet = /^- (?:Decision )?Status:\s*([^\n]+)/im.exec(text);
+  if (bullet) return canonicalDecisionStatus(bullet[1]);
+  const bold = /^\*\*(?:Decision )?Status:\*\*\s*([^\n]+)/im.exec(text);
+  if (bold) return canonicalDecisionStatus(bold[1]);
+  const section = /^## Status\s*\n+\s*([^\n]+)/im.exec(text);
+  return section ? canonicalDecisionStatus(section[1]) : null;
+}
+
+/** @param {string} text */
+function indexStatuses(text) {
+  const result = new Map();
+  const row = /^\|\s*\[([^\]]+)]\(([^)]+)\)\s*\|\s*([^|]+)\|/gm;
+  for (const match of text.matchAll(row)) {
+    const rawStatus = match[3].trim();
+    const status = canonicalDecisionStatus(rawStatus);
+    const targetId = /(SHIFU-ADR-[0-9]{4}|ADR-[0-9]{4})-/.exec(match[2])?.[1];
+    if (status)
+      result.set(targetId || match[1], {
+        status,
+        rawStatus,
+        target: match[2],
+      });
+  }
+  return result;
+}
+
+/**
+ * @param {{root?: string, files: string[], contract?: MetadataContract}} options
+ * @returns {Finding[]}
+ */
+export function validateDocumentMetadata(options) {
+  const root = path.resolve(options.root || ROOT);
+  const contract = options.contract || readMetadataContract(root);
+  /** @type {Finding[]} */
+  const findings = [];
+  const documents = new Map();
+
+  for (const rel of options.files) {
+    const text = fs.readFileSync(path.join(root, rel), 'utf8');
+    documents.set(rel, text);
+    if (
+      contract.externalFrontmatterSchemas.some((schema) => matches(rel, schema))
+    ) {
+      continue;
+    }
+    const profile = contract.profiles.find((candidate) =>
+      matches(rel, candidate),
+    );
+    if (!profile) {
+      findings.push({
+        code: 'metadata-profile',
+        file: rel,
+        line: 1,
+        message: 'document is not routed to a metadata profile',
+      });
+      continue;
+    }
+    const frontmatter = parseFrontmatter(text);
+    if (!frontmatter) {
+      if (profile.frontmatterRequired) {
+        findings.push({
+          code: 'metadata-required',
+          file: rel,
+          line: 1,
+          message: `frontmatter required by ${profile.id} profile`,
+        });
+      }
+      continue;
+    }
+    if (frontmatter.malformed) {
+      findings.push({
+        code: 'metadata-malformed',
+        file: rel,
+        line: 1,
+        message: 'frontmatter is missing its closing delimiter',
+      });
+      continue;
+    }
+    for (const duplicate of frontmatter.duplicates || []) {
+      findings.push({
+        code: 'metadata-duplicate',
+        file: rel,
+        line: duplicate.line,
+        message: `duplicate frontmatter field: ${duplicate.key}`,
+      });
+    }
+    for (const key of profile.required) {
+      if (!frontmatter.fields.has(key)) {
+        findings.push({
+          code: 'metadata-required-field',
+          file: rel,
+          line: 1,
+          message: `${profile.id} requires frontmatter field ${key}`,
+        });
+      }
+    }
+    for (const key of profile.forbidden || []) {
+      const field = frontmatter.fields.get(key);
+      if (field) {
+        findings.push({
+          code: 'metadata-forbidden-field',
+          file: rel,
+          line: field.line,
+          message: `${profile.id} forbids ambiguous legacy field ${key}`,
+        });
+      }
+    }
+    for (const [key, expected] of Object.entries(profile.constants || {})) {
+      const field = frontmatter.fields.get(key);
+      if (field && field.value !== expected) {
+        findings.push({
+          code: 'metadata-constant',
+          file: rel,
+          line: field.line,
+          message: `${key} must be ${expected} for ${profile.id}`,
+        });
+      }
+    }
+    for (const [key, allowed] of Object.entries(profile.enums || {})) {
+      const field = frontmatter.fields.get(key);
+      if (field && !allowed.includes(/** @type {string} */ (field.value))) {
+        findings.push({
+          code: 'metadata-enum',
+          file: rel,
+          line: field.line,
+          message: `${key} must be one of: ${allowed.join(', ')}`,
+        });
+      }
+    }
+    const sources = frontmatter.fields.get('sources');
+    if (sources) {
+      const allowed = contract.sourceKinds || [];
+      if (!Array.isArray(sources.value)) {
+        findings.push({
+          code: 'metadata-sources',
+          file: rel,
+          line: sources.line,
+          message: 'sources must be an inline YAML list',
+        });
+      } else {
+        for (const source of sources.value) {
+          if (!allowed.includes(source)) {
+            findings.push({
+              code: 'metadata-sources',
+              file: rel,
+              line: sources.line,
+              message: `unknown source kind: ${String(source)}`,
+            });
+          }
+        }
+      }
+    }
+
+    if (profile.id === 'architecture-decision') {
+      const expectedId = /\/(SHIFU-ADR-[0-9]{4}|ADR-[0-9]{4})-/.exec(
+        `/${rel}`,
+      )?.[1];
+      const id = frontmatter.fields.get('adr_id');
+      if (id && id.value !== expectedId) {
+        findings.push({
+          code: 'adr-id-drift',
+          file: rel,
+          line: id.line,
+          message: `adr_id must match filename: ${expectedId}`,
+        });
+      }
+      const visible = visibleDecisionStatus(text);
+      const decision = frontmatter.fields.get('decision_status');
+      if (!visible) {
+        findings.push({
+          code: 'adr-status-projection',
+          file: rel,
+          line: frontmatter.endLine + 1,
+          message: 'ADR body must project a visible decision status',
+        });
+      } else if (decision && visible !== decision.value) {
+        findings.push({
+          code: 'adr-status-drift',
+          file: rel,
+          line: frontmatter.endLine + 1,
+          message: `visible status ${visible} differs from decision_status ${String(decision.value)}`,
+        });
+      }
+    }
+  }
+
+  for (const registry of contract.adrRegistries) {
+    const indexText = documents.get(registry.index);
+    if (!indexText) continue;
+    const statuses = indexStatuses(indexText);
+    const recordPattern = new RegExp(registry.recordPattern);
+    for (const rel of options.files) {
+      const record = recordPattern.exec(rel);
+      if (!record) continue;
+      const frontmatter = parseFrontmatter(documents.get(rel) || '');
+      const decision = frontmatter?.fields.get('decision_status')?.value;
+      const indexed = statuses.get(record[1]);
+      if (!indexed) {
+        findings.push({
+          code: 'adr-index-missing',
+          file: registry.index,
+          line: 1,
+          message: `ADR index is missing ${record[1]}`,
+        });
+      } else if (indexed.status !== decision) {
+        findings.push({
+          code: 'adr-index-drift',
+          file: registry.index,
+          line: 1,
+          message: `${record[1]} index status ${indexed.status} differs from decision_status ${String(decision)}`,
+        });
+      } else if (indexed.rawStatus !== indexed.status) {
+        findings.push({
+          code: 'adr-index-compound-status',
+          file: registry.index,
+          line: 1,
+          message: `${record[1]} index status must contain decision state only; implementation belongs in metadata`,
+        });
+      }
+    }
+  }
+
+  return findings.sort(
+    (left, right) =>
+      left.file.localeCompare(right.file) || left.line - right.line,
+  );
+}

--- a/scripts/document-metadata-contract.test.mjs
+++ b/scripts/document-metadata-contract.test.mjs
@@ -1,0 +1,203 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, test } from 'node:test';
+
+import { validateDocumentMetadata } from './document-metadata-contract.mjs';
+
+const roots = [];
+
+afterEach(() => {
+  for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true });
+});
+
+function fixture(files) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'kungfu-metadata-'));
+  roots.push(root);
+  for (const [rel, text] of Object.entries(files)) {
+    const file = path.join(root, rel);
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, text);
+  }
+  return root;
+}
+
+const contract = {
+  schemaVersion: 1,
+  metadataSchema: 'kungfu.document-metadata/v1',
+  sourceKinds: ['local-files'],
+  externalFrontmatterSchemas: [{ id: 'skill', patterns: ['(^|/)SKILL\\.md$'] }],
+  profiles: [
+    {
+      id: 'architecture-decision',
+      patterns: ['^adr/(ADR-[0-9]{4})-.*\\.md$'],
+      frontmatterRequired: true,
+      required: [
+        'metadata_schema',
+        'doc_type',
+        'adr_id',
+        'decision_status',
+        'implementation_status',
+        'review_state',
+        'sensitivity',
+      ],
+      constants: {
+        metadata_schema: 'kungfu.document-metadata/v1',
+        doc_type: 'architecture-decision',
+        sensitivity: 'public',
+      },
+      enums: {
+        decision_status: ['proposed', 'accepted', 'superseded'],
+        implementation_status: ['unknown'],
+        review_state: ['legacy-unreviewed'],
+      },
+      forbidden: ['status'],
+    },
+    {
+      id: 'adr-index',
+      files: ['adr/README.md'],
+      frontmatterRequired: true,
+      required: [
+        'metadata_schema',
+        'doc_type',
+        'document_status',
+        'review_state',
+        'sensitivity',
+      ],
+      constants: {
+        metadata_schema: 'kungfu.document-metadata/v1',
+        doc_type: 'adr-index',
+        document_status: 'active',
+        sensitivity: 'public',
+      },
+      enums: { review_state: ['self-reviewed'] },
+      forbidden: ['status'],
+    },
+    {
+      id: 'public-document',
+      files: ['README.md'],
+      frontmatterRequired: true,
+      required: [
+        'metadata_schema',
+        'doc_type',
+        'document_status',
+        'review_state',
+        'sensitivity',
+      ],
+      constants: {
+        metadata_schema: 'kungfu.document-metadata/v1',
+        sensitivity: 'public',
+      },
+      enums: {
+        document_status: ['active'],
+        review_state: ['unreviewed'],
+      },
+      forbidden: ['status'],
+    },
+    {
+      id: 'repository-document',
+      patterns: ['.*'],
+      frontmatterRequired: false,
+      required: [],
+      forbidden: ['status'],
+    },
+  ],
+  adrRegistries: [
+    {
+      index: 'adr/README.md',
+      recordPattern: '^adr/(ADR-[0-9]{4})-.*\\.md$',
+    },
+  ],
+};
+
+const publicHeader = `---
+metadata_schema: kungfu.document-metadata/v1
+document_status: active
+doc_type: public-document
+review_state: unreviewed
+sensitivity: public
+---`;
+const indexHeader = `---
+metadata_schema: kungfu.document-metadata/v1
+document_status: active
+doc_type: adr-index
+review_state: self-reviewed
+sensitivity: public
+---`;
+const adrHeader = `---
+metadata_schema: kungfu.document-metadata/v1
+doc_type: architecture-decision
+adr_id: ADR-0001
+decision_status: accepted
+implementation_status: unknown
+review_state: legacy-unreviewed
+sensitivity: public
+---`;
+
+function run(files) {
+  const root = fixture(files);
+  return validateDocumentMetadata({
+    root,
+    files: Object.keys(files).sort(),
+    contract,
+  });
+}
+
+test('accepts typed public metadata and aligned ADR projections', () => {
+  const findings = run({
+    'README.md': `${publicHeader}\n\n# Home\n`,
+    'adr/README.md': `${indexHeader}\n\n# ADRs\n\n| ADR | Status | Title |\n|---|---|---|\n| [ADR-0001](ADR-0001-example.md) | accepted | Example |\n`,
+    'adr/ADR-0001-example.md': `${adrHeader}\n\n# ADR-0001: Example\n\n- Status: accepted\n`,
+  });
+  assert.deepEqual(findings, []);
+});
+
+test('rejects missing required public frontmatter', () => {
+  const findings = run({ 'README.md': '# Home\n' });
+  assert.ok(findings.some((finding) => finding.code === 'metadata-required'));
+});
+
+test('rejects the ambiguous legacy status field', () => {
+  const findings = run({
+    'README.md': `${publicHeader.replace('document_status: active', 'status: active')}\n\n# Home\n`,
+  });
+  assert.ok(
+    findings.some((finding) => finding.code === 'metadata-forbidden-field'),
+  );
+});
+
+test('rejects ADR body status drift', () => {
+  const findings = run({
+    'adr/README.md': `${indexHeader}\n\n# ADRs\n\n| ADR | Status | Title |\n|---|---|---|\n| [ADR-0001](ADR-0001-example.md) | accepted | Example |\n`,
+    'adr/ADR-0001-example.md': `${adrHeader}\n\n# ADR-0001: Example\n\n- Status: proposed\n`,
+  });
+  assert.ok(findings.some((finding) => finding.code === 'adr-status-drift'));
+});
+
+test('rejects ADR index status drift', () => {
+  const findings = run({
+    'adr/README.md': `${indexHeader}\n\n# ADRs\n\n| ADR | Status | Title |\n|---|---|---|\n| [ADR-0001](ADR-0001-example.md) | proposed | Example |\n`,
+    'adr/ADR-0001-example.md': `${adrHeader}\n\n# ADR-0001: Example\n\n- Status: accepted\n`,
+  });
+  assert.ok(findings.some((finding) => finding.code === 'adr-index-drift'));
+});
+
+test('rejects implementation detail in the ADR index status column', () => {
+  const findings = run({
+    'adr/README.md': `${indexHeader}\n\n# ADRs\n\n| ADR | Status | Title |\n|---|---|---|\n| [ADR-0001](ADR-0001-example.md) | accepted; staged | Example |\n`,
+    'adr/ADR-0001-example.md': `${adrHeader}\n\n# ADR-0001: Example\n\n- Status: accepted\n`,
+  });
+  assert.ok(
+    findings.some((finding) => finding.code === 'adr-index-compound-status'),
+  );
+});
+
+test('preserves independently consumed frontmatter schemas', () => {
+  const findings = run({
+    'skills/demo/SKILL.md': '---\nkey: demo\ntriggers: [demo]\n---\n\n# Demo\n',
+  });
+  assert.deepEqual(findings, []);
+});

--- a/scripts/run-docs-check.mjs
+++ b/scripts/run-docs-check.mjs
@@ -37,6 +37,7 @@ try {
   run('negative fixtures', [
     '--test',
     path.join('scripts', 'check-docs.test.mjs'),
+    path.join('scripts', 'document-metadata-contract.test.mjs'),
     path.join('scripts', 'vocabulary-contract.test.mjs'),
     path.join('scripts', 'check-docs-toolchain.test.mjs'),
   ]);


### PR DESCRIPTION
## Summary
- define versioned path-based document metadata profiles
- migrate public documentation and all Core/Shifu ADRs
- make ADR body and registry status checked projections
- preserve issue-template and Skill frontmatter as independent schemas

## Validation
- ./shifu check
- ./shifu docs:check
- ./shifu docs:prose:required
- ./shifu check:types