### PR TITLE
fix(yijinjing): carry page lifecycle as policy

### DIFF
--- a/framework/core/src/libkungfu/include/kungfu/runtime/io.h
+++ b/framework/core/src/libkungfu/include/kungfu/runtime/io.h
@@ -33,6 +33,11 @@ struct io_mapping_policy {
   [[nodiscard]] static constexpr io_mapping_policy from_legacy_lazy(bool lazy) noexcept {
     return lazy ? peer() : coordinator();
   }
+
+  [[nodiscard]] constexpr io_mapping_policy
+  with_lifecycle(yijinjing::journal::page_lifecycle_policy value) const noexcept {
+    return {reader.with_lifecycle(value), resource_manager_required, legacy_lazy_value};
+  }
 };
 
 FORWARD_DECLARE_CLASS_PTR(session)

--- a/framework/core/src/libkungfu/src/runtime/io/io.cpp
+++ b/framework/core/src/libkungfu/src/runtime/io/io.cpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
+#include <cstdlib>
+
 #include <kungfu/common.h>
 #include <kungfu/runtime/io.h>
 #include <kungfu/runtime/live/identity.h>
@@ -150,11 +152,34 @@ public:
   bool is_usable() override { return socket_.recv(NNG_FLAG_ALLOC) == 0; }
 };
 
+namespace {
+/**
+ * The process's single read of the legacy page-lifecycle environment knobs.
+ *
+ * Transitional. KF_KEEP_PAGE and KF_MAX_PRE_CREATE_SIZE are undocumented
+ * diagnostic knobs with no in-tree consumer; they are honoured here for one
+ * migration window and are scheduled for retirement, after which page
+ * lifecycle is supplied by the caller through io_mapping_policy only.
+ *
+ * Reading them here rather than inside journal's constructor keeps the journal
+ * a function of its arguments: the entry layer owns configuration, the core
+ * carries policy.
+ */
+io_mapping_policy resolve_legacy_env_lifecycle(io_mapping_policy policy) {
+  const auto parsed =
+      yijinjing::journal::parse_page_lifecycle(std::getenv("KF_KEEP_PAGE"), std::getenv("KF_MAX_PRE_CREATE_SIZE"));
+  if (not parsed.ok()) {
+    SPDLOG_WARN("ignoring unusable KF_MAX_PRE_CREATE_SIZE; page pre-creation size ceiling stays disabled");
+  }
+  return policy.with_lifecycle(parsed.policy);
+}
+} // namespace
+
 io_device::io_device(data::location_ptr home, const bool low_latency, io_mapping_policy policy)
     : home_(std::move(home)),
       live_home_(location::make_shared(mode::LIVE, home_->role, home_->namespace_, home_->name, home_->locator)),
-      low_latency_(low_latency), mapping_policy_(policy), begin_time_(time::now_in_nano()),
-      bus_(std::make_shared<bus>(is_resource_manager_required())) {
+      low_latency_(low_latency), mapping_policy_(resolve_legacy_env_lifecycle(policy)),
+      begin_time_(time::now_in_nano()), bus_(std::make_shared<bus>(is_resource_manager_required())) {
   // keep the guarantees deterministic even when static-library linking drops
   // the seam installers' load-time static initializers
   journal::install_typed_frame_dumper();

--- a/framework/core/src/libyijinjing/include/kungfu/yijinjing/journal/journal.h
+++ b/framework/core/src/libyijinjing/include/kungfu/yijinjing/journal/journal.h
@@ -51,10 +51,60 @@ typedef std::map<journal_key, journal_ptr> JournalMap;
 
 enum class page_precreation : uint8_t { disabled, coordinator };
 
+/**
+ * Page lifecycle knobs: how long a passed page is retained, and the page-size
+ * ceiling above which the coordinator stops pre-creating the next page.
+ *
+ * These are diagnostic knobs. They are carried as policy rather than read from
+ * the process environment inside the journal, so that a journal's behaviour is
+ * a function of its arguments only — copyable, testable, and injectable.
+ */
+struct page_lifecycle_policy {
+  /// Retain passed pages instead of releasing them (diagnostic).
+  bool keep_page = false;
+  /// Skip coordinator pre-creation once page size exceeds this many MB.
+  /// Zero means no ceiling, i.e. pre-creation is never skipped on size.
+  uint32_t max_pre_create_size_mb = 0;
+
+  [[nodiscard]] static constexpr page_lifecycle_policy defaults() noexcept { return {}; }
+};
+
+enum class page_lifecycle_parse_status : uint8_t { ok, max_pre_create_size_invalid };
+
+/**
+ * Outcome of parsing page lifecycle configuration. Parse failure is a value,
+ * not an exception and not a swallowed log: the caller decides whether an
+ * unusable setting deserves a warning or a hard stop (ADR-0082 tier 3).
+ * On failure `policy` carries the defaults for the field that failed.
+ */
+struct page_lifecycle_parse_result {
+  page_lifecycle_policy policy;
+  page_lifecycle_parse_status status = page_lifecycle_parse_status::ok;
+
+  [[nodiscard]] constexpr bool ok() const noexcept { return status == page_lifecycle_parse_status::ok; }
+};
+
+/**
+ * Parse page lifecycle configuration from raw string values.
+ *
+ * Pure: it reads no process state, so it is unit-testable without mutating the
+ * environment. The entry layer supplies the values; historically these came
+ * from KF_KEEP_PAGE / KF_MAX_PRE_CREATE_SIZE.
+ *
+ * @param keep_page_value       presence means enabled (any value, including
+ *                              empty); nullptr means absent. This preserves the
+ *                              historical getenv()-presence contract.
+ * @param max_pre_create_size_value decimal MB; nullptr means absent.
+ */
+[[nodiscard]] page_lifecycle_parse_result parse_page_lifecycle(const char *keep_page_value,
+                                                               const char *max_pre_create_size_value);
+
 struct journal_open_policy {
   page_open_policy current_page;
   page_open_policy preload_page;
   page_precreation precreation;
+  /// Defaulted so every existing named factory keeps its aggregate initializer.
+  page_lifecycle_policy lifecycle = {};
 
   [[nodiscard]] static constexpr journal_open_policy reader() noexcept {
     return {page_open_policy::reader(), page_open_policy::reader_preload(), page_precreation::disabled};
@@ -65,6 +115,12 @@ struct journal_open_policy {
   [[nodiscard]] static constexpr journal_open_policy writer() noexcept {
     return {page_open_policy::writer(), page_open_policy::writer_preload(), page_precreation::disabled};
   }
+
+  [[nodiscard]] constexpr journal_open_policy with_lifecycle(page_lifecycle_policy value) const noexcept {
+    journal_open_policy copy = *this;
+    copy.lifecycle = value;
+    return copy;
+  }
 };
 
 struct reader_policy {
@@ -74,6 +130,10 @@ struct reader_policy {
   [[nodiscard]] static constexpr reader_policy peer() noexcept { return {journal_open_policy::reader(), true}; }
   [[nodiscard]] static constexpr reader_policy coordinator() noexcept {
     return {journal_open_policy::coordinator_reader(), false};
+  }
+
+  [[nodiscard]] constexpr reader_policy with_lifecycle(page_lifecycle_policy value) const noexcept {
+    return {journal.with_lifecycle(value), discover_page_size};
   }
 };
 
@@ -139,8 +199,13 @@ protected:
   std::mutex passed_page_collector_mtx_ = {};
   frame_ptr frame_ = {};
   uint64_t page_frame_nb_ = 0;
-  bool keep_page_ = false;
-  uint32_t max_pre_create_size_ = 0;
+
+  /// Page lifecycle is carried by policy_ (const, and copied by the copy
+  /// constructor), so a copied journal keeps the behaviour it was configured
+  /// with. These were previously mutable members seeded from getenv() in the
+  /// constructor body, which the copy constructor silently dropped.
+  [[nodiscard]] bool keep_page() const noexcept { return policy_.lifecycle.keep_page; }
+  [[nodiscard]] uint32_t max_pre_create_size_mb() const noexcept { return policy_.lifecycle.max_pre_create_size_mb; }
 
   virtual void load_page(uint32_t page_id);
 

--- a/framework/core/src/libyijinjing/src/journal/journal.cpp
+++ b/framework/core/src/libyijinjing/src/journal/journal.cpp
@@ -9,23 +9,34 @@
 
 namespace kungfu::yijinjing::journal {
 
+page_lifecycle_parse_result parse_page_lifecycle(const char *keep_page_value, const char *max_pre_create_size_value) {
+  page_lifecycle_parse_result result = {};
+  // Presence means enabled: this preserves the historical getenv() contract,
+  // where any value (including an empty one) turned the knob on.
+  result.policy.keep_page = keep_page_value != nullptr;
+
+  if (max_pre_create_size_value == nullptr) {
+    return result;
+  }
+  try {
+    result.policy.max_pre_create_size_mb = static_cast<uint32_t>(std::stoul(max_pre_create_size_value));
+  } catch (const std::exception &) {
+    // An unusable setting is reported as a value, not swallowed here. The
+    // entry layer owns the diagnostic: this function must stay pure so it can
+    // be tested without touching the process environment.
+    result.policy.max_pre_create_size_mb = 0;
+    result.status = page_lifecycle_parse_status::max_pre_create_size_invalid;
+  }
+  return result;
+}
+
 journal::journal(data::location_ptr location, uint32_t dest_id, journal_open_policy policy, bool low_latency,
                  bus_ptr bus, uint64_t page_size, yijinjing::enums::Priority priority)
     : location_(std::move(location)), dest_id_(dest_id), policy_(policy), low_latency_(low_latency),
       bus_(std::move(bus)), frame_(std::shared_ptr<frame>(new frame())), page_frame_nb_(0u), page_size_(page_size),
       priority_(priority) {
-  keep_page_ = std::getenv("KF_KEEP_PAGE") != nullptr;
-  char *pre_create_size = std::getenv("KF_MAX_PRE_CREATE_SIZE");
-  try {
-    if (pre_create_size != nullptr) {
-      max_pre_create_size_ = std::stoul(pre_create_size);
-    }
-  } catch (std::exception &e) {
-    SPDLOG_ERROR("failed to parse KF_MAX_PRE_CREATE_SIZE: {}", e.what());
-    max_pre_create_size_ = 0;
-  }
-  SPDLOG_TRACE("keep_page_: {}, low_latency_: {}, max_pre_create_size_: {}", keep_page_, low_latency_,
-               max_pre_create_size_);
+  SPDLOG_TRACE("keep_page: {}, low_latency_: {}, max_pre_create_size_mb: {}", keep_page(), low_latency_,
+               max_pre_create_size_mb());
 }
 
 journal::journal(data::location_ptr location, uint32_t dest_id, bool is_writing, bool lazy, bool low_latency,
@@ -48,7 +59,6 @@ journal::~journal() {
   if (page_) {
     page_.reset();
   }
-  keep_page_ = false;
 
   for (auto &page : passed_page_collector_) {
     page.reset();
@@ -86,7 +96,7 @@ void journal::load_page(uint32_t page_id) {
         if (bus_->is_on_load_page_required()) {
           std::lock_guard<std::mutex> lk_passed_page(passed_page_collector_mtx_);
           passed_page_collector_.push_back(std::move(page_));
-        } else if (keep_page_) {
+        } else if (keep_page()) {
           passed_page_collector_.push_back(std::move(page_));
         }
       }
@@ -142,9 +152,9 @@ void journal::preload_next_page() {
 // Save page-switch time for other processes. This path is only used by the
 // coordinator reader in low-latency mode.
 void journal::try_load_next_extra_page() {
-  if (policy_.precreation != page_precreation::coordinator || !low_latency_ ||        //
-      page_->is_pre_open() ||                                                         //
-      max_pre_create_size_ > 0 and page_->get_page_size() > max_pre_create_size_ * MB //
+  if (policy_.precreation != page_precreation::coordinator || !low_latency_ ||                //
+      page_->is_pre_open() ||                                                                 //
+      max_pre_create_size_mb() > 0 and page_->get_page_size() > max_pre_create_size_mb() * MB //
   ) {
     return;
   }
@@ -153,7 +163,7 @@ void journal::try_load_next_extra_page() {
 }
 
 void journal::release_page() {
-  if (keep_page_) {
+  if (keep_page()) {
     return;
   }
 

--- a/framework/core/src/libyijinjing/tests/mmap_tests.cpp
+++ b/framework/core/src/libyijinjing/tests/mmap_tests.cpp
@@ -48,8 +48,12 @@ using kungfu::yijinjing::journal::journal_format_epoch;
 using kungfu::yijinjing::journal::journal_open_policy;
 using kungfu::yijinjing::journal::noop_publisher;
 using kungfu::yijinjing::journal::page;
+using kungfu::yijinjing::journal::page_lifecycle_parse_status;
+using kungfu::yijinjing::journal::page_lifecycle_policy;
+using kungfu::yijinjing::journal::page_open_intent;
 using kungfu::yijinjing::journal::page_open_policy;
 using kungfu::yijinjing::journal::page_precreation;
+using kungfu::yijinjing::journal::parse_page_lifecycle;
 using kungfu::yijinjing::journal::reader;
 using kungfu::yijinjing::journal::reader_policy;
 using kungfu::yijinjing::journal::writer;
@@ -362,6 +366,58 @@ void test_page_open_intent_truth_table() {
   require(!coordinator_reader.discover_page_size &&
               coordinator_reader.journal.precreation == page_precreation::coordinator,
           "coordinator reader did not receive explicit precreation authority");
+}
+
+void test_page_lifecycle_parse_is_pure_and_honest() {
+  // Absent configuration keeps the historical defaults.
+  const auto absent = parse_page_lifecycle(nullptr, nullptr);
+  require(absent.ok() && !absent.policy.keep_page && absent.policy.max_pre_create_size_mb == 0,
+          "absent page lifecycle configuration did not yield defaults");
+
+  // Presence means enabled, matching the historical getenv() contract: any
+  // value turns the knob on, including an empty one.
+  require(parse_page_lifecycle("", nullptr).policy.keep_page, "empty keep-page value did not count as present");
+  require(parse_page_lifecycle("0", nullptr).policy.keep_page, "keep-page presence contract is not value-insensitive");
+
+  const auto sized = parse_page_lifecycle(nullptr, "128");
+  require(sized.ok() && sized.policy.max_pre_create_size_mb == 128 && !sized.policy.keep_page,
+          "valid pre-create size was not parsed");
+
+  // An unusable setting is reported as a value rather than swallowed, and the
+  // ceiling stays disabled instead of silently taking an arbitrary number.
+  const auto invalid = parse_page_lifecycle(nullptr, "not-a-number");
+  require(!invalid.ok() && invalid.status == page_lifecycle_parse_status::max_pre_create_size_invalid &&
+              invalid.policy.max_pre_create_size_mb == 0,
+          "invalid pre-create size was not reported as a value");
+}
+
+void test_page_lifecycle_survives_policy_copy() {
+  // Regression: page lifecycle used to be seeded from getenv() into mutable
+  // journal members that the copy constructor did not carry, so a copied
+  // journal silently lost the configuration it was created with. Carrying it
+  // in the (copied) policy is what fixes that.
+  const auto configured = page_lifecycle_policy{true, 64};
+  const auto policy = journal_open_policy::coordinator_reader().with_lifecycle(configured);
+  require(policy.lifecycle.keep_page && policy.lifecycle.max_pre_create_size_mb == 64,
+          "with_lifecycle did not carry the configuration");
+  require(policy.precreation == page_precreation::coordinator &&
+              policy.current_page.intent() == page_open_intent::reader,
+          "with_lifecycle disturbed unrelated policy fields");
+
+  const journal_open_policy copied = policy;
+  require(copied.lifecycle.keep_page && copied.lifecycle.max_pre_create_size_mb == 64,
+          "page lifecycle did not survive a policy copy");
+
+  const auto reader = reader_policy::coordinator().with_lifecycle(configured);
+  require(reader.journal.lifecycle.keep_page && reader.journal.lifecycle.max_pre_create_size_mb == 64,
+          "reader policy did not carry page lifecycle down to the journal policy");
+  require(!reader.discover_page_size, "reader with_lifecycle disturbed unrelated policy fields");
+
+  // Defaults stay untouched for every named factory that does not ask for a
+  // lifecycle, so existing call sites keep their behaviour.
+  require(!journal_open_policy::writer().lifecycle.keep_page &&
+              journal_open_policy::writer().lifecycle.max_pre_create_size_mb == 0,
+          "named factory did not default page lifecycle");
 }
 
 void test_existing_mapping_never_creates_or_grows() {
@@ -1006,6 +1062,8 @@ int main() {
       {"retained wire-v1 fixture", test_retained_wire_v1_fixture},
       {"mapping policy truth table", test_mapping_policy_truth_table},
       {"page open intent truth table", test_page_open_intent_truth_table},
+      {"page lifecycle parse is pure and honest", test_page_lifecycle_parse_is_pure_and_honest},
+      {"page lifecycle survives policy copy", test_page_lifecycle_survives_policy_copy},
       {"existing mapping never creates or grows", test_existing_mapping_never_creates_or_grows},
       {"mapped region move ownership", test_mapped_region_move_ownership},
       {"mapping error paths release resources", test_mapping_error_paths_release_resources},


### PR DESCRIPTION
## Summary

- make page lifecycle an explicit runtime/journal policy rather than reading environment variables inside journal code
- keep the existing storage paths and defaults while making lifecycle selection testable
- supersede #1022 with a `fix/*` linear branch because the old `feature/*` name falsely required a feature-delivery ADR declaration

Supersedes #1022.

## Mac verification

- the original change passed a full `./shifu build:core` and 22/22 mmap tests on Mac
- the replacement rebased cleanly over #1024; the runtime IO source blobs remain byte-identical, while journal files contain the expected combined current-dev changes
- current native reconfiguration was attempted but correctly refused before compilation because this host has Ninja 1.10.2 while the current repository contract requires >=1.11.1
- `git diff --check` — passed; merge-queue affected-native is the current-base integration proof

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Moves an existing page-lifecycle choice into explicit policy plumbing without changing the accepted runtime architecture, file format, or release claims."
}
-->
