### PR TITLE
fix(agent-session): qualify packaged provider control

### DIFF
--- a/docs/adr/ADR-0081-durable-agent-session-capsule-control-plane.md
+++ b/docs/adr/ADR-0081-durable-agent-session-capsule-control-plane.md
@@ -204,7 +204,7 @@ evidence input under Profile/KFD authority.
 - Privacy configuration governs raw prompt/output retention; secrets and
   environment values are not part of lifecycle or control facts.
 - Synthetic provider qualification can prove host/transport invariants, but
-  final product promotion still requires real Codex and Claude interactive
+  product promotion also requires packaged real Codex and Claude interactive
   smoke.
 
 ## Implementation and qualification stages
@@ -243,6 +243,10 @@ passes instruction/output, approval denial, interrupt, main restart, and exit
 closure. Authenticated Claude Code `2.1.209` now passes the same loop under an
 explicit `Bash` ask rule: current VT-grid state overrides an erased volatile
 busy signature, the real approval modal is detected, Escape is delivered, and
-the disposable probe remains absent. Machine restart, Linux/Windows
-qualification, and packaged/promoted Mac product evidence remain open, so
-`promotionEligible` is false and the implementation status remains partial.
+the disposable probe remains absent. The packaged Mac build
+`20260714T150829Z-237b7662f` passes Codex PTY, Codex structured, and Claude PTY
+loops through the packaged worker, retains no raw terminal or private
+environment values, and is promoted at `/Applications/Kungfu Episodes.app`.
+Machine restart and Linux/Windows qualification remain open, so the
+implementation status remains partial even though Mac `promotionEligible` is
+true and the qualified build is current.

--- a/docs/adr/ADR-0081-durable-agent-session-capsule-control-plane.md
+++ b/docs/adr/ADR-0081-durable-agent-session-capsule-control-plane.md
@@ -240,9 +240,9 @@ terminates provider PTYs when worker authority ends. Synthetic Mac source
 qualification covers restart reattachment, worker loss, provider exit, bounded
 overflow, receipt privacy, and local RPC latency. Authenticated Codex `0.144.3`
 passes instruction/output, approval denial, interrupt, main restart, and exit
-closure. Authenticated Claude Code `2.1.209` passes start, temporary workspace
-trust, instruction/output, and main restart, but its approval-needed state did
-not converge within the bounded qualification window; no deny-key or approval
-outcome is claimed. Machine restart, Linux/Windows qualification, the complete
-Claude loop, and promoted Mac product evidence remain open, so
+closure. Authenticated Claude Code `2.1.209` now passes the same loop under an
+explicit `Bash` ask rule: current VT-grid state overrides an erased volatile
+busy signature, the real approval modal is detected, Escape is delivered, and
+the disposable probe remains absent. Machine restart, Linux/Windows
+qualification, and packaged/promoted Mac product evidence remain open, so
 `promotionEligible` is false and the implementation status remains partial.

--- a/docs/qualification/evidence/agent-session/stage6-macos-source-v1.json
+++ b/docs/qualification/evidence/agent-session/stage6-macos-source-v1.json
@@ -62,8 +62,60 @@
       "privateEnvironmentValuesRetained": false
     }
   },
+  "packagedProductQualification": {
+    "status": "passed",
+    "build": {
+      "id": "20260714T150829Z-237b7662f",
+      "commit": "237b7662fc3052144be7d45e1078abcc14c4bef2",
+      "worker": "packaged-app",
+      "catalogState": "current",
+      "installedPath": "/Applications/Kungfu Episodes.app",
+      "installedAgentSessionFilesMatchCandidate": true,
+      "nodePtySpawnHelpersExecutable": true
+    },
+    "authenticatedProviders": {
+      "codexPty": {
+        "version": "0.144.3",
+        "status": "passed",
+        "durationMilliseconds": 13840,
+        "transport": "pty",
+        "casesPassed": 6,
+        "casesTotal": 6,
+        "rawTerminalRetained": false,
+        "privateEnvironmentValuesRetained": false
+      },
+      "codexStructured": {
+        "version": "0.144.3",
+        "status": "passed",
+        "durationMilliseconds": 18848,
+        "transport": "structured",
+        "casesPassed": 6,
+        "casesTotal": 6,
+        "rawTerminalRetained": false,
+        "privateEnvironmentValuesRetained": false,
+        "rollback": "KUNGFU_AGENT_SESSION_CODEX_APP_SERVER=0 creates a new PTY attempt"
+      },
+      "claudePty": {
+        "version": "2.1.209",
+        "status": "passed",
+        "durationMilliseconds": 15514,
+        "transport": "pty",
+        "casesPassed": 6,
+        "casesTotal": 6,
+        "approvalPolicy": "explicit-bash-ask",
+        "qualificationProfile": {
+          "model": "sonnet",
+          "effort": "low"
+        },
+        "temporaryWorkspaceTrustAccepted": false,
+        "rawTerminalRetained": false,
+        "privateEnvironmentValuesRetained": false
+      }
+    }
+  },
   "linuxQualification": "not-run",
   "windowsQualification": "not-run",
-  "promotionEligible": false,
-  "promotionBlock": "packaged Mac dual-provider qualification and product promotion are not yet complete"
+  "machineRestartQualification": "not-run",
+  "promotionEligible": true,
+  "promotionStatus": "promoted"
 }

--- a/docs/qualification/evidence/agent-session/stage6-macos-source-v1.json
+++ b/docs/qualification/evidence/agent-session/stage6-macos-source-v1.json
@@ -23,6 +23,8 @@
     "codex": {
       "version": "0.144.3",
       "status": "passed",
+      "worker": "source-checkout",
+      "durationMilliseconds": 23224,
       "cases": {
         "start": "passed",
         "instructAndObserveOutput": "passed",
@@ -31,21 +33,31 @@
         "mainRestartReattach": "passed",
         "providerEndClosesInput": "passed"
       },
+      "approvalPolicy": "provider-untrusted-approval",
+      "convergenceTimeoutMilliseconds": 90000,
       "rawTerminalRetained": false,
       "privateEnvironmentValuesRetained": false
     },
     "claude": {
       "version": "2.1.209",
-      "status": "degraded",
-      "passedCases": [
-        "start",
-        "temporaryWorkspaceTrust",
-        "instructAndObserveOutput",
-        "mainRestartReattach"
-      ],
-      "blockingCase": "approval-needed state did not converge within 90000ms",
-      "denyKeyWritten": false,
-      "approvalOutcome": null,
+      "status": "passed",
+      "worker": "source-checkout",
+      "durationMilliseconds": 10413,
+      "cases": {
+        "start": "passed",
+        "instructAndObserveOutput": "passed",
+        "approvalDetectedAndDenyKeyWritten": "passed",
+        "interruptDelivered": "passed",
+        "mainRestartReattach": "passed",
+        "providerEndClosesInput": "passed"
+      },
+      "approvalPolicy": "explicit-bash-ask",
+      "qualificationProfile": {
+        "model": "sonnet",
+        "effort": "low",
+        "convergenceTimeoutMilliseconds": 90000
+      },
+      "temporaryWorkspaceTrustAccepted": false,
       "rawTerminalRetained": false,
       "privateEnvironmentValuesRetained": false
     }
@@ -53,5 +65,5 @@
   "linuxQualification": "not-run",
   "windowsQualification": "not-run",
   "promotionEligible": false,
-  "promotionBlock": "authenticated Claude approval and deny-key loop is incomplete"
+  "promotionBlock": "packaged Mac dual-provider qualification and product promotion are not yet complete"
 }

--- a/framework/agent-session/README.md
+++ b/framework/agent-session/README.md
@@ -93,8 +93,12 @@ same cases with an explicit `Bash` ask rule under `sonnet`/`low`; its real tool
 approval is detected and denied with Escape before the disposable probe can
 run. Current VT-grid state supersedes erased volatile busy signatures without
 weakening unknown/modal fail-closed behavior. Raw terminal bytes and
-environment values are never written to the retained report. Promotion remains
-blocked until the packaged Mac product passes the same dual-provider loop.
+environment values are never written to the retained report. Packaged build
+`20260714T150829Z-237b7662f` passes the same six-case loop for Codex PTY,
+Codex structured transport, and Claude PTY through the packaged worker. Its
+installed Agent Session files match the candidate and both node-pty
+`spawn-helper` binaries remain executable; the build is the current promoted
+Mac product. Machine-restart and Linux/Windows qualification remain open.
 
 Run the focused qualification through Shifu:
 

--- a/framework/agent-session/README.md
+++ b/framework/agent-session/README.md
@@ -88,11 +88,13 @@ The retained Mac source qualification proves main-process reconnect, provider
 exit fencing, worker-loss fail-closed behavior, bounded overflow gaps, receipt
 privacy, and sub-millisecond local RPC p95. Authenticated Codex 0.144.3 passes
 start, instruction/output, approval detection plus deny-key delivery,
-interrupt, reconnect, and end. Claude Code 2.1.209 passes start, temporary
-workspace trust, instruction/output, and reconnect, but its real tool-approval
-state did not converge to a supported signature; promotion remains blocked by
-that explicit degraded result. Raw terminal bytes and environment values are
-never written to the retained report.
+interrupt, reconnect, and end. Authenticated Claude Code 2.1.209 passes the
+same cases with an explicit `Bash` ask rule under `sonnet`/`low`; its real tool
+approval is detected and denied with Escape before the disposable probe can
+run. Current VT-grid state supersedes erased volatile busy signatures without
+weakening unknown/modal fail-closed behavior. Raw terminal bytes and
+environment values are never written to the retained report. Promotion remains
+blocked until the packaged Mac product passes the same dual-provider loop.
 
 Run the focused qualification through Shifu:
 

--- a/framework/agent-session/src/interaction-port.mjs
+++ b/framework/agent-session/src/interaction-port.mjs
@@ -1,4 +1,9 @@
 const MODES = new Set(['when-ready', 'queue', 'interrupt']);
+const PROVIDER_INPUT_WAIT = new Int32Array(new SharedArrayBuffer(4));
+
+function pauseProviderInput(milliseconds) {
+  Atomics.wait(PROVIDER_INPUT_WAIT, 0, 0, milliseconds);
+}
 
 function required(value, label) {
   if (typeof value !== 'string' || value.length === 0) {
@@ -26,6 +31,7 @@ export class AgentSessionInteractionPort {
     adapter,
     queueLimit = 32,
     now = () => Date.now(),
+    pause = pauseProviderInput,
   }) {
     if (
       !host ||
@@ -49,6 +55,12 @@ export class AgentSessionInteractionPort {
         'interaction port requires a provider adapter',
       );
     }
+    if (typeof pause !== 'function') {
+      throw new InteractionPortError(
+        'invalid_argument',
+        'interaction port pause must be a function',
+      );
+    }
     if (!Number.isSafeInteger(queueLimit) || queueLimit < 1) {
       throw new InteractionPortError(
         'invalid_argument',
@@ -60,6 +72,7 @@ export class AgentSessionInteractionPort {
     this.adapter = adapter;
     this.queueLimit = queueLimit;
     this.now = now;
+    this.pause = pause;
     this.queue = [];
   }
 
@@ -269,7 +282,16 @@ export class AgentSessionInteractionPort {
 
   #deliverInstruction(request) {
     const data = this.adapter.encodeInstruction(request.text);
-    const deliveryReceipt = this.transport.submitInput({ ...request, data });
+    let deliveryReceipt = this.transport.submitInput({ ...request, data });
+    if (this.adapter.instructionSubmitStrategy === 'separate-enter') {
+      this.pause(this.adapter.instructionSubmitDelayMilliseconds);
+      deliveryReceipt = this.transport.submitInput({
+        ...request,
+        actionId: `${request.actionId}:submit`,
+        inputId: `${request.inputId}:submit`,
+        data: this.adapter.instructionSubmitData,
+      });
+    }
     return {
       schema: 'kungfu.agent-session.interaction-receipt/v1',
       operation: 'instruct',

--- a/framework/agent-session/src/product-surface.mjs
+++ b/framework/agent-session/src/product-surface.mjs
@@ -79,6 +79,7 @@ function publicStatus(session) {
     inputAdmission: status.inputAdmission,
     foreground: status.foreground,
     output: status.output,
+    exit: status.exit,
     providerAdapter: status.providerAdapter,
     queuedInstructions: status.queuedInstructions,
     binding: session.binding,

--- a/framework/agent-session/src/provider-adapters.mjs
+++ b/framework/agent-session/src/provider-adapters.mjs
@@ -23,6 +23,11 @@ const PROVIDER_PROFILES = {
     testedVersions: ['2.1.209'],
     signatures: {
       approval: [
+        ['claude.approval.needs-permission', /claude needs your permission/iu],
+        [
+          'claude.approval.permission-rule',
+          /permission rule bash requires confirmation/iu,
+        ],
         ['claude.approval.proceed', /do you want to proceed\?/iu],
         ['claude.approval.permission', /allow (?:this|the) action/iu],
         [
@@ -143,6 +148,21 @@ function latestVolatileState(profile, volatileTail) {
   return candidates[0] ?? null;
 }
 
+function currentScreenState(profile, screen) {
+  const approval = matches(profile.signatures.approval, screen);
+  if (approval) {
+    return { state: 'approval-needed', signatureId: approval };
+  }
+  const busy = matches(profile.signatures.busy, screen);
+  if (busy) return { state: 'busy', signatureId: busy };
+  const ready = matches(profile.signatures.ready, screen);
+  if (ready) return { state: 'ready', signatureId: ready };
+  if (GENERIC_MODAL.test(screen)) {
+    return { state: 'unknown', signatureId: null };
+  }
+  return null;
+}
+
 function interactionResult({
   state,
   signatureId = null,
@@ -222,6 +242,10 @@ export function createProviderAdapter({ provider, version }) {
     provider,
     providerVersion: version,
     adapterVersion: profile.adapterVersion,
+    instructionSubmitStrategy:
+      provider === 'claude' ? 'separate-enter' : 'inline-enter',
+    instructionSubmitData: provider === 'claude' ? '\r' : null,
+    instructionSubmitDelayMilliseconds: provider === 'claude' ? 50 : 0,
     compatible,
     tested,
     knownLimits: [
@@ -254,6 +278,17 @@ export function createProviderAdapter({ provider, version }) {
           compatible: false,
         });
       }
+      const screen = cleanScreen(lines);
+      const current = currentScreenState(profile, screen);
+      if (current) {
+        return interactionResult({
+          state: current.state,
+          signatureId: current.signatureId,
+          reason:
+            current.state === 'unknown' ? 'unrecognized-modal-state' : null,
+          compatible: true,
+        });
+      }
       const latest = latestVolatileState(profile, volatileTail);
       if (latest) {
         return interactionResult({
@@ -261,31 +296,6 @@ export function createProviderAdapter({ provider, version }) {
           signatureId: latest.signatureId,
           reason:
             latest.state === 'unknown' ? 'unrecognized-modal-state' : null,
-          compatible: true,
-        });
-      }
-      const screen = cleanScreen(lines);
-      const approval = matches(profile.signatures.approval, screen);
-      if (approval) {
-        return interactionResult({
-          state: 'approval-needed',
-          signatureId: approval,
-          compatible: true,
-        });
-      }
-      const busy = matches(profile.signatures.busy, screen);
-      if (busy) {
-        return interactionResult({
-          state: 'busy',
-          signatureId: busy,
-          compatible: true,
-        });
-      }
-      const ready = matches(profile.signatures.ready, screen);
-      if (ready) {
-        return interactionResult({
-          state: 'ready',
-          signatureId: ready,
           compatible: true,
         });
       }
@@ -310,7 +320,8 @@ export function createProviderAdapter({ provider, version }) {
       if (Buffer.byteLength(text, 'utf8') > 64 * 1024) {
         throw new Error('instruction exceeds the 64 KiB atomic paste limit');
       }
-      return `\u001b[200~${text}\u001b[201~\r`;
+      const submit = provider === 'claude' ? '' : '\r';
+      return `\u001b[200~${text}\u001b[201~${submit}`;
     },
     encodeKey(key) {
       const sequence = KEY_SEQUENCES[key];

--- a/framework/agent-session/src/provider-adapters.mjs
+++ b/framework/agent-session/src/provider-adapters.mjs
@@ -38,6 +38,10 @@ const PROVIDER_PROFILES = {
           'claude.approval.run-command',
           /do you want to run (?:this|the) command/iu,
         ],
+        [
+          'claude.approval.bash-confirmation',
+          /(?=[\s\S]*\bbash\b)(?=[\s\S]*\b(?:allow|approve|proceed)\b)/iu,
+        ],
       ],
       busy: [['claude.busy.interrupt-hint', /esc to interrupt/iu]],
       ready: [

--- a/framework/agent-session/tests/fixtures/provider-adapters/claude-v2.1.209.json
+++ b/framework/agent-session/tests/fixtures/provider-adapters/claude-v2.1.209.json
@@ -30,6 +30,18 @@
     "signatureId": "claude.approval.proceed"
   },
   {
+    "id": "claude-approval-permission-title-redacted",
+    "lines": ["Claude needs your permission", "Bash command", "Esc to cancel"],
+    "expectedState": "approval-needed",
+    "signatureId": "claude.approval.needs-permission"
+  },
+  {
+    "id": "claude-approval-permission-rule-redacted",
+    "lines": ["Bash command", "Permission rule Bash requires confirmation", "Esc to cancel"],
+    "expectedState": "approval-needed",
+    "signatureId": "claude.approval.permission-rule"
+  },
+  {
     "id": "claude-approval-command-redacted",
     "lines": ["Allow this command?", "Esc to cancel"],
     "expectedState": "approval-needed",

--- a/framework/agent-session/tests/fixtures/provider-adapters/claude-v2.1.209.json
+++ b/framework/agent-session/tests/fixtures/provider-adapters/claude-v2.1.209.json
@@ -48,6 +48,12 @@
     "signatureId": "claude.approval.allow-command"
   },
   {
+    "id": "claude-approval-bash-confirmation-with-ready-prompt-redacted",
+    "lines": ["Bash", "Allow", "❯"],
+    "expectedState": "approval-needed",
+    "signatureId": "claude.approval.bash-confirmation"
+  },
+  {
     "id": "claude-unknown-redacted",
     "lines": ["A provider screen with no supported state marker"],
     "expectedState": "unknown",

--- a/framework/agent-session/tests/interaction-port.test.mjs
+++ b/framework/agent-session/tests/interaction-port.test.mjs
@@ -42,6 +42,7 @@ function fixture({
   provider = 'codex',
   version = '0.144.3',
   queueLimit = 4,
+  pause,
 } = {}) {
   const child = new FakePtyProcess();
   const host = new AgentSessionCapsuleHost({
@@ -83,6 +84,7 @@ function fixture({
     adapter,
     queueLimit,
     now: () => 1001,
+    ...(pause ? { pause } : {}),
   });
   const authority = {
     leaseId: 'lease-1',
@@ -137,6 +139,30 @@ test('ready instruction is one idempotent atomic paste and proves no outcome', (
     () =>
       port.instruct(instruction(authority, 'newline', { text: 'unsafe\n' })),
     /cannot end with Enter/u,
+  );
+});
+
+test('Claude instruction submits paste and Enter as separately idempotent writes', () => {
+  const pauses = [];
+  const { authority, child, port, screen } = fixture({
+    provider: 'claude',
+    version: '2.1.209',
+    pause: (milliseconds) => pauses.push(milliseconds),
+  });
+  screen('❯ Ask about this workspace');
+  const request = instruction(authority, 'claude-ready');
+  const first = port.instruct(request);
+  const duplicate = port.instruct(request);
+  assert.equal(first.status, 'written');
+  assert.equal(duplicate.status, 'duplicate');
+  assert.deepEqual(child.writes, [
+    '\u001b[200~instruction claude-ready\u001b[201~',
+    '\r',
+  ]);
+  assert.deepEqual(pauses, [50, 50]);
+  assert.equal(
+    first.deliveryReceipt.proves,
+    'validated-input-written-to-pty-only',
   );
 });
 

--- a/framework/agent-session/tests/product-surface.test.mjs
+++ b/framework/agent-session/tests/product-surface.test.mjs
@@ -453,6 +453,25 @@ test('the published v2 schema admits the Core registry and excludes presentation
   assert.equal('presentation' in schema.properties, false);
 });
 
+test('provider exit metadata remains visible without retaining terminal output', () => {
+  const { clients, input, runtime } = fixture();
+  const ref = {
+    workConsoleId: input.workConsoleId,
+    sessionAttemptId: input.sessionAttemptId,
+  };
+  clients.gui.start(clients.gui.planStart(input), {
+    attachmentId: 'view:go-card',
+    presentation: 'go-card-side-console',
+  });
+  runtime.list()[0].child.emit('exit', { exitCode: 64, signal: 0 });
+  const status = clients.cli.show(ref);
+  assert.equal(status.lifecycleState, 'ended');
+  assert.equal(status.inputAdmission, 'closed');
+  assert.equal(status.exit.exitCode, 64);
+  assert.equal(status.exit.signal, 0);
+  assert.doesNotMatch(JSON.stringify(status.exit), /terminal|stderr|output/iu);
+});
+
 test('controller lease has one winner and transfers only after exact release', () => {
   const { clients, input, runtime, surface } = fixture();
   const ref = {

--- a/framework/agent-session/tests/provider-adapters.test.mjs
+++ b/framework/agent-session/tests/provider-adapters.test.mjs
@@ -102,35 +102,83 @@ test('Claude volatile state uses the latest bounded signature and fails closed o
     inspect('Try "edit manual mode\nDo you want to proceed?').state,
     'approval-needed',
   );
+  assert.deepEqual(
+    inspect('Try "edit manual mode\nClaude needs your permission').signatureIds,
+    ['claude.approval.needs-permission'],
+  );
   const unknown = inspect('Try "edit manual mode\nPermission required');
   assert.equal(unknown.state, 'unknown');
   assert.equal(unknown.reason, 'unrecognized-modal-state');
 });
 
-test('instruction encoding is one bounded bracketed-paste frame with one Enter', () => {
+test('Claude current VT grid supersedes erased volatile states', () => {
   const adapter = createProviderAdapter({
+    provider: 'claude',
+    version: '2.1.209',
+  });
+  const inspect = (lines, volatileTail) =>
+    adapter.inspect({
+      lines,
+      volatileTail,
+      lifecycleState: 'ready',
+      inputAdmission: 'open',
+      foreground: { provider: 'claude' },
+    });
+  assert.equal(
+    inspect(['❯ Try a task'], 'Thinking… (esc to interrupt)').state,
+    'ready',
+  );
+  assert.equal(
+    inspect(['Thinking… (esc to interrupt)'], 'Claude needs your permission')
+      .state,
+    'busy',
+  );
+  const modal = inspect(
+    ['Permission required', '❯ Try a task'],
+    'Thinking… (esc to interrupt)',
+  );
+  assert.equal(modal.state, 'ready');
+  assert.deepEqual(modal.signatureIds, ['claude.ready.prompt']);
+});
+
+test('instruction encoding uses each provider bounded paste submit sequence', () => {
+  const codex = createProviderAdapter({
     provider: 'codex',
     version: '0.144.3',
   });
   assert.equal(
-    adapter.encodeInstruction('inspect the source'),
+    codex.encodeInstruction('inspect the source'),
     '\u001b[200~inspect the source\u001b[201~\r',
   );
+  const claude = createProviderAdapter({
+    provider: 'claude',
+    version: '2.1.209',
+  });
+  assert.equal(
+    claude.encodeInstruction('inspect the source'),
+    '\u001b[200~inspect the source\u001b[201~',
+  );
+  assert.equal(claude.instructionSubmitStrategy, 'separate-enter');
+  assert.equal(claude.instructionSubmitData, '\r');
+  assert.equal(claude.instructionSubmitDelayMilliseconds, 50);
+  assert.equal(codex.instructionSubmitStrategy, 'inline-enter');
+  assert.equal(codex.instructionSubmitData, null);
+  assert.equal(codex.instructionSubmitDelayMilliseconds, 0);
   assert.throws(
-    () => adapter.encodeInstruction('already submitted\n'),
+    () => codex.encodeInstruction('already submitted\n'),
     /cannot end with Enter/u,
   );
   assert.throws(
-    () => adapter.encodeInstruction('unsafe\u001bsequence'),
+    () => codex.encodeInstruction('unsafe\u001bsequence'),
     /escape bytes/u,
   );
   assert.throws(
-    () => adapter.encodeInstruction('x'.repeat(65 * 1024)),
+    () => codex.encodeInstruction('x'.repeat(65 * 1024)),
     /64 KiB/u,
   );
-  assert.equal(adapter.encodeKey('Enter'), '\r');
+  assert.equal(codex.encodeKey('Enter'), '\r');
   assert.throws(
-    () => adapter.encodeKey('Ctrl-Alt-Delete'),
+    () => codex.encodeKey('Ctrl-Alt-Delete'),
     /unsupported semantic key/u,
   );
 });

--- a/framework/agent-session/tests/provider-adapters.test.mjs
+++ b/framework/agent-session/tests/provider-adapters.test.mjs
@@ -139,6 +139,14 @@ test('Claude current VT grid supersedes erased volatile states', () => {
   );
   assert.equal(modal.state, 'ready');
   assert.deepEqual(modal.signatureIds, ['claude.ready.prompt']);
+  const approvalWithReadyPrompt = inspect(
+    ['Bash', 'Allow', '❯ Try a task'],
+    'Thinking… (esc to interrupt)',
+  );
+  assert.equal(approvalWithReadyPrompt.state, 'approval-needed');
+  assert.deepEqual(approvalWithReadyPrompt.signatureIds, [
+    'claude.approval.bash-confirmation',
+  ]);
 });
 
 test('instruction encoding uses each provider bounded paste submit sequence', () => {

--- a/scripts/run-agent-session-provider-dogfood.mjs
+++ b/scripts/run-agent-session-provider-dogfood.mjs
@@ -1,6 +1,13 @@
 import { spawn } from 'node:child_process';
 import { createHash } from 'node:crypto';
-import { chmodSync, cpSync, statSync } from 'node:fs';
+import {
+  constants,
+  accessSync,
+  chmodSync,
+  cpSync,
+  existsSync,
+  statSync,
+} from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import { createRequire } from 'node:module';
 import path from 'node:path';
@@ -11,6 +18,10 @@ import { createDetachedAgentSessionHost } from '../framework/agent-session/src/p
 
 const PROFILE_ROOT = `sha256:${'8'.repeat(64)}`;
 const PRIVATE_ENV_NAMES = new Set(['ANTHROPIC_API_KEY', 'OPENAI_API_KEY']);
+const CLAUDE_APPROVAL_SETTINGS = JSON.stringify({
+  permissions: { ask: ['Bash'] },
+  sandbox: { autoAllowBashIfSandboxed: false },
+});
 const require = createRequire(
   new URL('../framework/agent-session/package.json', import.meta.url),
 );
@@ -26,7 +37,26 @@ function requiredArgument(name) {
   return path.resolve(value);
 }
 
-async function eventually(probe, label, timeoutMs = 90_000) {
+function positiveIntegerArgument(name, fallback) {
+  const value = argument(name);
+  if (value === undefined) return fallback;
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed < 1) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return parsed;
+}
+
+const convergenceTimeoutMilliseconds = positiveIntegerArgument(
+  '--convergence-timeout-ms',
+  90_000,
+);
+
+async function eventually(
+  probe,
+  label,
+  timeoutMs = convergenceTimeoutMilliseconds,
+) {
   const deadline = Date.now() + timeoutMs;
   let lastError;
   while (Date.now() < deadline) {
@@ -67,7 +97,7 @@ function environment() {
   return selected;
 }
 
-function providerArguments(provider) {
+function providerArguments(provider, { claudeModel, claudeEffort }) {
   return provider === 'codex'
     ? [
         '--no-alt-screen',
@@ -76,7 +106,15 @@ function providerArguments(provider) {
         '--ask-for-approval',
         'untrusted',
       ]
-    : ['--safe-mode', '--permission-mode', 'manual'];
+    : [
+        '--safe-mode',
+        '--permission-mode',
+        'manual',
+        '--settings',
+        CLAUDE_APPROVAL_SETTINGS,
+        ...(claudeModel ? ['--model', claudeModel] : []),
+        ...(claudeEffort ? ['--effort', claudeEffort] : []),
+      ];
 }
 
 function prepareCheckoutNodePty(runtimeDir) {
@@ -134,6 +172,8 @@ async function waitForReady(host, ref, provider, label) {
         lifecycleState: current.lifecycleState,
         interactionState: current.interactionState,
         inputAdmission: current.inputAdmission,
+        signatureIds: current.providerAdapter?.signatureIds ?? [],
+        adapterReason: current.providerAdapter?.reason ?? null,
         providerSessionObserved: Boolean(current.foreground?.providerSessionId),
         providerTurnObserved: Boolean(current.foreground?.providerTurnId),
         adapterFailureCode: current.providerAdapter?.failureCode ?? null,
@@ -142,6 +182,8 @@ async function waitForReady(host, ref, provider, label) {
         stderrBytesObserved:
           current.providerAdapter?.stderrBytesObserved ?? null,
         attemptBoundary: current.attemptBoundary ?? null,
+        outputBytesObserved:
+          current.output.nextSequence - current.output.earliestSequence,
       };
       if (current.interactionState === 'ready') return current;
       if (
@@ -202,12 +244,33 @@ async function waitForReady(host, ref, provider, label) {
       temporaryTrustAccepted = true;
       return null;
     }, label);
+    if (status.interactionState !== 'ready') {
+      throw new Error(`${label} provider ended before ready`);
+    }
   } catch (error) {
     throw new Error(
       `${error.message}; adapterReason=${adapterReason ?? 'none'}; safeStatus=${JSON.stringify(lastSafeStatus)}; trustTokens=${observedTrustTokens.join(',') || 'none'}; readyTokens=${observedReadyTokens.join(',') || 'none'}`,
     );
   }
   return { status, temporaryTrustAccepted };
+}
+
+function redactedScreenSignals(snapshot, probePath) {
+  const vt = snapshot?.terminal?.vt;
+  const screen = Array.isArray(vt?.lines) ? vt.lines.join('\n') : '';
+  return {
+    currentReadyPrompt: /^\s*❯(?:\s|$)/mu.test(screen),
+    currentBusyHint: /esc to interrupt/iu.test(screen),
+    currentPermissionPrompt: /permission/iu.test(screen),
+    currentApprovalPrompt: /(?:allow|approve|proceed)/iu.test(screen),
+    currentBashPrompt: /bash(?: command)?/iu.test(screen),
+    currentProbeReference: screen.includes(path.basename(probePath)),
+    activeBuffer: vt?.activeBuffer ?? null,
+    cursor: vt?.cursor ?? null,
+    nonEmptyLines: Array.isArray(vt?.lines)
+      ? vt.lines.filter((line) => line.trim().length > 0).length
+      : 0,
+  };
 }
 
 async function stopWorker(metadata) {
@@ -229,6 +292,19 @@ const provider = argument('--provider');
 if (!['codex', 'claude'].includes(provider)) {
   throw new Error('--provider must be codex or claude');
 }
+const claudeModel = argument('--claude-model');
+const claudeEffort = argument('--claude-effort');
+if (provider !== 'claude' && (claudeModel || claudeEffort)) {
+  throw new Error(
+    '--claude-model and --claude-effort require --provider claude',
+  );
+}
+if (
+  claudeEffort &&
+  !['low', 'medium', 'high', 'xhigh', 'max'].includes(claudeEffort)
+) {
+  throw new Error('--claude-effort must be low, medium, high, xhigh, or max');
+}
 const transport = argument('--transport') ?? 'pty';
 if (!['pty', 'structured'].includes(transport)) {
   throw new Error('--transport must be pty or structured');
@@ -239,6 +315,11 @@ if (transport === 'structured' && provider !== 'codex') {
 const runtimeDir = requiredArgument('--runtime-dir');
 const workspace = requiredArgument('--workspace');
 const providerExecutable = requiredArgument('--provider-executable');
+try {
+  accessSync(providerExecutable, constants.X_OK);
+} catch {
+  throw new Error('--provider-executable must identify an executable file');
+}
 const workerExecutable = path.resolve(
   argument('--worker-executable') ?? process.execPath,
 );
@@ -276,7 +357,7 @@ try {
       providerVersion: provider === 'codex' ? '0.144.3' : '2.1.209',
       profileRoot: PROFILE_ROOT,
       executable: providerExecutable,
-      argv: providerArguments(provider),
+      argv: providerArguments(provider, { claudeModel, claudeEffort }),
       cwd: workspace,
       env,
     },
@@ -367,7 +448,7 @@ try {
       providerVersion: provider === 'codex' ? '0.144.3' : '2.1.209',
       profileRoot: PROFILE_ROOT,
       executable: providerExecutable,
-      argv: providerArguments(provider),
+      argv: providerArguments(provider, { claudeModel, claudeEffort }),
       cwd: workspace,
       env,
     },
@@ -390,13 +471,13 @@ try {
     provider,
     `${provider} approval attempt ready`,
   );
-  const approvalProbe = path.join(workspace, 'approval-probe-must-not-exist');
+  const approvalProbe = path.join(workspace, 'qualification-tool-call-probe');
   const approvalInstruction = await control(
     restartedMain,
     approvalRef,
     'instruct',
     {
-      text: `Use the shell tool to run touch ${JSON.stringify(approvalProbe)}. Do not avoid the tool request.`,
+      text: `Create the qualification fixture at ${JSON.stringify(approvalProbe)} now. Use the ${provider === 'claude' ? 'Bash' : 'shell'} tool with exactly this command: printf qualification > ${JSON.stringify(approvalProbe)}. Request confirmation instead of explaining the command.`,
     },
   );
   if (
@@ -406,6 +487,8 @@ try {
   ) {
     throw new Error(`${provider} approval probe instruction was not delivered`);
   }
+  const approvalObservations = new Set();
+  let approvalLastStatus = approvalReady.status;
   let approvalSafeStatus = null;
   try {
     await eventually(async () => {
@@ -413,6 +496,16 @@ try {
         operation: 'status',
         session: approvalRef,
       });
+      approvalLastStatus = status;
+      approvalObservations.add(
+        JSON.stringify({
+          interactionState: status.interactionState,
+          signatureIds: status.providerAdapter.signatureIds,
+          adapterReason: status.providerAdapter.reason,
+          lifecycleState: status.lifecycleState,
+          inputAdmission: status.inputAdmission,
+        }),
+      );
       approvalSafeStatus = {
         lifecycleState: status.lifecycleState,
         interactionState: status.interactionState,
@@ -424,8 +517,35 @@ try {
       return status.interactionState === 'approval-needed';
     }, `${provider} approval-needed state`);
   } catch (error) {
+    let screenSignals = { snapshotAvailable: false };
+    let cleanup = 'not-attempted';
+    try {
+      const snapshot = await restartedMain.invoke({
+        operation: 'snapshot',
+        session: approvalRef,
+        requestedSequence: approvalLastStatus.output.earliestSequence,
+      });
+      screenSignals = redactedScreenSignals(snapshot, approvalProbe);
+    } catch {
+      screenSignals = { snapshotAvailable: false };
+    }
+    try {
+      const stopped = await control(restartedMain, approvalRef, 'end', {});
+      cleanup = stopped.status;
+    } catch {
+      cleanup = 'failed';
+    }
     throw new Error(
-      `${error.message}; safeStatus=${JSON.stringify(approvalSafeStatus)}`,
+      `${error.message}; metadata=${JSON.stringify({
+        safeStatus: approvalSafeStatus,
+        observations: [...approvalObservations],
+        outputBytesObserved:
+          approvalLastStatus.output.nextSequence -
+          approvalReady.status.output.nextSequence,
+        probeExists: existsSync(approvalProbe),
+        screenSignals,
+        cleanup,
+      })}`,
     );
   }
   const pendingControl = (
@@ -454,6 +574,9 @@ try {
   ) {
     throw new Error(`${provider} approval denial was not delivered`);
   }
+  if (existsSync(approvalProbe)) {
+    throw new Error(`${provider} approval probe executed before denial`);
+  }
 
   const ended = await control(restartedMain, approvalRef, 'end', {});
   if (
@@ -472,6 +595,9 @@ try {
       status.lifecycleState === 'ended' && status.inputAdmission === 'closed'
     );
   }, `${provider} provider exit`);
+  if (existsSync(approvalProbe)) {
+    throw new Error(`${provider} approval probe executed despite denial`);
+  }
 
   const interruptRef = {
     workConsoleId: `work:provider-dogfood:${provider}:interrupt`,
@@ -485,7 +611,7 @@ try {
       providerVersion: provider === 'codex' ? '0.144.3' : '2.1.209',
       profileRoot: PROFILE_ROOT,
       executable: providerExecutable,
-      argv: providerArguments(provider),
+      argv: providerArguments(provider, { claudeModel, claudeEffort }),
       cwd: workspace,
       env,
     },
@@ -578,6 +704,19 @@ try {
     runtimeRoot: `sha256:${createHash('sha256').update(runtimeDir).digest('hex')}`,
     rawTerminalRetained: false,
     privateEnvironmentValuesRetained: false,
+    approvalPolicy:
+      provider === 'claude'
+        ? 'explicit-bash-ask'
+        : 'provider-untrusted-approval',
+    qualificationProfile: {
+      convergenceTimeoutMilliseconds,
+      ...(provider === 'claude'
+        ? {
+            model: claudeModel ?? 'provider-default',
+            effort: claudeEffort ?? 'provider-default',
+          }
+        : {}),
+    },
     temporaryWorkspaceTrustAccepted:
       initialReady.temporaryTrustAccepted ||
       approvalReady.temporaryTrustAccepted ||


### PR DESCRIPTION
## Summary

Close the Mac product slice of ADR-0081: keep each provider process under the
detached AgentSessionCapsule authority, make Claude prompt submission and
approval detection match the real 2.1.209 TUI, retain one GUI/CLI/Agent control
surface, and qualify the packaged Codex/Claude worker before promotion.

## Related issue

Atlas goal: 2026-07-14-kungfu-durable-agent-session-control-plane

## Changes

- Submit Claude bracketed paste and Enter as separately idempotent writes, and
  recognize the bounded Bash confirmation modal before a coexisting ready
  prompt can admit automatic input.
- Preserve fail-closed behavior for generic/unknown modals, stale plans,
  provider exits, approval states, and version drift; expose public exit
  metadata without retaining terminal output.
- Extend the real-provider dogfood harness with Claude model/effort policy,
  explicit Bash ask configuration, packaged-worker assertions, redacted
  diagnostics, Codex structured transport, and an explicit PTY rollback route.
- Record packaged Mac qualification and promotion evidence for build
  `20260714T150829Z-237b7662f` at `/Applications/Kungfu Episodes.app`.

## Verification

- `./shifu check:source`: 268/268 tests, 61 documentation contract fixtures,
  TypeScript, Biome, Markdown, links, schemas, and contract gates passed at
  `ad53886ff40939ecfaa760d98a4076239f58cf8e`.
- `./shifu dist`: packaged build `20260714T150829Z-237b7662f`; afterPack bundle
  audit passed and both Darwin node-pty spawn helpers are executable.
- Packaged Claude 2.1.209 PTY: 6/6 cases passed; explicit Bash ask, sonnet/low,
  approval denied before the disposable probe could run.
- Packaged Codex 0.144.3 PTY: 6/6 cases passed.
- Packaged Codex 0.144.3 structured transport: 6/6 cases passed; feature-off
  rollback creates a distinct PTY attempt.
- Installed Agent Session package/client/worker and node-pty helper hashes match
  the promoted candidate; Shifu catalog reports the build as current.
- All retained reports are metadata-only: no raw terminal bytes or private
  environment values.

## Retained limits

Machine-restart recovery and Linux/Windows product qualification remain
not-run. ADR-0081 therefore remains partial; this PR claims only the qualified
Mac product slice. The repository-wide `./shifu check` remains blocked by the
pre-existing canonical-policy rendered hash mismatch; this branch does not
change those policy inputs, while the complete source gate is green.

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "stage-ready",
  "adrs": ["ADR-0081"],
  "summary": "Qualify and promote the packaged Mac AgentSessionCapsule control plane for Codex PTY, Codex structured transport, and Claude PTY while retaining fail-closed authority and privacy boundaries",
  "verification": ["Shifu source gate 268/268", "packaged Mac dist and bundle audit", "packaged Codex PTY 6/6", "packaged Codex structured 6/6", "packaged Claude PTY 6/6", "installed candidate hash verification"]
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [x] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

Provider CLI behavior is version-pinned and tested through temporary runtimes.
No credentials, private transcripts, raw terminal bytes, or provider session
state are committed.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation and qualification evidence updated
- [x] Packaged product promoted without terminating or relaunching the running GUI


