### PR TITLE
fix(core): prefer native Cargo shim on Windows

### DIFF
--- a/framework/core/slices/libwasm-shared-membrane/CMakeLists.txt
+++ b/framework/core/slices/libwasm-shared-membrane/CMakeLists.txt
@@ -1,6 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
-find_program(KF_LIBWASM_CARGO cargo REQUIRED)
+if(KF_LIBWASM_CARGO AND NOT EXISTS "${KF_LIBWASM_CARGO}")
+  unset(KF_LIBWASM_CARGO CACHE)
+endif()
+if(WIN32)
+  find_program(KF_LIBWASM_CARGO NAMES cargo.cmd cargo.exe cargo REQUIRED)
+else()
+  find_program(KF_LIBWASM_CARGO cargo REQUIRED)
+endif()
 include("${CMAKE_CURRENT_LIST_DIR}/../../.cmake/libwasm-cargo-cache.cmake")
 set(KF_LIBWASM_CARGO_REGISTRY "" CACHE STRING
   "Optional sparse Cargo registry mirror, for example sparse+https://rsproxy.cn/index/")

--- a/framework/core/src/libwasm/CMakeLists.txt
+++ b/framework/core/src/libwasm/CMakeLists.txt
@@ -6,7 +6,13 @@
 if(KF_LIBWASM_CARGO AND NOT EXISTS "${KF_LIBWASM_CARGO}")
   unset(KF_LIBWASM_CARGO CACHE)
 endif()
-find_program(KF_LIBWASM_CARGO cargo REQUIRED)
+# A Shifu cache overlay carries both its POSIX shim and cargo.cmd. CMake's
+# exact-name lookup can otherwise cache the non-executable POSIX shim on Windows.
+if(WIN32)
+  find_program(KF_LIBWASM_CARGO NAMES cargo.cmd cargo.exe cargo REQUIRED)
+else()
+  find_program(KF_LIBWASM_CARGO cargo REQUIRED)
+endif()
 set(KF_LIBWASM_CARGO_REGISTRY_DEFAULT "")
 if(DEFINED ENV{KF_LIBWASM_CARGO_REGISTRY})
   set(KF_LIBWASM_CARGO_REGISTRY_DEFAULT "$ENV{KF_LIBWASM_CARGO_REGISTRY}")


### PR DESCRIPTION
## Summary

Make libwasm CMake discovery prefer the Windows-native Cargo shims exposed by the Shifu cache overlay. This prevents CMake from caching the POSIX shebang wrapper as `KF_LIBWASM_CARGO` on Windows.

## Related issue

None. Found while qualifying the zero-burden desktop runtime through the full Buildchain matrix.

## Changes

- Prefer `cargo.cmd`, then `cargo.exe`, before the extensionless wrapper on Windows.
- Drop stale cached Cargo paths in the shared-membrane slice before resolving the current overlay.
- Preserve the existing POSIX lookup unchanged.

## Verification

- `SHIFU_CACHE_BYPASS=source-acceptance ./shifu check`
- staged pre-commit gate
- Windows Buildchain qualification will provide the platform-native regression proof.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This fixes platform-native executable discovery without changing the libwasm or cache architecture contracts"
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] release evidence, provenance, package publishing, or deployment surfaces
- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed (not needed; executable discovery only)