### PR TITLE
docs(adr): stabilize runtime contract evidence

### DIFF
--- a/docs/adr/ADR-0080-topology-neutral-capability-driven-runtime-activation.md
+++ b/docs/adr/ADR-0080-topology-neutral-capability-driven-runtime-activation.md
@@ -4,7 +4,7 @@ doc_type: architecture-decision
 adr_id: ADR-0080
 decision_status: accepted
 implementation_status: partial
-implementation_commits: [9f167a3aae1e4233c737b4a4be5339c540c5c9c3]
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/815]
 review_state: self-reviewed
 sensitivity: public
 sources: [local-files, user-decision]


### PR DESCRIPTION
## Summary

- replace the pre-rebase implementation commit reference with the stable merged PR URL
- preserve ADR-0080 at partial implementation status without changing runtime semantics or qualification claims

## Verification

- `./shifu docs:check`

## Governance risk

Documentation evidence repair only; no runtime, deployment, release, or production behavior changes.

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "stage-ready",
  "adrs": ["ADR-0080"],
  "summary": "Replace the non-mainline pre-rebase commit evidence with the stable merged PR #815 evidence for the completed contract stage.",
  "verification": ["./shifu docs:check"]
}
-->