### PR TITLE
fix(qualification): close hosted acceptance gaps

### DIFF
--- a/docs/qualification/gates/execution-profiles.json
+++ b/docs/qualification/gates/execution-profiles.json
@@ -2,7 +2,7 @@
   "schema": "kungfu.qualification-execution-profiles/v1",
   "profiles": {
     "alpha": {
-      "budgetSeconds": 1800,
+      "budgetSeconds": 2700,
       "upstreamBudgetSeconds": 750,
       "reserveSeconds": 240,
       "fuzzSecondsPerTarget": 90,

--- a/docs/qualification/gates/policy-matrix.md
+++ b/docs/qualification/gates/policy-matrix.md
@@ -54,7 +54,7 @@ Do not hand-edit the generated block. A mode applies when the corresponding
 
 | Execution profile | Budget (s) | Upstream build (s) | Reserve (s) | Episode profile | Episode ceiling (s) | Fuzz seconds/target |
 | --- | ---: | ---: | ---: | --- | ---: | ---: |
-| `alpha` | 1800 | 750 | 240 | `mvp-smoke-v1` | 600 | 90 |
+| `alpha` | 2700 | 750 | 240 | `mvp-smoke-v1` | 600 | 90 |
 | `release-candidate` | 3600 | 900 | 600 | `mvp-candidate-v1` | 1200 | 90 |
 | `full-patrol` | 14400 | 900 | 900 | `mvp-baseline-v1` | 7200 | 90 |
 

--- a/docs/qualification/layer-gate-timing-baseline.md
+++ b/docs/qualification/layer-gate-timing-baseline.md
@@ -9,8 +9,8 @@ confidence: high
 sensitivity: internal
 evidence_grade: B
 review_state: self-reviewed
-last_reviewed: 2026-07-14
-ai_provenance: GPT-5 via Codex on 2026-07-14; visible local source, three-host lifecycle logs, Gate receipts, qualification reports, and host identity; no hosted CI or publication state inspected
+last_reviewed: 2026-07-15
+ai_provenance: GPT-5 via Codex on 2026-07-15; visible local source, three-host lifecycle logs, hosted CI logs, Gate receipts, qualification reports, and host identity; no private publication state inspected
 ---
 
 # Layer Gate timing baseline
@@ -247,12 +247,19 @@ bounding only the Episode seeds and accumulation/contention counts:
 
 | Execution profile | End-to-end budget | Upstream allowance | Reserve | Episode workload |
 | --- | ---: | ---: | ---: | --- |
-| `alpha` | 1800s | 750s | 240s | `mvp-smoke-v1` |
+| `alpha` | 2700s | 750s | 240s | `mvp-smoke-v1` |
 | `release-candidate` | 3600s | 900s | 600s | `mvp-candidate-v1` |
 | `full-patrol` | 14400s | 900s | 900s | unchanged `mvp-baseline-v1` |
 
 The alpha figures are anchored to the slowest measured upstream host
 (`673.13s` Linux install plus distribution) with additional setup allowance.
+The first exact-source hosted acceptance run then measured `1467s` inside the
+qualification process because runtime activation intentionally rebuilds and
+verifies the complete product distribution. The original `810s` execution
+allowance therefore rejected an otherwise passing Linux campaign. The revised
+alpha total preserves the upstream and reserve allocations while raising the
+qualification execution allowance to `1710s`; it does not skip or shorten any
+gate.
 The release profile adds the measured 10,000 accumulation checkpoint while the
 100,000 checkpoint and three-seed soak remain available in full-patrol. The
 workflow summary fails when qualification exceeds the budget after subtracting

--- a/framework/core/tests/qualification/live-peer-continuity/run.mjs
+++ b/framework/core/tests/qualification/live-peer-continuity/run.mjs
@@ -46,8 +46,18 @@ export function pythonInvocation({ platform = process.platform } = {}) {
   };
 }
 
-export function campaignTempParent(platform = process.platform) {
-  return platform === 'win32' ? null : '/tmp';
+export function campaignTempParent(
+  platform = process.platform,
+  { env = process.env, temporaryDirectory = os.tmpdir() } = {},
+) {
+  if (platform !== 'win32') return '/tmp';
+  // Release qualification deliberately redirects TEMP/TMP into the repository
+  // for native build performance. That path can exceed Windows AF_UNIX limits
+  // once the campaign appends its runtime endpoint hierarchy. GitHub exposes a
+  // shorter runner-owned root that remains isolated to the current job.
+  return (
+    env.RUNNER_TEMP || env.KUNGFU_QUALIFICATION_HOST_TEMP || temporaryDirectory
+  );
 }
 
 function nativeEnvironment() {
@@ -145,6 +155,12 @@ function runSuite(suite, outputDir) {
   const rawLog = `${suite.id}.log`;
   fs.writeFileSync(path.join(outputDir, rawLog), output, { flag: 'wx' });
   const passed = !result.error && result.status === 0;
+  if (!passed && suite.id === 'native-cross-process-restart') {
+    const campaign = nativeCampaignReport(outputDir);
+    const detail =
+      campaign?.error || result.error?.message || 'campaign report unavailable';
+    console.error(`[live-peer-continuity] native-campaign-error=${detail}`);
+  }
   console.log(
     `[live-peer-continuity] suite=${suite.id} status=${passed ? 'passed' : 'failed'} duration_ms=${Date.now() - started}`,
   );

--- a/framework/core/tests/qualification/live-peer-continuity/run.test.mjs
+++ b/framework/core/tests/qualification/live-peer-continuity/run.test.mjs
@@ -67,14 +67,41 @@ test('native campaign enters Python through the Shifu-managed uv project', () =>
   assert.equal(windows.shell, true);
 });
 
-test('native campaign uses a short Unix temp root without assuming /tmp on Windows', () => {
+test('native campaign uses a short platform-owned temp root', () => {
   assert.equal(campaignTempParent('linux'), '/tmp');
   assert.equal(campaignTempParent('darwin'), '/tmp');
-  assert.equal(campaignTempParent('win32'), null);
+  assert.equal(
+    campaignTempParent('win32', {
+      env: { RUNNER_TEMP: 'D:\\a\\_temp', TEMP: 'D:\\repo\\.buildchain\\tmp' },
+      temporaryDirectory: 'C:\\Users\\runneradmin\\AppData\\Local\\Temp',
+    }),
+    'D:\\a\\_temp',
+  );
+  assert.equal(
+    campaignTempParent('win32', {
+      env: {},
+      temporaryDirectory: 'C:\\Users\\local\\AppData\\Local\\Temp',
+    }),
+    'C:\\Users\\local\\AppData\\Local\\Temp',
+  );
+  assert.equal(
+    campaignTempParent('win32', {
+      env: {
+        KUNGFU_QUALIFICATION_HOST_TEMP:
+          'C:\\Users\\local\\AppData\\Local\\Temp',
+      },
+      temporaryDirectory: 'D:\\repo\\.buildchain\\tmp',
+    }),
+    'C:\\Users\\local\\AppData\\Local\\Temp',
+  );
   const linux = qualificationPlan('/qualification', { platform: 'linux' })[2];
   const windows = qualificationPlan('/qualification', { platform: 'win32' })[2];
   assert.deepEqual(linux.command.slice(-2), ['--temp-parent', '/tmp']);
-  assert.ok(!windows.command.includes('--temp-parent'));
+  assert.ok(windows.command.includes('--temp-parent'));
+  assert.notEqual(
+    windows.command[windows.command.indexOf('--temp-parent') + 1],
+    null,
+  );
 });
 
 test('clean complete evidence qualifies only the bounded single-host claim', () => {

--- a/scripts/run-release-qualification.mjs
+++ b/scripts/run-release-qualification.mjs
@@ -133,6 +133,12 @@ export function releaseQualificationEnvironment(
   fuzzSecondsPerTarget = 90,
 ) {
   const temporary = path.join(root, '.buildchain', 'tmp');
+  const hostTemporary =
+    inherited.RUNNER_TEMP ||
+    inherited.TEMP ||
+    inherited.TMP ||
+    inherited.TMPDIR ||
+    temporary;
   fs.mkdirSync(temporary, { recursive: true });
   return lifecycleEnvironment(
     {
@@ -140,6 +146,7 @@ export function releaseQualificationEnvironment(
       TMPDIR: temporary,
       TEMP: temporary,
       TMP: temporary,
+      KUNGFU_QUALIFICATION_HOST_TEMP: hostTemporary,
       KUNGFU_BUILDCHAIN_NO_OPTIONAL: '1',
       KUNGFU_BUILDCHAIN_SOURCE_BUILD: '1',
       SHIFU_NATIVE: '1',

--- a/scripts/run-release-qualification.test.mjs
+++ b/scripts/run-release-qualification.test.mjs
@@ -25,11 +25,26 @@ test('qualification temp state is repository scoped on every platform', () => {
     assert.equal(env.TMPDIR, expected);
     assert.equal(env.TEMP, expected);
     assert.equal(env.TMP, expected);
+    assert.equal(env.KUNGFU_QUALIFICATION_HOST_TEMP, '/host/temp');
     assert.match(env.KF_UPGRADE_QUALIFICATION_REF, /^buildchain-retained:/);
     assert.match(env.KF_RUNTIME_ARTIFACT_SIGNATURE, /#runtime$/);
     assert.match(env.KF_DESKTOP_ARTIFACT_SIGNATURE, /#desktop$/);
     assert.match(env.KF_CLI_ARTIFACT_SIGNATURE, /#cli$/);
     assert.equal(fs.statSync(expected).isDirectory(), true);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('hosted qualification preserves the short runner temp before redirecting build temp', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'kungfu-runner-env-'));
+  try {
+    const env = releaseQualificationEnvironment(root, {
+      RUNNER_TEMP: 'D:\\a\\_temp',
+      TEMP: 'D:\\a\\kungfu\\kungfu\\.buildchain\\tmp',
+    });
+    assert.equal(env.KUNGFU_QUALIFICATION_HOST_TEMP, 'D:\\a\\_temp');
+    assert.equal(env.TEMP, path.join(root, '.buildchain', 'tmp'));
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }
@@ -209,7 +224,7 @@ test('execution profile numeric constraints reject zero and negative values', ()
       () => loadExecutionProfile('alpha', file),
       /positive integer/,
     );
-    valid.profiles.alpha.budgetSeconds = 1800;
+    valid.profiles.alpha.budgetSeconds = 2700;
     valid.profiles.alpha.reserveSeconds = -1;
     fs.writeFileSync(file, JSON.stringify(valid));
     assert.throws(


### PR DESCRIPTION
## Summary

- preserve the host-owned short temporary root before release qualification redirects build temp into the repository
- use that short root for the Windows native live-peer campaign and surface its bounded failure reason in hosted logs
- calibrate the alpha qualification budget from 1800s to 2700s after the exact-source hosted run measured 1467s inside qualification
- keep every existing native, artifact, Episode, signature, and upgrade gate enabled

## Evidence

- `./shifu exec node --test framework/core/tests/qualification/live-peer-continuity/run.test.mjs scripts/run-release-qualification.test.mjs` (21/21)
- `SHIFU_CACHE_BYPASS=source-acceptance ./shifu check:source` (exit 0; build-free source gate passed)
- staged DCO, docs, catalog, TypeScript, and Biome checks passed
- hosted diagnosis: run 29394539339 reached all Linux gates before the 810s execution allowance rejected the passing path; Windows reached native live-peer qualification before its repository-scoped temp path failed

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Fixes hosted execution of existing release qualification contracts without changing an architecture decision."
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

This PR changes qualification workspace selection and an evidence-backed time budget; it does not publish or deploy artifacts.

## Checklist

- [x] Commit is signed off (DCO)
- [x] Source acceptance is green
- [x] No credentials or generated qualification evidence are committed