### PR TITLE
fix(core): scope the affected-native authority to its tracked roots

### DIFF
--- a/scripts/run-core-affected-native.mjs
+++ b/scripts/run-core-affected-native.mjs
@@ -75,6 +75,12 @@ function owns(rule, file) {
   );
 }
 
+function isTracked(authority, relative) {
+  return (authority.tracked_roots || []).some((root) =>
+    relative.startsWith(root),
+  );
+}
+
 function nonNativeCoreRule(relative) {
   return (
     nonNativeCoreRules.find(
@@ -321,6 +327,17 @@ function planFromChanged(changedFiles, authority, buildAuthority, base, head) {
     }
     if (!(authority.extensions || []).includes(extension)) {
       throw new Error(`${file}: unclassified Core file impact`);
+    }
+    // The authority governs exactly what tracked_roots declares. Native sources
+    // outside those roots have no owning component by construction, so demanding
+    // one fails closed on files the authority deliberately does not track — the
+    // capability slices, for instance, which are standalone probes built only
+    // under KUNGFU_WITH_SLICES and linked into no product target. Sources inside
+    // the roots that no component claims still fail below, so this widens the
+    // authority's edge rather than its interior.
+    if (!isTracked(authority, relative)) {
+      reasons.push({ path: file, kind: 'outside-architecture-authority' });
+      continue;
     }
     const owner = componentOwner(authority, relative);
     direct.add(owner.id);
@@ -767,6 +784,9 @@ function selfTest(authority, buildAuthority) {
       throw new Error('native binding contract classification missing');
     }
   });
+  // Guards the interior of the authority: src/libkungfu/src/ is a tracked root,
+  // so an unowned source under it must still fail closed. The tracked_roots
+  // exemption below widens the authority's edge, never its interior.
   expect(
     'unclassified source fails closed',
     () =>
@@ -779,6 +799,24 @@ function selfTest(authority, buildAuthority) {
       ),
     /exactly one architecture component/,
   );
+  expect('native source outside tracked_roots is outside the authority', () => {
+    const plan = planFromChanged(
+      ['framework/core/slices/embedding/main.cpp'],
+      authority,
+      buildAuthority,
+      'base',
+      'head',
+    );
+    if (
+      !plan.reasons.some(
+        ({ kind }) => kind === 'outside-architecture-authority',
+      )
+    ) {
+      throw new Error('untracked native source was not classified');
+    }
+    if (plan.directComponents.length !== 0)
+      throw new Error('untracked native source claimed a component');
+  });
   expect('Core test fixtures and qualification harness expand globally', () => {
     const plan = planFromChanged(
       [


### PR DESCRIPTION
<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Fixes a scoping defect in the affected-native gate's own script. It projects no ADR: no architecture decision changes, no component is added or removed, and layers.json is untouched. The gate simply now reads the tracked_roots the authority already declares.",
  "summary": "Classify native sources outside the architecture authority's tracked_roots as outside-authority instead of demanding an owning component.",
  "verification": ["node scripts/run-core-affected-native.mjs --self-test (16/16)"]
}
-->

## Problem

The gate requires exactly one owning architecture component for every native source under `framework/core/`, but it only ever filters on that prefix — it never consults the authority's own `tracked_roots`. Any source the authority deliberately does not track fails closed:

```
[core-affected] slices/embedding/main.cpp: expected exactly one architecture component, found none
```

The capability slices are the live case. They are standalone probes built only under `KUNGFU_WITH_SLICES` (default `OFF`), linked into no product target, and correspondingly absent from `tracked_roots`. No component can own them, and registering one is not available either: `component_budget` caps at 12 and all 12 are in use.

The net effect is that **any PR touching `framework/core/slices/*.cpp` is currently unmergeable**. This surfaced on #990, which migrates the slices off a `writer` constructor it removes — leaving them alone would break them under `KUNGFU_WITH_SLICES=ON`.

The path had simply never been exercised: this gate landed in `5e916c3628` on 2026-07-16, and the previous change to a slice `.cpp` was 2026-07-14.

## Fix

Classify native sources outside `tracked_roots` as `outside-architecture-authority`, exactly as `src/python/` is already held outside it.

The exemption is driven by the authority's own data rather than a hard-coded path list — no `slices` string appears in the gate — so `tracked_roots` remains the single switch, and `layers.json` is already in `globalPaths`, so editing it expands the gate globally.

## Boundaries

This widens the authority's **edge**, not its **interior**:

- The check sits *after* the extension check, so only native sources are exempt; a stray `.yaml` under `framework/core/` still throws `unclassified Core file impact`.
- An unowned source *inside* a tracked root still fails closed. The existing `unclassified source fails closed` fixture pins exactly that (`src/libkungfu/src/runtime/unknown.cpp` is under the tracked `src/libkungfu/src/` root but owned by no component), and it still passes.

**The risk, stated plainly:** native sources placed outside `tracked_roots` no longer fail closed, so `tracked_roots` now carries that weight by itself. If code that genuinely warrants component ownership is added outside those roots, this gate will no longer object. The mitigation is that `tracked_roots` lives in `layers.json`, which is architecture-authority data and triggers a global revalidation when edited.

## Verification

`node scripts/run-core-affected-native.mjs --self-test` → 16/16.

The new fixture was confirmed non-vacuous: forcing `isTracked()` to return `true` turns it red.

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] release evidence, provenance, package publishing, or deployment surfaces
- [x] none of the above
