### PR TITLE
feat(ci): qualify dev gate cache evidence

### DIFF
--- a/docs/adr/SHIFU-ADR-0004-gate-control-plane-contract.md
+++ b/docs/adr/SHIFU-ADR-0004-gate-control-plane-contract.md
@@ -4,7 +4,7 @@ doc_type: architecture-decision
 adr_id: SHIFU-ADR-0004
 decision_status: accepted
 implementation_status: implemented
-implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/762, https://github.com/kungfu-systems/kungfu/pull/765, https://github.com/kungfu-systems/kungfu/pull/767, https://github.com/kungfu-systems/kungfu/pull/769, https://github.com/kungfu-systems/kungfu/pull/773, https://github.com/kungfu-systems/kungfu/pull/781, https://github.com/kungfu-systems/kungfu/pull/786, https://github.com/kungfu-systems/kungfu/pull/1004]
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/762, https://github.com/kungfu-systems/kungfu/pull/765, https://github.com/kungfu-systems/kungfu/pull/767, https://github.com/kungfu-systems/kungfu/pull/769, https://github.com/kungfu-systems/kungfu/pull/773, https://github.com/kungfu-systems/kungfu/pull/781, https://github.com/kungfu-systems/kungfu/pull/786, https://github.com/kungfu-systems/kungfu/pull/1004, https://github.com/kungfu-systems/kungfu/pull/1014]
 closure_pr: https://github.com/kungfu-systems/kungfu/pull/781
 qualification_refs: [scripts/shifu-gate-runtime.test.mjs, scripts/check-kungfu-gate-catalog.test.mjs, scripts/shifu-cache-runtime.test.mjs, scripts/measure-dev-required-latency.test.mjs, scripts/write-affected-native-cache-manifests.test.mjs, .github/workflows/affected-native-pr.yml, .github/workflows/dev-verify-patrol.yml]
 review_state: self-reviewed
@@ -147,6 +147,16 @@ required-context P50/P95 and refuses a qualifying verdict below the declared
 sample floor. The retained initial window exceeds the target, so this projection
 does not claim the latency SLO is complete; subsequent real PR samples and fault
 campaign evidence must close that qualification separately.
+
+PR 1014 closes the cache-evidence observation boundary for that later
+qualification. The latency collector reads only the final successful
+affected-native run's retained artifact, validates its Buildchain dependency
+and compiler receipts against the artifact source, and reports exact or
+compatible warm reuse separately from qualified cold fallback. Missing,
+expired, malformed, source-mismatched, or fallback-incomplete artifacts remain
+unknown; elapsed time is never used to infer a hit. A latency window therefore
+cannot qualify until every native sample carries authoritative cache evidence,
+in addition to satisfying the sample floor and queue-inclusive P50/P95 target.
 
 ## Consequences
 

--- a/docs/qualification/gates/README.md
+++ b/docs/qualification/gates/README.md
@@ -79,11 +79,16 @@ runner execution time alone is not the metric.
 
 The report uses the current source planner to classify samples as `native`,
 `non-native`, or `unknown`, and reports nearest-rank P50/P95 for every stratum.
-Planner failures remain unknown instead of becoming non-native. Cache outcome
-also remains `unknown` unless a provider receipt is collected; duration is
-never used to infer a hit. Missing or non-success required contexts are retained
-as explicit exclusions with their reason and are never silently removed from
-the dataset.
+Planner failures remain unknown instead of becoming non-native. For each native
+sample, the collector reads the final successful affected-native workflow's
+retained artifact and validates the Buildchain dependency/compiler portable
+cache receipts. It reports exact/compatible warm reuse, miss/corrupt cold
+fallback, unknown evidence, ccache hits, and the aggregate warm/cold ratio;
+duration is never used to infer a hit. Non-native samples are explicitly
+`not-applicable`. Missing, expired, or malformed artifacts remain `unknown`, and
+a window with unknown native cache evidence cannot qualify. Missing or
+non-success required contexts are retained as explicit exclusions with their
+reason and are never silently removed from the dataset.
 
 The current dev objective is queue-inclusive P50 at most 300 seconds and P95 at
 most 600 seconds. A report is an observation, not a release credential, and a
@@ -95,7 +100,7 @@ otherwise the machine verdict remains non-qualifying. Rebuild it with:
 ./shifu gate:latency:measure --branch dev/v4/v4.0 --limit 30
 ```
 
-The command requires a read-only GitHub token through `GH_TOKEN` or
+The command requires `unzip` plus a read-only GitHub token through `GH_TOKEN` or
 `GITHUB_TOKEN`, or an authenticated `gh` client. It reads pull requests,
 workflow/check metadata, changed paths, and branch protection; it does not
 modify repository settings or workflow runs.

--- a/scripts/measure-dev-required-latency.mjs
+++ b/scripts/measure-dev-required-latency.mjs
@@ -4,6 +4,7 @@
 
 import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import process from 'node:process';
 import { fileURLToPath, pathToFileURL } from 'node:url';
@@ -76,20 +77,49 @@ function githubToken() {
   return result.stdout.trim();
 }
 
-async function githubJson(route, token) {
-  const response = await fetch(`https://api.github.com${route}`, {
-    headers: {
-      Accept: 'application/vnd.github+json',
-      Authorization: `Bearer ${token}`,
-      'User-Agent': 'kungfu-dev-gate-latency',
-      'X-GitHub-Api-Version': '2022-11-28',
-    },
-  });
-  if (!response.ok) {
-    const body = (await response.text()).slice(0, 500);
-    throw new Error(`GitHub API ${response.status} for ${route}: ${body}`);
+function retryDelay(attempt) {
+  return new Promise((resolve) => setTimeout(resolve, 250 * 2 ** attempt));
+}
+
+async function githubResponse(route, token) {
+  let lastError = null;
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    try {
+      const response = await fetch(`https://api.github.com${route}`, {
+        headers: {
+          Accept: 'application/vnd.github+json',
+          Authorization: `Bearer ${token}`,
+          'User-Agent': 'kungfu-dev-gate-latency',
+          'X-GitHub-Api-Version': '2022-11-28',
+        },
+      });
+      if (response.ok) return response;
+      const body = (await response.text()).slice(0, 500);
+      const error = new Error(
+        `GitHub API ${response.status} for ${route}: ${body}`,
+      );
+      if (response.status !== 429 && response.status < 500) throw error;
+      lastError = error;
+    } catch (error) {
+      lastError = error;
+      if (
+        !['TypeError', 'TimeoutError'].includes(error.name) ||
+        attempt === 2
+      ) {
+        throw error;
+      }
+    }
+    if (attempt < 2) await retryDelay(attempt);
   }
-  return response.json();
+  throw lastError || new Error(`GitHub API request failed for ${route}`);
+}
+
+async function githubJson(route, token) {
+  return (await githubResponse(route, token)).json();
+}
+
+async function githubBytes(route, token) {
+  return Buffer.from(await (await githubResponse(route, token)).arrayBuffer());
 }
 
 async function githubPages(route, token, limit = Number.POSITIVE_INFINITY) {
@@ -184,10 +214,223 @@ export function selectedContext(checkRuns, actionsRuns, context) {
       ? 'workflow.created_at'
       : 'check.started_at-fallback',
     checkRunId: latest.id,
+    finalWorkflowRunId: Number(
+      latest.details_url?.match(/\/actions\/runs\/(\d+)/)?.[1] || 0,
+    ),
     workflowRunIds: [...new Set(candidateRunIds.map(Number))].sort(
       (a, b) => a - b,
     ),
   };
+}
+
+function readZipMembers(archive, names) {
+  const temporary = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'kungfu-dev-gate-latency-'),
+  );
+  const archivePath = path.join(temporary, 'artifact.zip');
+  try {
+    fs.writeFileSync(archivePath, archive);
+    const listing = spawnSync('unzip', ['-Z1', archivePath], {
+      encoding: 'utf8',
+      shell: false,
+    });
+    if (listing.status !== 0) {
+      throw new Error(
+        `cannot list artifact zip: ${(listing.stderr || '').trim() || 'unzip failed'}`,
+      );
+    }
+    const entries = listing.stdout.split('\n').filter(Boolean);
+    return Object.fromEntries(
+      names.map((name) => {
+        const entry = entries.find(
+          (candidate) => candidate === name || candidate.endsWith(`/${name}`),
+        );
+        if (!entry) return [name, null];
+        const extracted = spawnSync('unzip', ['-p', archivePath, entry], {
+          encoding: 'utf8',
+          shell: false,
+          maxBuffer: 4 * 1024 * 1024,
+        });
+        if (extracted.status !== 0) {
+          throw new Error(`cannot read ${entry} from artifact zip`);
+        }
+        return [name, extracted.stdout];
+      }),
+    );
+  } finally {
+    fs.rmSync(temporary, { recursive: true, force: true });
+  }
+}
+
+function parseCompilerStats(value) {
+  if (!value) return null;
+  const calls = value.match(/Cacheable calls:\s+(\d+)\s*\/\s*(\d+)/);
+  const hits = value.match(/(?:^|\n)\s*Hits:\s+(\d+)\s*\/\s*(\d+)/);
+  const misses = value.match(/(?:^|\n)\s*Misses:\s+(\d+)\s*\/\s*(\d+)/);
+  if (!calls || !hits || !misses) return null;
+  return {
+    cacheableCalls: Number(calls[2]),
+    hits: Number(hits[1]),
+    misses: Number(misses[1]),
+    hitRatio: Number(calls[2]) ? Number(hits[1]) / Number(calls[2]) : null,
+  };
+}
+
+export function cacheEvidenceFromMembers(members, classification) {
+  if (classification.kind === 'non-native') {
+    return {
+      outcome: 'not-applicable',
+      authority: 'source-planner',
+      warm: false,
+      cold: false,
+      layers: [],
+      compilerStats: null,
+    };
+  }
+  if (classification.kind !== 'native') {
+    return {
+      outcome: 'unknown',
+      authority: 'classification-unknown',
+      warm: false,
+      cold: false,
+      layers: [],
+      compilerStats: null,
+    };
+  }
+  try {
+    const layers = ['dependency', 'compiler'].map((layer) => {
+      const raw = members[`cache/${layer}.receipt.json`];
+      if (!raw) throw new Error(`missing ${layer} receipt`);
+      const receipt = JSON.parse(raw);
+      if (
+        receipt.schema !== 'buildchain.portable-dev-cache-receipt/v1' ||
+        receipt.layer !== layer ||
+        typeof receipt.outcome !== 'string'
+      ) {
+        throw new Error(`invalid ${layer} receipt`);
+      }
+      return {
+        layer,
+        outcome: receipt.outcome,
+        usable: receipt.usable === true,
+        qualified: receipt.qualified === true,
+        coldFallbackRequired: receipt.coldFallbackRequired === true,
+        coldFallbackStatus: receipt.coldFallbackStatus || null,
+        sourceSha: receipt.sourceSha || null,
+        matchedKey: receipt.matchedKey || null,
+        receiptDigest: receipt.receiptDigest || null,
+      };
+    });
+    const outcomes = layers.map(({ outcome }) => outcome);
+    const warm =
+      layers.every(({ usable, qualified }) => usable && qualified) &&
+      outcomes.every((outcome) => ['exact', 'compatible'].includes(outcome));
+    const cold = outcomes.some((outcome) =>
+      ['miss', 'corrupt'].includes(outcome),
+    );
+    const coldQualified = layers.every(
+      ({
+        outcome: value,
+        qualified,
+        coldFallbackRequired,
+        coldFallbackStatus,
+      }) =>
+        !['miss', 'corrupt'].includes(value) ||
+        (qualified && coldFallbackRequired && coldFallbackStatus === 'passed'),
+    );
+    if (cold && !coldQualified) {
+      throw new Error('cold cache outcome lacks a passed fallback receipt');
+    }
+    const outcome = warm
+      ? outcomes.every((value) => value === 'exact')
+        ? 'exact'
+        : 'compatible'
+      : cold
+        ? outcomes.includes('corrupt')
+          ? 'corrupt'
+          : 'miss'
+        : 'unknown';
+    return {
+      outcome,
+      authority: 'buildchain-portable-cache-receipt',
+      warm,
+      cold,
+      layers,
+      compilerStats: parseCompilerStats(members['cache/compiler-stats.txt']),
+    };
+  } catch (error) {
+    return {
+      outcome: 'unknown',
+      authority: 'artifact-invalid-or-incomplete',
+      reason: error.message,
+      warm: false,
+      cold: false,
+      layers: [],
+      compilerStats: null,
+    };
+  }
+}
+
+async function collectCacheEvidence(repository, runId, classification, token) {
+  if (classification.kind === 'non-native') {
+    return cacheEvidenceFromMembers({}, classification);
+  }
+  if (!runId) {
+    return {
+      ...cacheEvidenceFromMembers({}, { kind: 'unknown' }),
+      authority: 'affected-native-workflow-run-missing',
+    };
+  }
+  try {
+    const payload = await githubJson(
+      `/repos/${repository}/actions/runs/${runId}/artifacts?per_page=100`,
+      token,
+    );
+    const artifact = (payload.artifacts || []).find(
+      ({ name, expired }) =>
+        !expired && name.startsWith('core-affected-native-'),
+    );
+    if (!artifact) {
+      throw new Error('affected-native artifact missing or expired');
+    }
+    const archive = await githubBytes(
+      `/repos/${repository}/actions/artifacts/${artifact.id}/zip`,
+      token,
+    );
+    const members = readZipMembers(archive, [
+      'cache/dependency.receipt.json',
+      'cache/compiler.receipt.json',
+      'cache/compiler-stats.txt',
+    ]);
+    const evidence = cacheEvidenceFromMembers(members, classification);
+    const artifactSourceSha = artifact.name.slice(
+      'core-affected-native-'.length,
+    );
+    if (
+      evidence.layers.some(
+        ({ sourceSha }) => !sourceSha || sourceSha !== artifactSourceSha,
+      )
+    ) {
+      throw new Error('portable cache receipt source does not match artifact');
+    }
+    return {
+      ...evidence,
+      artifactId: artifact.id,
+      artifactName: artifact.name,
+      workflowRunId: runId,
+    };
+  } catch (error) {
+    return {
+      outcome: 'unknown',
+      authority: 'artifact-unavailable',
+      reason: error.message,
+      warm: false,
+      cold: false,
+      layers: [],
+      compilerStats: null,
+      workflowRunId: runId,
+    };
+  }
 }
 
 function workflowRunIds(checkRuns) {
@@ -258,6 +501,15 @@ async function collectSample(repository, pull, requiredContexts, token) {
       checks,
     };
   }
+  const affectedNative = checks.find(
+    ({ context }) => context === 'affected-native / linux',
+  );
+  const cache = await collectCacheEvidence(
+    repository,
+    affectedNative?.finalWorkflowRunId,
+    classification,
+    token,
+  );
   const startedAt = checks.map(({ startedAt }) => startedAt).sort()[0];
   const completedAt = checks
     .map(({ completedAt }) => completedAt)
@@ -270,7 +522,7 @@ async function collectSample(repository, pull, requiredContexts, token) {
     sourceSha: sha,
     baseSha: pull.base.sha,
     classification,
-    cache: { outcome: 'unknown', authority: 'no-provider-receipt-collected' },
+    cache,
     startedAt,
     completedAt,
     durationMs: milliseconds(startedAt, completedAt),
@@ -293,6 +545,22 @@ export function report(repository, branch, requiredContexts, records) {
     statistics.native.sampleCount >= MINIMUM_NATIVE_SAMPLE_COUNT;
   const meetsTarget =
     statistics.all.p50Ms <= 300000 && statistics.all.p95Ms <= 600000;
+  const cache = {
+    warmCount: samples.filter(({ cache: value }) => value?.warm).length,
+    coldCount: samples.filter(({ cache: value }) => value?.cold).length,
+    notApplicableCount: samples.filter(
+      ({ cache: value }) => value?.outcome === 'not-applicable',
+    ).length,
+    unknownCount: samples.filter(
+      ({ cache: value }) => !value || value.outcome === 'unknown',
+    ).length,
+  };
+  const nativeCacheEvidenceComplete = byKind('native').every(
+    ({ cache: value }) => value && value.outcome !== 'unknown',
+  );
+  const cacheObserved = cache.warmCount + cache.coldCount;
+  cache.warmRatio = cacheObserved ? cache.warmCount / cacheObserved : null;
+  cache.coldRatio = cacheObserved ? cache.coldCount / cacheObserved : null;
   return {
     schema: 'kungfu.dev-required-latency/v1',
     generatedAt: new Date().toISOString(),
@@ -313,16 +581,19 @@ export function report(repository, branch, requiredContexts, records) {
     },
     branchProtection: { requiredContexts },
     statistics,
+    cache,
     verdict: {
-      qualified: enoughSamples && meetsTarget,
+      qualified: enoughSamples && meetsTarget && nativeCacheEvidenceComplete,
       reason:
         statistics.all.sampleCount === 0
           ? 'no qualifying samples'
           : !enoughSamples
             ? 'insufficient overall or native sample count'
-            : meetsTarget
-              ? 'observed sample meets target'
-              : 'observed sample exceeds target',
+            : !meetsTarget
+              ? 'observed sample exceeds target'
+              : !nativeCacheEvidenceComplete
+                ? 'native cache evidence is incomplete'
+                : 'observed sample meets target with complete native cache evidence',
     },
     samples,
     exclusions: records.filter(({ excluded }) => excluded),

--- a/scripts/measure-dev-required-latency.test.mjs
+++ b/scripts/measure-dev-required-latency.test.mjs
@@ -4,12 +4,28 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 
 import {
+  cacheEvidenceFromMembers,
   nearestRank,
   report,
   selectedContext,
   summarize,
   validateBaseline,
 } from './measure-dev-required-latency.mjs';
+
+function cacheReceipt(layer, outcome, overrides = {}) {
+  return JSON.stringify({
+    schema: 'buildchain.portable-dev-cache-receipt/v1',
+    layer,
+    outcome,
+    usable: ['exact', 'compatible'].includes(outcome),
+    qualified: ['exact', 'compatible', 'miss'].includes(outcome),
+    coldFallbackRequired: outcome === 'miss',
+    coldFallbackStatus: outcome === 'miss' ? 'passed' : 'not-run',
+    sourceSha: 'abc',
+    receiptDigest: `sha256:${layer}`,
+    ...overrides,
+  });
+}
 
 test('nearest-rank percentiles preserve the observed tail', () => {
   assert.equal(nearestRank([100, 200, 300, 400], 0.5), 200);
@@ -26,6 +42,86 @@ test('an under-sized passing window remains non-qualifying', () => {
   const value = report('owner/repo', 'dev', ['required'], [sample]);
   assert.equal(value.verdict.qualified, false);
   assert.match(value.verdict.reason, /insufficient/);
+});
+
+test('portable cache receipts distinguish warm compatibility from cold fallback', () => {
+  const warm = cacheEvidenceFromMembers(
+    {
+      'cache/dependency.receipt.json': cacheReceipt('dependency', 'compatible'),
+      'cache/compiler.receipt.json': cacheReceipt('compiler', 'exact'),
+      'cache/compiler-stats.txt': [
+        'Cacheable calls:     91 /  91 (100.0%)',
+        '  Hits:              91 /  91 (100.0%)',
+        '  Misses:             0 /  91 ( 0.00%)',
+      ].join('\n'),
+    },
+    { kind: 'native' },
+  );
+  assert.equal(warm.outcome, 'compatible');
+  assert.equal(warm.warm, true);
+  assert.deepEqual(warm.compilerStats, {
+    cacheableCalls: 91,
+    hits: 91,
+    misses: 0,
+    hitRatio: 1,
+  });
+
+  const cold = cacheEvidenceFromMembers(
+    {
+      'cache/dependency.receipt.json': cacheReceipt('dependency', 'miss'),
+      'cache/compiler.receipt.json': cacheReceipt('compiler', 'miss'),
+    },
+    { kind: 'native' },
+  );
+  assert.equal(cold.outcome, 'miss');
+  assert.equal(cold.cold, true);
+});
+
+test('missing or invalid cache receipts remain unknown', () => {
+  const value = cacheEvidenceFromMembers({}, { kind: 'native' });
+  assert.equal(value.outcome, 'unknown');
+  assert.match(value.reason, /missing dependency receipt/);
+});
+
+test('a cache miss without a passed cold fallback remains unknown', () => {
+  const value = cacheEvidenceFromMembers(
+    {
+      'cache/dependency.receipt.json': cacheReceipt('dependency', 'miss', {
+        coldFallbackStatus: 'failed',
+      }),
+      'cache/compiler.receipt.json': cacheReceipt('compiler', 'miss'),
+    },
+    { kind: 'native' },
+  );
+  assert.equal(value.outcome, 'unknown');
+  assert.match(value.reason, /passed fallback/);
+});
+
+test('non-native samples explicitly have no portable cache work', () => {
+  const value = cacheEvidenceFromMembers({}, { kind: 'non-native' });
+  assert.equal(value.outcome, 'not-applicable');
+  assert.equal(value.authority, 'source-planner');
+});
+
+test('a passing latency window still requires complete native cache evidence', () => {
+  const records = Array.from({ length: 20 }, (_, index) => ({
+    excluded: false,
+    durationMs: 120000,
+    classification: { kind: 'native' },
+    cache:
+      index === 0
+        ? { outcome: 'unknown', warm: false, cold: false }
+        : { outcome: 'compatible', warm: true, cold: false },
+  }));
+  const incomplete = report('owner/repo', 'dev', ['required'], records);
+  assert.equal(incomplete.verdict.qualified, false);
+  assert.match(incomplete.verdict.reason, /cache evidence is incomplete/);
+
+  records[0].cache = { outcome: 'miss', warm: false, cold: true };
+  const complete = report('owner/repo', 'dev', ['required'], records);
+  assert.equal(complete.verdict.qualified, true);
+  assert.equal(complete.cache.warmCount, 19);
+  assert.equal(complete.cache.coldCount, 1);
 });
 
 test('summary reports sample count and queue-inclusive distribution', () => {


### PR DESCRIPTION
## Summary

- collect the final successful affected-native artifact for every native latency sample
- validate Buildchain dependency/compiler portable-cache receipts and artifact source binding
- report exact/compatible warm reuse, qualified cold fallback, ccache statistics, and aggregate warm/cold ratios
- keep missing, expired, malformed, or source-mismatched evidence fail-closed as unknown
- retry only transient GitHub network, 429, and 5xx responses with a bounded three-attempt policy

## Related issue

Dev required gate latency SLO qualification.

## Changes

- add read-only Actions artifact collection to `gate:latency:measure`
- require complete native cache evidence before a latency window can qualify
- document the artifact and `unzip` requirements
- add warm, cold, malformed, missing-fallback, non-native, and verdict fixtures

## Verification

- `./shifu test:gate-latency` (12/12)
- `./shifu check:source` (passed)
- live 30-PR collection (28 qualifying duration samples): P50 879s, P95 3062s; 2 warm, 3 cold, 21 pre-receipt unknown native samples, 2 non-native not-applicable; verdict remains non-qualifying

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "stage-ready",
  "adrs": ["SHIFU-ADR-0004"],
  "summary": "Close the cache-evidence observability stage of dev Gate latency qualification without changing Gate strength",
  "verification": ["./shifu test:gate-latency", "./shifu check:source", "live 30-PR read-only measurement"]
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

This PR reads retained CI qualification artifacts with repository read access; it does not modify workflows, branch protection, publication authority, or repository settings.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed