### PR TITLE
fix(qualification): isolate installed provider drift

### DIFF
--- a/docs/qualification/zero-burden-desktop-runtime.md
+++ b/docs/qualification/zero-burden-desktop-runtime.md
@@ -27,8 +27,11 @@ The aggregate stage is:
 It fails closed unless both component directories contain `report.json` beside
 `raw-logs.jsonl.gz`, each report passes for the exact source revision and host
 platform, and each report binds the adjacent raw bundle by SHA-256. It then runs
-the complete Agent Session control-plane suite plus the terminal product
-presentation suite. Their raw output is stored in the aggregate gzip bundle.
+the complete deterministic Agent Session control-plane suite plus the terminal
+product presentation suite. Installed-provider version and Codex schema drift
+gates remain separate native checks: an unrelated CLI already present on a
+runner cannot change this credential-free aggregate result. Their raw output is
+stored in the aggregate gzip bundle.
 
 Buildchain uploads these three retained evidence pairs under
 `product/release/qualification/`:

--- a/framework/agent-session/package.json
+++ b/framework/agent-session/package.json
@@ -38,7 +38,8 @@
     "schemas"
   ],
   "scripts": {
-    "test": "node --test tests/*.test.mjs"
+    "test": "node --test tests/*.test.mjs",
+    "test:control-plane": "node --test --test-skip-pattern=installed tests/*.test.mjs"
   },
   "dependencies": {
     "node-pty": "^1.1.0"

--- a/scripts/run-zero-burden-product-qualification.mjs
+++ b/scripts/run-zero-burden-product-qualification.mjs
@@ -25,10 +25,15 @@ const COMPONENTS = [
   },
 ];
 
-const SUITES = [
+export const QUALIFICATION_SUITES = [
   {
     id: 'agent-session-control-plane',
-    command: [LAUNCHER, 'test:agent-session-capsule-host'],
+    command: [
+      LAUNCHER,
+      '--filter',
+      '@kungfu-tech/agent-session',
+      'test:control-plane',
+    ],
   },
   {
     id: 'frontend-product-presentation',
@@ -260,7 +265,9 @@ async function main() {
   const components = COMPONENTS.map((component) =>
     validateComponentEvidence(ROOT, component, expected),
   );
-  const suites = SUITES.map((suite) => runSuite(suite, outputDir));
+  const suites = QUALIFICATION_SUITES.map((suite) =>
+    runSuite(suite, outputDir),
+  );
   const bundle = createLogBundle(outputDir, suites);
   const report = evaluateQualification({
     source,

--- a/scripts/run-zero-burden-product-qualification.test.mjs
+++ b/scripts/run-zero-burden-product-qualification.test.mjs
@@ -8,6 +8,7 @@ import path from 'node:path';
 import { test } from 'node:test';
 
 import {
+  QUALIFICATION_SUITES,
   evaluateQualification,
   validateComponentEvidence,
 } from './run-zero-burden-product-qualification.mjs';
@@ -80,6 +81,27 @@ test('aggregate qualification preserves product and non-claim boundaries', () =>
   assert.equal(report.claims.product_artifacts_verified, true);
   assert.equal(report.claims.authenticated_provider_dogfood, false);
   assert.equal(report.claims.interactive_gui_lifecycle, false);
+});
+
+test('aggregate control-plane coverage is independent of installed provider CLIs', () => {
+  const suite = QUALIFICATION_SUITES.find(
+    ({ id }) => id === 'agent-session-control-plane',
+  );
+  assert.deepEqual(suite.command.slice(1), [
+    '--filter',
+    '@kungfu-tech/agent-session',
+    'test:control-plane',
+  ]);
+  const manifest = JSON.parse(
+    fs.readFileSync(
+      path.join(process.cwd(), 'framework/agent-session/package.json'),
+      'utf8',
+    ),
+  );
+  assert.match(
+    manifest.scripts['test:control-plane'],
+    /skip-pattern=installed/u,
+  );
 });
 
 test('provider approval dogfood delegates confirmation to the permission system', () => {


### PR DESCRIPTION
## Summary

- keep the credential-free zero-burden aggregate deterministic across self-hosted runners
- run the complete Agent Session control-plane/native recovery suite while keeping installed-provider version and Codex schema drift as separate native gates
- document and test that incidental runner CLI installations cannot widen or block the aggregate claim

## Evidence

- ./shifu build:core
- ./shifu --filter @kungfu-tech/agent-session test:control-plane (93/93)
- node --test scripts/run-zero-burden-product-qualification.test.mjs (4/4)
- ./shifu check
- SHIFU_CACHE_BYPASS=source-acceptance ./shifu check:source (324 source, 76 runtime-upgrade, 69 desktop-update)
- commit hook staged gate

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Keeps credential-free qualification independent of incidental runner provider installations without changing provider compatibility or runtime authority contracts."
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [x] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

No provider credentials or private state are read; installed-provider drift gates remain separately available. This changes qualification composition only and does not publish artifacts.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed