### PR TITLE
fix(qualification): bind source runtime environments

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,6 +51,11 @@ jobs:
       require-install: true
       require-build: true
       require-verify: true
+      # The complete Windows build plus the three retained runtime/product
+      # qualification campaigns exceeds Buildchain's 120-minute default.
+      # Keep the full gate intact and give the slowest supported platform a
+      # bounded completion window instead of cancelling during final evidence.
+      lifecycle-timeout-minutes: 180
       # This workflow only fires on alpha/release PRs, so it is the recurring
       # heavy gate (kungfu has no nightly). Override the default lifecycle verify
       # (.buildchain/buildchain.toml runs quick `verify`) with the kungfu::view

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
       artifact-paths: |
         product/release
       expected-artifacts-json: >-
-        {"minFiles":1,"minTotalBytes":1}
+        {"minFiles":7,"minTotalBytes":1,"requiredPaths":["product/release/qualification/layer-qualification-summary.json","product/release/qualification/live-peer-continuity/report.json","product/release/qualification/live-peer-continuity/raw-logs.jsonl.gz","product/release/qualification/runtime-activation/report.json","product/release/qualification/runtime-activation/raw-logs.jsonl.gz","product/release/qualification/zero-burden-desktop/report.json","product/release/qualification/zero-burden-desktop/raw-logs.jsonl.gz"]}
       require-install: true
       require-build: true
       require-verify: true

--- a/crates/shifu/src/registrar.rs
+++ b/crates/shifu/src/registrar.rs
@@ -51,11 +51,15 @@ use shifu_core::{bootstrap, host, json, style};
 /// verb; see docs/rust-adoption.md and the contract registry.
 const LAYOUT_DISCOVERY_CONTRACT: &str = "kungfu-buildchain-layout-discovery";
 
-/// Local, read-only hint used only to decide whether a fresh checkout needs
-/// the pinned Buildchain binary before a declared distribution task. It is
-/// never accepted as the authoritative registry path: after a hint match,
-/// Buildchain must still resolve the KFD-3 layout and that answer is reparsed.
+/// Local, read-only hint used to decide whether a fresh checkout needs the
+/// pinned Buildchain binary before a declared distribution task. Normally it
+/// only authorizes discovery: Buildchain resolves the KFD-3 layout and that
+/// answer is reparsed. The explicit Buildchain source-build boundary may use
+/// the tracked hint directly because that qualification environment owns the
+/// exact source checkout and intentionally has no released binary dependency.
 const REGISTRY_DISCOVERY_HINT: &str = ".buildchain/kfd/kfd-3/surfaces.json";
+
+const BUILDCHAIN_SOURCE_BUILD_ENV: &str = "KUNGFU_BUILDCHAIN_SOURCE_BUILD";
 
 /// Locate the repo's KFD-3 surface registry by asking buildchain, caching the
 /// answer per (repo, buildchain version). Returns the absolute registry path,
@@ -263,11 +267,21 @@ pub fn plan_for_task(root: &Path, task: &str) -> Option<DistributionPlan> {
     // A fresh runner has neither the per-repo layout cache nor a cached
     // Buildchain binary. Avoid fetching Buildchain for ordinary tasks: first
     // check the tracked registry hint for a host distribution declaration for
-    // this exact task. A match only authorizes discovery; Buildchain's answer
-    // remains the single source of truth for the plan used after the build.
-    plan_at(root, &root.join(REGISTRY_DISCOVERY_HINT), task)?;
+    // this exact task. A match normally only authorizes discovery; the named
+    // source-build boundary below is the sole direct-hint exception.
+    let hint_plan = plan_at(root, &root.join(REGISTRY_DISCOVERY_HINT), task)?;
+    if source_registry_hint_allowed(env::var_os(BUILDCHAIN_SOURCE_BUILD_ENV).as_deref()) {
+        warn(&format!(
+            "{BUILDCHAIN_SOURCE_BUILD_ENV}=1; using the tracked KFD-3 registry hint for source-build registration"
+        ));
+        return Some(hint_plan);
+    }
     let path = resolve_kfd3_registry_with(root, Acquire::Fetch)?;
     plan_at(root, &path, task)
+}
+
+fn source_registry_hint_allowed(value: Option<&std::ffi::OsStr>) -> bool {
+    value == Some(std::ffi::OsStr::new("1"))
 }
 
 /// Parse a distribution plan from a specific registry path. Split from
@@ -850,6 +864,20 @@ mod tests {
         assert!(plan_at(&dir, &registry, "dist").is_some());
         assert!(plan_at(&dir, &registry, "verify").is_none());
         let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn source_build_boundary_alone_allows_the_tracked_registry_hint() {
+        assert!(source_registry_hint_allowed(Some(std::ffi::OsStr::new(
+            "1"
+        ))));
+        assert!(!source_registry_hint_allowed(None));
+        assert!(!source_registry_hint_allowed(Some(std::ffi::OsStr::new(
+            "0"
+        ))));
+        assert!(!source_registry_hint_allowed(Some(std::ffi::OsStr::new(
+            "true"
+        ))));
     }
 
     #[test]

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -202,7 +202,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:b32ad86be6283bf3781a5491c71a2b0436649d11397533a7d216ce6b8ad98c1d",
+          "definitionDigest": "sha256:6a5273d99ac60996343d9e9af86ef5ffa1b0d6a1a565c865460dcdeea6d4ab19",
           "credentials": {
             "githubToken": "write",
             "oidc": true,

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -202,7 +202,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:3cd226ae1fea6303943df90ab4bea916c92a6a3c9c1fdc514f4b6b1e89b377f1",
+          "definitionDigest": "sha256:b32ad86be6283bf3781a5491c71a2b0436649d11397533a7d216ce6b8ad98c1d",
           "credentials": {
             "githubToken": "write",
             "oidc": true,

--- a/framework/agent-session/package.json
+++ b/framework/agent-session/package.json
@@ -39,7 +39,7 @@
   ],
   "scripts": {
     "test": "node --test tests/*.test.mjs",
-    "test:control-plane": "node --test --test-skip-pattern=installed tests/*.test.mjs"
+    "test:control-plane": "node --test --test-concurrency=1 --test-skip-pattern=installed tests/*.test.mjs"
   },
   "dependencies": {
     "node-pty": "^1.1.0"

--- a/framework/agent-session/tests/capsule-worker.test.mjs
+++ b/framework/agent-session/tests/capsule-worker.test.mjs
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { spawn } from 'node:child_process';
+import { spawn, spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import { createRequire } from 'node:module';
 import net from 'node:net';
@@ -31,6 +31,32 @@ function preparedNodePty(temp) {
     fs.chmodSync(helper, mode | 0o111);
   }
   return path.join(target, 'lib', 'index.js');
+}
+
+async function stopTestOwnedChild(child) {
+  if (!child || child.exitCode !== null || child.signalCode !== null) return;
+  let diagnostic = '';
+  if (process.platform === 'win32' && child.pid) {
+    const result = spawnSync(
+      'taskkill.exe',
+      ['/pid', String(child.pid), '/t', '/f'],
+      { encoding: 'utf8', windowsHide: true },
+    );
+    diagnostic = [result.error?.message, result.stdout, result.stderr]
+      .filter(Boolean)
+      .join('\n')
+      .trim();
+  } else {
+    child.kill('SIGTERM');
+  }
+  await Promise.race([
+    new Promise((resolve) => child.once('exit', resolve)),
+    new Promise((resolve) => setTimeout(resolve, 2_000)),
+  ]);
+  if (child.exitCode === null && child.signalCode === null)
+    throw new Error(
+      `test-owned Capsule process tree ${child.pid || 'unknown'} did not exit: ${diagnostic || 'no termination diagnostic'}`,
+    );
 }
 
 async function waitFor(check, message, timeout = 5000) {
@@ -65,7 +91,7 @@ async function connect(endpoint) {
     }
   });
   return {
-    close: () => socket.end(),
+    close: () => socket.destroy(),
     request(operation, payload) {
       sequence += 1;
       const id = `request-${sequence}`;
@@ -99,19 +125,20 @@ test('detached Capsule worker survives client loss and reattaches to the same PT
     { detached: true, stdio: 'ignore' },
   );
   child.unref();
-  t.after(() => {
-    try {
-      process.kill(child.pid, 'SIGTERM');
-    } catch {}
+  const clients = [];
+  t.after(async () => {
+    for (const client of clients) client.close();
+    await stopTestOwnedChild(child);
     fs.rmSync(temp, { force: true, recursive: true });
   });
   await waitFor(
     () => fs.existsSync(endpoint),
     'Capsule endpoint did not appear',
+    process.platform === 'win32' ? 20_000 : 5_000,
   );
 
   const first = await connect(endpoint);
-  t.after(() => first.close());
+  clients.push(first);
   const handshake = await first.request('handshake');
   assert.equal(handshake.processId, child.pid);
   assert.ok(handshake.capabilities.includes('pty-owner'));
@@ -133,7 +160,7 @@ test('detached Capsule worker survives client loss and reattaches to the same PT
 
   await new Promise((resolve) => setTimeout(resolve, 100));
   const second = await connect(endpoint);
-  t.after(() => second.close());
+  clients.push(second);
   const reattached = await second.request('status');
   assert.equal(reattached.sessionAttemptId, started.sessionAttemptId);
   assert.equal(reattached.foreground.pid, started.foreground.pid);

--- a/framework/agent-session/tests/codex-app-server-runtime.test.mjs
+++ b/framework/agent-session/tests/codex-app-server-runtime.test.mjs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
 import path from 'node:path';
 import test from 'node:test';
 import { fileURLToPath } from 'node:url';
@@ -51,7 +52,33 @@ async function waitUntil(predicate, message, timeoutMs = 2_000) {
 async function stop(host, actionId = 'shutdown-test') {
   if (!host.status().exit) {
     host.shutdown({ ...host.currentFence(), actionId });
-    await host.waitForExit();
+    const waitForExit = host.waitForExit();
+    const exited = await Promise.race([
+      waitForExit.then(() => true),
+      new Promise((resolve) => setTimeout(() => resolve(false), 2_000)),
+    ]);
+    if (exited) return;
+    if (process.platform !== 'win32')
+      throw new Error('test-owned Codex App Server did not exit after SIGTERM');
+    const pid = host.status().pid;
+    const result = spawnSync(
+      'taskkill.exe',
+      ['/pid', String(pid), '/t', '/f'],
+      { encoding: 'utf8', windowsHide: true },
+    );
+    const terminated = await Promise.race([
+      waitForExit.then(() => true),
+      new Promise((resolve) => setTimeout(() => resolve(false), 2_000)),
+    ]);
+    if (!terminated) {
+      const diagnostic = [result.error?.message, result.stdout, result.stderr]
+        .filter(Boolean)
+        .join('\n')
+        .trim();
+      throw new Error(
+        `test-owned Codex App Server process tree ${pid} did not exit: ${diagnostic || 'no termination diagnostic'}`,
+      );
+    }
   }
 }
 

--- a/framework/agent-session/tests/runtime-port.native.test.mjs
+++ b/framework/agent-session/tests/runtime-port.native.test.mjs
@@ -73,8 +73,8 @@ function waitForJsonLine(child, type, timeout = 20_000) {
 function spawnPeer(role, runtimeDir) {
   const child = spawn(process.execPath, [PEER_FIXTURE, role, runtimeDir], {
     cwd: ROOT,
-    env: coordinatorEnvironment(),
     detached: process.platform !== 'win32',
+    env: coordinatorEnvironment(),
     stdio: ['ignore', 'pipe', 'pipe'],
   });
   child.__stderr = '';
@@ -82,19 +82,6 @@ function spawnPeer(role, runtimeDir) {
     child.__stderr += chunk.toString('utf8');
   });
   return child;
-}
-
-function signalChildTree(child, signal) {
-  if (process.platform !== 'win32' && child.pid) {
-    try {
-      process.kill(-child.pid, signal);
-      return;
-    } catch (error) {
-      if (error?.code === 'ESRCH') return;
-      throw error;
-    }
-  }
-  child.kill(signal);
 }
 
 export function windowsTreeKillInvocation(pid) {
@@ -106,51 +93,55 @@ export function windowsTreeKillInvocation(pid) {
   };
 }
 
+function posixProcessGroupAlive(pid) {
+  try {
+    process.kill(-pid, 0);
+    return true;
+  } catch (error) {
+    if (error?.code === 'ESRCH') return false;
+    throw error;
+  }
+}
+
+async function waitForPosixProcessGroupExit(pid, timeout = 2_000) {
+  const deadline = Date.now() + timeout;
+  while (Date.now() < deadline) {
+    if (!posixProcessGroupAlive(pid)) return true;
+    await sleep(50);
+  }
+  return !posixProcessGroupAlive(pid);
+}
+
 async function stopChild(child) {
   if (!child) return;
-  const ownsProcessGroup = process.platform !== 'win32' && child.pid;
-  if (
-    (child.exitCode !== null || child.signalCode !== null) &&
-    !ownsProcessGroup
-  )
-    return;
   let treeKill = null;
   if (process.platform === 'win32' && child.pid) {
+    if (child.exitCode !== null || child.signalCode !== null) return;
     const invocation = windowsTreeKillInvocation(child.pid);
     treeKill = spawnSync(invocation.command, invocation.args, {
       encoding: 'utf8',
       windowsHide: true,
     });
   } else {
-    signalChildTree(child, 'SIGTERM');
+    if (!child.pid || !posixProcessGroupAlive(child.pid)) return;
+    process.kill(-child.pid, 'SIGTERM');
+    if (!(await waitForPosixProcessGroupExit(child.pid))) {
+      process.kill(-child.pid, 'SIGKILL');
+      if (!(await waitForPosixProcessGroupExit(child.pid)))
+        throw new Error(
+          `test-owned POSIX process group ${child.pid} did not exit after SIGKILL`,
+        );
+    }
+    return;
   }
   await Promise.race([
     new Promise((resolve) => child.once('exit', resolve)),
     sleep(2_000),
   ]);
-  if (process.platform === 'win32') {
-    if (child.exitCode === null && child.signalCode === null) {
-      const diagnostic = `${treeKill?.error?.message || ''}\n${treeKill?.stdout || ''}\n${treeKill?.stderr || ''}`.trim();
-      throw new Error(
-        `test-owned process tree ${child.pid || 'unknown'} did not exit: ${diagnostic}`,
-      );
-    }
-    return;
-  }
-  if (!child.pid) return;
-  // A native peer can keep libuv work alive after its direct wrapper exits.
-  // Always reap the POSIX fixture group after the grace period so a timed-out
-  // qualification cannot occupy a self-hosted runner indefinitely.
-  signalChildTree(child, 'SIGKILL');
-  if (child.exitCode === null) {
-    await Promise.race([
-      new Promise((resolve) => child.once('exit', resolve)),
-      sleep(2_000),
-    ]);
-  }
   if (child.exitCode === null && child.signalCode === null) {
+    const diagnostic = `${treeKill?.error?.message || ''}\n${treeKill?.stdout || ''}\n${treeKill?.stderr || ''}`.trim();
     throw new Error(
-      `test-owned process tree ${child.pid || 'unknown'} did not exit after SIGKILL`,
+      `test-owned process tree ${child.pid || 'unknown'} did not exit: ${diagnostic}`,
     );
   }
 }
@@ -163,18 +154,16 @@ test(
       process.execPath,
       [
         '-e',
-        "process.on('SIGTERM', () => {}); process.stdout.write('ready\\n'); setInterval(() => {}, 1_000);",
+        "const { spawn } = require('node:child_process'); const descendant = spawn(process.execPath, ['-e', \"process.on('SIGTERM', () => {}); process.stdout.write('ready\\\\n'); setInterval(() => {}, 1_000)\"], { stdio: ['ignore', 'pipe', 'ignore'] }); descendant.stdout.once('data', () => process.stdout.write(JSON.stringify({ type: 'ready', descendantPid: descendant.pid }) + '\\n')); setInterval(() => {}, 1_000);",
       ],
-      { stdio: ['ignore', 'pipe', 'pipe'] },
+      { detached: true, stdio: ['ignore', 'pipe', 'pipe'] },
     );
-    await new Promise((resolve, reject) => {
-      child.stdout.once('data', resolve);
-      child.once('error', reject);
-    });
+    const ready = await waitForJsonLine(child, 'ready');
 
     await stopChild(child);
 
-    assert.equal(child.signalCode, 'SIGKILL');
+    assert.equal(posixProcessGroupAlive(child.pid), false);
+    assert.ok(Number.isSafeInteger(ready.descendantPid));
   },
 );
 
@@ -210,11 +199,11 @@ test(
         runtimeDir,
         '--low-latency',
       ],
-      {
-        cwd: CORE_DIR,
-        env: coordinatorEnvironment(),
-        detached: process.platform !== 'win32',
-        stdio: ['ignore', output, output],
+        {
+          cwd: CORE_DIR,
+          detached: process.platform !== 'win32',
+          env: coordinatorEnvironment(),
+          stdio: ['ignore', output, output],
       },
     );
     let coordinatorExited = false;

--- a/framework/agent-session/tests/runtime-port.native.test.mjs
+++ b/framework/agent-session/tests/runtime-port.native.test.mjs
@@ -139,7 +139,8 @@ async function stopChild(child) {
     sleep(2_000),
   ]);
   if (child.exitCode === null && child.signalCode === null) {
-    const diagnostic = `${treeKill?.error?.message || ''}\n${treeKill?.stdout || ''}\n${treeKill?.stderr || ''}`.trim();
+    const diagnostic =
+      `${treeKill?.error?.message || ''}\n${treeKill?.stdout || ''}\n${treeKill?.stderr || ''}`.trim();
     throw new Error(
       `test-owned process tree ${child.pid || 'unknown'} did not exit: ${diagnostic}`,
     );
@@ -199,11 +200,11 @@ test(
         runtimeDir,
         '--low-latency',
       ],
-        {
-          cwd: CORE_DIR,
-          detached: process.platform !== 'win32',
-          env: coordinatorEnvironment(),
-          stdio: ['ignore', output, output],
+      {
+        cwd: CORE_DIR,
+        detached: process.platform !== 'win32',
+        env: coordinatorEnvironment(),
+        stdio: ['ignore', output, output],
       },
     );
     let coordinatorExited = false;

--- a/framework/agent-session/tests/runtime-port.native.test.mjs
+++ b/framework/agent-session/tests/runtime-port.native.test.mjs
@@ -109,7 +109,11 @@ export function windowsTreeKillInvocation(pid) {
 async function stopChild(child) {
   if (!child) return;
   const ownsProcessGroup = process.platform !== 'win32' && child.pid;
-  if (child.exitCode !== null && !ownsProcessGroup) return;
+  if (
+    (child.exitCode !== null || child.signalCode !== null) &&
+    !ownsProcessGroup
+  )
+    return;
   let treeKill = null;
   if (process.platform === 'win32' && child.pid) {
     const invocation = windowsTreeKillInvocation(child.pid);
@@ -150,6 +154,29 @@ async function stopChild(child) {
     );
   }
 }
+
+test(
+  'POSIX native fixture cleanup escalates when a child ignores SIGTERM',
+  { skip: process.platform === 'win32', timeout: 10_000 },
+  async () => {
+    const child = spawn(
+      process.execPath,
+      [
+        '-e',
+        "process.on('SIGTERM', () => {}); process.stdout.write('ready\\n'); setInterval(() => {}, 1_000);",
+      ],
+      { stdio: ['ignore', 'pipe', 'pipe'] },
+    );
+    await new Promise((resolve, reject) => {
+      child.stdout.once('data', resolve);
+      child.once('error', reject);
+    });
+
+    await stopChild(child);
+
+    assert.equal(child.signalCode, 'SIGKILL');
+  },
+);
 
 test(
   'native peers exchange an AgentSession frame through mmap journal plus nng notice',
@@ -197,10 +224,16 @@ test(
 
     const peers = [];
     context.after(async () => {
-      await Promise.all(peers.map((peer) => stopChild(peer)));
-      await stopChild(coordinator);
+      const cleanup = await Promise.allSettled(
+        [...peers, coordinator].map((child) => stopChild(child)),
+      );
       fs.closeSync(output);
       fs.rmSync(home, { recursive: true, force: true });
+      const failures = cleanup
+        .filter((result) => result.status === 'rejected')
+        .map((result) => result.reason);
+      if (failures.length > 0)
+        throw new AggregateError(failures, 'native fixture cleanup failed');
     });
 
     // The coordinator does not materialize the runtime journal tree until a

--- a/framework/agent-session/tests/runtime-port.native.test.mjs
+++ b/framework/agent-session/tests/runtime-port.native.test.mjs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import assert from 'node:assert/strict';
-import { spawn } from 'node:child_process';
+import { spawn, spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -97,16 +97,43 @@ function signalChildTree(child, signal) {
   child.kill(signal);
 }
 
+export function windowsTreeKillInvocation(pid) {
+  if (!Number.isSafeInteger(pid) || pid <= 0)
+    throw new Error(`invalid test-owned Windows process id: ${pid}`);
+  return {
+    command: 'taskkill.exe',
+    args: ['/pid', String(pid), '/t', '/f'],
+  };
+}
+
 async function stopChild(child) {
   if (!child) return;
   const ownsProcessGroup = process.platform !== 'win32' && child.pid;
   if (child.exitCode !== null && !ownsProcessGroup) return;
-  signalChildTree(child, 'SIGTERM');
+  let treeKill = null;
+  if (process.platform === 'win32' && child.pid) {
+    const invocation = windowsTreeKillInvocation(child.pid);
+    treeKill = spawnSync(invocation.command, invocation.args, {
+      encoding: 'utf8',
+      windowsHide: true,
+    });
+  } else {
+    signalChildTree(child, 'SIGTERM');
+  }
   await Promise.race([
     new Promise((resolve) => child.once('exit', resolve)),
     sleep(2_000),
   ]);
-  if (process.platform === 'win32' || !child.pid) return;
+  if (process.platform === 'win32') {
+    if (child.exitCode === null && child.signalCode === null) {
+      const diagnostic = `${treeKill?.error?.message || ''}\n${treeKill?.stdout || ''}\n${treeKill?.stderr || ''}`.trim();
+      throw new Error(
+        `test-owned process tree ${child.pid || 'unknown'} did not exit: ${diagnostic}`,
+      );
+    }
+    return;
+  }
+  if (!child.pid) return;
   // A native peer can keep libuv work alive after its direct wrapper exits.
   // Always reap the POSIX fixture group after the grace period so a timed-out
   // qualification cannot occupy a self-hosted runner indefinitely.
@@ -116,6 +143,11 @@ async function stopChild(child) {
       new Promise((resolve) => child.once('exit', resolve)),
       sleep(2_000),
     ]);
+  }
+  if (child.exitCode === null && child.signalCode === null) {
+    throw new Error(
+      `test-owned process tree ${child.pid || 'unknown'} did not exit after SIGKILL`,
+    );
   }
 }
 

--- a/framework/core/stubs/pykungfu/yijinjing/types.pyi
+++ b/framework/core/stubs/pykungfu/yijinjing/types.pyi
@@ -1,7 +1,7 @@
 from __future__ import annotations
 import pykungfu.yijinjing.enums
 import typing
-__all__: list[str] = ['AcceptedRangeRecorded', 'CacheReset', 'Channel', 'ChannelCursorUpdated', 'ChannelRequest', 'Config', 'Deregister', 'EpisodeClosed', 'EpisodeFrameAttached', 'EpisodeHeartbeat', 'EpisodeOpen', 'EpisodeRefAttached', 'ExportBundleRecorded', 'ImportManifestAccepted', 'Location', 'ManifestEntryRecorded', 'OperatorStateUpdate', 'Outlet', 'OutputKey', 'Register', 'RequestCachedDone', 'RequestReadFrom', 'RequestReadFromOthers', 'RequestReadFromPublic', 'RequestReadFromSync', 'RequestWriteTo', 'RequestWriteToOutlet', 'SourceHeadUpdated', 'SourceRegistered', 'SyntheticData', 'TimeKeyValue', 'TimeRequest', 'TimeReset', 'TimeValue', 'frame_header', 'page_header']
+__all__: list[str] = ['AcceptedRangeRecorded', 'CacheReset', 'Channel', 'ChannelCursorUpdated', 'ChannelRequest', 'Config', 'Deregister', 'EpisodeClosed', 'EpisodeFrameAttached', 'EpisodeHeartbeat', 'EpisodeOpen', 'EpisodeRefAttached', 'EpisodeRootCommitted', 'ExportBundleRecorded', 'ImportManifestAccepted', 'Location', 'ManifestEntryRecorded', 'OperatorStateUpdate', 'Outlet', 'OutputKey', 'Register', 'RequestCachedDone', 'RequestReadFrom', 'RequestReadFromOthers', 'RequestReadFromPublic', 'RequestReadFromSync', 'RequestWriteTo', 'RequestWriteToOutlet', 'SourceHeadUpdated', 'SourceRegistered', 'SyntheticData', 'TimeKeyValue', 'TimeRequest', 'TimeReset', 'TimeValue', 'frame_header', 'page_header']
 class AcceptedRangeRecorded:
     __has_data__: typing.ClassVar[bool] = True
     __tag__: typing.ClassVar[int] = 10903
@@ -319,6 +319,33 @@ class EpisodeRefAttached:
     schema_version: int
     update_time: int
     def __eq__(self, arg0: EpisodeRefAttached) -> bool:
+        ...
+    def __hash__(self) -> int:
+        ...
+    @typing.overload
+    def __init__(self) -> None:
+        ...
+    @typing.overload
+    def __init__(self, arg0: str) -> None:
+        ...
+    def __parse__(self, arg0: str) -> None:
+        ...
+    def __repr__(self) -> str:
+        ...
+    @property
+    def __uid__(self) -> int:
+        ...
+class EpisodeRootCommitted:
+    __has_data__: typing.ClassVar[bool] = True
+    __tag__: typing.ClassVar[int] = 10806
+    algorithm: String[str[16]]
+    commit_time: int
+    covered_record_count: int
+    episode_id: int
+    location_uid: int
+    root_value: String[str[72]]
+    schema_version: int
+    def __eq__(self, arg0: EpisodeRootCommitted) -> bool:
         ...
     def __hash__(self) -> int:
         ...

--- a/framework/core/tests/qualification/durability/run.test.mjs
+++ b/framework/core/tests/qualification/durability/run.test.mjs
@@ -133,7 +133,7 @@ test('Windows qualification commands enter Shifu through cmd.exe', () => {
   );
 });
 
-test('Windows Episode workers preserve the inherited Path search list', () => {
+test('Windows Episode workers preserve Path and declare the source runtime boundary', () => {
   const env = episodeRuntimeEnv(
     'win32',
     { Path: 'C:\\Users\\tester\\AppData\\Local\\Microsoft\\WinGet\\Links' },
@@ -141,6 +141,7 @@ test('Windows Episode workers preserve the inherited Path search list', () => {
   );
   assert.deepEqual(env, {
     Path: 'C:\\core\\dist\\kungfu;C:\\Users\\tester\\AppData\\Local\\Microsoft\\WinGet\\Links',
+    KUNGFU_ALLOW_FOREIGN_RUNTIME: '1',
   });
   assert.equal(env.PATH, undefined);
 });

--- a/framework/core/tests/qualification/episode/run.mjs
+++ b/framework/core/tests/qualification/episode/run.mjs
@@ -192,7 +192,11 @@ export function episodeRuntimeEnv(
   baseEnv = process.env,
   dist = path.join(coreDir, 'dist', 'kungfu'),
 ) {
-  const env = { ...baseEnv };
+  // This harness qualifies the freshly built source-tree binding through the
+  // locked project environment. Packaged-runtime blessedness is covered by the
+  // separate product runtime gate, so keep the existing named source-test
+  // boundary explicit when uv is backed by a system interpreter.
+  const env = { ...baseEnv, KUNGFU_ALLOW_FOREIGN_RUNTIME: '1' };
   const libraryKey =
     platform === 'darwin'
       ? 'DYLD_FALLBACK_LIBRARY_PATH'

--- a/framework/core/tests/qualification/live-peer-continuity/run.mjs
+++ b/framework/core/tests/qualification/live-peer-continuity/run.mjs
@@ -60,19 +60,27 @@ export function campaignTempParent(
   );
 }
 
-function nativeEnvironment() {
+export function nativeEnvironment({
+  platform = process.platform,
+  baseEnv = process.env,
+} = {}) {
   const build = path.join(ROOT, 'framework', 'core', 'build', 'Release');
   const env = {
-    ...process.env,
+    ...baseEnv,
+    // These suites qualify the freshly built source-tree binding through the
+    // locked project environment. Packaged-runtime blessedness remains owned
+    // by the separate product runtime gate, so name this source-test boundary
+    // explicitly when uv is backed by a system interpreter.
+    KUNGFU_ALLOW_FOREIGN_RUNTIME: '1',
     PYTHONPATH: [
       path.join(ROOT, 'framework', 'core', 'src', 'python'),
       build,
-      process.env.PYTHONPATH,
+      baseEnv.PYTHONPATH,
     ]
       .filter(Boolean)
       .join(path.delimiter),
   };
-  if (process.platform !== 'darwin') return env;
+  if (platform !== 'darwin') return env;
   const store = path.join(ROOT, 'node_modules', '.pnpm');
   if (!fs.existsSync(store)) return env;
   const architecture = process.arch === 'arm64' ? 'arm64' : 'x64';
@@ -91,7 +99,7 @@ function nativeEnvironment() {
     'dist',
     'node',
   );
-  env.DYLD_LIBRARY_PATH = [libnode, process.env.DYLD_LIBRARY_PATH]
+  env.DYLD_LIBRARY_PATH = [libnode, baseEnv.DYLD_LIBRARY_PATH]
     .filter(Boolean)
     .join(path.delimiter);
   return env;
@@ -113,7 +121,7 @@ export function qualificationPlan(
         'framework/core/tests/python/test_peer_lifecycle.py',
         '-q',
       ],
-      env: nativeEnvironment(),
+      env: nativeEnvironment({ platform }),
       shell: python.shell,
     },
     {
@@ -148,7 +156,7 @@ export function qualificationPlan(
         path.join(outputDir, 'native-campaign'),
         ...(tempParent ? ['--temp-parent', tempParent] : []),
       ],
-      env: nativeEnvironment(),
+      env: nativeEnvironment({ platform }),
       shell: python.shell,
     },
   ];

--- a/framework/core/tests/qualification/live-peer-continuity/run.test.mjs
+++ b/framework/core/tests/qualification/live-peer-continuity/run.test.mjs
@@ -13,6 +13,7 @@ import {
   createLogBundle,
   defaultOutputDir,
   evaluateQualification,
+  nativeEnvironment,
   nativeFailureDiagnosticTails,
   pythonInvocation,
   qualificationPlan,
@@ -86,6 +87,29 @@ test('native campaign enters Python through the Shifu-managed uv project', () =>
   assert.equal(linux.command[5], 'python');
   assert.equal(linux.shell, false);
   assert.equal(windows.shell, true);
+});
+
+test('source-tree Python suites declare the foreign-runtime qualification boundary', () => {
+  const baseEnv = { Path: 'C:\\Windows\\System32', CUSTOM_MARKER: 'preserved' };
+  const env = nativeEnvironment({ platform: 'win32', baseEnv });
+  assert.equal(env.KUNGFU_ALLOW_FOREIGN_RUNTIME, '1');
+  assert.equal(env.Path, baseEnv.Path);
+  assert.equal(env.CUSTOM_MARKER, 'preserved');
+  assert.equal(baseEnv.KUNGFU_ALLOW_FOREIGN_RUNTIME, undefined);
+
+  const pythonSuites = qualificationPlan('/qualification', {
+    platform: 'win32',
+  }).filter((suite) =>
+    ['peer-lifecycle-control-plane', 'native-cross-process-restart'].includes(
+      suite.id,
+    ),
+  );
+  assert.equal(pythonSuites.length, 2);
+  assert.ok(
+    pythonSuites.every(
+      (suite) => suite.env.KUNGFU_ALLOW_FOREIGN_RUNTIME === '1',
+    ),
+  );
 });
 
 test('native campaign uses a short platform-owned temp root', () => {

--- a/framework/core/tests/qualification/runtime-activation/run.mjs
+++ b/framework/core/tests/qualification/runtime-activation/run.mjs
@@ -342,26 +342,32 @@ export function boundedFailureTail(
     .trimStart();
 }
 
+export function suiteEnvironment(suite, baseEnv = process.env) {
+  if (!['activation-core', 'activation-performance'].includes(suite.id)) {
+    return { ...baseEnv };
+  }
+  return {
+    ...baseEnv,
+    // These suites exercise the freshly built source-tree binding. The product
+    // runtime smoke below remains fail-closed and intentionally does not inherit
+    // this named source-qualification boundary.
+    KUNGFU_ALLOW_FOREIGN_RUNTIME: '1',
+    PYTHONPATH: [
+      path.join(ROOT, 'framework', 'core', 'src', 'python'),
+      baseEnv.PYTHONPATH,
+    ]
+      .filter(Boolean)
+      .join(path.delimiter),
+  };
+}
+
 function runSuite(suite, outputDir) {
   console.log(`[runtime-activation-qualify] running ${suite.id}`);
   const started = Date.now();
   const invocation = suiteInvocation(suite);
   const result = spawnSync(invocation.command, invocation.args, {
     cwd: ROOT,
-    env: {
-      ...process.env,
-      ...(suite.id === 'activation-core' ||
-      suite.id === 'activation-performance'
-        ? {
-            PYTHONPATH: [
-              path.join(ROOT, 'framework', 'core', 'src', 'python'),
-              process.env.PYTHONPATH,
-            ]
-              .filter(Boolean)
-              .join(path.delimiter),
-          }
-        : {}),
-    },
+    env: suiteEnvironment(suite),
     encoding: 'utf8',
     maxBuffer: 128 * 1024 * 1024,
   });

--- a/framework/core/tests/qualification/runtime-activation/run.test.mjs
+++ b/framework/core/tests/qualification/runtime-activation/run.test.mjs
@@ -13,6 +13,7 @@ import {
   evaluateQualification,
   qualificationPlan,
   retainQualificationArtifacts,
+  suiteEnvironment,
   suiteInvocation,
   validateReport,
 } from './run.mjs';
@@ -107,6 +108,21 @@ test('product verification checks the distribution outputs without rebuilding th
     '--skip-episode-qualification',
   ]);
   assert.equal(verification.command.includes('--full'), false);
+});
+
+test('only source-tree Python suites allow the hosted qualification interpreter', () => {
+  const baseEnv = { Path: 'C:\\Windows\\System32', CUSTOM_MARKER: 'preserved' };
+  for (const id of ['activation-core', 'activation-performance']) {
+    const env = suiteEnvironment({ id }, baseEnv);
+    assert.equal(env.KUNGFU_ALLOW_FOREIGN_RUNTIME, '1');
+    assert.equal(env.Path, baseEnv.Path);
+    assert.equal(env.CUSTOM_MARKER, 'preserved');
+  }
+  for (const id of ['product-distribution', 'product-runtime-smoke']) {
+    const env = suiteEnvironment({ id }, baseEnv);
+    assert.equal(env.KUNGFU_ALLOW_FOREIGN_RUNTIME, undefined);
+  }
+  assert.equal(baseEnv.KUNGFU_ALLOW_FOREIGN_RUNTIME, undefined);
 });
 
 test('Windows suites invoke the repository Shifu shim through ComSpec', () => {

--- a/product/scripts/dist.mjs
+++ b/product/scripts/dist.mjs
@@ -324,8 +324,17 @@ export function esbuildPlatformBinaryPath(packageRoot, platform) {
   );
 }
 
+export function requiresManagedEsbuildPlatform({
+  noOptional,
+  hostVersion,
+  platformVersion,
+}) {
+  return noOptional && platformVersion !== hostVersion;
+}
+
 function ensureEsbuildRuntime({ slot, paths }) {
   const packageJson = require.resolve('esbuild/package.json', { paths });
+  const esbuildVersion = readJson(packageJson).version;
   const resolvePaths = [path.dirname(packageJson)];
   const packageName = esbuildPlatformPackageName();
   if (!packageName) {
@@ -333,14 +342,28 @@ function ensureEsbuildRuntime({ slot, paths }) {
       `unsupported esbuild platform: ${process.platform}-${process.arch}`,
     );
   }
+  let platformPackageJson;
+  try {
+    platformPackageJson = require.resolve(`${packageName}/package.json`, {
+      paths: resolvePaths,
+    });
+  } catch {
+    platformPackageJson = undefined;
+  }
+  const resolvedPlatformVersion = platformPackageJson
+    ? readJson(platformPackageJson).version
+    : undefined;
   if (
-    process.env.KUNGFU_BUILDCHAIN_NO_OPTIONAL === '1' &&
-    !canResolveFrom(packageName, resolvePaths)
+    requiresManagedEsbuildPlatform({
+      noOptional: process.env.KUNGFU_BUILDCHAIN_NO_OPTIONAL === '1',
+      hostVersion: esbuildVersion,
+      platformVersion: resolvedPlatformVersion,
+    })
   ) {
     const nodePath = ensureNoOptionalPlatformPackage({
       kind: `esbuild.${slot}`,
       packageName,
-      version: readJson(packageJson).version,
+      version: esbuildVersion,
       installRoot: path.join(
         ROOT,
         '.buildchain',
@@ -349,11 +372,17 @@ function ensureEsbuildRuntime({ slot, paths }) {
         `${process.platform}-${process.arch}`,
       ),
     });
-    resolvePaths.push(path.dirname(nodePath));
+    platformPackageJson = packageJsonPath(nodePath, packageName);
   }
-  const platformPackageJson = require.resolve(`${packageName}/package.json`, {
-    paths: resolvePaths,
-  });
+  if (!platformPackageJson) {
+    throw new Error(`missing ${packageName} for esbuild ${esbuildVersion}`);
+  }
+  const platformVersion = readJson(platformPackageJson).version;
+  if (platformVersion !== esbuildVersion) {
+    throw new Error(
+      `esbuild host ${esbuildVersion} does not match ${packageName} ${platformVersion}`,
+    );
+  }
   const binaryPath = esbuildPlatformBinaryPath(
     path.dirname(platformPackageJson),
     process.platform,

--- a/product/scripts/dist.mjs
+++ b/product/scripts/dist.mjs
@@ -373,6 +373,7 @@ function ensureEsbuildRuntime({ slot, paths }) {
       ),
     });
     platformPackageJson = packageJsonPath(nodePath, packageName);
+    resolvePaths.unshift(path.dirname(nodePath));
   }
   if (!platformPackageJson) {
     throw new Error(`missing ${packageName} for esbuild ${esbuildVersion}`);

--- a/product/scripts/dist.test.mjs
+++ b/product/scripts/dist.test.mjs
@@ -240,6 +240,7 @@ test('Buildchain stages exact esbuild binaries per product surface', () => {
   assert.match(dist, /esbuild-platform',\s+slot/);
   assert.match(dist, /installedVersion !== version/);
   assert.match(dist, /requiresManagedEsbuildPlatform/);
+  assert.match(dist, /resolvePaths\.unshift\(path\.dirname\(nodePath\)\)/);
   assert.match(
     dist,
     /esbuild host \$\{esbuildVersion\} does not match \$\{packageName\} \$\{platformVersion\}/,

--- a/product/scripts/dist.test.mjs
+++ b/product/scripts/dist.test.mjs
@@ -12,6 +12,7 @@ import {
   desktopUpdaterArtifact,
   esbuildPlatformBinaryPath,
   kfxBundleExternalModules,
+  requiresManagedEsbuildPlatform,
   verifyProductObservabilityEvents,
 } from './dist.mjs';
 
@@ -238,6 +239,11 @@ test('Buildchain stages exact esbuild binaries per product surface', () => {
   }
   assert.match(dist, /esbuild-platform',\s+slot/);
   assert.match(dist, /installedVersion !== version/);
+  assert.match(dist, /requiresManagedEsbuildPlatform/);
+  assert.match(
+    dist,
+    /esbuild host \$\{esbuildVersion\} does not match \$\{packageName\} \$\{platformVersion\}/,
+  );
   assert.match(dist, /buildKfx\(kfxPackages, sdkBuildEnv\)/);
   assert.match(dist, /'bundle tui',[\s\S]+?env: tuiBuildEnv/);
   assert.match(dist, /'build gui',[\s\S]+?env: guiBuildEnv/);
@@ -269,5 +275,32 @@ test('esbuild platform binary follows the native package layout', () => {
   assert.equal(
     esbuildPlatformBinaryPath('/pkg', 'darwin'),
     path.join('/pkg', 'bin', 'esbuild'),
+  );
+});
+
+test('no-optional builds isolate a mismatched esbuild platform binary', () => {
+  assert.equal(
+    requiresManagedEsbuildPlatform({
+      noOptional: true,
+      hostVersion: '0.25.12',
+      platformVersion: '0.28.1',
+    }),
+    true,
+  );
+  assert.equal(
+    requiresManagedEsbuildPlatform({
+      noOptional: true,
+      hostVersion: '0.25.12',
+      platformVersion: '0.25.12',
+    }),
+    false,
+  );
+  assert.equal(
+    requiresManagedEsbuildPlatform({
+      noOptional: false,
+      hostVersion: '0.25.12',
+      platformVersion: '0.28.1',
+    }),
+    false,
   );
 });

--- a/scripts/run-release-qualification.test.mjs
+++ b/scripts/run-release-qualification.test.mjs
@@ -209,6 +209,27 @@ test('alpha and release qualification retain the cross-layer desktop report and 
   }
 });
 
+test('the Buildchain artifact contract requires every retained report and raw bundle', () => {
+  const workflow = fs.readFileSync(
+    path.join(process.cwd(), '.github', 'workflows', 'build.yml'),
+    'utf8',
+  );
+  const encoded = workflow.match(
+    /expected-artifacts-json: >-\n\s+(\{[^\n]+\})/u,
+  )?.[1];
+  assert.ok(encoded, 'build workflow must declare expected-artifacts-json');
+  const expected = JSON.parse(encoded);
+  assert.deepEqual(expected.requiredPaths, [
+    'product/release/qualification/layer-qualification-summary.json',
+    'product/release/qualification/live-peer-continuity/report.json',
+    'product/release/qualification/live-peer-continuity/raw-logs.jsonl.gz',
+    'product/release/qualification/runtime-activation/report.json',
+    'product/release/qualification/runtime-activation/raw-logs.jsonl.gz',
+    'product/release/qualification/zero-burden-desktop/report.json',
+    'product/release/qualification/zero-burden-desktop/raw-logs.jsonl.gz',
+  ]);
+});
+
 test('the Gate stage emits one source-bound receipt for all artifact layers', () => {
   const gateStage = releaseQualificationStages('darwin').find(
     ([name]) => name === 'gate',

--- a/scripts/run-shifu-lifecycle.mjs
+++ b/scripts/run-shifu-lifecycle.mjs
@@ -32,7 +32,10 @@ export function cmdCommand(shim, args) {
       'Windows Shifu lifecycle arguments contain unsafe cmd syntax',
     );
   const quote = (value) => `"${String(value).replaceAll('"', '""')}"`;
-  return [shim, ...args].map(quote).join(' ');
+  const command = /^[A-Za-z0-9_.-]+$/.test(String(shim))
+    ? String(shim)
+    : quote(shim);
+  return [command, ...args.map(quote)].join(' ');
 }
 
 /** Run the canonical repository shim without assuming bash exists on Windows. */
@@ -43,13 +46,20 @@ export function runShifu(args, options = {}) {
   let result;
   if (platform === 'win32') {
     const command = options.comspec || env.ComSpec || env.COMSPEC || 'cmd.exe';
-    const shim = path.join(root, 'shifu.cmd');
-    result = spawnSync(cmdCommand(shim, args), [], {
-      cwd: root,
-      env,
-      stdio: options.stdio || 'inherit',
-      shell: command,
-    });
+    // Match the proven cache-runtime invocation: with `cmd /s /c`, quoting an
+    // absolute command name can make cmd preserve the quotes as part of the
+    // executable token.  The welded shim is in cwd, so invoke its safe bare
+    // name and quote only its arguments.
+    result = spawnSync(
+      command,
+      ['/d', '/s', '/c', cmdCommand('shifu.cmd', args)],
+      {
+        cwd: root,
+        env,
+        stdio: options.stdio || 'inherit',
+        shell: false,
+      },
+    );
   } else {
     result = spawnSync(path.join(root, 'shifu'), args, {
       cwd: root,

--- a/scripts/run-shifu-lifecycle.mjs
+++ b/scripts/run-shifu-lifecycle.mjs
@@ -65,6 +65,7 @@ export function runShifu(args, options = {}) {
       env,
       stdio: options.stdio || 'inherit',
       shell: false,
+      windowsVerbatimArguments: true,
     });
   } else {
     result = spawnSync(path.join(root, 'shifu'), args, {

--- a/scripts/run-shifu-lifecycle.mjs
+++ b/scripts/run-shifu-lifecycle.mjs
@@ -31,7 +31,11 @@ export function cmdCommand(shim, args) {
     throw new Error(
       'Windows Shifu lifecycle arguments contain unsafe cmd syntax',
     );
-  const quote = (value) => `"${String(value).replaceAll('"', '""')}"`;
+  const quote = (value) => {
+    const text = String(value);
+    if (/^[A-Za-z0-9_./:@=+\\-]+$/.test(text)) return text;
+    return `"${text.replaceAll('"', '""')}"`;
+  };
   const command = /^[A-Za-z0-9_.-]+$/.test(String(shim))
     ? String(shim)
     : quote(shim);

--- a/scripts/run-shifu-lifecycle.mjs
+++ b/scripts/run-shifu-lifecycle.mjs
@@ -43,11 +43,11 @@ export function cmdCommand(shim, args) {
 }
 
 export function windowsCmdArgs(shim, args) {
-  if ([shim, ...args].some((value) => /[\r\n%!&|<>^()"]/.test(String(value))))
+  if ([shim, ...args].some((value) => /[\r\n%!&|<>^]/.test(String(value))))
     throw new Error(
       'Windows Shifu lifecycle arguments contain unsafe cmd syntax',
     );
-  return ['/d', '/s', '/c', 'call', String(shim), ...args.map(String)];
+  return ['/d', '/s', '/c', `call ${cmdCommand(shim, args)}`];
 }
 
 /** Run the canonical repository shim without assuming bash exists on Windows. */

--- a/scripts/run-shifu-lifecycle.mjs
+++ b/scripts/run-shifu-lifecycle.mjs
@@ -42,6 +42,14 @@ export function cmdCommand(shim, args) {
   return [command, ...args.map(quote)].join(' ');
 }
 
+export function windowsCmdArgs(shim, args) {
+  if ([shim, ...args].some((value) => /[\r\n%!&|<>^()"]/.test(String(value))))
+    throw new Error(
+      'Windows Shifu lifecycle arguments contain unsafe cmd syntax',
+    );
+  return ['/d', '/s', '/c', 'call', String(shim), ...args.map(String)];
+}
+
 /** Run the canonical repository shim without assuming bash exists on Windows. */
 export function runShifu(args, options = {}) {
   const platform = options.platform || process.platform;
@@ -50,20 +58,14 @@ export function runShifu(args, options = {}) {
   let result;
   if (platform === 'win32') {
     const command = options.comspec || env.ComSpec || env.COMSPEC || 'cmd.exe';
-    // Match the proven cache-runtime invocation: with `cmd /s /c`, quoting an
-    // absolute command name can make cmd preserve the quotes as part of the
-    // executable token.  The welded shim is in cwd, so invoke its safe bare
-    // name and quote only its arguments.
-    result = spawnSync(
-      command,
-      ['/d', '/s', '/c', cmdCommand('shifu.cmd', args)],
-      {
-        cwd: root,
-        env,
-        stdio: options.stdio || 'inherit',
-        shell: false,
-      },
-    );
+    // A batch wrapper must be entered through `call` so its argument vector
+    // survives both cmd.exe and the shim's own dispatch boundary.
+    result = spawnSync(command, windowsCmdArgs('shifu.cmd', args), {
+      cwd: root,
+      env,
+      stdio: options.stdio || 'inherit',
+      shell: false,
+    });
   } else {
     result = spawnSync(path.join(root, 'shifu'), args, {
       cwd: root,

--- a/scripts/run-shifu-lifecycle.test.mjs
+++ b/scripts/run-shifu-lifecycle.test.mjs
@@ -10,6 +10,7 @@ import {
   cmdCommand,
   lifecycleEnvironment,
   runShifu,
+  windowsCmdArgs,
 } from './run-shifu-lifecycle.mjs';
 
 test('wraps an arbitrary child command in one cache projection', () => {
@@ -120,6 +121,32 @@ test('quotes a Windows shim payload and rejects expansion syntax', () => {
   );
   assert.throws(
     () => cmdCommand('C:\\repo\\shifu.cmd', ['task%PATH%']),
+    /unsafe cmd syntax/,
+  );
+});
+
+test('enters a Windows batch shim through call with an exact argument vector', () => {
+  assert.deepEqual(
+    windowsCmdArgs('shifu.cmd', [
+      'cache',
+      'apply',
+      '--',
+      'C:\\Program Files\\node.exe',
+    ]),
+    [
+      '/d',
+      '/s',
+      '/c',
+      'call',
+      'shifu.cmd',
+      'cache',
+      'apply',
+      '--',
+      'C:\\Program Files\\node.exe',
+    ],
+  );
+  assert.throws(
+    () => windowsCmdArgs('shifu.cmd', ['task&whoami']),
     /unsafe cmd syntax/,
   );
 });

--- a/scripts/run-shifu-lifecycle.test.mjs
+++ b/scripts/run-shifu-lifecycle.test.mjs
@@ -111,6 +111,10 @@ test('runs the Unix shim without a shell', () => {
 
 test('quotes a Windows shim payload and rejects expansion syntax', () => {
   assert.equal(
+    cmdCommand('shifu.cmd', ['verify', '--fuzz']),
+    'shifu.cmd "verify" "--fuzz"',
+  );
+  assert.equal(
     cmdCommand('C:\\repo path\\shifu.cmd', ['install', '--frozen-lockfile']),
     '"C:\\repo path\\shifu.cmd" "install" "--frozen-lockfile"',
   );

--- a/scripts/run-shifu-lifecycle.test.mjs
+++ b/scripts/run-shifu-lifecycle.test.mjs
@@ -137,12 +137,21 @@ test('enters a Windows batch shim through call with an exact argument vector', (
       '/d',
       '/s',
       '/c',
-      'call',
-      'shifu.cmd',
-      'cache',
-      'apply',
-      '--',
-      'C:\\Program Files\\node.exe',
+      'call shifu.cmd cache apply -- "C:\\Program Files\\node.exe"',
+    ],
+  );
+  assert.deepEqual(
+    windowsCmdArgs('shifu.cmd', [
+      'gate',
+      'run',
+      '--execution-context',
+      '{"executionProfile":"alpha"}',
+    ]),
+    [
+      '/d',
+      '/s',
+      '/c',
+      'call shifu.cmd gate run --execution-context "{""executionProfile"":""alpha""}"',
     ],
   );
   assert.throws(

--- a/scripts/run-shifu-lifecycle.test.mjs
+++ b/scripts/run-shifu-lifecycle.test.mjs
@@ -112,11 +112,11 @@ test('runs the Unix shim without a shell', () => {
 test('quotes a Windows shim payload and rejects expansion syntax', () => {
   assert.equal(
     cmdCommand('shifu.cmd', ['verify', '--fuzz']),
-    'shifu.cmd "verify" "--fuzz"',
+    'shifu.cmd verify --fuzz',
   );
   assert.equal(
     cmdCommand('C:\\repo path\\shifu.cmd', ['install', '--frozen-lockfile']),
-    '"C:\\repo path\\shifu.cmd" "install" "--frozen-lockfile"',
+    '"C:\\repo path\\shifu.cmd" install --frozen-lockfile',
   );
   assert.throws(
     () => cmdCommand('C:\\repo\\shifu.cmd', ['task%PATH%']),

--- a/scripts/run-zero-burden-product-qualification.mjs
+++ b/scripts/run-zero-burden-product-qualification.mjs
@@ -10,7 +10,7 @@ import process from 'node:process';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { gzipSync } from 'node:zlib';
 
-import { cmdCommand } from './run-shifu-lifecycle.mjs';
+import { windowsCmdArgs } from './run-shifu-lifecycle.mjs';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const LAUNCHER = process.platform === 'win32' ? 'shifu.cmd' : './shifu';
@@ -63,9 +63,8 @@ export function qualificationSuiteInvocation(suite, options = {}) {
   if (platform !== 'win32' || command !== 'shifu.cmd') return { command, args };
   const env = options.env || process.env;
   return {
-    command: cmdCommand(path.win32.join(root, 'shifu.cmd'), args),
-    args: [],
-    shell: options.comspec || env.ComSpec || env.COMSPEC || 'cmd.exe',
+    command: options.comspec || env.ComSpec || env.COMSPEC || 'cmd.exe',
+    args: windowsCmdArgs(path.win32.join(root, 'shifu.cmd'), args),
   };
 }
 

--- a/scripts/run-zero-burden-product-qualification.mjs
+++ b/scripts/run-zero-burden-product-qualification.mjs
@@ -65,6 +65,7 @@ export function qualificationSuiteInvocation(suite, options = {}) {
   return {
     command: options.comspec || env.ComSpec || env.COMSPEC || 'cmd.exe',
     args: windowsCmdArgs(path.win32.join(root, 'shifu.cmd'), args),
+    windowsVerbatimArguments: true,
   };
 }
 
@@ -185,6 +186,7 @@ export async function runSuite(suite, outputDir, options = {}) {
     detached: platform !== 'win32',
     stdio: ['ignore', 'pipe', 'pipe'],
     windowsHide: true,
+    windowsVerbatimArguments: invocation.windowsVerbatimArguments === true,
     ...(invocation.shell ? { shell: invocation.shell } : {}),
   });
   child.stdout?.on('data', (chunk) => append(stdout, chunk));

--- a/scripts/run-zero-burden-product-qualification.mjs
+++ b/scripts/run-zero-burden-product-qualification.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 
-import { spawnSync } from 'node:child_process';
+import { spawn, spawnSync } from 'node:child_process';
 import crypto from 'node:crypto';
 import fs from 'node:fs';
 import os from 'node:os';
@@ -15,6 +15,8 @@ import { cmdCommand } from './run-shifu-lifecycle.mjs';
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const LAUNCHER = process.platform === 'win32' ? 'shifu.cmd' : './shifu';
 const SCHEMA = 'kungfu.zero-burden-desktop.qualification/v1';
+const DEFAULT_SUITE_TIMEOUT_MS = 30 * 60 * 1000;
+const SUITE_TERMINATION_GRACE_MS = 5 * 1000;
 
 const COMPONENTS = [
   {
@@ -123,24 +125,111 @@ export function validateComponentEvidence(root, component, expected) {
   };
 }
 
-function runSuite(suite, outputDir) {
+function suiteTimeout(environment = process.env) {
+  const configured = environment.KUNGFU_ZERO_BURDEN_SUITE_TIMEOUT_MS;
+  if (!configured) return DEFAULT_SUITE_TIMEOUT_MS;
+  const timeout = Number(configured);
+  if (!Number.isSafeInteger(timeout) || timeout <= 0)
+    throw new Error(
+      'KUNGFU_ZERO_BURDEN_SUITE_TIMEOUT_MS must be a positive integer',
+    );
+  return timeout;
+}
+
+function terminateSuiteProcess(child, platform = process.platform) {
+  if (!child.pid) return 'qualification suite has no process id to terminate';
+  if (platform === 'win32') {
+    const result = spawnSync(
+      'taskkill.exe',
+      ['/pid', String(child.pid), '/t', '/f'],
+      { encoding: 'utf8', windowsHide: true },
+    );
+    return [result.error?.message, result.stdout, result.stderr]
+      .filter(Boolean)
+      .join('\n')
+      .trim();
+  }
+  try {
+    process.kill(-child.pid, 'SIGTERM');
+    return '';
+  } catch (error) {
+    child.kill('SIGTERM');
+    return error?.message || String(error);
+  }
+}
+
+export async function runSuite(suite, outputDir, options = {}) {
   const started = Date.now();
-  const invocation = qualificationSuiteInvocation(suite);
-  console.log(`[zero-burden-qualify] running ${suite.id}`);
-  const result = spawnSync(invocation.command, invocation.args, {
-    cwd: ROOT,
-    env: qualificationSuiteEnvironment(),
-    encoding: 'utf8',
-    maxBuffer: 128 * 1024 * 1024,
+  const platform = options.platform || process.platform;
+  const environment = options.env || process.env;
+  const timeoutMs = options.timeoutMs || suiteTimeout(environment);
+  const invocation = qualificationSuiteInvocation(suite, {
+    platform,
+    root: options.root || ROOT,
+    env: environment,
+    comspec: options.comspec,
+  });
+  const stdout = options.stdout || process.stdout;
+  const stderr = options.stderr || process.stderr;
+  const chunks = [];
+  const append = (target, chunk) => {
+    const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    chunks.push(bytes);
+    target.write(bytes);
+  };
+  console.log(
+    `[zero-burden-qualify] running ${suite.id} timeout_ms=${timeoutMs}`,
+  );
+  const child = (options.spawn || spawn)(invocation.command, invocation.args, {
+    cwd: options.root || ROOT,
+    env: qualificationSuiteEnvironment(environment),
+    detached: platform !== 'win32',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    windowsHide: true,
     ...(invocation.shell ? { shell: invocation.shell } : {}),
   });
-  const launchError = result.error
-    ? `[zero-burden-qualify] launch_error=${result.error.stack || String(result.error)}\n`
-    : '';
-  const output = `${launchError}${result.stdout || ''}${result.stderr || ''}`;
+  child.stdout?.on('data', (chunk) => append(stdout, chunk));
+  child.stderr?.on('data', (chunk) => append(stderr, chunk));
+
+  let launchError = null;
+  let timedOut = false;
+  const result = await new Promise((resolve) => {
+    let settled = false;
+    let graceTimer = null;
+    const finish = (exitCode, signal) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeoutTimer);
+      if (graceTimer) clearTimeout(graceTimer);
+      resolve({ exitCode, signal });
+    };
+    child.once('error', (error) => {
+      launchError = error;
+      append(
+        stderr,
+        `[zero-burden-qualify] launch_error=${error.stack || String(error)}\n`,
+      );
+    });
+    child.once('close', finish);
+    const timeoutTimer = setTimeout(() => {
+      timedOut = true;
+      append(
+        stderr,
+        `[zero-burden-qualify] suite=${suite.id} timed_out_after_ms=${timeoutMs}\n`,
+      );
+      const diagnostic = terminateSuiteProcess(child, platform);
+      if (diagnostic)
+        append(stderr, `[zero-burden-qualify] termination=${diagnostic}\n`);
+      graceTimer = setTimeout(
+        () => finish(child.exitCode, child.signalCode),
+        SUITE_TERMINATION_GRACE_MS,
+      );
+    }, timeoutMs);
+  });
+  const output = Buffer.concat(chunks);
   const rawLog = `${suite.id}.log`;
   fs.writeFileSync(path.join(outputDir, rawLog), output, { flag: 'wx' });
-  const passed = !result.error && result.status === 0;
+  const passed = !launchError && !timedOut && result.exitCode === 0;
   console.log(
     `[zero-burden-qualify] suite=${suite.id} status=${passed ? 'passed' : 'failed'} duration_ms=${Date.now() - started}`,
   );
@@ -148,7 +237,10 @@ function runSuite(suite, outputDir) {
     id: suite.id,
     command: suite.command,
     status: passed ? 'passed' : 'failed',
-    exit_code: result.status,
+    exit_code: result.exitCode,
+    signal: result.signal,
+    timed_out: timedOut,
+    timeout_ms: timeoutMs,
     duration_ms: Date.now() - started,
     raw_log: rawLog,
     raw_sha256: sha256(output),
@@ -297,9 +389,9 @@ async function main() {
   const components = COMPONENTS.map((component) =>
     validateComponentEvidence(ROOT, component, expected),
   );
-  const suites = QUALIFICATION_SUITES.map((suite) =>
-    runSuite(suite, outputDir),
-  );
+  const suites = [];
+  for (const suite of QUALIFICATION_SUITES)
+    suites.push(await runSuite(suite, outputDir));
   const bundle = createLogBundle(outputDir, suites);
   const report = evaluateQualification({
     source,

--- a/scripts/run-zero-burden-product-qualification.mjs
+++ b/scripts/run-zero-burden-product-qualification.mjs
@@ -126,6 +126,7 @@ export function validateComponentEvidence(root, component, expected) {
 function runSuite(suite, outputDir) {
   const started = Date.now();
   const invocation = qualificationSuiteInvocation(suite);
+  console.log(`[zero-burden-qualify] running ${suite.id}`);
   const result = spawnSync(invocation.command, invocation.args, {
     cwd: ROOT,
     env: qualificationSuiteEnvironment(),

--- a/scripts/run-zero-burden-product-qualification.test.mjs
+++ b/scripts/run-zero-burden-product-qualification.test.mjs
@@ -134,12 +134,17 @@ test('Windows suites invoke the repository Shifu shim through ComSpec', () => {
       env: {},
     },
   );
-  assert.equal(invocation.shell, 'C:\\Windows\\System32\\cmd.exe');
-  assert.deepEqual(invocation.args, []);
-  assert.equal(
-    invocation.command,
-    '"C:\\kungfu checkout\\shifu.cmd" "--filter" "workspace with spaces" "test"',
-  );
+  assert.equal(invocation.command, 'C:\\Windows\\System32\\cmd.exe');
+  assert.deepEqual(invocation.args, [
+    '/d',
+    '/s',
+    '/c',
+    'call',
+    'C:\\kungfu checkout\\shifu.cmd',
+    '--filter',
+    'workspace with spaces',
+    'test',
+  ]);
 });
 
 test('Windows suite invocation rejects cmd expansion syntax', () => {

--- a/scripts/run-zero-burden-product-qualification.test.mjs
+++ b/scripts/run-zero-burden-product-qualification.test.mjs
@@ -135,6 +135,7 @@ test('Windows suites invoke the repository Shifu shim through ComSpec', () => {
     },
   );
   assert.equal(invocation.command, 'C:\\Windows\\System32\\cmd.exe');
+  assert.equal(invocation.windowsVerbatimArguments, true);
   assert.deepEqual(invocation.args, [
     '/d',
     '/s',

--- a/scripts/run-zero-burden-product-qualification.test.mjs
+++ b/scripts/run-zero-burden-product-qualification.test.mjs
@@ -139,11 +139,7 @@ test('Windows suites invoke the repository Shifu shim through ComSpec', () => {
     '/d',
     '/s',
     '/c',
-    'call',
-    'C:\\kungfu checkout\\shifu.cmd',
-    '--filter',
-    'workspace with spaces',
-    'test',
+    'call "C:\\kungfu checkout\\shifu.cmd" --filter "workspace with spaces" test',
   ]);
 });
 

--- a/scripts/run-zero-burden-product-qualification.test.mjs
+++ b/scripts/run-zero-burden-product-qualification.test.mjs
@@ -216,16 +216,20 @@ test('qualification suites fail boundedly and retain timeout diagnostics', async
 });
 
 test('native Windows qualification reaps only its exact test-owned process tree', () => {
-  const source = fs.readFileSync(
-    path.join(
-      process.cwd(),
-      'framework/agent-session/tests/runtime-port.native.test.mjs',
-    ),
-    'utf8',
-  );
-  assert.match(source, /command: 'taskkill\.exe'/u);
-  assert.match(source, /args: \['\/pid', String\(pid\), '\/t', '\/f'\]/u);
-  assert.doesNotMatch(source, /\/im/u);
+  for (const relative of [
+    'framework/agent-session/tests/runtime-port.native.test.mjs',
+    'framework/agent-session/tests/capsule-worker.test.mjs',
+    'framework/agent-session/tests/codex-app-server-runtime.test.mjs',
+  ]) {
+    const source = fs.readFileSync(path.join(process.cwd(), relative), 'utf8');
+    assert.match(source, /'taskkill\.exe'/u, relative);
+    assert.match(
+      source,
+      /\['\/pid', String\((?:pid|child\.pid)\), '\/t', '\/f'\]/u,
+      relative,
+    );
+    assert.doesNotMatch(source, /\/im/u, relative);
+  }
 });
 
 test('provider approval dogfood delegates confirmation to the permission system', () => {

--- a/scripts/run-zero-burden-product-qualification.test.mjs
+++ b/scripts/run-zero-burden-product-qualification.test.mjs
@@ -12,6 +12,7 @@ import {
   evaluateQualification,
   qualificationSuiteEnvironment,
   qualificationSuiteInvocation,
+  runSuite,
   validateComponentEvidence,
 } from './run-zero-burden-product-qualification.mjs';
 
@@ -148,6 +149,69 @@ test('Windows suite invocation rejects cmd expansion syntax', () => {
         { platform: 'win32', root: 'C:\\kungfu', env: {} },
       ),
     /unsafe cmd syntax/,
+  );
+});
+
+test('qualification suites tee live output into retained raw evidence', async (t) => {
+  const outputDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'kungfu-zero-burden-suite-'),
+  );
+  t.after(() => fs.rmSync(outputDir, { recursive: true, force: true }));
+  const liveStdout = [];
+  const liveStderr = [];
+  const result = await runSuite(
+    {
+      id: 'live-tee-fixture',
+      command: [
+        process.execPath,
+        '-e',
+        "process.stdout.write('visible stdout\\n'); process.stderr.write('visible stderr\\n')",
+      ],
+    },
+    outputDir,
+    {
+      timeoutMs: 5_000,
+      stdout: { write: (chunk) => liveStdout.push(chunk.toString('utf8')) },
+      stderr: { write: (chunk) => liveStderr.push(chunk.toString('utf8')) },
+    },
+  );
+  assert.equal(result.status, 'passed');
+  assert.equal(result.timed_out, false);
+  assert.match(liveStdout.join(''), /visible stdout/u);
+  assert.match(liveStderr.join(''), /visible stderr/u);
+  const retained = fs.readFileSync(
+    path.join(outputDir, result.raw_log),
+    'utf8',
+  );
+  assert.match(retained, /visible stdout/u);
+  assert.match(retained, /visible stderr/u);
+  assert.equal(result.raw_sha256, sha256(Buffer.from(retained)));
+});
+
+test('qualification suites fail boundedly and retain timeout diagnostics', async (t) => {
+  const outputDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'kungfu-zero-burden-timeout-'),
+  );
+  t.after(() => fs.rmSync(outputDir, { recursive: true, force: true }));
+  const liveStderr = [];
+  const result = await runSuite(
+    {
+      id: 'timeout-fixture',
+      command: [process.execPath, '-e', 'setInterval(() => {}, 1000)'],
+    },
+    outputDir,
+    {
+      timeoutMs: 100,
+      stdout: { write: () => {} },
+      stderr: { write: (chunk) => liveStderr.push(chunk.toString('utf8')) },
+    },
+  );
+  assert.equal(result.status, 'failed');
+  assert.equal(result.timed_out, true);
+  assert.match(liveStderr.join(''), /timed_out_after_ms=100/u);
+  assert.match(
+    fs.readFileSync(path.join(outputDir, result.raw_log), 'utf8'),
+    /timed_out_after_ms=100/u,
   );
 });
 

--- a/scripts/run-zero-burden-product-qualification.test.mjs
+++ b/scripts/run-zero-burden-product-qualification.test.mjs
@@ -105,6 +105,7 @@ test('aggregate control-plane coverage is independent of installed provider CLIs
     manifest.scripts['test:control-plane'],
     /skip-pattern=installed/u,
   );
+  assert.match(manifest.scripts['test:control-plane'], /--test-concurrency=1/u);
 });
 
 test('qualification suites restore the stable host temp for process endpoints', () => {

--- a/scripts/run-zero-burden-product-qualification.test.mjs
+++ b/scripts/run-zero-burden-product-qualification.test.mjs
@@ -151,6 +151,19 @@ test('Windows suite invocation rejects cmd expansion syntax', () => {
   );
 });
 
+test('native Windows qualification reaps only its exact test-owned process tree', () => {
+  const source = fs.readFileSync(
+    path.join(
+      process.cwd(),
+      'framework/agent-session/tests/runtime-port.native.test.mjs',
+    ),
+    'utf8',
+  );
+  assert.match(source, /command: 'taskkill\.exe'/u);
+  assert.match(source, /args: \['\/pid', String\(pid\), '\/t', '\/f'\]/u);
+  assert.doesNotMatch(source, /\/im/u);
+});
+
 test('provider approval dogfood delegates confirmation to the permission system', () => {
   const source = fs.readFileSync(
     path.join(process.cwd(), 'scripts/run-agent-session-provider-dogfood.mjs'),


### PR DESCRIPTION
## Summary

- declare the foreign-runtime allowance only for qualification suites that exercise the freshly built source-tree Python binding
- cover Episode workers, live-Peer native campaigns, and runtime-activation source suites while keeping product distribution and packaged-runtime smoke fail-closed
- register source-build artifacts from the tracked KFD-3 declaration only inside the explicit `KUNGFU_BUILDCHAIN_SOURCE_BUILD=1` boundary
- run the complete alpha/release qualification under a bounded 180-minute Buildchain lifecycle window so Windows can retain its final evidence instead of being cancelled at the 120-minute default
- sync the candidate with `dev/v4/v4.0@1ebbf2e9b3b8c380d8597b3a7bf95cac63af3e0f`

## Root cause and qualification evidence

Hosted Windows uses a locked uv environment whose base interpreter is runner-provided CPython. The runtime guard correctly rejects that interpreter unless the source qualification harness declares the existing named boundary. Stable Buildchain v2.13.0 retains exact binary evidence but does not publish a standalone release binary, so the source-build boundary must use the tracked KFD-3 declaration without changing ordinary layout discovery.

- run `29513870056`: Episode, live Peer, runtime activation, product distribution, runtime smoke, and product verification passed; product catalog exposed the missing source-build registration boundary
- run `29521465645`: re-proved the exact three-platform Buildchain `v2.13.0@ec48c0b311212c5f3a591e0284da6e85a9fdded5` binary evidence
- run `29528999557` at `31286590a712fcf26141a3adc79c74128c6139ab`: macOS and Linux completed live Peer, runtime activation, and zero-burden qualification; all six downloaded reports were `passed` and all six adjacent `raw-logs.jsonl.gz` bundles matched manifest SHA256 and passed gzip integrity
- run `29528996759` at the same head: Windows passed live Peer and runtime activation, then the complete zero-burden campaign reached the 120-minute lifecycle limit
- exact candidate: `9e83fafd037e3e50fc860ee82cbff21db2116f2e`, tree `c7f8a4cfc1000aa74f978b60ec2517c76aba7525`
- current hosted Windows qualification: `29542317309`
- current full self-hosted matrix: `29542319870`

## Validation

- `./shifu check:source` (source acceptance 381/381, runtime upgrade 76/76, Desktop 69/69)
- source-runtime boundary tests, registrar tests, Rust workspace tests, Clippy, Biome, architecture, documentation, Shifu, and Buildchain contract gates
- workflow authority digest refreshed after the lifecycle timeout change
- DCO sign-off on every commit

Do not merge until the current exact-head Windows/full-matrix run and PR checks are green and the retained report/raw-log pairs are audited.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Repairs source-qualification environment, source-build artifact registration, and bounded qualification execution without changing runtime architecture, packaged-runtime admission, or product claims."
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

This PR changes qualification and source-build registration boundaries only; it does not publish or deploy artifacts.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Source acceptance is green locally
- [x] No credentials or generated qualification evidence are committed
