### PR TITLE
refactor(core): classify durability commit failures through std::expected

### DIFF
--- a/docs/adr/ADR-0082-cpp23-rx-core-language-strategy.md
+++ b/docs/adr/ADR-0082-cpp23-rx-core-language-strategy.md
@@ -5,7 +5,7 @@ adr_id: ADR-0082
 decision_status: accepted
 implementation_status: staged
 implementation_commits: [a296e6dfdf3a43340093accafbee646ef97ea821, 30a849db8a93895686e53076df779717ccd79a24, 6f20d83cf79751415ed9976be310ae610a4eb4bb]
-implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/660, https://github.com/kungfu-systems/kungfu/pull/858]
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/660, https://github.com/kungfu-systems/kungfu/pull/858, https://github.com/kungfu-systems/kungfu/pull/869]
 review_state: self-reviewed
 sensitivity: public
 sources: [local-files, user-decision]

--- a/docs/adr/ADR-0082-cpp23-rx-core-language-strategy.md
+++ b/docs/adr/ADR-0082-cpp23-rx-core-language-strategy.md
@@ -4,7 +4,7 @@ doc_type: architecture-decision
 adr_id: ADR-0082
 decision_status: accepted
 implementation_status: staged
-implementation_commits: [a296e6dfdf3a43340093accafbee646ef97ea821, 30a849db8a93895686e53076df779717ccd79a24]
+implementation_commits: [a296e6dfdf3a43340093accafbee646ef97ea821, 30a849db8a93895686e53076df779717ccd79a24, 6f20d83cf79751415ed9976be310ae610a4eb4bb]
 implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/660, https://github.com/kungfu-systems/kungfu/pull/858]
 review_state: self-reviewed
 sensitivity: public
@@ -207,9 +207,14 @@ independently:
    keep their unknown-record downgrade `default` arms
    (`source_registry_unknown_record` stays). C4061 / `-Wswitch-enum`, which
    would flag those designed `default` arms, is intentionally not enabled.
-2. Write the three-tier error policy into `CONTRIBUTING`-adjacent developer
-   docs; convert the durable-ingest `catch` ladders to `expected` +
-   `transform_error` as the reference implementation.
+2. **Landed**: write the three-tier error policy into the developer
+   docs ([`docs/development/cpp-error-handling.md`](../development/cpp-error-handling.md))
+   and convert the durable-ingest barrier-commit `catch` ladder to `expected` +
+   a single `transform_error` classifier as the reference implementation
+   (`durable_ingest.cpp`, `barrier(...)`). Behaviour is unchanged: the exception
+   → ingest-error / receipt-code / message projection is identical, valid early
+   returns stay values, and a classified failure still yields an `Unknown`
+   receipt.
 3. Migrate SFINAE constraints to concepts incrementally, starting with the
    `data<T>` accessor overloads (`common.h`) and the registry `copy()` pair —
    highest-traffic diagnostics first. No flag-day.

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -6,6 +6,7 @@ workflow starts in the repository [CONTRIBUTING guide](../../CONTRIBUTING.md).
 
 - [Buildchain](buildchain.md)
 - [C++ Toolchain Contract](cpp-toolchain.md)
+- [C++ Error-Handling Policy](cpp-error-handling.md)
 - [Rust Adoption](rust-adoption.md)
 - [Versioning](versioning.md)
 - [Version and Release Design](version-release-design.md)

--- a/docs/development/cpp-error-handling.md
+++ b/docs/development/cpp-error-handling.md
@@ -1,0 +1,93 @@
+# C++ error-handling policy
+
+Kungfu's core is C++23 + Rx ([ADR-0082](../adr/ADR-0082-cpp23-rx-core-language-strategy.md)).
+Error handling is not one mechanism applied everywhere; it is a written
+three-tier policy that matches the mechanism to where the failure is handled.
+Choosing the wrong tier is what produces either silent corruption or an
+unreadable tangle of `try`/`catch`, so the tier is a design decision, not a
+matter of taste.
+
+## The three tiers
+
+### Tier 1 — exceptions at the loop / ring boundary
+
+Deep call paths that can fail for many unrelated reasons throw, and the
+exception is caught once at the owning boundary — the reactor loop, the single
+writer's publish path, an owned ring. The boundary decides liveness (stop,
+degrade, retry) with local stop ownership; intermediate frames stay free of
+error plumbing. This is the default for the runtime's control flow.
+
+Use tier 1 when the failure means "this unit of work cannot continue" and the
+only sensible reader is the boundary that owns the loop.
+
+### Tier 2 — `std::expected` at classify-and-continue seams
+
+Some seams must *not* unwind to a loop boundary: they have to classify a failure
+into a domain outcome and keep serving. Here the throwing region is captured
+once as a value and mapped through a single central classifier with
+`std::expected` + `transform_error`, instead of a hand-maintained `catch`
+ladder repeated at every such seam. One classifier is the single source of truth
+for how an exception type projects onto the domain's error code, so the mapping
+cannot drift between seams.
+
+The reference implementation is the durability barrier commit path in
+[`durable_ingest.cpp`](../../framework/core/src/libkungfu/src/runtime/durable_ingest.cpp)
+(`barrier(...)`):
+
+```cpp
+// Capture the throwing commit body once; the body's own early returns stay
+// values (a valid timeout / unsupported-profile outcome is not an error).
+auto outcome = capture_ingest_exception([&]() -> barrier_result {
+  // ... commit path that throws through native_file / fence validation ...
+  return complete_result();
+}).transform_error(classify_durability_failure); // exception_ptr -> ingest_failure
+
+if (outcome) {
+  return *outcome;                 // success or a valid early return
+}
+const ingest_failure &failure = outcome.error();
+// project the classified failure onto status + receipt, then continue serving
+result.receipt.status = receipt_status::Unknown;
+```
+
+`classify_durability_failure` is the only place that rethrows-and-catches:
+`std::logic_error` → fencing lost, `std::system_error` → I/O error, anything
+else → injected/unknown fault, each surfaced as a `ServiceUnavailable` receipt
+with an `Unknown` outcome. Adding a new seam reuses that classifier rather than
+copying a ladder.
+
+Use tier 2 when a failure must become a returned domain outcome (an error code,
+a receipt) and the caller keeps running.
+
+### Tier 3 — value-style scan paths
+
+Hot scan and decode paths — offline manifest scanners, replay/fold, the
+storage registries — do not throw for expected-but-unknown inputs. An unknown
+record is a designed state, represented as a value and handled with an explicit,
+exhaustive branch. The compile contract enforces the exhaustiveness: closed-enum
+`switch` is `-Werror=switch` / `/we4062`, and the registry welds check
+membership at compile time. A deliberate `default` arm stays legal precisely so
+these downgrade paths can name the unknown case (see
+`source_registry_unknown_record`); `-Wswitch-enum` / C4061, which would outlaw
+those arms, is intentionally off.
+
+Use tier 3 on paths where failures are frequent, expected, and part of the
+data model rather than exceptional.
+
+## Choosing a tier
+
+| Question | Tier |
+| --- | --- |
+| "This unit of work must stop; the loop boundary decides." | 1 — exception to the boundary |
+| "This must become a domain outcome and we keep serving." | 2 — `expected` + central classifier |
+| "Unknown input is normal here; branch on it." | 3 — value + exhaustive `switch` |
+
+The tiers are not ranked by preference. A commit path uses all three: it throws
+through its helpers (tier 1 mechanics), the seam classifies once (tier 2), and
+the scanners it feeds branch on unknown records (tier 3).
+
+## Related
+
+- [ADR-0082 — C++23 + Rx core language strategy](../adr/ADR-0082-cpp23-rx-core-language-strategy.md)
+- [C++ toolchain contract](cpp-toolchain.md) — the compile contract that enforces tier 3 exhaustiveness
+- Contributor workflow: [CONTRIBUTING](../../CONTRIBUTING.md)

--- a/docs/document-metadata.registry.json
+++ b/docs/document-metadata.registry.json
@@ -847,6 +847,22 @@
       "doc_type": "public-document",
       "review_state": "unreviewed",
       "sensitivity": "public"
+    },
+    "docs/development/cpp-error-handling.md": {
+      "metadata_schema": "kungfu.document-metadata/v1",
+      "document_status": "active",
+      "doc_type": "reference",
+      "review_state": "self-reviewed",
+      "sensitivity": "public",
+      "sources": [
+        "local-files",
+        "architecture-decisions"
+      ],
+      "period": "ongoing",
+      "theme": "kungfu-cpp-error-handling",
+      "confidence": "high",
+      "evidence_grade": "A",
+      "last_reviewed": "2026-07-14"
     }
   }
 }

--- a/framework/core/src/libkungfu/src/runtime/durable_ingest.cpp
+++ b/framework/core/src/libkungfu/src/runtime/durable_ingest.cpp
@@ -6,6 +6,8 @@
 #include <array>
 #include <cerrno>
 #include <cstring>
+#include <exception>
+#include <expected>
 #include <filesystem>
 #include <fstream>
 #include <limits>
@@ -36,6 +38,46 @@ using yijinjing::ownership::evidence;
 using yijinjing::ownership::lease;
 using yijinjing::ownership::scope;
 using yijinjing::storage::compute_content_hash_value;
+
+// Classify-and-continue seam (ADR-0082 tier 2). A durability commit path throws
+// through several helpers; rather than a hand-maintained catch ladder at every
+// such seam, exceptions are captured once as a value and mapped through a single
+// central classifier via `std::expected::transform_error`. The classifier is the
+// one place that decides how an exception type projects onto the ingest error /
+// receipt code / message triple, so the mapping cannot drift between seams.
+struct ingest_failure {
+  ingest_error error;
+  durability_error_code code;
+  std::string message;
+};
+
+// Run a throwing body and capture any exception as a value. The body's own
+// early returns stay values (success or a valid non-error outcome); only a
+// thrown exception becomes the unexpected branch.
+template <class F>
+auto capture_ingest_exception(F &&body) -> std::expected<std::invoke_result_t<F &>, std::exception_ptr> {
+  try {
+    return std::forward<F>(body)();
+  } catch (...) {
+    return std::unexpected(std::current_exception());
+  }
+}
+
+// The single classification point for durability commit failures. Mirrors the
+// former three-arm catch ladder exactly: fencing (logic) -> FencingLost,
+// I/O (system) -> IoError, anything else -> InjectedFault; all surface as a
+// ServiceUnavailable receipt with an Unknown outcome at the call site.
+ingest_failure classify_durability_failure(std::exception_ptr eptr) {
+  try {
+    std::rethrow_exception(eptr);
+  } catch (const std::logic_error &error) {
+    return {ingest_error::FencingLost, durability_error_code::ServiceUnavailable, error.what()};
+  } catch (const std::system_error &error) {
+    return {ingest_error::IoError, durability_error_code::ServiceUnavailable, error.what()};
+  } catch (const std::exception &error) {
+    return {ingest_error::InjectedFault, durability_error_code::ServiceUnavailable, error.what()};
+  }
+}
 
 constexpr std::array<char, 8> SEGMENT_MAGIC{'K', 'F', 'D', 'L', 'S', 'E', 'G', '2'};
 constexpr std::array<char, 8> RECORD_MAGIC{'K', 'F', 'D', 'L', 'R', 'E', 'C', '2'};
@@ -1035,7 +1077,7 @@ struct durable_ingest_log::impl {
       return complete_result();
     }
     result.receipt.position = *pending_position;
-    try {
+    const auto commit_barrier = [&]() -> barrier_result {
       validate_service_fence(service_owner);
       if (service_owner.status().generation != pending_owner_generation ||
           service_owner.status().fence_token != pending_owner_fence) {
@@ -1140,25 +1182,17 @@ struct durable_ingest_log::impl {
       current_status.persisted_request_count = completed_requests.size();
       result.error = ingest_error::None;
       return complete_result();
-    } catch (const std::logic_error &error) {
-      current_status.last_error = ingest_error::FencingLost;
-      current_status.last_error_message = error.what();
-      result.error = ingest_error::FencingLost;
-      result.receipt.error = durability_error_code::ServiceUnavailable;
-      result.message = error.what();
-    } catch (const std::system_error &error) {
-      current_status.last_error = ingest_error::IoError;
-      current_status.last_error_message = error.what();
-      result.error = ingest_error::IoError;
-      result.receipt.error = durability_error_code::ServiceUnavailable;
-      result.message = error.what();
-    } catch (const std::exception &error) {
-      current_status.last_error = ingest_error::InjectedFault;
-      current_status.last_error_message = error.what();
-      result.error = ingest_error::InjectedFault;
-      result.receipt.error = durability_error_code::ServiceUnavailable;
-      result.message = error.what();
+    };
+    auto outcome = capture_ingest_exception(commit_barrier).transform_error(classify_durability_failure);
+    if (outcome) {
+      return *outcome;
     }
+    const ingest_failure &failure = outcome.error();
+    current_status.last_error = failure.error;
+    current_status.last_error_message = failure.message;
+    result.error = failure.error;
+    result.receipt.error = failure.code;
+    result.message = failure.message;
     result.receipt.status = receipt_status::Unknown;
     return complete_result();
   }


### PR DESCRIPTION
## Summary

Land ADR-0082 staged item 2: write the three-tier error-handling policy into the
developer docs, and convert the durability barrier-commit `catch` ladder in
`durable_ingest.cpp` to `std::expected` + a single `transform_error` classifier
as the tier-2 reference implementation. This is the first use of `std::expected`
in `libkungfu`.

## Related issue

Atlas goal: 2026-07-14-kungfu-adr0082-staged-increments

## Changes

- `framework/core/src/libkungfu/src/runtime/durable_ingest.cpp`: replace the
  hand-written three-arm `catch` ladder in `barrier(...)` with
  `capture_ingest_exception(commit_barrier).transform_error(classify_durability_failure)`.
  `capture_ingest_exception` runs the throwing commit body and captures any
  exception as a value; `classify_durability_failure` is the single place that
  rethrows-and-catches, mapping the exception type onto the ingest-error /
  receipt-code / message triple. Only this classify-and-continue seam changes;
  the poison-tail append handler (which re-throws to an outer boundary) is a
  tier-1 pattern and is left as-is.
- `docs/development/cpp-error-handling.md` (new): the three-tier policy — tier 1
  exceptions to the loop/ring boundary, tier 2 `std::expected` at
  classify-and-continue seams, tier 3 value-style scan paths — with a
  when-to-use table and the `durable_ingest` reference. Registered in the
  document metadata registry and linked from the development index and ADR-0082.
- `docs/adr/ADR-0082-...md`: mark staged item 2 as landed, link the new policy
  doc, and add the item-1 mainline commit (`6f20d83c`) to
  `implementation_commits` now that it is reachable.

## Behaviour equivalence

The exception → outcome projection is identical to the former ladder:

| Caught | ingest_error | receipt error | receipt status |
| --- | --- | --- | --- |
| `std::logic_error` | `FencingLost` | `ServiceUnavailable` | `Unknown` |
| `std::system_error` | `IoError` | `ServiceUnavailable` | `Unknown` |
| other `std::exception` | `InjectedFault` | `ServiceUnavailable` | `Unknown` |

Valid early returns inside the commit body (timeout, unsupported profile) are
values, not errors, so they flow through `capture_ingest_exception` unchanged.

## Verification

- Linux / GCC (agent-120): full `build:core` green; durability ctests pass —
  `durable_ingest`, `durability_contract`, `runtime_error`, `state_service`,
  `projection_bootstrap`, `crash_recovery` (0 failures)
- Windows / MSVC (VS 18): full `build:core` green under the new `<expected>` use
- pre-commit staged gate (clang-format 20.1.8, docs metadata + link gate)

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "stage-ready",
  "adrs": ["ADR-0082"],
  "summary": "Land ADR-0082 staged item 2: write the three-tier error-handling policy into developer docs and convert the durable-ingest barrier catch ladder to std::expected + a single transform_error classifier as the tier-2 reference implementation, behaviour-equivalent",
  "verification": ["Linux/GCC full core build + durability ctests", "Windows/MSVC full core build", "pre-commit staged gate"]
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] release evidence, provenance, package publishing, or deployment surfaces
- [x] none of the above

Behaviour-preserving refactor plus developer documentation. No contract, schema,
or runtime-outcome change.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated (new error-handling policy doc + ADR)