### PR TITLE
feat(kfx): declare Profile KFD-3 collaboration facet

### DIFF
--- a/framework/core/docs/adr/ADR-0074-profile-level-kfd3-qualification.md
+++ b/framework/core/docs/adr/ADR-0074-profile-level-kfd3-qualification.md
@@ -1,0 +1,101 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+doc_type: architecture-decision
+adr_id: ADR-0074
+decision_status: accepted
+implementation_status: not-started
+review_state: self-reviewed
+sensitivity: public
+sources: [local-files, user-decision]
+period: 2026-07-13
+theme: profile-level-kfd3-qualification
+confidence: high
+evidence_grade: B
+last_reviewed: 2026-07-13
+---
+
+# ADR-0074: Kungfu qualifies one KFD-3 collaboration protocol for conforming Profiles
+
+- Status: accepted; implementation in progress
+- Date: 2026-07-13
+- Category: Profile runtime / KFD-3 / dual-first product interface
+- Related: [ADR-0061](ADR-0061-agent-mediated-guidance-is-a-first-class-product-interface.md),
+  [ADR-0069](ADR-0069-agent-first-kfx-profile-suite-runtime.md)
+
+## Context
+
+ADR-0069 lets an installed Kungfu author and operate domain-neutral Profile Suites without rebuilding the Product.
+The current contract binds KFD-1 facts, KFD-2 claims and policies, actions, views, permissions, migrations and
+qualification. That is not by itself KFD-3. A schema-valid Profile may still expose a GUI-only mutation, an Agent-only
+command, hidden constraints or two clients that disagree about the plan, authorization, receipt or selected cut.
+
+Requiring every Profile author to hand-build a GUI, CLI, Agent brief and closure audit would repeat product engineering
+and make KFD-3 depend on author skill. Treating the presence of any GUI and any CLI as KFD-3 would be a false claim.
+
+## Decision
+
+### 1. Profile authors declare collaboration semantics; Kungfu owns their projection
+
+A conforming Profile may bind one content-addressed `kfd3.collaboration` facet. It declares participants, material
+intents, value, constraints, known limits, authority classes and presentation hints. It cannot declare its own Profile
+root, qualification result, witness or runtime authority.
+
+Kungfu projects that declaration into:
+
+- a generic Human GUI when no custom View is supplied;
+- an Agent-discoverable brief, capabilities and JSON CLI/API operations;
+- one shared application protocol:
+  `inspect -> advise -> preview -> authorize -> execute -> receipt -> verify`;
+- qualification probes and a content-bound collaboration-interface witness.
+
+### 2. KFD-3 is an earned Profile level, not an alias for KFD-1/KFD-2
+
+The `kfd3` facet is optional for backward compatibility. A Profile without it remains a valid KFD-1/KFD-2 Profile but
+cannot be reported as KFD-3 declared or qualified. A Profile with it is only declared until closure qualification
+passes. User-visible states must distinguish schema validity, KFD-1, KFD-2 and KFD-3 qualification.
+
+### 3. GUI and Agent clients have no separate mutation authority
+
+Both clients use the same plan identity, authorization decision, application service, receipt, cut and verify result.
+A custom KFX View may change presentation but cannot append facts, grant permissions or execute a material intent
+outside that service. A reachable participant-facing entrypoint that is absent from the collaboration registry fails
+closure rather than becoming an undocumented API.
+
+### 4. Qualification proves collaboration closure, not universal external truth
+
+The KFD-3 receipt binds the Profile root, collaboration facet root, runtime contract, public surface inventory, probe
+evidence, maturity and known limits. It proves the declared participant interface is discoverable, constraint-transparent
+and closed for that artifact. It does not prove that a user's source assertion is true, that the named actor owns a
+real-world identity, or that a domain action achieved its purpose.
+
+### 5. Existing KFD-3 authority remains single-source
+
+Profile qualification consumes the existing Kungfu/Buildchain KFD-3 collaboration-interface registry and witness
+contract. It does not introduce a second KFD definition, registry or release passport. Profile evidence is a scoped
+projection into that authority.
+
+## Invariants and falsification
+
+- Removing `kfd3` keeps an existing Profile valid but makes KFD-3 qualification unavailable.
+- Changing one collaboration byte changes the Profile content closure and invalidates stale plans/witnesses.
+- Missing value, constraints, known limits, participant identity, intent stage or public entrypoint classification fails
+  KFD-3 qualification.
+- Human and Agent probes over the same intent must return the same plan, receipt and verified cut.
+- A custom View with a private mutation path fails qualification.
+- A GUI-only, prose-only or unregistered reachable surface fails closure.
+
+## Consequences
+
+- Users can define domain workflows while Kungfu supplies the repeated dual-first product mechanics.
+- Profiles that only need the generic renderer require declarations, not TS/React code.
+- Custom presentation remains possible without becoming a second authority.
+- The Profile lifecycle gains a new qualification level and witness surface, but Core remains domain-neutral.
+- Mission Control must qualify through the same public path and receives no private KFD-3 exception.
+
+## Delivery stages
+
+1. Add the optional content-bound collaboration facet and negative contract fixtures.
+2. Add closure parsing, roots, qualification state and public Python/Node/CLI services.
+3. Project generic GUI and Agent surfaces over the shared intent protocol.
+4. Add reverse audit, no-bypass tests and Buildchain witness emission.
+5. Qualify an independent Profile and regress Mission Control in a frozen Product.

--- a/framework/core/docs/adr/ADR-0074-profile-level-kfd3-qualification.md
+++ b/framework/core/docs/adr/ADR-0074-profile-level-kfd3-qualification.md
@@ -3,7 +3,9 @@ metadata_schema: kungfu.document-metadata/v1
 doc_type: architecture-decision
 adr_id: ADR-0074
 decision_status: accepted
-implementation_status: not-started
+implementation_status: partial
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/734]
+qualification_refs: [scripts/run-kfx-profile-suite-tests.mjs]
 review_state: self-reviewed
 sensitivity: public
 sources: [local-files, user-decision]

--- a/framework/core/docs/adr/README.md
+++ b/framework/core/docs/adr/README.md
@@ -105,6 +105,7 @@ compound implementation notes to the index Status column.
 | [0071](ADR-0071-cli-language-split-and-membrane-diagnostic-surface.md) | accepted | CLI language fit is decided by where the work lives and what the embedding membrane reaches, not clap-vs-click; substrate diagnostics (fsck/verify) belong in Rust via a grown read-only membrane surface, not per-command rewrites; product/UI/orchestration stays Python |
 | [0072](ADR-0072-frame-identity-layering-journal-local-vs-ledger-global.md) | proposed | frame identity is layered: frame_uid stays journal-local (fixing the deterministic page-8-bit wrap), while permanent ledger-global uniqueness is the Episode content root + structural stream_position (stream_id, container_epoch, sequence), not a widened probabilistic frame_uid |
 | [0073](ADR-0073-buildchain-adr-release-admissibility.md) | accepted | Buildchain promotion is the settlement boundary for ADR implementation truth: dev declares bounded delivery, alpha settles qualified progress, and stable admits no unaccounted accepted decision |
+| [0074](ADR-0074-profile-level-kfd3-qualification.md) | accepted | conforming Profile Suites declare a content-bound collaboration facet; Kungfu projects and qualifies one shared Human/Agent protocol instead of making each Profile reimplement KFD-3 |
 
 ## Reading by theme
 

--- a/framework/kfx/kungfu-kfx.contract.json
+++ b/framework/kfx/kungfu-kfx.contract.json
@@ -1,7 +1,7 @@
 {
   "schema": "kungfu.kfx.contract/v1",
   "id": "kungfu-kfx",
-  "version": 3,
+  "version": 4,
   "weldedSurface": "kfx-contract",
   "description": "Single source for KFX package manifests, discovery rules, trust inputs, and build detection.",
   "contractSchema": {
@@ -551,6 +551,18 @@
           },
           "policies": {
             "$ref": "#/$defs/nonEmptyContentRefs"
+          }
+        }
+      },
+      "kfd3": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "collaboration"
+        ],
+        "properties": {
+          "collaboration": {
+            "$ref": "#/$defs/contentRef"
           }
         }
       },

--- a/framework/kfx/src/index.ts
+++ b/framework/kfx/src/index.ts
@@ -252,6 +252,10 @@ export type KfxProfileSuite = {
     purposes: string[];
     policies: KfxProfileSuiteContentRef[];
   };
+  // Optional because existing Profile Suites remain valid KFD-1/KFD-2
+  // closures. Only Profiles that bind this facet can request KFD-3
+  // qualification from the runtime.
+  kfd3?: { collaboration: KfxProfileSuiteContentRef };
   actions: { registry: KfxProfileSuiteContentRef };
   views: { registry: KfxProfileSuiteContentRef };
   migrations: { registry: KfxProfileSuiteContentRef };

--- a/framework/kfx/src/profile-suite.test.ts
+++ b/framework/kfx/src/profile-suite.test.ts
@@ -73,6 +73,18 @@ test('Node validates the complete Week/Day Profile Suite closure', () => {
   ]);
 });
 
+test('Node keeps a Profile without a KFD-3 facet valid but not KFD-3 declared', () => {
+  const profile = structuredClone(validProfile);
+  assert.equal(Reflect.deleteProperty(profile, 'kfd3'), true);
+  validateKfxProfileSuite(profile, contract, [
+    'week-day-contract',
+    'week-day-actions',
+    'week-day-assessment',
+    'week-day-dashboard',
+  ]);
+  assert.equal(profile.kfd3, undefined);
+});
+
 for (const fixture of invalidCases) {
   test(`Node rejects Profile Suite fixture: ${fixture.id}`, () => {
     const profile = structuredClone(validProfile);

--- a/tests/fixtures/kfx-profile-suite-contract/invalid-cases.json
+++ b/tests/fixtures/kfx-profile-suite-contract/invalid-cases.json
@@ -27,6 +27,20 @@
     "match": "does not match"
   },
   {
+    "id": "malformed-kfd3-collaboration-hash",
+    "operation": "set",
+    "path": ["kfd3", "collaboration", "sha256"],
+    "value": "not-a-content-hash",
+    "match": "does not match"
+  },
+  {
+    "id": "unknown-kfd3-authority-field",
+    "operation": "set",
+    "path": ["kfd3", "authorityOverride"],
+    "value": true,
+    "match": "Additional properties are not allowed"
+  },
+  {
     "id": "member-in-required-and-optional",
     "operation": "set",
     "path": ["members", "optional"],

--- a/tests/fixtures/kfx-profile-suite-contract/week-day.profile.json
+++ b/tests/fixtures/kfx-profile-suite-contract/week-day.profile.json
@@ -57,6 +57,12 @@
       }
     ]
   },
+  "kfd3": {
+    "collaboration": {
+      "path": "collaboration/interface.json",
+      "sha256": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+    }
+  },
   "actions": {
     "registry": {
       "path": "actions/registry.json",


### PR DESCRIPTION
## Summary

Linear S0 delivery for Profile-level KFD-3 qualification. Adds ADR-0074 and an optional content-bound collaboration facet while preserving KFD-1/KFD-2-only Profiles.

## Verification

- ./shifu test:kfx-profile-suite
- ./shifu docs:check
- ./shifu kfd:buildchain:check
- staged repository gate

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "stage-ready",
  "adrs": ["ADR-0074"],
  "summary": "Declare the content-bound collaboration facet and preserve non-KFD3 Profile compatibility",
  "verification": ["Profile Suite Node and Python fixtures", "documentation contract gate", "Buildchain KFD evidence check"]
}
-->

## Governance risk check

- [x] release evidence, provenance, package publishing, or deployment surfaces

No release channel is promoted by this PR.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed