### PR TITLE
fix(gui): preserve node-pty spawn helper mode

### DIFF
--- a/framework/gui/scripts/after-pack.cjs
+++ b/framework/gui/scripts/after-pack.cjs
@@ -4,9 +4,14 @@
 const {
   auditPackagedApp,
   findAppFromContext,
+  repairNodePtySpawnHelpers,
 } = require('./bundle-core-audit.cjs');
 
 exports.default = async function afterPack(context) {
   if (context.electronPlatformName !== 'darwin') return;
-  auditPackagedApp(findAppFromContext(context), { prune: true });
+  const appDir = findAppFromContext(context);
+  // electron-builder can copy node-pty's native helper without its executable
+  // bit. The addon then fails every PTY launch with only "posix_spawnp failed".
+  repairNodePtySpawnHelpers(appDir);
+  auditPackagedApp(appDir, { prune: true });
 };

--- a/framework/gui/scripts/bundle-core-audit.cjs
+++ b/framework/gui/scripts/bundle-core-audit.cjs
@@ -77,6 +77,40 @@ function resolveExplicitApp(appArg) {
   return appArg;
 }
 
+function nodePtySpawnHelpers(appDir) {
+  const prebuilds = path.join(
+    appDir,
+    'Contents',
+    'Resources',
+    'app',
+    'node_modules',
+    'node-pty',
+    'prebuilds',
+  );
+  if (!exists(prebuilds)) return [];
+  return fs
+    .readdirSync(prebuilds, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && entry.name.startsWith('darwin-'))
+    .map((entry) => path.join(prebuilds, entry.name, 'spawn-helper'))
+    .filter(exists)
+    .sort();
+}
+
+function repairNodePtySpawnHelpers(appDir) {
+  const helpers = nodePtySpawnHelpers(appDir);
+  if (helpers.length === 0) {
+    throw new Error('missing packaged node-pty Darwin spawn-helper');
+  }
+  for (const helper of helpers) {
+    const mode = fs.statSync(helper).mode & 0o777;
+    if ((mode & 0o111) === 0) {
+      fs.chmodSync(helper, mode | 0o111);
+      console.log(`[bundle-core-audit] restored executable mode: ${helper}`);
+    }
+  }
+  return helpers;
+}
+
 function auditPackagedApp(appDir, options = {}) {
   const prune = Boolean(options.prune);
   const resources = path.join(appDir, 'Contents', 'Resources');
@@ -148,6 +182,19 @@ function auditPackagedApp(appDir, options = {}) {
   );
 
   const failures = [];
+  const spawnHelpers = nodePtySpawnHelpers(appDir);
+  if (spawnHelpers.length === 0) {
+    failures.push('missing packaged node-pty Darwin spawn-helper');
+  } else {
+    const nonExecutableHelpers = spawnHelpers.filter(
+      (helper) => (fs.statSync(helper).mode & 0o111) === 0,
+    );
+    if (nonExecutableHelpers.length > 0) {
+      failures.push(
+        `non-executable node-pty Darwin spawn-helper:\n${nonExecutableHelpers.join('\n')}`,
+      );
+    }
+  }
   if (remainingCore.length > 0) {
     failures.push(
       `duplicate @kungfu-tech/core package trees:\n${remainingCore.join('\n')}`,
@@ -194,4 +241,8 @@ if (require.main === module) {
   }
 }
 
-module.exports = { auditPackagedApp, findAppFromContext };
+module.exports = {
+  auditPackagedApp,
+  findAppFromContext,
+  repairNodePtySpawnHelpers,
+};

--- a/framework/gui/scripts/bundle-core-audit.test.cjs
+++ b/framework/gui/scripts/bundle-core-audit.test.cjs
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+
+const {
+  auditPackagedApp,
+  repairNodePtySpawnHelpers,
+} = require('./bundle-core-audit.cjs');
+
+function packagedAppFixture() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'kungfu-bundle-audit-'));
+  const app = path.join(root, 'Kungfu Episodes.app');
+  const resources = path.join(app, 'Contents', 'Resources');
+  const runtime = path.join(resources, 'kungfu');
+  const helper = path.join(
+    resources,
+    'app',
+    'node_modules',
+    'node-pty',
+    'prebuilds',
+    'darwin-arm64',
+    'spawn-helper',
+  );
+  fs.mkdirSync(runtime, { recursive: true });
+  for (const name of [
+    'kungfu',
+    'kungfu_electron.node',
+    'libkungfu.dylib',
+    'profile-kfd3.json',
+  ]) {
+    fs.writeFileSync(path.join(runtime, name), 'fixture');
+  }
+  fs.mkdirSync(path.dirname(helper), { recursive: true });
+  fs.writeFileSync(helper, 'fixture', { mode: 0o644 });
+  return { root, app, helper };
+}
+
+test('repairs and audits the packaged node-pty Darwin spawn helper', (t) => {
+  const fixture = packagedAppFixture();
+  t.after(() => fs.rmSync(fixture.root, { recursive: true, force: true }));
+
+  assert.throws(
+    () => auditPackagedApp(fixture.app),
+    /non-executable node-pty Darwin spawn-helper/,
+  );
+  repairNodePtySpawnHelpers(fixture.app);
+  assert.notEqual(fs.statSync(fixture.helper).mode & 0o111, 0);
+  assert.doesNotThrow(() => auditPackagedApp(fixture.app));
+});

--- a/scripts/check.mjs
+++ b/scripts/check.mjs
@@ -384,6 +384,7 @@ function checkLayerQualification() {
     path.join('tests', 'qualification', 'layers', 'process-metrics.test.mjs'),
     path.join('framework', 'spec', 'index.test.js'),
     path.join('framework', 'gui', 'scripts', 'before-pack.test.cjs'),
+    path.join('framework', 'gui', 'scripts', 'bundle-core-audit.test.cjs'),
     path.join('product', 'scripts', 'compatibility.test.mjs'),
     path.join('product', 'scripts', 'dist.test.mjs'),
   ]);


### PR DESCRIPTION
## Summary

Restore executable permissions on packaged node-pty Darwin spawn helpers so Agent Console PTYs can launch.

## Related issue

Dogfood report: packaged Agent Console fails with `posix_spawnp failed`.

## Changes

- repair Darwin spawn-helper modes during Electron afterPack
- fail the packaged-app audit when the helper is missing or non-executable
- add a regression fixture to the changed-scope qualification suite

## Verification

- `./shifu check`
- fixture proves mode 0644 fails audit and repaired mode passes
- packaged macOS app launches `codex --version` through its bundled Electron and node-pty (exit 0)

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Packaging bug fix restores the existing Agent Console PTY contract without changing architecture."
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] release evidence, provenance, package publishing, or deployment surfaces
- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed (not needed; existing behavior restored)