### PR TITLE
fix(qualification): separate manual signing policy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,7 +73,11 @@ jobs:
       # On Linux it qualifies Episodes before running the ADR
       # release-admissibility gate.
       # shifu-entry-contract: allow cross-platform release qualification dispatch into the canonical shifu shim
-      verify-command: node scripts/run-release-qualification.mjs --execution-profile ${{ startsWith(github.base_ref, 'release/') && 'release-candidate' || 'alpha' }}
+      # Pull requests into alpha/release remain fail-closed on the credential-
+      # bearing native signing/notarization campaign. Manual frozen-ref runs
+      # exercise the same functional and artifact Gates without importing
+      # production signing credentials into the ordinary build runner profile.
+      verify-command: node scripts/run-release-qualification.mjs --execution-profile ${{ startsWith(github.base_ref, 'release/') && 'release-candidate' || 'alpha' }} --native-upgrade-policy ${{ github.event_name == 'pull_request' && 'required' || 'skip' }}
       release-candidate: true
       publish-channel: ${{ github.event_name == 'pull_request' && (startsWith(github.base_ref, 'release/') && 'release' || 'alpha') || 'none' }}
       artifact-transfer-mode: s3-to-github-artifacts

--- a/docs/qualification/gates/workflow-bindings.json
+++ b/docs/qualification/gates/workflow-bindings.json
@@ -297,7 +297,7 @@
           "require-install": true,
           "require-build": true,
           "require-verify": true,
-        "verify-command": "node scripts/run-release-qualification.mjs --execution-profile ${{ startsWith(github.base_ref, 'release/') && 'release-candidate' || 'alpha' }}",
+          "verify-command": "node scripts/run-release-qualification.mjs --execution-profile ${{ startsWith(github.base_ref, 'release/') && 'release-candidate' || 'alpha' }} --native-upgrade-policy ${{ github.event_name == 'pull_request' && 'required' || 'skip' }}",
           "release-candidate": true,
           "publish-channel": "${{ github.event_name == 'pull_request' && (startsWith(github.base_ref, 'release/') && 'release' || 'alpha') || 'none' }}",
           "artifact-transfer-mode": "s3-to-github-artifacts",

--- a/scripts/run-release-qualification.mjs
+++ b/scripts/run-release-qualification.mjs
@@ -109,22 +109,36 @@ export function loadExecutionProfile(name, file = EXECUTION_PROFILES) {
 }
 
 export function parseExecutionProfile(argv) {
+  return parseReleaseQualificationOptions(argv).executionProfile;
+}
+
+export function parseReleaseQualificationOptions(argv) {
   let name = '';
+  let nativeUpgradePolicy = 'required';
+  let nativeUpgradePolicySeen = false;
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
-    if (arg !== '--execution-profile')
+    if (!['--execution-profile', '--native-upgrade-policy'].includes(arg))
       throw new Error(`unknown release qualification option: ${arg}`);
     index += 1;
-    if (index >= argv.length)
-      throw new Error('--execution-profile requires a value');
-    if (name) throw new Error('--execution-profile may be specified once');
-    name = argv[index];
+    if (index >= argv.length) throw new Error(`${arg} requires a value`);
+    if (arg === '--execution-profile') {
+      if (name) throw new Error('--execution-profile may be specified once');
+      name = argv[index];
+      continue;
+    }
+    if (nativeUpgradePolicySeen)
+      throw new Error('--native-upgrade-policy may be specified once');
+    nativeUpgradePolicySeen = true;
+    nativeUpgradePolicy = argv[index];
   }
   if (!name)
     throw new Error(
       '--execution-profile is required (alpha, release-candidate, or full-patrol)',
     );
-  return name;
+  if (!['required', 'skip'].includes(nativeUpgradePolicy))
+    throw new Error('--native-upgrade-policy must be required or skip');
+  return { executionProfile: name, nativeUpgradePolicy };
 }
 
 export function releaseQualificationEnvironment(
@@ -160,7 +174,10 @@ export function releaseQualificationEnvironment(
 export function releaseQualificationStages(
   platform = process.platform,
   execution = loadExecutionProfile('full-patrol'),
+  nativeUpgradePolicy = 'required',
 ) {
+  if (!['required', 'skip'].includes(nativeUpgradePolicy))
+    throw new Error(`unknown native upgrade policy: ${nativeUpgradePolicy}`);
   const stages = [
     ['verify', '--fuzz'],
     [
@@ -229,7 +246,8 @@ export function releaseQualificationStages(
       policyRef: execution.policyRef,
     }),
   ]);
-  stages.push(['upgrade:qualify:native']);
+  if (nativeUpgradePolicy === 'required')
+    stages.push(['upgrade:qualify:native']);
   return stages;
 }
 
@@ -268,7 +286,13 @@ function artifactManifestDigest() {
   );
 }
 
-function writeSummary(execution, timings, status, startedAt) {
+function writeSummary(
+  execution,
+  timings,
+  status,
+  startedAt,
+  nativeUpgradePolicy,
+) {
   const receiptPath = path.join(
     ROOT,
     'product',
@@ -318,6 +342,7 @@ function writeSummary(execution, timings, status, startedAt) {
     startedAt,
     status: withinLimit ? 'passed' : 'failed',
     executionProfile: execution.name,
+    nativeUpgradePolicy,
     effectiveParameters: execution.parameters,
     policy: { ref: execution.policyRef, digest: execution.policyDigest },
     timings,
@@ -341,7 +366,8 @@ function writeSummary(execution, timings, status, startedAt) {
 }
 
 export function main(argv = process.argv.slice(2)) {
-  const execution = loadExecutionProfile(parseExecutionProfile(argv));
+  const options = parseReleaseQualificationOptions(argv);
+  const execution = loadExecutionProfile(options.executionProfile);
   const env = releaseQualificationEnvironment(
     ROOT,
     process.env,
@@ -350,7 +376,11 @@ export function main(argv = process.argv.slice(2)) {
   const timings = [];
   const startedAt = new Date().toISOString();
   let finalStatus = 0;
-  for (const args of releaseQualificationStages(process.platform, execution)) {
+  for (const args of releaseQualificationStages(
+    process.platform,
+    execution,
+    options.nativeUpgradePolicy,
+  )) {
     const started = Date.now();
     const status = runShifuWithCache(args, { env });
     timings.push({
@@ -363,7 +393,13 @@ export function main(argv = process.argv.slice(2)) {
       break;
     }
   }
-  const summary = writeSummary(execution, timings, finalStatus, startedAt);
+  const summary = writeSummary(
+    execution,
+    timings,
+    finalStatus,
+    startedAt,
+    options.nativeUpgradePolicy,
+  );
   if (finalStatus === 0 && !summary.budget.withinLimit) {
     console.error(
       `[release-qualification] execution profile ${execution.name} exceeded its ${summary.budget.executionLimitSeconds}s execution limit`,

--- a/scripts/run-release-qualification.test.mjs
+++ b/scripts/run-release-qualification.test.mjs
@@ -9,6 +9,7 @@ import { test } from 'node:test';
 import {
   loadExecutionProfile,
   parseExecutionProfile,
+  parseReleaseQualificationOptions,
   releaseQualificationEnvironment,
   releaseQualificationStages,
 } from './run-release-qualification.mjs';
@@ -87,6 +88,19 @@ test('every platform runs the complete qualification stage sequence', () => {
       ),
       required,
     );
+});
+
+test('manual qualification can explicitly omit the credential-bearing native signing campaign', () => {
+  for (const platform of ['linux', 'darwin', 'win32']) {
+    const stages = releaseQualificationStages(
+      platform,
+      loadExecutionProfile('alpha'),
+      'skip',
+    ).map(([name]) => name);
+    assert.ok(stages.includes('zero-burden:qualify'));
+    assert.ok(stages.includes('gate'));
+    assert.ok(!stages.includes('upgrade:qualify:native'));
+  }
 });
 
 test('cryptographic upgrade qualification runs before artifact layer admission', () => {
@@ -203,6 +217,37 @@ test('execution profile parsing fails closed on missing, duplicate, and unknown 
     /specified once/,
   );
   assert.throws(() => loadExecutionProfile('missing'), /unknown/);
+  assert.deepEqual(
+    parseReleaseQualificationOptions([
+      '--execution-profile',
+      'alpha',
+      '--native-upgrade-policy',
+      'skip',
+    ]),
+    { executionProfile: 'alpha', nativeUpgradePolicy: 'skip' },
+  );
+  assert.throws(
+    () =>
+      parseReleaseQualificationOptions([
+        '--execution-profile',
+        'alpha',
+        '--native-upgrade-policy',
+        'invalid',
+      ]),
+    /must be required or skip/,
+  );
+  assert.throws(
+    () =>
+      parseReleaseQualificationOptions([
+        '--execution-profile',
+        'alpha',
+        '--native-upgrade-policy',
+        'required',
+        '--native-upgrade-policy',
+        'skip',
+      ]),
+    /may be specified once/,
+  );
 });
 
 test('execution profile numeric constraints reject zero and negative values', () => {


### PR DESCRIPTION
## Summary

- keep the complete alpha/release Buildchain qualification fail-closed on native signing and notarization
- let trusted manual frozen-ref runs exercise the same functional and artifact Gates without importing production signing credentials into ordinary build runners
- record the selected native upgrade policy in the retained qualification summary
- retain all existing live Peer, runtime activation, zero-burden desktop, layer Gate, report, and compressed raw-log stages in manual runs

## Related issue

None.

## Changes

- add a fail-closed `--native-upgrade-policy required|skip` qualification option, defaulting to `required`
- bind alpha/release pull requests to `required` and workflow dispatch to explicit `skip`
- update the structured workflow binding and focused contract tests

## Verification

- `node --test scripts/run-release-qualification.test.mjs scripts/qualification-artifact-catalog.test.mjs` (15 passed)
- `./shifu check:source` (build-free source gate passed)
- staged repository gate passed during DCO commit
- `git diff --check`

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Separates credential-bearing native signing policy by workflow event without changing the runtime, release identity, or architecture contracts."
}
-->

## Governance risk check

- [x] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

Boundary: production signing and notarization remain mandatory only in the protected alpha/release PR gate. Manual validation records an explicit skip and never receives or handles signing credentials. No credentials, private logs, or generated qualification evidence are committed.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed
- [x] Source acceptance is green
- [x] No credentials or generated qualification evidence are committed