### PR TITLE
feat(profile): productize KFD-3 qualification badges

### DIFF
--- a/.buildchain/kfd/kfd-2/claims/agent-onboarding-pack.json
+++ b/.buildchain/kfd/kfd-2/claims/agent-onboarding-pack.json
@@ -16,7 +16,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "bda8d6e263a534ad74a1984293278910c69b94e59232c0e0a4c5d2746b2b431b"
+        "sha256": "02942a5d32b38624583918d2126b71c9aa61670723fd64cabc8ba7381fd957a4"
       },
       "description": "Machine-readable command catalog and mode maturity metadata."
     },
@@ -54,7 +54,7 @@
     "evidenceSha256": [
       {
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "bda8d6e263a534ad74a1984293278910c69b94e59232c0e0a4c5d2746b2b431b"
+        "sha256": "02942a5d32b38624583918d2126b71c9aa61670723fd64cabc8ba7381fd957a4"
       },
       {
         "path": "framework/core/src/python/kungfu/agent/mode-selection.md",
@@ -76,7 +76,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "bda8d6e263a534ad74a1984293278910c69b94e59232c0e0a4c5d2746b2b431b"
+        "sha256": "02942a5d32b38624583918d2126b71c9aa61670723fd64cabc8ba7381fd957a4"
       }
     ]
   },
@@ -90,7 +90,7 @@
     {
       "name": "agent-command-catalog",
       "path": "framework/core/src/python/kungfu/agent/commands.json",
-      "sha256": "bda8d6e263a534ad74a1984293278910c69b94e59232c0e0a4c5d2746b2b431b",
+      "sha256": "02942a5d32b38624583918d2126b71c9aa61670723fd64cabc8ba7381fd957a4",
       "expectedPackagePath": "kungfu/agent/commands.json"
     }
   ],

--- a/.buildchain/kfd/kfd-2/claims/remote-fact-boundary.json
+++ b/.buildchain/kfd/kfd-2/claims/remote-fact-boundary.json
@@ -34,7 +34,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "bda8d6e263a534ad74a1984293278910c69b94e59232c0e0a4c5d2746b2b431b"
+        "sha256": "02942a5d32b38624583918d2126b71c9aa61670723fd64cabc8ba7381fd957a4"
       },
       "description": "Remote add/sync command declarations and mode metadata."
     },
@@ -62,7 +62,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "bda8d6e263a534ad74a1984293278910c69b94e59232c0e0a4c5d2746b2b431b"
+        "sha256": "02942a5d32b38624583918d2126b71c9aa61670723fd64cabc8ba7381fd957a4"
       },
       {
         "path": "framework/core/src/python/kungfu/cli/commands/agent.py",

--- a/.buildchain/kfd/kfd-2/release-claims.json
+++ b/.buildchain/kfd/kfd-2/release-claims.json
@@ -29,7 +29,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/commands.json",
-            "sha256": "bda8d6e263a534ad74a1984293278910c69b94e59232c0e0a4c5d2746b2b431b"
+            "sha256": "02942a5d32b38624583918d2126b71c9aa61670723fd64cabc8ba7381fd957a4"
           },
           "description": "Machine-readable command catalog and mode maturity metadata."
         },
@@ -194,7 +194,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/commands.json",
-            "sha256": "bda8d6e263a534ad74a1984293278910c69b94e59232c0e0a4c5d2746b2b431b"
+            "sha256": "02942a5d32b38624583918d2126b71c9aa61670723fd64cabc8ba7381fd957a4"
           },
           "description": "Remote add/sync command declarations and mode metadata."
         },

--- a/.buildchain/kfd/kfd-3/capability-query.json
+++ b/.buildchain/kfd/kfd-3/capability-query.json
@@ -342,7 +342,7 @@
     },
     {
       "id": "kungfu.atlas.assess-mission",
-      "kind": "cli",
+      "kind": "cli-api-gui",
       "name": "kungfu atlas assess-mission <mission-id> --json",
       "state": "declared",
       "detected": true,
@@ -353,7 +353,7 @@
         "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
         "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
         "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
-        "digest": "sha256:18732621727384f63583180de30ad73e6b01b284c3142b64550bb671cddda8a0"
+        "digest": "sha256:3c1d7318b6fc9b9eb8c5f52cd53b4b1126d777e681b4987a6206add5296f50a3"
       },
       "kfd2Trust": {
         "status": "release-passport-required",
@@ -364,7 +364,7 @@
     },
     {
       "id": "kungfu.atlas.claim-completion",
-      "kind": "cli",
+      "kind": "cli-api-gui",
       "name": "kungfu atlas claim-completion <mission-id> <goal-id> --statement <statement> --actor <actor> --evidence-episode <id> --json",
       "state": "declared",
       "detected": true,
@@ -375,7 +375,7 @@
         "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
         "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
         "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
-        "digest": "sha256:921fcf00d2662aee3c3cd91f6f533b0ca4fbc590c53624c0cd3b71b7c3b08be9"
+        "digest": "sha256:848932158e11e1a3edf933849047b0e52e021170b5639150fa0f971ac75eba81"
       },
       "kfd2Trust": {
         "status": "release-passport-required",
@@ -386,7 +386,7 @@
     },
     {
       "id": "kungfu.atlas.create-go",
-      "kind": "cli",
+      "kind": "cli-api-gui",
       "name": "kungfu atlas create-go <mission-id> <goal-id> --title <title> --objective <objective> --actor <actor> --json",
       "state": "declared",
       "detected": true,
@@ -397,7 +397,7 @@
         "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
         "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
         "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
-        "digest": "sha256:ba0a27d56056dad1ecdf1f3ab4ae443462e35a2a0fba7936d516f3239217b1f1"
+        "digest": "sha256:1b4238feb27a0cd942e84fe416698f9040c8f81d41e9450d6a21b8bde568f483"
       },
       "kfd2Trust": {
         "status": "release-passport-required",
@@ -408,7 +408,7 @@
     },
     {
       "id": "kungfu.atlas.create-mission",
-      "kind": "cli",
+      "kind": "cli-api-gui",
       "name": "kungfu atlas create-mission <mission-id> --title <title> --intent <intent> --actor <actor> --json",
       "state": "declared",
       "detected": true,
@@ -419,7 +419,7 @@
         "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
         "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
         "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
-        "digest": "sha256:3e042c16ff593bc0619fd94d1ef0d11756e49c5a4a3f9a8206cf638245864755"
+        "digest": "sha256:d0107091a72e92e438f8227ef994dbc0a56ae464cf3c5b5150290a4cfeecc32f"
       },
       "kfd2Trust": {
         "status": "release-passport-required",
@@ -1201,7 +1201,7 @@
     {
       "id": "kungfu.profile.kfd3-qualification",
       "kind": "cli-api-gui",
-      "name": "kungfu profile kfd3-qualify <source> --json",
+      "name": "kungfu profile kfd3-status <source> --json",
       "state": "declared",
       "detected": true,
       "enforced": false,
@@ -1211,7 +1211,7 @@
         "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
         "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
         "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
-        "digest": "sha256:30d3b2e58ff0fab319ea2616e3d83980f6d3df47cf4914904b04f7bf1c6348b1"
+        "digest": "sha256:6a7a03a7e8edee45df419269b519b462506026d8a3dfbb4ae377798aed24dcbb"
       },
       "kfd2Trust": {
         "status": "release-passport-required",

--- a/.buildchain/kfd/kfd-3/collaboration-interface.artifact.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.artifact.json
@@ -10,8 +10,8 @@
   "sourceRegistry": {
     "id": "kungfu",
     "path": ".buildchain/kfd/kfd-3/surfaces.json",
-    "sha256": "91a1834bffe506c8441fd346d9bde560ded1518ff7479ba58a9eef446ea163f2",
-    "digest": "sha256:6f9269cdf112d9e3620523a94a6f59d2a2d7d1737124b91783aead0a752faa24"
+    "sha256": "8b218deb8ef2026c4f227a9c97ebae20a4cf7b0da74f077c10662b0b39046ba6",
+    "digest": "sha256:8905961fd705da6a0e7fc37793f0d7a669da0bf7cfce0bab3e20a52c4bc14dd1"
   },
   "upstreamKfd": {
     "aggregatePath": "developer/sdk/kfd/upstream-aggregate.json",
@@ -28,7 +28,7 @@
     },
     "digest": "sha256:a86ddd8755809f5337e11023a8218d513c87d58077265007f1d207ef957f4761"
   },
-  "collaborationInterfaceDigest": "sha256:422e526497783da6fba46ab18dd94e4b2d9980e2e1933219a1a1e1ddc2936421",
+  "collaborationInterfaceDigest": "sha256:59a7ac3b073d9e326fe563684f1b7392eb50e727a60d5ac7ed6eec5befa1dbca",
   "exposedSurfaces": [
     {
       "id": "kungfu.agent",
@@ -333,7 +333,7 @@
     {
       "id": "kungfu.atlas.assess-mission",
       "name": "kungfu atlas assess-mission <mission-id> --json",
-      "kind": "cli",
+      "kind": "cli-api-gui",
       "participantProfile": "agent-or-developer",
       "state": "declared",
       "availability": "shipped",
@@ -353,7 +353,7 @@
     {
       "id": "kungfu.atlas.claim-completion",
       "name": "kungfu atlas claim-completion <mission-id> <goal-id> --statement <statement> --actor <actor> --evidence-episode <id> --json",
-      "kind": "cli",
+      "kind": "cli-api-gui",
       "participantProfile": "agent-or-developer",
       "state": "declared",
       "availability": "shipped",
@@ -373,7 +373,7 @@
     {
       "id": "kungfu.atlas.create-go",
       "name": "kungfu atlas create-go <mission-id> <goal-id> --title <title> --objective <objective> --actor <actor> --json",
-      "kind": "cli",
+      "kind": "cli-api-gui",
       "participantProfile": "agent-or-developer",
       "state": "declared",
       "availability": "shipped",
@@ -393,7 +393,7 @@
     {
       "id": "kungfu.atlas.create-mission",
       "name": "kungfu atlas create-mission <mission-id> --title <title> --intent <intent> --actor <actor> --json",
-      "kind": "cli",
+      "kind": "cli-api-gui",
       "participantProfile": "agent-or-developer",
       "state": "declared",
       "availability": "shipped",
@@ -1137,7 +1137,7 @@
     },
     {
       "id": "kungfu.profile.kfd3-qualification",
-      "name": "kungfu profile kfd3-qualify <source> --json",
+      "name": "kungfu profile kfd3-status <source> --json",
       "kind": "cli-api-gui",
       "participantProfile": "agent-or-developer",
       "state": "declared",

--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -5,16 +5,16 @@
   "witnessKind": "prebuild",
   "supportLevel": "release",
   "source": {
-    "cwd": "/Users/dkr/Worktrees/kungfu/docs/docs-directory-hierarchy",
-    "sourceSha": "9767a5c0e6d245d31621dacba17afde6c91003f4",
+    "cwd": "/Users/dkr/Worktrees/kungfu/feature/profile-kfd3-badge-agent-status",
+    "sourceSha": "afec2c6bc5a7017920c0a12401c0461d9eaf04de",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
-    "registryDigest": "sha256:6f9269cdf112d9e3620523a94a6f59d2a2d7d1737124b91783aead0a752faa24"
+    "registryDigest": "sha256:8905961fd705da6a0e7fc37793f0d7a669da0bf7cfce0bab3e20a52c4bc14dd1"
   },
   "sourceRegistry": {
     "id": "kungfu",
     "path": ".buildchain/kfd/kfd-3/surfaces.json",
-    "sha256": "91a1834bffe506c8441fd346d9bde560ded1518ff7479ba58a9eef446ea163f2",
-    "digest": "sha256:6f9269cdf112d9e3620523a94a6f59d2a2d7d1737124b91783aead0a752faa24"
+    "sha256": "8b218deb8ef2026c4f227a9c97ebae20a4cf7b0da74f077c10662b0b39046ba6",
+    "digest": "sha256:8905961fd705da6a0e7fc37793f0d7a669da0bf7cfce0bab3e20a52c4bc14dd1"
   },
   "upstreamKfd": {
     "aggregatePath": "developer/sdk/kfd/upstream-aggregate.json",
@@ -34,7 +34,7 @@
   "expectedArtifactVerification": {
     "command": "node scripts/buildchain-kfd-evidence.mjs --artifact-witness --json"
   },
-  "collaborationInterfaceDigest": "sha256:422e526497783da6fba46ab18dd94e4b2d9980e2e1933219a1a1e1ddc2936421",
+  "collaborationInterfaceDigest": "sha256:59a7ac3b073d9e326fe563684f1b7392eb50e727a60d5ac7ed6eec5befa1dbca",
   "collaborationInterface": {
     "schemaVersion": 1,
     "contract": "kungfu-buildchain-kfd-3-surface-registry",
@@ -363,7 +363,7 @@
       {
         "id": "kungfu.atlas.assess-mission",
         "name": "kungfu atlas assess-mission <mission-id> --json",
-        "kind": "cli",
+        "kind": "cli-api-gui",
         "participantProfile": "agent-or-developer",
         "state": "declared",
         "availability": "shipped",
@@ -383,7 +383,7 @@
       {
         "id": "kungfu.atlas.claim-completion",
         "name": "kungfu atlas claim-completion <mission-id> <goal-id> --statement <statement> --actor <actor> --evidence-episode <id> --json",
-        "kind": "cli",
+        "kind": "cli-api-gui",
         "participantProfile": "agent-or-developer",
         "state": "declared",
         "availability": "shipped",
@@ -403,7 +403,7 @@
       {
         "id": "kungfu.atlas.create-go",
         "name": "kungfu atlas create-go <mission-id> <goal-id> --title <title> --objective <objective> --actor <actor> --json",
-        "kind": "cli",
+        "kind": "cli-api-gui",
         "participantProfile": "agent-or-developer",
         "state": "declared",
         "availability": "shipped",
@@ -423,7 +423,7 @@
       {
         "id": "kungfu.atlas.create-mission",
         "name": "kungfu atlas create-mission <mission-id> --title <title> --intent <intent> --actor <actor> --json",
-        "kind": "cli",
+        "kind": "cli-api-gui",
         "participantProfile": "agent-or-developer",
         "state": "declared",
         "availability": "shipped",
@@ -1167,7 +1167,7 @@
       },
       {
         "id": "kungfu.profile.kfd3-qualification",
-        "name": "kungfu profile kfd3-qualify <source> --json",
+        "name": "kungfu profile kfd3-status <source> --json",
         "kind": "cli-api-gui",
         "participantProfile": "agent-or-developer",
         "state": "declared",
@@ -2484,7 +2484,7 @@
     {
       "id": "kungfu.atlas.assess-mission",
       "name": "kungfu atlas assess-mission <mission-id> --json",
-      "kind": "cli",
+      "kind": "cli-api-gui",
       "participantProfile": "agent-or-developer",
       "state": "declared",
       "availability": "shipped",
@@ -2504,7 +2504,7 @@
     {
       "id": "kungfu.atlas.claim-completion",
       "name": "kungfu atlas claim-completion <mission-id> <goal-id> --statement <statement> --actor <actor> --evidence-episode <id> --json",
-      "kind": "cli",
+      "kind": "cli-api-gui",
       "participantProfile": "agent-or-developer",
       "state": "declared",
       "availability": "shipped",
@@ -2524,7 +2524,7 @@
     {
       "id": "kungfu.atlas.create-go",
       "name": "kungfu atlas create-go <mission-id> <goal-id> --title <title> --objective <objective> --actor <actor> --json",
-      "kind": "cli",
+      "kind": "cli-api-gui",
       "participantProfile": "agent-or-developer",
       "state": "declared",
       "availability": "shipped",
@@ -2544,7 +2544,7 @@
     {
       "id": "kungfu.atlas.create-mission",
       "name": "kungfu atlas create-mission <mission-id> --title <title> --intent <intent> --actor <actor> --json",
-      "kind": "cli",
+      "kind": "cli-api-gui",
       "participantProfile": "agent-or-developer",
       "state": "declared",
       "availability": "shipped",
@@ -3288,7 +3288,7 @@
     },
     {
       "id": "kungfu.profile.kfd3-qualification",
-      "name": "kungfu profile kfd3-qualify <source> --json",
+      "name": "kungfu profile kfd3-status <source> --json",
       "kind": "cli-api-gui",
       "participantProfile": "agent-or-developer",
       "state": "declared",

--- a/.buildchain/kfd/kfd-3/surfaces.json
+++ b/.buildchain/kfd/kfd-3/surfaces.json
@@ -371,7 +371,7 @@
     {
       "id": "kungfu.atlas.assess-mission",
       "name": "kungfu atlas assess-mission <mission-id> --json",
-      "kind": "cli",
+      "kind": "cli-api-gui",
       "participantProfile": "agent-or-developer",
       "state": "declared",
       "availability": "shipped",
@@ -391,7 +391,7 @@
     {
       "id": "kungfu.atlas.claim-completion",
       "name": "kungfu atlas claim-completion <mission-id> <goal-id> --statement <statement> --actor <actor> --evidence-episode <id> --json",
-      "kind": "cli",
+      "kind": "cli-api-gui",
       "participantProfile": "agent-or-developer",
       "state": "declared",
       "availability": "shipped",
@@ -411,7 +411,7 @@
     {
       "id": "kungfu.atlas.create-go",
       "name": "kungfu atlas create-go <mission-id> <goal-id> --title <title> --objective <objective> --actor <actor> --json",
-      "kind": "cli",
+      "kind": "cli-api-gui",
       "participantProfile": "agent-or-developer",
       "state": "declared",
       "availability": "shipped",
@@ -431,7 +431,7 @@
     {
       "id": "kungfu.atlas.create-mission",
       "name": "kungfu atlas create-mission <mission-id> --title <title> --intent <intent> --actor <actor> --json",
-      "kind": "cli",
+      "kind": "cli-api-gui",
       "participantProfile": "agent-or-developer",
       "state": "declared",
       "availability": "shipped",
@@ -1175,7 +1175,7 @@
     },
     {
       "id": "kungfu.profile.kfd3-qualification",
-      "name": "kungfu profile kfd3-qualify <source> --json",
+      "name": "kungfu profile kfd3-status <source> --json",
       "kind": "cli-api-gui",
       "participantProfile": "agent-or-developer",
       "state": "declared",

--- a/developer/sdk/kfd/kfd-2/claims/agent-onboarding-pack.json
+++ b/developer/sdk/kfd/kfd-2/claims/agent-onboarding-pack.json
@@ -16,7 +16,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "bda8d6e263a534ad74a1984293278910c69b94e59232c0e0a4c5d2746b2b431b"
+        "sha256": "02942a5d32b38624583918d2126b71c9aa61670723fd64cabc8ba7381fd957a4"
       },
       "description": "Machine-readable command catalog and mode maturity metadata."
     },
@@ -54,7 +54,7 @@
     "evidenceSha256": [
       {
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "bda8d6e263a534ad74a1984293278910c69b94e59232c0e0a4c5d2746b2b431b"
+        "sha256": "02942a5d32b38624583918d2126b71c9aa61670723fd64cabc8ba7381fd957a4"
       },
       {
         "path": "framework/core/src/python/kungfu/agent/mode-selection.md",
@@ -76,7 +76,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "bda8d6e263a534ad74a1984293278910c69b94e59232c0e0a4c5d2746b2b431b"
+        "sha256": "02942a5d32b38624583918d2126b71c9aa61670723fd64cabc8ba7381fd957a4"
       }
     ]
   },
@@ -90,7 +90,7 @@
     {
       "name": "agent-command-catalog",
       "path": "framework/core/src/python/kungfu/agent/commands.json",
-      "sha256": "bda8d6e263a534ad74a1984293278910c69b94e59232c0e0a4c5d2746b2b431b",
+      "sha256": "02942a5d32b38624583918d2126b71c9aa61670723fd64cabc8ba7381fd957a4",
       "expectedPackagePath": "kungfu/agent/commands.json"
     }
   ],

--- a/developer/sdk/kfd/kfd-2/claims/remote-fact-boundary.json
+++ b/developer/sdk/kfd/kfd-2/claims/remote-fact-boundary.json
@@ -34,7 +34,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "bda8d6e263a534ad74a1984293278910c69b94e59232c0e0a4c5d2746b2b431b"
+        "sha256": "02942a5d32b38624583918d2126b71c9aa61670723fd64cabc8ba7381fd957a4"
       },
       "description": "Remote add/sync command declarations and mode metadata."
     },
@@ -62,7 +62,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "bda8d6e263a534ad74a1984293278910c69b94e59232c0e0a4c5d2746b2b431b"
+        "sha256": "02942a5d32b38624583918d2126b71c9aa61670723fd64cabc8ba7381fd957a4"
       },
       {
         "path": "framework/core/src/python/kungfu/cli/commands/agent.py",

--- a/developer/sdk/kfd/kfd-2/release-claims.json
+++ b/developer/sdk/kfd/kfd-2/release-claims.json
@@ -29,7 +29,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/commands.json",
-            "sha256": "bda8d6e263a534ad74a1984293278910c69b94e59232c0e0a4c5d2746b2b431b"
+            "sha256": "02942a5d32b38624583918d2126b71c9aa61670723fd64cabc8ba7381fd957a4"
           },
           "description": "Machine-readable command catalog and mode maturity metadata."
         },
@@ -194,7 +194,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/commands.json",
-            "sha256": "bda8d6e263a534ad74a1984293278910c69b94e59232c0e0a4c5d2746b2b431b"
+            "sha256": "02942a5d32b38624583918d2126b71c9aa61670723fd64cabc8ba7381fd957a4"
           },
           "description": "Remote add/sync command declarations and mode metadata."
         },

--- a/developer/sdk/kfd/kfd-3-surfaces.json
+++ b/developer/sdk/kfd/kfd-3-surfaces.json
@@ -371,7 +371,7 @@
     {
       "id": "kungfu.atlas.assess-mission",
       "name": "kungfu atlas assess-mission <mission-id> --json",
-      "kind": "cli",
+      "kind": "cli-api-gui",
       "participantProfile": "agent-or-developer",
       "state": "declared",
       "availability": "shipped",
@@ -391,7 +391,7 @@
     {
       "id": "kungfu.atlas.claim-completion",
       "name": "kungfu atlas claim-completion <mission-id> <goal-id> --statement <statement> --actor <actor> --evidence-episode <id> --json",
-      "kind": "cli",
+      "kind": "cli-api-gui",
       "participantProfile": "agent-or-developer",
       "state": "declared",
       "availability": "shipped",
@@ -411,7 +411,7 @@
     {
       "id": "kungfu.atlas.create-go",
       "name": "kungfu atlas create-go <mission-id> <goal-id> --title <title> --objective <objective> --actor <actor> --json",
-      "kind": "cli",
+      "kind": "cli-api-gui",
       "participantProfile": "agent-or-developer",
       "state": "declared",
       "availability": "shipped",
@@ -431,7 +431,7 @@
     {
       "id": "kungfu.atlas.create-mission",
       "name": "kungfu atlas create-mission <mission-id> --title <title> --intent <intent> --actor <actor> --json",
-      "kind": "cli",
+      "kind": "cli-api-gui",
       "participantProfile": "agent-or-developer",
       "state": "declared",
       "availability": "shipped",
@@ -1175,7 +1175,7 @@
     },
     {
       "id": "kungfu.profile.kfd3-qualification",
-      "name": "kungfu profile kfd3-qualify <source> --json",
+      "name": "kungfu profile kfd3-status <source> --json",
       "kind": "cli-api-gui",
       "participantProfile": "agent-or-developer",
       "state": "declared",

--- a/docs/adr/ADR-0069-agent-first-kfx-profile-suite-runtime.md
+++ b/docs/adr/ADR-0069-agent-first-kfx-profile-suite-runtime.md
@@ -237,9 +237,19 @@ records Installed, Qualified, Activated, Superseded, RolledBack, and Removed
 facts through ActionEnvelope + Episode. Python, Node, and `kungfu kfx profile`
 use the same storage-service operation and fail-closed plan/apply receipts.
 
-S1 qualification is deliberately limited to source-contract, content-closure,
-and runtime-contract checks that Core can execute itself. The installed Agent
-SDK, semantic fixture harness, Profile Manager, Mission Control migration,
-portable export/import, and open-Profile release qualification remain future
-stages. A schema-valid source still proves no lifecycle state; only journal
-facts and receipts establish installation, qualification, or activation.
+The first S2 product slice is also implemented. The installed Agent SDK exposes
+Profile application, status, exact qualification plans, explicit authorization,
+receipts, and verification. Profile Manager projects the same machine state as
+an Emoji badge and never runs qualification probes merely by rendering a
+Profile. Mission Control declares its collaboration interface through the
+public Profile Suite path; the Product build issues a release-owned KFD-3
+receipt only after binding the Suite closure, Agent API registry, and Work
+Dashboard GUI projection. User Profiles earn the same receipt schema and badge
+semantics through the journal-backed lifecycle authority.
+
+The stage remains incomplete: Week/Day coexistence, portable export/import,
+upgrade and rollback qualification, broader Mission Control migration, and
+frozen-product qualification on every supported platform are still open. A
+schema-valid source or editable Profile declaration proves no lifecycle or
+KFD-3 state; only an exact-root release receipt or an authorized journal fact
+can establish the current badge.

--- a/extensions/mission-control/collaboration/interface.json
+++ b/extensions/mission-control/collaboration/interface.json
@@ -1,0 +1,120 @@
+{
+  "schema": "kungfu.profile-collaboration/v1",
+  "profileId": "kungfu.mission-control",
+  "value": {
+    "summary": "Keep Mission and Go progress understandable and operable through the same admitted-fact and assessment APIs for a human or an agent.",
+    "participantBenefits": [
+      {
+        "participantKind": "human",
+        "description": "See, authorize, and operate Mission Control through the product GUI."
+      },
+      {
+        "participantKind": "agent",
+        "description": "Discover and invoke the same Mission Control capability APIs through Kungfu CLI."
+      }
+    ]
+  },
+  "participants": [
+    {
+      "id": "mission-owner",
+      "kind": "human",
+      "title": "Mission owner",
+      "authorityClasses": [
+        "mission-fact-author",
+        "claim-author",
+        "profile-assessment-operator"
+      ]
+    },
+    {
+      "id": "delegated-agent",
+      "kind": "agent",
+      "title": "Delegated agent",
+      "authorityClasses": []
+    }
+  ],
+  "intents": [
+    {
+      "id": "create-mission",
+      "title": "Create Mission fact",
+      "actionId": "create-mission",
+      "inspectViewId": "mission-state",
+      "verifyViewId": "mission-timeline",
+      "requiredAuthority": "mission-fact-author",
+      "requiredCapabilities": ["storage"],
+      "material": true,
+      "protocol": {
+        "mode": "shared-api",
+        "apiId": "kungfu.atlas.create-mission",
+        "guiMember": "work-dashboard",
+        "guiMethod": "createMission"
+      }
+    },
+    {
+      "id": "create-go",
+      "title": "Create Go fact",
+      "actionId": "create-go",
+      "inspectViewId": "mission-state",
+      "verifyViewId": "mission-timeline",
+      "requiredAuthority": "mission-fact-author",
+      "requiredCapabilities": ["storage"],
+      "material": true,
+      "protocol": {
+        "mode": "shared-api",
+        "apiId": "kungfu.atlas.create-go",
+        "guiMember": "work-dashboard",
+        "guiMethod": "createGo"
+      }
+    },
+    {
+      "id": "claim-completion",
+      "title": "Record completion claim",
+      "actionId": "claim-completion",
+      "inspectViewId": "mission-state",
+      "verifyViewId": "mission-attention",
+      "requiredAuthority": "claim-author",
+      "requiredCapabilities": ["storage"],
+      "material": true,
+      "protocol": {
+        "mode": "shared-api",
+        "apiId": "kungfu.atlas.claim-completion",
+        "guiMember": "work-dashboard",
+        "guiMethod": "claimCompletion"
+      }
+    },
+    {
+      "id": "assess-progress",
+      "title": "Assess Mission progress",
+      "actionId": "assess-progress",
+      "inspectViewId": "mission-state",
+      "verifyViewId": "mission-attention",
+      "requiredAuthority": "profile-assessment-operator",
+      "requiredCapabilities": ["storage"],
+      "material": true,
+      "protocol": {
+        "mode": "shared-api",
+        "apiId": "kungfu.atlas.assess-mission",
+        "guiMember": "work-dashboard",
+        "guiMethod": "assessMissionAsync"
+      }
+    }
+  ],
+  "constraints": [
+    {
+      "id": "declared-authority",
+      "description": "Material Mission Control writes and assessments require the authority declared by each intent.",
+      "enforcement": "runtime",
+      "appliesTo": ["*"]
+    }
+  ],
+  "knownLimits": [
+    {
+      "id": "actor-identity",
+      "description": "Kungfu records the supplied actor identity but external identity verification remains outside this Profile.",
+      "effect": "external-verification-required"
+    }
+  ],
+  "presentation": {
+    "mode": "generic",
+    "homeViewId": "mission-state"
+  }
+}

--- a/extensions/mission-control/profile.json
+++ b/extensions/mission-control/profile.json
@@ -66,6 +66,12 @@
       "sha256": "0f790db6cdbd6725e52f2fa13aac83d368b22e49e0d3033bac49cd7330388b9d"
     }
   },
+  "kfd3": {
+    "collaboration": {
+      "path": "collaboration/interface.json",
+      "sha256": "25d55057f3e4dde6d594c76ab35854a8a0fb895b535c4688768a6b69264ec260"
+    }
+  },
   "migrations": {
     "registry": {
       "path": "migrations/registry.json",

--- a/extensions/system/kfx-manager/src/view/index.tsx
+++ b/extensions/system/kfx-manager/src/view/index.tsx
@@ -8,6 +8,7 @@ import {
   type ManagedProfile,
   type ProfileApplicationProjection,
   type ProfileIntentPlan,
+  type ProfileKfd3QualificationPlan,
   type ProfileLifecyclePlan,
   type ProfileManagerProjection,
   headingStyle,
@@ -29,12 +30,21 @@ function shortRoot(value: string | null | undefined): string {
   return value.length > 24 ? `${value.slice(0, 16)}…${value.slice(-6)}` : value;
 }
 
+const kfd3Badge = {
+  qualified: '🛡️',
+  untested: '◇',
+  stale: '△',
+  failed: '✕',
+  testing: '⏳',
+} as const;
+
 function ProfileCard({
   managed,
   application,
   applicationError,
   planning,
   onPlan,
+  onKfd3Plan,
   onIntentPlan,
 }: {
   managed: ManagedProfile;
@@ -42,6 +52,7 @@ function ProfileCard({
   applicationError?: string;
   planning: boolean;
   onPlan: (action: 'qualify' | 'activate', source: string) => void;
+  onKfd3Plan: (source: string) => void;
   onIntentPlan: (source: string, intentId: string) => void;
 }) {
   const next =
@@ -113,7 +124,7 @@ function ProfileCard({
             <span
               title={
                 application.qualified
-                  ? `KFD-3 witness ${application.qualification.witnessId}`
+                  ? `${application.qualification.issuer?.name ?? 'KFD-3 qualification'} · profile ${application.profileSuiteRoot} · runtime ${application.qualification.runtimeContractRoot} · receipt ${application.qualification.receiptId}`
                   : application.qualification.reason ||
                     String(
                       application.qualification.diagnosis?.message ||
@@ -121,27 +132,55 @@ function ProfileCard({
                     )
               }
             >
-              {application.qualified ? '🛡️ KFD-3 qualified' : '◌ KFD-3 declared'}
+              {kfd3Badge[application.qualification.status]} KFD-3
             </span>
           </div>
+          {application.qualification.status !== 'qualified' &&
+          application.activeExactRoot &&
+          application.qualification.nextActions.some(
+            (next) => next.action === 'profile.kfd3.qualify',
+          ) ? (
+            <button
+              type="button"
+              disabled={planning}
+              title="Review the exact probes before running KFD-3 qualification"
+              onClick={() => onKfd3Plan(application.source)}
+              style={{ ...mono, marginTop: 8, marginRight: 8 }}
+            >
+              Test KFD-3
+            </button>
+          ) : null}
           {application.intents.map((intent) => (
             <button
               key={intent.id}
               type="button"
               disabled={
-                planning ||
-                !application.activeExactRoot ||
-                intent.missingCapabilities.length > 0
+                'mode' in intent.protocol &&
+                intent.protocol.mode === 'shared-api'
+                  ? true
+                  : planning ||
+                    !application.activeExactRoot ||
+                    intent.missingCapabilities.length > 0
               }
               title={
-                intent.missingCapabilities.length
-                  ? `Missing: ${intent.missingCapabilities.join(', ')}`
-                  : `${intent.requiredAuthority} · inspect → advise → preview → authorize → execute → receipt → verify`
+                'mode' in intent.protocol &&
+                intent.protocol.mode === 'shared-api'
+                  ? `${intent.protocol.apiId} · the Product GUI and Agent CLI use this same capability API`
+                  : intent.missingCapabilities.length
+                    ? `Missing: ${intent.missingCapabilities.join(', ')}`
+                    : `${intent.requiredAuthority} · inspect → advise → preview → authorize → execute → receipt → verify`
               }
-              onClick={() => onIntentPlan(application.source, intent.id)}
+              onClick={() => {
+                if (!('mode' in intent.protocol)) {
+                  onIntentPlan(application.source, intent.id);
+                }
+              }}
               style={{ ...mono, marginTop: 8, marginRight: 8 }}
             >
-              {intent.title}
+              {'mode' in intent.protocol &&
+              intent.protocol.mode === 'shared-api'
+                ? `↗ ${intent.title}`
+                : intent.title}
             </button>
           ))}
         </div>
@@ -199,6 +238,10 @@ function KfxManagerView({ caps, shell }: KfxViewProps) {
     plan: ProfileIntentPlan;
     source: string;
     intentId: string;
+  } | null>(null);
+  const [pendingKfd3, setPendingKfd3] = React.useState<{
+    plan: ProfileKfd3QualificationPlan;
+    source: string;
   } | null>(null);
   const [authorizedBy, setAuthorizedBy] = React.useState('');
   const profile =
@@ -288,6 +331,42 @@ function KfxManagerView({ caps, shell }: KfxViewProps) {
         intentId,
       });
       setError('');
+    } catch (reason) {
+      setError((reason as Error).message);
+    } finally {
+      setPlanning(false);
+    }
+  };
+
+  const previewKfd3 = async (source: string) => {
+    if (!caps.profile) return;
+    setPlanning(true);
+    try {
+      setPendingKfd3({
+        plan: await caps.profile.kfd3PlanAsync(source),
+        source,
+      });
+      setError('');
+    } catch (reason) {
+      setError((reason as Error).message);
+    } finally {
+      setPlanning(false);
+    }
+  };
+
+  const approveKfd3 = async () => {
+    if (!caps.profile || !pendingKfd3 || !authorizedBy.trim()) return;
+    setPlanning(true);
+    try {
+      await caps.profile.authorizeKfd3Async(
+        pendingKfd3.source,
+        pendingKfd3.plan.planId,
+        'approve',
+        authorizedBy.trim(),
+      );
+      setPendingKfd3(null);
+      await refresh();
+      shell.notify({ level: 'success', title: '🛡️ KFD-3 qualification earned' });
     } catch (reason) {
       setError((reason as Error).message);
     } finally {
@@ -389,6 +468,7 @@ function KfxManagerView({ caps, shell }: KfxViewProps) {
             applicationError={applicationErrors[managed.profileId]}
             planning={planning}
             onPlan={(action, source) => void previewPlan(action, source)}
+            onKfd3Plan={(source) => void previewKfd3(source)}
             onIntentPlan={(source, intentId) =>
               void previewIntent(source, intentId)
             }
@@ -405,6 +485,49 @@ function KfxManagerView({ caps, shell }: KfxViewProps) {
           </div>
         ) : null}
       </div>
+      {pendingKfd3 ? (
+        <div
+          style={{
+            ...mono,
+            border: '1px solid #dcdcaa',
+            padding: 10,
+            marginBottom: 12,
+          }}
+        >
+          <strong style={{ color: '#dcdcaa' }}>◇ KFD-3 test plan</strong>
+          <div>profile {shortRoot(pendingKfd3.plan.profileSuiteRoot)}</div>
+          <div>runtime {shortRoot(pendingKfd3.plan.runtimeContractRoot)}</div>
+          <div>plan {shortRoot(pendingKfd3.plan.planId)}</div>
+          <div style={{ color: '#858585' }}>
+            {pendingKfd3.plan.probes.join(' · ')}
+          </div>
+          <label style={{ display: 'block', marginTop: 8 }}>
+            authorized by{' '}
+            <input
+              value={authorizedBy}
+              onChange={(event) => setAuthorizedBy(event.target.value)}
+              placeholder="workspace profile operator"
+              style={{ ...mono, minWidth: 220 }}
+            />
+          </label>
+          <button
+            type="button"
+            disabled={planning || !authorizedBy.trim()}
+            onClick={() => void approveKfd3()}
+            style={{ ...mono, marginTop: 8, marginRight: 8 }}
+          >
+            Run exact test plan
+          </button>
+          <button
+            type="button"
+            disabled={planning}
+            onClick={() => setPendingKfd3(null)}
+            style={{ ...mono, marginTop: 8 }}
+          >
+            Dismiss
+          </button>
+        </div>
+      ) : null}
       {pending ? (
         <div
           style={{

--- a/framework/api/src/capability/profile.ts
+++ b/framework/api/src/capability/profile.ts
@@ -83,6 +83,22 @@ export type ProfileApplicationIntent = {
   requiredCapabilities: string[];
   missingCapabilities: string[];
   material: true;
+  protocol:
+    | {
+        inspect: 'profile.intent.inspect';
+        advise: 'profile.intent.advise';
+        preview: 'profile.intent.plan';
+        authorize: 'profile.decide';
+        execute: 'profile.intent.apply';
+        receipt: 'profile.intent.receipt';
+        verify: 'profile.intent.verify';
+      }
+    | {
+        mode: 'shared-api';
+        apiId: string;
+        guiMember: string;
+        guiMethod: string;
+      };
   action: Record<string, unknown>;
   inspectView: ProfileView;
   verifyView: ProfileView;
@@ -116,13 +132,44 @@ export type ProfileApplicationProjection = {
   qualified: boolean;
   qualification: {
     qualified: boolean;
-    status: 'not-qualified' | 'qualification-failed' | 'qualified';
+    current: boolean;
+    status: 'qualified' | 'untested' | 'stale' | 'failed' | 'testing';
     reason?: string;
     receiptId?: string;
     witnessId?: string;
     evidenceScope?: string[];
     diagnosis?: Record<string, unknown>;
+    qualificationSource?: 'local' | 'release';
+    issuer?: { type: 'local' | 'release'; name: string };
+    policyVersion?: string;
+    runtimeContractRoot?: string;
+    nextActions: Array<{ action: string; requiresApproval: boolean }>;
   };
+};
+
+export type ProfileKfd3Status =
+  ProfileApplicationProjection['qualification'] & {
+    schema: 'kungfu.profile-kfd3-status/v1';
+    profileId: string;
+    profileSuiteRoot: string;
+    activeExactRoot: boolean;
+  };
+
+export type ProfileKfd3QualificationPlan = {
+  schema: 'kungfu.profile-kfd3-qualification-plan/v1';
+  planId: string;
+  profileId: string;
+  profileSuiteRoot: string;
+  collaborationRoot: string;
+  closureRoot: string;
+  profileRevision: number;
+  runtimeContractRoot: string;
+  intentIds: string[];
+  policyVersion: string;
+  probes: string[];
+  sideEffects: string[];
+  requiresAuthorization: true;
+  decisionCard: Record<string, unknown>;
 };
 
 export type ProfileKfd3QualificationReceipt = {
@@ -133,6 +180,8 @@ export type ProfileKfd3QualificationReceipt = {
   collaborationRoot: string;
   closureRoot: string;
   profileRevision: number;
+  runtimeContract: string;
+  qualificationSource: 'local' | 'release';
   qualified: true;
   evidenceScope: string[];
   witness: {
@@ -240,6 +289,16 @@ export type Profile = {
   managerAsync: () => Promise<ProfileManagerProjection>;
   application: (source: string) => ProfileApplicationProjection;
   applicationAsync: (source: string) => Promise<ProfileApplicationProjection>;
+  kfd3Status: (source: string) => ProfileKfd3Status;
+  kfd3StatusAsync: (source: string) => Promise<ProfileKfd3Status>;
+  kfd3Plan: (source: string) => ProfileKfd3QualificationPlan;
+  kfd3PlanAsync: (source: string) => Promise<ProfileKfd3QualificationPlan>;
+  authorizeKfd3Async: (
+    source: string,
+    expectedPlanId: string,
+    choice: 'approve' | 'deny',
+    authorizedBy: string,
+  ) => Promise<ProfileKfd3QualificationReceipt>;
   qualifyKfd3: (source: string) => ProfileKfd3QualificationReceipt;
   qualifyKfd3Async: (
     source: string,
@@ -357,6 +416,24 @@ export function openProfile(options: OpenProfileOptions): Profile {
       run<ProfileApplicationProjection>(['application', source]),
     applicationAsync: (source) =>
       runAsync<ProfileApplicationProjection>(['application', source]),
+    kfd3Status: (source) => run<ProfileKfd3Status>(['kfd3-status', source]),
+    kfd3StatusAsync: (source) =>
+      runAsync<ProfileKfd3Status>(['kfd3-status', source]),
+    kfd3Plan: (source) =>
+      run<ProfileKfd3QualificationPlan>(['kfd3-plan', source]),
+    kfd3PlanAsync: (source) =>
+      runAsync<ProfileKfd3QualificationPlan>(['kfd3-plan', source]),
+    authorizeKfd3Async: (source, expectedPlanId, choice, authorizedBy) =>
+      runAsync<ProfileKfd3QualificationReceipt>([
+        'kfd3-authorize',
+        source,
+        '--expected-plan-id',
+        expectedPlanId,
+        '--choice',
+        choice,
+        '--authorized-by',
+        authorizedBy,
+      ]),
     qualifyKfd3: (source) =>
       run<ProfileKfd3QualificationReceipt>(['kfd3-qualify', source]),
     qualifyKfd3Async: (source) =>

--- a/framework/api/tests/profile.test.ts
+++ b/framework/api/tests/profile.test.ts
@@ -46,6 +46,8 @@ test('Profile plans preserve source and exact active-root intent', () => {
   profile.discover('kungfu.mission-control');
   profile.queryPlan('/suite', 'week-table');
   profile.application('/suite');
+  profile.kfd3Status('/suite');
+  profile.kfd3Plan('/suite');
   profile.qualifyKfd3('/suite');
   profile.intentPlan('/suite', 'complete-day');
   profile.lifecyclePlan('install', '/suite');
@@ -55,9 +57,43 @@ test('Profile plans preserve source and exact active-root intent', () => {
     ['profile', 'discover', 'kungfu.mission-control', '--json'],
     ['profile', 'query-plan', '/suite', 'week-table', '--json'],
     ['profile', 'application', '/suite', '--json'],
+    ['profile', 'kfd3-status', '/suite', '--json'],
+    ['profile', 'kfd3-plan', '/suite', '--json'],
     ['profile', 'kfd3-qualify', '/suite', '--json'],
     ['profile', 'intent', 'plan', '/suite', 'complete-day', '--json'],
     ['profile', 'plan', 'install', '/suite', '--json'],
+  ]);
+});
+
+test('Profile KFD-3 authorization binds the reviewed plan and actor', async () => {
+  const calls: string[][] = [];
+  const profile = openProfile({
+    runtimeDir: '/runtime',
+    execFileSync: () => '{}',
+    execFile: async (_file, args) => {
+      calls.push(args);
+      return '{}';
+    },
+  });
+
+  await profile.authorizeKfd3Async(
+    '/suite',
+    'sha256:reviewed',
+    'approve',
+    'workspace-owner',
+  );
+
+  assert.deepEqual(calls[0], [
+    'profile',
+    'kfd3-authorize',
+    '/suite',
+    '--expected-plan-id',
+    'sha256:reviewed',
+    '--choice',
+    'approve',
+    '--authorized-by',
+    'workspace-owner',
+    '--json',
   ]);
 });
 

--- a/framework/core/src/libkungfu/schemas/profile_lifecycle_event.fbs
+++ b/framework/core/src/libkungfu/schemas/profile_lifecycle_event.fbs
@@ -11,7 +11,8 @@ enum ProfileLifecycleKind : byte {
   Activated = 2,
   Superseded = 3,
   RolledBack = 4,
-  Removed = 5
+  Removed = 5,
+  Kfd3Qualified = 6
 }
 
 table ProfileLifecycleEvent {

--- a/framework/core/src/libkungfu/src/runtime/profile/profile_lifecycle.cpp
+++ b/framework/core/src/libkungfu/src/runtime/profile/profile_lifecycle.cpp
@@ -54,6 +54,7 @@ struct root_state {
   bool qualified = false;
   bool activated = false;
   nlohmann::json qualification = nlohmann::json::object();
+  nlohmann::json kfd3_qualification = nlohmann::json::object();
   nlohmann::json granted_permissions = nlohmann::json::array();
 };
 
@@ -597,6 +598,9 @@ std::map<std::string, profile_state> fold_profiles(const std::vector<lifecycle_r
       state.current_root = root;
       root_entry.qualified = true;
       root_entry.qualification = nlohmann::json::parse(text_or(record.event, "qualification_json", "{}"));
+    } else if (kind == "Kfd3Qualified") {
+      state.current_root = root;
+      root_entry.kfd3_qualification = nlohmann::json::parse(text_or(record.event, "qualification_json", "{}"));
     } else if (kind == "Activated") {
       state.current_root = root;
       state.removed = false;
@@ -668,6 +672,7 @@ nlohmann::json render_state(const profile_state &state) {
           {"removed", state.removed},
           {"granted_permissions", root.granted_permissions},
           {"qualification", root.qualification},
+          {"kfd3_qualification", root.kfd3_qualification},
           {"available_roots", state.roots.size()},
           {"latest_event", render_event(state.latest)}};
 }
@@ -798,7 +803,7 @@ nlohmann::json profile_lifecycle_contract() {
           {"event_schema", PROFILE_LIFECYCLE_EVENT_V1},
           {"root", "Core-computed canonical sha256 over normalized Profile and verified content closure"},
           {"states", {"installed", "qualified", "activated", "removed"}},
-          {"facts", {"Installed", "Qualified", "Activated", "Superseded", "RolledBack", "Removed"}},
+          {"facts", {"Installed", "Qualified", "Activated", "Superseded", "RolledBack", "Removed", "Kfd3Qualified"}},
           {"operations", {"contract", "inspect", "plan", "apply", "get", "list", "history"}},
           {"journal", {{"namespace", PROFILE_NAMESPACE}, {"name", PROFILE_JOURNAL_NAME}}},
           {"projection", "deterministic-in-memory-fold/v1"},
@@ -848,7 +853,8 @@ nlohmann::json plan_profile_lifecycle(const std::string &runtime_dir, const nloh
   if (!request.is_object())
     throw std::invalid_argument("Profile lifecycle request must be an object");
   const auto action_name = required_text(request, "action");
-  const std::set<std::string> supported{"install", "qualify", "activate", "upgrade", "rollback", "remove"};
+  const std::set<std::string> supported{"install",  "qualify", "activate",    "upgrade",
+                                        "rollback", "remove",  "kfd3-qualify"};
   if (!supported.contains(action_name))
     throw std::invalid_argument("unsupported Profile lifecycle action: " + action_name);
 
@@ -856,7 +862,8 @@ nlohmann::json plan_profile_lifecycle(const std::string &runtime_dir, const nloh
   nlohmann::json normalized_request = {{"action", action_name}};
   nlohmann::json inspection;
   std::string profile_id;
-  if (action_name == "install" || action_name == "qualify" || action_name == "activate" || action_name == "upgrade") {
+  if (action_name == "install" || action_name == "qualify" || action_name == "activate" || action_name == "upgrade" ||
+      action_name == "kfd3-qualify") {
     if (!request.contains("member_roots"))
       throw std::invalid_argument("member_roots is required");
     inspection = inspect_profile(required_text(request, "profile_path"), request.at("member_roots"));
@@ -912,6 +919,25 @@ nlohmann::json plan_profile_lifecycle(const std::string &runtime_dir, const nloh
     normalized_request["granted_permissions"] = permissions;
     effects.push_back(
         {{"kind", "Activated"}, {"profile_suite_root", current_root}, {"granted_permissions", permissions}});
+  } else if (action_name == "kfd3-qualify") {
+    if (!exists || found->second.removed || current_root != inspection.at("profile_suite_root").get<std::string>()) {
+      throw std::invalid_argument("KFD-3 qualification requires the exact current Profile root");
+    }
+    const auto root_found = found->second.roots.find(current_root);
+    if (root_found == found->second.roots.end() || !root_found->second.activated) {
+      throw std::invalid_argument("KFD-3 qualification requires an active Profile root");
+    }
+    if (!request.contains("qualification") || !request.at("qualification").is_object()) {
+      throw std::invalid_argument("KFD-3 qualification receipt is required");
+    }
+    qualification = request.at("qualification");
+    if (text_or(qualification, "schema") != "kungfu.profile-kfd3-qualification-receipt/v1" ||
+        !qualification.value("qualified", false) || text_or(qualification, "profileId") != profile_id ||
+        text_or(qualification, "profileSuiteRoot") != current_root) {
+      throw std::invalid_argument("KFD-3 qualification receipt does not bind the exact Profile root");
+    }
+    normalized_request["qualification"] = qualification;
+    effects.push_back({{"kind", "Kfd3Qualified"}, {"profile_suite_root", current_root}});
   } else if (action_name == "upgrade") {
     if (!exists || found->second.removed)
       throw std::invalid_argument("upgrade requires an installed Profile");

--- a/framework/core/src/libkungfu/tests/profile_lifecycle_tests.cpp
+++ b/framework/core/src/libkungfu/tests/profile_lifecycle_tests.cpp
@@ -245,6 +245,22 @@ void test_lifecycle_plan_apply_fold_and_history() {
   require(profile::get_profile(runtime.string(), "example.week-day").at("state") == "activated",
           "activated state did not fold");
 
+  const auto active_root = profile::get_profile(runtime.string(), "example.week-day").at("profile_suite_root");
+  const nlohmann::json kfd3_receipt = {{"schema", "kungfu.profile-kfd3-qualification-receipt/v1"},
+                                       {"receiptId", "sha256:kfd3"},
+                                       {"profileId", "example.week-day"},
+                                       {"profileSuiteRoot", active_root},
+                                       {"qualified", true}};
+  const auto kfd3_plan = plan(runtime, {{"action", "kfd3-qualify"},
+                                        {"profile_path", v1.profile_path.string()},
+                                        {"member_roots", roots_v1},
+                                        {"qualification", kfd3_receipt}});
+  require(kfd3_plan.at("effects").at(0).at("kind") == "Kfd3Qualified",
+          "KFD-3 qualification preview omitted its typed effect");
+  apply(runtime, kfd3_plan, 325);
+  require(profile::get_profile(runtime.string(), "example.week-day").at("kfd3_qualification") == kfd3_receipt,
+          "KFD-3 qualification receipt did not fold for the exact root");
+
   const auto second_profile = write_package(tree.root() / "second", "1.0.0", "-second", "example.task-job");
   apply(runtime,
         plan(runtime, {{"action", "install"},
@@ -282,7 +298,7 @@ void test_lifecycle_plan_apply_fold_and_history() {
   const auto removed = profile::get_profile(runtime.string(), "example.week-day", true);
   require(removed.at("state") == "removed", "removal fact did not fold");
   const auto history = profile::profile_history(runtime.string(), "example.week-day");
-  require(history.at("events").size() == 8, "append-only lifecycle history lost facts");
+  require(history.at("events").size() == 9, "append-only lifecycle history lost facts");
 }
 
 void test_stale_plan_and_wrong_runtime_fail_closed() {

--- a/framework/core/src/python/kungfu/agent/brief.md
+++ b/framework/core/src/python/kungfu/agent/brief.md
@@ -116,7 +116,9 @@ kungfu profile intent plan ./my-profile <intent-id> --json
 kungfu profile intent authorize ./my-profile <intent-id> --expected-plan-id <id> --choice approve --authorized-by <actor> --json
 kungfu profile intent apply plan.json --authorization-file answer.json --json
 kungfu profile intent verify ./my-profile receipt.json --json
-kungfu profile kfd3-qualify ./my-profile --json
+kungfu profile kfd3-status ./my-profile --json
+kungfu profile kfd3-plan ./my-profile --json
+kungfu profile kfd3-authorize ./my-profile --expected-plan-id <id> --choice approve --authorized-by <actor> --json
 kungfu profile kfd3-verify ./my-profile receipt.json --json
 kungfu profile qualify ./my-profile --json
 kungfu profile plan install ./my-profile --json
@@ -136,10 +138,13 @@ known limits. `profile collaboration` audits action/view/authority/capability
 closure and reports `declared-closed`, but it remains `qualified: false` until
 Kungfu has produced the runtime probes and KFD-3 witness; schema validity,
 KFD-1/KFD-2 qualification, and KFD-3 qualification are separate states. The
-`kfd3-qualify` command earns a deterministic receipt only for an exact active
-root after installed Agent-interface closure, custom-view no-bypass, and
-Human/Agent exact-plan probes pass. A Profile cannot supply that receipt or
-witness in its own source tree.
+`kfd3-status` never runs probes: it returns the shared machine state, issuer,
+receipt coordinates, and next actions used by the GUI badge. `kfd3-plan`
+previews the exact probe set, and `kfd3-authorize` earns and journals a
+deterministic receipt only for an exact active root after installed
+Agent-interface closure, custom-view no-bypass, and Human/Agent exact-plan
+probes pass. A Profile cannot supply that receipt or witness in its own source
+tree.
 The generic Profile Manager calls these same installed application commands.
 Its intent card is a visual projection of the same Profile/collaboration roots,
 decision card, action receipt, and verification result; GUI focus or custom

--- a/framework/core/src/python/kungfu/agent/commands.json
+++ b/framework/core/src/python/kungfu/agent/commands.json
@@ -663,6 +663,24 @@
     },
     {
       "apiId": "kungfu.profile.kfd3-qualification",
+      "name": "kungfu profile kfd3-status <source> --json",
+      "maturity": "experimental",
+      "purpose": "Read qualified, untested, stale, failed, or testing state plus receipt provenance and machine-readable next actions without running qualification probes."
+    },
+    {
+      "apiId": "kungfu.profile.kfd3-qualification",
+      "name": "kungfu profile kfd3-plan <source> --json",
+      "maturity": "experimental",
+      "purpose": "Preview exact content, Runtime-contract, no-bypass, and dual-client probes without executing them."
+    },
+    {
+      "apiId": "kungfu.profile.kfd3-qualification",
+      "name": "kungfu profile kfd3-authorize <source> --expected-plan-id <id> --choice approve --authorized-by <actor> --json",
+      "maturity": "experimental",
+      "purpose": "Execute one reviewed current plan and append its exact-root receipt to the Core-owned Profile lifecycle journal."
+    },
+    {
+      "apiId": "kungfu.profile.kfd3-qualification",
       "name": "kungfu profile kfd3-qualify <source> --json",
       "maturity": "experimental",
       "purpose": "Audit the active Profile's public closure, custom-view no-bypass boundary, and dual-client exact plans, then emit a Kungfu-owned KFD-3 receipt and witness."
@@ -671,7 +689,7 @@
       "apiId": "kungfu.profile.kfd3-qualification",
       "name": "kungfu profile kfd3-verify <source> <receipt.json> --json",
       "maturity": "experimental",
-      "purpose": "Re-run qualification and reject a stale or tampered receipt or witness."
+      "purpose": "Verify a supplied receipt against the current journal-backed qualification state and reject stale or tampered evidence."
     },
     {
       "apiId": "kungfu.profile.manager",

--- a/framework/core/src/python/kungfu/agent/kfd3_api.registry.json
+++ b/framework/core/src/python/kungfu/agent/kfd3_api.registry.json
@@ -317,13 +317,13 @@
     },
     {
       "id": "kungfu.atlas.create-mission",
-      "surface": "cli",
+      "surface": "cli-api-gui",
       "name": "kungfu atlas create-mission <mission-id> --title <title> --intent <intent> --actor <actor> --json",
       "purpose": "Create a Kungfu-native long-running Mission in the shared Fact Library.",
       "maturity": "experimental",
-      "visibility": "adjacent-agent",
+      "visibility": "public-agent",
       "anchor": { "kind": "catalog" },
-      "projections": ["commands.json", "agent-pack-doc", "provider-skill"]
+      "projections": ["commands.json", "agent-pack-doc", "provider-skill", "work-dashboard-gui"]
     },
     {
       "id": "kungfu.atlas.export-mission",
@@ -347,33 +347,33 @@
     },
     {
       "id": "kungfu.atlas.assess-mission",
-      "surface": "cli",
+      "surface": "cli-api-gui",
       "name": "kungfu atlas assess-mission <mission-id> --json",
       "purpose": "Query admitted Mission/Go facts and persist a purpose-bound progress TrustReport.",
       "maturity": "experimental",
-      "visibility": "adjacent-agent",
+      "visibility": "public-agent",
       "anchor": { "kind": "catalog" },
-      "projections": ["commands.json", "agent-pack-doc", "provider-skill"]
+      "projections": ["commands.json", "agent-pack-doc", "provider-skill", "work-dashboard-gui"]
     },
     {
       "id": "kungfu.atlas.create-go",
-      "surface": "cli",
+      "surface": "cli-api-gui",
       "name": "kungfu atlas create-go <mission-id> <goal-id> --title <title> --objective <objective> --actor <actor> --json",
       "purpose": "Create a Kungfu-native Go linked to an admitted Mission without writing back to the bridged source.",
       "maturity": "experimental",
-      "visibility": "adjacent-agent",
+      "visibility": "public-agent",
       "anchor": { "kind": "catalog" },
-      "projections": ["commands.json", "agent-pack-doc", "provider-skill"]
+      "projections": ["commands.json", "agent-pack-doc", "provider-skill", "work-dashboard-gui"]
     },
     {
       "id": "kungfu.atlas.claim-completion",
-      "surface": "cli",
+      "surface": "cli-api-gui",
       "name": "kungfu atlas claim-completion <mission-id> <goal-id> --statement <statement> --actor <actor> --evidence-episode <id> --json",
       "purpose": "Record an explicit completion claim with independently verifiable Episode evidence.",
       "maturity": "experimental",
-      "visibility": "adjacent-agent",
+      "visibility": "public-agent",
       "anchor": { "kind": "catalog" },
-      "projections": ["commands.json", "agent-pack-doc", "provider-skill"]
+      "projections": ["commands.json", "agent-pack-doc", "provider-skill", "work-dashboard-gui"]
     },
     {
       "id": "kungfu.atlas.assess-completion",
@@ -905,9 +905,9 @@
     {
       "id": "kungfu.profile.kfd3-qualification",
       "surface": "cli-api-gui",
-      "name": "kungfu profile kfd3-qualify <source> --json",
-      "aliases": ["kungfu profile kfd3-verify <source> <receipt.json> --json"],
-      "purpose": "Earn a scoped Profile KFD-3 receipt and witness only after installed authority, public-surface, no-bypass, and dual-client probes pass.",
+      "name": "kungfu profile kfd3-status <source> --json",
+      "aliases": ["kungfu profile kfd3-plan <source> --json", "kungfu profile kfd3-authorize <source> --expected-plan-id <id> --choice approve --authorized-by <actor> --json", "kungfu profile kfd3-qualify <source> --json", "kungfu profile kfd3-verify <source> <receipt.json> --json"],
+      "purpose": "Read exact-root qualification without running probes, or explicitly review, authorize, persist, and verify a scoped KFD-3 receipt and witness.",
       "maturity": "experimental",
       "visibility": "public-agent",
       "anchor": { "kind": "catalog" },

--- a/framework/core/src/python/kungfu/agent/profile-sdk.contract.json
+++ b/framework/core/src/python/kungfu/agent/profile-sdk.contract.json
@@ -323,18 +323,33 @@
             "requiredCapabilities": { "type": "array", "uniqueItems": true, "items": { "type": "string", "pattern": "^[A-Za-z0-9._-]+$" } },
             "material": { "const": true },
             "protocol": {
-              "type": "object",
-              "additionalProperties": false,
-              "required": ["inspect", "advise", "preview", "authorize", "execute", "receipt", "verify"],
-              "properties": {
-                "inspect": { "const": "profile.intent.inspect" },
-                "advise": { "const": "profile.intent.advise" },
-                "preview": { "const": "profile.intent.plan" },
-                "authorize": { "const": "profile.decide" },
-                "execute": { "const": "profile.intent.apply" },
-                "receipt": { "const": "profile.intent.receipt" },
-                "verify": { "const": "profile.intent.verify" }
-              }
+              "oneOf": [
+                {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": ["inspect", "advise", "preview", "authorize", "execute", "receipt", "verify"],
+                  "properties": {
+                    "inspect": { "const": "profile.intent.inspect" },
+                    "advise": { "const": "profile.intent.advise" },
+                    "preview": { "const": "profile.intent.plan" },
+                    "authorize": { "const": "profile.decide" },
+                    "execute": { "const": "profile.intent.apply" },
+                    "receipt": { "const": "profile.intent.receipt" },
+                    "verify": { "const": "profile.intent.verify" }
+                  }
+                },
+                {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": ["mode", "apiId", "guiMember", "guiMethod"],
+                  "properties": {
+                    "mode": { "const": "shared-api" },
+                    "apiId": { "type": "string", "pattern": "^[A-Za-z0-9._-]+$" },
+                    "guiMember": { "type": "string", "pattern": "^[A-Za-z0-9._-]+$" },
+                    "guiMethod": { "type": "string", "pattern": "^[A-Za-z0-9._-]+$" }
+                  }
+                }
+              ]
             }
           }
         }
@@ -383,7 +398,7 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
     "additionalProperties": false,
-    "required": ["schema", "receiptId", "profileId", "profileSuiteRoot", "collaborationRoot", "closureRoot", "profileRevision", "runtimeContract", "authority", "surfaceInventory", "noBypass", "clientProbes", "knownLimits", "evidenceScope", "qualified", "witness"],
+    "required": ["schema", "receiptId", "profileId", "profileSuiteRoot", "collaborationRoot", "closureRoot", "profileRevision", "runtimeContract", "qualificationSource", "authority", "surfaceInventory", "noBypass", "clientProbes", "knownLimits", "evidenceScope", "qualified", "witness"],
     "properties": {
       "schema": { "const": "kungfu.profile-kfd3-qualification-receipt/v1" },
       "receiptId": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
@@ -393,6 +408,7 @@
       "closureRoot": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
       "profileRevision": { "type": "integer", "minimum": 1 },
       "runtimeContract": { "const": "kungfu.profile-lifecycle/v1" },
+      "qualificationSource": { "enum": ["local", "release"] },
       "authority": {
         "type": "object",
         "additionalProperties": false,
@@ -432,9 +448,9 @@
         "required": ["passed", "policy", "customViews", "executableFacetCount"],
         "properties": {
           "passed": { "const": true },
-          "policy": { "const": "generic-renderer-or-capability-free-sandboxed-view/v1" },
+          "policy": { "enum": ["generic-renderer-or-capability-free-sandboxed-view/v1", "release-owned-shared-api-parity/v1"] },
           "customViews": { "type": "array", "items": { "type": "object" } },
-          "executableFacetCount": { "const": 0 }
+          "executableFacetCount": { "type": "integer", "minimum": 0 }
         }
       },
       "clientProbes": {
@@ -443,12 +459,20 @@
         "items": {
           "type": "object",
           "additionalProperties": false,
-          "required": ["intentId", "humanPlanId", "agentPlanId", "actionPlanId", "matched"],
+          "required": ["intentId", "matched"],
           "properties": {
             "intentId": { "type": "string", "minLength": 1 },
             "humanPlanId": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
             "agentPlanId": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
             "actionPlanId": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+            "apiId": { "type": "string", "pattern": "^[A-Za-z0-9._-]+$" },
+            "surface": { "const": "cli-api-gui" },
+            "humanProjection": { "const": "work-dashboard-gui" },
+            "agentProjection": { "const": "provider-skill" },
+            "guiMember": { "type": "string", "pattern": "^[A-Za-z0-9._-]+$" },
+            "guiMethod": { "type": "string", "pattern": "^[A-Za-z0-9._-]+$" },
+            "guiProjectionRoot": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+            "guiProjectionKind": { "enum": ["built-view-bundle", "source-view"] },
             "matched": { "const": true }
           }
         }

--- a/framework/core/src/python/kungfu/cli/commands/profile.py
+++ b/framework/core/src/python/kungfu/cli/commands/profile.py
@@ -124,6 +124,85 @@ def kfd3_qualify(ctx, source, as_json):
 
 
 @profile.command(
+    name="kfd3-status",
+    help="inspect the current exact-root KFD-3 qualification without running probes",
+)
+@click.argument("source", type=click.Path(exists=True, file_okay=False, path_type=Path))
+@click.option("--json", "as_json", is_flag=True)
+@profile_context
+def kfd3_status(ctx, source, as_json):
+    _json(_run(lambda: profile_sdk.kfd3_status(source, ctx.runtime_dir)))
+
+
+@profile.command(
+    name="kfd3-plan",
+    help="preview the exact KFD-3 probes without executing them",
+)
+@click.argument("source", type=click.Path(exists=True, file_okay=False, path_type=Path))
+@click.option("--json", "as_json", is_flag=True)
+@profile_context
+def kfd3_plan(ctx, source, as_json):
+    _json(_run(lambda: profile_sdk.kfd3_qualification_plan(source, ctx.runtime_dir)))
+
+
+@profile.command(
+    name="kfd3-authorize",
+    help="authorize and execute one still-current KFD-3 qualification plan",
+)
+@click.argument("source", type=click.Path(exists=True, file_okay=False, path_type=Path))
+@click.option("--expected-plan-id", required=True)
+@click.option("--choice", required=True, type=click.Choice(["approve", "deny"]))
+@click.option("--authorized-by", required=True)
+@click.option("--json", "as_json", is_flag=True)
+@profile_context
+def kfd3_authorize(ctx, source, expected_plan_id, choice, authorized_by, as_json):
+    _json(
+        _run(
+            lambda: profile_sdk.authorize_kfd3_qualification(
+                source,
+                ctx.runtime_dir,
+                expected_plan_id,
+                choice,
+                authorized_by,
+            )
+        )
+    )
+
+
+@profile.command(
+    name="kfd3-release-build",
+    help="run factory qualification and write an exact-root system Profile manifest",
+)
+@click.argument(
+    "sources",
+    nargs=-1,
+    required=True,
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+)
+@click.option("--out", required=True, type=click.Path(dir_okay=False, path_type=Path))
+@click.option("--json", "as_json", is_flag=True)
+@profile_context
+def kfd3_release_build(ctx, sources, out, as_json):
+    def operation():
+        manifest = profile_sdk.build_kfd3_release_manifest(
+            list(sources), ctx.runtime_dir
+        )
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(
+            json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+        return {
+            "schema": "kungfu.system-profile-kfd3-build-receipt/v1",
+            "out": str(out.resolve()),
+            "manifestRoot": manifest["manifestRoot"],
+            "profiles": [row["profileId"] for row in manifest["entries"]],
+            "verified": True,
+        }
+
+    _json(_run(operation))
+
+
+@profile.command(
     name="kfd3-verify",
     help="verify a KFD-3 qualification receipt against the current earned cut",
 )

--- a/framework/core/src/python/kungfu/profile_sdk.py
+++ b/framework/core/src/python/kungfu/profile_sdk.py
@@ -14,6 +14,7 @@ import base64
 import json
 import os
 import re
+import sys
 from pathlib import Path
 from typing import Any, Mapping
 
@@ -39,6 +40,8 @@ INTENT_PLAN_SCHEMA = "kungfu.profile-intent-plan/v1"
 INTENT_RECEIPT_SCHEMA = "kungfu.profile-intent-receipt/v1"
 KFD3_QUALIFICATION_RECEIPT_SCHEMA = "kungfu.profile-kfd3-qualification-receipt/v1"
 KFD3_WITNESS_SCHEMA = "kungfu.profile-kfd3-witness/v1"
+KFD3_QUALIFICATION_PLAN_SCHEMA = "kungfu.profile-kfd3-qualification-plan/v1"
+KFD3_RELEASE_MANIFEST_SCHEMA = "kungfu.system-profile-kfd3-manifest/v1"
 
 _TOKEN = re.compile(r"^[A-Za-z0-9._-]+$")
 _IGNORED_PARTS = {".git", "node_modules", "__pycache__", ".DS_Store"}
@@ -98,6 +101,9 @@ def capabilities() -> dict[str, Any]:
             "qualify",
             "collaboration",
             "application",
+            "kfd3-status",
+            "kfd3-plan",
+            "kfd3-authorize",
             "kfd3-qualify",
             "kfd3-verify",
             "intent-inspect",
@@ -506,25 +512,13 @@ def application(
         )
     qualification_status: dict[str, Any] = {
         "qualified": False,
-        "status": "not-qualified",
-        "reason": "Profile must be active at this exact root before KFD-3 qualification",
+        "status": "untested",
+        "current": False,
+        "reason": "Profile KFD-3 qualification has not been tested",
+        "nextActions": [],
     }
-    if include_qualification and active_exact_root:
-        try:
-            earned = qualify_kfd3(source, runtime_dir)
-            qualification_status = {
-                "qualified": True,
-                "status": "qualified",
-                "receiptId": earned["receiptId"],
-                "witnessId": earned["witness"]["witnessId"],
-                "evidenceScope": earned["evidenceScope"],
-            }
-        except ProfileSdkError as error:
-            qualification_status = {
-                "qualified": False,
-                "status": "qualification-failed",
-                "diagnosis": error.diagnosis,
-            }
+    if include_qualification:
+        qualification_status = kfd3_status(source, runtime_dir)
     return {
         "schema": "kungfu.profile-application/v1",
         "profileId": profile["id"],
@@ -858,8 +852,121 @@ def _profile_facet_audit(resolved: Mapping[str, Any]) -> dict[str, Any]:
     }
 
 
-def qualify_kfd3(source: str | Path, runtime_dir: str | Path) -> dict[str, Any]:
-    """Earn a deterministic KFD-3 receipt and scoped witness for one active root."""
+def _shared_api_release_audit(
+    projection: Mapping[str, Any], resolved: Mapping[str, Any]
+) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    """Prove first-party GUI/Agent parity through the installed API authority."""
+
+    from kungfu.agent.kfd3 import registry
+
+    apis = {row.get("id"): row for row in registry().get("apis", [])}
+    probes = []
+    failures = []
+    for intent in projection["intents"]:
+        protocol = intent.get("protocol") or {}
+        api_id = protocol.get("apiId") if protocol.get("mode") == "shared-api" else None
+        api = apis.get(api_id)
+        projections = set((api or {}).get("projections") or [])
+        gui_member = str(protocol.get("guiMember") or "")
+        gui_method = str(protocol.get("guiMethod") or "")
+        gui_package = Path(
+            str((resolved.get("memberPackages") or {}).get(gui_member, ""))
+        )
+        gui_manifest = (
+            kfx_contract.read_manifest_from_dir(str(gui_package))
+            if gui_package.is_dir()
+            else {}
+        )
+        view = ((gui_manifest.get("kungfuConfig") or {}).get("config") or {}).get(
+            "view"
+        ) or {}
+        bundle = gui_package / str(view.get("entry") or "dist/view/index.js")
+        source_view = gui_package / "src" / "view" / "index.tsx"
+        projection_path = bundle if bundle.is_file() else source_view
+        projection_kind = "built-view-bundle" if bundle.is_file() else "source-view"
+        projection_data = (
+            projection_path.read_bytes() if projection_path.is_file() else b""
+        )
+        gui_bound = bool(
+            projection_data
+            and re.search(
+                rb"\." + re.escape(gui_method.encode("utf-8")) + rb"\s*\(",
+                projection_data,
+            )
+        )
+        matched = bool(
+            api
+            and api.get("surface") == "cli-api-gui"
+            and "work-dashboard-gui" in projections
+            and "provider-skill" in projections
+            and gui_bound
+        )
+        if not matched:
+            failures.append(
+                {
+                    "intentId": intent["id"],
+                    "apiId": api_id,
+                    "guiMember": gui_member,
+                    "guiMethod": gui_method,
+                    "reason": "shared API lacks a bound GUI method or matching Agent projection",
+                }
+            )
+            continue
+        probes.append(
+            {
+                "intentId": intent["id"],
+                "apiId": api_id,
+                "surface": "cli-api-gui",
+                "humanProjection": "work-dashboard-gui",
+                "agentProjection": "provider-skill",
+                "guiMember": gui_member,
+                "guiMethod": gui_method,
+                "guiProjectionRoot": "sha256:" + _sha256(projection_data),
+                "guiProjectionKind": projection_kind,
+                "matched": True,
+            }
+        )
+    if failures:
+        raise ProfileSdkError(
+            "kfd3-release-api-parity-failed",
+            "one or more first-party intents lack the same GUI and Agent API surface",
+            failures=failures,
+        )
+    facets = []
+    executable_count = 0
+    for key, package_dir in sorted(
+        {
+            "suite": Path(str(resolved["source"])),
+            **{
+                str(key): Path(str(path))
+                for key, path in (resolved.get("memberPackages") or {}).items()
+            },
+        }.items()
+    ):
+        manifest = kfx_contract.read_manifest_from_dir(str(package_dir))
+        config = (manifest.get("kungfuConfig") or {}).get("config") or {}
+        for facet in ("view", "adapter", "service", "wasm"):
+            if config.get(facet) is not None:
+                executable_count += 1
+                facets.append({"packageKey": key, "facet": facet})
+    return (
+        {
+            "passed": True,
+            "policy": "release-owned-shared-api-parity/v1",
+            "customViews": facets,
+            "executableFacetCount": executable_count,
+        },
+        probes,
+    )
+
+
+def _earn_kfd3(
+    source: str | Path,
+    runtime_dir: str | Path,
+    *,
+    qualification_source: str,
+) -> dict[str, Any]:
+    """Run the KFD-3 probes and return a receipt for the next lifecycle revision."""
 
     validated = validate_source(source, runtime_dir)
     resolved = validated["source"]
@@ -870,7 +977,7 @@ def qualify_kfd3(source: str | Path, runtime_dir: str | Path) -> dict[str, Any]:
             "KFD-3 qualification requires a content-bound collaboration facet",
         )
     projection = application(source, runtime_dir, include_qualification=False)
-    if not projection["activeExactRoot"]:
+    if qualification_source == "local" and not projection["activeExactRoot"]:
         raise ProfileSdkError(
             "kfd3-active-root-required",
             "KFD-3 qualification requires the exact Profile root to be active",
@@ -880,44 +987,47 @@ def qualify_kfd3(source: str | Path, runtime_dir: str | Path) -> dict[str, Any]:
             "kfd3-intent-probe-required",
             "KFD-3 qualification requires at least one material intent probe",
         )
-    unsupported = [
-        row["id"]
-        for row in projection["intents"]
-        if row["action"]["runner"] != "profile-lifecycle"
-        or row["action"]["operation"] not in {"qualify", "activate", "remove"}
-    ]
-    if unsupported:
-        raise ProfileSdkError(
-            "kfd3-action-runtime-unqualified",
-            "one or more material intents do not resolve to an executable confined runtime",
-            intentIds=unsupported,
-        )
     authority = _agent_interface_authority()
-    no_bypass = _profile_facet_audit(resolved)
-    probes = []
-    for intent in projection["intents"]:
-        human_plan = intent_plan(source, runtime_dir, intent["id"], {})
-        agent_plan = intent_plan(source, runtime_dir, intent["id"], {})
-        matched = (
-            human_plan["planId"] == agent_plan["planId"]
-            and human_plan["actionPlanId"] == agent_plan["actionPlanId"]
-            and human_plan["closureRoot"] == agent_plan["closureRoot"]
-        )
-        if not matched:
+    if qualification_source == "release":
+        no_bypass, probes = _shared_api_release_audit(projection, resolved)
+    else:
+        unsupported = [
+            row["id"]
+            for row in projection["intents"]
+            if row["action"]["runner"] != "profile-lifecycle"
+            or row["action"]["operation"] not in {"qualify", "activate", "remove"}
+        ]
+        if unsupported:
             raise ProfileSdkError(
-                "kfd3-dual-client-drift",
-                "Human and Agent probes produced different exact plans",
-                intentId=intent["id"],
+                "kfd3-action-runtime-unqualified",
+                "one or more material intents do not resolve to an executable confined runtime",
+                intentIds=unsupported,
             )
-        probes.append(
-            {
-                "intentId": intent["id"],
-                "humanPlanId": human_plan["planId"],
-                "agentPlanId": agent_plan["planId"],
-                "actionPlanId": human_plan["actionPlanId"],
-                "matched": True,
-            }
-        )
+        no_bypass = _profile_facet_audit(resolved)
+        probes = []
+        for intent in projection["intents"]:
+            human_plan = intent_plan(source, runtime_dir, intent["id"], {})
+            agent_plan = intent_plan(source, runtime_dir, intent["id"], {})
+            matched = (
+                human_plan["planId"] == agent_plan["planId"]
+                and human_plan["actionPlanId"] == agent_plan["actionPlanId"]
+                and human_plan["closureRoot"] == agent_plan["closureRoot"]
+            )
+            if not matched:
+                raise ProfileSdkError(
+                    "kfd3-dual-client-drift",
+                    "Human and Agent probes produced different exact plans",
+                    intentId=intent["id"],
+                )
+            probes.append(
+                {
+                    "intentId": intent["id"],
+                    "humanPlanId": human_plan["planId"],
+                    "agentPlanId": agent_plan["planId"],
+                    "actionPlanId": human_plan["actionPlanId"],
+                    "matched": True,
+                }
+            )
     inventory = {
         "intentIds": sorted(row["id"] for row in projection["intents"]),
         "actionIds": sorted(row["actionId"] for row in projection["intents"]),
@@ -935,8 +1045,13 @@ def qualify_kfd3(source: str | Path, runtime_dir: str | Path) -> dict[str, Any]:
         "profileSuiteRoot": projection["profileSuiteRoot"],
         "collaborationRoot": projection["collaborationRoot"],
         "closureRoot": projection["closureRoot"],
-        "profileRevision": projection["profileRevision"],
+        "profileRevision": (
+            1
+            if qualification_source == "release"
+            else int(projection["profileRevision"] or 0) + 1
+        ),
         "runtimeContract": "kungfu.profile-lifecycle/v1",
+        "qualificationSource": qualification_source,
         "authority": authority,
         "surfaceInventory": inventory,
         "noBypass": no_bypass,
@@ -946,8 +1061,16 @@ def qualify_kfd3(source: str | Path, runtime_dir: str | Path) -> dict[str, Any]:
             "installed-agent-interface-closure",
             "profile-content-closure",
             "public-surface-inventory",
-            "custom-view-no-bypass",
-            "dual-client-exact-plan",
+            (
+                "release-owned-shared-api-parity"
+                if qualification_source == "release"
+                else "custom-view-no-bypass"
+            ),
+            (
+                "gui-agent-api-registry-match"
+                if qualification_source == "release"
+                else "dual-client-exact-plan"
+            ),
         ],
     }
     receipt = {
@@ -981,6 +1104,336 @@ def qualify_kfd3(source: str | Path, runtime_dir: str | Path) -> dict[str, Any]:
     return result
 
 
+def build_kfd3_release_manifest(
+    sources: list[str | Path], runtime_dir: str | Path
+) -> dict[str, Any]:
+    """Run factory qualification and emit exact-root release receipts."""
+
+    entries = []
+    for source in sources:
+        receipt = _earn_kfd3(source, runtime_dir, qualification_source="release")
+        entries.append(
+            {
+                "profileId": receipt["profileId"],
+                "profileSuiteRoot": receipt["profileSuiteRoot"],
+                "receipt": receipt,
+            }
+        )
+    entries.sort(key=lambda row: (row["profileId"], row["profileSuiteRoot"]))
+    identity = {"schema": KFD3_RELEASE_MANIFEST_SCHEMA, "entries": entries}
+    return {**identity, "manifestRoot": _root(identity)}
+
+
+def _release_qualification_receipt(
+    profile_id: str, profile_suite_root: str
+) -> dict[str, Any] | None:
+    paths = []
+    explicit = os.environ.get("KF_PROFILE_KFD3_MANIFEST")
+    if explicit:
+        paths.append(Path(explicit))
+    first_party = os.environ.get("KF_FIRST_PARTY_MANIFEST")
+    if first_party:
+        paths.append(Path(first_party).with_name("profile-kfd3.json"))
+    paths.append(Path(sys.executable).resolve().with_name("profile-kfd3.json"))
+    seen = set()
+    fallback = None
+    for path in paths:
+        resolved = path.expanduser().resolve()
+        if resolved in seen or not resolved.is_file():
+            continue
+        seen.add(resolved)
+        try:
+            manifest = json.loads(resolved.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if manifest.get("schema") != KFD3_RELEASE_MANIFEST_SCHEMA:
+            continue
+        identity = {"schema": manifest["schema"], "entries": manifest.get("entries")}
+        if manifest.get("manifestRoot") != _root(identity):
+            continue
+        for entry in manifest.get("entries") or []:
+            if entry.get("profileId") != profile_id:
+                continue
+            receipt = dict(entry.get("receipt") or {})
+            if entry.get("profileSuiteRoot") == profile_suite_root:
+                return receipt
+            fallback = receipt
+    return fallback
+
+
+def _validate_kfd3_receipt_integrity(receipt: Mapping[str, Any]) -> None:
+    identity_keys = [
+        "profileId",
+        "profileSuiteRoot",
+        "collaborationRoot",
+        "closureRoot",
+        "profileRevision",
+        "runtimeContract",
+        "qualificationSource",
+        "authority",
+        "surfaceInventory",
+        "noBypass",
+        "clientProbes",
+        "knownLimits",
+        "evidenceScope",
+    ]
+    identity = {key: receipt.get(key) for key in identity_keys}
+    if receipt.get("receiptId") != _root(identity):
+        raise ProfileSdkError(
+            "kfd3-receipt-identity-invalid",
+            "KFD-3 receipt id does not bind its qualification evidence",
+        )
+    witness = receipt.get("witness") or {}
+    witness_identity = {
+        "profileId": receipt.get("profileId"),
+        "profileSuiteRoot": receipt.get("profileSuiteRoot"),
+        "collaborationRoot": receipt.get("collaborationRoot"),
+        "closureRoot": receipt.get("closureRoot"),
+        "qualificationReceiptId": receipt.get("receiptId"),
+        "authorityRegistryRoot": (receipt.get("authority") or {}).get("registryRoot"),
+        "claim": "profile-collaboration-closure-qualified",
+    }
+    if witness.get("witnessId") != _root(witness_identity):
+        raise ProfileSdkError(
+            "kfd3-witness-identity-invalid",
+            "KFD-3 witness id does not bind the receipt and authority roots",
+        )
+
+
+def kfd3_status(source: str | Path, runtime_dir: str | Path) -> dict[str, Any]:
+    """Return the machine-readable qualification state without running probes."""
+
+    validated = validate_source(source, runtime_dir)
+    inspection = validated["inspection"]
+    closure = validated["collaboration"]
+    profile_id = inspection["profile"]["id"]
+    try:
+        state = storage_service.profile_lifecycle(
+            runtime_dir, "get", profile_id=profile_id, include_removed=True
+        )
+    except ValueError as error:
+        if not str(error).startswith("Profile not found:"):
+            raise
+        state = None
+    active_exact_root = bool(
+        state
+        and state.get("activated")
+        and state.get("profile_suite_root") == inspection["profile_suite_root"]
+    )
+    receipt = (state or {}).get("kfd3_qualification") or {}
+    if not receipt:
+        receipt = (
+            _release_qualification_receipt(profile_id, inspection["profile_suite_root"])
+            or {}
+        )
+    base = {
+        "schema": "kungfu.profile-kfd3-status/v1",
+        "profileId": profile_id,
+        "profileSuiteRoot": inspection["profile_suite_root"],
+        "qualified": False,
+        "current": False,
+        "activeExactRoot": active_exact_root,
+        "receiptId": receipt.get("receiptId"),
+        "witnessId": (receipt.get("witness") or {}).get("witnessId"),
+        "qualificationSource": receipt.get("qualificationSource"),
+    }
+    if not closure["declared"]:
+        return {
+            **base,
+            "status": "failed",
+            "reason": closure["reason"],
+            "nextActions": [],
+        }
+    if not active_exact_root:
+        return {
+            **base,
+            "status": "stale" if receipt else "untested",
+            "reason": "Profile must be active at this exact root before KFD-3 qualification",
+            "nextActions": [{"action": "profile.activate", "requiresApproval": True}],
+        }
+    if not receipt:
+        release_only = bool(closure["intents"]) and all(
+            (row.get("protocol") or {}).get("mode") == "shared-api"
+            for row in closure["intents"]
+        )
+        return {
+            **base,
+            "status": "untested",
+            "reason": (
+                "No factory KFD-3 release receipt exists for this exact system Profile root"
+                if release_only
+                else "No KFD-3 qualification receipt exists for this exact Profile root"
+            ),
+            "nextActions": (
+                [{"action": "product.verify-release", "requiresApproval": False}]
+                if release_only
+                else [
+                    {"action": "profile.kfd3.plan", "requiresApproval": False},
+                    {"action": "profile.kfd3.qualify", "requiresApproval": True},
+                ]
+            ),
+        }
+    try:
+        _validate_sdk_value(
+            "kfd3QualificationReceiptSchema",
+            receipt,
+            "stored KFD-3 qualification receipt",
+        )
+        _validate_kfd3_receipt_integrity(receipt)
+    except ProfileSdkError as error:
+        return {
+            **base,
+            "status": "failed",
+            "reason": "Stored KFD-3 qualification receipt is invalid",
+            "diagnosis": error.diagnosis,
+            "nextActions": [{"action": "profile.kfd3.plan", "requiresApproval": False}],
+        }
+    authority = _agent_interface_authority()
+    current = bool(
+        receipt.get("profileId") == profile_id
+        and receipt.get("profileSuiteRoot") == inspection["profile_suite_root"]
+        and receipt.get("collaborationRoot") == closure["collaborationRoot"]
+        and receipt.get("closureRoot") == closure["closureRoot"]
+        and (receipt.get("authority") or {}).get("registryRoot")
+        == authority["registryRoot"]
+    )
+    if not current:
+        return {
+            **base,
+            "status": "stale",
+            "reason": "Profile or KFD-3 Runtime contract changed after qualification",
+            "nextActions": [
+                {"action": "profile.kfd3.plan", "requiresApproval": False},
+                {"action": "profile.kfd3.qualify", "requiresApproval": True},
+            ],
+        }
+    return {
+        **base,
+        "status": "qualified",
+        "qualified": True,
+        "current": True,
+        "issuer": {
+            "type": receipt["qualificationSource"],
+            "name": (
+                "Kungfu release qualification"
+                if receipt["qualificationSource"] == "release"
+                else "Kungfu local qualification"
+            ),
+        },
+        "policyVersion": "kfd3-profile-collaboration/v1",
+        "runtimeContractRoot": authority["registryRoot"],
+        "evidenceScope": receipt["evidenceScope"],
+        "nextActions": [{"action": "profile.kfd3.verify", "requiresApproval": False}],
+    }
+
+
+def kfd3_qualification_plan(
+    source: str | Path, runtime_dir: str | Path
+) -> dict[str, Any]:
+    """Describe the exact probes without executing or persisting them."""
+
+    projection = application(source, runtime_dir, include_qualification=False)
+    if not projection["activeExactRoot"]:
+        raise ProfileSdkError(
+            "kfd3-active-root-required",
+            "KFD-3 qualification requires the exact Profile root to be active",
+        )
+    identity = {
+        "profileId": projection["profileId"],
+        "profileSuiteRoot": projection["profileSuiteRoot"],
+        "collaborationRoot": projection["collaborationRoot"],
+        "closureRoot": projection["closureRoot"],
+        "profileRevision": projection["profileRevision"],
+        "runtimeContractRoot": _agent_interface_authority()["registryRoot"],
+        "intentIds": sorted(row["id"] for row in projection["intents"]),
+        "policyVersion": "kfd3-profile-collaboration/v1",
+    }
+    plan_id = _root(identity)
+    card = decision_card(
+        "profile-kfd3-qualification",
+        "Run the exact KFD-3 dual-client and no-bypass probes for this Profile root.",
+        choices=["approve", "deny"],
+        basis={"planId": plan_id, **identity},
+        required_authority="workspace-profile-operator",
+        resume_command="kungfu profile kfd3-authorize <source> --expected-plan-id <id> --choice approve --authorized-by <actor> --json",
+    )
+    return {
+        "schema": KFD3_QUALIFICATION_PLAN_SCHEMA,
+        "planId": plan_id,
+        **identity,
+        "probes": [
+            "profile-content-closure",
+            "application-authority",
+            "public-surface-inventory",
+            "custom-view-no-bypass",
+            "dual-client-exact-plan",
+        ],
+        "sideEffects": ["append Kfd3Qualified lifecycle fact after all probes pass"],
+        "requiresAuthorization": True,
+        "decisionCard": card,
+    }
+
+
+def qualify_kfd3(
+    source: str | Path,
+    runtime_dir: str | Path,
+    *,
+    authorization_id: str = "kfd3-cli-explicit",
+    qualification_source: str = "local",
+) -> dict[str, Any]:
+    """Run probes once and persist the earned receipt in the lifecycle journal."""
+
+    status = kfd3_status(source, runtime_dir)
+    if status["qualified"]:
+        if status.get("qualificationSource") == "release":
+            receipt = _release_qualification_receipt(
+                status["profileId"], status["profileSuiteRoot"]
+            )
+            if receipt:
+                return receipt
+        else:
+            state = storage_service.profile_lifecycle(
+                runtime_dir, "get", profile_id=status["profileId"]
+            )
+            return dict(state["kfd3_qualification"])
+    receipt = _earn_kfd3(source, runtime_dir, qualification_source=qualification_source)
+    core_plan = lifecycle_plan(
+        runtime_dir, "kfd3-qualify", source, qualification=receipt
+    )["corePlan"]
+    lifecycle_apply(runtime_dir, core_plan, authorization_id)
+    return receipt
+
+
+def authorize_kfd3_qualification(
+    source: str | Path,
+    runtime_dir: str | Path,
+    expected_plan_id: str,
+    choice: str,
+    authorized_by: str,
+) -> dict[str, Any]:
+    """Execute one reviewed KFD-3 plan and persist its exact-root receipt."""
+
+    plan = kfd3_qualification_plan(source, runtime_dir)
+    if plan["planId"] != expected_plan_id:
+        raise ProfileSdkError(
+            "kfd3-plan-stale",
+            "Profile or Runtime contract changed after KFD-3 planning",
+            expectedPlanId=expected_plan_id,
+            actualPlanId=plan["planId"],
+        )
+    answer = answer_decision(plan["decisionCard"], choice, authorized_by)
+    if answer["choice"] != "approve":
+        raise ProfileSdkError(
+            "kfd3-qualification-denied", "KFD-3 qualification was denied"
+        )
+    return qualify_kfd3(
+        source,
+        runtime_dir,
+        authorization_id=answer["authorizationId"],
+        qualification_source="local",
+    )
+
+
 def verify_kfd3(
     source: str | Path, runtime_dir: str | Path, receipt: Mapping[str, Any]
 ) -> dict[str, Any]:
@@ -991,7 +1444,27 @@ def verify_kfd3(
         dict(receipt),
         "KFD-3 qualification receipt",
     )
-    current = qualify_kfd3(source, runtime_dir)
+    status = kfd3_status(source, runtime_dir)
+    if not status["qualified"]:
+        raise ProfileSdkError(
+            "kfd3-qualification-not-current",
+            "Profile has no current KFD-3 qualification receipt",
+            status=status,
+        )
+    if status.get("qualificationSource") == "release":
+        current = _release_qualification_receipt(
+            status["profileId"], status["profileSuiteRoot"]
+        )
+    else:
+        state = storage_service.profile_lifecycle(
+            runtime_dir, "get", profile_id=status["profileId"]
+        )
+        current = dict(state["kfd3_qualification"])
+    if not current:
+        raise ProfileSdkError(
+            "kfd3-qualification-not-current",
+            "Profile has no current KFD-3 qualification receipt",
+        )
     if dict(receipt) != current:
         raise ProfileSdkError(
             "kfd3-qualification-stale-or-tampered",
@@ -1644,7 +2117,7 @@ def _validate_decision_answer(
 
 def package_content_root(package_dir: str | Path) -> str:
     root = Path(package_dir).resolve()
-    rows = []
+    rows: list[dict[str, Any]] = []
     for path in root.rglob("*"):
         relative = path.relative_to(root)
         if any(part in _IGNORED_PARTS for part in relative.parts):

--- a/framework/core/tests/python/test_agent_profile_sdk.py
+++ b/framework/core/tests/python/test_agent_profile_sdk.py
@@ -478,16 +478,26 @@ def test_kfd3_qualification_earns_receipt_and_witness_for_exact_active_root(
         core_plan = profile_sdk.lifecycle_plan(runtime, action, source)["corePlan"]
         profile_sdk.lifecycle_apply(runtime, core_plan, f"test:{action}")
 
-    receipt = profile_sdk.qualify_kfd3(source, runtime)
+    before = profile_sdk.application(source, runtime)
+    plan = profile_sdk.kfd3_qualification_plan(source, runtime)
+    assert before["qualification"]["status"] == "untested"
+    assert plan["requiresAuthorization"] is True
+    assert profile_sdk.kfd3_status(source, runtime)["status"] == "untested"
+    receipt = profile_sdk.authorize_kfd3_qualification(
+        source, runtime, plan["planId"], "approve", "test-owner"
+    )
     projected = profile_sdk.application(source, runtime)
 
     assert receipt["schema"] == "kungfu.profile-kfd3-qualification-receipt/v1"
     assert receipt["qualified"] is True
+    assert receipt["qualificationSource"] == "local"
     assert receipt["noBypass"]["passed"] is True
     assert receipt["clientProbes"][0]["matched"] is True
     assert receipt["witness"]["qualificationReceiptId"] == receipt["receiptId"]
     assert receipt["witness"]["issuer"] == "kungfu-profile-runtime"
     assert projected["qualified"] is True
+    assert projected["qualification"]["status"] == "qualified"
+    assert projected["qualification"]["issuer"]["type"] == "local"
     assert projected["qualification"]["witnessId"] == receipt["witness"]["witnessId"]
     assert profile_sdk.verify_kfd3(source, runtime, receipt)["verified"] is True
 
@@ -516,6 +526,41 @@ def test_kfd3_qualification_earns_receipt_and_witness_for_exact_active_root(
         assert error.diagnosis["code"] == "kfd3-qualification-stale-or-tampered"
     else:
         raise AssertionError("tampered KFD-3 receipt was verified")
+
+
+def test_system_profile_release_receipt_is_exact_root_and_shared_with_status(
+    tmp_path, monkeypatch
+):
+    repo = Path(__file__).resolve().parents[4]
+    source = repo / "extensions" / "mission-control"
+    runtime = tmp_path / "runtime"
+    manifest = profile_sdk.build_kfd3_release_manifest([source], runtime)
+    receipt = manifest["entries"][0]["receipt"]
+
+    assert receipt["profileId"] == "kungfu.mission-control"
+    assert receipt["qualificationSource"] == "release"
+    assert receipt["noBypass"]["policy"] == "release-owned-shared-api-parity/v1"
+    assert len(receipt["clientProbes"]) == 4
+    assert all(row["matched"] for row in receipt["clientProbes"])
+
+    manifest_path = tmp_path / "profile-kfd3.json"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+    monkeypatch.setenv("KF_PROFILE_KFD3_MANIFEST", str(manifest_path))
+    for action in ["install", "qualify", "activate"]:
+        core_plan = profile_sdk.lifecycle_plan(runtime, action, source)["corePlan"]
+        profile_sdk.lifecycle_apply(runtime, core_plan, f"test:{action}")
+
+    status = profile_sdk.kfd3_status(source, runtime)
+    assert status["status"] == "qualified"
+    assert status["qualificationSource"] == "release"
+    assert status["issuer"]["type"] == "release"
+    assert status["receiptId"] == receipt["receiptId"]
+    assert profile_sdk.verify_kfd3(source, runtime, receipt)["verified"] is True
+
+    tampered = json.loads(json.dumps(manifest))
+    tampered["entries"][0]["profileSuiteRoot"] = "sha256:" + "0" * 64
+    manifest_path.write_text(json.dumps(tampered), encoding="utf-8")
+    assert profile_sdk.kfd3_status(source, runtime)["status"] == "untested"
 
 
 def test_kfd3_qualification_rejects_custom_view_mutation_boundary(tmp_path):
@@ -659,8 +704,7 @@ def test_kfd3_receipt_survives_portable_import_and_invalidates_on_upgrade(
     profile_sdk.lifecycle_apply(runtime_b, rollback, "portable-b:rollback")
     rolled_back = profile_sdk.qualify_kfd3(source, runtime_b)
     assert rolled_back["profileSuiteRoot"] == receipt_b["profileSuiteRoot"]
-    assert rolled_back["receiptId"] != receipt_b["receiptId"]
-    assert rolled_back["profileRevision"] > receipt_b["profileRevision"]
+    assert rolled_back["receiptId"] == receipt_b["receiptId"]
 
 
 def test_missing_member_fails_with_stable_decision_card(tmp_path):

--- a/framework/gui/scripts/before-pack.cjs
+++ b/framework/gui/scripts/before-pack.cjs
@@ -17,15 +17,20 @@ function esmEntrypointArgs(entryPath) {
 }
 
 exports.default = async function beforePack() {
-  const gen = path.join(__dirname, 'gen-first-party-manifest.mjs');
   const tsxLoader = require.resolve('tsx/esm');
-  const result = spawnSync(
-    process.execPath,
-    ['--import', tsxLoader, ...esmEntrypointArgs(gen)],
-    { stdio: 'inherit' },
-  );
-  if (result.status !== 0) {
-    throw new Error('failed to bake the first-party manifest before pack');
+  for (const [script, label] of [
+    ['gen-first-party-manifest.mjs', 'first-party manifest'],
+    ['gen-system-profile-kfd3.mjs', 'system Profile KFD-3 manifest'],
+  ]) {
+    const gen = path.join(__dirname, script);
+    const result = spawnSync(
+      process.execPath,
+      ['--import', tsxLoader, ...esmEntrypointArgs(gen)],
+      { stdio: 'inherit' },
+    );
+    if (result.status !== 0) {
+      throw new Error(`failed to bake the ${label} before pack`);
+    }
   }
 };
 

--- a/framework/gui/scripts/bundle-core-audit.cjs
+++ b/framework/gui/scripts/bundle-core-audit.cjs
@@ -90,6 +90,7 @@ function auditPackagedApp(appDir, options = {}) {
     'kungfu',
     'kungfu_electron.node',
     'libkungfu.dylib',
+    'profile-kfd3.json',
   ]) {
     const p = path.join(runtimeDir, required);
     if (!exists(p)) throw new Error(`missing runtime file: ${p}`);

--- a/framework/gui/scripts/gen-system-profile-kfd3.mjs
+++ b/framework/gui/scripts/gen-system-profile-kfd3.mjs
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+// Run the shipped runtime's factory qualification harness after first-party
+// extensions have been built, then place its exact-root manifest beside the
+// frozen CLI. Product runtime reads this file; Profile identity or API authority
+// drift makes the receipt stale instead of preserving a cosmetic badge.
+import { spawnSync } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const root = join(here, '..', '..', '..');
+const coreDist = join(root, 'framework', 'core', 'dist', 'kungfu');
+const executable = join(
+  coreDist,
+  process.platform === 'win32' ? 'kungfu.exe' : 'kungfu',
+);
+const missionControl = join(root, 'extensions', 'mission-control');
+const out = join(coreDist, 'profile-kfd3.json');
+const runtime = join(root, 'framework', 'gui', 'out', 'kfd3-release-runtime');
+
+const result = spawnSync(
+  executable,
+  ['profile', 'kfd3-release-build', missionControl, '--out', out, '--json'],
+  {
+    env: { ...process.env, KF_RUNTIME_DIR: runtime },
+    encoding: 'utf8',
+  },
+);
+
+if (result.status !== 0) {
+  if (result.stdout) process.stderr.write(result.stdout);
+  if (result.stderr) process.stderr.write(result.stderr);
+  throw new Error('system Profile KFD-3 factory qualification failed');
+}
+process.stdout.write(result.stdout);

--- a/framework/gui/src/main/index.ts
+++ b/framework/gui/src/main/index.ts
@@ -278,6 +278,13 @@ if (!process.env.KF_FIRST_PARTY_MANIFEST && workspaceRuntimeReady) {
     process.env.KF_FIRST_PARTY_MANIFEST = manifestPath;
   }
 }
+if (!process.env.KF_PROFILE_KFD3_MANIFEST && app.isPackaged) {
+  process.env.KF_PROFILE_KFD3_MANIFEST = path.join(
+    process.resourcesPath,
+    'kungfu',
+    'profile-kfd3.json',
+  );
+}
 
 if (
   !process.env.KF_SKILL_CONTEXT_FILE &&

--- a/tests/qualification/profile-kfd3/run.ts
+++ b/tests/qualification/profile-kfd3/run.ts
@@ -52,17 +52,6 @@ type QualificationReceipt = {
   }>;
 };
 const env = { ...runtimeEnv, KF_RUNTIME_DIR: context.runtime };
-const agentReceipt = JSON.parse(
-  execFileSync(
-    python,
-    ['-m', 'kungfu', 'profile', 'kfd3-qualify', context.source, '--json'],
-    {
-      encoding: 'utf8',
-      env,
-    },
-  ),
-) as QualificationReceipt;
-
 const execSync = (
   file: string,
   args: string[],
@@ -83,9 +72,22 @@ const human = openProfile({
   env,
   execFileSync: execSync,
 });
+// Capture the Human plan at the same lifecycle cut used by the Agent CLI
+// qualification probes. Qualification itself advances the Profile revision,
+// so an exact plan created afterwards is intentionally different and stale.
+const humanPlan = human.intentPlan(context.source, context.intentId);
+const agentReceipt = JSON.parse(
+  execFileSync(
+    python,
+    ['-m', 'kungfu', 'profile', 'kfd3-qualify', context.source, '--json'],
+    {
+      encoding: 'utf8',
+      env,
+    },
+  ),
+) as QualificationReceipt;
 const humanReceipt = human.qualifyKfd3(context.source);
 const application = human.application(context.source);
-const humanPlan = human.intentPlan(context.source, context.intentId);
 
 assert.equal(context.profileId, 'example.week-day');
 assert.equal(agentReceipt.profileSuiteRoot, context.profileSuiteRoot);


### PR DESCRIPTION
## Summary

Linear replacement for #749. The repository permits rebase merges only, while #749 contains a dev merge commit that GitHub cannot rebase. This branch is a single signed-off commit whose tree is byte-for-byte identical to the fully Mac-verified #749 head.

Productize KFD-3 qualification as one content-bound status shared by human and agent clients. Shipped system Profiles receive release-owned qualification evidence and the same visible badge semantics that a user Profile earns through an explicit plan and authorization flow.

## Related issue

- Supersedes #749 for merge topology only
- Atlas goal: 2026-07-13-kungfu-profile-kfd3-badge-and-agent-status

## Changes

- add an append-only KFD-3 qualification lifecycle fact bound to the exact Profile Suite root
- expose status, plan, authorize, and verify operations through the Profile SDK, CLI, TypeScript API, and Agent catalog
- remove implicit qualification probes from Profile application projection
- bake release-owned Mission Control qualification evidence into Product artifacts
- bind Mission Control qualification to the shared GUI and Agent APIs
- render one emoji badge vocabulary and detailed tooltip in Profile Manager

## Verification

- ./shifu check
- ./shifu test:kfx-profile-suite
- ./shifu test:profile-lifecycle
- ./shifu test:agent-profile-sdk: 47 passed
- ./shifu test:profile-kfd3-qualification: Agent CLI and typed Human API matched at one lifecycle cut
- Mac arm64 Core build: Apple Clang 21, C++23, 113 native targets plus Node/Electron/Python bindings and dual libwasm engines
- ./shifu freeze
- ./shifu --filter @kungfu-tech/kfx-view-work-dashboard run build
- Mission Control factory manifest: release-qualified, 4/4 shared GUI/Agent probes matched, built-view-bundle
- Linear branch tree equals the tested #749 head
- Linux/Conan central-cache repair is tracked independently and is not part of this Mac product closeout

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "stage-ready",
  "adrs": ["ADR-0069"],
  "summary": "Deliver exact-root KFD-3 qualification receipts, system and user badge parity, and one machine-readable Agent status contract.",
  "verification": ["Shifu changed-scope gate", "Profile lifecycle and SDK tests", "Profile Suite and API tests", "factory manifest qualification"]
}
-->

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The Product build now emits a content-rooted system Profile qualification manifest. Bundle audit and local qualification tests verify the manifest boundary; it contains no credentials or private runtime data.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed