### PR TITLE
feat(runtime): unify product runtime projections

### DIFF
--- a/.buildchain/kfd/kfd-1/contract-world.witness.json
+++ b/.buildchain/kfd/kfd-1/contract-world.witness.json
@@ -69,9 +69,9 @@
     {
       "name": "kungfu-runtime",
       "sourcePath": "framework/runtime/kungfu-runtime.contract.json",
-      "sourceSha256": "11b4a8b598f5af833b2cf2b21cf2e195b7ac1c2884a444d749be674c3834db78",
+      "sourceSha256": "ecacaf692a10245f67a833474c378f3a99a6028774eaa327e3e27ff25b127094",
       "artifactPath": "config/kungfu-runtime.contract.json",
-      "expectedSha256": "11b4a8b598f5af833b2cf2b21cf2e195b7ac1c2884a444d749be674c3834db78",
+      "expectedSha256": "ecacaf692a10245f67a833474c378f3a99a6028774eaa327e3e27ff25b127094",
       "byteForByte": true
     }
   ],

--- a/.buildchain/kfd/kfd-1/release-gate.json
+++ b/.buildchain/kfd/kfd-1/release-gate.json
@@ -54,13 +54,13 @@
       "standard": "KFD-1",
       "standardKey": "kfd-1",
       "result": "passed",
-      "preBuildWitnessSha256": "283fa50d78a8f14ca5331a02d50468a14905b57c006206de80616adc32b42157",
+      "preBuildWitnessSha256": "dee8fab29ab16184f50377a98d18f6936fe6c37e86d68da30b69d16dcc0198d6",
       "sourceHashes": {
-        "sha256": "bc67cde1bf7ec8f3362a345eba6be51ffbf9eb818ad9b6db9e5d98f74bb83129",
+        "sha256": "ed846774461c4d10493d61a4352d76b177255a9261b620054a88a0f640a5be01",
         "surfaceCount": 4
       },
       "artifactHashes": {
-        "sha256": "4e1a24c98084a25e9a7c65d23ceed76d15ca213cecb9e61945acdc48e98edbb5",
+        "sha256": "0499094777d09c5e5f3eb0d618acef6cf28f1f57320366dd839522f74e547f26",
         "surfaceCount": 4
       },
       "witness": {
@@ -134,9 +134,9 @@
           {
             "name": "kungfu-runtime",
             "sourcePath": "framework/runtime/kungfu-runtime.contract.json",
-            "sourceSha256": "11b4a8b598f5af833b2cf2b21cf2e195b7ac1c2884a444d749be674c3834db78",
+            "sourceSha256": "ecacaf692a10245f67a833474c378f3a99a6028774eaa327e3e27ff25b127094",
             "artifactPath": "config/kungfu-runtime.contract.json",
-            "expectedSha256": "11b4a8b598f5af833b2cf2b21cf2e195b7ac1c2884a444d749be674c3834db78",
+            "expectedSha256": "ecacaf692a10245f67a833474c378f3a99a6028774eaa327e3e27ff25b127094",
             "byteForByte": true
           }
         ],
@@ -209,8 +209,8 @@
           {
             "name": "kungfu-runtime",
             "sourcePath": "framework/runtime/kungfu-runtime.contract.json",
-            "expectedSha256": "11b4a8b598f5af833b2cf2b21cf2e195b7ac1c2884a444d749be674c3834db78",
-            "actualSha256": "11b4a8b598f5af833b2cf2b21cf2e195b7ac1c2884a444d749be674c3834db78",
+            "expectedSha256": "ecacaf692a10245f67a833474c378f3a99a6028774eaa327e3e27ff25b127094",
+            "actualSha256": "ecacaf692a10245f67a833474c378f3a99a6028774eaa327e3e27ff25b127094",
             "status": "passed",
             "reason": ""
           }
@@ -256,10 +256,10 @@
           {
             "name": "kungfu-runtime",
             "sourcePath": "framework/runtime/kungfu-runtime.contract.json",
-            "sourceSha256": "11b4a8b598f5af833b2cf2b21cf2e195b7ac1c2884a444d749be674c3834db78",
+            "sourceSha256": "ecacaf692a10245f67a833474c378f3a99a6028774eaa327e3e27ff25b127094",
             "artifactPath": "config/kungfu-runtime.contract.json",
-            "expectedSha256": "11b4a8b598f5af833b2cf2b21cf2e195b7ac1c2884a444d749be674c3834db78",
-            "actualSha256": "11b4a8b598f5af833b2cf2b21cf2e195b7ac1c2884a444d749be674c3834db78",
+            "expectedSha256": "ecacaf692a10245f67a833474c378f3a99a6028774eaa327e3e27ff25b127094",
+            "actualSha256": "ecacaf692a10245f67a833474c378f3a99a6028774eaa327e3e27ff25b127094",
             "byteForByte": true,
             "status": "passed",
             "reason": ""

--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -6,7 +6,7 @@
   "supportLevel": "release",
   "source": {
     "cwd": "/Users/dkr/Worktrees/kungfu/feature/runtime-surface-integration",
-    "sourceSha": "985b74b469e689bdf2288e514744f9c85ba89bac",
+    "sourceSha": "55d84330744d641a4e291440432c725bb0a13db7",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
     "registryDigest": "sha256:6b8e5f64c722f6d97c5ff1f23bf5d8bd584a5358588e214424ea8cce461c5b82"
   },

--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -6,7 +6,7 @@
   "supportLevel": "release",
   "source": {
     "cwd": "/Users/dkr/Worktrees/kungfu/feature/runtime-surface-integration",
-    "sourceSha": "55d84330744d641a4e291440432c725bb0a13db7",
+    "sourceSha": "03afe5edde8136b104d4621c56d2a3b7c3eab899",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
     "registryDigest": "sha256:6b8e5f64c722f6d97c5ff1f23bf5d8bd584a5358588e214424ea8cce461c5b82"
   },

--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -5,8 +5,8 @@
   "witnessKind": "prebuild",
   "supportLevel": "release",
   "source": {
-    "cwd": "/Users/dkr/Worktrees/kungfu/feature/runtime-lease-recovery",
-    "sourceSha": "c2b4a81e52d3fe97c051e41811d9e52536555110",
+    "cwd": "/Users/dkr/Worktrees/kungfu/feature/runtime-surface-integration",
+    "sourceSha": "985b74b469e689bdf2288e514744f9c85ba89bac",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
     "registryDigest": "sha256:6b8e5f64c722f6d97c5ff1f23bf5d8bd584a5358588e214424ea8cce461c5b82"
   },

--- a/developer/sdk/kfd/kfd-1/contract-world.witness.json
+++ b/developer/sdk/kfd/kfd-1/contract-world.witness.json
@@ -69,9 +69,9 @@
     {
       "name": "kungfu-runtime",
       "sourcePath": "framework/runtime/kungfu-runtime.contract.json",
-      "sourceSha256": "11b4a8b598f5af833b2cf2b21cf2e195b7ac1c2884a444d749be674c3834db78",
+      "sourceSha256": "ecacaf692a10245f67a833474c378f3a99a6028774eaa327e3e27ff25b127094",
       "artifactPath": "config/kungfu-runtime.contract.json",
-      "expectedSha256": "11b4a8b598f5af833b2cf2b21cf2e195b7ac1c2884a444d749be674c3834db78",
+      "expectedSha256": "ecacaf692a10245f67a833474c378f3a99a6028774eaa327e3e27ff25b127094",
       "byteForByte": true
     }
   ],

--- a/developer/sdk/kfd/kfd-1/release-gate.json
+++ b/developer/sdk/kfd/kfd-1/release-gate.json
@@ -54,13 +54,13 @@
       "standard": "KFD-1",
       "standardKey": "kfd-1",
       "result": "passed",
-      "preBuildWitnessSha256": "283fa50d78a8f14ca5331a02d50468a14905b57c006206de80616adc32b42157",
+      "preBuildWitnessSha256": "dee8fab29ab16184f50377a98d18f6936fe6c37e86d68da30b69d16dcc0198d6",
       "sourceHashes": {
-        "sha256": "bc67cde1bf7ec8f3362a345eba6be51ffbf9eb818ad9b6db9e5d98f74bb83129",
+        "sha256": "ed846774461c4d10493d61a4352d76b177255a9261b620054a88a0f640a5be01",
         "surfaceCount": 4
       },
       "artifactHashes": {
-        "sha256": "4e1a24c98084a25e9a7c65d23ceed76d15ca213cecb9e61945acdc48e98edbb5",
+        "sha256": "0499094777d09c5e5f3eb0d618acef6cf28f1f57320366dd839522f74e547f26",
         "surfaceCount": 4
       },
       "witness": {
@@ -134,9 +134,9 @@
           {
             "name": "kungfu-runtime",
             "sourcePath": "framework/runtime/kungfu-runtime.contract.json",
-            "sourceSha256": "11b4a8b598f5af833b2cf2b21cf2e195b7ac1c2884a444d749be674c3834db78",
+            "sourceSha256": "ecacaf692a10245f67a833474c378f3a99a6028774eaa327e3e27ff25b127094",
             "artifactPath": "config/kungfu-runtime.contract.json",
-            "expectedSha256": "11b4a8b598f5af833b2cf2b21cf2e195b7ac1c2884a444d749be674c3834db78",
+            "expectedSha256": "ecacaf692a10245f67a833474c378f3a99a6028774eaa327e3e27ff25b127094",
             "byteForByte": true
           }
         ],
@@ -209,8 +209,8 @@
           {
             "name": "kungfu-runtime",
             "sourcePath": "framework/runtime/kungfu-runtime.contract.json",
-            "expectedSha256": "11b4a8b598f5af833b2cf2b21cf2e195b7ac1c2884a444d749be674c3834db78",
-            "actualSha256": "11b4a8b598f5af833b2cf2b21cf2e195b7ac1c2884a444d749be674c3834db78",
+            "expectedSha256": "ecacaf692a10245f67a833474c378f3a99a6028774eaa327e3e27ff25b127094",
+            "actualSha256": "ecacaf692a10245f67a833474c378f3a99a6028774eaa327e3e27ff25b127094",
             "status": "passed",
             "reason": ""
           }
@@ -256,10 +256,10 @@
           {
             "name": "kungfu-runtime",
             "sourcePath": "framework/runtime/kungfu-runtime.contract.json",
-            "sourceSha256": "11b4a8b598f5af833b2cf2b21cf2e195b7ac1c2884a444d749be674c3834db78",
+            "sourceSha256": "ecacaf692a10245f67a833474c378f3a99a6028774eaa327e3e27ff25b127094",
             "artifactPath": "config/kungfu-runtime.contract.json",
-            "expectedSha256": "11b4a8b598f5af833b2cf2b21cf2e195b7ac1c2884a444d749be674c3834db78",
-            "actualSha256": "11b4a8b598f5af833b2cf2b21cf2e195b7ac1c2884a444d749be674c3834db78",
+            "expectedSha256": "ecacaf692a10245f67a833474c378f3a99a6028774eaa327e3e27ff25b127094",
+            "actualSha256": "ecacaf692a10245f67a833474c378f3a99a6028774eaa327e3e27ff25b127094",
             "byteForByte": true,
             "status": "passed",
             "reason": ""

--- a/docs/adr/ADR-0080-topology-neutral-capability-driven-runtime-activation.md
+++ b/docs/adr/ADR-0080-topology-neutral-capability-driven-runtime-activation.md
@@ -287,6 +287,14 @@ products copy the exact contract through the existing KFD-1 contract registry.
 4. Bind recovery and projection readiness to an exact durable cut. **Core seam complete:** one per-workspace activation owner serializes first calls, persists the accepted generation, fences replaced process diagnostics, and admits native durability/projection evidence only at or beyond the requested cut. The process adapter remains fail closed when no `DurableEngine` readiness authority is supplied; product evidence discovery is stage 6 work.
 5. Add leases, idle draining, adoption, and restart recovery. **Core lifecycle complete:** generation-fenced semantic leases persist under the activation owner, idle draining atomically fences new demand before stopping a route, a replacement supervisor may adopt only the exact recorded coordinator generation, untracked orphans fail closed, and coordinator crash restarts stop at a bounded attempt window. Route heartbeat TTL remains diagnostic rather than a semantic lease. Cross-machine leasing and product lease acquisition remain outside this stage.
 6. Project the same contract through CLI, GUI, Python, Node, libkungfu, and KFX.
+   **Projection slice complete:** one canonical product-status value now keeps
+   daemonless workspaces available, preserves exact generation/cut/lease/error
+   semantics, and remains separate from advanced process diagnostics. CLI
+   exposes machine-readable operation planning, GUI startup/quit no longer owns
+   runtime processes, and Node/KFX/libkungfu-facing declarations share the same
+   vocabulary. Product action invocation still requires exact-cut evidence
+   discovery and therefore remains open rather than silently bypassing
+   readiness.
 7. Qualify daemonless/no-fork behavior, process crash recovery, product
    artifacts, and supported claims.
 

--- a/docs/adr/ADR-0080-topology-neutral-capability-driven-runtime-activation.md
+++ b/docs/adr/ADR-0080-topology-neutral-capability-driven-runtime-activation.md
@@ -4,7 +4,7 @@ doc_type: architecture-decision
 adr_id: ADR-0080
 decision_status: accepted
 implementation_status: partial
-implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/815, https://github.com/kungfu-systems/kungfu/pull/818, https://github.com/kungfu-systems/kungfu/pull/819, https://github.com/kungfu-systems/kungfu/pull/822, https://github.com/kungfu-systems/kungfu/pull/823]
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/815, https://github.com/kungfu-systems/kungfu/pull/818, https://github.com/kungfu-systems/kungfu/pull/819, https://github.com/kungfu-systems/kungfu/pull/822, https://github.com/kungfu-systems/kungfu/pull/823, https://github.com/kungfu-systems/kungfu/pull/825]
 review_state: self-reviewed
 sensitivity: public
 sources: [local-files, user-decision]

--- a/docs/architecture/runtime-service.md
+++ b/docs/architecture/runtime-service.md
@@ -116,6 +116,28 @@ diagnostics remain insufficient: without an explicitly supplied DurableEngine
 readiness authority the process adapter returns `readiness_not_established`.
 Product evidence discovery and entrypoint wiring remain stage 6 work.
 
+The first stage 6 projection slice adds one
+`kungfu.runtime.product-status/v1` value beside the retained process
+diagnostics. `kungfu runtime status` leads with workspace availability,
+generation, semantic readiness, exact cuts, effective leases, and typed failure;
+supervisor/coordinator facts remain in an explicitly labelled advanced section.
+`kungfu runtime operations --json` exposes the contract-owned operation catalog,
+and `kungfu runtime plan OPERATION --json` produces the same topology-neutral
+requirement used by the broker without activating a host.
+
+The GUI consumes that product projection and no longer starts or stops the
+runtime on application startup, ordinary quit, or tray actions. Node, KFX, and
+the libkungfu-facing TypeScript declaration surface share the exact status,
+handle, readiness, lease, error, and operation vocabulary. These projections
+do not create another lifecycle implementation or external executor ABI.
+
+This slice does not weaken the live admission boundary. A first live-required
+product action still needs an exact minimum cut and an explicitly configured
+`NativeReadinessAuthority`; a process that merely started cannot satisfy it.
+Binding product action invocation to discovered evidence remains required
+before stage 6 can close and before product qualification may claim cold live
+activation.
+
 ## Semantic Leases and Recovery
 
 `RuntimeLeaseManager` persists ADR-0080 leases in the same per-workspace

--- a/framework/api/src/capability/index.ts
+++ b/framework/api/src/capability/index.ts
@@ -17,6 +17,7 @@ export * from './query.js';
 export * from './profile.js';
 export * from './agent-runtime.js';
 export * from './agent-console.js';
+export * from './runtime.js';
 
 // The runtime-plane trust boundary (ADR-0013 / ADR-0014): the OS-sandbox
 // launcher, the child-process relay transport, the Node child-side guest proxy,

--- a/framework/api/src/capability/runtime.ts
+++ b/framework/api/src/capability/runtime.ts
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Topology-neutral runtime values projected by Core. Consumers may display or
+// transport these values, but must not infer readiness from process health.
+
+export type RuntimeStreamPosition = {
+  stream_id: string;
+  container_epoch: string;
+  sequence: string;
+  frame_uid: string;
+};
+
+export type RuntimeError = {
+  code: string;
+  message: string;
+  retryable: boolean;
+};
+
+export type RuntimeReadiness = {
+  schema: 'kungfu.runtime.readiness/v1';
+  state:
+    | 'starting'
+    | 'recovering'
+    | 'ready'
+    | 'draining'
+    | 'failed'
+    | 'restarting'
+    | 'stopped';
+  durableCut: RuntimeStreamPosition | null;
+  projectionCut: RuntimeStreamPosition | null;
+  evidence: Array<{ kind: string; ref: string }>;
+  observedAtNs: string;
+};
+
+export type RuntimeHandle = {
+  schema: 'kungfu.runtime.handle/v1';
+  runtimeId: string;
+  requirementId: string;
+  workspaceId: string;
+  generation: string;
+  state: RuntimeReadiness['state'];
+  capabilities: string[];
+  grantedAuthorities: string[];
+  readiness: RuntimeReadiness;
+  host: {
+    kind: string;
+    hostId: string;
+    diagnostics: Record<string, unknown>;
+  };
+};
+
+export type RuntimeLease = {
+  schema: 'kungfu.runtime.lease/v1';
+  leaseId: string;
+  runtimeId: string;
+  generation: string;
+  holderId: string;
+  capabilities: string[];
+  issuedAtNs: string;
+  expiresAtNs: string;
+  state: 'active' | 'released' | 'expired';
+};
+
+type RuntimeProductStatusBase = {
+  schema: 'kungfu.runtime.product-status/v1';
+  workspaceId: string;
+  availability: 'available';
+  leases: { activeCount: number; items: RuntimeLease[] };
+};
+
+export type RuntimeProductStatus = RuntimeProductStatusBase &
+  (
+    | { liveState: 'inactive'; handle: null; error: null }
+    | {
+        liveState: Exclude<RuntimeReadiness['state'], 'failed'>;
+        handle: RuntimeHandle;
+        error: null;
+      }
+    | {
+        liveState: 'failed';
+        handle: RuntimeHandle | null;
+        error: RuntimeError;
+      }
+  );
+
+export type RuntimeOperation = {
+  id: string;
+  operationClass: 'storage-only' | 'live-optional' | 'live-required';
+  requiredCapabilities: string[];
+  requestedAuthorities: string[];
+  recoveryGuidance: string;
+};
+
+export type RuntimeOperationCatalog = {
+  schema: 'kungfu.runtime-operation-registry/v1';
+  operations: RuntimeOperation[];
+};

--- a/framework/core/lib/kungfu.d.ts
+++ b/framework/core/lib/kungfu.d.ts
@@ -1,5 +1,79 @@
 // SPDX-License-Identifier: Apache-2.0
 
+interface KungfuRuntimeStreamPosition {
+  stream_id: string;
+  container_epoch: string;
+  sequence: string;
+  frame_uid: string;
+}
+
+interface KungfuRuntimeReadiness {
+  schema: 'kungfu.runtime.readiness/v1';
+  state:
+    | 'starting'
+    | 'recovering'
+    | 'ready'
+    | 'draining'
+    | 'failed'
+    | 'restarting'
+    | 'stopped';
+  durableCut: KungfuRuntimeStreamPosition | null;
+  projectionCut: KungfuRuntimeStreamPosition | null;
+  evidence: Array<{ kind: string; ref: string }>;
+  observedAtNs: string;
+}
+
+interface KungfuRuntimeHandle {
+  schema: 'kungfu.runtime.handle/v1';
+  runtimeId: string;
+  requirementId: string;
+  workspaceId: string;
+  generation: string;
+  state: KungfuRuntimeReadiness['state'];
+  capabilities: string[];
+  grantedAuthorities: string[];
+  readiness: KungfuRuntimeReadiness;
+  host: {
+    kind: string;
+    hostId: string;
+    diagnostics: Record<string, unknown>;
+  };
+}
+
+interface KungfuRuntimeLease {
+  schema: 'kungfu.runtime.lease/v1';
+  leaseId: string;
+  runtimeId: string;
+  generation: string;
+  holderId: string;
+  capabilities: string[];
+  issuedAtNs: string;
+  expiresAtNs: string;
+  state: 'active' | 'released' | 'expired';
+}
+
+interface KungfuRuntimeProductStatusBase {
+  schema: 'kungfu.runtime.product-status/v1';
+  workspaceId: string;
+  availability: 'available';
+  leases: { activeCount: number; items: KungfuRuntimeLease[] };
+}
+
+type KungfuRuntimeProductStatus = KungfuRuntimeProductStatusBase &
+  (
+    | { liveState: 'inactive'; handle: null; error: null }
+    | {
+        liveState: Exclude<KungfuRuntimeReadiness['state'], 'failed'>;
+        handle: KungfuRuntimeHandle;
+        error: null;
+      }
+    | {
+        liveState: 'failed';
+        handle: KungfuRuntimeHandle | null;
+        error: { code: string; message: string; retryable: boolean };
+      }
+  );
+
 interface StorageTimeRange {
   since: string;
   until: string;
@@ -1031,6 +1105,14 @@ interface KungfuRuntime {
     runtimeDir: string,
   ): StorageProjectionRebuildResult;
   [name: string]: unknown;
+}
+
+declare namespace createKungfuRuntime {
+  type RuntimeStreamPosition = KungfuRuntimeStreamPosition;
+  type RuntimeReadiness = KungfuRuntimeReadiness;
+  type RuntimeHandle = KungfuRuntimeHandle;
+  type RuntimeLease = KungfuRuntimeLease;
+  type RuntimeProductStatus = KungfuRuntimeProductStatus;
 }
 
 declare function createKungfuRuntime(): KungfuRuntime;

--- a/framework/core/src/python/kungfu/cli/commands/runtime.py
+++ b/framework/core/src/python/kungfu/cli/commands/runtime.py
@@ -7,7 +7,7 @@ import sys
 
 import click
 
-from kungfu import runtime_service
+from kungfu import runtime_broker, runtime_service
 from kungfu.cli.commands import PrioritizedCommandGroup, kfc
 
 runtime_command_context = kfc.pass_context()
@@ -18,19 +18,33 @@ def _json(payload):
 
 
 def _plain_status(payload):
-    click.echo(f"status: {payload['status']}")
-    click.echo(f"lifecycle: {payload.get('lifecycle', {}).get('state', '-')}")
+    product = payload.get("product") or {}
+    click.echo(f"workspace: {product.get('availability', 'unknown')}")
+    click.echo(f"live runtime: {product.get('liveState', 'unknown')}")
+    handle = product.get("handle") or {}
+    if handle:
+        click.echo(f"generation: {handle.get('generation', '-')}")
+        readiness = handle.get("readiness") or {}
+        click.echo(f"readiness: {readiness.get('state', '-')}")
+        click.echo(f"durable cut: {json.dumps(readiness.get('durableCut'))}")
+        click.echo(f"projection cut: {json.dumps(readiness.get('projectionCut'))}")
+        click.echo(f"active leases: {product.get('leases', {}).get('activeCount', 0)}")
+    error = product.get("error") or {}
+    if error:
+        click.echo(f"runtime error: {error.get('code')}: {error.get('message')}")
     click.echo(f"config: {payload['configHome']}")
     click.echo(f"data root: {payload['dataRoot']}")
     click.echo(f"runtime: {payload['runtimeDir']}")
+    click.echo("process diagnostics:")
+    click.echo(f"  lifecycle: {payload.get('lifecycle', {}).get('state', '-')}")
     click.echo(
-        "supervisor: "
+        "  supervisor: "
         f"{payload['supervisor']['pid'] or '-'} "
         f"({'running' if payload['supervisor']['running'] else 'stopped'})"
     )
     if "coordinator" in payload:
         click.echo(
-            "coordinator: "
+            "  coordinator: "
             f"{payload['coordinator']['pid'] or '-'} "
             f"({'running' if payload['coordinator']['running'] else 'stopped'})"
         )
@@ -42,7 +56,7 @@ def _plain_status(payload):
 @kfc.group(
     cls=PrioritizedCommandGroup,
     help_priority=2,
-    help="manage the resident Kungfu runtime",
+    help="inspect or operate the resident runtime (ordinary work auto-activates it)",
 )
 @click.help_option("-h", "--help")
 @kfc.pass_context()
@@ -50,7 +64,10 @@ def runtime(ctx):
     pass
 
 
-@runtime.command(name="status", help="print resident coordinator supervisor status")
+@runtime.command(
+    name="status",
+    help="print workspace runtime status with advanced process diagnostics",
+)
 @click.option("--json", "as_json", is_flag=True, help="machine-readable output")
 @runtime_command_context
 def runtime_status(ctx, as_json):
@@ -59,6 +76,64 @@ def runtime_status(ctx, as_json):
         _json(payload)
         return
     _plain_status(payload)
+
+
+@runtime.command(
+    name="operations",
+    help="list the machine-readable runtime capability operation catalog",
+)
+@click.option("--json", "as_json", is_flag=True, help="machine-readable output")
+def runtime_operations(as_json):
+    payload = runtime_broker.operation_catalog()
+    if as_json:
+        _json(payload)
+        return
+    for operation in payload["operations"]:
+        capabilities = ", ".join(operation["requiredCapabilities"]) or "none"
+        click.echo(
+            f"{operation['id']}: {operation['operationClass']} "
+            f"(capabilities: {capabilities})"
+        )
+
+
+@runtime.command(
+    name="plan",
+    help="project one operation into its topology-neutral runtime requirement",
+)
+@click.argument("operation_id")
+@click.option("--request-id", default=None, help="stable caller request identity")
+@click.option(
+    "--minimum-cut",
+    default=None,
+    help="minimum stream position as a JSON object",
+)
+@click.option("--json", "as_json", is_flag=True, help="machine-readable output")
+@runtime_command_context
+def runtime_plan(ctx, operation_id, request_id, minimum_cut, as_json):
+    try:
+        cut = json.loads(minimum_cut) if minimum_cut else None
+        if cut is not None and not isinstance(cut, dict):
+            raise ValueError("minimum cut must be a JSON object")
+        payload = runtime_broker.plan_operation(
+            operation_id,
+            workspace=runtime_broker.workspace_id(ctx.runtime_dir),
+            request_source="cli",
+            minimum_cut=cut,
+            request_id=request_id,
+        )
+    except (json.JSONDecodeError, KeyError, ValueError) as error:
+        raise click.ClickException(str(error)) from error
+    if as_json:
+        _json(payload)
+        return
+    requirement = payload["requirement"]
+    click.echo(f"operation: {payload['operation']['id']}")
+    click.echo(f"class: {requirement['operationClass']}")
+    click.echo(
+        "required capabilities: "
+        f"{', '.join(requirement['requiredCapabilities']) or 'none'}"
+    )
+    click.echo(f"recovery: {payload['recoveryGuidance']}")
 
 
 @runtime.command(

--- a/framework/core/src/python/kungfu/runtime_broker.py
+++ b/framework/core/src/python/kungfu/runtime_broker.py
@@ -19,6 +19,7 @@ PLAN_SCHEMA = "kungfu.runtime.invocation-plan/v1"
 RECEIPT_SCHEMA = "kungfu.runtime.invocation-receipt/v1"
 REQUIREMENT_SCHEMA = "kungfu.runtime.requirement/v1"
 ACTIVATION_RECEIPT_SCHEMA = "kungfu.runtime.activation-receipt/v1"
+PRODUCT_STATUS_SCHEMA = "kungfu.runtime.product-status/v1"
 REQUEST_SOURCES = {"libkungfu", "cli", "python", "node", "gui", "kfx"}
 
 
@@ -248,6 +249,91 @@ def _write_activation_state(path: Path, value: Mapping[str, Any]) -> None:
         pass
     finally:
         os.close(directory)
+
+
+def product_status(
+    config_home: str | Path,
+    runtime_dir: str | Path,
+    *,
+    clock: RuntimeLeaseClock | None = None,
+    contract: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Project one topology-neutral product status from the fenced snapshot.
+
+    An absent live snapshot is a normal daemonless workspace, not an offline
+    workspace. Process facts deliberately stay on the separate diagnostic
+    status surface and cannot promote this projection to ready.
+    """
+
+    workspace = workspace_id(runtime_dir)
+    status: dict[str, Any] = {
+        "schema": PRODUCT_STATUS_SCHEMA,
+        "workspaceId": workspace,
+        "availability": "available",
+        "liveState": "inactive",
+        "handle": None,
+        "leases": {"activeCount": 0, "items": []},
+        "error": None,
+    }
+    try:
+        state = _read_activation_state(_activation_state_path(config_home, workspace))
+        if state is None:
+            _validate_value("runtimeProductStatus", status, contract)
+            return status
+        _validate_value("runtimeSnapshot", state, contract)
+        if state.get("workspaceId") != workspace:
+            raise RuntimeLifecycleError(
+                "stale_generation",
+                "runtime activation workspace is inconsistent",
+            )
+        projected = copy.deepcopy(state)
+        _expire_leases(projected, (clock or SystemRuntimeLeaseClock()).now_ns())
+        handle = _snapshot_handle(projected)
+        leases = [
+            copy.deepcopy(dict(item))
+            for item in projected["leases"]
+            if isinstance(item, Mapping)
+        ]
+        status.update(
+            {
+                "liveState": str(handle["state"]),
+                "handle": handle,
+                "leases": {
+                    "activeCount": sum(
+                        1 for item in leases if item.get("state") == "active"
+                    ),
+                    "items": leases,
+                },
+            }
+        )
+        if handle["state"] == "failed":
+            status["error"] = {
+                "code": "activation_failed",
+                "message": "The fenced runtime generation is in the failed state.",
+                "retryable": True,
+            }
+        _validate_value("runtimeProductStatus", status, contract)
+        return status
+    except (OSError, ValueError, RuntimeLifecycleError) as error:
+        code = (
+            error.code
+            if isinstance(error, RuntimeLifecycleError)
+            else "stale_generation"
+        )
+        status.update(
+            {
+                "liveState": "failed",
+                "handle": None,
+                "leases": {"activeCount": 0, "items": []},
+                "error": {
+                    "code": code,
+                    "message": str(error),
+                    "retryable": False,
+                },
+            }
+        )
+    _validate_value("runtimeProductStatus", status, contract)
+    return status
 
 
 def _process_diagnostics(value: Mapping[str, Any]) -> dict[str, Any]:

--- a/framework/core/src/python/kungfu/runtime_service.py
+++ b/framework/core/src/python/kungfu/runtime_service.py
@@ -1087,6 +1087,8 @@ def route_status(
     runtime_dir: str,
     config_home: str | None = None,
 ) -> dict[str, Any]:
+    from kungfu import runtime_broker
+
     config_home = resolve_config_home(config_home)
     home = resolve_runtime_home(home)
     runtime_dir = resolve_runtime_dir(home, runtime_dir)
@@ -1162,6 +1164,7 @@ def route_status(
         },
         "lastSupervisorState": supervisor_state,
         "lastState": state,
+        "product": runtime_broker.product_status(config_home, runtime_dir),
     }
 
 

--- a/framework/core/tests/python/test_runtime_broker.py
+++ b/framework/core/tests/python/test_runtime_broker.py
@@ -683,6 +683,118 @@ def test_corrupt_generation_snapshot_fails_closed(tmp_path):
     assert receipt["error"]["code"] == "stale_generation"
 
 
+def test_product_status_treats_an_absent_live_runtime_as_available(tmp_path):
+    runtime_dir = tmp_path / "home" / "runtime"
+
+    status = runtime_broker.product_status(tmp_path / "config", runtime_dir)
+
+    assert status == {
+        "schema": "kungfu.runtime.product-status/v1",
+        "workspaceId": runtime_broker.workspace_id(runtime_dir),
+        "availability": "available",
+        "liveState": "inactive",
+        "handle": None,
+        "leases": {"activeCount": 0, "items": []},
+        "error": None,
+    }
+
+
+def test_product_status_projects_the_exact_handle_cut_and_effective_leases(tmp_path):
+    runtime_dir = tmp_path / "home" / "runtime"
+    config_home = tmp_path / "config"
+    requirement = runtime_broker.plan_operation(
+        "projection.subscribe",
+        workspace=runtime_broker.workspace_id(runtime_dir),
+        request_source="kfx",
+        minimum_cut=_cut("7", "17"),
+    )["requirement"]
+    activation = runtime_broker.ProcessRuntimeActivationClient(
+        str(runtime_dir.parent),
+        str(runtime_dir),
+        config_home=str(config_home),
+        host=_FileProcessHost(tmp_path / "activation-count"),
+        readiness_authority=_CutReadinessAuthority(),
+    ).activate(requirement, "kfx")
+    clock = _LeaseClock(100)
+    manager = runtime_broker.RuntimeLeaseManager(
+        config_home,
+        requirement["workspaceId"],
+        clock=clock,
+    )
+    manager.acquire(
+        activation["handle"],
+        holder_id="kfx:projection",
+        capabilities=["runtime.live-projection"],
+        ttl_ns=20,
+        lease_id="lease-projection",
+    )
+
+    current = runtime_broker.product_status(
+        config_home, runtime_dir, clock=_LeaseClock(110)
+    )
+    expired = runtime_broker.product_status(
+        config_home, runtime_dir, clock=_LeaseClock(121)
+    )
+
+    assert current["liveState"] == "ready"
+    assert current["handle"] == activation["handle"]
+    assert current["handle"]["readiness"]["durableCut"] == _cut("7", "17")
+    assert current["leases"]["activeCount"] == 1
+    assert expired["leases"]["activeCount"] == 0
+    assert expired["leases"]["items"][0]["state"] == "expired"
+
+
+def test_product_status_preserves_a_failed_generation_with_a_stable_error(tmp_path):
+    runtime_dir = tmp_path / "home" / "runtime"
+    config_home = tmp_path / "config"
+    workspace = runtime_broker.workspace_id(runtime_dir)
+    requirement = runtime_broker.plan_operation(
+        "assessment.request",
+        workspace=workspace,
+        request_source="python",
+        minimum_cut=_cut(),
+    )["requirement"]
+    runtime_broker.ProcessRuntimeActivationClient(
+        str(runtime_dir.parent),
+        str(runtime_dir),
+        config_home=str(config_home),
+        host=_FileProcessHost(tmp_path / "activation-count"),
+        readiness_authority=_CutReadinessAuthority(),
+    ).activate(requirement, "python")
+    state_path = runtime_broker._activation_state_path(config_home, workspace)
+    state = json.loads(state_path.read_text())
+    state["handles"][0]["state"] = "failed"
+    state["handles"][0]["readiness"]["state"] = "failed"
+    runtime_broker._write_activation_state(state_path, state)
+
+    status = runtime_broker.product_status(config_home, runtime_dir)
+
+    assert status["liveState"] == "failed"
+    assert status["handle"]["generation"] == "1"
+    assert status["error"] == {
+        "code": "activation_failed",
+        "message": "The fenced runtime generation is in the failed state.",
+        "retryable": True,
+    }
+
+
+def test_product_status_reports_a_stable_error_without_using_process_health(
+    tmp_path,
+):
+    runtime_dir = tmp_path / "home" / "runtime"
+    workspace = runtime_broker.workspace_id(runtime_dir)
+    state_path = runtime_broker._activation_state_path(tmp_path / "config", workspace)
+    state_path.parent.mkdir(parents=True)
+    state_path.write_text("{not-json")
+
+    status = runtime_broker.product_status(tmp_path / "config", runtime_dir)
+
+    assert status["availability"] == "available"
+    assert status["liveState"] == "failed"
+    assert status["handle"] is None
+    assert status["error"]["code"] == "stale_generation"
+
+
 def test_runtime_lease_acquire_renew_release_and_idle_drain_are_deterministic(
     tmp_path,
 ):

--- a/framework/core/tests/python/test_runtime_cli.py
+++ b/framework/core/tests/python/test_runtime_cli.py
@@ -1,0 +1,106 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+from pathlib import Path
+
+import click
+from click.testing import CliRunner
+import kungfu
+from kungfu import runtime_broker
+
+kungfu.__version__ = "test"
+
+from kungfu.cli.commands.runtime import runtime  # noqa: E402
+
+
+@click.group()
+@click.option("--home", type=click.Path(), required=True)
+@click.pass_context
+def runtime_test_cli(ctx, home):
+    ctx.name = "runtime-test"
+    ctx.config_home = str(Path(home) / "config")
+    ctx.home = str(home)
+    ctx.extension_path = None
+    ctx.log_level = "warning"
+    ctx.runtime_dir = str(Path(home) / "runtime")
+    ctx.dataset_dir = str(Path(home) / "dataset")
+    ctx.backtest_dir = str(Path(home) / "backtest")
+    ctx.inbox_dir = str(Path(home) / "inbox")
+    ctx.runtime_locator = None
+    ctx.backtest_locator = None
+    ctx.config_location = None
+    ctx.console_location = None
+    ctx.index_location = None
+    ctx.stage = "test"
+
+
+runtime_test_cli.add_command(runtime)
+
+
+def test_runtime_operations_exposes_the_contract_catalog_as_json(tmp_path):
+    result = CliRunner().invoke(
+        runtime_test_cli,
+        ["--home", str(tmp_path / "home"), "runtime", "operations", "--json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output) == runtime_broker.operation_catalog()
+
+
+def test_runtime_plan_projects_storage_only_without_starting_a_process(tmp_path):
+    home = tmp_path / "home"
+    result = CliRunner().invoke(
+        runtime_test_cli,
+        [
+            "--home",
+            str(home),
+            "runtime",
+            "plan",
+            "episode.append",
+            "--request-id",
+            "request-storage",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["operation"]["id"] == "episode.append"
+    assert payload["requirement"]["operationClass"] == "storage-only"
+    assert payload["requirement"]["requiredCapabilities"] == []
+    assert not (home / "runtime" / "supervisor").exists()
+    assert not (home / "runtime" / "coordinator").exists()
+
+
+def test_runtime_plan_exposes_live_requirements_and_exact_cut(tmp_path):
+    home = tmp_path / "home"
+    cut = {
+        "stream_id": "7",
+        "container_epoch": "11",
+        "sequence": "41",
+        "frame_uid": "1041",
+    }
+    result = CliRunner().invoke(
+        runtime_test_cli,
+        [
+            "--home",
+            str(home),
+            "runtime",
+            "plan",
+            "assessment.request",
+            "--minimum-cut",
+            json.dumps(cut),
+            "--request-id",
+            "request-live",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    requirement = payload["requirement"]
+    assert requirement["operationClass"] == "live-required"
+    assert requirement["requiredCapabilities"] == ["runtime.assessment-scheduling"]
+    assert requirement["minimumCut"] == cut
+    assert not (home / "runtime" / "supervisor").exists()
+    assert not (home / "runtime" / "coordinator").exists()

--- a/framework/core/tests/python/test_runtime_service.py
+++ b/framework/core/tests/python/test_runtime_service.py
@@ -128,6 +128,15 @@ def test_coordinator_status_reports_runtime_state(tmp_path):
     assert payload["route"]["registered"] is False
     assert payload["lifecycle"]["state"] == "stopped"
     assert payload["lifecycle"]["healthy"] is False
+    assert payload["product"] == {
+        "schema": "kungfu.runtime.product-status/v1",
+        "workspaceId": runtime_broker.workspace_id(runtime_dir),
+        "availability": "available",
+        "liveState": "inactive",
+        "handle": None,
+        "leases": {"activeCount": 0, "items": []},
+        "error": None,
+    }
 
 
 def test_coordinator_status_detects_live_recorded_pid(tmp_path):
@@ -155,6 +164,8 @@ def test_coordinator_status_detects_live_recorded_pid(tmp_path):
     assert payload["coordinator"]["running"] is True
     assert payload["lifecycle"]["state"] == "running"
     assert payload["lifecycle"]["healthy"] is True
+    assert payload["product"]["liveState"] == "inactive"
+    assert payload["product"]["availability"] == "available"
 
 
 def test_upsert_route_registers_data_root_under_user_supervisor(tmp_path):

--- a/framework/core/tests/runtime-product-status-types.ts
+++ b/framework/core/tests/runtime-product-status-types.ts
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import createKungfuRuntime = require('../lib/kungfu');
+
+declare const status: createKungfuRuntime.RuntimeProductStatus;
+
+if (status.liveState === 'inactive') {
+  status.handle satisfies null;
+  status.error satisfies null;
+} else if (status.liveState === 'failed') {
+  status.error.code satisfies string;
+} else {
+  status.handle.generation satisfies string;
+  status.error satisfies null;
+}

--- a/framework/gui/src/main/atlas-cli.test.ts
+++ b/framework/gui/src/main/atlas-cli.test.ts
@@ -30,6 +30,15 @@ test('renderer runtime status does not poll native ledger health', () => {
   assert.match(source, /\.invoke\(RUNTIME_STATUS_GET_CHANNEL\)/);
 });
 
+test('GUI startup and quit do not own the process runtime lifecycle', () => {
+  const source = readFileSync(new URL('./index.ts', import.meta.url), 'utf8');
+
+  assert.doesNotMatch(source, /ensureRuntimeForGuiStartup/);
+  assert.doesNotMatch(source, /Stop Runtime and Quit/);
+  assert.doesNotMatch(source, /\['runtime', '(?:ensure|start|stop)'/);
+  assert.match(source, /Advanced Runtime Diagnostics/);
+});
+
 test('Atlas CLI transport rejects non-Atlas commands before process startup', async () => {
   let called = false;
   const result = await executeAtlasCli(

--- a/framework/gui/src/main/index.ts
+++ b/framework/gui/src/main/index.ts
@@ -438,34 +438,6 @@ function readRuntimeStatus(): RuntimeStatusResult {
   }
 }
 
-function ensureRuntimeForGuiStartup() {
-  if (!workspaceRuntimeReady) {
-    console.log('KF_RUNTIME_ENSURE_DEFERRED workspace selected-uninitialized');
-    return;
-  }
-  try {
-    const out = execFileSync(kungfuBinPath(), ['runtime', 'ensure', '--json'], {
-      env: process.env,
-      timeout: 15000,
-    });
-    lastRuntimeStatus = {
-      ok: true,
-      payload: JSON.parse(out.toString()) as RuntimeStatusPayload,
-      error: '',
-      updatedAt: Date.now(),
-    };
-    console.log('KF_RUNTIME_ENSURE_OK');
-  } catch (e) {
-    lastRuntimeStatus = {
-      ok: false,
-      payload: null,
-      error: (e as Error).message,
-      updatedAt: Date.now(),
-    };
-    console.log(`KF_RUNTIME_ENSURE_FAIL ${lastRuntimeStatus.error}`);
-  }
-}
-
 function runtimeStatusLabel(result = lastRuntimeStatus ?? readRuntimeStatus()) {
   return deriveWorkspaceRuntimePresentation(result).label;
 }
@@ -517,22 +489,6 @@ async function showCommandResult(
 function quitGui() {
   appQuitting = true;
   app.quit();
-}
-
-async function stopRuntimeAndQuit() {
-  try {
-    execFileSync(kungfuBinPath(), ['runtime', 'stop', '--json'], {
-      env: process.env,
-      timeout: 10000,
-    });
-    quitGui();
-  } catch (e) {
-    await dialog.showMessageBox({
-      type: 'error',
-      message: 'Could not stop Kungfu Runtime',
-      detail: (e as Error).message,
-    });
-  }
 }
 
 function trayIcon() {
@@ -587,40 +543,18 @@ function buildTrayMenu() {
       },
       { type: 'separator' },
       {
-        label: 'Runtime Status',
+        label: 'Advanced Runtime Diagnostics',
         click: () =>
           void showCommandResult(
             'Could not read Kungfu Runtime status',
             ['runtime', 'status', '--json'],
-            'Kungfu Runtime Status',
-          ),
-      },
-      {
-        label: 'Start Runtime',
-        click: () =>
-          void showCommandResult(
-            'Could not start Kungfu Runtime',
-            ['runtime', 'start', '--json'],
-            'Kungfu Runtime started',
-          ),
-      },
-      {
-        label: 'Stop Runtime',
-        click: () =>
-          void showCommandResult(
-            'Could not stop Kungfu Runtime',
-            ['runtime', 'stop', '--json'],
-            'Kungfu Runtime stopped',
+            'Kungfu Runtime Diagnostics',
           ),
       },
       { type: 'separator' },
       {
         label: 'Quit GUI',
         click: quitGui,
-      },
-      {
-        label: 'Stop Runtime and Quit',
-        click: () => void stopRuntimeAndQuit(),
       },
     ]),
   );
@@ -1055,7 +989,6 @@ function createWindow() {
 
 app.whenReady().then(() => {
   app.setName(PRODUCT_NAME);
-  if (!qualificationMode) ensureRuntimeForGuiStartup();
   // Menus require a real display backend on Linux. The bounded qualification
   // path keeps them disabled together with the already-disabled Tray.
   if (!qualificationMode) buildMenu();

--- a/framework/gui/src/runtime-status.test.ts
+++ b/framework/gui/src/runtime-status.test.ts
@@ -11,6 +11,76 @@ function status(payload: RuntimeStatusResult['payload']): RuntimeStatusResult {
   return { ok: true, payload, error: '', updatedAt: 1 };
 }
 
+test('daemonless product status keeps the durable workspace available', () => {
+  const result = deriveWorkspaceRuntimePresentation(
+    status({
+      product: {
+        schema: 'kungfu.runtime.product-status/v1',
+        workspaceId: 'workspace-test',
+        availability: 'available',
+        liveState: 'inactive',
+        handle: null,
+        leases: { activeCount: 0, items: [] },
+        error: null,
+      },
+      lifecycle: { state: 'stopped', healthy: false },
+      supervisor: { running: false },
+      coordinator: { running: false },
+    }),
+  );
+  assert.equal(result.state, 'available');
+  assert.equal(result.label, 'Workspace available');
+  assert.doesNotMatch(result.detail, /start|coordinator|supervisor/i);
+});
+
+test('shared semantic readiness wins over process diagnostics', () => {
+  const result = deriveWorkspaceRuntimePresentation(
+    status({
+      product: {
+        schema: 'kungfu.runtime.product-status/v1',
+        workspaceId: 'workspace-test',
+        availability: 'available',
+        liveState: 'ready',
+        handle: {
+          schema: 'kungfu.runtime.handle/v1',
+          runtimeId: 'runtime-test',
+          requirementId: 'request-test',
+          workspaceId: 'workspace-test',
+          generation: '1',
+          state: 'ready',
+          capabilities: ['runtime.assessment-scheduling'],
+          grantedAuthorities: ['runtime.capability-use'],
+          readiness: {
+            schema: 'kungfu.runtime.readiness/v1',
+            state: 'ready',
+            durableCut: {
+              stream_id: '1',
+              container_epoch: '1',
+              sequence: '1',
+              frame_uid: '1',
+            },
+            projectionCut: null,
+            evidence: [{ kind: 'durability-receipt', ref: 'receipt:test' }],
+            observedAtNs: '1',
+          },
+          host: {
+            kind: 'process',
+            hostId: 'process-test',
+            diagnostics: {},
+          },
+        },
+        leases: { activeCount: 0, items: [] },
+        error: null,
+      },
+      lifecycle: { state: 'orphan-coordinator', healthy: false },
+      supervisor: { running: false },
+      coordinator: { running: true },
+    }),
+  );
+  assert.equal(result.state, 'ready');
+  assert.equal(result.label, 'Workspace ready');
+});
+
 test('process health alone reports online rather than continuity-ready', () => {
   const result = deriveWorkspaceRuntimePresentation(
     status({

--- a/framework/gui/src/runtime-status.ts
+++ b/framework/gui/src/runtime-status.ts
@@ -4,8 +4,11 @@
 // processes. Raw supervisor/coordinator facts remain available to the advanced
 // Status view, while the tray and status bar consume this foreground model.
 
+import type { RuntimeProductStatus } from '@kungfu-tech/api/capability';
+
 export type WorkspaceRuntimeState =
   | 'checking'
+  | 'available'
   | 'online'
   | 'ready'
   | 'starting'
@@ -38,6 +41,7 @@ export type RuntimeStatusPayload = {
     state?: WorkspaceRuntimeContinuityState;
     reason?: string;
   };
+  product?: RuntimeProductStatus;
   supervisor?: { pid?: number | null; running?: boolean };
   coordinator?: { pid?: number | null; running?: boolean };
   route?: {
@@ -113,6 +117,54 @@ export function deriveWorkspaceRuntimePresentation(
   }
 
   const payload = result.payload;
+  const product = payload.product;
+  if (product) {
+    if (product.error || product.liveState === 'failed') {
+      return presentation(
+        'needs-attention',
+        'Live capabilities need attention',
+        product.error?.message || 'Automatic live activation needs attention.',
+        '!',
+        'error',
+      );
+    }
+    if (product.liveState === 'inactive' || product.liveState === 'stopped') {
+      return presentation(
+        'available',
+        'Workspace available',
+        'Durable work is available; live capabilities activate when required.',
+        '●',
+        'ok',
+      );
+    }
+    if (product.liveState === 'ready') {
+      return presentation(
+        'ready',
+        'Workspace ready',
+        'Required live capabilities are ready at the reported durable cut.',
+        '●',
+        'ok',
+      );
+    }
+    if (product.liveState === 'draining') {
+      return presentation(
+        'available',
+        'Workspace available',
+        'Durable work remains available while unused live capabilities stop.',
+        '●',
+        'ok',
+      );
+    }
+    return presentation(
+      product.liveState === 'starting' ? 'starting' : 'recovering',
+      product.liveState === 'starting'
+        ? 'Live capabilities starting'
+        : 'Live capabilities recovering',
+      'Automatic activation is establishing the required durable cut.',
+      '◐',
+      'warning',
+    );
+  }
   const lifecycle = payload.lifecycle?.state || payload.status || '';
   const warnings = payload.lifecycle?.warnings?.filter(Boolean) ?? [];
   const warningDetail = warnings.length ? ` ${warnings.join(', ')}.` : '';

--- a/framework/kfx/src/index.ts
+++ b/framework/kfx/src/index.ts
@@ -17,6 +17,7 @@ import type {
   Ledger,
   Profile,
   Rewind,
+  RuntimeProductStatus,
   Storage,
   Terminal,
   Work,
@@ -55,6 +56,13 @@ export type {
   QueryChangelogPage,
   QueryChangelogState,
   QueryDefinition,
+  RuntimeError,
+  RuntimeHandle,
+  RuntimeLease,
+  RuntimeOperation,
+  RuntimeOperationCatalog,
+  RuntimeProductStatus,
+  RuntimeReadiness,
   QueryFrontier,
   GenericQueryViewSpec,
   QueryResumeToken,
@@ -1113,9 +1121,11 @@ export type ShellRuntimeInfo = {
   message: string;
   runtimeDir: string;
   kungfuVersion: string;
-  masterStatus: {
+  runtimeStatus: {
     ok: boolean;
-    payload: Record<string, unknown> | null;
+    payload:
+      | ({ product?: RuntimeProductStatus } & Record<string, unknown>)
+      | null;
     error: string;
     updatedAt: number;
   } | null;

--- a/framework/runtime/kungfu-runtime.contract.json
+++ b/framework/runtime/kungfu-runtime.contract.json
@@ -490,6 +490,10 @@
     "operation_cancelled"
   ],
   "compatibility": {
+    "productStatus": {
+      "statusSchema": "kungfu.runtime.product-status/v1",
+      "rule": "One topology-neutral workspace projection for CLI, GUI, Python, Node, libkungfu-facing, and KFX surfaces; process health cannot establish it."
+    },
     "processDiagnostics": {
       "statusSchema": "kungfu.runtime.status/v2",
       "routesSchema": "kungfu.runtime.routes/v2",
@@ -549,6 +553,9 @@
       },
       {
         "$ref": "#/$defs/runtimeSnapshot"
+      },
+      {
+        "$ref": "#/$defs/runtimeProductStatus"
       }
     ],
     "$defs": {
@@ -1188,6 +1195,147 @@
             }
           }
         }
+      },
+      "runtimeProductStatus": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "schema",
+          "workspaceId",
+          "availability",
+          "liveState",
+          "handle",
+          "leases",
+          "error"
+        ],
+        "properties": {
+          "schema": {
+            "const": "kungfu.runtime.product-status/v1"
+          },
+          "workspaceId": {
+            "type": "string",
+            "minLength": 1
+          },
+          "availability": {
+            "const": "available"
+          },
+          "liveState": {
+            "type": "string",
+            "enum": [
+              "inactive",
+              "starting",
+              "recovering",
+              "ready",
+              "draining",
+              "failed",
+              "restarting",
+              "stopped"
+            ]
+          },
+          "handle": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/$defs/runtimeHandle"
+              }
+            ]
+          },
+          "leases": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "activeCount",
+              "items"
+            ],
+            "properties": {
+              "activeCount": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "items": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/$defs/runtimeLease"
+                }
+              }
+            }
+          },
+          "error": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/$defs/runtimeError"
+              }
+            ]
+          }
+        },
+        "allOf": [
+          {
+            "if": {
+              "properties": {
+                "liveState": {
+                  "const": "inactive"
+                }
+              }
+            },
+            "then": {
+              "properties": {
+                "handle": {
+                  "type": "null"
+                },
+                "error": {
+                  "type": "null"
+                }
+              }
+            }
+          },
+          {
+            "if": {
+              "properties": {
+                "liveState": {
+                  "const": "failed"
+                }
+              }
+            },
+            "then": {
+              "properties": {
+                "error": {
+                  "$ref": "#/$defs/runtimeError"
+                }
+              }
+            }
+          },
+          {
+            "if": {
+              "properties": {
+                "liveState": {
+                  "enum": [
+                    "starting",
+                    "recovering",
+                    "ready",
+                    "draining",
+                    "restarting",
+                    "stopped"
+                  ]
+                }
+              }
+            },
+            "then": {
+              "properties": {
+                "handle": {
+                  "$ref": "#/$defs/runtimeHandle"
+                },
+                "error": {
+                  "type": "null"
+                }
+              }
+            }
+          }
+        ]
       }
     }
   }

--- a/framework/tui/src/main.tsx
+++ b/framework/tui/src/main.tsx
@@ -164,7 +164,7 @@ function App({
         <Text bold>Kungfu v4 reference TUI</Text>
         <Text color="green">● in-process binding · {exportCount} exports</Text>
         <Text color={live ? 'green' : 'gray'}>
-          {live ? '● live (coordinator connected)' : '○ offline'}
+          {live ? '● live updates connected' : '● durable workspace available'}
         </Text>
       </Box>
       <Text dimColor>
@@ -182,8 +182,8 @@ function App({
         </Text>
         {tail.length === 0 ? (
           <Text dimColor>
-            no journal frames yet — start the runtime coordinator against this
-            runtime home
+            no durable frames yet — live capabilities activate when an operation
+            requires them
           </Text>
         ) : null}
         {tail.map((record, index) => (

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "test:projection-bootstrap": "node scripts/require-shifu.mjs test:projection-bootstrap && node scripts/run-projection-bootstrap-tests.mjs",
     "test:crash-recovery": "node scripts/require-shifu.mjs test:crash-recovery && node scripts/run-crash-recovery-tests.mjs",
     "test:runtime-errors": "node scripts/require-shifu.mjs test:runtime-errors && node scripts/run-runtime-error-tests.mjs",
+    "test:runtime-surface": "node scripts/require-shifu.mjs test:runtime-surface && node scripts/check-runtime-surface-integration.mjs",
     "qualify:mmap": "node scripts/require-shifu.mjs qualify:mmap && node scripts/run-mmap-qualification.mjs",
     "qualify:cpp-modules": "node scripts/require-shifu.mjs qualify:cpp-modules && node scripts/run-cpp-modules-qualification.mjs",
     "qualify:embedding-membranes": "node scripts/require-shifu.mjs qualify:embedding-membranes && node scripts/qualify-embedding-membranes.mjs",

--- a/scripts/check-runtime-surface-integration.mjs
+++ b/scripts/check-runtime-surface-integration.mjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: Apache-2.0
+
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import ts from 'typescript';
+
+const root = process.cwd();
+const readJson = (relative) =>
+  JSON.parse(fs.readFileSync(path.join(root, relative), 'utf8'));
+const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8');
+const fixture = readJson(
+  'tests/fixtures/runtime-surface-integration/cases.json',
+);
+const contract = readJson('framework/runtime/kungfu-runtime.contract.json');
+const definitions = contract.valueSchemaBundle.$defs;
+
+const typeProgram = ts.createProgram(
+  [path.join(root, 'framework/core/tests/runtime-product-status-types.ts')],
+  {
+    module: ts.ModuleKind.Node16,
+    moduleResolution: ts.ModuleResolutionKind.Node16,
+    noEmit: true,
+    skipLibCheck: false,
+    strict: true,
+    target: ts.ScriptTarget.ES2022,
+  },
+);
+const typeDiagnostics = ts.getPreEmitDiagnostics(typeProgram);
+assert.equal(
+  typeDiagnostics.length,
+  0,
+  ts.formatDiagnosticsWithColorAndContext(typeDiagnostics, {
+    getCanonicalFileName: (fileName) => fileName,
+    getCurrentDirectory: () => root,
+    getNewLine: () => '\n',
+  }),
+);
+
+assert.equal(
+  definitions.runtimeProductStatus.properties.schema.const,
+  fixture.productStatusSchema,
+);
+
+for (const relative of Object.values(fixture.surfaces)) {
+  assert.ok(
+    fs.existsSync(path.join(root, relative)),
+    `missing surface: ${relative}`,
+  );
+}
+
+for (const relative of [
+  fixture.surfaces.python,
+  fixture.surfaces.cli,
+  fixture.surfaces.node,
+  fixture.surfaces.libkungfuTypes,
+  fixture.surfaces.gui,
+  fixture.surfaces.kfx,
+]) {
+  assert.match(
+    read(relative),
+    /kungfu\.runtime\.product-status\/v1|RuntimeProductStatus|product_status|payload\.get\("product"\)/,
+    `surface does not expose the shared product status: ${relative}`,
+  );
+}
+
+const guiMain = read('framework/gui/src/main/index.ts');
+for (const command of fixture.ordinaryLifecycleCommands) {
+  assert.doesNotMatch(
+    guiMain,
+    new RegExp(`\\['runtime', '${command}'`),
+    `GUI privately owns runtime ${command}`,
+  );
+}
+assert.match(guiMain, /Advanced Runtime Diagnostics/);
+
+const ordinaryCopies = [read(fixture.surfaces.gui), read(fixture.surfaces.tui)];
+for (const message of fixture.forbiddenOrdinaryMessages) {
+  for (const source of ordinaryCopies) {
+    assert.equal(
+      source.toLowerCase().includes(message.toLowerCase()),
+      false,
+      `ordinary surface exposes process-management copy: ${message}`,
+    );
+  }
+}
+
+const operations = new Set(
+  contract.operationRegistry.operations.map((operation) => operation.id),
+);
+const actionRegistry = readJson(
+  'extensions/mission-control/actions/registry.json',
+);
+for (const action of actionRegistry.actions) {
+  if (action.runtimeOperation) {
+    assert.ok(
+      operations.has(action.runtimeOperation),
+      `unregistered KFX runtime operation: ${action.runtimeOperation}`,
+    );
+  }
+}
+
+console.log(
+  `runtime surface parity passed: ${Object.keys(fixture.surfaces).length} surfaces, ${actionRegistry.actions.length} KFX actions`,
+);

--- a/tests/fixtures/runtime-surface-integration/cases.json
+++ b/tests/fixtures/runtime-surface-integration/cases.json
@@ -1,0 +1,23 @@
+{
+  "schema": "kungfu.runtime.surface-parity-fixture/v1",
+  "productStatusSchema": "kungfu.runtime.product-status/v1",
+  "surfaces": {
+    "python": "framework/core/src/python/kungfu/runtime_broker.py",
+    "cli": "framework/core/src/python/kungfu/cli/commands/runtime.py",
+    "node": "framework/api/src/capability/runtime.ts",
+    "libkungfuTypes": "framework/core/lib/kungfu.d.ts",
+    "gui": "framework/gui/src/runtime-status.ts",
+    "kfx": "framework/kfx/src/index.ts",
+    "tui": "framework/tui/src/main.tsx"
+  },
+  "ordinaryLifecycleCommands": [
+    "ensure",
+    "start",
+    "stop"
+  ],
+  "forbiddenOrdinaryMessages": [
+    "start the runtime coordinator",
+    "coordinator connected",
+    "○ offline"
+  ]
+}


### PR DESCRIPTION
## Summary

- add one contract-validated product runtime status that treats a daemonless workspace as available and preserves fenced generation, exact cuts, semantic leases, and typed failures
- expose topology-neutral operation catalogs and read-only plans through CLI, and share the same runtime vocabulary through API, KFX, and libkungfu TypeScript declarations
- make GUI and TUI product copy capability-driven: GUI startup, tray, ordinary quit no longer own resident runtime process lifecycle, while process facts remain advanced diagnostics
- add parity/type/CLI/Python/GUI tests and regenerate KFD contract evidence
- keep stage 6 open: live-required product action invocation and discovery of exact-cut native readiness evidence are not yet wired

## Verification

- `PYTHONPATH=framework/core/build/Release:framework/core/src/python KUNGFU_ALLOW_FOREIGN_RUNTIME=1 ./shifu --filter @kungfu-tech/core exec uv run --frozen python -m pytest tests/python/test_runtime_broker.py tests/python/test_runtime_service.py tests/python/test_runtime_cli.py -q` (50 passed)
- `./shifu test:runtime-surface` (7 surfaces and 4 KFX actions aligned; libkungfu declaration compile proof passed)
- API TypeScript build, KFX build, and GUI tests (14 passed)
- `./shifu --filter @kungfu-tech/core exec uv run --frozen --project framework/core --directory . node scripts/source-acceptance.mjs` (143 source contract tests; 61 documentation contract tests; 221 Markdown files; 220 link/contract checks; Biome; Ruff; mypy across 134 source files; passed)
- `./shifu kfd:buildchain` (KFD-1 witness, 3 KFD-2 claims, 113 KFD-3 surfaces)
- staged pre-commit gate passed

## Governance risk

No credentials, hosted services, deployment, production release, cross-machine leasing, distributed election, high availability, or production EmbeddedRuntimeHost are changed or claimed. Process health cannot establish product readiness. This delivery intentionally does not permit a live-required callback to bypass the broker: product action invocation remains open until exact-cut native evidence can be discovered and supplied fail closed.

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "stage-ready",
  "adrs": ["ADR-0080"],
  "summary": "Land the stage 6 projection slice: one daemonless-safe product runtime status, topology-neutral CLI planning, shared API and libkungfu vocabulary, and GUI/TUI process-ownership removal, while leaving exact-cut product action invocation and evidence discovery open.",
  "verification": ["runtime broker, service, and CLI pytest: 50 passed", "runtime surface parity: 7 surfaces and 4 KFX actions", "build-free source gate: 143 tests plus 61 documentation contracts, Biome, Ruff, mypy, and KFD checks", "staged pre-commit gate"]
}
-->
