### PR TITLE
feat(runtime): fence activation readiness generations

### DIFF
--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -5,8 +5,8 @@
   "witnessKind": "prebuild",
   "supportLevel": "release",
   "source": {
-    "cwd": "/Users/dkr/Worktrees/kungfu/feature/runtime-capability-broker",
-    "sourceSha": "a0fe41cdbc77319c004a72a58f67b56a05346c23",
+    "cwd": "/Users/dkr/Worktrees/kungfu/feature/runtime-activation-readiness",
+    "sourceSha": "7671da5688091a1220015ec3e7cfb13b261eee01",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
     "registryDigest": "sha256:6b8e5f64c722f6d97c5ff1f23bf5d8bd584a5358588e214424ea8cce461c5b82"
   },

--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -6,7 +6,7 @@
   "supportLevel": "release",
   "source": {
     "cwd": "/Users/dkr/Worktrees/kungfu/feature/runtime-activation-readiness",
-    "sourceSha": "7671da5688091a1220015ec3e7cfb13b261eee01",
+    "sourceSha": "0663a0803bf1aaa8ca455a85458c02916a256000",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
     "registryDigest": "sha256:6b8e5f64c722f6d97c5ff1f23bf5d8bd584a5358588e214424ea8cce461c5b82"
   },

--- a/docs/adr/ADR-0080-topology-neutral-capability-driven-runtime-activation.md
+++ b/docs/adr/ADR-0080-topology-neutral-capability-driven-runtime-activation.md
@@ -4,7 +4,7 @@ doc_type: architecture-decision
 adr_id: ADR-0080
 decision_status: accepted
 implementation_status: partial
-implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/815, https://github.com/kungfu-systems/kungfu/pull/818, https://github.com/kungfu-systems/kungfu/pull/819]
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/815, https://github.com/kungfu-systems/kungfu/pull/818, https://github.com/kungfu-systems/kungfu/pull/819, https://github.com/kungfu-systems/kungfu/pull/822]
 review_state: self-reviewed
 sensitivity: public
 sources: [local-files, user-decision]

--- a/docs/adr/ADR-0080-topology-neutral-capability-driven-runtime-activation.md
+++ b/docs/adr/ADR-0080-topology-neutral-capability-driven-runtime-activation.md
@@ -186,8 +186,9 @@ and OS service diagnostics stay in the adapter. RuntimeCapabilityBroker now
 plans and atomically admits operations from the contract-owned operation
 registry. Storage-only callbacks run without constructing a host; live-required
 callbacks run only after a matching semantic ready receipt. The current process
-bridge deliberately fails closed after requesting activation because
-generation-fenced readiness at a durable cut remains stage 4 work.
+bridge now serializes first activation per workspace, fences process generations,
+and admits an explicitly configured native readiness authority only at or beyond
+the required durable cut. It still fails closed when that authority is absent.
 EmbeddedRuntimeHost is a reserved non-claim: v1 deliberately contains no
 production implementation, thread model, or qualification claim for it. A
 future host must implement the same requirement, handle, readiness, generation,
@@ -282,8 +283,8 @@ products copy the exact contract through the existing KFD-1 contract registry.
 
 1. Land this ADR, the KFD-1 contract, fixtures, and source gate.
 2. Put the current supervisor/coordinator path behind ProcessRuntimeHost. **Complete:** CoordinatorEngine supplies the no-fork request seam; ProcessRuntimeHost owns process placement. The full semantic RuntimeHost adapter remains stages 3-4 work.
-3. Add the Core capability broker and generation-fenced handles. **Broker complete:** the operation registry and atomic daemonless/live admission seam are implemented; generation-fenced handles remain stage 4 work.
-4. Bind recovery and projection readiness to an exact durable cut.
+3. Add the Core capability broker and generation-fenced handles. **Complete:** the operation registry, atomic daemonless/live admission seam, and generation-fenced process handles are implemented.
+4. Bind recovery and projection readiness to an exact durable cut. **Core seam complete:** one per-workspace activation owner serializes first calls, persists the accepted generation, fences replaced process diagnostics, and admits native durability/projection evidence only at or beyond the requested cut. The process adapter remains fail closed when no `DurableEngine` readiness authority is supplied; product evidence discovery is stage 6 work.
 5. Add leases, idle draining, adoption, and restart recovery.
 6. Project the same contract through CLI, GUI, Python, Node, libkungfu, and KFX.
 7. Qualify daemonless/no-fork behavior, process crash recovery, product

--- a/docs/architecture/runtime-service.md
+++ b/docs/architecture/runtime-service.md
@@ -102,10 +102,19 @@ at invoke time and executes the callback only when the returned handle is ready
 at a durable cut with exactly the requested capabilities and authorities.
 
 The current `ProcessRuntimeActivationClient` requests the existing process host
-but returns `readiness_not_established`; PID and health diagnostics cannot admit
-the callback. Stage 4 will replace that fail-closed boundary with
-generation-fenced recovery and cut-bound readiness. Product entrypoints remain
-stage 6 work.
+through one cross-process activation owner per canonical workspace. Concurrent
+first calls wait behind the same owner, reuse one accepted generation, and
+advance the generation when the recorded process diagnostics are replaced.
+The accepted snapshot is written atomically only after semantic readiness.
+
+`NativeReadinessAuthority` invokes and projects the existing typed
+`kungfu.durability.reconciliation/v1` and
+`kungfu.projection-candidate-status/v1` outputs into the runtime readiness
+contract. A cut behind the requirement, a foreign projection authority, or a
+missing hydrated projection fails before callback admission. PID and health
+diagnostics remain insufficient: without an explicitly supplied DurableEngine
+readiness authority the process adapter returns `readiness_not_established`.
+Product evidence discovery and entrypoint wiring remain stage 6 work.
 
 If the supervisor is not running, a product entrypoint may start it. If a
 command only needs closed-data storage access, it may bypass the live coordinator and

--- a/docs/qualification/contracts.md
+++ b/docs/qualification/contracts.md
@@ -170,10 +170,12 @@ ProcessRuntimeHost placement adapter, directly callable CoordinatorEngine
 no-fork seam, contract-owned operation registry, and RuntimeCapabilityBroker
 atomic invocation seam are implemented. Storage-only qualification proves that
 no activation client is constructed; live-required qualification proves that a
-callback is not accepted without an exact semantic ready receipt. Generation-
-fenced recovery/readiness, full language/product projection, and product
-qualification land in later stages. EmbeddedRuntimeHost is an explicit
-non-claim.
+callback is not accepted without an exact semantic ready receipt. Four-process
+first-call qualification proves one host activation and one accepted
+generation; replacement diagnostics advance the generation, while native
+durability/projection evidence behind the requested cut fails closed. Lease and
+restart lifecycle, full language/product projection, and product qualification
+land in later stages. EmbeddedRuntimeHost is an explicit non-claim.
 
 ## The KFD-1 contract registry is the packaging source of truth
 

--- a/framework/core/src/python/kungfu/runtime_broker.py
+++ b/framework/core/src/python/kungfu/runtime_broker.py
@@ -5,11 +5,14 @@ from __future__ import annotations
 import copy
 import hashlib
 import json
+import os
+import time
 from collections.abc import Callable, Mapping
 from pathlib import Path
 from typing import Any, Protocol
 
 from kungfu import contract as contract_runtime
+from kungfu.coordination import locks as coordination_locks
 
 
 PLAN_SCHEMA = "kungfu.runtime.invocation-plan/v1"
@@ -22,6 +25,21 @@ REQUEST_SOURCES = {"libkungfu", "cli", "python", "node", "gui", "kfx"}
 class RuntimeActivationClient(Protocol):
     def activate(
         self, requirement: Mapping[str, Any], request_source: str
+    ) -> Mapping[str, Any]: ...
+
+
+class RuntimeProcessHost(Protocol):
+    def activate(self, home: str, runtime_dir: str) -> Mapping[str, Any]: ...
+
+    def inspect(self, home: str, runtime_dir: str) -> Mapping[str, Any]: ...
+
+
+class RuntimeReadinessAuthority(Protocol):
+    def establish(
+        self,
+        requirement: Mapping[str, Any],
+        generation: str,
+        diagnostics: Mapping[str, Any],
     ) -> Mapping[str, Any]: ...
 
 
@@ -170,6 +188,381 @@ def _failed_activation(
     )
 
 
+def _activation_state_path(config_home: str | Path, workspace: str) -> Path:
+    digest = hashlib.sha256(workspace.encode()).hexdigest()[:24]
+    return (
+        Path(config_home).expanduser().resolve()
+        / "runtime"
+        / "activations"
+        / f"{digest}.json"
+    )
+
+
+def _read_activation_state(path: Path) -> dict[str, Any] | None:
+    if not path.exists():
+        return None
+    try:
+        value = json.loads(path.read_text("utf-8"))
+    except (OSError, json.JSONDecodeError):
+        raise ValueError("runtime activation state is unreadable") from None
+    if not isinstance(value, dict):
+        raise ValueError("runtime activation state is not an object")
+    return value
+
+
+def _write_activation_state(path: Path, value: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(".json.tmp")
+    with temporary.open("w", encoding="utf-8") as state_file:
+        json.dump(value, state_file, indent=2, sort_keys=True)
+        state_file.write("\n")
+        state_file.flush()
+        os.fsync(state_file.fileno())
+    os.replace(temporary, path)
+    try:
+        directory = os.open(path.parent, os.O_RDONLY)
+    except OSError:
+        return
+    try:
+        os.fsync(directory)
+    except OSError:
+        pass
+    finally:
+        os.close(directory)
+
+
+def _process_diagnostics(value: Mapping[str, Any]) -> dict[str, Any]:
+    supervisor = value.get("supervisor")
+    coordinator = value.get("coordinator")
+    supervisor_value = supervisor if isinstance(supervisor, Mapping) else {}
+    coordinator_value = coordinator if isinstance(coordinator, Mapping) else {}
+    return {
+        "supervisorPid": supervisor_value.get("pid"),
+        "coordinatorPid": coordinator_value.get("pid"),
+        "socketPath": None,
+        "serviceInstalled": None,
+        "guiVisible": None,
+    }
+
+
+def _process_running(value: Mapping[str, Any]) -> bool:
+    supervisor = value.get("supervisor")
+    coordinator = value.get("coordinator")
+    return bool(
+        isinstance(supervisor, Mapping)
+        and supervisor.get("running") is True
+        and isinstance(coordinator, Mapping)
+        and coordinator.get("running") is True
+    )
+
+
+def _cut_at_or_after(
+    observed: Mapping[str, Any] | None, minimum: Mapping[str, Any] | None
+) -> bool:
+    if minimum is None:
+        return observed is not None
+    if observed is None:
+        return False
+    if observed.get("stream_id") != minimum.get("stream_id") or observed.get(
+        "container_epoch"
+    ) != minimum.get("container_epoch"):
+        return False
+    try:
+        observed_sequence = int(str(observed.get("sequence")))
+        minimum_sequence = int(str(minimum.get("sequence")))
+    except (TypeError, ValueError):
+        return False
+    if observed_sequence != minimum_sequence:
+        return observed_sequence > minimum_sequence
+    return observed.get("frame_uid") == minimum.get("frame_uid")
+
+
+def _readiness_admits_requirement(
+    requirement: Mapping[str, Any], readiness: Mapping[str, Any]
+) -> bool:
+    required = set(requirement.get("requiredCapabilities") or [])
+    durable_cut = readiness.get("durableCut")
+    projection_cut = readiness.get("projectionCut")
+    return bool(
+        readiness.get("state") == "ready"
+        and readiness.get("evidence")
+        and _cut_at_or_after(
+            durable_cut if isinstance(durable_cut, Mapping) else None,
+            requirement.get("minimumCut")
+            if isinstance(requirement.get("minimumCut"), Mapping)
+            else None,
+        )
+        and (
+            "runtime.live-projection" not in required
+            or isinstance(projection_cut, Mapping)
+            and _cut_at_or_after(
+                projection_cut,
+                durable_cut if isinstance(durable_cut, Mapping) else None,
+            )
+        )
+    )
+
+
+def _runtime_cut(value: Mapping[str, Any]) -> dict[str, str]:
+    fields = ("stream_id", "container_epoch", "sequence", "frame_uid")
+    if any(value.get(field) is None for field in fields):
+        raise ValueError("runtime cut is incomplete")
+    return {field: str(value[field]) for field in fields}
+
+
+class _ReconciledReadinessProjection:
+    """Project already-returned native evidence into runtime readiness."""
+
+    def __init__(
+        self,
+        durability_reconciliation: Mapping[str, Any],
+        projection_status: Mapping[str, Any] | None = None,
+    ) -> None:
+        self.durability_reconciliation = copy.deepcopy(dict(durability_reconciliation))
+        self.projection_status = (
+            copy.deepcopy(dict(projection_status))
+            if projection_status is not None
+            else None
+        )
+
+    def establish(
+        self,
+        requirement: Mapping[str, Any],
+        generation: str,
+        diagnostics: Mapping[str, Any],
+    ) -> Mapping[str, Any]:
+        reconciliation = self.durability_reconciliation
+        if (
+            reconciliation.get("schema") != "kungfu.durability.reconciliation/v1"
+            or reconciliation.get("state") != "reconciled"
+            or reconciliation.get("recovered") is not True
+        ):
+            raise ValueError("durability reconciliation is not authoritative")
+        receipt = reconciliation.get("receipt")
+        if (
+            not isinstance(receipt, Mapping)
+            or receipt.get("schema") != "kungfu.durability.receipt/v1"
+            or receipt.get("status") != "succeeded"
+            or receipt.get("durable_watermark") is None
+        ):
+            raise ValueError("durability receipt did not establish a durable cut")
+        durable_value = receipt["durable_watermark"]
+        if not isinstance(durable_value, Mapping):
+            raise ValueError("durability receipt cut is malformed")
+        durable_cut = _runtime_cut(durable_value)
+        evidence = [
+            {
+                "kind": "durability-receipt",
+                "ref": (
+                    f"receipt:durability:{receipt.get('request_id')}:"
+                    f"{receipt.get('barrier_id')}"
+                ),
+            }
+        ]
+        projection_cut = None
+        if "runtime.live-projection" in requirement.get("requiredCapabilities", []):
+            projection = self.projection_status
+            if (
+                not isinstance(projection, Mapping)
+                or projection.get("schema") != "kungfu.projection-candidate-status/v1"
+                or projection.get("authority") != "libkungfu"
+                or projection.get("outcome") != "ready"
+                or projection.get("hydrated") is not True
+                or projection.get("projection_watermark") is None
+            ):
+                raise ValueError("projection authority did not establish a ready cut")
+            projection_value = projection["projection_watermark"]
+            if not isinstance(projection_value, Mapping):
+                raise ValueError("projection readiness cut is malformed")
+            projection_cut = _runtime_cut(projection_value)
+            evidence.append(
+                {
+                    "kind": "projection-status",
+                    "ref": (
+                        "status:projection:"
+                        f"{projection.get('qualification_profile')}:"
+                        f"{projection_cut['sequence']}"
+                    ),
+                }
+            )
+        return {
+            "schema": "kungfu.runtime.readiness/v1",
+            "state": "ready",
+            "durableCut": durable_cut,
+            "projectionCut": projection_cut,
+            "evidence": evidence,
+            "observedAtNs": str(time.time_ns()),
+        }
+
+
+class NativeReadinessAuthority:
+    """Invoke the existing native authorities and project their exact evidence."""
+
+    def __init__(
+        self,
+        *,
+        data_root: str,
+        durability_request_id: int,
+        requested_profile: str,
+        writer_resource_id: str,
+        durability_qualification_profile: str,
+        projection_writer_resource_id: str | None = None,
+        projection_qualification_profile: str | None = None,
+    ) -> None:
+        self.data_root = data_root
+        self.durability_request_id = durability_request_id
+        self.requested_profile = requested_profile
+        self.writer_resource_id = writer_resource_id
+        self.durability_qualification_profile = durability_qualification_profile
+        self.projection_writer_resource_id = (
+            projection_writer_resource_id or writer_resource_id
+        )
+        self.projection_qualification_profile = projection_qualification_profile
+
+    def establish(
+        self,
+        requirement: Mapping[str, Any],
+        generation: str,
+        diagnostics: Mapping[str, Any],
+    ) -> Mapping[str, Any]:
+        minimum_cut = requirement.get("minimumCut")
+        if not isinstance(minimum_cut, Mapping):
+            raise ValueError("native readiness requires an explicit minimum cut")
+        cut = _runtime_cut(minimum_cut)
+        from kungfu import durability
+
+        reconciliation = durability.reconcile(
+            data_root=self.data_root,
+            request_id=self.durability_request_id,
+            stream_id=int(cut["stream_id"]),
+            container_epoch=int(cut["container_epoch"]),
+            sequence=int(cut["sequence"]),
+            frame_uid=int(cut["frame_uid"]),
+            requested_profile=self.requested_profile,
+            writer_resource_id=self.writer_resource_id,
+            qualification_profile=self.durability_qualification_profile,
+        )
+        projection_status = None
+        if "runtime.live-projection" in requirement.get("requiredCapabilities", []):
+            if not self.projection_qualification_profile:
+                raise ValueError(
+                    "native projection readiness requires a qualification profile"
+                )
+            from kungfu import projection
+
+            projection_status = projection.candidate_status(
+                data_root=self.data_root,
+                stream_id=int(cut["stream_id"]),
+                container_epoch=int(cut["container_epoch"]),
+                writer_resource_id=self.projection_writer_resource_id,
+                qualification_profile=self.projection_qualification_profile,
+            )
+        return _ReconciledReadinessProjection(
+            reconciliation,
+            projection_status,
+        ).establish(requirement, generation, diagnostics)
+
+
+def _runtime_handle(
+    requirement: Mapping[str, Any],
+    generation: str,
+    readiness: Mapping[str, Any],
+    diagnostics: Mapping[str, Any],
+) -> dict[str, Any]:
+    workspace = str(requirement["workspaceId"])
+    return {
+        "schema": "kungfu.runtime.handle/v1",
+        "runtimeId": _stable_id("runtime", {"workspaceId": workspace}),
+        "requirementId": requirement["requestId"],
+        "workspaceId": workspace,
+        "generation": generation,
+        "state": "ready",
+        "capabilities": list(requirement["requiredCapabilities"]),
+        "grantedAuthorities": list(requirement["requestedAuthorities"]),
+        "readiness": copy.deepcopy(dict(readiness)),
+        "host": {
+            "kind": "process",
+            "hostId": _stable_id(
+                "process-host",
+                {"workspaceId": workspace, "generation": generation},
+            ),
+            "diagnostics": _process_diagnostics(diagnostics),
+        },
+    }
+
+
+def _recorded_process_generation(
+    state: Mapping[str, Any], diagnostics: Mapping[str, Any]
+) -> str | None:
+    handles = state.get("handles")
+    if not isinstance(handles, list) or len(handles) != 1:
+        return None
+    previous = handles[0]
+    if not isinstance(previous, Mapping):
+        return None
+    generation = str(previous.get("generation") or "")
+    if (
+        previous.get("workspaceId") != state.get("workspaceId")
+        or state.get("activeGeneration") != generation
+        or not generation.isdigit()
+        or generation == "0"
+    ):
+        return None
+    previous_host = previous.get("host")
+    previous_diagnostics = (
+        previous_host.get("diagnostics") if isinstance(previous_host, Mapping) else None
+    )
+    if not isinstance(previous_diagnostics, Mapping):
+        return None
+    current_diagnostics = _process_diagnostics(diagnostics)
+    if any(
+        not previous_diagnostics.get(key)
+        or previous_diagnostics.get(key) != current_diagnostics.get(key)
+        for key in ("supervisorPid", "coordinatorPid")
+    ):
+        return None
+    return generation
+
+
+def _reusable_handle(
+    requirement: Mapping[str, Any],
+    state: Mapping[str, Any],
+    diagnostics: Mapping[str, Any],
+) -> dict[str, Any] | None:
+    handles = state.get("handles")
+    if not isinstance(handles, list) or len(handles) != 1:
+        return None
+    previous = handles[0]
+    if not isinstance(previous, Mapping) or previous.get("state") != "ready":
+        return None
+    if previous.get("workspaceId") != requirement.get("workspaceId"):
+        return None
+    if state.get("activeGeneration") != previous.get("generation"):
+        return None
+    generation = _recorded_process_generation(state, diagnostics)
+    if generation is None:
+        return None
+    if not set(requirement.get("requiredCapabilities") or []).issubset(
+        set(previous.get("capabilities") or [])
+    ):
+        return None
+    if not set(requirement.get("requestedAuthorities") or []).issubset(
+        set(previous.get("grantedAuthorities") or [])
+    ):
+        return None
+    readiness = previous.get("readiness")
+    if not isinstance(readiness, Mapping) or not _readiness_admits_requirement(
+        requirement, readiness
+    ):
+        return None
+    return _runtime_handle(
+        requirement,
+        generation,
+        readiness,
+        diagnostics,
+    )
+
+
 def _activation_admits(
     requirement: Mapping[str, Any], receipt: Mapping[str, Any]
 ) -> bool:
@@ -200,20 +593,18 @@ def _activation_admits(
     required = set(requirement["requiredCapabilities"])
     requested = set(requirement["requestedAuthorities"])
     readiness = handle.get("readiness")
+    generation = str(handle.get("generation") or "")
     return (
         achieved == required
         and granted == requested
         and set(handle.get("capabilities") or []) == required
         and set(handle.get("grantedAuthorities") or []) == requested
+        and generation.isdigit()
+        and generation != "0"
         and handle.get("requirementId") == requirement.get("requestId")
         and handle.get("workspaceId") == requirement.get("workspaceId")
         and isinstance(readiness, Mapping)
-        and readiness.get("state") == "ready"
-        and readiness.get("durableCut") is not None
-        and (
-            "runtime.live-projection" not in required
-            or readiness.get("projectionCut") is not None
-        )
+        and _readiness_admits_requirement(requirement, readiness)
     )
 
 
@@ -227,34 +618,176 @@ class ProcessRuntimeActivationClient:
         *,
         log_level: str = "warning",
         config_home: str | None = None,
+        host: RuntimeProcessHost | None = None,
+        readiness_authority: RuntimeReadinessAuthority | None = None,
+        contract: Mapping[str, Any] | None = None,
     ) -> None:
-        from kungfu import runtime_service
-
         self.home = home
         self.runtime_dir = runtime_dir
-        self.host = runtime_service.ProcessRuntimeHost(log_level, config_home)
+        if host is None:
+            from kungfu import runtime_service
+
+            self.config_home = runtime_service.resolve_config_home(config_home)
+            self.host: RuntimeProcessHost = runtime_service.ProcessRuntimeHost(
+                log_level, config_home
+            )
+        else:
+            self.config_home = str(
+                Path(config_home or "~/.kungfu-config").expanduser().resolve()
+            )
+            self.host = host
+        self.readiness_authority = readiness_authority
+        self.contract = contract
         self.diagnostics: Mapping[str, Any] | None = None
 
     def activate(
         self, requirement: Mapping[str, Any], request_source: str
     ) -> Mapping[str, Any]:
-        try:
-            self.diagnostics = self.host.activate(self.home, self.runtime_dir)
-        except (OSError, RuntimeError, ValueError) as error:
+        expected_workspace = workspace_id(self.runtime_dir)
+        if requirement.get("workspaceId") != expected_workspace:
             return _failed_activation(
                 requirement,
                 request_source,
-                "activation_failed",
-                str(error),
-                retryable=True,
+                "invalid_requirement",
+                "The requirement workspace does not match the process host runtime directory.",
+                retryable=False,
             )
-        return _failed_activation(
-            requirement,
-            request_source,
-            "readiness_not_established",
-            "The process host was requested, but semantic readiness at a durable cut is not implemented yet.",
-            retryable=True,
+        state_path = _activation_state_path(
+            self.config_home, str(requirement["workspaceId"])
         )
+        lock_root = state_path.parent / "locks"
+        with coordination_locks.held(
+            lock_root,
+            str(requirement["workspaceId"]),
+            label=f"runtime-activation:{requirement['requestId']}",
+        ):
+            try:
+                stored_state = _read_activation_state(state_path)
+                if stored_state is not None:
+                    _validate_value("runtimeSnapshot", stored_state, self.contract)
+                state = stored_state or {}
+            except ValueError as error:
+                return _failed_activation(
+                    requirement,
+                    request_source,
+                    "stale_generation",
+                    str(error),
+                    retryable=False,
+                )
+            try:
+                inspected = dict(self.host.inspect(self.home, self.runtime_dir))
+            except (OSError, RuntimeError, ValueError):
+                inspected = {}
+            process_running = _process_running(inspected)
+            recorded_generation = None
+            if process_running:
+                reused_handle = _reusable_handle(requirement, state, inspected)
+                if reused_handle is not None:
+                    return _activation_receipt(
+                        requirement,
+                        request_source,
+                        outcome="reused",
+                        error=None,
+                        handle=reused_handle,
+                        achieved_capabilities=list(requirement["requiredCapabilities"]),
+                        granted_authorities=list(requirement["requestedAuthorities"]),
+                    )
+                if stored_state is None:
+                    return _failed_activation(
+                        requirement,
+                        request_source,
+                        "stale_generation",
+                        "A process runtime is running without a fenced activation generation; explicit adoption is required.",
+                        retryable=False,
+                    )
+                recorded_generation = _recorded_process_generation(state, inspected)
+                if recorded_generation is None and not state.get("handles"):
+                    return _failed_activation(
+                        requirement,
+                        request_source,
+                        "stale_generation",
+                        "The activation snapshot cannot identify the running process generation; explicit adoption is required.",
+                        retryable=False,
+                    )
+            previous_generation = state.get("activeGeneration")
+            if recorded_generation is not None:
+                generation = recorded_generation
+                self.diagnostics = inspected
+            else:
+                generation = str(int(str(previous_generation or "0")) + 1)
+                try:
+                    self.diagnostics = dict(
+                        self.host.activate(self.home, self.runtime_dir)
+                    )
+                except (OSError, RuntimeError, ValueError) as error:
+                    return _failed_activation(
+                        requirement,
+                        request_source,
+                        "activation_failed",
+                        str(error),
+                        retryable=True,
+                    )
+            if not _process_running(self.diagnostics):
+                return _failed_activation(
+                    requirement,
+                    request_source,
+                    "activation_failed",
+                    "The process host did not establish one running supervisor and coordinator.",
+                    retryable=True,
+                )
+            if self.readiness_authority is None:
+                return _failed_activation(
+                    requirement,
+                    request_source,
+                    "readiness_not_established",
+                    "The process host is running, but no DurableEngine readiness authority is configured.",
+                    retryable=True,
+                )
+            try:
+                readiness = dict(
+                    self.readiness_authority.establish(
+                        requirement, generation, self.diagnostics
+                    )
+                )
+                _validate_value("runtimeReadiness", readiness, self.contract)
+            except (OSError, RuntimeError, TypeError, ValueError) as error:
+                return _failed_activation(
+                    requirement,
+                    request_source,
+                    "readiness_not_established",
+                    str(error),
+                    retryable=True,
+                )
+            if not _readiness_admits_requirement(requirement, readiness):
+                return _failed_activation(
+                    requirement,
+                    request_source,
+                    "readiness_cut_unavailable",
+                    "The readiness authority did not prove the required durable and projection cuts.",
+                    retryable=True,
+                )
+            handle = _runtime_handle(
+                requirement, generation, readiness, self.diagnostics
+            )
+            snapshot = {
+                "schema": "kungfu.runtime.snapshot/v1",
+                "workspaceId": requirement["workspaceId"],
+                "runtimeId": handle["runtimeId"],
+                "activeGeneration": generation,
+                "handles": [handle],
+                "leases": [],
+            }
+            _validate_value("runtimeSnapshot", snapshot, self.contract)
+            _write_activation_state(state_path, snapshot)
+            return _activation_receipt(
+                requirement,
+                request_source,
+                outcome="activated",
+                error=None,
+                handle=handle,
+                achieved_capabilities=list(requirement["requiredCapabilities"]),
+                granted_authorities=list(requirement["requestedAuthorities"]),
+            )
 
 
 class RuntimeCapabilityBroker:
@@ -275,6 +808,7 @@ class RuntimeCapabilityBroker:
         *,
         log_level: str = "warning",
         config_home: str | None = None,
+        readiness_authority: RuntimeReadinessAuthority | None = None,
         contract: Mapping[str, Any] | None = None,
     ) -> RuntimeCapabilityBroker:
         return cls(
@@ -283,6 +817,8 @@ class RuntimeCapabilityBroker:
                 runtime_dir,
                 log_level=log_level,
                 config_home=config_home,
+                readiness_authority=readiness_authority,
+                contract=contract,
             ),
             contract=contract,
         )

--- a/framework/core/tests/python/test_runtime_broker.py
+++ b/framework/core/tests/python/test_runtime_broker.py
@@ -1,10 +1,130 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import copy
+import json
+import multiprocessing
+from pathlib import Path
 
 import pytest
 
 from kungfu import runtime_broker
+
+
+ROOT = Path(__file__).parents[4]
+READINESS_FIXTURES = json.loads(
+    (ROOT / "tests/fixtures/runtime-activation-readiness/cases.json").read_text()
+)
+
+
+def _cut(sequence="1", frame_uid="1"):
+    return {
+        "stream_id": "1",
+        "container_epoch": "1",
+        "sequence": sequence,
+        "frame_uid": frame_uid,
+    }
+
+
+def _reconciliation(cut=None):
+    cut = cut or _cut()
+    return {
+        "schema": "kungfu.durability.reconciliation/v1",
+        "state": "reconciled",
+        "recovered": True,
+        "receipt": {
+            "schema": "kungfu.durability.receipt/v1",
+            "request_id": 17,
+            "status": "succeeded",
+            "durable_watermark": cut,
+            "barrier_id": 23,
+        },
+    }
+
+
+def _projection_status(cut=None):
+    cut = cut or _cut()
+    return {
+        "schema": "kungfu.projection-candidate-status/v1",
+        "authority": "libkungfu",
+        "outcome": "ready",
+        "hydrated": True,
+        "qualification_profile": "candidate/test-local-filesystem/v1",
+        "projection_watermark": cut,
+    }
+
+
+class _CutReadinessAuthority:
+    def __init__(self, cut=None):
+        self.cut = cut
+
+    def establish(self, requirement, generation, diagnostics):
+        cut = self.cut or requirement["minimumCut"] or _cut()
+        return {
+            "schema": "kungfu.runtime.readiness/v1",
+            "state": "ready",
+            "durableCut": cut,
+            "projectionCut": cut
+            if "runtime.live-projection" in requirement["requiredCapabilities"]
+            else None,
+            "evidence": [
+                {
+                    "kind": "durability-receipt",
+                    "ref": f"receipt:durability:generation-{generation}",
+                }
+            ],
+            "observedAtNs": "1",
+        }
+
+
+class _FileProcessHost:
+    def __init__(self, counter_path, supervisor_pid=1200, coordinator_pid=1201):
+        self.counter_path = Path(counter_path)
+        self.supervisor_pid = supervisor_pid
+        self.coordinator_pid = coordinator_pid
+
+    def _diagnostics(self, running):
+        return {
+            "supervisor": {
+                "pid": self.supervisor_pid if running else None,
+                "running": running,
+            },
+            "coordinator": {
+                "pid": self.coordinator_pid if running else None,
+                "running": running,
+            },
+        }
+
+    def inspect(self, home, runtime_dir):
+        return self._diagnostics(self.counter_path.exists())
+
+    def activate(self, home, runtime_dir):
+        count = int(self.counter_path.read_text()) if self.counter_path.exists() else 0
+        self.counter_path.write_text(str(count + 1))
+        return self._diagnostics(True)
+
+
+def _activation_worker(config_home, runtime_dir, counter_path, request_id, queue):
+    requirement = runtime_broker.plan_operation(
+        "assessment.request",
+        workspace=runtime_broker.workspace_id(runtime_dir),
+        request_source="python",
+        minimum_cut=_cut(),
+        request_id=request_id,
+    )["requirement"]
+    client = runtime_broker.ProcessRuntimeActivationClient(
+        str(Path(runtime_dir).parent),
+        runtime_dir,
+        config_home=config_home,
+        host=_FileProcessHost(counter_path),
+        readiness_authority=_CutReadinessAuthority(),
+    )
+    receipt = client.activate(requirement, "python")
+    queue.put(
+        {
+            "outcome": receipt["outcome"],
+            "generation": receipt["handle"]["generation"],
+        }
+    )
 
 
 def _ready_receipt(requirement, request_source):
@@ -180,3 +300,334 @@ def test_invoke_rejects_a_plan_that_downgrades_live_required_to_storage_only():
 
     with pytest.raises(ValueError, match="stale or altered"):
         broker.invoke(altered, lambda activation: activation)
+
+
+def test_process_activation_converges_concurrent_callers_to_one_generation(tmp_path):
+    context = multiprocessing.get_context("spawn")
+    config_home = tmp_path / "config"
+    runtime_dir = tmp_path / "home" / "runtime"
+    counter_path = tmp_path / "activation-count"
+    queue = context.Queue()
+    processes = [
+        context.Process(
+            target=_activation_worker,
+            args=(
+                str(config_home),
+                str(runtime_dir),
+                str(counter_path),
+                f"request-{index}",
+                queue,
+            ),
+        )
+        for index in range(4)
+    ]
+
+    for process in processes:
+        process.start()
+    for process in processes:
+        process.join(timeout=15)
+
+    assert [process.exitcode for process in processes] == [0, 0, 0, 0]
+    receipts = [queue.get(timeout=2) for _ in processes]
+    assert counter_path.read_text() == "1"
+    assert {receipt["generation"] for receipt in receipts} == {"1"}
+    assert sorted(receipt["outcome"] for receipt in receipts) == [
+        "activated",
+        "reused",
+        "reused",
+        "reused",
+    ]
+
+
+def test_process_activation_fences_a_replaced_process_generation(tmp_path):
+    config_home = tmp_path / "config"
+    runtime_dir = tmp_path / "home" / "runtime"
+    counter_path = tmp_path / "activation-count"
+    requirement = runtime_broker.plan_operation(
+        "assessment.request",
+        workspace=runtime_broker.workspace_id(runtime_dir),
+        request_source="python",
+        minimum_cut=_cut(),
+        request_id="request-first",
+    )["requirement"]
+    first = runtime_broker.ProcessRuntimeActivationClient(
+        str(runtime_dir.parent),
+        str(runtime_dir),
+        config_home=str(config_home),
+        host=_FileProcessHost(counter_path),
+        readiness_authority=_CutReadinessAuthority(),
+    ).activate(requirement, "python")
+    replacement_requirement = {
+        **requirement,
+        "requestId": "request-replacement",
+    }
+    replacement = runtime_broker.ProcessRuntimeActivationClient(
+        str(runtime_dir.parent),
+        str(runtime_dir),
+        config_home=str(config_home),
+        host=_FileProcessHost(counter_path, 2200, 2201),
+        readiness_authority=_CutReadinessAuthority(),
+    ).activate(replacement_requirement, "python")
+
+    assert first["handle"]["generation"] == "1"
+    assert replacement["outcome"] == "activated"
+    assert replacement["handle"]["generation"] == "2"
+    assert counter_path.read_text() == "2"
+
+
+def test_same_process_expands_readiness_without_advancing_generation(tmp_path):
+    config_home = tmp_path / "config"
+    runtime_dir = tmp_path / "home" / "runtime"
+    counter_path = tmp_path / "activation-count"
+    client = runtime_broker.ProcessRuntimeActivationClient(
+        str(runtime_dir.parent),
+        str(runtime_dir),
+        config_home=str(config_home),
+        host=_FileProcessHost(counter_path),
+        readiness_authority=_CutReadinessAuthority(),
+    )
+    first_requirement = runtime_broker.plan_operation(
+        "assessment.request",
+        workspace=runtime_broker.workspace_id(runtime_dir),
+        request_source="python",
+        minimum_cut=_cut(),
+        request_id="request-assessment",
+    )["requirement"]
+    expanded_requirement = runtime_broker.plan_operation(
+        "projection.subscribe",
+        workspace=runtime_broker.workspace_id(runtime_dir),
+        request_source="python",
+        minimum_cut=_cut(),
+        request_id="request-projection",
+    )["requirement"]
+
+    first = client.activate(first_requirement, "python")
+    expanded = client.activate(expanded_requirement, "python")
+
+    assert first["handle"]["generation"] == "1"
+    assert expanded["outcome"] == "activated"
+    assert expanded["handle"]["generation"] == "1"
+    assert counter_path.read_text() == "1"
+
+
+def test_process_activation_rejects_readiness_behind_the_required_cut(tmp_path):
+    fixture = READINESS_FIXTURES["behind"]
+    runtime_dir = tmp_path / "home" / "runtime"
+    requirement = runtime_broker.plan_operation(
+        "assessment.request",
+        workspace=runtime_broker.workspace_id(runtime_dir),
+        request_source="python",
+        minimum_cut=fixture["minimumCut"],
+    )["requirement"]
+    receipt = runtime_broker.ProcessRuntimeActivationClient(
+        str(runtime_dir.parent),
+        str(runtime_dir),
+        config_home=str(tmp_path / "config"),
+        host=_FileProcessHost(tmp_path / "activation-count"),
+        readiness_authority=_CutReadinessAuthority(fixture["observedCut"]),
+    ).activate(requirement, "python")
+
+    assert receipt["outcome"] == "failed"
+    assert receipt["error"]["code"] == fixture["expectedError"]
+    assert receipt["handle"] is None
+
+
+def test_broker_rejects_a_host_receipt_behind_the_required_cut():
+    calls = []
+
+    class _BehindClient:
+        def activate(self, requirement, request_source):
+            return _ready_receipt(requirement, request_source)
+
+    broker = runtime_broker.RuntimeCapabilityBroker(_BehindClient)
+    plan = broker.plan(
+        "assessment.request",
+        workspace="workspace-test",
+        request_source="python",
+        minimum_cut=_cut("5", "5"),
+    )
+    receipt = broker.invoke(plan, lambda activation: calls.append(activation))
+
+    assert receipt["accepted"] is False
+    assert calls == []
+
+
+def test_process_activation_without_a_readiness_authority_fails_closed(tmp_path):
+    runtime_dir = tmp_path / "home" / "runtime"
+    requirement = runtime_broker.plan_operation(
+        "assessment.request",
+        workspace=runtime_broker.workspace_id(runtime_dir),
+        request_source="python",
+        minimum_cut=_cut(),
+    )["requirement"]
+    receipt = runtime_broker.ProcessRuntimeActivationClient(
+        str(runtime_dir.parent),
+        str(runtime_dir),
+        config_home=str(tmp_path / "config"),
+        host=_FileProcessHost(tmp_path / "activation-count"),
+    ).activate(requirement, "python")
+
+    assert receipt["outcome"] == "failed"
+    assert receipt["error"]["code"] == "readiness_not_established"
+    assert receipt["handle"] is None
+
+
+def test_reconciled_native_evidence_projects_exact_durable_and_projection_cuts(
+    tmp_path,
+):
+    runtime_dir = tmp_path / "home" / "runtime"
+    requirement = runtime_broker.plan_operation(
+        "projection.subscribe",
+        workspace=runtime_broker.workspace_id(runtime_dir),
+        request_source="python",
+        minimum_cut=_cut(),
+    )["requirement"]
+    authority = runtime_broker._ReconciledReadinessProjection(
+        _reconciliation(),
+        _projection_status(),
+    )
+    receipt = runtime_broker.ProcessRuntimeActivationClient(
+        str(runtime_dir.parent),
+        str(runtime_dir),
+        config_home=str(tmp_path / "config"),
+        host=_FileProcessHost(tmp_path / "activation-count"),
+        readiness_authority=authority,
+    ).activate(requirement, "python")
+
+    assert receipt["outcome"] == "activated"
+    assert receipt["handle"]["readiness"]["durableCut"] == _cut()
+    assert receipt["handle"]["readiness"]["projectionCut"] == _cut()
+    assert [
+        evidence["kind"] for evidence in receipt["handle"]["readiness"]["evidence"]
+    ] == ["durability-receipt", "projection-status"]
+
+
+def test_reconciled_readiness_rejects_non_authoritative_durability_evidence():
+    authority = runtime_broker._ReconciledReadinessProjection(
+        {**_reconciliation(), "recovered": False}
+    )
+    requirement = runtime_broker.plan_operation(
+        "assessment.request",
+        workspace="workspace-test",
+        request_source="python",
+        minimum_cut=_cut(),
+    )["requirement"]
+
+    with pytest.raises(ValueError, match="not authoritative"):
+        authority.establish(requirement, "1", {})
+
+
+def test_retained_readiness_fixture_binds_native_evidence_above_the_minimum_cut():
+    fixture = READINESS_FIXTURES["valid"]
+    requirement = runtime_broker.plan_operation(
+        "projection.subscribe",
+        workspace="workspace-retained-fixture",
+        request_source="python",
+        minimum_cut=fixture["minimumCut"],
+    )["requirement"]
+    readiness = runtime_broker._ReconciledReadinessProjection(
+        fixture["durabilityReconciliation"],
+        fixture["projectionStatus"],
+    ).establish(requirement, "1", {})
+
+    assert runtime_broker._readiness_admits_requirement(requirement, readiness)
+    assert readiness["durableCut"]["sequence"] == "42"
+    assert readiness["projectionCut"] == readiness["durableCut"]
+
+
+def test_native_readiness_authority_invokes_existing_typed_authorities(
+    tmp_path, monkeypatch
+):
+    from kungfu import durability, projection
+
+    fixture = READINESS_FIXTURES["valid"]
+    calls = []
+    monkeypatch.setattr(
+        durability,
+        "reconcile",
+        lambda **kwargs: (
+            calls.append(("durability", kwargs)) or fixture["durabilityReconciliation"]
+        ),
+    )
+    monkeypatch.setattr(
+        projection,
+        "candidate_status",
+        lambda **kwargs: (
+            calls.append(("projection", kwargs)) or fixture["projectionStatus"]
+        ),
+    )
+    runtime_dir = tmp_path / "home" / "runtime"
+    requirement = runtime_broker.plan_operation(
+        "projection.subscribe",
+        workspace=runtime_broker.workspace_id(runtime_dir),
+        request_source="python",
+        minimum_cut=fixture["minimumCut"],
+    )["requirement"]
+    authority = runtime_broker.NativeReadinessAuthority(
+        data_root=str(runtime_dir),
+        durability_request_id=17,
+        requested_profile="durable_sync",
+        writer_resource_id="00000007.0000000b",
+        durability_qualification_profile="test/disposable-powercut/v1",
+        projection_writer_resource_id="projection-restart-writer",
+        projection_qualification_profile="candidate/test-local-filesystem/v1",
+    )
+    receipt = runtime_broker.ProcessRuntimeActivationClient(
+        str(runtime_dir.parent),
+        str(runtime_dir),
+        config_home=str(tmp_path / "config"),
+        host=_FileProcessHost(tmp_path / "activation-count"),
+        readiness_authority=authority,
+    ).activate(requirement, "python")
+
+    assert receipt["outcome"] == "activated"
+    assert [kind for kind, _ in calls] == ["durability", "projection"]
+    assert calls[0][1]["sequence"] == 41
+    assert calls[1][1]["container_epoch"] == 11
+
+
+def test_untracked_running_process_cannot_invent_generation_one(tmp_path):
+    runtime_dir = tmp_path / "home" / "runtime"
+    counter_path = tmp_path / "activation-count"
+    counter_path.write_text("1")
+    requirement = runtime_broker.plan_operation(
+        "assessment.request",
+        workspace=runtime_broker.workspace_id(runtime_dir),
+        request_source="python",
+        minimum_cut=_cut(),
+    )["requirement"]
+    receipt = runtime_broker.ProcessRuntimeActivationClient(
+        str(runtime_dir.parent),
+        str(runtime_dir),
+        config_home=str(tmp_path / "config"),
+        host=_FileProcessHost(counter_path),
+        readiness_authority=_CutReadinessAuthority(),
+    ).activate(requirement, "python")
+
+    assert receipt["outcome"] == "failed"
+    assert receipt["error"]["code"] == "stale_generation"
+    assert counter_path.read_text() == "1"
+
+
+def test_corrupt_generation_snapshot_fails_closed(tmp_path):
+    runtime_dir = tmp_path / "home" / "runtime"
+    workspace = runtime_broker.workspace_id(runtime_dir)
+    state_path = runtime_broker._activation_state_path(tmp_path / "config", workspace)
+    state_path.parent.mkdir(parents=True)
+    state_path.write_text("{not-json")
+    requirement = runtime_broker.plan_operation(
+        "assessment.request",
+        workspace=workspace,
+        request_source="python",
+        minimum_cut=_cut(),
+    )["requirement"]
+    receipt = runtime_broker.ProcessRuntimeActivationClient(
+        str(runtime_dir.parent),
+        str(runtime_dir),
+        config_home=str(tmp_path / "config"),
+        host=_FileProcessHost(tmp_path / "activation-count"),
+        readiness_authority=_CutReadinessAuthority(),
+    ).activate(requirement, "python")
+
+    assert receipt["outcome"] == "failed"
+    assert receipt["error"]["code"] == "stale_generation"

--- a/tests/fixtures/runtime-activation-readiness/cases.json
+++ b/tests/fixtures/runtime-activation-readiness/cases.json
@@ -1,0 +1,56 @@
+{
+  "schema": "kungfu.runtime-activation-readiness-fixtures/v1",
+  "valid": {
+    "minimumCut": {
+      "stream_id": "7",
+      "container_epoch": "11",
+      "sequence": "41",
+      "frame_uid": "1041"
+    },
+    "durabilityReconciliation": {
+      "schema": "kungfu.durability.reconciliation/v1",
+      "state": "reconciled",
+      "recovered": true,
+      "receipt": {
+        "schema": "kungfu.durability.receipt/v1",
+        "request_id": 17,
+        "status": "succeeded",
+        "durable_watermark": {
+          "stream_id": 7,
+          "container_epoch": 11,
+          "sequence": 42,
+          "frame_uid": 1042
+        },
+        "barrier_id": 23
+      }
+    },
+    "projectionStatus": {
+      "schema": "kungfu.projection-candidate-status/v1",
+      "authority": "libkungfu",
+      "outcome": "ready",
+      "hydrated": true,
+      "qualification_profile": "candidate/test-local-filesystem/v1",
+      "projection_watermark": {
+        "stream_id": 7,
+        "container_epoch": 11,
+        "sequence": 42,
+        "frame_uid": 1042
+      }
+    }
+  },
+  "behind": {
+    "minimumCut": {
+      "stream_id": "7",
+      "container_epoch": "11",
+      "sequence": "42",
+      "frame_uid": "1042"
+    },
+    "observedCut": {
+      "stream_id": "7",
+      "container_epoch": "11",
+      "sequence": "41",
+      "frame_uid": "1041"
+    },
+    "expectedError": "readiness_cut_unavailable"
+  }
+}


### PR DESCRIPTION
## Summary

- serialize first activation with one cross-process owner per canonical workspace
- persist atomic runtime snapshots and reuse one generation across concurrent first calls
- advance generation only when process diagnostics are replaced; revalidate expanded capabilities in the same process generation
- invoke existing durability reconciliation and projection candidate authorities, admitting readiness only at or beyond the requested cut
- fail closed for missing/corrupt generation state, untracked running processes, absent readiness authority, and behind-cut evidence
- retain lease/adoption/restart lifecycle, product entrypoint wiring, and production `EmbeddedRuntimeHost` as later-stage non-claims

## Verification

- `PYTHONPATH=framework/core/src/python ./shifu exec uv run --project framework/core --frozen -- python -m pytest -q framework/core/tests/python/test_runtime_broker.py` (17 passed)
- `XDG_CACHE_HOME=/tmp/kungfu-codex-runtime-readiness-cache ./shifu exec uv run --project framework/core --frozen -- ./shifu check:source` (130 contract tests; 61 documentation contract tests; docs, Biome, Ruff, mypy across 134 source files, and KFD checks passed)
- `./shifu kfd:buildchain` (KFD-1 witness, 3 KFD-2 claims, 113 KFD-3 surfaces)
- staged pre-commit gate passed

## Governance risk

No credentials, provider APIs, hosted services, deployment, production release, or production embedded runtime are changed. PID and health diagnostics remain non-authoritative. A running process without a valid fenced generation fails `stale_generation`; explicit adoption and lease/restart recovery remain stage 5 work. Product evidence discovery and entrypoint wiring remain stage 6 work.

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "stage-ready",
  "adrs": ["ADR-0080"],
  "summary": "Land stage 4: serialize first activation, persist and fence process generations, and bind native durability/projection readiness to the requested cut while leaving adoption, leases, restart recovery, product projection, and EmbeddedRuntimeHost to later stages.",
  "verification": ["runtime_broker pytest: 17 passed", "build-free source gate: 130 tests plus 61 documentation contracts, Biome, Ruff, mypy, and KFD checks", "staged pre-commit gate"]
}
-->
