### PR TITLE
fix(gui): preserve macOS signing ignore function

### DIFF
--- a/framework/gui/scripts/sign-macos.mjs
+++ b/framework/gui/scripts/sign-macos.mjs
@@ -13,8 +13,14 @@ export function resolveMacSigningIdentity(options, env = process.env) {
 }
 
 export function resolveMacSigningIgnore(ignore) {
-  const configured = ignore === undefined ? [] : [ignore].flat();
-  return [...configured, (filePath) => PYTHON_BYTECODE.test(filePath)];
+  const configured =
+    ignore === undefined ? [] : Array.isArray(ignore) ? ignore : [ignore];
+  // osx-sign 1.3.3 drops array ignores during option normalization.
+  return (filePath) =>
+    PYTHON_BYTECODE.test(filePath) ||
+    configured.some((rule) =>
+      typeof rule === 'function' ? rule(filePath) : filePath.match(rule),
+    );
 }
 
 export async function sign(options) {

--- a/framework/gui/scripts/sign-macos.test.mjs
+++ b/framework/gui/scripts/sign-macos.test.mjs
@@ -33,11 +33,7 @@ test('falls back to the identity resolved by electron-builder', () => {
 });
 
 test('skips Python bytecode without skipping native runtime code', () => {
-  const ignore = resolveMacSigningIgnore();
-  const shouldIgnore = (filePath) =>
-    ignore.some((rule) =>
-      typeof rule === 'function' ? rule(filePath) : filePath.match(rule),
-    );
+  const shouldIgnore = resolveMacSigningIgnore();
 
   assert.equal(shouldIgnore('/app/runtime/pkg/module.pyc'), true);
   assert.equal(shouldIgnore('C:\\app\\runtime\\pkg\\module.pyo'), true);
@@ -50,14 +46,27 @@ test('skips Python bytecode without skipping native runtime code', () => {
 test('preserves existing string, array, and function ignore rules', () => {
   const existingFunction = (filePath) => filePath.endsWith('.map');
 
-  assert.deepEqual(resolveMacSigningIgnore('existing-pattern').slice(0, -1), [
-    'existing-pattern',
-  ]);
-  assert.deepEqual(
-    resolveMacSigningIgnore(['first-pattern', 'second-pattern']).slice(0, -1),
-    ['first-pattern', 'second-pattern'],
+  assert.equal(
+    resolveMacSigningIgnore('existing-pattern')('/app/existing-pattern'),
+    true,
   );
-  assert.equal(resolveMacSigningIgnore(existingFunction)[0], existingFunction);
+  assert.equal(
+    resolveMacSigningIgnore(['first-pattern', 'second-pattern'])(
+      '/app/second-pattern',
+    ),
+    true,
+  );
+  assert.equal(
+    resolveMacSigningIgnore(existingFunction)('/app/source.map'),
+    true,
+  );
+});
+
+test('returns one function so osx-sign does not discard the ignore option', () => {
+  assert.equal(
+    typeof resolveMacSigningIgnore(['existing-pattern']),
+    'function',
+  );
 });
 
 test('both desktop builders resolve the signing hook from the GUI project', () => {


### PR DESCRIPTION
## Summary

- pass one combined ignore function to `@electron/osx-sign` instead of an array
- preserve existing string, array, and function rules inside that function
- keep Python bytecode out of code signing after the previous array form was discarded by osx-sign 1.3.3

## Runtime evidence

An exact-source signed product build after PR #913 still spawned `codesign` for a `.pyc` file. Inspection showed osx-sign 1.3.3 normalizes a non-array ignore into an array but returns `undefined` for an array input, silently discarding the prior hook result. The invalid signing run was stopped before further timestamp load.

## Validation

- `node --test framework/gui/scripts/sign-macos.test.mjs` (6 passed)
- `./shifu check:source` (316 source contract, 76 runtime upgrade, 67 desktop adapter tests passed)
- commit staged gate passed

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Corrects the macOS signing adapter compatibility fix without changing architecture authority or release policy"
}
-->