### PR TITLE
feat(agent-session): own work console registry in core

### DIFF
--- a/docs/adr/ADR-0083-core-system-kfx-profile-kfx-capability-boundary.md
+++ b/docs/adr/ADR-0083-core-system-kfx-profile-kfx-capability-boundary.md
@@ -218,6 +218,22 @@ new semantics. Removal or redirection before a stable 4.0 contract requires a
 separate compatibility decision with fixture evidence; until then it is a
 CLI-only legacy edge over the same underlying stored facts.
 
+Stage 4 adds `kungfu.work-console-registry/v2` to the detached Core Agent
+Session worker. The worker owns generic WorkRef-to-primary-WorkConsole
+resolution, distinct SessionAttempt history, reviewed plan roots, metadata-only
+receipts, and fail-closed recovery. Its shared surface exposes the same
+`resolve-console`, `list`, `show`, `plan-start`, `start`, `attach`, `detach`,
+`status`, and `end` operations to GUI, CLI, and KFD-3. A worker restart retains
+history but marks an old Capsule attempt `unrecoverable`; it never claims that
+the provider process survived.
+
+Terminal KFX no longer declares or writes WorkConsole/SessionAttempt state. Its
+workspace layout retains stable `consoleId`/`attemptId` references beside pane
+and window presentation only. The old Config contract v1 remains a
+read/import-only compatibility shape whose `presentation` member is discarded;
+new authority is written only by the Core worker, so this migration does not
+create a second Console store or choose a different transport backend.
+
 ## Acceptance gates
 
 ### Contract gate

--- a/docs/adr/ADR-0083-core-system-kfx-profile-kfx-capability-boundary.md
+++ b/docs/adr/ADR-0083-core-system-kfx-profile-kfx-capability-boundary.md
@@ -4,7 +4,7 @@ doc_type: architecture-decision
 adr_id: ADR-0083
 decision_status: accepted
 implementation_status: partial
-implementation_commits: [c6266fe3ea37e096ced272c497b6e729218c7a3b, ef4421c8607860978f7d2b890ab68c149d97747a, bdf3800cb34182b59d3f341dee08056a5ebf6bd0, fb67a700c748e8c355bec7d15077d654a2a9c3ea, 4734113513cb7f1868e29b45f505f3b6fd33eee1, 36381447657fcda49b7b5c48eafd9703236adcb0]
+implementation_commits: [c6266fe3ea37e096ced272c497b6e729218c7a3b, ef4421c8607860978f7d2b890ab68c149d97747a, bdf3800cb34182b59d3f341dee08056a5ebf6bd0, fb67a700c748e8c355bec7d15077d654a2a9c3ea, 4734113513cb7f1868e29b45f505f3b6fd33eee1, 36381447657fcda49b7b5c48eafd9703236adcb0, 183ee3f1346918eef1631c6410a6b42dc366e93e]
 review_state: self-reviewed
 sensitivity: public
 sources: [local-files, user-consensus]

--- a/extensions/terminal/src/view/index.tsx
+++ b/extensions/terminal/src/view/index.tsx
@@ -62,12 +62,8 @@ import {
 } from './pane-layout';
 import {
   type PersistedWindow,
-  type WorkConsoleRegistry,
   type WorkspaceLayout,
-  emptyConsoleRegistry,
-  loadConsoleRegistry,
   loadWorkspaceLayout,
-  saveConsoleRegistry,
   saveWorkspaceLayout,
 } from './persistence';
 
@@ -1284,12 +1280,6 @@ function SessionWorkspace({
   );
   const [catalogBusy, setCatalogBusy] = React.useState(true);
   const [catalogError, setCatalogError] = React.useState('');
-  const [consoleRegistry, setConsoleRegistry] =
-    React.useState<WorkConsoleRegistry>(() =>
-      domain
-        ? loadConsoleRegistry(domain, workspaceId)
-        : emptyConsoleRegistry(workspaceId),
-    );
   // The per-session OS window set (ADR-0016 stage 2). Seeded from the persisted
   // layout, then driven by the main process, which owns the real windows and
   // pushes a snapshot on every open/close/move; we mirror it back into the
@@ -1440,35 +1430,7 @@ function SessionWorkspace({
       }
       if (!cancelled) {
         if (restored.length > 0) setPanes(restored);
-        if (restored.length > 0) {
-          const preferredConsoleId = consoleRegistry.presentation.tabs[0];
-          setActiveRunId(
-            restored.find((pane) => pane.consoleId === preferredConsoleId)
-              ?.runId ?? restored[0].runId,
-          );
-        }
-        const restoredIds = new Set(restored.map((pane) => pane.runId));
-        setConsoleRegistry((current) => ({
-          ...current,
-          consoles: current.consoles.map((workConsole) => ({
-            ...workConsole,
-            attempts: workConsole.attempts.map((attempt) =>
-              restoredIds.has(attempt.runId)
-                ? { ...attempt, status: 'running' as const }
-                : attempt.status === 'running'
-                  ? {
-                      ...attempt,
-                      status:
-                        workConsole.backend === 'direct'
-                          ? ('unrecoverable' as const)
-                          : ('orphaned' as const),
-                      endedAt: Date.now(),
-                    }
-                  : attempt,
-            ),
-            updatedAt: Date.now(),
-          })),
-        }));
+        if (restored.length > 0) setActiveRunId(restored[0].runId);
         // Restore only windows whose session actually came back; a window for a
         // gone session cannot show anything, so it is dropped. The main process
         // clamps each saved rectangle onto a present display (F7).
@@ -1527,43 +1489,6 @@ function SessionWorkspace({
     saveWorkspaceLayout(domain, layout);
   }, [panes, domain, windowRecords]);
 
-  React.useEffect(() => {
-    if (!domain || !hydrated.current) return;
-    const consoleIds = panes
-      .map((pane) => pane.consoleId)
-      .filter((value): value is string => Boolean(value));
-    const visibleConsoleIds = visiblePanes
-      .map((pane) => pane.consoleId)
-      .filter((value): value is string => Boolean(value));
-    saveConsoleRegistry(domain, {
-      ...consoleRegistry,
-      workspaceId,
-      presentation: {
-        tabs: consoleIds,
-        splits: visibleConsoleIds,
-        drawer:
-          consoleRegistry.consoles.find(
-            (candidate) =>
-              candidate.bindingKind === 'workspace-assistant' &&
-              consoleIds.includes(candidate.consoleId),
-          )?.consoleId ?? null,
-        windows: windowRecords
-          .map(
-            (record) =>
-              panes.find((pane) => pane.runId === record.runId)?.consoleId,
-          )
-          .filter((value): value is string => Boolean(value)),
-      },
-    });
-  }, [
-    consoleRegistry,
-    domain,
-    panes,
-    visiblePanes,
-    windowRecords,
-    workspaceId,
-  ]);
-
   const refresh = React.useCallback(async () => {
     try {
       // discover reconciles the known session map (marks truly-gone sessions
@@ -1617,9 +1542,19 @@ function SessionWorkspace({
       const runId = mintRunId();
       const attemptId = `attempt:${runId}`;
       const workRef = await workRefFromShell(shell);
-      const consoleId = workRef
+      const fallbackConsoleId = workRef
         ? `work:${workRef.profileId}:${workRef.entityType}:${workRef.entityId}`
         : `assistant:${workspaceId}`;
+      const binding = workRef
+        ? { kind: 'work' as const, workRef }
+        : { kind: 'workspace-assistant' as const, workRef: null };
+      const resolution = caps.agentSession
+        ? await invokeAgentSession(caps, {
+            operation: 'resolve-console',
+            input: { workspaceId, binding },
+          })
+        : null;
+      const consoleId = String(resolution?.workConsoleId ?? fallbackConsoleId);
       const envelope = await buildAgentConsoleEnvelope({
         workspaceId,
         consoleId,
@@ -1690,9 +1625,9 @@ function SessionWorkspace({
             argv: args,
             cwd,
             env: capsuleEnv,
-            binding: workRef
-              ? { kind: 'work', workRef }
-              : { kind: 'workspace-assistant', workRef: null },
+            workspaceId,
+            runtimeProfileId: profile.id,
+            binding,
           },
         });
         const effectiveAttemptId = String(plan.sessionAttemptId);
@@ -1750,41 +1685,6 @@ function SessionWorkspace({
           },
         ]);
         setActiveRunId(effectiveAttemptId);
-        const now = Date.now();
-        setConsoleRegistry((current) => {
-          const previous = current.consoles.find(
-            (candidate) => candidate.consoleId === consoleId,
-          );
-          return {
-            ...current,
-            consoles: [
-              ...current.consoles.filter(
-                (candidate) => candidate.consoleId !== consoleId,
-              ),
-              {
-                consoleId,
-                bindingKind: workRef
-                  ? ('work' as const)
-                  : ('workspace-assistant' as const),
-                workRef,
-                runtimeProfileId:
-                  previous?.runtimeProfileId ?? effectiveProfileId,
-                backend: 'capsule' as const,
-                attempts: [
-                  ...(previous?.attempts ?? []),
-                  {
-                    attemptId: effectiveAttemptId,
-                    runId: effectiveAttemptId,
-                    status: 'running' as const,
-                    startedAt,
-                  },
-                ],
-                createdAt: previous?.createdAt ?? now,
-                updatedAt: now,
-              },
-            ],
-          };
-        });
         void refresh();
         return;
       }
@@ -1844,71 +1744,8 @@ function SessionWorkspace({
         },
       ]);
       setActiveRunId(session.runId);
-      const now = Date.now();
-      setConsoleRegistry((current) => {
-        const previous = current.consoles.find(
-          (candidate) => candidate.consoleId === consoleId,
-        );
-        const next = {
-          consoleId,
-          bindingKind: workRef
-            ? ('work' as const)
-            : ('workspace-assistant' as const),
-          workRef,
-          runtimeProfileId: profile.id,
-          backend: durable ? ('tmux' as const) : ('direct' as const),
-          attempts: [
-            ...(previous?.attempts ?? []),
-            {
-              attemptId,
-              runId: session.runId,
-              status: 'running' as const,
-              startedAt: session.startedAt,
-            },
-          ],
-          createdAt: previous?.createdAt ?? now,
-          updatedAt: now,
-        };
-        return {
-          ...current,
-          consoles: [
-            ...current.consoles.filter(
-              (candidate) => candidate.consoleId !== consoleId,
-            ),
-            next,
-          ],
-        };
-      });
     },
     [caps, refresh, shell, workspaceId],
-  );
-
-  const markAttempt = React.useCallback(
-    (runId: string, status: 'running' | 'detached' | 'exited' | 'orphaned') => {
-      setConsoleRegistry((current) => ({
-        ...current,
-        consoles: current.consoles.map((workConsole) => ({
-          ...workConsole,
-          attempts: workConsole.attempts.map((attempt) =>
-            attempt.runId === runId
-              ? {
-                  ...attempt,
-                  status,
-                  ...(status === 'exited' || status === 'orphaned'
-                    ? { endedAt: Date.now() }
-                    : {}),
-                }
-              : attempt,
-          ),
-          updatedAt: workConsole.attempts.some(
-            (attempt) => attempt.runId === runId,
-          )
-            ? Date.now()
-            : workConsole.updatedAt,
-        })),
-      }));
-    },
-    [],
   );
 
   const detachPane = React.useCallback(
@@ -1924,7 +1761,6 @@ function SessionWorkspace({
           attachmentId: pane.attachmentId,
         })
           .then(() => {
-            markAttempt(pane.runId, 'detached');
             setPanes((prev) => prev.filter((p) => p.key !== pane.key));
             void refresh();
           })
@@ -1936,11 +1772,10 @@ function SessionWorkspace({
       } catch {
         // a non-durable or already-ended session has nothing to detach
       }
-      markAttempt(pane.runId, 'detached');
       setPanes((prev) => prev.filter((p) => p.key !== pane.key));
       void refresh();
     },
-    [caps, markAttempt, refresh],
+    [caps, refresh],
   );
 
   const killPane = React.useCallback(
@@ -1972,7 +1807,6 @@ function SessionWorkspace({
             }),
           )
           .then(() => {
-            markAttempt(pane.runId, 'exited');
             setPanes((prev) => prev.filter((p) => p.key !== pane.key));
             void refresh();
           })
@@ -1984,11 +1818,10 @@ function SessionWorkspace({
       } catch {
         // best-effort
       }
-      markAttempt(pane.runId, 'exited');
       setPanes((prev) => prev.filter((p) => p.key !== pane.key));
       void refresh();
     },
-    [caps, markAttempt, refresh],
+    [caps, refresh],
   );
 
   const attachCapsule = React.useCallback(
@@ -2035,40 +1868,6 @@ function SessionWorkspace({
             ],
       );
       setActiveRunId(session.sessionAttemptId);
-      setConsoleRegistry((current) => {
-        const previous = current.consoles.find(
-          (candidate) => candidate.consoleId === session.workConsoleId,
-        );
-        return {
-          ...current,
-          consoles: [
-            ...current.consoles.filter(
-              (candidate) => candidate.consoleId !== session.workConsoleId,
-            ),
-            {
-              consoleId: session.workConsoleId,
-              bindingKind: session.binding?.kind ?? 'workspace-assistant',
-              workRef: session.binding?.workRef ?? null,
-              runtimeProfileId:
-                previous?.runtimeProfileId ?? `agent-session:${provider}`,
-              backend: 'capsule',
-              attempts: [
-                ...(previous?.attempts ?? []).filter(
-                  (attempt) => attempt.attemptId !== session.sessionAttemptId,
-                ),
-                {
-                  attemptId: session.sessionAttemptId,
-                  runId: session.sessionAttemptId,
-                  status: 'running',
-                  startedAt: now,
-                },
-              ],
-              createdAt: previous?.createdAt ?? now,
-              updatedAt: now,
-            },
-          ],
-        };
-      });
     },
     [caps, workspaceId],
   );
@@ -2077,13 +1876,6 @@ function SessionWorkspace({
     async (s: TerminalSession) => {
       try {
         const session = await resolve(caps.terminal.reattach(s.runId));
-        markAttempt(s.runId, 'running');
-        const workConsole = consoleRegistry.consoles.find((candidate) =>
-          candidate.attempts.some((attempt) => attempt.runId === s.runId),
-        );
-        const attempt = workConsole?.attempts.find(
-          (candidate) => candidate.runId === s.runId,
-        );
         setPanes((prev) =>
           prev.some((p) => p.runId === session.runId)
             ? prev
@@ -2100,9 +1892,6 @@ function SessionWorkspace({
                   command: session.command,
                   args: session.args,
                   cwd: session.cwd,
-                  consoleId: workConsole?.consoleId,
-                  attemptId: attempt?.attemptId,
-                  runtimeProfileId: workConsole?.runtimeProfileId,
                 },
               ],
         );
@@ -2111,7 +1900,7 @@ function SessionWorkspace({
       }
       void refresh();
     },
-    [caps.terminal, consoleRegistry.consoles, markAttempt, refresh],
+    [caps.terminal, refresh],
   );
 
   const dismiss = React.useCallback(
@@ -2121,14 +1910,9 @@ function SessionWorkspace({
       } catch {
         // best-effort
       }
-      markAttempt(s.runId, s.status === 'orphaned' ? 'orphaned' : 'exited');
       void refresh();
     },
-    [caps.terminal, markAttempt, refresh],
-  );
-  const handlePaneExit = React.useCallback(
-    (pane: Pane) => markAttempt(pane.runId, 'exited'),
-    [markAttempt],
+    [caps.terminal, refresh],
   );
 
   return (
@@ -2270,7 +2054,6 @@ function SessionWorkspace({
                 pane={pane}
                 onDetach={detachPane}
                 onKill={killPane}
-                onExit={handlePaneExit}
               />
             ) : (
               <SessionPane
@@ -2279,7 +2062,6 @@ function SessionWorkspace({
                 pane={pane}
                 onDetach={detachPane}
                 onKill={killPane}
-                onExit={handlePaneExit}
                 onPopOut={
                   shell.popOutSession
                     ? () => {

--- a/extensions/terminal/src/view/persistence.ts
+++ b/extensions/terminal/src/view/persistence.ts
@@ -1,19 +1,16 @@
 // Workspace layout persistence for the managed session workspace (W4).
 //
-// The set of open sessions and their arrangement is a journal-backed config
-// fact, not a private GUI file: it lives in the runtime home's ConfigStore at a
-// stable location, so the CLI and agents read and write the same record the GUI
-// shows (the same shape shell-state.ts uses for shell state). This is the F4
-// boundary — session lifecycle identity is a config fact the workspace owns —
-// and the F5 contract — a stable, tolerant JSON read that other surfaces can
-// depend on.
+// This file owns presentation persistence only. WorkConsole, SessionAttempt,
+// binding, lifecycle and receipts belong to the Core Agent Session registry;
+// panes/windows merely retain stable identity references used to reconstruct a
+// view after reload.
 //
 // Only the durable (tmux-backed) identity is restorable across an app restart:
 // on relaunch the in-memory session map is empty, so the workspace re-adopts
 // each persisted tmux session by runId. Direct (non-durable) sessions are
 // recorded for completeness but cannot be brought back — their process died
 // with the previous renderer.
-import type { DomainState, KfLocation, WorkRef } from '@kungfu-tech/kfx';
+import type { DomainState, KfLocation } from '@kungfu-tech/kfx';
 
 // One JSON blob, addressed like shell state (system/shell/…/live).
 export const WORKSPACE_LOCATION: KfLocation = {
@@ -21,50 +18,6 @@ export const WORKSPACE_LOCATION: KfLocation = {
   namespace: 'shell',
   name: 'terminal-workspace',
   mode: 'live',
-};
-
-export const CONSOLE_REGISTRY_LOCATION: KfLocation = {
-  role: 'system',
-  namespace: 'shell',
-  name: 'agent-console-registry',
-  mode: 'live',
-};
-
-export type SessionAttempt = {
-  attemptId: string;
-  runId: string;
-  status:
-    | 'planned'
-    | 'running'
-    | 'detached'
-    | 'exited'
-    | 'orphaned'
-    | 'unrecoverable';
-  startedAt: number;
-  endedAt?: number;
-};
-
-export type WorkConsole = {
-  consoleId: string;
-  bindingKind: 'work' | 'workspace-assistant';
-  workRef: WorkRef | null;
-  runtimeProfileId: string;
-  backend: 'capsule' | 'tmux' | 'direct';
-  attempts: SessionAttempt[];
-  createdAt: number;
-  updatedAt: number;
-};
-
-export type WorkConsoleRegistry = {
-  schema: 'kungfu.work-console-registry/v1';
-  workspaceId: string;
-  consoles: WorkConsole[];
-  presentation: {
-    tabs: string[];
-    splits: string[];
-    drawer: string | null;
-    windows: string[];
-  };
 };
 
 export type PersistedPane = {
@@ -224,136 +177,5 @@ export function saveWorkspaceLayout(
     domain.setConfig(WORKSPACE_LOCATION, JSON.stringify(layout));
   } catch {
     // persistence is best-effort; a failed write never breaks the workspace
-  }
-}
-
-export function emptyConsoleRegistry(
-  workspaceId = 'home',
-): WorkConsoleRegistry {
-  return {
-    schema: 'kungfu.work-console-registry/v1',
-    workspaceId,
-    consoles: [],
-    presentation: { tabs: [], splits: [], drawer: null, windows: [] },
-  };
-}
-
-function parseAttempt(value: unknown): SessionAttempt | null {
-  if (typeof value !== 'object' || value === null) return null;
-  const row = value as Record<string, unknown>;
-  if (typeof row.attemptId !== 'string' || typeof row.runId !== 'string')
-    return null;
-  const allowed = new Set([
-    'planned',
-    'running',
-    'detached',
-    'exited',
-    'orphaned',
-    'unrecoverable',
-  ]);
-  const status = allowed.has(String(row.status))
-    ? (String(row.status) as SessionAttempt['status'])
-    : 'orphaned';
-  return {
-    attemptId: row.attemptId,
-    runId: row.runId,
-    status,
-    startedAt: typeof row.startedAt === 'number' ? row.startedAt : 0,
-    endedAt: typeof row.endedAt === 'number' ? row.endedAt : undefined,
-  };
-}
-
-function parseConsole(value: unknown): WorkConsole | null {
-  if (typeof value !== 'object' || value === null) return null;
-  const row = value as Record<string, unknown>;
-  if (
-    typeof row.consoleId !== 'string' ||
-    typeof row.runtimeProfileId !== 'string'
-  )
-    return null;
-  const bindingKind =
-    row.bindingKind === 'work' ? 'work' : 'workspace-assistant';
-  const workRef =
-    bindingKind === 'work' && row.workRef && typeof row.workRef === 'object'
-      ? (row.workRef as WorkRef)
-      : null;
-  if (bindingKind === 'work' && !workRef) return null;
-  return {
-    consoleId: row.consoleId,
-    bindingKind,
-    workRef,
-    runtimeProfileId: row.runtimeProfileId,
-    backend:
-      row.backend === 'capsule'
-        ? 'capsule'
-        : row.backend === 'direct'
-          ? 'direct'
-          : 'tmux',
-    attempts: (Array.isArray(row.attempts) ? row.attempts : [])
-      .map(parseAttempt)
-      .filter((attempt): attempt is SessionAttempt => attempt !== null),
-    createdAt: typeof row.createdAt === 'number' ? row.createdAt : 0,
-    updatedAt: typeof row.updatedAt === 'number' ? row.updatedAt : 0,
-  };
-}
-
-export function parseConsoleRegistry(raw: string): WorkConsoleRegistry {
-  try {
-    const value = JSON.parse(raw) as Record<string, unknown>;
-    const fallback = emptyConsoleRegistry(
-      typeof value.workspaceId === 'string' ? value.workspaceId : 'home',
-    );
-    if (value.schema !== fallback.schema) return fallback;
-    const presentation =
-      value.presentation && typeof value.presentation === 'object'
-        ? (value.presentation as Record<string, unknown>)
-        : {};
-    return {
-      ...fallback,
-      consoles: (Array.isArray(value.consoles) ? value.consoles : [])
-        .map(parseConsole)
-        .filter((console): console is WorkConsole => console !== null),
-      presentation: {
-        tabs: asStringArray(presentation.tabs) ?? [],
-        splits: (asStringArray(presentation.splits) ?? []).slice(0, 3),
-        drawer:
-          typeof presentation.drawer === 'string' ? presentation.drawer : null,
-        windows: asStringArray(presentation.windows) ?? [],
-      },
-    };
-  } catch {
-    return emptyConsoleRegistry();
-  }
-}
-
-export function loadConsoleRegistry(
-  domain: DomainState,
-  workspaceId: string,
-): WorkConsoleRegistry {
-  try {
-    const entry = domain
-      .configs()
-      .find(
-        (row) =>
-          row.location.role === CONSOLE_REGISTRY_LOCATION.role &&
-          row.location.namespace === CONSOLE_REGISTRY_LOCATION.namespace &&
-          row.location.name === CONSOLE_REGISTRY_LOCATION.name,
-      );
-    return entry
-      ? parseConsoleRegistry(entry.value)
-      : emptyConsoleRegistry(workspaceId);
-  } catch {
-    return emptyConsoleRegistry(workspaceId);
-  }
-}
-
-export function saveConsoleRegistry(
-  domain: DomainState,
-  registry: WorkConsoleRegistry,
-): void {
-  try {
-    domain.setConfig(CONSOLE_REGISTRY_LOCATION, JSON.stringify(registry));
-  } catch {
-    // Same best-effort journal boundary as the presentation layout.
   }
 }

--- a/framework/agent-session/README.md
+++ b/framework/agent-session/README.md
@@ -75,6 +75,15 @@ stable local endpoint; a worker loss starts an empty runtime and never presents
 an old `SessionAttempt` as continuous. POSIX sockets use a short, per-UID 0700
 directory so long macOS runtime paths cannot exceed the Unix socket limit.
 
+The Stage 7 WorkConsole registry moves identity and lifecycle authority out of
+the Terminal KFX and into that detached Core worker. `resolve-console`, `list`,
+`show`, plans and metadata-only receipts now share one durable registry across
+GUI, CLI and KFD-3. A generic WorkRef has one primary WorkConsole and each
+provider restart/resume has a distinct SessionAttempt. Worker loss preserves
+the record but marks the old Capsule attempt `unrecoverable`; it never invents
+process continuity. Terminal panes, splits, drawers and windows retain only
+stable identity references and are not part of the portable registry.
+
 The retained Mac source qualification proves main-process reconnect, provider
 exit fencing, worker-loss fail-closed behavior, bounded overflow gaps, receipt
 privacy, and sub-millisecond local RPC p95. Authenticated Codex 0.144.3 passes

--- a/framework/agent-session/kungfu-agent-session.contract.json
+++ b/framework/agent-session/kungfu-agent-session.contract.json
@@ -49,6 +49,29 @@
       "owner": "runtime-controller-lease",
       "rule": "Only the current controller lease may admit input; observers are read-only."
     },
+    "workConsoleRegistry": {
+      "owner": "agent-session-product-worker",
+      "schema": "kungfu.work-console-registry/v2",
+      "schemaSource": "framework/agent-session/schemas/work-console-registry.schema.json",
+      "contains": [
+        "generic-workref-binding",
+        "workconsole-identity",
+        "sessionattempt-lifecycle",
+        "reviewed-plan-roots",
+        "metadata-only-receipts"
+      ],
+      "forbids": [
+        "tabs",
+        "splits",
+        "drawer",
+        "windows",
+        "terminal-transcript",
+        "semantic-work-outcome",
+        "proof"
+      ],
+      "presentationRole": "stable-identity-reference-only",
+      "guiOnlyWrite": false
+    },
     "workFacts": {
       "owner": "profile-kfd-action-episode",
       "terminalTransportRole": "observation-input-only",
@@ -138,6 +161,9 @@
     "writePath": "journal-input-frame-plus-notice",
     "publicOperations": [
       "plan-start",
+      "resolve-console",
+      "list",
+      "show",
       "start",
       "attach",
       "detach",
@@ -195,7 +221,7 @@
     "coordinatorRestart": "reregister-same-stream-epoch",
     "supervisorRestart": "adopt-only-with-proven-runtime-identity-generation-and-pid-start-identity",
     "capsuleCrash": "end-old-attempt-as-lost-control-and-use-provider-supported-resume-in-new-attempt",
-    "machineReboot": "new-attempt-and-provider-supported-resume-only",
+    "machineReboot": "persist-registry-and-mark-old-capsule-attempt-unrecoverable-before-new-attempt-or-provider-supported-resume",
     "fakePtyRecovery": false
   },
   "capabilityDiscovery": {

--- a/framework/agent-session/package.json
+++ b/framework/agent-session/package.json
@@ -25,6 +25,7 @@
     "./product-client": "./src/product-client.mjs",
     "./product-rpc": "./src/product-rpc.mjs",
     "./product-worker": "./src/product-worker.mjs",
+    "./work-console-registry": "./src/work-console-registry.mjs",
     "./provider-adapters": "./src/provider-adapters.mjs",
     "./runtime-port": "./src/runtime-port.mjs",
     "./worker": "./src/capsule-worker.mjs",

--- a/framework/agent-session/schemas/work-console-registry.schema.json
+++ b/framework/agent-session/schemas/work-console-registry.schema.json
@@ -1,0 +1,171 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "kungfu.work-console-registry/v2",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "consoles"],
+  "properties": {
+    "schema": { "const": "kungfu.work-console-registry/v2" },
+    "consoles": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/workConsole" }
+    }
+  },
+  "$defs": {
+    "workRef": {
+      "type": "object",
+      "required": [
+        "workspaceId",
+        "profileId",
+        "entityType",
+        "entityId"
+      ],
+      "properties": {
+        "workspaceId": { "type": "string", "minLength": 1 },
+        "profileId": { "type": "string", "minLength": 1 },
+        "entityType": { "type": "string", "minLength": 1 },
+        "entityId": { "type": "string", "minLength": 1 }
+      }
+    },
+    "binding": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "workRef"],
+          "properties": {
+            "kind": { "const": "work" },
+            "workRef": { "$ref": "#/$defs/workRef" }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "workRef"],
+          "properties": {
+            "kind": { "const": "workspace-assistant" },
+            "workRef": { "type": "null" }
+          }
+        }
+      ]
+    },
+    "plan": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "operation",
+        "planRoot",
+        "recordedAt",
+        "effects",
+        "workEffects",
+        "rollback"
+      ],
+      "properties": {
+        "operation": { "type": "string", "minLength": 1 },
+        "planRoot": { "type": "string", "pattern": "^sha256:[a-f0-9]{64}$" },
+        "recordedAt": { "type": "number" },
+        "effects": { "type": "array", "items": { "type": "string" } },
+        "workEffects": {
+          "type": "array",
+          "maxItems": 0
+        },
+        "rollback": { "type": "string", "minLength": 1 }
+      }
+    },
+    "receipt": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "operation",
+        "status",
+        "recordedAt",
+        "receiptRoot",
+        "semanticOutcome",
+        "workState",
+        "proof"
+      ],
+      "properties": {
+        "operation": { "type": "string", "minLength": 1 },
+        "status": { "type": "string", "minLength": 1 },
+        "reason": { "type": "string", "minLength": 1 },
+        "recordedAt": { "type": "number" },
+        "receiptRoot": {
+          "anyOf": [
+            { "type": "string", "pattern": "^sha256:[a-f0-9]{64}$" },
+            { "type": "null" }
+          ]
+        },
+        "semanticOutcome": { "type": "null" },
+        "workState": { "type": "null" },
+        "proof": { "type": "null" }
+      }
+    },
+    "sessionAttempt": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "sessionAttemptId",
+        "runId",
+        "provider",
+        "providerVersion",
+        "status",
+        "startedAt",
+        "plans",
+        "receipts"
+      ],
+      "properties": {
+        "sessionAttemptId": { "type": "string", "minLength": 1 },
+        "runId": { "type": "string", "minLength": 1 },
+        "provider": { "type": "string", "minLength": 1 },
+        "providerVersion": { "type": "string", "minLength": 1 },
+        "status": {
+          "enum": [
+            "planned",
+            "running",
+            "detached",
+            "exited",
+            "orphaned",
+            "unrecoverable"
+          ]
+        },
+        "startedAt": { "type": "number" },
+        "endedAt": { "type": "number" },
+        "plans": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/plan" }
+        },
+        "receipts": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/receipt" }
+        }
+      }
+    },
+    "workConsole": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "consoleId",
+        "workspaceId",
+        "binding",
+        "runtimeProfileId",
+        "backend",
+        "attempts",
+        "createdAt",
+        "updatedAt"
+      ],
+      "properties": {
+        "consoleId": { "type": "string", "minLength": 1 },
+        "workspaceId": { "type": "string", "minLength": 1 },
+        "binding": { "$ref": "#/$defs/binding" },
+        "runtimeProfileId": { "type": "string", "minLength": 1 },
+        "backend": { "enum": ["capsule", "structured", "tmux", "direct"] },
+        "attempts": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/sessionAttempt" }
+        },
+        "createdAt": { "type": "number" },
+        "updatedAt": { "type": "number" }
+      }
+    }
+  }
+}

--- a/framework/agent-session/src/product-client.mjs
+++ b/framework/agent-session/src/product-client.mjs
@@ -42,6 +42,7 @@ export function detachedAgentSessionPaths(runtimeDir) {
         ? `\\\\.\\pipe\\kungfu-agent-session-${scope}`
         : path.join(socketDirectory, `${scope}.sock`),
     metadata: path.join(directory, 'worker.json'),
+    registry: path.join(directory, 'work-console-registry.json'),
     startupLock: path.join(directory, 'worker-start.lock'),
   };
 }
@@ -180,6 +181,7 @@ export function createDetachedAgentSessionHost({
               ELECTRON_RUN_AS_NODE: '1',
               KUNGFU_AGENT_SESSION_ENDPOINT: paths.endpoint,
               KUNGFU_AGENT_SESSION_METADATA: paths.metadata,
+              KUNGFU_AGENT_SESSION_REGISTRY: paths.registry,
               KUNGFU_AGENT_SESSION_STARTED_AT: String(now()),
             },
           });

--- a/framework/agent-session/src/product-surface.mjs
+++ b/framework/agent-session/src/product-surface.mjs
@@ -1,4 +1,8 @@
 import { createHash, randomUUID } from 'node:crypto';
+import {
+  WORK_CONSOLE_REGISTRY_SCHEMA,
+  WorkConsoleRegistry,
+} from './work-console-registry.mjs';
 
 const CONTROL_OPERATIONS = new Set([
   'acquire-control',
@@ -63,6 +67,7 @@ function publicStatus(session) {
   const controller = status.controllerLease;
   return {
     schema: 'kungfu.agent-session.surface-status/v1',
+    live: true,
     workConsoleId: status.workConsoleId,
     sessionAttemptId: status.sessionAttemptId,
     capsuleId: status.capsuleId,
@@ -135,6 +140,7 @@ export class AgentSessionSurfaceError extends Error {
 export class AgentSessionProductSurface {
   constructor({
     runtime,
+    registry = new WorkConsoleRegistry(),
     now = () => Date.now(),
     makeId = () => randomUUID(),
   }) {
@@ -150,6 +156,7 @@ export class AgentSessionProductSurface {
       );
     }
     this.runtime = runtime;
+    this.registry = registry;
     this.now = now;
     this.makeId = makeId;
   }
@@ -160,6 +167,7 @@ export class AgentSessionProductSurface {
       schema: 'kungfu.agent-session.surface-capabilities/v1',
       actions: [
         'capabilities',
+        'resolve-console',
         'list',
         'show',
         'plan-start',
@@ -185,6 +193,7 @@ export class AgentSessionProductSurface {
         'presentation',
       ],
       authority: 'agent-session-capsule-interaction-port',
+      registryAuthority: WORK_CONSOLE_REGISTRY_SCHEMA,
       workMutationAuthority: 'profile-kfd3-actions-only',
       rawHumanFallback: 'current-controller-only',
       receipts: {
@@ -204,18 +213,68 @@ export class AgentSessionProductSurface {
   }
 
   list() {
+    this.registry.observe(this.runtime.list());
     const sessions = this.runtime
       .list()
       .map((session) => publicStatus(session));
+    const consoles = this.registry.snapshot().consoles;
     return {
       schema: 'kungfu.agent-session.surface-list/v1',
       sessions,
-      listRoot: agentSessionSurfaceRoot(sessions),
+      consoles,
+      listRoot: agentSessionSurfaceRoot({ sessions, consoles }),
     };
   }
 
   show(ref) {
-    return publicStatus(this.#session(ref));
+    const normalized = sessionRef(ref);
+    const session = this.runtime.get(normalized);
+    if (!session) {
+      const projection = this.registry.projection(normalized);
+      if (!projection) {
+        throw new AgentSessionSurfaceError(
+          'session_not_found',
+          `session '${normalized.sessionAttemptId}' is unavailable`,
+        );
+      }
+      return {
+        schema: 'kungfu.agent-session.surface-status/v1',
+        workConsoleId: normalized.workConsoleId,
+        sessionAttemptId: normalized.sessionAttemptId,
+        live: false,
+        lifecycleState: projection.attempt.status,
+        interactionState: 'unavailable',
+        inputAdmission: 'closed',
+        foreground: null,
+        output: null,
+        providerAdapter: {
+          provider: projection.attempt.provider,
+          providerVersion: projection.attempt.providerVersion,
+          compatible: false,
+          reason: 'worker-runtime-continuity-lost',
+        },
+        queuedInstructions: [],
+        binding: projection.console.binding,
+        attachments: [],
+        controller: null,
+        workOutcome: null,
+        proof: null,
+        console: projection.console,
+        attempt: projection.attempt,
+      };
+    }
+    this.registry.observe([session]);
+    const status = publicStatus(session);
+    const projection = this.registry.projection(ref);
+    return {
+      ...status,
+      console: projection?.console ?? null,
+      attempt: projection?.attempt ?? null,
+    };
+  }
+
+  resolveConsole(input) {
+    return this.registry.resolve(input);
   }
 
   planStart(input) {
@@ -238,7 +297,12 @@ export class AgentSessionProductSurface {
         'work binding requires a WorkRef',
       );
     }
-    const consoleId = required(input.workConsoleId, 'workConsoleId');
+    const resolution = this.registry.resolve({
+      workspaceId: input.workspaceId,
+      workConsoleId: input.workConsoleId,
+      binding,
+    });
+    const consoleId = resolution.workConsoleId;
     const existing = this.runtime
       .list()
       .find(
@@ -302,9 +366,11 @@ export class AgentSessionProductSurface {
           threadStartParams: input.structured?.threadStartParams ?? {},
         }
       : null;
+    const registeredConsole = this.registry.console(consoleId);
     const body = {
       schema: 'kungfu.agent-session.start-plan/v1',
       operation: existing ? 'attach-existing' : 'start',
+      workspaceId: resolution.workspaceId,
       workConsoleId: consoleId,
       sessionAttemptId: existing
         ? existing.sessionAttemptId
@@ -332,6 +398,12 @@ export class AgentSessionProductSurface {
       cwd: existing ? null : (input.cwd ?? null),
       environmentNames: existing ? [] : Object.keys(input.env ?? {}).sort(),
       binding: existing?.binding ?? fallbackSession?.binding ?? binding,
+      runtimeProfileId:
+        registeredConsole?.runtimeProfileId ??
+        input.runtimeProfileId ??
+        existingStatus?.providerAdapter.provider ??
+        'unknown',
+      backend: transportRoute?.kind === 'structured' ? 'structured' : 'capsule',
       effects: existing
         ? ['attach-presentation-to-existing-capsule']
         : transportRoute
@@ -357,7 +429,9 @@ export class AgentSessionProductSurface {
       ...(transportRoute ? { transportRoute, structured } : {}),
       ...(fallback ? { fallbackFrom: fallback } : {}),
     };
-    return { ...body, root: agentSessionSurfaceRoot(body) };
+    const plan = { ...body, root: agentSessionSurfaceRoot(body) };
+    this.registry.recordPlan(plan);
+    return plan;
   }
 
   start({ actorId, client, plan, expectedPlanRoot, attachment, execution }) {
@@ -441,7 +515,7 @@ export class AgentSessionProductSurface {
     }
     session.transport.detach({ attachmentId, actorId });
     session.attachments.delete(attachmentId);
-    return receipt(
+    const result = receipt(
       'detach',
       actorId,
       {
@@ -453,6 +527,8 @@ export class AgentSessionProductSurface {
       },
       this.now,
     );
+    this.registry.recordReceipt(ref, result);
+    return result;
   }
 
   planControl({ operation, session: ref, payload = {} }) {
@@ -571,8 +647,8 @@ export class AgentSessionProductSurface {
         result = session.port.respondControl(request);
       else result = session.end(request);
     }
-    const finish = (resolved) =>
-      receipt(
+    const finish = (resolved) => {
+      const receiptValue = receipt(
         plan.operation,
         actorId,
         {
@@ -589,12 +665,19 @@ export class AgentSessionProductSurface {
         },
         this.now,
       );
+      this.registry.recordReceipt(plan, receiptValue);
+      this.registry.observe([session]);
+      return receiptValue;
+    };
     if (result && typeof result.then === 'function') return result.then(finish);
     return finish(result);
   }
 
   invoke(request) {
     const operation = required(request.operation, 'operation');
+    if (operation === 'resolve-console') {
+      return this.resolveConsole(request.input ?? request);
+    }
     if (READ_OPERATIONS.has(operation)) {
       if (operation === 'capabilities') return this.capabilities();
       if (operation === 'list') return this.list();
@@ -650,7 +733,7 @@ export class AgentSessionProductSurface {
       presentation: attachment.presentation ?? 'headless',
       attachedAt: this.now(),
     });
-    return receipt(
+    const result = receipt(
       'attach',
       actorId,
       {
@@ -663,6 +746,8 @@ export class AgentSessionProductSurface {
       },
       this.now,
     );
+    this.registry.recordReceipt(session, result);
+    return result;
   }
 
   #finishStart({ actorId, client, plan, attachment, session, reused }) {
@@ -673,7 +758,7 @@ export class AgentSessionProductSurface {
       acquireControl: !session.controller,
     });
     const status = publicStatus(session);
-    return receipt(
+    const result = receipt(
       'start',
       actorId,
       {
@@ -690,6 +775,8 @@ export class AgentSessionProductSurface {
       },
       this.now,
     );
+    this.registry.recordStarted(plan, result);
+    return result;
   }
 
   #session(ref) {
@@ -729,6 +816,8 @@ export function createAgentSessionSurfaceClient({ invoke, client, actorId }) {
   required(actorId, 'actorId');
   return Object.freeze({
     capabilities: () => invoke({ operation: 'capabilities', client, actorId }),
+    resolveConsole: (input) =>
+      invoke({ operation: 'resolve-console', client, actorId, input }),
     list: () => invoke({ operation: 'list', client, actorId }),
     show: (session) => invoke({ operation: 'show', client, actorId, session }),
     planStart: (input) =>

--- a/framework/agent-session/src/product-worker.mjs
+++ b/framework/agent-session/src/product-worker.mjs
@@ -9,18 +9,25 @@ import {
 import { bindAgentSessionSurfaceRpc } from './product-rpc.mjs';
 import { InProcessAgentSessionProductRuntime } from './product-runtime.mjs';
 import { AgentSessionProductSurface } from './product-surface.mjs';
+import {
+  JsonFileWorkConsoleRegistryStore,
+  WorkConsoleRegistry,
+} from './work-console-registry.mjs';
 
 const require = createRequire(import.meta.url);
 
 export async function runAgentSessionProductWorker({
   endpoint = process.env.KUNGFU_AGENT_SESSION_ENDPOINT,
   metadata = process.env.KUNGFU_AGENT_SESSION_METADATA,
+  registryPath = process.env.KUNGFU_AGENT_SESSION_REGISTRY,
   pty = null,
   ptyModule = process.env.KUNGFU_AGENT_SESSION_NODE_PTY_MODULE,
   baseEnv = process.env,
 } = {}) {
-  if (!endpoint || !metadata) {
-    throw new Error('detached Agent Session worker requires endpoint metadata');
+  if (!endpoint || !metadata || !registryPath) {
+    throw new Error(
+      'detached Agent Session worker requires endpoint, metadata, and registry paths',
+    );
   }
   mkdirSync(path.dirname(metadata), { recursive: true, mode: 0o700 });
   const loadedPty =
@@ -33,7 +40,10 @@ export async function runAgentSessionProductWorker({
         ? new CodexAppServerProductRuntime({ baseEnv })
         : null,
   });
-  const surface = new AgentSessionProductSurface({ runtime });
+  const registry = new WorkConsoleRegistry({
+    store: new JsonFileWorkConsoleRegistryStore(registryPath),
+  });
+  const surface = new AgentSessionProductSurface({ runtime, registry });
   const server = bindAgentSessionSurfaceRpc({
     endpoint,
     invoke: (request) => surface.invoke(request),
@@ -69,7 +79,7 @@ export async function runAgentSessionProductWorker({
   };
   process.once('SIGTERM', () => void close().finally(() => process.exit(0)));
   process.once('SIGINT', () => void close().finally(() => process.exit(0)));
-  return { runtime, surface, server, record, close };
+  return { runtime, registry, surface, server, record, close };
 }
 
 if (

--- a/framework/agent-session/src/work-console-registry.mjs
+++ b/framework/agent-session/src/work-console-registry.mjs
@@ -1,0 +1,420 @@
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+} from 'node:fs';
+import path from 'node:path';
+
+export const WORK_CONSOLE_REGISTRY_SCHEMA = 'kungfu.work-console-registry/v2';
+
+const ATTEMPT_STATES = new Set([
+  'planned',
+  'running',
+  'detached',
+  'exited',
+  'orphaned',
+  'unrecoverable',
+]);
+
+function required(value, label) {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw Object.assign(new Error(`${label} is required`), {
+      code: 'invalid_argument',
+    });
+  }
+  return value;
+}
+
+function clone(value) {
+  return structuredClone(value);
+}
+
+function normalizeBinding(value) {
+  const binding = value ?? { kind: 'workspace-assistant', workRef: null };
+  if (!['work', 'workspace-assistant'].includes(binding.kind)) {
+    throw Object.assign(
+      new Error(`unsupported binding kind '${String(binding.kind)}'`),
+      { code: 'invalid_argument' },
+    );
+  }
+  if (binding.kind === 'work') {
+    if (!binding.workRef || typeof binding.workRef !== 'object') {
+      throw Object.assign(new Error('work binding requires a WorkRef'), {
+        code: 'invalid_argument',
+      });
+    }
+    for (const field of [
+      'workspaceId',
+      'profileId',
+      'entityType',
+      'entityId',
+    ]) {
+      required(binding.workRef[field], `workRef.${field}`);
+    }
+    return { kind: 'work', workRef: clone(binding.workRef) };
+  }
+  return { kind: 'workspace-assistant', workRef: null };
+}
+
+function canonical(value) {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(canonical).join(',')}]`;
+  return `{${Object.entries(value)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, child]) => `${JSON.stringify(key)}:${canonical(child)}`)
+    .join(',')}}`;
+}
+
+function bindingKey(binding) {
+  return canonical(binding);
+}
+
+export function primaryWorkConsoleId({ workspaceId, binding }) {
+  const normalized = normalizeBinding(binding);
+  if (normalized.kind === 'work') {
+    const { profileId, entityType, entityId } = normalized.workRef;
+    return `work:${profileId}:${entityType}:${entityId}`;
+  }
+  return `assistant:${required(workspaceId, 'workspaceId')}`;
+}
+
+function normalizeAttempt(value) {
+  if (!value || typeof value !== 'object') return null;
+  const sessionAttemptId =
+    typeof value.sessionAttemptId === 'string'
+      ? value.sessionAttemptId
+      : value.attemptId;
+  if (typeof sessionAttemptId !== 'string' || sessionAttemptId.length === 0)
+    return null;
+  return {
+    sessionAttemptId,
+    runId:
+      typeof value.runId === 'string' && value.runId.length > 0
+        ? value.runId
+        : sessionAttemptId,
+    provider: typeof value.provider === 'string' ? value.provider : 'unknown',
+    providerVersion:
+      typeof value.providerVersion === 'string'
+        ? value.providerVersion
+        : 'unknown',
+    status: ATTEMPT_STATES.has(value.status) ? value.status : 'orphaned',
+    startedAt: typeof value.startedAt === 'number' ? value.startedAt : 0,
+    ...(typeof value.endedAt === 'number' ? { endedAt: value.endedAt } : {}),
+    receipts: Array.isArray(value.receipts)
+      ? value.receipts.filter(
+          (receipt) => receipt && typeof receipt === 'object',
+        )
+      : [],
+    plans: Array.isArray(value.plans)
+      ? value.plans.filter((plan) => plan && typeof plan === 'object')
+      : [],
+  };
+}
+
+function normalizeConsole(value, fallbackWorkspaceId = 'home') {
+  if (!value || typeof value !== 'object') return null;
+  if (typeof value.consoleId !== 'string' || value.consoleId.length === 0)
+    return null;
+  const binding = normalizeBinding(
+    value.binding ?? {
+      kind: value.bindingKind === 'work' ? 'work' : 'workspace-assistant',
+      workRef: value.workRef ?? null,
+    },
+  );
+  const workspaceId =
+    typeof value.workspaceId === 'string'
+      ? value.workspaceId
+      : (binding.workRef?.workspaceId ?? fallbackWorkspaceId);
+  return {
+    consoleId: value.consoleId,
+    workspaceId,
+    binding,
+    runtimeProfileId:
+      typeof value.runtimeProfileId === 'string'
+        ? value.runtimeProfileId
+        : 'unknown',
+    backend: ['capsule', 'structured', 'tmux', 'direct'].includes(value.backend)
+      ? value.backend
+      : 'capsule',
+    attempts: (Array.isArray(value.attempts) ? value.attempts : [])
+      .map(normalizeAttempt)
+      .filter(Boolean),
+    createdAt: typeof value.createdAt === 'number' ? value.createdAt : 0,
+    updatedAt: typeof value.updatedAt === 'number' ? value.updatedAt : 0,
+  };
+}
+
+export function normalizeWorkConsoleRegistry(value) {
+  const fallbackWorkspaceId =
+    value && typeof value.workspaceId === 'string' ? value.workspaceId : 'home';
+  return {
+    schema: WORK_CONSOLE_REGISTRY_SCHEMA,
+    consoles: (Array.isArray(value?.consoles) ? value.consoles : [])
+      .map((entry) => {
+        try {
+          return normalizeConsole(entry, fallbackWorkspaceId);
+        } catch {
+          return null;
+        }
+      })
+      .filter(Boolean),
+  };
+}
+
+export class JsonFileWorkConsoleRegistryStore {
+  constructor(filePath) {
+    this.filePath = path.resolve(required(filePath, 'registry file path'));
+  }
+
+  load() {
+    if (!existsSync(this.filePath)) return null;
+    const stat = lstatSync(this.filePath);
+    if (!stat.isFile() || stat.isSymbolicLink()) {
+      throw new Error(
+        `WorkConsole registry '${this.filePath}' is not a regular file`,
+      );
+    }
+    return JSON.parse(readFileSync(this.filePath, 'utf8'));
+  }
+
+  save(value) {
+    mkdirSync(path.dirname(this.filePath), { recursive: true, mode: 0o700 });
+    const temporary = `${this.filePath}.${process.pid}.tmp`;
+    writeFileSync(temporary, `${JSON.stringify(value, null, 2)}\n`, {
+      mode: 0o600,
+    });
+    renameSync(temporary, this.filePath);
+  }
+}
+
+export class WorkConsoleRegistry {
+  constructor({ store = null, snapshot = null, now = () => Date.now() } = {}) {
+    this.store = store;
+    this.now = now;
+    this.value = normalizeWorkConsoleRegistry(snapshot ?? store?.load());
+    this.#recoverInterruptedAttempts();
+  }
+
+  snapshot() {
+    return clone(this.value);
+  }
+
+  resolve(input = {}) {
+    const binding = normalizeBinding(input.binding);
+    const inferredWorkspaceId =
+      typeof input.workConsoleId === 'string'
+        ? input.workConsoleId.startsWith('assistant:')
+          ? input.workConsoleId.slice('assistant:'.length)
+          : `legacy:${input.workConsoleId}`
+        : null;
+    const workspaceId =
+      binding.workRef?.workspaceId ??
+      input.workspaceId ??
+      required(inferredWorkspaceId, 'workspaceId');
+    const canonicalId = primaryWorkConsoleId({ workspaceId, binding });
+    const workConsoleId = input.workConsoleId ?? canonicalId;
+    const existing = this.value.consoles.find(
+      (entry) => entry.consoleId === workConsoleId,
+    );
+    if (existing && bindingKey(existing.binding) !== bindingKey(binding)) {
+      throw Object.assign(
+        new Error(
+          `WorkConsole '${workConsoleId}' is already bound to another work identity`,
+        ),
+        { code: 'console_binding_mismatch' },
+      );
+    }
+    const primary = this.value.consoles.find(
+      (entry) =>
+        entry.workspaceId === workspaceId &&
+        bindingKey(entry.binding) === bindingKey(binding),
+    );
+    return {
+      schema: 'kungfu.work-console-resolution/v1',
+      workspaceId,
+      workConsoleId: primary?.consoleId ?? workConsoleId,
+      canonicalWorkConsoleId: canonicalId,
+      existing: Boolean(primary ?? existing),
+      binding,
+    };
+  }
+
+  recordPlan(plan) {
+    const resolved = this.resolve({
+      workspaceId: plan.workspaceId,
+      workConsoleId: plan.workConsoleId,
+      binding: plan.binding,
+    });
+    const now = this.now();
+    let console = this.value.consoles.find(
+      (entry) => entry.consoleId === resolved.workConsoleId,
+    );
+    if (!console) {
+      console = {
+        consoleId: resolved.workConsoleId,
+        workspaceId: resolved.workspaceId,
+        binding: resolved.binding,
+        runtimeProfileId: plan.runtimeProfileId ?? 'unknown',
+        backend: plan.backend ?? 'capsule',
+        attempts: [],
+        createdAt: now,
+        updatedAt: now,
+      };
+      this.value.consoles.push(console);
+    }
+    let attempt = console.attempts.find(
+      (entry) => entry.sessionAttemptId === plan.sessionAttemptId,
+    );
+    if (!attempt) {
+      attempt = {
+        sessionAttemptId: plan.sessionAttemptId,
+        runId: plan.sessionAttemptId,
+        provider: plan.provider,
+        providerVersion: plan.providerVersion,
+        status: 'planned',
+        startedAt: now,
+        receipts: [],
+        plans: [],
+      };
+      console.attempts.push(attempt);
+    }
+    if (!attempt.plans.some((candidate) => candidate.planRoot === plan.root)) {
+      attempt.plans.push({
+        operation: plan.operation,
+        planRoot: plan.root,
+        recordedAt: now,
+        effects: [...plan.effects],
+        workEffects: [],
+        rollback: plan.rollback,
+      });
+    }
+    console.runtimeProfileId =
+      plan.runtimeProfileId ?? console.runtimeProfileId;
+    console.updatedAt = now;
+    this.#save();
+    return clone({ console, attempt });
+  }
+
+  recordStarted(plan, receipt) {
+    const { console, attempt } = this.#find(plan);
+    attempt.status = 'running';
+    attempt.startedAt = receipt.recordedAt;
+    attempt.endedAt = undefined;
+    this.#appendReceipt(attempt, receipt);
+    console.updatedAt = receipt.recordedAt;
+    this.#save();
+  }
+
+  recordReceipt(ref, receipt) {
+    const found = this.#find(ref, false);
+    if (!found) return;
+    this.#appendReceipt(found.attempt, receipt);
+    found.console.updatedAt = receipt.recordedAt;
+    this.#save();
+  }
+
+  observe(sessions) {
+    let changed = false;
+    for (const session of sessions) {
+      const status = session.port.status();
+      const found = this.#find(status, false);
+      if (!found) continue;
+      const next = status.lifecycleState === 'ended' ? 'exited' : 'running';
+      if (found.attempt.status !== next) {
+        found.attempt.status = next;
+        if (next === 'exited') found.attempt.endedAt = this.now();
+        found.console.updatedAt = this.now();
+        changed = true;
+      }
+    }
+    if (changed) this.#save();
+  }
+
+  projection(ref) {
+    const found = this.#find(ref, false);
+    return found ? clone(found) : null;
+  }
+
+  console(workConsoleId) {
+    const console = this.value.consoles.find(
+      (entry) => entry.consoleId === workConsoleId,
+    );
+    return console ? clone(console) : null;
+  }
+
+  #find(ref, requiredEntry = true) {
+    const workConsoleId = ref.workConsoleId ?? ref.consoleId;
+    const sessionAttemptId = ref.sessionAttemptId ?? ref.attemptId;
+    const console = this.value.consoles.find(
+      (entry) => entry.consoleId === workConsoleId,
+    );
+    const attempt = console?.attempts.find(
+      (entry) => entry.sessionAttemptId === sessionAttemptId,
+    );
+    if ((!console || !attempt) && requiredEntry) {
+      throw Object.assign(
+        new Error(
+          `SessionAttempt '${String(sessionAttemptId)}' is not registered`,
+        ),
+        { code: 'session_not_registered' },
+      );
+    }
+    return console && attempt ? { console, attempt } : null;
+  }
+
+  #appendReceipt(attempt, value) {
+    const receipt = {
+      operation: value.operation,
+      status: value.status,
+      recordedAt: value.recordedAt,
+      receiptRoot: value.receiptRoot,
+      semanticOutcome: null,
+      workState: null,
+      proof: null,
+    };
+    if (
+      !attempt.receipts.some(
+        (candidate) => candidate.receiptRoot === receipt.receiptRoot,
+      )
+    ) {
+      attempt.receipts.push(receipt);
+    }
+  }
+
+  #recoverInterruptedAttempts() {
+    const now = this.now();
+    let changed = false;
+    for (const console of this.value.consoles) {
+      for (const attempt of console.attempts) {
+        if (!['planned', 'running', 'detached'].includes(attempt.status))
+          continue;
+        attempt.status = ['direct', 'capsule', 'structured'].includes(
+          console.backend,
+        )
+          ? 'unrecoverable'
+          : 'orphaned';
+        attempt.endedAt = now;
+        attempt.receipts.push({
+          operation: 'recover',
+          status: attempt.status,
+          reason: 'worker-runtime-continuity-lost',
+          recordedAt: now,
+          receiptRoot: null,
+          semanticOutcome: null,
+          workState: null,
+          proof: null,
+        });
+        console.updatedAt = now;
+        changed = true;
+      }
+    }
+    if (changed) this.#save();
+  }
+
+  #save() {
+    this.store?.save(this.value);
+  }
+}

--- a/framework/agent-session/tests/product-recovery-qualification.test.mjs
+++ b/framework/agent-session/tests/product-recovery-qualification.test.mjs
@@ -277,11 +277,23 @@ test('detached product worker passes the retained recovery, privacy, and latency
 
   const afterLoss = await restartedMain.invoke({ operation: 'list' });
   assert.deepEqual(afterLoss.sessions, []);
-  assert.equal(workers.length, 2);
-  await assert.rejects(
-    restartedMain.invoke({ operation: 'status', session: lostRef }),
-    (error) => error.code === 'session_not_found',
+  const lostConsole = afterLoss.consoles.find(
+    (console) => console.consoleId === lostRef.workConsoleId,
   );
+  assert.equal(
+    lostConsole.attempts.find(
+      (attempt) => attempt.sessionAttemptId === lostRef.sessionAttemptId,
+    ).status,
+    'unrecoverable',
+  );
+  assert.equal(workers.length, 2);
+  const lostStatus = await restartedMain.invoke({
+    operation: 'status',
+    session: lostRef,
+  });
+  assert.equal(lostStatus.live, false);
+  assert.equal(lostStatus.lifecycleState, 'unrecoverable');
+  assert.equal(lostStatus.inputAdmission, 'closed');
 
   const metrics = {
     schema: 'kungfu.agent-session.recovery-qualification/v1',

--- a/framework/agent-session/tests/product-surface.test.mjs
+++ b/framework/agent-session/tests/product-surface.test.mjs
@@ -1,10 +1,11 @@
 import assert from 'node:assert/strict';
 import { EventEmitter } from 'node:events';
-import { mkdtemp, rm, stat } from 'node:fs/promises';
+import { mkdtemp, readFile, rm, stat } from 'node:fs/promises';
 import net from 'node:net';
 import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
+import Ajv2020 from 'ajv/dist/2020.js';
 import { AgentSessionCapsuleHost } from '../src/capsule-host.mjs';
 import { AgentSessionInteractionPort } from '../src/interaction-port.mjs';
 import {
@@ -18,6 +19,11 @@ import {
   createAgentSessionSurfaceClient,
 } from '../src/product-surface.mjs';
 import { createProviderAdapter } from '../src/provider-adapters.mjs';
+import {
+  JsonFileWorkConsoleRegistryStore,
+  WORK_CONSOLE_REGISTRY_SCHEMA,
+  WorkConsoleRegistry,
+} from '../src/work-console-registry.mjs';
 
 const PROFILE_ROOT = `sha256:${'d'.repeat(64)}`;
 
@@ -181,6 +187,21 @@ function fixture() {
   return { clients, input, runtime, surface };
 }
 
+test('Core resolves one primary WorkConsole for a generic WorkRef', () => {
+  const { clients, input } = fixture();
+  const first = clients.gui.resolveConsole({
+    binding: input.binding,
+    workspaceId: 'ignored-for-work-binding',
+  });
+  const second = clients.cli.resolveConsole({
+    binding: input.binding,
+    workspaceId: 'ignored-for-work-binding',
+  });
+  assert.deepEqual(first, second);
+  assert.equal(first.workConsoleId, 'work:kungfu.mission-control:go:go-42');
+  assert.equal(first.binding.workRef.entityType, 'go');
+});
+
 function invokeRpc(endpoint, request) {
   return new Promise((resolve, reject) => {
     const socket = net.createConnection(endpoint);
@@ -218,6 +239,15 @@ test('one Go action starts once, auto-attaches, and later views reuse the Capsul
   assert.equal(first.autoAttached, true);
   assert.equal(first.attachReceipt.controller, true);
   assert.equal(runtime.spawnCount, 1);
+  const registry = clients.cli.list();
+  assert.equal(registry.consoles.length, 1);
+  assert.equal(registry.consoles[0].attempts[0].status, 'running');
+  assert.equal(
+    registry.consoles[0].attempts[0].receipts.some(
+      (receipt) => receipt.operation === 'start',
+    ),
+    true,
+  );
 
   const secondPlan = clients.cli.planStart({
     ...input,
@@ -274,6 +304,140 @@ test('all clients see one Hub projection and presentation detach never ends the 
   assert.equal(detached.providerEnded, false);
   assert.equal(runtime.list()[0].host.status().lifecycleState, 'ready');
   assert.deepEqual(runtime.list()[0].child.signals, []);
+  const registered = clients.cli.list().consoles[0].attempts[0];
+  assert.equal(registered.status, 'running');
+  assert.equal(registered.receipts.at(-1).operation, 'detach');
+});
+
+test('a provider restart creates a new attempt under the same primary WorkConsole', () => {
+  const { clients, input, runtime } = fixture();
+  clients.gui.start(clients.gui.planStart(input), {
+    attachmentId: 'view:first-attempt',
+    presentation: 'headless',
+  });
+  runtime.list()[0].child.emit('exit', { exitCode: 0, signal: 0 });
+  const secondInput = {
+    ...input,
+    sessionAttemptId: 'attempt:go-42:2',
+  };
+  clients.cli.start(clients.cli.planStart(secondInput), {
+    attachmentId: 'view:second-attempt',
+    presentation: 'headless',
+  });
+  const registry = clients['kfd3-agent'].list().consoles;
+  assert.equal(registry.length, 1);
+  assert.equal(registry[0].consoleId, input.workConsoleId);
+  assert.deepEqual(
+    registry[0].attempts.map((attempt) => attempt.sessionAttemptId),
+    [input.sessionAttemptId, secondInput.sessionAttemptId],
+  );
+  assert.deepEqual(
+    registry[0].attempts.map((attempt) => attempt.status),
+    ['exited', 'running'],
+  );
+});
+
+test('the durable Core registry migrates view-owned v1 data without presentation authority', async () => {
+  const root = await mkdtemp(
+    path.join(os.tmpdir(), 'kungfu-console-registry-'),
+  );
+  const file = path.join(root, 'work-console-registry.json');
+  try {
+    const legacy = {
+      schema: 'kungfu.work-console-registry/v1',
+      workspaceId: 'workspace-legacy',
+      consoles: [
+        {
+          consoleId: 'assistant:workspace-legacy',
+          bindingKind: 'workspace-assistant',
+          workRef: null,
+          runtimeProfileId: 'codex-app',
+          backend: 'capsule',
+          attempts: [
+            {
+              attemptId: 'attempt:legacy',
+              runId: 'attempt:legacy',
+              status: 'running',
+              startedAt: 1,
+            },
+          ],
+          createdAt: 1,
+          updatedAt: 1,
+        },
+      ],
+      presentation: {
+        tabs: ['assistant:workspace-legacy'],
+        splits: [],
+        drawer: 'assistant:workspace-legacy',
+        windows: [],
+      },
+    };
+    const store = new JsonFileWorkConsoleRegistryStore(file);
+    store.save(legacy);
+    const registry = new WorkConsoleRegistry({ store, now: () => 2 });
+    const snapshot = registry.snapshot();
+    assert.equal(snapshot.schema, WORK_CONSOLE_REGISTRY_SCHEMA);
+    assert.equal(snapshot.consoles[0].attempts[0].status, 'unrecoverable');
+    assert.equal(snapshot.consoles[0].attempts[0].endedAt, 2);
+    assert.equal(
+      snapshot.consoles[0].attempts[0].receipts[0].reason,
+      'worker-runtime-continuity-lost',
+    );
+    assert.equal('presentation' in snapshot, false);
+    assert.doesNotMatch(
+      JSON.stringify(snapshot),
+      /tabs|splits|drawer|windows/u,
+    );
+    const historical = new AgentSessionProductSurface({
+      runtime: new SyntheticProductRuntime(),
+      registry,
+    }).show({
+      workConsoleId: 'assistant:workspace-legacy',
+      sessionAttemptId: 'attempt:legacy',
+    });
+    assert.equal(historical.live, false);
+    assert.equal(historical.lifecycleState, 'unrecoverable');
+    assert.equal(historical.binding.kind, 'workspace-assistant');
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('Terminal persistence contains presentation references but no Console authority', async () => {
+  const source = await readFile(
+    new URL(
+      '../../../extensions/terminal/src/view/persistence.ts',
+      import.meta.url,
+    ),
+    'utf8',
+  );
+  assert.doesNotMatch(
+    source,
+    /type WorkConsoleRegistry|type SessionAttempt|CONSOLE_REGISTRY_LOCATION|saveConsoleRegistry/u,
+  );
+  assert.match(source, /consoleId\?: string/u);
+  assert.match(source, /attemptId\?: string/u);
+});
+
+test('the published v2 schema admits the Core registry and excludes presentation', async () => {
+  const { clients, input } = fixture();
+  clients.gui.start(clients.gui.planStart(input), {
+    attachmentId: 'view:schema',
+    presentation: 'headless',
+  });
+  const schema = JSON.parse(
+    await readFile(
+      new URL('../schemas/work-console-registry.schema.json', import.meta.url),
+      'utf8',
+    ),
+  );
+  const validate = new Ajv2020({ strict: true }).compile(schema);
+  const registry = {
+    schema: WORK_CONSOLE_REGISTRY_SCHEMA,
+    consoles: clients.cli.list().consoles,
+  };
+  assert.equal(validate(registry), true, JSON.stringify(validate.errors));
+  assert.equal('presentation' in schema.properties, false);
 });
 
 test('controller lease has one winner and transfers only after exact release', () => {

--- a/framework/config/kungfu-config.contract.json
+++ b/framework/config/kungfu-config.contract.json
@@ -293,6 +293,9 @@
     "workConsoleRegistry": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "kungfu.work-console-registry/v1",
+      "description": "Legacy read/import shape only. Core Agent Session owns v2 authority; presentation fields are never imported.",
+      "x-kungfu-authority": "legacy-terminal-config-read-only",
+      "x-kungfu-successor": "kungfu.work-console-registry/v2",
       "type": "object",
       "additionalProperties": false,
       "required": [


### PR DESCRIPTION
## Summary

Move WorkConsole identity, SessionAttempt lifecycle, reviewed plans, and metadata-only receipts from Terminal presentation state into the detached Core Agent Session worker.

## Changes

- add a durable kungfu.work-console-registry/v2 schema and single-writer Core registry
- resolve one primary WorkConsole for generic WorkRef bindings and retain distinct provider attempts
- expose the same registry through GUI, CLI, and KFD-3 list/show/resolve-console operations
- preserve history while marking old attempts unrecoverable after worker continuity loss
- reduce Terminal persistence to stable console/attempt references plus pane/window presentation
- compose with both PTY/Capsule and structured Codex product routes without choosing a transport

## Verification

- ./shifu check:source (263 source acceptance tests)
- ./shifu test:agent-session-product-surfaces (13 passed)
- ./shifu test:agent-session-recovery-qualification
- ./shifu test:codex-app-server-product (3 passed)
- ./shifu test:agent-console-contract (9 passed)
- ./shifu --filter @kungfu-tech/gui build
- staged pre-commit gate

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "stage-ready",
  "adrs": ["ADR-0083"],
  "summary": "Complete the Core WorkConsole authority extraction while preserving presentation and transport boundaries",
  "verification": ["./shifu check:source", "./shifu test:agent-session-product-surfaces", "./shifu test:agent-session-recovery-qualification", "./shifu test:codex-app-server-product", "./shifu test:agent-console-contract", "./shifu --filter @kungfu-tech/gui build", "staged pre-commit gate"]
}
-->

## Governance risk check

- [x] none of credentials, hosted services, branding, publishing, or deployment boundaries

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated
