### PR TITLE
fix(product): separate CLI launcher from runtime tree

### DIFF
--- a/product/scripts/cli-launcher.mjs
+++ b/product/scripts/cli-launcher.mjs
@@ -1,13 +1,24 @@
 // SPDX-License-Identifier: Apache-2.0
 
+export function cliProductLayout(platform = process.platform) {
+  const windows = platform === 'win32';
+  const runtimeDirectory = windows ? 'kungfu' : 'runtime';
+  return {
+    launcher: windows ? 'kungfu.cmd' : 'kungfu',
+    runtimeDirectory,
+    runtimeEntrypoint: `${runtimeDirectory}/${windows ? 'kungfu.exe' : 'kungfu'}`,
+  };
+}
+
 export function cliLauncherContent(platform = process.platform) {
+  const layout = cliProductLayout(platform);
   if (platform === 'win32') {
     return [
       '@echo off',
       'set "KUNGFU_INSTALL_SOURCE=archive"',
       'set "KUNGFU_PRODUCT_MANIFEST=%~dp0product.json"',
       'set "KUNGFU_UPGRADE_MANIFEST=%~dp0upgrade\\kungfu-release-manifest.json"',
-      '"%~dp0kungfu\\kungfu.exe" %*',
+      `"%~dp0${layout.runtimeDirectory}\\kungfu.exe" %*`,
       '',
     ].join('\r\n');
   }
@@ -25,6 +36,6 @@ here=$(cd "$(dirname "$target")" && pwd)
 export KUNGFU_INSTALL_SOURCE=archive
 export KUNGFU_PRODUCT_MANIFEST="$here/product.json"
 export KUNGFU_UPGRADE_MANIFEST="$here/upgrade/kungfu-release-manifest.json"
-exec "$here/kungfu/kungfu" "$@"
+exec "$here/${layout.runtimeEntrypoint}" "$@"
 `;
 }

--- a/product/scripts/dist.mjs
+++ b/product/scripts/dist.mjs
@@ -17,7 +17,7 @@ import {
   verifyBuildchainLogEvents,
 } from '@kungfu-tech/buildchain/logging';
 import { extractTarGz, extractZip, writeTarGz, writeZip } from './archive.mjs';
-import { cliLauncherContent } from './cli-launcher.mjs';
+import { cliLauncherContent, cliProductLayout } from './cli-launcher.mjs';
 import { writeCompatibilityManifest } from './compatibility.mjs';
 import {
   assertLibwasmArtifact,
@@ -984,7 +984,7 @@ function copySdkRuntimePackageForCli(
 }
 
 function writeCliLauncher(stageRoot) {
-  const name = isWin ? 'kungfu.cmd' : 'kungfu';
+  const name = cliProductLayout().launcher;
   const output = path.join(stageRoot, name);
   fs.writeFileSync(output, cliLauncherContent(), 'utf8');
   if (!isWin) fs.chmodSync(output, 0o755);
@@ -992,6 +992,7 @@ function writeCliLauncher(stageRoot) {
 }
 
 function writeCliManifest(stageRoot, archiveName, launcherName) {
+  const layout = cliProductLayout();
   fs.writeFileSync(
     path.join(stageRoot, 'product.json'),
     `${JSON.stringify(
@@ -1008,7 +1009,7 @@ function writeCliManifest(stageRoot, archiveName, launcherName) {
         },
         entries: {
           kungfu: launcherName,
-          runtime: isWin ? 'kungfu/kungfu.exe' : 'kungfu/kungfu',
+          runtime: layout.runtimeEntrypoint,
           compatibility: 'kungfu/product-compatibility.json',
           sdk: 'sdk/sdk.js',
           sdkPackage: 'sdk/package.json',
@@ -1465,6 +1466,7 @@ function buildCliProduct(esbuildRuntime) {
         : `${archiveBase}.tar.gz`;
       const stageRoot = path.join(CLI_DIST_DIR, archiveBase);
       const archivePath = path.join(CLI_RELEASE_DIR, archiveName);
+      const layout = cliProductLayout();
 
       assertSafeGeneratedDir(CLI_DIST_DIR);
       assertSafeGeneratedDir(CLI_RELEASE_DIR);
@@ -1473,7 +1475,7 @@ function buildCliProduct(esbuildRuntime) {
       fs.mkdirSync(stageRoot, { recursive: true });
       fs.mkdirSync(CLI_RELEASE_DIR, { recursive: true });
 
-      copyTree(CORE_DIST, path.join(stageRoot, 'kungfu'));
+      copyTree(CORE_DIST, path.join(stageRoot, layout.runtimeDirectory));
       copyTree(ASSEMBLED_EXTENSIONS, path.join(stageRoot, 'extensions'));
       copyTree(path.join(TUI_DIR, 'dist'), path.join(stageRoot, 'tui'));
       bundleSdkForCli(stageRoot, esbuildRuntime);

--- a/product/scripts/dist.test.mjs
+++ b/product/scripts/dist.test.mjs
@@ -5,6 +5,7 @@ import fs from 'node:fs';
 import { createRequire } from 'node:module';
 import path from 'node:path';
 import { test } from 'node:test';
+import { cliLauncherContent, cliProductLayout } from './cli-launcher.mjs';
 import {
   cliArchiveBase,
   desktopUpdaterArtifact,
@@ -27,6 +28,27 @@ test('CLI product archive name uses the Kungfu Episodes product prefix', () => {
   );
   assert.equal(cliArchiveBase('linux-x64'), 'kungfu-episodes-cli-linux-x64');
   assert.equal(cliArchiveBase('win32-x64'), 'kungfu-episodes-cli-win32-x64');
+});
+
+test('CLI product layout keeps the Unix launcher separate from its runtime tree', () => {
+  for (const platform of ['darwin', 'linux']) {
+    const layout = cliProductLayout(platform);
+    assert.equal(layout.launcher, 'kungfu');
+    assert.equal(layout.runtimeDirectory, 'runtime');
+    assert.equal(layout.runtimeEntrypoint, 'runtime/kungfu');
+    assert.notEqual(layout.launcher, layout.runtimeDirectory);
+    assert.match(
+      cliLauncherContent(platform),
+      /exec "\$here\/runtime\/kungfu" "\$@"/,
+    );
+  }
+
+  assert.deepEqual(cliProductLayout('win32'), {
+    launcher: 'kungfu.cmd',
+    runtimeDirectory: 'kungfu',
+    runtimeEntrypoint: 'kungfu/kungfu.exe',
+  });
+  assert.match(cliLauncherContent('win32'), /"%~dp0kungfu\\kungfu\.exe" %\*/);
 });
 
 test('product observability ignores errors from sibling components', () => {


### PR DESCRIPTION
## Summary

- keep the Unix user-facing `kungfu` launcher at the archive root
- stage the Core runtime under `runtime/` on Unix so the launcher no longer collides with a directory
- preserve the existing Windows `kungfu.cmd` plus `kungfu/` layout
- bind `product.json` to the platform-specific runtime entry

## Failure evidence

The exact-source Ubuntu 26.04 qualification build reached product packaging and failed with `EISDIR` when the Unix launcher tried to replace the staged `kungfu/` runtime directory:

https://github.com/kungfu-systems/kungfu/actions/runs/29381760716

## Validation

- `./shifu check:source`
- `node --test product/scripts/dist.test.mjs product/scripts/archive.test.mjs product/scripts/upgrade-manifest.test.mjs` (23 passed)
- commit staged gate passed

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Fixes a Unix product packaging path collision without altering architecture authority or release policy"
}
-->