### PR TITLE
feat(agent): default Codex to structured transport

### DIFF
--- a/docs/adr/ADR-0085-codex-app-server-structured-hybrid-adapter.md
+++ b/docs/adr/ADR-0085-codex-app-server-structured-hybrid-adapter.md
@@ -5,7 +5,7 @@ adr_id: ADR-0085
 decision_status: accepted
 implementation_status: staged
 implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/849, https://github.com/kungfu-systems/kungfu/pull/851, https://github.com/kungfu-systems/kungfu/pull/855, https://github.com/kungfu-systems/kungfu/pull/857, https://github.com/kungfu-systems/kungfu/pull/861]
-qualification_refs: [framework/agent-session/tests/codex-app-server-contract.test.mjs, framework/agent-session/tests/codex-app-server-schema.native.test.mjs, framework/agent-session/tests/codex-app-server-runtime.test.mjs, framework/agent-session/tests/codex-app-server-interaction.test.mjs, framework/agent-session/tests/codex-app-server-recovery.test.mjs, framework/agent-session/tests/codex-app-server-product.test.mjs, framework/agent-session/schemas/codex-app-server/codex-v0.144.3-stable-schema-manifest.json]
+qualification_refs: [framework/agent-session/tests/codex-app-server-contract.test.mjs, framework/agent-session/tests/codex-app-server-schema.native.test.mjs, framework/agent-session/tests/codex-app-server-runtime.test.mjs, framework/agent-session/tests/codex-app-server-interaction.test.mjs, framework/agent-session/tests/codex-app-server-recovery.test.mjs, framework/agent-session/tests/codex-app-server-product.test.mjs, framework/agent-session/schemas/codex-app-server/codex-v0.144.3-stable-schema-manifest.json, scripts/run-agent-session-provider-dogfood.mjs]
 review_state: self-reviewed
 sensitivity: public
 sources: [local-files, user-consensus]
@@ -197,6 +197,26 @@ PTY fallback preserves the WorkConsole and provider, retains old structured
 receipts, and creates a distinct attempt only after an `unknown` or
 `interrupted` boundary. Product receipts still claim no semantic outcome,
 Profile/KFD work state, or proof.
+
+Stage 6 convergence makes that structured route the default for new Codex
+`0.144.3` attempts. `KUNGFU_AGENT_SESSION_CODEX_APP_SERVER=0` is the explicit
+rollback to a new PTY attempt; it never changes an in-flight attempt or erases
+its receipts. New structured threads pin `approvalPolicy=untrusted`,
+`approvalsReviewer=user`, `sandbox=read-only`, and the reviewed workspace cwd.
+The contract now admits three stable-schema notifications observed in real
+dogfood—remote-control status, MCP startup status, and account rate limits—as
+typed telemetry only. None can become session, work, outcome, or proof
+authority.
+
+Authenticated Mac source dogfood against Codex `0.144.3` passes start,
+instruction/output, exact approval denial, interrupt, main-process reattach,
+and provider exit closure through the structured route. It retains no raw
+terminal, prompt, transcript, credential, or private environment value. The
+same run shows the current Codex PTY screen no longer matches the pinned PTY
+adapter and therefore remains rollback/manual-recovery only. Claude Code stays
+PTY-authoritative and its separate approval-modal degradation remains an
+explicit provider limit; Codex structured qualification does not overwrite or
+upgrade that result.
 
 ## Rejected alternatives
 

--- a/docs/qualification/known-limits.md
+++ b/docs/qualification/known-limits.md
@@ -346,13 +346,15 @@ What is **not yet guaranteed**:
 
 A skill can request, explain, and compose. It cannot bypass the kfx trust gate.
 
-## Detached Agent Session recovery is qualified with one provider hold
+## Detached Agent Session recovery is provider-qualified, not uniform
 
 The runtime-scoped detached worker now owns the real Capsule/PTY surface, and
 the Mac source qualification passes GUI-main reconnect, provider exit fencing,
 worker-loss fail-closed behavior, bounded overflow, receipt privacy, and local
-RPC latency. Authenticated Codex 0.144.3 also passes the complete retained
-interaction loop.
+RPC latency. Authenticated Codex 0.144.3 now passes the complete retained
+interaction loop through the pinned App Server structured route. The current
+Codex PTY screen does not match its older qualified signature, so PTY is a
+manual recovery/new-attempt fallback rather than structured authority.
 
 What is **not yet guaranteed**:
 
@@ -362,11 +364,13 @@ What is **not yet guaranteed**:
 - Capsule worker loss and machine reboot end the old attempt; recovery requires
   a new attempt or provider-native resume and never adopts a stale PTY;
 - equivalent packaged evidence on Linux and Windows; and
-- Mac product promotion while the Claude approval hold remains open.
+- Claude automatic approval/deny parity with the structured Codex route.
 
-The Claude result is deliberately `degraded`, not passed. Terminal frames stay
-volatile and bounded; retained evidence contains only state, counts, latency,
-versions, and path digests.
+The Claude result is deliberately `degraded`, not passed, and remains a block
+for claiming a complete Claude tool-approval loop. It does not turn typed Codex
+events into Claude facts or block provider-scoped Codex structured promotion.
+Terminal frames stay volatile and bounded; retained evidence contains only
+state, counts, latency, versions, and path digests.
 
 ## Reference extensions are mid-migration
 

--- a/framework/agent-session/README.md
+++ b/framework/agent-session/README.md
@@ -189,12 +189,19 @@ existing Agent Session journal authority behind this append/read seam. The
 Stage 4 source test uses only a deterministic in-memory journal and synthetic
 runtime; it does not read provider credentials or private session state.
 
-The Stage 5 product adapter routes Codex `0.144.3` through direct stdio only
-when `KUNGFU_AGENT_SESSION_CODEX_APP_SERVER=1`. With the flag absent, Codex and
-Claude retain the existing PTY plan, capabilities, authority, and receipt
-shape. GUI, CLI, and KFD-3 use the same product `invoke` seam for structured
+The product adapter routes new Codex `0.144.3` attempts through direct stdio by
+default. Set `KUNGFU_AGENT_SESSION_CODEX_APP_SERVER=0` to route a newly created
+Codex attempt through the retained PTY fallback; the flag never hot-switches an
+existing attempt. Claude retains its PTY plan, authority, and receipt shape.
+GUI, CLI, and KFD-3 use the same product `invoke` seam for structured
 start, instruction, interrupt, exact provider control response, status, and
 receipts; no presentation owns a private provider mutation path.
+
+Structured starts default to an untrusted, user-reviewed, read-only sandbox in
+the reviewed workspace. The real-provider qualification command accepts
+`--transport structured` for Codex and emits metadata-only evidence. Stable
+remote-control, MCP startup, and rate-limit notifications are admitted only as
+typed provider telemetry; unknown methods still fail closed.
 
 The route is frozen for one `SessionAttempt`. Runtime loss or explicit end
 closes the structured attempt at an `unknown` or `interrupted` boundary. PTY

--- a/framework/agent-session/kungfu-codex-app-server.contract.json
+++ b/framework/agent-session/kungfu-codex-app-server.contract.json
@@ -218,6 +218,45 @@
     },
     {
       "direction": "server-notification",
+      "method": "account/rateLimits/updated",
+      "schemaFile": "v2/AccountRateLimitsUpdatedNotification.json",
+      "normalizedSemantic": "provider-rate-limit-telemetry",
+      "interactionOperation": "status",
+      "requiredPaths": [
+        "/params/rateLimits"
+      ],
+      "rawRetention": "typed-summary",
+      "authority": "quota-telemetry-not-work-fact"
+    },
+    {
+      "direction": "server-notification",
+      "method": "mcpServer/startupStatus/updated",
+      "schemaFile": "v2/McpServerStatusUpdatedNotification.json",
+      "normalizedSemantic": "provider-extension-startup-telemetry",
+      "interactionOperation": "status",
+      "requiredPaths": [
+        "/params/name",
+        "/params/status"
+      ],
+      "rawRetention": "metadata-only",
+      "authority": "provider-extension-telemetry-not-work-fact"
+    },
+    {
+      "direction": "server-notification",
+      "method": "remoteControl/status/changed",
+      "schemaFile": "v2/RemoteControlStatusChangedNotification.json",
+      "normalizedSemantic": "provider-connection-telemetry",
+      "interactionOperation": "status",
+      "requiredPaths": [
+        "/params/installationId",
+        "/params/serverName",
+        "/params/status"
+      ],
+      "rawRetention": "metadata-only",
+      "authority": "connection-telemetry-not-session-fact"
+    },
+    {
+      "direction": "server-notification",
       "method": "thread/started",
       "schemaFile": "v2/ThreadStartedNotification.json",
       "normalizedSemantic": "session-started",

--- a/framework/agent-session/src/codex-app-server-product.mjs
+++ b/framework/agent-session/src/codex-app-server-product.mjs
@@ -9,6 +9,21 @@ import { InMemoryJournalNoticePort } from './peer-transport.mjs';
 export const CODEX_APP_SERVER_FEATURE_FLAG =
   'KUNGFU_AGENT_SESSION_CODEX_APP_SERVER';
 
+/**
+ * Codex app-server is the product default for the exact qualified CLI.
+ * Setting the retained feature flag to `0` is the bounded rollback to PTY for
+ * newly-created attempts; an existing attempt never changes transport.
+ */
+export function codexAppServerProductEnabled(env = {}) {
+  const value = env[CODEX_APP_SERVER_FEATURE_FLAG];
+  if (value === undefined || value === '' || value === '1') return true;
+  if (value === '0') return false;
+  throw Object.assign(
+    new Error(`${CODEX_APP_SERVER_FEATURE_FLAG} must be 0 or 1`),
+    { code: 'invalid_route_policy' },
+  );
+}
+
 function required(value, label) {
   if (typeof value !== 'string' || value.length === 0) {
     throw Object.assign(new Error(`${label} is required`), {
@@ -99,6 +114,8 @@ function routeStatus(argv) {
     transport: 'codex-app-server-direct-stdio',
     argv: [...argv],
     featureFlag: CODEX_APP_SERVER_FEATURE_FLAG,
+    defaultPolicy: 'structured',
+    rollback: `${CODEX_APP_SERVER_FEATURE_FLAG}=0`,
     frozenPerAttempt: true,
     hotSwitch: false,
   };
@@ -360,6 +377,19 @@ export class CodexAppServerProductRuntime {
           adapterVersion: 'codex-app-server-structured/v1',
           compatible: true,
           tested: plan.providerVersion === '0.144.3',
+          failureCode:
+            state.eventFailure?.code ?? current.failure?.code ?? null,
+          failureDetail:
+            state.eventFailure?.message ?? current.failure?.message ?? null,
+          exit: current.exit
+            ? {
+                code: current.exit.code,
+                signal: current.exit.signal,
+                expected: current.exit.expected,
+              }
+            : null,
+          stderrBytesObserved: current.stderr.observedBytes,
+          stderrRetained: false,
         },
         queuedInstructions: 0,
         transportRoute: plan.transportRoute,

--- a/framework/agent-session/src/product-surface.mjs
+++ b/framework/agent-session/src/product-surface.mjs
@@ -363,7 +363,12 @@ export class AgentSessionProductSurface {
               version: '4.0.0-alpha.0',
             },
           },
-          threadStartParams: input.structured?.threadStartParams ?? {},
+          threadStartParams: input.structured?.threadStartParams ?? {
+            ...(input.cwd ? { cwd: input.cwd } : {}),
+            approvalPolicy: 'untrusted',
+            approvalsReviewer: 'user',
+            sandbox: 'read-only',
+          },
         }
       : null;
     const registeredConsole = this.registry.console(consoleId);

--- a/framework/agent-session/src/product-worker.mjs
+++ b/framework/agent-session/src/product-worker.mjs
@@ -3,8 +3,8 @@ import { createRequire } from 'node:module';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 import {
-  CODEX_APP_SERVER_FEATURE_FLAG,
   CodexAppServerProductRuntime,
+  codexAppServerProductEnabled,
 } from './codex-app-server-product.mjs';
 import { bindAgentSessionSurfaceRpc } from './product-rpc.mjs';
 import { InProcessAgentSessionProductRuntime } from './product-runtime.mjs';
@@ -35,10 +35,9 @@ export async function runAgentSessionProductWorker({
   const runtime = new InProcessAgentSessionProductRuntime({
     pty: loadedPty,
     baseEnv,
-    structuredRuntime:
-      baseEnv[CODEX_APP_SERVER_FEATURE_FLAG] === '1'
-        ? new CodexAppServerProductRuntime({ baseEnv })
-        : null,
+    structuredRuntime: codexAppServerProductEnabled(baseEnv)
+      ? new CodexAppServerProductRuntime({ baseEnv })
+      : null,
   });
   const registry = new WorkConsoleRegistry({
     store: new JsonFileWorkConsoleRegistryStore(registryPath),

--- a/framework/agent-session/tests/codex-app-server-product.test.mjs
+++ b/framework/agent-session/tests/codex-app-server-product.test.mjs
@@ -5,7 +5,11 @@ import { EventEmitter } from 'node:events';
 import path from 'node:path';
 import test from 'node:test';
 import { fileURLToPath } from 'node:url';
-import { CodexAppServerProductRuntime } from '../src/codex-app-server-product.mjs';
+import {
+  CODEX_APP_SERVER_FEATURE_FLAG,
+  CodexAppServerProductRuntime,
+  codexAppServerProductEnabled,
+} from '../src/codex-app-server-product.mjs';
 import { InProcessAgentSessionProductRuntime } from '../src/product-runtime.mjs';
 import { AgentSessionProductSurface } from '../src/product-surface.mjs';
 
@@ -45,6 +49,7 @@ function input(overrides = {}) {
     profileRoot: PROFILE_ROOT,
     executable: process.execPath,
     argv: [provider, 'product-route'],
+    cwd: here,
     env: {},
     ...overrides,
   };
@@ -87,6 +92,27 @@ test('production route freezes the exact Codex app-server stdio launch', () => {
   assert.throws(
     () => structured.planRoute(input({ providerVersion: '0.144.4' })),
     (error) => error.code === 'provider_version_drift',
+  );
+  assert.equal(route.defaultPolicy, 'structured');
+  assert.equal(route.rollback, `${CODEX_APP_SERVER_FEATURE_FLAG}=0`);
+});
+
+test('product policy defaults Codex to structured with an explicit PTY rollback', () => {
+  assert.equal(codexAppServerProductEnabled({}), true);
+  assert.equal(
+    codexAppServerProductEnabled({ [CODEX_APP_SERVER_FEATURE_FLAG]: '1' }),
+    true,
+  );
+  assert.equal(
+    codexAppServerProductEnabled({ [CODEX_APP_SERVER_FEATURE_FLAG]: '0' }),
+    false,
+  );
+  assert.throws(
+    () =>
+      codexAppServerProductEnabled({
+        [CODEX_APP_SERVER_FEATURE_FLAG]: 'unexpected',
+      }),
+    (error) => error.code === 'invalid_route_policy',
   );
 });
 
@@ -158,6 +184,12 @@ test('GUI CLI and Agent share one frozen structured route and exact controls', a
   assert.equal(guiPlan.transportRoute.kind, 'structured');
   assert.equal(guiPlan.transportRoute.frozenPerAttempt, true);
   assert.deepEqual(guiPlan.argv, [provider, 'product-route']);
+  assert.deepEqual(guiPlan.structured.threadStartParams, {
+    cwd: here,
+    approvalPolicy: 'untrusted',
+    approvalsReviewer: 'user',
+    sandbox: 'read-only',
+  });
 
   const started = await product.invoke({
     operation: 'start',

--- a/framework/agent-session/tests/fixtures/codex-app-server/positive-cases.json
+++ b/framework/agent-session/tests/fixtures/codex-app-server/positive-cases.json
@@ -35,6 +35,45 @@
     "expectedSemantic": "turn-started"
   },
   {
+    "id": "remote-control-status-is-connection-telemetry-only",
+    "direction": "server-notification",
+    "message": {
+      "method": "remoteControl/status/changed",
+      "params": {
+        "installationId": "redacted-installation",
+        "serverName": "redacted-server",
+        "status": "disabled"
+      }
+    },
+    "expectedSemantic": "provider-connection-telemetry"
+  },
+  {
+    "id": "account-rate-limits-are-provider-telemetry-only",
+    "direction": "server-notification",
+    "message": {
+      "method": "account/rateLimits/updated",
+      "params": {
+        "rateLimits": {
+          "primary": null,
+          "secondary": null
+        }
+      }
+    },
+    "expectedSemantic": "provider-rate-limit-telemetry"
+  },
+  {
+    "id": "mcp-startup-status-is-extension-telemetry-only",
+    "direction": "server-notification",
+    "message": {
+      "method": "mcpServer/startupStatus/updated",
+      "params": {
+        "name": "redacted-server",
+        "status": "ready"
+      }
+    },
+    "expectedSemantic": "provider-extension-startup-telemetry"
+  },
+  {
     "id": "command-approval-keeps-exact-control-target",
     "direction": "server-request",
     "message": {

--- a/framework/agent-session/tests/product-recovery-qualification.test.mjs
+++ b/framework/agent-session/tests/product-recovery-qualification.test.mjs
@@ -9,6 +9,7 @@ import path from 'node:path';
 import test from 'node:test';
 import { setTimeout as delay } from 'node:timers/promises';
 import { fileURLToPath } from 'node:url';
+import { CODEX_APP_SERVER_FEATURE_FLAG } from '../src/codex-app-server-product.mjs';
 import { createDetachedAgentSessionHost } from '../src/product-client.mjs';
 
 const PROVIDER = fileURLToPath(
@@ -140,6 +141,7 @@ test('detached product worker passes the retained recovery, privacy, and latency
     executable: process.execPath,
     env: {
       ...process.env,
+      [CODEX_APP_SERVER_FEATURE_FLAG]: '0',
       KUNGFU_AGENT_SESSION_NODE_PTY_MODULE: preparedNodePty(root),
     },
     spawnProcess,

--- a/scripts/run-agent-session-provider-dogfood.mjs
+++ b/scripts/run-agent-session-provider-dogfood.mjs
@@ -6,6 +6,7 @@ import { createRequire } from 'node:module';
 import path from 'node:path';
 import process from 'node:process';
 import { setTimeout as delay } from 'node:timers/promises';
+import { CODEX_APP_SERVER_FEATURE_FLAG } from '../framework/agent-session/src/codex-app-server-product.mjs';
 import { createDetachedAgentSessionHost } from '../framework/agent-session/src/product-client.mjs';
 
 const PROFILE_ROOT = `sha256:${'8'.repeat(64)}`;
@@ -95,21 +96,28 @@ function prepareCheckoutNodePty(runtimeDir) {
 }
 
 async function control(host, ref, operation, payload, automatic = true) {
-  const plan = await host.invoke({
-    operation: 'plan-control',
-    controlOperation: operation,
-    session: ref,
-    payload,
-  });
-  return host.invoke({
-    operation,
-    actorId: 'qualification-controller',
-    client: 'gui',
-    plan,
-    expectedPlanRoot: plan.root,
-    payload,
-    automatic,
-  });
+  for (let attempt = 1; attempt <= 3; attempt += 1) {
+    const plan = await host.invoke({
+      operation: 'plan-control',
+      controlOperation: operation,
+      session: ref,
+      payload,
+    });
+    try {
+      return await host.invoke({
+        operation,
+        actorId: 'qualification-controller',
+        client: 'gui',
+        plan,
+        expectedPlanRoot: plan.root,
+        payload,
+        automatic,
+      });
+    } catch (error) {
+      if (error.code !== 'stale_plan' || attempt === 3) throw error;
+    }
+  }
+  throw new Error('unreachable control planning state');
 }
 
 async function waitForReady(host, ref, provider, label) {
@@ -117,11 +125,31 @@ async function waitForReady(host, ref, provider, label) {
   let observedTrustTokens = [];
   let observedReadyTokens = [];
   let adapterReason = null;
+  let lastSafeStatus = null;
   let status;
   try {
     status = await eventually(async () => {
       const current = await host.invoke({ operation: 'status', session: ref });
+      lastSafeStatus = {
+        lifecycleState: current.lifecycleState,
+        interactionState: current.interactionState,
+        inputAdmission: current.inputAdmission,
+        providerSessionObserved: Boolean(current.foreground?.providerSessionId),
+        providerTurnObserved: Boolean(current.foreground?.providerTurnId),
+        adapterFailureCode: current.providerAdapter?.failureCode ?? null,
+        adapterFailureDetail: current.providerAdapter?.failureDetail ?? null,
+        adapterExit: current.providerAdapter?.exit ?? null,
+        stderrBytesObserved:
+          current.providerAdapter?.stderrBytesObserved ?? null,
+        attemptBoundary: current.attemptBoundary ?? null,
+      };
       if (current.interactionState === 'ready') return current;
+      if (
+        ['ended', 'failed'].includes(current.lifecycleState) ||
+        current.inputAdmission === 'closed'
+      ) {
+        throw new Error(`${provider} attempt ended before ready`);
+      }
       adapterReason = current.providerAdapter.reason;
       if (provider !== 'claude' || current.interactionState !== 'unknown') {
         return null;
@@ -176,7 +204,7 @@ async function waitForReady(host, ref, provider, label) {
     }, label);
   } catch (error) {
     throw new Error(
-      `${error.message}; adapterReason=${adapterReason ?? 'none'}; trustTokens=${observedTrustTokens.join(',') || 'none'}; readyTokens=${observedReadyTokens.join(',') || 'none'}`,
+      `${error.message}; adapterReason=${adapterReason ?? 'none'}; safeStatus=${JSON.stringify(lastSafeStatus)}; trustTokens=${observedTrustTokens.join(',') || 'none'}; readyTokens=${observedReadyTokens.join(',') || 'none'}`,
     );
   }
   return { status, temporaryTrustAccepted };
@@ -201,6 +229,13 @@ const provider = argument('--provider');
 if (!['codex', 'claude'].includes(provider)) {
   throw new Error('--provider must be codex or claude');
 }
+const transport = argument('--transport') ?? 'pty';
+if (!['pty', 'structured'].includes(transport)) {
+  throw new Error('--transport must be pty or structured');
+}
+if (transport === 'structured' && provider !== 'codex') {
+  throw new Error('structured transport is qualified only for codex');
+}
 const runtimeDir = requiredArgument('--runtime-dir');
 const workspace = requiredArgument('--workspace');
 const providerExecutable = requiredArgument('--provider-executable');
@@ -212,6 +247,8 @@ const ptyModule = process.argv.includes('--prepare-checkout-node-pty')
   ? prepareCheckoutNodePty(runtimeDir)
   : argument('--pty-module');
 const workerEnv = { ...process.env };
+workerEnv[CODEX_APP_SERVER_FEATURE_FLAG] =
+  transport === 'structured' ? '1' : '0';
 if (ptyModule)
   workerEnv.KUNGFU_AGENT_SESSION_NODE_PTY_MODULE = path.resolve(ptyModule);
 
@@ -277,21 +314,35 @@ try {
   const instruct = await control(restartedMain, ref, 'instruct', {
     text: `Reply with exactly ${token}. Do not use tools.`,
   });
-  if (instruct.status !== 'written') {
-    throw new Error(`${provider} instruction was not written`);
+  if (
+    transport === 'structured'
+      ? instruct.status !== 'delivered'
+      : instruct.status !== 'written'
+  ) {
+    throw new Error(`${provider} instruction was not delivered`);
   }
   const responseStatus = await eventually(async () => {
     const status = await restartedMain.invoke({
       operation: 'status',
       session: ref,
     });
+    if (transport === 'structured') {
+      return status.output.nextSequence > sequenceBeforeInstruction &&
+        status.interactionState === 'ready'
+        ? status
+        : null;
+    }
     return status.output.nextSequence > sequenceBeforeInstruction + 32
       ? status
       : null;
   }, `${provider} output after instruction`);
 
   const instructedEnd = await control(restartedMain, ref, 'end', {});
-  if (instructedEnd.status !== 'applied') {
+  if (
+    transport === 'structured'
+      ? instructedEnd.status !== 'signalled'
+      : instructedEnd.status !== 'applied'
+  ) {
     throw new Error(`${provider} instruction attempt did not end`);
   }
   await eventually(async () => {
@@ -348,29 +399,68 @@ try {
       text: `Use the shell tool to run touch ${JSON.stringify(approvalProbe)}. Do not avoid the tool request.`,
     },
   );
-  if (approvalInstruction.status !== 'written') {
-    throw new Error(`${provider} approval probe instruction was not written`);
+  if (
+    transport === 'structured'
+      ? approvalInstruction.status !== 'delivered'
+      : approvalInstruction.status !== 'written'
+  ) {
+    throw new Error(`${provider} approval probe instruction was not delivered`);
   }
-  await eventually(async () => {
-    const status = await restartedMain.invoke({
-      operation: 'status',
-      session: approvalRef,
-    });
-    return status.interactionState === 'approval-needed';
-  }, `${provider} approval-needed state`);
-  const denied = await control(
-    restartedMain,
-    approvalRef,
-    'send-key',
-    { key: 'Escape' },
-    false,
-  );
-  if (denied.status !== 'written') {
-    throw new Error(`${provider} approval denial key was not written`);
+  let approvalSafeStatus = null;
+  try {
+    await eventually(async () => {
+      const status = await restartedMain.invoke({
+        operation: 'status',
+        session: approvalRef,
+      });
+      approvalSafeStatus = {
+        lifecycleState: status.lifecycleState,
+        interactionState: status.interactionState,
+        inputAdmission: status.inputAdmission,
+        pendingControls: status.structuredControl?.pending?.length ?? null,
+        adapterFailureCode: status.providerAdapter?.failureCode ?? null,
+        adapterFailureDetail: status.providerAdapter?.failureDetail ?? null,
+      };
+      return status.interactionState === 'approval-needed';
+    }, `${provider} approval-needed state`);
+  } catch (error) {
+    throw new Error(
+      `${error.message}; safeStatus=${JSON.stringify(approvalSafeStatus)}`,
+    );
+  }
+  const pendingControl = (
+    await restartedMain.invoke({ operation: 'status', session: approvalRef })
+  ).structuredControl?.pending?.[0];
+  const denied =
+    transport === 'structured'
+      ? await control(
+          restartedMain,
+          approvalRef,
+          'respond-control',
+          { requestId: pendingControl?.requestId, decision: 'deny' },
+          false,
+        )
+      : await control(
+          restartedMain,
+          approvalRef,
+          'send-key',
+          { key: 'Escape' },
+          false,
+        );
+  if (
+    transport === 'structured'
+      ? denied.status !== 'delivered'
+      : denied.status !== 'written'
+  ) {
+    throw new Error(`${provider} approval denial was not delivered`);
   }
 
   const ended = await control(restartedMain, approvalRef, 'end', {});
-  if (ended.status !== 'applied') {
+  if (
+    transport === 'structured'
+      ? ended.status !== 'signalled'
+      : ended.status !== 'applied'
+  ) {
     throw new Error(`${provider} end signal was not delivered`);
   }
   await eventually(async () => {
@@ -418,17 +508,47 @@ try {
     provider,
     `${provider} interrupt attempt ready`,
   );
+  if (transport === 'structured') {
+    const longInstruction = await control(
+      restartedMain,
+      interruptRef,
+      'instruct',
+      {
+        text: 'Begin outputting consecutive integers from 1 to 10000, one per line. Do not use tools.',
+      },
+    );
+    if (longInstruction.status !== 'delivered') {
+      throw new Error(
+        `${provider} interrupt probe instruction was not delivered`,
+      );
+    }
+    await eventually(async () => {
+      const status = await restartedMain.invoke({
+        operation: 'status',
+        session: interruptRef,
+      });
+      return status.interactionState === 'busy';
+    }, `${provider} interrupt probe busy state`);
+  }
   const interrupted = await control(
     restartedMain,
     interruptRef,
     'interrupt',
     {},
   );
-  if (interrupted.status !== 'applied') {
+  if (
+    transport === 'structured'
+      ? interrupted.status !== 'delivered'
+      : interrupted.status !== 'applied'
+  ) {
     throw new Error(`${provider} interrupt signal was not delivered`);
   }
   const interruptEnd = await control(restartedMain, interruptRef, 'end', {});
-  if (interruptEnd.status !== 'applied') {
+  if (
+    transport === 'structured'
+      ? interruptEnd.status !== 'signalled'
+      : interruptEnd.status !== 'applied'
+  ) {
     throw new Error(`${provider} interrupt attempt did not end`);
   }
 
@@ -436,6 +556,11 @@ try {
     schema: 'kungfu.agent-session.provider-dogfood/v1',
     provider,
     providerVersion: initial.providerAdapter.providerVersion,
+    transport,
+    transportAuthority:
+      transport === 'structured'
+        ? 'codex-app-server-structured-events'
+        : `${provider}-pty-state-adapter`,
     platform: `${process.platform}-${process.arch}`,
     worker: workerPath ? 'packaged-app' : 'source-checkout',
     cases: {
@@ -457,6 +582,10 @@ try {
       initialReady.temporaryTrustAccepted ||
       approvalReady.temporaryTrustAccepted ||
       interruptReady.temporaryTrustAccepted,
+    rollback:
+      transport === 'structured'
+        ? `${CODEX_APP_SERVER_FEATURE_FLAG}=0 creates a new PTY attempt`
+        : null,
     linuxQualification: 'not-run',
     windowsQualification: 'not-run',
   };


### PR DESCRIPTION
## Summary

Make the qualified Codex 0.144.3 App Server structured adapter the product default for new Codex attempts, retain an explicit PTY rollback, and close the provider-scoped Mac convergence qualification.

## Changes

- default new Codex 0.144.3 attempts to direct App Server stdio while retaining `KUNGFU_AGENT_SESSION_CODEX_APP_SERVER=0` as new-attempt-only PTY rollback
- freeze reviewed structured thread defaults: untrusted approval policy, user reviewer, read-only sandbox, and exact workspace cwd
- admit three real stable-schema notifications as typed telemetry only, without work, outcome, session, or proof authority
- expose bounded metadata-only adapter failure and exit diagnostics while never retaining stderr content
- extend real-provider dogfood across structured instruction/output, exact approval denial, interrupt, main reattach, exit closure, and bounded stale-plan replanning
- keep Claude PTY authority and its known approval degradation explicit rather than widening Codex evidence into Claude claims

Version impact: minor. Codex changes its default transport for the exact qualified 0.144.3 provider. The retained flag value `0` rolls new attempts back to PTY; Claude remains PTY-based.

## Verification

- `./shifu test:codex-app-server-contract:native`
- focused contract/runtime/interaction/recovery/product/surface/provider suites
- `./shifu test:agent-session-recovery-qualification`
- authenticated Mac Codex 0.144.3 source-checkout structured dogfood: full retained interaction loop passed
- authenticated Mac Claude 2.1.209 PTY dogfood: degradation retained, no approval outcome claimed
- `XDG_CACHE_HOME=/tmp/kungfu-convergence-shifu-cache ./shifu check:source` after rebasing onto `a780b2b33`: source tests 264/264, docs 61/61, TypeScript and Biome passed
- pre-commit staged gate passed
- no prompt, transcript, credential, raw terminal, stderr content, private environment value, or provider private state retained

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "stage-ready",
  "adrs": [
    "ADR-0085"
  ],
  "summary": "Make the qualified Codex 0.144.3 App Server route the default with exact typed telemetry, safe structured thread policy, real provider qualification, and explicit new-attempt PTY rollback",
  "verification": [
    "./shifu test:codex-app-server-contract:native",
    "./shifu test:codex-app-server-product",
    "./shifu test:codex-app-server-recovery",
    "./shifu test:codex-app-server-interaction",
    "./shifu test:codex-app-server-runtime",
    "./shifu test:agent-session-product-surfaces",
    "./shifu test:agent-session-recovery-qualification",
    "./shifu docs:check",
    "./shifu check:source"
  ]
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [x] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The dogfood uses official ambient CLI authentication but reads no credential or private provider state. Retained evidence is metadata-only and this PR itself performs no publication or deployment.

## Checklist

- [x] DCO-signed linear delivery commit on the latest mainline
- [x] Codex structured route is default only for the exact qualified version
- [x] Explicit PTY rollback creates a new attempt and never hot-switches
- [x] Unknown structured methods still fail closed
- [x] Claude degradation remains visible and provider-scoped
- [x] Delivery receipts claim no semantic outcome, work state, or proof
