### PR TITLE
fix(facts): queue concurrent material writers

### DIFF
--- a/framework/core/src/libkungfu/src/runtime/facts/fact_admission.cpp
+++ b/framework/core/src/libkungfu/src/runtime/facts/fact_admission.cpp
@@ -7,17 +7,21 @@
 #include <kungfu/view/action_envelope.h>
 #include <kungfu/view/schema.h>
 #include <kungfu/yijinjing/journal/assemble.h>
+#include <kungfu/yijinjing/ownership.h>
 #include <kungfu/yijinjing/storage/content_hash.h>
 #include <kungfu/yijinjing/storage/episode_manifest.h>
 #include <kungfu/yijinjing/time.h>
 
 #include <algorithm>
 #include <charconv>
+#include <chrono>
 #include <limits>
 #include <map>
+#include <memory>
 #include <set>
 #include <stdexcept>
 #include <string>
+#include <thread>
 #include <utility>
 #include <vector>
 
@@ -31,6 +35,7 @@ namespace {
 constexpr uint32_t FACT_EVENT_SCHEMA_VERSION = 1;
 constexpr const char *FACT_NAMESPACE = "facts";
 constexpr const char *FACT_NAME = "admission";
+constexpr auto FACT_WRITER_WAIT_TIMEOUT = std::chrono::milliseconds(5000);
 
 struct schema_contract {
   view::schema_handle handle;
@@ -246,9 +251,24 @@ view::action::envelope wrap_event(const nlohmann::json &event, std::vector<uint8
   return envelope;
 }
 
-recorded_episode append_episode(const std::string &runtime_dir, std::vector<nlohmann::json> events, int64_t system_time,
-                                const std::string &title, const std::vector<owned_ref> &owned_refs = {}) {
-  action::action_recorder recorder(runtime_dir, FACT_NAMESPACE, FACT_NAME);
+std::unique_ptr<action::action_recorder> open_admission_writer(const std::string &runtime_dir) {
+  const auto deadline = std::chrono::steady_clock::now() + FACT_WRITER_WAIT_TIMEOUT;
+  while (true) {
+    try {
+      return std::make_unique<action::action_recorder>(runtime_dir, FACT_NAMESPACE, FACT_NAME);
+    } catch (const yy::ownership::busy_error &error) {
+      if (std::chrono::steady_clock::now() >= deadline) {
+        throw std::runtime_error("fact_writer_busy_timeout: fact admission writer remained busy for 5000 ms: " +
+                                 std::string(error.what()));
+      }
+      std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+  }
+}
+
+recorded_episode append_episode(action::action_recorder &recorder, const std::string &runtime_dir,
+                                std::vector<nlohmann::json> events, int64_t system_time, const std::string &title,
+                                const std::vector<owned_ref> &owned_refs = {}) {
   yy_storage::episode_manifest_store episodes(runtime_dir);
   yy_storage::episode_begin_options begin_options{};
   begin_options.location_uid = recorder.get_location()->uid;
@@ -669,16 +689,24 @@ nlohmann::json fact_contract_json() {
            {{"valid_time", "explicit observation range"},
             {"system_time", "journaled declaration/admission event time"},
             {"causal_time", "event parent plus frame trigger uid"}}},
+          {"writer_admission",
+           {{"mode", "bounded-core-wait/v1"},
+            {"timeout_ms", FACT_WRITER_WAIT_TIMEOUT.count()},
+            {"physical_writer", "single"},
+            {"concurrent_clients", "queued-before-read"}}},
           {"authority", "yijinjing-journal"},
-          {"known_limits", nlohmann::json::array({"single-writer admission journal", "opaque payload hash/ref only"})}};
+          {"known_limits", nlohmann::json::array({"single physical admission writer", "bounded concurrent client wait",
+                                                  "opaque payload hash/ref only"})}};
 }
 
 nlohmann::json declare_contract_world(const std::string &runtime_dir, const nlohmann::json &declaration,
                                       int64_t system_time) {
+  auto recorder = open_admission_writer(runtime_dir);
   const auto event_time = system_time == 0 ? yy::time::now_in_nano() : system_time;
   const auto normalized = normalize_world(declaration);
-  const auto recorded = append_episode(runtime_dir, {event_shell("ContractWorldDeclared", event_time, normalized)},
-                                       event_time, "contract world declaration");
+  const auto recorded =
+      append_episode(*recorder, runtime_dir, {event_shell("ContractWorldDeclared", event_time, normalized)}, event_time,
+                     "contract world declaration");
   return {{"schema", DOMAIN_FACT_CONTRACT_V1},
           {"declaration", normalized},
           {"reference", declaration_reference(normalized)},
@@ -688,6 +716,7 @@ nlohmann::json declare_contract_world(const std::string &runtime_dir, const nloh
 
 nlohmann::json declare_fact_surface(const std::string &runtime_dir, const nlohmann::json &declaration,
                                     int64_t system_time, const std::string &owned_schema_hash) {
+  auto recorder = open_admission_writer(runtime_dir);
   const auto event_time = system_time == 0 ? yy::time::now_in_nano() : system_time;
   const auto normalized = normalize_surface(declaration);
   const auto records = read_events(runtime_dir, event_time);
@@ -708,8 +737,9 @@ nlohmann::json declare_fact_surface(const std::string &runtime_dir, const nlohma
     }
     owned_refs.push_back({yy::enums::EpisodeRefKind::Schema, text_or(normalized, "id"), owned_schema_hash});
   }
-  const auto recorded = append_episode(runtime_dir, {event_shell("FactSurfaceDeclared", event_time, normalized)},
-                                       event_time, "fact surface declaration", owned_refs);
+  const auto recorded =
+      append_episode(*recorder, runtime_dir, {event_shell("FactSurfaceDeclared", event_time, normalized)}, event_time,
+                     "fact surface declaration", owned_refs);
   return {{"schema", DOMAIN_FACT_CONTRACT_V1},
           {"declaration", normalized},
           {"reference", declaration_reference(normalized)},
@@ -719,6 +749,7 @@ nlohmann::json declare_fact_surface(const std::string &runtime_dir, const nlohma
 
 nlohmann::json record_observation(const std::string &runtime_dir, const nlohmann::json &observation,
                                   int64_t system_time, const std::string &owned_payload_hash) {
+  auto recorder = open_admission_writer(runtime_dir);
   const auto event_time = system_time == 0 ? yy::time::now_in_nano() : system_time;
   const auto normalized = normalize_observation(observation);
   const auto records = read_events(runtime_dir, event_time);
@@ -758,7 +789,7 @@ nlohmann::json record_observation(const std::string &runtime_dir, const nlohmann
         {yy::enums::EpisodeRefKind::Payload, text_or(normalized, "observation_id"), owned_payload_hash});
   }
   const auto recorded =
-      append_episode(runtime_dir, {observation_event, admission_event}, event_time,
+      append_episode(*recorder, runtime_dir, {observation_event, admission_event}, event_time,
                      "observation admission " + normalized.at("observation_id").get<std::string>(), owned_refs);
   auto edge_admission = admission;
   edge_admission["outcome"] = verdict.outcome;

--- a/framework/core/src/libkungfu/src/runtime/storage/domain_dispatch.cpp
+++ b/framework/core/src/libkungfu/src/runtime/storage/domain_dispatch.cpp
@@ -312,6 +312,11 @@ public:
           {"redaction_policy", "hash-and-ref/v1"},
           {"compatibility_policy", "exact-schema-root/v1"}}},
         {"operations", nlohmann::json::array({"type-create", "type-list", "material-put", "material-list"})},
+        {"writer_admission",
+         {{"mode", "bounded-core-wait/v1"},
+          {"timeout_ms", 5000},
+          {"physical_writer", "single"},
+          {"concurrent_clients", "queued-before-read"}}},
         {"portability", {{"full", "owned schema and payload bytes"}, {"thin", "declared refs only"}}},
         {"known_limits", nlohmann::json::array({"one fixed semantic profile", "bounded JSON Schema object subset",
                                                 "no mutable global-latest workspace binding"})}};
@@ -464,7 +469,9 @@ public:
     if (!stored.ok()) {
       throw std::runtime_error("fact payload store failed: " + stored.message);
     }
-    const auto system_time = int64_or(options.operation_options, "system_time", kungfu::yijinjing::time::now_in_nano());
+    const auto requested_system_time = int64_or(options.operation_options, "system_time");
+    const auto identity_time =
+        requested_system_time == 0 ? kungfu::yijinjing::time::now_in_nano() : requested_system_time;
     auto observation_id = text_or(material, "observation_id");
     if (observation_id.empty()) {
       const auto identity = canonical_json({{"type_id", type_id},
@@ -472,7 +479,7 @@ public:
                                             {"source_id", source_id},
                                             {"subject_key", subject_key},
                                             {"payload_hash", payload_hash},
-                                            {"system_time", system_time}});
+                                            {"system_time", identity_time}});
       const auto identity_hash = yy_storage::compute_content_hash(identity).value;
       observation_id = "obs-" + identity_hash.substr(0, 24);
     }
@@ -483,13 +490,14 @@ public:
                                   {"schema_owner_root", required_text(selected, "schema_owner_root")},
                                   {"source_id", source_id},
                                   {"subject_key", subject_key},
-                                  {"valid_from", int64_or(material, "valid_from", system_time)},
+                                  {"valid_from", int64_or(material, "valid_from", identity_time)},
                                   {"valid_until", int64_or(material, "valid_until")},
                                   {"payload_hash", payload_hash},
                                   {"payload_ref", "content:payloads/" + payload_hash},
                                   {"action", text_or(material, "action", "assert")},
                                   {"target_observation_id", text_or(material, "target_observation_id")}};
-    const auto receipt = facts::record_observation(options.runtime_dir, observation, system_time, payload_hash);
+    const auto receipt =
+        facts::record_observation(options.runtime_dir, observation, requested_system_time, payload_hash);
     return {{"schema", "kungfu.facts.material-write/v1"},
             {"ok", receipt.at("admission").at("outcome") == "admitted"},
             {"payload_hash", payload_hash},

--- a/framework/core/src/python/kungfu/cli/commands/__init__.py
+++ b/framework/core/src/python/kungfu/cli/commands/__init__.py
@@ -20,8 +20,7 @@ def initialize_runtime_context(ctx) -> None:
     os.environ["KF_LOG_LEVEL"] = ctx.log_level
 
     def ensure_dir(path):
-        if not os.path.exists(path):
-            os.makedirs(path)
+        os.makedirs(path, exist_ok=True)
         return path
 
     ctx.runtime_dir = ensure_dir(ctx.runtime_dir)

--- a/framework/core/tests/python/test_storage_cli.py
+++ b/framework/core/tests/python/test_storage_cli.py
@@ -74,6 +74,63 @@ def _episode_cli_process(
     )
 
 
+def _fact_material_cli_process(
+    home: Path,
+    payload_path: Path,
+    *,
+    source: str,
+    subject: str,
+    observation_id: str,
+    ready_path: Path,
+    release_path: Path,
+) -> subprocess.Popen:
+    python_root = Path(__file__).resolve().parents[2] / "src" / "python"
+    env = os.environ.copy()
+    env["PYTHONPATH"] = os.pathsep.join(
+        value for value in [str(python_root), env.get("PYTHONPATH", "")] if value
+    )
+    env["KUNGFU_TEST_CLI_READY_PATH"] = str(ready_path)
+    env["KUNGFU_TEST_CLI_RELEASE_PATH"] = str(release_path)
+    return subprocess.Popen(
+        [
+            sys.executable,
+            "-c",
+            "import os, time; from pathlib import Path; "
+            "from kungfu.cli.commands import main; "
+            "ready = Path(os.environ['KUNGFU_TEST_CLI_READY_PATH']); "
+            "release = Path(os.environ['KUNGFU_TEST_CLI_RELEASE_PATH']); "
+            "ready.write_text('ready', encoding='utf-8'); "
+            "exec('deadline = time.monotonic() + 10\\nwhile not release.exists() and "
+            "time.monotonic() < deadline:\\n    time.sleep(0.005)'); "
+            "release.exists() or (_ for _ in ()).throw(RuntimeError('release barrier timed out')); "
+            "main()",
+            "--home",
+            str(home),
+            "facts",
+            "material",
+            "put",
+            "--type",
+            "qualification-job-facts",
+            "--type-version",
+            "v1",
+            "--source",
+            source,
+            "--subject",
+            subject,
+            "--payload-file",
+            str(payload_path),
+            "--observation-id",
+            observation_id,
+            "--action",
+            "assert",
+        ],
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+
 def _collect(processes: list[subprocess.Popen]) -> list[dict]:
     results = []
     for process in processes:
@@ -224,3 +281,78 @@ def test_episode_cli_absorbs_real_multi_process_manifest_contention(tmp_path):
         assert inspected["episode"]["close"]["status"] == 2
         fsck = service.fsck(runtime_dir, episode_id=episode_id)
         assert fsck["ok"], fsck
+
+
+def test_fact_cli_queues_real_multi_process_material_writers(tmp_path):
+    home = tmp_path / "home"
+    runtime_dir = home / "runtime"
+    writer_count = 8
+    sources = [f"agent-{index}" for index in range(writer_count)]
+    service.fact_type_create(
+        runtime_dir,
+        {
+            "id": "qualification-job-facts",
+            "version": "v1",
+            "source_authorities": sources,
+            "schema": {
+                "type": "object",
+                "properties": {"writer": {"type": "string"}},
+                "required": ["writer"],
+                "additionalProperties": False,
+            },
+        },
+    )
+
+    release_path = tmp_path / "release-fact-writers"
+    ready_paths = [
+        tmp_path / f"fact-writer-{index}.ready" for index in range(writer_count)
+    ]
+    payload_paths = [
+        tmp_path / f"fact-writer-{index}.json" for index in range(writer_count)
+    ]
+    for index, payload_path in enumerate(payload_paths):
+        payload_path.write_text(
+            json.dumps({"writer": sources[index]}), encoding="utf-8"
+        )
+    processes = [
+        _fact_material_cli_process(
+            home,
+            payload_paths[index],
+            source=sources[index],
+            subject=f"job-{index}",
+            observation_id=f"obs-{index}",
+            ready_path=ready_paths[index],
+            release_path=release_path,
+        )
+        for index in range(writer_count)
+    ]
+
+    deadline = time.monotonic() + 10
+    while (
+        not all(path.exists() for path in ready_paths) and time.monotonic() < deadline
+    ):
+        time.sleep(0.01)
+    assert all(path.exists() for path in ready_paths), (
+        "not every public CLI reached command dispatch"
+    )
+    release_path.write_text("go", encoding="utf-8")
+    results = _collect(processes)
+
+    assert all(
+        result["schema"] == "kungfu.facts.material-write/v1" for result in results
+    )
+    assert all(result["ok"] is True for result in results)
+    assert all(
+        result["receipt"]["admission"]["outcome"] == "admitted" for result in results
+    )
+    contract = service.fact_library_contract(runtime_dir)
+    assert contract["writer_admission"] == {
+        "mode": "bounded-core-wait/v1",
+        "timeout_ms": 5000,
+        "physical_writer": "single",
+        "concurrent_clients": "queued-before-read",
+    }
+    catalog = service.fact_material_list(runtime_dir, type_id="qualification-job-facts")
+    assert {
+        row["observation_id"] for row in catalog["state"]["observation_history"]
+    } == {f"obs-{index}" for index in range(writer_count)}


### PR DESCRIPTION
## Summary

- acquire the Fact admission writer before reading current state, so concurrent clients are serialized at the Core commit boundary instead of racing through a read/write gap
- expose a bounded 5-second `bounded-core-wait/v1` writer-admission contract while preserving the yijinjing single-physical-writer invariant
- make concurrent CLI home-directory initialization idempotent
- add a real 8-process public CLI test proving all distinct Fact subjects are admitted and visible without adapter-side retry

Fixes #1030

## Local validation

- C++23 macOS build: `cmake --build framework/core/build --target kungfu pykungfu --parallel 20`
- `pytest framework/core/tests/python/test_storage_cli.py -k fact_cli_queues_real_multi_process_material_writers -vv`
- `./shifu check`

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Fixes concurrent client admission for the existing Fact Library contract while preserving its single physical journal-writer authority."
}
-->
