### PR TITLE
feat(core): add git workspace episode provider

### DIFF
--- a/docs/adr/ADR-0099-git-workspace-episode-provider.md
+++ b/docs/adr/ADR-0099-git-workspace-episode-provider.md
@@ -1,0 +1,165 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+doc_type: architecture-decision
+adr_id: ADR-0099
+decision_status: proposed
+implementation_status: unknown
+qualification_refs: [scripts/check-git-episode-provider.test.mjs]
+review_state: self-reviewed
+sensitivity: public
+sources: [local-files, user-consensus]
+period: 2026-07-15
+theme: git-workspace-episode-provider
+confidence: high
+evidence_grade: B
+last_reviewed: 2026-07-15
+---
+
+# ADR-0099: Git Workspace stores qualified sealed Episodes as immutable per-Episode segments
+
+- Status: proposed; implementation evidence pending PR publication
+- Date: 2026-07-15
+- Category: Episode provider / Git workspace / immutable facts
+- Related: [ADR-0034](ADR-0034-yijinjing-episode-manifest-journal.md),
+  [ADR-0041](ADR-0041-episode-manifest-first-class-journal-structure.md),
+  [ADR-0042](ADR-0042-episode-atomic-safety-and-qualification.md),
+  [ADR-0043](ADR-0043-episode-identity-sealed-content-root.md),
+  [ADR-0053](ADR-0053-self-contained-episode-bundles.md), and
+  [ADR-0098](ADR-0098-project-cut-v1-canonical-root-and-source-projection.md)
+
+## Context
+
+Kungfu Episodes are authoritative yijinjing POD journal facts folded by one C++
+typed implementation. The content-addressed-file and RocksDB providers beneath
+the runtime storage service store payload bodies; they do not own a second
+Episode identity, fold, query, or fsck language.
+
+Low-frequency project work also needs a form that can travel with a Git
+workspace, survive branch review, and merge as an immutable object set. A
+single shared JSONL ledger is unsuitable: concurrent worktrees would contend
+on one append point, merge conflicts would couple unrelated Episodes, a global
+number allocator would serialize publication, and torn tails would affect an
+unbounded history. Copying the C++ fold into JavaScript would be worse because
+the shadow could silently disagree with the authority it claims to preserve.
+
+## Decision
+
+### 1. The provider is a qualified shadow, not Episode authority
+
+`git-workspace-jsonl/v1` admits only a thin
+`kungfu.storage.episode-bundle/v1` for an ended Episode with a recorded
+`sha256` Episode root, plus matching `kungfu.episode.qualification/v1`
+evidence produced by `cpp-typed-fold-fsck`. The qualification must identify
+the same Episode, report lifecycle `ended`, status `ok`, and safely advertise
+`export_evidence`.
+
+The provider preserves the recorded `kungfu.episode-root/v1` as
+`semanticRoot`. It does not recompute that journal-native POD root from JSON.
+It computes a separate `providerRoot` under
+`sha256-kungfu-git-episode-canonical-json-v1` over its canonical manifest, which
+commits to the JSONL digest, qualification root, dependencies, and content
+references. Equality of provider roots never implies Episode semantic equality
+without the qualified semantic-root declaration.
+
+### 2. One sealed Episode is one immutable segment
+
+Tracked state is:
+
+```text
+.kungfu/episodes/sealed/sha256/<prefix>/<semantic-root>/
+  manifest.json
+  claims.jsonl
+```
+
+The provider creates a tracked `.kungfu/.gitignore` that excludes `runtime/`,
+`episodes/.tmp/`, `private/`, and `cache/`. If an existing ignore file lacks
+any required exclusion, publication fails rather than overwriting or silently
+widening repository policy.
+
+`claims.jsonl` contains canonical JSON records framed with LF, each carrying a
+zero-based append-order index. It is local to one Episode. Sealed files are
+never edited in place. Git merge is set union over content-addressed segment
+directories; a same-root/different-provider-root collision is a verification
+failure, not a text merge policy.
+
+Open state, leases, temporary publication directories, caches, projections,
+and private material are not tracked authority:
+
+```text
+.kungfu/runtime/episode-provider/
+.kungfu/episodes/.tmp/
+.kungfu/private/
+.kungfu/cache/
+```
+
+Self-contained bundle `journals`, `ref_payloads`, and material bytes are
+rejected. Large or private bodies remain behind auditable content roots and
+refs rather than entering Git.
+
+### 3. Publication is per-Episode and atomic at directory visibility
+
+Each semantic root has one exclusive-create lease carrying writer identity and
+generation. Different roots use different lease files and share no ledger
+lock, global allocator, or publication lock. A second writer for the same root
+fails `episode-writer-busy`.
+
+The writer creates a unique sibling temporary directory, writes and fsyncs the
+claims and manifest, fsyncs the temporary directory, atomically renames it to
+the content-addressed destination, and fsyncs the parent directory. A crash
+before rename leaves no published Episode and an inspectable incomplete temp.
+A retry after successful publication is idempotent when both roots match.
+
+### 4. Git-provider fsck verifies representation, not Episode semantics
+
+Provider fsck checks known schemas, semantic/provider root consistency, exact
+claims digest and count, terminal LF, canonical JSONL, zero-based order, and
+duplicate indexes. Torn tails, malformed rows, duplicates, out-of-order rows,
+hash mismatch, unknown schema, missing files, and root collisions are bounded
+and fail visible.
+
+The C++ Episode fsck remains responsible for lifecycle, causal closure,
+payload/frame integrity, qualification, and recomputing the Episode root. A
+future authority cutover requires shadow parity and a declared qualification
+profile; this ADR does not perform one.
+
+### 5. Provider capability claims remain explicit
+
+| Provider composition | Episode authority | Computes Episode root | Preserves qualified root | Git tracked |
+| --- | --- | --- | --- | --- |
+| yijinjing + content-addressed-file | yes | yes | yes | no |
+| yijinjing + RocksDB | yes | yes | yes | no |
+| Git Workspace JSONL | no | no | yes | yes |
+
+The first two rows differ only in payload-provider implementation. The third is
+a portable shadow of already-qualified sealed claims. No row may advertise a
+capability stronger than its evidence.
+
+## Falsification and acceptance gates
+
+- Two different semantic roots seal without a shared lease.
+- A pre-existing lease rejects a second writer for the same root.
+- A fault before rename leaves no visible sealed segment and reports one
+  incomplete temp.
+- Cross-workspace export/import preserves both semantic and provider roots;
+  retry is a no-op.
+- Torn tail, duplicate index, out-of-order index, claims hash drift, unknown
+  schema, unqualified root, and self-contained private material are rejected.
+- Source acceptance runs the build-free deterministic fixtures.
+
+## Consequences
+
+- Low-frequency Episodes can move and review with source without creating a
+  global append bottleneck.
+- JSONL remains an interchange/storage projection with its own root rather
+  than becoming a competing Episode fact engine.
+- Git history can settle immutable Episode objects in later work, while open
+  runtime bytes stay local.
+- Qualification evidence is an admission dependency; an unqualified or
+  degraded Episode cannot be smuggled into a Project Cut as equivalent.
+
+## Non-claims
+
+This decision does not migrate a real `.kungfu`, replace yijinjing authority,
+recompute POD roots from JSON, store raw transcripts or payload bytes, define
+Git settlement/history commands, or qualify a production filesystem profile.
+Those operations require later staged evidence and explicit cutover.

--- a/docs/adr/ADR-0099-git-workspace-episode-provider.md
+++ b/docs/adr/ADR-0099-git-workspace-episode-provider.md
@@ -2,8 +2,10 @@
 metadata_schema: kungfu.document-metadata/v1
 doc_type: architecture-decision
 adr_id: ADR-0099
-decision_status: proposed
-implementation_status: unknown
+decision_status: accepted
+implementation_status: implemented
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/963]
+closure_pr: https://github.com/kungfu-systems/kungfu/pull/963
 qualification_refs: [scripts/check-git-episode-provider.test.mjs]
 review_state: self-reviewed
 sensitivity: public
@@ -17,7 +19,7 @@ last_reviewed: 2026-07-15
 
 # ADR-0099: Git Workspace stores qualified sealed Episodes as immutable per-Episode segments
 
-- Status: proposed; implementation evidence pending PR publication
+- Status: accepted; implementation implemented by PR #963
 - Date: 2026-07-15
 - Category: Episode provider / Git workspace / immutable facts
 - Related: [ADR-0034](ADR-0034-yijinjing-episode-manifest-journal.md),

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -168,7 +168,7 @@ implemented and qualified or explicitly waived for that release.
 | [0096](ADR-0096-xinfa-bounded-projection-and-task-chart.md) | accepted | Xinfa compiles bounded Human, Task Chart, and GUI projections from one Atlas while generated outputs remain provider-excluded derived data |
 | [0097](ADR-0097-project-cut-spacetime-and-publication-boundary.md) | accepted | Project Cut binds source publication, one Xinfa Atlas, and admitted Kungfu Episode change without collapsing their authority or introducing a Git hash cycle |
 | [0098](ADR-0098-project-cut-v1-canonical-root-and-source-projection.md) | accepted | Project Cut v1 freezes a closed canonical root input, explicit source projection policy, separate semantic/artifact/receipt identities, and fail-visible diagnostics |
-| [0099](ADR-0099-git-workspace-episode-provider.md) | proposed | Git Workspace stores qualified sealed Episodes as immutable per-Episode JSONL segments without becoming Episode authority |
+| [0099](ADR-0099-git-workspace-episode-provider.md) | accepted | Git Workspace stores qualified sealed Episodes as immutable per-Episode JSONL segments without becoming Episode authority |
 | [SHIFU-0001](SHIFU-ADR-0001-cache-profile-contract-and-ownership.md) | accepted | Cache profiles are Shifu-owned contracts; inventories project instances and Buildchain owns process |
 | [SHIFU-0002](SHIFU-ADR-0002-local-artifact-catalog-and-safe-promotion.md) | accepted | Shifu and Kungfu product artifacts share provenance-aware, Git-safe local promotion semantics |
 | [SHIFU-0003](SHIFU-ADR-0003-uv-effective-lock-cache-enforcement.md) | accepted | Strict uv cache execution uses a disposable effective lock while canonical locks stay public |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -168,6 +168,7 @@ implemented and qualified or explicitly waived for that release.
 | [0096](ADR-0096-xinfa-bounded-projection-and-task-chart.md) | accepted | Xinfa compiles bounded Human, Task Chart, and GUI projections from one Atlas while generated outputs remain provider-excluded derived data |
 | [0097](ADR-0097-project-cut-spacetime-and-publication-boundary.md) | accepted | Project Cut binds source publication, one Xinfa Atlas, and admitted Kungfu Episode change without collapsing their authority or introducing a Git hash cycle |
 | [0098](ADR-0098-project-cut-v1-canonical-root-and-source-projection.md) | accepted | Project Cut v1 freezes a closed canonical root input, explicit source projection policy, separate semantic/artifact/receipt identities, and fail-visible diagnostics |
+| [0099](ADR-0099-git-workspace-episode-provider.md) | proposed | Git Workspace stores qualified sealed Episodes as immutable per-Episode JSONL segments without becoming Episode authority |
 | [SHIFU-0001](SHIFU-ADR-0001-cache-profile-contract-and-ownership.md) | accepted | Cache profiles are Shifu-owned contracts; inventories project instances and Buildchain owns process |
 | [SHIFU-0002](SHIFU-ADR-0002-local-artifact-catalog-and-safe-promotion.md) | accepted | Shifu and Kungfu product artifacts share provenance-aware, Git-safe local promotion semantics |
 | [SHIFU-0003](SHIFU-ADR-0003-uv-effective-lock-cache-enforcement.md) | accepted | Strict uv cache execution uses a disposable effective lock while canonical locks stay public |

--- a/framework/episode-provider/README.md
+++ b/framework/episode-provider/README.md
@@ -1,0 +1,47 @@
+# Git Workspace Episode provider
+
+This build-free provider stores a qualified, sealed Kungfu Episode as one
+immutable Git-friendly segment. It is a shadow representation of the
+yijinjing authority, not a second Episode fold, query, fsck, or root engine.
+
+Tracked layout:
+
+```text
+.kungfu/episodes/sealed/sha256/<prefix>/<episode-root>/
+  manifest.json
+  claims.jsonl
+```
+
+The provider creates `.kungfu/.gitignore` on first use and refuses an existing
+file that does not ignore `runtime/`, `episodes/.tmp/`, `private/`, and
+`cache/`. It never silently widens or overwrites repository ignore policy.
+
+Open state, writer leases, private material, projections, caches, and temporary
+seals stay local under `.kungfu/runtime/episode-provider/` or
+`.kungfu/episodes/.tmp/`. Repositories should ignore both locations. One JSONL
+file belongs to one immutable Episode; there is no global ledger, numeric
+allocator, or publication lock.
+
+The provider admits only a thin `kungfu.storage.episode-bundle/v1` whose
+recorded root is accompanied by `kungfu.episode.qualification/v1` evidence from
+the C++ typed fold/fsck. It preserves that `kungfu.episode-root/v1` identity but
+does not recompute it from JSON. Its separate `providerRoot` commits to the
+canonical JSONL bytes and manifest under
+`sha256-kungfu-git-episode-canonical-json-v1`. Therefore provider-native equality is not
+silently promoted to Episode semantic equality.
+
+The seal path uses a per-Episode exclusive lease, sibling temporary directory,
+file and directory fsync, and atomic rename. Different Episodes share no lock.
+Faults before rename remain visible as incomplete temporary seals; published
+segments are never modified in place. Re-import of identical roots is a no-op,
+while the same semantic root with different provider bytes is rejected.
+
+Run the deterministic contract and fault fixtures:
+
+```sh
+node --test scripts/check-git-episode-provider.test.mjs
+```
+
+This stage does not migrate a real `.kungfu`, replace yijinjing authority,
+commit raw transcript/payload bytes, or claim file/RocksDB payload-provider
+identity as a separate Episode semantic contract.

--- a/framework/episode-provider/git-workspace-provider.contract.json
+++ b/framework/episode-provider/git-workspace-provider.contract.json
@@ -1,0 +1,24 @@
+{
+  "schema": "kungfu.episode.git-workspace-provider-contract/v1",
+  "provider": "git-workspace-jsonl/v1",
+  "status": "shadow",
+  "authority": "yijinjing-journal",
+  "semanticRootContract": "kungfu.episode-root/v1",
+  "providerRootContract": "sha256-kungfu-git-episode-canonical-json-v1",
+  "tracked": [".kungfu/episodes/sealed/sha256/<prefix>/<root>/claims.jsonl", ".kungfu/episodes/sealed/sha256/<prefix>/<root>/manifest.json"],
+  "ignored": [".kungfu/episodes/.tmp/", ".kungfu/runtime/episode-provider/", ".kungfu/private/", ".kungfu/cache/"],
+  "writer": {
+    "scope": "per-episode",
+    "lease": "exclusive-create",
+    "publication": "temp-fsync-rename-dir-fsync",
+    "globalAllocator": false,
+    "globalLedger": false,
+    "globalPublicationLock": false
+  },
+  "equivalence": {
+    "requiresCppQualification": true,
+    "recomputesEpisodeSemanticRoot": false,
+    "preservesQualifiedEpisodeSemanticRoot": true,
+    "providerRootIsEpisodeRoot": false
+  }
+}

--- a/framework/episode-provider/src/git-workspace-episode-provider.mjs
+++ b/framework/episode-provider/src/git-workspace-episode-provider.mjs
@@ -20,8 +20,7 @@ export const GIT_EPISODE_PROVIDER = 'git-workspace-jsonl/v1';
 export const GIT_EPISODE_PROVIDER_ROOT_ALGORITHM =
   'sha256-kungfu-git-episode-canonical-json-v1';
 export const EPISODE_BUNDLE_SCHEMA = 'kungfu.storage.episode-bundle/v1';
-export const EPISODE_QUALIFICATION_SCHEMA =
-  'kungfu.episode.qualification/v1';
+export const EPISODE_QUALIFICATION_SCHEMA = 'kungfu.episode.qualification/v1';
 
 const ROOT = /^sha256:[0-9a-f]{64}$/u;
 const BARE_ROOT = /^[0-9a-f]{64}$/u;
@@ -124,13 +123,18 @@ function recordLines(records) {
 }
 
 function jsonlBytes(lines) {
-  return Buffer.from(`${lines.map((line) => canonicalJson(line)).join('\n')}\n`);
+  return Buffer.from(
+    `${lines.map((line) => canonicalJson(line)).join('\n')}\n`,
+  );
 }
 
 export function buildGitEpisodeSegment(bundle, qualification) {
   requireObject(bundle, 'episode-bundle-invalid', 'Episode bundle is invalid');
   if (bundle.schema !== EPISODE_BUNDLE_SCHEMA) {
-    throw failure('episode-bundle-schema-unknown', 'unsupported Episode bundle');
+    throw failure(
+      'episode-bundle-schema-unknown',
+      'unsupported Episode bundle',
+    );
   }
   thinBundle(bundle);
   const semanticRootValue = portableRoot(bundle);
@@ -286,7 +290,10 @@ export function sealGitEpisode(
   if (!/^[A-Za-z0-9._-]+$/u.test(String(writerId ?? '')))
     throw failure('writer-id-invalid', 'writerId must be a safe path token');
   if (!Number.isSafeInteger(generation) || generation < 1)
-    throw failure('generation-invalid', 'generation must be a positive integer');
+    throw failure(
+      'generation-invalid',
+      'generation must be a positive integer',
+    );
   ensureWorkspaceIgnore(workspaceRoot);
   const paths = episodeProviderPaths(workspaceRoot, segment.semanticRoot);
   fs.mkdirSync(path.dirname(paths.segment), { recursive: true });
@@ -434,7 +441,10 @@ export function importGitEpisode(workspaceRoot, exported, options = {}) {
   }
   const claims = Buffer.from(exported.claims);
   if (sha256Bytes(claims) !== manifest.claims?.digest) {
-    throw failure('episode-export-claims-mismatch', 'Git export claims drifted');
+    throw failure(
+      'episode-export-claims-mismatch',
+      'Git export claims drifted',
+    );
   }
   return sealGitEpisode(
     workspaceRoot,
@@ -451,10 +461,13 @@ export function importGitEpisode(workspaceRoot, exported, options = {}) {
 export function inspectEpisodeProviderTemps(workspaceRoot) {
   const root = path.join(workspaceRoot, '.kungfu', 'episodes', '.tmp');
   if (!fs.existsSync(root)) return [];
-  return fs.readdirSync(root).sort().map((name) => ({
-    code: 'incomplete-seal',
-    path: path.join(root, name),
-  }));
+  return fs
+    .readdirSync(root)
+    .sort()
+    .map((name) => ({
+      code: 'incomplete-seal',
+      path: path.join(root, name),
+    }));
 }
 
 export function recoverGitEpisodeLease(
@@ -467,7 +480,10 @@ export function recoverGitEpisodeLease(
   try {
     lease = JSON.parse(fs.readFileSync(paths.lease, 'utf8'));
   } catch {
-    return { status: 'no-lease', incomplete: inspectEpisodeProviderTemps(workspaceRoot) };
+    return {
+      status: 'no-lease',
+      incomplete: inspectEpisodeProviderTemps(workspaceRoot),
+    };
   }
   if (
     lease.writerId !== expectedWriterId ||

--- a/framework/episode-provider/src/git-workspace-episode-provider.mjs
+++ b/framework/episode-provider/src/git-workspace-episode-provider.mjs
@@ -1,0 +1,514 @@
+// SPDX-License-Identifier: Apache-2.0
+// @ts-check
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+import {
+  canonicalJson,
+  semanticRoot,
+  sha256Bytes,
+} from '../../project-cut/src/project-cut.mjs';
+
+export const GIT_EPISODE_SEGMENT_SCHEMA =
+  'kungfu.episode.git-workspace-segment/v1';
+export const GIT_EPISODE_MANIFEST_SCHEMA =
+  'kungfu.episode.git-workspace-manifest/v1';
+export const GIT_EPISODE_RECEIPT_SCHEMA =
+  'kungfu.episode.git-workspace-receipt/v1';
+export const GIT_EPISODE_PROVIDER = 'git-workspace-jsonl/v1';
+export const GIT_EPISODE_PROVIDER_ROOT_ALGORITHM =
+  'sha256-kungfu-git-episode-canonical-json-v1';
+export const EPISODE_BUNDLE_SCHEMA = 'kungfu.storage.episode-bundle/v1';
+export const EPISODE_QUALIFICATION_SCHEMA =
+  'kungfu.episode.qualification/v1';
+
+const ROOT = /^sha256:[0-9a-f]{64}$/u;
+const BARE_ROOT = /^[0-9a-f]{64}$/u;
+const SEGMENT_FILE = 'claims.jsonl';
+const MANIFEST_FILE = 'manifest.json';
+const WORKSPACE_IGNORE = 'runtime/\nepisodes/.tmp/\nprivate/\ncache/\n';
+
+function failure(code, message, details = {}) {
+  return Object.assign(new Error(message), { code, ...details });
+}
+
+function isObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function requireObject(value, code, message) {
+  if (!isObject(value)) throw failure(code, message);
+  return value;
+}
+
+function portableRoot(bundle) {
+  const manifest = requireObject(
+    bundle.manifest,
+    'episode-manifest-missing',
+    'Episode bundle has no folded manifest',
+  );
+  if (manifest.closed !== true || manifest.status !== 'ended') {
+    throw failure('episode-not-sealed', 'only ended Episodes may be sealed');
+  }
+  if (
+    manifest.content_root_algorithm !== 'sha256' ||
+    !BARE_ROOT.test(String(manifest.content_root ?? ''))
+  ) {
+    throw failure(
+      'episode-root-unqualified',
+      'bundle has no supported recorded Episode root',
+    );
+  }
+  return `sha256:${manifest.content_root}`;
+}
+
+function verifyQualification(bundle, qualification) {
+  requireObject(
+    qualification,
+    'qualification-missing',
+    'C++ Episode qualification evidence is required',
+  );
+  if (qualification.schema !== EPISODE_QUALIFICATION_SCHEMA) {
+    throw failure('qualification-schema-unknown', 'unsupported qualification');
+  }
+  if (
+    qualification.policy_source !== 'cpp-typed-fold-fsck' ||
+    qualification.lifecycle !== 'ended' ||
+    qualification.status !== 'ok' ||
+    qualification.episode_id !== bundle.episode_id
+  ) {
+    throw failure(
+      'qualification-not-admissible',
+      'qualification does not admit this sealed Episode',
+    );
+  }
+  const exportCapability = qualification.capabilities?.find(
+    (entry) => entry?.name === 'export_evidence',
+  );
+  if (exportCapability?.safe !== true) {
+    throw failure(
+      'qualification-capability-missing',
+      'export_evidence is not qualified',
+    );
+  }
+}
+
+function thinBundle(bundle) {
+  const forbidden = ['journals', 'ref_payloads', 'material'];
+  for (const field of forbidden) {
+    if (Object.hasOwn(bundle, field)) {
+      throw failure(
+        'private-material-not-admitted',
+        `Git Episode segments reject bundle field '${field}'`,
+      );
+    }
+  }
+  if (bundle.self_contained === true) {
+    throw failure(
+      'private-material-not-admitted',
+      'self-contained runtime bytes are not Git-tracked material',
+    );
+  }
+}
+
+function recordLines(records) {
+  if (!Array.isArray(records) || records.length === 0) {
+    throw failure('episode-records-missing', 'bundle records are required');
+  }
+  return records.map((record, index) => ({
+    schema: GIT_EPISODE_SEGMENT_SCHEMA,
+    index,
+    record,
+  }));
+}
+
+function jsonlBytes(lines) {
+  return Buffer.from(`${lines.map((line) => canonicalJson(line)).join('\n')}\n`);
+}
+
+export function buildGitEpisodeSegment(bundle, qualification) {
+  requireObject(bundle, 'episode-bundle-invalid', 'Episode bundle is invalid');
+  if (bundle.schema !== EPISODE_BUNDLE_SCHEMA) {
+    throw failure('episode-bundle-schema-unknown', 'unsupported Episode bundle');
+  }
+  thinBundle(bundle);
+  const semanticRootValue = portableRoot(bundle);
+  verifyQualification(bundle, qualification);
+  const lines = recordLines(bundle.records);
+  const claims = jsonlBytes(lines);
+  const claimsDigest = sha256Bytes(claims);
+  const qualificationRoot = semanticRoot(qualification);
+  const manifestPreimage = {
+    schema: GIT_EPISODE_MANIFEST_SCHEMA,
+    provider: GIT_EPISODE_PROVIDER,
+    providerRootAlgorithm: GIT_EPISODE_PROVIDER_ROOT_ALGORITHM,
+    authority: 'shadow-of-yijinjing-journal',
+    episodeId: bundle.episode_id,
+    semanticRoot: semanticRootValue,
+    semanticRootContract: 'kungfu.episode-root/v1',
+    qualificationRoot,
+    claims: {
+      path: SEGMENT_FILE,
+      digest: claimsDigest,
+      count: lines.length,
+      framing: 'canonical-json-lines-lf/v1',
+    },
+    contentRefs: [
+      ...new Set(
+        (bundle.refs ?? [])
+          .map((entry) => entry?.record?.ref_hash ?? entry?.ref_hash)
+          .filter((entry) => typeof entry === 'string' && ROOT.test(entry)),
+      ),
+    ].sort(),
+    dependencies: bundle.dependencies ?? [],
+  };
+  const providerRoot = semanticRoot(manifestPreimage);
+  const manifest = { ...manifestPreimage, providerRoot };
+  return {
+    semanticRoot: semanticRootValue,
+    providerRoot,
+    manifest,
+    claims,
+    qualification,
+  };
+}
+
+function rootParts(root) {
+  if (!ROOT.test(root)) throw failure('invalid-root', 'invalid SHA-256 root');
+  const hex = root.slice('sha256:'.length);
+  return { hex, prefix: hex.slice(0, 2) };
+}
+
+export function episodeProviderPaths(workspaceRoot, semanticRootValue) {
+  const { hex, prefix } = rootParts(semanticRootValue);
+  const control = path.join(workspaceRoot, '.kungfu');
+  return {
+    trackedRoot: path.join(control, 'episodes'),
+    segment: path.join(control, 'episodes', 'sealed', 'sha256', prefix, hex),
+    tempRoot: path.join(control, 'episodes', '.tmp'),
+    runtimeRoot: path.join(control, 'runtime', 'episode-provider'),
+    lease: path.join(
+      control,
+      'runtime',
+      'episode-provider',
+      'leases',
+      `${hex}.json`,
+    ),
+  };
+}
+
+function syncFile(file) {
+  const handle = fs.openSync(file, 'r');
+  try {
+    fs.fsyncSync(handle);
+  } finally {
+    fs.closeSync(handle);
+  }
+}
+
+function syncDirectory(directory) {
+  if (process.platform === 'win32') return;
+  syncFile(directory);
+}
+
+function writeExclusive(file, bytes) {
+  const handle = fs.openSync(file, 'wx', 0o644);
+  try {
+    fs.writeFileSync(handle, bytes);
+    fs.fsyncSync(handle);
+  } finally {
+    fs.closeSync(handle);
+  }
+}
+
+function readManifest(segment) {
+  return JSON.parse(fs.readFileSync(path.join(segment, MANIFEST_FILE), 'utf8'));
+}
+
+function acquireLease(paths, writerId, generation) {
+  fs.mkdirSync(path.dirname(paths.lease), { recursive: true });
+  try {
+    writeExclusive(
+      paths.lease,
+      Buffer.from(
+        `${canonicalJson({
+          schema: 'kungfu.episode.git-workspace-lease/v1',
+          writerId,
+          generation,
+        })}\n`,
+      ),
+    );
+  } catch (error) {
+    if (error?.code === 'EEXIST') {
+      throw failure(
+        'episode-writer-busy',
+        'another writer holds this Episode lease',
+      );
+    }
+    throw error;
+  }
+}
+
+function ensureWorkspaceIgnore(workspaceRoot) {
+  const control = path.join(workspaceRoot, '.kungfu');
+  const ignore = path.join(control, '.gitignore');
+  fs.mkdirSync(control, { recursive: true });
+  try {
+    writeExclusive(ignore, Buffer.from(WORKSPACE_IGNORE));
+    syncDirectory(control);
+    return;
+  } catch (error) {
+    if (error?.code !== 'EEXIST') throw error;
+  }
+  const entries = new Set(
+    fs
+      .readFileSync(ignore, 'utf8')
+      .split(/\r?\n/u)
+      .map((entry) => entry.trim())
+      .filter(Boolean),
+  );
+  for (const required of WORKSPACE_IGNORE.trimEnd().split('\n')) {
+    if (!entries.has(required)) {
+      throw failure(
+        'workspace-ignore-incomplete',
+        `.kungfu/.gitignore must contain '${required}'`,
+      );
+    }
+  }
+}
+
+export function sealGitEpisode(
+  workspaceRoot,
+  segment,
+  { writerId, generation = 1, fault = null } = {},
+) {
+  if (!/^[A-Za-z0-9._-]+$/u.test(String(writerId ?? '')))
+    throw failure('writer-id-invalid', 'writerId must be a safe path token');
+  if (!Number.isSafeInteger(generation) || generation < 1)
+    throw failure('generation-invalid', 'generation must be a positive integer');
+  ensureWorkspaceIgnore(workspaceRoot);
+  const paths = episodeProviderPaths(workspaceRoot, segment.semanticRoot);
+  fs.mkdirSync(path.dirname(paths.segment), { recursive: true });
+  fs.mkdirSync(paths.tempRoot, { recursive: true });
+  acquireLease(paths, writerId, generation);
+  let releaseLease = true;
+  const temp = path.join(
+    paths.tempRoot,
+    `${path.basename(paths.segment)}.${generation}.${process.pid}.${writerId}`,
+  );
+  try {
+    if (fs.existsSync(paths.segment)) {
+      const existing = readManifest(paths.segment);
+      if (existing.providerRoot !== segment.providerRoot) {
+        throw failure(
+          'episode-provider-root-conflict',
+          'semantic root already maps to different provider bytes',
+        );
+      }
+      return receipt(segment, paths.segment, 'already-present');
+    }
+    fs.mkdirSync(temp, { recursive: false });
+    writeExclusive(path.join(temp, SEGMENT_FILE), segment.claims);
+    if (fault === 'after-claims') {
+      releaseLease = false;
+      throw failure('injected-crash', 'fault after claims publication');
+    }
+    writeExclusive(
+      path.join(temp, MANIFEST_FILE),
+      Buffer.from(`${canonicalJson(segment.manifest)}\n`),
+    );
+    syncDirectory(temp);
+    if (fault === 'before-rename') {
+      releaseLease = false;
+      throw failure('injected-crash', 'fault before atomic rename');
+    }
+    fs.renameSync(temp, paths.segment);
+    syncDirectory(path.dirname(paths.segment));
+    return receipt(segment, paths.segment, 'sealed');
+  } finally {
+    if (releaseLease) fs.rmSync(paths.lease, { force: true });
+  }
+}
+
+function receipt(segment, location, status) {
+  const preimage = {
+    schema: GIT_EPISODE_RECEIPT_SCHEMA,
+    provider: GIT_EPISODE_PROVIDER,
+    status,
+    semanticRoot: segment.semanticRoot,
+    providerRoot: segment.providerRoot,
+    location,
+  };
+  return { ...preimage, receiptRoot: semanticRoot(preimage) };
+}
+
+export function fsckGitEpisode(workspaceRoot, semanticRootValue) {
+  const paths = episodeProviderPaths(workspaceRoot, semanticRootValue);
+  const issues = [];
+  let manifest;
+  try {
+    manifest = readManifest(paths.segment);
+  } catch {
+    return { ok: false, issues: [{ code: 'episode-segment-missing' }] };
+  }
+  if (manifest.schema !== GIT_EPISODE_MANIFEST_SCHEMA)
+    issues.push({ code: 'unknown-schema' });
+  const { providerRoot, ...preimage } = manifest;
+  if (semanticRoot(preimage) !== providerRoot)
+    issues.push({ code: 'provider-root-mismatch' });
+  if (manifest.semanticRoot !== semanticRootValue)
+    issues.push({ code: 'semantic-root-mismatch' });
+  const claimsPath = path.join(paths.segment, SEGMENT_FILE);
+  let raw = Buffer.alloc(0);
+  try {
+    raw = fs.readFileSync(claimsPath);
+  } catch {
+    issues.push({ code: 'claims-missing' });
+  }
+  if (raw.length > 0) {
+    if (raw.at(-1) !== 0x0a) issues.push({ code: 'torn-tail' });
+    if (sha256Bytes(raw) !== manifest.claims?.digest)
+      issues.push({ code: 'claims-hash-mismatch' });
+    const seen = new Set();
+    const rows = raw.toString('utf8').split('\n').filter(Boolean);
+    rows.forEach((text, position) => {
+      try {
+        const row = JSON.parse(text);
+        if (row.schema !== GIT_EPISODE_SEGMENT_SCHEMA)
+          issues.push({ code: 'unknown-schema', index: position });
+        if (seen.has(row.index))
+          issues.push({ code: 'duplicate-record', index: position });
+        seen.add(row.index);
+        if (row.index !== position)
+          issues.push({ code: 'out-of-order', index: position });
+        if (`${canonicalJson(row)}\n` !== `${text}\n`)
+          issues.push({ code: 'non-canonical-jsonl', index: position });
+      } catch {
+        issues.push({ code: 'malformed-jsonl', index: position });
+      }
+    });
+    if (rows.length !== manifest.claims?.count)
+      issues.push({ code: 'record-count-mismatch' });
+  }
+  return { ok: issues.length === 0, issues, manifest };
+}
+
+export function exportGitEpisode(workspaceRoot, semanticRootValue) {
+  const report = fsckGitEpisode(workspaceRoot, semanticRootValue);
+  if (!report.ok)
+    throw failure('episode-fsck-failed', 'Episode segment failed fsck', {
+      issues: report.issues,
+    });
+  const paths = episodeProviderPaths(workspaceRoot, semanticRootValue);
+  return {
+    schema: 'kungfu.episode.git-workspace-export/v1',
+    semanticRoot: semanticRootValue,
+    providerRoot: report.manifest.providerRoot,
+    manifest: report.manifest,
+    claims: fs.readFileSync(path.join(paths.segment, SEGMENT_FILE)),
+  };
+}
+
+export function importGitEpisode(workspaceRoot, exported, options = {}) {
+  requireObject(
+    exported,
+    'episode-export-invalid',
+    'Git Episode export is invalid',
+  );
+  if (exported.schema !== 'kungfu.episode.git-workspace-export/v1') {
+    throw failure('episode-export-schema-unknown', 'unsupported Git export');
+  }
+  const manifest = requireObject(
+    exported.manifest,
+    'episode-manifest-missing',
+    'Git export has no manifest',
+  );
+  const { providerRoot, ...preimage } = manifest;
+  if (
+    semanticRoot(preimage) !== providerRoot ||
+    providerRoot !== exported.providerRoot ||
+    manifest.semanticRoot !== exported.semanticRoot
+  ) {
+    throw failure('episode-export-root-mismatch', 'Git export roots disagree');
+  }
+  const claims = Buffer.from(exported.claims);
+  if (sha256Bytes(claims) !== manifest.claims?.digest) {
+    throw failure('episode-export-claims-mismatch', 'Git export claims drifted');
+  }
+  return sealGitEpisode(
+    workspaceRoot,
+    {
+      semanticRoot: exported.semanticRoot,
+      providerRoot: exported.providerRoot,
+      manifest,
+      claims,
+    },
+    options,
+  );
+}
+
+export function inspectEpisodeProviderTemps(workspaceRoot) {
+  const root = path.join(workspaceRoot, '.kungfu', 'episodes', '.tmp');
+  if (!fs.existsSync(root)) return [];
+  return fs.readdirSync(root).sort().map((name) => ({
+    code: 'incomplete-seal',
+    path: path.join(root, name),
+  }));
+}
+
+export function recoverGitEpisodeLease(
+  workspaceRoot,
+  semanticRootValue,
+  { expectedWriterId, nextGeneration },
+) {
+  const paths = episodeProviderPaths(workspaceRoot, semanticRootValue);
+  let lease;
+  try {
+    lease = JSON.parse(fs.readFileSync(paths.lease, 'utf8'));
+  } catch {
+    return { status: 'no-lease', incomplete: inspectEpisodeProviderTemps(workspaceRoot) };
+  }
+  if (
+    lease.writerId !== expectedWriterId ||
+    !Number.isSafeInteger(nextGeneration) ||
+    nextGeneration <= lease.generation
+  ) {
+    throw failure(
+      'episode-lease-generation-mismatch',
+      'recovery must name the previous writer and advance generation',
+    );
+  }
+  fs.rmSync(paths.lease);
+  syncDirectory(path.dirname(paths.lease));
+  return {
+    status: 'lease-recovered',
+    previousGeneration: lease.generation,
+    nextGeneration,
+    incomplete: inspectEpisodeProviderTemps(workspaceRoot),
+  };
+}
+
+export const EPISODE_PROVIDER_CAPABILITY_MATRIX = Object.freeze([
+  {
+    provider: 'yijinjing+content-addressed-file',
+    authority: true,
+    computesSemanticRoot: true,
+    preservesQualifiedSemanticRoot: true,
+    gitTracked: false,
+  },
+  {
+    provider: 'yijinjing+rocksdb',
+    authority: true,
+    computesSemanticRoot: true,
+    preservesQualifiedSemanticRoot: true,
+    gitTracked: false,
+  },
+  {
+    provider: GIT_EPISODE_PROVIDER,
+    authority: false,
+    computesSemanticRoot: false,
+    preservesQualifiedSemanticRoot: true,
+    gitTracked: true,
+  },
+]);

--- a/scripts/check-git-episode-provider.test.mjs
+++ b/scripts/check-git-episode-provider.test.mjs
@@ -1,0 +1,240 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import {
+  EPISODE_PROVIDER_CAPABILITY_MATRIX,
+  buildGitEpisodeSegment,
+  episodeProviderPaths,
+  exportGitEpisode,
+  fsckGitEpisode,
+  inspectEpisodeProviderTemps,
+  importGitEpisode,
+  recoverGitEpisodeLease,
+  sealGitEpisode,
+} from '../framework/episode-provider/src/git-workspace-episode-provider.mjs';
+
+const ROOT = 'a'.repeat(64);
+
+function bundle(id = 7, root = ROOT) {
+  return {
+    schema: 'kungfu.storage.episode-bundle/v1',
+    bundle_id: `episode:${id}`,
+    scope: 'episode',
+    episode_id: id,
+    authority: 'yijinjing-journal',
+    manifest: {
+      schema: 'kungfu.episode.manifest/v1',
+      episode_id: id,
+      opened: true,
+      closed: true,
+      status: 'ended',
+      content_root_algorithm: 'sha256',
+      content_root: root,
+    },
+    records: [
+      { manifest_frame_uid: 91, carrier_type: 10801, record: { episode_id: id } },
+      { manifest_frame_uid: 92, carrier_type: 10805, record: { episode_id: id } },
+      { manifest_frame_uid: 93, carrier_type: 10806, record: { root_value: root } },
+    ],
+    refs: [],
+    dependencies: [],
+  };
+}
+
+function qualification(id = 7) {
+  return {
+    schema: 'kungfu.episode.qualification/v1',
+    policy_source: 'cpp-typed-fold-fsck',
+    episode_id: id,
+    lifecycle: 'ended',
+    status: 'ok',
+    evidence: { manifest_integrity: { state: 'verified', issue_codes: [] } },
+    issues: [],
+    capabilities: [
+      { name: 'export_evidence', safe: true, requires: [], blocked_by: [] },
+    ],
+    safe_capabilities: ['export_evidence'],
+    contractions: [],
+    repair_prerequisites: [],
+  };
+}
+
+function workspace(t) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'kungfu-git-episode-'));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  return root;
+}
+
+test('seals one immutable JSONL segment and re-import is idempotent', (t) => {
+  const root = workspace(t);
+  const segment = buildGitEpisodeSegment(bundle(), qualification());
+  const first = sealGitEpisode(root, segment, { writerId: 'writer-a' });
+  assert.equal(first.status, 'sealed');
+  assert.equal(
+    fs.readFileSync(path.join(root, '.kungfu', '.gitignore'), 'utf8'),
+    'runtime/\nepisodes/.tmp/\nprivate/\ncache/\n',
+  );
+  assert.equal(fsckGitEpisode(root, segment.semanticRoot).ok, true);
+  const second = sealGitEpisode(root, segment, { writerId: 'writer-b' });
+  assert.equal(second.status, 'already-present');
+  const exported = exportGitEpisode(root, segment.semanticRoot);
+  assert.equal(exported.semanticRoot, segment.semanticRoot);
+  assert.equal(exported.providerRoot, segment.providerRoot);
+});
+
+test('provider export/import preserves both roots across workspaces', (t) => {
+  const source = workspace(t);
+  const destination = workspace(t);
+  const segment = buildGitEpisodeSegment(bundle(), qualification());
+  sealGitEpisode(source, segment, { writerId: 'source' });
+  const exported = exportGitEpisode(source, segment.semanticRoot);
+  const receipt = importGitEpisode(destination, exported, {
+    writerId: 'destination',
+  });
+  assert.equal(receipt.status, 'sealed');
+  assert.equal(receipt.semanticRoot, segment.semanticRoot);
+  assert.equal(receipt.providerRoot, segment.providerRoot);
+  assert.equal(fsckGitEpisode(destination, segment.semanticRoot).ok, true);
+});
+
+test('different Episodes have independent leases; the same Episode rejects a second writer', (t) => {
+  const root = workspace(t);
+  const one = buildGitEpisodeSegment(bundle(7, 'a'.repeat(64)), qualification(7));
+  const two = buildGitEpisodeSegment(bundle(8, 'b'.repeat(64)), qualification(8));
+  const onePaths = episodeProviderPaths(root, one.semanticRoot);
+  fs.mkdirSync(path.dirname(onePaths.lease), { recursive: true });
+  fs.writeFileSync(onePaths.lease, '{}\n');
+  assert.throws(
+    () => sealGitEpisode(root, one, { writerId: 'writer-b' }),
+    { code: 'episode-writer-busy' },
+  );
+  assert.equal(
+    sealGitEpisode(root, two, { writerId: 'writer-c' }).status,
+    'sealed',
+  );
+});
+
+test('crash before rename is bounded and leaves no published segment', (t) => {
+  const root = workspace(t);
+  const segment = buildGitEpisodeSegment(bundle(), qualification());
+  assert.throws(
+    () =>
+      sealGitEpisode(root, segment, {
+        writerId: 'writer-a',
+        fault: 'before-rename',
+      }),
+    { code: 'injected-crash' },
+  );
+  assert.equal(fsckGitEpisode(root, segment.semanticRoot).ok, false);
+  assert.equal(inspectEpisodeProviderTemps(root).length, 1);
+  assert.throws(
+    () => sealGitEpisode(root, segment, { writerId: 'writer-b', generation: 2 }),
+    { code: 'episode-writer-busy' },
+  );
+  assert.throws(
+    () =>
+      recoverGitEpisodeLease(root, segment.semanticRoot, {
+        expectedWriterId: 'wrong-writer',
+        nextGeneration: 2,
+      }),
+    { code: 'episode-lease-generation-mismatch' },
+  );
+  const recovery = recoverGitEpisodeLease(root, segment.semanticRoot, {
+    expectedWriterId: 'writer-a',
+    nextGeneration: 2,
+  });
+  assert.equal(recovery.status, 'lease-recovered');
+  assert.equal(
+    sealGitEpisode(root, segment, { writerId: 'writer-b', generation: 2 }).status,
+    'sealed',
+  );
+});
+
+test('torn tail, duplicate, out-of-order, hash drift, and unknown schema fail visibly', (t) => {
+  const mutations = [
+    ['torn-tail', (raw) => raw.subarray(0, raw.length - 1)],
+    [
+      'duplicate-record',
+      (raw) => {
+        const rows = raw.toString().trimEnd().split('\n');
+        const second = JSON.parse(rows[1]);
+        second.index = 0;
+        rows[1] = JSON.stringify(second);
+        return Buffer.from(`${rows.join('\n')}\n`);
+      },
+    ],
+    [
+      'out-of-order',
+      (raw) => {
+        const rows = raw.toString().trimEnd().split('\n');
+        const second = JSON.parse(rows[1]);
+        second.index = 9;
+        rows[1] = JSON.stringify(second);
+        return Buffer.from(`${rows.join('\n')}\n`);
+      },
+    ],
+    ['claims-hash-mismatch', (raw) => Buffer.concat([raw, Buffer.from(' ')])],
+    [
+      'unknown-schema',
+      (raw) => Buffer.from(raw.toString().replace('/v1"', '/v2"')),
+    ],
+  ];
+  for (const [expected, mutate] of mutations) {
+    const root = workspace(t);
+    const segment = buildGitEpisodeSegment(bundle(), qualification());
+    sealGitEpisode(root, segment, { writerId: expected });
+    const paths = episodeProviderPaths(root, segment.semanticRoot);
+    const claims = path.join(paths.segment, 'claims.jsonl');
+    fs.writeFileSync(claims, mutate(fs.readFileSync(claims)));
+    const codes = fsckGitEpisode(root, segment.semanticRoot).issues.map(
+      ({ code }) => code,
+    );
+    assert.ok(codes.includes(expected), `${expected}: ${codes.join(', ')}`);
+  }
+});
+
+test('raw runtime material and unqualified roots are rejected', () => {
+  assert.throws(
+    () =>
+      buildGitEpisodeSegment(
+        { ...bundle(), self_contained: true, journals: [] },
+        qualification(),
+      ),
+    { code: 'private-material-not-admitted' },
+  );
+  assert.throws(
+    () => buildGitEpisodeSegment(bundle(), { ...qualification(), status: 'failed' }),
+    { code: 'qualification-not-admissible' },
+  );
+});
+
+test('an existing workspace ignore must retain every private/runtime exclusion', (t) => {
+  const root = workspace(t);
+  fs.mkdirSync(path.join(root, '.kungfu'), { recursive: true });
+  fs.writeFileSync(path.join(root, '.kungfu', '.gitignore'), 'runtime/\n');
+  const segment = buildGitEpisodeSegment(bundle(), qualification());
+  assert.throws(
+    () => sealGitEpisode(root, segment, { writerId: 'writer-a' }),
+    { code: 'workspace-ignore-incomplete' },
+  );
+});
+
+test('capability matrix keeps native authority separate from Git shadow storage', () => {
+  assert.deepEqual(
+    EPISODE_PROVIDER_CAPABILITY_MATRIX.map((entry) => [
+      entry.provider,
+      entry.authority,
+      entry.computesSemanticRoot,
+    ]),
+    [
+      ['yijinjing+content-addressed-file', true, true],
+      ['yijinjing+rocksdb', true, true],
+      ['git-workspace-jsonl/v1', false, false],
+    ],
+  );
+});

--- a/scripts/check-git-episode-provider.test.mjs
+++ b/scripts/check-git-episode-provider.test.mjs
@@ -12,8 +12,8 @@ import {
   episodeProviderPaths,
   exportGitEpisode,
   fsckGitEpisode,
-  inspectEpisodeProviderTemps,
   importGitEpisode,
+  inspectEpisodeProviderTemps,
   recoverGitEpisodeLease,
   sealGitEpisode,
 } from '../framework/episode-provider/src/git-workspace-episode-provider.mjs';
@@ -37,9 +37,21 @@ function bundle(id = 7, root = ROOT) {
       content_root: root,
     },
     records: [
-      { manifest_frame_uid: 91, carrier_type: 10801, record: { episode_id: id } },
-      { manifest_frame_uid: 92, carrier_type: 10805, record: { episode_id: id } },
-      { manifest_frame_uid: 93, carrier_type: 10806, record: { root_value: root } },
+      {
+        manifest_frame_uid: 91,
+        carrier_type: 10801,
+        record: { episode_id: id },
+      },
+      {
+        manifest_frame_uid: 92,
+        carrier_type: 10805,
+        record: { episode_id: id },
+      },
+      {
+        manifest_frame_uid: 93,
+        carrier_type: 10806,
+        record: { root_value: root },
+      },
     ],
     refs: [],
     dependencies: [],
@@ -104,15 +116,20 @@ test('provider export/import preserves both roots across workspaces', (t) => {
 
 test('different Episodes have independent leases; the same Episode rejects a second writer', (t) => {
   const root = workspace(t);
-  const one = buildGitEpisodeSegment(bundle(7, 'a'.repeat(64)), qualification(7));
-  const two = buildGitEpisodeSegment(bundle(8, 'b'.repeat(64)), qualification(8));
+  const one = buildGitEpisodeSegment(
+    bundle(7, 'a'.repeat(64)),
+    qualification(7),
+  );
+  const two = buildGitEpisodeSegment(
+    bundle(8, 'b'.repeat(64)),
+    qualification(8),
+  );
   const onePaths = episodeProviderPaths(root, one.semanticRoot);
   fs.mkdirSync(path.dirname(onePaths.lease), { recursive: true });
   fs.writeFileSync(onePaths.lease, '{}\n');
-  assert.throws(
-    () => sealGitEpisode(root, one, { writerId: 'writer-b' }),
-    { code: 'episode-writer-busy' },
-  );
+  assert.throws(() => sealGitEpisode(root, one, { writerId: 'writer-b' }), {
+    code: 'episode-writer-busy',
+  });
   assert.equal(
     sealGitEpisode(root, two, { writerId: 'writer-c' }).status,
     'sealed',
@@ -133,7 +150,8 @@ test('crash before rename is bounded and leaves no published segment', (t) => {
   assert.equal(fsckGitEpisode(root, segment.semanticRoot).ok, false);
   assert.equal(inspectEpisodeProviderTemps(root).length, 1);
   assert.throws(
-    () => sealGitEpisode(root, segment, { writerId: 'writer-b', generation: 2 }),
+    () =>
+      sealGitEpisode(root, segment, { writerId: 'writer-b', generation: 2 }),
     { code: 'episode-writer-busy' },
   );
   assert.throws(
@@ -150,7 +168,8 @@ test('crash before rename is bounded and leaves no published segment', (t) => {
   });
   assert.equal(recovery.status, 'lease-recovered');
   assert.equal(
-    sealGitEpisode(root, segment, { writerId: 'writer-b', generation: 2 }).status,
+    sealGitEpisode(root, segment, { writerId: 'writer-b', generation: 2 })
+      .status,
     'sealed',
   );
 });
@@ -208,7 +227,11 @@ test('raw runtime material and unqualified roots are rejected', () => {
     { code: 'private-material-not-admitted' },
   );
   assert.throws(
-    () => buildGitEpisodeSegment(bundle(), { ...qualification(), status: 'failed' }),
+    () =>
+      buildGitEpisodeSegment(bundle(), {
+        ...qualification(),
+        status: 'failed',
+      }),
     { code: 'qualification-not-admissible' },
   );
 });
@@ -218,10 +241,9 @@ test('an existing workspace ignore must retain every private/runtime exclusion',
   fs.mkdirSync(path.join(root, '.kungfu'), { recursive: true });
   fs.writeFileSync(path.join(root, '.kungfu', '.gitignore'), 'runtime/\n');
   const segment = buildGitEpisodeSegment(bundle(), qualification());
-  assert.throws(
-    () => sealGitEpisode(root, segment, { writerId: 'writer-a' }),
-    { code: 'workspace-ignore-incomplete' },
-  );
+  assert.throws(() => sealGitEpisode(root, segment, { writerId: 'writer-a' }), {
+    code: 'workspace-ignore-incomplete',
+  });
 });
 
 test('capability matrix keeps native authority separate from Git shadow storage', () => {

--- a/scripts/source-acceptance.mjs
+++ b/scripts/source-acceptance.mjs
@@ -213,6 +213,7 @@ export function sourceAcceptancePlan(files) {
         'scripts/upgrade-publication-admission.test.mjs',
         'scripts/check-agent-session-contract.test.mjs',
         'scripts/check-project-cut-contract.test.mjs',
+        'scripts/check-git-episode-provider.test.mjs',
         'framework/agent-session/tests/capsule-host.test.mjs',
         'framework/agent-session/tests/peer-transport.test.mjs',
         'framework/agent-session/tests/runtime-port.test.mjs',

--- a/scripts/source-acceptance.test.mjs
+++ b/scripts/source-acceptance.test.mjs
@@ -131,6 +131,9 @@ test('source plan covers representative source-only checks', () => {
   assert.ok(
     contractTests.args.includes('scripts/check-project-cut-contract.test.mjs'),
   );
+  assert.ok(
+    contractTests.args.includes('scripts/check-git-episode-provider.test.mjs'),
+  );
   const upgradeTests = plan.find(
     (step) => step.label === 'runtime upgrade control-plane tests',
   );


### PR DESCRIPTION
## Summary

Add a build-free Git Workspace Episode shadow provider that stores one qualified sealed Episode per immutable canonical JSONL segment without replacing yijinjing authority.

## Changes

- preserve the qualified journal-native Episode root while computing a separate provider root
- use per-Episode generation leases and temp/fsync/atomic-rename publication
- reject raw runtime/private material and require a safe `.kungfu/.gitignore`
- add deterministic import/export, recovery, concurrency, and corruption fixtures
- document the authority and capability boundary in ADR-0099

## Verification

- `node --test scripts/check-git-episode-provider.test.mjs scripts/source-acceptance.test.mjs` (21 passed)
- `node scripts/adr-audit.mjs`
- `node scripts/check-project-cut-contract.mjs`
- `git diff --check`
- `./shifu check:source` reached the dependency-backed Kungfu Gate catalog and stopped because local `yaml` is not installed; hosted CI must complete the full gate

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "implemented",
  "adrs": ["ADR-0099"],
  "summary": "Implement the Git Workspace Episode shadow provider with immutable per-Episode JSONL segments and qualified root preservation",
  "verification": ["Build-free provider contract and fault fixtures", "ADR registry audit", "Project Cut regression contract", "Hosted source acceptance"]
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [x] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The provider is shadow-only, rejects private/runtime bytes, and cannot advertise journal authority or recompute the Episode semantic root.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed