### PR TITLE
build(core): promote exhaustive enum switch to a compile error

### DIFF
--- a/docs/adr/ADR-0082-cpp23-rx-core-language-strategy.md
+++ b/docs/adr/ADR-0082-cpp23-rx-core-language-strategy.md
@@ -5,7 +5,7 @@ adr_id: ADR-0082
 decision_status: accepted
 implementation_status: staged
 implementation_commits: [a296e6dfdf3a43340093accafbee646ef97ea821, 30a849db8a93895686e53076df779717ccd79a24]
-implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/660]
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/660, https://github.com/kungfu-systems/kungfu/pull/858]
 review_state: self-reviewed
 sensitivity: public
 sources: [local-files, user-decision]
@@ -198,10 +198,15 @@ its welds (PR #660), and the Rx loop-error boundary with local stop ownership
 increments below are the pending stages, in dependency order, each shippable
 independently:
 
-1. Promote `-Werror=switch` in the compile contract
-   (`.cmake/compiler.cmake`); audit the three storage-layer `switch` sites and
-   keep deliberate `default` arms only where unknown inputs are a designed
-   state (`source_registry_unknown_record` stays).
+1. **Landed** (PR #858): promote `-Werror=switch` (Clang/GNU) and `/we4062`
+   (MSVC) in the compile contract (`.cmake/compiler.cmake`). A pre-promotion
+   audit across all three platforms (AppleClang, GCC 14.2, MSVC) found every one
+   of the 57 `switch` sites already exhaustive or carrying a deliberate
+   `default`, so the promotion required zero new case labels and changed no
+   runtime behaviour. The three storage-layer `switch(carrier_type)` scanners
+   keep their unknown-record downgrade `default` arms
+   (`source_registry_unknown_record` stays). C4061 / `-Wswitch-enum`, which
+   would flag those designed `default` arms, is intentionally not enabled.
 2. Write the three-tier error policy into `CONTRIBUTING`-adjacent developer
    docs; convert the durable-ingest `catch` ladders to `expected` +
    `transform_error` as the reference implementation.

--- a/framework/core/.cmake/compiler.cmake
+++ b/framework/core/.cmake/compiler.cmake
@@ -96,10 +96,17 @@ target_compile_definitions(kungfu_compile_contract INTERFACE
   SPDLOG_NO_NAME
   SPDLOG_NO_ATOMIC_LEVELS
   $<$<CXX_COMPILER_ID:MSVC>:HAVE_SNPRINTF;V8_DEPRECATION_WARNINGS=1;_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING>)
+# Exhaustive switch over closed enums is part of the compile contract
+# (ADR-0082): an enumerator with neither a case label nor a default arm is an
+# error, not a warning. A deliberate default arm stays legal -- it is the
+# designed escape for unknown inputs at durability seams (e.g. the storage
+# offline scanners' unknown-record downgrade paths). MSVC C4062 is the same
+# predicate as -Wswitch; C4061 (which fires even with a default present) would
+# outlaw those designed arms and is intentionally not enabled.
 target_compile_options(kungfu_compile_contract INTERFACE
-  $<$<CXX_COMPILER_ID:AppleClang,Clang>:-Wall>
-  $<$<CXX_COMPILER_ID:GNU>:-Wall;-ftemplate-backtrace-limit=0>
-  $<$<CXX_COMPILER_ID:MSVC>:/MP;/utf-8;/permissive-;/bigobj;/W3;/Zc:__cplusplus;/EHsc;/Z7>)
+  $<$<CXX_COMPILER_ID:AppleClang,Clang>:-Wall;-Werror=switch>
+  $<$<CXX_COMPILER_ID:GNU>:-Wall;-Werror=switch;-ftemplate-backtrace-limit=0>
+  $<$<CXX_COMPILER_ID:MSVC>:/MP;/utf-8;/permissive-;/bigobj;/W3;/we4062;/Zc:__cplusplus;/EHsc;/Z7>)
 target_link_options(kungfu_compile_contract INTERFACE
   $<$<CXX_COMPILER_ID:MSVC>:/DEBUG;/OPT:REF;/OPT:ICF;/IGNORE:4199>)
 


### PR DESCRIPTION
## Summary

Promote exhaustive `switch` over closed enums from a warning to a compile error, wiring `-Werror=switch` (Clang/GNU) and `/we4062` (MSVC) into `kungfu_compile_contract`. This is staged-adoption item 1 of ADR-0082: an enumerator with neither a case label nor a default arm now fails the build instead of scrolling past as a warning, so the closed-enum exhaustiveness the registry welds already enforce at set level is now also enforced at every hand-written `switch`.

## Related issue

Atlas goal: 2026-07-14-kungfu-adr0082-staged-increments

## Changes

- `framework/core/.cmake/compiler.cmake`: add `-Werror=switch` for AppleClang/Clang and GNU, and `/we4062` for MSVC, to the shared `kungfu_compile_contract` compile options
- keep the deliberate `default` arms legal: C4061 / `-Wswitch-enum` (which would flag a `switch` even when it carries a `default`) is intentionally NOT enabled, because the storage offline scanners' unknown-record downgrade paths are a designed state, not an oversight — the ADR calls this out explicitly

## Pre-promotion audit

- 89 translation units (libyijinjing, libkungfu incl. tests, libwasm, bindings) compiled clean under the new flag
- all 57 `switch` sites in `src/` either enumerate every case or carry a deliberate `default`; **zero** required a new case label, so this is a pure weld with no behavioural change
- the three storage `switch(carrier_type)` offline scanners (`manifest_catalog.cpp`, `source_registry.cpp`, `episode_manifest.cpp`) keep their unknown-record downgrade `default` arms unchanged, matching ADR-0082 §Staged adoption item 1

## Verification

- Mac / AppleClang: full `pnpm run build:core` green; native ctest 9/9
- Linux / GCC 14.2 (agent-120): full build green (`cmake-js build done`, only unrelated `-Wsign-compare` warnings remain)
- Windows / MSVC (VS 18): full build green under `/we4062`
- pre-commit staged gate

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "stage-ready",
  "adrs": ["ADR-0082"],
  "summary": "Promote exhaustive enum switch to a compile error (-Werror=switch / /we4062) as ADR-0082 staged adoption item 1, after a 89-TU three-platform audit that required zero new case labels",
  "verification": ["three-platform full core build (AppleClang, GCC 14.2, MSVC)", "native ctest", "pre-commit staged gate"]
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] release evidence, provenance, package publishing, or deployment surfaces
- [x] none of the above

This PR changes one line block of build configuration. It adds no code, changes no runtime behaviour (the audit found zero switch sites needing a new case), and makes no qualification claim.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated (the compile contract carries an inline comment explaining the flag choice and why C4061 stays off)