### PR TITLE
fix(profile): bind declared home view

### DIFF
--- a/framework/core/src/libkungfu/src/runtime/profile/profile_lifecycle.cpp
+++ b/framework/core/src/libkungfu/src/runtime/profile/profile_lifecycle.cpp
@@ -350,7 +350,7 @@ nlohmann::json normalize_profile(const nlohmann::json &input) {
   require_exact_keys(input,
                      {"schema", "id", "title", "version", "members", "kfd1", "kfd2", "actions", "views", "migrations",
                       "permissions", "qualification"},
-                     {"kfd3"});
+                     {"kfd3", "experience"});
   if (required_text(input, "schema") != PROFILE_SCHEMA_V1) {
     throw std::invalid_argument("Profile must use kungfu.profile-suite/v1");
   }
@@ -366,6 +366,16 @@ nlohmann::json normalize_profile(const nlohmann::json &input) {
   for (const auto &member : required_members) {
     if (std::binary_search(optional_members.begin(), optional_members.end(), member)) {
       throw std::invalid_argument("required and optional Profile members overlap");
+    }
+  }
+  std::string home_view;
+  if (input.contains("experience")) {
+    const auto &experience = input.at("experience");
+    require_exact_keys(experience, {"homeView"});
+    home_view = required_text(experience, "homeView");
+    if (!std::binary_search(required_members.begin(), required_members.end(), home_view) &&
+        !std::binary_search(optional_members.begin(), optional_members.end(), home_view)) {
+      throw std::invalid_argument("experience.homeView must be a Profile member");
     }
   }
 
@@ -404,6 +414,9 @@ nlohmann::json normalize_profile(const nlohmann::json &input) {
     const auto &kfd3 = input.at("kfd3");
     require_exact_keys(kfd3, {"collaboration"});
     normalized["kfd3"] = {{"collaboration", normalize_ref(kfd3.at("collaboration"))}};
+  }
+  if (!home_view.empty()) {
+    normalized["experience"] = {{"homeView", home_view}};
   }
   return normalized;
 }

--- a/framework/core/src/libkungfu/tests/profile_lifecycle_tests.cpp
+++ b/framework/core/src/libkungfu/tests/profile_lifecycle_tests.cpp
@@ -123,6 +123,7 @@ package_fixture write_package(const fs::path &root, const std::string &version, 
       {"migrations", {{"registry", ref("migrations/registry.json")}}},
       {"permissions", {{"registry", ref("permissions.json")}}},
       {"qualification", {{"profile", ref("qualification/profile.json")}}},
+      {"experience", {{"homeView", "week-day-dashboard"}}},
   };
   const auto profile_path = root / "profile.json";
   write_text(profile_path, document.dump(2));
@@ -170,6 +171,8 @@ void test_inspection_is_content_bound_and_confined() {
   require(first.at("closure").at("source_contract").at("root") ==
               profile::profile_lifecycle_contract().at("source_contract_root"),
           "Profile root did not bind the exact KFX source contract");
+  require(first.at("profile").at("experience").at("homeView") == "week-day-dashboard",
+          "Profile authority did not preserve the declared home view");
   require_invalid([&] { (void)profile::inspect_profile(fixture.profile_path.string(), nlohmann::json::object()); },
                   "unbound Suite member roots were accepted");
   auto changed_members = member_roots();
@@ -190,6 +193,14 @@ void test_inspection_is_content_bound_and_confined() {
   write_text(escaped.profile_path, document.dump(2));
   require_invalid([&] { (void)profile::inspect_profile(escaped.profile_path.string(), member_roots()); },
                   "parent traversal was accepted");
+
+  const auto invalid_experience = write_package(tree.root() / "invalid-experience", "1.0.0");
+  std::ifstream invalid_input(invalid_experience.profile_path);
+  auto invalid_document = nlohmann::json::parse(invalid_input);
+  invalid_document["experience"]["homeView"] = "unrelated-dashboard";
+  write_text(invalid_experience.profile_path, invalid_document.dump(2));
+  require_invalid([&] { (void)profile::inspect_profile(invalid_experience.profile_path.string(), member_roots()); },
+                  "home view outside the Profile Suite was accepted");
 }
 
 void test_optional_kfd3_collaboration_is_content_bound() {


### PR DESCRIPTION
## Summary

- accept the KFX `experience.homeView` field in the libkungfu Profile authority
- require the declared home view to resolve to a Suite member
- preserve the field in the normalized, content-bound Profile root

## Verification

- `./shifu rebuild:core`
- native Profile lifecycle tests (Node and Python build variants)
- `./shifu freeze && node framework/gui/scripts/gen-system-profile-kfd3.mjs`
- `./shifu check:source`

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bugfix aligns the C++ Profile authority with the existing shared KFX experience contract without changing that contract."
}
-->

## Governance risk check

- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed
