### PR TITLE
docs(shifu): close cache ADR evidence debt

### DIFF
--- a/docs/adr/SHIFU-ADR-0001-cache-profile-contract-and-ownership.md
+++ b/docs/adr/SHIFU-ADR-0001-cache-profile-contract-and-ownership.md
@@ -3,8 +3,11 @@ metadata_schema: kungfu.document-metadata/v1
 doc_type: architecture-decision
 adr_id: SHIFU-ADR-0001
 decision_status: accepted
-implementation_status: partial
-review_state: unreviewed
+implementation_status: implemented
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/644, https://github.com/kungfu-systems/kungfu/pull/655, https://github.com/kungfu-systems/kungfu/pull/696, https://github.com/kungfu-systems/kungfu/pull/727, https://github.com/kungfu-systems/kungfu/pull/739, https://github.com/kungfu-systems/kungfu/pull/755, https://github.com/kungfu-systems/kungfu/pull/774, https://github.com/kungfu-systems/kungfu/pull/779, https://github.com/kungfu-systems/kungfu/pull/786]
+closure_pr: https://github.com/kungfu-systems/kungfu/pull/786
+qualification_refs: [scripts/check-shifu-cache-contract.test.mjs, scripts/shifu-cache-runtime.test.mjs, scripts/shifu-uv-cache-adapter.test.mjs, scripts/shifu-conan-publish.test.mjs]
+review_state: self-reviewed
 sensitivity: public
 sources: [local-files, user-consensus]
 period: ongoing
@@ -16,7 +19,7 @@ last_reviewed: 2026-07-13
 
 # SHIFU-ADR-0001: Cache profile contract and ownership
 
-- Status: accepted; development implementation
+- Status: accepted and implemented
 - Date: 2026-07-12
 - Scope: Shifu execution and toolchain cache policy
 - Related: Kungfu Core [ADR-0044](./ADR-0044-shifu-delegation-protocol.md)

--- a/docs/adr/SHIFU-ADR-0004-gate-control-plane-contract.md
+++ b/docs/adr/SHIFU-ADR-0004-gate-control-plane-contract.md
@@ -4,10 +4,10 @@ doc_type: architecture-decision
 adr_id: SHIFU-ADR-0004
 decision_status: accepted
 implementation_status: implemented
-implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/762, https://github.com/kungfu-systems/kungfu/pull/765, https://github.com/kungfu-systems/kungfu/pull/767, https://github.com/kungfu-systems/kungfu/pull/769, https://github.com/kungfu-systems/kungfu/pull/773, https://github.com/kungfu-systems/kungfu/pull/781]
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/762, https://github.com/kungfu-systems/kungfu/pull/765, https://github.com/kungfu-systems/kungfu/pull/767, https://github.com/kungfu-systems/kungfu/pull/769, https://github.com/kungfu-systems/kungfu/pull/773, https://github.com/kungfu-systems/kungfu/pull/781, https://github.com/kungfu-systems/kungfu/pull/786]
 closure_pr: https://github.com/kungfu-systems/kungfu/pull/781
-qualification_refs: [scripts/shifu-gate-runtime.test.mjs, scripts/check-kungfu-gate-catalog.test.mjs, .github/workflows/dev-verify-patrol.yml]
-review_state: unreviewed
+qualification_refs: [scripts/shifu-gate-runtime.test.mjs, scripts/check-kungfu-gate-catalog.test.mjs, scripts/shifu-cache-runtime.test.mjs, .github/workflows/dev-verify-patrol.yml]
+review_state: self-reviewed
 sensitivity: public
 sources: [local-files, user-consensus]
 period: ongoing

--- a/docs/document-metadata.contract.json
+++ b/docs/document-metadata.contract.json
@@ -201,7 +201,6 @@
     "statusesForbiddingEvidence": ["not-started", "not-applicable"],
     "pullRequestPattern": "^https://github\\.com/kungfu-systems/kungfu/pull/[0-9]+$",
     "legacyEvidenceExemptions": {
-      "SHIFU-ADR-0001": "Partial cache-profile rollout predates immutable evidence capture.",
       "ADR-0005": "Partial modernization assessment needs a dedicated history reconstruction.",
       "ADR-0006": "Frontend platform implementation spans legacy history not yet reconstructed.",
       "ADR-0009": "Self-bootstrap evolved across several renames and needs semantic history review.",


### PR DESCRIPTION
## Summary

Close the stale documentation debt for the implemented Shifu cache contract and its Gate execution boundary by binding the accepted ADRs to their merged delivery and qualification evidence.

## Related issue

Documentation closeout for the completed Shifu cache profile rollout.

## Changes

- mark SHIFU-ADR-0001 implemented and bind PRs 644 through 786 plus focused qualification tests
- add the nested cache re-entry fix and runtime qualification to SHIFU-ADR-0004
- self-review both current ADR projections and remove the obsolete SHIFU-ADR-0001 legacy evidence exemption

## Verification

- `node --test` focused metadata, ADR, cache runtime, uv, and Conan suites: 69 passed
- `./shifu docs:check`: passed, including 59 documentation contract tests
- `./shifu check:source`: passed, including 104 source acceptance tests, TypeScript, and Biome
- ADR audit: structural findings 0; SHIFU-ADR-0001 and SHIFU-ADR-0004 have no remaining debt and are stable-admitted

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "implemented",
  "adrs": ["SHIFU-ADR-0001", "SHIFU-ADR-0004"],
  "summary": "Close the implemented Shifu cache and Gate cache-boundary ADRs with immutable delivery and qualification evidence",
  "verification": ["focused cache and metadata tests", "deterministic documentation gate", "build-free source acceptance"]
}
-->

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

This PR changes only public ADR evidence metadata; it does not alter runtime behavior or release credentials.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed