### PR TITLE
docs(adr): bind ADR-0070 phase-one evidence

### DIFF
--- a/framework/core/docs/adr/ADR-0070-peer-communication-primitives-layering.md
+++ b/framework/core/docs/adr/ADR-0070-peer-communication-primitives-layering.md
@@ -4,6 +4,9 @@ doc_type: architecture-decision
 adr_id: ADR-0070
 decision_status: accepted
 implementation_status: partial
+implementation_commits: [c42600c3d93ee18ac8e1381fa204592eeaedc44e]
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/723]
+qualification_refs: [scripts/check-live-runtime-terminology.mjs]
 review_state: maintainer-reviewed
 sensitivity: public
 sources: [local-files, user-decision]


### PR DESCRIPTION
## Summary\n\n- bind ADR-0070 phase-one implementation to commit c42600c3d and PR 723\n- link the live-runtime terminology gate as qualification evidence\n- satisfy the merged ADR evidence contract without claiming full ADR closure\n\n## Validation\n\n- ./shifu docs:check\n- ./shifu docs:prose:required