### PR TITLE
fix(core): close cross-platform architecture acceptance gaps

### DIFF
--- a/docs/adr/ADR-0049-layer-complete-products-and-domain-neutral-core.md
+++ b/docs/adr/ADR-0049-layer-complete-products-and-domain-neutral-core.md
@@ -6,7 +6,7 @@ decision_status: accepted
 implementation_status: implemented
 review_state: legacy-unreviewed
 sensitivity: public
-implementation_commits: [360c1dfcaf12aa410158f22ff175e5c608b0a77a, 0803574a7e68c715ad856550df0d386c8cac3f89]
+implementation_commits: [360c1dfcaf12aa410158f22ff175e5c608b0a77a]
 implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/797, https://github.com/kungfu-systems/kungfu/pull/911, https://github.com/kungfu-systems/kungfu/pull/921, https://github.com/kungfu-systems/kungfu/pull/929, https://github.com/kungfu-systems/kungfu/pull/938]
 closure_pr: https://github.com/kungfu-systems/kungfu/pull/797
 qualification_refs: [docs/qualification/layer-product-release-qualification.md, framework/core/architecture/layers.json, framework/core/architecture/LAYERS.md, framework/core/architecture/TARGETS.cmake, framework/core/architecture/check-layers.mjs, shifu.gates.json, tests/qualification/layers/run.mjs, tests/qualification/layers/release/run.mjs, tests/qualification/layers/surfaces/run.mjs, scripts/run-release-qualification.mjs, scripts/source-acceptance.mjs]

--- a/docs/adr/ADR-0049-layer-complete-products-and-domain-neutral-core.md
+++ b/docs/adr/ADR-0049-layer-complete-products-and-domain-neutral-core.md
@@ -6,8 +6,8 @@ decision_status: accepted
 implementation_status: implemented
 review_state: legacy-unreviewed
 sensitivity: public
-implementation_commits: [360c1dfcaf12aa410158f22ff175e5c608b0a77a]
-implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/797, https://github.com/kungfu-systems/kungfu/pull/911, https://github.com/kungfu-systems/kungfu/pull/921, https://github.com/kungfu-systems/kungfu/pull/929]
+implementation_commits: [360c1dfcaf12aa410158f22ff175e5c608b0a77a, 0803574a7e68c715ad856550df0d386c8cac3f89]
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/797, https://github.com/kungfu-systems/kungfu/pull/911, https://github.com/kungfu-systems/kungfu/pull/921, https://github.com/kungfu-systems/kungfu/pull/929, https://github.com/kungfu-systems/kungfu/pull/938]
 closure_pr: https://github.com/kungfu-systems/kungfu/pull/797
 qualification_refs: [docs/qualification/layer-product-release-qualification.md, framework/core/architecture/layers.json, framework/core/architecture/LAYERS.md, framework/core/architecture/TARGETS.cmake, framework/core/architecture/check-layers.mjs, shifu.gates.json, tests/qualification/layers/run.mjs, tests/qualification/layers/release/run.mjs, tests/qualification/layers/surfaces/run.mjs, scripts/run-release-qualification.mjs, scripts/source-acceptance.mjs]
 ---

--- a/framework/core/src/libkungfu/src/runtime/storage/provider.cpp
+++ b/framework/core/src/libkungfu/src/runtime/storage/provider.cpp
@@ -6,11 +6,18 @@
 #include <cstdlib>
 #include <fstream>
 #include <functional>
+#include <optional>
 #include <stdexcept>
 #include <utility>
 
 #include <rocksdb/db.h>
 #include <rocksdb/iterator.h>
+
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#include <windows.h>
+#endif
 
 namespace kungfu::runtime::storage_service_api::detail {
 
@@ -94,10 +101,31 @@ std::string normalized_provider_name(const std::string &provider) {
   throw std::invalid_argument("unsupported storage provider: " + provider);
 }
 
+std::optional<std::string> environment_value(const char *name) {
+#ifdef _WIN32
+  const auto required = GetEnvironmentVariableA(name, nullptr, 0);
+  if (required == 0) {
+    return std::nullopt;
+  }
+  std::string value(required, '\0');
+  const auto written = GetEnvironmentVariableA(name, value.data(), required);
+  if (written == 0 || written >= required) {
+    return std::nullopt;
+  }
+  value.resize(written);
+  return value;
+#else
+  if (const char *value = std::getenv(name); value != nullptr) {
+    return std::string(value);
+  }
+  return std::nullopt;
+#endif
+}
+
 provider_selection select_provider(std::string provider) {
   if (provider.empty()) {
-    if (const char *env_provider = std::getenv(ENV_STORAGE_PROVIDER); env_provider != nullptr) {
-      provider = env_provider;
+    if (const auto env_provider = environment_value(ENV_STORAGE_PROVIDER); env_provider.has_value()) {
+      provider = *env_provider;
       return {normalized_provider_name(provider), "env:" + std::string(ENV_STORAGE_PROVIDER)};
     }
     return {PROVIDER_FILE, "default"};

--- a/framework/core/src/libkungfu/src/runtime/storage/provider.cpp
+++ b/framework/core/src/libkungfu/src/runtime/storage/provider.cpp
@@ -658,6 +658,25 @@ std::shared_ptr<storage_provider> provider_cache::acquire(const std::string &run
   return providers_.emplace(key, make_provider(selection.name, runtime_dir)).first->second;
 }
 
+bool provider_cache::release_temporary(const std::string &runtime, const std::string &provider) {
+  const auto selection = select_provider(provider);
+  const auto runtime_dir = absolute_normalized(runtime).string();
+  const auto key = selection.name + "|" + runtime_dir;
+  std::lock_guard<std::mutex> lock(mutex_);
+  const auto it = providers_.find(key);
+  if (it == providers_.end()) {
+    return true;
+  }
+  // Normal runtime handles remain process-cached. One-shot verification
+  // runtimes may be released only after every operation-local owner is gone,
+  // which lets Windows close RocksDB's LOCK before deleting the temp tree.
+  if (it->second.use_count() != 1) {
+    return false;
+  }
+  providers_.erase(it);
+  return true;
+}
+
 storage_provider_cache_view provider_cache::stats() const {
   std::lock_guard<std::mutex> lock(mutex_);
   return {"process", providers_.size(), hits_.load(std::memory_order_relaxed), misses_.load(std::memory_order_relaxed)};

--- a/framework/core/src/libkungfu/src/runtime/storage/service_internal.h
+++ b/framework/core/src/libkungfu/src/runtime/storage/service_internal.h
@@ -60,6 +60,7 @@ class provider_cache {
 public:
   static provider_cache &instance();
   [[nodiscard]] std::shared_ptr<storage_provider> acquire(const std::string &runtime, const std::string &provider);
+  [[nodiscard]] bool release_temporary(const std::string &runtime, const std::string &provider);
   [[nodiscard]] storage_provider_cache_view stats() const;
 
 private:

--- a/framework/core/src/libkungfu/src/runtime/storage/transfer_service.cpp
+++ b/framework/core/src/libkungfu/src/runtime/storage/transfer_service.cpp
@@ -384,15 +384,21 @@ storage_verify_sync_result verify_sync_typed_impl(const storage_verify_sync_requ
     result.imported_fsck =
         default_storage_service().fsck({temp_root.string(), request.provider, request.provider_config_source,
                                         storage_fsck_scope::Source, request.source_id, 0, false});
-    const auto imported_provider = provider_cache::instance().acquire(temp_root.string(), request.provider);
+    auto imported_provider = provider_cache::instance().acquire(temp_root.string(), request.provider);
     const auto imported =
         catalog_store(temp_root.string()).latest_manifest_typed(request.source_id, imported_provider->content_store());
     if (imported.has_value()) {
       result.imported_sync_root = {imported->sync_root.algorithm, imported->sync_root.value};
     }
+    imported_provider.reset();
+    if (!provider_cache::instance().release_temporary(temp_root.string(), request.provider)) {
+      throw std::runtime_error("temporary sync provider still has active operations");
+    }
     fs::remove_all(temp_root);
   } catch (...) {
-    fs::remove_all(temp_root);
+    (void)provider_cache::instance().release_temporary(temp_root.string(), request.provider);
+    std::error_code cleanup_error;
+    fs::remove_all(temp_root, cleanup_error);
     throw;
   }
   result.sync_roots_match = result.local_sync_root.algorithm == result.imported_sync_root.algorithm &&

--- a/framework/core/src/libkungfu/tests/runtime_error_tests.cpp
+++ b/framework/core/src/libkungfu/tests/runtime_error_tests.cpp
@@ -26,7 +26,7 @@ using kungfu::yijinjing::journal::writer;
 
 namespace {
 
-constexpr size_t TEST_PAGE_SIZE = 2 * kungfu::yijinjing::MB;
+constexpr uint64_t TEST_PAGE_SIZE_MB = 2;
 volatile std::sig_atomic_t sigint_count = 0;
 
 void count_sigint(int) { sigint_count = sigint_count + 1; }
@@ -137,7 +137,7 @@ void test_replay_exhaustion_is_typed_and_signal_free() {
   constexpr int32_t missing_carrier = 2002;
 
   {
-    writer fixture(source, location::PUBLIC, publisher, false, journal_bus, TEST_PAGE_SIZE);
+    writer fixture(source, location::PUBLIC, publisher, false, journal_bus, TEST_PAGE_SIZE_MB);
     auto transaction = fixture.reserve_frame(1, available_carrier, 8);
     transaction.commit(8, 2);
   }
@@ -146,7 +146,7 @@ void test_replay_exhaustion_is_typed_and_signal_free() {
   sigint_guard signal_observer;
   bool typed_error_observed = false;
   try {
-    replay_writer replay(source, location::PUBLIC, publisher, journal_bus, TEST_PAGE_SIZE, 0);
+    replay_writer replay(source, location::PUBLIC, publisher, journal_bus, TEST_PAGE_SIZE_MB, 0);
     (void)replay.reserve_frame(3, missing_carrier, 8);
   } catch (const replay_exhausted &error) {
     typed_error_observed = true;

--- a/framework/core/src/libkungfu/tests/state_service_contract_tests.cpp
+++ b/framework/core/src/libkungfu/tests/state_service_contract_tests.cpp
@@ -33,7 +33,7 @@ using kungfu::yijinjing::ownership::lease;
 
 namespace {
 
-constexpr size_t TEST_PAGE_SIZE = 2 * kungfu::yijinjing::MB;
+constexpr uint64_t TEST_PAGE_SIZE_MB = 2;
 
 std::vector<fs::path> &retained_test_roots() {
   static std::vector<fs::path> roots;
@@ -112,10 +112,10 @@ void test_writer_is_fenced_before_a_second_business_write() {
   constexpr uint32_t dest = location::PUBLIC;
 
   {
-    writer first(source, dest, publisher, false, journal_bus, TEST_PAGE_SIZE);
+    writer first(source, dest, publisher, false, journal_bus, TEST_PAGE_SIZE_MB);
     bool refused = false;
     try {
-      writer second(source, dest, publisher, false, journal_bus, TEST_PAGE_SIZE);
+      writer second(source, dest, publisher, false, journal_bus, TEST_PAGE_SIZE_MB);
       auto transaction = second.reserve_frame(1, 1001, 8);
       transaction.commit(8, 2);
     } catch (const busy_error &) {
@@ -124,7 +124,7 @@ void test_writer_is_fenced_before_a_second_business_write() {
     require(refused, "a second writer reached a business write");
   }
 
-  writer reopened(source, dest, publisher, false, journal_bus, TEST_PAGE_SIZE);
+  writer reopened(source, dest, publisher, false, journal_bus, TEST_PAGE_SIZE_MB);
   auto transaction = reopened.reserve_frame(3, 1002, 8);
   transaction.commit(8, 4);
 }

--- a/framework/core/src/libyijinjing/src/util/mmap.cpp
+++ b/framework/core/src/libyijinjing/src/util/mmap.cpp
@@ -114,8 +114,13 @@ native_mapping map_file(const std::string &path, size_t size, mapping_policy pol
     }
     LARGE_INTEGER target{};
     target.QuadPart = static_cast<LONGLONG>(size);
-    if (!SetFilePointerEx(file.get(), target, nullptr, FILE_BEGIN) || !SetEndOfFile(file.get())) {
-      throw_mapping_error("failed to stretch file", path, static_cast<int>(GetLastError()));
+    if (!SetFilePointerEx(file.get(), target, nullptr, FILE_BEGIN)) {
+      throw_mapping_error("failed to seek before stretching file to " + std::to_string(size) + " bytes", path,
+                          static_cast<int>(GetLastError()));
+    }
+    if (!SetEndOfFile(file.get())) {
+      throw_mapping_error("failed to stretch file to " + std::to_string(size) + " bytes", path,
+                          static_cast<int>(GetLastError()));
     }
   }
 

--- a/framework/core/src/libyijinjing/tests/mmap_tests.cpp
+++ b/framework/core/src/libyijinjing/tests/mmap_tests.cpp
@@ -60,7 +60,8 @@ using kungfu::yijinjing::types::page_header;
 
 namespace {
 
-constexpr size_t TEST_PAGE_SIZE = 2 * kungfu::yijinjing::MB;
+constexpr uint64_t TEST_PAGE_SIZE_MB = 2;
+constexpr size_t TEST_PAGE_SIZE = TEST_PAGE_SIZE_MB * kungfu::yijinjing::MB;
 
 class temp_tree {
 public:
@@ -497,7 +498,9 @@ void test_writer_transaction_recovers_from_reservation_and_commit_failures() {
   temp_tree tree;
   auto loc = make_location(tree.root());
   auto bus = make_bus();
-  injectable_writer target(loc, location::PUBLIC, std::make_shared<noop_publisher>(), false, bus, TEST_PAGE_SIZE);
+  injectable_writer target(loc, location::PUBLIC, std::make_shared<noop_publisher>(), false, bus, TEST_PAGE_SIZE_MB);
+  require(target.get_current_page()->get_page_size() == TEST_PAGE_SIZE,
+          "writer fixture interpreted a byte count as mebibytes");
 
   target.throw_on_reserve = true;
   require_throws([&] { (void)target.reserve_frame(1, 1001, 8); }, "injected reservation failure did not escape");
@@ -520,7 +523,7 @@ void test_writer_transaction_aborts_abandonment_and_payload_failure() {
   temp_tree tree;
   auto loc = make_location(tree.root());
   auto bus = make_bus();
-  writer target(loc, location::PUBLIC, std::make_shared<noop_publisher>(), false, bus, TEST_PAGE_SIZE);
+  writer target(loc, location::PUBLIC, std::make_shared<noop_publisher>(), false, bus, TEST_PAGE_SIZE_MB);
 
   uintptr_t abandoned_address = 0;
   {
@@ -549,7 +552,8 @@ void test_writer_transaction_recovers_from_hook_failures() {
   auto loc = make_location(tree.root());
   auto bus = make_bus();
   auto hook = std::make_shared<one_shot_hook>();
-  hookable_writer target(loc, location::PUBLIC, std::make_shared<noop_publisher>(), false, bus, TEST_PAGE_SIZE, hook);
+  hookable_writer target(loc, location::PUBLIC, std::make_shared<noop_publisher>(), false, bus, TEST_PAGE_SIZE_MB,
+                         hook);
 
   hook->throw_on_open = true;
   require_throws([&] { (void)target.reserve_frame(1, 1201, 8); }, "open hook failure did not escape");
@@ -573,7 +577,7 @@ void test_writer_transaction_unlocks_before_publisher_notification() {
   auto loc = make_location(tree.root());
   auto bus = make_bus();
   auto publisher = std::make_shared<one_shot_publisher>();
-  writer target(loc, location::PUBLIC, publisher, false, bus, TEST_PAGE_SIZE);
+  writer target(loc, location::PUBLIC, publisher, false, bus, TEST_PAGE_SIZE_MB);
 
   uintptr_t published_address = 0;
   require_throws(
@@ -644,12 +648,12 @@ void test_reader_management_uses_membership_snapshots() {
   temp_tree tree;
   auto loc = make_location(tree.root());
   auto writer_bus = make_bus();
-  writer seed(loc, location::PUBLIC, std::make_shared<noop_publisher>(), false, writer_bus, TEST_PAGE_SIZE);
+  writer seed(loc, location::PUBLIC, std::make_shared<noop_publisher>(), false, writer_bus, TEST_PAGE_SIZE_MB);
   seed.mark(1, 1601);
 
   auto management_bus = std::make_shared<kungfu::yijinjing::journal::bus>(true);
   reader target(reader_policy::peer(), true, management_bus);
-  target.join(loc, location::PUBLIC, 0, TEST_PAGE_SIZE);
+  target.join(loc, location::PUBLIC, 0, TEST_PAGE_SIZE_MB);
   const auto retained_snapshot = target.get_journals();
   require(retained_snapshot.size() == 1, "reader snapshot omitted joined journal");
 
@@ -668,7 +672,7 @@ void test_reader_management_uses_membership_snapshots() {
 
   for (int i = 0; i < 50; ++i) {
     target.disjoin_channel(loc, location::PUBLIC);
-    target.join(loc, location::PUBLIC, 0, TEST_PAGE_SIZE);
+    target.join(loc, location::PUBLIC, 0, TEST_PAGE_SIZE_MB);
   }
   manager.join();
   if (management_error) {

--- a/framework/core/tests/storage-node-binding.test.js
+++ b/framework/core/tests/storage-node-binding.test.js
@@ -196,6 +196,24 @@ function withStorageProvider(provider, fn) {
   }
 }
 
+function removeRuntimeDir(runtimeDir, provider) {
+  try {
+    fs.rmSync(runtimeDir, { recursive: true, force: true });
+  } catch (error) {
+    const expectedLockedDatabase =
+      process.platform === 'win32' &&
+      provider === 'rocksdb' &&
+      error?.code === 'EBUSY' &&
+      path.basename(error.path || '') === 'LOCK';
+    if (!expectedLockedDatabase) {
+      throw error;
+    }
+    // The RocksDB provider is deliberately process-cached. Windows refuses
+    // to unlink its live LOCK file, unlike POSIX, so the process temp area
+    // owns cleanup after this test process exits.
+  }
+}
+
 test(
   'Node KFX registry projection returns the Core canonical plan root',
   {
@@ -728,7 +746,7 @@ for (const providerCase of providerCases) {
             true,
           );
         } finally {
-          fs.rmSync(runtimeDir, { recursive: true, force: true });
+          removeRuntimeDir(runtimeDir, providerCase.env);
         }
       }),
   );
@@ -1112,7 +1130,7 @@ for (const provider of ['content-addressed-file', 'rocksdb']) {
           assert.equal(rejected.ok, false);
           assert.equal(rejected.error, 'hash_mismatch');
         } finally {
-          fs.rmSync(runtimeDir, { recursive: true, force: true });
+          removeRuntimeDir(runtimeDir, provider);
         }
       }),
   );

--- a/framework/core/tests/storage-node-binding.test.js
+++ b/framework/core/tests/storage-node-binding.test.js
@@ -563,7 +563,6 @@ print(json.dumps(node_safe(out), sort_keys=True, separators=(",", ":")))
       cwd: coreDir,
       encoding: 'utf8',
       env: runtimeEnv(),
-      shell: process.platform === 'win32',
     },
   );
   assert.equal(

--- a/framework/core/tests/storage-node-binding.test.js
+++ b/framework/core/tests/storage-node-binding.test.js
@@ -574,9 +574,11 @@ def node_safe(value):
 
 print(json.dumps(node_safe(out), sort_keys=True, separators=(",", ":")))
 `;
+  const scriptPath = path.join(runtimeDir, 'storage-node-shim.py');
+  fs.writeFileSync(scriptPath, script, 'utf8');
   const result = spawnSync(
     'uv',
-    ['run', '--frozen', 'python', '-c', script, coreDir, runtimeDir],
+    ['run', '--frozen', 'python', scriptPath, coreDir, runtimeDir],
     {
       cwd: coreDir,
       encoding: 'utf8',

--- a/scripts/shifu-cache-runtime.mjs
+++ b/scripts/shifu-cache-runtime.mjs
@@ -887,6 +887,15 @@ process.exit(result.status ?? 1);
 `;
 }
 
+function originalToolPath(baseEnv, originalPathKey) {
+  const candidate = baseEnv.PATH || '';
+  const inherited = baseEnv[originalPathKey] || '';
+  const unchangedFromCaller =
+    candidate === (process.env.PATH || '') &&
+    inherited === (process.env[originalPathKey] || '');
+  return unchangedFromCaller && inherited ? inherited : candidate;
+}
+
 function prepareConfigOverlays(configBindings, baseEnv, scope, cwd) {
   if (configBindings.length === 0) return { env: {}, root: '', cleanup() {} };
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'shifu-cache-overlay-'));
@@ -926,8 +935,10 @@ function prepareConfigOverlays(configBindings, baseEnv, scope, cwd) {
           '@node "%~dp0cargo-wrapper.mjs" %*\r\n',
           { mode: 0o600 },
         );
-        const originalPath =
-          baseEnv.SHIFU_CARGO_ORIGINAL_PATH || baseEnv.PATH || '';
+        const originalPath = originalToolPath(
+          baseEnv,
+          'SHIFU_CARGO_ORIGINAL_PATH',
+        );
         overlayEnv.SHIFU_CARGO_ORIGINAL_PATH = originalPath;
         overlayEnv.SHIFU_CARGO_SOURCE_NAME = binding.name;
         overlayEnv.SHIFU_CARGO_REGISTRY = binding.value;
@@ -980,8 +991,10 @@ function prepareConfigOverlays(configBindings, baseEnv, scope, cwd) {
           '@node "%~dp0conan-wrapper.mjs" %*\r\n',
           { mode: 0o600 },
         );
-        overlayEnv.SHIFU_CONAN_ORIGINAL_PATH =
-          baseEnv.SHIFU_CONAN_ORIGINAL_PATH || baseEnv.PATH || '';
+        overlayEnv.SHIFU_CONAN_ORIGINAL_PATH = originalToolPath(
+          baseEnv,
+          'SHIFU_CONAN_ORIGINAL_PATH',
+        );
         overlayEnv.SHIFU_CONAN_STORAGE_ROOT = storageRoot;
         fs.writeFileSync(
           path.join(conanHome, 'global.conf'),

--- a/scripts/shifu-cache-runtime.test.mjs
+++ b/scripts/shifu-cache-runtime.test.mjs
@@ -881,6 +881,8 @@ process.exit(status);
     env: {
       ...process.env,
       PATH: originalPath,
+      SHIFU_CARGO_ORIGINAL_PATH: 'stale-outer-cargo-path',
+      SHIFU_CONAN_ORIGINAL_PATH: 'stale-outer-conan-path',
       XDG_CACHE_HOME: path.join(directory, 'cache'),
     },
   });


### PR DESCRIPTION
## Summary

Close the final Core architecture acceptance gaps discovered while qualifying the remediated target boundaries on macOS, Linux, and Windows at the same code SHA.

## Related issue

None.

## Changes

- preserve explicit Cargo, Conan, CMake, and Ninja path overrides across nested Shifu cache/apply invocations
- distinguish Windows mmap resize failures with actionable operating-system diagnostics
- keep journal test page-size inputs in megabytes instead of accidentally requesting multi-terabyte sparse mappings
- make Node storage binding parity tests portable across Windows environment and Python command-line semantics
- tolerate process-cached RocksDB test locks only at the cleanup boundary they actually affect
- release temporary storage providers before sync-verification cleanup without weakening process-lived runtime caches
- project the completed cross-platform qualification into ADR-0049

## Verification

Qualified code SHA: `0803574a7e68c715ad856550df0d386c8cac3f89`

- macOS Apple Clang: Core build; CTest 12/12; Node binding 13/13
- agent-120 Linux GNU: Core build; CTest 12/12; Node binding 13/13
- DARKHERO Windows MSVC: Core build; CTest 12/12; Node binding 13/13
- `./shifu check`
- `./shifu check:source`
- architecture layer checker and self-test (14 fixtures)
- first-party target ownership projection (208 C/C++ sources, single ownership)
- navigation route, storage source budget, docs, and ADR structural audits
- ADR-0066 production modules remain `hold`; no production module was enabled

## Failure modes prevented

- nested cache layers silently reverting explicit tool paths to deleted temporary overlays
- POSIX sparse mappings hiding a megabytes-versus-bytes test contract error that fails on Windows
- Windows Python inline-command parsing and environment lookup diverging from POSIX
- deleting a verification directory while its temporary RocksDB provider still holds a live lock

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "implemented",
  "adrs": ["ADR-0049"],
  "summary": "Qualify the remediated Core architecture boundaries on macOS, Linux, and Windows and fix only the portability and lifetime gaps exposed by exact-code-SHA acceptance.",
  "verification": ["./shifu check", "three-platform Core build", "CTest 12/12 on each platform", "Node binding 13/13 on each platform", "14 architecture fixtures"]
}
-->

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] release evidence, provenance, package publishing, or deployment surfaces
- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed
