### PR TITLE
feat(release): add promotion contract rehearsal

### DIFF
--- a/.github/workflows/buildchain-validate.yml
+++ b/.github/workflows/buildchain-validate.yml
@@ -11,6 +11,9 @@ on:
       - "alpha/**"
       - "release/**"
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest
@@ -21,3 +24,16 @@ jobs:
         with:
           require-version-state: "true"
           require-lifecycle-stages: "install,build,verify"
+
+  promotion-rehearsal:
+    needs: validate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+      - name: Rehearse alpha and stable promotion contracts
+        run: >-
+          ./shifu release:promotion:rehearse --
+          --report product/release/qualification/release-promotion-rehearsal.json

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -14,11 +14,14 @@ on:
       - "docs/document-metadata.registry.json"
       - "docs/adr-release.contract.json"
       - "docs/adr-release-waivers.json"
+      - "docs/release-promotion-rehearsal.contract.json"
       - "docs/vocabulary.registry.json"
       - "docs/toolchain.contract.json"
       - "scripts/check-docs.mjs"
       - "scripts/adr-release-gate.mjs"
       - "scripts/adr-release-gate.test.mjs"
+      - "scripts/release-promotion-rehearsal.mjs"
+      - "scripts/release-promotion-rehearsal.test.mjs"
       - "scripts/check-docs.test.mjs"
       - "scripts/check-docs-toolchain.mjs"
       - "scripts/check-docs-toolchain.test.mjs"
@@ -32,6 +35,12 @@ on:
       - "package.json"
       - "pnpm-lock.yaml"
       - ".github/workflows/docs-check.yml"
+      - ".github/workflows/build.yml"
+      - ".github/workflows/buildchain-validate.yml"
+      - ".github/workflows/release-new-version.yml"
+      - ".buildchain/contract-lock.json"
+      - ".buildchain/alpha-contract-lock.json"
+      - "tests/fixtures/release-promotion/*.json"
 
 permissions:
   contents: read

--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -16,7 +16,27 @@ permissions:
   id-token: write
 
 jobs:
+  promotion-contract:
+    if: ${{ github.event.pull_request.merged == true }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout immutable promotion result
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Rehearse the Kungfu promotion contract
+        run: >-
+          ./shifu release:promotion:rehearse --
+          --event "$GITHUB_EVENT_PATH"
+          --report product/release/qualification/release-promotion-rehearsal.json
+
   promote:
+    needs: promotion-contract
     if: ${{ github.event.pull_request.merged == true }}
     uses: kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@v2
     with:

--- a/docs/release-promotion-rehearsal.contract.json
+++ b/docs/release-promotion-rehearsal.contract.json
@@ -1,0 +1,56 @@
+{
+  "schema": "kungfu.release-promotion-rehearsal-contract/v1",
+  "workflows": {
+    "build": ".github/workflows/build.yml",
+    "promotion": ".github/workflows/release-new-version.yml",
+    "validation": ".github/workflows/buildchain-validate.yml"
+  },
+  "buildchain": {
+    "alpha": {
+      "workflow_ref": "v2-alpha",
+      "contract_lock": ".buildchain/alpha-contract-lock.json",
+      "publish_channel": "alpha",
+      "publish_dist_tag": "alpha"
+    },
+    "stable": {
+      "workflow_ref": "v2",
+      "contract_lock": ".buildchain/contract-lock.json",
+      "publish_channel": "release",
+      "publish_dist_tag": "latest"
+    },
+    "required_status_check": "build",
+    "required_artifact_count": 3,
+    "required_surfaces": [
+      "reusable-build",
+      "release-candidate-promote",
+      "release-passport-schema",
+      "kfd-1-release-gate",
+      "kfd-2-release-trust-passport-audit",
+      "kfd-3-collaboration-interface-release-gate"
+    ]
+  },
+  "evidence": {
+    "publish_command": "node scripts/buildchain-custom-publish-evidence.mjs",
+    "kfd_1_witnesses": [
+      ".buildchain/kfd/kfd-1/contract-world.witness.json"
+    ],
+    "kfd_2_claims": [
+      ".buildchain/kfd/kfd-2/claims/agent-onboarding-pack.json",
+      ".buildchain/kfd/kfd-2/claims/codex-report-receipts.json",
+      ".buildchain/kfd/kfd-2/claims/remote-fact-boundary.json"
+    ],
+    "kfd_3_prebuild_witnesses": [
+      ".buildchain/kfd/kfd-3/collaboration-interface.prebuild.json"
+    ],
+    "kfd_3_artifact_verify_command": "node scripts/buildchain-kfd-evidence.mjs --artifact-witness --json"
+  },
+  "safety": {
+    "forbidden_commands": [
+      "git tag",
+      "git push",
+      "npm publish",
+      "pnpm publish",
+      "gh release create"
+    ]
+  }
+}

--- a/docs/version-release-design.md
+++ b/docs/version-release-design.md
@@ -251,6 +251,41 @@ ADR and whether residual risk deserves a waiver. See
 [ADR-0073](../framework/core/docs/adr/ADR-0073-buildchain-adr-release-admissibility.md)
 and the [document metadata contract](document-metadata.md).
 
+### Side-effect-free promotion rehearsal
+
+Kungfu does not need to publish an alpha or stable release to test its side of
+the promotion contract. `./shifu release:promotion:rehearse` executes committed
+positive and fail-closed fixtures for both channels, validates the real GitHub
+workflow wiring and immutable Buildchain contract locks, checks every declared
+release-passport input, and reports current stable ADR readiness. The command
+also proves that tracked files, branches, and tags remain unchanged. It never
+receives release credentials and contains no version bump, tag, push, package
+publish, or GitHub Release operation.
+
+The ordinary `Buildchain Validate` workflow runs this rehearsal on a
+GitHub-hosted runner after Buildchain configuration validation. On a future
+merged alpha or stable promotion PR, `Release - New Version` runs the same
+rehearsal against the actual immutable PR event before the Buildchain reusable
+promotion job. Buildchain promotion has an explicit `needs` edge to that
+preflight, so contract drift or ADR-admission failure blocks publication before
+release credentials are exposed to the reusable job.
+
+This boundary is deliberately precise. The rehearsal proves Kungfu's event,
+evidence, channel routing, Buildchain lock, and workflow-consumer contract. It
+does not claim to execute or emulate Buildchain's internal publication engine;
+the first controlled alpha remains the black-box integration proof for that
+implementation.
+
+For a local report:
+
+```bash
+./shifu release:promotion:rehearse -- \
+  --report product/release/qualification/release-promotion-rehearsal.json
+```
+
+The report schema is `kungfu.release-promotion-rehearsal/v1`; its executable
+contract is `docs/release-promotion-rehearsal.contract.json`.
+
 ## Why not changesets / semantic-release / standard tools
 
 All mainstream version tools share one hidden axiom: **version intent must be explicitly

--- a/framework/core/docs/adr/ADR-0073-buildchain-adr-release-admissibility.md
+++ b/framework/core/docs/adr/ADR-0073-buildchain-adr-release-admissibility.md
@@ -6,7 +6,7 @@ decision_status: accepted
 implementation_status: implemented
 implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/731]
 closure_pr: https://github.com/kungfu-systems/kungfu/pull/731
-qualification_refs: [scripts/adr-release-gate.test.mjs]
+qualification_refs: [scripts/adr-release-gate.test.mjs, scripts/release-promotion-rehearsal.test.mjs]
 review_state: self-reviewed
 sensitivity: public
 sources: [local-files, user-decision]
@@ -104,6 +104,12 @@ The contract is `docs/adr-release.contract.json`. Pull requests carry one JSON
 manifest inside the `kungfu-adr-release:v1` marker. The validator emits a
 `kungfu.adr-release-report/v1` report containing admitted, waived, blocked, and
 invalid records.
+
+`docs/release-promotion-rehearsal.contract.json` extends that authority to the
+consumer wiring around Buildchain. Its side-effect-free rehearsal validates
+alpha/stable positive and negative fixtures, immutable Buildchain locks,
+release-passport evidence, and the dependency edge that prevents promotion
+before Kungfu admission succeeds. It does not emulate Buildchain publication.
 
 The gates establish process truth:
 

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "docs:prose:required": "node scripts/require-shifu.mjs docs:prose:required && node scripts/run-docs-prose-check.mjs --required",
     "docs:check:external": "node scripts/require-shifu.mjs docs:check:external && node scripts/run-docs-external-check.mjs",
     "adr:release:gate": "node scripts/require-shifu.mjs adr:release:gate && node scripts/adr-release-gate.mjs",
+    "release:promotion:rehearse": "node scripts/require-shifu.mjs release:promotion:rehearse && node scripts/release-promotion-rehearsal.mjs",
     "fix": "node scripts/require-shifu.mjs fix && node scripts/fix.mjs",
     "fix:staged": "node scripts/require-shifu.mjs fix:staged && node scripts/fix.mjs --staged",
     "fix:all": "node scripts/require-shifu.mjs fix:all && node scripts/fix.mjs --all",

--- a/scripts/release-promotion-rehearsal.mjs
+++ b/scripts/release-promotion-rehearsal.mjs
@@ -1,0 +1,579 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: Apache-2.0
+// @ts-check
+
+import childProcess from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { evaluateReleaseGate, parsePrManifest } from './adr-release-gate.mjs';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const DEFAULT_CONTRACT = 'docs/release-promotion-rehearsal.contract.json';
+const FIXTURE_DIR = 'tests/fixtures/release-promotion';
+
+/** @param {string} file */
+function readJson(file) {
+  return JSON.parse(fs.readFileSync(file, 'utf8'));
+}
+
+/** @param {string} root @param {string} relative */
+function readText(root, relative) {
+  return fs.readFileSync(path.join(root, relative), 'utf8');
+}
+
+/** @param {string} message @param {string} code */
+function finding(message, code = 'promotion-contract') {
+  return { code, message };
+}
+
+/**
+ * Extract one top-level job without requiring a YAML runtime dependency.
+ * The workflow contract intentionally treats job ids as stable public wiring.
+ * @param {string} source
+ * @param {string} job
+ */
+export function extractWorkflowJob(source, job) {
+  const lines = source.split(/\r?\n/);
+  const start = lines.findIndex((line) => line === `  ${job}:`);
+  if (start < 0) return '';
+  let end = lines.length;
+  for (let index = start + 1; index < lines.length; index += 1) {
+    if (/^ {2}[A-Za-z0-9_-]+:\s*$/.test(lines[index])) {
+      end = index;
+      break;
+    }
+  }
+  return lines.slice(start, end).join('\n');
+}
+
+/** @param {string} source @param {RegExp} pattern @param {any[]} findings @param {string} message */
+function requirePattern(source, pattern, findings, message) {
+  if (!pattern.test(source)) findings.push(finding(message));
+}
+
+/** @param {string} root @param {any} contract @param {Record<string, string>} [overrides] */
+export function validateWorkflowSources(root, contract, overrides = {}) {
+  /** @type {any[]} */
+  const findings = [];
+  const build = overrides.build || readText(root, contract.workflows.build);
+  const promotion =
+    overrides.promotion || readText(root, contract.workflows.promotion);
+  const validation =
+    overrides.validation || readText(root, contract.workflows.validation);
+  const preflight = extractWorkflowJob(promotion, 'promotion-contract');
+  const promote = extractWorkflowJob(promotion, 'promote');
+  const launcher = extractWorkflowJob(promotion, 'shifu-launcher-tag');
+  const rehearsal = extractWorkflowJob(validation, 'promotion-rehearsal');
+
+  requirePattern(
+    build,
+    /uses: kungfu-systems\/buildchain\/\.github\/workflows\/\.build\.yml@v2-alpha/,
+    findings,
+    'release-candidate build must consume Buildchain v2-alpha',
+  );
+  requirePattern(
+    build,
+    /buildchain-ref: \$\{\{ inputs\.buildchain-ref \|\| '' \}\}/,
+    findings,
+    'manual validation must retain the Buildchain ref pass-through',
+  );
+  requirePattern(
+    build,
+    /episode:qualify:release[\s\S]*adr:release:gate[\s\S]*adr-release-admissibility\.json/,
+    findings,
+    'candidate verify must qualify Episodes before ADR release admission',
+  );
+  requirePattern(
+    build,
+    /release-candidate: true/,
+    findings,
+    'candidate build must remain a Buildchain release candidate',
+  );
+
+  requirePattern(
+    promotion,
+    /branches:[\s\S]*alpha\/v\*\/v\*[\s\S]*release\/v\*\/v\*/,
+    findings,
+    'promotion workflow must cover alpha and stable channel branches',
+  );
+  requirePattern(
+    preflight,
+    /if: \$\{\{ github\.event\.pull_request\.merged == true \}\}/,
+    findings,
+    'promotion contract preflight must run only for a merged promotion PR',
+  );
+  requirePattern(
+    preflight,
+    /\.\/shifu release:promotion:rehearse --[\s\S]*--event "\$GITHUB_EVENT_PATH"/,
+    findings,
+    'promotion contract preflight must execute the current merged PR event',
+  );
+  requirePattern(
+    promote,
+    /needs: promotion-contract/,
+    findings,
+    'Buildchain promotion must depend on the Kungfu promotion contract preflight',
+  );
+  requirePattern(
+    promote,
+    /uses: kungfu-systems\/buildchain\/\.github\/workflows\/release-candidate-promote\.yml@v2/,
+    findings,
+    'promotion must consume the stable Buildchain workflow shell',
+  );
+  requirePattern(
+    promote,
+    new RegExp(
+      `required-status-check: ${contract.buildchain.required_status_check}`,
+    ),
+    findings,
+    'promotion required status check drifted from the rehearsal contract',
+  );
+  requirePattern(
+    promote,
+    new RegExp(
+      `required-artifact-count: ${contract.buildchain.required_artifact_count}`,
+    ),
+    findings,
+    'promotion artifact count drifted from the rehearsal contract',
+  );
+  requirePattern(
+    promote,
+    /buildchain-ref: \$\{\{ startsWith\(github\.event\.pull_request\.base\.ref, 'alpha\/'\) && 'v2-alpha' \|\| 'v2' \}\}/,
+    findings,
+    'alpha/stable Buildchain ref routing drifted',
+  );
+  requirePattern(
+    promote,
+    /buildchain-contract-lock-path: \$\{\{ startsWith\(github\.event\.pull_request\.base\.ref, 'alpha\/'\) && '\.buildchain\/alpha-contract-lock\.json' \|\| '\.buildchain\/contract-lock\.json' \}\}/,
+    findings,
+    'alpha/stable Buildchain contract-lock routing drifted',
+  );
+  requirePattern(
+    promote,
+    /publish-dist-tag: \$\{\{ startsWith\(github\.event\.pull_request\.base\.ref, 'alpha\/'\) && 'alpha' \|\| 'latest' \}\}/,
+    findings,
+    'alpha/stable distribution-tag routing drifted',
+  );
+  requirePattern(
+    promote,
+    new RegExp(
+      `publish-command: ${contract.evidence.publish_command.replaceAll('.', '\\.')}`,
+    ),
+    findings,
+    'custom publish evidence command drifted',
+  );
+  requirePattern(
+    launcher,
+    /needs: promote/,
+    findings,
+    'launcher tagging must remain downstream of Buildchain promotion',
+  );
+  requirePattern(
+    rehearsal,
+    /needs: validate/,
+    findings,
+    'routine promotion rehearsal must depend on Buildchain config validation',
+  );
+  requirePattern(
+    rehearsal,
+    /\.\/shifu release:promotion:rehearse --/,
+    findings,
+    'Buildchain validation workflow must execute the promotion rehearsal',
+  );
+
+  for (const command of contract.safety.forbidden_commands) {
+    if (preflight.includes(command)) {
+      findings.push(
+        finding(
+          `promotion contract preflight contains forbidden side effect: ${command}`,
+          'promotion-side-effect',
+        ),
+      );
+    }
+  }
+  if (/^\s+secrets:/m.test(preflight)) {
+    findings.push(
+      finding(
+        'promotion contract preflight must not receive release secrets',
+        'promotion-side-effect',
+      ),
+    );
+  }
+
+  for (const evidence of [
+    ...contract.evidence.kfd_1_witnesses,
+    ...contract.evidence.kfd_2_claims,
+    ...contract.evidence.kfd_3_prebuild_witnesses,
+  ]) {
+    if (!fs.existsSync(path.join(root, evidence))) {
+      findings.push(
+        finding(`declared release evidence does not exist: ${evidence}`),
+      );
+    }
+    if (!promote.includes(evidence)) {
+      findings.push(
+        finding(`Buildchain promotion does not consume evidence: ${evidence}`),
+      );
+    }
+  }
+  if (!promote.includes(contract.evidence.kfd_3_artifact_verify_command)) {
+    findings.push(finding('KFD-3 artifact verification command drifted'));
+  }
+
+  return { ok: findings.length === 0, findings };
+}
+
+/** @param {string} root @param {any} contract */
+export function validateBuildchainLocks(root, contract) {
+  /** @type {any[]} */
+  const findings = [];
+  for (const channel of ['alpha', 'stable']) {
+    const expected = contract.buildchain[channel];
+    const lock = readJson(path.join(root, expected.contract_lock));
+    if (lock.buildchain?.ref !== expected.workflow_ref) {
+      findings.push(
+        finding(
+          `${channel} contract lock resolves ${String(lock.buildchain?.ref)}, expected ${expected.workflow_ref}`,
+          'buildchain-lock',
+        ),
+      );
+    }
+    if (!/^[0-9a-f]{40}$/.test(String(lock.buildchain?.resolvedSha || ''))) {
+      findings.push(
+        finding(
+          `${channel} contract lock needs an immutable SHA`,
+          'buildchain-lock',
+        ),
+      );
+    }
+    if (
+      !/^sha256:[0-9a-f]{64}$/.test(
+        String(lock.buildchain?.contractDigest || ''),
+      )
+    ) {
+      findings.push(
+        finding(
+          `${channel} contract lock needs a contract digest`,
+          'buildchain-lock',
+        ),
+      );
+    }
+    const surfaces = new Set(
+      (lock.buildchain?.surfaces || []).map((surface) => surface.id),
+    );
+    for (const id of contract.buildchain.required_surfaces) {
+      if (!surfaces.has(id)) {
+        findings.push(
+          finding(
+            `${channel} contract lock is missing surface ${id}`,
+            'buildchain-lock',
+          ),
+        );
+      }
+    }
+  }
+  return { ok: findings.length === 0, findings };
+}
+
+/** @param {string} root @param {string} contractPath */
+export function validatePromotionContract(
+  root = ROOT,
+  contractPath = DEFAULT_CONTRACT,
+) {
+  const contract = readJson(path.join(root, contractPath));
+  /** @type {any[]} */
+  const findings = [];
+  if (contract.schema !== 'kungfu.release-promotion-rehearsal-contract/v1') {
+    findings.push(finding('unsupported promotion rehearsal contract schema'));
+  }
+  if (
+    !fs.existsSync(
+      path.join(root, 'scripts/buildchain-custom-publish-evidence.mjs'),
+    )
+  ) {
+    findings.push(finding('custom publish evidence adapter does not exist'));
+  }
+  const workflows = validateWorkflowSources(root, contract);
+  const locks = validateBuildchainLocks(root, contract);
+  findings.push(...workflows.findings, ...locks.findings);
+  return { ok: findings.length === 0, contract, findings };
+}
+
+/** @param {string} baseRef */
+function modeForBaseRef(baseRef) {
+  if (baseRef.startsWith('alpha/')) return 'alpha';
+  if (baseRef.startsWith('release/')) return 'stable';
+  return '';
+}
+
+/** @param {any} fixture */
+function createFixtureRoot(fixture) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'kungfu-promotion-'));
+  fs.mkdirSync(path.join(root, 'adr'), { recursive: true });
+  fs.mkdirSync(path.join(root, 'docs'), { recursive: true });
+  fs.writeFileSync(
+    path.join(root, 'docs/adr-release-waivers.json'),
+    `${JSON.stringify({ schema: 'kungfu.adr-release-waivers/v1', waivers: fixture.waivers || [] }, null, 2)}\n`,
+  );
+  for (const adr of fixture.adrs || []) {
+    const qualifications = (adr.qualification_refs || []).join(', ');
+    fs.writeFileSync(
+      path.join(root, `adr/${adr.id}-rehearsal.md`),
+      `---\nadr_id: ${adr.id}\ndecision_status: ${adr.decision_status || 'accepted'}\nimplementation_status: ${adr.implementation_status}\nqualification_refs: [${qualifications}]\n---\n\n# ${adr.id}\n`,
+    );
+  }
+  return root;
+}
+
+/** @param {string} file @param {any} adrContract */
+export function evaluatePromotionFixture(file, adrContract) {
+  const fixture = readJson(file);
+  const root = createFixtureRoot(fixture);
+  try {
+    const contract = {
+      ...adrContract,
+      adrRoots: ['adr'],
+      stable: {
+        ...adrContract.stable,
+        waiverFile: 'docs/adr-release-waivers.json',
+      },
+    };
+    const marker = contract.manifestMarker;
+    const manifest = parsePrManifest(
+      `<!-- ${marker}\n${JSON.stringify(fixture.manifest)}\n-->`,
+      marker,
+    );
+    const changedFiles = (fixture.changed_adrs || []).map(
+      (id) => `adr/${id}-rehearsal.md`,
+    );
+    const report = evaluateReleaseGate({
+      root,
+      contract,
+      manifest,
+      mode: modeForBaseRef(String(fixture.base_ref || '')),
+      changedFiles,
+      prUrl: String(fixture.pr_url || ''),
+    });
+    const actualCodes = new Set(report.findings.map((entry) => entry.code));
+    const missingCodes = (fixture.expected_findings || []).filter(
+      (code) => !actualCodes.has(code),
+    );
+    const ok = report.ok === fixture.expect_ok && missingCodes.length === 0;
+    return {
+      name: fixture.name,
+      base_ref: fixture.base_ref,
+      expected_ok: fixture.expect_ok,
+      actual_ok: report.ok,
+      expected_findings: fixture.expected_findings || [],
+      actual_findings: [...actualCodes].sort(),
+      ok,
+      report,
+    };
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+/** @param {string} root */
+export function runFixtureSuite(root = ROOT) {
+  const adrContract = readJson(
+    path.join(root, 'docs/adr-release.contract.json'),
+  );
+  const directory = path.join(root, FIXTURE_DIR);
+  const fixtures = fs
+    .readdirSync(directory)
+    .filter((name) => name.endsWith('.json'))
+    .sort()
+    .map((name) =>
+      evaluatePromotionFixture(path.join(directory, name), adrContract),
+    );
+  return {
+    ok: fixtures.length >= 4 && fixtures.every((entry) => entry.ok),
+    fixtures,
+  };
+}
+
+/** @param {string} root */
+function currentStableReadiness(root) {
+  const contract = readJson(path.join(root, 'docs/adr-release.contract.json'));
+  const currentVersion = String(
+    readJson(path.join(root, 'lerna.json')).version,
+  );
+  const release = currentVersion.split('-', 1)[0];
+  return evaluateReleaseGate({
+    root,
+    contract,
+    manifest: {
+      schema: contract.manifestSchema,
+      kind: 'stable-admission',
+      release,
+    },
+    mode: 'stable',
+    changedFiles: [],
+    prUrl: 'https://github.com/kungfu-systems/kungfu/pull/999999',
+  });
+}
+
+/** @param {string} root */
+function gitSnapshot(root) {
+  const run = (args) => {
+    const result = childProcess.spawnSync('git', args, {
+      cwd: root,
+      encoding: 'utf8',
+    });
+    if (result.status !== 0)
+      throw new Error(String(result.stderr || '').trim());
+    return String(result.stdout || '');
+  };
+  return {
+    tracked: run(['status', '--porcelain', '--untracked-files=no']),
+    refs: run([
+      'for-each-ref',
+      '--format=%(refname) %(objectname)',
+      'refs/heads',
+      'refs/tags',
+    ]),
+  };
+}
+
+/** @param {string} root @param {string} eventPath */
+function evaluateActualEvent(root, eventPath) {
+  const directory = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'kungfu-promotion-event-'),
+  );
+  const reportPath = path.join(directory, 'adr-release-report.json');
+  try {
+    const result = childProcess.spawnSync(
+      process.execPath,
+      [
+        'scripts/adr-release-gate.mjs',
+        '--event',
+        eventPath,
+        '--report',
+        reportPath,
+      ],
+      { cwd: root, encoding: 'utf8' },
+    );
+    const report = fs.existsSync(reportPath) ? readJson(reportPath) : null;
+    return {
+      ok: result.status === 0 && report?.ok === true,
+      status: result.status,
+      report,
+      output: `${result.stdout || ''}${result.stderr || ''}`.trim(),
+    };
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+}
+
+/** @param {{root?: string, contractPath?: string, eventPath?: string}} options */
+export function runRehearsal(options = {}) {
+  const root = path.resolve(options.root || ROOT);
+  const before = gitSnapshot(root);
+  const contract = validatePromotionContract(
+    root,
+    options.contractPath || DEFAULT_CONTRACT,
+  );
+  const fixtures = runFixtureSuite(root);
+  const currentStable = currentStableReadiness(root);
+  const event = options.eventPath
+    ? evaluateActualEvent(root, path.resolve(options.eventPath))
+    : null;
+  const after = gitSnapshot(root);
+  const repositoryUnchanged =
+    before.tracked === after.tracked && before.refs === after.refs;
+  const findings = [...contract.findings];
+  if (!fixtures.ok)
+    findings.push(
+      finding('one or more release promotion fixtures failed', 'fixture'),
+    );
+  if (event && !event.ok)
+    findings.push(
+      finding('current promotion event failed ADR admission', 'event'),
+    );
+  if (!repositoryUnchanged)
+    findings.push(
+      finding(
+        'rehearsal changed tracked files, branches, or tags',
+        'side-effect',
+      ),
+    );
+  return {
+    schema: 'kungfu.release-promotion-rehearsal/v1',
+    ok: findings.length === 0,
+    side_effects: {
+      tracked_files_changed: before.tracked !== after.tracked,
+      refs_changed: before.refs !== after.refs,
+      remote_mutations_attempted: false,
+      promotion_credentials_consumed: false,
+    },
+    contract: {
+      ok: contract.ok,
+      findings: contract.findings,
+      buildchain_refs: {
+        alpha: contract.contract.buildchain.alpha.workflow_ref,
+        stable: contract.contract.buildchain.stable.workflow_ref,
+      },
+    },
+    fixtures,
+    current_repository_stable_readiness: {
+      informational: true,
+      release: currentStable.release,
+      ok: currentStable.ok,
+      summary: currentStable.summary,
+      blocked: currentStable.blocked,
+    },
+    event,
+    findings,
+  };
+}
+
+function parseArgs(argv) {
+  const args = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--') continue;
+    if (arg === '--github-event')
+      args.eventPath = process.env.GITHUB_EVENT_PATH;
+    else if (arg === '--event') args.eventPath = argv[++index];
+    else if (arg === '--report') args.reportPath = argv[++index];
+    else if (arg === '--contract') args.contractPath = argv[++index];
+    else throw new Error(`unknown argument: ${arg}`);
+  }
+  return args;
+}
+
+function writeReport(report, destination) {
+  if (destination) {
+    const absolute = path.resolve(ROOT, destination);
+    fs.mkdirSync(path.dirname(absolute), { recursive: true });
+    fs.writeFileSync(absolute, `${JSON.stringify(report, null, 2)}\n`);
+  }
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    fs.appendFileSync(
+      process.env.GITHUB_STEP_SUMMARY,
+      `## Release promotion rehearsal\n\n- Result: **${report.ok ? 'admitted' : 'blocked'}**\n- Fixtures: ${report.fixtures.fixtures.length}\n- Current stable blockers: ${report.current_repository_stable_readiness.summary.blocked}\n- Tracked/ref mutations: ${report.side_effects.tracked_files_changed || report.side_effects.refs_changed ? 'detected' : 'none'}\n\n`,
+    );
+  }
+}
+
+if (
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+  try {
+    const args = parseArgs(process.argv.slice(2));
+    const report = runRehearsal(args);
+    writeReport(report, args.reportPath);
+    console.log(JSON.stringify(report, null, 2));
+    if (!report.ok) process.exit(1);
+  } catch (error) {
+    console.error(
+      `[release-promotion-rehearsal] ${error instanceof Error ? error.message : String(error)}`,
+    );
+    process.exit(1);
+  }
+}

--- a/scripts/release-promotion-rehearsal.test.mjs
+++ b/scripts/release-promotion-rehearsal.test.mjs
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import {
+  extractWorkflowJob,
+  runFixtureSuite,
+  runRehearsal,
+  validatePromotionContract,
+  validateWorkflowSources,
+} from './release-promotion-rehearsal.mjs';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const CONTRACT = JSON.parse(
+  fs.readFileSync(
+    path.join(ROOT, 'docs/release-promotion-rehearsal.contract.json'),
+    'utf8',
+  ),
+);
+
+test('the committed Buildchain promotion consumer contract is coherent', () => {
+  const result = validatePromotionContract(ROOT);
+  assert.equal(result.ok, true, JSON.stringify(result.findings, null, 2));
+});
+
+test('alpha and stable promotion fixtures cover admission and fail-closed paths', () => {
+  const result = runFixtureSuite(ROOT);
+  assert.equal(result.ok, true);
+  assert.deepEqual(
+    result.fixtures.map((fixture) => [fixture.base_ref, fixture.expected_ok]),
+    [
+      ['alpha/v4/v4.0', false],
+      ['alpha/v4/v4.0', true],
+      ['release/v4/v4.0', false],
+      ['release/v4/v4.0', true],
+    ],
+  );
+});
+
+test('promotion workflow drift is rejected before Buildchain promotion', () => {
+  const promotionPath = CONTRACT.workflows.promotion;
+  const original = fs.readFileSync(path.join(ROOT, promotionPath), 'utf8');
+  const drifted = original.replace(
+    'required-status-check: build',
+    'required-status-check: skipped',
+  );
+  assert.notEqual(drifted, original);
+  const result = validateWorkflowSources(ROOT, CONTRACT, {
+    promotion: drifted,
+  });
+  assert.equal(result.ok, false);
+  assert.ok(
+    result.findings.some((entry) =>
+      entry.message.includes('required status check drifted'),
+    ),
+  );
+});
+
+test('promotion preflight owns no release credentials or side-effect commands', () => {
+  const workflow = fs.readFileSync(
+    path.join(ROOT, CONTRACT.workflows.promotion),
+    'utf8',
+  );
+  const preflight = extractWorkflowJob(workflow, 'promotion-contract');
+  assert.ok(preflight);
+  assert.doesNotMatch(preflight, /^\s+secrets:/m);
+  for (const command of CONTRACT.safety.forbidden_commands) {
+    assert.equal(preflight.includes(command), false, command);
+  }
+});
+
+test('the full rehearsal preserves tracked files, branches, and tags', () => {
+  const result = runRehearsal({ root: ROOT });
+  assert.equal(result.ok, true, JSON.stringify(result.findings, null, 2));
+  assert.equal(result.side_effects.tracked_files_changed, false);
+  assert.equal(result.side_effects.refs_changed, false);
+  assert.equal(result.side_effects.remote_mutations_attempted, false);
+  assert.equal(result.side_effects.promotion_credentials_consumed, false);
+});
+
+test('an actual GitHub promotion event traverses the ADR gate CLI', () => {
+  const head = execFileSync('git', ['rev-parse', 'HEAD'], {
+    cwd: ROOT,
+    encoding: 'utf8',
+  }).trim();
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'kungfu-event-'));
+  const eventPath = path.join(directory, 'event.json');
+  fs.writeFileSync(
+    eventPath,
+    JSON.stringify({
+      pull_request: {
+        base: { ref: 'alpha/v4/v4.0', sha: head },
+        head: { ref: 'dev/v4/v4.0', sha: head },
+        html_url: 'https://github.com/kungfu-systems/kungfu/pull/999903',
+        body: `<!-- kungfu-adr-release:v1\n${JSON.stringify({
+          schema: 'kungfu.adr-release-pr/v1',
+          kind: 'alpha-settlement',
+          no_adr_progress_reason:
+            'Synthetic no-delta promotion proves the immutable event path',
+        })}\n-->`,
+      },
+    }),
+  );
+  try {
+    const result = runRehearsal({ root: ROOT, eventPath });
+    assert.equal(result.ok, true, result.event?.output);
+    assert.equal(result.event?.report?.mode, 'alpha');
+    assert.equal(result.event?.report?.ok, true);
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test('an actual stable event fails closed on the current ADR balance sheet', () => {
+  const head = execFileSync('git', ['rev-parse', 'HEAD'], {
+    cwd: ROOT,
+    encoding: 'utf8',
+  }).trim();
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'kungfu-event-'));
+  const eventPath = path.join(directory, 'event.json');
+  fs.writeFileSync(
+    eventPath,
+    JSON.stringify({
+      pull_request: {
+        base: { ref: 'release/v4/v4.0', sha: head },
+        head: { ref: 'alpha/v4/v4.0', sha: head },
+        html_url: 'https://github.com/kungfu-systems/kungfu/pull/999904',
+        body: `<!-- kungfu-adr-release:v1\n${JSON.stringify({
+          schema: 'kungfu.adr-release-pr/v1',
+          kind: 'stable-admission',
+          release: '4.0.0',
+        })}\n-->`,
+      },
+    }),
+  );
+  try {
+    const result = runRehearsal({ root: ROOT, eventPath });
+    assert.equal(result.ok, false);
+    assert.equal(result.event?.report?.mode, 'stable');
+    assert.equal(result.event?.report?.ok, false);
+    assert.ok(result.event?.report?.summary.blocked > 0);
+    assert.ok(result.findings.some((entry) => entry.code === 'event'));
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});

--- a/scripts/run-docs-check.mjs
+++ b/scripts/run-docs-check.mjs
@@ -37,6 +37,7 @@ try {
   run('negative fixtures', [
     '--test',
     path.join('scripts', 'adr-release-gate.test.mjs'),
+    path.join('scripts', 'release-promotion-rehearsal.test.mjs'),
     path.join('scripts', 'check-docs.test.mjs'),
     path.join('scripts', 'document-metadata-contract.test.mjs'),
     path.join('scripts', 'vocabulary-contract.test.mjs'),

--- a/tests/fixtures/release-promotion/alpha-blocked.json
+++ b/tests/fixtures/release-promotion/alpha-blocked.json
@@ -1,0 +1,31 @@
+{
+  "schema": "kungfu.release-promotion-fixture/v1",
+  "name": "alpha settlement blocks an undeclared ADR projection",
+  "base_ref": "alpha/v4/v4.0",
+  "expect_ok": false,
+  "adrs": [
+    {
+      "id": "ADR-9001",
+      "implementation_status": "staged",
+      "qualification_refs": ["tests/qualification/alpha.md"]
+    },
+    {
+      "id": "ADR-9002",
+      "implementation_status": "partial",
+      "qualification_refs": []
+    }
+  ],
+  "changed_adrs": ["ADR-9001", "ADR-9002"],
+  "manifest": {
+    "schema": "kungfu.adr-release-pr/v1",
+    "kind": "alpha-settlement",
+    "progress": [
+      {
+        "adr": "ADR-9001",
+        "to": "staged",
+        "summary": "The bounded implementation is ready for alpha qualification"
+      }
+    ]
+  },
+  "expected_findings": ["alpha-unsettled-change"]
+}

--- a/tests/fixtures/release-promotion/alpha-pass.json
+++ b/tests/fixtures/release-promotion/alpha-pass.json
@@ -1,0 +1,26 @@
+{
+  "schema": "kungfu.release-promotion-fixture/v1",
+  "name": "alpha settlement accepts declared ADR progress",
+  "base_ref": "alpha/v4/v4.0",
+  "expect_ok": true,
+  "adrs": [
+    {
+      "id": "ADR-9001",
+      "implementation_status": "staged",
+      "qualification_refs": ["tests/qualification/alpha.md"]
+    }
+  ],
+  "changed_adrs": ["ADR-9001"],
+  "manifest": {
+    "schema": "kungfu.adr-release-pr/v1",
+    "kind": "alpha-settlement",
+    "progress": [
+      {
+        "adr": "ADR-9001",
+        "to": "staged",
+        "summary": "The bounded implementation is ready for alpha qualification"
+      }
+    ]
+  },
+  "expected_findings": []
+}

--- a/tests/fixtures/release-promotion/stable-blocked.json
+++ b/tests/fixtures/release-promotion/stable-blocked.json
@@ -1,0 +1,26 @@
+{
+  "schema": "kungfu.release-promotion-fixture/v1",
+  "name": "stable admission blocks unqualified architecture debt",
+  "base_ref": "release/v4/v4.0",
+  "expect_ok": false,
+  "pr_url": "https://github.com/kungfu-systems/kungfu/pull/999902",
+  "adrs": [
+    {
+      "id": "ADR-9001",
+      "implementation_status": "implemented",
+      "qualification_refs": []
+    },
+    {
+      "id": "ADR-9002",
+      "implementation_status": "staged",
+      "qualification_refs": []
+    }
+  ],
+  "changed_adrs": [],
+  "manifest": {
+    "schema": "kungfu.adr-release-pr/v1",
+    "kind": "stable-admission",
+    "release": "4.0.0"
+  },
+  "expected_findings": ["stable-blocked"]
+}

--- a/tests/fixtures/release-promotion/stable-pass.json
+++ b/tests/fixtures/release-promotion/stable-pass.json
@@ -1,0 +1,26 @@
+{
+  "schema": "kungfu.release-promotion-fixture/v1",
+  "name": "stable admission accepts fully qualified decisions",
+  "base_ref": "release/v4/v4.0",
+  "expect_ok": true,
+  "pr_url": "https://github.com/kungfu-systems/kungfu/pull/999901",
+  "adrs": [
+    {
+      "id": "ADR-9001",
+      "implementation_status": "implemented",
+      "qualification_refs": ["tests/qualification/stable.md"]
+    },
+    {
+      "id": "ADR-9002",
+      "implementation_status": "not-applicable",
+      "qualification_refs": []
+    }
+  ],
+  "changed_adrs": [],
+  "manifest": {
+    "schema": "kungfu.adr-release-pr/v1",
+    "kind": "stable-admission",
+    "release": "4.0.0"
+  },
+  "expected_findings": []
+}


### PR DESCRIPTION
## Summary

Add a side-effect-free alpha/stable promotion rehearsal and make the Buildchain promotion job depend on its actual-event preflight.

## Changes

- validate alpha/stable admission fixtures and current stable readiness
- verify immutable Buildchain locks, release evidence inputs, channel routing, and workflow dependencies
- run the rehearsal after Buildchain config validation on GitHub-hosted runners
- block the future reusable promotion job until the same rehearsal accepts the merged promotion event

## Verification

- `./shifu release:promotion:rehearse -- --report /tmp/kungfu-release-promotion-rehearsal.json`
- `node --test scripts/adr-release-gate.test.mjs scripts/release-promotion-rehearsal.test.mjs`
- `./shifu docs:check:readonly`
- `./shifu check`
- `actionlint` on the four affected workflow contracts

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "implemented",
  "adrs": ["ADR-0073"],
  "summary": "Complete side-effect-free alpha/stable promotion rehearsal and Buildchain consumer wiring",
  "verification": ["release promotion rehearsal fixtures", "actual alpha/stable event tests", "full Shifu check", "workflow lint"]
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The preflight has read-only contents permission, receives no promotion secrets, and performs no version, tag, push, publish, or release mutation.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed