### PR TITLE
diag(qualification): retain native peer failure details

### DIFF
--- a/framework/core/tests/qualification/live-peer-continuity/native_campaign.py
+++ b/framework/core/tests/qualification/live-peer-continuity/native_campaign.py
@@ -345,9 +345,13 @@ def _run_campaign(output_dir: Path, temp_parent: Path | None = None) -> int:
             final = _wait_for_markers(marker_path, 3)
             _write_authority(capsule_command_path, "8", "1")
             capsule_final = _wait_for_markers(capsule_marker_path, 3)
-            if peer.poll() is not None or {item["pid"] for item in final} != {peer_pid}:
+            peer_return_code = peer.poll()
+            ready_pids = sorted({item["pid"] for item in final})
+            if peer_return_code is not None or ready_pids != [peer_pid]:
                 raise RuntimeError(
-                    "runtime generation replacement restarted the Peer workload"
+                    "runtime generation replacement did not preserve the Peer workload: "
+                    f"peer_pid={peer_pid} ready_pids={ready_pids} "
+                    f"peer_return_code={peer_return_code}"
                 )
             if [len(first), len(second), len(final)] != [1, 2, 3]:
                 raise RuntimeError("unexpected Peer readiness sequence")

--- a/framework/core/tests/qualification/live-peer-continuity/run.mjs
+++ b/framework/core/tests/qualification/live-peer-continuity/run.mjs
@@ -160,6 +160,14 @@ function runSuite(suite, outputDir) {
     const detail =
       campaign?.error || result.error?.message || 'campaign report unavailable';
     console.error(`[live-peer-continuity] native-campaign-error=${detail}`);
+    const peerTail = boundedDiagnosticTail(
+      path.join(outputDir, 'native-campaign', 'peer.log'),
+    );
+    if (peerTail) {
+      console.error(
+        `[live-peer-continuity] peer-log-tail-start\n${peerTail}\n[live-peer-continuity] peer-log-tail-end`,
+      );
+    }
   }
   console.log(
     `[live-peer-continuity] suite=${suite.id} status=${passed ? 'passed' : 'failed'} duration_ms=${Date.now() - started}`,
@@ -233,6 +241,23 @@ function nativeCampaignReport(outputDir) {
   } catch {
     return null;
   }
+}
+
+export function boundedDiagnosticTail(
+  logPath,
+  { maxBytes = 16 * 1024, maxLines = 40 } = {},
+) {
+  if (!fs.existsSync(logPath)) return null;
+  const content = fs.readFileSync(logPath);
+  const tail = content.subarray(Math.max(0, content.length - maxBytes));
+  return tail
+    .toString('utf8')
+    .replaceAll('\r\n', '\n')
+    .trimEnd()
+    .split('\n')
+    .slice(-maxLines)
+    .join('\n')
+    .trimStart();
 }
 
 export function evaluateQualification({

--- a/framework/core/tests/qualification/live-peer-continuity/run.test.mjs
+++ b/framework/core/tests/qualification/live-peer-continuity/run.test.mjs
@@ -8,6 +8,7 @@ import { test } from 'node:test';
 import { gunzipSync } from 'node:zlib';
 
 import {
+  boundedDiagnosticTail,
   campaignTempParent,
   createLogBundle,
   defaultOutputDir,
@@ -102,6 +103,21 @@ test('native campaign uses a short platform-owned temp root', () => {
     windows.command[windows.command.indexOf('--temp-parent') + 1],
     null,
   );
+});
+
+test('native campaign failure diagnostics retain only a bounded log tail', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'peer-log-tail-'));
+  const log = path.join(root, 'peer.log');
+  try {
+    fs.writeFileSync(log, 'first\r\nsecond\r\nthird\r\nfourth\r\n');
+    assert.equal(
+      boundedDiagnosticTail(log, { maxBytes: 1024, maxLines: 2 }),
+      'third\nfourth',
+    );
+    assert.equal(boundedDiagnosticTail(path.join(root, 'missing.log')), null);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
 });
 
 test('clean complete evidence qualifies only the bounded single-host claim', () => {


### PR DESCRIPTION
## Summary

- preserve fail-closed native peer continuity while reporting the exact peer PID set and return code
- emit only a bounded 40-line / 16 KiB tail from the test-owned peer log when the native campaign fails
- make the next hosted Windows failure actionable without retaining credentials or weakening any release claim

## Evidence

- `node --test framework/core/tests/qualification/live-peer-continuity/run.test.mjs` (8/8)
- Python compile check with external pycache
- `SHIFU_CACHE_BYPASS=source-acceptance ./shifu check:source` (exit 0; 325 source contracts, 76 runtime tests, 69 Desktop tests)
- staged DCO, docs, catalog, TypeScript, Biome, Ruff format and Ruff lint checks passed
- hosted diagnosis: exact-source run 29398665421 passed Windows packaging, NSIS, CLI smoke, 42/42 build verification and three 90-second fuzz legs, then failed the native cross-process restart assertion without retaining its peer child log

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Improves fail-closed hosted qualification diagnostics without changing architecture or release claims."
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

This PR prints only a bounded tail from a disposable qualification-owned peer log; it does not publish or deploy artifacts.

## Checklist

- [x] Commit is signed off (DCO)
- [x] Source acceptance is green
- [x] No credentials or generated qualification evidence are committed
