### PR TITLE
feat(shifu): execute gates with source-bound receipts

### DIFF
--- a/docs/adr/SHIFU-ADR-0004-gate-control-plane-contract.md
+++ b/docs/adr/SHIFU-ADR-0004-gate-control-plane-contract.md
@@ -4,7 +4,7 @@ doc_type: architecture-decision
 adr_id: SHIFU-ADR-0004
 decision_status: accepted
 implementation_status: partial
-implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/762]
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/762, https://github.com/kungfu-systems/kungfu/pull/765]
 review_state: unreviewed
 sensitivity: public
 sources: [local-files, user-consensus]

--- a/docs/adr/SHIFU-ADR-0004-gate-control-plane-contract.md
+++ b/docs/adr/SHIFU-ADR-0004-gate-control-plane-contract.md
@@ -19,7 +19,8 @@ last_reviewed: 2026-07-13
 
 - Status: accepted; development implementation
 - Date: 2026-07-13
-- Scope: Shifu quality and release gate declaration, explanation, and planning
+- Scope: Shifu quality and release gate declaration, explanation, planning,
+  execution, and receipts
 - Related: [SHIFU-ADR-0001](./SHIFU-ADR-0001-cache-profile-contract-and-ownership.md),
   [ADR-0044](./ADR-0044-shifu-delegation-protocol.md), and
   [ADR-0073](./ADR-0073-buildchain-adr-release-admissibility.md)
@@ -56,10 +57,24 @@ Actions are structured Shifu tasks, argv vectors, or named handlers. Raw shell
 strings are not the contract because they hide quoting, platform, and authority
 semantics.
 
-The read-only control surface is `shifu gate validate|list|show|explain|matrix|plan`.
+The inspection control surface is `shifu gate validate|list|show|explain|matrix|plan`.
 Validation is independent of registry validity. Planning closes dependencies,
 emits deterministic groups and platform constraints, and never turns a local
 diagnostic selection override into qualifying policy evidence.
+
+The execution control surface is `shifu gate run` plus
+`shifu gate receipt validate`. Explicit gate runs are diagnostic. A profile run
+executes its dependency closure once and emits a receipt bound to the source
+SHA, dirty state, registry and plan digests, per-gate definition and action
+digests, platform, capabilities, required action coverage, artifact presence,
+and redacted evidence pointers. Child output and inherited environment values
+are not receipt fields.
+
+Qualification is recomputed, not trusted: it requires a clean Git revision, a
+current profile plan and gate definitions, and complete passing coverage for
+every required action. Advisory failures remain visible without blocking
+required qualification. Buildchain can schedule plan groups and aggregate these
+receipts, but it cannot mint missing local evidence or reinterpret policy.
 
 Buildchain may consume a later execution plan and receipts to allocate runners
 and publish stable aggregate checks. It does not own or reinterpret Shifu Gate

--- a/docs/shifu/README.md
+++ b/docs/shifu/README.md
@@ -16,8 +16,9 @@ execution; Shifu owns how the task is executed after source checkout.
   discovery root for local build provenance and safe promotion semantics shared
   by `self-update` and `builds/promote`.
 - [Gate control plane](gates.md) explains the project-independent registry,
-  explicit profile matrix, validation, explanation, and deterministic planning
-  contract. [`gate-contract.json`](gate-contract.json) is its discovery root.
+  explicit profile matrix, validation, deterministic planning, bounded
+  execution, and source-bound receipt contract.
+  [`gate-contract.json`](gate-contract.json) is its discovery root.
 - [`schema/cache-profile-v1.schema.json`](schema/cache-profile-v1.schema.json)
   is the single source of truth for cache profile fields.
 - [`schema/cache-resolution-v1.schema.json`](schema/cache-resolution-v1.schema.json)
@@ -50,9 +51,13 @@ package:
 ./shifu artifacts receipt-schema
 ./shifu gate contract
 ./shifu gate schema registry
+./shifu gate schema plan
+./shifu gate schema receipt
 ./shifu gate validate --registry docs/shifu/examples/gates/minimal.gate-registry.json
 ./shifu gate matrix --registry docs/shifu/examples/gates/minimal.gate-registry.json
 ./shifu gate plan release --platform linux --registry docs/shifu/examples/gates/minimal.gate-registry.json --json
+./shifu gate run --profile success --registry docs/shifu/examples/gates/execution.gate-registry.json --json
+./shifu gate receipt validate build/gate-receipts/success.json --registry docs/shifu/examples/gates/execution.gate-registry.json --json
 ```
 
 The contract and schema discovery commands print the exact checked-in JSON.

--- a/docs/shifu/examples/gates/execution.gate-registry.json
+++ b/docs/shifu/examples/gates/execution.gate-registry.json
@@ -1,0 +1,240 @@
+{
+  "$schema": "https://libkungfu.dev/schemas/shifu/gate-registry-v1.schema.json",
+  "schema": "shifu.gate-registry/v1",
+  "project": { "id": "gate-execution-fixture", "title": "Gate execution fixture" },
+  "gates": [
+    {
+      "id": "fixture.prepare",
+      "title": "Prepare fixture",
+      "summary": "Records the shared dependency exactly once.",
+      "category": "fixture",
+      "documentation": "docs/shifu/gates.md",
+      "dependencies": [],
+      "platforms": ["any"],
+      "runner": { "capabilities": ["node"] },
+      "cost": { "class": "light", "timeoutSeconds": 5 },
+      "action": { "kind": "argv", "command": "node", "args": ["tests/fixtures/shifu-gates/run.mjs", "pass", "fixture.prepare"] },
+      "artifacts": [],
+      "receipt": { "expectation": "none" }
+    },
+    {
+      "id": "fixture.left",
+      "title": "Left fixture",
+      "summary": "Runs one branch after shared preparation.",
+      "category": "fixture",
+      "documentation": "docs/shifu/gates.md",
+      "dependencies": ["fixture.prepare"],
+      "platforms": ["any"],
+      "runner": { "capabilities": ["node"] },
+      "cost": { "class": "light", "timeoutSeconds": 5 },
+      "action": { "kind": "argv", "command": "node", "args": ["tests/fixtures/shifu-gates/run.mjs", "pass", "fixture.left"] },
+      "artifacts": [],
+      "receipt": { "expectation": "none" }
+    },
+    {
+      "id": "fixture.right",
+      "title": "Right fixture",
+      "summary": "Runs the other branch after shared preparation.",
+      "category": "fixture",
+      "documentation": "docs/shifu/gates.md",
+      "dependencies": ["fixture.prepare"],
+      "platforms": ["any"],
+      "runner": { "capabilities": ["node"] },
+      "cost": { "class": "light", "timeoutSeconds": 5 },
+      "action": { "kind": "argv", "command": "node", "args": ["tests/fixtures/shifu-gates/run.mjs", "pass", "fixture.right"] },
+      "artifacts": [],
+      "receipt": { "expectation": "none" }
+    },
+    {
+      "id": "fixture.aggregate",
+      "title": "Aggregate fixture",
+      "summary": "Proves both branches complete before aggregation.",
+      "category": "fixture",
+      "documentation": "docs/shifu/gates.md",
+      "dependencies": ["fixture.left", "fixture.right"],
+      "platforms": ["any"],
+      "runner": { "capabilities": ["node"] },
+      "cost": { "class": "light", "timeoutSeconds": 5 },
+      "action": { "kind": "argv", "command": "node", "args": ["tests/fixtures/shifu-gates/run.mjs", "pass", "fixture.aggregate"] },
+      "artifacts": [],
+      "receipt": { "expectation": "none" }
+    },
+    {
+      "id": "fixture.fail",
+      "title": "Failing fixture",
+      "summary": "Returns a deterministic non-zero action result.",
+      "category": "fixture",
+      "documentation": "docs/shifu/gates.md",
+      "dependencies": ["fixture.prepare"],
+      "platforms": ["any"],
+      "runner": { "capabilities": ["node"] },
+      "cost": { "class": "light", "timeoutSeconds": 5 },
+      "action": { "kind": "argv", "command": "node", "args": ["tests/fixtures/shifu-gates/run.mjs", "fail", "fixture.fail"] },
+      "artifacts": [],
+      "receipt": { "expectation": "none" }
+    },
+    {
+      "id": "fixture.evidence",
+      "title": "Evidence fixture",
+      "summary": "Writes a safe gate-specific evidence pointer.",
+      "category": "fixture",
+      "documentation": "docs/shifu/gates.md",
+      "dependencies": [],
+      "platforms": ["any"],
+      "runner": { "capabilities": ["node"] },
+      "cost": { "class": "light", "timeoutSeconds": 5 },
+      "action": { "kind": "argv", "command": "node", "args": ["tests/fixtures/shifu-gates/run.mjs", "evidence", "fixture.evidence"] },
+      "artifacts": [],
+      "receipt": { "expectation": "required", "schema": "fixture.evidence/v1" }
+    },
+    {
+      "id": "fixture.missing-evidence",
+      "title": "Missing evidence fixture",
+      "summary": "Passes its process without producing required evidence.",
+      "category": "fixture",
+      "documentation": "docs/shifu/gates.md",
+      "dependencies": [],
+      "platforms": ["any"],
+      "runner": { "capabilities": ["node"] },
+      "cost": { "class": "light", "timeoutSeconds": 5 },
+      "action": { "kind": "argv", "command": "node", "args": ["tests/fixtures/shifu-gates/run.mjs", "pass", "fixture.missing-evidence"] },
+      "artifacts": [],
+      "receipt": { "expectation": "required", "schema": "fixture.evidence/v1" }
+    },
+    {
+      "id": "fixture.timeout",
+      "title": "Timeout fixture",
+      "summary": "Exceeds its declared bounded timeout.",
+      "category": "fixture",
+      "documentation": "docs/shifu/gates.md",
+      "dependencies": [],
+      "platforms": ["any"],
+      "runner": { "capabilities": ["node"] },
+      "cost": { "class": "light", "timeoutSeconds": 1 },
+      "action": { "kind": "argv", "command": "node", "args": ["tests/fixtures/shifu-gates/run.mjs", "slow", "fixture.timeout"] },
+      "artifacts": [],
+      "receipt": { "expectation": "none" }
+    },
+    {
+      "id": "fixture.task-dogfood",
+      "title": "Task action dogfood",
+      "summary": "Re-enters one existing lightweight Shifu contract task.",
+      "category": "fixture",
+      "documentation": "docs/shifu/gates.md",
+      "dependencies": [],
+      "platforms": ["any"],
+      "runner": { "capabilities": ["node"] },
+      "cost": { "class": "light", "timeoutSeconds": 60 },
+      "action": { "kind": "task", "task": "check:shifu-gate-contract", "args": [] },
+      "artifacts": [],
+      "receipt": { "expectation": "none" }
+    }
+  ],
+  "profiles": [
+    {
+      "id": "success",
+      "title": "Successful dependency closure",
+      "decisions": {
+        "fixture.prepare": { "mode": "required", "reason": "Shared preparation is required." },
+        "fixture.left": { "mode": "required", "reason": "Left branch is required." },
+        "fixture.right": { "mode": "required", "reason": "Right branch is required." },
+        "fixture.aggregate": { "mode": "required", "reason": "Aggregate is required." },
+        "fixture.fail": { "mode": "off", "reason": "Failure fixture is excluded." },
+        "fixture.evidence": { "mode": "off", "reason": "Evidence fixture is tested separately." },
+        "fixture.missing-evidence": { "mode": "off", "reason": "Missing evidence is tested separately." },
+        "fixture.timeout": { "mode": "off", "reason": "Timeout is tested separately." },
+        "fixture.task-dogfood": { "mode": "off", "reason": "Task action is tested separately." }
+      }
+    },
+    {
+      "id": "advisory",
+      "title": "Advisory failure",
+      "decisions": {
+        "fixture.prepare": { "mode": "required", "reason": "Preparation remains required." },
+        "fixture.left": { "mode": "off", "reason": "Not selected." },
+        "fixture.right": { "mode": "off", "reason": "Not selected." },
+        "fixture.aggregate": { "mode": "off", "reason": "Not selected." },
+        "fixture.fail": { "mode": "advisory", "reason": "Failure must be reported without blocking." },
+        "fixture.evidence": { "mode": "off", "reason": "Not selected." },
+        "fixture.missing-evidence": { "mode": "off", "reason": "Not selected." },
+        "fixture.timeout": { "mode": "off", "reason": "Not selected." },
+        "fixture.task-dogfood": { "mode": "off", "reason": "Not selected." }
+      }
+    },
+    {
+      "id": "required-failure",
+      "title": "Required failure",
+      "decisions": {
+        "fixture.prepare": { "mode": "required", "reason": "Preparation is required." },
+        "fixture.left": { "mode": "off", "reason": "Not selected." },
+        "fixture.right": { "mode": "off", "reason": "Not selected." },
+        "fixture.aggregate": { "mode": "off", "reason": "Not selected." },
+        "fixture.fail": { "mode": "required", "reason": "Failure is required for this negative fixture." },
+        "fixture.evidence": { "mode": "off", "reason": "Not selected." },
+        "fixture.missing-evidence": { "mode": "off", "reason": "Not selected." },
+        "fixture.timeout": { "mode": "off", "reason": "Not selected." },
+        "fixture.task-dogfood": { "mode": "off", "reason": "Not selected." }
+      }
+    },
+    {
+      "id": "evidence-success",
+      "title": "Required evidence success",
+      "decisions": {
+        "fixture.prepare": { "mode": "off", "reason": "Not selected." },
+        "fixture.left": { "mode": "off", "reason": "Not selected." },
+        "fixture.right": { "mode": "off", "reason": "Not selected." },
+        "fixture.aggregate": { "mode": "off", "reason": "Not selected." },
+        "fixture.fail": { "mode": "off", "reason": "Not selected." },
+        "fixture.evidence": { "mode": "required", "reason": "Evidence is required." },
+        "fixture.missing-evidence": { "mode": "off", "reason": "Not selected." },
+        "fixture.timeout": { "mode": "off", "reason": "Not selected." },
+        "fixture.task-dogfood": { "mode": "off", "reason": "Not selected." }
+      }
+    },
+    {
+      "id": "evidence-missing",
+      "title": "Required evidence missing",
+      "decisions": {
+        "fixture.prepare": { "mode": "off", "reason": "Not selected." },
+        "fixture.left": { "mode": "off", "reason": "Not selected." },
+        "fixture.right": { "mode": "off", "reason": "Not selected." },
+        "fixture.aggregate": { "mode": "off", "reason": "Not selected." },
+        "fixture.fail": { "mode": "off", "reason": "Not selected." },
+        "fixture.evidence": { "mode": "off", "reason": "Not selected." },
+        "fixture.missing-evidence": { "mode": "required", "reason": "Missing evidence must fail." },
+        "fixture.timeout": { "mode": "off", "reason": "Not selected." },
+        "fixture.task-dogfood": { "mode": "off", "reason": "Not selected." }
+      }
+    },
+    {
+      "id": "timeout",
+      "title": "Required timeout",
+      "decisions": {
+        "fixture.prepare": { "mode": "off", "reason": "Not selected." },
+        "fixture.left": { "mode": "off", "reason": "Not selected." },
+        "fixture.right": { "mode": "off", "reason": "Not selected." },
+        "fixture.aggregate": { "mode": "off", "reason": "Not selected." },
+        "fixture.fail": { "mode": "off", "reason": "Not selected." },
+        "fixture.evidence": { "mode": "off", "reason": "Not selected." },
+        "fixture.missing-evidence": { "mode": "off", "reason": "Not selected." },
+        "fixture.timeout": { "mode": "required", "reason": "Timeout must be bounded and reported." },
+        "fixture.task-dogfood": { "mode": "off", "reason": "Not selected." }
+      }
+    },
+    {
+      "id": "task-dogfood",
+      "title": "Existing Shifu task dogfood",
+      "decisions": {
+        "fixture.prepare": { "mode": "off", "reason": "Not selected." },
+        "fixture.left": { "mode": "off", "reason": "Not selected." },
+        "fixture.right": { "mode": "off", "reason": "Not selected." },
+        "fixture.aggregate": { "mode": "off", "reason": "Not selected." },
+        "fixture.fail": { "mode": "off", "reason": "Not selected." },
+        "fixture.evidence": { "mode": "off", "reason": "Not selected." },
+        "fixture.missing-evidence": { "mode": "off", "reason": "Not selected." },
+        "fixture.timeout": { "mode": "off", "reason": "Not selected." },
+        "fixture.task-dogfood": { "mode": "required", "reason": "The existing lightweight contract task proves native task dispatch." }
+      }
+    }
+  ]
+}

--- a/docs/shifu/gate-contract.json
+++ b/docs/shifu/gate-contract.json
@@ -4,11 +4,13 @@
   "decision": "docs/adr/SHIFU-ADR-0004-gate-control-plane-contract.md",
   "authority": {
     "registrySchema": "docs/shifu/schema/gate-registry-v1.schema.json",
-    "planSchema": "docs/shifu/schema/gate-plan-v1.schema.json"
+    "planSchema": "docs/shifu/schema/gate-plan-v1.schema.json",
+    "receiptSchema": "docs/shifu/schema/gate-receipt-v1.schema.json"
   },
   "schemaIds": {
     "registry": "https://libkungfu.dev/schemas/shifu/gate-registry-v1.schema.json",
-    "plan": "https://libkungfu.dev/schemas/shifu/gate-plan-v1.schema.json"
+    "plan": "https://libkungfu.dev/schemas/shifu/gate-plan-v1.schema.json",
+    "receipt": "https://libkungfu.dev/schemas/shifu/gate-receipt-v1.schema.json"
   },
   "defaultRegistry": "shifu.gates.json",
   "environment": {
@@ -18,17 +20,22 @@
     "contract": "shifu gate contract",
     "registrySchema": "shifu gate schema registry",
     "planSchema": "shifu gate schema plan",
+    "receiptSchema": "shifu gate schema receipt",
     "validate": "shifu gate validate [--registry FILE|-] [--json]",
     "list": "shifu gate list [--registry FILE] [--json]",
     "show": "shifu gate show GATE [--registry FILE] [--json]",
     "explain": "shifu gate explain GATE [--profile PROFILE] [--registry FILE] [--json]",
     "matrix": "shifu gate matrix [--registry FILE] [--json]",
-    "plan": "shifu gate plan PROFILE [--include-advisory] [--gate GATE] [--platform PLATFORM] [--registry FILE] [--json]"
+    "plan": "shifu gate plan PROFILE [--include-advisory] [--gate GATE] [--platform PLATFORM] [--registry FILE] [--json]",
+    "runGates": "shifu gate run GATE... [--capability CAP] [--registry FILE] [--receipt FILE] [--json]",
+    "runProfile": "shifu gate run --profile PROFILE [--include-advisory] [--capability CAP] [--registry FILE] [--receipt FILE] [--json]",
+    "validateReceipt": "shifu gate receipt validate FILE [--registry FILE] [--json]"
   },
   "compatibility": {
     "unknownFields": "reject",
     "missingProfileDecision": "reject",
     "legacyTaskEntrypoints": "unchanged",
-    "execution": "not-in-v1-contract-stage"
+    "explicitRuns": "diagnostic-non-qualifying",
+    "qualification": "clean-source-current-definition-complete-required-coverage"
   }
 }

--- a/docs/shifu/gates.md
+++ b/docs/shifu/gates.md
@@ -1,14 +1,15 @@
 # Shifu Gate control plane
 
 Shifu Gate is the project-independent control plane for declaring, explaining,
-and planning quality and release gates. A project owns the gates it needs and
+planning, executing, and auditing quality and release gates. A project owns the gates it needs and
 the policy profiles that select them; Shifu owns the schema, validation rules,
 and command semantics. Buildchain may schedule a future plan, but it does not
 reinterpret the registry.
 
-This first contract stage is deliberately read-only. It does not execute gate
-actions, issue qualification receipts, replace existing task aliases, or change
-CI policy.
+Execution remains local and bounded: Shifu runs a selected dependency closure
+and emits one source-bound receipt, while Buildchain remains responsible for
+allocating remote runners and aggregating cross-platform results. Gate execution
+does not replace existing task aliases or change CI policy.
 
 ## Authority boundary
 
@@ -20,9 +21,10 @@ CI policy.
 | Required-check changes, release promotion and policy approval | project maintainers |
 
 The canonical discovery root is [`gate-contract.json`](gate-contract.json).
-The registry and plan schemas are
+The registry, plan, and receipt schemas are
 [`gate-registry-v1.schema.json`](schema/gate-registry-v1.schema.json) and
-[`gate-plan-v1.schema.json`](schema/gate-plan-v1.schema.json). A consuming
+[`gate-plan-v1.schema.json`](schema/gate-plan-v1.schema.json), and
+[`gate-receipt-v1.schema.json`](schema/gate-receipt-v1.schema.json). A consuming
 project normally commits `shifu.gates.json`; `--registry FILE` or
 `SHIFU_GATE_REGISTRY` selects another instance without changing the contract.
 
@@ -60,6 +62,13 @@ that would hide an effective policy upgrade inside the planner.
 ./shifu gate matrix --registry docs/shifu/examples/gates/minimal.gate-registry.json
 ./shifu gate plan release --platform linux \
   --registry docs/shifu/examples/gates/minimal.gate-registry.json --json
+./shifu gate run fixture.left fixture.right \
+  --registry docs/shifu/examples/gates/execution.gate-registry.json --json
+./shifu gate run --profile success \
+  --registry docs/shifu/examples/gates/execution.gate-registry.json \
+  --receipt build/gate-receipts/success.json
+./shifu gate receipt validate build/gate-receipts/success.json \
+  --registry docs/shifu/examples/gates/execution.gate-registry.json --json
 ```
 
 `validate` is the bootstrap primitive: it parses and reports an invalid
@@ -77,6 +86,49 @@ the plan fail; it is never presented as a successful skip.
 `--gate GATE` is a diagnostic selection override. It may plan a gate that the
 profile marks off, but the output is `qualifying: false`: selection does not
 rewrite project policy and cannot later produce a qualifying profile receipt.
+
+## Execution and receipts
+
+`run GATE...` closes and executes dependencies once, but it is always a
+diagnostic run. `run --profile PROFILE` is the only qualification candidate.
+It executes deterministic topological groups sequentially on the local runner;
+Buildchain may distribute the same planned groups later without changing gate
+meaning. `--include-advisory` runs advisory selections without making their
+failure block required qualification. `--capability CAP` declares additional
+runner capabilities; `node` is inherent because the Gate engine is already
+running under Shifu's pinned Node toolchain.
+
+Each result is one of `pass`, `fail`, `advisory-fail`, `unsupported`, `skip`,
+or `error`. A failed dependency skips its dependents, and the receipt retains a
+copyable explicit gate reproduction argv. Task actions re-enter the native
+Shifu launcher (`shifu` or `shifu.cmd`); argv actions use `shell: false`; named
+handlers must be registered by an embedding controller. Raw shell strings are
+never synthesized.
+
+The unified receipt binds all of the following:
+
+- source SHA and dirty state;
+- registry, plan, gate definition, and action digests;
+- actual platform and declared runner capabilities;
+- expected versus attempted actions, status, duration, exit code, and signal;
+- declared artifact presence and safe repository-relative evidence pointers.
+
+The executor never copies child stdout, stderr, inherited environment values,
+or absolute paths into the receipt; bounded reason strings redact repository,
+home, temporary, URL, and secret-like assignment material. A gate that declares required
+gate-specific evidence receives a temporary `SHIFU_GATE_EVIDENCE_FILE`; it
+must write `{ "schema": "...", "pointers": [...] }` with the declared schema
+and repository-relative refs. The temporary file is deleted after the run.
+
+A receipt is qualifying only when it came from a full profile, the source is a
+clean Git revision, the registry and definitions are current, and every
+required action was attempted and passed. Explicit overrides, dirty checkouts,
+stale source SHA, changed definitions, missing result rows, missing required
+artifacts, or missing required evidence cannot qualify. `gate receipt validate`
+recomputes these facts instead of trusting the stored `qualifying` boolean.
+Receipt files should be written to an ignored output such as `build/` or to an
+external evidence directory so writing the receipt does not dirty its own
+source checkout.
 
 All inspection commands support `--json`. Each JSON result carries a stable
 schema discriminator such as `shifu.gate-list/v1`,

--- a/docs/shifu/schema/gate-plan-v1.schema.json
+++ b/docs/shifu/schema/gate-plan-v1.schema.json
@@ -56,7 +56,7 @@
     "plannedGate": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["id", "mode", "selectedBy", "dependencies", "platforms", "runner", "cost", "action"],
+      "required": ["id", "mode", "selectedBy", "dependencies", "platforms", "runner", "cost", "action", "actionId", "definitionDigest", "artifacts", "receipt"],
       "properties": {
         "id": { "type": "string" },
         "mode": { "enum": ["required", "advisory", "off"] },
@@ -65,7 +65,11 @@
         "platforms": { "type": "array", "items": { "type": "string" } },
         "runner": { "type": "object" },
         "cost": { "type": "object" },
-        "action": { "type": "object" }
+        "action": { "type": "object" },
+        "actionId": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+        "definitionDigest": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+        "artifacts": { "type": "array" },
+        "receipt": { "type": "object" }
       }
     },
     "omission": {

--- a/docs/shifu/schema/gate-receipt-v1.schema.json
+++ b/docs/shifu/schema/gate-receipt-v1.schema.json
@@ -1,0 +1,195 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://libkungfu.dev/schemas/shifu/gate-receipt-v1.schema.json",
+  "title": "Shifu gate receipt v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "$schema",
+    "schema",
+    "runId",
+    "project",
+    "source",
+    "registry",
+    "selection",
+    "environment",
+    "plan",
+    "startedAt",
+    "finishedAt",
+    "durationMs",
+    "status",
+    "ok",
+    "qualifying",
+    "results",
+    "skipped",
+    "unsupported",
+    "integrity"
+  ],
+  "properties": {
+    "$schema": { "const": "https://libkungfu.dev/schemas/shifu/gate-receipt-v1.schema.json" },
+    "schema": { "const": "shifu.gate-receipt/v1" },
+    "runId": { "type": "string", "minLength": 1 },
+    "project": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id"],
+      "properties": { "id": { "type": "string", "minLength": 1 } }
+    },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["sha", "dirty"],
+      "properties": {
+        "sha": { "type": ["string", "null"], "pattern": "^[0-9a-f]{40,64}$" },
+        "dirty": { "type": "boolean" }
+      }
+    },
+    "registry": { "$ref": "#/$defs/registry" },
+    "selection": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["profile", "includeAdvisory", "explicitGates"],
+      "properties": {
+        "profile": { "type": ["string", "null"] },
+        "includeAdvisory": { "type": "boolean" },
+        "explicitGates": { "type": "array", "items": { "type": "string" }, "uniqueItems": true }
+      }
+    },
+    "environment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["platform", "runnerCapabilities"],
+      "properties": {
+        "platform": { "type": "string", "minLength": 1 },
+        "runnerCapabilities": { "type": "array", "items": { "type": "string" }, "uniqueItems": true }
+      }
+    },
+    "plan": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["digest", "qualifying", "expectedActionIds", "attemptedActionIds"],
+      "properties": {
+        "digest": { "$ref": "#/$defs/digest" },
+        "qualifying": { "type": "boolean" },
+        "expectedActionIds": { "type": "array", "items": { "$ref": "#/$defs/digest" }, "uniqueItems": true },
+        "attemptedActionIds": { "type": "array", "items": { "$ref": "#/$defs/digest" }, "uniqueItems": true }
+      }
+    },
+    "startedAt": { "type": "string", "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d{3})?Z$" },
+    "finishedAt": { "type": "string", "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d{3})?Z$" },
+    "durationMs": { "type": "integer", "minimum": 0 },
+    "status": { "$ref": "#/$defs/status" },
+    "ok": { "type": "boolean" },
+    "qualifying": { "type": "boolean" },
+    "results": { "type": "array", "items": { "$ref": "#/$defs/result" } },
+    "skipped": { "type": "array", "items": { "$ref": "#/$defs/omission" } },
+    "unsupported": { "type": "array", "items": { "$ref": "#/$defs/omission" } }
+    ,
+    "integrity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["digest"],
+      "properties": { "digest": { "$ref": "#/$defs/digest" } }
+    }
+  },
+  "$defs": {
+    "digest": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+    "status": { "enum": ["pass", "fail", "advisory-fail", "unsupported", "skip", "error"] },
+    "registry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["ref", "digest", "projectId"],
+      "properties": {
+        "ref": { "type": "string", "minLength": 1 },
+        "digest": { "$ref": "#/$defs/digest" },
+        "projectId": { "type": "string", "minLength": 1 }
+      }
+    },
+    "artifact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "path", "required", "present"],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "path": { "type": "string", "minLength": 1 },
+        "required": { "type": "boolean" },
+        "present": { "type": "boolean" }
+      }
+    },
+    "pointer": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "ref"],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "ref": { "type": "string", "minLength": 1 },
+        "digest": { "$ref": "#/$defs/digest" }
+      }
+    },
+    "evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["expectation", "schema", "present", "pointers"],
+      "properties": {
+        "expectation": { "enum": ["none", "optional", "required"] },
+        "schema": { "type": ["string", "null"] },
+        "present": { "type": "boolean" },
+        "pointers": { "type": "array", "items": { "$ref": "#/$defs/pointer" } }
+      }
+    },
+    "reproduce": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["argv"],
+      "properties": {
+        "argv": { "type": "array", "minItems": 1, "items": { "type": "string" } }
+      }
+    },
+    "result": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "gateId",
+        "policyMode",
+        "selectedBy",
+        "actionId",
+        "definitionDigest",
+        "status",
+        "attempted",
+        "durationMs",
+        "exitCode",
+        "signal",
+        "reason",
+        "artifacts",
+        "evidence",
+        "reproduce"
+      ],
+      "properties": {
+        "gateId": { "type": "string", "minLength": 1 },
+        "policyMode": { "enum": ["required", "advisory", "off", null] },
+        "selectedBy": { "type": "array", "items": { "type": "string" } },
+        "actionId": { "$ref": "#/$defs/digest" },
+        "definitionDigest": { "$ref": "#/$defs/digest" },
+        "status": { "$ref": "#/$defs/status" },
+        "attempted": { "type": "boolean" },
+        "durationMs": { "type": "integer", "minimum": 0 },
+        "exitCode": { "type": ["integer", "null"] },
+        "signal": { "type": ["string", "null"] },
+        "reason": { "type": ["string", "null"] },
+        "artifacts": { "type": "array", "items": { "$ref": "#/$defs/artifact" } },
+        "evidence": { "$ref": "#/$defs/evidence" },
+        "reproduce": { "$ref": "#/$defs/reproduce" }
+      }
+    },
+    "omission": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "mode", "reason"],
+      "properties": {
+        "id": { "type": "string" },
+        "mode": { "enum": ["required", "advisory", "off", null] },
+        "reason": { "type": "string" }
+      }
+    }
+  }
+}

--- a/scripts/check-shifu-gate-contract.mjs
+++ b/scripts/check-shifu-gate-contract.mjs
@@ -33,16 +33,24 @@ export async function checkShifuGateContract(root = ROOT) {
   assert.equal(contract.owner, 'shifu');
   const registrySchemaPath = path.join(root, contract.authority.registrySchema);
   const planSchemaPath = path.join(root, contract.authority.planSchema);
+  const receiptSchemaPath = path.join(root, contract.authority.receiptSchema);
   const decisionPath = path.join(root, contract.decision);
-  for (const source of [registrySchemaPath, planSchemaPath, decisionPath])
+  for (const source of [
+    registrySchemaPath,
+    planSchemaPath,
+    receiptSchemaPath,
+    decisionPath,
+  ])
     assert.ok(
       fs.existsSync(source),
       `contract source is missing: ${rel(root, source)}`,
     );
   const registrySchema = readJson(registrySchemaPath);
   const planSchema = readJson(planSchemaPath);
+  const receiptSchema = readJson(receiptSchemaPath);
   assert.equal(registrySchema.$id, contract.schemaIds.registry);
   assert.equal(planSchema.$id, contract.schemaIds.plan);
+  assert.equal(receiptSchema.$id, contract.schemaIds.receipt);
 
   const dispatchMarkers = [
     ['shifu', 'build | rebuild | gate | proxy | config)'],
@@ -101,6 +109,7 @@ export async function checkShifuGateContract(root = ROOT) {
     const ajv = new Ajv2020({ allErrors: true, strict: false });
     const validateRegistry = ajv.compile(registrySchema);
     const validatePlan = ajv.compile(planSchema);
+    ajv.compile(receiptSchema);
     assert.equal(
       validateRegistry(valid.registry),
       true,
@@ -118,6 +127,7 @@ export async function checkShifuGateContract(root = ROOT) {
   const engine = [
     'scripts/shifu-gate-runtime.mjs',
     'scripts/shifu-gate-cli.mjs',
+    'scripts/shifu-gate-executor.mjs',
   ]
     .map((source) => fs.readFileSync(path.join(root, source), 'utf8'))
     .join('\n');
@@ -130,6 +140,7 @@ export async function checkShifuGateContract(root = ROOT) {
     contract: rel(root, contractPath),
     registrySchema: rel(root, registrySchemaPath),
     planSchema: rel(root, planSchemaPath),
+    receiptSchema: rel(root, receiptSchemaPath),
     validFixtures: 1,
     rejectedFixtures: Object.keys(expectedInvalid).length,
     schemaValidation,

--- a/scripts/check.mjs
+++ b/scripts/check.mjs
@@ -356,6 +356,7 @@ function testShifuGateContract() {
   run('Shifu Gate contract tests', 'node', [
     '--test',
     path.join('scripts', 'shifu-gate-runtime.test.mjs'),
+    path.join('scripts', 'shifu-gate-executor.test.mjs'),
   ]);
 }
 

--- a/scripts/shifu-gate-cli.mjs
+++ b/scripts/shifu-gate-cli.mjs
@@ -4,6 +4,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
+import { executeGateRun, validateGateReceipt } from './shifu-gate-executor.mjs';
 import { buildGatePlan, loadGateRegistry } from './shifu-gate-runtime.mjs';
 
 const CONTRACT = path.join('docs', 'shifu', 'gate-contract.json');
@@ -16,15 +17,16 @@ const SCHEMAS = {
     'gate-registry-v1.schema.json',
   ),
   plan: path.join('docs', 'shifu', 'schema', 'gate-plan-v1.schema.json'),
+  receipt: path.join('docs', 'shifu', 'schema', 'gate-receipt-v1.schema.json'),
 };
 
 /** @typedef {{write:(chunk:any)=>any}} Writer */
 /** @typedef {{code:string, path:string, message:string}} GateIssue */
 
 export function gateHelp() {
-  return `shifu gate — inspect and plan project gates through one versioned control plane
+  return `shifu gate — inspect, plan, execute and validate project gates through one control plane
   gate contract                         print the canonical Gate contract
-  gate schema <registry|plan>           print a canonical JSON Schema
+  gate schema <registry|plan|receipt>   print a canonical JSON Schema
   gate validate [--registry FILE|-] [--json]
                                         validate syntax, ids, dependencies, cycles and profiles
   gate list [--registry FILE] [--json]  list registered gates
@@ -37,12 +39,19 @@ export function gateHelp() {
   gate plan PROFILE [--include-advisory] [--gate GATE] [--platform PLATFORM]
                     [--registry FILE] [--json]
                                         produce a deterministic dependency and platform plan
+  gate run GATE... [--capability CAP] [--registry FILE] [--receipt FILE] [--json]
+  gate run --profile PROFILE [--include-advisory] [--capability CAP]
+           [--registry FILE] [--receipt FILE] [--json]
+                                        execute a dependency closure and emit one unified receipt
+  gate receipt validate FILE [--registry FILE] [--json]
+                                        revalidate source, registry, definitions and action coverage
 
 Registry discovery: --registry, then SHIFU_GATE_REGISTRY, then shifu.gates.json.
 Every profile must explicitly decide every gate as required, advisory, or off.
---gate is a diagnostic selection override: it never changes profile policy and
-makes the resulting plan non-qualifying. This contract stage plans only; it does
-not execute actions or issue qualification receipts.`;
+Explicit gate runs are diagnostic and never qualifying. Only a complete profile
+run at a clean source SHA can issue a qualifying receipt. Child actions use
+structured argv and Shifu adds SHIFU_GATE_* evidence pointers; receipt output
+never captures command output or the inherited environment.`;
 }
 
 /** @param {unknown} value @param {Writer} stdout */
@@ -86,6 +95,15 @@ function registryIdentity(loaded) {
     digest: loaded.digest,
     projectId: loaded.registry.project.id,
   };
+}
+
+/** @param {string} root @param {string} ref */
+function receiptRegistryRef(root, ref) {
+  if (ref === '-') return '<stdin-registry>';
+  const relative = path.relative(root, path.resolve(root, ref));
+  if (!relative || (!relative.startsWith('..') && !path.isAbsolute(relative)))
+    return (relative || path.basename(ref)).split(path.sep).join('/');
+  return '<external-registry>';
 }
 
 /** @param {any} registry @param {string} id */
@@ -244,6 +262,71 @@ function humanPlan(plan, stdout) {
   }
 }
 
+/** @param {string[]} argv */
+function parseRunArgs(argv) {
+  let profile = '';
+  let includeAdvisory = false;
+  let receipt = '';
+  let overwrite = false;
+  const capabilities = [];
+  const gates = [];
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const value = () => {
+      index += 1;
+      if (index >= argv.length) throw new Error(`${arg} requires a value`);
+      return argv[index];
+    };
+    if (arg === '--profile') profile = value();
+    else if (arg === '--include-advisory') includeAdvisory = true;
+    else if (arg === '--capability') capabilities.push(value());
+    else if (arg === '--receipt') receipt = value();
+    else if (arg === '--overwrite') overwrite = true;
+    else if (arg.startsWith('-'))
+      throw new Error(`unknown gate run option: ${arg}`);
+    else gates.push(arg);
+  }
+  if (profile && gates.length)
+    throw new Error('gate run accepts either GATE ids or --profile, not both');
+  if (!profile && !gates.length)
+    throw new Error(
+      'gate run requires one or more GATE ids or --profile PROFILE',
+    );
+  if (includeAdvisory && !profile)
+    throw new Error('--include-advisory requires --profile PROFILE');
+  if (overwrite && !receipt)
+    throw new Error('--overwrite requires --receipt FILE');
+  return { profile, includeAdvisory, receipt, overwrite, capabilities, gates };
+}
+
+/** @param {any} receipt @param {Writer} stdout */
+function humanReceipt(receipt, stdout) {
+  stdout.write(
+    `gate run: ${receipt.status}; qualifying: ${receipt.qualifying}; source: ${receipt.source.sha || 'unavailable'}${receipt.source.dirty ? ' (dirty)' : ''}\n`,
+  );
+  for (const result of receipt.results)
+    stdout.write(
+      `  ${result.gateId}: ${result.status}${result.reason ? ` — ${result.reason}` : ''}\n`,
+    );
+  for (const item of receipt.unsupported)
+    stdout.write(`  ${item.id}: unsupported — ${item.reason}\n`);
+}
+
+/** @param {string} root @param {string} file @param {any} value @param {boolean} overwrite */
+function writeReceipt(root, file, value, overwrite) {
+  const target = path.resolve(root, file);
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  if (!overwrite && fs.existsSync(target))
+    throw new Error(
+      `receipt already exists: ${file} (use --overwrite to replace it)`,
+    );
+  const temporary = `${target}.tmp-${process.pid}`;
+  fs.writeFileSync(temporary, `${JSON.stringify(value, null, 2)}\n`, {
+    flag: 'wx',
+  });
+  fs.renameSync(temporary, target);
+}
+
 /**
  * @param {string[]} argv
  * @param {{root?:string, stdout?:Writer, stderr?:Writer}} [options]
@@ -371,6 +454,55 @@ export async function runGateCommand(
     if (json) printJson(plan, stdout);
     else humanPlan(plan, stdout);
     return plan.ok ? 0 : 1;
+  }
+  if (sub === 'run') {
+    const options = parseRunArgs(rest);
+    const safeRegistryRef = receiptRegistryRef(root, loaded.ref);
+    const receipt = await executeGateRun(registry, {
+      root,
+      registryRef: safeRegistryRef,
+      registryDigest: loaded.digest,
+      profile: options.profile,
+      explicitGates: options.gates,
+      includeAdvisory: options.includeAdvisory,
+      capabilities: options.capabilities,
+      writer: stderr,
+    });
+    if (options.receipt)
+      writeReceipt(root, options.receipt, receipt, options.overwrite);
+    if (json) printJson(receipt, stdout);
+    else {
+      humanReceipt(receipt, stdout);
+      if (options.receipt) stdout.write(`receipt: ${options.receipt}\n`);
+    }
+    return receipt.ok ? 0 : 1;
+  }
+  if (sub === 'receipt') {
+    if (rest[0] !== 'validate' || !rest[1] || rest.length !== 2)
+      throw new Error('gate receipt requires: validate FILE');
+    const receipt = JSON.parse(
+      fs.readFileSync(path.resolve(root, rest[1]), 'utf8'),
+    );
+    const validation = {
+      schema: 'shifu.gate-receipt-validation/v1',
+      receipt: rest[1],
+      ...validateGateReceipt(receipt, registry, {
+        root,
+        registryRef: receiptRegistryRef(root, loaded.ref),
+        registryDigest: loaded.digest,
+      }),
+    };
+    if (json) printJson(validation, stdout);
+    else {
+      stdout.write(
+        `gate receipt: valid=${validation.valid} current=${validation.current} qualifying=${validation.qualifying}\n`,
+      );
+      for (const item of validation.issues)
+        stderr.write(`  ${item.code} ${item.path}: ${item.message}\n`);
+    }
+    return validation.valid && validation.current && validation.qualifying
+      ? 0
+      : 1;
   }
   stderr.write(`${gateHelp()}\n`);
   return 2;

--- a/scripts/shifu-gate-executor.mjs
+++ b/scripts/shifu-gate-executor.mjs
@@ -1,0 +1,941 @@
+// SPDX-License-Identifier: Apache-2.0
+// @ts-check
+
+import { spawnSync } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  GATE_RECEIPT_SCHEMA,
+  buildGatePlan,
+  gateActionId,
+  gateDefinitionDigest,
+  gateDigest,
+  validateGateRegistry,
+} from './shifu-gate-runtime.mjs';
+
+const RESULT_STATUSES = new Set([
+  'pass',
+  'fail',
+  'advisory-fail',
+  'unsupported',
+  'skip',
+  'error',
+]);
+
+/** @typedef {{write:(chunk:any)=>any}} Writer */
+/** @typedef {{id:string, ref:string, digest?:string}} EvidencePointer */
+/** @typedef {{id:string, title:string, summary:string, category:string, documentation:string, dependencies:string[], platforms:string[], runner:{capabilities:string[]}, cost:{class:string,timeoutSeconds:number}, action:any, artifacts:any[], receipt:{expectation:string,schema?:string}}} Gate */
+/** @typedef {{code:string, path:string, message:string}} GateIssue */
+
+/** @param {NodeJS.Platform|string} platform */
+export function normalizeGatePlatform(platform = process.platform) {
+  if (platform === 'darwin') return 'macos';
+  if (platform === 'win32') return 'windows';
+  return String(platform);
+}
+
+/** @param {string} root @param {string[]} args */
+function git(root, args) {
+  const result = spawnSync('git', args, {
+    cwd: root,
+    encoding: 'utf8',
+    windowsHide: true,
+  });
+  return result.status === 0 ? result.stdout.trim() : '';
+}
+
+/** @param {string} root */
+export function readGateSourceIdentity(root) {
+  const sha = git(root, ['rev-parse', '--verify', 'HEAD']);
+  if (!sha) return { sha: null, dirty: true };
+  return {
+    sha,
+    dirty:
+      git(root, ['status', '--porcelain', '--untracked-files=normal']) !== '',
+  };
+}
+
+/** @param {any} registry @returns {Map<string, Gate>} */
+function gateMap(registry) {
+  return new Map(
+    registry.gates.map((/** @type {Gate} */ gate) => [gate.id, gate]),
+  );
+}
+
+/** @param {Map<string, Gate>} byId @param {string} id @returns {Gate} */
+function requireGate(byId, id) {
+  const gate = byId.get(id);
+  if (!gate) throw new Error(`unknown gate: ${id}`);
+  return gate;
+}
+
+/**
+ * @param {any} registry
+ * @param {string[]} explicitGates
+ * @param {string} platform
+ */
+function buildExplicitPlan(registry, explicitGates, platform) {
+  const byId = gateMap(registry);
+  const explicit = [...new Set(explicitGates)].sort();
+  const selected = new Set();
+  /** @type {Map<string, Set<string>>} */
+  const selectedBy = new Map();
+  const unsupported = [];
+  /** @param {string} id @param {string} reason */
+  const select = (id, reason) => {
+    if (!byId.has(id)) throw new Error(`unknown gate: ${id}`);
+    selected.add(id);
+    if (!selectedBy.has(id)) selectedBy.set(id, new Set());
+    selectedBy.get(id)?.add(reason);
+  };
+  /** @param {string} id */
+  const visit = (id) => {
+    const gate = requireGate(byId, id);
+    for (const dependency of [...gate.dependencies].sort()) {
+      select(dependency, `dependency-of:${id}`);
+      visit(dependency);
+    }
+  };
+  for (const id of explicit) select(id, 'explicit');
+  for (const id of explicit) visit(id);
+  for (const id of [...selected].sort()) {
+    const gate = requireGate(byId, id);
+    if (!gate.platforms.includes('any') && !gate.platforms.includes(platform))
+      unsupported.push({
+        id,
+        mode: null,
+        reason: `unsupported on ${platform}`,
+      });
+  }
+  const groups = [];
+  if (!unsupported.length) {
+    const remaining = new Set(selected);
+    let index = 0;
+    while (remaining.size) {
+      const ready = [...remaining]
+        .filter((id) =>
+          requireGate(byId, id).dependencies.every(
+            (/** @type {string} */ dependency) => !remaining.has(dependency),
+          ),
+        )
+        .sort();
+      if (!ready.length)
+        throw new Error('gate run could not resolve dependency order');
+      groups.push({
+        index,
+        gates: ready.map((id) => {
+          const gate = requireGate(byId, id);
+          return {
+            id,
+            mode: null,
+            selectedBy: [...(selectedBy.get(id) || [])].sort(),
+            dependencies: [...gate.dependencies].sort(),
+            platforms: [...gate.platforms].sort(),
+            runner: gate.runner,
+            cost: gate.cost,
+            action: gate.action,
+            actionId: gateActionId(gate),
+            definitionDigest: gateDefinitionDigest(gate),
+            artifacts: gate.artifacts,
+            receipt: gate.receipt,
+          };
+        }),
+      });
+      for (const id of ready) remaining.delete(id);
+      index += 1;
+    }
+  }
+  return {
+    schema: 'shifu.gate-run-plan/v1',
+    profile: null,
+    platform,
+    includeAdvisory: false,
+    explicitGates: explicit,
+    ok: unsupported.length === 0,
+    qualifying: false,
+    groups,
+    skipped: [],
+    unsupported,
+  };
+}
+
+/**
+ * @param {any} registry
+ * @param {{registryRef:string, registryDigest:string, profile?:string, explicitGates?:string[], includeAdvisory?:boolean, platform?:string}} options
+ */
+export function buildGateRunPlan(registry, options) {
+  const issues = validateGateRegistry(registry);
+  if (issues.length)
+    throw new Error(
+      `gate registry is invalid: ${issues[0].path || '/'} ${issues[0].message}`,
+    );
+  const platform = normalizeGatePlatform(options.platform);
+  const profile = options.profile || '';
+  const explicitGates = options.explicitGates || [];
+  if (Boolean(profile) === Boolean(explicitGates.length))
+    throw new Error(
+      'gate run requires either --profile PROFILE or one or more GATE ids',
+    );
+  const plan = profile
+    ? buildGatePlan(registry, profile, {
+        ref: options.registryRef,
+        digest: options.registryDigest,
+        includeAdvisory: options.includeAdvisory || false,
+        platform,
+      })
+    : buildExplicitPlan(registry, explicitGates, platform);
+  const identity = {
+    registryDigest: options.registryDigest,
+    profile: plan.profile,
+    platform: plan.platform,
+    includeAdvisory: plan.includeAdvisory,
+    explicitGates: plan.explicitGates,
+    qualifying: plan.qualifying,
+    groups: plan.groups.map((group) => ({
+      index: group.index,
+      gates: group.gates.map((gate) => ({
+        id: gate.id,
+        mode: gate.mode,
+        selectedBy: gate.selectedBy,
+        dependencies: gate.dependencies,
+        actionId: gate.actionId,
+        definitionDigest: gate.definitionDigest,
+      })),
+    })),
+    skipped: plan.skipped,
+    unsupported: plan.unsupported,
+  };
+  return { ...plan, digest: gateDigest(identity) };
+}
+
+/** @param {string} value */
+function cmdQuote(value) {
+  if (/^[A-Za-z0-9_./:\\-]+$/u.test(value)) return value;
+  return `"${value.replace(/(\\*)"/g, '$1$1\\"').replace(/(\\+)$/g, '$1$1')}"`;
+}
+
+/**
+ * @param {any} action
+ * @param {string} root
+ * @param {string} platform
+ */
+export function buildGateActionInvocation(action, root, platform) {
+  if (action.kind === 'argv')
+    return { command: action.command, args: [...(action.args || [])] };
+  if (action.kind !== 'task') return null;
+  const taskArgs = [action.task, ...(action.args || [])];
+  if (platform !== 'windows')
+    return { command: path.join(root, 'shifu'), args: taskArgs };
+  const command = process.env.ComSpec || 'cmd.exe';
+  const line = [path.join(root, 'shifu.cmd'), ...taskArgs]
+    .map((item) => cmdQuote(String(item)))
+    .join(' ');
+  return { command, args: ['/d', '/s', '/c', `call ${line}`] };
+}
+
+/** @param {unknown} value */
+function safeEvidence(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value))
+    throw new Error('gate evidence must be an object');
+  const record = /** @type {any} */ (value);
+  const schema = record.schema;
+  const pointers = record.pointers;
+  if (typeof schema !== 'string' || !schema)
+    throw new Error('gate evidence schema must be a non-empty string');
+  if (!Array.isArray(pointers))
+    throw new Error('gate evidence pointers must be an array');
+  return {
+    schema,
+    pointers: pointers.map((pointer, index) => {
+      if (!pointer || typeof pointer !== 'object' || Array.isArray(pointer))
+        throw new Error(`gate evidence pointer ${index} must be an object`);
+      const keys = Object.keys(pointer);
+      if (keys.some((key) => !['id', 'ref', 'digest'].includes(key)))
+        throw new Error(`gate evidence pointer ${index} has an unknown field`);
+      if (typeof pointer.id !== 'string' || !pointer.id)
+        throw new Error(`gate evidence pointer ${index} needs id`);
+      if (
+        typeof pointer.ref !== 'string' ||
+        !pointer.ref ||
+        path.posix.isAbsolute(pointer.ref) ||
+        path.win32.isAbsolute(pointer.ref) ||
+        /^[a-z][a-z0-9+.-]*:/i.test(pointer.ref) ||
+        pointer.ref.includes('?') ||
+        pointer.ref.includes('#') ||
+        pointer.ref.split(/[\\/]/).includes('..')
+      )
+        throw new Error(
+          `gate evidence pointer ${index} must use a safe repository-relative ref`,
+        );
+      if (
+        pointer.digest !== undefined &&
+        !/^sha256:[0-9a-f]{64}$/.test(pointer.digest)
+      )
+        throw new Error(`gate evidence pointer ${index} has an invalid digest`);
+      return {
+        id: pointer.id,
+        ref: pointer.ref.split(/[\\/]/).join('/'),
+        ...(pointer.digest ? { digest: pointer.digest } : {}),
+      };
+    }),
+  };
+}
+
+/**
+ * @param {any} gate
+ * @param {string} root
+ */
+function inspectArtifacts(gate, root) {
+  return gate.artifacts.map((/** @type {any} */ artifact) => {
+    const artifactPath = artifact.path.split(/[\\/]/).join('/');
+    return {
+      id: artifact.id,
+      path: artifactPath,
+      required: artifact.required,
+      present: fs.existsSync(path.resolve(root, artifactPath)),
+    };
+  });
+}
+
+/** @param {string} status @param {string|null} mode */
+function policyFailureStatus(status, mode) {
+  if (mode === 'advisory' && ['fail', 'error', 'unsupported'].includes(status))
+    return 'advisory-fail';
+  return status;
+}
+
+/** @param {unknown} value @param {string} root */
+function redactReceiptText(value, root) {
+  if (value === null || value === undefined) return null;
+  let text = String(value);
+  for (const prefix of [root, os.homedir(), os.tmpdir()].filter(Boolean))
+    text = text.split(prefix).join('<redacted-path>');
+  return text
+    .replace(/https?:\/\/\S+/gi, '<redacted-url>')
+    .replace(/[A-Za-z]:\\[^\s,;]+/g, '<redacted-path>')
+    .replace(
+      /\/(?:Users|home|private|tmp|var|Volumes)\/[^\s,;]+/g,
+      '<redacted-path>',
+    )
+    .replace(
+      /\b(token|secret|password|credential|authorization)=\S+/gi,
+      '$1=<redacted>',
+    )
+    .slice(0, 1000);
+}
+
+/**
+ * @param {any} gate
+ * @param {{root:string, platform:string, source:any, tempRoot:string, writer:Writer, handlers:Record<string,Function>}} context
+ */
+async function executeAction(gate, context) {
+  const actionId = gateActionId(gate);
+  const evidenceFile = path.join(context.tempRoot, `${gate.id}.evidence.json`);
+  const started = Date.now();
+  let rawStatus = 'pass';
+  let exitCode = null;
+  let signal = null;
+  let reason = null;
+  let evidence = null;
+  if (gate.action.kind === 'handler') {
+    const handler = context.handlers[gate.action.handler];
+    if (!handler) {
+      rawStatus = 'error';
+      reason = `unregistered gate handler: ${gate.action.handler}`;
+    } else {
+      try {
+        const outcome = await handler({
+          gateId: gate.id,
+          actionId,
+          parameters: gate.action.parameters || {},
+          root: context.root,
+          source: context.source,
+        });
+        rawStatus = outcome?.status || 'pass';
+        if (!RESULT_STATUSES.has(rawStatus))
+          throw new Error(`handler returned invalid status: ${rawStatus}`);
+        exitCode = outcome?.exitCode ?? (rawStatus === 'pass' ? 0 : null);
+        reason = outcome?.reason || null;
+        if (outcome?.evidence) evidence = safeEvidence(outcome.evidence);
+      } catch (error) {
+        rawStatus = 'error';
+        reason = error instanceof Error ? error.message : String(error);
+      }
+    }
+  } else {
+    const invocation = buildGateActionInvocation(
+      gate.action,
+      context.root,
+      context.platform,
+    );
+    try {
+      if (!invocation)
+        throw new Error(`unsupported gate action: ${gate.action.kind}`);
+      const result = spawnSync(invocation.command, invocation.args, {
+        cwd: context.root,
+        env: {
+          ...process.env,
+          SHIFU_GATE_ID: gate.id,
+          SHIFU_GATE_ACTION_ID: actionId,
+          SHIFU_GATE_SOURCE_SHA: context.source.sha || '',
+          SHIFU_GATE_EVIDENCE_FILE: evidenceFile,
+        },
+        encoding: 'utf8',
+        timeout: gate.cost.timeoutSeconds * 1000,
+        maxBuffer: 16 * 1024 * 1024,
+        windowsHide: true,
+      });
+      if (result.stdout)
+        context.writer.write(`[gate ${gate.id}] stdout\n${result.stdout}`);
+      if (result.stderr)
+        context.writer.write(`[gate ${gate.id}] stderr\n${result.stderr}`);
+      exitCode = result.status;
+      signal = result.signal;
+      if (result.error) {
+        rawStatus = 'error';
+        reason =
+          /** @type {any} */ (result.error).code === 'ETIMEDOUT'
+            ? `action timed out after ${gate.cost.timeoutSeconds}s`
+            : result.error.message;
+      } else if (result.signal) {
+        rawStatus = 'error';
+        reason = `action terminated by signal ${result.signal}`;
+      } else if (result.status !== 0) {
+        rawStatus = 'fail';
+        reason = `action exited with code ${result.status}`;
+      }
+    } catch (error) {
+      rawStatus = 'error';
+      reason = error instanceof Error ? error.message : String(error);
+    }
+  }
+  if (!evidence && fs.existsSync(evidenceFile)) {
+    try {
+      evidence = safeEvidence(
+        JSON.parse(fs.readFileSync(evidenceFile, 'utf8')),
+      );
+    } catch (error) {
+      rawStatus = 'error';
+      reason = `invalid gate evidence: ${error instanceof Error ? error.message : String(error)}`;
+    }
+  }
+  if (
+    evidence &&
+    gate.receipt.schema &&
+    evidence.schema !== gate.receipt.schema
+  ) {
+    rawStatus = 'fail';
+    reason = `evidence schema ${evidence.schema} does not match ${gate.receipt.schema}`;
+  }
+  if (
+    rawStatus === 'pass' &&
+    gate.receipt.expectation === 'required' &&
+    evidence &&
+    evidence.pointers.length === 0
+  ) {
+    rawStatus = 'fail';
+    reason = 'required gate evidence did not declare any safe pointers';
+  }
+  if (
+    rawStatus === 'pass' &&
+    gate.receipt.expectation === 'required' &&
+    !evidence
+  ) {
+    rawStatus = 'fail';
+    reason = 'required gate evidence was not produced';
+  }
+  const artifacts = inspectArtifacts(gate, context.root);
+  const missing = artifacts.filter(
+    (/** @type {any} */ artifact) => artifact.required && !artifact.present,
+  );
+  if (rawStatus === 'pass' && missing.length) {
+    rawStatus = 'fail';
+    reason = `required artifact missing: ${missing.map((/** @type {any} */ item) => item.id).join(', ')}`;
+  }
+  return {
+    rawStatus,
+    exitCode,
+    signal,
+    reason: redactReceiptText(reason, context.root),
+    durationMs: Date.now() - started,
+    artifacts,
+    evidence: {
+      expectation: gate.receipt.expectation,
+      schema: gate.receipt.schema || null,
+      present: Boolean(evidence),
+      pointers: /** @type {EvidencePointer[]} */ (evidence?.pointers || []),
+    },
+  };
+}
+
+/** @param {any[]} results @param {any[]} unsupported */
+function overallStatus(results, unsupported) {
+  if (unsupported.some((item) => item.mode !== 'advisory'))
+    return 'unsupported';
+  if (results.some((item) => item.status === 'error')) return 'error';
+  if (results.some((item) => item.status === 'fail')) return 'fail';
+  if (results.some((item) => item.status === 'unsupported'))
+    return 'unsupported';
+  if (results.some((item) => item.status === 'advisory-fail'))
+    return 'advisory-fail';
+  if (results.length && results.every((item) => item.status === 'skip'))
+    return 'skip';
+  return 'pass';
+}
+
+/** @param {any[]} results */
+function requiredCoverage(results) {
+  return results
+    .filter((item) => item.policyMode === 'required')
+    .every((item) => item.attempted && item.status === 'pass');
+}
+
+/**
+ * @param {any} registry
+ * @param {{root:string, registryRef:string, registryDigest:string, profile?:string, explicitGates?:string[], includeAdvisory?:boolean, platform?:string, capabilities?:string[], writer?:Writer, handlers?:Record<string,Function>, source?:{sha:string|null,dirty:boolean}, now?:()=>Date}} options
+ */
+export async function executeGateRun(registry, options) {
+  const root = options.root;
+  const platform = normalizeGatePlatform(options.platform);
+  const capabilities = [
+    ...new Set(['node', ...(options.capabilities || [])]),
+  ].sort();
+  const plan = buildGateRunPlan(registry, {
+    registryRef: options.registryRef,
+    registryDigest: options.registryDigest,
+    profile: options.profile,
+    explicitGates: options.explicitGates,
+    includeAdvisory: options.includeAdvisory,
+    platform,
+  });
+  const source = options.source || readGateSourceIdentity(root);
+  const now = options.now || (() => new Date());
+  const startedAt = now();
+  const writer = options.writer || process.stderr;
+  const byId = gateMap(registry);
+  /** @type {any[]} */
+  const results = [];
+  /** @type {Map<string, any>} */
+  const resultById = new Map();
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'shifu-gate-'));
+  try {
+    for (const group of plan.groups) {
+      for (const planned of group.gates) {
+        const gate = requireGate(byId, planned.id);
+        const failedDependency = gate.dependencies.find(
+          (/** @type {string} */ dependency) =>
+            resultById.get(dependency)?.status !== 'pass',
+        );
+        const base = {
+          gateId: gate.id,
+          policyMode: planned.mode,
+          selectedBy: planned.selectedBy,
+          actionId: gateActionId(gate),
+          definitionDigest: gateDefinitionDigest(gate),
+        };
+        if (failedDependency) {
+          const result = {
+            ...base,
+            status: 'skip',
+            attempted: false,
+            durationMs: 0,
+            exitCode: null,
+            signal: null,
+            reason: `dependency ${failedDependency} did not pass`,
+            artifacts: inspectArtifacts(gate, root),
+            evidence: {
+              expectation: gate.receipt.expectation,
+              schema: gate.receipt.schema || null,
+              present: false,
+              pointers: [],
+            },
+            reproduce: {
+              argv: [
+                platform === 'windows' ? 'shifu.cmd' : './shifu',
+                'gate',
+                'run',
+                gate.id,
+                '--registry',
+                options.registryRef,
+              ],
+            },
+          };
+          results.push(result);
+          resultById.set(gate.id, result);
+          continue;
+        }
+        const missingCapabilities = gate.runner.capabilities.filter(
+          (/** @type {string} */ capability) =>
+            !capabilities.includes(capability),
+        );
+        if (missingCapabilities.length) {
+          const result = {
+            ...base,
+            status: policyFailureStatus('unsupported', planned.mode),
+            attempted: false,
+            durationMs: 0,
+            exitCode: null,
+            signal: null,
+            reason: `missing runner capabilities: ${missingCapabilities.join(', ')}`,
+            artifacts: inspectArtifacts(gate, root),
+            evidence: {
+              expectation: gate.receipt.expectation,
+              schema: gate.receipt.schema || null,
+              present: false,
+              pointers: [],
+            },
+            reproduce: {
+              argv: [
+                platform === 'windows' ? 'shifu.cmd' : './shifu',
+                'gate',
+                'run',
+                gate.id,
+                '--registry',
+                options.registryRef,
+              ],
+            },
+          };
+          results.push(result);
+          resultById.set(gate.id, result);
+          continue;
+        }
+        const outcome = await executeAction(gate, {
+          root,
+          platform,
+          source,
+          tempRoot,
+          writer,
+          handlers: options.handlers || {},
+        });
+        const result = {
+          ...base,
+          status: policyFailureStatus(outcome.rawStatus, planned.mode),
+          attempted: true,
+          durationMs: outcome.durationMs,
+          exitCode: outcome.exitCode,
+          signal: outcome.signal,
+          reason: outcome.reason,
+          artifacts: outcome.artifacts,
+          evidence: outcome.evidence,
+          reproduce: {
+            argv: [
+              platform === 'windows' ? 'shifu.cmd' : './shifu',
+              'gate',
+              'run',
+              gate.id,
+              '--registry',
+              options.registryRef,
+            ],
+          },
+        };
+        results.push(result);
+        resultById.set(gate.id, result);
+      }
+    }
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+  const finishedAt = now();
+  const observedAfter = options.source ? source : readGateSourceIdentity(root);
+  const boundSource = {
+    sha: source.sha,
+    dirty:
+      source.dirty ||
+      observedAfter.dirty ||
+      Boolean(
+        source.sha && observedAfter.sha && source.sha !== observedAfter.sha,
+      ),
+  };
+  const status = overallStatus(results, plan.unsupported);
+  const requiredComplete = requiredCoverage(results);
+  const qualifying = Boolean(
+    plan.qualifying &&
+      source.sha &&
+      !boundSource.dirty &&
+      requiredComplete &&
+      ['pass', 'advisory-fail'].includes(status),
+  );
+  const receipt = {
+    $schema: GATE_RECEIPT_SCHEMA,
+    schema: 'shifu.gate-receipt/v1',
+    runId: `gate-${randomUUID()}`,
+    project: { id: registry.project.id },
+    source: boundSource,
+    registry: {
+      ref: options.registryRef,
+      digest: options.registryDigest,
+      projectId: registry.project.id,
+    },
+    selection: {
+      profile: plan.profile,
+      includeAdvisory: plan.includeAdvisory,
+      explicitGates: plan.explicitGates,
+    },
+    environment: { platform, runnerCapabilities: capabilities },
+    plan: {
+      digest: plan.digest,
+      qualifying: plan.qualifying,
+      expectedActionIds: plan.groups.flatMap((group) =>
+        group.gates.map((gate) => gate.actionId),
+      ),
+      attemptedActionIds: results
+        .filter((result) => result.attempted)
+        .map((result) => result.actionId),
+    },
+    startedAt: startedAt.toISOString(),
+    finishedAt: finishedAt.toISOString(),
+    durationMs: Math.max(0, finishedAt.getTime() - startedAt.getTime()),
+    status,
+    ok: ['pass', 'advisory-fail'].includes(status),
+    qualifying,
+    results,
+    skipped: plan.skipped,
+    unsupported: plan.unsupported,
+  };
+  return { ...receipt, integrity: { digest: gateDigest(receipt) } };
+}
+
+/**
+ * @param {any} receipt
+ * @param {any} registry
+ * @param {{root:string, registryRef:string, registryDigest:string, source?:{sha:string|null,dirty:boolean}}} options
+ */
+export function validateGateReceipt(receipt, registry, options) {
+  /** @type {GateIssue[]} */
+  const issues = [];
+  /** @param {string} code @param {string} at @param {string} message */
+  const add = (code, at, message) => issues.push({ code, path: at, message });
+  if (!receipt || typeof receipt !== 'object' || Array.isArray(receipt)) {
+    add('type', '/', 'receipt must be an object');
+    return { valid: false, current: false, qualifying: false, issues };
+  }
+  if (receipt.$schema !== GATE_RECEIPT_SCHEMA)
+    add('schema-id', '/$schema', `must be ${GATE_RECEIPT_SCHEMA}`);
+  if (receipt.schema !== 'shifu.gate-receipt/v1')
+    add('schema-version', '/schema', 'must be shifu.gate-receipt/v1');
+  if (!RESULT_STATUSES.has(receipt.status))
+    add('status', '/status', 'has an invalid status');
+  if (!Array.isArray(receipt.results))
+    add('type', '/results', 'must be an array');
+  const unsigned = { ...receipt };
+  Reflect.deleteProperty(unsigned, 'integrity');
+  if (receipt.integrity?.digest !== gateDigest(unsigned))
+    add(
+      'receipt-digest',
+      '/integrity/digest',
+      'does not match the receipt content',
+    );
+  const source = options.source || readGateSourceIdentity(options.root);
+  let current = true;
+  if (receipt.registry?.digest !== options.registryDigest) {
+    add(
+      'stale-registry',
+      '/registry/digest',
+      'does not match the current registry',
+    );
+    current = false;
+  }
+  if (receipt.registry?.ref !== options.registryRef) {
+    add(
+      'registry-ref',
+      '/registry/ref',
+      'does not match the selected registry ref',
+    );
+    current = false;
+  }
+  if (
+    receipt.source?.sha !== source.sha ||
+    receipt.source?.dirty !== source.dirty
+  ) {
+    add(
+      'stale-source',
+      '/source',
+      'does not match the current source SHA and dirty state',
+    );
+    current = false;
+  }
+  let plan = null;
+  try {
+    plan = buildGateRunPlan(registry, {
+      registryRef: options.registryRef,
+      registryDigest: options.registryDigest,
+      profile: receipt.selection?.profile || '',
+      explicitGates: receipt.selection?.explicitGates || [],
+      includeAdvisory: receipt.selection?.includeAdvisory || false,
+      platform: receipt.environment?.platform,
+    });
+    if (receipt.plan?.digest !== plan.digest) {
+      add(
+        'plan-digest',
+        '/plan/digest',
+        'does not match the current execution plan',
+      );
+      current = false;
+    }
+    if (receipt.plan?.qualifying !== plan.qualifying)
+      add(
+        'plan-qualification',
+        '/plan/qualifying',
+        'does not match the current plan',
+      );
+    if (gateDigest(receipt.skipped || []) !== gateDigest(plan.skipped))
+      add('plan-skipped', '/skipped', 'does not match the current plan');
+    if (gateDigest(receipt.unsupported || []) !== gateDigest(plan.unsupported))
+      add(
+        'plan-unsupported',
+        '/unsupported',
+        'does not match the current plan',
+      );
+  } catch (error) {
+    add(
+      'plan',
+      '/selection',
+      error instanceof Error ? error.message : String(error),
+    );
+  }
+  /** @type {Map<string, any>} */
+  const expected = new Map();
+  for (const group of plan?.groups || [])
+    for (const gate of group.gates) expected.set(gate.id, gate);
+  const seen = new Set();
+  if (Array.isArray(receipt.results)) {
+    for (let index = 0; index < receipt.results.length; index += 1) {
+      const result = receipt.results[index];
+      const at = `/results/${index}`;
+      if (!result || typeof result !== 'object') {
+        add('type', at, 'must be an object');
+        continue;
+      }
+      if (seen.has(result.gateId))
+        add('duplicate-result', `${at}/gateId`, 'is duplicated');
+      seen.add(result.gateId);
+      const planned = expected.get(result.gateId);
+      if (!planned) {
+        add('unexpected-result', `${at}/gateId`, 'is not in the current plan');
+        continue;
+      }
+      if (result.actionId !== planned.actionId)
+        add('action-id', `${at}/actionId`, 'does not match the current action');
+      if (result.policyMode !== planned.mode)
+        add(
+          'policy-mode',
+          `${at}/policyMode`,
+          'does not match the current plan',
+        );
+      if (result.definitionDigest !== planned.definitionDigest) {
+        add(
+          'definition-digest',
+          `${at}/definitionDigest`,
+          'does not match the current gate definition',
+        );
+        current = false;
+      }
+      if (!RESULT_STATUSES.has(result.status))
+        add('status', `${at}/status`, 'has an invalid status');
+    }
+  }
+  for (const id of expected.keys())
+    if (!seen.has(id))
+      add('missing-result', '/results', `is missing gate ${id}`);
+  const expectedActionIds = [...expected.values()].map((gate) => gate.actionId);
+  const attemptedActionIds = Array.isArray(receipt.results)
+    ? receipt.results
+        .filter((/** @type {any} */ result) => result?.attempted)
+        .map((/** @type {any} */ result) => result.actionId)
+    : [];
+  if (
+    gateDigest(receipt.plan?.expectedActionIds || []) !==
+    gateDigest(expectedActionIds)
+  )
+    add(
+      'expected-actions',
+      '/plan/expectedActionIds',
+      'does not match the current plan',
+    );
+  if (
+    gateDigest(receipt.plan?.attemptedActionIds || []) !==
+    gateDigest(attemptedActionIds)
+  )
+    add(
+      'attempted-actions',
+      '/plan/attemptedActionIds',
+      'does not match result coverage',
+    );
+  const derivedStatus = overallStatus(
+    Array.isArray(receipt.results) ? receipt.results : [],
+    Array.isArray(receipt.unsupported) ? receipt.unsupported : [],
+  );
+  if (receipt.status !== derivedStatus)
+    add(
+      'overall-status',
+      '/status',
+      `must be ${derivedStatus} for these results`,
+    );
+  if (receipt.ok !== ['pass', 'advisory-fail'].includes(derivedStatus))
+    add('overall-ok', '/ok', 'does not match the derived status');
+  const valid = !issues.some((item) =>
+    [
+      'type',
+      'schema-id',
+      'schema-version',
+      'status',
+      'duplicate-result',
+      'unexpected-result',
+      'action-id',
+      'policy-mode',
+      'missing-result',
+      'plan',
+      'plan-qualification',
+      'plan-skipped',
+      'plan-unsupported',
+      'receipt-digest',
+      'expected-actions',
+      'attempted-actions',
+      'overall-status',
+      'overall-ok',
+    ].includes(item.code),
+  );
+  const qualifying = Boolean(
+    valid &&
+      current &&
+      receipt.qualifying &&
+      plan?.qualifying &&
+      receipt.source?.sha &&
+      !receipt.source?.dirty &&
+      requiredCoverage(receipt.results || []),
+  );
+  if (!plan?.qualifying)
+    add(
+      'diagnostic-selection',
+      '/selection',
+      'explicit gate selection is non-qualifying',
+    );
+  if (!receipt.source?.sha)
+    add(
+      'source-unavailable',
+      '/source/sha',
+      'a Git source SHA is required for qualification',
+    );
+  if (receipt.source?.dirty)
+    add(
+      'dirty-source',
+      '/source/dirty',
+      'a dirty source checkout cannot qualify',
+    );
+  if (!requiredCoverage(receipt.results || []))
+    add(
+      'required-coverage',
+      '/results',
+      'every required action must be attempted and pass',
+    );
+  if (receipt.qualifying && !qualifying)
+    add(
+      'qualification',
+      '/qualifying',
+      'claim is not supported by current complete required coverage',
+    );
+  return { valid, current, qualifying, issues };
+}

--- a/scripts/shifu-gate-executor.test.mjs
+++ b/scripts/shifu-gate-executor.test.mjs
@@ -1,0 +1,310 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import {
+  buildGateActionInvocation,
+  executeGateRun,
+  validateGateReceipt,
+} from './shifu-gate-executor.mjs';
+import {
+  gateDigest,
+  validateGateRegistryBytes,
+} from './shifu-gate-runtime.mjs';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const REGISTRY_REF = 'docs/shifu/examples/gates/execution.gate-registry.json';
+const loaded = validateGateRegistryBytes(
+  fs.readFileSync(path.join(ROOT, REGISTRY_REF)),
+);
+const SOURCE = { sha: 'a'.repeat(40), dirty: false };
+const WRITER = { write() {} };
+
+assert.deepEqual(loaded.issues, []);
+
+/** @param {Record<string, any>} options */
+async function run(options) {
+  return executeGateRun(loaded.registry, {
+    root: ROOT,
+    registryRef: REGISTRY_REF,
+    registryDigest: loaded.digest,
+    source: SOURCE,
+    writer: WRITER,
+    ...options,
+  });
+}
+
+test('explicit multi-gate runs close and deduplicate shared dependencies', async () => {
+  const temporary = fs.mkdtempSync(path.join(os.tmpdir(), 'shifu-gate-test-'));
+  const log = path.join(temporary, 'actions.log');
+  const previous = process.env.SHIFU_GATE_FIXTURE_LOG;
+  process.env.SHIFU_GATE_FIXTURE_LOG = log;
+  try {
+    const receipt = await run({
+      explicitGates: ['fixture.left', 'fixture.right'],
+    });
+    assert.equal(receipt.status, 'pass');
+    assert.equal(receipt.ok, true);
+    assert.equal(receipt.qualifying, false);
+    assert.deepEqual(
+      receipt.results.map((result) => result.gateId),
+      ['fixture.prepare', 'fixture.left', 'fixture.right'],
+    );
+    assert.deepEqual(fs.readFileSync(log, 'utf8').trim().split('\n').sort(), [
+      'fixture.left',
+      'fixture.prepare',
+      'fixture.right',
+    ]);
+  } finally {
+    if (previous === undefined)
+      Reflect.deleteProperty(process.env, 'SHIFU_GATE_FIXTURE_LOG');
+    else process.env.SHIFU_GATE_FIXTURE_LOG = previous;
+    fs.rmSync(temporary, { recursive: true, force: true });
+  }
+});
+
+test('a clean complete profile produces a current qualifying receipt', async () => {
+  const receipt = await run({ profile: 'success' });
+  assert.equal(receipt.status, 'pass');
+  assert.equal(receipt.qualifying, true);
+  assert.deepEqual(
+    receipt.results.map((result) => result.gateId),
+    ['fixture.prepare', 'fixture.left', 'fixture.right', 'fixture.aggregate'],
+  );
+  const validation = validateGateReceipt(receipt, loaded.registry, {
+    root: ROOT,
+    registryRef: REGISTRY_REF,
+    registryDigest: loaded.digest,
+    source: SOURCE,
+  });
+  assert.deepEqual(validation, {
+    valid: true,
+    current: true,
+    qualifying: true,
+    issues: [],
+  });
+  const Ajv2020 = (await import('ajv/dist/2020.js')).default;
+  const validateSchema = new Ajv2020({
+    allErrors: true,
+    strict: false,
+  }).compile(
+    JSON.parse(
+      fs.readFileSync(
+        path.join(ROOT, 'docs/shifu/schema/gate-receipt-v1.schema.json'),
+        'utf8',
+      ),
+    ),
+  );
+  assert.equal(
+    validateSchema(receipt),
+    true,
+    JSON.stringify(validateSchema.errors),
+  );
+});
+
+test('advisory failures remain visible without blocking required qualification', async () => {
+  const receipt = await run({ profile: 'advisory', includeAdvisory: true });
+  assert.equal(receipt.status, 'advisory-fail');
+  assert.equal(receipt.ok, true);
+  assert.equal(receipt.qualifying, true);
+  assert.equal(
+    receipt.results.find((result) => result.gateId === 'fixture.fail').status,
+    'advisory-fail',
+  );
+});
+
+test('required failures keep a copyable single-gate reproduction argv', async () => {
+  const receipt = await run({ profile: 'required-failure' });
+  assert.equal(receipt.status, 'fail');
+  assert.equal(receipt.ok, false);
+  assert.equal(receipt.qualifying, false);
+  const failed = receipt.results.find(
+    (result) => result.gateId === 'fixture.fail',
+  );
+  assert.deepEqual(failed.reproduce.argv.slice(0, 3), [
+    './shifu',
+    'gate',
+    'run',
+  ]);
+});
+
+test('required gate-specific evidence is enforced without embedding its content', async () => {
+  const passed = await run({ profile: 'evidence-success' });
+  assert.equal(passed.status, 'pass');
+  assert.equal(passed.results[0].evidence.present, true);
+  assert.deepEqual(passed.results[0].evidence.pointers, [
+    { id: 'fixture-report', ref: 'build/fixture/report.json' },
+  ]);
+
+  const missing = await run({ profile: 'evidence-missing' });
+  assert.equal(missing.status, 'fail');
+  assert.match(missing.results[0].reason, /required gate evidence/);
+});
+
+test('unsafe evidence refs and inherited environment values cannot enter receipts', async () => {
+  const registry = structuredClone(loaded.registry);
+  const gate = registry.gates.find((item) => item.id === 'fixture.evidence');
+  gate.action = { kind: 'handler', handler: 'fixture.unsafe-evidence' };
+  const secret = 'do-not-store-this-sentinel';
+  const previous = process.env.SHIFU_GATE_SECRET_SENTINEL;
+  process.env.SHIFU_GATE_SECRET_SENTINEL = secret;
+  try {
+    const receipt = await executeGateRun(registry, {
+      root: ROOT,
+      registryRef: REGISTRY_REF,
+      registryDigest: gateDigest(registry),
+      profile: 'evidence-success',
+      source: SOURCE,
+      writer: WRITER,
+      handlers: {
+        'fixture.unsafe-evidence': async () => ({
+          status: 'pass',
+          evidence: {
+            schema: 'fixture.evidence/v1',
+            pointers: [
+              {
+                id: 'unsafe',
+                ref: 'https://example.invalid/report?token=secret',
+              },
+            ],
+          },
+        }),
+      },
+    });
+    assert.equal(receipt.status, 'error');
+    assert.match(receipt.results[0].reason, /safe repository-relative ref/);
+    assert.doesNotMatch(JSON.stringify(receipt), new RegExp(secret));
+    assert.doesNotMatch(JSON.stringify(receipt), /token=secret/);
+  } finally {
+    if (previous === undefined)
+      Reflect.deleteProperty(process.env, 'SHIFU_GATE_SECRET_SENTINEL');
+    else process.env.SHIFU_GATE_SECRET_SENTINEL = previous;
+  }
+});
+
+test('a required handler skip is non-successful and non-qualifying', async () => {
+  const registry = structuredClone(loaded.registry);
+  const gate = registry.gates.find((item) => item.id === 'fixture.evidence');
+  gate.action = { kind: 'handler', handler: 'fixture.skip' };
+  const receipt = await executeGateRun(registry, {
+    root: ROOT,
+    registryRef: REGISTRY_REF,
+    registryDigest: gateDigest(registry),
+    profile: 'evidence-success',
+    source: SOURCE,
+    writer: WRITER,
+    handlers: {
+      'fixture.skip': async () => ({
+        status: 'skip',
+        reason: 'not applicable',
+      }),
+    },
+  });
+  assert.equal(receipt.status, 'skip');
+  assert.equal(receipt.ok, false);
+  assert.equal(receipt.qualifying, false);
+});
+
+test('handler reasons are bounded and redact paths, URLs and secret-like assignments', async () => {
+  const registry = structuredClone(loaded.registry);
+  const gate = registry.gates.find((item) => item.id === 'fixture.evidence');
+  gate.action = { kind: 'handler', handler: 'fixture.error' };
+  const receipt = await executeGateRun(registry, {
+    root: ROOT,
+    registryRef: REGISTRY_REF,
+    registryDigest: gateDigest(registry),
+    profile: 'evidence-success',
+    source: SOURCE,
+    writer: WRITER,
+    handlers: {
+      'fixture.error': async () => ({
+        status: 'error',
+        reason: `${ROOT}/private.log https://example.invalid/a?token=x token=hidden`,
+      }),
+    },
+  });
+  const serialized = JSON.stringify(receipt);
+  assert.doesNotMatch(serialized, new RegExp(ROOT.replaceAll('/', '\\/')));
+  assert.doesNotMatch(serialized, /example\.invalid|token=x|token=hidden/);
+  assert.match(receipt.results[0].reason, /redacted/);
+});
+
+test('timeouts are bounded and recorded as errors', async () => {
+  const receipt = await run({ profile: 'timeout' });
+  assert.equal(receipt.status, 'error');
+  assert.equal(receipt.results[0].status, 'error');
+  assert.match(receipt.results[0].reason, /timed out/);
+});
+
+test('task actions re-enter an existing lightweight Shifu task', async () => {
+  const receipt = await run({ profile: 'task-dogfood' });
+  assert.equal(receipt.status, 'pass');
+  assert.equal(receipt.results[0].gateId, 'fixture.task-dogfood');
+  assert.equal(receipt.results[0].attempted, true);
+});
+
+test('stale source, changed definitions and incomplete coverage fail receipt reuse', async () => {
+  const receipt = await run({ profile: 'success' });
+  const stale = validateGateReceipt(receipt, loaded.registry, {
+    root: ROOT,
+    registryRef: REGISTRY_REF,
+    registryDigest: loaded.digest,
+    source: { sha: 'b'.repeat(40), dirty: false },
+  });
+  assert.equal(stale.current, false);
+  assert.equal(stale.qualifying, false);
+  assert.ok(stale.issues.some((issue) => issue.code === 'stale-source'));
+
+  const changed = structuredClone(receipt);
+  changed.results[0].definitionDigest = `sha256:${'0'.repeat(64)}`;
+  const changedValidation = validateGateReceipt(changed, loaded.registry, {
+    root: ROOT,
+    registryRef: REGISTRY_REF,
+    registryDigest: loaded.digest,
+    source: SOURCE,
+  });
+  assert.equal(changedValidation.current, false);
+  assert.equal(changedValidation.qualifying, false);
+  assert.ok(
+    changedValidation.issues.some(
+      (issue) => issue.code === 'definition-digest',
+    ),
+  );
+
+  const incomplete = structuredClone(receipt);
+  incomplete.results.pop();
+  const incompleteValidation = validateGateReceipt(
+    incomplete,
+    loaded.registry,
+    {
+      root: ROOT,
+      registryRef: REGISTRY_REF,
+      registryDigest: loaded.digest,
+      source: SOURCE,
+    },
+  );
+  assert.equal(incompleteValidation.valid, false);
+  assert.equal(incompleteValidation.qualifying, false);
+  assert.ok(
+    incompleteValidation.issues.some(
+      (issue) => issue.code === 'missing-result',
+    ),
+  );
+});
+
+test('task invocation uses the native Shifu entrypoint on POSIX and cmd.exe on Windows', () => {
+  const action = { kind: 'task', task: 'check:source', args: ['--example'] };
+  assert.deepEqual(buildGateActionInvocation(action, '/repo', 'linux'), {
+    command: '/repo/shifu',
+    args: ['check:source', '--example'],
+  });
+  const windows = buildGateActionInvocation(action, 'C:\\repo', 'windows');
+  assert.match(windows.command.toLowerCase(), /cmd(?:\.exe)?$/);
+  assert.deepEqual(windows.args.slice(0, 3), ['/d', '/s', '/c']);
+  assert.match(windows.args[3], /shifu\.cmd/);
+});

--- a/scripts/shifu-gate-runtime.mjs
+++ b/scripts/shifu-gate-runtime.mjs
@@ -9,6 +9,8 @@ export const GATE_REGISTRY_SCHEMA =
   'https://libkungfu.dev/schemas/shifu/gate-registry-v1.schema.json';
 export const GATE_PLAN_SCHEMA =
   'https://libkungfu.dev/schemas/shifu/gate-plan-v1.schema.json';
+export const GATE_RECEIPT_SCHEMA =
+  'https://libkungfu.dev/schemas/shifu/gate-receipt-v1.schema.json';
 
 const ID = /^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*$/;
 const MODES = new Set(['required', 'advisory', 'off']);
@@ -31,6 +33,32 @@ const ACTION_KEYS = {
 /** @param {unknown} value @returns {value is Record<string, any>} */
 function object(value) {
   return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+/** @param {unknown} value @returns {string} */
+export function stableJson(value) {
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(',')}]`;
+  if (object(value))
+    return `{${Object.keys(value)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${stableJson(value[key])}`)
+      .join(',')}}`;
+  return JSON.stringify(value) ?? 'null';
+}
+
+/** @param {unknown} value */
+export function gateDigest(value) {
+  return `sha256:${crypto.createHash('sha256').update(stableJson(value)).digest('hex')}`;
+}
+
+/** @param {Gate} gate */
+export function gateDefinitionDigest(gate) {
+  return gateDigest(gate);
+}
+
+/** @param {Gate} gate */
+export function gateActionId(gate) {
+  return gateDigest({ gateId: gate.id, action: gate.action });
 }
 
 /** @param {GateIssue[]} issues @param {string} code @param {string} at @param {string} message */
@@ -204,7 +232,21 @@ function validateGate(issues, gate, at) {
         if (!exactKeys(issues, artifact, itemAt, ['id', 'path', 'required']))
           return;
         stringField(issues, artifact.id, `${itemAt}/id`, { id: true });
-        stringField(issues, artifact.path, `${itemAt}/path`);
+        if (stringField(issues, artifact.path, `${itemAt}/path`)) {
+          const artifactPath = artifact.path;
+          if (
+            path.posix.isAbsolute(artifactPath) ||
+            path.win32.isAbsolute(artifactPath) ||
+            /^[a-z][a-z0-9+.-]*:/i.test(artifactPath) ||
+            artifactPath.split(/[\\/]/).includes('..')
+          )
+            issue(
+              issues,
+              'artifact-path',
+              `${itemAt}/path`,
+              'must be a repository-relative path without traversal',
+            );
+        }
         if (typeof artifact.required !== 'boolean')
           issue(issues, 'type', `${itemAt}/required`, 'must be boolean');
         if (artifactIds.has(artifact.id))
@@ -641,6 +683,10 @@ export function buildGatePlan(
             runner: gate.runner,
             cost: gate.cost,
             action: gate.action,
+            actionId: gateActionId(gate),
+            definitionDigest: gateDefinitionDigest(gate),
+            artifacts: gate.artifacts,
+            receipt: gate.receipt,
           };
         }),
       });

--- a/scripts/shifu-gate-runtime.test.mjs
+++ b/scripts/shifu-gate-runtime.test.mjs
@@ -45,6 +45,11 @@ for (const [label, args, source] of [
     ['schema', 'plan'],
     'docs/shifu/schema/gate-plan-v1.schema.json',
   ],
+  [
+    'receipt schema',
+    ['schema', 'receipt'],
+    'docs/shifu/schema/gate-receipt-v1.schema.json',
+  ],
 ]) {
   test(`shifu exposes the exact checked-in Gate ${label}`, () => {
     const result = gate(args);
@@ -148,6 +153,38 @@ test('required unsupported gates fail the plan without pretending to skip', () =
   assert.deepEqual(
     plan.unsupported.map((item) => item.id),
     ['native.smoke'],
+  );
+});
+
+test('explicit gate execution emits a non-qualifying unified receipt', () => {
+  const executionRegistry = path.join(
+    ROOT,
+    'docs',
+    'shifu',
+    'examples',
+    'gates',
+    'execution.gate-registry.json',
+  );
+  const result = gate([
+    'run',
+    'fixture.left',
+    'fixture.right',
+    '--registry',
+    executionRegistry,
+    '--json',
+  ]);
+  assert.equal(result.status, 0, result.stderr);
+  const receipt = JSON.parse(result.stdout);
+  assert.equal(receipt.schema, 'shifu.gate-receipt/v1');
+  assert.equal(receipt.status, 'pass');
+  assert.equal(receipt.qualifying, false);
+  assert.equal(
+    receipt.registry.ref,
+    'docs/shifu/examples/gates/execution.gate-registry.json',
+  );
+  assert.deepEqual(
+    receipt.results.map((item) => item.gateId),
+    ['fixture.prepare', 'fixture.left', 'fixture.right'],
   );
 });
 

--- a/scripts/source-acceptance.mjs
+++ b/scripts/source-acceptance.mjs
@@ -102,6 +102,7 @@ export function sourceAcceptancePlan(files) {
         'scripts/shifu-cache-runtime.test.mjs',
         'scripts/shifu-uv-cache-adapter.test.mjs',
         'scripts/shifu-gate-runtime.test.mjs',
+        'scripts/shifu-gate-executor.test.mjs',
         'scripts/check-schema-authority.test.mjs',
       ],
     },

--- a/tests/fixtures/shifu-gates/run.mjs
+++ b/tests/fixtures/shifu-gates/run.mjs
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from 'node:fs';
+
+const [mode = 'pass', id = 'fixture.unknown'] = process.argv.slice(2);
+if (process.env.SHIFU_GATE_FIXTURE_LOG)
+  fs.appendFileSync(process.env.SHIFU_GATE_FIXTURE_LOG, `${id}\n`);
+
+if (mode === 'fail') process.exitCode = 7;
+else if (mode === 'evidence') {
+  if (!process.env.SHIFU_GATE_EVIDENCE_FILE)
+    throw new Error('SHIFU_GATE_EVIDENCE_FILE is required');
+  fs.writeFileSync(
+    process.env.SHIFU_GATE_EVIDENCE_FILE,
+    `${JSON.stringify({
+      schema: 'fixture.evidence/v1',
+      pointers: [{ id: 'fixture-report', ref: 'build/fixture/report.json' }],
+    })}\n`,
+  );
+} else if (mode === 'slow') await new Promise((resolve) => setTimeout(resolve, 2500));


### PR DESCRIPTION
## Summary

Add the Shifu Gate execution and receipt layer so registered gates can be run individually or by profile, with source-bound evidence that downstream policy can validate and reuse.

## Related issue

SHIFU-ADR-0004

## Changes

- add `shifu gate run` for explicit diagnostic selections and full profile execution
- execute dependency-closed gates through native Shifu tasks, argv actions, or named handlers
- emit strict Gate receipt v1 evidence with source, definition, action, artifact, coverage, and integrity bindings
- add `shifu gate receipt validate` with fail-closed freshness and qualification checks
- preserve advisory visibility while blocking required failures, skips, unsupported capabilities, timeouts, stale source, and incomplete evidence
- redact paths, URLs, secrets, child output, and inherited environment values from receipts
- cover POSIX and Windows launcher construction plus real existing-task dogfood

## Verification

- `./shifu check`
- `./shifu check:source`
- `./shifu gate run --profile task-dogfood --registry docs/shifu/examples/gates/execution.gate-registry.json --receipt build/gate-receipts/task-dogfood-clean.json --overwrite`
- `./shifu gate receipt validate build/gate-receipts/task-dogfood-clean.json --registry docs/shifu/examples/gates/execution.gate-registry.json --json` returned valid/current/qualifying true

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "stage-ready",
  "adrs": ["SHIFU-ADR-0004"],
  "summary": "Complete the Gate v1 execution and source-bound receipt stage without migrating Kungfu gate catalogs or release workflows",
  "verification": ["./shifu check", "./shifu check:source", "clean-source qualifying Gate receipt dogfood"]
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

This stage defines and validates reusable gate evidence. It does not migrate release workflows, publish artifacts, modify branch protection, or perform a release. Receipt tests explicitly prove that secret-like values, inherited environment values, child output, URLs, and absolute paths are not retained.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed
