### PR TITLE
feat(kfx): add KFD-aware admission assessment

### DIFF
--- a/.buildchain/kfd/kfd-1/contract-world.witness.json
+++ b/.buildchain/kfd/kfd-1/contract-world.witness.json
@@ -35,7 +35,7 @@
   "sourceVerificationRequired": false,
   "canonicalPolicy": {
     "path": "framework/contract/kungfu-agent-first-canonical-policy.json",
-    "sha256": "cdbcff0b4ff23c0d5a60345d45a0f825507d72dd2a370b74e40ca61ce11b3743"
+    "sha256": "277b0afc14c06af13763e1ea305a6a05c22c1ca6d3efd18bcbd61c1f1abf15de"
   },
   "registry": {
     "path": "framework/contract/kungfu-contracts.registry.json",
@@ -53,9 +53,9 @@
     {
       "name": "kungfu-kfx",
       "sourcePath": "framework/kfx/kungfu-kfx.contract.json",
-      "sourceSha256": "c118da92cf60fcf01861c8b8f75a3b757fae32faa0184f4f999e0e9e7cd60c80",
+      "sourceSha256": "711566698a256127d938918698a1ff1312bf1238007b40c54724a7ba066ee34b",
       "artifactPath": "config/kungfu-kfx.contract.json",
-      "expectedSha256": "c118da92cf60fcf01861c8b8f75a3b757fae32faa0184f4f999e0e9e7cd60c80",
+      "expectedSha256": "711566698a256127d938918698a1ff1312bf1238007b40c54724a7ba066ee34b",
       "byteForByte": true
     },
     {

--- a/.buildchain/kfd/kfd-1/release-gate.json
+++ b/.buildchain/kfd/kfd-1/release-gate.json
@@ -54,13 +54,13 @@
       "standard": "KFD-1",
       "standardKey": "kfd-1",
       "result": "passed",
-      "preBuildWitnessSha256": "bb671dd22762940098839f505ef661e689986a6d66fa7ba1780518e25e56cfc1",
+      "preBuildWitnessSha256": "f699dad4b5a13819c61140cb837c12aa1d5666a3a47f2b3710c808a90125062a",
       "sourceHashes": {
-        "sha256": "d30fd52f1de1fc0d8915912aaf2bb5f4f82dc24285701b5f5702b289a54791bd",
+        "sha256": "1951d291b5f6f0bf8716d0cd858c102d7317bdbea1e57c137f08c36f28bdaf69",
         "surfaceCount": 6
       },
       "artifactHashes": {
-        "sha256": "68045a9d4dbf208b98382fb869d94a3dd0926df098023e16904c600568598ee6",
+        "sha256": "d0534917726ac83ca6095758a35966cb1f86fa3932ba940447439b63ac1d9015",
         "surfaceCount": 6
       },
       "witness": {
@@ -100,7 +100,7 @@
         "sourceVerificationRequired": true,
         "canonicalPolicy": {
           "path": "framework/contract/kungfu-agent-first-canonical-policy.json",
-          "sha256": "cdbcff0b4ff23c0d5a60345d45a0f825507d72dd2a370b74e40ca61ce11b3743"
+          "sha256": "277b0afc14c06af13763e1ea305a6a05c22c1ca6d3efd18bcbd61c1f1abf15de"
         },
         "registry": {
           "path": "framework/contract/kungfu-contracts.registry.json",
@@ -118,9 +118,9 @@
           {
             "name": "kungfu-kfx",
             "sourcePath": "framework/kfx/kungfu-kfx.contract.json",
-            "sourceSha256": "c118da92cf60fcf01861c8b8f75a3b757fae32faa0184f4f999e0e9e7cd60c80",
+            "sourceSha256": "711566698a256127d938918698a1ff1312bf1238007b40c54724a7ba066ee34b",
             "artifactPath": "config/kungfu-kfx.contract.json",
-            "expectedSha256": "c118da92cf60fcf01861c8b8f75a3b757fae32faa0184f4f999e0e9e7cd60c80",
+            "expectedSha256": "711566698a256127d938918698a1ff1312bf1238007b40c54724a7ba066ee34b",
             "byteForByte": true
           },
           {
@@ -209,8 +209,8 @@
           {
             "name": "kungfu-kfx",
             "sourcePath": "framework/kfx/kungfu-kfx.contract.json",
-            "expectedSha256": "c118da92cf60fcf01861c8b8f75a3b757fae32faa0184f4f999e0e9e7cd60c80",
-            "actualSha256": "c118da92cf60fcf01861c8b8f75a3b757fae32faa0184f4f999e0e9e7cd60c80",
+            "expectedSha256": "711566698a256127d938918698a1ff1312bf1238007b40c54724a7ba066ee34b",
+            "actualSha256": "711566698a256127d938918698a1ff1312bf1238007b40c54724a7ba066ee34b",
             "status": "passed",
             "reason": ""
           },
@@ -266,10 +266,10 @@
           {
             "name": "kungfu-kfx",
             "sourcePath": "framework/kfx/kungfu-kfx.contract.json",
-            "sourceSha256": "c118da92cf60fcf01861c8b8f75a3b757fae32faa0184f4f999e0e9e7cd60c80",
+            "sourceSha256": "711566698a256127d938918698a1ff1312bf1238007b40c54724a7ba066ee34b",
             "artifactPath": "config/kungfu-kfx.contract.json",
-            "expectedSha256": "c118da92cf60fcf01861c8b8f75a3b757fae32faa0184f4f999e0e9e7cd60c80",
-            "actualSha256": "c118da92cf60fcf01861c8b8f75a3b757fae32faa0184f4f999e0e9e7cd60c80",
+            "expectedSha256": "711566698a256127d938918698a1ff1312bf1238007b40c54724a7ba066ee34b",
+            "actualSha256": "711566698a256127d938918698a1ff1312bf1238007b40c54724a7ba066ee34b",
             "byteForByte": true,
             "status": "passed",
             "reason": ""

--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -6,7 +6,7 @@
   "supportLevel": "release",
   "source": {
     "cwd": "/Users/dkr/Worktrees/kungfu/feature/2026-07-15-kungfu-kfx-kfd-buildchain-admission",
-    "sourceSha": "9dbeb2bd025fdf8479c7eb4a2c7c7ce7573a4ce4",
+    "sourceSha": "9d73db6103e19c99daaa5a5fd7957a523267b8ff",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
     "registryDigest": "sha256:46fa6e6d8e6cabe4e89ed1f13dfb20382fdde55185db35a2d479c471ac077831"
   },

--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -5,8 +5,8 @@
   "witnessKind": "prebuild",
   "supportLevel": "release",
   "source": {
-    "cwd": "/Users/dkr/Worktrees/kungfu/fix/refresh-kfd-release-evidence-eb05604c9",
-    "sourceSha": "eb05604c9db6811c7fbe48f881a9387862ea831c",
+    "cwd": "/Users/dkr/Worktrees/kungfu/feature/2026-07-15-kungfu-kfx-kfd-buildchain-admission",
+    "sourceSha": "9dbeb2bd025fdf8479c7eb4a2c7c7ce7573a4ce4",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
     "registryDigest": "sha256:46fa6e6d8e6cabe4e89ed1f13dfb20382fdde55185db35a2d479c471ac077831"
   },

--- a/developer/sdk/kfd/kfd-1/contract-world.witness.json
+++ b/developer/sdk/kfd/kfd-1/contract-world.witness.json
@@ -35,7 +35,7 @@
   "sourceVerificationRequired": false,
   "canonicalPolicy": {
     "path": "framework/contract/kungfu-agent-first-canonical-policy.json",
-    "sha256": "cdbcff0b4ff23c0d5a60345d45a0f825507d72dd2a370b74e40ca61ce11b3743"
+    "sha256": "277b0afc14c06af13763e1ea305a6a05c22c1ca6d3efd18bcbd61c1f1abf15de"
   },
   "registry": {
     "path": "framework/contract/kungfu-contracts.registry.json",
@@ -53,9 +53,9 @@
     {
       "name": "kungfu-kfx",
       "sourcePath": "framework/kfx/kungfu-kfx.contract.json",
-      "sourceSha256": "c118da92cf60fcf01861c8b8f75a3b757fae32faa0184f4f999e0e9e7cd60c80",
+      "sourceSha256": "711566698a256127d938918698a1ff1312bf1238007b40c54724a7ba066ee34b",
       "artifactPath": "config/kungfu-kfx.contract.json",
-      "expectedSha256": "c118da92cf60fcf01861c8b8f75a3b757fae32faa0184f4f999e0e9e7cd60c80",
+      "expectedSha256": "711566698a256127d938918698a1ff1312bf1238007b40c54724a7ba066ee34b",
       "byteForByte": true
     },
     {

--- a/developer/sdk/kfd/kfd-1/release-gate.json
+++ b/developer/sdk/kfd/kfd-1/release-gate.json
@@ -54,13 +54,13 @@
       "standard": "KFD-1",
       "standardKey": "kfd-1",
       "result": "passed",
-      "preBuildWitnessSha256": "bb671dd22762940098839f505ef661e689986a6d66fa7ba1780518e25e56cfc1",
+      "preBuildWitnessSha256": "f699dad4b5a13819c61140cb837c12aa1d5666a3a47f2b3710c808a90125062a",
       "sourceHashes": {
-        "sha256": "d30fd52f1de1fc0d8915912aaf2bb5f4f82dc24285701b5f5702b289a54791bd",
+        "sha256": "1951d291b5f6f0bf8716d0cd858c102d7317bdbea1e57c137f08c36f28bdaf69",
         "surfaceCount": 6
       },
       "artifactHashes": {
-        "sha256": "68045a9d4dbf208b98382fb869d94a3dd0926df098023e16904c600568598ee6",
+        "sha256": "d0534917726ac83ca6095758a35966cb1f86fa3932ba940447439b63ac1d9015",
         "surfaceCount": 6
       },
       "witness": {
@@ -100,7 +100,7 @@
         "sourceVerificationRequired": true,
         "canonicalPolicy": {
           "path": "framework/contract/kungfu-agent-first-canonical-policy.json",
-          "sha256": "cdbcff0b4ff23c0d5a60345d45a0f825507d72dd2a370b74e40ca61ce11b3743"
+          "sha256": "277b0afc14c06af13763e1ea305a6a05c22c1ca6d3efd18bcbd61c1f1abf15de"
         },
         "registry": {
           "path": "framework/contract/kungfu-contracts.registry.json",
@@ -118,9 +118,9 @@
           {
             "name": "kungfu-kfx",
             "sourcePath": "framework/kfx/kungfu-kfx.contract.json",
-            "sourceSha256": "c118da92cf60fcf01861c8b8f75a3b757fae32faa0184f4f999e0e9e7cd60c80",
+            "sourceSha256": "711566698a256127d938918698a1ff1312bf1238007b40c54724a7ba066ee34b",
             "artifactPath": "config/kungfu-kfx.contract.json",
-            "expectedSha256": "c118da92cf60fcf01861c8b8f75a3b757fae32faa0184f4f999e0e9e7cd60c80",
+            "expectedSha256": "711566698a256127d938918698a1ff1312bf1238007b40c54724a7ba066ee34b",
             "byteForByte": true
           },
           {
@@ -209,8 +209,8 @@
           {
             "name": "kungfu-kfx",
             "sourcePath": "framework/kfx/kungfu-kfx.contract.json",
-            "expectedSha256": "c118da92cf60fcf01861c8b8f75a3b757fae32faa0184f4f999e0e9e7cd60c80",
-            "actualSha256": "c118da92cf60fcf01861c8b8f75a3b757fae32faa0184f4f999e0e9e7cd60c80",
+            "expectedSha256": "711566698a256127d938918698a1ff1312bf1238007b40c54724a7ba066ee34b",
+            "actualSha256": "711566698a256127d938918698a1ff1312bf1238007b40c54724a7ba066ee34b",
             "status": "passed",
             "reason": ""
           },
@@ -266,10 +266,10 @@
           {
             "name": "kungfu-kfx",
             "sourcePath": "framework/kfx/kungfu-kfx.contract.json",
-            "sourceSha256": "c118da92cf60fcf01861c8b8f75a3b757fae32faa0184f4f999e0e9e7cd60c80",
+            "sourceSha256": "711566698a256127d938918698a1ff1312bf1238007b40c54724a7ba066ee34b",
             "artifactPath": "config/kungfu-kfx.contract.json",
-            "expectedSha256": "c118da92cf60fcf01861c8b8f75a3b757fae32faa0184f4f999e0e9e7cd60c80",
-            "actualSha256": "c118da92cf60fcf01861c8b8f75a3b757fae32faa0184f4f999e0e9e7cd60c80",
+            "expectedSha256": "711566698a256127d938918698a1ff1312bf1238007b40c54724a7ba066ee34b",
+            "actualSha256": "711566698a256127d938918698a1ff1312bf1238007b40c54724a7ba066ee34b",
             "byteForByte": true,
             "status": "passed",
             "reason": ""

--- a/docs/adr/ADR-0090-kfd-aware-kfx-trust-and-buildchain-admission.md
+++ b/docs/adr/ADR-0090-kfd-aware-kfx-trust-and-buildchain-admission.md
@@ -4,7 +4,7 @@ doc_type: architecture-decision
 adr_id: ADR-0090
 decision_status: accepted
 implementation_status: partial
-implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/571, https://github.com/kungfu-systems/kungfu/pull/568, https://github.com/kungfu-systems/kungfu/pull/731, https://github.com/kungfu-systems/kungfu/pull/734, https://github.com/kungfu-systems/kungfu/pull/906, https://github.com/kungfu-systems/kungfu/pull/922]
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/571, https://github.com/kungfu-systems/kungfu/pull/568, https://github.com/kungfu-systems/kungfu/pull/731, https://github.com/kungfu-systems/kungfu/pull/734, https://github.com/kungfu-systems/kungfu/pull/906, https://github.com/kungfu-systems/kungfu/pull/922, https://github.com/kungfu-systems/kungfu/pull/942]
 review_state: self-reviewed
 sensitivity: public
 sources: [local-files, user-decision]
@@ -62,6 +62,34 @@ declared trust-input roots into deterministic native plans, and proves that a
 Product role cannot elevate an untrusted runtime tier. It still does not verify
 Buildchain attestations, produce a KFD-2 TrustReport, authorize capabilities,
 or grant Product System authority.
+
+The current native admission slice adds a read-only Core `assess` operation. It
+consumes the exact `kungfu-buildchain-artifact-verification` v1 result plus
+independently supplied, schema-closed trust inputs and policy; checks package,
+source, dependency, build-plan, toolchain, artifact, qualification, verifier,
+issuer, publisher, contract, expiry, revocation, and ADR-0052 qualification
+bindings; and
+returns one deterministic `kungfu.kfx-trust-report/v1` and
+`kungfu.kfx-admission-plan/v1`. The report binds the registry snapshot and all
+dependency roots. The plan binds the report root and defines the root a future
+mutation receipt must consume. Python CLI and the public Node/API Storage
+capability shared by GUI, TUI, KFX, and Agent consumers project the same Core
+result without re-evaluating trust; this slice does not add a presentation-owned
+badge or trust override.
+
+KFD qualification is not accepted from an attestation's self-reported claim
+list. The slice requires an existing fresh, purpose-bound ADR-0052 assessment;
+its assessment key, report hash, query proof, contract world, policy, and fact
+surface roots become report dependencies, and its report hash must equal the
+declared qualification root. KFX therefore projects operation admission from
+the durable KFD lifecycle rather than creating a competing evaluator.
+
+Implementation remains partial at this stage: Core validates a supplied pinned
+verifier result but does not execute or authenticate the Buildchain verifier;
+`assess` does not install, activate, mutate Profile state, or persist the full
+ADR-0052 Assessment Episode lifecycle. Those later mutation paths must consume
+the exact report, plan, package, and dependency roots frozen here rather than
+creating a second KFD evaluator.
 
 ## Decision
 

--- a/framework/api/src/capability/storage.ts
+++ b/framework/api/src/capability/storage.ts
@@ -75,7 +75,7 @@ export type Storage = {
     document: StorageValue,
   ) => StorageValue;
   kfxRegistry: (
-    action: 'list' | 'inspect' | 'resolve' | 'plan' | 'status',
+    action: 'list' | 'inspect' | 'resolve' | 'plan' | 'status' | 'assess',
     request: StorageValue,
   ) => StorageValue;
   factLibraryContract: () => StorageValue;

--- a/framework/api/tests/storage.test.ts
+++ b/framework/api/tests/storage.test.ts
@@ -32,6 +32,13 @@ test('native KFX helpers are transport-only storage edge calls', () => {
     roots: [{ kind: 'workspace', path: '/workspace/extensions' }],
   };
   assert.deepEqual(storage.kfxRegistry('plan', registryRequest), { ok: true });
+  assert.deepEqual(
+    storage.kfxRegistry('assess', {
+      ...registryRequest,
+      packageKey: 'example',
+    }),
+    { ok: true },
+  );
   assert.deepEqual(calls, [
     ['kfx_runtime', '/runtime', { action: 'contract' }],
     [
@@ -40,5 +47,13 @@ test('native KFX helpers are transport-only storage edge calls', () => {
       { action: 'validate', kind: 'request', document },
     ],
     ['kfx_runtime', '/runtime', { action: 'plan', request: registryRequest }],
+    [
+      'kfx_runtime',
+      '/runtime',
+      {
+        action: 'assess',
+        request: { ...registryRequest, packageKey: 'example' },
+      },
+    ],
   ]);
 });

--- a/framework/contract/kungfu-agent-first-canonical-policy.json
+++ b/framework/contract/kungfu-agent-first-canonical-policy.json
@@ -129,13 +129,13 @@
       },
       "source": {
         "path": "framework/kfx/kungfu-kfx.contract.json",
-        "sha256": "sha256:c118da92cf60fcf01861c8b8f75a3b757fae32faa0184f4f999e0e9e7cd60c80",
-        "renderedSha256": "sha256:c118da92cf60fcf01861c8b8f75a3b757fae32faa0184f4f999e0e9e7cd60c80",
+        "sha256": "sha256:711566698a256127d938918698a1ff1312bf1238007b40c54724a7ba066ee34b",
+        "renderedSha256": "sha256:711566698a256127d938918698a1ff1312bf1238007b40c54724a7ba066ee34b",
         "byteForByte": true
       },
       "artifact": {
         "path": "config/kungfu-kfx.contract.json",
-        "expectedSha256": "sha256:c118da92cf60fcf01861c8b8f75a3b757fae32faa0184f4f999e0e9e7cd60c80"
+        "expectedSha256": "sha256:711566698a256127d938918698a1ff1312bf1238007b40c54724a7ba066ee34b"
       }
     },
     {

--- a/framework/core/src/libkungfu/src/runtime/kfx/native_registry.cpp
+++ b/framework/core/src/libkungfu/src/runtime/kfx/native_registry.cpp
@@ -83,6 +83,20 @@ std::vector<std::string> string_array_or_empty(const json &value, const char *fi
   return result;
 }
 
+void require_exact_fields(const json &value, const std::set<std::string> &fields, const std::string &label) {
+  if (!value.is_object())
+    refuse("KF_KFX_SCHEMA_INVALID", label + " must be an object");
+  for (const auto &field : fields) {
+    if (!value.contains(field))
+      refuse("KF_KFX_SCHEMA_INVALID", label + " is missing required field " + field);
+  }
+  for (const auto &[field, ignored] : value.items()) {
+    (void)ignored;
+    if (!fields.contains(field))
+      refuse("KF_KFX_SCHEMA_INVALID", label + " contains unknown field " + field);
+  }
+}
+
 bool ignored_part(const fs::path &part) {
   static const std::set<std::string> ignored = {".git", "node_modules", "__pycache__", ".DS_Store"};
   return ignored.contains(part.string());
@@ -495,10 +509,324 @@ json public_package(json package) {
   return package;
 }
 
+bool contains_text(const json &values, const std::string &expected) {
+  return values.is_array() && std::any_of(values.begin(), values.end(),
+                                          [&](const auto &value) { return value.is_string() && value == expected; });
+}
+
+bool is_content_root(const std::string &value) {
+  return value.size() == 71 && value.starts_with("sha256:") &&
+         std::all_of(value.begin() + 7, value.end(),
+                     [](unsigned char ch) { return std::isdigit(ch) != 0 || (ch >= 'a' && ch <= 'f'); });
+}
+
+json assess_package(const json &package, const std::string &registry_root, const json &request) {
+  const auto operation = required_text(request, "operation", "request");
+  const auto purpose = required_text(request, "purpose", "request");
+  const auto cut = required_text(request, "cut", "request");
+  static const std::set<std::string> operations = {
+      "inspect", "install", "update", "enable", "activate", "host-placement", "capability", "migration", "system-role"};
+  validate_enum(operation, operations, "admission operation");
+
+  const auto policy = object_or_empty(request, "policy");
+  if (policy.empty() || policy.value("schema", "") != "kungfu.kfx-admission-policy/v1")
+    refuse("KF_KFX_SCHEMA_INVALID", "assessment requires kungfu.kfx-admission-policy/v1");
+  require_exact_fields(policy,
+                       {"schema", "allowedIssuers", "allowedPublishers", "allowedContracts", "allowedVerifierRoots",
+                        "autoOperations", "highConsequenceCapabilities", "systemCapabilities", "productSystemRoots",
+                        "residualRisk"},
+                       "admission policy");
+  if (!request.contains("assessmentTime") || !request.at("assessmentTime").is_number_integer())
+    refuse("KF_KFX_SCHEMA_INVALID", "assessmentTime must be a non-negative integer");
+  const auto assessment_time = request.at("assessmentTime").get<int64_t>();
+  if (assessment_time < 0)
+    refuse("KF_KFX_SCHEMA_INVALID", "assessmentTime must be a non-negative integer");
+  const auto allowed_issuers = string_array_or_empty(policy, "allowedIssuers");
+  const auto allowed_publishers = string_array_or_empty(policy, "allowedPublishers");
+  const auto allowed_contracts = string_array_or_empty(policy, "allowedContracts");
+  const auto allowed_verifier_roots = string_array_or_empty(policy, "allowedVerifierRoots");
+  (void)string_array_or_empty(policy, "autoOperations");
+  (void)string_array_or_empty(policy, "highConsequenceCapabilities");
+  (void)string_array_or_empty(policy, "systemCapabilities");
+  (void)string_array_or_empty(policy, "productSystemRoots");
+  const auto residual_risk = string_array_or_empty(policy, "residualRisk");
+  if (allowed_issuers.empty() || allowed_publishers.empty() || allowed_contracts.empty() ||
+      allowed_verifier_roots.empty())
+    refuse("KF_KFX_SCHEMA_INVALID",
+           "admission policy requires non-empty issuer, publisher, contract, and verifier allowlists");
+
+  json reasons = json::array();
+  json evidence_dependencies = json::array();
+  json trust_input = json::object();
+  json kfd_assessment_key = nullptr;
+  json kfd_report_root = nullptr;
+  std::string supply_chain_grade = "unverified";
+  const auto package_root = package.at("packageRoot").get<std::string>();
+  const auto attestation = object_or_empty(request, "attestation");
+  const auto identity = object_or_empty(request, "identity");
+  if (!attestation.empty() && !identity.empty())
+    refuse("KF_KFX_SCHEMA_INVALID", "assessment must choose attestation or identity evidence, not both");
+  if (attestation.empty() && (request.contains("trustInputs") || request.contains("kfdAssessment")))
+    refuse("KF_KFX_SCHEMA_INVALID", "trust inputs and KFD assessment require Buildchain attestation evidence");
+  if (!attestation.empty()) {
+    trust_input = object_or_empty(request, "trustInputs");
+    if (trust_input.empty() || trust_input.value("schema", "") != "kungfu.kfx-trust-inputs/v1")
+      refuse("KF_KFX_SCHEMA_INVALID", "Buildchain assessment requires kungfu.kfx-trust-inputs/v1");
+    require_exact_fields(trust_input,
+                         {"schema", "packageRoot", "sourceRoot", "dependencyRoot", "buildPlanRoot", "toolchainRoot",
+                          "artifactRoot", "qualificationRoot", "verifierRoot", "issuer", "publisher",
+                          "contractVersion"},
+                         "KFX trust inputs");
+    const auto bindings = object_or_empty(attestation, "bindings");
+    const auto subject = object_or_empty(attestation, "subject");
+    const auto passport = object_or_empty(attestation, "passport");
+    const auto verification = object_or_empty(passport, "verification");
+    const auto match = object_or_empty(attestation, "match");
+    const auto artifact = object_or_empty(match, "artifact");
+    const auto kfd_assessment = object_or_empty(request, "kfdAssessment");
+    const auto kfd_report = object_or_empty(kfd_assessment, "report");
+    const bool verifier_ok = attestation.value("contract", "") == "kungfu-buildchain-artifact-verification" &&
+                             attestation.value("schemaVersion", 0) == 1 && attestation.value("outcome", "") == "pass" &&
+                             attestation.value("ok", false) && attestation.value("trust", "") == "pass" &&
+                             verification.value("ok", false) && verification.value("trust", "") == "pass";
+    if (!verifier_ok)
+      reasons.push_back("KF_KFX_ATTESTATION_INVALID");
+
+    static const std::vector<std::string> root_fields = {"packageRoot",       "sourceRoot",    "dependencyRoot",
+                                                         "buildPlanRoot",     "toolchainRoot", "artifactRoot",
+                                                         "qualificationRoot", "verifierRoot"};
+    bool roots_ok = true;
+    for (const auto &field : root_fields) {
+      if (!bindings.contains(field) || !bindings.at(field).is_string() || !trust_input.contains(field) ||
+          !trust_input.at(field).is_string() || !is_content_root(bindings.at(field).get<std::string>()) ||
+          bindings.at(field) != trust_input.at(field)) {
+        roots_ok = false;
+        break;
+      }
+      evidence_dependencies.push_back(trust_input.at(field));
+    }
+    const auto subject_digest = subject.value("digest", "");
+    const auto matched_digest = artifact.value("digest", "");
+    if (!roots_ok || trust_input.value("packageRoot", "") != package_root ||
+        bindings.value("artifactRoot", "") != subject_digest || subject_digest != matched_digest)
+      reasons.push_back("KF_KFX_ATTESTATION_ROOT_MISMATCH");
+
+    const auto assessment_key = kfd_assessment.value("assessment_key", "");
+    const auto report_hash = kfd_report.value("report_hash", "");
+    const auto query_proof_root = kfd_report.value("query_proof_root", "");
+    const auto contract_world = object_or_empty(kfd_report, "contract_world");
+    const auto assessment_policy = object_or_empty(kfd_report, "policy");
+    bool kfd_assessment_ok = kfd_assessment.value("schema", "") == "kungfu.trust.assessment/v1" &&
+                             kfd_assessment.value("state", "") == "fresh" && kfd_report.value("state", "") == "fresh" &&
+                             kfd_report.value("purpose", "") == purpose && is_content_root(assessment_key) &&
+                             is_content_root(report_hash) && is_content_root(query_proof_root) &&
+                             is_content_root(contract_world.value("root", "")) &&
+                             is_content_root(assessment_policy.value("root", "")) &&
+                             trust_input.value("qualificationRoot", "") == report_hash;
+    if (kfd_report.contains("fact_surfaces") && kfd_report.at("fact_surfaces").is_array()) {
+      for (const auto &surface : kfd_report.at("fact_surfaces")) {
+        if (!surface.is_object() || !is_content_root(surface.value("root", ""))) {
+          kfd_assessment_ok = false;
+          break;
+        }
+        evidence_dependencies.push_back(surface.at("root"));
+      }
+    } else {
+      kfd_assessment_ok = false;
+    }
+    if (!kfd_assessment_ok) {
+      reasons.push_back("KF_KFX_KFD_ASSESSMENT_INVALID");
+    } else {
+      kfd_assessment_key = assessment_key;
+      kfd_report_root = report_hash;
+      evidence_dependencies.push_back(assessment_key);
+      evidence_dependencies.push_back(report_hash);
+      evidence_dependencies.push_back(query_proof_root);
+      evidence_dependencies.push_back(contract_world.at("root"));
+      evidence_dependencies.push_back(assessment_policy.at("root"));
+    }
+
+    const auto issuer = bindings.value("issuer", "");
+    const auto publisher = bindings.value("publisher", "");
+    const auto contract_version = bindings.value("contractVersion", "");
+    const auto verifier_root = bindings.value("verifierRoot", "");
+    if (issuer.empty() || publisher.empty() || contract_version.empty() || verifier_root.empty() ||
+        trust_input.value("issuer", "") != issuer || trust_input.value("publisher", "") != publisher ||
+        trust_input.value("contractVersion", "") != contract_version ||
+        !contains_text(policy.value("allowedIssuers", json::array()), issuer) ||
+        !contains_text(policy.value("allowedPublishers", json::array()), publisher) ||
+        !contains_text(policy.value("allowedContracts", json::array()), contract_version) ||
+        !contains_text(policy.value("allowedVerifierRoots", json::array()), verifier_root))
+      reasons.push_back("KF_KFX_ATTESTATION_PRINCIPAL_REJECTED");
+
+    const bool time_shape_ok = attestation.contains("issuedAt") && attestation.at("issuedAt").is_number_integer() &&
+                               attestation.contains("expiresAt") && attestation.at("expiresAt").is_number_integer() &&
+                               attestation.contains("revoked") && attestation.at("revoked").is_boolean();
+    const auto issued_at = time_shape_ok ? attestation.at("issuedAt").get<int64_t>() : int64_t{-1};
+    const auto expires_at = time_shape_ok ? attestation.at("expiresAt").get<int64_t>() : int64_t{-1};
+    if (time_shape_ok && attestation.at("revoked").get<bool>())
+      reasons.push_back("KF_KFX_ATTESTATION_REVOKED");
+    if (!time_shape_ok || issued_at < 0 || expires_at < issued_at || assessment_time < issued_at ||
+        assessment_time >= expires_at)
+      reasons.push_back("KF_KFX_ATTESTATION_EXPIRED");
+    if (reasons.empty())
+      supply_chain_grade = "kfd-attested";
+    evidence_dependencies.push_back(root_of(attestation));
+  } else {
+    if (!identity.empty() && identity.value("verified", false) && identity.value("artifactRoot", "") == package_root &&
+        contains_text(policy.value("allowedPublishers", json::array()), identity.value("publisher", ""))) {
+      supply_chain_grade = "identity-verified";
+      trust_input = identity;
+      evidence_dependencies.push_back(root_of(identity));
+    } else {
+      reasons.push_back("KF_KFX_ATTESTATION_MISSING");
+    }
+  }
+
+  std::string admission_grade = supply_chain_grade;
+  if (supply_chain_grade == "kfd-attested" &&
+      contains_text(policy.value("productSystemRoots", json::array()), package_root))
+    admission_grade = "product-system";
+
+  const auto requested_capabilities = string_array_or_empty(request, "requestedCapabilities");
+  const auto declared_capabilities = package.at("declaredCapabilities").get<std::vector<std::string>>();
+  json constraints = json::array();
+  json required_approvals = json::array();
+  for (const auto &capability : requested_capabilities) {
+    if (std::find(declared_capabilities.begin(), declared_capabilities.end(), capability) ==
+        declared_capabilities.end())
+      reasons.push_back("KF_KFX_CAPABILITY_BROADENING");
+    if (contains_text(policy.value("highConsequenceCapabilities", json::array()), capability)) {
+      constraints.push_back("high-consequence-capability:" + capability);
+      if (admission_grade != "product-system" ||
+          !contains_text(policy.value("systemCapabilities", json::array()), capability))
+        required_approvals.push_back("capability:" + capability);
+    }
+  }
+
+  bool allowed = operation == "inspect";
+  if (contains_text(policy.value("autoOperations", json::array()), operation) &&
+      (admission_grade == "kfd-attested" || admission_grade == "product-system"))
+    allowed = true;
+  if (operation == "update" && request.value("capabilityExpansion", false)) {
+    allowed = false;
+    required_approvals.push_back("capability-expansion");
+  }
+  if (operation == "migration") {
+    allowed = false;
+    required_approvals.push_back("irreversible-migration");
+  }
+  if (operation == "system-role" && admission_grade != "product-system") {
+    allowed = false;
+    required_approvals.push_back("product-system-assignment");
+  }
+  if (operation == "capability" && !required_approvals.empty())
+    allowed = false;
+
+  const auto runtime = object_or_empty(request, "runtimeEvidence");
+  const bool runtime_degraded = runtime.value("degraded", false) || runtime.value("receiptViolation", false);
+  if (runtime_degraded && (operation == "enable" || operation == "activate" || operation == "host-placement" ||
+                           operation == "capability" || operation == "system-role")) {
+    allowed = false;
+    constraints.push_back("runtime-assessment-degraded");
+    required_approvals.push_back("runtime-reassessment");
+  }
+  const auto policy_root = root_of(policy);
+  evidence_dependencies.push_back(policy_root);
+  if (!runtime.empty())
+    evidence_dependencies.push_back(root_of(runtime));
+  const auto trust_input_root = trust_input.empty() ? nullptr : json(root_of(trust_input));
+  std::sort(evidence_dependencies.begin(), evidence_dependencies.end());
+  evidence_dependencies.erase(std::unique(evidence_dependencies.begin(), evidence_dependencies.end()),
+                              evidence_dependencies.end());
+  const auto dependency_root = root_of({{"packageRoot", package.at("packageRoot")},
+                                        {"registryRoot", registry_root},
+                                        {"operation", operation},
+                                        {"purpose", purpose},
+                                        {"cut", cut},
+                                        {"assessmentTime", assessment_time},
+                                        {"requestedCapabilities", requested_capabilities},
+                                        {"policyRoot", policy_root},
+                                        {"trustInputRoot", trust_input_root},
+                                        {"evidenceDependencies", evidence_dependencies}});
+  bool stale = false;
+  if (request.contains("cachedDependencyRoot")) {
+    if (!request.at("cachedDependencyRoot").is_string() ||
+        !is_content_root(request.at("cachedDependencyRoot").get<std::string>()))
+      refuse("KF_KFX_SCHEMA_INVALID", "cachedDependencyRoot must be a canonical sha256 root");
+    stale = request.at("cachedDependencyRoot") != dependency_root;
+    if (stale)
+      reasons.push_back("KF_KFX_ASSESSMENT_STALE");
+  }
+  if (!reasons.empty() && operation != "inspect")
+    allowed = false;
+  if (!allowed && required_approvals.empty())
+    required_approvals.push_back("workspace-owner");
+
+  std::vector<std::string> recovery_guidance;
+  if (stale)
+    recovery_guidance.push_back("discard-cached-assessment-and-reassess");
+  if (!reasons.empty())
+    recovery_guidance.push_back("refresh-exact-evidence-and-reassess");
+  if (runtime_degraded)
+    recovery_guidance.push_back("repair-runtime-and-reassess");
+  if (!required_approvals.empty())
+    recovery_guidance.push_back("obtain-required-approval-and-replan");
+  if (allowed)
+    recovery_guidance.push_back("bind-report-and-plan-roots-into-operation-receipt");
+  std::sort(reasons.begin(), reasons.end());
+  std::sort(constraints.begin(), constraints.end());
+  std::sort(required_approvals.begin(), required_approvals.end());
+  std::sort(recovery_guidance.begin(), recovery_guidance.end());
+  json report_identity = {{"schema", "kungfu.kfx-trust-report/v1"},
+                          {"packageKey", package.at("key")},
+                          {"packageRoot", package.at("packageRoot")},
+                          {"registryRoot", registry_root},
+                          {"purpose", purpose},
+                          {"cut", cut},
+                          {"operation", operation},
+                          {"supplyChainGrade", supply_chain_grade},
+                          {"admissionGrade", admission_grade},
+                          {"runtimeAssessment", runtime_degraded ? "degraded" : "eligible"},
+                          {"fresh", !stale},
+                          {"policyRoot", policy_root},
+                          {"trustInputRoot", trust_input_root},
+                          {"kfdAssessmentKey", kfd_assessment_key},
+                          {"kfdReportRoot", kfd_report_root},
+                          {"dependencyRoot", dependency_root},
+                          {"evidenceDependencies", evidence_dependencies},
+                          {"reasons", reasons},
+                          {"constraints", constraints},
+                          {"recoveryGuidance", recovery_guidance},
+                          {"residualRisk", residual_risk}};
+  const auto report_root = root_of(report_identity);
+  json plan_identity = {{"schema", "kungfu.kfx-admission-plan/v1"},
+                        {"reportRoot", report_root},
+                        {"packageRoot", package.at("packageRoot")},
+                        {"dependencyRoot", dependency_root},
+                        {"operation", operation},
+                        {"allowed", allowed},
+                        {"requiredApprovals", required_approvals},
+                        {"constraints", constraints}};
+  const auto plan_root = root_of(plan_identity);
+  auto report = report_identity;
+  report["reportRoot"] = report_root;
+  auto plan = plan_identity;
+  plan["planRoot"] = plan_root;
+  plan["receiptDependencyRoot"] = root_of({{"reportRoot", report_root},
+                                           {"planRoot", plan_root},
+                                           {"packageRoot", package.at("packageRoot")},
+                                           {"dependencyRoot", dependency_root}});
+  return {{"schema", "kungfu.kfx-admission-assessment/v1"},
+          {"registryRoot", registry_root},
+          {"trustReport", report},
+          {"admissionPlan", plan}};
+}
+
 } // namespace
 
 static json query_native_kfx_registry_unchecked(const std::string &action, const json &request) {
-  static const std::set<std::string> actions = {"list", "inspect", "resolve", "plan", "status"};
+  static const std::set<std::string> actions = {"list", "inspect", "resolve", "plan", "status", "assess"};
   if (!actions.contains(action))
     refuse("KF_KFX_AUTHORITY_CLAIM_FORBIDDEN", "native KFX registry is read-only: " + action);
   const auto snapshot = build_snapshot(request);
@@ -530,6 +858,16 @@ static json query_native_kfx_registry_unchecked(const std::string &action, const
             {"registryRoot", snapshot.registry_root},
             {"package", package},
             {"diagnostics", snapshot.diagnostics}};
+  }
+  if (action == "assess") {
+    const auto key = required_text(request, "packageKey", "request");
+    const auto package = find_package(snapshot.packages, key);
+    if (package.is_null())
+      refuse("KF_KFX_MEMBER_MISSING", "KFX package is not present in the registry: " + key);
+    auto result = assess_package(package, snapshot.registry_root, request);
+    result["registryRoot"] = snapshot.registry_root;
+    result["diagnostics"] = snapshot.diagnostics;
+    return result;
   }
   if (action == "resolve") {
     const auto key = required_text(request, "suiteKey", "request");

--- a/framework/core/src/libkungfu/src/runtime/storage/domain_dispatch.cpp
+++ b/framework/core/src/libkungfu/src/runtime/storage/domain_dispatch.cpp
@@ -253,7 +253,8 @@ public:
       return kfx::validate_native_kfx_document(text_or(options.operation_options, "kind"),
                                                object_or_empty(options.operation_options, "document"));
     }
-    if (action == "list" || action == "inspect" || action == "resolve" || action == "plan" || action == "status") {
+    if (action == "list" || action == "inspect" || action == "resolve" || action == "plan" || action == "status" ||
+        action == "assess") {
       return kfx::query_native_kfx_registry(action, object_or_empty(options.operation_options, "request"));
     }
     throw std::invalid_argument("unsupported native KFX runtime action: " + action);

--- a/framework/core/src/libkungfu/tests/native_kfx_contract_tests.cpp
+++ b/framework/core/src/libkungfu/tests/native_kfx_contract_tests.cpp
@@ -3,6 +3,7 @@
 #include <kungfu/runtime/kfx/native_contract.h>
 #include <kungfu/runtime/kfx/native_registry.h>
 
+#include <algorithm>
 #include <chrono>
 #include <filesystem>
 #include <fstream>
@@ -62,6 +63,11 @@ fs::path temp_root(const std::string &name) {
   return root;
 }
 
+bool contains_text(const nlohmann::json &values, const std::string &expected) {
+  return values.is_array() && std::any_of(values.begin(), values.end(),
+                                          [&](const auto &value) { return value.is_string() && value == expected; });
+}
+
 void test_contract_is_versioned_and_core_owned() {
   const auto first = kfx::native_kfx_contract();
   const auto second = kfx::native_kfx_contract();
@@ -69,12 +75,22 @@ void test_contract_is_versioned_and_core_owned() {
   require(first.at("contractVersion") == 2, "native contract version drifted");
   require(first.at("versionNegotiation").at("supported") == nlohmann::json::array({1, 2}),
           "native contract stopped accepting frozen v1 documents");
-  require(first.at("sourceContractVersion") == 7, "native contract did not expose its source compatibility version");
+  require(first.at("sourceContractVersion") == 8, "native contract did not expose its source compatibility version");
   require(first.at("runtimeTiers") != first.at("admissionGrades"),
           "runtime tier and admission grade were collapsed into one authority field");
   require(first.at("authority").at("owner") == "libkungfu", "native contract did not assign Core authority");
   require(first.at("authority").at("profileLifecycle") == "existing-kungfu.profile-lifecycle/v1",
           "native seam created a parallel Profile lifecycle");
+  const auto &assessment = first.at("admissionAssessment");
+  require(assessment.at("verifierContract").at("contract") == "kungfu-buildchain-artifact-verification",
+          "native admission did not freeze the exact Buildchain verifier contract");
+  require(contains_text(assessment.at("trustReport").at("required"), "registryRoot") &&
+              contains_text(assessment.at("admissionPlan").at("required"), "receiptDependencyRoot"),
+          "native admission did not freeze its report and receipt dependency shapes");
+  require(assessment.at("receiptDependency").at("mutationRule") == "future-mutation-must-bind-exact-root",
+          "native admission contract did not bind future mutation receipts");
+  require(assessment.at("kfdAssessment").at("lifecycleOwner") == "ADR-0052",
+          "native KFX admission created a second KFD assessment lifecycle");
   require(first.at("nativeContractRoot") == second.at("nativeContractRoot"), "native contract root was unstable");
   require(first.at("sourceContractRoot").get<std::string>().rfind("sha256:", 0) == 0,
           "source contract root was not content-addressed");
@@ -249,6 +265,213 @@ void test_registry_negative_and_concurrent_reads() {
     require(reads[index].get() == expected, "concurrent registry readers observed different roots");
 }
 
+std::string fixture_root(char value) { return "sha256:" + std::string(64, value); }
+
+nlohmann::json assessment_request() {
+  auto request = registry_request();
+  auto inspect = request;
+  inspect["packageKey"] = "optional-view";
+  const auto package_root =
+      kfx::query_native_kfx_registry("inspect", inspect).at("package").at("packageRoot").get<std::string>();
+  nlohmann::json trust_inputs = {
+      {"schema", "kungfu.kfx-trust-inputs/v1"}, {"packageRoot", package_root},
+      {"sourceRoot", fixture_root('1')},        {"dependencyRoot", fixture_root('2')},
+      {"buildPlanRoot", fixture_root('3')},     {"toolchainRoot", fixture_root('4')},
+      {"artifactRoot", fixture_root('5')},      {"qualificationRoot", fixture_root('6')},
+      {"verifierRoot", fixture_root('7')},      {"issuer", "buildchain.libkungfu.dev"},
+      {"publisher", "kungfu-systems"},          {"contractVersion", "buildchain.release/v1"}};
+  request["packageKey"] = "optional-view";
+  request["operation"] = "install";
+  request["purpose"] = "workspace-install";
+  request["cut"] = "cut:fixture";
+  request["assessmentTime"] = 150;
+  request["requestedCapabilities"] = nlohmann::json::array({"domain"});
+  request["policy"] = {{"schema", "kungfu.kfx-admission-policy/v1"},
+                       {"allowedIssuers", nlohmann::json::array({"buildchain.libkungfu.dev"})},
+                       {"allowedPublishers", nlohmann::json::array({"kungfu-systems"})},
+                       {"allowedContracts", nlohmann::json::array({"buildchain.release/v1"})},
+                       {"allowedVerifierRoots", nlohmann::json::array({fixture_root('7')})},
+                       {"autoOperations", nlohmann::json::array({"install", "update", "activate", "system-role"})},
+                       {"highConsequenceCapabilities", nlohmann::json::array({"process"})},
+                       {"systemCapabilities", nlohmann::json::array({"domain"})},
+                       {"productSystemRoots", nlohmann::json::array()},
+                       {"residualRisk", nlohmann::json::array({"native guest code remains outside provenance proof"})}};
+  request["trustInputs"] = trust_inputs;
+  request["kfdAssessment"] = {{"schema", "kungfu.trust.assessment/v1"},
+                              {"state", "fresh"},
+                              {"assessment_key", fixture_root('a')},
+                              {"report",
+                               {{"report_hash", fixture_root('6')},
+                                {"state", "fresh"},
+                                {"purpose", "workspace-install"},
+                                {"query_proof_root", fixture_root('b')},
+                                {"contract_world", {{"root", fixture_root('c')}}},
+                                {"policy", {{"root", fixture_root('d')}}},
+                                {"fact_surfaces", nlohmann::json::array({{{"root", fixture_root('e')}}})}}}};
+  request["attestation"] = {{"contract", "kungfu-buildchain-artifact-verification"},
+                            {"schemaVersion", 1},
+                            {"outcome", "pass"},
+                            {"ok", true},
+                            {"trust", "pass"},
+                            {"issuedAt", 100},
+                            {"expiresAt", 200},
+                            {"revoked", false},
+                            {"subject", {{"digest", fixture_root('5')}}},
+                            {"passport", {{"verification", {{"ok", true}, {"trust", "pass"}}}}},
+                            {"match", {{"artifact", {{"digest", fixture_root('5')}}}}},
+                            {"bindings", trust_inputs}};
+  return request;
+}
+
+void test_exact_buildchain_attestation_and_operation_admission() {
+  const auto request = assessment_request();
+  const auto first = kfx::query_native_kfx_registry("assess", request);
+  const auto second = kfx::query_native_kfx_registry("assess", request);
+  require(first == second, "KFX TrustReport and admission plan are not deterministic");
+  require(first.at("registryRoot") == first.at("trustReport").at("registryRoot"),
+          "KFX TrustReport did not bind the assessed registry snapshot");
+  require(first.at("trustReport").at("supplyChainGrade") == "kfd-attested",
+          "exact Buildchain evidence did not produce the KFD-attested supply-chain grade");
+  require(first.at("trustReport").at("admissionGrade") == "kfd-attested",
+          "KFD attestation was collapsed into Product System authority");
+  require(first.at("admissionPlan").at("allowed"), "policy did not reduce friction for an exact attestation");
+  require(first.at("trustReport").at("reportRoot").get<std::string>().starts_with("sha256:"),
+          "TrustReport is not content-addressed");
+  require(first.at("admissionPlan").at("receiptDependencyRoot").get<std::string>().starts_with("sha256:"),
+          "admission plan did not bind the future receipt dependency");
+  require(!first.at("trustReport").at("recoveryGuidance").empty(),
+          "admission did not expose deterministic recovery guidance");
+
+  auto sibling = request;
+  sibling["attestation"]["bindings"]["packageRoot"] = fixture_root('8');
+  const auto rejected = kfx::query_native_kfx_registry("assess", sibling);
+  require(rejected.at("trustReport").at("supplyChainGrade") == "unverified",
+          "sibling artifact evidence incorrectly retained its trust grade");
+  require(!rejected.at("admissionPlan").at("allowed"), "sibling artifact evidence did not fail closed");
+
+  auto incomplete_policy = request;
+  incomplete_policy["policy"].erase("residualRisk");
+  require_refusal("KF_KFX_SCHEMA_INVALID", [&] { (void)kfx::query_native_kfx_registry("assess", incomplete_policy); });
+
+  auto ambiguous_inputs = request;
+  ambiguous_inputs["trustInputs"]["unversionedHint"] = true;
+  require_refusal("KF_KFX_SCHEMA_INVALID", [&] { (void)kfx::query_native_kfx_registry("assess", ambiguous_inputs); });
+
+  auto dependency_mismatch = request;
+  dependency_mismatch["attestation"]["bindings"]["dependencyRoot"] = fixture_root('9');
+  require(kfx::query_native_kfx_registry("assess", dependency_mismatch).at("trustReport").at("supplyChainGrade") ==
+              "unverified",
+          "mismatched dependency closure retained its trust grade");
+
+  auto publisher_mismatch = request;
+  publisher_mismatch["attestation"]["bindings"]["publisher"] = "sibling-publisher";
+  const auto publisher_rejected = kfx::query_native_kfx_registry("assess", publisher_mismatch);
+  require(publisher_rejected.at("trustReport").at("supplyChainGrade") == "unverified",
+          "mismatched publisher retained its trust grade");
+  require(contains_text(publisher_rejected.at("trustReport").at("reasons"), "KF_KFX_ATTESTATION_PRINCIPAL_REJECTED"),
+          "mismatched publisher did not emit the stable principal rejection reason");
+
+  auto issuer_mismatch = request;
+  issuer_mismatch["attestation"]["bindings"]["issuer"] = "unknown-issuer";
+  issuer_mismatch["trustInputs"]["issuer"] = "unknown-issuer";
+  require(kfx::query_native_kfx_registry("assess", issuer_mismatch).at("trustReport").at("supplyChainGrade") ==
+              "unverified",
+          "unaccepted issuer retained its trust grade");
+
+  auto contract_mismatch = request;
+  contract_mismatch["attestation"]["bindings"]["contractVersion"] = "buildchain.release/v2";
+  contract_mismatch["trustInputs"]["contractVersion"] = "buildchain.release/v2";
+  require(kfx::query_native_kfx_registry("assess", contract_mismatch).at("trustReport").at("supplyChainGrade") ==
+              "unverified",
+          "unaccepted verifier contract retained its trust grade");
+
+  auto verifier_mismatch = request;
+  verifier_mismatch["attestation"]["bindings"]["verifierRoot"] = fixture_root('9');
+  verifier_mismatch["trustInputs"]["verifierRoot"] = fixture_root('9');
+  require(kfx::query_native_kfx_registry("assess", verifier_mismatch).at("trustReport").at("supplyChainGrade") ==
+              "unverified",
+          "unaccepted verifier root retained its trust grade");
+
+  auto expired = request;
+  expired["assessmentTime"] = 200;
+  require(kfx::query_native_kfx_registry("assess", expired).at("trustReport").at("supplyChainGrade") == "unverified",
+          "expired Buildchain evidence remained trusted");
+
+  auto revoked = request;
+  revoked["attestation"]["revoked"] = true;
+  require(kfx::query_native_kfx_registry("assess", revoked).at("trustReport").at("supplyChainGrade") == "unverified",
+          "revoked Buildchain evidence remained trusted");
+
+  auto stale_kfd = request;
+  stale_kfd["kfdAssessment"]["state"] = "stale";
+  const auto stale_kfd_report = kfx::query_native_kfx_registry("assess", stale_kfd);
+  require(stale_kfd_report.at("trustReport").at("supplyChainGrade") == "unverified",
+          "stale ADR-0052 assessment retained the KFD-attested grade");
+  require(contains_text(stale_kfd_report.at("trustReport").at("reasons"), "KF_KFX_KFD_ASSESSMENT_INVALID"),
+          "stale ADR-0052 assessment did not expose its stable refusal reason");
+
+  auto broadened = request;
+  broadened["operation"] = "update";
+  broadened["capabilityExpansion"] = true;
+  require(!kfx::query_native_kfx_registry("assess", broadened).at("admissionPlan").at("allowed"),
+          "capability expansion inherited an old approval");
+
+  auto same_capability_update = request;
+  same_capability_update["operation"] = "update";
+  require(kfx::query_native_kfx_registry("assess", same_capability_update).at("admissionPlan").at("allowed"),
+          "same-capability update did not receive the policy-defined reduced-friction path");
+
+  auto high_consequence = request;
+  high_consequence["operation"] = "capability";
+  high_consequence["policy"]["highConsequenceCapabilities"] = nlohmann::json::array({"domain"});
+  const auto high_consequence_report = kfx::query_native_kfx_registry("assess", high_consequence);
+  require(!high_consequence_report.at("admissionPlan").at("allowed") &&
+              contains_text(high_consequence_report.at("admissionPlan").at("requiredApprovals"), "capability:domain"),
+          "high-consequence capability inherited automatic approval");
+
+  auto migration = request;
+  migration["operation"] = "migration";
+  require(!kfx::query_native_kfx_registry("assess", migration).at("admissionPlan").at("allowed"),
+          "irreversible migration inherited automatic admission");
+
+  auto degraded = request;
+  degraded["operation"] = "activate";
+  degraded["runtimeEvidence"] = {{"degraded", true}};
+  const auto degraded_report = kfx::query_native_kfx_registry("assess", degraded);
+  require(degraded_report.at("trustReport").at("supplyChainGrade") == "kfd-attested",
+          "runtime degradation rewrote the Buildchain supply-chain fact");
+  require(!degraded_report.at("admissionPlan").at("allowed"),
+          "runtime degradation did not suspend local activation admission");
+
+  auto changed_policy = request;
+  changed_policy["cachedDependencyRoot"] = first.at("trustReport").at("dependencyRoot");
+  changed_policy["policy"]["residualRisk"].push_back("policy changed");
+  const auto stale_report = kfx::query_native_kfx_registry("assess", changed_policy);
+  require(!stale_report.at("trustReport").at("fresh") && !stale_report.at("admissionPlan").at("allowed"),
+          "changed dependency root did not invalidate the cached assessment");
+
+  auto system = request;
+  system["operation"] = "system-role";
+  system["policy"]["productSystemRoots"].push_back(system["attestation"]["bindings"]["packageRoot"]);
+  const auto system_report = kfx::query_native_kfx_registry("assess", system);
+  require(system_report.at("trustReport").at("admissionGrade") == "product-system",
+          "Product assembly did not assign System authority to its exact eligible root");
+  require(system_report.at("admissionPlan").at("allowed"), "eligible Product System assignment was refused");
+
+  auto identity = request;
+  identity.erase("attestation");
+  identity.erase("trustInputs");
+  identity.erase("kfdAssessment");
+  identity["identity"] = {{"verified", true},
+                          {"artifactRoot", system["attestation"]["bindings"]["packageRoot"]},
+                          {"publisher", "kungfu-systems"}};
+  const auto identity_report = kfx::query_native_kfx_registry("assess", identity);
+  require(identity_report.at("trustReport").at("supplyChainGrade") == "identity-verified",
+          "exact publisher identity did not produce the identity-verified grade");
+  require(!identity_report.at("admissionPlan").at("allowed"),
+          "identity verification incorrectly inherited KFD-attested operation admission");
+}
+
 } // namespace
 
 int main() {
@@ -259,6 +482,7 @@ int main() {
     test_service_interface_routes_only_validated_requests();
     test_registry_produces_one_deterministic_cross_surface_plan();
     test_registry_negative_and_concurrent_reads();
+    test_exact_buildchain_attestation_and_operation_admission();
     std::cout << "native KFX contract tests passed\n";
     return 0;
   } catch (const std::exception &error) {

--- a/framework/core/src/python/kungfu/cli/commands/kfx.py
+++ b/framework/core/src/python/kungfu/cli/commands/kfx.py
@@ -418,6 +418,16 @@ def _native_query(ctx, action, roots, runtime_tiers, **values):
     )
 
 
+def _native_json_file(path, label):
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise click.BadParameter(f"cannot read {label}: {error}") from error
+    if not isinstance(value, dict):
+        raise click.BadParameter(f"{label} must contain one JSON object")
+    return value
+
+
 @native_group.command(name="list", help="list canonical KFX package candidates")
 @click.option("--root", "roots", multiple=True, required=True, help="KIND=PATH")
 @click.option("--runtime-tier", "runtime_tiers", multiple=True, help="KEY=TIER")
@@ -458,6 +468,104 @@ def native_plan(ctx, roots, runtime_tiers):
 @kfx_command_context
 def native_status(ctx, roots, runtime_tiers):
     _native_query(ctx, "status", roots, runtime_tiers)
+
+
+@native_group.command(
+    name="assess",
+    help="produce the Core TrustReport and operation-specific admission plan",
+)
+@click.argument("package_key")
+@click.option("--root", "roots", multiple=True, required=True, help="KIND=PATH")
+@click.option("--runtime-tier", "runtime_tiers", multiple=True, help="KEY=TIER")
+@click.option(
+    "--operation",
+    type=click.Choice(
+        [
+            "inspect",
+            "install",
+            "update",
+            "enable",
+            "activate",
+            "host-placement",
+            "capability",
+            "migration",
+            "system-role",
+        ]
+    ),
+    required=True,
+)
+@click.option("--purpose", required=True)
+@click.option("--cut", required=True)
+@click.option("--assessment-time", type=int, required=True)
+@click.option(
+    "--attestation", type=click.Path(exists=True, dir_okay=False, path_type=Path)
+)
+@click.option(
+    "--identity", type=click.Path(exists=True, dir_okay=False, path_type=Path)
+)
+@click.option(
+    "--trust-inputs", type=click.Path(exists=True, dir_okay=False, path_type=Path)
+)
+@click.option(
+    "--kfd-assessment",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+)
+@click.option(
+    "--policy",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    required=True,
+)
+@click.option(
+    "--runtime-evidence", type=click.Path(exists=True, dir_okay=False, path_type=Path)
+)
+@click.option("--requested-capability", "requested_capabilities", multiple=True)
+@click.option("--capability-expansion", is_flag=True)
+@click.option("--cached-dependency-root")
+@kfx_command_context
+def native_assess(
+    ctx,
+    package_key,
+    roots,
+    runtime_tiers,
+    operation,
+    purpose,
+    cut,
+    assessment_time,
+    attestation,
+    identity,
+    trust_inputs,
+    kfd_assessment,
+    policy,
+    runtime_evidence,
+    requested_capabilities,
+    capability_expansion,
+    cached_dependency_root,
+):
+    values = {
+        "packageKey": package_key,
+        "operation": operation,
+        "purpose": purpose,
+        "cut": cut,
+        "assessmentTime": assessment_time,
+        "policy": _native_json_file(policy, "policy"),
+        "requestedCapabilities": list(requested_capabilities),
+        "capabilityExpansion": capability_expansion,
+    }
+    if attestation is not None:
+        values["attestation"] = _native_json_file(attestation, "attestation")
+    if identity is not None:
+        values["identity"] = _native_json_file(identity, "identity")
+    if trust_inputs is not None:
+        values["trustInputs"] = _native_json_file(trust_inputs, "trust inputs")
+    if kfd_assessment is not None:
+        values["kfdAssessment"] = _native_json_file(kfd_assessment, "KFD assessment")
+    if runtime_evidence is not None:
+        values["runtimeEvidence"] = _native_json_file(
+            runtime_evidence, "runtime evidence"
+        )
+    if cached_dependency_root is not None:
+        values["cachedDependencyRoot"] = cached_dependency_root
+    _native_query(ctx, "assess", roots, runtime_tiers, **values)
 
 
 @kfx.group(

--- a/framework/core/src/python/kungfu/storage/service.py
+++ b/framework/core/src/python/kungfu/storage/service.py
@@ -796,7 +796,7 @@ def kfx_registry(
 ) -> dict[str, Any]:
     """Project one read-only Core-native KFX registry operation."""
 
-    if action not in {"list", "inspect", "resolve", "plan", "status"}:
+    if action not in {"list", "inspect", "resolve", "plan", "status", "assess"}:
         raise ValueError(f"unsupported read-only KFX registry action: {action}")
     return dict(
         _runtime().run_storage_service_operation(

--- a/framework/core/tests/python/test_native_kfx_contract.py
+++ b/framework/core/tests/python/test_native_kfx_contract.py
@@ -26,6 +26,83 @@ def _registry_request():
     }
 
 
+def _assessment_request(tmp_path):
+    request = _registry_request()
+    package_root = storage_service.kfx_registry(
+        "inspect", {**request, "packageKey": "optional-view"}, tmp_path
+    )["package"]["packageRoot"]
+
+    def root(value):
+        return f"sha256:{value * 64}"
+
+    policy = {
+        "schema": "kungfu.kfx-admission-policy/v1",
+        "allowedIssuers": ["buildchain.libkungfu.dev"],
+        "allowedPublishers": ["kungfu-systems"],
+        "allowedContracts": ["buildchain.release/v1"],
+        "allowedVerifierRoots": [root("7")],
+        "autoOperations": ["install", "update", "activate"],
+        "highConsequenceCapabilities": ["process"],
+        "systemCapabilities": [],
+        "productSystemRoots": [],
+        "residualRisk": ["provenance does not prove universal safety"],
+    }
+    trust_inputs = {
+        "schema": "kungfu.kfx-trust-inputs/v1",
+        "packageRoot": package_root,
+        "sourceRoot": root("1"),
+        "dependencyRoot": root("2"),
+        "buildPlanRoot": root("3"),
+        "toolchainRoot": root("4"),
+        "artifactRoot": root("5"),
+        "qualificationRoot": root("6"),
+        "verifierRoot": root("7"),
+        "issuer": "buildchain.libkungfu.dev",
+        "publisher": "kungfu-systems",
+        "contractVersion": "buildchain.release/v1",
+    }
+    attestation = {
+        "contract": "kungfu-buildchain-artifact-verification",
+        "schemaVersion": 1,
+        "outcome": "pass",
+        "ok": True,
+        "trust": "pass",
+        "issuedAt": 100,
+        "expiresAt": 200,
+        "revoked": False,
+        "subject": {"digest": root("5")},
+        "passport": {"verification": {"ok": True, "trust": "pass"}},
+        "match": {"artifact": {"digest": root("5")}},
+        "bindings": dict(trust_inputs),
+    }
+    return {
+        **request,
+        "packageKey": "optional-view",
+        "operation": "install",
+        "purpose": "workspace-install",
+        "cut": "cut:python-fixture",
+        "assessmentTime": 150,
+        "requestedCapabilities": ["domain"],
+        "policy": policy,
+        "trustInputs": trust_inputs,
+        "kfdAssessment": {
+            "schema": "kungfu.trust.assessment/v1",
+            "state": "fresh",
+            "assessment_key": root("a"),
+            "report": {
+                "report_hash": root("6"),
+                "state": "fresh",
+                "purpose": "workspace-install",
+                "query_proof_root": root("b"),
+                "contract_world": {"root": root("c")},
+                "policy": {"root": root("d")},
+                "fact_surfaces": [{"root": root("e")}],
+            },
+        },
+        "attestation": attestation,
+    }
+
+
 def test_native_kfx_python_binding_is_a_thin_core_edge(tmp_path):
     contract = storage_service.kfx_runtime_contract(tmp_path)
     assert contract["schema"] == "kungfu.kfx.native-contract/v2"
@@ -89,6 +166,61 @@ def test_native_kfx_cli_projects_the_same_plan_root(tmp_path):
 
     assert result.exit_code == 0, result.output
     assert json.loads(result.output)["planRoot"] == direct["planRoot"]
+
+
+def test_native_kfx_assessment_projects_one_report_across_python_and_cli(tmp_path):
+    request = _assessment_request(tmp_path / "runtime")
+    direct = storage_service.kfx_registry("assess", request, tmp_path / "runtime")
+    policy_path = tmp_path / "policy.json"
+    attestation_path = tmp_path / "attestation.json"
+    trust_inputs_path = tmp_path / "trust-inputs.json"
+    kfd_assessment_path = tmp_path / "kfd-assessment.json"
+    policy_path.write_text(json.dumps(request["policy"]), encoding="utf-8")
+    attestation_path.write_text(json.dumps(request["attestation"]), encoding="utf-8")
+    trust_inputs_path.write_text(json.dumps(request["trustInputs"]), encoding="utf-8")
+    kfd_assessment_path.write_text(
+        json.dumps(request["kfdAssessment"]), encoding="utf-8"
+    )
+    root = request["roots"][0]
+    result = CliRunner().invoke(
+        kfc,
+        [
+            "--home",
+            str(tmp_path),
+            "kfx",
+            "native",
+            "assess",
+            "optional-view",
+            "--root",
+            f"{root['kind']}={root['path']}",
+            "--runtime-tier",
+            "optional-view=verified-third-party",
+            "--operation",
+            "install",
+            "--purpose",
+            "workspace-install",
+            "--cut",
+            "cut:python-fixture",
+            "--assessment-time",
+            "150",
+            "--requested-capability",
+            "domain",
+            "--policy",
+            str(policy_path),
+            "--attestation",
+            str(attestation_path),
+            "--trust-inputs",
+            str(trust_inputs_path),
+            "--kfd-assessment",
+            str(kfd_assessment_path),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    projected = json.loads(result.output)
+    assert projected["trustReport"]["reportRoot"] == direct["trustReport"]["reportRoot"]
+    assert projected["admissionPlan"]["planRoot"] == direct["admissionPlan"]["planRoot"]
+    assert projected["trustReport"]["admissionGrade"] == "kfd-attested"
 
 
 def test_python_shadow_parity_matches_the_shared_fixture_corpus():

--- a/framework/kfx/kungfu-kfx.contract.json
+++ b/framework/kfx/kungfu-kfx.contract.json
@@ -1,7 +1,7 @@
 {
   "schema": "kungfu.kfx.contract/v1",
   "id": "kungfu-kfx",
-  "version": 7,
+  "version": 8,
   "weldedSurface": "kfx-contract",
   "description": "Single source for KFX package manifests, discovery rules, trust inputs, and build detection.",
   "contractSchema": {
@@ -759,6 +759,7 @@
         "inspect",
         "resolve",
         "plan",
+        "assess",
         "apply",
         "status",
         "history"
@@ -788,6 +789,230 @@
       "kfd-attested",
       "product-system"
     ],
+    "admissionAssessment": {
+      "schema": "kungfu.kfx-admission-assessment/v1",
+      "authority": "libkungfu-read-only-projection",
+      "verifierContract": {
+        "contract": "kungfu-buildchain-artifact-verification",
+        "schemaVersion": 1,
+        "requiredOutcome": "pass"
+      },
+      "operations": [
+        "inspect",
+        "install",
+        "update",
+        "enable",
+        "activate",
+        "host-placement",
+        "capability",
+        "migration",
+        "system-role"
+      ],
+      "trustInputs": {
+        "schema": "kungfu.kfx-trust-inputs/v1",
+        "required": [
+          "schema",
+          "packageRoot",
+          "sourceRoot",
+          "dependencyRoot",
+          "buildPlanRoot",
+          "toolchainRoot",
+          "artifactRoot",
+          "qualificationRoot",
+          "verifierRoot",
+          "issuer",
+          "publisher",
+          "contractVersion"
+        ],
+        "allowed": [
+          "schema",
+          "packageRoot",
+          "sourceRoot",
+          "dependencyRoot",
+          "buildPlanRoot",
+          "toolchainRoot",
+          "artifactRoot",
+          "qualificationRoot",
+          "verifierRoot",
+          "issuer",
+          "publisher",
+          "contractVersion"
+        ],
+        "rootFields": [
+          "packageRoot",
+          "sourceRoot",
+          "dependencyRoot",
+          "buildPlanRoot",
+          "toolchainRoot",
+          "artifactRoot",
+          "qualificationRoot",
+          "verifierRoot"
+        ],
+        "rootFormat": "canonical-lowercase-sha256"
+      },
+      "policy": {
+        "schema": "kungfu.kfx-admission-policy/v1",
+        "required": [
+          "schema",
+          "allowedIssuers",
+          "allowedPublishers",
+          "allowedContracts",
+          "allowedVerifierRoots",
+          "autoOperations",
+          "highConsequenceCapabilities",
+          "systemCapabilities",
+          "productSystemRoots",
+          "residualRisk"
+        ],
+        "allowed": [
+          "schema",
+          "allowedIssuers",
+          "allowedPublishers",
+          "allowedContracts",
+          "allowedVerifierRoots",
+          "autoOperations",
+          "highConsequenceCapabilities",
+          "systemCapabilities",
+          "productSystemRoots",
+          "residualRisk"
+        ],
+        "nonEmptyAllowlists": [
+          "allowedIssuers",
+          "allowedPublishers",
+          "allowedContracts",
+          "allowedVerifierRoots"
+        ]
+      },
+      "kfdAssessment": {
+        "schema": "kungfu.trust.assessment/v1",
+        "lifecycleOwner": "ADR-0052",
+        "requiredState": "fresh",
+        "required": [
+          "schema",
+          "state",
+          "assessment_key",
+          "report"
+        ],
+        "reportRequired": [
+          "report_hash",
+          "state",
+          "purpose",
+          "query_proof_root",
+          "contract_world",
+          "policy",
+          "fact_surfaces"
+        ],
+        "qualificationBinding": "trustInputs.qualificationRoot == report.report_hash"
+      },
+      "assessment": {
+        "required": [
+          "schema",
+          "registryRoot",
+          "trustReport",
+          "admissionPlan"
+        ],
+        "allowed": [
+          "schema",
+          "registryRoot",
+          "trustReport",
+          "admissionPlan"
+        ]
+      },
+      "trustReport": {
+        "schema": "kungfu.kfx-trust-report/v1",
+        "required": [
+          "schema",
+          "packageKey",
+          "packageRoot",
+          "registryRoot",
+          "purpose",
+          "cut",
+          "operation",
+          "supplyChainGrade",
+          "admissionGrade",
+          "runtimeAssessment",
+          "fresh",
+          "policyRoot",
+          "trustInputRoot",
+          "kfdAssessmentKey",
+          "kfdReportRoot",
+          "dependencyRoot",
+          "evidenceDependencies",
+          "reasons",
+          "constraints",
+          "recoveryGuidance",
+          "residualRisk",
+          "reportRoot"
+        ],
+        "allowed": [
+          "schema",
+          "packageKey",
+          "packageRoot",
+          "registryRoot",
+          "purpose",
+          "cut",
+          "operation",
+          "supplyChainGrade",
+          "admissionGrade",
+          "runtimeAssessment",
+          "fresh",
+          "policyRoot",
+          "trustInputRoot",
+          "kfdAssessmentKey",
+          "kfdReportRoot",
+          "dependencyRoot",
+          "evidenceDependencies",
+          "reasons",
+          "constraints",
+          "recoveryGuidance",
+          "residualRisk",
+          "reportRoot"
+        ]
+      },
+      "admissionPlan": {
+        "schema": "kungfu.kfx-admission-plan/v1",
+        "required": [
+          "schema",
+          "reportRoot",
+          "packageRoot",
+          "dependencyRoot",
+          "operation",
+          "allowed",
+          "requiredApprovals",
+          "constraints",
+          "planRoot",
+          "receiptDependencyRoot"
+        ],
+        "allowed": [
+          "schema",
+          "reportRoot",
+          "packageRoot",
+          "dependencyRoot",
+          "operation",
+          "allowed",
+          "requiredApprovals",
+          "constraints",
+          "planRoot",
+          "receiptDependencyRoot"
+        ]
+      },
+      "receiptDependency": {
+        "schema": "kungfu.kfx-admission-receipt-dependency/v1",
+        "requiredRoots": [
+          "reportRoot",
+          "planRoot",
+          "packageRoot",
+          "dependencyRoot"
+        ],
+        "mutationRule": "future-mutation-must-bind-exact-root"
+      },
+      "nonClaims": [
+        "verifier-report-is-not-universal-safety-proof",
+        "assessment-does-not-execute-or-authenticate-the-buildchain-verifier",
+        "assessment-does-not-mutate-package-or-profile-lifecycle",
+        "kfx-admission-consumes-adr-0052-report-and-does-not-replace-its-lifecycle"
+      ]
+    },
     "legacyV1": {
       "trustGradeMeaning": "runtime-tier",
       "runtimeTiers": [
@@ -819,6 +1044,13 @@
       "KF_KFX_REGISTRY_STALE",
       "KF_KFX_GENERATION_MISMATCH",
       "KF_KFX_CAPABILITY_BROADENING",
+      "KF_KFX_ATTESTATION_INVALID",
+      "KF_KFX_ATTESTATION_ROOT_MISMATCH",
+      "KF_KFX_ATTESTATION_PRINCIPAL_REJECTED",
+      "KF_KFX_KFD_ASSESSMENT_INVALID",
+      "KF_KFX_ATTESTATION_REVOKED",
+      "KF_KFX_ATTESTATION_EXPIRED",
+      "KF_KFX_ASSESSMENT_STALE",
       "KF_KFX_AUTHORITY_CLAIM_FORBIDDEN"
     ],
     "compatibility": {

--- a/framework/kfx/src/index.ts
+++ b/framework/kfx/src/index.ts
@@ -488,6 +488,62 @@ export type NativeKfxPlanProjection = {
   }>;
 };
 
+export type NativeKfxTrustReport = {
+  schema: 'kungfu.kfx-trust-report/v1';
+  packageKey: string;
+  packageRoot: string;
+  registryRoot: string;
+  purpose: string;
+  cut: string;
+  operation:
+    | 'inspect'
+    | 'install'
+    | 'update'
+    | 'enable'
+    | 'activate'
+    | 'host-placement'
+    | 'capability'
+    | 'migration'
+    | 'system-role';
+  supplyChainGrade: 'unverified' | 'identity-verified' | 'kfd-attested';
+  admissionGrade:
+    | 'unverified'
+    | 'identity-verified'
+    | 'kfd-attested'
+    | 'product-system';
+  runtimeAssessment: 'eligible' | 'degraded';
+  fresh: boolean;
+  policyRoot: string;
+  trustInputRoot: string | null;
+  kfdAssessmentKey: string | null;
+  kfdReportRoot: string | null;
+  dependencyRoot: string;
+  evidenceDependencies: string[];
+  reasons: string[];
+  constraints: string[];
+  recoveryGuidance: string[];
+  residualRisk: string[];
+  reportRoot: string;
+};
+
+export type NativeKfxAdmissionAssessment = {
+  schema: 'kungfu.kfx-admission-assessment/v1';
+  registryRoot: string;
+  trustReport: NativeKfxTrustReport;
+  admissionPlan: {
+    schema: 'kungfu.kfx-admission-plan/v1';
+    reportRoot: string;
+    packageRoot: string;
+    dependencyRoot: string;
+    operation: NativeKfxTrustReport['operation'];
+    allowed: boolean;
+    requiredApprovals: string[];
+    constraints: string[];
+    planRoot: string;
+    receiptDependencyRoot: string;
+  };
+};
+
 export type KfxShadowParityFinding = {
   packageKey: string;
   classification:

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "test:durability-contract": "node scripts/require-shifu.mjs test:durability-contract && node scripts/run-durability-contract-tests.mjs",
     "test:state-service": "node scripts/require-shifu.mjs test:state-service && node scripts/run-state-service-tests.mjs",
     "test:kfx-profile-suite": "node scripts/require-shifu.mjs test:kfx-profile-suite && node scripts/run-kfx-profile-suite-tests.mjs",
+    "test:native-kfx-admission": "node scripts/require-shifu.mjs test:native-kfx-admission && node scripts/run-native-kfx-admission-tests.mjs",
     "test:profile-lifecycle": "node scripts/require-shifu.mjs test:profile-lifecycle && node scripts/run-profile-lifecycle-tests.mjs",
     "test:agent-profile-sdk": "node scripts/require-shifu.mjs test:agent-profile-sdk && node scripts/run-agent-profile-sdk-tests.mjs",
     "test:agent-console-contract": "node scripts/require-shifu.mjs test:agent-console-contract && node scripts/run-agent-console-contract-tests.mjs",

--- a/scripts/run-native-kfx-admission-tests.mjs
+++ b/scripts/run-native-kfx-admission-tests.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: Apache-2.0
+
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const isWin = process.platform === 'win32';
+
+function run(label, command, args, env = process.env) {
+  process.stdout.write(`[native-kfx-admission] ${label}\n`);
+  const result = spawnSync(command, args, {
+    cwd: root,
+    env,
+    stdio: 'inherit',
+    shell: isWin,
+  });
+  if (result.error) throw result.error;
+  if (result.status !== 0) process.exit(result.status ?? 1);
+}
+
+run('Core contract and admission fixtures', 'ctest', [
+  '--test-dir',
+  path.join(root, 'framework/core/build'),
+  '--build-config',
+  'Release',
+  '--output-on-failure',
+  '--tests-regex',
+  '^kungfu_native_kfx_contract_tests$',
+]);
+
+const pythonPath = [
+  path.join(root, 'framework/core/build/Release'),
+  path.join(root, 'framework/core/src/python'),
+  process.env.PYTHONPATH,
+]
+  .filter(Boolean)
+  .join(path.delimiter);
+
+run(
+  'Python binding and CLI projection',
+  'uv',
+  [
+    'run',
+    '--project',
+    path.join(root, 'framework/core'),
+    '--frozen',
+    'pytest',
+    path.join(root, 'framework/core/tests/python/test_native_kfx_contract.py'),
+  ],
+  {
+    ...process.env,
+    KUNGFU_ALLOW_FOREIGN_RUNTIME: '1',
+    PYTHONPATH: pythonPath,
+  },
+);
+
+run('public API transport projection', 'pnpm', [
+  '--filter',
+  '@kungfu-tech/tui',
+  'exec',
+  'tsx',
+  '--test',
+  path.join(root, 'framework/api/tests/storage.test.ts'),
+]);
+
+run('public API type contract', 'pnpm', [
+  '--filter',
+  '@kungfu-tech/api',
+  'run',
+  'build',
+]);
+
+run('KFX type contract', 'pnpm', [
+  '--filter',
+  '@kungfu-tech/kfx',
+  'run',
+  'build',
+]);

--- a/scripts/shifu-cache-runtime.test.mjs
+++ b/scripts/shifu-cache-runtime.test.mjs
@@ -850,10 +850,7 @@ test('nested cache apply preserves the original tool PATH instead of wrapping a 
   const outputPath = path.join(directory, 'nested.json');
   const fakeBin = path.join(directory, 'fake-bin');
   const originalPath = `${fakeBin}${path.delimiter}${process.env.PATH || ''}`;
-  const expectedCargoOriginalPath =
-    process.env.SHIFU_CARGO_ORIGINAL_PATH || originalPath;
-  const expectedConanOriginalPath =
-    process.env.SHIFU_CONAN_ORIGINAL_PATH || originalPath;
+  const expectedOriginalPath = originalPath;
   fs.mkdirSync(fakeBin);
   fs.writeFileSync(profilePath, raw);
   fs.writeFileSync(
@@ -888,8 +885,8 @@ process.exit(status);
   });
   assert.equal(status, 0);
   const nested = JSON.parse(fs.readFileSync(outputPath, 'utf8'));
-  assert.equal(nested.cargoOriginalPath, expectedCargoOriginalPath);
-  assert.equal(nested.conanOriginalPath, expectedConanOriginalPath);
+  assert.equal(nested.cargoOriginalPath, expectedOriginalPath);
+  assert.equal(nested.conanOriginalPath, expectedOriginalPath);
   assert.match(nested.path[0], /shifu-cache-overlay-/);
   assert.match(nested.path[1], /shifu-cache-overlay-/);
   assert.notEqual(nested.path[0], nested.path[1]);


### PR DESCRIPTION
## Summary

Add a fail-closed native KFX admission assessment that consumes exact KFD lifecycle evidence and a pinned Buildchain verification result without creating a second trust evaluator.

## Related issue

Atlas goal `2026-07-15-kungfu-kfx-kfd-buildchain-admission`.

## Changes

- add the read-only Core `assess` operation with schema-closed trust inputs, policy, lifecycle checks, deterministic report/plan roots, and explicit operation/capability decisions
- require a fresh purpose-bound ADR-0052 assessment whose report hash and query/contract/policy/fact roots bind the KFX qualification result
- validate exact Buildchain verifier identity, contract, package/source/dependency/build-plan/toolchain/artifact/qualification roots, issuer/publisher allowlists, expiry, and revocation
- expose one transport-only Storage projection through Python CLI, Python API, Node API, and KFX TypeScript types for GUI, TUI, KFX, and Agent consumers
- add positive, downgrade, mismatch, revocation, cache-invalidation, capability-expansion, migration, and Product System fixtures plus a dedicated Shifu task
- re-render the KFD-1/KFD-3 derived evidence after synchronizing the latest development base
- correct the latest-base nested cache fixture so an explicit PATH override is checked against the effective original tool path instead of an inherited stale value
- document the remaining producer boundary: Core validates a supplied pinned verifier result but does not yet execute or authenticate the Buildchain verifier

## Verification

- `./shifu rebuild:core`
- `./shifu test:native-kfx-admission` (Core 1/1, Python 5/5, API transport 1/1, API/KFX type contracts)
- `./shifu check:source` (325 Node tests, 76 runtime-upgrade tests, 69 desktop tests; source gate passed)
- `./shifu check` (changed-scope gate passed; SDK contract audit 31/31)
- Shifu cache contract group 47/47 after latest-base synchronization
- staged DCO, documentation, C++, Python, and Biome checks passed

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "stage-ready",
  "adrs": ["ADR-0090"],
  "summary": "Add a deterministic fail-closed KFX admission assessment over exact KFD lifecycle evidence and pinned Buildchain verification inputs while preserving the producer boundary.",
  "verification": ["./shifu rebuild:core", "./shifu test:native-kfx-admission", "./shifu check:source", "./shifu check"]
}
-->

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change consumes provenance and qualification evidence but does not publish, sign, deploy, install, activate, or mutate packages. Invalid, stale, mismatched, revoked, or unsupported evidence fails closed.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed
