### PR TITLE
ci(source-acceptance): run the affected-native self-test

### DIFF
--- a/scripts/source-acceptance.mjs
+++ b/scripts/source-acceptance.mjs
@@ -179,6 +179,11 @@ export function sourceAcceptancePlan(files) {
       '--self-test',
     ],
     [
+      'core affected-native negative fixtures',
+      'scripts/run-core-affected-native.mjs',
+      '--self-test',
+    ],
+    [
       'journal authority boundary',
       'scripts/check-journal-authority-boundary.mjs',
     ],

--- a/scripts/source-acceptance.test.mjs
+++ b/scripts/source-acceptance.test.mjs
@@ -121,6 +121,7 @@ test('source plan covers representative source-only checks', () => {
   assert.ok(labels.includes('documentation contracts'));
   assert.ok(labels.includes('core architecture contract'));
   assert.ok(labels.includes('core architecture negative fixtures'));
+  assert.ok(labels.includes('core affected-native negative fixtures'));
   assert.ok(labels.includes('runtime activation contract'));
   assert.ok(labels.includes('runtime upgrade contract'));
   assert.ok(labels.includes('product upgrade qualification'));


### PR DESCRIPTION
## Summary
- register `run-core-affected-native.mjs --self-test` with source-acceptance, alongside the existing core negative fixtures
- assert the registration in the source-acceptance contract test so the wiring cannot be dropped silently

The affected-native gate has been required on `dev/*` since it landed, and it ships
negative fixtures by the repo's own convention. Those fixtures were never registered
with source-acceptance, so the only guard over the gate's classification rules never
ran in CI. A regression in those rules stayed green until it was caught by hand.

Three sibling guards (`check-layers.mjs`, `query-health.mjs`,
`check-build-capabilities.mjs`) are already wired this way; this is the one that was
missed, not a new mechanism.

`--self-test` is pure classification logic over committed authority JSON: it needs no
native toolchain, so source-acceptance (the light gate) is the right home for it
rather than the native matrix.

## Validation
- reverse verification: seeded a `globalPaths` rule deletion -> the wired step exits 1
  and source-acceptance fails; restored -> 18/18 fixtures pass
- `node --test scripts/source-acceptance.test.mjs`: 15/15 pass
- per ADR-0040, a guard that cannot fail is not a gate; the red/green cycle above is
  the evidence that this one can now fail

## Known limitation (not addressed here)
A mutation sweep over the gate's own `globalPaths` rules shows the self-test detects
only 3 of 11 rule deletions. For example, deleting `framework/core/CMakeLists.txt`
leaves the self-test green while a Core CMake change is reclassified
`core-documentation-only` (closure 0/12, no native validation). Wiring the self-test
in is a prerequisite for closing that gap; broadening fixture coverage is deliberately
left to follow-up work rather than mixed into this change.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Register an existing guard's self-test with the source gate; no architecture contract, classification rule, or release surface changes"
}
-->

## Governance risk check
- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] release evidence, provenance, package publishing, or deployment surfaces
- [x] none of the above

## Checklist
- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed