### PR TITLE
fix(runtime,core): forward create_task kwargs, declare+widen mypy surface, classify pyproject in native gate

### DIFF
--- a/extensions/mission-control/mission-control-actions/domain/mission_control.py
+++ b/extensions/mission-control/mission-control-actions/domain/mission_control.py
@@ -2491,7 +2491,7 @@ def _continuation_actions(verdict: str) -> list[str]:
 def _bounded_followups(rows: list[dict[str, Any]] | None) -> list[dict[str, Any]]:
     if len(rows or []) > 6:
         raise ValueError("continuation plans may contain at most six follow-up Go rows")
-    result = []
+    result: list[dict[str, Any]] = []
     for row in rows or []:
         if not isinstance(row, dict):
             raise ValueError("follow-up Go rows must be objects")

--- a/framework/core/pyproject.toml
+++ b/framework/core/pyproject.toml
@@ -144,6 +144,18 @@ ignore = ["E501", "F403", "F405"]
 python_version = "3.13"
 ignore_missing_imports = true
 exclude = ['(^|/)(fb|generated)/', '_fb\.py$', '(^|/)\.deps/']
+# Checked surface, in one place so verify and source-acceptance cannot drift
+# apart. Paths are relative to this file (framework/core). The core package is
+# the bulk; the three siblings are small but load-bearing — kungfu_sdk is the
+# public Python SDK surface, guest-harness backs the capability guest contract,
+# and mission-control-actions carries extension domain logic. All are error-free
+# under this baseline, so listing them locks that in rather than fixing debt.
+files = [
+    "src/python/kungfu",
+    "../sdk/python/kungfu_sdk",
+    "../api/src/capability/guest-harness",
+    "../../extensions/mission-control/mission-control-actions",
+]
 # The native pykungfu binding is not compiled in the type-check env; type
 # consumers against committed .pyi stubs (stubs/pykungfu/, generated from the
 # compiled binding via pybind11-stubgen) instead of falling back to Any.

--- a/framework/core/src/python/kungfu/runtime/live/event_loop.py
+++ b/framework/core/src/python/kungfu/runtime/live/event_loop.py
@@ -141,14 +141,14 @@ class LiveEventLoop(asyncio.AbstractEventLoop):
         handle._scheduled = True
         return handle
 
-    def create_task(self, coro):
+    def create_task(self, coro, *, name=None, context=None):
         async def wrapper():
             try:
                 await coro
             except Exception as e:
                 self._exception = e
 
-        return asyncio.Task(wrapper(), loop=self)
+        return asyncio.Task(wrapper(), loop=self, name=name, context=context)
 
     def create_future(self):
         return asyncio.Future(loop=self)

--- a/scripts/run-core-affected-native.mjs
+++ b/scripts/run-core-affected-native.mjs
@@ -242,6 +242,12 @@ function planFromChanged(changedFiles, authority, buildAuthority, base, head) {
     'framework/core/architecture/',
     'framework/core/CMakeLists.txt',
     'framework/core/conanfile.py',
+    // pyproject.toml is a Core build definition alongside conanfile.py and
+    // package.json: it pins the native toolchain (conan, cmake-js, ninja,
+    // pybind11-stubgen). Editing any section could change how the addon builds,
+    // and this gate cannot read TOML sections, so a change expands globally and
+    // re-validates every component rather than failing closed as unclassified.
+    'framework/core/pyproject.toml',
     'framework/core/package.json',
     'framework/core/tests/',
     'scripts/run-core-affected-native.mjs',
@@ -817,6 +823,23 @@ function selfTest(authority, buildAuthority) {
     );
     if (plan.closureComponents.length !== authority.components.length)
       throw new Error('closure incomplete');
+  });
+  expect('core build definition change expands globally', () => {
+    const plan = planFromChanged(
+      ['framework/core/pyproject.toml'],
+      authority,
+      buildAuthority,
+      'base',
+      'head',
+    );
+    if (plan.closureComponents.length !== authority.components.length)
+      throw new Error('pyproject.toml did not expand to the full closure');
+    if (
+      !plan.reasons.some(
+        ({ kind }) => kind === 'architecture-or-gate-authority',
+      )
+    )
+      throw new Error('pyproject.toml not classified as a build authority');
   });
   expect('public header propagates to consumers', () => {
     const plan = planFromChanged(

--- a/scripts/source-acceptance.mjs
+++ b/scripts/source-acceptance.mjs
@@ -10,6 +10,16 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const CPP = /\.(?:c|cc|cpp|cxx|h|hh|hpp|hxx)$/;
 const WEB = /\.(?:ts|tsx|js|jsx|mjs|cjs|json|jsonc|css)$/;
+// Repo-relative roots of the mypy-checked surface. Mirrors `files` under
+// [tool.mypy] in framework/core/pyproject.toml, which stays the single source of
+// truth for what gets checked; this list only decides whether a changed file
+// makes the type baseline worth running at all.
+const TYPED_PYTHON_ROOTS = [
+  'framework/core/src/python/',
+  'framework/sdk/python/kungfu_sdk/',
+  'framework/api/src/capability/guest-harness/',
+  'extensions/mission-control/mission-control-actions/',
+];
 const isWin = process.platform === 'win32';
 
 /** @typedef {{label: string, command: string, args: string[], cwd?: string, env?: NodeJS.ProcessEnv}} Command */
@@ -339,14 +349,10 @@ export function sourceAcceptancePlan(files) {
   }
 
   const typedPython = python.filter((file) =>
-    file.startsWith('framework/core/src/python/'),
+    TYPED_PYTHON_ROOTS.some((root) => file.startsWith(root)),
   );
   if (typedPython.length) {
-    const mypy = sourceMypyCommand([
-      '--config-file',
-      'pyproject.toml',
-      'src/python/kungfu',
-    ]);
+    const mypy = sourceMypyCommand(['--config-file', 'pyproject.toml']);
     plan.push({
       label: 'Python type baseline',
       ...mypy,

--- a/scripts/source-acceptance.test.mjs
+++ b/scripts/source-acceptance.test.mjs
@@ -15,6 +15,39 @@ import {
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 
+test('type baseline covers every Python surface declared by [tool.mypy]', () => {
+  // The three siblings of the core package are small but load-bearing
+  // (public SDK, capability guest harness, extension domain logic). Changing
+  // one must trigger the type baseline, and pyproject must actually check it —
+  // otherwise the scope silently narrows back to the core package.
+  const pyproject = fs.readFileSync(
+    path.join(ROOT, 'framework/core/pyproject.toml'),
+    'utf8',
+  );
+  const checked = [
+    ['framework/sdk/python/kungfu_sdk/native.py', '"../sdk/python/kungfu_sdk"'],
+    [
+      'framework/api/src/capability/guest-harness/facet.py',
+      '"../api/src/capability/guest-harness"',
+    ],
+    [
+      'extensions/mission-control/mission-control-actions/adapter.py',
+      '"../../extensions/mission-control/mission-control-actions"',
+    ],
+  ];
+  for (const [changedFile, mypyEntry] of checked) {
+    const labels = sourceAcceptancePlan([changedFile]).map((s) => s.label);
+    assert.ok(
+      labels.includes('Python type baseline'),
+      `${changedFile} must trigger the type baseline`,
+    );
+    assert.ok(
+      pyproject.includes(mypyEntry),
+      `[tool.mypy] files must list ${mypyEntry}`,
+    );
+  }
+});
+
 test('Python source checks use uvx when a bare ruff is unavailable', () => {
   const command = sourcePythonCommand(
     ['format', '--check'],
@@ -99,10 +132,12 @@ test('source plan covers representative source-only checks', () => {
     (step) => step.label === 'Python type baseline',
   );
   assert.ok(['mypy', 'uvx'].includes(typeBaseline.command));
-  assert.deepEqual(typeBaseline.args.slice(-3), [
+  // No path argument: the checked surface comes from `files` under [tool.mypy]
+  // in framework/core/pyproject.toml, so verify and source-acceptance cannot
+  // disagree about what is type-checked.
+  assert.deepEqual(typeBaseline.args.slice(-2), [
     '--config-file',
     'pyproject.toml',
-    'src/python/kungfu',
   ]);
   if (typeBaseline.command === 'uvx') {
     assert.deepEqual(typeBaseline.args.slice(0, 3), [

--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -341,15 +341,11 @@ function main() {
   // annotations land, with no big-bang. Read-only; runs in quick and full.
   console.log('\n[verify] stage 0b: python type check (mypy)');
   const coreDir = path.join(ROOT, 'framework', 'core');
-  const mypy = spawnSync(
-    'uv',
-    ['run', '--frozen', 'mypy', 'src/python/kungfu'],
-    {
-      cwd: coreDir,
-      encoding: 'utf8',
-      shell: isWin,
-    },
-  );
+  const mypy = spawnSync('uv', ['run', '--frozen', 'mypy'], {
+    cwd: coreDir,
+    encoding: 'utf8',
+    shell: isWin,
+  });
   if (mypy.status === 0) pass('python type check', 'mypy baseline clean');
   else if (
     isWin &&


### PR DESCRIPTION
## Summary

Four related changes around Python typing and the gate that enforces it.

**`create_task` dropped its keyword arguments.** `LiveEventLoop.create_task`
accepted only the coroutine, silently discarding the `name=` and `context=`
keywords its supertype defines. `asyncio.TaskGroup` calls
`self._loop.create_task(coro, name=name, context=context)`, so any strategy code
reaching for a `TaskGroup` would raise `TypeError`. It does not fire today only
because the sole entry path, `asyncio.ensure_future`, passes no keywords — a
trap waiting to spring rather than a live failure. Verified by loading the
module and making the exact call `TaskGroup` makes:

```
before: create_task signature: (self, coro)
        TaskGroup-style call: FAILED -> unexpected keyword argument 'name'
after:  create_task signature: (self, coro, *, name=None, context=None)
        TaskGroup-style call: OK, task name = tg-style
        legacy positional call: OK  (no regression)
```

**The type-checked surface was a path argument, not a declaration.** Both
`verify.mjs` and `source-acceptance.mjs` passed `src/python/kungfu` on the
command line, so the two could drift apart, and nothing outside
`framework/core/src` was ever checked. The surface now lives in `files` under
`[tool.mypy]`, and three siblings join it: the public `kungfu_sdk`, the
capability `guest-harness`, and the `mission-control-actions` extension domain.
Checked files go from 138 to 148.

**Widening the surface immediately caught a real defect in newer code.**
`_bounded_followups` (added on `dev/v4/v4.0` after this branch first opened, in
`d1fb9176f`) declares `-> list[dict[str, Any]]` but built its accumulator from a
bare list, so mypy inferred the element type from the appended literal and
joined it down to `dict[str, Sequence[str]]`. That made `row["goal_id"]` a
`Sequence`, which is not declared comparable, and the `result.sort(key=...)`
failed to type-check. Fixed by annotating the accumulator to match the declared
return type. The compiled bytecode for the function is byte-identical before and
after, so this is a pure annotation with no runtime effect. This is exactly the
class of regression the widened gate exists to stop.

**Widening the surface also exposed a gap in the affected-native gate itself.**
That gate (added earlier today) lists `conanfile.py`, `CMakeLists.txt`, and
`package.json` as Core build definitions that expand globally, but omitted
`framework/core/pyproject.toml` — which now pins the native toolchain after the
runtime deps were split into it. Any edit to that file fell through to the
unclassified branch and failed the required check closed. This branch is the
first to change `pyproject.toml` since the gate landed, so it is the first to
hit it. Fixed by classifying the file with its siblings; since the gate cannot
read TOML sections, a change now expands globally and re-validates every
component. Verified against real authority data: `pyproject.toml` yields the
full 12/12 component closure while a `src/python` change still schedules none.
(This is why this PR runs the full native matrix rather than a no-op.)

Two honest notes on that gate fix. First, `dev` independently added
`framework/core/tests/` to the same list while this branch was open, so the
omission was not unique to `pyproject.toml`; the two classifications are
complementary and rebased together cleanly. Second, the `--self-test` case added
here (`core build definition change expands globally`) does **not** run in CI —
no workflow passes `--self-test`, so the whole self-test suite is currently
dead code. The classification was therefore verified by driving `planFromChanged`
against the real authority data instead (`pyproject.toml` -> 12/12 component
closure, kind `architecture-or-gate-authority`; a `src/python` change -> 0). The
case is added anyway so it is correct whenever the suite is wired up, and wiring
it up (plus repairing the cases that have already silently broken) is tracked
separately rather than expanded into this PR.

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Fixes a dropped-keyword defect in the live event loop, declares and widens the mypy surface, annotates a follow-up accumulator, and classifies pyproject.toml in the affected-native gate; no architecture contract or ADR record is altered"
}
-->

## Governance risk check

- [x] none of the above

## Verification

- `uv run --frozen mypy` (framework/core, mypy 1.20.2): Success, 148 source files, 0 errors
- `uvx --from mypy==1.20.2 mypy --config-file pyproject.toml` (CI's exact form): Success, 148 source files, 0 errors
- `node --test scripts/source-acceptance.test.mjs`: 14/14 pass
- `pytest tests/python/test_event_loop_concurrency.py`: 6 passed
- `ruff format --check` / `ruff check` on the changed modules: clean
- The new scope guard was negatively verified: removing one `files` entry turns
  it red, restoring it turns it green.
- The mission-control fix was proven runtime-neutral by a byte-identical
  bytecode comparison of the changed function.

## Checklist

- [x] Commits are signed off (DCO)
