### PR TITLE
fix(product): separate CLI launcher from runtime tree

### DIFF
--- a/.buildchain/kfd/kfd-1/contract-world.witness.json
+++ b/.buildchain/kfd/kfd-1/contract-world.witness.json
@@ -35,7 +35,7 @@
   "sourceVerificationRequired": false,
   "canonicalPolicy": {
     "path": "framework/contract/kungfu-agent-first-canonical-policy.json",
-    "sha256": "0b0752af7c0bc8425f4a06b1b99e8a8ff291ffb48c6dce1c9242ed318ba15e37"
+    "sha256": "4329c84d72286e4cbc6d431b0558b994b05dbb0a84915abd6e9eb41023e13bb4"
   },
   "registry": {
     "path": "framework/contract/kungfu-contracts.registry.json",
@@ -53,9 +53,9 @@
     {
       "name": "kungfu-kfx",
       "sourcePath": "framework/kfx/kungfu-kfx.contract.json",
-      "sourceSha256": "1eb8c41c65501f3fa875ee0880cdc4a53e16d5a0603648324468c6524be45f88",
+      "sourceSha256": "021ec7758d342ee4d79f7a995e844a01e37bd8a8216da594d2a17d27d512f886",
       "artifactPath": "config/kungfu-kfx.contract.json",
-      "expectedSha256": "1eb8c41c65501f3fa875ee0880cdc4a53e16d5a0603648324468c6524be45f88",
+      "expectedSha256": "021ec7758d342ee4d79f7a995e844a01e37bd8a8216da594d2a17d27d512f886",
       "byteForByte": true
     },
     {

--- a/.buildchain/kfd/kfd-1/release-gate.json
+++ b/.buildchain/kfd/kfd-1/release-gate.json
@@ -54,13 +54,13 @@
       "standard": "KFD-1",
       "standardKey": "kfd-1",
       "result": "passed",
-      "preBuildWitnessSha256": "88d8e1ea51c92aa45b73928044375667c1e7a88ccd2264fae5991ee7a31e460f",
+      "preBuildWitnessSha256": "b0bbe561694fbeb56832e200a7de5fc60dc6922f33890458d5ceece2a1e9831c",
       "sourceHashes": {
-        "sha256": "0444b1958030130469b9675633ebc8ff9108642b03095317c015288063e9c7b5",
+        "sha256": "049fcca8db8441ea947f8e1b598388de9eb3051d00acde1f86b5e6a1e762a0db",
         "surfaceCount": 6
       },
       "artifactHashes": {
-        "sha256": "c2dcd7563759b66843e5481b74a0cf4b653db3fb9a9ca59ca282d3eb3bfea500",
+        "sha256": "156135c1b84380386875c88e0a01ababad9485e3f5e7dc6821c2f4a098a91908",
         "surfaceCount": 6
       },
       "witness": {
@@ -100,7 +100,7 @@
         "sourceVerificationRequired": true,
         "canonicalPolicy": {
           "path": "framework/contract/kungfu-agent-first-canonical-policy.json",
-          "sha256": "0b0752af7c0bc8425f4a06b1b99e8a8ff291ffb48c6dce1c9242ed318ba15e37"
+          "sha256": "4329c84d72286e4cbc6d431b0558b994b05dbb0a84915abd6e9eb41023e13bb4"
         },
         "registry": {
           "path": "framework/contract/kungfu-contracts.registry.json",
@@ -118,9 +118,9 @@
           {
             "name": "kungfu-kfx",
             "sourcePath": "framework/kfx/kungfu-kfx.contract.json",
-            "sourceSha256": "1eb8c41c65501f3fa875ee0880cdc4a53e16d5a0603648324468c6524be45f88",
+            "sourceSha256": "021ec7758d342ee4d79f7a995e844a01e37bd8a8216da594d2a17d27d512f886",
             "artifactPath": "config/kungfu-kfx.contract.json",
-            "expectedSha256": "1eb8c41c65501f3fa875ee0880cdc4a53e16d5a0603648324468c6524be45f88",
+            "expectedSha256": "021ec7758d342ee4d79f7a995e844a01e37bd8a8216da594d2a17d27d512f886",
             "byteForByte": true
           },
           {
@@ -209,8 +209,8 @@
           {
             "name": "kungfu-kfx",
             "sourcePath": "framework/kfx/kungfu-kfx.contract.json",
-            "expectedSha256": "1eb8c41c65501f3fa875ee0880cdc4a53e16d5a0603648324468c6524be45f88",
-            "actualSha256": "1eb8c41c65501f3fa875ee0880cdc4a53e16d5a0603648324468c6524be45f88",
+            "expectedSha256": "021ec7758d342ee4d79f7a995e844a01e37bd8a8216da594d2a17d27d512f886",
+            "actualSha256": "021ec7758d342ee4d79f7a995e844a01e37bd8a8216da594d2a17d27d512f886",
             "status": "passed",
             "reason": ""
           },
@@ -266,10 +266,10 @@
           {
             "name": "kungfu-kfx",
             "sourcePath": "framework/kfx/kungfu-kfx.contract.json",
-            "sourceSha256": "1eb8c41c65501f3fa875ee0880cdc4a53e16d5a0603648324468c6524be45f88",
+            "sourceSha256": "021ec7758d342ee4d79f7a995e844a01e37bd8a8216da594d2a17d27d512f886",
             "artifactPath": "config/kungfu-kfx.contract.json",
-            "expectedSha256": "1eb8c41c65501f3fa875ee0880cdc4a53e16d5a0603648324468c6524be45f88",
-            "actualSha256": "1eb8c41c65501f3fa875ee0880cdc4a53e16d5a0603648324468c6524be45f88",
+            "expectedSha256": "021ec7758d342ee4d79f7a995e844a01e37bd8a8216da594d2a17d27d512f886",
+            "actualSha256": "021ec7758d342ee4d79f7a995e844a01e37bd8a8216da594d2a17d27d512f886",
             "byteForByte": true,
             "status": "passed",
             "reason": ""

--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -5,8 +5,8 @@
   "witnessKind": "prebuild",
   "supportLevel": "release",
   "source": {
-    "cwd": "/Users/dkr/Worktrees/kungfu/feature/upgrade-qualification-gate",
-    "sourceSha": "1a27d9a431f0c6e8966b74462af27a5fbfdbbf4b",
+    "cwd": "/Users/dkr/Worktrees/kungfu/fix/cli-upgrade-binary-path",
+    "sourceSha": "3732e8a3f9e4cbaf29fb9accc1cc99a0ec0a6268",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
     "registryDigest": "sha256:46fa6e6d8e6cabe4e89ed1f13dfb20382fdde55185db35a2d479c471ac077831"
   },

--- a/developer/sdk/kfd/kfd-1/contract-world.witness.json
+++ b/developer/sdk/kfd/kfd-1/contract-world.witness.json
@@ -35,7 +35,7 @@
   "sourceVerificationRequired": false,
   "canonicalPolicy": {
     "path": "framework/contract/kungfu-agent-first-canonical-policy.json",
-    "sha256": "0b0752af7c0bc8425f4a06b1b99e8a8ff291ffb48c6dce1c9242ed318ba15e37"
+    "sha256": "4329c84d72286e4cbc6d431b0558b994b05dbb0a84915abd6e9eb41023e13bb4"
   },
   "registry": {
     "path": "framework/contract/kungfu-contracts.registry.json",
@@ -53,9 +53,9 @@
     {
       "name": "kungfu-kfx",
       "sourcePath": "framework/kfx/kungfu-kfx.contract.json",
-      "sourceSha256": "1eb8c41c65501f3fa875ee0880cdc4a53e16d5a0603648324468c6524be45f88",
+      "sourceSha256": "021ec7758d342ee4d79f7a995e844a01e37bd8a8216da594d2a17d27d512f886",
       "artifactPath": "config/kungfu-kfx.contract.json",
-      "expectedSha256": "1eb8c41c65501f3fa875ee0880cdc4a53e16d5a0603648324468c6524be45f88",
+      "expectedSha256": "021ec7758d342ee4d79f7a995e844a01e37bd8a8216da594d2a17d27d512f886",
       "byteForByte": true
     },
     {

--- a/developer/sdk/kfd/kfd-1/release-gate.json
+++ b/developer/sdk/kfd/kfd-1/release-gate.json
@@ -54,13 +54,13 @@
       "standard": "KFD-1",
       "standardKey": "kfd-1",
       "result": "passed",
-      "preBuildWitnessSha256": "88d8e1ea51c92aa45b73928044375667c1e7a88ccd2264fae5991ee7a31e460f",
+      "preBuildWitnessSha256": "b0bbe561694fbeb56832e200a7de5fc60dc6922f33890458d5ceece2a1e9831c",
       "sourceHashes": {
-        "sha256": "0444b1958030130469b9675633ebc8ff9108642b03095317c015288063e9c7b5",
+        "sha256": "049fcca8db8441ea947f8e1b598388de9eb3051d00acde1f86b5e6a1e762a0db",
         "surfaceCount": 6
       },
       "artifactHashes": {
-        "sha256": "c2dcd7563759b66843e5481b74a0cf4b653db3fb9a9ca59ca282d3eb3bfea500",
+        "sha256": "156135c1b84380386875c88e0a01ababad9485e3f5e7dc6821c2f4a098a91908",
         "surfaceCount": 6
       },
       "witness": {
@@ -100,7 +100,7 @@
         "sourceVerificationRequired": true,
         "canonicalPolicy": {
           "path": "framework/contract/kungfu-agent-first-canonical-policy.json",
-          "sha256": "0b0752af7c0bc8425f4a06b1b99e8a8ff291ffb48c6dce1c9242ed318ba15e37"
+          "sha256": "4329c84d72286e4cbc6d431b0558b994b05dbb0a84915abd6e9eb41023e13bb4"
         },
         "registry": {
           "path": "framework/contract/kungfu-contracts.registry.json",
@@ -118,9 +118,9 @@
           {
             "name": "kungfu-kfx",
             "sourcePath": "framework/kfx/kungfu-kfx.contract.json",
-            "sourceSha256": "1eb8c41c65501f3fa875ee0880cdc4a53e16d5a0603648324468c6524be45f88",
+            "sourceSha256": "021ec7758d342ee4d79f7a995e844a01e37bd8a8216da594d2a17d27d512f886",
             "artifactPath": "config/kungfu-kfx.contract.json",
-            "expectedSha256": "1eb8c41c65501f3fa875ee0880cdc4a53e16d5a0603648324468c6524be45f88",
+            "expectedSha256": "021ec7758d342ee4d79f7a995e844a01e37bd8a8216da594d2a17d27d512f886",
             "byteForByte": true
           },
           {
@@ -209,8 +209,8 @@
           {
             "name": "kungfu-kfx",
             "sourcePath": "framework/kfx/kungfu-kfx.contract.json",
-            "expectedSha256": "1eb8c41c65501f3fa875ee0880cdc4a53e16d5a0603648324468c6524be45f88",
-            "actualSha256": "1eb8c41c65501f3fa875ee0880cdc4a53e16d5a0603648324468c6524be45f88",
+            "expectedSha256": "021ec7758d342ee4d79f7a995e844a01e37bd8a8216da594d2a17d27d512f886",
+            "actualSha256": "021ec7758d342ee4d79f7a995e844a01e37bd8a8216da594d2a17d27d512f886",
             "status": "passed",
             "reason": ""
           },
@@ -266,10 +266,10 @@
           {
             "name": "kungfu-kfx",
             "sourcePath": "framework/kfx/kungfu-kfx.contract.json",
-            "sourceSha256": "1eb8c41c65501f3fa875ee0880cdc4a53e16d5a0603648324468c6524be45f88",
+            "sourceSha256": "021ec7758d342ee4d79f7a995e844a01e37bd8a8216da594d2a17d27d512f886",
             "artifactPath": "config/kungfu-kfx.contract.json",
-            "expectedSha256": "1eb8c41c65501f3fa875ee0880cdc4a53e16d5a0603648324468c6524be45f88",
-            "actualSha256": "1eb8c41c65501f3fa875ee0880cdc4a53e16d5a0603648324468c6524be45f88",
+            "expectedSha256": "021ec7758d342ee4d79f7a995e844a01e37bd8a8216da594d2a17d27d512f886",
+            "actualSha256": "021ec7758d342ee4d79f7a995e844a01e37bd8a8216da594d2a17d27d512f886",
             "byteForByte": true,
             "status": "passed",
             "reason": ""

--- a/framework/contract/kungfu-agent-first-canonical-policy.json
+++ b/framework/contract/kungfu-agent-first-canonical-policy.json
@@ -129,13 +129,13 @@
       },
       "source": {
         "path": "framework/kfx/kungfu-kfx.contract.json",
-        "sha256": "sha256:1eb8c41c65501f3fa875ee0880cdc4a53e16d5a0603648324468c6524be45f88",
-        "renderedSha256": "sha256:1eb8c41c65501f3fa875ee0880cdc4a53e16d5a0603648324468c6524be45f88",
+        "sha256": "sha256:021ec7758d342ee4d79f7a995e844a01e37bd8a8216da594d2a17d27d512f886",
+        "renderedSha256": "sha256:021ec7758d342ee4d79f7a995e844a01e37bd8a8216da594d2a17d27d512f886",
         "byteForByte": true
       },
       "artifact": {
         "path": "config/kungfu-kfx.contract.json",
-        "expectedSha256": "sha256:1eb8c41c65501f3fa875ee0880cdc4a53e16d5a0603648324468c6524be45f88"
+        "expectedSha256": "sha256:021ec7758d342ee4d79f7a995e844a01e37bd8a8216da594d2a17d27d512f886"
       }
     },
     {
@@ -186,13 +186,13 @@
       },
       "source": {
         "path": "framework/upgrade/kungfu-upgrade.contract.json",
-        "sha256": "sha256:080aa1b6e9fb747c6034920c5354a664be80d7096fc33557904a5b0c1ff55a99",
-        "renderedSha256": "sha256:080aa1b6e9fb747c6034920c5354a664be80d7096fc33557904a5b0c1ff55a99",
+        "sha256": "sha256:ffacc9cb2051f420b6be2c0d36fc2617a5b418258b43b2f8df526992a1b8ed02",
+        "renderedSha256": "sha256:ffacc9cb2051f420b6be2c0d36fc2617a5b418258b43b2f8df526992a1b8ed02",
         "byteForByte": true
       },
       "artifact": {
         "path": "config/kungfu-upgrade.contract.json",
-        "expectedSha256": "sha256:080aa1b6e9fb747c6034920c5354a664be80d7096fc33557904a5b0c1ff55a99"
+        "expectedSha256": "sha256:ffacc9cb2051f420b6be2c0d36fc2617a5b418258b43b2f8df526992a1b8ed02"
       }
     },
     {

--- a/product/scripts/cli-launcher.mjs
+++ b/product/scripts/cli-launcher.mjs
@@ -7,7 +7,7 @@ export function cliLauncherContent(platform = process.platform) {
       'set "KUNGFU_INSTALL_SOURCE=archive"',
       'set "KUNGFU_PRODUCT_MANIFEST=%~dp0product.json"',
       'set "KUNGFU_UPGRADE_MANIFEST=%~dp0upgrade\\kungfu-release-manifest.json"',
-      '"%~dp0kungfu\\kungfu.exe" %*',
+      '"%~dp0runtime\\kungfu.exe" %*',
       '',
     ].join('\r\n');
   }
@@ -25,6 +25,6 @@ here=$(cd "$(dirname "$target")" && pwd)
 export KUNGFU_INSTALL_SOURCE=archive
 export KUNGFU_PRODUCT_MANIFEST="$here/product.json"
 export KUNGFU_UPGRADE_MANIFEST="$here/upgrade/kungfu-release-manifest.json"
-exec "$here/kungfu/kungfu" "$@"
+exec "$here/runtime/kungfu" "$@"
 `;
 }

--- a/product/scripts/dist.mjs
+++ b/product/scripts/dist.mjs
@@ -983,15 +983,26 @@ function copySdkRuntimePackageForCli(
   copyTree(source, target);
 }
 
-function writeCliLauncher(stageRoot) {
-  const name = isWin ? 'kungfu.cmd' : 'kungfu';
-  const output = path.join(stageRoot, name);
-  fs.writeFileSync(output, cliLauncherContent(), 'utf8');
-  if (!isWin) fs.chmodSync(output, 0o755);
-  return name;
+export function cliArchiveLayout(platform = process.platform) {
+  const runtimeDirectory = 'runtime';
+  return {
+    launcherName: platform === 'win32' ? 'kungfu.cmd' : 'kungfu',
+    runtimeDirectory,
+    runtimeEntrypoint: `${runtimeDirectory}/${
+      platform === 'win32' ? 'kungfu.exe' : 'kungfu'
+    }`,
+    compatibility: `${runtimeDirectory}/product-compatibility.json`,
+  };
 }
 
-function writeCliManifest(stageRoot, archiveName, launcherName) {
+function writeCliLauncher(stageRoot, layout) {
+  const output = path.join(stageRoot, layout.launcherName);
+  fs.writeFileSync(output, cliLauncherContent(), 'utf8');
+  if (!isWin) fs.chmodSync(output, 0o755);
+  return layout.launcherName;
+}
+
+function writeCliManifest(stageRoot, archiveName, layout) {
   fs.writeFileSync(
     path.join(stageRoot, 'product.json'),
     `${JSON.stringify(
@@ -1007,9 +1018,9 @@ function writeCliManifest(stageRoot, archiveName, launcherName) {
           backgroundUpdater: false,
         },
         entries: {
-          kungfu: launcherName,
-          runtime: isWin ? 'kungfu/kungfu.exe' : 'kungfu/kungfu',
-          compatibility: 'kungfu/product-compatibility.json',
+          kungfu: layout.launcherName,
+          runtime: layout.runtimeEntrypoint,
+          compatibility: layout.compatibility,
           sdk: 'sdk/sdk.js',
           sdkPackage: 'sdk/package.json',
           kfd3Registry: 'kfd/kfd-3-surfaces.json',
@@ -1465,6 +1476,7 @@ function buildCliProduct(esbuildRuntime) {
         : `${archiveBase}.tar.gz`;
       const stageRoot = path.join(CLI_DIST_DIR, archiveBase);
       const archivePath = path.join(CLI_RELEASE_DIR, archiveName);
+      const layout = cliArchiveLayout();
 
       assertSafeGeneratedDir(CLI_DIST_DIR);
       assertSafeGeneratedDir(CLI_RELEASE_DIR);
@@ -1473,7 +1485,7 @@ function buildCliProduct(esbuildRuntime) {
       fs.mkdirSync(stageRoot, { recursive: true });
       fs.mkdirSync(CLI_RELEASE_DIR, { recursive: true });
 
-      copyTree(CORE_DIST, path.join(stageRoot, 'kungfu'));
+      copyTree(CORE_DIST, path.join(stageRoot, layout.runtimeDirectory));
       copyTree(ASSEMBLED_EXTENSIONS, path.join(stageRoot, 'extensions'));
       copyTree(path.join(TUI_DIR, 'dist'), path.join(stageRoot, 'tui'));
       bundleSdkForCli(stageRoot, esbuildRuntime);
@@ -1492,7 +1504,8 @@ function buildCliProduct(esbuildRuntime) {
         `${JSON.stringify(bundledUpgradeManifest, null, 2)}\n`,
         'utf8',
       );
-      writeCliManifest(stageRoot, archiveName, writeCliLauncher(stageRoot));
+      writeCliLauncher(stageRoot, layout);
+      writeCliManifest(stageRoot, archiveName, layout);
 
       if (isWin) {
         writeZip({ sourceDir: CLI_DIST_DIR, outputFile: archivePath });

--- a/product/scripts/dist.test.mjs
+++ b/product/scripts/dist.test.mjs
@@ -5,8 +5,10 @@ import fs from 'node:fs';
 import { createRequire } from 'node:module';
 import path from 'node:path';
 import { test } from 'node:test';
+import { cliLauncherContent } from './cli-launcher.mjs';
 import {
   cliArchiveBase,
+  cliArchiveLayout,
   desktopUpdaterArtifact,
   esbuildPlatformBinaryPath,
   kfxBundleExternalModules,
@@ -27,6 +29,23 @@ test('CLI product archive name uses the Kungfu Episodes product prefix', () => {
   );
   assert.equal(cliArchiveBase('linux-x64'), 'kungfu-episodes-cli-linux-x64');
   assert.equal(cliArchiveBase('win32-x64'), 'kungfu-episodes-cli-win32-x64');
+});
+
+test('CLI archive keeps the launcher distinct from its runtime tree', () => {
+  assert.deepEqual(cliArchiveLayout('darwin'), {
+    launcherName: 'kungfu',
+    runtimeDirectory: 'runtime',
+    runtimeEntrypoint: 'runtime/kungfu',
+    compatibility: 'runtime/product-compatibility.json',
+  });
+  assert.deepEqual(cliArchiveLayout('win32'), {
+    launcherName: 'kungfu.cmd',
+    runtimeDirectory: 'runtime',
+    runtimeEntrypoint: 'runtime/kungfu.exe',
+    compatibility: 'runtime/product-compatibility.json',
+  });
+  assert.match(cliLauncherContent('darwin'), /exec "\$here\/runtime\/kungfu"/);
+  assert.match(cliLauncherContent('win32'), /%~dp0runtime\\kungfu\.exe/);
 });
 
 test('product observability ignores errors from sibling components', () => {


### PR DESCRIPTION
## Summary

Separate the versioned CLI runtime tree from the user-facing launcher and refresh the deterministic KFD evidence that the qualification gate found stale.

## Related issue

None. Found while qualifying the zero-burden desktop runtime through the full Buildchain matrix.

## Changes

- Stage CLI runtime files under `runtime/` while keeping `kungfu` / `kungfu.cmd` as the archive launcher.
- Add an exact cross-platform archive layout and launcher-path regression test.
- Refresh the canonical agent-first policy and generated KFD-1/KFD-3 evidence through the repository generators.

## Verification

- `SHIFU_CACHE_BYPASS=source-acceptance ./shifu check`
- `node developer/sdk/src/sdk.js contract policy --check --json`
- `node scripts/buildchain-kfd-evidence.mjs --check`
- `pnpm --filter @kungfu-tech/sdk run build`
- staged pre-commit gates for both commits

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This fixes archive path collisions and refreshes deterministic evidence without changing the accepted product runtime or KFD architecture contracts"
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed (not needed; archive layout is asserted by tests)