### PR TITLE
feat(core): gate affected native changes

### DIFF
--- a/.github/workflows/affected-native-pr.yml
+++ b/.github/workflows/affected-native-pr.yml
@@ -6,13 +6,6 @@ on:
   pull_request:
     branches:
       - dev/v*/v*
-    paths:
-      - "framework/core/**"
-      - "scripts/run-core-affected-native.mjs"
-      - "package.json"
-      - "shifu.gates.json"
-      - "docs/qualification/gates/**"
-      - ".github/workflows/affected-native-pr.yml"
 
 permissions:
   contents: read

--- a/.github/workflows/affected-native-pr.yml
+++ b/.github/workflows/affected-native-pr.yml
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: Apache-2.0
+
+name: Core affected native
+
+on:
+  pull_request:
+    branches:
+      - dev/v*/v*
+    paths:
+      - "framework/core/**"
+      - "scripts/run-core-affected-native.mjs"
+      - "package.json"
+      - "shifu.gates.json"
+      - "docs/qualification/gates/**"
+      - ".github/workflows/affected-native-pr.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  affected-native:
+    name: affected-native / linux
+    runs-on: ubuntu-24.04
+    timeout-minutes: 25
+    env:
+      KUNGFU_BUILDCHAIN_SOURCE_BUILD: "1"
+      CC: gcc-14
+      CXX: g++-14
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v6.4.0
+        with:
+          node-version: "24"
+      - name: Install frozen workspace
+        shell: bash
+        run: ./shifu install --frozen-lockfile
+      - name: Resolve and run affected native closure
+        shell: bash
+        env:
+          GITHUB_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          GITHUB_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: ./shifu gate run source.changed-scope --capability native-toolchain
+      - name: Upload raw plan, receipt, and logs
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: core-affected-native-${{ github.event.pull_request.head.sha }}
+          path: product/qualification/affected-native
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/affected-native-pr.yml
+++ b/.github/workflows/affected-native-pr.yml
@@ -26,6 +26,12 @@ jobs:
       - uses: actions/setup-node@v6.4.0
         with:
           node-version: "24"
+      - name: Install pinned source acceptance tools
+        shell: bash
+        env:
+          BUILDCHAIN_CHECK_MODE: source
+        # shifu-entry-contract: allow source-tool bootstrap before Gate dependencies are runnable
+        run: node scripts/buildchain-install.mjs
       - name: Install frozen workspace
         shell: bash
         run: ./shifu install --frozen-lockfile
@@ -41,5 +47,5 @@ jobs:
         with:
           name: core-affected-native-${{ github.event.pull_request.head.sha }}
           path: product/qualification/affected-native
-          if-no-files-found: error
+          if-no-files-found: warn
           retention-days: 14

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,7 @@ layout, and code style.
 ```sh
 ./shifu check           # changed-scope lint, typecheck and unit/tooling tests
 ./shifu check:source    # GitHub-hosted source acceptance; no build or artifacts
+./shifu core:affected -- --base <base> --head <head> --json # explain the native PR closure
 ./shifu verify          # assert existing build artifacts (quick)
 ./shifu verify --full   # rebuild + freeze, then assert (slow; needs the full toolchain)
 ./shifu docs:check      # deterministic Markdown, local-link, anchor, and docs-contract gate

--- a/docs/adr/ADR-0066-native-cpp-toolchain-contract-and-modules-hold.md
+++ b/docs/adr/ADR-0066-native-cpp-toolchain-contract-and-modules-hold.md
@@ -4,7 +4,7 @@ doc_type: architecture-decision
 adr_id: ADR-0066
 decision_status: accepted
 implementation_status: staged
-implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/951, https://github.com/kungfu-systems/kungfu/pull/955, https://github.com/kungfu-systems/kungfu/pull/966, https://github.com/kungfu-systems/kungfu/pull/971]
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/951, https://github.com/kungfu-systems/kungfu/pull/955, https://github.com/kungfu-systems/kungfu/pull/966, https://github.com/kungfu-systems/kungfu/pull/971, https://github.com/kungfu-systems/kungfu/pull/973]
 qualification_refs: [framework/core/architecture/build-capabilities.json, framework/core/architecture/check-build-capabilities.mjs, framework/core/architecture/layers.json, framework/core/architecture/check-layers.mjs, framework/core/architecture/PUBLIC_CONTRACTS.cmake, framework/core/src/libkungfu/tests/domain_component_link_tests.cpp, framework/core/src/libkungfu/tests/compat/public_contract_compatibility_tests.c, framework/core/src/libyijinjing/tests/fixtures/journal-wire-v1.json, framework/core/src/libyijinjing/tests/custom_provider_qualification.cpp, .github/workflows/core-build-profiles.yml, scripts/source-acceptance.mjs]
 review_state: self-reviewed
 sensitivity: public

--- a/docs/qualification/gates/policy-matrix.md
+++ b/docs/qualification/gates/policy-matrix.md
@@ -17,7 +17,7 @@ Do not hand-edit the generated block. A mode applies when the corresponding
 | [`governance.buildchain-config`](source-and-governance.md#governance-buildchain-config) | light | required | off | required | required | off | required |
 | [`governance.promotion-rehearsal`](release-and-promotion.md#governance-promotion-rehearsal) | light | required | off | required | required | advisory | required |
 | [`source.acceptance`](source-and-governance.md#source-acceptance) | light | required | off | off | off | advisory | off |
-| [`source.changed-scope`](source-and-governance.md#source-changed-scope) | light | off | off | off | off | advisory | off |
+| [`source.changed-scope`](source-and-governance.md#source-changed-scope) | heavy | required | off | off | off | advisory | off |
 | [`source.whole-tree`](source-and-governance.md#source-whole-tree) | heavy | off | off | off | off | advisory | off |
 | [`docs.contracts`](source-and-governance.md#docs-contracts) | light | required | advisory | off | off | advisory | off |
 | [`docs.prose`](source-and-governance.md#docs-prose) | light | required | off | off | off | advisory | off |

--- a/docs/qualification/gates/source-and-governance.md
+++ b/docs/qualification/gates/source-and-governance.md
@@ -101,7 +101,7 @@ Each section is bound to the registry id by the catalog meta gate.
   <base> --head <head> --json`; run mutation fixtures with `./shifu
   core:affected -- --self-test`.
 - **Cost:** heavy; timeout 1500 seconds.
-- **Current source:** .github/workflows/affected-native-pr.yml (affected-native; development pull request touching Core architecture, source, build, gate, or resolver paths)
+- **Current source:** .github/workflows/affected-native-pr.yml (affected-native; every development pull request; outside-Core changes produce a passed tier-none receipt so the required check never deadlocks)
 - **Retirement:** remove only with a replacement that consumes the same
   architecture authority and preserves changed-path completeness, raw native
   evidence and the alpha/release responsibility split.

--- a/docs/qualification/gates/source-and-governance.md
+++ b/docs/qualification/gates/source-and-governance.md
@@ -78,20 +78,33 @@ Each section is bound to the registry id by the catalog meta gate.
 
 <a id="source-changed-scope"></a>
 <!-- gate-doc:source.changed-scope -->
-## Changed-scope developer check (`source.changed-scope`)
+## Affected Core native developer check (`source.changed-scope`)
 
-- **Problem:** Checks changed source plus shared contract and tooling tests.
-- **Protects:** source regressions from becoming an unexplained green profile or release claim.
-- **Action:** `./shifu check`
-- **Dependencies:** `gate.catalog`.
-- **Platforms and runner:** linux, macos, windows; capabilities `node`.
-- **Pass:** the structured action exits successfully, required artifacts exist, and the Gate receipt remains current for the source and definition.
-- **Failure or skip:** action failure, timeout, unsupported required capability, dependency failure, or missing required artifact is non-qualifying; advisory mode remains visible.
-- **Evidence:** unified Gate receipt; no separate artifact is currently required.
-- **Diagnosis:** `./shifu gate explain source.changed-scope --profile <profile>`; reproduce with `./shifu gate run source.changed-scope` on a capable runner.
-- **Cost:** light; timeout 1200 seconds.
-- **Current source:** independent Shifu task; not selected by a current remote profile.
-- **Retirement:** remove only after every selecting profile and workflow binding is migrated or explicitly replaced, with the registry and matrix changed in the same review.
+- **Problem:** Resolves changed Core paths through the architecture authority and compiles, links, and tests the bounded native impact closure.
+- **Protects:** template instantiation, link, public-header propagation and
+  native contract regressions that the deliberately build-free source gate
+  cannot observe.
+- **Action:** `./shifu core:affected -- --execute`
+- **Dependencies:** `gate.catalog`, `source.acceptance`.
+- **Platforms and runner:** linux; capabilities `native-toolchain`.
+- **Pass:** the resolver validates the authority, selects a supported minimal
+  profile, and the selected configure/compile/link/CTest closure passes.
+- **Failure or skip:** unclassified Core files, missing target/test evidence,
+  stale authority, unsupported profiles, native failures, timeout or receipt
+  drift are non-qualifying.
+- **Evidence:** the unified Gate receipt plus
+  `kungfu.core-affected-native-receipt/v1` and raw per-step logs under
+  `product/qualification/affected-native/`. The receipt binds exact source,
+  architecture digests, toolchain, targets/tests, duration and honest cache
+  facts.
+- **Diagnosis:** inspect without building with `./shifu core:affected -- --base
+  <base> --head <head> --json`; run mutation fixtures with `./shifu
+  core:affected -- --self-test`.
+- **Cost:** heavy; timeout 1500 seconds.
+- **Current source:** .github/workflows/affected-native-pr.yml (affected-native; development pull request touching Core architecture, source, build, gate, or resolver paths)
+- **Retirement:** remove only with a replacement that consumes the same
+  architecture authority and preserves changed-path completeness, raw native
+  evidence and the alpha/release responsibility split.
 <!-- /gate-doc:source.changed-scope -->
 
 <a id="source-whole-tree"></a>

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -43,7 +43,7 @@
     {
       "path": ".github/workflows/affected-native-pr.yml",
       "authority": "qualification",
-      "definitionDigest": "sha256:8e62eff482e0fca0696f6bd993d710f0ae8b79e21c2d3fc8573e9dddec2c8ea4",
+      "definitionDigest": "sha256:1595ebe91c02f6cd012cc727ca549c0a8ea53c80e8bcdf3cb0f9aecdd4a802e0",
       "jobs": [
         {
           "id": "affected-native",

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -41,6 +41,64 @@
       ]
     },
     {
+      "path": ".github/workflows/affected-native-pr.yml",
+      "authority": "qualification",
+      "definitionDigest": "sha256:8e62eff482e0fca0696f6bd993d710f0ae8b79e21c2d3fc8573e9dddec2c8ea4",
+      "jobs": [
+        {
+          "id": "affected-native",
+          "authority": "qualification",
+          "publication": "none",
+          "receipt": "diagnostic",
+          "definitionDigest": "sha256:ff4c92f7baa3e4c15c6a19056e5e3a64a2dcae5b7210ec85a23de505ff5f4cb5",
+          "credentials": {
+            "githubToken": "read",
+            "oidc": false,
+            "repositorySecrets": [],
+            "inheritedSecrets": false,
+            "environment": null
+          },
+          "externalActions": [
+            "actions/checkout@v4",
+            "actions/setup-node@v6.4.0",
+            "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02"
+          ],
+          "steps": [
+            {
+              "index": 1,
+              "label": "uses:actions/checkout@v4",
+              "authority": "qualification",
+              "definitionDigest": "sha256:013f3e07e00504e33bda746183e505021d945acc2dfb178cf1d094ef09ea5c8f"
+            },
+            {
+              "index": 2,
+              "label": "uses:actions/setup-node@v6.4.0",
+              "authority": "qualification",
+              "definitionDigest": "sha256:789e56d63991440fb89fffa3b2795c1cab043e6b7df6237a0c830c5c89759690"
+            },
+            {
+              "index": 3,
+              "label": "name:Install frozen workspace",
+              "authority": "qualification",
+              "definitionDigest": "sha256:69ea68940dc616ba6987005e02e4a7b177faea26e2b88a9099bd7fdee99532a4"
+            },
+            {
+              "index": 4,
+              "label": "name:Resolve and run affected native closure",
+              "authority": "qualification",
+              "definitionDigest": "sha256:0739d9270b170c10be5fe15be1aa8b877cf7eea4f6bcffdfa655fdfef2ee3790"
+            },
+            {
+              "index": 5,
+              "label": "name:Upload raw plan, receipt, and logs",
+              "authority": "evidence-publication",
+              "definitionDigest": "sha256:514fa92b2e415e583b2468677de7089278684ba772400a690c90f004008eeb7d"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "path": ".github/workflows/build.yml",
       "authority": "qualification",
       "definitionDigest": "sha256:b65b60b8963ae416588ea7d494e7f96a3a70d0c82d07fbbdd2a0ccabc2327839",

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -50,7 +50,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:ff4c92f7baa3e4c15c6a19056e5e3a64a2dcae5b7210ec85a23de505ff5f4cb5",
+          "definitionDigest": "sha256:3894261eb4d2e6d3d19ec1a200c24567b0c876983c324c66f0546a2036945f75",
           "credentials": {
             "githubToken": "read",
             "oidc": false,
@@ -78,21 +78,27 @@
             },
             {
               "index": 3,
+              "label": "name:Install pinned source acceptance tools",
+              "authority": "qualification",
+              "definitionDigest": "sha256:8f73a6ce23af072a4eb6783d631d2e07de85bf68d16f48656a94c69b229102f1"
+            },
+            {
+              "index": 4,
               "label": "name:Install frozen workspace",
               "authority": "qualification",
               "definitionDigest": "sha256:69ea68940dc616ba6987005e02e4a7b177faea26e2b88a9099bd7fdee99532a4"
             },
             {
-              "index": 4,
+              "index": 5,
               "label": "name:Resolve and run affected native closure",
-              "authority": "qualification",
+              "authority": "evidence-publication",
               "definitionDigest": "sha256:0739d9270b170c10be5fe15be1aa8b877cf7eea4f6bcffdfa655fdfef2ee3790"
             },
             {
-              "index": 5,
+              "index": 6,
               "label": "name:Upload raw plan, receipt, and logs",
               "authority": "evidence-publication",
-              "definitionDigest": "sha256:514fa92b2e415e583b2468677de7089278684ba772400a690c90f004008eeb7d"
+              "definitionDigest": "sha256:bba7ae2210a39e6817240dd0e1bc92bf837ce79b6bb5fc3dd1f86aea1e0e4603"
             }
           ]
         }

--- a/docs/qualification/gates/workflow-authority.md
+++ b/docs/qualification/gates/workflow-authority.md
@@ -40,6 +40,7 @@ without changing and refreshing the manifest fails the Gate catalog check.
 | Workflow | Job | Authority | Publication | Receipt | Credentials | Environment | Steps |
 | --- | --- | --- | --- | --- | --- | --- | ---: |
 | `.github/workflows/adr-release-gate.yml` | `adr-release` | qualification | none | diagnostic | token:read | none | 2 |
+| `.github/workflows/affected-native-pr.yml` | `affected-native` | qualification | none | diagnostic | token:read | none | 5 |
 | `.github/workflows/build.yml` | `build` | qualification | none | qualifying | token:write, oidc, repo-secret:BUILDCHAIN_ARTIFACT_RELAY_S3_DOWNLOAD_ROLE_ARN+BUILDCHAIN_ARTIFACT_RELAY_S3_ROLE_ARN+BUILDCHAIN_ARTIFACT_RELAY_S3_UPLOAD_ROLE_ARN | none | 0 |
 | `.github/workflows/buildchain-validate.yml` | `promotion-rehearsal` | qualification | none | diagnostic | token:read | none | 2 |
 | `.github/workflows/buildchain-validate.yml` | `validate` | qualification | none | diagnostic | token:read | none | 2 |

--- a/docs/qualification/gates/workflow-authority.md
+++ b/docs/qualification/gates/workflow-authority.md
@@ -40,7 +40,7 @@ without changing and refreshing the manifest fails the Gate catalog check.
 | Workflow | Job | Authority | Publication | Receipt | Credentials | Environment | Steps |
 | --- | --- | --- | --- | --- | --- | --- | ---: |
 | `.github/workflows/adr-release-gate.yml` | `adr-release` | qualification | none | diagnostic | token:read | none | 2 |
-| `.github/workflows/affected-native-pr.yml` | `affected-native` | qualification | none | diagnostic | token:read | none | 5 |
+| `.github/workflows/affected-native-pr.yml` | `affected-native` | qualification | none | diagnostic | token:read | none | 6 |
 | `.github/workflows/build.yml` | `build` | qualification | none | qualifying | token:write, oidc, repo-secret:BUILDCHAIN_ARTIFACT_RELAY_S3_DOWNLOAD_ROLE_ARN+BUILDCHAIN_ARTIFACT_RELAY_S3_ROLE_ARN+BUILDCHAIN_ARTIFACT_RELAY_S3_UPLOAD_ROLE_ARN | none | 0 |
 | `.github/workflows/buildchain-validate.yml` | `promotion-rehearsal` | qualification | none | diagnostic | token:read | none | 2 |
 | `.github/workflows/buildchain-validate.yml` | `validate` | qualification | none | diagnostic | token:read | none | 2 |

--- a/docs/qualification/gates/workflow-bindings.json
+++ b/docs/qualification/gates/workflow-bindings.json
@@ -38,7 +38,7 @@
       "gates": [
         "source.changed-scope"
       ],
-      "activation": "development pull request touching Core architecture, source, build, gate, or resolver paths",
+      "activation": "every development pull request; outside-Core changes produce a passed tier-none receipt so the required check never deadlocks",
       "invocation": {
         "args": [
           "--capability",

--- a/docs/qualification/gates/workflow-bindings.json
+++ b/docs/qualification/gates/workflow-bindings.json
@@ -28,6 +28,25 @@
       }
     },
     {
+      "id": "dev-core-affected-native",
+      "execution": "gate",
+      "workflow": ".github/workflows/affected-native-pr.yml",
+      "job": "affected-native",
+      "profiles": [
+        "dev-pr"
+      ],
+      "gates": [
+        "source.changed-scope"
+      ],
+      "activation": "development pull request touching Core architecture, source, build, gate, or resolver paths",
+      "invocation": {
+        "args": [
+          "--capability",
+          "native-toolchain"
+        ]
+      }
+    },
+    {
       "id": "dev-adr",
       "execution": "gate",
       "workflow": ".github/workflows/adr-release-gate.yml",

--- a/framework/core/architecture/affected-native-baseline.json
+++ b/framework/core/architecture/affected-native-baseline.json
@@ -3,6 +3,7 @@
   "platformTier": "github-hosted-linux-native-pr",
   "requiredBudgetSeconds": 1200,
   "hardTimeoutSeconds": 1500,
+  "maxParallelism": 12,
   "cachePolicy": {
     "identityFields": ["source", "profile", "toolchain", "architecture-authority"],
     "unknownHitPolicy": "record-null-do-not-claim",

--- a/framework/core/architecture/affected-native-baseline.json
+++ b/framework/core/architecture/affected-native-baseline.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "kungfu.core-affected-native-baseline/v1",
+  "platformTier": "github-hosted-linux-native-pr",
+  "requiredBudgetSeconds": 1200,
+  "hardTimeoutSeconds": 1500,
+  "cachePolicy": {
+    "identityFields": ["source", "profile", "toolchain", "architecture-authority"],
+    "unknownHitPolicy": "record-null-do-not-claim",
+    "overBudgetPolicy": "optimize-graph-or-cache-never-delete-required-tests"
+  },
+  "measurements": []
+}

--- a/framework/core/architecture/affected-native-baseline.json
+++ b/framework/core/architecture/affected-native-baseline.json
@@ -9,5 +9,31 @@
     "unknownHitPolicy": "record-null-do-not-claim",
     "overBudgetPolicy": "optimize-graph-or-cache-never-delete-required-tests"
   },
-  "measurements": []
+  "measurements": [
+    {
+      "measuredAt": "2026-07-15",
+      "environment": "agent-120-linux-x64",
+      "source": "37942d3ad41a2079ed44abe5c8dc8831ba76f184",
+      "profile": "embedded-sqlite",
+      "changedFixture": "framework/core/src/libkungfu/src/runtime/storage/query_render.cpp",
+      "status": "passed",
+      "durationMs": 243184,
+      "budgetMs": 1200000,
+      "cache": {
+        "hit": null,
+        "reason": "The current build tools do not expose trustworthy per-target cache hit facts."
+      },
+      "toolchain": {
+        "compiler": "GCC 14.2.0",
+        "cmake": "3.28.3",
+        "ninja": "1.11.1"
+      },
+      "steps": {
+        "conanInstallMs": 129607,
+        "cmakeConfigureMs": 398,
+        "cmakeBuildMs": 113055,
+        "ctestMs": 115
+      }
+    }
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -78,6 +78,8 @@
     "build:app": "node scripts/require-shifu.mjs build:app && pnpm --filter @kungfu-tech/gui run build",
     "build:cli": "node scripts/require-shifu.mjs build:cli && pnpm --filter @kungfu-tech/tui run build",
     "build:core": "node scripts/require-shifu.mjs build:core && pnpm --filter @kungfu-tech/core run build",
+    "core:affected": "node scripts/require-shifu.mjs core:affected && node scripts/run-core-affected-native.mjs",
+    "core:affected:configure": "node scripts/require-shifu.mjs core:affected:configure && pnpm --filter @kungfu-tech/core run configure",
     "pack:sdk": "node scripts/require-shifu.mjs pack:sdk && pnpm --filter @kungfu-tech/storage run pack",
     "pack:spec": "node scripts/require-shifu.mjs pack:spec && pnpm --filter @kungfu-tech/spec run pack:artifact",
     "freeze": "node scripts/require-shifu.mjs freeze && pnpm --filter @kungfu-tech/core run freeze",

--- a/product/.gitignore
+++ b/product/.gitignore
@@ -1,3 +1,4 @@
 dist/
 extensions/
 release/
+qualification/

--- a/scripts/check-kungfu-gate-catalog.test.mjs
+++ b/scripts/check-kungfu-gate-catalog.test.mjs
@@ -85,7 +85,7 @@ test('current Kungfu catalog, docs, matrix, actions, and workflows align', () =>
   );
   assert.equal(controllers.length, 6);
   assert.ok(controllers.every((fact) => fact.gates.length > 0));
-  assert.equal(result.workflowAuthority.workflows.length, 15);
+  assert.equal(result.workflowAuthority.workflows.length, 16);
 });
 
 test('workflow authority rejects unknown workflows, jobs, steps, and activation drift', () => {
@@ -445,11 +445,11 @@ test('matrix, gate document, and workflow drift each fail closed', () => {
     'docs/qualification/gates/workflow-bindings.json',
   );
   const bindings = JSON.parse(fs.readFileSync(bindingsPath, 'utf8'));
-  bindings.bindings[0].gates.push('source.changed-scope');
+  bindings.bindings[0].gates.push('source.whole-tree');
   fs.writeFileSync(bindingsPath, JSON.stringify(bindings));
   assert.ok(
     checkKungfuGateCatalog(root).issues.some((issue) =>
-      issue.includes('dev-pr:source.changed-scope is bound but policy is off'),
+      issue.includes('dev-pr:source.whole-tree is bound but policy is off'),
     ),
   );
 });

--- a/scripts/run-core-affected-native.mjs
+++ b/scripts/run-core-affected-native.mjs
@@ -302,6 +302,7 @@ function planFromChanged(changedFiles, authority, buildAuthority, base, head) {
   const closure = new Set([...direct, ...broad]);
   const internalByComponent = new Map();
   for (const target of authority.internal_targets) {
+    if (target.kind === 'INTERFACE') continue;
     const list = internalByComponent.get(target.component) || [];
     list.push(target.id);
     internalByComponent.set(target.component, list);
@@ -666,6 +667,8 @@ function selfTest(authority, buildAuthority) {
       throw new Error('no propagation');
     if (!plan.tests.includes('kungfu_public_contract_compatibility_tests'))
       throw new Error('compat test missing');
+    if (plan.targets.includes('kungfu_contracts'))
+      throw new Error('INTERFACE target scheduled as a build goal');
   });
   expect(
     'target deletion fails closed',

--- a/scripts/run-core-affected-native.mjs
+++ b/scripts/run-core-affected-native.mjs
@@ -1,0 +1,731 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { spawnSync } from 'node:child_process';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+
+const root = process.cwd();
+const coreRoot = path.join(root, 'framework', 'core');
+const architecturePath = path.join(coreRoot, 'architecture', 'layers.json');
+const buildPath = path.join(
+  coreRoot,
+  'architecture',
+  'build-capabilities.json',
+);
+const baselinePath = path.join(
+  coreRoot,
+  'architecture',
+  'affected-native-baseline.json',
+);
+
+function ordered(value) {
+  if (Array.isArray(value)) return value.map(ordered);
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.keys(value)
+        .sort()
+        .map((key) => [key, ordered(value[key])]),
+    );
+  }
+  return value;
+}
+
+function stableJson(value) {
+  return JSON.stringify(ordered(value));
+}
+
+function digest(value) {
+  return `sha256:${crypto
+    .createHash('sha256')
+    .update(typeof value === 'string' ? value : stableJson(value))
+    .digest('hex')}`;
+}
+
+function readJson(file) {
+  return JSON.parse(fs.readFileSync(file, 'utf8'));
+}
+
+function unique(items) {
+  return [...new Set(items)].sort();
+}
+
+function owns(rule, file) {
+  const included =
+    (rule.include_files || []).includes(file) ||
+    (rule.include_prefixes || []).some((prefix) => file.startsWith(prefix));
+  return (
+    included &&
+    !(rule.exclude_files || []).includes(file) &&
+    !(rule.exclude_prefixes || []).some((prefix) => file.startsWith(prefix))
+  );
+}
+
+function targetEvidence(authority) {
+  return new Set(
+    authority.target_evidence.flatMap((record) => record.targets || []),
+  );
+}
+
+function validateAuthority(authority, buildAuthority) {
+  const problems = [];
+  const components = new Map(
+    authority.components.map((component) => [component.id, component]),
+  );
+  const evidence = targetEvidence(authority);
+  const internalTargets = new Set(
+    authority.internal_targets.map((target) => target.id),
+  );
+  for (const component of authority.components) {
+    for (const dependency of component.dependencies || []) {
+      if (!components.has(dependency)) {
+        problems.push(`${component.id}: unknown dependency ${dependency}`);
+      }
+    }
+    for (const target of component.current_targets || []) {
+      if (!evidence.has(target)) {
+        problems.push(
+          `${component.id}: target lacks CMake evidence: ${target}`,
+        );
+      }
+    }
+    for (const test of component.contract_tests || []) {
+      if (!evidence.has(test)) {
+        problems.push(
+          `${component.id}: contract test lacks CMake evidence: ${test}`,
+        );
+      }
+    }
+  }
+  for (const target of authority.internal_targets) {
+    if (!components.has(target.component)) {
+      problems.push(`${target.id}: unknown component ${target.component}`);
+    }
+    if (!evidence.has(target.id)) {
+      problems.push(`${target.id}: internal target lacks CMake evidence`);
+    }
+    for (const dependency of target.dependencies || []) {
+      if (!internalTargets.has(dependency)) {
+        problems.push(`${target.id}: unknown target dependency ${dependency}`);
+      }
+    }
+  }
+  const architectureComponents = new Set(
+    authority.components.map(({ id }) => id),
+  );
+  const projected = new Set(
+    buildAuthority.components.flatMap(
+      (component) => component.architecture_components || [],
+    ),
+  );
+  for (const component of architectureComponents) {
+    if (
+      component !== 'core-native-qualification' &&
+      !projected.has(component)
+    ) {
+      problems.push(`${component}: absent from build capability projection`);
+    }
+  }
+  if (problems.length) throw new Error(problems.join('\n'));
+}
+
+function componentOwner(authority, file) {
+  const owners = authority.components.filter((component) =>
+    owns(component, file),
+  );
+  if (owners.length !== 1) {
+    throw new Error(
+      `${file}: expected exactly one architecture component, found ${owners.map(({ id }) => id).join(', ') || 'none'}`,
+    );
+  }
+  return owners[0];
+}
+
+function reverseClosure(authority, direct) {
+  const result = new Set(direct);
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const component of authority.components) {
+      if (
+        !result.has(component.id) &&
+        (component.dependencies || []).some((dependency) =>
+          result.has(dependency),
+        )
+      ) {
+        result.add(component.id);
+        changed = true;
+      }
+    }
+  }
+  return result;
+}
+
+function publicRule(authority, file) {
+  const matches = (authority.public_contracts?.header_rules || []).filter(
+    (rule) => owns(rule, file),
+  );
+  if (matches.length > 1) {
+    throw new Error(`${file}: ambiguous public contract impact`);
+  }
+  return matches[0] || null;
+}
+
+function selectProfile(buildAuthority, components, forceFull) {
+  if (forceFull) return 'full';
+  const required = new Set(
+    [...components].filter(
+      (component) => component !== 'core-native-qualification',
+    ),
+  );
+  const supported = buildAuthority.profiles.filter(
+    (profile) => profile.status === 'supported',
+  );
+  const candidates = supported.filter((profile) => {
+    const projected = new Set(
+      buildAuthority.components
+        .filter((component) => profile.components.includes(component.id))
+        .flatMap((component) => component.architecture_components || []),
+    );
+    return [...required].every((component) => projected.has(component));
+  });
+  candidates.sort(
+    (left, right) =>
+      left.components.length +
+        left.providers.length +
+        left.bindings.length -
+        (right.components.length +
+          right.providers.length +
+          right.bindings.length) || left.id.localeCompare(right.id),
+  );
+  if (!candidates.length) {
+    throw new Error(
+      `no supported Core profile covers ${[...required].join(', ')}`,
+    );
+  }
+  return candidates[0].id;
+}
+
+function planFromChanged(changedFiles, authority, buildAuthority, base, head) {
+  validateAuthority(authority, buildAuthority);
+  const direct = new Set();
+  const broad = new Set();
+  const reasons = [];
+  const publicRules = new Set();
+  let global = false;
+  let forceFull = false;
+  const globalPaths = [
+    'framework/core/architecture/',
+    'framework/core/CMakeLists.txt',
+    'framework/core/conanfile.py',
+    'framework/core/package.json',
+    'scripts/run-core-affected-native.mjs',
+    '.github/workflows/affected-native-pr.yml',
+    'shifu.gates.json',
+    'docs/qualification/gates/',
+    'package.json',
+  ];
+
+  for (const file of changedFiles) {
+    if (
+      globalPaths.some(
+        (candidate) => file === candidate || file.startsWith(candidate),
+      )
+    ) {
+      global = true;
+      reasons.push({ path: file, kind: 'architecture-or-gate-authority' });
+      continue;
+    }
+    if (!file.startsWith('framework/core/')) {
+      reasons.push({ path: file, kind: 'outside-core' });
+      continue;
+    }
+    const relative = file.slice('framework/core/'.length);
+    if (/\.(md|txt)$/.test(relative)) {
+      reasons.push({ path: file, kind: 'core-documentation-only' });
+      continue;
+    }
+    if (/\/CMakeLists\.txt$/.test(relative)) {
+      global = true;
+      reasons.push({ path: file, kind: 'composition-or-build-definition' });
+      continue;
+    }
+    if (
+      relative.startsWith('src/libkungfu/schemas/') &&
+      relative.endsWith('.fbs')
+    ) {
+      const owner = 'libkungfu-contracts';
+      direct.add(owner);
+      for (const component of reverseClosure(authority, [owner]))
+        broad.add(component);
+      reasons.push({
+        path: file,
+        kind: 'schema-layout-propagation',
+        component: owner,
+      });
+      continue;
+    }
+    const extension = path.extname(relative);
+    if (!(authority.extensions || []).includes(extension)) {
+      throw new Error(`${file}: unclassified Core file impact`);
+    }
+    const owner = componentOwner(authority, relative);
+    direct.add(owner.id);
+    const rule = publicRule(authority, relative);
+    const header = ['.h', '.hh', '.hpp', '.hxx'].includes(extension);
+    if (rule) publicRules.add(rule.id);
+    if (header || rule) {
+      for (const component of reverseClosure(authority, [owner.id]))
+        broad.add(component);
+      reasons.push({
+        path: file,
+        kind: rule ? 'public-contract-propagation' : 'header-propagation',
+        component: owner.id,
+        publicContract: rule?.id || null,
+      });
+    } else {
+      reasons.push({ path: file, kind: 'implementation', component: owner.id });
+    }
+    if (
+      relative.startsWith('src/bindings/') ||
+      relative.startsWith('src/libwasm/')
+    ) {
+      forceFull = true;
+    }
+  }
+
+  if (global) {
+    for (const component of authority.components) broad.add(component.id);
+  }
+  const closure = new Set([...direct, ...broad]);
+  const internalByComponent = new Map();
+  for (const target of authority.internal_targets) {
+    const list = internalByComponent.get(target.component) || [];
+    list.push(target.id);
+    internalByComponent.set(target.component, list);
+  }
+  const targets = [];
+  const tests = [];
+  const componentById = new Map(
+    authority.components.map((component) => [component.id, component]),
+  );
+  for (const componentId of closure) {
+    const component = componentById.get(componentId);
+    targets.push(...(internalByComponent.get(componentId) || []));
+    if (['yijinjing-schema', 'yijinjing-kernel'].includes(componentId)) {
+      targets.push('yijinjing');
+    }
+    tests.push(...(component?.contract_tests || []));
+  }
+  for (const ruleId of publicRules) {
+    targets.push(
+      `kungfu_public_headers_${ruleId.replace(/[^A-Za-z0-9]+/g, '_')}`,
+    );
+  }
+  if (publicRules.size) {
+    targets.push('kungfu_public_contract_compatibility_tests');
+    tests.push('kungfu_public_contract_compatibility_tests');
+  }
+  if (global) {
+    targets.push('kungfu', 'yijinjing');
+  }
+  targets.push(...tests);
+  const profile = closure.size
+    ? selectProfile(buildAuthority, closure, forceFull)
+    : null;
+  const plan = {
+    schema: 'kungfu.core-affected-native-plan/v1',
+    base,
+    head,
+    authority: {
+      layers: digest(fs.readFileSync(architecturePath, 'utf8')),
+      buildCapabilities: digest(fs.readFileSync(buildPath, 'utf8')),
+    },
+    changedPaths: unique(changedFiles),
+    directComponents: unique(direct),
+    closureComponents: unique(closure),
+    targets: unique(targets),
+    tests: unique(tests),
+    profile,
+    platformTier: closure.size ? 'github-hosted-linux-native-pr' : 'none',
+    reasons: reasons.sort((left, right) => left.path.localeCompare(right.path)),
+  };
+  return { ...plan, planDigest: digest(plan) };
+}
+
+function git(...args) {
+  const result = spawnSync('git', args, { cwd: root, encoding: 'utf8' });
+  if (result.status !== 0)
+    throw new Error(result.stderr.trim() || `git ${args.join(' ')} failed`);
+  return result.stdout.trim();
+}
+
+function parseArgs(argv) {
+  const options = {
+    base: process.env.GITHUB_BASE_SHA || 'origin/dev/v4/v4.0',
+    head: process.env.GITHUB_HEAD_SHA || 'HEAD',
+    changedFiles: [],
+    json: false,
+    execute: false,
+    selfTest: false,
+    receipt: '',
+    verifyReceipt: '',
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--') continue;
+    if (arg === '--base') options.base = argv[++index];
+    else if (arg === '--head') options.head = argv[++index];
+    else if (arg === '--changed-file') options.changedFiles.push(argv[++index]);
+    else if (arg === '--receipt') options.receipt = argv[++index];
+    else if (arg === '--verify-receipt') options.verifyReceipt = argv[++index];
+    else if (arg === '--json') options.json = true;
+    else if (arg === '--execute') options.execute = true;
+    else if (arg === '--self-test') options.selfTest = true;
+    else throw new Error(`unknown argument: ${arg}`);
+  }
+  return options;
+}
+
+function runStep(id, command, args, cwd, env, logRoot) {
+  const started = Date.now();
+  const result = spawnSync(command, args, {
+    cwd,
+    env,
+    encoding: 'utf8',
+    maxBuffer: 256 * 1024 * 1024,
+  });
+  const output = `${result.stdout || ''}${result.stderr || ''}`;
+  fs.mkdirSync(logRoot, { recursive: true });
+  const log = path.join(logRoot, `${id}.log`);
+  fs.writeFileSync(log, output);
+  process.stdout.write(output);
+  const step = {
+    id,
+    command: [command, ...args],
+    durationMs: Date.now() - started,
+    exitCode: result.status ?? 1,
+    log: path.relative(root, log).split(path.sep).join('/'),
+  };
+  if (step.exitCode !== 0) {
+    throw Object.assign(new Error(`${id} failed with exit ${step.exitCode}`), {
+      step,
+    });
+  }
+  return step;
+}
+
+function toolFact(command, args = ['--version']) {
+  const result = spawnSync(command, args, { encoding: 'utf8' });
+  return (
+    (result.stdout || result.stderr || '').split('\n')[0].trim() ||
+    'unavailable'
+  );
+}
+
+function execute(plan, receiptPath) {
+  const baseline = readJson(baselinePath);
+  const receiptFile =
+    receiptPath ||
+    path.join(
+      'product',
+      'qualification',
+      'affected-native',
+      plan.head.slice(0, 12),
+      'receipt.json',
+    );
+  const absoluteReceipt = path.resolve(root, receiptFile);
+  const logRoot = path.join(path.dirname(absoluteReceipt), 'logs');
+  const steps = [];
+  const env = {
+    ...process.env,
+    KUNGFU_BUILDCHAIN_SOURCE_BUILD: '1',
+    KUNGFU_BUILD_PROFILE: plan.profile || 'journal',
+    KUNGFU_BUILD_SKIP_KUNGFU_NODE: 'on',
+    KUNGFU_BUILD_SKIP_PYKUNGFU: 'on',
+  };
+  const started = Date.now();
+  let status = 'passed';
+  let failure = null;
+  try {
+    if (plan.targets.length) {
+      steps.push(
+        runStep(
+          'conan-install',
+          path.join(root, 'shifu'),
+          ['core:affected:configure'],
+          root,
+          env,
+          logRoot,
+        ),
+      );
+      const buildRoot = path.join(coreRoot, 'build', 'affected-native');
+      steps.push(
+        runStep(
+          'cmake-configure',
+          'cmake',
+          [
+            '-S',
+            coreRoot,
+            '-B',
+            buildRoot,
+            '-G',
+            'Ninja',
+            `-DCMAKE_TOOLCHAIN_FILE=${path.join(coreRoot, 'build', 'conan_toolchain.cmake')}`,
+            '-DCMAKE_BUILD_TYPE=Release',
+            `-DKUNGFU_BUILD_PROFILE=${plan.profile}`,
+          ],
+          root,
+          env,
+          logRoot,
+        ),
+      );
+      steps.push(
+        runStep(
+          'cmake-build',
+          'cmake',
+          [
+            '--build',
+            buildRoot,
+            '--target',
+            ...plan.targets,
+            '--parallel',
+            String(os.availableParallelism()),
+          ],
+          root,
+          env,
+          logRoot,
+        ),
+      );
+      if (plan.tests.length) {
+        const expression = `^(${plan.tests.map((test) => test.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|')})$`;
+        steps.push(
+          runStep(
+            'ctest',
+            'ctest',
+            ['--test-dir', buildRoot, '-R', expression, '--output-on-failure'],
+            root,
+            env,
+            logRoot,
+          ),
+        );
+      }
+    }
+  } catch (error) {
+    status = 'failed';
+    if (error.step) steps.push(error.step);
+    failure = error.message;
+  }
+  const receipt = {
+    schema: 'kungfu.core-affected-native-receipt/v1',
+    status,
+    source: { base: plan.base, head: plan.head },
+    plan,
+    planDigest: plan.planDigest,
+    platform: `${process.platform}-${process.arch}`,
+    toolchain: {
+      compiler: toolFact(process.env.CXX || 'c++'),
+      cmake: toolFact('cmake'),
+      ninja: toolFact('ninja'),
+    },
+    cache: {
+      identity: digest({
+        head: plan.head,
+        profile: plan.profile,
+        toolchain: toolFact(process.env.CXX || 'c++'),
+        authority: plan.authority,
+      }),
+      profileDigest: process.env.SHIFU_CACHE_PROFILE_DIGEST || null,
+      hit: null,
+      reason:
+        'The current build tools do not expose trustworthy per-target cache hit facts.',
+    },
+    durationMs: Date.now() - started,
+    budgetMs: baseline.requiredBudgetSeconds * 1000,
+    steps,
+    failure,
+  };
+  fs.mkdirSync(path.dirname(absoluteReceipt), { recursive: true });
+  fs.writeFileSync(absoluteReceipt, `${JSON.stringify(receipt, null, 2)}\n`);
+  console.log(
+    `[core-affected] receipt=${path.relative(root, absoluteReceipt)}`,
+  );
+  if (status !== 'passed') process.exitCode = 1;
+  return receipt;
+}
+
+function verifyReceipt(receipt) {
+  if (receipt.schema !== 'kungfu.core-affected-native-receipt/v1') {
+    throw new Error('unsupported affected-native receipt schema');
+  }
+  const { planDigest, ...planWithoutDigest } = receipt.plan;
+  if (
+    planDigest !== digest(planWithoutDigest) ||
+    receipt.planDigest !== planDigest
+  ) {
+    throw new Error('affected-native receipt plan digest drift');
+  }
+  if (!['passed', 'failed'].includes(receipt.status)) {
+    throw new Error('affected-native receipt status is invalid');
+  }
+  return true;
+}
+
+function selfTest(authority, buildAuthority) {
+  let passed = 0;
+  const expect = (name, action, pattern = null) => {
+    try {
+      action();
+      if (pattern) throw new Error(`${name}: expected failure`);
+      console.log(`  ok: ${name}`);
+      passed += 1;
+    } catch (error) {
+      if (!pattern || !pattern.test(error.message)) throw error;
+      console.log(`  ok: ${name}`);
+      passed += 1;
+    }
+  };
+  const implementation = [
+    'framework/core/src/libkungfu/src/runtime/storage/query_render.cpp',
+  ];
+  const first = planFromChanged(
+    implementation,
+    authority,
+    buildAuthority,
+    'base',
+    'head',
+  );
+  const second = planFromChanged(
+    implementation,
+    authority,
+    buildAuthority,
+    'base',
+    'head',
+  );
+  expect('deterministic implementation plan', () => {
+    if (stableJson(first) !== stableJson(second)) throw new Error('plan drift');
+    if (!first.directComponents.includes('runtime-storage-services'))
+      throw new Error('owner missing');
+  });
+  expect(
+    'unclassified source fails closed',
+    () =>
+      planFromChanged(
+        ['framework/core/src/libkungfu/src/runtime/unknown.cpp'],
+        authority,
+        buildAuthority,
+        'base',
+        'head',
+      ),
+    /exactly one architecture component/,
+  );
+  expect('authority dependency change expands globally', () => {
+    const plan = planFromChanged(
+      ['framework/core/architecture/layers.json'],
+      authority,
+      buildAuthority,
+      'base',
+      'head',
+    );
+    if (plan.closureComponents.length !== authority.components.length)
+      throw new Error('closure incomplete');
+  });
+  expect('public header propagates to consumers', () => {
+    const plan = planFromChanged(
+      ['framework/core/src/libkungfu/include/kungfu/embedding.h'],
+      authority,
+      buildAuthority,
+      'base',
+      'head',
+    );
+    if (plan.closureComponents.length <= plan.directComponents.length)
+      throw new Error('no propagation');
+    if (!plan.tests.includes('kungfu_public_contract_compatibility_tests'))
+      throw new Error('compat test missing');
+  });
+  expect(
+    'target deletion fails closed',
+    () => {
+      const changed = structuredClone(authority);
+      changed.target_evidence = changed.target_evidence.map((record) => ({
+        ...record,
+        targets: record.targets.filter(
+          (target) => target !== 'kungfu_storage_services',
+        ),
+      }));
+      validateAuthority(changed, buildAuthority);
+    },
+    /lacks CMake evidence/,
+  );
+  expect(
+    'test mapping loss fails closed',
+    () => {
+      const changed = structuredClone(authority);
+      changed.components[0].contract_tests.push('missing_native_contract_test');
+      validateAuthority(changed, buildAuthority);
+    },
+    /contract test lacks CMake evidence/,
+  );
+  expect(
+    'receipt drift fails closed',
+    () => {
+      const receipt = {
+        schema: 'kungfu.core-affected-native-receipt/v1',
+        status: 'passed',
+        plan: { ...first, planDigest: `sha256:${'0'.repeat(64)}` },
+        planDigest: first.planDigest,
+      };
+      verifyReceipt(receipt);
+    },
+    /plan digest drift/,
+  );
+  console.log(`[core-affected] ${passed} negative/determinism fixtures passed`);
+}
+
+function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const authority = readJson(architecturePath);
+  const buildAuthority = readJson(buildPath);
+  if (options.selfTest) return selfTest(authority, buildAuthority);
+  if (options.verifyReceipt) {
+    verifyReceipt(readJson(path.resolve(root, options.verifyReceipt)));
+    console.log('[core-affected] receipt verified');
+    return;
+  }
+  const base = git('rev-parse', options.base);
+  const head = git('rev-parse', options.head);
+  const changedFiles = options.changedFiles.length
+    ? options.changedFiles
+    : git('diff', '--name-only', '--diff-filter=ACMRTUXB', `${base}...${head}`)
+        .split('\n')
+        .filter(Boolean);
+  const plan = planFromChanged(
+    changedFiles,
+    authority,
+    buildAuthority,
+    base,
+    head,
+  );
+  if (options.json) console.log(JSON.stringify(plan, null, 2));
+  else {
+    console.log(`[core-affected] ${base.slice(0, 12)}..${head.slice(0, 12)}`);
+    console.log(
+      `[core-affected] profile=${plan.profile || 'none'} tier=${plan.platformTier}`,
+    );
+    console.log(
+      `[core-affected] components=${plan.closureComponents.join(', ') || 'none'}`,
+    );
+    console.log(`[core-affected] targets=${plan.targets.join(', ') || 'none'}`);
+    console.log(`[core-affected] tests=${plan.tests.join(', ') || 'none'}`);
+  }
+  if (options.execute) execute(plan, options.receipt);
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(`[core-affected] ${error.message}`);
+  process.exitCode = 1;
+}

--- a/scripts/run-core-affected-native.mjs
+++ b/scripts/run-core-affected-native.mjs
@@ -492,7 +492,9 @@ function execute(plan, receiptPath) {
             '--target',
             ...plan.targets,
             '--parallel',
-            String(os.availableParallelism()),
+            String(
+              Math.min(os.availableParallelism(), baseline.maxParallelism),
+            ),
           ],
           root,
           env,

--- a/scripts/run-core-affected-native.mjs
+++ b/scripts/run-core-affected-native.mjs
@@ -612,6 +612,26 @@ function selfTest(authority, buildAuthority) {
       throw new Error('owner missing');
   });
   expect(
+    'outside-Core change emits a required-check-safe tier-none plan',
+    () => {
+      const plan = planFromChanged(
+        ['docs/MAP.md'],
+        authority,
+        buildAuthority,
+        'base',
+        'head',
+      );
+      if (
+        plan.platformTier !== 'none' ||
+        plan.profile !== null ||
+        plan.targets.length ||
+        plan.tests.length
+      ) {
+        throw new Error('outside-Core plan scheduled native work');
+      }
+    },
+  );
+  expect(
     'unclassified source fails closed',
     () =>
       planFromChanged(

--- a/scripts/run-core-affected-native.mjs
+++ b/scripts/run-core-affected-native.mjs
@@ -7,6 +7,8 @@ import os from 'node:os';
 import path from 'node:path';
 import process from 'node:process';
 
+import { writeShifuGateEvidence } from './shifu-gate-evidence.mjs';
+
 const root = process.cwd();
 const coreRoot = path.join(root, 'framework', 'core');
 const architecturePath = path.join(coreRoot, 'architecture', 'layers.json');
@@ -552,6 +554,11 @@ function execute(plan, receiptPath) {
   };
   fs.mkdirSync(path.dirname(absoluteReceipt), { recursive: true });
   fs.writeFileSync(absoluteReceipt, `${JSON.stringify(receipt, null, 2)}\n`);
+  writeShifuGateEvidence({
+    schema: 'kungfu.core-affected-native-receipt/v1',
+    pointers: [{ id: 'core-affected-native-receipt', file: absoluteReceipt }],
+    root,
+  });
   console.log(
     `[core-affected] receipt=${path.relative(root, absoluteReceipt)}`,
   );

--- a/shifu.gates.json
+++ b/shifu.gates.json
@@ -219,35 +219,44 @@
     },
     {
       "id": "source.changed-scope",
-      "title": "Changed-scope developer check",
-      "summary": "Checks changed source plus shared contract and tooling tests.",
-      "category": "source",
+      "title": "Affected Core native developer check",
+      "summary": "Resolves changed Core paths through the architecture authority and compiles, links, and tests the bounded native impact closure.",
+      "category": "native",
       "documentation": "docs/qualification/gates/source-and-governance.md",
       "dependencies": [
-        "gate.catalog"
+        "gate.catalog",
+        "source.acceptance"
       ],
       "platforms": [
-        "linux",
-        "macos",
-        "windows"
+        "linux"
       ],
       "runner": {
         "capabilities": [
-          "node"
+          "native-toolchain"
         ]
       },
       "cost": {
-        "class": "light",
-        "timeoutSeconds": 1200
+        "class": "heavy",
+        "timeoutSeconds": 1500
       },
       "action": {
         "kind": "task",
-        "task": "check",
-        "args": []
+        "task": "core:affected",
+        "args": [
+          "--",
+          "--execute"
+        ]
       },
-      "artifacts": [],
+      "artifacts": [
+        {
+          "id": "core-affected-native-receipt",
+          "path": "product/qualification/affected-native",
+          "required": true
+        }
+      ],
       "receipt": {
-        "expectation": "optional"
+        "expectation": "required",
+        "schema": "kungfu.core-affected-native-receipt/v1"
       }
     },
     {
@@ -1381,8 +1390,8 @@
           "reason": "Selected by the current dev-pr workflow policy when its activation condition matches."
         },
         "source.changed-scope": {
-          "mode": "off",
-          "reason": "Not selected by the current dev-pr workflow policy."
+          "mode": "required",
+          "reason": "Core-affecting development pull requests require the deterministic GitHub-hosted Linux native closure."
         },
         "source.whole-tree": {
           "mode": "off",


### PR DESCRIPTION
## Summary

Turn Core architecture ownership into a deterministic affected-native development gate that resolves changed paths to the smallest supported profile, native targets, and contract tests while failing closed on unknown impact.

## Related issue

Atlas child goal `2026-07-15-kungfu-affected-native-pr-gate` and parent `2026-07-15-kungfu-core-architecture-level5`.

## Changes

- resolve implementation, header, public-contract, schema, build, and architecture changes through the single Core authority
- compile, link, and test the bounded closure on GitHub-hosted `ubuntu-24.04`
- retain source, authority, profile, toolchain, cache, timing, plan, step, and raw-log evidence in a verified receipt
- require the same `source.changed-scope` Gate locally and in CI
- emit a valid tier-none receipt for outside-Core PRs so the protected required check cannot deadlock
- enforce a 20-minute budget, 25-minute timeout, and maximum parallelism of 12 without deleting required tests

## Verification

- `./shifu check:source`
- `./shifu core:affected -- --self-test` (8/8 determinism and failure fixtures)
- outside-Core tier-none receipt generation and verification
- agent-120 Linux execution: passed in 243,184 ms (Conan 129,607 ms; build 113,055 ms; CTest 115 ms)
- `./shifu build:core`

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "stage-ready",
  "adrs": ["ADR-0066"],
  "summary": "Add a deterministic, fail-closed affected-native development gate with retained plan, build, test, timing, and cache evidence.",
  "verification": ["./shifu check:source", "./shifu core:affected -- --self-test", "agent-120 affected-native receipt passed in 243184 ms"]
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] release evidence, provenance, package publishing, or deployment surfaces
- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed
