### PR TITLE
feat(coordination): journal-native lock arbiter body (ADR-0077)

### DIFF
--- a/docs/adr/ADR-0077-agent-coordination-on-live-runtime.md
+++ b/docs/adr/ADR-0077-agent-coordination-on-live-runtime.md
@@ -4,7 +4,7 @@ doc_type: architecture-decision
 adr_id: ADR-0077
 decision_status: accepted
 implementation_status: partial
-implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/771, https://github.com/kungfu-systems/kungfu/pull/804]
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/771, https://github.com/kungfu-systems/kungfu/pull/804, https://github.com/kungfu-systems/kungfu/pull/805]
 review_state: maintainer-reviewed
 sensitivity: public
 sources: [local-files, user-decision]
@@ -89,7 +89,7 @@ Build agent coordination as a live-runtime consumer on the existing substrate,
   crash-safe auto-release via holder-pid liveness, and Episode audit of each
   run's wait/acquire/release. The stdlib lock is dependency-free and tested
   cross-process; the audit and CLI run on a local core build.
-- **Runtime plumbing (this increment).** The live-runtime primitives the
+- **Runtime plumbing (PR #799).** The live-runtime primitives the
   journal-native arbiter is built on: a Python-overridable peer react hook
   (`on_react`/`on_start` trampolines plus `observe(carrier_type, callback)` and
   the `request_read_from` / `request_write_to` / `get_public_writer` bindings),
@@ -99,18 +99,38 @@ Build agent coordination as a live-runtime consumer on the existing substrate,
   command journals do not yet exist — the coordinator reader creates the missing
   page instead of failing the read-only open. Both are validated on a local core
   build (nine native journal / durability / crash-recovery tests plus a
-  three-process live peer round-trip); they carry no in-tree consumer yet.
-- **Foreground product projection (this increment).** Desktop tray and status
+  three-process live peer round-trip).
+- **Foreground product projection (PR #804).** Desktop tray and status
   bar present one workspace-level runtime state instead of exposing supervisor
   and coordinator processes as separate user concerns. Process health proves
   only `Workspace online`; the stronger `Workspace ready`, `reconnecting`, and
   recovery states require explicit continuity evidence. Raw process diagnostics
   remain available in the advanced System Status view.
-- **Deferred to a follow-up.** The arbiter peer itself — the in-memory lock
-  table that consumes the react hook, replacing the waiter's short poll with a
-  grant frame awaited over the live stream — and the instruct-injection path.
-  Both build directly on the runtime plumbing above. Cross-host coordination and
-  hard confinement remain out of scope.
+- **Arbiter body (this increment).** The journal-native arbiter that consumes
+  the react hook — the first live Python peer and the first `coloop`-style
+  grant-await consumer in the tree. A pure `LockTable` (FIFO request / release /
+  forget; stdlib-only, unit-tested off the runtime) plus a resident
+  `Arbiter(peer)` that observes `coordination.lock.request` / `release` frames,
+  is the single writer of a `coordination.lock.grant` stream on its public
+  journal, and records the whole stream as one replayable coordination Episode
+  (the native audit that subsumes the first slice's per-run `audit.py`). A
+  contending `LockClient` awaits its grant frame with no table poll. Auto-release
+  keeps the ADR invariant on both paths: a clean holder sends a release frame; a
+  hard-killed holder is reclaimed by a same-host pid-liveness reaper on the
+  arbiter (each request carries the client pid), because the live runtime emits
+  no deregister for an ungraceful death — a centralized, model-token-free check
+  rather than N agents polling a table. The instruct-injection path (a one-shot
+  writer addressing a worker's location so it reacts while holding a lock) is
+  included. Custom `coordination.*` action types ride the action envelope with no
+  C++ schema change. Proven end-to-end on a local core build by a cross-process
+  harness — two workers serialize with zero poll, a SIGKILLed holder's lock is
+  reclaimed and granted onward, an instruction is delivered to a lock-holding
+  worker, and the coordination stream replays as a closed audit Episode — plus
+  the `LockTable` unit suite.
+- **Deferred to a follow-up.** Switching the `kungfu lock` CLI onto the arbiter
+  backend as a managed resident service (the arbiter library and mechanism are
+  in place; the CLI still drives the file-backed lock). Cross-host coordination
+  and hard confinement remain out of scope.
 
 ### Architecture — reuse vs build
 

--- a/framework/core/src/python/kungfu/coordination/arbiter.py
+++ b/framework/core/src/python/kungfu/coordination/arbiter.py
@@ -1,0 +1,186 @@
+#  SPDX-License-Identifier: Apache-2.0
+#
+# Journal-native coordination arbiter — the ADR-0077 next increment over the
+# file-backed `locks.py` prototype. A single resident peer (the arbiter) owns an
+# in-memory lock table and is the sole writer of a grant stream. Clients write a
+# `coordination.lock.request` frame TO the arbiter and block on a coroutine that
+# resolves when the matching `coordination.lock.grant` frame arrives on the
+# arbiter's public journal. This removes the two prototype simplifications at
+# once:
+#
+#   * No poll. A waiter is woken by the nng/reactor when its grant frame lands,
+#     instead of re-reading a JSON table on a timer.
+#   * Native audit. request / grant / release are journal frames, i.e. Episodes,
+#     so the coordination history is a replayable record with no bespoke audit
+#     side-channel (this subsumes `audit.py`).
+#
+# The contention logic lives in `LockTable`, which is pure standard library and
+# is unit-tested without the native runtime. `Arbiter` is the thin live layer
+# that binds the table to the journal substrate (peer.observe / get_public_writer
+# / request_write_to), validated by the PoC in the goal record.
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+# Custom action-envelope types. These need no C++ schema change: `wrap_event`
+# falls back to an identity schema_ref and `unwrap_event(..., schema_bfbs=None)`
+# skips domain verification, so a JSON payload rides inside the envelope.
+ACTION_REQUEST = "coordination.lock.request"
+ACTION_GRANT = "coordination.lock.grant"
+ACTION_RELEASE = "coordination.lock.release"
+ACTION_INSTRUCT = "coordination.instruct"
+
+
+class LockTable:
+    """In-memory arbiter lock table — pure logic, no runtime dependency.
+
+    Every method returns the *grant decision* rather than performing any IO, so
+    the live layer can turn a decision into a grant frame while this class stays
+    unit-testable off the native runtime. A lock is identified by ``name`` and a
+    holder / waiter by an opaque integer ``uid`` (the peer location uid on the
+    live path). Waiters are served strictly FIFO, which gives bounded wait: a
+    request never starves behind later arrivals.
+    """
+
+    def __init__(self) -> None:
+        self._holders: dict[str, int] = {}
+        self._waiters: dict[str, list[int]] = {}
+
+    def request(self, name: str, uid: int) -> int | None:
+        """``uid`` asks for ``name``.
+
+        Return ``uid`` if it is granted now — either the lock was free, or
+        ``uid`` already holds it (an idempotent re-grant so a client that missed
+        its grant frame can re-request and be re-answered). Return ``None`` if
+        ``uid`` is enqueued as a waiter (a duplicate request while waiting is a
+        no-op, so a retry never enqueues twice).
+        """
+        holder = self._holders.get(name)
+        if holder is None:
+            self._holders[name] = uid
+            return uid
+        if holder == uid:
+            return uid
+        queue = self._waiters.setdefault(name, [])
+        if uid not in queue:
+            queue.append(uid)
+        return None
+
+    def release(self, name: str, uid: int) -> int | None:
+        """``uid`` releases ``name``.
+
+        If ``uid`` is the holder, hand the lock to the next waiter and return the
+        new holder uid (or ``None`` if the lock is now free). A release from a
+        non-holder only cancels that uid's pending wait, if any, and returns
+        ``None`` — it never disturbs the current holder.
+        """
+        if self._holders.get(name) != uid:
+            queue = self._waiters.get(name)
+            if queue and uid in queue:
+                queue.remove(uid)
+                if not queue:
+                    self._waiters.pop(name, None)
+            return None
+        return self._grant_next(name)
+
+    def forget(self, uid: int) -> list[tuple[str, int | None]]:
+        """A peer died or deregistered: reclaim everything tied to ``uid``.
+
+        Drop ``uid`` from every waiter queue first (so it can never be granted a
+        lock it will never take), then hand off every lock it currently holds to
+        the next waiter. Return ``[(name, new_holder_or_None), ...]`` for exactly
+        the locks whose holder changed, so the live layer emits one grant frame
+        per real transition. This is the crash-safe auto-release invariant of
+        ADR-0077, now driven by peer liveness instead of pid liveness.
+        """
+        for name in list(self._waiters):
+            queue = self._waiters[name]
+            if uid in queue:
+                queue.remove(uid)
+            if not queue:
+                self._waiters.pop(name, None)
+        transitions: list[tuple[str, int | None]] = []
+        for name, holder in list(self._holders.items()):
+            if holder == uid:
+                transitions.append((name, self._grant_next(name)))
+        return transitions
+
+    def _grant_next(self, name: str) -> int | None:
+        """Pass ``name`` to the head of its waiter queue, or free it."""
+        queue = self._waiters.get(name)
+        if queue:
+            nxt = queue.pop(0)
+            self._holders[name] = nxt
+            if not queue:
+                self._waiters.pop(name, None)
+            return nxt
+        self._holders.pop(name, None)
+        self._waiters.pop(name, None)
+        return None
+
+    def holder(self, name: str) -> int | None:
+        return self._holders.get(name)
+
+    def waiters(self, name: str) -> list[int]:
+        return list(self._waiters.get(name, []))
+
+    def snapshot(self) -> dict[str, dict[str, Any]]:
+        """Debug / status view of the whole table."""
+        return {
+            name: {"holder": holder, "waiters": list(self._waiters.get(name, []))}
+            for name, holder in self._holders.items()
+        }
+
+
+def grant_payload(name: str, holder: int) -> bytes:
+    """Canonical grant-frame payload. Clients match on ``holder == self_uid``."""
+    return json.dumps({"name": name, "holder": holder}, sort_keys=True).encode("utf-8")
+
+
+def request_payload(name: str, pid: int | None = None) -> bytes:
+    """Request / release payload. ``pid`` lets the arbiter reap a holder that
+    died without releasing (a hard kill sends no graceful deregister frame)."""
+    obj: dict[str, Any] = {"name": name}
+    if pid is not None:
+        obj["pid"] = int(pid)
+    return json.dumps(obj, sort_keys=True).encode("utf-8")
+
+
+def _decode(payload: bytes) -> dict[str, Any] | None:
+    try:
+        obj = json.loads(bytes(payload).decode("utf-8"))
+    except (ValueError, UnicodeDecodeError):
+        return None
+    return obj if isinstance(obj, dict) else None
+
+
+def parse_name(payload: bytes) -> str | None:
+    """Read the ``name`` field out of a request / release / grant payload."""
+    obj = _decode(payload)
+    name = obj.get("name") if obj else None
+    return name if isinstance(name, str) else None
+
+
+def parse_pid(payload: bytes) -> int | None:
+    """Read the optional ``pid`` field out of a request / release payload."""
+    obj = _decode(payload)
+    if not obj or "pid" not in obj:
+        return None
+    try:
+        return int(obj["pid"])
+    except (TypeError, ValueError):
+        return None
+
+
+def instruct_payload(text: str) -> bytes:
+    """Payload for a `coordination.instruct` frame addressed at a worker."""
+    return json.dumps({"instruct": text}, sort_keys=True).encode("utf-8")
+
+
+def parse_instruct(payload: bytes) -> str | None:
+    """Read the instruction text out of a `coordination.instruct` payload."""
+    obj = _decode(payload)
+    text = obj.get("instruct") if obj else None
+    return text if isinstance(text, str) else None

--- a/framework/core/src/python/kungfu/coordination/arbiter_client.py
+++ b/framework/core/src/python/kungfu/coordination/arbiter_client.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import os
 import time
+from typing import Any
 
 import kungfu
 
@@ -32,7 +33,9 @@ from kungfu.coordination.arbiter import (
     request_payload,
 )
 
-yjj = kungfu.__binding__.runtime
+# Any so the native `yjj.peer` is usable as a base class under mypy (the
+# binding is dynamic; matches kungfu/runtime/live/peer.py).
+yjj: Any = kungfu.__binding__.runtime
 
 _STEP_SLEEP = 0.002
 

--- a/framework/core/src/python/kungfu/coordination/arbiter_client.py
+++ b/framework/core/src/python/kungfu/coordination/arbiter_client.py
@@ -199,7 +199,9 @@ def send_instruct(location, target_uid: int, text: str, timeout: float = 8.0) ->
         sender.step(0)
         time.sleep(_STEP_SLEEP)
     carrier, data = wrap_event(ACTION_INSTRUCT, instruct_payload(text))
-    sender.get_writer(target_uid).write_bytes(sender.now(), carrier, list(data), len(data))
+    sender.get_writer(target_uid).write_bytes(
+        sender.now(), carrier, list(data), len(data)
+    )
     for _ in range(100):
         if not sender.is_live():
             break

--- a/framework/core/src/python/kungfu/coordination/arbiter_client.py
+++ b/framework/core/src/python/kungfu/coordination/arbiter_client.py
@@ -1,0 +1,208 @@
+#  SPDX-License-Identifier: Apache-2.0
+#
+# The arbiter lock client (ADR-0077 next increment). A client acquires a named
+# lock by writing a `coordination.lock.request` frame to the arbiter and then
+# waiting for the matching `coordination.lock.grant` frame on the arbiter's
+# public journal — the wait is driven by the nng/reactor, not by polling a table
+# on a timer, so a contending agent's model spends no tokens while it waits.
+#
+# The client reactor is driven manually (pre_setup/setup/step) rather than by a
+# blocking run(), because acquiring requires acting *between* reactor steps:
+# become live -> open the request channel + subscribe to grants -> write the
+# request -> step until the grant lands. `is_started()` (not `is_live()`) is the
+# gate: the coordinator command writer that `request_write_to` needs only exists
+# after the register round-trip completes.
+
+from __future__ import annotations
+
+import os
+import time
+
+import kungfu
+
+from kungfu.action_envelope import CARRIER_ACTION_ENVELOPE
+from kungfu.work.wire import unwrap_event, wrap_event
+from kungfu.coordination.arbiter import (
+    ACTION_GRANT,
+    ACTION_INSTRUCT,
+    ACTION_RELEASE,
+    ACTION_REQUEST,
+    instruct_payload,
+    parse_instruct,
+    request_payload,
+)
+
+yjj = kungfu.__binding__.runtime
+
+_STEP_SLEEP = 0.002
+
+
+class LockClient(yjj.peer):
+    """A peer that acquires named locks from the arbiter and tracks its grants.
+
+    Grants land on the arbiter's public stream; the client subscribes once and
+    records every grant addressed to itself (``holder == self_uid``) so the
+    acquire loop just waits for the name to appear in ``self._granted``.
+    """
+
+    def __init__(self, location, arbiter_uid: int, low_latency: bool = False):
+        yjj.peer.__init__(self, location, low_latency=low_latency)
+        self._arbiter_uid = int(arbiter_uid)
+        self._self_uid = int(location.uid)
+        self._granted: set[str] = set()
+        self._instructs: list[str] = []
+
+    @property
+    def instructs(self) -> list[str]:
+        """Instruction texts this worker has received, in arrival order.
+
+        A separate one-shot writer can address this worker's location and inject
+        a `coordination.instruct` frame; because the worker already subscribes to
+        the live stream for grants, it also reacts to instructions without any
+        extra channel — this is the injection path an out-of-band controller uses
+        to steer a worker that holds a lock across judgement steps."""
+        return list(self._instructs)
+
+    def on_exit(self):  # pragma: no cover - lifecycle glue
+        pass
+
+    def on_react(self):
+        self.observe(CARRIER_ACTION_ENVELOPE, self._on_frame)
+
+    def on_start(self):  # pragma: no cover - lifecycle glue
+        pass
+
+    def _on_frame(self, event):
+        if event.carrier_type != CARRIER_ACTION_ENVELOPE:
+            return
+        decoded = unwrap_event(bytes(event.data_as_byte_array))
+        if decoded is None:
+            return
+        action_type, payload = decoded
+        if action_type == ACTION_GRANT:
+            import json
+
+            try:
+                obj = json.loads(bytes(payload).decode("utf-8"))
+            except (ValueError, UnicodeDecodeError):
+                return
+            if isinstance(obj, dict) and int(obj.get("holder", -1)) == self._self_uid:
+                name = obj.get("name")
+                if isinstance(name, str):
+                    self._granted.add(name)
+        elif action_type == ACTION_INSTRUCT:
+            text = parse_instruct(payload)
+            if text is not None:
+                self._instructs.append(text)
+
+    # --- driving ----------------------------------------------------------
+    def start_manual(self, timeout: float = 8.0) -> bool:
+        """Bring the reactor up and subscribe to the arbiter's grant stream.
+
+        Returns True once the peer is started and the request channel + grant
+        subscription are open. Idempotent enough for a harness to call once.
+        """
+        self.pre_setup()
+        self.setup()
+        deadline = time.time() + timeout
+        while not self.is_started():
+            if time.time() > deadline:
+                return False
+            self.step(0)
+            time.sleep(_STEP_SLEEP)
+        # Open the write channel to the arbiter and subscribe to its grants.
+        self.request_write_to(self.now(), self._arbiter_uid, 0)
+        self.request_read_from_public(self.now(), self._arbiter_uid, 0)
+        while not self.has_writer(self._arbiter_uid):
+            if time.time() > deadline:
+                return False
+            self.step(0)
+            time.sleep(_STEP_SLEEP)
+        return True
+
+    def acquire(self, name: str, timeout: float = 8.0) -> bool:
+        """Request ``name`` and step the reactor until it is granted to us.
+
+        The step loop drains nng-delivered frames; the wait ends the moment the
+        grant frame arrives (no timer poll). Returns True on grant, False on
+        timeout.
+        """
+        self._write(ACTION_REQUEST, request_payload(name, pid=os.getpid()))
+        deadline = time.time() + timeout
+        while name not in self._granted:
+            if time.time() > deadline or not self.is_live():
+                return False
+            self.step(0)
+            time.sleep(_STEP_SLEEP)
+        return True
+
+    def release(self, name: str) -> None:
+        """Release ``name``; the arbiter grants it to the next waiter, if any."""
+        self._granted.discard(name)
+        self._write(ACTION_RELEASE, request_payload(name))
+        # Flush the release frame out through a few reactor steps.
+        for _ in range(50):
+            if not self.is_live():
+                break
+            self.step(0)
+            time.sleep(_STEP_SLEEP)
+
+    def pump(self, seconds: float) -> None:
+        """Drive the reactor for a while (e.g. to keep holding / observe frames)."""
+        deadline = time.time() + seconds
+        while time.time() < deadline and self.is_live():
+            self.step(0)
+            time.sleep(_STEP_SLEEP)
+
+    def _write(self, action_type: str, payload: bytes):
+        carrier, data = wrap_event(action_type, payload)
+        self.get_writer(self._arbiter_uid).write_bytes(
+            self.now(), carrier, list(data), len(data)
+        )
+
+
+class _OneshotWriter(yjj.peer):
+    """A throwaway peer used only to write one frame to a target location."""
+
+    def on_exit(self):  # pragma: no cover - lifecycle glue
+        pass
+
+    def on_react(self):  # pragma: no cover - no subscriptions needed
+        pass
+
+    def on_start(self):  # pragma: no cover - lifecycle glue
+        pass
+
+
+def send_instruct(location, target_uid: int, text: str, timeout: float = 8.0) -> bool:
+    """Inject one `coordination.instruct` frame into ``target_uid``'s stream.
+
+    A short-lived peer becomes live, opens a write channel to the target, writes
+    the instruction, flushes it through the reactor, and exits. The target reacts
+    to the frame on its own live stream (see `LockClient.instructs`). Returns
+    True once the frame has been written.
+    """
+    target_uid = int(target_uid)
+    sender = _OneshotWriter(location, low_latency=False)
+    sender.pre_setup()
+    sender.setup()
+    deadline = time.time() + timeout
+    while not sender.is_started():
+        if time.time() > deadline:
+            return False
+        sender.step(0)
+        time.sleep(_STEP_SLEEP)
+    sender.request_write_to(sender.now(), target_uid, 0)
+    while not sender.has_writer(target_uid):
+        if time.time() > deadline:
+            return False
+        sender.step(0)
+        time.sleep(_STEP_SLEEP)
+    carrier, data = wrap_event(ACTION_INSTRUCT, instruct_payload(text))
+    sender.get_writer(target_uid).write_bytes(sender.now(), carrier, list(data), len(data))
+    for _ in range(100):
+        if not sender.is_live():
+            break
+        sender.step(0)
+        time.sleep(_STEP_SLEEP)
+    return True

--- a/framework/core/src/python/kungfu/coordination/arbiter_peer.py
+++ b/framework/core/src/python/kungfu/coordination/arbiter_peer.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 
 import os
 import time
+import uuid
 
 import kungfu
 
@@ -47,6 +48,8 @@ from kungfu.coordination.arbiter import (
 )
 
 yjj = kungfu.__binding__.runtime
+
+ACTION_REAP = "coordination.lock.reap"
 
 _REAP_INTERVAL = 0.5
 _STEP_SLEEP = 0.002
@@ -76,11 +79,62 @@ class Arbiter(yjj.peer):
     harness or the CLI observe decisions without re-reading the journal.
     """
 
-    def __init__(self, location, low_latency: bool = False, on_transition=None):
+    def __init__(
+        self,
+        location,
+        low_latency: bool = False,
+        on_transition=None,
+        runtime_dir: str | None = None,
+    ):
         yjj.peer.__init__(self, location, low_latency=low_latency)
         self._table = LockTable()
         self._pids: dict[int, int] = {}
         self._on_transition = on_transition
+        self._audit = self._open_audit(runtime_dir)
+        self._run_id = uuid.uuid4().hex
+
+    # --- native audit (subsumes coordination/audit.py) --------------------
+    def _open_audit(self, runtime_dir):
+        """Central replayable audit Episode for all coordination.
+
+        The arbiter is the single authority for lock decisions, so it records the
+        request / grant / release / reap stream as one `coordination` Episode —
+        this replaces the first slice's per-lock-run `audit.py`, which recorded
+        from each client because the file lock had no journal. Best-effort:
+        coordination must never fail because storage is unavailable. A distinct
+        location name keeps the audit journal off the peer's own grant journal.
+        """
+        if not runtime_dir:
+            return None
+        try:
+            from kungfu.storage.episode_lifecycle import RuntimeEpisodeLifecycle
+
+            return RuntimeEpisodeLifecycle(
+                runtime_dir=runtime_dir,
+                namespace="coordination",
+                name="arbiter-audit",
+                title="coordination arbiter",
+                actor="coordination arbiter",
+                source=f"arbiter:{int(self.get_home_uid())}",
+            )
+        except Exception:  # noqa: BLE001 - audit is additive, never load-bearing
+            return None
+
+    def _record_audit(self, action_type: str, payload: bytes):
+        if self._audit is None:
+            return
+        try:
+            self._audit.record_event(action_type, payload, run_id=self._run_id)
+        except Exception:  # noqa: BLE001
+            pass
+
+    def close_audit(self):
+        if self._audit is not None:
+            try:
+                self._audit.close(ok=True)
+            except Exception:  # noqa: BLE001
+                pass
+            self._audit = None
 
     # --- peer hooks -------------------------------------------------------
     def on_exit(self):  # pragma: no cover - lifecycle glue
@@ -111,15 +165,18 @@ class Arbiter(yjj.peer):
             self.step(0)
             time.sleep(_STEP_SLEEP)
         next_reap = time.time() + _REAP_INTERVAL
-        while self.is_live():
-            if should_stop is not None and should_stop():
-                break
-            self.step(0)
-            now = time.time()
-            if now >= next_reap:
-                self._reap_dead_holders()
-                next_reap = now + _REAP_INTERVAL
-            time.sleep(_STEP_SLEEP)
+        try:
+            while self.is_live():
+                if should_stop is not None and should_stop():
+                    break
+                self.step(0)
+                now = time.time()
+                if now >= next_reap:
+                    self._reap_dead_holders()
+                    next_reap = now + _REAP_INTERVAL
+                time.sleep(_STEP_SLEEP)
+        finally:
+            self.close_audit()
         return True
 
     # --- frame handlers ---------------------------------------------------
@@ -138,11 +195,13 @@ class Arbiter(yjj.peer):
             pid = parse_pid(payload)
             if pid is not None:
                 self._pids[source] = pid
+            self._record_audit(ACTION_REQUEST, payload)
             grant = self._table.request(name, source)
             self._note(name, ACTION_REQUEST, source)
             if grant is not None:
                 self._emit_grant(name, grant)
         elif action_type == ACTION_RELEASE:
+            self._record_audit(ACTION_RELEASE, payload)
             nxt = self._table.release(name, source)
             self._note(name, ACTION_RELEASE, source)
             if nxt is not None:
@@ -160,7 +219,10 @@ class Arbiter(yjj.peer):
             if not _pid_alive(self._pids.get(holder)):
                 dead.append(holder)
         for uid in dead:
-            for name, nxt in self._table.forget(uid):
+            transitions = self._table.forget(uid)
+            for name, _nxt in transitions:
+                self._record_audit(ACTION_REAP, grant_payload(name, uid))
+            for name, nxt in transitions:
                 self._note(name, "reap", uid)
                 if nxt is not None:
                     self._emit_grant(name, nxt)
@@ -168,9 +230,11 @@ class Arbiter(yjj.peer):
 
     # --- outbound ---------------------------------------------------------
     def _emit_grant(self, name: str, holder: int):
-        carrier, data = wrap_event(ACTION_GRANT, grant_payload(name, holder))
+        payload = grant_payload(name, holder)
+        carrier, data = wrap_event(ACTION_GRANT, payload)
         writer = self.get_public_writer()
         writer.write_bytes(self.now(), carrier, list(data), len(data))
+        self._record_audit(ACTION_GRANT, payload)
         self._note(name, ACTION_GRANT, holder)
 
     def _note(self, name, action, uid):

--- a/framework/core/src/python/kungfu/coordination/arbiter_peer.py
+++ b/framework/core/src/python/kungfu/coordination/arbiter_peer.py
@@ -1,0 +1,181 @@
+#  SPDX-License-Identifier: Apache-2.0
+#
+# The live arbiter peer (ADR-0077 next increment). This is the thin journal
+# layer over the pure `LockTable`: a single resident peer that is the sole
+# writer of the grant stream. It keeps no lock state the journal does not — the
+# frames it reads (requests) and writes (grants) ARE the coordination record, so
+# the audit trail is the journal itself (the "native audit" that subsumes
+# `audit.py`).
+#
+# Substrate (validated by the goal PoC, `poc_channel.py`):
+#   * client -> arbiter: a client does `request_write_to(arbiter_uid)` and writes
+#     a `coordination.lock.request` frame; the coordinator's Channel machinery
+#     auto-joins the arbiter as a reader, so the arbiter's `observe` callback
+#     fires with `event.source` = the requesting peer's uid. No client discovery.
+#   * arbiter -> client: the arbiter writes a `coordination.lock.grant` frame to
+#     its PUBLIC journal; each client does `request_read_from_public(arbiter_uid)`
+#     and filters grants by `holder == self_uid`.
+#
+# Auto-release (crash safety) has two paths, so no lock outlives its holder:
+#   * clean exit: the client sends a `coordination.lock.release` frame; the
+#     arbiter grants the lock to the next waiter immediately (zero poll).
+#   * hard kill: a SIGKILLed holder sends nothing, and the live runtime emits no
+#     deregister for an ungraceful death, so the arbiter reaps it. Each request
+#     carries the client pid; the arbiter checks holder liveness on a cheap
+#     same-host interval (os.kill(pid, 0)) and reclaims a dead holder's locks.
+#     This is a centralized, model-token-free check — one service polling pids,
+#     not N agents polling a table — and preserves the ADR-0077 auto-release
+#     invariant for the ungraceful case.
+
+from __future__ import annotations
+
+import os
+import time
+
+import kungfu
+
+from kungfu.action_envelope import CARRIER_ACTION_ENVELOPE
+from kungfu.work.wire import unwrap_event, wrap_event
+from kungfu.coordination.arbiter import (
+    ACTION_GRANT,
+    ACTION_RELEASE,
+    ACTION_REQUEST,
+    LockTable,
+    grant_payload,
+    parse_name,
+    parse_pid,
+)
+
+yjj = kungfu.__binding__.runtime
+
+_REAP_INTERVAL = 0.5
+_STEP_SLEEP = 0.002
+
+
+def _pid_alive(pid: int | None) -> bool:
+    if not pid or pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+        return True
+    except OSError:
+        return False
+
+
+def _event_bytes(event) -> bytes:
+    return bytes(event.data_as_byte_array)
+
+
+class Arbiter(yjj.peer):
+    """Resident single-writer lock arbiter over the live journal.
+
+    Construct with a SERVICE location and call ``serve()`` to run. The instance
+    owns a `LockTable`; every request / release frame drives one table transition
+    and, when the holder changes, one grant frame on the public stream. An
+    optional ``on_transition(name, action, uid, snapshot)`` callback lets a
+    harness or the CLI observe decisions without re-reading the journal.
+    """
+
+    def __init__(self, location, low_latency: bool = False, on_transition=None):
+        yjj.peer.__init__(self, location, low_latency=low_latency)
+        self._table = LockTable()
+        self._pids: dict[int, int] = {}
+        self._on_transition = on_transition
+
+    # --- peer hooks -------------------------------------------------------
+    def on_exit(self):  # pragma: no cover - lifecycle glue
+        pass
+
+    def on_react(self):
+        # Subscriptions must be installed in on_react(), before the reactor
+        # connects the event stream (see peer::observe docstring).
+        self.observe(CARRIER_ACTION_ENVELOPE, self._on_action)
+
+    def on_start(self):  # pragma: no cover - lifecycle glue
+        pass
+
+    # --- serving loop -----------------------------------------------------
+    def serve(self, should_stop=None, start_timeout: float = 10.0) -> bool:
+        """Drive the reactor manually and reap dead holders on an interval.
+
+        Manual driving (rather than the blocking ``run()``) is what lets the
+        arbiter interleave the same-host liveness reap between reactor steps
+        without a bound native timer. Returns False if the peer never started.
+        """
+        self.pre_setup()
+        self.setup()
+        deadline = time.time() + start_timeout
+        while not self.is_started():
+            if time.time() > deadline:
+                return False
+            self.step(0)
+            time.sleep(_STEP_SLEEP)
+        next_reap = time.time() + _REAP_INTERVAL
+        while self.is_live():
+            if should_stop is not None and should_stop():
+                break
+            self.step(0)
+            now = time.time()
+            if now >= next_reap:
+                self._reap_dead_holders()
+                next_reap = now + _REAP_INTERVAL
+            time.sleep(_STEP_SLEEP)
+        return True
+
+    # --- frame handlers ---------------------------------------------------
+    def _on_action(self, event):
+        if event.carrier_type != CARRIER_ACTION_ENVELOPE:
+            return
+        decoded = unwrap_event(_event_bytes(event))
+        if decoded is None:
+            return
+        action_type, payload = decoded
+        name = parse_name(payload)
+        if name is None:
+            return
+        source = int(event.source)
+        if action_type == ACTION_REQUEST:
+            pid = parse_pid(payload)
+            if pid is not None:
+                self._pids[source] = pid
+            grant = self._table.request(name, source)
+            self._note(name, ACTION_REQUEST, source)
+            if grant is not None:
+                self._emit_grant(name, grant)
+        elif action_type == ACTION_RELEASE:
+            nxt = self._table.release(name, source)
+            self._note(name, ACTION_RELEASE, source)
+            if nxt is not None:
+                self._emit_grant(name, nxt)
+
+    def _reap_dead_holders(self):
+        """Reclaim locks whose holder process is gone (ungraceful death)."""
+        dead: list[int] = []
+        seen: set[int] = set()
+        for name in list(self._table.snapshot()):
+            holder = self._table.holder(name)
+            if holder is None or holder in seen:
+                continue
+            seen.add(holder)
+            if not _pid_alive(self._pids.get(holder)):
+                dead.append(holder)
+        for uid in dead:
+            for name, nxt in self._table.forget(uid):
+                self._note(name, "reap", uid)
+                if nxt is not None:
+                    self._emit_grant(name, nxt)
+            self._pids.pop(uid, None)
+
+    # --- outbound ---------------------------------------------------------
+    def _emit_grant(self, name: str, holder: int):
+        carrier, data = wrap_event(ACTION_GRANT, grant_payload(name, holder))
+        writer = self.get_public_writer()
+        writer.write_bytes(self.now(), carrier, list(data), len(data))
+        self._note(name, ACTION_GRANT, holder)
+
+    def _note(self, name, action, uid):
+        if self._on_transition is not None:
+            try:
+                self._on_transition(name, action, uid, self._table.snapshot())
+            except Exception:  # noqa: BLE001 - observation must never break serving
+                pass

--- a/framework/core/src/python/kungfu/coordination/arbiter_peer.py
+++ b/framework/core/src/python/kungfu/coordination/arbiter_peer.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 import os
 import time
 import uuid
+from typing import Any
 
 import kungfu
 
@@ -47,7 +48,9 @@ from kungfu.coordination.arbiter import (
     parse_pid,
 )
 
-yjj = kungfu.__binding__.runtime
+# Any so the native `yjj.peer` is usable as a base class under mypy (the
+# binding is dynamic; matches kungfu/runtime/live/peer.py).
+yjj: Any = kungfu.__binding__.runtime
 
 ACTION_REAP = "coordination.lock.reap"
 

--- a/framework/core/tests/python/test_coordination_arbiter.py
+++ b/framework/core/tests/python/test_coordination_arbiter.py
@@ -1,0 +1,180 @@
+#  SPDX-License-Identifier: Apache-2.0
+#
+# Unit tests for the arbiter lock table (ADR-0077 next increment). `LockTable`
+# is the pure contention logic behind the journal-native arbiter; it depends
+# only on the standard library, so these tests load it by file path and run
+# without the native runtime binding — the same pattern as
+# `test_coordination_locks.py`. The live journal wiring is exercised separately
+# by the cross-process arbiter harness.
+
+import importlib.util
+from pathlib import Path
+
+_ARBITER_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "src"
+    / "python"
+    / "kungfu"
+    / "coordination"
+    / "arbiter.py"
+)
+
+
+def _load_arbiter():
+    spec = importlib.util.spec_from_file_location("adr0077_arbiter", _ARBITER_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+arbiter = _load_arbiter()
+LockTable = arbiter.LockTable
+
+
+def test_free_lock_is_granted_immediately():
+    table = LockTable()
+    assert table.request("L", 1) == 1
+    assert table.holder("L") == 1
+    assert table.waiters("L") == []
+
+
+def test_second_requester_is_queued_not_granted():
+    table = LockTable()
+    assert table.request("L", 1) == 1
+    assert table.request("L", 2) is None
+    assert table.holder("L") == 1
+    assert table.waiters("L") == [2]
+
+
+def test_release_grants_next_waiter_fifo():
+    table = LockTable()
+    table.request("L", 1)
+    table.request("L", 2)
+    table.request("L", 3)
+    assert table.waiters("L") == [2, 3]
+    # Holder releases -> lock passes to the FIFO head, others stay queued.
+    assert table.release("L", 1) == 2
+    assert table.holder("L") == 2
+    assert table.waiters("L") == [3]
+    assert table.release("L", 2) == 3
+    assert table.holder("L") == 3
+    assert table.waiters("L") == []
+
+
+def test_release_of_last_holder_frees_lock():
+    table = LockTable()
+    table.request("L", 1)
+    assert table.release("L", 1) is None
+    assert table.holder("L") is None
+    # Freed lock is grantable again to a fresh requester.
+    assert table.request("L", 9) == 9
+    assert table.holder("L") == 9
+
+
+def test_reentrant_request_regrants_without_enqueue():
+    table = LockTable()
+    assert table.request("L", 1) == 1
+    # The holder re-requesting (e.g. it missed the grant frame) is re-granted
+    # and must not enqueue itself as its own waiter.
+    assert table.request("L", 1) == 1
+    assert table.waiters("L") == []
+
+
+def test_duplicate_wait_is_idempotent():
+    table = LockTable()
+    table.request("L", 1)
+    assert table.request("L", 2) is None
+    assert table.request("L", 2) is None
+    assert table.waiters("L") == [2]
+
+
+def test_release_by_non_holder_cancels_pending_wait():
+    table = LockTable()
+    table.request("L", 1)
+    table.request("L", 2)
+    table.request("L", 3)
+    # A queued waiter withdraws; the holder and the rest of the queue are intact.
+    assert table.release("L", 2) is None
+    assert table.holder("L") == 1
+    assert table.waiters("L") == [3]
+
+
+def test_release_by_stranger_is_noop():
+    table = LockTable()
+    table.request("L", 1)
+    assert table.release("L", 42) is None
+    assert table.holder("L") == 1
+
+
+def test_forget_reassigns_held_lock_to_next_waiter():
+    table = LockTable()
+    table.request("L", 1)
+    table.request("L", 2)
+    transitions = table.forget(1)
+    assert transitions == [("L", 2)]
+    assert table.holder("L") == 2
+
+
+def test_forget_frees_held_lock_with_no_waiters():
+    table = LockTable()
+    table.request("L", 1)
+    assert table.forget(1) == [("L", None)]
+    assert table.holder("L") is None
+
+
+def test_forget_removes_uid_from_other_waiter_queues():
+    table = LockTable()
+    table.request("A", 1)
+    table.request("A", 2)  # 2 waits on A
+    table.request("B", 2)  # 2 holds B
+    # 2 dies: it must be dropped from A's queue AND B handed off / freed.
+    transitions = dict(table.forget(2))
+    assert transitions == {"B": None}
+    assert table.waiters("A") == []
+    assert table.holder("A") == 1
+    assert table.holder("B") is None
+
+
+def test_forget_holder_with_multiple_locks():
+    table = LockTable()
+    table.request("A", 1)
+    table.request("A", 2)
+    table.request("B", 1)
+    transitions = dict(table.forget(1))
+    assert transitions == {"A": 2, "B": None}
+    assert table.holder("A") == 2
+    assert table.holder("B") is None
+
+
+def test_independent_locks_do_not_interfere():
+    table = LockTable()
+    assert table.request("A", 1) == 1
+    assert table.request("B", 2) == 2
+    assert table.request("A", 3) is None
+    assert table.snapshot() == {
+        "A": {"holder": 1, "waiters": [3]},
+        "B": {"holder": 2, "waiters": []},
+    }
+
+
+def test_payload_helpers_roundtrip():
+    assert arbiter.parse_name(arbiter.request_payload("L")) == "L"
+    assert arbiter.parse_name(arbiter.grant_payload("L", 7)) == "L"
+    assert arbiter.parse_name(b"not json") is None
+    assert arbiter.parse_name(b"[1,2,3]") is None
+
+
+if __name__ == "__main__":
+    import sys
+
+    failures = 0
+    for entry in sorted(dict(globals()).items()):
+        entry_name, fn = entry
+        if entry_name.startswith("test_") and callable(fn):
+            try:
+                fn()
+                print(f"PASS {entry_name}")
+            except AssertionError as exc:
+                failures += 1
+                print(f"FAIL {entry_name}: {exc}")
+    sys.exit(1 if failures else 0)


### PR DESCRIPTION
Journal-native lock arbiter body — the ADR-0077 next increment over the
file-backed lock prototype (PR #771) and the runtime plumbing (PR #799).

**What lands**
- `coordination/arbiter.py` — pure `LockTable` (FIFO request/release/forget) +
  action-envelope payload helpers; stdlib-only, unit-tested off the native
  runtime (14 cases in `test_coordination_arbiter.py`).
- `coordination/arbiter_peer.py` — resident `Arbiter(peer)`: `serve()` manual
  loop, observes `coordination.lock.request`/`release`, is the single writer of a
  `coordination.lock.grant` stream, and records the whole stream as one
  replayable coordination Episode (native audit that subsumes the first slice's
  per-run `audit.py`). Auto-release on both paths: clean holder sends a release
  frame; a hard-killed holder is reclaimed by a same-host pid-liveness reaper.
- `coordination/arbiter_client.py` — `LockClient` (manual-driven acquire /
  await-grant / release with zero table poll) + `send_instruct` one-shot.

Custom `coordination.*` action types ride the action envelope with no C++ schema
change. First live Python peer and first `coloop`-style grant-await consumer in
the tree.

**Verification (local core build)** — race: two workers serialize with zero
poll; kill: a SIGKILLed holder's lock is reclaimed and granted onward; instruct:
delivered to a lock-holding worker; audit: coordination stream replays as a
closed Episode (6 frames). `LockTable` unit suite green. `shifu build` green.

**Deferred** — switching the `kungfu lock` CLI onto the arbiter backend as a
managed resident service (library + mechanism are in place; CLI still drives the
file lock). ADR-0077 stays `partial`.

<!-- kungfu-adr-release:v1 {"schema":"kungfu.adr-release-pr/v1","kind":"dev-delivery","intent":"stage-ready","adrs":["ADR-0077"],"summary":"Journal-native lock arbiter body: resident Arbiter peer + pure LockTable + LockClient + replayable Episode audit; the ADR-0077 next increment over the file-backed lock, status stays partial (kungfu lock CLI backend switch deferred).","verification":["LockTable unit suite (14 cases) green off the native runtime","cross-process harness on a local core build: race two-workers-serialize zero-poll, kill SIGKILL-holder-reclaimed-and-granted, instruct delivered-to-lock-holding-worker","coordination stream replays as a closed audit Episode via episode_list (6 frames)","shifu build green SHIFU_BUILD_RC=0"]} -->