### PR TITLE
docs(layers): link release Gate policy path

### DIFF
--- a/docs/concepts/product-layers.md
+++ b/docs/concepts/product-layers.md
@@ -48,6 +48,13 @@ compatibility remain separate release claims. See the
 [layer-complete release qualification contract](../qualification/layer-product-release-qualification.md)
 for the exact evidence chain and current boundary.
 
+For the shortest audit path from the seven release rows to executable policy,
+follow the [layer-complete qualification contract](../qualification/layer-product-release-qualification.md)
+to the [Kungfu Gate catalog](../qualification/gates/README.md) and its
+[generated policy matrix](../qualification/gates/policy-matrix.md). The matrix
+shows which `layers.*` Gates are required, advisory, or off in each profile;
+[`shifu.gates.json`](../../shifu.gates.json) remains the machine source of truth.
+
 ## The rule behind the choices
 
 ```text


### PR DESCRIPTION
## Summary

Link Product Layers directly to the seven-row qualification contract, Gate catalog, generated policy matrix, and machine source of truth.

## Verification

- `./shifu docs:check`
- staged pre-commit gate

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Documentation-only navigation change; it does not alter an architecture contract or Gate policy."
}
-->