### PR TITLE
fix(qualification): return from Windows Shifu shim

### DIFF
--- a/framework/core/tests/qualification/runtime-activation/run.mjs
+++ b/framework/core/tests/qualification/runtime-activation/run.mjs
@@ -317,7 +317,12 @@ export function suiteInvocation(suite, options = {}) {
   };
   return {
     command: comspec,
-    args: ['/d', '/s', '/c', ['shifu.cmd', ...args.map(quote)].join(' ')],
+    args: [
+      '/d',
+      '/s',
+      '/c',
+      ['call', 'shifu.cmd', ...args.map(quote)].join(' '),
+    ],
   };
 }
 

--- a/framework/core/tests/qualification/runtime-activation/run.test.mjs
+++ b/framework/core/tests/qualification/runtime-activation/run.test.mjs
@@ -108,7 +108,10 @@ test('Windows suites invoke the repository Shifu shim through ComSpec', () => {
   );
   assert.equal(invocation.command, 'C:\\Windows\\System32\\cmd.exe');
   assert.deepEqual(invocation.args.slice(0, 3), ['/d', '/s', '/c']);
-  assert.equal(invocation.args[3], 'shifu.cmd exec "argument with spaces"');
+  assert.equal(
+    invocation.args[3],
+    'call shifu.cmd exec "argument with spaces"',
+  );
 });
 
 test('Windows suite invocation rejects cmd expansion syntax', () => {


### PR DESCRIPTION
## Summary

- invoke the welded Windows Shifu batch shim with `call` so nested qualification commands return to the Node harness
- retain the unquoted shim token and argument quoting/expansion rejection from the prior Windows launcher fix
- cover the exact `call shifu.cmd ...` payload in the launcher contract test

## Hosted evidence

- exact-source run `29416494142` passed build, product packaging, 42/42 base verify, three 90-second fuzz targets, and live-peer/native restart on Windows
- the first runtime-activation suite then stopped at `Terminate batch job (Y/N)?`, proving the batch-return boundary was the remaining failure

## Validation

- `./shifu exec node --test framework/core/tests/qualification/runtime-activation/run.test.mjs` (9/9)
- `SHIFU_CACHE_BYPASS=source-acceptance ./shifu check:source` (329 Node, 76 runtime upgrade, 69 desktop update; TypeScript and Biome passed)

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Repairs nested Windows batch return semantics in the existing qualification launcher without changing runtime architecture or product claims."
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

This PR repairs qualification execution only; it does not publish or deploy artifacts.

## Checklist

- [x] Commit is signed off (DCO)
- [x] Source acceptance is green locally
- [x] No credentials or generated qualification evidence are committed