### PR TITLE
feat(gui): keep work context with contextual agent consoles

### DIFF
--- a/extensions/terminal/src/view/auto-launch.ts
+++ b/extensions/terminal/src/view/auto-launch.ts
@@ -1,0 +1,30 @@
+import type { AgentRuntimeProfile } from '@kungfu-tech/api/capability';
+
+export type WorkConsoleAutoLaunch = {
+  key: string;
+  profile: AgentRuntimeProfile;
+};
+
+export function workConsoleAutoLaunch(input: {
+  enabled: boolean;
+  requestedConsoleId: string | null;
+  workspaceHydrated: boolean;
+  catalogBusy: boolean;
+  profiles: readonly AgentRuntimeProfile[];
+  hasBoundPane: boolean;
+  attemptedKeys: ReadonlySet<string>;
+}): WorkConsoleAutoLaunch | null {
+  if (
+    !input.enabled ||
+    !input.requestedConsoleId ||
+    !input.workspaceHydrated ||
+    input.catalogBusy ||
+    input.hasBoundPane
+  ) {
+    return null;
+  }
+  const profile = input.profiles[0];
+  if (!profile) return null;
+  const key = `${input.requestedConsoleId}:${profile.id}`;
+  return input.attemptedKeys.has(key) ? null : { key, profile };
+}

--- a/extensions/terminal/src/view/console-scope.ts
+++ b/extensions/terminal/src/view/console-scope.ts
@@ -1,0 +1,15 @@
+export function assistantConsoleId(workspaceId: string): string {
+  return `assistant:${workspaceId}`;
+}
+
+export function workConsoleId(params: Record<string, string>): string | null {
+  if (!params.workEntityId) return null;
+  return `work:${params.workProfileId || 'kungfu.mission-control'}:${params.workEntityType || 'work'}:${params.workEntityId}`;
+}
+
+export function consoleScopeId(
+  workspaceId: string,
+  params: Record<string, string>,
+): string {
+  return workConsoleId(params) ?? assistantConsoleId(workspaceId);
+}

--- a/extensions/terminal/src/view/index.tsx
+++ b/extensions/terminal/src/view/index.tsx
@@ -52,6 +52,11 @@ import {
   rememberDiscoveredAgentRuntimeProfile,
 } from './agent-runtime-catalog';
 import {
+  assistantConsoleId,
+  consoleScopeId,
+  workConsoleId,
+} from './console-scope';
+import {
   DEFAULT_PANE_LAYOUT,
   type PaneLayoutAxis,
   type PaneLayoutMode,
@@ -62,6 +67,7 @@ import {
 } from './pane-layout';
 import {
   type PersistedWindow,
+  type WorkConsole,
   type WorkConsoleRegistry,
   type WorkspaceLayout,
   emptyConsoleRegistry,
@@ -893,8 +899,13 @@ function SessionWorkspace({
     (typeof process !== 'undefined'
       ? process.env.KF_WORKSPACE_ID || 'home'
       : 'home');
+  const requestedWorkConsoleId = workConsoleId(shell.params ?? {});
+  const defaultConsoleId = consoleScopeId(workspaceId, shell.params ?? {});
   const [panes, setPanes] = React.useState<Pane[]>([]);
   const [activeRunId, setActiveRunId] = React.useState<string | null>(null);
+  const [selectedConsoleId, setSelectedConsoleId] =
+    React.useState(defaultConsoleId);
+  const [consoleCatalogOpen, setConsoleCatalogOpen] = React.useState(false);
   const [paneLayout, setPaneLayout] =
     React.useState<PaneLayoutMode>(DEFAULT_PANE_LAYOUT);
   const [paneSizes, setPaneSizes] = React.useState<number[]>([1]);
@@ -933,6 +944,11 @@ function SessionWorkspace({
   // read the stored layout, so mounting never clobbers it with an empty set.
   const hydrated = React.useRef(false);
 
+  React.useEffect(() => {
+    setSelectedConsoleId(defaultConsoleId);
+    setConsoleCatalogOpen(false);
+  }, [defaultConsoleId]);
+
   const refreshCatalog = React.useCallback(async () => {
     if (!caps.agentRuntime) {
       setNotice('Agent Runtime capability unavailable');
@@ -965,31 +981,39 @@ function SessionWorkspace({
     [panes],
   );
 
+  const scopedPanes = React.useMemo(
+    () => panes.filter((pane) => pane.consoleId === selectedConsoleId),
+    [panes, selectedConsoleId],
+  );
+
   React.useEffect(() => {
-    if (panes.length === 0) {
+    if (scopedPanes.length === 0) {
       setActiveRunId(null);
       return;
     }
-    if (!activeRunId || !panes.some((pane) => pane.runId === activeRunId)) {
-      setActiveRunId(panes[0].runId);
+    if (
+      !activeRunId ||
+      !scopedPanes.some((pane) => pane.runId === activeRunId)
+    ) {
+      setActiveRunId(scopedPanes[0].runId);
     }
-  }, [activeRunId, panes]);
+  }, [activeRunId, scopedPanes]);
 
   const visiblePanes = React.useMemo(() => {
-    if (panes.length === 0) return [];
+    if (scopedPanes.length === 0) return [];
     const activeIndex = Math.max(
       0,
-      panes.findIndex((pane) => pane.runId === activeRunId),
+      scopedPanes.findIndex((pane) => pane.runId === activeRunId),
     );
     const ordered = [
-      ...panes.slice(activeIndex),
-      ...panes.slice(0, activeIndex),
+      ...scopedPanes.slice(activeIndex),
+      ...scopedPanes.slice(0, activeIndex),
     ];
     return ordered.slice(
       0,
       Math.min(paneCountForLayout(paneLayout), ordered.length),
     );
-  }, [activeRunId, paneLayout, panes]);
+  }, [activeRunId, paneLayout, scopedPanes]);
 
   const selectPaneLayout = React.useCallback((mode: PaneLayoutMode) => {
     setPaneLayout(mode);
@@ -1225,10 +1249,15 @@ function SessionWorkspace({
       }
       const runId = mintRunId();
       const attemptId = `attempt:${runId}`;
-      const workRef = await workRefFromShell(shell);
+      const selectedWorkConsole = consoleRegistry.consoles.find(
+        (candidate) => candidate.consoleId === selectedConsoleId,
+      );
+      const workRef = requestedWorkConsoleId
+        ? await workRefFromShell(shell)
+        : (selectedWorkConsole?.workRef ?? null);
       const consoleId = workRef
         ? `work:${workRef.profileId}:${workRef.entityType}:${workRef.entityId}`
-        : `assistant:${workspaceId}`;
+        : assistantConsoleId(workspaceId);
       const envelope = await buildAgentConsoleEnvelope({
         workspaceId,
         consoleId,
@@ -1305,6 +1334,7 @@ function SessionWorkspace({
         },
       ]);
       setActiveRunId(session.runId);
+      setSelectedConsoleId(consoleId);
       const now = Date.now();
       setConsoleRegistry((current) => {
         const previous = current.consoles.find(
@@ -1341,7 +1371,15 @@ function SessionWorkspace({
         };
       });
     },
-    [caps.agentRuntime, caps.terminal, shell, workspaceId],
+    [
+      caps.agentRuntime,
+      caps.terminal,
+      consoleRegistry.consoles,
+      requestedWorkConsoleId,
+      selectedConsoleId,
+      shell,
+      workspaceId,
+    ],
   );
 
   const markAttempt = React.useCallback(
@@ -1458,6 +1496,34 @@ function SessionWorkspace({
     [markAttempt],
   );
 
+  const selectedConsole = consoleRegistry.consoles.find(
+    (candidate) => candidate.consoleId === selectedConsoleId,
+  );
+  const selectedAttemptIds = new Set(
+    selectedConsole?.attempts.map((attempt) => attempt.runId) ?? [],
+  );
+  const scopedRecoverable = recoverable.filter((session) =>
+    selectedAttemptIds.has(session.runId),
+  );
+  const bindingLabel = selectedConsole?.workRef
+    ? `${selectedConsole.workRef.entityType === 'go' ? 'Go' : 'Work'} · ${selectedConsole.workRef.entityId}`
+    : requestedWorkConsoleId
+      ? `Go · ${shell.params.workEntityId}`
+      : 'Workspace assistant';
+  const orderedConsoles = [...consoleRegistry.consoles].sort(
+    (left, right) => right.updatedAt - left.updatedAt,
+  );
+
+  const consoleLabel = (workConsole: WorkConsole): string =>
+    workConsole.workRef
+      ? `${workConsole.workRef.entityType === 'go' ? 'Go' : 'Work'} · ${workConsole.workRef.entityId}`
+      : 'Workspace assistant';
+
+  const consoleStatus = (workConsole: WorkConsole): string => {
+    const attempts = workConsole.attempts;
+    return attempts.length ? attempts[attempts.length - 1].status : 'idle';
+  };
+
   return (
     <div
       style={{
@@ -1469,11 +1535,7 @@ function SessionWorkspace({
     >
       <LauncherStrip
         profiles={availableAgentRuntimeProfiles(catalog)}
-        bindingLabel={
-          shell.params?.workEntityId
-            ? `Go · ${shell.params.workEntityId}`
-            : 'Workspace assistant'
-        }
+        bindingLabel={bindingLabel}
         busy={catalogBusy}
         loaded={catalog !== null}
         error={catalogError}
@@ -1485,7 +1547,71 @@ function SessionWorkspace({
         onRetry={() => void refreshCatalog()}
         onConfigure={() => shell.open('settings')}
       />
-      {panes.length > 0 && (
+      {!requestedWorkConsoleId && (
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 6,
+            flexWrap: 'wrap',
+            paddingBottom: 6,
+            borderBottom: '1px solid #333',
+          }}
+        >
+          <button
+            type="button"
+            onClick={() =>
+              setSelectedConsoleId(assistantConsoleId(workspaceId))
+            }
+            style={{
+              ...iconButtonStyle,
+              color:
+                selectedConsoleId === assistantConsoleId(workspaceId)
+                  ? '#9cdcfe'
+                  : '#858585',
+              borderColor:
+                selectedConsoleId === assistantConsoleId(workspaceId)
+                  ? '#2d8fcc'
+                  : '#3a3a3a',
+            }}
+          >
+            🏠 Assistant
+          </button>
+          <button
+            type="button"
+            onClick={() => setConsoleCatalogOpen((current) => !current)}
+            aria-expanded={consoleCatalogOpen}
+            style={{ ...iconButtonStyle, color: '#858585' }}
+          >
+            ☰ All consoles · {orderedConsoles.length}
+          </button>
+          {consoleCatalogOpen &&
+            orderedConsoles.map((workConsole) => (
+              <button
+                key={workConsole.consoleId}
+                type="button"
+                onClick={() => {
+                  setSelectedConsoleId(workConsole.consoleId);
+                  setConsoleCatalogOpen(false);
+                }}
+                title={workConsole.consoleId}
+                style={{
+                  ...iconButtonStyle,
+                  color:
+                    selectedConsoleId === workConsole.consoleId
+                      ? '#9cdcfe'
+                      : '#858585',
+                }}
+              >
+                {workConsole.bindingKind === 'workspace-assistant'
+                  ? '🏠'
+                  : '🎯'}{' '}
+                {consoleLabel(workConsole)} · {consoleStatus(workConsole)}
+              </button>
+            ))}
+        </div>
+      )}
+      {scopedPanes.length > 0 && (
         <div
           style={{
             display: 'flex',
@@ -1497,7 +1623,7 @@ function SessionWorkspace({
             paddingBottom: 5,
           }}
         >
-          {panes.map((pane) => (
+          {scopedPanes.map((pane) => (
             <button
               key={pane.runId}
               type="button"
@@ -1528,14 +1654,15 @@ function SessionWorkspace({
             <button
               key={mode}
               type="button"
-              disabled={panes.length < paneCountForLayout(mode)}
+              disabled={scopedPanes.length < paneCountForLayout(mode)}
               onClick={() => selectPaneLayout(mode)}
               title={label}
               aria-label={label}
               style={{
                 ...iconButtonStyle,
                 color: paneLayout === mode ? '#9cdcfe' : '#858585',
-                opacity: panes.length < paneCountForLayout(mode) ? 0.35 : 1,
+                opacity:
+                  scopedPanes.length < paneCountForLayout(mode) ? 0.35 : 1,
               }}
             >
               {icon}
@@ -1547,12 +1674,12 @@ function SessionWorkspace({
         <div style={{ ...mono, fontSize: 11, color: '#c9a227' }}>{notice}</div>
       )}
       <RecoverableTray
-        sessions={recoverable}
+        sessions={scopedRecoverable}
         onReattach={reattach}
         onDismiss={dismiss}
         onRefresh={() => void refresh()}
       />
-      {panes.length === 0 ? (
+      {scopedPanes.length === 0 ? (
         <div
           style={{
             ...panelStyle,

--- a/extensions/terminal/src/view/index.tsx
+++ b/extensions/terminal/src/view/index.tsx
@@ -51,6 +51,7 @@ import {
   availableAgentRuntimeProfiles,
   rememberDiscoveredAgentRuntimeProfile,
 } from './agent-runtime-catalog';
+import { workConsoleAutoLaunch } from './auto-launch';
 import {
   assistantConsoleId,
   consoleScopeId,
@@ -916,6 +917,8 @@ function SessionWorkspace({
   );
   const [catalogBusy, setCatalogBusy] = React.useState(true);
   const [catalogError, setCatalogError] = React.useState('');
+  const [workspaceHydrated, setWorkspaceHydrated] = React.useState(!domain);
+  const [autoLaunchBusy, setAutoLaunchBusy] = React.useState(false);
   const [consoleRegistry, setConsoleRegistry] =
     React.useState<WorkConsoleRegistry>(() =>
       domain
@@ -943,6 +946,7 @@ function SessionWorkspace({
   // ephemeral. `hydrated` blocks the save effect until the initial restore has
   // read the stored layout, so mounting never clobbers it with an empty set.
   const hydrated = React.useRef(false);
+  const autoLaunchAttempts = React.useRef(new Set<string>());
 
   React.useEffect(() => {
     setSelectedConsoleId(defaultConsoleId);
@@ -1039,6 +1043,7 @@ function SessionWorkspace({
   React.useEffect(() => {
     if (!domain) {
       hydrated.current = true;
+      setWorkspaceHydrated(true);
       return;
     }
     // Read synchronously before the save effect can run, so the stored layout
@@ -1123,6 +1128,7 @@ function SessionWorkspace({
         );
         if (liveWindows.length > 0) shell.restoreSessionWindows?.(liveWindows);
         hydrated.current = true;
+        setWorkspaceHydrated(true);
         // the pane-set change triggers the tray refresh effect below; no need
         // to call refresh() here (it is declared later)
       }
@@ -1382,6 +1388,40 @@ function SessionWorkspace({
     ],
   );
 
+  const runtimeProfiles = React.useMemo(
+    () => availableAgentRuntimeProfiles(catalog),
+    [catalog],
+  );
+  React.useEffect(() => {
+    const request = workConsoleAutoLaunch({
+      enabled: shell.params.autoStart === 'true',
+      requestedConsoleId: requestedWorkConsoleId,
+      workspaceHydrated,
+      catalogBusy,
+      profiles: runtimeProfiles,
+      hasBoundPane: panes.some(
+        (pane) => pane.consoleId === requestedWorkConsoleId,
+      ),
+      attemptedKeys: autoLaunchAttempts.current,
+    });
+    if (!request) return;
+    autoLaunchAttempts.current.add(request.key);
+    setAutoLaunchBusy(true);
+    void launch(request.profile)
+      .catch((error) =>
+        setNotice(`Agent launch failed: ${(error as Error).message}`),
+      )
+      .finally(() => setAutoLaunchBusy(false));
+  }, [
+    catalogBusy,
+    launch,
+    panes,
+    requestedWorkConsoleId,
+    runtimeProfiles,
+    shell.params.autoStart,
+    workspaceHydrated,
+  ]);
+
   const markAttempt = React.useCallback(
     (runId: string, status: 'running' | 'detached' | 'exited' | 'orphaned') => {
       setConsoleRegistry((current) => ({
@@ -1534,9 +1574,9 @@ function SessionWorkspace({
       }}
     >
       <LauncherStrip
-        profiles={availableAgentRuntimeProfiles(catalog)}
+        profiles={runtimeProfiles}
         bindingLabel={bindingLabel}
-        busy={catalogBusy}
+        busy={catalogBusy || autoLaunchBusy}
         loaded={catalog !== null}
         error={catalogError}
         onLaunch={(profile) => {
@@ -1692,7 +1732,9 @@ function SessionWorkspace({
             fontSize: 12,
           }}
         >
-          launch a session above — panes stack here, several visible at once
+          {autoLaunchBusy
+            ? 'starting the bound Agent session…'
+            : 'launch a session above — panes stack here, several visible at once'}
         </div>
       ) : (
         <ResizablePaneLayout

--- a/extensions/terminal/src/view/index.tsx
+++ b/extensions/terminal/src/view/index.tsx
@@ -61,6 +61,7 @@ import {
   DEFAULT_PANE_LAYOUT,
   type PaneLayoutAxis,
   type PaneLayoutMode,
+  emptyPaneSlotsForLayout,
   normalizePaneSizes,
   paneAxisForLayout,
   paneCountForLayout,
@@ -141,6 +142,7 @@ interface Pane {
 const PANE_SEPARATOR_SIZE = 8;
 const MIN_PANE_COLUMN_WIDTH = 240;
 const MIN_PANE_ROW_HEIGHT = 180;
+const EMPTY_PANE_SLOT_IDS = ['primary', 'secondary', 'tertiary'] as const;
 
 function ResizablePaneLayout({
   axis,
@@ -1018,6 +1020,10 @@ function SessionWorkspace({
       Math.min(paneCountForLayout(paneLayout), ordered.length),
     );
   }, [activeRunId, paneLayout, scopedPanes]);
+  const emptyPaneSlotCount = emptyPaneSlotsForLayout(
+    paneLayout,
+    visiblePanes.length,
+  );
 
   const selectPaneLayout = React.useCallback((mode: PaneLayoutMode) => {
     setPaneLayout(mode);
@@ -1694,15 +1700,13 @@ function SessionWorkspace({
             <button
               key={mode}
               type="button"
-              disabled={scopedPanes.length < paneCountForLayout(mode)}
               onClick={() => selectPaneLayout(mode)}
               title={label}
               aria-label={label}
+              aria-pressed={paneLayout === mode}
               style={{
                 ...iconButtonStyle,
                 color: paneLayout === mode ? '#9cdcfe' : '#858585',
-                opacity:
-                  scopedPanes.length < paneCountForLayout(mode) ? 0.35 : 1,
               }}
             >
               {icon}
@@ -1739,7 +1743,10 @@ function SessionWorkspace({
       ) : (
         <ResizablePaneLayout
           axis={paneAxisForLayout(paneLayout)}
-          sizes={normalizePaneSizes(paneSizes, visiblePanes.length)}
+          sizes={normalizePaneSizes(
+            paneSizes,
+            visiblePanes.length + emptyPaneSlotCount,
+          )}
           onSizesChange={setPaneSizes}
         >
           {visiblePanes.map((pane) => (
@@ -1767,6 +1774,28 @@ function SessionWorkspace({
               poppedOut={poppedOutRunIds.has(pane.runId)}
             />
           ))}
+          {EMPTY_PANE_SLOT_IDS.slice(0, emptyPaneSlotCount).map(
+            (slotId, index) => (
+              <div
+                key={`empty-pane-${slotId}`}
+                aria-label={`Empty Agent pane ${index + 1}`}
+                style={{
+                  ...panelStyle,
+                  minWidth: 0,
+                  minHeight: 0,
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  borderStyle: 'dashed',
+                  color: '#6a6a6a',
+                  ...mono,
+                  fontSize: 11,
+                }}
+              >
+                ＋ launch another Agent above
+              </div>
+            ),
+          )}
         </ResizablePaneLayout>
       )}
     </div>

--- a/extensions/terminal/src/view/pane-layout.ts
+++ b/extensions/terminal/src/view/pane-layout.ts
@@ -19,6 +19,13 @@ export function paneAxisForLayout(mode: PaneLayoutMode): PaneLayoutAxis {
   return mode.startsWith('rows') ? 'rows' : 'columns';
 }
 
+export function emptyPaneSlotsForLayout(
+  mode: PaneLayoutMode,
+  visiblePaneCount: number,
+): number {
+  return Math.max(0, paneCountForLayout(mode) - Math.max(0, visiblePaneCount));
+}
+
 export function normalizePaneSizes(
   sizes: readonly number[],
   count: number,

--- a/extensions/terminal/tests/auto-launch.test.ts
+++ b/extensions/terminal/tests/auto-launch.test.ts
@@ -1,0 +1,55 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type { AgentRuntimeProfile } from '@kungfu-tech/api/capability';
+import { workConsoleAutoLaunch } from '../src/view/auto-launch.ts';
+
+const profile = {
+  id: 'codex-default',
+  label: 'Codex',
+} as AgentRuntimeProfile;
+
+const base = {
+  enabled: true,
+  requestedConsoleId: 'work:kungfu.mission-control:go:go-1',
+  workspaceHydrated: true,
+  catalogBusy: false,
+  profiles: [profile],
+  hasBoundPane: false,
+  attemptedKeys: new Set<string>(),
+};
+
+test('a bound Go Console selects the preferred Agent for immediate launch', () => {
+  assert.deepEqual(workConsoleAutoLaunch(base), {
+    key: 'work:kungfu.mission-control:go:go-1:codex-default',
+    profile,
+  });
+});
+
+test('auto launch waits for persistence and Agent discovery', () => {
+  assert.equal(
+    workConsoleAutoLaunch({ ...base, workspaceHydrated: false }),
+    null,
+  );
+  assert.equal(workConsoleAutoLaunch({ ...base, catalogBusy: true }), null);
+});
+
+test('auto launch never duplicates an existing or attempted Go session', () => {
+  assert.equal(workConsoleAutoLaunch({ ...base, hasBoundPane: true }), null);
+  assert.equal(
+    workConsoleAutoLaunch({
+      ...base,
+      attemptedKeys: new Set([
+        'work:kungfu.mission-control:go:go-1:codex-default',
+      ]),
+    }),
+    null,
+  );
+});
+
+test('the global assistant remains explicitly launched by the user', () => {
+  assert.equal(
+    workConsoleAutoLaunch({ ...base, requestedConsoleId: null }),
+    null,
+  );
+  assert.equal(workConsoleAutoLaunch({ ...base, enabled: false }), null);
+});

--- a/extensions/terminal/tests/console-scope.test.ts
+++ b/extensions/terminal/tests/console-scope.test.ts
@@ -1,0 +1,25 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  assistantConsoleId,
+  consoleScopeId,
+  workConsoleId,
+} from '../src/view/console-scope.ts';
+
+test('the main Agent Console defaults to the workspace assistant', () => {
+  assert.equal(assistantConsoleId('atlas'), 'assistant:atlas');
+  assert.equal(consoleScopeId('atlas', {}), 'assistant:atlas');
+});
+
+test('a contextual Go drawer selects only its stable work console', () => {
+  const params = {
+    workProfileId: 'kungfu.mission-control',
+    workEntityType: 'go',
+    workEntityId: 'go-contextual-console',
+  };
+  assert.equal(
+    workConsoleId(params),
+    'work:kungfu.mission-control:go:go-contextual-console',
+  );
+  assert.equal(consoleScopeId('atlas', params), workConsoleId(params));
+});

--- a/extensions/terminal/tests/console-scope.test.ts
+++ b/extensions/terminal/tests/console-scope.test.ts
@@ -11,7 +11,7 @@ test('the main Agent Console defaults to the workspace assistant', () => {
   assert.equal(consoleScopeId('atlas', {}), 'assistant:atlas');
 });
 
-test('a contextual Go drawer selects only its stable work console', () => {
+test('a contextual Go work surface selects only its stable work console', () => {
   const params = {
     workProfileId: 'kungfu.mission-control',
     workEntityType: 'go',

--- a/extensions/terminal/tests/pane-layout.test.ts
+++ b/extensions/terminal/tests/pane-layout.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
   DEFAULT_PANE_LAYOUT,
+  emptyPaneSlotsForLayout,
   normalizePaneSizes,
   paneAxisForLayout,
   paneCountForLayout,
@@ -27,6 +28,13 @@ test('the standard layout choices map to the expected axis and pane count', () =
       ['rows', 3],
     ],
   );
+});
+
+test('layout capacity remains visible before every pane is launched', () => {
+  assert.equal(emptyPaneSlotsForLayout('columns-3', 2), 1);
+  assert.equal(emptyPaneSlotsForLayout('rows-3', 1), 2);
+  assert.equal(emptyPaneSlotsForLayout('columns-2', 2), 0);
+  assert.equal(emptyPaneSlotsForLayout('single', 3), 0);
 });
 
 test('invalid or stale pane sizes fall back to equal tracks', () => {

--- a/extensions/work-dashboard/src/view/agent-console-launch.ts
+++ b/extensions/work-dashboard/src/view/agent-console-launch.ts
@@ -16,14 +16,14 @@ export async function resolveMissionControlProfileRoot(
   if (!current) {
     throw new Error('Mission Control Profile is not installed');
   }
-  if (current.catalog && !current.catalog.activeExactRoot) {
-    throw new Error(
-      'Mission Control Profile update requires approval in Work Dashboard',
-    );
-  }
+  // The lifecycle root remains the active authority while a newer packaged
+  // source waits for explicit upgrade approval. catalog.activeExactRoot
+  // compares that available source with the lifecycle root; it must not make
+  // existing Go-bound Consoles unusable during the approval window.
   if (
-    current.health !== 'active' ||
-    !current.catalog ||
+    current.lifecycleState !== 'activated' ||
+    !current.activated ||
+    current.removed ||
     !current.profileSuiteRoot
   ) {
     throw new Error('Mission Control Profile setup is not complete');

--- a/extensions/work-dashboard/src/view/dashboard-presentation.ts
+++ b/extensions/work-dashboard/src/view/dashboard-presentation.ts
@@ -1,0 +1,49 @@
+export type DashboardPresentation = {
+  selectedMission: string;
+  selectedGoal: string | null;
+  statusFilter: string;
+  displayMode: 'visual' | 'audit';
+};
+
+const PREFIX = 'work-dashboard.presentation.';
+
+export function readDashboardPresentation(
+  settings: Record<string, string>,
+): Partial<DashboardPresentation> {
+  const displayMode = settings[`${PREFIX}displayMode`];
+  return {
+    selectedMission: settings[`${PREFIX}selectedMission`] || undefined,
+    selectedGoal: settings[`${PREFIX}selectedGoal`] || null,
+    statusFilter: settings[`${PREFIX}statusFilter`] || undefined,
+    displayMode:
+      displayMode === 'visual' || displayMode === 'audit'
+        ? displayMode
+        : undefined,
+  };
+}
+
+export function writeDashboardPresentation(
+  settings: Record<string, string>,
+  presentation: DashboardPresentation,
+): Record<string, string> {
+  return {
+    ...settings,
+    [`${PREFIX}selectedMission`]: presentation.selectedMission,
+    [`${PREFIX}selectedGoal`]: presentation.selectedGoal ?? '',
+    [`${PREFIX}statusFilter`]: presentation.statusFilter,
+    [`${PREFIX}displayMode`]: presentation.displayMode,
+  };
+}
+
+export function dashboardPresentationMatches(
+  settings: Record<string, string>,
+  presentation: DashboardPresentation,
+): boolean {
+  const current = readDashboardPresentation(settings);
+  return (
+    current.selectedMission === presentation.selectedMission &&
+    (current.selectedGoal ?? null) === presentation.selectedGoal &&
+    current.statusFilter === presentation.statusFilter &&
+    current.displayMode === presentation.displayMode
+  );
+}

--- a/extensions/work-dashboard/src/view/index.tsx
+++ b/extensions/work-dashboard/src/view/index.tsx
@@ -39,6 +39,11 @@ import { headingStyle, mono, panelStyle } from '@kungfu-tech/kfx';
 import React from 'react';
 import { resolveMissionControlProfileRoot } from './agent-console-launch';
 import {
+  dashboardPresentationMatches,
+  readDashboardPresentation,
+  writeDashboardPresentation,
+} from './dashboard-presentation';
+import {
   dashboardMetricVisuals,
   dashboardSnapshotVisual,
   missionControlProfileVisual,
@@ -365,6 +370,7 @@ function AtlasProjectionView({
   storage: Storage;
 }) {
   const initialDashboard = atlas.currentDashboard();
+  const savedPresentation = readDashboardPresentation(shell.state.settings);
   const [repoRoot, setRepoRoot] = React.useState(atlas.defaultRepoRoot);
   const [missions, setMissions] = React.useState<AtlasMission[]>(
     () => initialDashboard?.missions ?? [],
@@ -394,16 +400,24 @@ function AtlasProjectionView({
   const [profileSetupActor, setProfileSetupActor] = React.useState('');
   const profileSetupActorInput = React.useRef<HTMLInputElement>(null);
   const [profileSetupBusy, setProfileSetupBusy] = React.useState(false);
-  const [selectedMission, setSelectedMission] = React.useState<string>(() =>
-    missions.length ? missions[0].mission_id : 'all',
+  const [selectedMission, setSelectedMission] = React.useState<string>(
+    () =>
+      savedPresentation.selectedMission ||
+      (missions.length ? missions[0].mission_id : 'all'),
   );
-  const autoSelectMission = React.useRef(missions.length === 0);
+  const autoSelectMission = React.useRef(
+    !savedPresentation.selectedMission && missions.length === 0,
+  );
   const mounted = React.useRef(true);
   const assessmentRequest = React.useRef(0);
-  const [statusFilter, setStatusFilter] = React.useState<string>('all');
-  const [selectedGoal, setSelectedGoal] = React.useState<string | null>(null);
+  const [statusFilter, setStatusFilter] = React.useState<string>(
+    savedPresentation.statusFilter || 'all',
+  );
+  const [selectedGoal, setSelectedGoal] = React.useState<string | null>(
+    savedPresentation.selectedGoal ?? null,
+  );
   const [displayMode, setDisplayMode] = React.useState<'visual' | 'audit'>(
-    'visual',
+    savedPresentation.displayMode || 'visual',
   );
   const [goalCardQuery, setGoalCardQuery] = React.useState<GoalCardQuerySpec>(
     () => ({
@@ -469,6 +483,20 @@ function AtlasProjectionView({
     };
   }, []);
 
+  React.useEffect(() => {
+    const presentation = {
+      selectedMission,
+      selectedGoal,
+      statusFilter,
+      displayMode,
+    };
+    if (dashboardPresentationMatches(shell.state.settings, presentation))
+      return;
+    shell.updateState({
+      settings: writeDashboardPresentation(shell.state.settings, presentation),
+    });
+  }, [displayMode, selectedGoal, selectedMission, shell, statusFilter]);
+
   const applyDashboard = React.useCallback(
     (snapshot: AtlasDashboardSnapshot) => {
       setInfo(snapshot.import_info);
@@ -500,6 +528,28 @@ function AtlasProjectionView({
     dashboardRefresh.request();
     return () => dashboardRefresh.dispose();
   }, [dashboardRefresh]);
+
+  React.useEffect(() => {
+    if (
+      missions.length > 0 &&
+      selectedMission !== 'all' &&
+      !missions.some((mission) => mission.mission_id === selectedMission)
+    ) {
+      setSelectedMission(missions[0].mission_id);
+      setSelectedGoal(null);
+      return;
+    }
+    if (
+      selectedGoal &&
+      !goals.some(
+        (goal) =>
+          goal.goal_id === selectedGoal &&
+          (selectedMission === 'all' || goal.mission_id === selectedMission),
+      )
+    ) {
+      setSelectedGoal(null);
+    }
+  }, [goals, missions, selectedGoal, selectedMission]);
 
   const refreshProfileStatus = React.useCallback(async () => {
     if (!profile) {
@@ -953,7 +1003,7 @@ function AtlasProjectionView({
       try {
         const profileRoot = await resolveMissionControlProfileRoot(profile);
         if (!mounted.current) return;
-        shell.open('terminal', {
+        const consoleParams = {
           workWorkspaceId:
             (typeof process !== 'undefined'
               ? process.env.KF_WORKSPACE_ID
@@ -966,13 +1016,20 @@ function AtlasProjectionView({
           workPurpose:
             goal.next_action || goal.summary || goal.title || goal.goal_id,
           workSystemTimeCut: dashboardCut || new Date().toISOString(),
-        });
+          contextTitle: goal.title || goal.goal_id,
+          contextSubtitle: currentMission?.title || goal.mission_id || 'Go',
+        };
+        if (shell.openContextualView) {
+          shell.openContextualView('terminal', consoleParams);
+        } else {
+          shell.open('terminal', consoleParams);
+        }
       } catch (error) {
         if (!mounted.current) return;
         setMessage(`Agent Console unavailable · ${(error as Error).message}`);
       }
     },
-    [dashboardCut, profile, shell],
+    [currentMission?.title, dashboardCut, profile, shell],
   );
   const goalTrustById = React.useMemo(
     () =>

--- a/extensions/work-dashboard/src/view/index.tsx
+++ b/extensions/work-dashboard/src/view/index.tsx
@@ -51,6 +51,7 @@ import {
 } from './dashboard-status';
 import { createLatestRefresh } from './latest-refresh';
 import {
+  GOAL_DETAIL_COMPANION_WIDTH,
   GoalCardField,
   GoalDetailDrawer,
   MissionSituationOverview,
@@ -1018,6 +1019,9 @@ function AtlasProjectionView({
           workSystemTimeCut: dashboardCut || new Date().toISOString(),
           contextTitle: goal.title || goal.goal_id,
           contextSubtitle: currentMission?.title || goal.mission_id || 'Go',
+          contextPlacement: 'left-of-companion',
+          contextCompanionWidth: GOAL_DETAIL_COMPANION_WIDTH,
+          autoStart: 'true',
         };
         if (shell.openContextualView) {
           shell.openContextualView('terminal', consoleParams);

--- a/extensions/work-dashboard/src/view/mission-visual.tsx
+++ b/extensions/work-dashboard/src/view/mission-visual.tsx
@@ -36,6 +36,8 @@ const COLORS = {
   violet: '#b59cff',
 };
 
+export const GOAL_DETAIL_COMPANION_WIDTH = 'min(460px, 48%)';
+
 const TRUST_COLORS: Record<VisualTrustState, string> = {
   established: COLORS.green,
   partial: COLORS.amber,
@@ -1110,7 +1112,7 @@ export function GoalDetailDrawer({
         top: 0,
         right: 0,
         bottom: 0,
-        width: 'min(460px, 92vw)',
+        width: 'var(--kf-contextual-companion-width, min(460px, 92vw))',
         display: 'flex',
         flexDirection: 'column',
         background: '#151b23',

--- a/extensions/work-dashboard/tests/agent-console-launch.test.ts
+++ b/extensions/work-dashboard/tests/agent-console-launch.test.ts
@@ -67,21 +67,38 @@ test('Agent Console binds the current active exact Profile root without an asses
   );
 });
 
-test('Agent Console refuses a Profile whose exact root is not active', async () => {
+test('Agent Console keeps using the active lifecycle root while an upgrade waits for approval', async () => {
   const catalog = managedProfile().catalog;
   assert.ok(catalog);
-  await assert.rejects(
-    resolveMissionControlProfileRoot(
+  assert.equal(
+    await resolveMissionControlProfileRoot(
       profileWith(
         managedProfile({
+          health: 'inactive',
           catalog: {
             ...catalog,
+            profileSuiteRoot: `sha256:${'c'.repeat(64)}`,
             activeExactRoot: false,
           },
         }),
       ),
     ),
-    /update requires approval in Work Dashboard/,
+    ROOT,
+  );
+});
+
+test('Agent Console refuses a Profile without an active lifecycle root', async () => {
+  await assert.rejects(
+    resolveMissionControlProfileRoot(
+      profileWith(
+        managedProfile({
+          lifecycleState: 'qualified',
+          activated: false,
+          health: 'inactive',
+        }),
+      ),
+    ),
+    /setup is not complete/,
   );
 });
 

--- a/extensions/work-dashboard/tests/dashboard-presentation.test.ts
+++ b/extensions/work-dashboard/tests/dashboard-presentation.test.ts
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  dashboardPresentationMatches,
+  readDashboardPresentation,
+  writeDashboardPresentation,
+} from '../src/view/dashboard-presentation.ts';
+
+test('dashboard presentation round-trips Mission, Go, filter and display mode', () => {
+  const state = {
+    selectedMission: 'mission-kungfu',
+    selectedGoal: 'go-contextual-console',
+    statusFilter: 'active',
+    displayMode: 'visual' as const,
+  };
+  const settings = writeDashboardPresentation({ existing: 'kept' }, state);
+  assert.equal(settings.existing, 'kept');
+  assert.deepEqual(readDashboardPresentation(settings), state);
+  assert.equal(dashboardPresentationMatches(settings, state), true);
+});
+
+test('invalid display modes degrade without blocking dashboard boot', () => {
+  assert.deepEqual(
+    readDashboardPresentation({
+      'work-dashboard.presentation.selectedMission': 'mission-kungfu',
+      'work-dashboard.presentation.displayMode': 'broken',
+    }),
+    {
+      selectedMission: 'mission-kungfu',
+      selectedGoal: null,
+      statusFilter: undefined,
+      displayMode: undefined,
+    },
+  );
+});

--- a/framework/gui/docs/shell-and-kfx.md
+++ b/framework/gui/docs/shell-and-kfx.md
@@ -28,6 +28,9 @@ externalizable so publishing it later is a move, not a rewrite.
    Activity Rail adds Agent Console, Profiles and Skills; application menus,
    the command palette, `KFE_INITIAL_VIEW`, and cross-kfx navigation with
    parameters (`shell.open('rewind', { run })`) reach the wider installed set.
+   A first-party view can instead request contextual presentation through
+   `shell.openContextualView(...)`; the reference GUI renders that target in a
+   right-side drawer without replacing or remounting the active view.
 5. **Refresh coordination.** A shared refresh bus with one timer; kfx
    subscribe instead of running their own intervals.
 6. **Profiles and suites.** A Profile Suite declares semantic/distribution
@@ -181,6 +184,13 @@ still giving first-party/system kfx a stable notification surface. Sandboxed
 views currently receive inert shell-chrome methods because the sandbox bridge
 only relays declared capabilities; a future shell bridge must be explicit IPC,
 not shared renderer callbacks.
+
+Contextual presentation follows the same ownership boundary. A view supplies a
+target kfx id and string parameters; the shell resolves that target's own
+declared capabilities and mounts it in shell chrome. The requesting view never
+imports the target package or borrows its capability set. Closing the drawer
+removes only that presentation; session lifecycle remains owned by the target
+kfx and its runtime capabilities.
 
 ## Trust tiers (ADR-0011 / ADR-0013 / ADR-0014)
 

--- a/framework/gui/src/renderer/contextual-view-layout.test.ts
+++ b/framework/gui/src/renderer/contextual-view-layout.test.ts
@@ -1,0 +1,40 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  DEFAULT_CONTEXTUAL_COMPANION_WIDTH,
+  contextualViewLayout,
+} from './src/contextual-view-layout.ts';
+
+test('ordinary contextual views remain right-side overlays', () => {
+  assert.deepEqual(contextualViewLayout({}), {
+    placement: 'overlay-right',
+    companionWidth: null,
+    left: 'auto',
+    right: 0,
+    width: 'min(760px, 68vw)',
+    minWidth: 480,
+    borderLeft: '1px solid #3c3c3c',
+    borderRight: 'none',
+    boxShadow: '-18px 0 46px rgba(0, 0, 0, 0.48)',
+  });
+});
+
+test('a Go Console docks to the left of its reserved detail companion', () => {
+  const layout = contextualViewLayout({
+    contextPlacement: 'left-of-companion',
+    contextCompanionWidth: 'min(520px, 50%)',
+  });
+  assert.equal(layout.placement, 'left-of-companion');
+  assert.equal(layout.left, 0);
+  assert.equal(layout.right, 'min(520px, 50%)');
+  assert.equal(layout.width, 'auto');
+  assert.equal(layout.companionWidth, 'min(520px, 50%)');
+});
+
+test('side-by-side contextual views have a stable companion fallback', () => {
+  assert.equal(
+    contextualViewLayout({ contextPlacement: 'left-of-companion' })
+      .companionWidth,
+    DEFAULT_CONTEXTUAL_COMPANION_WIDTH,
+  );
+});

--- a/framework/gui/src/renderer/src/contextual-view-layout.ts
+++ b/framework/gui/src/renderer/src/contextual-view-layout.ts
@@ -1,0 +1,48 @@
+export const DEFAULT_CONTEXTUAL_COMPANION_WIDTH = 'min(460px, 48%)';
+
+export type ContextualViewLayout = {
+  placement: 'overlay-right' | 'left-of-companion';
+  companionWidth: string | null;
+  left: number | 'auto';
+  right: number | string;
+  width: string;
+  minWidth: number;
+  borderLeft: string;
+  borderRight: string;
+  boxShadow: string;
+};
+
+function companionWidth(params: Record<string, string>): string {
+  const requested = params.contextCompanionWidth?.trim();
+  return requested || DEFAULT_CONTEXTUAL_COMPANION_WIDTH;
+}
+
+export function contextualViewLayout(
+  params: Record<string, string>,
+): ContextualViewLayout {
+  if (params.contextPlacement === 'left-of-companion') {
+    const reserved = companionWidth(params);
+    return {
+      placement: 'left-of-companion',
+      companionWidth: reserved,
+      left: 0,
+      right: reserved,
+      width: 'auto',
+      minWidth: 0,
+      borderLeft: 'none',
+      borderRight: '1px solid #3c3c3c',
+      boxShadow: '18px 0 46px rgba(0, 0, 0, 0.38)',
+    };
+  }
+  return {
+    placement: 'overlay-right',
+    companionWidth: null,
+    left: 'auto',
+    right: 0,
+    width: 'min(760px, 68vw)',
+    minWidth: 480,
+    borderLeft: '1px solid #3c3c3c',
+    borderRight: 'none',
+    boxShadow: '-18px 0 46px rgba(0, 0, 0, 0.48)',
+  };
+}

--- a/framework/gui/src/renderer/src/main.tsx
+++ b/framework/gui/src/renderer/src/main.tsx
@@ -778,6 +778,10 @@ function App() {
       window.process.env.KFE_INITIAL_VIEW || profileHomeId(profile, enabled),
   );
   const [params, setParams] = React.useState<Record<string, string>>({});
+  const [contextualView, setContextualView] = React.useState<{
+    kfxId: string;
+    params: Record<string, string>;
+  } | null>(null);
   const [settingsOpen, setSettingsOpen] = React.useState(false);
   const [workspaceOpen, setWorkspaceOpen] = React.useState(false);
   const [commandText, setCommandText] = React.useState('');
@@ -888,11 +892,23 @@ function App() {
 
   const openKfx = React.useCallback(
     (kfxId: string, nextParams?: Record<string, string>) => {
+      setContextualView(null);
       setParams(nextParams ?? {});
       setActive(kfxId);
     },
     [],
   );
+
+  const openContextualView = React.useCallback(
+    (kfxId: string, nextParams?: Record<string, string>) => {
+      setContextualView({ kfxId, params: nextParams ?? {} });
+    },
+    [],
+  );
+
+  const closeContextualView = React.useCallback(() => {
+    setContextualView(null);
+  }, []);
 
   const updateState = React.useCallback(
     (patch: Partial<ShellState>) => {
@@ -1165,6 +1181,8 @@ function App() {
 
   const shell: Shell = {
     open: openKfx,
+    openContextualView,
+    closeContextualView,
     params,
     onRefresh: subscribeRefresh,
     setting: (key) => state.settings[key] ?? settingFallbacks[key] ?? '',
@@ -1242,6 +1260,15 @@ function App() {
   );
 
   const caps = activeKfx ? subsetCaps(runtime, activeKfx) : null;
+  const contextualKfx = contextualView
+    ? (enabled.find((entry) => entry.id === contextualView.kfxId) ?? null)
+    : null;
+  const contextualCaps = contextualKfx
+    ? subsetCaps(runtime, contextualKfx)
+    : null;
+  const contextualShell: Shell = contextualView
+    ? { ...shell, params: contextualView.params }
+    : shell;
   const settingsKfx =
     enabled.find((k) => k.id === 'settings') ??
     loaded.entries.find((k) => k.id === 'settings') ??
@@ -1771,7 +1798,14 @@ function App() {
                 </div>
               )}
             </nav>
-            <div style={{ flex: 1, minHeight: 0, overflow: 'hidden' }}>
+            <div
+              style={{
+                flex: 1,
+                minHeight: 0,
+                overflow: 'hidden',
+                position: 'relative',
+              }}
+            >
               {activeKfx && activeKfx.tier === 'sandboxed-ipc' ? (
                 // isolated third-party view: embedded, not mounted here
                 <KfxErrorBoundary kfxId={activeKfx.id}>
@@ -1802,6 +1836,120 @@ function App() {
                     </div>
                   ))}
                 </section>
+              )}
+              {contextualView && (
+                <aside
+                  aria-label={
+                    contextualView.params.contextTitle || 'Contextual view'
+                  }
+                  style={{
+                    position: 'absolute',
+                    top: 0,
+                    right: 0,
+                    bottom: 0,
+                    zIndex: 100,
+                    width: 'min(760px, 68vw)',
+                    minWidth: 480,
+                    display: 'flex',
+                    flexDirection: 'column',
+                    overflow: 'hidden',
+                    background: '#1e1e1e',
+                    borderLeft: '1px solid #3c3c3c',
+                    boxShadow: '-18px 0 46px rgba(0, 0, 0, 0.48)',
+                    animation: 'kf-contextual-view-in 140ms ease-out',
+                  }}
+                >
+                  <style>
+                    {
+                      '@keyframes kf-contextual-view-in { from { transform: translateX(24px); opacity: 0; } to { transform: translateX(0); opacity: 1; } }'
+                    }
+                  </style>
+                  <header
+                    style={{
+                      minHeight: 42,
+                      padding: '7px 10px',
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 10,
+                      borderBottom: '1px solid #333',
+                      background: '#252526',
+                    }}
+                  >
+                    <div style={{ minWidth: 0, flex: 1 }}>
+                      <div
+                        style={{
+                          ...mono,
+                          color: '#9cdcfe',
+                          fontSize: 11,
+                          overflow: 'hidden',
+                          textOverflow: 'ellipsis',
+                          whiteSpace: 'nowrap',
+                        }}
+                      >
+                        {contextualView.params.contextTitle ||
+                          contextualKfx?.title ||
+                          'Context'}
+                      </div>
+                      {contextualView.params.contextSubtitle && (
+                        <div
+                          style={{
+                            ...mono,
+                            color: '#858585',
+                            fontSize: 9,
+                            overflow: 'hidden',
+                            textOverflow: 'ellipsis',
+                            whiteSpace: 'nowrap',
+                          }}
+                        >
+                          {contextualView.params.contextSubtitle}
+                        </div>
+                      )}
+                    </div>
+                    <button
+                      type="button"
+                      onClick={closeContextualView}
+                      title="Close contextual view"
+                      aria-label="Close contextual view"
+                      style={{
+                        ...mono,
+                        width: 28,
+                        height: 28,
+                        border: '1px solid #3c3c3c',
+                        borderRadius: 5,
+                        cursor: 'pointer',
+                        background: '#1e1e1e',
+                        color: '#cccccc',
+                      }}
+                    >
+                      ×
+                    </button>
+                  </header>
+                  <div
+                    style={{
+                      flex: 1,
+                      minHeight: 0,
+                      overflow: 'hidden',
+                      padding: 8,
+                    }}
+                  >
+                    {contextualKfx &&
+                    contextualKfx.tier === 'node-integrated' &&
+                    contextualCaps ? (
+                      <KfxErrorBoundary kfxId={contextualKfx.id}>
+                        <contextualKfx.View
+                          caps={contextualCaps}
+                          shell={contextualShell}
+                        />
+                      </KfxErrorBoundary>
+                    ) : (
+                      <section style={panelStyle}>
+                        <div style={{ ...mono, color: '#f48771' }}>
+                          contextual view unavailable
+                        </div>
+                      </section>
+                    )}
+                  </div>
+                </aside>
               )}
             </div>
           </div>

--- a/framework/gui/src/renderer/src/main.tsx
+++ b/framework/gui/src/renderer/src/main.tsx
@@ -59,6 +59,7 @@ import {
 } from '../../sandbox/channels';
 import { publishRefresh } from '../../sandbox/refresh';
 import { createKfxSharedModules } from '../shared-modules';
+import { contextualViewLayout } from './contextual-view-layout';
 import {
   loadKungfuConfig,
   normalizedUiConfig,
@@ -1269,6 +1270,9 @@ function App() {
   const contextualShell: Shell = contextualView
     ? { ...shell, params: contextualView.params }
     : shell;
+  const contextualLayout = contextualView
+    ? contextualViewLayout(contextualView.params)
+    : null;
   const settingsKfx =
     enabled.find((k) => k.id === 'settings') ??
     loaded.entries.find((k) => k.id === 'settings') ??
@@ -1804,6 +1808,12 @@ function App() {
                 minHeight: 0,
                 overflow: 'hidden',
                 position: 'relative',
+                ...(contextualLayout?.companionWidth
+                  ? ({
+                      '--kf-contextual-companion-width':
+                        contextualLayout.companionWidth,
+                    } as React.CSSProperties)
+                  : {}),
               }}
             >
               {activeKfx && activeKfx.tier === 'sandboxed-ipc' ? (
@@ -1845,17 +1855,22 @@ function App() {
                   style={{
                     position: 'absolute',
                     top: 0,
-                    right: 0,
+                    right: contextualLayout?.right ?? 0,
                     bottom: 0,
+                    left: contextualLayout?.left ?? 'auto',
                     zIndex: 100,
-                    width: 'min(760px, 68vw)',
-                    minWidth: 480,
+                    width: contextualLayout?.width ?? 'min(760px, 68vw)',
+                    minWidth: contextualLayout?.minWidth ?? 480,
                     display: 'flex',
                     flexDirection: 'column',
                     overflow: 'hidden',
                     background: '#1e1e1e',
-                    borderLeft: '1px solid #3c3c3c',
-                    boxShadow: '-18px 0 46px rgba(0, 0, 0, 0.48)',
+                    borderLeft:
+                      contextualLayout?.borderLeft ?? '1px solid #3c3c3c',
+                    borderRight: contextualLayout?.borderRight ?? 'none',
+                    boxShadow:
+                      contextualLayout?.boxShadow ??
+                      '-18px 0 46px rgba(0, 0, 0, 0.48)',
                     animation: 'kf-contextual-view-in 140ms ease-out',
                   }}
                 >

--- a/framework/kfx/src/index.ts
+++ b/framework/kfx/src/index.ts
@@ -1233,6 +1233,11 @@ export type SessionWindowRecord = {
 export type Shell = {
   // cross-kfx navigation with parameters; params reach the target view
   open: (kfxId: string, params?: Record<string, string>) => void;
+  // Present a KFX beside the current view without replacing its navigation
+  // context. The reference GUI renders this as a right-side contextual drawer;
+  // hosts that do not support contextual presentation leave these undefined.
+  openContextualView?: (kfxId: string, params?: Record<string, string>) => void;
+  closeContextualView?: () => void;
   // the params this view was last opened with
   params: Record<string, string>;
   // shared refresh bus (one shell-owned timer); returns the unsubscribe

--- a/framework/kfx/src/index.ts
+++ b/framework/kfx/src/index.ts
@@ -1234,7 +1234,7 @@ export type Shell = {
   // cross-kfx navigation with parameters; params reach the target view
   open: (kfxId: string, params?: Record<string, string>) => void;
   // Present a KFX beside the current view without replacing its navigation
-  // context. The reference GUI renders this as a right-side contextual drawer;
+  // context. The reference GUI supports both overlay and companion layouts;
   // hosts that do not support contextual presentation leave these undefined.
   openContextualView?: (kfxId: string, params?: Record<string, string>) => void;
   closeContextualView?: () => void;


### PR DESCRIPTION
## Summary

Keep Mission Control navigation state and present Go-bound Agent Consoles contextually without replacing the Dashboard.

## Changes

- persist Mission, Go, filter, and display selection through the journal-backed shell settings
- add a shell-owned contextual KFX drawer for Go-bound Agent Consoles
- default the main Agent Console to the workspace assistant while retaining an explicit all-console registry
- keep contextual console scope bound to the exact WorkRef

## Verification

- ./shifu check
- ./shifu exec node --test extensions/terminal/tests/*.test.ts extensions/work-dashboard/tests/*.test.ts (31/31)
- ./shifu build:app
- ./shifu dist:dir
- Shifu Product build 20260714T031557Z-c0748deeb-dirty promoted and launched on macOS

<!-- kungfu-adr-release:v1
{"schema":"kungfu.adr-release-pr/v1","kind":"dev-delivery","intent":"stage-ready","adrs":["ADR-0079"],"summary":"Complete the bounded Mission Control to contextual WorkConsole presentation stage while keeping the workspace assistant as the main Agent Console default.","verification":["shifu check","31 focused Node tests","Mac GUI production bundle","Mac Product build and Shifu promotion"]}
-->

## Governance risk check

- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed