### PR TITLE
fix(gui): recover broken workspace runtimes

### DIFF
--- a/framework/gui/src/main/index.ts
+++ b/framework/gui/src/main/index.ts
@@ -18,7 +18,7 @@ import {
 // is spawned by this main process, so the runtime directory must be exported
 // here, before any window (and therefore the renderer process) is created.
 import { DEVELOPER_NAVIGATION, TOOLS_NAVIGATION } from '../navigation';
-
+import { isResettableRuntimeFailure } from '../runtime-recovery-contract';
 import {
   type RuntimeStatusPayload,
   type RuntimeStatusResult,
@@ -30,6 +30,7 @@ import {
   ENSURE_CHANNEL,
   HIDE_CHANNEL,
   PROFILE_CLI_EXEC_CHANNEL,
+  RUNTIME_BACKUP_RESET_CHANNEL,
   RUNTIME_STATUS_GET_CHANNEL,
   SET_BOUNDS_CHANNEL,
   SHELL_NAVIGATE_CHANNEL,
@@ -58,6 +59,7 @@ import {
   uninstallKungfuCliFromPath,
 } from './installCli';
 import { executeProfileCli } from './profile-cli';
+import { backupAndResetRuntime } from './runtime-recovery';
 import { type Rect, SandboxManager } from './sandbox-manager';
 import { bindSessionWindows } from './session-windows-host';
 import {
@@ -649,6 +651,48 @@ ipcMain.handle(WINDOW_CHROME_CONTROL_CHANNEL, (event, payload) => {
 });
 
 ipcMain.handle(RUNTIME_STATUS_GET_CHANNEL, () => readRuntimeStatus());
+ipcMain.handle(RUNTIME_BACKUP_RESET_CHANNEL, async (_event, payload) => {
+  const message = String((payload as { message?: unknown })?.message || '');
+  if (!isResettableRuntimeFailure(message)) {
+    return { ok: false, error: 'runtime failure is not resettable' };
+  }
+  const dataHome = process.env.KF_HOME || '';
+  const runtimeDir = process.env.KF_RUNTIME_DIR || '';
+  if (!dataHome || !runtimeDir || !workspaceRuntimeReady) {
+    return { ok: false, error: 'selected workspace runtime is unavailable' };
+  }
+  const confirmation = await dialog.showMessageBox({
+    type: 'warning',
+    buttons: ['Cancel', 'Back Up and Reset'],
+    defaultId: 0,
+    cancelId: 0,
+    message: 'Back up and reset this workspace runtime?',
+    detail:
+      'Kungfu will stop the workspace runtime, move the complete runtime directory into .kungfu/backups/runtime-recovery, create a fresh runtime, and relaunch. Workspace source files are not changed.',
+  });
+  if (confirmation.response !== 1) return { ok: false, canceled: true };
+  try {
+    execFileSync(kungfuBinPath(), ['runtime', 'stop'], {
+      env: process.env,
+      timeout: 15_000,
+    });
+    const receipt = backupAndResetRuntime({
+      dataHome,
+      runtimeDir,
+      reason: message,
+    });
+    setImmediate(() => {
+      if (desktopWorkspaceIsRegistryManaged) {
+        clearDesktopWorkspaceEnvForRelaunch(process.env);
+      }
+      app.relaunch();
+      app.exit(0);
+    });
+    return { ok: true, receipt };
+  } catch (error) {
+    return { ok: false, error: (error as Error).message };
+  }
+});
 
 function workspaceSnapshot() {
   return {
@@ -768,7 +812,7 @@ function buildMenu() {
       label: 'Show Agent Onboarding Brief',
       click: async () => {
         const kungfuBin = path.join(
-          path.dirname(process.env.KFE_PATH),
+          path.dirname(process.env.KFE_PATH || bindingPath),
           'kungfu',
         );
         try {

--- a/framework/gui/src/main/runtime-recovery.test.ts
+++ b/framework/gui/src/main/runtime-recovery.test.ts
@@ -1,0 +1,76 @@
+import assert from 'node:assert/strict';
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import { isResettableRuntimeFailure } from '../runtime-recovery-contract';
+import { backupAndResetRuntime } from './runtime-recovery';
+
+function fixture(name: string): { dataHome: string; runtimeDir: string } {
+  const dataHome = path.join(tmpdir(), `kungfu-gui-runtime-recovery-${name}`);
+  rmSync(dataHome, { recursive: true, force: true });
+  const runtimeDir = path.join(dataHome, 'runtime');
+  mkdirSync(runtimeDir, { recursive: true });
+  return { dataHome, runtimeDir };
+}
+
+test('classifies missing journal pages as resettable without blaming KFE_PATH', () => {
+  assert.equal(
+    isResettableRuntimeFailure(
+      'failed to open file for page /tmp/runtime/journal/a.1.journal, errno: No such file or directory',
+    ),
+    true,
+  );
+  assert.equal(isResettableRuntimeFailure('KFE_PATH not set'), false);
+  assert.equal(isResettableRuntimeFailure('journal epoch incompatible'), true);
+});
+
+test('backs up the complete runtime and creates an empty replacement', () => {
+  const { dataHome, runtimeDir } = fixture('success');
+  writeFileSync(path.join(runtimeDir, 'sentinel.json'), '{"kept":true}\n');
+
+  const receipt = backupAndResetRuntime({
+    dataHome,
+    runtimeDir,
+    reason: 'missing journal page',
+    now: new Date('2026-07-15T00:00:00.000Z'),
+  });
+
+  assert.equal(existsSync(runtimeDir), true);
+  assert.equal(existsSync(path.join(runtimeDir, 'sentinel.json')), false);
+  assert.equal(
+    readFileSync(path.join(receipt.backupPath, 'sentinel.json'), 'utf8'),
+    '{"kept":true}\n',
+  );
+  assert.deepEqual(
+    JSON.parse(
+      readFileSync(
+        path.join(receipt.backupPath, 'gui-runtime-recovery.json'),
+        'utf8',
+      ),
+    ),
+    receipt,
+  );
+});
+
+test('refuses to move a runtime outside the selected data home', () => {
+  const { dataHome } = fixture('boundary');
+  const otherRuntime = path.join(tmpdir(), 'kungfu-gui-runtime-other');
+  mkdirSync(otherRuntime, { recursive: true });
+  assert.throws(
+    () =>
+      backupAndResetRuntime({
+        dataHome,
+        runtimeDir: otherRuntime,
+        reason: 'boundary test',
+      }),
+    /outside the selected data home/u,
+  );
+});

--- a/framework/gui/src/main/runtime-recovery.ts
+++ b/framework/gui/src/main/runtime-recovery.ts
@@ -1,0 +1,79 @@
+import {
+  existsSync,
+  mkdirSync,
+  renameSync,
+  rmdirSync,
+  writeFileSync,
+} from 'node:fs';
+import path from 'node:path';
+
+export type RuntimeRecoveryReceipt = {
+  schema: 'kungfu.gui.runtime-recovery/v1';
+  recoveredAt: string;
+  originalRuntimeDir: string;
+  backupPath: string;
+  reason: string;
+};
+
+function timestampSegment(now: Date): string {
+  return now.toISOString().replaceAll(/[-:.]/gu, '');
+}
+
+function availableBackupPath(root: string, segment: string): string {
+  const candidate = path.join(root, `runtime-${segment}`);
+  if (!existsSync(candidate)) return candidate;
+  for (let suffix = 2; suffix < 10_000; suffix += 1) {
+    const next = `${candidate}-${suffix}`;
+    if (!existsSync(next)) return next;
+  }
+  throw new Error('could not allocate a unique runtime backup path');
+}
+
+export function backupAndResetRuntime(options: {
+  dataHome: string;
+  runtimeDir: string;
+  reason: string;
+  now?: Date;
+}): RuntimeRecoveryReceipt {
+  const dataHome = path.resolve(options.dataHome);
+  const runtimeDir = path.resolve(options.runtimeDir);
+  const expectedRuntimeDir = path.join(dataHome, 'runtime');
+  if (runtimeDir !== expectedRuntimeDir) {
+    throw new Error(
+      `refusing runtime recovery outside the selected data home: ${runtimeDir}`,
+    );
+  }
+  if (!existsSync(runtimeDir)) {
+    throw new Error(`runtime directory does not exist: ${runtimeDir}`);
+  }
+
+  const now = options.now ?? new Date();
+  const backupRoot = path.join(dataHome, 'backups', 'runtime-recovery');
+  mkdirSync(backupRoot, { recursive: true });
+  const backupPath = availableBackupPath(backupRoot, timestampSegment(now));
+  renameSync(runtimeDir, backupPath);
+  try {
+    mkdirSync(runtimeDir, { recursive: false });
+    const receipt: RuntimeRecoveryReceipt = {
+      schema: 'kungfu.gui.runtime-recovery/v1',
+      recoveredAt: now.toISOString(),
+      originalRuntimeDir: runtimeDir,
+      backupPath,
+      reason: options.reason,
+    };
+    writeFileSync(
+      path.join(backupPath, 'gui-runtime-recovery.json'),
+      `${JSON.stringify(receipt, null, 2)}\n`,
+      { encoding: 'utf8', flag: 'wx' },
+    );
+    return receipt;
+  } catch (error) {
+    try {
+      rmdirSync(runtimeDir);
+      renameSync(backupPath, runtimeDir);
+    } catch {
+      // Preserve the original failure. The backup path remains intact.
+    }
+    throw error;
+  }
+}

--- a/framework/gui/src/renderer/src/main.tsx
+++ b/framework/gui/src/renderer/src/main.tsx
@@ -36,11 +36,13 @@ import {
   primaryNavigation,
   profileHomeId,
 } from '../../navigation';
+import { isResettableRuntimeFailure } from '../../runtime-recovery-contract';
 import {
   type RuntimeStatusResult,
   deriveWorkspaceRuntimePresentation,
 } from '../../runtime-status';
 import {
+  RUNTIME_BACKUP_RESET_CHANNEL,
   RUNTIME_STATUS_GET_CHANNEL,
   SESSION_WINDOW_OPEN_CHANNEL,
   SESSION_WINDOW_RESTORE_CHANNEL,
@@ -716,6 +718,69 @@ function WorkspacePanel() {
           {recent.display_path || recent.workspace_root || 'Home Workspace'}
         </button>
       ))}
+      {error && <div style={{ ...mono, color: '#f48771' }}>{error}</div>}
+    </section>
+  );
+}
+
+function RuntimeFailurePanel({ message }: { message: string }) {
+  const [busy, setBusy] = React.useState(false);
+  const [error, setError] = React.useState('');
+  const resettable = isResettableRuntimeFailure(message);
+  const backupAndReset = () => {
+    setBusy(true);
+    setError('');
+    const ipcRenderer = (
+      window.require('electron') as {
+        ipcRenderer: {
+          invoke: (
+            channel: string,
+            payload: unknown,
+          ) => Promise<{ ok?: boolean; canceled?: boolean; error?: string }>;
+        };
+      }
+    ).ipcRenderer;
+    void ipcRenderer
+      .invoke(RUNTIME_BACKUP_RESET_CHANNEL, { message })
+      .then((result) => {
+        if (!result.ok && !result.canceled) {
+          setError(result.error || 'runtime recovery failed');
+        }
+      })
+      .catch((reason) => setError((reason as Error).message))
+      .finally(() => setBusy(false));
+  };
+  return (
+    <section style={{ ...panelStyle, width: 'min(680px, 100%)' }}>
+      <h2 style={{ margin: '0 0 8px', fontSize: 15 }}>
+        Workspace runtime unavailable
+      </h2>
+      <pre
+        style={{
+          ...mono,
+          color: '#f48771',
+          whiteSpace: 'pre-wrap',
+          overflowWrap: 'anywhere',
+        }}
+      >
+        {message || 'Unknown runtime startup failure'}
+      </pre>
+      {resettable && (
+        <>
+          <button
+            type="button"
+            disabled={busy}
+            onClick={backupAndReset}
+            style={{ ...mono, padding: '6px 10px' }}
+          >
+            {busy ? 'Preparing recovery…' : 'Back up and reset runtime'}
+          </button>
+          <div style={{ ...mono, color: '#858585', marginTop: 8 }}>
+            The current runtime is preserved under
+            .kungfu/backups/runtime-recovery before Kungfu creates a fresh one.
+          </div>
+        </>
+      )}
       {error && <div style={{ ...mono, color: '#f48771' }}>{error}</div>}
     </section>
   );
@@ -1788,10 +1853,7 @@ function App() {
             window.process.env.KF_WORKSPACE_STATE === 'unavailable' ? (
               <WorkspacePanel />
             ) : (
-              <p style={{ ...mono, color: '#f48771' }}>
-                binding unavailable — set KFE_PATH to a built
-                kungfu_electron.node
-              </p>
+              <RuntimeFailurePanel message={runtime.message} />
             )}
           </div>
         )}

--- a/framework/gui/src/runtime-recovery-contract.ts
+++ b/framework/gui/src/runtime-recovery-contract.ts
@@ -1,0 +1,14 @@
+export function isResettableRuntimeFailure(message: string): boolean {
+  const normalized = message.trim().toLowerCase();
+  if (!normalized) return false;
+  if (
+    normalized.includes('failed to open file for page') &&
+    normalized.includes('no such file or directory')
+  ) {
+    return true;
+  }
+  return (
+    /journal.*(corrupt|epoch|incompatible|missing)/u.test(normalized) ||
+    /(corrupt|epoch|incompatible|missing).*journal/u.test(normalized)
+  );
+}

--- a/framework/gui/src/sandbox/channels.ts
+++ b/framework/gui/src/sandbox/channels.ts
@@ -40,6 +40,7 @@ export const WINDOW_CHROME_CONTROL_CHANNEL = 'kf-window-chrome:control';
 export const WINDOW_CHROME_STATE_CHANNEL = 'kf-window-chrome:state';
 
 export const RUNTIME_STATUS_GET_CHANNEL = 'kf-runtime-status:get';
+export const RUNTIME_BACKUP_RESET_CHANNEL = 'kf-runtime:backup-reset';
 
 // trusted renderer -> main: asynchronous Profile and Agent CLI transports.
 // The renderer keeps native runtime access, but process startup and JSON reads


### PR DESCRIPTION
## Summary
- surface the real packaged runtime startup error instead of masking every failure as a missing KFE_PATH
- offer a guarded one-click backup/reset flow for missing, corrupt, or incompatible workspace journals
- preserve the complete previous runtime under `.kungfu/backups/runtime-recovery` and relaunch with a fresh runtime

## Verification
- `./shifu check:source`
- runtime/workspace Node tests: 7 passed
- `./shifu dist:dir` (Mac arm64, Conan requirements 12/12 from cache)
- packaged Electron qualification: binding loaded, `KF_GUI_QUALIFICATION_READY`
- Shifu build: `20260714T224018Z-586470b49`

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Fixes packaged GUI runtime error projection and adds a guarded backup-reset recovery action without changing an architecture contract or widening supported claims"
}
-->

## Governance risk check
- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The recovery receipt and registered local Product build are provenance surfaces only; this change does not publish or deploy artifacts.

## Checklist
- [x] Commit is signed off (DCO)
- [x] Existing architecture claims remain unchanged