### PR TITLE
fix(gui): inject complete KFX shared-module contract

### DIFF
--- a/developer/sdk/package.json
+++ b/developer/sdk/package.json
@@ -30,6 +30,7 @@
     "@kungfu-tech/core": "workspace:*",
     "@kungfu-tech/gui": "workspace:*",
     "@kungfu-tech/kfd": "1.0.0-alpha.21",
+    "@kungfu-tech/kfx": "workspace:*",
     "@kungfu-tech/tui": "workspace:*",
     "ajv": "^8.20.0",
     "esbuild": "^0.28.1"

--- a/developer/sdk/src/sdk.js
+++ b/developer/sdk/src/sdk.js
@@ -31,6 +31,9 @@ import {
   sha256Json as sha256KfdJson,
   validateKfd1ReleaseGateEvidence,
 } from '@kungfu-tech/buildchain/kfd-gate';
+import kfxSharedModuleContract from '@kungfu-tech/kfx/shared-modules' with {
+  type: 'json',
+};
 
 const TEMPLATE_ROOT = path.join(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -2325,13 +2328,7 @@ function contractAdd(surfaceArg, options) {
 // ── kfx view extension build ──────────────────────────────────────────────
 // Modules that stay external and are injected by the shell at load time; a
 // view extension must never ship its own copy of these.
-const KFX_EXTERNALS = [
-  'react',
-  'react/jsx-runtime',
-  'react-dom',
-  '@kungfu-tech/api',
-  '@kungfu-tech/api/capability',
-];
+const KFX_EXTERNALS = kfxSharedModuleContract.modules;
 
 /**
  * The subset of a kfx package.json this driver reads.

--- a/framework/gui/src/renderer/sandbox-view-harness/harness.ts
+++ b/framework/gui/src/renderer/sandbox-view-harness/harness.ts
@@ -17,6 +17,7 @@
 // capability boundary — the security-critical surface — is fully wired here.
 import * as capability from '@kungfu-tech/api/capability';
 import { createCapabilityGuest } from '@kungfu-tech/api/capability';
+import * as query from '@kungfu-tech/api/query';
 import type {
   KfxCapabilities,
   KfxViewComponent,
@@ -27,6 +28,7 @@ import * as ReactDOM from 'react-dom';
 import { createRoot } from 'react-dom/client';
 import * as jsxRuntime from 'react/jsx-runtime';
 import { type SandboxBridge, bridgeChannel } from '../../sandbox/transport';
+import { createKfxSharedModules } from '../shared-modules';
 
 declare global {
   interface Window {
@@ -44,17 +46,18 @@ const bridge = window.__kfxBridge;
 // exactly the declared capabilities, each call marshalled over the bridge
 const caps = createCapabilityGuest(bridge.declared, bridgeChannel(bridge));
 
-// The externals a `kungfu sdk kfx build` bundle expects, same contract as the shared
-// renderer: one React instance and the capability surface. A sandboxed view that
-// tries to require anything else fails loudly rather than reaching node.
-const shared: Record<string, unknown> = {
+// The externals a `kungfu sdk kfx build` bundle expects, same contract as the
+// shared renderer: one React instance and the public API surfaces. A sandboxed
+// view that tries to require anything else fails loudly rather than reaching node.
+const shared = createKfxSharedModules({
   react: React,
-  'react-dom': ReactDOM,
-  'react-dom/client': { createRoot },
-  'react/jsx-runtime': jsxRuntime,
-  '@kungfu-tech/api': capability,
-  '@kungfu-tech/api/capability': capability,
-};
+  jsxRuntime,
+  reactDom: ReactDOM,
+  reactDomClient: { createRoot },
+  api: capability,
+  capability,
+  query,
+});
 
 // A minimal shell for the sandboxed view. Only the capability boundary is wired;
 // the rest is inert until shell bridging lands.

--- a/framework/gui/src/renderer/session-window/main.tsx
+++ b/framework/gui/src/renderer/session-window/main.tsx
@@ -7,11 +7,13 @@
 // terminal proxy, because a session window renders one live terminal and nothing
 // else. The stage-2 placeholder page is replaced by this entry.
 import * as capability from '@kungfu-tech/api/capability';
+import * as query from '@kungfu-tech/api/query';
 import type { KfxCapabilities, KfxEntry, Shell } from '@kungfu-tech/kfx';
 import React from 'react';
 import * as ReactDOM from 'react-dom';
 import { createRoot } from 'react-dom/client';
 import * as jsxRuntime from 'react/jsx-runtime';
+import { createKfxSharedModules } from '../shared-modules';
 import { loadKfx } from '../src/kfx-loader';
 import {
   type IpcRendererLike,
@@ -19,14 +21,16 @@ import {
 } from '../src/terminal-proxy';
 
 // The externals contract `kungfu sdk kfx build` injects into every kfx bundle:
-// one React instance and one capability surface (see renderer/src/main.tsx).
-const SHARED_MODULES = {
+// one React instance and the public API surfaces (see renderer/src/main.tsx).
+const SHARED_MODULES = createKfxSharedModules({
   react: React,
-  'react/jsx-runtime': jsxRuntime,
-  'react-dom': ReactDOM,
-  '@kungfu-tech/api': capability,
-  '@kungfu-tech/api/capability': capability,
-};
+  jsxRuntime,
+  reactDom: ReactDOM,
+  reactDomClient: { createRoot },
+  api: capability,
+  capability,
+  query,
+});
 
 // Render a plain failure line into #root. A session window has no shell chrome
 // to fall back to, so a misconfigured launch should still say why.

--- a/framework/gui/src/renderer/shared-modules.test.ts
+++ b/framework/gui/src/renderer/shared-modules.test.ts
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import {
+  KFX_SHARED_MODULE_KEYS,
+  createKfxSharedModules,
+} from './shared-modules';
+
+test('every declared kfx external has a renderer injection', () => {
+  const sentinel = {
+    react: {},
+    jsxRuntime: {},
+    reactDom: {},
+    reactDomClient: {},
+    api: {},
+    capability: {},
+    query: {},
+  };
+  const shared = createKfxSharedModules(sentinel);
+
+  assert.deepEqual(
+    Object.keys(shared).sort(),
+    [...KFX_SHARED_MODULE_KEYS].sort(),
+  );
+  assert.equal(shared['@kungfu-tech/api/query'], sentinel.query);
+  assert.equal(shared['react-dom/client'], sentinel.reactDomClient);
+});

--- a/framework/gui/src/renderer/shared-modules.ts
+++ b/framework/gui/src/renderer/shared-modules.ts
@@ -1,0 +1,34 @@
+import contract from '@kungfu-tech/kfx/shared-modules';
+
+export type KfxSharedModuleInputs = {
+  react: unknown;
+  jsxRuntime: unknown;
+  reactDom: unknown;
+  reactDomClient: unknown;
+  api: unknown;
+  capability: unknown;
+  query: unknown;
+};
+
+export const KFX_SHARED_MODULE_KEYS = Object.freeze([...contract.modules]);
+
+export function createKfxSharedModules(
+  inputs: KfxSharedModuleInputs,
+): Record<string, unknown> {
+  const modules: Record<string, unknown> = {
+    react: inputs.react,
+    'react/jsx-runtime': inputs.jsxRuntime,
+    'react-dom': inputs.reactDom,
+    'react-dom/client': inputs.reactDomClient,
+    '@kungfu-tech/api': inputs.api,
+    '@kungfu-tech/api/capability': inputs.capability,
+    '@kungfu-tech/api/query': inputs.query,
+  };
+  const missing = KFX_SHARED_MODULE_KEYS.filter((key) => !(key in modules));
+  if (missing.length > 0) {
+    throw new Error(
+      `kfx shared module contract missing: ${missing.join(', ')}`,
+    );
+  }
+  return modules;
+}

--- a/framework/gui/src/renderer/src/kfx-loader.ts
+++ b/framework/gui/src/renderer/src/kfx-loader.ts
@@ -3,9 +3,9 @@
 // Landing evaluates a trusted view's bundle — and injects its sibling CSS —
 // into this document, or stands in a placeholder for a sandboxed view the shell
 // embeds as an isolated renderer. Bundles are built by `kungfu sdk kfx build`
-// with react/react-dom/jsx-runtime and the capability SDK left external; the
-// shell injects its own instances through a require shim, so every kfx shares
-// one React and one capability surface.
+// with the modules declared by `framework/kfx/shared-modules.json` left
+// external; the shell injects its own instances through a require shim, so
+// every kfx shares one React and one public API surface.
 //
 // The discovery + trust/tier rule now lives in `planKfx` so the CLI/TUI host
 // reaches the same verdict for the same kfx (ADR-0017). Only the renderer-

--- a/framework/gui/src/renderer/src/main.tsx
+++ b/framework/gui/src/renderer/src/main.tsx
@@ -1,4 +1,5 @@
 import * as capability from '@kungfu-tech/api/capability';
+import * as query from '@kungfu-tech/api/query';
 // Reference app shell: boots the in-process runtime and mounts kfx loaded
 // from extension packages. The shell owns system concerns only — extension
 // scanning and lifecycle, capability injection by declaration, navigation
@@ -57,6 +58,7 @@ import {
   WORKSPACE_SELECT_RECENT_CHANNEL,
 } from '../../sandbox/channels';
 import { publishRefresh } from '../../sandbox/refresh';
+import { createKfxSharedModules } from '../shared-modules';
 import {
   loadKungfuConfig,
   normalizedUiConfig,
@@ -71,14 +73,16 @@ import { sandboxClient } from './sandbox-client';
 import { DEFAULT_STATE, loadShellState, saveShellState } from './shell-state';
 
 // Modules injected into every kfx bundle (the externals contract of
-// `kungfu sdk kfx build`): one React instance, one capability surface.
-const SHARED_MODULES = {
+// `kungfu sdk kfx build`): one React instance and the public API surfaces.
+const SHARED_MODULES = createKfxSharedModules({
   react: React,
-  'react/jsx-runtime': jsxRuntime,
-  'react-dom': ReactDOM,
-  '@kungfu-tech/api': capability,
-  '@kungfu-tech/api/capability': capability,
-};
+  jsxRuntime,
+  reactDom: ReactDOM,
+  reactDomClient: { createRoot },
+  api: capability,
+  capability,
+  query,
+});
 
 // One failing kfx renders its error panel; it never takes the shell down.
 class KfxErrorBoundary extends React.Component<

--- a/framework/kfx/package.json
+++ b/framework/kfx/package.json
@@ -12,7 +12,8 @@
   "types": "src/index.ts",
   "exports": {
     ".": "./src/index.ts",
-    "./query-view": "./src/query-view.tsx"
+    "./query-view": "./src/query-view.tsx",
+    "./shared-modules": "./shared-modules.json"
   },
   "repository": {
     "url": "https://github.com/kungfu-systems/kungfu.git"
@@ -25,7 +26,8 @@
   "files": [
     "src",
     "README.md",
-    "kungfu-kfx.contract.json"
+    "kungfu-kfx.contract.json",
+    "shared-modules.json"
   ],
   "scripts": {
     "build": "tsc --noEmit"

--- a/framework/kfx/shared-modules.json
+++ b/framework/kfx/shared-modules.json
@@ -1,0 +1,12 @@
+{
+  "schema": "kungfu.kfx.shared-modules/v1",
+  "modules": [
+    "react",
+    "react/jsx-runtime",
+    "react-dom",
+    "react-dom/client",
+    "@kungfu-tech/api",
+    "@kungfu-tech/api/capability",
+    "@kungfu-tech/api/query"
+  ]
+}

--- a/framework/kfx/src/index.ts
+++ b/framework/kfx/src/index.ts
@@ -1,9 +1,10 @@
 // The kfx view contract: the types a view extension implements and the shell
 // consumes, plus the shared UI tokens. This package is bundled INTO each view
 // extension (it is types and plain style objects — nothing stateful), while
-// `react`, `react/jsx-runtime`, `react-dom` and `@kungfu-tech/api/capability`
-// stay external and are injected by the shell at load time, so every kfx
-// shares the shell's React instance and capability handles.
+// React and the public `@kungfu-tech/api` entrypoints stay external and are
+// injected by the shell at load time, so every kfx shares the shell's React
+// instance and capability/query surfaces. The exact list lives in
+// `framework/kfx/shared-modules.json`.
 //
 // Static facts about a view (title, capabilities, settings, system flag)
 // live in the package manifest (`kungfuConfig.config.view`), never in code:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,6 +80,9 @@ importers:
       '@kungfu-tech/kfd':
         specifier: 1.0.0-alpha.21
         version: 1.0.0-alpha.21
+      '@kungfu-tech/kfx':
+        specifier: workspace:*
+        version: link:../../framework/kfx
       '@kungfu-tech/tui':
         specifier: workspace:*
         version: link:../../framework/tui

--- a/product/scripts/dist.mjs
+++ b/product/scripts/dist.mjs
@@ -532,6 +532,41 @@ function buildKfx(packages, baseEnv = process.env) {
   }
 }
 
+export function kfxBundleExternalModules(code) {
+  const modules = new Set();
+  const literalRequire = /(^|[^\w$.])require\(\s*(['"])([^'"]+)\2\s*\)/gm;
+  for (const match of code.matchAll(literalRequire)) modules.add(match[3]);
+  return [...modules].sort();
+}
+
+function assertKfxBundleExternals(packages) {
+  const contract = readJson(
+    path.join(ROOT, 'framework', 'kfx', 'shared-modules.json'),
+  );
+  const supported = new Set(contract.modules || []);
+  const unsupported = [];
+  for (const pkg of packages) {
+    if (!pkg.config?.config?.view) continue;
+    const entry = pkg.config.config.view.entry || 'dist/view/index.js';
+    const bundlePath = path.join(pkg.dir, entry);
+    for (const moduleId of kfxBundleExternalModules(
+      fs.readFileSync(bundlePath, 'utf8'),
+    )) {
+      if (!supported.has(moduleId)) {
+        unsupported.push(`${pkg.name}: ${moduleId}`);
+      }
+    }
+  }
+  if (unsupported.length > 0) {
+    throw new Error(
+      `kfx bundles require modules the GUI cannot inject:\n${unsupported.join('\n')}`,
+    );
+  }
+  console.log(
+    `[product] kfx shared-module contract: ${supported.size} modules`,
+  );
+}
+
 function assembleKfx(packages) {
   buildchainLogger.spanSync(
     'product.kfx.assemble',
@@ -1365,6 +1400,7 @@ function main() {
       stageTrunk();
 
       buildKfx(kfxPackages, buildEnv);
+      assertKfxBundleExternals(kfxPackages);
       assembleKfx(kfxPackages);
 
       runPnpm('bundle tui', ['--filter', '@kungfu-tech/tui', 'run', 'bundle'], {

--- a/product/scripts/dist.test.mjs
+++ b/product/scripts/dist.test.mjs
@@ -4,7 +4,11 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import { createRequire } from 'node:module';
 import { test } from 'node:test';
-import { cliArchiveBase, verifyProductObservabilityEvents } from './dist.mjs';
+import {
+  cliArchiveBase,
+  kfxBundleExternalModules,
+  verifyProductObservabilityEvents,
+} from './dist.mjs';
 
 const require = createRequire(import.meta.url);
 const workDashboardPackage = require('../../extensions/work-dashboard/package.json');
@@ -91,6 +95,19 @@ test('work dashboard declares the storage handle used by its query stream', () =
       'storage',
     ),
   );
+});
+
+test('product kfx gate sees bundle externals but ignores window.require', () => {
+  const code = [
+    'var query = require("@kungfu-tech/api/query");',
+    'var react = require("react");',
+    'window.require("node:fs");',
+    'win.require("node:path");',
+  ].join('\n');
+  assert.deepEqual(kfxBundleExternalModules(code), [
+    '@kungfu-tech/api/query',
+    'react',
+  ]);
 });
 
 test('desktop product carries the installed Agent authoring runtime', () => {

--- a/scripts/run-kfx-profile-suite-tests.mjs
+++ b/scripts/run-kfx-profile-suite-tests.mjs
@@ -38,6 +38,15 @@ run('GUI Profile navigation projection', 'pnpm', [
   path.join(root, 'framework/gui/src/navigation.test.ts'),
 ]);
 
+run('GUI KFX shared-module contract', 'pnpm', [
+  '--filter',
+  '@kungfu-tech/tui',
+  'exec',
+  'tsx',
+  '--test',
+  path.join(root, 'framework/gui/src/renderer/shared-modules.test.ts'),
+]);
+
 run('GUI workspace runtime foreground projection', 'pnpm', [
   '--filter',
   '@kungfu-tech/tui',


### PR DESCRIPTION
## Summary

Inject the complete published KFX shared-module contract into every GUI renderer boundary and fail Product assembly when a bundled KFX external cannot be landed.

## Verification

- `./shifu test:kfx-profile-suite`
- `./shifu check:source`
- `./shifu exec node --test product/scripts/dist.test.mjs`
- `./shifu --filter @kungfu-tech/sdk run build`
- `./shifu build:app`

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Fix packaged KFX shared-module injection and qualification without changing an architecture contract"
}
-->

## Governance risk check

- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The Product assembly gate now verifies the shipped KFX external contract before build registration.