### PR TITLE
docs(adr): bind merged Profile API evidence

### DIFF
--- a/docs/adr/ADR-0083-core-system-kfx-profile-kfx-capability-boundary.md
+++ b/docs/adr/ADR-0083-core-system-kfx-profile-kfx-capability-boundary.md
@@ -4,7 +4,7 @@ doc_type: architecture-decision
 adr_id: ADR-0083
 decision_status: accepted
 implementation_status: partial
-implementation_commits: [c6266fe3ea37e096ced272c497b6e729218c7a3b, ef4421c8607860978f7d2b890ab68c149d97747a, bdf3800cb34182b59d3f341dee08056a5ebf6bd0, fb67a700c748e8c355bec7d15077d654a2a9c3ea, c484adc5fcdf3e838c4f6e8cc84e6d93b75d10df]
+implementation_commits: [c6266fe3ea37e096ced272c497b6e729218c7a3b, ef4421c8607860978f7d2b890ab68c149d97747a, bdf3800cb34182b59d3f341dee08056a5ebf6bd0, fb67a700c748e8c355bec7d15077d654a2a9c3ea, 4734113513cb7f1868e29b45f505f3b6fd33eee1]
 review_state: self-reviewed
 sensitivity: public
 sources: [local-files, user-consensus]


### PR DESCRIPTION
## Summary

Repair ADR-0083 implementation evidence after PR #852 was rebased into `dev/v4/v4.0`: replace the feature-branch commit identity with its canonical mainline equivalent.

## Changes

- update only the newest `implementation_commits` entry in ADR-0083
- preserve the accepted decision, partial implementation status, and all existing evidence

## Verification

- `./shifu docs:check` (documentation contracts passed)
- source acceptance reached the full suite after restoring evidence reachability
- staged DCO and documentation gates passed

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "stage-ready",
  "adrs": ["ADR-0083"],
  "summary": "Bind the Profile domain extraction stage to the canonical commit created by the required rebase merge",
  "verification": ["deterministic documentation gate", "ADR evidence reachability checks", "staged pre-commit gate"]
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

This PR changes one evidence pointer only. It does not change runtime behavior, qualification claims, publishing, or deployment.

## Checklist

- [x] Commit is signed off (DCO)
- [x] Evidence points to the canonical mainline commit
- [x] No behavior or implementation file changed
