### PR TITLE
feat(agent): add Codex App Server stdio runtime

### DIFF
--- a/docs/adr/ADR-0085-codex-app-server-structured-hybrid-adapter.md
+++ b/docs/adr/ADR-0085-codex-app-server-structured-hybrid-adapter.md
@@ -4,8 +4,8 @@ doc_type: architecture-decision
 adr_id: ADR-0085
 decision_status: accepted
 implementation_status: staged
-implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/849]
-qualification_refs: [framework/agent-session/tests/codex-app-server-contract.test.mjs, framework/agent-session/tests/codex-app-server-schema.native.test.mjs, framework/agent-session/schemas/codex-app-server/codex-v0.144.3-stable-schema-manifest.json]
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/849, https://github.com/kungfu-systems/kungfu/pull/851]
+qualification_refs: [framework/agent-session/tests/codex-app-server-contract.test.mjs, framework/agent-session/tests/codex-app-server-schema.native.test.mjs, framework/agent-session/tests/codex-app-server-runtime.test.mjs, framework/agent-session/schemas/codex-app-server/codex-v0.144.3-stable-schema-manifest.json]
 review_state: self-reviewed
 sensitivity: public
 sources: [local-files, user-consensus]
@@ -162,6 +162,12 @@ contract major and an explicit migration.
    surfaces are stable.
 6. Qualify provider routing, real Codex dogfood, Mac Product build, and
    promotion with the PTY route.
+
+Stage 2 is delivered by PR #851: the reader is installed before initialize,
+request and server-request ids are correlated exactly, every post-handshake
+write carries attempt/generation/process fencing, and the in-memory consumer
+queue freezes admission before its hard bound. Runtime or stdout loss leaves the
+old attempt outcome unknown and never triggers input replay.
 
 ## Rejected alternatives
 

--- a/framework/agent-session/README.md
+++ b/framework/agent-session/README.md
@@ -119,9 +119,21 @@ Shifu:
 ```
 
 The native gate generates stable schema under a temporary `HOME` and
-`CODEX_HOME`; it does not inspect provider auth or session state. Runtime,
-normalization, recovery guards, product routing, and real authenticated dogfood
-belong to later ADR-0085 implementation stages.
+`CODEX_HOME`; it does not inspect provider auth or session state. Normalization,
+recovery guards, product routing, and real authenticated dogfood belong to later
+ADR-0085 implementation stages.
+
+The Stage 2 direct-stdio runtime host adds a single continuously draining JSONL
+reader, exact request/server-request correlation, attempt/generation/process
+fencing, metadata-only stderr observation, and a bounded in-memory consumer
+queue. Reaching the admission threshold permanently freezes new writes for that
+attempt; crossing the hard bound fails visibly and terminates the provider.
+Runtime loss never replays input or claims a provider outcome. The synthetic
+provider smoke reads no credentials or private provider state:
+
+```sh
+./shifu test:codex-app-server-runtime
+```
 
 On Darwin, packaged products must restore the executable bit on node-pty's
 `spawn-helper`. The existing Electron `afterPack` audit already owns that

--- a/framework/agent-session/package.json
+++ b/framework/agent-session/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@kungfu-tech/agent-session",
   "version": "4.0.0-alpha.0",
-  "description": "Kungfu AgentSessionCapsule process, PTY transport, and interaction port",
+  "description": "Kungfu agent session process, PTY, structured stdio, and interaction ports",
   "license": "Apache-2.0",
   "type": "module",
   "repository": {
@@ -15,6 +15,7 @@
     ".": "./src/capsule-host.mjs",
     "./interaction-port": "./src/interaction-port.mjs",
     "./codex-app-server-contract": "./src/codex-app-server-contract.mjs",
+    "./codex-app-server-runtime": "./src/codex-app-server-runtime.mjs",
     "./peer-transport": "./src/peer-transport.mjs",
     "./product-surface": "./src/product-surface.mjs",
     "./product-runtime": "./src/product-runtime.mjs",

--- a/framework/agent-session/src/codex-app-server-runtime.mjs
+++ b/framework/agent-session/src/codex-app-server-runtime.mjs
@@ -1,0 +1,802 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { spawn as spawnProcess } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import { EventEmitter } from 'node:events';
+import path from 'node:path';
+import { createCodexAppServerContractGate } from './codex-app-server-contract.mjs';
+
+const RUNTIME_SCHEMA = 'kungfu.codex-app-server.runtime-host/v1';
+const EVENT_SCHEMA = 'kungfu.codex-app-server.runtime-event/v1';
+const RECEIPT_SCHEMA = 'kungfu.codex-app-server.runtime-write-receipt/v1';
+
+export class CodexAppServerRuntimeError extends Error {
+  constructor(code, message) {
+    super(message);
+    this.name = 'CodexAppServerRuntimeError';
+    this.code = code;
+  }
+}
+
+function runtimeError(code, message) {
+  return new CodexAppServerRuntimeError(code, message);
+}
+
+function requireString(value, label) {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw runtimeError('invalid-spec', `${label} must be a non-empty string`);
+  }
+  return value;
+}
+
+function requireGeneration(value) {
+  if (typeof value !== 'string' || !/^[1-9][0-9]*$/u.test(value)) {
+    throw runtimeError(
+      'invalid-spec',
+      'runtimeGeneration must be a positive integer string',
+    );
+  }
+  return value;
+}
+
+function requestKey(id) {
+  if (
+    !(
+      typeof id === 'string' ||
+      (Number.isSafeInteger(id) && Number.isFinite(id))
+    ) ||
+    String(id).length === 0
+  ) {
+    throw runtimeError(
+      'invalid-request-id',
+      'Codex App Server request id must be a non-empty string or safe integer',
+    );
+  }
+  return `${typeof id}:${String(id)}`;
+}
+
+function validateQueueBounds(maxQueueEvents, admissionStopThreshold) {
+  if (!Number.isSafeInteger(maxQueueEvents) || maxQueueEvents < 2) {
+    throw runtimeError(
+      'invalid-queue-bound',
+      'maxQueueEvents must be a safe integer of at least 2',
+    );
+  }
+  if (
+    !Number.isSafeInteger(admissionStopThreshold) ||
+    admissionStopThreshold < 1 ||
+    admissionStopThreshold >= maxQueueEvents
+  ) {
+    throw runtimeError(
+      'invalid-queue-bound',
+      'admissionStopThreshold must be below maxQueueEvents',
+    );
+  }
+}
+
+function hasOwn(value, key) {
+  return Object.prototype.hasOwnProperty.call(value, key);
+}
+
+function clone(value) {
+  return value === undefined ? undefined : structuredClone(value);
+}
+
+/**
+ * One direct-stdio Codex App Server process for one Kungfu SessionAttempt.
+ *
+ * The host intentionally owns only process, framing, correlation and bounded
+ * in-memory delivery. Event normalization and product routing are later seams.
+ */
+export class CodexAppServerRuntimeHost extends EventEmitter {
+  constructor({
+    spawn = spawnProcess,
+    runtimeIdentity,
+    maxQueueEvents = 256,
+    admissionStopThreshold = 192,
+    maxLineBytes = 1024 * 1024,
+    initializeTimeoutMs = 10_000,
+    now = () => Date.now(),
+    uuid = randomUUID,
+  }) {
+    super();
+    if (typeof spawn !== 'function') {
+      throw runtimeError('invalid-runtime', 'spawn must be a function');
+    }
+    validateQueueBounds(maxQueueEvents, admissionStopThreshold);
+    if (!Number.isSafeInteger(maxLineBytes) || maxLineBytes < 256) {
+      throw runtimeError(
+        'invalid-runtime',
+        'maxLineBytes must be a safe integer of at least 256',
+      );
+    }
+    if (!Number.isSafeInteger(initializeTimeoutMs) || initializeTimeoutMs < 1) {
+      throw runtimeError(
+        'invalid-runtime',
+        'initializeTimeoutMs must be a positive safe integer',
+      );
+    }
+    this.spawn = spawn;
+    this.runtimeIdentity = requireString(runtimeIdentity, 'runtimeIdentity');
+    this.maxQueueEvents = maxQueueEvents;
+    this.admissionStopThreshold = admissionStopThreshold;
+    this.maxLineBytes = maxLineBytes;
+    this.initializeTimeoutMs = initializeTimeoutMs;
+    this.now = now;
+    this.uuid = uuid;
+    this.state = null;
+  }
+
+  async start(spec) {
+    if (this.state) {
+      throw runtimeError(
+        'runtime-already-started',
+        'runtime host is already bound to a session attempt',
+      );
+    }
+    const executable = requireString(spec.executable, 'executable');
+    if (!path.isAbsolute(executable)) {
+      throw runtimeError('invalid-spec', 'executable must be an absolute path');
+    }
+    if (
+      !Array.isArray(spec.argv) ||
+      !spec.argv.every((entry) => typeof entry === 'string')
+    ) {
+      throw runtimeError('invalid-spec', 'argv must be an array of strings');
+    }
+    if (spec.cwd !== undefined && !path.isAbsolute(spec.cwd)) {
+      throw runtimeError('invalid-spec', 'cwd must be an absolute path');
+    }
+    if (
+      spec.env !== undefined &&
+      (spec.env === null ||
+        typeof spec.env !== 'object' ||
+        Array.isArray(spec.env) ||
+        !Object.values(spec.env).every((value) => typeof value === 'string'))
+    ) {
+      throw runtimeError('invalid-spec', 'env must contain only string values');
+    }
+
+    const sessionAttemptId = requireString(
+      spec.sessionAttemptId,
+      'sessionAttemptId',
+    );
+    const runtimeGeneration = requireGeneration(spec.runtimeGeneration);
+    const initializeParams = clone(spec.initializeParams ?? {});
+    if (
+      initializeParams === null ||
+      typeof initializeParams !== 'object' ||
+      Array.isArray(initializeParams) ||
+      initializeParams.clientInfo === null ||
+      typeof initializeParams.clientInfo !== 'object'
+    ) {
+      throw runtimeError(
+        'invalid-spec',
+        'initializeParams.clientInfo is required',
+      );
+    }
+    const gate = createCodexAppServerContractGate({
+      cliVersion: requireString(spec.cliVersion, 'cliVersion'),
+      initializeCapabilities: initializeParams,
+    });
+
+    const child = this.spawn(executable, [...spec.argv], {
+      cwd: spec.cwd,
+      env: spec.env,
+      shell: false,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    if (
+      !child ||
+      !child.stdin ||
+      typeof child.stdin.write !== 'function' ||
+      !child.stdout ||
+      typeof child.stdout.on !== 'function' ||
+      !child.stderr ||
+      typeof child.stderr.on !== 'function' ||
+      typeof child.on !== 'function'
+    ) {
+      throw runtimeError(
+        'invalid-child-process',
+        'spawn did not return a direct stdio child process',
+      );
+    }
+
+    const startedAt = this.now();
+    let resolveExit;
+    const exitPromise = new Promise((resolve) => {
+      resolveExit = resolve;
+    });
+    this.state = {
+      sessionAttemptId,
+      runtimeGeneration,
+      cliVersion: spec.cliVersion,
+      executable,
+      argv: [...spec.argv],
+      cwd: spec.cwd ?? null,
+      gate,
+      child,
+      pid: child.pid ?? null,
+      processStartIdentity: `${String(child.pid ?? 'unknown')}:${startedAt}:${this.uuid()}`,
+      startedAt,
+      lifecycleState: 'initializing',
+      inputAdmission: 'handshake-only',
+      expectedShutdown: false,
+      stdoutBuffer: Buffer.alloc(0),
+      stdoutEnded: false,
+      stderrBytes: 0,
+      queue: [],
+      nextSequence: 0,
+      nextRequestId: 1,
+      clientRequests: new Map(),
+      serverRequests: new Map(),
+      failure: null,
+      exit: null,
+      consumerFailures: 0,
+      exitPromise,
+      resolveExit,
+    };
+
+    // Reader and process boundaries are installed before initialize is written.
+    child.stdout.on('data', (chunk) => this.#onStdout(chunk));
+    child.stdout.on('end', () => this.#onStdoutEnd());
+    child.stdout.on('error', (error) =>
+      this.#fail('stdout-error', 'Codex App Server stdout failed', error),
+    );
+    child.stderr.on('data', (chunk) => {
+      if (!this.state) return;
+      this.state.stderrBytes += Buffer.byteLength(chunk);
+    });
+    child.stderr.on('error', (error) =>
+      this.#fail('stderr-error', 'Codex App Server stderr failed', error),
+    );
+    child.on('error', (error) =>
+      this.#fail('process-error', 'Codex App Server process failed', error),
+    );
+    child.on('close', (code, signal) => this.#onClose(code, signal));
+
+    const initialize = this.#sendRequest('initialize', initializeParams, {
+      handshake: true,
+    });
+    let timer;
+    try {
+      await Promise.race([
+        initialize,
+        new Promise((_, reject) => {
+          timer = setTimeout(
+            () =>
+              reject(
+                runtimeError(
+                  'initialize-timeout',
+                  'Codex App Server initialize response timed out',
+                ),
+              ),
+            this.initializeTimeoutMs,
+          );
+          timer.unref?.();
+        }),
+      ]);
+      if (this.state.failure) throw this.#failureError();
+      this.#writeNotification('initialized');
+      if (this.state.inputAdmission !== 'handshake-only') {
+        throw runtimeError(
+          'initialize-admission-frozen',
+          'runtime admission froze before initialize completed',
+        );
+      }
+      this.state.lifecycleState = 'ready';
+      this.state.inputAdmission = 'open';
+      return this.status();
+    } catch (error) {
+      this.#fail(
+        error.code ?? 'initialize-failed',
+        error.message ?? 'Codex App Server initialize failed',
+        error,
+      );
+      throw this.#failureError();
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  status() {
+    const state = this.#requireState();
+    return {
+      schema: RUNTIME_SCHEMA,
+      runtimeIdentity: this.runtimeIdentity,
+      sessionAttemptId: state.sessionAttemptId,
+      runtimeGeneration: state.runtimeGeneration,
+      lifecycleState: state.lifecycleState,
+      inputAdmission: state.inputAdmission,
+      backend: 'codex-app-server-direct-stdio',
+      provider: {
+        name: 'codex',
+        cliVersion: state.cliVersion,
+        schemaBundleSha256: state.gate.schemaBundleSha256,
+        experimentalApi: false,
+      },
+      foreground: {
+        executable: state.executable,
+        argv: [...state.argv],
+        cwd: state.cwd,
+        pid: state.pid,
+        processStartIdentity: state.processStartIdentity,
+        state: state.exit ? 'ended' : 'running',
+      },
+      queue: {
+        depth: state.queue.length,
+        maxEvents: this.maxQueueEvents,
+        admissionStopThreshold: this.admissionStopThreshold,
+        nextSequence: state.nextSequence,
+      },
+      correlation: {
+        outstandingClientRequests: state.clientRequests.size,
+        outstandingServerRequests: state.serverRequests.size,
+      },
+      stderr: { observedBytes: state.stderrBytes, retainedContent: false },
+      consumerFailures: state.consumerFailures,
+      failure: state.failure ? { ...state.failure } : null,
+      exit: state.exit ? { ...state.exit } : null,
+    };
+  }
+
+  currentFence() {
+    const state = this.#requireState();
+    return Object.freeze({
+      sessionAttemptId: state.sessionAttemptId,
+      runtimeGeneration: state.runtimeGeneration,
+      processStartIdentity: state.processStartIdentity,
+    });
+  }
+
+  request(action) {
+    this.#requireCurrent(action);
+    requireString(action.actionId, 'actionId');
+    if (this.state.inputAdmission !== 'open') {
+      throw runtimeError(
+        'input-admission-closed',
+        'Codex App Server input admission is not open',
+      );
+    }
+    return this.#sendRequest(
+      requireString(action.method, 'method'),
+      clone(action.params ?? {}),
+      { actionId: action.actionId },
+    );
+  }
+
+  respond(action) {
+    this.#requireCurrent(action);
+    const actionId = requireString(action.actionId, 'actionId');
+    if (this.state.inputAdmission !== 'open') {
+      throw runtimeError(
+        'input-admission-closed',
+        'Codex App Server input admission is not open',
+      );
+    }
+    const key = requestKey(action.requestId);
+    const pending = this.state.serverRequests.get(key);
+    if (!pending) {
+      throw runtimeError(
+        'unknown-server-request',
+        'server request is unknown, stale, or already resolved',
+      );
+    }
+    const hasResult = hasOwn(action, 'result');
+    const hasError = hasOwn(action, 'error');
+    if (hasResult === hasError) {
+      throw runtimeError(
+        'invalid-response',
+        'response must contain exactly one result or error',
+      );
+    }
+    const message = {
+      id: action.requestId,
+      ...(hasResult
+        ? { result: clone(action.result) }
+        : { error: clone(action.error) }),
+    };
+    const plan = this.state.gate.classify({
+      direction: 'client-response',
+      message,
+      requestMethod: pending.method,
+    });
+    this.#writeLine(message);
+    this.state.serverRequests.delete(key);
+    return Object.freeze({
+      schema: RECEIPT_SCHEMA,
+      operation: 'server-request-response',
+      actionId,
+      requestId: action.requestId,
+      providerMethod: pending.method,
+      normalizedSemantic: plan.normalizedSemantic,
+      status: 'written',
+      ...this.currentFence(),
+    });
+  }
+
+  takeEvents(limit = this.maxQueueEvents) {
+    const state = this.#requireState();
+    if (!Number.isSafeInteger(limit) || limit < 1) {
+      throw runtimeError('invalid-limit', 'event limit must be positive');
+    }
+    return state.queue.splice(0, limit).map((event) => clone(event));
+  }
+
+  subscribe(listener) {
+    if (typeof listener !== 'function') {
+      throw runtimeError('invalid-consumer', 'listener must be a function');
+    }
+    this.on('runtime-event', listener);
+    return () => this.off('runtime-event', listener);
+  }
+
+  shutdown(action) {
+    const state = this.#requireCurrent(action);
+    const actionId = requireString(action.actionId, 'actionId');
+    if (state.exit) {
+      return Object.freeze({
+        schema: RECEIPT_SCHEMA,
+        operation: 'shutdown',
+        actionId,
+        status: 'already-ended',
+        ...this.currentFence(),
+      });
+    }
+    const alreadyFailing = state.failure !== null;
+    if (!alreadyFailing) {
+      state.expectedShutdown = true;
+      state.lifecycleState = 'stopping';
+      state.inputAdmission = 'closed';
+    }
+    state.child.kill('SIGTERM');
+    return Object.freeze({
+      schema: RECEIPT_SCHEMA,
+      operation: 'shutdown',
+      actionId,
+      status: alreadyFailing ? 'failure-termination-signalled' : 'signalled',
+      signal: 'SIGTERM',
+      ...this.currentFence(),
+    });
+  }
+
+  waitForExit() {
+    return this.#requireState().exitPromise;
+  }
+
+  #sendRequest(method, params, { handshake = false, actionId = null } = {}) {
+    const state = this.#requireState();
+    if (!handshake && state.inputAdmission !== 'open') {
+      throw runtimeError(
+        'input-admission-closed',
+        'Codex App Server input admission is not open',
+      );
+    }
+    const id = state.nextRequestId++;
+    const message = { id, method, params };
+    const plan = state.gate.classify({
+      direction: 'client-request',
+      message,
+    });
+    const key = requestKey(id);
+    let resolve;
+    let reject;
+    const response = new Promise((resolvePromise, rejectPromise) => {
+      resolve = resolvePromise;
+      reject = rejectPromise;
+    });
+    state.clientRequests.set(key, {
+      id,
+      method,
+      actionId,
+      plan,
+      resolve,
+      reject,
+    });
+    try {
+      this.#writeLine(message);
+    } catch (error) {
+      state.clientRequests.delete(key);
+      reject(error);
+      this.#fail(
+        'stdin-write-error',
+        'Codex App Server stdin write failed',
+        error,
+      );
+    }
+    return response;
+  }
+
+  #writeNotification(method) {
+    const message = { method };
+    this.state.gate.classify({
+      direction: 'client-notification',
+      message,
+    });
+    this.#writeLine(message);
+  }
+
+  #writeLine(message) {
+    const state = this.#requireState();
+    if (state.exit || state.failure) throw this.#failureError();
+    state.child.stdin.write(`${JSON.stringify(message)}\n`);
+  }
+
+  #onStdout(chunk) {
+    const state = this.state;
+    if (!state || state.failure || state.exit) return;
+    const incoming = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    state.stdoutBuffer = Buffer.concat([state.stdoutBuffer, incoming]);
+    if (state.stdoutBuffer.length > this.maxLineBytes) {
+      const newline = state.stdoutBuffer.indexOf(0x0a);
+      if (newline < 0 || newline > this.maxLineBytes) {
+        this.#fail(
+          'stdout-frame-too-large',
+          'Codex App Server emitted a JSONL frame above the byte limit',
+        );
+        return;
+      }
+    }
+    while (!state.failure) {
+      const newline = state.stdoutBuffer.indexOf(0x0a);
+      if (newline < 0) break;
+      const line = state.stdoutBuffer.subarray(0, newline);
+      state.stdoutBuffer = state.stdoutBuffer.subarray(newline + 1);
+      if (line.length === 0) continue;
+      if (line.length > this.maxLineBytes) {
+        this.#fail(
+          'stdout-frame-too-large',
+          'Codex App Server emitted a JSONL frame above the byte limit',
+        );
+        return;
+      }
+      let message;
+      try {
+        message = JSON.parse(line.toString('utf8'));
+      } catch (error) {
+        this.#fail(
+          'malformed-jsonl',
+          'Codex App Server emitted malformed JSONL',
+          error,
+        );
+        return;
+      }
+      this.#acceptServerMessage(message);
+    }
+  }
+
+  #acceptServerMessage(message) {
+    const state = this.#requireState();
+    try {
+      if (
+        message === null ||
+        typeof message !== 'object' ||
+        Array.isArray(message)
+      ) {
+        throw runtimeError(
+          'invalid-envelope',
+          'Codex App Server message must be an object',
+        );
+      }
+      if (hasOwn(message, 'method')) {
+        const direction = hasOwn(message, 'id')
+          ? 'server-request'
+          : 'server-notification';
+        const plan = state.gate.classify({ direction, message });
+        if (direction === 'server-request') {
+          const key = requestKey(message.id);
+          if (state.serverRequests.has(key)) {
+            throw runtimeError(
+              'duplicate-server-request',
+              'Codex App Server repeated an outstanding server request id',
+            );
+          }
+          state.serverRequests.set(key, {
+            id: message.id,
+            method: message.method,
+          });
+        }
+        this.#enqueue(direction, message, plan);
+        return;
+      }
+      if (hasOwn(message, 'id')) {
+        const key = requestKey(message.id);
+        const pending = state.clientRequests.get(key);
+        if (!pending) {
+          throw runtimeError(
+            'unknown-client-response',
+            'Codex App Server response is unknown, stale, or duplicated',
+          );
+        }
+        const plan = state.gate.classify({
+          direction: 'server-response',
+          message,
+          requestMethod: pending.method,
+        });
+        state.clientRequests.delete(key);
+        this.#enqueue('server-response', message, plan);
+        pending.resolve(
+          Object.freeze({
+            schema: RECEIPT_SCHEMA,
+            operation: 'client-request-response',
+            actionId: pending.actionId,
+            requestId: message.id,
+            providerMethod: pending.method,
+            normalizedSemantic: plan.normalizedSemantic,
+            outcome: hasOwn(message, 'error') ? 'error' : 'result',
+            response: clone(message),
+            status: 'observed',
+            ...this.currentFence(),
+          }),
+        );
+        return;
+      }
+      throw runtimeError(
+        'invalid-envelope',
+        'Codex App Server frame is neither a method nor a response',
+      );
+    } catch (error) {
+      this.#fail(
+        error.code ?? 'protocol-frame-rejected',
+        error.message ?? 'Codex App Server frame failed closed',
+        error,
+      );
+    }
+  }
+
+  #enqueue(direction, message, plan) {
+    const state = this.#requireState();
+    if (state.queue.length >= this.maxQueueEvents) {
+      this.#fail(
+        'consumer-queue-hard-bound',
+        'Codex App Server consumer queue reached its hard bound',
+      );
+      return;
+    }
+    const event = Object.freeze({
+      schema: EVENT_SCHEMA,
+      sequence: state.nextSequence++,
+      receivedAt: this.now(),
+      direction,
+      requestId: hasOwn(message, 'id') ? message.id : null,
+      providerMethod: plan.providerMethod,
+      normalizedSemantic: plan.normalizedSemantic,
+      authority: plan.authority,
+      retention: 'private-in-memory-bounded',
+      message: clone(message),
+    });
+    state.queue.push(event);
+    if (
+      state.queue.length >= this.admissionStopThreshold &&
+      state.inputAdmission === 'open'
+    ) {
+      state.inputAdmission = 'frozen';
+    } else if (
+      state.queue.length >= this.admissionStopThreshold &&
+      state.inputAdmission === 'handshake-only'
+    ) {
+      state.inputAdmission = 'frozen';
+    }
+    for (const listener of this.listeners('runtime-event')) {
+      queueMicrotask(() => {
+        try {
+          Promise.resolve(listener(clone(event))).catch(() => {
+            if (this.state) this.state.consumerFailures += 1;
+          });
+        } catch {
+          if (this.state) this.state.consumerFailures += 1;
+        }
+      });
+    }
+  }
+
+  #onStdoutEnd() {
+    const state = this.state;
+    if (!state || state.stdoutEnded) return;
+    state.stdoutEnded = true;
+    if (!state.exit) {
+      state.inputAdmission = 'frozen';
+      if (!state.expectedShutdown && !state.failure) {
+        this.#fail(
+          'stdout-ended',
+          'Codex App Server stdout ended before process close',
+        );
+      }
+    }
+  }
+
+  #onClose(code, signal) {
+    const state = this.state;
+    if (!state || state.exit) return;
+    if (state.stdoutBuffer.length > 0 && !state.failure) {
+      this.#fail(
+        'truncated-jsonl',
+        'Codex App Server closed with a partial JSONL frame',
+      );
+    }
+    state.inputAdmission = 'closed';
+    if (!state.failure && !state.expectedShutdown) {
+      state.failure = {
+        code: 'unexpected-process-exit',
+        message: 'Codex App Server process exited without an explicit shutdown',
+        boundary: 'attempt-outcome-unknown',
+        recordedAt: this.now(),
+      };
+    }
+    state.lifecycleState = state.failure ? 'failed' : 'ended';
+    state.exit = {
+      code,
+      signal: signal ?? null,
+      expected: state.expectedShutdown,
+      endedAt: this.now(),
+      boundary: state.expectedShutdown
+        ? 'attempt-interrupted'
+        : 'attempt-outcome-unknown',
+    };
+    this.#rejectPending(
+      state.failure
+        ? this.#failureError()
+        : runtimeError('runtime-ended', 'Codex App Server runtime ended'),
+    );
+    state.resolveExit(this.status());
+  }
+
+  #fail(code, message, cause = null) {
+    const state = this.state;
+    if (!state || state.failure || state.exit) return;
+    state.failure = {
+      code,
+      message,
+      boundary: 'attempt-outcome-unknown',
+      recordedAt: this.now(),
+      cause: cause?.name ?? null,
+    };
+    state.lifecycleState = 'failed';
+    state.inputAdmission = 'frozen';
+    this.#rejectPending(this.#failureError());
+    try {
+      state.child.kill('SIGTERM');
+    } catch {
+      // Process failure is already recorded; shutdown errors cannot replace it.
+    }
+  }
+
+  #rejectPending(error) {
+    const state = this.state;
+    if (!state) return;
+    for (const pending of state.clientRequests.values()) pending.reject(error);
+    state.clientRequests.clear();
+  }
+
+  #failureError() {
+    const failure = this.state?.failure;
+    return runtimeError(
+      failure?.code ?? 'runtime-unavailable',
+      failure?.message ?? 'Codex App Server runtime is unavailable',
+    );
+  }
+
+  #requireState() {
+    if (!this.state) {
+      throw runtimeError(
+        'runtime-not-started',
+        'runtime host has no session attempt',
+      );
+    }
+    return this.state;
+  }
+
+  #requireCurrent(action) {
+    const state = this.#requireState();
+    if (action.sessionAttemptId !== state.sessionAttemptId) {
+      throw runtimeError('stale-attempt', 'stale session attempt');
+    }
+    if (action.runtimeGeneration !== state.runtimeGeneration) {
+      throw runtimeError('stale-generation', 'stale runtime generation');
+    }
+    if (action.processStartIdentity !== state.processStartIdentity) {
+      throw runtimeError('stale-process', 'stale provider process identity');
+    }
+    return state;
+  }
+}

--- a/framework/agent-session/tests/codex-app-server-runtime.test.mjs
+++ b/framework/agent-session/tests/codex-app-server-runtime.test.mjs
@@ -1,0 +1,290 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+import {
+  CodexAppServerRuntimeError,
+  CodexAppServerRuntimeHost,
+} from '../src/codex-app-server-runtime.mjs';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const provider = path.join(
+  here,
+  'fixtures',
+  'codex-app-server-runtime-provider.mjs',
+);
+
+function createHost(overrides = {}) {
+  return new CodexAppServerRuntimeHost({
+    runtimeIdentity: 'runtime-test-1',
+    initializeTimeoutMs: 2_000,
+    ...overrides,
+  });
+}
+
+async function start(mode, overrides = {}) {
+  const host = createHost(overrides);
+  await host.start({
+    sessionAttemptId: 'attempt-1',
+    runtimeGeneration: '7',
+    executable: process.execPath,
+    argv: [provider, mode],
+    cliVersion: '0.144.3',
+    initializeParams: {
+      clientInfo: { name: 'kungfu-test', version: '4.0.0-alpha.0' },
+    },
+  });
+  return host;
+}
+
+async function waitUntil(predicate, message, timeoutMs = 2_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  assert.fail(message);
+}
+
+async function stop(host, actionId = 'shutdown-test') {
+  if (!host.status().exit) {
+    host.shutdown({ ...host.currentFence(), actionId });
+    await host.waitForExit();
+  }
+}
+
+function expectRuntimeCode(fn, code) {
+  assert.throws(fn, (error) => {
+    assert.ok(error instanceof CodexAppServerRuntimeError);
+    assert.equal(error.code, code);
+    return true;
+  });
+}
+
+test('continuous reader exposes turn identity before a late turn/start response', async (t) => {
+  const host = await start('late-turn-response');
+  t.after(() => stop(host));
+  const response = await host.request({
+    ...host.currentFence(),
+    actionId: 'turn-start-1',
+    method: 'turn/start',
+    params: {
+      threadId: 'thread-1',
+      input: [{ type: 'text', text: 'redacted synthetic input' }],
+    },
+  });
+  const events = host.takeEvents();
+  const started = events.findIndex(
+    (event) => event.normalizedSemantic === 'turn-started',
+  );
+  const completed = events.findIndex(
+    (event) => event.normalizedSemantic === 'turn-terminal',
+  );
+  const correlated = events.findIndex(
+    (event) =>
+      event.direction === 'server-response' &&
+      event.requestId === response.requestId,
+  );
+  assert.ok(started >= 0);
+  assert.ok(completed > started);
+  assert.ok(correlated > completed);
+  assert.equal(events[started].message.params.turn.id, 'turn-authority');
+  assert.equal(response.providerMethod, 'turn/start');
+  assert.equal(response.status, 'observed');
+});
+
+test('malformed and unknown frames fail closed and freeze admission', async (t) => {
+  for (const [mode, code] of [
+    ['malformed', 'malformed-jsonl'],
+    ['unknown-method', 'unknown-method'],
+  ]) {
+    const host = await start(mode);
+    t.after(() => stop(host, `shutdown-${mode}`));
+    await waitUntil(
+      () => host.status().failure !== null,
+      `${mode} did not fail visibly`,
+    );
+    assert.equal(host.status().failure.code, code);
+    assert.notEqual(host.status().inputAdmission, 'open');
+    expectRuntimeCode(
+      () =>
+        host.request({
+          ...host.currentFence(),
+          actionId: `late-${mode}`,
+          method: 'thread/read',
+          params: { threadId: 'thread-1' },
+        }),
+      'input-admission-closed',
+    );
+  }
+});
+
+test('bounded queue freezes before the hard bound and reports overflow without growth', async (t) => {
+  const host = await start('burst', {
+    maxQueueEvents: 5,
+    admissionStopThreshold: 3,
+  });
+  t.after(() => stop(host));
+  await waitUntil(
+    () => host.status().failure?.code === 'consumer-queue-hard-bound',
+    'burst did not reach the hard bound',
+  );
+  const status = host.status();
+  assert.equal(status.queue.depth, 5);
+  assert.equal(status.queue.maxEvents, 5);
+  assert.equal(status.failure.code, 'consumer-queue-hard-bound');
+  assert.equal(status.failure.boundary, 'attempt-outcome-unknown');
+  assert.notEqual(status.inputAdmission, 'open');
+});
+
+test('thread and turn identities remain isolated across concurrent notifications', async (t) => {
+  const host = await start('multi-identity');
+  t.after(() => stop(host));
+  await waitUntil(
+    () => host.status().queue.depth >= 3,
+    'identity notifications were not drained',
+  );
+  const identities = host
+    .takeEvents()
+    .filter((event) => event.normalizedSemantic === 'turn-started')
+    .map((event) => [
+      event.message.params.threadId,
+      event.message.params.turn.id,
+    ]);
+  assert.deepEqual(identities, [
+    ['thread-a', 'turn-a'],
+    ['thread-b', 'turn-b'],
+  ]);
+});
+
+test('server requests correlate exactly and stale writers are rejected', async (t) => {
+  const host = await start('server-request');
+  t.after(() => stop(host));
+  await waitUntil(
+    () => host.status().correlation.outstandingServerRequests === 1,
+    'server request was not correlated',
+  );
+  const fence = host.currentFence();
+  expectRuntimeCode(
+    () =>
+      host.respond({
+        ...fence,
+        runtimeGeneration: '6',
+        actionId: 'stale-response',
+        requestId: 'approval-1',
+        result: { decision: 'decline' },
+      }),
+    'stale-generation',
+  );
+  const receipt = host.respond({
+    ...fence,
+    actionId: 'deny-response',
+    requestId: 'approval-1',
+    result: { decision: 'decline' },
+  });
+  assert.equal(receipt.status, 'written');
+  assert.equal(host.status().correlation.outstandingServerRequests, 0);
+  expectRuntimeCode(
+    () =>
+      host.respond({
+        ...fence,
+        actionId: 'duplicate-response',
+        requestId: 'approval-1',
+        result: { decision: 'decline' },
+      }),
+    'unknown-server-request',
+  );
+  expectRuntimeCode(
+    () =>
+      host.request({
+        ...fence,
+        processStartIdentity: 'stale-process',
+        actionId: 'stale-request',
+        method: 'thread/read',
+        params: { threadId: 'thread-1' },
+      }),
+    'stale-process',
+  );
+});
+
+test('slow or failing consumers cannot block stdout draining', async (t) => {
+  const host = createHost();
+  host.subscribe(() => {
+    throw new Error('synthetic consumer failure');
+  });
+  await host.start({
+    sessionAttemptId: 'attempt-1',
+    runtimeGeneration: '7',
+    executable: process.execPath,
+    argv: [provider, 'multi-identity'],
+    cliVersion: '0.144.3',
+    initializeParams: {
+      clientInfo: { name: 'kungfu-test', version: '4.0.0-alpha.0' },
+    },
+  });
+  t.after(() => stop(host));
+  await waitUntil(
+    () => host.status().consumerFailures >= 3,
+    'consumer failure was not isolated',
+  );
+  assert.ok(host.status().queue.depth >= 3);
+  assert.equal(host.status().lifecycleState, 'ready');
+});
+
+test('stderr content is never retained or surfaced', async (t) => {
+  const host = await start('stderr-redaction');
+  t.after(() => stop(host));
+  await waitUntil(
+    () => host.status().stderr.observedBytes > 0,
+    'stderr bytes were not observed',
+  );
+  const visible = JSON.stringify({
+    status: host.status(),
+    events: host.takeEvents(),
+  });
+  assert.equal(
+    visible.includes('synthetic-secret-must-not-be-retained'),
+    false,
+  );
+  assert.equal(host.status().stderr.retainedContent, false);
+});
+
+test('stdout pipe loss terminates the provider with an unknown attempt boundary', async () => {
+  const host = await start('stdout-end');
+  await waitUntil(
+    () => host.status().failure?.code === 'stdout-ended',
+    'stdout loss did not fail visibly',
+  );
+  host.shutdown({ ...host.currentFence(), actionId: 'repeat-termination' });
+  const status = await host.waitForExit();
+  assert.equal(status.failure.code, 'stdout-ended');
+  assert.equal(status.failure.boundary, 'attempt-outcome-unknown');
+  assert.equal(status.exit.expected, false);
+  assert.equal(status.exit.boundary, 'attempt-outcome-unknown');
+});
+
+test('version drift fails before spawn', async () => {
+  let spawned = false;
+  const host = createHost({
+    spawn: () => {
+      spawned = true;
+      throw new Error('must not spawn');
+    },
+  });
+  await assert.rejects(
+    host.start({
+      sessionAttemptId: 'attempt-1',
+      runtimeGeneration: '1',
+      executable: process.execPath,
+      argv: [provider],
+      cliVersion: '0.145.0',
+      initializeParams: {
+        clientInfo: { name: 'kungfu-test', version: '4.0.0-alpha.0' },
+      },
+    }),
+    (error) => error.code === 'cli-version-drift',
+  );
+  assert.equal(spawned, false);
+});

--- a/framework/agent-session/tests/codex-app-server-runtime.test.mjs
+++ b/framework/agent-session/tests/codex-app-server-runtime.test.mjs
@@ -265,6 +265,17 @@ test('stdout pipe loss terminates the provider with an unknown attempt boundary'
   assert.equal(status.exit.boundary, 'attempt-outcome-unknown');
 });
 
+test('unexpected provider exit is visible and never claims a terminal outcome', async () => {
+  const host = await start('unexpected-exit');
+  const status = await host.waitForExit();
+  assert.equal(status.lifecycleState, 'failed');
+  assert.equal(status.exit.code, 23);
+  assert.equal(status.exit.expected, false);
+  assert.equal(status.exit.boundary, 'attempt-outcome-unknown');
+  assert.equal(status.failure.boundary, 'attempt-outcome-unknown');
+  assert.notEqual(status.inputAdmission, 'open');
+});
+
 test('version drift fails before spawn', async () => {
   let spawned = false;
   const host = createHost({

--- a/framework/agent-session/tests/fixtures/codex-app-server-runtime-provider.mjs
+++ b/framework/agent-session/tests/fixtures/codex-app-server-runtime-provider.mjs
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import readline from 'node:readline';
+
+const mode = process.argv[2] ?? 'late-turn-response';
+const lines = readline.createInterface({ input: process.stdin });
+
+function send(message) {
+  process.stdout.write(`${JSON.stringify(message)}\n`);
+}
+
+function turn(threadId, turnId, status = 'inProgress') {
+  return { id: turnId, status, items: [] };
+}
+
+lines.on('line', (line) => {
+  const message = JSON.parse(line);
+  if (message.method === 'initialize') {
+    send({ id: message.id, result: { userAgent: 'synthetic-redacted' } });
+    return;
+  }
+  if (message.method === 'initialized') {
+    if (mode === 'malformed') {
+      process.stdout.write('{not-json}\n');
+    } else if (mode === 'unknown-method') {
+      send({ method: 'provider/unknown', params: {} });
+    } else if (mode === 'burst') {
+      for (let index = 0; index < 32; index += 1) {
+        send({
+          method: 'thread/status/changed',
+          params: { threadId: `thread-${index}`, status: { type: 'idle' } },
+        });
+      }
+    } else if (mode === 'server-request') {
+      send({
+        id: 'approval-1',
+        method: 'item/commandExecution/requestApproval',
+        params: {
+          threadId: 'thread-1',
+          turnId: 'turn-1',
+          itemId: 'item-1',
+          startedAtMs: 1,
+        },
+      });
+    } else if (mode === 'multi-identity') {
+      send({
+        method: 'turn/started',
+        params: { threadId: 'thread-a', turn: turn('thread-a', 'turn-a') },
+      });
+      send({
+        method: 'turn/started',
+        params: { threadId: 'thread-b', turn: turn('thread-b', 'turn-b') },
+      });
+    } else if (mode === 'stderr-redaction') {
+      process.stderr.write('synthetic-secret-must-not-be-retained');
+    } else if (mode === 'stdout-end') {
+      process.stdout.end();
+    }
+    return;
+  }
+  if (message.method === 'turn/start') {
+    const threadId = message.params.threadId;
+    send({
+      method: 'turn/started',
+      params: { threadId, turn: turn(threadId, 'turn-authority') },
+    });
+    send({
+      method: 'turn/completed',
+      params: {
+        threadId,
+        turn: turn(threadId, 'turn-authority', 'completed'),
+      },
+    });
+    setTimeout(
+      () => send({ id: message.id, result: { turn: { id: 'turn-authority' } } }),
+      10,
+    );
+  }
+});
+
+process.on('SIGTERM', () => process.exit(0));

--- a/framework/agent-session/tests/fixtures/codex-app-server-runtime-provider.mjs
+++ b/framework/agent-session/tests/fixtures/codex-app-server-runtime-provider.mjs
@@ -55,6 +55,8 @@ lines.on('line', (line) => {
       process.stderr.write('synthetic-secret-must-not-be-retained');
     } else if (mode === 'stdout-end') {
       process.stdout.end();
+    } else if (mode === 'unexpected-exit') {
+      setTimeout(() => process.exit(23), 5);
     }
     return;
   }

--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "test:agent-session-interaction-adapters:native": "node scripts/require-shifu.mjs test:agent-session-interaction-adapters:native && node --test framework/agent-session/tests/provider-version.native.test.mjs",
     "test:codex-app-server-contract": "node scripts/require-shifu.mjs test:codex-app-server-contract && node --test framework/agent-session/tests/codex-app-server-contract.test.mjs",
     "test:codex-app-server-contract:native": "node scripts/require-shifu.mjs test:codex-app-server-contract:native && node --test framework/agent-session/tests/codex-app-server-schema.native.test.mjs",
+    "test:codex-app-server-runtime": "node scripts/require-shifu.mjs test:codex-app-server-runtime && node --test framework/agent-session/tests/codex-app-server-runtime.test.mjs",
     "generate:codex-app-server-schema-manifest": "node scripts/require-shifu.mjs generate:codex-app-server-schema-manifest && node scripts/generate-codex-app-server-schema-manifest.mjs",
     "test:agent-session-product-surfaces": "node scripts/require-shifu.mjs test:agent-session-product-surfaces && node --test framework/agent-session/tests/product-surface.test.mjs",
     "test:profile-kfd3-qualification": "node scripts/require-shifu.mjs test:profile-kfd3-qualification && node tests/qualification/profile-kfd3/run.ts",

--- a/scripts/source-acceptance.mjs
+++ b/scripts/source-acceptance.mjs
@@ -162,6 +162,7 @@ export function sourceAcceptancePlan(files) {
         'framework/agent-session/tests/provider-adapters.test.mjs',
         'framework/agent-session/tests/interaction-port.test.mjs',
         'framework/agent-session/tests/codex-app-server-contract.test.mjs',
+        'framework/agent-session/tests/codex-app-server-runtime.test.mjs',
         'framework/agent-session/tests/product-surface.test.mjs',
         'framework/core/tests/qualification/runtime-activation/run.test.mjs',
         'framework/core/tests/qualification/durability/run.test.mjs',

--- a/scripts/source-acceptance.test.mjs
+++ b/scripts/source-acceptance.test.mjs
@@ -116,6 +116,11 @@ test('source plan covers representative source-only checks', () => {
   );
   assert.ok(
     contractTests.args.includes(
+      'framework/agent-session/tests/codex-app-server-runtime.test.mjs',
+    ),
+  );
+  assert.ok(
+    contractTests.args.includes(
       'framework/agent-session/tests/product-surface.test.mjs',
     ),
   );


### PR DESCRIPTION
## Summary

Linear replacement for #850 after `dev/v4/v4.0` advanced while its checks were running. This branch starts at the current mainline and does not force-push or bypass the up-to-date merge requirement.

Add the Stage 2 direct-stdio runtime host for the pinned Codex App Server surface without activating product routing or changing the shared Agent Interaction Port.

## Changes

- spawn an absolute executable plus argv with direct stdin/stdout/stderr pipes and no shell
- install the continuous JSONL reader before the initialize request is written
- correlate client responses and provider server requests by exact typed request id
- fence every post-handshake write by SessionAttempt, runtime generation, and process-start identity
- freeze new admission before the bounded consumer queue hard limit and fail visibly on overflow
- isolate consumer callback failures, retain stderr metadata only, and mark pipe/runtime loss as outcome unknown
- add a credential-free synthetic provider proving late turn/start response ordering, malformed/unknown frames, queue pressure, identity isolation, stale writers, pipe loss, and unexpected exit
- register the runtime test in build-free source acceptance

Version impact: minor. This adds an optional public agent-session runtime export; existing PTY, Claude, product surface, and provider routing behavior remain unchanged.

## Verification

- `./shifu test:codex-app-server-runtime` (10/10)
- #850 completed all 9 required CI checks before the up-to-date merge rule rejected its stale base
- #850 local `./shifu check:source` (229/229, exit 0)
- #850 pre-commit staged gate, including documentation contracts (61/61)
- Markdown whole-tree lint (234 files, 0 errors)

Local non-qualifying probe on #850: `./shifu test:agent-session-capsule-host` reached 56/57; its only failure is the pre-existing native peer test requiring `./shifu build:core` to create `framework/core/dist/kungfu/kungfu_node.node`. The build-free source gate and this PR's runtime test both pass.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "stage-ready",
  "adrs": ["ADR-0085"],
  "summary": "Add the pinned direct-stdio runtime host, continuous reader, exact correlation, bounded queue admission, and attempt process generation fencing without activating product routing",
  "verification": [
    "./shifu test:codex-app-server-runtime",
    "./shifu test:codex-app-server-contract",
    "./shifu test:agent-session-product-surfaces",
    "./shifu docs:check",
    "./shifu check:source"
  ]
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [x] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The runtime consumes only the explicit direct-stdio child process. Synthetic tests use Node under temporary process state, retain no stderr content, and do not read Codex credentials, auth storage, private sessions, or transcripts. This PR performs no publication, deployment, product-route activation, or real provider action.

## Checklist

- [x] Linear DCO-signed delivery history on the latest mainline
- [x] Runtime and source acceptance documentation updated
- [x] Existing contract and product-surface tests remain green
- [x] No shared Interaction Port, PTY authority, or product route changed
