### PR TITLE
fix(product): scope observability to current run

### DIFF
--- a/product/scripts/dist.mjs
+++ b/product/scripts/dist.mjs
@@ -58,6 +58,9 @@ const buildchainLogger = createBuildchainLogger({
     package: '@kungfu-tech/product-kungfu',
   },
 });
+const buildchainLogEventStartIndex = buildchainLogger.path
+  ? readBuildchainLogEvents(buildchainLogger.path).length
+  : 0;
 
 const parsedArgs = parseArgs(process.argv.slice(2));
 const builderArgs = parsedArgs.builderArgs;
@@ -1397,7 +1400,11 @@ function main() {
   );
 }
 
-export function verifyProductObservabilityEvents(events, target = 'all') {
+export function verifyProductObservabilityEvents(
+  events,
+  target = 'all',
+  startIndex = 0,
+) {
   const requiredEvents = [
     'product.dist.start',
     'product.kfx.dependencies.declared',
@@ -1414,7 +1421,9 @@ export function verifyProductObservabilityEvents(events, target = 'all') {
     requiredEvents.push('product.cli.smoke.start');
   }
   return verifyBuildchainLogEvents({
-    events: events.filter((event) => event.component === 'kungfu-product'),
+    events: events
+      .slice(startIndex)
+      .filter((event) => event.component === 'kungfu-product'),
     minEvents: 12,
     requireComponents: ['kungfu-product'],
     requirePhases: [
@@ -1436,6 +1445,7 @@ function verifyObservability() {
   const report = verifyProductObservabilityEvents(
     readBuildchainLogEvents(buildchainLogger.path),
     productTarget,
+    buildchainLogEventStartIndex,
   );
   if (!report.ok) {
     throw new Error(

--- a/product/scripts/dist.test.mjs
+++ b/product/scripts/dist.test.mjs
@@ -59,6 +59,47 @@ test('product observability ignores errors from sibling components', () => {
   assert.equal(report.summary.eventCount, names.length);
 });
 
+test('product observability ignores same-component errors from prior runs', () => {
+  const events = [
+    {
+      contract: 'kungfu-buildchain-log-event',
+      timestamp: '2026-07-12T00:00:00.000Z',
+      level: 'error',
+      source: 'user',
+      component: 'kungfu-product',
+      event: 'product.dist.error',
+      phase: 'package',
+    },
+    ...[
+      ['product.dist.start', 'prepare'],
+      ['product.kfx.dependencies.declared', 'dependencies'],
+      ['product.dependencies.sync.start', 'dependencies'],
+      ['product.core.rebuild.start', 'core'],
+      ['product.core.freeze.start', 'core'],
+      ['product.extensions.build.start', 'extensions'],
+      ['product.ui.bundle.start', 'ui'],
+      ['product.desktop.electron-builder.start', 'package'],
+      ['product.cli.archive.start', 'package'],
+      ['product.cli.smoke.start', 'package'],
+      ['product.cli.smoke.end', 'package'],
+      ['product.dist.end', 'package'],
+    ].map(([event, phase]) => ({
+      contract: 'kungfu-buildchain-log-event',
+      timestamp: '2026-07-12T00:01:00.000Z',
+      level: 'info',
+      source: 'user',
+      component: 'kungfu-product',
+      event,
+      phase,
+    })),
+  ];
+
+  const report = verifyProductObservabilityEvents(events, 'all', 1);
+  assert.equal(report.ok, true);
+  assert.equal(report.summary.errorCount, 0);
+  assert.equal(report.summary.eventCount, 12);
+});
+
 test('electron before-pack uses a file URL only on Windows', () => {
   const entryPath = new URL(
     '../../framework/gui/scripts/gen-first-party-manifest.mjs',


### PR DESCRIPTION
## Summary

- snapshot the Buildchain log-event index when the product process starts
- verify only current-process events instead of re-reading stale same-component failures from prior runs
- keep sibling-component filtering and add a regression fixture for stale `kungfu-product` errors

## Validation

- `./shifu check`
- regression test: `product observability ignores same-component errors from prior runs`

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Current-run observability scoping fixes stale-log attribution without changing an architecture contract."
}
-->
