### PR TITLE
fix(agent-session): keep Darwin test sockets short

### DIFF
--- a/framework/agent-session/tests/capsule-worker.test.mjs
+++ b/framework/agent-session/tests/capsule-worker.test.mjs
@@ -14,6 +14,7 @@ const workerScript = path.join(here, '..', 'src', 'capsule-worker.mjs');
 const providerScript = path.join(here, 'fixtures', 'synthetic-provider.mjs');
 const PROFILE_ROOT = `sha256:${'b'.repeat(64)}`;
 const require = createRequire(import.meta.url);
+const socketTempRoot = process.platform === 'darwin' ? '/tmp' : os.tmpdir();
 
 function preparedNodePty(temp) {
   const source = path.dirname(require.resolve('node-pty/package.json'));
@@ -77,7 +78,7 @@ async function connect(endpoint) {
 }
 
 test('detached Capsule worker survives client loss and reattaches to the same PTY', async (t) => {
-  const temp = fs.mkdtempSync(path.join(os.tmpdir(), 'kungfu-capsule-'));
+  const temp = fs.mkdtempSync(path.join(socketTempRoot, 'kungfu-capsule-'));
   const endpoint = path.join(temp, 'capsule.sock');
   const ptyModule = preparedNodePty(temp);
   const child = spawn(

--- a/framework/agent-session/tests/product-surface.test.mjs
+++ b/framework/agent-session/tests/product-surface.test.mjs
@@ -675,7 +675,10 @@ test('the product runtime executes a reviewed plan through the real Capsule host
 
 test('the local product RPC preserves the same action and error envelopes', async (t) => {
   const directory = await mkdtemp(
-    path.join(os.tmpdir(), 'kungfu-agent-session-product-rpc-'),
+    path.join(
+      process.platform === 'darwin' ? '/tmp' : os.tmpdir(),
+      'kungfu-agent-session-product-rpc-',
+    ),
   );
   const endpoint = path.join(directory, 'surface.sock');
   const { surface } = fixture();


### PR DESCRIPTION
## Summary

- keep direct Agent Session Unix-domain socket tests on the same short Darwin temp-root policy as production
- prevent deeply nested Buildchain TMPDIR values from turning valid detached-worker and local-RPC assertions into path-length failures
- preserve the full recovery and RPC assertions on every platform

## Evidence

- ./shifu build:core
- TMPDIR="$PWD/.buildchain/tmp" node --test framework/agent-session/tests/capsule-worker.test.mjs framework/agent-session/tests/product-surface.test.mjs (17/17)
- corepack pnpm --filter @kungfu-tech/agent-session test:control-plane (93/93)
- node --test framework/core/tests/qualification/live-peer-continuity/run.test.mjs (7/7)
- node --test scripts/check-shifu-cache-contract.test.mjs scripts/shifu-cache-runtime.test.mjs scripts/shifu-uv-cache-adapter.test.mjs (47/47)
- commit hook staged gate

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Aligns test-owned Darwin socket paths with the existing production runtime policy without changing runtime authority or product behavior."
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

No product authority or release contract changes. The patch only prevents qualification-only endpoint paths from exceeding Darwin's Unix-domain socket limit.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed
