### PR TITLE
chore(shifu): pin final stable gate runtime

### DIFF
--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -5,8 +5,8 @@
   "witnessKind": "prebuild",
   "supportLevel": "release",
   "source": {
-    "cwd": "/Users/dkr/Worktrees/kungfu/feature/native-work-agent-console-loop",
-    "sourceSha": "529050830881d9083bfbbe26d533659b9b8a5af1",
+    "cwd": "/Users/dkr/Worktrees/kungfu/fix/gate-profile-final-runtime",
+    "sourceSha": "9c9711574fbe50d40918eed128874b3d2162d049",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
     "registryDigest": "sha256:4566b4e5d837d0c6f3dc10e9b1838b9968de21554d3a57497c8840af71994b71"
   },

--- a/.github/workflows/dev-verify-patrol.yml
+++ b/.github/workflows/dev-verify-patrol.yml
@@ -33,7 +33,7 @@ permissions:
 
 jobs:
   verify:
-    uses: kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@0d5487b64cc4df52519e4b30492876f3819b9137
+    uses: kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@a6145efc210a961da0e5c63d7024d42061550f60
     with:
       buildchain-ref: ${{ inputs.buildchain-ref || '' }}
       gate-profile: dev-patrol

--- a/docs/qualification/gates/README.md
+++ b/docs/qualification/gates/README.md
@@ -13,8 +13,8 @@ explains Kungfu's current policy and does not redefine Shifu semantics.
 - [Workflow bindings](workflow-bindings.json) record how current GitHub
   workflows activate profiles and gates while migration is incomplete.
 - Buildchain owns runner allocation and aggregate checks; the standing patrol
-  is pinned to the immutable `v2.12.2` release commit
-  `0d5487b64cc4df52519e4b30492876f3819b9137`. Buildchain cannot weaken a
+  is pinned to the immutable `v2.12.4` release commit
+  `a6145efc210a961da0e5c63d7024d42061550f60`. Buildchain cannot weaken a
   Kungfu profile or mint missing Gate receipts.
 - `required` means blocking when the workflow activation condition matches.
   Path filters, same-repository restrictions, schedules, and post-merge events
@@ -56,9 +56,12 @@ evidence, and a documented failure/rollback decision in the same change.
 - Kungfu PR `#773` published the fail-closed standing patrol on dev after the
   operator explicitly required publication after the Windows attempt,
   regardless of its result.
-- Buildchain alpha `v2.12.2-alpha.1` and stable `v2.12.2` were published from
-  the exact controller source through protected promotion PRs. The standing
-  patrol now consumes the immutable stable release commit above.
+- Buildchain stable `v2.12.4` was published from the protected release train
+  after cross-platform fixture checks, alpha self-dogfood, exact-alpha
+  qualification, and the stable candidate patrol. It includes the Windows
+  batch adapter, per-run managed receipt cleanup, and human-authority stable
+  reconciliation fixes discovered by the first three-runner patrols. The
+  standing patrol consumes the immutable stable release commit above.
 
 The old single-Linux `build.yml@v2-alpha` patrol remains available through Git
 history as the rollback implementation. Rollback is a normal reviewed workflow

--- a/docs/qualification/gates/workflow-bindings.json
+++ b/docs/qualification/gates/workflow-bindings.json
@@ -146,7 +146,7 @@
         "gate-profile: dev-patrol",
         "runner-preset: kungfu-v4-self-hosted",
         "{\"linux\":[\"./shifu\"],\"macos\":[\"./shifu\"],\"windows\":[\"./shifu.cmd\"]}",
-        ".github/workflows/.gate-profile.yml@0d5487b64cc4df52519e4b30492876f3819b9137"
+        ".github/workflows/.gate-profile.yml@a6145efc210a961da0e5c63d7024d42061550f60"
       ]
     },
     {


### PR DESCRIPTION
## Summary

- pin Kungfu dev heavy-gate patrol and gate workflow bindings to Buildchain v2.12.4 stable runtime
- document the Windows batch adapter, per-run managed receipt cleanup, and human-authority stable-patrol reconciliation
- regenerate KFD evidence projections against the final contract

## Verification

- `./shifu gate validate` (34 gates, 5 profiles)
- `./shifu gate run gate.catalog`
- `node --test scripts/check-kungfu-gate-catalog.test.mjs` (4 passed)
- `./shifu kfd:buildchain:check`
- staged commit hook: gate catalog/docs (59 tests), ADR evidence, and KFD evidence passed

Buildchain stable runtime: `a6145efc210a961da0e5c63d7024d42061550f60` (v2.12.4).

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Pins an immutable stable gate runtime and refreshes generated KFD projections without changing an architecture decision."
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [x] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The PR pins an immutable published Buildchain commit and updates only repository-controlled gate/release evidence.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed