### PR TITLE
feat(agent-session): project recoverable product states

### DIFF
--- a/docs/adr/ADR-0081-durable-agent-session-capsule-control-plane.md
+++ b/docs/adr/ADR-0081-durable-agent-session-capsule-control-plane.md
@@ -250,3 +250,11 @@ environment values, and is promoted at `/Applications/Kungfu Episodes.app`.
 Machine restart and Linux/Windows qualification remain open, so the
 implementation status remains partial even though Mac `promotionEligible` is
 true and the qualified build is current.
+
+The shared surface also projects each live or retained attempt into the same
+product states for GUI, CLI, and Agent clients: `available`, `starting`,
+`working`, `recovering`, `action-required`, or `ended`. A lost worker never
+turns an unrecoverable attempt into an empty successful Hub: it retains the
+attempt as `action-required` with the single safe recommendation to start a new
+attempt or use provider-supported resume. Normal presentation does not expose
+Capsule, worker, PID, Supervisor, or Coordinator terminology.

--- a/docs/adr/ADR-0087-versioned-product-runtime-upgrade-control-plane.md
+++ b/docs/adr/ADR-0087-versioned-product-runtime-upgrade-control-plane.md
@@ -4,7 +4,7 @@ doc_type: architecture-decision
 adr_id: ADR-0087
 decision_status: accepted
 implementation_status: staged
-implementation_commits: [2bc98d7e9b408bb9f02ae835388000a8fcaf451b]
+implementation_commits: [1ceeb033efadff7416533c6ca7f882b0263e1d5c]
 qualification_refs: [framework/core/tests/python/test_runtime_upgrade.py, scripts/check-upgrade-contract.test.mjs, tests/fixtures/runtime-upgrade-control-plane/cases.json]
 review_state: self-reviewed
 sensitivity: public

--- a/extensions/terminal/src/view/agent-session-presentation.ts
+++ b/extensions/terminal/src/view/agent-session-presentation.ts
@@ -1,0 +1,113 @@
+export type AgentSessionProductState =
+  | 'available'
+  | 'starting'
+  | 'working'
+  | 'recovering'
+  | 'action-required'
+  | 'ended';
+
+export type AgentSessionProductProjection = {
+  state: AgentSessionProductState;
+  reason: string;
+  recommendedAction: string | null;
+};
+
+type AgentSessionStatusCompatibilityInput = {
+  product?: AgentSessionProductProjection;
+  live?: boolean;
+  lifecycleState?: string;
+  interactionState?: string;
+};
+
+const LABELS: Record<AgentSessionProductState, string> = {
+  available: 'Available',
+  starting: 'Starting',
+  working: 'Working',
+  recovering: 'Recovering',
+  'action-required': 'Action required',
+  ended: 'Ended',
+};
+
+const DETAILS: Record<string, string> = {
+  'ready-for-input': 'Ready for your next instruction.',
+  'attempt-starting': 'The session is starting automatically.',
+  'provider-working': 'The session is working.',
+  'reattaching-session': 'Reattaching to the current session.',
+  'provider-request-needs-review': 'Review the provider request to continue.',
+  'interaction-state-needs-review':
+    'Review the session before continuing or starting a new attempt.',
+  'automatic-recovery-cannot-continue':
+    'Review the session before continuing or starting a new attempt.',
+  'prior-attempt-cannot-be-reattached':
+    'Start a new attempt or use provider-supported resume.',
+  'attempt-ended': 'This attempt has ended.',
+};
+
+export function agentSessionProductLabel(
+  product: AgentSessionProductProjection,
+): string {
+  return LABELS[product.state];
+}
+
+export function resolveAgentSessionProduct(
+  status: AgentSessionStatusCompatibilityInput,
+): AgentSessionProductProjection {
+  if (status.product) return status.product;
+  if (['ended', 'exited'].includes(status.lifecycleState ?? '')) {
+    return {
+      state: 'ended',
+      reason: 'attempt-ended',
+      recommendedAction: null,
+    };
+  }
+  if (['unrecoverable', 'lost-control'].includes(status.lifecycleState ?? '')) {
+    return {
+      state: 'action-required',
+      reason: 'prior-attempt-cannot-be-reattached',
+      recommendedAction: 'start-new-attempt-or-provider-resume',
+    };
+  }
+  if (status.interactionState === 'approval-needed') {
+    return {
+      state: 'action-required',
+      reason: 'provider-request-needs-review',
+      recommendedAction: 'review-provider-request',
+    };
+  }
+  if (['starting', 'planned'].includes(status.lifecycleState ?? '')) {
+    return {
+      state: 'starting',
+      reason: 'attempt-starting',
+      recommendedAction: null,
+    };
+  }
+  if (status.live !== false && status.interactionState === 'busy') {
+    return {
+      state: 'working',
+      reason: 'provider-working',
+      recommendedAction: null,
+    };
+  }
+  if (
+    status.live !== false &&
+    status.lifecycleState === 'ready' &&
+    status.interactionState === 'ready'
+  ) {
+    return {
+      state: 'available',
+      reason: 'ready-for-input',
+      recommendedAction: null,
+    };
+  }
+  return {
+    state: 'recovering',
+    reason: 'reattaching-session',
+    recommendedAction: null,
+  };
+}
+
+export function agentSessionProductDetail(
+  product: AgentSessionProductProjection,
+): string {
+  return DETAILS[product.reason] ?? 'Review the current session state.';
+}

--- a/extensions/terminal/src/view/index.tsx
+++ b/extensions/terminal/src/view/index.tsx
@@ -52,6 +52,12 @@ import {
   rememberDiscoveredAgentRuntimeProfile,
 } from './agent-runtime-catalog';
 import {
+  type AgentSessionProductProjection,
+  agentSessionProductDetail,
+  agentSessionProductLabel,
+  resolveAgentSessionProduct,
+} from './agent-session-presentation';
+import {
   DEFAULT_PANE_LAYOUT,
   type PaneLayoutAxis,
   type PaneLayoutMode,
@@ -733,6 +739,8 @@ type CapsuleSurfaceStatus = {
   interactionState: string;
   inputAdmission: string;
   queuedInstructions: number;
+  live?: boolean;
+  product?: AgentSessionProductProjection;
   providerAdapter?: {
     provider?: string;
     compatible?: boolean;
@@ -751,6 +759,7 @@ type CapsuleSurfaceStatus = {
 
 type CapsuleSurfaceList = {
   sessions: CapsuleSurfaceStatus[];
+  attempts?: CapsuleSurfaceStatus[];
 };
 
 type CapsuleSurfaceSnapshot = {
@@ -864,6 +873,7 @@ function CapsuleSessionPane({
       .catch((error) => setNotice((error as Error).message));
   };
   const status = snapshot?.status;
+  const product = status ? resolveAgentSessionProduct(status) : null;
   const ended = status?.lifecycleState === 'ended';
 
   return (
@@ -890,7 +900,7 @@ function CapsuleSessionPane({
       >
         <span style={providerChipStyle(pane.provider)}>{pane.provider}</span>
         <span style={{ flex: 1, fontSize: 12, color: '#e6e6e6' }}>
-          {pane.title} · Capsule
+          {pane.title} · Agent session
         </span>
         <span
           style={{
@@ -899,9 +909,7 @@ function CapsuleSessionPane({
             color: ended ? '#c46b6b' : '#5bbf6a',
           }}
         >
-          {status
-            ? `${status.lifecycleState} · ${status.interactionState}`
-            : 'attaching'}
+          {product ? agentSessionProductLabel(product) : 'Attaching'}
         </span>
         {!ended && (
           <button
@@ -1206,7 +1214,7 @@ function CapsuleHubTray({
     <div style={{ ...panelStyle, padding: 8 }}>
       <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
         <span style={{ ...headingStyle, margin: 0 }}>
-          Capsule Console Hub · {sessions.length}
+          Agent sessions · {sessions.length}
         </span>
         <button type="button" onClick={onRefresh} style={iconButtonStyle}>
           Refresh
@@ -1223,6 +1231,8 @@ function CapsuleHubTray({
         >
           {sessions.map((session) => {
             const attached = attachedAttemptIds.has(session.sessionAttemptId);
+            const attachable = session.live !== false;
+            const product = resolveAgentSessionProduct(session);
             return (
               <div
                 key={session.sessionAttemptId}
@@ -1244,20 +1254,26 @@ function CapsuleHubTray({
                   {session.providerAdapter?.provider ?? 'agent'}
                 </span>
                 <span style={{ ...mono, fontSize: 10.5, color: '#9a9a9a' }}>
-                  {session.workConsoleId} · {session.lifecycleState} ·{' '}
-                  {session.interactionState}
+                  {session.workConsoleId} · {agentSessionProductLabel(product)}
                 </span>
-                <button
-                  type="button"
-                  disabled={attached}
-                  onClick={() => onAttach(session)}
-                  style={{
-                    ...iconButtonStyle,
-                    color: attached ? '#666' : '#7fb4d8',
-                  }}
-                >
-                  {attached ? 'Attached' : 'Attach'}
-                </button>
+                {product.state === 'action-required' && (
+                  <span style={{ ...mono, fontSize: 10.5, color: '#c9a227' }}>
+                    {agentSessionProductDetail(product)}
+                  </span>
+                )}
+                {attachable && (
+                  <button
+                    type="button"
+                    disabled={attached}
+                    onClick={() => onAttach(session)}
+                    style={{
+                      ...iconButtonStyle,
+                      color: attached ? '#666' : '#7fb4d8',
+                    }}
+                  >
+                    {attached ? 'Attached' : 'Attach'}
+                  </button>
+                )}
               </div>
             );
           })}
@@ -1522,7 +1538,7 @@ function SessionWorkspace({
         const listed = (await invokeAgentSession(caps, {
           operation: 'list',
         })) as unknown as CapsuleSurfaceList;
-        setCapsuleSessions(listed.sessions);
+        setCapsuleSessions(listed.attempts ?? listed.sessions);
       } catch {
         setCapsuleSessions([]);
       }

--- a/extensions/terminal/tests/agent-session-presentation.test.ts
+++ b/extensions/terminal/tests/agent-session-presentation.test.ts
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  agentSessionProductDetail,
+  agentSessionProductLabel,
+  resolveAgentSessionProduct,
+} from '../src/view/agent-session-presentation.ts';
+
+test('normal Agent Session presentation uses product states and one recovery action', () => {
+  assert.equal(
+    agentSessionProductLabel({
+      state: 'recovering',
+      reason: 'reattaching-session',
+      recommendedAction: null,
+    }),
+    'Recovering',
+  );
+  const actionRequired = {
+    state: 'action-required' as const,
+    reason: 'prior-attempt-cannot-be-reattached',
+    recommendedAction: 'start-new-attempt-or-provider-resume',
+  };
+  assert.equal(agentSessionProductLabel(actionRequired), 'Action required');
+  assert.equal(
+    agentSessionProductDetail(actionRequired),
+    'Start a new attempt or use provider-supported resume.',
+  );
+  assert.doesNotMatch(
+    `${agentSessionProductLabel(actionRequired)} ${agentSessionProductDetail(actionRequired)}`,
+    /capsule|worker|pid|supervisor|coordinator/i,
+  );
+  assert.deepEqual(
+    resolveAgentSessionProduct({
+      live: true,
+      lifecycleState: 'ready',
+      interactionState: 'ready',
+    }),
+    {
+      state: 'available',
+      reason: 'ready-for-input',
+      recommendedAction: null,
+    },
+  );
+});

--- a/framework/agent-session/README.md
+++ b/framework/agent-session/README.md
@@ -84,6 +84,12 @@ the record but marks the old Capsule attempt `unrecoverable`; it never invents
 process continuity. Terminal panes, splits, drawers and windows retain only
 stable identity references and are not part of the portable registry.
 
+Every client receives the same product-state projection for live and retained
+attempts: `available`, `starting`, `working`, `recovering`, `action-required`,
+or `ended`. Worker loss therefore remains visible as one `action-required`
+attempt with the single safe recommendation to start a new attempt or use
+provider-supported resume; ordinary GUI text does not expose process topology.
+
 The retained Mac source qualification proves main-process reconnect, provider
 exit fencing, worker-loss fail-closed behavior, bounded overflow gaps, receipt
 privacy, and sub-millisecond local RPC p95. Authenticated Codex 0.144.3 passes

--- a/framework/agent-session/kungfu-agent-session.contract.json
+++ b/framework/agent-session/kungfu-agent-session.contract.json
@@ -224,6 +224,28 @@
     "machineReboot": "persist-registry-and-mark-old-capsule-attempt-unrecoverable-before-new-attempt-or-provider-supported-resume",
     "fakePtyRecovery": false
   },
+  "productProjection": {
+    "schema": "kungfu.agent-session.product-state/v1",
+    "states": [
+      "available",
+      "starting",
+      "working",
+      "recovering",
+      "action-required",
+      "ended"
+    ],
+    "normalSurfaceProcessTerms": false,
+    "automaticStates": [
+      "starting",
+      "recovering"
+    ],
+    "actionRequiredRule": "Expose one product-level recommended action only when automatic recovery cannot continue safely.",
+    "workerLoss": {
+      "state": "action-required",
+      "recommendedAction": "start-new-attempt-or-provider-resume",
+      "fakeContinuity": false
+    }
+  },
   "capabilityDiscovery": {
     "schema": "kungfu.agent-session.capabilities/v1",
     "contractVersion": 1,
@@ -269,6 +291,7 @@
       "interactionPort",
       "providerProcess",
       "recovery",
+      "productProjection",
       "capabilityDiscovery",
       "compatibility",
       "valueSchemaBundle"
@@ -310,6 +333,9 @@
         "type": "object"
       },
       "recovery": {
+        "type": "object"
+      },
+      "productProjection": {
         "type": "object"
       },
       "capabilityDiscovery": {

--- a/framework/agent-session/src/product-surface.mjs
+++ b/framework/agent-session/src/product-surface.mjs
@@ -62,6 +62,68 @@ function sessionRef(value) {
   };
 }
 
+function sessionKey(workConsoleId, sessionAttemptId) {
+  return `${workConsoleId}\u0000${sessionAttemptId}`;
+}
+
+export function agentSessionProductState({
+  live = false,
+  lifecycleState = '',
+  interactionState = '',
+  attemptStatus = '',
+  providerCompatible = null,
+} = {}) {
+  const state = live ? lifecycleState : attemptStatus || lifecycleState;
+  let productState = 'recovering';
+  let reason = 'reattaching-session';
+  let recommendedAction = null;
+
+  if (state === 'ended' || state === 'exited') {
+    productState = 'ended';
+    reason = 'attempt-ended';
+  } else if (state === 'unrecoverable' || state === 'lost-control') {
+    productState = 'action-required';
+    reason = 'prior-attempt-cannot-be-reattached';
+    recommendedAction = 'start-new-attempt-or-provider-resume';
+  } else if (live && interactionState === 'approval-needed') {
+    productState = 'action-required';
+    reason = 'provider-request-needs-review';
+    recommendedAction = 'review-provider-request';
+  } else if (
+    live &&
+    interactionState === 'unknown' &&
+    providerCompatible === false
+  ) {
+    productState = 'action-required';
+    reason = 'interaction-state-needs-review';
+    recommendedAction = 'inspect-session-and-choose-resume-or-new-attempt';
+  } else if (state === 'degraded') {
+    productState = 'action-required';
+    reason = 'automatic-recovery-cannot-continue';
+    recommendedAction = 'inspect-session-and-choose-resume-or-new-attempt';
+  } else if (state === 'starting' || state === 'planned') {
+    productState = 'starting';
+    reason = 'attempt-starting';
+  } else if (live && interactionState === 'busy') {
+    productState = 'working';
+    reason = 'provider-working';
+  } else if (
+    live &&
+    lifecycleState === 'ready' &&
+    interactionState === 'ready'
+  ) {
+    productState = 'available';
+    reason = 'ready-for-input';
+  }
+
+  return {
+    schema: 'kungfu.agent-session.product-state/v1',
+    state: productState,
+    reason,
+    recommendedAction,
+  };
+}
+
 function publicStatus(session) {
   const status = session.port.status();
   const controller = status.controllerLease;
@@ -99,6 +161,12 @@ function publicStatus(session) {
       : null,
     workOutcome: null,
     proof: null,
+    product: agentSessionProductState({
+      live: true,
+      lifecycleState: status.lifecycleState,
+      interactionState: status.interactionState,
+      providerCompatible: status.providerAdapter?.compatible ?? null,
+    }),
     ...(status.transportRoute
       ? {
           transportRoute: status.transportRoute,
@@ -214,16 +282,49 @@ export class AgentSessionProductSurface {
   }
 
   list() {
-    this.registry.observe(this.runtime.list());
-    const sessions = this.runtime
-      .list()
-      .map((session) => publicStatus(session));
+    const runtimeSessions = this.runtime.list();
+    this.registry.observe(runtimeSessions);
+    const sessions = runtimeSessions.map((session) => publicStatus(session));
     const consoles = this.registry.snapshot().consoles;
+    const liveByAttempt = new Map(
+      sessions.map((session) => [
+        sessionKey(session.workConsoleId, session.sessionAttemptId),
+        session,
+      ]),
+    );
+    const attempts = consoles.flatMap((console) =>
+      console.attempts.map((attempt) => {
+        const live = liveByAttempt.get(
+          sessionKey(console.consoleId, attempt.sessionAttemptId),
+        );
+        return {
+          schema: 'kungfu.agent-session.attempt-presentation/v1',
+          workConsoleId: console.consoleId,
+          sessionAttemptId: attempt.sessionAttemptId,
+          provider: attempt.provider,
+          live: Boolean(live),
+          lifecycleState: live?.lifecycleState ?? attempt.status,
+          interactionState: live?.interactionState ?? 'unavailable',
+          inputAdmission: live?.inputAdmission ?? 'closed',
+          queuedInstructions: live?.queuedInstructions ?? 0,
+          providerAdapter: live?.providerAdapter ?? {
+            provider: attempt.provider,
+            providerVersion: attempt.providerVersion,
+            compatible: false,
+            reason: 'attempt-not-live',
+          },
+          product:
+            live?.product ??
+            agentSessionProductState({ attemptStatus: attempt.status }),
+        };
+      }),
+    );
     return {
       schema: 'kungfu.agent-session.surface-list/v1',
       sessions,
       consoles,
-      listRoot: agentSessionSurfaceRoot({ sessions, consoles }),
+      attempts,
+      listRoot: agentSessionSurfaceRoot({ sessions, consoles, attempts }),
     };
   }
 
@@ -260,6 +361,9 @@ export class AgentSessionProductSurface {
         controller: null,
         workOutcome: null,
         proof: null,
+        product: agentSessionProductState({
+          attemptStatus: projection.attempt.status,
+        }),
         console: projection.console,
         attempt: projection.attempt,
       };

--- a/framework/agent-session/tests/product-recovery-qualification.test.mjs
+++ b/framework/agent-session/tests/product-recovery-qualification.test.mjs
@@ -288,6 +288,14 @@ test('detached product worker passes the retained recovery, privacy, and latency
     ).status,
     'unrecoverable',
   );
+  const lostPresentation = afterLoss.attempts.find(
+    (attempt) => attempt.sessionAttemptId === lostRef.sessionAttemptId,
+  );
+  assert.equal(lostPresentation.product.state, 'action-required');
+  assert.equal(
+    lostPresentation.product.recommendedAction,
+    'start-new-attempt-or-provider-resume',
+  );
   assert.equal(workers.length, 2);
   const lostStatus = await restartedMain.invoke({
     operation: 'status',

--- a/framework/agent-session/tests/product-surface.test.mjs
+++ b/framework/agent-session/tests/product-surface.test.mjs
@@ -16,6 +16,7 @@ import { bindAgentSessionSurfaceRpc } from '../src/product-rpc.mjs';
 import { InProcessAgentSessionProductRuntime } from '../src/product-runtime.mjs';
 import {
   AgentSessionProductSurface,
+  agentSessionProductState,
   createAgentSessionSurfaceClient,
 } from '../src/product-surface.mjs';
 import { createProviderAdapter } from '../src/provider-adapters.mjs';
@@ -187,6 +188,40 @@ function fixture() {
   return { clients, input, runtime, surface };
 }
 
+test('product state hides process topology and reserves action-required for unsafe recovery', () => {
+  assert.deepEqual(
+    agentSessionProductState({
+      live: true,
+      lifecycleState: 'ready',
+      interactionState: 'busy',
+    }),
+    {
+      schema: 'kungfu.agent-session.product-state/v1',
+      state: 'working',
+      reason: 'provider-working',
+      recommendedAction: null,
+    },
+  );
+  assert.deepEqual(
+    agentSessionProductState({ attemptStatus: 'unrecoverable' }),
+    {
+      schema: 'kungfu.agent-session.product-state/v1',
+      state: 'action-required',
+      reason: 'prior-attempt-cannot-be-reattached',
+      recommendedAction: 'start-new-attempt-or-provider-resume',
+    },
+  );
+  assert.equal(
+    agentSessionProductState({
+      live: true,
+      lifecycleState: 'ready',
+      interactionState: 'unknown',
+      providerCompatible: true,
+    }).state,
+    'recovering',
+  );
+});
+
 test('Core resolves one primary WorkConsole for a generic WorkRef', () => {
   const { clients, input } = fixture();
   const first = clients.gui.resolveConsole({
@@ -241,6 +276,7 @@ test('one Go action starts once, auto-attaches, and later views reuse the Capsul
   assert.equal(runtime.spawnCount, 1);
   const registry = clients.cli.list();
   assert.equal(registry.consoles.length, 1);
+  assert.equal(registry.attempts[0].product.state, 'recovering');
   assert.equal(registry.consoles[0].attempts[0].status, 'running');
   assert.equal(
     registry.consoles[0].attempts[0].receipts.some(

--- a/framework/contract/kungfu-agent-first-canonical-policy.json
+++ b/framework/contract/kungfu-agent-first-canonical-policy.json
@@ -205,13 +205,13 @@
       },
       "source": {
         "path": "framework/agent-session/kungfu-agent-session.contract.json",
-        "sha256": "sha256:992f277c9f3bace704f82e85c7985201a235fb6d92888602d19589ce25530c10",
-        "renderedSha256": "sha256:992f277c9f3bace704f82e85c7985201a235fb6d92888602d19589ce25530c10",
+        "sha256": "sha256:c9e69800339341e8f74850270881fda13b4c1777c417ddbda3f5e16a1ae8e8b7",
+        "renderedSha256": "sha256:c9e69800339341e8f74850270881fda13b4c1777c417ddbda3f5e16a1ae8e8b7",
         "byteForByte": true
       },
       "artifact": {
         "path": "config/kungfu-agent-session.contract.json",
-        "expectedSha256": "sha256:992f277c9f3bace704f82e85c7985201a235fb6d92888602d19589ce25530c10"
+        "expectedSha256": "sha256:c9e69800339341e8f74850270881fda13b4c1777c417ddbda3f5e16a1ae8e8b7"
       }
     }
   ]


### PR DESCRIPTION
## Summary

- project live and retained Agent Session attempts into one product recovery vocabulary
- keep worker-loss attempts visible with a safe action-required recommendation
- remove ordinary Capsule terminology from the terminal product surface
- repair the ADR-0087 evidence SHA rewritten by the immediately preceding rebase merge

## Verification

- ./shifu test:agent-session-product-surfaces (16/16)
- ./shifu --filter @kungfu-tech/kfx-view-terminal test (8/8)
- ./shifu test:agent-session-recovery-qualification (passed; local list RPC p95 1.143 ms)
- ./shifu check:source (passed; 272 code tests and 61 docs contract tests)
- git diff --check

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "stage-ready",
  "adrs": ["ADR-0081"],
  "summary": "Project retained and live Agent Session attempts into one product recovery vocabulary and keep worker-loss action visible without process terminology",
  "verification": [
    "./shifu test:agent-session-product-surfaces",
    "./shifu --filter @kungfu-tech/kfx-view-terminal test",
    "./shifu test:agent-session-recovery-qualification",
    "./shifu check:source"
  ]
}
-->