### PR TITLE
fix(gates): require measurements for new gates

### DIFF
--- a/docs/document-metadata.registry.json
+++ b/docs/document-metadata.registry.json
@@ -524,6 +524,22 @@
       "review_state": "self-reviewed",
       "sensitivity": "public"
     },
+    "docs/qualification/gates/measurement-coverage.md": {
+      "metadata_schema": "kungfu.document-metadata/v1",
+      "document_status": "active",
+      "doc_type": "qualification-evidence-index",
+      "review_state": "self-reviewed",
+      "sensitivity": "public",
+      "sources": [
+        "executable-probe",
+        "local-files"
+      ],
+      "period": "2026-07-14",
+      "theme": "gate-measurement-coverage",
+      "confidence": "high",
+      "evidence_grade": "A",
+      "last_reviewed": "2026-07-14"
+    },
     "docs/qualification/gates/native-qualification.md": {
       "metadata_schema": "kungfu.document-metadata/v1",
       "document_status": "active",

--- a/docs/qualification/gates/README.md
+++ b/docs/qualification/gates/README.md
@@ -13,6 +13,9 @@ explains Kungfu's current policy and does not redefine Shifu semantics.
 - [Workflow bindings](workflow-bindings.json) record how current GitHub
   workflows activate profiles and gates. Schema v2 makes direct Gate,
   Buildchain Gate-profile, and controller entries structure-checked.
+- [Measurement coverage](measurement-coverage.md) records the observed
+  per-platform `durationMs`, clean source SHA, Gate definition digest, registry
+  digest, and retained Shifu receipt for measured Gates.
 - Buildchain owns runner allocation and aggregate checks; the standing patrol
   is pinned to the immutable `v2.12.4` release commit
   `a6145efc210a961da0e5c63d7024d42061550f60`. Buildchain cannot weaken a
@@ -148,12 +151,30 @@ the Buildchain orchestration stage registers their handlers.
 3. Declare the workflow/job execution in `workflow-bindings.json`; direct Gate
    and profile ids must be statically recoverable from YAML, while every
    controller must declare one bounded adapter.
-4. Regenerate the matrix with the catalog checker write mode.
-5. Run `./shifu check:gate-catalog` and `./shifu check:source`.
-6. Treat policy-strength changes as rollout decisions, not documentation edits.
+4. For every new Gate, run the diagnostic Gate on every platform declared by
+   `platforms` from one clean source revision and retain each
+   `shifu.gate-receipt/v1` JSON under `docs/qualification/evidence/`. The
+   matching result must be attempted, passing, exit `0`, and contain the
+   current Gate definition digest and measured `durationMs`.
+5. Add the receipts and their exact source, registry, duration, and platform
+   fields to `measurement-coverage.json`. The frozen adoption baseline cannot
+   be expanded; even a new `off` Gate requires measurement coverage.
+6. Regenerate the policy and measurement tables with
+   `node scripts/check-kungfu-gate-catalog.mjs --write`.
+7. Run `./shifu check:gate-catalog` and `./shifu check:source`.
+8. Treat policy-strength changes as rollout decisions, not documentation edits.
+
+Measurements are retained observations, not live benchmarks. They do not
+change automatically after a later code commit. A Gate definition change makes
+its registered definition digest stale and fails the catalog check. An
+implementation-only change cannot be inferred from the registry, so the author
+must re-run and replace the observations whenever it can materially affect
+runtime or expected cost.
 
 The catalog meta gate checks schema and semantic validity, task existence,
 documentation anchors and required fields, the generated matrix bytes,
 structured direct/profile/controller workflow facts, adapter uniqueness and
-input contracts, and profile coverage. It proves structural consistency, not
-that a prose explanation is semantically wise.
+input contracts, profile coverage, and source-bound measurement coverage. It
+rejects missing platforms, dirty source, failed/skipped results, stale Gate
+definitions, mismatched durations, and missing receipts. It proves structural
+consistency, not that a prose explanation is semantically wise.

--- a/docs/qualification/gates/measurement-coverage.json
+++ b/docs/qualification/gates/measurement-coverage.json
@@ -1,0 +1,180 @@
+{
+  "schema": "kungfu.gate-measurement-coverage/v1",
+  "registry": "shifu.gates.json",
+  "baseline": {
+    "adoptedAt": "2026-07-14",
+    "unmeasuredGateIds": [
+      "docs.contracts",
+      "docs.external-links",
+      "docs.prose",
+      "durability.contracts",
+      "embedding.membranes",
+      "episode.release",
+      "episode.smoke",
+      "governance.adr-delivery",
+      "governance.buildchain-config",
+      "governance.dco",
+      "governance.promotion-rehearsal",
+      "layers.release",
+      "mmap.contracts",
+      "mmap.performance",
+      "product.distribution",
+      "product.verify-full",
+      "product.verify-fuzz",
+      "profile.agent-sdk",
+      "profile.kfd3",
+      "profile.lifecycle",
+      "profile.suite",
+      "release.artifact-admission",
+      "runtime.crash-recovery",
+      "runtime.durable-ingest",
+      "runtime.errors",
+      "runtime.projection-bootstrap",
+      "shifu.workspace",
+      "source.acceptance",
+      "source.changed-scope",
+      "source.whole-tree",
+      "state-service.contracts",
+      "toolchain.cpp-modules",
+      "toolchain.libwasm-cache"
+    ],
+    "digest": "sha256:2fc06a1263119544e4130724390f737016797de7c5df0a17cbf10ab23c024fb9"
+  },
+  "measurements": [
+    {
+      "gateId": "gate.catalog",
+      "definitionDigest": "sha256:2102f39caca0c0286084c59e552b7f42f5d6df2315adac134e5ae9d834559856",
+      "observations": [
+        {
+          "platform": "linux",
+          "sourceSha": "c4ba70d9542d42bbd75ddd9dd4c7ff079f4570fa",
+          "registryDigest": "sha256:26716c1b1979fa3789f35caf5db97dae103462a7e02aebd4f4026b0ea2923526",
+          "durationMs": 433,
+          "receipt": "docs/qualification/evidence/layer-gates/c4ba70d95/linux-x64.raw/layer-artifact-gate-receipt.json"
+        },
+        {
+          "platform": "macos",
+          "sourceSha": "c4ba70d9542d42bbd75ddd9dd4c7ff079f4570fa",
+          "registryDigest": "sha256:26716c1b1979fa3789f35caf5db97dae103462a7e02aebd4f4026b0ea2923526",
+          "durationMs": 694,
+          "receipt": "docs/qualification/evidence/layer-gates/c4ba70d95/macos-arm64.raw/layer-artifact-gate-receipt.json"
+        },
+        {
+          "platform": "windows",
+          "sourceSha": "c4ba70d9542d42bbd75ddd9dd4c7ff079f4570fa",
+          "registryDigest": "sha256:26716c1b1979fa3789f35caf5db97dae103462a7e02aebd4f4026b0ea2923526",
+          "durationMs": 2008,
+          "receipt": "docs/qualification/evidence/layer-gates/c4ba70d95/windows-x64.raw/layer-artifact-gate-receipt.json"
+        }
+      ]
+    },
+    {
+      "gateId": "layers.contract",
+      "definitionDigest": "sha256:40f678362cf64a02f9397e05a8beaf9ef2f91becb804fb86a5bb4c54eb7b64d8",
+      "observations": [
+        {
+          "platform": "linux",
+          "sourceSha": "c4ba70d9542d42bbd75ddd9dd4c7ff079f4570fa",
+          "registryDigest": "sha256:26716c1b1979fa3789f35caf5db97dae103462a7e02aebd4f4026b0ea2923526",
+          "durationMs": 387,
+          "receipt": "docs/qualification/evidence/layer-gates/c4ba70d95/linux-x64.raw/layer-artifact-gate-receipt.json"
+        },
+        {
+          "platform": "macos",
+          "sourceSha": "c4ba70d9542d42bbd75ddd9dd4c7ff079f4570fa",
+          "registryDigest": "sha256:26716c1b1979fa3789f35caf5db97dae103462a7e02aebd4f4026b0ea2923526",
+          "durationMs": 705,
+          "receipt": "docs/qualification/evidence/layer-gates/c4ba70d95/macos-arm64.raw/layer-artifact-gate-receipt.json"
+        },
+        {
+          "platform": "windows",
+          "sourceSha": "c4ba70d9542d42bbd75ddd9dd4c7ff079f4570fa",
+          "registryDigest": "sha256:26716c1b1979fa3789f35caf5db97dae103462a7e02aebd4f4026b0ea2923526",
+          "durationMs": 2011,
+          "receipt": "docs/qualification/evidence/layer-gates/c4ba70d95/windows-x64.raw/layer-artifact-gate-receipt.json"
+        }
+      ]
+    },
+    {
+      "gateId": "layers.format",
+      "definitionDigest": "sha256:94407629dec03f71b22a719cbc1783e0e99a3757ed2b691315a842f1e0429eda",
+      "observations": [
+        {
+          "platform": "linux",
+          "sourceSha": "c4ba70d9542d42bbd75ddd9dd4c7ff079f4570fa",
+          "registryDigest": "sha256:26716c1b1979fa3789f35caf5db97dae103462a7e02aebd4f4026b0ea2923526",
+          "durationMs": 2660,
+          "receipt": "docs/qualification/evidence/layer-gates/c4ba70d95/linux-x64.raw/layer-artifact-gate-receipt.json"
+        },
+        {
+          "platform": "macos",
+          "sourceSha": "c4ba70d9542d42bbd75ddd9dd4c7ff079f4570fa",
+          "registryDigest": "sha256:26716c1b1979fa3789f35caf5db97dae103462a7e02aebd4f4026b0ea2923526",
+          "durationMs": 4787,
+          "receipt": "docs/qualification/evidence/layer-gates/c4ba70d95/macos-arm64.raw/layer-artifact-gate-receipt.json"
+        },
+        {
+          "platform": "windows",
+          "sourceSha": "c4ba70d9542d42bbd75ddd9dd4c7ff079f4570fa",
+          "registryDigest": "sha256:26716c1b1979fa3789f35caf5db97dae103462a7e02aebd4f4026b0ea2923526",
+          "durationMs": 8263,
+          "receipt": "docs/qualification/evidence/layer-gates/c4ba70d95/windows-x64.raw/layer-artifact-gate-receipt.json"
+        }
+      ]
+    },
+    {
+      "gateId": "layers.sdk",
+      "definitionDigest": "sha256:acb4d1bab4c7a4abbe2bf70da7797a638a3498a3c3cc51fa2e7006695adcb7ce",
+      "observations": [
+        {
+          "platform": "linux",
+          "sourceSha": "c4ba70d9542d42bbd75ddd9dd4c7ff079f4570fa",
+          "registryDigest": "sha256:26716c1b1979fa3789f35caf5db97dae103462a7e02aebd4f4026b0ea2923526",
+          "durationMs": 10505,
+          "receipt": "docs/qualification/evidence/layer-gates/c4ba70d95/linux-x64.raw/layer-artifact-gate-receipt.json"
+        },
+        {
+          "platform": "macos",
+          "sourceSha": "c4ba70d9542d42bbd75ddd9dd4c7ff079f4570fa",
+          "registryDigest": "sha256:26716c1b1979fa3789f35caf5db97dae103462a7e02aebd4f4026b0ea2923526",
+          "durationMs": 14200,
+          "receipt": "docs/qualification/evidence/layer-gates/c4ba70d95/macos-arm64.raw/layer-artifact-gate-receipt.json"
+        },
+        {
+          "platform": "windows",
+          "sourceSha": "c4ba70d9542d42bbd75ddd9dd4c7ff079f4570fa",
+          "registryDigest": "sha256:26716c1b1979fa3789f35caf5db97dae103462a7e02aebd4f4026b0ea2923526",
+          "durationMs": 18834,
+          "receipt": "docs/qualification/evidence/layer-gates/c4ba70d95/windows-x64.raw/layer-artifact-gate-receipt.json"
+        }
+      ]
+    },
+    {
+      "gateId": "layers.surfaces",
+      "definitionDigest": "sha256:55d5e6632cc8d9146896dcccbfe612d32ff2249b5029a08cd654f2ec51bd1e53",
+      "observations": [
+        {
+          "platform": "linux",
+          "sourceSha": "c4ba70d9542d42bbd75ddd9dd4c7ff079f4570fa",
+          "registryDigest": "sha256:26716c1b1979fa3789f35caf5db97dae103462a7e02aebd4f4026b0ea2923526",
+          "durationMs": 9979,
+          "receipt": "docs/qualification/evidence/layer-gates/c4ba70d95/linux-x64.raw/layer-artifact-gate-receipt.json"
+        },
+        {
+          "platform": "macos",
+          "sourceSha": "c4ba70d9542d42bbd75ddd9dd4c7ff079f4570fa",
+          "registryDigest": "sha256:26716c1b1979fa3789f35caf5db97dae103462a7e02aebd4f4026b0ea2923526",
+          "durationMs": 23536,
+          "receipt": "docs/qualification/evidence/layer-gates/c4ba70d95/macos-arm64.raw/layer-artifact-gate-receipt.json"
+        },
+        {
+          "platform": "windows",
+          "sourceSha": "c4ba70d9542d42bbd75ddd9dd4c7ff079f4570fa",
+          "registryDigest": "sha256:26716c1b1979fa3789f35caf5db97dae103462a7e02aebd4f4026b0ea2923526",
+          "durationMs": 32821,
+          "receipt": "docs/qualification/evidence/layer-gates/c4ba70d95/windows-x64.raw/layer-artifact-gate-receipt.json"
+        }
+      ]
+    }
+  ]
+}

--- a/docs/qualification/gates/measurement-coverage.md
+++ b/docs/qualification/gates/measurement-coverage.md
@@ -1,0 +1,54 @@
+# Kungfu Gate measurement coverage
+
+This report is generated from
+[`measurement-coverage.json`](measurement-coverage.json). Do not hand-edit the
+generated block.
+
+A measured observation is an immutable result from one clean source revision;
+it does not update when later code changes. Re-run the Gate and register its new
+receipt when its implementation or expected cost changes. Any Gate outside the
+frozen 2026-07-14 adoption baseline must have a passing observation for every
+declared platform before the catalog check succeeds.
+
+<!-- BEGIN GENERATED GATE MEASUREMENTS -->
+| Gate | Coverage | Source-bound observations |
+| --- | --- | --- |
+| `gate.catalog` | measured | [linux: 433 ms @ c4ba70d95](../evidence/layer-gates/c4ba70d95/linux-x64.raw/layer-artifact-gate-receipt.json)<br>[macos: 694 ms @ c4ba70d95](../evidence/layer-gates/c4ba70d95/macos-arm64.raw/layer-artifact-gate-receipt.json)<br>[windows: 2008 ms @ c4ba70d95](../evidence/layer-gates/c4ba70d95/windows-x64.raw/layer-artifact-gate-receipt.json) |
+| `governance.dco` | adoption baseline | — |
+| `governance.adr-delivery` | adoption baseline | — |
+| `governance.buildchain-config` | adoption baseline | — |
+| `governance.promotion-rehearsal` | adoption baseline | — |
+| `source.acceptance` | adoption baseline | — |
+| `source.changed-scope` | adoption baseline | — |
+| `source.whole-tree` | adoption baseline | — |
+| `docs.contracts` | adoption baseline | — |
+| `docs.prose` | adoption baseline | — |
+| `docs.external-links` | adoption baseline | — |
+| `shifu.workspace` | adoption baseline | — |
+| `product.distribution` | adoption baseline | — |
+| `product.verify-full` | adoption baseline | — |
+| `product.verify-fuzz` | adoption baseline | — |
+| `release.artifact-admission` | adoption baseline | — |
+| `layers.contract` | measured | [linux: 387 ms @ c4ba70d95](../evidence/layer-gates/c4ba70d95/linux-x64.raw/layer-artifact-gate-receipt.json)<br>[macos: 705 ms @ c4ba70d95](../evidence/layer-gates/c4ba70d95/macos-arm64.raw/layer-artifact-gate-receipt.json)<br>[windows: 2011 ms @ c4ba70d95](../evidence/layer-gates/c4ba70d95/windows-x64.raw/layer-artifact-gate-receipt.json) |
+| `layers.format` | measured | [linux: 2660 ms @ c4ba70d95](../evidence/layer-gates/c4ba70d95/linux-x64.raw/layer-artifact-gate-receipt.json)<br>[macos: 4787 ms @ c4ba70d95](../evidence/layer-gates/c4ba70d95/macos-arm64.raw/layer-artifact-gate-receipt.json)<br>[windows: 8263 ms @ c4ba70d95](../evidence/layer-gates/c4ba70d95/windows-x64.raw/layer-artifact-gate-receipt.json) |
+| `layers.sdk` | measured | [linux: 10505 ms @ c4ba70d95](../evidence/layer-gates/c4ba70d95/linux-x64.raw/layer-artifact-gate-receipt.json)<br>[macos: 14200 ms @ c4ba70d95](../evidence/layer-gates/c4ba70d95/macos-arm64.raw/layer-artifact-gate-receipt.json)<br>[windows: 18834 ms @ c4ba70d95](../evidence/layer-gates/c4ba70d95/windows-x64.raw/layer-artifact-gate-receipt.json) |
+| `layers.surfaces` | measured | [linux: 9979 ms @ c4ba70d95](../evidence/layer-gates/c4ba70d95/linux-x64.raw/layer-artifact-gate-receipt.json)<br>[macos: 23536 ms @ c4ba70d95](../evidence/layer-gates/c4ba70d95/macos-arm64.raw/layer-artifact-gate-receipt.json)<br>[windows: 32821 ms @ c4ba70d95](../evidence/layer-gates/c4ba70d95/windows-x64.raw/layer-artifact-gate-receipt.json) |
+| `layers.release` | adoption baseline | — |
+| `episode.smoke` | adoption baseline | — |
+| `episode.release` | adoption baseline | — |
+| `embedding.membranes` | adoption baseline | — |
+| `mmap.contracts` | adoption baseline | — |
+| `mmap.performance` | adoption baseline | — |
+| `durability.contracts` | adoption baseline | — |
+| `state-service.contracts` | adoption baseline | — |
+| `profile.suite` | adoption baseline | — |
+| `profile.lifecycle` | adoption baseline | — |
+| `profile.agent-sdk` | adoption baseline | — |
+| `profile.kfd3` | adoption baseline | — |
+| `runtime.durable-ingest` | adoption baseline | — |
+| `runtime.projection-bootstrap` | adoption baseline | — |
+| `runtime.crash-recovery` | adoption baseline | — |
+| `runtime.errors` | adoption baseline | — |
+| `toolchain.cpp-modules` | adoption baseline | — |
+| `toolchain.libwasm-cache` | adoption baseline | — |
+<!-- END GENERATED GATE MEASUREMENTS -->

--- a/scripts/check-kungfu-gate-catalog.mjs
+++ b/scripts/check-kungfu-gate-catalog.mjs
@@ -11,14 +11,25 @@ import {
   validateControllerAdapters,
 } from './kungfu-gate-controller-adapters.mjs';
 import { scanWorkflowInvocations } from './kungfu-gate-workflow-facts.mjs';
-import { validateGateRegistry } from './shifu-gate-runtime.mjs';
+import {
+  gateDefinitionDigest,
+  gateDigest,
+  validateGateRegistry,
+} from './shifu-gate-runtime.mjs';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const MATRIX = 'docs/qualification/gates/policy-matrix.md';
 const BINDINGS = 'docs/qualification/gates/workflow-bindings.json';
 const EXECUTION_PROFILES = 'docs/qualification/gates/execution-profiles.json';
+const MEASUREMENT_COVERAGE =
+  'docs/qualification/gates/measurement-coverage.json';
+const MEASUREMENT_REPORT = 'docs/qualification/gates/measurement-coverage.md';
+const MEASUREMENT_BASELINE_DIGEST =
+  'sha256:2fc06a1263119544e4130724390f737016797de7c5df0a17cbf10ab23c024fb9';
 const BEGIN = '<!-- BEGIN GENERATED GATE MATRIX -->';
 const END = '<!-- END GENERATED GATE MATRIX -->';
+const MEASUREMENT_BEGIN = '<!-- BEGIN GENERATED GATE MEASUREMENTS -->';
+const MEASUREMENT_END = '<!-- END GENERATED GATE MEASUREMENTS -->';
 const REQUIRED_DOC_FIELDS = [
   'Problem',
   'Protects',
@@ -36,6 +47,293 @@ const REQUIRED_DOC_FIELDS = [
 
 function readJson(root, relative) {
   return JSON.parse(fs.readFileSync(path.join(root, relative), 'utf8'));
+}
+
+function exactObjectKeys(value, required, prefix, issues) {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    issues.push(`[measurement] ${prefix} must be an object`);
+    return false;
+  }
+  const allowed = new Set(required);
+  for (const key of required) {
+    if (!Object.hasOwn(value, key))
+      issues.push(`[measurement] ${prefix}.${key} is required`);
+  }
+  for (const key of Object.keys(value)) {
+    if (!allowed.has(key))
+      issues.push(`[measurement] ${prefix}.${key} is not allowed`);
+  }
+  return true;
+}
+
+function safeEvidencePath(relative) {
+  return (
+    typeof relative === 'string' &&
+    relative.startsWith('docs/qualification/evidence/') &&
+    relative.endsWith('.json') &&
+    !path.isAbsolute(relative) &&
+    !relative.split('/').includes('..')
+  );
+}
+
+function sameStringSet(actual, expected) {
+  return (
+    Array.isArray(actual) &&
+    actual.length === new Set(actual).size &&
+    [...actual].sort().join('\0') === [...expected].sort().join('\0')
+  );
+}
+
+export function validateMeasurementCoverage(root, registry) {
+  const issues = [];
+  const document = readJson(root, MEASUREMENT_COVERAGE);
+  exactObjectKeys(
+    document,
+    ['schema', 'registry', 'baseline', 'measurements'],
+    'document',
+    issues,
+  );
+  if (document.schema !== 'kungfu.gate-measurement-coverage/v1')
+    issues.push('[measurement] unsupported schema');
+  if (document.registry !== 'shifu.gates.json')
+    issues.push('[measurement] registry must be shifu.gates.json');
+
+  const baseline = document.baseline;
+  if (
+    exactObjectKeys(
+      baseline,
+      ['adoptedAt', 'unmeasuredGateIds', 'digest'],
+      'baseline',
+      issues,
+    )
+  ) {
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(baseline.adoptedAt || ''))
+      issues.push('[measurement] baseline.adoptedAt must be YYYY-MM-DD');
+    if (
+      !Array.isArray(baseline.unmeasuredGateIds) ||
+      baseline.unmeasuredGateIds.some(
+        (gateId) => typeof gateId !== 'string' || !gateId,
+      ) ||
+      baseline.unmeasuredGateIds.length !==
+        new Set(baseline.unmeasuredGateIds).size ||
+      baseline.unmeasuredGateIds.join('\0') !==
+        [...baseline.unmeasuredGateIds].sort().join('\0')
+    ) {
+      issues.push(
+        '[measurement] baseline.unmeasuredGateIds must be unique and sorted',
+      );
+    }
+    const actualDigest = gateDigest(
+      Array.isArray(baseline.unmeasuredGateIds)
+        ? baseline.unmeasuredGateIds
+        : [],
+    );
+    if (baseline.digest !== actualDigest)
+      issues.push('[measurement] baseline.digest does not match its Gate ids');
+    if (actualDigest !== MEASUREMENT_BASELINE_DIGEST)
+      issues.push(
+        '[measurement] frozen unmeasured baseline changed; new Gates must add measurements',
+      );
+  }
+
+  const gates = new Map(registry.gates.map((gate) => [gate.id, gate]));
+  const exempt = new Set(
+    Array.isArray(baseline?.unmeasuredGateIds)
+      ? baseline.unmeasuredGateIds
+      : [],
+  );
+  const records = new Map();
+  if (!Array.isArray(document.measurements)) {
+    issues.push('[measurement] document.measurements must be an array');
+  }
+  for (const [recordIndex, record] of (Array.isArray(document.measurements)
+    ? document.measurements
+    : []
+  ).entries()) {
+    const at = `measurements[${recordIndex}]`;
+    if (
+      !exactObjectKeys(
+        record,
+        ['gateId', 'definitionDigest', 'observations'],
+        at,
+        issues,
+      )
+    )
+      continue;
+    if (records.has(record.gateId))
+      issues.push(`[measurement] duplicate Gate record '${record.gateId}'`);
+    records.set(record.gateId, record);
+    const gate = gates.get(record.gateId);
+    if (!gate) {
+      issues.push(`[measurement] unknown Gate '${record.gateId}'`);
+      continue;
+    }
+    const currentDefinitionDigest = gateDefinitionDigest(gate);
+    if (record.definitionDigest !== currentDefinitionDigest)
+      issues.push(`[measurement] ${record.gateId}: definition digest is stale`);
+    if (!Array.isArray(record.observations) || !record.observations.length) {
+      issues.push(
+        `[measurement] ${record.gateId}: observations must be a non-empty array`,
+      );
+      continue;
+    }
+    const observedPlatforms = record.observations.map(
+      (observation) => observation?.platform,
+    );
+    if (!sameStringSet(observedPlatforms, gate.platforms))
+      issues.push(
+        `[measurement] ${record.gateId}: measured platforms [${observedPlatforms.join(', ')}], expected [${gate.platforms.join(', ')}]`,
+      );
+    const sourceShas = new Set(
+      record.observations.map((observation) => observation?.sourceSha),
+    );
+    const registryDigests = new Set(
+      record.observations.map((observation) => observation?.registryDigest),
+    );
+    if (sourceShas.size !== 1 || registryDigests.size !== 1)
+      issues.push(
+        `[measurement] ${record.gateId}: all platforms must measure one source and registry revision`,
+      );
+    for (const [
+      observationIndex,
+      observation,
+    ] of record.observations.entries()) {
+      const observationAt = `${at}.observations[${observationIndex}]`;
+      if (
+        !exactObjectKeys(
+          observation,
+          ['platform', 'sourceSha', 'registryDigest', 'durationMs', 'receipt'],
+          observationAt,
+          issues,
+        )
+      )
+        continue;
+      if (!gate.platforms.includes(observation.platform))
+        issues.push(
+          `[measurement] ${record.gateId}: unsupported platform '${observation.platform}'`,
+        );
+      if (!/^[0-9a-f]{40}$/.test(observation.sourceSha || ''))
+        issues.push(
+          `[measurement] ${record.gateId}:${observation.platform}: sourceSha must be a full Git SHA`,
+        );
+      if (!/^sha256:[0-9a-f]{64}$/.test(observation.registryDigest || ''))
+        issues.push(
+          `[measurement] ${record.gateId}:${observation.platform}: registryDigest must be sha256`,
+        );
+      if (
+        !Number.isInteger(observation.durationMs) ||
+        observation.durationMs < 0
+      )
+        issues.push(
+          `[measurement] ${record.gateId}:${observation.platform}: durationMs must be a non-negative integer`,
+        );
+      if (!safeEvidencePath(observation.receipt)) {
+        issues.push(
+          `[measurement] ${record.gateId}:${observation.platform}: unsafe receipt path`,
+        );
+        continue;
+      }
+      const receiptPath = path.join(root, observation.receipt);
+      if (!fs.existsSync(receiptPath)) {
+        issues.push(
+          `[measurement] ${record.gateId}:${observation.platform}: missing ${observation.receipt}`,
+        );
+        continue;
+      }
+      let receipt;
+      try {
+        receipt = JSON.parse(fs.readFileSync(receiptPath, 'utf8'));
+      } catch {
+        issues.push(
+          `[measurement] ${record.gateId}:${observation.platform}: receipt is not valid JSON`,
+        );
+        continue;
+      }
+      if (receipt.schema !== 'shifu.gate-receipt/v1')
+        issues.push(
+          `[measurement] ${record.gateId}:${observation.platform}: unsupported receipt schema`,
+        );
+      if (
+        receipt.source?.dirty !== false ||
+        receipt.source?.sha !== observation.sourceSha
+      )
+        issues.push(
+          `[measurement] ${record.gateId}:${observation.platform}: receipt must match a clean source SHA`,
+        );
+      if (
+        receipt.registry?.ref !== 'shifu.gates.json' ||
+        receipt.registry?.projectId !== registry.project.id ||
+        receipt.registry?.digest !== observation.registryDigest
+      )
+        issues.push(
+          `[measurement] ${record.gateId}:${observation.platform}: receipt registry identity does not match`,
+        );
+      if (receipt.environment?.platform !== observation.platform)
+        issues.push(
+          `[measurement] ${record.gateId}:${observation.platform}: receipt platform does not match`,
+        );
+      const results = Array.isArray(receipt.results)
+        ? receipt.results.filter((result) => result.gateId === record.gateId)
+        : [];
+      if (results.length !== 1) {
+        issues.push(
+          `[measurement] ${record.gateId}:${observation.platform}: receipt must contain exactly one matching result`,
+        );
+        continue;
+      }
+      const result = results[0];
+      if (result.definitionDigest !== currentDefinitionDigest)
+        issues.push(
+          `[measurement] ${record.gateId}:${observation.platform}: receipt definition digest is stale`,
+        );
+      if (
+        result.attempted !== true ||
+        result.status !== 'pass' ||
+        result.exitCode !== 0
+      )
+        issues.push(
+          `[measurement] ${record.gateId}:${observation.platform}: receipt result must be an attempted pass`,
+        );
+      if (result.durationMs !== observation.durationMs)
+        issues.push(
+          `[measurement] ${record.gateId}:${observation.platform}: durationMs differs from the receipt`,
+        );
+    }
+  }
+  for (const gate of registry.gates) {
+    if (!exempt.has(gate.id) && !records.has(gate.id))
+      issues.push(
+        `[measurement] ${gate.id}: measurement record is required for every Gate outside the frozen baseline`,
+      );
+  }
+  return { issues, document };
+}
+
+export function renderMeasurementCoverage(registry, document) {
+  const records = new Map(
+    (document.measurements || []).map((record) => [record.gateId, record]),
+  );
+  const baseline = new Set(document.baseline?.unmeasuredGateIds || []);
+  const rows = registry.gates.map((gate) => {
+    const record = records.get(gate.id);
+    if (!record)
+      return `| \`${gate.id}\` | ${baseline.has(gate.id) ? 'adoption baseline' : 'missing'} | — |`;
+    const observations = record.observations
+      .map((observation) => {
+        const href = path.posix.relative(
+          'docs/qualification/gates',
+          observation.receipt,
+        );
+        return `[${observation.platform}: ${observation.durationMs} ms @ ${observation.sourceSha.slice(0, 9)}](${href})`;
+      })
+      .join('<br>');
+    return `| \`${gate.id}\` | measured | ${observations} |`;
+  });
+  return [
+    '| Gate | Coverage | Source-bound observations |',
+    '| --- | --- | --- |',
+    ...rows,
+  ].join('\n');
 }
 
 function objectFieldDrift(actual, expected, prefix) {
@@ -200,6 +498,17 @@ function replaceGeneratedMatrix(text, matrix) {
   return `${text.slice(0, start + BEGIN.length)}\n${matrix}\n${text.slice(finish)}`;
 }
 
+function replaceGeneratedMeasurements(text, measurements) {
+  const start = text.indexOf(MEASUREMENT_BEGIN);
+  const finish = text.indexOf(MEASUREMENT_END);
+  if (start < 0 || finish < 0 || finish <= start) {
+    throw new Error(
+      `missing ordered measurement markers in ${MEASUREMENT_REPORT}`,
+    );
+  }
+  return `${text.slice(0, start + MEASUREMENT_BEGIN.length)}\n${measurements}\n${text.slice(finish)}`;
+}
+
 export function checkKungfuGateCatalog(root = ROOT) {
   const issues = [];
   const registry = readJson(root, 'shifu.gates.json');
@@ -208,6 +517,24 @@ export function checkKungfuGateCatalog(root = ROOT) {
     issues.push(`[registry] ${issue.path}: ${issue.message}`);
   }
   if (validation.length) return { issues, registry };
+
+  const measurementValidation = validateMeasurementCoverage(root, registry);
+  issues.push(...measurementValidation.issues);
+  if (!measurementValidation.issues.length) {
+    const measurementReportPath = path.join(root, MEASUREMENT_REPORT);
+    const measurementReportText = fs.readFileSync(
+      measurementReportPath,
+      'utf8',
+    );
+    const expectedMeasurementReport = replaceGeneratedMeasurements(
+      measurementReportText,
+      renderMeasurementCoverage(registry, measurementValidation.document),
+    );
+    if (measurementReportText !== expectedMeasurementReport)
+      issues.push(
+        `[measurement] ${MEASUREMENT_REPORT} differs from registered measurements`,
+      );
+  }
 
   const bindingDocument = readJson(root, BINDINGS);
   const executionValidation = validateExecutionProfiles(root, bindingDocument);
@@ -504,6 +831,7 @@ export function checkKungfuGateCatalog(root = ROOT) {
 export function writePolicyMatrix(root = ROOT) {
   const registry = readJson(root, 'shifu.gates.json');
   const executionDocument = readJson(root, EXECUTION_PROFILES);
+  const measurementDocument = readJson(root, MEASUREMENT_COVERAGE);
   const file = path.join(root, MATRIX);
   const current = fs.readFileSync(file, 'utf8');
   fs.writeFileSync(
@@ -511,6 +839,15 @@ export function writePolicyMatrix(root = ROOT) {
     replaceGeneratedMatrix(
       current,
       renderPolicyMatrix(registry, executionDocument),
+    ),
+  );
+  const measurementFile = path.join(root, MEASUREMENT_REPORT);
+  const currentMeasurements = fs.readFileSync(measurementFile, 'utf8');
+  fs.writeFileSync(
+    measurementFile,
+    replaceGeneratedMeasurements(
+      currentMeasurements,
+      renderMeasurementCoverage(registry, measurementDocument),
     ),
   );
 }
@@ -524,7 +861,7 @@ function main() {
     process.exit(1);
   }
   console.log(
-    `[kungfu-gates] ${result.registry.gates.length} gates, ${result.registry.profiles.length} profiles, ${result.workflowFacts.length} structured workflow invocations aligned`,
+    `[kungfu-gates] ${result.registry.gates.length} gates, ${result.registry.profiles.length} profiles, ${result.workflowFacts.length} structured workflow invocations and measurement coverage aligned`,
   );
 }
 

--- a/scripts/check-kungfu-gate-catalog.test.mjs
+++ b/scripts/check-kungfu-gate-catalog.test.mjs
@@ -9,7 +9,9 @@ import { fileURLToPath } from 'node:url';
 import {
   checkKungfuGateCatalog,
   renderPolicyMatrix,
+  validateMeasurementCoverage,
 } from './check-kungfu-gate-catalog.mjs';
+import { gateDefinitionDigest, gateDigest } from './shifu-gate-runtime.mjs';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 
@@ -19,6 +21,9 @@ function fixture() {
     'shifu.gates.json',
     'package.json',
     'docs/qualification/gates',
+    'docs/qualification/evidence/layer-gates/c4ba70d95/linux-x64.raw/layer-artifact-gate-receipt.json',
+    'docs/qualification/evidence/layer-gates/c4ba70d95/macos-arm64.raw/layer-artifact-gate-receipt.json',
+    'docs/qualification/evidence/layer-gates/c4ba70d95/windows-x64.raw/layer-artifact-gate-receipt.json',
     'framework/core/tests/qualification/episode/profiles',
   ]) {
     const source = path.join(ROOT, relative);
@@ -39,6 +44,22 @@ function fixture() {
     fs.copyFileSync(source, target);
   }
   return root;
+}
+
+function readMeasurementCoverage(root) {
+  return JSON.parse(
+    fs.readFileSync(
+      path.join(root, 'docs/qualification/gates/measurement-coverage.json'),
+      'utf8',
+    ),
+  );
+}
+
+function writeMeasurementCoverage(root, document) {
+  fs.writeFileSync(
+    path.join(root, 'docs/qualification/gates/measurement-coverage.json'),
+    JSON.stringify(document, null, 2),
+  );
 }
 
 test('current Kungfu catalog, docs, matrix, actions, and workflows align', () => {
@@ -86,6 +107,181 @@ test('matrix rendering is deterministic and includes every profile', () => {
   }
   assert.match(matrix, /Execution parameters/);
   assert.match(matrix, /release-candidate/);
+});
+
+test('a new Gate requires complete source-bound measurement coverage', () => {
+  const root = fixture();
+  const registry = JSON.parse(
+    fs.readFileSync(path.join(root, 'shifu.gates.json'), 'utf8'),
+  );
+  const gate = structuredClone(
+    registry.gates.find((item) => item.id === 'governance.dco'),
+  );
+  gate.id = 'governance.measurement-fixture';
+  gate.title = 'Measurement fixture';
+  gate.summary = 'Proves a new Gate cannot bypass measured evidence.';
+  registry.gates.push(gate);
+  for (const profile of registry.profiles) {
+    profile.decisions[gate.id] = {
+      mode: 'off',
+      reason: 'Measurement enforcement fixture.',
+    };
+  }
+
+  assert.ok(
+    validateMeasurementCoverage(root, registry).issues.some((issue) =>
+      issue.includes(
+        'governance.measurement-fixture: measurement record is required',
+      ),
+    ),
+  );
+  fs.writeFileSync(
+    path.join(root, 'shifu.gates.json'),
+    JSON.stringify(registry),
+  );
+  assert.ok(
+    checkKungfuGateCatalog(root).issues.some((issue) =>
+      issue.includes(
+        'governance.measurement-fixture: measurement record is required',
+      ),
+    ),
+  );
+
+  const receiptRelative =
+    'docs/qualification/evidence/fixtures/measurement-fixture.json';
+  const receiptPath = path.join(root, receiptRelative);
+  fs.mkdirSync(path.dirname(receiptPath), { recursive: true });
+  const definitionDigest = gateDefinitionDigest(gate);
+  const sourceSha = 'a'.repeat(40);
+  const registryDigest = `sha256:${'b'.repeat(64)}`;
+  fs.writeFileSync(
+    receiptPath,
+    JSON.stringify({
+      schema: 'shifu.gate-receipt/v1',
+      source: { sha: sourceSha, dirty: false },
+      registry: {
+        ref: 'shifu.gates.json',
+        digest: registryDigest,
+        projectId: 'kungfu',
+      },
+      environment: { platform: 'linux' },
+      results: [
+        {
+          gateId: gate.id,
+          definitionDigest,
+          attempted: true,
+          status: 'pass',
+          exitCode: 0,
+          durationMs: 17,
+        },
+      ],
+    }),
+  );
+  const coverage = readMeasurementCoverage(root);
+  coverage.measurements.push({
+    gateId: gate.id,
+    definitionDigest,
+    observations: [
+      {
+        platform: 'linux',
+        sourceSha,
+        registryDigest,
+        durationMs: 17,
+        receipt: receiptRelative,
+      },
+    ],
+  });
+  writeMeasurementCoverage(root, coverage);
+  assert.deepEqual(validateMeasurementCoverage(root, registry).issues, []);
+});
+
+test('the frozen unmeasured baseline cannot absorb a new Gate', () => {
+  const root = fixture();
+  const registry = JSON.parse(
+    fs.readFileSync(path.join(root, 'shifu.gates.json'), 'utf8'),
+  );
+  const coverage = readMeasurementCoverage(root);
+  coverage.baseline.unmeasuredGateIds.push('source.unmeasured-new-gate');
+  coverage.baseline.unmeasuredGateIds.sort();
+  coverage.baseline.digest = gateDigest(coverage.baseline.unmeasuredGateIds);
+  writeMeasurementCoverage(root, coverage);
+  assert.ok(
+    validateMeasurementCoverage(root, registry).issues.some((issue) =>
+      issue.includes(
+        'frozen unmeasured baseline changed; new Gates must add measurements',
+      ),
+    ),
+  );
+});
+
+test('missing platforms and stale Gate definitions fail measurement coverage', () => {
+  const platformRoot = fixture();
+  const platformRegistry = JSON.parse(
+    fs.readFileSync(path.join(platformRoot, 'shifu.gates.json'), 'utf8'),
+  );
+  const platformCoverage = readMeasurementCoverage(platformRoot);
+  platformCoverage.measurements
+    .find((record) => record.gateId === 'gate.catalog')
+    .observations.pop();
+  writeMeasurementCoverage(platformRoot, platformCoverage);
+  assert.ok(
+    validateMeasurementCoverage(platformRoot, platformRegistry).issues.some(
+      (issue) => issue.includes('gate.catalog: measured platforms'),
+    ),
+  );
+
+  const staleRoot = fixture();
+  const staleRegistry = JSON.parse(
+    fs.readFileSync(path.join(staleRoot, 'shifu.gates.json'), 'utf8'),
+  );
+  const staleCoverage = readMeasurementCoverage(staleRoot);
+  staleCoverage.measurements.find(
+    (record) => record.gateId === 'gate.catalog',
+  ).definitionDigest = `sha256:${'0'.repeat(64)}`;
+  writeMeasurementCoverage(staleRoot, staleCoverage);
+  assert.ok(
+    validateMeasurementCoverage(staleRoot, staleRegistry).issues.some((issue) =>
+      issue.includes('gate.catalog: definition digest is stale'),
+    ),
+  );
+});
+
+test('dirty, unsuccessful, and duration-drifted receipts fail measurement coverage', () => {
+  const root = fixture();
+  const registry = JSON.parse(
+    fs.readFileSync(path.join(root, 'shifu.gates.json'), 'utf8'),
+  );
+  const receiptPath = path.join(
+    root,
+    'docs/qualification/evidence/layer-gates/c4ba70d95/linux-x64.raw/layer-artifact-gate-receipt.json',
+  );
+  const receipt = JSON.parse(fs.readFileSync(receiptPath, 'utf8'));
+  receipt.source.dirty = true;
+  const result = receipt.results.find((item) => item.gateId === 'gate.catalog');
+  result.status = 'fail';
+  result.exitCode = 1;
+  result.durationMs += 1;
+  fs.writeFileSync(receiptPath, JSON.stringify(receipt));
+  const issues = validateMeasurementCoverage(root, registry).issues;
+  assert.ok(
+    issues.some((issue) =>
+      issue.includes(
+        'gate.catalog:linux: receipt must match a clean source SHA',
+      ),
+    ),
+  );
+  assert.ok(
+    issues.some((issue) =>
+      issue.includes(
+        'gate.catalog:linux: receipt result must be an attempted pass',
+      ),
+    ),
+  );
+  assert.ok(
+    issues.some((issue) =>
+      issue.includes('gate.catalog:linux: durationMs differs from the receipt'),
+    ),
+  );
 });
 
 test('matrix, gate document, and workflow drift each fail closed', () => {


### PR DESCRIPTION
## Summary

Close the Kungfu Gate catalog enforcement gap: every Gate added after the frozen adoption baseline must retain passing, source-bound timing measurements for all declared platforms.

## Related issue

None.

## Changes

- add a versioned measurement coverage manifest with a frozen 33-Gate unmeasured adoption baseline
- seed the five existing Layer Gate measurements from retained three-platform Shifu receipts
- fail the catalog check on missing platforms, dirty source, stale definitions, registry/source drift, failed or skipped results, duration drift, and missing receipts
- generate a human-readable timing table and document the exact new-Gate measurement workflow
- add fail-closed regressions, including proof that a new Gate cannot be hidden by expanding the baseline

## Verification

- `node --test scripts/check-kungfu-gate-catalog.test.mjs` (15/15)
- `./shifu check:gate-catalog`
- `node scripts/source-acceptance.mjs` (203/203 contract tests, tooling type check, Biome, documentation and source gate passed before rebasing the latest dev head)
- staged pre-commit Gate, documentation, schema, and Biome checks passed

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This patch enforces Kungfu project measurement evidence using the existing SHIFU-ADR-0004 source-bound receipt contract; it does not change Shifu Gate architecture or receipt semantics."
}
-->

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The patch reads retained public qualification receipts and validates their source, registry, Gate definition, platform, outcome, and duration fields. It adds no credentials, publication authority, or deployment side effects.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed