### PR TITLE
feat(core): add executable layer architecture contract

### DIFF
--- a/docs/adr/ADR-0049-layer-complete-products-and-domain-neutral-core.md
+++ b/docs/adr/ADR-0049-layer-complete-products-and-domain-neutral-core.md
@@ -7,9 +7,9 @@ implementation_status: implemented
 review_state: legacy-unreviewed
 sensitivity: public
 implementation_commits: [360c1dfcaf12aa410158f22ff175e5c608b0a77a]
-implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/797]
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/797, https://github.com/kungfu-systems/kungfu/pull/911]
 closure_pr: https://github.com/kungfu-systems/kungfu/pull/797
-qualification_refs: [docs/qualification/layer-product-release-qualification.md, shifu.gates.json, tests/qualification/layers/run.mjs, tests/qualification/layers/release/run.mjs, tests/qualification/layers/surfaces/run.mjs, scripts/run-release-qualification.mjs]
+qualification_refs: [docs/qualification/layer-product-release-qualification.md, framework/core/architecture/layers.json, framework/core/architecture/LAYERS.md, framework/core/architecture/check-layers.mjs, shifu.gates.json, tests/qualification/layers/run.mjs, tests/qualification/layers/release/run.mjs, tests/qualification/layers/surfaces/run.mjs, scripts/run-release-qualification.mjs, scripts/source-acceptance.mjs]
 ---
 
 # ADR-0049: every product layer is independently complete and the core remains domain-neutral

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -6,6 +6,7 @@ Architecture decisions and their historical rationale remain in
 [ADR](../adr/README.md).
 
 - [Architecture Overview](overview.md)
+- [Core Layer Map](../../framework/core/architecture/LAYERS.md)
 - [Event Model](event-model.md)
 - [Adapters](adapters.md)
 - [Carrier Type Registry](carrier-type-registry.md)

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -85,6 +85,11 @@ journal contract.
 
 ## Layers
 
+The repository-level product layers below are complemented by the checked
+[Core Layer Map](../../framework/core/architecture/LAYERS.md). That map assigns
+every first-party Core C/C++ source and public header to one component owner,
+declares the allowed dependency direction, and is enforced by the source gate.
+
 Kungfu is a platform plus a minimal reference application — the editor-platform
 model: the core provides capability; products are built on top. The packages
 group into the following layers.

--- a/framework/core/architecture/LAYERS.md
+++ b/framework/core/architecture/LAYERS.md
@@ -1,0 +1,77 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+document_status: active
+period: ongoing
+theme: kungfu-core-architecture
+doc_type: architecture-map
+sources: [local-files]
+confidence: high
+sensitivity: public
+evidence_grade: B
+review_state: self-reviewed
+last_reviewed: 2026-07-15
+---
+
+# Core Layer Map
+
+This map is a checked projection of [`layers.json`](layers.json). Edit the
+contract first, then update this projection; `check-layers.mjs` rejects drift.
+
+Dependency direction is downward: composition and bindings may consume adapters
+and services; the journal kernel may consume only schema/value contracts.
+
+## Layers
+
+| Order | Layer | Responsibility | May depend on |
+| ---: | --- | --- | --- |
+| 0 | `schema-values` | Stable value and schema contracts shared by the journal kernel. | `schema-values` |
+| 1 | `journal-kernel` | Journal, mmap, hash, content and storage semantic kernel without runtime engines. | `journal-kernel`, `schema-values` |
+| 2 | `ports-contracts` | Public runtime contracts and ports, independent of concrete adapters and bindings. | `ports-contracts`, `journal-kernel`, `schema-values` |
+| 3 | `application-services` | Runtime application services for durability, state, query, trust, live and storage orchestration. | `application-services`, `ports-contracts`, `journal-kernel`, `schema-values` |
+| 4 | `adapters` | Concrete storage, transport, OS, FlatBuffers and process adapters. | `adapters`, `application-services`, `ports-contracts`, `journal-kernel`, `schema-values` |
+| 5 | `composition-bindings` | Composition roots and C, Python, Node and WASM-facing bindings. | `composition-bindings`, `adapters`, `application-services`, `ports-contracts`, `journal-kernel`, `schema-values` |
+| 6 | `qualification` | Native qualification fixtures and tests; never a production dependency. | `qualification`, `composition-bindings`, `adapters`, `application-services`, `ports-contracts`, `journal-kernel`, `schema-values` |
+
+## Components
+
+Current targets describe the build as it exists today. Repeated aggregate
+targets expose the boundaries that the next remediation stage must split;
+they are not a claim that the component already has a dedicated target.
+
+| Component | Layer | Owner | Files | Current targets | Entry points |
+| --- | --- | --- | ---: | --- | --- |
+| `yijinjing-schema` | `schema-values` | `core/schema` | 5 | `yijinjing` | `src/libyijinjing/include/kungfu/yijinjing/schema/core.h` |
+| `yijinjing-kernel` | `journal-kernel` | `core/yijinjing` | 42 | `yijinjing` | `src/libyijinjing/include/kungfu/yijinjing/journal/journal.h`<br>`src/libyijinjing/include/kungfu/yijinjing/storage.h` |
+| `libkungfu-contracts` | `ports-contracts` | `core/runtime-contracts` | 54 | `yijinjing`<br>`kungfu` | `src/libkungfu/include/kungfu/runtime/common.h`<br>`src/libkungfu/include/kungfu/runtime/storage/service.h` |
+| `libkungfu-services` | `application-services` | `core/runtime-services` | 29 | `kungfu_state_cache`<br>`kungfu_optim`<br>`kungfu` | `src/libkungfu/src/runtime/storage/service.cpp`<br>`src/libkungfu/src/runtime/state_service.cpp`<br>`src/libkungfu/src/runtime/query/fact_query.cpp` |
+| `libkungfu-adapters` | `adapters` | `core/runtime-adapters` | 13 | `kungfu_optim`<br>`kungfu`<br>`kungfu_native_storage_shared` | `src/libkungfu/src/view/schema.cpp`<br>`src/libkungfu/src/runtime/native_storage.cpp`<br>`src/libkungfu/src/runtime/util/rocks.cpp` |
+| `core-composition-bindings` | `composition-bindings` | `core/bindings` | 42 | `kungfu`<br>`kungfu_embedding`<br>`kungfu_wasm_host`<br>`kungfu_node`<br>`kungfu_electron`<br>`drone`<br>`kungfu_kfc`<br>`kungfu_node_host`<br>`pykungfu` | `src/bindings/node/binding/kungfu_node.cpp`<br>`src/bindings/python/binding/pykungfu.cpp`<br>`src/libkungfu/src/runtime/embedding.cpp` |
+| `core-native-qualification` | `qualification` | `core/qualification` | 16 | `yijinjing_mmap_tests`<br>`yijinjing_content_hash_tests`<br>`yijinjing_mmap_qualification`<br>`kungfu_durability_contract_tests`<br>`kungfu_runtime_error_tests`<br>`kungfu_embedding_generic_codec_tests`<br>`kungfu_peer_continuity_tests`<br>`kungfu_state_service_contract_tests`<br>`kungfu_durable_ingest_tests`<br>`kungfu_durability_powercut_fixture`<br>`kungfu_durability_slo_fixture`<br>`kungfu_offhost_backup_fixture`<br>`kungfu_projection_bootstrap_tests`<br>`kungfu_crash_recovery_tests`<br>`kungfu_profile_lifecycle_tests` | `src/libkungfu/tests/durability_contract_tests.cpp`<br>`src/libyijinjing/tests/mmap_tests.cpp` |
+
+## Navigation
+
+| Question | Start here |
+| --- | --- |
+| Journal write, mmap publication or replay kernel | `yijinjing-kernel` → `src/libyijinjing/include/kungfu/yijinjing/journal/journal.h` |
+| Durability and crash-recovery policy | `libkungfu-services` → `src/libkungfu/src/runtime/durability.cpp` |
+| State service and projections | `libkungfu-services` → `src/libkungfu/src/runtime/state_service.cpp` |
+| Runtime fact and saved-query behavior | `libkungfu-services` → `src/libkungfu/src/runtime/query/fact_query.cpp` |
+| Trust assessment or live coordination | `libkungfu-services` → `src/libkungfu/src/runtime/trust/assessment_runtime.cpp` |
+| Storage service composition | `libkungfu-services` → `src/libkungfu/src/runtime/storage/service.cpp` |
+| RocksDB or SQLite integration | `libkungfu-adapters` → `src/libkungfu/src/runtime/util/rocks.cpp` |
+| FlatBuffers projection boundary | `libkungfu-adapters` → `src/libkungfu/src/view/schema.cpp` |
+| Transport, process or OS integration | `libkungfu-adapters` → `src/libkungfu/src/runtime/io/io.cpp` |
+| Python, Node, C embedding or WASM entry | `core-composition-bindings` → `src/libkungfu/src/runtime/embedding.cpp` |
+| Native regression or qualification fixture | `core-native-qualification` → `src/libkungfu/tests/durability_contract_tests.cpp` |
+
+## Gate
+
+```sh
+./shifu check:source
+```
+
+The source gate fails when a tracked C/C++ file has zero or multiple owners,
+when a current target loses its CMake evidence, when a resolved internal
+include is undeclared, when a declared dependency or resolved include reverses
+the layer contract, when a forbidden include enters a protected layer, or
+when this map drifts.

--- a/framework/core/architecture/check-layers.mjs
+++ b/framework/core/architecture/check-layers.mjs
@@ -1,0 +1,491 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const architectureRoot = path.dirname(fileURLToPath(import.meta.url));
+const coreRoot = path.resolve(architectureRoot, '..');
+const contractPath = path.join(architectureRoot, 'layers.json');
+const mapPath = path.join(architectureRoot, 'LAYERS.md');
+
+function posix(value) {
+  return value.split(path.sep).join('/');
+}
+
+function walk(root) {
+  if (!fs.existsSync(root)) return [];
+  const files = [];
+  for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+    const full = path.join(root, entry.name);
+    if (entry.isDirectory()) files.push(...walk(full));
+    else if (entry.isFile()) files.push(full);
+  }
+  return files;
+}
+
+function owns(component, file) {
+  const included =
+    (component.include_files || []).includes(file) ||
+    (component.include_prefixes || []).some((prefix) =>
+      file.startsWith(prefix),
+    );
+  if (!included) return false;
+  if ((component.exclude_files || []).includes(file)) return false;
+  return !(component.exclude_prefixes || []).some((prefix) =>
+    file.startsWith(prefix),
+  );
+}
+
+function trackedFiles(root, contract) {
+  const extensions = new Set(contract.extensions);
+  const files = new Set();
+  for (const relRoot of contract.tracked_roots) {
+    const absoluteRoot = path.join(root, relRoot);
+    for (const file of walk(absoluteRoot)) {
+      if (extensions.has(path.extname(file))) {
+        files.add(posix(path.relative(root, file)));
+      }
+    }
+  }
+  return [...files].sort();
+}
+
+function validate(root, contract) {
+  const problems = [];
+  if (contract.$schema !== 'kungfu.core-architecture/v1') {
+    problems.push(`unsupported schema: ${contract.$schema || '<missing>'}`);
+  }
+
+  const layerById = new Map();
+  for (const layer of contract.layers || []) {
+    if (layerById.has(layer.id)) problems.push(`duplicate layer: ${layer.id}`);
+    layerById.set(layer.id, layer);
+  }
+  const componentById = new Map();
+  const usedTargets = new Set();
+  for (const component of contract.components || []) {
+    if (componentById.has(component.id)) {
+      problems.push(`duplicate component: ${component.id}`);
+    }
+    componentById.set(component.id, component);
+    if (!layerById.has(component.layer)) {
+      problems.push(`${component.id}: unknown layer ${component.layer}`);
+    }
+    if (
+      !Array.isArray(component.current_targets) ||
+      component.current_targets.length === 0
+    ) {
+      problems.push(`${component.id}: current_targets must not be empty`);
+    }
+    for (const target of component.current_targets || [])
+      usedTargets.add(target);
+  }
+
+  const evidencedTargets = new Set();
+  for (const entry of contract.target_evidence || []) {
+    const evidencePath = path.join(root, entry.file);
+    if (!fs.existsSync(evidencePath)) {
+      problems.push(`missing target evidence file: ${entry.file}`);
+      continue;
+    }
+    const cmake = fs.readFileSync(evidencePath, 'utf8');
+    for (const target of entry.targets || []) {
+      if (evidencedTargets.has(target)) {
+        problems.push(`duplicate target evidence: ${target}`);
+      }
+      evidencedTargets.add(target);
+      const token = entry.tokens?.[target] || target;
+      if (!cmake.includes(token)) {
+        problems.push(`${target}: token ${token} is absent from ${entry.file}`);
+      }
+    }
+  }
+  for (const target of usedTargets) {
+    if (!evidencedTargets.has(target))
+      problems.push(`target lacks CMake evidence: ${target}`);
+  }
+  for (const target of evidencedTargets) {
+    if (!usedTargets.has(target))
+      problems.push(`stale unused target evidence: ${target}`);
+  }
+
+  const excluded = new Set(
+    (contract.excluded_files || []).map((entry) => entry.path),
+  );
+  const ownership = new Map();
+  for (const file of trackedFiles(root, contract)) {
+    if (excluded.has(file)) continue;
+    const owners = (contract.components || []).filter((component) =>
+      owns(component, file),
+    );
+    if (owners.length === 0) problems.push(`unclassified file: ${file}`);
+    if (owners.length > 1) {
+      problems.push(
+        `multiply owned file: ${file} -> ${owners.map((item) => item.id).join(', ')}`,
+      );
+    }
+    if (owners.length === 1) ownership.set(file, owners[0].id);
+  }
+
+  for (const entry of contract.excluded_files || []) {
+    if (!fs.existsSync(path.join(root, entry.path))) {
+      problems.push(`stale excluded file: ${entry.path}`);
+    }
+    if (!entry.reason)
+      problems.push(`excluded file lacks reason: ${entry.path}`);
+  }
+
+  for (const component of contract.components || []) {
+    const sourceLayer = layerById.get(component.layer);
+    for (const dependencyId of component.dependencies || []) {
+      const dependency = componentById.get(dependencyId);
+      if (!dependency) {
+        problems.push(`${component.id}: unknown dependency ${dependencyId}`);
+        continue;
+      }
+      if (!sourceLayer.may_depend_on.includes(dependency.layer)) {
+        problems.push(
+          `${component.id}: layer ${component.layer} may not depend on ${dependency.layer} (${dependencyId})`,
+        );
+      }
+    }
+    for (const entryPoint of component.entry_points || []) {
+      if (ownership.get(entryPoint) !== component.id) {
+        problems.push(
+          `${component.id}: entry point is missing or owned elsewhere: ${entryPoint}`,
+        );
+      }
+    }
+  }
+
+  const includePattern = /^\s*#\s*include\s*[<"]([^>"]+)[>"]/;
+  const headerIndex = new Map();
+  for (const file of ownership.keys()) {
+    const marker = '/include/';
+    const index = file.indexOf(marker);
+    if (index >= 0) headerIndex.set(file.slice(index + marker.length), file);
+  }
+  const usedExceptions = new Set();
+  const dependencyExceptions = contract.dependency_exceptions || [];
+  for (const [file, componentId] of ownership) {
+    const component = componentById.get(componentId);
+    const layer = layerById.get(component.layer);
+    const prefixes = layer.forbidden_include_prefixes || [];
+    const lines = fs.readFileSync(path.join(root, file), 'utf8').split('\n');
+    lines.forEach((line, index) => {
+      const match = line.match(includePattern);
+      if (!match) return;
+      const forbidden = prefixes.find((prefix) => match[1].startsWith(prefix));
+      if (forbidden) {
+        problems.push(
+          `${file}:${index + 1}: ${component.layer} forbids include ${match[1]}`,
+        );
+      }
+      const localCandidate = posix(
+        path.normalize(path.join(path.dirname(file), match[1])),
+      );
+      const targetFile =
+        headerIndex.get(match[1]) ||
+        (ownership.has(localCandidate) ? localCandidate : undefined);
+      if (!targetFile) return;
+      const targetComponentId = ownership.get(targetFile);
+      const targetComponent = componentById.get(targetComponentId);
+      if (
+        targetComponentId !== componentId &&
+        !(component.dependencies || []).includes(targetComponentId)
+      ) {
+        problems.push(
+          `${file}:${index + 1}: ${componentId} has undeclared dependency on ${targetComponentId} via ${match[1]}`,
+        );
+      }
+      if (layer.may_depend_on.includes(targetComponent.layer)) return;
+      const exceptionIndex = dependencyExceptions.findIndex(
+        (entry) =>
+          entry.from_component === componentId &&
+          entry.to_component === targetComponentId &&
+          entry.include === match[1],
+      );
+      if (exceptionIndex >= 0) {
+        usedExceptions.add(exceptionIndex);
+        return;
+      }
+      problems.push(
+        `${file}:${index + 1}: ${componentId} (${component.layer}) may not include ${match[1]} from ${targetComponentId} (${targetComponent.layer})`,
+      );
+    });
+  }
+  dependencyExceptions.forEach((entry, index) => {
+    if (!entry.reason || !entry.follow_up_goal) {
+      problems.push(
+        `dependency exception ${index} lacks reason or follow_up_goal`,
+      );
+    }
+    if (!usedExceptions.has(index)) {
+      problems.push(
+        `stale dependency exception: ${entry.from_component} -> ${entry.to_component} via ${entry.include}`,
+      );
+    }
+  });
+  for (const item of contract.navigation || []) {
+    if (!componentById.has(item.component)) {
+      problems.push(`navigation row has unknown component: ${item.component}`);
+    } else if (ownership.get(item.entry_point) !== item.component) {
+      problems.push(
+        `navigation row points outside ${item.component}: ${item.entry_point}`,
+      );
+    }
+  }
+
+  return { problems, ownership };
+}
+
+function renderMap(contract, ownership) {
+  const lines = [
+    '---',
+    'metadata_schema: kungfu.document-metadata/v1',
+    'document_status: active',
+    'period: ongoing',
+    'theme: kungfu-core-architecture',
+    'doc_type: architecture-map',
+    'sources: [local-files]',
+    'confidence: high',
+    'sensitivity: public',
+    'evidence_grade: B',
+    'review_state: self-reviewed',
+    'last_reviewed: 2026-07-15',
+    '---',
+    '',
+    '# Core Layer Map',
+    '',
+    'This map is a checked projection of [`layers.json`](layers.json). Edit the',
+    'contract first, then update this projection; `check-layers.mjs` rejects drift.',
+    '',
+    'Dependency direction is downward: composition and bindings may consume adapters',
+    'and services; the journal kernel may consume only schema/value contracts.',
+    '',
+    '## Layers',
+    '',
+    '| Order | Layer | Responsibility | May depend on |',
+    '| ---: | --- | --- | --- |',
+  ];
+  for (const layer of [...contract.layers].sort((a, b) => a.order - b.order)) {
+    lines.push(
+      `| ${layer.order} | \`${layer.id}\` | ${layer.responsibility} | ${layer.may_depend_on.map((item) => `\`${item}\``).join(', ')} |`,
+    );
+  }
+  lines.push(
+    '',
+    '## Components',
+    '',
+    'Current targets describe the build as it exists today. Repeated aggregate',
+    'targets expose the boundaries that the next remediation stage must split;',
+    'they are not a claim that the component already has a dedicated target.',
+    '',
+    '| Component | Layer | Owner | Files | Current targets | Entry points |',
+    '| --- | --- | --- | ---: | --- | --- |',
+  );
+  const counts = new Map();
+  for (const componentId of ownership.values()) {
+    counts.set(componentId, (counts.get(componentId) || 0) + 1);
+  }
+  for (const component of contract.components) {
+    lines.push(
+      `| \`${component.id}\` | \`${component.layer}\` | \`${component.owner}\` | ${counts.get(component.id) || 0} | ${component.current_targets.map((item) => `\`${item}\``).join('<br>')} | ${component.entry_points.map((item) => `\`${item}\``).join('<br>')} |`,
+    );
+  }
+  lines.push(
+    '',
+    '## Navigation',
+    '',
+    '| Question | Start here |',
+    '| --- | --- |',
+  );
+  for (const item of contract.navigation) {
+    lines.push(
+      `| ${item.question} | \`${item.component}\` → \`${item.entry_point}\` |`,
+    );
+  }
+  lines.push(
+    '',
+    '## Gate',
+    '',
+    '```sh',
+    './shifu check:source',
+    '```',
+    '',
+    'The source gate fails when a tracked C/C++ file has zero or multiple owners,',
+    'when a current target loses its CMake evidence, when a resolved internal',
+    'include is undeclared, when a declared dependency or resolved include reverses',
+    'the layer contract, when a forbidden include enters a protected layer, or',
+    'when this map drifts.',
+    '',
+  );
+  return lines.join('\n');
+}
+
+function selfTest() {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'kungfu-core-layers-'));
+  const write = (rel, text) => {
+    const target = path.join(tmp, rel);
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.writeFileSync(target, text);
+  };
+  const base = {
+    $schema: 'kungfu.core-architecture/v1',
+    tracked_roots: ['src/'],
+    extensions: ['.h', '.cpp'],
+    excluded_files: [],
+    target_evidence: [{ file: 'CMakeLists.txt', targets: ['low', 'high'] }],
+    layers: [
+      {
+        id: 'low',
+        order: 0,
+        responsibility: 'low',
+        may_depend_on: ['low'],
+        forbidden_include_prefixes: ['high/'],
+      },
+      {
+        id: 'high',
+        order: 1,
+        responsibility: 'high',
+        may_depend_on: ['high', 'low'],
+        forbidden_include_prefixes: [],
+      },
+    ],
+    components: [
+      {
+        id: 'low-core',
+        layer: 'low',
+        owner: 'low',
+        include_prefixes: ['src/low/'],
+        include_files: [],
+        exclude_prefixes: [],
+        exclude_files: [],
+        dependencies: [],
+        current_targets: ['low'],
+        entry_points: ['src/low/include/low/value.h'],
+      },
+      {
+        id: 'high-app',
+        layer: 'high',
+        owner: 'high',
+        include_prefixes: ['src/high/'],
+        include_files: [],
+        exclude_prefixes: [],
+        exclude_files: [],
+        dependencies: ['low-core'],
+        current_targets: ['high'],
+        entry_points: ['src/high/app.cpp'],
+      },
+    ],
+    navigation: [],
+  };
+  const expect = (label, condition) => {
+    console.log(`  ${condition ? 'ok' : 'MISS'}: ${label}`);
+    if (!condition) throw new Error(`self-test missed: ${label}`);
+  };
+  try {
+    write('CMakeLists.txt', 'add_library(low)\nadd_library(high)\n');
+    write('src/low/include/low/value.h', '#pragma once\n');
+    write('src/high/app.cpp', '#include <low/value.h>\n');
+    write('src/high/include/high/service.h', '#pragma once\n');
+    expect('clean contract passes', validate(tmp, base).problems.length === 0);
+
+    const missingTarget = structuredClone(base);
+    missingTarget.target_evidence[0].targets = ['low'];
+    expect(
+      'target without CMake evidence fails',
+      validate(tmp, missingTarget).problems.some((item) =>
+        item.includes('target lacks CMake evidence'),
+      ),
+    );
+
+    write('src/orphan.cpp', 'int orphan = 0;\n');
+    expect(
+      'unclassified source fails',
+      validate(tmp, base).problems.some((item) =>
+        item.includes('unclassified file'),
+      ),
+    );
+    fs.rmSync(path.join(tmp, 'src/orphan.cpp'));
+
+    const duplicate = structuredClone(base);
+    duplicate.components[1].include_prefixes.push('src/low/');
+    expect(
+      'multiple ownership fails',
+      validate(tmp, duplicate).problems.some((item) =>
+        item.includes('multiply owned file'),
+      ),
+    );
+
+    write('src/low/include/low/value.h', '#include <high/service.h>\n');
+    expect(
+      'forbidden reverse include fails',
+      validate(tmp, base).problems.some((item) =>
+        item.includes('forbids include'),
+      ),
+    );
+
+    const resolvedReverse = structuredClone(base);
+    resolvedReverse.layers[0].forbidden_include_prefixes = [];
+    expect(
+      'resolved internal reverse include fails',
+      validate(tmp, resolvedReverse).problems.some((item) =>
+        item.includes('may not include'),
+      ),
+    );
+    write('src/low/include/low/value.h', '#pragma once\n');
+
+    const undeclared = structuredClone(base);
+    undeclared.components[1].dependencies = [];
+    expect(
+      'undeclared resolved dependency fails',
+      validate(tmp, undeclared).problems.some((item) =>
+        item.includes('undeclared dependency'),
+      ),
+    );
+
+    const reversed = structuredClone(base);
+    reversed.components[0].dependencies = ['high-app'];
+    expect(
+      'declared reverse dependency fails',
+      validate(tmp, reversed).problems.some((item) =>
+        item.includes('may not depend'),
+      ),
+    );
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+  console.log(
+    'OK: core architecture negative fixtures fail for the intended reasons.',
+  );
+}
+
+if (process.argv.includes('--self-test')) {
+  selfTest();
+  process.exit(0);
+}
+
+const contract = JSON.parse(fs.readFileSync(contractPath, 'utf8'));
+const result = validate(coreRoot, contract);
+if (result.problems.length) {
+  console.error(result.problems.join('\n'));
+  process.exit(1);
+}
+const rendered = renderMap(contract, result.ownership);
+if (process.argv.includes('--print-map')) {
+  process.stdout.write(rendered);
+  process.exit(0);
+}
+if (!fs.existsSync(mapPath) || fs.readFileSync(mapPath, 'utf8') !== rendered) {
+  console.error(
+    'framework/core/architecture/LAYERS.md is stale; regenerate it from layers.json.',
+  );
+  process.exit(1);
+}
+console.log(
+  `OK: ${result.ownership.size} first-party C/C++ files have one component owner and the layer map is current.`,
+);

--- a/framework/core/architecture/layers.json
+++ b/framework/core/architecture/layers.json
@@ -1,0 +1,216 @@
+{
+  "$schema": "kungfu.core-architecture/v1",
+  "tracked_roots": [
+    "src/libyijinjing/include/",
+    "src/libyijinjing/src/",
+    "src/libyijinjing/tests/",
+    "src/libkungfu/include/",
+    "src/libkungfu/src/",
+    "src/libkungfu/tests/",
+    "src/bindings/node/",
+    "src/bindings/python/",
+    "src/capability/",
+    "src/libwasm/"
+  ],
+  "extensions": [".c", ".cc", ".cpp", ".cxx", ".h", ".hh", ".hpp", ".hxx"],
+  "excluded_files": [
+    {
+      "path": "src/libkungfu/src/view/ActionEnvelope_generated.h",
+      "reason": "Checked-in FlatBuffers projection generated from the canonical schema."
+    }
+  ],
+  "target_evidence": [
+    {
+      "file": "src/libyijinjing/CMakeLists.txt",
+      "targets": ["yijinjing", "yijinjing_mmap_tests", "yijinjing_content_hash_tests", "yijinjing_mmap_qualification"]
+    },
+    {
+      "file": "src/libkungfu/CMakeLists.txt",
+      "targets": ["kungfu", "kungfu_state_cache", "kungfu_optim", "kungfu_native_storage_shared", "kungfu_durability_contract_tests", "kungfu_runtime_error_tests", "kungfu_embedding_generic_codec_tests", "kungfu_peer_continuity_tests", "kungfu_state_service_contract_tests", "kungfu_durable_ingest_tests", "kungfu_durability_powercut_fixture", "kungfu_durability_slo_fixture", "kungfu_offhost_backup_fixture", "kungfu_projection_bootstrap_tests", "kungfu_crash_recovery_tests", "kungfu_profile_lifecycle_tests"],
+      "tokens": {"kungfu": "${LIBKUNGFU_NAME}"}
+    },
+    {
+      "file": "src/libembedding/CMakeLists.txt",
+      "targets": ["kungfu_embedding"]
+    },
+    {
+      "file": "src/libwasm/CMakeLists.txt",
+      "targets": ["kungfu_wasm_host"]
+    },
+    {
+      "file": "src/bindings/node/CMakeLists.txt",
+      "targets": ["kungfu_node", "kungfu_electron", "drone", "kungfu_kfc", "kungfu_node_host"]
+    },
+    {
+      "file": "src/bindings/python/CMakeLists.txt",
+      "targets": ["pykungfu"]
+    }
+  ],
+  "layers": [
+    {
+      "id": "schema-values",
+      "order": 0,
+      "responsibility": "Stable value and schema contracts shared by the journal kernel.",
+      "may_depend_on": ["schema-values"],
+      "forbidden_include_prefixes": ["kungfu/runtime/", "rocksdb/", "sqlite"]
+    },
+    {
+      "id": "journal-kernel",
+      "order": 1,
+      "responsibility": "Journal, mmap, hash, content and storage semantic kernel without runtime engines.",
+      "may_depend_on": ["journal-kernel", "schema-values"],
+      "forbidden_include_prefixes": ["kungfu/runtime/", "rocksdb/", "sqlite"]
+    },
+    {
+      "id": "ports-contracts",
+      "order": 2,
+      "responsibility": "Public runtime contracts and ports, independent of concrete adapters and bindings.",
+      "may_depend_on": ["ports-contracts", "journal-kernel", "schema-values"],
+      "forbidden_include_prefixes": ["kungfu/bindings/"]
+    },
+    {
+      "id": "application-services",
+      "order": 3,
+      "responsibility": "Runtime application services for durability, state, query, trust, live and storage orchestration.",
+      "may_depend_on": ["application-services", "ports-contracts", "journal-kernel", "schema-values"],
+      "forbidden_include_prefixes": ["kungfu/bindings/"]
+    },
+    {
+      "id": "adapters",
+      "order": 4,
+      "responsibility": "Concrete storage, transport, OS, FlatBuffers and process adapters.",
+      "may_depend_on": ["adapters", "application-services", "ports-contracts", "journal-kernel", "schema-values"],
+      "forbidden_include_prefixes": ["kungfu/bindings/"]
+    },
+    {
+      "id": "composition-bindings",
+      "order": 5,
+      "responsibility": "Composition roots and C, Python, Node and WASM-facing bindings.",
+      "may_depend_on": ["composition-bindings", "adapters", "application-services", "ports-contracts", "journal-kernel", "schema-values"],
+      "forbidden_include_prefixes": []
+    },
+    {
+      "id": "qualification",
+      "order": 6,
+      "responsibility": "Native qualification fixtures and tests; never a production dependency.",
+      "may_depend_on": ["qualification", "composition-bindings", "adapters", "application-services", "ports-contracts", "journal-kernel", "schema-values"],
+      "forbidden_include_prefixes": []
+    }
+  ],
+  "components": [
+    {
+      "id": "yijinjing-schema",
+      "layer": "schema-values",
+      "owner": "core/schema",
+      "include_prefixes": ["src/libyijinjing/include/kungfu/yijinjing/schema/"],
+      "include_files": [
+        "src/libyijinjing/include/kungfu/common.h",
+        "src/libyijinjing/include/kungfu/yijinjing/journal/layout_fingerprint.h"
+      ],
+      "exclude_prefixes": [],
+      "exclude_files": [],
+      "dependencies": [],
+      "current_targets": ["yijinjing"],
+      "entry_points": ["src/libyijinjing/include/kungfu/yijinjing/schema/core.h"]
+    },
+    {
+      "id": "yijinjing-kernel",
+      "layer": "journal-kernel",
+      "owner": "core/yijinjing",
+      "include_prefixes": ["src/libyijinjing/include/", "src/libyijinjing/src/"],
+      "exclude_prefixes": ["src/libyijinjing/include/kungfu/yijinjing/schema/"],
+      "exclude_files": [
+        "src/libyijinjing/include/kungfu/common.h",
+        "src/libyijinjing/include/kungfu/yijinjing/journal/layout_fingerprint.h"
+      ],
+      "dependencies": ["yijinjing-schema"],
+      "current_targets": ["yijinjing"],
+      "entry_points": ["src/libyijinjing/include/kungfu/yijinjing/journal/journal.h", "src/libyijinjing/include/kungfu/yijinjing/storage.h"]
+    },
+    {
+      "id": "libkungfu-contracts",
+      "layer": "ports-contracts",
+      "owner": "core/runtime-contracts",
+      "include_prefixes": ["src/libkungfu/include/"],
+      "exclude_prefixes": [],
+      "exclude_files": [],
+      "dependencies": ["yijinjing-kernel", "yijinjing-schema"],
+      "current_targets": ["yijinjing", "kungfu"],
+      "entry_points": ["src/libkungfu/include/kungfu/runtime/common.h", "src/libkungfu/include/kungfu/runtime/storage/service.h"]
+    },
+    {
+      "id": "libkungfu-services",
+      "layer": "application-services",
+      "owner": "core/runtime-services",
+      "include_prefixes": ["src/libkungfu/src/runtime/"],
+      "exclude_prefixes": [
+        "src/libkungfu/src/runtime/io/",
+        "src/libkungfu/src/runtime/sandbox/",
+        "src/libkungfu/src/runtime/util/"
+      ],
+      "exclude_files": [
+        "src/libkungfu/src/runtime/embedding.cpp",
+        "src/libkungfu/src/runtime/native_storage.cpp",
+        "src/libkungfu/src/runtime/projection_bootstrap.cpp"
+      ],
+      "dependencies": ["libkungfu-contracts", "yijinjing-kernel", "yijinjing-schema"],
+      "current_targets": ["kungfu_state_cache", "kungfu_optim", "kungfu"],
+      "entry_points": ["src/libkungfu/src/runtime/storage/service.cpp", "src/libkungfu/src/runtime/state_service.cpp", "src/libkungfu/src/runtime/query/fact_query.cpp"]
+    },
+    {
+      "id": "libkungfu-adapters",
+      "layer": "adapters",
+      "owner": "core/runtime-adapters",
+      "include_prefixes": [
+        "src/libkungfu/src/runtime/io/",
+        "src/libkungfu/src/runtime/sandbox/",
+        "src/libkungfu/src/runtime/util/",
+        "src/libkungfu/src/view/"
+      ],
+      "include_files": [
+        "src/libkungfu/src/runtime/native_storage.cpp"
+      ],
+      "exclude_prefixes": [],
+      "exclude_files": [],
+      "dependencies": ["libkungfu-services", "libkungfu-contracts", "yijinjing-kernel", "yijinjing-schema"],
+      "current_targets": ["kungfu_optim", "kungfu", "kungfu_native_storage_shared"],
+      "entry_points": ["src/libkungfu/src/view/schema.cpp", "src/libkungfu/src/runtime/native_storage.cpp", "src/libkungfu/src/runtime/util/rocks.cpp"]
+    },
+    {
+      "id": "core-composition-bindings",
+      "layer": "composition-bindings",
+      "owner": "core/bindings",
+      "include_prefixes": ["src/bindings/", "src/capability/", "src/libwasm/"],
+      "include_files": ["src/libkungfu/src/runtime/embedding.cpp", "src/libkungfu/src/runtime/projection_bootstrap.cpp"],
+      "exclude_prefixes": [],
+      "exclude_files": [],
+      "dependencies": ["libkungfu-adapters", "libkungfu-services", "libkungfu-contracts", "yijinjing-kernel", "yijinjing-schema"],
+      "current_targets": ["kungfu", "kungfu_embedding", "kungfu_wasm_host", "kungfu_node", "kungfu_electron", "drone", "kungfu_kfc", "kungfu_node_host", "pykungfu"],
+      "entry_points": ["src/bindings/node/binding/kungfu_node.cpp", "src/bindings/python/binding/pykungfu.cpp", "src/libkungfu/src/runtime/embedding.cpp"]
+    },
+    {
+      "id": "core-native-qualification",
+      "layer": "qualification",
+      "owner": "core/qualification",
+      "include_prefixes": ["src/libkungfu/tests/", "src/libyijinjing/tests/"],
+      "exclude_prefixes": [],
+      "exclude_files": [],
+      "dependencies": ["core-composition-bindings", "libkungfu-adapters", "libkungfu-services", "libkungfu-contracts", "yijinjing-kernel", "yijinjing-schema"],
+      "current_targets": ["yijinjing_mmap_tests", "yijinjing_content_hash_tests", "yijinjing_mmap_qualification", "kungfu_durability_contract_tests", "kungfu_runtime_error_tests", "kungfu_embedding_generic_codec_tests", "kungfu_peer_continuity_tests", "kungfu_state_service_contract_tests", "kungfu_durable_ingest_tests", "kungfu_durability_powercut_fixture", "kungfu_durability_slo_fixture", "kungfu_offhost_backup_fixture", "kungfu_projection_bootstrap_tests", "kungfu_crash_recovery_tests", "kungfu_profile_lifecycle_tests"],
+      "entry_points": ["src/libkungfu/tests/durability_contract_tests.cpp", "src/libyijinjing/tests/mmap_tests.cpp"]
+    }
+  ],
+  "navigation": [
+    {"question": "Journal write, mmap publication or replay kernel", "component": "yijinjing-kernel", "entry_point": "src/libyijinjing/include/kungfu/yijinjing/journal/journal.h"},
+    {"question": "Durability and crash-recovery policy", "component": "libkungfu-services", "entry_point": "src/libkungfu/src/runtime/durability.cpp"},
+    {"question": "State service and projections", "component": "libkungfu-services", "entry_point": "src/libkungfu/src/runtime/state_service.cpp"},
+    {"question": "Runtime fact and saved-query behavior", "component": "libkungfu-services", "entry_point": "src/libkungfu/src/runtime/query/fact_query.cpp"},
+    {"question": "Trust assessment or live coordination", "component": "libkungfu-services", "entry_point": "src/libkungfu/src/runtime/trust/assessment_runtime.cpp"},
+    {"question": "Storage service composition", "component": "libkungfu-services", "entry_point": "src/libkungfu/src/runtime/storage/service.cpp"},
+    {"question": "RocksDB or SQLite integration", "component": "libkungfu-adapters", "entry_point": "src/libkungfu/src/runtime/util/rocks.cpp"},
+    {"question": "FlatBuffers projection boundary", "component": "libkungfu-adapters", "entry_point": "src/libkungfu/src/view/schema.cpp"},
+    {"question": "Transport, process or OS integration", "component": "libkungfu-adapters", "entry_point": "src/libkungfu/src/runtime/io/io.cpp"},
+    {"question": "Python, Node, C embedding or WASM entry", "component": "core-composition-bindings", "entry_point": "src/libkungfu/src/runtime/embedding.cpp"},
+    {"question": "Native regression or qualification fixture", "component": "core-native-qualification", "entry_point": "src/libkungfu/tests/durability_contract_tests.cpp"}
+  ]
+}

--- a/scripts/source-acceptance.mjs
+++ b/scripts/source-acceptance.mjs
@@ -140,6 +140,15 @@ export function sourceAcceptancePlan(files) {
     ['runtime greenfield', 'scripts/check-runtime-greenfield.mjs'],
     ['schema authority', 'scripts/check-schema-authority.mjs'],
     [
+      'core architecture contract',
+      'framework/core/architecture/check-layers.mjs',
+    ],
+    [
+      'core architecture negative fixtures',
+      'framework/core/architecture/check-layers.mjs',
+      '--self-test',
+    ],
+    [
       'journal authority boundary',
       'scripts/check-journal-authority-boundary.mjs',
     ],

--- a/scripts/source-acceptance.test.mjs
+++ b/scripts/source-acceptance.test.mjs
@@ -86,6 +86,8 @@ test('source plan covers representative source-only checks', () => {
   assert.ok(labels.includes('Python type baseline'));
   assert.ok(labels.includes('changed C/C++ format'));
   assert.ok(labels.includes('documentation contracts'));
+  assert.ok(labels.includes('core architecture contract'));
+  assert.ok(labels.includes('core architecture negative fixtures'));
   assert.ok(labels.includes('runtime activation contract'));
   assert.ok(labels.includes('runtime upgrade contract'));
   assert.ok(labels.includes('product upgrade qualification'));


### PR DESCRIPTION
## Summary

Add one executable authority for the C++ Core layer model so source ownership, dependency direction, current target evidence, and developer navigation stay synchronized.

## Related issue

None.

## Changes

- define seven ordered Core layers and seven uniquely owned components in `framework/core/architecture/layers.json`
- validate every tracked first-party C/C++ file, actual internal includes, declared component dependencies, current CMake target evidence, and navigation entrypoints
- generate-check the human-readable `LAYERS.md` map from the same authority
- add the architecture contract and eight controlled negative fixtures to the build-free source acceptance gate
- link the architecture entry from the existing documentation map

## Verification

- `./shifu check:source`
- `node framework/core/architecture/check-layers.mjs`
- `node framework/core/architecture/check-layers.mjs --self-test`
- `node --test scripts/source-acceptance.test.mjs`

`./shifu check` reaches the existing SDK contract audit and reports an unrelated canonical-policy projection mismatch; this PR does not change `framework/contract`, `developer/sdk`, package manifests, or `pnpm-lock.yaml`.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "stage-ready",
  "adrs": ["ADR-0049"],
  "summary": "Add the executable Core layer, ownership, dependency, and navigation contract required to keep the domain-neutral Core structurally enforceable.",
  "verification": ["./shifu check:source", "core architecture positive and negative fixtures"]
}
-->

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] release evidence, provenance, package publishing, or deployment surfaces
- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed