### PR TITLE
feat(runtime): ADR-0077 live-runtime plumbing — peer react hook + coordinator page-precreate

### DIFF
--- a/docs/adr/ADR-0077-agent-coordination-on-live-runtime.md
+++ b/docs/adr/ADR-0077-agent-coordination-on-live-runtime.md
@@ -9,7 +9,7 @@ review_state: maintainer-reviewed
 sensitivity: public
 sources: [local-files, user-decision]
 theme: agent-coordination-on-live-runtime
-last_reviewed: 2026-07-13
+last_reviewed: 2026-07-14
 ---
 
 # ADR-0077: agent coordination on the live runtime — same-host locks, signals, and audited Episodes
@@ -89,10 +89,22 @@ Build agent coordination as a live-runtime consumer on the existing substrate,
   crash-safe auto-release via holder-pid liveness, and Episode audit of each
   run's wait/acquire/release. The stdlib lock is dependency-free and tested
   cross-process; the audit and CLI run on a local core build.
-- **Deferred to a follow-up.** The journal-native arbiter that replaces the
-  waiter's short poll with a `coloop` coroutine awaiting a grant frame, and the
-  instruct-injection path — both share the arbiter-peer machinery and land
-  together. Cross-host coordination and hard confinement remain out of scope.
+- **Runtime plumbing (this increment).** The live-runtime primitives the
+  journal-native arbiter is built on: a Python-overridable peer react hook
+  (`on_react`/`on_start` trampolines plus `observe(carrier_type, callback)` and
+  the `request_read_from` / `request_write_to` / `get_public_writer` bindings),
+  so a live consumer written outside C++ can react to journal frames without a
+  bespoke C++ reactor subclass; and a coordinator-side fix so a peer that has
+  just registered no longer crashes the coordinator when its PUBLIC / SYNC /
+  command journals do not yet exist — the coordinator reader creates the missing
+  page instead of failing the read-only open. Both are validated on a local core
+  build (nine native journal / durability / crash-recovery tests plus a
+  three-process live peer round-trip); they carry no in-tree consumer yet.
+- **Deferred to a follow-up.** The arbiter peer itself — the in-memory lock
+  table that consumes the react hook, replacing the waiter's short poll with a
+  grant frame awaited over the live stream — and the instruct-injection path.
+  Both build directly on the runtime plumbing above. Cross-host coordination and
+  hard confinement remain out of scope.
 
 ### Architecture — reuse vs build
 

--- a/framework/core/src/bindings/python/binding/py-runtime.cpp
+++ b/framework/core/src/bindings/python/binding/py-runtime.cpp
@@ -5,6 +5,7 @@
 #include <limits>
 
 #include <nlohmann/json.hpp>
+#include <pybind11/functional.h>
 #include <pybind11/stl.h>
 
 #include <kungfu/runtime/action_recorder.h>
@@ -384,6 +385,13 @@ public:
   using peer::peer;
 
   void on_exit() override { PYBIND11_OVERLOAD_PURE(void, peer, on_exit); }
+
+  // The react hook: a Python subclass overrides on_react() to install frame
+  // subscriptions via observe(), and on_start() to run once the peer is live.
+  // Base peer provides empty impls, so these are OVERLOAD (not PURE).
+  void on_react() override { PYBIND11_OVERLOAD(void, peer, on_react); }
+
+  void on_start() override { PYBIND11_OVERLOAD(void, peer, on_start); }
 };
 
 void bind(pybind11::module &&m) {
@@ -1352,6 +1360,14 @@ void bind(pybind11::module &&m) {
       .def("is_started", &peer::is_started)
       .def("has_writer", &peer::has_writer)
       .def("get_writer", &peer::get_writer)
+      .def("observe", &peer::observe, py::arg("carrier_type"), py::arg("callback"))
+      .def("request_read_from", &peer::request_read_from, py::arg("trigger_time"), py::arg("source_id"),
+           py::arg("from_time"), py::arg("page_size") = 0)
+      .def("request_read_from_public", &peer::request_read_from_public, py::arg("trigger_time"), py::arg("source_id"),
+           py::arg("from_time"), py::arg("page_size") = 0)
+      .def("request_write_to", &peer::request_write_to, py::arg("trigger_time"), py::arg("dest_id"),
+           py::arg("page_size") = 0)
+      .def("get_public_writer", &peer::get_public_writer)
       .def("on_exit", &peer::on_exit);
 }
 } // namespace kungfu::runtime

--- a/framework/core/src/libkungfu/include/kungfu/runtime/live/peer.h
+++ b/framework/core/src/libkungfu/include/kungfu/runtime/live/peer.h
@@ -53,6 +53,13 @@ public:
 
   const state_cache::bank &get_state_bank() const;
 
+  // Register a per-frame callback for a carrier_type on the live event stream.
+  // Intended to be called from a subclass on_react() (including a Python
+  // subclass via the binding), so the subscription is installed before the
+  // reactor connects events_. This is the react hook that lets a live consumer
+  // written outside C++ react to frames without a bespoke C++ reactor subclass.
+  void observe(int32_t carrier_type, const std::function<void(const event_ptr &)> &callback);
+
   void request_read_from(int64_t trigger_time, uint32_t source_id, int64_t from_time, uint64_t page_size = 0);
 
   void request_read_from_public(int64_t trigger_time, uint32_t source_id, int64_t from_time, uint64_t page_size = 0);

--- a/framework/core/src/libkungfu/src/runtime/live/peer.cpp
+++ b/framework/core/src/libkungfu/src/runtime/live/peer.cpp
@@ -207,6 +207,13 @@ void peer::on_react() {}
 
 void peer::on_start() {}
 
+void peer::observe(int32_t carrier_type, const std::function<void(const event_ptr &)> &callback) {
+  // Same shape as the built-in react() subscriptions, but the handler is
+  // supplied by the caller (e.g. a Python subclass). Capture the callback by
+  // value so it outlives this call and lives for the reactor's lifetime.
+  events_ | is(carrier_type) | $([callback](const event_ptr &event) { callback(event); });
+}
+
 void peer::on_register(int64_t trigger_time, const Register &register_data) {
   register_location(trigger_time, register_data);
 }

--- a/framework/core/src/libyijinjing/src/journal/journal.cpp
+++ b/framework/core/src/libyijinjing/src/journal/journal.cpp
@@ -95,7 +95,20 @@ void journal::load_page(uint32_t page_id) {
         page_ = std::move(preload_page_);
         page_->enable_page();
       } else {
-        page_ = page::load(location_, dest_id_, page_size_, page_id, policy_.current_page);
+        // A coordinator reader joins a freshly-registered peer's PUBLIC / SYNC /
+        // command journals (coordinator::register_peer) before that peer has
+        // opened its own writers, so the page may not exist yet. Create it here
+        // — the "create sync journal" intent at the register site — rather than
+        // failing the read-only open. The peer subsequently opens the same page
+        // as a writer. Guarded so only the coordinator reader
+        // (precreation == coordinator) and only a genuinely missing page take
+        // this path; normal readers and existing pages are unaffected.
+        auto page_policy = policy_.current_page;
+        if (policy_.precreation == page_precreation::coordinator and
+            not page::check_page_existed(location_, dest_id_, page_id)) {
+          page_policy = page_open_policy::coordinator_precreate();
+        }
+        page_ = page::load(location_, dest_id_, page_size_, page_id, page_policy);
       }
     }
     frame_->set_address(page_->first_frame_address());


### PR DESCRIPTION
ADR-0077 increment: the live-runtime plumbing the journal-native arbiter is
built on. No arbiter yet — this lands the two primitives and keeps the arbiter
itself deferred to a follow-up.

**What lands**

- `feat(runtime)`: a Python-overridable peer react hook — `on_react` / `on_start`
  trampolines plus `observe(carrier_type, callback)` and the `request_read_from`
  / `request_read_from_public` / `request_write_to` / `get_public_writer`
  bindings — so a live consumer written outside C++ can react to journal frames
  without a bespoke C++ reactor subclass. No schema change.
- `fix(journal)`: a coordinator-side correctness fix. `register_peer` read-joins
  a freshly-registered peer's PUBLIC / SYNC / command journals before that peer
  has opened its own writers, so the pages may not exist yet; the read-only page
  load then failed with ENOENT and tore down the coordinator event loop. The
  coordinator reader now creates the missing page (`coordinator_precreate`)
  instead of failing — the "create sync journal" intent already at the register
  site. Guarded so only the coordinator reader and only a genuinely missing page
  take this path; normal readers and existing pages are unaffected. This path
  had no exercised consumer since v4 removed the last live peer.

**Validation (local core build)**

- Nine native journal / durability / crash-recovery ctests pass.
- A three-process live round-trip (coordinator + a writer peer + a reader peer)
  delivers an action-envelope frame through the react hook — reader `observe`
  callback fires with the decoded payload — with the coordinator surviving both
  peers' registration purely on the page-precreate fix (no peer-side workaround).

**Scope**

The arbiter peer that consumes the react hook (the in-memory lock table that
replaces the lock waiter's poll with a grant frame) and the instruct path are
deferred; they build directly on this plumbing. ADR-0077 stays `partial`.

<!-- kungfu-adr-release:v1 {"schema":"kungfu.adr-release-pr/v1","kind":"dev-delivery","intent":"stage-ready","adrs":["ADR-0077"],"summary":"ADR-0077 live-runtime plumbing increment: a Python-overridable peer react hook (observe/on_react/on_start plus read/write bindings) and a coordinator page-precreate fix so a freshly-registered peer no longer crashes the coordinator when its PUBLIC/SYNC/command journals do not yet exist. The journal-native arbiter that consumes these is deferred to a follow-up.","verification":["nine native journal/durability/crash-recovery ctests pass on a local core build","three-process live peer round-trip (coordinator + writer + reader) delivers a frame through the react hook with the coordinator surviving registration on the page-precreate fix alone, no peer-side workaround","clang-format / ADR / docs commit gates pass; ADR-0077 implementation_status stays partial"]} -->