### PR TITLE
feat(agent): guard Codex App Server recovery receipts

### DIFF
--- a/docs/adr/ADR-0085-codex-app-server-structured-hybrid-adapter.md
+++ b/docs/adr/ADR-0085-codex-app-server-structured-hybrid-adapter.md
@@ -4,8 +4,8 @@ doc_type: architecture-decision
 adr_id: ADR-0085
 decision_status: accepted
 implementation_status: staged
-implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/849, https://github.com/kungfu-systems/kungfu/pull/851, https://github.com/kungfu-systems/kungfu/pull/855]
-qualification_refs: [framework/agent-session/tests/codex-app-server-contract.test.mjs, framework/agent-session/tests/codex-app-server-schema.native.test.mjs, framework/agent-session/tests/codex-app-server-runtime.test.mjs, framework/agent-session/tests/codex-app-server-interaction.test.mjs, framework/agent-session/schemas/codex-app-server/codex-v0.144.3-stable-schema-manifest.json]
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/849, https://github.com/kungfu-systems/kungfu/pull/851, https://github.com/kungfu-systems/kungfu/pull/855, https://github.com/kungfu-systems/kungfu/pull/857]
+qualification_refs: [framework/agent-session/tests/codex-app-server-contract.test.mjs, framework/agent-session/tests/codex-app-server-schema.native.test.mjs, framework/agent-session/tests/codex-app-server-runtime.test.mjs, framework/agent-session/tests/codex-app-server-interaction.test.mjs, framework/agent-session/tests/codex-app-server-recovery.test.mjs, framework/agent-session/schemas/codex-app-server/codex-v0.144.3-stable-schema-manifest.json]
 review_state: self-reviewed
 sensitivity: public
 sources: [local-files, user-consensus]
@@ -176,6 +176,16 @@ traffic. Exact request/thread/turn/item targeting, default-deny controls, one
 terminal boundary per turn, contiguous ordering, and immutable plan roots fail
 closed without upgrading delivery into semantic work outcome or Profile/KFD
 work state.
+
+Stage 4 is delivered by PR #857: a prompt-free durable journal receipt is
+written before every provider request or control response. Exact input and
+side-effect ids deduplicate completed work to one receipt, while opened or
+unknown duplicates reject blind replay. Runtime loss marks unresolved inputs
+and approvals unknown before cutting the immutable old attempt; read is
+observation-only, resume and PTY fallback require a new attempt, and queue
+admission, runtime-fence, journal-gap, and receipt-root drift fail closed. The
+guard injects the existing Agent Session journal seam and adds no database or
+provider-private state reader.
 
 ## Rejected alternatives
 

--- a/framework/agent-session/README.md
+++ b/framework/agent-session/README.md
@@ -161,6 +161,25 @@ never claim semantic work outcome, Profile/KFD work state, or proof:
 ./shifu test:codex-app-server-interaction
 ```
 
+The Stage 4 recovery guard writes provider-private, prompt-free admission
+metadata to an injected durable journal before any provider request or control
+response. Exact input and side-effect ids deduplicate completed receipts; an
+opened or unknown receipt forbids blind replay. Runtime loss first marks
+unresolved admissions and controls unknown, then closes the old attempt.
+`thread/read` is observation rather than replay, `thread/resume` requires an
+exact old boundary and a new attempt, and PTY fallback can only plan another
+new attempt while preserving the old structured receipts. Journal gaps,
+receipt-root drift, queue admission freeze, and process-fence drift fail closed:
+
+```sh
+./shifu test:codex-app-server-recovery
+```
+
+The adapter owns no second database: product integration must inject the
+existing Agent Session journal authority behind this append/read seam. The
+Stage 4 source test uses only a deterministic in-memory journal and synthetic
+runtime; it does not read provider credentials or private session state.
+
 On Darwin, packaged products must restore the executable bit on node-pty's
 `spawn-helper`. The existing Electron `afterPack` audit already owns that
 repair. The Mac smoke copies node-pty into a temporary harness directory and

--- a/framework/agent-session/package.json
+++ b/framework/agent-session/package.json
@@ -16,6 +16,7 @@
     "./interaction-port": "./src/interaction-port.mjs",
     "./codex-app-server-contract": "./src/codex-app-server-contract.mjs",
     "./codex-app-server-interaction": "./src/codex-app-server-interaction.mjs",
+    "./codex-app-server-recovery": "./src/codex-app-server-recovery.mjs",
     "./codex-app-server-runtime": "./src/codex-app-server-runtime.mjs",
     "./peer-transport": "./src/peer-transport.mjs",
     "./product-surface": "./src/product-surface.mjs",

--- a/framework/agent-session/src/codex-app-server-interaction.mjs
+++ b/framework/agent-session/src/codex-app-server-interaction.mjs
@@ -97,6 +97,8 @@ function receiptBody(event, kind, details = {}) {
     runtimeGeneration: event.runtimeGeneration,
     processStartIdentity: event.processStartIdentity,
     providerReceiveSequence: event.sequence,
+    providerRequestId:
+      event.requestId ?? event.message.params?.requestId ?? null,
     recordedAt: event.receivedAt,
     evidencePointer: {
       kind: 'runtime-event',

--- a/framework/agent-session/src/codex-app-server-recovery.mjs
+++ b/framework/agent-session/src/codex-app-server-recovery.mjs
@@ -1,0 +1,662 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { createHash } from 'node:crypto';
+
+const LEDGER_SCHEMA = 'kungfu.codex-app-server.recovery-receipt/v1';
+const FALLBACK_SCHEMA = 'kungfu.codex-app-server.fallback-plan/v1';
+const FRAME_CLASS = 'provider-private-control';
+const MUTATING_OPERATIONS = new Set([
+  'start',
+  'resume',
+  'instruct',
+  'steer',
+  'interrupt',
+  'control',
+]);
+
+export class CodexAppServerRecoveryError extends Error {
+  constructor(code, message, details = null) {
+    super(message);
+    this.name = 'CodexAppServerRecoveryError';
+    this.code = code;
+    this.details = details;
+  }
+}
+
+function fail(code, message, details = null) {
+  throw new CodexAppServerRecoveryError(code, message, details);
+}
+
+function required(value, label) {
+  if (typeof value !== 'string' || value.length === 0) {
+    fail('invalid_argument', `${label} is required`);
+  }
+  return value;
+}
+
+function canonical(value) {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(canonical).join(',')}]`;
+  return `{${Object.entries(value)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, child]) => `${JSON.stringify(key)}:${canonical(child)}`)
+    .join(',')}}`;
+}
+
+function root(value) {
+  return `sha256:${createHash('sha256').update(canonical(value)).digest('hex')}`;
+}
+
+function requireRuntime(runtime) {
+  for (const method of ['status', 'currentFence']) {
+    if (typeof runtime?.[method] !== 'function') {
+      fail('invalid_runtime', `recovery guard requires runtime.${method}()`);
+    }
+  }
+  return runtime;
+}
+
+function requireInteraction(interaction) {
+  for (const method of [
+    'status',
+    'ingest',
+    'executeRequest',
+    'executeControlResponse',
+  ]) {
+    if (typeof interaction?.[method] !== 'function') {
+      fail(
+        'invalid_interaction',
+        `recovery guard requires interaction.${method}()`,
+      );
+    }
+  }
+  return interaction;
+}
+
+function requireLedger(ledger) {
+  for (const method of ['append', 'read']) {
+    if (typeof ledger?.[method] !== 'function') {
+      fail('invalid_ledger', `recovery guard requires ledger.${method}()`);
+    }
+  }
+  return ledger;
+}
+
+function requestKey(id) {
+  if (
+    !(
+      typeof id === 'string' ||
+      (Number.isSafeInteger(id) && Number.isFinite(id))
+    ) ||
+    String(id).length === 0
+  ) {
+    fail('invalid_request_id', 'provider request id is invalid');
+  }
+  return `${typeof id}:${String(id)}`;
+}
+
+function safeInteractionReceipt(receipt) {
+  return {
+    interactionReceiptRoot: receipt.receiptRoot,
+    receiptKind: receipt.receiptKind,
+    providerMethod: receipt.providerMethod,
+    providerReceiveSequence: receipt.providerReceiveSequence,
+    providerRequestId: receipt.providerRequestId,
+    providerSessionId: receipt.providerSessionId,
+    providerTurnId: receipt.providerTurnId,
+    providerItemId: receipt.providerItemId,
+    providerTerminal: receipt.providerTerminal,
+    defaultDecision: receipt.defaultDecision,
+  };
+}
+
+export class CodexAppServerRecoveryGuard {
+  constructor({ runtime, interaction, ledger, now = () => Date.now() }) {
+    this.runtime = requireRuntime(runtime);
+    this.interaction = requireInteraction(interaction);
+    this.ledger = requireLedger(ledger);
+    this.now = now;
+    const status = this.runtime.status();
+    this.runtimeIdentity = required(status.runtimeIdentity, 'runtimeIdentity');
+    this.fence = Object.freeze({ ...this.runtime.currentFence() });
+    this.inputs = new Map();
+    this.sideEffects = new Map();
+    this.pendingControls = new Map();
+    this.providerTerminalReceipts = 0;
+    this.boundariesByRoot = new Map();
+    this.boundary = null;
+    this.ledgerFailure = null;
+    this.#rehydrate();
+    this.boundaryPromise =
+      typeof this.runtime.waitForExit === 'function'
+        ? this.runtime
+            .waitForExit()
+            .then((exitStatus) => this.reconcileRuntimeExit(exitStatus))
+            .catch((error) => {
+              this.ledgerFailure = {
+                reason: 'runtime-exit-observation-failed',
+                errorCode: error?.code ?? null,
+              };
+              return null;
+            })
+        : null;
+  }
+
+  status() {
+    const runtime = this.runtime.status();
+    const inputAdmission =
+      this.ledgerFailure || this.boundary || runtime.inputAdmission !== 'open'
+        ? 'closed'
+        : 'open';
+    return Object.freeze({
+      schema: 'kungfu.codex-app-server.recovery-status/v1',
+      provider: 'codex',
+      runtimeIdentity: this.runtimeIdentity,
+      ...this.fence,
+      state: this.boundary?.boundary ?? 'active',
+      inputAdmission,
+      durableLedger: this.ledgerFailure ? 'incomplete' : 'current',
+      ledgerFailure: this.ledgerFailure
+        ? structuredClone(this.ledgerFailure)
+        : null,
+      admissions: {
+        total: this.inputs.size,
+        unresolved: [...this.inputs.values()].filter(
+          (entry) => entry.state === 'opened' || entry.state === 'unknown',
+        ).length,
+      },
+      pendingControls: this.pendingControls.size,
+      providerTerminalReceipts: this.providerTerminalReceipts,
+      hotSwitch: false,
+      semanticOutcome: null,
+      workState: null,
+    });
+  }
+
+  recordEvent(event) {
+    this.#requireLedgerCurrent();
+    const receipt = this.interaction.ingest(event);
+    const stored = this.#append('interaction-receipt', {
+      ...safeInteractionReceipt(receipt),
+      retention: 'provider-private-durable-metadata',
+    });
+    this.#apply(stored);
+    return receipt;
+  }
+
+  async executeRequest({ inputId, sideEffectId = null, plan, recoveryFrom }) {
+    const operation = required(plan?.operation, 'plan.operation');
+    const duplicate = this.#lookupInput(inputId, sideEffectId, plan);
+    if (duplicate) return duplicate;
+    this.#requireAdmission();
+    this.#requireRecovery(operation, recoveryFrom);
+    const opened = this.#openInput({
+      inputId,
+      sideEffectId,
+      plan,
+      operation,
+      providerRequestId: null,
+      recoveryFrom,
+    });
+    if (opened.duplicate) return opened.receipt;
+    try {
+      const delivery = await this.interaction.executeRequest(plan);
+      const completed = this.#append('input-completed', {
+        inputId,
+        sideEffectId,
+        openedReceiptRoot: opened.receipt.receiptRoot,
+        planRoot: plan.root,
+        actionId: plan.actionId,
+        operation,
+        providerMethod: plan.providerMethod,
+        providerRequestId: delivery.requestId,
+        deliveryStatus: delivery.status,
+        responseOutcome: delivery.responseOutcome,
+        proves: delivery.proves,
+        recoveryMode:
+          operation === 'read'
+            ? 'observation-not-replay'
+            : operation === 'resume'
+              ? 'new-attempt-only'
+              : null,
+        semanticOutcome: null,
+        workState: null,
+        proof: null,
+      });
+      this.#apply(completed);
+      return completed;
+    } catch (error) {
+      const unknown = this.#recordInputUnknown({
+        inputId,
+        reason: 'provider-delivery-or-response-not-provable',
+        errorCode: error?.code ?? null,
+      });
+      fail(
+        'delivery_unknown',
+        'provider delivery or response is not provable; blind replay is forbidden',
+        { receiptRoot: unknown.receiptRoot },
+      );
+    }
+  }
+
+  async executeControl({ inputId, sideEffectId, plan }) {
+    const duplicate = this.#lookupInput(inputId, sideEffectId, plan);
+    if (duplicate) return duplicate;
+    this.#requireAdmission();
+    const key = requestKey(plan?.requestId);
+    const pendingControl = this.pendingControls.get(key);
+    if (
+      !pendingControl ||
+      pendingControl.sessionAttemptId !== this.fence.sessionAttemptId
+    ) {
+      fail('unknown_control', 'control request has no durable pending receipt');
+    }
+    const opened = this.#openInput({
+      inputId,
+      sideEffectId,
+      plan,
+      operation: 'control',
+      providerRequestId: plan.requestId,
+      recoveryFrom: null,
+    });
+    if (opened.duplicate) return opened.receipt;
+    try {
+      const delivery = await this.interaction.executeControlResponse(plan);
+      const completed = this.#append('input-completed', {
+        inputId,
+        sideEffectId,
+        openedReceiptRoot: opened.receipt.receiptRoot,
+        planRoot: plan.root,
+        actionId: plan.actionId,
+        operation: 'control',
+        providerMethod: plan.providerMethod,
+        providerRequestId: plan.requestId,
+        deliveryStatus: delivery.deliveryStatus,
+        decision: plan.decision,
+        proves: delivery.proves,
+        semanticOutcome: null,
+        workState: null,
+        proof: null,
+      });
+      this.#apply(completed);
+      this.pendingControls.delete(key);
+      return completed;
+    } catch (error) {
+      const unknown = this.#recordInputUnknown({
+        inputId,
+        reason: 'control-delivery-not-provable',
+        errorCode: error?.code ?? null,
+      });
+      fail(
+        'control_unknown',
+        'control delivery is not provable; the request cannot be replayed',
+        { receiptRoot: unknown.receiptRoot },
+      );
+    }
+  }
+
+  reconcileRuntimeExit(exitStatus = this.runtime.status()) {
+    this.#requireLedgerCurrent();
+    if (this.boundary) return this.boundary;
+    if (
+      exitStatus.inputAdmission === 'open' &&
+      !exitStatus.failure &&
+      !exitStatus.exit
+    ) {
+      fail('runtime_still_active', 'runtime has no recovery boundary');
+    }
+    for (const entry of this.inputs.values()) {
+      if (entry.attemptId !== this.fence.sessionAttemptId) continue;
+      if (entry.state !== 'opened') continue;
+      this.#recordInputUnknown({
+        inputId: entry.inputId,
+        reason: 'runtime-ended-before-durable-completion',
+        errorCode: exitStatus.failure?.code ?? null,
+      });
+    }
+    const pending = [...this.pendingControls.values()].filter(
+      (control) => control.sessionAttemptId === this.fence.sessionAttemptId,
+    );
+    for (const control of pending) {
+      const unknown = this.#append('control-unknown', {
+        providerRequestId: control.providerRequestId,
+        providerMethod: control.providerMethod,
+        providerSessionId: control.providerSessionId,
+        providerTurnId: control.providerTurnId,
+        providerItemId: control.providerItemId,
+        interactionReceiptRoot: control.interactionReceiptRoot,
+        reason: 'runtime-ended-with-control-outstanding',
+        defaultDecision: 'deny-unavailable-after-pipe-loss',
+        semanticOutcome: null,
+        workState: null,
+        proof: null,
+      });
+      this.#apply(unknown);
+    }
+    const boundary =
+      exitStatus.exit?.expected === true ? 'interrupted' : 'unknown';
+    const receipt = this.#append('attempt-boundary', {
+      boundary,
+      reason:
+        exitStatus.failure?.code ??
+        exitStatus.exit?.boundary ??
+        'runtime-admission-closed',
+      unresolvedAdmissions: [...this.inputs.values()].filter(
+        (entry) =>
+          entry.attemptId === this.fence.sessionAttemptId &&
+          entry.state === 'unknown',
+      ).length,
+      unresolvedControls: pending.length,
+      inputReplay: false,
+      eventReplay: false,
+      oldReceiptsImmutable: true,
+      semanticOutcome: null,
+      workState: null,
+      proof: null,
+    });
+    this.#apply(receipt);
+    return receipt;
+  }
+
+  waitForBoundary() {
+    if (!this.boundaryPromise) {
+      fail('runtime_not_observable', 'runtime has no waitForExit boundary');
+    }
+    return this.boundaryPromise;
+  }
+
+  planPtyFallback({ actionId, newSessionAttemptId, boundaryReceiptRoot }) {
+    required(actionId, 'actionId');
+    required(newSessionAttemptId, 'newSessionAttemptId');
+    const boundary = this.boundariesByRoot.get(
+      required(boundaryReceiptRoot, 'boundaryReceiptRoot'),
+    );
+    if (!boundary) fail('unknown_boundary', 'fallback boundary is not durable');
+    if (!['unknown', 'interrupted'].includes(boundary.boundary)) {
+      fail(
+        'invalid_boundary',
+        'fallback requires unknown or interrupted boundary',
+      );
+    }
+    if (newSessionAttemptId === boundary.sessionAttemptId) {
+      fail(
+        'hot_switch_forbidden',
+        'fallback must create a new session attempt',
+      );
+    }
+    const body = {
+      schema: FALLBACK_SCHEMA,
+      actionId,
+      provider: 'codex',
+      transport: 'pty',
+      previousSessionAttemptId: boundary.sessionAttemptId,
+      newSessionAttemptId,
+      boundaryReceiptRoot,
+      hotSwitch: false,
+      preservesStructuredReceipts: true,
+      effects: ['create-new-pty-attempt-only'],
+      semanticOutcome: null,
+      workState: null,
+    };
+    return Object.freeze({ ...body, root: root(body) });
+  }
+
+  #requireAdmission() {
+    this.#requireLedgerCurrent();
+    if (this.boundary)
+      fail('attempt_closed', 'old attempt admission is closed');
+    const runtime = this.runtime.status();
+    if (runtime.inputAdmission !== 'open') {
+      fail('runtime_admission_closed', 'runtime input admission is not open');
+    }
+    const currentFence = this.runtime.currentFence();
+    for (const field of [
+      'sessionAttemptId',
+      'runtimeGeneration',
+      'processStartIdentity',
+    ]) {
+      if (currentFence[field] !== this.fence[field]) {
+        fail('stale_runtime', `runtime ${field} changed`);
+      }
+    }
+  }
+
+  #requireLedgerCurrent() {
+    if (this.ledgerFailure) {
+      fail('ledger_incomplete', 'durable recovery ledger is incomplete', {
+        ...this.ledgerFailure,
+      });
+    }
+  }
+
+  #requireRecovery(operation, recoveryFrom) {
+    if (operation !== 'resume' && !recoveryFrom) return;
+    if (!recoveryFrom) {
+      fail(
+        'recovery_boundary_required',
+        'resume requires an old attempt boundary',
+      );
+    }
+    const boundary = this.boundariesByRoot.get(
+      required(recoveryFrom.boundaryReceiptRoot, 'boundaryReceiptRoot'),
+    );
+    if (!boundary) fail('unknown_boundary', 'recovery boundary is not durable');
+    if (boundary.sessionAttemptId !== recoveryFrom.sessionAttemptId) {
+      fail('stale_recovery', 'recovery attempt id does not match its boundary');
+    }
+    if (boundary.sessionAttemptId === this.fence.sessionAttemptId) {
+      fail('same_attempt_recovery', 'recovery must use a new session attempt');
+    }
+    if (!['unknown', 'interrupted'].includes(boundary.boundary)) {
+      fail('invalid_boundary', 'recovery boundary is not resumable');
+    }
+  }
+
+  #openInput({
+    inputId,
+    sideEffectId,
+    plan,
+    operation,
+    providerRequestId,
+    recoveryFrom,
+  }) {
+    required(inputId, 'inputId');
+    required(plan?.root, 'plan.root');
+    required(plan?.actionId, 'plan.actionId');
+    required(plan?.providerMethod, 'plan.providerMethod');
+    if (MUTATING_OPERATIONS.has(operation)) {
+      required(sideEffectId, 'sideEffectId');
+    }
+    const existing = this.#lookupInput(inputId, sideEffectId, plan);
+    if (existing) return { duplicate: true, receipt: existing };
+    if (sideEffectId) {
+      const owner = this.sideEffects.get(sideEffectId);
+      if (owner && owner !== inputId) {
+        fail('side_effect_conflict', 'side effect id belongs to another input');
+      }
+    }
+    const receipt = this.#append('input-opened', {
+      inputId,
+      sideEffectId,
+      planRoot: plan.root,
+      actionId: plan.actionId,
+      operation,
+      providerMethod: plan.providerMethod,
+      providerRequestId,
+      recoveryFrom: recoveryFrom
+        ? {
+            sessionAttemptId: recoveryFrom.sessionAttemptId,
+            boundaryReceiptRoot: recoveryFrom.boundaryReceiptRoot,
+          }
+        : null,
+      retention: 'provider-private-durable-metadata',
+      semanticOutcome: null,
+      workState: null,
+      proof: null,
+    });
+    this.#apply(receipt);
+    return { duplicate: false, receipt };
+  }
+
+  #lookupInput(inputId, sideEffectId, plan) {
+    required(inputId, 'inputId');
+    const existing = this.inputs.get(inputId);
+    if (!existing) return null;
+    if (
+      existing.planRoot !== plan?.root ||
+      existing.sideEffectId !== sideEffectId
+    ) {
+      fail('idempotency_conflict', 'input id was used for another exact plan');
+    }
+    if (existing.state === 'completed') return existing.receipt;
+    fail(
+      'duplicate_unknown',
+      'input is unresolved; query its receipt and never replay blindly',
+      {
+        receiptRoot:
+          existing.receipt?.receiptRoot ?? existing.opened.receiptRoot,
+      },
+    );
+  }
+
+  #append(kind, detail) {
+    const body = {
+      schema: LEDGER_SCHEMA,
+      kind,
+      provider: 'codex',
+      runtimeIdentity: this.runtimeIdentity,
+      ...this.fence,
+      recordedAt: this.now(),
+      ...structuredClone(detail),
+    };
+    const payload = Object.freeze({ ...body, receiptRoot: root(body) });
+    let stored;
+    try {
+      stored = this.ledger.append({
+        frameClass: FRAME_CLASS,
+        kind,
+        payload,
+      });
+    } catch (error) {
+      this.ledgerFailure = {
+        reason: 'ledger-append-failed',
+        errorCode: error?.code ?? null,
+      };
+      fail('ledger_append_failed', 'durable ledger append failed');
+    }
+    if (!stored || !Number.isSafeInteger(stored.cursor) || stored.cursor < 1) {
+      this.ledgerFailure = { reason: 'invalid-ledger-cursor' };
+      fail('ledger_append_failed', 'ledger append returned no durable cursor');
+    }
+    return Object.freeze({ ...payload, journalCursor: stored.cursor });
+  }
+
+  #rehydrate() {
+    const journal = this.ledger.read({ fromCursor: 0 });
+    if (journal?.gap) {
+      this.ledgerFailure = {
+        reason: journal.gap.reason ?? 'ledger-gap',
+        fromCursor: journal.gap.fromCursor ?? 0,
+        toCursor: journal.gap.toCursor ?? null,
+      };
+      return;
+    }
+    for (const frame of journal?.frames ?? []) {
+      if (frame.frameClass !== FRAME_CLASS) continue;
+      const payload = frame.payload;
+      if (!payload || payload.schema !== LEDGER_SCHEMA) {
+        this.ledgerFailure = {
+          reason: 'invalid-ledger-receipt',
+          cursor: frame.cursor ?? null,
+        };
+        return;
+      }
+      const { receiptRoot, ...body } = payload;
+      if (receiptRoot !== root(body)) {
+        this.ledgerFailure = {
+          reason: 'ledger-receipt-root-mismatch',
+          cursor: frame.cursor ?? null,
+        };
+        return;
+      }
+      this.#apply({ ...payload, journalCursor: frame.cursor });
+    }
+  }
+
+  #recordInputUnknown({ inputId, reason, errorCode }) {
+    const entry = this.inputs.get(inputId);
+    if (!entry) fail('unknown_input', 'input has no durable admission receipt');
+    if (entry.state === 'unknown') return entry.receipt;
+    if (entry.state === 'completed') return entry.receipt;
+    const unknown = this.#append('input-unknown', {
+      inputId: entry.inputId,
+      sideEffectId: entry.sideEffectId,
+      openedReceiptRoot: entry.opened.receiptRoot,
+      planRoot: entry.planRoot,
+      actionId: entry.actionId,
+      operation: entry.operation,
+      providerMethod: entry.providerMethod,
+      providerRequestId: entry.providerRequestId,
+      reason,
+      errorCode,
+      semanticOutcome: null,
+      workState: null,
+      proof: null,
+    });
+    this.#apply(unknown);
+    return unknown;
+  }
+
+  #apply(receipt) {
+    if (receipt.kind === 'input-opened') {
+      this.inputs.set(receipt.inputId, {
+        inputId: receipt.inputId,
+        sideEffectId: receipt.sideEffectId,
+        planRoot: receipt.planRoot,
+        actionId: receipt.actionId,
+        operation: receipt.operation,
+        providerMethod: receipt.providerMethod,
+        providerRequestId: receipt.providerRequestId,
+        attemptId: receipt.sessionAttemptId,
+        state: 'opened',
+        opened: receipt,
+        receipt,
+      });
+      if (receipt.sideEffectId) {
+        this.sideEffects.set(receipt.sideEffectId, receipt.inputId);
+      }
+    }
+    if (
+      receipt.kind === 'input-completed' ||
+      receipt.kind === 'input-unknown'
+    ) {
+      const entry = this.inputs.get(receipt.inputId);
+      if (entry) {
+        entry.state =
+          receipt.kind === 'input-completed' ? 'completed' : 'unknown';
+        entry.receipt = receipt;
+      }
+    }
+    if (receipt.kind === 'interaction-receipt') {
+      if (receipt.providerTerminal) this.providerTerminalReceipts += 1;
+      if (receipt.receiptKind === 'control-request') {
+        this.pendingControls.set(
+          requestKey(receipt.providerRequestId),
+          receipt,
+        );
+      }
+      if (receipt.receiptKind === 'control-resolution') {
+        this.pendingControls.delete(requestKey(receipt.providerRequestId));
+      }
+    }
+    if (receipt.kind === 'control-unknown') {
+      this.pendingControls.delete(requestKey(receipt.providerRequestId));
+    }
+    if (receipt.kind === 'attempt-boundary') {
+      this.boundariesByRoot.set(receipt.receiptRoot, receipt);
+      if (receipt.sessionAttemptId === this.fence.sessionAttemptId) {
+        this.boundary = receipt;
+      }
+    }
+  }
+}

--- a/framework/agent-session/tests/codex-app-server-interaction.test.mjs
+++ b/framework/agent-session/tests/codex-app-server-interaction.test.mjs
@@ -140,6 +140,7 @@ test('approval control is exact-targeted and defaults to deny', () => {
     }),
   );
   assert.equal(control.receiptKind, 'control-request');
+  assert.equal(control.providerRequestId, 'approval-1');
   assert.equal(control.defaultDecision, 'deny');
   assert.equal(adapter.status().pendingControls, 1);
   expectCode(

--- a/framework/agent-session/tests/codex-app-server-recovery.test.mjs
+++ b/framework/agent-session/tests/codex-app-server-recovery.test.mjs
@@ -1,0 +1,502 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { createCodexAppServerContractGate } from '../src/codex-app-server-contract.mjs';
+import { CodexAppServerInteractionAdapter } from '../src/codex-app-server-interaction.mjs';
+import {
+  CodexAppServerRecoveryError,
+  CodexAppServerRecoveryGuard,
+} from '../src/codex-app-server-recovery.mjs';
+
+class MemoryLedger {
+  constructor({ maxFrames = 256 } = {}) {
+    this.maxFrames = maxFrames;
+    this.nextCursor = 1;
+    this.frames = [];
+  }
+
+  append(frame) {
+    const stored = { cursor: this.nextCursor++, ...structuredClone(frame) };
+    this.frames.push(stored);
+    while (this.frames.length > this.maxFrames) this.frames.shift();
+    return structuredClone(stored);
+  }
+
+  read({ fromCursor = 0 }) {
+    const earliestCursor = this.frames[0]?.cursor ?? this.nextCursor;
+    return {
+      earliestCursor,
+      nextCursor: this.nextCursor - 1,
+      gap:
+        fromCursor + 1 < earliestCursor
+          ? {
+              fromCursor,
+              toCursor: earliestCursor - 1,
+              reason: 'bounded-journal-retention-overflow',
+            }
+          : null,
+      frames: structuredClone(
+        this.frames.filter((frame) => frame.cursor > fromCursor),
+      ),
+    };
+  }
+}
+
+class FakeRuntime {
+  constructor({ attemptId = 'attempt-1', generation = '1' } = {}) {
+    this.runtimeIdentity = 'runtime-codex';
+    this.fence = {
+      sessionAttemptId: attemptId,
+      runtimeGeneration: generation,
+      processStartIdentity: `process:${attemptId}:${generation}`,
+    };
+    this.inputAdmission = 'open';
+    this.failure = null;
+    this.exit = null;
+    this.requests = [];
+    this.responses = [];
+    this.requestResult = {
+      requestId: 41,
+      outcome: 'result',
+      status: 'observed',
+    };
+  }
+
+  status() {
+    return {
+      schema: 'kungfu.codex-app-server.runtime-host/v1',
+      runtimeIdentity: this.runtimeIdentity,
+      ...this.fence,
+      inputAdmission: this.inputAdmission,
+      failure: this.failure,
+      exit: this.exit,
+    };
+  }
+
+  currentFence() {
+    return { ...this.fence };
+  }
+
+  async request(action) {
+    this.requests.push(structuredClone(action));
+    return await this.requestResult;
+  }
+
+  respond(action) {
+    this.responses.push(structuredClone(action));
+    return { status: 'written' };
+  }
+}
+
+function harness({
+  runtime = new FakeRuntime(),
+  ledger = new MemoryLedger(),
+} = {}) {
+  const interaction = new CodexAppServerInteractionAdapter({ runtime });
+  const guard = new CodexAppServerRecoveryGuard({
+    runtime,
+    interaction,
+    ledger,
+    now: () => 1000 + ledger.nextCursor,
+  });
+  const gate = createCodexAppServerContractGate({ cliVersion: '0.144.3' });
+  let sequence = 0;
+  return {
+    runtime,
+    ledger,
+    interaction,
+    guard,
+    event(direction, message, requestMethod = null) {
+      const plan = gate.classify({ direction, message, requestMethod });
+      return {
+        schema: 'kungfu.codex-app-server.runtime-event/v1',
+        sequence: sequence++,
+        receivedAt: 2000 + sequence,
+        runtimeIdentity: runtime.runtimeIdentity,
+        ...runtime.currentFence(),
+        direction,
+        requestId: Object.hasOwn(message, 'id') ? message.id : null,
+        providerMethod: plan.providerMethod,
+        normalizedSemantic: plan.normalizedSemantic,
+        authority: plan.authority,
+        retention: 'private-in-memory-bounded',
+        message: structuredClone(message),
+      };
+    },
+  };
+}
+
+async function expectCode(fn, code) {
+  await assert.rejects(fn, (error) => {
+    assert.ok(error instanceof CodexAppServerRecoveryError);
+    assert.equal(error.code, code);
+    return true;
+  });
+}
+
+function startPlan(interaction, actionId = 'start-1') {
+  return interaction.planRequest({
+    actionId,
+    operation: 'start',
+    params: { model: 'redacted-model' },
+  });
+}
+
+test('durable admission precedes provider write and exact duplicates reuse one receipt', async () => {
+  const { guard, interaction, runtime, ledger } = harness();
+  const plan = startPlan(interaction);
+  const first = await guard.executeRequest({
+    inputId: 'input-1',
+    sideEffectId: 'effect-1',
+    plan,
+  });
+  assert.equal(ledger.frames[0].kind, 'input-opened');
+  assert.equal(ledger.frames[1].kind, 'input-completed');
+  assert.equal(runtime.requests.length, 1);
+  assert.equal(first.semanticOutcome, null);
+  assert.equal(first.workState, null);
+  assert.equal(
+    first.proves,
+    'provider-request-written-and-response-observed-only',
+  );
+
+  const duplicate = await guard.executeRequest({
+    inputId: 'input-1',
+    sideEffectId: 'effect-1',
+    plan,
+  });
+  assert.equal(duplicate.receiptRoot, first.receiptRoot);
+  assert.equal(runtime.requests.length, 1);
+
+  await expectCode(
+    () =>
+      guard.executeRequest({
+        inputId: 'input-1',
+        sideEffectId: 'effect-1',
+        plan: startPlan(interaction, 'changed-action'),
+      }),
+    'idempotency_conflict',
+  );
+  await expectCode(
+    () =>
+      guard.executeRequest({
+        inputId: 'input-2',
+        sideEffectId: 'effect-1',
+        plan: startPlan(interaction, 'start-2'),
+      }),
+    'side_effect_conflict',
+  );
+});
+
+test('a crash window rehydrates as duplicate unknown and never writes twice', async () => {
+  const runtime = new FakeRuntime();
+  const ledger = new MemoryLedger();
+  let resolveRequest;
+  runtime.requestResult = new Promise((resolve) => {
+    resolveRequest = resolve;
+  });
+  const first = harness({ runtime, ledger });
+  const plan = startPlan(first.interaction);
+  const pending = first.guard.executeRequest({
+    inputId: 'input-crash',
+    sideEffectId: 'effect-crash',
+    plan,
+  });
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(ledger.frames.at(-1).kind, 'input-opened');
+  assert.equal(runtime.requests.length, 1);
+
+  const recovered = harness({ runtime, ledger });
+  await expectCode(
+    () =>
+      recovered.guard.executeRequest({
+        inputId: 'input-crash',
+        sideEffectId: 'effect-crash',
+        plan: startPlan(recovered.interaction),
+      }),
+    'duplicate_unknown',
+  );
+  assert.equal(runtime.requests.length, 1);
+
+  resolveRequest({ requestId: 7, outcome: 'result', status: 'observed' });
+  await pending;
+});
+
+test('runtime exit and request rejection converge on one unknown receipt', async () => {
+  const runtime = new FakeRuntime();
+  let rejectRequest;
+  runtime.requestResult = new Promise((_, reject) => {
+    rejectRequest = reject;
+  });
+  const { guard, interaction, ledger } = harness({ runtime });
+  const pending = guard.executeRequest({
+    inputId: 'input-race',
+    sideEffectId: 'effect-race',
+    plan: startPlan(interaction),
+  });
+  await new Promise((resolve) => setImmediate(resolve));
+  runtime.inputAdmission = 'closed';
+  runtime.failure = { code: 'stdout-ended' };
+  runtime.exit = { expected: false, boundary: 'attempt-outcome-unknown' };
+  guard.reconcileRuntimeExit();
+  rejectRequest(
+    Object.assign(new Error('pipe lost'), { code: 'stdout-ended' }),
+  );
+  await expectCode(() => pending, 'delivery_unknown');
+  assert.equal(
+    ledger.frames.filter((frame) => frame.kind === 'input-unknown').length,
+    1,
+  );
+});
+
+test('approval controls retain exact request identity, default deny and deduplicate', async () => {
+  const { guard, interaction, runtime, event } = harness();
+  const receipt = guard.recordEvent(
+    event('server-request', {
+      id: 'approval-1',
+      method: 'item/commandExecution/requestApproval',
+      params: {
+        threadId: 'thread-1',
+        turnId: 'turn-1',
+        itemId: 'item-1',
+        startedAtMs: 1,
+      },
+    }),
+  );
+  assert.equal(receipt.providerRequestId, 'approval-1');
+  assert.equal(guard.status().pendingControls, 1);
+  const plan = interaction.planControlResponse({
+    actionId: 'deny-1',
+    requestId: 'approval-1',
+    providerSessionId: 'thread-1',
+    providerTurnId: 'turn-1',
+    providerItemId: 'item-1',
+  });
+  const first = await guard.executeControl({
+    inputId: 'control-1',
+    sideEffectId: 'approval-effect-1',
+    plan,
+  });
+  assert.equal(first.decision, 'deny');
+  assert.equal(runtime.responses.length, 1);
+  assert.equal(guard.status().pendingControls, 0);
+  const duplicate = await guard.executeControl({
+    inputId: 'control-1',
+    sideEffectId: 'approval-effect-1',
+    plan,
+  });
+  assert.equal(duplicate.receiptRoot, first.receiptRoot);
+  assert.equal(runtime.responses.length, 1);
+});
+
+test('runtime loss marks unresolved input and controls unknown before closing attempt', async () => {
+  const { guard, interaction, runtime, event } = harness();
+  runtime.requestResult = Promise.reject(
+    Object.assign(new Error('pipe lost'), { code: 'stdout-ended' }),
+  );
+  const plan = startPlan(interaction);
+  await expectCode(
+    () =>
+      guard.executeRequest({
+        inputId: 'input-lost',
+        sideEffectId: 'effect-lost',
+        plan,
+      }),
+    'delivery_unknown',
+  );
+  guard.recordEvent(
+    event('server-request', {
+      id: 'approval-lost',
+      method: 'item/fileChange/requestApproval',
+      params: {
+        threadId: 'thread-1',
+        turnId: 'turn-1',
+        itemId: 'item-1',
+        startedAtMs: 1,
+      },
+    }),
+  );
+  runtime.inputAdmission = 'closed';
+  runtime.failure = {
+    code: 'stdout-ended',
+    boundary: 'attempt-outcome-unknown',
+  };
+  runtime.exit = {
+    expected: false,
+    boundary: 'attempt-outcome-unknown',
+  };
+  const boundary = guard.reconcileRuntimeExit();
+  assert.equal(boundary.boundary, 'unknown');
+  assert.equal(boundary.inputReplay, false);
+  assert.equal(boundary.unresolvedAdmissions, 1);
+  assert.equal(boundary.unresolvedControls, 1);
+  assert.equal(guard.status().pendingControls, 0);
+  assert.equal(guard.status().inputAdmission, 'closed');
+  await expectCode(
+    () =>
+      guard.executeRequest({
+        inputId: 'input-lost',
+        sideEffectId: 'effect-lost',
+        plan,
+      }),
+    'duplicate_unknown',
+  );
+  assert.equal(runtime.requests.length, 1);
+});
+
+test('resume and read bind an exact old boundary without replaying old input', async () => {
+  const ledger = new MemoryLedger();
+  const oldRuntime = new FakeRuntime({ attemptId: 'attempt-old' });
+  const old = harness({ runtime: oldRuntime, ledger });
+  oldRuntime.inputAdmission = 'closed';
+  oldRuntime.failure = { code: 'pipe-lost' };
+  oldRuntime.exit = { expected: false, boundary: 'attempt-outcome-unknown' };
+  const boundary = old.guard.reconcileRuntimeExit();
+
+  const newRuntime = new FakeRuntime({
+    attemptId: 'attempt-new',
+    generation: '2',
+  });
+  const current = harness({ runtime: newRuntime, ledger });
+  const recoveryFrom = {
+    sessionAttemptId: 'attempt-old',
+    boundaryReceiptRoot: boundary.receiptRoot,
+  };
+  const resumePlan = current.interaction.planRequest({
+    actionId: 'resume-1',
+    operation: 'resume',
+    params: { threadId: 'thread-1' },
+  });
+  const resumed = await current.guard.executeRequest({
+    inputId: 'resume-input',
+    sideEffectId: 'resume-effect',
+    plan: resumePlan,
+    recoveryFrom,
+  });
+  assert.equal(resumed.recoveryMode, 'new-attempt-only');
+  assert.equal(resumed.semanticOutcome, null);
+
+  const readPlan = current.interaction.planRequest({
+    actionId: 'read-1',
+    operation: 'read',
+    params: { threadId: 'thread-1' },
+  });
+  const observed = await current.guard.executeRequest({
+    inputId: 'read-input',
+    plan: readPlan,
+    recoveryFrom,
+  });
+  assert.equal(observed.recoveryMode, 'observation-not-replay');
+  assert.equal(newRuntime.requests.length, 2);
+  assert.equal(
+    ledger.frames.some((frame) =>
+      JSON.stringify(frame.payload).includes('redacted-model'),
+    ),
+    false,
+  );
+});
+
+test('backpressure, fence drift and ledger corruption fail before provider write', async () => {
+  const runtime = new FakeRuntime();
+  runtime.inputAdmission = 'frozen';
+  const frozen = harness({ runtime });
+  await expectCode(
+    () =>
+      frozen.guard.executeRequest({
+        inputId: 'input-frozen',
+        sideEffectId: 'effect-frozen',
+        plan: startPlan(frozen.interaction),
+      }),
+    'runtime_admission_closed',
+  );
+  assert.equal(runtime.requests.length, 0);
+  assert.equal(frozen.ledger.frames.length, 0);
+
+  const drifted = harness();
+  drifted.runtime.fence.runtimeGeneration = '2';
+  await expectCode(
+    () =>
+      drifted.guard.executeRequest({
+        inputId: 'input-stale-runtime',
+        sideEffectId: 'effect-stale-runtime',
+        plan: startPlan(drifted.interaction),
+      }),
+    'stale_runtime',
+  );
+  assert.equal(drifted.runtime.requests.length, 0);
+  assert.equal(drifted.ledger.frames.length, 0);
+
+  const ledger = new MemoryLedger({ maxFrames: 1 });
+  const seed = harness({ ledger });
+  await seed.guard.executeRequest({
+    inputId: 'input-seed',
+    sideEffectId: 'effect-seed',
+    plan: startPlan(seed.interaction),
+  });
+  const recovered = harness({ runtime: seed.runtime, ledger });
+  assert.equal(recovered.guard.status().durableLedger, 'incomplete');
+  await expectCode(
+    () =>
+      recovered.guard.executeRequest({
+        inputId: 'input-after-gap',
+        sideEffectId: 'effect-after-gap',
+        plan: startPlan(recovered.interaction, 'start-after-gap'),
+      }),
+    'ledger_incomplete',
+  );
+  assert.equal(seed.runtime.requests.length, 1);
+
+  const corruptedLedger = new MemoryLedger();
+  const durable = harness({ ledger: corruptedLedger });
+  await durable.guard.executeRequest({
+    inputId: 'input-corrupt',
+    sideEffectId: 'effect-corrupt',
+    plan: startPlan(durable.interaction),
+  });
+  corruptedLedger.frames[0].payload.receiptRoot = 'sha256:corrupted';
+  const corrupted = harness({
+    runtime: durable.runtime,
+    ledger: corruptedLedger,
+  });
+  assert.equal(corrupted.guard.status().durableLedger, 'incomplete');
+  await expectCode(
+    () =>
+      corrupted.guard.executeRequest({
+        inputId: 'input-after-corruption',
+        sideEffectId: 'effect-after-corruption',
+        plan: startPlan(corrupted.interaction, 'start-after-corruption'),
+      }),
+    'ledger_incomplete',
+  );
+  assert.equal(durable.runtime.requests.length, 1);
+});
+
+test('PTY fallback preserves the old structured receipts and requires a new attempt', () => {
+  const runtime = new FakeRuntime({ attemptId: 'attempt-old' });
+  const { guard } = harness({ runtime });
+  runtime.inputAdmission = 'closed';
+  runtime.exit = { expected: true, boundary: 'attempt-interrupted' };
+  const boundary = guard.reconcileRuntimeExit();
+  assert.equal(boundary.boundary, 'interrupted');
+  const fallback = guard.planPtyFallback({
+    actionId: 'fallback-1',
+    newSessionAttemptId: 'attempt-pty-new',
+    boundaryReceiptRoot: boundary.receiptRoot,
+  });
+  assert.equal(fallback.transport, 'pty');
+  assert.equal(fallback.hotSwitch, false);
+  assert.equal(fallback.preservesStructuredReceipts, true);
+  assert.throws(
+    () =>
+      guard.planPtyFallback({
+        actionId: 'fallback-same',
+        newSessionAttemptId: 'attempt-old',
+        boundaryReceiptRoot: boundary.receiptRoot,
+      }),
+    (error) => {
+      assert.equal(error.code, 'hot_switch_forbidden');
+      return true;
+    },
+  );
+});

--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "test:codex-app-server-contract": "node scripts/require-shifu.mjs test:codex-app-server-contract && node --test framework/agent-session/tests/codex-app-server-contract.test.mjs",
     "test:codex-app-server-contract:native": "node scripts/require-shifu.mjs test:codex-app-server-contract:native && node --test framework/agent-session/tests/codex-app-server-schema.native.test.mjs",
     "test:codex-app-server-interaction": "node scripts/require-shifu.mjs test:codex-app-server-interaction && node --test framework/agent-session/tests/codex-app-server-interaction.test.mjs",
+    "test:codex-app-server-recovery": "node scripts/require-shifu.mjs test:codex-app-server-recovery && node --test framework/agent-session/tests/codex-app-server-recovery.test.mjs",
     "test:codex-app-server-runtime": "node scripts/require-shifu.mjs test:codex-app-server-runtime && node --test framework/agent-session/tests/codex-app-server-runtime.test.mjs",
     "generate:codex-app-server-schema-manifest": "node scripts/require-shifu.mjs generate:codex-app-server-schema-manifest && node scripts/generate-codex-app-server-schema-manifest.mjs",
     "test:agent-session-product-surfaces": "node scripts/require-shifu.mjs test:agent-session-product-surfaces && node --test framework/agent-session/tests/product-surface.test.mjs",

--- a/scripts/source-acceptance.mjs
+++ b/scripts/source-acceptance.mjs
@@ -163,6 +163,7 @@ export function sourceAcceptancePlan(files) {
         'framework/agent-session/tests/interaction-port.test.mjs',
         'framework/agent-session/tests/codex-app-server-contract.test.mjs',
         'framework/agent-session/tests/codex-app-server-interaction.test.mjs',
+        'framework/agent-session/tests/codex-app-server-recovery.test.mjs',
         'framework/agent-session/tests/codex-app-server-runtime.test.mjs',
         'framework/agent-session/tests/product-surface.test.mjs',
         'framework/agent-session/tests/product-detached-host.test.mjs',

--- a/scripts/source-acceptance.test.mjs
+++ b/scripts/source-acceptance.test.mjs
@@ -121,6 +121,11 @@ test('source plan covers representative source-only checks', () => {
   );
   assert.ok(
     contractTests.args.includes(
+      'framework/agent-session/tests/codex-app-server-recovery.test.mjs',
+    ),
+  );
+  assert.ok(
+    contractTests.args.includes(
       'framework/agent-session/tests/codex-app-server-runtime.test.mjs',
     ),
   );


### PR DESCRIPTION
## Summary

Deliver ADR-0085 Stage 4: Kungfu-owned durable admission/result receipts, exact input and side-effect idempotency, and fail-closed recovery boundaries for the Codex App Server structured adapter. This does not activate a product route or claim provider replay semantics.

## Changes

- add a recovery guard that appends prompt-free provider-private admission metadata before any provider request or control response
- deduplicate exact completed inputs and side effects to the same durable receipt
- reject opened or unknown duplicates so a crash window cannot create a second provider write
- mark unresolved inputs and approvals unknown before closing a lost runtime attempt
- bind read/resume recovery to an exact immutable old boundary and a distinct new attempt
- reject runtime-fence drift, ledger gaps/root corruption, closed backpressure admission, and stale controls before provider writes
- allow PTY fallback only as a new attempt while preserving structured receipts
- inject the existing Agent Session journal seam; add no database and retain no prompt, transcript, provider output, error text, credentials, or private session state
- expose the recovery adapter and include its credential-free tests in source acceptance

Version impact: minor. This is an additive optional agent-session export; shared Interaction Port, Claude/PTTY behavior, provider routing, and product surfaces remain unchanged.

## Verification

- `XDG_CACHE_HOME=/tmp/kungfu-recovery-guards-cache ./shifu test:codex-app-server-recovery` (8/8)
- focused contract/runtime/interaction/recovery/product suite (30/30)
- `XDG_CACHE_HOME=/tmp/kungfu-recovery-guards-source-cache ./shifu check:source` on base `c44ccb271` (source tests 254/254, docs 61/61, TypeScript and Biome passed)
- pre-commit staged gate passed, including docs 61/61 and Biome
- no real provider process, credential, prompt, transcript, or private session state used

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "stage-ready",
  "adrs": ["ADR-0085"],
  "summary": "Add durable prompt-free admission and result receipts, exact input and side-effect idempotency, immutable unknown or interrupted attempt cuts, and no-blind-replay recovery guards for Codex App Server",
  "verification": [
    "./shifu test:codex-app-server-recovery",
    "./shifu test:codex-app-server-interaction",
    "./shifu test:codex-app-server-runtime",
    "./shifu test:codex-app-server-contract",
    "./shifu test:agent-session-product-surfaces",
    "./shifu docs:check",
    "./shifu check:source"
  ]
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [x] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The implementation and tests use only synthetic runtime events and an in-memory deterministic journal. This PR performs no publication, deployment, product-route activation, real provider action, or private-state inspection.

## Checklist

- [x] Linear DCO-signed delivery history on the latest mainline at push time
- [x] Recovery guard and source acceptance documentation updated
- [x] Contract, runtime, interaction, recovery, and product-surface tests remain green
- [x] No shared Interaction Port, PTY authority, Claude behavior, or product route changed
