### PR TITLE
fix(core): run live-peer campaign through uv

### DIFF
--- a/framework/core/tests/qualification/live-peer-continuity/run.mjs
+++ b/framework/core/tests/qualification/live-peer-continuity/run.mjs
@@ -32,17 +32,18 @@ export function sourceFacts() {
   };
 }
 
-export function pythonExecutable({
-  projectEnvironment = process.env.UV_PROJECT_ENVIRONMENT,
-  platform = process.platform,
-} = {}) {
-  const environment =
-    projectEnvironment || path.join(ROOT, 'framework', 'core', '.venv');
-  return path.join(
-    environment,
-    platform === 'win32' ? 'Scripts' : 'bin',
-    platform === 'win32' ? 'python.exe' : 'python',
-  );
+export function pythonInvocation({ platform = process.platform } = {}) {
+  return {
+    command: [
+      'uv',
+      'run',
+      '--frozen',
+      '--project',
+      path.join(ROOT, 'framework', 'core'),
+      'python',
+    ],
+    shell: platform === 'win32',
+  };
 }
 
 function nativeEnvironment() {
@@ -82,6 +83,7 @@ function nativeEnvironment() {
 }
 
 export function qualificationPlan(outputDir) {
+  const python = pythonInvocation();
   return [
     {
       id: 'core-continuity-state-machine',
@@ -108,13 +110,14 @@ export function qualificationPlan(outputDir) {
     {
       id: 'native-cross-process-restart',
       command: [
-        pythonExecutable(),
+        ...python.command,
         path.join(HARNESS_DIR, 'native_campaign.py'),
         'campaign',
         '--output-dir',
         path.join(outputDir, 'native-campaign'),
       ],
       env: nativeEnvironment(),
+      shell: python.shell,
     },
   ];
 }
@@ -126,6 +129,7 @@ function runSuite(suite, outputDir) {
     env: suite.env,
     encoding: 'utf8',
     maxBuffer: 128 * 1024 * 1024,
+    shell: suite.shell || false,
   });
   const output = `${result.stdout || ''}${result.stderr || ''}`;
   const rawLog = `${suite.id}.log`;

--- a/framework/core/tests/qualification/live-peer-continuity/run.test.mjs
+++ b/framework/core/tests/qualification/live-peer-continuity/run.test.mjs
@@ -11,7 +11,7 @@ import {
   createLogBundle,
   defaultOutputDir,
   evaluateQualification,
-  pythonExecutable,
+  pythonInvocation,
   qualificationPlan,
   retainQualificationArtifacts,
 } from './run.mjs';
@@ -51,16 +51,19 @@ test('native state-machine leg fails when CTest discovers no matching test', () 
   assert.ok(command.includes('framework/core/build/src/libkungfu'));
 });
 
-test('native campaign follows the projected Shifu Python environment', () => {
-  const environment = path.join('/tmp', 'projected-core-environment');
-  assert.equal(
-    pythonExecutable({ projectEnvironment: environment, platform: 'linux' }),
-    path.join(environment, 'bin', 'python'),
-  );
-  assert.equal(
-    pythonExecutable({ projectEnvironment: environment, platform: 'win32' }),
-    path.join(environment, 'Scripts', 'python.exe'),
-  );
+test('native campaign enters Python through the Shifu-managed uv project', () => {
+  const linux = pythonInvocation({ platform: 'linux' });
+  const windows = pythonInvocation({ platform: 'win32' });
+  assert.deepEqual(linux.command.slice(0, 4), [
+    'uv',
+    'run',
+    '--frozen',
+    '--project',
+  ]);
+  assert.match(linux.command[4], /framework[/\\]core$/u);
+  assert.equal(linux.command[5], 'python');
+  assert.equal(linux.shell, false);
+  assert.equal(windows.shell, true);
 });
 
 test('clean complete evidence qualifies only the bounded single-host claim', () => {


### PR DESCRIPTION
## Summary

Run the live-peer native campaign through the Shifu-managed `uv run` project entry so strict cache overlays remain active for the whole campaign.

## Related issue

None. Found while qualifying the zero-burden desktop runtime through the full Buildchain matrix.

## Changes

- Replace direct virtual-environment interpreter resolution with `uv run --frozen --project framework/core python`.
- Preserve Windows command resolution through the existing bounded shell path.
- Cover the Shifu-managed invocation contract with a focused regression test.

## Verification

- `node --test framework/core/tests/qualification/live-peer-continuity/run.test.mjs`
- `XDG_CACHE_HOME="$HOME/.cache/kungfu-agent-partitions/live-peer-uv-run" ./shifu check`
- `SHIFU_CACHE_BYPASS=source-acceptance ./shifu check:source`
- staged pre-commit gate

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This fixes the qualification execution route through the existing Shifu uv authority without changing the accepted runtime architecture or claim envelope"
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed (not needed; execution behavior is asserted by tests)
