### PR TITLE
fix(runtime): make product qualification fresh-runner safe

### DIFF
--- a/crates/shifu/src/registrar.rs
+++ b/crates/shifu/src/registrar.rs
@@ -51,6 +51,12 @@ use shifu_core::{bootstrap, host, json, style};
 /// verb; see docs/rust-adoption.md and the contract registry.
 const LAYOUT_DISCOVERY_CONTRACT: &str = "kungfu-buildchain-layout-discovery";
 
+/// Local, read-only hint used only to decide whether a fresh checkout needs
+/// the pinned Buildchain binary before a declared distribution task. It is
+/// never accepted as the authoritative registry path: after a hint match,
+/// Buildchain must still resolve the KFD-3 layout and that answer is reparsed.
+const REGISTRY_DISCOVERY_HINT: &str = ".buildchain/kfd/kfd-3/surfaces.json";
+
 /// Locate the repo's KFD-3 surface registry by asking buildchain, caching the
 /// answer per (repo, buildchain version). Returns the absolute registry path,
 /// or None when the repo is not buildchain-managed (no `.buildchain-version`
@@ -250,7 +256,17 @@ struct DeclaredArtifact {
 /// parsed gets a named warning: a declared intent we cannot read is worth a
 /// line, but never worth blocking the task.
 pub fn plan_for_task(root: &Path, task: &str) -> Option<DistributionPlan> {
-    let path = resolve_kfd3_registry(root)?;
+    if let Some(path) = resolve_kfd3_registry(root) {
+        return plan_at(root, &path, task);
+    }
+
+    // A fresh runner has neither the per-repo layout cache nor a cached
+    // Buildchain binary. Avoid fetching Buildchain for ordinary tasks: first
+    // check the tracked registry hint for a host distribution declaration for
+    // this exact task. A match only authorizes discovery; Buildchain's answer
+    // remains the single source of truth for the plan used after the build.
+    plan_at(root, &root.join(REGISTRY_DISCOVERY_HINT), task)?;
+    let path = resolve_kfd3_registry_with(root, Acquire::Fetch)?;
     plan_at(root, &path, task)
 }
 
@@ -803,6 +819,36 @@ mod tests {
         assert_eq!(plan.artifacts[0].path_glob, "out/*.bin");
         assert!(plan_at(&dir, &reg, "package").is_some());
         assert!(plan_at(&dir, &reg, "verify").is_none());
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn discovery_hint_prefilters_only_declared_distribution_tasks() {
+        let dir = shifu_core::host::unique_temp_dir("registrar-hint").unwrap();
+        let registry = dir.join(REGISTRY_DISCOVERY_HINT);
+        fs::create_dir_all(registry.parent().unwrap()).unwrap();
+        fs::write(
+            &registry,
+            format!(
+                r#"{{
+                  "product": {{"id": "kungfu"}},
+                  "surfaces": [{{
+                    "id": "kungfu.product.release-build",
+                    "distribution": {{
+                      "registrar": "shifu",
+                      "tasks": ["dist"],
+                      "artifacts": [
+                        {{"kind": "appimage", "platform": "{os}", "pathGlob": "out/*.bin"}}
+                      ]
+                    }}
+                  }}]
+                }}"#,
+                os = env::consts::OS
+            ),
+        )
+        .unwrap();
+        assert!(plan_at(&dir, &registry, "dist").is_some());
+        assert!(plan_at(&dir, &registry, "verify").is_none());
         let _ = fs::remove_dir_all(&dir);
     }
 

--- a/framework/core/tests/qualification/runtime-activation/run.mjs
+++ b/framework/core/tests/qualification/runtime-activation/run.mjs
@@ -91,7 +91,10 @@ export const SUITES = [
   {
     id: 'product-verification',
     product: true,
-    command: [LAUNCHER, 'verify', '--full', '--with-app'],
+    // product-distribution has just built the complete product. Verify those
+    // exact outputs instead of starting a second native rebuild inside the
+    // qualification run (which also obscures which build was qualified).
+    command: [LAUNCHER, 'verify', '--with-app'],
   },
   {
     id: 'product-catalog',

--- a/framework/core/tests/qualification/runtime-activation/run.mjs
+++ b/framework/core/tests/qualification/runtime-activation/run.mjs
@@ -91,10 +91,11 @@ export const SUITES = [
   {
     id: 'product-verification',
     product: true,
-    // product-distribution has just built the complete product. Verify those
-    // exact outputs instead of starting a second native rebuild inside the
-    // qualification run (which also obscures which build was qualified).
-    command: [LAUNCHER, 'verify', '--with-app'],
+    // product-distribution has just built the complete product, and the outer
+    // release qualification has already run the Episode campaign. Verify these
+    // exact outputs without starting a second native rebuild or duplicating an
+    // unrelated Episode campaign inside the artifact-verification suite.
+    command: [LAUNCHER, 'verify', '--with-app', '--skip-episode-qualification'],
   },
   {
     id: 'product-catalog',

--- a/framework/core/tests/qualification/runtime-activation/run.test.mjs
+++ b/framework/core/tests/qualification/runtime-activation/run.test.mjs
@@ -83,6 +83,15 @@ test('dry-run plans every Shifu-owned qualification step without claims', () => 
   assert.ok(Object.values(value.claims).every((claim) => claim === false));
 });
 
+test('product verification checks the distribution outputs without rebuilding them', () => {
+  const verification = qualificationPlan({
+    mode: 'execute',
+    withProduct: true,
+  }).find((suite) => suite.id === 'product-verification');
+  assert.deepEqual(verification.command.slice(1), ['verify', '--with-app']);
+  assert.equal(verification.command.includes('--full'), false);
+});
+
 test('clean passing source qualifies exact product artifacts with bounded claims', () => {
   const value = report();
   validateReport(value);

--- a/framework/core/tests/qualification/runtime-activation/run.test.mjs
+++ b/framework/core/tests/qualification/runtime-activation/run.test.mjs
@@ -88,7 +88,11 @@ test('product verification checks the distribution outputs without rebuilding th
     mode: 'execute',
     withProduct: true,
   }).find((suite) => suite.id === 'product-verification');
-  assert.deepEqual(verification.command.slice(1), ['verify', '--with-app']);
+  assert.deepEqual(verification.command.slice(1), [
+    'verify',
+    '--with-app',
+    '--skip-episode-qualification',
+  ]);
   assert.equal(verification.command.includes('--full'), false);
 });
 

--- a/framework/gui/src/main/index.ts
+++ b/framework/gui/src/main/index.ts
@@ -72,7 +72,10 @@ import {
   uninstallKungfuCliFromPath,
 } from './installCli';
 import { executeProfileCli } from './profile-cli';
-import { backupAndResetRuntime } from './runtime-recovery';
+import {
+  backupAndResetRuntime,
+  stopRuntimeForRecovery,
+} from './runtime-recovery';
 import { type Rect, SandboxManager } from './sandbox-manager';
 import { bindSessionWindows } from './session-windows-host';
 import {
@@ -789,9 +792,9 @@ ipcMain.handle(RUNTIME_BACKUP_RESET_CHANNEL, async (_event, payload) => {
   });
   if (confirmation.response !== 1) return { ok: false, canceled: true };
   try {
-    execFileSync(kungfuBinPath(), ['runtime', 'stop'], {
+    stopRuntimeForRecovery({
+      kungfuBinary: kungfuBinPath(),
       env: process.env,
-      timeout: 15_000,
     });
     const receipt = backupAndResetRuntime({
       dataHome,

--- a/framework/gui/src/main/runtime-recovery.test.ts
+++ b/framework/gui/src/main/runtime-recovery.test.ts
@@ -11,7 +11,10 @@ import path from 'node:path';
 import test from 'node:test';
 
 import { isResettableRuntimeFailure } from '../runtime-recovery-contract';
-import { backupAndResetRuntime } from './runtime-recovery';
+import {
+  backupAndResetRuntime,
+  stopRuntimeForRecovery,
+} from './runtime-recovery';
 
 function fixture(name: string): { dataHome: string; runtimeDir: string } {
   const dataHome = path.join(tmpdir(), `kungfu-gui-runtime-recovery-${name}`);
@@ -73,4 +76,20 @@ test('refuses to move a runtime outside the selected data home', () => {
       }),
     /outside the selected data home/u,
   );
+});
+
+test('stops through the shared CLI before filesystem recovery', () => {
+  const calls: unknown[][] = [];
+  const env = { KF_HOME: '/tmp/kungfu-recovery-test' };
+  stopRuntimeForRecovery({
+    kungfuBinary: '/opt/kungfu/bin/kungfu',
+    env,
+    run: (...args: unknown[]) => {
+      calls.push(args);
+      return Buffer.alloc(0);
+    },
+  });
+  assert.deepEqual(calls, [
+    ['/opt/kungfu/bin/kungfu', ['runtime', 'stop'], { env, timeout: 15_000 }],
+  ]);
 });

--- a/framework/gui/src/main/runtime-recovery.ts
+++ b/framework/gui/src/main/runtime-recovery.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from 'node:child_process';
 import {
   existsSync,
   mkdirSync,
@@ -14,6 +15,29 @@ export type RuntimeRecoveryReceipt = {
   backupPath: string;
   reason: string;
 };
+
+type RuntimeCommandRunner = (
+  file: string,
+  args: string[],
+  options: { env: NodeJS.ProcessEnv; timeout: number },
+) => unknown;
+
+/**
+ * Recovery is the one GUI flow allowed to stop a runtime: it invokes the
+ * shared public CLI before moving the selected workspace's runtime directory.
+ * Ordinary lifecycle remains owned by the shared runtime surfaces.
+ */
+export function stopRuntimeForRecovery(options: {
+  kungfuBinary: string;
+  env: NodeJS.ProcessEnv;
+  run?: RuntimeCommandRunner;
+}): void {
+  const run = options.run ?? execFileSync;
+  run(options.kungfuBinary, ['runtime', 'stop'], {
+    env: options.env,
+    timeout: 15_000,
+  });
+}
 
 function timestampSegment(now: Date): string {
   return now.toISOString().replaceAll(/[-:.]/gu, '');

--- a/scripts/check-runtime-surface-integration.mjs
+++ b/scripts/check-runtime-surface-integration.mjs
@@ -70,10 +70,24 @@ for (const command of fixture.ordinaryLifecycleCommands) {
   assert.doesNotMatch(
     guiMain,
     new RegExp(`\\['runtime', '${command}'`),
-    `GUI privately owns runtime ${command}`,
+    `GUI main bypasses the shared runtime surface for ${command}`,
   );
 }
 assert.match(guiMain, /Advanced Runtime Diagnostics/);
+assert.match(guiMain, /stopRuntimeForRecovery/);
+
+const guiRecovery = read('framework/gui/src/main/runtime-recovery.ts');
+assert.match(guiRecovery, /shared public CLI/);
+assert.match(guiRecovery, /\['runtime', 'stop'\]/);
+for (const command of fixture.ordinaryLifecycleCommands.filter(
+  (item) => item !== 'stop',
+)) {
+  assert.doesNotMatch(
+    guiRecovery,
+    new RegExp(`\\['runtime', '${command}'`),
+    `runtime recovery unexpectedly owns ${command}`,
+  );
+}
 
 const ordinaryCopies = [read(fixture.surfaces.gui), read(fixture.surfaces.tui)];
 for (const message of fixture.forbiddenOrdinaryMessages) {


### PR DESCRIPTION
## Summary

- keep ordinary runtime lifecycle ownership out of the GUI main process while preserving the explicit backup/reset recovery flow through the shared CLI
- verify the exact product outputs just produced by runtime qualification instead of starting a second native rebuild
- bootstrap pinned Buildchain layout discovery only for KFD-declared distribution tasks so fresh runners register artifacts before `shifu builds --json`

## Evidence

- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo test --manifest-path crates/Cargo.toml -p shifu registrar::tests` (10 passed)
- `./shifu check:source` (323 source contract tests, 76 runtime upgrade tests, 69 desktop update/signing tests, TypeScript checks)
- commit hook: workspace clippy with `-D warnings`, workspace Rust tests, documentation and staged gates
- agent-120 product verification reached 34/35; the only failure was a duplicate Episode timeout under concurrent IO, so the artifact suite now skips that already-completed outer campaign
- targeted runtime-activation tests (7 passed) plus a fresh `./shifu check:source` on `efce4b90b`

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Repairs fresh-runner qualification execution and preserves existing runtime ownership contracts without changing an architecture decision."
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change affects qualification evidence generation only. It does not publish or deploy artifacts.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed (inline contract comments and tests cover the bounded behavior)


