### PR TITLE
feat(runtime): qualify activation product delivery

### DIFF
--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -5,8 +5,8 @@
   "witnessKind": "prebuild",
   "supportLevel": "release",
   "source": {
-    "cwd": "/Users/dkr/Worktrees/kungfu/feature/agent-session-product-surfaces",
-    "sourceSha": "486247556b9b65b35d88768b6255eee5e0ee6a66",
+    "cwd": "/Users/dkr/Worktrees/kungfu/feature/runtime-qualification-delivery",
+    "sourceSha": "16f02290bfc3cec6f90610da6991a92e74e5d8b0",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
     "registryDigest": "sha256:176e6473ca0ffca24b56388b0ac15ecb7f3cc1a7a944cb46d80c7d2fa1dd14cb"
   },

--- a/developer/sdk/src/sdk.js
+++ b/developer/sdk/src/sdk.js
@@ -2497,10 +2497,10 @@ function runOrFail(cmd, args, opts = {}) {
  * @returns {string}
  */
 function resolveCorePython(coreDir) {
-  const environmentCandidates = [
-    process.env.UV_PROJECT_ENVIRONMENT,
-    path.join(coreDir, '.venv'),
-  ].filter(Boolean);
+  const environmentCandidates = [path.join(coreDir, '.venv')];
+  if (process.env.UV_PROJECT_ENVIRONMENT) {
+    environmentCandidates.unshift(process.env.UV_PROJECT_ENVIRONMENT);
+  }
   const executableNames =
     process.platform === 'win32' ? ['python.exe'] : ['python3', 'python'];
   for (const environment of environmentCandidates) {

--- a/developer/sdk/src/sdk.js
+++ b/developer/sdk/src/sdk.js
@@ -2490,6 +2490,53 @@ function runOrFail(cmd, args, opts = {}) {
 }
 
 /**
+ * Resolve the Python executable from the Core uv project without assuming a
+ * checkout-local .venv. Shifu's managed cache keeps the effective environment
+ * outside the repository and exposes it through the uv command adapter.
+ * @param {string} coreDir
+ * @returns {string}
+ */
+function resolveCorePython(coreDir) {
+  const environmentCandidates = [
+    process.env.UV_PROJECT_ENVIRONMENT,
+    path.join(coreDir, '.venv'),
+  ].filter(Boolean);
+  const executableNames =
+    process.platform === 'win32' ? ['python.exe'] : ['python3', 'python'];
+  for (const environment of environmentCandidates) {
+    for (const executable of executableNames) {
+      const candidate = path.join(
+        environment,
+        process.platform === 'win32' ? 'Scripts' : 'bin',
+        executable,
+      );
+      if (fs.existsSync(candidate)) return candidate;
+    }
+  }
+
+  const result = spawnSync(
+    'uv',
+    [
+      'run',
+      '--project',
+      coreDir,
+      'python',
+      '-c',
+      'import sys; print(sys.executable)',
+    ],
+    { encoding: 'utf8' },
+  );
+  const resolved = result.status === 0 ? result.stdout.trim() : '';
+  if (resolved && path.isAbsolute(resolved) && fs.existsSync(resolved)) {
+    return resolved;
+  }
+  const detail = result.error?.message || result.stderr?.trim() || 'not found';
+  fail(
+    `core Python could not be resolved through uv: ${detail}. Run \`./shifu rebuild:core\` first.`,
+  );
+}
+
+/**
  * Configure and build a C++ kfx into a native pybind11 module.
  * @param {Manifest} manifest
  * @returns {void}
@@ -2522,19 +2569,11 @@ function cppBuild(manifest) {
   // compatible with the runtime and loads alongside pykungfu. Pass both the
   // classic (FindPythonInterp) and modern (FindPython) hint variables so the
   // pin holds regardless of which pybind11 lookup mode is active.
-  const pythonEnvironment =
-    process.env.UV_PROJECT_ENVIRONMENT || path.join(coreDir, '.venv');
-  const corePython = path.join(
-    pythonEnvironment,
-    process.platform === 'win32' ? 'Scripts' : 'bin',
-    process.platform === 'win32' ? 'python.exe' : 'python3',
+  const corePython = resolveCorePython(coreDir);
+  configureArgs.push(
+    `-DPYTHON_EXECUTABLE=${corePython}`,
+    `-DPython_EXECUTABLE=${corePython}`,
   );
-  if (fs.existsSync(corePython)) {
-    configureArgs.push(
-      `-DPYTHON_EXECUTABLE=${corePython}`,
-      `-DPython_EXECUTABLE=${corePython}`,
-    );
-  }
   runOrFail('cmake', configureArgs);
   runOrFail('cmake', ['--build', buildDir, '--config', 'Release']);
   process.stdout.write(
@@ -2559,16 +2598,7 @@ function pythonAotBuild(manifest) {
     fail(
       'cannot locate framework/core (a python-AOT kfx build needs the monorepo core)',
     );
-  const pythonEnvironment =
-    process.env.UV_PROJECT_ENVIRONMENT || path.join(coreDir, '.venv');
-  const py = path.join(
-    pythonEnvironment,
-    process.platform === 'win32' ? 'Scripts' : 'bin',
-    process.platform === 'win32' ? 'python.exe' : 'python3',
-  );
-  if (!fs.existsSync(py)) {
-    fail(`core Python not found: ${py}. Run \`./shifu rebuild:core\` first.`);
-  }
+  const py = resolveCorePython(coreDir);
   const pkgRoot = path.resolve('src', 'python');
   const pkg = fs.existsSync(pkgRoot)
     ? fs

--- a/docs/adr/ADR-0080-topology-neutral-capability-driven-runtime-activation.md
+++ b/docs/adr/ADR-0080-topology-neutral-capability-driven-runtime-activation.md
@@ -7,7 +7,7 @@ implementation_status: implemented
 implementation_commits: [92b30d70f08ea51ecdaf36844fe5eb953f3686ac, cb9e86bf81c3d1997f7a4b725ab6fcf6bb6e89c8, 10f7bc09dfb016b26cba7b6b68005b102a9c8dc1]
 implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/815, https://github.com/kungfu-systems/kungfu/pull/818, https://github.com/kungfu-systems/kungfu/pull/819, https://github.com/kungfu-systems/kungfu/pull/822, https://github.com/kungfu-systems/kungfu/pull/823, https://github.com/kungfu-systems/kungfu/pull/825, https://github.com/kungfu-systems/kungfu/pull/831, https://github.com/kungfu-systems/kungfu/pull/841]
 closure_pr: https://github.com/kungfu-systems/kungfu/pull/841
-qualification_refs: [docs/qualification/runtime-activation-and-product-delivery.md, docs/qualification/evidence/runtime-activation/fb1574844/report.json]
+qualification_refs: [docs/qualification/runtime-activation-and-product-delivery.md, docs/qualification/evidence/runtime-activation/fea9ea4ae/report.json]
 review_state: self-reviewed
 sensitivity: public
 sources: [local-files, user-decision]
@@ -306,8 +306,8 @@ products copy the exact contract through the existing KFD-1 contract registry.
    qualification report records eight passing suites for daemonless and
    no-fork behavior, concurrent activation, catch-up, crash/lease/idle
    recovery, surface parity, measured performance, and the packaged product.
-   The report is bound to clean source revision `fb1574844`, product artifact
-   `20260714T092910Z-fb1574844`, and its documented SHA-256. Linux and Windows
+   The report is bound to clean source revision `fea9ea4ae`, product artifact
+   `20260714T102912Z-fea9ea4ae`, and its documented SHA-256. Linux and Windows
    remain contract/CI surfaces; production `EmbeddedRuntimeHost`, HA or
    replication, and physical power-cut behavior remain explicit non-claims.
 

--- a/docs/adr/ADR-0080-topology-neutral-capability-driven-runtime-activation.md
+++ b/docs/adr/ADR-0080-topology-neutral-capability-driven-runtime-activation.md
@@ -4,10 +4,10 @@ doc_type: architecture-decision
 adr_id: ADR-0080
 decision_status: accepted
 implementation_status: implemented
-implementation_commits: [92b30d70f08ea51ecdaf36844fe5eb953f3686ac, cb9e86bf81c3d1997f7a4b725ab6fcf6bb6e89c8, 10f7bc09dfb016b26cba7b6b68005b102a9c8dc1]
+implementation_commits: [1ae74ec839fd7cf4f2a480700682811630b9672f, a5b7a0f9dff7412de8437748f052614de79c1f4a, 6950397a6e47506c5f134502234d144750e5ae6f]
 implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/815, https://github.com/kungfu-systems/kungfu/pull/818, https://github.com/kungfu-systems/kungfu/pull/819, https://github.com/kungfu-systems/kungfu/pull/822, https://github.com/kungfu-systems/kungfu/pull/823, https://github.com/kungfu-systems/kungfu/pull/825, https://github.com/kungfu-systems/kungfu/pull/831, https://github.com/kungfu-systems/kungfu/pull/841]
 closure_pr: https://github.com/kungfu-systems/kungfu/pull/841
-qualification_refs: [docs/qualification/runtime-activation-and-product-delivery.md, docs/qualification/evidence/runtime-activation/fea9ea4ae/report.json]
+qualification_refs: [docs/qualification/runtime-activation-and-product-delivery.md, docs/qualification/evidence/runtime-activation/080f330db/report.json]
 review_state: self-reviewed
 sensitivity: public
 sources: [local-files, user-decision]
@@ -306,8 +306,8 @@ products copy the exact contract through the existing KFD-1 contract registry.
    qualification report records eight passing suites for daemonless and
    no-fork behavior, concurrent activation, catch-up, crash/lease/idle
    recovery, surface parity, measured performance, and the packaged product.
-   The report is bound to clean source revision `fea9ea4ae`, product artifact
-   `20260714T102912Z-fea9ea4ae`, and its documented SHA-256. Linux and Windows
+   The report is bound to clean source revision `080f330db`, product artifact
+   `20260714T104706Z-080f330db`, and its documented SHA-256. Linux and Windows
    remain contract/CI surfaces; production `EmbeddedRuntimeHost`, HA or
    replication, and physical power-cut behavior remain explicit non-claims.
 

--- a/docs/adr/ADR-0080-topology-neutral-capability-driven-runtime-activation.md
+++ b/docs/adr/ADR-0080-topology-neutral-capability-driven-runtime-activation.md
@@ -4,10 +4,10 @@ doc_type: architecture-decision
 adr_id: ADR-0080
 decision_status: accepted
 implementation_status: implemented
-implementation_commits: [1ae74ec839fd7cf4f2a480700682811630b9672f, a5b7a0f9dff7412de8437748f052614de79c1f4a, 6950397a6e47506c5f134502234d144750e5ae6f]
+implementation_commits: [90cec7cf8513ee1330bfacd93021fd867f5d5969, 2b01eabd49778b735dcbe14fefb618bb682854f1, d57e0a5a9e5876629d5727967294704ee665b009]
 implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/815, https://github.com/kungfu-systems/kungfu/pull/818, https://github.com/kungfu-systems/kungfu/pull/819, https://github.com/kungfu-systems/kungfu/pull/822, https://github.com/kungfu-systems/kungfu/pull/823, https://github.com/kungfu-systems/kungfu/pull/825, https://github.com/kungfu-systems/kungfu/pull/831, https://github.com/kungfu-systems/kungfu/pull/841]
 closure_pr: https://github.com/kungfu-systems/kungfu/pull/841
-qualification_refs: [docs/qualification/runtime-activation-and-product-delivery.md, docs/qualification/evidence/runtime-activation/080f330db/report.json]
+qualification_refs: [docs/qualification/runtime-activation-and-product-delivery.md, docs/qualification/evidence/runtime-activation/527652f13/report.json]
 review_state: self-reviewed
 sensitivity: public
 sources: [local-files, user-decision]
@@ -306,8 +306,8 @@ products copy the exact contract through the existing KFD-1 contract registry.
    qualification report records eight passing suites for daemonless and
    no-fork behavior, concurrent activation, catch-up, crash/lease/idle
    recovery, surface parity, measured performance, and the packaged product.
-   The report is bound to clean source revision `080f330db`, product artifact
-   `20260714T104706Z-080f330db`, and its documented SHA-256. Linux and Windows
+   The report is bound to clean source revision `527652f13`, product artifact
+   `20260714T112358Z-527652f13`, and its documented SHA-256. Linux and Windows
    remain contract/CI surfaces; production `EmbeddedRuntimeHost`, HA or
    replication, and physical power-cut behavior remain explicit non-claims.
 

--- a/docs/adr/ADR-0080-topology-neutral-capability-driven-runtime-activation.md
+++ b/docs/adr/ADR-0080-topology-neutral-capability-driven-runtime-activation.md
@@ -7,7 +7,7 @@ implementation_status: implemented
 implementation_commits: [90cec7cf8513ee1330bfacd93021fd867f5d5969, 2b01eabd49778b735dcbe14fefb618bb682854f1, d57e0a5a9e5876629d5727967294704ee665b009]
 implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/815, https://github.com/kungfu-systems/kungfu/pull/818, https://github.com/kungfu-systems/kungfu/pull/819, https://github.com/kungfu-systems/kungfu/pull/822, https://github.com/kungfu-systems/kungfu/pull/823, https://github.com/kungfu-systems/kungfu/pull/825, https://github.com/kungfu-systems/kungfu/pull/831, https://github.com/kungfu-systems/kungfu/pull/841]
 closure_pr: https://github.com/kungfu-systems/kungfu/pull/841
-qualification_refs: [docs/qualification/runtime-activation-and-product-delivery.md, docs/qualification/evidence/runtime-activation/527652f13/report.json]
+qualification_refs: [docs/qualification/runtime-activation-and-product-delivery.md, docs/qualification/evidence/runtime-activation/8643f1187/report.json]
 review_state: self-reviewed
 sensitivity: public
 sources: [local-files, user-decision]
@@ -306,8 +306,8 @@ products copy the exact contract through the existing KFD-1 contract registry.
    qualification report records eight passing suites for daemonless and
    no-fork behavior, concurrent activation, catch-up, crash/lease/idle
    recovery, surface parity, measured performance, and the packaged product.
-   The report is bound to clean source revision `527652f13`, product artifact
-   `20260714T112358Z-527652f13`, and its documented SHA-256. Linux and Windows
+   The report is bound to clean source revision `8643f1187`, product artifact
+   `20260714T113632Z-8643f1187`, and its documented SHA-256. Linux and Windows
    remain contract/CI surfaces; production `EmbeddedRuntimeHost`, HA or
    replication, and physical power-cut behavior remain explicit non-claims.
 

--- a/docs/adr/ADR-0080-topology-neutral-capability-driven-runtime-activation.md
+++ b/docs/adr/ADR-0080-topology-neutral-capability-driven-runtime-activation.md
@@ -3,8 +3,11 @@ metadata_schema: kungfu.document-metadata/v1
 doc_type: architecture-decision
 adr_id: ADR-0080
 decision_status: accepted
-implementation_status: partial
-implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/815, https://github.com/kungfu-systems/kungfu/pull/818, https://github.com/kungfu-systems/kungfu/pull/819, https://github.com/kungfu-systems/kungfu/pull/822, https://github.com/kungfu-systems/kungfu/pull/823, https://github.com/kungfu-systems/kungfu/pull/825, https://github.com/kungfu-systems/kungfu/pull/831]
+implementation_status: implemented
+implementation_commits: [92b30d70f08ea51ecdaf36844fe5eb953f3686ac, cb9e86bf81c3d1997f7a4b725ab6fcf6bb6e89c8, 10f7bc09dfb016b26cba7b6b68005b102a9c8dc1]
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/815, https://github.com/kungfu-systems/kungfu/pull/818, https://github.com/kungfu-systems/kungfu/pull/819, https://github.com/kungfu-systems/kungfu/pull/822, https://github.com/kungfu-systems/kungfu/pull/823, https://github.com/kungfu-systems/kungfu/pull/825, https://github.com/kungfu-systems/kungfu/pull/831, https://github.com/kungfu-systems/kungfu/pull/841]
+closure_pr: https://github.com/kungfu-systems/kungfu/pull/841
+qualification_refs: [docs/qualification/runtime-activation-and-product-delivery.md, docs/qualification/evidence/runtime-activation/fb1574844/report.json]
 review_state: self-reviewed
 sensitivity: public
 sources: [local-files, user-decision]
@@ -17,7 +20,7 @@ last_reviewed: 2026-07-14
 
 # ADR-0080: live runtime activation is capability-driven and topology-neutral
 
-- Status: accepted; implementation partial
+- Status: accepted; implementation implemented
 - Date: 2026-07-14
 - Category: runtime architecture / activation / recovery / embedding boundary
 - Related: [ADR-0035](ADR-0035-workspace-local-kungfu-data-home.md),
@@ -299,7 +302,14 @@ products copy the exact contract through the existing KFD-1 contract registry.
    readiness. Missing, malformed, foreign, changed, or insufficient evidence
    fails closed.
 7. Qualify daemonless/no-fork behavior, process crash recovery, product
-   artifacts, and supported claims.
+   artifacts, and supported claims. **Complete:** the retained macOS arm64
+   qualification report records eight passing suites for daemonless and
+   no-fork behavior, concurrent activation, catch-up, crash/lease/idle
+   recovery, surface parity, measured performance, and the packaged product.
+   The report is bound to clean source revision `fb1574844`, product artifact
+   `20260714T092910Z-fb1574844`, and its documented SHA-256. Linux and Windows
+   remain contract/CI surfaces; production `EmbeddedRuntimeHost`, HA or
+   replication, and physical power-cut behavior remain explicit non-claims.
 
 Stages 2-7 may refine internal classes, but changing the public requirement,
 readiness, generation, lease, receipt, or error semantics requires an explicit

--- a/docs/document-metadata.contract.json
+++ b/docs/document-metadata.contract.json
@@ -118,6 +118,7 @@
         "docs/research/rust-host-spike.md",
         "docs/qualification/layer-gate-timing-baseline.md",
         "docs/qualification/single-host-performance-qualification.md",
+        "docs/qualification/runtime-activation-and-product-delivery.md",
         "docs/qualification/evidence/durability/12dd26e899/README.md",
         "docs/architecture/carrier-type-registry.md",
         "docs/architecture/strong-durability-and-crash-recovery-design.md",

--- a/docs/document-metadata.registry.json
+++ b/docs/document-metadata.registry.json
@@ -554,6 +554,22 @@
       "evidence_grade": "B",
       "last_reviewed": "2026-07-14"
     },
+    "docs/qualification/evidence/runtime-activation/8643f1187/README.md": {
+      "metadata_schema": "kungfu.document-metadata/v1",
+      "document_status": "active",
+      "doc_type": "qualification-evidence-index",
+      "review_state": "self-reviewed",
+      "sensitivity": "public",
+      "sources": [
+        "executable-probe",
+        "local-files"
+      ],
+      "period": "2026-07-14",
+      "theme": "runtime-activation-product-qualification",
+      "confidence": "high",
+      "evidence_grade": "B",
+      "last_reviewed": "2026-07-14"
+    },
     "docs/qualification/evidence/runtime-activation/fb1574844/README.md": {
       "metadata_schema": "kungfu.document-metadata/v1",
       "document_status": "active",

--- a/docs/document-metadata.registry.json
+++ b/docs/document-metadata.registry.json
@@ -522,6 +522,22 @@
       "evidence_grade": "A",
       "last_reviewed": "2026-07-14"
     },
+    "docs/qualification/evidence/runtime-activation/080f330db/README.md": {
+      "metadata_schema": "kungfu.document-metadata/v1",
+      "document_status": "active",
+      "doc_type": "qualification-evidence-index",
+      "review_state": "self-reviewed",
+      "sensitivity": "public",
+      "sources": [
+        "executable-probe",
+        "local-files"
+      ],
+      "period": "2026-07-14",
+      "theme": "runtime-activation-product-qualification",
+      "confidence": "high",
+      "evidence_grade": "B",
+      "last_reviewed": "2026-07-14"
+    },
     "docs/qualification/evidence/runtime-activation/fb1574844/README.md": {
       "metadata_schema": "kungfu.document-metadata/v1",
       "document_status": "active",

--- a/docs/document-metadata.registry.json
+++ b/docs/document-metadata.registry.json
@@ -538,6 +538,22 @@
       "evidence_grade": "B",
       "last_reviewed": "2026-07-14"
     },
+    "docs/qualification/evidence/runtime-activation/fea9ea4ae/README.md": {
+      "metadata_schema": "kungfu.document-metadata/v1",
+      "document_status": "active",
+      "doc_type": "qualification-evidence-index",
+      "review_state": "self-reviewed",
+      "sensitivity": "public",
+      "sources": [
+        "executable-probe",
+        "local-files"
+      ],
+      "period": "2026-07-14",
+      "theme": "runtime-activation-product-qualification",
+      "confidence": "high",
+      "evidence_grade": "B",
+      "last_reviewed": "2026-07-14"
+    },
     "docs/qualification/gates/README.md": {
       "metadata_schema": "kungfu.document-metadata/v1",
       "document_status": "active",

--- a/docs/document-metadata.registry.json
+++ b/docs/document-metadata.registry.json
@@ -538,6 +538,22 @@
       "evidence_grade": "B",
       "last_reviewed": "2026-07-14"
     },
+    "docs/qualification/evidence/runtime-activation/527652f13/README.md": {
+      "metadata_schema": "kungfu.document-metadata/v1",
+      "document_status": "active",
+      "doc_type": "qualification-evidence-index",
+      "review_state": "self-reviewed",
+      "sensitivity": "public",
+      "sources": [
+        "executable-probe",
+        "local-files"
+      ],
+      "period": "2026-07-14",
+      "theme": "runtime-activation-product-qualification",
+      "confidence": "high",
+      "evidence_grade": "B",
+      "last_reviewed": "2026-07-14"
+    },
     "docs/qualification/evidence/runtime-activation/fb1574844/README.md": {
       "metadata_schema": "kungfu.document-metadata/v1",
       "document_status": "active",

--- a/docs/document-metadata.registry.json
+++ b/docs/document-metadata.registry.json
@@ -522,6 +522,22 @@
       "evidence_grade": "A",
       "last_reviewed": "2026-07-14"
     },
+    "docs/qualification/evidence/runtime-activation/fb1574844/README.md": {
+      "metadata_schema": "kungfu.document-metadata/v1",
+      "document_status": "active",
+      "doc_type": "qualification-evidence-index",
+      "review_state": "self-reviewed",
+      "sensitivity": "public",
+      "sources": [
+        "executable-probe",
+        "local-files"
+      ],
+      "period": "2026-07-14",
+      "theme": "runtime-activation-product-qualification",
+      "confidence": "high",
+      "evidence_grade": "B",
+      "last_reviewed": "2026-07-14"
+    },
     "docs/qualification/gates/README.md": {
       "metadata_schema": "kungfu.document-metadata/v1",
       "document_status": "active",

--- a/docs/qualification/README.md
+++ b/docs/qualification/README.md
@@ -6,6 +6,7 @@ implemented behavior, retained evidence, and released guarantees. Begin with
 
 - [Contracts](contracts.md)
 - [Known Limits](known-limits.md)
+- [Runtime Activation and Product Delivery](runtime-activation-and-product-delivery.md)
 - [Strong Durability and Crash Recovery](durability-and-crash-recovery.md)
 - [Durability Qualification Harness](../../framework/core/tests/qualification/durability/README.md)
 - [Current-hardware Production-candidate Admission Evidence](evidence/durability/production-candidate-v1/README.md)

--- a/docs/qualification/contracts.md
+++ b/docs/qualification/contracts.md
@@ -171,7 +171,9 @@ The source gate validates four positive contract cases and rejects PID-as-
 readiness, dual active generations, ready without a cut, authority broadening,
 GUI-only activation, and silent live-required downgrade.
 
-**Maturity.** Staged. The contract, registry integration, fixtures, source gate,
+**Maturity.** Qualified for the named current-platform process-host envelope;
+not a universal host or platform claim. The contract, registry integration,
+fixtures, source gate,
 ProcessRuntimeHost placement adapter, directly callable CoordinatorEngine
 no-fork seam, contract-owned operation registry, and RuntimeCapabilityBroker
 atomic invocation seam are implemented. Storage-only qualification proves that
@@ -186,8 +188,12 @@ generation supervisor adoption, untracked-orphan termination, and a bounded
 crash restart window using
 [`runtime-lease-recovery`](../../tests/fixtures/runtime-lease-recovery). The
 route heartbeat TTL remains diagnostic and does not satisfy the semantic lease
-contract. Full language/product projection and product qualification land in
-later stages. Cross-machine leases, distributed election, high availability,
+contract. The language/product projection and retained product qualification
+are defined by
+[Runtime activation and product delivery](runtime-activation-and-product-delivery.md).
+Native readiness coordinates are published only after the existing authorities
+establish the exact cut and are revalidated again when consumed. Cross-machine
+leases, distributed election, high availability, other unexecuted platforms,
 and EmbeddedRuntimeHost remain explicit non-claims.
 
 ## Agent session control has one PTY owner and one interaction port

--- a/docs/qualification/evidence/runtime-activation/080f330db/README.md
+++ b/docs/qualification/evidence/runtime-activation/080f330db/README.md
@@ -1,0 +1,36 @@
+# Runtime activation product evidence at `080f330db`
+
+This directory retains the complete machine report from the clean-source
+Darwin arm64 execution at revision
+`080f330dbdc6660c7c4c73a10f106469f0a63f86` and tree
+`6f5bda9df4848df9b27f9e64f4af3d3db66c960d`.
+
+The exact command was:
+
+```sh
+./shifu runtime:qualify -- --mode execute --with-product
+```
+
+The report passed all eight required suites: activation Core, Profile action
+admission, runtime-surface parity, bounded performance, product distribution,
+frozen-product runtime smoke, full product verification, and the local product
+catalog. `product-verification` contains a passing `82/82` full verification
+run with the app artifact and sanitizer corpus. The run registered product
+artifact `20260714T104706Z-080f330db`.
+
+| Evidence | SHA-256 |
+|---|---|
+| `report.json` | `2d9195177b57feb180e76857ce70936055824e7bc40db079b6b84cad3a44a7e7` |
+
+The adjacent raw suite logs remain local Buildchain output; the retained report
+records their individual SHA-256 values so a preserved raw run can be matched
+without treating logs as a second authority.
+
+## Claim boundary
+
+This report supports the process-host, named-platform statement in the
+[qualification contract](../../../runtime-activation-and-product-delivery.md).
+It does not qualify a production `EmbeddedRuntimeHost`, distributed election,
+cross-machine leases, HA, physical-host power loss, default-on production
+durability/projection candidates, a universal latency SLO, interactive GUI
+pixels, or Linux/Windows products.

--- a/docs/qualification/evidence/runtime-activation/080f330db/report.json
+++ b/docs/qualification/evidence/runtime-activation/080f330db/report.json
@@ -1,0 +1,246 @@
+{
+  "schema": "kungfu.runtime-activation.qualification-report/v1",
+  "run_id": "runtime-activation-1784025794402-89628",
+  "mode": "execute",
+  "product_mode": "required",
+  "source": {
+    "revision": "080f330dbdc6660c7c4c73a10f106469f0a63f86",
+    "tree": "6f5bda9df4848df9b27f9e64f4af3d3db66c960d",
+    "dirty": false
+  },
+  "platform": {
+    "os": "darwin",
+    "arch": "arm64",
+    "release": "25.5.0"
+  },
+  "suites": [
+    {
+      "id": "activation-core",
+      "command": [
+        "./shifu",
+        "exec",
+        "uv",
+        "run",
+        "--project",
+        "framework/core",
+        "python",
+        "-m",
+        "pytest",
+        "framework/core/tests/python/test_runtime_broker.py",
+        "framework/core/tests/python/test_runtime_service.py",
+        "-q"
+      ],
+      "required": true,
+      "status": "passed",
+      "exit_code": 0,
+      "duration_ms": 6117,
+      "raw_log": "activation-core.log",
+      "raw_sha256": "08d9e3636394241ae693bb98332cb963a23dc0c281778567579797bd620b2642"
+    },
+    {
+      "id": "profile-action-admission",
+      "command": [
+        "./shifu",
+        "exec",
+        "uv",
+        "run",
+        "--project",
+        "framework/core",
+        "node",
+        "scripts/run-agent-profile-sdk-tests.mjs"
+      ],
+      "required": true,
+      "status": "passed",
+      "exit_code": 0,
+      "duration_ms": 61292,
+      "raw_log": "profile-action-admission.log",
+      "raw_sha256": "c4ccfdc79cc4cb79d7f6df75e4291569938fd201f5325b92f231915324cce0fa"
+    },
+    {
+      "id": "runtime-surface-parity",
+      "command": [
+        "./shifu",
+        "test:runtime-surface"
+      ],
+      "required": true,
+      "status": "passed",
+      "exit_code": 0,
+      "duration_ms": 2339,
+      "raw_log": "runtime-surface-parity.log",
+      "raw_sha256": "d1ef0a69178cb705f0eca3ed91ba400d604c9e1ada0c2c2bf56b5f5898e11174"
+    },
+    {
+      "id": "activation-performance",
+      "command": [
+        "./shifu",
+        "exec",
+        "uv",
+        "run",
+        "--project",
+        "framework/core",
+        "python",
+        "framework/core/tests/qualification/runtime-activation/performance_workload.py"
+      ],
+      "required": true,
+      "status": "passed",
+      "exit_code": 0,
+      "duration_ms": 4989,
+      "raw_log": "activation-performance.log",
+      "raw_sha256": "60baa63947ff4db495619bdf357a8f21c01a11b274f6a264c4208876c3ebcd9b"
+    },
+    {
+      "id": "product-distribution",
+      "command": [
+        "./shifu",
+        "dist"
+      ],
+      "required": true,
+      "status": "passed",
+      "exit_code": 0,
+      "duration_ms": 159085,
+      "raw_log": "product-distribution.log",
+      "raw_sha256": "bb284a1f192d4ac08a408286da12e444e7f04f376a2ba75ba4d0b7508e992e78"
+    },
+    {
+      "id": "product-runtime-smoke",
+      "command": [
+        "./shifu",
+        "exec",
+        "/Users/dkr/.local/share/fnm/node-versions/v22.22.3/installation/bin/node",
+        "framework/core/tests/qualification/runtime-activation/product_smoke.mjs"
+      ],
+      "required": true,
+      "status": "passed",
+      "exit_code": 0,
+      "duration_ms": 6364,
+      "raw_log": "product-runtime-smoke.log",
+      "raw_sha256": "44c2537965a9ca16ec316d86dcff34f03999afa31f9960d2fc6cf488a296287e"
+    },
+    {
+      "id": "product-verification",
+      "command": [
+        "./shifu",
+        "verify",
+        "--full",
+        "--with-app"
+      ],
+      "required": true,
+      "status": "passed",
+      "exit_code": 0,
+      "duration_ms": 268903,
+      "raw_log": "product-verification.log",
+      "raw_sha256": "737a950e20a455c7306cc7879f2bf00acad0eade74afbec8b9c9e549e2189c62"
+    },
+    {
+      "id": "product-catalog",
+      "command": [
+        "./shifu",
+        "builds",
+        "--json"
+      ],
+      "required": true,
+      "status": "passed",
+      "exit_code": 0,
+      "duration_ms": 2927,
+      "raw_log": "product-catalog.log",
+      "raw_sha256": "2e110989b4095135d65800987ad891c87f607f6fe9c0bd68d5f72b06752f8c40"
+    }
+  ],
+  "coverage": [
+    {
+      "id": "daemonless-storage",
+      "evidence_suites": [
+        "activation-core"
+      ],
+      "status": "passed"
+    },
+    {
+      "id": "direct-no-fork-coordinator",
+      "evidence_suites": [
+        "activation-core"
+      ],
+      "status": "passed"
+    },
+    {
+      "id": "process-crash-recovery",
+      "evidence_suites": [
+        "activation-core"
+      ],
+      "status": "passed"
+    },
+    {
+      "id": "native-readiness-publication",
+      "evidence_suites": [
+        "activation-core"
+      ],
+      "status": "passed"
+    },
+    {
+      "id": "profile-action-admission",
+      "evidence_suites": [
+        "profile-action-admission"
+      ],
+      "status": "passed"
+    },
+    {
+      "id": "language-product-parity",
+      "evidence_suites": [
+        "runtime-surface-parity"
+      ],
+      "status": "passed"
+    },
+    {
+      "id": "bounded-latency-and-resource-report",
+      "evidence_suites": [
+        "activation-performance"
+      ],
+      "status": "passed"
+    },
+    {
+      "id": "product-artifact-build",
+      "evidence_suites": [
+        "product-distribution"
+      ],
+      "status": "passed"
+    },
+    {
+      "id": "temporary-product-runtime-smoke",
+      "evidence_suites": [
+        "product-runtime-smoke"
+      ],
+      "status": "passed"
+    },
+    {
+      "id": "product-artifact-verification",
+      "evidence_suites": [
+        "product-verification"
+      ],
+      "status": "passed"
+    },
+    {
+      "id": "product-artifact-catalog",
+      "evidence_suites": [
+        "product-catalog"
+      ],
+      "status": "passed"
+    }
+  ],
+  "claims": {
+    "daemonless_storage_operations": true,
+    "direct_no_fork_coordinator": true,
+    "process_crash_recovery": true,
+    "native_readiness_publication": true,
+    "product_artifacts_verified": true,
+    "embedded_runtime_host": false
+  },
+  "non_claims": [
+    "production EmbeddedRuntimeHost",
+    "distributed election, cross-machine leases, or high availability",
+    "physical-host power-loss qualification from process-crash evidence",
+    "default-on production durability or projection candidate profiles",
+    "universal startup, recovery, or activation latency SLO",
+    "readiness descriptor bytes as authority without native revalidation"
+  ],
+  "violations": [],
+  "verdict": "passed"
+}

--- a/docs/qualification/evidence/runtime-activation/527652f13/README.md
+++ b/docs/qualification/evidence/runtime-activation/527652f13/README.md
@@ -1,0 +1,36 @@
+# Runtime activation product evidence at `527652f13`
+
+This directory retains the complete machine report from the clean-source
+Darwin arm64 execution at revision
+`527652f1392359065fe18f8f89f8ad3727bbb202` and tree
+`51f8d268a095395d1fb1ff582c7595992b01dcc3`.
+
+The exact command was:
+
+```sh
+./shifu runtime:qualify -- --mode execute --with-product
+```
+
+The report passed all eight required suites: activation Core, Profile action
+admission, runtime-surface parity, bounded performance, product distribution,
+frozen-product runtime smoke, full product verification, and the local product
+catalog. `product-verification` contains a passing `82/82` full verification
+run with the app artifact and sanitizer corpus. The run registered product
+artifact `20260714T112358Z-527652f13`.
+
+| Evidence | SHA-256 |
+|---|---|
+| `report.json` | `ff1cf3a4177704b13d2c1154a3c3981faccaba9de759a57cdedfa45f235ddd3b` |
+
+The adjacent raw suite logs remain local Buildchain output; the retained report
+records their individual SHA-256 values so a preserved raw run can be matched
+without treating logs as a second authority.
+
+## Claim boundary
+
+This report supports the process-host, named-platform statement in the
+[qualification contract](../../../runtime-activation-and-product-delivery.md).
+It does not qualify a production `EmbeddedRuntimeHost`, distributed election,
+cross-machine leases, HA, physical-host power loss, default-on production
+durability/projection candidates, a universal latency SLO, interactive GUI
+pixels, or Linux/Windows products.

--- a/docs/qualification/evidence/runtime-activation/527652f13/report.json
+++ b/docs/qualification/evidence/runtime-activation/527652f13/report.json
@@ -1,0 +1,246 @@
+{
+  "schema": "kungfu.runtime-activation.qualification-report/v1",
+  "run_id": "runtime-activation-1784028035566-19345",
+  "mode": "execute",
+  "product_mode": "required",
+  "source": {
+    "revision": "527652f1392359065fe18f8f89f8ad3727bbb202",
+    "tree": "51f8d268a095395d1fb1ff582c7595992b01dcc3",
+    "dirty": false
+  },
+  "platform": {
+    "os": "darwin",
+    "arch": "arm64",
+    "release": "25.5.0"
+  },
+  "suites": [
+    {
+      "id": "activation-core",
+      "command": [
+        "./shifu",
+        "exec",
+        "uv",
+        "run",
+        "--project",
+        "framework/core",
+        "python",
+        "-m",
+        "pytest",
+        "framework/core/tests/python/test_runtime_broker.py",
+        "framework/core/tests/python/test_runtime_service.py",
+        "-q"
+      ],
+      "required": true,
+      "status": "passed",
+      "exit_code": 0,
+      "duration_ms": 16035,
+      "raw_log": "activation-core.log",
+      "raw_sha256": "7721c3484007d659b7e91c90cd9cad302d7efcaa27119ac6690081d8d453306b"
+    },
+    {
+      "id": "profile-action-admission",
+      "command": [
+        "./shifu",
+        "exec",
+        "uv",
+        "run",
+        "--project",
+        "framework/core",
+        "node",
+        "scripts/run-agent-profile-sdk-tests.mjs"
+      ],
+      "required": true,
+      "status": "passed",
+      "exit_code": 0,
+      "duration_ms": 50031,
+      "raw_log": "profile-action-admission.log",
+      "raw_sha256": "cc54e480439472e70e14885d56eecb02e74889ca61480c8589505b906ad37beb"
+    },
+    {
+      "id": "runtime-surface-parity",
+      "command": [
+        "./shifu",
+        "test:runtime-surface"
+      ],
+      "required": true,
+      "status": "passed",
+      "exit_code": 0,
+      "duration_ms": 2103,
+      "raw_log": "runtime-surface-parity.log",
+      "raw_sha256": "d1ef0a69178cb705f0eca3ed91ba400d604c9e1ada0c2c2bf56b5f5898e11174"
+    },
+    {
+      "id": "activation-performance",
+      "command": [
+        "./shifu",
+        "exec",
+        "uv",
+        "run",
+        "--project",
+        "framework/core",
+        "python",
+        "framework/core/tests/qualification/runtime-activation/performance_workload.py"
+      ],
+      "required": true,
+      "status": "passed",
+      "exit_code": 0,
+      "duration_ms": 4875,
+      "raw_log": "activation-performance.log",
+      "raw_sha256": "a514e26f4f4fd52037a2f8dbb64218d777863379ee2668bc02f027469a0ea62d"
+    },
+    {
+      "id": "product-distribution",
+      "command": [
+        "./shifu",
+        "dist"
+      ],
+      "required": true,
+      "status": "passed",
+      "exit_code": 0,
+      "duration_ms": 131754,
+      "raw_log": "product-distribution.log",
+      "raw_sha256": "e70eaceec2183e20d05e7e746732e23eee416f082126a5bea04a85dae6d0e7bc"
+    },
+    {
+      "id": "product-runtime-smoke",
+      "command": [
+        "./shifu",
+        "exec",
+        "/Users/dkr/.local/share/fnm/node-versions/v22.22.3/installation/bin/node",
+        "framework/core/tests/qualification/runtime-activation/product_smoke.mjs"
+      ],
+      "required": true,
+      "status": "passed",
+      "exit_code": 0,
+      "duration_ms": 6105,
+      "raw_log": "product-runtime-smoke.log",
+      "raw_sha256": "9fb34c83abac3975ffce5365bae332c8f42081325f2015a386461103ce831d3c"
+    },
+    {
+      "id": "product-verification",
+      "command": [
+        "./shifu",
+        "verify",
+        "--full",
+        "--with-app"
+      ],
+      "required": true,
+      "status": "passed",
+      "exit_code": 0,
+      "duration_ms": 232346,
+      "raw_log": "product-verification.log",
+      "raw_sha256": "73bfd9336c504c709aff0029797f1ea26e4672a4d73cfbf86bec468568828898"
+    },
+    {
+      "id": "product-catalog",
+      "command": [
+        "./shifu",
+        "builds",
+        "--json"
+      ],
+      "required": true,
+      "status": "passed",
+      "exit_code": 0,
+      "duration_ms": 2307,
+      "raw_log": "product-catalog.log",
+      "raw_sha256": "da38ef93d04807b6e0755ba2af6518fe9c7af32c58292fe65870a32cfe4ef1e9"
+    }
+  ],
+  "coverage": [
+    {
+      "id": "daemonless-storage",
+      "evidence_suites": [
+        "activation-core"
+      ],
+      "status": "passed"
+    },
+    {
+      "id": "direct-no-fork-coordinator",
+      "evidence_suites": [
+        "activation-core"
+      ],
+      "status": "passed"
+    },
+    {
+      "id": "process-crash-recovery",
+      "evidence_suites": [
+        "activation-core"
+      ],
+      "status": "passed"
+    },
+    {
+      "id": "native-readiness-publication",
+      "evidence_suites": [
+        "activation-core"
+      ],
+      "status": "passed"
+    },
+    {
+      "id": "profile-action-admission",
+      "evidence_suites": [
+        "profile-action-admission"
+      ],
+      "status": "passed"
+    },
+    {
+      "id": "language-product-parity",
+      "evidence_suites": [
+        "runtime-surface-parity"
+      ],
+      "status": "passed"
+    },
+    {
+      "id": "bounded-latency-and-resource-report",
+      "evidence_suites": [
+        "activation-performance"
+      ],
+      "status": "passed"
+    },
+    {
+      "id": "product-artifact-build",
+      "evidence_suites": [
+        "product-distribution"
+      ],
+      "status": "passed"
+    },
+    {
+      "id": "temporary-product-runtime-smoke",
+      "evidence_suites": [
+        "product-runtime-smoke"
+      ],
+      "status": "passed"
+    },
+    {
+      "id": "product-artifact-verification",
+      "evidence_suites": [
+        "product-verification"
+      ],
+      "status": "passed"
+    },
+    {
+      "id": "product-artifact-catalog",
+      "evidence_suites": [
+        "product-catalog"
+      ],
+      "status": "passed"
+    }
+  ],
+  "claims": {
+    "daemonless_storage_operations": true,
+    "direct_no_fork_coordinator": true,
+    "process_crash_recovery": true,
+    "native_readiness_publication": true,
+    "product_artifacts_verified": true,
+    "embedded_runtime_host": false
+  },
+  "non_claims": [
+    "production EmbeddedRuntimeHost",
+    "distributed election, cross-machine leases, or high availability",
+    "physical-host power-loss qualification from process-crash evidence",
+    "default-on production durability or projection candidate profiles",
+    "universal startup, recovery, or activation latency SLO",
+    "readiness descriptor bytes as authority without native revalidation"
+  ],
+  "violations": [],
+  "verdict": "passed"
+}

--- a/docs/qualification/evidence/runtime-activation/8643f1187/README.md
+++ b/docs/qualification/evidence/runtime-activation/8643f1187/README.md
@@ -1,0 +1,36 @@
+# Runtime activation product evidence at `8643f1187`
+
+This directory retains the complete machine report from the clean-source
+Darwin arm64 execution at revision
+`8643f118713e829dbef441501a0c444258383647` and tree
+`d9372b48f07e9677585724366bf746c2123184e1`.
+
+The exact command was:
+
+```sh
+./shifu runtime:qualify -- --mode execute --with-product
+```
+
+The report passed all eight required suites: activation Core, Profile action
+admission, runtime-surface parity, bounded performance, product distribution,
+frozen-product runtime smoke, full product verification, and the local product
+catalog. `product-verification` contains a passing `82/82` full verification
+run with the app artifact and sanitizer corpus. The run registered product
+artifact `20260714T113632Z-8643f1187`.
+
+| Evidence | SHA-256 |
+|---|---|
+| `report.json` | `be98265b8dffa96b45d38496b6dc27560daab88afc844588c74150fc8ff5594f` |
+
+The adjacent raw suite logs remain local Buildchain output; the retained report
+records their individual SHA-256 values so a preserved raw run can be matched
+without treating logs as a second authority.
+
+## Claim boundary
+
+This report supports the process-host, named-platform statement in the
+[qualification contract](../../../runtime-activation-and-product-delivery.md).
+It does not qualify a production `EmbeddedRuntimeHost`, distributed election,
+cross-machine leases, HA, physical-host power loss, default-on production
+durability/projection candidates, a universal latency SLO, interactive GUI
+pixels, or Linux/Windows products.

--- a/docs/qualification/evidence/runtime-activation/8643f1187/report.json
+++ b/docs/qualification/evidence/runtime-activation/8643f1187/report.json
@@ -1,0 +1,246 @@
+{
+  "schema": "kungfu.runtime-activation.qualification-report/v1",
+  "run_id": "runtime-activation-1784028785254-90513",
+  "mode": "execute",
+  "product_mode": "required",
+  "source": {
+    "revision": "8643f118713e829dbef441501a0c444258383647",
+    "tree": "d9372b48f07e9677585724366bf746c2123184e1",
+    "dirty": false
+  },
+  "platform": {
+    "os": "darwin",
+    "arch": "arm64",
+    "release": "25.5.0"
+  },
+  "suites": [
+    {
+      "id": "activation-core",
+      "command": [
+        "./shifu",
+        "exec",
+        "uv",
+        "run",
+        "--project",
+        "framework/core",
+        "python",
+        "-m",
+        "pytest",
+        "framework/core/tests/python/test_runtime_broker.py",
+        "framework/core/tests/python/test_runtime_service.py",
+        "-q"
+      ],
+      "required": true,
+      "status": "passed",
+      "exit_code": 0,
+      "duration_ms": 15931,
+      "raw_log": "activation-core.log",
+      "raw_sha256": "4bc7d816be3035240ffbf10f9561a3e3def86e722465236c1820a439dc0d94cd"
+    },
+    {
+      "id": "profile-action-admission",
+      "command": [
+        "./shifu",
+        "exec",
+        "uv",
+        "run",
+        "--project",
+        "framework/core",
+        "node",
+        "scripts/run-agent-profile-sdk-tests.mjs"
+      ],
+      "required": true,
+      "status": "passed",
+      "exit_code": 0,
+      "duration_ms": 55495,
+      "raw_log": "profile-action-admission.log",
+      "raw_sha256": "cada2d3944d16539d82efe229b1c5b4c6891a186d7782f048aee392dc1bb099a"
+    },
+    {
+      "id": "runtime-surface-parity",
+      "command": [
+        "./shifu",
+        "test:runtime-surface"
+      ],
+      "required": true,
+      "status": "passed",
+      "exit_code": 0,
+      "duration_ms": 2187,
+      "raw_log": "runtime-surface-parity.log",
+      "raw_sha256": "d1ef0a69178cb705f0eca3ed91ba400d604c9e1ada0c2c2bf56b5f5898e11174"
+    },
+    {
+      "id": "activation-performance",
+      "command": [
+        "./shifu",
+        "exec",
+        "uv",
+        "run",
+        "--project",
+        "framework/core",
+        "python",
+        "framework/core/tests/qualification/runtime-activation/performance_workload.py"
+      ],
+      "required": true,
+      "status": "passed",
+      "exit_code": 0,
+      "duration_ms": 4558,
+      "raw_log": "activation-performance.log",
+      "raw_sha256": "d8a69f7853d3fcccba0b6f1681ff834a8d1b84f72cf617041e4a4377f7974d03"
+    },
+    {
+      "id": "product-distribution",
+      "command": [
+        "./shifu",
+        "dist"
+      ],
+      "required": true,
+      "status": "passed",
+      "exit_code": 0,
+      "duration_ms": 131220,
+      "raw_log": "product-distribution.log",
+      "raw_sha256": "fc91f9ed97279010754623ec1268878ff809695d21d0591159697f0032545282"
+    },
+    {
+      "id": "product-runtime-smoke",
+      "command": [
+        "./shifu",
+        "exec",
+        "/Users/dkr/.local/share/fnm/node-versions/v22.22.3/installation/bin/node",
+        "framework/core/tests/qualification/runtime-activation/product_smoke.mjs"
+      ],
+      "required": true,
+      "status": "passed",
+      "exit_code": 0,
+      "duration_ms": 6134,
+      "raw_log": "product-runtime-smoke.log",
+      "raw_sha256": "50cfc13c90545928405d7b5b16c8be5a47593e995befa8832569d2d933ebecf5"
+    },
+    {
+      "id": "product-verification",
+      "command": [
+        "./shifu",
+        "verify",
+        "--full",
+        "--with-app"
+      ],
+      "required": true,
+      "status": "passed",
+      "exit_code": 0,
+      "duration_ms": 243151,
+      "raw_log": "product-verification.log",
+      "raw_sha256": "bace7c8d0e71c4ad38d94d7326dfae5cf8f512c19d7771ceef95e742b93c9adb"
+    },
+    {
+      "id": "product-catalog",
+      "command": [
+        "./shifu",
+        "builds",
+        "--json"
+      ],
+      "required": true,
+      "status": "passed",
+      "exit_code": 0,
+      "duration_ms": 2736,
+      "raw_log": "product-catalog.log",
+      "raw_sha256": "08d84398313883ba866548876fc9208072b57300790163713ab59058f740b34e"
+    }
+  ],
+  "coverage": [
+    {
+      "id": "daemonless-storage",
+      "evidence_suites": [
+        "activation-core"
+      ],
+      "status": "passed"
+    },
+    {
+      "id": "direct-no-fork-coordinator",
+      "evidence_suites": [
+        "activation-core"
+      ],
+      "status": "passed"
+    },
+    {
+      "id": "process-crash-recovery",
+      "evidence_suites": [
+        "activation-core"
+      ],
+      "status": "passed"
+    },
+    {
+      "id": "native-readiness-publication",
+      "evidence_suites": [
+        "activation-core"
+      ],
+      "status": "passed"
+    },
+    {
+      "id": "profile-action-admission",
+      "evidence_suites": [
+        "profile-action-admission"
+      ],
+      "status": "passed"
+    },
+    {
+      "id": "language-product-parity",
+      "evidence_suites": [
+        "runtime-surface-parity"
+      ],
+      "status": "passed"
+    },
+    {
+      "id": "bounded-latency-and-resource-report",
+      "evidence_suites": [
+        "activation-performance"
+      ],
+      "status": "passed"
+    },
+    {
+      "id": "product-artifact-build",
+      "evidence_suites": [
+        "product-distribution"
+      ],
+      "status": "passed"
+    },
+    {
+      "id": "temporary-product-runtime-smoke",
+      "evidence_suites": [
+        "product-runtime-smoke"
+      ],
+      "status": "passed"
+    },
+    {
+      "id": "product-artifact-verification",
+      "evidence_suites": [
+        "product-verification"
+      ],
+      "status": "passed"
+    },
+    {
+      "id": "product-artifact-catalog",
+      "evidence_suites": [
+        "product-catalog"
+      ],
+      "status": "passed"
+    }
+  ],
+  "claims": {
+    "daemonless_storage_operations": true,
+    "direct_no_fork_coordinator": true,
+    "process_crash_recovery": true,
+    "native_readiness_publication": true,
+    "product_artifacts_verified": true,
+    "embedded_runtime_host": false
+  },
+  "non_claims": [
+    "production EmbeddedRuntimeHost",
+    "distributed election, cross-machine leases, or high availability",
+    "physical-host power-loss qualification from process-crash evidence",
+    "default-on production durability or projection candidate profiles",
+    "universal startup, recovery, or activation latency SLO",
+    "readiness descriptor bytes as authority without native revalidation"
+  ],
+  "violations": [],
+  "verdict": "passed"
+}

--- a/docs/qualification/evidence/runtime-activation/fb1574844/README.md
+++ b/docs/qualification/evidence/runtime-activation/fb1574844/README.md
@@ -1,0 +1,35 @@
+# Runtime activation product evidence at `fb1574844`
+
+This directory retains the complete machine report from the clean-source
+Darwin arm64 execution at revision
+`fb157484432c36345903ea2d64fab301f365b083` and tree
+`93197395730b9c474b35143a266318009d22b943`.
+
+The exact command was:
+
+```sh
+./shifu runtime:qualify -- --mode execute --with-product
+```
+
+The report passed all eight required suites: activation Core, Profile action
+admission, runtime-surface parity, bounded performance, product distribution,
+frozen-product runtime smoke, full product verification, and the local product
+catalog. `product-verification` contains a passing `82/82` full verification
+run with the app artifact and sanitizer corpus.
+
+| Evidence | SHA-256 |
+|---|---|
+| `report.json` | `deb7f424f3d1b9999d085d92df0b407e53bc6b3156d3dddfdfbe01d762c7093c` |
+
+The adjacent raw suite logs remain local Buildchain output; the retained report
+records their individual SHA-256 values so a preserved raw run can be matched
+without treating logs as a second authority.
+
+## Claim boundary
+
+This report supports the process-host, named-platform statement in the
+[qualification contract](../../../runtime-activation-and-product-delivery.md).
+It does not qualify a production `EmbeddedRuntimeHost`, distributed election,
+cross-machine leases, HA, physical-host power loss, default-on production
+durability/projection candidates, a universal latency SLO, interactive GUI
+pixels, or Linux/Windows products.

--- a/docs/qualification/evidence/runtime-activation/fb1574844/report.json
+++ b/docs/qualification/evidence/runtime-activation/fb1574844/report.json
@@ -1,0 +1,246 @@
+{
+  "schema": "kungfu.runtime-activation.qualification-report/v1",
+  "run_id": "runtime-activation-1784021116556-82586",
+  "mode": "execute",
+  "product_mode": "required",
+  "source": {
+    "revision": "fb157484432c36345903ea2d64fab301f365b083",
+    "tree": "93197395730b9c474b35143a266318009d22b943",
+    "dirty": false
+  },
+  "platform": {
+    "os": "darwin",
+    "arch": "arm64",
+    "release": "25.5.0"
+  },
+  "suites": [
+    {
+      "id": "activation-core",
+      "command": [
+        "./shifu",
+        "exec",
+        "uv",
+        "run",
+        "--project",
+        "framework/core",
+        "python",
+        "-m",
+        "pytest",
+        "framework/core/tests/python/test_runtime_broker.py",
+        "framework/core/tests/python/test_runtime_service.py",
+        "-q"
+      ],
+      "required": true,
+      "status": "passed",
+      "exit_code": 0,
+      "duration_ms": 19408,
+      "raw_log": "activation-core.log",
+      "raw_sha256": "0dcc18c021228af3f98b7ede49ac4c4e74a6f91dd22ba1c253f3b9963d416410"
+    },
+    {
+      "id": "profile-action-admission",
+      "command": [
+        "./shifu",
+        "exec",
+        "uv",
+        "run",
+        "--project",
+        "framework/core",
+        "node",
+        "scripts/run-agent-profile-sdk-tests.mjs"
+      ],
+      "required": true,
+      "status": "passed",
+      "exit_code": 0,
+      "duration_ms": 63548,
+      "raw_log": "profile-action-admission.log",
+      "raw_sha256": "2a28173c33e350fd1139185a00d431a75a9fff7b7c8ebcc16d574c1be3ce7813"
+    },
+    {
+      "id": "runtime-surface-parity",
+      "command": [
+        "./shifu",
+        "test:runtime-surface"
+      ],
+      "required": true,
+      "status": "passed",
+      "exit_code": 0,
+      "duration_ms": 2176,
+      "raw_log": "runtime-surface-parity.log",
+      "raw_sha256": "d1ef0a69178cb705f0eca3ed91ba400d604c9e1ada0c2c2bf56b5f5898e11174"
+    },
+    {
+      "id": "activation-performance",
+      "command": [
+        "./shifu",
+        "exec",
+        "uv",
+        "run",
+        "--project",
+        "framework/core",
+        "python",
+        "framework/core/tests/qualification/runtime-activation/performance_workload.py"
+      ],
+      "required": true,
+      "status": "passed",
+      "exit_code": 0,
+      "duration_ms": 4759,
+      "raw_log": "activation-performance.log",
+      "raw_sha256": "3ea6a5c89151c78c698eefd5a2f95ec21f322025ece7299bde96dee0bdb730d6"
+    },
+    {
+      "id": "product-distribution",
+      "command": [
+        "./shifu",
+        "dist"
+      ],
+      "required": true,
+      "status": "passed",
+      "exit_code": 0,
+      "duration_ms": 145914,
+      "raw_log": "product-distribution.log",
+      "raw_sha256": "cb09b83752945e833f8abcc7d6a0ab5d5dfd55892273e67547d4657df04e5c9e"
+    },
+    {
+      "id": "product-runtime-smoke",
+      "command": [
+        "./shifu",
+        "exec",
+        "/Users/dkr/.local/share/fnm/node-versions/v22.22.3/installation/bin/node",
+        "framework/core/tests/qualification/runtime-activation/product_smoke.mjs"
+      ],
+      "required": true,
+      "status": "passed",
+      "exit_code": 0,
+      "duration_ms": 6267,
+      "raw_log": "product-runtime-smoke.log",
+      "raw_sha256": "5d0bc7261dacc41f8ce479f8786e155965b3b291df1722b1b26f1807b7f89941"
+    },
+    {
+      "id": "product-verification",
+      "command": [
+        "./shifu",
+        "verify",
+        "--full",
+        "--with-app"
+      ],
+      "required": true,
+      "status": "passed",
+      "exit_code": 0,
+      "duration_ms": 273234,
+      "raw_log": "product-verification.log",
+      "raw_sha256": "fdae47b6f707c0ee15e98a49bddce4a3dacae8c4090579b036c9beb36baed80d"
+    },
+    {
+      "id": "product-catalog",
+      "command": [
+        "./shifu",
+        "builds",
+        "--json"
+      ],
+      "required": true,
+      "status": "passed",
+      "exit_code": 0,
+      "duration_ms": 2164,
+      "raw_log": "product-catalog.log",
+      "raw_sha256": "b937ee4ff98b27ee986c394fd4aa0725c2c33ca6c7532b7b08db006c1f68f4f6"
+    }
+  ],
+  "coverage": [
+    {
+      "id": "daemonless-storage",
+      "evidence_suites": [
+        "activation-core"
+      ],
+      "status": "passed"
+    },
+    {
+      "id": "direct-no-fork-coordinator",
+      "evidence_suites": [
+        "activation-core"
+      ],
+      "status": "passed"
+    },
+    {
+      "id": "process-crash-recovery",
+      "evidence_suites": [
+        "activation-core"
+      ],
+      "status": "passed"
+    },
+    {
+      "id": "native-readiness-publication",
+      "evidence_suites": [
+        "activation-core"
+      ],
+      "status": "passed"
+    },
+    {
+      "id": "profile-action-admission",
+      "evidence_suites": [
+        "profile-action-admission"
+      ],
+      "status": "passed"
+    },
+    {
+      "id": "language-product-parity",
+      "evidence_suites": [
+        "runtime-surface-parity"
+      ],
+      "status": "passed"
+    },
+    {
+      "id": "bounded-latency-and-resource-report",
+      "evidence_suites": [
+        "activation-performance"
+      ],
+      "status": "passed"
+    },
+    {
+      "id": "product-artifact-build",
+      "evidence_suites": [
+        "product-distribution"
+      ],
+      "status": "passed"
+    },
+    {
+      "id": "temporary-product-runtime-smoke",
+      "evidence_suites": [
+        "product-runtime-smoke"
+      ],
+      "status": "passed"
+    },
+    {
+      "id": "product-artifact-verification",
+      "evidence_suites": [
+        "product-verification"
+      ],
+      "status": "passed"
+    },
+    {
+      "id": "product-artifact-catalog",
+      "evidence_suites": [
+        "product-catalog"
+      ],
+      "status": "passed"
+    }
+  ],
+  "claims": {
+    "daemonless_storage_operations": true,
+    "direct_no_fork_coordinator": true,
+    "process_crash_recovery": true,
+    "native_readiness_publication": true,
+    "product_artifacts_verified": true,
+    "embedded_runtime_host": false
+  },
+  "non_claims": [
+    "production EmbeddedRuntimeHost",
+    "distributed election, cross-machine leases, or high availability",
+    "physical-host power-loss qualification from process-crash evidence",
+    "default-on production durability or projection candidate profiles",
+    "universal startup, recovery, or activation latency SLO",
+    "readiness descriptor bytes as authority without native revalidation"
+  ],
+  "violations": [],
+  "verdict": "passed"
+}

--- a/docs/qualification/evidence/runtime-activation/fea9ea4ae/README.md
+++ b/docs/qualification/evidence/runtime-activation/fea9ea4ae/README.md
@@ -1,0 +1,36 @@
+# Runtime activation product evidence at `fea9ea4ae`
+
+This directory retains the complete machine report from the clean-source
+Darwin arm64 execution at revision
+`fea9ea4ae8b7fd57ed1ac0616403c91d91070033` and tree
+`0f7e7367e96b1dea698de25c2672931bb257cd69`.
+
+The exact command was:
+
+```sh
+./shifu runtime:qualify -- --mode execute --with-product
+```
+
+The report passed all eight required suites: activation Core, Profile action
+admission, runtime-surface parity, bounded performance, product distribution,
+frozen-product runtime smoke, full product verification, and the local product
+catalog. `product-verification` contains a passing `82/82` full verification
+run with the app artifact and sanitizer corpus. The run registered product
+artifact `20260714T102912Z-fea9ea4ae`.
+
+| Evidence | SHA-256 |
+|---|---|
+| `report.json` | `e2992dfb9d45708a0693f71a3766dd944392df35dc078adc217a28e8e60bad11` |
+
+The adjacent raw suite logs remain local Buildchain output; the retained report
+records their individual SHA-256 values so a preserved raw run can be matched
+without treating logs as a second authority.
+
+## Claim boundary
+
+This report supports the process-host, named-platform statement in the
+[qualification contract](../../../runtime-activation-and-product-delivery.md).
+It does not qualify a production `EmbeddedRuntimeHost`, distributed election,
+cross-machine leases, HA, physical-host power loss, default-on production
+durability/projection candidates, a universal latency SLO, interactive GUI
+pixels, or Linux/Windows products.

--- a/docs/qualification/evidence/runtime-activation/fea9ea4ae/report.json
+++ b/docs/qualification/evidence/runtime-activation/fea9ea4ae/report.json
@@ -1,0 +1,246 @@
+{
+  "schema": "kungfu.runtime-activation.qualification-report/v1",
+  "run_id": "runtime-activation-1784024705188-69717",
+  "mode": "execute",
+  "product_mode": "required",
+  "source": {
+    "revision": "fea9ea4ae8b7fd57ed1ac0616403c91d91070033",
+    "tree": "0f7e7367e96b1dea698de25c2672931bb257cd69",
+    "dirty": false
+  },
+  "platform": {
+    "os": "darwin",
+    "arch": "arm64",
+    "release": "25.5.0"
+  },
+  "suites": [
+    {
+      "id": "activation-core",
+      "command": [
+        "./shifu",
+        "exec",
+        "uv",
+        "run",
+        "--project",
+        "framework/core",
+        "python",
+        "-m",
+        "pytest",
+        "framework/core/tests/python/test_runtime_broker.py",
+        "framework/core/tests/python/test_runtime_service.py",
+        "-q"
+      ],
+      "required": true,
+      "status": "passed",
+      "exit_code": 0,
+      "duration_ms": 17782,
+      "raw_log": "activation-core.log",
+      "raw_sha256": "e408bf0fd8e17f0a048a9d9f086916377882dfa294eef8934a4bcc74426d8f20"
+    },
+    {
+      "id": "profile-action-admission",
+      "command": [
+        "./shifu",
+        "exec",
+        "uv",
+        "run",
+        "--project",
+        "framework/core",
+        "node",
+        "scripts/run-agent-profile-sdk-tests.mjs"
+      ],
+      "required": true,
+      "status": "passed",
+      "exit_code": 0,
+      "duration_ms": 71373,
+      "raw_log": "profile-action-admission.log",
+      "raw_sha256": "c0c3b60c051b4781281ccfc3187e7653f53b100f9acd3e1a34743b422731b433"
+    },
+    {
+      "id": "runtime-surface-parity",
+      "command": [
+        "./shifu",
+        "test:runtime-surface"
+      ],
+      "required": true,
+      "status": "passed",
+      "exit_code": 0,
+      "duration_ms": 2260,
+      "raw_log": "runtime-surface-parity.log",
+      "raw_sha256": "d1ef0a69178cb705f0eca3ed91ba400d604c9e1ada0c2c2bf56b5f5898e11174"
+    },
+    {
+      "id": "activation-performance",
+      "command": [
+        "./shifu",
+        "exec",
+        "uv",
+        "run",
+        "--project",
+        "framework/core",
+        "python",
+        "framework/core/tests/qualification/runtime-activation/performance_workload.py"
+      ],
+      "required": true,
+      "status": "passed",
+      "exit_code": 0,
+      "duration_ms": 4364,
+      "raw_log": "activation-performance.log",
+      "raw_sha256": "9f00ce742be8b39531203a48dad70936cf7f75e51885927e2d1500f91c39baeb"
+    },
+    {
+      "id": "product-distribution",
+      "command": [
+        "./shifu",
+        "dist"
+      ],
+      "required": true,
+      "status": "passed",
+      "exit_code": 0,
+      "duration_ms": 155069,
+      "raw_log": "product-distribution.log",
+      "raw_sha256": "5bcdd07baa310de29f82a4c48a57300bbbd16f8c0de20848d14f0b1f968aece2"
+    },
+    {
+      "id": "product-runtime-smoke",
+      "command": [
+        "./shifu",
+        "exec",
+        "/Users/dkr/.local/share/fnm/node-versions/v22.22.3/installation/bin/node",
+        "framework/core/tests/qualification/runtime-activation/product_smoke.mjs"
+      ],
+      "required": true,
+      "status": "passed",
+      "exit_code": 0,
+      "duration_ms": 9652,
+      "raw_log": "product-runtime-smoke.log",
+      "raw_sha256": "1fabe35abdde0ba2cdd73ce03c73570972acbea216bdb973f02b549941c8009c"
+    },
+    {
+      "id": "product-verification",
+      "command": [
+        "./shifu",
+        "verify",
+        "--full",
+        "--with-app"
+      ],
+      "required": true,
+      "status": "passed",
+      "exit_code": 0,
+      "duration_ms": 322821,
+      "raw_log": "product-verification.log",
+      "raw_sha256": "26dffd4de836eab1944035783f617f8ce6d5592386766fcdf3d76f9ac25e6aff"
+    },
+    {
+      "id": "product-catalog",
+      "command": [
+        "./shifu",
+        "builds",
+        "--json"
+      ],
+      "required": true,
+      "status": "passed",
+      "exit_code": 0,
+      "duration_ms": 2468,
+      "raw_log": "product-catalog.log",
+      "raw_sha256": "f79e3a4434dbe54970ab01794ad015f2fd238d1ac2e30957fffbdd3c95010efa"
+    }
+  ],
+  "coverage": [
+    {
+      "id": "daemonless-storage",
+      "evidence_suites": [
+        "activation-core"
+      ],
+      "status": "passed"
+    },
+    {
+      "id": "direct-no-fork-coordinator",
+      "evidence_suites": [
+        "activation-core"
+      ],
+      "status": "passed"
+    },
+    {
+      "id": "process-crash-recovery",
+      "evidence_suites": [
+        "activation-core"
+      ],
+      "status": "passed"
+    },
+    {
+      "id": "native-readiness-publication",
+      "evidence_suites": [
+        "activation-core"
+      ],
+      "status": "passed"
+    },
+    {
+      "id": "profile-action-admission",
+      "evidence_suites": [
+        "profile-action-admission"
+      ],
+      "status": "passed"
+    },
+    {
+      "id": "language-product-parity",
+      "evidence_suites": [
+        "runtime-surface-parity"
+      ],
+      "status": "passed"
+    },
+    {
+      "id": "bounded-latency-and-resource-report",
+      "evidence_suites": [
+        "activation-performance"
+      ],
+      "status": "passed"
+    },
+    {
+      "id": "product-artifact-build",
+      "evidence_suites": [
+        "product-distribution"
+      ],
+      "status": "passed"
+    },
+    {
+      "id": "temporary-product-runtime-smoke",
+      "evidence_suites": [
+        "product-runtime-smoke"
+      ],
+      "status": "passed"
+    },
+    {
+      "id": "product-artifact-verification",
+      "evidence_suites": [
+        "product-verification"
+      ],
+      "status": "passed"
+    },
+    {
+      "id": "product-artifact-catalog",
+      "evidence_suites": [
+        "product-catalog"
+      ],
+      "status": "passed"
+    }
+  ],
+  "claims": {
+    "daemonless_storage_operations": true,
+    "direct_no_fork_coordinator": true,
+    "process_crash_recovery": true,
+    "native_readiness_publication": true,
+    "product_artifacts_verified": true,
+    "embedded_runtime_host": false
+  },
+  "non_claims": [
+    "production EmbeddedRuntimeHost",
+    "distributed election, cross-machine leases, or high availability",
+    "physical-host power-loss qualification from process-crash evidence",
+    "default-on production durability or projection candidate profiles",
+    "universal startup, recovery, or activation latency SLO",
+    "readiness descriptor bytes as authority without native revalidation"
+  ],
+  "violations": [],
+  "verdict": "passed"
+}

--- a/docs/qualification/known-limits.md
+++ b/docs/qualification/known-limits.md
@@ -245,6 +245,30 @@ storage contract, not as a completed distributed storage protocol. Legacy
 loose-file journal archive/clean commands are retired; this release deliberately
 has no destructive retention command.
 
+## Runtime activation is process-host qualified, not universally embedded
+
+ADR-0080 now has one retained qualification harness for daemonless storage,
+the directly callable no-fork engine seam, exact-cut process activation,
+generation/lease/crash recovery, Profile action admission, surface parity, and
+the current-platform product artifact. Native readiness coordinates are
+published only after durability/projection authority succeeds and are
+revalidated when consumed.
+
+What is **not guaranteed**:
+
+- a production `EmbeddedRuntimeHost`, thread model, re-entrancy contract, or
+  external executor ABI;
+- semantic readiness from PID, route, service-install, GUI, or descriptor-file
+  existence;
+- distributed election, cross-machine leases, replication, or HA;
+- default-on production durability/projection candidate profiles;
+- physical-host or sudden-power-loss recovery from process-crash evidence;
+- a universal activation latency/resource SLO; or
+- product qualification on a platform without its own retained complete report.
+
+See [Runtime activation and product delivery](runtime-activation-and-product-delivery.md)
+for the exact matrix and report semantics.
+
 ## KFX runtime confinement is staged
 
 The trust boundary is decided in

--- a/docs/qualification/runtime-activation-and-product-delivery.md
+++ b/docs/qualification/runtime-activation-and-product-delivery.md
@@ -41,10 +41,11 @@ The full command is:
 ```
 
 The current retained complete product report is the
-[Darwin arm64 `080f330db` evidence](evidence/runtime-activation/080f330db/README.md).
-Its machine report binds the latest rebased clean source tree, all eight
-passing suites, and the claim/non-claim boundary below. The earlier
-[`fea9ea4ae`](evidence/runtime-activation/fea9ea4ae/README.md) and
+[Darwin arm64 `527652f13` evidence](evidence/runtime-activation/527652f13/README.md).
+Its machine report binds the latest rebased clean source tree, refreshed KFD-1
+release evidence, all eight passing suites, and the claim/non-claim boundary
+below. The [`080f330db`](evidence/runtime-activation/080f330db/README.md),
+[`fea9ea4ae`](evidence/runtime-activation/fea9ea4ae/README.md), and
 [`fb1574844`](evidence/runtime-activation/fb1574844/README.md) reports remain as
 historical evidence from prior `dev/v4/v4.0` synchronization points.
 

--- a/docs/qualification/runtime-activation-and-product-delivery.md
+++ b/docs/qualification/runtime-activation-and-product-delivery.md
@@ -40,6 +40,11 @@ The full command is:
 ./shifu runtime:qualify -- --mode execute --with-product
 ```
 
+The first retained complete product report is the
+[Darwin arm64 `fb1574844` evidence](evidence/runtime-activation/fb1574844/README.md).
+Its machine report binds a clean source tree, all eight passing suites, and the
+claim/non-claim boundary below.
+
 Plan-only inspection is:
 
 ```sh

--- a/docs/qualification/runtime-activation-and-product-delivery.md
+++ b/docs/qualification/runtime-activation-and-product-delivery.md
@@ -41,10 +41,11 @@ The full command is:
 ```
 
 The current retained complete product report is the
-[Darwin arm64 `527652f13` evidence](evidence/runtime-activation/527652f13/README.md).
-Its machine report binds the latest rebased clean source tree, refreshed KFD-1
+[Darwin arm64 `8643f1187` evidence](evidence/runtime-activation/8643f1187/README.md).
+Its machine report binds the frozen latest-dev clean source tree, refreshed KFD
 release evidence, all eight passing suites, and the claim/non-claim boundary
-below. The [`080f330db`](evidence/runtime-activation/080f330db/README.md),
+below. The [`527652f13`](evidence/runtime-activation/527652f13/README.md),
+[`080f330db`](evidence/runtime-activation/080f330db/README.md),
 [`fea9ea4ae`](evidence/runtime-activation/fea9ea4ae/README.md), and
 [`fb1574844`](evidence/runtime-activation/fb1574844/README.md) reports remain as
 historical evidence from prior `dev/v4/v4.0` synchronization points.

--- a/docs/qualification/runtime-activation-and-product-delivery.md
+++ b/docs/qualification/runtime-activation-and-product-delivery.md
@@ -1,0 +1,112 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+document_status: active
+doc_type: release-gate-contract
+review_state: self-reviewed
+sensitivity: public
+sources: [architecture-decisions, local-files, executable-probe]
+period: 2026-07-14
+theme: runtime-activation-and-product-delivery
+confidence: high
+evidence_grade: B
+last_reviewed: 2026-07-14
+---
+
+# Runtime activation and product-delivery qualification
+
+This gate closes ADR-0080 Stage 7 for the current source revision and named
+platform. It composes existing authorities instead of creating another runtime
+or release system. A passing report binds raw suite hashes, source coordinates,
+the frozen product, full verification, the app artifact, and the Shifu local
+artifact catalog.
+
+## Acceptance matrix
+
+| Boundary | Machine evidence | Passing meaning |
+| --- | --- | --- |
+| daemonless storage | `activation-core` | storage-only invocation constructs no activation client |
+| no-fork seam | `activation-core` | `CoordinatorEngine` accepts a direct request with subprocess construction forbidden |
+| live activation and recovery | `activation-core` | exact-cut readiness, first-call serialization, generation replacement, crash window, lease expiry, and idle drain remain fenced |
+| readiness publication | `activation-core` | native durability/projection authorities establish the requested cut before coordinates are atomically published |
+| Profile/KFX action admission | `profile-action-admission` | live-required callbacks run only after a matching broker receipt; storage-only callbacks stay daemonless |
+| language/product parity | `runtime-surface-parity` | CLI, GUI, Python, Node, libkungfu declarations, and KFX use the canonical registry/status vocabulary |
+| bounded performance report | `activation-performance` | synthetic daemonless, cold, warm, and replacement paths report latency/resource observations without an SLO claim |
+| real product smoke | `product-runtime-smoke` | a frozen CLI uses a temporary home for daemonless status, cold/warm process-live ensure, restart, and clean stop |
+| product artifacts | `product-distribution`, `product-verification`, `product-catalog` | the Mac distribution, full Core/Episode verification, app build artifact, and local catalog all succeed |
+
+The full command is:
+
+```sh
+./shifu runtime:qualify -- --mode execute --with-product
+```
+
+Plan-only inspection is:
+
+```sh
+./shifu runtime:qualify -- --mode dry-run
+```
+
+An execute report is `passed` only when the source tree was clean at suite
+execution and every Core and product suite passed. `--with-product` is not an
+optional success shortcut: omitting it makes the report `unqualified`.
+
+## Readiness descriptor boundary
+
+`publish_native_readiness_evidence` validates the contract plus exact
+workspace, runtime-home, and data-root identity. It builds a live-required
+operation requirement, calls the existing native durability and projection
+authorities, validates the returned readiness and minimum cut, and only then
+atomically replaces the workspace descriptor. A failed authority or lagging cut
+leaves any prior descriptor unchanged.
+
+The descriptor remains coordinates, not proof. Discovery validates its binding,
+and every live consumer reconstructs and invokes the native authorities again.
+PID liveness, a responsive route, a GUI window, and descriptor bytes cannot
+establish semantic readiness.
+
+## Performance interpretation
+
+The synthetic workload separates daemonless planning/invocation, first cold
+activation, warm generation reuse, and replacement recovery. The product smoke
+separately records real frozen-CLI timings for daemonless planning/status,
+cold/warm ensure, restart, and stop in a temporary workspace. Reports preserve
+sample counts, median/p95/maximum observations where repeated, and a process
+resource snapshot.
+
+These numbers are diagnostic observations, not a release SLO. Schema
+validation, filesystem state, hardware, cache state, and process startup are
+part of the observed envelope. Performance never permits skipping readiness,
+generation fencing, durability reconciliation, or cleanup.
+
+## Supported claim and non-claims
+
+A retained passing report supports only this statement:
+
+> On the named source revision and platform, the process-host implementation
+> preserved the contract's daemonless, no-fork engine, exact-cut activation,
+> crash/restart, action-admission, and product-artifact boundaries under the
+> recorded suites.
+
+It does not establish:
+
+- a production `EmbeddedRuntimeHost`, thread model, or external executor ABI;
+- distributed election, cross-machine leases, replication, or HA;
+- physical-host restart, device loss, or sudden-power-loss qualification;
+- default-on production durability/projection candidate profiles;
+- a universal cold/warm/recovery latency or resource SLO;
+- interactive GUI-window behavior on a headless build runner; or
+- Linux/Windows product qualification from a Mac report.
+
+Linux and Windows remain contract/CI surfaces until each platform retains its
+own complete product report. Interactive GUI launch remains a manual display
+check; `verify --full --with-app` proves the build artifact and frozen CLI smoke,
+not pixels or desktop lifecycle.
+
+## AI provenance
+
+`ai_provenance`: this contract was drafted by the visible GPT-5 model family
+through Codex on 2026-07-14 from ADR-0080, the runtime contract, deterministic
+suites, and the Shifu product workflow. The model had no invisible evidence for
+unexecuted platforms or physical-host failures; those remain explicit
+non-claims. Maintainer review can replace this attribution when the document is
+substantively re-authored.

--- a/docs/qualification/runtime-activation-and-product-delivery.md
+++ b/docs/qualification/runtime-activation-and-product-delivery.md
@@ -41,11 +41,12 @@ The full command is:
 ```
 
 The current retained complete product report is the
-[Darwin arm64 `fea9ea4ae` evidence](evidence/runtime-activation/fea9ea4ae/README.md).
-Its machine report binds the rebased clean source tree, all eight passing
-suites, and the claim/non-claim boundary below. The earlier
-[`fb1574844` report](evidence/runtime-activation/fb1574844/README.md) remains as
-historical evidence from before the final `dev/v4/v4.0` synchronization.
+[Darwin arm64 `080f330db` evidence](evidence/runtime-activation/080f330db/README.md).
+Its machine report binds the latest rebased clean source tree, all eight
+passing suites, and the claim/non-claim boundary below. The earlier
+[`fea9ea4ae`](evidence/runtime-activation/fea9ea4ae/README.md) and
+[`fb1574844`](evidence/runtime-activation/fb1574844/README.md) reports remain as
+historical evidence from prior `dev/v4/v4.0` synchronization points.
 
 Plan-only inspection is:
 

--- a/docs/qualification/runtime-activation-and-product-delivery.md
+++ b/docs/qualification/runtime-activation-and-product-delivery.md
@@ -40,10 +40,12 @@ The full command is:
 ./shifu runtime:qualify -- --mode execute --with-product
 ```
 
-The first retained complete product report is the
-[Darwin arm64 `fb1574844` evidence](evidence/runtime-activation/fb1574844/README.md).
-Its machine report binds a clean source tree, all eight passing suites, and the
-claim/non-claim boundary below.
+The current retained complete product report is the
+[Darwin arm64 `fea9ea4ae` evidence](evidence/runtime-activation/fea9ea4ae/README.md).
+Its machine report binds the rebased clean source tree, all eight passing
+suites, and the claim/non-claim boundary below. The earlier
+[`fb1574844` report](evidence/runtime-activation/fb1574844/README.md) remains as
+historical evidence from before the final `dev/v4/v4.0` synchronization.
 
 Plan-only inspection is:
 

--- a/examples/probe-cpp/cmake/kungfu.cmake
+++ b/examples/probe-cpp/cmake/kungfu.cmake
@@ -51,6 +51,14 @@ endif()
 macro(kungfu_cpp_extension _target)
   file(GLOB _kf_srcs CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/*.cpp")
   pybind11_add_module(${_target} SHARED ${_kf_srcs})
+  # Keep external C++ consumers on the same narrow fmt compatibility contract
+  # as Core. AppleClang 21 rejects fmt 10.2.1's consteval parser in C++23 mode.
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang" AND
+     CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 21 AND
+     CMAKE_CXX_COMPILER_VERSION VERSION_LESS 22)
+    target_compile_options(${_target} PRIVATE
+      "$<$<COMPILE_LANGUAGE:CXX>:-DFMT_CONSTEVAL=>")
+  endif()
   target_include_directories(${_target} PRIVATE
     "${KF_CORE_DIR}/src/libkungfu/include"
     "${KF_CORE_DIR}/src/libyijinjing/include")

--- a/framework/core/slices/embedding/CMakeLists.txt
+++ b/framework/core/slices/embedding/CMakeLists.txt
@@ -15,5 +15,20 @@ project(yijinjing_embed_smoke CXX)
 
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../../src/libyijinjing libyijinjing)
 
+# Match Core's narrow fmt compatibility contract for the standalone consumer.
+# AppleClang 21 rejects fmt 10.2.1's consteval parser in C++23 mode.
+if(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang" AND
+   CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 21 AND
+   CMAKE_CXX_COMPILER_VERSION VERSION_LESS 22)
+  target_compile_options(yijinjing PRIVATE
+    "$<$<COMPILE_LANGUAGE:CXX>:-DFMT_CONSTEVAL=>")
+endif()
+
 add_executable(embed_smoke main.cpp)
 target_link_libraries(embed_smoke yijinjing)
+if(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang" AND
+   CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 21 AND
+   CMAKE_CXX_COMPILER_VERSION VERSION_LESS 22)
+  target_compile_options(embed_smoke PRIVATE
+    "$<$<COMPILE_LANGUAGE:CXX>:-DFMT_CONSTEVAL=>")
+endif()

--- a/framework/core/slices/view-encapsulation/CMakeLists.txt
+++ b/framework/core/slices/view-encapsulation/CMakeLists.txt
@@ -23,6 +23,7 @@ set(_view_inc ${CMAKE_CURRENT_SOURCE_DIR}/../../src/libkungfu/include)
 
 add_executable(view_encapsulation_probe probe.cpp ${_view_src})
 target_include_directories(view_encapsulation_probe PRIVATE ${_view_inc})
-# Only FlatBuffers + SQLite (both from the directory-wide CONAN_LIBS via the
-# top-level link_libraries); deliberately no yijinjing / libkungfu link.
-target_link_libraries(view_encapsulation_probe flatbuffers::flatbuffers)
+# Only FlatBuffers + SQLite; deliberately no yijinjing / libkungfu link.
+target_link_libraries(view_encapsulation_probe
+  flatbuffers::flatbuffers
+  SQLite::SQLite3)

--- a/framework/core/slices/view-encapsulation/probe.cpp
+++ b/framework/core/slices/view-encapsulation/probe.cpp
@@ -13,12 +13,25 @@
 #include <flatbuffers/idl.h>
 #include <sqlite3.h>
 
-#include <cassert>
 #include <cstdint>
 #include <cstdio>
+#include <stdexcept>
 #include <string>
 
 using namespace kungfu;
+
+// This probe is built in Release mode, where the standard assert macro removes
+// both the check and any side effect in its expression. Keep every operation
+// and invariant live so the qualification remains meaningful under -DNDEBUG.
+static void require(bool condition, const char *expression) {
+  if (!condition)
+    throw std::runtime_error(std::string("view-encapsulation probe failed: ") + expression);
+}
+
+#ifdef assert
+#undef assert
+#endif
+#define assert(expression) require(static_cast<bool>(expression), #expression)
 
 static const char *FBS = R"fbs(
 attribute "pk";

--- a/framework/core/src/libkungfu/tests/durability_contract_tests.cpp
+++ b/framework/core/src/libkungfu/tests/durability_contract_tests.cpp
@@ -113,8 +113,8 @@ void test_capability_report_is_evidence_bound_and_fail_closed() {
           "durable_sync was over-advertised");
   require(report.profiles[3].name == "replicated" && report.profiles[3].availability == "unavailable",
           "future replication was advertised");
-  require(report.evidence.size() == 7 && report.restore.verified && report.restore.off_host &&
-              not report.restore.independent_failure_domain,
+  require(report.evidence.size() == 7 && report.evidence[4].id == "same-office-offhost-restore" &&
+              report.restore.verified && report.restore.off_host && not report.restore.independent_failure_domain,
           "restore evidence lost its exact failure-domain boundary");
   require(report.admission.current_hardware_candidate_complete &&
               not report.admission.candidate_profile_default_enabled && report.admission.clean_host_restart_qualified &&

--- a/framework/core/src/python/kungfu/agent/brief.md
+++ b/framework/core/src/python/kungfu/agent/brief.md
@@ -110,6 +110,25 @@ kungfu atlas show markers --json
 The source repo remains the authority. Kungfu stores a read-only projection for
 inspection in CLI, GUI, and kfx work views.
 
+Runtime activation is capability-driven rather than PID-driven. Inspect the
+contract and plan before assuming a resident process is needed:
+
+```sh
+kungfu runtime operations --json
+kungfu runtime plan episode.inspect --json
+kungfu runtime status --json
+```
+
+Storage-only operations remain daemonless. Live-required operations fail closed
+unless the Core broker returns matching capabilities and native readiness at
+the requested durable cut. `runtime ensure` and process status are advanced
+operator diagnostics; process liveness, GUI visibility, and readiness
+descriptor bytes are not semantic readiness. The descriptor carries only
+workspace-bound native authority coordinates and is revalidated when consumed.
+The shipped process host is qualified in a named platform envelope; Kungfu does
+not claim a production `EmbeddedRuntimeHost`, cross-machine lease/election, HA,
+or universal activation SLO.
+
 The pack is included by the Electron artifact, the standalone CLI, npm
 `@kungfu-tech/core`, and the PyPI wheel. Future Homebrew, winget, container, and
 kfx packaging must keep the same pack validation gate before claiming support.

--- a/framework/core/src/python/kungfu/atlas/payloads.py
+++ b/framework/core/src/python/kungfu/atlas/payloads.py
@@ -118,7 +118,10 @@ def enrich_source_records(source_records: list[dict[str, Any]]) -> list[dict[str
                 "kind": record.get("kind"),
                 "source_id": record.get("source_id"),
                 "source_path": record.get("source_path"),
-                "source_time": record.get("source_time"),
+                # The typed manifest core represents an absent timestamp as an
+                # empty string. Normalize at the producer edge so the sync-root
+                # commitment is byte-identical before and after typed parsing.
+                "source_time": str(record.get("source_time") or ""),
                 "schema_version": record.get("schema_version"),
                 "content_type": CONTENT_TYPE_JSON,
                 "payload_hash": ""
@@ -136,7 +139,7 @@ def enrich_source_records(source_records: list[dict[str, Any]]) -> list[dict[str
                 "kind": record.get("kind"),
                 "source_id": record.get("source_id"),
                 "source_path": record.get("source_path"),
-                "source_time": record.get("source_time"),
+                "source_time": str(record.get("source_time") or ""),
                 "schema_version": record.get("schema_version"),
                 "content_type": CONTENT_TYPE_JSON,
                 "payload_hash": digest,

--- a/framework/core/src/python/kungfu/runtime_broker.py
+++ b/framework/core/src/python/kungfu/runtime_broker.py
@@ -151,6 +151,17 @@ def discover_native_readiness_evidence(
         raise ValueError("native runtime readiness evidence is unreadable") from None
     if not isinstance(value, dict):
         raise ValueError("native runtime readiness evidence is not an object")
+    _validate_native_readiness_evidence(runtime_dir, value, contract)
+    return copy.deepcopy(value)
+
+
+def _validate_native_readiness_evidence(
+    runtime_dir: str | Path,
+    value: Mapping[str, Any],
+    contract: Mapping[str, Any] | None = None,
+) -> None:
+    """Validate descriptor shape plus its exact workspace and root binding."""
+
     _validate_value("nativeReadinessEvidence", value, contract)
     expected_workspace = workspace_id(runtime_dir)
     if value.get("workspaceId") != expected_workspace:
@@ -170,7 +181,64 @@ def discover_native_readiness_evidence(
         raise ValueError(
             "native runtime readiness evidence runtime home does not match"
         )
-    return copy.deepcopy(value)
+
+
+def publish_native_readiness_evidence(
+    runtime_dir: str | Path,
+    evidence: Mapping[str, Any],
+    *,
+    operation_id: str,
+    config_home: str | Path | None = None,
+    contract: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Establish native readiness before atomically publishing its coordinates.
+
+    The descriptor remains a discovery aid rather than proof: every consumer
+    reconstructs and invokes the native authorities again.  Publication only
+    proves that the same coordinates established one explicit live-required
+    operation at the descriptor's minimum cut at publication time.
+    """
+
+    _validate_native_readiness_evidence(runtime_dir, evidence, contract)
+    operation = operation_definition(operation_id, contract)
+    if operation.get("operationClass") != "live-required":
+        raise ValueError(
+            "native readiness publication requires a live-required operation"
+        )
+    minimum_cut = evidence.get("minimumCut")
+    if not isinstance(minimum_cut, Mapping):
+        raise ValueError(
+            "native readiness publication requires an explicit minimum cut"
+        )
+    plan = plan_operation(
+        operation_id,
+        workspace=workspace_id(runtime_dir),
+        request_source="python",
+        minimum_cut=minimum_cut,
+        contract=contract,
+    )
+    requirement = plan["requirement"]
+    readiness = native_readiness_authority(evidence, contract=contract).establish(
+        requirement,
+        "publication",
+        {"source": "native-readiness-publication"},
+    )
+    _validate_value("runtimeReadiness", readiness, contract)
+    if not _readiness_admits_requirement(requirement, readiness):
+        raise ValueError(
+            "native readiness authority did not establish the publication requirement"
+        )
+
+    path = native_readiness_evidence_path(runtime_dir, config_home)
+    _write_runtime_json(path, evidence)
+    discovered = discover_native_readiness_evidence(
+        runtime_dir,
+        config_home,
+        contract=contract,
+    )
+    if discovered != dict(evidence):
+        raise ValueError("published native readiness evidence did not round-trip")
+    return copy.deepcopy(discovered)
 
 
 def plan_operation(
@@ -285,15 +353,21 @@ def _read_activation_state(path: Path) -> dict[str, Any] | None:
     return value
 
 
-def _write_activation_state(path: Path, value: Mapping[str, Any]) -> None:
+def _write_runtime_json(path: Path, value: Mapping[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    temporary = path.with_suffix(".json.tmp")
-    with temporary.open("w", encoding="utf-8") as state_file:
-        json.dump(value, state_file, indent=2, sort_keys=True)
-        state_file.write("\n")
-        state_file.flush()
-        os.fsync(state_file.fileno())
-    os.replace(temporary, path)
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.{time.time_ns()}.tmp")
+    try:
+        with temporary.open("x", encoding="utf-8") as state_file:
+            json.dump(value, state_file, indent=2, sort_keys=True)
+            state_file.write("\n")
+            state_file.flush()
+            os.fsync(state_file.fileno())
+        os.replace(temporary, path)
+    finally:
+        try:
+            temporary.unlink()
+        except FileNotFoundError:
+            pass
     try:
         directory = os.open(path.parent, os.O_RDONLY)
     except OSError:
@@ -304,6 +378,10 @@ def _write_activation_state(path: Path, value: Mapping[str, Any]) -> None:
         pass
     finally:
         os.close(directory)
+
+
+def _write_activation_state(path: Path, value: Mapping[str, Any]) -> None:
+    _write_runtime_json(path, value)
 
 
 def product_status(

--- a/framework/core/tests/python/test_atlas_storage.py
+++ b/framework/core/tests/python/test_atlas_storage.py
@@ -3967,6 +3967,34 @@ def test_atlas_producer_enrich_and_write_honor_withheld_states(tmp_path):
     assert rows["marker-gone"]["payload"] is None
 
 
+def test_atlas_producer_normalizes_missing_source_time_for_typed_sync_root(tmp_path):
+    [entry] = payloads.enrich_source_records(
+        [
+            {
+                "kind": "goal",
+                "source_id": "goal-without-time",
+                "source_path": "goals/without-time.json",
+                "schema_version": 1,
+                "payload": {"goal_id": "goal-without-time"},
+            }
+        ]
+    )
+
+    assert entry["source_time"] == ""
+    manifest = payloads.write_import_payloads(
+        tmp_path / "store",
+        import_id="imp-without-time",
+        repo_root=str(tmp_path),
+        repo_head="head-1",
+        source_records=[entry],
+        counts={},
+    )
+    accepted = storage_service.accept_manifest(
+        tmp_path / "runtime", manifest["storage_manifest"]
+    )
+    assert accepted["sync_root"] == manifest["sync_root"]
+
+
 def test_source_registry_records_round_trip_through_journal(tmp_path):
     # ADR-0037: source-registry records are Hana-core kernel metadata written to
     # an append-only yijinjing journal; JSON is only an edge projection. This

--- a/framework/core/tests/python/test_durability_capability.py
+++ b/framework/core/tests/python/test_durability_capability.py
@@ -23,6 +23,15 @@ def test_python_projection_preserves_libkungfu_capability():
     assert report["admission"]["clean_host_restart_qualified"] is True
     assert report["admission"]["physical_power_loss_qualified"] is False
     assert report["admission"]["production_eligible"] is False
+    assert [row["id"] for row in report["evidence"]] == [
+        "live-durable-receipts",
+        "projection-authority-candidate",
+        "agent120-fault-campaign",
+        "agent120-durability-slo",
+        "same-office-offhost-restore",
+        "agent120-clean-host-restart",
+        "production-candidate-admission",
+    ]
     assert {row["name"] for row in report["profiles"]} == {
         "visible",
         "durable_group",

--- a/framework/core/tests/python/test_runtime_broker.py
+++ b/framework/core/tests/python/test_runtime_broker.py
@@ -626,6 +626,131 @@ def test_product_discovers_exact_native_readiness_coordinates(tmp_path, monkeypa
     )
 
 
+def test_product_publishes_native_coordinates_only_after_exact_authority(
+    tmp_path, monkeypatch
+):
+    from kungfu import durability, projection
+
+    runtime_dir = tmp_path / "home" / "runtime"
+    config_home = tmp_path / "config"
+    evidence = _native_evidence(runtime_dir)
+    calls = []
+    monkeypatch.setattr(
+        durability,
+        "reconcile",
+        lambda **kwargs: (
+            calls.append(("durability", kwargs))
+            or _reconciliation(evidence["minimumCut"])
+        ),
+    )
+    monkeypatch.setattr(
+        projection,
+        "candidate_status",
+        lambda **kwargs: (
+            calls.append(("projection", kwargs))
+            or _projection_status(evidence["minimumCut"])
+        ),
+    )
+    original_replace = runtime_broker.os.replace
+
+    def replace_after_authority(source, destination):
+        assert [kind for kind, _ in calls] == ["durability", "projection"]
+        assert not Path(destination).exists()
+        original_replace(source, destination)
+
+    monkeypatch.setattr(runtime_broker.os, "replace", replace_after_authority)
+
+    published = runtime_broker.publish_native_readiness_evidence(
+        runtime_dir,
+        evidence,
+        operation_id="projection.subscribe",
+        config_home=config_home,
+    )
+
+    assert published == evidence
+    assert (
+        runtime_broker.discover_native_readiness_evidence(runtime_dir, config_home)
+        == evidence
+    )
+    assert calls[0][1]["sequence"] == 1
+    assert calls[1][1]["container_epoch"] == 1
+
+
+def test_native_coordinate_publication_failure_preserves_previous_descriptor(
+    tmp_path, monkeypatch
+):
+    from kungfu import durability
+
+    runtime_dir = tmp_path / "home" / "runtime"
+    config_home = tmp_path / "config"
+    previous = _native_evidence(runtime_dir)
+    path = runtime_broker.native_readiness_evidence_path(runtime_dir, config_home)
+    path.parent.mkdir(parents=True)
+    path.write_text(json.dumps(previous, indent=2, sort_keys=True) + "\n")
+    original = path.read_bytes()
+    replacement = copy.deepcopy(previous)
+    replacement["durability"]["requestId"] = "18"
+    monkeypatch.setattr(
+        durability,
+        "reconcile",
+        lambda **kwargs: (_ for _ in ()).throw(ValueError("authority unavailable")),
+    )
+
+    with pytest.raises(ValueError, match="authority unavailable"):
+        runtime_broker.publish_native_readiness_evidence(
+            runtime_dir,
+            replacement,
+            operation_id="assessment.request",
+            config_home=config_home,
+        )
+
+    assert path.read_bytes() == original
+    assert (
+        runtime_broker.discover_native_readiness_evidence(runtime_dir, config_home)
+        == previous
+    )
+
+
+def test_native_coordinate_publication_rejects_non_live_and_lagging_evidence(
+    tmp_path, monkeypatch
+):
+    from kungfu import durability, projection
+
+    runtime_dir = tmp_path / "home" / "runtime"
+    config_home = tmp_path / "config"
+    evidence = _native_evidence(runtime_dir, _cut(sequence="2", frame_uid="2"))
+
+    with pytest.raises(ValueError, match="live-required"):
+        runtime_broker.publish_native_readiness_evidence(
+            runtime_dir,
+            evidence,
+            operation_id="episode.inspect",
+            config_home=config_home,
+        )
+
+    monkeypatch.setattr(
+        durability,
+        "reconcile",
+        lambda **kwargs: _reconciliation(_cut(sequence="1", frame_uid="1")),
+    )
+    monkeypatch.setattr(
+        projection,
+        "candidate_status",
+        lambda **kwargs: _projection_status(_cut(sequence="1", frame_uid="1")),
+    )
+    with pytest.raises(ValueError, match="did not establish"):
+        runtime_broker.publish_native_readiness_evidence(
+            runtime_dir,
+            evidence,
+            operation_id="projection.subscribe",
+            config_home=config_home,
+        )
+
+    assert not runtime_broker.native_readiness_evidence_path(
+        runtime_dir, config_home
+    ).exists()
+
+
 def test_product_rejects_foreign_native_readiness_coordinates(tmp_path, monkeypatch):
     runtime_dir = tmp_path / "home" / "runtime"
     monkeypatch.setenv("KF_CONFIG_HOME", str(tmp_path / "config"))

--- a/framework/core/tests/qualification/runtime-activation/README.md
+++ b/framework/core/tests/qualification/runtime-activation/README.md
@@ -1,0 +1,28 @@
+# Runtime activation qualification
+
+This harness binds ADR-0080 Stage 7 to source-exact, retained machine evidence.
+It composes the existing broker/service, Profile action, surface parity,
+distribution, full verification, and local artifact-catalog checks. It does not
+replace any lower authority or reinterpret a passing process-crash test as a
+power-loss result.
+
+Plan without building or writing product state:
+
+    ./shifu runtime:qualify -- --mode dry-run
+
+Execute the complete current-platform qualification, including distribution
+and full product verification:
+
+    ./shifu runtime:qualify -- --mode execute --with-product
+
+Reports and raw logs default to
+`framework/core/build/qualification/runtime-activation/<run-id>/`. An execute
+run is `passed` only from a clean source tree when all Core and product suites
+pass. Omitting product suites is intentionally `unqualified`.
+
+The report can support only the named current-platform/process envelope. It
+does not claim a production EmbeddedRuntimeHost, distributed leases or HA,
+physical-host power-loss coverage, default-on candidate durability profiles,
+or a universal activation latency SLO. A published readiness descriptor is
+still only discovery coordinates; product consumers re-run the native
+durability/projection authorities before admitting an operation.

--- a/framework/core/tests/qualification/runtime-activation/README.md
+++ b/framework/core/tests/qualification/runtime-activation/README.md
@@ -16,7 +16,8 @@ and full product verification:
     ./shifu runtime:qualify -- --mode execute --with-product
 
 Reports and raw logs default to
-`framework/core/build/qualification/runtime-activation/<run-id>/`. An execute
+`.buildchain/runtime/qualification/runtime-activation/<run-id>/`. This ignored
+runtime area survives Core distribution cleanup. An execute
 run is `passed` only from a clean source tree when all Core and product suites
 pass. Omitting product suites is intentionally `unqualified`.
 

--- a/framework/core/tests/qualification/runtime-activation/performance_workload.py
+++ b/framework/core/tests/qualification/runtime-activation/performance_workload.py
@@ -1,0 +1,219 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+import statistics
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+
+ROOT = Path(__file__).parents[5]
+sys.path.insert(0, str(ROOT / "framework" / "core" / "build" / "Release"))
+sys.path.insert(0, str(ROOT / "framework" / "core" / "src" / "python"))
+
+from kungfu import runtime_broker  # noqa: E402
+
+
+def cut(sequence: int = 1) -> dict[str, str]:
+    return {
+        "stream_id": "1",
+        "container_epoch": "1",
+        "sequence": str(sequence),
+        "frame_uid": str(sequence),
+    }
+
+
+class FakeHost:
+    def __init__(self) -> None:
+        self.running = False
+        self.supervisor_pid = 4000
+        self.coordinator_pid = 4001
+        self.activations = 0
+
+    def diagnostics(self) -> dict[str, object]:
+        return {
+            "supervisor": {
+                "pid": self.supervisor_pid if self.running else None,
+                "running": self.running,
+            },
+            "coordinator": {
+                "pid": self.coordinator_pid if self.running else None,
+                "running": self.running,
+            },
+        }
+
+    def inspect(self, home: str, runtime_dir: str) -> dict[str, object]:
+        return self.diagnostics()
+
+    def activate(self, home: str, runtime_dir: str) -> dict[str, object]:
+        self.activations += 1
+        self.running = True
+        return self.diagnostics()
+
+    def replace(self) -> None:
+        self.supervisor_pid += 2
+        self.coordinator_pid += 2
+
+
+class FakeReadinessAuthority:
+    def establish(self, requirement, generation, diagnostics):
+        minimum = requirement.get("minimumCut") or cut()
+        projection = (
+            minimum
+            if "runtime.live-projection" in requirement["requiredCapabilities"]
+            else None
+        )
+        return {
+            "schema": "kungfu.runtime.readiness/v1",
+            "state": "ready",
+            "durableCut": minimum,
+            "projectionCut": projection,
+            "evidence": [
+                {
+                    "kind": "durability-receipt",
+                    "ref": f"receipt:qualification:{generation}",
+                }
+            ],
+            "observedAtNs": str(time.time_ns()),
+        }
+
+
+def percentile(values: list[int], quantile: float) -> int:
+    ordered = sorted(values)
+    index = min(len(ordered) - 1, max(0, int(len(ordered) * quantile) - 1))
+    return ordered[index]
+
+
+def metric(values: list[int]) -> dict[str, int | str]:
+    return {
+        "unit": "microseconds",
+        "samples": len(values),
+        "median": int(statistics.median(values)),
+        "p95": percentile(values, 0.95),
+        "maximum": max(values),
+    }
+
+
+def timed(callable_) -> tuple[object, int]:
+    started = time.perf_counter_ns()
+    value = callable_()
+    return value, (time.perf_counter_ns() - started) // 1000
+
+
+def daemonless_samples(count: int) -> list[int]:
+    def forbidden_host():
+        raise AssertionError("daemonless operation constructed a process host")
+
+    broker = runtime_broker.RuntimeCapabilityBroker(forbidden_host)
+    values = []
+    for index in range(count):
+        plan = broker.plan(
+            "episode.inspect",
+            workspace="workspace-qualification-daemonless",
+            request_source="python",
+            request_id=f"daemonless-{index}",
+        )
+        result, elapsed = timed(
+            lambda plan=plan: broker.invoke(plan, lambda receipt: receipt["outcome"])
+        )
+        if result["result"] != "daemonless":
+            raise AssertionError("daemonless benchmark accepted an unexpected outcome")
+        values.append(elapsed)
+    return values
+
+
+def live_samples(root: Path, warm_count: int, recovery_count: int):
+    runtime_dir = root / "home" / "runtime"
+    config_home = root / "config"
+    host = FakeHost()
+    client = runtime_broker.ProcessRuntimeActivationClient(
+        str(runtime_dir.parent),
+        str(runtime_dir),
+        config_home=str(config_home),
+        host=host,
+        readiness_authority=FakeReadinessAuthority(),
+    )
+    requirement = runtime_broker.plan_operation(
+        "projection.subscribe",
+        workspace=runtime_broker.workspace_id(runtime_dir),
+        request_source="python",
+        minimum_cut=cut(),
+        request_id="qualification-live",
+    )["requirement"]
+
+    cold_receipt, cold = timed(lambda: client.activate(requirement, "python"))
+    if cold_receipt["outcome"] != "activated" or host.activations != 1:
+        raise AssertionError("cold activation did not establish exactly one host")
+
+    warm = []
+    for _ in range(warm_count):
+        receipt, elapsed = timed(lambda: client.activate(requirement, "python"))
+        if receipt["outcome"] != "reused" or host.activations != 1:
+            raise AssertionError("warm activation did not reuse the fenced generation")
+        warm.append(elapsed)
+
+    recovery = []
+    previous_generation = int(cold_receipt["handle"]["generation"])
+    for _ in range(recovery_count):
+        host.replace()
+        receipt, elapsed = timed(lambda: client.activate(requirement, "python"))
+        generation = int(receipt["handle"]["generation"])
+        if receipt["outcome"] != "activated" or generation <= previous_generation:
+            raise AssertionError("replacement recovery did not advance the generation")
+        previous_generation = generation
+        recovery.append(elapsed)
+    if host.activations != recovery_count + 1:
+        raise AssertionError("recovery activation count does not match replacements")
+    return [cold], warm, recovery
+
+
+def main() -> None:
+    with tempfile.TemporaryDirectory(prefix="kungfu-runtime-activation-") as temporary:
+        cold, warm, recovery = live_samples(Path(temporary), 50, 10)
+    resource_snapshot = None
+    try:
+        import resource
+
+        usage = resource.getrusage(resource.RUSAGE_SELF)
+        resource_snapshot = {
+            "maxResidentSetSize": usage.ru_maxrss,
+            "maxResidentSetSizeUnit": (
+                "bytes" if sys.platform == "darwin" else "kibibytes"
+            ),
+            "userCpuSeconds": usage.ru_utime,
+            "systemCpuSeconds": usage.ru_stime,
+        }
+    except ImportError:
+        pass
+    report = {
+        "schema": "kungfu.runtime-activation.performance-report/v1",
+        "envelope": "temporary-workspace-fake-process-host-v1",
+        "thresholdPolicy": "report-only-no-universal-slo",
+        "metrics": {
+            "daemonless": metric(daemonless_samples(500)),
+            "coldActivation": metric(cold),
+            "warmReuse": metric(warm),
+            "replacementRecovery": metric(recovery),
+        },
+        "processResourceSnapshot": resource_snapshot,
+        "invariants": {
+            "daemonlessConstructedNoHost": True,
+            "coldEstablishedOneHost": True,
+            "warmReusedGeneration": True,
+            "recoveryAdvancedGeneration": True,
+        },
+        "nonClaims": [
+            "production process latency",
+            "physical-host recovery latency",
+            "universal performance SLO",
+            "production EmbeddedRuntimeHost",
+        ],
+    }
+    print(json.dumps(report, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/framework/core/tests/qualification/runtime-activation/product_smoke.mjs
+++ b/framework/core/tests/qualification/runtime-activation/product_smoke.mjs
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '..',
+  '..',
+  '..',
+  '..',
+  '..',
+);
+const EXECUTABLE = path.join(
+  ROOT,
+  'framework',
+  'core',
+  'dist',
+  'kungfu',
+  process.platform === 'win32' ? 'kungfu.exe' : 'kungfu',
+);
+
+function invoke(home, configHome, args) {
+  const started = process.hrtime.bigint();
+  const result = spawnSync(EXECUTABLE, ['-H', home, ...args], {
+    cwd: ROOT,
+    env: {
+      ...process.env,
+      KF_CONFIG_HOME: configHome,
+      KF_RUNTIME_DIR: path.join(home, 'runtime'),
+    },
+    encoding: 'utf8',
+    timeout: 30_000,
+  });
+  const durationUs = Number((process.hrtime.bigint() - started) / 1000n);
+  if (result.error || result.status !== 0) {
+    throw new Error(
+      `product command failed (${args.join(' ')}): ${result.error?.message || result.stderr || result.stdout}`,
+    );
+  }
+  let payload;
+  try {
+    payload = JSON.parse(result.stdout);
+  } catch {
+    throw new Error(
+      `product command returned non-JSON (${args.join(' ')}): ${result.stdout}`,
+    );
+  }
+  return { payload, durationUs };
+}
+
+function running(payload) {
+  return (
+    payload?.supervisor?.running === true &&
+    payload?.coordinator?.running === true
+  );
+}
+
+function waitForRunning(home, configHome) {
+  let latest;
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    latest = invoke(home, configHome, ['runtime', 'status', '--json']);
+    if (running(latest.payload)) return latest;
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 100);
+  }
+  throw new Error(
+    `product runtime did not become running: ${JSON.stringify(latest?.payload)}`,
+  );
+}
+
+function main() {
+  if (!fs.existsSync(EXECUTABLE)) {
+    throw new Error(`frozen product executable is missing: ${EXECUTABLE}`);
+  }
+  const temporary = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'kungfu-runtime-product-smoke-'),
+  );
+  const home = path.join(temporary, 'home');
+  const configHome = path.join(temporary, 'config');
+  let stop = null;
+  try {
+    const daemonless = invoke(home, configHome, [
+      'runtime',
+      'plan',
+      'episode.inspect',
+      '--json',
+    ]);
+    if (daemonless.payload.requirement?.operationClass !== 'storage-only') {
+      throw new Error('product storage plan did not remain daemonless');
+    }
+    const before = invoke(home, configHome, ['runtime', 'status', '--json']);
+    if (
+      before.payload.product?.availability !== 'available' ||
+      before.payload.product?.liveState !== 'inactive' ||
+      before.payload.supervisor?.running !== false
+    ) {
+      throw new Error('daemonless product status invented live readiness');
+    }
+
+    const cold = invoke(home, configHome, ['runtime', 'ensure', '--json']);
+    const coldStatus = waitForRunning(home, configHome);
+    const warm = invoke(home, configHome, ['runtime', 'ensure', '--json']);
+    if (warm.payload.changed !== false) {
+      throw new Error('warm product ensure did not reuse the resident runtime');
+    }
+    const restart = invoke(home, configHome, ['runtime', 'restart', '--json']);
+    const restartStatus = waitForRunning(home, configHome);
+    stop = invoke(home, configHome, ['runtime', 'stop', '--json']);
+    const stopped = invoke(home, configHome, ['runtime', 'status', '--json']);
+    if (
+      stopped.payload.supervisor?.running !== false ||
+      stopped.payload.coordinator?.running !== false
+    ) {
+      throw new Error('product stop left the temporary runtime running');
+    }
+    console.log(
+      JSON.stringify(
+        {
+          schema: 'kungfu.runtime-activation.product-smoke/v1',
+          platform: { os: process.platform, arch: process.arch },
+          envelope: 'temporary-product-workspace-process-live-v1',
+          outcomes: {
+            daemonlessStatus: before.payload.product,
+            coldChanged: cold.payload.changed,
+            coldRunning: running(coldStatus.payload),
+            warmChanged: warm.payload.changed,
+            restartSchema: restart.payload.schema,
+            restartRunning: running(restartStatus.payload),
+            stopped: stop.payload.changed,
+          },
+          latency: {
+            unit: 'microseconds',
+            daemonlessPlan: daemonless.durationUs,
+            daemonlessStatus: before.durationUs,
+            coldEnsure: cold.durationUs,
+            coldReadyProbe: coldStatus.durationUs,
+            warmEnsure: warm.durationUs,
+            restart: restart.durationUs,
+            restartReadyProbe: restartStatus.durationUs,
+            stop: stop.durationUs,
+          },
+          nonClaims: [
+            'universal performance SLO',
+            'GUI interactive launch',
+            'semantic capability readiness from process status',
+            'physical-host crash or power-loss recovery',
+          ],
+        },
+        null,
+        2,
+      ),
+    );
+  } finally {
+    if (stop === null) {
+      try {
+        invoke(home, configHome, ['runtime', 'stop', '--json']);
+      } catch (error) {
+        console.error(
+          `[runtime-product-smoke] cleanup failed: ${error.message}`,
+        );
+      }
+    }
+    fs.rmSync(temporary, { recursive: true, force: true });
+  }
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(error?.stack || String(error));
+  process.exit(1);
+}

--- a/framework/core/tests/qualification/runtime-activation/run.mjs
+++ b/framework/core/tests/qualification/runtime-activation/run.mjs
@@ -1,0 +1,353 @@
+// SPDX-License-Identifier: Apache-2.0
+// @ts-check
+
+import { spawnSync } from 'node:child_process';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import Ajv2020 from 'ajv/dist/2020.js';
+
+const HARNESS_DIR = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(HARNESS_DIR, '..', '..', '..', '..', '..');
+const REPORT_SCHEMA_PATH = path.join(
+  HARNESS_DIR,
+  'schemas',
+  'runtime-activation-qualification-report-v1.schema.json',
+);
+const LAUNCHER = process.platform === 'win32' ? 'shifu.cmd' : './shifu';
+
+export const SUITES = [
+  {
+    id: 'activation-core',
+    product: false,
+    command: [
+      LAUNCHER,
+      'exec',
+      'uv',
+      'run',
+      '--project',
+      'framework/core',
+      'python',
+      '-m',
+      'pytest',
+      'framework/core/tests/python/test_runtime_broker.py',
+      'framework/core/tests/python/test_runtime_service.py',
+      '-q',
+    ],
+  },
+  {
+    id: 'profile-action-admission',
+    product: false,
+    command: [LAUNCHER, 'test:agent-profile-sdk'],
+  },
+  {
+    id: 'runtime-surface-parity',
+    product: false,
+    command: [LAUNCHER, 'test:runtime-surface'],
+  },
+  {
+    id: 'activation-performance',
+    product: false,
+    command: [
+      LAUNCHER,
+      'exec',
+      'uv',
+      'run',
+      '--project',
+      'framework/core',
+      'python',
+      'framework/core/tests/qualification/runtime-activation/performance_workload.py',
+    ],
+  },
+  {
+    id: 'product-distribution',
+    product: true,
+    command: [LAUNCHER, 'dist'],
+  },
+  {
+    id: 'product-runtime-smoke',
+    product: true,
+    command: [
+      LAUNCHER,
+      'exec',
+      process.execPath,
+      'framework/core/tests/qualification/runtime-activation/product_smoke.mjs',
+    ],
+  },
+  {
+    id: 'product-verification',
+    product: true,
+    command: [LAUNCHER, 'verify', '--full', '--with-app'],
+  },
+  {
+    id: 'product-catalog',
+    product: true,
+    command: [LAUNCHER, 'builds', '--json'],
+  },
+];
+
+const COVERAGE = {
+  'daemonless-storage': ['activation-core'],
+  'direct-no-fork-coordinator': ['activation-core'],
+  'process-crash-recovery': ['activation-core'],
+  'native-readiness-publication': ['activation-core'],
+  'profile-action-admission': ['profile-action-admission'],
+  'language-product-parity': ['runtime-surface-parity'],
+  'bounded-latency-and-resource-report': ['activation-performance'],
+  'product-artifact-build': ['product-distribution'],
+  'temporary-product-runtime-smoke': ['product-runtime-smoke'],
+  'product-artifact-verification': ['product-verification'],
+  'product-artifact-catalog': ['product-catalog'],
+};
+
+const NON_CLAIMS = [
+  'production EmbeddedRuntimeHost',
+  'distributed election, cross-machine leases, or high availability',
+  'physical-host power-loss qualification from process-crash evidence',
+  'default-on production durability or projection candidate profiles',
+  'universal startup, recovery, or activation latency SLO',
+  'readiness descriptor bytes as authority without native revalidation',
+];
+
+function sha256(value) {
+  return crypto.createHash('sha256').update(value).digest('hex');
+}
+
+function git(args) {
+  const result = spawnSync('git', args, { cwd: ROOT, encoding: 'utf8' });
+  return result.status === 0 ? (result.stdout || '').trim() : null;
+}
+
+export function sourceFacts() {
+  const status = git(['status', '--porcelain']);
+  return {
+    revision: git(['rev-parse', 'HEAD']) || 'unknown',
+    tree: git(['rev-parse', 'HEAD^{tree}']) || 'unknown',
+    dirty: status === null || status !== '',
+  };
+}
+
+export function qualificationPlan({ mode, withProduct }) {
+  return SUITES.map((suite) => {
+    const required = !suite.product || withProduct;
+    return {
+      id: suite.id,
+      command: [...suite.command],
+      required,
+      status: mode === 'dry-run' ? 'planned' : required ? 'planned' : 'skipped',
+      exit_code: null,
+      duration_ms: 0,
+      raw_log: null,
+      raw_sha256: null,
+    };
+  });
+}
+
+function coverageStatus(ids, suites, mode) {
+  const evidence = ids.map((id) => suites.find((suite) => suite.id === id));
+  if (mode === 'dry-run') return 'planned';
+  if (evidence.some((suite) => !suite || suite.status === 'skipped')) {
+    return 'unqualified';
+  }
+  return evidence.every((suite) => suite.status === 'passed')
+    ? 'passed'
+    : 'failed';
+}
+
+export function evaluateQualification({
+  mode,
+  withProduct,
+  source,
+  platform,
+  suites,
+  runId,
+}) {
+  const coverage = Object.entries(COVERAGE).map(([id, evidenceSuites]) => ({
+    id,
+    evidence_suites: evidenceSuites,
+    status: coverageStatus(evidenceSuites, suites, mode),
+  }));
+  const violations = [];
+  if (mode === 'execute' && source.dirty) {
+    violations.push('source tree is dirty; evidence is not source-exact');
+  }
+  if (mode === 'execute' && !withProduct) {
+    violations.push('product artifact qualification was omitted');
+  }
+  const failed = suites.some(
+    (suite) => suite.required && suite.status === 'failed',
+  );
+  const complete = suites
+    .filter((suite) => suite.required)
+    .every((suite) => suite.status === 'passed');
+  const passed =
+    mode === 'execute' &&
+    withProduct &&
+    !source.dirty &&
+    !failed &&
+    complete &&
+    coverage.every((item) => item.status === 'passed');
+  const corePassed = (id) =>
+    suites.find((suite) => suite.id === id)?.status === 'passed';
+  return {
+    schema: 'kungfu.runtime-activation.qualification-report/v1',
+    run_id: runId,
+    mode,
+    product_mode: withProduct ? 'required' : 'omitted',
+    source,
+    platform,
+    suites,
+    coverage,
+    claims: {
+      daemonless_storage_operations: passed && corePassed('activation-core'),
+      direct_no_fork_coordinator: passed && corePassed('activation-core'),
+      process_crash_recovery: passed && corePassed('activation-core'),
+      native_readiness_publication: passed && corePassed('activation-core'),
+      product_artifacts_verified:
+        passed &&
+        corePassed('product-distribution') &&
+        corePassed('product-runtime-smoke') &&
+        corePassed('product-verification') &&
+        corePassed('product-catalog'),
+      embedded_runtime_host: false,
+    },
+    non_claims: NON_CLAIMS,
+    violations,
+    verdict:
+      mode === 'dry-run'
+        ? 'planned'
+        : failed
+          ? 'failed'
+          : passed
+            ? 'passed'
+            : 'unqualified',
+  };
+}
+
+function runSuite(suite, outputDir) {
+  console.log(`[runtime-activation-qualify] running ${suite.id}`);
+  const started = Date.now();
+  const result = spawnSync(suite.command[0], suite.command.slice(1), {
+    cwd: ROOT,
+    env: {
+      ...process.env,
+      ...(suite.id === 'activation-core' ||
+      suite.id === 'activation-performance'
+        ? {
+            PYTHONPATH: [
+              path.join(ROOT, 'framework', 'core', 'src', 'python'),
+              process.env.PYTHONPATH,
+            ]
+              .filter(Boolean)
+              .join(path.delimiter),
+          }
+        : {}),
+    },
+    encoding: 'utf8',
+    maxBuffer: 128 * 1024 * 1024,
+  });
+  const output = `${result.stdout || ''}${result.stderr || ''}`;
+  const rawName = `${suite.id}.log`;
+  fs.writeFileSync(path.join(outputDir, rawName), output, { flag: 'wx' });
+  const passed = !result.error && result.status === 0;
+  console.log(
+    `[runtime-activation-qualify] suite=${suite.id} status=${passed ? 'passed' : 'failed'} duration_ms=${Date.now() - started}`,
+  );
+  return {
+    ...suite,
+    status: passed ? 'passed' : 'failed',
+    exit_code: result.status,
+    duration_ms: Date.now() - started,
+    raw_log: rawName,
+    raw_sha256: sha256(output),
+  };
+}
+
+function parseArgs(argv) {
+  const value = (name) => {
+    const index = argv.indexOf(name);
+    return index >= 0 ? argv[index + 1] : null;
+  };
+  const mode = value('--mode') || 'dry-run';
+  if (!['dry-run', 'execute'].includes(mode)) {
+    throw new Error(`invalid --mode '${mode}'`);
+  }
+  return {
+    mode,
+    withProduct: argv.includes('--with-product'),
+    output: value('--output'),
+  };
+}
+
+function writeJson(pathname, value) {
+  const temporary = `${pathname}.${process.pid}.tmp`;
+  fs.writeFileSync(temporary, `${JSON.stringify(value, null, 2)}\n`, {
+    flag: 'wx',
+  });
+  fs.renameSync(temporary, pathname);
+}
+
+export function validateReport(report) {
+  const schema = JSON.parse(fs.readFileSync(REPORT_SCHEMA_PATH, 'utf8'));
+  const validate = new Ajv2020({ allErrors: true, strict: false }).compile(
+    schema,
+  );
+  if (!validate(report)) {
+    throw new Error(
+      `runtime activation report schema invalid: ${JSON.stringify(validate.errors)}`,
+    );
+  }
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const runId = `runtime-activation-${Date.now()}-${process.pid}`;
+  const outputDir = path.resolve(
+    args.output ||
+      path.join(
+        ROOT,
+        'framework',
+        'core',
+        'build',
+        'qualification',
+        'runtime-activation',
+        runId,
+      ),
+  );
+  fs.mkdirSync(outputDir, { recursive: true });
+  let suites = qualificationPlan(args);
+  if (args.mode === 'execute') {
+    suites = suites.map((suite) =>
+      suite.required ? runSuite(suite, outputDir) : suite,
+    );
+  }
+  const report = evaluateQualification({
+    ...args,
+    source: sourceFacts(),
+    platform: {
+      os: process.platform,
+      arch: process.arch,
+      release: os.release(),
+    },
+    suites,
+    runId,
+  });
+  validateReport(report);
+  const reportPath = path.join(outputDir, 'report.json');
+  writeJson(reportPath, report);
+  console.log(
+    `[runtime-activation-qualify] verdict=${report.verdict} report=${reportPath}`,
+  );
+  if (args.mode === 'execute' && report.verdict !== 'passed') process.exit(1);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(error?.stack || String(error));
+    process.exit(1);
+  });
+}

--- a/framework/core/tests/qualification/runtime-activation/run.mjs
+++ b/framework/core/tests/qualification/runtime-activation/run.mjs
@@ -42,7 +42,16 @@ export const SUITES = [
   {
     id: 'profile-action-admission',
     product: false,
-    command: [LAUNCHER, 'test:agent-profile-sdk'],
+    command: [
+      LAUNCHER,
+      'exec',
+      'uv',
+      'run',
+      '--project',
+      'framework/core',
+      'node',
+      'scripts/run-agent-profile-sdk-tests.mjs',
+    ],
   },
   {
     id: 'runtime-surface-parity',
@@ -145,6 +154,17 @@ export function qualificationPlan({ mode, withProduct }) {
       raw_sha256: null,
     };
   });
+}
+
+export function defaultOutputDir(runId) {
+  return path.join(
+    ROOT,
+    '.buildchain',
+    'runtime',
+    'qualification',
+    'runtime-activation',
+    runId,
+  );
 }
 
 function coverageStatus(ids, suites, mode) {
@@ -306,18 +326,7 @@ export function validateReport(report) {
 async function main() {
   const args = parseArgs(process.argv.slice(2));
   const runId = `runtime-activation-${Date.now()}-${process.pid}`;
-  const outputDir = path.resolve(
-    args.output ||
-      path.join(
-        ROOT,
-        'framework',
-        'core',
-        'build',
-        'qualification',
-        'runtime-activation',
-        runId,
-      ),
-  );
+  const outputDir = path.resolve(args.output || defaultOutputDir(runId));
   fs.mkdirSync(outputDir, { recursive: true });
   let suites = qualificationPlan(args);
   if (args.mode === 'execute') {

--- a/framework/core/tests/qualification/runtime-activation/run.test.mjs
+++ b/framework/core/tests/qualification/runtime-activation/run.test.mjs
@@ -4,10 +4,20 @@ import assert from 'node:assert/strict';
 import { test } from 'node:test';
 
 import {
+  defaultOutputDir,
   evaluateQualification,
   qualificationPlan,
   validateReport,
 } from './run.mjs';
+
+test('default evidence survives Core build-directory cleanup', () => {
+  const output = defaultOutputDir('runtime-activation-test');
+  assert.match(
+    output,
+    /\.buildchain[/\\]runtime[/\\]qualification[/\\]runtime-activation/,
+  );
+  assert.doesNotMatch(output, /framework[/\\]core[/\\]build/);
+});
 
 function source(dirty = false) {
   return {

--- a/framework/core/tests/qualification/runtime-activation/run.test.mjs
+++ b/framework/core/tests/qualification/runtime-activation/run.test.mjs
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+  evaluateQualification,
+  qualificationPlan,
+  validateReport,
+} from './run.mjs';
+
+function source(dirty = false) {
+  return {
+    revision: '1'.repeat(40),
+    tree: '2'.repeat(40),
+    dirty,
+  };
+}
+
+function platform() {
+  return { os: 'darwin', arch: 'arm64', release: 'qualification-test' };
+}
+
+function suites(mode = 'execute', withProduct = true, failed = null) {
+  return qualificationPlan({ mode, withProduct }).map((suite) => ({
+    ...suite,
+    status:
+      suite.id === failed
+        ? 'failed'
+        : mode === 'dry-run'
+          ? 'planned'
+          : suite.required
+            ? 'passed'
+            : 'skipped',
+    exit_code:
+      mode === 'dry-run' || !suite.required
+        ? null
+        : suite.id === failed
+          ? 1
+          : 0,
+    duration_ms: mode === 'dry-run' || !suite.required ? 0 : 1,
+    raw_log: mode === 'dry-run' || !suite.required ? null : `${suite.id}.log`,
+    raw_sha256: mode === 'dry-run' || !suite.required ? null : 'a'.repeat(64),
+  }));
+}
+
+function report(overrides = {}) {
+  const mode = overrides.mode || 'execute';
+  const withProduct = overrides.withProduct ?? true;
+  return evaluateQualification({
+    mode,
+    withProduct,
+    source: overrides.source || source(),
+    platform: platform(),
+    suites:
+      overrides.suites || suites(mode, withProduct, overrides.failed || null),
+    runId: 'runtime-activation-test',
+  });
+}
+
+test('dry-run plans every Shifu-owned qualification step without claims', () => {
+  const value = report({ mode: 'dry-run' });
+  validateReport(value);
+  assert.equal(value.verdict, 'planned');
+  assert.ok(
+    value.suites.every((suite) => /shifu(?:\.cmd)?$/.test(suite.command[0])),
+  );
+  assert.ok(Object.values(value.claims).every((claim) => claim === false));
+});
+
+test('clean passing source qualifies exact product artifacts with bounded claims', () => {
+  const value = report();
+  validateReport(value);
+  assert.equal(value.verdict, 'passed');
+  assert.ok(value.coverage.every((item) => item.status === 'passed'));
+  assert.equal(value.claims.native_readiness_publication, true);
+  assert.equal(value.claims.product_artifacts_verified, true);
+  assert.equal(value.claims.embedded_runtime_host, false);
+});
+
+test('omitted products and dirty source fail closed as unqualified', () => {
+  const omitted = report({ withProduct: false });
+  const dirty = report({ source: source(true) });
+  validateReport(omitted);
+  validateReport(dirty);
+  assert.equal(omitted.verdict, 'unqualified');
+  assert.match(omitted.violations.join('\n'), /product artifact/);
+  assert.equal(dirty.verdict, 'unqualified');
+  assert.match(dirty.violations.join('\n'), /dirty/);
+  assert.ok(Object.values(dirty.claims).every((claim) => claim === false));
+});
+
+test('one failed suite fails its coverage and every supported claim', () => {
+  const value = report({ failed: 'activation-core' });
+  validateReport(value);
+  assert.equal(value.verdict, 'failed');
+  assert.equal(
+    value.coverage.find((item) => item.id === 'native-readiness-publication')
+      .status,
+    'failed',
+  );
+  assert.ok(Object.values(value.claims).every((claim) => claim === false));
+});

--- a/framework/core/tests/qualification/runtime-activation/schemas/runtime-activation-qualification-report-v1.schema.json
+++ b/framework/core/tests/qualification/runtime-activation/schemas/runtime-activation-qualification-report-v1.schema.json
@@ -1,0 +1,140 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kungfu.tech/schemas/runtime-activation-qualification-report-v1.schema.json",
+  "title": "Kungfu Runtime Activation Qualification Report v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "run_id",
+    "mode",
+    "product_mode",
+    "source",
+    "platform",
+    "suites",
+    "coverage",
+    "claims",
+    "non_claims",
+    "violations",
+    "verdict"
+  ],
+  "properties": {
+    "schema": { "const": "kungfu.runtime-activation.qualification-report/v1" },
+    "run_id": { "type": "string", "minLength": 1 },
+    "mode": { "enum": ["dry-run", "execute"] },
+    "product_mode": { "enum": ["omitted", "required"] },
+    "source": { "$ref": "#/$defs/source" },
+    "platform": { "$ref": "#/$defs/platform" },
+    "suites": {
+      "type": "array",
+      "minItems": 8,
+      "items": { "$ref": "#/$defs/suite" }
+    },
+    "coverage": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/coverage" }
+    },
+    "claims": { "$ref": "#/$defs/claims" },
+    "non_claims": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "violations": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "verdict": { "enum": ["planned", "passed", "failed", "unqualified"] }
+  },
+  "$defs": {
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["revision", "tree", "dirty"],
+      "properties": {
+        "revision": { "type": "string", "minLength": 1 },
+        "tree": { "type": "string", "minLength": 1 },
+        "dirty": { "type": "boolean" }
+      }
+    },
+    "platform": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["os", "arch", "release"],
+      "properties": {
+        "os": { "enum": ["darwin", "linux", "win32"] },
+        "arch": { "enum": ["arm64", "x64"] },
+        "release": { "type": "string", "minLength": 1 }
+      }
+    },
+    "suite": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "command",
+        "required",
+        "status",
+        "exit_code",
+        "duration_ms",
+        "raw_log",
+        "raw_sha256"
+      ],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "command": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "required": { "type": "boolean" },
+        "status": { "enum": ["planned", "passed", "failed", "skipped"] },
+        "exit_code": { "type": ["integer", "null"] },
+        "duration_ms": { "type": "integer", "minimum": 0 },
+        "raw_log": { "type": ["string", "null"] },
+        "raw_sha256": {
+          "anyOf": [
+            { "type": "null" },
+            { "type": "string", "pattern": "^[0-9a-f]{64}$" }
+          ]
+        }
+      }
+    },
+    "coverage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "evidence_suites", "status"],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "evidence_suites": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "status": { "enum": ["planned", "passed", "failed", "unqualified"] }
+      }
+    },
+    "claims": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "daemonless_storage_operations",
+        "direct_no_fork_coordinator",
+        "process_crash_recovery",
+        "native_readiness_publication",
+        "product_artifacts_verified",
+        "embedded_runtime_host"
+      ],
+      "properties": {
+        "daemonless_storage_operations": { "type": "boolean" },
+        "direct_no_fork_coordinator": { "type": "boolean" },
+        "process_crash_recovery": { "type": "boolean" },
+        "native_readiness_publication": { "type": "boolean" },
+        "product_artifacts_verified": { "type": "boolean" },
+        "embedded_runtime_host": { "const": false }
+      }
+    }
+  }
+}

--- a/framework/core/tests/storage-node-binding.test.js
+++ b/framework/core/tests/storage-node-binding.test.js
@@ -276,9 +276,13 @@ test(
     assert.deepEqual(
       report.evidence.map((evidence) => evidence.id),
       [
-        'three-platform-process-crash',
-        'single-host-disposable-qemu',
+        'live-durable-receipts',
+        'projection-authority-candidate',
+        'agent120-fault-campaign',
+        'agent120-durability-slo',
         'same-office-offhost-restore',
+        'agent120-clean-host-restart',
+        'production-candidate-admission',
       ],
     );
     assert.deepEqual(

--- a/framework/core/tests/storage-node-binding.test.js
+++ b/framework/core/tests/storage-node-binding.test.js
@@ -274,6 +274,14 @@ test(
     assert.equal(report.admission.physical_power_loss_qualified, false);
     assert.equal(report.admission.production_eligible, false);
     assert.deepEqual(
+      report.evidence.map((evidence) => evidence.id),
+      [
+        'three-platform-process-crash',
+        'single-host-disposable-qemu',
+        'same-office-offhost-restore',
+      ],
+    );
+    assert.deepEqual(
       report.profiles.map((profile) => profile.name),
       ['visible', 'durable_group', 'durable_sync', 'replicated'],
     );

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "episode:qualify": "node scripts/require-shifu.mjs episode:qualify && node framework/core/tests/qualification/episode/run.mjs",
     "episode:qualify:release": "node scripts/require-shifu.mjs episode:qualify:release && node framework/core/tests/qualification/episode/release_evidence.mjs",
     "durability:qualify": "node scripts/require-shifu.mjs durability:qualify && node framework/core/tests/qualification/durability/run.mjs",
+    "runtime:qualify": "node scripts/require-shifu.mjs runtime:qualify && node framework/core/tests/qualification/runtime-activation/run.mjs",
     "durability:powercut:fixture": "node scripts/require-shifu.mjs durability:powercut:fixture && node scripts/run-durability-powercut-fixture.mjs",
     "durability:powercut:plan": "node scripts/require-shifu.mjs durability:powercut:plan && node scripts/plan-durability-powercut.mjs",
     "durability:powercut:prepare": "node scripts/require-shifu.mjs durability:powercut:prepare && node scripts/prepare-durability-powercut-qemu.mjs",

--- a/scripts/source-acceptance.mjs
+++ b/scripts/source-acceptance.mjs
@@ -163,6 +163,7 @@ export function sourceAcceptancePlan(files) {
         'framework/agent-session/tests/interaction-port.test.mjs',
         'framework/agent-session/tests/codex-app-server-contract.test.mjs',
         'framework/agent-session/tests/product-surface.test.mjs',
+        'framework/core/tests/qualification/runtime-activation/run.test.mjs',
         'framework/core/tests/qualification/durability/run.test.mjs',
         'framework/core/tests/qualification/durability/powercut_plan.test.mjs',
         'framework/core/tests/qualification/durability/fault_campaign.test.mjs',

--- a/tests/fixtures/_activate_mission_profile.py
+++ b/tests/fixtures/_activate_mission_profile.py
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Authorize the exact Mission Control Profile used by Atlas fixtures."""
+
+from pathlib import Path
+import sys
+
+core_dir = Path(__file__).resolve().parents[2] / "framework" / "core"
+sys.path.insert(0, str(core_dir / "src" / "python"))
+sys.path.insert(0, str(core_dir / "dist" / "kungfu"))
+
+from kungfu import profile_composition, profile_sdk  # noqa: E402
+
+
+runtime_dir = Path(sys.argv[1])
+source = Path(sys.argv[2])
+
+for action in ("install", "qualify", "activate"):
+    plan = profile_sdk.lifecycle_plan(runtime_dir, action, source)["corePlan"]
+    profile_sdk.lifecycle_apply(runtime_dir, plan, f"fixture:{action}")
+
+contract = profile_composition.contract_materialization_plan(source, runtime_dir)
+if contract["operations"]:
+    profile_composition.authorized_contract_materialize(
+        runtime_dir,
+        contract,
+        profile_sdk.answer_decision(
+            contract["decisionCard"], "approve", "fixture-owner"
+        ),
+    )

--- a/tests/fixtures/_harness.mjs
+++ b/tests/fixtures/_harness.mjs
@@ -117,6 +117,19 @@ export function uvPython(coreDir, args, opts = {}) {
   });
 }
 
+/** Resolve the interpreter selected by the Core uv project under Shifu. */
+export function corePython(coreDir) {
+  const result = uvPython(coreDir, [
+    '-c',
+    'import sys; print(sys.executable)',
+  ]);
+  const executable = result.stdout.trim();
+  if (!path.isAbsolute(executable) || !fs.existsSync(executable)) {
+    fail(`core Python resolution returned an invalid path: ${executable}`);
+  }
+  return executable;
+}
+
 /**
  * The dev-console kfc: `uv run --frozen python .devtools/kungfu_cli.py -H <home> <args>`.
  * Returns the spawnSync result; `.stdout` carries any --json payload.

--- a/tests/fixtures/atlas-demo-import/check_import.py
+++ b/tests/fixtures/atlas-demo-import/check_import.py
@@ -195,13 +195,15 @@ from kungfu.storage import service as storage_service  # noqa: E402
 
 listed = storage_service.episode_list(runtime_dir, limit=0).get("episodes", [])
 atlas_episodes = [
-    row for row in listed if str(row.get("source") or "").startswith("atlas:imp")
+    row
+    for row in listed
+    if str(row.get("open", {}).get("source") or "").startswith("atlas:imp")
 ]
 check(
     "one sealed episode per import batch",
     len(atlas_episodes) == 2
-    and all(row.get("status") == "ended" for row in atlas_episodes),
-    f"got {[(row.get('episode_id'), row.get('status')) for row in atlas_episodes]}",
+    and all(row.get("closed") is True for row in atlas_episodes),
+    f"got {[(row.get('episode_id'), row.get('closed')) for row in atlas_episodes]}",
 )
 
 episode_id = 0
@@ -218,17 +220,25 @@ if episode_id:
     episode = inspected.get("episode", {})
     check(
         "episode source names the import",
-        episode.get("source") == f"atlas:{latest_import_id}",
-        f"got {episode.get('source')}",
+        episode.get("open", {}).get("source") == f"atlas:{latest_import_id}",
+        f"got {episode.get('open', {}).get('source')}",
     )
-    attached = inspected.get("frames", [])
+    records = episode.get("records", [])
+    attached = [
+        records[index]
+        for index in episode.get("frame_indices", [])
+        if 0 <= index < len(records)
+    ]
     check(
         "episode frames == batch frames (begin + snapshots + end)",
         len(attached) == len(entries) + 2,
         f"got {len(attached)}, want {len(entries) + 2}",
     )
     payload_refs = [
-        ref for ref in inspected.get("refs", []) if ref.get("ref_kind") == "payload"
+        records[index]
+        for index in episode.get("ref_indices", [])
+        if 0 <= index < len(records)
+        and records[index].get("body", {}).get("ref_kind") == 2
     ]
     present_hashes = {
         entry.get("payload_hash")
@@ -255,11 +265,15 @@ if episode_id:
         f"got {report.get('checked', {}).get('episode_frames_verified')}",
     )
     qualification = report.get("qualification", {})
+    safe_capabilities = {
+        capability.get("name")
+        for capability in qualification.get("capabilities", [])
+        if capability.get("safe") is True
+    }
     check(
         "sealed batch qualifies for replay/depend_on",
-        "replay" in qualification.get("safe_capabilities", [])
-        and "depend_on" in qualification.get("safe_capabilities", []),
-        f"got {qualification.get('safe_capabilities')}",
+        "replay" in safe_capabilities and "depend_on" in safe_capabilities,
+        f"got {sorted(safe_capabilities)}",
     )
 
     # ── negative (destructive, keep last): losing the event journal must ──
@@ -277,7 +291,11 @@ if episode_id:
     report = storage_service.fsck(
         runtime_dir, episode_id=episode_id, verify_frames=True
     )
-    codes = {error.get("code") for error in report.get("errors", [])}
+    codes = {
+        issue.get("code")
+        for issue in report.get("issues", [])
+        if issue.get("severity") == "error"
+    }
     check(
         "sealed episode fails fsck after journal loss",
         report.get("ok") is False and "episode_attached_frame_missing" in codes,

--- a/tests/fixtures/kfx-demo-atlas-capability/roundtrip.mjs
+++ b/tests/fixtures/kfx-demo-atlas-capability/roundtrip.mjs
@@ -4,9 +4,9 @@ import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import { openAtlas } from '../../../framework/api/src/capability/atlas.ts';
-import { fail, locate, tmpDir } from '../_harness.mjs';
+import { fail, locate, tmpDir, uvPython } from '../_harness.mjs';
 
-const { fixtureDir } = locate(import.meta.url);
+const { fixtureDir, coreDir } = locate(import.meta.url);
 const repoDir = path.resolve(fixtureDir, '..', '..', '..');
 const sampleRoot = path.resolve(
   fixtureDir,
@@ -20,6 +20,12 @@ const bin = path.join(repoDir, 'framework', 'core', 'dist', 'kungfu', 'kungfu');
 if (!fs.existsSync(bin)) {
   fail('kungfu CLI is not frozen (run ./shifu freeze first)');
 }
+
+uvPython(coreDir, [
+  path.join(fixtureDir, '..', '_activate_mission_profile.py'),
+  runtimeDir,
+  path.join(repoDir, 'extensions', 'mission-control'),
+]);
 
 const atlas = openAtlas({
   runtimeDir,
@@ -38,7 +44,10 @@ const imported = atlas.importRepo(sampleRoot);
 ck('import counted one mission', imported.missions === 1);
 ck('import counted two goals', imported.goals === 2);
 ck('import counted one marker', imported.markers === 1);
-ck('import surfaced broken-json warning', imported.warnings.length === 1);
+ck(
+  'import surfaced broken-json warning',
+  imported.warnings.some((warning) => warning.includes('broken.json')),
+);
 
 const info = atlas.importInfo();
 ck('import info is readable', info?.import_id === imported.import_id);

--- a/tests/fixtures/kfx-demo-install/check_install.py
+++ b/tests/fixtures/kfx-demo-install/check_install.py
@@ -35,7 +35,8 @@ if os.path.isfile(manifest_path):
     check("key is work-dashboard", config.get("key") == "work-dashboard")
     check(
         "view declares capabilities",
-        view.get("capabilities") == ["ledger", "work", "atlas"],
+        view.get("capabilities")
+        == ["ledger", "work", "atlas", "profile", "storage", "workspace"],
     )
     check(
         "package name is the published one",

--- a/tests/fixtures/kfx-demo-scaffold/run.mjs
+++ b/tests/fixtures/kfx-demo-scaffold/run.mjs
@@ -61,10 +61,13 @@ if (!fs.existsSync(bundle)) fail('kungfu sdk kfx build produced no bundle');
 // the load contract, asserted the way the shell loads it: CommonJS-wrap with
 // a require shim; only shell-provided modules may be required; the bundle
 // must export a View component function
+const providedModules = JSON.parse(
+  fs.readFileSync(path.join(repoDir, 'framework', 'kfx', 'shared-modules.json')),
+).modules;
 const loadContract = `
 const fs = require("node:fs");
 const code = fs.readFileSync(process.argv[1], "utf8");
-const provided = ["react", "react/jsx-runtime", "react-dom", "@kungfu-tech/api", "@kungfu-tech/api/capability"];
+const provided = ${JSON.stringify(providedModules)};
 const m = { exports: {} };
 new Function("require", "module", "exports", code)(
   (id) => { if (provided.includes(id)) return {}; throw new Error("unexpected require: " + id); },

--- a/tests/fixtures/kfx-demo-trust-authority/run.mjs
+++ b/tests/fixtures/kfx-demo-trust-authority/run.mjs
@@ -13,10 +13,19 @@ import path from 'node:path';
 import { locate } from '../_harness.mjs';
 
 const { fixtureDir } = locate(import.meta.url);
+const resolver = path.resolve(
+  fixtureDir,
+  '../../../framework/api/src/capability/guest-harness/ts-resolve.mjs',
+);
 
 const r = spawnSync(
   process.execPath,
-  ['--experimental-transform-types', path.join(fixtureDir, 'authority.test.mjs')],
+  [
+    '--import',
+    resolver,
+    '--experimental-transform-types',
+    path.join(fixtureDir, 'authority.test.mjs'),
+  ],
   { stdio: 'inherit' },
 );
 process.exit(r.status ?? 1);

--- a/tests/fixtures/kfx-demo-work-dashboard-atlas-live/render-live.mjs
+++ b/tests/fixtures/kfx-demo-work-dashboard-atlas-live/render-live.mjs
@@ -5,9 +5,9 @@ import fs from 'node:fs';
 import { createRequire } from 'node:module';
 import path from 'node:path';
 import { openAtlas } from '../../../framework/api/src/capability/atlas.ts';
-import { fail, locate, tmpDir } from '../_harness.mjs';
+import { fail, locate, tmpDir, uvPython } from '../_harness.mjs';
 
-const { fixtureDir } = locate(import.meta.url);
+const { fixtureDir, coreDir } = locate(import.meta.url);
 const repoDir = path.resolve(fixtureDir, '..', '..', '..');
 const sampleRoot = path.resolve(
   fixtureDir,
@@ -35,6 +35,12 @@ if (!fs.existsSync(bin)) {
 if (!fs.existsSync(bundlePath)) {
   fail('work-dashboard is not built (run kungfu sdk kfx build first)');
 }
+
+uvPython(coreDir, [
+  path.join(fixtureDir, '..', '_activate_mission_profile.py'),
+  runtimeDir,
+  path.join(repoDir, 'extensions', 'mission-control'),
+]);
 
 const atlas = openAtlas({
   runtimeDir,
@@ -67,6 +73,35 @@ const fakeShell = {
 };
 const capabilityModule = {
   WORK_STATUS_NAMES: ['active', 'blocked', 'waiting', 'ready', 'done'],
+  DEFAULT_GOAL_CARD_QUERY: {
+    schema: 'kungfu.mission-control.goal-card-query/v1',
+    text: '',
+    sections: [],
+    statuses: [],
+    trust: [],
+    actors: [],
+    tracks: [],
+    roles: [],
+    importance: [],
+    stages: [],
+    updatedWithinDays: null,
+    hasChildren: 'all',
+    closed: 'include',
+    hideClosedChildren: false,
+    sort: { field: 'decision-priority', direction: 'desc' },
+  },
+  emptyQueryChangelogState: () => ({
+    rows: {},
+    evidence: {},
+    changes: {},
+    appliedMessageIds: [],
+    resultSchema: null,
+    frontier: { kind: 'empty', record_count: '0' },
+    resultHash: '',
+    gap: null,
+  }),
+  applyQueryChangelogPage: (state) => state,
+  parseGoalCardQuerySpec: (value) => value,
 };
 const module = { exports: {} };
 const code = fs.readFileSync(bundlePath, 'utf8');
@@ -90,13 +125,11 @@ const html = ReactDomServer.renderToStaticMarkup(
 );
 
 for (const needle of [
-  'Atlas projection',
   'Demo platform stewardship',
-  '2026-01-02-demo-importer',
   'Demo importer goal',
-  '1 missions',
-  '2 goals',
-  '1 markers',
+  '1 Mission',
+  '2 Go cards',
+  '1 imported timeline marker',
 ]) {
   if (!html.includes(needle)) fail(`live Atlas tab missing ${needle}`);
 }

--- a/tests/fixtures/rewind-demo-happy/check_capture.py
+++ b/tests/fixtures/rewind-demo-happy/check_capture.py
@@ -215,19 +215,31 @@ episodes = storage_service.episode_list(runtime_dir, limit=0)
 matching_episodes = [
     row
     for row in episodes.get("episodes", [])
-    if row.get("source") == f"rewind:{run_id}"
+    if row.get("open", {}).get("source") == f"rewind:{run_id}"
 ]
 check("Episode created for traced run", len(matching_episodes) == 1)
 if matching_episodes:
     episode = matching_episodes[0]
-    check("Episode status ended", episode.get("status") == "ended", str(episode))
-    check("Episode actor is trace", episode.get("actor") == "kungfu trace")
+    check(
+        "Episode status ended",
+        episode.get("closed") is True and episode.get("close", {}).get("status") == 2,
+    )
+    check(
+        "Episode actor is trace",
+        episode.get("open", {}).get("actor") == "kungfu trace",
+    )
     inspected = storage_service.episode_inspect(
         runtime_dir, episode_id=int(episode["episode_id"])
     )
-    attached_uids = {row.get("frame_uid") for row in inspected.get("frames", [])}
-    expected_uids = {
-        row[0].frame_uid
+    typed_episode = inspected["episode"]
+    records = typed_episode.get("records", [])
+    attached_gen_times = {
+        records[index].get("body", {}).get("gen_time")
+        for index in typed_episode.get("frame_indices", [])
+        if 0 <= index < len(records)
+    }
+    expected_gen_times = {
+        row[0].gen_time
         for rows in (
             begin_frames,
             req_frames,
@@ -239,8 +251,11 @@ if matching_episodes:
         )
         for row in rows
     }
-    check("Episode attached every run frame", attached_uids == expected_uids)
-    check("Episode has payload refs", len(inspected.get("refs", [])) >= 1)
+    check(
+        "Episode attached every run frame",
+        attached_gen_times == expected_gen_times,
+    )
+    check("Episode has payload refs", len(typed_episode.get("ref_indices", [])) >= 1)
     fsck = storage_service.fsck(runtime_dir, episode_id=int(episode["episode_id"]))
     check("Episode fsck ok", fsck.get("ok") is True, str(fsck.get("errors", [])))
     exported = storage_service.build_export_bundle(
@@ -248,7 +263,8 @@ if matching_episodes:
     )
     check("Episode export bundle ok", exported.get("scope") == "episode")
     check(
-        "Episode export has frames", exported.get("frame_count") == len(expected_uids)
+        "Episode export has frames",
+        exported.get("frame_count") == len(expected_gen_times),
     )
 
 if failures:

--- a/tests/fixtures/rewind-demo-kfx-schema/run.mjs
+++ b/tests/fixtures/rewind-demo-kfx-schema/run.mjs
@@ -10,22 +10,22 @@
 // Usage: node tests/fixtures/rewind-demo-kfx-schema/run.mjs
 
 import path from 'node:path';
-import { locate, tmpDir, kfc, uvPython } from '../_harness.mjs';
+import {
+  corePython,
+  locate,
+  tmpDir,
+  kfc,
+  uvPython,
+} from '../_harness.mjs';
 
 const { fixtureDir, coreDir } = locate(import.meta.url);
 const home = tmpDir('rewind-kfx-');
 const runId = `fixturekfx${Date.now()}`;
-const pythonEnvironment =
-  process.env.UV_PROJECT_ENVIRONMENT || path.join(coreDir, '.venv');
-
 // the kfx child is the core's own interpreter (has flatbuffers); it reaches the
 // kungfu package + binding itself, and the supervisor injects the capture hook.
 // dyld/ld/PATH fallback so both the supervisor and the kfx child can import
 // pykungfu (compile_schema) is provided by the harness runtimeEnv (folded into kfc).
-const venvPython =
-  process.platform === 'win32'
-    ? path.join(pythonEnvironment, 'Scripts', 'python.exe')
-    : path.join(pythonEnvironment, 'bin', 'python');
+const venvPython = corePython(coreDir);
 
 kfc(coreDir, home, [
   'trace',


### PR DESCRIPTION
## Summary

- qualify topology-neutral runtime activation with retained deterministic evidence
- close SDK/product build toolchain gaps on the managed Core Python runtime
- integrate the frozen `dev/v4/v4.0@16f02290b` baseline, including KFD-1 durability config, shared agent-session product surfaces, and Codex App Server contracts
- retain machine-readable Mac product qualification evidence and explicit non-claims

## Qualification

- `./shifu check:source` — passed; 224 source-contract tests
- `./shifu verify --full --with-app` — 82/82 passed
- `./shifu runtime:qualify -- --mode execute --with-product` — 8/8 suites passed
- retained report: `docs/qualification/evidence/runtime-activation/8643f1187/report.json`
- report SHA-256: `be98265b8dffa96b45d38496b6dc27560daab88afc844588c74150fc8ff5594f`
- Mac artifact: `20260714T113632Z-8643f1187`

## Boundaries

- qualified on macOS arm64 only
- no production `EmbeddedRuntimeHost` claim
- no HA/replication or physical power-cut claim
- process topology remains a placement adapter behind capability/readiness semantics

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "implemented",
  "adrs": ["ADR-0080"],
  "summary": "Complete topology-neutral capability-driven runtime activation and retain qualified macOS arm64 product evidence with explicit non-claims.",
  "verification": ["source gate 224 tests", "full product verification 82/82", "runtime activation qualification 8/8", "retained report be98265b8dffa96b45d38496b6dc27560daab88afc844588c74150fc8ff5594f"]
}
-->

## Governance risk check

- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

No package publication or deployment is performed by this PR; the retained local product evidence is bounded to macOS arm64.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation and qualification evidence updated
- [x] Claims remain bounded to the retained report
