### PR TITLE
docs(adr): repair rebased implementation evidence

### DIFF
--- a/docs/adr/ADR-0083-core-system-kfx-profile-kfx-capability-boundary.md
+++ b/docs/adr/ADR-0083-core-system-kfx-profile-kfx-capability-boundary.md
@@ -4,7 +4,7 @@ doc_type: architecture-decision
 adr_id: ADR-0083
 decision_status: accepted
 implementation_status: partial
-implementation_commits: [c6266fe3ea37e096ced272c497b6e729218c7a3b, ef4421c8607860978f7d2b890ab68c149d97747a, bdf3800cb34182b59d3f341dee08056a5ebf6bd0, 7e17031ef398e77caab1f707426e7b2270533b60]
+implementation_commits: [c6266fe3ea37e096ced272c497b6e729218c7a3b, ef4421c8607860978f7d2b890ab68c149d97747a, bdf3800cb34182b59d3f341dee08056a5ebf6bd0, fb67a700c748e8c355bec7d15077d654a2a9c3ea]
 review_state: self-reviewed
 sensitivity: public
 sources: [local-files, user-consensus]


### PR DESCRIPTION
## Summary

Repair ADR-0083 implementation evidence after PR #843 was rebased into `dev/v4/v4.0`: replace the feature-branch commit `7e17031e` with its mainline-equivalent commit `fb67a700`.

## Related issue

Unblocks current dev documentation and source acceptance checks after PR #843.

## Changes

- update one `implementation_commits` entry in ADR-0083 to the reachable mainline hash
- leave the ADR decision and partial implementation status unchanged

## Verification

- `node scripts/run-docs-check.mjs` (61/61 documentation contract tests)
- staged documentation and ADR gates passed

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "stage-ready",
  "adrs": ["ADR-0083"],
  "summary": "Repair the first shell-neutrality stage evidence after rebase merge changed its commit identity",
  "verification": ["deterministic documentation gate", "ADR evidence reachability checks"]
}
-->

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] release evidence, provenance, package publishing, or deployment surfaces
- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed