### PR TITLE
fix(core): preserve RocksDB source archive type

### DIFF
--- a/docs/adr/ADR-0068-tiered-durability-and-crash-recovery.md
+++ b/docs/adr/ADR-0068-tiered-durability-and-crash-recovery.md
@@ -4,7 +4,7 @@ doc_type: architecture-decision
 adr_id: ADR-0068
 decision_status: accepted
 implementation_status: staged
-implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/668, https://github.com/kungfu-systems/kungfu/pull/673, https://github.com/kungfu-systems/kungfu/pull/682, https://github.com/kungfu-systems/kungfu/pull/687, https://github.com/kungfu-systems/kungfu/pull/691, https://github.com/kungfu-systems/kungfu/pull/693, https://github.com/kungfu-systems/kungfu/pull/697, https://github.com/kungfu-systems/kungfu/pull/701, https://github.com/kungfu-systems/kungfu/pull/705, https://github.com/kungfu-systems/kungfu/pull/754, https://github.com/kungfu-systems/kungfu/pull/770, https://github.com/kungfu-systems/kungfu/pull/783, https://github.com/kungfu-systems/kungfu/pull/784]
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/668, https://github.com/kungfu-systems/kungfu/pull/673, https://github.com/kungfu-systems/kungfu/pull/682, https://github.com/kungfu-systems/kungfu/pull/687, https://github.com/kungfu-systems/kungfu/pull/691, https://github.com/kungfu-systems/kungfu/pull/693, https://github.com/kungfu-systems/kungfu/pull/697, https://github.com/kungfu-systems/kungfu/pull/701, https://github.com/kungfu-systems/kungfu/pull/705, https://github.com/kungfu-systems/kungfu/pull/754, https://github.com/kungfu-systems/kungfu/pull/770, https://github.com/kungfu-systems/kungfu/pull/783, https://github.com/kungfu-systems/kungfu/pull/784, https://github.com/kungfu-systems/kungfu/pull/788]
 review_state: self-reviewed
 sensitivity: public
 sources: [local-files, user-consensus]

--- a/docs/adr/ADR-0068-tiered-durability-and-crash-recovery.md
+++ b/docs/adr/ADR-0068-tiered-durability-and-crash-recovery.md
@@ -4,7 +4,7 @@ doc_type: architecture-decision
 adr_id: ADR-0068
 decision_status: accepted
 implementation_status: staged
-implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/668, https://github.com/kungfu-systems/kungfu/pull/673, https://github.com/kungfu-systems/kungfu/pull/682, https://github.com/kungfu-systems/kungfu/pull/687, https://github.com/kungfu-systems/kungfu/pull/691, https://github.com/kungfu-systems/kungfu/pull/693, https://github.com/kungfu-systems/kungfu/pull/697, https://github.com/kungfu-systems/kungfu/pull/701, https://github.com/kungfu-systems/kungfu/pull/705, https://github.com/kungfu-systems/kungfu/pull/754, https://github.com/kungfu-systems/kungfu/pull/770, https://github.com/kungfu-systems/kungfu/pull/783]
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/668, https://github.com/kungfu-systems/kungfu/pull/673, https://github.com/kungfu-systems/kungfu/pull/682, https://github.com/kungfu-systems/kungfu/pull/687, https://github.com/kungfu-systems/kungfu/pull/691, https://github.com/kungfu-systems/kungfu/pull/693, https://github.com/kungfu-systems/kungfu/pull/697, https://github.com/kungfu-systems/kungfu/pull/701, https://github.com/kungfu-systems/kungfu/pull/705, https://github.com/kungfu-systems/kungfu/pull/754, https://github.com/kungfu-systems/kungfu/pull/770, https://github.com/kungfu-systems/kungfu/pull/783, https://github.com/kungfu-systems/kungfu/pull/784]
 review_state: self-reviewed
 sensitivity: public
 sources: [local-files, user-consensus]
@@ -265,6 +265,12 @@ Linux/ext4, and Windows/NTFS profiles have passed this process envelope at the
 same revision through local Shifu builds and qualification runs. The report
 schema fixes power-loss qualification and production-profile eligibility to
 false, so these results cannot activate a stronger public claim.
+
+The Core dependency acquisition path used by that qualification now preserves
+the RocksDB codeload archive type explicitly. Local no-controller-cache Shifu
+Core builds passed on macOS, Linux, and Windows at `1140d28d`; this establishes
+cross-platform buildability of the qualification path, not additional crash or
+power-loss evidence.
 
 The production mmap claim remains `demand + visibility`. The backup/restore
 round trip and projection cut equality are implementation evidence, not an

--- a/framework/core/.conan/recipes/rocksdb/conanfile.py
+++ b/framework/core/.conan/recipes/rocksdb/conanfile.py
@@ -101,6 +101,7 @@ class RocksDBConan(ConanFile):
         get(
             self,
             url=os.getenv("KUNGFU_CONAN_ROCKSDB_SOURCE_URL", source["url"]),
+            filename="rocksdb-source.tar.gz",
             sha256=source["sha256"],
             strip_root=True,
         )

--- a/scripts/source-acceptance.test.mjs
+++ b/scripts/source-acceptance.test.mjs
@@ -34,6 +34,14 @@ test('Conan recipe Python is linted without widening into the product type basel
   assert.ok(!labels.includes('Python type baseline'));
 });
 
+test('RocksDB source archive keeps an explicit tar filename', () => {
+  const recipe = fs.readFileSync(
+    path.join(ROOT, 'framework/core/.conan/recipes/rocksdb/conanfile.py'),
+    'utf8',
+  );
+  assert.match(recipe, /filename="rocksdb-source\.tar\.gz"/);
+});
+
 test('source plan cannot enter build, compiler, artifact, or release lifecycles', () => {
   const plan = sourceAcceptancePlan(['scripts/example.mjs']);
   const commands = plan


### PR DESCRIPTION
## Summary

Give the RocksDB Conan source download an explicit `.tar.gz` filename. The codeload URL ends in a commit hash, so Conan otherwise saves the valid gzip archive without an extension and attempts ZIP extraction, producing the same `BadZipFile` failure on macOS, Linux, and Windows.

This PR supersedes #784 by replaying the same validated patch and ADR projection directly on the latest protected dev head. It avoids bypassing the stale KFD witness exposed when attempting a local merge of the newly advanced dev baseline.

## Changes

- retain the existing source URL, SHA-256 verification, and `strip_root` behavior
- name the temporary source object `rocksdb-source.tar.gz`
- add a build-free regression assertion to the source acceptance suite
- retain ADR-0068's explicit process-only evidence boundary

## Verification

- no-controller-cache `./shifu check:source` passed with 101 source-contract tests at `2fdb3c4c0bb6d982ffd2777ae2934371f99b996d`
- pre-fix local Shifu `build:core` reproduced `BadZipFile: File is not a zip file` on macOS, Linux, and Windows
- post-fix local no-controller-cache Shifu `build:core` passed at the identical code patch `1140d28d9f5e2ff17a22596d0fb71a8f1398c7bf` on:
  - macOS arm64 / Apple Clang 21 / C++23
  - Linux x86_64 / GCC 14 / C++23
  - Windows x86_64 / MSVC 19.51 / C++23
- all three builds used the existing host Conan cache through the normal Shifu command; no global cache configuration was changed

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "stage-ready",
  "adrs": ["ADR-0068"],
  "summary": "Repair the cross-platform Core source acquisition path required by durability qualification without expanding its evidence claims",
  "verification": ["Build-free Shifu source gate passed with 101 tests at 2fdb3c4c", "Mac, Linux, and Windows local no-controller-cache Shifu Core builds passed for the identical source patch at 1140d28d"]
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The evidence remains local-only and revision-bound. This bugfix does not change workflows, Buildchain configuration, Shifu protocol, cache ownership, source URL, source digest, release artifacts, or the declared durability envelope.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed
