### PR TITLE
fix(mission-control): close native review evidence gaps

### DIFF
--- a/docs/adr/ADR-0104-native-mission-go-authority-cutover.md
+++ b/docs/adr/ADR-0104-native-mission-go-authority-cutover.md
@@ -4,7 +4,7 @@ doc_type: architecture-decision
 adr_id: ADR-0104
 decision_status: accepted
 implementation_status: staged
-implementation_prs: []
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/978, https://github.com/kungfu-systems/kungfu/pull/997]
 qualification_refs: [framework/core/tests/python/test_atlas_storage.py, extensions/mission-control/migrations/registry.json, framework/core/src/python/kungfu/agent/kfd3_api.registry.json]
 review_state: self-reviewed
 sensitivity: public
@@ -12,7 +12,7 @@ sources: [local-files, user-consensus]
 period: 2026-07-16
 theme: native-mission-go-authority-cutover
 confidence: high
-evidence_grade: B
+evidence_grade: A
 last_reviewed: 2026-07-16
 ---
 
@@ -100,3 +100,19 @@ to be runtime truth and without carrying a permanent dual-writer bridge. The
 extra parity and root inputs make cutover deliberately explicit. Rollback is a
 new forward event rather than state erasure, so a later re-cutover must prove a
 fresh parity basis.
+
+## Stage-ready qualification
+
+The real-control-plane qualification imported 799 Atlas Mission/Go records,
+proved exact parity, cut authority over once, and exercised the native
+create/claim/review/continuation path before an append-only rollback restored
+the Atlas adapter. The post-rollback native write failed closed and a later
+Atlas import admitted newly observed facts without deleting native history.
+
+The same run exposed two review-path defects that PR #997 repairs and retains:
+the synchronous completion review was incorrectly classified as a live-runtime
+assessment request, and a multi-batch Mission query omitted its composed row
+count. The Profile action now uses the storage-only Episode append boundary and
+the query receipt binds all 586 canonical facts seen by the independent
+assessment. `test_agent_profile_sdk.py` and `test_atlas_storage.py` keep both
+failures in the stage-ready gate.

--- a/extensions/mission-control/actions/registry.json
+++ b/extensions/mission-control/actions/registry.json
@@ -66,7 +66,7 @@
       "title": "Review completion independently",
       "runner": "kfx-member",
       "operation": "mission-control-actions",
-      "runtimeOperation": "assessment.request",
+      "runtimeOperation": "episode.append",
       "authorityClass": "independent-reviewer",
       "requiredCapabilities": ["storage"],
       "effects": [

--- a/extensions/mission-control/mission-control-actions/domain/mission_control.py
+++ b/extensions/mission-control/mission-control-actions/domain/mission_control.py
@@ -645,6 +645,7 @@ def _batched_state_query(
             }
         ),
         "result_hash": result_hash,
+        "row_count": len(rows),
         "rows": rows,
         "lineage": lineage,
     }

--- a/extensions/mission-control/profile.json
+++ b/extensions/mission-control/profile.json
@@ -57,7 +57,7 @@
   "actions": {
     "registry": {
       "path": "actions/registry.json",
-      "sha256": "d371a9a7b50eb03a13c20d2bd9519ec2911637d23a626916e3752256288f0ff9"
+      "sha256": "d3c686ddd1ba5034a4e8c5e9231158d15b06008c43cef05693dc516de829376a"
     }
   },
   "views": {

--- a/framework/core/tests/python/test_agent_profile_sdk.py
+++ b/framework/core/tests/python/test_agent_profile_sdk.py
@@ -1252,6 +1252,31 @@ def test_live_profile_action_plan_fails_without_native_evidence(tmp_path, monkey
         raise AssertionError("live action planned without native evidence")
 
 
+def test_completion_review_plans_as_storage_append_without_native_runtime_evidence(
+    tmp_path, monkeypatch
+):
+    runtime = tmp_path / "runtime"
+    source = _activate_mission_control(runtime)
+    monkeypatch.setenv("KF_CONFIG_HOME", str(tmp_path / "config"))
+
+    plan = profile_sdk.plan_action(
+        source,
+        runtime,
+        "review-completion",
+        {
+            "missionId": "mission:test",
+            "goalId": "goal:test",
+            "reviewer": "independent-reviewer",
+            "reviewerSource": "qualification",
+            "executorProfile": "inline",
+        },
+    )
+
+    assert plan["runtimePlan"]["operation"]["id"] == "episode.append"
+    assert plan["runtimePlan"]["requirement"]["operationClass"] == "storage-only"
+    assert plan["runtimePlan"]["requirement"]["minimumCut"] is None
+
+
 def test_live_profile_action_does_not_run_callback_when_broker_refuses(
     tmp_path, monkeypatch
 ):

--- a/framework/core/tests/python/test_atlas_storage.py
+++ b/framework/core/tests/python/test_atlas_storage.py
@@ -1443,6 +1443,7 @@ def test_mission_control_batches_large_mission_state_queries(tmp_path):
         "subquery_count": 2,
     }
     assert len(state["lineage"]["subqueries"]) == 2
+    assert state["profile_query_receipt"]["result"]["row_count"] == 262
     assert state["query_proof_root"].startswith("sha256:")
 
 


### PR DESCRIPTION
## Summary

Close two protocol defects exposed by the real Atlas-to-Kungfu native authority cutover qualification.

Independent completion review is a synchronous storage-backed operation, but the Profile registry classified it as a live assessment request and rejected it without broker durability evidence. Large Mission queries also omitted the composed row count, causing assessment to interpret hundreds of canonical facts as zero. This patch aligns the action class with the actual execution boundary and carries the canonical row count through batched query composition.

## Related issue

Atlas goal: `2026-07-16-project-cut-native-authority-cutover`

## Changes

- Classify `review-completion` as the storage-only `episode.append` runtime operation.
- Update the Mission Control Profile registry digest.
- Preserve `row_count` on composed multi-batch Mission state results.
- Add regression coverage for storage-only review planning without live runtime evidence.
- Assert exact composed row count for a large Mission query.

## Real qualification

- Imported real Atlas head `6b4ff8e98ac23882a293103d0f212cb7bb572bc5` into Episode `13006490241876826514`.
- Cut over authority with migration `authority-ca9d482dbc5eced36ef7575b` at parity root `sha256:795b70812707ceacd4ed1dc34b17c1bffce98348d4512b5696fc4af5f7a787f0`.
- Created a native Go, appended a completion claim, and obtained independent review `review-5e74ef091feb089a6d43f530` with verdict `fit` over 586 admitted canonical facts.
- Applied exact-root continuation `close` as decision `decision-e032ba4f02d1f41017fdef7b`.
- Rolled authority back to `atlas-adapter`; post-rollback native create-go failed closed and legacy Atlas import admitted new facts.
- Exact active Profile root during qualification: `sha256:852074eab411e6d0306159d47657f2ad3f5716c4426a12f2110707f3995f738a`.

## Verification

- `./shifu check:source`: passed.
- `./shifu test:agent-profile-sdk`: 56/56 passed.
- `./shifu test:mission-authority-cutover`: Dashboard 25/25 and authority domain 4/4 passed.
- `./shifu test:agent-review-continuation`: Dashboard 25/25 and independent review domain 1/1 passed.
- Staged DCO, Ruff, Biome, documentation, schema authority, and Shifu contract gates passed.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "stage-ready",
  "adrs": ["ADR-0104"],
  "summary": "Qualify the native Mission and Go authority cutover with real Atlas state and repair the review proof path",
  "verification": ["source acceptance", "Mission authority cutover tests", "independent review and continuation tests", "real rollback oracle"]
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [x] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The PR changes only public Mission Control action planning and proof-bearing query result accounting. No private Atlas payloads, runtime journals, credentials, or generated qualification bundles are committed.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Source acceptance is green locally
- [x] Regression tests cover both defects

