### PR TITLE
fix(shifu): harden cache doctor probes

### DIFF
--- a/docs/adr/SHIFU-ADR-0001-cache-profile-contract-and-ownership.md
+++ b/docs/adr/SHIFU-ADR-0001-cache-profile-contract-and-ownership.md
@@ -107,6 +107,11 @@ registered KFD-1 version decision process.
   environment variables outside Buildchain, validates the detected platform,
   and uploads an exact package list; the ordinary Buildchain interface remains
   only profile reference plus digest.
+- Cache diagnostics use optional, same-origin per-service probe policy with
+  bounded timeout and retry limits. Provider-aware lightweight targets avoid
+  treating an expensive index listing as a health endpoint, while persistent
+  transport or server failures remain degraded and endpoint coordinates stay
+  out of diagnostic receipts.
 - A future Shifu repository extraction can move this ADR registry and contract
   together without renumbering Kungfu Core ADRs.
 

--- a/docs/shifu/cache-profiles.md
+++ b/docs/shifu/cache-profiles.md
@@ -192,7 +192,17 @@ cache infrastructure:
 
 `status` reads only the local projection and resolution receipt. It performs no
 network I/O. `doctor` resolves the pinned profile and verifies its digest;
-`--probe` additionally performs bounded HTTP `HEAD` checks. Diagnostics keep
+`--probe` additionally performs bounded HTTP `HEAD` checks. Each HTTP service
+may declare `verification.probe.path`, `timeoutMs`, `attempts`, and
+`retryDelayMs`; the path is same-origin and attempts are capped at three.
+Without an explicit policy, Shifu makes two attempts and uses the command
+timeout, except that Python indexes receive a five-second floor. A devpi
+`/<user>/<index>/+simple/` endpoint is probed through its lightweight `+api`
+root instead of downloading or waiting on the package index listing. Only
+timeouts, transport failures, and HTTP 5xx responses are retried; a persistent
+failure remains `degraded`. Probe evidence records target class, timeout,
+attempt count, status, and duration without recording the endpoint URL.
+Diagnostics keep
 `configured`, `resolved`, `reachable`, `effective`, and `hit` separate. A
 successful resolution receipt proves selected bindings, not a provider cache
 hit, so `hit` remains `unproven` without provider evidence.

--- a/docs/shifu/examples/self-hosted-runner.cache-profile.json
+++ b/docs/shifu/examples/self-hosted-runner.cache-profile.json
@@ -48,7 +48,7 @@
       "mode": "require",
       "endpoint": {
         "type": "http",
-        "url": "https://cache.example.invalid/pypi/simple/"
+        "url": "https://cache.example.invalid/root/pypi/+simple/"
       },
       "bindings": [
         {
@@ -61,7 +61,13 @@
         "mode": "fail"
       },
       "verification": {
-        "method": "tool-native"
+        "method": "tool-native",
+        "probe": {
+          "path": "/+api",
+          "timeoutMs": 5000,
+          "attempts": 2,
+          "retryDelayMs": 100
+        }
       }
     },
     "cargo-registry": {

--- a/docs/shifu/schema/cache-diagnostic-v1.schema.json
+++ b/docs/shifu/schema/cache-diagnostic-v1.schema.json
@@ -89,7 +89,10 @@
                   "method": { "enum": ["none", "HEAD"] },
                   "durationMs": { "type": "integer", "minimum": 0 },
                   "status": { "type": "integer", "minimum": 100, "maximum": 599 },
-                  "reason": { "enum": ["timeout", "request-failed"] }
+                  "reason": { "enum": ["timeout", "request-failed"] },
+                  "attempts": { "type": "integer", "minimum": 1, "maximum": 3 },
+                  "timeoutMs": { "type": "integer", "minimum": 100, "maximum": 30000 },
+                  "target": { "enum": ["endpoint", "same-origin-path", "provider-health"] }
                 }
               }
             ]

--- a/docs/shifu/schema/cache-profile-v1.schema.json
+++ b/docs/shifu/schema/cache-profile-v1.schema.json
@@ -377,6 +377,31 @@
           "type": "string",
           "minLength": 1,
           "maxLength": 512
+        },
+        "probe": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "path": {
+              "type": "string",
+              "pattern": "^/(?!/)[^?#\\\\]*$"
+            },
+            "timeoutMs": {
+              "type": "integer",
+              "minimum": 100,
+              "maximum": 30000
+            },
+            "attempts": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 3
+            },
+            "retryDelayMs": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 2000
+            }
+          }
         }
       },
       "allOf": [
@@ -389,7 +414,10 @@
             }
           },
           "then": {
-            "required": ["rationale"]
+            "required": ["rationale"],
+            "not": {
+              "required": ["probe"]
+            }
           }
         }
       ]

--- a/scripts/check-shifu-cache-contract.test.mjs
+++ b/scripts/check-shifu-cache-contract.test.mjs
@@ -16,6 +16,7 @@ import {
   cacheStatus,
   cacheUnset,
   cacheUse,
+  probeHttp,
 } from './shifu-cache-operations.mjs';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
@@ -359,6 +360,7 @@ test('cache doctor probes selected HTTP endpoints only when requested', async (t
   const fixture = shellHarness(t);
   const server = http.createServer((request, response) => {
     assert.equal(request.method, 'HEAD');
+    assert.equal(request.url, '/healthz');
     response.writeHead(200).end();
   });
   await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
@@ -367,6 +369,12 @@ test('cache doctor probes selected HTTP endpoints only when requested', async (t
   assert.equal(typeof address, 'object');
   const profile = JSON.parse(fs.readFileSync(fixture.profilePath, 'utf8'));
   profile.services.npm.endpoint.url = `http://127.0.0.1:${address.port}/npm/`;
+  profile.services.npm.verification.probe = {
+    path: '/healthz',
+    timeoutMs: 250,
+    attempts: 3,
+    retryDelayMs: 0,
+  };
   const raw = `${JSON.stringify(profile, null, 2)}\n`;
   fs.writeFileSync(fixture.profilePath, raw);
   const digest = `sha256:${crypto.createHash('sha256').update(raw).digest('hex')}`;
@@ -385,6 +393,151 @@ test('cache doctor probes selected HTTP endpoints only when requested', async (t
   assert.equal(diagnostic.overall, 'healthy');
   assert.equal(diagnostic.probe, true);
   assert.equal(diagnostic.services.npm.reachable, 'reachable');
+  assert.deepEqual(diagnostic.services.npm.probeEvidence, {
+    state: 'reachable',
+    method: 'HEAD',
+    status: 200,
+    durationMs: diagnostic.services.npm.probeEvidence.durationMs,
+    attempts: 1,
+    timeoutMs: 250,
+    target: 'same-origin-path',
+  });
+});
+
+test('cache doctor uses the lightweight devpi API for legacy Python profiles', async (t) => {
+  const fixture = shellHarness(t);
+  const requests = [];
+  const server = http.createServer((request, response) => {
+    requests.push({ method: request.method, url: request.url });
+    response.writeHead(200).end();
+  });
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  t.after(() => server.close());
+  const address = server.address();
+  assert.equal(typeof address, 'object');
+  const profile = JSON.parse(fs.readFileSync(fixture.profilePath, 'utf8'));
+  profile.services = { 'python-index': profile.services.npm };
+  profile.services['python-index'].endpoint.url =
+    `http://127.0.0.1:${address.port}/root/pypi/+simple/`;
+  profile.services['python-index'].bindings[0].key = 'UV_DEFAULT_INDEX';
+  const raw = `${JSON.stringify(profile, null, 2)}\n`;
+  fs.writeFileSync(fixture.profilePath, raw);
+  const digest = `sha256:${crypto.createHash('sha256').update(raw).digest('hex')}`;
+  const configFile = path.join(fixture.root, 'build-local.env');
+  fs.writeFileSync(
+    configFile,
+    `export SHIFU_CACHE_PROFILE_REF='${fixture.profilePath}'\nexport SHIFU_CACHE_PROFILE_DIGEST='${digest}'\n`,
+  );
+
+  const diagnostic = await cacheDoctor({
+    configFile,
+    receiptPath: fixture.receipt,
+    env: {},
+    probe: true,
+    timeoutMs: 1000,
+  });
+
+  assert.equal(diagnostic.overall, 'healthy');
+  assert.deepEqual(requests, [{ method: 'HEAD', url: '/+api' }]);
+  assert.equal(
+    diagnostic.services['python-index'].probeEvidence.target,
+    'provider-health',
+  );
+  assert.equal(
+    diagnostic.services['python-index'].probeEvidence.timeoutMs,
+    5000,
+  );
+});
+
+test('HTTP probe retries a transient timeout and succeeds', async () => {
+  let requests = 0;
+  const timeout = Object.assign(new Error('timed out'), {
+    name: 'TimeoutError',
+  });
+  const evidence = await probeHttp('https://cache.example.invalid/health', {
+    timeoutMs: 100,
+    attempts: 2,
+    retryDelayMs: 0,
+    request: async () => {
+      requests += 1;
+      if (requests === 1) throw timeout;
+      return { status: 200 };
+    },
+  });
+  assert.equal(requests, 2);
+  assert.equal(evidence.state, 'reachable');
+  assert.equal(evidence.attempts, 2);
+  assert.equal(evidence.status, 200);
+});
+
+test('HTTP probe keeps persistent timeouts failed at the attempt bound', async () => {
+  let requests = 0;
+  const evidence = await probeHttp('https://cache.example.invalid/health', {
+    timeoutMs: 100,
+    attempts: 3,
+    retryDelayMs: 0,
+    request: async () => {
+      requests += 1;
+      throw Object.assign(new Error('timed out'), { name: 'TimeoutError' });
+    },
+  });
+  assert.equal(requests, 3);
+  assert.equal(evidence.state, 'failed');
+  assert.equal(evidence.reason, 'timeout');
+  assert.equal(evidence.attempts, 3);
+});
+
+test('HTTP probe retries 5xx but accepts a reachable 4xx without retry', async () => {
+  let retryableRequests = 0;
+  const recovered = await probeHttp('https://cache.example.invalid/health', {
+    timeoutMs: 100,
+    attempts: 2,
+    retryDelayMs: 0,
+    request: async () => ({
+      status: ++retryableRequests === 1 ? 503 : 204,
+    }),
+  });
+  assert.equal(retryableRequests, 2);
+  assert.equal(recovered.state, 'reachable');
+  assert.equal(recovered.attempts, 2);
+
+  let nonRetryableRequests = 0;
+  const reachable = await probeHttp('https://cache.example.invalid/missing', {
+    timeoutMs: 100,
+    attempts: 3,
+    retryDelayMs: 0,
+    request: async () => {
+      nonRetryableRequests += 1;
+      return { status: 404 };
+    },
+  });
+  assert.equal(nonRetryableRequests, 1);
+  assert.equal(reachable.state, 'reachable');
+  assert.equal(reachable.status, 404);
+});
+
+test('cache profile runtime rejects probe attempts above the schema bound', async (t) => {
+  const fixture = shellHarness(t);
+  const profile = JSON.parse(fs.readFileSync(fixture.profilePath, 'utf8'));
+  profile.services.npm.verification.probe = { attempts: 4 };
+  const raw = `${JSON.stringify(profile, null, 2)}\n`;
+  fs.writeFileSync(fixture.profilePath, raw);
+  const digest = `sha256:${crypto.createHash('sha256').update(raw).digest('hex')}`;
+  const configFile = path.join(fixture.root, 'build-local.env');
+  fs.writeFileSync(
+    configFile,
+    `export SHIFU_CACHE_PROFILE_REF='${fixture.profilePath}'\nexport SHIFU_CACHE_PROFILE_DIGEST='${digest}'\n`,
+  );
+  const diagnostic = await cacheDoctor({
+    configFile,
+    receiptPath: fixture.receipt,
+    env: {},
+  });
+  assert.equal(diagnostic.overall, 'failed');
+  assert.match(
+    diagnostic.error,
+    /probe\.attempts must be an integer from 1 to 3/,
+  );
 });
 
 test('cache status CLI emits the diagnostic receipt as JSON', (t) => {

--- a/scripts/shifu-cache-operations.mjs
+++ b/scripts/shifu-cache-operations.mjs
@@ -249,31 +249,100 @@ export function cacheStatus({ configFile, receiptPath, env = process.env }) {
   };
 }
 
-async function probeHttp(url, timeoutMs) {
-  const started = Date.now();
-  try {
-    const response = await fetch(url, {
-      method: 'HEAD',
-      redirect: 'manual',
-      signal: AbortSignal.timeout(timeoutMs),
-    });
-    return {
-      state:
-        response.status >= 200 && response.status < 500
-          ? 'reachable'
-          : 'failed',
-      method: 'HEAD',
-      durationMs: Date.now() - started,
-      status: response.status,
-    };
-  } catch (error) {
-    return {
-      state: 'failed',
-      durationMs: Date.now() - started,
-      method: 'HEAD',
-      reason: error?.name === 'TimeoutError' ? 'timeout' : 'request-failed',
-    };
+const DEFAULT_PROBE_ATTEMPTS = 2;
+const DEFAULT_PROBE_RETRY_DELAY_MS = 100;
+const PYTHON_INDEX_TIMEOUT_MS = 5000;
+
+function sleep(milliseconds) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+function serviceProbe(serviceId, profileService, selected, fallbackTimeoutMs) {
+  const policy = profileService?.verification?.probe || {};
+  let url = selected.url;
+  let target = 'endpoint';
+  if (policy.path) {
+    url = new URL(policy.path, selected.url).toString();
+    target = 'same-origin-path';
+  } else if (serviceId === 'python-index') {
+    const parsed = new URL(selected.url);
+    if (/\/(?:[^/]+\/){2}\+simple\/?$/.test(parsed.pathname)) {
+      url = new URL('/+api', selected.url).toString();
+      target = 'provider-health';
+    }
   }
+  return {
+    url,
+    target,
+    timeoutMs:
+      policy.timeoutMs ||
+      (serviceId === 'python-index'
+        ? Math.max(fallbackTimeoutMs, PYTHON_INDEX_TIMEOUT_MS)
+        : fallbackTimeoutMs),
+    attempts: policy.attempts || DEFAULT_PROBE_ATTEMPTS,
+    retryDelayMs: policy.retryDelayMs ?? DEFAULT_PROBE_RETRY_DELAY_MS,
+  };
+}
+
+export async function probeHttp(
+  url,
+  {
+    timeoutMs,
+    attempts = DEFAULT_PROBE_ATTEMPTS,
+    retryDelayMs = DEFAULT_PROBE_RETRY_DELAY_MS,
+    target = 'endpoint',
+    request = fetch,
+  },
+) {
+  if (!Number.isInteger(timeoutMs) || timeoutMs < 100 || timeoutMs > 30_000)
+    throw new RangeError(
+      'probe timeoutMs must be an integer from 100 to 30000',
+    );
+  if (!Number.isInteger(attempts) || attempts < 1 || attempts > 3)
+    throw new RangeError('probe attempts must be an integer from 1 to 3');
+  if (
+    !Number.isInteger(retryDelayMs) ||
+    retryDelayMs < 0 ||
+    retryDelayMs > 2_000
+  )
+    throw new RangeError(
+      'probe retryDelayMs must be an integer from 0 to 2000',
+    );
+  const started = Date.now();
+  let evidence;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      const response = await request(url, {
+        method: 'HEAD',
+        redirect: 'manual',
+        signal: AbortSignal.timeout(timeoutMs),
+      });
+      evidence = {
+        state:
+          response.status >= 200 && response.status < 500
+            ? 'reachable'
+            : 'failed',
+        method: 'HEAD',
+        status: response.status,
+      };
+    } catch (error) {
+      evidence = {
+        state: 'failed',
+        method: 'HEAD',
+        reason: error?.name === 'TimeoutError' ? 'timeout' : 'request-failed',
+      };
+    }
+    if (evidence.state === 'reachable' || attempt === attempts)
+      return {
+        ...evidence,
+        durationMs: Date.now() - started,
+        attempts: attempt,
+        timeoutMs,
+        target,
+      };
+    if (retryDelayMs > 0) await sleep(retryDelayMs);
+  }
+  throw new Error('unreachable probe state');
 }
 
 function redactedError(error, configuration) {
@@ -309,16 +378,25 @@ export async function cacheDoctor({
     const reachable = {};
     if (probe) {
       const results = await Promise.all(
-        Object.entries(resolved.receipt.services).map(async ([id, service]) => [
-          id,
-          service.selected?.type === 'http'
-            ? await probeHttp(service.selected.url, timeoutMs)
-            : {
-                state: 'not-applicable',
-                method: 'none',
-                durationMs: 0,
-              },
-        ]),
+        Object.entries(resolved.receipt.services).map(async ([id, service]) => {
+          if (service.selected?.type === 'http') {
+            const probeOptions = serviceProbe(
+              id,
+              resolved.profile.services[id],
+              service.selected,
+              timeoutMs,
+            );
+            return [id, await probeHttp(probeOptions.url, probeOptions)];
+          }
+          return [
+            id,
+            {
+              state: 'not-applicable',
+              method: 'none',
+              durationMs: 0,
+            },
+          ];
+        }),
       );
       Object.assign(reachable, Object.fromEntries(results));
     }

--- a/scripts/shifu-cache-runtime.mjs
+++ b/scripts/shifu-cache-runtime.mjs
@@ -54,6 +54,14 @@ const CONFIG_KEYS = new Set([
 const SHIFU_CACHE_HOME_TOKEN = '${SHIFU_CACHE_HOME}';
 const SECRET_KEY_RE =
   /(TOKEN|SECRET|PASSWORD|CREDENTIAL|COOKIE|PRIVATE_KEY|AUTH)/;
+const VERIFICATION_METHODS = new Set([
+  'upstream-checksum',
+  'sha256-manifest',
+  'signature',
+  'tool-native',
+  'transport-only',
+  'none',
+]);
 
 export class CacheProfileError extends Error {}
 
@@ -273,6 +281,74 @@ function validateEndpoint(endpoint, serviceId) {
   return endpoint;
 }
 
+function validateVerification(verification, serviceId) {
+  const label = `services.${serviceId}.verification`;
+  assertExactKeys(
+    verification,
+    new Set(['method', 'rationale', 'probe']),
+    ['method'],
+    label,
+  );
+  assert(
+    VERIFICATION_METHODS.has(verification.method),
+    `${label}.method is invalid`,
+  );
+  if (Object.hasOwn(verification, 'rationale'))
+    assert(
+      typeof verification.rationale === 'string' &&
+        verification.rationale.length >= 1 &&
+        verification.rationale.length <= 512,
+      `${label}.rationale must contain 1-512 characters`,
+    );
+  if (verification.method === 'none') {
+    assert(
+      Object.hasOwn(verification, 'rationale'),
+      `${label}.rationale is required when method is none`,
+    );
+    assert(
+      !Object.hasOwn(verification, 'probe'),
+      `${label}.probe is incompatible with method none`,
+    );
+  }
+  if (!Object.hasOwn(verification, 'probe')) return;
+  const probe = verification.probe;
+  assertExactKeys(
+    probe,
+    new Set(['path', 'timeoutMs', 'attempts', 'retryDelayMs']),
+    [],
+    `${label}.probe`,
+  );
+  if (Object.hasOwn(probe, 'path'))
+    assert(
+      typeof probe.path === 'string' &&
+        probe.path.startsWith('/') &&
+        !probe.path.startsWith('//') &&
+        !/[?#\\]/.test(probe.path),
+      `${label}.probe.path must be a same-origin absolute path without query or fragment`,
+    );
+  if (Object.hasOwn(probe, 'timeoutMs'))
+    assert(
+      Number.isInteger(probe.timeoutMs) &&
+        probe.timeoutMs >= 100 &&
+        probe.timeoutMs <= 30_000,
+      `${label}.probe.timeoutMs must be an integer from 100 to 30000`,
+    );
+  if (Object.hasOwn(probe, 'attempts'))
+    assert(
+      Number.isInteger(probe.attempts) &&
+        probe.attempts >= 1 &&
+        probe.attempts <= 3,
+      `${label}.probe.attempts must be an integer from 1 to 3`,
+    );
+  if (Object.hasOwn(probe, 'retryDelayMs'))
+    assert(
+      Number.isInteger(probe.retryDelayMs) &&
+        probe.retryDelayMs >= 0 &&
+        probe.retryDelayMs <= 2_000,
+      `${label}.probe.retryDelayMs must be an integer from 0 to 2000`,
+    );
+}
+
 export function validateProfileBytes(
   raw,
   { expectedDigest = '', scope = '', platform = '' } = {},
@@ -475,6 +551,7 @@ export function validateProfileBytes(
         service.fallback.mode !== 'upstream',
         `service ${serviceId} cannot use public fallback`,
       );
+    validateVerification(service.verification, serviceId);
     receiptServices[serviceId] = {
       outcome: 'hit',
       selected:

--- a/shifu.mjs
+++ b/shifu.mjs
@@ -219,7 +219,7 @@ function cacheHelp() {
   cache status [--json] [--receipt FILE]
                             inspect local projection and receipt without network I/O
   cache doctor [--json] [--probe] [--receipt FILE] [--timeout-ms N]
-                            resolve the profile; --probe adds bounded endpoint HEAD checks
+                            resolve the profile; --probe adds policy-aware bounded HEAD checks
   cache use --profile REF --digest SHA256 [--scope SCOPE] [--execute]
                             plan or write only Shifu's managed local config block
   cache unset [--execute]   plan or remove only Shifu's managed local config block
@@ -319,8 +319,12 @@ function parseCacheDiagnosticOptions(argv, { allowProbe = false } = {}) {
     else if (arg === '--probe' && allowProbe) options.probe = true;
     else if (arg === '--timeout-ms' && allowProbe) {
       options.timeoutMs = Number(value());
-      if (!Number.isInteger(options.timeoutMs) || options.timeoutMs < 100)
-        throw new Error('--timeout-ms must be an integer >= 100');
+      if (
+        !Number.isInteger(options.timeoutMs) ||
+        options.timeoutMs < 100 ||
+        options.timeoutMs > 30_000
+      )
+        throw new Error('--timeout-ms must be an integer from 100 to 30000');
     } else throw new Error(`unknown cache diagnostic option: ${arg}`);
   }
   return options;


### PR DESCRIPTION
## Summary

Eliminate transient Python index false negatives in `shifu cache doctor --probe` while preserving fail-closed diagnostics for persistent failures.

## Related issue

None.

## Changes

- add optional same-origin per-service probe policy to the Shifu cache profile schema;
- probe devpi Python indexes through the lightweight `+api` root, with a five-second floor and bounded retry;
- record redacted target class, timeout, attempts, status, and duration in diagnostic evidence;
- validate the policy in the dependency-free runtime and document the compatible KFD-1 addition.

## Verification

- `SHIFU_CACHE_ACTIVE=1 ./shifu check:source` on macOS: pass, including 98 source-acceptance tests;
- `SHIFU_CACHE_ACTIVE=1 ./shifu check:source` on Ubuntu: pass, including 98 source-acceptance tests;
- DARKHERO read-only live validation: three healthy runs, Python probe `provider-health`, HTTP 200 in 5 ms, projected config hash and Git status unchanged;
- Atlas profile projection dry-run and cross-repository inventory test: pass for development and self-hosted-runner revision 4.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "stage-ready",
  "adrs": ["SHIFU-ADR-0001"],
  "summary": "Deliver policy-aware bounded cache diagnostics without changing profile authority or Buildchain boundaries",
  "verification": ["macOS and Ubuntu source gates", "DARKHERO read-only doctor validation", "Atlas projection dry-run"]
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] release evidence, provenance, package publishing, or deployment surfaces
- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed
