### PR TITLE
refactor(gui): make shell profile-neutral

### DIFF
--- a/docs/adr/ADR-0083-core-system-kfx-profile-kfx-capability-boundary.md
+++ b/docs/adr/ADR-0083-core-system-kfx-profile-kfx-capability-boundary.md
@@ -4,7 +4,7 @@ doc_type: architecture-decision
 adr_id: ADR-0083
 decision_status: accepted
 implementation_status: partial
-implementation_commits: [c6266fe3ea37e096ced272c497b6e729218c7a3b, ef4421c8607860978f7d2b890ab68c149d97747a, bdf3800cb34182b59d3f341dee08056a5ebf6bd0]
+implementation_commits: [c6266fe3ea37e096ced272c497b6e729218c7a3b, ef4421c8607860978f7d2b890ab68c149d97747a, bdf3800cb34182b59d3f341dee08056a5ebf6bd0, 7e17031ef398e77caab1f707426e7b2270533b60]
 review_state: self-reviewed
 sensitivity: public
 sources: [local-files, user-consensus]

--- a/framework/gui/docs/shell-and-kfx.md
+++ b/framework/gui/docs/shell-and-kfx.md
@@ -124,6 +124,11 @@ Profile. A custom Profile therefore supplies its own first screen without a
 Kungfu rebuild or a Shell edit. If that view is absent or disabled, the Shell
 opens Profiles visibly instead of rendering a blank screen.
 
+Product assembly can recommend the first focused Profile by setting
+`KFE_DEFAULT_PROFILE` to a discovered Profile id. A persisted valid focus wins;
+an absent recommendation falls back to discovery order, while a stale persisted
+id opens Profile Manager. The Shell never assigns domain meaning to the id.
+
 Mission Control uses this public path. Its Home plus the fixed Agent Console,
 Profiles and Skills entries form the primary Activity Rail. Facts live under
 Tools; Runtime Status, Config Store, Journal Inspector and Rewind Inspector

--- a/framework/gui/src/main/index.ts
+++ b/framework/gui/src/main/index.ts
@@ -40,7 +40,6 @@ import {
   WINDOW_CHROME_CONTROL_CHANNEL,
   WINDOW_CHROME_GET_CHANNEL,
   WINDOW_CHROME_STATE_CHANNEL,
-  WORKSPACE_CREATE_MISSION_CHANNEL,
   WORKSPACE_GET_CHANNEL,
   WORKSPACE_OPEN_CHANNEL,
   WORKSPACE_SELECT_HOME_CHANNEL,
@@ -729,56 +728,6 @@ ipcMain.handle(WORKSPACE_SELECT_RECENT_CHANNEL, (_event, payload) => {
     '--json',
   ]);
 });
-ipcMain.handle(WORKSPACE_CREATE_MISSION_CHANNEL, (_event, payload) => {
-  const input = payload as {
-    missionId?: unknown;
-    title?: unknown;
-    intent?: unknown;
-  };
-  const missionId = String(input.missionId || '').trim();
-  const title = String(input.title || '').trim();
-  const intent = String(input.intent || '').trim();
-  if (!missionId || !title || !intent) {
-    throw new Error('Mission id, title, and intent are required');
-  }
-  const ensureArgs = ['workspace', 'ensure'];
-  if (process.env.KF_WORKSPACE_KIND === 'home') ensureArgs.push('--home');
-  else if (process.env.KF_WORKSPACE_ROOT)
-    ensureArgs.push(process.env.KF_WORKSPACE_ROOT);
-  else throw new Error('selected project workspace root is unavailable');
-  ensureArgs.push('--reason', 'create-mission', '--json');
-  execFileSync(kungfuBinPath(), ensureArgs, {
-    env: process.env,
-    timeout: 10000,
-  });
-  const out = execFileSync(
-    kungfuBinPath(),
-    [
-      'atlas',
-      'create-mission',
-      missionId,
-      '--title',
-      title,
-      '--intent',
-      intent,
-      '--actor',
-      'desktop-user',
-      '--actor-type',
-      'user',
-      '--status',
-      'active',
-      '--json',
-    ],
-    { env: process.env, timeout: 15000 },
-  );
-  const receipt = JSON.parse(out.toString());
-  setImmediate(() => {
-    app.relaunch();
-    app.exit(0);
-  });
-  return { ok: true, receipt };
-});
-
 // Application menu with the VS Code-style "Install 'kungfu' Command in PATH"
 // action, so a real user who installed Kungfu Episodes.app can use `kungfu` in a shell.
 function buildMenu() {

--- a/framework/gui/src/navigation.test.ts
+++ b/framework/gui/src/navigation.test.ts
@@ -14,7 +14,7 @@ import {
 } from './navigation';
 
 const state: ShellState = {
-  profileId: 'kungfu.mission-control',
+  profileId: 'default',
   disabledKfx: [],
   disabledSuites: [],
   sidebarCollapsed: false,
@@ -96,10 +96,32 @@ test('missing Profile Home falls back visibly to Profiles', () => {
   });
 });
 
-test('legacy default focus resolves to discovered Mission Control', () => {
-  const profiles = availableProfiles([missionControl]);
-  assert.equal(focusedProfile(profiles, 'default').id, missionControl.id);
-  assert.equal(availableProfiles([])[0].defaultView, 'kfx-manager');
+test('default focus resolves to the first discovered Profile', () => {
+  const custom: ProfileManifest = {
+    id: 'example.week-day',
+    title: 'Week / Day',
+    kfx: ['week-dashboard'],
+    defaultView: 'week-dashboard',
+  };
+  const profiles = availableProfiles([custom, missionControl]);
+  assert.equal(focusedProfile(profiles, 'default').id, custom.id);
+  assert.equal(
+    focusedProfile(profiles, 'default', missionControl.id).id,
+    missionControl.id,
+  );
+});
+
+test('empty discovery resolves to the visible Profile Manager fallback', () => {
+  const profiles = availableProfiles([]);
+  assert.equal(profiles[0].id, 'system.profile-manager');
+  assert.equal(focusedProfile(profiles, 'default').defaultView, 'kfx-manager');
+});
+
+test('a missing persisted Profile degrades to Profile Manager', () => {
+  assert.equal(
+    focusedProfile([missionControl], 'missing.profile').id,
+    'system.profile-manager',
+  );
 });
 
 test('focus does not deactivate KFX; explicit disable state does', () => {

--- a/framework/gui/src/navigation.ts
+++ b/framework/gui/src/navigation.ts
@@ -47,16 +47,18 @@ export function availableProfiles(
 export function focusedProfile(
   profiles: readonly ProfileManifest[],
   profileId: string,
+  recommendedProfileId = '',
 ): ProfileManifest {
   const exact = profiles.find((profile) => profile.id === profileId);
   if (exact) return exact;
   if (profileId === 'default') {
-    const missionControl = profiles.find(
-      (profile) => profile.id === 'kungfu.mission-control',
+    return (
+      profiles.find((profile) => profile.id === recommendedProfileId) ??
+      profiles[0] ??
+      FALLBACK_PROFILE
     );
-    if (missionControl) return missionControl;
   }
-  return profiles[0] ?? FALLBACK_PROFILE;
+  return FALLBACK_PROFILE;
 }
 
 export function accessibleEntries<T extends NavigationEntry>(

--- a/framework/gui/src/renderer/src/main.tsx
+++ b/framework/gui/src/renderer/src/main.tsx
@@ -51,7 +51,6 @@ import {
   WINDOW_CHROME_CONTROL_CHANNEL,
   WINDOW_CHROME_GET_CHANNEL,
   WINDOW_CHROME_STATE_CHANNEL,
-  WORKSPACE_CREATE_MISSION_CHANNEL,
   WORKSPACE_GET_CHANNEL,
   WORKSPACE_OPEN_CHANNEL,
   WORKSPACE_SELECT_HOME_CHANNEL,
@@ -623,12 +622,6 @@ function workspaceIpc() {
     home: () => ipcRenderer.invoke(WORKSPACE_SELECT_HOME_CHANNEL),
     recent: (workspaceId: string) =>
       ipcRenderer.invoke(WORKSPACE_SELECT_RECENT_CHANNEL, { workspaceId }),
-    createMission: (missionId: string, title: string, intent: string) =>
-      ipcRenderer.invoke(WORKSPACE_CREATE_MISSION_CHANNEL, {
-        missionId,
-        title,
-        intent,
-      }),
   };
 }
 
@@ -638,9 +631,6 @@ function WorkspacePanel() {
     null,
   );
   const [error, setError] = React.useState<string | null>(null);
-  const [missionId, setMissionId] = React.useState('');
-  const [missionTitle, setMissionTitle] = React.useState('');
-  const [missionIntent, setMissionIntent] = React.useState('');
   React.useEffect(() => {
     void bridge
       .get()
@@ -692,37 +682,12 @@ function WorkspacePanel() {
           }}
         >
           <div style={{ ...mono, color: '#9cdcfe' }}>
-            First fact-bearing action · Create Mission
+            This Workspace has not been initialized yet.
           </div>
-          <input
-            value={missionId}
-            placeholder="stable Mission id"
-            onChange={(event) => setMissionId(event.target.value)}
-            style={{ ...mono, padding: '5px 7px' }}
-          />
-          <input
-            value={missionTitle}
-            placeholder="Mission title"
-            onChange={(event) => setMissionTitle(event.target.value)}
-            style={{ ...mono, padding: '5px 7px' }}
-          />
-          <input
-            value={missionIntent}
-            placeholder="What are we trying to achieve?"
-            onChange={(event) => setMissionIntent(event.target.value)}
-            style={{ ...mono, padding: '5px 7px' }}
-          />
-          <button
-            type="button"
-            onClick={() =>
-              run(() =>
-                bridge.createMission(missionId, missionTitle, missionIntent),
-              )
-            }
-            style={{ ...mono, padding: '6px 10px' }}
-          >
-            Create Mission and initialize Workspace
-          </button>
+          <div style={{ ...mono, color: '#858585' }}>
+            Open the focused Profile and run its first fact-bearing action when
+            you are ready.
+          </div>
         </div>
       )}
       {snapshot?.recent.map((recent) => (
@@ -768,7 +733,11 @@ function App() {
     () => availableProfiles(loaded.profiles),
     [loaded.profiles],
   );
-  const profile = focusedProfile(profiles, state.profileId);
+  const profile = focusedProfile(
+    profiles,
+    state.profileId,
+    window.process.env.KFE_DEFAULT_PROFILE,
+  );
   const enabled = React.useMemo(
     () => accessibleEntries(loaded.entries, state),
     [loaded.entries, state],

--- a/framework/gui/src/renderer/src/shell-state.ts
+++ b/framework/gui/src/renderer/src/shell-state.ts
@@ -13,7 +13,7 @@ export const SHELL_STATE_LOCATION = {
 } as const;
 
 export const DEFAULT_STATE: ShellState = {
-  profileId: 'kungfu.mission-control',
+  profileId: 'default',
   disabledKfx: [],
   disabledSuites: [],
   sidebarCollapsed: false,

--- a/framework/gui/src/sandbox/channels.ts
+++ b/framework/gui/src/sandbox/channels.ts
@@ -68,4 +68,3 @@ export const WORKSPACE_GET_CHANNEL = 'kf-workspace:get';
 export const WORKSPACE_OPEN_CHANNEL = 'kf-workspace:open';
 export const WORKSPACE_SELECT_HOME_CHANNEL = 'kf-workspace:select-home';
 export const WORKSPACE_SELECT_RECENT_CHANNEL = 'kf-workspace:select-recent';
-export const WORKSPACE_CREATE_MISSION_CHANNEL = 'kf-workspace:create-mission';


### PR DESCRIPTION
## Summary

Make the GUI Shell profile-neutral while preserving Workspace selection, lazy initialization, and recovery behavior.

## Related issue

None.

## Changes

- replace the Mission Control default and special fallback with a generic product recommendation and persisted Profile focus
- degrade missing or empty Profiles to Profile Manager instead of a blank or domain-specific page
- remove the Create Mission form, IPC channel, and main-process domain write from Workspace UI
- document the generic `KFE_DEFAULT_PROFILE` assembly seam and bind ADR-0083 to the implementation commit

## Verification

- `./shifu test:kfx-profile-suite`
- `./shifu check:source`
- `./shifu build:app`
- `./shifu docs:check`
- `./shifu adr:audit -- --json`
- staged pre-commit gate

The full `./shifu check` reached unrelated baseline SDK contract drift after all changed-scope checks passed: the base branch already exposes `agent-session` while the SDK expected surface list and rendered canonical policy still contain four surfaces.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "stage-ready",
  "adrs": ["ADR-0083"],
  "summary": "Complete the profile-neutral GUI Shell stage without changing Workspace or Profile authority",
  "verification": ["./shifu test:kfx-profile-suite", "./shifu check:source", "./shifu build:app", "./shifu docs:check", "./shifu adr:audit -- --json", "staged pre-commit gate"]
}
-->

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] release evidence, provenance, package publishing, or deployment surfaces
- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed
