### PR TITLE
fix(ci): advance dev patrol Buildchain runtime

### DIFF
--- a/.github/workflows/dev-verify-patrol.yml
+++ b/.github/workflows/dev-verify-patrol.yml
@@ -34,7 +34,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@a6145efc210a961da0e5c63d7024d42061550f60
+    uses: kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@ec48c0b311212c5f3a591e0284da6e85a9fdded5 # v2.13.0
     with:
       buildchain-ref: ${{ inputs.buildchain-ref || '' }}
       gate-profile: dev-patrol

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -498,7 +498,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:d6b16780206fe7b7d72d912b7c96cf6b7c76b0534f3b90f4b8f51cb03962cac4",
+          "definitionDigest": "sha256:c07d917791b1220526427325815b6675aa0e54cccf77c16c8bca98a210127265",
           "credentials": {
             "githubToken": "write",
             "oidc": true,
@@ -507,7 +507,7 @@
             "environment": null
           },
           "externalActions": [
-            "kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@a6145efc210a961da0e5c63d7024d42061550f60"
+            "kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@ec48c0b311212c5f3a591e0284da6e85a9fdded5"
           ],
           "steps": []
         }

--- a/docs/qualification/gates/workflow-bindings.json
+++ b/docs/qualification/gates/workflow-bindings.json
@@ -193,7 +193,7 @@
       ],
       "activation": "daily or manual on dev",
       "invocation": {
-        "uses": "kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@a6145efc210a961da0e5c63d7024d42061550f60",
+        "uses": "kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@ec48c0b311212c5f3a591e0284da6e85a9fdded5",
         "with": {
           "gate-profile": "dev-patrol",
           "runner-preset": "kungfu-v4-self-hosted",

--- a/scripts/check-kungfu-gate-catalog.test.mjs
+++ b/scripts/check-kungfu-gate-catalog.test.mjs
@@ -859,7 +859,7 @@ test('direct Gate arguments and profile inputs fail closed on drift', () => {
     fs
       .readFileSync(profileRefWorkflow, 'utf8')
       .replace(
-        '.gate-profile.yml@a6145efc210a961da0e5c63d7024d42061550f60',
+        '.gate-profile.yml@ec48c0b311212c5f3a591e0284da6e85a9fdded5',
         '.gate-profile.yml@v2-alpha',
       ),
   );


### PR DESCRIPTION
## Summary

- advance the dev verify patrol from Buildchain v2.12.4 to stable v2.13.0
- pick up the exact-SHA stale bundle fallback already proven in Buildchain #1261
- refresh the governed workflow authority and invocation facts

Closes #612.

## Mac verification

- `node --test scripts/check-kungfu-gate-catalog.test.mjs` — 21/21 passed
- staged repository gate — passed
- `git diff --check` — passed

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Advances a pinned CI controller runtime to a published compatible fix without changing Kungfu runtime architecture or release claims."
}
-->
