### PR TITLE
fix(product): package Agent Session worker

### DIFF
--- a/framework/gui/scripts/bundle-core-audit.cjs
+++ b/framework/gui/scripts/bundle-core-audit.cjs
@@ -116,6 +116,11 @@ function auditPackagedApp(appDir, options = {}) {
   const resources = path.join(appDir, 'Contents', 'Resources');
   const runtimeDir = path.join(resources, 'kungfu');
   const appNodeModules = path.join(resources, 'app', 'node_modules');
+  const agentSessionPackage = path.join(
+    appNodeModules,
+    '@kungfu-tech',
+    'agent-session',
+  );
 
   if (!exists(runtimeDir)) {
     throw new Error(`missing bundled runtime directory: ${runtimeDir}`);
@@ -182,6 +187,18 @@ function auditPackagedApp(appDir, options = {}) {
   );
 
   const failures = [];
+  for (const required of [
+    'package.json',
+    path.join('src', 'product-client.mjs'),
+    path.join('src', 'product-worker.mjs'),
+  ]) {
+    const requiredPath = path.join(agentSessionPackage, required);
+    if (!exists(requiredPath)) {
+      failures.push(
+        `missing packaged Agent Session runtime file: ${requiredPath}`,
+      );
+    }
+  }
   const spawnHelpers = nodePtySpawnHelpers(appDir);
   if (spawnHelpers.length === 0) {
     failures.push('missing packaged node-pty Darwin spawn-helper');

--- a/framework/gui/scripts/bundle-core-audit.test.cjs
+++ b/framework/gui/scripts/bundle-core-audit.test.cjs
@@ -25,6 +25,13 @@ function packagedAppFixture() {
     'darwin-arm64',
     'spawn-helper',
   );
+  const agentSessionPackage = path.join(
+    resources,
+    'app',
+    'node_modules',
+    '@kungfu-tech',
+    'agent-session',
+  );
   fs.mkdirSync(runtime, { recursive: true });
   for (const name of [
     'kungfu',
@@ -36,7 +43,16 @@ function packagedAppFixture() {
   }
   fs.mkdirSync(path.dirname(helper), { recursive: true });
   fs.writeFileSync(helper, 'fixture', { mode: 0o644 });
-  return { root, app, helper };
+  for (const required of [
+    'package.json',
+    path.join('src', 'product-client.mjs'),
+    path.join('src', 'product-worker.mjs'),
+  ]) {
+    const requiredPath = path.join(agentSessionPackage, required);
+    fs.mkdirSync(path.dirname(requiredPath), { recursive: true });
+    fs.writeFileSync(requiredPath, 'fixture');
+  }
+  return { root, app, helper, agentSessionPackage };
 }
 
 test('repairs and audits the packaged node-pty Darwin spawn helper', (t) => {
@@ -50,4 +66,18 @@ test('repairs and audits the packaged node-pty Darwin spawn helper', (t) => {
   repairNodePtySpawnHelpers(fixture.app);
   assert.notEqual(fs.statSync(fixture.helper).mode & 0o111, 0);
   assert.doesNotThrow(() => auditPackagedApp(fixture.app));
+});
+
+test('rejects an app without the detached Agent Session worker', (t) => {
+  const fixture = packagedAppFixture();
+  t.after(() => fs.rmSync(fixture.root, { recursive: true, force: true }));
+
+  repairNodePtySpawnHelpers(fixture.app);
+  fs.rmSync(
+    path.join(fixture.agentSessionPackage, 'src', 'product-worker.mjs'),
+  );
+  assert.throws(
+    () => auditPackagedApp(fixture.app),
+    /missing packaged Agent Session runtime file/,
+  );
 });

--- a/product/electron-builder.yml
+++ b/product/electron-builder.yml
@@ -17,6 +17,18 @@ files:
   - "!node_modules/@kungfu-tech/**/build{,/**}"
   - "!node_modules/@kungfu-tech/**/dist/kungfu{,/**}"
 extraResources:
+  # pnpm workspace packages are symlinked outside framework/gui, so
+  # electron-builder does not follow @kungfu-tech/agent-session into the app.
+  # Ship the runtime package explicitly: product-client resolves its detached
+  # worker beside itself and node-pty from the enclosing app/node_modules.
+  - from: ../agent-session
+    to: app/node_modules/@kungfu-tech/agent-session
+    filter:
+      - package.json
+      - src/**/*
+      - kungfu-agent-session.contract.json
+      - kungfu-codex-app-server.contract.json
+      - schemas/**/*
   - from: ../core/dist/kungfu
     to: kungfu
   - from: resources/cli


### PR DESCRIPTION
## Summary

Package the detached Agent Session runtime explicitly so the desktop application's main process can resolve the structured Codex product client and launch its packaged worker.

## Changes

- copy the workspace-linked @kungfu-tech/agent-session runtime, contracts, and pinned schemas into the application resources
- extend the post-package audit to fail when the product client or detached worker is absent
- add a regression fixture proving a package without the worker is rejected

Version impact: patch. This fixes packaging of the already-integrated ADR-0085 product route without changing its architecture contract, wire contract, default transport, or rollback policy.

## Verification

- node --test framework/gui/scripts/bundle-core-audit.test.cjs
- XDG_CACHE_HOME=/tmp/kungfu-packaged-worker-source-cache ./shifu check:source
- ./shifu dist:dir
- post-package audit against the real unsigned macOS arm64 .app
- Electron main-process resolution of @kungfu-tech/agent-session/product-client
- authenticated packaged-app Codex 0.144.3 structured dogfood: start, instruction/output, exact approval denial, interrupt, main restart reattach, and provider exit all passed
- approval probe file was not created
- git diff --check
- staged pre-commit gate

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This patch only restores the packaged files required by the already-integrated ADR-0085 product route and adds a package audit regression; it does not change the architecture contract."
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [x] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The packaged dogfood uses ambient CLI authentication but retains no credential, prompt, transcript, raw terminal, stderr content, or private provider state. The build is an unsigned local qualification artifact and this PR does not publish or promote it.

## Checklist

- [x] Commit is signed off (DCO)
- [x] Post-package audit prevents recurrence
- [x] Existing structured transport and PTY rollback contracts are unchanged
- [x] Documentation does not change because this is a packaging correction
