### PR TITLE
feat(core): grow embedding membrane v2 with read-only storage fsck

### DIFF
--- a/crates/kungfu-embedding/src/lib.rs
+++ b/crates/kungfu-embedding/src/lib.rs
@@ -4,11 +4,17 @@
 //!
 //! This is the one shared borrowing layer required by the Stage 3 embedding
 //! contract RFC (`framework/core/docs/embedding-contract-face.md`, decision D7):
-//! a single membrane (`kungfu_embedding_get_api` + the `kf_embedding_api_v1`
+//! a single membrane (`kungfu_embedding_get_api` + the `kf_embedding_api_v*`
 //! table, mirrored from `framework/core/src/libkungfu/include/kungfu/embedding.h`)
 //! consumed by two callers — the product trunk (`crates/trunk`) and the future
 //! native-authoring crate (`kungfu-kfx`, ADR-0045 gate 2). There is exactly one
 //! copy of the FFI seam, here.
+//!
+//! The table is version-negotiated: v1 exposes journal batch-read + capability
+//! negotiation; v2 (ADR-0071 Bucket A) appends a read-only substrate-diagnostic
+//! surface ([`Context::storage_fsck`]) after a byte-identical v1 prefix.
+//! [`Context::open`] negotiates v2 first and falls back to v1, so a v1-only core
+//! still yields a working journal-read context.
 //!
 //! # ABI fidelity
 //!
@@ -45,6 +51,11 @@ use std::slice;
 /// The frozen v1 ABI version negotiated through [`kungfu_embedding_get_api`].
 pub const ABI_V1: u32 = 1;
 
+/// The v2 ABI version: v1 plus the read-only substrate-diagnostic surface
+/// (`storage_fsck`). [`Context::open`] negotiates v2 first and falls back to v1,
+/// so a v1-only core still yields a working journal-read context.
+pub const ABI_V2: u32 = 2;
+
 /// Maximum frames a single `read_batch` call may return (`KF_EMBEDDING_MAX_BATCH_FRAMES`).
 pub const MAX_BATCH_FRAMES: u32 = 4096;
 
@@ -56,6 +67,13 @@ pub const CAP_READ_JOURNAL_BATCH: u64 = 1 << 0;
 
 /// Capability bit: batch payloads are zero-copy mmap views (`KF_EMBEDDING_CAP_MMAP_PAYLOAD_VIEW`).
 pub const CAP_MMAP_PAYLOAD_VIEW: u64 = 1 << 1;
+
+/// Capability bit: read-only substrate diagnostics reachable without CPython
+/// (`KF_EMBEDDING_CAP_STORAGE_DIAGNOSTICS`).
+pub const CAP_STORAGE_DIAGNOSTICS: u64 = 1 << 2;
+
+/// Report blob format tag: UTF-8 JSON (`KF_EMBEDDING_REPORT_FORMAT_JSON`).
+pub const REPORT_FORMAT_JSON: u32 = 1;
 
 const OK: i32 = 0;
 
@@ -115,6 +133,36 @@ struct BatchV1 {
     token: u64,
 }
 
+/// v2: a read-only storage fsck request (mirrors `kf_embedding_storage_fsck_request_v1`).
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct StorageFsckRequestV1 {
+    struct_size: u32,
+    scope: u32,
+    runtime_dir: *const c_char,
+    provider: *const c_char,
+    provider_config_source: *const c_char,
+    source_id: *const c_char,
+    episode_id: u64,
+    verify_frames: u32,
+    reserved: u32,
+}
+
+/// v2: an owned diagnostic report blob (mirrors `kf_embedding_report_v1`). The
+/// `data` bytes and their backing `owner` are freed by `report_release`.
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct ReportV1 {
+    struct_size: u32,
+    format: u32,
+    ok: u8,
+    degraded: u8,
+    reserved0: [u8; 2],
+    data: *const u8,
+    data_size: u64,
+    owner: *mut c_void,
+}
+
 type ContextOpen = unsafe extern "C" fn(*const ContextConfigV1, *mut *mut c_void) -> i32;
 type ContextCapabilities = unsafe extern "C" fn(*const c_void, *mut u64) -> i32;
 type ContextClose = unsafe extern "C" fn(*mut c_void) -> i32;
@@ -122,6 +170,9 @@ type ReaderOpen = unsafe extern "C" fn(*mut c_void, *const LocationV1, *mut *mut
 type ReaderReadBatch = unsafe extern "C" fn(*mut c_void, u32, *mut BatchV1) -> i32;
 type ReaderReleaseBatch = unsafe extern "C" fn(*mut c_void, u64) -> i32;
 type ReaderClose = unsafe extern "C" fn(*mut c_void) -> i32;
+type StorageFsck =
+    unsafe extern "C" fn(*mut c_void, *const StorageFsckRequestV1, *mut ReportV1) -> i32;
+type ReportRelease = unsafe extern "C" fn(*mut ReportV1) -> i32;
 
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -138,13 +189,50 @@ struct ApiV1 {
     reader_close: ReaderClose,
 }
 
+/// The v2 table: a byte-identical v1 prefix followed by the diagnostic pointers.
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct ApiV2 {
+    abi_version: u32,
+    struct_size: u32,
+    capabilities: u64,
+    context_open: ContextOpen,
+    context_capabilities: ContextCapabilities,
+    context_close: ContextClose,
+    reader_open: ReaderOpen,
+    reader_read_batch: ReaderReadBatch,
+    reader_release_batch: ReaderReleaseBatch,
+    reader_close: ReaderClose,
+    storage_fsck: StorageFsck,
+    report_release: ReportRelease,
+}
+
+impl ApiV2 {
+    /// The v1 view of this table's shared prefix.
+    fn as_v1(&self) -> ApiV1 {
+        ApiV1 {
+            abi_version: self.abi_version,
+            struct_size: self.struct_size,
+            capabilities: self.capabilities,
+            context_open: self.context_open,
+            context_capabilities: self.context_capabilities,
+            context_close: self.context_close,
+            reader_open: self.reader_open,
+            reader_read_batch: self.reader_read_batch,
+            reader_release_batch: self.reader_release_batch,
+            reader_close: self.reader_close,
+        }
+    }
+}
+
 extern "C" {
     /// The only link-visible bootstrap: negotiates version + table size and fills
-    /// `out_api`. Supplied by libkungfu at final link (see the crate docs).
+    /// `out_api` (a `kf_embedding_api_v{requested_version}`). Supplied by libkungfu
+    /// at final link (see the crate docs).
     fn kungfu_embedding_get_api(
         requested_version: u32,
         caller_struct_size: u32,
-        out_api: *mut ApiV1,
+        out_api: *mut c_void,
     ) -> i32;
 }
 
@@ -203,6 +291,14 @@ fn cstr(value: &str, field: &'static str) -> Result<CString, EmbeddingError> {
     CString::new(value).map_err(|_| EmbeddingError::NulInString(field))
 }
 
+fn opt_cstr(value: Option<&str>, field: &'static str) -> Result<Option<CString>, EmbeddingError> {
+    value.map(|v| cstr(v, field)).transpose()
+}
+
+fn opt_ptr(value: &Option<CString>) -> *const c_char {
+    value.as_ref().map_or(std::ptr::null(), |c| c.as_ptr())
+}
+
 fn api_v1() -> Result<ApiV1, EmbeddingError> {
     let mut api = std::mem::MaybeUninit::<ApiV1>::uninit();
     // SAFETY: the negotiator fills `out_api` only on OK, and we pass our own
@@ -211,7 +307,7 @@ fn api_v1() -> Result<ApiV1, EmbeddingError> {
         kungfu_embedding_get_api(
             ABI_V1,
             std::mem::size_of::<ApiV1>() as u32,
-            api.as_mut_ptr(),
+            api.as_mut_ptr().cast(),
         )
     };
     status(result)?;
@@ -221,6 +317,50 @@ fn api_v1() -> Result<ApiV1, EmbeddingError> {
         return Err(EmbeddingError::IncompatibleTable);
     }
     Ok(api)
+}
+
+fn api_v2() -> Result<ApiV2, EmbeddingError> {
+    let mut api = std::mem::MaybeUninit::<ApiV2>::uninit();
+    // SAFETY: the negotiator fills `out_api` only on OK; we pass our own struct
+    // size so a v1-only core rejects v2 with UnsupportedVersion.
+    let result = unsafe {
+        kungfu_embedding_get_api(
+            ABI_V2,
+            std::mem::size_of::<ApiV2>() as u32,
+            api.as_mut_ptr().cast(),
+        )
+    };
+    status(result)?;
+    // SAFETY: OK from the negotiator means the table is initialized.
+    let api = unsafe { api.assume_init() };
+    if api.abi_version != ABI_V2 || api.struct_size < std::mem::size_of::<ApiV2>() as u32 {
+        return Err(EmbeddingError::IncompatibleTable);
+    }
+    Ok(api)
+}
+
+/// Negotiate the richest table the core offers: v2 (with diagnostics) if
+/// available, otherwise fall back to v1. Only `UnsupportedVersion` triggers the
+/// fallback; any other error is surfaced.
+fn negotiate() -> Result<(ApiV1, Option<Diagnostics>), EmbeddingError> {
+    match api_v2() {
+        Ok(v2) => Ok((
+            v2.as_v1(),
+            Some(Diagnostics {
+                storage_fsck: v2.storage_fsck,
+                report_release: v2.report_release,
+            }),
+        )),
+        Err(EmbeddingError::UnsupportedVersion) => Ok((api_v1()?, None)),
+        Err(other) => Err(other),
+    }
+}
+
+/// The v2 diagnostic function pointers, present only when v2 was negotiated.
+#[derive(Clone, Copy)]
+struct Diagnostics {
+    storage_fsck: StorageFsck,
+    report_release: ReportRelease,
 }
 
 // ── typed enums ──
@@ -297,6 +437,11 @@ impl Capabilities {
     pub fn mmap_payload_view(self) -> bool {
         self.0 & CAP_MMAP_PAYLOAD_VIEW != 0
     }
+
+    /// Whether the read-only substrate-diagnostic surface (fsck) is reachable.
+    pub fn storage_diagnostics(self) -> bool {
+        self.0 & CAP_STORAGE_DIAGNOSTICS != 0
+    }
 }
 
 // ── config ──
@@ -360,18 +505,78 @@ impl<'a> Location<'a> {
     }
 }
 
+// ── storage diagnostics (v2) ──
+
+/// Which slice of a runtime an fsck covers (`kf_embedding_storage_fsck_scope`).
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum StorageFsckScope {
+    /// `KF_EMBEDDING_FSCK_SCOPE_ALL` — the whole runtime.
+    #[default]
+    All,
+    /// `KF_EMBEDDING_FSCK_SCOPE_SOURCE` — one source.
+    Source,
+    /// `KF_EMBEDDING_FSCK_SCOPE_EPISODE` — one episode of one source.
+    Episode,
+}
+
+impl StorageFsckScope {
+    fn as_u32(self) -> u32 {
+        match self {
+            Self::All => 0,
+            Self::Source => 1,
+            Self::Episode => 2,
+        }
+    }
+}
+
+/// A read-only storage fsck request. Optional fields map to nullable C strings.
+#[derive(Clone, Copy, Debug)]
+pub struct StorageFsckRequest<'a> {
+    /// The runtime root to check (the `--runtime-dir`).
+    pub runtime_dir: &'a str,
+    /// Storage provider name (`None` for the runtime default).
+    pub provider: Option<&'a str>,
+    /// Where the provider config came from (`None` for the default).
+    pub provider_config_source: Option<&'a str>,
+    /// Which slice to check.
+    pub scope: StorageFsckScope,
+    /// The source id for `Source`/`Episode` scope.
+    pub source_id: Option<&'a str>,
+    /// The episode id for `Episode` scope.
+    pub episode_id: u64,
+    /// Whether to verify journal frame integrity (heavier).
+    pub verify_frames: bool,
+}
+
+impl<'a> StorageFsckRequest<'a> {
+    /// An `All`-scope request over `runtime_dir` with defaults elsewhere.
+    pub fn new(runtime_dir: &'a str) -> Self {
+        Self {
+            runtime_dir,
+            provider: None,
+            provider_config_source: None,
+            scope: StorageFsckScope::All,
+            source_id: None,
+            episode_id: 0,
+            verify_frames: false,
+        }
+    }
+}
+
 // ── handles ──
 
 /// An open embedding context: a live view into a kungfu runtime root.
 pub struct Context {
     api: ApiV1,
+    diagnostics: Option<Diagnostics>,
     raw: *mut c_void,
 }
 
 impl Context {
-    /// Negotiate the v1 table and open a context for `config`.
+    /// Negotiate the richest table the core offers (v2 with diagnostics, else v1)
+    /// and open a context for `config`.
     pub fn open(config: &ContextConfig) -> Result<Self, EmbeddingError> {
-        let api = api_v1()?;
+        let (api, diagnostics) = negotiate()?;
         let root = cstr(config.root, "root")?;
         let namespace = cstr(config.host_namespace, "host_namespace")?;
         let name = cstr(config.host_name, "host_name")?;
@@ -391,7 +596,57 @@ impl Context {
         let mut raw = std::ptr::null_mut();
         // SAFETY: the CStrings outlive the call; `raw_config` points at live memory.
         status(unsafe { (api.context_open)(&raw_config, &mut raw) })?;
-        Ok(Self { api, raw })
+        Ok(Self {
+            api,
+            diagnostics,
+            raw,
+        })
+    }
+
+    /// Run a read-only storage fsck over `request.runtime_dir`, returning the
+    /// report (JSON detail plus an `ok`/`degraded` verdict). This is the
+    /// `doctor`-class path: it reuses the C++ `storage_service::fsck` through the
+    /// membrane and needs no CPython, so it works when the Python runtime is down.
+    ///
+    /// Returns [`EmbeddingError::UnsupportedVersion`] if the core only offers v1
+    /// (no diagnostic surface).
+    pub fn storage_fsck(&self, request: &StorageFsckRequest) -> Result<FsckReport, EmbeddingError> {
+        let diagnostics = self.diagnostics.ok_or(EmbeddingError::UnsupportedVersion)?;
+
+        let runtime_dir = cstr(request.runtime_dir, "runtime_dir")?;
+        let provider = opt_cstr(request.provider, "provider")?;
+        let provider_config_source =
+            opt_cstr(request.provider_config_source, "provider_config_source")?;
+        let source_id = opt_cstr(request.source_id, "source_id")?;
+
+        let raw_request = StorageFsckRequestV1 {
+            struct_size: std::mem::size_of::<StorageFsckRequestV1>() as u32,
+            scope: request.scope.as_u32(),
+            runtime_dir: runtime_dir.as_ptr(),
+            provider: opt_ptr(&provider),
+            provider_config_source: opt_ptr(&provider_config_source),
+            source_id: opt_ptr(&source_id),
+            episode_id: request.episode_id,
+            verify_frames: u32::from(request.verify_frames),
+            reserved: 0,
+        };
+        let mut raw_report = ReportV1 {
+            struct_size: std::mem::size_of::<ReportV1>() as u32,
+            format: 0,
+            ok: 0,
+            degraded: 0,
+            reserved0: [0; 2],
+            data: std::ptr::null(),
+            data_size: 0,
+            owner: std::ptr::null_mut(),
+        };
+        // SAFETY: the CStrings outlive the call; `self.raw` is a live context;
+        // `raw_report` points at live stack memory.
+        status(unsafe { (diagnostics.storage_fsck)(self.raw, &raw_request, &mut raw_report) })?;
+        Ok(FsckReport {
+            release: diagnostics.report_release,
+            raw: raw_report,
+        })
     }
 
     /// The capabilities this specific context can service.
@@ -578,6 +833,58 @@ impl Drop for Batch<'_, '_> {
     }
 }
 
+/// An owned storage fsck report. Holds the core-owned report blob until dropped,
+/// when it returns the blob through `report_release`. The `ok`/`degraded` verdict
+/// is typed, so a caller can decide an exit code without parsing the JSON.
+pub struct FsckReport {
+    release: ReportRelease,
+    raw: ReportV1,
+}
+
+impl FsckReport {
+    /// Whether the runtime passed the check.
+    pub fn ok(&self) -> bool {
+        self.raw.ok != 0
+    }
+
+    /// Whether the check ran but the runtime is degraded.
+    pub fn degraded(&self) -> bool {
+        self.raw.degraded != 0
+    }
+
+    /// Whether the report blob is UTF-8 JSON.
+    pub fn is_json(&self) -> bool {
+        self.raw.format == REPORT_FORMAT_JSON
+    }
+
+    /// The raw report blob (JSON bytes for the current core). Empty if the core
+    /// returned no payload.
+    pub fn bytes(&self) -> &[u8] {
+        if self.raw.data.is_null() || self.raw.data_size == 0 {
+            &[]
+        } else {
+            // SAFETY: the core guarantees `data`/`data_size` describe a live blob
+            // owned by this report until `report_release` (called on drop).
+            unsafe { slice::from_raw_parts(self.raw.data, self.raw.data_size as usize) }
+        }
+    }
+
+    /// The report blob as UTF-8, or a UTF-8 error if the bytes are not valid text.
+    pub fn as_str(&self) -> Result<&str, std::str::Utf8Error> {
+        std::str::from_utf8(self.bytes())
+    }
+}
+
+impl Drop for FsckReport {
+    fn drop(&mut self) {
+        if !self.raw.owner.is_null() {
+            // SAFETY: `raw` owns a live report blob issued by `storage_fsck`.
+            let result = unsafe { (self.release)(&mut self.raw) };
+            debug_assert_eq!(result, OK);
+        }
+    }
+}
+
 // ── compile-time ABI layout guards (mirror embedding.h; 64-bit targets) ──
 //
 // kungfu ships on 64-bit platforms only (arm64 / x86-64), so the raw structs
@@ -598,6 +905,12 @@ mod layout_guards {
     const _: () = assert!(align_of::<BatchV1>() == 8);
     const _: () = assert!(size_of::<ApiV1>() == 72);
     const _: () = assert!(align_of::<ApiV1>() == 8);
+    const _: () = assert!(size_of::<StorageFsckRequestV1>() == 56);
+    const _: () = assert!(align_of::<StorageFsckRequestV1>() == 8);
+    const _: () = assert!(size_of::<ReportV1>() == 40);
+    const _: () = assert!(align_of::<ReportV1>() == 8);
+    const _: () = assert!(size_of::<ApiV2>() == 88);
+    const _: () = assert!(align_of::<ApiV2>() == 8);
 }
 
 #[cfg(test)]
@@ -640,6 +953,37 @@ mod tests {
         assert!(caps.mmap_payload_view());
         assert_eq!(caps.bits(), 3);
         assert!(!Capabilities(0).read_journal_batch());
+        assert!(!caps.storage_diagnostics());
+        assert!(Capabilities(CAP_STORAGE_DIAGNOSTICS).storage_diagnostics());
+    }
+
+    #[test]
+    fn fsck_scope_maps_to_abi_values() {
+        assert_eq!(StorageFsckScope::All.as_u32(), 0);
+        assert_eq!(StorageFsckScope::Source.as_u32(), 1);
+        assert_eq!(StorageFsckScope::Episode.as_u32(), 2);
+        assert_eq!(StorageFsckScope::default(), StorageFsckScope::All);
+    }
+
+    #[test]
+    fn fsck_request_defaults() {
+        let req = StorageFsckRequest::new("/rt");
+        assert_eq!(req.runtime_dir, "/rt");
+        assert_eq!(req.scope, StorageFsckScope::All);
+        assert!(req.provider.is_none());
+        assert!(!req.verify_frames);
+        assert_eq!(req.episode_id, 0);
+    }
+
+    #[test]
+    fn opt_cstr_handles_none_and_nul() {
+        assert!(matches!(opt_cstr(None, "provider"), Ok(None)));
+        assert!(matches!(opt_cstr(Some("ok"), "provider"), Ok(Some(_))));
+        assert_eq!(
+            opt_cstr(Some("a\0b"), "provider"),
+            Err(EmbeddingError::NulInString("provider"))
+        );
+        assert!(opt_ptr(&None).is_null());
     }
 
     #[test]

--- a/crates/trunk/src/fsck.rs
+++ b/crates/trunk/src/fsck.rs
@@ -1,0 +1,223 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// `fsck` — read-only substrate integrity check of the kungfu storage runtime
+// through the embedding membrane.
+//
+// This is `doctor`'s natural sibling (ADR-0071 Bucket A): it negotiates the v2
+// embedding table, opens a context on the runtime root, and runs the C++
+// `storage_service::fsck` through the membrane's read-only diagnostic surface.
+// The compute is native C++ reused verbatim — no domain logic is rewritten in
+// Rust — and it runs without booting CPython, so it survives a broken Python
+// runtime, the same reason `doctor` is Rust-native (ADR-0046 driver 1).
+//
+// The FFI path is behind the `embedding` feature so a coreless build still has an
+// `fsck` command that explains how to get the real thing.
+
+/// Parsed `fsck` arguments. Feature-independent so the default-feature test build
+/// exercises the parser; the FFI lives in `inspect`.
+#[derive(Debug, Default, PartialEq, Eq)]
+struct FsckArgs {
+    runtime_dir: Option<String>,
+    provider: Option<String>,
+    provider_config_source: Option<String>,
+    source: Option<String>,
+    episode: Option<u64>,
+    verify_frames: bool,
+    json: bool,
+}
+
+const USAGE: &str = "\
+usage: kungfu fsck [--runtime-dir <dir>] [--provider <name>]
+                   [--provider-config-source <src>] [--source <id>]
+                   [--episode <id>] [--verify-frames] [--json]
+
+Read-only substrate integrity check of the kungfu storage runtime through the
+embedding membrane. Reuses the native C++ storage fsck (no CPython), so it runs
+even when the Python runtime is down. Reports an ok/degraded verdict plus the
+full JSON report. Scope: --episode implies one episode (needs --source),
+--source alone implies one source, otherwise the whole runtime.
+
+Exit status is 0 when the runtime passes, non-zero when checks fail.";
+
+pub fn run(args: &[String]) -> Result<(), String> {
+    if args.iter().any(|a| a == "--help" || a == "-h") {
+        println!("{USAGE}");
+        return Ok(());
+    }
+    let parsed = parse_args(args)?;
+    inspect(parsed)
+}
+
+fn parse_args(args: &[String]) -> Result<FsckArgs, String> {
+    let mut out = FsckArgs::default();
+    let mut it = args.iter();
+    while let Some(arg) = it.next() {
+        let mut take = |flag: &str| -> Result<String, String> {
+            it.next()
+                .cloned()
+                .ok_or_else(|| format!("fsck {flag} needs a value"))
+        };
+        match arg.as_str() {
+            "--runtime-dir" => out.runtime_dir = Some(take("--runtime-dir")?),
+            "--provider" => out.provider = Some(take("--provider")?),
+            "--provider-config-source" => {
+                out.provider_config_source = Some(take("--provider-config-source")?);
+            }
+            "--source" => out.source = Some(take("--source")?),
+            "--episode" => {
+                let raw = take("--episode")?;
+                let id = raw.parse::<u64>().map_err(|_| {
+                    format!("fsck --episode needs a non-negative integer, got '{raw}'")
+                })?;
+                out.episode = Some(id);
+            }
+            "--verify-frames" => out.verify_frames = true,
+            "--json" => out.json = true,
+            other => return Err(format!("fsck: unknown argument '{other}'\n\n{USAGE}")),
+        }
+    }
+    if out.episode.is_some() && out.source.is_none() {
+        return Err(
+            "fsck --episode needs --source <id> to select the episode's source".to_string(),
+        );
+    }
+    Ok(out)
+}
+
+#[cfg(feature = "embedding")]
+fn inspect(args: FsckArgs) -> Result<(), String> {
+    use crate::envs;
+    use kungfu_embedding::{Context, ContextConfig, StorageFsckRequest, StorageFsckScope, ABI_V2};
+
+    let home = envs::kf_home();
+    let runtime_dir = match &args.runtime_dir {
+        Some(dir) => dir.clone(),
+        None => home
+            .to_str()
+            .ok_or("the kungfu home path is not valid UTF-8")?
+            .to_string(),
+    };
+
+    let context = Context::open(&ContextConfig::new(&runtime_dir, "kungfu-trunk", "fsck"))
+        .map_err(|e| e.to_string())?;
+
+    let scope = if args.episode.is_some() {
+        StorageFsckScope::Episode
+    } else if args.source.is_some() {
+        StorageFsckScope::Source
+    } else {
+        StorageFsckScope::All
+    };
+
+    let mut request = StorageFsckRequest::new(&runtime_dir);
+    request.provider = args.provider.as_deref();
+    request.provider_config_source = args.provider_config_source.as_deref();
+    request.scope = scope;
+    request.source_id = args.source.as_deref();
+    request.episode_id = args.episode.unwrap_or(0);
+    request.verify_frames = args.verify_frames;
+
+    let report = context.storage_fsck(&request).map_err(|e| e.to_string())?;
+
+    if !args.json {
+        println!(
+            "kungfu fsck — embedding membrane (ABI v{ABI_V2})\n  runtime: {runtime_dir}\n  verdict: ok={} degraded={}",
+            report.ok(),
+            report.degraded(),
+        );
+    }
+    // The report blob is JSON produced by the native core; emit it verbatim.
+    match report.as_str() {
+        Ok(json) => println!("{json}"),
+        Err(_) => return Err("fsck: report blob was not valid UTF-8".to_string()),
+    }
+    if report.degraded() && report.ok() {
+        eprintln!("kungfu: fsck: runtime is degraded (see report)");
+    }
+    if !report.ok() {
+        return Err("fsck: storage integrity checks failed (see report above)".to_string());
+    }
+    Ok(())
+}
+
+#[cfg(not(feature = "embedding"))]
+fn inspect(_args: FsckArgs) -> Result<(), String> {
+    Err(
+        "fsck: substrate inspection needs the assembled product build — a \
+         kungfu-trunk compiled with --features embedding next to libkungfu. The \
+         shipped product enables it; a bare dev build does not."
+            .to_string(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn s(v: &[&str]) -> Vec<String> {
+        v.iter().map(|x| x.to_string()).collect()
+    }
+
+    #[test]
+    fn no_args_is_all_scope_defaults() {
+        let parsed = parse_args(&[]).unwrap();
+        assert_eq!(parsed, FsckArgs::default());
+        assert!(parsed.runtime_dir.is_none());
+        assert!(!parsed.verify_frames);
+        assert!(!parsed.json);
+    }
+
+    #[test]
+    fn parses_all_flags() {
+        let parsed = parse_args(&s(&[
+            "--runtime-dir",
+            "/rt",
+            "--provider",
+            "rocksdb",
+            "--provider-config-source",
+            "cfg",
+            "--source",
+            "md-xtp",
+            "--episode",
+            "42",
+            "--verify-frames",
+            "--json",
+        ]))
+        .unwrap();
+        assert_eq!(parsed.runtime_dir.as_deref(), Some("/rt"));
+        assert_eq!(parsed.provider.as_deref(), Some("rocksdb"));
+        assert_eq!(parsed.provider_config_source.as_deref(), Some("cfg"));
+        assert_eq!(parsed.source.as_deref(), Some("md-xtp"));
+        assert_eq!(parsed.episode, Some(42));
+        assert!(parsed.verify_frames);
+        assert!(parsed.json);
+    }
+
+    #[test]
+    fn episode_requires_source() {
+        assert!(parse_args(&s(&["--episode", "1"])).is_err());
+        assert!(parse_args(&s(&["--episode", "1", "--source", "s"])).is_ok());
+    }
+
+    #[test]
+    fn episode_rejects_non_integer() {
+        assert!(parse_args(&s(&["--source", "s", "--episode", "x"])).is_err());
+    }
+
+    #[test]
+    fn missing_flag_value_is_named() {
+        assert!(parse_args(&s(&["--runtime-dir"])).is_err());
+        assert!(parse_args(&s(&["--source"])).is_err());
+    }
+
+    #[test]
+    fn unknown_argument_is_named() {
+        assert!(parse_args(&s(&["--bogus"])).is_err());
+    }
+
+    #[test]
+    fn help_exits_success() {
+        assert!(run(&s(&["--help"])).is_ok());
+        assert!(run(&s(&["-h"])).is_ok());
+    }
+}

--- a/crates/trunk/src/main.rs
+++ b/crates/trunk/src/main.rs
@@ -10,6 +10,7 @@
 
 mod doctor;
 mod envs;
+mod fsck;
 mod help;
 mod launch;
 mod pins;
@@ -33,6 +34,9 @@ usage:
                                                run a command inside an env (default: python)
   kungfu-trunk prewarm                         pre-fetch the pinned uv + satellite CPython
   kungfu-trunk doctor [--read <ns> <name>]     read-only runtime inspection via the
+                                               embedding membrane (product build)
+  kungfu-trunk fsck [--runtime-dir <dir>] [--source <id>] [--episode <id>]
+                                               read-only storage integrity check via the
                                                embedding membrane (product build)
   kungfu-trunk --version | --help
 
@@ -77,6 +81,7 @@ fn main() {
             Some("env") => dispatch_env(&args[1..]),
             Some("prewarm") => envs::prewarm(),
             Some("doctor") => doctor::run(&args[1..]),
+            Some("fsck") => fsck::run(&args[1..]),
             _ => launch::launch(&args),
         };
         if let Err(msg) = result {
@@ -89,6 +94,7 @@ fn main() {
         Some("env") => dispatch_env(&args[1..]),
         Some("prewarm") => envs::prewarm(),
         Some("doctor") => doctor::run(&args[1..]),
+        Some("fsck") => fsck::run(&args[1..]),
         Some("--version" | "-V" | "version") => {
             println!("kungfu-trunk {}", env!("CARGO_PKG_VERSION"));
             Ok(())

--- a/framework/core/docs/adr/ADR-0071-cli-language-split-and-membrane-diagnostic-surface.md
+++ b/framework/core/docs/adr/ADR-0071-cli-language-split-and-membrane-diagnostic-surface.md
@@ -3,7 +3,8 @@ metadata_schema: kungfu.document-metadata/v1
 doc_type: architecture-decision
 adr_id: ADR-0071
 decision_status: accepted
-implementation_status: not-started
+implementation_status: partial
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/735]
 review_state: self-reviewed
 sensitivity: public
 sources: [local-files, user-decision]
@@ -163,8 +164,12 @@ schema-compile as read-only entries), then putting thin Rust CLIs over it. That:
 
 ## Follow-up
 
-- Implementation of Bucket A (grow the membrane's read-only diagnostic surface,
-  then ship a Rust `fsck` / `storage verify`) is tracked as an Atlas go card,
-  not scoped in this ADR.
+- Bucket A first stage delivered: the embedding membrane grew a versioned v2
+  table exposing a read-only `storage_fsck` diagnostic entry (reusing the native
+  C++ `storage_service::fsck` verbatim, no CPython on the path), and a Rust
+  `kungfu fsck` consumer landed over it, behind the `embedding` feature with a
+  graceful coreless fallback — `doctor`'s sibling. This is a bounded stage:
+  `verify` / `gc-plan` / `repair-plan` diagnostic entries and the Windows DLL
+  runtime smoke remain follow-ups, so the ADR is `partial`, not `implemented`.
 - Bucket B is measurement-gated; open a separate item only if a real workload
   shows the CPython fold is felt.

--- a/framework/core/slices/shared-embedding-membrane/host.cpp
+++ b/framework/core/slices/shared-embedding-membrane/host.cpp
@@ -143,7 +143,9 @@ int main(int argc, char **argv) {
   }
 
   kf_embedding_api_v1 api{};
-  if (kungfu_embedding_get_api(KF_EMBEDDING_ABI_V1 + 1, sizeof(api), &api) != KF_EMBEDDING_UNSUPPORTED_VERSION ||
+  // A version above the highest supported table is UNSUPPORTED_VERSION; an
+  // undersized buffer for a supported version is INVALID_ARGUMENT.
+  if (kungfu_embedding_get_api(KF_EMBEDDING_ABI_V2 + 1, sizeof(api), &api) != KF_EMBEDDING_UNSUPPORTED_VERSION ||
       kungfu_embedding_get_api(KF_EMBEDDING_ABI_V1, sizeof(api) - 1, &api) != KF_EMBEDDING_INVALID_ARGUMENT) {
     std::fprintf(stderr, "ABI version/size negotiation failed\n");
     return 4;
@@ -151,6 +153,23 @@ int main(int argc, char **argv) {
   const auto api_status = kungfu_embedding_get_api(KF_EMBEDDING_ABI_V1, sizeof(api), &api);
   if (api_status != KF_EMBEDDING_OK || api.abi_version != KF_EMBEDDING_ABI_V1) {
     std::fprintf(stderr, "get_api failed: %d\n", api_status);
+    return 5;
+  }
+  // v2 (ADR-0071) negotiates the read-only diagnostic surface on top of the v1
+  // prefix. Requesting v2 into a v1-sized buffer must be rejected on size; a
+  // correctly sized v2 request must advertise the storage-diagnostics capability
+  // and populate the diagnostic pointers.
+  kf_embedding_api_v2 api_v2{};
+  if (kungfu_embedding_get_api(KF_EMBEDDING_ABI_V2, sizeof(kf_embedding_api_v1), &api_v2) !=
+      KF_EMBEDDING_INVALID_ARGUMENT) {
+    std::fprintf(stderr, "ABI v2 size negotiation failed\n");
+    return 4;
+  }
+  const auto v2_status = kungfu_embedding_get_api(KF_EMBEDDING_ABI_V2, sizeof(api_v2), &api_v2);
+  if (v2_status != KF_EMBEDDING_OK || api_v2.abi_version != KF_EMBEDDING_ABI_V2 ||
+      (api_v2.capabilities & KF_EMBEDDING_CAP_STORAGE_DIAGNOSTICS) == 0 || api_v2.storage_fsck == nullptr ||
+      api_v2.report_release == nullptr) {
+    std::fprintf(stderr, "ABI v2 negotiation failed: %d\n", v2_status);
     return 5;
   }
   if (!check_error_paths(api, argv[1])) {

--- a/framework/core/src/libkungfu/include/kungfu/embedding.h
+++ b/framework/core/src/libkungfu/include/kungfu/embedding.h
@@ -28,6 +28,7 @@ extern "C" {
 #endif
 
 #define KF_EMBEDDING_ABI_V1 UINT32_C(1)
+#define KF_EMBEDDING_ABI_V2 UINT32_C(2)
 #define KF_EMBEDDING_MAX_BATCH_FRAMES UINT32_C(4096)
 #define KF_EMBEDDING_CONTEXT_LOW_LATENCY UINT32_C(1)
 
@@ -46,6 +47,8 @@ typedef enum kf_embedding_status {
 
 #define KF_EMBEDDING_CAP_READ_JOURNAL_BATCH (UINT64_C(1) << 0)
 #define KF_EMBEDDING_CAP_MMAP_PAYLOAD_VIEW (UINT64_C(1) << 1)
+/* v2: read-only substrate diagnostics (fsck) reachable without booting CPython. */
+#define KF_EMBEDDING_CAP_STORAGE_DIAGNOSTICS (UINT64_C(1) << 2)
 
 typedef enum kf_embedding_mode {
   KF_EMBEDDING_MODE_LIVE = 0,
@@ -113,6 +116,46 @@ typedef struct kf_embedding_batch_v1 {
   uint64_t token;
 } kf_embedding_batch_v1;
 
+/*
+ * v2 read-only substrate-diagnostic surface. `storage_fsck` bridges to the C++
+ * `storage_service::fsck` (native, no CPython) and returns the report as a JSON
+ * byte blob (`render_storage_fsck_result(...).dump()`), plus the `ok`/`degraded`
+ * verdict as typed bytes so callers can decide an exit code without parsing JSON.
+ * The blob and its backing store are owned by the call; the caller must return
+ * them with `report_release`. This keeps the contract face narrow: growing the
+ * diagnostic surface adds JSON fields, not C ABI structs.
+ */
+typedef enum kf_embedding_storage_fsck_scope {
+  KF_EMBEDDING_FSCK_SCOPE_ALL = 0,
+  KF_EMBEDDING_FSCK_SCOPE_SOURCE = 1,
+  KF_EMBEDDING_FSCK_SCOPE_EPISODE = 2
+} kf_embedding_storage_fsck_scope;
+
+typedef struct kf_embedding_storage_fsck_request_v1 {
+  uint32_t struct_size;
+  uint32_t scope; /* kf_embedding_storage_fsck_scope */
+  const char *runtime_dir;
+  const char *provider;               /* nullable */
+  const char *provider_config_source; /* nullable */
+  const char *source_id;              /* nullable; used for Source/Episode scope */
+  uint64_t episode_id;                /* used for Episode scope */
+  uint32_t verify_frames;             /* bool 0/1 */
+  uint32_t reserved;
+} kf_embedding_storage_fsck_request_v1;
+
+#define KF_EMBEDDING_REPORT_FORMAT_JSON UINT32_C(1)
+
+typedef struct kf_embedding_report_v1 {
+  uint32_t struct_size;
+  uint32_t format; /* KF_EMBEDDING_REPORT_FORMAT_JSON */
+  uint8_t ok;
+  uint8_t degraded;
+  uint8_t reserved0[2];
+  const uint8_t *data; /* owned report bytes, valid until report_release */
+  uint64_t data_size;
+  void *owner; /* opaque; report_release frees this */
+} kf_embedding_report_v1;
+
 typedef int32_t(KF_EMBEDDING_CALL *kf_embedding_context_open_v1_fn)(const kf_embedding_context_config_v1 *config,
                                                                     kf_embedding_context **out_context);
 typedef int32_t(KF_EMBEDDING_CALL *kf_embedding_context_capabilities_v1_fn)(const kf_embedding_context *context,
@@ -127,6 +170,9 @@ typedef int32_t(KF_EMBEDDING_CALL *kf_embedding_reader_read_batch_v1_fn)(kf_embe
 typedef int32_t(KF_EMBEDDING_CALL *kf_embedding_reader_release_batch_v1_fn)(kf_embedding_reader *reader,
                                                                             uint64_t token);
 typedef int32_t(KF_EMBEDDING_CALL *kf_embedding_reader_close_v1_fn)(kf_embedding_reader *reader);
+typedef int32_t(KF_EMBEDDING_CALL *kf_embedding_storage_fsck_v1_fn)(
+    kf_embedding_context *context, const kf_embedding_storage_fsck_request_v1 *request, kf_embedding_report_v1 *out_report);
+typedef int32_t(KF_EMBEDDING_CALL *kf_embedding_report_release_v1_fn)(kf_embedding_report_v1 *report);
 
 typedef struct kf_embedding_api_v1 {
   uint32_t abi_version;
@@ -141,10 +187,34 @@ typedef struct kf_embedding_api_v1 {
   kf_embedding_reader_close_v1_fn reader_close;
 } kf_embedding_api_v1;
 
-/* The only link-visible bootstrap. All versioned operations live in the table. */
+/*
+ * v2 appends the diagnostic pointers after a byte-identical v1 prefix, so a v2
+ * table can be read as a v1 table. Growth is version-gated: the bootstrap fills
+ * the table matching `requested_version`, and `caller_struct_size` guards the
+ * copy. A v1-only caller keeps working unchanged against a v2 core.
+ */
+typedef struct kf_embedding_api_v2 {
+  uint32_t abi_version;
+  uint32_t struct_size;
+  uint64_t capabilities;
+  kf_embedding_context_open_v1_fn context_open;
+  kf_embedding_context_capabilities_v1_fn context_capabilities;
+  kf_embedding_context_close_v1_fn context_close;
+  kf_embedding_reader_open_v1_fn reader_open;
+  kf_embedding_reader_read_batch_v1_fn reader_read_batch;
+  kf_embedding_reader_release_batch_v1_fn reader_release_batch;
+  kf_embedding_reader_close_v1_fn reader_close;
+  kf_embedding_storage_fsck_v1_fn storage_fsck;
+  kf_embedding_report_release_v1_fn report_release;
+} kf_embedding_api_v2;
+
+/*
+ * The only link-visible bootstrap. All versioned operations live in the table.
+ * `out_api` points at a caller-owned `kf_embedding_api_v{requested_version}`;
+ * `caller_struct_size` must be at least the size of that versioned table.
+ */
 KF_EMBEDDING_EXPORT int32_t KF_EMBEDDING_CALL kungfu_embedding_get_api(uint32_t requested_version,
-                                                                       uint32_t caller_struct_size,
-                                                                       kf_embedding_api_v1 *out_api);
+                                                                       uint32_t caller_struct_size, void *out_api);
 
 #ifdef __cplusplus
 }

--- a/framework/core/src/libkungfu/src/runtime/embedding.cpp
+++ b/framework/core/src/libkungfu/src/runtime/embedding.cpp
@@ -2,11 +2,14 @@
 
 #include <kungfu/embedding.h>
 #include <kungfu/runtime/io.h>
+#include <kungfu/runtime/storage/json_edge.h>
+#include <kungfu/runtime/storage/service.h>
 
 #include <algorithm>
 #include <cstring>
 #include <memory>
 #include <new>
+#include <string>
 #include <vector>
 
 using namespace kungfu::yijinjing;
@@ -191,22 +194,99 @@ int32_t KF_EMBEDDING_CALL reader_close(kf_embedding_reader *reader) noexcept {
   });
 }
 
+int32_t KF_EMBEDDING_CALL storage_fsck(kf_embedding_context *context,
+                                       const kf_embedding_storage_fsck_request_v1 *request,
+                                       kf_embedding_report_v1 *out_report) noexcept {
+  return contain_exceptions([&]() -> int32_t {
+    if (context == nullptr || request == nullptr || out_report == nullptr || request->struct_size < sizeof(*request) ||
+        out_report->struct_size < sizeof(*out_report) || request->runtime_dir == nullptr ||
+        request->scope > KF_EMBEDDING_FSCK_SCOPE_EPISODE) {
+      return KF_EMBEDDING_INVALID_ARGUMENT;
+    }
+    // The context is the "membrane is live" token; fsck targets request->runtime_dir.
+    (void)context;
+
+    namespace ssa = kungfu::runtime::storage_service_api;
+    ssa::storage_fsck_request req;
+    req.runtime_dir = request->runtime_dir;
+    if (request->provider != nullptr) {
+      req.provider = request->provider;
+    }
+    if (request->provider_config_source != nullptr) {
+      req.provider_config_source = request->provider_config_source;
+    }
+    req.scope = static_cast<ssa::storage_fsck_scope>(request->scope);
+    if (request->source_id != nullptr) {
+      req.source_id = request->source_id;
+    }
+    req.episode_id = request->episode_id;
+    req.verify_frames = request->verify_frames != 0;
+
+    const auto result = ssa::default_storage_service().fsck(req);
+    // render_storage_fsck_result is native C++ (nlohmann::json), no CPython on the path.
+    auto payload = std::make_unique<std::string>(ssa::render_storage_fsck_result(result).dump());
+
+    out_report->format = KF_EMBEDDING_REPORT_FORMAT_JSON;
+    out_report->ok = result.ok ? 1 : 0;
+    out_report->degraded = result.degraded ? 1 : 0;
+    out_report->reserved0[0] = 0;
+    out_report->reserved0[1] = 0;
+    out_report->data = reinterpret_cast<const uint8_t *>(payload->data());
+    out_report->data_size = payload->size();
+    out_report->owner = payload.release();
+    return KF_EMBEDDING_OK;
+  });
+}
+
+int32_t KF_EMBEDDING_CALL report_release(kf_embedding_report_v1 *report) noexcept {
+  return contain_exceptions([&]() -> int32_t {
+    if (report == nullptr) {
+      return KF_EMBEDDING_INVALID_ARGUMENT;
+    }
+    delete static_cast<std::string *>(report->owner);
+    report->owner = nullptr;
+    report->data = nullptr;
+    report->data_size = 0;
+    return KF_EMBEDDING_OK;
+  });
+}
+
 const kf_embedding_api_v1 API_V1 = {KF_EMBEDDING_ABI_V1, sizeof(kf_embedding_api_v1), CAPABILITIES,
                                     context_open,        context_capabilities,        context_close,
                                     reader_open,         reader_read_batch,           reader_release_batch,
                                     reader_close};
 
+constexpr uint64_t CAPABILITIES_V2 = CAPABILITIES | KF_EMBEDDING_CAP_STORAGE_DIAGNOSTICS;
+
+const kf_embedding_api_v2 API_V2 = {KF_EMBEDDING_ABI_V2, sizeof(kf_embedding_api_v2),
+                                    CAPABILITIES_V2,     context_open,
+                                    context_capabilities, context_close,
+                                    reader_open,         reader_read_batch,
+                                    reader_release_batch, reader_close,
+                                    storage_fsck,        report_release};
+
 } // namespace
 
 extern "C" KF_EMBEDDING_EXPORT int32_t KF_EMBEDDING_CALL kungfu_embedding_get_api(uint32_t requested_version,
                                                                                   uint32_t caller_struct_size,
-                                                                                  kf_embedding_api_v1 *out_api) {
-  if (requested_version != KF_EMBEDDING_ABI_V1) {
-    return KF_EMBEDDING_UNSUPPORTED_VERSION;
-  }
-  if (out_api == nullptr || caller_struct_size < sizeof(kf_embedding_api_v1)) {
+                                                                                  void *out_api) {
+  if (out_api == nullptr) {
     return KF_EMBEDDING_INVALID_ARGUMENT;
   }
-  std::memcpy(out_api, &API_V1, sizeof(API_V1));
-  return KF_EMBEDDING_OK;
+  switch (requested_version) {
+  case KF_EMBEDDING_ABI_V1:
+    if (caller_struct_size < sizeof(kf_embedding_api_v1)) {
+      return KF_EMBEDDING_INVALID_ARGUMENT;
+    }
+    std::memcpy(out_api, &API_V1, sizeof(API_V1));
+    return KF_EMBEDDING_OK;
+  case KF_EMBEDDING_ABI_V2:
+    if (caller_struct_size < sizeof(kf_embedding_api_v2)) {
+      return KF_EMBEDDING_INVALID_ARGUMENT;
+    }
+    std::memcpy(out_api, &API_V2, sizeof(API_V2));
+    return KF_EMBEDDING_OK;
+  default:
+    return KF_EMBEDDING_UNSUPPORTED_VERSION;
+  }
 }


### PR DESCRIPTION
## Summary

Grow the embedding membrane to a versioned ABI v2 that appends a read-only
substrate-diagnostic surface after a byte-identical v1 prefix, and ship a Rust
`kungfu fsck` over it — `doctor`'s sibling. The first diagnostic entry,
`storage_fsck`, bridges to the native C++ `storage_service::fsck` and returns
the report as a JSON blob plus an `ok`/`degraded` verdict; `report_release`
frees the owned buffer. No domain logic is rewritten and CPython is never
booted, so the diagnostic survives a broken Python runtime. This delivers the
ADR-0071 Bucket A lever (grow the membrane, don't rewrite commands).

## Changes

- `embedding.h` / `embedding.cpp`: `kf_embedding_api_v2` table (v1 prefix +
  `storage_fsck` + `report_release`), `KF_EMBEDDING_CAP_STORAGE_DIAGNOSTICS`,
  request/report structs; `kungfu_embedding_get_api` dispatches v1/v2 by
  `requested_version`, so v1 callers are unchanged. Windows single-export DLL is
  untouched — the new functions stay anonymous-namespace statics in the table.
- `crates/kungfu-embedding`: mirrors the v2 table, negotiates v2-first with a v1
  fallback, adds an RAII `FsckReport`; compile-time layout guards pin the new
  struct sizes.
- `crates/trunk`: a top-level `fsck` command behind the `embedding` feature with
  a graceful coreless fallback.
- `slices/shared-embedding-membrane/host.cpp`: the consumer spike now treats
  v2 as supported (unsupported-version probe uses `ABI_V2 + 1`) and additionally
  asserts v2 negotiation + the storage-diagnostics capability.
- `ADR-0071`: `implementation_status` → `partial`; Follow-up records the Bucket A
  stage delivered and what remains.

## Verification

- `check (macos-14, ubuntu-22.04, windows-2022)`: core build + tests on all three
  platforms.
- `Embedding membrane spikes`: exercise v1 and v2 negotiation across POSIX and
  Windows.
- `cargo test` / `cargo clippy` for `kungfu-embedding` and `kungfu-trunk` (default
  and `--features embedding`).
- Manual macOS `kungfu fsck` run: healthy store `ok=true`/exit 0; degraded store
  (corrupt projections) warn/exit 0; `--source <missing>` `ok=false`/exit 1;
  coreless build degrades gracefully.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "stage-ready",
  "adrs": ["ADR-0071"],
  "summary": "Grow the embedding membrane to ABI v2 with a read-only storage fsck diagnostic surface and ship a Rust kungfu fsck consumer over it (ADR-0071 Bucket A lever).",
  "verification": ["check (macos-14, ubuntu-22.04, windows-2022) build and tests", "Embedding membrane spikes exercise v1 and v2 negotiation across POSIX and Windows", "cargo test and clippy for kungfu-embedding and kungfu-trunk in both feature configs", "manual macOS fsck run: healthy=ok/exit0, degraded=warn/exit0, source-missing=exit1, coreless=graceful"]
}
-->

## Governance risk check

- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed
