### PR TITLE
fix(qualification): track Windows peer child identity

### DIFF
--- a/framework/core/tests/python/test_runtime_upgrade.py
+++ b/framework/core/tests/python/test_runtime_upgrade.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib.util
 import json
 import os
 import sys
@@ -37,6 +38,20 @@ ROOT = Path(__file__).parents[4]
 CASES = json.loads(
     (ROOT / "tests/fixtures/runtime-upgrade-control-plane/cases.json").read_text()
 )["cases"]
+
+
+def _load_live_peer_campaign():
+    path = (
+        ROOT
+        / "framework/core/tests/qualification/live-peer-continuity/native_campaign.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "kungfu_live_peer_continuity_campaign", path
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 @click.group()
@@ -574,3 +589,20 @@ def test_qualification_churns_128_generations_without_mixed_authority_or_data_lo
         '{"owner":"workspace","retained":true}\n'
     )
     assert not (config_home / "runtime" / "quarantine").exists()
+
+
+def test_live_peer_marker_identity_uses_the_real_peer_process():
+    campaign = _load_live_peer_campaign()
+    markers = [{"pid": 7648}, {"pid": 7648}, {"pid": 7648}]
+
+    assert campaign._single_process_identity(markers, "Peer") == 7648
+
+
+def test_live_peer_marker_identity_rejects_a_real_restart():
+    campaign = _load_live_peer_campaign()
+
+    with pytest.raises(
+        RuntimeError,
+        match=r"observed_pids=\[6644, 7648\]",
+    ):
+        campaign._single_process_identity([{"pid": 6644}, {"pid": 7648}], "Peer")

--- a/framework/core/tests/qualification/live-peer-continuity/native_campaign.py
+++ b/framework/core/tests/qualification/live-peer-continuity/native_campaign.py
@@ -41,6 +41,16 @@ def _read_markers(path: Path) -> list[dict[str, Any]]:
     return [json.loads(line) for line in path.read_text("utf-8").splitlines()]
 
 
+def _single_process_identity(markers: list[dict[str, Any]], label: str) -> int:
+    identities = sorted({int(marker["pid"]) for marker in markers})
+    if len(identities) != 1:
+        raise RuntimeError(
+            f"{label} markers did not preserve one process identity: "
+            f"observed_pids={identities}"
+        )
+    return identities[0]
+
+
 def _write_authority(
     path: Path, runtime_generation: str, coordinator_epoch: str
 ) -> None:
@@ -274,7 +284,8 @@ def _run_campaign(output_dir: Path, temp_parent: Path | None = None) -> int:
             )
             streams.append(stream)
             first = _wait_for_markers(marker_path, 1)
-            peer_pid = peer.pid
+            peer_process_identity = _single_process_identity(first, "initial Peer")
+            peer_launcher_pid = peer.pid
             capsule, stream = _spawn_capsule(
                 capsule_command_path,
                 capsule_marker_path,
@@ -301,9 +312,14 @@ def _run_campaign(output_dir: Path, temp_parent: Path | None = None) -> int:
             second = _wait_for_markers(marker_path, 2)
             _write_authority(capsule_command_path, "7", "2")
             capsule_second = _wait_for_markers(capsule_marker_path, 2)
-            if peer.poll() is not None or peer.pid != peer_pid:
+            second_identity = _single_process_identity(second, "same-generation Peer")
+            if peer.poll() is not None or second_identity != peer_process_identity:
                 raise RuntimeError(
-                    "peer process did not survive Coordinator replacement"
+                    "peer process did not survive Coordinator replacement: "
+                    f"peer_launcher_pid={peer_launcher_pid} "
+                    f"peer_process_identity={peer_process_identity} "
+                    f"observed_pid={second_identity} "
+                    f"peer_return_code={peer.poll()}"
                 )
 
             _stop_test_process(coordinator, hard=True)
@@ -346,11 +362,13 @@ def _run_campaign(output_dir: Path, temp_parent: Path | None = None) -> int:
             _write_authority(capsule_command_path, "8", "1")
             capsule_final = _wait_for_markers(capsule_marker_path, 3)
             peer_return_code = peer.poll()
-            ready_pids = sorted({item["pid"] for item in final})
-            if peer_return_code is not None or ready_pids != [peer_pid]:
+            final_identity = _single_process_identity(final, "runtime-generation Peer")
+            if peer_return_code is not None or final_identity != peer_process_identity:
                 raise RuntimeError(
                     "runtime generation replacement did not preserve the Peer workload: "
-                    f"peer_pid={peer_pid} ready_pids={ready_pids} "
+                    f"peer_launcher_pid={peer_launcher_pid} "
+                    f"peer_process_identity={peer_process_identity} "
+                    f"observed_pid={final_identity} "
                     f"peer_return_code={peer_return_code}"
                 )
             if [len(first), len(second), len(final)] != [1, 2, 3]:


### PR DESCRIPTION
## Summary

- derive the continuity identity from Peer readiness markers instead of the Windows virtualenv launcher PID
- keep the launcher liveness check while comparing all same-generation and post-upgrade markers to one real child process identity
- fail closed on mixed marker PIDs and retain bounded diagnostics for an actual restart

## Evidence

- targeted runtime test: 2 passed
- `SHIFU_CACHE_BYPASS=source-acceptance ./shifu check:source` (exit 0; 325 source contracts, 78 runtime upgrade tests, 69 Desktop tests)
- staged DCO, docs, catalog, TypeScript, Ruff format and Ruff lint checks passed
- hosted diagnosis: exact-source run 29402669464 reported launcher PID 6644 while all readiness markers and the live Peer used PID 7648, proving a Windows venv launcher/child identity mismatch rather than a product Peer restart

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Corrects the Windows qualification harness process identity without changing product architecture or release claims."
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

This PR changes only the fail-closed qualification harness and its regression tests; it does not publish or deploy artifacts.

## Checklist

- [x] Commit is signed off (DCO)
- [x] Source acceptance is green
- [x] No credentials or generated qualification evidence are committed