### PR TITLE
refactor(core): migrate the highest-traffic SFINAE overloads to concepts

### DIFF
--- a/docs/adr/ADR-0082-cpp23-rx-core-language-strategy.md
+++ b/docs/adr/ADR-0082-cpp23-rx-core-language-strategy.md
@@ -5,7 +5,7 @@ adr_id: ADR-0082
 decision_status: accepted
 implementation_status: staged
 implementation_commits: [a296e6dfdf3a43340093accafbee646ef97ea821, 30a849db8a93895686e53076df779717ccd79a24, 6f20d83cf79751415ed9976be310ae610a4eb4bb, 531d40d899685c5a86a51ae721d6388bbe384680]
-implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/660, https://github.com/kungfu-systems/kungfu/pull/858, https://github.com/kungfu-systems/kungfu/pull/869]
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/660, https://github.com/kungfu-systems/kungfu/pull/858, https://github.com/kungfu-systems/kungfu/pull/869, https://github.com/kungfu-systems/kungfu/pull/871]
 review_state: self-reviewed
 sensitivity: public
 sources: [local-files, user-decision]

--- a/docs/adr/ADR-0082-cpp23-rx-core-language-strategy.md
+++ b/docs/adr/ADR-0082-cpp23-rx-core-language-strategy.md
@@ -4,7 +4,7 @@ doc_type: architecture-decision
 adr_id: ADR-0082
 decision_status: accepted
 implementation_status: staged
-implementation_commits: [a296e6dfdf3a43340093accafbee646ef97ea821, 30a849db8a93895686e53076df779717ccd79a24, 6f20d83cf79751415ed9976be310ae610a4eb4bb]
+implementation_commits: [a296e6dfdf3a43340093accafbee646ef97ea821, 30a849db8a93895686e53076df779717ccd79a24, 6f20d83cf79751415ed9976be310ae610a4eb4bb, 531d40d899685c5a86a51ae721d6388bbe384680]
 implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/660, https://github.com/kungfu-systems/kungfu/pull/858, https://github.com/kungfu-systems/kungfu/pull/869]
 review_state: self-reviewed
 sensitivity: public
@@ -215,9 +215,15 @@ independently:
    → ingest-error / receipt-code / message projection is identical, valid early
    returns stay values, and a classified failure still yields an `Unknown`
    receipt.
-3. Migrate SFINAE constraints to concepts incrementally, starting with the
-   `data<T>` accessor overloads (`common.h`) and the registry `copy()` pair —
-   highest-traffic diagnostics first. No flag-day.
+3. **In progress** (first batch landed): migrate SFINAE constraints to concepts
+   incrementally. The first batch converts the `event::data<T>()` accessor
+   overloads (`common.h`, now selected by a named `frame_inline_payload<T>`
+   concept + `requires`) and the registry `copy()` pair (`schema/registry.h`,
+   `requires size_fixed_v` / `requires (not size_fixed_v)`) — the
+   highest-traffic diagnostics. The two overloads in each pair stay mutually
+   exclusive by construction; the payoff is that an unsatisfied constraint now
+   reports "constraints not satisfied" instead of a bare "no type named 'type'
+   in enable_if". No flag-day: remaining SFINAE sites migrate in later batches.
 4. Opportunistic: deducing this where CRTP is boilerplate; ranges where the
    `reader.cpp` TODO already points.
 

--- a/framework/core/src/libyijinjing/include/kungfu/common.h
+++ b/framework/core/src/libyijinjing/include/kungfu/common.h
@@ -278,6 +278,14 @@ struct size_fixed<DataType, std::enable_if_t<std::is_class_v<DataType> and DataT
 template <typename DataType> static constexpr bool size_fixed_v = size_fixed<DataType>::value;
 template <typename DataType> static constexpr bool size_unfixed_v = not size_fixed<DataType>::value;
 
+// An event payload whose bytes live inline in the frame's memory -- a fixed-size
+// POD, or a json blob stored whole -- is returned by const reference into that
+// memory; any other type is materialized by value from the byte span. This
+// concept is the discriminator event::data<T>() selects its two access
+// strategies on, replacing a pair of mutually exclusive enable_if overloads.
+template <typename T>
+concept frame_inline_payload = size_fixed_v<T> or std::is_same_v<T, nlohmann::json>;
+
 template <typename ValueType>
 static constexpr bool is_signed_int_v = std::is_integral_v<ValueType> and (sizeof(ValueType) <= 4) and
                                         not std::is_same_v<ValueType, bool> and std::is_signed_v<ValueType>;
@@ -480,12 +488,15 @@ struct event {
    * @tparam T
    * @return a casted reference to the underlying memory address
    */
-  template <typename T> std::enable_if_t<size_fixed_v<T> or std::is_same_v<T, nlohmann::json>, const T &> data() const {
+  template <typename T>
+    requires frame_inline_payload<T>
+  const T &data() const {
     return *(reinterpret_cast<const T *>(data_address()));
   }
 
   template <typename T>
-  std::enable_if_t<not size_fixed_v<T> and not std::is_same_v<T, nlohmann::json>, const T> data() const {
+    requires(not frame_inline_payload<T>)
+  const T data() const {
     return T(data_as_bytes(), data_length());
   }
 

--- a/framework/core/src/libyijinjing/include/kungfu/yijinjing/schema/registry.h
+++ b/framework/core/src/libyijinjing/include/kungfu/yijinjing/schema/registry.h
@@ -363,11 +363,15 @@ DECLARE_PTR(StateMapType)
 using StateDequeMapType = decltype(build_state_deque_map(StateDataTypes));
 DECLARE_PTR(StateDequeMapType)
 
-template <typename DataType> std::enable_if_t<size_fixed_v<DataType>> copy(DataType &to, const DataType &from) {
+template <typename DataType>
+  requires size_fixed_v<DataType>
+void copy(DataType &to, const DataType &from) {
   memcpy(&to, &from, sizeof(DataType));
 }
 
-template <typename DataType> std::enable_if_t<not size_fixed_v<DataType>> copy(DataType &to, const DataType &from) {
+template <typename DataType>
+  requires(not size_fixed_v<DataType>)
+void copy(DataType &to, const DataType &from) {
   boost::hana::for_each(boost::hana::accessors<DataType>(), [&](auto it) {
     auto accessor = boost::hana::second(it);
     accessor(to) = accessor(from);


### PR DESCRIPTION
## Summary

First batch of ADR-0082 staged item 3: migrate the two highest-traffic
`enable_if` SFINAE overload pairs in the core to C++20 concepts. `libyijinjing`
already compiles as C++20, and these two pairs are the most-instantiated
diagnostics surface in the codebase.

## Related issue

Atlas goal: 2026-07-14-kungfu-adr0082-staged-increments

## Changes

- `framework/core/src/libyijinjing/include/kungfu/common.h`: add a named
  `frame_inline_payload<T>` concept (`size_fixed_v<T> or std::is_same_v<T,
  nlohmann::json>`) and select the two `event::data<T>()` accessor overloads on
  `requires frame_inline_payload<T>` / `requires (not frame_inline_payload<T>)`.
  The return type (`const T &` vs `const T`) is now stated directly instead of
  wrapped in `std::enable_if_t<..., R>`.
- `framework/core/src/libyijinjing/include/kungfu/yijinjing/schema/registry.h`:
  select the `copy()` pair on `requires size_fixed_v<DataType>` / `requires (not
  size_fixed_v<DataType>)`, returning `void` directly.
- `docs/adr/ADR-0082-...md`: mark staged item 3 in progress (first batch landed)
  and add the item-2 mainline commit (`531d40d8`) to `implementation_commits`.

## Equivalence

Each pair's two constraints are exact negations, so overload resolution selects
the same overload for every `T` as the former `enable_if` pair — a
behaviour-preserving refactor. The observable change is diagnostics: an
unsatisfied constraint reports `constraints not satisfied` at the call site
rather than a bare `no type named 'type' in 'std::enable_if_t<...>'`.

This is the first use of concepts in the core; `enable_if` elsewhere migrates in
later batches, no flag-day.

## Verification

- Linux / GCC (agent-120): full `build:core` green — every translation unit that
  instantiates `event::data<T>()` or `copy()` recompiles under the new
  constraints; durability / journal / recovery ctests pass
- Windows / MSVC (VS 18): full `build:core` green
- pre-commit staged gate (clang-format 20.1.8)

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "stage-ready",
  "adrs": ["ADR-0082"],
  "summary": "First batch of ADR-0082 staged item 3: migrate the two highest-traffic enable_if overload pairs (event::data<T>() and registry copy()) to C++20 concepts, a behaviour-preserving refactor that improves constraint diagnostics",
  "verification": ["Linux/GCC full core build + ctests", "Windows/MSVC full core build", "pre-commit staged gate"]
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] release evidence, provenance, package publishing, or deployment surfaces
- [x] none of the above

Behaviour-preserving compile-time refactor of two overload constraints.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated (ADR staged-item status)