### PR TITLE
chore(node): drop dead MakeInstructionUID helper

### DIFF
--- a/framework/core/src/bindings/node/binding/watcher.h
+++ b/framework/core/src/bindings/node/binding/watcher.h
@@ -18,8 +18,6 @@
 #include <kungfu/runtime/state_cache/model.h>
 
 namespace kungfu::node {
-constexpr uint64_t ID_TRANC = 0x00000000FFFFFFFF;
-constexpr uint32_t PAGE_ID_MASK = 0x80000000;
 constexpr uint32_t TRANSFER_STATIC_DATA_LIMIT = 2000;
 
 class Watcher : public Napi::ObjectWrap<Watcher>, public runtime::live::peer {
@@ -140,12 +138,6 @@ private:
   void RecordWorkerError(const std::exception_ptr &error);
 
   std::exception_ptr TakeWorkerError();
-
-  uint64_t MakeInstructionUID(yijinjing::journal::writer_ptr &writer, uint32_t dest, uint32_t client_id = 0) {
-    uint64_t id_left = (uint64_t)(client_id xor dest) << 32u;
-    uint64_t id_right = (ID_TRANC & writer->current_frame_uid()) | PAGE_ID_MASK;
-    return id_left | id_right;
-  }
 
   template <typename DataType> void UpdateLedger(const boost::hana::basic_type<DataType> &type) {
     using DataTypeMap = std::unordered_map<uint64_t, state<DataType>>;


### PR DESCRIPTION
## Summary

Remove the dead `MakeInstructionUID` helper (and its `ID_TRANC` / `PAGE_ID_MASK`
constants) from the node watcher binding.

## Changes

- `MakeInstructionUID` had no callers anywhere in the repo. It was a trading-era
  helper that packed a `frame_uid`'s low 32 bits into an instruction id.
- After the ADR-0072 Phase 1 `frame_uid` restructure, those low bits no longer
  carry the page id, so the helper was both unused and semantically stale.
- `ID_TRANC` and `PAGE_ID_MASK` fed only this helper and are removed with it.
  `TRANSFER_STATIC_DATA_LIMIT` is unrelated and kept.

## Verification

- Full `core` build green (node binding compiles without the removed symbols).
- Repo-wide grep confirms zero remaining references to `MakeInstructionUID`,
  `ID_TRANC`, or `PAGE_ID_MASK`.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Removes dead, unreferenced trading-era code (MakeInstructionUID + two constants); no architecture contract change and no ADR file touched."
}
-->