### PR TITLE
fix(docs): bind ADR-0081 to merged contract commit

### DIFF
--- a/docs/adr/ADR-0081-durable-agent-session-capsule-control-plane.md
+++ b/docs/adr/ADR-0081-durable-agent-session-capsule-control-plane.md
@@ -4,7 +4,7 @@ doc_type: architecture-decision
 adr_id: ADR-0081
 decision_status: accepted
 implementation_status: partial
-implementation_commits: [eed8a90cb760593025afe457f98db79289cd506b]
+implementation_commits: [90e878b696a6a6a6a1a9d21f166f0e63bc527bb2]
 qualification_refs: [scripts/check-agent-session-contract.test.mjs, tests/fixtures/agent-session-capsule-contract]
 review_state: self-reviewed
 sensitivity: public


### PR DESCRIPTION
## Summary

Repair ADR-0081 implementation evidence after PR #828 was integrated with the repository-required rebase merge. The contract implementation is now commit 90e878b696a6a6a6a1a9d21f166f0e63bc527bb2 on dev/v4/v4.0; the original feature SHA is no longer the canonical merged coordinate.

This clean linear replacement supersedes PR #829, whose old feature branch contains merge commits and therefore cannot pass the repository rebase-only merge policy.

## Changes

- replace the pre-merge feature SHA with the merged, dev-reachable contract implementation SHA
- preserve ADR-0081 partial status and its existing qualification references

## Verification

- ./shifu check:source
- pre-commit documentation and ADR audit

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "stage-ready",
  "adrs": ["ADR-0081"],
  "summary": "Bind ADR-0081 implementation evidence to the canonical rebased contract commit already merged on dev/v4/v4.0",
  "verification": ["build-free source acceptance", "documentation and ADR audit"]
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

This PR changes one public ADR evidence pointer to an already merged commit. It does not change runtime behavior, provider integration, publishing, or deployment.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed
