### PR TITLE
refactor(core): express data member constraints as concepts

### DIFF
--- a/docs/adr/ADR-0082-cpp23-rx-core-language-strategy.md
+++ b/docs/adr/ADR-0082-cpp23-rx-core-language-strategy.md
@@ -224,6 +224,14 @@ independently:
    exclusive by construction; the payoff is that an unsatisfied constraint now
    reports "constraints not satisfied" instead of a bare "no type named 'type'
    in enable_if". No flag-day: remaining SFINAE sites migrate in later batches.
+   The second batch converts the five `data<T>` member-initialization and JSON
+   decoding overloads from `enable_if_t<..., void>` to named concepts plus
+   `requires`. Their two-way and three-way partitions, explicit `void` return,
+   and function bodies remain unchanged. A concurrent inventory keeps 14
+   partial-specialization sites on SFINAE because concepts do not remove their
+   specialization-selection role, and defers the four SQLite `make_default`
+   seam overloads to separately scoped validation rather than forcing a
+   quantity-driven migration.
 4. Opportunistic. **Ranges landed**: `reader::sort_without_buffer()` discharges
    the `reader.cpp` TODO it named — the manual filter loop plus `std::max_element`
    is now `journals_ | std::views::values | std::views::filter(...)` fed to

--- a/framework/core/src/libyijinjing/include/kungfu/common.h
+++ b/framework/core/src/libyijinjing/include/kungfu/common.h
@@ -305,6 +305,21 @@ static constexpr bool is_unsigned_bigint_v = //
 template <typename ValueType>
 static constexpr bool is_numeric_v = std::is_arithmetic_v<ValueType> or std::is_enum_v<ValueType>;
 
+// These concepts preserve data<T>'s existing member-initialization and JSON
+// decoding partitions while making the selected overload visible in compiler
+// diagnostics. The three JSON concepts are mutually exclusive by construction.
+template <typename V>
+concept data_numeric_member = is_numeric_v<V>;
+
+template <typename V>
+concept data_json_direct_member = std::is_arithmetic_v<V> or is_array_of_others_v<V, char>;
+
+template <typename V>
+concept data_json_string_member = is_array_of_v<V, char>;
+
+template <typename V>
+concept data_json_deserialized_member = not std::is_arithmetic_v<V> and not is_array_v<V>;
+
 template <typename ValueType>
 static constexpr bool is_enum_class_v = std::is_enum_v<ValueType> and not std::is_convertible_v<ValueType, int>;
 
@@ -420,22 +435,32 @@ template <typename DataType> struct data {
   }
 
 private:
-  template <typename V> static std::enable_if_t<is_numeric_v<V>> init_member(V &v) { v = static_cast<V>(0); }
+  template <typename V>
+    requires data_numeric_member<V>
+  static void init_member(V &v) {
+    v = static_cast<V>(0);
+  }
 
-  template <typename V> static std::enable_if_t<not is_numeric_v<V>> init_member(V &) {}
+  template <typename V>
+    requires(not data_numeric_member<V>)
+  static void init_member(V &) {}
 
   template <typename J, typename V>
-  static std::enable_if_t<std::is_arithmetic_v<V> or is_array_of_others_v<V, char>> restore_from_json(J &j, V &v) {
+    requires data_json_direct_member<V>
+  static void restore_from_json(J &j, V &v) {
     v = j;
   }
 
-  template <typename J, typename V> static std::enable_if_t<is_array_of_v<V, char>> restore_from_json(J &j, V &v) {
+  template <typename J, typename V>
+    requires data_json_string_member<V>
+  static void restore_from_json(J &j, V &v) {
     std::string value = j;
     v = value.c_str(); // kungfu_array overload operator=, it actually use memcpy rather than assign pointer
   }
 
   template <typename J, typename V>
-  static std::enable_if_t<not std::is_arithmetic_v<V> and not is_array_v<V>> restore_from_json(J &j, V &v) {
+    requires data_json_deserialized_member<V>
+  static void restore_from_json(J &j, V &v) {
     j.get_to(v);
   }
 };


### PR DESCRIPTION
## Summary

Deliver the next bounded ADR-0082 concepts maintenance increment by replacing five function-level SFINAE constraints in `data<T>` with named concepts and `requires` clauses. Runtime behavior and overload partitions remain unchanged.

## Related issue

ADR-0082 concepts policy, item 3 incremental maintenance.

## Changes

- Add named concepts for numeric initialization and the three mutually exclusive JSON member-decoding partitions.
- Convert the two `init_member` overloads and three `restore_from_json` overloads from `enable_if_t<..., void>` to explicit `void` plus `requires`.
- Keep every function body unchanged.
- Audit the remaining 37 code-level `enable_if` sites: retain 14 partial-specialization sites because concepts do not remove their specialization-selection role; retain the four `hana_sqlite.h::make_default` SQLite seam overloads for separately scoped validation; leave 14 other Kungfu-owned function constraints for later benefit-ordered batches.
- Preserve the implemented ADR-0082 closure from PR #892 while recording this later maintenance batch.

Representative diagnostic probe:

- Before: the candidate is ignored because the raw predicate requirement is not satisfied.
- After: the compiler reports `constraints not satisfied`, names `data_json_direct_member`, and shows the exact predicate that evaluated to false.

## Verification

- `./shifu check:source`: passed (281 tooling tests, 13 runtime-upgrade tests, C++ format and source contracts).
- Staged pre-commit gate and `./shifu docs:check`: passed.
- AppleClang C++23 `-fsyntax-only` through a sibling compile database: 69 current translation units passed; one stale database entry for removed `webserver.cpp` was excluded explicitly.
- Negative diagnostic probes: both failed as intended; the concepts version exposed the named constraint chain.
- Mac AppleClang: `./shifu build:core` plus durability-contract, durable-ingest, crash-recovery, state-service, and projection-bootstrap passed on PR head `1bb66940d`.
- Linux GCC 14.2 on agent-120: the same build and five-test matrix passed on PR head `1bb66940d`.
- Windows MSVC 19.51 on DARKHERO: `./shifu build:core` passed on PR head `1bb66940d`; durability-contract, durable-ingest, crash-recovery, and projection-bootstrap passed. The state-service test reached the native binary but its temporary journal stretch returned Win32 error 112 twice despite 1.4 TiB free; Mac/Linux coverage of that test passed.
- GitHub delivery intent, docs, source acceptance, promotion rehearsal, signoff, and validate checks: passed.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "stage-ready",
  "adrs": ["ADR-0082"],
  "summary": "Migrate the data member initialization and JSON decode overload partition from SFINAE to named concepts without changing behavior",
  "verification": ["Source acceptance passed", "AppleClang syntax-only passed for 69 current translation units", "Mac and Linux native build plus behavior matrix passed", "Windows MSVC native build passed"]
}
-->

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] release evidence, provenance, package publishing, or deployment surfaces
- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated; no runtime behavior changed
