### PR TITLE
feat(agent): add provider interaction adapters

### DIFF
--- a/docs/adr/ADR-0081-durable-agent-session-capsule-control-plane.md
+++ b/docs/adr/ADR-0081-durable-agent-session-capsule-control-plane.md
@@ -5,7 +5,7 @@ adr_id: ADR-0081
 decision_status: accepted
 implementation_status: partial
 implementation_commits: [80593936763261a38eb1fb696a254390c2decd67, 8b02979d68751924810d1dc25424dd7289f5d3e6, f3743218981bee7b1ffbe4fc14511845b8ac0b53]
-implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/834, https://github.com/kungfu-systems/kungfu/pull/837]
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/834, https://github.com/kungfu-systems/kungfu/pull/837, https://github.com/kungfu-systems/kungfu/pull/840]
 qualification_refs: [scripts/check-agent-session-contract.test.mjs, tests/fixtures/agent-session-capsule-contract, framework/agent-session/tests/capsule-host.test.mjs, framework/agent-session/tests/capsule-worker.test.mjs, framework/agent-session/tests/peer-transport.test.mjs, framework/agent-session/tests/runtime-port.test.mjs, framework/agent-session/tests/runtime-port.native.test.mjs, framework/agent-session/tests/provider-adapters.test.mjs, framework/agent-session/tests/interaction-port.test.mjs, framework/agent-session/tests/provider-version.native.test.mjs]
 review_state: self-reviewed
 sensitivity: public

--- a/docs/adr/ADR-0081-durable-agent-session-capsule-control-plane.md
+++ b/docs/adr/ADR-0081-durable-agent-session-capsule-control-plane.md
@@ -4,7 +4,7 @@ doc_type: architecture-decision
 adr_id: ADR-0081
 decision_status: accepted
 implementation_status: partial
-implementation_commits: [90e878b696a6a6a6a1a9d21f166f0e63bc527bb2, 8b02979d68751924810d1dc25424dd7289f5d3e6, f3743218981bee7b1ffbe4fc14511845b8ac0b53]
+implementation_commits: [80593936763261a38eb1fb696a254390c2decd67, 8b02979d68751924810d1dc25424dd7289f5d3e6, f3743218981bee7b1ffbe4fc14511845b8ac0b53]
 implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/834, https://github.com/kungfu-systems/kungfu/pull/837]
 qualification_refs: [scripts/check-agent-session-contract.test.mjs, tests/fixtures/agent-session-capsule-contract, framework/agent-session/tests/capsule-host.test.mjs, framework/agent-session/tests/capsule-worker.test.mjs, framework/agent-session/tests/peer-transport.test.mjs, framework/agent-session/tests/runtime-port.test.mjs, framework/agent-session/tests/runtime-port.native.test.mjs]
 review_state: self-reviewed

--- a/docs/adr/ADR-0081-durable-agent-session-capsule-control-plane.md
+++ b/docs/adr/ADR-0081-durable-agent-session-capsule-control-plane.md
@@ -6,7 +6,7 @@ decision_status: accepted
 implementation_status: partial
 implementation_commits: [80593936763261a38eb1fb696a254390c2decd67, 8b02979d68751924810d1dc25424dd7289f5d3e6, f3743218981bee7b1ffbe4fc14511845b8ac0b53]
 implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/834, https://github.com/kungfu-systems/kungfu/pull/837]
-qualification_refs: [scripts/check-agent-session-contract.test.mjs, tests/fixtures/agent-session-capsule-contract, framework/agent-session/tests/capsule-host.test.mjs, framework/agent-session/tests/capsule-worker.test.mjs, framework/agent-session/tests/peer-transport.test.mjs, framework/agent-session/tests/runtime-port.test.mjs, framework/agent-session/tests/runtime-port.native.test.mjs]
+qualification_refs: [scripts/check-agent-session-contract.test.mjs, tests/fixtures/agent-session-capsule-contract, framework/agent-session/tests/capsule-host.test.mjs, framework/agent-session/tests/capsule-worker.test.mjs, framework/agent-session/tests/peer-transport.test.mjs, framework/agent-session/tests/runtime-port.test.mjs, framework/agent-session/tests/runtime-port.native.test.mjs, framework/agent-session/tests/provider-adapters.test.mjs, framework/agent-session/tests/interaction-port.test.mjs, framework/agent-session/tests/provider-version.native.test.mjs]
 review_state: self-reviewed
 sensitivity: public
 sources: [local-files, user-decision]
@@ -217,14 +217,17 @@ evidence input under Profile/KFD authority.
 6. Fault, privacy, performance, Mac product, and promoted real-provider evidence
    close the decision.
 
-The contract slice, Stage 2 independent synthetic Capsule PTY host, and the
-Stage 3 journal/notice transport authority state machine are implemented and
-recorded, so the implementation status is partial. Deterministic transport
-fixtures prove multi-reader cursors, one-controller arbitration, input dedup,
-bounded gaps, Coordinator re-registration, Supervisor adoption fencing and
-writer-path fanout bounds. The production adapter binds that seam to native
-Watcher Peers: action envelopes use the Capsule's public mmap journal, the
-existing writer publication provides the nng notice, and a cross-process
-Coordinator/writer/reader qualification proves cursor reconstruction without a
-Coordinator byte proxy. Stages 4–6 remain required for real-provider semantics,
-shared product surfaces and machine-restart qualification.
+The contract slice, Stage 2 independent synthetic Capsule PTY host, Stage 3
+journal/notice transport authority, and Stage 4 provider-neutral interaction
+port are implemented and recorded, so the implementation status remains
+partial. Deterministic transport fixtures prove multi-reader cursors,
+one-controller arbitration, input dedup, bounded gaps, Coordinator
+re-registration, Supervisor adoption fencing and writer-path fanout bounds.
+The production adapter binds that seam to native Watcher Peers without a
+Coordinator byte proxy. Versioned, redacted Codex and Claude Code fixtures now
+prove ready/busy/approval/unknown admission policy, atomic paste, bounded queue,
+manual-only keys, interrupt fencing, exit closure and visible adapter drift.
+Local `--version` probes match Codex `0.144.3` and Claude Code `2.1.209` without
+reading private state; they do not qualify authenticated TUI behavior. Stages 5
+and 6 remain required for shared product surfaces, real-provider semantic
+dogfood, machine restart and promoted product evidence.

--- a/docs/qualification/contracts.md
+++ b/docs/qualification/contracts.md
@@ -211,6 +211,8 @@ then run:
     ./shifu test:agent-session-peer-transport
     ./shifu build:core
     ./shifu test:agent-session-peer-transport:native
+    ./shifu test:agent-session-interaction-adapters
+    ./shifu test:agent-session-interaction-adapters:native
     ./shifu check:source
 
 The fixture gate accepts seven canonical plan/status/receipt cases and rejects
@@ -231,8 +233,14 @@ count. The native ADR-0077 adapter is also implemented and qualified with a
 real Coordinator plus separate writer and reader Watcher processes: action
 envelopes traverse the writer's public mmap journal, the existing nng notice
 wakes the reader, and the Coordinator does not proxy payload bytes. Provider
-adapters, product surfaces, machine restart, and real Codex/Claude smoke remain
-staged; this contract does not claim those behaviors already exist.
+adapters now implement versioned redacted state classification,
+when-ready/queue/interrupt policy, atomic bracketed paste, manual-only keys,
+provider-exit closure, opaque-shell fallback, and delivery/outcome separation.
+Local no-private-state version probes match Codex `0.144.3` and Claude Code
+`2.1.209`; they do not prove authenticated interaction, approval outcome, or
+provider semantic response. Product surfaces, machine restart, and real
+Codex/Claude dogfood remain staged; this contract does not claim those behaviors
+already exist.
 
 ## The KFD-1 contract registry is the packaging source of truth
 

--- a/framework/agent-session/README.md
+++ b/framework/agent-session/README.md
@@ -1,4 +1,4 @@
-# AgentSessionCapsule host and peer transport
+# AgentSessionCapsule host, peer transport, and interaction port
 
 `@kungfu-tech/agent-session` contains the process-lifetime boundary that owns
 one provider PTY for one `SessionAttempt`. It directly spawns an absolute
@@ -39,8 +39,24 @@ a production broker. `NativeKungfuJournalNoticePort` binds the same authority
 state machine to a native Watcher Peer: one public mmap journal writer carries
 `kungfu.action-envelope/v1` frames and the writer's existing nng publication is
 the payload-free wakeup plane. The Coordinator never proxies frame bytes and
-the Capsule worker's local test socket is not a public relay. Codex and Claude
-semantic adapters belong to Stage 4, and product surfaces belong to Stage 5.
+the Capsule worker's local test socket is not a public relay.
+
+The Stage 4 provider-neutral Interaction Port adds:
+
+- `status`, `snapshot`, `instruct`, `sendKey`, and `interrupt` over the same
+  generation-, epoch-, controller-, and foreground-fenced transport;
+- deterministic `when-ready`, bounded `queue`, and interrupt-then-wait policy;
+- versioned Codex `0.144.x` and Claude Code `2.1.x` redacted TUI signatures for
+  `ready`, `busy`, `approval-needed`, `ended`, and `unknown`;
+- one atomic bracketed-paste instruction plus one Enter, with duplicate input
+  and trailing-Enter rejection; and
+- visible adapter drift and opaque-shell fallback to explicit raw human input.
+
+An automatic instruction is never delivered or queued from
+`approval-needed` or `unknown`. `sendKey` is manual-only. Delivery receipts do
+not contain instruction text and never claim provider understanding, semantic
+outcome, work state, approval result, or interrupt result. Adapter fixtures are
+synthetic and redacted. Product surfaces still belong to Stage 5.
 
 Run the focused qualification through Shifu:
 
@@ -49,6 +65,8 @@ Run the focused qualification through Shifu:
 ./shifu test:agent-session-peer-transport
 ./shifu build:core
 ./shifu test:agent-session-peer-transport:native
+./shifu test:agent-session-interaction-adapters
+./shifu test:agent-session-interaction-adapters:native
 ```
 
 The build-free source gate runs the pure host and transport tests only. Native
@@ -58,6 +76,12 @@ cursor reconstruction and absence of a Coordinator byte proxy. The Capsule host
 focused command also runs the native node-pty worker smoke; native checks stay
 outside the source-only lifecycle because that runner installs dependencies
 without native build scripts.
+
+The interaction adapter native command is build-free and local-only: it checks
+installed Codex and Claude Code version output under a temporary HOME without
+reading provider auth, private transcripts, or hidden session databases. Real
+authenticated instruction, approval/deny, and provider-outcome dogfood remains
+a Stage 6 product qualification obligation.
 
 On Darwin, packaged products must restore the executable bit on node-pty's
 `spawn-helper`. The existing Electron `afterPack` audit already owns that

--- a/framework/agent-session/package.json
+++ b/framework/agent-session/package.json
@@ -13,7 +13,9 @@
   },
   "exports": {
     ".": "./src/capsule-host.mjs",
+    "./interaction-port": "./src/interaction-port.mjs",
     "./peer-transport": "./src/peer-transport.mjs",
+    "./provider-adapters": "./src/provider-adapters.mjs",
     "./runtime-port": "./src/runtime-port.mjs",
     "./worker": "./src/capsule-worker.mjs",
     "./vt-snapshot": "./src/vt-snapshot.mjs"

--- a/framework/agent-session/package.json
+++ b/framework/agent-session/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@kungfu-tech/agent-session",
   "version": "4.0.0-alpha.0",
-  "description": "Kungfu AgentSessionCapsule process and PTY host",
+  "description": "Kungfu AgentSessionCapsule process, PTY transport, and interaction port",
   "license": "Apache-2.0",
   "type": "module",
   "repository": {

--- a/framework/agent-session/src/interaction-port.mjs
+++ b/framework/agent-session/src/interaction-port.mjs
@@ -1,0 +1,302 @@
+const MODES = new Set(['when-ready', 'queue', 'interrupt']);
+
+function required(value, label) {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new InteractionPortError('invalid_argument', `${label} is required`);
+  }
+  return value;
+}
+
+function nullOutcome() {
+  return { semanticOutcome: null, workState: null };
+}
+
+export class InteractionPortError extends Error {
+  constructor(code, message) {
+    super(message);
+    this.name = 'InteractionPortError';
+    this.code = code;
+  }
+}
+
+export class AgentSessionInteractionPort {
+  constructor({
+    host,
+    transport,
+    adapter,
+    queueLimit = 32,
+    now = () => Date.now(),
+  }) {
+    if (
+      !host ||
+      typeof host.status !== 'function' ||
+      typeof host.snapshot !== 'function'
+    ) {
+      throw new InteractionPortError(
+        'invalid_host',
+        'interaction port requires a Capsule host',
+      );
+    }
+    if (!transport || typeof transport.submitInput !== 'function') {
+      throw new InteractionPortError(
+        'invalid_transport',
+        'interaction port requires Capsule peer transport',
+      );
+    }
+    if (!adapter || typeof adapter.inspect !== 'function') {
+      throw new InteractionPortError(
+        'invalid_adapter',
+        'interaction port requires a provider adapter',
+      );
+    }
+    if (!Number.isSafeInteger(queueLimit) || queueLimit < 1) {
+      throw new InteractionPortError(
+        'invalid_argument',
+        'queueLimit must be a positive safe integer',
+      );
+    }
+    this.host = host;
+    this.transport = transport;
+    this.adapter = adapter;
+    this.queueLimit = queueLimit;
+    this.now = now;
+    this.queue = [];
+  }
+
+  status() {
+    const observation = this.#observe();
+    return {
+      schema: 'kungfu.agent-session.interaction-status/v1',
+      ...observation.hostStatus,
+      interactionState: observation.interaction.state,
+      providerAdapter: {
+        provider: this.adapter.provider,
+        providerVersion: this.adapter.providerVersion,
+        adapterVersion: this.adapter.adapterVersion,
+        compatible: observation.interaction.compatible,
+        tested: this.adapter.tested,
+        signatureIds: observation.interaction.signatureIds,
+        reason: observation.interaction.reason,
+        rawHumanFallback: true,
+        knownLimits: [...this.adapter.knownLimits],
+      },
+      queuedInstructions: this.queue.length,
+    };
+  }
+
+  snapshot({ requestedSequence = 0 } = {}) {
+    return {
+      schema: 'kungfu.agent-session.interaction-snapshot/v1',
+      status: this.status(),
+      terminal: this.host.snapshot(requestedSequence),
+    };
+  }
+
+  instruct(request) {
+    const mode = request.mode ?? 'when-ready';
+    if (!MODES.has(mode)) {
+      throw new InteractionPortError(
+        'invalid_argument',
+        `unsupported instruction mode '${String(mode)}'`,
+      );
+    }
+    required(request.actionId, 'actionId');
+    required(request.inputId, 'inputId');
+    const observation = this.#observe();
+    const blocked = this.#admissionBlock(observation);
+    if (blocked) return this.#held(request, blocked);
+    if (observation.interaction.state === 'ready') {
+      return this.#deliverInstruction(request);
+    }
+    if (observation.interaction.state === 'busy' && mode === 'queue') {
+      return this.#enqueue(request, 'provider-busy');
+    }
+    if (observation.interaction.state === 'busy' && mode === 'interrupt') {
+      const controlReceipt = this.interrupt({
+        ...request,
+        inputId: `${request.inputId}:interrupt`,
+      });
+      const held = this.#enqueue(request, 'interrupt-sent-awaiting-ready');
+      return { ...held, controlReceipt };
+    }
+    return this.#held(request, `state-${observation.interaction.state}`);
+  }
+
+  flushQueued() {
+    if (this.queue.length === 0) {
+      return {
+        schema: 'kungfu.agent-session.interaction-receipt/v1',
+        operation: 'instruct',
+        status: 'held',
+        reason: 'queue-empty',
+        queueDepth: 0,
+        deliveryReceipt: null,
+        ...nullOutcome(),
+      };
+    }
+    const observation = this.#observe();
+    const blocked = this.#admissionBlock(observation);
+    if (blocked || observation.interaction.state !== 'ready') {
+      return {
+        schema: 'kungfu.agent-session.interaction-receipt/v1',
+        operation: 'instruct',
+        status: 'held',
+        reason: blocked ?? `state-${observation.interaction.state}`,
+        queueDepth: this.queue.length,
+        deliveryReceipt: null,
+        ...nullOutcome(),
+      };
+    }
+    const request = this.queue.shift();
+    try {
+      return this.#deliverInstruction(request);
+    } catch (error) {
+      return {
+        schema: 'kungfu.agent-session.interaction-receipt/v1',
+        operation: 'instruct',
+        actionId: request.actionId,
+        inputId: request.inputId,
+        status: 'rejected',
+        reason: error.code ?? 'delivery-failed',
+        queueDepth: this.queue.length,
+        deliveryReceipt: null,
+        ...nullOutcome(),
+      };
+    }
+  }
+
+  sendKey(request) {
+    if (request.automatic !== false) {
+      throw new InteractionPortError(
+        'manual_key_required',
+        'sendKey is an explicit raw-human fallback',
+      );
+    }
+    const observation = this.#observe();
+    const blocked = this.#admissionBlock(observation, { allowUnknown: true });
+    if (blocked) return this.#held(request, blocked, 'send-key');
+    const data = this.adapter.encodeKey(request.key);
+    const deliveryReceipt = this.transport.submitInput({ ...request, data });
+    return {
+      schema: 'kungfu.agent-session.interaction-receipt/v1',
+      operation: 'send-key',
+      actionId: request.actionId,
+      inputId: request.inputId,
+      status: deliveryReceipt.status,
+      reason: null,
+      queueDepth: this.queue.length,
+      deliveryReceipt,
+      rawHumanFallback: true,
+      ...nullOutcome(),
+    };
+  }
+
+  interrupt(request) {
+    const observation = this.#observe();
+    const blocked = this.#admissionBlock(observation, { allowUnknown: true });
+    if (blocked) return this.#held(request, blocked, 'interrupt');
+    if (typeof this.transport.submitSignal !== 'function') {
+      throw new InteractionPortError(
+        'interrupt_unavailable',
+        'transport does not expose fenced signal delivery',
+      );
+    }
+    const controlReceipt = this.transport.submitSignal({
+      ...request,
+      signal: 'SIGINT',
+    });
+    return {
+      schema: 'kungfu.agent-session.interaction-receipt/v1',
+      operation: 'interrupt',
+      actionId: request.actionId,
+      inputId: request.inputId,
+      status: controlReceipt.status,
+      reason: null,
+      queueDepth: this.queue.length,
+      controlReceipt,
+      signalOutcome: null,
+      ...nullOutcome(),
+    };
+  }
+
+  #observe() {
+    const hostStatus = this.transport.status();
+    const terminal = this.host.snapshot(hostStatus.output.earliestSequence);
+    const interaction = this.adapter.inspect({
+      lines: terminal.vt.lines,
+      lifecycleState: hostStatus.lifecycleState,
+      inputAdmission: hostStatus.inputAdmission,
+      foreground: hostStatus.foreground,
+    });
+    return { hostStatus, interaction };
+  }
+
+  #admissionBlock(observation, { allowUnknown = false } = {}) {
+    if (
+      observation.hostStatus.lifecycleState === 'ended' ||
+      observation.hostStatus.inputAdmission === 'closed'
+    ) {
+      return 'provider-ended';
+    }
+    if (!observation.interaction.compatible)
+      return observation.interaction.reason ?? 'adapter-incompatible';
+    if (observation.hostStatus.foreground.provider !== this.adapter.provider)
+      return 'foreground-provider-mismatch';
+    if (
+      !allowUnknown &&
+      ['approval-needed', 'unknown'].includes(observation.interaction.state)
+    ) {
+      return `automatic-delivery-held-${observation.interaction.state}`;
+    }
+    return null;
+  }
+
+  #enqueue(request, reason) {
+    if (this.queue.length >= this.queueLimit) {
+      return {
+        ...this.#held(request, 'instruction-queue-full'),
+        status: 'rejected',
+      };
+    }
+    this.queue.push({ ...request });
+    return {
+      ...this.#held(request, reason),
+      queued: true,
+      queueDepth: this.queue.length,
+    };
+  }
+
+  #deliverInstruction(request) {
+    const data = this.adapter.encodeInstruction(request.text);
+    const deliveryReceipt = this.transport.submitInput({ ...request, data });
+    return {
+      schema: 'kungfu.agent-session.interaction-receipt/v1',
+      operation: 'instruct',
+      actionId: request.actionId,
+      inputId: request.inputId,
+      status: deliveryReceipt.status,
+      reason: null,
+      queueDepth: this.queue.length,
+      deliveryReceipt,
+      deliveredAt: this.now(),
+      ...nullOutcome(),
+    };
+  }
+
+  #held(request, reason, operation = 'instruct') {
+    return {
+      schema: 'kungfu.agent-session.interaction-receipt/v1',
+      operation,
+      actionId: request.actionId ?? null,
+      inputId: request.inputId ?? null,
+      status: 'held',
+      reason,
+      queued: false,
+      queueDepth: this.queue.length,
+      deliveryReceipt: null,
+      requiresHuman:
+        /approval-needed|unknown|version-drift|provider-mismatch/u.test(reason),
+      ...nullOutcome(),
+    };
+  }
+}

--- a/framework/agent-session/src/peer-transport.mjs
+++ b/framework/agent-session/src/peer-transport.mjs
@@ -430,6 +430,52 @@ export class AgentSessionCapsulePeerTransport {
     return delivered;
   }
 
+  submitSignal({
+    leaseId,
+    holderId,
+    coordinatorEpoch,
+    expectedForeground,
+    ...action
+  }) {
+    const existing = this.inputReceipts.get(action.inputId);
+    if (existing) return { ...existing, status: 'duplicate' };
+    if (coordinatorEpoch !== this.#requireRegistration().coordinatorEpoch) {
+      throw new PeerTransportError(
+        'stale_coordinator',
+        'signal Coordinator epoch does not match current registration',
+      );
+    }
+    const current = this.#activeController(this.now());
+    if (
+      !current ||
+      current.leaseId !== leaseId ||
+      current.holderId !== holderId
+    ) {
+      throw new PeerTransportError(
+        'stale_controller_lease',
+        'signal requires the exact active controller lease',
+      );
+    }
+    const status = this.host.status();
+    if (!sameForeground(expectedForeground, status.foreground)) {
+      throw new PeerTransportError(
+        'foreground_mismatch',
+        'signal expected foreground does not match the provider',
+      );
+    }
+    const receipt = this.host.signal(action);
+    const delivered = this.#append('auditable-control', 'interrupt-delivered', {
+      ...receipt,
+      inputId: required(action.inputId, 'inputId'),
+      controllerLeaseId: leaseId,
+      controllerHolderId: holderId,
+      semanticOutcome: null,
+      workState: null,
+    });
+    this.inputReceipts.set(action.inputId, delivered);
+    return delivered;
+  }
+
   queueResize({ leaseId, holderId, ...action }) {
     const current = this.#activeController(this.now());
     if (

--- a/framework/agent-session/src/provider-adapters.mjs
+++ b/framework/agent-session/src/provider-adapters.mjs
@@ -1,0 +1,251 @@
+import { spawnSync } from 'node:child_process';
+
+const PROVIDER_PROFILES = {
+  codex: {
+    adapterVersion: 'codex-tui/v1',
+    supportedVersion: /^0\.144\.[0-9]+$/u,
+    testedVersions: ['0.144.3'],
+    signatures: {
+      approval: [
+        [
+          'codex.approval.run-command',
+          /would you like to run (?:this|the) command/iu,
+        ],
+        ['codex.approval.confirm', /press enter to confirm or esc to cancel/iu],
+      ],
+      busy: [['codex.busy.interrupt-hint', /esc to interrupt/iu]],
+      ready: [['codex.ready.prompt', /^\s*›(?:\s|$)/mu]],
+    },
+  },
+  claude: {
+    adapterVersion: 'claude-code-tui/v1',
+    supportedVersion: /^2\.1\.[0-9]+$/u,
+    testedVersions: ['2.1.209'],
+    signatures: {
+      approval: [
+        ['claude.approval.proceed', /do you want to proceed\?/iu],
+        ['claude.approval.permission', /allow (?:this|the) action/iu],
+      ],
+      busy: [['claude.busy.interrupt-hint', /esc to interrupt/iu]],
+      ready: [['claude.ready.prompt', /^\s*❯(?:\s|$)/mu]],
+    },
+  },
+};
+
+const GENERIC_MODAL =
+  /(?:\[(?:y|yes)\/(?:n|no)\]|\((?:y|yes)\/(?:n|no)\)|permission required|press enter|approve|allow)/iu;
+const VERSION = /([0-9]+\.[0-9]+\.[0-9]+)/u;
+const NUL = String.fromCharCode(0);
+const ESCAPE = String.fromCharCode(27);
+const KEY_SEQUENCES = {
+  Enter: '\r',
+  Escape: '\u001b',
+  Tab: '\t',
+  ArrowUp: '\u001b[A',
+  ArrowDown: '\u001b[B',
+  ArrowRight: '\u001b[C',
+  ArrowLeft: '\u001b[D',
+  Backspace: '\u007f',
+  y: 'y',
+  n: 'n',
+};
+
+function requireProvider(provider) {
+  const profile = PROVIDER_PROFILES[provider];
+  if (!profile) {
+    throw new Error(
+      `provider adapter is unavailable for '${String(provider)}'`,
+    );
+  }
+  return profile;
+}
+
+function cleanScreen(lines) {
+  if (
+    !Array.isArray(lines) ||
+    !lines.every((line) => typeof line === 'string')
+  ) {
+    throw new Error('provider inspection requires redacted VT text-grid lines');
+  }
+  return lines
+    .filter((line) => line.trim().length > 0)
+    .slice(-12)
+    .join('\n');
+}
+
+function matches(signatures, screen) {
+  return signatures.find(([, pattern]) => pattern.test(screen))?.[0] ?? null;
+}
+
+function interactionResult({
+  state,
+  signatureId = null,
+  reason = null,
+  compatible,
+}) {
+  return {
+    schema: 'kungfu.agent-session.provider-interaction/v1',
+    state,
+    compatible,
+    signatureIds: signatureId ? [signatureId] : [],
+    reason,
+    rawHumanFallback: true,
+  };
+}
+
+export function parseProviderVersion(provider, output) {
+  requireProvider(provider);
+  const version = String(output ?? '').match(VERSION)?.[1] ?? null;
+  if (!version) {
+    throw new Error(`${provider} --version did not return a semantic version`);
+  }
+  return version;
+}
+
+export function probeProviderVersion({
+  provider,
+  executable,
+  env,
+  run = spawnSync,
+}) {
+  requireProvider(provider);
+  if (typeof executable !== 'string' || executable.length === 0) {
+    throw new Error('provider version probe requires an executable');
+  }
+  const result = run(executable, ['--version'], {
+    encoding: 'utf8',
+    env: env ?? {
+      PATH: process.env.PATH,
+      LANG: 'C',
+      LC_ALL: 'C',
+    },
+    shell: false,
+    timeout: 10_000,
+  });
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(
+      `${provider} version probe exited with ${String(result.status)}`,
+    );
+  }
+  const version = parseProviderVersion(
+    provider,
+    result.stdout || result.stderr,
+  );
+  const adapter = createProviderAdapter({ provider, version });
+  return {
+    schema: 'kungfu.agent-session.provider-version-probe/v1',
+    provider,
+    version,
+    adapterVersion: adapter.adapterVersion,
+    compatible: adapter.compatible,
+    tested: adapter.tested,
+    inspectedPrivateState: false,
+  };
+}
+
+export function createProviderAdapter({ provider, version }) {
+  const profile = requireProvider(provider);
+  if (typeof version !== 'string' || version.length === 0) {
+    throw new Error('provider adapter requires an explicit version');
+  }
+  const compatible = profile.supportedVersion.test(version);
+  const tested = profile.testedVersions.includes(version);
+  return Object.freeze({
+    schema: 'kungfu.agent-session.provider-adapter/v1',
+    provider,
+    providerVersion: version,
+    adapterVersion: profile.adapterVersion,
+    compatible,
+    tested,
+    knownLimits: [
+      'tui-signatures-are-versioned-and-may-drift',
+      'delivery-receipt-does-not-prove-provider-understanding',
+      'approval-and-deny-require-stage-6-real-provider-dogfood',
+      'interrupt-proves-signal-delivery-not-provider-outcome',
+    ],
+    inspect({ lines, lifecycleState, inputAdmission, foreground }) {
+      if (lifecycleState === 'ended' || inputAdmission === 'closed') {
+        return interactionResult({ state: 'ended', compatible });
+      }
+      if (foreground?.provider !== provider) {
+        return interactionResult({
+          state: 'unknown',
+          reason: 'foreground-provider-mismatch',
+          compatible: false,
+        });
+      }
+      if (!compatible) {
+        return interactionResult({
+          state: 'unknown',
+          reason: 'adapter-version-drift',
+          compatible: false,
+        });
+      }
+      const screen = cleanScreen(lines);
+      const approval = matches(profile.signatures.approval, screen);
+      if (approval) {
+        return interactionResult({
+          state: 'approval-needed',
+          signatureId: approval,
+          compatible: true,
+        });
+      }
+      const busy = matches(profile.signatures.busy, screen);
+      if (busy) {
+        return interactionResult({
+          state: 'busy',
+          signatureId: busy,
+          compatible: true,
+        });
+      }
+      const ready = matches(profile.signatures.ready, screen);
+      if (ready) {
+        return interactionResult({
+          state: 'ready',
+          signatureId: ready,
+          compatible: true,
+        });
+      }
+      return interactionResult({
+        state: 'unknown',
+        reason: GENERIC_MODAL.test(screen)
+          ? 'unrecognized-modal-state'
+          : 'no-supported-state-signature',
+        compatible: true,
+      });
+    },
+    encodeInstruction(text) {
+      if (typeof text !== 'string' || text.length === 0) {
+        throw new Error('instruction text must be non-empty');
+      }
+      if (text.includes(NUL) || text.includes(ESCAPE)) {
+        throw new Error('instruction text cannot contain NUL or escape bytes');
+      }
+      if (/(?:\r|\n)$/u.test(text)) {
+        throw new Error('instruction text cannot end with Enter');
+      }
+      if (Buffer.byteLength(text, 'utf8') > 64 * 1024) {
+        throw new Error('instruction exceeds the 64 KiB atomic paste limit');
+      }
+      return `\u001b[200~${text}\u001b[201~\r`;
+    },
+    encodeKey(key) {
+      const sequence = KEY_SEQUENCES[key];
+      if (sequence === undefined) {
+        throw new Error(`unsupported semantic key '${String(key)}'`);
+      }
+      return sequence;
+    },
+  });
+}
+
+export function providerAdapterMatrix() {
+  return Object.entries(PROVIDER_PROFILES).map(([provider, profile]) => ({
+    provider,
+    adapterVersion: profile.adapterVersion,
+    testedVersions: [...profile.testedVersions],
+    versionPolicy: 'exact-minor-family; unrecognized versions fail visible',
+    privateTranscriptRequired: false,
+  }));
+}

--- a/framework/agent-session/tests/fixtures/provider-adapters/claude-v2.1.209.json
+++ b/framework/agent-session/tests/fixtures/provider-adapters/claude-v2.1.209.json
@@ -1,0 +1,26 @@
+[
+  {
+    "id": "claude-ready-redacted",
+    "lines": ["Claude Code", "❯ Try a task"],
+    "expectedState": "ready",
+    "signatureId": "claude.ready.prompt"
+  },
+  {
+    "id": "claude-busy-redacted",
+    "lines": ["Thinking… (esc to interrupt)"],
+    "expectedState": "busy",
+    "signatureId": "claude.busy.interrupt-hint"
+  },
+  {
+    "id": "claude-approval-redacted",
+    "lines": ["Do you want to proceed?", "1. Yes", "2. No"],
+    "expectedState": "approval-needed",
+    "signatureId": "claude.approval.proceed"
+  },
+  {
+    "id": "claude-unknown-redacted",
+    "lines": ["A provider screen with no supported state marker"],
+    "expectedState": "unknown",
+    "reason": "no-supported-state-signature"
+  }
+]

--- a/framework/agent-session/tests/fixtures/provider-adapters/codex-v0.144.3.json
+++ b/framework/agent-session/tests/fixtures/provider-adapters/codex-v0.144.3.json
@@ -1,0 +1,26 @@
+[
+  {
+    "id": "codex-ready-redacted",
+    "lines": ["codex", "› Ask about this workspace"],
+    "expectedState": "ready",
+    "signatureId": "codex.ready.prompt"
+  },
+  {
+    "id": "codex-busy-redacted",
+    "lines": ["Working (12s • esc to interrupt)"],
+    "expectedState": "busy",
+    "signatureId": "codex.busy.interrupt-hint"
+  },
+  {
+    "id": "codex-approval-redacted",
+    "lines": ["Would you like to run this command?", "1. Yes", "2. No"],
+    "expectedState": "approval-needed",
+    "signatureId": "codex.approval.run-command"
+  },
+  {
+    "id": "codex-unknown-modal-redacted",
+    "lines": ["A changed layout says permission required"],
+    "expectedState": "unknown",
+    "reason": "unrecognized-modal-state"
+  }
+]

--- a/framework/agent-session/tests/interaction-port.test.mjs
+++ b/framework/agent-session/tests/interaction-port.test.mjs
@@ -1,0 +1,254 @@
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import test from 'node:test';
+import { AgentSessionCapsuleHost } from '../src/capsule-host.mjs';
+import { AgentSessionInteractionPort } from '../src/interaction-port.mjs';
+import {
+  AgentSessionCapsulePeerTransport,
+  InMemoryJournalNoticePort,
+} from '../src/peer-transport.mjs';
+import { createProviderAdapter } from '../src/provider-adapters.mjs';
+
+const PROFILE_ROOT = `sha256:${'c'.repeat(64)}`;
+
+class FakePtyProcess extends EventEmitter {
+  constructor() {
+    super();
+    this.pid = 9191;
+    this.writes = [];
+    this.signals = [];
+  }
+
+  onData(listener) {
+    this.on('data', listener);
+  }
+
+  onExit(listener) {
+    this.on('exit', listener);
+  }
+
+  write(data) {
+    this.writes.push(data);
+  }
+
+  resize() {}
+
+  kill(signal) {
+    this.signals.push(signal);
+  }
+}
+
+function fixture({
+  provider = 'codex',
+  version = '0.144.3',
+  queueLimit = 4,
+} = {}) {
+  const child = new FakePtyProcess();
+  const host = new AgentSessionCapsuleHost({
+    pty: { spawn: () => child },
+    capsuleId: 'capsule-interaction-1',
+    runtimeIdentity: 'runtime-interaction-1',
+    maxOutputBytes: 4096,
+    now: () => 1000,
+  });
+  const started = host.start({
+    workConsoleId: 'console-1',
+    sessionAttemptId: 'attempt-1',
+    capsuleGeneration: '7',
+    sessionStreamEpoch: '11',
+    provider,
+    profileRoot: PROFILE_ROOT,
+    executable: '/usr/bin/provider',
+    argv: ['--tui'],
+    cwd: '/tmp',
+  });
+  const transport = new AgentSessionCapsulePeerTransport({
+    host,
+    port: new InMemoryJournalNoticePort(),
+    now: () => 1000,
+  });
+  transport.register({ coordinatorEpoch: '3', supervisorGeneration: '5' });
+  transport.acquireControl({
+    leaseId: 'lease-1',
+    holderId: 'controller-1',
+    planRoot: 'plan-1',
+  });
+  const adapter = createProviderAdapter({
+    provider: provider === 'custom' ? 'codex' : provider,
+    version,
+  });
+  const port = new AgentSessionInteractionPort({
+    host,
+    transport,
+    adapter,
+    queueLimit,
+    now: () => 1001,
+  });
+  const authority = {
+    leaseId: 'lease-1',
+    holderId: 'controller-1',
+    coordinatorEpoch: '3',
+    expectedForeground: started.foreground,
+    sessionAttemptId: 'attempt-1',
+    capsuleGeneration: '7',
+    sessionStreamEpoch: '11',
+    processStartIdentity: started.foreground.processStartIdentity,
+  };
+  return {
+    authority,
+    child,
+    host,
+    port,
+    screen(value) {
+      child.emit('data', `\u001b[2J\u001b[H${value}`);
+    },
+  };
+}
+
+function instruction(authority, id, overrides = {}) {
+  return {
+    ...authority,
+    actionId: `action-${id}`,
+    inputId: `input-${id}`,
+    text: `instruction ${id}`,
+    mode: 'when-ready',
+    automatic: true,
+    ...overrides,
+  };
+}
+
+test('ready instruction is one idempotent atomic paste and proves no outcome', () => {
+  const { authority, child, port, screen } = fixture();
+  screen('› Ask about this workspace');
+  const request = instruction(authority, 'ready');
+  const first = port.instruct(request);
+  const duplicate = port.instruct(request);
+  assert.equal(first.status, 'written');
+  assert.equal(duplicate.status, 'duplicate');
+  assert.deepEqual(child.writes, ['\u001b[200~instruction ready\u001b[201~\r']);
+  assert.equal(
+    first.deliveryReceipt.proves,
+    'validated-input-written-to-pty-only',
+  );
+  assert.equal(first.semanticOutcome, null);
+  assert.equal(first.workState, null);
+  assert.doesNotMatch(JSON.stringify(first), /instruction ready/u);
+  assert.throws(
+    () =>
+      port.instruct(instruction(authority, 'newline', { text: 'unsafe\n' })),
+    /cannot end with Enter/u,
+  );
+});
+
+test('busy queue flushes only after a supported ready signature', () => {
+  const { authority, child, port, screen } = fixture();
+  screen('Working (1s • esc to interrupt)');
+  const held = port.instruct(
+    instruction(authority, 'queued', { mode: 'queue' }),
+  );
+  assert.equal(held.status, 'held');
+  assert.equal(held.queued, true);
+  assert.deepEqual(child.writes, []);
+  assert.equal(port.flushQueued().status, 'held');
+  screen('› Ready');
+  assert.equal(port.flushQueued().status, 'written');
+  assert.equal(port.status().queuedInstructions, 0);
+});
+
+test('approval and unknown modal states never auto-deliver or auto-queue', () => {
+  const { authority, child, port, screen } = fixture();
+  screen('Would you like to run this command?');
+  const approval = port.instruct(
+    instruction(authority, 'approval', { mode: 'queue' }),
+  );
+  assert.equal(approval.status, 'held');
+  assert.equal(approval.queued, false);
+  assert.equal(approval.requiresHuman, true);
+  screen('A changed layout says permission required');
+  const unknown = port.instruct(
+    instruction(authority, 'unknown', { mode: 'interrupt' }),
+  );
+  assert.equal(unknown.status, 'held');
+  assert.equal(unknown.queued, false);
+  assert.deepEqual(child.writes, []);
+  assert.deepEqual(child.signals, []);
+});
+
+test('interrupt mode sends one fenced signal then waits for ready before text', () => {
+  const { authority, child, port, screen } = fixture();
+  screen('Working (3s • esc to interrupt)');
+  const held = port.instruct(
+    instruction(authority, 'interrupt', { mode: 'interrupt' }),
+  );
+  assert.equal(held.status, 'held');
+  assert.equal(held.controlReceipt.operation, 'interrupt');
+  assert.deepEqual(child.signals, ['SIGINT']);
+  assert.deepEqual(child.writes, []);
+  screen('› Ready');
+  assert.equal(port.flushQueued().status, 'written');
+  assert.equal(held.controlReceipt.semanticOutcome, null);
+});
+
+test('sendKey is manual-only, deduplicated, and never implies approval outcome', () => {
+  const { authority, child, port, screen } = fixture();
+  screen('Would you like to run this command?');
+  const request = {
+    ...authority,
+    actionId: 'action-key',
+    inputId: 'input-key',
+    key: 'y',
+    automatic: false,
+  };
+  assert.equal(port.sendKey(request).status, 'written');
+  assert.equal(port.sendKey(request).status, 'duplicate');
+  assert.deepEqual(child.writes, ['y']);
+  assert.throws(
+    () => port.sendKey({ ...request, inputId: 'input-auto', automatic: true }),
+    (error) => error.code === 'manual_key_required',
+  );
+});
+
+test('provider exit and opaque shell fallback fail closed', () => {
+  const ended = fixture();
+  ended.screen('› Ready');
+  ended.child.emit('exit', { exitCode: 0, signal: 0 });
+  const afterExit = ended.port.instruct(instruction(ended.authority, 'late'));
+  assert.equal(afterExit.status, 'held');
+  assert.equal(afterExit.reason, 'provider-ended');
+  assert.deepEqual(ended.child.writes, []);
+
+  const custom = fixture({ provider: 'custom' });
+  custom.screen('› Looks ready but belongs to an opaque shell');
+  const shell = custom.port.instruct(instruction(custom.authority, 'shell'));
+  assert.equal(shell.status, 'held');
+  assert.equal(shell.reason, 'foreground-provider-mismatch');
+  assert.equal(shell.requiresHuman, true);
+  assert.deepEqual(custom.child.writes, []);
+});
+
+test('adapter version drift is visible and cannot write through a ready-looking screen', () => {
+  const { authority, child, port, screen } = fixture({ version: '0.145.0' });
+  screen('› Ready-looking prompt');
+  const receipt = port.instruct(instruction(authority, 'drift'));
+  assert.equal(receipt.status, 'held');
+  assert.equal(receipt.reason, 'adapter-version-drift');
+  assert.equal(receipt.requiresHuman, true);
+  assert.equal(port.status().providerAdapter.rawHumanFallback, true);
+  assert.deepEqual(child.writes, []);
+});
+
+test('bounded queue rejects overflow without dropping or writing hidden input', () => {
+  const { authority, child, port, screen } = fixture({ queueLimit: 1 });
+  screen('Working (1s • esc to interrupt)');
+  assert.equal(
+    port.instruct(instruction(authority, 'one', { mode: 'queue' })).status,
+    'held',
+  );
+  const overflow = port.instruct(
+    instruction(authority, 'two', { mode: 'queue' }),
+  );
+  assert.equal(overflow.status, 'rejected');
+  assert.equal(overflow.reason, 'instruction-queue-full');
+  assert.equal(overflow.queueDepth, 1);
+  assert.deepEqual(child.writes, []);
+});

--- a/framework/agent-session/tests/peer-transport.test.mjs
+++ b/framework/agent-session/tests/peer-transport.test.mjs
@@ -16,6 +16,7 @@ class FakePtyProcess extends EventEmitter {
     this.pid = 8118;
     this.writes = [];
     this.resizes = [];
+    this.signals = [];
   }
 
   onData(listener) {
@@ -34,7 +35,9 @@ class FakePtyProcess extends EventEmitter {
     this.resizes.push([cols, rows]);
   }
 
-  kill() {}
+  kill(signal) {
+    this.signals.push(signal);
+  }
 }
 
 function fixture({ maxFrames = 256, maxOutputBytes = 1024 } = {}) {
@@ -159,6 +162,46 @@ test('one controller wins, duplicate input is idempotent, and stale authority fa
         coordinatorEpoch: '2',
       }),
     (error) => error.code === 'stale_coordinator',
+  );
+});
+
+test('interrupt signal is idempotent and uses the same controller and foreground fencing', () => {
+  const { child, current, foreground, transport } = fixture();
+  transport.acquireControl({
+    leaseId: 'lease-gui',
+    holderId: 'gui',
+    planRoot: 'plan-gui',
+  });
+  const action = {
+    ...current,
+    actionId: 'interrupt-1',
+    inputId: 'interrupt-input-1',
+    signal: 'SIGINT',
+    leaseId: 'lease-gui',
+    holderId: 'gui',
+    coordinatorEpoch: '3',
+    expectedForeground: foreground,
+  };
+  assert.equal(transport.submitSignal(action).status, 'applied');
+  assert.equal(transport.submitSignal(action).status, 'duplicate');
+  assert.deepEqual(child.signals, ['SIGINT']);
+  assert.throws(
+    () =>
+      transport.submitSignal({
+        ...action,
+        inputId: 'interrupt-input-2',
+        leaseId: 'stale-lease',
+      }),
+    (error) => error.code === 'stale_controller_lease',
+  );
+  assert.throws(
+    () =>
+      transport.submitSignal({
+        ...action,
+        inputId: 'interrupt-input-3',
+        expectedForeground: { ...foreground, processStartIdentity: 'stale' },
+      }),
+    (error) => error.code === 'foreground_mismatch',
   );
 });
 

--- a/framework/agent-session/tests/provider-adapters.test.mjs
+++ b/framework/agent-session/tests/provider-adapters.test.mjs
@@ -1,0 +1,133 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+import {
+  createProviderAdapter,
+  parseProviderVersion,
+  probeProviderVersion,
+  providerAdapterMatrix,
+} from '../src/provider-adapters.mjs';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+
+function fixtures(name) {
+  return JSON.parse(
+    fs.readFileSync(
+      path.join(here, 'fixtures', 'provider-adapters', name),
+      'utf8',
+    ),
+  );
+}
+
+for (const [provider, version, filename] of [
+  ['codex', '0.144.3', 'codex-v0.144.3.json'],
+  ['claude', '2.1.209', 'claude-v2.1.209.json'],
+]) {
+  test(`${provider} adapter classifies only versioned redacted fixtures`, () => {
+    const adapter = createProviderAdapter({ provider, version });
+    assert.equal(adapter.compatible, true);
+    assert.equal(adapter.tested, true);
+    for (const fixture of fixtures(filename)) {
+      const result = adapter.inspect({
+        lines: fixture.lines,
+        lifecycleState: 'ready',
+        inputAdmission: 'open',
+        foreground: { provider },
+      });
+      assert.equal(result.state, fixture.expectedState, fixture.id);
+      if (fixture.signatureId) {
+        assert.deepEqual(
+          result.signatureIds,
+          [fixture.signatureId],
+          fixture.id,
+        );
+      }
+      if (fixture.reason)
+        assert.equal(result.reason, fixture.reason, fixture.id);
+    }
+  });
+}
+
+test('version drift and foreground mismatch fail visibly to raw human fallback', () => {
+  const drifted = createProviderAdapter({
+    provider: 'codex',
+    version: '0.145.0',
+  });
+  const result = drifted.inspect({
+    lines: ['› prompt'],
+    lifecycleState: 'ready',
+    inputAdmission: 'open',
+    foreground: { provider: 'codex' },
+  });
+  assert.equal(result.state, 'unknown');
+  assert.equal(result.compatible, false);
+  assert.equal(result.reason, 'adapter-version-drift');
+  assert.equal(result.rawHumanFallback, true);
+
+  const adapter = createProviderAdapter({
+    provider: 'codex',
+    version: '0.144.3',
+  });
+  assert.equal(
+    adapter.inspect({
+      lines: ['› prompt'],
+      lifecycleState: 'ready',
+      inputAdmission: 'open',
+      foreground: { provider: 'custom' },
+    }).reason,
+    'foreground-provider-mismatch',
+  );
+});
+
+test('instruction encoding is one bounded bracketed-paste frame with one Enter', () => {
+  const adapter = createProviderAdapter({
+    provider: 'codex',
+    version: '0.144.3',
+  });
+  assert.equal(
+    adapter.encodeInstruction('inspect the source'),
+    '\u001b[200~inspect the source\u001b[201~\r',
+  );
+  assert.throws(
+    () => adapter.encodeInstruction('already submitted\n'),
+    /cannot end with Enter/u,
+  );
+  assert.throws(
+    () => adapter.encodeInstruction('unsafe\u001bsequence'),
+    /escape bytes/u,
+  );
+  assert.throws(
+    () => adapter.encodeInstruction('x'.repeat(65 * 1024)),
+    /64 KiB/u,
+  );
+  assert.equal(adapter.encodeKey('Enter'), '\r');
+  assert.throws(
+    () => adapter.encodeKey('Ctrl-Alt-Delete'),
+    /unsupported semantic key/u,
+  );
+});
+
+test('version probe returns metadata only and never claims private-state inspection', () => {
+  const probe = probeProviderVersion({
+    provider: 'codex',
+    executable: '/test/codex',
+    run: (_command, args, options) => {
+      assert.deepEqual(args, ['--version']);
+      assert.equal(options.shell, false);
+      return { status: 0, stdout: 'codex-cli 0.144.3\n', stderr: '' };
+    },
+  });
+  assert.equal(
+    parseProviderVersion('claude', '2.1.209 (Claude Code)'),
+    '2.1.209',
+  );
+  assert.equal(probe.compatible, true);
+  assert.equal(probe.tested, true);
+  assert.equal(probe.inspectedPrivateState, false);
+  assert.deepEqual(
+    providerAdapterMatrix().map((entry) => entry.provider),
+    ['codex', 'claude'],
+  );
+});

--- a/framework/agent-session/tests/provider-version.native.test.mjs
+++ b/framework/agent-session/tests/provider-version.native.test.mjs
@@ -1,0 +1,40 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { probeProviderVersion } from '../src/provider-adapters.mjs';
+
+for (const [provider, variable, fallback] of [
+  ['codex', 'KUNGFU_CODEX_BIN', 'codex'],
+  ['claude', 'KUNGFU_CLAUDE_BIN', 'claude'],
+]) {
+  test(`installed ${provider} CLI matches the versioned adapter without private state`, (t) => {
+    const home = fs.mkdtempSync(
+      path.join(os.tmpdir(), `kungfu-${provider}-version-`),
+    );
+    t.after(() => fs.rmSync(home, { force: true, recursive: true }));
+    let result;
+    try {
+      result = probeProviderVersion({
+        provider,
+        executable: process.env[variable] ?? fallback,
+        env: {
+          PATH: process.env.PATH,
+          HOME: home,
+          LANG: 'C',
+          LC_ALL: 'C',
+        },
+      });
+    } catch (error) {
+      if (error.code === 'ENOENT') {
+        t.skip(`${provider} CLI is not installed`);
+        return;
+      }
+      throw error;
+    }
+    assert.equal(result.compatible, true);
+    assert.equal(result.tested, true);
+    assert.equal(result.inspectedPrivateState, false);
+  });
+}

--- a/package.json
+++ b/package.json
@@ -110,6 +110,8 @@
     "test:agent-session-capsule-host": "node scripts/require-shifu.mjs test:agent-session-capsule-host && pnpm --filter @kungfu-tech/agent-session test",
     "test:agent-session-peer-transport": "node scripts/require-shifu.mjs test:agent-session-peer-transport && node --test framework/agent-session/tests/peer-transport.test.mjs framework/agent-session/tests/runtime-port.test.mjs",
     "test:agent-session-peer-transport:native": "node scripts/require-shifu.mjs test:agent-session-peer-transport:native && node --test framework/agent-session/tests/runtime-port.native.test.mjs",
+    "test:agent-session-interaction-adapters": "node scripts/require-shifu.mjs test:agent-session-interaction-adapters && node --test framework/agent-session/tests/provider-adapters.test.mjs framework/agent-session/tests/interaction-port.test.mjs",
+    "test:agent-session-interaction-adapters:native": "node scripts/require-shifu.mjs test:agent-session-interaction-adapters:native && node --test framework/agent-session/tests/provider-version.native.test.mjs",
     "test:profile-kfd3-qualification": "node scripts/require-shifu.mjs test:profile-kfd3-qualification && node tests/qualification/profile-kfd3/run.ts",
     "schema:profile-lifecycle": "node scripts/require-shifu.mjs schema:profile-lifecycle && node scripts/generate-profile-lifecycle-schema.mjs",
     "test:durable-ingest": "node scripts/require-shifu.mjs test:durable-ingest && node scripts/run-durable-ingest-tests.mjs",

--- a/scripts/source-acceptance.mjs
+++ b/scripts/source-acceptance.mjs
@@ -118,6 +118,8 @@ export function sourceAcceptancePlan(files) {
         'framework/agent-session/tests/capsule-host.test.mjs',
         'framework/agent-session/tests/peer-transport.test.mjs',
         'framework/agent-session/tests/runtime-port.test.mjs',
+        'framework/agent-session/tests/provider-adapters.test.mjs',
+        'framework/agent-session/tests/interaction-port.test.mjs',
         'framework/core/tests/qualification/durability/run.test.mjs',
         'framework/core/tests/qualification/durability/powercut_plan.test.mjs',
         'framework/core/tests/qualification/durability/fault_campaign.test.mjs',

--- a/scripts/source-acceptance.test.mjs
+++ b/scripts/source-acceptance.test.mjs
@@ -44,6 +44,16 @@ test('source plan covers representative source-only checks', () => {
     ),
   );
   assert.ok(
+    contractTests.args.includes(
+      'framework/agent-session/tests/provider-adapters.test.mjs',
+    ),
+  );
+  assert.ok(
+    contractTests.args.includes(
+      'framework/agent-session/tests/interaction-port.test.mjs',
+    ),
+  );
+  assert.ok(
     !contractTests.args.includes(
       'framework/agent-session/tests/capsule-worker.test.mjs',
     ),


### PR DESCRIPTION
## Summary

- add a provider-neutral AgentSession Interaction Port for status, snapshot, instruct, manual sendKey, and fenced interrupt
- add versioned Codex 0.144.x and Claude Code 2.1.x redacted TUI adapters with fail-visible drift and raw-human fallback
- enforce ready-only automatic instruction, bounded busy queues, approval/unknown hold, one atomic bracketed paste plus one Enter, and delivery/outcome separation
- repair ADR-0081 merged evidence coordinates; keep authenticated approval/deny/semantic dogfood explicitly staged for Stage 6

## Verification

- `./shifu test:agent-session-interaction-adapters` (13/13)
- `./shifu test:agent-session-peer-transport` (11/11)
- `./shifu check:source` (199/199 source tests; full build-free gate passed)
- `./shifu test:agent-session-interaction-adapters:native` (2/2; installed Codex 0.144.3 and Claude Code 2.1.209 version probes under temporary HOME, no auth/private transcript inspection)

## Known limits

- version probes do not prove authenticated TUI interaction or provider semantic outcome
- approval/deny and interrupt outcome require Stage 6 real-provider product dogfood
- adapter signature drift fails to `unknown` and requires explicit raw-human fallback

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "stage-ready",
  "adrs": ["ADR-0081"],
  "summary": "Complete Stage 4 provider-neutral interaction policy and versioned Codex/Claude adapters; ADR-0081 remains partial pending product surfaces and real-provider recovery qualification.",
  "verification": ["source gate 199 tests", "interaction adapter 13 tests", "transport regression 11 tests", "two no-private-state installed CLI version probes"]
}
-->

## Governance risk check

- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed