### PR TITLE
feat(runtime): fold interrupted Episodes into recovery

### DIFF
--- a/docs/adr/ADR-0068-tiered-durability-and-crash-recovery.md
+++ b/docs/adr/ADR-0068-tiered-durability-and-crash-recovery.md
@@ -4,6 +4,7 @@ doc_type: architecture-decision
 adr_id: ADR-0068
 decision_status: accepted
 implementation_status: staged
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/668, https://github.com/kungfu-systems/kungfu/pull/673, https://github.com/kungfu-systems/kungfu/pull/682, https://github.com/kungfu-systems/kungfu/pull/687, https://github.com/kungfu-systems/kungfu/pull/691, https://github.com/kungfu-systems/kungfu/pull/693, https://github.com/kungfu-systems/kungfu/pull/697, https://github.com/kungfu-systems/kungfu/pull/701, https://github.com/kungfu-systems/kungfu/pull/705, https://github.com/kungfu-systems/kungfu/pull/720]
 review_state: self-reviewed
 sensitivity: public
 sources: [local-files, user-consensus]
@@ -11,7 +12,7 @@ period: 2026-07-12
 theme: tiered-durability-and-crash-recovery
 confidence: high
 evidence_grade: B
-last_reviewed: 2026-07-12
+last_reviewed: 2026-07-13
 ---
 
 # ADR-0068: tiered durability separates hot visibility, durable fact admission, projections, and replication
@@ -236,8 +237,16 @@ journal wire compatibility, or edge-only JSON rules accidentally.
 
 ## Current implementation status
 
-This ADR records the target decision and is not a statement that strong
-durability is already shipped. Current production mmap qualification remains
-`demand + visibility`. State cache/projections remain asynchronous derived
-state. Dedicated durable ingest, unified watermarks/receipts, coordinator
-separation, and power-loss qualification are pending.
+This ADR remains staged and is not a statement that strong durability is
+already shipped. The integrated development stages now provide typed durability
+positions and receipts, append-only durable ingest with checkpoint barriers, a
+separate state-service boundary, typed snapshot-at-`T` projection bootstrap,
+read-only crash classification, retained-evidence quarantine, and typed
+interrupted-Episode classification. Recovery inspection is deterministic and
+does not silently abort, resume, repair, or promote uncertain facts.
+
+The production mmap claim remains `demand + visibility`. Consistent export and
+empty-root verified restore, projection rebuild/cut equality, production
+bootstrap authority cutover, named platform/filesystem qualification, and the
+public durability product contract remain pending. In particular, process-kill
+and cross-platform CI evidence do not establish sudden-power-loss durability.

--- a/docs/document-metadata.contract.json
+++ b/docs/document-metadata.contract.json
@@ -208,7 +208,6 @@
       "ADR-0046": "Rust host trunk is staged; qualification evidence remains distributed across spike history.",
       "ADR-0048": "Runtime fact query work is staged and awaiting evidence consolidation.",
       "ADR-0049": "Layer-complete product work is staged and awaiting evidence consolidation.",
-      "ADR-0068": "Durability work is staged across a planned card series and is not closed.",
       "ADR-0069": "The agent-first profile suite is staged and awaiting end-to-end qualification."
     }
   }

--- a/framework/core/src/libkungfu/include/kungfu/runtime/crash_recovery.h
+++ b/framework/core/src/libkungfu/include/kungfu/runtime/crash_recovery.h
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include <kungfu/runtime/durable_ingest.h>
+#include <kungfu/runtime/storage/service.h>
 
 namespace kungfu::runtime::recovery {
 
@@ -66,6 +67,8 @@ struct recovery_report {
   std::string evidence_message = {};
   std::string qualification_profile = {};
   bool qualification_passed = false;
+  uint64_t episode_unknown_record_count = 0;
+  std::vector<storage_service_api::episode_qualification_result> interrupted_episodes = {};
   bool mutation_performed = false;
   std::vector<std::string> restart_order = {"supervisor", "state_service", "projection", "peers"};
 

--- a/framework/core/src/libkungfu/include/kungfu/runtime/storage/projection_types.h
+++ b/framework/core/src/libkungfu/include/kungfu/runtime/storage/projection_types.h
@@ -12,6 +12,8 @@ namespace kungfu::runtime::storage_service_api {
 struct storage_projection_count {
   std::string table = {};
   uint64_t count = 0;
+
+  friend bool operator==(const storage_projection_count &, const storage_projection_count &) = default;
 };
 
 struct storage_projection_drift {
@@ -21,6 +23,8 @@ struct storage_projection_drift {
   std::string reason = {};
   std::string projection_digest = {};
   std::string journal_digest = {};
+
+  friend bool operator==(const storage_projection_drift &, const storage_projection_drift &) = default;
 };
 
 struct storage_projection_verify_result {
@@ -35,6 +39,8 @@ struct storage_projection_verify_result {
   std::vector<storage_projection_drift> drift = {};
   std::vector<storage_projection_count> rows = {};
   std::vector<storage_projection_count> journal_distinct = {};
+
+  friend bool operator==(const storage_projection_verify_result &, const storage_projection_verify_result &) = default;
 };
 
 struct storage_projection_rebuild_result {

--- a/framework/core/src/libkungfu/include/kungfu/runtime/storage/service.h
+++ b/framework/core/src/libkungfu/include/kungfu/runtime/storage/service.h
@@ -300,6 +300,8 @@ struct episode_frame_field_mismatch {
   std::string field = {};
   episode_frame_field_value claimed = uint64_t{0};
   episode_frame_field_value actual = uint64_t{0};
+
+  friend bool operator==(const episode_frame_field_mismatch &, const episode_frame_field_mismatch &) = default;
 };
 
 struct episode_frame_verification_issue {
@@ -314,6 +316,8 @@ struct episode_frame_verification_issue {
   std::optional<uint64_t> actual_payload_checksum = {};
   std::optional<uint64_t> claimed_frame_checksum = {};
   std::optional<uint64_t> actual_frame_checksum = {};
+
+  friend bool operator==(const episode_frame_verification_issue &, const episode_frame_verification_issue &) = default;
 };
 
 struct episode_frame_verification {
@@ -327,6 +331,8 @@ struct episode_qualification_evidence {
   std::string name = {};
   std::string state = {};
   std::vector<std::string> issue_codes = {};
+
+  friend bool operator==(const episode_qualification_evidence &, const episode_qualification_evidence &) = default;
 };
 
 using episode_qualification_issue_detail =
@@ -338,6 +344,8 @@ struct episode_qualification_issue {
   std::string code = {};
   std::string evidence = {};
   episode_qualification_issue_detail detail = yijinjing::storage::episode_fsck_issue{};
+
+  friend bool operator==(const episode_qualification_issue &, const episode_qualification_issue &) = default;
 };
 
 struct episode_qualification_capability {
@@ -345,6 +353,8 @@ struct episode_qualification_capability {
   bool safe = false;
   std::vector<std::string> required_evidence = {};
   std::vector<std::string> blocked_by = {};
+
+  friend bool operator==(const episode_qualification_capability &, const episode_qualification_capability &) = default;
 };
 
 struct episode_repair_subject {
@@ -355,6 +365,8 @@ struct episode_repair_subject {
   std::optional<std::string> ref_id = {};
   std::optional<std::string> ref_hash = {};
   std::optional<std::string> role = {};
+
+  friend bool operator==(const episode_repair_subject &, const episode_repair_subject &) = default;
 };
 
 struct episode_repair_prerequisite {
@@ -362,6 +374,8 @@ struct episode_repair_prerequisite {
   std::string action = {};
   std::vector<std::string> required_inputs = {};
   episode_repair_subject subject = {};
+
+  friend bool operator==(const episode_repair_prerequisite &, const episode_repair_prerequisite &) = default;
 };
 
 struct episode_qualification_result {
@@ -372,6 +386,8 @@ struct episode_qualification_result {
   std::vector<episode_qualification_issue> issues = {};
   std::vector<episode_qualification_capability> capabilities = {};
   std::vector<episode_repair_prerequisite> repair_prerequisites = {};
+
+  friend bool operator==(const episode_qualification_result &, const episode_qualification_result &) = default;
 };
 
 enum class storage_fsck_scope { All, Source, Episode };

--- a/framework/core/src/libkungfu/src/runtime/crash_recovery.cpp
+++ b/framework/core/src/libkungfu/src/runtime/crash_recovery.cpp
@@ -93,6 +93,9 @@ bool retained_package_matches(const fs::path &package, const quarantine_preview 
 using durability::durable_ingest_log;
 using durability::ingest_error;
 using durability::tail_integrity;
+using storage_service_api::storage_episode_list_request;
+using storage_service_api::storage_fsck_request;
+using storage_service_api::storage_fsck_scope;
 
 recovery_engine::recovery_engine(durability::ingest_options options) : options_(std::move(options)) {
   options_.read_only = true;
@@ -106,24 +109,50 @@ recovery_report recovery_engine::inspect() const {
   report.completed_phases.push_back(recovery_phase::Discover);
   try {
     durable_ingest_log log(options_);
-    report.completed_phases.push_back(recovery_phase::Verify);
     const auto status = log.status();
     report.durable_frontier = status.durable_watermark;
     report.durable_record_count = log.read_durable_records().size();
-    report.completed_phases.push_back(recovery_phase::Select);
     report.unacknowledged_tail_bytes = status.unacknowledged_tail_bytes;
     report.unacknowledged_tail_integrity = status.unacknowledged_tail_integrity;
     report.evidence_error = status.last_error;
     report.evidence_message = status.last_error_message;
     report.qualification_profile = status.qualification_profile;
     report.qualification_passed = status.qualification_passed;
+    const auto &storage = storage_service_api::default_storage_service();
+    const auto episodes = storage.episode_list(storage_episode_list_request{options_.data_root, 0, 0});
+    report.episode_unknown_record_count = episodes.unknown_record_count;
+    for (const auto &episode : episodes.episodes) {
+      if (!episode.opened || episode.closed) {
+        continue;
+      }
+      storage_fsck_request request{};
+      request.runtime_dir = options_.data_root;
+      request.scope = storage_fsck_scope::Episode;
+      request.episode_id = episode.episode_id;
+      request.verify_frames = true;
+      const auto fsck = storage.fsck(request);
+      if (!fsck.qualification.has_value()) {
+        throw std::runtime_error("recovery_episode_qualification_missing");
+      }
+      report.interrupted_episodes.push_back(*fsck.qualification);
+    }
+    report.completed_phases.push_back(recovery_phase::Verify);
+    report.completed_phases.push_back(recovery_phase::Select);
     report.completed_phases.push_back(recovery_phase::Classify);
 
-    if (!status.available ||
+    const bool episode_blocked =
+        report.episode_unknown_record_count != 0 ||
+        std::any_of(report.interrupted_episodes.begin(), report.interrupted_episodes.end(),
+                    [](const auto &qualification) { return qualification.status == "failed"; });
+    const bool episode_degraded =
+        !report.interrupted_episodes.empty() ||
+        std::any_of(report.interrupted_episodes.begin(), report.interrupted_episodes.end(),
+                    [](const auto &qualification) { return qualification.status == "degraded"; });
+    if (!status.available || episode_blocked ||
         (!status.durable_watermark.has_value() && status.last_error == ingest_error::CheckpointCorrupt)) {
       report.outcome = recovery_outcome::Blocked;
     } else if (status.unacknowledged_tail_integrity != tail_integrity::None ||
-               status.last_error != ingest_error::None) {
+               status.last_error != ingest_error::None || episode_degraded) {
       report.outcome = recovery_outcome::Degraded;
     } else {
       report.outcome = recovery_outcome::Ready;

--- a/framework/core/src/libkungfu/src/runtime/durable_ingest.cpp
+++ b/framework/core/src/libkungfu/src/runtime/durable_ingest.cpp
@@ -185,8 +185,9 @@ private:
 
 void sync_directory(const fs::path &directory) {
 #ifdef _WIN32
-  const auto handle = CreateFileW(directory.wstring().c_str(), GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE,
-                                  nullptr, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, nullptr);
+  const auto handle =
+      CreateFileW(directory.wstring().c_str(), GENERIC_READ | GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE,
+                  nullptr, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, nullptr);
   if (handle == INVALID_HANDLE_VALUE) {
     throw std::system_error(static_cast<int>(GetLastError()), std::system_category(), "open durable directory");
   }

--- a/framework/core/src/libkungfu/tests/crash_recovery_tests.cpp
+++ b/framework/core/src/libkungfu/tests/crash_recovery_tests.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <kungfu/runtime/crash_recovery.h>
+#include <kungfu/runtime/storage/service.h>
 #include <kungfu/yijinjing/ownership.h>
 
 #include <algorithm>
@@ -14,6 +15,7 @@
 namespace fs = std::filesystem;
 using namespace kungfu::runtime::durability;
 using namespace kungfu::runtime::recovery;
+using namespace kungfu::runtime::storage_service_api;
 using kungfu::yijinjing::ownership::lease;
 
 namespace {
@@ -69,9 +71,58 @@ std::vector<std::pair<std::string, std::string>> file_bytes(const fs::path &dire
   return result;
 }
 
+std::vector<std::pair<std::string, std::string>> recursive_file_bytes(const fs::path &directory) {
+  std::vector<std::pair<std::string, std::string>> result;
+  for (const auto &entry : fs::recursive_directory_iterator(directory)) {
+    if (!entry.is_regular_file()) {
+      continue;
+    }
+    std::ifstream input(entry.path(), std::ios::binary);
+    result.emplace_back(fs::relative(entry.path(), directory).generic_string(),
+                        std::string(std::istreambuf_iterator<char>(input), std::istreambuf_iterator<char>()));
+  }
+  std::sort(result.begin(), result.end());
+  return result;
+}
+
+void begin_episode(const fs::path &root, uint64_t episode_id) {
+  storage_episode_begin_request request{};
+  request.runtime_dir = root.string();
+  request.options.episode_id = episode_id;
+  request.options.location_uid = 1;
+  request.options.begin_time = 1000 + static_cast<int64_t>(episode_id);
+  request.options.title = "crash-recovery-fixture";
+  const auto opened = default_storage_service().episode_begin(request);
+  require(opened.episode_id == episode_id, "Episode fixture opened the wrong identity");
+}
+
+void end_episode(const fs::path &root, uint64_t episode_id) {
+  storage_episode_close_request request{};
+  request.runtime_dir = root.string();
+  request.options.episode_id = episode_id;
+  request.options.location_uid = 1;
+  request.options.end_time = 2000 + static_cast<int64_t>(episode_id);
+  const auto closed = default_storage_service().episode_end(request);
+  require(closed.close.episode_id == episode_id, "Episode fixture closed the wrong identity");
+}
+
+const episode_qualification_capability &capability(const episode_qualification_result &qualification,
+                                                   const std::string &name) {
+  const auto found = std::find_if(qualification.capabilities.begin(), qualification.capabilities.end(),
+                                  [&name](const auto &candidate) { return candidate.name == name; });
+  if (found == qualification.capabilities.end()) {
+    throw std::runtime_error("missing episode capability: " + name);
+  }
+  return *found;
+}
+
 void test_clean_frontier_is_ready_and_repeatable() {
   temp_tree tree;
   fixture_owners owners(tree.root());
+  const auto active_writer =
+      kungfu::yijinjing::ownership::inspect_active_stream_writer(tree.root().string(), "recovery-writer");
+  require(active_writer.owned && active_writer.resource_id == "recovery-writer",
+          "active writer evidence was not readable while its ownership lock was held");
   {
     durable_ingest_log log(options(tree.root()));
     log.append(position(1), 1001, "durable", owners.service, owners.writer);
@@ -108,6 +159,73 @@ void test_complete_unknown_tail_is_degraded_without_promotion() {
               report.durable_record_count == 1 && report.unacknowledged_tail_bytes > 0 &&
               report.unacknowledged_tail_integrity == tail_integrity::CompleteRecords,
           "complete unknown tail was promoted, hidden, or misclassified");
+}
+
+void test_interrupted_episode_reuses_typed_qualification_without_mutation() {
+  temp_tree tree;
+  fixture_owners owners(tree.root());
+  {
+    durable_ingest_log log(options(tree.root()));
+    log.append(position(1), 1001, "durable", owners.service, owners.writer);
+    require(log.barrier(1, durability_profile::DurableGroup, owners.service, owners.writer).receipt.status ==
+                receipt_status::Succeeded,
+            "interrupted Episode fixture barrier failed");
+  }
+  begin_episode(tree.root(), 41);
+  const auto before = recursive_file_bytes(tree.root());
+
+  recovery_engine engine(options(tree.root()));
+  const auto first = engine.inspect();
+  const auto repeated = engine.inspect();
+
+  require(first == repeated, "interrupted Episode fold was not deterministic");
+  require(recursive_file_bytes(tree.root()) == before, "interrupted Episode inspection mutated the data root");
+  require(first.outcome == recovery_outcome::Degraded && first.episode_unknown_record_count == 0 &&
+              first.interrupted_episodes.size() == 1,
+          "interrupted Episode was not classified as degraded retained evidence");
+  const auto &qualification = first.interrupted_episodes.front();
+  require(qualification.episode_id == 41 && qualification.lifecycle == "open" && qualification.status == "ok",
+          "recovery did not reuse the typed Episode qualification contract");
+  require(capability(qualification, "append").safe && !capability(qualification, "replay").safe &&
+              !capability(qualification, "depend_on").safe,
+          "interrupted Episode capabilities diverged from ADR-0042 qualification semantics");
+}
+
+void test_invalid_interrupted_episode_blocks_recovery() {
+  temp_tree tree;
+  fixture_owners owners(tree.root());
+  {
+    durable_ingest_log log(options(tree.root()));
+    log.append(position(1), 1001, "durable", owners.service, owners.writer);
+    require(log.barrier(1, durability_profile::DurableGroup, owners.service, owners.writer).receipt.status ==
+                receipt_status::Succeeded,
+            "invalid Episode fixture barrier failed");
+  }
+  begin_episode(tree.root(), 42);
+  begin_episode(tree.root(), 42);
+
+  const auto report = recovery_engine(options(tree.root())).inspect();
+  require(report.outcome == recovery_outcome::Blocked && report.interrupted_episodes.size() == 1 &&
+              report.interrupted_episodes.front().status == "failed",
+          "invalid interrupted Episode did not fail recovery closed");
+}
+
+void test_closed_episode_does_not_degrade_recovery() {
+  temp_tree tree;
+  fixture_owners owners(tree.root());
+  {
+    durable_ingest_log log(options(tree.root()));
+    log.append(position(1), 1001, "durable", owners.service, owners.writer);
+    require(log.barrier(1, durability_profile::DurableGroup, owners.service, owners.writer).receipt.status ==
+                receipt_status::Succeeded,
+            "closed Episode fixture barrier failed");
+  }
+  begin_episode(tree.root(), 43);
+  end_episode(tree.root(), 43);
+
+  const auto report = recovery_engine(options(tree.root())).inspect();
+  require(report.outcome == recovery_outcome::Ready && report.interrupted_episodes.empty(),
+          "closed Episode was misclassified as interrupted recovery evidence");
 }
 
 void test_torn_tail_is_degraded_and_frontier_stays_at_checkpoint() {
@@ -235,6 +353,10 @@ int main() {
   const std::pair<const char *, void (*)()> tests[] = {
       {"clean frontier is ready and repeatable", test_clean_frontier_is_ready_and_repeatable},
       {"complete unknown tail is degraded without promotion", test_complete_unknown_tail_is_degraded_without_promotion},
+      {"interrupted Episode reuses typed qualification without mutation",
+       test_interrupted_episode_reuses_typed_qualification_without_mutation},
+      {"invalid interrupted Episode blocks recovery", test_invalid_interrupted_episode_blocks_recovery},
+      {"closed Episode does not degrade recovery", test_closed_episode_does_not_degrade_recovery},
       {"torn tail is degraded at checkpoint frontier", test_torn_tail_is_degraded_and_frontier_stays_at_checkpoint},
       {"no provable checkpoint is blocked", test_no_provable_checkpoint_is_blocked},
       {"quarantine retains exact evidence idempotently",

--- a/framework/core/src/libyijinjing/include/kungfu/yijinjing/storage/episode_manifest_types.h
+++ b/framework/core/src/libyijinjing/include/kungfu/yijinjing/storage/episode_manifest_types.h
@@ -174,6 +174,8 @@ struct episode_fsck_issue {
   std::optional<std::string> algorithm = {};
   std::optional<std::string> recorded = {};
   std::optional<std::string> computed = {};
+
+  friend bool operator==(const episode_fsck_issue &, const episode_fsck_issue &) = default;
 };
 
 struct episode_fsck_result {

--- a/framework/core/src/libyijinjing/src/io/ownership.cpp
+++ b/framework/core/src/libyijinjing/src/io/ownership.cpp
@@ -35,6 +35,17 @@ std::mutex local_owners_mutex;
 std::set<std::string> local_owners;
 std::atomic<uint64_t> token_counter{0};
 
+#ifdef _WIN32
+OVERLAPPED ownership_lock_region() noexcept {
+  OVERLAPPED region{};
+  // Keep the advisory ownership byte outside the evidence payload. Windows
+  // enforces byte-range locks on reads from other handles, so locking byte 0
+  // makes the JSON evidence appear empty while the writer is alive.
+  region.OffsetHigh = 1;
+  return region;
+}
+#endif
+
 uint64_t current_pid() noexcept {
 #ifdef _WIN32
   return static_cast<uint64_t>(GetCurrentProcessId());
@@ -187,7 +198,7 @@ struct lease::impl {
     if (handle == INVALID_HANDLE_VALUE) {
       throw std::runtime_error("ownership_io_error: cannot open " + lock_path);
     }
-    OVERLAPPED overlapped{};
+    auto overlapped = ownership_lock_region();
     if (LockFileEx(handle, LOCKFILE_EXCLUSIVE_LOCK | LOCKFILE_FAIL_IMMEDIATELY, 0, 1, 0, &overlapped) == 0) {
       CloseHandle(handle);
       handle = INVALID_HANDLE_VALUE;
@@ -239,7 +250,7 @@ struct lease::impl {
   void release_os_lock() noexcept {
 #ifdef _WIN32
     if (handle != INVALID_HANDLE_VALUE) {
-      OVERLAPPED overlapped{};
+      auto overlapped = ownership_lock_region();
       UnlockFileEx(handle, 0, 1, 0, &overlapped);
       CloseHandle(handle);
       handle = INVALID_HANDLE_VALUE;
@@ -369,7 +380,7 @@ evidence inspect_active_stream_writer(const std::string &data_root, const std::s
     if (handle == INVALID_HANDLE_VALUE) {
       throw std::runtime_error("ownership_io_error: cannot inspect " + path);
     }
-    OVERLAPPED overlapped{};
+    auto overlapped = ownership_lock_region();
     if (LockFileEx(handle, LOCKFILE_EXCLUSIVE_LOCK | LOCKFILE_FAIL_IMMEDIATELY, 0, 1, 0, &overlapped) != 0) {
       UnlockFileEx(handle, 0, 1, 0, &overlapped);
       CloseHandle(handle);

--- a/scripts/run-crash-recovery-tests.mjs
+++ b/scripts/run-crash-recovery-tests.mjs
@@ -34,6 +34,8 @@ const executable =
 const candidates = [
   path.join(buildDir, 'Release', executable),
   path.join(buildDir, executable),
+  path.join(buildDir, 'src', 'libkungfu', 'Release', executable),
+  path.join(buildDir, 'src', 'libkungfu', executable),
 ];
 const testBinary = candidates.find((candidate) => fs.existsSync(candidate));
 if (!testBinary) {


### PR DESCRIPTION
## Summary
- compose the existing typed Storage/Episode qualification result into crash-recovery reports
- classify retained open Episodes as DEGRADED and invalid/unknown Episode evidence as BLOCKED
- preserve read-only inspection, full report repeatability, and closed-Episode isolation
- supersede #720 with an equivalent single-parent commit because the repository only permits rebase merge

## Verification
- `./shifu check:source`
- direct `kungfu_crash_recovery_tests` execution: 10 passed
- direct `kungfu_durable_ingest_tests` execution: 25 passed
- direct `kungfu_projection_bootstrap_tests` execution: 13 passed
- `git diff --check`
- `build:core` compiled and linked all three target binaries; the aggregate build then stopped on the unrelated dev-baseline `view_encapsulation_probe` SQLite link defect

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "stage-ready",
  "adrs": ["ADR-0068"],
  "summary": "Fold interrupted Episode qualification into deterministic read-only crash recovery",
  "verification": ["crash-recovery contracts", "durable-ingest contracts", "projection-bootstrap contracts", "build-free source acceptance"]
}
-->

## Boundaries
- no automatic Episode abort/resume or other mutation
- no second lifecycle/capability vocabulary and no JSON service currency
- no workflow, Buildchain, artifact, or release-path changes
- export/empty-root restore and projection rebuild equality remain later recovery stages

## Governance risk check
- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

This PR updates ADR delivery evidence only; it does not modify workflows, publish artifacts, or deploy anything.

## Checklist
- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed