### PR TITLE
fix(qualification): budget complete hosted alpha gate

### DIFF
--- a/docs/qualification/gates/execution-profiles.json
+++ b/docs/qualification/gates/execution-profiles.json
@@ -2,9 +2,9 @@
   "schema": "kungfu.qualification-execution-profiles/v1",
   "profiles": {
     "alpha": {
-      "budgetSeconds": 2700,
-      "upstreamBudgetSeconds": 750,
-      "reserveSeconds": 240,
+      "budgetSeconds": 5400,
+      "upstreamBudgetSeconds": 2400,
+      "reserveSeconds": 600,
       "fuzzSecondsPerTarget": 90,
       "episodeProfile": "mvp-smoke-v1",
       "episodeTimeoutSeconds": 600

--- a/docs/qualification/gates/policy-matrix.md
+++ b/docs/qualification/gates/policy-matrix.md
@@ -54,7 +54,7 @@ Do not hand-edit the generated block. A mode applies when the corresponding
 
 | Execution profile | Budget (s) | Upstream build (s) | Reserve (s) | Episode profile | Episode ceiling (s) | Fuzz seconds/target |
 | --- | ---: | ---: | ---: | --- | ---: | ---: |
-| `alpha` | 2700 | 750 | 240 | `mvp-smoke-v1` | 600 | 90 |
+| `alpha` | 5400 | 2400 | 600 | `mvp-smoke-v1` | 600 | 90 |
 | `release-candidate` | 3600 | 900 | 600 | `mvp-candidate-v1` | 1200 | 90 |
 | `full-patrol` | 14400 | 900 | 900 | `mvp-baseline-v1` | 7200 | 90 |
 

--- a/docs/qualification/layer-gate-timing-baseline.md
+++ b/docs/qualification/layer-gate-timing-baseline.md
@@ -247,19 +247,25 @@ bounding only the Episode seeds and accumulation/contention counts:
 
 | Execution profile | End-to-end budget | Upstream allowance | Reserve | Episode workload |
 | --- | ---: | ---: | ---: | --- |
-| `alpha` | 2700s | 750s | 240s | `mvp-smoke-v1` |
+| `alpha` | 5400s | 2400s | 600s | `mvp-smoke-v1` |
 | `release-candidate` | 3600s | 900s | 600s | `mvp-candidate-v1` |
 | `full-patrol` | 14400s | 900s | 900s | unchanged `mvp-baseline-v1` |
 
-The alpha figures are anchored to the slowest measured upstream host
+The original alpha figures were anchored to the slowest measured upstream host
 (`673.13s` Linux install plus distribution) with additional setup allowance.
 The first exact-source hosted acceptance run then measured `1467s` inside the
 qualification process because runtime activation intentionally rebuilds and
-verifies the complete product distribution. The original `810s` execution
-allowance therefore rejected an otherwise passing Linux campaign. The revised
-alpha total preserves the upstream and reserve allocations while raising the
-qualification execution allowance to `1710s`; it does not skip or shorten any
-gate.
+verifies the complete product distribution. That raised the execution
+allowance from `810s` to `1710s`.
+
+GitHub run `29410685685` later exercised the expanded exact-source product gate
+on hosted Linux. Install plus build consumed `2086s`; the qualification wrapper
+then ran for `1751s`, reached the native upgrade evidence stage with all prior
+stages passing, and failed only because it exceeded the `1710s` execution
+allowance. The revised alpha profile reserves `2400s` for upstream work and
+`600s` for transfer and variance, leaving a `2400s` qualification execution
+allowance inside a `5400s` end-to-end budget. It does not skip or shorten any
+gate, fuzz target, or Episode workload.
 The release profile adds the measured 10,000 accumulation checkpoint while the
 100,000 checkpoint and three-seed soak remain available in full-patrol. The
 workflow summary fails when qualification exceeds the budget after subtracting

--- a/scripts/run-release-qualification.test.mjs
+++ b/scripts/run-release-qualification.test.mjs
@@ -175,6 +175,25 @@ test('the Gate stage emits one source-bound receipt for all artifact layers', ()
 });
 
 test('execution profiles propagate bounded Episode and receipt parameters', () => {
+  const alpha = loadExecutionProfile('alpha');
+  assert.deepEqual(
+    {
+      budgetSeconds: alpha.parameters.budgetSeconds,
+      upstreamBudgetSeconds: alpha.parameters.upstreamBudgetSeconds,
+      reserveSeconds: alpha.parameters.reserveSeconds,
+    },
+    {
+      budgetSeconds: 5400,
+      upstreamBudgetSeconds: 2400,
+      reserveSeconds: 600,
+    },
+  );
+  assert.equal(
+    alpha.parameters.budgetSeconds -
+      alpha.parameters.upstreamBudgetSeconds -
+      alpha.parameters.reserveSeconds,
+    2400,
+  );
   const release = loadExecutionProfile('release-candidate');
   const stages = releaseQualificationStages('linux', release);
   const episode = stages.find(([name]) => name === 'episode:qualify:release');
@@ -269,7 +288,7 @@ test('execution profile numeric constraints reject zero and negative values', ()
       () => loadExecutionProfile('alpha', file),
       /positive integer/,
     );
-    valid.profiles.alpha.budgetSeconds = 2700;
+    valid.profiles.alpha.budgetSeconds = 5400;
     valid.profiles.alpha.reserveSeconds = -1;
     fs.writeFileSync(file, JSON.stringify(valid));
     assert.throws(


### PR DESCRIPTION
## Summary

- raise the hosted alpha budget to cover the complete measured install, build, and qualification lifecycle
- retain every gate, fuzz target, and Episode workload while reserving explicit upstream and variance allowances
- bind the alpha budget contract in tests and record the exact hosted timing evidence

## Validation

- `./shifu exec node --test scripts/run-release-qualification.test.mjs scripts/check-kungfu-gate-catalog.test.mjs` (30/30)
- `SHIFU_CACHE_BYPASS=source-acceptance ./shifu check:source` (329 Node, 76 runtime upgrade, 69 desktop update; TypeScript and Biome passed)

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Calibrates the existing hosted alpha qualification budget from exact run evidence without changing architecture, gate workload, or product claims."
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

This PR adjusts qualification timing policy only; it does not publish or deploy artifacts.

## Checklist

- [x] Commit is signed off (DCO)
- [x] Source acceptance is green locally
- [x] No credentials or generated qualification evidence are committed