### PR TITLE
feat(core): call generic frame checksum + decode primitives from outer rings (ADR-0078)

### DIFF
--- a/docs/adr/ADR-0078-minimal-generic-core-closure-and-membrane-decode-checksum.md
+++ b/docs/adr/ADR-0078-minimal-generic-core-closure-and-membrane-decode-checksum.md
@@ -18,9 +18,10 @@ last_reviewed: 2026-07-13
 # ADR-0078: The minimal generic `.kungfu` core closure — libkungfu owns generic maintenance/self-describing primitives; domain interpretation stays in outer rings; expose generic frame decode and frame checksum on the membrane
 
 - Status: accepted (criterion + direction); implementation **partial** — the line
-  (Decision 1) and the primitive **exposure** (Decision 2, on pybind + membrane C
-  ABI v3 + the Rust wrapper) have landed; the outer-ring **de-duplication**
-  (Decision 3) is deferred to a follow-up go card (see Follow-up)
+  (Decision 1), the primitive **exposure** (Decision 2, on pybind + membrane C
+  ABI v3 + the Rust wrapper), and the outer-ring **de-duplication** (Decision 3 —
+  `rewind` decode + `atlas` checksum call the exposed primitives) have all landed;
+  the remaining item is cross-membrane enum-representation symmetry (see Follow-up)
 - Date: 2026-07-13
 - Category: layering / native-core closure / embedding membrane
 - Related: [ADR-0049](ADR-0049-layer-complete-products-and-domain-neutral-core.md)
@@ -158,19 +159,29 @@ in the outer ring.
 
 ## Follow-up
 
-- **Landed (this delivery, `implementation_status: partial`)**: Decision 1 (the
-  line, documented here) and Decision 2 (expose the two generic primitives) —
-  `decode_json` → `decode_flatbuffer_payload_json` (pybind) + `decode_frame_json`
-  (membrane C ABI v3), and `checksum_frame` on pybind + the C ABI, both mirrored
-  in the `kungfu-embedding` Rust wrapper (ABI v3, `CAP_GENERIC_CODEC`). Validated
-  on Mac (arm64) and Linux (x86_64) — membrane v3 negotiation + a pybind
-  generic-primitive smoke — plus the Rust `ApiV3` layout guard on all three
-  targets (arm64 / Linux x86_64 / Windows x86_64).
-- **Deferred to a follow-up go card**: Decision 3 (de-duplicate `rewind` decode
-  and `atlas` checksum to call the exposed primitives; leave domain folds in the
-  outer rings). It carries a prerequisite surfaced during grounding — the
-  `atlas` checksum call needs a narrow byte accessor on the `frame_header` bind
-  (the pybind `checksum_frame` takes a header buffer, which the longfist bind
-  does not currently expose) — and a full-build equivalence test. The Windows
-  full-build spike/pybind validation (blocked here by the RocksDB source-build
-  needing GitHub, unreachable from that host) is tracked with it.
+- **Landed (exposure delivery, PR #772)**: Decision 1 (the line, documented here)
+  and Decision 2 (expose the two generic primitives) — `decode_json` →
+  `decode_flatbuffer_payload_json` (pybind) + `decode_frame_json` (membrane C ABI
+  v3), and `checksum_frame` on pybind + the C ABI, both mirrored in the
+  `kungfu-embedding` Rust wrapper (ABI v3, `CAP_GENERIC_CODEC`).
+- **Landed (de-dup delivery, this PR)**: Decision 3 — `rewind` `BundleDecoder`
+  decodes through `decode_flatbuffer_payload_json` (filling absent strings with
+  `None` for contract parity) and `atlas` store checksums call `checksum_frame` /
+  `checksum_payload`; the hand-rolled reflection walk, crc32c/fnv1a tables, and
+  `frame_header` layout packing are removed, with the domain folds left in the
+  outer rings. The grounding-surfaced prerequisite is met by opting `frame_header`
+  into a read-only zero-copy Python buffer protocol, and the decode primitive now
+  takes `enum_as_int` (integer enum form matching the three reflection decoders —
+  Python `BundleDecoder`, TS `ReflectionDecoder`, the generated accessors) and
+  `object_name` (decode a specific table, not just the `.bfbs` root). Validated by
+  old-vs-native checksum equivalence (both algorithms) and rewind field-by-field
+  parity against the generated-accessor oracle, on **all three hosts** — Mac
+  (arm64), agent-120 (Linux x86_64), and DARKHERO (Windows x86_64) — full build
+  plus equivalence tests. The earlier Windows RocksDB source-build blocker is
+  resolved (RocksDB now resolves from the qualified Conan cache, no GitHub clone).
+- **Remaining follow-up**: cross-membrane enum representation symmetry. The de-dup
+  makes the pybind `decode_flatbuffer_payload_json` emit integer enums
+  (`enum_as_int`); the C ABI `decode_frame_json` and its Rust mirror still emit
+  enum identifiers. A follow-up should give those membranes the same integer-enum
+  form so the generic decode primitive reads identically across all three
+  membranes. `implementation_status` stays `partial` until that symmetry lands.

--- a/docs/adr/ADR-0078-minimal-generic-core-closure-and-membrane-decode-checksum.md
+++ b/docs/adr/ADR-0078-minimal-generic-core-closure-and-membrane-decode-checksum.md
@@ -4,7 +4,7 @@ doc_type: architecture-decision
 adr_id: ADR-0078
 decision_status: accepted
 implementation_status: partial
-implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/772]
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/772, https://github.com/kungfu-systems/kungfu/pull/802]
 review_state: self-reviewed
 sensitivity: public
 sources: [local-files, user-decision]

--- a/framework/core/src/bindings/python/binding/py-runtime.cpp
+++ b/framework/core/src/bindings/python/binding/py-runtime.cpp
@@ -1125,18 +1125,21 @@ void bind(pybind11::module &&m) {
   // reflection chokepoint.
   m.def(
       "decode_flatbuffer_payload_json",
-      [](py::bytes schema_bfbs, py::bytes payload) {
+      [](py::bytes schema_bfbs, py::bytes payload, const std::string &object_name) {
         const auto schema_bytes = schema_bfbs.cast<std::string>();
         const auto payload_bytes = payload.cast<std::string>();
         const auto schema = view::schema_handle::from_bytes(schema_bytes);
-        const auto result =
-            schema.decode_json(reinterpret_cast<const uint8_t *>(payload_bytes.data()), payload_bytes.size());
+        // ADR-0078 Decision 3: integer enum form so the JSON matches the three
+        // reflection decoders the outer rings de-dup against; object_name selects
+        // the event table for multi-table schemas (empty = root_type).
+        const auto result = schema.decode_json(reinterpret_cast<const uint8_t *>(payload_bytes.data()),
+                                               payload_bytes.size(), /*enum_as_int=*/true, object_name);
         if (!result.ok) {
           throw std::runtime_error("decode_flatbuffer_payload_json: " + result.error);
         }
         return result.json;
       },
-      py::arg("schema_bfbs"), py::arg("payload"));
+      py::arg("schema_bfbs"), py::arg("payload"), py::arg("object_name") = "");
 
   py::class_<action::action_recorder, action::action_recorder_ptr>(m, "action_recorder")
       .def(py::init<const std::string &, const std::string &, const std::string &, uint32_t, uint64_t>(),

--- a/framework/core/src/bindings/python/binding/py-yijinjing-types.cpp
+++ b/framework/core/src/bindings/python/binding/py-yijinjing-types.cpp
@@ -5,7 +5,9 @@
 #include <pybind11/stl.h>
 #include <pybind11/stl_bind.h>
 
+#include <cstdint>
 #include <sstream>
+#include <type_traits>
 
 #include <kungfu/yijinjing/schema/registry.h>
 
@@ -70,7 +72,16 @@ namespace py = pybind11;
 namespace hana = boost::hana;
 
 template <typename DataType> void bind_data_type(pybind11::module &m_types, const char *type_name) {
-  auto py_class = py::class_<DataType, std::shared_ptr<DataType>>(m_types, type_name);
+  // ADR-0078 Decision 3: frame_header opts into the Python buffer protocol so
+  // its raw struct bytes can be handed to the native checksum_frame primitive
+  // zero-copy; def_buffer below requires the py::buffer_protocol() tag here.
+  auto py_class = [&] {
+    if constexpr (std::is_same_v<DataType, kungfu::yijinjing::types::frame_header>) {
+      return py::class_<DataType, std::shared_ptr<DataType>>(m_types, type_name, py::buffer_protocol());
+    } else {
+      return py::class_<DataType, std::shared_ptr<DataType>>(m_types, type_name);
+    }
+  }();
   py_class.def(py::init<>());
   py_class.def(py::init<const std::string &>());
 
@@ -91,6 +102,21 @@ template <typename DataType> void bind_data_type(pybind11::module &m_types, cons
   py_class.def("__eq__", [&](DataType &a, DataType &b) { return a.uid() == b.uid(); });
   py_class.def("__sizeof__", [&](const DataType &target) { return sizeof(target); });
   py_class.def("__parse__", [&](DataType &target, std::string &s) { target.parse(s.c_str(), s.length()); });
+
+  // ADR-0078 Decision 3: expose the raw frame_header struct bytes as a
+  // read-only, zero-copy Python buffer so outer rings (e.g. kungfu.atlas.store)
+  // hand the header straight to the native checksum_frame primitive instead of
+  // re-packing the frame_header layout by hand. Only frame_header opts in; the
+  // buffer is readonly (checksum never writes the header) and callers must keep
+  // its lifetime bound to the synchronous checksum_frame call (a memoryview of a
+  // live header object), never store it across the header's lifetime.
+  if constexpr (std::is_same_v<DataType, kungfu::yijinjing::types::frame_header>) {
+    py_class.def_buffer([](DataType &self) -> py::buffer_info {
+      return py::buffer_info(reinterpret_cast<uint8_t *>(&self), static_cast<py::ssize_t>(sizeof(uint8_t)),
+                             py::format_descriptor<uint8_t>::format(), static_cast<py::ssize_t>(sizeof(DataType)),
+                             /*readonly=*/true);
+    });
+  }
 }
 
 void bind_types(py::module &m) {

--- a/framework/core/src/libkungfu/include/kungfu/view/schema.h
+++ b/framework/core/src/libkungfu/include/kungfu/view/schema.h
@@ -117,7 +117,17 @@ public:
   // returned bytes remain the persisted schema-owned payload.
   [[nodiscard]] table_codec_result encode_json(std::string_view json) const;
 
-  [[nodiscard]] table_codec_result decode_json(const uint8_t *buf, size_t len) const;
+  // ADR-0078 Decision 3: `enum_as_int` renders enum fields as their underlying
+  // integer instead of the schema identifier. The default (false) keeps the
+  // identifier form the domain-runtime decode_json consumers already rely on;
+  // the generic membrane decode primitive (decode_flatbuffer_payload_json) opts
+  // into the integer form so it matches the three reflection decoders
+  // (Python BundleDecoder, TS ReflectionDecoder, the generated accessors).
+  // `object_name` decodes a specific table instead of the .bfbs root_type,
+  // resolved through the same suffix-tolerant lookup as verify_table; empty
+  // means the root table (the existing single-root consumers).
+  [[nodiscard]] table_codec_result decode_json(const uint8_t *buf, size_t len, bool enum_as_int = false,
+                                               std::string_view object_name = {}) const;
 
 private:
   // Co-owned `.bfbs` bytes. shared_ptr<const> so copies share one immutable

--- a/framework/core/src/libkungfu/src/view/schema.cpp
+++ b/framework/core/src/libkungfu/src/view/schema.cpp
@@ -200,19 +200,34 @@ table_codec_result schema_handle::encode_json(std::string_view json) const {
   return result;
 }
 
-table_codec_result schema_handle::decode_json(const uint8_t *buf, size_t len) const {
+table_codec_result schema_handle::decode_json(const uint8_t *buf, size_t len, bool enum_as_int,
+                                              std::string_view object_name) const {
   table_codec_result result;
-  if (!verify_table(buf, len)) {
+  if (!verify_table(buf, len, object_name)) {
     result.error = "kungfu::view: FlatBuffers table failed schema verification";
     return result;
   }
   flatbuffers::IDLOptions options;
   options.strict_json = true;
   options.output_default_scalars_in_json = true;
+  // ADR-0078 Decision 3: the generic membrane decode primitive asks for the
+  // integer enum form so its JSON matches the three reflection decoders; the
+  // domain-runtime consumers keep the default identifier form.
+  options.output_enum_identifiers = !enum_as_int;
   flatbuffers::Parser parser(options);
   if (!parser.Deserialize(schema_of(*bfbs_))) {
     result.error = "kungfu::view: cannot deserialize reflection schema";
     return result;
+  }
+  // ADR-0078 Decision 3: rewind's multi-table schema decodes a specific event
+  // table, not the .bfbs root_type. Point the parser at the named table (resolved
+  // through the same suffix-tolerant lookup as verify_table) before generating.
+  if (!object_name.empty()) {
+    const reflection::Object *object = object_of(schema_of(*bfbs_), object_name);
+    if (object == nullptr || !parser.SetRootType(object->name()->c_str())) {
+      result.error = "kungfu::view: object not found in schema: " + std::string(object_name);
+      return result;
+    }
   }
   if (const auto *error = flatbuffers::GenerateText(parser, buf, &result.json); error != nullptr) {
     result.error = error;

--- a/framework/core/src/python/kungfu/atlas/store.py
+++ b/framework/core/src/python/kungfu/atlas/store.py
@@ -7,7 +7,6 @@
 
 import json
 import os
-import struct
 import uuid
 
 import kungfu
@@ -432,69 +431,23 @@ def _frame_data_type_value(header):
         return 0 if name == "raw" else str(value)
 
 
-def _fnv1a64_update(state, data):
-    for value in bytes(data):
-        state ^= value
-        state = (state * 1099511628211) & 0xFFFFFFFFFFFFFFFF
-    return state
-
-
-def _crc32c_table():
-    table = []
-    for i in range(256):
-        crc = i
-        for _ in range(8):
-            crc = (crc >> 1) ^ (0x82F63B78 if crc & 1 else 0)
-        table.append(crc & 0xFFFFFFFF)
-    return table
-
-
-_CRC32C_TABLE = _crc32c_table()
-
-
-def _crc32c_update(state, data):
-    for value in bytes(data):
-        state = (state >> 8) ^ _CRC32C_TABLE[(state ^ value) & 0xFF]
-    return state & 0xFFFFFFFF
-
-
 def _checksum_payload(data, algorithm=payloads.DEFAULT_FRAME_CHECKSUM_ALGORITHM):
-    if algorithm == payloads.FRAME_CHECKSUM_ALGORITHM_CRC32C:
-        return _crc32c_update(0xFFFFFFFF, data) ^ 0xFFFFFFFF
-    return _fnv1a64_update(14695981039346656037, data)
-
-
-def _pack_scalar(fmt, value):
-    return struct.pack("<" + fmt, value)
+    # ADR-0078 Decision 3: the payload checksum is the generic whole-frame
+    # integrity primitive exposed on the runtime membrane; call it instead of
+    # re-implementing crc32c / fnv1a here.
+    return yjj.checksum_payload(data, algorithm)
 
 
 def _checksum_frame(
     header, data, payload_length, algorithm=payloads.DEFAULT_FRAME_CHECKSUM_ALGORITHM
 ):
-    fields = [
-        ("I", int(getattr(header, "length", 0))),
-        ("I", int(getattr(header, "header_length", 0))),
-        ("q", int(header.gen_time)),
-        ("q", int(header.trigger_time)),
-        ("i", int(header.carrier_type)),
-        ("I", int(header.source)),
-        ("I", int(header.dest)),
-        ("b", int(_frame_data_type_value(header))),
-        ("I", int(header.initial_source)),
-        ("Q", int(header.journal_frame_uid)),
-        ("Q", int(header.trigger_frame_uid)),
-        ("Q", int(header.stream_id)),
-        ("I", int(payload_length)),
-    ]
-    if algorithm == payloads.FRAME_CHECKSUM_ALGORITHM_CRC32C:
-        state = 0xFFFFFFFF
-        for fmt, value in fields:
-            state = _crc32c_update(state, _pack_scalar(fmt, value))
-        return _crc32c_update(state, data[:payload_length]) ^ 0xFFFFFFFF
-    state = 14695981039346656037
-    for fmt, value in fields:
-        state = _fnv1a64_update(state, _pack_scalar(fmt, value))
-    return _fnv1a64_update(state, data[:payload_length])
+    # ADR-0078 Decision 3: hand the raw frame_header bytes (zero-copy read-only
+    # buffer) and the exact payload slice to the native checksum_frame primitive
+    # instead of re-packing the frame_header layout and re-implementing the
+    # checksum here. The primitive derives payload_length from the payload
+    # buffer, so pass exactly payload_length bytes. `memoryview(header)` stays
+    # alive only for this synchronous call.
+    return yjj.checksum_frame(memoryview(header), data[:payload_length], algorithm)
 
 
 def read_action_frame_index(runtime_dir):

--- a/framework/core/src/python/kungfu/rewind/replay.py
+++ b/framework/core/src/python/kungfu/rewind/replay.py
@@ -8,9 +8,12 @@
 #           flatc-generated accessors (what `kungfu rewind show` renders);
 #   bundle  the reader-without-the-writer path: the run manifest's schema
 #           bindings plus the content-addressed .bfbs blob, decoded through
-#           FlatBuffers reflection — no generated event code involved
-#           (reflection_fb.py is generated from reflection.fbs itself, the
-#           schema of schemas, not from the event schema).
+#           FlatBuffers reflection — no generated event code involved. ADR-0078
+#           Decision 3: the reflection decode runs in the native generic
+#           primitive (the ADR-0039 chokepoint, shared by all three runtimes)
+#           rather than a hand-rolled Python reflection walk; reflection_fb (the
+#           schema of schemas, generated from reflection.fbs) is used only to
+#           enumerate schema fields for the absent-string None contract.
 #
 # `verify` diffs the two paths fact by fact. Identical output means the trace
 # bundle really is decodable without the runtime that wrote it; any drift —
@@ -26,9 +29,6 @@ import os
 import re
 from typing import Any
 
-import flatbuffers
-import flatbuffers.encode
-import flatbuffers.number_types as N
 import kungfu
 
 from kungfu.action_envelope import CARRIER_ACTION_ENVELOPE
@@ -143,64 +143,30 @@ class BundleDecoder:
             self._schema_bytes[action_type], payload, self._objects[action_type]
         ):
             raise ValueError(f"invalid FlatBuffers payload for {action_type}")
+        # ADR-0078 Decision 3: decode through the native generic reflection
+        # primitive (the ADR-0039 chokepoint) instead of re-walking the .bfbs
+        # reflection schema in Python. output_default_scalars + enum_as_int make
+        # its JSON match the generated-accessor facts. The one gap is that
+        # FlatBuffers omits absent (non-default) strings, so fill those with None
+        # to preserve the decode contract the forensic diff checks against.
+        facts: dict[str, Any] = json.loads(
+            yjj.decode_flatbuffer_payload_json(
+                self._schema_bytes[action_type],
+                payload,
+                self._objects[action_type],
+            )
+        )
         schema = self._schemas[action_type]
         obj = self._find_object(schema, self._objects[action_type])
-        n = flatbuffers.encode.Get(flatbuffers.packer.uoffset, payload, 0)
-        table = flatbuffers.table.Table(payload, n)
-        facts = {}
         for i in range(obj.FieldsLength()):
             field = obj.Fields(i)
             name = field.Name().decode()
-            base_type = field.Type().BaseType()
-            offset = field.Offset()
-            facts[name] = self._read_field(table, base_type, offset, field)
+            if (
+                name not in facts
+                and field.Type().BaseType() == reflection_fb.BaseType.String
+            ):
+                facts[name] = None
         return facts
-
-    @staticmethod
-    def _read_field(table: Any, base_type: Any, offset: int, field: Any) -> Any:
-        B = reflection_fb.BaseType
-        o = table.Offset(offset)
-        if base_type == B.String:
-            return table.String(o + table.Pos).decode() if o else None
-        # (flags, python-cast, element-width) for every reflection scalar —
-        # the full set so an arbitrary kfx schema decodes, not just the subset
-        # the Rewind capture events happen to use.
-        scalars = {
-            B.Bool: (N.BoolFlags, bool, 1),
-            B.Byte: (N.Int8Flags, int, 1),
-            B.UByte: (N.Uint8Flags, int, 1),
-            B.Short: (N.Int16Flags, int, 2),
-            B.UShort: (N.Uint16Flags, int, 2),
-            B.Int: (N.Int32Flags, int, 4),
-            B.UInt: (N.Uint32Flags, int, 4),
-            B.Long: (N.Int64Flags, int, 8),
-            B.ULong: (N.Uint64Flags, int, 8),
-            B.Float: (N.Float32Flags, float, 4),
-            B.Double: (N.Float64Flags, float, 8),
-        }
-        if base_type in scalars:
-            flags, cast, _ = scalars[base_type]
-            if not o:
-                default = (
-                    field.DefaultReal() if cast is float else field.DefaultInteger()
-                )
-                return cast(default)
-            return cast(table.Get(flags, o + table.Pos))
-        if base_type == B.Vector:
-            if not o:
-                return []
-            elem = field.Type().Element()
-            start = table.Vector(o)
-            length = table.VectorLen(o)
-            if elem == B.String:
-                return [table.String(start + i * 4).decode() for i in range(length)]
-            if elem in scalars:
-                flags, cast, width = scalars[elem]
-                return [
-                    cast(table.Get(flags, start + i * width)) for i in range(length)
-                ]
-            raise ValueError(f"unsupported vector element type {elem}")
-        raise ValueError(f"unsupported base type {base_type}")
 
 
 def verify(runtime_dir: str, run_id: str, bundle_dir: str) -> tuple[int, list[str]]:

--- a/framework/core/tests/python/test_generic_primitive_dedup.py
+++ b/framework/core/tests/python/test_generic_primitive_dedup.py
@@ -1,0 +1,225 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# ADR-0078 Decision 3 equivalence net. The outer rings (kungfu.atlas.store
+# checksums, kungfu.rewind.replay bundle decode) now call the generic C++
+# primitives instead of re-implementing them. These tests pin the migration:
+# the native-backed paths must reproduce, byte for byte and field for field,
+# what the removed hand-rolled Python produced.
+
+from __future__ import annotations
+
+import struct
+
+import pytest
+
+import kungfu
+from kungfu.atlas import payloads
+from kungfu.atlas import store as atlas_store
+from kungfu.rewind import ACTION_TYPE_NAMES
+from kungfu.rewind import replay as rewind_replay
+from kungfu.rewind import reporting as rewind_reporting
+
+yjj = kungfu.__binding__.runtime
+
+
+# --- Reference (pre-ADR-0078) hand-rolled checksum, kept only for this net. ---
+
+
+def _ref_fnv1a64_update(state, data):
+    for value in bytes(data):
+        state ^= value
+        state = (state * 1099511628211) & 0xFFFFFFFFFFFFFFFF
+    return state
+
+
+def _ref_crc32c_table():
+    table = []
+    for i in range(256):
+        crc = i
+        for _ in range(8):
+            crc = (crc >> 1) ^ (0x82F63B78 if crc & 1 else 0)
+        table.append(crc & 0xFFFFFFFF)
+    return table
+
+
+_REF_CRC32C_TABLE = _ref_crc32c_table()
+
+
+def _ref_crc32c_update(state, data):
+    for value in bytes(data):
+        state = (state >> 8) ^ _REF_CRC32C_TABLE[(state ^ value) & 0xFF]
+    return state & 0xFFFFFFFF
+
+
+def _ref_checksum_payload(data, algorithm):
+    if algorithm == payloads.FRAME_CHECKSUM_ALGORITHM_CRC32C:
+        return _ref_crc32c_update(0xFFFFFFFF, data) ^ 0xFFFFFFFF
+    return _ref_fnv1a64_update(14695981039346656037, data)
+
+
+def _ref_pack_scalar(fmt, value):
+    return struct.pack("<" + fmt, value)
+
+
+def _ref_frame_data_type_value(header):
+    value = getattr(header, "data_type", 0)
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        name = str(value).split(".")[-1].lower()
+        return 0 if name == "raw" else str(value)
+
+
+def _ref_checksum_frame(header, data, payload_length, algorithm):
+    fields = [
+        ("I", int(getattr(header, "length", 0))),
+        ("I", int(getattr(header, "header_length", 0))),
+        ("q", int(header.gen_time)),
+        ("q", int(header.trigger_time)),
+        ("i", int(header.carrier_type)),
+        ("I", int(header.source)),
+        ("I", int(header.dest)),
+        ("b", int(_ref_frame_data_type_value(header))),
+        ("I", int(header.initial_source)),
+        ("Q", int(header.journal_frame_uid)),
+        ("Q", int(header.trigger_frame_uid)),
+        ("Q", int(header.stream_id)),
+        ("I", int(payload_length)),
+    ]
+    if algorithm == payloads.FRAME_CHECKSUM_ALGORITHM_CRC32C:
+        state = 0xFFFFFFFF
+        for fmt, value in fields:
+            state = _ref_crc32c_update(state, _ref_pack_scalar(fmt, value))
+        return _ref_crc32c_update(state, data[:payload_length]) ^ 0xFFFFFFFF
+    state = 14695981039346656037
+    for fmt, value in fields:
+        state = _ref_fnv1a64_update(state, _ref_pack_scalar(fmt, value))
+    return _ref_fnv1a64_update(state, data[:payload_length])
+
+
+# --- Fixtures. ---
+
+
+@pytest.fixture
+def captured_run(tmp_path):
+    """A rewind run spanning every enum and both present/absent string fields."""
+    runtime_dir = str(tmp_path / "runtime")
+    run_id = "dedup-equivalence"
+    rewind_reporting.begin_run(
+        runtime_dir,
+        run_id=run_id,
+        provider="anthropic",
+        cwd="/tmp/work",
+        work_id="w-1",
+    )
+    # CostSnapshot: CaptureLayer + Attribution enums, a float, present strings
+    # (provider/surface/source/model/session_id) and absent ones (raw_ref).
+    rewind_reporting.report_cost(
+        runtime_dir,
+        run_id=run_id,
+        provider="anthropic",
+        surface="cli",
+        source="adapter",
+        attribution="exact_run",
+        model="claude-opus-4-8",
+        session_id="s-1",
+        input_tokens=100,
+        output_tokens=42,
+        cost_usd=0.25,
+    )
+    # ApprovalDecision: Decision enum, present decided_by/detail and absent
+    # request_id/surface/reason.
+    rewind_reporting.report_approval(
+        runtime_dir,
+        run_id=run_id,
+        decision="approve",
+        decided_by="keren",
+        detail="looks good",
+    )
+    rewind_reporting.end_run(
+        runtime_dir, run_id=run_id, status="succeeded", exit_code=0
+    )
+    return runtime_dir, run_id, rewind_reporting.bundle_dir(runtime_dir, run_id)
+
+
+# --- atlas checksum de-dup: native path reproduces the reference values. ---
+
+
+@pytest.mark.parametrize(
+    "algorithm",
+    [
+        payloads.FRAME_CHECKSUM_ALGORITHM_CRC32C,
+        payloads.FRAME_CHECKSUM_ALGORITHM_FNV1A64,
+    ],
+)
+def test_atlas_checksum_matches_reference(captured_run, algorithm):
+    runtime_dir, run_id, _ = captured_run
+    frames = rewind_replay.read_frames(runtime_dir, run_id)
+    assert frames, "expected recorded frames to checksum against"
+
+    payloads_seen = [b"", b"\x00", b"payload-bytes-\xff\x01\x02", bytes(range(64))]
+    checked = 0
+    for _action_type, header, _event_payload in frames:
+        for data in payloads_seen:
+            # payload_length may be shorter than the buffer, exactly as the
+            # atlas store slices it before checksumming.
+            for payload_length in {0, len(data), max(0, len(data) - 3)}:
+                assert atlas_store._checksum_payload(
+                    data[:payload_length], algorithm
+                ) == _ref_checksum_payload(data[:payload_length], algorithm)
+                assert atlas_store._checksum_frame(
+                    header, data, payload_length, algorithm
+                ) == _ref_checksum_frame(header, data, payload_length, algorithm)
+                checked += 1
+    assert checked > 0
+
+
+def test_atlas_checksum_frame_uses_readonly_header_buffer(captured_run):
+    """The frame_header buffer is exposed read-only (checksum never writes it)."""
+    runtime_dir, run_id, _ = captured_run
+    _action_type, header, _payload = rewind_replay.read_frames(runtime_dir, run_id)[0]
+    view = memoryview(header)
+    assert view.readonly is True
+    assert len(view) == header.__sizeof__()
+    with pytest.raises((TypeError, ValueError)):
+        view[0] = 0
+
+
+# --- rewind decode de-dup: native bundle decode matches the generated oracle. ---
+
+
+def test_rewind_bundle_decode_matches_generated(captured_run):
+    runtime_dir, run_id, bundle_dir = captured_run
+    count, differences = rewind_replay.verify(runtime_dir, run_id, bundle_dir)
+    assert count == 4
+    assert differences == []
+
+
+def test_rewind_bundle_decode_field_by_field(captured_run):
+    runtime_dir, run_id, bundle_dir = captured_run
+    decoder = rewind_replay.BundleDecoder(bundle_dir)
+    frames = rewind_replay.read_frames(runtime_dir, run_id)
+
+    saw_enum_int = False
+    saw_absent_none = False
+    for action_type, _header, payload in frames:
+        native = rewind_replay.decode_native(action_type, payload)
+        bundle = decoder.decode(action_type, payload)
+        # Field-by-field equivalence against the generated-accessor oracle,
+        # i.e. the exact contract the removed Python reflection produced.
+        assert bundle == native, action_type
+        name = ACTION_TYPE_NAMES[action_type]
+        if name == "RunEnd":
+            # enum rendered as its underlying int, never the identifier string.
+            assert bundle["status"] == 1
+            assert isinstance(bundle["status"], int)
+            saw_enum_int = True
+        if name == "ApprovalDecision":
+            assert bundle["decision"] == 0  # Approve
+            assert isinstance(bundle["decision"], int)
+            saw_enum_int = True
+            # request_id was not supplied -> absent string decodes to None.
+            assert bundle["request_id"] is None
+            saw_absent_none = True
+    assert saw_enum_int
+    assert saw_absent_none


### PR DESCRIPTION
## Summary

ADR-0078 Decision 3 (outer-ring de-duplication): `rewind` `BundleDecoder` decodes
through the exposed `decode_flatbuffer_payload_json` primitive and `atlas` store
checksums call `checksum_frame` / `checksum_payload`, instead of re-implementing
FlatBuffers reflection, crc32c/fnv1a, and the `frame_header` layout in Python.
Domain folds stay in the outer rings.

- `frame_header` opts into a read-only zero-copy Python buffer protocol.
- `decode_json` gains `enum_as_int` (integer enums matching the three reflection
  decoders) and `object_name` (decode a specific table, not just the root).
- `implementation_status` stays `partial`: the cross-membrane enum-int symmetry
  (C-ABI / Rust `decode_frame_json`) is a recorded follow-up.

## Validation (three hosts, local — no CI reliance for heavy build)

- Mac (arm64) + agent-120 (Linux x86_64) + DARKHERO (Windows x86_64): full build +
  14 equivalence tests each, all green.
- old-vs-native checksum parity (crc32c + fnv1a64); rewind field-by-field parity
  vs the generated-accessor oracle; enum-as-int + absent-string-None contract.
- Mac full python suite: 331 passed; the 11 failures are verified pre-existing on
  base (dev/v4/v4.0), i.e. zero regression from this change.

<!-- kungfu-adr-release:v1
{"schema":"kungfu.adr-release-pr/v1","kind":"dev-delivery","intent":"stage-ready","adrs":["ADR-0078"],"summary":"ADR-0078 Decision 3: rewind decode and atlas checksum de-duplicate onto the exposed generic primitives; domain folds stay in the outer rings.","verification":["Mac arm64 + agent-120 Linux x86_64 + DARKHERO Windows x86_64: full build + 14 equivalence tests each","old-vs-native checksum parity (crc32c + fnv1a64); rewind field-by-field parity vs generated-accessor oracle; enum-as-int + absent-string-None contract","Mac full python suite 331 passed; 11 failures verified pre-existing on base (zero regression)"]}
-->