### PR TITLE
fix(qualification): launch Windows Shifu suites via ComSpec

### DIFF
--- a/framework/core/tests/qualification/runtime-activation/run.mjs
+++ b/framework/core/tests/qualification/runtime-activation/run.mjs
@@ -12,6 +12,8 @@ import { gzipSync } from 'node:zlib';
 
 import Ajv2020 from 'ajv/dist/2020.js';
 
+import { cmdCommand } from '../../../../../scripts/run-shifu-lifecycle.mjs';
+
 const HARNESS_DIR = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(HARNESS_DIR, '..', '..', '..', '..', '..');
 const REPORT_SCHEMA_PATH = path.join(
@@ -297,10 +299,31 @@ export function evaluateQualification({
   return report;
 }
 
+export function suiteInvocation(suite, options = {}) {
+  const platform = options.platform || process.platform;
+  const root = options.root || ROOT;
+  const env = options.env || process.env;
+  const [command, ...args] = suite.command;
+  if (platform !== 'win32' || command !== 'shifu.cmd') {
+    return { command, args };
+  }
+  const comspec = options.comspec || env.ComSpec || env.COMSPEC || 'cmd.exe';
+  return {
+    command: comspec,
+    args: [
+      '/d',
+      '/s',
+      '/c',
+      `call ${cmdCommand(path.join(root, 'shifu.cmd'), args)}`,
+    ],
+  };
+}
+
 function runSuite(suite, outputDir) {
   console.log(`[runtime-activation-qualify] running ${suite.id}`);
   const started = Date.now();
-  const result = spawnSync(suite.command[0], suite.command.slice(1), {
+  const invocation = suiteInvocation(suite);
+  const result = spawnSync(invocation.command, invocation.args, {
     cwd: ROOT,
     env: {
       ...process.env,
@@ -319,7 +342,10 @@ function runSuite(suite, outputDir) {
     encoding: 'utf8',
     maxBuffer: 128 * 1024 * 1024,
   });
-  const output = `${result.stdout || ''}${result.stderr || ''}`;
+  const launchError = result.error
+    ? `[runtime-activation-qualify] launch_error=${result.error.stack || String(result.error)}\n`
+    : '';
+  const output = `${result.stdout || ''}${result.stderr || ''}${launchError}`;
   const rawName = `${suite.id}.log`;
   fs.writeFileSync(path.join(outputDir, rawName), output, { flag: 'wx' });
   const passed = !result.error && result.status === 0;

--- a/framework/core/tests/qualification/runtime-activation/run.test.mjs
+++ b/framework/core/tests/qualification/runtime-activation/run.test.mjs
@@ -12,6 +12,7 @@ import {
   evaluateQualification,
   qualificationPlan,
   retainQualificationArtifacts,
+  suiteInvocation,
   validateReport,
 } from './run.mjs';
 
@@ -94,6 +95,24 @@ test('product verification checks the distribution outputs without rebuilding th
     '--skip-episode-qualification',
   ]);
   assert.equal(verification.command.includes('--full'), false);
+});
+
+test('Windows suites invoke the repository Shifu shim through ComSpec', () => {
+  const invocation = suiteInvocation(
+    { command: ['shifu.cmd', 'exec', 'argument with spaces'] },
+    {
+      platform: 'win32',
+      root: '/repo root',
+      comspec: 'C:\\Windows\\System32\\cmd.exe',
+      env: {},
+    },
+  );
+  assert.equal(invocation.command, 'C:\\Windows\\System32\\cmd.exe');
+  assert.deepEqual(invocation.args.slice(0, 3), ['/d', '/s', '/c']);
+  assert.equal(
+    invocation.args[3],
+    'call "/repo root/shifu.cmd" "exec" "argument with spaces"',
+  );
 });
 
 test('clean passing source qualifies exact product artifacts with bounded claims', () => {


### PR DESCRIPTION
## Summary

- launch runtime-activation Shifu suites through ComSpec on Windows
- bind execution to the repository-local absolute `shifu.cmd` path
- retain spawn failures in checksummed raw qualification logs

## Validation

- `node --test framework/core/tests/qualification/runtime-activation/run.test.mjs`
- `SHIFU_CACHE_BYPASS=source-acceptance ./shifu check:source`

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Restores the existing Windows runtime-activation qualification launcher without changing runtime architecture or product claims."
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

This PR repairs qualification execution and retained diagnostics only; it does not publish or deploy artifacts.

## Checklist

- [x] Commit is signed off (DCO)
- [x] Source acceptance is green locally
- [x] No credentials or generated qualification evidence are committed
