### PR TITLE
feat(release): close workflow publication authority

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,8 +29,11 @@ permissions:
 
 jobs:
   build:
-    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@v2-alpha
-    secrets: inherit
+    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@52dba6d30051b53d6f6b723fa6e27b090ce4311f # v2.12.7
+    secrets:
+      BUILDCHAIN_ARTIFACT_RELAY_S3_ROLE_ARN: ${{ secrets.BUILDCHAIN_ARTIFACT_RELAY_S3_ROLE_ARN }}
+      BUILDCHAIN_ARTIFACT_RELAY_S3_UPLOAD_ROLE_ARN: ${{ secrets.BUILDCHAIN_ARTIFACT_RELAY_S3_UPLOAD_ROLE_ARN }}
+      BUILDCHAIN_ARTIFACT_RELAY_S3_DOWNLOAD_ROLE_ARN: ${{ secrets.BUILDCHAIN_ARTIFACT_RELAY_S3_DOWNLOAD_ROLE_ARN }}
     with:
       buildchain-ref: ${{ inputs.buildchain-ref || '' }}
       runner-preset: ${{ inputs.platforms-json && 'custom' || 'kungfu-v4-self-hosted' }}

--- a/.github/workflows/dev-verify-patrol.yml
+++ b/.github/workflows/dev-verify-patrol.yml
@@ -28,11 +28,12 @@ on:
 
 permissions:
   contents: read
-  issues: write
-  id-token: write
 
 jobs:
   verify:
+    permissions:
+      contents: read
+      id-token: write
     uses: kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@a6145efc210a961da0e5c63d7024d42061550f60
     with:
       buildchain-ref: ${{ inputs.buildchain-ref || '' }}

--- a/.github/workflows/publish-layer-artifacts.yml
+++ b/.github/workflows/publish-layer-artifacts.yml
@@ -21,8 +21,7 @@ on:
 
 permissions:
   actions: read
-  contents: write
-  id-token: write
+  contents: read
 
 jobs:
   prepare:
@@ -41,10 +40,10 @@ jobs:
           test "$conclusion" = success
           sha="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}" --jq .head_sha)"
           echo "source-sha=$sha" >> "$GITHUB_OUTPUT"
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ steps.build.outputs.source-sha }}
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22.14.0
       - name: Read release version
@@ -52,7 +51,7 @@ jobs:
         run: |
           # shifu-entry-contract: allow release control-plane metadata lookup before launcher dispatch
           echo "version=$(node -p "require('./lerna.json').version")" >> "$GITHUB_OUTPUT"
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           github-token: ${{ github.token }}
           run-id: ${{ inputs.build-run-id }}
@@ -77,7 +76,7 @@ jobs:
             --repo "$GITHUB_REPOSITORY" \
             --tag "${{ inputs.release-tag }}" \
             --report publication/preflight-report.json
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: adr0049-publication-set
           path: |
@@ -90,15 +89,19 @@ jobs:
     if: ${{ inputs.execute }}
     runs-on: ubuntu-22.04
     environment: adr0049-production-publication
+    permissions:
+      actions: read
+      contents: write
+      id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ needs.prepare.outputs.source-sha }}
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22.14.0
           registry-url: https://registry.npmjs.org
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: adr0049-publication-set
           path: publication-set
@@ -119,7 +122,7 @@ jobs:
           gh release view "$TAG" >/dev/null 2>&1 || gh release create "$TAG" --target "${{ needs.prepare.outputs.source-sha }}" --title "Kungfu Episodes ${VERSION}" --notes "ADR-0049 qualified release ${VERSION}"
           gh release upload "$TAG" publication-set/publication/github/*
       - name: Preserve exact PyPI wheels for isolated publisher job
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: adr0049-pypi-wheels
           path: publication-set/publication/pypi/*.whl
@@ -130,23 +133,28 @@ jobs:
     runs-on: ubuntu-22.04
     environment: adr0049-production-publication
     permissions:
+      actions: read
+      contents: read
       id-token: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: adr0049-pypi-wheels
           path: dist
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
 
   verify-publication:
     needs: [prepare, publish, publish-pypi]
     if: ${{ inputs.execute }}
     runs-on: ubuntu-22.04
+    permissions:
+      actions: read
+      contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ needs.prepare.outputs.source-sha }}
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: adr0049-publication-set
           path: product/release/qualification/publication-set
@@ -165,7 +173,7 @@ jobs:
             --capability publication-evidence \
             --receipt product/release/qualification/layer-publication-gate-receipt.json \
             --overwrite
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: adr0049-publication-verdict
           path: |

--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -10,10 +10,7 @@ on:
       - release/v*/v*
 
 permissions:
-  contents: write
-  actions: read
-  issues: write
-  id-token: write
+  contents: read
 
 jobs:
   promotion-contract:
@@ -35,7 +32,12 @@ jobs:
   promote:
     needs: promotion-contract
     if: ${{ github.event.pull_request.merged == true }}
-    uses: kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@v2
+    permissions:
+      actions: read
+      contents: write
+      issues: write
+      id-token: write
+    uses: kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@52dba6d30051b53d6f6b723fa6e27b090ce4311f # v2.12.7
     with:
       channel: ${{ startsWith(github.event.pull_request.base.ref, 'alpha/') && 'alpha' || 'release' }}
       buildchain-ref: ${{ startsWith(github.event.pull_request.base.ref, 'alpha/') && 'v2-alpha' || 'v2' }}
@@ -85,8 +87,10 @@ jobs:
     needs: promote
     if: ${{ github.event.pull_request.merged == true }}
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.event.pull_request.base.ref }}
           token: ${{ secrets.KUNGFU_GITHUB_TOKEN }}

--- a/.github/workflows/release-shifu.yml
+++ b/.github/workflows/release-shifu.yml
@@ -17,7 +17,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   build:
@@ -39,7 +39,7 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Verify tag matches Cargo.toml version
         if: startsWith(github.ref, 'refs/tags/')
         run: |
@@ -78,7 +78,7 @@ jobs:
           else
             shasum -a 256 "${{ matrix.asset }}" > "${{ matrix.asset }}.sha256"
           fi
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ${{ matrix.asset }}
           path: dist/*
@@ -88,8 +88,10 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     needs: build
     runs-on: ubuntu-22.04
+    permissions:
+      contents: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           path: dist
           merge-multiple: true

--- a/.github/workflows/source-acceptance.yml
+++ b/.github/workflows/source-acceptance.yml
@@ -13,8 +13,8 @@ permissions:
 jobs:
   source-acceptance:
     name: Source acceptance
-    uses: kungfu-systems/buildchain/.github/workflows/check.yml@v2-alpha
+    uses: kungfu-systems/buildchain/.github/workflows/check.yml@52dba6d30051b53d6f6b723fa6e27b090ce4311f # v2.12.7
     with:
-      buildchain-ref: v2-alpha
+      buildchain-ref: v2
       mode: source
       upload-artifacts: true

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -175,6 +175,7 @@ implemented and qualified or explicitly waived for that release.
 | [SHIFU-0004](SHIFU-ADR-0004-gate-control-plane-contract.md) | accepted | Shifu owns the project-independent Gate contract; projects own catalogs and explicit policy profiles |
 | [SHIFU-0005](SHIFU-ADR-0005-repo-root-discovery-and-jurisdiction.md) | accepted | Two-level repo discovery; a buildchain-managed repo joins by declaring `registrar: shifu`, and shifu asks buildchain for the KFD-3 layout instead of copying it |
 | [SHIFU-0006](SHIFU-ADR-0006-documentation-protocol-and-provider-boundary.md) | accepted | Shifu owns a project-independent documentation submission, canonical-root, diagnostics, and receipt contract while projects retain semantic providers and routes |
+| [SHIFU-0007](SHIFU-ADR-0007-closed-world-workflow-release-admission.md) | accepted | Kungfu classifies the complete workflow execution surface and grants product or channel authority only through an independently reverified sealed capability |
 
 ## Reading by theme
 

--- a/docs/adr/SHIFU-ADR-0007-closed-world-workflow-release-admission.md
+++ b/docs/adr/SHIFU-ADR-0007-closed-world-workflow-release-admission.md
@@ -1,0 +1,101 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+doc_type: architecture-decision
+adr_id: SHIFU-ADR-0007
+decision_status: accepted
+implementation_status: staged
+implementation_prs: []
+qualification_refs: [scripts/check-kungfu-gate-catalog.test.mjs, scripts/verify-kungfu-release-admission.test.mjs, docs/qualification/gates/workflow-authority.json, docs/qualification/gates/release-admission-policy.json]
+review_state: self-reviewed
+sensitivity: public
+sources: [local-files, user-consensus]
+period: ongoing
+theme: closed-world-release-admission
+confidence: high
+evidence_grade: B
+last_reviewed: 2026-07-15
+---
+
+# SHIFU-ADR-0007: Closed-world workflow and release admission
+
+- Status: accepted and staged
+- Date: 2026-07-15
+- Scope: Kungfu workflow authority, qualifying evidence, product publication,
+  and channel promotion
+- Related: [SHIFU-ADR-0004](./SHIFU-ADR-0004-gate-control-plane-contract.md),
+  [ADR-0073](./ADR-0073-buildchain-adr-release-admissibility.md), and
+  [ADR-0090](./ADR-0090-kfd-aware-kfx-trust-and-buildchain-admission.md)
+
+## Context
+
+The Shifu Gate catalog already closes direct Gate, profile, and registered
+controller invocation in both directions. That proves declared Gate routing,
+but it does not classify every workflow job and shell step, bind activation and
+permission drift, or prevent an unrelated write-capable job from being mistaken
+for release authority.
+
+Buildchain now provides a project-neutral sealed publication authority,
+controller evidence, runner provenance, control-plane audit, artifact-byte
+verification, and an independent verifier. Kungfu must consume that protocol
+without copying Buildchain's workflow internals or letting its own manifest
+self-certify a release.
+
+## Decision
+
+Kungfu owns one closed-world workflow authority manifest. Every workflow, job,
+and step has an exact definition digest and a finite authority class. Workflow
+activation, permissions, runner, Environment, secret/OIDC surface, reusable
+workflow identity, action ref, inputs, conditions, and shell body are included
+in the digests. Unknown inventory and drift fail source acceptance.
+
+Evidence publication, diagnostic writes, product publication, and channel
+promotion are distinct authorities. A workflow that contains qualifying or
+publication authority may use external actions only at immutable commit SHAs.
+Write and OIDC permissions live on the smallest job that requires them.
+
+Kungfu product publication requires the project-neutral Buildchain sealed
+capability and a second project-owned predicate. The predicate fixes the
+Buildchain version/runtime/contract, publisher workflow, product, target,
+allowed channels, Gate profile, current Gate registry, and three required
+platforms. It rejects stale or replayed admission, missing or failing receipts,
+runner downgrade, control-plane drift, source/runtime substitution, and
+artifact-byte substitution. Unknown or diagnostic execution may still run and
+publish failure evidence, but it cannot obtain product capability.
+
+The checked-in policy and authority manifest are not proof that live GitHub,
+OIDC, registry, or runner state is correct. Those facts enter only through a
+fresh Buildchain audit and provenance receipt, and unreadable state is denial.
+
+## Authority boundaries
+
+| Owner | Authority |
+| --- | --- |
+| Kungfu | Gate policy, workflow classification, activation contract, product/channel admission decision |
+| Shifu | Gate plan/run and source-bound Gate receipts |
+| Buildchain | controller/runtime evidence, sealed capability protocol, runner and external control-plane verification |
+| Provider | final credential exchange and product write after all predicates pass |
+
+## Consequences
+
+- Adding a harmless workflow still requires classification, which is deliberate
+  closed-world maintenance cost.
+- Refreshing digests cannot authorize mutable actions or publication classes.
+- Windows failure evidence can be uploaded immediately without granting a
+  product release.
+- Missing sealed inputs block the current promotion controller instead of
+  falling back to a legacy release path.
+- A successful local fixture proves the predicate implementation, not live
+  provider state; a real canary must record the exact source, runtime, run, and
+  receipt/passport digests.
+
+## Alternatives considered
+
+- **Scan only known Gate commands** — rejected because unknown jobs, permissions,
+  and triggers remain outside the proof.
+- **Treat every successful workflow as qualifying** — rejected because job
+  success does not prove source, runtime, artifact, runner, or provider state.
+- **Reimplement Buildchain publication authority in Kungfu** — rejected because
+  it would create a divergent trust protocol.
+- **Prevent all unknown code from running** — rejected as an unprovable claim;
+  the enforceable boundary is that unknown execution cannot obtain product
+  publication authority.

--- a/docs/adr/SHIFU-ADR-0007-closed-world-workflow-release-admission.md
+++ b/docs/adr/SHIFU-ADR-0007-closed-world-workflow-release-admission.md
@@ -4,7 +4,7 @@ doc_type: architecture-decision
 adr_id: SHIFU-ADR-0007
 decision_status: accepted
 implementation_status: staged
-implementation_prs: []
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/965]
 qualification_refs: [scripts/check-kungfu-gate-catalog.test.mjs, scripts/verify-kungfu-release-admission.test.mjs, docs/qualification/gates/workflow-authority.json, docs/qualification/gates/release-admission-policy.json]
 review_state: self-reviewed
 sensitivity: public

--- a/docs/document-metadata.registry.json
+++ b/docs/document-metadata.registry.json
@@ -758,12 +758,46 @@
       "review_state": "self-reviewed",
       "sensitivity": "public"
     },
+    "docs/qualification/gates/release-admission.md": {
+      "metadata_schema": "kungfu.document-metadata/v1",
+      "document_status": "active",
+      "doc_type": "design-reference",
+      "review_state": "self-reviewed",
+      "sensitivity": "public",
+      "sources": [
+        "architecture-decisions",
+        "local-files",
+        "user-consensus"
+      ],
+      "period": "ongoing",
+      "theme": "sealed-release-admission",
+      "confidence": "high",
+      "evidence_grade": "B",
+      "last_reviewed": "2026-07-15"
+    },
     "docs/qualification/gates/source-and-governance.md": {
       "metadata_schema": "kungfu.document-metadata/v1",
       "document_status": "active",
       "doc_type": "public-document",
       "review_state": "self-reviewed",
       "sensitivity": "public"
+    },
+    "docs/qualification/gates/workflow-authority.md": {
+      "metadata_schema": "kungfu.document-metadata/v1",
+      "document_status": "active",
+      "doc_type": "design-reference",
+      "review_state": "self-reviewed",
+      "sensitivity": "public",
+      "sources": [
+        "architecture-decisions",
+        "local-files",
+        "user-consensus"
+      ],
+      "period": "ongoing",
+      "theme": "closed-world-workflow-authority",
+      "confidence": "high",
+      "evidence_grade": "B",
+      "last_reviewed": "2026-07-15"
     },
     "docs/qualification/kfd-native-sdk-release-gates.md": {
       "metadata_schema": "kungfu.document-metadata/v1",

--- a/docs/qualification/gates/README.md
+++ b/docs/qualification/gates/README.md
@@ -13,6 +13,13 @@ explains Kungfu's current policy and does not redefine Shifu semantics.
 - [Workflow bindings](workflow-bindings.json) record how current GitHub
   workflows activate profiles and gates. Schema v2 makes direct Gate,
   Buildchain Gate-profile, and controller entries structure-checked.
+- [Closed-world workflow authority](workflow-authority.md) classifies every
+  workflow, job, and step, including activation digests, permissions,
+  Environment, secret/OIDC surfaces, immutable external refs, publication
+  class, and qualifying-receipt authority.
+- [Release admission](release-admission.md) binds the current Gate policy to
+  Buildchain's sealed capability, runner provenance, control-plane audit,
+  exact artifact bytes, freshness, channel, and consumer decision.
 - [Measurement coverage](measurement-coverage.md) records the observed
   per-platform `durationMs`, clean source SHA, Gate definition digest, registry
   digest, and retained Shifu receipt for measured Gates.
@@ -20,6 +27,11 @@ explains Kungfu's current policy and does not redefine Shifu semantics.
   is pinned to the immutable `v2.12.4` release commit
   `a6145efc210a961da0e5c63d7024d42061550f60`. Buildchain cannot weaken a
   Kungfu profile or mint missing Gate receipts.
+- The alpha/release build, source acceptance, and release promotion controllers
+  are pinned separately to stable Buildchain `v2.12.7` at
+  `52dba6d30051b53d6f6b723fa6e27b090ce4311f`. Its sealed publication verifier
+  is consumed through the Kungfu release-admission policy; missing inputs deny
+  publication rather than selecting a legacy path.
 - `required` means blocking when the workflow activation condition matches.
   Path filters, same-repository restrictions, schedules, and post-merge events
   remain explicit in workflow bindings rather than being hidden in the matrix.
@@ -139,6 +151,12 @@ reusable workflow or the runtime behavior of a shell body. Immutable
 references, contract locks, source-bound receipts, and runtime receipts remain
 responsible for that cross-repository evidence.
 
+This structured Gate closure is nested inside the broader closed-world
+authority manifest. Gate bindings answer which registered Gate/profile/controller
+is invoked. Workflow authority separately answers whether every other job and
+step is diagnostic, qualifying, product-publication, or channel-control code,
+and what credential surface it receives. Both checks must pass.
+
 ## Operator commands
 
 ```sh
@@ -164,18 +182,23 @@ the Buildchain orchestration stage registers their handlers.
 3. Declare the workflow/job execution in `workflow-bindings.json`; direct Gate
    and profile ids must be statically recoverable from YAML, while every
    controller must declare one bounded adapter.
-4. For every new Gate, run the diagnostic Gate on every platform declared by
+4. Classify every changed workflow/job/step in `workflow-authority.json`, then
+   review the generated [authority matrix](workflow-authority.md). A refresh
+   records exact YAML but cannot authorize a mutable external ref or elevate a
+   publication class.
+5. For every new Gate, run the diagnostic Gate on every platform declared by
    `platforms` from one clean source revision and retain each
    `shifu.gate-receipt/v1` JSON under `docs/qualification/evidence/`. The
    matching result must be attempted, passing, exit `0`, and contain the
    current Gate definition digest and measured `durationMs`.
-5. Add the receipts and their exact source, registry, duration, and platform
+6. Add the receipts and their exact source, registry, duration, and platform
    fields to `measurement-coverage.json`. The frozen adoption baseline cannot
    be expanded; even a new `off` Gate requires measurement coverage.
-6. Regenerate the policy and measurement tables with
+7. Regenerate the policy and measurement tables with
    `node scripts/check-kungfu-gate-catalog.mjs --write`.
-7. Run `./shifu check:gate-catalog` and `./shifu check:source`.
-8. Treat policy-strength changes as rollout decisions, not documentation edits.
+8. Run `./shifu check:gate-catalog` and `./shifu check:source`.
+9. Treat policy-strength, credential, and publication-authority changes as
+   rollout decisions, not documentation edits.
 
 Measurements are retained observations, not live benchmarks. They do not
 change automatically after a later code commit. A Gate definition change makes
@@ -187,7 +210,9 @@ runtime or expected cost.
 The catalog meta gate checks schema and semantic validity, task existence,
 documentation anchors and required fields, the generated matrix bytes,
 structured direct/profile/controller workflow facts, adapter uniqueness and
-input contracts, profile coverage, and source-bound measurement coverage. It
+input contracts, closed-world workflow authority, sealed release policy,
+generated authority documentation, profile coverage, and source-bound
+measurement coverage. It
 rejects missing platforms, dirty source, failed/skipped results, stale Gate
 definitions, mismatched durations, and missing receipts. It proves structural
 consistency, not that a prose explanation is semantically wise.

--- a/docs/qualification/gates/release-admission-policy.json
+++ b/docs/qualification/gates/release-admission-policy.json
@@ -1,0 +1,29 @@
+{
+  "schema": "kungfu.release-admission-policy/v1",
+  "repository": "kungfu-systems/kungfu",
+  "profile": "release-promotion",
+  "requiredPlatforms": ["linux", "macos", "windows"],
+  "workflowAuthority": {
+    "manifest": "docs/qualification/gates/workflow-authority.json",
+    "workflow": ".github/workflows/release-new-version.yml",
+    "job": "promote"
+  },
+  "buildchain": {
+    "version": "2.12.7",
+    "runtimeSha": "52dba6d30051b53d6f6b723fa6e27b090ce4311f",
+    "contractDigest": "sha256:247a0f3dcfa7e066a3222f5fab5a46fa50a4870c97b1bc40001479044aed8619",
+    "registry": "node_modules/@kungfu-tech/buildchain/dist/site/publication-authority-registry.json"
+  },
+  "publication": {
+    "workflowPath": ".github/workflows/release-candidate-promote.yml",
+    "publisherWorkflowPath": ".github/workflows/release-new-version.yml",
+    "environment": "none",
+    "product": "Kungfu Episodes",
+    "target": "kungfu-product",
+    "channels": ["alpha", "release"]
+  },
+  "freshness": {
+    "maximumLifetimeSeconds": 900,
+    "nonceReplay": "deny"
+  }
+}

--- a/docs/qualification/gates/release-admission.md
+++ b/docs/qualification/gates/release-admission.md
@@ -1,0 +1,70 @@
+# Kungfu release admission
+
+Kungfu product publication is deny-by-default. The project policy is
+[`release-admission-policy.json`](./release-admission-policy.json); the
+independent consumer verifier is
+[`scripts/verify-kungfu-release-admission.mjs`](../../../scripts/verify-kungfu-release-admission.mjs).
+The verifier delegates the project-neutral sealed publication protocol to the
+exact Buildchain runtime declared by the policy, then independently rechecks
+Kungfu's current Gate registry, release profile, workflow authority, channels,
+product identity, and required Linux/macOS/Windows coverage.
+
+## Required evidence
+
+A qualifying capability must bind all of the following exact values:
+
+| Dimension | Required proof |
+| --- | --- |
+| Source | one 40-character Kungfu revision and its release-candidate tree |
+| Gate policy | current `shifu.gates.json`, `release-promotion` matrix digest, complete passing rows and platform receipts |
+| Runtime | Buildchain `2.12.7` at `52dba6d30051b53d6f6b723fa6e27b090ce4311f` and its contract digest |
+| Controller | qualifying source/runtime-bound Buildchain controller receipt referenced by the RC passport |
+| Runner | qualifying ephemeral, reimaged, or measured persistent-runner provenance; unqualified is denied |
+| Control plane | fresh passing Actions, branch/ruleset, Environment, OIDC, publisher, and runner audit facts |
+| Artifact | recomputed manifests and every product payload byte for the exact RC platform set |
+| Target | Kungfu Episodes, `kungfu-product`, exact version, and only `alpha` or `release` |
+| Freshness | unique nonce, no replay, and no more than 15 minutes from issue to expiry |
+
+The verifier ignores a producer's own allow/deny statement. It recomputes the
+Buildchain registry, admission, controller, Gate aggregate, runner,
+control-plane, manifest, payload, and capability digests. Missing expected
+fields are errors, not wildcards. Unreadable external audit state fails closed.
+
+## Three different publication meanings
+
+- **Test evidence publication** uploads logs, receipts, or failure reports. It
+  runs even after a failed Windows attempt where the workflow contract says
+  `always()`. It never grants product capability.
+- **Product artifact publication** writes packages or release assets and
+  requires a fresh sealed capability.
+- **Channel promotion** moves `alpha` or `release` to an exact already-qualified
+  source and requires the same capability chain.
+
+The current Buildchain stable controller accepts sealed inputs but receives no
+fallback self-certification from Kungfu. If admission evidence is missing, the
+promotion remains blocked. A failing canary is therefore useful evidence of a
+consumer/runtime gap; it is never rewritten as a qualifying release.
+
+## Verification and diagnosis
+
+Run the static and negative contract suite:
+
+```text
+./shifu check:gate-catalog
+./shifu test:release-admission
+```
+
+For a collected evidence directory, invoke the verifier with exact JSON files:
+
+```text
+./shifu verify:release-admission \
+  --admission admission.json \
+  --runner-provenance runner.json \
+  --control-plane-audit control-plane.json \
+  --publication-evidence publication-evidence.json \
+  --expected expected.json \
+  --used-nonces used-nonces.json
+```
+
+The command prints a `kungfu.release-admission-capability/v1` object only after
+both the Buildchain protocol and Kungfu policy pass. It does not publish.

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -1,0 +1,1084 @@
+{
+  "schema": "kungfu.workflow-authority/v1",
+  "workflowRoot": ".github/workflows",
+  "workflows": [
+    {
+      "path": ".github/workflows/adr-release-gate.yml",
+      "authority": "qualification",
+      "definitionDigest": "sha256:d013214baea0c069e28dc0a7caa1b63e8218ca606b9d9a9544f16d1f7126d726",
+      "jobs": [
+        {
+          "id": "adr-release",
+          "authority": "qualification",
+          "publication": "none",
+          "receipt": "diagnostic",
+          "definitionDigest": "sha256:2ad5c08ed02d496191f486d3eb35a6ec79143499756758771276d2897a1e8cce",
+          "credentials": {
+            "githubToken": "read",
+            "oidc": false,
+            "repositorySecrets": [],
+            "inheritedSecrets": false,
+            "environment": null
+          },
+          "externalActions": [
+            "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
+          ],
+          "steps": [
+            {
+              "index": 1,
+              "label": "name:Checkout immutable PR head",
+              "authority": "qualification",
+              "definitionDigest": "sha256:792d372d2c3084322a7a6a97f95d61ecadaaef1ed3c447aa7196ed80f0ee8ec0"
+            },
+            {
+              "index": 2,
+              "label": "name:Verify ADR delivery intent",
+              "authority": "qualification",
+              "definitionDigest": "sha256:48e72bd895c8aa22b8c612709f9293c257b8a12867d2ae22eab5eed5c4f2930a"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": ".github/workflows/build.yml",
+      "authority": "qualification",
+      "definitionDigest": "sha256:b65b60b8963ae416588ea7d494e7f96a3a70d0c82d07fbbdd2a0ccabc2327839",
+      "jobs": [
+        {
+          "id": "build",
+          "authority": "qualification",
+          "publication": "none",
+          "receipt": "qualifying",
+          "definitionDigest": "sha256:652fa2c1f933f58fc7f9d17b3da45b47dfd06cb4455b16154fc44313e841e0d0",
+          "credentials": {
+            "githubToken": "write",
+            "oidc": true,
+            "repositorySecrets": [
+              "BUILDCHAIN_ARTIFACT_RELAY_S3_DOWNLOAD_ROLE_ARN",
+              "BUILDCHAIN_ARTIFACT_RELAY_S3_ROLE_ARN",
+              "BUILDCHAIN_ARTIFACT_RELAY_S3_UPLOAD_ROLE_ARN"
+            ],
+            "inheritedSecrets": false,
+            "environment": null
+          },
+          "externalActions": [
+            "kungfu-systems/buildchain/.github/workflows/.build.yml@52dba6d30051b53d6f6b723fa6e27b090ce4311f"
+          ],
+          "steps": []
+        }
+      ]
+    },
+    {
+      "path": ".github/workflows/buildchain-validate.yml",
+      "authority": "qualification",
+      "definitionDigest": "sha256:378ca5c8d9aa0c837b2b29a363753755a1650ad22ce724f21624cddad72ccbcc",
+      "jobs": [
+        {
+          "id": "promotion-rehearsal",
+          "authority": "qualification",
+          "publication": "none",
+          "receipt": "diagnostic",
+          "definitionDigest": "sha256:85df61a82b7a9d50d23ae343ea26638815809a8b8aaa66a170be75a7f509a369",
+          "credentials": {
+            "githubToken": "read",
+            "oidc": false,
+            "repositorySecrets": [],
+            "inheritedSecrets": false,
+            "environment": null
+          },
+          "externalActions": [
+            "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
+          ],
+          "steps": [
+            {
+              "index": 1,
+              "label": "uses:actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0",
+              "authority": "qualification",
+              "definitionDigest": "sha256:632ec7dde43669059eab6d285d75746bede178c3eb57b9a15f693b4ac96c355d"
+            },
+            {
+              "index": 2,
+              "label": "name:Rehearse alpha and stable promotion contracts",
+              "authority": "qualification",
+              "definitionDigest": "sha256:4d2045f4b3c7579ce197cfeda1d57ccb35a6a23fa10ccd537888359f9b657165"
+            }
+          ]
+        },
+        {
+          "id": "validate",
+          "authority": "qualification",
+          "publication": "none",
+          "receipt": "diagnostic",
+          "definitionDigest": "sha256:8c0eeabfd000ae242aed8732f85cedf0f888055851b130675a3676d927cf2e37",
+          "credentials": {
+            "githubToken": "read",
+            "oidc": false,
+            "repositorySecrets": [],
+            "inheritedSecrets": false,
+            "environment": null
+          },
+          "externalActions": [
+            "actions/checkout@v4",
+            "kungfu-systems/buildchain/actions/validate-config@v2"
+          ],
+          "steps": [
+            {
+              "index": 1,
+              "label": "uses:actions/checkout@v4",
+              "authority": "qualification",
+              "definitionDigest": "sha256:dd0465395fff2eaf34fe466af3f46904442331f18fbcb4d67ae136cd3ae05d18"
+            },
+            {
+              "index": 2,
+              "label": "name:Validate .buildchain/buildchain.toml",
+              "authority": "qualification",
+              "definitionDigest": "sha256:e4e1d777b76d54a4fb4a5f3b60157a1054e990d194b363266b66264b32f2edfc"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": ".github/workflows/core-build-profiles.yml",
+      "authority": "qualification",
+      "definitionDigest": "sha256:3e5e6b4699933fb3c1ca94726ef490d4106a171ae0dd1b51fc453d7d4180180b",
+      "jobs": [
+        {
+          "id": "qualify",
+          "authority": "qualification",
+          "publication": "none",
+          "receipt": "diagnostic",
+          "definitionDigest": "sha256:a3bfa7aff80b1c8d8e7b614f55a98a72026b7430fab0c3048b6ac468ee20dcfc",
+          "credentials": {
+            "githubToken": "read",
+            "oidc": false,
+            "repositorySecrets": [],
+            "inheritedSecrets": false,
+            "environment": null
+          },
+          "externalActions": [
+            "actions/checkout@v4",
+            "actions/setup-node@v6.4.0"
+          ],
+          "steps": [
+            {
+              "index": 1,
+              "label": "uses:actions/checkout@v4",
+              "authority": "qualification",
+              "definitionDigest": "sha256:dd0465395fff2eaf34fe466af3f46904442331f18fbcb4d67ae136cd3ae05d18"
+            },
+            {
+              "index": 2,
+              "label": "uses:actions/setup-node@v6.4.0",
+              "authority": "qualification",
+              "definitionDigest": "sha256:789e56d63991440fb89fffa3b2795c1cab043e6b7df6237a0c830c5c89759690"
+            },
+            {
+              "index": 3,
+              "label": "name:Select Linux qualification compiler",
+              "authority": "qualification",
+              "definitionDigest": "sha256:76bdffe2d6af4ba38f5d1b09ce40d8f1e70132362e65592a29b947e1360d0c16"
+            },
+            {
+              "index": 4,
+              "label": "name:Install frozen minimal workspace (POSIX)",
+              "authority": "qualification",
+              "definitionDigest": "sha256:4567708a4b1f2b41f4ba375e11c15aee2c2045c8966d8d3fd61e9d307631aaad"
+            },
+            {
+              "index": 5,
+              "label": "name:Install frozen full workspace (POSIX)",
+              "authority": "qualification",
+              "definitionDigest": "sha256:8d2aca2fdbe34f1bb124bd0d27401d1ab7478672dbdc4acde8d10c7e51647beb"
+            },
+            {
+              "index": 6,
+              "label": "name:Install frozen minimal workspace (Windows)",
+              "authority": "qualification",
+              "definitionDigest": "sha256:71e88597eaf3e2dd390909aa4719d7486ce5f6f2beaf7cc427f5fdd68cbbf4be"
+            },
+            {
+              "index": 7,
+              "label": "name:Install frozen full workspace (Windows)",
+              "authority": "qualification",
+              "definitionDigest": "sha256:d2202c5cbf6f6736deca6f5dea61103cdc1d57e6b8995d494ef1dfc7193f4ba1"
+            },
+            {
+              "index": 8,
+              "label": "name:Build selected Core profile (POSIX)",
+              "authority": "qualification",
+              "definitionDigest": "sha256:eed157056e74d7e9d86b796a422d279b7b89dddbba47426ef7ff4f76d97edd61"
+            },
+            {
+              "index": 9,
+              "label": "name:Build selected Core profile (Windows)",
+              "authority": "qualification",
+              "definitionDigest": "sha256:dfb21d44d7d2f83776df08c1fab766c6872775a6cba6391d662ac4a186750b0a"
+            },
+            {
+              "index": 10,
+              "label": "name:Verify build identity and custom provider contract (POSIX)",
+              "authority": "qualification",
+              "definitionDigest": "sha256:2b1684e02cb83f64b85eaabff5926dec3c086e61aee7378acb25d7201bc0527e"
+            },
+            {
+              "index": 11,
+              "label": "name:Verify build identity and custom provider contract (Windows)",
+              "authority": "qualification",
+              "definitionDigest": "sha256:7df17b699a10afac40362f7f249fd591a91774bd527355660db3e5e1c6f22fa1"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": ".github/workflows/dco.yml",
+      "authority": "qualification",
+      "definitionDigest": "sha256:c34ea72079f35dab0224f1a39865171dbd762b83a2625b5ba2c73caa14de800e",
+      "jobs": [
+        {
+          "id": "signoff",
+          "authority": "qualification",
+          "publication": "none",
+          "receipt": "diagnostic",
+          "definitionDigest": "sha256:1b69a8f3a5a9c87bcfb393e626514db0a02223b9e5baa6ac6f0f304c0a44159e",
+          "credentials": {
+            "githubToken": "read",
+            "oidc": false,
+            "repositorySecrets": [],
+            "inheritedSecrets": false,
+            "environment": null
+          },
+          "externalActions": [
+            "actions/checkout@v4"
+          ],
+          "steps": [
+            {
+              "index": 1,
+              "label": "name:Checkout",
+              "authority": "qualification",
+              "definitionDigest": "sha256:4b6c4cdb034cac5905d93c1b9e371ae30d123452e15daf73b2e2665b5f4d531d"
+            },
+            {
+              "index": 2,
+              "label": "name:Check commit sign-offs",
+              "authority": "qualification",
+              "definitionDigest": "sha256:6083c50b5f66371374b00892addfb43a13c06b9da7e95c7ead15747b508fd831"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": ".github/workflows/dev-verify-patrol.yml",
+      "authority": "diagnostic",
+      "definitionDigest": "sha256:be738defd03951e68bc9185cf11823fc15b09de537dc15806ce7eb06ee920f9d",
+      "jobs": [
+        {
+          "id": "report",
+          "authority": "diagnostic",
+          "publication": "none",
+          "receipt": "none",
+          "definitionDigest": "sha256:6a45d39ebc824af0745f5feaba81d10dc72425963d8d52b5b71186504e1542f9",
+          "credentials": {
+            "githubToken": "write",
+            "oidc": false,
+            "repositorySecrets": [],
+            "inheritedSecrets": false,
+            "environment": null
+          },
+          "externalActions": [],
+          "steps": [
+            {
+              "index": 1,
+              "label": "name:Sync tracking issue with patrol result",
+              "authority": "diagnostic-write",
+              "definitionDigest": "sha256:6755647fb4c13a229144bf4f4c181ec9b806719868335e730a7feca50852d08d"
+            }
+          ]
+        },
+        {
+          "id": "verify",
+          "authority": "qualification",
+          "publication": "none",
+          "receipt": "qualifying",
+          "definitionDigest": "sha256:d6b16780206fe7b7d72d912b7c96cf6b7c76b0534f3b90f4b8f51cb03962cac4",
+          "credentials": {
+            "githubToken": "write",
+            "oidc": true,
+            "repositorySecrets": [],
+            "inheritedSecrets": false,
+            "environment": null
+          },
+          "externalActions": [
+            "kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@a6145efc210a961da0e5c63d7024d42061550f60"
+          ],
+          "steps": []
+        }
+      ]
+    },
+    {
+      "path": ".github/workflows/docs-check.yml",
+      "authority": "qualification",
+      "definitionDigest": "sha256:ba50e098607d5051e67dcc25ee144118d29263719771f556a34f6d2f762f45d2",
+      "jobs": [
+        {
+          "id": "docs-check",
+          "authority": "qualification",
+          "publication": "none",
+          "receipt": "diagnostic",
+          "definitionDigest": "sha256:19432ed907fb0e36fa5173e519bcf71f94daa9356312b1bb28d25d3f7a8d2eb7",
+          "credentials": {
+            "githubToken": "read",
+            "oidc": false,
+            "repositorySecrets": [],
+            "inheritedSecrets": false,
+            "environment": null
+          },
+          "externalActions": [
+            "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
+          ],
+          "steps": [
+            {
+              "index": 1,
+              "label": "name:Checkout",
+              "authority": "qualification",
+              "definitionDigest": "sha256:4caee36f776cb8497a3bff586c96c8149921a3f72d8b324f491fe74d6008a320"
+            },
+            {
+              "index": 2,
+              "label": "name:Run blocking documentation Gate closure",
+              "authority": "qualification",
+              "definitionDigest": "sha256:a83d2a922468b9e756fdbf736f2b7968ef712e1a8dd5a7aaf8acd57efc914063"
+            },
+            {
+              "index": 3,
+              "label": "name:Report advisory prose policy",
+              "authority": "qualification",
+              "definitionDigest": "sha256:6907d944238956636521c6c7ffa6244cf573d2405590bce11cc5b752f92b3a3a"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": ".github/workflows/docs-external-links.yml",
+      "authority": "qualification",
+      "definitionDigest": "sha256:a3fb95a32b9c39ca66e1539e5c900ed597da67fe53ae94ff941d9088a4e293dd",
+      "jobs": [
+        {
+          "id": "external-links",
+          "authority": "qualification",
+          "publication": "none",
+          "receipt": "diagnostic",
+          "definitionDigest": "sha256:7db1f376cad52de3fcd0e62ad3f9f218560e49ac15c31924549fbaec087fe7d5",
+          "credentials": {
+            "githubToken": "read",
+            "oidc": false,
+            "repositorySecrets": [
+              "GITHUB_TOKEN"
+            ],
+            "inheritedSecrets": false,
+            "environment": null
+          },
+          "externalActions": [
+            "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0",
+            "lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8"
+          ],
+          "steps": [
+            {
+              "index": 1,
+              "label": "name:Checkout",
+              "authority": "qualification",
+              "definitionDigest": "sha256:10da89364e3f92df269335444dd1818466f7ead7c010d1908c370808c24e365d"
+            },
+            {
+              "index": 2,
+              "label": "name:Check external links",
+              "authority": "qualification",
+              "definitionDigest": "sha256:ddddb14806d721762e31ac228520b6e4d93e986e84a008d4912de95c58fd6672"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": ".github/workflows/embedding-membrane-spike.yml",
+      "authority": "qualification",
+      "definitionDigest": "sha256:b72ae3f9c61268df8b1b8adef3f7f3f3e94d289973a0ff0e55c3a727dee28a5a",
+      "jobs": [
+        {
+          "id": "native-membrane",
+          "authority": "qualification",
+          "publication": "none",
+          "receipt": "diagnostic",
+          "definitionDigest": "sha256:da5a1cfce13094945d788a2568e33d980ce45af9d1ae05b4444425d7d0dec055",
+          "credentials": {
+            "githubToken": "read",
+            "oidc": false,
+            "repositorySecrets": [],
+            "inheritedSecrets": false,
+            "environment": null
+          },
+          "externalActions": [
+            "actions/setup-node@v6.4.0",
+            "actions/download-artifact@v4"
+          ],
+          "steps": [
+            {
+              "index": 1,
+              "label": "name:Setup Node.js",
+              "authority": "qualification",
+              "definitionDigest": "sha256:9424aacf2347b34a9835c02db44a3809c43ddec5d7136b2ad824f34b18a2eeab"
+            },
+            {
+              "index": 2,
+              "label": "name:Select Linux qualification compiler",
+              "authority": "qualification",
+              "definitionDigest": "sha256:306425180b20e85f0a4e20beb148d1a347ff917c4589e3de45f2880a4028a287"
+            },
+            {
+              "index": 3,
+              "label": "name:Expose Git Bash on Windows",
+              "authority": "qualification",
+              "definitionDigest": "sha256:4364410e6f95a35b6ee2f31bf58a367d48430fe8fb1007e1006079f1477247cb"
+            },
+            {
+              "index": 4,
+              "label": "name:Download immutable source delta",
+              "authority": "evidence-publication",
+              "definitionDigest": "sha256:4d4fe701f8fb0628b0079f48246b42934722916c94212421e4082da85259daae"
+            },
+            {
+              "index": 5,
+              "label": "name:Reconstruct and verify immutable PR head",
+              "authority": "qualification",
+              "definitionDigest": "sha256:95a07c1c75e327642b256e1d750054d14cb5bba5194babb48f7013b5b042065b"
+            },
+            {
+              "index": 6,
+              "label": "name:Verify pinned spike Rust toolchain",
+              "authority": "qualification",
+              "definitionDigest": "sha256:32fd42c280abcb64c25877dd920f9e95637132dacce97fdd10528dcf4cf2aed2"
+            },
+            {
+              "index": 7,
+              "label": "name:Install frozen workspace (POSIX)",
+              "authority": "qualification",
+              "definitionDigest": "sha256:83ac971e6eb92b156a748aaa3cdb27cb2a5c96614ddc4d6d12654bc4c62569b9"
+            },
+            {
+              "index": 8,
+              "label": "name:Install frozen workspace (Windows)",
+              "authority": "qualification",
+              "definitionDigest": "sha256:35ca8c89e9bbef955eb2e84bfe29bb86b8d26fd7b774dd3e176520fa472c8e88"
+            },
+            {
+              "index": 9,
+              "label": "name:Rebind frozen Python registry metadata",
+              "authority": "qualification",
+              "definitionDigest": "sha256:eaca1af79930be947d706aa36e7630b415d1aa62fa0cc7c6564c0179a9e0a4e4"
+            },
+            {
+              "index": 10,
+              "label": "name:Generate core toolchain (POSIX)",
+              "authority": "qualification",
+              "definitionDigest": "sha256:0fc1eb442e26d5e22e0aec0b31461eb93ecbc0423a23533751b07ba7c281bc23"
+            },
+            {
+              "index": 11,
+              "label": "name:Generate core toolchain (Windows)",
+              "authority": "qualification",
+              "definitionDigest": "sha256:fc216bcc3a96c15f031a444e048dd1b234a837a71c56f91e580c15eb87b0ad93"
+            },
+            {
+              "index": 12,
+              "label": "name:Build and run membrane consumers (POSIX)",
+              "authority": "qualification",
+              "definitionDigest": "sha256:01fa4c367bff5bfc1cb6c36d26a9ba05296ba1e1ab9b2cb0781c0fa6b7e9a691"
+            },
+            {
+              "index": 13,
+              "label": "name:Build and run membrane consumers (Windows)",
+              "authority": "qualification",
+              "definitionDigest": "sha256:c46a1f25437849007a71c826c949d8e104b40a49186a277425eee3139d6219f1"
+            }
+          ]
+        },
+        {
+          "id": "source-delta",
+          "authority": "qualification",
+          "publication": "none",
+          "receipt": "diagnostic",
+          "definitionDigest": "sha256:65045e3c45f2f8b574fa637ae8105b510791efdc03322a93ab04a6c6471a96e4",
+          "credentials": {
+            "githubToken": "read",
+            "oidc": false,
+            "repositorySecrets": [],
+            "inheritedSecrets": false,
+            "environment": null
+          },
+          "externalActions": [
+            "actions/checkout@v4",
+            "actions/upload-artifact@v4"
+          ],
+          "steps": [
+            {
+              "index": 1,
+              "label": "name:Checkout immutable PR head",
+              "authority": "qualification",
+              "definitionDigest": "sha256:017a0bde27a4c9c4c9314405c89a229aa9db9e80af40187fb643c2c5d1383e8a"
+            },
+            {
+              "index": 2,
+              "label": "name:Pack tree-verified source delta",
+              "authority": "qualification",
+              "definitionDigest": "sha256:840a81ef18751a61a97456314323f281a0d2f7457f41716e60d6bd7e90b17b2b"
+            },
+            {
+              "index": 3,
+              "label": "name:Upload source delta",
+              "authority": "evidence-publication",
+              "definitionDigest": "sha256:2809a9d13b03259858d18fb2efeac45c788cd65bdd01edb8a5c5f4d9bbd4eae2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": ".github/workflows/gate-measurement.yml",
+      "authority": "qualification",
+      "definitionDigest": "sha256:e6986be0ab6906463da6627f1a134f6e945786108ff7da2ff988fe64c803a2d4",
+      "jobs": [
+        {
+          "id": "measure",
+          "authority": "qualification",
+          "publication": "none",
+          "receipt": "qualifying",
+          "definitionDigest": "sha256:c73d2f4c10329e9ed44b43642e687eb0d64b7bbf902d11b3d551d264c513aa7d",
+          "credentials": {
+            "githubToken": "read",
+            "oidc": false,
+            "repositorySecrets": [],
+            "inheritedSecrets": false,
+            "environment": null
+          },
+          "externalActions": [
+            "kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@a6145efc210a961da0e5c63d7024d42061550f60"
+          ],
+          "steps": []
+        }
+      ]
+    },
+    {
+      "path": ".github/workflows/publish-layer-artifacts.yml",
+      "authority": "product-publication",
+      "definitionDigest": "sha256:f4186ee831659f177fa148c2a9cacc7910f6aa72b4e7ce654d43617e9c542738",
+      "jobs": [
+        {
+          "id": "prepare",
+          "authority": "qualification",
+          "publication": "none",
+          "receipt": "diagnostic",
+          "definitionDigest": "sha256:117cd6b183e91a1faf4028c2684bdb41b725b731ae320b6dc482fc808a355109",
+          "credentials": {
+            "githubToken": "read",
+            "oidc": false,
+            "repositorySecrets": [],
+            "inheritedSecrets": false,
+            "environment": null
+          },
+          "externalActions": [
+            "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5",
+            "actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020",
+            "actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093",
+            "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02"
+          ],
+          "steps": [
+            {
+              "index": 1,
+              "label": "id:build",
+              "authority": "qualification",
+              "definitionDigest": "sha256:a42f331b3c4035f17ec569c39151aadd4ffa83eaa18b59b9ee1434201eac2774"
+            },
+            {
+              "index": 2,
+              "label": "uses:actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5",
+              "authority": "qualification",
+              "definitionDigest": "sha256:603dec98c7c478ef6fc737162288f426a981111b9bf14c242fa5dcf4cbe48ee7"
+            },
+            {
+              "index": 3,
+              "label": "uses:actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020",
+              "authority": "qualification",
+              "definitionDigest": "sha256:3f5d59b2fc99a4a6970f16f8e27636577ea327b037412d2794b841ba448f4dc4"
+            },
+            {
+              "index": 4,
+              "label": "id:version",
+              "authority": "qualification",
+              "definitionDigest": "sha256:829c3ca125080230199900458aa6b6346bba824a0a7f7948503851904642f3db"
+            },
+            {
+              "index": 5,
+              "label": "uses:actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093",
+              "authority": "evidence-publication",
+              "definitionDigest": "sha256:91c8ae062b6e9e59852d670c39782799079953a957230a332efe684f592e7dcc"
+            },
+            {
+              "index": 6,
+              "label": "name:Collect the exact cross-platform publication set",
+              "authority": "qualification",
+              "definitionDigest": "sha256:77114f57c992cf3f1a88f2e659766d24bb38a0b02e3c1a7e106b684e2c5d089c"
+            },
+            {
+              "index": 7,
+              "label": "name:Validate npm archives without publishing",
+              "authority": "qualification",
+              "definitionDigest": "sha256:b5f9fab59f0bf45b82937714441d58b3c9de5e54e7330db746b4da5efa1f897f"
+            },
+            {
+              "index": 8,
+              "label": "name:Prove target registry versions and release assets are absent",
+              "authority": "qualification",
+              "definitionDigest": "sha256:9a891b224cf7fe1503d723e5db0bf53ae35ce0ab1d961380d9e3bfcc608ab083"
+            },
+            {
+              "index": 9,
+              "label": "uses:actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02",
+              "authority": "evidence-publication",
+              "definitionDigest": "sha256:3d7bfe61794513738598b74538638f884ecfb413a772bd35bdcbf4b5b97e3350"
+            }
+          ]
+        },
+        {
+          "id": "publish",
+          "authority": "product-publication",
+          "publication": "product",
+          "receipt": "none",
+          "definitionDigest": "sha256:b13f6218db68e2990a1b5b017a7b59692e5c5239eece2f8f18d13ce279f798f8",
+          "credentials": {
+            "githubToken": "write",
+            "oidc": true,
+            "repositorySecrets": [
+              "CARGO_REGISTRY_TOKEN"
+            ],
+            "inheritedSecrets": false,
+            "environment": "adr0049-production-publication"
+          },
+          "externalActions": [
+            "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5",
+            "actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020",
+            "actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093",
+            "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02"
+          ],
+          "steps": [
+            {
+              "index": 1,
+              "label": "uses:actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5",
+              "authority": "product-publication",
+              "definitionDigest": "sha256:ddb9aff13ce48b26c658b6b4eec1547237c9b1b471a321e31e0702acae574dff"
+            },
+            {
+              "index": 2,
+              "label": "uses:actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020",
+              "authority": "product-publication",
+              "definitionDigest": "sha256:d0b72d1fa3b4c9c5d5c79795d1615bafc43067222d53248635445235546db837"
+            },
+            {
+              "index": 3,
+              "label": "uses:actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093",
+              "authority": "product-publication",
+              "definitionDigest": "sha256:4f9e6c14ab0c591a4fa97a52328ffed068ac19bc2ec702cdd6da2a4dd80a84e8"
+            },
+            {
+              "index": 4,
+              "label": "name:Publish exact npm archives with trusted publishing",
+              "authority": "product-publication",
+              "definitionDigest": "sha256:79bec259ff9c97352ff634828bf834b43213624b4d89134f07438594ee042dca"
+            },
+            {
+              "index": 5,
+              "label": "name:Publish Cargo SDK",
+              "authority": "product-publication",
+              "definitionDigest": "sha256:8dafd4af05b6cec0ba3687e8b670132311601b873c0efa9381760e195759317c"
+            },
+            {
+              "index": 6,
+              "label": "name:Publish exact GitHub product assets",
+              "authority": "product-publication",
+              "definitionDigest": "sha256:552a1b782555e0958ede95397fe3abeda254a18565eaead5005366554f33b9db"
+            },
+            {
+              "index": 7,
+              "label": "name:Preserve exact PyPI wheels for isolated publisher job",
+              "authority": "product-publication",
+              "definitionDigest": "sha256:bb6e8fce8ce381ffa655774509d6acb54c81d934d530240eed35b078aedc9d53"
+            }
+          ]
+        },
+        {
+          "id": "publish-pypi",
+          "authority": "product-publication",
+          "publication": "product",
+          "receipt": "none",
+          "definitionDigest": "sha256:6480df9451c1778516a69db9f9248025a1e7616555fc2db40bbd1a5f44842d46",
+          "credentials": {
+            "githubToken": "write",
+            "oidc": true,
+            "repositorySecrets": [],
+            "inheritedSecrets": false,
+            "environment": "adr0049-production-publication"
+          },
+          "externalActions": [
+            "actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093",
+            "pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b"
+          ],
+          "steps": [
+            {
+              "index": 1,
+              "label": "uses:actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093",
+              "authority": "product-publication",
+              "definitionDigest": "sha256:3b208db5746480de4b9e3c45a61c5a89bd3af28ad1bff21076ff5a140e14cffd"
+            },
+            {
+              "index": 2,
+              "label": "uses:pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b",
+              "authority": "product-publication",
+              "definitionDigest": "sha256:edc0be5d0928df1387318314c25d1fff6f2f1d9a1382e9964f08432f4232fb2c"
+            }
+          ]
+        },
+        {
+          "id": "verify-publication",
+          "authority": "qualification",
+          "publication": "none",
+          "receipt": "diagnostic",
+          "definitionDigest": "sha256:63d90c8bcfa0a2691c90e154a8b75cf7084a8c3447ad836e6577ff309528964c",
+          "credentials": {
+            "githubToken": "read",
+            "oidc": false,
+            "repositorySecrets": [],
+            "inheritedSecrets": false,
+            "environment": null
+          },
+          "externalActions": [
+            "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5",
+            "actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093",
+            "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02"
+          ],
+          "steps": [
+            {
+              "index": 1,
+              "label": "uses:actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5",
+              "authority": "qualification",
+              "definitionDigest": "sha256:ddb9aff13ce48b26c658b6b4eec1547237c9b1b471a321e31e0702acae574dff"
+            },
+            {
+              "index": 2,
+              "label": "uses:actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093",
+              "authority": "evidence-publication",
+              "definitionDigest": "sha256:950ccd41ba0c9aead8c15160a45748c62592b247b5c38240f3a3249f14a9ae6e"
+            },
+            {
+              "index": 3,
+              "label": "name:Verify immutable public coordinates and compute the seven-row verdict",
+              "authority": "qualification",
+              "definitionDigest": "sha256:a5d43f9aacb1c96ae9ec35f315b7739070b4a5f0dacdca0810fdb6ce65f460bf"
+            },
+            {
+              "index": 4,
+              "label": "uses:actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02",
+              "authority": "evidence-publication",
+              "definitionDigest": "sha256:a0c5bfd0f26c35c3f71c5b47f48db6322de501714f38f9709c543799841cad87"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": ".github/workflows/release-new-version.yml",
+      "authority": "release-control",
+      "definitionDigest": "sha256:4dd64cbab092f03d424568d7f267c7f6a7a32fa002354fb27bf81db5b76e94b0",
+      "jobs": [
+        {
+          "id": "promote",
+          "authority": "release-control",
+          "publication": "channel",
+          "receipt": "qualifying",
+          "definitionDigest": "sha256:50a630e7295a077c5ab9261a0e633f8fd87e186fa58763eea79602e206af8e30",
+          "credentials": {
+            "githubToken": "write",
+            "oidc": true,
+            "repositorySecrets": [
+              "BUILDCHAIN_ISSUE_APP_ID",
+              "BUILDCHAIN_ISSUE_APP_PRIVATE_KEY",
+              "KUNGFU_GITHUB_TOKEN"
+            ],
+            "inheritedSecrets": false,
+            "environment": null
+          },
+          "externalActions": [
+            "kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@52dba6d30051b53d6f6b723fa6e27b090ce4311f"
+          ],
+          "steps": []
+        },
+        {
+          "id": "promotion-contract",
+          "authority": "qualification",
+          "publication": "none",
+          "receipt": "diagnostic",
+          "definitionDigest": "sha256:bf05b86ee8537750c695be755526f3a641905d64b582485bc21b280b72c10588",
+          "credentials": {
+            "githubToken": "read",
+            "oidc": false,
+            "repositorySecrets": [],
+            "inheritedSecrets": false,
+            "environment": null
+          },
+          "externalActions": [
+            "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
+          ],
+          "steps": [
+            {
+              "index": 1,
+              "label": "name:Checkout immutable promotion result",
+              "authority": "qualification",
+              "definitionDigest": "sha256:30859e4b5b1c9ae475c5cb4d0e454f73b16e0aef2bb2f18bf054533e86644e2c"
+            },
+            {
+              "index": 2,
+              "label": "name:Rehearse the Kungfu promotion contract",
+              "authority": "qualification",
+              "definitionDigest": "sha256:2f802c22213d0324e5690e3b067d33e3efc69e7170968e49cf4ec130e15aadea"
+            }
+          ]
+        },
+        {
+          "id": "shifu-launcher-tag",
+          "authority": "release-control",
+          "publication": "channel",
+          "receipt": "none",
+          "definitionDigest": "sha256:1efadf5775773727ce45c4adadd24ec3b5282f054fba4093c8db0f53c3a50de7",
+          "credentials": {
+            "githubToken": "read",
+            "oidc": false,
+            "repositorySecrets": [
+              "KUNGFU_GITHUB_TOKEN"
+            ],
+            "inheritedSecrets": false,
+            "environment": null
+          },
+          "externalActions": [
+            "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5"
+          ],
+          "steps": [
+            {
+              "index": 1,
+              "label": "uses:actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5",
+              "authority": "release-control",
+              "definitionDigest": "sha256:41beae5694a3e5dd3178a99f2f165e6e6fbee83563d062e991509dc52d462212"
+            },
+            {
+              "index": 2,
+              "label": "name:Tag the launcher release for the promoted version",
+              "authority": "release-control",
+              "definitionDigest": "sha256:7f4691d2621d2d418f01ad327a16dd05b969fad38ddae0af08aa8f9b41c5bef9"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": ".github/workflows/release-shifu.yml",
+      "authority": "product-publication",
+      "definitionDigest": "sha256:ea6621578c0ae053477b4bc2a4de5a2aeb489293acbd17ea341abd8c24230a1c",
+      "jobs": [
+        {
+          "id": "build",
+          "authority": "qualification",
+          "publication": "none",
+          "receipt": "diagnostic",
+          "definitionDigest": "sha256:4d75dbb1bcad2acb26625795be31df4af23956486a2c0f100d94d94043f29f43",
+          "credentials": {
+            "githubToken": "read",
+            "oidc": false,
+            "repositorySecrets": [],
+            "inheritedSecrets": false,
+            "environment": null
+          },
+          "externalActions": [
+            "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5",
+            "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02"
+          ],
+          "steps": [
+            {
+              "index": 1,
+              "label": "uses:actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5",
+              "authority": "qualification",
+              "definitionDigest": "sha256:0acab1e0b5ab1599539295552c0f98c224e233684d6f614e6aaf04f4a8e659cc"
+            },
+            {
+              "index": 2,
+              "label": "name:Verify tag matches Cargo.toml version",
+              "authority": "qualification",
+              "definitionDigest": "sha256:d85877b9229e76c210970d1f243ab431baa2e334bf2f9944073c57303d0095e9"
+            },
+            {
+              "index": 3,
+              "label": "name:Install musl target",
+              "authority": "qualification",
+              "definitionDigest": "sha256:77379dcf80a322b2c87c8ebc2d2d83ac0441bdeb9ab4df7659a106f8ba0c9a48"
+            },
+            {
+              "index": 4,
+              "label": "name:Add target",
+              "authority": "qualification",
+              "definitionDigest": "sha256:a4ab1497968f6812ee8bb7d3d89e6b6a39a3e70a3e3b1455b1c23ddc0f78f874"
+            },
+            {
+              "index": 5,
+              "label": "name:Build",
+              "authority": "qualification",
+              "definitionDigest": "sha256:71bea966d857d1f2c3d6ffa495e29bfad70db272e290c4971b58875b2cff766f"
+            },
+            {
+              "index": 6,
+              "label": "name:Stage asset",
+              "authority": "qualification",
+              "definitionDigest": "sha256:54a5dd3feef52f67fbebb70db18ada20d308c79db2bf8d3401ae3e5a78f70161"
+            },
+            {
+              "index": 7,
+              "label": "name:Checksum",
+              "authority": "qualification",
+              "definitionDigest": "sha256:69ea732fd8ff4e13a0358d054719a9042b5153d1523718db57f394a43e9ad48f"
+            },
+            {
+              "index": 8,
+              "label": "uses:actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02",
+              "authority": "evidence-publication",
+              "definitionDigest": "sha256:c3bd89a945bbb595ba86aa09938668d2a0b55e05da4fcdafe635250003fcc24f"
+            }
+          ]
+        },
+        {
+          "id": "release",
+          "authority": "product-publication",
+          "publication": "product",
+          "receipt": "none",
+          "definitionDigest": "sha256:f3b16b343c6d1dad0be6a80a12ab0035981a224fc2267fe40c6b4f18b6a6ba1b",
+          "credentials": {
+            "githubToken": "write",
+            "oidc": false,
+            "repositorySecrets": [
+              "GITHUB_TOKEN"
+            ],
+            "inheritedSecrets": false,
+            "environment": null
+          },
+          "externalActions": [
+            "actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093"
+          ],
+          "steps": [
+            {
+              "index": 1,
+              "label": "uses:actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093",
+              "authority": "product-publication",
+              "definitionDigest": "sha256:002dc164de7ce67b0f53de40e6d7c12abdbddfbeb352561f2e1b90be1ca7309e"
+            },
+            {
+              "index": 2,
+              "label": "name:Combined checksums",
+              "authority": "product-publication",
+              "definitionDigest": "sha256:8af37947573149784267ecf3762511eb0bfd814047ef071eef3a8fae8f4c8bd6"
+            },
+            {
+              "index": 3,
+              "label": "name:Create release",
+              "authority": "product-publication",
+              "definitionDigest": "sha256:c3f9e83f952bfac691870d95e82276664f39c42e2b42d9306317b7adf996fac5"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": ".github/workflows/shifu-ci.yml",
+      "authority": "qualification",
+      "definitionDigest": "sha256:c13dbb54f1dadb08e8f42337bc65e69d06fd2ce6110d79f3a0174dbaedeb7f96",
+      "jobs": [
+        {
+          "id": "check",
+          "authority": "qualification",
+          "publication": "none",
+          "receipt": "diagnostic",
+          "definitionDigest": "sha256:496176007abb380d55340564a08028f2ecb075c1c7c8ba6b2c18a53646b5306e",
+          "credentials": {
+            "githubToken": "read",
+            "oidc": false,
+            "repositorySecrets": [],
+            "inheritedSecrets": false,
+            "environment": null
+          },
+          "externalActions": [
+            "actions/checkout@v4",
+            "actions/setup-node@v6.4.0"
+          ],
+          "steps": [
+            {
+              "index": 1,
+              "label": "uses:actions/checkout@v4",
+              "authority": "qualification",
+              "definitionDigest": "sha256:dd0465395fff2eaf34fe466af3f46904442331f18fbcb4d67ae136cd3ae05d18"
+            },
+            {
+              "index": 2,
+              "label": "uses:actions/setup-node@v6.4.0",
+              "authority": "qualification",
+              "definitionDigest": "sha256:c18c6bcd952b8a597d4a32bed3cc75aa1f3e9867ea94ff6bab439a3fd7e28974"
+            },
+            {
+              "index": 3,
+              "label": "name:Run Shifu workspace Gate (POSIX)",
+              "authority": "qualification",
+              "definitionDigest": "sha256:962a4107981fd4e81dc3cc3e95cd25e50621a70856c7d2f5fcfae1def3d30215"
+            },
+            {
+              "index": 4,
+              "label": "name:Run Shifu workspace Gate (Windows)",
+              "authority": "qualification",
+              "definitionDigest": "sha256:f82bc35e53cd3f3c048c0b5f687a7a087c841b3c541802530415c86ee8c7a7fd"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": ".github/workflows/source-acceptance.yml",
+      "authority": "qualification",
+      "definitionDigest": "sha256:192b9c96c6f56ef78dde4a9906ee89018383a6db34b1d9bad35dc9508f02fab7",
+      "jobs": [
+        {
+          "id": "source-acceptance",
+          "authority": "qualification",
+          "publication": "none",
+          "receipt": "qualifying",
+          "definitionDigest": "sha256:98af341c8abb1093d4235641e36ed1a2fd96a9755364726118432b2206ebdb31",
+          "credentials": {
+            "githubToken": "read",
+            "oidc": false,
+            "repositorySecrets": [],
+            "inheritedSecrets": false,
+            "environment": null
+          },
+          "externalActions": [
+            "kungfu-systems/buildchain/.github/workflows/check.yml@52dba6d30051b53d6f6b723fa6e27b090ce4311f"
+          ],
+          "steps": []
+        }
+      ]
+    }
+  ]
+}

--- a/docs/qualification/gates/workflow-authority.md
+++ b/docs/qualification/gates/workflow-authority.md
@@ -1,0 +1,81 @@
+# Closed-world workflow authority
+
+Kungfu classifies every workflow, job, and step under `.github/workflows` in
+[`workflow-authority.json`](./workflow-authority.json). The manifest is an
+authority allowlist, not a workflow index assembled from prose. A new workflow,
+job, or step is unknown until it is classified; unknown execution fails
+`./shifu check:gate-catalog` and therefore source acceptance.
+
+The manifest records a digest of the complete workflow activation surface and
+each complete job and step definition. This binds triggers and path filters,
+`if`, `needs`, permissions, runner selection, reusable workflow or action refs,
+inputs, environment, secrets/OIDC use, shell actions, and step ordering. A
+one-sided YAML change is drift even when the command text still looks familiar.
+
+## Authority classes
+
+- `qualification` may produce diagnostic or qualifying test evidence but may
+  not publish a product or move a release channel.
+- `diagnostic` may update bounded failure reporting, such as the dev patrol
+  issue, but never signs a release capability.
+- `release-control` may move a declared channel only after the independent
+  [release-admission predicate](./release-admission.md) returns a fresh scoped
+  capability.
+- `product-publication` is the narrow package, registry, or GitHub Release
+  write lane. Evidence upload alone remains `evidence-publication` and does not
+  become product authority.
+
+An authority-bearing workflow may reference an external action or reusable
+workflow only by an immutable 40-character commit SHA. Write, OIDC, repository
+secret, inherited-secret, and Environment surfaces are recorded explicitly.
+Moving a permission from one job to workflow scope changes the recorded
+credential surface and fails the contract.
+
+## Generated inventory
+
+The table below is generated from the machine manifest. Editing it by hand
+without changing and refreshing the manifest fails the Gate catalog check.
+
+<!-- BEGIN GENERATED WORKFLOW AUTHORITY MATRIX -->
+| Workflow | Job | Authority | Publication | Receipt | Credentials | Environment | Steps |
+| --- | --- | --- | --- | --- | --- | --- | ---: |
+| `.github/workflows/adr-release-gate.yml` | `adr-release` | qualification | none | diagnostic | token:read | none | 2 |
+| `.github/workflows/build.yml` | `build` | qualification | none | qualifying | token:write, oidc, repo-secret:BUILDCHAIN_ARTIFACT_RELAY_S3_DOWNLOAD_ROLE_ARN+BUILDCHAIN_ARTIFACT_RELAY_S3_ROLE_ARN+BUILDCHAIN_ARTIFACT_RELAY_S3_UPLOAD_ROLE_ARN | none | 0 |
+| `.github/workflows/buildchain-validate.yml` | `promotion-rehearsal` | qualification | none | diagnostic | token:read | none | 2 |
+| `.github/workflows/buildchain-validate.yml` | `validate` | qualification | none | diagnostic | token:read | none | 2 |
+| `.github/workflows/core-build-profiles.yml` | `qualify` | qualification | none | diagnostic | token:read | none | 11 |
+| `.github/workflows/dco.yml` | `signoff` | qualification | none | diagnostic | token:read | none | 2 |
+| `.github/workflows/dev-verify-patrol.yml` | `report` | diagnostic | none | none | token:write | none | 1 |
+| `.github/workflows/dev-verify-patrol.yml` | `verify` | qualification | none | qualifying | token:write, oidc | none | 0 |
+| `.github/workflows/docs-check.yml` | `docs-check` | qualification | none | diagnostic | token:read | none | 3 |
+| `.github/workflows/docs-external-links.yml` | `external-links` | qualification | none | diagnostic | token:read, repo-secret:GITHUB_TOKEN | none | 2 |
+| `.github/workflows/embedding-membrane-spike.yml` | `native-membrane` | qualification | none | diagnostic | token:read | none | 13 |
+| `.github/workflows/embedding-membrane-spike.yml` | `source-delta` | qualification | none | diagnostic | token:read | none | 3 |
+| `.github/workflows/gate-measurement.yml` | `measure` | qualification | none | qualifying | token:read | none | 0 |
+| `.github/workflows/publish-layer-artifacts.yml` | `prepare` | qualification | none | diagnostic | token:read | none | 9 |
+| `.github/workflows/publish-layer-artifacts.yml` | `publish` | product-publication | product | none | token:write, oidc, repo-secret:CARGO_REGISTRY_TOKEN | `adr0049-production-publication` | 7 |
+| `.github/workflows/publish-layer-artifacts.yml` | `publish-pypi` | product-publication | product | none | token:write, oidc | `adr0049-production-publication` | 2 |
+| `.github/workflows/publish-layer-artifacts.yml` | `verify-publication` | qualification | none | diagnostic | token:read | none | 4 |
+| `.github/workflows/release-new-version.yml` | `promote` | release-control | channel | qualifying | token:write, oidc, repo-secret:BUILDCHAIN_ISSUE_APP_ID+BUILDCHAIN_ISSUE_APP_PRIVATE_KEY+KUNGFU_GITHUB_TOKEN | none | 0 |
+| `.github/workflows/release-new-version.yml` | `promotion-contract` | qualification | none | diagnostic | token:read | none | 2 |
+| `.github/workflows/release-new-version.yml` | `shifu-launcher-tag` | release-control | channel | none | token:read, repo-secret:KUNGFU_GITHUB_TOKEN | none | 2 |
+| `.github/workflows/release-shifu.yml` | `build` | qualification | none | diagnostic | token:read | none | 8 |
+| `.github/workflows/release-shifu.yml` | `release` | product-publication | product | none | token:write, repo-secret:GITHUB_TOKEN | none | 3 |
+| `.github/workflows/shifu-ci.yml` | `check` | qualification | none | diagnostic | token:read | none | 4 |
+| `.github/workflows/source-acceptance.yml` | `source-acceptance` | qualification | none | qualifying | token:read | none | 0 |
+<!-- END GENERATED WORKFLOW AUTHORITY MATRIX -->
+
+## Change procedure
+
+1. Change the workflow in the same PR as its authority decision.
+2. Run `./shifu gate:workflow-authority:refresh` to refresh exact
+   definitions. New entries must be reviewed rather than accepted because the
+   command generated a digest.
+3. Review the credential and publication columns, then run
+   `./shifu check:gate-catalog` and `./shifu check:source`.
+4. If a job can publish a product or move a channel, update the release
+   admission policy and its negative fixtures in the same change.
+
+The refresh command cannot make a mutable action acceptable and cannot turn a
+non-publication job into a publication authority. Those are semantic checks,
+not generated fields.

--- a/docs/qualification/gates/workflow-bindings.json
+++ b/docs/qualification/gates/workflow-bindings.json
@@ -19,9 +19,9 @@
       "adapter": {
         "type": "buildchain-source",
         "kind": "job-uses",
-        "uses": "kungfu-systems/buildchain/.github/workflows/check.yml@v2-alpha",
+        "uses": "kungfu-systems/buildchain/.github/workflows/check.yml@52dba6d30051b53d6f6b723fa6e27b090ce4311f",
         "with": {
-          "buildchain-ref": "v2-alpha",
+          "buildchain-ref": "v2",
           "mode": "source",
           "upload-artifacts": true
         }
@@ -288,9 +288,13 @@
       "adapter": {
         "type": "buildchain-heavy-build",
         "kind": "job-uses",
-        "uses": "kungfu-systems/buildchain/.github/workflows/.build.yml@v2-alpha",
+        "uses": "kungfu-systems/buildchain/.github/workflows/.build.yml@52dba6d30051b53d6f6b723fa6e27b090ce4311f",
         "job": {
-          "secrets": "inherit"
+          "secrets": {
+            "BUILDCHAIN_ARTIFACT_RELAY_S3_ROLE_ARN": "${{ secrets.BUILDCHAIN_ARTIFACT_RELAY_S3_ROLE_ARN }}",
+            "BUILDCHAIN_ARTIFACT_RELAY_S3_UPLOAD_ROLE_ARN": "${{ secrets.BUILDCHAIN_ARTIFACT_RELAY_S3_UPLOAD_ROLE_ARN }}",
+            "BUILDCHAIN_ARTIFACT_RELAY_S3_DOWNLOAD_ROLE_ARN": "${{ secrets.BUILDCHAIN_ARTIFACT_RELAY_S3_DOWNLOAD_ROLE_ARN }}"
+          }
         },
         "with": {
           "runner-preset": "${{ inputs.platforms-json && 'custom' || 'kungfu-v4-self-hosted' }}",
@@ -362,7 +366,7 @@
       "adapter": {
         "type": "buildchain-release-admission",
         "kind": "job-uses",
-        "uses": "kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@v2",
+        "uses": "kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@52dba6d30051b53d6f6b723fa6e27b090ce4311f",
         "job": {
           "needs": "promotion-contract",
           "if": "${{ github.event.pull_request.merged == true }}"

--- a/docs/release-promotion-rehearsal.contract.json
+++ b/docs/release-promotion-rehearsal.contract.json
@@ -6,6 +6,7 @@
     "validation": ".github/workflows/buildchain-validate.yml"
   },
   "buildchain": {
+    "workflow_shell_sha": "52dba6d30051b53d6f6b723fa6e27b090ce4311f",
     "alpha": {
       "workflow_ref": "v2-alpha",
       "contract_lock": ".buildchain/alpha-contract-lock.json",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,9 @@
     "check:shifu-documentation-contract": "node scripts/require-shifu.mjs check:shifu-documentation-contract && node scripts/check-shifu-documentation-contract.mjs",
     "check:shifu-gate-contract": "node scripts/require-shifu.mjs check:shifu-gate-contract && node scripts/check-shifu-gate-contract.mjs",
     "check:gate-catalog": "node scripts/require-shifu.mjs check:gate-catalog && node scripts/check-kungfu-gate-catalog.mjs",
+    "gate:workflow-authority:refresh": "node scripts/require-shifu.mjs gate:workflow-authority:refresh && node scripts/kungfu-workflow-authority.mjs --refresh",
+    "test:release-admission": "node scripts/require-shifu.mjs test:release-admission && node --test scripts/verify-kungfu-release-admission.test.mjs",
+    "verify:release-admission": "node scripts/require-shifu.mjs verify:release-admission && node scripts/verify-kungfu-release-admission.mjs",
     "check:shifu-workspace": "node scripts/require-shifu.mjs check:shifu-workspace && node scripts/check-shifu-workspace.mjs",
     "xinfa:build": "node scripts/require-shifu.mjs xinfa:build && node xinfa/tooling/task.mjs build",
     "xinfa:check": "node scripts/require-shifu.mjs xinfa:check && node xinfa/tooling/task.mjs check",
@@ -162,7 +165,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "1.9.4",
-    "@kungfu-tech/buildchain": "2.12.1-alpha.4",
+    "@kungfu-tech/buildchain": "2.12.7",
     "@types/fs-extra": "^11.0.4",
     "@types/markdown-it": "14.1.2",
     "@types/node": "^22.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,8 +33,8 @@ importers:
         specifier: 1.9.4
         version: 1.9.4
       '@kungfu-tech/buildchain':
-        specifier: 2.12.1-alpha.4
-        version: 2.12.1-alpha.4
+        specifier: 2.12.7
+        version: 2.12.7
       '@types/fs-extra':
         specifier: ^11.0.4
         version: 11.0.4
@@ -1381,8 +1381,8 @@ packages:
     engines: {node: '>=22.14.0'}
     hasBin: true
 
-  '@kungfu-tech/buildchain@2.12.1-alpha.4':
-    resolution: {integrity: sha512-Y8ONa44fNbJDXBs/lYcx5snriG5tygaKeGQljqGFOPeyWBjXi+tS3RaPANrPTyLEeutMir/vaCFeIlFzdokX/w==}
+  '@kungfu-tech/buildchain@2.12.7':
+    resolution: {integrity: sha512-DlKBKvMBF7V5VHIyskxaINWWgi37GAUP3hYMaHogGUgkPGXBzArL0r/oY42/9j68JlzT78WoIMDQqvO444LSYA==}
     engines: {node: '>=22.14.0'}
     hasBin: true
 
@@ -5713,7 +5713,7 @@ snapshots:
       '@kungfu-tech/kfd': 1.0.0-alpha.21
       smol-toml: 1.7.0
 
-  '@kungfu-tech/buildchain@2.12.1-alpha.4':
+  '@kungfu-tech/buildchain@2.12.7':
     dependencies:
       '@kungfu-tech/kfd': 1.0.0-alpha.21
       smol-toml: 1.7.0

--- a/scripts/check-kungfu-gate-catalog.mjs
+++ b/scripts/check-kungfu-gate-catalog.mjs
@@ -12,10 +12,16 @@ import {
 } from './kungfu-gate-controller-adapters.mjs';
 import { scanWorkflowInvocations } from './kungfu-gate-workflow-facts.mjs';
 import {
+  WORKFLOW_AUTHORITY_DOC,
+  replaceWorkflowAuthorityMatrix,
+  validateWorkflowAuthority,
+} from './kungfu-workflow-authority.mjs';
+import {
   gateDefinitionDigest,
   gateDigest,
   validateGateRegistry,
 } from './shifu-gate-runtime.mjs';
+import { validateKungfuReleaseAdmissionPolicy } from './verify-kungfu-release-admission.mjs';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const MATRIX = 'docs/qualification/gates/policy-matrix.md';
@@ -521,6 +527,23 @@ export function checkKungfuGateCatalog(root = ROOT) {
   }
   if (validation.length) return { issues, registry };
 
+  const authorityValidation = validateWorkflowAuthority(root);
+  issues.push(...authorityValidation.issues);
+  const authorityDocPath = path.join(root, WORKFLOW_AUTHORITY_DOC);
+  const authorityDoc = fs.readFileSync(authorityDocPath, 'utf8');
+  if (
+    authorityDoc !==
+    replaceWorkflowAuthorityMatrix(authorityDoc, authorityValidation.document)
+  )
+    issues.push(
+      `[workflow-authority] ${WORKFLOW_AUTHORITY_DOC} differs from the authority manifest`,
+    );
+  try {
+    validateKungfuReleaseAdmissionPolicy(root);
+  } catch (error) {
+    issues.push(`[release-admission] ${error.message}`);
+  }
+
   const measurementValidation = validateMeasurementCoverage(root, registry);
   issues.push(...measurementValidation.issues);
   if (!measurementValidation.issues.length) {
@@ -834,7 +857,12 @@ export function checkKungfuGateCatalog(root = ROOT) {
       }
     }
   }
-  return { issues, registry, workflowFacts: workflowScan.facts };
+  return {
+    issues,
+    registry,
+    workflowFacts: workflowScan.facts,
+    workflowAuthority: authorityValidation.document,
+  };
 }
 
 export function writePolicyMatrix(root = ROOT) {
@@ -870,7 +898,7 @@ function main() {
     process.exit(1);
   }
   console.log(
-    `[kungfu-gates] ${result.registry.gates.length} gates, ${result.registry.profiles.length} profiles, ${result.workflowFacts.length} structured workflow invocations and measurement coverage aligned`,
+    `[kungfu-gates] ${result.registry.gates.length} gates, ${result.registry.profiles.length} profiles, ${result.workflowFacts.length} structured invocations and ${result.workflowAuthority.workflows.length} closed-world workflows aligned`,
   );
 }
 

--- a/scripts/check-kungfu-gate-catalog.test.mjs
+++ b/scripts/check-kungfu-gate-catalog.test.mjs
@@ -11,6 +11,10 @@ import {
   renderPolicyMatrix,
   validateMeasurementCoverage,
 } from './check-kungfu-gate-catalog.mjs';
+import {
+  projectWorkflowAuthority,
+  validateWorkflowAuthority,
+} from './kungfu-workflow-authority.mjs';
 import { gateDefinitionDigest, gateDigest } from './shifu-gate-runtime.mjs';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
@@ -20,6 +24,10 @@ function fixture() {
   for (const relative of [
     'shifu.gates.json',
     'package.json',
+    '.github/workflows',
+    'node_modules/@kungfu-tech/buildchain/package.json',
+    'node_modules/@kungfu-tech/buildchain/dist/site/buildchain-contract.json',
+    'node_modules/@kungfu-tech/buildchain/dist/site/publication-authority-registry.json',
     'docs/qualification/gates',
     'docs/qualification/evidence/layer-gates/c4ba70d95/linux-x64.raw/layer-artifact-gate-receipt.json',
     'docs/qualification/evidence/layer-gates/c4ba70d95/macos-arm64.raw/layer-artifact-gate-receipt.json',
@@ -30,18 +38,6 @@ function fixture() {
     const target = path.join(root, relative);
     fs.mkdirSync(path.dirname(target), { recursive: true });
     fs.cpSync(source, target, { recursive: true });
-  }
-  const bindings = JSON.parse(
-    fs.readFileSync(
-      path.join(root, 'docs/qualification/gates/workflow-bindings.json'),
-      'utf8',
-    ),
-  );
-  for (const binding of bindings.bindings) {
-    const source = path.join(ROOT, binding.workflow);
-    const target = path.join(root, binding.workflow);
-    fs.mkdirSync(path.dirname(target), { recursive: true });
-    fs.copyFileSync(source, target);
   }
   return root;
 }
@@ -89,6 +85,128 @@ test('current Kungfu catalog, docs, matrix, actions, and workflows align', () =>
   );
   assert.equal(controllers.length, 6);
   assert.ok(controllers.every((fact) => fact.gates.length > 0));
+  assert.equal(result.workflowAuthority.workflows.length, 15);
+});
+
+test('workflow authority rejects unknown workflows, jobs, steps, and activation drift', () => {
+  const root = fixture();
+  fs.writeFileSync(
+    path.join(root, '.github/workflows/unknown.yml'),
+    'name: Unknown\non: workflow_dispatch\njobs: {}\n',
+  );
+  assert.ok(
+    validateWorkflowAuthority(root).issues.some((issue) =>
+      issue.includes('workflow inventory drift'),
+    ),
+  );
+  fs.rmSync(path.join(root, '.github/workflows/unknown.yml'));
+
+  const workflow = path.join(root, '.github/workflows/dco.yml');
+  const original = fs.readFileSync(workflow, 'utf8');
+  fs.writeFileSync(
+    workflow,
+    original.replace(
+      'jobs:\n',
+      'jobs:\n  unknown-job:\n    runs-on: ubuntu-latest\n    steps: []\n',
+    ),
+  );
+  assert.ok(
+    validateWorkflowAuthority(root).issues.some((issue) =>
+      issue.includes('dco.yml job inventory drift'),
+    ),
+  );
+  fs.writeFileSync(
+    workflow,
+    original.replace(
+      '    steps:\n',
+      '    steps:\n      - name: Unknown step\n        run: echo unexpected\n',
+    ),
+  );
+  assert.ok(
+    validateWorkflowAuthority(root).issues.some((issue) =>
+      issue.includes('dco.yml#signoff step inventory drift'),
+    ),
+  );
+  fs.writeFileSync(
+    workflow,
+    original.replace('contents: read', 'contents: write'),
+  );
+  const activationOrPermissionIssues = validateWorkflowAuthority(root).issues;
+  assert.ok(
+    activationOrPermissionIssues.some((issue) =>
+      issue.includes('dco.yml definition drift'),
+    ),
+  );
+  assert.ok(
+    activationOrPermissionIssues.some((issue) =>
+      issue.includes('dco.yml#signoff credentials drift'),
+    ),
+  );
+});
+
+test('refreshing digests cannot authorize a mutable action in an authority-bearing workflow', () => {
+  const root = fixture();
+  const workflow = path.join(root, '.github/workflows/source-acceptance.yml');
+  fs.writeFileSync(
+    workflow,
+    fs
+      .readFileSync(workflow, 'utf8')
+      .replace(/check\.yml@[0-9a-f]{40}/, 'check.yml@v2'),
+  );
+  const currentManifest = JSON.parse(
+    fs.readFileSync(
+      path.join(root, 'docs/qualification/gates/workflow-authority.json'),
+      'utf8',
+    ),
+  );
+  const refreshed = projectWorkflowAuthority(root, currentManifest).document;
+  assert.ok(
+    validateWorkflowAuthority(root, refreshed).issues.some((issue) =>
+      issue.includes(
+        'authority-bearing workflows require immutable external action refs',
+      ),
+    ),
+  );
+});
+
+test('refreshing digests cannot give qualification jobs inherited secrets or an Environment', () => {
+  const root = fixture();
+  const workflow = path.join(root, '.github/workflows/build.yml');
+  const original = fs.readFileSync(workflow, 'utf8');
+  const currentManifest = JSON.parse(
+    fs.readFileSync(
+      path.join(root, 'docs/qualification/gates/workflow-authority.json'),
+      'utf8',
+    ),
+  );
+
+  fs.writeFileSync(
+    workflow,
+    original.replace(
+      / {4}secrets:\n(?: {6}BUILDCHAIN_ARTIFACT_RELAY_S3_[A-Z_]+:.*\n){3}/,
+      '    secrets: inherit\n',
+    ),
+  );
+  let refreshed = projectWorkflowAuthority(root, currentManifest).document;
+  assert.ok(
+    validateWorkflowAuthority(root, refreshed).issues.some((issue) =>
+      issue.includes('inherited secrets require'),
+    ),
+  );
+
+  fs.writeFileSync(
+    workflow,
+    original.replace(
+      '    uses: kungfu-systems/buildchain/',
+      '    environment: production\n    uses: kungfu-systems/buildchain/',
+    ),
+  );
+  refreshed = projectWorkflowAuthority(root, currentManifest).document;
+  assert.ok(
+    validateWorkflowAuthority(root, refreshed).issues.some((issue) =>
+      issue.includes('Environment access requires'),
+    ),
+  );
 });
 
 test('matrix rendering is deterministic and includes every profile', () => {
@@ -486,12 +604,12 @@ test('rogue, duplicate, missing, and invalid controller adapters fail closed', (
   const rogueRoot = fixture();
   fs.writeFileSync(
     path.join(rogueRoot, '.github/workflows/rogue-controller.yml'),
-    'name: Rogue controller\njobs:\n  source-copy:\n    uses: kungfu-systems/buildchain/.github/workflows/check.yml@v2-alpha\n    with:\n      buildchain-ref: v2-alpha\n      mode: source\n      upload-artifacts: true\n',
+    'name: Rogue controller\njobs:\n  source-copy:\n    uses: kungfu-systems/buildchain/.github/workflows/check.yml@52dba6d30051b53d6f6b723fa6e27b090ce4311f\n    with:\n      buildchain-ref: v2\n      mode: source\n      upload-artifacts: true\n',
   );
   assert.ok(
     checkKungfuGateCatalog(rogueRoot).issues.some((issue) =>
       issue.includes(
-        '.github/workflows/rogue-controller.yml#source-copy:job-uses:kungfu-systems/buildchain/.github/workflows/check.yml@v2-alpha: invocation has no matching binding',
+        '.github/workflows/rogue-controller.yml#source-copy:job-uses:kungfu-systems/buildchain/.github/workflows/check.yml@52dba6d30051b53d6f6b723fa6e27b090ce4311f: invocation has no matching binding',
       ),
     ),
   );

--- a/scripts/kungfu-workflow-authority.mjs
+++ b/scripts/kungfu-workflow-authority.mjs
@@ -1,0 +1,543 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: Apache-2.0
+// @ts-check
+
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { isDeepStrictEqual } from 'node:util';
+import { parseDocument } from 'yaml';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+export const WORKFLOW_AUTHORITY =
+  'docs/qualification/gates/workflow-authority.json';
+export const WORKFLOW_AUTHORITY_DOC =
+  'docs/qualification/gates/workflow-authority.md';
+const MATRIX_BEGIN = '<!-- BEGIN GENERATED WORKFLOW AUTHORITY MATRIX -->';
+const MATRIX_END = '<!-- END GENERATED WORKFLOW AUTHORITY MATRIX -->';
+
+const WORKFLOW_AUTHORITIES = new Set([
+  'qualification',
+  'diagnostic',
+  'release-control',
+  'product-publication',
+]);
+const JOB_AUTHORITIES = new Set([
+  'qualification',
+  'diagnostic',
+  'release-control',
+  'product-publication',
+]);
+const STEP_AUTHORITIES = new Set([
+  'qualification',
+  'evidence-publication',
+  'diagnostic-write',
+  'release-control',
+  'product-publication',
+]);
+const PUBLICATION_CLASSES = new Set(['none', 'evidence', 'product', 'channel']);
+const RECEIPT_CLASSES = new Set(['none', 'diagnostic', 'qualifying']);
+
+function canonical(value) {
+  if (Array.isArray(value)) return value.map(canonical);
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, child]) => [key, canonical(child)]),
+    );
+  }
+  return value;
+}
+
+export function authorityDigest(value) {
+  return `sha256:${crypto
+    .createHash('sha256')
+    .update(JSON.stringify(canonical(value)))
+    .digest('hex')}`;
+}
+
+function workflowFiles(root) {
+  const directory = path.join(root, '.github/workflows');
+  return fs
+    .readdirSync(directory)
+    .filter((name) => /\.ya?ml$/.test(name))
+    .map((name) => `.github/workflows/${name}`)
+    .sort();
+}
+
+function parseWorkflow(root, relative, issues) {
+  const document = parseDocument(
+    fs.readFileSync(path.join(root, relative), 'utf8'),
+    { prettyErrors: false, uniqueKeys: true },
+  );
+  for (const error of document.errors)
+    issues.push(`[workflow-authority-yaml] ${relative}: ${error.message}`);
+  return document.errors.length ? null : document.toJS();
+}
+
+function workflowDefinition(value) {
+  const { jobs: _jobs, ...definition } = value;
+  return definition;
+}
+
+function permissionMode(permissions) {
+  if (permissions === 'write-all') return 'write';
+  if (permissions === 'read-all') return 'read';
+  if (
+    permissions === null ||
+    (permissions &&
+      typeof permissions === 'object' &&
+      !Array.isArray(permissions) &&
+      Object.keys(permissions).length === 0)
+  )
+    return 'none';
+  if (!permissions || typeof permissions !== 'object') return 'unspecified';
+  if (Object.values(permissions).includes('write')) return 'write';
+  if (Object.values(permissions).includes('read')) return 'read';
+  return 'none';
+}
+
+function secretReferences(value) {
+  const serialized = JSON.stringify(value);
+  const names = new Set();
+  for (const match of serialized.matchAll(/secrets\.([A-Za-z0-9_]+)/g))
+    names.add(match[1]);
+  for (const match of serialized.matchAll(/secrets\[['"]([^'"]+)['"]\]/g))
+    names.add(match[1]);
+  return [...names].sort();
+}
+
+function environmentName(environment) {
+  if (typeof environment === 'string') return environment;
+  if (environment && typeof environment === 'object')
+    return typeof environment.name === 'string' ? environment.name : 'dynamic';
+  return null;
+}
+
+function credentialSurface(workflow, job) {
+  const permissions = job.permissions ?? workflow.permissions;
+  return {
+    githubToken: permissionMode(permissions),
+    oidc:
+      Boolean(permissions) &&
+      typeof permissions === 'object' &&
+      permissions['id-token'] === 'write',
+    repositorySecrets: secretReferences(job),
+    inheritedSecrets: job.secrets === 'inherit',
+    environment: environmentName(job.environment),
+  };
+}
+
+function stepLabel(step, index) {
+  if (typeof step.id === 'string') return `id:${step.id}`;
+  if (typeof step.name === 'string') return `name:${step.name}`;
+  if (typeof step.uses === 'string') return `uses:${step.uses}`;
+  const firstLine = typeof step.run === 'string' ? step.run.split('\n')[0] : '';
+  return `run:${firstLine || `step-${index + 1}`}`;
+}
+
+function externalActionReferences(job) {
+  const references = [];
+  if (typeof job.uses === 'string') references.push(job.uses);
+  for (const step of Array.isArray(job.steps) ? job.steps : [])
+    if (typeof step.uses === 'string') references.push(step.uses);
+  return references.filter(
+    (reference) =>
+      !reference.startsWith('./') && !reference.startsWith('docker://'),
+  );
+}
+
+function immutableReference(reference) {
+  const marker = reference.lastIndexOf('@');
+  return marker > 0 && /^[0-9a-f]{40}$/.test(reference.slice(marker + 1));
+}
+
+function exactKeys(value, keys, location, issues) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    issues.push(`[workflow-authority] ${location} must be an object`);
+    return false;
+  }
+  const allowed = new Set(keys);
+  for (const key of keys)
+    if (!Object.hasOwn(value, key))
+      issues.push(`[workflow-authority] ${location}.${key} is required`);
+  for (const key of Object.keys(value))
+    if (!allowed.has(key))
+      issues.push(`[workflow-authority] ${location}.${key} is not allowed`);
+  return true;
+}
+
+function initialJobPolicy(workflowPath, jobId) {
+  if (workflowPath.endsWith('/publish-layer-artifacts.yml')) {
+    if (['publish', 'publish-pypi'].includes(jobId))
+      return ['product-publication', 'product', 'none'];
+  }
+  if (workflowPath.endsWith('/release-new-version.yml')) {
+    if (jobId === 'promote')
+      return ['release-control', 'channel', 'qualifying'];
+    if (jobId === 'shifu-launcher-tag')
+      return ['release-control', 'channel', 'none'];
+  }
+  if (workflowPath.endsWith('/release-shifu.yml') && jobId === 'release')
+    return ['product-publication', 'product', 'none'];
+  if (workflowPath.endsWith('/dev-verify-patrol.yml') && jobId === 'report')
+    return ['diagnostic', 'none', 'none'];
+  if (
+    (workflowPath.endsWith('/dev-verify-patrol.yml') && jobId === 'verify') ||
+    (workflowPath.endsWith('/gate-measurement.yml') && jobId === 'measure') ||
+    (workflowPath.endsWith('/build.yml') && jobId === 'build') ||
+    (workflowPath.endsWith('/source-acceptance.yml') &&
+      jobId === 'source-acceptance')
+  )
+    return ['qualification', 'none', 'qualifying'];
+  return ['qualification', 'none', 'diagnostic'];
+}
+
+function initialStepAuthority(jobAuthority, step) {
+  if (jobAuthority === 'product-publication') return 'product-publication';
+  if (jobAuthority === 'release-control') return 'release-control';
+  if (jobAuthority === 'diagnostic') return 'diagnostic-write';
+  if (
+    typeof step.uses === 'string' &&
+    /(upload-artifact|download-artifact)/.test(step.uses)
+  )
+    return 'evidence-publication';
+  return 'qualification';
+}
+
+export function projectWorkflowAuthority(root = ROOT, previous = null) {
+  const issues = [];
+  const previousWorkflows = new Map(
+    (previous?.workflows || []).map((workflow) => [workflow.path, workflow]),
+  );
+  const workflows = [];
+  for (const relative of workflowFiles(root)) {
+    const value = parseWorkflow(root, relative, issues);
+    if (!value) continue;
+    const previousWorkflow = previousWorkflows.get(relative);
+    const previousJobs = new Map(
+      (previousWorkflow?.jobs || []).map((job) => [job.id, job]),
+    );
+    const jobs = [];
+    for (const [jobId, job] of Object.entries(value.jobs || {}).sort(
+      ([a], [b]) => a.localeCompare(b),
+    )) {
+      const previousJob = previousJobs.get(jobId);
+      const [initialAuthority, initialPublication, initialReceipt] =
+        initialJobPolicy(relative, jobId);
+      const steps = (Array.isArray(job.steps) ? job.steps : []).map(
+        (step, index) => ({
+          index: index + 1,
+          label: stepLabel(step, index),
+          authority:
+            previousJob?.steps?.find((item) => item.index === index + 1)
+              ?.authority || initialStepAuthority(initialAuthority, step),
+          definitionDigest: authorityDigest(step),
+        }),
+      );
+      jobs.push({
+        id: jobId,
+        authority: previousJob?.authority || initialAuthority,
+        publication: previousJob?.publication || initialPublication,
+        receipt: previousJob?.receipt || initialReceipt,
+        definitionDigest: authorityDigest(job),
+        credentials: credentialSurface(value, job),
+        externalActions: externalActionReferences(job),
+        steps,
+      });
+    }
+    workflows.push({
+      path: relative,
+      authority:
+        previousWorkflow?.authority ||
+        (jobs.some((job) => job.authority === 'product-publication')
+          ? 'product-publication'
+          : jobs.some((job) => job.authority === 'release-control')
+            ? 'release-control'
+            : jobs.some((job) => job.authority === 'diagnostic')
+              ? 'diagnostic'
+              : 'qualification'),
+      definitionDigest: authorityDigest(workflowDefinition(value)),
+      jobs,
+    });
+  }
+  return {
+    issues,
+    document: {
+      schema: 'kungfu.workflow-authority/v1',
+      workflowRoot: '.github/workflows',
+      workflows,
+    },
+  };
+}
+
+function credentialSummary(credentials) {
+  const parts = [`token:${credentials.githubToken}`];
+  if (credentials.oidc) parts.push('oidc');
+  if (credentials.repositorySecrets.length)
+    parts.push(`repo-secret:${credentials.repositorySecrets.join('+')}`);
+  if (credentials.inheritedSecrets) parts.push('inherited-secrets');
+  return parts.join(', ');
+}
+
+export function renderWorkflowAuthorityMatrix(document) {
+  return [
+    '| Workflow | Job | Authority | Publication | Receipt | Credentials | Environment | Steps |',
+    '| --- | --- | --- | --- | --- | --- | --- | ---: |',
+    ...document.workflows.flatMap((workflow) =>
+      workflow.jobs.map(
+        (job) =>
+          `| \`${workflow.path}\` | \`${job.id}\` | ${job.authority} | ${job.publication} | ${job.receipt} | ${credentialSummary(job.credentials)} | ${job.credentials.environment ? `\`${job.credentials.environment}\`` : 'none'} | ${job.steps.length} |`,
+      ),
+    ),
+  ].join('\n');
+}
+
+export function replaceWorkflowAuthorityMatrix(text, document) {
+  const start = text.indexOf(MATRIX_BEGIN);
+  const finish = text.indexOf(MATRIX_END);
+  if (start < 0 || finish <= start)
+    throw new Error(
+      `missing ordered authority matrix markers in ${WORKFLOW_AUTHORITY_DOC}`,
+    );
+  return `${text.slice(0, start + MATRIX_BEGIN.length)}\n${renderWorkflowAuthorityMatrix(document)}\n${text.slice(finish)}`;
+}
+
+function compareProjection(actual, expected, location, issues) {
+  if (!isDeepStrictEqual(actual, expected))
+    issues.push(
+      `[workflow-authority] ${location} drift: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`,
+    );
+}
+
+export function validateWorkflowAuthority(root = ROOT, document = null) {
+  const issues = [];
+  const manifest =
+    document ||
+    JSON.parse(fs.readFileSync(path.join(root, WORKFLOW_AUTHORITY)));
+  exactKeys(
+    manifest,
+    ['schema', 'workflowRoot', 'workflows'],
+    'document',
+    issues,
+  );
+  if (manifest.schema !== 'kungfu.workflow-authority/v1')
+    issues.push('[workflow-authority] unsupported schema');
+  if (manifest.workflowRoot !== '.github/workflows')
+    issues.push('[workflow-authority] workflowRoot must be .github/workflows');
+  if (!Array.isArray(manifest.workflows)) return { issues, document: manifest };
+
+  const projected = projectWorkflowAuthority(root, manifest);
+  issues.push(...projected.issues);
+  const actualPaths = projected.document.workflows.map((item) => item.path);
+  const declaredPaths = manifest.workflows.map((item) => item.path);
+  compareProjection(actualPaths, declaredPaths, 'workflow inventory', issues);
+  const actualByPath = new Map(
+    projected.document.workflows.map((item) => [item.path, item]),
+  );
+  const seen = new Set();
+  for (const [workflowIndex, workflow] of manifest.workflows.entries()) {
+    const at = `workflows[${workflowIndex}]`;
+    exactKeys(
+      workflow,
+      ['path', 'authority', 'definitionDigest', 'jobs'],
+      at,
+      issues,
+    );
+    if (seen.has(workflow.path))
+      issues.push(`[workflow-authority] duplicate workflow '${workflow.path}'`);
+    seen.add(workflow.path);
+    if (!WORKFLOW_AUTHORITIES.has(workflow.authority))
+      issues.push(`[workflow-authority] ${at}.authority is unsupported`);
+    const actualWorkflow = actualByPath.get(workflow.path);
+    if (!actualWorkflow) continue;
+    const workflowCarriesAuthority = (workflow.jobs || []).some(
+      (job) => job.receipt === 'qualifying' || job.publication !== 'none',
+    );
+    compareProjection(
+      actualWorkflow.definitionDigest,
+      workflow.definitionDigest,
+      `${workflow.path} definition`,
+      issues,
+    );
+    const actualJobIds = actualWorkflow.jobs.map((item) => item.id);
+    const declaredJobIds = (workflow.jobs || []).map((item) => item.id);
+    compareProjection(
+      actualJobIds,
+      declaredJobIds,
+      `${workflow.path} job inventory`,
+      issues,
+    );
+    const actualJobs = new Map(
+      actualWorkflow.jobs.map((item) => [item.id, item]),
+    );
+    for (const [jobIndex, job] of (workflow.jobs || []).entries()) {
+      const jobAt = `${workflow.path}#${job.id}`;
+      exactKeys(
+        job,
+        [
+          'id',
+          'authority',
+          'publication',
+          'receipt',
+          'definitionDigest',
+          'credentials',
+          'externalActions',
+          'steps',
+        ],
+        `${at}.jobs[${jobIndex}]`,
+        issues,
+      );
+      if (!JOB_AUTHORITIES.has(job.authority))
+        issues.push(`[workflow-authority] ${jobAt}: unsupported authority`);
+      if (!PUBLICATION_CLASSES.has(job.publication))
+        issues.push(`[workflow-authority] ${jobAt}: unsupported publication`);
+      if (!RECEIPT_CLASSES.has(job.receipt))
+        issues.push(`[workflow-authority] ${jobAt}: unsupported receipt`);
+      if (
+        ['product', 'channel'].includes(job.publication) &&
+        !['product-publication', 'release-control'].includes(job.authority)
+      )
+        issues.push(
+          `[workflow-authority] ${jobAt}: publication requires publication authority`,
+        );
+      if (
+        job.receipt === 'qualifying' &&
+        job.authority !== 'qualification' &&
+        job.authority !== 'release-control'
+      )
+        issues.push(
+          `[workflow-authority] ${jobAt}: qualifying receipt requires qualification or release-control authority`,
+        );
+      const actualJob = actualJobs.get(job.id);
+      if (!actualJob) continue;
+      if (
+        actualJob.credentials.inheritedSecrets &&
+        !['product-publication', 'release-control'].includes(job.authority)
+      )
+        issues.push(
+          `[workflow-authority] ${jobAt}: inherited secrets require product-publication or release-control authority`,
+        );
+      if (
+        actualJob.credentials.environment &&
+        !['product-publication', 'release-control'].includes(job.authority)
+      )
+        issues.push(
+          `[workflow-authority] ${jobAt}: Environment access requires product-publication or release-control authority`,
+        );
+      for (const field of [
+        'definitionDigest',
+        'credentials',
+        'externalActions',
+      ])
+        compareProjection(
+          actualJob[field],
+          job[field],
+          `${jobAt} ${field}`,
+          issues,
+        );
+      if (
+        workflowCarriesAuthority &&
+        actualJob.externalActions.some(
+          (reference) => !immutableReference(reference),
+        )
+      )
+        issues.push(
+          `[workflow-authority] ${jobAt}: authority-bearing workflows require immutable external action refs`,
+        );
+      const actualStepIndexes = actualJob.steps.map((item) => item.index);
+      const declaredStepIndexes = (job.steps || []).map((item) => item.index);
+      compareProjection(
+        actualStepIndexes,
+        declaredStepIndexes,
+        `${jobAt} step inventory`,
+        issues,
+      );
+      for (const [stepIndex, step] of (job.steps || []).entries()) {
+        exactKeys(
+          step,
+          ['index', 'label', 'authority', 'definitionDigest'],
+          `${jobAt}.steps[${stepIndex}]`,
+          issues,
+        );
+        if (!STEP_AUTHORITIES.has(step.authority))
+          issues.push(
+            `[workflow-authority] ${jobAt}.steps[${stepIndex}]: unsupported authority`,
+          );
+        const actualStep = actualJob.steps[stepIndex];
+        if (!actualStep) continue;
+        compareProjection(
+          actualStep.label,
+          step.label,
+          `${jobAt} step ${step.index} label`,
+          issues,
+        );
+        compareProjection(
+          actualStep.definitionDigest,
+          step.definitionDigest,
+          `${jobAt} step ${step.index} definition`,
+          issues,
+        );
+        const permittedStepAuthorities = {
+          qualification: ['qualification', 'evidence-publication'],
+          diagnostic: ['qualification', 'diagnostic-write'],
+          'release-control': [
+            'qualification',
+            'evidence-publication',
+            'release-control',
+          ],
+          'product-publication': [
+            'qualification',
+            'evidence-publication',
+            'product-publication',
+          ],
+        };
+        if (!permittedStepAuthorities[job.authority]?.includes(step.authority))
+          issues.push(
+            `[workflow-authority] ${jobAt} step ${step.index}: step authority exceeds job authority`,
+          );
+      }
+    }
+  }
+  return { issues, document: manifest, projection: projected.document };
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const refresh = process.argv.includes('--refresh');
+  if (refresh) {
+    const target = path.join(ROOT, WORKFLOW_AUTHORITY);
+    const previous = fs.existsSync(target)
+      ? JSON.parse(fs.readFileSync(target, 'utf8'))
+      : null;
+    const projection = projectWorkflowAuthority(ROOT, previous);
+    if (projection.issues.length) {
+      console.error(projection.issues.join('\n'));
+      process.exit(1);
+    }
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.writeFileSync(
+      target,
+      `${JSON.stringify(projection.document, null, 2)}\n`,
+    );
+    const docTarget = path.join(ROOT, WORKFLOW_AUTHORITY_DOC);
+    if (fs.existsSync(docTarget)) {
+      fs.writeFileSync(
+        docTarget,
+        replaceWorkflowAuthorityMatrix(
+          fs.readFileSync(docTarget, 'utf8'),
+          projection.document,
+        ),
+      );
+    }
+    console.log(`refreshed ${WORKFLOW_AUTHORITY}`);
+  } else {
+    const result = validateWorkflowAuthority(ROOT);
+    if (result.issues.length) {
+      console.error(result.issues.join('\n'));
+      process.exit(1);
+    }
+    console.log('Kungfu workflow authority: closed world verified');
+  }
+}

--- a/scripts/release-promotion-rehearsal.mjs
+++ b/scripts/release-promotion-rehearsal.mjs
@@ -73,9 +73,11 @@ export function validateWorkflowSources(root, contract, overrides = {}) {
 
   requirePattern(
     build,
-    /uses: kungfu-systems\/buildchain\/\.github\/workflows\/\.build\.yml@v2-alpha/,
+    new RegExp(
+      `uses: kungfu-systems/buildchain/\\.github/workflows/\\.build\\.yml@${contract.buildchain.workflow_shell_sha}`,
+    ),
     findings,
-    'release-candidate build must consume Buildchain v2-alpha',
+    'release-candidate build must consume the exact stable Buildchain workflow shell',
   );
   requirePattern(
     build,
@@ -122,7 +124,9 @@ export function validateWorkflowSources(root, contract, overrides = {}) {
   );
   requirePattern(
     promote,
-    /uses: kungfu-systems\/buildchain\/\.github\/workflows\/release-candidate-promote\.yml@v2/,
+    new RegExp(
+      `uses: kungfu-systems/buildchain/\\.github/workflows/release-candidate-promote\\.yml@${contract.buildchain.workflow_shell_sha}`,
+    ),
     findings,
     'promotion must consume the stable Buildchain workflow shell',
   );

--- a/scripts/source-acceptance.mjs
+++ b/scripts/source-acceptance.mjs
@@ -205,6 +205,7 @@ export function sourceAcceptancePlan(files) {
         'scripts/shifu-documentation-runtime.test.mjs',
         'scripts/kungfu-xinfa-consumer.test.mjs',
         'scripts/check-kungfu-gate-catalog.test.mjs',
+        'scripts/verify-kungfu-release-admission.test.mjs',
         'xinfa/tooling/check-boundary.test.mjs',
         'scripts/check-schema-authority.test.mjs',
         'scripts/check-runtime-contract.test.mjs',

--- a/scripts/source-acceptance.test.mjs
+++ b/scripts/source-acceptance.test.mjs
@@ -259,14 +259,14 @@ test('source plan cannot enter build, compiler, artifact, or release lifecycles'
   );
 });
 
-test('reusable workflow is bound to source mode and the protected alpha channel', () => {
+test('reusable workflow is bound to source mode and the pinned stable runtime', () => {
   const workflow = fs.readFileSync(
     path.join(ROOT, '.github/workflows/source-acceptance.yml'),
     'utf8',
   );
   assert.match(workflow, /mode: source/);
-  assert.match(workflow, /check\.yml@v2-alpha/);
-  assert.match(workflow, /buildchain-ref: v2-alpha/);
+  assert.match(workflow, /check\.yml@52dba6d30051b53d6f6b723fa6e27b090ce4311f/);
+  assert.match(workflow, /buildchain-ref: v2/);
   assert.doesNotMatch(workflow, /self-hosted/);
 });
 

--- a/scripts/verify-kungfu-release-admission.mjs
+++ b/scripts/verify-kungfu-release-admission.mjs
@@ -1,0 +1,354 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: Apache-2.0
+// @ts-check
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  publicationAuthorityDigest,
+  verifyPublicationAdmission,
+} from '@kungfu-tech/buildchain/publication-authority';
+import {
+  authorityDigest,
+  validateWorkflowAuthority,
+} from './kungfu-workflow-authority.mjs';
+import {
+  buildGatePlan,
+  gateActionId,
+  gateDefinitionDigest,
+  gateDigest,
+} from './shifu-gate-runtime.mjs';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const POLICY = 'docs/qualification/gates/release-admission-policy.json';
+
+function readJson(root, relative) {
+  return JSON.parse(fs.readFileSync(path.resolve(root, relative), 'utf8'));
+}
+
+function requiredFile(value, label) {
+  if (typeof value !== 'string' || !value)
+    throw new Error(`${label} path is required`);
+  return value;
+}
+
+function exactKeys(value, keys, label) {
+  if (!value || typeof value !== 'object' || Array.isArray(value))
+    throw new Error(`${label} must be an object`);
+  const actual = Object.keys(value).sort();
+  const expected = [...keys].sort();
+  if (actual.join('\0') !== expected.join('\0'))
+    throw new Error(`${label} fields must be exactly [${expected.join(', ')}]`);
+}
+
+function validatePolicy(policy) {
+  exactKeys(
+    policy,
+    [
+      'schema',
+      'repository',
+      'profile',
+      'requiredPlatforms',
+      'workflowAuthority',
+      'buildchain',
+      'publication',
+      'freshness',
+    ],
+    'release admission policy',
+  );
+  if (policy.schema !== 'kungfu.release-admission-policy/v1')
+    throw new Error('unsupported Kungfu release admission policy');
+  if (
+    !Array.isArray(policy.requiredPlatforms) ||
+    policy.requiredPlatforms.join('\0') !== 'linux\0macos\0windows'
+  )
+    throw new Error(
+      'Kungfu release admission requires linux, macos, and windows',
+    );
+  exactKeys(
+    policy.workflowAuthority,
+    ['manifest', 'workflow', 'job'],
+    'workflowAuthority',
+  );
+  exactKeys(
+    policy.buildchain,
+    ['version', 'runtimeSha', 'contractDigest', 'registry'],
+    'buildchain',
+  );
+  exactKeys(
+    policy.publication,
+    [
+      'workflowPath',
+      'publisherWorkflowPath',
+      'environment',
+      'product',
+      'target',
+      'channels',
+    ],
+    'publication',
+  );
+  exactKeys(
+    policy.freshness,
+    ['maximumLifetimeSeconds', 'nonceReplay'],
+    'freshness',
+  );
+  if (
+    policy.freshness.maximumLifetimeSeconds !== 900 ||
+    policy.freshness.nonceReplay !== 'deny'
+  )
+    throw new Error(
+      'Kungfu admission freshness must remain fail closed at 900 seconds',
+    );
+  if (
+    !Array.isArray(policy.publication.channels) ||
+    policy.publication.channels.length === 0 ||
+    new Set(policy.publication.channels).size !==
+      policy.publication.channels.length
+  )
+    throw new Error('publication.channels must be a non-empty unique array');
+}
+
+function currentBuildchain(root, policy) {
+  const packageDocument = readJson(
+    root,
+    'node_modules/@kungfu-tech/buildchain/package.json',
+  );
+  if (packageDocument.version !== policy.buildchain.version)
+    throw new Error(
+      'installed Buildchain version differs from release admission policy',
+    );
+  const contract = readJson(
+    root,
+    'node_modules/@kungfu-tech/buildchain/dist/site/buildchain-contract.json',
+  );
+  if (contract.contractDigest !== policy.buildchain.contractDigest)
+    throw new Error(
+      'installed Buildchain contract digest differs from release admission policy',
+    );
+  return readJson(root, policy.buildchain.registry);
+}
+
+function validateAuthorityJob(authorityDocument, policy) {
+  const workflow = authorityDocument.workflows.find(
+    (item) => item.path === policy.workflowAuthority.workflow,
+  );
+  const job = workflow?.jobs.find(
+    (item) => item.id === policy.workflowAuthority.job,
+  );
+  if (!job)
+    throw new Error('release admission authority job is not classified');
+  if (
+    job.authority !== 'release-control' ||
+    job.publication !== 'channel' ||
+    job.receipt !== 'qualifying'
+  )
+    throw new Error(
+      'release admission authority job classification is not qualifying channel control',
+    );
+}
+
+export function validateKungfuReleaseAdmissionPolicy(root = ROOT) {
+  const policy = readJson(root, POLICY);
+  validatePolicy(policy);
+  const authority = validateWorkflowAuthority(root);
+  if (authority.issues.length)
+    throw new Error(
+      `workflow authority is not closed: ${authority.issues.join('; ')}`,
+    );
+  validateAuthorityJob(authority.document, policy);
+  const buildchainRegistry = currentBuildchain(root, policy);
+  const descriptor = buildchainRegistry.entries?.find(
+    (item) => item.workflowPath === policy.publication.workflowPath,
+  );
+  if (
+    !descriptor ||
+    descriptor.authorityClass !== 'product-publication' ||
+    descriptor.publicationCapable !== true ||
+    descriptor.publisherWorkflowMode !== 'caller-bound' ||
+    descriptor.environment !== policy.publication.environment
+  )
+    throw new Error(
+      'Buildchain registry does not authorize the configured sealed publication lane',
+    );
+  return { policy, authority: authority.document, buildchainRegistry };
+}
+
+function validateGateAggregate(root, aggregate, policy) {
+  if (aggregate?.contract !== 'buildchain.shifu-gate-aggregate/v1')
+    throw new Error('Kungfu requires a Buildchain Shifu Gate aggregate');
+  if (
+    aggregate.profile !== policy.profile ||
+    aggregate.status !== 'pass' ||
+    aggregate.ok !== true ||
+    aggregate.qualifying !== true
+  )
+    throw new Error(
+      'Kungfu release Gate aggregate is not qualifying for the configured profile',
+    );
+  if (!Array.isArray(aggregate.issues) || aggregate.issues.length !== 0)
+    throw new Error('Kungfu release Gate aggregate contains issues');
+
+  const registry = readJson(root, 'shifu.gates.json');
+  const registryDigest = gateDigest(registry);
+  if (aggregate.registry?.digest !== registryDigest)
+    throw new Error('Kungfu release Gate registry digest is stale');
+  const plan = buildGatePlan(registry, policy.profile, {
+    digest: registryDigest,
+  });
+  if (!plan.ok || !plan.qualifying)
+    throw new Error('current Kungfu release Gate plan is not qualifying');
+  const expectedGates = new Map(
+    plan.groups.flatMap((group) => group.gates).map((gate) => [gate.id, gate]),
+  );
+  const covered = new Set();
+  for (const row of aggregate.gates || []) {
+    const gate = expectedGates.get(row.gateId);
+    if (!gate)
+      throw new Error(`Gate aggregate contains unknown Gate '${row.gateId}'`);
+    if (
+      row.mode !== gate.mode ||
+      row.definitionDigest !==
+        gateDefinitionDigest(
+          registry.gates.find((item) => item.id === row.gateId),
+        ) ||
+      row.actionId !==
+        gateActionId(registry.gates.find((item) => item.id === row.gateId))
+    )
+      throw new Error(`Gate aggregate definition drift for '${row.gateId}'`);
+    if (
+      row.attempted !== true ||
+      !['pass', 'passed', 'success'].includes(row.status) ||
+      (Array.isArray(row.issues) && row.issues.length)
+    )
+      throw new Error(`Gate aggregate row did not qualify for '${row.gateId}'`);
+    covered.add(row.gateId);
+  }
+  const missing = [...expectedGates.keys()].filter(
+    (gateId) => !covered.has(gateId),
+  );
+  if (missing.length)
+    throw new Error(
+      `Gate aggregate is missing required Gates: ${missing.join(', ')}`,
+    );
+  if (
+    !Array.isArray(aggregate.receipts) ||
+    aggregate.receipts.length === 0 ||
+    aggregate.receipts.some(
+      (receipt) =>
+        receipt.qualifying !== true ||
+        !['pass', 'passed', 'success'].includes(receipt.status) ||
+        (Array.isArray(receipt.issues) && receipt.issues.length),
+    )
+  )
+    throw new Error(
+      'Gate aggregate has missing or non-qualifying platform receipts',
+    );
+  const receiptPlatforms = new Set(
+    aggregate.receipts.map((receipt) =>
+      String(
+        receipt.platform?.os ||
+          receipt.platform?.id ||
+          receipt.platform ||
+          receipt.platformId ||
+          '',
+      ).toLowerCase(),
+    ),
+  );
+  for (const platform of policy.requiredPlatforms)
+    if (![...receiptPlatforms].some((item) => item.includes(platform)))
+      throw new Error(`Gate aggregate is missing ${platform} qualification`);
+  return { registryDigest, plan };
+}
+
+export function verifyKungfuReleaseAdmission({
+  root = ROOT,
+  admission,
+  runnerProvenance,
+  controlPlaneAudit,
+  publicationEvidence,
+  expected,
+  usedNonces = [],
+  now = new Date(),
+} = {}) {
+  const validated = validateKungfuReleaseAdmissionPolicy(root);
+  const { policy, authority, buildchainRegistry } = validated;
+  const aggregate = publicationEvidence?.gateAggregate;
+  validateGateAggregate(root, aggregate, policy);
+
+  const fixedBindings = {
+    repository: policy.repository,
+    publisherWorkflowPath: policy.publication.publisherWorkflowPath,
+    runtimeSha: policy.buildchain.runtimeSha,
+    contractDigest: policy.buildchain.contractDigest.replace(/^sha256:/, ''),
+    environment: policy.publication.environment,
+    product: policy.publication.product,
+    target: policy.publication.target,
+  };
+  for (const [key, value] of Object.entries(fixedBindings))
+    if (expected?.[key] !== value)
+      throw new Error(
+        `Kungfu release admission expected ${key} policy mismatch`,
+      );
+  if (!policy.publication.channels.includes(expected?.channel))
+    throw new Error('Kungfu release admission channel is not allowed');
+  if (admission?.workflowPath !== policy.publication.workflowPath)
+    throw new Error(
+      'Kungfu release admission workflow is not the sealed Buildchain authority',
+    );
+  if (expected?.policyDigest !== aggregate.matrixDigest)
+    throw new Error(
+      'Kungfu release admission policy digest differs from the Gate matrix',
+    );
+
+  const capability = verifyPublicationAdmission({
+    admission,
+    registry: buildchainRegistry,
+    runnerProvenance,
+    controlPlaneAudit,
+    publicationEvidence,
+    expected,
+    usedNonces,
+    now,
+  });
+  const consumerPolicy = {
+    policy,
+    workflowAuthorityDigest: authorityDigest(authority),
+    gateRegistryDigest: aggregate.registry.digest,
+    gateMatrixDigest: aggregate.matrixDigest,
+  };
+  return {
+    schema: 'kungfu.release-admission-capability/v1',
+    qualifying: true,
+    consumerPolicyDigest: publicationAuthorityDigest(consumerPolicy),
+    capability,
+  };
+}
+
+function arg(name) {
+  const index = process.argv.indexOf(`--${name}`);
+  return index >= 0 ? process.argv[index + 1] : '';
+}
+
+function main() {
+  const result = verifyKungfuReleaseAdmission({
+    admission: readJson(ROOT, requiredFile(arg('admission'), 'admission')),
+    runnerProvenance: readJson(
+      ROOT,
+      requiredFile(arg('runner-provenance'), 'runner provenance'),
+    ),
+    controlPlaneAudit: readJson(
+      ROOT,
+      requiredFile(arg('control-plane-audit'), 'control-plane audit'),
+    ),
+    publicationEvidence: readJson(
+      ROOT,
+      requiredFile(arg('publication-evidence'), 'publication evidence'),
+    ),
+    expected: readJson(ROOT, requiredFile(arg('expected'), 'expected')),
+    usedNonces: arg('used-nonces') ? readJson(ROOT, arg('used-nonces')) : [],
+  });
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) main();

--- a/scripts/verify-kungfu-release-admission.test.mjs
+++ b/scripts/verify-kungfu-release-admission.test.mjs
@@ -1,0 +1,367 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import assert from 'node:assert/strict';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+import {
+  BUILDCHAIN_CONTROLLER_EVIDENCE_CONTRACT,
+  controllerEvidenceDigest,
+} from '@kungfu-tech/buildchain/controller-evidence';
+import {
+  createPublicationAdmission,
+  createPublicationArtifactManifestSet,
+  createPublicationControlPlaneAudit,
+  createRunnerProvenance,
+  publicationAuthorityDigest,
+} from '@kungfu-tech/buildchain/publication-authority';
+import { sha256Json } from '@kungfu-tech/buildchain/release-candidate';
+import {
+  buildGatePlan,
+  gateActionId,
+  gateDefinitionDigest,
+  gateDigest,
+} from './shifu-gate-runtime.mjs';
+import { verifyKungfuReleaseAdmission } from './verify-kungfu-release-admission.mjs';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const SOURCE_SHA = '1'.repeat(40);
+const RUNTIME_SHA = '52dba6d30051b53d6f6b723fa6e27b090ce4311f';
+const SOURCE_TREE_SHA = 'a'.repeat(40);
+const CONTRACT_DIGEST =
+  '247a0f3dcfa7e066a3222f5fab5a46fa50a4870c97b1bc40001479044aed8619';
+
+function manifestSummaryDigest(files) {
+  const hash = crypto.createHash('sha256');
+  for (const file of files)
+    hash.update(`${file.path}\0${file.size}\0${file.sha256}\n`);
+  return hash.digest('hex');
+}
+
+function fixture() {
+  const registry = JSON.parse(
+    fs.readFileSync(path.join(ROOT, 'shifu.gates.json'), 'utf8'),
+  );
+  const registryDigest = gateDigest(registry);
+  const plan = buildGatePlan(registry, 'release-promotion', {
+    digest: registryDigest,
+  });
+  const matrixDigest = publicationAuthorityDigest({
+    profile: 'release-promotion',
+    registryDigest,
+    requiredPlatforms: ['linux', 'macos', 'windows'],
+  });
+  const gates = plan.groups.flatMap((group) =>
+    group.gates.map((gate) => {
+      const definition = registry.gates.find((item) => item.id === gate.id);
+      return {
+        platformId: 'fixture',
+        gateId: gate.id,
+        mode: gate.mode,
+        status: 'passed',
+        attempted: true,
+        definitionDigest: gateDefinitionDigest(definition),
+        actionId: gateActionId(definition),
+        issues: [],
+      };
+    }),
+  );
+  const aggregatePayload = {
+    contract: 'buildchain.shifu-gate-aggregate/v1',
+    profile: 'release-promotion',
+    sourceSha: SOURCE_SHA,
+    registry: {
+      ref: 'shifu.gates.json',
+      digest: registryDigest,
+      projectId: 'kungfu',
+    },
+    matrixDigest,
+    status: 'pass',
+    ok: true,
+    qualifying: true,
+    receipts: ['linux', 'macos', 'windows'].map((platform) => ({
+      platformId: `${platform}-fixture`,
+      platform: { os: platform },
+      status: 'passed',
+      qualifying: true,
+      issues: [],
+    })),
+    gates,
+    omitted: [],
+    issues: [],
+  };
+  const gateAggregate = {
+    ...aggregatePayload,
+    digest: `sha256:${publicationAuthorityDigest(aggregatePayload)}`,
+  };
+  const runnerProvenance = createRunnerProvenance({
+    runnerClass: 'ephemeral',
+    os: 'linux',
+    architecture: 'x64',
+    imageDigest: '7'.repeat(64),
+    measurementDigest: '8'.repeat(64),
+    isolation: 'fresh-vm-per-job',
+  });
+  const controlPlaneAudit = createPublicationControlPlaneAudit({
+    repository: 'kungfu-systems/kungfu',
+    workflowPath: '.github/workflows/release-candidate-promote.yml',
+    publisherWorkflowPath: '.github/workflows/release-new-version.yml',
+    environment: 'none',
+    facts: [
+      'actions-policy',
+      'branch-policy',
+      'environment-policy',
+      'oidc-policy',
+      'publisher-policy',
+      'runner-policy',
+    ].map((id, index) => ({
+      id,
+      status: 'pass',
+      digest: String(index + 1).repeat(64),
+    })),
+    observedAt: '2026-07-15T00:00:00.000Z',
+    expiresAt: '2026-07-15T00:12:00.000Z',
+  });
+  const controllerPayload = {
+    schemaVersion: 1,
+    contract: BUILDCHAIN_CONTROLLER_EVIDENCE_CONTRACT,
+    kind: 'receipt',
+    controller: { id: 'build-lifecycle' },
+    source: { repository: 'kungfu-systems/kungfu', sha: SOURCE_SHA },
+    runtime: {
+      ref: RUNTIME_SHA,
+      sha: RUNTIME_SHA,
+      contractDigest: `sha256:${CONTRACT_DIGEST}`,
+    },
+    planDigest: `sha256:${'b'.repeat(64)}`,
+    status: 'passed',
+    qualifying: true,
+    stages: [],
+    evidence: [],
+    issues: [],
+  };
+  const controllerReceipt = {
+    ...controllerPayload,
+    digest: controllerEvidenceDigest(controllerPayload),
+  };
+  const buildSummary = {};
+  const files = [
+    {
+      path: '.buildchain/artifacts/linux-x64/diagnostics.json',
+      size: 4,
+      sha256: 'b'.repeat(64),
+    },
+    { path: 'product/release/kungfu.tgz', size: 3, sha256: '6'.repeat(64) },
+  ];
+  const artifactManifests = [
+    {
+      schemaVersion: 1,
+      contract: 'kungfu-buildchain-artifact',
+      artifactName: 'kungfu-linux-x64',
+      platform: { id: 'linux-x64' },
+      git: { repository: 'kungfu-systems/kungfu', sha: SOURCE_SHA },
+      summary: {
+        contract: 'kungfu-buildchain-artifact-summary',
+        artifactName: 'kungfu-linux-x64',
+        platform: { id: 'linux-x64' },
+        fileCount: files.length,
+        totalBytes: 7,
+        digest: manifestSummaryDigest(files),
+      },
+      expectedArtifacts: { ok: true },
+      files,
+    },
+  ];
+  const artifactPayloads = [
+    {
+      artifactName: 'kungfu-linux-x64',
+      files: [{ ...files[1] }],
+    },
+  ];
+  const manifestSet = createPublicationArtifactManifestSet({
+    repository: 'kungfu-systems/kungfu',
+    sourceSha: SOURCE_SHA,
+    sourceTreeSha: SOURCE_TREE_SHA,
+    manifests: artifactManifests,
+    payloads: artifactPayloads,
+  });
+  const releaseCandidatePassport = {
+    schemaVersion: 1,
+    contract: 'kungfu-buildchain-release-candidate-passport',
+    repository: 'kungfu-systems/kungfu',
+    target: { channel: 'alpha' },
+    source: {
+      headSha: SOURCE_SHA,
+      mergeRefSha: SOURCE_SHA,
+      treeHash: SOURCE_TREE_SHA,
+    },
+    buildchain: { sha: RUNTIME_SHA },
+    platformMatrix: [
+      { platformId: 'linux-x64', artifactName: 'kungfu-linux-x64' },
+    ],
+    diagnostics: { buildSummaryHash: sha256Json(buildSummary) },
+    gateProfileEvidence: {
+      contract: gateAggregate.contract,
+      digest: gateAggregate.digest,
+      profile: gateAggregate.profile,
+      sourceSha: gateAggregate.sourceSha,
+      registry: {
+        projectId: gateAggregate.registry.projectId,
+        digest: gateAggregate.registry.digest,
+      },
+      matrixDigest: gateAggregate.matrixDigest,
+      status: gateAggregate.status,
+      qualifying: gateAggregate.qualifying,
+      receiptCount: gateAggregate.receipts.length,
+      gateResultCount: gateAggregate.gates.length,
+    },
+    controllerReceipts: [
+      {
+        controllerId: 'build-lifecycle',
+        planDigest: controllerReceipt.planDigest,
+        receiptDigest: controllerReceipt.digest,
+        sourceSha: SOURCE_SHA,
+        runtimeSha: RUNTIME_SHA,
+        status: 'passed',
+      },
+    ],
+  };
+  releaseCandidatePassport.candidateHash = sha256Json({
+    repository: releaseCandidatePassport.repository,
+    target: releaseCandidatePassport.target,
+    source: releaseCandidatePassport.source,
+    platformMatrix: releaseCandidatePassport.platformMatrix,
+    buildchain: releaseCandidatePassport.buildchain,
+    gateProfileEvidence: releaseCandidatePassport.gateProfileEvidence,
+    controllerReceipts: releaseCandidatePassport.controllerReceipts,
+  });
+  const publicationEvidence = {
+    sourceTreeSha: SOURCE_TREE_SHA,
+    releaseCandidatePassport,
+    buildSummary,
+    controllerReceipt,
+    gateAggregate,
+    artifactManifests,
+    artifactPayloads,
+  };
+  const admission = createPublicationAdmission({
+    registryDigest: JSON.parse(
+      fs.readFileSync(
+        path.join(
+          ROOT,
+          'node_modules/@kungfu-tech/buildchain/dist/site/publication-authority-registry.json',
+        ),
+        'utf8',
+      ),
+    ).registryDigest,
+    workflowPath: '.github/workflows/release-candidate-promote.yml',
+    publisherWorkflowPath: '.github/workflows/release-new-version.yml',
+    repository: 'kungfu-systems/kungfu',
+    sourceSha: SOURCE_SHA,
+    runtimeSha: RUNTIME_SHA,
+    contractDigest: CONTRACT_DIGEST,
+    policyDigest: matrixDigest,
+    controllerReceiptDigest: controllerReceipt.digest,
+    runnerProvenanceDigest: runnerProvenance.receiptDigest,
+    controlPlaneAuditDigest: controlPlaneAudit.receiptDigest,
+    gateAggregateDigest: gateAggregate.digest,
+    environment: 'none',
+    product: 'Kungfu Episodes',
+    target: 'kungfu-product',
+    version: '4.0.0-alpha.1',
+    channel: 'alpha',
+    artifactDigest: manifestSet.manifestSetDigest,
+    nonce: 'kungfu-run-1:attempt-1:publish',
+    issuedAt: '2026-07-15T00:01:00.000Z',
+    expiresAt: '2026-07-15T00:10:00.000Z',
+  });
+  const expected = Object.fromEntries(
+    [
+      'repository',
+      'publisherWorkflowPath',
+      'sourceSha',
+      'runtimeSha',
+      'contractDigest',
+      'policyDigest',
+      'controllerReceiptDigest',
+      'gateAggregateDigest',
+      'environment',
+      'product',
+      'target',
+      'version',
+      'channel',
+      'artifactDigest',
+    ].map((key) => [key, admission[key]]),
+  );
+  return {
+    root: ROOT,
+    admission,
+    runnerProvenance,
+    controlPlaneAudit,
+    publicationEvidence,
+    expected,
+    now: new Date('2026-07-15T00:05:00.000Z'),
+  };
+}
+
+test('Kungfu independently accepts only a current sealed qualifying capability', () => {
+  const result = verifyKungfuReleaseAdmission(fixture());
+  assert.equal(result.qualifying, true);
+  assert.equal(result.capability.decision, 'allow');
+  assert.equal(result.capability.runtimeSha, RUNTIME_SHA);
+  assert.match(result.consumerPolicyDigest, /^[0-9a-f]{64}$/);
+});
+
+test('Kungfu rejects missing platform evidence and replayed or stale admission', () => {
+  const missingPlatform = fixture();
+  missingPlatform.publicationEvidence.gateAggregate.receipts.pop();
+  assert.throws(
+    () => verifyKungfuReleaseAdmission(missingPlatform),
+    /missing windows qualification/,
+  );
+
+  const replayed = fixture();
+  replayed.usedNonces = [replayed.admission.nonce];
+  assert.throws(
+    () => verifyKungfuReleaseAdmission(replayed),
+    /nonce was replayed/,
+  );
+
+  const stale = fixture();
+  stale.now = new Date('2026-07-15T00:11:00.000Z');
+  assert.throws(() => verifyKungfuReleaseAdmission(stale), /stale/);
+});
+
+test('Kungfu rejects policy, runner, control-plane, and artifact substitution', () => {
+  const policy = fixture();
+  policy.expected.channel = 'latest';
+  assert.throws(
+    () => verifyKungfuReleaseAdmission(policy),
+    /channel is not allowed/,
+  );
+
+  const runner = fixture();
+  runner.runnerProvenance.qualificationStatus = 'unqualified';
+  assert.throws(
+    () => verifyKungfuReleaseAdmission(runner),
+    /runner provenance qualification floor was not met|digest mismatch/,
+  );
+
+  const controlPlane = fixture();
+  controlPlane.controlPlaneAudit.facts[0].status = 'fail';
+  assert.throws(
+    () => verifyKungfuReleaseAdmission(controlPlane),
+    /control-plane audit fact did not pass|digest mismatch/,
+  );
+
+  const artifact = fixture();
+  artifact.publicationEvidence.artifactPayloads[0].files[0].sha256 = 'e'.repeat(
+    64,
+  );
+  assert.throws(
+    () => verifyKungfuReleaseAdmission(artifact),
+    /payload bytes do not match/,
+  );
+});


### PR DESCRIPTION
## Summary

Close Kungfu's GitHub Actions execution surface into one machine-checked authority inventory and add an independent consumer predicate for sealed product publication.

## Changes

- classify all 15 workflows, 24 jobs, and 82 steps with exact activation, permission, credential, external-action, and definition digests
- reject unknown workflows/jobs/steps, one-sided activation or permission drift, mutable authority-bearing refs, qualification jobs with inherited secrets, and qualification Environment access
- pin source/build/promotion controllers to Buildchain 2.12.7 and reduce write/OIDC/secret scope to the smallest declared jobs
- independently reverify source, current Gate policy, Buildchain runtime/contract, controller receipt, three-platform Gate aggregate, runner provenance, live control-plane audit, artifact bytes, channel, freshness, and nonce replay
- document workflow authority and release admission, and register SHIFU-ADR-0007

## Verification

- `./shifu check:gate-catalog`
- `./shifu test:release-admission`
- `./shifu check:source`
- staged pre-commit gate, documentation contract, ADR audit, Biome, and KFD evidence checks

## Current publication boundary

This PR makes missing sealed inputs fail closed and does not execute a product publication. Successful live cutover remains stage-ready until Buildchain transports the complete Gate aggregate/capability through a consumer-owned predicate immediately before the provider write; no static or no-Gate fallback is introduced here.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "stage-ready",
  "adrs": ["SHIFU-ADR-0007"],
  "summary": "Close Kungfu workflow authority and stage a project-owned sealed release-admission predicate while preserving fail-closed publication until the upstream capability handoff exists.",
  "verification": ["./shifu check:gate-catalog", "./shifu test:release-admission", "./shifu check:source"]
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

This changes release authority and verification contracts only; it performs no product publication or deployment.

## Checklist

- [x] Commit is signed off (DCO)
- [x] Source acceptance is green locally
- [x] Documentation and negative fixtures are included
- [x] No credential values or generated live evidence are committed
