### PR TITLE
fix(adr): support PR-stable closure evidence

### DIFF
--- a/docs/document-metadata.contract.json
+++ b/docs/document-metadata.contract.json
@@ -14,6 +14,7 @@
     "implementation_commits",
     "implementation_prs",
     "closure_commit",
+    "closure_pr",
     "qualification_refs"
   ],
   "sourceKinds": [
@@ -193,6 +194,7 @@
     "commitFields": ["implementation_commits"],
     "pullRequestFields": ["implementation_prs"],
     "closureCommitField": "closure_commit",
+    "closurePullRequestField": "closure_pr",
     "qualificationRefField": "qualification_refs",
     "statusesRequiringImplementationEvidence": ["partial", "staged", "implemented"],
     "statusesRequiringClosure": ["implemented"],

--- a/docs/document-metadata.md
+++ b/docs/document-metadata.md
@@ -99,7 +99,7 @@ An implementation state is a claim, so ADRs may bind it to immutable evidence:
 ```yaml
 implementation_commits: [68dc33a3f3daa56ac1893f9e8671575c6e85f9a8]
 implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/123]
-closure_commit: 68dc33a3f3daa56ac1893f9e8671575c6e85f9a8
+closure_pr: https://github.com/kungfu-systems/kungfu/pull/123
 qualification_refs: [framework/core/docs/qualification/mmap-performance.md]
 ```
 
@@ -109,14 +109,17 @@ qualification_refs: [framework/core/docs/qualification/mmap-performance.md]
   part of the evidence.
 - `closure_commit` identifies the reachable commit at which the accepted scope
   was considered fulfilled. It may be the final implementation slice or a
-  dedicated closure record.
+  dedicated closure record. `closure_pr` is the stable alternative for a
+  repository whose rebase/squash merge policy rewrites every PR commit SHA;
+  implemented ADRs require one of the two, not both.
 - `qualification_refs` contains existing repository-relative evidence paths or
   `commit:<full-sha>` references.
 
 The gate validates shape, repository identity, local commit existence,
-reachability from the checked-out mainline, and contradictions such as evidence
-on a `not-started` ADR. It cannot prove that code semantically fulfills a
-decision. That judgment remains a review responsibility.
+reachability from the checked-out mainline, canonical repository identity for
+PR evidence, and contradictions such as evidence on a `not-started` ADR. It
+cannot prove that code semantically fulfills a decision. That judgment remains
+a review responsibility.
 
 ## Release admissibility projection
 

--- a/framework/core/docs/adr/ADR-0073-buildchain-adr-release-admissibility.md
+++ b/framework/core/docs/adr/ADR-0073-buildchain-adr-release-admissibility.md
@@ -4,8 +4,8 @@ doc_type: architecture-decision
 adr_id: ADR-0073
 decision_status: accepted
 implementation_status: implemented
-implementation_commits: [99be5659cca3057a524acc34414bb7314b871eeb]
-closure_commit: 57b2da83b0d3071411f12387a8a07ab97b28d9a3
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/731]
+closure_pr: https://github.com/kungfu-systems/kungfu/pull/731
 qualification_refs: [scripts/adr-release-gate.test.mjs]
 review_state: self-reviewed
 sensitivity: public

--- a/scripts/document-metadata-contract.mjs
+++ b/scripts/document-metadata-contract.mjs
@@ -280,12 +280,17 @@ function validateAdrEvidence(fields, rel, root, contract, findings) {
   const exemption = evidence.legacyEvidenceExemptions[id];
   const commits = fields.get(evidence.commitFields[0]);
   const prs = fields.get(evidence.pullRequestFields[0]);
-  const closure = fields.get(evidence.closureCommitField);
+  const closureCommit = fields.get(evidence.closureCommitField);
+  const closurePr = fields.get(evidence.closurePullRequestField);
   const qualifications = fields.get(evidence.qualificationRefField);
-  const present = [commits, prs, closure, qualifications].some(Boolean);
+  const present = [commits, prs, closureCommit, closurePr, qualifications].some(
+    Boolean,
+  );
   const evidenceComplete =
     (commits || prs) &&
-    (!evidence.statusesRequiringClosure.includes(status) || closure);
+    (!evidence.statusesRequiringClosure.includes(status) ||
+      closureCommit ||
+      closurePr);
 
   if (
     exemption &&
@@ -315,14 +320,15 @@ function validateAdrEvidence(fields, rel, root, contract, findings) {
   }
   if (
     evidence.statusesRequiringClosure.includes(status) &&
-    !closure &&
+    !closureCommit &&
+    !closurePr &&
     !exemption
   ) {
     findings.push({
       code: 'adr-closure-required',
       file: rel,
       line: 1,
-      message: `${status} requires closure_commit`,
+      message: `${status} requires closure_commit or closure_pr`,
     });
   }
   if (evidence.statusesForbiddingEvidence.includes(status) && present) {
@@ -355,12 +361,12 @@ function validateAdrEvidence(fields, rel, root, contract, findings) {
         findings,
       );
   }
-  if (closure) {
+  if (closureCommit) {
     checkCommit(
-      String(closure.value),
+      String(closureCommit.value),
       evidence.closureCommitField,
       rel,
-      closure.line,
+      closureCommit.line,
       root,
       findings,
     );
@@ -377,6 +383,14 @@ function validateAdrEvidence(fields, rel, root, contract, findings) {
         });
       }
     }
+  }
+  if (closurePr && !prPattern.test(String(closurePr.value))) {
+    findings.push({
+      code: 'adr-evidence-pr',
+      file: rel,
+      line: closurePr.line,
+      message: `closure_pr must use a stable kungfu-systems/kungfu PR URL: ${String(closurePr.value)}`,
+    });
   }
   if (Array.isArray(qualifications?.value)) {
     for (const reference of qualifications.value) {

--- a/scripts/document-metadata-contract.test.mjs
+++ b/scripts/document-metadata-contract.test.mjs
@@ -34,6 +34,7 @@ const contract = {
     'implementation_commits',
     'implementation_prs',
     'closure_commit',
+    'closure_pr',
     'qualification_refs',
   ],
   sourceKinds: ['local-files'],
@@ -123,6 +124,7 @@ const contract = {
     commitFields: ['implementation_commits'],
     pullRequestFields: ['implementation_prs'],
     closureCommitField: 'closure_commit',
+    closurePullRequestField: 'closure_pr',
     qualificationRefField: 'qualification_refs',
     statusesRequiringImplementationEvidence: ['implemented'],
     statusesRequiringClosure: ['implemented'],
@@ -356,6 +358,38 @@ test('accepts reachable full-SHA implementation and closure evidence', () => {
   const { root, file } = evidenceFixture();
   const findings = validateDocumentMetadata({ root, files: [file], contract });
   assert.deepEqual(findings, []);
+});
+
+test('accepts stable PR implementation and closure evidence', () => {
+  const { root, file } = evidenceFixture();
+  const target = path.join(root, file);
+  fs.writeFileSync(
+    target,
+    fs
+      .readFileSync(target, 'utf8')
+      .replace(
+        /^implementation_commits:.*\nclosure_commit:.*$/m,
+        'implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/731]\nclosure_pr: https://github.com/kungfu-systems/kungfu/pull/731',
+      ),
+  );
+  const findings = validateDocumentMetadata({ root, files: [file], contract });
+  assert.deepEqual(findings, []);
+});
+
+test('rejects closure PR evidence outside the canonical repository', () => {
+  const { root, file } = evidenceFixture();
+  const target = path.join(root, file);
+  fs.writeFileSync(
+    target,
+    fs
+      .readFileSync(target, 'utf8')
+      .replace(
+        /^closure_commit:.*$/m,
+        'closure_pr: https://github.com/example/fork/pull/1',
+      ),
+  );
+  const findings = validateDocumentMetadata({ root, files: [file], contract });
+  assert.ok(findings.some((finding) => finding.code === 'adr-evidence-pr'));
 });
 
 test('rejects malformed implementation commit evidence', () => {


### PR DESCRIPTION
## Summary

Make ADR closure evidence stable under Kungfu's rebase/squash-only PR merge policy.

## Changes

- allow implemented ADRs to use either reachable `closure_commit` or canonical `closure_pr` evidence;
- validate `closure_pr` against the canonical kungfu-systems repository URL shape;
- add positive and negative metadata fixtures;
- rebind ADR-0073 to merged PR #731 so dev metadata is valid after GitHub rewrites its commits.

## Verification

- `./shifu check`
- `./shifu docs:check`
- 43 documentation/metadata fixtures pass, including canonical and foreign closure PR cases

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "implemented",
  "adrs": ["ADR-0073"],
  "summary": "Close the rebase-merge evidence loop with stable PR authority",
  "verification": ["./shifu check", "./shifu docs:check"]
}
-->

## Governance risk check

- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

This tightens evidence compatibility with repository merge policy. It does not accept arbitrary URLs or weaken semantic closure review.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed
