### PR TITLE
fix(gates): close controller workflow drift

### DIFF
--- a/docs/qualification/gates/README.md
+++ b/docs/qualification/gates/README.md
@@ -11,9 +11,8 @@ explains Kungfu's current policy and does not redefine Shifu semantics.
 - Kungfu owns the 38 concrete gate ids, actions, documentation, and five remote
   policy profiles.
 - [Workflow bindings](workflow-bindings.json) record how current GitHub
-  workflows activate profiles and gates. Schema v2 makes direct Gate and
-  Buildchain Gate-profile entries structure-checked; controller adapters are
-  the remaining migration boundary.
+  workflows activate profiles and gates. Schema v2 makes direct Gate,
+  Buildchain Gate-profile, and controller entries structure-checked.
 - Buildchain owns runner allocation and aggregate checks; the standing patrol
   is pinned to the immutable `v2.12.4` release commit
   `a6145efc210a961da0e5c63d7024d42061550f60`. Buildchain cannot weaken a
@@ -99,13 +98,31 @@ The checker reconciles those facts in both directions:
 - duplicate ownership, missing execution, unknown or dynamic ids, and
   Gate/profile mismatches fail closed.
 
-`requiredSnippets` remains a temporary execution witness only for
-`execution: controller` bindings. Those controller entries are still checked
-forward in this phase; their structured adapters and reverse discovery are the
-next closure stage. Static workflow inspection proves the checked YAML shape,
-not the internals of an external reusable workflow. Immutable references,
-contract locks, source-bound receipts, and runtime receipts remain responsible
-for that cross-repository evidence.
+Controller bindings use one of three finite adapter kinds:
+
+| Binding | Adapter type | Structured identity |
+| --- | --- | --- |
+| `dev-source` | `buildchain-source` | Buildchain source reusable workflow plus `mode`, ref, and artifact inputs |
+| `all-pr-dco` | `dco-shell` | named run step, base/head environment, and bounded DCO failure-path tokens |
+| `channel-buildchain-config` | `buildchain-config` | Buildchain validation action plus version/lifecycle inputs |
+| `dev-external-links` | `external-links-action` | immutable Lychee action plus blocking inputs |
+| `channel-heavy-build` | `buildchain-heavy-build` | Buildchain build workflow plus runner, verify, publication, cache, and contract inputs |
+| `release-admission` | `buildchain-release-admission` | Buildchain promotion workflow plus dependency, artifact, passport, and publish inputs |
+
+The adapter identity is also the reverse-discovery key. Reusing a registered
+controller workflow, action, or named run-step elsewhere creates a fact that
+must receive its own binding. Removing the declared structure, changing a key
+input, registering overlapping ownership, or declaring a controller without an
+adapter fails closed. A genuinely new controller identity cannot be inferred
+from arbitrary YAML semantics: its first change must add one bounded adapter
+type, tests, Gate mapping, and retirement condition. If an entry can use a
+normal Shifu Gate or profile, it should do that instead of adding an adapter.
+
+There is no `requiredSnippets` execution proof in schema v2. Static workflow
+inspection proves the checked YAML shape, not the internals of an external
+reusable workflow or the runtime behavior of a shell body. Immutable
+references, contract locks, source-bound receipts, and runtime receipts remain
+responsible for that cross-repository evidence.
 
 ## Operator commands
 
@@ -129,13 +146,14 @@ the Buildchain orchestration stage registers their handlers.
 1. Change `shifu.gates.json` first.
 2. Update the gate's detailed section and workflow binding if reality changed.
 3. Declare the workflow/job execution in `workflow-bindings.json`; direct Gate
-   and profile ids must be statically recoverable from YAML.
+   and profile ids must be statically recoverable from YAML, while every
+   controller must declare one bounded adapter.
 4. Regenerate the matrix with the catalog checker write mode.
 5. Run `./shifu check:gate-catalog` and `./shifu check:source`.
 6. Treat policy-strength changes as rollout decisions, not documentation edits.
 
 The catalog meta gate checks schema and semantic validity, task existence,
 documentation anchors and required fields, the generated matrix bytes,
-structured direct workflow facts, temporary controller witnesses, and profile
-coverage. It proves structural consistency, not that a prose explanation is
-semantically wise.
+structured direct/profile/controller workflow facts, adapter uniqueness and
+input contracts, and profile coverage. It proves structural consistency, not
+that a prose explanation is semantically wise.

--- a/docs/qualification/gates/workflow-bindings.json
+++ b/docs/qualification/gates/workflow-bindings.json
@@ -15,10 +15,16 @@
         "source.acceptance"
       ],
       "activation": "dev pull request",
-      "requiredSnippets": [
-        "- dev/v*/v*",
-        "mode: source"
-      ]
+      "adapter": {
+        "type": "buildchain-source",
+        "kind": "job-uses",
+        "uses": "kungfu-systems/buildchain/.github/workflows/check.yml@v2-alpha",
+        "with": {
+          "buildchain-ref": "v2-alpha",
+          "mode": "source",
+          "upload-artifacts": true
+        }
+      }
     },
     {
       "id": "dev-adr",
@@ -32,9 +38,9 @@
         "governance.adr-delivery"
       ],
       "activation": "dev pull request",
-      "requiredSnippets": [
-        "./shifu gate run governance.adr-delivery"
-      ]
+      "invocation": {
+        "args": []
+      }
     },
     {
       "id": "dev-docs",
@@ -49,9 +55,9 @@
         "docs.prose"
       ],
       "activation": "dev pull request touching declared documentation paths",
-      "requiredSnippets": [
-        "./shifu gate run docs.prose"
-      ]
+      "invocation": {
+        "args": []
+      }
     },
     {
       "id": "all-pr-dco",
@@ -67,10 +73,22 @@
         "governance.dco"
       ],
       "activation": "all pull requests",
-      "requiredSnippets": [
-        "Missing DCO sign-off",
-        "Signed-off-by:"
-      ]
+      "adapter": {
+        "type": "dco-shell",
+        "kind": "run-step",
+        "name": "Check commit sign-offs",
+        "env": {
+          "BASE_SHA": "${{ github.event.pull_request.base.sha }}",
+          "HEAD_SHA": "${{ github.event.pull_request.head.sha }}"
+        },
+        "runContains": [
+          "git rev-list",
+          "--format=%B",
+          "^Signed-off-by:",
+          "missing=1",
+          "exit 1"
+        ]
+      }
     },
     {
       "id": "channel-buildchain-config",
@@ -86,9 +104,16 @@
         "governance.buildchain-config"
       ],
       "activation": "pull request or channel push",
-      "requiredSnippets": [
-        "require-lifecycle-stages: \"install,check,build,verify\""
-      ]
+      "adapter": {
+        "type": "buildchain-config",
+        "kind": "step-uses",
+        "uses": "kungfu-systems/buildchain/actions/validate-config@v2",
+        "name": "Validate .buildchain/buildchain.toml",
+        "with": {
+          "require-version-state": "true",
+          "require-lifecycle-stages": "install,check,build,verify"
+        }
+      }
     },
     {
       "id": "channel-promotion-rehearsal",
@@ -104,9 +129,9 @@
         "governance.promotion-rehearsal"
       ],
       "activation": "pull request or channel push",
-      "requiredSnippets": [
-        "./shifu gate run governance.promotion-rehearsal"
-      ]
+      "invocation": {
+        "args": []
+      }
     },
     {
       "id": "shifu-workspace",
@@ -122,12 +147,12 @@
         "shifu.workspace"
       ],
       "activation": "channel pull request touching crates/**",
-      "requiredSnippets": [
-        "macos-14",
-        "ubuntu-22.04",
-        "windows-2022",
-        "./shifu gate run shifu.workspace"
-      ]
+      "invocation": {
+        "args": [
+          "--capability",
+          "rust"
+        ]
+      }
     },
     {
       "id": "dev-heavy-patrol",
@@ -144,12 +169,14 @@
         "product.verify-full"
       ],
       "activation": "daily or manual on dev",
-      "requiredSnippets": [
-        "gate-profile: dev-patrol",
-        "runner-preset: kungfu-v4-self-hosted",
-        "{\"linux\":[\"./shifu\"],\"macos\":[\"./shifu\"],\"windows\":[\"./shifu.cmd\"]}",
-        ".github/workflows/.gate-profile.yml@a6145efc210a961da0e5c63d7024d42061550f60"
-      ]
+      "invocation": {
+        "uses": "kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@a6145efc210a961da0e5c63d7024d42061550f60",
+        "with": {
+          "gate-profile": "dev-patrol",
+          "runner-preset": "kungfu-v4-self-hosted",
+          "gate-command-json": "{\"linux\":[\"./shifu\"],\"macos\":[\"./shifu\"],\"windows\":[\"./shifu.cmd\"]}"
+        }
+      }
     },
     {
       "id": "dev-external-links",
@@ -164,10 +191,20 @@
         "docs.external-links"
       ],
       "activation": "daily or manual",
-      "requiredSnippets": [
-        "lycheeverse/lychee-action",
-        "failIfEmpty: true"
-      ]
+      "adapter": {
+        "type": "external-links-action",
+        "kind": "step-uses",
+        "uses": "lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8",
+        "name": "Check external links",
+        "with": {
+          "args": "--config lychee.toml --no-progress './**/*.md'",
+          "fail": true,
+          "failIfEmpty": true,
+          "format": "markdown",
+          "jobSummary": true,
+          "lycheeVersion": "v0.24.2"
+        }
+      }
     },
     {
       "id": "channel-heavy-build",
@@ -191,12 +228,27 @@
         "episode.release"
       ],
       "activation": "alpha or release pull request",
-      "requiredSnippets": [
-        "runner-preset: ${{ inputs.platforms-json && 'custom' || 'kungfu-v4-self-hosted' }}",
-        "verify-command: node scripts/run-release-qualification.mjs",
-        "publish-channel: ${{ github.event_name == 'pull_request' && (startsWith(github.base_ref, 'release/') && 'release' || 'alpha') || 'none' }}",
-        "docs/shifu/qualification-portable-off.cache-profile.json"
-      ]
+      "adapter": {
+        "type": "buildchain-heavy-build",
+        "kind": "job-uses",
+        "uses": "kungfu-systems/buildchain/.github/workflows/.build.yml@v2-alpha",
+        "job": {
+          "secrets": "inherit"
+        },
+        "with": {
+          "runner-preset": "${{ inputs.platforms-json && 'custom' || 'kungfu-v4-self-hosted' }}",
+          "require-install": true,
+          "require-build": true,
+          "require-verify": true,
+          "verify-command": "node scripts/run-release-qualification.mjs",
+          "release-candidate": true,
+          "publish-channel": "${{ github.event_name == 'pull_request' && (startsWith(github.base_ref, 'release/') && 'release' || 'alpha') || 'none' }}",
+          "artifact-transfer-mode": "s3-to-github-artifacts",
+          "shifu-cache-profile-ref": "${{ inputs.platforms-json && 'docs/shifu/qualification-portable-off.cache-profile.json' || vars.SHIFU_CACHE_PROFILE_REF }}",
+          "buildchain-contract-lock-path": ".buildchain/contract-lock.json",
+          "buildchain-contract-compatibility-policy": "major-compatible"
+        }
+      }
     },
     {
       "id": "channel-membranes",
@@ -211,12 +263,14 @@
         "embedding.membranes"
       ],
       "activation": "same-repo channel PR touching membrane paths",
-      "requiredSnippets": [
-        "Linux x64",
-        "macOS ARM64",
-        "Windows x64",
-        "./shifu gate run embedding.membranes"
-      ]
+      "invocation": {
+        "args": [
+          "--capability",
+          "native-toolchain",
+          "--capability",
+          "rust"
+        ]
+      }
     },
     {
       "id": "release-rehearsal",
@@ -231,9 +285,9 @@
         "governance.promotion-rehearsal"
       ],
       "activation": "merged alpha or release pull request",
-      "requiredSnippets": [
-        "./shifu gate run governance.promotion-rehearsal"
-      ]
+      "invocation": {
+        "args": []
+      }
     },
     {
       "id": "release-admission",
@@ -248,11 +302,24 @@
         "release.artifact-admission"
       ],
       "activation": "merged alpha or release pull request",
-      "requiredSnippets": [
-        "required-status-check: build",
-        "required-artifact-count: 3",
-        "release-passport: true"
-      ]
+      "adapter": {
+        "type": "buildchain-release-admission",
+        "kind": "job-uses",
+        "uses": "kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@v2",
+        "job": {
+          "needs": "promotion-contract",
+          "if": "${{ github.event.pull_request.merged == true }}"
+        },
+        "with": {
+          "channel": "${{ startsWith(github.event.pull_request.base.ref, 'alpha/') && 'alpha' || 'release' }}",
+          "target-sha": "${{ github.event.pull_request.merge_commit_sha || github.sha }}",
+          "required-status-check": "build",
+          "publish-command": "node scripts/buildchain-custom-publish-evidence.mjs",
+          "runner-preset": "kungfu-v4-self-hosted",
+          "required-artifact-count": 3,
+          "release-passport": true
+        }
+      }
     },
     {
       "id": "layer-publication-verdict",
@@ -266,11 +333,15 @@
         "layers.release"
       ],
       "activation": "manually executed public layer publication",
-      "requiredSnippets": [
-        "./shifu gate run layers.release",
-        "--capability publication-evidence",
-        "product/release/qualification/layer-publication-gate-receipt.json"
-      ]
+      "invocation": {
+        "args": [
+          "--capability",
+          "publication-evidence",
+          "--receipt",
+          "product/release/qualification/layer-publication-gate-receipt.json",
+          "--overwrite"
+        ]
+      }
     }
   ]
 }

--- a/scripts/check-kungfu-gate-catalog.mjs
+++ b/scripts/check-kungfu-gate-catalog.mjs
@@ -5,6 +5,11 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
+import { isDeepStrictEqual } from 'node:util';
+import {
+  controllerAdapterMismatches,
+  validateControllerAdapters,
+} from './kungfu-gate-controller-adapters.mjs';
 import { scanWorkflowInvocations } from './kungfu-gate-workflow-facts.mjs';
 import { validateGateRegistry } from './shifu-gate-runtime.mjs';
 
@@ -30,6 +35,31 @@ const REQUIRED_DOC_FIELDS = [
 
 function readJson(root, relative) {
   return JSON.parse(fs.readFileSync(path.join(root, relative), 'utf8'));
+}
+
+function objectFieldDrift(actual, expected, prefix) {
+  const drift = [];
+  for (const [key, value] of Object.entries(expected || {})) {
+    if (!isDeepStrictEqual(actual?.[key], value))
+      drift.push(`${prefix}.${key}`);
+  }
+  return drift;
+}
+
+function invocationDrift(fact, binding) {
+  const invocation = binding.invocation || {};
+  if (fact.execution === 'gate') {
+    return isDeepStrictEqual(fact.args, invocation.args || []) ? [] : ['args'];
+  }
+  if (fact.execution === 'profile') {
+    const drift = [];
+    if (fact._actual?.uses !== invocation.uses) drift.push('uses');
+    drift.push(
+      ...objectFieldDrift(fact._actual?.with, invocation.with, 'with'),
+    );
+    return drift;
+  }
+  return [];
 }
 
 function gateActionLine(gate) {
@@ -193,10 +223,39 @@ export function checkKungfuGateCatalog(root = ROOT) {
     if (!binding.job || !binding.activation) {
       issues.push(`[workflow] ${binding.id}: job and activation are required`);
     }
+    if (Object.hasOwn(binding, 'requiredSnippets')) {
+      issues.push(
+        `[workflow] ${binding.id}: requiredSnippets is not an execution proof in schema v2`,
+      );
+    }
     if (!['gate', 'profile', 'controller'].includes(binding.execution)) {
       issues.push(
         `[workflow] ${binding.id}: execution must be 'gate', 'profile', or 'controller'`,
       );
+    }
+    if (binding.execution === 'gate') {
+      if (
+        !binding.invocation ||
+        !Array.isArray(binding.invocation.args) ||
+        binding.invocation.args.some((item) => typeof item !== 'string')
+      ) {
+        issues.push(
+          `[workflow] ${binding.id}: gate invocation.args must be a string array`,
+        );
+      }
+    }
+    if (binding.execution === 'profile') {
+      if (
+        typeof binding.invocation?.uses !== 'string' ||
+        binding.invocation.uses.includes('${{') ||
+        !binding.invocation?.with ||
+        typeof binding.invocation.with !== 'object' ||
+        Array.isArray(binding.invocation.with)
+      ) {
+        issues.push(
+          `[workflow] ${binding.id}: profile invocation requires static uses and with object`,
+        );
+      }
     }
     if (!binding.profiles?.length || !binding.gates?.length) {
       issues.push(
@@ -234,38 +293,17 @@ export function checkKungfuGateCatalog(root = ROOT) {
       issues.push(`[workflow] ${binding.id}: unsafe workflow path`);
       continue;
     }
-    if (
-      binding.execution === 'controller' &&
-      (!binding.requiredSnippets?.length ||
-        binding.requiredSnippets.some(
-          (snippet) => typeof snippet !== 'string' || snippet.length === 0,
-        ))
-    ) {
-      issues.push(
-        `[workflow] ${binding.id}: controller requiredSnippets must contain non-empty strings`,
-      );
-    }
     const workflow = path.join(root, workflowRelative);
     if (!fs.existsSync(workflow)) {
       issues.push(`[workflow] ${binding.id}: missing ${binding.workflow}`);
-      continue;
-    }
-    if (binding.execution === 'controller') {
-      const workflowText = fs.readFileSync(workflow, 'utf8');
-      for (const snippet of binding.requiredSnippets || []) {
-        if (!workflowText.includes(snippet)) {
-          issues.push(
-            `[workflow] ${binding.id}: '${snippet}' not found in ${binding.workflow}`,
-          );
-        }
-      }
     }
   }
 
-  const workflowScan = scanWorkflowInvocations(root, registry);
+  issues.push(...validateControllerAdapters(bindings));
+  const workflowScan = scanWorkflowInvocations(root, registry, bindings);
   issues.push(...workflowScan.issues);
   const structuredBindings = bindings.filter((binding) =>
-    ['gate', 'profile'].includes(binding.execution),
+    ['gate', 'profile', 'controller'].includes(binding.execution),
   );
   const factsByBinding = new Map(
     structuredBindings.map((binding) => [binding.id, []]),
@@ -279,16 +317,48 @@ export function checkKungfuGateCatalog(root = ROOT) {
     );
     const matches = locationBindings.filter((binding) => {
       if (fact.execution === 'gate') {
-        return binding.gates?.includes(fact.gates[0]);
+        return (
+          binding.gates?.includes(fact.gates[0]) &&
+          invocationDrift(fact, binding).length === 0
+        );
+      }
+      if (fact.execution === 'controller') {
+        return controllerAdapterMismatches(fact, binding).length === 0;
       }
       return (
         binding.profiles?.length === 1 &&
         binding.profiles[0] === fact.profile &&
-        [...(binding.gates || [])].sort().join('\0') === fact.gates.join('\0')
+        [...(binding.gates || [])].sort().join('\0') ===
+          fact.gates.join('\0') &&
+        invocationDrift(fact, binding).length === 0
       );
     });
-    const label = `${fact.workflow}#${fact.job}:${fact.profile || fact.gates[0]}`;
+    const invocation =
+      fact.profile ||
+      fact.gates[0] ||
+      `${fact.controller?.kind}:${fact.controller?.identity}`;
+    const label = `${fact.workflow}#${fact.job}:${invocation}`;
     if (matches.length === 0) {
+      if (fact.execution === 'gate' || fact.execution === 'profile') {
+        for (const binding of locationBindings) {
+          const drift = invocationDrift(fact, binding);
+          if (drift.length) {
+            issues.push(
+              `[workflow-${fact.execution}] ${binding.id}: invocation drift at ${drift.join(', ')}`,
+            );
+          }
+        }
+      }
+      if (fact.execution === 'controller') {
+        for (const binding of locationBindings) {
+          const drift = controllerAdapterMismatches(fact, binding);
+          if (drift.length) {
+            issues.push(
+              `[workflow-controller] ${binding.id}: adapter input drift at ${drift.join(', ')}`,
+            );
+          }
+        }
+      }
       issues.push(
         `[workflow-fact] ${label}: invocation has no matching binding`,
       );
@@ -297,6 +367,9 @@ export function checkKungfuGateCatalog(root = ROOT) {
         `[workflow-fact] ${label}: invocation matches multiple bindings (${matches.map((binding) => binding.id).join(', ')})`,
       );
     } else {
+      if (fact.execution === 'controller') {
+        fact.gates = [...(matches[0].gates || [])].sort();
+      }
       factsByBinding.get(matches[0].id).push(fact);
     }
   }
@@ -328,6 +401,10 @@ export function checkKungfuGateCatalog(root = ROOT) {
           `[workflow-fact] ${binding.id}: direct Gate entries are [${actual.join(', ')}], expected [${expected.join(', ')}]`,
         );
       }
+    } else if (binding.execution === 'controller' && facts.length !== 1) {
+      issues.push(
+        `[workflow-controller] ${binding.id}: expected one controller invocation, found ${facts.length}`,
+      );
     }
   }
   for (const profile of registry.profiles) {

--- a/scripts/check-kungfu-gate-catalog.test.mjs
+++ b/scripts/check-kungfu-gate-catalog.test.mjs
@@ -62,6 +62,11 @@ test('current Kungfu catalog, docs, matrix, actions, and workflows align', () =>
     ).length,
     2,
   );
+  const controllers = result.workflowFacts.filter(
+    (fact) => fact.execution === 'controller',
+  );
+  assert.equal(controllers.length, 6);
+  assert.ok(controllers.every((fact) => fact.gates.length > 0));
 });
 
 test('matrix rendering is deterministic and includes every profile', () => {
@@ -109,7 +114,7 @@ test('matrix, gate document, and workflow drift each fail closed', () => {
   );
   assert.ok(
     checkKungfuGateCatalog(root).issues.some((issue) =>
-      issue.includes("'mode: source' not found"),
+      issue.includes('dev-source: adapter input drift at with.mode'),
     ),
   );
 
@@ -186,7 +191,156 @@ test('document facts and workflow entrypoints fail closed', () => {
   );
   assert.ok(
     checkKungfuGateCatalog(controllerRoot).issues.some((issue) =>
-      issue.includes("dev-source: 'mode: source' not found"),
+      issue.includes('dev-source: adapter input drift at with.mode'),
+    ),
+  );
+});
+
+test('every controller class has a structured adapter and input drift fails closed', () => {
+  const cases = [
+    {
+      id: 'dev-source',
+      workflow: '.github/workflows/source-acceptance.yml',
+      from: 'mode: source',
+      to: 'mode: ${{ inputs.mode }}',
+      drift: 'with.mode',
+    },
+    {
+      id: 'all-pr-dco',
+      workflow: '.github/workflows/dco.yml',
+      from: 'BASE_SHA:',
+      to: 'OLD_BASE_SHA:',
+      drift: 'env.BASE_SHA',
+    },
+    {
+      id: 'channel-buildchain-config',
+      workflow: '.github/workflows/buildchain-validate.yml',
+      from: 'require-lifecycle-stages: "install,check,build,verify"',
+      to: 'require-lifecycle-stages: "install,check"',
+      drift: 'with.require-lifecycle-stages',
+    },
+    {
+      id: 'dev-external-links',
+      workflow: '.github/workflows/docs-external-links.yml',
+      from: 'failIfEmpty: true',
+      to: 'failIfEmpty: false',
+      drift: 'with.failIfEmpty',
+    },
+    {
+      id: 'channel-heavy-build',
+      workflow: '.github/workflows/build.yml',
+      from: 'verify-command: node scripts/run-release-qualification.mjs',
+      to: 'verify-command: ./shifu verify',
+      drift: 'with.verify-command',
+    },
+    {
+      id: 'release-admission',
+      workflow: '.github/workflows/release-new-version.yml',
+      from: 'required-artifact-count: 3',
+      to: 'required-artifact-count: 2',
+      drift: 'with.required-artifact-count',
+    },
+  ];
+  for (const item of cases) {
+    const root = fixture();
+    const workflow = path.join(root, item.workflow);
+    fs.writeFileSync(
+      workflow,
+      fs.readFileSync(workflow, 'utf8').replace(item.from, item.to),
+    );
+    assert.ok(
+      checkKungfuGateCatalog(root).issues.some((issue) =>
+        issue.includes(
+          `[workflow-controller] ${item.id}: adapter input drift at ${item.drift}`,
+        ),
+      ),
+      item.id,
+    );
+  }
+});
+
+test('rogue, duplicate, missing, and invalid controller adapters fail closed', () => {
+  const rogueRoot = fixture();
+  fs.writeFileSync(
+    path.join(rogueRoot, '.github/workflows/rogue-controller.yml'),
+    'name: Rogue controller\njobs:\n  source-copy:\n    uses: kungfu-systems/buildchain/.github/workflows/check.yml@v2-alpha\n    with:\n      buildchain-ref: v2-alpha\n      mode: source\n      upload-artifacts: true\n',
+  );
+  assert.ok(
+    checkKungfuGateCatalog(rogueRoot).issues.some((issue) =>
+      issue.includes(
+        '.github/workflows/rogue-controller.yml#source-copy:job-uses:kungfu-systems/buildchain/.github/workflows/check.yml@v2-alpha: invocation has no matching binding',
+      ),
+    ),
+  );
+
+  const duplicateRoot = fixture();
+  const duplicateWorkflow = path.join(
+    duplicateRoot,
+    '.github/workflows/buildchain-validate.yml',
+  );
+  fs.writeFileSync(
+    duplicateWorkflow,
+    fs
+      .readFileSync(duplicateWorkflow, 'utf8')
+      .replace(
+        '      - name: Validate .buildchain/buildchain.toml',
+        '      - name: Validate .buildchain/buildchain.toml\n        uses: kungfu-systems/buildchain/actions/validate-config@v2\n        with:\n          require-version-state: "true"\n          require-lifecycle-stages: "install,check,build,verify"\n      - name: Validate .buildchain/buildchain.toml',
+      ),
+  );
+  assert.ok(
+    checkKungfuGateCatalog(duplicateRoot).issues.some((issue) =>
+      issue.includes(
+        'channel-buildchain-config: expected one controller invocation, found 2',
+      ),
+    ),
+  );
+
+  const missingRoot = fixture();
+  const missingWorkflow = path.join(missingRoot, '.github/workflows/dco.yml');
+  fs.writeFileSync(
+    missingWorkflow,
+    fs
+      .readFileSync(missingWorkflow, 'utf8')
+      .replace(
+        'name: Check commit sign-offs',
+        'name: Unregistered shell check',
+      ),
+  );
+  assert.ok(
+    checkKungfuGateCatalog(missingRoot).issues.some((issue) =>
+      issue.includes('all-pr-dco: no structured controller invocation'),
+    ),
+  );
+
+  const commentRoot = fixture();
+  const commentWorkflow = path.join(commentRoot, '.github/workflows/dco.yml');
+  fs.writeFileSync(
+    commentWorkflow,
+    fs
+      .readFileSync(commentWorkflow, 'utf8')
+      .replace(
+        '          commits="$(git rev-list "${BASE_SHA}..${HEAD_SHA}")"',
+        '          # commits="$(git rev-list "${BASE_SHA}..${HEAD_SHA}")"',
+      ),
+  );
+  assert.ok(
+    checkKungfuGateCatalog(commentRoot).issues.some((issue) =>
+      issue.includes('all-pr-dco: adapter input drift at run:git rev-list'),
+    ),
+  );
+
+  const invalidRoot = fixture();
+  const bindingsPath = path.join(
+    invalidRoot,
+    'docs/qualification/gates/workflow-bindings.json',
+  );
+  const bindings = JSON.parse(fs.readFileSync(bindingsPath, 'utf8'));
+  bindings.bindings.find((binding) => binding.id === 'dev-source').adapter =
+    undefined;
+  fs.writeFileSync(bindingsPath, JSON.stringify(bindings));
+  assert.ok(
+    checkKungfuGateCatalog(invalidRoot).issues.some((issue) =>
+      issue.includes('dev-source: adapter object is required'),
     ),
   );
 });
@@ -222,6 +376,110 @@ test('direct Gate invocations are discovered from YAML and must have one binding
     checkKungfuGateCatalog(duplicateRoot).issues.some((issue) =>
       issue.includes(
         'invocation matches multiple bindings (dev-adr, dev-adr-duplicate)',
+      ),
+    ),
+  );
+});
+
+test('direct Gate arguments and profile inputs fail closed on drift', () => {
+  const gateRoot = fixture();
+  const gateWorkflow = path.join(gateRoot, '.github/workflows/shifu-ci.yml');
+  fs.writeFileSync(
+    gateWorkflow,
+    fs
+      .readFileSync(gateWorkflow, 'utf8')
+      .replaceAll('--capability rust', '--capability node'),
+  );
+  assert.ok(
+    checkKungfuGateCatalog(gateRoot).issues.some((issue) =>
+      issue.includes(
+        '[workflow-gate] shifu-workspace: invocation drift at args',
+      ),
+    ),
+  );
+
+  const profileRefRoot = fixture();
+  const profileRefWorkflow = path.join(
+    profileRefRoot,
+    '.github/workflows/dev-verify-patrol.yml',
+  );
+  fs.writeFileSync(
+    profileRefWorkflow,
+    fs
+      .readFileSync(profileRefWorkflow, 'utf8')
+      .replace(
+        '.gate-profile.yml@a6145efc210a961da0e5c63d7024d42061550f60',
+        '.gate-profile.yml@v2-alpha',
+      ),
+  );
+  assert.ok(
+    checkKungfuGateCatalog(profileRefRoot).issues.some((issue) =>
+      issue.includes(
+        '[workflow-profile] dev-heavy-patrol: invocation drift at uses',
+      ),
+    ),
+  );
+
+  const profileInputRoot = fixture();
+  const profileInputWorkflow = path.join(
+    profileInputRoot,
+    '.github/workflows/dev-verify-patrol.yml',
+  );
+  fs.writeFileSync(
+    profileInputWorkflow,
+    fs
+      .readFileSync(profileInputWorkflow, 'utf8')
+      .replace(
+        'runner-preset: kungfu-v4-self-hosted',
+        'runner-preset: portable',
+      ),
+  );
+  assert.ok(
+    checkKungfuGateCatalog(profileInputRoot).issues.some((issue) =>
+      issue.includes(
+        '[workflow-profile] dev-heavy-patrol: invocation drift at with.runner-preset',
+      ),
+    ),
+  );
+});
+
+test('schema v2 rejects missing invocation contracts and legacy snippets', () => {
+  const root = fixture();
+  const bindingsPath = path.join(
+    root,
+    'docs/qualification/gates/workflow-bindings.json',
+  );
+  const bindings = JSON.parse(fs.readFileSync(bindingsPath, 'utf8'));
+  const gateBinding = bindings.bindings.find(
+    (binding) => binding.id === 'dev-adr',
+  );
+  gateBinding.invocation = undefined;
+  const profileBinding = bindings.bindings.find(
+    (binding) => binding.id === 'dev-heavy-patrol',
+  );
+  profileBinding.invocation = undefined;
+  bindings.bindings.find(
+    (binding) => binding.id === 'channel-heavy-build',
+  ).requiredSnippets = ['verify-command:'];
+  fs.writeFileSync(bindingsPath, JSON.stringify(bindings));
+
+  const issues = checkKungfuGateCatalog(root).issues;
+  assert.ok(
+    issues.some((issue) =>
+      issue.includes('dev-adr: gate invocation.args must be a string array'),
+    ),
+  );
+  assert.ok(
+    issues.some((issue) =>
+      issue.includes(
+        'dev-heavy-patrol: profile invocation requires static uses and with object',
+      ),
+    ),
+  );
+  assert.ok(
+    issues.some((issue) =>
+      issue.includes(
+        'channel-heavy-build: requiredSnippets is not an execution proof in schema v2',
       ),
     ),
   );

--- a/scripts/kungfu-gate-controller-adapters.mjs
+++ b/scripts/kungfu-gate-controller-adapters.mjs
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: Apache-2.0
+// @ts-check
+
+import { isDeepStrictEqual } from 'node:util';
+
+const COMMON_FIELDS = new Set(['type', 'kind']);
+const KIND_FIELDS = {
+  'job-uses': new Set(['uses', 'job', 'with']),
+  'step-uses': new Set(['uses', 'name', 'with']),
+  'run-step': new Set(['name', 'env', 'runContains']),
+};
+
+function isObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+export function controllerAdapterIdentity(adapter) {
+  if (!isObject(adapter) || !KIND_FIELDS[adapter.kind]) return null;
+  const value = adapter.kind === 'run-step' ? adapter.name : adapter.uses;
+  return typeof value === 'string' && value
+    ? `${adapter.kind}\0${value}`
+    : null;
+}
+
+export function validateControllerAdapters(bindings) {
+  const issues = [];
+  const types = new Set();
+  for (const binding of bindings.filter(
+    (item) => item.execution === 'controller',
+  )) {
+    const adapter = binding.adapter;
+    const prefix = `[workflow-adapter] ${binding.id}`;
+    if (!isObject(adapter)) {
+      issues.push(`${prefix}: adapter object is required`);
+      continue;
+    }
+    if (
+      typeof adapter.type !== 'string' ||
+      !/^[a-z0-9][a-z0-9.-]*$/.test(adapter.type)
+    ) {
+      issues.push(`${prefix}: adapter.type must be a static id`);
+    } else if (types.has(adapter.type)) {
+      issues.push(`${prefix}: duplicate adapter type '${adapter.type}'`);
+    } else {
+      types.add(adapter.type);
+    }
+    const fields = KIND_FIELDS[adapter.kind];
+    if (!fields) {
+      issues.push(`${prefix}: unsupported adapter kind '${adapter.kind}'`);
+      continue;
+    }
+    for (const field of Object.keys(adapter)) {
+      if (!COMMON_FIELDS.has(field) && !fields.has(field)) {
+        issues.push(`${prefix}: unsupported adapter field '${field}'`);
+      }
+    }
+    const identity = controllerAdapterIdentity(adapter);
+    if (!identity || identity.includes('${{')) {
+      issues.push(`${prefix}: adapter identity must be static`);
+    }
+    if (adapter.job !== undefined && !isObject(adapter.job)) {
+      issues.push(`${prefix}: adapter.job must be an object`);
+    }
+    if (adapter.with !== undefined && !isObject(adapter.with)) {
+      issues.push(`${prefix}: adapter.with must be an object`);
+    }
+    if (
+      adapter.kind === 'run-step' &&
+      (!isObject(adapter.env) || !Object.keys(adapter.env).length)
+    ) {
+      issues.push(`${prefix}: run-step env must be a non-empty object`);
+    }
+    if (
+      adapter.kind === 'run-step' &&
+      (!Array.isArray(adapter.runContains) || !adapter.runContains.length)
+    ) {
+      issues.push(`${prefix}: run-step runContains must be non-empty`);
+    }
+    for (const [field, values] of [['runContains', adapter.runContains]]) {
+      if (
+        values !== undefined &&
+        (!Array.isArray(values) ||
+          values.some((value) => typeof value !== 'string' || !value))
+      ) {
+        issues.push(`${prefix}: ${field} must contain non-empty strings`);
+      }
+    }
+  }
+  return issues;
+}
+
+function uniqueIdentities(bindings) {
+  const identities = new Map();
+  for (const binding of bindings) {
+    if (binding.execution !== 'controller') continue;
+    const identity = controllerAdapterIdentity(binding.adapter);
+    if (!identity || identities.has(identity)) continue;
+    identities.set(identity, binding.adapter);
+  }
+  return [...identities.values()];
+}
+
+function controllerFact(workflow, job, source, adapter, actual, jobNode) {
+  return {
+    workflow,
+    job,
+    execution: 'controller',
+    profile: null,
+    gates: [],
+    source,
+    controller: {
+      kind: adapter.kind,
+      identity: adapter.kind === 'run-step' ? adapter.name : adapter.uses,
+    },
+    _actual: actual,
+    _job: jobNode,
+  };
+}
+
+export function controllerFactsForJob(workflow, jobId, job, bindings) {
+  const facts = [];
+  for (const adapter of uniqueIdentities(bindings)) {
+    if (adapter.kind === 'job-uses' && job.uses === adapter.uses) {
+      facts.push(controllerFact(workflow, jobId, 'uses', adapter, job, job));
+    }
+    const steps = Array.isArray(job.steps) ? job.steps : [];
+    for (const [stepIndex, step] of steps.entries()) {
+      if (!step || typeof step !== 'object') continue;
+      if (adapter.kind === 'step-uses' && step.uses === adapter.uses) {
+        facts.push(
+          controllerFact(
+            workflow,
+            jobId,
+            `steps[${stepIndex}].uses`,
+            adapter,
+            step,
+            job,
+          ),
+        );
+      }
+      if (
+        adapter.kind === 'run-step' &&
+        step.name === adapter.name &&
+        typeof step.run === 'string'
+      ) {
+        facts.push(
+          controllerFact(
+            workflow,
+            jobId,
+            `steps[${stepIndex}].run`,
+            adapter,
+            step,
+            job,
+          ),
+        );
+      }
+    }
+  }
+  return facts;
+}
+
+function objectMismatches(actual, expected, prefix) {
+  const issues = [];
+  for (const [key, value] of Object.entries(expected || {})) {
+    if (!isDeepStrictEqual(actual?.[key], value)) {
+      issues.push(`${prefix}.${key}`);
+    }
+  }
+  return issues;
+}
+
+export function controllerAdapterMismatches(fact, binding) {
+  const adapter = binding.adapter || {};
+  const identity = controllerAdapterIdentity(adapter);
+  if (!identity) return ['adapter identity'];
+  const factIdentity = `${fact.controller?.kind}\0${fact.controller?.identity}`;
+  if (factIdentity !== identity) return ['adapter identity'];
+  const issues = [];
+  if (adapter.kind === 'job-uses') {
+    issues.push(...objectMismatches(fact._actual, adapter.job, 'job'));
+    issues.push(...objectMismatches(fact._actual?.with, adapter.with, 'with'));
+  } else if (adapter.kind === 'step-uses') {
+    if (adapter.name !== undefined && fact._actual?.name !== adapter.name) {
+      issues.push('step.name');
+    }
+    issues.push(...objectMismatches(fact._actual?.with, adapter.with, 'with'));
+  } else if (adapter.kind === 'run-step') {
+    issues.push(...objectMismatches(fact._actual?.env, adapter.env, 'env'));
+    const executableRun = String(fact._actual?.run || '')
+      .split(/\r?\n/)
+      .filter((line) => !line.trimStart().startsWith('#'))
+      .join('\n');
+    for (const token of adapter.runContains || []) {
+      if (!executableRun.includes(token)) {
+        issues.push(`run:${token}`);
+      }
+    }
+  }
+  return issues;
+}

--- a/scripts/kungfu-gate-workflow-facts.mjs
+++ b/scripts/kungfu-gate-workflow-facts.mjs
@@ -4,11 +4,12 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { parseDocument } from 'yaml';
+import { controllerFactsForJob } from './kungfu-gate-controller-adapters.mjs';
 
 const WORKFLOW_ROOT = '.github/workflows';
 const GATE_PROFILE_WORKFLOW = '/.github/workflows/.gate-profile.yml@';
 const GATE_COMMAND =
-  /(?:^|[\n;]|&&|\|\|)\s*(\.\/shifu|\.\\shifu\.cmd)\s+gate\s+run(?:\s+("[^"]*"|'[^']*'|[^\s;&|]+))?/g;
+  /(?:^|[\n;]|&&|\|\|)\s*(\.\/shifu|\.\\shifu\.cmd)\s+gate\s+run(?:\s+("[^"]*"|'[^']*'|[^\s;&|]+))?([^\n;]*?)(?=$|\n|;|&&|\|\|)/g;
 
 function workflowFiles(root) {
   const directory = path.join(root, WORKFLOW_ROOT);
@@ -44,6 +45,12 @@ function commandText(run) {
     .replace(/`\r?\n\s*/g, ' ');
 }
 
+function shellWords(value) {
+  return [...value.matchAll(/"([^"]*)"|'([^']*)'|([^\s]+)/g)].map(
+    (match) => match[1] ?? match[2] ?? match[3],
+  );
+}
+
 function directGateFacts(workflow, jobId, steps, gateIds, issues) {
   const facts = [];
   for (const [stepIndex, step] of steps.entries()) {
@@ -71,6 +78,7 @@ function directGateFacts(workflow, jobId, steps, gateIds, issues) {
         execution: 'gate',
         profile: null,
         gates: [gate],
+        args: shellWords(match[3] || ''),
         source: `steps[${stepIndex}].run`,
       });
     }
@@ -111,10 +119,11 @@ function profileFact(workflow, jobId, job, profilesById, issues) {
     profile,
     gates,
     source: 'uses.with.gate-profile',
+    _actual: job,
   };
 }
 
-export function scanWorkflowInvocations(root, registry) {
+export function scanWorkflowInvocations(root, registry, bindings = []) {
   const issues = [];
   const facts = [];
   const gateIds = new Set(registry.gates.map((gate) => gate.id));
@@ -142,6 +151,7 @@ export function scanWorkflowInvocations(root, registry) {
       }
       const reusable = profileFact(workflow, jobId, job, profilesById, issues);
       if (reusable) facts.push(reusable);
+      facts.push(...controllerFactsForJob(workflow, jobId, job, bindings));
     }
   }
   facts.sort((left, right) =>


### PR DESCRIPTION
## Summary

Close Kungfu workflow-to-Gate policy drift in both directions for direct Gate calls, Buildchain Gate profiles, and the six remaining controller classes.

## Related issue

Atlas goal 2026-07-14-kungfu-gate-controller-reverse-scan.

## Changes

- replace legacy requiredSnippets witnesses with finite structured controller adapters
- reverse-discover registered controller identities across workflow YAML
- bind direct Gate arguments and profile refs/inputs to declared invocation contracts
- fail closed on missing, duplicate, rogue, or input-drifted workflow facts
- document the adapter boundary and extension/retirement rule

## Verification

- ./shifu fix
- ./shifu check:gate-catalog
- ./shifu check:source (124 tests)
- ./shifu check

## KFD-1 version impact

Patch. This strengthens a Kungfu repository checker without changing a registered public contract or opening a version line.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This patch strengthens repository-local Gate workflow drift enforcement without changing an architecture contract"
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

Boundary: workflow admission semantics only; validation is source-static and does not publish or deploy artifacts.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed