### PR TITLE
shifu: two-level repo discovery + buildchain-answered KFD-3 layout

### DIFF
--- a/crates/shifu/src/main.rs
+++ b/crates/shifu/src/main.rs
@@ -458,8 +458,39 @@ fn is_repo_root(dir: &Path) -> bool {
     dir.join("shifu").is_file() && dir.join("shifu.cmd").is_file()
 }
 
+/// Nearest ancestor (inclusive) that is a kungfu bootstrap repo root.
+fn find_kungfu_root(start: &Path) -> Option<PathBuf> {
+    start
+        .ancestors()
+        .find(|dir| is_repo_root(dir))
+        .map(Path::to_path_buf)
+}
+
+/// Nearest ancestor (inclusive) that is a buildchain-managed repo declaring
+/// shifu as its KFD-3 registrar. The `.buildchain-version` pin narrows the
+/// walk with a cheap existence check; recognition still requires the explicit
+/// jurisdiction declaration (read via buildchain), so a stray buildchain repo
+/// that never opted into shifu is not claimed.
+fn find_buildchain_managed_root(start: &Path) -> Option<PathBuf> {
+    start
+        .ancestors()
+        .filter(|dir| dir.join(tools::BUILDCHAIN.pin_file()).is_file())
+        .find(|dir| registrar::declares_shifu_jurisdiction(dir))
+        .map(Path::to_path_buf)
+}
+
+/// Locate the repository root, two-level. Level 1 is a kungfu bootstrap repo —
+/// the welded `shifu`/`shifu.cmd` entrypoint pair (ADR-0044), which delegates
+/// to its own repo-pinned launcher. Level 2, reached only for real dispatch,
+/// is a buildchain-managed repo that declares shifu as its KFD-3 registrar: it
+/// has no in-repo entrypoint to spawn, so the installed binary serves it
+/// directly (delegation no-ops when the pair is absent, then `run_pnpm` runs
+/// the declared task).
+///
 /// With `lenient` (used by --version and doctor), failing to find a repo
-/// returns None instead of dying — those verbs are useful outside a checkout.
+/// returns None instead of dying — those verbs are useful rootless, and they
+/// deliberately skip the Level-2 check so a version print never triggers a
+/// buildchain acquisition.
 fn find_repo_root(lenient: bool) -> Option<PathBuf> {
     if let Some(explicit) = env::var_os("SHIFU_ROOT") {
         let root = PathBuf::from(explicit);
@@ -472,29 +503,54 @@ fn find_repo_root(lenient: bool) -> Option<PathBuf> {
         ));
     }
     let start = env::current_dir().unwrap_or_else(|e| util::die(&format!("cannot read cwd: {e}")));
-    let mut dir = start.as_path();
-    loop {
-        if is_repo_root(dir) {
-            return Some(dir.to_path_buf());
-        }
-        match dir.parent() {
-            Some(parent) => dir = parent,
-            None => {
-                if lenient {
-                    return None;
-                }
-                util::die(
-                    "not inside a kungfu repository (no shifu.mjs found walking up from the \
-                     current directory; set SHIFU_ROOT to override)",
-                )
-            }
+    if let Some(root) = find_kungfu_root(&start) {
+        return Some(root);
+    }
+    if !lenient {
+        if let Some(root) = find_buildchain_managed_root(&start) {
+            return Some(root);
         }
     }
+    if lenient {
+        return None;
+    }
+    util::die(
+        "not inside a kungfu repository (no shifu/shifu.cmd entrypoint pair, and no \
+         buildchain-managed repo declaring shifu, walking up from the current \
+         directory; set SHIFU_ROOT to override)",
+    )
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{auto_apply_args, command_requires_msvc, should_auto_apply_cache};
+    use super::{
+        auto_apply_args, command_requires_msvc, find_kungfu_root, is_repo_root,
+        should_auto_apply_cache,
+    };
+    use std::fs;
+
+    #[test]
+    fn kungfu_root_needs_the_welded_entrypoint_pair() {
+        let base = shifu_core::host::unique_temp_dir("shifu-root").unwrap();
+        let repo = base.join("repo");
+        let nested = repo.join("a/b");
+        fs::create_dir_all(&nested).unwrap();
+
+        // No entrypoint pair anywhere → no kungfu root.
+        assert!(find_kungfu_root(&nested).is_none());
+        // A lone `shifu` file is not enough (a stray file must not be a root).
+        fs::write(repo.join("shifu"), "x").unwrap();
+        assert!(!is_repo_root(&repo));
+        assert!(find_kungfu_root(&nested).is_none());
+        // Both welded files → the nested cwd resolves up to the repo root.
+        fs::write(repo.join("shifu.cmd"), "x").unwrap();
+        assert!(is_repo_root(&repo));
+        assert_eq!(
+            find_kungfu_root(&nested).unwrap().canonicalize().unwrap(),
+            repo.canonicalize().unwrap()
+        );
+        let _ = fs::remove_dir_all(&base);
+    }
 
     #[test]
     fn compiler_environment_precedes_every_build_capable_dispatch() {

--- a/crates/shifu/src/registrar.rs
+++ b/crates/shifu/src/registrar.rs
@@ -61,8 +61,23 @@ const LAYOUT_DISCOVERY_CONTRACT: &str = "kungfu-buildchain-layout-discovery";
 /// is buildchain's own answer, never a shifu-side copy that could silently
 /// drift when buildchain moves the layout.
 fn resolve_kfd3_registry(root: &Path) -> Option<PathBuf> {
-    // Not buildchain-managed → no registry, no registration (the common,
-    // silent case, same as a repo without a registry today).
+    // Registration is advisory, so path resolution must not add a network
+    // fetch to ordinary dispatch: resolve only from an already-available
+    // buildchain (PATH/cache), never a forced download.
+    resolve_kfd3_registry_with(root, Acquire::CachedOnly)
+}
+
+/// How to obtain the buildchain binary when the layout answer is not yet
+/// cached: the advisory dispatch hot path stays cache-only, while a deliberate
+/// serve-downstream jurisdiction check may fetch the pinned release.
+enum Acquire {
+    CachedOnly,
+    Fetch,
+}
+
+fn resolve_kfd3_registry_with(root: &Path, acquire: Acquire) -> Option<PathBuf> {
+    // Not buildchain-managed → no registry (the common, silent case, same as a
+    // repo without a registry today).
     if !root.join(bootstrap::BUILDCHAIN.pin_file()).is_file() {
         return None;
     }
@@ -70,14 +85,50 @@ fn resolve_kfd3_registry(root: &Path) -> Option<PathBuf> {
     if let Some(rel) = read_layout_cache(root, &version) {
         return Some(root.join(rel));
     }
-    // Registration is advisory, so path resolution must not add a network
-    // fetch to ordinary dispatch: resolve only from an already-available
-    // buildchain (PATH/cache), never a forced download. The answer is cached,
-    // so the ask happens at most once per buildchain version.
-    let buildchain = bootstrap::find_tool(&bootstrap::BUILDCHAIN, root)?;
+    // The answer is cached, so the ask happens at most once per buildchain
+    // version regardless of which acquisition strategy resolved it.
+    let buildchain = match acquire {
+        Acquire::CachedOnly => bootstrap::find_tool(&bootstrap::BUILDCHAIN, root)?,
+        Acquire::Fetch => bootstrap::ensure_tool(&bootstrap::BUILDCHAIN, root).ok()?,
+    };
     let rel = query_layout_registry(&buildchain, root)?;
     write_layout_cache(root, &version, &rel);
     Some(root.join(rel))
+}
+
+/// Whether this repo explicitly declares shifu as its KFD-3 distribution
+/// registrar — the jurisdiction signal that makes a non-kungfu,
+/// buildchain-managed repo one that shifu serves. A `.buildchain-version` pin
+/// alone is not enough (a KFD file is not the same as opting into shifu), so a
+/// stray buildchain repo cannot have its management silently claimed. Reads
+/// the registry buildchain points to, fetching the pinned binary if needed
+/// (this is the deliberate serve-downstream context, not the hot path).
+pub fn declares_shifu_jurisdiction(root: &Path) -> bool {
+    let Some(path) = resolve_kfd3_registry_with(root, Acquire::Fetch) else {
+        return false;
+    };
+    let Ok(text) = fs::read_to_string(&path) else {
+        return false;
+    };
+    match json::parse(&text) {
+        Ok(doc) => registry_declares_shifu(&doc),
+        Err(_) => false,
+    }
+}
+
+/// Pure jurisdiction test over a parsed registry: any surface whose
+/// distribution names shifu as registrar.
+fn registry_declares_shifu(doc: &json::Json) -> bool {
+    doc.get("surfaces")
+        .and_then(json::Json::as_array)
+        .unwrap_or(&[])
+        .iter()
+        .any(|surface| {
+            surface
+                .get("distribution")
+                .map(|dist| dist.str_of("registrar") == "shifu")
+                .unwrap_or(false)
+        })
 }
 
 /// Ask `buildchain layout --json` where the KFD-3 registry lives. Returns the
@@ -699,6 +750,23 @@ mod tests {
     fn quoting_strips_single_quotes() {
         assert_eq!(quote("a'b"), "'ab'");
         assert_eq!(quote("plain"), "'plain'");
+    }
+
+    #[test]
+    fn jurisdiction_requires_an_explicit_shifu_registrar() {
+        let shifu =
+            json::parse(r#"{"surfaces": [{"distribution": {"registrar": "shifu"}}]}"#).unwrap();
+        assert!(registry_declares_shifu(&shifu));
+        // A KFD registry that names some other registrar, or none, is not
+        // shifu's to claim.
+        let other =
+            json::parse(r#"{"surfaces": [{"distribution": {"registrar": "someone-else"}}]}"#)
+                .unwrap();
+        assert!(!registry_declares_shifu(&other));
+        let bare = json::parse(r#"{"surfaces": [{"id": "x"}]}"#).unwrap();
+        assert!(!registry_declares_shifu(&bare));
+        let empty = json::parse(r#"{"product": {"id": "x"}}"#).unwrap();
+        assert!(!registry_declares_shifu(&empty));
     }
 
     #[test]

--- a/crates/shifu/src/registrar.rs
+++ b/crates/shifu/src/registrar.rs
@@ -43,7 +43,140 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use shifu_core::{bootstrap, host, json, style};
 
-const KFD3_REGISTRY: &str = ".buildchain/kfd/kfd-3/surfaces.json";
+/// The buildchain self-describe contract shifu asks for the repo's KFD-3
+/// registry location. shifu holds no copy of that layout path: the layout is
+/// buildchain's to define, so shifu asks the pinned `buildchain` binary
+/// (`buildchain layout --json`) and reads `kfd.registries."kfd-3".path` back.
+/// The two welded surfaces are the `.buildchain-version` pin name and this
+/// verb; see docs/rust-adoption.md and the contract registry.
+const LAYOUT_DISCOVERY_CONTRACT: &str = "kungfu-buildchain-layout-discovery";
+
+/// Locate the repo's KFD-3 surface registry by asking buildchain, caching the
+/// answer per (repo, buildchain version). Returns the absolute registry path,
+/// or None when the repo is not buildchain-managed (no `.buildchain-version`
+/// pin) or buildchain is not already available on this advisory hot path.
+///
+/// There is deliberately no hardcoded fallback path: a repo with a KFD-3
+/// registry is by definition buildchain-managed, so the single source of truth
+/// is buildchain's own answer, never a shifu-side copy that could silently
+/// drift when buildchain moves the layout.
+fn resolve_kfd3_registry(root: &Path) -> Option<PathBuf> {
+    // Not buildchain-managed → no registry, no registration (the common,
+    // silent case, same as a repo without a registry today).
+    if !root.join(bootstrap::BUILDCHAIN.pin_file()).is_file() {
+        return None;
+    }
+    let version = bootstrap::BUILDCHAIN.version(root);
+    if let Some(rel) = read_layout_cache(root, &version) {
+        return Some(root.join(rel));
+    }
+    // Registration is advisory, so path resolution must not add a network
+    // fetch to ordinary dispatch: resolve only from an already-available
+    // buildchain (PATH/cache), never a forced download. The answer is cached,
+    // so the ask happens at most once per buildchain version.
+    let buildchain = bootstrap::find_tool(&bootstrap::BUILDCHAIN, root)?;
+    let rel = query_layout_registry(&buildchain, root)?;
+    write_layout_cache(root, &version, &rel);
+    Some(root.join(rel))
+}
+
+/// Ask `buildchain layout --json` where the KFD-3 registry lives. Returns the
+/// repo-relative path, or None on any failure (advisory: never blocks).
+fn query_layout_registry(buildchain: &Path, root: &Path) -> Option<String> {
+    let out = Command::new(buildchain)
+        .arg("layout")
+        .arg("--json")
+        .arg("--cwd")
+        .arg(root)
+        .current_dir(root)
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let doc = json::parse(&String::from_utf8_lossy(&out.stdout)).ok()?;
+    let contract = doc.str_of("contract");
+    if contract != LAYOUT_DISCOVERY_CONTRACT {
+        warn(&format!(
+            "buildchain layout returned contract {contract:?} (expected \
+             {LAYOUT_DISCOVERY_CONTRACT}); builds will not be registered"
+        ));
+        return None;
+    }
+    let rel = doc
+        .get("kfd")
+        .and_then(|kfd| kfd.get("registries"))
+        .and_then(|reg| reg.get("kfd-3"))
+        .map(|k3| k3.str_of("path"))
+        .unwrap_or("");
+    (!rel.is_empty()).then(|| rel.to_string())
+}
+
+/// Cache file for a resolved layout answer, namespaced per buildchain version.
+/// The file records the root and version it was resolved for so a hash
+/// collision (or a moved checkout) reads as a miss, never a wrong path.
+fn layout_cache_path(root: &Path, version: &str) -> PathBuf {
+    let key = fnv1a_hex(root.to_string_lossy().as_bytes());
+    host::kungfu_cache_dir()
+        .join("shifu")
+        .join("layout")
+        .join(version)
+        .join(format!("{key}.json"))
+}
+
+fn read_layout_cache(root: &Path, version: &str) -> Option<String> {
+    let doc = json::parse(&fs::read_to_string(layout_cache_path(root, version)).ok()?).ok()?;
+    if doc.str_of("root") != root.to_string_lossy() || doc.str_of("version") != version {
+        return None;
+    }
+    let rel = doc.str_of("registryPath");
+    (!rel.is_empty()).then(|| rel.to_string())
+}
+
+fn write_layout_cache(root: &Path, version: &str, rel: &str) {
+    let path = layout_cache_path(root, version);
+    if let Some(parent) = path.parent() {
+        let _ = fs::create_dir_all(parent);
+    }
+    let body = format!(
+        "{{\"root\":{},\"version\":{},\"registryPath\":{}}}\n",
+        json_string(&root.to_string_lossy()),
+        json_string(version),
+        json_string(rel),
+    );
+    let _ = fs::write(path, body);
+}
+
+/// Minimal JSON string encoding for the cache file (paths can contain
+/// backslashes and quotes on Windows).
+fn json_string(value: &str) -> String {
+    let mut out = String::with_capacity(value.len() + 2);
+    out.push('"');
+    for ch in value.chars() {
+        match ch {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+    out
+}
+
+/// FNV-1a 64-bit, hex — a fast, dependency-free cache-key hash. Not
+/// cryptographic; the cache file's stored root/version make any collision a
+/// harmless miss.
+fn fnv1a_hex(bytes: &[u8]) -> String {
+    let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
+    for &b in bytes {
+        hash ^= b as u64;
+        hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    format!("{hash:016x}")
+}
 
 pub struct DistributionPlan {
     product_id: String,
@@ -66,22 +199,46 @@ struct DeclaredArtifact {
 /// parsed gets a named warning: a declared intent we cannot read is worth a
 /// line, but never worth blocking the task.
 pub fn plan_for_task(root: &Path, task: &str) -> Option<DistributionPlan> {
-    let path = root.join(KFD3_REGISTRY);
-    let text = fs::read_to_string(&path).ok()?;
+    let path = resolve_kfd3_registry(root)?;
+    plan_at(root, &path, task)
+}
+
+/// Parse a distribution plan from a specific registry path. Split from
+/// `plan_for_task` so parsing is exercised without a live buildchain to answer
+/// the layout query.
+fn plan_at(root: &Path, path: &Path, task: &str) -> Option<DistributionPlan> {
+    // The registry path relative to the repo, for messages and the
+    // self-attestation check below.
+    let rel = path
+        .strip_prefix(root)
+        .unwrap_or(path)
+        .to_string_lossy()
+        .into_owned();
+    let text = fs::read_to_string(path).ok()?;
     let doc = match json::parse(&text) {
         Ok(doc) => doc,
         Err(e) => {
             warn(&format!(
-                "cannot read {KFD3_REGISTRY} ({e}); builds will not be registered"
+                "cannot read {rel} ({e}); builds will not be registered"
             ));
             return None;
         }
     };
+    // Self-attestation: the registry declares its own path; if buildchain
+    // answered a different location the two have drifted — worth a named line
+    // (never blocks: buildchain's answer is authoritative for where we read).
+    let declared = doc.str_of("registryPath");
+    if !declared.is_empty() && declared != rel {
+        warn(&format!(
+            "buildchain resolved the KFD-3 registry at {rel} but it self-declares \
+             registryPath {declared}; the layout has drifted"
+        ));
+    }
     let product_id = {
         let id = doc.get("product").map(|p| p.str_of("id")).unwrap_or("");
         if id.is_empty() {
             warn(&format!(
-                "{KFD3_REGISTRY} has no product.id; builds will not be registered"
+                "{rel} has no product.id; builds will not be registered"
             ));
             return None;
         }
@@ -476,7 +633,7 @@ mod tests {
         fs::create_dir_all(root.join("out")).unwrap();
         fs::write(root.join("out/app.bin"), b"artifact-bytes").unwrap();
 
-        let plan = plan_for_task(&root, "dist").expect("plan");
+        let plan = plan_at(&root, &kfd.join("surfaces.json"), "dist").expect("plan");
         register(&root, &plan);
 
         let registry = cache.join("kungfu/product").join(host::os_arch());
@@ -494,6 +651,25 @@ mod tests {
         assert!(meta.contains(
             "KUNGFU_BUILD_SHA256='6521df166eb07efaf36eba5b6bedefd9d6a252e9c80bab1c99653700ec71473c'"
         ));
+
+        // Layout-answer cache round-trip. This lives inside the single test
+        // that owns XDG_CACHE_HOME (its writes land in the isolated cache);
+        // running it here keeps env mutation from racing the parallel suite.
+        assert!(read_layout_cache(&root, "2.12.1-alpha.4").is_none());
+        write_layout_cache(
+            &root,
+            "2.12.1-alpha.4",
+            ".buildchain/kfd/kfd-3/surfaces.json",
+        );
+        assert_eq!(
+            read_layout_cache(&root, "2.12.1-alpha.4").as_deref(),
+            Some(".buildchain/kfd/kfd-3/surfaces.json")
+        );
+        // A different pinned version is a distinct cache slot (a miss), and a
+        // different root never reads another root's answer.
+        assert!(read_layout_cache(&root, "2.13.0").is_none());
+        assert!(read_layout_cache(&root.join("other"), "2.12.1-alpha.4").is_none());
+
         env::remove_var("XDG_CACHE_HOME");
         let _ = fs::remove_dir_all(&root);
     }
@@ -551,14 +727,29 @@ mod tests {
             ),
         )
         .unwrap();
-        let plan = plan_for_task(&dir, "dist").expect("plan for dist");
+        let reg = kfd.join("surfaces.json");
+        let plan = plan_at(&dir, &reg, "dist").expect("plan for dist");
         assert_eq!(plan.product_id, "kungfu");
         assert_eq!(plan.surface_id, "kungfu.product.release-build");
         assert_eq!(plan.artifacts.len(), 1);
         assert_eq!(plan.artifacts[0].path_glob, "out/*.bin");
-        assert!(plan_for_task(&dir, "package").is_some());
-        assert!(plan_for_task(&dir, "verify").is_none());
+        assert!(plan_at(&dir, &reg, "package").is_some());
+        assert!(plan_at(&dir, &reg, "verify").is_none());
         let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn fnv1a_is_deterministic_and_distinguishes_inputs() {
+        assert_eq!(fnv1a_hex(b"/a/b"), fnv1a_hex(b"/a/b"));
+        assert_ne!(fnv1a_hex(b"/a/b"), fnv1a_hex(b"/a/c"));
+        assert_eq!(fnv1a_hex(b"").len(), 16);
+    }
+
+    #[test]
+    fn json_string_escapes_backslashes_and_quotes() {
+        assert_eq!(json_string(r"C:\repo"), r#""C:\\repo""#);
+        assert_eq!(json_string(r#"a"b"#), r#""a\"b""#);
+        assert_eq!(json_string("plain"), r#""plain""#);
     }
 
     #[test]

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -154,6 +154,7 @@ implemented and qualified or explicitly waived for that release.
 | [SHIFU-0002](SHIFU-ADR-0002-local-artifact-catalog-and-safe-promotion.md) | accepted | Shifu and Kungfu product artifacts share provenance-aware, Git-safe local promotion semantics |
 | [SHIFU-0003](SHIFU-ADR-0003-uv-effective-lock-cache-enforcement.md) | accepted | Strict uv cache execution uses a disposable effective lock while canonical locks stay public |
 | [SHIFU-0004](SHIFU-ADR-0004-gate-control-plane-contract.md) | accepted | Shifu owns the project-independent Gate contract; projects own catalogs and explicit policy profiles |
+| [SHIFU-0005](SHIFU-ADR-0005-repo-root-discovery-and-jurisdiction.md) | accepted | Two-level repo discovery; a buildchain-managed repo joins by declaring `registrar: shifu`, and shifu asks buildchain for the KFD-3 layout instead of copying it |
 
 ## Reading by theme
 

--- a/docs/adr/SHIFU-ADR-0005-repo-root-discovery-and-jurisdiction.md
+++ b/docs/adr/SHIFU-ADR-0005-repo-root-discovery-and-jurisdiction.md
@@ -1,0 +1,119 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+doc_type: architecture-decision
+adr_id: SHIFU-ADR-0005
+decision_status: accepted
+implementation_status: partial
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/757]
+review_state: unreviewed
+sensitivity: public
+sources: [local-files, user-consensus]
+period: ongoing
+theme: shifu-repo-root-discovery
+confidence: high
+evidence_grade: B
+last_reviewed: 2026-07-13
+---
+
+# SHIFU-ADR-0005: Repository root discovery and jurisdiction
+
+- Status: accepted; development implementation
+- Date: 2026-07-13
+- Scope: Shifu launcher repository recognition and the buildchain layout it
+  consumes
+- Related: [ADR-0044](./ADR-0044-shifu-delegation-protocol.md) (unchanged),
+  [SHIFU-ADR-0002](./SHIFU-ADR-0002-local-artifact-catalog-and-safe-promotion.md)
+
+## Context
+
+Shifu recognised exactly one kind of repository: a kungfu bootstrap checkout,
+identified by the welded `shifu` / `shifu.cmd` entrypoint pair, to which it
+delegates (ADR-0044). Two facts made that single level too narrow.
+
+First, other repositories are also built and released through Buildchain and
+declare their distribution surfaces in a Buildchain-managed KFD-3 registry. The
+declarative build registrar (the successor to per-repo registration scripts)
+already lets such a repository be registered by declaring
+`distribution.registrar = "shifu"`. But shifu could only find that registry at a
+single hardcoded path, `.buildchain/kfd/kfd-3/surfaces.json` — a copy of a
+layout that is Buildchain's to define. If Buildchain ever moved the registry,
+the copy would silently drift.
+
+Second, letting a non-kungfu repository join shifu's management must not mean
+scattering executable entrypoint files. The `shifu` / `shifu.cmd` pair is a
+kungfu-bootstrap delegation surface (two executable files), not a portable
+opt-in signal: copying executables into every downstream repository multiplies
+the audit surface and rots on divergence, the same reason the registrar replaced
+per-repo scripts with declarations. A declaration can propagate safely; an
+executable cannot.
+
+## Decision
+
+Shifu holds no copy of the KFD-3 layout path. The single source of truth is
+Buildchain's own runtime self-description: shifu ensures the repo-pinned
+`buildchain` binary and asks it (`buildchain layout --json`, contract
+`kungfu-buildchain-layout-discovery`), reading `kfd.registries."kfd-3".path`
+back. Shifu's welded knowledge of Buildchain shrinks to two surfaces — the pin
+file name `.buildchain-version` and this self-describe verb. The layout answer
+is cached per repository and Buildchain version, so ordinary invocations do not
+re-ask; on the advisory build-registration hot path resolution is cache-only and
+never forces a download, so a task like `check` keeps its fast startup.
+
+Repository discovery becomes two-level:
+
+- **Level 1 — kungfu bootstrap repo.** The welded `shifu` / `shifu.cmd`
+  entrypoint pair (ADR-0044), which delegates to the repo's own pinned launcher.
+  Unchanged.
+- **Level 2 — buildchain-managed repo.** Reached only for real dispatch. A
+  directory carrying a `.buildchain-version` pin whose KFD-3 registry (located
+  via the layout answer) explicitly declares `distribution.registrar = "shifu"`.
+  Such a repository has no in-repo entrypoint to spawn, so delegation no-ops and
+  the installed shifu binary serves it directly through `run_pnpm`.
+
+A `.buildchain-version` pin alone is not recognition. The explicit
+`registrar = "shifu"` declaration is required, so a repository that is
+buildchain-managed but never opted into shifu is not claimed — a KFD file is not
+the same as opting into shifu management. Lenient verbs (`--version`, `doctor`)
+skip the Level-2 check entirely and stay useful rootless, so a version print
+never triggers a Buildchain acquisition.
+
+## Compatibility
+
+The `.buildchain-version` pin name and the `buildchain layout --json` verb are
+the two welded seams shifu depends on; they are registered as a contract in
+[`contracts.md`](../qualification/contracts.md). Changing either — the pin file name, the
+verb, or the `kungfu-buildchain-layout-discovery` schema shape shifu reads — is a
+breaking change to this contract and follows Buildchain's major-version
+discipline. The registry's own `registryPath` self-attestation is read back and
+a drift warning is emitted when it disagrees with Buildchain's answer.
+
+kungfu repositories are unaffected: the Level-1 entrypoint pair is matched first
+and delegates exactly as before; ADR-0044 is not changed by this decision.
+
+## Consequences
+
+- A downstream buildchain-managed repository joins shifu's management by
+  declaration alone, with no in-repo executables added.
+- Shifu can no longer silently drift from Buildchain's layout: the path is
+  asked, not copied.
+- Shifu's compiled Buildchain knowledge is two named seams, both contract-bound,
+  rather than an embedded path constant.
+- Serving a downstream repository is a deliberate, opt-in act gated on an
+  explicit registrar declaration, not on the mere presence of a KFD file.
+
+## Alternatives considered
+
+- **Keep the hardcoded registry path** — rejected: it is a copy of Buildchain's
+  layout that drifts the moment Buildchain moves the registry.
+- **Project the layout into shifu at build time** — rejected: build-time
+  projection has weak version semantics; asking the repo-pinned binary at runtime
+  keeps the answer tied to the pinned Buildchain version.
+- **Keep a fallback path when Buildchain cannot be asked** — rejected: a
+  repository with a KFD-3 registry is by definition buildchain-managed, so the
+  fallback client set is empty and would only grow a second, drifting copy.
+- **Recognise any `.buildchain-version` repo as shifu-served** — rejected: it
+  would let shifu claim management of repositories that never declared it,
+  defeating the explicit-opt-in property.
+- **Extend the `shifu` / `shifu.cmd` pair to downstream repos** — rejected:
+  propagating executables multiplies audit surface and rots on divergence; the
+  opt-in signal must be a declaration.

--- a/docs/development/rust-adoption.md
+++ b/docs/development/rust-adoption.md
@@ -217,7 +217,10 @@ per-platform special-casing) with one binary that:
   assuming what it is implemented in, and carry a two-fuse anti-loop guard
   (`SHIFU_FROM_SHIM` / `SHIFU_DELEGATED`) — so the handover survives any
   toolchain evolution, including one that retires node. Protocol authority:
-  [ADR-0044](../adr/ADR-0044-shifu-delegation-protocol.md).
+  [ADR-0044](../adr/ADR-0044-shifu-delegation-protocol.md). This entrypoint-pair
+  recognition is Level 1 of a two-level discovery; a buildchain-managed repo
+  that declares shifu is served without any entrypoint files (see "Two-level
+  repository discovery" below, [SHIFU-ADR-0005](../adr/SHIFU-ADR-0005-repo-root-discovery-and-jurisdiction.md)).
 
 It scores three yeses: it *is* the process boundary in front of everything
 else; it needs to exist before node/python are provisioned, which only a
@@ -291,6 +294,15 @@ that `builds` / `promote` already read. Registration is advisory: a build
 that succeeded is never failed by its own bookkeeping — every problem is a
 named warning and the task's exit code passes through.
 
+Shifu does not hold the KFD-3 registry's path as a constant. That layout is
+Buildchain's to define, so shifu asks the repo-pinned `buildchain` binary
+(`buildchain layout --json`, contract `kungfu-buildchain-layout-discovery`) and
+reads `kfd.registries."kfd-3".path` back, caching the answer per repo and
+Buildchain version. The two seams shifu welds to are the pin file name
+`.buildchain-version` and that verb; both are contract-bound
+([`contracts.md`](../qualification/contracts.md)) so Buildchain changing either is a breaking
+change, and the path can never silently drift from a stale shifu copy.
+
 The division of labor is deliberate. Build logic stays declarative in the
 repo; what the launcher carries is the one thing repo scripts cannot do for
 themselves: outlive the build. Worktrees are temporary, so the stash is
@@ -299,3 +311,24 @@ which is also why onboarding a new repo costs zero scripts: declare the
 artifacts in the KFD registry and the installed launcher does the rest. The
 KFD registry was already the repo's fact ledger; letting the recorded facts
 drive distribution is the same load-bearing member carrying one more load.
+
+### Two-level repository discovery
+
+Onboarding a downstream repo also costs zero *executables*. Repository
+recognition is two-level ([SHIFU-ADR-0005](../adr/SHIFU-ADR-0005-repo-root-discovery-and-jurisdiction.md)):
+
+- **Level 1 — a kungfu bootstrap repo**, identified by the welded
+  `shifu` / `shifu.cmd` entrypoint pair, to which the installed binary
+  delegates (ADR-0044). Unchanged.
+- **Level 2 — a buildchain-managed repo**, reached only for real dispatch: a
+  directory carrying a `.buildchain-version` pin whose KFD-3 registry (located
+  via the layout answer above) declares `distribution.registrar = "shifu"`.
+  It has no in-repo entrypoint to spawn, so delegation no-ops and the installed
+  shifu serves it directly through the pinned toolchain.
+
+The signal that a downstream repo joins shifu's management is therefore a pure
+declaration, not two copied shell files. A `.buildchain-version` pin alone is
+not enough — the explicit `registrar: "shifu"` declaration is required, so a
+buildchain-managed repo that never opted in is not claimed. Lenient verbs
+(`--version`, `doctor`) skip the Level-2 check and stay useful rootless, so a
+version print never acquires Buildchain.

--- a/docs/qualification/contracts.md
+++ b/docs/qualification/contracts.md
@@ -345,6 +345,34 @@ Buildchain 2.10 then collects:
 current surface set is agent/SDK/product focused. The Buildchain release
 passport wiring is active and is now part of `./shifu verify`.
 
+## Shifu asks Buildchain for its KFD-3 layout — two welded seams
+
+**Guarantee.** Shifu holds no copy of where a repository's KFD-3 surface
+registry lives. The location is Buildchain's to define, and shifu obtains it by
+asking the repo-pinned `buildchain` binary at runtime, not by embedding a path.
+Shifu's compiled knowledge of Buildchain is exactly two seams: the pin file name
+`.buildchain-version` and the self-describe verb `buildchain layout --json`
+(contract `kungfu-buildchain-layout-discovery`), from which shifu reads
+`kfd.registries."kfd-3".path`. Changing either seam — the pin name, the verb, or
+that contract's shape — is a breaking change and follows Buildchain's
+major-version discipline. On this basis a buildchain-managed repository can join
+shifu's management by declaring `distribution.registrar = "shifu"` in that
+registry, with no in-repo executables added.
+
+**Verify.** The consumer is `resolve_kfd3_registry` and `declares_shifu_jurisdiction`
+in [`crates/shifu/src/registrar.rs`](../../crates/shifu/src/registrar.rs) and the
+two-level `find_repo_root` in
+[`crates/shifu/src/main.rs`](../../crates/shifu/src/main.rs); the producer is
+`buildchain layout --json` (Buildchain `packages/core/buildchain-layout.js`). The
+decision and its boundaries are
+[SHIFU-ADR-0005](../adr/SHIFU-ADR-0005-repo-root-discovery-and-jurisdiction.md);
+the narrative is in [`rust-adoption.md`](../development/rust-adoption.md). Shifu reads the
+registry's own `registryPath` self-attestation back and warns on drift.
+
+**Maturity.** `development` — implemented in the launcher and unit-tested, with
+the discovery path exercised end to end against the pinned Buildchain binary; the
+downstream-repo onboarding surface is still maturing.
+
 ## The agent-first bridge is Kungfu's current KFD-3 profile
 
 **Guarantee.** The installed runtime carries a local Agent Onboarding Pack and


### PR DESCRIPTION
## Summary

Repository-root discovery in the shifu launcher becomes two-level, and shifu
stops holding a copy of the KFD-3 registry path.

- **`resolve KFD-3 registry via buildchain layout`** — the registrar no longer
  hardcodes `.buildchain/kfd/kfd-3/surfaces.json`. It asks the repo-pinned
  `buildchain` binary (`buildchain layout --json`, contract
  `kungfu-buildchain-layout-discovery`) and reads `kfd.registries."kfd-3".path`
  back, caching the answer per repo and buildchain version. The advisory
  dispatch hot path resolves cache-only (no forced download), so `check` keeps
  its fast startup. The registry's `registryPath` self-attestation is read back
  and a drift warning is emitted on mismatch.
- **`recognize buildchain-managed repos as a second root level`** —
  `find_repo_root` gains Level 2: a `.buildchain-version`-pinned repo whose
  KFD-3 registry declares `distribution.registrar = "shifu"` is served directly
  (delegation no-ops with no entrypoint pair). A pin alone is not enough — the
  explicit registrar declaration is required, so a buildchain-managed repo that
  never opted in is not claimed. Lenient verbs (`--version`, `doctor`) skip the
  Level-2 check and stay useful rootless.

The two welded seams shifu depends on — the `.buildchain-version` pin name and
the `buildchain layout --json` verb — are registered as a contract in
`docs/contracts.md`. ADR-0044 (delegation) is unchanged. See SHIFU-ADR-0005.

## Verification

- `cargo test -p shifu` (25 tests) and `cargo clippy` / `cargo fmt` clean.
- End to end against the pinned buildchain: a synthetic downstream repo
  declaring `registrar: shifu` is recognized and dispatched; the same repo with
  a non-shifu registrar, and a non-buildchain directory, both fall back to the
  not-a-repo error.
- ADR release gate and document-metadata contract validated locally.

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "stage-ready",
  "adrs": ["SHIFU-ADR-0005"],
  "summary": "Shifu repo-root discovery becomes two-level and asks buildchain for the KFD-3 layout instead of copying it.",
  "verification": [
    "cargo test -p shifu (25 tests) plus cargo clippy and fmt clean",
    "end-to-end against pinned buildchain: synthetic downstream repo declaring registrar=shifu is recognized and dispatched; a non-shifu registrar and a non-buildchain directory both fall back to the not-a-repo error"
  ]
}
-->
