### PR TITLE
fix(qualification): track Windows peer workload pid

### DIFF
--- a/framework/core/tests/qualification/live-peer-continuity/native_campaign.py
+++ b/framework/core/tests/qualification/live-peer-continuity/native_campaign.py
@@ -274,7 +274,12 @@ def _run_campaign(output_dir: Path, temp_parent: Path | None = None) -> int:
             )
             streams.append(stream)
             first = _wait_for_markers(marker_path, 1)
-            peer_pid = peer.pid
+            # The Windows Shifu/uv Python launch chain may keep a launcher
+            # process in front of the interpreter. Popen.pid therefore proves
+            # launcher liveness, while the first ready marker is the workload's
+            # self-reported process identity that must remain stable.
+            peer_launcher_pid = peer.pid
+            peer_pid = int(first[0]["pid"])
             capsule, stream = _spawn_capsule(
                 capsule_command_path,
                 capsule_marker_path,
@@ -301,9 +306,14 @@ def _run_campaign(output_dir: Path, temp_parent: Path | None = None) -> int:
             second = _wait_for_markers(marker_path, 2)
             _write_authority(capsule_command_path, "7", "2")
             capsule_second = _wait_for_markers(capsule_marker_path, 2)
-            if peer.poll() is not None or peer.pid != peer_pid:
+            peer_return_code = peer.poll()
+            second_ready_pids = sorted({int(item["pid"]) for item in second})
+            if peer_return_code is not None or second_ready_pids != [peer_pid]:
                 raise RuntimeError(
-                    "peer process did not survive Coordinator replacement"
+                    "peer process did not survive Coordinator replacement: "
+                    f"peer_launcher_pid={peer_launcher_pid} peer_pid={peer_pid} "
+                    f"ready_pids={second_ready_pids} "
+                    f"peer_return_code={peer_return_code}"
                 )
 
             _stop_test_process(coordinator, hard=True)
@@ -346,11 +356,12 @@ def _run_campaign(output_dir: Path, temp_parent: Path | None = None) -> int:
             _write_authority(capsule_command_path, "8", "1")
             capsule_final = _wait_for_markers(capsule_marker_path, 3)
             peer_return_code = peer.poll()
-            ready_pids = sorted({item["pid"] for item in final})
+            ready_pids = sorted({int(item["pid"]) for item in final})
             if peer_return_code is not None or ready_pids != [peer_pid]:
                 raise RuntimeError(
                     "runtime generation replacement did not preserve the Peer workload: "
-                    f"peer_pid={peer_pid} ready_pids={ready_pids} "
+                    f"peer_launcher_pid={peer_launcher_pid} peer_pid={peer_pid} "
+                    f"ready_pids={ready_pids} "
                     f"peer_return_code={peer_return_code}"
                 )
             if [len(first), len(second), len(final)] != [1, 2, 3]:

--- a/framework/core/tests/qualification/live-peer-continuity/run.test.mjs
+++ b/framework/core/tests/qualification/live-peer-continuity/run.test.mjs
@@ -120,6 +120,17 @@ test('native campaign failure diagnostics retain only a bounded log tail', () =>
   }
 });
 
+test('native campaign binds Peer workload identity to its ready marker', () => {
+  const campaignSource = fs.readFileSync(
+    path.join(import.meta.dirname, 'native_campaign.py'),
+    'utf8',
+  );
+  assert.match(campaignSource, /peer_launcher_pid = peer\.pid/u);
+  assert.match(campaignSource, /peer_pid = int\(first\[0\]\["pid"\]\)/u);
+  assert.match(campaignSource, /second_ready_pids != \[peer_pid\]/u);
+  assert.doesNotMatch(campaignSource, /peer_pid = peer\.pid/u);
+});
+
 test('clean complete evidence qualifies only the bounded single-host claim', () => {
   const report = evaluateQualification({
     source: source(),


### PR DESCRIPTION
## Summary

- bind native Peer workload identity to the first self-reported ready marker
- keep `Popen.pid` as launcher-liveness evidence because Windows Shifu/uv may retain a launcher process in front of Python
- require the same marker PID across same-generation and generation-advance recovery without weakening the fail-closed process check

## Evidence

- hosted Windows run `29402850286`: launcher PID `7016`, stable Peer marker/log PID `4532`, launcher remained alive (`peer_return_code=None`)
- `node --test framework/core/tests/qualification/live-peer-continuity/run.test.mjs` (9/9)
- Python compile check with external pycache
- `SHIFU_CACHE_BYPASS=source-acceptance ./shifu check:source` (325 source contracts, 76 runtime tests, 69 Desktop tests; all passed)
- staged DCO, docs, catalog, Biome, Ruff format and Ruff lint checks passed

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Corrects a Windows qualification launcher/workload PID distinction without changing runtime architecture or product claims."
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

This PR corrects qualification identity evidence only; it does not publish or deploy artifacts.

## Checklist

- [x] Commit is signed off (DCO)
- [x] Source acceptance is green
- [x] No credentials or generated qualification evidence are committed
