### PR TITLE
feat(runtime): route profile actions through readiness broker

### DIFF
--- a/docs/adr/ADR-0080-topology-neutral-capability-driven-runtime-activation.md
+++ b/docs/adr/ADR-0080-topology-neutral-capability-driven-runtime-activation.md
@@ -4,7 +4,7 @@ doc_type: architecture-decision
 adr_id: ADR-0080
 decision_status: accepted
 implementation_status: partial
-implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/815, https://github.com/kungfu-systems/kungfu/pull/818, https://github.com/kungfu-systems/kungfu/pull/819, https://github.com/kungfu-systems/kungfu/pull/822, https://github.com/kungfu-systems/kungfu/pull/823, https://github.com/kungfu-systems/kungfu/pull/825]
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/815, https://github.com/kungfu-systems/kungfu/pull/818, https://github.com/kungfu-systems/kungfu/pull/819, https://github.com/kungfu-systems/kungfu/pull/822, https://github.com/kungfu-systems/kungfu/pull/823, https://github.com/kungfu-systems/kungfu/pull/825, https://github.com/kungfu-systems/kungfu/pull/831]
 review_state: self-reviewed
 sensitivity: public
 sources: [local-files, user-decision]

--- a/docs/adr/ADR-0080-topology-neutral-capability-driven-runtime-activation.md
+++ b/docs/adr/ADR-0080-topology-neutral-capability-driven-runtime-activation.md
@@ -287,14 +287,17 @@ products copy the exact contract through the existing KFD-1 contract registry.
 4. Bind recovery and projection readiness to an exact durable cut. **Core seam complete:** one per-workspace activation owner serializes first calls, persists the accepted generation, fences replaced process diagnostics, and admits native durability/projection evidence only at or beyond the requested cut. The process adapter remains fail closed when no `DurableEngine` readiness authority is supplied; product evidence discovery is stage 6 work.
 5. Add leases, idle draining, adoption, and restart recovery. **Core lifecycle complete:** generation-fenced semantic leases persist under the activation owner, idle draining atomically fences new demand before stopping a route, a replacement supervisor may adopt only the exact recorded coordinator generation, untracked orphans fail closed, and coordinator crash restarts stop at a bounded attempt window. Route heartbeat TTL remains diagnostic rather than a semantic lease. Cross-machine leasing and product lease acquisition remain outside this stage.
 6. Project the same contract through CLI, GUI, Python, Node, libkungfu, and KFX.
-   **Projection slice complete:** one canonical product-status value now keeps
+   **Complete:** one canonical product-status value now keeps
    daemonless workspaces available, preserves exact generation/cut/lease/error
    semantics, and remains separate from advanced process diagnostics. CLI
    exposes machine-readable operation planning, GUI startup/quit no longer owns
    runtime processes, and Node/KFX/libkungfu-facing declarations share the same
-   vocabulary. Product action invocation still requires exact-cut evidence
-   discovery and therefore remains open rather than silently bypassing
-   readiness.
+   vocabulary. Profile/KFX action plans now embed the canonical runtime
+   invocation plan. Storage-only callbacks remain daemonless; live-required
+   planning discovers workspace-bound native evidence coordinates and invocation
+   admits the callback only through the capability broker after exact-cut native
+   readiness. Missing, malformed, foreign, changed, or insufficient evidence
+   fails closed.
 7. Qualify daemonless/no-fork behavior, process crash recovery, product
    artifacts, and supported claims.
 

--- a/docs/architecture/runtime-service.md
+++ b/docs/architecture/runtime-service.md
@@ -114,7 +114,13 @@ contract. A cut behind the requirement, a foreign projection authority, or a
 missing hydrated projection fails before callback admission. PID and health
 diagnostics remain insufficient: without an explicitly supplied DurableEngine
 readiness authority the process adapter returns `readiness_not_established`.
-Product evidence discovery and entrypoint wiring remain stage 6 work.
+Profile/KFX product actions now discover a workspace-bound
+`kungfu.runtime.native-readiness-evidence/v1` descriptor under
+`KF_CONFIG_HOME/runtime/readiness/`. The descriptor is only a set of exact
+coordinates: workspace and data roots, minimum cut, durability request, profile,
+writer identity, and optional projection identity. It is not readiness proof.
+`NativeReadinessAuthority` still calls the existing typed authorities and the
+broker still rejects any evidence that does not establish the requested cut.
 
 The first stage 6 projection slice adds one
 `kungfu.runtime.product-status/v1` value beside the retained process
@@ -131,12 +137,15 @@ the libkungfu-facing TypeScript declaration surface share the exact status,
 handle, readiness, lease, error, and operation vocabulary. These projections
 do not create another lifecycle implementation or external executor ABI.
 
-This slice does not weaken the live admission boundary. A first live-required
-product action still needs an exact minimum cut and an explicitly configured
-`NativeReadinessAuthority`; a process that merely started cannot satisfy it.
-Binding product action invocation to discovered evidence remains required
-before stage 6 can close and before product qualification may claim cold live
-activation.
+Profile/KFX action planning binds the declared `runtimeOperation` to that same
+runtime invocation plan. Storage-only action invocation returns a daemonless
+activation receipt and runs no host factory. Live-required planning fails when
+the descriptor is absent or invalid; invocation refreshes the descriptor and
+the complete action plan, constructs the existing `NativeReadinessAuthority`,
+and runs the domain callback only when the broker returns an admitted receipt.
+A process that merely started cannot satisfy this boundary. Stage 7 must still
+qualify the producer of these coordinates and cold product activation before a
+release may claim that behavior.
 
 ## Semantic Leases and Recovery
 

--- a/extensions/mission-control/profile.json
+++ b/extensions/mission-control/profile.json
@@ -57,7 +57,7 @@
   "actions": {
     "registry": {
       "path": "actions/registry.json",
-      "sha256": "c39874b40d2e2ebcfaa41168b52c6b3cf6537dbf210ffb867d5b5e8281c742c6"
+      "sha256": "9fd5ceda97c8efc71196942cb00132205f9020ba0029981cf1cb0ee29717e0ce"
     }
   },
   "views": {

--- a/framework/core/src/python/kungfu/profile_sdk.py
+++ b/framework/core/src/python/kungfu/profile_sdk.py
@@ -1828,6 +1828,55 @@ def action_catalog(source: str | Path, runtime_dir: str | Path) -> dict[str, Any
     }
 
 
+def _action_runtime_plan(
+    runtime_dir: str | Path, action: Mapping[str, Any]
+) -> tuple[dict[str, Any], dict[str, Any] | None]:
+    operation_id = str(action.get("runtimeOperation") or "")
+    try:
+        operation = runtime_broker.operation_definition(operation_id)
+    except (KeyError, ValueError) as error:
+        raise ProfileSdkError(
+            "action-runtime-operation-invalid", str(error), operationId=operation_id
+        ) from error
+    evidence = None
+    minimum_cut = None
+    if operation["operationClass"] != "storage-only":
+        evidence_path = runtime_broker.native_readiness_evidence_path(runtime_dir)
+        try:
+            evidence = runtime_broker.discover_native_readiness_evidence(runtime_dir)
+        except ValueError as error:
+            raise ProfileSdkError(
+                "runtime-evidence-invalid",
+                str(error),
+                evidencePath=str(evidence_path),
+            ) from error
+        if evidence is None:
+            raise ProfileSdkError(
+                "runtime-evidence-unavailable",
+                "live Profile action requires native durability evidence coordinates",
+                evidencePath=str(evidence_path),
+                operationId=operation_id,
+            )
+        minimum_cut = evidence["minimumCut"]
+        if (
+            "runtime.live-projection" in operation["requiredCapabilities"]
+            and evidence.get("projection") is None
+        ):
+            raise ProfileSdkError(
+                "runtime-evidence-incomplete",
+                "live projection action requires projection evidence coordinates",
+                evidencePath=str(evidence_path),
+                operationId=operation_id,
+            )
+    runtime_plan = runtime_broker.plan_operation(
+        operation_id,
+        workspace=runtime_broker.workspace_id(runtime_dir),
+        request_source="kfx",
+        minimum_cut=minimum_cut,
+    )
+    return runtime_plan, evidence
+
+
 def plan_action(
     source: str | Path, runtime_dir: str | Path, action_id: str, input_value: Any
 ) -> dict[str, Any]:
@@ -1885,11 +1934,22 @@ def plan_action(
             "Action requires Profile capabilities that are not active",
             missingCapabilities=missing_capabilities,
         )
+    runtime_plan, runtime_evidence = _action_runtime_plan(runtime_dir, action)
+    identity["runtimeOperation"] = runtime_plan["operation"]["id"]
+    if runtime_evidence is not None:
+        identity.update(
+            {
+                "runtimePlan": runtime_plan,
+                "runtimeEvidence": runtime_evidence,
+            }
+        )
     plan = {
         "schema": ACTION_PLAN_SCHEMA,
         "planId": _root(identity),
         **identity,
         "source": catalog["source"],
+        "runtimePlan": runtime_plan,
+        "runtimeEvidence": runtime_evidence,
         "requiresAuthorization": action["authorityClass"] != "none",
         "effects": action.get("effects", []),
     }
@@ -1906,6 +1966,136 @@ def plan_action(
             resume_command="answer this card, then invoke with the exact action plan and decision answer",
         )
     return plan
+
+
+def _invoke_mission_control_action(
+    runtime_dir: str | Path, plan: Mapping[str, Any]
+) -> dict[str, Any]:
+    action = plan.get("action") or {}
+    if plan.get("profileId") != "kungfu.mission-control" or action.get(
+        "operation"
+    ) not in {"mission-control-actions", "mission-control-assessment"}:
+        raise ProfileSdkError(
+            "action-runner-unsupported",
+            "no confined runtime adapter is installed for this KFX member action",
+        )
+    values = plan.get("input")
+    if not isinstance(values, Mapping):
+        raise ProfileSdkError(
+            "action-input-invalid", "Mission Control action input must be an object"
+        )
+    from kungfu.atlas import mission_control
+
+    action_id = str(action.get("id") or "")
+    try:
+        if action_id == "create-mission":
+            allowed = {
+                "missionId",
+                "title",
+                "intent",
+                "actor",
+                "actorType",
+                "status",
+                "horizon",
+            }
+            unknown = set(values) - allowed
+            if unknown:
+                raise ValueError(f"unknown create-mission input: {sorted(unknown)}")
+            core_receipt = mission_control.create_mission(
+                str(runtime_dir),
+                mission_id=str(values.get("missionId") or ""),
+                title=str(values.get("title") or ""),
+                intent=str(values.get("intent") or ""),
+                actor=str(values.get("actor") or ""),
+                actor_type=str(values.get("actorType") or "agent"),
+                status=str(values.get("status") or "active"),
+                horizon=str(values.get("horizon") or "long-term"),
+            )
+            affected = [core_receipt["mission_subject"]]
+        elif action_id == "create-go":
+            allowed = {
+                "missionId",
+                "goalId",
+                "title",
+                "objective",
+                "actor",
+                "actorType",
+                "source",
+                "status",
+            }
+            unknown = set(values) - allowed
+            if unknown:
+                raise ValueError(f"unknown create-go input: {sorted(unknown)}")
+            core_receipt = mission_control.create_go(
+                str(runtime_dir),
+                mission_id=str(values.get("missionId") or ""),
+                goal_id=str(values.get("goalId") or ""),
+                title=str(values.get("title") or ""),
+                objective=str(values.get("objective") or ""),
+                actor=str(values.get("actor") or ""),
+                actor_type=str(values.get("actorType") or "agent"),
+                storage_source_id=str(values.get("source") or "atlas"),
+                status=str(values.get("status") or "active"),
+            )
+            affected = [core_receipt["mission_subject"], core_receipt["go_subject"]]
+        elif action_id == "claim-completion":
+            allowed = {
+                "missionId",
+                "goalId",
+                "statement",
+                "actor",
+                "actorType",
+                "source",
+                "evidenceEpisodeIds",
+            }
+            unknown = set(values) - allowed
+            if unknown:
+                raise ValueError(f"unknown claim-completion input: {sorted(unknown)}")
+            core_receipt = mission_control.claim_completion(
+                str(runtime_dir),
+                mission_id=str(values.get("missionId") or ""),
+                goal_id=str(values.get("goalId") or ""),
+                statement=str(values.get("statement") or ""),
+                actor=str(values.get("actor") or ""),
+                actor_type=str(values.get("actorType") or "agent"),
+                storage_source_id=str(values.get("source") or "atlas"),
+                evidence_episode_ids=[
+                    int(row) for row in values.get("evidenceEpisodeIds", [])
+                ],
+            )
+            affected = [
+                core_receipt["mission_subject"],
+                core_receipt["go_subject"],
+                core_receipt["claim"]["claim_id"],
+            ]
+        elif action_id == "assess-progress":
+            allowed = {"missionId", "source", "purpose", "authorizedBy"}
+            unknown = set(values) - allowed
+            if unknown:
+                raise ValueError(f"unknown assess-progress input: {sorted(unknown)}")
+            core_receipt = mission_control.assess_progress(
+                str(runtime_dir),
+                mission_id=str(values.get("missionId") or ""),
+                storage_source_id=str(values.get("source") or "atlas"),
+                purpose=str(values.get("purpose") or "operator-review"),
+                authorized_by=str(values.get("authorizedBy") or "kungfu-profile"),
+            )
+            affected = [core_receipt["state"]["mission_subject"]]
+        else:
+            raise ProfileSdkError(
+                "action-operation-unsupported",
+                f"unsupported Mission Control action: {action_id}",
+            )
+    except (RuntimeError, ValueError) as exc:
+        raise ProfileSdkError("action-execution-failed", str(exc)) from exc
+    return {
+        "coreReceipt": core_receipt,
+        "affected": {
+            "profileId": plan["profileId"],
+            "entityKeys": affected,
+            "queryKeys": ["mission-state", "mission-timeline", "mission-attention"],
+        },
+    }
 
 
 def invoke_action(
@@ -1925,6 +2115,12 @@ def invoke_action(
         raise ProfileSdkError(
             "action-plan-stale", "Profile source or active state changed after planning"
         )
+    if refreshed.get("runtimePlan") != plan.get("runtimePlan") or refreshed.get(
+        "runtimeEvidence"
+    ) != plan.get("runtimeEvidence"):
+        raise ProfileSdkError(
+            "action-plan-stale", "runtime execution material changed after planning"
+        )
     action = plan.get("action") or {}
     if plan.get("requiresAuthorization") and not authorization_id:
         raise ProfileSdkError(
@@ -1940,172 +2136,80 @@ def invoke_action(
             "action-plan-stale", "active Profile state changed after action planning"
         )
     if action.get("runner") == "kfx-member":
-        if plan.get("profileId") != "kungfu.mission-control" or action.get(
-            "operation"
-        ) not in {"mission-control-actions", "mission-control-assessment"}:
-            raise ProfileSdkError(
-                "action-runner-unsupported",
-                "no confined runtime adapter is installed for this KFX member action",
-            )
-        values = plan.get("input")
-        if not isinstance(values, Mapping):
-            raise ProfileSdkError(
-                "action-input-invalid", "Mission Control action input must be an object"
-            )
-        from kungfu.atlas import mission_control
 
-        action_id = str(action.get("id") or "")
+        def invoke_kfx(_activation: Mapping[str, Any]) -> dict[str, Any]:
+            return _invoke_mission_control_action(runtime_dir, plan)
+
+        callback = invoke_kfx
+    elif action.get("runner") == "profile-lifecycle":
+        lifecycle_action = action.get("operation")
+        if lifecycle_action not in {"qualify", "activate", "remove"}:
+            raise ProfileSdkError(
+                "action-operation-unsupported",
+                "unsupported lifecycle action operation",
+            )
+        source_value = plan.get("source")
+        lifecycle_source = str(source_value) if source_value is not None else None
+        lifecycle_values: dict[str, Any] = {}
+        if lifecycle_action == "remove":
+            lifecycle_values["profile_id"] = plan["profileId"]
+            lifecycle_source = None
+        core = lifecycle_plan(
+            runtime_dir, lifecycle_action, lifecycle_source, **lifecycle_values
+        )["corePlan"]
+
+        def invoke_lifecycle(_activation: Mapping[str, Any]) -> dict[str, Any]:
+            return {
+                "coreReceipt": lifecycle_apply(
+                    runtime_dir, core, authorization_id or "action-policy:none"
+                )
+            }
+
+        callback = invoke_lifecycle
+    else:
+        raise ProfileSdkError(
+            "action-runner-unsupported", "unsupported Profile action runner"
+        )
+
+    evidence = plan.get("runtimeEvidence")
+    readiness_authority = None
+    runtime_home = str(Path(runtime_dir).expanduser().resolve().parent)
+    if isinstance(evidence, Mapping):
         try:
-            if action_id == "create-mission":
-                allowed = {
-                    "missionId",
-                    "title",
-                    "intent",
-                    "actor",
-                    "actorType",
-                    "status",
-                    "horizon",
-                }
-                unknown = set(values) - allowed
-                if unknown:
-                    raise ValueError(f"unknown create-mission input: {sorted(unknown)}")
-                core_receipt = mission_control.create_mission(
-                    str(runtime_dir),
-                    mission_id=str(values.get("missionId") or ""),
-                    title=str(values.get("title") or ""),
-                    intent=str(values.get("intent") or ""),
-                    actor=str(values.get("actor") or ""),
-                    actor_type=str(values.get("actorType") or "agent"),
-                    status=str(values.get("status") or "active"),
-                    horizon=str(values.get("horizon") or "long-term"),
-                )
-                affected = [core_receipt["mission_subject"]]
-            elif action_id == "create-go":
-                allowed = {
-                    "missionId",
-                    "goalId",
-                    "title",
-                    "objective",
-                    "actor",
-                    "actorType",
-                    "source",
-                    "status",
-                }
-                unknown = set(values) - allowed
-                if unknown:
-                    raise ValueError(f"unknown create-go input: {sorted(unknown)}")
-                core_receipt = mission_control.create_go(
-                    str(runtime_dir),
-                    mission_id=str(values.get("missionId") or ""),
-                    goal_id=str(values.get("goalId") or ""),
-                    title=str(values.get("title") or ""),
-                    objective=str(values.get("objective") or ""),
-                    actor=str(values.get("actor") or ""),
-                    actor_type=str(values.get("actorType") or "agent"),
-                    storage_source_id=str(values.get("source") or "atlas"),
-                    status=str(values.get("status") or "active"),
-                )
-                affected = [
-                    core_receipt["mission_subject"],
-                    core_receipt["go_subject"],
-                ]
-            elif action_id == "claim-completion":
-                allowed = {
-                    "missionId",
-                    "goalId",
-                    "statement",
-                    "actor",
-                    "actorType",
-                    "source",
-                    "evidenceEpisodeIds",
-                }
-                unknown = set(values) - allowed
-                if unknown:
-                    raise ValueError(
-                        f"unknown claim-completion input: {sorted(unknown)}"
-                    )
-                core_receipt = mission_control.claim_completion(
-                    str(runtime_dir),
-                    mission_id=str(values.get("missionId") or ""),
-                    goal_id=str(values.get("goalId") or ""),
-                    statement=str(values.get("statement") or ""),
-                    actor=str(values.get("actor") or ""),
-                    actor_type=str(values.get("actorType") or "agent"),
-                    storage_source_id=str(values.get("source") or "atlas"),
-                    evidence_episode_ids=[
-                        int(row) for row in values.get("evidenceEpisodeIds", [])
-                    ],
-                )
-                affected = [
-                    core_receipt["mission_subject"],
-                    core_receipt["go_subject"],
-                    core_receipt["claim"]["claim_id"],
-                ]
-            elif action_id == "assess-progress":
-                allowed = {
-                    "missionId",
-                    "source",
-                    "purpose",
-                    "authorizedBy",
-                }
-                unknown = set(values) - allowed
-                if unknown:
-                    raise ValueError(
-                        f"unknown assess-progress input: {sorted(unknown)}"
-                    )
-                core_receipt = mission_control.assess_progress(
-                    str(runtime_dir),
-                    mission_id=str(values.get("missionId") or ""),
-                    storage_source_id=str(values.get("source") or "atlas"),
-                    purpose=str(values.get("purpose") or "operator-review"),
-                    authorized_by=str(values.get("authorizedBy") or "kungfu-profile"),
-                )
-                affected = [core_receipt["state"]["mission_subject"]]
-            else:
-                raise ProfileSdkError(
-                    "action-operation-unsupported",
-                    f"unsupported Mission Control action: {action_id}",
-                )
-        except (RuntimeError, ValueError) as exc:
-            raise ProfileSdkError("action-execution-failed", str(exc)) from exc
+            readiness_authority = runtime_broker.native_readiness_authority(evidence)
+        except (TypeError, ValueError) as error:
+            raise ProfileSdkError("runtime-evidence-invalid", str(error)) from error
+        runtime_home = str(evidence["runtimeHome"])
+    broker = runtime_broker.RuntimeCapabilityBroker.for_process(
+        runtime_home,
+        str(runtime_dir),
+        readiness_authority=readiness_authority,
+    )
+    runtime_plan = plan.get("runtimePlan")
+    if not isinstance(runtime_plan, Mapping):
+        raise ProfileSdkError(
+            "action-runtime-plan-invalid", "Profile action has no runtime plan"
+        )
+    try:
+        runtime_receipt = broker.invoke(runtime_plan, callback)
+    except ValueError as error:
+        raise ProfileSdkError("action-runtime-plan-invalid", str(error)) from error
+    result = runtime_receipt.get("result")
+    if not runtime_receipt.get("accepted") or not isinstance(result, Mapping):
         return {
             "schema": ACTION_RECEIPT_SCHEMA,
             "planId": plan["planId"],
             "authorizationId": authorization_id,
-            "coreReceipt": core_receipt,
-            "affected": {
-                "profileId": plan["profileId"],
-                "entityKeys": affected,
-                "queryKeys": ["mission-state", "mission-timeline", "mission-attention"],
-            },
-            "verified": True,
+            "runtimeReceipt": runtime_receipt,
+            "coreReceipt": None,
+            "verified": False,
         }
-    if action.get("runner") != "profile-lifecycle":
-        raise ProfileSdkError(
-            "action-runner-unsupported", "unsupported Profile action runner"
-        )
-    lifecycle_action = action.get("operation")
-    if lifecycle_action not in {"qualify", "activate", "remove"}:
-        raise ProfileSdkError(
-            "action-operation-unsupported", "unsupported lifecycle action operation"
-        )
-    source_value = plan.get("source")
-    lifecycle_source = str(source_value) if source_value is not None else None
-    lifecycle_values: dict[str, Any] = {}
-    if lifecycle_action == "remove":
-        lifecycle_values["profile_id"] = plan["profileId"]
-        lifecycle_source = None
-    core = lifecycle_plan(
-        runtime_dir, lifecycle_action, lifecycle_source, **lifecycle_values
-    )["corePlan"]
-    receipt = lifecycle_apply(
-        runtime_dir, core, authorization_id or "action-policy:none"
-    )
     return {
         "schema": ACTION_RECEIPT_SCHEMA,
         "planId": plan["planId"],
         "authorizationId": authorization_id,
-        "coreReceipt": receipt,
+        "runtimeReceipt": runtime_receipt,
+        **result,
         "verified": True,
     }
 

--- a/framework/core/src/python/kungfu/runtime_broker.py
+++ b/framework/core/src/python/kungfu/runtime_broker.py
@@ -20,6 +20,7 @@ RECEIPT_SCHEMA = "kungfu.runtime.invocation-receipt/v1"
 REQUIREMENT_SCHEMA = "kungfu.runtime.requirement/v1"
 ACTIVATION_RECEIPT_SCHEMA = "kungfu.runtime.activation-receipt/v1"
 PRODUCT_STATUS_SCHEMA = "kungfu.runtime.product-status/v1"
+NATIVE_READINESS_EVIDENCE_SCHEMA = "kungfu.runtime.native-readiness-evidence/v1"
 REQUEST_SOURCES = {"libkungfu", "cli", "python", "node", "gui", "kfx"}
 
 
@@ -116,6 +117,60 @@ def _validate_value(
         "$ref": f"#/$defs/{target}",
     }
     contract_runtime.validate_json_schema(value, schema, f"runtime {target}")
+
+
+def native_readiness_evidence_path(
+    runtime_dir: str | Path, config_home: str | Path | None = None
+) -> Path:
+    """Return the product discovery path for one workspace's evidence coordinates."""
+
+    from kungfu import runtime_service
+
+    workspace = workspace_id(runtime_dir)
+    digest = hashlib.sha256(workspace.encode()).hexdigest()[:24]
+    resolved_config_home = runtime_service.resolve_config_home(
+        str(config_home) if config_home is not None else None
+    )
+    return Path(resolved_config_home) / "runtime" / "readiness" / f"{digest}.json"
+
+
+def discover_native_readiness_evidence(
+    runtime_dir: str | Path,
+    config_home: str | Path | None = None,
+    *,
+    contract: Mapping[str, Any] | None = None,
+) -> dict[str, Any] | None:
+    """Discover coordinates for native authorities without treating them as proof."""
+
+    path = native_readiness_evidence_path(runtime_dir, config_home)
+    if not path.exists():
+        return None
+    try:
+        value = json.loads(path.read_text("utf-8"))
+    except (OSError, json.JSONDecodeError):
+        raise ValueError("native runtime readiness evidence is unreadable") from None
+    if not isinstance(value, dict):
+        raise ValueError("native runtime readiness evidence is not an object")
+    _validate_value("nativeReadinessEvidence", value, contract)
+    expected_workspace = workspace_id(runtime_dir)
+    if value.get("workspaceId") != expected_workspace:
+        raise ValueError(
+            "native runtime readiness evidence belongs to another workspace"
+        )
+    expected_data_root_path = Path(runtime_dir).expanduser().resolve()
+    expected_data_root = str(expected_data_root_path)
+    actual_data_root = str(Path(str(value.get("dataRoot"))).expanduser().resolve())
+    if actual_data_root != expected_data_root:
+        raise ValueError("native runtime readiness evidence data root does not match")
+    expected_runtime_home = str(expected_data_root_path.parent)
+    actual_runtime_home = str(
+        Path(str(value.get("runtimeHome"))).expanduser().resolve()
+    )
+    if actual_runtime_home != expected_runtime_home:
+        raise ValueError(
+            "native runtime readiness evidence runtime home does not match"
+        )
+    return copy.deepcopy(value)
 
 
 def plan_operation(
@@ -566,6 +621,36 @@ class NativeReadinessAuthority:
             reconciliation,
             projection_status,
         ).establish(requirement, generation, diagnostics)
+
+
+def native_readiness_authority(
+    evidence: Mapping[str, Any],
+    *,
+    contract: Mapping[str, Any] | None = None,
+) -> NativeReadinessAuthority:
+    """Construct the existing native authority from validated discovery coordinates."""
+
+    _validate_value("nativeReadinessEvidence", evidence, contract)
+    durability_value = evidence["durability"]
+    projection_value = evidence.get("projection")
+    projection_mapping = (
+        projection_value if isinstance(projection_value, Mapping) else {}
+    )
+    return NativeReadinessAuthority(
+        data_root=str(evidence["dataRoot"]),
+        durability_request_id=int(str(durability_value["requestId"])),
+        requested_profile=str(durability_value["requestedProfile"]),
+        writer_resource_id=str(durability_value["writerResourceId"]),
+        durability_qualification_profile=str(durability_value["qualificationProfile"]),
+        projection_writer_resource_id=(
+            str(projection_mapping["writerResourceId"]) if projection_mapping else None
+        ),
+        projection_qualification_profile=(
+            str(projection_mapping["qualificationProfile"])
+            if projection_mapping
+            else None
+        ),
+    )
 
 
 def _runtime_handle(

--- a/framework/core/tests/python/test_agent_profile_sdk.py
+++ b/framework/core/tests/python/test_agent_profile_sdk.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from click.testing import CliRunner
 
-from kungfu import profile_composition, profile_sdk
+from kungfu import profile_composition, profile_sdk, runtime_broker
 from kungfu.cli.commands import __registry__  # noqa: F401
 from kungfu.cli.commands import kfc
 from kungfu.storage import service as storage_service
@@ -1028,6 +1028,46 @@ def test_semantic_diff_classifies_permission_and_requires_decision(tmp_path):
     assert result["decisionCards"][0]["kind"] == "profile-permission-change"
 
 
+def _activate_mission_control(runtime):
+    source = Path(__file__).resolve().parents[4] / "extensions" / "mission-control"
+    for action in ["install", "qualify", "activate"]:
+        core_plan = profile_sdk.lifecycle_plan(
+            runtime,
+            action,
+            source,
+            **({"granted_permissions": ["storage"]} if action == "activate" else {}),
+        )["corePlan"]
+        profile_sdk.lifecycle_apply(runtime, core_plan, f"test:{action}")
+    return source
+
+
+def _write_native_runtime_evidence(runtime, config_home):
+    runtime_path = Path(runtime).resolve()
+    evidence = {
+        "schema": "kungfu.runtime.native-readiness-evidence/v1",
+        "workspaceId": runtime_broker.workspace_id(runtime_path),
+        "runtimeHome": str(runtime_path.parent),
+        "dataRoot": str(runtime_path),
+        "minimumCut": {
+            "stream_id": "1",
+            "container_epoch": "1",
+            "sequence": "1",
+            "frame_uid": "1",
+        },
+        "durability": {
+            "requestId": "17",
+            "requestedProfile": "durable_sync",
+            "writerResourceId": "00000007.0000000b",
+            "qualificationProfile": "test/disposable-powercut/v1",
+        },
+        "projection": None,
+    }
+    path = runtime_broker.native_readiness_evidence_path(runtime, config_home)
+    path.parent.mkdir(parents=True)
+    path.write_text(json.dumps(evidence))
+    return evidence
+
+
 def test_action_invoke_rechecks_active_root_and_returns_core_receipt(tmp_path):
     source, _ = create_source(tmp_path)
     registry_path = source / "actions" / "registry.json"
@@ -1075,17 +1115,8 @@ def test_action_invoke_rechecks_active_root_and_returns_core_receipt(tmp_path):
 
 
 def test_mission_control_profile_action_executes_through_public_intent(tmp_path):
-    repo = Path(__file__).resolve().parents[4]
-    source = repo / "extensions" / "mission-control"
     runtime = tmp_path / "runtime"
-    for action in ["install", "qualify", "activate"]:
-        core_plan = profile_sdk.lifecycle_plan(
-            runtime,
-            action,
-            source,
-            **({"granted_permissions": ["storage"]} if action == "activate" else {}),
-        )["corePlan"]
-        profile_sdk.lifecycle_apply(runtime, core_plan, f"test:{action}")
+    source = _activate_mission_control(runtime)
     contract = profile_composition.contract_materialization_plan(source, runtime)
     profile_composition.authorized_contract_materialize(
         runtime,
@@ -1106,6 +1137,9 @@ def test_mission_control_profile_action_executes_through_public_intent(tmp_path)
 
     execution = receipt["actionReceipt"]
     assert execution["schema"] == "kungfu.profile-action-receipt/v1"
+    assert execution["runtimeReceipt"]["accepted"] is True
+    assert execution["runtimeReceipt"]["activation"]["outcome"] == "daemonless"
+    assert plan["actionPlan"]["runtimePlan"]["operation"]["id"] == "episode.append"
     assert execution["coreReceipt"]["mission_subject"] == "kungfu:mission:test"
     assert execution["affected"] == {
         "profileId": "kungfu.mission-control",
@@ -1113,3 +1147,130 @@ def test_mission_control_profile_action_executes_through_public_intent(tmp_path)
         "queryKeys": ["mission-state", "mission-timeline", "mission-attention"],
     }
     assert receipt["executionReceiptVerified"] is True
+
+
+def test_profile_action_rejects_tampered_runtime_execution_material(tmp_path):
+    runtime = tmp_path / "runtime"
+    source = _activate_mission_control(runtime)
+    plan = profile_sdk.plan_action(
+        source,
+        runtime,
+        "create-mission",
+        {
+            "missionId": "mission:tampered-runtime",
+            "title": "Tampered Runtime",
+            "intent": "The callback must not bypass its exact runtime plan",
+            "actor": "test-agent",
+        },
+    )
+    answer = profile_sdk.answer_decision(plan["decisionCard"], "approve", "test-owner")
+    plan["runtimePlan"]["operation"]["id"] = "assessment.request"
+
+    try:
+        profile_sdk.authorized_action_invoke(runtime, plan, answer)
+    except profile_sdk.ProfileSdkError as error:
+        assert error.diagnosis["code"] == "action-plan-stale"
+        assert error.diagnosis["message"] == (
+            "runtime execution material changed after planning"
+        )
+    else:
+        raise AssertionError("tampered runtime execution material reached the callback")
+
+
+def test_live_profile_action_plan_fails_without_native_evidence(tmp_path, monkeypatch):
+    runtime = tmp_path / "runtime"
+    source = _activate_mission_control(runtime)
+    monkeypatch.setenv("KF_CONFIG_HOME", str(tmp_path / "config"))
+
+    try:
+        profile_sdk.plan_action(
+            source, runtime, "assess-progress", {"missionId": "mission:test"}
+        )
+    except profile_sdk.ProfileSdkError as error:
+        assert error.diagnosis["code"] == "runtime-evidence-unavailable"
+        assert error.diagnosis["operationId"] == "assessment.request"
+    else:
+        raise AssertionError("live action planned without native evidence")
+
+
+def test_live_profile_action_does_not_run_callback_when_broker_refuses(
+    tmp_path, monkeypatch
+):
+    runtime = tmp_path / "runtime"
+    source = _activate_mission_control(runtime)
+    config_home = tmp_path / "config"
+    monkeypatch.setenv("KF_CONFIG_HOME", str(config_home))
+    evidence = _write_native_runtime_evidence(runtime, config_home)
+    calls = []
+    monkeypatch.setattr(
+        profile_sdk,
+        "_invoke_mission_control_action",
+        lambda *_args: calls.append("callback") or {"coreReceipt": {}},
+    )
+    monkeypatch.setattr(
+        runtime_broker.RuntimeCapabilityBroker,
+        "for_process",
+        classmethod(
+            lambda cls, *_args, **_kwargs: runtime_broker.RuntimeCapabilityBroker()
+        ),
+    )
+
+    plan = profile_sdk.plan_action(
+        source, runtime, "assess-progress", {"missionId": "mission:test"}
+    )
+    answer = profile_sdk.answer_decision(plan["decisionCard"], "approve", "test-owner")
+    receipt = profile_sdk.authorized_action_invoke(runtime, plan, answer)
+
+    assert plan["runtimePlan"]["operation"]["id"] == "assessment.request"
+    assert plan["runtimePlan"]["requirement"]["minimumCut"] == evidence["minimumCut"]
+    assert receipt["runtimeReceipt"]["accepted"] is False
+    assert receipt["runtimeReceipt"]["activation"]["error"]["code"] == (
+        "runtime_unavailable"
+    )
+    assert receipt["verified"] is False
+    assert calls == []
+
+
+def test_live_profile_action_runs_only_through_admitted_runtime_receipt(
+    tmp_path, monkeypatch
+):
+    runtime = tmp_path / "runtime"
+    source = _activate_mission_control(runtime)
+    config_home = tmp_path / "config"
+    monkeypatch.setenv("KF_CONFIG_HOME", str(config_home))
+    _write_native_runtime_evidence(runtime, config_home)
+    calls = []
+
+    def invoke_action(_runtime, _plan):
+        calls.append("callback")
+        return {"coreReceipt": {"scheduled": True}, "affected": {"entityKeys": []}}
+
+    class AdmittingBroker:
+        def invoke(self, plan, callback):
+            activation = {"outcome": "activated"}
+            return {
+                "schema": "kungfu.runtime.invocation-receipt/v1",
+                "planId": plan["planId"],
+                "operationId": plan["operation"]["id"],
+                "accepted": True,
+                "activation": activation,
+                "result": callback(activation),
+            }
+
+    monkeypatch.setattr(profile_sdk, "_invoke_mission_control_action", invoke_action)
+    monkeypatch.setattr(
+        runtime_broker.RuntimeCapabilityBroker,
+        "for_process",
+        classmethod(lambda cls, *_args, **_kwargs: AdmittingBroker()),
+    )
+
+    plan = profile_sdk.plan_action(
+        source, runtime, "assess-progress", {"missionId": "mission:test"}
+    )
+    answer = profile_sdk.answer_decision(plan["decisionCard"], "approve", "test-owner")
+    receipt = profile_sdk.authorized_action_invoke(runtime, plan, answer)
+
+    assert calls == ["callback"]
+    assert receipt["runtimeReceipt"]["accepted"] is True
+    assert receipt["coreReceipt"] == {"scheduled": True}
+    assert receipt["verified"] is True

--- a/framework/core/tests/python/test_runtime_broker.py
+++ b/framework/core/tests/python/test_runtime_broker.py
@@ -56,6 +56,27 @@ def _projection_status(cut=None):
     }
 
 
+def _native_evidence(runtime_dir, cut=None):
+    runtime_path = Path(runtime_dir).resolve()
+    return {
+        "schema": "kungfu.runtime.native-readiness-evidence/v1",
+        "workspaceId": runtime_broker.workspace_id(runtime_path),
+        "runtimeHome": str(runtime_path.parent),
+        "dataRoot": str(runtime_path),
+        "minimumCut": cut or _cut(),
+        "durability": {
+            "requestId": "17",
+            "requestedProfile": "durable_sync",
+            "writerResourceId": "00000007.0000000b",
+            "qualificationProfile": "test/disposable-powercut/v1",
+        },
+        "projection": {
+            "writerResourceId": "projection-restart-writer",
+            "qualificationProfile": "candidate/test-local-filesystem/v1",
+        },
+    }
+
+
 class _CutReadinessAuthority:
     def __init__(self, cut=None):
         self.cut = cut
@@ -583,6 +604,52 @@ def test_retained_readiness_fixture_binds_native_evidence_above_the_minimum_cut(
     assert runtime_broker._readiness_admits_requirement(requirement, readiness)
     assert readiness["durableCut"]["sequence"] == "42"
     assert readiness["projectionCut"] == readiness["durableCut"]
+
+
+def test_product_discovers_exact_native_readiness_coordinates(tmp_path, monkeypatch):
+    runtime_dir = tmp_path / "home" / "runtime"
+    config_home = tmp_path / "config"
+    monkeypatch.setenv("KF_CONFIG_HOME", str(config_home))
+    assert runtime_broker.discover_native_readiness_evidence(runtime_dir) is None
+
+    evidence = _native_evidence(runtime_dir)
+    path = runtime_broker.native_readiness_evidence_path(runtime_dir)
+    path.parent.mkdir(parents=True)
+    path.write_text(json.dumps(evidence))
+
+    discovered = runtime_broker.discover_native_readiness_evidence(runtime_dir)
+    assert discovered == evidence
+    authority = runtime_broker.native_readiness_authority(discovered)
+    assert authority.durability_request_id == 17
+    assert authority.projection_qualification_profile == (
+        "candidate/test-local-filesystem/v1"
+    )
+
+
+def test_product_rejects_foreign_native_readiness_coordinates(tmp_path, monkeypatch):
+    runtime_dir = tmp_path / "home" / "runtime"
+    monkeypatch.setenv("KF_CONFIG_HOME", str(tmp_path / "config"))
+    evidence = _native_evidence(runtime_dir)
+    evidence["workspaceId"] = "workspace-foreign"
+    path = runtime_broker.native_readiness_evidence_path(runtime_dir)
+    path.parent.mkdir(parents=True)
+    path.write_text(json.dumps(evidence))
+
+    with pytest.raises(ValueError, match="another workspace"):
+        runtime_broker.discover_native_readiness_evidence(runtime_dir)
+
+
+def test_product_rejects_mismatched_native_runtime_home(tmp_path, monkeypatch):
+    runtime_dir = tmp_path / "home" / "runtime"
+    monkeypatch.setenv("KF_CONFIG_HOME", str(tmp_path / "config"))
+    evidence = _native_evidence(runtime_dir)
+    evidence["runtimeHome"] = str(tmp_path / "foreign-home")
+    path = runtime_broker.native_readiness_evidence_path(runtime_dir)
+    path.parent.mkdir(parents=True)
+    path.write_text(json.dumps(evidence))
+
+    with pytest.raises(ValueError, match="runtime home does not match"):
+        runtime_broker.discover_native_readiness_evidence(runtime_dir)
 
 
 def test_native_readiness_authority_invokes_existing_typed_authorities(

--- a/framework/runtime/kungfu-runtime.contract.json
+++ b/framework/runtime/kungfu-runtime.contract.json
@@ -758,6 +758,91 @@
           }
         ]
       },
+      "nativeReadinessEvidence": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "schema",
+          "workspaceId",
+          "runtimeHome",
+          "dataRoot",
+          "minimumCut",
+          "durability",
+          "projection"
+        ],
+        "properties": {
+          "schema": {
+            "const": "kungfu.runtime.native-readiness-evidence/v1"
+          },
+          "workspaceId": {
+            "type": "string",
+            "minLength": 1
+          },
+          "runtimeHome": {
+            "type": "string",
+            "minLength": 1
+          },
+          "dataRoot": {
+            "type": "string",
+            "minLength": 1
+          },
+          "minimumCut": {
+            "$ref": "#/$defs/streamPosition"
+          },
+          "durability": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "requestId",
+              "requestedProfile",
+              "writerResourceId",
+              "qualificationProfile"
+            ],
+            "properties": {
+              "requestId": {
+                "$ref": "#/$defs/uint64"
+              },
+              "requestedProfile": {
+                "type": "string",
+                "minLength": 1
+              },
+              "writerResourceId": {
+                "type": "string",
+                "minLength": 1
+              },
+              "qualificationProfile": {
+                "type": "string",
+                "minLength": 1
+              }
+            }
+          },
+          "projection": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                  "writerResourceId",
+                  "qualificationProfile"
+                ],
+                "properties": {
+                  "writerResourceId": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "qualificationProfile": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                }
+              }
+            ]
+          }
+        }
+      },
       "readinessEvidence": {
         "type": "object",
         "additionalProperties": false,

--- a/scripts/check-runtime-contract.test.mjs
+++ b/scripts/check-runtime-contract.test.mjs
@@ -37,8 +37,8 @@ test('runtime contract accepts positive fixtures and rejects all safety failures
     result.contract,
     'framework/runtime/kungfu-runtime.contract.json',
   );
-  assert.equal(result.validFixtures, 4);
-  assert.equal(result.rejectedFixtures, 6);
+  assert.equal(result.validFixtures, 5);
+  assert.equal(result.rejectedFixtures, 7);
   assert.ok(['passed', 'skipped'].includes(result.schemaValidation));
 });
 

--- a/scripts/runtime-contract.mjs
+++ b/scripts/runtime-contract.mjs
@@ -470,6 +470,7 @@ export function validateRuntimeContractValue(target, value, contract) {
     return validateReceipt(object(value), contract);
   if (target === 'runtimeSnapshot')
     return validateSnapshot(object(value), contract);
+  if (target === 'nativeReadinessEvidence') return [];
   return [
     issue(
       'unknown-target',
@@ -631,6 +632,7 @@ export async function checkRuntimeContract(root = ROOT) {
       'runtimeLease',
       'activationReceipt',
       'runtimeSnapshot',
+      'nativeReadinessEvidence',
     ]) {
       const validate = ajv.getSchema(
         `${contract.valueSchemaBundle.$id}#/$defs/${target}`,

--- a/tests/fixtures/runtime-contract-topology-neutral/invalid-cases.json
+++ b/tests/fixtures/runtime-contract-topology-neutral/invalid-cases.json
@@ -166,5 +166,18 @@
         "value": null
       }
     ]
+  },
+  {
+    "id": "native-evidence-without-cut",
+    "base": "native-readiness-evidence",
+    "issue": "schema-invalid",
+    "operations": [
+      {
+        "operation": "remove",
+        "path": [
+          "minimumCut"
+        ]
+      }
+    ]
   }
 ]

--- a/tests/fixtures/runtime-contract-topology-neutral/valid-cases.json
+++ b/tests/fixtures/runtime-contract-topology-neutral/valid-cases.json
@@ -238,5 +238,31 @@
         }
       ]
     }
+  },
+  {
+    "id": "native-readiness-evidence",
+    "target": "nativeReadinessEvidence",
+    "value": {
+      "schema": "kungfu.runtime.native-readiness-evidence/v1",
+      "workspaceId": "workspace-demo",
+      "runtimeHome": "/tmp/kungfu-home",
+      "dataRoot": "/tmp/kungfu-home/runtime",
+      "minimumCut": {
+        "stream_id": "7",
+        "container_epoch": "11",
+        "sequence": "41",
+        "frame_uid": "1041"
+      },
+      "durability": {
+        "requestId": "17",
+        "requestedProfile": "durable_sync",
+        "writerResourceId": "00000007.0000000b",
+        "qualificationProfile": "candidate/linux-ext4-agent120-slo-v1"
+      },
+      "projection": {
+        "writerResourceId": "projection-restart-writer",
+        "qualificationProfile": "candidate/linux-ext4-agent120-slo-v1"
+      }
+    }
   }
 ]


### PR DESCRIPTION
## Summary

- bind every Profile/KFX action runtimeOperation to the canonical runtime invocation plan
- keep storage-only callbacks daemonless while routing live-required callbacks through RuntimeCapabilityBroker
- discover workspace-bound native readiness coordinates, then fail closed on absent, malformed, foreign, changed, or insufficient evidence
- preserve portable KFD-3 plan and receipt identity while rechecking exact execution material before invocation
- close ADR-0080 stage 6 without claiming a production-qualified evidence producer or EmbeddedRuntimeHost

## Verification

- `./shifu build:core` (passed)
- Profile/runtime Python suite after latest rebase: 81 passed
- `./shifu test:runtime-surface` (7 surfaces, 4 KFX actions)
- KFX Profile suite: Node 13, navigation 6, shared module 1, runtime foreground 9, Python 11; all passed
- KFD-3 dual-client proof: Agent CLI and typed Human API produced the same plan, receipt, and witness
- source gate on the implementation base: 150 contract/tooling tests, 61 documentation contracts, Biome, Ruff, and mypy passed
- latest mainline rerun is currently blocked only by pre-existing ADR-0081 metadata: it references rebase-predecessor `eed8a90cb760593025afe457f98db79289cd506b` instead of reachable mainline implementation `90e878b69`; the target Python suite remains 81/81 on that base
- staged pre-commit gate passed

## Governance risk

No credentials, deployment, release, hosted service, cross-machine lease, distributed election, or production EmbeddedRuntimeHost is changed or claimed. The discovery descriptor contains coordinates rather than readiness proof. Native typed authorities still establish durability and projection at the requested cut, and the domain callback is never invoked after broker refusal. Stage 7 still owns producer qualification and cold product activation evidence.

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "stage-ready",
  "adrs": ["ADR-0080"],
  "summary": "Close ADR-0080 stage 6 by binding Profile and KFX action invocation to the canonical broker, with daemonless storage execution and fail-closed exact-cut native evidence discovery for live-required work.",
  "verification": ["core build passed", "Profile and runtime Python suite: 81 passed", "runtime surface parity and KFX Profile suite passed", "KFD-3 dual-client proof passed", "source gate passed before the documented upstream ADR-0081 stale-SHA regression", "staged pre-commit gate"]
}
-->