### PR TITLE
fix(terminal): keep WorkRef launch profile neutral

### DIFF
--- a/docs/adr/ADR-0083-core-system-kfx-profile-kfx-capability-boundary.md
+++ b/docs/adr/ADR-0083-core-system-kfx-profile-kfx-capability-boundary.md
@@ -4,7 +4,7 @@ doc_type: architecture-decision
 adr_id: ADR-0083
 decision_status: accepted
 implementation_status: partial
-implementation_commits: [c6266fe3ea37e096ced272c497b6e729218c7a3b, ef4421c8607860978f7d2b890ab68c149d97747a, bdf3800cb34182b59d3f341dee08056a5ebf6bd0, fb67a700c748e8c355bec7d15077d654a2a9c3ea, 4734113513cb7f1868e29b45f505f3b6fd33eee1, 36381447657fcda49b7b5c48eafd9703236adcb0, 19ed717bd1db545782f366fd47b14ec3a1c35add]
+implementation_commits: [c6266fe3ea37e096ced272c497b6e729218c7a3b, ef4421c8607860978f7d2b890ab68c149d97747a, bdf3800cb34182b59d3f341dee08056a5ebf6bd0, fb67a700c748e8c355bec7d15077d654a2a9c3ea, 4734113513cb7f1868e29b45f505f3b6fd33eee1, 36381447657fcda49b7b5c48eafd9703236adcb0, 19ed717bd1db545782f366fd47b14ec3a1c35add, cf89ef827eff152ec8f8dcb15ae249d7bda4a239]
 review_state: self-reviewed
 sensitivity: public
 sources: [local-files, user-consensus]
@@ -233,6 +233,11 @@ and window presentation only. The old Config contract v1 remains a
 read/import-only compatibility shape whose `presentation` member is discarded;
 new authority is written only by the Core worker, so this migration does not
 create a second Console store or choose a different transport backend.
+
+The final boundary audit also removes Terminal KFX's Mission Control fallback
+when constructing a WorkRef. A work-bound launch must supply its Profile id,
+Profile root, and entity id together; a partial identity now fails visibly
+instead of silently binding another Profile's work to Mission Control.
 
 ## Acceptance gates
 

--- a/extensions/terminal/src/view/index.tsx
+++ b/extensions/terminal/src/view/index.tsx
@@ -83,7 +83,19 @@ function mintRunId(): string {
 
 async function workRefFromShell(shell: Shell): Promise<WorkRef | null> {
   const params = shell.params ?? {};
-  if (!params.workEntityId || !params.workProfileRoot) return null;
+  const hasWorkRefParams = Boolean(
+    params.workEntityId || params.workProfileId || params.workProfileRoot,
+  );
+  if (!hasWorkRefParams) return null;
+  if (
+    !params.workEntityId ||
+    !params.workProfileId ||
+    !params.workProfileRoot
+  ) {
+    throw new Error(
+      'WorkRef launch requires workProfileId, workProfileRoot, and workEntityId',
+    );
+  }
   let entity: unknown = { id: params.workEntityId };
   try {
     entity = JSON.parse(params.workEntity ?? '{}');
@@ -96,7 +108,7 @@ async function workRefFromShell(shell: Shell): Promise<WorkRef | null> {
       (typeof process !== 'undefined'
         ? process.env.KF_WORKSPACE_ID || 'home'
         : 'home'),
-    profileId: params.workProfileId || 'kungfu.mission-control',
+    profileId: params.workProfileId,
     profileRoot: params.workProfileRoot,
     entityType: params.workEntityType || 'work',
     entityId: params.workEntityId,

--- a/framework/agent-session/tests/product-surface.test.mjs
+++ b/framework/agent-session/tests/product-surface.test.mjs
@@ -419,6 +419,19 @@ test('Terminal persistence contains presentation references but no Console autho
   assert.match(source, /attemptId\?: string/u);
 });
 
+test('Terminal WorkRef launch remains Profile-neutral and rejects partial identity', async () => {
+  const source = await readFile(
+    new URL('../../../extensions/terminal/src/view/index.tsx', import.meta.url),
+    'utf8',
+  );
+  assert.doesNotMatch(source, /kungfu\.mission-control/u);
+  assert.match(
+    source,
+    /WorkRef launch requires workProfileId, workProfileRoot, and workEntityId/u,
+  );
+  assert.match(source, /profileId: params\.workProfileId/u);
+});
+
 test('the published v2 schema admits the Core registry and excludes presentation', async () => {
   const { clients, input } = fixture();
   clients.gui.start(clients.gui.planStart(input), {


### PR DESCRIPTION
## Summary

- remove the Mission Control fallback from generic Terminal WorkRef construction
- reject partial WorkRef launch identity instead of silently rebinding another Profile as Mission Control
- add a regression test that keeps Terminal WorkRef launch Profile-neutral

## Verification

- ./shifu test:agent-session-product-surfaces
- ./shifu check:source
- ./shifu build:app
- staged pre-commit gate

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "stage-ready",
  "adrs": ["ADR-0083"],
  "summary": "Close the final generic Terminal Profile identity leak found by the capability boundary audit",
  "verification": ["./shifu test:agent-session-product-surfaces", "./shifu check:source", "./shifu build:app", "staged pre-commit gate"]
}
-->

## Governance risk check

- [x] none of credentials, hosted services, branding, publishing, or deployment boundaries

## Checklist

- [x] Commit is signed off (DCO)
- [x] Correct Mission Control callers already pass workProfileId explicitly
