### PR TITLE
fix(gates): close direct workflow invocation drift

### DIFF
--- a/docs/qualification/gates/README.md
+++ b/docs/qualification/gates/README.md
@@ -8,10 +8,12 @@ explains Kungfu's current policy and does not redefine Shifu semantics.
 ## Authority and current-state boundary
 
 - Shifu owns the registry, plan, execution, and receipt contracts.
-- Kungfu owns the 34 concrete gate ids, actions, documentation, and five remote
+- Kungfu owns the 38 concrete gate ids, actions, documentation, and five remote
   policy profiles.
 - [Workflow bindings](workflow-bindings.json) record how current GitHub
-  workflows activate profiles and gates while migration is incomplete.
+  workflows activate profiles and gates. Schema v2 makes direct Gate and
+  Buildchain Gate-profile entries structure-checked; controller adapters are
+  the remaining migration boundary.
 - Buildchain owns runner allocation and aggregate checks; the standing patrol
   is pinned to the immutable `v2.12.4` release commit
   `a6145efc210a961da0e5c63d7024d42061550f60`. Buildchain cannot weaken a
@@ -76,6 +78,35 @@ documents:
 - [Native and qualification gates](native-qualification.md)
 - [Release and promotion gates](release-and-promotion.md)
 
+## Bidirectional workflow closure
+
+`./shifu check:gate-catalog` parses every `.github/workflows/*.yml` file as
+YAML and projects direct execution into normalized facts containing the
+workflow, job, execution kind, profile, and Gate ids. It recognizes both POSIX
+`./shifu gate run` and Windows `.\\shifu.cmd gate run` steps, including
+multiline scalars, plus the pinned Buildchain `.gate-profile.yml` reusable
+workflow with a static `gate-profile` input.
+
+The checker reconciles those facts in both directions:
+
+- every discovered direct Gate or profile invocation must match exactly one
+  binding at the same workflow and job;
+- every `execution: gate` or `execution: profile` binding must have a real YAML
+  invocation, not a comment or unrelated string;
+- Gate ids and profile ids must be static registry ids, profile Gate sets must
+  equal the non-`off` policy, and every selected Gate must remain non-`off` for
+  the binding's declared profiles;
+- duplicate ownership, missing execution, unknown or dynamic ids, and
+  Gate/profile mismatches fail closed.
+
+`requiredSnippets` remains a temporary execution witness only for
+`execution: controller` bindings. Those controller entries are still checked
+forward in this phase; their structured adapters and reverse discovery are the
+next closure stage. Static workflow inspection proves the checked YAML shape,
+not the internals of an external reusable workflow. Immutable references,
+contract locks, source-bound receipts, and runtime receipts remain responsible
+for that cross-repository evidence.
+
 ## Operator commands
 
 ```sh
@@ -97,11 +128,14 @@ the Buildchain orchestration stage registers their handlers.
 
 1. Change `shifu.gates.json` first.
 2. Update the gate's detailed section and workflow binding if reality changed.
-3. Regenerate the matrix with the catalog checker write mode.
-4. Run `./shifu check:gate-catalog` and `./shifu check:source`.
-5. Treat policy-strength changes as rollout decisions, not documentation edits.
+3. Declare the workflow/job execution in `workflow-bindings.json`; direct Gate
+   and profile ids must be statically recoverable from YAML.
+4. Regenerate the matrix with the catalog checker write mode.
+5. Run `./shifu check:gate-catalog` and `./shifu check:source`.
+6. Treat policy-strength changes as rollout decisions, not documentation edits.
 
 The catalog meta gate checks schema and semantic validity, task existence,
-documentation anchors and required fields, the generated matrix bytes, workflow
-snippets, and profile coverage. It proves structural consistency, not that a
-prose explanation is semantically wise.
+documentation anchors and required fields, the generated matrix bytes,
+structured direct workflow facts, temporary controller witnesses, and profile
+coverage. It proves structural consistency, not that a prose explanation is
+semantically wise.

--- a/docs/qualification/gates/source-and-governance.md
+++ b/docs/qualification/gates/source-and-governance.md
@@ -126,7 +126,7 @@ Each section is bound to the registry id by the catalog meta gate.
 - **Evidence:** unified Gate receipt; no separate artifact is currently required.
 - **Diagnosis:** `./shifu gate explain docs.contracts --profile <profile>`; reproduce with `./shifu gate run docs.contracts` on a capable runner.
 - **Cost:** light; timeout 600 seconds.
-- **Current source:** .github/workflows/docs-check.yml (docs-check; dev pull request touching declared documentation paths); .github/workflows/docs-external-links.yml (external-links; daily or manual).
+- **Current source:** .github/workflows/docs-check.yml (docs-check; dev pull request touching declared documentation paths); .github/workflows/dev-verify-patrol.yml (verify; daily or manual on dev); .github/workflows/docs-external-links.yml (external-links; daily or manual).
 - **Retirement:** remove only after every selecting profile and workflow binding is migrated or explicitly replaced, with the registry and matrix changed in the same review.
 <!-- /gate-doc:docs.contracts -->
 
@@ -162,7 +162,7 @@ Each section is bound to the registry id by the catalog meta gate.
 - **Evidence:** unified Gate receipt; no separate artifact is currently required.
 - **Diagnosis:** `./shifu gate explain docs.external-links --profile <profile>`; reproduce with `./shifu gate run docs.external-links` on a capable runner.
 - **Cost:** light; timeout 900 seconds.
-- **Current source:** .github/workflows/docs-external-links.yml (external-links; daily or manual).
+- **Current source:** .github/workflows/dev-verify-patrol.yml (verify; daily or manual on dev); .github/workflows/docs-external-links.yml (external-links; daily or manual).
 - **Retirement:** remove only after every selecting profile and workflow binding is migrated or explicitly replaced, with the registry and matrix changed in the same review.
 <!-- /gate-doc:docs.external-links -->
 

--- a/docs/qualification/gates/workflow-bindings.json
+++ b/docs/qualification/gates/workflow-bindings.json
@@ -1,5 +1,5 @@
 {
-  "schema": "kungfu.gate-workflow-bindings/v1",
+  "schema": "kungfu.gate-workflow-bindings/v2",
   "registry": "shifu.gates.json",
   "bindings": [
     {
@@ -131,7 +131,7 @@
     },
     {
       "id": "dev-heavy-patrol",
-      "execution": "controller",
+      "execution": "profile",
       "workflow": ".github/workflows/dev-verify-patrol.yml",
       "job": "verify",
       "profiles": [
@@ -139,6 +139,8 @@
       ],
       "gates": [
         "gate.catalog",
+        "docs.contracts",
+        "docs.external-links",
         "product.verify-full"
       ],
       "activation": "daily or manual on dev",

--- a/package.json
+++ b/package.json
@@ -131,6 +131,7 @@
     "github-slugger": "2.0.0",
     "markdown-it": "14.1.0",
     "markdownlint-cli2": "0.22.1",
-    "typescript": "^5.6.0"
+    "typescript": "^5.6.0",
+    "yaml": "2.9.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       typescript:
         specifier: ^5.6.0
         version: 5.9.3
+      yaml:
+        specifier: 2.9.0
+        version: 2.9.0
 
   developer/sdk:
     dependencies:

--- a/scripts/check-kungfu-gate-catalog.mjs
+++ b/scripts/check-kungfu-gate-catalog.mjs
@@ -5,6 +5,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
+import { scanWorkflowInvocations } from './kungfu-gate-workflow-facts.mjs';
 import { validateGateRegistry } from './shifu-gate-runtime.mjs';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
@@ -174,7 +175,7 @@ export function checkKungfuGateCatalog(root = ROOT) {
     issues.push(`[matrix] ${MATRIX} differs from shifu.gates.json`);
   }
 
-  if (bindingDocument.schema !== 'kungfu.gate-workflow-bindings/v1') {
+  if (bindingDocument.schema !== 'kungfu.gate-workflow-bindings/v2') {
     issues.push('[workflow] unsupported binding schema');
   }
   if (bindingDocument.registry !== 'shifu.gates.json') {
@@ -192,9 +193,9 @@ export function checkKungfuGateCatalog(root = ROOT) {
     if (!binding.job || !binding.activation) {
       issues.push(`[workflow] ${binding.id}: job and activation are required`);
     }
-    if (!['gate', 'controller'].includes(binding.execution)) {
+    if (!['gate', 'profile', 'controller'].includes(binding.execution)) {
       issues.push(
-        `[workflow] ${binding.id}: execution must be 'gate' or 'controller'`,
+        `[workflow] ${binding.id}: execution must be 'gate', 'profile', or 'controller'`,
       );
     }
     if (!binding.profiles?.length || !binding.gates?.length) {
@@ -234,21 +235,14 @@ export function checkKungfuGateCatalog(root = ROOT) {
       continue;
     }
     if (
-      !binding.requiredSnippets?.length ||
-      binding.requiredSnippets.some(
-        (snippet) => typeof snippet !== 'string' || snippet.length === 0,
-      )
+      binding.execution === 'controller' &&
+      (!binding.requiredSnippets?.length ||
+        binding.requiredSnippets.some(
+          (snippet) => typeof snippet !== 'string' || snippet.length === 0,
+        ))
     ) {
       issues.push(
-        `[workflow] ${binding.id}: requiredSnippets must contain non-empty strings`,
-      );
-    }
-    if (
-      binding.execution === 'gate' &&
-      !binding.requiredSnippets?.some((snippet) => snippet.includes('gate run'))
-    ) {
-      issues.push(
-        `[workflow] ${binding.id}: gate execution must prove a 'gate run' entrypoint`,
+        `[workflow] ${binding.id}: controller requiredSnippets must contain non-empty strings`,
       );
     }
     const workflow = path.join(root, workflowRelative);
@@ -256,11 +250,82 @@ export function checkKungfuGateCatalog(root = ROOT) {
       issues.push(`[workflow] ${binding.id}: missing ${binding.workflow}`);
       continue;
     }
-    const workflowText = fs.readFileSync(workflow, 'utf8');
-    for (const snippet of binding.requiredSnippets || []) {
-      if (!workflowText.includes(snippet)) {
+    if (binding.execution === 'controller') {
+      const workflowText = fs.readFileSync(workflow, 'utf8');
+      for (const snippet of binding.requiredSnippets || []) {
+        if (!workflowText.includes(snippet)) {
+          issues.push(
+            `[workflow] ${binding.id}: '${snippet}' not found in ${binding.workflow}`,
+          );
+        }
+      }
+    }
+  }
+
+  const workflowScan = scanWorkflowInvocations(root, registry);
+  issues.push(...workflowScan.issues);
+  const structuredBindings = bindings.filter((binding) =>
+    ['gate', 'profile'].includes(binding.execution),
+  );
+  const factsByBinding = new Map(
+    structuredBindings.map((binding) => [binding.id, []]),
+  );
+  for (const fact of workflowScan.facts) {
+    const locationBindings = structuredBindings.filter(
+      (binding) =>
+        binding.workflow === fact.workflow &&
+        binding.job === fact.job &&
+        binding.execution === fact.execution,
+    );
+    const matches = locationBindings.filter((binding) => {
+      if (fact.execution === 'gate') {
+        return binding.gates?.includes(fact.gates[0]);
+      }
+      return (
+        binding.profiles?.length === 1 &&
+        binding.profiles[0] === fact.profile &&
+        [...(binding.gates || [])].sort().join('\0') === fact.gates.join('\0')
+      );
+    });
+    const label = `${fact.workflow}#${fact.job}:${fact.profile || fact.gates[0]}`;
+    if (matches.length === 0) {
+      issues.push(
+        `[workflow-fact] ${label}: invocation has no matching binding`,
+      );
+    } else if (matches.length > 1) {
+      issues.push(
+        `[workflow-fact] ${label}: invocation matches multiple bindings (${matches.map((binding) => binding.id).join(', ')})`,
+      );
+    } else {
+      factsByBinding.get(matches[0].id).push(fact);
+    }
+  }
+  for (const binding of structuredBindings) {
+    const facts = factsByBinding.get(binding.id) || [];
+    if (!facts.length) {
+      issues.push(
+        `[workflow-fact] ${binding.id}: no structured ${binding.execution} invocation in ${binding.workflow}#${binding.job}`,
+      );
+      continue;
+    }
+    if (binding.execution === 'gate') {
+      const actual = [...new Set(facts.flatMap((fact) => fact.gates))].sort();
+      const dependencyIds = new Set();
+      const collectDependencies = (gateId) => {
+        const gate = registry.gates.find((item) => item.id === gateId);
+        for (const dependency of gate?.dependencies || []) {
+          if (dependencyIds.has(dependency)) continue;
+          dependencyIds.add(dependency);
+          collectDependencies(dependency);
+        }
+      };
+      for (const gate of binding.gates || []) collectDependencies(gate);
+      const expected = (binding.gates || [])
+        .filter((gate) => !dependencyIds.has(gate))
+        .sort();
+      if (actual.join('\0') !== expected.join('\0')) {
         issues.push(
-          `[workflow] ${binding.id}: '${snippet}' not found in ${binding.workflow}`,
+          `[workflow-fact] ${binding.id}: direct Gate entries are [${actual.join(', ')}], expected [${expected.join(', ')}]`,
         );
       }
     }
@@ -274,7 +339,7 @@ export function checkKungfuGateCatalog(root = ROOT) {
       }
     }
   }
-  return { issues, registry };
+  return { issues, registry, workflowFacts: workflowScan.facts };
 }
 
 export function writePolicyMatrix(root = ROOT) {
@@ -296,7 +361,7 @@ function main() {
     process.exit(1);
   }
   console.log(
-    `[kungfu-gates] ${result.registry.gates.length} gates, ${result.registry.profiles.length} profiles, docs/matrix/workflows aligned`,
+    `[kungfu-gates] ${result.registry.gates.length} gates, ${result.registry.profiles.length} profiles, ${result.workflowFacts.length} structured workflow invocations aligned`,
   );
 }
 

--- a/scripts/check-kungfu-gate-catalog.test.mjs
+++ b/scripts/check-kungfu-gate-catalog.test.mjs
@@ -42,7 +42,26 @@ function fixture() {
 
 test('current Kungfu catalog, docs, matrix, actions, and workflows align', () => {
   const root = fixture();
-  assert.deepEqual(checkKungfuGateCatalog(root).issues, []);
+  const result = checkKungfuGateCatalog(root);
+  assert.deepEqual(result.issues, []);
+  assert.ok(
+    result.workflowFacts.some(
+      (fact) =>
+        fact.execution === 'profile' &&
+        fact.profile === 'dev-patrol' &&
+        fact.workflow === '.github/workflows/dev-verify-patrol.yml' &&
+        fact.job === 'verify',
+    ),
+  );
+  assert.equal(
+    result.workflowFacts.filter(
+      (fact) =>
+        fact.workflow === '.github/workflows/shifu-ci.yml' &&
+        fact.job === 'check' &&
+        fact.gates[0] === 'shifu.workspace',
+    ).length,
+    2,
+  );
 });
 
 test('matrix rendering is deterministic and includes every profile', () => {
@@ -125,21 +144,22 @@ test('document facts and workflow entrypoints fail closed', () => {
     ),
   );
 
-  const bindingsPath = path.join(
+  const gateWorkflow = path.join(
     root,
-    'docs/qualification/gates/workflow-bindings.json',
+    '.github/workflows/adr-release-gate.yml',
   );
-  const bindings = JSON.parse(fs.readFileSync(bindingsPath, 'utf8'));
-  const gateBinding = bindings.bindings.find(
-    (binding) => binding.id === 'dev-adr',
+  fs.writeFileSync(
+    gateWorkflow,
+    fs
+      .readFileSync(gateWorkflow, 'utf8')
+      .replace(
+        '          ./shifu gate run governance.adr-delivery',
+        '          # ./shifu gate run governance.adr-delivery',
+      ),
   );
-  gateBinding.requiredSnippets = ['governance.adr-delivery'];
-  fs.writeFileSync(bindingsPath, JSON.stringify(bindings));
   assert.ok(
     checkKungfuGateCatalog(root).issues.some((issue) =>
-      issue.includes(
-        "dev-adr: gate execution must prove a 'gate run' entrypoint",
-      ),
+      issue.includes('dev-adr: no structured gate invocation'),
     ),
   );
 
@@ -152,7 +172,7 @@ test('document facts and workflow entrypoints fail closed', () => {
     fs.readFileSync(controllerBindingsPath, 'utf8'),
   );
   const controllerBinding = controllerBindings.bindings.find(
-    (binding) => binding.id === 'dev-heavy-patrol',
+    (binding) => binding.id === 'dev-source',
   );
   const controllerWorkflow = path.join(
     controllerRoot,
@@ -162,11 +182,138 @@ test('document facts and workflow entrypoints fail closed', () => {
     controllerWorkflow,
     fs
       .readFileSync(controllerWorkflow, 'utf8')
-      .replace('gate-profile: dev-patrol', 'gate-profile: dev-pr'),
+      .replace('mode: source', 'mode: changed'),
   );
   assert.ok(
     checkKungfuGateCatalog(controllerRoot).issues.some((issue) =>
-      issue.includes("dev-heavy-patrol: 'gate-profile: dev-patrol' not found"),
+      issue.includes("dev-source: 'mode: source' not found"),
+    ),
+  );
+});
+
+test('direct Gate invocations are discovered from YAML and must have one binding', () => {
+  const rogueRoot = fixture();
+  const rogue = path.join(rogueRoot, '.github/workflows/rogue.yml');
+  fs.writeFileSync(
+    rogue,
+    'name: Rogue\njobs:\n  unbound:\n    runs-on: ubuntu-latest\n    steps:\n      - run: ./shifu gate run source.acceptance\n',
+  );
+  assert.ok(
+    checkKungfuGateCatalog(rogueRoot).issues.some((issue) =>
+      issue.includes(
+        '.github/workflows/rogue.yml#unbound:source.acceptance: invocation has no matching binding',
+      ),
+    ),
+  );
+
+  const duplicateRoot = fixture();
+  const bindingsPath = path.join(
+    duplicateRoot,
+    'docs/qualification/gates/workflow-bindings.json',
+  );
+  const bindings = JSON.parse(fs.readFileSync(bindingsPath, 'utf8'));
+  const duplicate = structuredClone(
+    bindings.bindings.find((binding) => binding.id === 'dev-adr'),
+  );
+  duplicate.id = 'dev-adr-duplicate';
+  bindings.bindings.push(duplicate);
+  fs.writeFileSync(bindingsPath, JSON.stringify(bindings));
+  assert.ok(
+    checkKungfuGateCatalog(duplicateRoot).issues.some((issue) =>
+      issue.includes(
+        'invocation matches multiple bindings (dev-adr, dev-adr-duplicate)',
+      ),
+    ),
+  );
+});
+
+test('Gate and profile mismatch or dynamic ids fail closed', () => {
+  const mismatchRoot = fixture();
+  const mismatchWorkflow = path.join(
+    mismatchRoot,
+    '.github/workflows/adr-release-gate.yml',
+  );
+  fs.writeFileSync(
+    mismatchWorkflow,
+    fs
+      .readFileSync(mismatchWorkflow, 'utf8')
+      .replace('governance.adr-delivery', 'source.acceptance'),
+  );
+  assert.ok(
+    checkKungfuGateCatalog(mismatchRoot).issues.some((issue) =>
+      issue.includes(
+        '#adr-release:source.acceptance: invocation has no matching binding',
+      ),
+    ),
+  );
+
+  const dynamicRoot = fixture();
+  const dynamicWorkflow = path.join(
+    dynamicRoot,
+    '.github/workflows/adr-release-gate.yml',
+  );
+  fs.writeFileSync(
+    dynamicWorkflow,
+    fs
+      .readFileSync(dynamicWorkflow, 'utf8')
+      .replace('governance.adr-delivery', '${{ inputs.gate }}'),
+  );
+  assert.ok(
+    checkKungfuGateCatalog(dynamicRoot).issues.some((issue) =>
+      issue.includes('Gate id must be a static catalog id'),
+    ),
+  );
+
+  const unknownRoot = fixture();
+  const unknownWorkflow = path.join(
+    unknownRoot,
+    '.github/workflows/adr-release-gate.yml',
+  );
+  fs.writeFileSync(
+    unknownWorkflow,
+    fs
+      .readFileSync(unknownWorkflow, 'utf8')
+      .replace('governance.adr-delivery', 'governance.not-registered'),
+  );
+  assert.ok(
+    checkKungfuGateCatalog(unknownRoot).issues.some((issue) =>
+      issue.includes("unknown Gate 'governance.not-registered'"),
+    ),
+  );
+
+  const profileRoot = fixture();
+  const profileWorkflow = path.join(
+    profileRoot,
+    '.github/workflows/dev-verify-patrol.yml',
+  );
+  fs.writeFileSync(
+    profileWorkflow,
+    fs
+      .readFileSync(profileWorkflow, 'utf8')
+      .replace('gate-profile: dev-patrol', 'gate-profile: dev-pr'),
+  );
+  assert.ok(
+    checkKungfuGateCatalog(profileRoot).issues.some((issue) =>
+      issue.includes('#verify:dev-pr: invocation has no matching binding'),
+    ),
+  );
+
+  const profilePolicyRoot = fixture();
+  const bindingsPath = path.join(
+    profilePolicyRoot,
+    'docs/qualification/gates/workflow-bindings.json',
+  );
+  const bindings = JSON.parse(fs.readFileSync(bindingsPath, 'utf8'));
+  const profileBinding = bindings.bindings.find(
+    (binding) => binding.id === 'dev-heavy-patrol',
+  );
+  profileBinding.gates = profileBinding.gates.filter(
+    (gate) => gate !== 'docs.external-links',
+  );
+  fs.writeFileSync(bindingsPath, JSON.stringify(bindings));
+  assert.ok(
+    checkKungfuGateCatalog(profilePolicyRoot).issues.some((issue) =>
+      issue.includes('#verify:dev-patrol: invocation has no matching binding'),
     ),
   );
 });

--- a/scripts/kungfu-gate-workflow-facts.mjs
+++ b/scripts/kungfu-gate-workflow-facts.mjs
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: Apache-2.0
+// @ts-check
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { parseDocument } from 'yaml';
+
+const WORKFLOW_ROOT = '.github/workflows';
+const GATE_PROFILE_WORKFLOW = '/.github/workflows/.gate-profile.yml@';
+const GATE_COMMAND =
+  /(?:^|[\n;]|&&|\|\|)\s*(\.\/shifu|\.\\shifu\.cmd)\s+gate\s+run(?:\s+("[^"]*"|'[^']*'|[^\s;&|]+))?/g;
+
+function workflowFiles(root) {
+  const directory = path.join(root, WORKFLOW_ROOT);
+  if (!fs.existsSync(directory)) return [];
+  return fs
+    .readdirSync(directory, { withFileTypes: true })
+    .filter(
+      (entry) =>
+        entry.isFile() &&
+        (entry.name.endsWith('.yml') || entry.name.endsWith('.yaml')),
+    )
+    .map((entry) => `${WORKFLOW_ROOT}/${entry.name}`)
+    .sort();
+}
+
+function staticToken(token) {
+  if (!token) return null;
+  if (
+    (token.startsWith('"') && token.endsWith('"')) ||
+    (token.startsWith("'") && token.endsWith("'"))
+  ) {
+    return token.slice(1, -1);
+  }
+  return token;
+}
+
+function commandText(run) {
+  return run
+    .split(/\r?\n/)
+    .filter((line) => !line.trimStart().startsWith('#'))
+    .join('\n')
+    .replace(/\\\r?\n\s*/g, ' ')
+    .replace(/`\r?\n\s*/g, ' ');
+}
+
+function directGateFacts(workflow, jobId, steps, gateIds, issues) {
+  const facts = [];
+  for (const [stepIndex, step] of steps.entries()) {
+    if (!step || typeof step !== 'object' || typeof step.run !== 'string') {
+      continue;
+    }
+    const run = commandText(step.run);
+    GATE_COMMAND.lastIndex = 0;
+    for (const match of run.matchAll(GATE_COMMAND)) {
+      const gate = staticToken(match[2]);
+      const location = `${workflow}#${jobId}.steps[${stepIndex}]`;
+      if (!gate || !/^[a-z0-9][a-z0-9.-]*$/.test(gate)) {
+        issues.push(
+          `[workflow-fact] ${location}: Gate id must be a static catalog id`,
+        );
+        continue;
+      }
+      if (!gateIds.has(gate)) {
+        issues.push(`[workflow-fact] ${location}: unknown Gate '${gate}'`);
+        continue;
+      }
+      facts.push({
+        workflow,
+        job: jobId,
+        execution: 'gate',
+        profile: null,
+        gates: [gate],
+        source: `steps[${stepIndex}].run`,
+      });
+    }
+  }
+  return facts;
+}
+
+function profileFact(workflow, jobId, job, profilesById, issues) {
+  if (
+    typeof job.uses !== 'string' ||
+    !job.uses.includes(GATE_PROFILE_WORKFLOW)
+  ) {
+    return null;
+  }
+  const profile = job.with?.['gate-profile'];
+  const location = `${workflow}#${jobId}.with.gate-profile`;
+  if (typeof profile !== 'string' || !/^[a-z0-9][a-z0-9.-]*$/.test(profile)) {
+    issues.push(
+      `[workflow-fact] ${location}: Gate profile must be a static catalog profile`,
+    );
+    return null;
+  }
+  const policy = profilesById.get(profile);
+  if (!policy) {
+    issues.push(
+      `[workflow-fact] ${location}: unknown Gate profile '${profile}'`,
+    );
+    return null;
+  }
+  const gates = Object.entries(policy.decisions)
+    .filter(([, decision]) => decision.mode !== 'off')
+    .map(([gate]) => gate)
+    .sort();
+  return {
+    workflow,
+    job: jobId,
+    execution: 'profile',
+    profile,
+    gates,
+    source: 'uses.with.gate-profile',
+  };
+}
+
+export function scanWorkflowInvocations(root, registry) {
+  const issues = [];
+  const facts = [];
+  const gateIds = new Set(registry.gates.map((gate) => gate.id));
+  const profilesById = new Map(
+    registry.profiles.map((profile) => [profile.id, profile]),
+  );
+  for (const workflow of workflowFiles(root)) {
+    const file = path.join(root, workflow);
+    const document = parseDocument(fs.readFileSync(file, 'utf8'), {
+      prettyErrors: false,
+      uniqueKeys: true,
+    });
+    for (const error of document.errors) {
+      issues.push(`[workflow-yaml] ${workflow}: ${error.message}`);
+    }
+    if (document.errors.length) continue;
+    const value = document.toJS();
+    if (!value?.jobs || typeof value.jobs !== 'object') continue;
+    for (const [jobId, job] of Object.entries(value.jobs)) {
+      if (!job || typeof job !== 'object') continue;
+      if (Array.isArray(job.steps)) {
+        facts.push(
+          ...directGateFacts(workflow, jobId, job.steps, gateIds, issues),
+        );
+      }
+      const reusable = profileFact(workflow, jobId, job, profilesById, issues);
+      if (reusable) facts.push(reusable);
+    }
+  }
+  facts.sort((left, right) =>
+    [left.workflow, left.job, left.execution, left.profile || '', ...left.gates]
+      .join('\0')
+      .localeCompare(
+        [
+          right.workflow,
+          right.job,
+          right.execution,
+          right.profile || '',
+          ...right.gates,
+        ].join('\0'),
+      ),
+  );
+  return { facts, issues };
+}


### PR DESCRIPTION
## Summary

Close the first reverse-scan stage of the Kungfu Gate catalog. Direct Shifu Gate commands and the Buildchain Gate-profile workflow are now parsed from YAML into normalized execution facts and reconciled bidirectionally with registry policy and workflow bindings.

KFD-1 version impact: patch. This strengthens an internal validation contract without changing a public runtime or artifact interface.

## Related issue

Atlas goal `2026-07-14-kungfu-gate-direct-reverse-scan`.

## Changes

- add a declared `yaml` parser and scan every managed workflow structurally
- recognize POSIX, Windows, multiline, `cd &&`, and reusable Gate-profile forms
- fail closed on rogue, missing, duplicate, mismatched, dynamic, unknown, or policy-drifting invocations
- upgrade workflow bindings to v2 and document static versus runtime evidence boundaries

## Verification

- `./shifu check:gate-catalog`
- `./shifu check:source` — 120 tests passed
- staged pre-commit gate

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This patch strengthens Gate catalog validation without changing an accepted architecture contract"
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] release evidence, provenance, package publishing, or deployment surfaces
- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed