### PR TITLE
feat(agent): route Codex App Server through product surface

### DIFF
--- a/docs/adr/ADR-0085-codex-app-server-structured-hybrid-adapter.md
+++ b/docs/adr/ADR-0085-codex-app-server-structured-hybrid-adapter.md
@@ -4,8 +4,8 @@ doc_type: architecture-decision
 adr_id: ADR-0085
 decision_status: accepted
 implementation_status: staged
-implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/849, https://github.com/kungfu-systems/kungfu/pull/851, https://github.com/kungfu-systems/kungfu/pull/855, https://github.com/kungfu-systems/kungfu/pull/857]
-qualification_refs: [framework/agent-session/tests/codex-app-server-contract.test.mjs, framework/agent-session/tests/codex-app-server-schema.native.test.mjs, framework/agent-session/tests/codex-app-server-runtime.test.mjs, framework/agent-session/tests/codex-app-server-interaction.test.mjs, framework/agent-session/tests/codex-app-server-recovery.test.mjs, framework/agent-session/schemas/codex-app-server/codex-v0.144.3-stable-schema-manifest.json]
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/849, https://github.com/kungfu-systems/kungfu/pull/851, https://github.com/kungfu-systems/kungfu/pull/855, https://github.com/kungfu-systems/kungfu/pull/857, https://github.com/kungfu-systems/kungfu/pull/861]
+qualification_refs: [framework/agent-session/tests/codex-app-server-contract.test.mjs, framework/agent-session/tests/codex-app-server-schema.native.test.mjs, framework/agent-session/tests/codex-app-server-runtime.test.mjs, framework/agent-session/tests/codex-app-server-interaction.test.mjs, framework/agent-session/tests/codex-app-server-recovery.test.mjs, framework/agent-session/tests/codex-app-server-product.test.mjs, framework/agent-session/schemas/codex-app-server/codex-v0.144.3-stable-schema-manifest.json]
 review_state: self-reviewed
 sensitivity: public
 sources: [local-files, user-consensus]
@@ -186,6 +186,17 @@ observation-only, resume and PTY fallback require a new attempt, and queue
 admission, runtime-fence, journal-gap, and receipt-root drift fail closed. The
 guard injects the existing Agent Session journal seam and adds no database or
 provider-private state reader.
+
+Stage 5 is delivered by PR #861: an opt-in product adapter freezes the exact
+Codex `0.144.3` `app-server --stdio` launch in the reviewed start plan and
+routes structured start, instruction, interrupt, exact control response,
+status, snapshot, and receipts through the same GUI, CLI, and KFD-3 action
+surface. The feature flag is off by default, so existing Codex and Claude PTY
+plans and capabilities remain unchanged. One attempt cannot hot-switch routes;
+PTY fallback preserves the WorkConsole and provider, retains old structured
+receipts, and creates a distinct attempt only after an `unknown` or
+`interrupted` boundary. Product receipts still claim no semantic outcome,
+Profile/KFD work state, or proof.
 
 ## Rejected alternatives
 

--- a/framework/agent-session/README.md
+++ b/framework/agent-session/README.md
@@ -180,6 +180,26 @@ existing Agent Session journal authority behind this append/read seam. The
 Stage 4 source test uses only a deterministic in-memory journal and synthetic
 runtime; it does not read provider credentials or private session state.
 
+The Stage 5 product adapter routes Codex `0.144.3` through direct stdio only
+when `KUNGFU_AGENT_SESSION_CODEX_APP_SERVER=1`. With the flag absent, Codex and
+Claude retain the existing PTY plan, capabilities, authority, and receipt
+shape. GUI, CLI, and KFD-3 use the same product `invoke` seam for structured
+start, instruction, interrupt, exact provider control response, status, and
+receipts; no presentation owns a private provider mutation path.
+
+The route is frozen for one `SessionAttempt`. Runtime loss or explicit end
+closes the structured attempt at an `unknown` or `interrupted` boundary. PTY
+fallback must preserve the same WorkConsole, create a distinct attempt, and
+retain the old structured receipts; hot switching the live attempt is
+forbidden. Product status projects provider thread/turn identity and pending
+controls, but receipts still claim neither semantic outcome, work state, nor
+proof. The source-only product qualification uses a synthetic provider and
+reads no provider credentials or private state:
+
+```sh
+./shifu test:codex-app-server-product
+```
+
 On Darwin, packaged products must restore the executable bit on node-pty's
 `spawn-helper`. The existing Electron `afterPack` audit already owns that
 repair. The Mac smoke copies node-pty into a temporary harness directory and

--- a/framework/agent-session/package.json
+++ b/framework/agent-session/package.json
@@ -16,6 +16,7 @@
     "./interaction-port": "./src/interaction-port.mjs",
     "./codex-app-server-contract": "./src/codex-app-server-contract.mjs",
     "./codex-app-server-interaction": "./src/codex-app-server-interaction.mjs",
+    "./codex-app-server-product": "./src/codex-app-server-product.mjs",
     "./codex-app-server-recovery": "./src/codex-app-server-recovery.mjs",
     "./codex-app-server-runtime": "./src/codex-app-server-runtime.mjs",
     "./peer-transport": "./src/peer-transport.mjs",

--- a/framework/agent-session/src/codex-app-server-product.mjs
+++ b/framework/agent-session/src/codex-app-server-product.mjs
@@ -1,0 +1,481 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { spawn } from 'node:child_process';
+import { CodexAppServerInteractionAdapter } from './codex-app-server-interaction.mjs';
+import { CodexAppServerRecoveryGuard } from './codex-app-server-recovery.mjs';
+import { CodexAppServerRuntimeHost } from './codex-app-server-runtime.mjs';
+import { InMemoryJournalNoticePort } from './peer-transport.mjs';
+
+export const CODEX_APP_SERVER_FEATURE_FLAG =
+  'KUNGFU_AGENT_SESSION_CODEX_APP_SERVER';
+
+function required(value, label) {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw Object.assign(new Error(`${label} is required`), {
+      code: 'invalid_argument',
+    });
+  }
+  return value;
+}
+
+function sameKeys(left, right) {
+  return (
+    JSON.stringify(Object.keys(left ?? {}).sort()) ===
+    JSON.stringify([...right].sort())
+  );
+}
+
+class StructuredAuthorityTransport {
+  constructor({ ledger, now }) {
+    this.ledger = ledger;
+    this.now = now;
+    this.attachments = new Map();
+    this.controllerLease = null;
+  }
+
+  status() {
+    return { controllerLease: this.controllerLease };
+  }
+
+  attach({ attachmentId, actorId }) {
+    this.attachments.set(attachmentId, actorId);
+  }
+
+  detach({ attachmentId, actorId }) {
+    if (this.attachments.get(attachmentId) === actorId) {
+      this.attachments.delete(attachmentId);
+    }
+  }
+
+  acquireControl({ leaseId, holderId, planRoot }) {
+    if (this.controllerLease) {
+      return {
+        status:
+          this.controllerLease.holderId === holderId ? 'duplicate' : 'denied',
+        ...this.controllerLease,
+      };
+    }
+    this.controllerLease = {
+      leaseId,
+      holderId,
+      planRoot,
+      expiresAt: null,
+    };
+    this.#append('controller-granted', this.controllerLease);
+    return { status: 'granted', ...this.controllerLease };
+  }
+
+  releaseControl({ leaseId, holderId, planRoot }) {
+    if (
+      !this.controllerLease ||
+      this.controllerLease.leaseId !== leaseId ||
+      this.controllerLease.holderId !== holderId
+    ) {
+      return { status: 'denied', reason: 'stale-controller-lease' };
+    }
+    const released = { ...this.controllerLease };
+    this.controllerLease = null;
+    this.#append('controller-released', { ...released, planRoot });
+    return { status: 'released', ...released };
+  }
+
+  #append(kind, payload) {
+    this.ledger.append({
+      frameClass: 'auditable-control',
+      kind,
+      payload: {
+        schema: 'kungfu.agent-session.structured-controller-receipt/v1',
+        ...payload,
+        recordedAt: this.now(),
+      },
+    });
+  }
+}
+
+function routeStatus(argv) {
+  return {
+    kind: 'structured',
+    provider: 'codex',
+    transport: 'codex-app-server-direct-stdio',
+    argv: [...argv],
+    featureFlag: CODEX_APP_SERVER_FEATURE_FLAG,
+    frozenPerAttempt: true,
+    hotSwitch: false,
+  };
+}
+
+/** Product runtime for one direct-stdio Codex route behind the shared surface. */
+export class CodexAppServerProductRuntime {
+  constructor({
+    spawnProcess = spawn,
+    journalFactory = () => new InMemoryJournalNoticePort({ maxFrames: 4096 }),
+    baseEnv = {},
+    now = () => Date.now(),
+    appServerArgv = ['app-server', '--stdio'],
+  } = {}) {
+    this.spawnProcess = spawnProcess;
+    this.journalFactory = journalFactory;
+    this.baseEnv = baseEnv;
+    this.now = now;
+    this.appServerArgv = Object.freeze([...appServerArgv]);
+    this.sessions = new Map();
+    this.generation = 0;
+  }
+
+  capabilities() {
+    return {
+      featureFlag: CODEX_APP_SERVER_FEATURE_FLAG,
+      enabled: true,
+      routes: [
+        {
+          ...routeStatus(this.appServerArgv),
+          providerVersion: '0.144.3',
+          capabilities: [
+            'structured-provider-events',
+            'exact-provider-controls',
+            'provider-resume-new-attempt-only',
+          ],
+        },
+      ],
+    };
+  }
+
+  planRoute(input) {
+    if (input.provider !== 'codex' || input.fallbackFrom) return null;
+    if (input.providerVersion !== '0.144.3') {
+      throw Object.assign(
+        new Error('structured Codex route requires provider version 0.144.3'),
+        { code: 'provider_version_drift' },
+      );
+    }
+    return routeStatus(this.appServerArgv);
+  }
+
+  list() {
+    return [...this.sessions.values()];
+  }
+
+  get(ref) {
+    const session = this.sessions.get(ref.sessionAttemptId) ?? null;
+    return session?.workConsoleId === ref.workConsoleId ? session : null;
+  }
+
+  async start(plan, execution = {}) {
+    if (this.sessions.has(plan.sessionAttemptId)) {
+      throw new Error(`session '${plan.sessionAttemptId}' already exists`);
+    }
+    if (!sameKeys(execution.env, plan.environmentNames)) {
+      throw new Error(
+        'execution environment names do not match the reviewed plan',
+      );
+    }
+    if (
+      JSON.stringify(plan.argv) !== JSON.stringify(this.appServerArgv) ||
+      JSON.stringify(plan.transportRoute?.argv) !==
+        JSON.stringify(this.appServerArgv)
+    ) {
+      throw Object.assign(
+        new Error('structured Codex route launch arguments drifted'),
+        { code: 'provider_launch_drift' },
+      );
+    }
+    this.generation += 1;
+    const generation = String(this.generation);
+    const ledger = this.journalFactory(plan);
+    const runtime = new CodexAppServerRuntimeHost({
+      spawn: this.spawnProcess,
+      runtimeIdentity: `product-codex-runtime:${plan.sessionAttemptId}:${generation}`,
+      now: this.now,
+    });
+    const env = {};
+    for (const name of plan.environmentNames) {
+      const value = execution.env?.[name] ?? this.baseEnv[name];
+      if (typeof value === 'string') env[name] = value;
+    }
+    await runtime.start({
+      sessionAttemptId: plan.sessionAttemptId,
+      runtimeGeneration: generation,
+      executable: plan.executable,
+      argv: plan.argv,
+      cwd: plan.cwd ?? undefined,
+      env,
+      cliVersion: plan.providerVersion,
+      initializeParams: plan.structured.initializeParams,
+    });
+    const interaction = new CodexAppServerInteractionAdapter({ runtime });
+    const recovery = new CodexAppServerRecoveryGuard({
+      runtime,
+      interaction,
+      ledger,
+      now: this.now,
+    });
+    const state = {
+      providerSessionId: null,
+      providerTurnId: null,
+      lastReceiptRoot: null,
+      pendingControls: new Map(),
+      eventFailure: null,
+      draining: false,
+    };
+    const applyReceipt = (receipt) => {
+      state.lastReceiptRoot = receipt.receiptRoot;
+      if (receipt.providerSessionId)
+        state.providerSessionId = receipt.providerSessionId;
+      if (receipt.providerMethod === 'turn/started')
+        state.providerTurnId = receipt.providerTurnId;
+      if (receipt.providerTerminal) state.providerTurnId = null;
+      if (receipt.receiptKind === 'control-request') {
+        state.pendingControls.set(String(receipt.providerRequestId), receipt);
+      }
+      if (receipt.receiptKind === 'control-resolution') {
+        state.pendingControls.delete(String(receipt.providerRequestId));
+      }
+    };
+    const drain = () => {
+      if (state.draining || state.eventFailure) return;
+      state.draining = true;
+      try {
+        for (const event of runtime.takeEvents()) {
+          applyReceipt(recovery.recordEvent(event));
+        }
+      } catch (error) {
+        state.eventFailure = error;
+        if (!runtime.status().exit) {
+          runtime.shutdown({
+            ...runtime.currentFence(),
+            actionId: `event-consumer-failed:${plan.sessionAttemptId}`,
+          });
+        }
+      } finally {
+        state.draining = false;
+      }
+    };
+    const unsubscribe = runtime.subscribe(drain);
+    drain();
+    const startRequest = interaction.planRequest({
+      actionId: `product-thread-start:${plan.sessionAttemptId}`,
+      operation: 'start',
+      params: plan.structured.threadStartParams,
+    });
+    await recovery.executeRequest({
+      inputId: `product-thread-start:${plan.root}`,
+      sideEffectId: `provider-thread:${plan.sessionAttemptId}`,
+      plan: startRequest,
+    });
+    drain();
+    if (!state.providerSessionId || state.eventFailure) {
+      runtime.shutdown({
+        ...runtime.currentFence(),
+        actionId: `missing-thread-identity:${plan.sessionAttemptId}`,
+      });
+      throw Object.assign(
+        new Error('Codex thread/start returned no durable provider identity'),
+        { code: 'missing_provider_identity' },
+      );
+    }
+    const transport = new StructuredAuthorityTransport({
+      ledger,
+      now: this.now,
+    });
+    const session = this.#session({
+      plan,
+      runtime,
+      interaction,
+      recovery,
+      ledger,
+      state,
+      drain,
+      unsubscribe,
+      transport,
+      generation,
+    });
+    this.sessions.set(plan.sessionAttemptId, session);
+    return session;
+  }
+
+  shutdown() {
+    for (const session of this.sessions.values()) {
+      if (session.runtime.status().exit) continue;
+      void session
+        .end({ actionId: 'product-worker-shutdown' })
+        .catch(() => undefined);
+    }
+  }
+
+  #session(context) {
+    const { plan, runtime, interaction, recovery, state, drain, transport } =
+      context;
+    const interactionState = () => {
+      if (state.eventFailure || recovery.status().inputAdmission !== 'open')
+        return runtime.status().exit ? 'ended' : 'unknown';
+      if (state.pendingControls.size > 0) return 'approval-needed';
+      if (state.providerTurnId) return 'busy';
+      return state.providerSessionId ? 'ready' : 'unknown';
+    };
+    const pendingControls = () =>
+      [...state.pendingControls.values()].map((receipt) => ({
+        requestId: receipt.providerRequestId,
+        providerMethod: receipt.providerMethod,
+        providerSessionId: receipt.providerSessionId,
+        providerTurnId: receipt.providerTurnId,
+        providerItemId: receipt.providerItemId,
+        defaultDecision: receipt.defaultDecision,
+      }));
+    const status = () => {
+      const current = runtime.status();
+      const boundary = recovery.status().state;
+      return {
+        workConsoleId: plan.workConsoleId,
+        sessionAttemptId: plan.sessionAttemptId,
+        capsuleId: null,
+        capsuleGeneration: current.runtimeGeneration,
+        coordinatorEpoch: '1',
+        sessionStreamEpoch: '1',
+        lifecycleState: current.exit
+          ? 'ended'
+          : current.failure
+            ? 'failed'
+            : 'ready',
+        interactionState: interactionState(),
+        inputAdmission: recovery.status().inputAdmission,
+        foreground: {
+          provider: 'codex',
+          profileRoot: plan.profileRoot,
+          executable: plan.executable,
+          argv: [...plan.argv],
+          processStartIdentity: current.processStartIdentity,
+          providerSessionId: state.providerSessionId,
+          providerTurnId: state.providerTurnId,
+          backend: current.backend,
+        },
+        output: {
+          kind: 'structured-events',
+          nextSequence: current.queue.nextSequence,
+          retainedTranscript: false,
+        },
+        providerAdapter: {
+          schema: 'kungfu.agent-session.provider-adapter/v1',
+          provider: 'codex',
+          providerVersion: plan.providerVersion,
+          adapterVersion: 'codex-app-server-structured/v1',
+          compatible: true,
+          tested: plan.providerVersion === '0.144.3',
+        },
+        queuedInstructions: 0,
+        transportRoute: plan.transportRoute,
+        structuredControl: { pending: pendingControls() },
+        attemptBoundary: ['unknown', 'interrupted'].includes(boundary)
+          ? boundary
+          : null,
+      };
+    };
+    const execute = async (request, operation, params) => {
+      if (state.eventFailure) throw state.eventFailure;
+      const providerPlan = interaction.planRequest({
+        actionId: request.actionId,
+        operation,
+        params,
+      });
+      const deliveryReceipt = await recovery.executeRequest({
+        inputId: request.inputId,
+        sideEffectId: `structured:${request.inputId}`,
+        plan: providerPlan,
+      });
+      drain();
+      return { status: 'delivered', deliveryReceipt };
+    };
+    const port = {
+      status,
+      snapshot: () => ({
+        schema: 'kungfu.agent-session.structured-snapshot/v1',
+        sessionAttemptId: plan.sessionAttemptId,
+        providerSessionId: state.providerSessionId,
+        providerTurnId: state.providerTurnId,
+        pendingControls: pendingControls(),
+        lastReceiptRoot: state.lastReceiptRoot,
+        retainedTranscript: false,
+        semanticOutcome: null,
+        workState: null,
+        proof: null,
+      }),
+      instruct: (request) => {
+        if (interactionState() !== 'ready') {
+          return { status: 'held', reason: 'structured-provider-not-ready' };
+        }
+        return execute(request, 'instruct', {
+          threadId: state.providerSessionId,
+          input: [{ type: 'text', text: required(request.text, 'text') }],
+        });
+      },
+      sendKey: () => ({
+        status: 'rejected',
+        reason: 'structured-route-has-no-semantic-key-path',
+      }),
+      interrupt: (request) => {
+        if (!state.providerTurnId) {
+          return { status: 'held', reason: 'no-active-provider-turn' };
+        }
+        return execute(request, 'interrupt', {
+          threadId: state.providerSessionId,
+          turnId: state.providerTurnId,
+        });
+      },
+      respondControl: async (request) => {
+        const pending = state.pendingControls.get(String(request.requestId));
+        if (!pending) {
+          throw Object.assign(new Error('structured control is not pending'), {
+            code: 'unknown_control',
+          });
+        }
+        const controlPlan = interaction.planControlResponse({
+          actionId: request.actionId,
+          requestId: request.requestId,
+          providerSessionId: pending.providerSessionId,
+          providerTurnId: pending.providerTurnId,
+          providerItemId: pending.providerItemId,
+          decision: request.decision,
+          result: request.result,
+        });
+        const controlReceipt = await recovery.executeControl({
+          inputId: request.inputId,
+          sideEffectId: `structured-control:${request.inputId}`,
+          plan: controlPlan,
+        });
+        state.pendingControls.delete(String(request.requestId));
+        drain();
+        return { status: 'delivered', controlReceipt };
+      },
+    };
+    const session = {
+      workConsoleId: plan.workConsoleId,
+      sessionAttemptId: plan.sessionAttemptId,
+      binding: plan.binding,
+      runtime,
+      recovery,
+      transport,
+      port,
+      attachments: new Map(),
+      authority(actorId) {
+        return {
+          holderId: actorId,
+          ...runtime.currentFence(),
+        };
+      },
+      async end(request) {
+        const controlReceipt = runtime.shutdown({
+          ...runtime.currentFence(),
+          actionId: request.actionId,
+        });
+        await runtime.waitForExit();
+        const boundaryReceipt = await recovery.waitForBoundary();
+        drain();
+        return {
+          status: controlReceipt.status,
+          controlReceipt,
+          boundaryReceipt,
+        };
+      },
+    };
+    return session;
+  }
+}

--- a/framework/agent-session/src/product-runtime.mjs
+++ b/framework/agent-session/src/product-runtime.mjs
@@ -21,7 +21,13 @@ function sameKeys(left, right) {
  * can replace this in-process constructor without changing any product client.
  */
 export class InProcessAgentSessionProductRuntime {
-  constructor({ pty, baseEnv = {}, now = () => Date.now(), maxOutputBytes }) {
+  constructor({
+    pty,
+    baseEnv = {},
+    now = () => Date.now(),
+    maxOutputBytes,
+    structuredRuntime = null,
+  }) {
     if (!pty || typeof pty.spawn !== 'function') {
       throw new Error('product runtime requires a node-pty compatible module');
     }
@@ -29,23 +35,40 @@ export class InProcessAgentSessionProductRuntime {
     this.baseEnv = baseEnv;
     this.now = now;
     this.maxOutputBytes = maxOutputBytes;
+    this.structuredRuntime = structuredRuntime;
     this.sessions = new Map();
     this.generation = 0;
   }
 
   list() {
-    return [...this.sessions.values()];
+    return [
+      ...this.sessions.values(),
+      ...(this.structuredRuntime?.list() ?? []),
+    ];
   }
 
   get(ref) {
-    const session = this.sessions.get(ref.sessionAttemptId) ?? null;
+    const session =
+      this.sessions.get(ref.sessionAttemptId) ??
+      this.structuredRuntime?.get(ref) ??
+      null;
     if (!session || session.workConsoleId !== ref.workConsoleId) return null;
     return session;
   }
 
   start(plan, execution = {}) {
-    if (this.sessions.has(plan.sessionAttemptId)) {
+    if (
+      this.list().some(
+        (session) => session.sessionAttemptId === plan.sessionAttemptId,
+      )
+    ) {
       throw new Error(`session '${plan.sessionAttemptId}' already exists`);
+    }
+    if (plan.transportRoute?.kind === 'structured') {
+      if (!this.structuredRuntime) {
+        throw new Error('structured provider route is not enabled');
+      }
+      return this.structuredRuntime.start(plan, execution);
     }
     if (!sameKeys(execution.env, plan.environmentNames)) {
       throw new Error(
@@ -144,5 +167,14 @@ export class InProcessAgentSessionProductRuntime {
         signal: 'SIGTERM',
       });
     }
+    this.structuredRuntime?.shutdown();
+  }
+
+  planRoute(input) {
+    return this.structuredRuntime?.planRoute(input) ?? null;
+  }
+
+  capabilities() {
+    return this.structuredRuntime?.capabilities() ?? null;
   }
 }

--- a/framework/agent-session/src/product-surface.mjs
+++ b/framework/agent-session/src/product-surface.mjs
@@ -6,6 +6,7 @@ const CONTROL_OPERATIONS = new Set([
   'instruct',
   'send-key',
   'interrupt',
+  'respond-control',
   'end',
 ]);
 const READ_OPERATIONS = new Set([
@@ -92,6 +93,13 @@ function publicStatus(session) {
       : null,
     workOutcome: null,
     proof: null,
+    ...(status.transportRoute
+      ? {
+          transportRoute: status.transportRoute,
+          structuredControl: status.structuredControl,
+          attemptBoundary: status.attemptBoundary,
+        }
+      : {}),
   };
 }
 
@@ -147,6 +155,7 @@ export class AgentSessionProductSurface {
   }
 
   capabilities() {
+    const productRoutes = this.runtime.capabilities?.();
     return {
       schema: 'kungfu.agent-session.surface-capabilities/v1',
       actions: [
@@ -165,6 +174,7 @@ export class AgentSessionProductSurface {
         'instruct',
         'send-key',
         'interrupt',
+        ...(productRoutes ? ['respond-control'] : []),
         'end',
       ],
       clients: ['gui', 'cli', 'kfd3-agent'],
@@ -189,6 +199,7 @@ export class AgentSessionProductSurface {
         'capsule-worker-loss-ends-the-old-attempt-and-cannot-fake-continuity',
         'machine-reboot-requires-a-new-attempt-or-provider-resume',
       ],
+      ...(productRoutes ? { providerRoutes: productRoutes } : {}),
     };
   }
 
@@ -236,6 +247,61 @@ export class AgentSessionProductSurface {
           publicStatus(session).lifecycleState !== 'ended',
       );
     const existingStatus = existing ? publicStatus(existing) : null;
+    let fallback = null;
+    let fallbackSession = null;
+    let fallbackStatus = null;
+    if (input.fallbackFrom) {
+      const previous = this.#session(input.fallbackFrom);
+      const previousStatus = publicStatus(previous);
+      if (
+        previousStatus.transportRoute?.kind !== 'structured' ||
+        previousStatus.lifecycleState !== 'ended' ||
+        !['unknown', 'interrupted'].includes(previousStatus.attemptBoundary)
+      ) {
+        throw new AgentSessionSurfaceError(
+          'fallback_not_ready',
+          'fallback requires an ended structured attempt boundary',
+        );
+      }
+      if (previous.sessionAttemptId === input.sessionAttemptId) {
+        throw new AgentSessionSurfaceError(
+          'hot_switch_forbidden',
+          'fallback must create a new session attempt',
+        );
+      }
+      if (previous.workConsoleId !== consoleId) {
+        throw new AgentSessionSurfaceError(
+          'fallback_console_mismatch',
+          'fallback must preserve the original WorkConsole identity',
+        );
+      }
+      if (input.provider !== previousStatus.foreground.provider) {
+        throw new AgentSessionSurfaceError(
+          'fallback_provider_mismatch',
+          'fallback must preserve the original provider identity',
+        );
+      }
+      fallbackSession = previous;
+      fallbackStatus = previousStatus;
+      fallback = {
+        workConsoleId: previous.workConsoleId,
+        sessionAttemptId: previous.sessionAttemptId,
+        boundary: previousStatus.attemptBoundary,
+      };
+    }
+    const transportRoute =
+      existingStatus?.transportRoute ?? this.runtime.planRoute?.(input) ?? null;
+    const structured = transportRoute
+      ? {
+          initializeParams: input.structured?.initializeParams ?? {
+            clientInfo: {
+              name: 'kungfu-agent-session',
+              version: '4.0.0-alpha.0',
+            },
+          },
+          threadStartParams: input.structured?.threadStartParams ?? {},
+        }
+      : null;
     const body = {
       schema: 'kungfu.agent-session.start-plan/v1',
       operation: existing ? 'attach-existing' : 'start',
@@ -245,31 +311,51 @@ export class AgentSessionProductSurface {
         : required(input.sessionAttemptId, 'sessionAttemptId'),
       provider:
         existingStatus?.foreground.provider ??
+        fallbackStatus?.foreground.provider ??
         required(input.provider, 'provider'),
       providerVersion:
         existingStatus?.providerAdapter.providerVersion ??
+        fallbackStatus?.providerAdapter.providerVersion ??
         required(input.providerVersion, 'providerVersion'),
       profileRoot:
         existingStatus?.foreground.profileRoot ??
+        fallbackStatus?.foreground.profileRoot ??
         required(input.profileRoot, 'profileRoot'),
       executable:
         existingStatus?.foreground.executable ??
+        fallbackStatus?.foreground.executable ??
         required(input.executable, 'executable'),
       argv:
         existingStatus?.foreground.argv ??
+        transportRoute?.argv ??
         (Array.isArray(input.argv) ? [...input.argv] : []),
       cwd: existing ? null : (input.cwd ?? null),
       environmentNames: existing ? [] : Object.keys(input.env ?? {}).sort(),
-      binding: existing?.binding ?? binding,
+      binding: existing?.binding ?? fallbackSession?.binding ?? binding,
       effects: existing
         ? ['attach-presentation-to-existing-capsule']
-        : [
-            'spawn-provider-in-capsule',
-            'register-session',
-            'attach-presentation',
-          ],
+        : transportRoute
+          ? [
+              'spawn-codex-app-server-direct-stdio',
+              'start-one-provider-thread',
+              'register-session',
+              'attach-presentation',
+            ]
+          : fallback
+            ? [
+                'create-new-pty-attempt-only',
+                'preserve-old-structured-receipts',
+                'attach-presentation',
+              ]
+            : [
+                'spawn-provider-in-capsule',
+                'register-session',
+                'attach-presentation',
+              ],
       workEffects: [],
       rollback: existing ? 'detach-presentation' : 'end-new-session-attempt',
+      ...(transportRoute ? { transportRoute, structured } : {}),
+      ...(fallback ? { fallbackFrom: fallback } : {}),
     };
     return { ...body, root: agentSessionSurfaceRoot(body) };
   }
@@ -290,7 +376,20 @@ export class AgentSessionProductSurface {
           'planned existing session is no longer available',
         );
       }
-      session = this.runtime.start(plan, execution);
+      const started = this.runtime.start(plan, execution);
+      if (started && typeof started.then === 'function') {
+        return started.then((resolved) =>
+          this.#finishStart({
+            actorId,
+            client,
+            plan,
+            attachment,
+            session: resolved,
+            reused: false,
+          }),
+        );
+      }
+      session = started;
       reused = false;
     } else if (plan.operation !== 'attach-existing') {
       throw new AgentSessionSurfaceError(
@@ -298,26 +397,14 @@ export class AgentSessionProductSurface {
         'start plan would duplicate an existing live WorkConsole',
       );
     }
-    const attachReceipt = this.#attach(session, {
+    return this.#finishStart({
       actorId,
       client,
-      attachment: attachment ?? {},
-      acquireControl: !session.controller,
+      plan,
+      attachment,
+      session,
+      reused,
     });
-    return receipt(
-      'start',
-      actorId,
-      {
-        status: reused ? 'reused' : 'started',
-        planRoot: plan.root,
-        workConsoleId: session.workConsoleId,
-        sessionAttemptId: session.sessionAttemptId,
-        capsuleId: session.port.status().capsuleId,
-        autoAttached: true,
-        attachReceipt,
-      },
-      this.now,
-    );
   }
 
   attach({
@@ -377,6 +464,15 @@ export class AgentSessionProductSurface {
     }
     const session = this.#session(ref);
     const status = publicStatus(session);
+    if (
+      operation === 'respond-control' &&
+      status.transportRoute?.kind !== 'structured'
+    ) {
+      throw new AgentSessionSurfaceError(
+        'unsupported_operation',
+        'provider control responses require a structured route',
+      );
+    }
     const body = {
       schema: 'kungfu.agent-session.control-plan/v1',
       operation,
@@ -397,14 +493,21 @@ export class AgentSessionProductSurface {
               ? ['end-exact-provider-attempt']
               : operation === 'interrupt'
                 ? ['signal-exact-provider-attempt']
-                : ['deliver-to-exact-provider-pty'],
+                : operation === 'respond-control'
+                  ? ['respond-to-exact-provider-control-request']
+                  : ['deliver-to-exact-provider-pty'],
       workEffects: [],
       proves:
         operation === 'acquire-control' || operation === 'release-control'
           ? 'controller-lease-decision-only'
           : operation === 'end'
             ? 'control-request-delivery-only'
-            : 'validated-input-written-to-pty-only',
+            : operation === 'respond-control'
+              ? 'provider-control-response-written-only'
+              : 'validated-input-written-to-pty-only',
+      ...(status.transportRoute
+        ? { transportRoute: status.transportRoute }
+        : {}),
     };
     return { ...body, root: agentSessionSurfaceRoot(body) };
   }
@@ -464,22 +567,30 @@ export class AgentSessionProductSurface {
         result = session.port.sendKey(request);
       else if (plan.operation === 'interrupt')
         result = session.port.interrupt(request);
+      else if (plan.operation === 'respond-control')
+        result = session.port.respondControl(request);
       else result = session.end(request);
     }
-    return receipt(
-      plan.operation,
-      actorId,
-      {
-        status: result.status,
-        reason: result.reason ?? null,
-        planRoot: plan.root,
-        workConsoleId: session.workConsoleId,
-        sessionAttemptId: session.sessionAttemptId,
-        deliveryReceipt: result.deliveryReceipt ?? null,
-        controlReceipt: result.controlReceipt ?? result,
-      },
-      this.now,
-    );
+    const finish = (resolved) =>
+      receipt(
+        plan.operation,
+        actorId,
+        {
+          status: resolved.status,
+          reason: resolved.reason ?? null,
+          planRoot: plan.root,
+          workConsoleId: session.workConsoleId,
+          sessionAttemptId: session.sessionAttemptId,
+          deliveryReceipt: resolved.deliveryReceipt ?? null,
+          controlReceipt: resolved.controlReceipt ?? resolved,
+          ...(publicStatus(session).transportRoute
+            ? { transportRoute: publicStatus(session).transportRoute }
+            : {}),
+        },
+        this.now,
+      );
+    if (result && typeof result.then === 'function') return result.then(finish);
+    return finish(result);
   }
 
   invoke(request) {
@@ -549,6 +660,33 @@ export class AgentSessionProductSurface {
         attachmentId,
         controller,
         providerStarted: false,
+      },
+      this.now,
+    );
+  }
+
+  #finishStart({ actorId, client, plan, attachment, session, reused }) {
+    const attachReceipt = this.#attach(session, {
+      actorId,
+      client,
+      attachment: attachment ?? {},
+      acquireControl: !session.controller,
+    });
+    const status = publicStatus(session);
+    return receipt(
+      'start',
+      actorId,
+      {
+        status: reused ? 'reused' : 'started',
+        planRoot: plan.root,
+        workConsoleId: session.workConsoleId,
+        sessionAttemptId: session.sessionAttemptId,
+        capsuleId: session.port.status().capsuleId,
+        autoAttached: true,
+        attachReceipt,
+        ...(status.transportRoute
+          ? { transportRoute: status.transportRoute }
+          : {}),
       },
       this.now,
     );

--- a/framework/agent-session/src/product-worker.mjs
+++ b/framework/agent-session/src/product-worker.mjs
@@ -2,6 +2,10 @@ import { mkdirSync, renameSync, unlinkSync, writeFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
+import {
+  CODEX_APP_SERVER_FEATURE_FLAG,
+  CodexAppServerProductRuntime,
+} from './codex-app-server-product.mjs';
 import { bindAgentSessionSurfaceRpc } from './product-rpc.mjs';
 import { InProcessAgentSessionProductRuntime } from './product-runtime.mjs';
 import { AgentSessionProductSurface } from './product-surface.mjs';
@@ -24,6 +28,10 @@ export async function runAgentSessionProductWorker({
   const runtime = new InProcessAgentSessionProductRuntime({
     pty: loadedPty,
     baseEnv,
+    structuredRuntime:
+      baseEnv[CODEX_APP_SERVER_FEATURE_FLAG] === '1'
+        ? new CodexAppServerProductRuntime({ baseEnv })
+        : null,
   });
   const surface = new AgentSessionProductSurface({ runtime });
   const server = bindAgentSessionSurfaceRpc({

--- a/framework/agent-session/tests/codex-app-server-product.test.mjs
+++ b/framework/agent-session/tests/codex-app-server-product.test.mjs
@@ -1,0 +1,336 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { CodexAppServerProductRuntime } from '../src/codex-app-server-product.mjs';
+import { InProcessAgentSessionProductRuntime } from '../src/product-runtime.mjs';
+import { AgentSessionProductSurface } from '../src/product-surface.mjs';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const provider = path.join(
+  here,
+  'fixtures',
+  'codex-app-server-runtime-provider.mjs',
+);
+const PROFILE_ROOT = `sha256:${'e'.repeat(64)}`;
+
+class FakePtyProcess extends EventEmitter {
+  constructor() {
+    super();
+    this.pid = 9001;
+  }
+
+  onData(listener) {
+    this.on('data', listener);
+  }
+
+  onExit(listener) {
+    this.on('exit', listener);
+  }
+
+  write() {}
+  resize() {}
+  kill() {}
+}
+
+function input(overrides = {}) {
+  return {
+    workConsoleId: 'console-product',
+    sessionAttemptId: 'attempt-structured',
+    provider: 'codex',
+    providerVersion: '0.144.3',
+    profileRoot: PROFILE_ROOT,
+    executable: process.execPath,
+    argv: [provider, 'product-route'],
+    env: {},
+    ...overrides,
+  };
+}
+
+function runtime({ structured = true } = {}) {
+  return new InProcessAgentSessionProductRuntime({
+    pty: { spawn: () => new FakePtyProcess() },
+    structuredRuntime: structured
+      ? new CodexAppServerProductRuntime({
+          appServerArgv: [provider, 'product-route'],
+        })
+      : null,
+  });
+}
+
+function surface(options = {}) {
+  let id = 0;
+  return new AgentSessionProductSurface({
+    runtime: runtime(options),
+    now: () => 10_000 + id,
+    makeId: () => `product-id-${++id}`,
+  });
+}
+
+async function waitFor(predicate, label, timeoutMs = 2000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const value = predicate();
+    if (value) return value;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  assert.fail(label);
+}
+
+test('production route freezes the exact Codex app-server stdio launch', () => {
+  const structured = new CodexAppServerProductRuntime();
+  const route = structured.planRoute(input());
+  assert.deepEqual(route.argv, ['app-server', '--stdio']);
+  assert.throws(
+    () => structured.planRoute(input({ providerVersion: '0.144.4' })),
+    (error) => error.code === 'provider_version_drift',
+  );
+});
+
+test('feature flag off and non-Codex providers retain the PTY plan', () => {
+  const disabled = surface({ structured: false });
+  const plan = disabled.invoke({ operation: 'plan-start', input: input() });
+  assert.equal(Object.hasOwn(plan, 'transportRoute'), false);
+  assert.deepEqual(plan.effects, [
+    'spawn-provider-in-capsule',
+    'register-session',
+    'attach-presentation',
+  ]);
+  assert.equal(
+    Object.hasOwn(
+      disabled.invoke({ operation: 'capabilities' }),
+      'providerRoutes',
+    ),
+    false,
+  );
+  disabled.invoke({
+    operation: 'start',
+    client: 'cli',
+    actorId: 'actor-pty',
+    plan,
+    expectedPlanRoot: plan.root,
+    execution: { env: {} },
+  });
+  assert.throws(
+    () =>
+      disabled.invoke({
+        operation: 'plan-control',
+        controlOperation: 'respond-control',
+        session: {
+          workConsoleId: plan.workConsoleId,
+          sessionAttemptId: plan.sessionAttemptId,
+        },
+      }),
+    (error) => error.code === 'unsupported_operation',
+  );
+
+  const enabled = surface();
+  const claude = enabled.invoke({
+    operation: 'plan-start',
+    input: input({
+      provider: 'claude',
+      providerVersion: '2.1.209',
+      sessionAttemptId: 'attempt-claude',
+      argv: [],
+    }),
+  });
+  assert.equal(Object.hasOwn(claude, 'transportRoute'), false);
+});
+
+test('GUI CLI and Agent share one frozen structured route and exact controls', async () => {
+  const product = surface();
+  const guiPlan = product.invoke({
+    operation: 'plan-start',
+    client: 'gui',
+    actorId: 'actor-gui',
+    input: input(),
+  });
+  const cliPlan = product.invoke({
+    operation: 'plan-start',
+    client: 'cli',
+    actorId: 'actor-cli',
+    input: input(),
+  });
+  assert.deepEqual(guiPlan, cliPlan);
+  assert.equal(guiPlan.transportRoute.kind, 'structured');
+  assert.equal(guiPlan.transportRoute.frozenPerAttempt, true);
+  assert.deepEqual(guiPlan.argv, [provider, 'product-route']);
+
+  const started = await product.invoke({
+    operation: 'start',
+    client: 'kfd3-agent',
+    actorId: 'actor-agent',
+    plan: guiPlan,
+    expectedPlanRoot: guiPlan.root,
+    attachment: { presentation: 'assistant-console' },
+    execution: { env: {} },
+  });
+  assert.equal(started.transportRoute.kind, 'structured');
+  const duplicateAttemptPlan = product.invoke({
+    operation: 'plan-start',
+    input: input({ workConsoleId: 'other-console' }),
+  });
+  await assert.rejects(
+    async () =>
+      product.invoke({
+        operation: 'start',
+        client: 'gui',
+        actorId: 'actor-gui',
+        plan: duplicateAttemptPlan,
+        expectedPlanRoot: duplicateAttemptPlan.root,
+        execution: { env: {} },
+      }),
+    /already exists/,
+  );
+  const ref = {
+    workConsoleId: guiPlan.workConsoleId,
+    sessionAttemptId: guiPlan.sessionAttemptId,
+  };
+  let status = product.invoke({ operation: 'status', session: ref });
+  assert.equal(status.foreground.providerSessionId, 'thread-product');
+  assert.equal(status.transportRoute.hotSwitch, false);
+  assert.equal(status.workOutcome, null);
+
+  const instruction = { text: 'redacted product instruction' };
+  const instructionPlan = product.invoke({
+    operation: 'plan-control',
+    controlOperation: 'instruct',
+    client: 'gui',
+    actorId: 'actor-agent',
+    session: ref,
+    payload: instruction,
+  });
+  const instructed = await product.invoke({
+    operation: 'instruct',
+    client: 'cli',
+    actorId: 'actor-agent',
+    plan: instructionPlan,
+    expectedPlanRoot: instructionPlan.root,
+    payload: instruction,
+  });
+  assert.equal(instructed.deliveryReceipt.deliveryStatus, 'observed');
+  assert.equal(instructed.semanticOutcome, null);
+
+  status = await waitFor(() => {
+    const current = product.invoke({ operation: 'status', session: ref });
+    return current.structuredControl.pending.length > 0 ? current : null;
+  }, 'structured approval was not projected');
+  assert.equal(status.interactionState, 'approval-needed');
+  assert.equal(
+    status.structuredControl.pending[0].requestId,
+    'approval-product',
+  );
+
+  const denial = { requestId: 'approval-product', decision: 'deny' };
+  const denialPlan = product.invoke({
+    operation: 'plan-control',
+    controlOperation: 'respond-control',
+    client: 'gui',
+    actorId: 'actor-agent',
+    session: ref,
+    payload: denial,
+  });
+  const denied = await product.invoke({
+    operation: 'respond-control',
+    client: 'kfd3-agent',
+    actorId: 'actor-agent',
+    plan: denialPlan,
+    expectedPlanRoot: denialPlan.root,
+    payload: denial,
+  });
+  assert.equal(denied.controlReceipt.decision, 'deny');
+  assert.equal(denied.workState, null);
+  await waitFor(
+    () =>
+      product.invoke({ operation: 'status', session: ref }).interactionState ===
+      'ready',
+    'structured turn did not return to ready',
+  );
+
+  assert.throws(
+    () =>
+      product.invoke({
+        operation: 'plan-start',
+        input: input({
+          sessionAttemptId: 'attempt-hot-switch',
+          fallbackFrom: ref,
+        }),
+      }),
+    (error) => error.code === 'fallback_not_ready',
+  );
+
+  const endPlan = product.invoke({
+    operation: 'plan-control',
+    controlOperation: 'end',
+    actorId: 'actor-agent',
+    session: ref,
+    payload: {},
+  });
+  await product.invoke({
+    operation: 'end',
+    actorId: 'actor-agent',
+    plan: endPlan,
+    expectedPlanRoot: endPlan.root,
+    payload: {},
+  });
+  status = product.invoke({ operation: 'status', session: ref });
+  assert.equal(status.attemptBoundary, 'interrupted');
+
+  assert.throws(
+    () =>
+      product.invoke({
+        operation: 'plan-start',
+        input: input({
+          workConsoleId: 'other-console',
+          sessionAttemptId: 'attempt-wrong-console',
+          fallbackFrom: ref,
+        }),
+      }),
+    (error) => error.code === 'fallback_console_mismatch',
+  );
+  assert.throws(
+    () =>
+      product.invoke({
+        operation: 'plan-start',
+        input: input({
+          provider: 'claude',
+          providerVersion: '2.1.209',
+          sessionAttemptId: 'attempt-wrong-provider',
+          fallbackFrom: ref,
+        }),
+      }),
+    (error) => error.code === 'fallback_provider_mismatch',
+  );
+
+  const fallback = product.invoke({
+    operation: 'plan-start',
+    input: input({
+      sessionAttemptId: 'attempt-pty-fallback',
+      fallbackFrom: ref,
+      argv: [],
+    }),
+  });
+  assert.equal(Object.hasOwn(fallback, 'transportRoute'), false);
+  assert.deepEqual(fallback.effects, [
+    'create-new-pty-attempt-only',
+    'preserve-old-structured-receipts',
+    'attach-presentation',
+  ]);
+  assert.equal(fallback.provider, 'codex');
+  assert.equal(fallback.providerVersion, '0.144.3');
+  assert.equal(fallback.profileRoot, PROFILE_ROOT);
+  const fallbackReceipt = await product.invoke({
+    operation: 'start',
+    client: 'gui',
+    actorId: 'actor-agent',
+    plan: fallback,
+    expectedPlanRoot: fallback.root,
+    attachment: { presentation: 'console-hub' },
+    execution: { env: {} },
+  });
+  assert.equal(fallbackReceipt.sessionAttemptId, 'attempt-pty-fallback');
+  assert.notEqual(fallbackReceipt.sessionAttemptId, ref.sessionAttemptId);
+});

--- a/framework/agent-session/tests/fixtures/codex-app-server-runtime-provider.mjs
+++ b/framework/agent-session/tests/fixtures/codex-app-server-runtime-provider.mjs
@@ -60,12 +60,34 @@ lines.on('line', (line) => {
     }
     return;
   }
+  if (message.method === 'thread/start' && mode === 'product-route') {
+    send({
+      method: 'thread/started',
+      params: { thread: { id: 'thread-product' } },
+    });
+    send({ id: message.id, result: { thread: { id: 'thread-product' } } });
+    return;
+  }
   if (message.method === 'turn/start') {
     const threadId = message.params.threadId;
     send({
       method: 'turn/started',
       params: { threadId, turn: turn(threadId, 'turn-authority') },
     });
+    if (mode === 'product-route') {
+      send({
+        id: 'approval-product',
+        method: 'item/commandExecution/requestApproval',
+        params: {
+          threadId,
+          turnId: 'turn-authority',
+          itemId: 'item-product',
+          startedAtMs: 1,
+        },
+      });
+      send({ id: message.id, result: { turn: { id: 'turn-authority' } } });
+      return;
+    }
     send({
       method: 'turn/completed',
       params: {
@@ -77,6 +99,38 @@ lines.on('line', (line) => {
       () => send({ id: message.id, result: { turn: { id: 'turn-authority' } } }),
       10,
     );
+    return;
+  }
+  if (message.id === 'approval-product' && mode === 'product-route') {
+    send({
+      method: 'serverRequest/resolved',
+      params: {
+        requestId: 'approval-product',
+        threadId: 'thread-product',
+      },
+    });
+    send({
+      method: 'turn/completed',
+      params: {
+        threadId: 'thread-product',
+        turn: turn('thread-product', 'turn-authority', 'completed'),
+      },
+    });
+    return;
+  }
+  if (message.method === 'turn/interrupt' && mode === 'product-route') {
+    send({
+      method: 'turn/completed',
+      params: {
+        threadId: message.params.threadId,
+        turn: turn(
+          message.params.threadId,
+          message.params.turnId,
+          'interrupted',
+        ),
+      },
+    });
+    send({ id: message.id, result: {} });
   }
 });
 

--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "test:codex-app-server-contract": "node scripts/require-shifu.mjs test:codex-app-server-contract && node --test framework/agent-session/tests/codex-app-server-contract.test.mjs",
     "test:codex-app-server-contract:native": "node scripts/require-shifu.mjs test:codex-app-server-contract:native && node --test framework/agent-session/tests/codex-app-server-schema.native.test.mjs",
     "test:codex-app-server-interaction": "node scripts/require-shifu.mjs test:codex-app-server-interaction && node --test framework/agent-session/tests/codex-app-server-interaction.test.mjs",
+    "test:codex-app-server-product": "node scripts/require-shifu.mjs test:codex-app-server-product && node --test framework/agent-session/tests/codex-app-server-product.test.mjs",
     "test:codex-app-server-recovery": "node scripts/require-shifu.mjs test:codex-app-server-recovery && node --test framework/agent-session/tests/codex-app-server-recovery.test.mjs",
     "test:codex-app-server-runtime": "node scripts/require-shifu.mjs test:codex-app-server-runtime && node --test framework/agent-session/tests/codex-app-server-runtime.test.mjs",
     "generate:codex-app-server-schema-manifest": "node scripts/require-shifu.mjs generate:codex-app-server-schema-manifest && node scripts/generate-codex-app-server-schema-manifest.mjs",

--- a/scripts/source-acceptance.mjs
+++ b/scripts/source-acceptance.mjs
@@ -165,6 +165,7 @@ export function sourceAcceptancePlan(files) {
         'framework/agent-session/tests/codex-app-server-interaction.test.mjs',
         'framework/agent-session/tests/codex-app-server-recovery.test.mjs',
         'framework/agent-session/tests/codex-app-server-runtime.test.mjs',
+        'framework/agent-session/tests/codex-app-server-product.test.mjs',
         'framework/agent-session/tests/product-surface.test.mjs',
         'framework/agent-session/tests/product-detached-host.test.mjs',
         'framework/core/tests/qualification/runtime-activation/run.test.mjs',

--- a/scripts/source-acceptance.test.mjs
+++ b/scripts/source-acceptance.test.mjs
@@ -131,6 +131,11 @@ test('source plan covers representative source-only checks', () => {
   );
   assert.ok(
     contractTests.args.includes(
+      'framework/agent-session/tests/codex-app-server-product.test.mjs',
+    ),
+  );
+  assert.ok(
+    contractTests.args.includes(
       'framework/agent-session/tests/product-surface.test.mjs',
     ),
   );


### PR DESCRIPTION
## Summary

Deliver ADR-0085 Stage 5: an opt-in Codex App Server direct-stdio route behind the existing Agent Session product surface. The flag is off by default; the existing Codex and Claude PTY route remains unchanged unless explicitly enabled.

## Changes

- add an exact Codex 0.144.3 product adapter that freezes `codex app-server --stdio` in the reviewed start plan
- route structured start, instruction, interrupt, approval response, status, snapshot, and receipts through the same GUI/CLI/KFD-3 `invoke` seam
- reuse the existing product controller/attachment authority and injected Agent Session journal seam without adding another database or GUI-private mutation path
- project exact provider thread, turn, pending-control, transport, and attempt-boundary metadata without retaining prompts or transcripts
- preserve semantic outcome, work state, and proof as null delivery non-claims
- keep feature-off and non-Codex plans/capabilities byte-shape compatible with the PTY surface
- forbid live hot switching; PTY fallback requires the same WorkConsole/provider, a distinct attempt, and an ended unknown/interrupted structured boundary
- include the synthetic credential-free product qualification in source acceptance

Version impact: minor. This is an additive opt-in provider route and package export. The default PTY path, Claude behavior, public product endpoint, and Profile/KFD work authority remain unchanged.

## Verification

- `XDG_CACHE_HOME=/tmp/kungfu-product-integration-cache ./shifu test:codex-app-server-product` (3/3)
- focused contract/runtime/interaction/recovery/product/detached suite (44/44)
- `XDG_CACHE_HOME=/tmp/kungfu-product-integration-source-cache ./shifu check:source` after rebasing onto `930ded6f6` (source tests 258/258, docs 61/61, TypeScript and Biome passed)
- pre-commit staged gate passed, including docs 61/61 and Biome
- local read-only `codex --version` and `codex app-server --help` confirmed the exact 0.144.3 `app-server --stdio` launch surface
- no real provider session, credential, prompt, transcript, hidden database, or private state was read

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "stage-ready",
  "adrs": [
    "ADR-0085"
  ],
  "summary": "Add an opt-in exact-version Codex App Server route through the shared GUI CLI and KFD-3 product surface with frozen per-attempt routing and new-attempt-only PTY fallback",
  "verification": [
    "./shifu test:codex-app-server-product",
    "./shifu test:codex-app-server-recovery",
    "./shifu test:codex-app-server-interaction",
    "./shifu test:codex-app-server-runtime",
    "./shifu test:codex-app-server-contract",
    "./shifu test:agent-session-product-surfaces",
    "./shifu docs:check",
    "./shifu check:source"
  ]
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [x] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The implementation and tests use only synthetic provider traffic. The route is opt-in and this PR performs no publication, deployment, real provider action, credential access, or private-state inspection.

## Checklist

- [x] Linear DCO-signed delivery history on the latest mainline at push time
- [x] Product route and source acceptance documentation updated
- [x] Feature flag absent preserves the existing PTY route and capabilities
- [x] GUI, CLI, and KFD-3 share one reviewed structured action path
- [x] Hot switching is forbidden and fallback creates a new attempt
- [x] Delivery receipts do not claim semantic outcome, work state, or proof

