### PR TITLE
ci(gates): pin patrol to stable Buildchain release

### DIFF
--- a/.github/workflows/dev-verify-patrol.yml
+++ b/.github/workflows/dev-verify-patrol.yml
@@ -33,7 +33,7 @@ permissions:
 
 jobs:
   verify:
-    uses: kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@29a3daaf5417b138683f99a031268afd6efa9afd
+    uses: kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@0d5487b64cc4df52519e4b30492876f3819b9137
     with:
       buildchain-ref: ${{ inputs.buildchain-ref || '' }}
       gate-profile: dev-patrol

--- a/docs/adr/SHIFU-ADR-0004-gate-control-plane-contract.md
+++ b/docs/adr/SHIFU-ADR-0004-gate-control-plane-contract.md
@@ -3,8 +3,10 @@ metadata_schema: kungfu.document-metadata/v1
 doc_type: architecture-decision
 adr_id: SHIFU-ADR-0004
 decision_status: accepted
-implementation_status: partial
-implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/762, https://github.com/kungfu-systems/kungfu/pull/765, https://github.com/kungfu-systems/kungfu/pull/767, https://github.com/kungfu-systems/kungfu/pull/769, https://github.com/kungfu-systems/kungfu/pull/773]
+implementation_status: implemented
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/762, https://github.com/kungfu-systems/kungfu/pull/765, https://github.com/kungfu-systems/kungfu/pull/767, https://github.com/kungfu-systems/kungfu/pull/769, https://github.com/kungfu-systems/kungfu/pull/773, https://github.com/kungfu-systems/kungfu/pull/781]
+closure_pr: https://github.com/kungfu-systems/kungfu/pull/781
+qualification_refs: [scripts/shifu-gate-runtime.test.mjs, scripts/check-kungfu-gate-catalog.test.mjs, .github/workflows/dev-verify-patrol.yml]
 review_state: unreviewed
 sensitivity: public
 sources: [local-files, user-consensus]
@@ -17,7 +19,7 @@ last_reviewed: 2026-07-13
 
 # SHIFU-ADR-0004: Gate control plane contract
 
-- Status: accepted; development implementation
+- Status: accepted and implemented
 - Date: 2026-07-13
 - Scope: Shifu quality and release gate declaration, explanation, planning,
   execution, and receipts
@@ -117,7 +119,12 @@ definitions. Planning and execution accept separate argv maps so a read-only
 plan does not depend on a project cache or container wrapper. Kungfu supplies
 only its profile id, runner preset, non-sensitive runtime environment, and
 opaque cache reference; Buildchain contains no Kungfu Gate ids or policy rows.
-PR 773 is the three-platform consumer canary for Buildchain PR 1152.
+PR 773 published the three-platform standing dev patrol after the consumer
+canary recorded its Linux/macOS failures and Windows Actions transport failure
+without rewriting them as passing. Buildchain then published the controller as
+stable `v2.12.2`; PR 781 pins the patrol to that release's immutable commit and
+closes the project-side rollout. Gates without a current qualification binding
+remain explicit `off` policy decisions rather than implicit omissions.
 
 ## Consequences
 

--- a/docs/qualification/gates/README.md
+++ b/docs/qualification/gates/README.md
@@ -8,11 +8,13 @@ explains Kungfu's current policy and does not redefine Shifu semantics.
 ## Authority and current-state boundary
 
 - Shifu owns the registry, plan, execution, and receipt contracts.
-- Kungfu owns the 34 concrete gate ids, actions, documentation, and five policy
-  profiles.
+- Kungfu owns the 34 concrete gate ids, actions, documentation, and five remote
+  policy profiles.
 - [Workflow bindings](workflow-bindings.json) record how current GitHub
   workflows activate profiles and gates while migration is incomplete.
-- Buildchain owns runner allocation and aggregate checks; it cannot weaken a
+- Buildchain owns runner allocation and aggregate checks; the standing patrol
+  is pinned to the immutable `v2.12.2` release commit
+  `0d5487b64cc4df52519e4b30492876f3819b9137`. Buildchain cannot weaken a
   Kungfu profile or mint missing Gate receipts.
 - `required` means blocking when the workflow activation condition matches.
   Path filters, same-repository restrictions, schedules, and post-merge events
@@ -25,10 +27,43 @@ explains Kungfu's current policy and does not redefine Shifu semantics.
 | Profile | Current entry |
 | --- | --- |
 | `dev-pr` | GitHub-hosted build-free source, governance, docs-path, and Shifu-path checks |
-| `dev-patrol` | daily Linux self-hosted full product verify plus advisory external links |
+| `dev-patrol` | daily or manual three-platform self-hosted full product verify plus advisory external links |
 | `alpha-pr` | three-platform self-hosted build/verify/fuzz/release evidence plus conditional membrane and Shifu matrices |
 | `release-pr` | currently the same qualification strength as alpha, with the release publication channel |
 | `release-promotion` | post-merge promotion rehearsal and Buildchain artifact/passport admission |
+
+`local-changed` is intentionally not a qualifying profile. Local diagnosis uses
+`./shifu gate run source.changed-scope` or an explicit list of Gate ids, and the
+result is non-qualifying by contract. Keeping it outside the remote profile
+matrix prevents a partial changed-file selection from minting a release receipt
+or becoming a sixth publication policy by accident.
+
+The matrix is deliberately conservative during rollout. Existing blocking
+checks remain `required`; independently runnable heavy Gates without a current
+qualification binding remain explicitly `off` instead of being silently
+promoted to release requirements. Moving one of those Gates to `advisory` or
+`required` is a policy change and must add a workflow binding, current runner
+evidence, and a documented failure/rollback decision in the same change.
+
+## Rollout evidence and failure boundary
+
+- Buildchain PR `#1152` introduced the project-neutral profile controller and
+  merged to dev as `29a3daaf5417b138683f99a031268afd6efa9afd`.
+- Consumer canary run `29245122385` proved deterministic planning but did not
+  qualify: Linux and macOS failed, while the restored Windows runner hit an
+  Actions acquire-job TLS/session failure. Those outcomes remain failures; no
+  receipt or aggregate is rewritten as passing.
+- Kungfu PR `#773` published the fail-closed standing patrol on dev after the
+  operator explicitly required publication after the Windows attempt,
+  regardless of its result.
+- Buildchain alpha `v2.12.2-alpha.1` and stable `v2.12.2` were published from
+  the exact controller source through protected promotion PRs. The standing
+  patrol now consumes the immutable stable release commit above.
+
+The old single-Linux `build.yml@v2-alpha` patrol remains available through Git
+history as the rollback implementation. Rollback is a normal reviewed workflow
+change; it must not delete the failed canary evidence or claim profile
+qualification.
 
 See the [generated policy matrix](policy-matrix.md) and the detailed gate
 documents:

--- a/docs/qualification/gates/workflow-bindings.json
+++ b/docs/qualification/gates/workflow-bindings.json
@@ -145,7 +145,7 @@
       "requiredSnippets": [
         "gate-profile: dev-patrol",
         "runner-preset: kungfu-v4-self-hosted",
-        ".github/workflows/.gate-profile.yml@29a3daaf5417b138683f99a031268afd6efa9afd"
+        ".github/workflows/.gate-profile.yml@0d5487b64cc4df52519e4b30492876f3819b9137"
       ]
     },
     {


### PR DESCRIPTION
## Summary

- pin the standing `dev-patrol` reusable workflow to immutable Buildchain stable release commit `0d5487b64cc4df52519e4b30492876f3819b9137` (`v2.12.2`)
- correct the policy documentation from the retired single-Linux patrol to the current three-platform self-hosted matrix
- record the rollout evidence and preserve the non-qualifying canary boundary
- make explicit that unbound heavy Gates stay `off` until runner evidence and rollback are added
- keep `local-changed` as non-qualifying local diagnosis, not a sixth remote publication profile

## Release evidence

- Buildchain PR #1152 merged the generic controller
- Buildchain PR #1154 promoted it to alpha; `v2.12.2-alpha.1` published successfully
- Buildchain Stable Candidate Patrol run `29250692558` froze and approved the exact candidate
- Buildchain PR #1156 passed protected checks and merged to release
- Buildchain promotion run `29250889040` published stable `v2.12.2`; floating `v2.12` and `v2` resolve to the same stable commit
- Kungfu canary run `29245122385` remains explicitly non-qualifying; publication followed the operator's release-after-Windows decision and does not rewrite failures as passes

## Validation

- `node scripts/check-kungfu-gate-catalog.mjs`
- `node --test scripts/check-kungfu-gate-catalog.test.mjs`
- `actionlint .github/workflows/dev-verify-patrol.yml`
- `KUNGFU_DOCS_MODULES=... node scripts/run-docs-check.mjs`
- direct Biome check and `git diff --check`

The isolated worktree's commit hook reached its final `pnpm exec biome` step but `pnpm` attempted a direct install that the repository correctly rejects in favor of Shifu. The same local Biome binary passed, and PR CI is the authoritative clean-environment repetition.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "implemented",
  "adrs": ["SHIFU-ADR-0004"],
  "summary": "Complete the Gate control-plane rollout by pinning Kungfu to the stable Buildchain controller release",
  "verification": ["node scripts/check-kungfu-gate-catalog.mjs", "node --test scripts/check-kungfu-gate-catalog.test.mjs", "actionlint .github/workflows/dev-verify-patrol.yml"]
}
-->

## Governance risk check
- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

## Checklist
- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed

Signed-off-by: Keren Dong <keren.dong+cx@kungfu.link>

