### PR TITLE
docs(adr): bind native console delivery PR

### DIFF
--- a/docs/adr/ADR-0079-native-work-agent-console-loop.md
+++ b/docs/adr/ADR-0079-native-work-agent-console-loop.md
@@ -4,7 +4,7 @@ doc_type: architecture-decision
 adr_id: ADR-0079
 decision_status: accepted
 implementation_status: staged
-implementation_commits: [f614e82c10d49d437a432d4110b986d1a2074f48]
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/790]
 review_state: self-reviewed
 sensitivity: public
 sources: [local-files, user-decision]


### PR DESCRIPTION
## Summary

Replace the pre-rebase implementation commit anchor in ADR-0079 with the canonical merged delivery PR.

## Changes

- bind ADR-0079 staged implementation evidence to merged PR #790
- avoid evidence drift when GitHub rebase merge rewrites commit SHAs

## Verification

- ./shifu docs:check
- pre-commit staged gate

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "stage-ready",
  "adrs": ["ADR-0079"],
  "summary": "Repairs the staged evidence anchor after the canonical rebase merge of PR #790.",
  "verification": ["./shifu docs:check", "pre-commit staged gate"]
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed