### PR TITLE
fix(profile): add Mission Control setup flow

### DIFF
--- a/extensions/work-dashboard/src/view/index.tsx
+++ b/extensions/work-dashboard/src/view/index.tsx
@@ -13,6 +13,7 @@ import type {
   AtlasMissionControlReport,
   GoalCardQuerySpec,
   Profile,
+  ProfileLifecyclePlan,
   QueryChangelogState,
   QueryResumeToken,
   Storage,
@@ -43,6 +44,10 @@ import {
   MissionSituationOverview,
 } from './mission-visual';
 import { deriveTrustVisual } from './mission-visual-model';
+import {
+  type MissionControlProfileSetupStep,
+  missionControlProfileSetupStep,
+} from './profile-setup';
 
 const STATUS_ORDER = ['active', 'blocked', 'waiting', 'ready', 'done'] as const;
 const ATLAS_GOAL_STATUSES = [
@@ -86,25 +91,28 @@ function StatusBadge({ name }: { name: string }) {
 
 function SmallButton({
   active = false,
+  disabled = false,
   children,
   onClick,
 }: {
   active?: boolean;
+  disabled?: boolean;
   children: React.ReactNode;
   onClick: () => void;
 }) {
   return (
     <button
       type="button"
+      disabled={disabled}
       onClick={onClick}
       style={{
         ...mono,
         padding: '3px 8px',
         border: active ? '1px solid #2d8fcc' : '1px solid #3c3c3c',
         borderRadius: 4,
-        cursor: 'pointer',
+        cursor: disabled ? 'default' : 'pointer',
         background: active ? '#04395e' : 'transparent',
-        color: active ? '#9cdcfe' : '#cccccc',
+        color: disabled ? '#6a6a6a' : active ? '#9cdcfe' : '#cccccc',
       }}
     >
       {children}
@@ -369,6 +377,12 @@ function AtlasProjectionView({
       ? 'Mission Control Profile pending'
       : 'Profile capability unavailable',
   );
+  const [profileSetup, setProfileSetup] =
+    React.useState<MissionControlProfileSetupStep | null>(null);
+  const [profileSetupPlan, setProfileSetupPlan] =
+    React.useState<ProfileLifecyclePlan | null>(null);
+  const [profileSetupActor, setProfileSetupActor] = React.useState('');
+  const [profileSetupBusy, setProfileSetupBusy] = React.useState(false);
   const [selectedMission, setSelectedMission] = React.useState<string>(() =>
     missions.length ? missions[0].mission_id : 'all',
   );
@@ -479,6 +493,7 @@ function AtlasProjectionView({
   const refreshProfileStatus = React.useCallback(async () => {
     if (!profile) {
       setProfileStatus('Profile capability unavailable');
+      setProfileSetup(null);
       return;
     }
     try {
@@ -486,14 +501,29 @@ function AtlasProjectionView({
       const current = manager.profiles.find(
         (candidate) => candidate.profileId === 'kungfu.mission-control',
       );
+      let discovery = null;
+      if (!current || !current.source) {
+        try {
+          discovery = await profile.discoverAsync('kungfu.mission-control');
+        } catch {
+          discovery = null;
+        }
+      }
+      const setup = missionControlProfileSetupStep(current ?? null, discovery);
+      setProfileSetup(setup);
       if (!current) {
-        setProfileStatus('Mission Control Profile not installed');
+        setProfileStatus(
+          setup
+            ? 'Mission Control setup required · install'
+            : 'Mission Control Profile not installed · source unavailable',
+        );
       } else if (current.health !== 'active' || !current.catalog) {
         const diagnosis = current.diagnostics[0]?.message;
         setProfileStatus(
-          `Mission Control Profile ${current.lifecycleState}/${current.health}${diagnosis ? ` · ${diagnosis}` : ''}`,
+          `Mission Control setup required · ${setup?.action ?? `${current.lifecycleState}/${current.health}`}${diagnosis ? ` · ${diagnosis}` : ''}`,
         );
       } else {
+        setProfileSetupPlan(null);
         const contract = current.source
           ? await profile.contractPlanAsync(current.source)
           : null;
@@ -508,9 +538,65 @@ function AtlasProjectionView({
         }
       }
     } catch (error) {
+      setProfileSetup(null);
       setProfileStatus(`Profile degraded · ${(error as Error).message}`);
     }
   }, [profile]);
+
+  const reviewProfileSetup = React.useCallback(async () => {
+    if (!profile || !profileSetup) return;
+    setProfileSetupBusy(true);
+    try {
+      setProfileSetupPlan(
+        await profile.lifecyclePlanAsync(
+          profileSetup.action,
+          profileSetup.source,
+        ),
+      );
+      setMessage('Review the exact Profile lifecycle plan before approval.');
+    } catch (error) {
+      setMessage(`Profile setup failed · ${(error as Error).message}`);
+    } finally {
+      setProfileSetupBusy(false);
+    }
+  }, [profile, profileSetup]);
+
+  const approveProfileSetup = React.useCallback(async () => {
+    if (
+      !profile ||
+      !profileSetup ||
+      !profileSetupPlan ||
+      !profileSetupActor.trim()
+    ) {
+      return;
+    }
+    setProfileSetupBusy(true);
+    try {
+      await profile.authorizeLifecycleAsync(
+        profileSetup.action,
+        profileSetup.source,
+        String(profileSetupPlan.corePlan.plan_id ?? ''),
+        'approve',
+        profileSetupActor.trim(),
+      );
+      setProfileSetupPlan(null);
+      setProfileSetupActor('');
+      setMessage(
+        `Mission Control ${profileSetup.action} applied · review the next explicit lifecycle gate.`,
+      );
+      await refreshProfileStatus();
+    } catch (error) {
+      setMessage(`Profile setup failed · ${(error as Error).message}`);
+    } finally {
+      setProfileSetupBusy(false);
+    }
+  }, [
+    profile,
+    profileSetup,
+    profileSetupPlan,
+    profileSetupActor,
+    refreshProfileStatus,
+  ]);
 
   React.useEffect(() => {
     void refreshProfileStatus();
@@ -957,7 +1043,62 @@ function AtlasProjectionView({
           >
             {profileStatus}
           </span>
+          {profileSetup ? (
+            <SmallButton
+              disabled={profileSetupBusy}
+              onClick={() => void reviewProfileSetup()}
+            >
+              {profileSetupBusy ? 'planning…' : `review ${profileSetup.action}`}
+            </SmallButton>
+          ) : null}
         </div>
+        {profileSetupPlan && profileSetup ? (
+          <div
+            style={{
+              ...mono,
+              border: '1px solid #dcdcaa',
+              padding: 8,
+              marginTop: 8,
+            }}
+          >
+            <strong style={{ color: '#dcdcaa' }}>
+              Decision required · {profileSetup.action}
+            </strong>
+            <div>plan {String(profileSetupPlan.corePlan.plan_id ?? '—')}</div>
+            <div>{String(profileSetupPlan.decisionCard.question ?? '')}</div>
+            <div style={{ color: '#ce9178' }}>
+              effects {JSON.stringify(profileSetupPlan.corePlan.effects ?? [])}
+            </div>
+            <div style={{ color: '#858585' }}>
+              authority{' '}
+              {String(
+                profileSetupPlan.decisionCard.requiredAuthority ??
+                  'workspace-profile-operator',
+              )}
+            </div>
+            <label style={{ display: 'block', marginTop: 6 }}>
+              authorized by{' '}
+              <input
+                value={profileSetupActor}
+                onChange={(event) => setProfileSetupActor(event.target.value)}
+                placeholder="workspace owner identity"
+                style={{ ...mono, minWidth: 220 }}
+              />
+            </label>
+            <SmallButton
+              disabled={profileSetupBusy || !profileSetupActor.trim()}
+              onClick={() => void approveProfileSetup()}
+            >
+              approve exact plan
+            </SmallButton>{' '}
+            <SmallButton
+              disabled={profileSetupBusy}
+              onClick={() => setProfileSetupPlan(null)}
+            >
+              dismiss
+            </SmallButton>
+          </div>
+        ) : null}
         {message && (
           <div style={{ ...mono, color: '#dcdcaa', marginTop: 5 }}>
             {message}

--- a/extensions/work-dashboard/src/view/profile-setup.ts
+++ b/extensions/work-dashboard/src/view/profile-setup.ts
@@ -1,0 +1,27 @@
+import type {
+  ManagedProfile,
+  ProfileLifecycleAction,
+  ProfileSourceDiscovery,
+} from '@kungfu-tech/api/capability';
+
+export type MissionControlProfileSetupStep = {
+  action: Extract<ProfileLifecycleAction, 'install' | 'qualify' | 'activate'>;
+  source: string;
+};
+
+export function missionControlProfileSetupStep(
+  managed: ManagedProfile | null,
+  discovery: ProfileSourceDiscovery | null,
+): MissionControlProfileSetupStep | null {
+  if (managed?.activated && managed.health === 'active') return null;
+  const source = managed?.source ?? discovery?.source ?? '';
+  if (!source) return null;
+  if (!managed || managed.removed) return { action: 'install', source };
+  if (managed.lifecycleState === 'installed') {
+    return { action: 'qualify', source };
+  }
+  if (managed.lifecycleState === 'qualified') {
+    return { action: 'activate', source };
+  }
+  return null;
+}

--- a/extensions/work-dashboard/tests/profile-setup.test.ts
+++ b/extensions/work-dashboard/tests/profile-setup.test.ts
@@ -1,0 +1,70 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type {
+  ManagedProfile,
+  ProfileSourceDiscovery,
+} from '@kungfu-tech/api/capability';
+import { missionControlProfileSetupStep } from '../src/view/profile-setup.ts';
+
+const discovery: ProfileSourceDiscovery = {
+  schema: 'kungfu.profile-source-discovery/v1',
+  profileId: 'kungfu.mission-control',
+  profileSuiteRoot: 'sha256:source',
+  memberRoots: {},
+  source: '/product/extensions/mission-control',
+};
+
+function managed(
+  lifecycleState: ManagedProfile['lifecycleState'],
+  overrides: Partial<ManagedProfile> = {},
+): ManagedProfile {
+  return {
+    profileId: 'kungfu.mission-control',
+    profileVersion: '3.0.0',
+    profileSuiteRoot: 'sha256:source',
+    profileRevision: 1,
+    lifecycleState,
+    activated: lifecycleState === 'activated',
+    removed: lifecycleState === 'removed',
+    grantedPermissions: [],
+    qualification: {},
+    availableRoots: 1,
+    source: '/product/extensions/mission-control',
+    health: lifecycleState === 'activated' ? 'active' : 'inactive',
+    catalog: null,
+    diagnostics: [],
+    ...overrides,
+  };
+}
+
+test('Mission Control setup starts with the packaged public Profile source', () => {
+  assert.deepEqual(missionControlProfileSetupStep(null, discovery), {
+    action: 'install',
+    source: discovery.source,
+  });
+});
+
+test('Mission Control setup preserves explicit lifecycle gates', () => {
+  assert.deepEqual(
+    missionControlProfileSetupStep(managed('installed'), discovery),
+    { action: 'qualify', source: discovery.source },
+  );
+  assert.deepEqual(
+    missionControlProfileSetupStep(managed('qualified'), discovery),
+    { action: 'activate', source: discovery.source },
+  );
+  assert.equal(
+    missionControlProfileSetupStep(managed('activated'), discovery),
+    null,
+  );
+});
+
+test('removed Mission Control can be explicitly reinstalled', () => {
+  assert.deepEqual(
+    missionControlProfileSetupStep(
+      managed('removed', { health: 'removed' }),
+      discovery,
+    ),
+    { action: 'install', source: discovery.source },
+  );
+});

--- a/framework/api/src/capability/profile.ts
+++ b/framework/api/src/capability/profile.ts
@@ -73,6 +73,20 @@ export type ProfileManagerProjection = {
   knownLimits: string[];
 };
 
+export type ProfileSourceDiscovery = {
+  schema: 'kungfu.profile-source-discovery/v1';
+  profileId: string;
+  profileSuiteRoot: string;
+  memberRoots: Record<string, string>;
+  source: string;
+};
+
+export type ProfileLifecycleAction =
+  | 'install'
+  | 'qualify'
+  | 'activate'
+  | 'upgrade';
+
 export type ProfileQueryPlan = {
   schema: 'kungfu.profile-query-plan/v1';
   planId: string;
@@ -112,6 +126,8 @@ export type ProfileContractPlan = {
 
 export type Profile = {
   runtimeDir: string;
+  discover: (profileId: string) => ProfileSourceDiscovery;
+  discoverAsync: (profileId: string) => Promise<ProfileSourceDiscovery>;
   manager: () => ProfileManagerProjection;
   managerAsync: () => Promise<ProfileManagerProjection>;
   catalog: (
@@ -127,15 +143,15 @@ export type Profile = {
   contractPlan: (source: string) => ProfileContractPlan;
   contractPlanAsync: (source: string) => Promise<ProfileContractPlan>;
   lifecyclePlan: (
-    action: 'install' | 'qualify' | 'activate' | 'upgrade',
+    action: ProfileLifecycleAction,
     source: string,
   ) => ProfileLifecyclePlan;
   lifecyclePlanAsync: (
-    action: 'install' | 'qualify' | 'activate' | 'upgrade',
+    action: ProfileLifecycleAction,
     source: string,
   ) => Promise<ProfileLifecyclePlan>;
   authorizeLifecycleAsync: (
-    action: 'install' | 'qualify' | 'activate' | 'upgrade',
+    action: ProfileLifecycleAction,
     source: string,
     expectedPlanId: string,
     choice: 'approve' | 'deny',
@@ -201,6 +217,10 @@ export function openProfile(options: OpenProfileOptions): Profile {
   ];
   return {
     runtimeDir: options.runtimeDir,
+    discover: (profileId) =>
+      run<ProfileSourceDiscovery>(['discover', profileId]),
+    discoverAsync: (profileId) =>
+      runAsync<ProfileSourceDiscovery>(['discover', profileId]),
     manager: () => run<ProfileManagerProjection>(['manager']),
     managerAsync: () => runAsync<ProfileManagerProjection>(['manager']),
     catalog: (source, requireActive = false) =>

--- a/framework/api/tests/profile.test.ts
+++ b/framework/api/tests/profile.test.ts
@@ -43,13 +43,15 @@ test('Profile plans preserve source and exact active-root intent', () => {
   });
 
   profile.catalog('/suite', true);
+  profile.discover('kungfu.mission-control');
   profile.queryPlan('/suite', 'week-table');
-  profile.lifecyclePlan('activate', '/suite');
+  profile.lifecyclePlan('install', '/suite');
 
   assert.deepEqual(calls, [
     ['profile', 'catalog', '/suite', '--require-active', '--json'],
+    ['profile', 'discover', 'kungfu.mission-control', '--json'],
     ['profile', 'query-plan', '/suite', 'week-table', '--json'],
-    ['profile', 'plan', 'activate', '/suite', '--json'],
+    ['profile', 'plan', 'install', '/suite', '--json'],
   ]);
 });
 


### PR DESCRIPTION
## Summary
- expose installed Profile source discovery through the public TypeScript capability
- turn the Work Dashboard missing-Profile dead end into explicit install, qualify, and activate decision gates
- show exact plan, authority, question, and effects before each authorized lifecycle mutation

## Validation
- ./shifu check
- @kungfu-tech/api tests: 12 passed
- work-dashboard tests: 12 passed
- disposable runtime: install -> qualify -> activate -> active
- ./shifu product gui build

The current known CI issue is not treated as a merge gate for this dogfood repair.