### PR TITLE
ci(dev): decouple optional core profile matrix

### DIFF
--- a/.github/workflows/core-build-profiles.yml
+++ b/.github/workflows/core-build-profiles.yml
@@ -3,15 +3,9 @@
 name: Core build profiles
 
 on:
-  pull_request:
-    branches:
-      - dev/v*/v*
-    paths:
-      - "framework/core/**"
-      - "scripts/**"
-      - "package.json"
-      - "pnpm-lock.yaml"
-      - ".github/workflows/core-build-profiles.yml"
+  schedule:
+    - cron: "17 5 * * *"
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/docs/adr/SHIFU-ADR-0004-gate-control-plane-contract.md
+++ b/docs/adr/SHIFU-ADR-0004-gate-control-plane-contract.md
@@ -6,7 +6,7 @@ decision_status: accepted
 implementation_status: implemented
 implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/762, https://github.com/kungfu-systems/kungfu/pull/765, https://github.com/kungfu-systems/kungfu/pull/767, https://github.com/kungfu-systems/kungfu/pull/769, https://github.com/kungfu-systems/kungfu/pull/773, https://github.com/kungfu-systems/kungfu/pull/781, https://github.com/kungfu-systems/kungfu/pull/786, https://github.com/kungfu-systems/kungfu/pull/1004, https://github.com/kungfu-systems/kungfu/pull/1014]
 closure_pr: https://github.com/kungfu-systems/kungfu/pull/781
-qualification_refs: [scripts/shifu-gate-runtime.test.mjs, scripts/check-kungfu-gate-catalog.test.mjs, scripts/shifu-cache-runtime.test.mjs, scripts/measure-dev-required-latency.test.mjs, scripts/write-affected-native-cache-manifests.test.mjs, .github/workflows/affected-native-pr.yml, .github/workflows/dev-verify-patrol.yml]
+qualification_refs: [scripts/shifu-gate-runtime.test.mjs, scripts/check-kungfu-gate-catalog.test.mjs, scripts/shifu-cache-runtime.test.mjs, scripts/measure-dev-required-latency.test.mjs, scripts/write-affected-native-cache-manifests.test.mjs, .github/workflows/affected-native-pr.yml, .github/workflows/core-build-profiles.yml, .github/workflows/dev-verify-patrol.yml]
 review_state: self-reviewed
 sensitivity: public
 sources: [local-files, user-consensus]
@@ -147,6 +147,16 @@ required-context P50/P95 and refuses a qualifying verdict below the declared
 sample floor. The retained initial window exceeds the target, so this projection
 does not claim the latency SLO is complete; subsequent real PR samples and fault
 campaign evidence must close that qualification separately.
+
+The dev latency policy also separates merge admission from asynchronous
+observation. The protected branch continues to require its three Linux-hosted
+contexts, while `Core build profiles` exercises both Core profiles across
+Linux, macOS, and Windows on a daily or manual trigger instead of launching six
+optional jobs for every development PR. This preserves cross-platform drift
+and fault visibility without allowing non-required work to queue ahead of the
+required merge group. The `dev-patrol`, alpha, and release profiles retain
+their existing cross-platform semantics; this scheduling change cannot mint a
+qualifying receipt or weaken a matrix decision.
 
 PR 1014 closes the cache-evidence observation boundary for that later
 qualification. The latency collector reads only the final successful

--- a/docs/adr/SHIFU-ADR-0004-gate-control-plane-contract.md
+++ b/docs/adr/SHIFU-ADR-0004-gate-control-plane-contract.md
@@ -4,7 +4,7 @@ doc_type: architecture-decision
 adr_id: SHIFU-ADR-0004
 decision_status: accepted
 implementation_status: implemented
-implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/762, https://github.com/kungfu-systems/kungfu/pull/765, https://github.com/kungfu-systems/kungfu/pull/767, https://github.com/kungfu-systems/kungfu/pull/769, https://github.com/kungfu-systems/kungfu/pull/773, https://github.com/kungfu-systems/kungfu/pull/781, https://github.com/kungfu-systems/kungfu/pull/786, https://github.com/kungfu-systems/kungfu/pull/1004, https://github.com/kungfu-systems/kungfu/pull/1014]
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/762, https://github.com/kungfu-systems/kungfu/pull/765, https://github.com/kungfu-systems/kungfu/pull/767, https://github.com/kungfu-systems/kungfu/pull/769, https://github.com/kungfu-systems/kungfu/pull/773, https://github.com/kungfu-systems/kungfu/pull/781, https://github.com/kungfu-systems/kungfu/pull/786, https://github.com/kungfu-systems/kungfu/pull/1004, https://github.com/kungfu-systems/kungfu/pull/1014, https://github.com/kungfu-systems/kungfu/pull/1020]
 closure_pr: https://github.com/kungfu-systems/kungfu/pull/781
 qualification_refs: [scripts/shifu-gate-runtime.test.mjs, scripts/check-kungfu-gate-catalog.test.mjs, scripts/shifu-cache-runtime.test.mjs, scripts/measure-dev-required-latency.test.mjs, scripts/write-affected-native-cache-manifests.test.mjs, .github/workflows/affected-native-pr.yml, .github/workflows/core-build-profiles.yml, .github/workflows/dev-verify-patrol.yml]
 review_state: self-reviewed

--- a/docs/qualification/gates/README.md
+++ b/docs/qualification/gates/README.md
@@ -51,6 +51,16 @@ explains Kungfu's current policy and does not redefine Shifu semantics.
 | `release-promotion` | post-merge promotion rehearsal and Buildchain artifact/passport admission |
 | `measurement` | manual three-platform source-bound observation of every task-backed Gate; all selected actions are advisory and it never publishes |
 
+The separate `Core build profiles` workflow is an asynchronous diagnostic
+observer, not a policy profile or qualifying receipt source. It runs the
+`embedded-minimal` and `full` Core profiles on Linux, macOS, and Windows once
+per day or on explicit manual dispatch. It deliberately does not run for each
+development pull request: optional cross-platform observation must not occupy
+GitHub-hosted capacity ahead of the Linux required contexts or extend the dev
+merge critical path. Alpha and release qualification continue to require their
+declared three-platform Gate profiles; moving this observer off the PR event
+does not weaken those policies.
+
 `local-changed` is intentionally not a qualifying profile. Local diagnosis uses
 `./shifu gate run source.changed-scope` or an explicit list of Gate ids, and the
 result is non-qualifying by contract. Keeping it outside the remote profile
@@ -99,6 +109,13 @@ otherwise the machine verdict remains non-qualifying. Rebuild it with:
 ```sh
 ./shifu gate:latency:measure --branch dev/v4/v4.0 --limit 30
 ```
+
+Dev admission is intentionally narrower than asynchronous observation. The
+protected branch keeps the three Linux-hosted required contexts as its only
+merge-critical set. Daily/manual patrol and Core-profile workflows retain
+macOS, Windows, full-profile, and fault evidence without placing those optional
+jobs in front of required merge-group work. Alpha and release admission remain
+cross-platform and fail closed according to their own matrix rows.
 
 The command requires `unzip` plus a read-only GitHub token through `GH_TOKEN` or
 `GITHUB_TOKEN`, or an authenticated `gh` client. It reads pull requests,

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -294,7 +294,7 @@
     {
       "path": ".github/workflows/core-build-profiles.yml",
       "authority": "qualification",
-      "definitionDigest": "sha256:3e5e6b4699933fb3c1ca94726ef490d4106a171ae0dd1b51fc453d7d4180180b",
+      "definitionDigest": "sha256:34c03b54cbe085fa521cbc9a676b68414100300ed6eae78264bf9f7393f4d1f6",
       "jobs": [
         {
           "id": "qualify",


### PR DESCRIPTION
## Summary

- move the optional Core build profile matrix off every development pull request
- retain Linux, macOS, and Windows coverage for both embedded-minimal and full profiles on a daily or manual observer
- keep the protected dev required set Linux-hosted and leave alpha/release cross-platform policy unchanged
- refresh closed-world workflow authority
- supersede #1018 with one linear commit on the latest dev base so the repository rebase merge queue can admit it without replaying historical conflict resolutions

## Related issue

Dev required gate latency SLO qualification.

## Changes

- replace the pull_request trigger for Core build profiles with daily schedule and workflow_dispatch
- document the boundary between dev admission, asynchronous observation, and alpha/release qualification
- refresh workflow authority

## Verification

- ./shifu check:gate-catalog
- ./shifu docs:check
- ./shifu kfd:buildchain:check
- commit staged gate
- equivalent #1018 head passed Source Acceptance, affected-native, ADR, docs, DCO, Buildchain validation, and promotion rehearsal before the queue rejected its non-linear history

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "stage-ready",
  "adrs": ["SHIFU-ADR-0004"],
  "summary": "Remove optional six-job Core profile observation from the dev PR critical path without weakening alpha or release policy",
  "verification": ["./shifu check:gate-catalog", "./shifu docs:check", "./shifu kfd:buildchain:check", "equivalent PR 1018 full check set"]
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

This PR changes diagnostic scheduling only. It does not alter branch protection, required Gate rows, release credentials, publication authority, or repository settings.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed
