### PR TITLE
fix(gui): sign only macOS code artifacts

### DIFF
--- a/framework/gui/scripts/sign-macos.mjs
+++ b/framework/gui/scripts/sign-macos.mjs
@@ -1,9 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
+import fs from 'node:fs';
 import { signAsync } from '@electron/osx-sign';
 
 const CERTIFICATE_HASH = /^[A-F0-9]{40}$/i;
-const PYTHON_BYTECODE = /(?:^|[\\/])__pycache__(?:[\\/]|$)|\.py[co]$/i;
+const MAC_CODE_BUNDLE = /\.(?:app|framework)$/i;
+const MACH_O_MAGICS = new Set([
+  0xfeedface, 0xcefaedfe, 0xfeedfacf, 0xcffaedfe, 0xcafebabe, 0xbebafeca,
+  0xcafebabf, 0xbfbafeca,
+]);
 
 export function resolveMacSigningIdentity(options, env = process.env) {
   const configured = env.CSC_NAME?.trim();
@@ -12,15 +17,52 @@ export function resolveMacSigningIdentity(options, env = process.env) {
     : options.identity;
 }
 
-export function resolveMacSigningIgnore(ignore) {
+export function isMachOHeader(header) {
+  return header.length >= 4 && MACH_O_MAGICS.has(header.readUInt32BE(0));
+}
+
+export function isMacCodeArtifact(filePath) {
+  const stat = fs.statSync(filePath);
+  if (stat.isDirectory()) return MAC_CODE_BUNDLE.test(filePath);
+  if (!stat.isFile()) return false;
+
+  const header = Buffer.alloc(4);
+  const descriptor = fs.openSync(filePath, 'r');
+  let bytesRead;
+  try {
+    bytesRead = fs.readSync(descriptor, header, 0, header.length, 0);
+  } finally {
+    fs.closeSync(descriptor);
+  }
+  return bytesRead === header.length && isMachOHeader(header);
+}
+
+export function resolveMacSigningIgnore(
+  ignore,
+  inspectCode = isMacCodeArtifact,
+) {
   const configured =
     ignore === undefined ? [] : Array.isArray(ignore) ? ignore : [ignore];
   // osx-sign 1.3.3 drops array ignores during option normalization.
-  return (filePath) =>
-    PYTHON_BYTECODE.test(filePath) ||
-    configured.some((rule) =>
-      typeof rule === 'function' ? rule(filePath) : filePath.match(rule),
-    );
+  return (filePath) => {
+    if (
+      configured.some((rule) =>
+        typeof rule === 'function' ? rule(filePath) : filePath.match(rule),
+      )
+    ) {
+      return true;
+    }
+    try {
+      // osx-sign treats every binary-looking resource as code. Restrict its
+      // traversal to Mach-O files and nested code bundles; the app signature
+      // still seals ordinary resources such as .pak, .pyc, and JSON files.
+      return !inspectCode(filePath);
+    } catch {
+      // Do not silently skip paths that cannot be inspected. Let codesign fail
+      // closed with the concrete path and filesystem error instead.
+      return false;
+    }
+  };
 }
 
 export async function sign(options) {

--- a/framework/gui/scripts/sign-macos.test.mjs
+++ b/framework/gui/scripts/sign-macos.test.mjs
@@ -6,6 +6,7 @@ import path from 'node:path';
 import test from 'node:test';
 
 import {
+  isMachOHeader,
   resolveMacSigningIdentity,
   resolveMacSigningIgnore,
 } from './sign-macos.mjs';
@@ -32,32 +33,70 @@ test('falls back to the identity resolved by electron-builder', () => {
   );
 });
 
-test('skips Python bytecode without skipping native runtime code', () => {
-  const shouldIgnore = resolveMacSigningIgnore();
+test('recognizes thin and universal Mach-O headers', () => {
+  for (const magic of [
+    0xfeedface, 0xcefaedfe, 0xfeedfacf, 0xcffaedfe, 0xcafebabe, 0xbebafeca,
+    0xcafebabf, 0xbfbafeca,
+  ]) {
+    const header = Buffer.alloc(4);
+    header.writeUInt32BE(magic);
+    assert.equal(isMachOHeader(header), true);
+  }
+  assert.equal(isMachOHeader(Buffer.from('data')), false);
+  assert.equal(isMachOHeader(Buffer.alloc(3)), false);
+});
+
+test('skips ordinary resources without skipping native runtime code', () => {
+  const code = new Set([
+    '/app/runtime/pkg/native.so',
+    '/app/runtime/pkg/native.dylib',
+    '/app/runtime/pkg/native.node',
+    '/app/runtime/kungfu',
+    '/app/Frameworks/Electron Framework.framework',
+  ]);
+  const shouldIgnore = resolveMacSigningIgnore(undefined, (filePath) =>
+    code.has(filePath),
+  );
 
   assert.equal(shouldIgnore('/app/runtime/pkg/module.pyc'), true);
   assert.equal(shouldIgnore('C:\\app\\runtime\\pkg\\module.pyo'), true);
   assert.equal(shouldIgnore('/app/runtime/pkg/__pycache__/module.data'), true);
+  assert.equal(shouldIgnore('/app/Resources/en.lproj/locale.pak'), true);
+  assert.equal(shouldIgnore('/app/Resources/app/config.json'), true);
   assert.equal(shouldIgnore('/app/runtime/pkg/native.so'), false);
   assert.equal(shouldIgnore('/app/runtime/pkg/native.dylib'), false);
+  assert.equal(shouldIgnore('/app/runtime/pkg/native.node'), false);
   assert.equal(shouldIgnore('/app/runtime/kungfu'), false);
+  assert.equal(
+    shouldIgnore('/app/Frameworks/Electron Framework.framework'),
+    false,
+  );
+});
+
+test('fails closed when a candidate cannot be inspected', () => {
+  const shouldIgnore = resolveMacSigningIgnore(undefined, () => {
+    throw new Error('unreadable');
+  });
+  assert.equal(shouldIgnore('/app/unreadable'), false);
 });
 
 test('preserves existing string, array, and function ignore rules', () => {
   const existingFunction = (filePath) => filePath.endsWith('.map');
+  const code = () => true;
 
   assert.equal(
-    resolveMacSigningIgnore('existing-pattern')('/app/existing-pattern'),
+    resolveMacSigningIgnore('existing-pattern', code)('/app/existing-pattern'),
     true,
   );
   assert.equal(
-    resolveMacSigningIgnore(['first-pattern', 'second-pattern'])(
-      '/app/second-pattern',
-    ),
+    resolveMacSigningIgnore(
+      ['first-pattern', 'second-pattern'],
+      code,
+    )('/app/second-pattern'),
     true,
   );
   assert.equal(
-    resolveMacSigningIgnore(existingFunction)('/app/source.map'),
+    resolveMacSigningIgnore(existingFunction, code)('/app/source.map'),
     true,
   );
 });


### PR DESCRIPTION
## Summary
- restrict the custom macOS signing traversal to Mach-O files and nested code bundles
- keep existing ignore rules while preventing `@electron/osx-sign` 1.3.3 from treating binary-looking resources such as Electron locale `.pak` and Python bytecode as code
- fail closed when a signing candidate cannot be inspected

## Verification
- `./shifu check:source`
- desktop signing tests: 8 passed
- real Developer ID re-sign of the complete arm64 app bundle
- `codesign --verify --deep --strict --verbose=2`: passed
- observed native `.node`, `.dylib`, `.so`, executables, and `.framework` as signable; `.pyc` and `locale.pak` as sealed resources

Notarization is not claimed by this PR; Gatekeeper correctly reports the locally signed test bundle as unnotarized.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Corrects macOS code-artifact discovery without changing the versioned upgrade or release architecture contract"
}
-->

## Governance risk check
- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

## Checklist
- [x] Commit is signed off (DCO)
- [x] Existing architecture claims remain unchanged
