### PR TITLE
fix(shifu): remove private cache address from fixture

### DIFF
--- a/scripts/shifu-uv-cache-adapter.test.mjs
+++ b/scripts/shifu-uv-cache-adapter.test.mjs
@@ -90,8 +90,8 @@ test('official PyPI lock policy rejects private and alternate hosts', () => {
   assert.deepEqual(publicUvLockViolations(lock()), []);
   const violations = publicUvLockViolations(
     lock(
-      'http://192.168.100.222:3141/root/pypi/+simple/',
-      'http://cache.local',
+      'http://package-cache.local/pypi/simple/',
+      'http://artifact-cache.local',
     ),
   );
   assert.ok(violations.some((item) => item.includes('private registry host')));


### PR DESCRIPTION
## Summary

Remove an office-private cache address from a public Shifu test fixture and replace it with reserved `.local` fixture hosts. The test continues to cover rejection of private and non-PyPI transports without disclosing real topology.

## Related issue

None.

## Changes

- replace the real private cache coordinate with `package-cache.local`
- keep private registry and artifact rejection assertions unchanged

## Verification

- `node --test scripts/shifu-uv-cache-adapter.test.mjs`
- `node scripts/check-shifu-cache-contract.mjs`
- pre-commit documentation, contract, and Biome gates
- public fixture scan confirms the office address is absent

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This privacy fix changes only test fixture coordinates and does not alter the accepted cache enforcement architecture"
}
-->

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] release evidence, provenance, package publishing, or deployment surfaces
- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed