### PR TITLE
docs(metadata): separate public metadata and bind ADR evidence

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -10,6 +10,8 @@ on:
       - "**/*.md"
       - ".markdownlint-cli2.mjs"
       - "docs.contract.json"
+      - "docs/document-metadata.contract.json"
+      - "docs/document-metadata.registry.json"
       - "docs/vocabulary.registry.json"
       - "docs/toolchain.contract.json"
       - "scripts/check-docs.mjs"
@@ -39,6 +41,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
+          fetch-depth: 0
 
       - name: Check Markdown documentation from external tool cache
         env:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,11 +1,3 @@
----
-metadata_schema: kungfu.document-metadata/v1
-document_status: active
-doc_type: public-document
-review_state: unreviewed
-sensitivity: public
----
-
 # AGENTS.md
 
 This file orients coding agents (and people) working with this repository. It is

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,3 @@
----
-metadata_schema: kungfu.document-metadata/v1
-document_status: active
-doc_type: public-document
-review_state: unreviewed
-sensitivity: public
----
-
 # Contributing to Kungfu
 
 Thanks for your interest in Kungfu. This guide covers how to build the project,
@@ -177,7 +169,10 @@ changed-file filter. The intentionally small Markdownlint rule baseline lives
 in `.markdownlint-cli2.mjs`; do not enable a style rule by rewriting unrelated
 documents. `docs.contract.json` owns only required documents and navigation
 pointers. [`docs/document-metadata.contract.json`](docs/document-metadata.contract.json)
-owns typed frontmatter profiles and makes ADR body/index status checked
+routes each governed document to inline, registry, or external metadata;
+[`docs/document-metadata.registry.json`](docs/document-metadata.registry.json)
+keeps public entry and guide metadata out of the rendered page. The same gate
+makes ADR body/index status and immutable implementation references checked
 projections of ADR metadata; see
 [`docs/document-metadata.md`](docs/document-metadata.md). GitHub issue templates
 and Kungfu Skills retain their independently consumed frontmatter schemas.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,3 @@
----
-metadata_schema: kungfu.document-metadata/v1
-document_status: active
-doc_type: public-document
-review_state: unreviewed
-sensitivity: public
----
-
 # Kungfu
 
 <!-- buildchain:badges:start -->

--- a/crates/host-spike/README.md
+++ b/crates/host-spike/README.md
@@ -10,11 +10,6 @@ theme: rust-host-spike
 confidence: medium
 evidence_grade: B
 last_reviewed: 2026-07-10
-ai_provenance:
-  model_family: GPT-5
-  product: Codex
-  generated_at: 2026-07-10
-  invisible_context: exact model build and hidden reasoning unavailable
 ---
 
 # host-spike — Rust host shell feasibility probe

--- a/docs/MAP.md
+++ b/docs/MAP.md
@@ -1,11 +1,3 @@
----
-metadata_schema: kungfu.document-metadata/v1
-document_status: active
-doc_type: public-document
-review_state: unreviewed
-sensitivity: public
----
-
 # Documentation Map
 
 This is Kungfu's exhaustive question and evidence index. It is optimized for a

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,11 +1,3 @@
----
-metadata_schema: kungfu.document-metadata/v1
-document_status: active
-doc_type: public-document
-review_state: unreviewed
-sensitivity: public
----
-
 # Kungfu Documentation
 
 Kungfu is execution infrastructure for real-world agent work. Its flagship
@@ -108,8 +100,8 @@ design target into a production guarantee.
   channel intent, and release mechanics.
 - [Shifu Documentation](shifu/README.md) — development/build execution and
   versioned cache contracts.
-- [Document Metadata Contract](document-metadata.md) — typed frontmatter,
-  lifecycle axes, ADR projections, and schema exemptions.
+- [Document Metadata Contract](document-metadata.md) — reader-hidden public
+  metadata, inline engineering evidence, lifecycle axes, and ADR projections.
 - [Core ADRs](../framework/core/docs/adr/) — load-bearing decisions.
 - [Documentation Map](MAP.md) — the complete question and keyword index.
 
@@ -163,8 +155,10 @@ retired positioning, preferred terms, and load-bearing guarantee language.
 Objective prose errors block pull requests through `docs:prose:required`;
 warning-level policy remains advisory until its false-positive behavior is
 qualified. `docs.contract.json` owns document topology,
-[`document-metadata.contract.json`](document-metadata.contract.json) owns typed
-frontmatter and ADR projections, while
+[`document-metadata.contract.json`](document-metadata.contract.json) owns
+metadata routing and ADR projections;
+[`document-metadata.registry.json`](document-metadata.registry.json) keeps
+public entry and guide metadata out of rendered pages, while
 [`vocabulary.registry.json`](vocabulary.registry.json) owns executable language
 policy; generated Vale files are disposable projections of that registry.
 External URL health is deliberately separate because remote availability is

--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -1,11 +1,3 @@
----
-metadata_schema: kungfu.document-metadata/v1
-document_status: active
-doc_type: public-document
-review_state: unreviewed
-sensitivity: public
----
-
 # Adapters — language and framework boundaries
 
 Where the boundaries are between the C++ core and the languages that consume it,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,11 +1,3 @@
----
-metadata_schema: kungfu.document-metadata/v1
-document_status: active
-doc_type: public-document
-review_state: unreviewed
-sensitivity: public
----
-
 # Architecture
 
 How the Kungfu repository is layered, and the principle that shapes it. For the

--- a/docs/buildchain.md
+++ b/docs/buildchain.md
@@ -1,11 +1,3 @@
----
-metadata_schema: kungfu.document-metadata/v1
-document_status: active
-doc_type: public-document
-review_state: unreviewed
-sensitivity: public
----
-
 # Buildchain — from source to binary
 
 How source becomes the binaries you run, and where each binary comes from. This

--- a/docs/choose-your-kungfu.md
+++ b/docs/choose-your-kungfu.md
@@ -1,11 +1,3 @@
----
-metadata_schema: kungfu.document-metadata/v1
-document_status: active
-doc_type: public-document
-review_state: unreviewed
-sensitivity: public
----
-
 # Choose Your Kungfu
 
 Use only the layer you need.

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -1,11 +1,3 @@
----
-metadata_schema: kungfu.document-metadata/v1
-document_status: active
-doc_type: public-document
-review_state: unreviewed
-sensitivity: public
----
-
 # Implementation Concepts
 
 The product names, repository components, and runtime terms used across Kungfu's

--- a/docs/config.md
+++ b/docs/config.md
@@ -1,11 +1,3 @@
----
-metadata_schema: kungfu.document-metadata/v1
-document_status: active
-doc_type: public-document
-review_state: unreviewed
-sensitivity: public
----
-
 # Kungfu Config
 
 Kungfu separates local state into workspace data, user config, and machine data

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -1,11 +1,3 @@
----
-metadata_schema: kungfu.document-metadata/v1
-document_status: active
-doc_type: public-document
-review_state: unreviewed
-sensitivity: public
----
-
 # Contracts — what kungfu actually guarantees
 
 What you can rely on, stated as contracts you can verify, with each one's current

--- a/docs/cost-state-proof-profile.md
+++ b/docs/cost-state-proof-profile.md
@@ -1,11 +1,3 @@
----
-metadata_schema: kungfu.document-metadata/v1
-document_status: active
-doc_type: public-document
-review_state: unreviewed
-sensitivity: public
----
-
 # Cost/State/Proof profile
 
 Cost/State/Proof is the first commercial profile of Kungfu Mission Control. It

--- a/docs/cpp-toolchain.md
+++ b/docs/cpp-toolchain.md
@@ -1,22 +1,3 @@
----
-metadata_schema: kungfu.document-metadata/v1
-document_status: active
-doc_type: reference
-review_state: self-reviewed
-sensitivity: public
-sources: [local-files]
-period: ongoing
-theme: kungfu-cpp-toolchain
-confidence: high
-evidence_grade: A
-last_reviewed: 2026-07-12
-ai_provenance:
-  model_family: GPT-5
-  product: Codex
-  generated_at: 2026-07-12
-  invisible_context: not asserted
----
-
 # C++ toolchain contract
 
 Kungfu uses one native build contract, not one compiler binary on every

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -1,11 +1,3 @@
----
-metadata_schema: kungfu.document-metadata/v1
-document_status: active
-doc_type: public-document
-review_state: unreviewed
-sensitivity: public
----
-
 # Debugging kungfu
 
 If kungfu itself misbehaves — a frame that looks wrong, a component that does not

--- a/docs/design-philosophy.md
+++ b/docs/design-philosophy.md
@@ -1,11 +1,3 @@
----
-metadata_schema: kungfu.document-metadata/v1
-document_status: active
-doc_type: public-document
-review_state: unreviewed
-sensitivity: public
----
-
 # Design Philosophy
 
 Two choices in this repository look wrong at first glance, and both are

--- a/docs/document-metadata.contract.json
+++ b/docs/document-metadata.contract.json
@@ -1,6 +1,21 @@
 {
   "schemaVersion": 1,
   "metadataSchema": "kungfu.document-metadata/v1",
+  "metadataRegistry": "docs/document-metadata.registry.json",
+  "optionalFields": [
+    "sources",
+    "last_reviewed",
+    "period",
+    "theme",
+    "confidence",
+    "evidence_grade",
+    "review_refs",
+    "open_questions",
+    "implementation_commits",
+    "implementation_prs",
+    "closure_commit",
+    "qualification_refs"
+  ],
   "sourceKinds": [
     "architecture-decisions",
     "executable-probe",
@@ -23,11 +38,11 @@
   "profiles": [
     {
       "id": "architecture-decision",
+      "metadataMode": "inline",
       "patterns": [
         "^framework/core/docs/adr/ADR-[0-9]{4}-.*\\.md$",
         "^docs/shifu/adr/SHIFU-ADR-[0-9]{4}-.*\\.md$"
       ],
-      "frontmatterRequired": true,
       "required": [
         "metadata_schema",
         "doc_type",
@@ -63,11 +78,11 @@
     },
     {
       "id": "adr-index",
+      "metadataMode": "inline",
       "files": [
         "framework/core/docs/adr/README.md",
         "docs/shifu/adr/README.md"
       ],
-      "frontmatterRequired": true,
       "required": [
         "metadata_schema",
         "doc_type",
@@ -87,10 +102,44 @@
       "forbidden": ["status", "decision_status", "source_level"]
     },
     {
+      "id": "engineering-evidence",
+      "metadataMode": "inline",
+      "files": [
+        "crates/host-spike/README.md",
+        "docs/episode-atomicity-qualification.md",
+        "docs/libkungfu-embedding-membrane-spike.md",
+        "docs/libwasm-embedding-membrane-spike.md",
+        "docs/rust-host-spike.md",
+        "docs/single-host-performance-qualification.md",
+        "framework/core/docs/carrier-type-registry.md",
+        "framework/core/docs/qualification/mmap-performance.md",
+        "framework/core/docs/strong-durability-and-crash-recovery-design.md",
+        "framework/core/slices/libwasm-shared-membrane/README.md",
+        "framework/core/slices/native-storage-closure/README.md",
+        "framework/core/slices/shared-embedding-membrane/README.md"
+      ],
+      "required": [
+        "metadata_schema",
+        "doc_type",
+        "document_status",
+        "review_state",
+        "sensitivity"
+      ],
+      "constants": {
+        "metadata_schema": "kungfu.document-metadata/v1"
+      },
+      "enums": {
+        "document_status": ["draft", "active", "stable", "deprecated", "archived"],
+        "review_state": ["unreviewed", "self-reviewed", "maintainer-reviewed"],
+        "sensitivity": ["public", "internal"]
+      },
+      "forbidden": ["status", "decision_status", "source_level"]
+    },
+    {
       "id": "public-document",
+      "metadataMode": "registry",
       "files": ["README.md", "AGENTS.md", "CONTRIBUTING.md"],
       "patterns": ["^docs/.*\\.md$", "^framework/spec/.*\\.md$"],
-      "frontmatterRequired": true,
       "required": [
         "metadata_schema",
         "doc_type",
@@ -110,8 +159,8 @@
     },
     {
       "id": "repository-document",
+      "metadataMode": "inline-optional",
       "patterns": [".*"],
-      "frontmatterRequired": false,
       "required": [
         "metadata_schema",
         "doc_type",
@@ -139,5 +188,26 @@
       "index": "docs/shifu/adr/README.md",
       "recordPattern": "^docs/shifu/adr/(SHIFU-ADR-[0-9]{4})-.*\\.md$"
     }
-  ]
+  ],
+  "adrEvidence": {
+    "commitFields": ["implementation_commits"],
+    "pullRequestFields": ["implementation_prs"],
+    "closureCommitField": "closure_commit",
+    "qualificationRefField": "qualification_refs",
+    "statusesRequiringImplementationEvidence": ["partial", "staged", "implemented"],
+    "statusesRequiringClosure": ["implemented"],
+    "statusesForbiddingEvidence": ["not-started", "not-applicable"],
+    "pullRequestPattern": "^https://github\\.com/kungfu-systems/kungfu/pull/[0-9]+$",
+    "legacyEvidenceExemptions": {
+      "SHIFU-ADR-0001": "Partial cache-profile rollout predates immutable evidence capture.",
+      "ADR-0005": "Partial modernization assessment needs a dedicated history reconstruction.",
+      "ADR-0006": "Frontend platform implementation spans legacy history not yet reconstructed.",
+      "ADR-0009": "Self-bootstrap evolved across several renames and needs semantic history review.",
+      "ADR-0046": "Rust host trunk is staged; qualification evidence remains distributed across spike history.",
+      "ADR-0048": "Runtime fact query work is staged and awaiting evidence consolidation.",
+      "ADR-0049": "Layer-complete product work is staged and awaiting evidence consolidation.",
+      "ADR-0068": "Durability work is staged across a planned card series and is not closed.",
+      "ADR-0069": "The agent-first profile suite is staged and awaiting end-to-end qualification."
+    }
+  }
 }

--- a/docs/document-metadata.md
+++ b/docs/document-metadata.md
@@ -1,36 +1,47 @@
----
-metadata_schema: kungfu.document-metadata/v1
-document_status: active
-doc_type: reference
-review_state: maintainer-reviewed
-sensitivity: public
-sources: [local-files, user-consensus]
-last_reviewed: 2026-07-13
----
-
 # Document Metadata Contract
 
-Kungfu treats documentation metadata as an executable product contract. The
-frontmatter identifies what kind of document a file is, which lifecycle axes
-apply to it, and which fields tools may trust. It is not decorative YAML.
+Kungfu treats documentation metadata as an executable product contract. It
+identifies what kind of document a file is, which lifecycle axes apply to it,
+and which fields tools may trust. Metadata is not decorative YAML, and public
+readers should not have to see maintenance records before the document title.
 
 The machine authority is
-[`document-metadata.contract.json`](document-metadata.contract.json). The
-deterministic `./shifu docs:check` gate validates the contract, all governed
-frontmatter, ADR body projections, and ADR registry rows.
+[`document-metadata.contract.json`](document-metadata.contract.json). Public
+sidecar records live in
+[`document-metadata.registry.json`](document-metadata.registry.json). The
+deterministic `./shifu docs:check` gate validates both authorities, governed
+frontmatter, ADR body projections, immutable implementation evidence, and ADR
+registry rows.
+
+## One authority per governed document
+
+The contract routes a governed document to one metadata mode:
+
+- `registry`: public entry, guide, and reference pages keep metadata in the
+  sidecar registry so GitHub and documentation renderers begin with the title.
+- `inline`: ADRs, ADR indexes, qualification contracts, and bounded engineering
+  evidence keep audit context beside the claim it qualifies.
+- `external`: issue templates and Kungfu Skills retain the schema required by
+  their native consumer.
+
+`inline-optional` is the catch-all for package-local repository notes that are
+not part of the governed public reading surface. If one declares Kungfu
+metadata, the same field contract applies. A governed file cannot appear in
+both frontmatter and the registry, and stale registry entries fail the gate.
 
 ## Profiles
 
-| Profile | Coverage | Required authority |
-| --- | --- | --- |
-| public document | repository entry documents, `docs/`, and `framework/spec/` | document lifecycle, type, review state, and public sensitivity |
-| architecture decision | Core and Shifu ADR records | ADR id, decision status, implementation status, review state, and public sensitivity |
-| ADR index | Core and Shifu ADR registries | active index identity and review state; every row must match record metadata |
-| repository document | other tracked Markdown that already declares Kungfu metadata | the base document lifecycle profile |
-| external schema | issue templates and Kungfu Skills | the schema owned by their consumer, not this contract |
+| Profile | Mode | Coverage | Required authority |
+| --- | --- | --- | --- |
+| public document | registry | repository entry documents, `docs/`, and `framework/spec/` | document lifecycle, type, review state, and public sensitivity |
+| architecture decision | inline | Core and Shifu ADR records | ADR id, decision and implementation state, review state, evidence, and public sensitivity |
+| ADR index | inline | Core and Shifu ADR registries | active index identity and review state; every row must match record metadata |
+| engineering evidence | inline | selected spikes, qualification contracts, and implementation slices | local audit context for a bounded engineering claim |
+| repository document | inline optional | other tracked Markdown that declares Kungfu metadata | the base document lifecycle profile |
+| external schema | external | issue templates and Kungfu Skills | the schema owned by their consumer, not this contract |
 
-The contract intentionally does not require frontmatter on every nested package
-README. A repository document may remain headerless until it needs governed
+The contract intentionally does not require metadata on every nested package
+README. A repository document may remain ungoverned until it needs typed
 metadata. Once it declares Kungfu metadata, it must use the current schema.
 
 ## Separate lifecycle axes
@@ -49,16 +60,17 @@ some files and decision state in others.
   for migrated ADRs whose historical review cannot be reconstructed honestly.
 
 `unknown` and `legacy-unreviewed` are deliberate evidence boundaries. Do not
-invent implementation completion, review, dates, sources, or AI provenance to
-make an older file look complete.
+invent implementation completion, review, dates, or sources to make an older
+file look complete.
 
-## Sources and provenance
+## Sources and public maintenance boundary
 
-Use the structured inline `sources` list and only the values declared by the
-contract. Do not concatenate source names into a free-form `source_level`
-string. `ai_provenance` remains conditional: include it when an AI materially
-generated or rewrote the document and the visible generation context is known;
-do not fabricate it for historical records.
+Use the structured `sources` list and only the values declared by the contract.
+Do not concatenate source names into a free-form `source_level` string. Public
+Kungfu metadata records evidence about the product and its decisions; it does
+not carry tool-generation or automated-maintenance attribution. Private work
+coordination may retain that information in its own authority, but it is not
+part of the public product contract.
 
 ## ADR projection rule
 
@@ -80,9 +92,42 @@ contain the record and show the same canonical decision status. Implementation
 detail belongs in `implementation_status` and the ADR body, not in a compound
 registry status cell.
 
+## ADR implementation evidence
+
+An implementation state is a claim, so ADRs may bind it to immutable evidence:
+
+```yaml
+implementation_commits: [68dc33a3f3daa56ac1893f9e8671575c6e85f9a8]
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/123]
+closure_commit: 68dc33a3f3daa56ac1893f9e8671575c6e85f9a8
+qualification_refs: [framework/core/docs/qualification/mmap-performance.md]
+```
+
+- `implementation_commits` contains full 40-character SHAs for implementation
+  slices.
+- `implementation_prs` contains stable pull-request URLs when review history is
+  part of the evidence.
+- `closure_commit` identifies the reachable commit at which the accepted scope
+  was considered fulfilled. It may be the final implementation slice or a
+  dedicated closure record.
+- `qualification_refs` contains existing repository-relative evidence paths or
+  `commit:<full-sha>` references.
+
+The gate validates shape, repository identity, local commit existence,
+reachability from the checked-out mainline, and contradictions such as evidence
+on a `not-started` ADR. It cannot prove that code semantically fulfills a
+decision. That judgment remains a review responsibility.
+
+Implemented, staged, and partial legacy ADRs without reconstructed immutable
+evidence must appear in the contract's reviewed exemption ledger. New claims do
+not silently inherit that exemption. Stale exemptions fail the gate once the
+required evidence is present or the status no longer needs it. Do not invent a
+convenient commit to make coverage look complete.
+
 ## Changing the contract
 
-Change the JSON contract, validator, fixtures, affected documents, and this
-reference together. Add a negative fixture for every new failure mode. Prefer
-extending an existing profile over adding one; create a new profile only when a
-different consumer or lifecycle semantics make the distinction load-bearing.
+Change the JSON contract, registry, validator, fixtures, affected documents,
+and this reference together. Add a negative fixture for every new failure mode.
+Prefer extending an existing profile over adding one; create a new profile only
+when a different consumer or lifecycle semantics make the distinction
+load-bearing.

--- a/docs/document-metadata.registry.json
+++ b/docs/document-metadata.registry.json
@@ -1,0 +1,457 @@
+{
+  "schemaVersion": 1,
+  "metadataSchema": "kungfu.document-metadata/v1",
+  "documents": {
+    "AGENTS.md": {
+      "metadata_schema": "kungfu.document-metadata/v1",
+      "document_status": "active",
+      "doc_type": "public-document",
+      "review_state": "unreviewed",
+      "sensitivity": "public"
+    },
+    "CONTRIBUTING.md": {
+      "metadata_schema": "kungfu.document-metadata/v1",
+      "document_status": "active",
+      "doc_type": "public-document",
+      "review_state": "unreviewed",
+      "sensitivity": "public"
+    },
+    "README.md": {
+      "metadata_schema": "kungfu.document-metadata/v1",
+      "document_status": "active",
+      "doc_type": "public-document",
+      "review_state": "unreviewed",
+      "sensitivity": "public"
+    },
+    "docs/MAP.md": {
+      "metadata_schema": "kungfu.document-metadata/v1",
+      "document_status": "active",
+      "doc_type": "public-document",
+      "review_state": "unreviewed",
+      "sensitivity": "public"
+    },
+    "docs/README.md": {
+      "metadata_schema": "kungfu.document-metadata/v1",
+      "document_status": "active",
+      "doc_type": "public-document",
+      "review_state": "unreviewed",
+      "sensitivity": "public"
+    },
+    "docs/adapters.md": {
+      "metadata_schema": "kungfu.document-metadata/v1",
+      "document_status": "active",
+      "doc_type": "public-document",
+      "review_state": "unreviewed",
+      "sensitivity": "public"
+    },
+    "docs/architecture.md": {
+      "metadata_schema": "kungfu.document-metadata/v1",
+      "document_status": "active",
+      "doc_type": "public-document",
+      "review_state": "unreviewed",
+      "sensitivity": "public"
+    },
+    "docs/buildchain.md": {
+      "metadata_schema": "kungfu.document-metadata/v1",
+      "document_status": "active",
+      "doc_type": "public-document",
+      "review_state": "unreviewed",
+      "sensitivity": "public"
+    },
+    "docs/choose-your-kungfu.md": {
+      "metadata_schema": "kungfu.document-metadata/v1",
+      "document_status": "active",
+      "doc_type": "public-document",
+      "review_state": "unreviewed",
+      "sensitivity": "public"
+    },
+    "docs/concepts.md": {
+      "metadata_schema": "kungfu.document-metadata/v1",
+      "document_status": "active",
+      "doc_type": "public-document",
+      "review_state": "unreviewed",
+      "sensitivity": "public"
+    },
+    "docs/config.md": {
+      "metadata_schema": "kungfu.document-metadata/v1",
+      "document_status": "active",
+      "doc_type": "public-document",
+      "review_state": "unreviewed",
+      "sensitivity": "public"
+    },
+    "docs/contracts.md": {
+      "metadata_schema": "kungfu.document-metadata/v1",
+      "document_status": "active",
+      "doc_type": "public-document",
+      "review_state": "unreviewed",
+      "sensitivity": "public"
+    },
+    "docs/cost-state-proof-profile.md": {
+      "metadata_schema": "kungfu.document-metadata/v1",
+      "document_status": "active",
+      "doc_type": "public-document",
+      "review_state": "unreviewed",
+      "sensitivity": "public"
+    },
+    "docs/cpp-toolchain.md": {
+      "metadata_schema": "kungfu.document-metadata/v1",
+      "document_status": "active",
+      "doc_type": "reference",
+      "review_state": "self-reviewed",
+      "sensitivity": "public",
+      "sources": [
+        "local-files"
+      ],
+      "period": "ongoing",
+      "theme": "kungfu-cpp-toolchain",
+      "confidence": "high",
+      "evidence_grade": "A",
+      "last_reviewed": "2026-07-12"
+    },
+    "docs/debugging.md": {
+      "metadata_schema": "kungfu.document-metadata/v1",
+      "document_status": "active",
+      "doc_type": "public-document",
+      "review_state": "unreviewed",
+      "sensitivity": "public"
+    },
+    "docs/design-philosophy.md": {
+      "metadata_schema": "kungfu.document-metadata/v1",
+      "document_status": "active",
+      "doc_type": "public-document",
+      "review_state": "unreviewed",
+      "sensitivity": "public"
+    },
+    "docs/document-metadata.md": {
+      "metadata_schema": "kungfu.document-metadata/v1",
+      "document_status": "active",
+      "doc_type": "reference",
+      "review_state": "maintainer-reviewed",
+      "sensitivity": "public",
+      "sources": [
+        "local-files",
+        "user-consensus"
+      ],
+      "last_reviewed": "2026-07-13"
+    },
+    "docs/domain-horizons.md": {
+      "metadata_schema": "kungfu.document-metadata/v1",
+      "document_status": "active",
+      "doc_type": "public-document",
+      "review_state": "unreviewed",
+      "sensitivity": "public"
+    },
+    "docs/durability-and-crash-recovery.md": {
+      "metadata_schema": "kungfu.document-metadata/v1",
+      "document_status": "draft",
+      "doc_type": "capability-overview",
+      "review_state": "self-reviewed",
+      "sensitivity": "public",
+      "sources": [
+        "architecture-decisions",
+        "local-files"
+      ],
+      "period": "2026-07-12",
+      "theme": "strong-durability-and-crash-recovery",
+      "confidence": "high",
+      "evidence_grade": "B",
+      "last_reviewed": "2026-07-12"
+    },
+    "docs/episode-object-model.md": {
+      "metadata_schema": "kungfu.document-metadata/v1",
+      "document_status": "active",
+      "doc_type": "public-document",
+      "review_state": "unreviewed",
+      "sensitivity": "public"
+    },
+    "docs/event-model.md": {
+      "metadata_schema": "kungfu.document-metadata/v1",
+      "document_status": "active",
+      "doc_type": "public-document",
+      "review_state": "unreviewed",
+      "sensitivity": "public"
+    },
+    "docs/extensions.md": {
+      "metadata_schema": "kungfu.document-metadata/v1",
+      "document_status": "active",
+      "doc_type": "public-document",
+      "review_state": "unreviewed",
+      "sensitivity": "public"
+    },
+    "docs/fact-surface-admission.md": {
+      "metadata_schema": "kungfu.document-metadata/v1",
+      "document_status": "active",
+      "doc_type": "public-document",
+      "review_state": "unreviewed",
+      "sensitivity": "public"
+    },
+    "docs/facts-before-trust.md": {
+      "metadata_schema": "kungfu.document-metadata/v1",
+      "document_status": "active",
+      "doc_type": "public-document",
+      "review_state": "unreviewed",
+      "sensitivity": "public"
+    },
+    "docs/journal-page-sizing-and-episode-reclamation.md": {
+      "metadata_schema": "kungfu.document-metadata/v1",
+      "document_status": "active",
+      "doc_type": "public-document",
+      "review_state": "unreviewed",
+      "sensitivity": "public"
+    },
+    "docs/kfd-native-sdk-release-gates.md": {
+      "metadata_schema": "kungfu.document-metadata/v1",
+      "document_status": "active",
+      "doc_type": "public-document",
+      "review_state": "unreviewed",
+      "sensitivity": "public"
+    },
+    "docs/kfd2-trust-assessment.md": {
+      "metadata_schema": "kungfu.document-metadata/v1",
+      "document_status": "active",
+      "doc_type": "public-document",
+      "review_state": "unreviewed",
+      "sensitivity": "public"
+    },
+    "docs/kfx-topology.md": {
+      "metadata_schema": "kungfu.document-metadata/v1",
+      "document_status": "active",
+      "doc_type": "public-document",
+      "review_state": "unreviewed",
+      "sensitivity": "public"
+    },
+    "docs/known-limits.md": {
+      "metadata_schema": "kungfu.document-metadata/v1",
+      "document_status": "active",
+      "doc_type": "public-document",
+      "review_state": "unreviewed",
+      "sensitivity": "public"
+    },
+    "docs/mission-control-workspaces.md": {
+      "metadata_schema": "kungfu.document-metadata/v1",
+      "document_status": "draft",
+      "doc_type": "product-design",
+      "review_state": "unreviewed",
+      "sensitivity": "public",
+      "sources": [
+        "local-files",
+        "user-consensus"
+      ],
+      "period": "2026-07-11",
+      "theme": "kungfu-mission-control-workspaces",
+      "confidence": "high",
+      "evidence_grade": "B",
+      "last_reviewed": "2026-07-11"
+    },
+    "docs/mission-control.md": {
+      "metadata_schema": "kungfu.document-metadata/v1",
+      "document_status": "draft",
+      "doc_type": "product-design",
+      "review_state": "unreviewed",
+      "sensitivity": "public",
+      "sources": [
+        "local-files",
+        "user-consensus"
+      ],
+      "period": "2026-07-12",
+      "theme": "kungfu-mission-control",
+      "confidence": "high",
+      "evidence_grade": "B",
+      "last_reviewed": "2026-07-12"
+    },
+    "docs/product-layers.md": {
+      "metadata_schema": "kungfu.document-metadata/v1",
+      "document_status": "active",
+      "doc_type": "public-document",
+      "review_state": "unreviewed",
+      "sensitivity": "public"
+    },
+    "docs/profile-authoring.md": {
+      "metadata_schema": "kungfu.document-metadata/v1",
+      "document_status": "draft",
+      "doc_type": "public-document",
+      "review_state": "self-reviewed",
+      "sensitivity": "public"
+    },
+    "docs/profile-lifecycle.md": {
+      "metadata_schema": "kungfu.document-metadata/v1",
+      "document_status": "draft",
+      "doc_type": "public-document",
+      "review_state": "self-reviewed",
+      "sensitivity": "public"
+    },
+    "docs/python-environments.md": {
+      "metadata_schema": "kungfu.document-metadata/v1",
+      "document_status": "active",
+      "doc_type": "public-document",
+      "review_state": "unreviewed",
+      "sensitivity": "public"
+    },
+    "docs/querying-runtime-facts.md": {
+      "metadata_schema": "kungfu.document-metadata/v1",
+      "document_status": "active",
+      "doc_type": "public-document",
+      "review_state": "unreviewed",
+      "sensitivity": "public"
+    },
+    "docs/rewind.md": {
+      "metadata_schema": "kungfu.document-metadata/v1",
+      "document_status": "active",
+      "doc_type": "public-document",
+      "review_state": "unreviewed",
+      "sensitivity": "public"
+    },
+    "docs/runtime-service.md": {
+      "metadata_schema": "kungfu.document-metadata/v1",
+      "document_status": "active",
+      "doc_type": "public-document",
+      "review_state": "unreviewed",
+      "sensitivity": "public"
+    },
+    "docs/runtime-storage-service.md": {
+      "metadata_schema": "kungfu.document-metadata/v1",
+      "document_status": "active",
+      "doc_type": "public-document",
+      "review_state": "unreviewed",
+      "sensitivity": "public"
+    },
+    "docs/rust-adoption.md": {
+      "metadata_schema": "kungfu.document-metadata/v1",
+      "document_status": "active",
+      "doc_type": "public-document",
+      "review_state": "unreviewed",
+      "sensitivity": "public"
+    },
+    "docs/shifu/README.md": {
+      "metadata_schema": "kungfu.document-metadata/v1",
+      "document_status": "draft",
+      "doc_type": "documentation-map",
+      "review_state": "unreviewed",
+      "sensitivity": "public",
+      "sources": [
+        "local-files"
+      ],
+      "period": "ongoing",
+      "theme": "shifu",
+      "confidence": "high",
+      "evidence_grade": "B",
+      "last_reviewed": "2026-07-12"
+    },
+    "docs/shifu/cache-profiles.md": {
+      "metadata_schema": "kungfu.document-metadata/v1",
+      "document_status": "draft",
+      "doc_type": "design-reference",
+      "review_state": "unreviewed",
+      "sensitivity": "public",
+      "sources": [
+        "local-files"
+      ],
+      "period": "ongoing",
+      "theme": "shifu-cache-profiles",
+      "confidence": "high",
+      "evidence_grade": "B",
+      "last_reviewed": "2026-07-12"
+    },
+    "docs/single-host-institutional-trust.md": {
+      "metadata_schema": "kungfu.document-metadata/v1",
+      "document_status": "draft",
+      "doc_type": "adoption-contract",
+      "review_state": "self-reviewed",
+      "sensitivity": "public",
+      "sources": [
+        "architecture-decisions",
+        "local-files"
+      ],
+      "period": "2026-07-12",
+      "theme": "single-host-institutional-trust",
+      "confidence": "high",
+      "evidence_grade": "B",
+      "last_reviewed": "2026-07-12"
+    },
+    "docs/skills.md": {
+      "metadata_schema": "kungfu.document-metadata/v1",
+      "document_status": "active",
+      "doc_type": "public-document",
+      "review_state": "unreviewed",
+      "sensitivity": "public"
+    },
+    "docs/the-episode.md": {
+      "metadata_schema": "kungfu.document-metadata/v1",
+      "document_status": "active",
+      "doc_type": "public-document",
+      "review_state": "unreviewed",
+      "sensitivity": "public"
+    },
+    "docs/version-release-design.md": {
+      "metadata_schema": "kungfu.document-metadata/v1",
+      "document_status": "active",
+      "doc_type": "public-document",
+      "review_state": "unreviewed",
+      "sensitivity": "public"
+    },
+    "docs/versioning.md": {
+      "metadata_schema": "kungfu.document-metadata/v1",
+      "document_status": "active",
+      "doc_type": "public-document",
+      "review_state": "unreviewed",
+      "sensitivity": "public"
+    },
+    "docs/vocabulary.md": {
+      "metadata_schema": "kungfu.document-metadata/v1",
+      "document_status": "active",
+      "doc_type": "public-document",
+      "review_state": "unreviewed",
+      "sensitivity": "public"
+    },
+    "framework/spec/CONSUMING.md": {
+      "metadata_schema": "kungfu.document-metadata/v1",
+      "document_status": "active",
+      "doc_type": "public-document",
+      "review_state": "unreviewed",
+      "sensitivity": "public"
+    },
+    "framework/spec/README.md": {
+      "metadata_schema": "kungfu.document-metadata/v1",
+      "document_status": "active",
+      "doc_type": "public-document",
+      "review_state": "unreviewed",
+      "sensitivity": "public"
+    },
+    "framework/spec/docs/format-spec.md": {
+      "metadata_schema": "kungfu.document-metadata/v1",
+      "document_status": "active",
+      "doc_type": "public-document",
+      "review_state": "unreviewed",
+      "sensitivity": "public"
+    },
+    "framework/spec/docs/handbooks/cli.md": {
+      "metadata_schema": "kungfu.document-metadata/v1",
+      "document_status": "active",
+      "doc_type": "public-document",
+      "review_state": "unreviewed",
+      "sensitivity": "public"
+    },
+    "framework/spec/docs/handbooks/node.md": {
+      "metadata_schema": "kungfu.document-metadata/v1",
+      "document_status": "active",
+      "doc_type": "public-document",
+      "review_state": "unreviewed",
+      "sensitivity": "public"
+    },
+    "framework/spec/docs/handbooks/python.md": {
+      "metadata_schema": "kungfu.document-metadata/v1",
+      "document_status": "active",
+      "doc_type": "public-document",
+      "review_state": "unreviewed",
+      "sensitivity": "public"
+    },
+    "framework/spec/docs/overview.md": {
+      "metadata_schema": "kungfu.document-metadata/v1",
+      "document_status": "active",
+      "doc_type": "public-document",
+      "review_state": "unreviewed",
+      "sensitivity": "public"
+    }
+  }
+}
+

--- a/docs/domain-horizons.md
+++ b/docs/domain-horizons.md
@@ -1,11 +1,3 @@
----
-metadata_schema: kungfu.document-metadata/v1
-document_status: active
-doc_type: public-document
-review_state: unreviewed
-sensitivity: public
----
-
 # Domain horizons for the runtime-fact core
 
 Kungfu's current product focus is accountable agent runtime. Its native core is

--- a/docs/durability-and-crash-recovery.md
+++ b/docs/durability-and-crash-recovery.md
@@ -1,22 +1,3 @@
----
-metadata_schema: kungfu.document-metadata/v1
-document_status: draft
-doc_type: capability-overview
-review_state: self-reviewed
-sensitivity: public
-sources: [architecture-decisions, local-files]
-period: 2026-07-12
-theme: strong-durability-and-crash-recovery
-confidence: high
-evidence_grade: B
-last_reviewed: 2026-07-12
-ai_provenance:
-  model_family: GPT-5
-  product: Codex
-  generated_at: 2026-07-12
-  invisible_context_boundary: Exact hidden model build, untested hardware behavior, and future implementation results are unknown
----
-
 # Strong durability and crash recovery
 
 Kungfu's target is unusual but deliberate: preserve the low-latency and

--- a/docs/episode-atomicity-qualification.md
+++ b/docs/episode-atomicity-qualification.md
@@ -10,12 +10,6 @@ theme: episode-atomicity-qualification
 confidence: medium-high
 evidence_grade: B
 last_reviewed: 2026-07-10
-ai_provenance:
-  model_family: GPT-5
-  product: Codex
-  generated_at: 2026-07-10
-  visible_context: ADR-0042 design discussion, current Episode v1 implementation/tests, and Kungfu fuzz/verification conventions
-  invisible_context_boundary: The current harness and first local single-node baselines are visible; no multi-platform CI result, fleet-scale run, payload-volume qualification, or industrial soak is available yet
 ---
 
 # Episode Atomicity Qualification

--- a/docs/episode-object-model.md
+++ b/docs/episode-object-model.md
@@ -1,11 +1,3 @@
----
-metadata_schema: kungfu.document-metadata/v1
-document_status: active
-doc_type: public-document
-review_state: unreviewed
-sensitivity: public
----
-
 # Episode Object Model
 
 Status: accepted design direction with v1 implementation. The term and

--- a/docs/event-model.md
+++ b/docs/event-model.md
@@ -1,11 +1,3 @@
----
-metadata_schema: kungfu.document-metadata/v1
-document_status: active
-doc_type: public-document
-review_state: unreviewed
-sensitivity: public
----
-
 # Event Model — journal, frame, replay
 
 How kungfu represents and moves data. This is the *use* reference for the data

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -1,11 +1,3 @@
----
-metadata_schema: kungfu.document-metadata/v1
-document_status: active
-doc_type: public-document
-review_state: unreviewed
-sensitivity: public
----
-
 # Extensions (kfx)
 
 How to write, build and install a kungfu extension. This is the

--- a/docs/fact-surface-admission.md
+++ b/docs/fact-surface-admission.md
@@ -1,11 +1,3 @@
----
-metadata_schema: kungfu.document-metadata/v1
-document_status: active
-doc_type: public-document
-review_state: unreviewed
-sensitivity: public
----
-
 # Bringing domain facts into Kungfu
 
 Kungfu can preserve and query facts from a product, user, extension, or domain

--- a/docs/facts-before-trust.md
+++ b/docs/facts-before-trust.md
@@ -1,11 +1,3 @@
----
-metadata_schema: kungfu.document-metadata/v1
-document_status: active
-doc_type: public-document
-review_state: unreviewed
-sensitivity: public
----
-
 # Facts Before Trust
 
 Kungfu starts from the rule KFD makes explicit:

--- a/docs/journal-page-sizing-and-episode-reclamation.md
+++ b/docs/journal-page-sizing-and-episode-reclamation.md
@@ -1,11 +1,3 @@
----
-metadata_schema: kungfu.document-metadata/v1
-document_status: active
-doc_type: public-document
-review_state: unreviewed
-sensitivity: public
----
-
 # Design note: journal page sizing, max-frame, and Episode-aware reclamation
 
 - Status: design judgment (note, not a decision record)

--- a/docs/kfd-native-sdk-release-gates.md
+++ b/docs/kfd-native-sdk-release-gates.md
@@ -1,11 +1,3 @@
----
-metadata_schema: kungfu.document-metadata/v1
-document_status: active
-doc_type: public-document
-review_state: unreviewed
-sensitivity: public
----
-
 # KFD-Native SDK And Release Gates
 
 This records how KFD-1/2/3 are native to Kungfu developer workflows and

--- a/docs/kfd2-trust-assessment.md
+++ b/docs/kfd2-trust-assessment.md
@@ -1,11 +1,3 @@
----
-metadata_schema: kungfu.document-metadata/v1
-document_status: active
-doc_type: public-document
-review_state: unreviewed
-sensitivity: public
----
-
 # KFD-2 trust assessment in a live workspace
 
 Kungfu records work continuously, but it does not run a full trust analysis

--- a/docs/kfx-topology.md
+++ b/docs/kfx-topology.md
@@ -1,11 +1,3 @@
----
-metadata_schema: kungfu.document-metadata/v1
-document_status: active
-doc_type: public-document
-review_state: unreviewed
-sensitivity: public
----
-
 # kfx topology — how a kfx is loaded, trusted, confined, and connected
 
 This page is the mental model behind [`extensions.md`](extensions.md). That page

--- a/docs/known-limits.md
+++ b/docs/known-limits.md
@@ -1,11 +1,3 @@
----
-metadata_schema: kungfu.document-metadata/v1
-document_status: active
-doc_type: public-document
-review_state: unreviewed
-sensitivity: public
----
-
 # Known Limits
 
 What kungfu does *not* yet guarantee, stated plainly. This is part of answering

--- a/docs/libkungfu-embedding-membrane-spike.md
+++ b/docs/libkungfu-embedding-membrane-spike.md
@@ -10,11 +10,6 @@ theme: libkungfu-shared-embedding-membrane
 confidence: high
 evidence_grade: A
 last_reviewed: 2026-07-11
-ai_provenance:
-  model_family: GPT-5
-  product: Codex
-  generated_at: 2026-07-10
-  invisible_context: exact model build and hidden reasoning unavailable
 ---
 
 # libkungfu shared embedding membrane spike

--- a/docs/libwasm-embedding-membrane-spike.md
+++ b/docs/libwasm-embedding-membrane-spike.md
@@ -10,12 +10,6 @@ theme: libwasm-shared-embedding-membrane
 confidence: high
 evidence_grade: B
 last_reviewed: 2026-07-11
-ai_provenance:
-  model_family: GPT-5
-  product: Codex
-  generated_at: 2026-07-11
-  visible_context: ADR-0045, the merged libkungfu embedding membrane, official Wasmtime and Wasmer Rust APIs, and run 29138796710 on macOS ARM64, Linux x64, and Windows x64
-  invisible_context_boundary: Exact hidden model build and unimplemented production admission, receipt, WIT, and Wasmer CPU-metering behavior are unknown
 ---
 
 # libwasm shared embedding membrane spike

--- a/docs/mission-control-workspaces.md
+++ b/docs/mission-control-workspaces.md
@@ -1,23 +1,3 @@
----
-metadata_schema: kungfu.document-metadata/v1
-document_status: draft
-doc_type: product-design
-review_state: unreviewed
-sensitivity: public
-sources: [local-files, user-consensus]
-period: 2026-07-11
-theme: kungfu-mission-control-workspaces
-confidence: high
-evidence_grade: B
-last_reviewed: 2026-07-11
-ai_provenance:
-  model_family: GPT-5
-  product: Codex
-  generated_at: 2026-07-11
-  visible_context: User product requirements, Atlas Mission working model, ADR-0035, ADR-0048, ADR-0051, ADR-0052, ADR-0059, Work Dashboard source, config and product launcher code, Saved Query Catalog source
-  invisible_context_boundary: Did not inspect private Atlas document bodies, provider payloads, credentials, or hidden model state
----
-
 # Mission Control Workspace Product Design
 
 ## Product outcome

--- a/docs/mission-control.md
+++ b/docs/mission-control.md
@@ -1,22 +1,3 @@
----
-metadata_schema: kungfu.document-metadata/v1
-document_status: draft
-doc_type: product-design
-review_state: unreviewed
-sensitivity: public
-sources: [local-files, user-consensus]
-period: 2026-07-12
-theme: kungfu-mission-control
-confidence: high
-evidence_grade: B
-last_reviewed: 2026-07-12
-ai_provenance:
-  model_family: GPT-5
-  product: Codex
-  generated_at: 2026-07-12
-  unavailable_details: exact model checkpoint and hidden runtime parameters
----
-
 # Kungfu Mission Control
 
 Kungfu Mission Control is the local-first responsibility layer that connects a

--- a/docs/product-layers.md
+++ b/docs/product-layers.md
@@ -1,11 +1,3 @@
----
-metadata_schema: kungfu.document-metadata/v1
-document_status: active
-doc_type: public-document
-review_state: unreviewed
-sensitivity: public
----
-
 # Product Layers
 
 Independent adoption from the App to the format.

--- a/docs/profile-authoring.md
+++ b/docs/profile-authoring.md
@@ -1,11 +1,3 @@
----
-metadata_schema: kungfu.document-metadata/v1
-document_status: draft
-doc_type: public-document
-review_state: self-reviewed
-sensitivity: public
----
-
 # Agent-first Profile authoring
 
 An installed Kungfu product can author and operate a KFX Profile Suite without

--- a/docs/profile-lifecycle.md
+++ b/docs/profile-lifecycle.md
@@ -1,11 +1,3 @@
----
-metadata_schema: kungfu.document-metadata/v1
-document_status: draft
-doc_type: public-document
-review_state: self-reviewed
-sensitivity: public
----
-
 # KFX Profile Suite lifecycle
 
 The Profile lifecycle turns a schema-valid `kungfu.profile-suite/v1`

--- a/docs/python-environments.md
+++ b/docs/python-environments.md
@@ -1,11 +1,3 @@
----
-metadata_schema: kungfu.document-metadata/v1
-document_status: active
-doc_type: public-document
-review_state: unreviewed
-sensitivity: public
----
-
 # Python environments — `kungfu env`
 
 How to use the full Python package ecosystem (PyTorch-class included) with

--- a/docs/querying-runtime-facts.md
+++ b/docs/querying-runtime-facts.md
@@ -1,11 +1,3 @@
----
-metadata_schema: kungfu.document-metadata/v1
-document_status: active
-doc_type: public-document
-review_state: unreviewed
-sensitivity: public
----
-
 # Querying runtime facts
 
 Kungfu's runtime fact ledger is designed to answer both current-state and

--- a/docs/rewind.md
+++ b/docs/rewind.md
@@ -1,11 +1,3 @@
----
-metadata_schema: kungfu.document-metadata/v1
-document_status: active
-doc_type: public-document
-review_state: unreviewed
-sensitivity: public
----
-
 # Rewind an Episode
 
 Rewind is the user-facing operation of reopening an **Episode** for causal

--- a/docs/runtime-service.md
+++ b/docs/runtime-service.md
@@ -1,11 +1,3 @@
----
-metadata_schema: kungfu.document-metadata/v1
-document_status: active
-doc_type: public-document
-review_state: unreviewed
-sensitivity: public
----
-
 # Kungfu Runtime Service
 
 Status: draft implementation slice.

--- a/docs/runtime-storage-service.md
+++ b/docs/runtime-storage-service.md
@@ -1,11 +1,3 @@
----
-metadata_schema: kungfu.document-metadata/v1
-document_status: active
-doc_type: public-document
-review_state: unreviewed
-sensitivity: public
----
-
 # Runtime Storage Service
 
 Status: draft design plan with implemented Atlas and generic source first

--- a/docs/rust-adoption.md
+++ b/docs/rust-adoption.md
@@ -1,11 +1,3 @@
----
-metadata_schema: kungfu.document-metadata/v1
-document_status: active
-doc_type: public-document
-review_state: unreviewed
-sensitivity: public
----
-
 # Rust adoption paradigm
 
 Kungfu treats Rust as a **first-class option**, not a migration target: the

--- a/docs/rust-host-spike.md
+++ b/docs/rust-host-spike.md
@@ -10,11 +10,6 @@ theme: rust-host-spike
 confidence: medium
 evidence_grade: B
 last_reviewed: 2026-07-10
-ai_provenance:
-  model_family: GPT-5
-  product: Codex
-  generated_at: 2026-07-10
-  invisible_context: exact model build and hidden reasoning unavailable
 ---
 
 # Rust host shell — feasibility spike report

--- a/docs/shifu/README.md
+++ b/docs/shifu/README.md
@@ -1,17 +1,3 @@
----
-metadata_schema: kungfu.document-metadata/v1
-document_status: draft
-doc_type: documentation-map
-review_state: unreviewed
-sensitivity: public
-sources: [local-files]
-period: ongoing
-theme: shifu
-confidence: high
-evidence_grade: B
-last_reviewed: 2026-07-12
----
-
 # Shifu
 
 Shifu is Kungfu's development and build execution tool. It opens a checkout,

--- a/docs/shifu/cache-profiles.md
+++ b/docs/shifu/cache-profiles.md
@@ -1,17 +1,3 @@
----
-metadata_schema: kungfu.document-metadata/v1
-document_status: draft
-doc_type: design-reference
-review_state: unreviewed
-sensitivity: public
-sources: [local-files]
-period: ongoing
-theme: shifu-cache-profiles
-confidence: high
-evidence_grade: B
-last_reviewed: 2026-07-12
----
-
 # Shifu cache profiles
 
 A cache profile is a generated, secret-free instruction set for one principal,

--- a/docs/single-host-institutional-trust.md
+++ b/docs/single-host-institutional-trust.md
@@ -1,22 +1,3 @@
----
-metadata_schema: kungfu.document-metadata/v1
-document_status: draft
-doc_type: adoption-contract
-review_state: self-reviewed
-sensitivity: public
-sources: [architecture-decisions, local-files]
-period: 2026-07-12
-theme: single-host-institutional-trust
-confidence: high
-evidence_grade: B
-last_reviewed: 2026-07-12
-ai_provenance:
-  model_family: GPT-5
-  product: Codex
-  generated_at: 2026-07-12
-  invisible_context_boundary: Exact hidden model build, untested hardware behavior, future qualification results, and institution-specific controls are unknown
----
-
 # Single-host institutional trust profile
 
 This page is for an institution deciding whether Kungfu can serve as a local

--- a/docs/single-host-performance-qualification.md
+++ b/docs/single-host-performance-qualification.md
@@ -10,11 +10,6 @@ theme: single-host-performance-qualification
 confidence: high
 evidence_grade: B
 last_reviewed: 2026-07-12
-ai_provenance:
-  model_family: GPT-5
-  product: Codex
-  generated_at: 2026-07-12
-  invisible_context_boundary: Future implementation results, qualification hardware, retained benchmark evidence, and third-party product changes are unknown
 ---
 
 # Single-host end-to-end performance qualification

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -1,11 +1,3 @@
----
-metadata_schema: kungfu.document-metadata/v1
-document_status: active
-doc_type: public-document
-review_state: unreviewed
-sensitivity: public
----
-
 # Kungfu Skills
 
 Kungfu Skills are the agent-facing capability layer above kfx. A skill teaches

--- a/docs/the-episode.md
+++ b/docs/the-episode.md
@@ -1,11 +1,3 @@
----
-metadata_schema: kungfu.document-metadata/v1
-document_status: active
-doc_type: public-document
-review_state: unreviewed
-sensitivity: public
----
-
 # The Episode
 
 ## A vocabulary for real-world agent work

--- a/docs/version-release-design.md
+++ b/docs/version-release-design.md
@@ -1,11 +1,3 @@
----
-metadata_schema: kungfu.document-metadata/v1
-document_status: active
-doc_type: public-document
-review_state: unreviewed
-sensitivity: public
----
-
 # Version & Release Mechanism — Design Rationale
 
 > Audience: maintainers evaluating, extending, or considering replacing

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -1,11 +1,3 @@
----
-metadata_schema: kungfu.document-metadata/v1
-document_status: active
-doc_type: public-document
-review_state: unreviewed
-sensitivity: public
----
-
 # Versioning — welded surfaces and the decision log
 
 How this repository decides patch, minor, and major. The rule is

--- a/docs/vocabulary.md
+++ b/docs/vocabulary.md
@@ -1,11 +1,3 @@
----
-metadata_schema: kungfu.document-metadata/v1
-document_status: active
-doc_type: public-document
-review_state: unreviewed
-sensitivity: public
----
-
 # Kungfu Vocabulary Reference
 
 This reference defines the public language Kungfu uses for real-world

--- a/framework/core/docs/adr/ADR-0001-yijinjing-publish-barrier.md
+++ b/framework/core/docs/adr/ADR-0001-yijinjing-publish-barrier.md
@@ -4,6 +4,9 @@ doc_type: architecture-decision
 adr_id: ADR-0001
 decision_status: accepted
 implementation_status: implemented
+implementation_commits: [879e7acfeb23be6c82cd17f1563f9ae412f06a03]
+closure_commit: edbcab6980f402b5403fefaf863924c645fdb6be
+qualification_refs: [framework/core/src/libyijinjing/tests/mmap_tests.cpp]
 review_state: legacy-unreviewed
 sensitivity: public
 ---

--- a/framework/core/docs/adr/ADR-0011-v4-capability-sdk-contract.md
+++ b/framework/core/docs/adr/ADR-0011-v4-capability-sdk-contract.md
@@ -4,6 +4,9 @@ doc_type: architecture-decision
 adr_id: ADR-0011
 decision_status: accepted
 implementation_status: implemented
+implementation_commits: [c25fdaa88469d8fa614cde6585c6d07685308874]
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/152]
+closure_commit: b804326d1ce0e11fda5332746fbd0ce0d5603e17
 review_state: legacy-unreviewed
 sensitivity: public
 ---

--- a/framework/core/docs/adr/ADR-0037-storage-records-hana-core-kernel-metadata.md
+++ b/framework/core/docs/adr/ADR-0037-storage-records-hana-core-kernel-metadata.md
@@ -4,6 +4,9 @@ doc_type: architecture-decision
 adr_id: ADR-0037
 decision_status: accepted
 implementation_status: implemented
+implementation_commits: [90dbc34f4ade3fbc6801f7e5c5f222d4901f0fd0, 2acbe59faac7cbd02708427acf4a594d1875398f, 93ea338e77452356b322929d7adcd4559f2cbe30, e94e5e9cde1f24464dae2b35abc2528f103588d0]
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/459]
+closure_commit: e431253ce7c91ac89668d0852026fdc8ccba6e7c
 review_state: legacy-unreviewed
 sensitivity: public
 ---

--- a/framework/core/docs/adr/ADR-0042-episode-atomic-safety-and-qualification.md
+++ b/framework/core/docs/adr/ADR-0042-episode-atomic-safety-and-qualification.md
@@ -12,12 +12,6 @@ theme: episode-atomic-safety
 confidence: high
 evidence_grade: B
 last_reviewed: 2026-07-10
-ai_provenance:
-  model_family: GPT-5
-  product: Codex
-  generated_at: 2026-07-10
-  visible_context: User discussion, ADR-0033, ADR-0034, ADR-0040, ADR-0041, the Episode object model, and current v1 degraded/repair tests
-  invisible_context_boundary: Exact model build and hidden system implementation are unknown
 ---
 
 # ADR-0042: Episode is the atomic safety and fault-containment unit, qualified by evidence under load

--- a/framework/core/docs/adr/ADR-0045-kfx-execution-profiles-native-rust-wasm.md
+++ b/framework/core/docs/adr/ADR-0045-kfx-execution-profiles-native-rust-wasm.md
@@ -4,6 +4,10 @@ doc_type: architecture-decision
 adr_id: ADR-0045
 decision_status: accepted
 implementation_status: implemented
+implementation_commits: [28dd60daead399122aefdfd72d160fe18d382509, 7033137ccd75d794ded69f14ed16e250fdb0ecdb]
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/583]
+closure_commit: 765e7d5af654729585c83b3e1fd8a49e25b9ee8c
+qualification_refs: [docs/libwasm-embedding-membrane-spike.md]
 review_state: maintainer-reviewed
 sensitivity: public
 sources: [local-files, official-upstream]

--- a/framework/core/docs/adr/ADR-0047-authoritative-facts-hana-pod-or-flatbuffers.md
+++ b/framework/core/docs/adr/ADR-0047-authoritative-facts-hana-pod-or-flatbuffers.md
@@ -4,6 +4,9 @@ doc_type: architecture-decision
 adr_id: ADR-0047
 decision_status: accepted
 implementation_status: implemented
+implementation_commits: [1543a4e060d55309edb25dd8cb6cd765c95be3fe]
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/549]
+closure_commit: 1543a4e060d55309edb25dd8cb6cd765c95be3fe
 review_state: legacy-unreviewed
 sensitivity: public
 ---

--- a/framework/core/docs/adr/ADR-0051-kfd-contract-world-fact-admission-and-trust.md
+++ b/framework/core/docs/adr/ADR-0051-kfd-contract-world-fact-admission-and-trust.md
@@ -4,6 +4,9 @@ doc_type: architecture-decision
 adr_id: ADR-0051
 decision_status: accepted
 implementation_status: implemented
+implementation_commits: [716a6c2f16990de852f7fd553aa6fc20f4671559, 355a7c1c702ba7cabfc56a135f21553b56a34649]
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/571]
+closure_commit: 355a7c1c702ba7cabfc56a135f21553b56a34649
 review_state: legacy-unreviewed
 sensitivity: public
 ---

--- a/framework/core/docs/adr/ADR-0052-kfd2-assessment-lifecycle-and-executors.md
+++ b/framework/core/docs/adr/ADR-0052-kfd2-assessment-lifecycle-and-executors.md
@@ -4,6 +4,9 @@ doc_type: architecture-decision
 adr_id: ADR-0052
 decision_status: accepted
 implementation_status: implemented
+implementation_commits: [68dc33a3f3daa56ac1893f9e8671575c6e85f9a8]
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/568]
+closure_commit: 68dc33a3f3daa56ac1893f9e8671575c6e85f9a8
 review_state: legacy-unreviewed
 sensitivity: public
 ---

--- a/framework/core/docs/adr/ADR-0054-libwasm-production-runtime-and-release.md
+++ b/framework/core/docs/adr/ADR-0054-libwasm-production-runtime-and-release.md
@@ -12,12 +12,6 @@ theme: libwasm-production-runtime
 confidence: high
 evidence_grade: B
 last_reviewed: 2026-07-11
-ai_provenance:
-  model_family: GPT-5
-  product: Codex
-  generated_at: 2026-07-11
-  visible_context: ADR-0045, the merged dual-engine spike, Kungfu fact admission, the product assembly path, and Wasmer 7.2 metering middleware
-  invisible_context_boundary: Future engine releases and unobserved release-candidate behavior remain outside this decision
 ---
 
 # ADR-0054: libwasm is a governed product runtime, not a copied spike library

--- a/framework/core/docs/adr/ADR-0055-retire-journal-session-and-separate-runtime-state-from-projection.md
+++ b/framework/core/docs/adr/ADR-0055-retire-journal-session-and-separate-runtime-state-from-projection.md
@@ -4,6 +4,9 @@ doc_type: architecture-decision
 adr_id: ADR-0055
 decision_status: accepted
 implementation_status: implemented
+implementation_commits: [a8e8d979867e587266c420ead438862f29a31a82, b7b0f2ce6776d19d7bcd12046870827f4f417fb0]
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/572]
+closure_commit: b7b0f2ce6776d19d7bcd12046870827f4f417fb0
 review_state: legacy-unreviewed
 sensitivity: public
 ---

--- a/framework/core/docs/adr/ADR-0056-retire-legacy-journal-cli-lifecycle-tools.md
+++ b/framework/core/docs/adr/ADR-0056-retire-legacy-journal-cli-lifecycle-tools.md
@@ -4,6 +4,9 @@ doc_type: architecture-decision
 adr_id: ADR-0056
 decision_status: accepted
 implementation_status: implemented
+implementation_commits: [b7b0f2ce6776d19d7bcd12046870827f4f417fb0]
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/572]
+closure_commit: b7b0f2ce6776d19d7bcd12046870827f4f417fb0
 review_state: maintainer-reviewed
 sensitivity: public
 sources: [local-files, user-decision]

--- a/framework/core/docs/adr/ADR-0057-domain-neutral-live-runtime-terminology.md
+++ b/framework/core/docs/adr/ADR-0057-domain-neutral-live-runtime-terminology.md
@@ -4,6 +4,9 @@ doc_type: architecture-decision
 adr_id: ADR-0057
 decision_status: accepted
 implementation_status: implemented
+implementation_commits: [bf606dcd4ded16810e122d31f67b8676f9b651de]
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/578]
+closure_commit: bf606dcd4ded16810e122d31f67b8676f9b651de
 review_state: maintainer-reviewed
 sensitivity: public
 sources: [local-files, user-decision]

--- a/framework/core/docs/adr/ADR-0058-yijinjing-explicit-mapping-policies.md
+++ b/framework/core/docs/adr/ADR-0058-yijinjing-explicit-mapping-policies.md
@@ -4,6 +4,10 @@ doc_type: architecture-decision
 adr_id: ADR-0058
 decision_status: accepted
 implementation_status: implemented
+implementation_commits: [5d4240edde731e857ec4ca8fba8dead7104e0b9b, 81f6b61ca3fbf75399c49b32f75310c25e52962d]
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/599]
+closure_commit: 81f6b61ca3fbf75399c49b32f75310c25e52962d
+qualification_refs: [framework/core/docs/qualification/mmap-performance.md]
 review_state: maintainer-reviewed
 sensitivity: public
 sources: [local-files, user-decision]

--- a/framework/core/docs/adr/ADR-0059-mission-control-mission-go-responsibility-model.md
+++ b/framework/core/docs/adr/ADR-0059-mission-control-mission-go-responsibility-model.md
@@ -4,6 +4,9 @@ doc_type: architecture-decision
 adr_id: ADR-0059
 decision_status: accepted
 implementation_status: implemented
+implementation_commits: [fac15d2660223b48196060107e40e99ff7c4f3e2, 9da49c368806f89d11402375479ebc84cbd724d2, 2daa0df6ecd4a9178f521e2230c0a3c2e079f472, bcbe4abe0918e65647e9df7c2309ef489b1e16d4]
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/585]
+closure_commit: bcbe4abe0918e65647e9df7c2309ef489b1e16d4
 review_state: legacy-unreviewed
 sensitivity: public
 ---

--- a/framework/core/docs/adr/ADR-0060-desktop-workspace-selection-and-lazy-data-home.md
+++ b/framework/core/docs/adr/ADR-0060-desktop-workspace-selection-and-lazy-data-home.md
@@ -12,12 +12,6 @@ theme: kungfu-workspace-product
 confidence: high
 evidence_grade: B
 last_reviewed: 2026-07-11
-ai_provenance:
-  model_family: GPT-5
-  product: Codex
-  generated_at: 2026-07-11
-  visible_context: User workspace and Mission Control requirements, ADR-0035, ADR-0059, current GUI boot/runtime code, Saved Query Catalog implementation, Atlas dogfood behavior
-  invisible_context_boundary: Did not inspect private Atlas bodies, credentials, provider payloads, or hidden model state
 ---
 
 # ADR-0060: Desktop selects one explicit workspace and initializes its data home lazily

--- a/framework/core/docs/adr/ADR-0061-agent-mediated-guidance-is-a-first-class-product-interface.md
+++ b/framework/core/docs/adr/ADR-0061-agent-mediated-guidance-is-a-first-class-product-interface.md
@@ -12,12 +12,6 @@ theme: kungfu-agent-mediated-product
 confidence: high
 evidence_grade: B
 last_reviewed: 2026-07-11
-ai_provenance:
-  model_family: GPT-5
-  product: Codex
-  generated_at: 2026-07-11
-  visible_context: User product principle, Mission Control workspace design, Shifu delegation protocol, KFD-3, and current GUI/CLI parity contracts
-  invisible_context_boundary: Did not inspect private provider sessions, credentials, hidden prompts, or hidden model state
 ---
 
 # ADR-0061: Agent-mediated guidance is a first-class product interface

--- a/framework/core/docs/adr/ADR-0062-journal-container-epoch-and-offline-conversion.md
+++ b/framework/core/docs/adr/ADR-0062-journal-container-epoch-and-offline-conversion.md
@@ -4,6 +4,9 @@ doc_type: architecture-decision
 adr_id: ADR-0062
 decision_status: accepted
 implementation_status: implemented
+implementation_commits: [508fc89c0c9f97364ee688da627df24ba717bd3f, fe1f97cbc5b8d20d969c5cbd637bb51be3b20947]
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/617]
+closure_commit: a4d02b20509bd07db90172a64a2408c36844959f
 review_state: legacy-unreviewed
 sensitivity: public
 ---

--- a/framework/core/docs/adr/ADR-0066-native-cpp-toolchain-contract-and-modules-hold.md
+++ b/framework/core/docs/adr/ADR-0066-native-cpp-toolchain-contract-and-modules-hold.md
@@ -12,11 +12,6 @@ theme: kungfu-cpp-modernization
 confidence: high
 evidence_grade: A
 last_reviewed: 2026-07-12
-ai_provenance:
-  model_family: GPT-5
-  product: Codex
-  generated_at: 2026-07-12
-  invisible_context: not asserted
 ---
 
 # ADR-0066: native compilers share one C++ contract; modules remain qualification-only

--- a/framework/core/docs/adr/ADR-0067-schema-registry-compile-time-contract-welds.md
+++ b/framework/core/docs/adr/ADR-0067-schema-registry-compile-time-contract-welds.md
@@ -3,14 +3,18 @@ metadata_schema: kungfu.document-metadata/v1
 doc_type: architecture-decision
 adr_id: ADR-0067
 decision_status: accepted
-implementation_status: not-started
+implementation_status: implemented
+implementation_commits: [7ebd631147fe9e1094b0a345ebf19551f97ced09, a6d3b4ef0cff62baf68374acb29f069fc0fcec74]
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/660]
+closure_commit: a6d3b4ef0cff62baf68374acb29f069fc0fcec74
+qualification_refs: [framework/core/src/libyijinjing/include/kungfu/yijinjing/schema/registry.h]
 review_state: legacy-unreviewed
 sensitivity: public
 ---
 
 # ADR-0067: schema-registry contract invariants are welded at compile time — tag uniqueness and payload layout↔version binding
 
-- Status: accepted; not yet implemented
+- Status: accepted; implemented
 - Date: 2026-07-12
 - Category: (b) mechanism / governance — schema contract enforcement
 - Subsystem: `libyijinjing` schema (`schema/registry.h`, `schema/types.h`), storage manifest records

--- a/framework/core/docs/adr/ADR-0068-tiered-durability-and-crash-recovery.md
+++ b/framework/core/docs/adr/ADR-0068-tiered-durability-and-crash-recovery.md
@@ -12,11 +12,6 @@ theme: tiered-durability-and-crash-recovery
 confidence: high
 evidence_grade: B
 last_reviewed: 2026-07-12
-ai_provenance:
-  model_family: GPT-5
-  product: Codex
-  generated_at: 2026-07-12
-  invisible_context_boundary: Exact hidden model build, future implementation behavior, and unqualified device guarantees are unknown
 ---
 
 # ADR-0068: tiered durability separates hot visibility, durable fact admission, projections, and replication

--- a/framework/core/docs/adr/ADR-0069-agent-first-kfx-profile-suite-runtime.md
+++ b/framework/core/docs/adr/ADR-0069-agent-first-kfx-profile-suite-runtime.md
@@ -12,11 +12,6 @@ theme: agent-first-kfx-profile-suite-runtime
 confidence: high
 evidence_grade: B
 last_reviewed: 2026-07-13
-ai_provenance:
-  model_family: GPT-5
-  product: Codex
-  generated_at: 2026-07-13
-  invisible_context_boundary: Exact future runtime behavior, third-party Profile designs, and unqualified compatibility claims are unknown
 ---
 
 # ADR-0069: Agent-first KFX Profile Suites carry domain semantics over a domain-neutral Core

--- a/framework/core/docs/carrier-type-registry.md
+++ b/framework/core/docs/carrier-type-registry.md
@@ -10,12 +10,6 @@ theme: kungfu-v4-carrier-type-registry
 confidence: high
 evidence_grade: B
 last_reviewed: 2026-07-11
-ai_provenance:
-  generated_by: Codex
-  product: Codex CLI
-  generated_at: 2026-07-08T12:20:00+08:00
-  visible_context: local Kungfu source tree and current user consensus
-  invisible_context: exact model build and hidden system implementation are unknown
 ---
 
 # Carrier Type Registry

--- a/framework/core/docs/qualification/mmap-performance.md
+++ b/framework/core/docs/qualification/mmap-performance.md
@@ -10,11 +10,6 @@ theme: yijinjing-mmap-performance-qualification
 confidence: high
 evidence_grade: B
 last_reviewed: 2026-07-11
-ai_provenance:
-  model_family: GPT-5
-  product: Codex
-  generated_at: 2026-07-11
-  invisible_context_boundary: No credentials, private journals, or hidden provider state were read
 ---
 
 # yijinjing mmap performance qualification

--- a/framework/core/docs/strong-durability-and-crash-recovery-design.md
+++ b/framework/core/docs/strong-durability-and-crash-recovery-design.md
@@ -10,11 +10,6 @@ theme: strong-durability-and-crash-recovery
 confidence: high
 evidence_grade: B
 last_reviewed: 2026-07-12
-ai_provenance:
-  model_family: GPT-5
-  product: Codex
-  generated_at: 2026-07-12
-  invisible_context_boundary: Exact hidden model build, future implementation behavior, and unqualified storage hardware guarantees are unknown
 ---
 
 # Strong-durability and crash-recovery design

--- a/framework/core/slices/libwasm-shared-membrane/README.md
+++ b/framework/core/slices/libwasm-shared-membrane/README.md
@@ -10,12 +10,6 @@ theme: libwasm-shared-embedding-membrane
 confidence: high
 evidence_grade: B
 last_reviewed: 2026-07-11
-ai_provenance:
-  model_family: GPT-5
-  product: Codex
-  generated_at: 2026-07-11
-  visible_context: ADR-0045, merged libkungfu embedding ABI, Wasmtime and Wasmer public Rust embedding APIs, and run 29138796710 on macOS ARM64, Linux x64, and Windows x64
-  invisible_context_boundary: Exact hidden model build and unimplemented production admission, receipt, WIT, and Wasmer CPU-metering behavior are unknown
 ---
 
 # libwasm shared embedding membrane spike

--- a/framework/core/slices/native-storage-closure/README.md
+++ b/framework/core/slices/native-storage-closure/README.md
@@ -10,11 +10,6 @@ theme: adr-0049-native-storage-closure
 confidence: high
 evidence_grade: A
 last_reviewed: 2026-07-11
-ai_provenance:
-  model_family: GPT-5
-  product: Codex
-  generated_at: 2026-07-11
-  invisible_context: exact model build and hidden reasoning unavailable
 ---
 
 # Native storage closure

--- a/framework/core/slices/shared-embedding-membrane/README.md
+++ b/framework/core/slices/shared-embedding-membrane/README.md
@@ -10,11 +10,6 @@ theme: libkungfu-shared-embedding-membrane
 confidence: high
 evidence_grade: A
 last_reviewed: 2026-07-11
-ai_provenance:
-  model_family: GPT-5
-  product: Codex
-  generated_at: 2026-07-10
-  invisible_context: exact model build and hidden reasoning unavailable
 ---
 
 # Shared embedding membrane spike

--- a/framework/spec/CONSUMING.md
+++ b/framework/spec/CONSUMING.md
@@ -1,11 +1,3 @@
----
-metadata_schema: kungfu.document-metadata/v1
-document_status: active
-doc_type: public-document
-review_state: unreviewed
-sensitivity: public
----
-
 # Consuming `@kungfu-tech/spec` (for `site-libkungfu-dev`)
 
 This is the **connection contract** between the monorepo and the docs site. The

--- a/framework/spec/README.md
+++ b/framework/spec/README.md
@@ -1,11 +1,3 @@
----
-metadata_schema: kungfu.document-metadata/v1
-document_status: active
-doc_type: public-document
-review_state: unreviewed
-sensitivity: public
----
-
 # @kungfu-tech/spec
 
 The portable fact-ledger **format spec** bundle for kungfu, and the **manifest

--- a/framework/spec/docs/format-spec.md
+++ b/framework/spec/docs/format-spec.md
@@ -1,11 +1,3 @@
----
-metadata_schema: kungfu.document-metadata/v1
-document_status: active
-doc_type: public-document
-review_state: unreviewed
-sensitivity: public
----
-
 # Kungfu Fact-Ledger Format — Spec 0.1 (pre-release draft)
 
 > **Historical walking-skeleton input, not the current normative `.kungfu`

--- a/framework/spec/docs/handbooks/cli.md
+++ b/framework/spec/docs/handbooks/cli.md
@@ -1,11 +1,3 @@
----
-metadata_schema: kungfu.document-metadata/v1
-document_status: active
-doc_type: public-document
-review_state: unreviewed
-sensitivity: public
----
-
 # Kungfu CLI handbook
 
 > **Pre-release source guidance.** Public CLI artifacts are not yet a polished

--- a/framework/spec/docs/handbooks/node.md
+++ b/framework/spec/docs/handbooks/node.md
@@ -1,11 +1,3 @@
----
-metadata_schema: kungfu.document-metadata/v1
-document_status: active
-doc_type: public-document
-review_state: unreviewed
-sensitivity: public
----
-
 # Node SDK handbook
 
 > **Staged surface.** The Node `@kungfu-tech/storage` source adapter and shared

--- a/framework/spec/docs/handbooks/python.md
+++ b/framework/spec/docs/handbooks/python.md
@@ -1,11 +1,3 @@
----
-metadata_schema: kungfu.document-metadata/v1
-document_status: active
-doc_type: public-document
-review_state: unreviewed
-sensitivity: public
----
-
 # Python SDK handbook
 
 > **Staged surface.** The Python `kungfu-storage` source adapter and shared

--- a/framework/spec/docs/overview.md
+++ b/framework/spec/docs/overview.md
@@ -1,11 +1,3 @@
----
-metadata_schema: kungfu.document-metadata/v1
-document_status: active
-doc_type: public-document
-review_state: unreviewed
-sensitivity: public
----
-
 # libkungfu portable format surface
 
 This package is the pre-release aggregation surface for a portable Kungfu fact

--- a/scripts/document-metadata-contract.mjs
+++ b/scripts/document-metadata-contract.mjs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // @ts-check
 
+import childProcess from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -15,7 +16,7 @@ const DEFAULT_CONTRACT = 'docs/document-metadata.contract.json';
  *   id: string,
  *   files?: string[],
  *   patterns?: string[],
- *   frontmatterRequired: boolean,
+ *   metadataMode: 'inline' | 'registry' | 'inline-optional',
  *   required: string[],
  *   constants?: Record<string, string>,
  *   enums?: Record<string, string[]>,
@@ -26,12 +27,27 @@ const DEFAULT_CONTRACT = 'docs/document-metadata.contract.json';
  * @typedef {{
  *   schemaVersion: number,
  *   metadataSchema: string,
+ *   metadataRegistry: string,
+ *   optionalFields?: string[],
  *   sourceKinds?: string[],
  *   externalFrontmatterSchemas: {id: string, patterns: string[]}[],
  *   profiles: MetadataProfile[],
- *   adrRegistries: {index: string, recordPattern: string}[]
+ *   adrRegistries: {index: string, recordPattern: string}[],
+ *   adrEvidence?: {
+ *     commitFields: string[],
+ *     pullRequestFields: string[],
+ *     closureCommitField: string,
+ *     qualificationRefField: string,
+ *     statusesRequiringImplementationEvidence: string[],
+ *     statusesRequiringClosure: string[],
+ *     statusesForbiddingEvidence: string[],
+ *     pullRequestPattern: string,
+ *     legacyEvidenceExemptions: Record<string, string>
+ *   }
  * }} MetadataContract
  */
+
+/** @typedef {{schemaVersion: number, metadataSchema: string, documents: Record<string, Record<string, string | string[]>>}} MetadataRegistry */
 
 /** @param {string} value */
 function parseScalar(value) {
@@ -86,6 +102,24 @@ export function readMetadataContract(
   return /** @type {MetadataContract} */ (contract);
 }
 
+/** @param {string} root @param {MetadataContract} contract */
+function readMetadataRegistry(root, contract) {
+  const registry = JSON.parse(
+    fs.readFileSync(path.join(root, contract.metadataRegistry), 'utf8'),
+  );
+  if (
+    registry.schemaVersion !== 1 ||
+    registry.metadataSchema !== contract.metadataSchema ||
+    typeof registry.documents !== 'object' ||
+    Array.isArray(registry.documents)
+  ) {
+    throw new Error(
+      `${contract.metadataRegistry}: invalid document metadata registry`,
+    );
+  }
+  return /** @type {MetadataRegistry} */ (registry);
+}
+
 /** @param {string} rel @param {{files?: string[], patterns?: string[]}} rule */
 function matches(rel, rule) {
   return (
@@ -128,6 +162,250 @@ function indexStatuses(text) {
   return result;
 }
 
+/** @param {Map<string, {value: unknown, line: number}>} fields @param {MetadataProfile} profile @param {MetadataContract} contract @param {string} rel @param {Finding[]} findings */
+function validateFields(fields, profile, contract, rel, findings) {
+  const allowed = new Set([
+    ...profile.required,
+    ...Object.keys(profile.constants || {}),
+    ...Object.keys(profile.enums || {}),
+    ...(contract.optionalFields || []),
+  ]);
+  for (const [key, field] of fields) {
+    if (!allowed.has(key)) {
+      findings.push({
+        code: 'metadata-unknown-field',
+        file: rel,
+        line: field.line,
+        message: `metadata field is not declared by the contract: ${key}`,
+      });
+    }
+  }
+  for (const key of profile.required) {
+    if (!fields.has(key)) {
+      findings.push({
+        code: 'metadata-required-field',
+        file: rel,
+        line: 1,
+        message: `${profile.id} requires metadata field ${key}`,
+      });
+    }
+  }
+  for (const key of profile.forbidden || []) {
+    const field = fields.get(key);
+    if (field) {
+      findings.push({
+        code: 'metadata-forbidden-field',
+        file: rel,
+        line: field.line,
+        message: `${profile.id} forbids ambiguous legacy field ${key}`,
+      });
+    }
+  }
+  for (const [key, expected] of Object.entries(profile.constants || {})) {
+    const field = fields.get(key);
+    if (field && field.value !== expected) {
+      findings.push({
+        code: 'metadata-constant',
+        file: rel,
+        line: field.line,
+        message: `${key} must be ${expected} for ${profile.id}`,
+      });
+    }
+  }
+  for (const [key, allowed] of Object.entries(profile.enums || {})) {
+    const field = fields.get(key);
+    if (field && !allowed.includes(/** @type {string} */ (field.value))) {
+      findings.push({
+        code: 'metadata-enum',
+        file: rel,
+        line: field.line,
+        message: `${key} must be one of: ${allowed.join(', ')}`,
+      });
+    }
+  }
+}
+
+/** @param {Record<string, unknown>} values */
+function registryFields(values) {
+  return new Map(
+    Object.entries(values).map(([key, value]) => [key, { value, line: 1 }]),
+  );
+}
+
+function isolatedGitEnvironment() {
+  return Object.fromEntries(
+    Object.entries(process.env).filter(([key]) => !key.startsWith('GIT_')),
+  );
+}
+
+/** @param {string} root @param {string} commit */
+function validateReachableCommit(root, commit) {
+  if (!/^[0-9a-f]{40}$/.test(commit))
+    return 'must be a full 40-character lowercase Git SHA';
+  const exists = childProcess.spawnSync(
+    'git',
+    ['cat-file', '-e', `${commit}^{commit}`],
+    { cwd: root, env: isolatedGitEnvironment(), stdio: 'ignore' },
+  );
+  if (exists.status !== 0) return 'does not identify a commit in this checkout';
+  const reachable = childProcess.spawnSync(
+    'git',
+    ['merge-base', '--is-ancestor', commit, 'HEAD'],
+    { cwd: root, env: isolatedGitEnvironment(), stdio: 'ignore' },
+  );
+  return reachable.status === 0
+    ? null
+    : 'is not reachable from the checked-out mainline history';
+}
+
+/** @param {string} value @param {string} field @param {string} rel @param {number} line @param {string} root @param {Finding[]} findings */
+function checkCommit(value, field, rel, line, root, findings) {
+  const problem = validateReachableCommit(root, value);
+  if (problem) {
+    findings.push({
+      code: 'adr-evidence-commit',
+      file: rel,
+      line,
+      message: `${field} ${value} ${problem}`,
+    });
+  }
+}
+
+/** @param {Map<string, {value: unknown, line: number}>} fields @param {string} rel @param {string} root @param {MetadataContract} contract @param {Finding[]} findings */
+function validateAdrEvidence(fields, rel, root, contract, findings) {
+  const evidence = contract.adrEvidence;
+  if (!evidence) return;
+  const id = String(fields.get('adr_id')?.value || '');
+  const status = String(fields.get('implementation_status')?.value || '');
+  const exemption = evidence.legacyEvidenceExemptions[id];
+  const commits = fields.get(evidence.commitFields[0]);
+  const prs = fields.get(evidence.pullRequestFields[0]);
+  const closure = fields.get(evidence.closureCommitField);
+  const qualifications = fields.get(evidence.qualificationRefField);
+  const present = [commits, prs, closure, qualifications].some(Boolean);
+  const evidenceComplete =
+    (commits || prs) &&
+    (!evidence.statusesRequiringClosure.includes(status) || closure);
+
+  if (
+    exemption &&
+    (!evidence.statusesRequiringImplementationEvidence.includes(status) ||
+      evidenceComplete)
+  ) {
+    findings.push({
+      code: 'adr-evidence-exemption-stale',
+      file: rel,
+      line: 1,
+      message: `legacy evidence exemption for ${id} is no longer needed`,
+    });
+  }
+
+  if (
+    evidence.statusesRequiringImplementationEvidence.includes(status) &&
+    !commits &&
+    !prs &&
+    !exemption
+  ) {
+    findings.push({
+      code: 'adr-evidence-required',
+      file: rel,
+      line: 1,
+      message: `${status} requires implementation_commits or implementation_prs`,
+    });
+  }
+  if (
+    evidence.statusesRequiringClosure.includes(status) &&
+    !closure &&
+    !exemption
+  ) {
+    findings.push({
+      code: 'adr-closure-required',
+      file: rel,
+      line: 1,
+      message: `${status} requires closure_commit`,
+    });
+  }
+  if (evidence.statusesForbiddingEvidence.includes(status) && present) {
+    findings.push({
+      code: 'adr-evidence-contradiction',
+      file: rel,
+      line: 1,
+      message: `${status} cannot declare implementation evidence`,
+    });
+  }
+
+  for (const field of [commits, prs, qualifications]) {
+    if (field && !Array.isArray(field.value)) {
+      findings.push({
+        code: 'adr-evidence-list',
+        file: rel,
+        line: field.line,
+        message: 'ADR evidence collections must be inline YAML lists',
+      });
+    }
+  }
+  if (Array.isArray(commits?.value)) {
+    for (const commit of commits.value)
+      checkCommit(
+        String(commit),
+        evidence.commitFields[0],
+        rel,
+        commits.line,
+        root,
+        findings,
+      );
+  }
+  if (closure) {
+    checkCommit(
+      String(closure.value),
+      evidence.closureCommitField,
+      rel,
+      closure.line,
+      root,
+      findings,
+    );
+  }
+  const prPattern = new RegExp(evidence.pullRequestPattern);
+  if (Array.isArray(prs?.value)) {
+    for (const pr of prs.value) {
+      if (!prPattern.test(String(pr))) {
+        findings.push({
+          code: 'adr-evidence-pr',
+          file: rel,
+          line: prs.line,
+          message: `implementation_prs must use a stable kungfu-systems/kungfu PR URL: ${String(pr)}`,
+        });
+      }
+    }
+  }
+  if (Array.isArray(qualifications?.value)) {
+    for (const reference of qualifications.value) {
+      const value = String(reference);
+      if (value.startsWith('commit:')) {
+        checkCommit(
+          value.slice('commit:'.length),
+          evidence.qualificationRefField,
+          rel,
+          qualifications.line,
+          root,
+          findings,
+        );
+      } else if (
+        path.isAbsolute(value) ||
+        value.split('/').includes('..') ||
+        !fs.existsSync(path.join(root, value))
+      ) {
+        findings.push({
+          code: 'adr-evidence-qualification',
+          file: rel,
+          line: qualifications.line,
+          message: `qualification_refs must be an existing repository-relative path or commit:<sha>: ${value}`,
+        });
+      }
+    }
+  }
+}
+
 /**
  * @param {{root?: string, files: string[], contract?: MetadataContract}} options
  * @returns {Finding[]}
@@ -138,6 +416,10 @@ export function validateDocumentMetadata(options) {
   /** @type {Finding[]} */
   const findings = [];
   const documents = new Map();
+  const metadataRegistry = readMetadataRegistry(root, contract);
+  const registered = metadataRegistry.documents;
+  const fileSet = new Set(options.files);
+  const adrIds = new Set();
 
   for (const rel of options.files) {
     const text = fs.readFileSync(path.join(root, rel), 'utf8');
@@ -145,6 +427,15 @@ export function validateDocumentMetadata(options) {
     if (
       contract.externalFrontmatterSchemas.some((schema) => matches(rel, schema))
     ) {
+      if (registered[rel]) {
+        findings.push({
+          code: 'metadata-authority-duplicate',
+          file: rel,
+          line: 1,
+          message:
+            'external-schema document cannot also use the Kungfu metadata registry',
+        });
+      }
       continue;
     }
     const profile = contract.profiles.find((candidate) =>
@@ -160,18 +451,50 @@ export function validateDocumentMetadata(options) {
       continue;
     }
     const frontmatter = parseFrontmatter(text);
-    if (!frontmatter) {
-      if (profile.frontmatterRequired) {
+    const registryEntry = registered[rel];
+    if (profile.metadataMode === 'registry') {
+      if (frontmatter) {
         findings.push({
-          code: 'metadata-required',
+          code: 'metadata-authority-duplicate',
           file: rel,
           line: 1,
-          message: `frontmatter required by ${profile.id} profile`,
+          message: `${profile.id} metadata belongs in ${contract.metadataRegistry}, not visible frontmatter`,
         });
       }
+      if (!registryEntry) {
+        findings.push({
+          code: 'metadata-registry-required',
+          file: rel,
+          line: 1,
+          message: `${profile.id} requires one entry in ${contract.metadataRegistry}`,
+        });
+        continue;
+      }
+    } else if (registryEntry) {
+      findings.push({
+        code: 'metadata-authority-duplicate',
+        file: rel,
+        line: 1,
+        message: `${profile.id} metadata must be inline and cannot also appear in the registry`,
+      });
+    }
+    if (profile.metadataMode === 'inline' && !frontmatter) {
+      findings.push({
+        code: 'metadata-required',
+        file: rel,
+        line: 1,
+        message: `frontmatter required by ${profile.id} profile`,
+      });
       continue;
     }
-    if (frontmatter.malformed) {
+    if (
+      profile.metadataMode === 'inline-optional' &&
+      !frontmatter &&
+      !registryEntry
+    ) {
+      continue;
+    }
+    if (frontmatter?.malformed) {
       findings.push({
         code: 'metadata-malformed',
         file: rel,
@@ -180,7 +503,7 @@ export function validateDocumentMetadata(options) {
       });
       continue;
     }
-    for (const duplicate of frontmatter.duplicates || []) {
+    for (const duplicate of frontmatter?.duplicates || []) {
       findings.push({
         code: 'metadata-duplicate',
         file: rel,
@@ -188,50 +511,26 @@ export function validateDocumentMetadata(options) {
         message: `duplicate frontmatter field: ${duplicate.key}`,
       });
     }
-    for (const key of profile.required) {
-      if (!frontmatter.fields.has(key)) {
-        findings.push({
-          code: 'metadata-required-field',
-          file: rel,
-          line: 1,
-          message: `${profile.id} requires frontmatter field ${key}`,
-        });
-      }
+    const fields = registryEntry
+      ? registryFields(registryEntry)
+      : frontmatter?.fields || new Map();
+    const headerText = frontmatter
+      ? text
+          .split(/\r?\n/)
+          .slice(1, frontmatter.endLine - 1)
+          .join('\n')
+      : '';
+    if (/^\s+[a-z][a-z0-9_]*\s*:/m.test(headerText)) {
+      findings.push({
+        code: 'metadata-nested-field',
+        file: rel,
+        line: 1,
+        message:
+          'Kungfu metadata is flat; nested maintenance or generation attribution is not allowed',
+      });
     }
-    for (const key of profile.forbidden || []) {
-      const field = frontmatter.fields.get(key);
-      if (field) {
-        findings.push({
-          code: 'metadata-forbidden-field',
-          file: rel,
-          line: field.line,
-          message: `${profile.id} forbids ambiguous legacy field ${key}`,
-        });
-      }
-    }
-    for (const [key, expected] of Object.entries(profile.constants || {})) {
-      const field = frontmatter.fields.get(key);
-      if (field && field.value !== expected) {
-        findings.push({
-          code: 'metadata-constant',
-          file: rel,
-          line: field.line,
-          message: `${key} must be ${expected} for ${profile.id}`,
-        });
-      }
-    }
-    for (const [key, allowed] of Object.entries(profile.enums || {})) {
-      const field = frontmatter.fields.get(key);
-      if (field && !allowed.includes(/** @type {string} */ (field.value))) {
-        findings.push({
-          code: 'metadata-enum',
-          file: rel,
-          line: field.line,
-          message: `${key} must be one of: ${allowed.join(', ')}`,
-        });
-      }
-    }
-    const sources = frontmatter.fields.get('sources');
+    validateFields(fields, profile, contract, rel, findings);
+    const sources = fields.get('sources');
     if (sources) {
       const allowed = contract.sourceKinds || [];
       if (!Array.isArray(sources.value)) {
@@ -259,7 +558,8 @@ export function validateDocumentMetadata(options) {
       const expectedId = /\/(SHIFU-ADR-[0-9]{4}|ADR-[0-9]{4})-/.exec(
         `/${rel}`,
       )?.[1];
-      const id = frontmatter.fields.get('adr_id');
+      const id = fields.get('adr_id');
+      if (id) adrIds.add(String(id.value));
       if (id && id.value !== expectedId) {
         findings.push({
           code: 'adr-id-drift',
@@ -269,22 +569,46 @@ export function validateDocumentMetadata(options) {
         });
       }
       const visible = visibleDecisionStatus(text);
-      const decision = frontmatter.fields.get('decision_status');
+      const decision = fields.get('decision_status');
       if (!visible) {
         findings.push({
           code: 'adr-status-projection',
           file: rel,
-          line: frontmatter.endLine + 1,
+          line: (frontmatter?.endLine || 1) + 1,
           message: 'ADR body must project a visible decision status',
         });
       } else if (decision && visible !== decision.value) {
         findings.push({
           code: 'adr-status-drift',
           file: rel,
-          line: frontmatter.endLine + 1,
+          line: (frontmatter?.endLine || 1) + 1,
           message: `visible status ${visible} differs from decision_status ${String(decision.value)}`,
         });
       }
+      validateAdrEvidence(fields, rel, root, contract, findings);
+    }
+  }
+
+  for (const rel of Object.keys(registered)) {
+    if (!fileSet.has(rel)) {
+      findings.push({
+        code: 'metadata-registry-orphan',
+        file: contract.metadataRegistry,
+        line: 1,
+        message: `registry entry has no tracked Markdown document: ${rel}`,
+      });
+    }
+  }
+  for (const id of Object.keys(
+    contract.adrEvidence?.legacyEvidenceExemptions || {},
+  )) {
+    if (!adrIds.has(id)) {
+      findings.push({
+        code: 'adr-evidence-exemption-orphan',
+        file: DEFAULT_CONTRACT,
+        line: 1,
+        message: `legacy evidence exemption has no ADR record: ${id}`,
+      });
     }
   }
 

--- a/scripts/document-metadata-contract.test.mjs
+++ b/scripts/document-metadata-contract.test.mjs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import assert from 'node:assert/strict';
+import childProcess from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -28,13 +29,20 @@ function fixture(files) {
 const contract = {
   schemaVersion: 1,
   metadataSchema: 'kungfu.document-metadata/v1',
+  metadataRegistry: 'docs/document-metadata.registry.json',
+  optionalFields: [
+    'implementation_commits',
+    'implementation_prs',
+    'closure_commit',
+    'qualification_refs',
+  ],
   sourceKinds: ['local-files'],
   externalFrontmatterSchemas: [{ id: 'skill', patterns: ['(^|/)SKILL\\.md$'] }],
   profiles: [
     {
       id: 'architecture-decision',
+      metadataMode: 'inline',
       patterns: ['^adr/(ADR-[0-9]{4})-.*\\.md$'],
-      frontmatterRequired: true,
       required: [
         'metadata_schema',
         'doc_type',
@@ -51,15 +59,15 @@ const contract = {
       },
       enums: {
         decision_status: ['proposed', 'accepted', 'superseded'],
-        implementation_status: ['unknown'],
+        implementation_status: ['unknown', 'implemented', 'not-started'],
         review_state: ['legacy-unreviewed'],
       },
       forbidden: ['status'],
     },
     {
       id: 'adr-index',
+      metadataMode: 'inline',
       files: ['adr/README.md'],
-      frontmatterRequired: true,
       required: [
         'metadata_schema',
         'doc_type',
@@ -78,8 +86,8 @@ const contract = {
     },
     {
       id: 'public-document',
+      metadataMode: 'registry',
       files: ['README.md'],
-      frontmatterRequired: true,
       required: [
         'metadata_schema',
         'doc_type',
@@ -99,8 +107,8 @@ const contract = {
     },
     {
       id: 'repository-document',
+      metadataMode: 'inline-optional',
       patterns: ['.*'],
-      frontmatterRequired: false,
       required: [],
       forbidden: ['status'],
     },
@@ -111,6 +119,18 @@ const contract = {
       recordPattern: '^adr/(ADR-[0-9]{4})-.*\\.md$',
     },
   ],
+  adrEvidence: {
+    commitFields: ['implementation_commits'],
+    pullRequestFields: ['implementation_prs'],
+    closureCommitField: 'closure_commit',
+    qualificationRefField: 'qualification_refs',
+    statusesRequiringImplementationEvidence: ['implemented'],
+    statusesRequiringClosure: ['implemented'],
+    statusesForbiddingEvidence: ['not-started'],
+    pullRequestPattern:
+      '^https://github\\.com/kungfu-systems/kungfu/pull/[0-9]+$',
+    legacyEvidenceExemptions: {},
+  },
 };
 
 const publicHeader = `---
@@ -137,35 +157,165 @@ review_state: legacy-unreviewed
 sensitivity: public
 ---`;
 
-function run(files) {
-  const root = fixture(files);
+function run(files, documents = {}) {
+  const root = fixture({
+    ...files,
+    'docs/document-metadata.registry.json': `${JSON.stringify(
+      {
+        schemaVersion: 1,
+        metadataSchema: 'kungfu.document-metadata/v1',
+        documents,
+      },
+      null,
+      2,
+    )}\n`,
+  });
   return validateDocumentMetadata({
     root,
-    files: Object.keys(files).sort(),
+    files: Object.keys(files)
+      .filter((file) => file.endsWith('.md'))
+      .sort(),
     contract,
   });
 }
 
-test('accepts typed public metadata and aligned ADR projections', () => {
-  const findings = run({
-    'README.md': `${publicHeader}\n\n# Home\n`,
-    'adr/README.md': `${indexHeader}\n\n# ADRs\n\n| ADR | Status | Title |\n|---|---|---|\n| [ADR-0001](ADR-0001-example.md) | accepted | Example |\n`,
-    'adr/ADR-0001-example.md': `${adrHeader}\n\n# ADR-0001: Example\n\n- Status: accepted\n`,
+function git(root, args) {
+  const env = Object.fromEntries(
+    Object.entries(process.env).filter(([key]) => !key.startsWith('GIT_')),
+  );
+  return childProcess
+    .execFileSync('git', args, {
+      cwd: root,
+      encoding: 'utf8',
+      env,
+    })
+    .trim();
+}
+
+function evidenceFixture(status = 'implemented') {
+  const root = fixture({
+    'seed.txt': 'implementation\n',
+    'docs/document-metadata.registry.json': `${JSON.stringify({
+      schemaVersion: 1,
+      metadataSchema: 'kungfu.document-metadata/v1',
+      documents: {},
+    })}\n`,
   });
+  git(root, ['init', '-q']);
+  git(root, ['config', 'user.name', 'Test']);
+  git(root, ['config', 'user.email', 'test@example.com']);
+  git(root, ['add', 'seed.txt']);
+  git(root, ['-c', 'core.hooksPath=/dev/null', 'commit', '-q', '-m', 'seed']);
+  const commit = git(root, ['rev-parse', 'HEAD']);
+  const file = 'adr/ADR-0001-example.md';
+  const text = `${adrHeader.replace(
+    'implementation_status: unknown',
+    `implementation_status: ${status}\nimplementation_commits: [${commit}]\nclosure_commit: ${commit}`,
+  )}\n\n# ADR-0001: Example\n\n- Status: accepted\n`;
+  fs.mkdirSync(path.join(root, 'adr'), { recursive: true });
+  fs.writeFileSync(path.join(root, file), text);
+  return { root, file, commit };
+}
+
+test('accepts typed public metadata and aligned ADR projections', () => {
+  const findings = run(
+    {
+      'README.md': '# Home\n',
+      'adr/README.md': `${indexHeader}\n\n# ADRs\n\n| ADR | Status | Title |\n|---|---|---|\n| [ADR-0001](ADR-0001-example.md) | accepted | Example |\n`,
+      'adr/ADR-0001-example.md': `${adrHeader}\n\n# ADR-0001: Example\n\n- Status: accepted\n`,
+    },
+    {
+      'README.md': {
+        metadata_schema: 'kungfu.document-metadata/v1',
+        document_status: 'active',
+        doc_type: 'public-document',
+        review_state: 'unreviewed',
+        sensitivity: 'public',
+      },
+    },
+  );
   assert.deepEqual(findings, []);
 });
 
-test('rejects missing required public frontmatter', () => {
+test('rejects missing required public registry metadata', () => {
   const findings = run({ 'README.md': '# Home\n' });
-  assert.ok(findings.some((finding) => finding.code === 'metadata-required'));
+  assert.ok(
+    findings.some((finding) => finding.code === 'metadata-registry-required'),
+  );
 });
 
 test('rejects the ambiguous legacy status field', () => {
-  const findings = run({
-    'README.md': `${publicHeader.replace('document_status: active', 'status: active')}\n\n# Home\n`,
-  });
+  const findings = run(
+    {
+      'README.md': '# Home\n',
+    },
+    {
+      'README.md': {
+        metadata_schema: 'kungfu.document-metadata/v1',
+        status: 'active',
+        doc_type: 'public-document',
+        review_state: 'unreviewed',
+        sensitivity: 'public',
+      },
+    },
+  );
   assert.ok(
     findings.some((finding) => finding.code === 'metadata-forbidden-field'),
+  );
+});
+
+test('rejects visible frontmatter when the registry is authoritative', () => {
+  const findings = run(
+    { 'README.md': `${publicHeader}\n\n# Home\n` },
+    {
+      'README.md': {
+        metadata_schema: 'kungfu.document-metadata/v1',
+        document_status: 'active',
+        doc_type: 'public-document',
+        review_state: 'unreviewed',
+        sensitivity: 'public',
+      },
+    },
+  );
+  assert.ok(
+    findings.some((finding) => finding.code === 'metadata-authority-duplicate'),
+  );
+});
+
+test('rejects undeclared maintenance attribution in registry metadata', () => {
+  const findings = run(
+    { 'README.md': '# Home\n' },
+    {
+      'README.md': {
+        metadata_schema: 'kungfu.document-metadata/v1',
+        document_status: 'active',
+        doc_type: 'public-document',
+        review_state: 'unreviewed',
+        sensitivity: 'public',
+        generation_attribution: 'automated',
+      },
+    },
+  );
+  assert.ok(
+    findings.some((finding) => finding.code === 'metadata-unknown-field'),
+  );
+});
+
+test('rejects orphaned registry entries', () => {
+  const findings = run(
+    {},
+    {
+      'missing.md': {
+        metadata_schema: 'kungfu.document-metadata/v1',
+        document_status: 'active',
+        doc_type: 'public-document',
+        review_state: 'unreviewed',
+        sensitivity: 'public',
+      },
+    },
+  );
+  assert.ok(
+    findings.some((finding) => finding.code === 'metadata-registry-orphan'),
   );
 });
 
@@ -200,4 +350,64 @@ test('preserves independently consumed frontmatter schemas', () => {
     'skills/demo/SKILL.md': '---\nkey: demo\ntriggers: [demo]\n---\n\n# Demo\n',
   });
   assert.deepEqual(findings, []);
+});
+
+test('accepts reachable full-SHA implementation and closure evidence', () => {
+  const { root, file } = evidenceFixture();
+  const findings = validateDocumentMetadata({ root, files: [file], contract });
+  assert.deepEqual(findings, []);
+});
+
+test('rejects malformed implementation commit evidence', () => {
+  const { root, file, commit } = evidenceFixture();
+  const target = path.join(root, file);
+  fs.writeFileSync(
+    target,
+    fs.readFileSync(target, 'utf8').replace(commit, commit.slice(0, 12)),
+  );
+  const findings = validateDocumentMetadata({ root, files: [file], contract });
+  assert.ok(findings.some((finding) => finding.code === 'adr-evidence-commit'));
+});
+
+test('rejects implementation evidence on a not-started ADR', () => {
+  const { root, file } = evidenceFixture('not-started');
+  const findings = validateDocumentMetadata({ root, files: [file], contract });
+  assert.ok(
+    findings.some((finding) => finding.code === 'adr-evidence-contradiction'),
+  );
+});
+
+test('rejects pull-request evidence outside the canonical repository', () => {
+  const { root, file } = evidenceFixture();
+  const target = path.join(root, file);
+  fs.writeFileSync(
+    target,
+    fs
+      .readFileSync(target, 'utf8')
+      .replace(
+        /^closure_commit:/m,
+        'implementation_prs: [https://github.com/example/fork/pull/1]\nclosure_commit:',
+      ),
+  );
+  const findings = validateDocumentMetadata({ root, files: [file], contract });
+  assert.ok(findings.some((finding) => finding.code === 'adr-evidence-pr'));
+});
+
+test('rejects a legacy exemption after evidence becomes complete', () => {
+  const { root, file } = evidenceFixture();
+  const exempted = {
+    ...contract,
+    adrEvidence: {
+      ...contract.adrEvidence,
+      legacyEvidenceExemptions: { 'ADR-0001': 'legacy debt' },
+    },
+  };
+  const findings = validateDocumentMetadata({
+    root,
+    files: [file],
+    contract: exempted,
+  });
+  assert.ok(
+    findings.some((finding) => finding.code === 'adr-evidence-exemption-stale'),
+  );
 });


### PR DESCRIPTION
## Summary\n\n- move public entry and guide metadata to a checked sidecar registry\n- enforce one metadata authority and flat allowlisted fields\n- bind high-confidence ADR implementation history to commits, pull requests, closure, and qualification evidence\n\n## Validation\n\n- ./shifu docs:check\n- ./shifu docs:prose:required\n- ./shifu check:types\n- ./shifu check