### PR TITLE
ci(core): harden durable toolchain qualification

### DIFF
--- a/.github/workflows/embedding-membrane-spike.yml
+++ b/.github/workflows/embedding-membrane-spike.yml
@@ -12,6 +12,8 @@ on:
       - "framework/core/src/libkungfu/include/kungfu/native_storage.h"
       - "framework/core/src/libkungfu/src/runtime/embedding.cpp"
       - "framework/core/src/libkungfu/src/runtime/native_storage.cpp"
+      - "framework/core/src/libkungfu/include/kungfu/runtime/durable_ingest.h"
+      - "framework/core/src/libkungfu/src/runtime/durable_ingest.cpp"
       - "framework/core/src/libyijinjing/include/kungfu/yijinjing/ownership.h"
       - "framework/core/src/libyijinjing/src/io/ownership.cpp"
       - "framework/core/slices/shared-embedding-membrane/**"
@@ -97,6 +99,8 @@ jobs:
       KUNGFU_BUILD_SKIP_PYKUNGFU: "1"
       SHIFU_NATIVE: "1"
       SHIFU_REQUIRE_MSVC: "1"
+      CARGO_HTTP_TIMEOUT: "120"
+      CARGO_NET_RETRY: "5"
       MIRROR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
       MIRROR_REF: refs/heads/dev/v4/v4.0
       MIRROR_URL: http://192.168.100.222:8088/git-mirrors/kungfu.git


### PR DESCRIPTION
## Summary

- run the hosted GCC 14 / Apple Clang / MSVC membrane matrix when the durable-ingest interface or implementation changes
- retain the existing ownership PImpl coverage on the current paths
- give Cargo registry traffic a 120-second HTTP timeout and five retries so transient rsproxy timeouts do not mask compiler results

## Validation

- `./shifu check`
- prior runs #29196153424 and #29197363539 identified the exact GCC 14 / MSVC regressions now present in current dev, plus repeated 30-second Cargo registry timeouts on Windows
