### PR TITLE
fix(gui): recover profile and agent console setup

### DIFF
--- a/extensions/system/kfx-manager/src/view/index.tsx
+++ b/extensions/system/kfx-manager/src/view/index.tsx
@@ -51,7 +51,7 @@ function ProfileCard({
   application?: ProfileApplicationProjection;
   applicationError?: string;
   planning: boolean;
-  onPlan: (action: 'qualify' | 'activate', source: string) => void;
+  onPlan: (action: 'qualify' | 'activate' | 'upgrade', source: string) => void;
   onKfd3Plan: (source: string) => void;
   onIntentPlan: (source: string, intentId: string) => void;
 }) {
@@ -60,7 +60,11 @@ function ProfileCard({
       ? 'qualify'
       : managed.lifecycleState === 'qualified'
         ? 'activate'
-        : null;
+        : managed.lifecycleState === 'activated' &&
+            managed.catalog &&
+            !managed.catalog.activeExactRoot
+          ? 'upgrade'
+          : null;
   return (
     <article
       style={{
@@ -230,7 +234,7 @@ function KfxManagerView({ caps, shell }: KfxViewProps) {
   const [loading, setLoading] = React.useState(true);
   const [pending, setPending] = React.useState<{
     plan: ProfileLifecyclePlan;
-    action: 'qualify' | 'activate';
+    action: 'qualify' | 'activate' | 'upgrade';
     source: string;
   } | null>(null);
   const [planning, setPlanning] = React.useState(false);
@@ -302,7 +306,7 @@ function KfxManagerView({ caps, shell }: KfxViewProps) {
   }, [onRefresh, refresh]);
 
   const previewPlan = async (
-    action: 'qualify' | 'activate',
+    action: 'qualify' | 'activate' | 'upgrade',
     source: string,
   ) => {
     if (!caps.profile) return;

--- a/extensions/terminal/package.json
+++ b/extensions/terminal/package.json
@@ -22,7 +22,8 @@
   ],
   "scripts": {
     "build": "kungfu sdk kfx build",
-    "clean": "kungfu sdk kfx clean"
+    "clean": "kungfu sdk kfx clean",
+    "test": "node --test tests/*.test.ts"
   },
   "dependencies": {
     "@kungfu-tech/api": "workspace:*",

--- a/extensions/terminal/src/view/agent-runtime-catalog.ts
+++ b/extensions/terminal/src/view/agent-runtime-catalog.ts
@@ -1,0 +1,43 @@
+import type {
+  AgentRuntime,
+  AgentRuntimeCatalog,
+  AgentRuntimeProfile,
+} from '@kungfu-tech/api/capability';
+
+export function availableAgentRuntimeProfiles(
+  catalog: AgentRuntimeCatalog | null,
+): AgentRuntimeProfile[] {
+  if (!catalog) return [];
+  const rows = [...catalog.configured];
+  const ids = new Set(rows.map((profile) => profile.id));
+  for (const candidate of catalog.discovered) {
+    if (!ids.has(candidate.profile.id)) rows.push(candidate.profile);
+  }
+  const preferred = catalog.defaultProfileId ?? catalog.recommendedProfileId;
+  return rows.sort((left, right) =>
+    left.id === preferred ? -1 : right.id === preferred ? 1 : 0,
+  );
+}
+
+export async function rememberDiscoveredAgentRuntimeProfile(
+  runtime: AgentRuntime,
+  profile: AgentRuntimeProfile,
+): Promise<boolean> {
+  if (profile.source !== 'discovered') return false;
+  await runtime.upsert(
+    {
+      id: profile.id,
+      label: profile.label,
+      provider: profile.provider,
+      executable: profile.launch.executable,
+      argv: profile.launch.argv,
+      shellMode: profile.launch.shellMode,
+      cwdPolicy: profile.cwdPolicy,
+      backend: profile.backendDefault,
+      envelope: profile.bootstrap.envelope,
+    },
+    true,
+  );
+  await runtime.setDefault(profile.id, true);
+  return true;
+}

--- a/extensions/terminal/src/view/index.tsx
+++ b/extensions/terminal/src/view/index.tsx
@@ -48,6 +48,10 @@ import { FitAddon } from '@xterm/addon-fit';
 import { Terminal as XTerm } from '@xterm/xterm';
 import React from 'react';
 import {
+  availableAgentRuntimeProfiles,
+  rememberDiscoveredAgentRuntimeProfile,
+} from './agent-runtime-catalog';
+import {
   type PersistedWindow,
   type WorkConsoleRegistry,
   type WorkspaceLayout,
@@ -60,19 +64,6 @@ import {
 
 async function resolve<T>(value: T | Promise<T>): Promise<T> {
   return await value;
-}
-
-function availableProfiles(catalog: AgentRuntimeCatalog | null) {
-  if (!catalog) return [];
-  const rows = [...catalog.configured];
-  const ids = new Set(rows.map((profile) => profile.id));
-  for (const candidate of catalog.discovered) {
-    if (!ids.has(candidate.profile.id)) rows.push(candidate.profile);
-  }
-  const preferred = catalog.defaultProfileId ?? catalog.recommendedProfileId;
-  return rows.sort((left, right) =>
-    left.id === preferred ? -1 : right.id === preferred ? 1 : 0,
-  );
 }
 
 // A tmux-safe run identity minted GUI-side. It becomes the session runId, the
@@ -554,12 +545,20 @@ function LauncherStrip({
   profiles,
   bindingLabel,
   busy,
+  loaded,
+  error,
   onLaunch,
+  onRetry,
+  onConfigure,
 }: {
   profiles: AgentRuntimeProfile[];
   bindingLabel: string;
   busy: boolean;
+  loaded: boolean;
+  error: string;
   onLaunch: (profile: AgentRuntimeProfile) => void;
+  onRetry: () => void;
+  onConfigure: () => void;
 }) {
   return (
     <div
@@ -599,10 +598,30 @@ function LauncherStrip({
           <span style={{ color: '#5bbf6a', fontWeight: 600 }}>+</span>
         </button>
       ))}
-      {profiles.length === 0 && (
-        <span style={{ ...mono, fontSize: 11, color: '#dcdcaa' }}>
-          Configure Codex or Claude in Settings → Agents
+      {profiles.length === 0 && busy && (
+        <span style={{ ...mono, fontSize: 11, color: '#858585' }}>
+          Detecting Codex and Claude…
         </span>
+      )}
+      {profiles.length === 0 && !busy && error && (
+        <>
+          <span style={{ ...mono, fontSize: 11, color: '#f48771' }}>
+            Agent detection failed · {error}
+          </span>
+          <button type="button" onClick={onRetry} style={iconButtonStyle}>
+            Retry
+          </button>
+        </>
+      )}
+      {profiles.length === 0 && loaded && !busy && !error && (
+        <span style={{ ...mono, fontSize: 11, color: '#dcdcaa' }}>
+          No Codex or Claude executable detected
+        </span>
+      )}
+      {profiles.length === 0 && loaded && !busy && !error && (
+        <button type="button" onClick={onConfigure} style={iconButtonStyle}>
+          Configure Agent
+        </button>
       )}
     </div>
   );
@@ -706,7 +725,8 @@ function SessionWorkspace({
   const [catalog, setCatalog] = React.useState<AgentRuntimeCatalog | null>(
     null,
   );
-  const [catalogBusy, setCatalogBusy] = React.useState(false);
+  const [catalogBusy, setCatalogBusy] = React.useState(true);
+  const [catalogError, setCatalogError] = React.useState('');
   const [consoleRegistry, setConsoleRegistry] =
     React.useState<WorkConsoleRegistry>(() =>
       domain
@@ -743,8 +763,9 @@ function SessionWorkspace({
     setCatalogBusy(true);
     try {
       setCatalog(await caps.agentRuntime.list());
+      setCatalogError('');
     } catch (error) {
-      setNotice(`Agent Runtime catalog failed: ${(error as Error).message}`);
+      setCatalogError((error as Error).message);
     } finally {
       setCatalogBusy(false);
     }
@@ -752,7 +773,13 @@ function SessionWorkspace({
 
   React.useEffect(() => {
     void refreshCatalog();
-    return shell.onRefresh(() => void refreshCatalog());
+    const offRefresh = shell.onRefresh(() => void refreshCatalog());
+    const onFocus = () => void refreshCatalog();
+    window.addEventListener('focus', onFocus);
+    return () => {
+      offRefresh();
+      window.removeEventListener('focus', onFocus);
+    };
   }, [refreshCatalog, shell]);
 
   const panedIds = React.useMemo(
@@ -1001,6 +1028,20 @@ function SessionWorkspace({
 
   const launch = React.useCallback(
     async (profile: AgentRuntimeProfile) => {
+      if (profile.source === 'discovered' && caps.agentRuntime) {
+        try {
+          await rememberDiscoveredAgentRuntimeProfile(
+            caps.agentRuntime,
+            profile,
+          );
+          setCatalog(await caps.agentRuntime.list());
+          setCatalogError('');
+        } catch (error) {
+          setNotice(
+            `Using detected ${profile.label}; could not remember it: ${(error as Error).message}`,
+          );
+        }
+      }
       const runId = mintRunId();
       const attemptId = `attempt:${runId}`;
       const workRef = await workRefFromShell(shell);
@@ -1119,7 +1160,7 @@ function SessionWorkspace({
         };
       });
     },
-    [caps.terminal, shell, workspaceId],
+    [caps.agentRuntime, caps.terminal, shell, workspaceId],
   );
 
   const markAttempt = React.useCallback(
@@ -1246,18 +1287,22 @@ function SessionWorkspace({
       }}
     >
       <LauncherStrip
-        profiles={availableProfiles(catalog)}
+        profiles={availableAgentRuntimeProfiles(catalog)}
         bindingLabel={
           shell.params?.workEntityId
             ? `Go · ${shell.params.workEntityId}`
             : 'Workspace assistant'
         }
         busy={catalogBusy}
+        loaded={catalog !== null}
+        error={catalogError}
         onLaunch={(profile) => {
           void launch(profile).catch((error) =>
             setNotice(`Agent launch failed: ${(error as Error).message}`),
           );
         }}
+        onRetry={() => void refreshCatalog()}
+        onConfigure={() => shell.open('settings')}
       />
       {panes.length > 0 && (
         <div

--- a/extensions/terminal/tests/agent-runtime-catalog.test.ts
+++ b/extensions/terminal/tests/agent-runtime-catalog.test.ts
@@ -1,0 +1,71 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type {
+  AgentRuntime,
+  AgentRuntimeCatalog,
+  AgentRuntimeProfile,
+} from '@kungfu-tech/api/capability';
+import {
+  availableAgentRuntimeProfiles,
+  rememberDiscoveredAgentRuntimeProfile,
+} from '../src/view/agent-runtime-catalog.ts';
+
+function profile(
+  id: string,
+  source: AgentRuntimeProfile['source'],
+): AgentRuntimeProfile {
+  return {
+    schema: 'kungfu.agent-runtime-profile/v1',
+    id,
+    label: id,
+    provider: 'codex',
+    launch: { executable: '/usr/bin/codex', argv: [], shellMode: false },
+    cwdPolicy: 'workspace-root',
+    backendDefault: 'tmux',
+    bootstrap: { adapter: 'codex', envelope: 'required' },
+    source,
+  };
+}
+
+test('detected recommended Agent is launchable before Settings configuration', () => {
+  const detected = profile('codex.detected', 'discovered');
+  const catalog = {
+    configured: [],
+    discovered: [
+      {
+        profile: detected,
+        pathClass: 'path',
+        version: 'codex-cli test',
+        available: true,
+        candidatesChecked: ['/usr/bin/codex'],
+      },
+    ],
+    defaultProfileId: null,
+    recommendedProfileId: detected.id,
+  } as AgentRuntimeCatalog;
+
+  assert.deepEqual(availableAgentRuntimeProfiles(catalog), [detected]);
+});
+
+test('first launch remembers a detected Agent as the exact default profile', async () => {
+  const detected = profile('codex.detected', 'discovered');
+  const calls: unknown[][] = [];
+  const runtime = {
+    upsert: async (...args: unknown[]) => {
+      calls.push(['upsert', ...args]);
+      return {};
+    },
+    setDefault: async (...args: unknown[]) => {
+      calls.push(['setDefault', ...args]);
+      return {};
+    },
+  } as unknown as AgentRuntime;
+
+  assert.equal(
+    await rememberDiscoveredAgentRuntimeProfile(runtime, detected),
+    true,
+  );
+  assert.equal((calls[0][1] as { id: string }).id, detected.id);
+  assert.deepEqual(calls[0].slice(-1), [true]);
+  assert.deepEqual(calls[1], ['setDefault', detected.id, true]);
+});

--- a/extensions/work-dashboard/src/view/agent-console-launch.ts
+++ b/extensions/work-dashboard/src/view/agent-console-launch.ts
@@ -16,12 +16,17 @@ export async function resolveMissionControlProfileRoot(
   if (!current) {
     throw new Error('Mission Control Profile is not installed');
   }
+  if (current.catalog && !current.catalog.activeExactRoot) {
+    throw new Error(
+      'Mission Control Profile update requires approval in Work Dashboard',
+    );
+  }
   if (
     current.health !== 'active' ||
-    !current.catalog?.activeExactRoot ||
+    !current.catalog ||
     !current.profileSuiteRoot
   ) {
-    throw new Error('Mission Control Profile exact root is not active');
+    throw new Error('Mission Control Profile setup is not complete');
   }
   return current.profileSuiteRoot;
 }

--- a/extensions/work-dashboard/src/view/profile-setup.ts
+++ b/extensions/work-dashboard/src/view/profile-setup.ts
@@ -5,7 +5,10 @@ import type {
 } from '@kungfu-tech/api/capability';
 
 export type MissionControlProfileSetupStep = {
-  action: Extract<ProfileLifecycleAction, 'install' | 'qualify' | 'activate'>;
+  action: Extract<
+    ProfileLifecycleAction,
+    'install' | 'qualify' | 'activate' | 'upgrade'
+  >;
   source: string;
 };
 
@@ -13,10 +16,23 @@ export function missionControlProfileSetupStep(
   managed: ManagedProfile | null,
   discovery: ProfileSourceDiscovery | null,
 ): MissionControlProfileSetupStep | null {
-  if (managed?.activated && managed.health === 'active') return null;
+  if (
+    managed?.activated &&
+    managed.health === 'active' &&
+    managed.catalog?.activeExactRoot
+  ) {
+    return null;
+  }
   const source = managed?.source ?? discovery?.source ?? '';
   if (!source) return null;
   if (!managed || managed.removed) return { action: 'install', source };
+  if (
+    managed.lifecycleState === 'activated' &&
+    managed.catalog &&
+    !managed.catalog.activeExactRoot
+  ) {
+    return { action: 'upgrade', source };
+  }
   if (managed.lifecycleState === 'installed') {
     return { action: 'qualify', source };
   }

--- a/extensions/work-dashboard/tests/agent-console-launch.test.ts
+++ b/extensions/work-dashboard/tests/agent-console-launch.test.ts
@@ -81,7 +81,7 @@ test('Agent Console refuses a Profile whose exact root is not active', async () 
         }),
       ),
     ),
-    /exact root is not active/,
+    /update requires approval in Work Dashboard/,
   );
 });
 

--- a/extensions/work-dashboard/tests/profile-setup.test.ts
+++ b/extensions/work-dashboard/tests/profile-setup.test.ts
@@ -59,6 +59,34 @@ test('Mission Control setup preserves explicit lifecycle gates', () => {
   );
 });
 
+test('a promoted factory Profile exposes the exact upgrade gate', () => {
+  assert.deepEqual(
+    missionControlProfileSetupStep(
+      managed('activated', {
+        health: 'inactive',
+        catalog: {
+          schema: 'kungfu.profile-composition/v1',
+          profileId: 'kungfu.mission-control',
+          profileVersion: '3.0.0',
+          profileSuiteRoot: 'sha256:promoted-source',
+          profileRevision: 2,
+          activeExactRoot: false,
+          memberRoots: {},
+          purposes: [],
+          factSurfaces: [],
+          claims: [],
+          policies: [],
+          views: [],
+          diagnostics: [],
+          catalogRoot: 'sha256:catalog',
+        },
+      }),
+      discovery,
+    ),
+    { action: 'upgrade', source: discovery.source },
+  );
+});
+
 test('removed Mission Control can be explicitly reinstalled', () => {
   assert.deepEqual(
     missionControlProfileSetupStep(


### PR DESCRIPTION
## Summary

- expose the exact upgrade gate when a promoted factory Profile root supersedes the active workspace root
- distinguish Agent detection loading, failure, and empty states in Agent Console
- let the first explicit launch of a detected Agent remember it as the default runtime profile

## Validation

- 22 targeted Work Dashboard and Agent Runtime tests passed
- ./shifu check:types passed
- ./shifu dist:dir produced a verified macOS Product candidate
- ./shifu check and check:source reach the pre-existing ADR-0049 evidence reachability failure on the current base; changed-file checks pass

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Restores existing Profile lifecycle and Agent Console behavior without changing an architectural decision."
}
-->