### PR TITLE
refactor(core): fold reader.cpp journal selection to std::ranges

### DIFF
--- a/docs/adr/ADR-0082-cpp23-rx-core-language-strategy.md
+++ b/docs/adr/ADR-0082-cpp23-rx-core-language-strategy.md
@@ -4,7 +4,7 @@ doc_type: architecture-decision
 adr_id: ADR-0082
 decision_status: accepted
 implementation_status: staged
-implementation_commits: [a296e6dfdf3a43340093accafbee646ef97ea821, 30a849db8a93895686e53076df779717ccd79a24, 6f20d83cf79751415ed9976be310ae610a4eb4bb, 531d40d899685c5a86a51ae721d6388bbe384680]
+implementation_commits: [a296e6dfdf3a43340093accafbee646ef97ea821, 30a849db8a93895686e53076df779717ccd79a24, 6f20d83cf79751415ed9976be310ae610a4eb4bb, 531d40d899685c5a86a51ae721d6388bbe384680, 6232f1e1a3d94055e72a20a86e5193b5ca0a0250]
 implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/660, https://github.com/kungfu-systems/kungfu/pull/858, https://github.com/kungfu-systems/kungfu/pull/869, https://github.com/kungfu-systems/kungfu/pull/871]
 review_state: self-reviewed
 sensitivity: public
@@ -224,8 +224,14 @@ independently:
    exclusive by construction; the payoff is that an unsatisfied constraint now
    reports "constraints not satisfied" instead of a bare "no type named 'type'
    in enable_if". No flag-day: remaining SFINAE sites migrate in later batches.
-4. Opportunistic: deducing this where CRTP is boilerplate; ranges where the
-   `reader.cpp` TODO already points.
+4. Opportunistic. **Ranges landed**: `reader::sort_without_buffer()` discharges
+   the `reader.cpp` TODO it named — the manual filter loop plus `std::max_element`
+   is now `journals_ | std::views::values | std::views::filter(...)` fed to
+   `std::ranges::max_element`, behaviour-preserving. **Deducing this deferred**:
+   the core's CRTP base is `kungfu::data<T>` (via `KF_DEFINE_DATA_TYPE`), a
+   widely-inherited pack-layout base whose replacement is invasive rather than a
+   clean opportunistic win, so it is left for a dedicated change if it ever earns
+   one.
 
 ## Re-evaluation triggers
 

--- a/docs/adr/ADR-0082-cpp23-rx-core-language-strategy.md
+++ b/docs/adr/ADR-0082-cpp23-rx-core-language-strategy.md
@@ -5,7 +5,7 @@ adr_id: ADR-0082
 decision_status: accepted
 implementation_status: staged
 implementation_commits: [a296e6dfdf3a43340093accafbee646ef97ea821, 30a849db8a93895686e53076df779717ccd79a24, 6f20d83cf79751415ed9976be310ae610a4eb4bb, 531d40d899685c5a86a51ae721d6388bbe384680, 6232f1e1a3d94055e72a20a86e5193b5ca0a0250]
-implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/660, https://github.com/kungfu-systems/kungfu/pull/858, https://github.com/kungfu-systems/kungfu/pull/869, https://github.com/kungfu-systems/kungfu/pull/871]
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/660, https://github.com/kungfu-systems/kungfu/pull/858, https://github.com/kungfu-systems/kungfu/pull/869, https://github.com/kungfu-systems/kungfu/pull/871, https://github.com/kungfu-systems/kungfu/pull/874]
 review_state: self-reviewed
 sensitivity: public
 sources: [local-files, user-decision]

--- a/docs/adr/ADR-0086-live-peer-continuity-and-coordinator-authority.md
+++ b/docs/adr/ADR-0086-live-peer-continuity-and-coordinator-authority.md
@@ -4,7 +4,7 @@ doc_type: architecture-decision
 adr_id: ADR-0086
 decision_status: accepted
 implementation_status: partial
-implementation_commits: [cabf0c34615fb80f7aca6ede43bc5b57abf5fcc1]
+implementation_commits: [69b0b82ebdf972a39f09e9a2737b0456314c2de8]
 qualification_refs: [framework/core/src/libkungfu/tests/peer_continuity_tests.cpp, framework/core/tests/python/test_runtime_service.py, framework/core/tests/python/test_runtime_broker.py, framework/agent-session/tests/peer-transport.test.mjs, framework/core/tests/qualification/live-peer-continuity/run.mjs, framework/core/tests/qualification/live-peer-continuity/native_campaign.py]
 review_state: self-reviewed
 sensitivity: public

--- a/framework/core/src/libyijinjing/src/journal/reader.cpp
+++ b/framework/core/src/libyijinjing/src/journal/reader.cpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
+#include <ranges>
+
 #include <kungfu/yijinjing/journal/journal.h>
 #include <kungfu/yijinjing/journal/page.h>
 #include <kungfu/yijinjing/time.h>
@@ -114,16 +116,11 @@ void reader::next() {
 
 void reader::sort_without_buffer() {
   buffer_built_ = false;
-  // those could be refacted to std::ranges after cxx==20
-  std::vector<journal_ptr> has_data_journals;
-  for (auto &pair : journals_) {
-    auto &journal = pair.second;
-    if (journal->current_frame()->has_data()) {
-      has_data_journals.push_back(journal);
-    }
-  }
-  auto min_journal_it = std::max_element(has_data_journals.cbegin(), has_data_journals.cend(), later{});
-  if (min_journal_it != has_data_journals.end()) {
+  auto has_data_journals = journals_ | std::views::values | std::views::filter([](const journal_ptr &journal) {
+                             return journal->current_frame()->has_data();
+                           });
+  auto min_journal_it = std::ranges::max_element(has_data_journals, later{});
+  if (min_journal_it != std::ranges::end(has_data_journals)) {
     current_ = *min_journal_it;
   }
 }


### PR DESCRIPTION
## Summary

Opportunistic ADR-0082 staged item 4 (ranges): fold the manual filter loop in
`reader::sort_without_buffer()` to `std::ranges`, discharging the `reader.cpp`
TODO the ADR names. `libyijinjing` already compiles as C++20.

## Related issue

Atlas goal: 2026-07-14-kungfu-adr0082-staged-increments

## Changes

- `framework/core/src/libyijinjing/src/journal/reader.cpp`:
  `sort_without_buffer()` replaces the hand-written "collect has-data journals
  into a vector, then `std::max_element`" loop with
  `journals_ | std::views::values | std::views::filter(...)` fed to
  `std::ranges::max_element(..., later{})`.
- `docs/adr/ADR-0082-...md`: record staged item 4 ranges as landed and deducing
  this as deferred (the `kungfu::data<T>` CRTP base is too widely inherited to be
  a clean opportunistic target), and add the item-3 mainline commit (`6232f1e1`)
  to `implementation_commits`.

## Equivalence

Same journals with `has_data()` are considered, compared by the same `later{}`
predicate, and the same one is assigned to `current_`. The view is lazy where
the old vector was eager, but `max_element` consumes it fully either way, so the
selection is identical. `sort_without_buffer()` runs only on join / disjoin /
seek, not on the per-frame `next()` path.

## Verification

- Linux / GCC (agent-120): full `build:core` green; journal / reader / mmap /
  durability / crash-recovery ctests pass
- Windows / MSVC (VS 18): full `build:core` green
- pre-commit staged gate (clang-format 20.1.8)

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "stage-ready",
  "adrs": ["ADR-0082"],
  "summary": "Opportunistic ADR-0082 staged item 4 ranges: fold reader::sort_without_buffer() to std::views + std::ranges::max_element, discharging the reader.cpp TODO the ADR names, behaviour-preserving",
  "verification": ["Linux/GCC full core build + journal/reader ctests", "Windows/MSVC full core build", "pre-commit staged gate"]
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] release evidence, provenance, package publishing, or deployment surfaces
- [x] none of the above

Behaviour-preserving refactor of one journal-selection helper.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated (ADR staged-item status)