### PR TITLE
docs(episode): publish provider schemas

### DIFF
--- a/framework/episode-provider/README.md
+++ b/framework/episode-provider/README.md
@@ -34,6 +34,40 @@ canonical JSONL bytes and manifest under
 `sha256-kungfu-git-episode-canonical-json-v1`. Therefore provider-native equality is not
 silently promoted to Episode semantic equality.
 
+## Public schemas and framing
+
+The versioned provider schemas are public under [`schema/`](schema/):
+
+- `git-workspace-manifest-v1.schema.json` covers the sealed manifest, claims
+  index, content-reference closure, dependency closure, and all three roots;
+- `git-workspace-segment-v1.schema.json` covers each `claims.jsonl` row;
+- `episode-qualification-v1.schema.json` covers the C++ typed-fold/fsck
+  qualification preimage admitted by this provider;
+- `git-workspace-provider-contract-v1.schema.json` welds those schemas to the
+  shadow-provider authority boundary.
+
+Objects use NFC strings, non-negative safe JSON integers, recursively sorted
+UTF-8 object keys, compact JSON, and one final LF. Claims contain exactly one
+canonical row per line, end in LF, and use contiguous zero-based `index`
+values. The manifest `claims.digest` hashes the original JSONL bytes and
+`claims.count` equals the row count. `contentRefs` are unique roots sorted by
+UTF-8 bytes. Native dependency closure records retain their declared order and
+remain opaque to the shadow verifier; their bytes are nevertheless bound by
+`providerRoot`.
+
+Runtime `uint64` values at or below `2^53-1` use JSON integers. Larger values
+use unsigned base-10 strings with no sign or leading zero and must not exceed
+`18446744073709551615`. The schema recognizes the wire shape; the provider's
+contract test enforces the numeric boundary that JSON Schema cannot express as
+a decimal-string comparison.
+
+An independent verifier may recompute the claims byte digest,
+`qualificationRoot`, and `providerRoot`, validate closure framing, and confirm
+that all declarations agree. It must not derive or replace `semanticRoot`:
+that root remains the recorded `kungfu.episode-root/v1` from yijinjing and is
+admitted only with `policy_source=cpp-typed-fold-fsck`, an ended lifecycle, an
+`ok` result, and safe `export_evidence` capability.
+
 Runtime `uint64` tokens are read losslessly. Values above the cross-language
 safe-integer range are represented in tracked claims as decimal strings, and
 the manifest binds

--- a/framework/episode-provider/fixtures/schema-cases-v1.json
+++ b/framework/episode-provider/fixtures/schema-cases-v1.json
@@ -1,0 +1,15 @@
+{
+  "schema": "kungfu.episode.git-workspace-schema-cases/v1",
+  "positive": ["provider-contract", "sealed-manifest", "qualification", "claims-jsonl-rows"],
+  "adversarial": [
+    { "id": "manifest-extra-field", "schema": "manifest" },
+    { "id": "segment-negative-index", "schema": "segment" },
+    { "id": "qualification-wrong-policy", "schema": "qualification" },
+    { "id": "provider-authority-widened", "schema": "provider-contract" },
+    { "id": "provider-schema-path-substitution", "schema": "provider-contract" },
+    { "id": "dependency-unsafe-integer", "schema": "manifest" },
+    { "id": "content-ref-order", "rule": "unique-root-utf8-order/v1" },
+    { "id": "uint64-overflow-string", "rule": "uint64-decimal-string-above-safe-range/v1" },
+    { "id": "uint64-unsafe-number", "rule": "uint64-decimal-string-above-safe-range/v1" }
+  ]
+}

--- a/framework/episode-provider/git-workspace-provider.contract.json
+++ b/framework/episode-provider/git-workspace-provider.contract.json
@@ -8,6 +8,18 @@
   "integerEncoding": "uint64-decimal-string-above-safe-range/v1",
   "tracked": [".kungfu/episodes/sealed/sha256/<prefix>/<root>/claims.jsonl", ".kungfu/episodes/sealed/sha256/<prefix>/<root>/manifest.json", ".kungfu/episodes/sealed/sha256/<prefix>/<root>/qualification.json"],
   "ignored": [".kungfu/episodes/.tmp/", ".kungfu/runtime/episode-provider/", ".kungfu/private/", ".kungfu/cache/"],
+  "schemas": {
+    "manifest": "schema/git-workspace-manifest-v1.schema.json",
+    "segment": "schema/git-workspace-segment-v1.schema.json",
+    "qualification": "schema/episode-qualification-v1.schema.json",
+    "providerContract": "schema/git-workspace-provider-contract-v1.schema.json"
+  },
+  "framing": {
+    "canonicalJson": "utf8-key-order-compact-nfc-safe-integer/v1",
+    "claims": "canonical-json-lines-lf-contiguous-index/v1",
+    "contentRefs": "unique-root-utf8-order/v1",
+    "dependencies": "declared-order-opaque-native-closure/v1"
+  },
   "writer": {
     "scope": "per-episode",
     "lease": "exclusive-create",

--- a/framework/episode-provider/schema/episode-qualification-v1.schema.json
+++ b/framework/episode-provider/schema/episode-qualification-v1.schema.json
@@ -1,0 +1,154 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kungfu.tech/schemas/episode-provider/episode-qualification-v1.schema.json",
+  "title": "Kungfu Episode Qualification v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "policy_source",
+    "episode_id",
+    "lifecycle",
+    "status",
+    "evidence",
+    "issues",
+    "capabilities",
+    "safe_capabilities",
+    "contractions",
+    "repair_prerequisites"
+  ],
+  "properties": {
+    "schema": { "const": "kungfu.episode.qualification/v1" },
+    "policy_source": { "const": "cpp-typed-fold-fsck" },
+    "episode_id": { "$ref": "#/$defs/uint64" },
+    "lifecycle": {
+      "enum": ["missing", "dangling", "open", "ended", "aborted", "tombstoned"]
+    },
+    "status": { "enum": ["ok", "degraded", "failed"] },
+    "evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "minProperties": 1,
+      "properties": {
+        "manifest_records": { "$ref": "#/$defs/evidence" },
+        "manifest_integrity": { "$ref": "#/$defs/evidence" },
+        "causal_closure": { "$ref": "#/$defs/evidence" },
+        "content": { "$ref": "#/$defs/evidence" },
+        "frames": { "$ref": "#/$defs/evidence" },
+        "schemas": { "$ref": "#/$defs/evidence" },
+        "projection": { "$ref": "#/$defs/evidence" }
+      }
+    },
+    "issues": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/issue" }
+    },
+    "capabilities": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/capability" }
+    },
+    "safe_capabilities": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": { "$ref": "#/$defs/capabilityName" }
+    },
+    "contractions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["capability", "blocked_by"],
+        "properties": {
+          "capability": { "$ref": "#/$defs/capabilityName" },
+          "blocked_by": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "type": "string", "minLength": 1 }
+          }
+        }
+      }
+    },
+    "repair_prerequisites": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/repairPrerequisite" }
+    }
+  },
+  "$defs": {
+    "uint64": {
+      "oneOf": [
+        {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 9007199254740991
+        },
+        {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{15,19}$"
+        }
+      ]
+    },
+    "evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["state", "issue_codes"],
+      "properties": {
+        "state": {
+          "enum": ["verified", "not_applicable", "not_checked", "missing", "degraded", "failed"]
+        },
+        "issue_codes": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "issue": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["severity", "code", "evidence", "detail"],
+      "properties": {
+        "severity": { "enum": ["info", "warning", "error"] },
+        "code": { "type": "string", "minLength": 1 },
+        "evidence": {
+          "enum": ["manifest_records", "manifest_integrity", "causal_closure", "content", "frames", "schemas", "projection"]
+        },
+        "detail": { "type": "object" }
+      }
+    },
+    "capabilityName": {
+      "enum": ["inspect", "fsck", "export_evidence", "plan_repair", "rebuild_projection", "append", "replay", "depend_on"]
+    },
+    "capability": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "safe", "requires", "blocked_by"],
+      "properties": {
+        "name": { "$ref": "#/$defs/capabilityName" },
+        "safe": { "type": "boolean" },
+        "requires": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "blocked_by": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "repairPrerequisite": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["issue_code", "action", "required_inputs", "subject"],
+      "properties": {
+        "issue_code": { "type": "string", "minLength": 1 },
+        "action": { "type": "string", "minLength": 1 },
+        "required_inputs": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "subject": { "type": "object" }
+      }
+    }
+  }
+}

--- a/framework/episode-provider/schema/git-workspace-manifest-v1.schema.json
+++ b/framework/episode-provider/schema/git-workspace-manifest-v1.schema.json
@@ -1,0 +1,102 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kungfu.tech/schemas/episode-provider/git-workspace-manifest-v1.schema.json",
+  "title": "Kungfu Git Workspace Episode Manifest v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "provider",
+    "providerRootAlgorithm",
+    "authority",
+    "episodeId",
+    "semanticRoot",
+    "semanticRootContract",
+    "integerEncoding",
+    "qualificationRoot",
+    "claims",
+    "contentRefs",
+    "dependencies",
+    "providerRoot"
+  ],
+  "properties": {
+    "schema": { "const": "kungfu.episode.git-workspace-manifest/v1" },
+    "provider": { "const": "git-workspace-jsonl/v1" },
+    "providerRootAlgorithm": {
+      "const": "sha256-kungfu-git-episode-canonical-json-v1"
+    },
+    "authority": { "const": "shadow-of-yijinjing-journal" },
+    "episodeId": { "$ref": "#/$defs/uint64" },
+    "semanticRoot": { "$ref": "#/$defs/root" },
+    "semanticRootContract": { "const": "kungfu.episode-root/v1" },
+    "integerEncoding": {
+      "const": "uint64-decimal-string-above-safe-range/v1"
+    },
+    "qualificationRoot": { "$ref": "#/$defs/root" },
+    "claims": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "digest", "count", "framing"],
+      "properties": {
+        "path": { "const": "claims.jsonl" },
+        "digest": { "$ref": "#/$defs/root" },
+        "count": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 9007199254740991
+        },
+        "framing": { "const": "canonical-json-lines-lf/v1" }
+      }
+    },
+    "contentRefs": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": { "$ref": "#/$defs/root" }
+    },
+    "dependencies": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/object" }
+    },
+    "providerRoot": { "$ref": "#/$defs/root" }
+  },
+  "$defs": {
+    "root": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    },
+    "uint64": {
+      "oneOf": [
+        {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 9007199254740991
+        },
+        {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{15,19}$"
+        }
+      ]
+    },
+    "object": {
+      "type": "object",
+      "additionalProperties": { "$ref": "#/$defs/value" }
+    },
+    "value": {
+      "oneOf": [
+        { "type": "null" },
+        { "type": "boolean" },
+        { "type": "string" },
+        {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 9007199254740991
+        },
+        {
+          "type": "array",
+          "items": { "$ref": "#/$defs/value" }
+        },
+        { "$ref": "#/$defs/object" }
+      ]
+    }
+  }
+}

--- a/framework/episode-provider/schema/git-workspace-provider-contract-v1.schema.json
+++ b/framework/episode-provider/schema/git-workspace-provider-contract-v1.schema.json
@@ -1,0 +1,104 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kungfu.tech/schemas/episode-provider/git-workspace-provider-contract-v1.schema.json",
+  "title": "Kungfu Git Workspace Episode Provider Contract v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "provider",
+    "status",
+    "authority",
+    "semanticRootContract",
+    "providerRootContract",
+    "integerEncoding",
+    "tracked",
+    "ignored",
+    "schemas",
+    "framing",
+    "writer",
+    "equivalence"
+  ],
+  "properties": {
+    "schema": { "const": "kungfu.episode.git-workspace-provider-contract/v1" },
+    "provider": { "const": "git-workspace-jsonl/v1" },
+    "status": { "const": "shadow" },
+    "authority": { "const": "yijinjing-journal" },
+    "semanticRootContract": { "const": "kungfu.episode-root/v1" },
+    "providerRootContract": {
+      "const": "sha256-kungfu-git-episode-canonical-json-v1"
+    },
+    "integerEncoding": {
+      "const": "uint64-decimal-string-above-safe-range/v1"
+    },
+    "tracked": {
+      "const": [
+        ".kungfu/episodes/sealed/sha256/<prefix>/<root>/claims.jsonl",
+        ".kungfu/episodes/sealed/sha256/<prefix>/<root>/manifest.json",
+        ".kungfu/episodes/sealed/sha256/<prefix>/<root>/qualification.json"
+      ]
+    },
+    "ignored": {
+      "const": [
+        ".kungfu/episodes/.tmp/",
+        ".kungfu/runtime/episode-provider/",
+        ".kungfu/private/",
+        ".kungfu/cache/"
+      ]
+    },
+    "schemas": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["manifest", "segment", "qualification", "providerContract"],
+      "properties": {
+        "manifest": {
+          "const": "schema/git-workspace-manifest-v1.schema.json"
+        },
+        "segment": {
+          "const": "schema/git-workspace-segment-v1.schema.json"
+        },
+        "qualification": {
+          "const": "schema/episode-qualification-v1.schema.json"
+        },
+        "providerContract": {
+          "const": "schema/git-workspace-provider-contract-v1.schema.json"
+        }
+      }
+    },
+    "framing": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["canonicalJson", "claims", "contentRefs", "dependencies"],
+      "properties": {
+        "canonicalJson": { "const": "utf8-key-order-compact-nfc-safe-integer/v1" },
+        "claims": { "const": "canonical-json-lines-lf-contiguous-index/v1" },
+        "contentRefs": { "const": "unique-root-utf8-order/v1" },
+        "dependencies": { "const": "declared-order-opaque-native-closure/v1" }
+      }
+    },
+    "writer": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["scope", "lease", "publication", "globalAllocator", "globalLedger", "globalPublicationLock"],
+      "properties": {
+        "scope": { "const": "per-episode" },
+        "lease": { "const": "exclusive-create" },
+        "publication": { "const": "temp-fsync-rename-dir-fsync" },
+        "globalAllocator": { "const": false },
+        "globalLedger": { "const": false },
+        "globalPublicationLock": { "const": false }
+      }
+    },
+    "equivalence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["requiresCppQualification", "recomputesEpisodeSemanticRoot", "preservesQualifiedEpisodeSemanticRoot", "providerRootIsEpisodeRoot"],
+      "properties": {
+        "requiresCppQualification": { "const": true },
+        "recomputesEpisodeSemanticRoot": { "const": false },
+        "preservesQualifiedEpisodeSemanticRoot": { "const": true },
+        "providerRootIsEpisodeRoot": { "const": false }
+      }
+    }
+  }
+}

--- a/framework/episode-provider/schema/git-workspace-segment-v1.schema.json
+++ b/framework/episode-provider/schema/git-workspace-segment-v1.schema.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kungfu.tech/schemas/episode-provider/git-workspace-segment-v1.schema.json",
+  "title": "Kungfu Git Workspace Episode JSONL Row v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "index", "record"],
+  "properties": {
+    "schema": { "const": "kungfu.episode.git-workspace-segment/v1" },
+    "index": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 9007199254740991
+    },
+    "record": { "$ref": "#/$defs/value" }
+  },
+  "$defs": {
+    "value": {
+      "oneOf": [
+        { "type": "null" },
+        { "type": "boolean" },
+        { "type": "string" },
+        {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 9007199254740991
+        },
+        {
+          "type": "array",
+          "items": { "$ref": "#/$defs/value" }
+        },
+        {
+          "type": "object",
+          "additionalProperties": { "$ref": "#/$defs/value" }
+        }
+      ]
+    }
+  }
+}

--- a/scripts/check-git-episode-provider.test.mjs
+++ b/scripts/check-git-episode-provider.test.mjs
@@ -5,6 +5,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
+import Ajv2020 from 'ajv/dist/2020.js';
 
 import {
   EPISODE_PROVIDER_CAPABILITY_MATRIX,
@@ -17,8 +18,42 @@ import {
   recoverGitEpisodeLease,
   sealGitEpisode,
 } from '../framework/episode-provider/src/git-workspace-episode-provider.mjs';
+import {
+  canonicalJson,
+  semanticRoot,
+  sha256Bytes,
+} from '../framework/project-cut/src/project-cut.mjs';
 
 const ROOT = 'a'.repeat(64);
+const MAX_SAFE_UINT64 = BigInt(Number.MAX_SAFE_INTEGER);
+const MAX_UINT64 = 18446744073709551615n;
+
+function readJson(relative) {
+  return JSON.parse(
+    fs.readFileSync(path.join(import.meta.dirname, '..', relative), 'utf8'),
+  );
+}
+
+function validUint64Wire(value) {
+  if (typeof value === 'number')
+    return Number.isSafeInteger(value) && value >= 0;
+  if (typeof value !== 'string' || !/^[1-9][0-9]{15,19}$/u.test(value))
+    return false;
+  const parsed = BigInt(value);
+  return parsed > MAX_SAFE_UINT64 && parsed <= MAX_UINT64;
+}
+
+function sortedUniqueRoots(values) {
+  return values.every(
+    (value, index) =>
+      /^sha256:[0-9a-f]{64}$/u.test(value) &&
+      (index === 0 ||
+        Buffer.compare(
+          Buffer.from(values[index - 1], 'utf8'),
+          Buffer.from(value, 'utf8'),
+        ) < 0),
+  );
+}
 
 function bundle(id = 7, root = ROOT) {
   return {
@@ -82,6 +117,130 @@ function workspace(t) {
   t.after(() => fs.rmSync(root, { recursive: true, force: true }));
   return root;
 }
+
+test('public schemas close producer bytes without claiming the native root', () => {
+  const ajv = new Ajv2020({ allErrors: true, strict: true });
+  const validateManifest = ajv.compile(
+    readJson(
+      'framework/episode-provider/schema/git-workspace-manifest-v1.schema.json',
+    ),
+  );
+  const validateSegment = ajv.compile(
+    readJson(
+      'framework/episode-provider/schema/git-workspace-segment-v1.schema.json',
+    ),
+  );
+  const validateQualification = ajv.compile(
+    readJson(
+      'framework/episode-provider/schema/episode-qualification-v1.schema.json',
+    ),
+  );
+  const validateProvider = ajv.compile(
+    readJson(
+      'framework/episode-provider/schema/git-workspace-provider-contract-v1.schema.json',
+    ),
+  );
+  const providerContract = readJson(
+    'framework/episode-provider/git-workspace-provider.contract.json',
+  );
+  const cases = readJson(
+    'framework/episode-provider/fixtures/schema-cases-v1.json',
+  );
+  assert.deepEqual(cases.positive, [
+    'provider-contract',
+    'sealed-manifest',
+    'qualification',
+    'claims-jsonl-rows',
+  ]);
+
+  const input = bundle();
+  input.refs = [
+    { ref_hash: `sha256:${'b'.repeat(64)}` },
+    { ref_hash: `sha256:${'a'.repeat(64)}` },
+    { ref_hash: `sha256:${'a'.repeat(64)}` },
+  ];
+  input.dependencies = [{ episode_id: 9 }, { episode_id: 8 }];
+  const qualified = qualification();
+  const segment = buildGitEpisodeSegment(input, qualified);
+  const rows = segment.claims
+    .toString('utf8')
+    .trimEnd()
+    .split('\n')
+    .map((row) => JSON.parse(row));
+
+  assert.equal(validateProvider(providerContract), true, ajv.errorsText());
+  assert.equal(validateManifest(segment.manifest), true, ajv.errorsText());
+  assert.equal(validateQualification(qualified), true, ajv.errorsText());
+  for (const row of rows)
+    assert.equal(validateSegment(row), true, ajv.errorsText());
+  assert.equal(segment.claims.at(-1), 0x0a);
+  assert.equal(segment.manifest.claims.count, rows.length);
+  assert.equal(segment.manifest.claims.digest, sha256Bytes(segment.claims));
+  assert.deepEqual(
+    rows.map(({ index }) => index),
+    rows.map((_, index) => index),
+  );
+  assert.equal(sortedUniqueRoots(segment.manifest.contentRefs), true);
+  assert.deepEqual(segment.manifest.dependencies, input.dependencies);
+  assert.equal(validUint64Wire(rows[0].record.record.begin_time), true);
+  const { providerRoot, ...providerPreimage } = segment.manifest;
+  assert.equal(providerRoot, semanticRoot(providerPreimage));
+  assert.equal(segment.manifest.qualificationRoot, semanticRoot(qualified));
+  assert.equal(segment.semanticRoot, `sha256:${ROOT}`);
+  assert.equal(
+    providerContract.equivalence.recomputesEpisodeSemanticRoot,
+    false,
+  );
+
+  const manifestExtra = structuredClone(segment.manifest);
+  manifestExtra.unexpected = true;
+  assert.equal(validateManifest(manifestExtra), false);
+  assert.equal(validateSegment({ ...rows[0], index: -1 }), false);
+  assert.equal(
+    validateQualification({ ...qualified, policy_source: 'javascript' }),
+    false,
+  );
+  assert.equal(
+    validateProvider({ ...providerContract, authority: 'git-workspace' }),
+    false,
+  );
+  assert.equal(
+    validateProvider({
+      ...providerContract,
+      schemas: { ...providerContract.schemas, manifest: 'consumer-owned.json' },
+    }),
+    false,
+  );
+  const unsafeDependency = structuredClone(segment.manifest);
+  unsafeDependency.dependencies = [{ episode_id: 9007199254740992 }];
+  assert.equal(validateManifest(unsafeDependency), false);
+  assert.equal(
+    sortedUniqueRoots([`sha256:${'b'.repeat(64)}`, `sha256:${'a'.repeat(64)}`]),
+    false,
+  );
+  assert.equal(validUint64Wire('18446744073709551616'), false);
+  assert.equal(validUint64Wire('9007199254740991'), false);
+  assert.equal(validUint64Wire(9007199254740992), false);
+  assert.equal(validUint64Wire('18446744073709551615'), true);
+  assert.deepEqual(
+    cases.adversarial.map(({ id }) => id),
+    [
+      'manifest-extra-field',
+      'segment-negative-index',
+      'qualification-wrong-policy',
+      'provider-authority-widened',
+      'provider-schema-path-substitution',
+      'dependency-unsafe-integer',
+      'content-ref-order',
+      'uint64-overflow-string',
+      'uint64-unsafe-number',
+    ],
+  );
+  assert.equal(
+    segment.qualificationBytes.toString('utf8'),
+    `${canonicalJson(qualified)}\n`,
+  );
+});
 
 test('seals one immutable JSONL segment and re-import is idempotent', (t) => {
   const root = workspace(t);


### PR DESCRIPTION
## Summary

- publish versioned JSON Schemas for the sealed Git workspace manifest, qualification evidence, immutable JSONL segments, and provider closure contract
- make JSONL framing, safe integer encoding, ordering, digest preimages, and tracked/ignored path authority explicit
- add product-owned positive and adversarial fixtures that recompute claims, qualification, and provider roots while refusing schema substitution and unsafe values
- preserve the native yijinjing semantic root as the sole authority; portable consumers verify the declared closure without inventing provider semantics

Fixes #1029

## Local validation

- `node scripts/check-git-episode-provider.test.mjs` (10/10)
- `./shifu docs:check`
- `./shifu check` on macOS after linearizing onto current `dev/v4/v4.0`

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Publishes portable schemas and verification rules for existing Episode provider bytes while preserving the native semantic-root authority boundary."
}
-->
