### PR TITLE
fix(core): honor projected Python environment

### DIFF
--- a/framework/core/tests/qualification/live-peer-continuity/run.mjs
+++ b/framework/core/tests/qualification/live-peer-continuity/run.mjs
@@ -32,14 +32,16 @@ export function sourceFacts() {
   };
 }
 
-function pythonExecutable() {
+export function pythonExecutable({
+  projectEnvironment = process.env.UV_PROJECT_ENVIRONMENT,
+  platform = process.platform,
+} = {}) {
+  const environment =
+    projectEnvironment || path.join(ROOT, 'framework', 'core', '.venv');
   return path.join(
-    ROOT,
-    'framework',
-    'core',
-    '.venv',
-    process.platform === 'win32' ? 'Scripts' : 'bin',
-    process.platform === 'win32' ? 'python.exe' : 'python',
+    environment,
+    platform === 'win32' ? 'Scripts' : 'bin',
+    platform === 'win32' ? 'python.exe' : 'python',
   );
 }
 

--- a/framework/core/tests/qualification/live-peer-continuity/run.test.mjs
+++ b/framework/core/tests/qualification/live-peer-continuity/run.test.mjs
@@ -11,6 +11,7 @@ import {
   createLogBundle,
   defaultOutputDir,
   evaluateQualification,
+  pythonExecutable,
   qualificationPlan,
   retainQualificationArtifacts,
 } from './run.mjs';
@@ -48,6 +49,18 @@ test('native state-machine leg fails when CTest discovers no matching test', () 
   assert.ok(command.includes('--no-tests=error'));
   assert.ok(command.includes('^kungfu_peer_continuity_tests$'));
   assert.ok(command.includes('framework/core/build/src/libkungfu'));
+});
+
+test('native campaign follows the projected Shifu Python environment', () => {
+  const environment = path.join('/tmp', 'projected-core-environment');
+  assert.equal(
+    pythonExecutable({ projectEnvironment: environment, platform: 'linux' }),
+    path.join(environment, 'bin', 'python'),
+  );
+  assert.equal(
+    pythonExecutable({ projectEnvironment: environment, platform: 'win32' }),
+    path.join(environment, 'Scripts', 'python.exe'),
+  );
 });
 
 test('clean complete evidence qualifies only the bounded single-host claim', () => {


### PR DESCRIPTION
## Summary

Make live-peer qualification launch its native campaign from the Python environment projected by Shifu and Buildchain.

## Related issue

None. Found while qualifying the zero-burden desktop runtime through the full Buildchain matrix.

## Changes

- Resolve the native campaign Python from `UV_PROJECT_ENVIRONMENT` when projected.
- Preserve the repository-local Core virtual environment as the development fallback.
- Cover POSIX and Windows interpreter layouts with a focused regression test.

## Verification

- `./shifu exec node --test framework/core/tests/qualification/live-peer-continuity/run.test.mjs`
- `./shifu check`
- `SHIFU_CACHE_BYPASS=source-acceptance ./shifu check:source`
- staged pre-commit gate

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This fixes qualification environment resolution without changing the accepted runtime architecture or claim envelope"
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed (not needed; environment behavior is asserted by tests)
