### PR TITLE
fix(qualification): invoke Windows Shifu shim directly

### DIFF
--- a/framework/core/tests/qualification/runtime-activation/run.mjs
+++ b/framework/core/tests/qualification/runtime-activation/run.mjs
@@ -12,8 +12,6 @@ import { gzipSync } from 'node:zlib';
 
 import Ajv2020 from 'ajv/dist/2020.js';
 
-import { cmdCommand } from '../../../../../scripts/run-shifu-lifecycle.mjs';
-
 const HARNESS_DIR = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(HARNESS_DIR, '..', '..', '..', '..', '..');
 const REPORT_SCHEMA_PATH = path.join(
@@ -301,21 +299,25 @@ export function evaluateQualification({
 
 export function suiteInvocation(suite, options = {}) {
   const platform = options.platform || process.platform;
-  const root = options.root || ROOT;
   const env = options.env || process.env;
   const [command, ...args] = suite.command;
   if (platform !== 'win32' || command !== 'shifu.cmd') {
     return { command, args };
   }
   const comspec = options.comspec || env.ComSpec || env.COMSPEC || 'cmd.exe';
+  if (args.some((value) => /[\r\n%!]/.test(String(value)))) {
+    throw new Error(
+      'Windows runtime activation arguments contain unsafe cmd syntax',
+    );
+  }
+  const quote = (value) => {
+    const text = String(value);
+    if (/^[A-Za-z0-9_./:@=+\\-]+$/.test(text)) return text;
+    return `"${text.replaceAll('"', '""')}"`;
+  };
   return {
     command: comspec,
-    args: [
-      '/d',
-      '/s',
-      '/c',
-      `call ${cmdCommand(path.join(root, 'shifu.cmd'), args)}`,
-    ],
+    args: ['/d', '/s', '/c', ['shifu.cmd', ...args.map(quote)].join(' ')],
   };
 }
 

--- a/framework/core/tests/qualification/runtime-activation/run.test.mjs
+++ b/framework/core/tests/qualification/runtime-activation/run.test.mjs
@@ -102,16 +102,23 @@ test('Windows suites invoke the repository Shifu shim through ComSpec', () => {
     { command: ['shifu.cmd', 'exec', 'argument with spaces'] },
     {
       platform: 'win32',
-      root: '/repo root',
       comspec: 'C:\\Windows\\System32\\cmd.exe',
       env: {},
     },
   );
   assert.equal(invocation.command, 'C:\\Windows\\System32\\cmd.exe');
   assert.deepEqual(invocation.args.slice(0, 3), ['/d', '/s', '/c']);
-  assert.equal(
-    invocation.args[3],
-    'call "/repo root/shifu.cmd" "exec" "argument with spaces"',
+  assert.equal(invocation.args[3], 'shifu.cmd exec "argument with spaces"');
+});
+
+test('Windows suite invocation rejects cmd expansion syntax', () => {
+  assert.throws(
+    () =>
+      suiteInvocation(
+        { command: ['shifu.cmd', 'exec', 'task%PATH%'] },
+        { platform: 'win32', env: {} },
+      ),
+    /unsafe cmd syntax/,
   );
 });
 


### PR DESCRIPTION
## Summary

- invoke Windows runtime-activation suites through ComSpec with the repository welded shim token left unquoted
- quote only suite arguments and reject cmd expansion syntax
- preserve spawn failures in checksummed raw qualification logs

## Validation

- `./shifu exec node --test framework/core/tests/qualification/runtime-activation/run.test.mjs` (9/9)
- `SHIFU_CACHE_BYPASS=source-acceptance ./shifu check:source` (329 Node, 76 runtime upgrade, 69 desktop update; TypeScript and Biome passed)

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Restores the existing Windows runtime-activation qualification launcher without changing runtime architecture or product claims."
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

This PR repairs qualification execution and retained diagnostics only; it does not publish or deploy artifacts.

## Checklist

- [x] Commit is signed off (DCO)
- [x] Source acceptance is green locally
- [x] No credentials or generated qualification evidence are committed