### PR TITLE
fix(gui): make structured console input discoverable

### DIFF
--- a/extensions/terminal/src/view/agent-session-presentation.ts
+++ b/extensions/terminal/src/view/agent-session-presentation.ts
@@ -12,6 +12,13 @@ export type AgentSessionProductProjection = {
   recommendedAction: string | null;
 };
 
+export type AgentSessionComposerPresentation = {
+  state: 'ready' | 'waiting' | 'blocked';
+  label: string;
+  guidance: string;
+  canSend: boolean;
+};
+
 type AgentSessionStatusCompatibilityInput = {
   product?: AgentSessionProductProjection;
   live?: boolean;
@@ -110,4 +117,99 @@ export function agentSessionProductDetail(
   product: AgentSessionProductProjection,
 ): string {
   return DETAILS[product.reason] ?? 'Review the current session state.';
+}
+
+export function resolveAgentSessionComposer({
+  product,
+  inputAdmission,
+  controllerHolderId,
+  actorId,
+  providerLabel = 'Agent',
+  submitting = false,
+}: {
+  product: AgentSessionProductProjection;
+  inputAdmission?: string;
+  controllerHolderId?: string | null;
+  actorId?: string;
+  providerLabel?: string;
+  submitting?: boolean;
+}): AgentSessionComposerPresentation {
+  if (submitting) {
+    return {
+      state: 'waiting',
+      label: 'Sending…',
+      guidance: `Delivering this instruction to the active ${providerLabel} session.`,
+      canSend: false,
+    };
+  }
+  if (inputAdmission !== 'open') {
+    return {
+      state: 'blocked',
+      label: 'Input paused',
+      guidance: 'This session is not accepting new instructions right now.',
+      canSend: false,
+    };
+  }
+  if (product.state === 'action-required') {
+    return {
+      state: 'blocked',
+      label: 'Action required',
+      guidance: agentSessionProductDetail(product),
+      canSend: false,
+    };
+  }
+  if (product.state === 'working') {
+    return {
+      state: 'waiting',
+      label: `${providerLabel} is working`,
+      guidance: `You can prepare the next instruction now. Send unlocks when ${providerLabel} is available.`,
+      canSend: false,
+    };
+  }
+  if (product.state === 'starting' || product.state === 'recovering') {
+    return {
+      state: 'waiting',
+      label:
+        product.state === 'starting'
+          ? `Starting ${providerLabel}`
+          : 'Reconnecting',
+      guidance:
+        'You can prepare an instruction while the session becomes available.',
+      canSend: false,
+    };
+  }
+  if (product.state === 'ended') {
+    return {
+      state: 'blocked',
+      label: 'Session ended',
+      guidance: 'Start or attach another session to continue.',
+      canSend: false,
+    };
+  }
+  if (!controllerHolderId) {
+    return {
+      state: 'blocked',
+      label: 'Control required',
+      guidance: 'Request control above before sending an instruction.',
+      canSend: false,
+    };
+  }
+  if (controllerHolderId !== actorId) {
+    return {
+      state: 'blocked',
+      label: 'Controlled elsewhere',
+      guidance: 'Another attached client currently controls this session.',
+      canSend: false,
+    };
+  }
+  return {
+    state: 'ready',
+    label: 'Ready to send',
+    guidance: 'Press Enter to send · Shift+Enter for a new line.',
+    canSend: true,
+  };
+}
+
+export function instructionWasDelivered(status: unknown): boolean {
+  return status === 'written' || status === 'delivered';
 }

--- a/extensions/terminal/src/view/index.tsx
+++ b/extensions/terminal/src/view/index.tsx
@@ -55,6 +55,8 @@ import {
   type AgentSessionProductProjection,
   agentSessionProductDetail,
   agentSessionProductLabel,
+  instructionWasDelivered,
+  resolveAgentSessionComposer,
   resolveAgentSessionProduct,
 } from './agent-session-presentation';
 import { agentSessionSnapshotText } from './agent-session-snapshot';
@@ -747,6 +749,9 @@ type CapsuleSurfaceStatus = {
     compatible?: boolean;
     reason?: string | null;
   };
+  transportRoute?: {
+    kind?: string;
+  };
   controller?: {
     holderId: string;
     leaseId: string;
@@ -799,6 +804,8 @@ function CapsuleSessionPane({
   );
   const [instruction, setInstruction] = React.useState('');
   const [notice, setNotice] = React.useState('');
+  const [submitting, setSubmitting] = React.useState(false);
+  const [composerFocused, setComposerFocused] = React.useState(false);
   const ref = React.useMemo(
     () => ({
       workConsoleId: pane.consoleId ?? '',
@@ -874,18 +881,38 @@ function CapsuleSessionPane({
     [caps, pane.actorId, ref],
   );
 
-  const sendInstruction = () => {
-    const text = instruction.trim();
-    if (!text) return;
-    void control('instruct', { text, mode: 'when-ready' }, true)
-      .then((result) => {
-        if (result.status === 'written') setInstruction('');
-      })
-      .catch((error) => setNotice((error as Error).message));
-  };
   const status = snapshot?.status;
   const product = status ? resolveAgentSessionProduct(status) : null;
   const ended = status?.lifecycleState === 'ended';
+  const providerLabel =
+    pane.provider === 'codex'
+      ? 'Codex'
+      : pane.provider === 'claude'
+        ? 'Claude'
+        : pane.provider;
+  const composer = product
+    ? resolveAgentSessionComposer({
+        product,
+        inputAdmission: status?.inputAdmission,
+        controllerHolderId: status?.controller?.holderId,
+        actorId: pane.actorId,
+        providerLabel,
+        submitting,
+      })
+    : null;
+  const canSend = Boolean(composer?.canSend && instruction.trim());
+
+  const sendInstruction = () => {
+    const text = instruction.trim();
+    if (!text || !composer?.canSend || submitting) return;
+    setSubmitting(true);
+    void control('instruct', { text, mode: 'when-ready' }, true)
+      .then((result) => {
+        if (instructionWasDelivered(result.status)) setInstruction('');
+      })
+      .catch((error) => setNotice((error as Error).message))
+      .finally(() => setSubmitting(false));
+  };
 
   return (
     <div
@@ -958,16 +985,45 @@ function CapsuleSessionPane({
           {ended ? 'Close' : 'End'}
         </button>
       </div>
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 7,
+          padding: '5px 10px',
+          color: '#858585',
+          background: '#1a1a1a',
+          borderBottom: '1px solid #2b2b2b',
+          ...mono,
+          fontSize: 10.5,
+          textTransform: 'uppercase',
+          letterSpacing: '0.05em',
+        }}
+      >
+        <span style={{ color: '#b8b8b8' }}>Session output</span>
+        <span
+          style={{
+            padding: '1px 6px',
+            border: '1px solid #3a3a3a',
+            borderRadius: 999,
+            color: '#737373',
+            fontSize: 9.5,
+          }}
+        >
+          Read only
+        </span>
+      </div>
       <pre
+        aria-label="Session output"
         style={{
           flex: 1,
           minHeight: 0,
           margin: 0,
-          padding: 10,
+          padding: 12,
           overflow: 'auto',
           whiteSpace: 'pre-wrap',
           color: '#d4d4d4',
-          background: '#1a1a1a',
+          background: '#171717',
           ...mono,
           fontSize: 12,
         }}
@@ -975,67 +1031,194 @@ function CapsuleSessionPane({
         {agentSessionSnapshotText(snapshot)}
       </pre>
       {!ended && (
-        <div
+        <fieldset
+          aria-labelledby={`composer-label-${pane.key}`}
           style={{
-            display: 'flex',
-            gap: 6,
-            padding: 8,
-            borderTop: '1px solid #2b2b2b',
+            display: 'grid',
+            gap: 7,
+            minWidth: 0,
+            margin: 8,
+            padding: 10,
+            border: `1px solid ${
+              composerFocused
+                ? '#5ea6d6'
+                : composer?.state === 'ready'
+                  ? '#3f6f8f'
+                  : '#343a40'
+            }`,
+            borderRadius: 9,
+            background: composerFocused
+              ? 'rgba(51, 100, 133, 0.16)'
+              : 'rgba(35, 49, 59, 0.72)',
+            boxShadow: composerFocused
+              ? '0 0 0 2px rgba(94, 166, 214, 0.12)'
+              : 'none',
+            transition:
+              'border-color 120ms ease, box-shadow 120ms ease, background 120ms ease',
           }}
         >
-          <textarea
-            value={instruction}
-            onChange={(event) => setInstruction(event.target.value)}
-            placeholder="Send a semantic instruction through the Interaction Port"
-            rows={2}
-            style={{ flex: 1, resize: 'vertical', ...mono, fontSize: 11 }}
-          />
-          <button
-            type="button"
-            onClick={sendInstruction}
-            style={iconButtonStyle}
-          >
-            Send
-          </button>
-          {['y', 'n', 'Enter', 'Escape'].map((key) => (
-            <button
-              key={key}
-              type="button"
-              title={`Manual controller key: ${key}`}
-              onClick={() =>
-                void control('send-key', { key }, false).catch((error) =>
-                  setNotice((error as Error).message),
-                )
-              }
-              style={iconButtonStyle}
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <label
+              id={`composer-label-${pane.key}`}
+              htmlFor={`composer-${pane.key}`}
+              style={{
+                flex: 1,
+                color: '#e6f2fa',
+                fontSize: 12.5,
+                fontWeight: 650,
+              }}
             >
-              {key}
+              Message {providerLabel}
+            </label>
+            <span
+              style={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: 5,
+                color:
+                  composer?.state === 'ready'
+                    ? '#75c98a'
+                    : composer?.state === 'blocked'
+                      ? '#d6a85e'
+                      : '#8eb8d3',
+                ...mono,
+                fontSize: 10.5,
+              }}
+            >
+              <span
+                aria-hidden="true"
+                style={{
+                  width: 6,
+                  height: 6,
+                  borderRadius: '50%',
+                  background: 'currentColor',
+                }}
+              />
+              {composer?.label ?? 'Connecting'}
+            </span>
+          </div>
+          <div style={{ display: 'flex', alignItems: 'stretch', gap: 8 }}>
+            <textarea
+              id={`composer-${pane.key}`}
+              value={instruction}
+              onChange={(event) => setInstruction(event.target.value)}
+              onFocus={() => setComposerFocused(true)}
+              onBlur={() => setComposerFocused(false)}
+              onKeyDown={(event) => {
+                if (
+                  event.key === 'Enter' &&
+                  !event.shiftKey &&
+                  !event.nativeEvent.isComposing
+                ) {
+                  event.preventDefault();
+                  sendInstruction();
+                }
+              }}
+              aria-describedby={`composer-guidance-${pane.key}`}
+              placeholder="Describe what you want Codex to do next…"
+              rows={3}
+              style={{
+                flex: 1,
+                minWidth: 0,
+                resize: 'vertical',
+                padding: '9px 10px',
+                color: '#f0f4f7',
+                background: '#12171b',
+                border: '1px solid #3d4d57',
+                borderRadius: 7,
+                outline: 'none',
+                lineHeight: 1.45,
+                ...mono,
+                fontSize: 12,
+              }}
+            />
+            <button
+              type="button"
+              onClick={sendInstruction}
+              disabled={!canSend}
+              title={
+                canSend
+                  ? 'Send instruction (Enter)'
+                  : (composer?.guidance ?? 'Waiting for the session')
+              }
+              style={{
+                alignSelf: 'stretch',
+                minWidth: 94,
+                padding: '0 14px',
+                color: canSend ? '#08131a' : '#727b80',
+                background: canSend ? '#75bde8' : '#252d32',
+                border: `1px solid ${canSend ? '#8bcaf0' : '#374147'}`,
+                borderRadius: 7,
+                cursor: canSend ? 'pointer' : 'not-allowed',
+                fontWeight: 700,
+                ...mono,
+                fontSize: 11.5,
+              }}
+            >
+              {submitting ? 'Sending…' : 'Send'}
             </button>
-          ))}
-          <button
-            type="button"
-            onClick={() =>
-              void control('interrupt', {}, false).catch((error) =>
-                setNotice((error as Error).message),
-              )
-            }
-            style={{ ...iconButtonStyle, color: '#d98a8a' }}
+          </div>
+          <div
+            id={`composer-guidance-${pane.key}`}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 8,
+              color: '#9aa7af',
+              ...mono,
+              fontSize: 10.5,
+            }}
           >
-            Interrupt
-          </button>
-        </div>
+            <span style={{ flex: 1 }}>
+              {composer?.guidance ??
+                'Preparing the structured instruction channel.'}
+            </span>
+            {status?.transportRoute?.kind !== 'structured' &&
+              ['y', 'n', 'Enter', 'Escape'].map((key) => (
+                <button
+                  key={key}
+                  type="button"
+                  title={`Manual controller key: ${key}`}
+                  onClick={() =>
+                    void control('send-key', { key }, false).catch((error) =>
+                      setNotice((error as Error).message),
+                    )
+                  }
+                  style={iconButtonStyle}
+                >
+                  {key}
+                </button>
+              ))}
+            {(product?.state === 'working' ||
+              product?.state === 'action-required') && (
+              <button
+                type="button"
+                onClick={() =>
+                  void control('interrupt', {}, false).catch((error) =>
+                    setNotice((error as Error).message),
+                  )
+                }
+                style={{ ...iconButtonStyle, color: '#d98a8a' }}
+              >
+                Interrupt
+              </button>
+            )}
+          </div>
+        </fieldset>
       )}
       {notice && (
-        <div
+        <output
+          aria-live="polite"
           style={{
-            padding: '0 8px 6px',
+            display: 'block',
+            padding: '0 10px 8px',
             ...mono,
             fontSize: 10,
             color: '#c9a227',
           }}
         >
           {notice} · delivery is not work proof
-        </div>
+        </output>
       )}
     </div>
   );

--- a/extensions/terminal/tests/agent-session-presentation.test.ts
+++ b/extensions/terminal/tests/agent-session-presentation.test.ts
@@ -3,6 +3,8 @@ import test from 'node:test';
 import {
   agentSessionProductDetail,
   agentSessionProductLabel,
+  instructionWasDelivered,
+  resolveAgentSessionComposer,
   resolveAgentSessionProduct,
 } from '../src/view/agent-session-presentation.ts';
 
@@ -41,4 +43,83 @@ test('normal Agent Session presentation uses product states and one recovery act
       recommendedAction: null,
     },
   );
+});
+
+test('composer makes the ready input path explicit only to the controller', () => {
+  const product = {
+    state: 'available' as const,
+    reason: 'ready-for-input',
+    recommendedAction: null,
+  };
+  assert.deepEqual(
+    resolveAgentSessionComposer({
+      product,
+      inputAdmission: 'open',
+      controllerHolderId: 'gui:home',
+      actorId: 'gui:home',
+      providerLabel: 'Codex',
+    }),
+    {
+      state: 'ready',
+      label: 'Ready to send',
+      guidance: 'Press Enter to send · Shift+Enter for a new line.',
+      canSend: true,
+    },
+  );
+  assert.deepEqual(
+    resolveAgentSessionComposer({
+      product,
+      inputAdmission: 'open',
+      controllerHolderId: 'gui:other',
+      actorId: 'gui:home',
+      providerLabel: 'Codex',
+    }),
+    {
+      state: 'blocked',
+      label: 'Controlled elsewhere',
+      guidance: 'Another attached client currently controls this session.',
+      canSend: false,
+    },
+  );
+});
+
+test('composer preserves drafts while Codex is working or input is paused', () => {
+  const working = resolveAgentSessionComposer({
+    product: {
+      state: 'working',
+      reason: 'provider-working',
+      recommendedAction: null,
+    },
+    inputAdmission: 'open',
+    controllerHolderId: 'gui:home',
+    actorId: 'gui:home',
+    providerLabel: 'Codex',
+  });
+  assert.equal(working.label, 'Codex is working');
+  assert.equal(working.canSend, false);
+  assert.deepEqual(
+    resolveAgentSessionComposer({
+      product: {
+        state: 'available',
+        reason: 'ready-for-input',
+        recommendedAction: null,
+      },
+      inputAdmission: 'closed',
+      controllerHolderId: 'gui:home',
+      actorId: 'gui:home',
+    }),
+    {
+      state: 'blocked',
+      label: 'Input paused',
+      guidance: 'This session is not accepting new instructions right now.',
+      canSend: false,
+    },
+  );
+});
+
+test('composer clears instructions for PTY writes and structured delivery', () => {
+  assert.equal(instructionWasDelivered('written'), true);
+  assert.equal(instructionWasDelivered('delivered'), true);
+  assert.equal(instructionWasDelivered('held'), false);
+  assert.equal(instructionWasDelivered('rejected'), false);
 });


### PR DESCRIPTION
## Summary

Make the structured Agent Console clearly distinguish read-only session output from the user instruction composer.

## Related issue

User-reported discoverability friction in the structured Codex console.

## Changes

- label the session output boundary as read-only
- add a prominent state-aware instruction composer and primary Send action
- support Enter to send, Shift+Enter for a newline, and preserve drafts until delivery
- hide raw PTY key controls when the session uses the structured transport

## Verification

- `./shifu --filter @kungfu-tech/kfx-view-terminal test`
- `./shifu check`
- source-local SDK KFX bundle build
- headless browser visual inspection of the ready-state layout

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bug fix improves existing console affordances without changing an architecture contract"
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [x] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change presents existing provider session state and does not alter provider API or CLI behavior.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed (not required for this bounded UI fix)