### PR TITLE
feat(shifu): migrate gate workflow entrypoints

### DIFF
--- a/.github/workflows/adr-release-gate.yml
+++ b/.github/workflows/adr-release-gate.yml
@@ -25,5 +25,4 @@ jobs:
 
       - name: Verify ADR delivery intent
         run: >-
-          ./shifu adr:release:gate -- --github-event
-          --report product/release/qualification/adr-release-admissibility.json
+          ./shifu gate run governance.adr-delivery

--- a/.github/workflows/buildchain-validate.yml
+++ b/.github/workflows/buildchain-validate.yml
@@ -35,5 +35,4 @@ jobs:
           fetch-depth: 0
       - name: Rehearse alpha and stable promotion contracts
         run: >-
-          ./shifu release:promotion:rehearse --
-          --report product/release/qualification/release-promotion-rehearsal.json
+          ./shifu gate run governance.promotion-rehearsal

--- a/.github/workflows/dev-verify-patrol.yml
+++ b/.github/workflows/dev-verify-patrol.yml
@@ -74,7 +74,8 @@ jobs:
       # match the .buildchain/buildchain.toml stages.
       verify-command: >-
         bash -c "KUNGFU_BUILDCHAIN_NO_OPTIONAL=1 KUNGFU_BUILDCHAIN_SOURCE_BUILD=1
-        SHIFU_NATIVE=1 ./shifu cache apply -- ./shifu verify --full"
+        SHIFU_NATIVE=1 ./shifu cache apply -- ./shifu gate run product.verify-full
+        --capability native-toolchain --capability product-artifacts"
 
   # Keep one tracking issue in sync with the patrol result: open or refresh it
   # when dev is red, close it when dev returns to green. This is the standing

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -58,13 +58,10 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
-      - name: Check Markdown documentation from external tool cache
+      - name: Run blocking documentation Gate closure
         env:
           KUNGFU_DOCS_TOOL_CACHE: ${{ runner.temp }}/kungfu-docs-tools
-        run: ./shifu docs:check:readonly
-
-      - name: Enforce objective prose contracts
-        run: ./shifu docs:prose:required
+        run: ./shifu gate run docs.prose
 
       - name: Report advisory prose policy
         env:

--- a/.github/workflows/embedding-membrane-spike.yml
+++ b/.github/workflows/embedding-membrane-spike.yml
@@ -218,11 +218,13 @@ jobs:
       - name: Build and run membrane consumers (POSIX)
         if: ${{ runner.os != 'Windows' }}
         shell: bash
-        run: cd "$SOURCE_ROOT" && ./shifu qualify:embedding-membranes
+        run: >-
+          cd "$SOURCE_ROOT" && ./shifu gate run embedding.membranes
+          --capability native-toolchain --capability rust
 
       - name: Build and run membrane consumers (Windows)
         if: ${{ runner.os == 'Windows' }}
         shell: pwsh
         run: |
           Set-Location $env:SOURCE_ROOT
-          .\shifu.cmd qualify:embedding-membranes
+          .\shifu.cmd gate run embedding.membranes --capability native-toolchain --capability rust

--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -30,10 +30,7 @@ jobs:
           persist-credentials: false
 
       - name: Rehearse the Kungfu promotion contract
-        run: >-
-          ./shifu release:promotion:rehearse --
-          --event "$GITHUB_EVENT_PATH"
-          --report product/release/qualification/release-promotion-rehearsal.json
+        run: ./shifu gate run governance.promotion-rehearsal
 
   promote:
     needs: promotion-contract

--- a/.github/workflows/shifu-ci.yml
+++ b/.github/workflows/shifu-ci.yml
@@ -15,6 +15,10 @@ on:
       - release/v*/v*
     paths:
       - "crates/**"
+      - "scripts/check-shifu-workspace.mjs"
+      - "scripts/shifu-gate-*.mjs"
+      - "package.json"
+      - "shifu.gates.json"
       - ".github/workflows/shifu-ci.yml"
 
 permissions:
@@ -32,23 +36,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-      - name: Toolchain versions
-        run: rustc --version && cargo --version
-      - name: Format
-        run: cargo fmt --all --check
-        working-directory: crates
-      - name: Clippy
-        run: cargo clippy --workspace --all-targets -- -D warnings
-        working-directory: crates
-      - name: Test
-        run: cargo test --workspace
-        working-directory: crates
-      - name: Build (release)
-        run: cargo build --workspace --release
-        working-directory: crates
-      - name: Launcher smoke (self-version)
+      - uses: actions/setup-node@v6.4.0
+        with:
+          node-version: 24
+      - name: Run Shifu workspace Gate (POSIX)
         if: runner.os != 'Windows'
-        run: ./crates/target/release/shifu self-version
-      - name: Launcher smoke (self-version, Windows)
+        run: ./shifu gate run shifu.workspace --capability rust
+      - name: Run Shifu workspace Gate (Windows)
         if: runner.os == 'Windows'
-        run: .\crates\target\release\shifu.exe self-version
+        run: .\shifu.cmd gate run shifu.workspace --capability rust

--- a/docs/adr/SHIFU-ADR-0004-gate-control-plane-contract.md
+++ b/docs/adr/SHIFU-ADR-0004-gate-control-plane-contract.md
@@ -4,7 +4,7 @@ doc_type: architecture-decision
 adr_id: SHIFU-ADR-0004
 decision_status: accepted
 implementation_status: partial
-implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/762, https://github.com/kungfu-systems/kungfu/pull/765, https://github.com/kungfu-systems/kungfu/pull/767]
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/762, https://github.com/kungfu-systems/kungfu/pull/765, https://github.com/kungfu-systems/kungfu/pull/767, https://github.com/kungfu-systems/kungfu/pull/769]
 review_state: unreviewed
 sensitivity: public
 sources: [local-files, user-consensus]
@@ -101,11 +101,13 @@ the [Kungfu Gate catalog](../qualification/gates/README.md). A dedicated meta
 gate validates the registry, task references, detailed documentation, exact
 generated matrix, profile coverage, and current workflow bindings together.
 
-This projection records current policy without pretending migration is
-complete. Existing workflows remain the activation surface until they consume
-Shifu profile plans directly, and named handlers remain non-executable until a
-controller registers them. The workflow bindings make that compatibility debt
-explicit and fail closed when the recorded current source drifts.
+Task-backed workflows now enter through `shifu gate run` for ADR delivery,
+promotion rehearsal, documentation closure, development full verification,
+the native membrane matrix, and the Shifu workspace matrix. Supply-chain-pinned
+actions and Buildchain-owned orchestration remain explicit controller bindings;
+named handlers remain non-executable until those controllers register them.
+The workflow bindings make that remaining compatibility debt explicit and fail
+closed when either the execution authority or recorded current source drifts.
 
 ## Consequences
 

--- a/docs/qualification/gates/build-and-runtime.md
+++ b/docs/qualification/gates/build-and-runtime.md
@@ -18,7 +18,7 @@ Each section is bound to the registry id by the catalog meta gate.
 - **Evidence:** unified Gate receipt; artifacts `product/release`.
 - **Diagnosis:** `./shifu gate explain product.distribution --profile <profile>`; reproduce with `./shifu gate run product.distribution` on a capable runner.
 - **Cost:** heavy; timeout 7200 seconds.
-- **Current source:** .github/workflows/dev-verify-patrol.yml (verify; daily or manual on dev); .github/workflows/build.yml (build; alpha or release pull request).
+- **Current source:** .github/workflows/build.yml (build; alpha or release pull request).
 - **Retirement:** remove only after every selecting profile and workflow binding is migrated or explicitly replaced, with the registry and matrix changed in the same review.
 <!-- /gate-doc:product.distribution -->
 
@@ -29,7 +29,7 @@ Each section is bound to the registry id by the catalog meta gate.
 - **Problem:** Rebuilds Core, freezes product, verifies runtime, slices, fixtures, and Episode smoke.
 - **Protects:** build regressions from becoming an unexplained green profile or release claim.
 - **Action:** `./shifu verify --full`
-- **Dependencies:** `product.distribution`.
+- **Dependencies:** `gate.catalog`.
 - **Platforms and runner:** linux, macos, windows; capabilities `native-toolchain`, `product-artifacts`.
 - **Pass:** the structured action exits successfully, required artifacts exist, and the Gate receipt remains current for the source and definition.
 - **Failure or skip:** action failure, timeout, unsupported required capability, dependency failure, or missing required artifact is non-qualifying; advisory mode remains visible.

--- a/docs/qualification/gates/native-qualification.md
+++ b/docs/qualification/gates/native-qualification.md
@@ -36,7 +36,7 @@ Each section is bound to the registry id by the catalog meta gate.
 - **Evidence:** unified Gate receipt; no separate artifact is currently required.
 - **Diagnosis:** `./shifu gate explain episode.smoke --profile <profile>`; reproduce with `./shifu gate run episode.smoke` on a capable runner.
 - **Cost:** heavy; timeout 900 seconds.
-- **Current source:** .github/workflows/dev-verify-patrol.yml (verify; daily or manual on dev); .github/workflows/build.yml (build; alpha or release pull request).
+- **Current source:** .github/workflows/build.yml (build; alpha or release pull request).
 - **Retirement:** remove only after every selecting profile and workflow binding is migrated or explicitly replaced, with the registry and matrix changed in the same review.
 <!-- /gate-doc:episode.smoke -->
 
@@ -65,7 +65,7 @@ Each section is bound to the registry id by the catalog meta gate.
 - **Problem:** Builds and runs language, storage, and libwasm membrane consumers.
 - **Protects:** qualification regressions from becoming an unexplained green profile or release claim.
 - **Action:** `./shifu qualify:embedding-membranes`
-- **Dependencies:** `product.distribution`.
+- **Dependencies:** `gate.catalog`.
 - **Platforms and runner:** linux, macos, windows; capabilities `native-toolchain`, `rust`.
 - **Pass:** the structured action exits successfully, required artifacts exist, and the Gate receipt remains current for the source and definition.
 - **Failure or skip:** action failure, timeout, unsupported required capability, dependency failure, or missing required artifact is non-qualifying; advisory mode remains visible.

--- a/docs/qualification/gates/policy-matrix.md
+++ b/docs/qualification/gates/policy-matrix.md
@@ -11,7 +11,7 @@ Do not hand-edit the generated block. A mode applies when the corresponding
 <!-- BEGIN GENERATED GATE MATRIX -->
 | Gate | Cost | dev-pr | dev-patrol | alpha-pr | release-pr | release-promotion |
 | --- | --- | :---: | :---: | :---: | :---: | :---: |
-| [`gate.catalog`](source-and-governance.md#gate-catalog) | light | required | required | required | required | off |
+| [`gate.catalog`](source-and-governance.md#gate-catalog) | light | required | required | required | required | required |
 | [`governance.dco`](source-and-governance.md#governance-dco) | light | required | off | required | required | off |
 | [`governance.adr-delivery`](release-and-promotion.md#governance-adr-delivery) | light | required | off | required | required | off |
 | [`governance.buildchain-config`](source-and-governance.md#governance-buildchain-config) | light | required | off | required | required | required |
@@ -23,12 +23,12 @@ Do not hand-edit the generated block. A mode applies when the corresponding
 | [`docs.prose`](source-and-governance.md#docs-prose) | light | required | off | off | off | off |
 | [`docs.external-links`](source-and-governance.md#docs-external-links) | light | off | advisory | off | off | off |
 | [`shifu.workspace`](source-and-governance.md#shifu-workspace) | heavy | required | off | required | required | off |
-| [`product.distribution`](build-and-runtime.md#product-distribution) | heavy | off | required | required | required | off |
+| [`product.distribution`](build-and-runtime.md#product-distribution) | heavy | off | off | required | required | off |
 | [`product.verify-full`](build-and-runtime.md#product-verify-full) | heavy | off | required | off | off | off |
 | [`product.verify-fuzz`](build-and-runtime.md#product-verify-fuzz) | heavy | off | off | required | required | off |
 | [`release.artifact-admission`](release-and-promotion.md#release-artifact-admission) | heavy | off | off | off | off | required |
 | [`layers.contract`](native-qualification.md#layers-contract) | light | off | off | off | off | off |
-| [`episode.smoke`](native-qualification.md#episode-smoke) | heavy | off | required | required | required | off |
+| [`episode.smoke`](native-qualification.md#episode-smoke) | heavy | off | off | required | required | off |
 | [`episode.release`](native-qualification.md#episode-release) | heavy | off | off | required | required | off |
 | [`embedding.membranes`](native-qualification.md#embedding-membranes) | heavy | off | off | required | required | off |
 | [`mmap.contracts`](native-qualification.md#mmap-contracts) | heavy | off | off | off | off | off |

--- a/docs/qualification/gates/release-and-promotion.md
+++ b/docs/qualification/gates/release-and-promotion.md
@@ -10,7 +10,7 @@ Each section is bound to the registry id by the catalog meta gate.
 
 - **Problem:** Checks the applicable ADR delivery and promotion declaration.
 - **Protects:** release regressions from becoming an unexplained green profile or release claim.
-- **Action:** `./shifu adr:release:gate -- --allow-non-pr --report product/release/qualification/adr-release-admissibility.json`
+- **Action:** `./shifu adr:release:gate -- --allow-non-pr --github-event --report product/release/qualification/adr-release-admissibility.json`
 - **Dependencies:** none.
 - **Platforms and runner:** linux, macos, windows; capabilities `node`.
 - **Pass:** the structured action exits successfully, required artifacts exist, and the Gate receipt remains current for the source and definition.
@@ -28,15 +28,15 @@ Each section is bound to the registry id by the catalog meta gate.
 
 - **Problem:** Rehearses alpha and stable promotion admission without publishing.
 - **Protects:** release regressions from becoming an unexplained green profile or release claim.
-- **Action:** `./shifu release:promotion:rehearse -- --report product/release/qualification/release-promotion-rehearsal.json`
-- **Dependencies:** `governance.buildchain-config`.
+- **Action:** `./shifu release:promotion:rehearse -- --github-event --report product/release/qualification/release-promotion-rehearsal.json`
+- **Dependencies:** `gate.catalog`.
 - **Platforms and runner:** linux, macos, windows; capabilities `node`.
 - **Pass:** the structured action exits successfully, required artifacts exist, and the Gate receipt remains current for the source and definition.
 - **Failure or skip:** action failure, timeout, unsupported required capability, dependency failure, or missing required artifact is non-qualifying; advisory mode remains visible.
 - **Evidence:** unified Gate receipt; artifacts `product/release/qualification/release-promotion-rehearsal.json`.
 - **Diagnosis:** `./shifu gate explain governance.promotion-rehearsal --profile <profile>`; reproduce with `./shifu gate run governance.promotion-rehearsal` on a capable runner.
 - **Cost:** light; timeout 180 seconds.
-- **Current source:** .github/workflows/buildchain-validate.yml (validate,promotion-rehearsal; pull request or channel push); .github/workflows/release-new-version.yml (promotion-contract,promote; merged alpha or release pull request).
+- **Current source:** .github/workflows/buildchain-validate.yml (promotion-rehearsal; pull request or channel push); .github/workflows/release-new-version.yml (promotion-contract; merged alpha or release pull request).
 - **Retirement:** remove only after every selecting profile and workflow binding is migrated or explicitly replaced, with the registry and matrix changed in the same review.
 <!-- /gate-doc:governance.promotion-rehearsal -->
 
@@ -54,6 +54,6 @@ Each section is bound to the registry id by the catalog meta gate.
 - **Evidence:** unified Gate receipt; no separate artifact is currently required.
 - **Diagnosis:** `./shifu gate explain release.artifact-admission --profile <profile>`; reproduce with `./shifu gate run release.artifact-admission` on a capable runner.
 - **Cost:** heavy; timeout 1800 seconds.
-- **Current source:** .github/workflows/release-new-version.yml (promotion-contract,promote; merged alpha or release pull request).
+- **Current source:** .github/workflows/release-new-version.yml (promote; merged alpha or release pull request).
 - **Retirement:** remove only after every selecting profile and workflow binding is migrated or explicitly replaced, with the registry and matrix changed in the same review.
 <!-- /gate-doc:release.artifact-admission -->

--- a/docs/qualification/gates/source-and-governance.md
+++ b/docs/qualification/gates/source-and-governance.md
@@ -18,7 +18,7 @@ Each section is bound to the registry id by the catalog meta gate.
 - **Evidence:** unified Gate receipt; no separate artifact is currently required.
 - **Diagnosis:** `./shifu gate explain gate.catalog --profile <profile>`; reproduce with `./shifu gate run gate.catalog` on a capable runner.
 - **Cost:** light; timeout 120 seconds.
-- **Current source:** .github/workflows/source-acceptance.yml (source-acceptance; dev pull request); .github/workflows/dev-verify-patrol.yml (verify; daily or manual on dev); .github/workflows/build.yml (build; alpha or release pull request).
+- **Current source:** .github/workflows/source-acceptance.yml (source-acceptance; dev pull request); .github/workflows/dev-verify-patrol.yml (verify; daily or manual on dev); .github/workflows/build.yml (build; alpha or release pull request); .github/workflows/release-new-version.yml (promotion-contract; merged alpha or release pull request).
 - **Retirement:** remove only after every selecting profile and workflow binding is migrated or explicitly replaced, with the registry and matrix changed in the same review.
 <!-- /gate-doc:gate.catalog -->
 
@@ -54,7 +54,7 @@ Each section is bound to the registry id by the catalog meta gate.
 - **Evidence:** unified Gate receipt; no separate artifact is currently required.
 - **Diagnosis:** `./shifu gate explain governance.buildchain-config --profile <profile>`; reproduce with `./shifu gate run governance.buildchain-config` on a capable runner.
 - **Cost:** light; timeout 120 seconds.
-- **Current source:** .github/workflows/buildchain-validate.yml (validate,promotion-rehearsal; pull request or channel push); .github/workflows/release-new-version.yml (promotion-contract,promote; merged alpha or release pull request).
+- **Current source:** .github/workflows/buildchain-validate.yml (validate; pull request or channel push); .github/workflows/release-new-version.yml (promote; merged alpha or release pull request).
 - **Retirement:** remove only after every selecting profile and workflow binding is migrated or explicitly replaced, with the registry and matrix changed in the same review.
 <!-- /gate-doc:governance.buildchain-config -->
 
@@ -126,7 +126,7 @@ Each section is bound to the registry id by the catalog meta gate.
 - **Evidence:** unified Gate receipt; no separate artifact is currently required.
 - **Diagnosis:** `./shifu gate explain docs.contracts --profile <profile>`; reproduce with `./shifu gate run docs.contracts` on a capable runner.
 - **Cost:** light; timeout 600 seconds.
-- **Current source:** .github/workflows/docs-check.yml (docs-check; dev pull request touching declared documentation paths).
+- **Current source:** .github/workflows/docs-check.yml (docs-check; dev pull request touching declared documentation paths); .github/workflows/docs-external-links.yml (external-links; daily or manual).
 - **Retirement:** remove only after every selecting profile and workflow binding is migrated or explicitly replaced, with the registry and matrix changed in the same review.
 <!-- /gate-doc:docs.contracts -->
 
@@ -172,7 +172,7 @@ Each section is bound to the registry id by the catalog meta gate.
 
 - **Problem:** Formats, lints, tests, release-builds, and smokes Shifu on three hosted OSes.
 - **Protects:** toolchain regressions from becoming an unexplained green profile or release claim.
-- **Action:** named handler `kungfu.workflow.shifu-workspace`; execution requires the declared remote controller capability.
+- **Action:** `./shifu check:shifu-workspace`
 - **Dependencies:** `gate.catalog`.
 - **Platforms and runner:** linux, macos, windows; capabilities `rust`.
 - **Pass:** the structured action exits successfully, required artifacts exist, and the Gate receipt remains current for the source and definition.

--- a/docs/qualification/gates/workflow-bindings.json
+++ b/docs/qualification/gates/workflow-bindings.json
@@ -4,6 +4,7 @@
   "bindings": [
     {
       "id": "dev-source",
+      "execution": "controller",
       "workflow": ".github/workflows/source-acceptance.yml",
       "job": "source-acceptance",
       "profiles": [
@@ -21,6 +22,7 @@
     },
     {
       "id": "dev-adr",
+      "execution": "gate",
       "workflow": ".github/workflows/adr-release-gate.yml",
       "job": "adr-release",
       "profiles": [
@@ -31,11 +33,12 @@
       ],
       "activation": "dev pull request",
       "requiredSnippets": [
-        "./shifu adr:release:gate -- --github-event"
+        "./shifu gate run governance.adr-delivery"
       ]
     },
     {
       "id": "dev-docs",
+      "execution": "gate",
       "workflow": ".github/workflows/docs-check.yml",
       "job": "docs-check",
       "profiles": [
@@ -47,12 +50,12 @@
       ],
       "activation": "dev pull request touching declared documentation paths",
       "requiredSnippets": [
-        "./shifu docs:check:readonly",
-        "./shifu docs:prose:required"
+        "./shifu gate run docs.prose"
       ]
     },
     {
       "id": "all-pr-dco",
+      "execution": "controller",
       "workflow": ".github/workflows/dco.yml",
       "job": "signoff",
       "profiles": [
@@ -70,26 +73,44 @@
       ]
     },
     {
-      "id": "channel-buildchain-contract",
+      "id": "channel-buildchain-config",
+      "execution": "controller",
       "workflow": ".github/workflows/buildchain-validate.yml",
-      "job": "validate,promotion-rehearsal",
+      "job": "validate",
       "profiles": [
         "dev-pr",
         "alpha-pr",
         "release-pr"
       ],
       "gates": [
-        "governance.buildchain-config",
+        "governance.buildchain-config"
+      ],
+      "activation": "pull request or channel push",
+      "requiredSnippets": [
+        "require-lifecycle-stages: \"install,check,build,verify\""
+      ]
+    },
+    {
+      "id": "channel-promotion-rehearsal",
+      "execution": "gate",
+      "workflow": ".github/workflows/buildchain-validate.yml",
+      "job": "promotion-rehearsal",
+      "profiles": [
+        "dev-pr",
+        "alpha-pr",
+        "release-pr"
+      ],
+      "gates": [
         "governance.promotion-rehearsal"
       ],
       "activation": "pull request or channel push",
       "requiredSnippets": [
-        "require-lifecycle-stages: \"install,check,build,verify\"",
-        "./shifu release:promotion:rehearse --"
+        "./shifu gate run governance.promotion-rehearsal"
       ]
     },
     {
       "id": "shifu-workspace",
+      "execution": "gate",
       "workflow": ".github/workflows/shifu-ci.yml",
       "job": "check",
       "profiles": [
@@ -105,12 +126,12 @@
         "macos-14",
         "ubuntu-22.04",
         "windows-2022",
-        "cargo test --workspace",
-        "cargo build --workspace --release"
+        "./shifu gate run shifu.workspace"
       ]
     },
     {
       "id": "dev-heavy-patrol",
+      "execution": "gate",
       "workflow": ".github/workflows/dev-verify-patrol.yml",
       "job": "verify",
       "profiles": [
@@ -118,18 +139,17 @@
       ],
       "gates": [
         "gate.catalog",
-        "product.distribution",
-        "product.verify-full",
-        "episode.smoke"
+        "product.verify-full"
       ],
       "activation": "daily or manual on dev",
       "requiredSnippets": [
-        "./shifu cache apply -- ./shifu verify --full",
+        "./shifu gate run product.verify-full",
         "kungfu-build-v4-linux-x64"
       ]
     },
     {
       "id": "dev-external-links",
+      "execution": "controller",
       "workflow": ".github/workflows/docs-external-links.yml",
       "job": "external-links",
       "profiles": [
@@ -147,6 +167,7 @@
     },
     {
       "id": "channel-heavy-build",
+      "execution": "controller",
       "workflow": ".github/workflows/build.yml",
       "job": "build",
       "profiles": [
@@ -171,6 +192,7 @@
     },
     {
       "id": "channel-membranes",
+      "execution": "gate",
       "workflow": ".github/workflows/embedding-membrane-spike.yml",
       "job": "native-membrane",
       "profiles": [
@@ -185,19 +207,36 @@
         "Linux x64",
         "macOS ARM64",
         "Windows x64",
-        "./shifu qualify:embedding-membranes"
+        "./shifu gate run embedding.membranes"
+      ]
+    },
+    {
+      "id": "release-rehearsal",
+      "execution": "gate",
+      "workflow": ".github/workflows/release-new-version.yml",
+      "job": "promotion-contract",
+      "profiles": [
+        "release-promotion"
+      ],
+      "gates": [
+        "gate.catalog",
+        "governance.promotion-rehearsal"
+      ],
+      "activation": "merged alpha or release pull request",
+      "requiredSnippets": [
+        "./shifu gate run governance.promotion-rehearsal"
       ]
     },
     {
       "id": "release-admission",
+      "execution": "controller",
       "workflow": ".github/workflows/release-new-version.yml",
-      "job": "promotion-contract,promote",
+      "job": "promote",
       "profiles": [
         "release-promotion"
       ],
       "gates": [
         "governance.buildchain-config",
-        "governance.promotion-rehearsal",
         "release.artifact-admission"
       ],
       "activation": "merged alpha or release pull request",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "check:shifu-cache-contract": "node scripts/require-shifu.mjs check:shifu-cache-contract && node scripts/check-shifu-cache-contract.mjs",
     "check:shifu-gate-contract": "node scripts/require-shifu.mjs check:shifu-gate-contract && node scripts/check-shifu-gate-contract.mjs",
     "check:gate-catalog": "node scripts/require-shifu.mjs check:gate-catalog && node scripts/check-kungfu-gate-catalog.mjs",
+    "check:shifu-workspace": "node scripts/require-shifu.mjs check:shifu-workspace && node scripts/check-shifu-workspace.mjs",
     "docs:check": "node scripts/require-shifu.mjs docs:check && node scripts/run-docs-check.mjs",
     "docs:check:readonly": "node scripts/require-shifu.mjs docs:check:readonly && node scripts/run-docs-readonly.mjs",
     "docs:prose": "node scripts/require-shifu.mjs docs:prose && node scripts/run-docs-prose-check.mjs",

--- a/scripts/check-kungfu-gate-catalog.mjs
+++ b/scripts/check-kungfu-gate-catalog.mjs
@@ -31,6 +31,39 @@ function readJson(root, relative) {
   return JSON.parse(fs.readFileSync(path.join(root, relative), 'utf8'));
 }
 
+function gateActionLine(gate) {
+  if (gate.action.kind === 'task') {
+    const command = [gate.action.task, ...(gate.action.args || [])].join(' ');
+    return `- **Action:** \`./shifu ${command}\``;
+  }
+  return `- **Action:** named handler \`${gate.action.handler}\`; execution requires the declared remote controller capability.`;
+}
+
+function gateDependenciesLine(gate) {
+  if (!gate.dependencies.length) return '- **Dependencies:** none.';
+  return `- **Dependencies:** ${gate.dependencies.map((item) => `\`${item}\``).join(', ')}.`;
+}
+
+function gatePlatformsLine(gate) {
+  const capabilities = gate.runner.capabilities
+    .map((item) => `\`${item}\``)
+    .join(', ');
+  return `- **Platforms and runner:** ${gate.platforms.join(', ')}; capabilities ${capabilities}.`;
+}
+
+function gateCurrentSourceLine(gate, bindings) {
+  const sources = bindings
+    .filter((binding) => binding.gates?.includes(gate.id))
+    .map(
+      (binding) =>
+        `${binding.workflow} (${binding.job}; ${binding.activation})`,
+    );
+  const current = sources.length
+    ? sources.join('; ')
+    : 'independent Shifu task; not selected by a current remote profile.';
+  return `- **Current source:** ${current}`;
+}
+
 export function renderPolicyMatrix(registry) {
   const profiles = registry.profiles;
   const header = [
@@ -65,6 +98,8 @@ export function checkKungfuGateCatalog(root = ROOT) {
   }
   if (validation.length) return { issues, registry };
 
+  const bindingDocument = readJson(root, BINDINGS);
+  const bindings = bindingDocument.bindings || [];
   const packageScripts = readJson(root, 'package.json').scripts || {};
   for (const gate of registry.gates) {
     if (gate.action.kind === 'task' && !packageScripts[gate.action.task]) {
@@ -114,6 +149,19 @@ export function checkKungfuGateCatalog(root = ROOT) {
         issues.push(`[doc] ${gate.id}: missing '${field}' field`);
       }
     }
+    const expectedFacts = [
+      `- **Problem:** ${gate.summary}`,
+      gateActionLine(gate),
+      gateDependenciesLine(gate),
+      gatePlatformsLine(gate),
+      `- **Cost:** ${gate.cost.class}; timeout ${gate.cost.timeoutSeconds} seconds.`,
+      gateCurrentSourceLine(gate, bindings),
+    ];
+    for (const fact of expectedFacts) {
+      if (!block.includes(fact)) {
+        issues.push(`[doc-fact] ${gate.id}: expected '${fact}'`);
+      }
+    }
   }
 
   const matrixPath = path.join(root, MATRIX);
@@ -126,7 +174,6 @@ export function checkKungfuGateCatalog(root = ROOT) {
     issues.push(`[matrix] ${MATRIX} differs from shifu.gates.json`);
   }
 
-  const bindingDocument = readJson(root, BINDINGS);
   if (bindingDocument.schema !== 'kungfu.gate-workflow-bindings/v1') {
     issues.push('[workflow] unsupported binding schema');
   }
@@ -137,13 +184,18 @@ export function checkKungfuGateCatalog(root = ROOT) {
   const profileIds = new Set(registry.profiles.map((profile) => profile.id));
   const covered = new Set();
   const bindingIds = new Set();
-  for (const binding of bindingDocument.bindings || []) {
+  for (const binding of bindings) {
     if (bindingIds.has(binding.id)) {
       issues.push(`[workflow] duplicate binding id '${binding.id}'`);
     }
     bindingIds.add(binding.id);
     if (!binding.job || !binding.activation) {
       issues.push(`[workflow] ${binding.id}: job and activation are required`);
+    }
+    if (!['gate', 'controller'].includes(binding.execution)) {
+      issues.push(
+        `[workflow] ${binding.id}: execution must be 'gate' or 'controller'`,
+      );
     }
     if (!binding.profiles?.length || !binding.gates?.length) {
       issues.push(
@@ -189,6 +241,14 @@ export function checkKungfuGateCatalog(root = ROOT) {
     ) {
       issues.push(
         `[workflow] ${binding.id}: requiredSnippets must contain non-empty strings`,
+      );
+    }
+    if (
+      binding.execution === 'gate' &&
+      !binding.requiredSnippets?.some((snippet) => snippet.includes('gate run'))
+    ) {
+      issues.push(
+        `[workflow] ${binding.id}: gate execution must prove a 'gate run' entrypoint`,
       );
     }
     const workflow = path.join(root, workflowRelative);

--- a/scripts/check-kungfu-gate-catalog.test.mjs
+++ b/scripts/check-kungfu-gate-catalog.test.mjs
@@ -107,3 +107,39 @@ test('matrix, gate document, and workflow drift each fail closed', () => {
     ),
   );
 });
+
+test('document facts and Gate-owned workflow entrypoints fail closed', () => {
+  const root = fixture();
+  const docs = path.join(root, 'docs/qualification/gates/build-and-runtime.md');
+  fs.writeFileSync(
+    docs,
+    fs
+      .readFileSync(docs, 'utf8')
+      .replace('`./shifu verify --full`', '`./shifu verify --quick`'),
+  );
+  assert.ok(
+    checkKungfuGateCatalog(root).issues.some(
+      (issue) =>
+        issue.startsWith('[doc-fact] product.verify-full:') &&
+        issue.includes('./shifu verify --full'),
+    ),
+  );
+
+  const bindingsPath = path.join(
+    root,
+    'docs/qualification/gates/workflow-bindings.json',
+  );
+  const bindings = JSON.parse(fs.readFileSync(bindingsPath, 'utf8'));
+  const migration = bindings.bindings.find(
+    (binding) => binding.id === 'dev-heavy-patrol',
+  );
+  migration.requiredSnippets = ['kungfu-build-v4-linux-x64'];
+  fs.writeFileSync(bindingsPath, JSON.stringify(bindings));
+  assert.ok(
+    checkKungfuGateCatalog(root).issues.some((issue) =>
+      issue.includes(
+        "dev-heavy-patrol: gate execution must prove a 'gate run' entrypoint",
+      ),
+    ),
+  );
+});

--- a/scripts/check-shifu-workspace.mjs
+++ b/scripts/check-shifu-workspace.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: Apache-2.0
+// @ts-check
+
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const CRATES = path.join(ROOT, 'crates');
+const isWin = process.platform === 'win32';
+
+/** @param {string} label @param {string[]} args */
+function cargo(label, args) {
+  console.log(`[shifu-workspace] ${label}`);
+  const result = spawnSync('cargo', args, {
+    cwd: CRATES,
+    stdio: 'inherit',
+  });
+  if (result.error) {
+    throw new Error(
+      `cargo could not start: ${result.error.code || result.error.message}`,
+    );
+  }
+  if (result.status !== 0) {
+    throw new Error(`${label} failed (exit ${result.status ?? result.signal})`);
+  }
+}
+
+try {
+  cargo('format', ['fmt', '--all', '--check']);
+  cargo('clippy', [
+    'clippy',
+    '--workspace',
+    '--all-targets',
+    '--',
+    '-D',
+    'warnings',
+  ]);
+  cargo('test', ['test', '--workspace']);
+  cargo('release build', ['build', '--workspace', '--release']);
+
+  const launcher = path.join(
+    CRATES,
+    'target',
+    'release',
+    isWin ? 'shifu.exe' : 'shifu',
+  );
+  if (!fs.existsSync(launcher)) {
+    throw new Error(
+      `release launcher missing: ${path.relative(ROOT, launcher)}`,
+    );
+  }
+  const smoke = spawnSync(launcher, ['self-version'], {
+    cwd: ROOT,
+    stdio: 'inherit',
+  });
+  if (smoke.error || smoke.status !== 0) {
+    throw new Error(
+      `launcher self-version failed (exit ${smoke.status ?? smoke.signal ?? smoke.error?.code})`,
+    );
+  }
+  console.log('[shifu-workspace] workspace matrix action passed');
+} catch (error) {
+  console.error(
+    `[shifu-workspace] ${error instanceof Error ? error.message : String(error)}`,
+  );
+  process.exit(1);
+}

--- a/scripts/release-promotion-rehearsal.mjs
+++ b/scripts/release-promotion-rehearsal.mjs
@@ -107,7 +107,7 @@ export function validateWorkflowSources(root, contract, overrides = {}) {
   );
   requirePattern(
     preflight,
-    /\.\/shifu release:promotion:rehearse --[\s\S]*--event "\$GITHUB_EVENT_PATH"/,
+    /\.\/shifu gate run governance\.promotion-rehearsal/,
     findings,
     'promotion contract preflight must execute the current merged PR event',
   );
@@ -179,7 +179,7 @@ export function validateWorkflowSources(root, contract, overrides = {}) {
   );
   requirePattern(
     rehearsal,
-    /\.\/shifu release:promotion:rehearse --/,
+    /\.\/shifu gate run governance\.promotion-rehearsal/,
     findings,
     'Buildchain validation workflow must execute the promotion rehearsal',
   );

--- a/shifu.gates.json
+++ b/shifu.gates.json
@@ -95,6 +95,7 @@
         "args": [
           "--",
           "--allow-non-pr",
+          "--github-event",
           "--report",
           "product/release/qualification/adr-release-admissibility.json"
         ]
@@ -148,7 +149,7 @@
       "category": "release",
       "documentation": "docs/qualification/gates/release-and-promotion.md",
       "dependencies": [
-        "governance.buildchain-config"
+        "gate.catalog"
       ],
       "platforms": [
         "linux",
@@ -169,6 +170,7 @@
         "task": "release:promotion:rehearse",
         "args": [
           "--",
+          "--github-event",
           "--report",
           "product/release/qualification/release-promotion-rehearsal.json"
         ]
@@ -403,11 +405,9 @@
         "timeoutSeconds": 1800
       },
       "action": {
-        "kind": "handler",
-        "handler": "kungfu.workflow.shifu-workspace",
-        "parameters": {
-          "workflow": ".github/workflows/shifu-ci.yml"
-        }
+        "kind": "task",
+        "task": "check:shifu-workspace",
+        "args": []
       },
       "artifacts": [],
       "receipt": {
@@ -460,7 +460,7 @@
       "category": "build",
       "documentation": "docs/qualification/gates/build-and-runtime.md",
       "dependencies": [
-        "product.distribution"
+        "gate.catalog"
       ],
       "platforms": [
         "linux",
@@ -681,7 +681,7 @@
       "category": "qualification",
       "documentation": "docs/qualification/gates/native-qualification.md",
       "dependencies": [
-        "product.distribution"
+        "gate.catalog"
       ],
       "platforms": [
         "linux",
@@ -1379,8 +1379,8 @@
           "reason": "Not selected by the current dev-patrol workflow policy."
         },
         "product.distribution": {
-          "mode": "required",
-          "reason": "Selected by the current dev-patrol workflow policy when its activation condition matches."
+          "mode": "off",
+          "reason": "The aggregate product.verify-full Gate performs its own rebuild; a separate dist action would duplicate the patrol build."
         },
         "product.verify-full": {
           "mode": "required",
@@ -1399,8 +1399,8 @@
           "reason": "Not selected by the current dev-patrol workflow policy."
         },
         "episode.smoke": {
-          "mode": "required",
-          "reason": "Selected by the current dev-patrol workflow policy when its activation condition matches."
+          "mode": "off",
+          "reason": "The aggregate product.verify-full Gate includes mvp-smoke-v1; the standalone Episode Gate remains independently runnable."
         },
         "episode.release": {
           "mode": "off",
@@ -1757,8 +1757,8 @@
       "title": "Release promotion",
       "decisions": {
         "gate.catalog": {
-          "mode": "off",
-          "reason": "Not selected by the current release-promotion workflow policy."
+          "mode": "required",
+          "reason": "The promotion rehearsal enters through Shifu Gate and fail-closes catalog, documentation, matrix, and workflow drift first."
         },
         "governance.dco": {
           "mode": "off",


### PR DESCRIPTION
## Summary

Migrate task-backed Kungfu workflow gates onto the generic Shifu Gate executor while preserving controller-owned and supply-chain-pinned boundaries.

## Related issue

SHIFU-ADR-0004

## Changes

- route ADR delivery, promotion rehearsal, documentation closure, dev full verification, membrane qualification, and Shifu workspace CI through `shifu gate run`
- replace the Shifu workspace remote handler with an independently executable cross-platform Gate task
- mark every workflow binding as `gate` or `controller`, and fail closed when a Gate-owned binding lacks a real `gate run` entrypoint
- make the catalog meta gate verify exact documented action, dependency, platform, cost, and current workflow source facts
- align dev patrol with its real aggregate `product.verify-full` action so it does not duplicate distribution or Episode smoke work
- retain the immutable lychee action and Buildchain-owned workflows as controllers for their existing trust/orchestration boundaries

## Verification

- `./shifu gate run shifu.workspace --capability rust --json`
- `./shifu gate run governance.promotion-rehearsal --json`
- `./shifu gate run governance.adr-delivery --json`
- `./shifu gate plan dev-patrol --json`
- `./shifu gate plan alpha-pr --json`
- `./shifu check:gate-catalog`
- `./shifu docs:check:readonly`
- `./shifu check:source`
- `./shifu check`

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "stage-ready",
  "adrs": ["SHIFU-ADR-0004"],
  "summary": "Migrate task-backed Kungfu workflow gates onto Shifu Gate while preserving controller and immutable toolchain boundaries",
  "verification": ["./shifu gate run shifu.workspace --capability rust --json", "./shifu check:gate-catalog", "./shifu docs:check:readonly", "./shifu check:source", "./shifu check"]
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

This stage changes Gate entrypoints and validation only. It does not publish, alter branch protection, or bypass controller-owned release admission.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed