### PR TITLE
fix(schema): close the ADR-0067 tag-uniqueness hole and correct two records

### DIFF
--- a/docs/adr/ADR-0065-schema-registry-consolidation.md
+++ b/docs/adr/ADR-0065-schema-registry-consolidation.md
@@ -2,15 +2,18 @@
 metadata_schema: kungfu.document-metadata/v1
 doc_type: architecture-decision
 adr_id: ADR-0065
-decision_status: proposed
-implementation_status: not-started
+decision_status: accepted
+implementation_status: partial
+implementation_commits: [aff6e13dae271217a141e6bc591708682fb9b032, 3e33c0811bac36a60c0825ff90e9afdea195aebd, 30a849db8a93895686e53076df779717ccd79a24]
 review_state: legacy-unreviewed
 sensitivity: public
 ---
 
 # ADR-0065: the schema type registry has one authoritative set and trait-derived subsets
 
-- Status: proposed
+- Status: accepted; partially implemented (pure-category subsets derived from the
+  membership table and tag sets made compile-time; the `CorePublic*` structural
+  subsets and the numeric tag comments are not yet retired)
 - Date: 2026-07-12
 - Category: (b) mechanism / governance — schema registry hygiene
 - Subsystem: `libyijinjing` schema registry, Hana reflection, projections, state cache

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -134,7 +134,7 @@ implemented and qualified or explicitly waived for that release.
 | [0062](ADR-0062-journal-container-epoch-and-offline-conversion.md) | accepted | the journal container epoch is derived from its layout; cross-epoch replay is deferred offline conversion, not an online adapter |
 | [0063](ADR-0063-yijinjing-concurrency-and-lifetime-contract.md) | proposed | yijinjing separates lock-free publication from cursor, write, and page-lifetime ownership |
 | [0064](ADR-0064-runtime-error-propagation-and-stop-ownership.md) | proposed | runtime libraries propagate structured errors; loop owners decide how execution stops |
-| [0065](ADR-0065-schema-registry-consolidation.md) | proposed | the schema type registry has one authoritative set and trait-derived subsets; numeric tag comments retired; `msg_type` vocabulary finished except the frozen v1 embedding ABI |
+| [0065](ADR-0065-schema-registry-consolidation.md) | accepted | the schema type registry has one authoritative set and trait-derived subsets; numeric tag comments retired; `msg_type` vocabulary finished except the frozen v1 embedding ABI |
 | [0066](ADR-0066-native-cpp-toolchain-contract-and-modules-hold.md) | accepted | native compilers share one C++ contract; modules remain qualification-only |
 | [0067](ADR-0067-schema-registry-compile-time-contract-welds.md) | accepted | schema contract invariants welded at compile time — `carrier_type` tag uniqueness and payload layout↔`schema_version` binding (reusing the ADR-0062 fingerprint) |
 | [0068](ADR-0068-tiered-durability-and-crash-recovery.md) | accepted | tiered durability separates hot mmap visibility, durable fact admission, rebuildable projections, and later replication |

--- a/framework/core/src/libkungfu/src/runtime/storage/manifest_catalog_projection.cpp
+++ b/framework/core/src/libkungfu/src/runtime/storage/manifest_catalog_projection.cpp
@@ -167,11 +167,19 @@ storage_projection_verify_result manifest_catalog_projection::verify_typed() con
           degraded,
           {},
           std::move(drift),
+          // Every projected family is reported, including export receipts. Their
+          // journal_distinct may legitimately exceed rows between rebuilds (the
+          // append-only audit stream above); that lag is judged by the subset
+          // check and is absent from drift, so reporting the honest counts here
+          // cannot be misread as drift -- whereas omitting the table entirely
+          // left an operator unable to see whether exports were projected at all.
           {{"import_manifest_accepted", projected_manifests.rows},
            {"manifest_entry_recorded", projected_entries.rows},
+           {"export_bundle_recorded", projected_exports.rows},
            {"channel_cursor_updated", projected_cursors.rows}},
           {{"import_manifest_accepted", expected_manifests.rows},
            {"manifest_entry_recorded", expected_entries.rows},
+           {"export_bundle_recorded", expected_exports.rows},
            {"channel_cursor_updated", expected_cursors.rows}}};
 }
 

--- a/framework/core/src/libyijinjing/include/kungfu/yijinjing/schema/registry.h
+++ b/framework/core/src/libyijinjing/include/kungfu/yijinjing/schema/registry.h
@@ -59,6 +59,7 @@ constexpr auto AllTypes = boost::hana::make_map( //
     TYPE_PAIR(EpisodeFrameAttached),             // 10803
     TYPE_PAIR(EpisodeRefAttached),               // 10804
     TYPE_PAIR(EpisodeClosed),                    // 10805
+    TYPE_PAIR(EpisodeRootCommitted),             // 10806
     TYPE_PAIR(SourceRegistered),                 // 10901
     TYPE_PAIR(SourceHeadUpdated),                // 10902
     TYPE_PAIR(AcceptedRangeRecorded),            // 10903
@@ -79,7 +80,7 @@ constexpr auto AllDataTypes =
                                               return boost::hana::bool_c<DataType::has_data>;
                                             }),
                         boost::hana::make_map);
-static_assert(decltype(boost::hana::length(AllDataTypes))::value == 36);
+static_assert(decltype(boost::hana::length(AllDataTypes))::value == 37);
 
 constexpr auto CorePublicDataTypes = boost::hana::make_map( //
     TYPE_PAIR(frame_header),                                // 0
@@ -111,6 +112,7 @@ constexpr auto CorePublicDataTypes = boost::hana::make_map( //
     TYPE_PAIR(EpisodeFrameAttached),                        // 10803
     TYPE_PAIR(EpisodeRefAttached),                          // 10804
     TYPE_PAIR(EpisodeClosed),                               // 10805
+    TYPE_PAIR(EpisodeRootCommitted),                        // 10806
     TYPE_PAIR(SourceRegistered),                            // 10901
     TYPE_PAIR(SourceHeadUpdated),                           // 10902
     TYPE_PAIR(AcceptedRangeRecorded),                       // 10903
@@ -211,6 +213,24 @@ static_assert(decltype(boost::hana::length(ProfileDataTypes))::value == 2);
 static_assert(decltype(boost::hana::length(SourceRegistryDataTypes))::value == 3);
 static_assert(decltype(boost::hana::length(ManifestCatalogDataTypes))::value == 4);
 static_assert(decltype(boost::hana::length(EpisodeManifestDataTypes))::value == 6);
+
+// Every membership-table member must also be in the AllTypes roster. The two are
+// declared separately, so a type can join a category -- and get an ADR-0067 layout
+// weld -- while never entering AllTypes, which silently excludes it from
+// AllTypesTags and therefore from the ADR-0067 tag-uniqueness assert. That is not
+// hypothetical: EpisodeRootCommitted (10806) shipped in exactly this state. Bind the
+// two rosters so the omission is a build failure rather than a hole in a guard.
+constexpr bool all_membership_types_registered() {
+  bool registered = true;
+  boost::hana::for_each(membership::table, [&registered](auto entry) {
+    using DataType = typename decltype(+boost::hana::first(entry))::type;
+    registered = registered && boost::hana::contains(AllTypes, DataType::type_name);
+  });
+  return registered;
+}
+static_assert(all_membership_types_registered(),
+              "a membership-table type is missing from AllTypes; it would escape the "
+              "ADR-0067 tag-uniqueness guard (see EpisodeRootCommitted/10806)");
 
 // ADR-0067: each versioned manifest POD record's payload layout is welded to its
 // schema_version by a paired compile-time assert. The read path validates size


### PR DESCRIPTION
## What

`EpisodeRootCommitted` (10806) was declared, given an ADR-0067 layout weld, and placed in the
`episode_manifest` membership table -- but was never added to the `AllTypes` roster.
`AllTypesTags` derives from `AllTypes`, so the type silently escaped the ADR-0067
tag-uniqueness `static_assert`: a guard with a hole in it.

Registering it is the one-line half. The other half binds the two rosters, so a
membership-table member missing from `AllTypes` fails the build rather than quietly
bypassing the uniqueness check.

Two record corrections ride along:

- **ADR-0065** was still `proposed` / `not-started` while three of its four decisions had
  shipped. It is now `accepted` / `partial` with implementation commits; it is not
  `implemented` because the `CorePublic*` structural subsets are still hand-listed and the
  numeric tag comments are not yet retired.
- **`manifest_catalog_projection::verify_typed`** reported row counts for three of its four
  projected families, silently omitting `export_bundle_recorded` from both `rows` and
  `journal_distinct`. The counts were already computed and used in the drift path, so an
  operator could see the table only when it drifted -- never whether it was projected at all.

## Verification

- Core builds with no compile errors; `pykungfu` links.
- The full build's final import step fails on a pre-existing rocksdb `crc32c_arm64` symbol gap
  on macOS arm64. Reproduced identically on an unmodified `dev/v4/v4.0` worktree, so it is
  unrelated to this change and blocks the local build for everyone on that platform today.
- Docs gate passes, including ADR body/index status drift checks.
- No test asserts the row-map shape; the existing export drift test asserts only the drift map
  and still holds.

<!-- kungfu-adr-release:v1
{"schema": "kungfu.adr-release-pr/v1", "kind": "dev-delivery", "intent": "stage-ready", "adrs": ["ADR-0065"], "summary": "Register EpisodeRootCommitted so it stops escaping the ADR-0067 tag-uniqueness assert, bind the membership table to AllTypes, and correct ADR-0065 to accepted/partial", "verification": ["core builds with no compile errors", "docs gate including ADR body/index status drift", "existing export drift test"]}
-->
