### PR TITLE
fix(adr): point ADR-0049 evidence at the on-dev qualification commit

### DIFF
--- a/docs/adr/ADR-0049-layer-complete-products-and-domain-neutral-core.md
+++ b/docs/adr/ADR-0049-layer-complete-products-and-domain-neutral-core.md
@@ -6,7 +6,7 @@ decision_status: accepted
 implementation_status: staged
 review_state: legacy-unreviewed
 sensitivity: public
-implementation_commits: [409537aa42752388311705305a61a323f06ffa22]
+implementation_commits: [360c1dfcaf12aa410158f22ff175e5c608b0a77a]
 qualification_refs: [tests/qualification/layers/run.mjs, tests/qualification/layers/release/run.mjs, tests/qualification/layers/surfaces/run.mjs, scripts/run-release-qualification.mjs]
 ---
 


### PR DESCRIPTION
Correct ADR-0049's qualification evidence pointer.

The ADR-0049 layer-qualification work landed on `dev/v4/v4.0` as `360c1dfca` via a
rebase merge, which rewrote the feature-branch hash. ADR-0049
`implementation_commits` still referenced the pre-rebase hash `409537aa` — present
only on `feature/adr0049-seven-staged-release-linear-v2` and unreachable from the
mainline — so the docs `adr-evidence-commit` gate rejects every new `dev/*` PR.
This points the evidence at the reachable on-dev commit (identical patch-id, no
content change).

<!-- kungfu-adr-release:v1 {"schema":"kungfu.adr-release-pr/v1","kind":"dev-delivery","intent":"stage-ready","adrs":["ADR-0049"],"summary":"Correct ADR-0049 qualification evidence to the reachable on-dev commit 360c1dfca; the pre-rebase feature hash 409537aa is unreachable from mainline and breaks the adr-evidence-commit docs gate for all new dev PRs.","verification":["git merge-base --is-ancestor 360c1dfca origin/dev/v4/v4.0 confirms the evidence commit is reachable from mainline","360c1dfca has an identical patch-id to the unreachable 409537aa (same change, rebased hash)","implementation_status unchanged (staged); one-line front-matter correction only"]} -->