### PR TITLE
fix(docs): reject PR-only ADR commit evidence

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -27,6 +27,8 @@ on:
       - "scripts/check-docs.test.mjs"
       - "scripts/check-docs-toolchain.mjs"
       - "scripts/check-docs-toolchain.test.mjs"
+      - "scripts/document-metadata-contract.mjs"
+      - "scripts/document-metadata-contract.test.mjs"
       - "scripts/run-docs-check.mjs"
       - "scripts/run-docs-examples.mjs"
       - "scripts/run-docs-readonly.mjs"
@@ -60,6 +62,7 @@ jobs:
 
       - name: Run blocking documentation Gate closure
         env:
+          KUNGFU_ADR_EVIDENCE_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           KUNGFU_DOCS_TOOL_CACHE: ${{ runner.temp }}/kungfu-docs-tools
         run: ./shifu gate run docs.prose
 

--- a/docs/development/document-metadata.md
+++ b/docs/development/document-metadata.md
@@ -141,7 +141,11 @@ qualification_refs: [docs/qualification/mmap-performance.md]
 ```
 
 - `implementation_commits` contains full 40-character SHAs for implementation
-  slices.
+  slices that are already reachable from the target mainline. Do not record a
+  commit that exists only on the current pull-request branch: rebase and squash
+  merges rewrite that identity. Use `implementation_prs` while the work is in
+  review, then add the merged mainline SHA in a later change when commit-level
+  evidence is still useful.
 - `implementation_prs` contains stable pull-request URLs when review history is
   part of the evidence.
 - `closure_commit` identifies the reachable commit at which the accepted scope
@@ -154,9 +158,11 @@ qualification_refs: [docs/qualification/mmap-performance.md]
 
 The gate validates shape, repository identity, local commit existence,
 reachability from the checked-out mainline, canonical repository identity for
-PR evidence, and contradictions such as evidence on a `not-started` ADR. It
-cannot prove that code semantically fulfills a decision. That judgment remains
-a review responsibility.
+PR evidence, and contradictions such as evidence on a `not-started` ADR. On a
+pull request, the blocking documentation workflow pins reachability to the
+exact base SHA, so a commit that exists only in the merge preview fails before
+it can enter the mainline. The gate cannot prove that code semantically
+fulfills a decision. That judgment remains a review responsibility.
 
 ## Release admissibility projection
 

--- a/scripts/document-metadata-contract.mjs
+++ b/scripts/document-metadata-contract.mjs
@@ -240,17 +240,34 @@ function isolatedGitEnvironment() {
   );
 }
 
-/** @param {string} root @param {string} commit */
-export function validateReachableCommit(root, commit) {
-  if (!/^[0-9a-f]{40}$/.test(commit))
-    return 'must be a full 40-character lowercase Git SHA';
-  const exists = childProcess.spawnSync(
-    'git',
-    ['cat-file', '-e', `${commit}^{commit}`],
-    { cwd: root, env: isolatedGitEnvironment(), stdio: 'ignore' },
-  );
-  if (exists.status !== 0) return 'does not identify a commit in this checkout';
+/**
+ * @param {string} root
+ * @param {string | undefined} pullRequestBaseCommit
+ */
+function reachabilityRoots(root, pullRequestBaseCommit) {
   const env = isolatedGitEnvironment();
+  if (pullRequestBaseCommit) {
+    if (!/^[0-9a-f]{40}$/.test(pullRequestBaseCommit)) {
+      throw new Error(
+        'KUNGFU_ADR_EVIDENCE_BASE_SHA must be a full 40-character lowercase Git SHA',
+      );
+    }
+    const exists = childProcess.spawnSync(
+      'git',
+      ['cat-file', '-e', `${pullRequestBaseCommit}^{commit}`],
+      { cwd: root, env, stdio: 'ignore' },
+    );
+    if (exists.status !== 0) {
+      throw new Error(
+        `KUNGFU_ADR_EVIDENCE_BASE_SHA does not identify a commit in this checkout: ${pullRequestBaseCommit}`,
+      );
+    }
+    return {
+      roots: [pullRequestBaseCommit],
+      label: `pull-request base history ${pullRequestBaseCommit}`,
+    };
+  }
+
   const roots = ['HEAD'];
   const mergeHead = childProcess.spawnSync(
     'git',
@@ -260,7 +277,26 @@ export function validateReachableCommit(root, commit) {
   if (mergeHead.status === 0 && mergeHead.stdout.trim()) {
     roots.push(mergeHead.stdout.trim());
   }
-  for (const candidate of roots) {
+  return { roots, label: 'the checked-out mainline history' };
+}
+
+/**
+ * @param {string} root
+ * @param {string} commit
+ * @param {string | undefined} [pullRequestBaseCommit]
+ */
+export function validateReachableCommit(root, commit, pullRequestBaseCommit) {
+  if (!/^[0-9a-f]{40}$/.test(commit))
+    return 'must be a full 40-character lowercase Git SHA';
+  const exists = childProcess.spawnSync(
+    'git',
+    ['cat-file', '-e', `${commit}^{commit}`],
+    { cwd: root, env: isolatedGitEnvironment(), stdio: 'ignore' },
+  );
+  if (exists.status !== 0) return 'does not identify a commit in this checkout';
+  const env = isolatedGitEnvironment();
+  const reachability = reachabilityRoots(root, pullRequestBaseCommit);
+  for (const candidate of reachability.roots) {
     const reachable = childProcess.spawnSync(
       'git',
       ['merge-base', '--is-ancestor', commit, candidate],
@@ -268,12 +304,20 @@ export function validateReachableCommit(root, commit) {
     );
     if (reachable.status === 0) return null;
   }
-  return 'is not reachable from the checked-out mainline history';
+  return `is not reachable from ${reachability.label}`;
 }
 
-/** @param {string} value @param {string} field @param {string} rel @param {number} line @param {string} root @param {Finding[]} findings */
-function checkCommit(value, field, rel, line, root, findings) {
-  const problem = validateReachableCommit(root, value);
+/** @param {string} value @param {string} field @param {string} rel @param {number} line @param {string} root @param {Finding[]} findings @param {string | undefined} pullRequestBaseCommit */
+function checkCommit(
+  value,
+  field,
+  rel,
+  line,
+  root,
+  findings,
+  pullRequestBaseCommit,
+) {
+  const problem = validateReachableCommit(root, value, pullRequestBaseCommit);
   if (problem) {
     findings.push({
       code: 'adr-evidence-commit',
@@ -284,8 +328,15 @@ function checkCommit(value, field, rel, line, root, findings) {
   }
 }
 
-/** @param {Map<string, {value: unknown, line: number}>} fields @param {string} rel @param {string} root @param {MetadataContract} contract @param {Finding[]} findings */
-function validateAdrEvidence(fields, rel, root, contract, findings) {
+/** @param {Map<string, {value: unknown, line: number}>} fields @param {string} rel @param {string} root @param {MetadataContract} contract @param {Finding[]} findings @param {string | undefined} pullRequestBaseCommit */
+function validateAdrEvidence(
+  fields,
+  rel,
+  root,
+  contract,
+  findings,
+  pullRequestBaseCommit,
+) {
   const evidence = contract.adrEvidence;
   if (!evidence) return;
   const id = String(fields.get('adr_id')?.value || '');
@@ -372,6 +423,7 @@ function validateAdrEvidence(fields, rel, root, contract, findings) {
         commits.line,
         root,
         findings,
+        pullRequestBaseCommit,
       );
   }
   if (closureCommit) {
@@ -382,6 +434,7 @@ function validateAdrEvidence(fields, rel, root, contract, findings) {
       closureCommit.line,
       root,
       findings,
+      pullRequestBaseCommit,
     );
   }
   const prPattern = new RegExp(evidence.pullRequestPattern);
@@ -416,6 +469,7 @@ function validateAdrEvidence(fields, rel, root, contract, findings) {
           qualifications.line,
           root,
           findings,
+          pullRequestBaseCommit,
         );
       } else if (
         path.isAbsolute(value) ||
@@ -434,12 +488,18 @@ function validateAdrEvidence(fields, rel, root, contract, findings) {
 }
 
 /**
- * @param {{root?: string, files: string[], contract?: MetadataContract}} options
+ * @param {{root?: string, files: string[], contract?: MetadataContract, evidenceBaseCommit?: string}} options
  * @returns {Finding[]}
  */
 export function validateDocumentMetadata(options) {
   const root = path.resolve(options.root || ROOT);
   const contract = options.contract || readMetadataContract(root);
+  const pullRequestBaseCommit =
+    options.evidenceBaseCommit ||
+    (root === ROOT
+      ? process.env.KUNGFU_ADR_EVIDENCE_BASE_SHA?.trim()
+      : undefined) ||
+    undefined;
   /** @type {Finding[]} */
   const findings = [];
   const documents = new Map();
@@ -646,7 +706,14 @@ export function validateDocumentMetadata(options) {
           message: `visible status ${visible} differs from decision_status ${String(decision.value)}`,
         });
       }
-      validateAdrEvidence(fields, rel, root, contract, findings);
+      validateAdrEvidence(
+        fields,
+        rel,
+        root,
+        contract,
+        findings,
+        pullRequestBaseCommit,
+      );
     }
   }
 

--- a/scripts/document-metadata-contract.test.mjs
+++ b/scripts/document-metadata-contract.test.mjs
@@ -6,6 +6,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { afterEach, test } from 'node:test';
+import { fileURLToPath } from 'node:url';
 
 import {
   validateDocumentMetadata,
@@ -13,6 +14,10 @@ import {
 } from './document-metadata-contract.mjs';
 
 const roots = [];
+const REPO_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '..',
+);
 
 afterEach(() => {
   for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true });
@@ -471,7 +476,19 @@ test('accepts reachable full-SHA implementation and closure evidence', () => {
   assert.deepEqual(findings, []);
 });
 
-test('accepts evidence reachable through the active merge parent', () => {
+test('pins PR evidence reachability to the workflow base SHA', () => {
+  const workflow = fs.readFileSync(
+    path.join(REPO_ROOT, '.github/workflows/docs-check.yml'),
+    'utf8',
+  );
+  assert.match(workflow, /"scripts\/document-metadata-contract\.mjs"/);
+  assert.match(
+    workflow,
+    /KUNGFU_ADR_EVIDENCE_BASE_SHA:\s*\$\{\{ github\.event\.pull_request\.base\.sha \}\}/,
+  );
+});
+
+test('accepts a merge preview by default but rejects PR-only evidence against its base', () => {
   const root = fixture({ 'seed.txt': 'seed\n' });
   git(root, ['init', '-q']);
   git(root, ['config', 'user.name', 'Test']);
@@ -508,6 +525,11 @@ test('accepts evidence reachable through the active merge parent', () => {
 
   git(root, ['merge', '--no-commit', '--no-ff', 'evidence']);
   assert.equal(validateReachableCommit(root, evidence), null);
+  assert.match(
+    validateReachableCommit(root, evidence, base),
+    new RegExp(`is not reachable from pull-request base history ${base}`),
+  );
+  assert.equal(validateReachableCommit(root, base, base), null);
 });
 
 test('accepts stable PR implementation and closure evidence', () => {


### PR DESCRIPTION
## Summary

Reject ADR commit evidence that is reachable only through a pull request merge preview and would become unreachable after a rebase or squash merge.

## Related issue

None.

## Changes

- pin ADR evidence reachability to the pull request base SHA in the blocking documentation workflow
- retain the existing local/merge-preview behavior outside the pull request gate
- add regression coverage for branch-only evidence and workflow drift
- document the stable PR-evidence path for in-review implementation work

## Verification

- `KUNGFU_ADR_EVIDENCE_BASE_SHA=$(git rev-parse origin/dev/v4/v4.0) ./shifu gate run docs.prose`
- `./shifu check:source`
- staged commit gate

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bug fix strengthens validation of existing ADR evidence metadata without changing an architecture contract"
}
-->

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change is limited to validation of public ADR evidence metadata and fails closed against the immutable pull request base SHA. It does not publish or deploy artifacts.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed
