### PR TITLE
feat(profile): qualify user-defined KFD-3 collaboration

### DIFF
--- a/.buildchain/kfd/kfd-1/contract-world.witness.json
+++ b/.buildchain/kfd/kfd-1/contract-world.witness.json
@@ -53,9 +53,9 @@
     {
       "name": "kungfu-kfx",
       "sourcePath": "framework/kfx/kungfu-kfx.contract.json",
-      "sourceSha256": "238b2fcd1fe881dc9c476e818df7161e7caddbd6a9ca5cf3737672383a877ca4",
+      "sourceSha256": "ec1333c32b869c3c87d3b68d675e2eb371b063d1847c8f791e76659c8ae3200c",
       "artifactPath": "config/kungfu-kfx.contract.json",
-      "expectedSha256": "238b2fcd1fe881dc9c476e818df7161e7caddbd6a9ca5cf3737672383a877ca4",
+      "expectedSha256": "ec1333c32b869c3c87d3b68d675e2eb371b063d1847c8f791e76659c8ae3200c",
       "byteForByte": true
     },
     {

--- a/.buildchain/kfd/kfd-1/release-gate.json
+++ b/.buildchain/kfd/kfd-1/release-gate.json
@@ -54,13 +54,13 @@
       "standard": "KFD-1",
       "standardKey": "kfd-1",
       "result": "passed",
-      "preBuildWitnessSha256": "96ed167f14be7f8724bf93e26868a2615ee841e8a58f971c218915f2cc558a82",
+      "preBuildWitnessSha256": "432884c7dce0bca2acd5d0a656ce521f43f378a4ca40c2253309204cd3732364",
       "sourceHashes": {
-        "sha256": "49b05398fa09ef3106953ca54b33c42b1ac72c6016437f6f8b43e10f94edf968",
+        "sha256": "e3766b58e08fde0d1b73dcad09a97fcee18d7e667d7806be58e4e758353b2162",
         "surfaceCount": 3
       },
       "artifactHashes": {
-        "sha256": "6756ccd7727792f89b97a6ad732a5635f296b8f255f5fcd70c07f4ff3154edbc",
+        "sha256": "b112457fab68e622d315d456bdaaa4d9aba2e6569cbfb8fec32de586b597fc65",
         "surfaceCount": 3
       },
       "witness": {
@@ -118,9 +118,9 @@
           {
             "name": "kungfu-kfx",
             "sourcePath": "framework/kfx/kungfu-kfx.contract.json",
-            "sourceSha256": "238b2fcd1fe881dc9c476e818df7161e7caddbd6a9ca5cf3737672383a877ca4",
+            "sourceSha256": "ec1333c32b869c3c87d3b68d675e2eb371b063d1847c8f791e76659c8ae3200c",
             "artifactPath": "config/kungfu-kfx.contract.json",
-            "expectedSha256": "238b2fcd1fe881dc9c476e818df7161e7caddbd6a9ca5cf3737672383a877ca4",
+            "expectedSha256": "ec1333c32b869c3c87d3b68d675e2eb371b063d1847c8f791e76659c8ae3200c",
             "byteForByte": true
           },
           {
@@ -185,8 +185,8 @@
           {
             "name": "kungfu-kfx",
             "sourcePath": "framework/kfx/kungfu-kfx.contract.json",
-            "expectedSha256": "238b2fcd1fe881dc9c476e818df7161e7caddbd6a9ca5cf3737672383a877ca4",
-            "actualSha256": "238b2fcd1fe881dc9c476e818df7161e7caddbd6a9ca5cf3737672383a877ca4",
+            "expectedSha256": "ec1333c32b869c3c87d3b68d675e2eb371b063d1847c8f791e76659c8ae3200c",
+            "actualSha256": "ec1333c32b869c3c87d3b68d675e2eb371b063d1847c8f791e76659c8ae3200c",
             "status": "passed",
             "reason": ""
           },
@@ -218,10 +218,10 @@
           {
             "name": "kungfu-kfx",
             "sourcePath": "framework/kfx/kungfu-kfx.contract.json",
-            "sourceSha256": "238b2fcd1fe881dc9c476e818df7161e7caddbd6a9ca5cf3737672383a877ca4",
+            "sourceSha256": "ec1333c32b869c3c87d3b68d675e2eb371b063d1847c8f791e76659c8ae3200c",
             "artifactPath": "config/kungfu-kfx.contract.json",
-            "expectedSha256": "238b2fcd1fe881dc9c476e818df7161e7caddbd6a9ca5cf3737672383a877ca4",
-            "actualSha256": "238b2fcd1fe881dc9c476e818df7161e7caddbd6a9ca5cf3737672383a877ca4",
+            "expectedSha256": "ec1333c32b869c3c87d3b68d675e2eb371b063d1847c8f791e76659c8ae3200c",
+            "actualSha256": "ec1333c32b869c3c87d3b68d675e2eb371b063d1847c8f791e76659c8ae3200c",
             "byteForByte": true,
             "status": "passed",
             "reason": ""

--- a/.buildchain/kfd/kfd-2/claims/agent-onboarding-pack.json
+++ b/.buildchain/kfd/kfd-2/claims/agent-onboarding-pack.json
@@ -16,7 +16,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "dd788c377e152a9c4a65dba5e4b2ca58b1bd1ee4c189d13f5cdf9d53b9158eb5"
+        "sha256": "bda8d6e263a534ad74a1984293278910c69b94e59232c0e0a4c5d2746b2b431b"
       },
       "description": "Machine-readable command catalog and mode maturity metadata."
     },
@@ -54,7 +54,7 @@
     "evidenceSha256": [
       {
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "dd788c377e152a9c4a65dba5e4b2ca58b1bd1ee4c189d13f5cdf9d53b9158eb5"
+        "sha256": "bda8d6e263a534ad74a1984293278910c69b94e59232c0e0a4c5d2746b2b431b"
       },
       {
         "path": "framework/core/src/python/kungfu/agent/mode-selection.md",
@@ -76,7 +76,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "dd788c377e152a9c4a65dba5e4b2ca58b1bd1ee4c189d13f5cdf9d53b9158eb5"
+        "sha256": "bda8d6e263a534ad74a1984293278910c69b94e59232c0e0a4c5d2746b2b431b"
       }
     ]
   },
@@ -90,7 +90,7 @@
     {
       "name": "agent-command-catalog",
       "path": "framework/core/src/python/kungfu/agent/commands.json",
-      "sha256": "dd788c377e152a9c4a65dba5e4b2ca58b1bd1ee4c189d13f5cdf9d53b9158eb5",
+      "sha256": "bda8d6e263a534ad74a1984293278910c69b94e59232c0e0a4c5d2746b2b431b",
       "expectedPackagePath": "kungfu/agent/commands.json"
     }
   ],

--- a/.buildchain/kfd/kfd-2/claims/remote-fact-boundary.json
+++ b/.buildchain/kfd/kfd-2/claims/remote-fact-boundary.json
@@ -34,7 +34,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "dd788c377e152a9c4a65dba5e4b2ca58b1bd1ee4c189d13f5cdf9d53b9158eb5"
+        "sha256": "bda8d6e263a534ad74a1984293278910c69b94e59232c0e0a4c5d2746b2b431b"
       },
       "description": "Remote add/sync command declarations and mode metadata."
     },
@@ -62,7 +62,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "dd788c377e152a9c4a65dba5e4b2ca58b1bd1ee4c189d13f5cdf9d53b9158eb5"
+        "sha256": "bda8d6e263a534ad74a1984293278910c69b94e59232c0e0a4c5d2746b2b431b"
       },
       {
         "path": "framework/core/src/python/kungfu/cli/commands/agent.py",

--- a/.buildchain/kfd/kfd-2/release-claims.json
+++ b/.buildchain/kfd/kfd-2/release-claims.json
@@ -29,7 +29,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/commands.json",
-            "sha256": "dd788c377e152a9c4a65dba5e4b2ca58b1bd1ee4c189d13f5cdf9d53b9158eb5"
+            "sha256": "bda8d6e263a534ad74a1984293278910c69b94e59232c0e0a4c5d2746b2b431b"
           },
           "description": "Machine-readable command catalog and mode maturity metadata."
         },
@@ -194,7 +194,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/commands.json",
-            "sha256": "dd788c377e152a9c4a65dba5e4b2ca58b1bd1ee4c189d13f5cdf9d53b9158eb5"
+            "sha256": "bda8d6e263a534ad74a1984293278910c69b94e59232c0e0a4c5d2746b2b431b"
           },
           "description": "Remote add/sync command declarations and mode metadata."
         },

--- a/.buildchain/kfd/kfd-3/capability-query.json
+++ b/.buildchain/kfd/kfd-3/capability-query.json
@@ -1057,7 +1057,7 @@
         "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
         "sourcePath": "product/scripts/dist.mjs",
         "artifactPath": "product/package.json",
-        "digest": "sha256:d8d7ee2a25e7490a2e5c5201fa31573fc88652d2b4557bf1ac7bbb6cbc48f32e"
+        "digest": "sha256:09701f1739f051ea55d1819b3582a04ac4e85a1b6c7d1b8b1be876e78badeddf"
       },
       "kfd2Trust": {
         "status": "release-passport-required",
@@ -1080,6 +1080,28 @@
         "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
         "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
         "digest": "sha256:faa149e0b5490018a583e4cb6b4216bc8972033f289ccf843b16706d085de41b"
+      },
+      "kfd2Trust": {
+        "status": "release-passport-required",
+        "trustImpact": "query-release-passport-for-final-trust",
+        "residualRisk": []
+      },
+      "residualRisk": []
+    },
+    {
+      "id": "kungfu.profile.application",
+      "kind": "cli-api-gui",
+      "name": "kungfu profile application <source> --json",
+      "state": "declared",
+      "detected": true,
+      "enforced": false,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "kfd1Basis": {
+        "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+        "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+        "digest": "sha256:b4212df72f28d3d80e5d0199c6b81c705dbc770e48020bf1db8a05808cf12139"
       },
       "kfd2Trust": {
         "status": "release-passport-required",
@@ -1168,6 +1190,28 @@
         "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
         "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
         "digest": "sha256:2c679fd427421b21fb456bcdd9316e415902cd0a839a71c850b96b0467c498f3"
+      },
+      "kfd2Trust": {
+        "status": "release-passport-required",
+        "trustImpact": "query-release-passport-for-final-trust",
+        "residualRisk": []
+      },
+      "residualRisk": []
+    },
+    {
+      "id": "kungfu.profile.kfd3-qualification",
+      "kind": "cli-api-gui",
+      "name": "kungfu profile kfd3-qualify <source> --json",
+      "state": "declared",
+      "detected": true,
+      "enforced": false,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "kfd1Basis": {
+        "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+        "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+        "digest": "sha256:30d3b2e58ff0fab319ea2616e3d83980f6d3df47cf4914904b04f7bf1c6348b1"
       },
       "kfd2Trust": {
         "status": "release-passport-required",

--- a/.buildchain/kfd/kfd-3/collaboration-interface.artifact.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.artifact.json
@@ -10,8 +10,8 @@
   "sourceRegistry": {
     "id": "kungfu",
     "path": ".buildchain/kfd/kfd-3/surfaces.json",
-    "sha256": "ed69924f52ec3cd789ecef41905f2f25dd33311d5fcfb575bd1f4116c4d898a4",
-    "digest": "sha256:f2e8e23ceba73cceea5c2000a093911244f04c181a0cffc353debc7fc15cdfc3"
+    "sha256": "71d429b9bf117cf812315c8b0aa20db257096bd0791f5cc4b74d6bfcb3358f0b",
+    "digest": "sha256:0f825d989935c9b386e3c34f203b6d4fd8dd2a134ed14df299a97b4f87979af5"
   },
   "upstreamKfd": {
     "aggregatePath": "developer/sdk/kfd/upstream-aggregate.json",
@@ -28,7 +28,7 @@
     },
     "digest": "sha256:a86ddd8755809f5337e11023a8218d513c87d58077265007f1d207ef957f4761"
   },
-  "collaborationInterfaceDigest": "sha256:9aa4df189c3219b54a8d80fecc5fa13bf6814d0b096135e1c3dd0b2ea7840534",
+  "collaborationInterfaceDigest": "sha256:fe813f8fc8420a6c27b7a49a346a9ea5f36926763b8376946a196833975f5de0",
   "exposedSurfaces": [
     {
       "id": "kungfu.agent",
@@ -993,6 +993,7 @@
         "registrar": "shifu",
         "tasks": [
           "dist",
+          "dist:dir",
           "package"
         ],
         "artifacts": [
@@ -1018,6 +1019,26 @@
       "id": "kungfu.profile.action",
       "name": "kungfu profile actions <source> --json",
       "kind": "cli",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
+      "id": "kungfu.profile.application",
+      "name": "kungfu profile application <source> --json",
+      "kind": "cli-api-gui",
       "participantProfile": "agent-or-developer",
       "state": "declared",
       "availability": "shipped",
@@ -1098,6 +1119,26 @@
       "id": "kungfu.profile.discovery",
       "name": "kungfu profile capabilities --json",
       "kind": "cli",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
+      "id": "kungfu.profile.kfd3-qualification",
+      "name": "kungfu profile kfd3-qualify <source> --json",
+      "kind": "cli-api-gui",
       "participantProfile": "agent-or-developer",
       "state": "declared",
       "availability": "shipped",

--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -5,16 +5,16 @@
   "witnessKind": "prebuild",
   "supportLevel": "release",
   "source": {
-    "cwd": "/Users/dkr/Worktrees/kungfu/feature/profile-composition-manager",
-    "sourceSha": "5935895ae780120bbc034194e558108ad258fd43",
+    "cwd": "/Users/dkr/Worktrees/kungfu/feature/profile-kfd3-qualification-s5",
+    "sourceSha": "0b73fa3e5fde5b55571746b9354df5924068f3d3",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
-    "registryDigest": "sha256:f2e8e23ceba73cceea5c2000a093911244f04c181a0cffc353debc7fc15cdfc3"
+    "registryDigest": "sha256:0f825d989935c9b386e3c34f203b6d4fd8dd2a134ed14df299a97b4f87979af5"
   },
   "sourceRegistry": {
     "id": "kungfu",
     "path": ".buildchain/kfd/kfd-3/surfaces.json",
-    "sha256": "ed69924f52ec3cd789ecef41905f2f25dd33311d5fcfb575bd1f4116c4d898a4",
-    "digest": "sha256:f2e8e23ceba73cceea5c2000a093911244f04c181a0cffc353debc7fc15cdfc3"
+    "sha256": "71d429b9bf117cf812315c8b0aa20db257096bd0791f5cc4b74d6bfcb3358f0b",
+    "digest": "sha256:0f825d989935c9b386e3c34f203b6d4fd8dd2a134ed14df299a97b4f87979af5"
   },
   "upstreamKfd": {
     "aggregatePath": "developer/sdk/kfd/upstream-aggregate.json",
@@ -34,7 +34,7 @@
   "expectedArtifactVerification": {
     "command": "node scripts/buildchain-kfd-evidence.mjs --artifact-witness --json"
   },
-  "collaborationInterfaceDigest": "sha256:9aa4df189c3219b54a8d80fecc5fa13bf6814d0b096135e1c3dd0b2ea7840534",
+  "collaborationInterfaceDigest": "sha256:fe813f8fc8420a6c27b7a49a346a9ea5f36926763b8376946a196833975f5de0",
   "collaborationInterface": {
     "schemaVersion": 1,
     "contract": "kungfu-buildchain-kfd-3-surface-registry",
@@ -1023,6 +1023,7 @@
           "registrar": "shifu",
           "tasks": [
             "dist",
+            "dist:dir",
             "package"
           ],
           "artifacts": [
@@ -1048,6 +1049,26 @@
         "id": "kungfu.profile.action",
         "name": "kungfu profile actions <source> --json",
         "kind": "cli",
+        "participantProfile": "agent-or-developer",
+        "state": "declared",
+        "availability": "shipped",
+        "visibility": "public",
+        "participantFacing": true,
+        "public": true,
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+        "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+        "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+        "maturity": "experimental",
+        "declaration": {
+          "owner": "kungfu",
+          "source": "scripts/buildchain-kfd-evidence.mjs",
+          "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+        }
+      },
+      {
+        "id": "kungfu.profile.application",
+        "name": "kungfu profile application <source> --json",
+        "kind": "cli-api-gui",
         "participantProfile": "agent-or-developer",
         "state": "declared",
         "availability": "shipped",
@@ -1128,6 +1149,26 @@
         "id": "kungfu.profile.discovery",
         "name": "kungfu profile capabilities --json",
         "kind": "cli",
+        "participantProfile": "agent-or-developer",
+        "state": "declared",
+        "availability": "shipped",
+        "visibility": "public",
+        "participantFacing": true,
+        "public": true,
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+        "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+        "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+        "maturity": "experimental",
+        "declaration": {
+          "owner": "kungfu",
+          "source": "scripts/buildchain-kfd-evidence.mjs",
+          "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+        }
+      },
+      {
+        "id": "kungfu.profile.kfd3-qualification",
+        "name": "kungfu profile kfd3-qualify <source> --json",
+        "kind": "cli-api-gui",
         "participantProfile": "agent-or-developer",
         "state": "declared",
         "availability": "shipped",
@@ -2127,8 +2168,8 @@
     ],
     "audit": {
       "status": "passed",
-      "declared": 102,
-      "artifactPublic": 102,
+      "declared": 104,
+      "artifactPublic": 104,
       "policy": {
         "sourceOfTruth": ".buildchain/kfd/kfd-3/surfaces.json",
         "detectedButUnregistered": "product-specific-audit",
@@ -3103,6 +3144,7 @@
         "registrar": "shifu",
         "tasks": [
           "dist",
+          "dist:dir",
           "package"
         ],
         "artifacts": [
@@ -3128,6 +3170,26 @@
       "id": "kungfu.profile.action",
       "name": "kungfu profile actions <source> --json",
       "kind": "cli",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
+      "id": "kungfu.profile.application",
+      "name": "kungfu profile application <source> --json",
+      "kind": "cli-api-gui",
       "participantProfile": "agent-or-developer",
       "state": "declared",
       "availability": "shipped",
@@ -3208,6 +3270,26 @@
       "id": "kungfu.profile.discovery",
       "name": "kungfu profile capabilities --json",
       "kind": "cli",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
+      "id": "kungfu.profile.kfd3-qualification",
+      "name": "kungfu profile kfd3-qualify <source> --json",
+      "kind": "cli-api-gui",
       "participantProfile": "agent-or-developer",
       "state": "declared",
       "availability": "shipped",

--- a/.buildchain/kfd/kfd-3/surfaces.json
+++ b/.buildchain/kfd/kfd-3/surfaces.json
@@ -1031,6 +1031,7 @@
         "registrar": "shifu",
         "tasks": [
           "dist",
+          "dist:dir",
           "package"
         ],
         "artifacts": [
@@ -1056,6 +1057,26 @@
       "id": "kungfu.profile.action",
       "name": "kungfu profile actions <source> --json",
       "kind": "cli",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
+      "id": "kungfu.profile.application",
+      "name": "kungfu profile application <source> --json",
+      "kind": "cli-api-gui",
       "participantProfile": "agent-or-developer",
       "state": "declared",
       "availability": "shipped",
@@ -1136,6 +1157,26 @@
       "id": "kungfu.profile.discovery",
       "name": "kungfu profile capabilities --json",
       "kind": "cli",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
+      "id": "kungfu.profile.kfd3-qualification",
+      "name": "kungfu profile kfd3-qualify <source> --json",
+      "kind": "cli-api-gui",
       "participantProfile": "agent-or-developer",
       "state": "declared",
       "availability": "shipped",

--- a/crates/shifu/src/registrar.rs
+++ b/crates/shifu/src/registrar.rs
@@ -9,7 +9,7 @@
 //
 //   "distribution": {
 //     "registrar": "shifu",
-//     "tasks": ["dist", "package"],
+//     "tasks": ["dist", "dist:dir", "package"],
 //     "artifacts": [
 //       {"kind": "app", "platform": "macos", "pathGlob": "product/dist/desktop/mac*/*.app"},
 //       {"kind": "installer", "platform": "windows", "pathGlob": "product/dist/desktop/*.exe"},

--- a/developer/sdk/kfd/kfd-1/contract-world.witness.json
+++ b/developer/sdk/kfd/kfd-1/contract-world.witness.json
@@ -53,9 +53,9 @@
     {
       "name": "kungfu-kfx",
       "sourcePath": "framework/kfx/kungfu-kfx.contract.json",
-      "sourceSha256": "238b2fcd1fe881dc9c476e818df7161e7caddbd6a9ca5cf3737672383a877ca4",
+      "sourceSha256": "ec1333c32b869c3c87d3b68d675e2eb371b063d1847c8f791e76659c8ae3200c",
       "artifactPath": "config/kungfu-kfx.contract.json",
-      "expectedSha256": "238b2fcd1fe881dc9c476e818df7161e7caddbd6a9ca5cf3737672383a877ca4",
+      "expectedSha256": "ec1333c32b869c3c87d3b68d675e2eb371b063d1847c8f791e76659c8ae3200c",
       "byteForByte": true
     },
     {

--- a/developer/sdk/kfd/kfd-1/release-gate.json
+++ b/developer/sdk/kfd/kfd-1/release-gate.json
@@ -54,13 +54,13 @@
       "standard": "KFD-1",
       "standardKey": "kfd-1",
       "result": "passed",
-      "preBuildWitnessSha256": "96ed167f14be7f8724bf93e26868a2615ee841e8a58f971c218915f2cc558a82",
+      "preBuildWitnessSha256": "432884c7dce0bca2acd5d0a656ce521f43f378a4ca40c2253309204cd3732364",
       "sourceHashes": {
-        "sha256": "49b05398fa09ef3106953ca54b33c42b1ac72c6016437f6f8b43e10f94edf968",
+        "sha256": "e3766b58e08fde0d1b73dcad09a97fcee18d7e667d7806be58e4e758353b2162",
         "surfaceCount": 3
       },
       "artifactHashes": {
-        "sha256": "6756ccd7727792f89b97a6ad732a5635f296b8f255f5fcd70c07f4ff3154edbc",
+        "sha256": "b112457fab68e622d315d456bdaaa4d9aba2e6569cbfb8fec32de586b597fc65",
         "surfaceCount": 3
       },
       "witness": {
@@ -118,9 +118,9 @@
           {
             "name": "kungfu-kfx",
             "sourcePath": "framework/kfx/kungfu-kfx.contract.json",
-            "sourceSha256": "238b2fcd1fe881dc9c476e818df7161e7caddbd6a9ca5cf3737672383a877ca4",
+            "sourceSha256": "ec1333c32b869c3c87d3b68d675e2eb371b063d1847c8f791e76659c8ae3200c",
             "artifactPath": "config/kungfu-kfx.contract.json",
-            "expectedSha256": "238b2fcd1fe881dc9c476e818df7161e7caddbd6a9ca5cf3737672383a877ca4",
+            "expectedSha256": "ec1333c32b869c3c87d3b68d675e2eb371b063d1847c8f791e76659c8ae3200c",
             "byteForByte": true
           },
           {
@@ -185,8 +185,8 @@
           {
             "name": "kungfu-kfx",
             "sourcePath": "framework/kfx/kungfu-kfx.contract.json",
-            "expectedSha256": "238b2fcd1fe881dc9c476e818df7161e7caddbd6a9ca5cf3737672383a877ca4",
-            "actualSha256": "238b2fcd1fe881dc9c476e818df7161e7caddbd6a9ca5cf3737672383a877ca4",
+            "expectedSha256": "ec1333c32b869c3c87d3b68d675e2eb371b063d1847c8f791e76659c8ae3200c",
+            "actualSha256": "ec1333c32b869c3c87d3b68d675e2eb371b063d1847c8f791e76659c8ae3200c",
             "status": "passed",
             "reason": ""
           },
@@ -218,10 +218,10 @@
           {
             "name": "kungfu-kfx",
             "sourcePath": "framework/kfx/kungfu-kfx.contract.json",
-            "sourceSha256": "238b2fcd1fe881dc9c476e818df7161e7caddbd6a9ca5cf3737672383a877ca4",
+            "sourceSha256": "ec1333c32b869c3c87d3b68d675e2eb371b063d1847c8f791e76659c8ae3200c",
             "artifactPath": "config/kungfu-kfx.contract.json",
-            "expectedSha256": "238b2fcd1fe881dc9c476e818df7161e7caddbd6a9ca5cf3737672383a877ca4",
-            "actualSha256": "238b2fcd1fe881dc9c476e818df7161e7caddbd6a9ca5cf3737672383a877ca4",
+            "expectedSha256": "ec1333c32b869c3c87d3b68d675e2eb371b063d1847c8f791e76659c8ae3200c",
+            "actualSha256": "ec1333c32b869c3c87d3b68d675e2eb371b063d1847c8f791e76659c8ae3200c",
             "byteForByte": true,
             "status": "passed",
             "reason": ""

--- a/developer/sdk/kfd/kfd-2/claims/agent-onboarding-pack.json
+++ b/developer/sdk/kfd/kfd-2/claims/agent-onboarding-pack.json
@@ -16,7 +16,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "dd788c377e152a9c4a65dba5e4b2ca58b1bd1ee4c189d13f5cdf9d53b9158eb5"
+        "sha256": "bda8d6e263a534ad74a1984293278910c69b94e59232c0e0a4c5d2746b2b431b"
       },
       "description": "Machine-readable command catalog and mode maturity metadata."
     },
@@ -54,7 +54,7 @@
     "evidenceSha256": [
       {
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "dd788c377e152a9c4a65dba5e4b2ca58b1bd1ee4c189d13f5cdf9d53b9158eb5"
+        "sha256": "bda8d6e263a534ad74a1984293278910c69b94e59232c0e0a4c5d2746b2b431b"
       },
       {
         "path": "framework/core/src/python/kungfu/agent/mode-selection.md",
@@ -76,7 +76,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "dd788c377e152a9c4a65dba5e4b2ca58b1bd1ee4c189d13f5cdf9d53b9158eb5"
+        "sha256": "bda8d6e263a534ad74a1984293278910c69b94e59232c0e0a4c5d2746b2b431b"
       }
     ]
   },
@@ -90,7 +90,7 @@
     {
       "name": "agent-command-catalog",
       "path": "framework/core/src/python/kungfu/agent/commands.json",
-      "sha256": "dd788c377e152a9c4a65dba5e4b2ca58b1bd1ee4c189d13f5cdf9d53b9158eb5",
+      "sha256": "bda8d6e263a534ad74a1984293278910c69b94e59232c0e0a4c5d2746b2b431b",
       "expectedPackagePath": "kungfu/agent/commands.json"
     }
   ],

--- a/developer/sdk/kfd/kfd-2/claims/remote-fact-boundary.json
+++ b/developer/sdk/kfd/kfd-2/claims/remote-fact-boundary.json
@@ -34,7 +34,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "dd788c377e152a9c4a65dba5e4b2ca58b1bd1ee4c189d13f5cdf9d53b9158eb5"
+        "sha256": "bda8d6e263a534ad74a1984293278910c69b94e59232c0e0a4c5d2746b2b431b"
       },
       "description": "Remote add/sync command declarations and mode metadata."
     },
@@ -62,7 +62,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "dd788c377e152a9c4a65dba5e4b2ca58b1bd1ee4c189d13f5cdf9d53b9158eb5"
+        "sha256": "bda8d6e263a534ad74a1984293278910c69b94e59232c0e0a4c5d2746b2b431b"
       },
       {
         "path": "framework/core/src/python/kungfu/cli/commands/agent.py",

--- a/developer/sdk/kfd/kfd-2/release-claims.json
+++ b/developer/sdk/kfd/kfd-2/release-claims.json
@@ -29,7 +29,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/commands.json",
-            "sha256": "dd788c377e152a9c4a65dba5e4b2ca58b1bd1ee4c189d13f5cdf9d53b9158eb5"
+            "sha256": "bda8d6e263a534ad74a1984293278910c69b94e59232c0e0a4c5d2746b2b431b"
           },
           "description": "Machine-readable command catalog and mode maturity metadata."
         },
@@ -194,7 +194,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/commands.json",
-            "sha256": "dd788c377e152a9c4a65dba5e4b2ca58b1bd1ee4c189d13f5cdf9d53b9158eb5"
+            "sha256": "bda8d6e263a534ad74a1984293278910c69b94e59232c0e0a4c5d2746b2b431b"
           },
           "description": "Remote add/sync command declarations and mode metadata."
         },

--- a/developer/sdk/kfd/kfd-3-surfaces.json
+++ b/developer/sdk/kfd/kfd-3-surfaces.json
@@ -1031,6 +1031,7 @@
         "registrar": "shifu",
         "tasks": [
           "dist",
+          "dist:dir",
           "package"
         ],
         "artifacts": [
@@ -1056,6 +1057,26 @@
       "id": "kungfu.profile.action",
       "name": "kungfu profile actions <source> --json",
       "kind": "cli",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
+      "id": "kungfu.profile.application",
+      "name": "kungfu profile application <source> --json",
+      "kind": "cli-api-gui",
       "participantProfile": "agent-or-developer",
       "state": "declared",
       "availability": "shipped",
@@ -1136,6 +1157,26 @@
       "id": "kungfu.profile.discovery",
       "name": "kungfu profile capabilities --json",
       "kind": "cli",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
+      "id": "kungfu.profile.kfd3-qualification",
+      "name": "kungfu profile kfd3-qualify <source> --json",
+      "kind": "cli-api-gui",
       "participantProfile": "agent-or-developer",
       "state": "declared",
       "availability": "shipped",

--- a/docs/adr/ADR-0075-profile-level-kfd3-qualification.md
+++ b/docs/adr/ADR-0075-profile-level-kfd3-qualification.md
@@ -1,0 +1,107 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+doc_type: architecture-decision
+adr_id: ADR-0075
+decision_status: accepted
+implementation_status: implemented
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/734, https://github.com/kungfu-systems/kungfu/pull/744]
+closure_pr: https://github.com/kungfu-systems/kungfu/pull/744
+qualification_refs: [scripts/run-kfx-profile-suite-tests.mjs, framework/core/tests/python/test_agent_profile_sdk.py, tests/qualification/profile-kfd3/run.ts, scripts/buildchain-kfd-evidence.mjs]
+review_state: self-reviewed
+sensitivity: public
+sources: [local-files, user-decision]
+period: 2026-07-13
+theme: profile-level-kfd3-qualification
+confidence: high
+evidence_grade: B
+last_reviewed: 2026-07-13
+---
+
+# ADR-0075: Kungfu qualifies one KFD-3 collaboration protocol for conforming Profiles
+
+- Status: accepted; implemented and qualified
+- Date: 2026-07-13
+- Category: Profile runtime / KFD-3 / dual-first product interface
+- Related: [ADR-0061](ADR-0061-agent-mediated-guidance-is-a-first-class-product-interface.md),
+  [ADR-0069](ADR-0069-agent-first-kfx-profile-suite-runtime.md)
+
+## Context
+
+ADR-0069 lets an installed Kungfu author and operate domain-neutral Profile Suites without rebuilding the Product.
+The current contract binds KFD-1 facts, KFD-2 claims and policies, actions, views, permissions, migrations and
+qualification. That is not by itself KFD-3. A schema-valid Profile may still expose a GUI-only mutation, an Agent-only
+command, hidden constraints or two clients that disagree about the plan, authorization, receipt or selected cut.
+
+Requiring every Profile author to hand-build a GUI, CLI, Agent brief and closure audit would repeat product engineering
+and make KFD-3 depend on author skill. Treating the presence of any GUI and any CLI as KFD-3 would be a false claim.
+
+## Decision
+
+### 1. Profile authors declare collaboration semantics; Kungfu owns their projection
+
+A conforming Profile may bind one content-addressed `kfd3.collaboration` facet. It declares participants, material
+intents, value, constraints, known limits, authority classes and presentation hints. It cannot declare its own Profile
+root, qualification result, witness or runtime authority.
+
+Kungfu projects that declaration into:
+
+- a generic Human GUI when no custom View is supplied;
+- an Agent-discoverable brief, capabilities and JSON CLI/API operations;
+- one shared application protocol:
+  `inspect -> advise -> preview -> authorize -> execute -> receipt -> verify`;
+- qualification probes and a content-bound collaboration-interface witness.
+
+### 2. KFD-3 is an earned Profile level, not an alias for KFD-1/KFD-2
+
+The `kfd3` facet is optional for backward compatibility. A Profile without it remains a valid KFD-1/KFD-2 Profile but
+cannot be reported as KFD-3 declared or qualified. A Profile with it is only declared until closure qualification
+passes. User-visible states must distinguish schema validity, KFD-1, KFD-2 and KFD-3 qualification.
+
+### 3. GUI and Agent clients have no separate mutation authority
+
+Both clients use the same plan identity, authorization decision, application service, receipt, cut and verify result.
+A custom KFX View may change presentation but cannot append facts, grant permissions or execute a material intent
+outside that service. A reachable participant-facing entrypoint that is absent from the collaboration registry fails
+closure rather than becoming an undocumented API.
+
+### 4. Qualification proves collaboration closure, not universal external truth
+
+The KFD-3 receipt binds the Profile root, collaboration facet root, runtime contract, public surface inventory, probe
+evidence, maturity and known limits. It proves the declared participant interface is discoverable, constraint-transparent
+and closed for that artifact. It does not prove that a user's source assertion is true, that the named actor owns a
+real-world identity, or that a domain action achieved its purpose.
+
+### 5. Existing KFD-3 authority remains single-source
+
+Profile qualification consumes the existing Kungfu/Buildchain KFD-3 collaboration-interface registry and witness
+contract. It does not introduce a second KFD definition, registry or release passport. Profile evidence is a scoped
+projection into that authority.
+
+## Invariants and falsification
+
+- Removing `kfd3` keeps an existing Profile valid but makes KFD-3 qualification unavailable.
+- Changing one collaboration byte changes the Profile content closure and invalidates stale plans/witnesses.
+- Missing value, constraints, known limits, participant identity, intent stage or public entrypoint classification fails
+  KFD-3 qualification.
+- Human and Agent probes over the same intent must return the same plan, receipt and verified cut.
+- A custom View with a private mutation path fails qualification.
+- A GUI-only, prose-only or unregistered reachable surface fails closure.
+
+## Consequences
+
+- Users can define domain workflows while Kungfu supplies the repeated dual-first product mechanics.
+- Profiles that only need the generic renderer require declarations, not TS/React code.
+- Custom presentation remains possible without becoming a second authority.
+- The Profile lifecycle gains a new qualification level and witness surface, but Core remains domain-neutral.
+- Mission Control must qualify through the same public path and receives no private KFD-3 exception.
+
+## Delivery stages
+
+1. Done: add the optional content-bound collaboration facet and negative contract fixtures.
+2. Done: add closure parsing, roots, qualification state and public Python/Node/CLI services.
+3. Done: project generic GUI and Agent surfaces over the shared intent protocol.
+4. Done: add installed-authority audit, custom-facet no-bypass tests, deterministic receipt verification and a scoped
+   Profile witness bound to the Buildchain-projected collaboration-interface registry.
+5. Done: the independent Week/Day Profile proves identical Agent CLI and typed Human API plans, receipts and witnesses
+   plus export/import, upgrade invalidation, rollback and Mission Control regression. The final assembled Product reran
+   the same proof and clean build `746bfafb0` was promoted through Shifu for local dogfood.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -144,6 +144,7 @@ implemented and qualified or explicitly waived for that release.
 | [0072](ADR-0072-frame-identity-layering-journal-local-vs-ledger-global.md) | accepted | frame identity is layered: frame_uid stays journal-local (fixing the deterministic page-8-bit wrap), while permanent ledger-global uniqueness is the Episode content root + structural stream_position (stream_id, container_epoch, sequence), not a widened probabilistic frame_uid |
 | [0073](ADR-0073-buildchain-adr-release-admissibility.md) | accepted | Buildchain promotion is the settlement boundary for ADR implementation truth: dev declares bounded delivery, alpha settles qualified progress, and stable admits no unaccounted accepted decision |
 | [0074](ADR-0074-canonical-adr-authority-and-lifecycle-audit.md) | accepted | `docs/adr/` is the sole Core and Shifu decision authority, with typed redirects and executable lifecycle, evidence, and release audit |
+| [0075](ADR-0075-profile-level-kfd3-qualification.md) | accepted | conforming Profile Suites declare a content-bound collaboration facet; Kungfu projects and qualifies one shared Human/Agent protocol instead of making each Profile reimplement KFD-3 |
 | [SHIFU-0001](SHIFU-ADR-0001-cache-profile-contract-and-ownership.md) | accepted | Cache profiles are Shifu-owned contracts; inventories project instances and Buildchain owns process |
 | [SHIFU-0002](SHIFU-ADR-0002-local-artifact-catalog-and-safe-promotion.md) | accepted | Shifu and Kungfu product artifacts share provenance-aware, Git-safe local promotion semantics |
 

--- a/docs/adr/SHIFU-ADR-0002-local-artifact-catalog-and-safe-promotion.md
+++ b/docs/adr/SHIFU-ADR-0002-local-artifact-catalog-and-safe-promotion.md
@@ -4,7 +4,7 @@ doc_type: architecture-decision
 adr_id: SHIFU-ADR-0002
 decision_status: accepted
 implementation_status: partial
-implementation_commits: [c0ae2970240ce3bb2ff2320065797899e28a69ea, 1935a89c8dcb0418cdf587a0007dcd135d2230c7]
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/743]
 review_state: unreviewed
 sensitivity: public
 sources: [local-files, user-consensus]

--- a/docs/rust-adoption.md
+++ b/docs/rust-adoption.md
@@ -273,7 +273,7 @@ provenance. The exact contract and schemas are available through
 ```json
 "distribution": {
   "registrar": "shifu",
-  "tasks": ["dist", "package"],
+  "tasks": ["dist", "dist:dir", "package"],
   "artifacts": [
     { "kind": "app", "platform": "macos", "pathGlob": "product/dist/desktop/mac*/*.app" },
     { "kind": "installer", "platform": "windows", "pathGlob": "product/dist/desktop/*.exe" },

--- a/extensions/system/kfx-manager/src/view/index.tsx
+++ b/extensions/system/kfx-manager/src/view/index.tsx
@@ -6,6 +6,8 @@
 import {
   type KfxViewProps,
   type ManagedProfile,
+  type ProfileApplicationProjection,
+  type ProfileIntentPlan,
   type ProfileLifecyclePlan,
   type ProfileManagerProjection,
   headingStyle,
@@ -29,12 +31,18 @@ function shortRoot(value: string | null | undefined): string {
 
 function ProfileCard({
   managed,
+  application,
+  applicationError,
   planning,
   onPlan,
+  onIntentPlan,
 }: {
   managed: ManagedProfile;
+  application?: ProfileApplicationProjection;
+  applicationError?: string;
   planning: boolean;
   onPlan: (action: 'qualify' | 'activate', source: string) => void;
+  onIntentPlan: (source: string, intentId: string) => void;
 }) {
   const next =
     managed.lifecycleState === 'installed'
@@ -80,6 +88,64 @@ function ProfileCard({
           ? 'recorded'
           : 'not recorded'}
       </div>
+      {applicationError ? (
+        <div style={{ ...mono, color: '#f48771', marginTop: 8 }}>
+          Application projection unavailable: {applicationError}
+        </div>
+      ) : null}
+      {application ? (
+        <div
+          style={{
+            borderTop: '1px solid #3c3c3c',
+            marginTop: 10,
+            paddingTop: 10,
+          }}
+        >
+          <div style={{ color: '#dcdcaa' }}>{application.value.summary}</div>
+          <div style={{ ...mono, color: '#858585', marginTop: 4 }}>
+            {application.participants
+              .map((participant) => `${participant.kind}:${participant.title}`)
+              .join(' · ')}
+          </div>
+          <div style={{ ...mono, color: '#858585' }}>
+            {application.constraints.length} constraints ·{' '}
+            {application.knownLimits.length} known limits ·{' '}
+            <span
+              title={
+                application.qualified
+                  ? `KFD-3 witness ${application.qualification.witnessId}`
+                  : application.qualification.reason ||
+                    String(
+                      application.qualification.diagnosis?.message ||
+                        'qualification not earned',
+                    )
+              }
+            >
+              {application.qualified ? '🛡️ KFD-3 qualified' : '◌ KFD-3 declared'}
+            </span>
+          </div>
+          {application.intents.map((intent) => (
+            <button
+              key={intent.id}
+              type="button"
+              disabled={
+                planning ||
+                !application.activeExactRoot ||
+                intent.missingCapabilities.length > 0
+              }
+              title={
+                intent.missingCapabilities.length
+                  ? `Missing: ${intent.missingCapabilities.join(', ')}`
+                  : `${intent.requiredAuthority} · inspect → advise → preview → authorize → execute → receipt → verify`
+              }
+              onClick={() => onIntentPlan(application.source, intent.id)}
+              style={{ ...mono, marginTop: 8, marginRight: 8 }}
+            >
+              {intent.title}
+            </button>
+          ))}
+        </div>
+      ) : null}
       <div style={{ ...mono, color: '#cccccc' }}>
         views:{' '}
         {managed.catalog?.views.map((view) => view.title).join(', ') ||
@@ -116,6 +182,12 @@ function KfxManagerView({ caps, shell }: KfxViewProps) {
     null,
   );
   const [error, setError] = React.useState('');
+  const [applications, setApplications] = React.useState<
+    Record<string, ProfileApplicationProjection>
+  >({});
+  const [applicationErrors, setApplicationErrors] = React.useState<
+    Record<string, string>
+  >({});
   const [loading, setLoading] = React.useState(true);
   const [pending, setPending] = React.useState<{
     plan: ProfileLifecyclePlan;
@@ -123,6 +195,11 @@ function KfxManagerView({ caps, shell }: KfxViewProps) {
     source: string;
   } | null>(null);
   const [planning, setPlanning] = React.useState(false);
+  const [pendingIntent, setPendingIntent] = React.useState<{
+    plan: ProfileIntentPlan;
+    source: string;
+    intentId: string;
+  } | null>(null);
   const [authorizedBy, setAuthorizedBy] = React.useState('');
   const profile =
     shell.profiles.find((p) => p.id === shell.state.profileId) ??
@@ -133,7 +210,41 @@ function KfxManagerView({ caps, shell }: KfxViewProps) {
     if (!caps.profile) return;
     setLoading(true);
     try {
-      setManager(await caps.profile.managerAsync());
+      const next = await caps.profile.managerAsync();
+      setManager(next);
+      const rows = await Promise.all(
+        next.profiles
+          .filter((managed) => managed.source)
+          .map(async (managed) => {
+            try {
+              return {
+                profileId: managed.profileId,
+                application: await caps.profile?.applicationAsync(
+                  managed.source as string,
+                ),
+              };
+            } catch (reason) {
+              return {
+                profileId: managed.profileId,
+                error: (reason as Error).message,
+              };
+            }
+          }),
+      );
+      setApplications(
+        Object.fromEntries(
+          rows
+            .filter((row) => row.application)
+            .map((row) => [row.profileId, row.application]),
+        ) as Record<string, ProfileApplicationProjection>,
+      );
+      setApplicationErrors(
+        Object.fromEntries(
+          rows
+            .filter((row) => row.error)
+            .map((row) => [row.profileId, row.error]),
+        ) as Record<string, string>,
+      );
       setError('');
     } catch (reason) {
       setError((reason as Error).message);
@@ -160,6 +271,49 @@ function KfxManagerView({ caps, shell }: KfxViewProps) {
         source,
       });
       setError('');
+    } catch (reason) {
+      setError((reason as Error).message);
+    } finally {
+      setPlanning(false);
+    }
+  };
+
+  const previewIntent = async (source: string, intentId: string) => {
+    if (!caps.profile) return;
+    setPlanning(true);
+    try {
+      setPendingIntent({
+        plan: await caps.profile.intentPlanAsync(source, intentId),
+        source,
+        intentId,
+      });
+      setError('');
+    } catch (reason) {
+      setError((reason as Error).message);
+    } finally {
+      setPlanning(false);
+    }
+  };
+
+  const approveIntent = async () => {
+    if (!caps.profile || !pendingIntent || !authorizedBy.trim()) return;
+    setPlanning(true);
+    try {
+      const receipt = await caps.profile.authorizeIntentAsync(
+        pendingIntent.source,
+        pendingIntent.intentId,
+        pendingIntent.plan.planId,
+        'approve',
+        authorizedBy.trim(),
+      );
+      setPendingIntent(null);
+      await refresh();
+      shell.notify({
+        level: receipt.verification?.verified ? 'success' : 'warning',
+        title: receipt.verification?.verified
+          ? 'Intent receipt verified'
+          : 'Intent executed; verification incomplete',
+      });
     } catch (reason) {
       setError((reason as Error).message);
     } finally {
@@ -231,8 +385,13 @@ function KfxManagerView({ caps, shell }: KfxViewProps) {
           <ProfileCard
             key={managed.profileId}
             managed={managed}
+            application={applications[managed.profileId]}
+            applicationError={applicationErrors[managed.profileId]}
             planning={planning}
             onPlan={(action, source) => void previewPlan(action, source)}
+            onIntentPlan={(source, intentId) =>
+              void previewIntent(source, intentId)
+            }
           />
         ))}
         {!loading && manager?.count === 0 ? (
@@ -290,6 +449,49 @@ function KfxManagerView({ caps, shell }: KfxViewProps) {
             type="button"
             disabled={planning}
             onClick={() => setPending(null)}
+            style={{ ...mono, marginTop: 8 }}
+          >
+            Dismiss
+          </button>
+        </div>
+      ) : null}
+      {pendingIntent ? (
+        <div
+          style={{
+            ...mono,
+            border: '1px solid #dcdcaa',
+            padding: 10,
+            marginBottom: 12,
+          }}
+        >
+          <strong style={{ color: '#dcdcaa' }}>Intent decision required</strong>
+          <div>intent {pendingIntent.intentId}</div>
+          <div>plan {pendingIntent.plan.planId}</div>
+          <div style={{ color: '#858585' }}>
+            This exact plan is shared with the Agent CLI. Apply re-plans, emits
+            a receipt, and verifies the same Profile and collaboration roots.
+          </div>
+          <label style={{ display: 'block', marginTop: 8 }}>
+            authorized by{' '}
+            <input
+              value={authorizedBy}
+              onChange={(event) => setAuthorizedBy(event.target.value)}
+              placeholder="declared authority identity"
+              style={{ ...mono, minWidth: 220 }}
+            />
+          </label>
+          <button
+            type="button"
+            disabled={planning || !authorizedBy.trim()}
+            onClick={() => void approveIntent()}
+            style={{ ...mono, marginTop: 8, marginRight: 8 }}
+          >
+            Approve exact intent
+          </button>
+          <button
+            type="button"
+            disabled={planning}
+            onClick={() => setPendingIntent(null)}
             style={{ ...mono, marginTop: 8 }}
           >
             Dismiss

--- a/framework/api/src/capability/profile.ts
+++ b/framework/api/src/capability/profile.ts
@@ -73,6 +73,114 @@ export type ProfileManagerProjection = {
   knownLimits: string[];
 };
 
+export type ProfileApplicationIntent = {
+  id: string;
+  title: string;
+  actionId: string;
+  inspectViewId: string;
+  verifyViewId: string;
+  requiredAuthority: string;
+  requiredCapabilities: string[];
+  missingCapabilities: string[];
+  material: true;
+  action: Record<string, unknown>;
+  inspectView: ProfileView;
+  verifyView: ProfileView;
+};
+
+export type ProfileApplicationProjection = {
+  schema: 'kungfu.profile-application/v1';
+  profileId: string;
+  profileSuiteRoot: string;
+  collaborationRoot: string;
+  closureRoot: string;
+  source: string;
+  activeExactRoot: boolean;
+  profileRevision: number | null;
+  grantedCapabilities: string[];
+  value: {
+    summary: string;
+    participantBenefits: Array<Record<string, unknown>>;
+  };
+  participants: Array<{
+    id: string;
+    kind: 'human' | 'agent' | 'operator' | 'service';
+    title: string;
+    authorityClasses: string[];
+  }>;
+  constraints: Array<Record<string, unknown>>;
+  knownLimits: Array<Record<string, unknown>>;
+  intents: ProfileApplicationIntent[];
+  presentation: { mode: 'generic' };
+  protocol: string[];
+  qualified: boolean;
+  qualification: {
+    qualified: boolean;
+    status: 'not-qualified' | 'qualification-failed' | 'qualified';
+    reason?: string;
+    receiptId?: string;
+    witnessId?: string;
+    evidenceScope?: string[];
+    diagnosis?: Record<string, unknown>;
+  };
+};
+
+export type ProfileKfd3QualificationReceipt = {
+  schema: 'kungfu.profile-kfd3-qualification-receipt/v1';
+  receiptId: string;
+  profileId: string;
+  profileSuiteRoot: string;
+  collaborationRoot: string;
+  closureRoot: string;
+  profileRevision: number;
+  qualified: true;
+  evidenceScope: string[];
+  witness: {
+    schema: 'kungfu.profile-kfd3-witness/v1';
+    witnessId: string;
+    qualificationReceiptId: string;
+    qualified: true;
+  };
+};
+
+export type ProfileKfd3Verification = {
+  schema: 'kungfu.profile-kfd3-verification/v1';
+  profileId: string;
+  profileSuiteRoot: string;
+  receiptId: string;
+  witnessId: string;
+  verified: true;
+};
+
+export type ProfileIntentPlan = {
+  schema: 'kungfu.profile-intent-plan/v1';
+  planId: string;
+  profileSuiteRoot: string;
+  collaborationRoot: string;
+  closureRoot: string;
+  intentId: string;
+  actionPlanId: string;
+  source: string;
+  actionPlan: Record<string, unknown>;
+  decisionCard: Record<string, unknown>;
+  protocolStage: 'preview';
+};
+
+export type ProfileIntentReceipt = {
+  schema: 'kungfu.profile-intent-receipt/v1';
+  receiptId: string;
+  planId: string;
+  actionPlanId: string;
+  intentId: string;
+  verified: false;
+  executionReceiptVerified: boolean;
+  verification: {
+    schema: 'kungfu.profile-intent-verification/v1';
+    receiptId: string;
+    verified: true;
+  };
+};
+
 export type ProfileSourceDiscovery = {
   schema: 'kungfu.profile-source-discovery/v1';
   profileId: string;
@@ -130,6 +238,28 @@ export type Profile = {
   discoverAsync: (profileId: string) => Promise<ProfileSourceDiscovery>;
   manager: () => ProfileManagerProjection;
   managerAsync: () => Promise<ProfileManagerProjection>;
+  application: (source: string) => ProfileApplicationProjection;
+  applicationAsync: (source: string) => Promise<ProfileApplicationProjection>;
+  qualifyKfd3: (source: string) => ProfileKfd3QualificationReceipt;
+  qualifyKfd3Async: (
+    source: string,
+  ) => Promise<ProfileKfd3QualificationReceipt>;
+  verifyKfd3Async: (
+    source: string,
+    receiptPath: string,
+  ) => Promise<ProfileKfd3Verification>;
+  intentPlan: (source: string, intentId: string) => ProfileIntentPlan;
+  intentPlanAsync: (
+    source: string,
+    intentId: string,
+  ) => Promise<ProfileIntentPlan>;
+  authorizeIntentAsync: (
+    source: string,
+    intentId: string,
+    expectedPlanId: string,
+    choice: 'approve' | 'deny',
+    authorizedBy: string,
+  ) => Promise<ProfileIntentReceipt>;
   catalog: (
     source: string,
     requireActive?: boolean,
@@ -223,6 +353,39 @@ export function openProfile(options: OpenProfileOptions): Profile {
       runAsync<ProfileSourceDiscovery>(['discover', profileId]),
     manager: () => run<ProfileManagerProjection>(['manager']),
     managerAsync: () => runAsync<ProfileManagerProjection>(['manager']),
+    application: (source) =>
+      run<ProfileApplicationProjection>(['application', source]),
+    applicationAsync: (source) =>
+      runAsync<ProfileApplicationProjection>(['application', source]),
+    qualifyKfd3: (source) =>
+      run<ProfileKfd3QualificationReceipt>(['kfd3-qualify', source]),
+    qualifyKfd3Async: (source) =>
+      runAsync<ProfileKfd3QualificationReceipt>(['kfd3-qualify', source]),
+    verifyKfd3Async: (source, receiptPath) =>
+      runAsync<ProfileKfd3Verification>(['kfd3-verify', source, receiptPath]),
+    intentPlan: (source, intentId) =>
+      run<ProfileIntentPlan>(['intent', 'plan', source, intentId]),
+    intentPlanAsync: (source, intentId) =>
+      runAsync<ProfileIntentPlan>(['intent', 'plan', source, intentId]),
+    authorizeIntentAsync: (
+      source,
+      intentId,
+      expectedPlanId,
+      choice,
+      authorizedBy,
+    ) =>
+      runAsync<ProfileIntentReceipt>([
+        'intent',
+        'authorize',
+        source,
+        intentId,
+        '--expected-plan-id',
+        expectedPlanId,
+        '--choice',
+        choice,
+        '--authorized-by',
+        authorizedBy,
+      ]),
     catalog: (source, requireActive = false) =>
       run<ProfileCompositionCatalog>(catalogArgs(source, requireActive)),
     catalogAsync: (source, requireActive = false) =>

--- a/framework/api/tests/profile.test.ts
+++ b/framework/api/tests/profile.test.ts
@@ -45,13 +45,76 @@ test('Profile plans preserve source and exact active-root intent', () => {
   profile.catalog('/suite', true);
   profile.discover('kungfu.mission-control');
   profile.queryPlan('/suite', 'week-table');
+  profile.application('/suite');
+  profile.qualifyKfd3('/suite');
+  profile.intentPlan('/suite', 'complete-day');
   profile.lifecyclePlan('install', '/suite');
 
   assert.deepEqual(calls, [
     ['profile', 'catalog', '/suite', '--require-active', '--json'],
     ['profile', 'discover', 'kungfu.mission-control', '--json'],
     ['profile', 'query-plan', '/suite', 'week-table', '--json'],
+    ['profile', 'application', '/suite', '--json'],
+    ['profile', 'kfd3-qualify', '/suite', '--json'],
+    ['profile', 'intent', 'plan', '/suite', 'complete-day', '--json'],
     ['profile', 'plan', 'install', '/suite', '--json'],
+  ]);
+});
+
+test('Profile KFD-3 verification uses the installed receipt verifier', async () => {
+  const calls: string[][] = [];
+  const profile = openProfile({
+    runtimeDir: '/runtime',
+    execFileSync: () => '{}',
+    execFile: async (_file, args) => {
+      calls.push(args);
+      return '{}';
+    },
+  });
+
+  await profile.verifyKfd3Async('/suite', '/tmp/receipt.json');
+
+  assert.deepEqual(calls[0], [
+    'profile',
+    'kfd3-verify',
+    '/suite',
+    '/tmp/receipt.json',
+    '--json',
+  ]);
+});
+
+test('Profile intent authorization re-plans the same shared application path', async () => {
+  const calls: string[][] = [];
+  const profile = openProfile({
+    runtimeDir: '/runtime',
+    execFileSync: () => '{}',
+    execFile: async (_file, args) => {
+      calls.push(args);
+      return '{}';
+    },
+  });
+
+  await profile.authorizeIntentAsync(
+    '/suite',
+    'complete-day',
+    'sha256:reviewed',
+    'approve',
+    'workspace-owner',
+  );
+
+  assert.deepEqual(calls[0], [
+    'profile',
+    'intent',
+    'authorize',
+    '/suite',
+    'complete-day',
+    '--expected-plan-id',
+    'sha256:reviewed',
+    '--choice',
+    'approve',
+    '--authorized-by',
+    'workspace-owner',
+    '--json',
   ]);
 });
 

--- a/framework/core/src/libkungfu/include/kungfu/embedding.h
+++ b/framework/core/src/libkungfu/include/kungfu/embedding.h
@@ -170,8 +170,9 @@ typedef int32_t(KF_EMBEDDING_CALL *kf_embedding_reader_read_batch_v1_fn)(kf_embe
 typedef int32_t(KF_EMBEDDING_CALL *kf_embedding_reader_release_batch_v1_fn)(kf_embedding_reader *reader,
                                                                             uint64_t token);
 typedef int32_t(KF_EMBEDDING_CALL *kf_embedding_reader_close_v1_fn)(kf_embedding_reader *reader);
-typedef int32_t(KF_EMBEDDING_CALL *kf_embedding_storage_fsck_v1_fn)(
-    kf_embedding_context *context, const kf_embedding_storage_fsck_request_v1 *request, kf_embedding_report_v1 *out_report);
+typedef int32_t(KF_EMBEDDING_CALL *kf_embedding_storage_fsck_v1_fn)(kf_embedding_context *context,
+                                                                    const kf_embedding_storage_fsck_request_v1 *request,
+                                                                    kf_embedding_report_v1 *out_report);
 typedef int32_t(KF_EMBEDDING_CALL *kf_embedding_report_release_v1_fn)(kf_embedding_report_v1 *report);
 
 typedef struct kf_embedding_api_v1 {

--- a/framework/core/src/libkungfu/src/runtime/embedding.cpp
+++ b/framework/core/src/libkungfu/src/runtime/embedding.cpp
@@ -258,12 +258,12 @@ const kf_embedding_api_v1 API_V1 = {KF_EMBEDDING_ABI_V1, sizeof(kf_embedding_api
 
 constexpr uint64_t CAPABILITIES_V2 = CAPABILITIES | KF_EMBEDDING_CAP_STORAGE_DIAGNOSTICS;
 
-const kf_embedding_api_v2 API_V2 = {KF_EMBEDDING_ABI_V2, sizeof(kf_embedding_api_v2),
-                                    CAPABILITIES_V2,     context_open,
+const kf_embedding_api_v2 API_V2 = {KF_EMBEDDING_ABI_V2,  sizeof(kf_embedding_api_v2),
+                                    CAPABILITIES_V2,      context_open,
                                     context_capabilities, context_close,
-                                    reader_open,         reader_read_batch,
+                                    reader_open,          reader_read_batch,
                                     reader_release_batch, reader_close,
-                                    storage_fsck,        report_release};
+                                    storage_fsck,         report_release};
 
 } // namespace
 

--- a/framework/core/src/libkungfu/src/runtime/profile/profile_lifecycle.cpp
+++ b/framework/core/src/libkungfu/src/runtime/profile/profile_lifecycle.cpp
@@ -346,8 +346,10 @@ nlohmann::json normalize_refs(const nlohmann::json &value, const char *field, bo
 
 nlohmann::json normalize_profile(const nlohmann::json &input) {
   validate_source_contract(input);
-  require_exact_keys(input, {"schema", "id", "title", "version", "members", "kfd1", "kfd2", "actions", "views",
-                             "migrations", "permissions", "qualification"});
+  require_exact_keys(input,
+                     {"schema", "id", "title", "version", "members", "kfd1", "kfd2", "actions", "views", "migrations",
+                      "permissions", "qualification"},
+                     {"kfd3"});
   if (required_text(input, "schema") != PROFILE_SCHEMA_V1) {
     throw std::invalid_argument("Profile must use kungfu.profile-suite/v1");
   }
@@ -378,25 +380,31 @@ nlohmann::json normalize_profile(const nlohmann::json &input) {
   const auto &qualification = input.at("qualification");
   require_exact_keys(qualification, {"profile"});
 
-  return {{"schema", PROFILE_SCHEMA_V1},
-          {"id", profile_id},
-          {"title", title},
-          {"version", version},
-          {"members", {{"required", required_members}, {"optional", optional_members}}},
-          {"kfd1",
-           {{"contractWorld", normalize_ref(kfd1.at("contractWorld"))},
-            {"factSurfaces", normalize_refs(kfd1.at("factSurfaces"), "kfd1.factSurfaces", true)},
-            {"reducers", normalize_refs(kfd1.at("reducers"), "kfd1.reducers", false)},
-            {"compatibility", normalize_ref(kfd1.at("compatibility"))}}},
-          {"kfd2",
-           {{"claims", normalize_refs(kfd2.at("claims"), "kfd2.claims", true)},
-            {"purposes", normalize_tokens(kfd2.at("purposes"), "kfd2.purposes", true)},
-            {"policies", normalize_refs(kfd2.at("policies"), "kfd2.policies", true)}}},
-          {"actions", registry(input.at("actions"))},
-          {"views", registry(input.at("views"))},
-          {"migrations", registry(input.at("migrations"))},
-          {"permissions", registry(input.at("permissions"))},
-          {"qualification", {{"profile", normalize_ref(qualification.at("profile"))}}}};
+  nlohmann::json normalized = {{"schema", PROFILE_SCHEMA_V1},
+                               {"id", profile_id},
+                               {"title", title},
+                               {"version", version},
+                               {"members", {{"required", required_members}, {"optional", optional_members}}},
+                               {"kfd1",
+                                {{"contractWorld", normalize_ref(kfd1.at("contractWorld"))},
+                                 {"factSurfaces", normalize_refs(kfd1.at("factSurfaces"), "kfd1.factSurfaces", true)},
+                                 {"reducers", normalize_refs(kfd1.at("reducers"), "kfd1.reducers", false)},
+                                 {"compatibility", normalize_ref(kfd1.at("compatibility"))}}},
+                               {"kfd2",
+                                {{"claims", normalize_refs(kfd2.at("claims"), "kfd2.claims", true)},
+                                 {"purposes", normalize_tokens(kfd2.at("purposes"), "kfd2.purposes", true)},
+                                 {"policies", normalize_refs(kfd2.at("policies"), "kfd2.policies", true)}}},
+                               {"actions", registry(input.at("actions"))},
+                               {"views", registry(input.at("views"))},
+                               {"migrations", registry(input.at("migrations"))},
+                               {"permissions", registry(input.at("permissions"))},
+                               {"qualification", {{"profile", normalize_ref(qualification.at("profile"))}}}};
+  if (input.contains("kfd3")) {
+    const auto &kfd3 = input.at("kfd3");
+    require_exact_keys(kfd3, {"collaboration"});
+    normalized["kfd3"] = {{"collaboration", normalize_ref(kfd3.at("collaboration"))}};
+  }
+  return normalized;
 }
 
 nlohmann::json normalize_member_roots(const nlohmann::json &profile, const nlohmann::json &input) {
@@ -445,6 +453,8 @@ std::vector<nlohmann::json> profile_refs(const nlohmann::json &profile) {
   collect_ref(profile.at("migrations").at("registry"), refs);
   collect_ref(profile.at("permissions").at("registry"), refs);
   collect_ref(profile.at("qualification").at("profile"), refs);
+  if (profile.contains("kfd3"))
+    collect_ref(profile.at("kfd3").at("collaboration"), refs);
   std::sort(refs.begin(), refs.end(), [](const auto &left, const auto &right) {
     return left.at("path").template get<std::string>() < right.at("path").template get<std::string>();
   });

--- a/framework/core/src/libkungfu/tests/profile_lifecycle_tests.cpp
+++ b/framework/core/src/libkungfu/tests/profile_lifecycle_tests.cpp
@@ -143,6 +143,15 @@ void rewrite_bound_artifact(const fs::path &profile_path, const std::string &rel
   write_text(profile_path, document.dump(2));
 }
 
+void attach_kfd3_collaboration(const fs::path &profile_path, const std::string &value) {
+  const auto relative = std::string("collaboration/interface.json");
+  write_text(profile_path.parent_path() / relative, value);
+  std::ifstream input(profile_path);
+  auto document = nlohmann::json::parse(input);
+  document["kfd3"] = {{"collaboration", {{"path", relative}, {"sha256", sha256(value)}}}};
+  write_text(profile_path, document.dump(2));
+}
+
 nlohmann::json plan(const fs::path &runtime, const nlohmann::json &request) {
   return profile::plan_profile_lifecycle(runtime.string(), request);
 }
@@ -181,6 +190,22 @@ void test_inspection_is_content_bound_and_confined() {
   write_text(escaped.profile_path, document.dump(2));
   require_invalid([&] { (void)profile::inspect_profile(escaped.profile_path.string(), member_roots()); },
                   "parent traversal was accepted");
+}
+
+void test_optional_kfd3_collaboration_is_content_bound() {
+  temp_tree tree;
+  const auto fixture = write_package(tree.root() / "package", "1.0.0");
+  const auto collaboration = R"({"schema":"kungfu.profile-collaboration/v1"})";
+  attach_kfd3_collaboration(fixture.profile_path, collaboration);
+
+  const auto inspection = profile::inspect_profile(fixture.profile_path.string(), member_roots());
+  require(inspection.at("profile").at("kfd3").at("collaboration").at("path") == "collaboration/interface.json",
+          "KFD-3 collaboration authority was not preserved");
+  require(inspection.at("artifacts").size() == 13, "KFD-3 collaboration artifact was not in content closure");
+
+  write_text(fixture.profile_path.parent_path() / "collaboration" / "interface.json", "drift");
+  require_invalid([&] { (void)profile::inspect_profile(fixture.profile_path.string(), member_roots()); },
+                  "KFD-3 collaboration artifact hash drift was accepted");
 }
 
 void test_lifecycle_plan_apply_fold_and_history() {
@@ -321,6 +346,7 @@ void test_incompatible_runtime_and_unsupported_qualification_fail_closed() {
 int run_tests() {
   const std::pair<const char *, void (*)()> tests[] = {
       {"inspection is deterministic, content-bound, and confined", test_inspection_is_content_bound_and_confined},
+      {"optional KFD-3 collaboration is content-bound", test_optional_kfd3_collaboration_is_content_bound},
       {"lifecycle plans, receipts, folds, history, and cuts", test_lifecycle_plan_apply_fold_and_history},
       {"stale and cross-runtime plans fail closed", test_stale_plan_and_wrong_runtime_fail_closed},
       {"runtime and qualification inputs fail closed",

--- a/framework/core/src/libwasm/CMakeLists.txt
+++ b/framework/core/src/libwasm/CMakeLists.txt
@@ -1,5 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
+# Shifu cache projection intentionally gives Cargo a short-lived wrapper path.
+# CMake persists find_program results, so discard a wrapper that disappeared
+# with the previous overlay before resolving the current command environment.
+if(KF_LIBWASM_CARGO AND NOT EXISTS "${KF_LIBWASM_CARGO}")
+  unset(KF_LIBWASM_CARGO CACHE)
+endif()
 find_program(KF_LIBWASM_CARGO cargo REQUIRED)
 set(KF_LIBWASM_CARGO_REGISTRY_DEFAULT "")
 if(DEFINED ENV{KF_LIBWASM_CARGO_REGISTRY})

--- a/framework/core/src/python/kungfu/agent/brief.md
+++ b/framework/core/src/python/kungfu/agent/brief.md
@@ -108,6 +108,16 @@ kungfu profile capabilities --json
 kungfu profile examples --json
 kungfu profile scaffold brief.json --out ./my-profile --json
 kungfu profile validate ./my-profile --json
+kungfu profile collaboration ./my-profile --json
+kungfu profile application ./my-profile --json
+kungfu profile intent inspect ./my-profile <intent-id> --json
+kungfu profile intent advise ./my-profile <intent-id> --json
+kungfu profile intent plan ./my-profile <intent-id> --json
+kungfu profile intent authorize ./my-profile <intent-id> --expected-plan-id <id> --choice approve --authorized-by <actor> --json
+kungfu profile intent apply plan.json --authorization-file answer.json --json
+kungfu profile intent verify ./my-profile receipt.json --json
+kungfu profile kfd3-qualify ./my-profile --json
+kungfu profile kfd3-verify ./my-profile receipt.json --json
 kungfu profile qualify ./my-profile --json
 kungfu profile plan install ./my-profile --json
 kungfu profile manager --json
@@ -120,6 +130,21 @@ lifecycle state to Core. Decision cards are open questions, not authorization;
 after an answer, produce a fresh plan and apply it with the resulting external
 authorization identity. Optional code members build with
 `kungfu sdk kfx build` and do not require rebuilding Kungfu.
+When a brief includes `collaboration`, scaffold emits a content-bound generic
+Human/Agent declaration with explicit participants, value, constraints, and
+known limits. `profile collaboration` audits action/view/authority/capability
+closure and reports `declared-closed`, but it remains `qualified: false` until
+Kungfu has produced the runtime probes and KFD-3 witness; schema validity,
+KFD-1/KFD-2 qualification, and KFD-3 qualification are separate states. The
+`kfd3-qualify` command earns a deterministic receipt only for an exact active
+root after installed Agent-interface closure, custom-view no-bypass, and
+Human/Agent exact-plan probes pass. A Profile cannot supply that receipt or
+witness in its own source tree.
+The generic Profile Manager calls these same installed application commands.
+Its intent card is a visual projection of the same Profile/collaboration roots,
+decision card, action receipt, and verification result; GUI focus or custom
+presentation never grants a separate mutation path. Verification proves the
+declared cut and execution receipt, not that a domain claim is true in reality.
 The Profile Manager GUI reads the same manager projection and previews the same
 decision card. Its apply path re-plans against the reviewed plan id; GUI focus
 does not activate a Profile and removing a Profile does not delete facts.

--- a/framework/core/src/python/kungfu/agent/commands.json
+++ b/framework/core/src/python/kungfu/agent/commands.json
@@ -555,6 +555,12 @@
     },
     {
       "apiId": "kungfu.profile.source",
+      "name": "kungfu profile collaboration <source> --json",
+      "maturity": "experimental",
+      "purpose": "Inspect the content-bound Human and Agent collaboration declaration, closure root, constraints, known limits, and qualification boundary."
+    },
+    {
+      "apiId": "kungfu.profile.source",
       "name": "kungfu profile qualify <source> --json",
       "maturity": "experimental",
       "purpose": "Run only the installed source-contract, content-closure, and runtime-contract qualification checks."
@@ -612,6 +618,60 @@
       "name": "kungfu profile invoke <source> <action> [--execute --plan-file <plan.json> --authorization-file <answer.json>] --json",
       "maturity": "experimental",
       "purpose": "Plan first, then invoke a supported confined Profile action with freshness and authorization checks."
+    },
+    {
+      "apiId": "kungfu.profile.application",
+      "name": "kungfu profile application <source> --json",
+      "maturity": "experimental",
+      "purpose": "Project the content-bound generic Human/Agent application model for one Profile."
+    },
+    {
+      "apiId": "kungfu.profile.application",
+      "name": "kungfu profile intent inspect <source> <intent-id> --json",
+      "maturity": "experimental",
+      "purpose": "Inspect one declared intent, its view, and exact Profile revision cut."
+    },
+    {
+      "apiId": "kungfu.profile.application",
+      "name": "kungfu profile intent advise <source> <intent-id> --json",
+      "maturity": "experimental",
+      "purpose": "Project current constraints, known limits, capabilities, and preconditions without mutating state."
+    },
+    {
+      "apiId": "kungfu.profile.application",
+      "name": "kungfu profile intent plan <source> <intent-id> --json",
+      "maturity": "experimental",
+      "purpose": "Preview an intent bound to the Profile root, collaboration root, revision, action, and decision card."
+    },
+    {
+      "apiId": "kungfu.profile.application",
+      "name": "kungfu profile intent authorize <source> <intent-id> --expected-plan-id <id> --choice approve --authorized-by <actor> --json",
+      "maturity": "experimental",
+      "purpose": "Re-plan, authorize, execute, emit a receipt, and verify the same exact intent reviewed by Human or Agent clients."
+    },
+    {
+      "apiId": "kungfu.profile.application",
+      "name": "kungfu profile intent apply <plan.json> --authorization-file <answer.json> --json",
+      "maturity": "experimental",
+      "purpose": "Execute an authorized intent plan only while its Profile, collaboration, closure, revision, action, and input identities remain current."
+    },
+    {
+      "apiId": "kungfu.profile.application",
+      "name": "kungfu profile intent verify <source> <receipt.json> --json",
+      "maturity": "experimental",
+      "purpose": "Verify an execution receipt against the current Profile and collaboration closures while preserving the domain-truth known limit."
+    },
+    {
+      "apiId": "kungfu.profile.kfd3-qualification",
+      "name": "kungfu profile kfd3-qualify <source> --json",
+      "maturity": "experimental",
+      "purpose": "Audit the active Profile's public closure, custom-view no-bypass boundary, and dual-client exact plans, then emit a Kungfu-owned KFD-3 receipt and witness."
+    },
+    {
+      "apiId": "kungfu.profile.kfd3-qualification",
+      "name": "kungfu profile kfd3-verify <source> <receipt.json> --json",
+      "maturity": "experimental",
+      "purpose": "Re-run qualification and reject a stale or tampered receipt or witness."
     },
     {
       "apiId": "kungfu.profile.manager",

--- a/framework/core/src/python/kungfu/agent/kfd3_api.registry.json
+++ b/framework/core/src/python/kungfu/agent/kfd3_api.registry.json
@@ -831,7 +831,7 @@
       "id": "kungfu.profile.source",
       "surface": "cli",
       "name": "kungfu profile validate <source> --json",
-      "aliases": ["kungfu profile qualify <source> --json"],
+      "aliases": ["kungfu profile collaboration <source> --json", "kungfu profile qualify <source> --json"],
       "purpose": "Resolve KFX members and validate or qualify the exact source closure against installed authorities.",
       "maturity": "experimental",
       "visibility": "public-agent",
@@ -882,6 +882,17 @@
       "projections": ["commands.json", "agent-pack-doc", "provider-skill"]
     },
     {
+      "id": "kungfu.profile.application",
+      "surface": "cli-api-gui",
+      "name": "kungfu profile application <source> --json",
+      "aliases": ["kungfu profile intent inspect <source> <intent-id> --json", "kungfu profile intent advise <source> <intent-id> --json", "kungfu profile intent plan <source> <intent-id> --json", "kungfu profile intent authorize <source> <intent-id> --expected-plan-id <id> --choice approve --authorized-by <actor> --json", "kungfu profile intent apply <plan.json> --authorization-file <answer.json> --json", "kungfu profile intent verify <source> <receipt.json> --json"],
+      "purpose": "Project and run the same content-bound inspect, advise, preview, authorize, execute, receipt, and verify protocol for Human GUI and Agent clients.",
+      "maturity": "experimental",
+      "visibility": "public-agent",
+      "anchor": { "kind": "catalog" },
+      "projections": ["commands.json", "agent-pack-doc", "provider-skill", "profile-manager-gui"]
+    },
+    {
       "id": "kungfu.profile.manager",
       "surface": "cli-gui",
       "name": "kungfu profile manager --json",
@@ -890,6 +901,17 @@
       "visibility": "public-agent",
       "anchor": { "kind": "catalog" },
       "projections": ["commands.json", "agent-pack-doc", "profile-manager-gui"]
+    },
+    {
+      "id": "kungfu.profile.kfd3-qualification",
+      "surface": "cli-api-gui",
+      "name": "kungfu profile kfd3-qualify <source> --json",
+      "aliases": ["kungfu profile kfd3-verify <source> <receipt.json> --json"],
+      "purpose": "Earn a scoped Profile KFD-3 receipt and witness only after installed authority, public-surface, no-bypass, and dual-client probes pass.",
+      "maturity": "experimental",
+      "visibility": "public-agent",
+      "anchor": { "kind": "catalog" },
+      "projections": ["commands.json", "agent-pack-doc", "provider-skill", "profile-manager-gui"]
     },
     {
       "id": "kungfu.profile.composition",

--- a/framework/core/src/python/kungfu/agent/profile-sdk.contract.json
+++ b/framework/core/src/python/kungfu/agent/profile-sdk.contract.json
@@ -1,7 +1,7 @@
 {
   "schema": "kungfu.agent-profile-sdk-contract/v1",
   "id": "kungfu-agent-profile-sdk",
-  "version": 4,
+  "version": 6,
   "briefSchema": {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
@@ -46,6 +46,9 @@
         "properties": {
           "mode": { "enum": ["additive", "explicit-destructive-plan"] }
         }
+      },
+      "collaboration": {
+        "type": "object"
       }
     }
   },
@@ -258,6 +261,232 @@
           }
         }
       }
+    }
+  },
+  "collaborationSchema": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "additionalProperties": false,
+    "required": ["schema", "profileId", "value", "participants", "intents", "constraints", "knownLimits", "presentation"],
+    "properties": {
+      "schema": { "const": "kungfu.profile-collaboration/v1" },
+      "profileId": { "type": "string", "pattern": "^[A-Za-z0-9._-]+$" },
+      "value": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["summary", "participantBenefits"],
+        "properties": {
+          "summary": { "type": "string", "minLength": 1 },
+          "participantBenefits": {
+            "type": "array",
+            "minItems": 2,
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["participantKind", "description"],
+              "properties": {
+                "participantKind": { "enum": ["human", "agent", "operator", "service"] },
+                "description": { "type": "string", "minLength": 1 }
+              }
+            }
+          }
+        }
+      },
+      "participants": {
+        "type": "array",
+        "minItems": 2,
+        "items": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["id", "kind", "title", "authorityClasses"],
+          "properties": {
+            "id": { "type": "string", "pattern": "^[A-Za-z0-9._-]+$" },
+            "kind": { "enum": ["human", "agent", "operator", "service"] },
+            "title": { "type": "string", "minLength": 1 },
+            "authorityClasses": { "type": "array", "uniqueItems": true, "items": { "type": "string", "pattern": "^[A-Za-z0-9._-]+$" } }
+          }
+        }
+      },
+      "intents": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["id", "title", "actionId", "inspectViewId", "verifyViewId", "requiredAuthority", "requiredCapabilities", "material", "protocol"],
+          "properties": {
+            "id": { "type": "string", "pattern": "^[A-Za-z0-9._-]+$" },
+            "title": { "type": "string", "minLength": 1 },
+            "actionId": { "type": "string", "pattern": "^[A-Za-z0-9._-]+$" },
+            "inspectViewId": { "type": "string", "pattern": "^[A-Za-z0-9._-]+$" },
+            "verifyViewId": { "type": "string", "pattern": "^[A-Za-z0-9._-]+$" },
+            "requiredAuthority": { "type": "string", "pattern": "^[A-Za-z0-9._-]+$", "not": { "const": "none" } },
+            "requiredCapabilities": { "type": "array", "uniqueItems": true, "items": { "type": "string", "pattern": "^[A-Za-z0-9._-]+$" } },
+            "material": { "const": true },
+            "protocol": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["inspect", "advise", "preview", "authorize", "execute", "receipt", "verify"],
+              "properties": {
+                "inspect": { "const": "profile.intent.inspect" },
+                "advise": { "const": "profile.intent.advise" },
+                "preview": { "const": "profile.intent.plan" },
+                "authorize": { "const": "profile.decide" },
+                "execute": { "const": "profile.intent.apply" },
+                "receipt": { "const": "profile.intent.receipt" },
+                "verify": { "const": "profile.intent.verify" }
+              }
+            }
+          }
+        }
+      },
+      "constraints": {
+        "type": "array",
+        "minItems": 1,
+        "items": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["id", "description", "enforcement", "appliesTo"],
+          "properties": {
+            "id": { "type": "string", "pattern": "^[A-Za-z0-9._-]+$" },
+            "description": { "type": "string", "minLength": 1 },
+            "enforcement": { "enum": ["runtime", "external-policy"] },
+            "appliesTo": { "type": "array", "minItems": 1, "uniqueItems": true, "items": { "type": "string", "pattern": "^(?:\\*|[A-Za-z0-9._-]+)$" } }
+          }
+        }
+      },
+      "knownLimits": {
+        "type": "array",
+        "minItems": 1,
+        "items": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["id", "description", "effect"],
+          "properties": {
+            "id": { "type": "string", "pattern": "^[A-Za-z0-9._-]+$" },
+            "description": { "type": "string", "minLength": 1 },
+            "effect": { "enum": ["degraded", "unsupported", "external-verification-required"] }
+          }
+        }
+      },
+      "presentation": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["mode", "homeViewId"],
+        "properties": {
+          "mode": { "const": "generic" },
+          "homeViewId": { "type": ["string", "null"], "pattern": "^[A-Za-z0-9._-]+$" }
+        }
+      }
+    }
+  },
+  "kfd3QualificationReceiptSchema": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "additionalProperties": false,
+    "required": ["schema", "receiptId", "profileId", "profileSuiteRoot", "collaborationRoot", "closureRoot", "profileRevision", "runtimeContract", "authority", "surfaceInventory", "noBypass", "clientProbes", "knownLimits", "evidenceScope", "qualified", "witness"],
+    "properties": {
+      "schema": { "const": "kungfu.profile-kfd3-qualification-receipt/v1" },
+      "receiptId": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+      "profileId": { "type": "string", "pattern": "^[A-Za-z0-9._-]+$" },
+      "profileSuiteRoot": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+      "collaborationRoot": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+      "closureRoot": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+      "profileRevision": { "type": "integer", "minimum": 1 },
+      "runtimeContract": { "const": "kungfu.profile-lifecycle/v1" },
+      "authority": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["standard", "registryId", "registryRoot", "auditRoot", "applicationApi"],
+        "properties": {
+          "standard": { "const": "KFD-3" },
+          "registryId": { "type": "string", "minLength": 1 },
+          "registryRoot": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+          "auditRoot": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+          "applicationApi": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["id", "surface", "name", "aliases"],
+            "properties": {
+              "id": { "const": "kungfu.profile.application" },
+              "surface": { "type": "string", "minLength": 1 },
+              "name": { "type": "string", "minLength": 1 },
+              "aliases": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 } }
+            }
+          }
+        }
+      },
+      "surfaceInventory": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["intentIds", "actionIds", "viewIds", "applicationApiId"],
+        "properties": {
+          "intentIds": { "type": "array", "minItems": 1, "uniqueItems": true, "items": { "type": "string" } },
+          "actionIds": { "type": "array", "minItems": 1, "uniqueItems": true, "items": { "type": "string" } },
+          "viewIds": { "type": "array", "minItems": 1, "uniqueItems": true, "items": { "type": "string" } },
+          "applicationApiId": { "const": "kungfu.profile.application" }
+        }
+      },
+      "noBypass": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["passed", "policy", "customViews", "executableFacetCount"],
+        "properties": {
+          "passed": { "const": true },
+          "policy": { "const": "generic-renderer-or-capability-free-sandboxed-view/v1" },
+          "customViews": { "type": "array", "items": { "type": "object" } },
+          "executableFacetCount": { "const": 0 }
+        }
+      },
+      "clientProbes": {
+        "type": "array",
+        "minItems": 1,
+        "items": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["intentId", "humanPlanId", "agentPlanId", "actionPlanId", "matched"],
+          "properties": {
+            "intentId": { "type": "string", "minLength": 1 },
+            "humanPlanId": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+            "agentPlanId": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+            "actionPlanId": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+            "matched": { "const": true }
+          }
+        }
+      },
+      "knownLimits": { "type": "array", "minItems": 1, "items": { "type": "object" } },
+      "evidenceScope": { "type": "array", "minItems": 1, "uniqueItems": true, "items": { "type": "string", "minLength": 1 } },
+      "qualified": { "const": true },
+      "witness": {
+        "type": "object",
+        "required": ["schema", "witnessId", "qualificationReceiptId", "issuer", "qualified"],
+        "properties": {
+          "schema": { "const": "kungfu.profile-kfd3-witness/v1" },
+          "witnessId": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+          "qualificationReceiptId": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+          "issuer": { "const": "kungfu-profile-runtime" },
+          "qualified": { "const": true }
+        }
+      }
+    }
+  },
+  "kfd3WitnessSchema": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "additionalProperties": false,
+    "required": ["schema", "witnessId", "profileId", "profileSuiteRoot", "collaborationRoot", "closureRoot", "qualificationReceiptId", "authorityRegistryRoot", "claim", "standard", "issuer", "qualified"],
+    "properties": {
+      "schema": { "const": "kungfu.profile-kfd3-witness/v1" },
+      "witnessId": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+      "profileId": { "type": "string", "pattern": "^[A-Za-z0-9._-]+$" },
+      "profileSuiteRoot": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+      "collaborationRoot": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+      "closureRoot": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+      "qualificationReceiptId": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+      "authorityRegistryRoot": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+      "claim": { "const": "profile-collaboration-closure-qualified" },
+      "standard": { "const": "KFD-3" },
+      "issuer": { "const": "kungfu-profile-runtime" },
+      "qualified": { "const": true }
     }
   },
   "sourceBundleSchema": {

--- a/framework/core/src/python/kungfu/cli/commands/profile.py
+++ b/framework/core/src/python/kungfu/cli/commands/profile.py
@@ -96,6 +96,184 @@ def validate(ctx, source, as_json):
     _json(_run(lambda: profile_sdk.validate_source(source, ctx.runtime_dir)))
 
 
+@profile.command(help="inspect the content-bound Profile collaboration closure")
+@click.argument("source", type=click.Path(exists=True, file_okay=False, path_type=Path))
+@click.option("--json", "as_json", is_flag=True)
+@profile_context
+def collaboration(ctx, source, as_json):
+    _json(_run(lambda: profile_sdk.collaboration(source, ctx.runtime_dir)))
+
+
+@profile.command(help="project a declared Profile for the generic Human/Agent renderer")
+@click.argument("source", type=click.Path(exists=True, file_okay=False, path_type=Path))
+@click.option("--json", "as_json", is_flag=True)
+@profile_context
+def application(ctx, source, as_json):
+    _json(_run(lambda: profile_sdk.application(source, ctx.runtime_dir)))
+
+
+@profile.command(
+    name="kfd3-qualify",
+    help="audit no-bypass and dual-client closure, then emit a Kungfu-owned witness",
+)
+@click.argument("source", type=click.Path(exists=True, file_okay=False, path_type=Path))
+@click.option("--json", "as_json", is_flag=True)
+@profile_context
+def kfd3_qualify(ctx, source, as_json):
+    _json(_run(lambda: profile_sdk.qualify_kfd3(source, ctx.runtime_dir)))
+
+
+@profile.command(
+    name="kfd3-verify",
+    help="verify a KFD-3 qualification receipt against the current earned cut",
+)
+@click.argument("source", type=click.Path(exists=True, file_okay=False, path_type=Path))
+@click.argument(
+    "receipt_file", type=click.Path(exists=True, dir_okay=False, path_type=Path)
+)
+@click.option("--json", "as_json", is_flag=True)
+@profile_context
+def kfd3_verify(ctx, source, receipt_file, as_json):
+    _json(
+        _run(
+            lambda: profile_sdk.verify_kfd3(
+                source, ctx.runtime_dir, _load_json(receipt_file)
+            )
+        )
+    )
+
+
+@profile.group(help="run the shared Profile intent application protocol")
+@click.help_option("-h", "--help")
+@profile_context
+def intent(ctx):
+    pass
+
+
+@intent.command(name="inspect", help="inspect one intent at an exact Profile cut")
+@click.argument("source", type=click.Path(exists=True, file_okay=False, path_type=Path))
+@click.argument("intent_id")
+@click.option("--json", "as_json", is_flag=True)
+@profile_context
+def intent_inspect(ctx, source, intent_id, as_json):
+    _json(_run(lambda: profile_sdk.intent_inspect(source, ctx.runtime_dir, intent_id)))
+
+
+@intent.command(
+    name="advise", help="project constraints and preconditions for one intent"
+)
+@click.argument("source", type=click.Path(exists=True, file_okay=False, path_type=Path))
+@click.argument("intent_id")
+@click.option("--json", "as_json", is_flag=True)
+@profile_context
+def intent_advise(ctx, source, intent_id, as_json):
+    _json(_run(lambda: profile_sdk.intent_advise(source, ctx.runtime_dir, intent_id)))
+
+
+@intent.command(name="plan", help="preview one still-unexecuted intent")
+@click.argument("source", type=click.Path(exists=True, file_okay=False, path_type=Path))
+@click.argument("intent_id")
+@click.option(
+    "--input",
+    "input_path",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+)
+@click.option("--out", type=click.Path(dir_okay=False, path_type=Path))
+@click.option("--json", "as_json", is_flag=True)
+@profile_context
+def intent_plan(ctx, source, intent_id, input_path, out, as_json):
+    payload = _run(
+        lambda: profile_sdk.intent_plan(
+            source,
+            ctx.runtime_dir,
+            intent_id,
+            _load_json(input_path) if input_path else {},
+        )
+    )
+    if out:
+        out.write_text(
+            json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+        payload["intentPlanPath"] = str(out.resolve())
+    _json(payload)
+
+
+@intent.command(
+    name="authorize",
+    help="re-plan, authorize, execute, receipt and verify one exact intent",
+)
+@click.argument("source", type=click.Path(exists=True, file_okay=False, path_type=Path))
+@click.argument("intent_id")
+@click.option(
+    "--input",
+    "input_path",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+)
+@click.option("--expected-plan-id", required=True)
+@click.option("--choice", required=True, type=click.Choice(["approve", "deny"]))
+@click.option("--authorized-by", required=True)
+@click.option("--json", "as_json", is_flag=True)
+@profile_context
+def intent_authorize(
+    ctx, source, intent_id, input_path, expected_plan_id, choice, authorized_by, as_json
+):
+    _json(
+        _run(
+            lambda: profile_sdk.authorize_current_intent(
+                ctx.runtime_dir,
+                source,
+                intent_id,
+                _load_json(input_path) if input_path else {},
+                expected_plan_id,
+                choice,
+                authorized_by,
+            )
+        )
+    )
+
+
+@intent.command(name="apply", help="execute an authorized, still-current intent plan")
+@click.argument(
+    "plan_file", type=click.Path(exists=True, dir_okay=False, path_type=Path)
+)
+@click.option(
+    "--authorization-file",
+    required=True,
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+)
+@click.option("--json", "as_json", is_flag=True)
+@profile_context
+def intent_apply(ctx, plan_file, authorization_file, as_json):
+    _json(
+        _run(
+            lambda: profile_sdk.intent_apply(
+                ctx.runtime_dir,
+                _load_json(plan_file),
+                _load_json(authorization_file),
+            )
+        )
+    )
+
+
+@intent.command(
+    name="verify", help="verify an intent receipt against the current declared closure"
+)
+@click.argument("source", type=click.Path(exists=True, file_okay=False, path_type=Path))
+@click.argument(
+    "receipt_file", type=click.Path(exists=True, dir_okay=False, path_type=Path)
+)
+@click.option("--json", "as_json", is_flag=True)
+@profile_context
+def intent_verify(ctx, source, receipt_file, as_json):
+    _json(
+        _run(
+            lambda: profile_sdk.intent_verify(
+                source, ctx.runtime_dir, _load_json(receipt_file)
+            )
+        )
+    )
+
+
 @profile.command(help="run the installed source qualification checks")
 @click.argument("source", type=click.Path(exists=True, file_okay=False, path_type=Path))
 @click.option("--json", "as_json", is_flag=True)

--- a/framework/core/src/python/kungfu/profile_sdk.py
+++ b/framework/core/src/python/kungfu/profile_sdk.py
@@ -34,6 +34,11 @@ ACTION_RECEIPT_SCHEMA = "kungfu.profile-action-receipt/v1"
 DECISION_ANSWER_SCHEMA = "kungfu.decision-answer/v1"
 SOURCE_BUNDLE_SCHEMA = "kungfu.profile-source-bundle/v1"
 SOURCE_IMPORT_PLAN_SCHEMA = "kungfu.profile-source-import-plan/v1"
+COLLABORATION_SCHEMA = "kungfu.profile-collaboration/v1"
+INTENT_PLAN_SCHEMA = "kungfu.profile-intent-plan/v1"
+INTENT_RECEIPT_SCHEMA = "kungfu.profile-intent-receipt/v1"
+KFD3_QUALIFICATION_RECEIPT_SCHEMA = "kungfu.profile-kfd3-qualification-receipt/v1"
+KFD3_WITNESS_SCHEMA = "kungfu.profile-kfd3-witness/v1"
 
 _TOKEN = re.compile(r"^[A-Za-z0-9._-]+$")
 _IGNORED_PARTS = {".git", "node_modules", "__pycache__", ".DS_Store"}
@@ -76,6 +81,9 @@ def capabilities() -> dict[str, Any]:
             "claims": sdk_contract["claimsSchema"],
             "assessmentPolicies": sdk_contract["assessmentPoliciesSchema"],
             "views": sdk_contract["viewsSchema"],
+            "collaboration": sdk_contract["collaborationSchema"],
+            "kfd3QualificationReceipt": sdk_contract["kfd3QualificationReceiptSchema"],
+            "kfd3Witness": sdk_contract["kfd3WitnessSchema"],
             "sourceBundle": sdk_contract["sourceBundleSchema"],
         },
         "sourcePlanSchema": SOURCE_PLAN_SCHEMA,
@@ -88,6 +96,15 @@ def capabilities() -> dict[str, Any]:
             "scaffold",
             "validate",
             "qualify",
+            "collaboration",
+            "application",
+            "kfd3-qualify",
+            "kfd3-verify",
+            "intent-inspect",
+            "intent-advise",
+            "intent-plan",
+            "intent-apply",
+            "intent-verify",
             "plan",
             "decide",
             "apply",
@@ -423,11 +440,574 @@ def validate_source(source: str | Path, runtime_dir: str | Path) -> dict[str, An
         profile_path=resolved["profilePath"],
         member_roots=resolved["memberRoots"],
     )
+    collaboration = _collaboration_closure(inspection)
     return {
         "schema": "kungfu.profile-validation/v1",
         "source": resolved,
         "inspection": inspection,
+        "collaboration": collaboration,
         "ok": True,
+    }
+
+
+def collaboration(source: str | Path, runtime_dir: str | Path) -> dict[str, Any]:
+    """Return the installed, content-bound KFD-3 declaration closure."""
+
+    return validate_source(source, runtime_dir)["collaboration"]
+
+
+def application(
+    source: str | Path,
+    runtime_dir: str | Path,
+    *,
+    include_qualification: bool = True,
+) -> dict[str, Any]:
+    """Project one declared collaboration closure for generic Human/Agent use."""
+
+    validated = validate_source(source, runtime_dir)
+    closure = validated["collaboration"]
+    if not closure["declared"]:
+        raise ProfileSdkError(
+            "collaboration-not-declared",
+            "Profile has no collaboration interface to project",
+        )
+    inspection = validated["inspection"]
+    profile = inspection["profile"]
+    actions = _read_ref_json(inspection, profile["actions"]["registry"])["actions"]
+    views = _read_ref_json(inspection, profile["views"]["registry"])["views"]
+    actions_by_id = {row["id"]: row for row in actions}
+    views_by_id = {row["id"]: row for row in views}
+    try:
+        state = storage_service.profile_lifecycle(
+            runtime_dir, "get", profile_id=profile["id"]
+        )
+    except ValueError as error:
+        if not str(error).startswith("Profile not found:"):
+            raise
+        state = None
+    active_exact_root = bool(
+        state
+        and state.get("activated")
+        and state.get("profile_suite_root") == inspection["profile_suite_root"]
+    )
+    granted = sorted((state or {}).get("granted_permissions", []))
+    intents = []
+    for intent in closure["intents"]:
+        intents.append(
+            {
+                **intent,
+                "action": actions_by_id[intent["actionId"]],
+                "inspectView": views_by_id[intent["inspectViewId"]],
+                "verifyView": views_by_id[intent["verifyViewId"]],
+                "missingCapabilities": sorted(
+                    set(intent["requiredCapabilities"]) - set(granted)
+                ),
+            }
+        )
+    qualification_status: dict[str, Any] = {
+        "qualified": False,
+        "status": "not-qualified",
+        "reason": "Profile must be active at this exact root before KFD-3 qualification",
+    }
+    if include_qualification and active_exact_root:
+        try:
+            earned = qualify_kfd3(source, runtime_dir)
+            qualification_status = {
+                "qualified": True,
+                "status": "qualified",
+                "receiptId": earned["receiptId"],
+                "witnessId": earned["witness"]["witnessId"],
+                "evidenceScope": earned["evidenceScope"],
+            }
+        except ProfileSdkError as error:
+            qualification_status = {
+                "qualified": False,
+                "status": "qualification-failed",
+                "diagnosis": error.diagnosis,
+            }
+    return {
+        "schema": "kungfu.profile-application/v1",
+        "profileId": profile["id"],
+        "profileSuiteRoot": inspection["profile_suite_root"],
+        "collaborationRoot": closure["collaborationRoot"],
+        "closureRoot": closure["closureRoot"],
+        "source": str(Path(source).resolve()),
+        "activeExactRoot": active_exact_root,
+        "profileRevision": (state or {}).get("revision"),
+        "grantedCapabilities": granted,
+        "value": closure["value"],
+        "participants": closure["participants"],
+        "constraints": closure["constraints"],
+        "knownLimits": closure["knownLimits"],
+        "intents": intents,
+        "presentation": {"mode": "generic"},
+        "protocol": closure["protocol"],
+        "qualified": qualification_status["qualified"],
+        "qualification": qualification_status,
+    }
+
+
+def intent_inspect(
+    source: str | Path, runtime_dir: str | Path, intent_id: str
+) -> dict[str, Any]:
+    projection = application(source, runtime_dir, include_qualification=False)
+    intent = next(
+        (row for row in projection["intents"] if row["id"] == intent_id), None
+    )
+    if intent is None:
+        raise ProfileSdkError(
+            "collaboration-intent-not-found", f"intent not found: {intent_id}"
+        )
+    return {
+        "schema": "kungfu.profile-intent-inspection/v1",
+        "profileId": projection["profileId"],
+        "profileSuiteRoot": projection["profileSuiteRoot"],
+        "collaborationRoot": projection["collaborationRoot"],
+        "closureRoot": projection["closureRoot"],
+        "source": projection["source"],
+        "profileRevision": projection["profileRevision"],
+        "activeExactRoot": projection["activeExactRoot"],
+        "intent": intent,
+        "cut": {
+            "kind": "profile-revision",
+            "value": projection["profileRevision"],
+        },
+    }
+
+
+def intent_advise(
+    source: str | Path, runtime_dir: str | Path, intent_id: str
+) -> dict[str, Any]:
+    inspected = intent_inspect(source, runtime_dir, intent_id)
+    intent = inspected["intent"]
+    application_value = application(source, runtime_dir, include_qualification=False)
+    constraints = [
+        row
+        for row in application_value["constraints"]
+        if "*" in row["appliesTo"] or intent_id in row["appliesTo"]
+    ]
+    eligible = inspected["activeExactRoot"] and not intent["missingCapabilities"]
+    return {
+        "schema": "kungfu.profile-intent-advice/v1",
+        "profileId": inspected["profileId"],
+        "profileSuiteRoot": inspected["profileSuiteRoot"],
+        "collaborationRoot": inspected["collaborationRoot"],
+        "closureRoot": inspected["closureRoot"],
+        "source": inspected["source"],
+        "intentId": intent_id,
+        "eligible": eligible,
+        "recommendation": "preview" if eligible else "resolve-preconditions",
+        "constraints": constraints,
+        "knownLimits": application_value["knownLimits"],
+        "missingCapabilities": intent["missingCapabilities"],
+        "preconditions": {
+            "activeExactRoot": inspected["activeExactRoot"],
+            "profileRevision": inspected["profileRevision"],
+        },
+    }
+
+
+def intent_plan(
+    source: str | Path,
+    runtime_dir: str | Path,
+    intent_id: str,
+    input_value: Any,
+) -> dict[str, Any]:
+    advice = intent_advise(source, runtime_dir, intent_id)
+    if not advice["eligible"]:
+        raise ProfileSdkError(
+            "intent-precondition-failed",
+            "intent cannot be previewed until its active-root and capability preconditions hold",
+            advice=advice,
+        )
+    inspected = intent_inspect(source, runtime_dir, intent_id)
+    action_plan = plan_action(
+        source, runtime_dir, inspected["intent"]["actionId"], input_value
+    )
+    identity = {
+        "profileSuiteRoot": inspected["profileSuiteRoot"],
+        "collaborationRoot": inspected["collaborationRoot"],
+        "closureRoot": inspected["closureRoot"],
+        "intentId": intent_id,
+        "actionPlanId": action_plan["planId"],
+        "input": input_value,
+    }
+    return {
+        "schema": INTENT_PLAN_SCHEMA,
+        "planId": _root(identity),
+        **identity,
+        "source": inspected["source"],
+        "actionPlan": action_plan,
+        "decisionCard": action_plan.get("decisionCard"),
+        "protocolStage": "preview",
+    }
+
+
+def intent_apply(
+    runtime_dir: str | Path,
+    plan: Mapping[str, Any],
+    answer: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    if plan.get("schema") != INTENT_PLAN_SCHEMA:
+        raise ProfileSdkError(
+            "intent-plan-invalid", "intent apply requires an intent plan"
+        )
+    refreshed = intent_plan(
+        str(plan.get("source") or ""),
+        runtime_dir,
+        str(plan.get("intentId") or ""),
+        plan.get("input"),
+    )
+    if refreshed["planId"] != plan.get("planId"):
+        raise ProfileSdkError("intent-plan-stale", "intent plan changed after preview")
+    action_receipt = authorized_action_invoke(
+        runtime_dir, plan.get("actionPlan") or {}, answer
+    )
+    identity = {
+        "planId": plan["planId"],
+        "actionPlanId": plan["actionPlanId"],
+        "profileSuiteRoot": plan["profileSuiteRoot"],
+        "collaborationRoot": plan["collaborationRoot"],
+        "closureRoot": plan["closureRoot"],
+        "intentId": plan["intentId"],
+        "actionReceipt": action_receipt,
+    }
+    return {
+        "schema": INTENT_RECEIPT_SCHEMA,
+        "receiptId": _root(identity),
+        **identity,
+        "source": plan["source"],
+        "protocolStage": "receipt",
+        "executionReceiptVerified": action_receipt["verified"],
+        "verified": False,
+    }
+
+
+def intent_verify(
+    source: str | Path, runtime_dir: str | Path, receipt: Mapping[str, Any]
+) -> dict[str, Any]:
+    if receipt.get("schema") != INTENT_RECEIPT_SCHEMA:
+        raise ProfileSdkError(
+            "intent-receipt-invalid", "verify requires an intent receipt"
+        )
+    inspected = intent_inspect(source, runtime_dir, str(receipt.get("intentId") or ""))
+    current = {
+        "profileSuiteRoot": inspected["profileSuiteRoot"],
+        "collaborationRoot": inspected["collaborationRoot"],
+        "closureRoot": inspected["closureRoot"],
+    }
+    expected = {key: receipt.get(key) for key in current}
+    if current != expected:
+        raise ProfileSdkError(
+            "intent-receipt-stale",
+            "Profile or collaboration closure changed after execution",
+            expected=expected,
+            actual=current,
+        )
+    action_receipt = receipt.get("actionReceipt") or {}
+    verified = bool(
+        receipt.get("executionReceiptVerified")
+        and action_receipt.get("verified")
+        and action_receipt.get("planId") == receipt.get("actionPlanId")
+    )
+    if not verified:
+        raise ProfileSdkError(
+            "intent-execution-unverified", "underlying action receipt is not verified"
+        )
+    return {
+        "schema": "kungfu.profile-intent-verification/v1",
+        "receiptId": receipt["receiptId"],
+        **current,
+        "intentId": receipt["intentId"],
+        "verifyView": inspected["intent"]["verifyView"],
+        "protocolStage": "verify",
+        "verified": True,
+        "evidenceScope": "profile-root/collaboration-root/execution-receipt/declared-verify-view",
+        "knownLimit": "declared verify view is bound but domain outcome truth remains evidence-dependent",
+    }
+
+
+def authorize_current_intent(
+    runtime_dir: str | Path,
+    source: str | Path,
+    intent_id: str,
+    input_value: Any,
+    expected_plan_id: str,
+    choice: str,
+    authorized_by: str,
+) -> dict[str, Any]:
+    plan = intent_plan(source, runtime_dir, intent_id, input_value)
+    if plan["planId"] != expected_plan_id:
+        raise ProfileSdkError(
+            "intent-plan-stale",
+            "intent plan changed; review a fresh preview",
+            expectedPlanId=expected_plan_id,
+            actualPlanId=plan["planId"],
+        )
+    answer = answer_decision(plan["decisionCard"], choice, authorized_by)
+    receipt = intent_apply(runtime_dir, plan, answer)
+    return {**receipt, "verification": intent_verify(source, runtime_dir, receipt)}
+
+
+def _agent_interface_authority() -> dict[str, Any]:
+    """Audit the installed KFD-3 authority rather than trusting Profile prose."""
+
+    from kungfu.agent.kfd3 import registry, registry_digest, verify_agent_interface
+    from kungfu.cli.commands.agent import agent
+
+    verification = verify_agent_interface(agent)
+    application_api = next(
+        (
+            row
+            for row in registry().get("apis", [])
+            if row.get("id") == "kungfu.profile.application"
+        ),
+        None,
+    )
+    if not verification["ok"] or application_api is None:
+        raise ProfileSdkError(
+            "kfd3-authority-audit-failed",
+            "installed collaboration-interface authority is not closed",
+            agentVerification=verification,
+        )
+    return {
+        "standard": "KFD-3",
+        "registryId": verification["registry"]["registryId"],
+        "registryRoot": "sha256:" + registry_digest(),
+        "auditRoot": _root(verification),
+        "applicationApi": {
+            "id": application_api["id"],
+            "surface": application_api["surface"],
+            "name": application_api["name"],
+            "aliases": application_api.get("aliases", []),
+        },
+    }
+
+
+def _profile_facet_audit(resolved: Mapping[str, Any]) -> dict[str, Any]:
+    """Reject executable/custom surfaces that can bypass the shared service."""
+
+    package_dirs = {
+        "suite": Path(str(resolved["source"])),
+        **{
+            str(key): Path(str(path))
+            for key, path in (resolved.get("memberPackages") or {}).items()
+        },
+    }
+    custom_views = []
+    failures = []
+    for key, package_dir in sorted(package_dirs.items()):
+        manifest = kfx_contract.read_manifest_from_dir(str(package_dir))
+        config = (manifest.get("kungfuConfig") or {}).get("config") or {}
+        view = config.get("view")
+        if view is not None:
+            capabilities = sorted(view.get("capabilities") or [])
+            runtime = view.get("runtime") or "node-integrated"
+            entry = str(view.get("entry") or "dist/view/index.js")
+            entry_path = _confined(package_dir, entry)
+            reasons = []
+            if runtime != "sandboxed-ipc":
+                reasons.append("custom Profile views must use sandboxed-ipc")
+            if capabilities:
+                reasons.append(
+                    "custom Profile views may not receive capability handles"
+                )
+            if view.get("system"):
+                reasons.append("custom Profile views may not claim system authority")
+            if not entry_path.is_file():
+                reasons.append("custom Profile view bundle is missing")
+            row = {
+                "packageKey": key,
+                "runtime": runtime,
+                "capabilities": capabilities,
+                "entry": entry,
+                "bundleRoot": (
+                    "sha256:" + _sha256(entry_path.read_bytes())
+                    if entry_path.is_file()
+                    else None
+                ),
+                "passed": not reasons,
+            }
+            custom_views.append(row)
+            if reasons:
+                failures.append(
+                    {"packageKey": key, "facet": "view", "reasons": reasons}
+                )
+        for facet in ("adapter", "service", "wasm"):
+            if config.get(facet) is not None:
+                failures.append(
+                    {
+                        "packageKey": key,
+                        "facet": facet,
+                        "reasons": [
+                            "executable Profile member facets are not yet confined to the shared intent runtime"
+                        ],
+                    }
+                )
+    if failures:
+        raise ProfileSdkError(
+            "kfd3-no-bypass-failed",
+            "Profile exposes a custom surface outside the qualified application service",
+            failures=failures,
+        )
+    return {
+        "passed": True,
+        "policy": "generic-renderer-or-capability-free-sandboxed-view/v1",
+        "customViews": custom_views,
+        "executableFacetCount": 0,
+    }
+
+
+def qualify_kfd3(source: str | Path, runtime_dir: str | Path) -> dict[str, Any]:
+    """Earn a deterministic KFD-3 receipt and scoped witness for one active root."""
+
+    validated = validate_source(source, runtime_dir)
+    resolved = validated["source"]
+    closure = validated["collaboration"]
+    if not closure["declared"]:
+        raise ProfileSdkError(
+            "collaboration-not-declared",
+            "KFD-3 qualification requires a content-bound collaboration facet",
+        )
+    projection = application(source, runtime_dir, include_qualification=False)
+    if not projection["activeExactRoot"]:
+        raise ProfileSdkError(
+            "kfd3-active-root-required",
+            "KFD-3 qualification requires the exact Profile root to be active",
+        )
+    if not projection["intents"]:
+        raise ProfileSdkError(
+            "kfd3-intent-probe-required",
+            "KFD-3 qualification requires at least one material intent probe",
+        )
+    unsupported = [
+        row["id"]
+        for row in projection["intents"]
+        if row["action"]["runner"] != "profile-lifecycle"
+        or row["action"]["operation"] not in {"qualify", "activate", "remove"}
+    ]
+    if unsupported:
+        raise ProfileSdkError(
+            "kfd3-action-runtime-unqualified",
+            "one or more material intents do not resolve to an executable confined runtime",
+            intentIds=unsupported,
+        )
+    authority = _agent_interface_authority()
+    no_bypass = _profile_facet_audit(resolved)
+    probes = []
+    for intent in projection["intents"]:
+        human_plan = intent_plan(source, runtime_dir, intent["id"], {})
+        agent_plan = intent_plan(source, runtime_dir, intent["id"], {})
+        matched = (
+            human_plan["planId"] == agent_plan["planId"]
+            and human_plan["actionPlanId"] == agent_plan["actionPlanId"]
+            and human_plan["closureRoot"] == agent_plan["closureRoot"]
+        )
+        if not matched:
+            raise ProfileSdkError(
+                "kfd3-dual-client-drift",
+                "Human and Agent probes produced different exact plans",
+                intentId=intent["id"],
+            )
+        probes.append(
+            {
+                "intentId": intent["id"],
+                "humanPlanId": human_plan["planId"],
+                "agentPlanId": agent_plan["planId"],
+                "actionPlanId": human_plan["actionPlanId"],
+                "matched": True,
+            }
+        )
+    inventory = {
+        "intentIds": sorted(row["id"] for row in projection["intents"]),
+        "actionIds": sorted(row["actionId"] for row in projection["intents"]),
+        "viewIds": sorted(
+            {
+                view_id
+                for row in projection["intents"]
+                for view_id in (row["inspectViewId"], row["verifyViewId"])
+            }
+        ),
+        "applicationApiId": authority["applicationApi"]["id"],
+    }
+    identity = {
+        "profileId": projection["profileId"],
+        "profileSuiteRoot": projection["profileSuiteRoot"],
+        "collaborationRoot": projection["collaborationRoot"],
+        "closureRoot": projection["closureRoot"],
+        "profileRevision": projection["profileRevision"],
+        "runtimeContract": "kungfu.profile-lifecycle/v1",
+        "authority": authority,
+        "surfaceInventory": inventory,
+        "noBypass": no_bypass,
+        "clientProbes": probes,
+        "knownLimits": projection["knownLimits"],
+        "evidenceScope": [
+            "installed-agent-interface-closure",
+            "profile-content-closure",
+            "public-surface-inventory",
+            "custom-view-no-bypass",
+            "dual-client-exact-plan",
+        ],
+    }
+    receipt = {
+        "schema": KFD3_QUALIFICATION_RECEIPT_SCHEMA,
+        "receiptId": _root(identity),
+        **identity,
+        "qualified": True,
+    }
+    witness_identity = {
+        "profileId": receipt["profileId"],
+        "profileSuiteRoot": receipt["profileSuiteRoot"],
+        "collaborationRoot": receipt["collaborationRoot"],
+        "closureRoot": receipt["closureRoot"],
+        "qualificationReceiptId": receipt["receiptId"],
+        "authorityRegistryRoot": authority["registryRoot"],
+        "claim": "profile-collaboration-closure-qualified",
+    }
+    witness = {
+        "schema": KFD3_WITNESS_SCHEMA,
+        "witnessId": _root(witness_identity),
+        **witness_identity,
+        "standard": "KFD-3",
+        "issuer": "kungfu-profile-runtime",
+        "qualified": True,
+    }
+    _validate_sdk_value("kfd3WitnessSchema", witness, "KFD-3 witness")
+    result = {**receipt, "witness": witness}
+    _validate_sdk_value(
+        "kfd3QualificationReceiptSchema", result, "KFD-3 qualification receipt"
+    )
+    return result
+
+
+def verify_kfd3(
+    source: str | Path, runtime_dir: str | Path, receipt: Mapping[str, Any]
+) -> dict[str, Any]:
+    """Verify a supplied qualification receipt against the current earned cut."""
+
+    _validate_sdk_value(
+        "kfd3QualificationReceiptSchema",
+        dict(receipt),
+        "KFD-3 qualification receipt",
+    )
+    current = qualify_kfd3(source, runtime_dir)
+    if dict(receipt) != current:
+        raise ProfileSdkError(
+            "kfd3-qualification-stale-or-tampered",
+            "qualification receipt does not match the current earned Profile cut",
+            expectedReceiptId=current["receiptId"],
+            actualReceiptId=receipt.get("receiptId"),
+            expectedWitnessId=current["witness"]["witnessId"],
+            actualWitnessId=(receipt.get("witness") or {}).get("witnessId"),
+        )
+    return {
+        "schema": "kungfu.profile-kfd3-verification/v1",
+        "profileId": current["profileId"],
+        "profileSuiteRoot": current["profileSuiteRoot"],
+        "receiptId": current["receiptId"],
+        "witnessId": current["witness"]["witnessId"],
+        "verified": True,
     }
 
 
@@ -455,12 +1035,20 @@ def qualify_source(source: str | Path, runtime_dir: str | Path) -> dict[str, Any
             "This runtime only qualifies content-closure and runtime-contract",
             requested=checks,
         )
+    collaboration = validated["collaboration"]
     return {
         "schema": "kungfu.profile-source-qualification/v1",
         "profileSuiteRoot": inspection["profile_suite_root"],
         "status": "qualified-for-install-plan",
         "checks": sorted(checks),
         "evidenceScope": "source-contract/content-closure/runtime-contract",
+        "kfd3": {
+            "declared": collaboration["declared"],
+            "qualified": False,
+            "status": collaboration.get("qualificationStatus", "not-declared"),
+            "closureRoot": collaboration.get("closureRoot"),
+            "reason": collaboration.get("reason"),
+        },
         "lifecycleMutation": False,
     }
 
@@ -720,7 +1308,7 @@ def semantic_diff(left: str | Path, right: str | Path) -> dict[str, Any]:
         "display": _changes(pa, pb, ["title", "views"]),
         "content": _changes(pa, pb, ["kfd1", "members"]),
         "permission": _changes(pa, pb, ["permissions"]),
-        "authority": _changes(pa, pb, ["actions"]),
+        "authority": _changes(pa, pb, ["actions", "kfd3"]),
         "evidence": _changes(pa, pb, ["kfd2", "qualification"]),
         "migration": _changes(pa, pb, ["migrations"]),
     }
@@ -770,6 +1358,7 @@ def plan_action(
     source: str | Path, runtime_dir: str | Path, action_id: str, input_value: Any
 ) -> dict[str, Any]:
     catalog = action_catalog(source, runtime_dir)
+    collaboration_value = collaboration(source, runtime_dir)
     action = next((row for row in catalog["actions"] if row["id"] == action_id), None)
     if action is None:
         raise ProfileSdkError(
@@ -791,8 +1380,28 @@ def plan_action(
         "action": action,
         "input": input_value,
         "stateRevision": state["revision"],
-        "source": catalog["source"],
     }
+    if collaboration_value["declared"]:
+        intent = next(
+            (
+                row
+                for row in collaboration_value["intents"]
+                if row["actionId"] == action_id
+            ),
+            None,
+        )
+        if intent is None:
+            raise ProfileSdkError(
+                "collaboration-action-closure",
+                "declared collaboration has no intent for this action",
+            )
+        identity.update(
+            {
+                "collaborationRoot": collaboration_value["collaborationRoot"],
+                "closureRoot": collaboration_value["closureRoot"],
+                "intentId": intent["id"],
+            }
+        )
     missing_capabilities = sorted(
         set(action["requiredCapabilities"]) - set(state.get("granted_permissions", []))
     )
@@ -806,6 +1415,7 @@ def plan_action(
         "schema": ACTION_PLAN_SCHEMA,
         "planId": _root(identity),
         **identity,
+        "source": catalog["source"],
         "requiresAuthorization": action["authorityClass"] != "none",
         "effects": action.get("effects", []),
     }
@@ -1071,6 +1681,7 @@ def _normalize_brief(
         "identity",
         "evidence",
         "migration",
+        "collaboration",
     }
     if set(brief) - allowed:
         raise ProfileSdkError(
@@ -1156,6 +1767,30 @@ def _normalize_brief(
         "evidence": dict(brief.get("evidence") or {}),
         "migration": dict(brief.get("migration") or {}),
     }
+    collaboration = brief.get("collaboration")
+    if collaboration is not None:
+        if not isinstance(collaboration, Mapping):
+            raise ProfileSdkError(
+                "collaboration-brief-invalid",
+                "brief.collaboration must be an object when KFD-3 is requested",
+            )
+        artifact = {
+            "schema": COLLABORATION_SCHEMA,
+            "profileId": profile_id,
+            "value": {
+                "summary": collaboration.get("summary"),
+                "participantBenefits": collaboration.get("participantBenefits", []),
+            },
+            "participants": collaboration.get("participants", []),
+            "intents": [],
+            "constraints": collaboration.get("constraints", []),
+            "knownLimits": collaboration.get("knownLimits", []),
+            "presentation": {"mode": "generic", "homeViewId": None},
+        }
+        _validate_sdk_value(
+            "collaborationSchema", artifact, "Profile brief collaboration"
+        )
+        normalized["collaboration"] = artifact
     if not cards:
         _validate_sdk_value("briefSchema", normalized, "Profile brief")
     return normalized, cards
@@ -1203,6 +1838,8 @@ def _source_files(brief: Mapping[str, Any]) -> dict[str, bytes]:
             "checks": ["content-closure", "runtime-contract"],
         },
     }
+    if brief.get("collaboration") is not None:
+        artifacts["collaboration/interface.json"] = brief["collaboration"]
     encoded = {path: _pretty(value) for path, value in artifacts.items()}
 
     def ref(path):
@@ -1231,6 +1868,8 @@ def _source_files(brief: Mapping[str, Any]) -> dict[str, bytes]:
         "permissions": {"registry": ref("permissions.json")},
         "qualification": {"profile": ref("qualification/profile.json")},
     }
+    if brief.get("collaboration") is not None:
+        profile["kfd3"] = {"collaboration": ref("collaboration/interface.json")}
     files = {
         "package.json": _pretty(
             {
@@ -1290,6 +1929,186 @@ def _read_ref_json(
     root = Path(str(inspection["profile_path"])).parent
     path = _confined(root, str(ref["path"]))
     return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _collaboration_closure(inspection: Mapping[str, Any]) -> dict[str, Any]:
+    profile = inspection["profile"]
+    declaration = profile.get("kfd3")
+    if not isinstance(declaration, Mapping):
+        return {
+            "schema": "kungfu.profile-collaboration-closure/v1",
+            "profileId": profile["id"],
+            "profileSuiteRoot": inspection["profile_suite_root"],
+            "status": "not-declared",
+            "declared": False,
+            "qualified": False,
+            "reason": "Profile has no content-bound kfd3.collaboration facet",
+        }
+
+    ref = declaration.get("collaboration")
+    if not isinstance(ref, Mapping):
+        raise ProfileSdkError(
+            "collaboration-ref-invalid",
+            "Profile kfd3 declaration has no collaboration content reference",
+        )
+    artifact = _read_ref_json(inspection, ref)
+    _validate_sdk_value("collaborationSchema", artifact, "collaboration interface")
+    if artifact["profileId"] != profile["id"]:
+        raise ProfileSdkError(
+            "collaboration-profile-mismatch",
+            "collaboration interface profileId does not match the Profile",
+            expected=profile["id"],
+            actual=artifact["profileId"],
+        )
+
+    participants = artifact["participants"]
+    participant_ids = [row["id"] for row in participants]
+    if len(participant_ids) != len(set(participant_ids)):
+        raise ProfileSdkError(
+            "collaboration-participant-duplicate",
+            "collaboration participant ids must be unique",
+        )
+    participant_kinds = {row["kind"] for row in participants}
+    if not {"human", "agent"}.issubset(participant_kinds):
+        raise ProfileSdkError(
+            "collaboration-dual-first-required",
+            "KFD-3 Profile qualification requires human and agent participants",
+            participantKinds=sorted(participant_kinds),
+        )
+    benefit_kinds = {
+        row["participantKind"] for row in artifact["value"]["participantBenefits"]
+    }
+    if not {"human", "agent"}.issubset(benefit_kinds):
+        raise ProfileSdkError(
+            "collaboration-value-incomplete",
+            "Profile value must be explicit for human and agent participants",
+            participantKinds=sorted(benefit_kinds),
+        )
+
+    action_registry = _read_ref_json(inspection, profile["actions"]["registry"])
+    _validate_action_registry(action_registry, profile)
+    actions = {row["id"]: row for row in action_registry["actions"]}
+    view_registry = _read_ref_json(inspection, profile["views"]["registry"])
+    _validate_sdk_value("viewsSchema", view_registry, "view registry")
+    view_ids = [row["id"] for row in view_registry["views"]]
+    if len(view_ids) != len(set(view_ids)):
+        raise ProfileSdkError(
+            "collaboration-view-duplicate", "Profile view ids must be unique"
+        )
+    views = set(view_ids)
+
+    intents = artifact["intents"]
+    intent_ids = [row["id"] for row in intents]
+    action_ids = [row["actionId"] for row in intents]
+    if len(intent_ids) != len(set(intent_ids)) or len(action_ids) != len(
+        set(action_ids)
+    ):
+        raise ProfileSdkError(
+            "collaboration-intent-duplicate",
+            "intent ids and action bindings must be unique",
+        )
+    if set(action_ids) != set(actions):
+        raise ProfileSdkError(
+            "collaboration-action-closure",
+            "every public Profile action must have exactly one collaboration intent",
+            declared=sorted(action_ids),
+            actions=sorted(actions),
+        )
+
+    authority_classes = {
+        authority
+        for participant in participants
+        for authority in participant["authorityClasses"]
+    }
+    for intent in intents:
+        action = actions[intent["actionId"]]
+        missing_views = sorted(
+            {intent["inspectViewId"], intent["verifyViewId"]} - views
+        )
+        if missing_views:
+            raise ProfileSdkError(
+                "collaboration-view-unresolved",
+                "intent inspect and verify views must resolve in the Profile",
+                intentId=intent["id"],
+                missingViews=missing_views,
+            )
+        if intent["requiredAuthority"] != action["authorityClass"]:
+            raise ProfileSdkError(
+                "collaboration-authority-drift",
+                "intent and action authority classes must match",
+                intentId=intent["id"],
+            )
+        if intent["requiredAuthority"] not in authority_classes:
+            raise ProfileSdkError(
+                "collaboration-authority-unowned",
+                "an intent authority class is not owned by any declared participant",
+                intentId=intent["id"],
+            )
+        if sorted(intent["requiredCapabilities"]) != sorted(
+            action["requiredCapabilities"]
+        ):
+            raise ProfileSdkError(
+                "collaboration-capability-drift",
+                "intent and action required capabilities must match",
+                intentId=intent["id"],
+            )
+
+    known_targets = set(intent_ids)
+    for constraint in artifact["constraints"]:
+        unknown = sorted(
+            target
+            for target in constraint["appliesTo"]
+            if target != "*" and target not in known_targets
+        )
+        if unknown:
+            raise ProfileSdkError(
+                "collaboration-constraint-unresolved",
+                "constraint appliesTo contains an unknown intent",
+                constraintId=constraint["id"],
+                unknownIntents=unknown,
+            )
+
+    home_view = artifact["presentation"]["homeViewId"]
+    if home_view is not None and home_view not in views:
+        raise ProfileSdkError(
+            "collaboration-home-view-unresolved",
+            "generic presentation homeViewId must resolve in the Profile",
+            homeViewId=home_view,
+        )
+
+    closure = {
+        "profileSuiteRoot": inspection["profile_suite_root"],
+        "collaborationRoot": f"sha256:{ref['sha256']}",
+        "participantIds": sorted(participant_ids),
+        "intentIds": sorted(intent_ids),
+        "actionIds": sorted(actions),
+        "viewIds": sorted(views),
+        "protocol": [
+            "inspect",
+            "advise",
+            "preview",
+            "authorize",
+            "execute",
+            "receipt",
+            "verify",
+        ],
+    }
+    return {
+        "schema": "kungfu.profile-collaboration-closure/v1",
+        "profileId": profile["id"],
+        **closure,
+        "closureRoot": _root(closure),
+        "status": "declared-closed",
+        "declared": True,
+        "qualified": False,
+        "qualificationStatus": "not-qualified",
+        "genericRenderer": artifact["presentation"]["mode"] == "generic",
+        "value": artifact["value"],
+        "constraints": artifact["constraints"],
+        "knownLimits": artifact["knownLimits"],
+        "participants": participants,
+        "intents": intents,
+    }
 
 
 def _validate_action_registry(

--- a/framework/core/stubs/pykungfu/yijinjing/types.pyi
+++ b/framework/core/stubs/pykungfu/yijinjing/types.pyi
@@ -1,7 +1,7 @@
 from __future__ import annotations
 import pykungfu.yijinjing.enums
 import typing
-__all__: list[str] = ['AcceptedRangeRecorded', 'Outlet', 'CacheReset', 'Channel', 'ChannelCursorUpdated', 'ChannelRequest', 'Config', 'Deregister', 'EpisodeClosed', 'EpisodeFrameAttached', 'EpisodeHeartbeat', 'EpisodeOpen', 'EpisodeRefAttached', 'ExportBundleRecorded', 'ImportManifestAccepted', 'Location', 'ManifestEntryRecorded', 'OperatorStateUpdate', 'OutputKey', 'Register', 'RequestCachedDone', 'RequestReadFrom', 'RequestReadFromOthers', 'RequestReadFromPublic', 'RequestReadFromSync', 'RequestWriteTo', 'RequestWriteToOutlet', 'SourceHeadUpdated', 'SourceRegistered', 'SyntheticData', 'TimeKeyValue', 'TimeRequest', 'TimeReset', 'TimeValue', 'frame_header', 'page_header']
+__all__: list[str] = ['AcceptedRangeRecorded', 'CacheReset', 'Channel', 'ChannelCursorUpdated', 'ChannelRequest', 'Config', 'Deregister', 'EpisodeClosed', 'EpisodeFrameAttached', 'EpisodeHeartbeat', 'EpisodeOpen', 'EpisodeRefAttached', 'ExportBundleRecorded', 'ImportManifestAccepted', 'Location', 'ManifestEntryRecorded', 'OperatorStateUpdate', 'Outlet', 'OutputKey', 'Register', 'RequestCachedDone', 'RequestReadFrom', 'RequestReadFromOthers', 'RequestReadFromPublic', 'RequestReadFromSync', 'RequestWriteTo', 'RequestWriteToOutlet', 'SourceHeadUpdated', 'SourceRegistered', 'SyntheticData', 'TimeKeyValue', 'TimeRequest', 'TimeReset', 'TimeValue', 'frame_header', 'page_header']
 class AcceptedRangeRecorded:
     __has_data__: typing.ClassVar[bool] = True
     __tag__: typing.ClassVar[int] = 10903
@@ -18,28 +18,6 @@ class AcceptedRangeRecorded:
     status: ...
     until: int
     def __eq__(self, arg0: AcceptedRangeRecorded) -> bool:
-        ...
-    def __hash__(self) -> int:
-        ...
-    @typing.overload
-    def __init__(self) -> None:
-        ...
-    @typing.overload
-    def __init__(self, arg0: str) -> None:
-        ...
-    def __parse__(self, arg0: str) -> None:
-        ...
-    def __repr__(self) -> str:
-        ...
-    @property
-    def __uid__(self) -> int:
-        ...
-class Outlet:
-    __has_data__: typing.ClassVar[bool] = True
-    __tag__: typing.ClassVar[int] = 10308
-    dest_id: int
-    source_id: int
-    def __eq__(self, arg0: Outlet) -> bool:
         ...
     def __hash__(self) -> int:
         ...
@@ -503,6 +481,28 @@ class OperatorStateUpdate:
     update_time: int
     value: str
     def __eq__(self, arg0: OperatorStateUpdate) -> bool:
+        ...
+    def __hash__(self) -> int:
+        ...
+    @typing.overload
+    def __init__(self) -> None:
+        ...
+    @typing.overload
+    def __init__(self, arg0: str) -> None:
+        ...
+    def __parse__(self, arg0: str) -> None:
+        ...
+    def __repr__(self) -> str:
+        ...
+    @property
+    def __uid__(self) -> int:
+        ...
+class Outlet:
+    __has_data__: typing.ClassVar[bool] = True
+    __tag__: typing.ClassVar[int] = 10308
+    dest_id: int
+    source_id: int
+    def __eq__(self, arg0: Outlet) -> bool:
         ...
     def __hash__(self) -> int:
         ...

--- a/framework/core/tests/python/test_agent_profile_sdk.py
+++ b/framework/core/tests/python/test_agent_profile_sdk.py
@@ -28,6 +28,46 @@ def brief(**changes):
     return value
 
 
+def collaboration_brief():
+    return {
+        "summary": "Coordinate Week and Day work without hiding authority.",
+        "participantBenefits": [
+            {
+                "participantKind": "human",
+                "description": "Review exact plans and receipts.",
+            },
+            {
+                "participantKind": "agent",
+                "description": "Discover constraints and execute authorized intents.",
+            },
+        ],
+        "participants": [
+            {
+                "id": "owner",
+                "kind": "human",
+                "title": "Owner",
+                "authorityClasses": ["workflow-owner"],
+            },
+            {"id": "worker", "kind": "agent", "title": "Agent", "authorityClasses": []},
+        ],
+        "constraints": [
+            {
+                "id": "authorization",
+                "description": "Material actions require declared authority.",
+                "enforcement": "runtime",
+                "appliesTo": ["*"],
+            }
+        ],
+        "knownLimits": [
+            {
+                "id": "identity",
+                "description": "Actor identity is externally verified.",
+                "effect": "external-verification-required",
+            }
+        ],
+    }
+
+
 def create_source(tmp_path):
     source = tmp_path / "profile"
     plan = profile_sdk.scaffold_plan(brief(), source)
@@ -35,6 +75,140 @@ def create_source(tmp_path):
     receipt = profile_sdk.apply_scaffold(plan)
     assert receipt["verified"] is True
     return source, plan
+
+
+def _write_json(path, value):
+    data = json.dumps(value, indent=2, sort_keys=True).encode() + b"\n"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(data)
+    return {
+        "path": path.relative_to(path.parents[1]).as_posix(),
+        "sha256": hashlib.sha256(data).hexdigest(),
+    }
+
+
+def add_collaboration(source):
+    actions = {
+        "schema": "kungfu.profile-actions/v1",
+        "actions": [
+            {
+                "id": "complete-day",
+                "title": "Complete day",
+                "runner": "kfx-member",
+                "operation": "example-week-day-actions",
+                "authorityClass": "workflow-owner",
+                "requiredCapabilities": [],
+                "effects": ["append-admitted-fact"],
+            }
+        ],
+    }
+    views = {
+        "schema": "kungfu.profile-views/v1",
+        "views": [
+            {
+                "id": "week-state",
+                "title": "Week state",
+                "factSurfaces": ["example.week-day.day"],
+                "definition": {"schema": "kungfu.query.definition/v1"},
+                "view": {"kind": "table", "columns": ["subject_key"]},
+            }
+        ],
+    }
+    collaboration = {
+        "schema": "kungfu.profile-collaboration/v1",
+        "profileId": "example.week-day",
+        "value": {
+            "summary": "Coordinate Week and Day work without hiding authority.",
+            "participantBenefits": [
+                {
+                    "participantKind": "human",
+                    "description": "Review exact plans and receipts.",
+                },
+                {
+                    "participantKind": "agent",
+                    "description": "Discover constraints and execute authorized intents.",
+                },
+            ],
+        },
+        "participants": [
+            {
+                "id": "owner",
+                "kind": "human",
+                "title": "Owner",
+                "authorityClasses": ["workflow-owner"],
+            },
+            {"id": "worker", "kind": "agent", "title": "Agent", "authorityClasses": []},
+        ],
+        "intents": [
+            {
+                "id": "complete-day",
+                "title": "Complete day",
+                "actionId": "complete-day",
+                "inspectViewId": "week-state",
+                "verifyViewId": "week-state",
+                "requiredAuthority": "workflow-owner",
+                "requiredCapabilities": [],
+                "material": True,
+                "protocol": {
+                    "inspect": "profile.intent.inspect",
+                    "advise": "profile.intent.advise",
+                    "preview": "profile.intent.plan",
+                    "authorize": "profile.decide",
+                    "execute": "profile.intent.apply",
+                    "receipt": "profile.intent.receipt",
+                    "verify": "profile.intent.verify",
+                },
+            }
+        ],
+        "constraints": [
+            {
+                "id": "authorization",
+                "description": "Owner approval is required.",
+                "enforcement": "runtime",
+                "appliesTo": ["*"],
+            }
+        ],
+        "knownLimits": [
+            {
+                "id": "identity",
+                "description": "Actor identity is externally verified.",
+                "effect": "external-verification-required",
+            }
+        ],
+        "presentation": {"mode": "generic", "homeViewId": "week-state"},
+    }
+    action_ref = _write_json(source / "actions" / "registry.json", actions)
+    view_ref = _write_json(source / "views" / "registry.json", views)
+    collaboration_ref = _write_json(
+        source / "collaboration" / "interface.json", collaboration
+    )
+    profile_path = source / "profile.json"
+    profile = json.loads(profile_path.read_text())
+    profile["actions"]["registry"] = action_ref
+    profile["views"]["registry"] = view_ref
+    profile["kfd3"] = {"collaboration": collaboration_ref}
+    profile_path.write_text(json.dumps(profile, indent=2, sort_keys=True) + "\n")
+    return collaboration
+
+
+def make_collaboration_action_lifecycle(source):
+    collaboration = add_collaboration(source)
+    actions_path = source / "actions" / "registry.json"
+    actions = json.loads(actions_path.read_text())
+    actions["actions"][0].update(
+        {
+            "title": "Remove Profile",
+            "runner": "profile-lifecycle",
+            "operation": "remove",
+            "effects": ["append-Removed-event"],
+        }
+    )
+    action_ref = _write_json(actions_path, actions)
+    profile_path = source / "profile.json"
+    profile = json.loads(profile_path.read_text())
+    profile["actions"]["registry"] = action_ref
+    profile_path.write_text(json.dumps(profile, indent=2, sort_keys=True) + "\n")
+    return collaboration
 
 
 def test_profile_resolution_skips_unreadable_unrelated_siblings(tmp_path, monkeypatch):
@@ -61,6 +235,23 @@ def test_scaffold_is_plan_first_deterministic_and_does_not_self_certify(tmp_path
     assert first["selfCertifiedFields"] == []
     assert not source.exists()
     assert "profile_suite_root" not in first["files"]["profile.json"]
+
+
+def test_scaffold_can_declare_generic_dual_first_collaboration(tmp_path):
+    source = tmp_path / "profile"
+    plan = profile_sdk.scaffold_plan(brief(collaboration=collaboration_brief()), source)
+    profile_sdk.apply_scaffold(plan)
+
+    profile = json.loads((source / "profile.json").read_text())
+    assert profile["kfd3"]["collaboration"]["path"] == ("collaboration/interface.json")
+    closure = profile_sdk.collaboration(source, tmp_path / "runtime")
+    assert closure["declared"] is True
+    assert closure["qualified"] is False
+    assert closure["genericRenderer"] is True
+    assert closure["actionIds"] == []
+    qualification = profile_sdk.qualify_source(source, tmp_path / "runtime")
+    assert qualification["kfd3"]["declared"] is True
+    assert qualification["kfd3"]["qualified"] is False
 
 
 def test_unresolved_semantics_return_open_decision_cards(tmp_path):
@@ -122,6 +313,356 @@ def test_resolver_computes_exact_member_roots_and_core_verifies_closure(tmp_path
     )
 
 
+def test_collaboration_closure_binds_dual_first_actions_views_and_limits(tmp_path):
+    source, _ = create_source(tmp_path)
+    add_collaboration(source)
+
+    result = profile_sdk.collaboration(source, tmp_path / "runtime")
+
+    assert result["status"] == "declared-closed"
+    assert result["declared"] is True
+    assert result["qualified"] is False
+    assert result["actionIds"] == ["complete-day"]
+    assert result["viewIds"] == ["week-state"]
+    assert result["closureRoot"].startswith("sha256:")
+    assert {row["kind"] for row in result["participants"]} == {"human", "agent"}
+
+
+def test_profile_without_collaboration_is_explicitly_not_declared(tmp_path):
+    source, _ = create_source(tmp_path)
+
+    result = profile_sdk.collaboration(source, tmp_path / "runtime")
+
+    assert result["status"] == "not-declared"
+    assert result["declared"] is False
+    assert result["qualified"] is False
+
+
+def test_collaboration_rejects_missing_agent_participant(tmp_path):
+    source, _ = create_source(tmp_path)
+    collaboration = add_collaboration(source)
+    collaboration["participants"][1] = {
+        "id": "reviewer",
+        "kind": "human",
+        "title": "Reviewer",
+        "authorityClasses": [],
+    }
+    ref = _write_json(source / "collaboration" / "interface.json", collaboration)
+    profile_path = source / "profile.json"
+    profile = json.loads(profile_path.read_text())
+    profile["kfd3"] = {"collaboration": ref}
+    profile_path.write_text(json.dumps(profile, indent=2, sort_keys=True) + "\n")
+
+    try:
+        profile_sdk.collaboration(source, tmp_path / "runtime")
+    except profile_sdk.ProfileSdkError as error:
+        assert error.diagnosis["code"] == "collaboration-dual-first-required"
+    else:
+        raise AssertionError("single-participant collaboration was accepted")
+
+
+def test_collaboration_rejects_action_capability_drift(tmp_path):
+    source, _ = create_source(tmp_path)
+    collaboration = add_collaboration(source)
+    collaboration["intents"][0]["requiredCapabilities"] = ["network"]
+    ref = _write_json(source / "collaboration" / "interface.json", collaboration)
+    profile_path = source / "profile.json"
+    profile = json.loads(profile_path.read_text())
+    profile["kfd3"] = {"collaboration": ref}
+    profile_path.write_text(json.dumps(profile, indent=2, sort_keys=True) + "\n")
+
+    try:
+        profile_sdk.collaboration(source, tmp_path / "runtime")
+    except profile_sdk.ProfileSdkError as error:
+        assert error.diagnosis["code"] == "collaboration-capability-drift"
+    else:
+        raise AssertionError("capability drift was accepted")
+
+
+def test_collaboration_rejects_material_action_without_authority(tmp_path):
+    source, _ = create_source(tmp_path)
+    collaboration = add_collaboration(source)
+    collaboration["intents"][0]["requiredAuthority"] = "none"
+    collaboration_ref = _write_json(
+        source / "collaboration" / "interface.json", collaboration
+    )
+    actions_path = source / "actions" / "registry.json"
+    actions = json.loads(actions_path.read_text())
+    actions["actions"][0]["authorityClass"] = "none"
+    action_ref = _write_json(actions_path, actions)
+    profile_path = source / "profile.json"
+    profile = json.loads(profile_path.read_text())
+    profile["actions"]["registry"] = action_ref
+    profile["kfd3"] = {"collaboration": collaboration_ref}
+    profile_path.write_text(json.dumps(profile, indent=2, sort_keys=True) + "\n")
+
+    try:
+        profile_sdk.collaboration(source, tmp_path / "runtime")
+    except profile_sdk.ProfileSdkError as error:
+        assert error.diagnosis["code"] == "profile-sdk-contract-invalid"
+    else:
+        raise AssertionError("material action without authority was accepted")
+
+
+def test_application_projection_is_generic_and_binds_both_participants(tmp_path):
+    source, _ = create_source(tmp_path)
+    add_collaboration(source)
+
+    result = profile_sdk.application(source, tmp_path / "runtime")
+
+    assert result["schema"] == "kungfu.profile-application/v1"
+    assert result["presentation"] == {"mode": "generic"}
+    assert result["activeExactRoot"] is False
+    assert {row["kind"] for row in result["participants"]} == {"human", "agent"}
+    assert result["intents"][0]["action"]["id"] == "complete-day"
+    assert result["intents"][0]["inspectView"]["id"] == "week-state"
+    assert result["qualified"] is False
+
+
+def test_intent_protocol_shares_plan_receipt_and_verify_identities(tmp_path):
+    source, _ = create_source(tmp_path)
+    make_collaboration_action_lifecycle(source)
+    runtime = tmp_path / "runtime"
+    for action in ["install", "qualify", "activate"]:
+        core_plan = profile_sdk.lifecycle_plan(runtime, action, source)["corePlan"]
+        profile_sdk.lifecycle_apply(runtime, core_plan, f"test:{action}")
+
+    inspected = profile_sdk.intent_inspect(source, runtime, "complete-day")
+    advised = profile_sdk.intent_advise(source, runtime, "complete-day")
+    plan = profile_sdk.intent_plan(source, runtime, "complete-day", {})
+    answer = profile_sdk.answer_decision(plan["decisionCard"], "approve", "test-owner")
+    receipt = profile_sdk.intent_apply(runtime, plan, answer)
+    verification = profile_sdk.intent_verify(source, runtime, receipt)
+
+    assert inspected["closureRoot"] == advised["closureRoot"] == plan["closureRoot"]
+    assert advised["eligible"] is True
+    assert plan["actionPlan"]["intentId"] == "complete-day"
+    assert receipt["verified"] is False
+    assert receipt["executionReceiptVerified"] is True
+    assert verification["receiptId"] == receipt["receiptId"]
+    assert verification["verified"] is True
+
+
+def test_intent_authorize_rejects_stale_reviewed_plan(tmp_path):
+    source, _ = create_source(tmp_path)
+    make_collaboration_action_lifecycle(source)
+    runtime = tmp_path / "runtime"
+    for action in ["install", "qualify", "activate"]:
+        core_plan = profile_sdk.lifecycle_plan(runtime, action, source)["corePlan"]
+        profile_sdk.lifecycle_apply(runtime, core_plan, f"test:{action}")
+
+    try:
+        profile_sdk.authorize_current_intent(
+            runtime,
+            source,
+            "complete-day",
+            {},
+            "sha256:stale",
+            "approve",
+            "test-owner",
+        )
+    except profile_sdk.ProfileSdkError as error:
+        assert error.diagnosis["code"] == "intent-plan-stale"
+    else:
+        raise AssertionError("stale intent plan was authorized")
+
+
+def test_kfd3_qualification_earns_receipt_and_witness_for_exact_active_root(
+    tmp_path,
+):
+    source, _ = create_source(tmp_path)
+    make_collaboration_action_lifecycle(source)
+    home = tmp_path / "home"
+    runtime = home / "runtime"
+    for action in ["install", "qualify", "activate"]:
+        core_plan = profile_sdk.lifecycle_plan(runtime, action, source)["corePlan"]
+        profile_sdk.lifecycle_apply(runtime, core_plan, f"test:{action}")
+
+    receipt = profile_sdk.qualify_kfd3(source, runtime)
+    projected = profile_sdk.application(source, runtime)
+
+    assert receipt["schema"] == "kungfu.profile-kfd3-qualification-receipt/v1"
+    assert receipt["qualified"] is True
+    assert receipt["noBypass"]["passed"] is True
+    assert receipt["clientProbes"][0]["matched"] is True
+    assert receipt["witness"]["qualificationReceiptId"] == receipt["receiptId"]
+    assert receipt["witness"]["issuer"] == "kungfu-profile-runtime"
+    assert projected["qualified"] is True
+    assert projected["qualification"]["witnessId"] == receipt["witness"]["witnessId"]
+    assert profile_sdk.verify_kfd3(source, runtime, receipt)["verified"] is True
+
+    cli = CliRunner().invoke(
+        kfc,
+        [
+            "--home",
+            str(home),
+            "profile",
+            "kfd3-qualify",
+            str(source),
+            "--json",
+        ],
+    )
+    assert cli.exit_code == 0, cli.output
+    assert (
+        json.loads(cli.output)["witness"]["witnessId"]
+        == receipt["witness"]["witnessId"]
+    )
+
+    tampered = json.loads(json.dumps(receipt))
+    tampered["knownLimits"][0]["description"] = "hidden drift"
+    try:
+        profile_sdk.verify_kfd3(source, runtime, tampered)
+    except profile_sdk.ProfileSdkError as error:
+        assert error.diagnosis["code"] == "kfd3-qualification-stale-or-tampered"
+    else:
+        raise AssertionError("tampered KFD-3 receipt was verified")
+
+
+def test_kfd3_qualification_rejects_custom_view_mutation_boundary(tmp_path):
+    source, _ = create_source(tmp_path)
+    make_collaboration_action_lifecycle(source)
+    member = source / "members" / "example-week-day-contract"
+    manifest_path = member / "package.json"
+    manifest = json.loads(manifest_path.read_text())
+    manifest["kungfuConfig"]["config"] = {
+        "view": {
+            "title": "Private mutation view",
+            "runtime": "node-integrated",
+            "capabilities": ["profile"],
+        }
+    }
+    manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n")
+    runtime = tmp_path / "runtime"
+    for action in ["install", "qualify", "activate"]:
+        core_plan = profile_sdk.lifecycle_plan(runtime, action, source)["corePlan"]
+        profile_sdk.lifecycle_apply(runtime, core_plan, f"test:{action}")
+
+    try:
+        profile_sdk.qualify_kfd3(source, runtime)
+    except profile_sdk.ProfileSdkError as error:
+        assert error.diagnosis["code"] == "kfd3-no-bypass-failed"
+        assert error.diagnosis["failures"][0]["facet"] == "view"
+    else:
+        raise AssertionError("custom mutation view bypass was qualified")
+
+
+def test_kfd3_qualification_allows_capability_free_sandboxed_view(tmp_path):
+    source, _ = create_source(tmp_path)
+    make_collaboration_action_lifecycle(source)
+    member = source / "members" / "example-week-day-contract"
+    manifest_path = member / "package.json"
+    manifest = json.loads(manifest_path.read_text())
+    manifest["kungfuConfig"]["config"] = {
+        "view": {
+            "title": "Presentational view",
+            "runtime": "sandboxed-ipc",
+            "capabilities": [],
+        }
+    }
+    manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n")
+    bundle = member / "dist" / "view" / "index.js"
+    bundle.parent.mkdir(parents=True)
+    bundle.write_text("export function View() { return null; }\n")
+    runtime = tmp_path / "runtime"
+    for action in ["install", "qualify", "activate"]:
+        core_plan = profile_sdk.lifecycle_plan(runtime, action, source)["corePlan"]
+        profile_sdk.lifecycle_apply(runtime, core_plan, f"test:{action}")
+
+    receipt = profile_sdk.qualify_kfd3(source, runtime)
+
+    assert receipt["noBypass"]["customViews"][0]["passed"] is True
+    assert receipt["noBypass"]["customViews"][0]["bundleRoot"].startswith("sha256:")
+
+
+def test_kfd3_qualification_requires_active_exact_root(tmp_path):
+    source, _ = create_source(tmp_path)
+    make_collaboration_action_lifecycle(source)
+
+    try:
+        profile_sdk.qualify_kfd3(source, tmp_path / "runtime")
+    except profile_sdk.ProfileSdkError as error:
+        assert error.diagnosis["code"] == "kfd3-active-root-required"
+    else:
+        raise AssertionError("inactive Profile was KFD-3 qualified")
+
+
+def test_kfd3_receipt_survives_portable_import_and_invalidates_on_upgrade(
+    tmp_path,
+):
+    source, _ = create_source(tmp_path / "author")
+    make_collaboration_action_lifecycle(source)
+    runtime_a = tmp_path / "runtime-a"
+    for action in ["install", "qualify", "activate"]:
+        plan = profile_sdk.lifecycle_plan(runtime_a, action, source)["corePlan"]
+        profile_sdk.lifecycle_apply(runtime_a, plan, f"portable-a:{action}")
+    receipt_a = profile_sdk.qualify_kfd3(source, runtime_a)
+
+    bundle = profile_sdk.export_source_bundle(source, runtime_a)
+    import_plan = profile_sdk.source_import_plan(bundle, tmp_path / "imported")
+    import_answer = profile_sdk.answer_decision(
+        import_plan["decisionCard"], "approve", "portable-owner"
+    )
+    imported = profile_sdk.authorized_source_import(import_plan, import_answer)
+    imported_source = Path(imported["destination"])
+    runtime_b = tmp_path / "runtime-b"
+    for action in ["install", "qualify", "activate"]:
+        plan = profile_sdk.lifecycle_plan(runtime_b, action, imported_source)[
+            "corePlan"
+        ]
+        profile_sdk.lifecycle_apply(runtime_b, plan, f"portable-b:{action}")
+    receipt_b = profile_sdk.qualify_kfd3(imported_source, runtime_b)
+
+    assert receipt_b["profileSuiteRoot"] == receipt_a["profileSuiteRoot"]
+    assert receipt_b["receiptId"] == receipt_a["receiptId"]
+    assert receipt_b["witness"]["witnessId"] == receipt_a["witness"]["witnessId"]
+
+    collaboration_path = imported_source / "collaboration" / "interface.json"
+    collaboration = json.loads(collaboration_path.read_text())
+    collaboration["knownLimits"][0]["description"] = "Identity evidence upgraded."
+    collaboration_bytes = (
+        json.dumps(collaboration, indent=2, sort_keys=True) + "\n"
+    ).encode()
+    collaboration_path.write_bytes(collaboration_bytes)
+    profile_path = imported_source / "profile.json"
+    profile = json.loads(profile_path.read_text())
+    profile["version"] = "1.1.0"
+    profile["kfd3"]["collaboration"]["sha256"] = hashlib.sha256(
+        collaboration_bytes
+    ).hexdigest()
+    profile_path.write_text(json.dumps(profile, indent=2, sort_keys=True) + "\n")
+
+    upgrade = profile_sdk.lifecycle_plan(runtime_b, "upgrade", imported_source)[
+        "corePlan"
+    ]
+    profile_sdk.lifecycle_apply(runtime_b, upgrade, "portable-b:upgrade")
+    for action in ["qualify", "activate"]:
+        plan = profile_sdk.lifecycle_plan(runtime_b, action, imported_source)[
+            "corePlan"
+        ]
+        profile_sdk.lifecycle_apply(runtime_b, plan, f"portable-b:{action}-v2")
+    receipt_v2 = profile_sdk.qualify_kfd3(imported_source, runtime_b)
+    assert receipt_v2["profileSuiteRoot"] != receipt_b["profileSuiteRoot"]
+    try:
+        profile_sdk.verify_kfd3(imported_source, runtime_b, receipt_b)
+    except profile_sdk.ProfileSdkError as error:
+        assert error.diagnosis["code"] == "kfd3-qualification-stale-or-tampered"
+    else:
+        raise AssertionError("pre-upgrade KFD-3 receipt remained current")
+
+    rollback = profile_sdk.lifecycle_plan(
+        runtime_b,
+        "rollback",
+        None,
+        profile_id="example.week-day",
+        target_root=receipt_b["profileSuiteRoot"],
+    )["corePlan"]
+    profile_sdk.lifecycle_apply(runtime_b, rollback, "portable-b:rollback")
+    rolled_back = profile_sdk.qualify_kfd3(source, runtime_b)
+    assert rolled_back["profileSuiteRoot"] == receipt_b["profileSuiteRoot"]
+    assert rolled_back["receiptId"] != receipt_b["receiptId"]
+    assert rolled_back["profileRevision"] > receipt_b["profileRevision"]
+
+
 def test_missing_member_fails_with_stable_decision_card(tmp_path):
     source, _ = create_source(tmp_path)
     missing = source / "members" / "example-week-day-actions"
@@ -166,6 +707,69 @@ def test_member_package_ignores_dependency_directory_symlinks(tmp_path):
     assert result["ok"] is True
 
 
+def test_cli_exposes_collaboration_closure_to_agents(tmp_path):
+    source, _ = create_source(tmp_path)
+    add_collaboration(source)
+    runner = CliRunner()
+
+    result = runner.invoke(
+        kfc,
+        [
+            "--home",
+            str(tmp_path / "home"),
+            "profile",
+            "collaboration",
+            str(source),
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["status"] == "declared-closed"
+    assert payload["protocol"] == [
+        "inspect",
+        "advise",
+        "preview",
+        "authorize",
+        "execute",
+        "receipt",
+        "verify",
+    ]
+
+    application = runner.invoke(
+        kfc,
+        [
+            "--home",
+            str(tmp_path / "home"),
+            "profile",
+            "application",
+            str(source),
+            "--json",
+        ],
+    )
+    assert application.exit_code == 0, application.output
+    application_payload = json.loads(application.output)
+    assert application_payload["schema"] == "kungfu.profile-application/v1"
+    assert application_payload["qualified"] is False
+
+    inspected = runner.invoke(
+        kfc,
+        [
+            "--home",
+            str(tmp_path / "home"),
+            "profile",
+            "intent",
+            "inspect",
+            str(source),
+            "complete-day",
+            "--json",
+        ],
+    )
+    assert inspected.exit_code == 0, inspected.output
+    assert json.loads(inspected.output)["intent"]["id"] == "complete-day"
+
+
 def test_cli_installed_flow_plans_then_applies_core_lifecycle(tmp_path):
     source, _ = create_source(tmp_path)
     home = tmp_path / "home"
@@ -175,7 +779,12 @@ def test_cli_installed_flow_plans_then_applies_core_lifecycle(tmp_path):
         kfc, ["--home", str(home), "profile", "capabilities", "--json"]
     )
     assert capability.exit_code == 0, capability.output
-    assert json.loads(capability.output)["schema"] == "kungfu.agent-profile-sdk/v1"
+    capability_payload = json.loads(capability.output)
+    assert capability_payload["schema"] == "kungfu.agent-profile-sdk/v1"
+    assert (
+        capability_payload["schemas"]["collaboration"]["properties"]["schema"]["const"]
+        == "kungfu.profile-collaboration/v1"
+    )
 
     plan_file = tmp_path / "install-plan.json"
     planned = runner.invoke(

--- a/framework/kfx/kungfu-kfx.contract.json
+++ b/framework/kfx/kungfu-kfx.contract.json
@@ -1,7 +1,7 @@
 {
   "schema": "kungfu.kfx.contract/v1",
   "id": "kungfu-kfx",
-  "version": 3,
+  "version": 4,
   "weldedSurface": "kfx-contract",
   "description": "Single source for KFX package manifests, discovery rules, trust inputs, and build detection.",
   "contractSchema": {
@@ -551,6 +551,18 @@
           },
           "policies": {
             "$ref": "#/$defs/nonEmptyContentRefs"
+          }
+        }
+      },
+      "kfd3": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "collaboration"
+        ],
+        "properties": {
+          "collaboration": {
+            "$ref": "#/$defs/contentRef"
           }
         }
       },

--- a/framework/kfx/src/index.ts
+++ b/framework/kfx/src/index.ts
@@ -49,6 +49,10 @@ export type {
   QueryResultSchema,
   QueryViewSpec,
   ManagedProfile,
+  ProfileApplicationProjection,
+  ProfileKfd3QualificationReceipt,
+  ProfileKfd3Verification,
+  ProfileIntentPlan,
   ProfileLifecyclePlan,
   ProfileManagerProjection,
   SavedQueryCatalog,
@@ -252,6 +256,10 @@ export type KfxProfileSuite = {
     purposes: string[];
     policies: KfxProfileSuiteContentRef[];
   };
+  // Optional because existing Profile Suites remain valid KFD-1/KFD-2
+  // closures. Only Profiles that bind this facet can request KFD-3
+  // qualification from the runtime.
+  kfd3?: { collaboration: KfxProfileSuiteContentRef };
   actions: { registry: KfxProfileSuiteContentRef };
   views: { registry: KfxProfileSuiteContentRef };
   migrations: { registry: KfxProfileSuiteContentRef };

--- a/framework/kfx/src/profile-suite.test.ts
+++ b/framework/kfx/src/profile-suite.test.ts
@@ -73,6 +73,18 @@ test('Node validates the complete Week/Day Profile Suite closure', () => {
   ]);
 });
 
+test('Node keeps a Profile without a KFD-3 facet valid but not KFD-3 declared', () => {
+  const profile = structuredClone(validProfile);
+  assert.equal(Reflect.deleteProperty(profile, 'kfd3'), true);
+  validateKfxProfileSuite(profile, contract, [
+    'week-day-contract',
+    'week-day-actions',
+    'week-day-assessment',
+    'week-day-dashboard',
+  ]);
+  assert.equal(profile.kfd3, undefined);
+});
+
 for (const fixture of invalidCases) {
   test(`Node rejects Profile Suite fixture: ${fixture.id}`, () => {
     const profile = structuredClone(validProfile);

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "test:kfx-profile-suite": "node scripts/require-shifu.mjs test:kfx-profile-suite && node scripts/run-kfx-profile-suite-tests.mjs",
     "test:profile-lifecycle": "node scripts/require-shifu.mjs test:profile-lifecycle && node scripts/run-profile-lifecycle-tests.mjs",
     "test:agent-profile-sdk": "node scripts/require-shifu.mjs test:agent-profile-sdk && node scripts/run-agent-profile-sdk-tests.mjs",
+    "test:profile-kfd3-qualification": "node scripts/require-shifu.mjs test:profile-kfd3-qualification && node tests/qualification/profile-kfd3/run.ts",
     "schema:profile-lifecycle": "node scripts/require-shifu.mjs schema:profile-lifecycle && node scripts/generate-profile-lifecycle-schema.mjs",
     "test:durable-ingest": "node scripts/require-shifu.mjs test:durable-ingest && node scripts/run-durable-ingest-tests.mjs",
     "test:projection-bootstrap": "node scripts/require-shifu.mjs test:projection-bootstrap && node scripts/run-projection-bootstrap-tests.mjs",

--- a/scripts/buildchain-kfd-evidence.mjs
+++ b/scripts/buildchain-kfd-evidence.mjs
@@ -697,7 +697,7 @@ function sdkAndProductSurfaces() {
       // onboards its artifacts by stating them here.
       distribution: {
         registrar: 'shifu',
-        tasks: ['dist', 'package'],
+        tasks: ['dist', 'dist:dir', 'package'],
         artifacts: [
           {
             kind: 'app',

--- a/tests/fixtures/kfx-profile-suite-contract/invalid-cases.json
+++ b/tests/fixtures/kfx-profile-suite-contract/invalid-cases.json
@@ -27,6 +27,20 @@
     "match": "does not match"
   },
   {
+    "id": "malformed-kfd3-collaboration-hash",
+    "operation": "set",
+    "path": ["kfd3", "collaboration", "sha256"],
+    "value": "not-a-content-hash",
+    "match": "does not match"
+  },
+  {
+    "id": "unknown-kfd3-authority-field",
+    "operation": "set",
+    "path": ["kfd3", "authorityOverride"],
+    "value": true,
+    "match": "Additional properties are not allowed"
+  },
+  {
     "id": "member-in-required-and-optional",
     "operation": "set",
     "path": ["members", "optional"],

--- a/tests/fixtures/kfx-profile-suite-contract/week-day.profile.json
+++ b/tests/fixtures/kfx-profile-suite-contract/week-day.profile.json
@@ -57,6 +57,12 @@
       }
     ]
   },
+  "kfd3": {
+    "collaboration": {
+      "path": "collaboration/interface.json",
+      "sha256": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+    }
+  },
   "actions": {
     "registry": {
       "path": "actions/registry.json",

--- a/tests/qualification/profile-kfd3/run.ts
+++ b/tests/qualification/profile-kfd3/run.ts
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import path from 'node:path';
+import process from 'node:process';
+import { openProfile } from '../../../framework/api/src/capability/profile.ts';
+
+const repo = process.cwd();
+const runtimeRoot = process.env.KUNGFU_QUALIFICATION_RUNTIME_ROOT || repo;
+const core = path.join(runtimeRoot, 'framework', 'core');
+const python = path.join(core, '.venv', 'bin', 'python');
+const release = path.join(core, 'build', 'Release');
+const pythonPath = [
+  path.join(repo, 'framework', 'core', 'src', 'python'),
+  release,
+].join(path.delimiter);
+const runtimeEnv = {
+  ...process.env,
+  KUNGFU_ALLOW_FOREIGN_RUNTIME: '1',
+  PYTHONPATH: pythonPath,
+};
+
+const setupText = execFileSync(
+  python,
+  [path.join(repo, 'tests', 'qualification', 'profile-kfd3', 'setup.py'), repo],
+  {
+    encoding: 'utf8',
+    env: runtimeEnv,
+  },
+);
+const context = JSON.parse(setupText) as {
+  source: string;
+  runtime: string;
+  profileId: string;
+  profileSuiteRoot: string;
+  intentId: string;
+};
+type QualificationReceipt = {
+  profileSuiteRoot: string;
+  receiptId: string;
+  witness: { witnessId: string };
+  clientProbes: Array<{
+    humanPlanId: string;
+    agentPlanId: string;
+  }>;
+};
+const env = { ...runtimeEnv, KF_RUNTIME_DIR: context.runtime };
+const agentReceipt = JSON.parse(
+  execFileSync(
+    python,
+    ['-m', 'kungfu', 'profile', 'kfd3-qualify', context.source, '--json'],
+    {
+      encoding: 'utf8',
+      env,
+    },
+  ),
+) as QualificationReceipt;
+
+const execSync = (
+  file: string,
+  args: string[],
+  options: {
+    encoding: 'utf8';
+    env: Record<string, string | undefined>;
+    maxBuffer?: number;
+  },
+): string =>
+  execFileSync(
+    file,
+    file === python ? ['-m', 'kungfu', ...args] : args,
+    options,
+  );
+const human = openProfile({
+  runtimeDir: context.runtime,
+  bin: python,
+  env,
+  execFileSync: execSync,
+});
+const humanReceipt = human.qualifyKfd3(context.source);
+const application = human.application(context.source);
+const humanPlan = human.intentPlan(context.source, context.intentId);
+
+assert.equal(context.profileId, 'example.week-day');
+assert.equal(agentReceipt.profileSuiteRoot, context.profileSuiteRoot);
+assert.equal(humanReceipt.receiptId, agentReceipt.receiptId);
+assert.equal(humanReceipt.witness.witnessId, agentReceipt.witness.witnessId);
+assert.equal(application.qualified, true);
+assert.equal(
+  application.qualification.witnessId,
+  agentReceipt.witness.witnessId,
+);
+assert.equal(humanPlan.planId, agentReceipt.clientProbes[0].humanPlanId);
+assert.equal(
+  agentReceipt.clientProbes[0].humanPlanId,
+  agentReceipt.clientProbes[0].agentPlanId,
+);
+
+console.log(
+  JSON.stringify({
+    schema: 'kungfu.profile-kfd3-dual-client-proof/v1',
+    domain: 'week-day',
+    profileId: context.profileId,
+    profileSuiteRoot: context.profileSuiteRoot,
+    receiptId: agentReceipt.receiptId,
+    witnessId: agentReceipt.witness.witnessId,
+    planId: humanPlan.planId,
+    clients: ['agent-cli', 'typed-human-api'],
+    verified: true,
+  }),
+);

--- a/tests/qualification/profile-kfd3/setup.py
+++ b/tests/qualification/profile-kfd3/setup.py
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Prepare an independent Week/Day Profile for the dual-client live probe."""
+
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+
+repo = Path(sys.argv[1]).resolve()
+sys.path.insert(0, str(repo / "framework" / "core" / "tests" / "python"))
+
+from kungfu import profile_sdk  # noqa: E402
+from test_agent_profile_sdk import (  # noqa: E402
+    create_source,
+    make_collaboration_action_lifecycle,
+)
+
+
+root = Path(tempfile.mkdtemp(prefix="kungfu-profile-kfd3-"))
+source, _ = create_source(root)
+make_collaboration_action_lifecycle(source)
+home = root / "home"
+runtime = home / "runtime"
+for action in ["install", "qualify", "activate"]:
+    plan = profile_sdk.lifecycle_plan(runtime, action, source)["corePlan"]
+    profile_sdk.lifecycle_apply(runtime, plan, f"qualification-setup:{action}")
+
+projection = profile_sdk.application(source, runtime, include_qualification=False)
+print(
+    json.dumps(
+        {
+            "schema": "kungfu.profile-kfd3-live-context/v1",
+            "domain": "week-day",
+            "source": str(source),
+            "home": str(home),
+            "runtime": str(runtime),
+            "profileId": projection["profileId"],
+            "profileSuiteRoot": projection["profileSuiteRoot"],
+            "intentId": projection["intents"][0]["id"],
+        },
+        sort_keys=True,
+    )
+)


### PR DESCRIPTION
## Summary

Completes the Profile-level KFD-3 qualification path across Agent CLI and typed Human API. A conforming user-defined Profile can now earn, export, import, and independently verify a content-bound qualification receipt and witness. The same shared intent protocol drives inspect, advise, preview, authorize, execute, receipt, and verify. Unsupported custom execution surfaces fail closed.

Also proves an independent Week/Day Profile through both clients, verifies upgrade and rollback invalidation, and repairs Shifu directory-build registration so the exact Product can be promoted without a DMG.

## Verification

- ./shifu test:kfx-profile-suite
- ./shifu --filter @kungfu-tech/api run test:query
- ./shifu test:profile-kfd3-qualification
- ./shifu docs:check
- ./shifu kfd:buildchain:check
- cargo test --workspace
- staged repository gate
- ./shifu dist:dir
- shifu build registration and promote of clean 746bfafb0

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "implemented",
  "adrs": ["ADR-0075"],
  "summary": "Qualify conforming user-defined Profiles for shared Human and Agent KFD-3 collaboration",
  "verification": ["independent Week Day dual-client proof", "portable receipt and witness verification", "upgrade and rollback invalidation", "exact Product directory build and promote"]
}
-->

## Governance risk check

- [x] release evidence, provenance, package publishing, or deployment surfaces

No public release channel is promoted by this PR. The exact local Product directory build was promoted for dogfood.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed