### PR TITLE
refactor(core): enforce internal target boundaries

### DIFF
--- a/docs/adr/ADR-0049-layer-complete-products-and-domain-neutral-core.md
+++ b/docs/adr/ADR-0049-layer-complete-products-and-domain-neutral-core.md
@@ -7,9 +7,9 @@ implementation_status: implemented
 review_state: legacy-unreviewed
 sensitivity: public
 implementation_commits: [360c1dfcaf12aa410158f22ff175e5c608b0a77a]
-implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/797, https://github.com/kungfu-systems/kungfu/pull/911]
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/797, https://github.com/kungfu-systems/kungfu/pull/911, https://github.com/kungfu-systems/kungfu/pull/921]
 closure_pr: https://github.com/kungfu-systems/kungfu/pull/797
-qualification_refs: [docs/qualification/layer-product-release-qualification.md, framework/core/architecture/layers.json, framework/core/architecture/LAYERS.md, framework/core/architecture/check-layers.mjs, shifu.gates.json, tests/qualification/layers/run.mjs, tests/qualification/layers/release/run.mjs, tests/qualification/layers/surfaces/run.mjs, scripts/run-release-qualification.mjs, scripts/source-acceptance.mjs]
+qualification_refs: [docs/qualification/layer-product-release-qualification.md, framework/core/architecture/layers.json, framework/core/architecture/LAYERS.md, framework/core/architecture/TARGETS.cmake, framework/core/architecture/check-layers.mjs, shifu.gates.json, tests/qualification/layers/run.mjs, tests/qualification/layers/release/run.mjs, tests/qualification/layers/surfaces/run.mjs, scripts/run-release-qualification.mjs, scripts/source-acceptance.mjs]
 ---
 
 # ADR-0049: every product layer is independently complete and the core remains domain-neutral

--- a/framework/core/architecture/LAYERS.md
+++ b/framework/core/architecture/LAYERS.md
@@ -34,19 +34,32 @@ and services; the journal kernel may consume only schema/value contracts.
 
 ## Components
 
-Current targets describe the build as it exists today. Repeated aggregate
-targets expose the boundaries that the next remediation stage must split;
-they are not a claim that the component already has a dedicated target.
+Current targets describe the checked build graph. Internal component targets
+remain private implementation details behind the public `kungfu` facade.
 
 | Component | Layer | Owner | Files | Current targets | Entry points |
 | --- | --- | --- | ---: | --- | --- |
 | `yijinjing-schema` | `schema-values` | `core/schema` | 5 | `yijinjing` | `src/libyijinjing/include/kungfu/yijinjing/schema/core.h` |
 | `yijinjing-kernel` | `journal-kernel` | `core/yijinjing` | 42 | `yijinjing` | `src/libyijinjing/include/kungfu/yijinjing/journal/journal.h`<br>`src/libyijinjing/include/kungfu/yijinjing/storage.h` |
-| `libkungfu-contracts` | `ports-contracts` | `core/runtime-contracts` | 55 | `yijinjing`<br>`kungfu` | `src/libkungfu/include/kungfu/runtime/common.h`<br>`src/libkungfu/include/kungfu/runtime/storage/service.h` |
-| `libkungfu-services` | `application-services` | `core/runtime-services` | 30 | `kungfu_state_cache`<br>`kungfu_optim`<br>`kungfu` | `src/libkungfu/src/runtime/storage/service.cpp`<br>`src/libkungfu/src/runtime/state_service.cpp`<br>`src/libkungfu/src/runtime/query/fact_query.cpp` |
-| `libkungfu-adapters` | `adapters` | `core/runtime-adapters` | 13 | `kungfu_optim`<br>`kungfu`<br>`kungfu_native_storage_shared` | `src/libkungfu/src/view/schema.cpp`<br>`src/libkungfu/src/runtime/native_storage.cpp`<br>`src/libkungfu/src/runtime/util/rocks.cpp` |
-| `core-composition-bindings` | `composition-bindings` | `core/bindings` | 42 | `kungfu`<br>`kungfu_embedding`<br>`kungfu_wasm_host`<br>`kungfu_node`<br>`kungfu_electron`<br>`drone`<br>`kungfu_kfc`<br>`kungfu_node_host`<br>`pykungfu` | `src/bindings/node/binding/kungfu_node.cpp`<br>`src/bindings/python/binding/pykungfu.cpp`<br>`src/libkungfu/src/runtime/embedding.cpp` |
+| `libkungfu-contracts` | `ports-contracts` | `core/runtime-contracts` | 55 | `yijinjing`<br>`kungfu_contracts`<br>`kungfu` | `src/libkungfu/include/kungfu/runtime/common.h`<br>`src/libkungfu/include/kungfu/runtime/storage/service.h` |
+| `libkungfu-services` | `application-services` | `core/runtime-services` | 30 | `kungfu_services`<br>`kungfu_services_state_cache`<br>`kungfu` | `src/libkungfu/src/runtime/storage/service.cpp`<br>`src/libkungfu/src/runtime/state_service.cpp`<br>`src/libkungfu/src/runtime/query/fact_query.cpp` |
+| `libkungfu-adapters` | `adapters` | `core/runtime-adapters` | 13 | `kungfu_adapters`<br>`kungfu`<br>`kungfu_native_storage_shared` | `src/libkungfu/src/view/schema.cpp`<br>`src/libkungfu/src/runtime/native_storage.cpp`<br>`src/libkungfu/src/runtime/util/rocks.cpp` |
+| `core-composition-bindings` | `composition-bindings` | `core/bindings` | 42 | `kungfu_composition`<br>`kungfu`<br>`kungfu_embedding`<br>`kungfu_wasm_host`<br>`kungfu_node`<br>`kungfu_electron`<br>`drone`<br>`kungfu_kfc`<br>`kungfu_node_host`<br>`pykungfu` | `src/bindings/node/binding/kungfu_node.cpp`<br>`src/bindings/python/binding/pykungfu.cpp`<br>`src/libkungfu/src/runtime/embedding.cpp` |
 | `core-native-qualification` | `qualification` | `core/qualification` | 16 | `yijinjing_mmap_tests`<br>`yijinjing_content_hash_tests`<br>`yijinjing_mmap_qualification`<br>`kungfu_durability_contract_tests`<br>`kungfu_runtime_error_tests`<br>`kungfu_embedding_generic_codec_tests`<br>`kungfu_peer_continuity_tests`<br>`kungfu_state_service_contract_tests`<br>`kungfu_durable_ingest_tests`<br>`kungfu_durability_powercut_fixture`<br>`kungfu_durability_slo_fixture`<br>`kungfu_offhost_backup_fixture`<br>`kungfu_projection_bootstrap_tests`<br>`kungfu_crash_recovery_tests`<br>`kungfu_profile_lifecycle_tests` | `src/libkungfu/tests/durability_contract_tests.cpp`<br>`src/libyijinjing/tests/mmap_tests.cpp` |
+
+## Internal target graph
+
+The public `kungfu` target remains the compatibility facade. These internal
+targets express compile ownership and are generated into `TARGETS.cmake`
+from the same authority as this map.
+
+| Target | Kind | Component | Depends on | Sources |
+| --- | --- | --- | --- | ---: |
+| `kungfu_contracts` | `INTERFACE` | `libkungfu-contracts` | — | 0 |
+| `kungfu_services` | `OBJECT` | `libkungfu-services` | `kungfu_contracts` | 26 |
+| `kungfu_services_state_cache` | `OBJECT` | `libkungfu-services` | `kungfu_contracts` | 3 |
+| `kungfu_adapters` | `OBJECT` | `libkungfu-adapters` | `kungfu_services`<br>`kungfu_services_state_cache` | 12 |
+| `kungfu_composition` | `OBJECT` | `core-composition-bindings` | `kungfu_adapters` | 2 |
 
 ## Navigation
 
@@ -73,5 +86,6 @@ they are not a claim that the component already has a dedicated target.
 The source gate fails when a tracked C/C++ file has zero or multiple owners,
 when a current target loses its CMake evidence, when a resolved internal
 include is undeclared, when a declared dependency or resolved include reverses
-the layer contract, when a forbidden include enters a protected layer, or
-when this map drifts.
+the layer contract, when an internal source has zero or multiple build targets,
+when a target edge reverses the layer contract, when a forbidden include enters
+a protected layer, or when the map or generated CMake projection drifts.

--- a/framework/core/architecture/LAYERS.md
+++ b/framework/core/architecture/LAYERS.md
@@ -56,7 +56,7 @@ from the same authority as this map.
 | Target | Kind | Component | Depends on | Sources |
 | --- | --- | --- | --- | ---: |
 | `kungfu_contracts` | `INTERFACE` | `libkungfu-contracts` | — | 0 |
-| `kungfu_services` | `OBJECT` | `libkungfu-services` | `kungfu_contracts` | 26 |
+| `kungfu_services` | `OBJECT` | `libkungfu-services` | `kungfu_contracts` | 27 |
 | `kungfu_services_state_cache` | `OBJECT` | `libkungfu-services` | `kungfu_contracts` | 3 |
 | `kungfu_adapters` | `OBJECT` | `libkungfu-adapters` | `kungfu_services`<br>`kungfu_services_state_cache` | 12 |
 | `kungfu_composition` | `OBJECT` | `core-composition-bindings` | `kungfu_adapters` | 2 |

--- a/framework/core/architecture/TARGETS.cmake
+++ b/framework/core/architecture/TARGETS.cmake
@@ -15,6 +15,7 @@ set(KUNGFU_SERVICES_SOURCE_FILES
   "${PROJECT_SOURCE_DIR}/src/runtime/journal/replay_writer.cpp"
   "${PROJECT_SOURCE_DIR}/src/runtime/journal/tracer.cpp"
   "${PROJECT_SOURCE_DIR}/src/runtime/kfx/native_contract.cpp"
+  "${PROJECT_SOURCE_DIR}/src/runtime/kfx/native_registry.cpp"
   "${PROJECT_SOURCE_DIR}/src/runtime/live/continuity.cpp"
   "${PROJECT_SOURCE_DIR}/src/runtime/live/coordinator.cpp"
   "${PROJECT_SOURCE_DIR}/src/runtime/live/peer.cpp"

--- a/framework/core/architecture/TARGETS.cmake
+++ b/framework/core/architecture/TARGETS.cmake
@@ -1,0 +1,77 @@
+# Generated from architecture/layers.json by check-layers.mjs.
+# Do not edit this projection directly.
+
+add_library(kungfu_contracts INTERFACE)
+target_include_directories(kungfu_contracts INTERFACE ${PROJECT_SOURCE_DIR}/include ${KUNGFU_GENERATED_INCLUDE_DIR})
+target_include_directories(kungfu_contracts SYSTEM INTERFACE ${LIBKUNGFU_SQLITE_ORM_INCLUDE})
+target_link_libraries(kungfu_contracts INTERFACE yijinjing kungfu_compile_contract ${CONAN_LIBS})
+
+set(KUNGFU_SERVICES_SOURCE_FILES
+  "${PROJECT_SOURCE_DIR}/src/runtime/action_recorder.cpp"
+  "${PROJECT_SOURCE_DIR}/src/runtime/crash_recovery.cpp"
+  "${PROJECT_SOURCE_DIR}/src/runtime/durability.cpp"
+  "${PROJECT_SOURCE_DIR}/src/runtime/durable_ingest.cpp"
+  "${PROJECT_SOURCE_DIR}/src/runtime/facts/fact_admission.cpp"
+  "${PROJECT_SOURCE_DIR}/src/runtime/journal/replay_writer.cpp"
+  "${PROJECT_SOURCE_DIR}/src/runtime/journal/tracer.cpp"
+  "${PROJECT_SOURCE_DIR}/src/runtime/kfx/native_contract.cpp"
+  "${PROJECT_SOURCE_DIR}/src/runtime/live/continuity.cpp"
+  "${PROJECT_SOURCE_DIR}/src/runtime/live/coordinator.cpp"
+  "${PROJECT_SOURCE_DIR}/src/runtime/live/peer.cpp"
+  "${PROJECT_SOURCE_DIR}/src/runtime/live/reactor.cpp"
+  "${PROJECT_SOURCE_DIR}/src/runtime/live/resource_manager.cpp"
+  "${PROJECT_SOURCE_DIR}/src/runtime/profile/profile_lifecycle.cpp"
+  "${PROJECT_SOURCE_DIR}/src/runtime/query/fact_query.cpp"
+  "${PROJECT_SOURCE_DIR}/src/runtime/query/saved_query_catalog.cpp"
+  "${PROJECT_SOURCE_DIR}/src/runtime/schema/schema_compiler.cpp"
+  "${PROJECT_SOURCE_DIR}/src/runtime/state_service.cpp"
+  "${PROJECT_SOURCE_DIR}/src/runtime/state_shadow.cpp"
+  "${PROJECT_SOURCE_DIR}/src/runtime/storage/episode_manifest_projection.cpp"
+  "${PROJECT_SOURCE_DIR}/src/runtime/storage/manifest_catalog_projection.cpp"
+  "${PROJECT_SOURCE_DIR}/src/runtime/storage/service.cpp"
+  "${PROJECT_SOURCE_DIR}/src/runtime/storage/source_registry_projection.cpp"
+  "${PROJECT_SOURCE_DIR}/src/runtime/trust/assessment_runtime.cpp"
+  "${PROJECT_SOURCE_DIR}/src/runtime/typed_frame_dump.cpp"
+  "${PROJECT_SOURCE_DIR}/src/runtime/typed_state_projection.cpp"
+)
+add_library_object(kungfu_services "${KUNGFU_SERVICES_SOURCE_FILES}" "${COMPILER_OPTIMIZE_ON_OPTIONS}" "${KUNGFU_BUILD_DIR}")
+target_link_libraries(kungfu_services PUBLIC kungfu_contracts)
+
+set(KUNGFU_SERVICES_STATE_CACHE_SOURCE_FILES
+  "${PROJECT_SOURCE_DIR}/src/runtime/state_cache/manager.cpp"
+  "${PROJECT_SOURCE_DIR}/src/runtime/state_cache/profile.cpp"
+  "${PROJECT_SOURCE_DIR}/src/runtime/state_cache/store.cpp"
+)
+add_library_object(kungfu_services_state_cache "${KUNGFU_SERVICES_STATE_CACHE_SOURCE_FILES}" "${COMPILER_OPTIMIZE_OFF_OPTIONS}" "${KUNGFU_BUILD_DIR}")
+target_link_libraries(kungfu_services_state_cache PUBLIC kungfu_contracts)
+
+set(KUNGFU_ADAPTERS_SOURCE_FILES
+  "${PROJECT_SOURCE_DIR}/src/runtime/io/io.cpp"
+  "${PROJECT_SOURCE_DIR}/src/runtime/io/sqlite.cpp"
+  "${PROJECT_SOURCE_DIR}/src/runtime/native_storage.cpp"
+  "${PROJECT_SOURCE_DIR}/src/runtime/sandbox/app_container.cpp"
+  "${PROJECT_SOURCE_DIR}/src/runtime/util/StackWalker.cpp"
+  "${PROJECT_SOURCE_DIR}/src/runtime/util/nanomsg.cpp"
+  "${PROJECT_SOURCE_DIR}/src/runtime/util/rocks.cpp"
+  "${PROJECT_SOURCE_DIR}/src/runtime/util/signal.cpp"
+  "${PROJECT_SOURCE_DIR}/src/runtime/util/stacktrace.cpp"
+  "${PROJECT_SOURCE_DIR}/src/runtime/util/terminal.cpp"
+  "${PROJECT_SOURCE_DIR}/src/view/action_envelope.cpp"
+  "${PROJECT_SOURCE_DIR}/src/view/schema.cpp"
+)
+add_library_object(kungfu_adapters "${KUNGFU_ADAPTERS_SOURCE_FILES}" "${COMPILER_OPTIMIZE_ON_OPTIONS}" "${KUNGFU_BUILD_DIR}")
+target_link_libraries(kungfu_adapters PUBLIC kungfu_services kungfu_services_state_cache)
+
+set(KUNGFU_COMPOSITION_SOURCE_FILES
+  "${PROJECT_SOURCE_DIR}/src/runtime/embedding.cpp"
+  "${PROJECT_SOURCE_DIR}/src/runtime/projection_bootstrap.cpp"
+)
+add_library_object(kungfu_composition "${KUNGFU_COMPOSITION_SOURCE_FILES}" "${COMPILER_OPTIMIZE_ON_OPTIONS}" "${KUNGFU_BUILD_DIR}")
+target_link_libraries(kungfu_composition PUBLIC kungfu_adapters)
+
+set(KUNGFU_INTERNAL_OBJECTS
+  $<TARGET_OBJECTS:kungfu_services>
+  $<TARGET_OBJECTS:kungfu_services_state_cache>
+  $<TARGET_OBJECTS:kungfu_adapters>
+  $<TARGET_OBJECTS:kungfu_composition>
+)

--- a/framework/core/architecture/check-layers.mjs
+++ b/framework/core/architecture/check-layers.mjs
@@ -10,6 +10,7 @@ const architectureRoot = path.dirname(fileURLToPath(import.meta.url));
 const coreRoot = path.resolve(architectureRoot, '..');
 const contractPath = path.join(architectureRoot, 'layers.json');
 const mapPath = path.join(architectureRoot, 'LAYERS.md');
+const targetsCmakePath = path.join(architectureRoot, 'TARGETS.cmake');
 
 function posix(value) {
   return value.split(path.sep).join('/');
@@ -35,6 +36,24 @@ function owns(component, file) {
   if (!included) return false;
   if ((component.exclude_files || []).includes(file)) return false;
   return !(component.exclude_prefixes || []).some((prefix) =>
+    file.startsWith(prefix),
+  );
+}
+
+function targetOwns(target, file, componentId) {
+  if (target.component !== componentId) return false;
+  const includeFiles = target.include_files || [];
+  const includePrefixes = target.include_prefixes || [];
+  const hasSelector = includeFiles.length > 0 || includePrefixes.length > 0;
+  if (
+    hasSelector &&
+    !includeFiles.includes(file) &&
+    !includePrefixes.some((prefix) => file.startsWith(prefix))
+  ) {
+    return false;
+  }
+  if ((target.exclude_files || []).includes(file)) return false;
+  return !(target.exclude_prefixes || []).some((prefix) =>
     file.startsWith(prefix),
   );
 }
@@ -84,6 +103,20 @@ function validate(root, contract) {
       usedTargets.add(target);
   }
 
+  const internalTargetById = new Map();
+  for (const target of contract.internal_targets || []) {
+    if (internalTargetById.has(target.id)) {
+      problems.push(`duplicate internal target: ${target.id}`);
+    }
+    internalTargetById.set(target.id, target);
+    if (!componentById.has(target.component)) {
+      problems.push(`${target.id}: unknown component ${target.component}`);
+    }
+    if (!['INTERFACE', 'OBJECT'].includes(target.kind)) {
+      problems.push(`${target.id}: unsupported target kind ${target.kind}`);
+    }
+  }
+
   const evidencedTargets = new Set();
   for (const entry of contract.target_evidence || []) {
     const evidencePath = path.join(root, entry.file);
@@ -110,6 +143,25 @@ function validate(root, contract) {
   for (const target of evidencedTargets) {
     if (!usedTargets.has(target))
       problems.push(`stale unused target evidence: ${target}`);
+  }
+
+  if (contract.target_projection) {
+    const consumerPath = path.join(root, contract.target_projection.consumer);
+    if (!fs.existsSync(consumerPath)) {
+      problems.push(
+        `missing target projection consumer: ${contract.target_projection.consumer}`,
+      );
+    } else {
+      const consumer = fs.readFileSync(consumerPath, 'utf8');
+      for (const field of ['include_token', 'facade_token']) {
+        const token = contract.target_projection[field];
+        if (!token || !consumer.includes(token)) {
+          problems.push(
+            `${contract.target_projection.consumer}: missing ${field} ${token || '<missing>'}`,
+          );
+        }
+      }
+    }
   }
 
   const excluded = new Set(
@@ -158,6 +210,66 @@ function validate(root, contract) {
           `${component.id}: entry point is missing or owned elsewhere: ${entryPoint}`,
         );
       }
+    }
+  }
+
+  for (const target of contract.internal_targets || []) {
+    const sourceComponent = componentById.get(target.component);
+    if (!sourceComponent) continue;
+    const sourceLayer = layerById.get(sourceComponent.layer);
+    for (const dependencyId of target.dependencies || []) {
+      const dependency = internalTargetById.get(dependencyId);
+      if (!dependency) {
+        problems.push(
+          `${target.id}: unknown target dependency ${dependencyId}`,
+        );
+        continue;
+      }
+      const dependencyComponent = componentById.get(dependency.component);
+      if (
+        dependencyComponent &&
+        !sourceLayer.may_depend_on.includes(dependencyComponent.layer)
+      ) {
+        problems.push(
+          `${target.id}: layer ${sourceComponent.layer} may not depend on target ${dependencyId} (${dependencyComponent.layer})`,
+        );
+      }
+    }
+  }
+
+  const internalTargetRoots = contract.internal_target_roots || [];
+  const internalTargetSourceCounts = new Map(
+    (contract.internal_targets || []).map((target) => [target.id, 0]),
+  );
+  for (const [file, componentId] of ownership) {
+    if (!internalTargetRoots.some((prefix) => file.startsWith(prefix)))
+      continue;
+    if (!['.c', '.cc', '.cpp', '.cxx'].includes(path.extname(file))) continue;
+    const targets = (contract.internal_targets || []).filter((target) =>
+      targetOwns(target, file, componentId),
+    );
+    if (targets.length === 0) {
+      problems.push(`source lacks internal target: ${file}`);
+    }
+    if (targets.length > 1) {
+      problems.push(
+        `source has multiple internal targets: ${file} -> ${targets.map((target) => target.id).join(', ')}`,
+      );
+    }
+    if (targets.length === 1) {
+      internalTargetSourceCounts.set(
+        targets[0].id,
+        (internalTargetSourceCounts.get(targets[0].id) || 0) + 1,
+      );
+    }
+  }
+  for (const target of contract.internal_targets || []) {
+    const count = internalTargetSourceCounts.get(target.id) || 0;
+    if (target.kind === 'INTERFACE' && count !== 0) {
+      problems.push(`${target.id}: INTERFACE target owns ${count} sources`);
+    }
+    if (target.kind === 'OBJECT' && count === 0) {
+      problems.push(`${target.id}: OBJECT target owns no sources`);
     }
   }
 
@@ -280,9 +392,8 @@ function renderMap(contract, ownership) {
     '',
     '## Components',
     '',
-    'Current targets describe the build as it exists today. Repeated aggregate',
-    'targets expose the boundaries that the next remediation stage must split;',
-    'they are not a claim that the component already has a dedicated target.',
+    'Current targets describe the checked build graph. Internal component targets',
+    'remain private implementation details behind the public `kungfu` facade.',
     '',
     '| Component | Layer | Owner | Files | Current targets | Entry points |',
     '| --- | --- | --- | ---: | --- | --- |',
@@ -294,6 +405,27 @@ function renderMap(contract, ownership) {
   for (const component of contract.components) {
     lines.push(
       `| \`${component.id}\` | \`${component.layer}\` | \`${component.owner}\` | ${counts.get(component.id) || 0} | ${component.current_targets.map((item) => `\`${item}\``).join('<br>')} | ${component.entry_points.map((item) => `\`${item}\``).join('<br>')} |`,
+    );
+  }
+  lines.push(
+    '',
+    '## Internal target graph',
+    '',
+    'The public `kungfu` target remains the compatibility facade. These internal',
+    'targets express compile ownership and are generated into `TARGETS.cmake`',
+    'from the same authority as this map.',
+    '',
+    '| Target | Kind | Component | Depends on | Sources |',
+    '| --- | --- | --- | --- | ---: |',
+  );
+  for (const target of contract.internal_targets || []) {
+    const sourceCount = [...ownership].filter(
+      ([file, componentId]) =>
+        ['.c', '.cc', '.cpp', '.cxx'].includes(path.extname(file)) &&
+        targetOwns(target, file, componentId),
+    ).length;
+    lines.push(
+      `| \`${target.id}\` | \`${target.kind}\` | \`${target.component}\` | ${(target.dependencies || []).map((item) => `\`${item}\``).join('<br>') || '—'} | ${sourceCount} |`,
     );
   }
   lines.push(
@@ -319,10 +451,66 @@ function renderMap(contract, ownership) {
     'The source gate fails when a tracked C/C++ file has zero or multiple owners,',
     'when a current target loses its CMake evidence, when a resolved internal',
     'include is undeclared, when a declared dependency or resolved include reverses',
-    'the layer contract, when a forbidden include enters a protected layer, or',
-    'when this map drifts.',
+    'the layer contract, when an internal source has zero or multiple build targets,',
+    'when a target edge reverses the layer contract, when a forbidden include enters',
+    'a protected layer, or when the map or generated CMake projection drifts.',
     '',
   );
+  return lines.join('\n');
+}
+
+function renderTargetsCmake(contract, ownership) {
+  const lines = [
+    '# Generated from architecture/layers.json by check-layers.mjs.',
+    '# Do not edit this projection directly.',
+    '',
+  ];
+  const objectTargets = [];
+  for (const target of contract.internal_targets || []) {
+    if (target.kind === 'INTERFACE') {
+      lines.push(
+        `add_library(${target.id} INTERFACE)`,
+        `target_include_directories(${target.id} INTERFACE \${PROJECT_SOURCE_DIR}/include \${KUNGFU_GENERATED_INCLUDE_DIR})`,
+        `target_include_directories(${target.id} SYSTEM INTERFACE \${LIBKUNGFU_SQLITE_ORM_INCLUDE})`,
+        `target_link_libraries(${target.id} INTERFACE yijinjing kungfu_compile_contract \${CONAN_LIBS})`,
+        '',
+      );
+      continue;
+    }
+    objectTargets.push(target.id);
+    const variable = `${target.id.toUpperCase().replace(/[^A-Z0-9]+/g, '_')}_SOURCE_FILES`;
+    const sources = [...ownership]
+      .filter(
+        ([file, componentId]) =>
+          ['.c', '.cc', '.cpp', '.cxx'].includes(path.extname(file)) &&
+          targetOwns(target, file, componentId),
+      )
+      .map(([file]) => file.replace(/^src\/libkungfu\//, ''))
+      .sort();
+    const options =
+      target.compile_options === 'optimize-off'
+        ? 'COMPILER_OPTIMIZE_OFF_OPTIONS'
+        : 'COMPILER_OPTIMIZE_ON_OPTIONS';
+    lines.push(`set(${variable}`);
+    for (const source of sources) {
+      lines.push(`  "\${PROJECT_SOURCE_DIR}/${source}"`);
+    }
+    lines.push(
+      ')',
+      `add_library_object(${target.id} "\${${variable}}" "\${${options}}" "\${KUNGFU_BUILD_DIR}")`,
+    );
+    if ((target.dependencies || []).length) {
+      lines.push(
+        `target_link_libraries(${target.id} PUBLIC ${(target.dependencies || []).join(' ')})`,
+      );
+    }
+    lines.push('');
+  }
+  lines.push('set(KUNGFU_INTERNAL_OBJECTS');
+  for (const target of objectTargets) {
+    lines.push(`  $<TARGET_OBJECTS:${target}>`);
+  }
+  lines.push(')', '');
   return lines.join('\n');
 }
 
@@ -339,6 +527,7 @@ function selfTest() {
     extensions: ['.h', '.cpp'],
     excluded_files: [],
     target_evidence: [{ file: 'CMakeLists.txt', targets: ['low', 'high'] }],
+    internal_target_roots: ['src/'],
     layers: [
       {
         id: 'low',
@@ -379,6 +568,20 @@ function selfTest() {
         dependencies: ['low-core'],
         current_targets: ['high'],
         entry_points: ['src/high/app.cpp'],
+      },
+    ],
+    internal_targets: [
+      {
+        id: 'low',
+        component: 'low-core',
+        kind: 'INTERFACE',
+        dependencies: [],
+      },
+      {
+        id: 'high',
+        component: 'high-app',
+        kind: 'OBJECT',
+        dependencies: ['low'],
       },
     ],
     navigation: [],
@@ -456,6 +659,40 @@ function selfTest() {
         item.includes('may not depend'),
       ),
     );
+
+    const reversedTarget = structuredClone(base);
+    reversedTarget.internal_targets[0].dependencies = ['high'];
+    expect(
+      'reverse target dependency fails',
+      validate(tmp, reversedTarget).problems.some((item) =>
+        item.includes('may not depend on target'),
+      ),
+    );
+
+    const missingSourceTarget = structuredClone(base);
+    missingSourceTarget.internal_targets[1].include_files = [
+      'src/high/not-app.cpp',
+    ];
+    expect(
+      'source without internal target fails',
+      validate(tmp, missingSourceTarget).problems.some((item) =>
+        item.includes('source lacks internal target'),
+      ),
+    );
+
+    const duplicateSourceTarget = structuredClone(base);
+    duplicateSourceTarget.internal_targets.push({
+      id: 'high-copy',
+      component: 'high-app',
+      kind: 'OBJECT',
+      dependencies: ['low'],
+    });
+    expect(
+      'source with multiple internal targets fails',
+      validate(tmp, duplicateSourceTarget).problems.some((item) =>
+        item.includes('source has multiple internal targets'),
+      ),
+    );
   } finally {
     fs.rmSync(tmp, { recursive: true, force: true });
   }
@@ -476,8 +713,21 @@ if (result.problems.length) {
   process.exit(1);
 }
 const rendered = renderMap(contract, result.ownership);
+const renderedTargetsCmake = renderTargetsCmake(contract, result.ownership);
+if (process.argv.includes('--write-projections')) {
+  fs.writeFileSync(mapPath, rendered);
+  fs.writeFileSync(targetsCmakePath, renderedTargetsCmake);
+  console.log(
+    'Updated LAYERS.md and TARGETS.cmake from the architecture authority.',
+  );
+  process.exit(0);
+}
 if (process.argv.includes('--print-map')) {
   process.stdout.write(rendered);
+  process.exit(0);
+}
+if (process.argv.includes('--print-targets')) {
+  process.stdout.write(renderedTargetsCmake);
   process.exit(0);
 }
 if (!fs.existsSync(mapPath) || fs.readFileSync(mapPath, 'utf8') !== rendered) {
@@ -486,6 +736,15 @@ if (!fs.existsSync(mapPath) || fs.readFileSync(mapPath, 'utf8') !== rendered) {
   );
   process.exit(1);
 }
+if (
+  !fs.existsSync(targetsCmakePath) ||
+  fs.readFileSync(targetsCmakePath, 'utf8') !== renderedTargetsCmake
+) {
+  console.error(
+    'framework/core/architecture/TARGETS.cmake is stale; regenerate it from layers.json.',
+  );
+  process.exit(1);
+}
 console.log(
-  `OK: ${result.ownership.size} first-party C/C++ files have one component owner and the layer map is current.`,
+  `OK: ${result.ownership.size} first-party C/C++ files have one component owner; the layer map and internal target graph are current.`,
 );

--- a/framework/core/architecture/layers.json
+++ b/framework/core/architecture/layers.json
@@ -13,6 +13,7 @@
     "src/libwasm/"
   ],
   "extensions": [".c", ".cc", ".cpp", ".cxx", ".h", ".hh", ".hpp", ".hxx"],
+  "internal_target_roots": ["src/libkungfu/src/"],
   "excluded_files": [
     {
       "path": "src/libkungfu/src/view/ActionEnvelope_generated.h",
@@ -26,8 +27,12 @@
     },
     {
       "file": "src/libkungfu/CMakeLists.txt",
-      "targets": ["kungfu", "kungfu_state_cache", "kungfu_optim", "kungfu_native_storage_shared", "kungfu_durability_contract_tests", "kungfu_runtime_error_tests", "kungfu_embedding_generic_codec_tests", "kungfu_peer_continuity_tests", "kungfu_state_service_contract_tests", "kungfu_durable_ingest_tests", "kungfu_durability_powercut_fixture", "kungfu_durability_slo_fixture", "kungfu_offhost_backup_fixture", "kungfu_projection_bootstrap_tests", "kungfu_crash_recovery_tests", "kungfu_profile_lifecycle_tests"],
+      "targets": ["kungfu", "kungfu_native_storage_shared", "kungfu_durability_contract_tests", "kungfu_runtime_error_tests", "kungfu_embedding_generic_codec_tests", "kungfu_peer_continuity_tests", "kungfu_state_service_contract_tests", "kungfu_durable_ingest_tests", "kungfu_durability_powercut_fixture", "kungfu_durability_slo_fixture", "kungfu_offhost_backup_fixture", "kungfu_projection_bootstrap_tests", "kungfu_crash_recovery_tests", "kungfu_profile_lifecycle_tests"],
       "tokens": {"kungfu": "${LIBKUNGFU_NAME}"}
+    },
+    {
+      "file": "architecture/TARGETS.cmake",
+      "targets": ["kungfu_contracts", "kungfu_services", "kungfu_services_state_cache", "kungfu_adapters", "kungfu_composition"]
     },
     {
       "file": "src/libembedding/CMakeLists.txt",
@@ -44,6 +49,53 @@
     {
       "file": "src/bindings/python/CMakeLists.txt",
       "targets": ["pykungfu"]
+    }
+  ],
+  "target_projection": {
+    "consumer": "src/libkungfu/CMakeLists.txt",
+    "include_token": "architecture/TARGETS.cmake",
+    "facade_token": "${KUNGFU_INTERNAL_OBJECTS}"
+  },
+  "internal_targets": [
+    {
+      "id": "kungfu_contracts",
+      "component": "libkungfu-contracts",
+      "kind": "INTERFACE",
+      "dependencies": []
+    },
+    {
+      "id": "kungfu_services",
+      "component": "libkungfu-services",
+      "kind": "OBJECT",
+      "compile_options": "optimize-on",
+      "exclude_prefixes": ["src/libkungfu/src/runtime/state_cache/"],
+      "dependencies": ["kungfu_contracts"]
+    },
+    {
+      "id": "kungfu_services_state_cache",
+      "component": "libkungfu-services",
+      "kind": "OBJECT",
+      "compile_options": "optimize-off",
+      "include_prefixes": ["src/libkungfu/src/runtime/state_cache/"],
+      "dependencies": ["kungfu_contracts"]
+    },
+    {
+      "id": "kungfu_adapters",
+      "component": "libkungfu-adapters",
+      "kind": "OBJECT",
+      "compile_options": "optimize-on",
+      "dependencies": ["kungfu_services", "kungfu_services_state_cache"]
+    },
+    {
+      "id": "kungfu_composition",
+      "component": "core-composition-bindings",
+      "kind": "OBJECT",
+      "compile_options": "optimize-on",
+      "include_files": [
+        "src/libkungfu/src/runtime/embedding.cpp",
+        "src/libkungfu/src/runtime/projection_bootstrap.cpp"
+      ],
+      "dependencies": ["kungfu_adapters"]
     }
   ],
   "layers": [
@@ -135,7 +187,7 @@
       "exclude_prefixes": [],
       "exclude_files": [],
       "dependencies": ["yijinjing-kernel", "yijinjing-schema"],
-      "current_targets": ["yijinjing", "kungfu"],
+      "current_targets": ["yijinjing", "kungfu_contracts", "kungfu"],
       "entry_points": ["src/libkungfu/include/kungfu/runtime/common.h", "src/libkungfu/include/kungfu/runtime/storage/service.h"]
     },
     {
@@ -154,7 +206,7 @@
         "src/libkungfu/src/runtime/projection_bootstrap.cpp"
       ],
       "dependencies": ["libkungfu-contracts", "yijinjing-kernel", "yijinjing-schema"],
-      "current_targets": ["kungfu_state_cache", "kungfu_optim", "kungfu"],
+      "current_targets": ["kungfu_services", "kungfu_services_state_cache", "kungfu"],
       "entry_points": ["src/libkungfu/src/runtime/storage/service.cpp", "src/libkungfu/src/runtime/state_service.cpp", "src/libkungfu/src/runtime/query/fact_query.cpp"]
     },
     {
@@ -173,7 +225,7 @@
       "exclude_prefixes": [],
       "exclude_files": [],
       "dependencies": ["libkungfu-services", "libkungfu-contracts", "yijinjing-kernel", "yijinjing-schema"],
-      "current_targets": ["kungfu_optim", "kungfu", "kungfu_native_storage_shared"],
+      "current_targets": ["kungfu_adapters", "kungfu", "kungfu_native_storage_shared"],
       "entry_points": ["src/libkungfu/src/view/schema.cpp", "src/libkungfu/src/runtime/native_storage.cpp", "src/libkungfu/src/runtime/util/rocks.cpp"]
     },
     {
@@ -185,7 +237,7 @@
       "exclude_prefixes": [],
       "exclude_files": [],
       "dependencies": ["libkungfu-adapters", "libkungfu-services", "libkungfu-contracts", "yijinjing-kernel", "yijinjing-schema"],
-      "current_targets": ["kungfu", "kungfu_embedding", "kungfu_wasm_host", "kungfu_node", "kungfu_electron", "drone", "kungfu_kfc", "kungfu_node_host", "pykungfu"],
+      "current_targets": ["kungfu_composition", "kungfu", "kungfu_embedding", "kungfu_wasm_host", "kungfu_node", "kungfu_electron", "drone", "kungfu_kfc", "kungfu_node_host", "pykungfu"],
       "entry_points": ["src/bindings/node/binding/kungfu_node.cpp", "src/bindings/python/binding/pykungfu.cpp", "src/libkungfu/src/runtime/embedding.cpp"]
     },
     {

--- a/framework/core/src/libkungfu/CMakeLists.txt
+++ b/framework/core/src/libkungfu/CMakeLists.txt
@@ -70,34 +70,20 @@ configure_file(
   @ONLY
 )
 
-# this directory holds the libkungfu runtime layer above the standalone
-# yijinjing journal core, so the source GLOB needs no exclusion list beyond the
-# state-cache/optim split
-file(GLOB_RECURSE KUNGFU_OPTIM_SOURCE_FILES ${PROJECT_SOURCE_DIR}/src/*.cpp)
-file(GLOB_RECURSE KUNGFU_STATE_CACHE_SOURCE_FILES ${PROJECT_SOURCE_DIR}/src/runtime/state_cache/*.cpp)
-list(REMOVE_ITEM KUNGFU_OPTIM_SOURCE_FILES ${KUNGFU_STATE_CACHE_SOURCE_FILES})
-
-add_library_object(kungfu_state_cache "${KUNGFU_STATE_CACHE_SOURCE_FILES}" "${COMPILER_OPTIMIZE_OFF_OPTIONS}" "${KUNGFU_BUILD_DIR}")
-add_library_object(kungfu_optim "${KUNGFU_OPTIM_SOURCE_FILES}" "${COMPILER_OPTIMIZE_ON_OPTIONS}" "${KUNGFU_BUILD_DIR}")
-
-# the OBJECT libraries compile independently of the final target, so they
-# need the runtime headers, the vendored sqlite_orm, and the yijinjing core
-# usage requirements (headers, hana, public C++20 contract) at their own scope
+# The layer authority generates exact source ownership and the internal target
+# graph. Source additions must update layers.json and its checked projections;
+# an architecture-blind recursive GLOB must not silently absorb them.
 set(LIBKUNGFU_SQLITE_ORM_INCLUDE ${PROJECT_SOURCE_DIR}/../../.deps/sqlite_orm-1.7.1/include)
-foreach(_kf_obj kungfu_state_cache kungfu_optim)
-  target_include_directories(${_kf_obj} PRIVATE ${PROJECT_SOURCE_DIR}/include ${KUNGFU_GENERATED_INCLUDE_DIR})
-  target_include_directories(${_kf_obj} SYSTEM PRIVATE ${LIBKUNGFU_SQLITE_ORM_INCLUDE})
-  target_link_libraries(${_kf_obj} PRIVATE yijinjing kungfu_compile_contract ${CONAN_LIBS})
-endforeach()
+include("${CMAKE_CURRENT_SOURCE_DIR}/../../architecture/TARGETS.cmake")
 
 # Windows: 用 STATIC。libkungfu 含 rocksdb/boost::hana/sqlite_orm 大量模板实例化，作为 SHARED DLL 时
 # CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS 自动导出的符号数 >65535，撞 COFF 库成员上限(LNK1189)。改 STATIC 由各
 # binding 链接；journal 是 mmap 文件、跨实例本就共享，故 Windows 上多 binding 各自静态链接 libkungfu 仍读同一 journal。
 # Mac/Linux 维持 SHARED(运行时多语言绑定在同进程共享同一 dylib/so)。
 if (WIN32)
-  add_library(${LIBKUNGFU_NAME} STATIC $<TARGET_OBJECTS:kungfu_optim> $<TARGET_OBJECTS:kungfu_state_cache>)
+  add_library(${LIBKUNGFU_NAME} STATIC ${KUNGFU_INTERNAL_OBJECTS})
 else ()
-  add_library(${LIBKUNGFU_NAME} SHARED $<TARGET_OBJECTS:kungfu_optim> $<TARGET_OBJECTS:kungfu_state_cache>)
+  add_library(${LIBKUNGFU_NAME} SHARED ${KUNGFU_INTERNAL_OBJECTS})
 endif ()
 set_target_properties(${LIBKUNGFU_NAME} PROPERTIES LINKER_LANGUAGE CXX)
 set_target_properties(${LIBKUNGFU_NAME} PROPERTIES ARCHIVE_OUTPUT_DIRECTORY ${KUNGFU_BUILD_DIR})


### PR DESCRIPTION
## Summary

Turn the executable Core layer contract into concrete CMake target boundaries while preserving the public `kungfu` artifact and platform behavior.

## Related issue

None.

## Changes

- derive five internal target boundaries from `framework/core/architecture/layers.json`
- generate-check explicit CMake source ownership in `TARGETS.cmake` without recursive globbing
- aggregate internal OBJECT targets behind the existing public `kungfu` target
- enforce dependency direction, unique production-source ownership, projection freshness, and target-kind invariants
- document the internal target graph and add controlled negative fixtures

## Verification

- `./shifu check:source`
- `./shifu check`
- `./shifu exec node framework/core/architecture/check-layers.mjs`
- `./shifu exec node framework/core/architecture/check-layers.mjs --self-test` (11 fixtures)
- macOS AppleClang 21: clean `rebuild:core` + incremental `build:core`
- Linux GCC 14 on agent-120: clean `rebuild:core` + incremental `build:core`
- Windows MSVC 19.5 on DARKHERO: clean `rebuild:core` + incremental `build:core`

The Windows runner required a worktree-local CMake cache override to bypass an unrelated `sccache` temporary-file permission failure; the MSVC compile/link/package path then completed successfully.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "stage-ready",
  "adrs": ["ADR-0049"],
  "summary": "Enforce concrete internal CMake target boundaries and downward dependencies for the domain-neutral Core while preserving the public libkungfu artifact.",
  "verification": ["./shifu check", "11 architecture target fixtures", "clean and incremental Core builds on macOS, Linux, and Windows"]
}
-->

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] release evidence, provenance, package publishing, or deployment surfaces
- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed