### PR TITLE
fix(gui): resolve active Profile root for Agent launch

### DIFF
--- a/extensions/work-dashboard/src/view/agent-console-launch.ts
+++ b/extensions/work-dashboard/src/view/agent-console-launch.ts
@@ -1,0 +1,27 @@
+import type { Profile } from '@kungfu-tech/api/capability';
+
+const MISSION_CONTROL_PROFILE_ID = 'kungfu.mission-control';
+
+export async function resolveMissionControlProfileRoot(
+  profile: Pick<Profile, 'managerAsync'> | undefined,
+): Promise<string> {
+  if (!profile) {
+    throw new Error('Profile capability unavailable');
+  }
+
+  const manager = await profile.managerAsync();
+  const current = manager.profiles.find(
+    (candidate) => candidate.profileId === MISSION_CONTROL_PROFILE_ID,
+  );
+  if (!current) {
+    throw new Error('Mission Control Profile is not installed');
+  }
+  if (
+    current.health !== 'active' ||
+    !current.catalog?.activeExactRoot ||
+    !current.profileSuiteRoot
+  ) {
+    throw new Error('Mission Control Profile exact root is not active');
+  }
+  return current.profileSuiteRoot;
+}

--- a/extensions/work-dashboard/src/view/index.tsx
+++ b/extensions/work-dashboard/src/view/index.tsx
@@ -37,6 +37,7 @@ import {
 import type { KfxCapabilities, Shell } from '@kungfu-tech/kfx';
 import { headingStyle, mono, panelStyle } from '@kungfu-tech/kfx';
 import React from 'react';
+import { resolveMissionControlProfileRoot } from './agent-console-launch';
 import {
   dashboardMetricVisuals,
   dashboardSnapshotVisual,
@@ -948,31 +949,30 @@ function AtlasProjectionView({
   const currentMission =
     missions.find((mission) => mission.mission_id === selectedMission) ?? null;
   const openGoalConsole = React.useCallback(
-    (goal: AtlasGoal) => {
-      const profileRoot =
-        trustReport?.state.profile_suite_root ??
-        trustReport?.query_profile?.profile.profile_suite_root;
-      if (!profileRoot) {
-        setMessage(
-          'Run the Mission assessment first so the Console can bind the exact Profile root.',
-        );
-        return;
+    async (goal: AtlasGoal) => {
+      try {
+        const profileRoot = await resolveMissionControlProfileRoot(profile);
+        if (!mounted.current) return;
+        shell.open('terminal', {
+          workWorkspaceId:
+            (typeof process !== 'undefined'
+              ? process.env.KF_WORKSPACE_ID
+              : '') || 'home',
+          workProfileId: 'kungfu.mission-control',
+          workProfileRoot: profileRoot,
+          workEntityType: 'go',
+          workEntityId: goal.goal_id,
+          workEntity: JSON.stringify(goal),
+          workPurpose:
+            goal.next_action || goal.summary || goal.title || goal.goal_id,
+          workSystemTimeCut: dashboardCut || new Date().toISOString(),
+        });
+      } catch (error) {
+        if (!mounted.current) return;
+        setMessage(`Agent Console unavailable · ${(error as Error).message}`);
       }
-      shell.open('terminal', {
-        workWorkspaceId:
-          (typeof process !== 'undefined' ? process.env.KF_WORKSPACE_ID : '') ||
-          'home',
-        workProfileId: 'kungfu.mission-control',
-        workProfileRoot: profileRoot,
-        workEntityType: 'go',
-        workEntityId: goal.goal_id,
-        workEntity: JSON.stringify(goal),
-        workPurpose:
-          goal.next_action || goal.summary || goal.title || goal.goal_id,
-        workSystemTimeCut: dashboardCut || new Date().toISOString(),
-      });
     },
-    [dashboardCut, shell, trustReport],
+    [dashboardCut, profile, shell],
   );
   const goalTrustById = React.useMemo(
     () =>

--- a/extensions/work-dashboard/tests/agent-console-launch.test.ts
+++ b/extensions/work-dashboard/tests/agent-console-launch.test.ts
@@ -1,0 +1,97 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type {
+  ManagedProfile,
+  Profile,
+  ProfileManagerProjection,
+} from '@kungfu-tech/api/capability';
+import { resolveMissionControlProfileRoot } from '../src/view/agent-console-launch.ts';
+
+const ROOT = `sha256:${'a'.repeat(64)}`;
+
+function managedProfile(
+  overrides: Partial<ManagedProfile> = {},
+): ManagedProfile {
+  return {
+    profileId: 'kungfu.mission-control',
+    profileVersion: '3.0.0',
+    profileSuiteRoot: ROOT,
+    profileRevision: 1,
+    lifecycleState: 'activated',
+    activated: true,
+    removed: false,
+    grantedPermissions: [],
+    qualification: {},
+    availableRoots: 1,
+    source: '/tmp/mission-control.profile.json',
+    health: 'active',
+    catalog: {
+      schema: 'kungfu.profile-composition/v1',
+      profileId: 'kungfu.mission-control',
+      profileVersion: '3.0.0',
+      profileSuiteRoot: ROOT,
+      profileRevision: 1,
+      activeExactRoot: true,
+      memberRoots: {},
+      purposes: [],
+      factSurfaces: [],
+      claims: [],
+      policies: [],
+      views: [],
+      diagnostics: [],
+      catalogRoot: `sha256:${'b'.repeat(64)}`,
+    },
+    diagnostics: [],
+    ...overrides,
+  };
+}
+
+function profileWith(
+  ...profiles: ManagedProfile[]
+): Pick<Profile, 'managerAsync'> {
+  const projection: ProfileManagerProjection = {
+    schema: 'kungfu.profile-manager/v1',
+    runtimeDir: '/tmp/profile-runtime',
+    cutSystemTime: 1,
+    profiles,
+    count: profiles.length,
+    knownLimits: [],
+  };
+  return { managerAsync: async () => projection };
+}
+
+test('Agent Console binds the current active exact Profile root without an assessment', async () => {
+  assert.equal(
+    await resolveMissionControlProfileRoot(profileWith(managedProfile())),
+    ROOT,
+  );
+});
+
+test('Agent Console refuses a Profile whose exact root is not active', async () => {
+  const catalog = managedProfile().catalog;
+  assert.ok(catalog);
+  await assert.rejects(
+    resolveMissionControlProfileRoot(
+      profileWith(
+        managedProfile({
+          catalog: {
+            ...catalog,
+            activeExactRoot: false,
+          },
+        }),
+      ),
+    ),
+    /exact root is not active/,
+  );
+});
+
+test('Agent Console reports missing Profile capability and installation', async () => {
+  await assert.rejects(
+    resolveMissionControlProfileRoot(undefined),
+    /capability unavailable/,
+  );
+  await assert.rejects(
+    resolveMissionControlProfileRoot(profileWith()),
+    /not installed/,
+  );
+});


### PR DESCRIPTION
## Summary

Resolve the active exact Mission Control Profile root through Profile Manager when launching an Agent Console from a Go card. Mission assessment remains a trust surface and is no longer an execution prerequisite.

## Verification

- ./shifu --filter @kungfu-tech/kfx-view-work-dashboard test
- ./shifu check
- ./shifu check:source

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bug fix restores the existing Profile Manager authority boundary and does not alter an architecture contract"
}
-->

## Governance risk check

- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)