### PR TITLE
fix(shifu): preserve tool path across nested cache apply

### DIFF
--- a/scripts/shifu-cache-runtime.mjs
+++ b/scripts/shifu-cache-runtime.mjs
@@ -926,7 +926,8 @@ function prepareConfigOverlays(configBindings, baseEnv, scope, cwd) {
           '@node "%~dp0cargo-wrapper.mjs" %*\r\n',
           { mode: 0o600 },
         );
-        const originalPath = baseEnv.PATH || '';
+        const originalPath =
+          baseEnv.SHIFU_CARGO_ORIGINAL_PATH || baseEnv.PATH || '';
         overlayEnv.SHIFU_CARGO_ORIGINAL_PATH = originalPath;
         overlayEnv.SHIFU_CARGO_SOURCE_NAME = binding.name;
         overlayEnv.SHIFU_CARGO_REGISTRY = binding.value;
@@ -979,7 +980,8 @@ function prepareConfigOverlays(configBindings, baseEnv, scope, cwd) {
           '@node "%~dp0conan-wrapper.mjs" %*\r\n',
           { mode: 0o600 },
         );
-        overlayEnv.SHIFU_CONAN_ORIGINAL_PATH = baseEnv.PATH || '';
+        overlayEnv.SHIFU_CONAN_ORIGINAL_PATH =
+          baseEnv.SHIFU_CONAN_ORIGINAL_PATH || baseEnv.PATH || '';
         overlayEnv.SHIFU_CONAN_STORAGE_ROOT = storageRoot;
         fs.writeFileSync(
           path.join(conanHome, 'global.conf'),

--- a/scripts/shifu-cache-runtime.test.mjs
+++ b/scripts/shifu-cache-runtime.test.mjs
@@ -834,6 +834,56 @@ test('cache apply cleans config overlays after a failing child', async (t) => {
   assert.equal(fs.existsSync(path.join(storage, '.shifu-conan.lock')), false);
 });
 
+test('nested cache apply preserves the original tool PATH instead of wrapping a wrapper', async (t) => {
+  const directory = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'shifu-cache-nested-tools-'),
+  );
+  t.after(() => fs.rmSync(directory, { recursive: true, force: true }));
+  const raw = bytes(toolConfigProfile());
+  const profilePath = path.join(directory, 'profile.json');
+  const childPath = path.join(directory, 'nested-apply.mjs');
+  const outputPath = path.join(directory, 'nested.json');
+  const fakeBin = path.join(directory, 'fake-bin');
+  const originalPath = `${fakeBin}${path.delimiter}${process.env.PATH || ''}`;
+  fs.mkdirSync(fakeBin);
+  fs.writeFileSync(profilePath, raw);
+  fs.writeFileSync(
+    childPath,
+    `import fs from 'node:fs';
+import path from 'node:path';
+import { applyCacheProfile } from ${JSON.stringify(pathToFileURL(path.join(ROOT, 'scripts/shifu-cache-runtime.mjs')).href)};
+const status = await applyCacheProfile({
+  reference: ${JSON.stringify(profilePath)},
+  expectedDigest: ${JSON.stringify(sha256(raw))},
+  scope: 'development',
+  command: process.execPath,
+  args: ['-e', ${JSON.stringify(`const fs = require('node:fs'); const path = require('node:path'); fs.writeFileSync(${JSON.stringify(outputPath)}, JSON.stringify({ path: process.env.PATH.split(path.delimiter), cargoOriginalPath: process.env.SHIFU_CARGO_ORIGINAL_PATH, conanOriginalPath: process.env.SHIFU_CONAN_ORIGINAL_PATH }));`)}],
+  env: process.env,
+});
+process.exit(status);
+`,
+  );
+  const status = await applyCacheProfile({
+    reference: profilePath,
+    expectedDigest: sha256(raw),
+    scope: 'development',
+    command: process.execPath,
+    args: [childPath],
+    env: {
+      ...process.env,
+      PATH: originalPath,
+      XDG_CACHE_HOME: path.join(directory, 'cache'),
+    },
+  });
+  assert.equal(status, 0);
+  const nested = JSON.parse(fs.readFileSync(outputPath, 'utf8'));
+  assert.equal(nested.cargoOriginalPath, originalPath);
+  assert.equal(nested.conanOriginalPath, originalPath);
+  assert.match(nested.path[0], /shifu-cache-overlay-/);
+  assert.match(nested.path[1], /shifu-cache-overlay-/);
+  assert.notEqual(nested.path[0], nested.path[1]);
+});
+
 test('nested Gate task re-entry does not acquire Conan storage when Conan is unused', async (t) => {
   const directory = fs.mkdtempSync(
     path.join(os.tmpdir(), 'shifu-cache-gate-reentry-'),


### PR DESCRIPTION
## Summary

- preserve the first real Cargo and Conan PATH across nested Shifu cache overlays
- prevent an inner wrapper from resolving an outer wrapper as the real tool
- add a bounded regression test for nested wrapper PATH provenance

## Evidence

- `node --test scripts/shifu-cache-runtime.test.mjs` (18/18)
- `./shifu check:source` (325 Node tests, 76 Python tests, 69 desktop update tests)
- `./shifu check:shifu-cache-contract`

## Failure prevented

A nested `layers.sdk` Gate under the development cache profile could recursively invoke the Cargo wrapper, repeatedly append registry config, and spawn thousands of Node processes. The Gate was interrupted and all residual overlay processes were verified absent before this patch.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Fixes nested cache wrapper execution so existing Shifu and Gate contracts run safely without changing an architecture decision."
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

This PR changes only local cache-wrapper process selection and does not publish or deploy artifacts.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Regression test and source acceptance are green
