### PR TITLE
fix(gui): close packaged agent session gaps

### DIFF
--- a/extensions/terminal/src/view/agent-session-snapshot.ts
+++ b/extensions/terminal/src/view/agent-session-snapshot.ts
@@ -1,0 +1,19 @@
+export type AgentSessionSurfaceSnapshot = {
+  retainedTranscript?: boolean;
+  terminal?: {
+    vt?: {
+      lines?: string[];
+    };
+  };
+};
+
+export function agentSessionSnapshotText(
+  snapshot: AgentSessionSurfaceSnapshot | null,
+): string {
+  const lines = snapshot?.terminal?.vt?.lines;
+  if (lines) return lines.join('\n');
+  if (snapshot?.retainedTranscript === false) {
+    return 'Structured provider session active · terminal transcript is intentionally not retained.';
+  }
+  return 'Waiting for Capsule output…';
+}

--- a/extensions/terminal/src/view/index.tsx
+++ b/extensions/terminal/src/view/index.tsx
@@ -57,6 +57,7 @@ import {
   agentSessionProductLabel,
   resolveAgentSessionProduct,
 } from './agent-session-presentation';
+import { agentSessionSnapshotText } from './agent-session-snapshot';
 import {
   DEFAULT_PANE_LAYOUT,
   type PaneLayoutAxis,
@@ -764,7 +765,8 @@ type CapsuleSurfaceList = {
 
 type CapsuleSurfaceSnapshot = {
   status: CapsuleSurfaceStatus;
-  terminal: { vt: { lines: string[] } };
+  terminal?: { vt?: { lines: string[] } };
+  retainedTranscript?: boolean;
 };
 
 async function invokeAgentSession(
@@ -809,11 +811,20 @@ function CapsuleSessionPane({
     let active = true;
     const pull = async () => {
       try {
-        const value = (await invokeAgentSession(caps, {
+        const received = (await invokeAgentSession(caps, {
           operation: 'snapshot',
           session: ref,
           requestedSequence: 0,
         })) as unknown as CapsuleSurfaceSnapshot;
+        const value = received.status
+          ? received
+          : {
+              ...received,
+              status: (await invokeAgentSession(caps, {
+                operation: 'status',
+                session: ref,
+              })) as unknown as CapsuleSurfaceStatus,
+            };
         if (!active) return;
         setSnapshot(value);
         if (value.status.lifecycleState === 'ended') onExit?.(pane);
@@ -961,8 +972,7 @@ function CapsuleSessionPane({
           fontSize: 12,
         }}
       >
-        {snapshot?.terminal.vt.lines.join('\n') ??
-          'Waiting for Capsule output…'}
+        {agentSessionSnapshotText(snapshot)}
       </pre>
       {!ended && (
         <div

--- a/extensions/terminal/tests/agent-session-snapshot.test.ts
+++ b/extensions/terminal/tests/agent-session-snapshot.test.ts
@@ -1,0 +1,21 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { agentSessionSnapshotText } from '../src/view/agent-session-snapshot.ts';
+
+test('renders retained PTY transcript lines', () => {
+  assert.equal(
+    agentSessionSnapshotText({ terminal: { vt: { lines: ['one', 'two'] } } }),
+    'one\ntwo',
+  );
+});
+
+test('renders structured-session status without requiring a terminal snapshot', () => {
+  assert.equal(
+    agentSessionSnapshotText({ retainedTranscript: false }),
+    'Structured provider session active · terminal transcript is intentionally not retained.',
+  );
+});
+
+test('renders the waiting state before a snapshot arrives', () => {
+  assert.equal(agentSessionSnapshotText(null), 'Waiting for Capsule output…');
+});

--- a/framework/agent-session/src/codex-app-server-product.mjs
+++ b/framework/agent-session/src/codex-app-server-product.mjs
@@ -418,6 +418,7 @@ export class CodexAppServerProductRuntime {
       status,
       snapshot: () => ({
         schema: 'kungfu.agent-session.structured-snapshot/v1',
+        status: status(),
         sessionAttemptId: plan.sessionAttemptId,
         providerSessionId: state.providerSessionId,
         providerTurnId: state.providerTurnId,

--- a/framework/agent-session/tests/codex-app-server-product.test.mjs
+++ b/framework/agent-session/tests/codex-app-server-product.test.mjs
@@ -225,6 +225,11 @@ test('GUI CLI and Agent share one frozen structured route and exact controls', a
   assert.equal(status.foreground.providerSessionId, 'thread-product');
   assert.equal(status.transportRoute.hotSwitch, false);
   assert.equal(status.workOutcome, null);
+  const snapshot = product.invoke({ operation: 'snapshot', session: ref });
+  assert.equal(snapshot.status.sessionAttemptId, ref.sessionAttemptId);
+  assert.equal(snapshot.status.output.kind, 'structured-events');
+  assert.equal(snapshot.retainedTranscript, false);
+  assert.equal(Object.hasOwn(snapshot, 'terminal'), false);
 
   const instruction = { text: 'redacted product instruction' };
   const instructionPlan = product.invoke({

--- a/framework/core/src/python/kungfu/agent/runtime_profiles.py
+++ b/framework/core/src/python/kungfu/agent/runtime_profiles.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import copy
 import hashlib
 import os
+import re
 import shutil
 import subprocess
 from datetime import UTC, datetime
@@ -27,6 +28,14 @@ PROVIDERS = ("codex", "claude")
 BACKENDS = ("tmux", "direct")
 CWD_POLICIES = ("workspace-root", "home", "inherit")
 _VERSION_TIMEOUT_SECONDS = 5.0
+_SEMANTIC_VERSION = re.compile(
+    r"(?<![0-9])([0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?)(?![0-9])"
+)
+
+
+def _parse_semantic_version(output: str) -> str | None:
+    match = _SEMANTIC_VERSION.search(output)
+    return match.group(1) if match else None
 
 
 def _profile_id(provider: str, path_class: str, path: str) -> str:
@@ -345,9 +354,14 @@ def verify_profile(profile: Mapping[str, Any]) -> dict[str, Any]:
                 check=False,
             )
             text = (result.stdout or result.stderr or "").strip()
-            version = text.splitlines()[0] if text else None
             if result.returncode != 0:
                 error = f"version probe exited {result.returncode}"
+            elif text:
+                version = _parse_semantic_version(text.splitlines()[0])
+                if version is None:
+                    error = "version probe did not return a semantic version"
+            else:
+                error = "version probe returned no output"
         except (OSError, subprocess.SubprocessError) as exc:
             error = str(exc)
     else:

--- a/framework/core/tests/python/test_agent_console_contract.py
+++ b/framework/core/tests/python/test_agent_console_contract.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 import json
+from types import SimpleNamespace
 import sys
 
 import click
@@ -152,6 +153,34 @@ def test_discovery_returns_path_and_app_candidates_without_first_hit_collapse():
     assert all(row.found for row in rows)
     assert rows[0].path == "/usr/local/bin/codex"
     assert rows[1].path.endswith("/Contents/Resources/codex")
+
+
+@pytest.mark.parametrize(
+    ("provider_output", "expected"),
+    [
+        ("codex-cli 0.144.3\n", "0.144.3"),
+        ("2.1.209 (Claude Code)\n", "2.1.209"),
+    ],
+)
+def test_runtime_profile_verification_returns_a_semantic_provider_version(
+    monkeypatch, provider_output, expected
+):
+    monkeypatch.setattr(
+        runtime_profiles.subprocess,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(
+            returncode=0, stdout=provider_output, stderr=""
+        ),
+    )
+    result = runtime_profiles.verify_profile(
+        {
+            "id": "provider.path.test",
+            "provider": "codex",
+            "launch": {"executable": sys.executable},
+        }
+    )
+    assert result["ok"] is True
+    assert result["version"] == expected
 
 
 def test_runtime_profile_plan_apply_default_and_remove_are_preview_first(

--- a/framework/gui/src/renderer/src/runtime.ts
+++ b/framework/gui/src/renderer/src/runtime.ts
@@ -311,7 +311,7 @@ function createRuntime(): Runtime {
         return result.stdout;
       },
     });
-    const agentSession = createAgentSessionProxy(atlasIpc);
+    const agentSession = createAgentSessionProxy(cliIpc);
     const workspace = openWorkspaceGuidance(cliOptions);
     const remoteWork = openRemoteWork({
       binding,

--- a/scripts/check-typescript-files.mjs
+++ b/scripts/check-typescript-files.mjs
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: Apache-2.0
+// @ts-check
+
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import ts from 'typescript';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+function normalize(file) {
+  return path.resolve(file).replaceAll('\\', '/');
+}
+
+export function typeDiagnosticsForFiles(project, files, root = ROOT) {
+  const projectPath = path.resolve(root, project);
+  const config = ts.readConfigFile(projectPath, ts.sys.readFile);
+  if (config.error) return [config.error];
+
+  const parsed = ts.parseJsonConfigFileContent(
+    config.config,
+    ts.sys,
+    path.dirname(projectPath),
+    undefined,
+    projectPath,
+  );
+  if (parsed.errors.length) return parsed.errors;
+
+  const targets = new Set(
+    files.map((file) => normalize(path.resolve(root, file))),
+  );
+  const included = new Set(parsed.fileNames.map(normalize));
+  const missing = [...targets].filter((file) => !included.has(file));
+  if (missing.length) {
+    throw new Error(
+      `files are outside ${path.relative(root, projectPath)}: ${missing
+        .map((file) => path.relative(root, file))
+        .join(', ')}`,
+    );
+  }
+
+  const program = ts.createProgram({
+    rootNames: parsed.fileNames,
+    options: parsed.options,
+    projectReferences: parsed.projectReferences,
+  });
+  return ts
+    .getPreEmitDiagnostics(program)
+    .filter(
+      (diagnostic) =>
+        diagnostic.file && targets.has(normalize(diagnostic.file.fileName)),
+    );
+}
+
+function parseArgs(argv) {
+  const projectIndex = argv.indexOf('--project');
+  if (projectIndex === -1 || !argv[projectIndex + 1]) {
+    throw new Error(
+      'usage: check-typescript-files.mjs --project <tsconfig> <files...>',
+    );
+  }
+  const project = argv[projectIndex + 1];
+  const files = argv.filter(
+    (_arg, index) => index !== projectIndex && index !== projectIndex + 1,
+  );
+  if (!files.length)
+    throw new Error('at least one TypeScript file is required');
+  return { project, files };
+}
+
+function main() {
+  const { project, files } = parseArgs(process.argv.slice(2));
+  const diagnostics = typeDiagnosticsForFiles(project, files);
+  if (diagnostics.length) {
+    process.stderr.write(
+      ts.formatDiagnosticsWithColorAndContext(diagnostics, {
+        getCanonicalFileName: (file) => file,
+        getCurrentDirectory: () => ROOT,
+        getNewLine: () => '\n',
+      }),
+    );
+    process.exitCode = 1;
+    return;
+  }
+  console.log(
+    `[typescript-files] project=${project} checked=${files.length} passed`,
+  );
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  try {
+    main();
+  } catch (error) {
+    console.error(
+      `[typescript-files] ${error instanceof Error ? error.message : String(error)}`,
+    );
+    process.exit(1);
+  }
+}

--- a/scripts/check-typescript-files.test.mjs
+++ b/scripts/check-typescript-files.test.mjs
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import { typeDiagnosticsForFiles } from './check-typescript-files.mjs';
+
+test('file-scoped type check reports only diagnostics owned by requested files', (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'kungfu-ts-files-'));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  fs.writeFileSync(
+    path.join(root, 'tsconfig.json'),
+    JSON.stringify({
+      compilerOptions: { strict: true, noEmit: true },
+      include: ['*.ts'],
+    }),
+  );
+  fs.writeFileSync(path.join(root, 'good.ts'), 'export const value = 1;\n');
+  fs.writeFileSync(
+    path.join(root, 'bad.ts'),
+    'export const value = missingValue;\n',
+  );
+
+  assert.deepEqual(
+    typeDiagnosticsForFiles('tsconfig.json', ['good.ts'], root),
+    [],
+  );
+  const diagnostics = typeDiagnosticsForFiles(
+    'tsconfig.json',
+    ['bad.ts'],
+    root,
+  );
+  assert.deepEqual(
+    diagnostics.map((diagnostic) => diagnostic.code),
+    [2304],
+  );
+});

--- a/scripts/source-acceptance.mjs
+++ b/scripts/source-acceptance.mjs
@@ -164,6 +164,7 @@ export function sourceAcceptancePlan(files) {
       args: [
         '--test',
         'scripts/buildchain-install.test.mjs',
+        'scripts/check-typescript-files.test.mjs',
         'scripts/source-acceptance.test.mjs',
         'scripts/check-shifu-entry-contract.test.mjs',
         'scripts/check-shifu-cache-contract.test.mjs',
@@ -189,6 +190,7 @@ export function sourceAcceptancePlan(files) {
         'framework/agent-session/tests/codex-app-server-product.test.mjs',
         'framework/agent-session/tests/product-surface.test.mjs',
         'framework/agent-session/tests/product-detached-host.test.mjs',
+        'extensions/terminal/tests/agent-session-snapshot.test.ts',
         'framework/core/tests/qualification/runtime-activation/run.test.mjs',
         'framework/core/tests/qualification/durability/run.test.mjs',
         'framework/core/tests/qualification/durability/powercut_plan.test.mjs',
@@ -232,6 +234,22 @@ export function sourceAcceptancePlan(files) {
         'check',
         '--no-errors-on-unmatched',
         ...web,
+      ],
+    });
+  }
+
+  const guiTypeScript = files.filter(
+    (file) => file.startsWith('framework/gui/src/') && /\.tsx?$/.test(file),
+  );
+  if (guiTypeScript.length) {
+    plan.push({
+      label: 'changed GUI TypeScript check',
+      command: process.execPath,
+      args: [
+        'scripts/check-typescript-files.mjs',
+        '--project',
+        'framework/gui/tsconfig.json',
+        ...guiTypeScript,
       ],
     });
   }

--- a/scripts/source-acceptance.test.mjs
+++ b/scripts/source-acceptance.test.mjs
@@ -113,6 +113,9 @@ test('source plan covers representative source-only checks', () => {
   assert.ok(
     contractTests.args.includes('scripts/check-upgrade-contract.test.mjs'),
   );
+  assert.ok(
+    contractTests.args.includes('scripts/check-typescript-files.test.mjs'),
+  );
   const upgradeTests = plan.find(
     (step) => step.label === 'runtime upgrade control-plane tests',
   );
@@ -189,6 +192,24 @@ test('Conan recipe Python is linted without widening into the product type basel
   assert.ok(labels.includes('changed Python format'));
   assert.ok(labels.includes('changed Python lint'));
   assert.ok(!labels.includes('Python type baseline'));
+});
+
+test('changed GUI TypeScript receives a file-scoped semantic check', () => {
+  const plan = sourceAcceptancePlan([
+    'framework/gui/src/renderer/src/runtime.ts',
+    'framework/gui/src/renderer/src/app.tsx',
+    'framework/gui/src/renderer/src/theme.css',
+  ]);
+  const typeCheck = plan.find(
+    (step) => step.label === 'changed GUI TypeScript check',
+  );
+  assert.deepEqual(typeCheck?.args, [
+    'scripts/check-typescript-files.mjs',
+    '--project',
+    'framework/gui/tsconfig.json',
+    'framework/gui/src/renderer/src/runtime.ts',
+    'framework/gui/src/renderer/src/app.tsx',
+  ]);
 });
 
 test('RocksDB source archive keeps an explicit tar filename', () => {


### PR DESCRIPTION
## Summary

Close three implementation defects found by real macOS packaged GUI dogfood. This does not alter the accepted Agent Session, capability-boundary, or structured-provider architecture contracts.

## Changes

- route Agent Session actions through the generic CLI IPC capability
- normalize Codex and Claude version-probe output to semantic versions
- include product status in structured snapshots and keep old workers reattachable through a status fallback
- render structured sessions without assuming a retained terminal transcript
- add a changed-file semantic TypeScript gate for GUI sources

## Verification

- `./shifu check:source` (281 Node contract tests; 13 runtime-upgrade tests; TypeScript, Biome, Ruff, and mypy passed)
- `./shifu product gui pack`
- real packaged Codex 0.144.3: launch, full GUI quit, same worker/provider PID reattach, semantic instruction receipt, ready recovery, 0 console errors/warnings
- real packaged Claude 2.1.209: workspace-trust modal, full GUI quit, same worker/provider PID reattach, 0 console errors/warnings; authenticated provider work remains a nonclaim because PATH Claude reports not logged in
- live-peer continuity qualification: passed; paired report/raw bundle hashes `86f1f9b6e...` / `d142c680e...`
- runtime activation/product qualification: passed; paired report/raw bundle hashes `01d9300ec...` / `396e0c260...`
- zero-burden aggregate: 6/6, passed; paired report/raw bundle hashes `09b935cba...` / `0ac836cb3...`

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Fix packaged GUI IPC wiring, provider version parsing, and structured snapshot rendering defects without changing architecture contracts or supported claims"
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [x] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The provider boundary remains pinned and redacted; no transcript or credential material is retained. Qualification reports remain source/platform-bound and preserve current nonclaims.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Existing qualification documentation remains accurate because this bugfix does not widen claims
