### PR TITLE
feat(runtime): isolate process host from coordinator engine

### DIFF
--- a/.buildchain/kfd/kfd-1/contract-world.witness.json
+++ b/.buildchain/kfd/kfd-1/contract-world.witness.json
@@ -35,7 +35,7 @@
   "sourceVerificationRequired": false,
   "canonicalPolicy": {
     "path": "framework/contract/kungfu-agent-first-canonical-policy.json",
-    "sha256": "ab9cdea224f0fc617ef75cdf48f920605b75da2cd401a8ec43713931b0b7307d"
+    "sha256": "410aef8c9689ac0a9719d0e0bfbbd0bd7181fd29152e8b3f1bf25670120b0760"
   },
   "registry": {
     "path": "framework/contract/kungfu-contracts.registry.json",
@@ -69,9 +69,9 @@
     {
       "name": "kungfu-runtime",
       "sourcePath": "framework/runtime/kungfu-runtime.contract.json",
-      "sourceSha256": "63f869f92ece01fc3e0d62ccd3de1a53ca49ad61acafd01c62213d6d50268263",
+      "sourceSha256": "9e374d67f59d3f59a382d6cb8412e7033cd89809d39cde2772d36fe081740373",
       "artifactPath": "config/kungfu-runtime.contract.json",
-      "expectedSha256": "63f869f92ece01fc3e0d62ccd3de1a53ca49ad61acafd01c62213d6d50268263",
+      "expectedSha256": "9e374d67f59d3f59a382d6cb8412e7033cd89809d39cde2772d36fe081740373",
       "byteForByte": true
     }
   ],

--- a/.buildchain/kfd/kfd-1/release-gate.json
+++ b/.buildchain/kfd/kfd-1/release-gate.json
@@ -54,13 +54,13 @@
       "standard": "KFD-1",
       "standardKey": "kfd-1",
       "result": "passed",
-      "preBuildWitnessSha256": "ba98bf94b69919ece4c2c29da815627c7ebf63fdfe14bde48919475675e06e7c",
+      "preBuildWitnessSha256": "9f55af33a0fcf9811c29afc960131c89eec4de8641b49a824313fb62de1224e0",
       "sourceHashes": {
-        "sha256": "33dabf613ee2e54aab958ca05f65412a9c5b68717e36f880aa68aed24bbac402",
+        "sha256": "61972f067187189b02e5cb01e1d311633b5ffff1408e79400e9c33105d3004ff",
         "surfaceCount": 4
       },
       "artifactHashes": {
-        "sha256": "99022353f04209b9ecc52de20b42fda3f3829d878dd911008ed64ba0446de2f0",
+        "sha256": "f1cfd47d8d141e60f8be6413fa1e72dbe6486d96451939805b54e238fbd378bc",
         "surfaceCount": 4
       },
       "witness": {
@@ -100,7 +100,7 @@
         "sourceVerificationRequired": true,
         "canonicalPolicy": {
           "path": "framework/contract/kungfu-agent-first-canonical-policy.json",
-          "sha256": "ab9cdea224f0fc617ef75cdf48f920605b75da2cd401a8ec43713931b0b7307d"
+          "sha256": "410aef8c9689ac0a9719d0e0bfbbd0bd7181fd29152e8b3f1bf25670120b0760"
         },
         "registry": {
           "path": "framework/contract/kungfu-contracts.registry.json",
@@ -134,9 +134,9 @@
           {
             "name": "kungfu-runtime",
             "sourcePath": "framework/runtime/kungfu-runtime.contract.json",
-            "sourceSha256": "63f869f92ece01fc3e0d62ccd3de1a53ca49ad61acafd01c62213d6d50268263",
+            "sourceSha256": "9e374d67f59d3f59a382d6cb8412e7033cd89809d39cde2772d36fe081740373",
             "artifactPath": "config/kungfu-runtime.contract.json",
-            "expectedSha256": "63f869f92ece01fc3e0d62ccd3de1a53ca49ad61acafd01c62213d6d50268263",
+            "expectedSha256": "9e374d67f59d3f59a382d6cb8412e7033cd89809d39cde2772d36fe081740373",
             "byteForByte": true
           }
         ],
@@ -209,8 +209,8 @@
           {
             "name": "kungfu-runtime",
             "sourcePath": "framework/runtime/kungfu-runtime.contract.json",
-            "expectedSha256": "63f869f92ece01fc3e0d62ccd3de1a53ca49ad61acafd01c62213d6d50268263",
-            "actualSha256": "63f869f92ece01fc3e0d62ccd3de1a53ca49ad61acafd01c62213d6d50268263",
+            "expectedSha256": "9e374d67f59d3f59a382d6cb8412e7033cd89809d39cde2772d36fe081740373",
+            "actualSha256": "9e374d67f59d3f59a382d6cb8412e7033cd89809d39cde2772d36fe081740373",
             "status": "passed",
             "reason": ""
           }
@@ -256,10 +256,10 @@
           {
             "name": "kungfu-runtime",
             "sourcePath": "framework/runtime/kungfu-runtime.contract.json",
-            "sourceSha256": "63f869f92ece01fc3e0d62ccd3de1a53ca49ad61acafd01c62213d6d50268263",
+            "sourceSha256": "9e374d67f59d3f59a382d6cb8412e7033cd89809d39cde2772d36fe081740373",
             "artifactPath": "config/kungfu-runtime.contract.json",
-            "expectedSha256": "63f869f92ece01fc3e0d62ccd3de1a53ca49ad61acafd01c62213d6d50268263",
-            "actualSha256": "63f869f92ece01fc3e0d62ccd3de1a53ca49ad61acafd01c62213d6d50268263",
+            "expectedSha256": "9e374d67f59d3f59a382d6cb8412e7033cd89809d39cde2772d36fe081740373",
+            "actualSha256": "9e374d67f59d3f59a382d6cb8412e7033cd89809d39cde2772d36fe081740373",
             "byteForByte": true,
             "status": "passed",
             "reason": ""

--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -5,8 +5,8 @@
   "witnessKind": "prebuild",
   "supportLevel": "release",
   "source": {
-    "cwd": "/Users/dkr/Worktrees/kungfu/feature/runtime-contract-topology-neutral",
-    "sourceSha": "19aab0b6033bb2e7431223b7cfcd62de126da77c",
+    "cwd": "/Users/dkr/Worktrees/kungfu/feature/runtime-engine-process-host",
+    "sourceSha": "1bf69175fdb6dbc19ba83cabc0031e1c711d71c3",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
     "registryDigest": "sha256:6b8e5f64c722f6d97c5ff1f23bf5d8bd584a5358588e214424ea8cce461c5b82"
   },

--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -6,7 +6,7 @@
   "supportLevel": "release",
   "source": {
     "cwd": "/Users/dkr/Worktrees/kungfu/feature/runtime-engine-process-host",
-    "sourceSha": "1bf69175fdb6dbc19ba83cabc0031e1c711d71c3",
+    "sourceSha": "a189758e2483c01cf3d986b6d45f208782dc566b",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
     "registryDigest": "sha256:6b8e5f64c722f6d97c5ff1f23bf5d8bd584a5358588e214424ea8cce461c5b82"
   },

--- a/developer/sdk/kfd/kfd-1/contract-world.witness.json
+++ b/developer/sdk/kfd/kfd-1/contract-world.witness.json
@@ -35,7 +35,7 @@
   "sourceVerificationRequired": false,
   "canonicalPolicy": {
     "path": "framework/contract/kungfu-agent-first-canonical-policy.json",
-    "sha256": "ab9cdea224f0fc617ef75cdf48f920605b75da2cd401a8ec43713931b0b7307d"
+    "sha256": "410aef8c9689ac0a9719d0e0bfbbd0bd7181fd29152e8b3f1bf25670120b0760"
   },
   "registry": {
     "path": "framework/contract/kungfu-contracts.registry.json",
@@ -69,9 +69,9 @@
     {
       "name": "kungfu-runtime",
       "sourcePath": "framework/runtime/kungfu-runtime.contract.json",
-      "sourceSha256": "63f869f92ece01fc3e0d62ccd3de1a53ca49ad61acafd01c62213d6d50268263",
+      "sourceSha256": "9e374d67f59d3f59a382d6cb8412e7033cd89809d39cde2772d36fe081740373",
       "artifactPath": "config/kungfu-runtime.contract.json",
-      "expectedSha256": "63f869f92ece01fc3e0d62ccd3de1a53ca49ad61acafd01c62213d6d50268263",
+      "expectedSha256": "9e374d67f59d3f59a382d6cb8412e7033cd89809d39cde2772d36fe081740373",
       "byteForByte": true
     }
   ],

--- a/developer/sdk/kfd/kfd-1/release-gate.json
+++ b/developer/sdk/kfd/kfd-1/release-gate.json
@@ -54,13 +54,13 @@
       "standard": "KFD-1",
       "standardKey": "kfd-1",
       "result": "passed",
-      "preBuildWitnessSha256": "ba98bf94b69919ece4c2c29da815627c7ebf63fdfe14bde48919475675e06e7c",
+      "preBuildWitnessSha256": "9f55af33a0fcf9811c29afc960131c89eec4de8641b49a824313fb62de1224e0",
       "sourceHashes": {
-        "sha256": "33dabf613ee2e54aab958ca05f65412a9c5b68717e36f880aa68aed24bbac402",
+        "sha256": "61972f067187189b02e5cb01e1d311633b5ffff1408e79400e9c33105d3004ff",
         "surfaceCount": 4
       },
       "artifactHashes": {
-        "sha256": "99022353f04209b9ecc52de20b42fda3f3829d878dd911008ed64ba0446de2f0",
+        "sha256": "f1cfd47d8d141e60f8be6413fa1e72dbe6486d96451939805b54e238fbd378bc",
         "surfaceCount": 4
       },
       "witness": {
@@ -100,7 +100,7 @@
         "sourceVerificationRequired": true,
         "canonicalPolicy": {
           "path": "framework/contract/kungfu-agent-first-canonical-policy.json",
-          "sha256": "ab9cdea224f0fc617ef75cdf48f920605b75da2cd401a8ec43713931b0b7307d"
+          "sha256": "410aef8c9689ac0a9719d0e0bfbbd0bd7181fd29152e8b3f1bf25670120b0760"
         },
         "registry": {
           "path": "framework/contract/kungfu-contracts.registry.json",
@@ -134,9 +134,9 @@
           {
             "name": "kungfu-runtime",
             "sourcePath": "framework/runtime/kungfu-runtime.contract.json",
-            "sourceSha256": "63f869f92ece01fc3e0d62ccd3de1a53ca49ad61acafd01c62213d6d50268263",
+            "sourceSha256": "9e374d67f59d3f59a382d6cb8412e7033cd89809d39cde2772d36fe081740373",
             "artifactPath": "config/kungfu-runtime.contract.json",
-            "expectedSha256": "63f869f92ece01fc3e0d62ccd3de1a53ca49ad61acafd01c62213d6d50268263",
+            "expectedSha256": "9e374d67f59d3f59a382d6cb8412e7033cd89809d39cde2772d36fe081740373",
             "byteForByte": true
           }
         ],
@@ -209,8 +209,8 @@
           {
             "name": "kungfu-runtime",
             "sourcePath": "framework/runtime/kungfu-runtime.contract.json",
-            "expectedSha256": "63f869f92ece01fc3e0d62ccd3de1a53ca49ad61acafd01c62213d6d50268263",
-            "actualSha256": "63f869f92ece01fc3e0d62ccd3de1a53ca49ad61acafd01c62213d6d50268263",
+            "expectedSha256": "9e374d67f59d3f59a382d6cb8412e7033cd89809d39cde2772d36fe081740373",
+            "actualSha256": "9e374d67f59d3f59a382d6cb8412e7033cd89809d39cde2772d36fe081740373",
             "status": "passed",
             "reason": ""
           }
@@ -256,10 +256,10 @@
           {
             "name": "kungfu-runtime",
             "sourcePath": "framework/runtime/kungfu-runtime.contract.json",
-            "sourceSha256": "63f869f92ece01fc3e0d62ccd3de1a53ca49ad61acafd01c62213d6d50268263",
+            "sourceSha256": "9e374d67f59d3f59a382d6cb8412e7033cd89809d39cde2772d36fe081740373",
             "artifactPath": "config/kungfu-runtime.contract.json",
-            "expectedSha256": "63f869f92ece01fc3e0d62ccd3de1a53ca49ad61acafd01c62213d6d50268263",
-            "actualSha256": "63f869f92ece01fc3e0d62ccd3de1a53ca49ad61acafd01c62213d6d50268263",
+            "expectedSha256": "9e374d67f59d3f59a382d6cb8412e7033cd89809d39cde2772d36fe081740373",
+            "actualSha256": "9e374d67f59d3f59a382d6cb8412e7033cd89809d39cde2772d36fe081740373",
             "byteForByte": true,
             "status": "passed",
             "reason": ""

--- a/docs/adr/ADR-0080-topology-neutral-capability-driven-runtime-activation.md
+++ b/docs/adr/ADR-0080-topology-neutral-capability-driven-runtime-activation.md
@@ -4,7 +4,7 @@ doc_type: architecture-decision
 adr_id: ADR-0080
 decision_status: accepted
 implementation_status: partial
-implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/815]
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/815, https://github.com/kungfu-systems/kungfu/pull/818]
 review_state: self-reviewed
 sensitivity: public
 sources: [local-files, user-decision]

--- a/docs/adr/ADR-0080-topology-neutral-capability-driven-runtime-activation.md
+++ b/docs/adr/ADR-0080-topology-neutral-capability-driven-runtime-activation.md
@@ -179,13 +179,16 @@ layouts, a C ABI, thread affinity, re-entrancy, or an external executor
 interface. RuntimeClockExecutor remains internal and provisional until a second
 host requires a qualified implementation.
 
-The current supervisor/coordinator process topology is the first target for
-ProcessRuntimeHost; that contract adapter and broker implementation belong to
-delivery stage 2. EmbeddedRuntimeHost is a reserved non-claim: v1 deliberately
-contains no production implementation, thread model, or qualification claim
-for it. A future host must implement the same requirement, handle, readiness,
-generation, lease, receipt, and error semantics rather than introduce an
-embedded-only public path.
+The current supervisor/coordinator process topology is now behind the Python
+ProcessRuntimeHost placement adapter. CoordinatorEngine provides the directly
+callable, no-fork request seam while process placement, PIDs, signals, spawning,
+and OS service diagnostics stay in the adapter. The semantic RuntimeHost
+requirement/handle adapter remains incomplete until the Core capability broker
+lands in a later delivery stage. EmbeddedRuntimeHost is a reserved non-claim:
+v1 deliberately contains no production implementation, thread model, or
+qualification claim for it. A future host must implement the same requirement,
+handle, readiness, generation, lease, receipt, and error semantics rather than
+introduce an embedded-only public path.
 
 ## Current capability vocabulary
 
@@ -218,7 +221,7 @@ to report one of these errors.
 | Current surface | Migration role | Compatibility rule |
 | --- | --- | --- |
 | kungfu.runtime.status/v2 and kungfu.runtime.routes/v2 | process diagnostics | retain; running/healthy never imply semantic readiness |
-| Python runtime_service.ensure_coordinator | current process-control implementation | move behind ProcessRuntimeHost.activate; do not expose it as the new public requirement |
+| Python runtime_service.ensure_coordinator | compatibility entrypoint | delegates to ProcessRuntimeHost.activate; do not expose it as the new public requirement |
 | kungfu runtime ensure/start/status/stop/restart | operator commands | retain command compatibility while projecting requirement, receipt, handle, and advanced diagnostics |
 | C++ runtime::live::coordinator | coordinator engine | keep domain-neutral terminology and historic wire identity adapter from ADR-0057 |
 | GUI tray/status bar | request and presentation | consume the shared handle/readiness projection; no GUI-only activation authority |
@@ -274,7 +277,7 @@ products copy the exact contract through the existing KFD-1 contract registry.
 ## Delivery stages
 
 1. Land this ADR, the KFD-1 contract, fixtures, and source gate.
-2. Put the current supervisor/coordinator path behind ProcessRuntimeHost.
+2. Put the current supervisor/coordinator path behind ProcessRuntimeHost. **Complete:** CoordinatorEngine supplies the no-fork request seam; ProcessRuntimeHost owns process placement. The full semantic RuntimeHost adapter remains stage 3 work.
 3. Add the Core capability broker and generation-fenced handles.
 4. Bind recovery and projection readiness to an exact durable cut.
 5. Add leases, idle draining, adoption, and restart recovery.

--- a/docs/architecture/runtime-service.md
+++ b/docs/architecture/runtime-service.md
@@ -11,8 +11,9 @@ The topology-neutral activation and readiness contract is defined by
 The canonical process-adapter terminology is defined by
 [ADR-0057](../adr/ADR-0057-domain-neutral-live-runtime-terminology.md);
 [ADR-0036](../adr/ADR-0036-supervisor-and-workspace-master-topology.md)
-records the original topology decision. The current process-control topology
-has two live process roles:
+records the original topology decision. The current process-control topology is
+implemented by `ProcessRuntimeHost` over a directly callable
+`CoordinatorEngine` and has two live process roles:
 
 - `supervisor` is one per OS user/session. It owns no workspace facts. It
   starts, discovers, health-checks, and stops workspace coordinators.
@@ -35,7 +36,7 @@ updates. It does not become fact authority or embed every domain assessor. See
 
 ## Current CLI Surface
 
-The current implementation slice exposes the process-control topology through
+The current implementation slice exposes this process adapter through
 `kungfu runtime ...` commands:
 
 - `kungfu runtime supervise` is the foreground supervisor loop used by a user
@@ -67,7 +68,7 @@ The v2 status and route payloads are compatibility diagnostics. A reported
 `running` process lifecycle does not establish the ADR-0080 runtime `ready`
 state, capability set, generation, or durable cut.
 
-## Current Process-control Topology
+## Current ProcessRuntimeHost Topology
 
 The target live command path is:
 
@@ -78,6 +79,14 @@ CLI / GUI / TUI
   -> supervisor ensure_coordinator(data_root)
   -> command talks to that data-root coordinator
 ```
+
+`kungfu.runtime_service.ensure_coordinator` is a compatibility function that
+delegates activation to `ProcessRuntimeHost`. The adapter owns PID files,
+signals, child spawning, detached supervisor startup, and process diagnostics.
+`CoordinatorEngine` owns the directly callable coordinator request seam and
+accepts an injected assessment executor; its no-fork fixture uses no PID,
+signal, argv, environment, or subprocess authority. This seam is qualification
+evidence, not a production EmbeddedRuntimeHost.
 
 If the supervisor is not running, a product entrypoint may start it. If a
 command only needs closed-data storage access, it may bypass the live coordinator and

--- a/docs/qualification/contracts.md
+++ b/docs/qualification/contracts.md
@@ -165,11 +165,12 @@ The source gate validates four positive contract cases and rejects PID-as-
 readiness, dual active generations, ready without a cut, authority broadening,
 GUI-only activation, and silent live-required downgrade.
 
-**Maturity.** Staged. The contract, registry integration, fixtures, and source
-gate are implemented. The current supervisor/coordinator process topology
-remains active; ProcessRuntimeHost, the Core broker, recovery-bound activation,
-full language/product projection, and product qualification land in later
-stages. EmbeddedRuntimeHost is an explicit non-claim.
+**Maturity.** Staged. The contract, registry integration, fixtures, source gate,
+ProcessRuntimeHost placement adapter, and directly callable CoordinatorEngine
+no-fork seam are implemented. The semantic RuntimeHost requirement/handle
+adapter, Core broker, recovery-bound activation, full language/product
+projection, and product qualification land in later stages. EmbeddedRuntimeHost
+is an explicit non-claim.
 
 ## The KFD-1 contract registry is the packaging source of truth
 

--- a/framework/contract/kungfu-agent-first-canonical-policy.json
+++ b/framework/contract/kungfu-agent-first-canonical-policy.json
@@ -157,13 +157,13 @@
       },
       "source": {
         "path": "framework/runtime/kungfu-runtime.contract.json",
-        "sha256": "sha256:63f869f92ece01fc3e0d62ccd3de1a53ca49ad61acafd01c62213d6d50268263",
-        "renderedSha256": "sha256:63f869f92ece01fc3e0d62ccd3de1a53ca49ad61acafd01c62213d6d50268263",
+        "sha256": "sha256:9e374d67f59d3f59a382d6cb8412e7033cd89809d39cde2772d36fe081740373",
+        "renderedSha256": "sha256:9e374d67f59d3f59a382d6cb8412e7033cd89809d39cde2772d36fe081740373",
         "byteForByte": true
       },
       "artifact": {
         "path": "config/kungfu-runtime.contract.json",
-        "expectedSha256": "sha256:63f869f92ece01fc3e0d62ccd3de1a53ca49ad61acafd01c62213d6d50268263"
+        "expectedSha256": "sha256:9e374d67f59d3f59a382d6cb8412e7033cd89809d39cde2772d36fe081740373"
       }
     }
   ]

--- a/framework/core/src/python/kungfu/runtime_service.py
+++ b/framework/core/src/python/kungfu/runtime_service.py
@@ -11,7 +11,7 @@ import time
 from dataclasses import dataclass
 from hashlib import sha256
 from pathlib import Path
-from typing import Any
+from typing import Any, Protocol
 from xml.sax.saxutils import escape as xml_escape
 
 import kungfu
@@ -37,6 +37,28 @@ LEGACY_STATE_DIR_NAME = "master"
 SERVICE_ID = "tech.kungfu.supervisor"
 SERVICE_NAME = "Kungfu Supervisor"
 ROUTE_LEASE_TTL_SECONDS = 30.0
+
+
+@dataclass(frozen=True)
+class RuntimeEngineRequest:
+    operation: str
+
+
+@dataclass(frozen=True)
+class RuntimeEngineReceipt:
+    operation: str
+    accepted: bool
+    state: str
+    capabilities: tuple[str, ...]
+    error: str | None = None
+
+
+class AssessmentExecutor(Protocol):
+    def ready(self, nanotime: int) -> bool: ...
+
+    def start(self, assessment_key: str, nanotime: int) -> None: ...
+
+    def close(self) -> None: ...
 
 
 def _now() -> float:
@@ -505,7 +527,9 @@ def repair_route_state(
         unlink_coordinator_pid_files(runtime_dir)
         repairs.append("removed-dead-coordinator-pid")
     if current["lifecycle"]["state"] == "orphan-coordinator" and coordinator_pid:
-        if _terminate_and_wait(coordinator_pid):
+        if ProcessRuntimeHost(config_home=config_home).terminate_and_wait(
+            coordinator_pid
+        ):
             unlink_coordinator_pid_files(runtime_dir)
             repairs.append("terminated-orphan-coordinator")
         else:
@@ -515,8 +539,86 @@ def repair_route_state(
     return repairs
 
 
-class Coordinator(NativeCoordinator):
-    def __init__(self, home: str, runtime_dir: str, low_latency: bool = False) -> None:
+class ProcessAssessmentExecutor:
+    def __init__(self, home: str, runtime_dir: str, log_level: str) -> None:
+        self.home = home
+        self.runtime_dir = runtime_dir
+        self.log_level = log_level
+        self.current: tuple[str, subprocess.Popen[Any], int] | None = None
+
+    @staticmethod
+    def _timeout_ns() -> int:
+        raw = os.environ.get("KF_ASSESSMENT_WORKER_TIMEOUT_SECONDS", "30")
+        try:
+            seconds = max(float(raw), 0.1)
+        except ValueError:
+            seconds = 30.0
+        return int(seconds * 1_000_000_000)
+
+    def ready(self, nanotime: int) -> bool:
+        if self.current is None:
+            return True
+        _, child, started_at = self.current
+        if child.poll() is not None:
+            self.current = None
+            return True
+        if nanotime - started_at < self._timeout_ns():
+            return False
+        child.terminate()
+        try:
+            child.wait(timeout=2)
+        except subprocess.TimeoutExpired:
+            child.kill()
+            child.wait()
+        self.current = None
+        return True
+
+    def start(self, assessment_key: str, nanotime: int) -> None:
+        command = assessment_worker_command(self.runtime_dir, assessment_key)
+        coordinator_log_path(self.runtime_dir).parent.mkdir(parents=True, exist_ok=True)
+        with coordinator_log_path(self.runtime_dir).open("ab") as log:
+            child = subprocess.Popen(
+                command,
+                stdin=subprocess.DEVNULL,
+                stdout=log,
+                stderr=subprocess.STDOUT,
+                env=command_env(
+                    self.home,
+                    self.runtime_dir,
+                    self.log_level,
+                ),
+            )
+        self.current = (assessment_key, child, nanotime)
+
+    def close(self) -> None:
+        if self.current is None:
+            return
+        _, child, _ = self.current
+        if child.poll() is None:
+            child.terminate()
+            try:
+                child.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                child.kill()
+                child.wait()
+        self.current = None
+
+
+class CoordinatorEngine(NativeCoordinator):
+    CAPABILITIES = (
+        "runtime.peer-registry",
+        "runtime.channel-routing",
+        "runtime.assessment-scheduling",
+    )
+
+    def __init__(
+        self,
+        home: str,
+        runtime_dir: str,
+        low_latency: bool = False,
+        *,
+        assessment_executor: AssessmentExecutor | None = None,
+    ) -> None:
         locator = yjj.locator(runtime_dir)
         location = yjj.location(
             lf.enums.mode.LIVE,
@@ -528,17 +630,24 @@ class Coordinator(NativeCoordinator):
         super().__init__(location, low_latency)
         self.home_dir = home
         self.runtime_dir = runtime_dir
-        self._assessment_worker: tuple[str, subprocess.Popen[Any], int] | None = None
+        self._assessment_executor = assessment_executor
         self._assessment_last_check = 0
 
-    @staticmethod
-    def _assessment_worker_timeout_ns() -> int:
-        raw = os.environ.get("KF_ASSESSMENT_WORKER_TIMEOUT_SECONDS", "30")
-        try:
-            seconds = max(float(raw), 0.1)
-        except ValueError:
-            seconds = 30.0
-        return int(seconds * 1_000_000_000)
+    def handle_request(self, request: RuntimeEngineRequest) -> RuntimeEngineReceipt:
+        if request.operation == "inspect":
+            return RuntimeEngineReceipt(
+                operation=request.operation,
+                accepted=True,
+                state="constructed",
+                capabilities=self.CAPABILITIES,
+            )
+        return RuntimeEngineReceipt(
+            operation=request.operation,
+            accepted=False,
+            state="rejected",
+            capabilities=(),
+            error="unsupported-operation",
+        )
 
     def on_register(self, gen_time: int, register_data: Any) -> None:
         return None
@@ -550,18 +659,11 @@ class Coordinator(NativeCoordinator):
         if nanotime - self._assessment_last_check < 500_000_000:
             return
         self._assessment_last_check = nanotime
-        if self._assessment_worker is not None:
-            _, child, started_at = self._assessment_worker
-            if child.poll() is None:
-                if nanotime - started_at < self._assessment_worker_timeout_ns():
-                    return
-                child.terminate()
-                try:
-                    child.wait(timeout=2)
-                except subprocess.TimeoutExpired:
-                    child.kill()
-                    child.wait()
-            self._assessment_worker = None
+        if (
+            self._assessment_executor is not None
+            and not self._assessment_executor.ready(nanotime)
+        ):
+            return
 
         snapshot = publish_assessment_snapshot(self.runtime_dir)
         pending = [
@@ -571,47 +673,196 @@ class Coordinator(NativeCoordinator):
         ]
         if not pending:
             return
+        if self._assessment_executor is None:
+            return
         assessment_key = str(pending[0]["assessment_key"])
-        command = assessment_worker_command(self.runtime_dir, assessment_key)
-        coordinator_log_path(self.runtime_dir).parent.mkdir(parents=True, exist_ok=True)
-        with coordinator_log_path(self.runtime_dir).open("ab") as log:
-            child = subprocess.Popen(
+        self._assessment_executor.start(assessment_key, nanotime)
+
+    def close(self) -> None:
+        if self._assessment_executor is not None:
+            self._assessment_executor.close()
+
+
+class Coordinator(CoordinatorEngine):
+    """Compatibility process coordinator; new no-fork code uses CoordinatorEngine."""
+
+    def __init__(self, home: str, runtime_dir: str, low_latency: bool = False) -> None:
+        super().__init__(
+            home,
+            runtime_dir,
+            low_latency,
+            assessment_executor=ProcessAssessmentExecutor(
+                home,
+                runtime_dir,
+                os.environ.get("KF_LOG_LEVEL", "warning"),
+            ),
+        )
+
+
+class ProcessRuntimeHost:
+    """Owns process placement while CoordinatorEngine owns runtime semantics."""
+
+    def __init__(
+        self,
+        log_level: str = "warning",
+        config_home: str | None = None,
+    ) -> None:
+        self.log_level = log_level
+        self.config_home = resolve_config_home(config_home)
+
+    def run_foreground(
+        self, home: str, runtime_dir: str, low_latency: bool = False
+    ) -> int:
+        home = resolve_runtime_home(home)
+        runtime_dir = resolve_runtime_dir(home, runtime_dir)
+        state_dir(runtime_dir).mkdir(parents=True, exist_ok=True)
+        write_pid(coordinator_pid_path(runtime_dir), os.getpid())
+        _json_write(
+            state_path(runtime_dir),
+            {
+                "schema": SCHEMA_STATUS,
+                "status": "coordinator-running",
+                "home": home,
+                "runtimeDir": runtime_dir,
+                "coordinatorPid": os.getpid(),
+                "updatedAt": _now(),
+            },
+        )
+        engine = CoordinatorEngine(
+            home,
+            runtime_dir,
+            low_latency=low_latency,
+            assessment_executor=ProcessAssessmentExecutor(
+                home, runtime_dir, self.log_level
+            ),
+        )
+        try:
+            engine.run()
+            return 0
+        finally:
+            engine.close()
+            unlink_coordinator_pid_files(runtime_dir)
+
+    def spawn_coordinator(self, home: str, runtime_dir: str) -> subprocess.Popen[Any]:
+        home = resolve_runtime_home(home)
+        runtime_dir = resolve_runtime_dir(home, runtime_dir)
+        command = coordinator_run_command(home, runtime_dir, self.log_level)
+        coordinator_log_path(runtime_dir).parent.mkdir(parents=True, exist_ok=True)
+        with coordinator_log_path(runtime_dir).open("ab") as log:
+            return subprocess.Popen(
                 command,
-                stdin=subprocess.DEVNULL,
-                stdout=log,
-                stderr=subprocess.STDOUT,
                 env=command_env(
-                    self.home_dir,
-                    self.runtime_dir,
-                    os.environ.get("KF_LOG_LEVEL", "warning"),
+                    home,
+                    runtime_dir,
+                    self.log_level,
+                    self.config_home,
                 ),
+                stdout=log,
+                stderr=log,
             )
-        self._assessment_worker = (assessment_key, child, nanotime)
+
+    def spawn_supervisor(
+        self, home: str, runtime_dir: str
+    ) -> tuple[subprocess.Popen[Any], list[str]]:
+        home = resolve_runtime_home(home)
+        runtime_dir = resolve_runtime_dir(home, runtime_dir)
+        supervisor_state_dir(self.config_home).mkdir(parents=True, exist_ok=True)
+        command = supervisor_command(
+            self.config_home,
+            self.log_level,
+            home=home,
+            runtime_dir=runtime_dir,
+            foreground=True,
+        )
+        with supervisor_log_path(self.config_home).open("ab") as log:
+            kwargs: dict[str, Any] = {
+                "env": command_env(
+                    home,
+                    runtime_dir,
+                    self.log_level,
+                    self.config_home,
+                ),
+                "stdout": log,
+                "stderr": log,
+            }
+            if platform.system() == "Windows":
+                detached_process = getattr(subprocess, "DETACHED_PROCESS", 0x00000008)
+                new_process_group = getattr(
+                    subprocess, "CREATE_NEW_PROCESS_GROUP", 0x00000200
+                )
+                kwargs["creationflags"] = detached_process | new_process_group
+            else:
+                kwargs["start_new_session"] = True
+            child = subprocess.Popen(command, **kwargs)
+        return child, command
+
+    def activate(self, home: str, runtime_dir: str) -> dict[str, Any]:
+        home = resolve_runtime_home(home)
+        runtime_dir = resolve_runtime_dir(home, runtime_dir)
+        repairs = repair_route_state(home, runtime_dir, self.config_home)
+        route = upsert_route(self.config_home, home, runtime_dir)
+        current = route_status(home, runtime_dir, self.config_home)
+        if current["supervisor"]["running"]:
+            return _wait_for_coordinator(
+                home,
+                runtime_dir,
+                self.config_home,
+                changed=False,
+                route=route,
+                repairs=repairs,
+            )
+        _, command = self.spawn_supervisor(home, runtime_dir)
+        return _wait_for_coordinator(
+            home,
+            runtime_dir,
+            self.config_home,
+            changed=True,
+            command=command,
+            route=route,
+            repairs=repairs,
+        )
+
+    def inspect(self, home: str, runtime_dir: str) -> dict[str, Any]:
+        return route_status(home, runtime_dir, self.config_home)
+
+    def drain(self, timeout: float = 10.0) -> dict[str, Any]:
+        return self.stop_supervisor(timeout)
+
+    def install_stop_handlers(self, callback: Any) -> None:
+        signal.signal(signal.SIGTERM, callback)
+        if platform.system() != "Windows":
+            signal.signal(signal.SIGINT, callback)
+
+    @staticmethod
+    def terminate_child(child: subprocess.Popen[Any]) -> None:
+        if child.poll() is None:
+            child.terminate()
+
+    @staticmethod
+    def terminate_and_wait(pid: int, timeout: float = 2.0) -> bool:
+        return _terminate_and_wait(pid, timeout)
+
+    def stop_supervisor(self, timeout: float = 10.0) -> dict[str, Any]:
+        current = supervisor_status(self.config_home)
+        pid = current["supervisor"]["pid"]
+        if not current["supervisor"]["running"] or not pid:
+            return {**current, "changed": False}
+        _terminate_pid(pid)
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            current = supervisor_status(self.config_home)
+            if not current["supervisor"]["running"]:
+                return {**current, "changed": True}
+            time.sleep(0.2)
+        return {
+            **supervisor_status(self.config_home),
+            "changed": False,
+            "error": "timeout",
+        }
 
 
 def run_coordinator(home: str, runtime_dir: str, low_latency: bool = False) -> int:
-    home = resolve_runtime_home(home)
-    runtime_dir = resolve_runtime_dir(home, runtime_dir)
-    service_state_dir = state_dir(runtime_dir)
-    service_state_dir.mkdir(parents=True, exist_ok=True)
-    write_pid(coordinator_pid_path(runtime_dir), os.getpid())
-    _json_write(
-        state_path(runtime_dir),
-        {
-            "schema": SCHEMA_STATUS,
-            "status": "coordinator-running",
-            "home": home,
-            "runtimeDir": runtime_dir,
-            "coordinatorPid": os.getpid(),
-            "updatedAt": _now(),
-        },
-    )
-    try:
-        coordinator = Coordinator(home, runtime_dir, low_latency=low_latency)
-        coordinator.run()
-        return 0
-    finally:
-        unlink_coordinator_pid_files(runtime_dir)
+    return ProcessRuntimeHost().run_foreground(home, runtime_dir, low_latency)
 
 
 def status(home: str, runtime_dir: str) -> dict[str, Any]:
@@ -710,6 +961,7 @@ def run_supervisor(
     restart_delay: float = 2.0,
 ) -> int:
     config_home = resolve_config_home(config_home)
+    process_host = ProcessRuntimeHost(log_level, config_home)
     service_state_dir = supervisor_state_dir(config_home)
     service_state_dir.mkdir(parents=True, exist_ok=True)
     write_pid(supervisor_pid_path(config_home), os.getpid())
@@ -722,12 +974,9 @@ def run_supervisor(
         nonlocal stopping
         stopping = True
         for child in children.values():
-            if child.poll() is None:
-                child.terminate()
+            process_host.terminate_child(child)
 
-    signal.signal(signal.SIGTERM, request_stop)
-    if platform.system() != "Windows":
-        signal.signal(signal.SIGINT, request_stop)
+    process_host.install_stop_handlers(request_stop)
 
     try:
         while not stopping:
@@ -743,7 +992,7 @@ def run_supervisor(
                     if route:
                         unlink_coordinator_pid_files(str(route["runtimeDir"]))
                     if route_id_ not in desired_routes and child.poll() is None:
-                        child.terminate()
+                        process_host.terminate_child(child)
                     children.pop(route_id_, None)
             for route_id_, route in desired_routes.items():
                 running_child = children.get(route_id_)
@@ -757,24 +1006,10 @@ def run_supervisor(
                     continue
                 route_home = str(route["home"])
                 route_runtime_dir = str(route["runtimeDir"])
-                command = coordinator_run_command(
-                    route_home, route_runtime_dir, log_level
+                child = process_host.spawn_coordinator(
+                    route_home,
+                    route_runtime_dir,
                 )
-                coordinator_log_path(route_runtime_dir).parent.mkdir(
-                    parents=True, exist_ok=True
-                )
-                with coordinator_log_path(route_runtime_dir).open("ab") as log:
-                    child = subprocess.Popen(
-                        command,
-                        env=command_env(
-                            route_home,
-                            route_runtime_dir,
-                            log_level,
-                            config_home,
-                        ),
-                        stdout=log,
-                        stderr=log,
-                    )
                 children[route_id_] = child
                 write_pid(coordinator_pid_path(route_runtime_dir), child.pid)
                 touch_route_heartbeat(
@@ -807,10 +1042,9 @@ def run_supervisor(
         return 0
     finally:
         for route_id_, child in list(children.items()):
-            if child.poll() is None:
-                child.terminate()
+            process_host.terminate_child(child)
         for route_id_, child in list(children.items()):
-            child.terminate()
+            process_host.terminate_child(child)
             try:
                 child.wait(timeout=5)
             except subprocess.TimeoutExpired:
@@ -836,48 +1070,7 @@ def ensure_coordinator(
     log_level: str,
     config_home: str | None = None,
 ) -> dict[str, Any]:
-    config_home = resolve_config_home(config_home)
-    home = resolve_runtime_home(home)
-    runtime_dir = resolve_runtime_dir(home, runtime_dir)
-    repairs = repair_route_state(home, runtime_dir, config_home)
-    route = upsert_route(config_home, home, runtime_dir)
-    current = route_status(home, runtime_dir, config_home)
-    if current["supervisor"]["running"]:
-        return _wait_for_coordinator(
-            home, runtime_dir, config_home, changed=False, route=route, repairs=repairs
-        )
-    supervisor_state_dir(config_home).mkdir(parents=True, exist_ok=True)
-    command = supervisor_command(
-        config_home,
-        log_level,
-        home=home,
-        runtime_dir=runtime_dir,
-        foreground=True,
-    )
-    with supervisor_log_path(config_home).open("ab") as log:
-        kwargs: dict[str, Any] = {
-            "env": command_env(home, runtime_dir, log_level, config_home),
-            "stdout": log,
-            "stderr": log,
-        }
-        if platform.system() == "Windows":
-            detached_process = getattr(subprocess, "DETACHED_PROCESS", 0x00000008)
-            new_process_group = getattr(
-                subprocess, "CREATE_NEW_PROCESS_GROUP", 0x00000200
-            )
-            kwargs["creationflags"] = detached_process | new_process_group
-        else:
-            kwargs["start_new_session"] = True
-        subprocess.Popen(command, **kwargs)
-    return _wait_for_coordinator(
-        home,
-        runtime_dir,
-        config_home,
-        changed=True,
-        command=command,
-        route=route,
-        repairs=repairs,
-    )
+    return ProcessRuntimeHost(log_level, config_home).activate(home, runtime_dir)
 
 
 def _wait_for_coordinator(
@@ -909,7 +1102,11 @@ def _wait_for_coordinator(
         **route_status(home, runtime_dir, config_home),
         "changed": changed,
     }
-    payload["route"] = {**route, **payload.get("route", {})}
+    current_route = payload.get("route")
+    payload["route"] = {
+        **route,
+        **(current_route if isinstance(current_route, dict) else {}),
+    }
     if repairs is not None:
         payload["repairs"] = repairs
     if command:
@@ -920,19 +1117,7 @@ def _wait_for_coordinator(
 def stop_supervisor(
     config_home: str | None = None, timeout: float = 10.0
 ) -> dict[str, Any]:
-    config_home = resolve_config_home(config_home)
-    current = supervisor_status(config_home)
-    pid = current["supervisor"]["pid"]
-    if not current["supervisor"]["running"] or not pid:
-        return {**current, "changed": False}
-    _terminate_pid(pid)
-    deadline = time.time() + timeout
-    while time.time() < deadline:
-        current = supervisor_status(config_home)
-        if not current["supervisor"]["running"]:
-            return {**current, "changed": True}
-        time.sleep(0.2)
-    return {**supervisor_status(config_home), "changed": False, "error": "timeout"}
+    return ProcessRuntimeHost(config_home=config_home).stop_supervisor(timeout)
 
 
 def supervisor_status(config_home: str | None = None) -> dict[str, Any]:

--- a/framework/core/tests/python/test_runtime_service.py
+++ b/framework/core/tests/python/test_runtime_service.py
@@ -23,18 +23,19 @@ def _install_fake_pykungfu():
             location_role=types.SimpleNamespace(SYSTEM="SYSTEM"),
         )
     )
-    fake.runtime = types.SimpleNamespace(
-        coordinator=_FakeCoordinator,
-        locator=lambda runtime_dir: {"runtime_dir": runtime_dir},
-        location=lambda mode, role, namespace, name, locator: {
-            "mode": mode,
-            "role": role,
-            "namespace": namespace,
-            "name": name,
-            "locator": locator,
-        },
-    )
+    runtime = types.ModuleType("pykungfu.runtime")
+    runtime.coordinator = _FakeCoordinator
+    runtime.locator = lambda runtime_dir: {"runtime_dir": runtime_dir}
+    runtime.location = lambda mode, role, namespace, name, locator: {
+        "mode": mode,
+        "role": role,
+        "namespace": namespace,
+        "name": name,
+        "locator": locator,
+    }
+    fake.runtime = runtime
     sys.modules.setdefault("pykungfu", fake)
+    sys.modules.setdefault("pykungfu.runtime", runtime)
 
 
 _install_fake_pykungfu()
@@ -185,6 +186,58 @@ def test_coordinator_keeps_wire_v1_location_identity(tmp_path):
 
     assert coordinator.location["namespace"] == "master"
     assert coordinator.location["name"] == "master"
+
+
+def test_coordinator_engine_handles_inspect_request_without_process_state(
+    tmp_path, monkeypatch
+):
+    def _process_boundary_used(*args, **kwargs):
+        raise AssertionError("no-fork engine crossed the process boundary")
+
+    monkeypatch.setattr(runtime_service.subprocess, "Popen", _process_boundary_used)
+    monkeypatch.setattr(runtime_service.os, "getpid", _process_boundary_used)
+    monkeypatch.setattr(runtime_service.signal, "signal", _process_boundary_used)
+
+    engine = runtime_service.CoordinatorEngine(
+        str(tmp_path / "home"),
+        str(tmp_path / "runtime"),
+    )
+    receipt = engine.handle_request(runtime_service.RuntimeEngineRequest("inspect"))
+
+    assert receipt.accepted is True
+    assert receipt.state == "constructed"
+    assert receipt.capabilities == (
+        "runtime.peer-registry",
+        "runtime.channel-routing",
+        "runtime.assessment-scheduling",
+    )
+
+
+def test_process_runtime_host_wraps_engine_with_pid_lifecycle(tmp_path, monkeypatch):
+    events = []
+
+    class _FakeEngine:
+        def __init__(self, *args, **kwargs):
+            events.append(("constructed", args, kwargs))
+
+        def run(self):
+            events.append(("run",))
+
+        def close(self):
+            events.append(("close",))
+
+    monkeypatch.setattr(runtime_service, "CoordinatorEngine", _FakeEngine)
+    runtime_dir = tmp_path / "runtime"
+    result = runtime_service.ProcessRuntimeHost().run_foreground(
+        str(tmp_path / "home"), str(runtime_dir)
+    )
+
+    assert result == 0
+    assert [event[0] for event in events] == ["constructed", "run", "close"]
+    assert runtime_service.read_coordinator_pid(str(runtime_dir)) is None
+    state = runtime_service._json_read(runtime_service.state_path(str(runtime_dir)))
+    assert state["status"] == "coordinator-running"
+    assert state["coordinatorPid"] == os.getpid()
 
 
 def test_repair_route_state_removes_dead_pid_files(tmp_path, monkeypatch):
@@ -346,7 +399,7 @@ def test_workspace_coordinator_schedules_one_pending_assessment_process(
 
     assert len(spawned) == 1
     assert spawned[0][0] == ["worker", str(runtime_dir), pending_key]
-    assert coordinator._assessment_worker[0] == pending_key
+    assert coordinator._assessment_executor.current[0] == pending_key
 
 
 def test_workspace_coordinator_cancels_timed_out_assessor_and_retries_pending_request(
@@ -395,7 +448,7 @@ def test_workspace_coordinator_cancels_timed_out_assessor_and_retries_pending_re
 
     assert len(spawned) == 2
     assert spawned[0].terminated is True
-    assert coordinator._assessment_worker[1] is spawned[1]
+    assert coordinator._assessment_executor.current[1] is spawned[1]
 
 
 def test_assessment_subscription_snapshot_exposes_summary_before_proof(

--- a/framework/runtime/kungfu-runtime.contract.json
+++ b/framework/runtime/kungfu-runtime.contract.json
@@ -157,7 +157,7 @@
     "currentTopology": [
       {
         "id": "process",
-        "implementation": "kungfu.runtime_service supervisor/coordinator",
+        "implementation": "kungfu.runtime_service ProcessRuntimeHost over CoordinatorEngine",
         "contractAdapter": "ProcessRuntimeHost",
         "contractAdapterImplemented": false
       }
@@ -345,7 +345,7 @@
     "processDiagnostics": {
       "statusSchema": "kungfu.runtime.status/v2",
       "routesSchema": "kungfu.runtime.routes/v2",
-      "rule": "Retained as process-control and advanced diagnostic surfaces until the ProcessRuntimeHost adapter lands; running and healthy do not imply runtime readiness."
+      "rule": "Retained as ProcessRuntimeHost control and advanced diagnostic surfaces; running and healthy do not imply runtime readiness."
     },
     "legacyAliases": [
       {

--- a/scripts/check-runtime-contract.test.mjs
+++ b/scripts/check-runtime-contract.test.mjs
@@ -65,7 +65,7 @@ test('process diagnostics do not upgrade a handle without a durable cut', () => 
   assert.ok(issues.some((item) => item.code === 'readiness-cut-missing'));
 });
 
-test('process is the current topology while both contract adapters remain honest', () => {
+test('process placement is explicit while semantic host and embedded remain non-claims', () => {
   assert.deepEqual(
     CONTRACT.hostKinds.currentTopology.map((item) => item.id),
     ['process'],


### PR DESCRIPTION
## Summary

- extract a directly callable `CoordinatorEngine` request seam with typed receipts
- move PID files, signals, spawning, detachment, child ownership, and process diagnostics behind `ProcessRuntimeHost`
- preserve the existing CLI and service entrypoints through compatibility delegation
- keep the full semantic `RuntimeHost` requirement/handle adapter and production `EmbeddedRuntimeHost` as explicit non-claims

## Verification

- `PYTHONPATH=framework/core/src/python ./shifu exec uv run --project framework/core --frozen pytest framework/core/tests/python/test_runtime_service.py -q` (16 passed)
- `./shifu exec uv run --project framework/core --frozen node scripts/source-acceptance.mjs` (128 contract tests; Ruff, Mypy, Biome, docs, KFD gates passed)
- staged pre-commit gate passed

## Governance risk

No credentials, provider APIs, hosted services, production release, deployment, or production embedded runtime are changed. This PR only isolates the current process placement boundary and adds a no-fork qualification seam.

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "stage-ready",
  "adrs": ["ADR-0080"],
  "summary": "Land stage 2: isolate the current supervisor/coordinator process placement behind ProcessRuntimeHost and add a directly callable CoordinatorEngine no-fork seam without claiming the semantic RuntimeHost broker or EmbeddedRuntimeHost.",
  "verification": ["runtime_service pytest: 16 passed", "build-free source gate: 128 tests plus Ruff, Mypy, Biome, docs, and KFD checks", "staged pre-commit gate"]
}
-->