### PR TITLE
feat(shifu): make local promotion ancestry-aware

### DIFF
--- a/crates/shifu/src/artifact_catalog.rs
+++ b/crates/shifu/src/artifact_catalog.rs
@@ -1,0 +1,434 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Shared local-artifact semantics for the Shifu binary and Kungfu products.
+// Storage and installation stay in their command adapters; this module owns
+// Git relation, automatic/manual disposition, compact display, and JSON safety.
+
+use std::fs;
+use std::path::Path;
+use std::process::{Command, Stdio};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const CONTRACT: &str = include_str!("../../../docs/shifu/artifact-contract.json");
+const SCHEMA: &str =
+    include_str!("../../../docs/shifu/schema/local-artifact-catalog-v1.schema.json");
+const RECEIPT_SCHEMA: &str =
+    include_str!("../../../docs/shifu/schema/local-promotion-receipt-v1.schema.json");
+
+pub fn run_discovery(args: &[String]) -> ! {
+    match args {
+        [verb] if verb == "contract" => print!("{CONTRACT}"),
+        [verb] if verb == "schema" => print!("{SCHEMA}"),
+        [verb] if verb == "receipt-schema" => print!("{RECEIPT_SCHEMA}"),
+        _ => {
+            eprintln!("usage: shifu artifacts <contract|schema|receipt-schema>");
+            std::process::exit(2);
+        }
+    }
+    std::process::exit(0)
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum GitRelation {
+    Same,
+    Descendant,
+    Ancestor,
+    Diverged,
+    Unknown,
+}
+
+impl GitRelation {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Same => "same",
+            Self::Descendant => "descendant",
+            Self::Ancestor => "ancestor",
+            Self::Diverged => "diverged",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ArtifactState {
+    Current,
+    Candidate,
+    Manual,
+    Superseded,
+    Rollback,
+    Invalid,
+}
+
+impl ArtifactState {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Current => "current",
+            Self::Candidate => "candidate",
+            Self::Manual => "manual",
+            Self::Superseded => "superseded",
+            Self::Rollback => "rollback",
+            Self::Invalid => "invalid",
+        }
+    }
+}
+
+pub fn state_for(relation: GitRelation, valid: bool, rollback_only: bool) -> ArtifactState {
+    if !valid {
+        ArtifactState::Invalid
+    } else if rollback_only {
+        ArtifactState::Rollback
+    } else {
+        match relation {
+            GitRelation::Same => ArtifactState::Current,
+            GitRelation::Descendant => ArtifactState::Candidate,
+            GitRelation::Ancestor => ArtifactState::Superseded,
+            GitRelation::Diverged | GitRelation::Unknown => ArtifactState::Manual,
+        }
+    }
+}
+
+pub fn automatic(relation: GitRelation, valid: bool, rollback_only: bool) -> bool {
+    valid && !rollback_only && matches!(relation, GitRelation::Same | GitRelation::Descendant)
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SelectionError {
+    None,
+    Ambiguous,
+}
+
+/// Shared default resolver for every locally promoted product. Ordering is
+/// deliberately absent: callers must never smuggle mtime or slot names back in
+/// as authority.
+pub fn select_unique_automatic(
+    artifacts: &[(GitRelation, bool, bool)],
+) -> Result<usize, SelectionError> {
+    let descendants: Vec<_> = artifacts
+        .iter()
+        .enumerate()
+        .filter(|(_, (relation, valid, rollback_only))| {
+            *valid && !*rollback_only && *relation == GitRelation::Descendant
+        })
+        .map(|(index, _)| index)
+        .collect();
+    match descendants.as_slice() {
+        [index] => Ok(*index),
+        [] => {
+            let same: Vec<_> = artifacts
+                .iter()
+                .enumerate()
+                .filter(|(_, (relation, valid, rollback_only))| {
+                    *valid && !*rollback_only && *relation == GitRelation::Same
+                })
+                .map(|(index, _)| index)
+                .collect();
+            match same.as_slice() {
+                [index] => Ok(*index),
+                [] => Err(SelectionError::None),
+                _ => Err(SelectionError::Ambiguous),
+            }
+        }
+        _ => Err(SelectionError::Ambiguous),
+    }
+}
+
+fn clean_sha(value: &str) -> &str {
+    value.strip_suffix("-dirty").unwrap_or(value)
+}
+
+fn git_success(repo: &Path, args: &[&str]) -> Option<bool> {
+    Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args(args)
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_WORK_TREE")
+        .env_remove("GIT_COMMON_DIR")
+        .env_remove("GIT_INDEX_FILE")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .ok()
+        .map(|status| status.success())
+}
+
+fn resolve_commit(repo: &Path, value: &str) -> Option<String> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args(["rev-parse", "--verify"])
+        .arg(format!("{value}^{{commit}}"))
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_WORK_TREE")
+        .env_remove("GIT_COMMON_DIR")
+        .env_remove("GIT_INDEX_FILE")
+        .stderr(Stdio::null())
+        .output()
+        .ok()?;
+    output
+        .status
+        .success()
+        .then(|| String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+/// Compare candidate to installed. A candidate descended from installed is an
+/// automatic forward move; a candidate that installed descends from is older.
+pub fn git_relation(repo: &Path, installed: &str, candidate: &str) -> GitRelation {
+    let installed = clean_sha(installed);
+    let candidate = clean_sha(candidate);
+    if installed.is_empty()
+        || candidate.is_empty()
+        || installed == "unknown"
+        || candidate == "unknown"
+        || installed.contains("dirty")
+        || candidate.contains("dirty")
+    {
+        return GitRelation::Unknown;
+    }
+    let Some(installed) = resolve_commit(repo, installed) else {
+        return GitRelation::Unknown;
+    };
+    let Some(candidate) = resolve_commit(repo, candidate) else {
+        return GitRelation::Unknown;
+    };
+    if installed == candidate {
+        return GitRelation::Same;
+    }
+    let installed_to_candidate = git_success(
+        repo,
+        &["merge-base", "--is-ancestor", &installed, &candidate],
+    );
+    let candidate_to_installed = git_success(
+        repo,
+        &["merge-base", "--is-ancestor", &candidate, &installed],
+    );
+    match (installed_to_candidate, candidate_to_installed) {
+        (Some(true), _) => GitRelation::Descendant,
+        (_, Some(true)) => GitRelation::Ancestor,
+        (Some(false), Some(false)) => GitRelation::Diverged,
+        _ => GitRelation::Unknown,
+    }
+}
+
+/// Human compact view. Preserve the branch-kind prefix, twelve characters of
+/// the meaningful name, and an eight-character suffix. UTF-8 is handled by
+/// character count rather than byte slicing.
+pub fn compact_branch(branch: &str, no_truncate: bool) -> String {
+    const MAX: usize = 34;
+    if no_truncate || branch.chars().count() <= MAX {
+        return branch.to_string();
+    }
+    let (prefix, rest) = branch
+        .split_once('/')
+        .map(|(head, tail)| (format!("{head}/"), tail))
+        .unwrap_or_else(|| (String::new(), branch));
+    let rest_chars: Vec<char> = rest.chars().collect();
+    if rest_chars.len() <= 22 {
+        return branch.to_string();
+    }
+    let start: String = rest_chars.iter().take(12).collect();
+    let end: String = rest_chars[rest_chars.len() - 8..].iter().collect();
+    format!("{prefix}{start}…{end}")
+}
+
+pub fn short_sha(sha: &str) -> &str {
+    sha.get(..sha.len().min(9)).unwrap_or(sha)
+}
+
+pub fn json_escape(value: &str) -> String {
+    let mut out = String::with_capacity(value.len() + 2);
+    for ch in value.chars() {
+        match ch {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if c < ' ' => out.push_str(&format!("\\u{:04x}", c as u32)),
+            c => out.push(c),
+        }
+    }
+    out
+}
+
+pub fn write_promotion_receipt(
+    root: &Path,
+    product: &str,
+    action: &str,
+    artifact_id: &str,
+    from_commit: &str,
+    to_commit: &str,
+    relation: GitRelation,
+) -> Result<(), String> {
+    fs::create_dir_all(root).map_err(|error| error.to_string())?;
+    let occurred_at = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .unwrap_or(0);
+    let receipt = format!(
+        "{{\n  \"schema\": \"shifu.local-promotion-receipt/v1\",\n  \
+         \"product\": \"{}\",\n  \"action\": \"{}\",\n  \"artifactId\": \"{}\",\n  \
+         \"fromCommit\": \"{}\",\n  \"toCommit\": \"{}\",\n  \"relation\": \"{}\",\n  \
+         \"occurredAt\": {}\n}}\n",
+        json_escape(product),
+        json_escape(action),
+        json_escape(artifact_id),
+        json_escape(from_commit),
+        json_escape(to_commit),
+        relation.as_str(),
+        occurred_at
+    );
+    let target = root.join("last-promotion.json");
+    let staged = root.join(format!(".last-promotion-{}.tmp", std::process::id()));
+    fs::write(&staged, receipt).map_err(|error| error.to_string())?;
+    fs::rename(&staged, &target).map_err(|error| {
+        let _ = fs::remove_file(&staged);
+        error.to_string()
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn git(repo: &Path, args: &[&str]) {
+        let status = Command::new("git")
+            .arg("-C")
+            .arg(repo)
+            .args(args)
+            .env_remove("GIT_DIR")
+            .env_remove("GIT_WORK_TREE")
+            .env_remove("GIT_COMMON_DIR")
+            .env_remove("GIT_INDEX_FILE")
+            .status()
+            .unwrap();
+        assert!(status.success(), "git {args:?}");
+    }
+
+    fn output(repo: &Path, args: &[&str]) -> String {
+        let out = Command::new("git")
+            .arg("-C")
+            .arg(repo)
+            .args(args)
+            .env_remove("GIT_DIR")
+            .env_remove("GIT_WORK_TREE")
+            .env_remove("GIT_COMMON_DIR")
+            .env_remove("GIT_INDEX_FILE")
+            .output()
+            .unwrap();
+        assert!(out.status.success());
+        String::from_utf8_lossy(&out.stdout).trim().to_string()
+    }
+
+    #[test]
+    fn compact_branch_keeps_identifying_middle_and_suffix() {
+        assert_eq!(compact_branch("dev/v4/v4.0", false), "dev/v4/v4.0");
+        assert_eq!(
+            compact_branch("feature/profile-kfd3-qualification-s1", false),
+            "feature/profile-kfd3…ation-s1"
+        );
+        assert_eq!(
+            compact_branch("feature/profile-kfd3-qualification-s1", true),
+            "feature/profile-kfd3-qualification-s1"
+        );
+    }
+
+    #[test]
+    fn state_separates_manual_and_rollback_from_candidates() {
+        assert_eq!(
+            state_for(GitRelation::Descendant, true, false),
+            ArtifactState::Candidate
+        );
+        assert_eq!(
+            state_for(GitRelation::Diverged, true, false),
+            ArtifactState::Manual
+        );
+        assert_eq!(
+            state_for(GitRelation::Ancestor, true, true),
+            ArtifactState::Rollback
+        );
+        assert!(!automatic(GitRelation::Diverged, true, false));
+        assert!(!automatic(GitRelation::Descendant, true, true));
+    }
+
+    #[test]
+    fn divergent_newer_build_cannot_win_default_selection() {
+        let artifacts = [
+            (GitRelation::Diverged, true, false),
+            (GitRelation::Ancestor, true, false),
+            (GitRelation::Ancestor, true, true),
+        ];
+        assert_eq!(
+            select_unique_automatic(&artifacts),
+            Err(SelectionError::None),
+            "the observed 8c9001c90 -> 5d3613fc0 divergent overwrite must fail closed"
+        );
+    }
+
+    #[test]
+    fn one_descendant_wins_over_the_current_slot() {
+        let artifacts = [
+            (GitRelation::Same, true, false),
+            (GitRelation::Descendant, true, false),
+            (GitRelation::Ancestor, true, false),
+        ];
+        assert_eq!(select_unique_automatic(&artifacts), Ok(1));
+    }
+
+    #[test]
+    fn promotion_receipt_contains_no_local_paths() {
+        let root = shifu_core::host::unique_temp_dir("promotion-receipt").unwrap();
+        write_promotion_receipt(
+            &root,
+            "shifu",
+            "self-update",
+            "slot-1",
+            "aaaa",
+            "bbbb",
+            GitRelation::Descendant,
+        )
+        .unwrap();
+        let text = fs::read_to_string(root.join("last-promotion.json")).unwrap();
+        assert!(text.contains("\"relation\": \"descendant\""));
+        assert!(!text.contains(&root.display().to_string()));
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn git_relation_distinguishes_linear_and_diverged_history() {
+        let repo = shifu_core::host::unique_temp_dir("artifact-relation").unwrap();
+        git(&repo, &["init", "-q"]);
+        git(&repo, &["config", "user.name", "Shifu Test"]);
+        git(&repo, &["config", "user.email", "shifu@example.invalid"]);
+        fs::write(repo.join("value"), "one").unwrap();
+        git(&repo, &["add", "value"]);
+        git(
+            &repo,
+            &["-c", "core.hooksPath=", "commit", "-q", "-m", "one"],
+        );
+        let one = output(&repo, &["rev-parse", "HEAD"]);
+        git(&repo, &["branch", "side"]);
+        fs::write(repo.join("value"), "two").unwrap();
+        git(&repo, &["-c", "core.hooksPath=", "commit", "-qam", "two"]);
+        let two = output(&repo, &["rev-parse", "HEAD"]);
+        git(&repo, &["checkout", "-q", "side"]);
+        fs::write(repo.join("side"), "side").unwrap();
+        git(&repo, &["add", "side"]);
+        git(
+            &repo,
+            &["-c", "core.hooksPath=", "commit", "-q", "-m", "side"],
+        );
+        let side = output(&repo, &["rev-parse", "HEAD"]);
+        assert_eq!(git_relation(&repo, &one, &two), GitRelation::Descendant);
+        assert_eq!(git_relation(&repo, &two, &one), GitRelation::Ancestor);
+        assert_eq!(git_relation(&repo, &two, &side), GitRelation::Diverged);
+        assert_eq!(git_relation(&repo, &two, &two), GitRelation::Same);
+        assert_eq!(
+            git_relation(&repo, &two[..9], &two),
+            GitRelation::Same,
+            "short and full forms of one commit are the same artifact history"
+        );
+        let _ = fs::remove_dir_all(repo);
+    }
+}

--- a/crates/shifu/src/main.rs
+++ b/crates/shifu/src/main.rs
@@ -34,6 +34,7 @@ use std::env;
 use std::path::{Path, PathBuf};
 use std::process::exit;
 
+mod artifact_catalog;
 mod dispatch;
 mod doctor;
 mod envfile;
@@ -140,10 +141,11 @@ fn print_usage() {
     );
     println!(
         "                             {}",
-        style::dim("release; --list generations; --rollback one step back)")
+        style::dim("release; --list provenance; --rollback one step back)")
     );
-    println!("  shifu promote [--launch]   install the freshest built dev kungfu");
-    println!("  shifu builds               list registered dev builds");
+    println!("  shifu promote [--launch]   install the unique descendant dev build");
+    println!("  shifu builds               list provenance and Git relation for dev builds");
+    println!("  shifu artifacts <verb>     print the local artifact contract or schema");
     println!("  shifu help                 pnpm's own help (tasks are pnpm scripts)");
     println!();
     println!(
@@ -186,7 +188,9 @@ fn main() {
     // user-global precisely so a cleaned worktree cannot strand its build.
     let is_promote = first == Some("promote");
     let is_builds = first == Some("builds");
-    let lenient = is_version || is_doctor || is_self_update || is_promote || is_builds;
+    let is_artifacts = first == Some("artifacts");
+    let lenient =
+        is_version || is_doctor || is_self_update || is_promote || is_builds || is_artifacts;
 
     let root = find_repo_root(lenient);
 
@@ -224,7 +228,10 @@ fn main() {
         promote::run_promote(&args[1..]);
     }
     if is_builds {
-        promote::run_builds();
+        promote::run_builds(&args[1..]);
+    }
+    if is_artifacts {
+        artifact_catalog::run_discovery(&args[1..]);
     }
     let root = root.expect("strict repo discovery cannot return None");
 

--- a/crates/shifu/src/promote.rs
+++ b/crates/shifu/src/promote.rs
@@ -36,6 +36,7 @@ struct BuildEntry {
     name: String,
     sha: String,
     branch: String,
+    repo: String,
     worktree: String,
     built_at: String,
     kind: String,
@@ -99,6 +100,7 @@ fn entries() -> Vec<BuildEntry> {
             Some(BuildEntry {
                 sha: meta_get(&meta, "KUNGFU_BUILD_SHA"),
                 branch: meta_get(&meta, "KUNGFU_BUILD_BRANCH"),
+                repo: meta_get(&meta, "KUNGFU_BUILD_REPO"),
                 worktree: meta_get(&meta, "KUNGFU_BUILD_WORKTREE"),
                 built_at: meta_get(&meta, "KUNGFU_BUILD_TIME"),
                 kind: meta_get(&meta, "KUNGFU_BUILD_KIND"),
@@ -143,10 +145,15 @@ fn build_relation(entry: &BuildEntry, installed: &str, entry_count: usize) -> Gi
         };
     }
     let worktree = Path::new(&entry.worktree);
-    if !worktree.is_dir() {
+    let canonical = Path::new(&entry.repo);
+    let root = worktree
+        .is_dir()
+        .then_some(worktree)
+        .or_else(|| canonical.is_dir().then_some(canonical));
+    let Some(root) = root else {
         return GitRelation::Unknown;
-    }
-    git_relation(worktree, installed, &entry.sha)
+    };
+    git_relation(root, installed, &entry.sha)
 }
 
 fn build_valid(entry: &BuildEntry) -> bool {
@@ -248,7 +255,7 @@ fn print_builds_json(entries: &[BuildEntry]) {
                 relation.as_str(),
                 automatic(relation, valid, false),
                 entry.sha.ends_with("-dirty"),
-                json_escape(&entry.worktree),
+                json_escape(&entry.repo),
                 json_escape(&entry.worktree),
                 json_escape(&entry.worktree),
                 json_escape(&entry.slot.join(&entry.artifact).display().to_string()),
@@ -266,11 +273,13 @@ fn write_installed_receipt(entry: &BuildEntry, installed: &Path) {
         "KUNGFU_ARTIFACT_SCHEMA='shifu.local-artifact/v1'\n\
          KUNGFU_INSTALLED_SHA='{}'\n\
          KUNGFU_INSTALLED_BRANCH='{}'\n\
+         KUNGFU_INSTALLED_REPO='{}'\n\
          KUNGFU_INSTALLED_BUILD_ID='{}'\n\
          KUNGFU_INSTALLED_WORKTREE='{}'\n\
          KUNGFU_INSTALLED_ARTIFACT='{}'\n",
         entry.sha,
         entry.branch.replace('\'', ""),
+        entry.repo.replace('\'', ""),
         entry.name,
         entry.worktree.replace('\'', ""),
         installed.display()
@@ -291,10 +300,15 @@ fn write_installed_receipt(entry: &BuildEntry, installed: &Path) {
 /// A successful promotion is the only point where ancestry authorizes
 /// retirement. Divergent and unknown builds remain visible and manual-only.
 fn retire_superseded(promoted: &BuildEntry, entries: &[BuildEntry]) {
-    let repo = Path::new(&promoted.worktree);
-    if !repo.is_dir() {
+    let worktree = Path::new(&promoted.worktree);
+    let canonical = Path::new(&promoted.repo);
+    let repo = worktree
+        .is_dir()
+        .then_some(worktree)
+        .or_else(|| canonical.is_dir().then_some(canonical));
+    let Some(repo) = repo else {
         return;
-    }
+    };
     for entry in entries {
         if entry.name == promoted.name {
             continue;
@@ -357,7 +371,7 @@ pub fn run_builds(args: &[String]) -> ! {
                 " (worktree cleaned; stash still usable)"
             };
             println!(
-                "      id={} built={} kind={} digest={}\n      artifact={}\n      worktree={}{}",
+                "      id={} built={} kind={} digest={}\n      artifact={}\n      repo={}\n      worktree={}{}",
                 entry.name,
                 entry.built_at,
                 entry.kind,
@@ -367,6 +381,11 @@ pub fn run_builds(args: &[String]) -> ! {
                     &entry.digest
                 },
                 entry.slot.join(&entry.artifact).display(),
+                if entry.repo.is_empty() {
+                    "unknown"
+                } else {
+                    &entry.repo
+                },
                 entry.worktree,
                 worktree_state
             );

--- a/crates/shifu/src/promote.rs
+++ b/crates/shifu/src/promote.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// `shifu promote` / `shifu builds` — use the freshest built dev kungfu from
-// any terminal.
+// `shifu promote` / `shifu builds` — inspect and install provenance-qualified
+// dev Kungfu artifacts from any terminal.
 //
 // Builds happen in worktrees, and worktrees are temporary: the launcher
 // therefore stashes each successful build user-globally as declared by the
@@ -12,12 +12,11 @@
 //     meta.env      KEY='VALUE' lines (build-local.env shape)
 //     <artifact>    unpacked .app (mac) / nsis installer (win) / AppImage
 //
-// The newest build is the lexicographically greatest slot. `builds` lists
-// the stash; `promote` installs the newest entry — the shifu-jurisdiction
-// sibling of `clone`: clone acquires the repository, promote acquires the
-// product. Configuration rides the existing build-local.env surface:
-// KUNGFU_PRODUCT_INSTALL_DIR (install target) and, on the producer side,
-// KUNGFU_PRODUCT_BUILDS_KEEP (stash retention).
+// Slot timestamps are display provenance, never version authority. `builds`
+// classifies every entry against the installed receipt; `promote` advances
+// only to one unique Git descendant and retires proven ancestors afterward.
+// Divergent/unknown entries remain manual-only. Configuration rides the
+// existing KUNGFU_PRODUCT_INSTALL_DIR surface.
 
 use std::env;
 use std::fs;
@@ -26,6 +25,10 @@ use std::process::Command;
 
 use shifu_core::{host, style};
 
+use crate::artifact_catalog::{
+    automatic, compact_branch, git_relation, json_escape, select_unique_automatic, short_sha,
+    state_for, write_promotion_receipt, GitRelation, SelectionError,
+};
 use crate::{envfile, util};
 
 struct BuildEntry {
@@ -37,6 +40,14 @@ struct BuildEntry {
     built_at: String,
     kind: String,
     artifact: String,
+    digest: String,
+}
+
+#[derive(Default)]
+struct ListOptions {
+    verbose: bool,
+    json: bool,
+    no_truncate: bool,
 }
 
 fn registry_dir() -> PathBuf {
@@ -91,6 +102,7 @@ fn entries() -> Vec<BuildEntry> {
                 worktree: meta_get(&meta, "KUNGFU_BUILD_WORKTREE"),
                 built_at: meta_get(&meta, "KUNGFU_BUILD_TIME"),
                 kind: meta_get(&meta, "KUNGFU_BUILD_KIND"),
+                digest: meta_get(&meta, "KUNGFU_BUILD_SHA256"),
                 artifact,
                 slot,
                 name,
@@ -107,11 +119,219 @@ fn no_builds_hint() -> ! {
     ));
 }
 
-pub fn run_builds() -> ! {
+fn installed_receipt_path() -> PathBuf {
+    registry_dir().join("installed.meta.env")
+}
+
+fn installed_sha() -> String {
+    let Ok(text) = fs::read_to_string(installed_receipt_path()) else {
+        return String::new();
+    };
+    text.lines()
+        .filter_map(envfile::parse_line)
+        .find(|(key, _)| *key == "KUNGFU_INSTALLED_SHA")
+        .map(|(_, value)| value.to_string())
+        .unwrap_or_default()
+}
+
+fn build_relation(entry: &BuildEntry, installed: &str, entry_count: usize) -> GitRelation {
+    if installed.is_empty() {
+        return if entry_count == 1 {
+            GitRelation::Descendant
+        } else {
+            GitRelation::Unknown
+        };
+    }
+    let worktree = Path::new(&entry.worktree);
+    if !worktree.is_dir() {
+        return GitRelation::Unknown;
+    }
+    git_relation(worktree, installed, &entry.sha)
+}
+
+fn build_valid(entry: &BuildEntry) -> bool {
+    !entry.sha.is_empty()
+        && entry.sha != "unknown"
+        && matches!(entry.kind.as_str(), "app" | "installer" | "appimage")
+        && entry.slot.join(&entry.artifact).exists()
+}
+
+fn schema_kind(entry: &BuildEntry) -> &str {
+    if matches!(entry.kind.as_str(), "app" | "installer" | "appimage") {
+        &entry.kind
+    } else {
+        "unknown"
+    }
+}
+
+fn select_product_build<'a>(
+    entries: &'a [BuildEntry],
+    installed: &str,
+    selected: Option<&str>,
+    allow_nonlinear: bool,
+) -> &'a BuildEntry {
+    if let Some(id) = selected {
+        let matches: Vec<_> = entries
+            .iter()
+            .filter(|entry| entry.name == id || entry.name.starts_with(id))
+            .collect();
+        if matches.len() != 1 {
+            util::die(&format!(
+                "--build {id} matched {} builds; use the exact id from shifu builds",
+                matches.len()
+            ));
+        }
+        let entry = matches[0];
+        if !build_valid(entry) {
+            util::die(&format!(
+                "build {} is invalid and cannot be promoted even with an override",
+                entry.name
+            ));
+        }
+        let relation = build_relation(entry, installed, entries.len());
+        if !automatic(relation, build_valid(entry), false) && !allow_nonlinear {
+            util::die(&format!(
+                "build {} is {} and is manual-only; after review pass \
+                 --build {} --allow-nonlinear",
+                entry.name,
+                relation.as_str(),
+                entry.name
+            ));
+        }
+        return entry;
+    }
+    let dispositions: Vec<_> = entries
+        .iter()
+        .map(|entry| {
+            (
+                build_relation(entry, installed, entries.len()),
+                build_valid(entry),
+                false,
+            )
+        })
+        .collect();
+    match select_unique_automatic(&dispositions) {
+        Ok(index) => &entries[index],
+        Err(SelectionError::None) => util::die(
+            "no automatic product candidate: builds are older, divergent, or have unknown \
+             provenance; inspect shifu builds and select --build <id> --allow-nonlinear",
+        ),
+        Err(SelectionError::Ambiguous) => util::die(
+            "multiple automatic product candidates remain; inspect shifu builds and select \
+             one explicitly with --build <id>",
+        ),
+    }
+}
+
+fn print_builds_json(entries: &[BuildEntry]) {
+    let installed = installed_sha();
+    println!("{{");
+    println!("  \"schema\": \"shifu.local-artifact-catalog/v1\",");
+    println!("  \"product\": \"kungfu\",");
+    println!("  \"platform\": \"{}\",", json_escape(&host::os_arch()));
+    println!("  \"artifacts\": [");
+    let rows: Vec<_> = entries
+        .iter()
+        .map(|entry| {
+            let relation = build_relation(entry, &installed, entries.len());
+            let valid = build_valid(entry);
+            let state = state_for(relation, valid, false);
+            format!(
+                "    {{\"id\":\"{}\",\"kind\":\"{}\",\"version\":\"\",\"commit\":\"{}\",\"branch\":\"{}\",\"digest\":\"{}\",\"builtAt\":\"{}\",\"state\":\"{}\",\"relation\":\"{}\",\"automatic\":{},\"rollbackOnly\":false,\"dirty\":{},\"repoPath\":\"{}\",\"worktreePath\":\"{}\",\"buildPath\":\"{}\",\"artifactPath\":\"{}\",\"pathDigest\":\"\",\"reason\":\"{}\"}}",
+                json_escape(&entry.name),
+                json_escape(schema_kind(entry)),
+                json_escape(&entry.sha),
+                json_escape(&entry.branch),
+                json_escape(&entry.digest),
+                json_escape(&entry.built_at),
+                state.as_str(),
+                relation.as_str(),
+                automatic(relation, valid, false),
+                entry.sha.ends_with("-dirty"),
+                json_escape(&entry.worktree),
+                json_escape(&entry.worktree),
+                json_escape(&entry.worktree),
+                json_escape(&entry.slot.join(&entry.artifact).display().to_string()),
+                relation.as_str()
+            )
+        })
+        .collect();
+    println!("{}", rows.join(",\n"));
+    println!("  ]");
+    println!("}}");
+}
+
+fn write_installed_receipt(entry: &BuildEntry, installed: &Path) {
+    let text = format!(
+        "KUNGFU_ARTIFACT_SCHEMA='shifu.local-artifact/v1'\n\
+         KUNGFU_INSTALLED_SHA='{}'\n\
+         KUNGFU_INSTALLED_BRANCH='{}'\n\
+         KUNGFU_INSTALLED_BUILD_ID='{}'\n\
+         KUNGFU_INSTALLED_WORKTREE='{}'\n\
+         KUNGFU_INSTALLED_ARTIFACT='{}'\n",
+        entry.sha,
+        entry.branch.replace('\'', ""),
+        entry.name,
+        entry.worktree.replace('\'', ""),
+        installed.display()
+    );
+    let path = installed_receipt_path();
+    let staged = path.with_extension("tmp");
+    if fs::write(&staged, text).is_ok() {
+        if let Err(error) = fs::rename(&staged, &path) {
+            let _ = fs::remove_file(&staged);
+            eprintln!(
+                "   {}",
+                style::yellow(&format!("could not write promotion receipt: {error}"))
+            );
+        }
+    }
+}
+
+/// A successful promotion is the only point where ancestry authorizes
+/// retirement. Divergent and unknown builds remain visible and manual-only.
+fn retire_superseded(promoted: &BuildEntry, entries: &[BuildEntry]) {
+    let repo = Path::new(&promoted.worktree);
+    if !repo.is_dir() {
+        return;
+    }
+    for entry in entries {
+        if entry.name == promoted.name {
+            continue;
+        }
+        if git_relation(repo, &promoted.sha, &entry.sha) == GitRelation::Ancestor {
+            if let Err(error) = fs::remove_dir_all(&entry.slot) {
+                eprintln!(
+                    "   {}",
+                    style::yellow(&format!(
+                        "could not retire superseded build {}: {error}",
+                        entry.name
+                    ))
+                );
+            }
+        }
+    }
+}
+
+pub fn run_builds(args: &[String]) -> ! {
+    let mut options = ListOptions::default();
+    for arg in args {
+        match arg.as_str() {
+            "--verbose" => options.verbose = true,
+            "--json" => options.json = true,
+            "--no-truncate" => options.no_truncate = true,
+            _ => util::die("usage: shifu builds [--verbose] [--json] [--no-truncate]"),
+        }
+    }
     let entries = entries();
     if entries.is_empty() {
         no_builds_hint();
     }
+    if options.json {
+        print_builds_json(&entries);
+        std::process::exit(0);
+    }
+    let installed = installed_sha();
     println!(
         "{}",
         style::cyan(&format!(
@@ -120,25 +340,40 @@ pub fn run_builds() -> ! {
         ))
     );
     for (index, entry) in entries.iter().enumerate() {
-        let worktree_note = if Path::new(&entry.worktree).is_dir() {
-            entry.worktree.clone()
-        } else {
-            format!("{} (worktree cleaned; stash still usable)", entry.worktree)
-        };
+        let relation = build_relation(entry, &installed, entries.len());
+        let state = state_for(relation, build_valid(entry), false);
         println!(
-            "  {} {} {} @ {}",
+            "  {} {:10} {:9} {:34} {:10}",
             style::bold(&format!("[{index}]")),
-            entry.built_at,
-            style::bold(&entry.sha),
-            entry.branch,
+            state.as_str(),
+            short_sha(&entry.sha),
+            compact_branch(&entry.branch, options.no_truncate),
+            relation.as_str(),
         );
-        println!(
-            "      {}",
-            style::dim(&format!("{} - from {}", entry.artifact, worktree_note))
-        );
+        if options.verbose {
+            let worktree_state = if Path::new(&entry.worktree).is_dir() {
+                ""
+            } else {
+                " (worktree cleaned; stash still usable)"
+            };
+            println!(
+                "      id={} built={} kind={} digest={}\n      artifact={}\n      worktree={}{}",
+                entry.name,
+                entry.built_at,
+                entry.kind,
+                if entry.digest.is_empty() {
+                    "unknown"
+                } else {
+                    &entry.digest
+                },
+                entry.slot.join(&entry.artifact).display(),
+                entry.worktree,
+                worktree_state
+            );
+        }
     }
     println!(
-        "\n{} shifu promote [--launch] installs [0]",
+        "\n{} shifu promote installs the unique descendant; use --build <id> for manual selection",
         style::cyan("Next:")
     );
     std::process::exit(0)
@@ -147,18 +382,28 @@ pub fn run_builds() -> ! {
 pub fn run_promote(args: &[String]) -> ! {
     let mut launch = false;
     let mut force = false;
-    for arg in args {
+    let mut allow_nonlinear = false;
+    let mut build_arg: Option<String> = None;
+    let mut iter = args.iter();
+    while let Some(arg) = iter.next() {
         match arg.as_str() {
             "--launch" => launch = true,
             "--force" => force = true,
-            _ => util::die("usage: shifu promote [--launch] [--force]"),
+            "--allow-nonlinear" => allow_nonlinear = true,
+            "--build" => match iter.next() {
+                Some(value) => build_arg = Some(value.clone()),
+                None => util::die(PROMOTE_USAGE),
+            },
+            _ => util::die(PROMOTE_USAGE),
         }
     }
 
     let entries = entries();
-    let Some(entry) = entries.first() else {
+    if entries.is_empty() {
         no_builds_hint();
-    };
+    }
+    let installed = installed_sha();
+    let entry = select_product_build(&entries, &installed, build_arg.as_deref(), allow_nonlinear);
     eprintln!(
         "\u{1f94b} {}",
         style::bold(&format!(
@@ -179,11 +424,32 @@ pub fn run_promote(args: &[String]) -> ! {
         style::green("promoted"),
         style::bold(&installed.display().to_string())
     );
+    let previous_sha = installed_sha();
+    let relation = build_relation(entry, &previous_sha, entries.len());
+    write_installed_receipt(entry, &installed);
+    if let Err(error) = write_promotion_receipt(
+        &registry_dir(),
+        "kungfu",
+        "promote",
+        &entry.name,
+        &previous_sha,
+        &entry.sha,
+        relation,
+    ) {
+        eprintln!(
+            "   {}",
+            style::yellow(&format!("could not write promotion receipt: {error}"))
+        );
+    }
+    retire_superseded(entry, &entries);
     if launch {
         launch_product(&installed);
     }
     std::process::exit(0)
 }
+
+const PROMOTE_USAGE: &str =
+    "usage: shifu promote [--build <id> [--allow-nonlinear]] [--launch] [--force]";
 
 /// Install target: KUNGFU_PRODUCT_INSTALL_DIR > platform default (falling
 /// back to a per-user location when the default is not writable).

--- a/crates/shifu/src/registrar.rs
+++ b/crates/shifu/src/registrar.rs
@@ -199,6 +199,11 @@ pub fn register(root: &Path, plan: &DistributionPlan) {
     } else {
         branch
     };
+    let repo = git(root, &["worktree", "list", "--porcelain"])
+        .lines()
+        .find_map(|line| line.strip_prefix("worktree "))
+        .map(str::to_string)
+        .unwrap_or_else(|| root.display().to_string());
     let (stamp, built_at) = utc_now();
 
     let registry = registry_dir(&plan.product_id);
@@ -224,6 +229,7 @@ pub fn register(root: &Path, plan: &DistributionPlan) {
     let mut meta = vec![
         format!("KUNGFU_BUILD_SHA={}", quote(&fingerprint)),
         format!("KUNGFU_BUILD_BRANCH={}", quote(&branch)),
+        format!("KUNGFU_BUILD_REPO={}", quote(&repo)),
         format!(
             "KUNGFU_BUILD_WORKTREE={}",
             quote(&root.display().to_string())

--- a/crates/shifu/src/registrar.rs
+++ b/crates/shifu/src/registrar.rs
@@ -252,7 +252,6 @@ pub fn register(root: &Path, plan: &DistributionPlan) {
         "\u{1f94b} {}",
         style::bold(&format!("registered build -> {}", slot.display()))
     );
-    retire_old_slots(&registry);
 }
 
 /// The kungfu product keeps its historical registry path (existing `builds` /
@@ -265,35 +264,6 @@ fn registry_dir(product_id: &str) -> PathBuf {
         base.join(product_id)
     };
     base.join(host::os_arch())
-}
-
-/// Retention: keep the newest KUNGFU_PRODUCT_BUILDS_KEEP slots (default 2).
-fn retire_old_slots(registry: &Path) {
-    let keep = env::var("KUNGFU_PRODUCT_BUILDS_KEEP")
-        .ok()
-        .and_then(|v| v.parse::<usize>().ok())
-        .filter(|&n| n >= 1)
-        .unwrap_or(2);
-    let Ok(read) = fs::read_dir(registry) else {
-        return;
-    };
-    let mut names: Vec<String> = read
-        .flatten()
-        .filter(|e| e.path().is_dir())
-        .map(|e| e.file_name().to_string_lossy().to_string())
-        .filter(|name| !name.contains(".tmp-"))
-        .filter(|name| registry.join(name).join("meta.env").is_file())
-        .collect();
-    names.sort();
-    names.reverse();
-    for name in names.iter().skip(keep) {
-        if fs::remove_dir_all(registry.join(name)).is_ok() {
-            eprintln!(
-                "   {}",
-                style::dim(&format!("retired build {name} (keep {keep})"))
-            );
-        }
-    }
 }
 
 fn warn(msg: &str) {

--- a/crates/shifu/src/self_update.rs
+++ b/crates/shifu/src/self_update.rs
@@ -13,11 +13,10 @@
 //                          also the explicit road back to the official build
 //   2. inside a checkout   built from the checkout's current source (cargo
 //                          present) — fresher than any stash can be
-//   3. local build slot    the newest source-fresh cache slot the repo shim
-//                          built (~/.cache/kungfu/shifu/<slot>/): the binary
-//                          that actually drove the last build, surviving its
-//                          worktree — so upgrading needs no checkout at all;
-//                          its full identity line prints before the swap
+//   3. local build slot    one unique same/descendant source-fresh cache slot
+//                          recorded by the repo shim. Ancestor, divergent,
+//                          unknown, and ambiguous slots fail closed unless the
+//                          operator names one with --from and --force.
 //
 // Every replacement first archives the outgoing binary (this very process, so
 // its identity is compile-time exact) under .../shifu/generations/, keeping
@@ -38,10 +37,21 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use shifu_core::bootstrap::{self, FetchSpec};
 use shifu_core::{host, style};
 
+use crate::artifact_catalog::{
+    automatic, compact_branch, git_relation, json_escape, select_unique_automatic, short_sha,
+    state_for, write_promotion_receipt, GitRelation, SelectionError,
+};
 use crate::{envfile, util};
 
 const DIST_BASE: &str = "https://github.com/kungfu-systems/kungfu/releases/download";
-const USAGE: &str = "usage: shifu self-update [--version <version> | --list | --rollback]";
+const USAGE: &str = "usage: shifu self-update [--version <version> | --from <id> [--force] | --list [--verbose] [--json] [--no-truncate] | --rollback]";
+
+#[derive(Default)]
+struct ListOptions {
+    verbose: bool,
+    json: bool,
+    no_truncate: bool,
+}
 
 /// The running binary's own identity — exact by construction: these are the
 /// compile-time constants of the process doing the archiving.
@@ -55,8 +65,11 @@ fn own_identity() -> (&'static str, &'static str, &'static str) {
 
 pub fn run(root: Option<&Path>, args: &[String]) -> ! {
     let mut version_arg: Option<String> = None;
+    let mut from_arg: Option<String> = None;
     let mut list = false;
     let mut rollback = false;
+    let mut force = false;
+    let mut list_options = ListOptions::default();
     let mut iter = args.iter();
     while let Some(arg) = iter.next() {
         match arg.as_str() {
@@ -64,12 +77,24 @@ pub fn run(root: Option<&Path>, args: &[String]) -> ! {
                 Some(v) => version_arg = Some(v.clone()),
                 None => util::die(USAGE),
             },
+            "--from" => match iter.next() {
+                Some(v) => from_arg = Some(v.clone()),
+                None => util::die(USAGE),
+            },
             "--list" => list = true,
             "--rollback" => rollback = true,
+            "--force" => force = true,
+            "--verbose" => list_options.verbose = true,
+            "--json" => list_options.json = true,
+            "--no-truncate" => list_options.no_truncate = true,
             _ => util::die(USAGE),
         }
     }
-    if (list && rollback) || (version_arg.is_some() && (list || rollback)) {
+    if (list && rollback)
+        || (version_arg.is_some() && (list || rollback || from_arg.is_some()))
+        || (from_arg.is_some() && (list || rollback))
+        || (!list && (list_options.verbose || list_options.json || list_options.no_truncate))
+    {
         util::die(USAGE);
     }
 
@@ -87,7 +112,7 @@ pub fn run(root: Option<&Path>, args: &[String]) -> ! {
     }
 
     if list {
-        run_list();
+        run_list(root, &list_options);
     }
     if rollback {
         run_rollback(&exe);
@@ -100,21 +125,39 @@ pub fn run(root: Option<&Path>, args: &[String]) -> ! {
         Some(_) => None,
     };
     let new_binary = if let Some(root) = source_root {
+        guard_checkout_candidate(root, force);
         build_from_source(root)
     } else if let Some(version) = version_arg.or_else(|| root.and_then(pinned_version)) {
         fetch_release(&version)
-    } else if let Some(slot) = newest_build_slot() {
-        announce_slot(&slot);
-        slot
     } else {
-        util::die(
-            "nothing to update from: no local build slot exists yet — run inside a kungfu \
-             checkout, or pass an explicit release: shifu self-update --version <version>",
-        )
+        select_build_slot(from_arg.as_deref(), force)
     };
 
+    let candidate_sha = identity_parts(&new_binary).1;
+    let candidate_relation = candidate_relation(&new_binary, source_root);
+    let candidate_id = new_binary
+        .parent()
+        .and_then(Path::file_name)
+        .map(|name| name.to_string_lossy().to_string())
+        .unwrap_or_else(|| "source".to_string());
+    let previous_sha = own_identity().1.to_string();
     archive_current(&exe);
     replace_binary(&exe, &new_binary);
+    write_installed_receipt(&new_binary, source_root);
+    if let Err(error) = write_promotion_receipt(
+        &host::kungfu_cache_dir().join("shifu"),
+        "shifu",
+        "self-update",
+        &candidate_id,
+        &previous_sha,
+        &candidate_sha,
+        candidate_relation,
+    ) {
+        eprintln!(
+            "   {}",
+            style::yellow(&format!("could not write promotion receipt: {error}"))
+        );
+    }
     eprintln!(
         "\u{2705} {} {}",
         style::green("updated"),
@@ -243,13 +286,61 @@ fn fetch_release(version: &str) -> PathBuf {
 // ---------------------------------------------------------------------------
 // Local build slots — the shim's source-fresh cache as an upgrade source.
 
-/// The newest binary among the shim's cache slots (release-pin and
-/// source-fresh alike), by binary mtime: the build most recently placed is
-/// the one most recently proven in use. Bookkeeping dirs are excluded.
-fn newest_build_slot() -> Option<PathBuf> {
+#[derive(Clone)]
+struct BuildSlot {
+    id: String,
+    binary: PathBuf,
+    version: String,
+    sha: String,
+    channel: String,
+    branch: String,
+    worktree: String,
+    build_path: String,
+    built_at: String,
+    modified: SystemTime,
+    valid: bool,
+}
+
+fn meta_value(dir: &Path, key: &str) -> String {
+    let Ok(text) = fs::read_to_string(dir.join("meta.env")) else {
+        return String::new();
+    };
+    text.lines()
+        .filter_map(envfile::parse_line)
+        .find(|(name, _)| *name == key)
+        .map(|(_, value)| value.to_string())
+        .unwrap_or_default()
+}
+
+fn identity_parts(binary: &Path) -> (String, String, String) {
+    let Some(line) = identity_of(binary) else {
+        return (String::new(), String::new(), String::new());
+    };
+    let version = line.split_whitespace().nth(1).unwrap_or("").to_string();
+    let sha = line
+        .split("(git ")
+        .nth(1)
+        .and_then(|tail| tail.split(',').next())
+        .unwrap_or("")
+        .to_string();
+    let channel = line
+        .split("(git ")
+        .nth(1)
+        .and_then(|tail| tail.split(',').nth(1))
+        .map(str::trim)
+        .unwrap_or("")
+        .to_string();
+    (version, sha, channel)
+}
+
+/// Every usable launcher slot. Recency is display provenance only; it is never
+/// the authority for automatic selection.
+fn build_slots() -> Vec<BuildSlot> {
     let root = host::kungfu_cache_dir().join("shifu");
-    let entries = fs::read_dir(&root).ok()?;
-    let mut best: Option<(SystemTime, PathBuf)> = None;
+    let Ok(entries) = fs::read_dir(&root) else {
+        return Vec::new();
+    };
+    let mut slots = Vec::new();
     for entry in entries.flatten() {
         let dir = entry.path();
         if !dir.is_dir() {
@@ -264,11 +355,147 @@ fn newest_build_slot() -> Option<PathBuf> {
             continue;
         };
         let modified = meta.modified().unwrap_or(UNIX_EPOCH);
-        if best.as_ref().is_none_or(|(t, _)| modified > *t) {
-            best = Some((modified, bin));
-        }
+        let (version, identity_sha, channel) = identity_parts(&bin);
+        let recorded_sha = meta_value(&dir, "KUNGFU_ARTIFACT_SHA");
+        let sha = if recorded_sha.is_empty() {
+            identity_sha
+        } else {
+            recorded_sha
+        };
+        slots.push(BuildSlot {
+            id: name,
+            binary: bin,
+            version,
+            sha: sha.clone(),
+            channel,
+            branch: meta_value(&dir, "KUNGFU_ARTIFACT_BRANCH"),
+            worktree: meta_value(&dir, "KUNGFU_ARTIFACT_WORKTREE"),
+            build_path: meta_value(&dir, "KUNGFU_ARTIFACT_BUILD_PATH"),
+            built_at: meta_value(&dir, "KUNGFU_ARTIFACT_BUILT_AT"),
+            modified,
+            valid: !sha.is_empty(),
+        });
     }
-    best.map(|(_, bin)| bin)
+    slots.sort_by_key(|slot| std::cmp::Reverse(slot.modified));
+    slots
+}
+
+fn git_output(root: &Path, args: &[&str]) -> String {
+    Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(args)
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_WORK_TREE")
+        .env_remove("GIT_COMMON_DIR")
+        .env_remove("GIT_INDEX_FILE")
+        .output()
+        .ok()
+        .filter(|out| out.status.success())
+        .map(|out| String::from_utf8_lossy(&out.stdout).trim().to_string())
+        .unwrap_or_default()
+}
+
+fn slot_relation(slot: &BuildSlot, fallback_root: Option<&Path>) -> GitRelation {
+    let worktree = Path::new(&slot.worktree);
+    let repo = worktree.is_dir().then_some(worktree).or(fallback_root);
+    repo.map(|root| git_relation(root, own_identity().1, &slot.sha))
+        .unwrap_or(GitRelation::Unknown)
+}
+
+fn candidate_relation(binary: &Path, source_root: Option<&Path>) -> GitRelation {
+    let candidate_sha = identity_parts(binary).1;
+    let parent = binary.parent().unwrap_or_else(|| Path::new(""));
+    let recorded_worktree = meta_value(parent, "KUNGFU_ARTIFACT_WORKTREE");
+    let recorded_root = Path::new(&recorded_worktree);
+    source_root
+        .or_else(|| recorded_root.is_dir().then_some(recorded_root))
+        .map(|repo| git_relation(repo, own_identity().1, &candidate_sha))
+        .unwrap_or(GitRelation::Unknown)
+}
+
+fn guard_checkout_candidate(root: &Path, force: bool) {
+    let candidate = git_output(root, &["rev-parse", "HEAD"]);
+    let relation = git_relation(root, own_identity().1, &candidate);
+    if matches!(relation, GitRelation::Same | GitRelation::Descendant) {
+        return;
+    }
+    if !force {
+        util::die(&format!(
+            "refusing non-linear self-update: installed {} -> candidate {} is {}\n  \
+             inspect with: shifu self-update --list --verbose\n  \
+             override only after review: shifu self-update --force",
+            short_sha(own_identity().1),
+            short_sha(&candidate),
+            relation.as_str()
+        ));
+    }
+    eprintln!(
+        "   {}",
+        style::yellow(&format!(
+            "non-linear history explicitly accepted: {}",
+            relation.as_str()
+        ))
+    );
+}
+
+fn select_build_slot(from: Option<&str>, force: bool) -> PathBuf {
+    let slots = build_slots();
+    if slots.is_empty() {
+        util::die(
+            "nothing to update from: no local build slot exists yet — run inside a kungfu \
+             checkout, or pass an explicit release: shifu self-update --version <version>",
+        );
+    }
+    if let Some(id) = from {
+        let matches: Vec<_> = slots
+            .iter()
+            .filter(|slot| slot.id == id || slot.id.starts_with(id))
+            .collect();
+        if matches.len() != 1 {
+            util::die(&format!(
+                "--from {id} matched {} slots; use the exact id from --list",
+                matches.len()
+            ));
+        }
+        let slot = matches[0];
+        if !slot.valid {
+            util::die(&format!(
+                "artifact {} is invalid and cannot be installed even with --force",
+                slot.id
+            ));
+        }
+        let relation = slot_relation(slot, None);
+        if !automatic(relation, slot.valid, false) && !force {
+            util::die(&format!(
+                "artifact {} is {} and requires both --from {} and --force",
+                slot.id,
+                relation.as_str(),
+                slot.id
+            ));
+        }
+        announce_slot(&slot.binary);
+        return slot.binary.clone();
+    }
+    let dispositions: Vec<_> = slots
+        .iter()
+        .map(|slot| (slot_relation(slot, None), slot.valid, false))
+        .collect();
+    match select_unique_automatic(&dispositions) {
+        Ok(index) => {
+            let slot = &slots[index];
+            announce_slot(&slot.binary);
+            slot.binary.clone()
+        }
+        Err(SelectionError::None) => util::die(
+            "no automatic self-update candidate: every local slot is older, divergent, or \
+             has unknown provenance; inspect --list and select with --from <id> --force",
+        ),
+        Err(SelectionError::Ambiguous) => util::die(
+            "multiple automatic self-update candidates remain; inspect --list and select \
+             one explicitly with --from <id>",
+        ),
+    }
 }
 
 /// A binary's full identity line, by asking it. Spawning is safe: --version
@@ -303,6 +530,95 @@ fn generations_dir() -> PathBuf {
     host::kungfu_cache_dir().join("shifu").join("generations")
 }
 
+fn installed_receipt_path() -> PathBuf {
+    host::kungfu_cache_dir()
+        .join("shifu")
+        .join("installed.meta.env")
+}
+
+fn installed_provenance(key: &str) -> String {
+    let Ok(text) = fs::read_to_string(installed_receipt_path()) else {
+        return String::new();
+    };
+    let recorded_sha = text
+        .lines()
+        .filter_map(envfile::parse_line)
+        .find(|(name, _)| *name == "KUNGFU_SHIFU_SHA")
+        .map(|(_, value)| value.to_string())
+        .unwrap_or_default();
+    if recorded_sha != own_identity().1 {
+        return String::new();
+    }
+    text.lines()
+        .filter_map(envfile::parse_line)
+        .find(|(name, _)| *name == key)
+        .map(|(_, value)| value.to_string())
+        .unwrap_or_default()
+}
+
+fn write_installed_receipt(binary: &Path, source_root: Option<&Path>) {
+    let (version, sha, channel) = identity_parts(binary);
+    let parent = binary.parent().unwrap_or_else(|| Path::new(""));
+    let branch = source_root
+        .map(|root| git_output(root, &["symbolic-ref", "--short", "HEAD"]))
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| meta_value(parent, "KUNGFU_ARTIFACT_BRANCH"));
+    let worktree = source_root
+        .map(|root| root.display().to_string())
+        .unwrap_or_else(|| meta_value(parent, "KUNGFU_ARTIFACT_WORKTREE"));
+    let build_path = if source_root.is_some() {
+        binary
+            .parent()
+            .map(|path| path.display().to_string())
+            .unwrap_or_default()
+    } else {
+        meta_value(parent, "KUNGFU_ARTIFACT_BUILD_PATH")
+    };
+    let text = format!(
+        "KUNGFU_ARTIFACT_SCHEMA='shifu.local-artifact/v1'\n\
+         KUNGFU_SHIFU_VERSION='{}'\n\
+         KUNGFU_SHIFU_SHA='{}'\n\
+         KUNGFU_SHIFU_CHANNEL='{}'\n\
+         KUNGFU_SHIFU_BRANCH='{}'\n\
+         KUNGFU_SHIFU_WORKTREE='{}'\n\
+         KUNGFU_SHIFU_BUILD_PATH='{}'\n",
+        version,
+        sha,
+        channel,
+        branch.replace('\'', ""),
+        worktree.replace('\'', ""),
+        build_path.replace('\'', "")
+    );
+    let path = installed_receipt_path();
+    let staged = path.with_extension("tmp");
+    if fs::write(&staged, text).is_ok() && fs::rename(&staged, &path).is_err() {
+        let _ = fs::remove_file(staged);
+    }
+}
+
+fn write_generation_installed_receipt(generation: &Generation) {
+    let text = format!(
+        "KUNGFU_ARTIFACT_SCHEMA='shifu.local-artifact/v1'\n\
+         KUNGFU_SHIFU_VERSION='{}'\n\
+         KUNGFU_SHIFU_SHA='{}'\n\
+         KUNGFU_SHIFU_CHANNEL='{}'\n\
+         KUNGFU_SHIFU_BRANCH='{}'\n\
+         KUNGFU_SHIFU_WORKTREE='{}'\n\
+         KUNGFU_SHIFU_BUILD_PATH='{}'\n",
+        generation.version,
+        generation.sha,
+        generation.channel,
+        generation.branch.replace('\'', ""),
+        generation.worktree.replace('\'', ""),
+        generation.build_path.replace('\'', "")
+    );
+    let path = installed_receipt_path();
+    let staged = path.with_extension("tmp");
+    if fs::write(&staged, text).is_ok() && fs::rename(&staged, &path).is_err() {
+        let _ = fs::remove_file(staged);
+    }
+}
+
 fn generations_keep() -> usize {
     env::var("KUNGFU_SHIFU_GENERATIONS_KEEP")
         .ok()
@@ -323,6 +639,9 @@ struct Generation {
     version: String,
     sha: String,
     channel: String,
+    branch: String,
+    worktree: String,
+    build_path: String,
     archived_at: u64,
 }
 
@@ -360,6 +679,9 @@ fn generations() -> Vec<Generation> {
                 version: get("KUNGFU_SHIFU_VERSION"),
                 sha: get("KUNGFU_SHIFU_SHA"),
                 channel: get("KUNGFU_SHIFU_CHANNEL"),
+                branch: get("KUNGFU_SHIFU_BRANCH"),
+                worktree: get("KUNGFU_SHIFU_WORKTREE"),
+                build_path: get("KUNGFU_SHIFU_BUILD_PATH"),
                 archived_at: get("KUNGFU_SHIFU_ARCHIVED_AT").parse().unwrap_or(0),
                 dir,
             })
@@ -384,6 +706,9 @@ fn age(archived_at: u64) -> String {
 /// Best-effort: an archive failure warns but never blocks the update.
 fn archive_current(exe: &Path) {
     let (version, sha, channel) = own_identity();
+    let branch = installed_provenance("KUNGFU_SHIFU_BRANCH");
+    let worktree = installed_provenance("KUNGFU_SHIFU_WORKTREE");
+    let build_path = installed_provenance("KUNGFU_SHIFU_BUILD_PATH");
     let slot = generations_dir().join(format!("{:012}-{sha}", epoch_now()));
     let staging = slot.with_extension("tmp");
     let _ = fs::remove_dir_all(&staging);
@@ -393,7 +718,9 @@ fn archive_current(exe: &Path) {
             staging.join("meta.env"),
             format!(
                 "KUNGFU_SHIFU_VERSION='{version}'\nKUNGFU_SHIFU_SHA='{sha}'\n\
-                 KUNGFU_SHIFU_CHANNEL='{channel}'\nKUNGFU_SHIFU_ARCHIVED_AT='{}'\n\
+                 KUNGFU_SHIFU_CHANNEL='{channel}'\nKUNGFU_SHIFU_BRANCH='{branch}'\n\
+                 KUNGFU_SHIFU_WORKTREE='{worktree}'\n\
+                 KUNGFU_SHIFU_BUILD_PATH='{build_path}'\nKUNGFU_SHIFU_ARCHIVED_AT='{}'\n\
                  KUNGFU_SHIFU_FROM='{}'\n",
                 epoch_now(),
                 exe.display()
@@ -417,32 +744,159 @@ fn archive_current(exe: &Path) {
     }
 }
 
-fn run_list() -> ! {
+fn run_list(root: Option<&Path>, options: &ListOptions) -> ! {
     let (version, sha, channel) = own_identity();
-    println!(
-        "{} shifu {version} (git {sha}, {channel})",
-        style::cyan("Installed:")
-    );
-    match newest_build_slot() {
-        Some(slot) => {
-            let line = identity_of(&slot).unwrap_or_else(|| slot.display().to_string());
-            println!("{} {line}", style::cyan("Local build slot:"));
-        }
-        None => println!("{} none", style::cyan("Local build slot:")),
-    }
+    let installed_branch = installed_provenance("KUNGFU_SHIFU_BRANCH");
+    let slots = build_slots();
     let generations = generations();
+    if options.json {
+        println!("{{");
+        println!("  \"schema\": \"shifu.local-artifact-catalog/v1\",");
+        println!("  \"product\": \"shifu\",");
+        println!("  \"platform\": \"{}\",", json_escape(&host::os_arch()));
+        println!("  \"artifacts\": [");
+        println!(
+            "    {{\"id\":\"installed\",\"kind\":\"shifu-binary\",\"version\":\"{}\",\"commit\":\"{}\",\"branch\":\"{}\",\"digest\":\"\",\"builtAt\":\"\",\"state\":\"current\",\"relation\":\"same\",\"automatic\":false,\"rollbackOnly\":false,\"dirty\":null,\"repoPath\":\"\",\"worktreePath\":\"\",\"buildPath\":\"\",\"artifactPath\":\"{}\",\"pathDigest\":\"\",\"reason\":\"currently installed\"}}{}",
+            json_escape(version),
+            json_escape(sha),
+            json_escape(&installed_branch),
+            json_escape(
+                &env::current_exe()
+                    .map(|p| p.display().to_string())
+                    .unwrap_or_default()
+            ),
+            if slots.is_empty() && generations.is_empty() { "" } else { "," }
+        );
+        let mut rows = Vec::new();
+        for slot in &slots {
+            let relation = slot_relation(slot, root);
+            let state = state_for(relation, slot.valid, false);
+            rows.push(format!(
+                "    {{\"id\":\"{}\",\"kind\":\"shifu-binary\",\"version\":\"{}\",\"commit\":\"{}\",\"branch\":\"{}\",\"digest\":\"\",\"builtAt\":\"{}\",\"state\":\"{}\",\"relation\":\"{}\",\"automatic\":{},\"rollbackOnly\":false,\"dirty\":null,\"repoPath\":\"{}\",\"worktreePath\":\"{}\",\"buildPath\":\"{}\",\"artifactPath\":\"{}\",\"pathDigest\":\"\",\"reason\":\"{}\"}}",
+                json_escape(&slot.id),
+                json_escape(&slot.version),
+                json_escape(&slot.sha),
+                json_escape(&slot.branch),
+                json_escape(&slot.built_at),
+                state.as_str(),
+                relation.as_str(),
+                automatic(relation, slot.valid, false),
+                json_escape(&slot.worktree),
+                json_escape(&slot.worktree),
+                json_escape(&slot.build_path),
+                json_escape(&slot.binary.display().to_string()),
+                if slot.valid { relation.as_str() } else { "identity unavailable" }
+            ));
+        }
+        for generation in &generations {
+            let relation = root
+                .map(|repo| git_relation(repo, sha, &generation.sha))
+                .unwrap_or(GitRelation::Unknown);
+            rows.push(format!(
+                "    {{\"id\":\"{}\",\"kind\":\"shifu-binary\",\"version\":\"{}\",\"commit\":\"{}\",\"branch\":\"{}\",\"digest\":\"\",\"builtAt\":\"{}\",\"state\":\"rollback\",\"relation\":\"{}\",\"automatic\":false,\"rollbackOnly\":true,\"dirty\":null,\"repoPath\":\"{}\",\"worktreePath\":\"{}\",\"buildPath\":\"{}\",\"artifactPath\":\"{}\",\"pathDigest\":\"\",\"reason\":\"rollback only\"}}",
+                json_escape(
+                    &generation
+                        .dir
+                        .file_name()
+                        .map(|name| name.to_string_lossy().to_string())
+                        .unwrap_or_default()
+                ),
+                json_escape(&generation.version),
+                json_escape(&generation.sha),
+                json_escape(&generation.branch),
+                generation.archived_at,
+                relation.as_str(),
+                json_escape(&generation.worktree),
+                json_escape(&generation.worktree),
+                json_escape(&generation.build_path),
+                json_escape(&generation.dir.join(binary_name()).display().to_string())
+            ));
+        }
+        println!("{}", rows.join(",\n"));
+        println!("  ]");
+        println!("}}");
+        std::process::exit(0)
+    }
+    println!(
+        "{} shifu {version} (git {sha}, {channel}) @ {}",
+        style::cyan("Installed:"),
+        if installed_branch.is_empty() {
+            "unknown"
+        } else {
+            &installed_branch
+        }
+    );
+    if slots.is_empty() {
+        println!("{} none", style::cyan("Local artifacts:"));
+    } else {
+        println!("{}", style::cyan("Local artifacts:"));
+        for (index, slot) in slots.iter().enumerate() {
+            let relation = slot_relation(slot, root);
+            let state = state_for(relation, slot.valid, false);
+            let branch = if slot.branch.is_empty() {
+                "unknown".to_string()
+            } else {
+                compact_branch(&slot.branch, options.no_truncate)
+            };
+            println!(
+                "  {} {:10} {:9} {:34} {:10}",
+                style::bold(&format!("[{index}]")),
+                state.as_str(),
+                short_sha(&slot.sha),
+                branch,
+                relation.as_str()
+            );
+            if options.verbose {
+                println!(
+                    "      id={} built={} channel={}\n      artifact={}\n      worktree={}\n      build={}",
+                    slot.id,
+                    if slot.built_at.is_empty() { "unknown" } else { &slot.built_at },
+                    slot.channel,
+                    slot.binary.display(),
+                    if slot.worktree.is_empty() { "unknown" } else { &slot.worktree },
+                    if slot.build_path.is_empty() { "unknown" } else { &slot.build_path }
+                );
+            }
+        }
+    }
     if generations.is_empty() {
         println!("{} none yet", style::cyan("Generations:"));
     } else {
         println!("{}", style::cyan("Generations (newest first):"));
         for (index, generation) in generations.iter().enumerate() {
             println!(
-                "  [{index}] shifu {} (git {}, {}) {}",
-                generation.version,
-                generation.sha,
-                generation.channel,
+                "  [{index}] rollback   {:9} {:34} {:10} {}",
+                short_sha(&generation.sha),
+                compact_branch(
+                    if generation.branch.is_empty() {
+                        "unknown"
+                    } else {
+                        &generation.branch
+                    },
+                    options.no_truncate
+                ),
+                root.map(|repo| git_relation(repo, sha, &generation.sha).as_str())
+                    .unwrap_or("unknown"),
                 style::dim(&age(generation.archived_at)),
             );
+            if options.verbose {
+                println!(
+                    "      shifu {} ({})\n      artifact={}\n      worktree={}\n      build={}",
+                    generation.version,
+                    generation.channel,
+                    generation.dir.join(binary_name()).display(),
+                    if generation.worktree.is_empty() {
+                        "unknown"
+                    } else {
+                        &generation.worktree
+                    },
+                    if generation.build_path.is_empty() {
+                        "unknown"
+                    } else {
+                        &generation.build_path
+                    }
+                );
+            }
         }
         println!(
             "\n{} shifu self-update --rollback restores [0]",
@@ -480,6 +934,35 @@ fn run_rollback(exe: &Path) -> ! {
     }
     archive_current(exe);
     replace_binary(exe, &staging.join(binary_name()));
+    write_generation_installed_receipt(&generation);
+    let relation = {
+        let repo = Path::new(&generation.worktree);
+        if generation.sha == own_identity().1 {
+            GitRelation::Same
+        } else if repo.is_dir() {
+            git_relation(repo, own_identity().1, &generation.sha)
+        } else {
+            GitRelation::Unknown
+        }
+    };
+    if let Err(error) = write_promotion_receipt(
+        &host::kungfu_cache_dir().join("shifu"),
+        "shifu",
+        "rollback",
+        &generation
+            .dir
+            .file_name()
+            .map(|name| name.to_string_lossy().to_string())
+            .unwrap_or_default(),
+        own_identity().1,
+        &generation.sha,
+        relation,
+    ) {
+        eprintln!(
+            "   {}",
+            style::yellow(&format!("could not write rollback receipt: {error}"))
+        );
+    }
     let _ = fs::remove_dir_all(&staging);
     eprintln!(
         "\u{2705} {} {}",

--- a/crates/shifu/src/self_update.rs
+++ b/crates/shifu/src/self_update.rs
@@ -294,6 +294,7 @@ struct BuildSlot {
     sha: String,
     channel: String,
     branch: String,
+    repo: String,
     worktree: String,
     build_path: String,
     built_at: String,
@@ -369,6 +370,7 @@ fn build_slots() -> Vec<BuildSlot> {
             sha: sha.clone(),
             channel,
             branch: meta_value(&dir, "KUNGFU_ARTIFACT_BRANCH"),
+            repo: meta_value(&dir, "KUNGFU_ARTIFACT_REPO"),
             worktree: meta_value(&dir, "KUNGFU_ARTIFACT_WORKTREE"),
             build_path: meta_value(&dir, "KUNGFU_ARTIFACT_BUILD_PATH"),
             built_at: meta_value(&dir, "KUNGFU_ARTIFACT_BUILT_AT"),
@@ -398,8 +400,25 @@ fn git_output(root: &Path, args: &[&str]) -> String {
 
 fn slot_relation(slot: &BuildSlot, fallback_root: Option<&Path>) -> GitRelation {
     let worktree = Path::new(&slot.worktree);
-    let repo = worktree.is_dir().then_some(worktree).or(fallback_root);
+    let canonical = Path::new(&slot.repo);
+    let repo = worktree
+        .is_dir()
+        .then_some(worktree)
+        .or(fallback_root)
+        .or_else(|| canonical.is_dir().then_some(canonical));
     repo.map(|root| git_relation(root, own_identity().1, &slot.sha))
+        .unwrap_or(GitRelation::Unknown)
+}
+
+fn generation_relation(generation: &Generation, fallback_root: Option<&Path>) -> GitRelation {
+    let worktree = Path::new(&generation.worktree);
+    let canonical = Path::new(&generation.repo);
+    worktree
+        .is_dir()
+        .then_some(worktree)
+        .or(fallback_root)
+        .or_else(|| canonical.is_dir().then_some(canonical))
+        .map(|root| git_relation(root, own_identity().1, &generation.sha))
         .unwrap_or(GitRelation::Unknown)
 }
 
@@ -407,9 +426,12 @@ fn candidate_relation(binary: &Path, source_root: Option<&Path>) -> GitRelation 
     let candidate_sha = identity_parts(binary).1;
     let parent = binary.parent().unwrap_or_else(|| Path::new(""));
     let recorded_worktree = meta_value(parent, "KUNGFU_ARTIFACT_WORKTREE");
+    let recorded_repo = meta_value(parent, "KUNGFU_ARTIFACT_REPO");
     let recorded_root = Path::new(&recorded_worktree);
+    let canonical_root = Path::new(&recorded_repo);
     source_root
         .or_else(|| recorded_root.is_dir().then_some(recorded_root))
+        .or_else(|| canonical_root.is_dir().then_some(canonical_root))
         .map(|repo| git_relation(repo, own_identity().1, &candidate_sha))
         .unwrap_or(GitRelation::Unknown)
 }
@@ -563,6 +585,16 @@ fn write_installed_receipt(binary: &Path, source_root: Option<&Path>) {
         .map(|root| git_output(root, &["symbolic-ref", "--short", "HEAD"]))
         .filter(|value| !value.is_empty())
         .unwrap_or_else(|| meta_value(parent, "KUNGFU_ARTIFACT_BRANCH"));
+    let repo = source_root
+        .map(|root| {
+            git_output(root, &["worktree", "list", "--porcelain"])
+                .lines()
+                .find_map(|line| line.strip_prefix("worktree "))
+                .unwrap_or("")
+                .to_string()
+        })
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| meta_value(parent, "KUNGFU_ARTIFACT_REPO"));
     let worktree = source_root
         .map(|root| root.display().to_string())
         .unwrap_or_else(|| meta_value(parent, "KUNGFU_ARTIFACT_WORKTREE"));
@@ -580,12 +612,14 @@ fn write_installed_receipt(binary: &Path, source_root: Option<&Path>) {
          KUNGFU_SHIFU_SHA='{}'\n\
          KUNGFU_SHIFU_CHANNEL='{}'\n\
          KUNGFU_SHIFU_BRANCH='{}'\n\
+         KUNGFU_SHIFU_REPO='{}'\n\
          KUNGFU_SHIFU_WORKTREE='{}'\n\
          KUNGFU_SHIFU_BUILD_PATH='{}'\n",
         version,
         sha,
         channel,
         branch.replace('\'', ""),
+        repo.replace('\'', ""),
         worktree.replace('\'', ""),
         build_path.replace('\'', "")
     );
@@ -603,12 +637,14 @@ fn write_generation_installed_receipt(generation: &Generation) {
          KUNGFU_SHIFU_SHA='{}'\n\
          KUNGFU_SHIFU_CHANNEL='{}'\n\
          KUNGFU_SHIFU_BRANCH='{}'\n\
+         KUNGFU_SHIFU_REPO='{}'\n\
          KUNGFU_SHIFU_WORKTREE='{}'\n\
          KUNGFU_SHIFU_BUILD_PATH='{}'\n",
         generation.version,
         generation.sha,
         generation.channel,
         generation.branch.replace('\'', ""),
+        generation.repo.replace('\'', ""),
         generation.worktree.replace('\'', ""),
         generation.build_path.replace('\'', "")
     );
@@ -640,6 +676,7 @@ struct Generation {
     sha: String,
     channel: String,
     branch: String,
+    repo: String,
     worktree: String,
     build_path: String,
     archived_at: u64,
@@ -680,6 +717,7 @@ fn generations() -> Vec<Generation> {
                 sha: get("KUNGFU_SHIFU_SHA"),
                 channel: get("KUNGFU_SHIFU_CHANNEL"),
                 branch: get("KUNGFU_SHIFU_BRANCH"),
+                repo: get("KUNGFU_SHIFU_REPO"),
                 worktree: get("KUNGFU_SHIFU_WORKTREE"),
                 build_path: get("KUNGFU_SHIFU_BUILD_PATH"),
                 archived_at: get("KUNGFU_SHIFU_ARCHIVED_AT").parse().unwrap_or(0),
@@ -707,6 +745,7 @@ fn age(archived_at: u64) -> String {
 fn archive_current(exe: &Path) {
     let (version, sha, channel) = own_identity();
     let branch = installed_provenance("KUNGFU_SHIFU_BRANCH");
+    let repo = installed_provenance("KUNGFU_SHIFU_REPO");
     let worktree = installed_provenance("KUNGFU_SHIFU_WORKTREE");
     let build_path = installed_provenance("KUNGFU_SHIFU_BUILD_PATH");
     let slot = generations_dir().join(format!("{:012}-{sha}", epoch_now()));
@@ -719,6 +758,7 @@ fn archive_current(exe: &Path) {
             format!(
                 "KUNGFU_SHIFU_VERSION='{version}'\nKUNGFU_SHIFU_SHA='{sha}'\n\
                  KUNGFU_SHIFU_CHANNEL='{channel}'\nKUNGFU_SHIFU_BRANCH='{branch}'\n\
+                 KUNGFU_SHIFU_REPO='{repo}'\n\
                  KUNGFU_SHIFU_WORKTREE='{worktree}'\n\
                  KUNGFU_SHIFU_BUILD_PATH='{build_path}'\nKUNGFU_SHIFU_ARCHIVED_AT='{}'\n\
                  KUNGFU_SHIFU_FROM='{}'\n",
@@ -781,7 +821,7 @@ fn run_list(root: Option<&Path>, options: &ListOptions) -> ! {
                 state.as_str(),
                 relation.as_str(),
                 automatic(relation, slot.valid, false),
-                json_escape(&slot.worktree),
+                json_escape(&slot.repo),
                 json_escape(&slot.worktree),
                 json_escape(&slot.build_path),
                 json_escape(&slot.binary.display().to_string()),
@@ -789,9 +829,7 @@ fn run_list(root: Option<&Path>, options: &ListOptions) -> ! {
             ));
         }
         for generation in &generations {
-            let relation = root
-                .map(|repo| git_relation(repo, sha, &generation.sha))
-                .unwrap_or(GitRelation::Unknown);
+            let relation = generation_relation(generation, root);
             rows.push(format!(
                 "    {{\"id\":\"{}\",\"kind\":\"shifu-binary\",\"version\":\"{}\",\"commit\":\"{}\",\"branch\":\"{}\",\"digest\":\"\",\"builtAt\":\"{}\",\"state\":\"rollback\",\"relation\":\"{}\",\"automatic\":false,\"rollbackOnly\":true,\"dirty\":null,\"repoPath\":\"{}\",\"worktreePath\":\"{}\",\"buildPath\":\"{}\",\"artifactPath\":\"{}\",\"pathDigest\":\"\",\"reason\":\"rollback only\"}}",
                 json_escape(
@@ -806,7 +844,7 @@ fn run_list(root: Option<&Path>, options: &ListOptions) -> ! {
                 json_escape(&generation.branch),
                 generation.archived_at,
                 relation.as_str(),
-                json_escape(&generation.worktree),
+                json_escape(&generation.repo),
                 json_escape(&generation.worktree),
                 json_escape(&generation.build_path),
                 json_escape(&generation.dir.join(binary_name()).display().to_string())
@@ -848,11 +886,12 @@ fn run_list(root: Option<&Path>, options: &ListOptions) -> ! {
             );
             if options.verbose {
                 println!(
-                    "      id={} built={} channel={}\n      artifact={}\n      worktree={}\n      build={}",
+                    "      id={} built={} channel={}\n      artifact={}\n      repo={}\n      worktree={}\n      build={}",
                     slot.id,
                     if slot.built_at.is_empty() { "unknown" } else { &slot.built_at },
                     slot.channel,
                     slot.binary.display(),
+                    if slot.repo.is_empty() { "unknown" } else { &slot.repo },
                     if slot.worktree.is_empty() { "unknown" } else { &slot.worktree },
                     if slot.build_path.is_empty() { "unknown" } else { &slot.build_path }
                 );
@@ -875,16 +914,20 @@ fn run_list(root: Option<&Path>, options: &ListOptions) -> ! {
                     },
                     options.no_truncate
                 ),
-                root.map(|repo| git_relation(repo, sha, &generation.sha).as_str())
-                    .unwrap_or("unknown"),
+                generation_relation(generation, root).as_str(),
                 style::dim(&age(generation.archived_at)),
             );
             if options.verbose {
                 println!(
-                    "      shifu {} ({})\n      artifact={}\n      worktree={}\n      build={}",
+                    "      shifu {} ({})\n      artifact={}\n      repo={}\n      worktree={}\n      build={}",
                     generation.version,
                     generation.channel,
                     generation.dir.join(binary_name()).display(),
+                    if generation.repo.is_empty() {
+                        "unknown"
+                    } else {
+                        &generation.repo
+                    },
                     if generation.worktree.is_empty() {
                         "unknown"
                     } else {
@@ -935,15 +978,10 @@ fn run_rollback(exe: &Path) -> ! {
     archive_current(exe);
     replace_binary(exe, &staging.join(binary_name()));
     write_generation_installed_receipt(&generation);
-    let relation = {
-        let repo = Path::new(&generation.worktree);
-        if generation.sha == own_identity().1 {
-            GitRelation::Same
-        } else if repo.is_dir() {
-            git_relation(repo, own_identity().1, &generation.sha)
-        } else {
-            GitRelation::Unknown
-        }
+    let relation = if generation.sha == own_identity().1 {
+        GitRelation::Same
+    } else {
+        generation_relation(&generation, None)
     };
     if let Err(error) = write_promotion_receipt(
         &host::kungfu_cache_dir().join("shifu"),

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -145,6 +145,7 @@ implemented and qualified or explicitly waived for that release.
 | [0073](ADR-0073-buildchain-adr-release-admissibility.md) | accepted | Buildchain promotion is the settlement boundary for ADR implementation truth: dev declares bounded delivery, alpha settles qualified progress, and stable admits no unaccounted accepted decision |
 | [0074](ADR-0074-canonical-adr-authority-and-lifecycle-audit.md) | accepted | `docs/adr/` is the sole Core and Shifu decision authority, with typed redirects and executable lifecycle, evidence, and release audit |
 | [SHIFU-0001](SHIFU-ADR-0001-cache-profile-contract-and-ownership.md) | accepted | Cache profiles are Shifu-owned contracts; inventories project instances and Buildchain owns process |
+| [SHIFU-0002](SHIFU-ADR-0002-local-artifact-catalog-and-safe-promotion.md) | accepted | Shifu and Kungfu product artifacts share provenance-aware, Git-safe local promotion semantics |
 
 ## Reading by theme
 

--- a/docs/adr/SHIFU-ADR-0002-local-artifact-catalog-and-safe-promotion.md
+++ b/docs/adr/SHIFU-ADR-0002-local-artifact-catalog-and-safe-promotion.md
@@ -1,0 +1,102 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+doc_type: architecture-decision
+adr_id: SHIFU-ADR-0002
+decision_status: accepted
+implementation_status: not-started
+review_state: unreviewed
+sensitivity: public
+sources: [local-files, user-consensus]
+period: ongoing
+theme: shifu-local-artifact-catalog
+confidence: high
+evidence_grade: B
+last_reviewed: 2026-07-13
+---
+
+# SHIFU-ADR-0002: Local artifact catalog and safe promotion
+
+- Status: accepted; development implementation
+- Date: 2026-07-13
+- Scope: Shifu launcher and locally registered Kungfu product artifacts
+- Related: [ADR-0044](./ADR-0044-shifu-delegation-protocol.md) and
+  [SHIFU-ADR-0001](./SHIFU-ADR-0001-cache-profile-contract-and-ownership.md)
+
+## Context
+
+Shifu has two local promotion paths. `self-update` replaces the installed Shifu
+binary from checkout source, a release, or a launcher cache slot. `builds` and
+`promote` list and install registered Kungfu product artifacts. Both paths
+currently treat recency as authority: launcher slots use filesystem modification
+time and product builds use timestamped slot names.
+
+Recency is not Git history. A newer build time can belong to an older or
+divergent feature branch. It can therefore silently replace a descendant that
+was already installed. The existing records also expose different provenance:
+product builds record branch and worktree, while Shifu generations record only
+version, commit, channel, and archive time.
+
+## Decision
+
+Shifu owns one versioned local artifact catalog contract shared by launcher and
+product promotion. Product-specific code remains responsible for building and
+installing bytes; the shared substrate owns identity, provenance, Git relation,
+candidate disposition, display, retention state, and promotion receipts.
+
+Each record identifies its product, artifact kind, version, digest, source
+commit, build-time branch, repository, worktree/build path, dirty state,
+platform, timestamps, lifecycle state, and available promotion provenance.
+Missing legacy fields remain explicit rather than inferred.
+
+Candidate resolution compares the candidate commit with the installed commit:
+
+- `same` is idempotent;
+- one unique `descendant` may advance automatically;
+- `ancestor`, `diverged`, `unknown`, ambiguous, and invalid artifacts are
+  manual-only or unusable and never win through timestamp ordering;
+- an explicit override names the artifact and acknowledges non-linear history;
+- rollback-only generations never re-enter automatic candidate selection.
+
+After a successful descendant promotion, strict ancestor build slots become
+`superseded` and leave the automatic candidate pool. Implementations may remove
+superseded build slots under their bounded retention policy. Rollback
+generations remain a separate bounded ledger so pruning candidates does not
+erase the immediate recovery path.
+
+Human list output is compact by default but must remain identifying. Long
+branches use middle truncation: preserve the branch-kind prefix, at least twelve
+characters after it, and a useful suffix. `--no-truncate` prints full branch
+names; `--verbose` adds full local paths and digests; `--json` emits the exact
+catalog contract.
+
+The canonical schema is
+[`local-artifact-catalog-v1.schema.json`](../shifu/schema/local-artifact-catalog-v1.schema.json).
+Local paths are allowed in explicitly local output. Portable or externally
+reported receipts redact them to path digests.
+
+## Compatibility
+
+Legacy `meta.env` slots remain readable. New optional provenance keys are
+additive. Missing repository, branch, digest, or installed-receipt fields yield
+`unknown` relation and fail closed for automatic promotion. The catalog schema
+major version changes if field meaning or candidate safety semantics change.
+
+## Consequences
+
+- Developers can distinguish builds without reconstructing worktree history.
+- A newer wall-clock build cannot silently override Git ancestry.
+- `self-update` and `builds/promote` share one mental model and test matrix.
+- Local paths are diagnostic provenance, not portable identity.
+- Existing cache directories remain disposable implementation storage; the
+  catalog is evidence about artifacts, not a second source repository.
+
+## Alternatives considered
+
+- **Keep per-command metadata and improve formatting only** — rejected because
+  the unsafe selection rule would remain duplicated.
+- **Treat build time as the version order** — rejected because branches are not
+  linearly ordered by time.
+- **Delete all older artifacts after promotion** — rejected because candidates
+  and rollback generations have different recovery responsibilities.
+- **Always require an explicit artifact id** — rejected because a unique Git
+  descendant is safe and should remain convenient.

--- a/docs/adr/SHIFU-ADR-0002-local-artifact-catalog-and-safe-promotion.md
+++ b/docs/adr/SHIFU-ADR-0002-local-artifact-catalog-and-safe-promotion.md
@@ -3,7 +3,8 @@ metadata_schema: kungfu.document-metadata/v1
 doc_type: architecture-decision
 adr_id: SHIFU-ADR-0002
 decision_status: accepted
-implementation_status: not-started
+implementation_status: partial
+implementation_commits: [c0ae2970240ce3bb2ff2320065797899e28a69ea]
 review_state: unreviewed
 sensitivity: public
 sources: [local-files, user-consensus]

--- a/docs/adr/SHIFU-ADR-0002-local-artifact-catalog-and-safe-promotion.md
+++ b/docs/adr/SHIFU-ADR-0002-local-artifact-catalog-and-safe-promotion.md
@@ -4,7 +4,7 @@ doc_type: architecture-decision
 adr_id: SHIFU-ADR-0002
 decision_status: accepted
 implementation_status: partial
-implementation_commits: [c0ae2970240ce3bb2ff2320065797899e28a69ea]
+implementation_commits: [c0ae2970240ce3bb2ff2320065797899e28a69ea, 1935a89c8dcb0418cdf587a0007dcd135d2230c7]
 review_state: unreviewed
 sensitivity: public
 sources: [local-files, user-consensus]

--- a/docs/rust-adoption.md
+++ b/docs/rust-adoption.md
@@ -202,9 +202,10 @@ per-platform special-casing) with one binary that:
 - `shifu clone [path]` fetches the repository itself and `shifu doctor`
   checks the development environment (install pointers for the heavyweight
   prerequisites it deliberately does not manage); `shifu promote` installs
-  the freshest built dev product from the user-global build stash (successful
-  desktop builds register themselves there, so a cleaned worktree cannot
-  strand its build) and `shifu builds` lists that stash — the jurisdiction
+  the unique Git-descendant dev product from the user-global build stash
+  (successful desktop builds register themselves there, so a cleaned worktree
+  cannot strand its build) and `shifu builds` lists provenance and Git
+  relation for that stash — the jurisdiction
   siblings of clone: clone acquires the repository, promote acquires the
   product. Together with delegation
   this makes an installed shifu a self-sufficient bootstrap core: install
@@ -260,6 +261,14 @@ stash is fed by declaration, not by script. A repo that wants its builds
 registered states the facts in its Buildchain-managed KFD-3 surface registry
 (`.buildchain/kfd/kfd-3/surfaces.json`), on the surface that produces the
 artifact:
+
+Both commands consume the same local artifact contract as `self-update`.
+Timestamp order never authorizes promotion: one unique descendant advances
+automatically, while ancestor, divergent, and unknown builds require explicit
+selection. Compact lists retain an identifying branch prefix/suffix;
+`--no-truncate`, `--verbose`, and `--json` expose progressively more local
+provenance. The exact contract and schemas are available through
+`shifu artifacts contract|schema|receipt-schema`.
 
 ```json
 "distribution": {

--- a/docs/shifu/README.md
+++ b/docs/shifu/README.md
@@ -12,6 +12,9 @@ execution; Shifu owns how the task is executed after source checkout.
 - [`cache-contract.json`](cache-contract.json) is the machine-readable contract
   manifest and the discovery root for schema paths, schema IDs, ownership, and
   compatibility rules.
+- [`artifact-contract.json`](artifact-contract.json) is the machine-readable
+  discovery root for local build provenance and safe promotion semantics shared
+  by `self-update` and `builds/promote`.
 - [`schema/cache-profile-v1.schema.json`](schema/cache-profile-v1.schema.json)
   is the single source of truth for cache profile fields.
 - [`schema/cache-resolution-v1.schema.json`](schema/cache-resolution-v1.schema.json)
@@ -39,6 +42,9 @@ package:
 ./shifu cache doctor --json [--probe]
 ./shifu cache use --profile path/to/cache-profile.json --digest sha256:... [--execute]
 ./shifu cache unset [--execute]
+./shifu artifacts contract
+./shifu artifacts schema
+./shifu artifacts receipt-schema
 ```
 
 The contract and schema discovery commands print the exact checked-in JSON.

--- a/docs/shifu/artifact-contract.json
+++ b/docs/shifu/artifact-contract.json
@@ -1,0 +1,18 @@
+{
+  "schema": "shifu.local-artifact-contract/v1",
+  "owner": "shifu",
+  "decision": "docs/adr/SHIFU-ADR-0002-local-artifact-catalog-and-safe-promotion.md",
+  "catalogSchema": "docs/shifu/schema/local-artifact-catalog-v1.schema.json",
+  "promotionReceiptSchema": "docs/shifu/schema/local-promotion-receipt-v1.schema.json",
+  "consumers": [
+    "shifu self-update",
+    "shifu builds",
+    "shifu promote"
+  ],
+  "selection": {
+    "automatic": ["same", "descendant"],
+    "manual": ["ancestor", "diverged", "unknown"],
+    "rollbackOnlyIsCandidate": false,
+    "recencyIsAuthority": false
+  }
+}

--- a/docs/shifu/schema/local-artifact-catalog-v1.schema.json
+++ b/docs/shifu/schema/local-artifact-catalog-v1.schema.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kungfu.dev/schema/shifu/local-artifact-catalog-v1.schema.json",
+  "title": "Shifu local artifact catalog v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "product", "platform", "artifacts"],
+  "properties": {
+    "schema": { "const": "shifu.local-artifact-catalog/v1" },
+    "product": { "type": "string", "minLength": 1 },
+    "platform": { "type": "string", "minLength": 1 },
+    "artifacts": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/artifact" }
+    }
+  },
+  "$defs": {
+    "artifact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id", "kind", "version", "commit", "branch", "digest",
+        "builtAt", "state", "relation", "automatic", "rollbackOnly"
+      ],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "kind": { "enum": ["shifu-binary", "app", "installer", "appimage", "unknown"] },
+        "version": { "type": "string" },
+        "commit": { "type": "string" },
+        "branch": { "type": "string" },
+        "digest": { "type": "string" },
+        "builtAt": { "type": "string" },
+        "state": { "enum": ["current", "candidate", "manual", "superseded", "rollback", "invalid"] },
+        "relation": { "enum": ["same", "descendant", "ancestor", "diverged", "unknown"] },
+        "automatic": { "type": "boolean" },
+        "rollbackOnly": { "type": "boolean" },
+        "dirty": { "type": ["boolean", "null"] },
+        "repoPath": { "type": "string" },
+        "worktreePath": { "type": "string" },
+        "buildPath": { "type": "string" },
+        "artifactPath": { "type": "string" },
+        "pathDigest": { "type": "string" },
+        "reason": { "type": "string" }
+      }
+    }
+  }
+}

--- a/docs/shifu/schema/local-promotion-receipt-v1.schema.json
+++ b/docs/shifu/schema/local-promotion-receipt-v1.schema.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kungfu.dev/schema/shifu/local-promotion-receipt-v1.schema.json",
+  "title": "Shifu local promotion receipt v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema", "product", "action", "artifactId", "fromCommit",
+    "toCommit", "relation", "occurredAt"
+  ],
+  "properties": {
+    "schema": { "const": "shifu.local-promotion-receipt/v1" },
+    "product": { "type": "string", "minLength": 1 },
+    "action": { "enum": ["promote", "self-update", "rollback"] },
+    "artifactId": { "type": "string" },
+    "fromCommit": { "type": "string" },
+    "toCommit": { "type": "string" },
+    "relation": { "enum": ["same", "descendant", "ancestor", "diverged", "unknown"] },
+    "occurredAt": { "type": "integer", "minimum": 0 }
+  }
+}

--- a/shifu
+++ b/shifu
@@ -118,7 +118,31 @@ kungfu_native_build() {
   mkdir -p "$(dirname "$_dest")" "$_tgt"
   if CARGO_TARGET_DIR="$_tgt" cargo build --release --locked --manifest-path crates/Cargo.toml -p shifu >&2; then
     _built="$_tgt/release/$(kungfu_native_binname "$(kungfu_native_platform)")"
-    cp "$_built" "${_dest}.tmp" && chmod +x "${_dest}.tmp" && mv "${_dest}.tmp" "$_dest" && return 0
+    if cp "$_built" "${_dest}.tmp" && chmod +x "${_dest}.tmp" && mv "${_dest}.tmp" "$_dest"; then
+      _meta="$(dirname "$_dest")/meta.env"
+      _sha="$(git rev-parse HEAD 2>/dev/null || true)"
+      _branch="$(git symbolic-ref --short HEAD 2>/dev/null || echo detached)"
+      _dirty=false
+      # shellcheck disable=SC2086
+      [ -n "$(git status --porcelain -- $KUNGFU_LAUNCHER_SRC 2>/dev/null)" ] && _dirty=true
+      # Single quotes are the meta.env delimiter; branch/path provenance is
+      # diagnostic, so strip an embedded quote rather than creating code.
+      _branch="$(printf %s "$_branch" | tr -d "'")"
+      _worktree="$(printf %s "$PWD" | tr -d "'")"
+      {
+        printf "KUNGFU_ARTIFACT_SCHEMA='shifu.local-artifact/v1'\n"
+        printf "KUNGFU_ARTIFACT_PRODUCT='shifu'\n"
+        printf "KUNGFU_ARTIFACT_SHA='%s'\n" "$_sha"
+        printf "KUNGFU_ARTIFACT_BRANCH='%s'\n" "$_branch"
+        printf "KUNGFU_ARTIFACT_WORKTREE='%s'\n" "$_worktree"
+        printf "KUNGFU_ARTIFACT_BUILD_PATH='%s'\n" "$_tgt"
+        printf "KUNGFU_ARTIFACT_BUILT_AT='%s'\n" "$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+        printf "KUNGFU_ARTIFACT_DIRTY='%s'\n" "$_dirty"
+      } > "${_meta}.tmp"
+      mv "${_meta}.tmp" "$_meta"
+      unset _meta _sha _branch _dirty _worktree
+      return 0
+    fi
     rm -f "${_dest}.tmp"
   fi
   return 1
@@ -231,10 +255,9 @@ if [ "${SHIFU_NATIVE:-}" != "0" ]; then
       *) if [ -x "$kungfu_dev_bin" ]; then exec "$kungfu_dev_bin" "$@"; fi ;;
     esac
     if kungfu_native_build "$kungfu_dev_bin"; then
-      # Retire older source-keyed slots; the release-pinned slot stays.
-      for _slot in "${kungfu_cache_root}/${kungfu_ver}-"*; do
-        [ -d "$_slot" ] && [ "$_slot" != "$kungfu_dev_dir" ] && rm -rf "$_slot"
-      done
+      # Source slots are catalog entries. The native catalog retires only
+      # proven ancestors after a successful promotion; recency alone must not
+      # delete a divergent worktree's provenance.
       exec "$kungfu_dev_bin" "$@"
     fi
     echo "shifu: source build failed; falling back to the release-pinned launcher" >&2

--- a/shifu
+++ b/shifu
@@ -122,25 +122,28 @@ kungfu_native_build() {
       _meta="$(dirname "$_dest")/meta.env"
       _sha="$(git rev-parse HEAD 2>/dev/null || true)"
       _branch="$(git symbolic-ref --short HEAD 2>/dev/null || echo detached)"
+      _repo="$(git worktree list --porcelain 2>/dev/null | sed -n 's/^worktree //p' | head -n 1)"
       _dirty=false
       # shellcheck disable=SC2086
       [ -n "$(git status --porcelain -- $KUNGFU_LAUNCHER_SRC 2>/dev/null)" ] && _dirty=true
       # Single quotes are the meta.env delimiter; branch/path provenance is
       # diagnostic, so strip an embedded quote rather than creating code.
       _branch="$(printf %s "$_branch" | tr -d "'")"
+      _repo="$(printf %s "$_repo" | tr -d "'")"
       _worktree="$(printf %s "$PWD" | tr -d "'")"
       {
         printf "KUNGFU_ARTIFACT_SCHEMA='shifu.local-artifact/v1'\n"
         printf "KUNGFU_ARTIFACT_PRODUCT='shifu'\n"
         printf "KUNGFU_ARTIFACT_SHA='%s'\n" "$_sha"
         printf "KUNGFU_ARTIFACT_BRANCH='%s'\n" "$_branch"
+        printf "KUNGFU_ARTIFACT_REPO='%s'\n" "$_repo"
         printf "KUNGFU_ARTIFACT_WORKTREE='%s'\n" "$_worktree"
         printf "KUNGFU_ARTIFACT_BUILD_PATH='%s'\n" "$_tgt"
         printf "KUNGFU_ARTIFACT_BUILT_AT='%s'\n" "$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
         printf "KUNGFU_ARTIFACT_DIRTY='%s'\n" "$_dirty"
       } > "${_meta}.tmp"
       mv "${_meta}.tmp" "$_meta"
-      unset _meta _sha _branch _dirty _worktree
+      unset _meta _sha _branch _repo _dirty _worktree
       return 0
     fi
     rm -f "${_dest}.tmp"

--- a/shifu.cmd
+++ b/shifu.cmd
@@ -139,10 +139,25 @@ cargo build --release --locked --manifest-path crates\Cargo.toml -p shifu 1>&2 &
   set "CARGO_TARGET_DIR="
   if not exist "%_KFC_DEVDIR%" mkdir "%_KFC_DEVDIR%" >nul 2>nul
   copy /y "%_KFC_TGT%\release\shifu.exe" "%_KFC_DEVBIN%" >nul && (
-    rem Retire older source-keyed slots; the release-pinned slot stays.
-    for /d %%d in ("%_KFC_CACHE%\kungfu\shifu\%_KFC_VER%-*") do (
-      if /i not "%%~fd"=="%_KFC_DEVDIR%" rd /s /q "%%~fd" >nul 2>nul
-    )
+    set "_KFC_HEAD="
+    set "_KFC_BRANCH=detached"
+    for /f "usebackq" %%s in (`git rev-parse HEAD 2^>nul`) do set "_KFC_HEAD=%%s"
+    for /f "usebackq" %%s in (`git symbolic-ref --short HEAD 2^>nul`) do set "_KFC_BRANCH=%%s"
+    set "_KFC_DIRTY_VALUE=false"
+    if defined _KFC_DIRTY set "_KFC_DIRTY_VALUE=true"
+    (
+      echo KUNGFU_ARTIFACT_SCHEMA='shifu.local-artifact/v1'
+      echo KUNGFU_ARTIFACT_PRODUCT='shifu'
+      echo KUNGFU_ARTIFACT_SHA='!_KFC_HEAD!'
+      echo KUNGFU_ARTIFACT_BRANCH='!_KFC_BRANCH!'
+      echo KUNGFU_ARTIFACT_WORKTREE='!CD!'
+      echo KUNGFU_ARTIFACT_BUILD_PATH='!_KFC_TGT!'
+      echo KUNGFU_ARTIFACT_BUILT_AT='unknown'
+      echo KUNGFU_ARTIFACT_DIRTY='!_KFC_DIRTY_VALUE!'
+    ) > "%_KFC_DEVDIR%\meta.env.tmp"
+    move /y "%_KFC_DEVDIR%\meta.env.tmp" "%_KFC_DEVDIR%\meta.env" >nul
+    rem Source slots are catalog entries. The native catalog retires only
+    rem proven ancestors after a successful promotion.
     "%_KFC_DEVBIN%" %*
     exit /b !errorlevel!
   )

--- a/shifu.cmd
+++ b/shifu.cmd
@@ -141,8 +141,12 @@ cargo build --release --locked --manifest-path crates\Cargo.toml -p shifu 1>&2 &
   copy /y "%_KFC_TGT%\release\shifu.exe" "%_KFC_DEVBIN%" >nul && (
     set "_KFC_HEAD="
     set "_KFC_BRANCH=detached"
+    set "_KFC_REPO="
     for /f "usebackq" %%s in (`git rev-parse HEAD 2^>nul`) do set "_KFC_HEAD=%%s"
     for /f "usebackq" %%s in (`git symbolic-ref --short HEAD 2^>nul`) do set "_KFC_BRANCH=%%s"
+    for /f "usebackq tokens=1,*" %%a in (`git worktree list --porcelain 2^>nul`) do (
+      if "%%a"=="worktree" if not defined _KFC_REPO set "_KFC_REPO=%%b"
+    )
     set "_KFC_DIRTY_VALUE=false"
     if defined _KFC_DIRTY set "_KFC_DIRTY_VALUE=true"
     (
@@ -150,6 +154,7 @@ cargo build --release --locked --manifest-path crates\Cargo.toml -p shifu 1>&2 &
       echo KUNGFU_ARTIFACT_PRODUCT='shifu'
       echo KUNGFU_ARTIFACT_SHA='!_KFC_HEAD!'
       echo KUNGFU_ARTIFACT_BRANCH='!_KFC_BRANCH!'
+      echo KUNGFU_ARTIFACT_REPO='!_KFC_REPO!'
       echo KUNGFU_ARTIFACT_WORKTREE='!CD!'
       echo KUNGFU_ARTIFACT_BUILD_PATH='!_KFC_TGT!'
       echo KUNGFU_ARTIFACT_BUILT_AT='unknown'


### PR DESCRIPTION
## Summary

Unify Shifu binary self-update and Kungfu product builds/promote around one provenance-aware local artifact contract.

Default promotion now follows Git history instead of filesystem recency: same or one unique descendant is automatic, while ancestor, divergent, unknown, ambiguous, rollback-only, and invalid artifacts fail closed or require explicit review.

## Related issue

None.

## Changes

- add SHIFU-ADR-0002 plus catalog and redacted promotion-receipt schemas
- add compact, --no-truncate, --verbose, and --json inventories
- preserve identifiable feature branch names with middle truncation
- record branch, canonical repository, worktree, build path, digest, relation, and lifecycle state
- retire only proven ancestor build slots after successful descendant promotion
- retain bounded rollback-only Shifu generations outside the candidate pool
- expose the exact contract through shifu artifacts contract/schema/receipt-schema
- make Git fixture tests independent of caller hook and repository environment

## Verification

- ./shifu check
- ./shifu docs:check
- cargo test --workspace
- AJV 2020 validation of self-update and builds JSON output
- isolated XDG fixture: 8c9001c90 is ancestor and 5d3613fc0 is diverged; default promote exits 1
- isolated linear fixture: unique descendant promotes, writes receipt, and retires only its ancestor
- isolated self-update fixture: update and rollback both write receipts and preserve rollback-only generations

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "stage-ready",
  "adrs": ["SHIFU-ADR-0002"],
  "summary": "Deliver the shared local artifact catalog and fail-closed ancestry-aware promotion substrate.",
  "verification": ["./shifu check", "./shifu docs:check", "cargo test --workspace", "isolated promotion and rollback fixtures"]
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change affects only local development artifact provenance and promotion. Receipts omit local paths; full paths remain local diagnostic output.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed