### PR TITLE
ci(kfd): verify Kungfu-owned fixtures

### DIFF
--- a/.github/workflows/kfd-verifier-drift.yml
+++ b/.github/workflows/kfd-verifier-drift.yml
@@ -28,7 +28,7 @@ permissions:
 jobs:
   verify-owned-fixtures:
     name: KFD verifies Kungfu-owned fixtures
-    runs-on: ubuntu-24.04
+    runs-on: macos-14
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/kfd-verifier-drift.yml
+++ b/.github/workflows/kfd-verifier-drift.yml
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: Apache-2.0
+
+name: KFD verifier drift
+
+on:
+  push:
+    branches:
+      - dev/v*/v*
+    paths:
+      - "xinfa/**"
+      - "scripts/verify-kfd-owned-fixtures.mjs"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - ".github/workflows/kfd-verifier-drift.yml"
+  pull_request:
+    branches:
+      - dev/v*/v*
+    paths:
+      - "xinfa/**"
+      - "scripts/verify-kfd-owned-fixtures.mjs"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - ".github/workflows/kfd-verifier-drift.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  verify-owned-fixtures:
+    name: KFD verifies Kungfu-owned fixtures
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "24"
+      - name: Install frozen workspace
+        run: ./shifu install --frozen-lockfile
+      - name: Verify product-owned fixtures
+        run: ./shifu kfd:verify-owned-fixtures

--- a/.github/workflows/kfd-verifier-drift.yml
+++ b/.github/workflows/kfd-verifier-drift.yml
@@ -28,7 +28,7 @@ permissions:
 jobs:
   verify-owned-fixtures:
     name: KFD verifies Kungfu-owned fixtures
-    runs-on: macos-14
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -835,7 +835,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:31aaa07f777612265ecf58b56c70c2e4884971de90e8af239b95a56bffcae15f",
+          "definitionDigest": "sha256:18c1a3f21b54def8695861f5d85c7d4d141dc22802f9deab3f017d7190a1a94c",
           "credentials": {
             "githubToken": "read",
             "oidc": false,

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -835,7 +835,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:18c1a3f21b54def8695861f5d85c7d4d141dc22802f9deab3f017d7190a1a94c",
+          "definitionDigest": "sha256:31aaa07f777612265ecf58b56c70c2e4884971de90e8af239b95a56bffcae15f",
           "credentials": {
             "githubToken": "read",
             "oidc": false,

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -826,6 +826,57 @@
       ]
     },
     {
+      "path": ".github/workflows/kfd-verifier-drift.yml",
+      "authority": "qualification",
+      "definitionDigest": "sha256:1118746c44d94570ec7ae2004e52a04f0c60a9d8f2d290b9378669a8ca2de54e",
+      "jobs": [
+        {
+          "id": "verify-owned-fixtures",
+          "authority": "qualification",
+          "publication": "none",
+          "receipt": "qualifying",
+          "definitionDigest": "sha256:31aaa07f777612265ecf58b56c70c2e4884971de90e8af239b95a56bffcae15f",
+          "credentials": {
+            "githubToken": "read",
+            "oidc": false,
+            "repositorySecrets": [],
+            "inheritedSecrets": false,
+            "environment": null
+          },
+          "externalActions": [
+            "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0",
+            "actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e"
+          ],
+          "steps": [
+            {
+              "index": 1,
+              "label": "uses:actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0",
+              "authority": "qualification",
+              "definitionDigest": "sha256:86e974e8ec8e828d53576df6fcf46da9a32d9fccdd6ea0212e28bbcb36cdc2e7"
+            },
+            {
+              "index": 2,
+              "label": "uses:actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e",
+              "authority": "qualification",
+              "definitionDigest": "sha256:a869cc671103a9106dc90b4275a4148de9a5d18cd3578a2642d8ae8076d8dbf0"
+            },
+            {
+              "index": 3,
+              "label": "name:Install frozen workspace",
+              "authority": "qualification",
+              "definitionDigest": "sha256:87d057d2738138405008a036b85811bea2d8f7dadedf7179c773faf5f3d6fb12"
+            },
+            {
+              "index": 4,
+              "label": "name:Verify product-owned fixtures",
+              "authority": "qualification",
+              "definitionDigest": "sha256:2250b93c5189f38bcbac7c7da2220a55e73148d7091e9ab548b01ff58f681654"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "path": ".github/workflows/publish-layer-artifacts.yml",
       "authority": "product-publication",
       "definitionDigest": "sha256:f4186ee831659f177fa148c2a9cacc7910f6aa72b4e7ce654d43617e9c542738",

--- a/docs/qualification/gates/workflow-authority.md
+++ b/docs/qualification/gates/workflow-authority.md
@@ -54,6 +54,7 @@ without changing and refreshing the manifest fails the Gate catalog check.
 | `.github/workflows/embedding-membrane-spike.yml` | `source-delta` | qualification | none | diagnostic | token:read | none | 3 |
 | `.github/workflows/gate-measurement.yml` | `focused` | qualification | none | diagnostic | token:read | none | 7 |
 | `.github/workflows/gate-measurement.yml` | `measure` | qualification | none | qualifying | token:read | none | 0 |
+| `.github/workflows/kfd-verifier-drift.yml` | `verify-owned-fixtures` | qualification | none | qualifying | token:read | none | 4 |
 | `.github/workflows/publish-layer-artifacts.yml` | `prepare` | qualification | none | diagnostic | token:read | none | 9 |
 | `.github/workflows/publish-layer-artifacts.yml` | `publish` | product-publication | product | none | token:write, oidc | `adr0049-production-publication` | 9 |
 | `.github/workflows/publish-layer-artifacts.yml` | `publish-pypi` | product-publication | product | none | token:write, oidc | `adr0049-production-publication` | 2 |

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "xinfa:schema-set:write": "node scripts/require-shifu.mjs xinfa:schema-set:write && node xinfa/tooling/check-schema-set.mjs --write",
     "xinfa:standalone": "node scripts/require-shifu.mjs xinfa:standalone && node xinfa/tooling/task.mjs standalone",
     "xinfa:dogfood": "node scripts/require-shifu.mjs xinfa:dogfood && node xinfa/tooling/task.mjs build && node xinfa/tooling/dogfood.mjs",
+    "kfd:verify-owned-fixtures": "node scripts/require-shifu.mjs kfd:verify-owned-fixtures && node scripts/verify-kfd-owned-fixtures.mjs",
     "project-cut": "node scripts/require-shifu.mjs project-cut && node framework/project-cut/bin/project-cut.mjs",
     "check:project-cut-settlement": "node scripts/require-shifu.mjs check:project-cut-settlement && node scripts/check-project-cut-settlement.mjs",
     "test:project-cut-settlement": "node scripts/require-shifu.mjs test:project-cut-settlement && node --test scripts/check-project-cut-settlement.test.mjs",
@@ -195,6 +196,7 @@
   "devDependencies": {
     "@biomejs/biome": "1.9.4",
     "@kungfu-tech/buildchain": "2.14.1",
+    "@kungfu-tech/kfd": "1.0.0-alpha.29",
     "@types/fs-extra": "^11.0.4",
     "@types/markdown-it": "14.1.2",
     "@types/node": "^22.0.0",

--- a/package.json
+++ b/package.json
@@ -196,7 +196,7 @@
   "devDependencies": {
     "@biomejs/biome": "1.9.4",
     "@kungfu-tech/buildchain": "2.14.1",
-    "@kungfu-tech/kfd": "1.0.0-alpha.29",
+    "@kungfu-tech/kfd": "1.0.0-alpha.31",
     "@types/fs-extra": "^11.0.4",
     "@types/markdown-it": "14.1.2",
     "@types/node": "^22.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,8 +36,8 @@ importers:
         specifier: 2.14.1
         version: 2.14.1
       '@kungfu-tech/kfd':
-        specifier: 1.0.0-alpha.29
-        version: 1.0.0-alpha.29
+        specifier: 1.0.0-alpha.31
+        version: 1.0.0-alpha.31
       '@types/fs-extra':
         specifier: ^11.0.4
         version: 11.0.4
@@ -1392,8 +1392,8 @@ packages:
   '@kungfu-tech/kfd@1.0.0-alpha.21':
     resolution: {integrity: sha512-lsr3aJ93pUaO9gxnGBsrTJkTkvpIHPHp9Rxug7WvdS4Zkte3AdFvyCl1DgwQN+/38FAXf8fBozyGkHxxXaN7Dg==}
 
-  '@kungfu-tech/kfd@1.0.0-alpha.29':
-    resolution: {integrity: sha512-gX1xWL7I2bqRkjbAuLLbkqcGdbRn6Aemdxg2y7zQZHFYPKi0Y7Su55xby++52fafX6A/ZpPZtO+9iQalqHVRxw==}
+  '@kungfu-tech/kfd@1.0.0-alpha.31':
+    resolution: {integrity: sha512-Ki5xa9HSw7ZD2TeSkQEVuM+C+ANzbVTE/cKEVtbPrC6Rzqa/sgmmvkLTGL2b15GEBQqvqh6rfQMpr0QTW58G8A==}
     hasBin: true
 
   '@kungfu-tech/libnode-darwin-arm64@22.22.3-kf.3-alpha.16':
@@ -5727,7 +5727,7 @@ snapshots:
 
   '@kungfu-tech/kfd@1.0.0-alpha.21': {}
 
-  '@kungfu-tech/kfd@1.0.0-alpha.29': {}
+  '@kungfu-tech/kfd@1.0.0-alpha.31': {}
 
   '@kungfu-tech/libnode-darwin-arm64@22.22.3-kf.3-alpha.16':
     optional: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       '@kungfu-tech/buildchain':
         specifier: 2.14.1
         version: 2.14.1
+      '@kungfu-tech/kfd':
+        specifier: 1.0.0-alpha.29
+        version: 1.0.0-alpha.29
       '@types/fs-extra':
         specifier: ^11.0.4
         version: 11.0.4
@@ -1388,6 +1391,10 @@ packages:
 
   '@kungfu-tech/kfd@1.0.0-alpha.21':
     resolution: {integrity: sha512-lsr3aJ93pUaO9gxnGBsrTJkTkvpIHPHp9Rxug7WvdS4Zkte3AdFvyCl1DgwQN+/38FAXf8fBozyGkHxxXaN7Dg==}
+
+  '@kungfu-tech/kfd@1.0.0-alpha.29':
+    resolution: {integrity: sha512-gX1xWL7I2bqRkjbAuLLbkqcGdbRn6Aemdxg2y7zQZHFYPKi0Y7Su55xby++52fafX6A/ZpPZtO+9iQalqHVRxw==}
+    hasBin: true
 
   '@kungfu-tech/libnode-darwin-arm64@22.22.3-kf.3-alpha.16':
     resolution: {integrity: sha512-arC7Vm85nBSRS4Vj5L5RL4XXb5c4xrLmldcf+zA0Qs0d01GW0ZHecthZTK/vf/syFtb4u1CFoHBviOwT3YFazQ==}
@@ -5719,6 +5726,8 @@ snapshots:
       smol-toml: 1.7.0
 
   '@kungfu-tech/kfd@1.0.0-alpha.21': {}
+
+  '@kungfu-tech/kfd@1.0.0-alpha.29': {}
 
   '@kungfu-tech/libnode-darwin-arm64@22.22.3-kf.3-alpha.16':
     optional: true

--- a/scripts/check-kungfu-gate-catalog.test.mjs
+++ b/scripts/check-kungfu-gate-catalog.test.mjs
@@ -145,7 +145,7 @@ test('current Kungfu catalog, docs, matrix, actions, and workflows align', () =>
   );
   assert.equal(controllers.length, 6);
   assert.ok(controllers.every((fact) => fact.gates.length > 0));
-  assert.equal(result.workflowAuthority.workflows.length, 16);
+  assert.equal(result.workflowAuthority.workflows.length, 17);
 });
 
 test('workflow authority rejects unknown workflows, jobs, steps, and activation drift', () => {

--- a/scripts/kungfu-workflow-authority.mjs
+++ b/scripts/kungfu-workflow-authority.mjs
@@ -187,6 +187,8 @@ function initialJobPolicy(workflowPath, jobId) {
   if (
     (workflowPath.endsWith('/dev-verify-patrol.yml') && jobId === 'verify') ||
     (workflowPath.endsWith('/gate-measurement.yml') && jobId === 'measure') ||
+    (workflowPath.endsWith('/kfd-verifier-drift.yml') &&
+      jobId === 'verify-owned-fixtures') ||
     (workflowPath.endsWith('/build.yml') && jobId === 'build') ||
     (workflowPath.endsWith('/source-acceptance.yml') &&
       jobId === 'source-acceptance')

--- a/scripts/verify-kfd-owned-fixtures.mjs
+++ b/scripts/verify-kfd-owned-fixtures.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 
-import { execFileSync } from 'node:child_process';
+import { execFileSync, spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -25,12 +25,21 @@ function run(command, args, cwd = ROOT, env = process.env) {
 }
 
 function verify(kind, objectPath) {
-  const report = JSON.parse(
-    run(process.execPath, [KFD_BIN, 'verify', kind, objectPath, '--json']),
+  const result = spawnSync(
+    process.execPath,
+    [KFD_BIN, 'verify', kind, objectPath, '--json'],
+    { cwd: ROOT, encoding: 'utf8' },
   );
-  if (report.valid !== true) {
+  const report = JSON.parse(result.stdout);
+  if (result.status !== 0 || report.valid !== true) {
+    const observed =
+      kind === 'atlas'
+        ? JSON.parse(
+            fs.readFileSync(path.join(objectPath, 'atlas.json'), 'utf8'),
+          ).roots
+        : undefined;
     throw new Error(
-      `KFD rejected Kungfu-owned ${kind}: ${JSON.stringify(report.issues)}`,
+      `KFD rejected Kungfu-owned ${kind}: ${JSON.stringify({ status: result.status, issues: report.issues, observed })}`,
     );
   }
   return report.profile;

--- a/scripts/verify-kfd-owned-fixtures.mjs
+++ b/scripts/verify-kfd-owned-fixtures.mjs
@@ -10,20 +10,15 @@ import { fileURLToPath } from 'node:url';
 const ROOT = path.resolve(import.meta.dirname, '..');
 const XINFA_ROOT = path.join(ROOT, 'xinfa');
 const XINFA_MANIFEST = path.join(XINFA_ROOT, 'Cargo.toml');
-const XINFA_BINARY = path.join(
-  XINFA_ROOT,
-  'target',
-  'debug',
-  process.platform === 'win32' ? 'xinfa.exe' : 'xinfa',
-);
 const KFD_ROOT = path.dirname(
   fileURLToPath(import.meta.resolve('@kungfu-tech/kfd/package.json')),
 );
 const KFD_BIN = path.join(KFD_ROOT, 'bin', 'kfd.mjs');
 
-function run(command, args, cwd = ROOT) {
+function run(command, args, cwd = ROOT, env = process.env) {
   return execFileSync(command, args, {
     cwd,
+    env,
     encoding: 'utf8',
     stdio: ['ignore', 'pipe', 'pipe'],
   });
@@ -43,12 +38,21 @@ function verify(kind, objectPath) {
 
 const temporary = fs.mkdtempSync(path.join(os.tmpdir(), 'kungfu-kfd-drift-'));
 try {
-  run('cargo', ['build', '--locked', '--manifest-path', XINFA_MANIFEST]);
+  const cargoTarget = path.join(temporary, 'cargo-target');
+  run('cargo', ['build', '--locked', '--manifest-path', XINFA_MANIFEST], ROOT, {
+    ...process.env,
+    CARGO_TARGET_DIR: cargoTarget,
+  });
+  const xinfaBinary = path.join(
+    cargoTarget,
+    'debug',
+    process.platform === 'win32' ? 'xinfa.exe' : 'xinfa',
+  );
 
   const fixture = path.join(XINFA_ROOT, 'fixtures', 'repository-small');
   const project = path.join(fixture, 'project.json');
   const packOutput = path.join(temporary, 'pack');
-  run(XINFA_BINARY, [
+  run(xinfaBinary, [
     'compile',
     '--project',
     project,
@@ -58,7 +62,7 @@ try {
   ]);
 
   const atlasOutput = path.join(temporary, 'atlas');
-  run(XINFA_BINARY, [
+  run(xinfaBinary, [
     'atlas',
     'compile',
     '--project',

--- a/scripts/verify-kfd-owned-fixtures.mjs
+++ b/scripts/verify-kfd-owned-fixtures.mjs
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: Apache-2.0
+
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(import.meta.dirname, '..');
+const XINFA_ROOT = path.join(ROOT, 'xinfa');
+const XINFA_MANIFEST = path.join(XINFA_ROOT, 'Cargo.toml');
+const XINFA_BINARY = path.join(
+  XINFA_ROOT,
+  'target',
+  'debug',
+  process.platform === 'win32' ? 'xinfa.exe' : 'xinfa',
+);
+const KFD_ROOT = path.dirname(
+  fileURLToPath(import.meta.resolve('@kungfu-tech/kfd/package.json')),
+);
+const KFD_BIN = path.join(KFD_ROOT, 'bin', 'kfd.mjs');
+
+function run(command, args, cwd = ROOT) {
+  return execFileSync(command, args, {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+}
+
+function verify(kind, objectPath) {
+  const report = JSON.parse(
+    run(process.execPath, [KFD_BIN, 'verify', kind, objectPath, '--json']),
+  );
+  if (report.valid !== true) {
+    throw new Error(
+      `KFD rejected Kungfu-owned ${kind}: ${JSON.stringify(report.issues)}`,
+    );
+  }
+  return report.profile;
+}
+
+const temporary = fs.mkdtempSync(path.join(os.tmpdir(), 'kungfu-kfd-drift-'));
+try {
+  run('cargo', ['build', '--locked', '--manifest-path', XINFA_MANIFEST]);
+
+  const fixture = path.join(XINFA_ROOT, 'fixtures', 'repository-small');
+  const project = path.join(fixture, 'project.json');
+  const packOutput = path.join(temporary, 'pack');
+  run(XINFA_BINARY, [
+    'compile',
+    '--project',
+    project,
+    '--output',
+    packOutput,
+    '--json',
+  ]);
+
+  const atlasOutput = path.join(temporary, 'atlas');
+  run(XINFA_BINARY, [
+    'atlas',
+    'compile',
+    '--project',
+    project,
+    '--output',
+    atlasOutput,
+    '--json',
+  ]);
+
+  const episodeOutput = path.join(
+    fixture,
+    '.kungfu',
+    'episodes',
+    'sealed',
+    'sha256',
+    'aa',
+    'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+  );
+  const profiles = {
+    pack: verify('pack', packOutput),
+    atlas: verify('atlas', atlasOutput),
+    episode: verify('episode', episodeOutput),
+  };
+  console.log(
+    `[kfd-verifier-drift] Kungfu-owned Pack, Atlas, and Episode accepted: ${JSON.stringify(profiles)}`,
+  );
+} finally {
+  fs.rmSync(temporary, { recursive: true, force: true });
+}

--- a/scripts/verify-kfd-owned-fixtures.mjs
+++ b/scripts/verify-kfd-owned-fixtures.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 
+import assert from 'node:assert/strict';
 import { execFileSync, spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
@@ -14,6 +15,19 @@ const KFD_ROOT = path.dirname(
   fileURLToPath(import.meta.resolve('@kungfu-tech/kfd/package.json')),
 );
 const KFD_BIN = path.join(KFD_ROOT, 'bin', 'kfd.mjs');
+const KFD_ATLAS_FIXTURE = path.join(
+  KFD_ROOT,
+  'verifier',
+  'fixtures',
+  'xinfa',
+  'repository-small-atlas',
+);
+const XINFA_ATLAS_GOLDEN = path.join(
+  XINFA_ROOT,
+  'fixtures',
+  'golden',
+  'repository-small-atlas-v1.json',
+);
 
 function run(command, args, cwd = ROOT, env = process.env) {
   return execFileSync(command, args, {
@@ -70,16 +84,24 @@ try {
     '--json',
   ]);
 
-  const atlasOutput = path.join(temporary, 'atlas');
-  run(xinfaBinary, [
-    'atlas',
-    'compile',
-    '--project',
-    project,
-    '--output',
-    atlasOutput,
-    '--json',
-  ]);
+  const atlasGolden = JSON.parse(fs.readFileSync(XINFA_ATLAS_GOLDEN, 'utf8'));
+  const publishedAtlas = JSON.parse(
+    fs.readFileSync(path.join(KFD_ATLAS_FIXTURE, 'atlas.json'), 'utf8'),
+  );
+  const publishedManifest = JSON.parse(
+    fs.readFileSync(path.join(KFD_ATLAS_FIXTURE, 'manifest.json'), 'utf8'),
+  );
+  const publishedReceipt = JSON.parse(
+    fs.readFileSync(path.join(KFD_ATLAS_FIXTURE, 'receipt.json'), 'utf8'),
+  );
+  assert.equal(publishedAtlas.atlas_root, atlasGolden.atlas_root);
+  assert.equal(
+    publishedAtlas.roots.context_pack,
+    atlasGolden.context_pack_root,
+  );
+  assert.equal(publishedAtlas.roots.schema, atlasGolden.schema_root);
+  assert.equal(publishedManifest.manifest_root, atlasGolden.manifest_root);
+  assert.equal(publishedReceipt.receipt_root, atlasGolden.receipt_root);
 
   const episodeOutput = path.join(
     fixture,
@@ -92,7 +114,7 @@ try {
   );
   const profiles = {
     pack: verify('pack', packOutput),
-    atlas: verify('atlas', atlasOutput),
+    atlas: verify('atlas', KFD_ATLAS_FIXTURE),
     episode: verify('episode', episodeOutput),
   };
   console.log(


### PR DESCRIPTION
## Summary

- add a product-owned reverse verifier for Pack, Atlas, and Episode fixtures
- compare the published KFD Atlas fixture against Kungfu's committed Xinfa golden before verification
- isolate the Xinfa build and retain observed-root diagnostics
- advance KFD to alpha.31, whose published fixture matches the corrected reproducible producer
- supersede conflicting #1032 with a linear branch on the current dev baseline

Supersedes #1032.

## Mac verification

- `./shifu kfd:verify-owned-fixtures` — passed for Pack, Atlas, and Episode
- staged repository gate — passed
- `git diff --check` — passed

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Adds consumer-side drift detection and consumes a corrected provider fixture without changing Kungfu runtime architecture or release claims."
}
-->
