### PR TITLE
docs(adr): bind runtime evidence after merge

### DIFF
--- a/docs/adr/ADR-0080-topology-neutral-capability-driven-runtime-activation.md
+++ b/docs/adr/ADR-0080-topology-neutral-capability-driven-runtime-activation.md
@@ -4,7 +4,7 @@ doc_type: architecture-decision
 adr_id: ADR-0080
 decision_status: accepted
 implementation_status: implemented
-implementation_commits: [90cec7cf8513ee1330bfacd93021fd867f5d5969, 2b01eabd49778b735dcbe14fefb618bb682854f1, d57e0a5a9e5876629d5727967294704ee665b009]
+implementation_commits: [7e1384edf69d5fe37d3b05459a9a4e0fcc258706, b27de277bc870c7cdc28fdc5ebd03040d139ae63, 363497dc1e0ef0369048216fb8de6eb1ad72bb7e]
 implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/815, https://github.com/kungfu-systems/kungfu/pull/818, https://github.com/kungfu-systems/kungfu/pull/819, https://github.com/kungfu-systems/kungfu/pull/822, https://github.com/kungfu-systems/kungfu/pull/823, https://github.com/kungfu-systems/kungfu/pull/825, https://github.com/kungfu-systems/kungfu/pull/831, https://github.com/kungfu-systems/kungfu/pull/841]
 closure_pr: https://github.com/kungfu-systems/kungfu/pull/841
 qualification_refs: [docs/qualification/runtime-activation-and-product-delivery.md, docs/qualification/evidence/runtime-activation/8643f1187/report.json]


### PR DESCRIPTION
## Summary

Repair ADR-0080 implementation evidence after PR #841 was rebased into `dev/v4/v4.0`: replace the three feature-branch commit identities with their canonical mainline equivalents.

## Changes

- update only the three `implementation_commits` entries in ADR-0080
- preserve the implemented decision, qualification report, product artifact, and bounded claims

## Verification

- `./shifu docs:check` (61/61 documentation contract tests)
- staged documentation and ADR gates passed

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "implemented",
  "adrs": ["ADR-0080"],
  "summary": "Bind the implemented runtime activation delivery to the canonical commits created by the required rebase merge",
  "verification": ["deterministic documentation gate", "ADR evidence reachability checks", "staged pre-commit gate"]
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

This PR changes evidence pointers only. It does not change runtime behavior, qualification claims, publishing, or deployment.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed
