### PR TITLE
fix(gui): package Agent Session runtime

### DIFF
--- a/docs/adr/ADR-0083-core-system-kfx-profile-kfx-capability-boundary.md
+++ b/docs/adr/ADR-0083-core-system-kfx-profile-kfx-capability-boundary.md
@@ -4,7 +4,8 @@ doc_type: architecture-decision
 adr_id: ADR-0083
 decision_status: accepted
 implementation_status: partial
-implementation_commits: [c6266fe3ea37e096ced272c497b6e729218c7a3b, ef4421c8607860978f7d2b890ab68c149d97747a, bdf3800cb34182b59d3f341dee08056a5ebf6bd0, fb67a700c748e8c355bec7d15077d654a2a9c3ea, 4734113513cb7f1868e29b45f505f3b6fd33eee1, 36381447657fcda49b7b5c48eafd9703236adcb0, 19ed717bd1db545782f366fd47b14ec3a1c35add, 88624d97677a439f557d07f7ae0eeb577a7d8206]
+implementation_commits: [c6266fe3ea37e096ced272c497b6e729218c7a3b, ef4421c8607860978f7d2b890ab68c149d97747a, bdf3800cb34182b59d3f341dee08056a5ebf6bd0, fb67a700c748e8c355bec7d15077d654a2a9c3ea, 4734113513cb7f1868e29b45f505f3b6fd33eee1, 36381447657fcda49b7b5c48eafd9703236adcb0, 19ed717bd1db545782f366fd47b14ec3a1c35add, 88624d97677a439f557d07f7ae0eeb577a7d8206, eabb2a0dc0bf18f6794a1524ba8f0b94c6b5f567]
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/842, https://github.com/kungfu-systems/kungfu/pull/843, https://github.com/kungfu-systems/kungfu/pull/852, https://github.com/kungfu-systems/kungfu/pull/854, https://github.com/kungfu-systems/kungfu/pull/860, https://github.com/kungfu-systems/kungfu/pull/862, https://github.com/kungfu-systems/kungfu/pull/863, https://github.com/kungfu-systems/kungfu/pull/864, https://github.com/kungfu-systems/kungfu/pull/865, https://github.com/kungfu-systems/kungfu/pull/867, https://github.com/kungfu-systems/kungfu/pull/873]
 review_state: self-reviewed
 sensitivity: public
 sources: [local-files, user-consensus]

--- a/framework/gui/electron-builder.yml
+++ b/framework/gui/electron-builder.yml
@@ -17,6 +17,17 @@ files:
   - "!node_modules/@kungfu-tech/**/build{,/**}"
   - "!node_modules/@kungfu-tech/**/dist/kungfu{,/**}"
 extraResources:
+  # electron-vite keeps production dependencies external in the main bundle.
+  # pnpm workspace links are outside the packaged app and electron-builder does
+  # not follow them reliably, so copy the complete Agent Session runtime into
+  # the app-local node_modules tree explicitly.
+  - from: ../agent-session
+    to: app/node_modules/@kungfu-tech/agent-session
+    filter:
+      - package.json
+      - src/**/*
+      - "*.contract.json"
+      - schemas/**/*
   # Ship the kungfu runtime (libkungfu.dylib + kungfu_electron.node) so the
   # packaged app loads the binding from Resources/kungfu, matching its rpath.
   - from: ../core/dist/kungfu

--- a/framework/gui/scripts/bundle-core-audit.cjs
+++ b/framework/gui/scripts/bundle-core-audit.cjs
@@ -3,6 +3,7 @@
 // exactly once: Contents/Resources/kungfu. Workspace/package-manager layouts can
 // otherwise copy @kungfu-tech/core through nested app dependencies.
 const fs = require('node:fs');
+const { createRequire } = require('node:module');
 const path = require('node:path');
 
 function exists(p) {
@@ -109,6 +110,52 @@ function repairNodePtySpawnHelpers(appDir) {
     }
   }
   return helpers;
+}
+
+function auditPackagedMainDependencies(appDir) {
+  const appRoot = path.join(appDir, 'Contents', 'Resources', 'app');
+  const packageJson = path.join(appRoot, 'package.json');
+  if (!exists(packageJson)) {
+    throw new Error(`missing packaged app metadata: ${packageJson}`);
+  }
+  const main = JSON.parse(fs.readFileSync(packageJson, 'utf8')).main;
+  if (typeof main !== 'string' || main.length === 0) {
+    throw new Error(`packaged app metadata has no main entry: ${packageJson}`);
+  }
+  const mainPath = path.join(appRoot, main);
+  if (!exists(mainPath)) {
+    throw new Error(`missing packaged app main entry: ${mainPath}`);
+  }
+
+  const code = fs.readFileSync(mainPath, 'utf8');
+  const externalRequires = [...code.matchAll(/\brequire\(["']([^"']+)["']\)/g)]
+    .map((match) => match[1])
+    .filter(
+      (specifier) =>
+        specifier !== 'electron' &&
+        !specifier.startsWith('node:') &&
+        !specifier.startsWith('.') &&
+        !path.isAbsolute(specifier),
+    );
+  const packagedRequire = createRequire(mainPath);
+  const unresolved = [...new Set(externalRequires)]
+    .sort()
+    .filter((specifier) => {
+      try {
+        packagedRequire.resolve(specifier);
+        return false;
+      } catch {
+        return true;
+      }
+    });
+  if (unresolved.length > 0) {
+    throw new Error(
+      `unresolved packaged main dependencies:\n${unresolved.join('\n')}`,
+    );
+  }
+  console.log(
+    `[bundle-core-audit] ok: ${new Set(externalRequires).size} packaged main dependencies resolve`,
+  );
 }
 
 function auditPackagedApp(appDir, options = {}) {
@@ -236,6 +283,7 @@ function auditPackagedApp(appDir, options = {}) {
     throw new Error(failures.join('\n\n'));
   }
 
+  auditPackagedMainDependencies(appDir);
   console.log(`[bundle-core-audit] ok: single kungfu runtime at ${runtimeDir}`);
 }
 
@@ -260,6 +308,7 @@ if (require.main === module) {
 
 module.exports = {
   auditPackagedApp,
+  auditPackagedMainDependencies,
   findAppFromContext,
   repairNodePtySpawnHelpers,
 };

--- a/framework/gui/scripts/bundle-core-audit.test.cjs
+++ b/framework/gui/scripts/bundle-core-audit.test.cjs
@@ -25,9 +25,10 @@ function packagedAppFixture() {
     'darwin-arm64',
     'spawn-helper',
   );
+  const appRoot = path.join(resources, 'app');
+  const main = path.join(appRoot, 'out', 'main', 'index.js');
   const agentSessionPackage = path.join(
-    resources,
-    'app',
+    appRoot,
     'node_modules',
     '@kungfu-tech',
     'agent-session',
@@ -43,16 +44,31 @@ function packagedAppFixture() {
   }
   fs.mkdirSync(path.dirname(helper), { recursive: true });
   fs.writeFileSync(helper, 'fixture', { mode: 0o644 });
-  for (const required of [
-    'package.json',
-    path.join('src', 'product-client.mjs'),
-    path.join('src', 'product-worker.mjs'),
-  ]) {
-    const requiredPath = path.join(agentSessionPackage, required);
-    fs.mkdirSync(path.dirname(requiredPath), { recursive: true });
-    fs.writeFileSync(requiredPath, 'fixture');
-  }
-  return { root, app, helper, agentSessionPackage };
+  fs.mkdirSync(path.dirname(main), { recursive: true });
+  fs.writeFileSync(
+    path.join(appRoot, 'package.json'),
+    JSON.stringify({ main: 'out/main/index.js' }),
+  );
+  fs.writeFileSync(main, 'require("electron"); require("node:path");');
+  fs.mkdirSync(path.join(agentSessionPackage, 'src'), { recursive: true });
+  fs.writeFileSync(
+    path.join(agentSessionPackage, 'package.json'),
+    JSON.stringify({
+      name: '@kungfu-tech/agent-session',
+      version: '0.0.0',
+      type: 'module',
+      exports: { './product-client': './src/product-client.mjs' },
+    }),
+  );
+  fs.writeFileSync(
+    path.join(agentSessionPackage, 'src', 'product-client.mjs'),
+    '',
+  );
+  fs.writeFileSync(
+    path.join(agentSessionPackage, 'src', 'product-worker.mjs'),
+    '',
+  );
+  return { root, app, appRoot, helper, main, agentSessionPackage };
 }
 
 test('repairs and audits the packaged node-pty Darwin spawn helper', (t) => {
@@ -80,4 +96,31 @@ test('rejects an app without the detached Agent Session worker', (t) => {
     () => auditPackagedApp(fixture.app),
     /missing packaged Agent Session runtime file/,
   );
+});
+
+test('rejects an external main dependency missing from the packaged app', (t) => {
+  const fixture = packagedAppFixture();
+  t.after(() => fs.rmSync(fixture.root, { recursive: true, force: true }));
+  repairNodePtySpawnHelpers(fixture.app);
+  fs.writeFileSync(
+    fixture.main,
+    'require("@kungfu-tech/missing-runtime/entry");',
+  );
+
+  assert.throws(
+    () => auditPackagedApp(fixture.app),
+    /unresolved packaged main dependencies:[\s\S]+missing-runtime\/entry/,
+  );
+});
+
+test('accepts a packaged external main dependency', (t) => {
+  const fixture = packagedAppFixture();
+  t.after(() => fs.rmSync(fixture.root, { recursive: true, force: true }));
+  repairNodePtySpawnHelpers(fixture.app);
+  fs.writeFileSync(
+    fixture.main,
+    'require("@kungfu-tech/agent-session/product-client");',
+  );
+
+  assert.doesNotThrow(() => auditPackagedApp(fixture.app));
 });

--- a/product/scripts/dist.test.mjs
+++ b/product/scripts/dist.test.mjs
@@ -125,6 +125,15 @@ test('desktop product carries the installed Agent authoring runtime', () => {
   }
 });
 
+test('desktop product carries the externalized Agent Session runtime', () => {
+  const config = fs.readFileSync(
+    new URL('../electron-builder.yml', import.meta.url),
+    'utf8',
+  );
+  assert.match(config, /from: \.\.\/agent-session/);
+  assert.match(config, /to: app\/node_modules\/@kungfu-tech\/agent-session/);
+});
+
 test('installed SDK resolves the packaged KFX contract beside its resources', () => {
   const sdk = fs.readFileSync(
     new URL('../../developer/sdk/src/sdk.js', import.meta.url),


### PR DESCRIPTION
## Summary

- ship the externalized Agent Session workspace runtime inside the packaged Electron app
- fail after-pack when any static external main-process dependency cannot resolve from the app
- add regression coverage for the missing-package failure and product packaging config

## Verification

- node --test framework/gui/scripts/bundle-core-audit.test.cjs product/scripts/dist.test.mjs
- XDG_CACHE_HOME=/tmp/kungfu-gui-package-closure-cache ./shifu check:source
- XDG_CACHE_HOME=/tmp/kungfu-gui-package-closure-cache ./shifu product gui build
- isolated packaged cold launch: KF_GUI_QUALIFICATION_READY and exit 0
- staged pre-commit gate

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "stage-ready",
  "adrs": ["ADR-0083"],
  "summary": "Close the packaged GUI main-process dependency boundary so the WorkConsole product cold-starts from its installed artifact",
  "verification": ["node --test framework/gui/scripts/bundle-core-audit.test.cjs product/scripts/dist.test.mjs", "./shifu check:source", "./shifu product gui build", "isolated packaged cold launch", "staged pre-commit gate"]
}
-->

## Governance risk check

- [x] none of credentials, hosted services, branding, publishing, or deployment boundaries

## Checklist

- [x] Commit is signed off (DCO)
- [x] Installed package resolves every static external main-process dependency
