### PR TITLE
fix(cache): unwrap nested uv projections

### DIFF
--- a/scripts/shifu-uv-cache-adapter.mjs
+++ b/scripts/shifu-uv-cache-adapter.mjs
@@ -376,7 +376,11 @@ export function prepareUvCacheOverlay({
   timeoutMs = 120_000,
 } = {}) {
   if (!endpoint) fail('uv cache adapter requires a selected index endpoint');
-  const originalPath = env.PATH || '';
+  // A lifecycle can invoke Shifu again while already inside a cache
+  // projection. Reusing PATH here would make the inner UV overlay discover
+  // the outer wrapper as its "real" UV; carry forward the first unwrapped
+  // PATH instead.
+  const originalPath = env.SHIFU_UV_ORIGINAL_PATH || env.PATH || '';
   const realUv = findExecutable('uv', originalPath);
   if (!realUv) fail('strict Python cache profile requires uv on PATH');
   const projects = trackedUvProjects(cwd);
@@ -475,6 +479,7 @@ export function prepareUvCacheOverlay({
       root,
       env: {
         PATH: `${bin}${path.delimiter}${originalPath}`,
+        SHIFU_UV_ORIGINAL_PATH: originalPath,
         SHIFU_UV_ADAPTER_MANIFEST: manifestPath,
         SHIFU_CACHE_MANAGED_UV: '1',
       },

--- a/scripts/shifu-uv-cache-adapter.test.mjs
+++ b/scripts/shifu-uv-cache-adapter.test.mjs
@@ -122,8 +122,10 @@ test('effective lock and environment stay outside the canonical checkout', (t) =
   const repo = path.join(root, 'repo');
   const project = path.join(repo, 'framework', 'core');
   const bin = path.join(root, 'bin');
+  const inheritedWrapperBin = path.join(root, 'inherited-wrapper-bin');
   fs.mkdirSync(project, { recursive: true });
   fs.mkdirSync(bin);
+  fs.mkdirSync(inheritedWrapperBin);
   fs.writeFileSync(
     path.join(project, 'pyproject.toml'),
     '[project]\nname="demo"\nversion="1.0.0"\n',
@@ -136,6 +138,18 @@ test('effective lock and environment stay outside the canonical checkout', (t) =
     { cwd: repo },
   );
   fakeUv(bin);
+  if (process.platform === 'win32') {
+    fs.writeFileSync(
+      path.join(inheritedWrapperBin, 'uv.cmd'),
+      '@exit /b 99\r\n',
+    );
+  } else {
+    fs.writeFileSync(
+      path.join(inheritedWrapperBin, 'uv'),
+      '#!/bin/sh\nexit 99\n',
+      { mode: 0o700 },
+    );
+  }
 
   const output = path.join(root, 'uv-run.json');
   const original = fs.readFileSync(path.join(project, 'uv.lock'), 'utf8');
@@ -147,7 +161,8 @@ test('effective lock and environment stay outside the canonical checkout', (t) =
     endpoint: 'http://cache.example.invalid/simple/',
     env: {
       ...process.env,
-      PATH: `${bin}${path.delimiter}${process.env.PATH || ''}`,
+      PATH: `${inheritedWrapperBin}${path.delimiter}${bin}${path.delimiter}${process.env.PATH || ''}`,
+      SHIFU_UV_ORIGINAL_PATH: `${bin}${path.delimiter}${process.env.PATH || ''}`,
       FAKE_UV_OUTPUT: output,
     },
   });
@@ -155,6 +170,10 @@ test('effective lock and environment stay outside the canonical checkout', (t) =
 
   assert.equal(overlay.evidence.enforcement, 'project-overlay');
   assert.equal(overlay.evidence.projectCount, 1);
+  assert.equal(
+    overlay.env.SHIFU_UV_ORIGINAL_PATH,
+    `${bin}${path.delimiter}${process.env.PATH || ''}`,
+  );
   assert.equal(
     fs.readFileSync(path.join(project, 'uv.lock'), 'utf8'),
     original,


### PR DESCRIPTION
## Summary

- preserve the first unwrapped UV PATH across nested Shifu cache projections
- prevent release layer Gates from treating the outer managed wrapper as the real uv
- cover the nested-wrapper path with a cross-platform regression fixture

## Verification

- `node --test scripts/shifu-uv-cache-adapter.test.mjs scripts/run-layer-artifact-gate.test.mjs`
- exact nested `gate run layers.format layers.sdk layers.surfaces` no longer reports a missing UV adapter manifest
- `SHIFU_CACHE_BYPASS=source-acceptance ./shifu check:source`

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Corrects nested UV cache wrapper discovery without changing architecture, release claims, or product behavior."
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

This PR changes qualification cache plumbing only; it does not publish or deploy artifacts.

## Checklist

- [x] Commit is signed off (DCO)
- [x] Source acceptance is green
- [x] No credentials or generated qualification evidence are committed

Signed-off-by: Keren Dong <keren.dong@kungfu.link>