### PR TITLE
docs(adr): repair live peer merge evidence

### DIFF
--- a/docs/adr/ADR-0086-live-peer-continuity-and-coordinator-authority.md
+++ b/docs/adr/ADR-0086-live-peer-continuity-and-coordinator-authority.md
@@ -4,7 +4,7 @@ doc_type: architecture-decision
 adr_id: ADR-0086
 decision_status: accepted
 implementation_status: partial
-implementation_commits: [cabf0c34615fb80f7aca6ede43bc5b57abf5fcc1]
+implementation_commits: [69b0b82ebdf972a39f09e9a2737b0456314c2de8]
 qualification_refs: [framework/core/src/libkungfu/tests/peer_continuity_tests.cpp, framework/core/tests/python/test_runtime_service.py, framework/core/tests/python/test_runtime_broker.py, framework/agent-session/tests/peer-transport.test.mjs, framework/core/tests/qualification/live-peer-continuity/run.mjs, framework/core/tests/qualification/live-peer-continuity/native_campaign.py]
 review_state: self-reviewed
 sensitivity: public


### PR DESCRIPTION
## Summary

- replace the unreachable PR-head SHA in ADR-0086 with the canonical rebased mainline commit from PR #876
- restore the documentation and source acceptance gates without changing implementation status or claims

## Verification

- ./shifu docs:check:readonly
- staged pre-commit gate

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "stage-ready",
  "adrs": ["ADR-0086"],
  "summary": "Repair ADR-0086 evidence after the implementation PR was rebased into main",
  "verification": ["./shifu docs:check:readonly", "staged pre-commit gate"]
}
-->

## Governance risk check

- [x] none of credentials, hosted services, branding, publishing, or deployment boundaries

## Checklist

- [x] Commit is signed off (DCO)
- [x] No implementation or qualification claim changed
