### PR TITLE
fix(gui): skip Python bytecode during macOS signing

### DIFF
--- a/framework/gui/scripts/sign-macos.mjs
+++ b/framework/gui/scripts/sign-macos.mjs
@@ -3,6 +3,7 @@
 import { signAsync } from '@electron/osx-sign';
 
 const CERTIFICATE_HASH = /^[A-F0-9]{40}$/i;
+const PYTHON_BYTECODE = /(?:^|[\\/])__pycache__(?:[\\/]|$)|\.py[co]$/i;
 
 export function resolveMacSigningIdentity(options, env = process.env) {
   const configured = env.CSC_NAME?.trim();
@@ -11,9 +12,15 @@ export function resolveMacSigningIdentity(options, env = process.env) {
     : options.identity;
 }
 
+export function resolveMacSigningIgnore(ignore) {
+  const configured = ignore === undefined ? [] : [ignore].flat();
+  return [...configured, (filePath) => PYTHON_BYTECODE.test(filePath)];
+}
+
 export async function sign(options) {
   await signAsync({
     ...options,
     identity: resolveMacSigningIdentity(options),
+    ignore: resolveMacSigningIgnore(options.ignore),
   });
 }

--- a/framework/gui/scripts/sign-macos.test.mjs
+++ b/framework/gui/scripts/sign-macos.test.mjs
@@ -5,7 +5,10 @@ import fs from 'node:fs';
 import path from 'node:path';
 import test from 'node:test';
 
-import { resolveMacSigningIdentity } from './sign-macos.mjs';
+import {
+  resolveMacSigningIdentity,
+  resolveMacSigningIgnore,
+} from './sign-macos.mjs';
 
 const ROOT = path.resolve(import.meta.dirname, '../../..');
 
@@ -27,6 +30,34 @@ test('falls back to the identity resolved by electron-builder', () => {
     ),
     'Developer ID Application: Example (TEAMID)',
   );
+});
+
+test('skips Python bytecode without skipping native runtime code', () => {
+  const ignore = resolveMacSigningIgnore();
+  const shouldIgnore = (filePath) =>
+    ignore.some((rule) =>
+      typeof rule === 'function' ? rule(filePath) : filePath.match(rule),
+    );
+
+  assert.equal(shouldIgnore('/app/runtime/pkg/module.pyc'), true);
+  assert.equal(shouldIgnore('C:\\app\\runtime\\pkg\\module.pyo'), true);
+  assert.equal(shouldIgnore('/app/runtime/pkg/__pycache__/module.data'), true);
+  assert.equal(shouldIgnore('/app/runtime/pkg/native.so'), false);
+  assert.equal(shouldIgnore('/app/runtime/pkg/native.dylib'), false);
+  assert.equal(shouldIgnore('/app/runtime/kungfu'), false);
+});
+
+test('preserves existing string, array, and function ignore rules', () => {
+  const existingFunction = (filePath) => filePath.endsWith('.map');
+
+  assert.deepEqual(resolveMacSigningIgnore('existing-pattern').slice(0, -1), [
+    'existing-pattern',
+  ]);
+  assert.deepEqual(
+    resolveMacSigningIgnore(['first-pattern', 'second-pattern']).slice(0, -1),
+    ['first-pattern', 'second-pattern'],
+  );
+  assert.equal(resolveMacSigningIgnore(existingFunction)[0], existingFunction);
 });
 
 test('both desktop builders resolve the signing hook from the GUI project', () => {


### PR DESCRIPTION
## Summary

- exclude Python bytecode and `__pycache__` contents from the macOS code-signing walk
- preserve every existing ignore rule and continue signing native libraries and executables
- avoid thousands of unnecessary Apple timestamp requests that made signed product packaging intermittently fail

## Failure evidence

Two exact-source macOS qualification attempts reached `@electron/osx-sign` and failed on different `.pyc` files with `A timestamp was expected but was not found`; signing the same failed file manually succeeded immediately afterward. The failure is therefore isolated to high-volume timestamping of non-code Python cache artifacts.

## Validation

- `node --test framework/gui/scripts/sign-macos.test.mjs` (5 passed)
- `./shifu check:source` (316 source contract, 76 runtime upgrade, 66 desktop adapter tests passed)
- commit staged gate passed

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Stabilizes macOS product signing by excluding non-code Python cache artifacts without changing architecture authority or release policy"
}
-->