### PR TITLE
feat(profile): qualify installed profile authoring

### DIFF
--- a/developer/sdk/src/sdk.js
+++ b/developer/sdk/src/sdk.js
@@ -2379,6 +2379,12 @@ function ancestorDirs(start) {
 function resolveKfxContractPath() {
   const explicit = process.env[KFX_CONTRACT_ENV];
   if (explicit) return path.resolve(explicit);
+  for (const candidate of [
+    path.join(SDK_ROOT, 'kungfu', 'config', KFX_CONTRACT_FILE),
+    path.join(SDK_ROOT, 'config', KFX_CONTRACT_FILE),
+  ]) {
+    if (fs.existsSync(candidate)) return candidate;
+  }
   for (const dir of ancestorDirs(process.cwd())) {
     for (const rel of [
       path.join('framework', 'kfx', KFX_CONTRACT_FILE),

--- a/framework/core/src/python/kungfu/agent/profile-sdk.contract.json
+++ b/framework/core/src/python/kungfu/agent/profile-sdk.contract.json
@@ -1,7 +1,7 @@
 {
   "schema": "kungfu.agent-profile-sdk-contract/v1",
   "id": "kungfu-agent-profile-sdk",
-  "version": 3,
+  "version": 4,
   "briefSchema": {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
@@ -259,6 +259,52 @@
         }
       }
     }
+  },
+  "sourceBundleSchema": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "additionalProperties": false,
+    "required": ["schema", "mode", "selfContained", "profileId", "profileVersion", "profileSuiteRoot", "memberRoots", "entries", "bundleRoot"],
+    "properties": {
+      "schema": { "const": "kungfu.profile-source-bundle/v1" },
+      "mode": { "enum": ["full", "thin"] },
+      "selfContained": { "type": "boolean" },
+      "profileId": { "type": "string", "pattern": "^[A-Za-z0-9._-]+$" },
+      "profileVersion": { "type": "string", "minLength": 1 },
+      "profileSuiteRoot": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+      "memberRoots": {
+        "type": "object",
+        "additionalProperties": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" }
+      },
+      "entries": {
+        "type": "array",
+        "minItems": 1,
+        "items": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["path", "sha256", "size"],
+          "properties": {
+            "path": { "type": "string", "pattern": "^(?!/)(?!.*(?:^|/)\\.\\.(?:/|$))[A-Za-z0-9._/-]+$" },
+            "sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+            "size": { "type": "integer", "minimum": 0 },
+            "contentBase64": { "type": "string" }
+          }
+        }
+      },
+      "bundleRoot": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" }
+    },
+    "allOf": [
+      {
+        "if": { "properties": { "mode": { "const": "full" } } },
+        "then": {
+          "properties": {
+            "selfContained": { "const": true },
+            "entries": { "items": { "required": ["contentBase64"] } }
+          }
+        },
+        "else": { "properties": { "selfContained": { "const": false } } }
+      }
+    ]
   },
   "actionRegistrySchema": {
     "$schema": "https://json-schema.org/draft/2020-12/schema",

--- a/framework/core/src/python/kungfu/cli/commands/profile.py
+++ b/framework/core/src/python/kungfu/cli/commands/profile.py
@@ -104,6 +104,72 @@ def qualify(ctx, source, as_json):
     _json(_run(lambda: profile_sdk.qualify_source(source, ctx.runtime_dir)))
 
 
+@profile.command(
+    name="export", help="export an exact full or thin Profile source bundle"
+)
+@click.argument("source", type=click.Path(exists=True, file_okay=False, path_type=Path))
+@click.option("--out", required=True, type=click.Path(dir_okay=False, path_type=Path))
+@click.option(
+    "--thin", is_flag=True, help="export roots and inventory without source bytes"
+)
+@click.option("--json", "as_json", is_flag=True)
+@profile_context
+def export_bundle(ctx, source, out, thin, as_json):
+    def operation():
+        if not out.parent.is_dir():
+            raise FileNotFoundError(
+                f"Profile bundle parent does not exist: {out.parent}"
+            )
+        bundle = profile_sdk.export_source_bundle(source, ctx.runtime_dir, thin=thin)
+        out.write_text(
+            json.dumps(bundle, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+        return {
+            "schema": "kungfu.profile-source-export-receipt/v1",
+            "mode": bundle["mode"],
+            "profileId": bundle["profileId"],
+            "profileSuiteRoot": bundle["profileSuiteRoot"],
+            "bundleRoot": bundle["bundleRoot"],
+            "entryCount": len(bundle["entries"]),
+            "out": str(out.resolve()),
+        }
+
+    _json(_run(operation))
+
+
+@profile.command(
+    name="import", help="plan or authorize reconstruction of a Profile source bundle"
+)
+@click.argument("bundle", type=click.Path(exists=True, dir_okay=False, path_type=Path))
+@click.option("--out", required=True, type=click.Path(path_type=Path))
+@click.option("--execute", is_flag=True)
+@click.option("--authorized-by")
+@click.option("--json", "as_json", is_flag=True)
+@profile_context
+def import_bundle(ctx, bundle, out, execute, authorized_by, as_json):
+    def operation():
+        plan = profile_sdk.source_import_plan(_load_json(bundle), out)
+        if not execute:
+            return plan
+        if not authorized_by:
+            raise profile_sdk.ProfileSdkError(
+                "decision-actor-required",
+                "--authorized-by is required to execute a Profile source import",
+            )
+        if not plan["requiresAuthorization"]:
+            raise profile_sdk.ProfileSdkError(
+                "source-import-not-ready",
+                "Profile source import needs a full bundle and an empty destination",
+                decisionCards=[plan["decisionCard"]],
+            )
+        answer = profile_sdk.answer_decision(
+            plan["decisionCard"], "approve", authorized_by
+        )
+        return profile_sdk.authorized_source_import(plan, answer)
+
+    _json(_run(operation))
+
+
 @profile.command(help="plan a Core-owned Profile lifecycle change")
 @click.argument(
     "action",
@@ -426,6 +492,11 @@ def contract_apply(ctx, plan_file, authorization_file, as_json):
 @click.option("--policy-id", required=True)
 @click.option("--purpose", required=True)
 @click.option("--work-episode-id", required=True, type=int)
+@click.option(
+    "--independent-observation-file",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    help="independent observation bound to the verified work Episode root",
+)
 @click.option("--out", type=click.Path(dir_okay=False, path_type=Path))
 @click.option("--json", "as_json", is_flag=True)
 @profile_context
@@ -438,6 +509,7 @@ def assess_plan(
     policy_id,
     purpose,
     work_episode_id,
+    independent_observation_file,
     out,
     as_json,
 ):
@@ -451,6 +523,11 @@ def assess_plan(
             policy_id=policy_id,
             purpose=purpose,
             work_episode_id=work_episode_id,
+            independent_observation=(
+                _load_json(independent_observation_file)
+                if independent_observation_file
+                else None
+            ),
         )
     )
     if out:

--- a/framework/core/src/python/kungfu/profile_sdk.py
+++ b/framework/core/src/python/kungfu/profile_sdk.py
@@ -10,6 +10,7 @@ mutation to the Core service introduced by ADR-0069.
 from __future__ import annotations
 
 import hashlib
+import base64
 import json
 import os
 import re
@@ -31,6 +32,8 @@ ACTION_REGISTRY_SCHEMA = "kungfu.profile-actions/v1"
 ACTION_PLAN_SCHEMA = "kungfu.profile-action-plan/v1"
 ACTION_RECEIPT_SCHEMA = "kungfu.profile-action-receipt/v1"
 DECISION_ANSWER_SCHEMA = "kungfu.decision-answer/v1"
+SOURCE_BUNDLE_SCHEMA = "kungfu.profile-source-bundle/v1"
+SOURCE_IMPORT_PLAN_SCHEMA = "kungfu.profile-source-import-plan/v1"
 
 _TOKEN = re.compile(r"^[A-Za-z0-9._-]+$")
 _IGNORED_PARTS = {".git", "node_modules", "__pycache__", ".DS_Store"}
@@ -73,6 +76,7 @@ def capabilities() -> dict[str, Any]:
             "claims": sdk_contract["claimsSchema"],
             "assessmentPolicies": sdk_contract["assessmentPoliciesSchema"],
             "views": sdk_contract["viewsSchema"],
+            "sourceBundle": sdk_contract["sourceBundleSchema"],
         },
         "sourcePlanSchema": SOURCE_PLAN_SCHEMA,
         "actionRegistrySchema": ACTION_REGISTRY_SCHEMA,
@@ -103,6 +107,8 @@ def capabilities() -> dict[str, Any]:
             "assess-run",
             "manager",
             "authorize-lifecycle",
+            "export",
+            "import",
         ],
         "customMemberBuild": {
             "command": "kungfu sdk kfx build",
@@ -455,6 +461,137 @@ def qualify_source(source: str | Path, runtime_dir: str | Path) -> dict[str, Any
         "status": "qualified-for-install-plan",
         "checks": sorted(checks),
         "evidenceScope": "source-contract/content-closure/runtime-contract",
+        "lifecycleMutation": False,
+    }
+
+
+def export_source_bundle(
+    source: str | Path, runtime_dir: str | Path, *, thin: bool = False
+) -> dict[str, Any]:
+    """Export an exact Profile source closure without lifecycle side effects."""
+
+    validated = validate_source(source, runtime_dir)
+    root = Path(validated["source"]["source"]).resolve()
+    entries = []
+    for path in _portable_source_paths(root):
+        data = path.read_bytes()
+        entry = {
+            "path": path.relative_to(root).as_posix(),
+            "sha256": _sha256(data),
+            "size": len(data),
+        }
+        if not thin:
+            entry["contentBase64"] = base64.b64encode(data).decode("ascii")
+        entries.append(entry)
+    body = {
+        "schema": SOURCE_BUNDLE_SCHEMA,
+        "mode": "thin" if thin else "full",
+        "selfContained": not thin,
+        "profileId": validated["source"]["profile"]["id"],
+        "profileVersion": validated["source"]["profile"]["version"],
+        "profileSuiteRoot": validated["inspection"]["profile_suite_root"],
+        "memberRoots": validated["source"]["memberRoots"],
+        "entries": entries,
+    }
+    body["bundleRoot"] = _root(body)
+    _validate_sdk_value("sourceBundleSchema", body, "Profile source bundle")
+    return body
+
+
+def source_import_plan(
+    bundle: Mapping[str, Any], destination: str | Path
+) -> dict[str, Any]:
+    """Plan reconstruction of source bytes; never install or activate a Profile."""
+
+    normalized = _validate_source_bundle(bundle)
+    target = Path(destination).expanduser().resolve()
+    collision = target.exists() and (not target.is_dir() or any(target.iterdir()))
+    identity = {
+        "bundle": normalized,
+        "destination": str(target),
+        "destinationCollision": collision,
+    }
+    plan = {
+        "schema": SOURCE_IMPORT_PLAN_SCHEMA,
+        "planId": _root(identity),
+        **identity,
+        "requiresAuthorization": normalized["mode"] == "full" and not collision,
+    }
+    if normalized["mode"] == "thin":
+        plan["decisionCard"] = decision_card(
+            "profile-source-material-required",
+            "Thin Profile bundles are root inventories; supply a full bundle before reconstruction.",
+            choices=["supply-full-bundle"],
+            basis={"bundleRoot": normalized["bundleRoot"]},
+            required_authority="profile-source-owner",
+            resume_command="export or obtain the exact full Profile source bundle",
+        )
+    elif collision:
+        plan["decisionCard"] = decision_card(
+            "profile-source-collision",
+            "The Profile source import destination is not empty.",
+            choices=["choose-an-empty-directory", "inspect-and-merge-manually"],
+            basis={"bundleRoot": normalized["bundleRoot"], "destination": str(target)},
+            required_authority="profile-source-owner",
+            resume_command="choose an empty destination and re-plan",
+        )
+    else:
+        plan["decisionCard"] = decision_card(
+            "profile-source-import-authorization",
+            "Authorize reconstruction of this exact Profile source closure without lifecycle activation.",
+            choices=["approve", "deny"],
+            basis={"planId": plan["planId"], "bundleRoot": normalized["bundleRoot"]},
+            required_authority="profile-source-owner",
+            resume_command="answer this card, then apply the exact source import plan",
+        )
+    return plan
+
+
+def authorized_source_import(
+    plan: Mapping[str, Any], answer: Mapping[str, Any]
+) -> dict[str, Any]:
+    if plan.get("schema") != SOURCE_IMPORT_PLAN_SCHEMA:
+        raise ProfileSdkError(
+            "source-import-plan-invalid", "Profile source import requires an exact plan"
+        )
+    refreshed = source_import_plan(
+        dict(plan.get("bundle") or {}), str(plan.get("destination") or "")
+    )
+    if refreshed["planId"] != plan.get("planId"):
+        raise ProfileSdkError(
+            "source-import-plan-stale", "Profile source bundle or destination changed"
+        )
+    if not refreshed["requiresAuthorization"]:
+        raise ProfileSdkError(
+            "source-import-not-ready",
+            "Profile source import needs a full bundle and an empty destination",
+            decisionCards=[refreshed["decisionCard"]],
+        )
+    validate_decision_answer(answer, refreshed["decisionCard"])
+    if (
+        answer.get("choice") != "approve"
+        or (answer.get("basis") or {}).get("planId") != refreshed["planId"]
+    ):
+        raise ProfileSdkError(
+            "decision-denied", "Profile source import was not approved"
+        )
+    target = Path(refreshed["destination"])
+    target.mkdir(parents=True, exist_ok=True)
+    written = []
+    for entry in refreshed["bundle"]["entries"]:
+        path = _confined(target, entry["path"])
+        path.parent.mkdir(parents=True, exist_ok=True)
+        data = base64.b64decode(entry["contentBase64"], validate=True)
+        path.write_bytes(data)
+        written.append(entry["path"])
+    return {
+        "schema": "kungfu.profile-source-import-receipt/v1",
+        "planId": refreshed["planId"],
+        "authorizationId": answer["authorizationId"],
+        "bundleRoot": refreshed["bundle"]["bundleRoot"],
+        "profileSuiteRoot": refreshed["bundle"]["profileSuiteRoot"],
+        "destination": str(target),
+        "written": written,
         "lifecycleMutation": False,
     }
 
@@ -1137,7 +1274,11 @@ def _package_dirs(suite_dir: Path) -> list[Path]:
             continue
         for candidate in [root, *[p for p in root.iterdir() if p.is_dir()]]:
             resolved = candidate.resolve()
-            if resolved not in seen and (resolved / "package.json").is_file():
+            try:
+                is_package = (resolved / "package.json").is_file()
+            except OSError:
+                is_package = False
+            if resolved not in seen and is_package:
                 seen.add(resolved)
                 result.append(resolved)
     return result
@@ -1215,6 +1356,72 @@ def _changes(
         for key in keys
         if left.get(key) != right.get(key)
     ]
+
+
+def _portable_source_paths(root: Path) -> list[Path]:
+    paths = []
+    for path in root.rglob("*"):
+        relative = path.relative_to(root)
+        if any(part in _IGNORED_PARTS for part in relative.parts):
+            continue
+        if path.is_symlink():
+            raise ProfileSdkError(
+                "source-bundle-symlink-rejected",
+                "Profile source bundles do not follow symlinks",
+                path=relative.as_posix(),
+            )
+        if path.is_file():
+            paths.append(path)
+    return sorted(paths, key=lambda path: path.relative_to(root).as_posix())
+
+
+def _validate_source_bundle(bundle: Mapping[str, Any]) -> dict[str, Any]:
+    normalized = dict(bundle)
+    _validate_sdk_value("sourceBundleSchema", normalized, "Profile source bundle")
+    expected = str(normalized.get("bundleRoot") or "")
+    body = dict(normalized)
+    body.pop("bundleRoot", None)
+    if expected != _root(body):
+        raise ProfileSdkError(
+            "source-bundle-root-mismatch", "Profile source bundle root mismatch"
+        )
+    paths = []
+    for entry in normalized["entries"]:
+        relative = str(entry["path"])
+        candidate = Path(relative)
+        if (
+            candidate.is_absolute()
+            or not relative
+            or ".." in candidate.parts
+            or any(part in _IGNORED_PARTS for part in candidate.parts)
+        ):
+            raise ProfileSdkError(
+                "source-bundle-path-invalid",
+                "Profile source bundle contains an unsafe path",
+                path=relative,
+            )
+        paths.append(relative)
+        if normalized["mode"] == "full":
+            try:
+                data = base64.b64decode(entry["contentBase64"], validate=True)
+            except (ValueError, TypeError) as error:
+                raise ProfileSdkError(
+                    "source-bundle-content-invalid",
+                    "Profile source bundle content is not canonical base64",
+                    path=relative,
+                ) from error
+            if len(data) != entry["size"] or _sha256(data) != entry["sha256"]:
+                raise ProfileSdkError(
+                    "source-bundle-content-mismatch",
+                    "Profile source bundle content does not match its inventory",
+                    path=relative,
+                )
+    if paths != sorted(set(paths)):
+        raise ProfileSdkError(
+            "source-bundle-inventory-invalid",
+            "Profile source bundle paths must be unique and sorted",
+        )
+    return normalized
 
 
 def _confined(root: Path, relative: str) -> Path:

--- a/framework/core/tests/python/test_agent_profile_sdk.py
+++ b/framework/core/tests/python/test_agent_profile_sdk.py
@@ -2,12 +2,14 @@
 
 import hashlib
 import json
+from pathlib import Path
 
 from click.testing import CliRunner
 
 from kungfu import profile_sdk
 from kungfu.cli.commands import __registry__  # noqa: F401
 from kungfu.cli.commands import kfc
+from kungfu.storage import service as storage_service
 
 
 def brief(**changes):
@@ -33,6 +35,21 @@ def create_source(tmp_path):
     receipt = profile_sdk.apply_scaffold(plan)
     assert receipt["verified"] is True
     return source, plan
+
+
+def test_profile_resolution_skips_unreadable_unrelated_siblings(tmp_path, monkeypatch):
+    source, _ = create_source(tmp_path)
+    blocked_manifest = tmp_path / "unrelated" / "package.json"
+    blocked_manifest.parent.mkdir()
+    original_is_file = Path.is_file
+
+    def guarded_is_file(path):
+        if path == blocked_manifest:
+            raise PermissionError("unrelated sibling is not readable")
+        return original_is_file(path)
+
+    monkeypatch.setattr(Path, "is_file", guarded_is_file)
+    assert profile_sdk.validate_source(source, tmp_path / "runtime")["ok"] is True
 
 
 def test_scaffold_is_plan_first_deterministic_and_does_not_self_certify(tmp_path):
@@ -216,6 +233,114 @@ def test_cli_installed_flow_plans_then_applies_core_lifecycle(tmp_path):
     )
     assert applied.exit_code == 0, applied.output
     assert json.loads(applied.output)["state"]["state"] == "installed"
+
+
+def test_cli_exports_and_imports_profile_source_without_lifecycle_mutation(tmp_path):
+    source, _ = create_source(tmp_path)
+    home = tmp_path / "home"
+    full_path = tmp_path / "profile.full.json"
+    thin_path = tmp_path / "profile.thin.json"
+    imported_source = tmp_path / "imported-profile"
+    runner = CliRunner()
+
+    exported = runner.invoke(
+        kfc,
+        [
+            "--home",
+            str(home),
+            "profile",
+            "export",
+            str(source),
+            "--out",
+            str(full_path),
+            "--json",
+        ],
+    )
+    assert exported.exit_code == 0, exported.output
+    full = json.loads(full_path.read_text())
+    assert full["schema"] == "kungfu.profile-source-bundle/v1"
+    assert full["mode"] == "full"
+    assert all("contentBase64" in row for row in full["entries"])
+
+    planned = runner.invoke(
+        kfc,
+        [
+            "--home",
+            str(home),
+            "profile",
+            "import",
+            str(full_path),
+            "--out",
+            str(imported_source),
+            "--json",
+        ],
+    )
+    assert planned.exit_code == 0, planned.output
+    assert json.loads(planned.output)["requiresAuthorization"] is True
+    imported = runner.invoke(
+        kfc,
+        [
+            "--home",
+            str(home),
+            "profile",
+            "import",
+            str(full_path),
+            "--out",
+            str(imported_source),
+            "--execute",
+            "--authorized-by",
+            "test-owner",
+            "--json",
+        ],
+    )
+    assert imported.exit_code == 0, imported.output
+    receipt = json.loads(imported.output)
+    assert receipt["lifecycleMutation"] is False
+    assert profile_sdk.validate_source(imported_source, home / "runtime")["ok"]
+    assert (
+        storage_service.profile_lifecycle(
+            home / "runtime", "list", include_removed=True
+        )["profiles"]
+        == []
+    )
+
+    thin = runner.invoke(
+        kfc,
+        [
+            "--home",
+            str(home),
+            "profile",
+            "export",
+            str(source),
+            "--out",
+            str(thin_path),
+            "--thin",
+            "--json",
+        ],
+    )
+    assert thin.exit_code == 0, thin.output
+    assert all(
+        "contentBase64" not in row
+        for row in json.loads(thin_path.read_text())["entries"]
+    )
+    thin_import = runner.invoke(
+        kfc,
+        [
+            "--home",
+            str(home),
+            "profile",
+            "import",
+            str(thin_path),
+            "--out",
+            str(tmp_path / "thin-import"),
+            "--execute",
+            "--authorized-by",
+            "test-owner",
+            "--json",
+        ],
+    )
+    assert thin_import.exit_code == 2
+    assert json.loads(thin_import.output)["code"] == "source-import-not-ready"
 
 
 def test_lifecycle_apply_rejects_tampered_decision_answer(tmp_path):

--- a/framework/core/tests/python/test_profile_composition.py
+++ b/framework/core/tests/python/test_profile_composition.py
@@ -677,6 +677,16 @@ def test_installed_cli_assessment_plan_decide_and_run(tmp_path):
     )
     query_file = tmp_path / "query-receipt.json"
     query_file.write_text(json.dumps(query))
+    observation_file = tmp_path / "independent-observation.json"
+    observation_file.write_text(
+        json.dumps(
+            {
+                "episodeRoot": "sha256:" + verified["computed"]["value"],
+                "authority": "independent-reviewer",
+                "relation": "admitted-source",
+            }
+        )
+    )
     plan_file = tmp_path / "assessment-plan.json"
     answer_file = tmp_path / "assessment-answer.json"
     runner = CliRunner()
@@ -700,6 +710,8 @@ def test_installed_cli_assessment_plan_decide_and_run(tmp_path):
             "operator-review",
             "--work-episode-id",
             str(verified["episode_id"]),
+            "--independent-observation-file",
+            str(observation_file),
             "--out",
             str(plan_file),
             "--json",
@@ -739,6 +751,9 @@ def test_installed_cli_assessment_plan_decide_and_run(tmp_path):
     assert planned.exit_code == 0, planned.output
     assert json.loads(plan_file.read_text())["claimInstanceId"] == (
         "week-progress:cli-cut"
+    )
+    assert json.loads(plan_file.read_text())["independentObservation"] == json.loads(
+        observation_file.read_text()
     )
     assert decided.exit_code == 0, decided.output
     assert executed.exit_code == 0, executed.output

--- a/product/electron-builder.yml
+++ b/product/electron-builder.yml
@@ -25,6 +25,14 @@ extraResources:
     to: tui
   - from: ../../product/extensions
     to: extensions
+  - from: ../../product/dist/desktop-authoring/sdk
+    to: sdk
+  - from: ../../product/dist/desktop-authoring/kfd
+    to: kfd
+  - from: ../../product/dist/desktop-authoring/templates
+    to: templates
+  - from: ../../product/dist/desktop-authoring/node_modules
+    to: node_modules
 mac:
   target:
     - dir

--- a/product/scripts/dist.mjs
+++ b/product/scripts/dist.mjs
@@ -39,6 +39,7 @@ const EXTENSIONS_ROOT = path.join(ROOT, 'extensions');
 const ASSEMBLED_EXTENSIONS = path.join(PRODUCT_DIR, 'extensions');
 const DIST_DIR = path.join(PRODUCT_DIR, 'dist');
 const DESKTOP_DIST_DIR = path.join(DIST_DIR, 'desktop');
+const DESKTOP_AUTHORING_DIR = path.join(DIST_DIR, 'desktop-authoring');
 const CLI_DIST_DIR = path.join(DIST_DIR, 'cli');
 const RELEASE_DIR = path.join(PRODUCT_DIR, 'release');
 const DESKTOP_RELEASE_DIR = path.join(RELEASE_DIR, 'desktop');
@@ -748,6 +749,7 @@ function bundleSdkForCli(stageRoot) {
     platform: 'node',
     format: 'esm',
     target: 'node20',
+    external: ['esbuild'],
     outfile: sdkOut,
     logLevel: 'silent',
   });
@@ -757,12 +759,36 @@ function bundleSdkForCli(stageRoot) {
   );
   copyTree(path.join(SDK_DIR, 'kfd'), path.join(stageRoot, 'kfd'));
   copyTree(path.join(SDK_DIR, 'templates'), path.join(stageRoot, 'templates'));
+  const esbuildPackageJson = require.resolve('esbuild/package.json', {
+    paths: [SDK_DIR, TUI_DIR, GUI_DIR, ROOT],
+  });
+  const esbuildResolvePaths = [path.dirname(esbuildPackageJson)];
+  copySdkRuntimePackageForCli(stageRoot, 'esbuild', esbuildResolvePaths);
+  copySdkRuntimePackageForCli(
+    stageRoot,
+    `@esbuild/${process.platform}-${process.arch}`,
+    esbuildResolvePaths,
+  );
   copySdkRuntimePackageForCli(stageRoot, '@kungfu-tech/kfd');
 }
 
-function copySdkRuntimePackageForCli(stageRoot, packageName) {
+function stageDesktopAuthoringRuntime() {
+  assertSafeGeneratedDir(DESKTOP_AUTHORING_DIR);
+  fs.rmSync(DESKTOP_AUTHORING_DIR, { recursive: true, force: true });
+  fs.mkdirSync(DESKTOP_AUTHORING_DIR, { recursive: true });
+  bundleSdkForCli(DESKTOP_AUTHORING_DIR);
+  console.log(
+    `[product] staged installed Agent authoring runtime -> ${rel(DESKTOP_AUTHORING_DIR)}`,
+  );
+}
+
+function copySdkRuntimePackageForCli(
+  stageRoot,
+  packageName,
+  resolvePaths = [SDK_DIR, ROOT],
+) {
   const packageJson = require.resolve(`${packageName}/package.json`, {
-    paths: [SDK_DIR, ROOT],
+    paths: resolvePaths,
   });
   const source = path.dirname(packageJson);
   const target = path.join(
@@ -1312,6 +1338,7 @@ function main() {
         event: 'product.tui.bundle',
       });
       if (wantsDesktop()) {
+        stageDesktopAuthoringRuntime();
         runPnpm(
           'ensure electron',
           ['--filter', '@kungfu-tech/gui', 'run', 'ensure-electron'],

--- a/product/scripts/dist.test.mjs
+++ b/product/scripts/dist.test.mjs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import assert from 'node:assert/strict';
+import fs from 'node:fs';
 import { createRequire } from 'node:module';
 import { test } from 'node:test';
 import { cliArchiveBase, verifyProductObservabilityEvents } from './dist.mjs';
@@ -90,4 +91,38 @@ test('work dashboard declares the storage handle used by its query stream', () =
       'storage',
     ),
   );
+});
+
+test('desktop product carries the installed Agent authoring runtime', () => {
+  const config = fs.readFileSync(
+    new URL('../electron-builder.yml', import.meta.url),
+    'utf8',
+  );
+  for (const target of ['sdk', 'kfd', 'templates', 'node_modules']) {
+    assert.match(
+      config,
+      new RegExp(`desktop-authoring/${target}\\n\\s+to: ${target}`),
+    );
+  }
+});
+
+test('installed SDK resolves the packaged KFX contract beside its resources', () => {
+  const sdk = fs.readFileSync(
+    new URL('../../developer/sdk/src/sdk.js', import.meta.url),
+    'utf8',
+  );
+  assert.match(
+    sdk,
+    /path\.join\(SDK_ROOT, 'kungfu', 'config', KFX_CONTRACT_FILE\)/,
+  );
+});
+
+test('installed SDK keeps esbuild external and carries its native runtime', () => {
+  const dist = fs.readFileSync(new URL('./dist.mjs', import.meta.url), 'utf8');
+  assert.match(dist, /external: \['esbuild'\]/);
+  assert.match(
+    dist,
+    /copySdkRuntimePackageForCli\(stageRoot, 'esbuild', esbuildResolvePaths\)/,
+  );
+  assert.match(dist, /`@esbuild\/\$\{process\.platform\}-\$\{process\.arch\}`/);
 });


### PR DESCRIPTION
## Summary
- package the Agent Profile SDK and native esbuild runtime in the desktop product
- add exact-root full/thin Profile source export/import without lifecycle mutation
- expose independent observation evidence to Profile assessment planning
- harden installed source discovery against unreadable unrelated siblings

## Verification
- `./shifu test:agent-profile-sdk` (31 passed)
- `./shifu check`
- `./shifu product gui build`
- frozen product CLI built and qualified an external Week/Day/Action Suite, proved Mission coexistence, lifecycle rollback/removal/reinstall, KFD-1 query, KFD-2 assessment, and full/thin portability