### PR TITLE
feat(gui): present workspace runtime as one foreground state

### DIFF
--- a/docs/adr/ADR-0077-agent-coordination-on-live-runtime.md
+++ b/docs/adr/ADR-0077-agent-coordination-on-live-runtime.md
@@ -4,7 +4,7 @@ doc_type: architecture-decision
 adr_id: ADR-0077
 decision_status: accepted
 implementation_status: partial
-implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/771]
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/771, https://github.com/kungfu-systems/kungfu/pull/804]
 review_state: maintainer-reviewed
 sensitivity: public
 sources: [local-files, user-decision]
@@ -100,6 +100,12 @@ Build agent coordination as a live-runtime consumer on the existing substrate,
   page instead of failing the read-only open. Both are validated on a local core
   build (nine native journal / durability / crash-recovery tests plus a
   three-process live peer round-trip); they carry no in-tree consumer yet.
+- **Foreground product projection (this increment).** Desktop tray and status
+  bar present one workspace-level runtime state instead of exposing supervisor
+  and coordinator processes as separate user concerns. Process health proves
+  only `Workspace online`; the stronger `Workspace ready`, `reconnecting`, and
+  recovery states require explicit continuity evidence. Raw process diagnostics
+  remain available in the advanced System Status view.
 - **Deferred to a follow-up.** The arbiter peer itself — the in-memory lock
   table that consumes the react hook, replacing the waiter's short poll with a
   grant frame awaited over the live stream — and the instruct-injection path.

--- a/framework/gui/src/main/index.ts
+++ b/framework/gui/src/main/index.ts
@@ -20,6 +20,11 @@ import {
 import { DEVELOPER_NAVIGATION, TOOLS_NAVIGATION } from '../navigation';
 
 import {
+  type RuntimeStatusPayload,
+  type RuntimeStatusResult,
+  deriveWorkspaceRuntimePresentation,
+} from '../runtime-status';
+import {
   AGENT_RUNTIME_CLI_EXEC_CHANNEL,
   ATLAS_CLI_EXEC_CHANNEL,
   DESTROY_CHANNEL,
@@ -389,39 +394,6 @@ process.env.PATH = [kungfuBinDir, process.env.PATH || '']
   .filter(Boolean)
   .join(path.delimiter);
 
-type RuntimeStatusPayload = {
-  status?: string;
-  configHome?: string;
-  dataRoot?: string;
-  runtimeDir?: string;
-  lifecycle?: {
-    state?: string;
-    healthy?: boolean;
-    warnings?: string[];
-  };
-  supervisor?: { pid?: number | null; running?: boolean };
-  coordinator?: { pid?: number | null; running?: boolean };
-  route?: { routeId?: string; registered?: boolean; stale?: boolean };
-  routes?: { count?: number; staleCount?: number };
-  assessments?: {
-    assessment_count?: number;
-    counts?: Record<string, number>;
-    assessments?: Array<{
-      state?: string;
-      assessment_key?: string;
-      request?: { claim_id?: string; purpose?: string };
-      report?: { residual_risks?: string[]; query_proof_root?: string };
-    }>;
-  };
-};
-
-type RuntimeStatusResult = {
-  ok: boolean;
-  payload: RuntimeStatusPayload | null;
-  error: string;
-  updatedAt: number;
-};
-
 function readRuntimeStatus(): RuntimeStatusResult {
   if (!workspaceRuntimeReady) {
     return {
@@ -495,18 +467,7 @@ function ensureRuntimeForGuiStartup() {
 }
 
 function runtimeStatusLabel(result = lastRuntimeStatus ?? readRuntimeStatus()) {
-  if (!result.ok || !result.payload) return 'Runtime: unavailable';
-  const lifecycle = result.payload.lifecycle?.state || result.payload.status;
-  if (lifecycle === 'stale-route') return 'Runtime: stale route';
-  if (lifecycle === 'degraded') return 'Runtime: degraded';
-  if (lifecycle === 'dead') return 'Runtime: dead pid';
-  if (lifecycle === 'orphan-coordinator') return 'Runtime: orphan';
-  const supervisor = result.payload.supervisor?.running;
-  const runtime = result.payload.coordinator?.running;
-  if (supervisor && runtime) return 'Runtime: running';
-  if (supervisor) return 'Runtime: waiting';
-  if (runtime) return 'Runtime: orphan';
-  return 'Runtime: stopped';
+  return deriveWorkspaceRuntimePresentation(result).label;
 }
 
 function showShellWindow() {
@@ -602,13 +563,7 @@ function buildTrayMenu() {
   const visible =
     shellWindow && !shellWindow.isDestroyed() ? shellWindow.isVisible() : false;
   const status = readRuntimeStatus();
-  const payload = status.payload;
-  const statusDetail =
-    status.ok && payload
-      ? `Lifecycle: ${payload.lifecycle?.state || payload.status || '-'} · Data root: ${
-          payload.dataRoot || '-'
-        }`
-      : status.error || 'Status unavailable';
+  const workspaceStatus = deriveWorkspaceRuntimePresentation(status);
   tray.setContextMenu(
     Menu.buildFromTemplate([
       {
@@ -616,7 +571,7 @@ function buildTrayMenu() {
         enabled: false,
       },
       {
-        label: statusDetail,
+        label: workspaceStatus.detail,
         enabled: false,
       },
       { type: 'separator' },

--- a/framework/gui/src/renderer/src/main.tsx
+++ b/framework/gui/src/renderer/src/main.tsx
@@ -36,6 +36,10 @@ import {
   profileHomeId,
 } from '../../navigation';
 import {
+  type RuntimeStatusResult,
+  deriveWorkspaceRuntimePresentation,
+} from '../../runtime-status';
+import {
   RUNTIME_STATUS_GET_CHANNEL,
   SESSION_WINDOW_OPEN_CHANNEL,
   SESSION_WINDOW_RESTORE_CHANNEL,
@@ -220,85 +224,6 @@ function statusColor(severity: StatusBarSeverity | undefined): string {
   if (severity === 'warning') return '#dcdcaa';
   if (severity === 'error') return '#f48771';
   return '#cccccc';
-}
-
-type RuntimeStatusPayload = {
-  status?: string;
-  configHome?: string;
-  dataRoot?: string;
-  runtimeDir?: string;
-  lifecycle?: {
-    state?: string;
-    healthy?: boolean;
-    warnings?: string[];
-  };
-  supervisor?: { pid?: number | null; running?: boolean };
-  coordinator?: { pid?: number | null; running?: boolean };
-  route?: { routeId?: string; registered?: boolean; stale?: boolean };
-  routes?: { count?: number; staleCount?: number };
-  assessments?: {
-    assessment_count?: number;
-    counts?: Record<string, number>;
-    assessments?: Array<{
-      state?: string;
-      assessment_key?: string;
-      request?: { claim_id?: string; purpose?: string };
-      report?: { residual_risks?: string[]; query_proof_root?: string };
-    }>;
-  };
-};
-
-type RuntimeStatusResult = {
-  ok: boolean;
-  payload: RuntimeStatusPayload | null;
-  error: string;
-  updatedAt: number;
-};
-
-function runtimeStatusText(status: RuntimeStatusResult | null): string {
-  if (!status) return 'runtime checking';
-  if (!status.ok || !status.payload) return 'runtime unavailable';
-  const lifecycle = status.payload.lifecycle?.state || status.payload.status;
-  if (lifecycle === 'stale-route') return 'runtime stale route';
-  if (lifecycle === 'degraded') return 'runtime degraded';
-  if (lifecycle === 'dead') return 'runtime dead pid';
-  if (lifecycle === 'orphan-coordinator') return 'runtime orphan';
-  const supervisor = status.payload.supervisor?.running;
-  const runtime = status.payload.coordinator?.running;
-  if (supervisor && runtime) return 'runtime live';
-  if (supervisor) return 'runtime starting';
-  if (runtime) return 'runtime orphan';
-  return 'runtime offline';
-}
-
-function supervisorStatusText(status: RuntimeStatusResult | null): string {
-  if (!status) return 'supervisor checking';
-  if (!status.ok || !status.payload) return 'supervisor unavailable';
-  const lifecycle = status.payload.lifecycle?.state || status.payload.status;
-  if (lifecycle === 'dead') return 'supervisor dead pid';
-  if (lifecycle === 'stale-route') return 'supervisor stale route';
-  return status.payload.supervisor?.running
-    ? 'supervisor live'
-    : 'supervisor stopped';
-}
-
-function statusTooltip(status: RuntimeStatusResult | null): string {
-  if (!status) return 'Supervisor/runtime status is being checked';
-  if (!status.ok || !status.payload)
-    return status.error || 'Status unavailable';
-  const payload = status.payload;
-  return [
-    `Status: ${payload.status || '-'}`,
-    `Lifecycle: ${payload.lifecycle?.state || '-'}`,
-    `Warnings: ${payload.lifecycle?.warnings?.join(', ') || '-'}`,
-    `Config: ${payload.configHome || '-'}`,
-    `Data root: ${payload.dataRoot || '-'}`,
-    `Runtime: ${payload.runtimeDir || '-'}`,
-    `Route: ${payload.route?.routeId || '-'}${
-      payload.route?.registered ? ' registered' : ' not registered'
-    }${payload.route?.stale ? ' stale' : ''}`,
-    `Stale routes: ${String(payload.routes?.staleCount ?? 0)}`,
-  ].join('\n');
 }
 
 function trustStatusText(status: RuntimeStatusResult | null): string {
@@ -1342,23 +1267,7 @@ function App() {
     setCommandText('');
   }, [commandText, enabled, openKfx, showNotification]);
 
-  const supervisorRunning =
-    runtimeStatus?.payload?.supervisor?.running === true;
-  const coordinatorRunning =
-    runtimeStatus?.payload?.coordinator?.running === true;
-  const lifecycleState =
-    runtimeStatus?.payload?.lifecycle?.state || runtimeStatus?.payload?.status;
-  const lifecycleHealthy = runtimeStatus?.payload?.lifecycle?.healthy === true;
-  const lifecycleDegraded =
-    lifecycleState === 'stale-route' ||
-    lifecycleState === 'degraded' ||
-    lifecycleState === 'dead' ||
-    lifecycleState === 'orphan-coordinator';
-  const runtimeSeverity: StatusBarSeverity = lifecycleHealthy
-    ? 'ok'
-    : lifecycleDegraded || supervisorRunning
-      ? 'warning'
-      : 'error';
+  const workspaceRuntime = deriveWorkspaceRuntimePresentation(runtimeStatus);
   const trustCounts = runtimeStatus?.payload?.assessments?.counts ?? {};
   const trustBlocked =
     (trustCounts.stale ?? 0) +
@@ -1369,28 +1278,13 @@ function App() {
   const trustPending = (trustCounts.pending ?? 0) + (trustCounts.running ?? 0);
   const systemStatusItems: StatusBarItem[] = [
     {
-      id: 'system.supervisor',
-      text: supervisorStatusText(runtimeStatus),
-      icon: supervisorRunning ? '●' : '○',
-      severity:
-        lifecycleState === 'dead'
-          ? 'error'
-          : supervisorRunning
-            ? 'ok'
-            : 'warning',
-      side: 'left',
-      priority: -110,
-      tooltip: statusTooltip(runtimeStatus),
-      command: { kind: 'open-kfx', kfxId: 'system-status' },
-    },
-    {
-      id: 'system.coordinator',
-      text: runtimeStatusText(runtimeStatus),
-      icon: coordinatorRunning ? '●' : '○',
-      severity: runtimeSeverity,
+      id: 'system.workspace-runtime',
+      text: workspaceRuntime.label,
+      icon: workspaceRuntime.icon,
+      severity: workspaceRuntime.severity,
       side: 'left',
       priority: -100,
-      tooltip: statusTooltip(runtimeStatus),
+      tooltip: workspaceRuntime.detail,
       command: { kind: 'open-kfx', kfxId: 'system-status' },
     },
     {

--- a/framework/gui/src/runtime-status.test.ts
+++ b/framework/gui/src/runtime-status.test.ts
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import {
+  type RuntimeStatusResult,
+  deriveWorkspaceRuntimePresentation,
+} from './runtime-status';
+
+function status(payload: RuntimeStatusResult['payload']): RuntimeStatusResult {
+  return { ok: true, payload, error: '', updatedAt: 1 };
+}
+
+test('process health alone reports online rather than continuity-ready', () => {
+  const result = deriveWorkspaceRuntimePresentation(
+    status({
+      lifecycle: { state: 'running', healthy: true },
+      supervisor: { running: true },
+      coordinator: { running: true },
+    }),
+  );
+  assert.equal(result.state, 'online');
+  assert.equal(result.label, 'Workspace online');
+  assert.match(result.detail, /continuity is not yet reported/);
+});
+
+test('current continuity evidence upgrades an online runtime to ready', () => {
+  const result = deriveWorkspaceRuntimePresentation(
+    status({
+      lifecycle: { state: 'running', healthy: true },
+      continuity: { state: 'ready' },
+      supervisor: { running: true },
+      coordinator: { running: true },
+    }),
+  );
+  assert.equal(result.state, 'ready');
+  assert.equal(result.severity, 'ok');
+});
+
+test('surviving sessions can render reconnecting while processes are live', () => {
+  const result = deriveWorkspaceRuntimePresentation(
+    status({
+      lifecycle: { state: 'running', healthy: true },
+      continuity: {
+        state: 'reconnecting',
+        reason: '2 agents are joining the current generation.',
+      },
+      supervisor: { running: true },
+      coordinator: { running: true },
+    }),
+  );
+  assert.equal(result.state, 'reconnecting');
+  assert.equal(result.detail, '2 agents are joining the current generation.');
+});
+
+test('a supervised coordinator outage renders starting', () => {
+  const result = deriveWorkspaceRuntimePresentation(
+    status({
+      lifecycle: { state: 'degraded', healthy: false },
+      supervisor: { running: true },
+      coordinator: { running: false },
+    }),
+  );
+  assert.equal(result.state, 'starting');
+});
+
+test('authority failures cannot be overridden by stale ready evidence', () => {
+  const result = deriveWorkspaceRuntimePresentation(
+    status({
+      lifecycle: { state: 'orphan-coordinator', healthy: false },
+      continuity: { state: 'ready' },
+      supervisor: { running: false },
+      coordinator: { running: true },
+    }),
+  );
+  assert.equal(result.state, 'needs-attention');
+  assert.equal(result.severity, 'error');
+});
+
+test('stopped processes render one workspace-level offline state', () => {
+  const result = deriveWorkspaceRuntimePresentation(
+    status({
+      lifecycle: { state: 'stopped', healthy: false },
+      supervisor: { running: false },
+      coordinator: { running: false },
+    }),
+  );
+  assert.equal(result.state, 'offline');
+  assert.equal(result.label, 'Workspace offline');
+});
+
+test('status transport failure is visible without exposing process vocabulary', () => {
+  const result = deriveWorkspaceRuntimePresentation({
+    ok: false,
+    payload: null,
+    error: 'status timed out',
+    updatedAt: 1,
+  });
+  assert.equal(result.state, 'needs-attention');
+  assert.equal(result.label, 'Workspace unavailable');
+  assert.equal(result.detail, 'status timed out');
+});

--- a/framework/gui/src/runtime-status.ts
+++ b/framework/gui/src/runtime-status.ts
@@ -1,0 +1,228 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// The ordinary GUI describes one workspace runtime, not its implementation
+// processes. Raw supervisor/coordinator facts remain available to the advanced
+// Status view, while the tray and status bar consume this foreground model.
+
+export type WorkspaceRuntimeState =
+  | 'checking'
+  | 'online'
+  | 'ready'
+  | 'starting'
+  | 'reconnecting'
+  | 'recovering'
+  | 'degraded'
+  | 'needs-attention'
+  | 'offline';
+
+export type WorkspaceRuntimeContinuityState =
+  | 'ready'
+  | 'reconnecting'
+  | 'recovering'
+  | 'degraded'
+  | 'needs-attention';
+
+export type RuntimeStatusPayload = {
+  status?: string;
+  configHome?: string;
+  dataRoot?: string;
+  runtimeDir?: string;
+  lifecycle?: {
+    state?: string;
+    healthy?: boolean;
+    warnings?: string[];
+  };
+  // Optional forward-compatible foreground contract. Until Core reports this,
+  // process health proves only `online`, never peer/session continuity.
+  continuity?: {
+    state?: WorkspaceRuntimeContinuityState;
+    reason?: string;
+  };
+  supervisor?: { pid?: number | null; running?: boolean };
+  coordinator?: { pid?: number | null; running?: boolean };
+  route?: {
+    routeId?: string;
+    registered?: boolean;
+    stale?: boolean;
+    freshness?: { ageSeconds?: number | null; ttlSeconds?: number };
+  };
+  routes?: { count?: number; staleCount?: number };
+  assessments?: {
+    assessment_count?: number;
+    counts?: Record<string, number>;
+    assessments?: Array<{
+      state?: string;
+      assessment_key?: string;
+      request?: { claim_id?: string; purpose?: string };
+      report?: { residual_risks?: string[]; query_proof_root?: string };
+    }>;
+  };
+};
+
+export type RuntimeStatusResult = {
+  ok: boolean;
+  payload: RuntimeStatusPayload | null;
+  error: string;
+  updatedAt: number;
+};
+
+export type WorkspaceRuntimePresentation = {
+  state: WorkspaceRuntimeState;
+  label: string;
+  detail: string;
+  icon: '●' | '○' | '◐' | '!';
+  severity: 'info' | 'ok' | 'warning' | 'error';
+};
+
+const NEEDS_ATTENTION_LIFECYCLES = new Set([
+  'dead',
+  'orphan-coordinator',
+  'stale-route',
+]);
+
+function presentation(
+  state: WorkspaceRuntimeState,
+  label: string,
+  detail: string,
+  icon: WorkspaceRuntimePresentation['icon'],
+  severity: WorkspaceRuntimePresentation['severity'],
+): WorkspaceRuntimePresentation {
+  return { state, label, detail, icon, severity };
+}
+
+export function deriveWorkspaceRuntimePresentation(
+  result: RuntimeStatusResult | null,
+): WorkspaceRuntimePresentation {
+  if (!result) {
+    return presentation(
+      'checking',
+      'Workspace checking',
+      'Workspace readiness is being checked.',
+      '◐',
+      'info',
+    );
+  }
+  if (!result.ok || !result.payload) {
+    return presentation(
+      'needs-attention',
+      'Workspace unavailable',
+      result.error || 'Workspace status is unavailable.',
+      '!',
+      'error',
+    );
+  }
+
+  const payload = result.payload;
+  const lifecycle = payload.lifecycle?.state || payload.status || '';
+  const warnings = payload.lifecycle?.warnings?.filter(Boolean) ?? [];
+  const warningDetail = warnings.length ? ` ${warnings.join(', ')}.` : '';
+  const supervisorRunning = payload.supervisor?.running === true;
+  const coordinatorRunning = payload.coordinator?.running === true;
+
+  // Process/lifecycle failure always wins over a continuity claim. A stale
+  // foreground projection must never turn a dead authority green.
+  if (NEEDS_ATTENTION_LIFECYCLES.has(lifecycle)) {
+    return presentation(
+      'needs-attention',
+      'Workspace needs attention',
+      `Automatic runtime recovery is not healthy.${warningDetail}`,
+      '!',
+      'error',
+    );
+  }
+  if (coordinatorRunning && !supervisorRunning) {
+    return presentation(
+      'needs-attention',
+      'Workspace needs attention',
+      'The workspace runtime has lost its automatic recovery owner.',
+      '!',
+      'error',
+    );
+  }
+  if (!supervisorRunning && !coordinatorRunning) {
+    return presentation(
+      'offline',
+      'Workspace offline',
+      'The workspace runtime is stopped.',
+      '○',
+      'warning',
+    );
+  }
+  if (supervisorRunning && !coordinatorRunning) {
+    return presentation(
+      'starting',
+      'Workspace starting',
+      'The workspace runtime is starting or being restarted.',
+      '◐',
+      'warning',
+    );
+  }
+
+  const continuity = payload.continuity;
+  if (continuity?.state === 'needs-attention') {
+    return presentation(
+      'needs-attention',
+      'Workspace needs attention',
+      continuity.reason || 'Automatic workspace recovery needs attention.',
+      '!',
+      'error',
+    );
+  }
+  if (continuity?.state === 'degraded' || lifecycle === 'degraded') {
+    return presentation(
+      'degraded',
+      'Workspace degraded',
+      continuity?.reason ||
+        `The workspace is available with reduced capabilities.${warningDetail}`,
+      '!',
+      'warning',
+    );
+  }
+  if (continuity?.state === 'reconnecting') {
+    return presentation(
+      'reconnecting',
+      'Workspace reconnecting',
+      continuity.reason ||
+        'Running agents are reconnecting to the current workspace runtime.',
+      '◐',
+      'warning',
+    );
+  }
+  if (continuity?.state === 'recovering') {
+    return presentation(
+      'recovering',
+      'Workspace recovering',
+      continuity.reason || 'Workspace state is recovering and catching up.',
+      '◐',
+      'warning',
+    );
+  }
+  if (continuity?.state === 'ready' && payload.lifecycle?.healthy === true) {
+    return presentation(
+      'ready',
+      'Workspace ready',
+      continuity.reason ||
+        'The workspace runtime and live sessions are current.',
+      '●',
+      'ok',
+    );
+  }
+
+  if (payload.lifecycle?.healthy === false) {
+    return presentation(
+      'recovering',
+      'Workspace recovering',
+      `The workspace runtime is online but has not reported healthy.${warningDetail}`,
+      '◐',
+      'warning',
+    );
+  }
+
+  return presentation(
+    'online',
+    'Workspace online',
+    'The workspace runtime is online; live-session continuity is not yet reported.',
+    '●',
+    'info',
+  );
+}

--- a/scripts/run-kfx-profile-suite-tests.mjs
+++ b/scripts/run-kfx-profile-suite-tests.mjs
@@ -38,6 +38,15 @@ run('GUI Profile navigation projection', 'pnpm', [
   path.join(root, 'framework/gui/src/navigation.test.ts'),
 ]);
 
+run('GUI workspace runtime foreground projection', 'pnpm', [
+  '--filter',
+  '@kungfu-tech/tui',
+  'exec',
+  'tsx',
+  '--test',
+  path.join(root, 'framework/gui/src/runtime-status.test.ts'),
+]);
+
 const pythonPath = [
   path.join(root, 'framework/core/src/python'),
   process.env.PYTHONPATH,


### PR DESCRIPTION
## Summary

Present the ordinary desktop runtime as one workspace-level foreground state instead of exposing supervisor and coordinator processes as separate user concerns.

Process health alone now reports Workspace online. The GUI reports Workspace ready only when explicit continuity evidence is available, preventing process presence from being mistaken for recovered live sessions.

## Related issue

ADR-0077

## Changes

- add one shared workspace runtime presentation model for Electron main and renderer
- collapse the tray and status bar process indicators into one Workspace status
- retain raw supervisor and coordinator diagnostics in the advanced System Status view
- accept an optional continuity state for ready, reconnecting, recovering, degraded, and needs-attention projections
- add seven regression cases and include them in the KFX Profile Suite

## Verification

- ./shifu check:source
- ./shifu check
- ./shifu test:kfx-profile-suite
- ./shifu build:app

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "stage-ready",
  "adrs": ["ADR-0077"],
  "summary": "Project live-runtime and future agent continuity evidence into one workspace foreground status without exposing process topology in the ordinary GUI",
  "verification": ["./shifu check:source", "./shifu check", "./shifu test:kfx-profile-suite", "./shifu build:app"]
}
-->

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] release evidence, provenance, package publishing, or deployment surfaces
- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [ ] Documentation updated if behavior changed

No public documentation was changed because the advanced System Status diagnostics remain available and this PR only changes the ordinary shell projection.