### PR TITLE
feat(shifu): enforce uv cache with disposable effective locks

### DIFF
--- a/crates/shifu/src/envfile.rs
+++ b/crates/shifu/src/envfile.rs
@@ -13,25 +13,45 @@ use std::path::Path;
 
 use crate::util;
 
+const EXPLICIT_CACHE_PROJECTION_KEYS: [&str; 3] = [
+    "SHIFU_CACHE_PROFILE_REF",
+    "SHIFU_CACHE_PROFILE_DIGEST",
+    "SHIFU_CACHE_SCOPE",
+];
+
 /// Load the two-layer config: the user-global file always (rootless verbs
 /// like `promote` and `builds` read configuration too), the repo-root
 /// override only inside a checkout.
 pub fn load(repo_root: Option<&Path>) {
+    // Buildchain and runner projections are execution-scoped authority. Keep
+    // any non-empty value that was present before loading the user-global
+    // development config, including a partial ref/digest pair so resolution
+    // can fail closed instead of silently changing profiles.
+    let explicit_cache_projection = EXPLICIT_CACHE_PROJECTION_KEYS
+        .map(|key| (key, std::env::var_os(key).filter(|value| !value.is_empty())));
     let user_global = util::xdg_dir("XDG_CONFIG_HOME", ".config")
         .join("kungfu")
         .join("build-local.env");
-    apply_file(&user_global);
+    apply_file(&user_global, &explicit_cache_projection);
     if let Some(root) = repo_root {
-        apply_file(&root.join("build-local.env"));
+        apply_file(&root.join("build-local.env"), &explicit_cache_projection);
     }
 }
 
-fn apply_file(path: &Path) {
+fn apply_file(path: &Path, explicit_cache_projection: &[(&str, Option<std::ffi::OsString>)]) {
     let Ok(text) = std::fs::read_to_string(path) else {
         return;
     };
     for line in text.lines() {
         if let Some((key, value)) = parse_line(line) {
+            if explicit_cache_projection
+                .iter()
+                .any(|(explicit_key, explicit_value)| {
+                    key == *explicit_key && explicit_value.is_some()
+                })
+            {
+                continue;
+            }
             std::env::set_var(key, value);
         }
     }
@@ -63,7 +83,7 @@ pub(crate) fn parse_line(line: &str) -> Option<(&str, &str)> {
 
 #[cfg(test)]
 mod tests {
-    use super::parse_line;
+    use super::{parse_line, EXPLICIT_CACHE_PROJECTION_KEYS};
 
     #[test]
     fn parses_documented_shapes() {
@@ -85,5 +105,17 @@ mod tests {
         assert_eq!(parse_line("not a var line"), None);
         assert_eq!(parse_line("1BAD=x"), None);
         assert_eq!(parse_line("BAD KEY=x"), None);
+    }
+
+    #[test]
+    fn cache_projection_precedence_covers_ref_digest_and_scope() {
+        assert_eq!(
+            EXPLICIT_CACHE_PROJECTION_KEYS,
+            [
+                "SHIFU_CACHE_PROFILE_REF",
+                "SHIFU_CACHE_PROFILE_DIGEST",
+                "SHIFU_CACHE_SCOPE"
+            ]
+        );
     }
 }

--- a/developer/sdk/src/sdk.js
+++ b/developer/sdk/src/sdk.js
@@ -2525,7 +2525,13 @@ function cppBuild(manifest) {
   // compatible with the runtime and loads alongside pykungfu. Pass both the
   // classic (FindPythonInterp) and modern (FindPython) hint variables so the
   // pin holds regardless of which pybind11 lookup mode is active.
-  const corePython = path.join(coreDir, '.venv', 'bin', 'python3');
+  const pythonEnvironment =
+    process.env.UV_PROJECT_ENVIRONMENT || path.join(coreDir, '.venv');
+  const corePython = path.join(
+    pythonEnvironment,
+    process.platform === 'win32' ? 'Scripts' : 'bin',
+    process.platform === 'win32' ? 'python.exe' : 'python3',
+  );
   if (fs.existsSync(corePython)) {
     configureArgs.push(
       `-DPYTHON_EXECUTABLE=${corePython}`,
@@ -2556,7 +2562,13 @@ function pythonAotBuild(manifest) {
     fail(
       'cannot locate framework/core (a python-AOT kfx build needs the monorepo core)',
     );
-  const py = path.join(coreDir, '.venv', 'bin', 'python3');
+  const pythonEnvironment =
+    process.env.UV_PROJECT_ENVIRONMENT || path.join(coreDir, '.venv');
+  const py = path.join(
+    pythonEnvironment,
+    process.platform === 'win32' ? 'Scripts' : 'bin',
+    process.platform === 'win32' ? 'python.exe' : 'python3',
+  );
   if (!fs.existsSync(py)) {
     fail(`core Python not found: ${py}. Run \`./shifu rebuild:core\` first.`);
   }

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -148,6 +148,7 @@ implemented and qualified or explicitly waived for that release.
 | [0076](ADR-0076-documentation-directory-authority.md) | accepted | canonical public documentation is organized by maintenance authority, and the source tree carries no speculative pre-release compatibility paths |
 | [SHIFU-0001](SHIFU-ADR-0001-cache-profile-contract-and-ownership.md) | accepted | Cache profiles are Shifu-owned contracts; inventories project instances and Buildchain owns process |
 | [SHIFU-0002](SHIFU-ADR-0002-local-artifact-catalog-and-safe-promotion.md) | accepted | Shifu and Kungfu product artifacts share provenance-aware, Git-safe local promotion semantics |
+| [SHIFU-0003](SHIFU-ADR-0003-uv-effective-lock-cache-enforcement.md) | accepted | Strict uv cache execution uses a disposable effective lock while canonical locks stay public |
 
 ## Reading by theme
 

--- a/docs/adr/SHIFU-ADR-0003-uv-effective-lock-cache-enforcement.md
+++ b/docs/adr/SHIFU-ADR-0003-uv-effective-lock-cache-enforcement.md
@@ -44,29 +44,27 @@ every tracked lock and rejects private, local, alternate, or malformed hosts.
 When a profile selects a Python index, Shifu performs these steps before
 starting the requested build task:
 
-1. For a required fail-closed profile, probe the selected Python endpoint with
-   a bounded request.
-2. Mirror each tracked uv project into a process-private temporary directory,
+1. Mirror each tracked uv project into a process-private temporary directory,
    copying only `pyproject.toml` and `uv.lock` and linking the remaining source
    tree without writing it.
-3. Ask the pinned `uv` executable to refresh the copied lock against the
+2. Ask the pinned `uv` executable to refresh the copied lock against the
    selected endpoint.
-4. Normalize transport-only fields and require the effective lock's dependency
+3. Normalize transport-only fields and require the effective lock's dependency
    semantic digest to equal the canonical lock's digest.
-5. Require every effective registry and artifact URL origin to equal the
+4. Require every effective registry and artifact URL origin to equal the
    selected endpoint origin.
-6. Put a child-only `uv` wrapper first on `PATH`. Project commands use the
+5. Put a child-only `uv` wrapper first on `PATH`. Project commands use the
    mirrored project, a disposable `UV_PROJECT_ENVIRONMENT`, and frozen mode.
-7. Remove the overlay after the child exits and emit only digests, counts,
+6. Remove the overlay after the child exits and emit only digests, counts,
    verification state, and cleanup state in the resolution receipt.
 
 `uv add`, `uv remove`, and `uv version` are rejected inside a cache-managed
 execution because mutations belong in the canonical development checkout.
 Non-project uv commands continue to reach the real executable. Profiles that
-allow fallback attempt the same effective-lock overlay without the strict
-pre-probe. If tool-native rebinding fails, Shifu records the declared fallback
-and continues with the canonical public lock. Required profiles never take that
-path.
+allow fallback attempt the same effective-lock overlay. If tool-native
+rebinding fails, Shifu records the declared fallback and continues with the
+canonical public lock. Required profiles never take that path. A generic HTTP
+probe is diagnostic evidence only; tool-native rebind is the execution gate.
 
 ## Compatibility
 

--- a/docs/adr/SHIFU-ADR-0003-uv-effective-lock-cache-enforcement.md
+++ b/docs/adr/SHIFU-ADR-0003-uv-effective-lock-cache-enforcement.md
@@ -1,0 +1,105 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+doc_type: architecture-decision
+adr_id: SHIFU-ADR-0003
+decision_status: accepted
+implementation_status: not-started
+review_state: unreviewed
+sensitivity: public
+sources: [local-files, user-consensus, official-upstream]
+period: ongoing
+theme: shifu-uv-effective-lock
+confidence: high
+evidence_grade: B
+last_reviewed: 2026-07-13
+---
+
+# SHIFU-ADR-0003: uv cache enforcement uses a disposable effective lock
+
+- Status: accepted; development implementation
+- Date: 2026-07-13
+- Scope: Shifu strict cache execution for uv-managed Python projects
+- Related: [SHIFU-ADR-0001](./SHIFU-ADR-0001-cache-profile-contract-and-ownership.md)
+
+## Context
+
+An environment binding such as `UV_DEFAULT_INDEX` controls package discovery,
+but a frozen `uv.lock` also records exact registry and artifact URLs. A build can
+therefore receive the selected central index and still fetch locked artifacts
+from a public host. Rewriting the tracked lock in place would leak private
+topology into a public repository, make the checkout dirty, and couple one
+developer's transport path to every other consumer.
+
+The committed lock remains a public reproducibility artifact. Strict
+self-hosted execution still needs a fail-closed guarantee that every registry
+and registry artifact request uses the profile-selected endpoint.
+
+## Decision
+
+Tracked `uv.lock` files in the Kungfu repository contain only official PyPI
+transport URLs: `https://pypi.org/simple` for registry sources and
+`https://files.pythonhosted.org` for registry artifacts. A source gate checks
+every tracked lock and rejects private, local, alternate, or malformed hosts.
+
+When a profile selects a Python index, Shifu performs these steps before
+starting the requested build task:
+
+1. For a required fail-closed profile, probe the selected Python endpoint with
+   a bounded request.
+2. Mirror each tracked uv project into a process-private temporary directory,
+   copying only `pyproject.toml` and `uv.lock` and linking the remaining source
+   tree without writing it.
+3. Ask the pinned `uv` executable to refresh the copied lock against the
+   selected endpoint.
+4. Normalize transport-only fields and require the effective lock's dependency
+   semantic digest to equal the canonical lock's digest.
+5. Require every effective registry and artifact URL origin to equal the
+   selected endpoint origin.
+6. Put a child-only `uv` wrapper first on `PATH`. Project commands use the
+   mirrored project, a disposable `UV_PROJECT_ENVIRONMENT`, and frozen mode.
+7. Remove the overlay after the child exits and emit only digests, counts,
+   verification state, and cleanup state in the resolution receipt.
+
+`uv add`, `uv remove`, and `uv version` are rejected inside a cache-managed
+execution because mutations belong in the canonical development checkout.
+Non-project uv commands continue to reach the real executable. Profiles that
+allow fallback attempt the same effective-lock overlay without the strict
+pre-probe. If tool-native rebinding fails, Shifu records the declared fallback
+and continues with the canonical public lock. Required profiles never take that
+path.
+
+## Compatibility
+
+The input profile schema does not gain a second uv-specific policy language.
+The existing `UV_DEFAULT_INDEX` binding plus strict profile policy selects this
+behavior. The resolution schema gains an optional `toolEvidence` object; this
+is an additive v1-compatible receipt extension. Unknown fields remain rejected.
+
+Buildchain still passes only the profile reference and digest. It does not
+interpret lock contents, mirror URLs, or uv arguments. The inventory controller
+continues to own the concrete endpoint projected into the profile.
+
+## Consequences
+
+- Public source history and generated artifacts do not expose private network
+  addresses.
+- Strict runner builds cannot silently escape to PyPI when the central endpoint
+  is unavailable or incomplete.
+- Canonical locks and the checkout remain byte-identical and Git-clean.
+- The disposable Python environment may cost more than reusing a project-local
+  `.venv`; that isolation is intentional because URL-keyed uv cache entries are
+  not portable between the central and public lock identities.
+- Direct URL dependencies whose origin differs from the selected endpoint fail
+  strict validation until the cache profile and provider can represent them.
+
+## Alternatives considered
+
+- **Environment override only** — rejected because frozen artifact URLs remain
+  authoritative.
+- **Rewrite the tracked lock in place and restore it later** — rejected because
+  crashes can leave a dirty checkout and private coordinates can enter commits.
+- **Prewarm through a central lock, then install the public lock offline** —
+  rejected because uv cache keys include the artifact URL identity; a central
+  fetch does not prove the public URL-keyed lock is available offline.
+- **Teach Buildchain uv fields** — rejected because Buildchain owns process and
+  Shifu owns execution semantics.

--- a/docs/adr/SHIFU-ADR-0003-uv-effective-lock-cache-enforcement.md
+++ b/docs/adr/SHIFU-ADR-0003-uv-effective-lock-cache-enforcement.md
@@ -3,8 +3,11 @@ metadata_schema: kungfu.document-metadata/v1
 doc_type: architecture-decision
 adr_id: SHIFU-ADR-0003
 decision_status: accepted
-implementation_status: not-started
-review_state: unreviewed
+implementation_status: implemented
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/755]
+closure_pr: https://github.com/kungfu-systems/kungfu/pull/755
+qualification_refs: [scripts/shifu-uv-cache-adapter.test.mjs, scripts/shifu-cache-runtime.test.mjs, scripts/check-shifu-cache-contract.test.mjs]
+review_state: self-reviewed
 sensitivity: public
 sources: [local-files, user-consensus, official-upstream]
 period: ongoing
@@ -16,7 +19,7 @@ last_reviewed: 2026-07-13
 
 # SHIFU-ADR-0003: uv cache enforcement uses a disposable effective lock
 
-- Status: accepted; development implementation
+- Status: accepted; implemented and qualified
 - Date: 2026-07-13
 - Scope: Shifu strict cache execution for uv-managed Python projects
 - Related: [SHIFU-ADR-0001](./SHIFU-ADR-0001-cache-profile-contract-and-ownership.md)

--- a/docs/shifu/cache-contract.json
+++ b/docs/shifu/cache-contract.json
@@ -36,6 +36,7 @@
       "post-checkout cache profile schema",
       "cache resolution",
       "tool bindings",
+      "strict uv effective-lock enforcement",
       "developer status, doctor, and bounded local configuration",
       "non-secret resolution evidence"
     ],
@@ -50,6 +51,7 @@
     "endpointUserInfo": "forbidden",
     "endpointQueryAndFragment": "forbidden",
     "persistentToolConfig": "not-read-or-written-by-shifu",
+    "trackedUvLocks": "official-pypi-urls-only",
     "evidenceRedaction": "credentials-userinfo-query-fragment"
   },
   "integrity": {

--- a/docs/shifu/cache-profiles.md
+++ b/docs/shifu/cache-profiles.md
@@ -90,6 +90,28 @@ only the managed remote plus an explicitly declared development fallback, if
 any; Kungfu detects a default compiler profile inside that isolated home. Both
 temporary overlays are removed after the child exits, including non-zero exits.
 The nested libwasm Cargo invocation inherits the same wrapper.
+
+For a selected Python index, an environment binding alone is insufficient:
+frozen uv locks contain exact registry artifact URLs. Shifu therefore copies
+each tracked uv project into a disposable overlay,
+refreshes the copied lock against `UV_DEFAULT_INDEX`, compares a normalized
+dependency semantic digest with the canonical lock, and rejects any effective
+registry or artifact URL outside the selected origin. A child-only uv wrapper
+routes project commands to that overlay and sets a disposable
+`UV_PROJECT_ENVIRONMENT`; the tracked lock, project `.venv`, and checkout remain
+untouched. Mutating `uv add`, `uv remove`, and `uv version` commands are rejected
+inside this managed execution. The receipt records only lock digests, rebinding
+counts, verification state, and cleanup state.
+Required profiles fail before the child starts when the endpoint or rebind is
+unavailable. Development profiles with an explicit public fallback attempt the
+same overlay first, then record a fallback and use the canonical public lock if
+tool-native rebinding is unavailable.
+
+Every tracked Kungfu `uv.lock` is a public source artifact and must use
+`https://pypi.org/simple` plus `https://files.pythonhosted.org`. The cache
+contract gate rejects private, local, alternate, and malformed registry or
+artifact hosts. Concrete central endpoints exist only in secret-free projected
+profiles and process-private effective locks, never in Git history.
 Unsupported argument/config bindings, protected or secret-like environment
 keys, unsafe URLs, applicability drift, and digest drift fail closed. Receipts
 name binding kinds and overlay cleanup without exposing local paths.

--- a/docs/shifu/schema/cache-resolution-v1.schema.json
+++ b/docs/shifu/schema/cache-resolution-v1.schema.json
@@ -188,6 +188,47 @@
             },
             "overlayCleanup": {
               "enum": ["not-run", "completed", "not-applicable"]
+            },
+            "toolEvidence": {
+              "$ref": "#/$defs/uvToolEvidence"
+            }
+          }
+        }
+      }
+    },
+    "uvToolEvidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["adapter", "enforcement", "projectCount", "locks"],
+      "properties": {
+        "adapter": {
+          "const": "uv-effective-lock"
+        },
+        "enforcement": {
+          "enum": ["project-overlay", "not-applicable"]
+        },
+        "projectCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "locks": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "canonicalDigest",
+              "effectiveDigest",
+              "semanticDigest",
+              "registryRebindings",
+              "artifactRebindings"
+            ],
+            "properties": {
+              "canonicalDigest": { "$ref": "#/$defs/sha256" },
+              "effectiveDigest": { "$ref": "#/$defs/sha256" },
+              "semanticDigest": { "$ref": "#/$defs/sha256" },
+              "registryRebindings": { "type": "integer", "minimum": 1 },
+              "artifactRebindings": { "type": "integer", "minimum": 0 }
             }
           }
         }

--- a/framework/core/.gyp/run-build.js
+++ b/framework/core/.gyp/run-build.js
@@ -135,13 +135,14 @@ function makePackage() {
 // “node native 编译用哪个 python 不确定”的脆弱点。uv 不可用时静默跳过，回退默认查找。
 function useUvPython() {
   const isWin = process.platform === 'win32';
-  // 直接定位 uv 项目 venv 的 python（__dirname=.gyp → 上一级=core 根 → .venv）。
+  // Shifu strict cache execution supplies a disposable UV_PROJECT_ENVIRONMENT;
+  // ordinary development continues to use the project-local .venv.
   // 不解 realpath：venv 的 python 是指向 base python 的 symlink，靠“在 .venv/bin 下”这一
   // 路径语义才会启用 venv site-packages（setuptools 的 _distutils shim）；解到真身就丢了。
+  const environment =
+    process.env.UV_PROJECT_ENVIRONMENT || path.join(__dirname, '..', '.venv');
   const venvPy = path.join(
-    __dirname,
-    '..',
-    '.venv',
+    environment,
     isWin ? 'Scripts' : 'bin',
     isWin ? 'python.exe' : 'python3',
   );

--- a/scripts/check-shifu-cache-contract.mjs
+++ b/scripts/check-shifu-cache-contract.mjs
@@ -3,9 +3,12 @@
 // @ts-check
 
 import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import { publicUvLockViolations } from './shifu-uv-cache-adapter.mjs';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const SHIFU_DOCS = path.join(ROOT, 'docs', 'shifu');
@@ -154,6 +157,33 @@ export async function checkShifuCacheContract(root = ROOT) {
   assert.doesNotMatch(publicJson, /\b(?:10|127)\.\d+\.\d+\.\d+\b/);
   assert.doesNotMatch(publicJson, /\b192\.168\.\d+\.\d+\b/);
   assert.doesNotMatch(publicJson, /\b172\.(?:1[6-9]|2\d|3[01])\.\d+\.\d+\b/);
+
+  const trackedLocks = [];
+  const gitIndex = spawnSync('git', ['ls-files', '-z', '*uv.lock'], {
+    cwd: root,
+    encoding: 'utf8',
+    shell: false,
+  });
+  assert.equal(
+    gitIndex.status,
+    0,
+    gitIndex.stderr || 'cannot list tracked uv.lock files',
+  );
+  for (const relative of gitIndex.stdout.split('\0').filter(Boolean)) {
+    const violations = publicUvLockViolations(
+      fs.readFileSync(path.join(root, relative), 'utf8'),
+    );
+    assert.deepEqual(
+      violations,
+      [],
+      `${relative} must contain only official PyPI registry and artifact URLs`,
+    );
+    trackedLocks.push(relative);
+  }
+  assert.ok(
+    trackedLocks.length > 0,
+    'repository must track at least one uv.lock',
+  );
 
   return {
     contract: rel(contractPath),

--- a/scripts/check-shifu-cache-contract.test.mjs
+++ b/scripts/check-shifu-cache-contract.test.mjs
@@ -452,6 +452,41 @@ test(
 );
 
 test(
+  'explicit runner projection overrides user-global development config',
+  { skip: process.platform === 'win32' },
+  (t) => {
+    const fixture = shellHarness(t);
+    const configDir = path.join(fixture.root, 'config', 'kungfu');
+    fs.mkdirSync(configDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(configDir, 'build-local.env'),
+      [
+        "export SHIFU_CACHE_PROFILE_REF='missing-development-profile.json'",
+        `export SHIFU_CACHE_PROFILE_DIGEST='sha256:${'0'.repeat(64)}'`,
+        "export SHIFU_CACHE_SCOPE='development'",
+        '',
+      ].join('\n'),
+    );
+    const result = spawnSync(SHIFU_SH, ['test:runner-projection'], {
+      cwd: ROOT,
+      encoding: 'utf8',
+      env: {
+        ...fixture.env,
+        SHIFU_CACHE_ACTIVE: '',
+        SHIFU_CACHE_PROFILE_REF: fixture.profilePath,
+        SHIFU_CACHE_PROFILE_DIGEST: fixture.digest,
+        SHIFU_CACHE_SCOPE: 'self-hosted-runner',
+      },
+    });
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(
+      JSON.parse(fs.readFileSync(fixture.receipt, 'utf8')).execution.scope,
+      'self-hosted-runner',
+    );
+  },
+);
+
+test(
   'active child and absent projection bypass automatic cache application',
   { skip: process.platform === 'win32' },
   (t) => {

--- a/scripts/check.mjs
+++ b/scripts/check.mjs
@@ -342,6 +342,7 @@ function testShifuCacheContract() {
     '--test',
     path.join('scripts', 'check-shifu-cache-contract.test.mjs'),
     path.join('scripts', 'shifu-cache-runtime.test.mjs'),
+    path.join('scripts', 'shifu-uv-cache-adapter.test.mjs'),
   ]);
 }
 

--- a/scripts/qualify-embedding-membranes.mjs
+++ b/scripts/qualify-embedding-membranes.mjs
@@ -11,9 +11,10 @@ import { fileURLToPath } from 'node:url';
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const core = path.join(root, 'framework', 'core');
 const build = path.join(core, 'build');
+const pythonEnvironment =
+  process.env.UV_PROJECT_ENVIRONMENT || path.join(core, '.venv');
 const python = path.join(
-  core,
-  '.venv',
+  pythonEnvironment,
   process.platform === 'win32' ? 'Scripts' : 'bin',
   process.platform === 'win32' ? 'python.exe' : 'python3',
 );

--- a/scripts/run-agent-profile-sdk-tests.mjs
+++ b/scripts/run-agent-profile-sdk-tests.mjs
@@ -6,10 +6,13 @@ import path from 'node:path';
 import process from 'node:process';
 
 const root = process.cwd();
+const pythonEnvironment =
+  process.env.UV_PROJECT_ENVIRONMENT ||
+  path.join(root, 'framework', 'core', '.venv');
 const python =
   process.platform === 'win32'
-    ? path.join(root, 'framework', 'core', '.venv', 'Scripts', 'python.exe')
-    : path.join(root, 'framework', 'core', '.venv', 'bin', 'python');
+    ? path.join(pythonEnvironment, 'Scripts', 'python.exe')
+    : path.join(pythonEnvironment, 'bin', 'python');
 const pythonPath = [
   path.join(root, 'framework', 'core', 'build', 'Release'),
   path.join(root, 'framework', 'core', 'src', 'python'),

--- a/scripts/run-cpp-modules-qualification.mjs
+++ b/scripts/run-cpp-modules-qualification.mjs
@@ -10,11 +10,11 @@ import { fileURLToPath } from 'node:url';
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const source = path.join(root, 'tests', 'qualification', 'cpp-modules');
 const work = fs.mkdtempSync(path.join(os.tmpdir(), 'kungfu-cpp-modules-'));
+const pythonEnvironment =
+  process.env.UV_PROJECT_ENVIRONMENT ||
+  path.join(root, 'framework', 'core', '.venv');
 const ninja = path.join(
-  root,
-  'framework',
-  'core',
-  '.venv',
+  pythonEnvironment,
   process.platform === 'win32' ? 'Scripts' : 'bin',
   process.platform === 'win32' ? 'ninja.exe' : 'ninja',
 );

--- a/scripts/run-durability-contract-tests.mjs
+++ b/scripts/run-durability-contract-tests.mjs
@@ -43,17 +43,13 @@ if (nativeResult.error) {
 }
 if (nativeResult.status !== 0) process.exit(nativeResult.status ?? 1);
 
+const pythonEnvironment =
+  process.env.UV_PROJECT_ENVIRONMENT ||
+  path.join(process.cwd(), 'framework', 'core', '.venv');
 const python =
   process.platform === 'win32'
-    ? path.join(
-        process.cwd(),
-        'framework',
-        'core',
-        '.venv',
-        'Scripts',
-        'python.exe',
-      )
-    : path.join(process.cwd(), 'framework', 'core', '.venv', 'bin', 'python');
+    ? path.join(pythonEnvironment, 'Scripts', 'python.exe')
+    : path.join(pythonEnvironment, 'bin', 'python');
 console.log('[durability-contract-test] checking Python typed surface');
 const pythonResult = spawnSync(
   python,

--- a/scripts/run-profile-lifecycle-tests.mjs
+++ b/scripts/run-profile-lifecycle-tests.mjs
@@ -73,17 +73,13 @@ if (result.error || result.status !== 0) {
   process.exit(result.status ?? 1);
 }
 
+const pythonEnvironment =
+  process.env.UV_PROJECT_ENVIRONMENT ||
+  path.join(process.cwd(), 'framework', 'core', '.venv');
 const python =
   process.platform === 'win32'
-    ? path.join(
-        process.cwd(),
-        'framework',
-        'core',
-        '.venv',
-        'Scripts',
-        'python.exe',
-      )
-    : path.join(process.cwd(), 'framework', 'core', '.venv', 'bin', 'python');
+    ? path.join(pythonEnvironment, 'Scripts', 'python.exe')
+    : path.join(pythonEnvironment, 'bin', 'python');
 const pythonPath = [
   path.join(process.cwd(), 'framework', 'core', 'build', 'Release'),
   path.join(process.cwd(), 'framework', 'core', 'src', 'python'),

--- a/scripts/run-runtime-error-tests.mjs
+++ b/scripts/run-runtime-error-tests.mjs
@@ -35,17 +35,13 @@ if (result.error) {
 }
 if (result.status !== 0) process.exit(result.status ?? 1);
 
+const pythonEnvironment =
+  process.env.UV_PROJECT_ENVIRONMENT ||
+  path.join(process.cwd(), 'framework', 'core', '.venv');
 const python =
   process.platform === 'win32'
-    ? path.join(
-        process.cwd(),
-        'framework',
-        'core',
-        '.venv',
-        'Scripts',
-        'python.exe',
-      )
-    : path.join(process.cwd(), 'framework', 'core', '.venv', 'bin', 'python');
+    ? path.join(pythonEnvironment, 'Scripts', 'python.exe')
+    : path.join(pythonEnvironment, 'bin', 'python');
 const bindingDir = path.join(
   process.cwd(),
   'framework',

--- a/scripts/shifu-cache-runtime.mjs
+++ b/scripts/shifu-cache-runtime.mjs
@@ -11,6 +11,8 @@ import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { prepareUvCacheOverlay } from './shifu-uv-cache-adapter.mjs';
+
 const PROFILE_SCHEMA = 'shifu.cache-profile/v1';
 const RECEIPT_SCHEMA = 'shifu.cache-resolution/v1';
 const REDACTION = 'credentials-userinfo-query-fragment';
@@ -25,6 +27,15 @@ const BLOCKED_ENV_KEYS = new Set([
   'GH_TOKEN',
   'NODE_OPTIONS',
   'CARGO_HOME',
+  'UV_PROJECT',
+  'UV_PROJECT_ENVIRONMENT',
+  'UV_FROZEN',
+  'UV_LOCKED',
+  'UV_OFFLINE',
+  'UV_INDEX',
+  'UV_INDEX_URL',
+  'UV_EXTRA_INDEX_URL',
+  'UV_FIND_LINKS',
   'CONAN_HOME',
   'KF_LIBWASM_CARGO_REGISTRY',
   'SHIFU_CACHE_ACTIVE',
@@ -638,6 +649,78 @@ function markOverlayCleanup(receipt) {
   }
 }
 
+function pythonCacheBinding(resolved) {
+  for (const [serviceId, service] of Object.entries(
+    resolved.profile.services,
+  )) {
+    const binding = service.bindings.find(
+      (item) => item.kind === 'environment' && item.key === 'UV_DEFAULT_INDEX',
+    );
+    if (binding)
+      return {
+        serviceId,
+        endpoint: resolved.bindings.UV_DEFAULT_INDEX,
+        strict:
+          resolved.profile.policy.mode === 'require' &&
+          resolved.profile.policy.onUnavailable === 'fail' &&
+          !resolved.profile.policy.allowPublicFallback,
+      };
+  }
+  return null;
+}
+
+async function probeRequiredEndpoint(endpoint, timeoutMs = 5_000) {
+  let response;
+  try {
+    response = await fetch(endpoint, {
+      method: 'HEAD',
+      redirect: 'follow',
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+  } catch (error) {
+    throw new CacheProfileError(
+      `required Python cache endpoint is unavailable: ${error.message}`,
+    );
+  }
+  assert(
+    response.ok,
+    `required Python cache endpoint is unavailable: HTTP ${response.status}`,
+  );
+}
+
+function markPythonVerification(receipt, pythonCache, evidence, durationMs) {
+  const service = receipt.services[pythonCache.serviceId];
+  service.verification =
+    evidence.enforcement === 'not-applicable' ? 'not-applicable' : 'passed';
+  service.durationMs = durationMs;
+  service.reason =
+    evidence.enforcement === 'not-applicable'
+      ? 'no tracked uv project in execution repository'
+      : 'effective uv lock rebound and semantic digest verified';
+  service.application.overlayCleanup =
+    evidence.enforcement === 'not-applicable' ? 'not-applicable' : 'not-run';
+  service.application.toolEvidence = evidence;
+}
+
+function markPythonFailure(receipt, pythonCache, durationMs) {
+  const service = receipt.services[pythonCache.serviceId];
+  service.outcome = 'failed';
+  service.verification = 'failed';
+  service.durationMs = durationMs;
+  service.reason =
+    'required Python cache verification failed before child execution';
+}
+
+function markPythonFallback(receipt, pythonCache, durationMs) {
+  const service = receipt.services[pythonCache.serviceId];
+  service.outcome = 'fallback';
+  service.fallbackUsed = true;
+  service.verification = 'failed';
+  service.durationMs = durationMs;
+  service.reason =
+    'effective lock unavailable; declared canonical public-lock fallback selected';
+}
+
 function receiptFor(resolved) {
   return {
     $schema:
@@ -751,13 +834,55 @@ export async function applyCacheProfile({
     scope,
     cwd,
   });
-  const overlays = prepareConfigOverlays(resolved.configBindings, env);
+  const pythonCache = pythonCacheBinding(resolved);
+  let overlays = { env: {}, cleanup() {} };
+  let uvOverlay = { env: {}, cleanup() {} };
+  const verificationStarted = Date.now();
   let result;
   try {
-    const childEnv = {
+    overlays = prepareConfigOverlays(resolved.configBindings, env);
+    const boundEnv = {
       ...env,
       ...resolved.bindings,
       ...overlays.env,
+    };
+    if (pythonCache) {
+      try {
+        if (pythonCache.strict)
+          await probeRequiredEndpoint(pythonCache.endpoint);
+        uvOverlay = prepareUvCacheOverlay({
+          cwd,
+          env: boundEnv,
+          endpoint: pythonCache.endpoint,
+        });
+        markPythonVerification(
+          resolved.receipt,
+          pythonCache,
+          uvOverlay.evidence,
+          Date.now() - verificationStarted,
+        );
+      } catch (error) {
+        if (pythonCache.strict) {
+          markPythonFailure(
+            resolved.receipt,
+            pythonCache,
+            Date.now() - verificationStarted,
+          );
+          throw error;
+        }
+        markPythonFallback(
+          resolved.receipt,
+          pythonCache,
+          Date.now() - verificationStarted,
+        );
+        console.warn(
+          'shifu cache: Python effective lock unavailable; using declared public fallback',
+        );
+      }
+    }
+    const childEnv = {
+      ...boundEnv,
+      ...uvOverlay.env,
       SHIFU_CACHE_ACTIVE: '1',
     };
     result = spawnChild(command, args, {
@@ -767,6 +892,7 @@ export async function applyCacheProfile({
       shell: false,
     });
   } finally {
+    uvOverlay.cleanup();
     overlays.cleanup();
     markOverlayCleanup(resolved.receipt);
     writeReceipt(resolved.receipt, receiptPath);

--- a/scripts/shifu-cache-runtime.mjs
+++ b/scripts/shifu-cache-runtime.mjs
@@ -669,25 +669,6 @@ function pythonCacheBinding(resolved) {
   return null;
 }
 
-async function probeRequiredEndpoint(endpoint, timeoutMs = 5_000) {
-  let response;
-  try {
-    response = await fetch(endpoint, {
-      method: 'HEAD',
-      redirect: 'follow',
-      signal: AbortSignal.timeout(timeoutMs),
-    });
-  } catch (error) {
-    throw new CacheProfileError(
-      `required Python cache endpoint is unavailable: ${error.message}`,
-    );
-  }
-  assert(
-    response.ok,
-    `required Python cache endpoint is unavailable: HTTP ${response.status}`,
-  );
-}
-
 function markPythonVerification(receipt, pythonCache, evidence, durationMs) {
   const service = receipt.services[pythonCache.serviceId];
   service.verification =
@@ -848,8 +829,6 @@ export async function applyCacheProfile({
     };
     if (pythonCache) {
       try {
-        if (pythonCache.strict)
-          await probeRequiredEndpoint(pythonCache.endpoint);
         uvOverlay = prepareUvCacheOverlay({
           cwd,
           env: boundEnv,

--- a/scripts/shifu-cache-runtime.test.mjs
+++ b/scripts/shifu-cache-runtime.test.mjs
@@ -407,12 +407,29 @@ test('strict Python cache uses a disposable effective lock and redacted receipt'
   );
 });
 
-test('strict Python cache fails before starting the child when endpoint is unavailable', async (t) => {
+test('strict Python cache fails before starting the child when effective lock rebinding fails', async (t) => {
   const directory = fs.mkdtempSync(
     path.join(os.tmpdir(), 'shifu-cache-uv-fail-'),
   );
   t.after(() => fs.rmSync(directory, { recursive: true, force: true }));
-  const raw = bytes(pythonCacheProfile('http://127.0.0.1:1/simple/'));
+  const repo = path.join(directory, 'repo');
+  const project = path.join(repo, 'framework', 'core');
+  const bin = path.join(directory, 'bin');
+  fs.mkdirSync(project, { recursive: true });
+  fs.mkdirSync(bin);
+  fs.writeFileSync(
+    path.join(project, 'pyproject.toml'),
+    '[project]\nname="demo"\nversion="1.0.0"\n',
+  );
+  fs.writeFileSync(path.join(project, 'uv.lock'), minimalUvLock());
+  spawnSync('git', ['init', '-q'], { cwd: repo });
+  spawnSync(
+    'git',
+    ['add', 'framework/core/pyproject.toml', 'framework/core/uv.lock'],
+    { cwd: repo },
+  );
+  installFakeUv(bin);
+  const raw = bytes(pythonCacheProfile('http://cache.example.invalid/simple/'));
   const profilePath = path.join(directory, 'profile.json');
   const receiptPath = path.join(directory, 'receipt.json');
   const childPath = path.join(directory, 'child-ran');
@@ -428,9 +445,14 @@ test('strict Python cache fails before starting the child when endpoint is unava
         '-e',
         `require('node:fs').writeFileSync(${JSON.stringify(childPath)}, 'ran')`,
       ],
-      cwd: directory,
+      cwd: repo,
+      env: {
+        ...process.env,
+        PATH: `${bin}${path.delimiter}${process.env.PATH || ''}`,
+        FAKE_UV_FAIL_LOCK: '1',
+      },
     }),
-    /endpoint is unavailable/,
+    /uv lock.*failed/,
   );
   assert.equal(fs.existsSync(childPath), false);
   const receipt = JSON.parse(fs.readFileSync(receiptPath, 'utf8'));

--- a/scripts/shifu-cache-runtime.test.mjs
+++ b/scripts/shifu-cache-runtime.test.mjs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import http from 'node:http';
 import os from 'node:os';
@@ -116,6 +117,88 @@ function toolConfigProfile() {
       },
     },
   });
+}
+
+function pythonCacheProfile(endpoint, { strict = true } = {}) {
+  return profile({
+    policy: strict
+      ? profile().policy
+      : {
+          mode: 'prefer',
+          onUnavailable: 'fallback',
+          allowPublicFallback: true,
+          secretPolicy: 'references-only',
+        },
+    services: {
+      'python-index': {
+        kind: 'package-registry',
+        mode: strict ? 'require' : 'prefer',
+        endpoint: { type: 'http', url: endpoint },
+        bindings: [
+          {
+            kind: 'environment',
+            key: 'UV_DEFAULT_INDEX',
+            valueFrom: 'endpoint.url',
+          },
+        ],
+        fallback: strict
+          ? { mode: 'fail' }
+          : { mode: 'upstream', upstreamUrl: 'https://pypi.org/simple' },
+        verification: { method: 'tool-native' },
+      },
+    },
+  });
+}
+
+function minimalUvLock() {
+  return `version = 1
+revision = 3
+requires-python = ">=3.12"
+
+[[package]]
+name = "demo"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/demo.tar.gz", hash = "sha256:${'a'.repeat(64)}", size = 1 }
+`;
+}
+
+function installFakeUv(bin) {
+  fs.writeFileSync(
+    path.join(bin, 'fake-uv.mjs'),
+    `import fs from 'node:fs';
+import path from 'node:path';
+const args = process.argv.slice(2);
+const projectAt = args.indexOf('--project');
+const project = args[projectAt + 1];
+if (args.includes('lock')) {
+  if (process.env.FAKE_UV_FAIL_LOCK) process.exit(42);
+  const file = path.join(project, 'uv.lock');
+  const endpoint = args[args.indexOf('--default-index') + 1];
+  fs.writeFileSync(file, fs.readFileSync(file, 'utf8')
+    .replaceAll('https://pypi.org/simple', endpoint)
+    .replaceAll('https://files.pythonhosted.org', new URL(endpoint).origin));
+} else if (process.env.FAKE_UV_OUTPUT) {
+  fs.writeFileSync(process.env.FAKE_UV_OUTPUT, JSON.stringify({
+    args,
+    environment: process.env.UV_PROJECT_ENVIRONMENT,
+    frozen: process.env.UV_FROZEN,
+  }));
+}
+`,
+  );
+  if (process.platform === 'win32') {
+    fs.writeFileSync(
+      path.join(bin, 'uv.cmd'),
+      '@node "%~dp0fake-uv.mjs" %*\r\n',
+    );
+  } else {
+    fs.writeFileSync(
+      path.join(bin, 'uv'),
+      '#!/bin/sh\nexec node "$(dirname "$0")/fake-uv.mjs" "$@"\n',
+      { mode: 0o700 },
+    );
+  }
 }
 
 test('validates exact bytes and applies only environment bindings', () => {
@@ -243,6 +326,174 @@ test('cache apply injects bindings and writes a receipt', async (t) => {
   const receipt = JSON.parse(fs.readFileSync(receiptPath, 'utf8'));
   assert.equal(receipt.profile.digest, sha256(raw));
   assert.match(receipt.execution.id, /^run:/);
+});
+
+test('strict Python cache uses a disposable effective lock and redacted receipt', async (t) => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'shifu-cache-uv-'));
+  t.after(() => fs.rmSync(directory, { recursive: true, force: true }));
+  const repo = path.join(directory, 'repo');
+  const project = path.join(repo, 'framework', 'core');
+  const bin = path.join(directory, 'bin');
+  fs.mkdirSync(project, { recursive: true });
+  fs.mkdirSync(bin);
+  fs.writeFileSync(
+    path.join(project, 'pyproject.toml'),
+    '[project]\nname="demo"\nversion="1.0.0"\n',
+  );
+  fs.writeFileSync(path.join(project, 'uv.lock'), minimalUvLock());
+  spawnSync('git', ['init', '-q'], { cwd: repo });
+  spawnSync(
+    'git',
+    ['add', 'framework/core/pyproject.toml', 'framework/core/uv.lock'],
+    { cwd: repo },
+  );
+  installFakeUv(bin);
+
+  const server = http.createServer((_request, response) => {
+    response.writeHead(200);
+    response.end();
+  });
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  t.after(() => server.close());
+  const address = server.address();
+  const endpoint = `http://127.0.0.1:${address.port}/simple/`;
+  const raw = bytes(pythonCacheProfile(endpoint));
+  const profilePath = path.join(directory, 'profile.json');
+  const outputPath = path.join(directory, 'uv-invocation.json');
+  const receiptPath = path.join(directory, 'receipt.json');
+  fs.writeFileSync(profilePath, raw);
+  const canonical = fs.readFileSync(path.join(project, 'uv.lock'), 'utf8');
+  const statusBefore = spawnSync('git', ['status', '--short'], {
+    cwd: repo,
+    encoding: 'utf8',
+  }).stdout;
+  const script = `const result = require('node:child_process').spawnSync('uv', ['sync'], {stdio:'inherit'}); process.exit(result.status ?? 1)`;
+  const status = await applyCacheProfile({
+    reference: profilePath,
+    expectedDigest: sha256(raw),
+    scope: 'self-hosted-runner',
+    receiptPath,
+    command: process.execPath,
+    args: ['-e', script],
+    cwd: repo,
+    env: {
+      ...process.env,
+      PATH: `${bin}${path.delimiter}${process.env.PATH || ''}`,
+      FAKE_UV_OUTPUT: outputPath,
+    },
+  });
+  assert.equal(status, 0);
+  assert.equal(
+    fs.readFileSync(path.join(project, 'uv.lock'), 'utf8'),
+    canonical,
+  );
+  assert.equal(
+    spawnSync('git', ['status', '--short'], { cwd: repo, encoding: 'utf8' })
+      .stdout,
+    statusBefore,
+  );
+  const invocation = JSON.parse(fs.readFileSync(outputPath, 'utf8'));
+  assert.match(invocation.environment, /shifu-uv-overlay-/);
+  assert.equal(invocation.frozen, '1');
+  const receipt = JSON.parse(fs.readFileSync(receiptPath, 'utf8'));
+  const service = receipt.services['python-index'];
+  assert.equal(service.verification, 'passed');
+  assert.equal(service.application.overlayCleanup, 'completed');
+  assert.equal(service.application.toolEvidence.adapter, 'uv-effective-lock');
+  assert.equal(service.application.toolEvidence.projectCount, 1);
+  assert.doesNotMatch(
+    JSON.stringify(receipt),
+    /shifu-uv-overlay-|framework\/core/,
+  );
+});
+
+test('strict Python cache fails before starting the child when endpoint is unavailable', async (t) => {
+  const directory = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'shifu-cache-uv-fail-'),
+  );
+  t.after(() => fs.rmSync(directory, { recursive: true, force: true }));
+  const raw = bytes(pythonCacheProfile('http://127.0.0.1:1/simple/'));
+  const profilePath = path.join(directory, 'profile.json');
+  const receiptPath = path.join(directory, 'receipt.json');
+  const childPath = path.join(directory, 'child-ran');
+  fs.writeFileSync(profilePath, raw);
+  await assert.rejects(
+    applyCacheProfile({
+      reference: profilePath,
+      expectedDigest: sha256(raw),
+      scope: 'self-hosted-runner',
+      receiptPath,
+      command: process.execPath,
+      args: [
+        '-e',
+        `require('node:fs').writeFileSync(${JSON.stringify(childPath)}, 'ran')`,
+      ],
+      cwd: directory,
+    }),
+    /endpoint is unavailable/,
+  );
+  assert.equal(fs.existsSync(childPath), false);
+  const receipt = JSON.parse(fs.readFileSync(receiptPath, 'utf8'));
+  assert.equal(receipt.services['python-index'].outcome, 'failed');
+  assert.equal(receipt.services['python-index'].verification, 'failed');
+});
+
+test('development Python cache records declared fallback when effective lock is unavailable', async (t) => {
+  const directory = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'shifu-cache-uv-fallback-'),
+  );
+  t.after(() => fs.rmSync(directory, { recursive: true, force: true }));
+  const repo = path.join(directory, 'repo');
+  const project = path.join(repo, 'framework', 'core');
+  const bin = path.join(directory, 'bin');
+  fs.mkdirSync(project, { recursive: true });
+  fs.mkdirSync(bin);
+  fs.writeFileSync(
+    path.join(project, 'pyproject.toml'),
+    '[project]\nname="demo"\nversion="1.0.0"\n',
+  );
+  fs.writeFileSync(path.join(project, 'uv.lock'), minimalUvLock());
+  spawnSync('git', ['init', '-q'], { cwd: repo });
+  spawnSync(
+    'git',
+    ['add', 'framework/core/pyproject.toml', 'framework/core/uv.lock'],
+    { cwd: repo },
+  );
+  installFakeUv(bin);
+  const raw = bytes(
+    pythonCacheProfile('http://cache.example.invalid/simple/', {
+      strict: false,
+    }),
+  );
+  const profilePath = path.join(directory, 'profile.json');
+  const receiptPath = path.join(directory, 'receipt.json');
+  const childPath = path.join(directory, 'child-ran');
+  fs.writeFileSync(profilePath, raw);
+  const status = await applyCacheProfile({
+    reference: profilePath,
+    expectedDigest: sha256(raw),
+    scope: 'development',
+    receiptPath,
+    command: process.execPath,
+    args: [
+      '-e',
+      `require('node:fs').writeFileSync(${JSON.stringify(childPath)}, 'ran')`,
+    ],
+    cwd: repo,
+    env: {
+      ...process.env,
+      PATH: `${bin}${path.delimiter}${process.env.PATH || ''}`,
+      FAKE_UV_FAIL_LOCK: '1',
+    },
+  });
+  assert.equal(status, 0);
+  assert.equal(fs.readFileSync(childPath, 'utf8'), 'ran');
+  const service = JSON.parse(fs.readFileSync(receiptPath, 'utf8')).services[
+    'python-index'
+  ];
+  assert.equal(service.outcome, 'fallback');
+  assert.equal(service.fallbackUsed, true);
+  assert.equal(service.verification, 'failed');
 });
 
 test('cache apply overrides Cargo and isolates Conan without mutating persistent config', async (t) => {

--- a/scripts/shifu-uv-cache-adapter.mjs
+++ b/scripts/shifu-uv-cache-adapter.mjs
@@ -1,0 +1,617 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: Apache-2.0
+// @ts-check
+// Build a disposable uv project overlay whose lock is rebound to the selected
+// package index. The canonical checkout and its project environment remain
+// untouched; nested uv commands are routed through a child-only PATH wrapper.
+
+import { spawnSync } from 'node:child_process';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const MANIFEST_SCHEMA = 'shifu.uv-cache-overlay/v1';
+const PROJECT_COMMANDS = new Set(['run', 'sync', 'tree', 'export', 'lock']);
+const MUTATING_COMMANDS = new Set(['add', 'remove', 'version']);
+const TOP_LEVEL_COMMANDS = new Set([
+  ...PROJECT_COMMANDS,
+  ...MUTATING_COMMANDS,
+  'auth',
+  'build',
+  'cache',
+  'generate-shell-completion',
+  'help',
+  'init',
+  'pip',
+  'publish',
+  'python',
+  'self',
+  'tool',
+  'venv',
+  'x',
+]);
+
+/** @typedef {{repoRoot: string, projectRoot: string, lock: string}} UvProject */
+/** @typedef {{source: string, overlay: string, environment: string}} ManifestProject */
+/** @typedef {{schema: string, realUv: string, projects: ManifestProject[]}} UvManifest */
+
+export class UvCacheAdapterError extends Error {}
+
+/** @param {string} message @returns {never} */
+function fail(message) {
+  throw new UvCacheAdapterError(message);
+}
+
+/** @param {string | Buffer} raw */
+function digest(raw) {
+  return `sha256:${crypto.createHash('sha256').update(raw).digest('hex')}`;
+}
+
+/**
+ * @param {string} command
+ * @param {string[]} args
+ * @param {Omit<import('node:child_process').SpawnSyncOptionsWithStringEncoding,
+ *   'encoding'>} [options]
+ */
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    encoding: 'utf8',
+    shell: false,
+    ...options,
+  });
+  if (result.error || result.status !== 0) {
+    const detail =
+      `${result.stderr || result.stdout || result.error?.message || ''}`
+        .trim()
+        .split('\n')
+        .slice(-8)
+        .join('\n');
+    fail(
+      `${path.basename(command)} ${args.join(' ')} failed${detail ? `:\n${detail}` : ''}`,
+    );
+  }
+  return result;
+}
+
+/** @param {string} cwd @param {string[]} args */
+function git(cwd, args) {
+  return run('git', args, { cwd }).stdout.trim();
+}
+
+/** @param {string} name */
+function executableNames(name) {
+  if (process.platform !== 'win32') return [name];
+  return [`${name}.exe`, `${name}.cmd`, `${name}.bat`, name];
+}
+
+/** @param {string} name @param {string} [searchPath] */
+export function findExecutable(name, searchPath = process.env.PATH || '') {
+  for (const directory of searchPath.split(path.delimiter).filter(Boolean)) {
+    for (const candidateName of executableNames(name)) {
+      const candidate = path.join(directory, candidateName);
+      try {
+        fs.accessSync(candidate, fs.constants.X_OK);
+        return candidate;
+      } catch {}
+    }
+  }
+  return '';
+}
+
+/** @param {string} raw */
+function registrySourceUrls(raw) {
+  return [...raw.matchAll(/source = \{ registry = "([^"]+)" \}/g)].map(
+    (match) => match[1],
+  );
+}
+
+/** @param {string} raw */
+function registryArtifactUrls(raw) {
+  return [...raw.matchAll(/(?:sdist = )?\{ url = "([^"]+)", hash = /g)].map(
+    (match) => match[1],
+  );
+}
+
+/** @param {string} raw */
+function lockUrls(raw) {
+  return [...raw.matchAll(/https?:\/\/[^"\s}]+/g)].map((match) => match[0]);
+}
+
+/** @param {string} raw */
+export function normalizeUvLock(raw) {
+  return raw
+    .split(/(?<=\n)/)
+    .map((line) => {
+      if (/^source = \{ registry = "[^"]+" \}\s*$/.test(line.trimEnd())) {
+        return line.replace(/registry = "[^"]+"/, 'registry = "<registry>"');
+      }
+      const artifact = line.match(
+        /^(\s*)(sdist = )?\{ url = "[^"]+", hash = "([^"]+)"[^}]*\}(,?)(\r?\n)?$/,
+      );
+      if (!artifact) return line;
+      return `${artifact[1]}${artifact[2] || ''}{ registry-artifact-hash = "${artifact[3]}" }${artifact[4]}${artifact[5] || ''}`;
+    })
+    .join('');
+}
+
+/** @param {string} raw */
+export function uvLockSemanticDigest(raw) {
+  return digest(Buffer.from(normalizeUvLock(raw)));
+}
+
+/** @param {string} hostname */
+function isPrivateHostname(hostname) {
+  const host = hostname.toLowerCase().replace(/^\[|\]$/g, '');
+  if (
+    host === 'localhost' ||
+    host.endsWith('.localhost') ||
+    host.endsWith('.local')
+  )
+    return true;
+  if (/^10\./.test(host) || /^127\./.test(host) || /^192\.168\./.test(host))
+    return true;
+  const match = host.match(/^172\.(\d+)\./);
+  return Boolean(match && Number(match[1]) >= 16 && Number(match[1]) <= 31);
+}
+
+/** @param {string} raw */
+export function publicUvLockViolations(raw) {
+  const violations = [];
+  for (const value of lockUrls(raw)) {
+    let url;
+    try {
+      url = new URL(value);
+    } catch {
+      violations.push(`invalid URL: ${value}`);
+      continue;
+    }
+    const officialRegistry =
+      url.protocol === 'https:' &&
+      url.hostname === 'pypi.org' &&
+      url.pathname.replace(/\/+$/, '') === '/simple';
+    const officialArtifact =
+      url.protocol === 'https:' && url.hostname === 'files.pythonhosted.org';
+    if (!officialRegistry && !officialArtifact)
+      violations.push(
+        `URL is not an official PyPI transport: ${url.origin}${url.pathname}`,
+      );
+  }
+  for (const value of registrySourceUrls(raw)) {
+    let url;
+    try {
+      url = new URL(value);
+    } catch {
+      violations.push(`invalid registry URL: ${value}`);
+      continue;
+    }
+    if (isPrivateHostname(url.hostname))
+      violations.push(`private registry host: ${url.hostname}`);
+    const normalizedPath = url.pathname.replace(/\/+$/, '');
+    if (
+      url.protocol !== 'https:' ||
+      url.hostname !== 'pypi.org' ||
+      normalizedPath !== '/simple'
+    )
+      violations.push(
+        `registry is not official PyPI: ${url.origin}${url.pathname}`,
+      );
+  }
+  for (const value of registryArtifactUrls(raw)) {
+    let url;
+    try {
+      url = new URL(value);
+    } catch {
+      violations.push(`invalid artifact URL: ${value}`);
+      continue;
+    }
+    if (isPrivateHostname(url.hostname))
+      violations.push(`private artifact host: ${url.hostname}`);
+    if (url.protocol !== 'https:' || url.hostname !== 'files.pythonhosted.org')
+      violations.push(
+        `artifact is not official PyPI: ${url.origin}${url.pathname}`,
+      );
+  }
+  return [...new Set(violations)];
+}
+
+/** @param {string} raw @param {string} endpoint */
+function validateEffectiveLock(raw, endpoint) {
+  const expected = new URL(endpoint).origin;
+  const registries = registrySourceUrls(raw);
+  const artifacts = registryArtifactUrls(raw);
+  if (registries.length === 0)
+    fail('effective uv.lock has no registry sources');
+  for (const value of lockUrls(raw)) {
+    let actual;
+    try {
+      actual = new URL(value).origin;
+    } catch {
+      fail('effective uv.lock contains an invalid registry artifact URL');
+    }
+    if (actual !== expected)
+      fail(
+        `effective uv.lock escaped the selected index origin: expected ${expected}, got ${actual}`,
+      );
+  }
+  return { registries: registries.length, artifacts: artifacts.length };
+}
+
+/** @param {string} source @param {string} target */
+function linkOrCopy(source, target) {
+  const stat = fs.lstatSync(source);
+  if (process.platform === 'win32') {
+    if (stat.isDirectory()) {
+      fs.symlinkSync(source, target, 'junction');
+      return;
+    }
+    fs.copyFileSync(source, target);
+    return;
+  }
+  fs.symlinkSync(source, target, stat.isDirectory() ? 'dir' : 'file');
+}
+
+/** @param {string} source @param {string} target @param {string} [reserved] */
+function mirrorLevel(source, target, reserved = '') {
+  fs.mkdirSync(target, { recursive: true, mode: 0o700 });
+  for (const entry of fs.readdirSync(source, { withFileTypes: true })) {
+    if (entry.name === '.git' || entry.name === reserved) continue;
+    linkOrCopy(path.join(source, entry.name), path.join(target, entry.name));
+  }
+}
+
+/** @param {string} repoRoot @param {string} projectRoot @param {string} overlayRepo */
+function mirrorProject(repoRoot, projectRoot, overlayRepo) {
+  const relative = path.relative(repoRoot, projectRoot);
+  if (relative.startsWith('..') || path.isAbsolute(relative))
+    fail('uv project escapes the repository root');
+  const parts = relative ? relative.split(path.sep) : [];
+  let source = repoRoot;
+  let target = overlayRepo;
+  for (const part of parts) {
+    mirrorLevel(source, target, part);
+    source = path.join(source, part);
+    target = path.join(target, part);
+  }
+  fs.mkdirSync(target, { recursive: true, mode: 0o700 });
+  for (const entry of fs.readdirSync(source, { withFileTypes: true })) {
+    if (['.git', '.venv', 'pyproject.toml', 'uv.lock'].includes(entry.name))
+      continue;
+    linkOrCopy(path.join(source, entry.name), path.join(target, entry.name));
+  }
+  for (const name of ['pyproject.toml', 'uv.lock'])
+    fs.copyFileSync(path.join(source, name), path.join(target, name));
+  return target;
+}
+
+/** @param {string} cwd @returns {UvProject[]} */
+function trackedUvProjects(cwd) {
+  let repoRoot;
+  try {
+    repoRoot = git(cwd, ['rev-parse', '--show-toplevel']);
+  } catch {
+    return [];
+  }
+  const listed = git(repoRoot, ['ls-files', '-z', '*uv.lock']);
+  /** @type {UvProject[]} */
+  const projects = [];
+  for (const relativeLock of listed.split('\0').filter(Boolean)) {
+    const lock = path.join(repoRoot, relativeLock);
+    const projectRoot = path.dirname(lock);
+    if (fs.existsSync(path.join(projectRoot, 'pyproject.toml')))
+      projects.push({ repoRoot, projectRoot, lock });
+  }
+  return projects;
+}
+
+/** @param {string} moduleUrl */
+function adapterLauncherSource(moduleUrl) {
+  return `#!/usr/bin/env node
+import { runUvCacheAdapter } from ${JSON.stringify(moduleUrl)};
+try {
+  process.exit(runUvCacheAdapter(process.argv.slice(2)));
+} catch (error) {
+  console.error(\`shifu cache: \${error instanceof Error ? error.message : String(error)}\`);
+  process.exit(1);
+}
+`;
+}
+
+/** @param {string} root */
+function writeWrapper(root) {
+  const bin = path.join(root, 'bin');
+  fs.mkdirSync(bin, { recursive: true, mode: 0o700 });
+  const moduleUrl = pathToFileURL(fileURLToPath(import.meta.url)).href;
+  fs.writeFileSync(
+    path.join(bin, 'uv-wrapper.mjs'),
+    adapterLauncherSource(moduleUrl),
+    {
+      mode: 0o700,
+    },
+  );
+  fs.writeFileSync(
+    path.join(bin, 'uv'),
+    '#!/bin/sh\nexec node "$(dirname "$0")/uv-wrapper.mjs" "$@"\n',
+    {
+      mode: 0o700,
+    },
+  );
+  fs.writeFileSync(
+    path.join(bin, 'uv.cmd'),
+    '@node "%~dp0uv-wrapper.mjs" %*\r\n',
+    { mode: 0o600 },
+  );
+  return bin;
+}
+
+/** @param {NodeJS.ProcessEnv} env */
+function cleanUvEnvironment(env) {
+  const result = { ...env };
+  for (const key of [
+    'UV_PROJECT',
+    'UV_PROJECT_ENVIRONMENT',
+    'UV_FROZEN',
+    'UV_LOCKED',
+    'UV_OFFLINE',
+    'UV_INDEX',
+    'UV_INDEX_URL',
+    'UV_EXTRA_INDEX_URL',
+    'UV_FIND_LINKS',
+    'SHIFU_UV_ADAPTER_MANIFEST',
+    'SHIFU_CACHE_MANAGED_UV',
+  ])
+    delete result[key];
+  return result;
+}
+
+/**
+ * @param {{cwd?: string, env?: NodeJS.ProcessEnv, endpoint?: string,
+ *   timeoutMs?: number}} [options]
+ */
+export function prepareUvCacheOverlay({
+  cwd = process.cwd(),
+  env = process.env,
+  endpoint,
+  timeoutMs = 120_000,
+} = {}) {
+  if (!endpoint) fail('uv cache adapter requires a selected index endpoint');
+  const originalPath = env.PATH || '';
+  const realUv = findExecutable('uv', originalPath);
+  if (!realUv) fail('strict Python cache profile requires uv on PATH');
+  const projects = trackedUvProjects(cwd);
+  if (projects.length === 0)
+    return {
+      env: {},
+      root: '',
+      evidence: {
+        adapter: 'uv-effective-lock',
+        enforcement: 'not-applicable',
+        projectCount: 0,
+        locks: [],
+      },
+      cleanup() {},
+    };
+
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'shifu-uv-overlay-'));
+  fs.chmodSync(root, 0o700);
+  const manifestProjects = [];
+  const locks = [];
+  try {
+    for (const project of projects) {
+      const canonical = fs.readFileSync(project.lock);
+      const key = digest(Buffer.from(project.projectRoot)).slice(7, 23);
+      const projectRoot = path.join(root, 'projects', key);
+      const overlayRepo = path.join(projectRoot, 'repo');
+      const overlayProject = mirrorProject(
+        project.repoRoot,
+        project.projectRoot,
+        overlayRepo,
+      );
+      const effectiveLock = path.join(overlayProject, 'uv.lock');
+      const lockEnv = cleanUvEnvironment(env);
+      lockEnv.UV_DEFAULT_INDEX = endpoint;
+      run(
+        realUv,
+        [
+          'lock',
+          '--refresh',
+          '--default-index',
+          endpoint,
+          '--project',
+          overlayProject,
+        ],
+        {
+          cwd: project.projectRoot,
+          env: lockEnv,
+          timeout: timeoutMs,
+        },
+      );
+      const effective = fs.readFileSync(effectiveLock);
+      const canonicalSemantic = uvLockSemanticDigest(
+        canonical.toString('utf8'),
+      );
+      const effectiveSemantic = uvLockSemanticDigest(
+        effective.toString('utf8'),
+      );
+      if (canonicalSemantic !== effectiveSemantic)
+        fail(
+          `uv effective lock changed dependency semantics: canonical ${canonicalSemantic}, effective ${effectiveSemantic}`,
+        );
+      const rebound = validateEffectiveLock(
+        effective.toString('utf8'),
+        endpoint,
+      );
+      const environment = path.join(projectRoot, 'environment');
+      manifestProjects.push({
+        source: project.projectRoot,
+        overlay: overlayProject,
+        environment,
+      });
+      locks.push({
+        canonicalDigest: digest(canonical),
+        effectiveDigest: digest(effective),
+        semanticDigest: canonicalSemantic,
+        registryRebindings: rebound.registries,
+        artifactRebindings: rebound.artifacts,
+      });
+    }
+    const manifestPath = path.join(root, 'manifest.json');
+    fs.writeFileSync(
+      manifestPath,
+      `${JSON.stringify(
+        {
+          schema: MANIFEST_SCHEMA,
+          realUv,
+          projects: manifestProjects,
+        },
+        null,
+        2,
+      )}\n`,
+      { mode: 0o600 },
+    );
+    const bin = writeWrapper(root);
+    return {
+      root,
+      env: {
+        PATH: `${bin}${path.delimiter}${originalPath}`,
+        SHIFU_UV_ADAPTER_MANIFEST: manifestPath,
+        SHIFU_CACHE_MANAGED_UV: '1',
+      },
+      evidence: {
+        adapter: 'uv-effective-lock',
+        enforcement: 'project-overlay',
+        projectCount: locks.length,
+        locks,
+      },
+      cleanup() {
+        fs.rmSync(root, { recursive: true, force: true });
+      },
+    };
+  } catch (error) {
+    fs.rmSync(root, { recursive: true, force: true });
+    throw error;
+  }
+}
+
+/** @param {string[]} args @param {string} cwd @param {NodeJS.ProcessEnv} env */
+function projectArgument(args, cwd, env) {
+  const index = args.findIndex(
+    (value) => value === '--project' || value.startsWith('--project='),
+  );
+  if (index >= 0) {
+    const value = args[index].startsWith('--project=')
+      ? args[index].slice('--project='.length)
+      : args[index + 1];
+    return value ? path.resolve(cwd, value) : '';
+  }
+  return env.UV_PROJECT ? path.resolve(cwd, env.UV_PROJECT) : '';
+}
+
+/** @param {string[]} args */
+function withoutProjectArgument(args) {
+  const result = [];
+  for (let index = 0; index < args.length; index += 1) {
+    if (args[index] === '--project') {
+      index += 1;
+      continue;
+    }
+    if (args[index].startsWith('--project=')) continue;
+    result.push(args[index]);
+  }
+  return result;
+}
+
+/**
+ * @param {UvManifest} manifest @param {string[]} args
+ * @param {string} cwd @param {NodeJS.ProcessEnv} env
+ * @returns {ManifestProject | undefined}
+ */
+function selectedProject(manifest, args, cwd, env) {
+  const explicit = projectArgument(args, cwd, env);
+  if (explicit)
+    return manifest.projects.find(
+      (project) => path.resolve(project.source) === explicit,
+    );
+  const nested = manifest.projects
+    .filter((project) => {
+      const relative = path.relative(project.source, cwd);
+      return (
+        relative === '' ||
+        (!relative.startsWith('..') && !path.isAbsolute(relative))
+      );
+    })
+    .sort((left, right) => right.source.length - left.source.length)[0];
+  if (nested) return nested;
+  return manifest.projects.length === 1 ? manifest.projects[0] : undefined;
+}
+
+/** @param {string[]} args */
+function uvCommand(args) {
+  return args.find((value) => TOP_LEVEL_COMMANDS.has(value));
+}
+
+/**
+ * @param {string[]} args
+ * @param {{env?: NodeJS.ProcessEnv, cwd?: string}} [options]
+ */
+export function runUvCacheAdapter(
+  args,
+  { env = process.env, cwd = process.cwd() } = {},
+) {
+  const manifestPath = env.SHIFU_UV_ADAPTER_MANIFEST || '';
+  if (!manifestPath) fail('uv cache adapter manifest is missing');
+  /** @type {UvManifest} */
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+  if (manifest.schema !== MANIFEST_SCHEMA)
+    fail('unsupported uv adapter manifest');
+  const command = uvCommand(args);
+  if (command && MUTATING_COMMANDS.has(command))
+    fail(`uv ${command} is not allowed inside a cache-managed build execution`);
+  if (!command || !PROJECT_COMMANDS.has(command)) {
+    const result = spawnSync(manifest.realUv, args, {
+      cwd,
+      env: cleanUvEnvironment(env),
+      stdio: 'inherit',
+      shell: false,
+    });
+    if (result.error) fail(`cannot run uv: ${result.error.message}`);
+    return result.status ?? 1;
+  }
+  const project = selectedProject(manifest, args, cwd, env);
+  if (!project)
+    fail(
+      'strict cache profile cannot map this uv project to an effective lock',
+    );
+  const childEnv = cleanUvEnvironment(env);
+  childEnv.UV_DEFAULT_INDEX = env.UV_DEFAULT_INDEX || '';
+  childEnv.UV_PROJECT_ENVIRONMENT = project.environment;
+  if (command !== 'lock') childEnv.UV_FROZEN = '1';
+  const childArgs = [
+    '--project',
+    project.overlay,
+    ...withoutProjectArgument(args),
+  ];
+  const result = spawnSync(manifest.realUv, childArgs, {
+    cwd,
+    env: childEnv,
+    stdio: 'inherit',
+    shell: false,
+  });
+  if (result.error) fail(`cannot run uv: ${result.error.message}`);
+  return result.status ?? 1;
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  try {
+    process.exit(runUvCacheAdapter(process.argv.slice(2)));
+  } catch (error) {
+    console.error(
+      `shifu cache: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    process.exit(1);
+  }
+}

--- a/scripts/shifu-uv-cache-adapter.test.mjs
+++ b/scripts/shifu-uv-cache-adapter.test.mjs
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import {
+  prepareUvCacheOverlay,
+  publicUvLockViolations,
+  runUvCacheAdapter,
+  uvLockSemanticDigest,
+} from './shifu-uv-cache-adapter.mjs';
+
+const HASH_A = `sha256:${'a'.repeat(64)}`;
+const HASH_B = `sha256:${'b'.repeat(64)}`;
+
+function lock(
+  registry = 'https://pypi.org/simple',
+  artifacts = 'https://files.pythonhosted.org',
+) {
+  return `version = 1
+revision = 3
+requires-python = ">=3.12"
+
+[[package]]
+name = "demo"
+version = "1.0.0"
+source = { registry = "${registry}" }
+sdist = { url = "${artifacts}/packages/demo-1.0.0.tar.gz", hash = "${HASH_A}", size = 1 }
+wheels = [
+    { url = "${artifacts}/packages/demo-1.0.0.whl", hash = "${HASH_B}", size = 1 },
+]
+`;
+}
+
+function checked(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    encoding: 'utf8',
+    shell: false,
+    ...options,
+  });
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  return result;
+}
+
+function fakeUv(bin) {
+  const module = path.join(bin, 'fake-uv.mjs');
+  fs.writeFileSync(
+    module,
+    `import fs from 'node:fs';
+import path from 'node:path';
+const args = process.argv.slice(2);
+const projectAt = args.indexOf('--project');
+const project = projectAt >= 0 ? args[projectAt + 1] : process.cwd();
+if (args.includes('lock')) {
+  const lock = path.join(project, 'uv.lock');
+  const endpoint = args[args.indexOf('--default-index') + 1];
+  const origin = new URL(endpoint).origin;
+  const rebound = fs.readFileSync(lock, 'utf8')
+    .replaceAll('https://pypi.org/simple', endpoint)
+    .replaceAll('https://files.pythonhosted.org', origin);
+  fs.writeFileSync(lock, rebound);
+} else if (process.env.FAKE_UV_OUTPUT) {
+  fs.writeFileSync(process.env.FAKE_UV_OUTPUT, JSON.stringify({
+    args,
+    projectEnvironment: process.env.UV_PROJECT_ENVIRONMENT,
+    frozen: process.env.UV_FROZEN,
+  }));
+}
+`,
+  );
+  if (process.platform === 'win32') {
+    fs.writeFileSync(
+      path.join(bin, 'uv.cmd'),
+      '@node "%~dp0fake-uv.mjs" %*\r\n',
+    );
+  } else {
+    fs.writeFileSync(
+      path.join(bin, 'uv'),
+      '#!/bin/sh\nexec node "$(dirname "$0")/fake-uv.mjs" "$@"\n',
+      { mode: 0o700 },
+    );
+  }
+}
+
+test('official PyPI lock policy rejects private and alternate hosts', () => {
+  assert.deepEqual(publicUvLockViolations(lock()), []);
+  const violations = publicUvLockViolations(
+    lock(
+      'http://192.168.100.222:3141/root/pypi/+simple/',
+      'http://cache.local',
+    ),
+  );
+  assert.ok(violations.some((item) => item.includes('private registry host')));
+  assert.ok(violations.some((item) => item.includes('private artifact host')));
+  assert.ok(violations.some((item) => item.includes('not official PyPI')));
+  assert.ok(
+    publicUvLockViolations(
+      `${lock()}\nsource = { url = "http://10.0.0.8/private.whl" }\n`,
+    ).some((item) => item.includes('not an official PyPI transport')),
+  );
+});
+
+test('transport URL rebinding preserves the uv lock semantic digest', () => {
+  assert.equal(
+    uvLockSemanticDigest(lock()),
+    uvLockSemanticDigest(
+      lock(
+        'http://cache.example.invalid/simple/',
+        'http://cache.example.invalid',
+      ),
+    ),
+  );
+});
+
+test('effective lock and environment stay outside the canonical checkout', (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'shifu-uv-test-'));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const repo = path.join(root, 'repo');
+  const project = path.join(repo, 'framework', 'core');
+  const bin = path.join(root, 'bin');
+  fs.mkdirSync(project, { recursive: true });
+  fs.mkdirSync(bin);
+  fs.writeFileSync(
+    path.join(project, 'pyproject.toml'),
+    '[project]\nname="demo"\nversion="1.0.0"\n',
+  );
+  fs.writeFileSync(path.join(project, 'uv.lock'), lock());
+  checked('git', ['init', '-q'], { cwd: repo });
+  checked(
+    'git',
+    ['add', 'framework/core/pyproject.toml', 'framework/core/uv.lock'],
+    { cwd: repo },
+  );
+  fakeUv(bin);
+
+  const output = path.join(root, 'uv-run.json');
+  const original = fs.readFileSync(path.join(project, 'uv.lock'), 'utf8');
+  const statusBefore = checked('git', ['status', '--short'], {
+    cwd: repo,
+  }).stdout;
+  const overlay = prepareUvCacheOverlay({
+    cwd: repo,
+    endpoint: 'http://cache.example.invalid/simple/',
+    env: {
+      ...process.env,
+      PATH: `${bin}${path.delimiter}${process.env.PATH || ''}`,
+      FAKE_UV_OUTPUT: output,
+    },
+  });
+  t.after(() => overlay.cleanup());
+
+  assert.equal(overlay.evidence.enforcement, 'project-overlay');
+  assert.equal(overlay.evidence.projectCount, 1);
+  assert.equal(
+    fs.readFileSync(path.join(project, 'uv.lock'), 'utf8'),
+    original,
+  );
+  assert.equal(
+    checked('git', ['status', '--short'], { cwd: repo }).stdout,
+    statusBefore,
+  );
+
+  const status = runUvCacheAdapter(['sync'], {
+    cwd: project,
+    env: {
+      ...process.env,
+      ...overlay.env,
+      UV_DEFAULT_INDEX: 'http://cache.example.invalid/simple/',
+      FAKE_UV_OUTPUT: output,
+    },
+  });
+  assert.equal(status, 0);
+  const invocation = JSON.parse(fs.readFileSync(output, 'utf8'));
+  assert.equal(invocation.args[0], '--project');
+  assert.match(invocation.args[1], /shifu-uv-overlay-/);
+  assert.equal(invocation.args.at(-1), 'sync');
+  assert.match(invocation.projectEnvironment, /shifu-uv-overlay-/);
+  assert.equal(invocation.frozen, '1');
+  assert.throws(
+    () =>
+      runUvCacheAdapter(['add', 'another-package'], {
+        cwd: project,
+        env: overlay.env,
+      }),
+    /not allowed/,
+  );
+
+  const overlayRoot = overlay.root;
+  overlay.cleanup();
+  assert.equal(fs.existsSync(overlayRoot), false);
+});

--- a/scripts/source-acceptance.mjs
+++ b/scripts/source-acceptance.mjs
@@ -99,6 +99,7 @@ export function sourceAcceptancePlan(files) {
         'scripts/check-shifu-entry-contract.test.mjs',
         'scripts/check-shifu-cache-contract.test.mjs',
         'scripts/shifu-cache-runtime.test.mjs',
+        'scripts/shifu-uv-cache-adapter.test.mjs',
         'scripts/check-schema-authority.test.mjs',
       ],
     },

--- a/shifu
+++ b/shifu
@@ -179,7 +179,21 @@ kungfu_native_acquire() {
   return 1
 }
 
+# Buildchain and runner environments are an explicit per-execution projection;
+# they take precedence over the user-global development projection sourced
+# below. Preserve even a partial explicit pair so the resolver can fail closed.
+_kungfu_explicit_cache_ref="${SHIFU_CACHE_PROFILE_REF:-}"
+_kungfu_explicit_cache_digest="${SHIFU_CACHE_PROFILE_DIGEST:-}"
+_kungfu_explicit_cache_scope="${SHIFU_CACHE_SCOPE:-}"
 kungfu_load_proxy
+[ -n "$_kungfu_explicit_cache_ref" ] \
+  && export SHIFU_CACHE_PROFILE_REF="$_kungfu_explicit_cache_ref"
+[ -n "$_kungfu_explicit_cache_digest" ] \
+  && export SHIFU_CACHE_PROFILE_DIGEST="$_kungfu_explicit_cache_digest"
+[ -n "$_kungfu_explicit_cache_scope" ] \
+  && export SHIFU_CACHE_SCOPE="$_kungfu_explicit_cache_scope"
+unset _kungfu_explicit_cache_ref _kungfu_explicit_cache_digest \
+  _kungfu_explicit_cache_scope
 
 # Mark the canonical entrypoint and keep native dispatches from re-delegating
 # back to this script (see the launcher's installed-binary delegation).

--- a/shifu.cmd
+++ b/shifu.cmd
@@ -43,10 +43,17 @@ setlocal enabledelayedexpansion
 cd /d "%~dp0"
 
 rem Load local cache proxy config: user-global first, then optional in-repo override (set propagates to children).
+rem Explicit Buildchain/runner cache projection wins over local development config.
+set "_KFC_EXPLICIT_CACHE_REF=%SHIFU_CACHE_PROFILE_REF%"
+set "_KFC_EXPLICIT_CACHE_DIGEST=%SHIFU_CACHE_PROFILE_DIGEST%"
+set "_KFC_EXPLICIT_CACHE_SCOPE=%SHIFU_CACHE_SCOPE%"
 set "_KFC_USERCFG=%USERPROFILE%\.config\kungfu\build-local.env"
 if defined XDG_CONFIG_HOME set "_KFC_USERCFG=%XDG_CONFIG_HOME%\kungfu\build-local.env"
 call :loadenv "%_KFC_USERCFG%"
 call :loadenv ".\build-local.env"
+if defined _KFC_EXPLICIT_CACHE_REF set "SHIFU_CACHE_PROFILE_REF=%_KFC_EXPLICIT_CACHE_REF%"
+if defined _KFC_EXPLICIT_CACHE_DIGEST set "SHIFU_CACHE_PROFILE_DIGEST=%_KFC_EXPLICIT_CACHE_DIGEST%"
+if defined _KFC_EXPLICIT_CACHE_SCOPE set "SHIFU_CACHE_SCOPE=%_KFC_EXPLICIT_CACHE_SCOPE%"
 
 rem Mark the canonical entrypoint and keep native dispatches from re-delegating here.
 set "SHIFU_FROM_SHIM=1"

--- a/tests/fixtures/rewind-demo-kfx-schema/run.mjs
+++ b/tests/fixtures/rewind-demo-kfx-schema/run.mjs
@@ -15,6 +15,8 @@ import { locate, tmpDir, kfc, uvPython } from '../_harness.mjs';
 const { fixtureDir, coreDir } = locate(import.meta.url);
 const home = tmpDir('rewind-kfx-');
 const runId = `fixturekfx${Date.now()}`;
+const pythonEnvironment =
+  process.env.UV_PROJECT_ENVIRONMENT || path.join(coreDir, '.venv');
 
 // the kfx child is the core's own interpreter (has flatbuffers); it reaches the
 // kungfu package + binding itself, and the supervisor injects the capture hook.
@@ -22,8 +24,8 @@ const runId = `fixturekfx${Date.now()}`;
 // pykungfu (compile_schema) is provided by the harness runtimeEnv (folded into kfc).
 const venvPython =
   process.platform === 'win32'
-    ? path.join(coreDir, '.venv', 'Scripts', 'python.exe')
-    : path.join(coreDir, '.venv', 'bin', 'python');
+    ? path.join(pythonEnvironment, 'Scripts', 'python.exe')
+    : path.join(pythonEnvironment, 'bin', 'python');
 
 kfc(coreDir, home, [
   'trace',

--- a/tests/qualification/profile-kfd3/run.ts
+++ b/tests/qualification/profile-kfd3/run.ts
@@ -9,7 +9,13 @@ import { openProfile } from '../../../framework/api/src/capability/profile.ts';
 const repo = process.cwd();
 const runtimeRoot = process.env.KUNGFU_QUALIFICATION_RUNTIME_ROOT || repo;
 const core = path.join(runtimeRoot, 'framework', 'core');
-const python = path.join(core, '.venv', 'bin', 'python');
+const pythonEnvironment =
+  process.env.UV_PROJECT_ENVIRONMENT || path.join(core, '.venv');
+const python = path.join(
+  pythonEnvironment,
+  process.platform === 'win32' ? 'Scripts' : 'bin',
+  process.platform === 'win32' ? 'python.exe' : 'python',
+);
 const release = path.join(core, 'build', 'Release');
 const pythonPath = [
   path.join(repo, 'framework', 'core', 'src', 'python'),


### PR DESCRIPTION
## Summary

Make strict Shifu cache profiles enforce the selected Python index without rewriting tracked uv.lock files or exposing private network topology in public source.

## Related issue

None.

## Changes

- create process-private effective uv lock and environment overlays for cache-managed execution
- preserve dependency semantics and fail closed when strict rebinding cannot be proven
- require every tracked uv.lock URL to use official PyPI hosts
- preserve explicit Buildchain and runner cache projections across shell, Windows, and native config loading
- emit redacted digest-only tool evidence and cleanup state

## Verification

- `node scripts/source-acceptance.mjs`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- strict self-hosted profile dry-run on Ubuntu and agent-120
- full `shifu sync && shifu check:source` on agent-120 with canonical lock SHA and Git status unchanged
- development profile execution on macOS with canonical lock SHA and Git status unchanged

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "implemented",
  "adrs": ["SHIFU-ADR-0003"],
  "summary": "Implement disposable uv effective locks, official-PyPI canonical lock policy, and strict cache enforcement",
  "verification": ["source acceptance", "Rust workspace tests", "macOS development profile", "Ubuntu and agent-120 strict profile"]
}
-->

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The ADR and receipt define public evidence boundaries; receipts contain digests and counts, while repository locks remain restricted to official PyPI hosts.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed
