### PR TITLE
fix(qualification): preserve RC evidence across platforms

### DIFF
--- a/framework/core/tests/qualification/live-peer-continuity/native_campaign.py
+++ b/framework/core/tests/qualification/live-peer-continuity/native_campaign.py
@@ -6,6 +6,7 @@ import argparse
 import hashlib
 import json
 import os
+import platform
 import signal
 import subprocess
 import sys
@@ -232,13 +233,13 @@ def _spawn_capsule(
     return process, stream
 
 
-def _run_campaign(output_dir: Path) -> int:
+def _run_campaign(output_dir: Path, temp_parent: Path | None = None) -> int:
     output_dir.mkdir(parents=True, exist_ok=True)
     report_path = output_dir / "report.json"
     # NNG's ipc transport inherits the platform Unix-domain socket path limit.
     # Keep this test-owned workspace short so macOS does not reject valid
     # runtime endpoints solely because $TMPDIR is deeply nested.
-    with tempfile.TemporaryDirectory(prefix="kfp-", dir="/tmp") as root:
+    with tempfile.TemporaryDirectory(prefix="kfp-", dir=temp_parent) as root:
         runtime_dir = Path(root) / "workspace" / "runtime"
         marker_path = Path(root) / "peer-ready.jsonl"
         capsule_command_path = Path(root) / "capsule-authority.jsonl"
@@ -386,7 +387,7 @@ def _run_campaign(output_dir: Path) -> int:
             "verdict": verdict,
             "startedAtNs": str(started_at),
             "completedAtNs": str(time.time_ns()),
-            "platform": {"os": sys.platform, "machine": os.uname().machine},
+            "platform": {"os": sys.platform, "machine": platform.machine()},
             "coverage": {
                 "hardCoordinatorCrash": verdict == "passed",
                 "sameGenerationEpochAdvance": verdict == "passed",
@@ -424,6 +425,7 @@ def _parser() -> argparse.ArgumentParser:
     peer.add_argument("--marker-path", type=Path, required=True)
     campaign = subparsers.add_parser("campaign")
     campaign.add_argument("--output-dir", type=Path, required=True)
+    campaign.add_argument("--temp-parent", type=Path)
     return parser
 
 
@@ -435,7 +437,7 @@ def main() -> int:
         )
     if args.role == "peer":
         return _run_peer(args.runtime_dir, args.marker_path)
-    return _run_campaign(args.output_dir)
+    return _run_campaign(args.output_dir, args.temp_parent)
 
 
 if __name__ == "__main__":

--- a/framework/core/tests/qualification/live-peer-continuity/run.mjs
+++ b/framework/core/tests/qualification/live-peer-continuity/run.mjs
@@ -46,6 +46,10 @@ export function pythonInvocation({ platform = process.platform } = {}) {
   };
 }
 
+export function campaignTempParent(platform = process.platform) {
+  return platform === 'win32' ? null : '/tmp';
+}
+
 function nativeEnvironment() {
   const build = path.join(ROOT, 'framework', 'core', 'build', 'Release');
   const env = {
@@ -60,6 +64,7 @@ function nativeEnvironment() {
   };
   if (process.platform !== 'darwin') return env;
   const store = path.join(ROOT, 'node_modules', '.pnpm');
+  if (!fs.existsSync(store)) return env;
   const architecture = process.arch === 'arm64' ? 'arm64' : 'x64';
   const packageName = fs
     .readdirSync(store)
@@ -82,8 +87,12 @@ function nativeEnvironment() {
   return env;
 }
 
-export function qualificationPlan(outputDir) {
-  const python = pythonInvocation();
+export function qualificationPlan(
+  outputDir,
+  { platform = process.platform } = {},
+) {
+  const python = pythonInvocation({ platform });
+  const tempParent = campaignTempParent(platform);
   return [
     {
       id: 'core-continuity-state-machine',
@@ -115,6 +124,7 @@ export function qualificationPlan(outputDir) {
         'campaign',
         '--output-dir',
         path.join(outputDir, 'native-campaign'),
+        ...(tempParent ? ['--temp-parent', tempParent] : []),
       ],
       env: nativeEnvironment(),
       shell: python.shell,

--- a/framework/core/tests/qualification/live-peer-continuity/run.test.mjs
+++ b/framework/core/tests/qualification/live-peer-continuity/run.test.mjs
@@ -8,6 +8,7 @@ import { test } from 'node:test';
 import { gunzipSync } from 'node:zlib';
 
 import {
+  campaignTempParent,
   createLogBundle,
   defaultOutputDir,
   evaluateQualification,
@@ -64,6 +65,16 @@ test('native campaign enters Python through the Shifu-managed uv project', () =>
   assert.equal(linux.command[5], 'python');
   assert.equal(linux.shell, false);
   assert.equal(windows.shell, true);
+});
+
+test('native campaign uses a short Unix temp root without assuming /tmp on Windows', () => {
+  assert.equal(campaignTempParent('linux'), '/tmp');
+  assert.equal(campaignTempParent('darwin'), '/tmp');
+  assert.equal(campaignTempParent('win32'), null);
+  const linux = qualificationPlan('/qualification', { platform: 'linux' })[2];
+  const windows = qualificationPlan('/qualification', { platform: 'win32' })[2];
+  assert.deepEqual(linux.command.slice(-2), ['--temp-parent', '/tmp']);
+  assert.ok(!windows.command.includes('--temp-parent'));
 });
 
 test('clean complete evidence qualifies only the bounded single-host claim', () => {

--- a/scripts/run-release-qualification.mjs
+++ b/scripts/run-release-qualification.mjs
@@ -134,17 +134,20 @@ export function releaseQualificationEnvironment(
 ) {
   const temporary = path.join(root, '.buildchain', 'tmp');
   fs.mkdirSync(temporary, { recursive: true });
-  return lifecycleEnvironment({
-    ...inherited,
-    TMPDIR: temporary,
-    TEMP: temporary,
-    TMP: temporary,
-    KUNGFU_BUILDCHAIN_NO_OPTIONAL: '1',
-    KUNGFU_BUILDCHAIN_SOURCE_BUILD: '1',
-    SHIFU_NATIVE: '1',
-    SHIFU_REQUIRE_MSVC: '1',
-    KUNGFU_FUZZ_SECONDS: String(fuzzSecondsPerTarget),
-  });
+  return lifecycleEnvironment(
+    {
+      ...inherited,
+      TMPDIR: temporary,
+      TEMP: temporary,
+      TMP: temporary,
+      KUNGFU_BUILDCHAIN_NO_OPTIONAL: '1',
+      KUNGFU_BUILDCHAIN_SOURCE_BUILD: '1',
+      SHIFU_NATIVE: '1',
+      SHIFU_REQUIRE_MSVC: '1',
+      KUNGFU_FUZZ_SECONDS: String(fuzzSecondsPerTarget),
+    },
+    'dist',
+  );
 }
 
 export function releaseQualificationStages(

--- a/scripts/run-release-qualification.test.mjs
+++ b/scripts/run-release-qualification.test.mjs
@@ -25,6 +25,10 @@ test('qualification temp state is repository scoped on every platform', () => {
     assert.equal(env.TMPDIR, expected);
     assert.equal(env.TEMP, expected);
     assert.equal(env.TMP, expected);
+    assert.match(env.KF_UPGRADE_QUALIFICATION_REF, /^buildchain-retained:/);
+    assert.match(env.KF_RUNTIME_ARTIFACT_SIGNATURE, /#runtime$/);
+    assert.match(env.KF_DESKTOP_ARTIFACT_SIGNATURE, /#desktop$/);
+    assert.match(env.KF_CLI_ARTIFACT_SIGNATURE, /#cli$/);
     assert.equal(fs.statSync(expected).isDirectory(), true);
   } finally {
     fs.rmSync(root, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

- preserve the Buildchain-retained upgrade qualification reference through nested product distribution builds
- use a platform-safe temporary root for the Windows native live-peer campaign
- replace the Unix-only machine probe with a portable platform probe
- add bounded regression coverage for both release evidence and platform planning

## Evidence

- `node --test scripts/run-release-qualification.test.mjs framework/core/tests/qualification/live-peer-continuity/run.test.mjs` (20/20)
- `./shifu check:source` (325 Node tests, 76 Python tests, 69 desktop update tests)
- staged DCO hook and Python/TypeScript format checks passed

## Hosted failures fixed

- Linux final qualification rebuilt product artifacts without `KF_UPGRADE_QUALIFICATION_REF`, causing `upgrade:qualify:native` to reject an otherwise RC-qualified build.
- Windows native live-peer qualification failed immediately because the campaign assumed `/tmp` and later used `os.uname()`.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Fixes cross-platform execution of existing release qualification contracts without changing an architecture decision."
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

This PR changes only qualification environment propagation and disposable test workspace selection; it does not publish or deploy artifacts.

## Checklist

- [x] Commit is signed off (DCO)
- [x] Source acceptance is green
- [x] No credentials or generated qualification evidence are committed