### PR TITLE
fix(kfd): refresh release evidence

### DIFF
--- a/.buildchain/kfd/kfd-1/contract-world.witness.json
+++ b/.buildchain/kfd/kfd-1/contract-world.witness.json
@@ -85,9 +85,9 @@
     {
       "name": "kungfu-diagnostics",
       "sourcePath": "framework/runtime/kungfu-diagnostics.contract.json",
-      "sourceSha256": "19bb153fd0e1695e013ab11fa0f55914918a8d2a10d1952b1010c8b9c1a7e7f8",
+      "sourceSha256": "5367d9a3f02c338d7d56874f016f1cbebe1550aebdf6b8fe0e4c6f2a6067b745",
       "artifactPath": "config/kungfu-diagnostics.contract.json",
-      "expectedSha256": "19bb153fd0e1695e013ab11fa0f55914918a8d2a10d1952b1010c8b9c1a7e7f8",
+      "expectedSha256": "5367d9a3f02c338d7d56874f016f1cbebe1550aebdf6b8fe0e4c6f2a6067b745",
       "byteForByte": true
     },
     {

--- a/.buildchain/kfd/kfd-1/release-gate.json
+++ b/.buildchain/kfd/kfd-1/release-gate.json
@@ -54,13 +54,13 @@
       "standard": "KFD-1",
       "standardKey": "kfd-1",
       "result": "passed",
-      "preBuildWitnessSha256": "85d13b9761e05bbee2a03456d99965863db82726c2e4d981984fd582b5cc1834",
+      "preBuildWitnessSha256": "3ee79275e0c62ad10590eb62c7d07be7d794589944bf9ccba1d654bf58630044",
       "sourceHashes": {
-        "sha256": "45f443b092e93792e3a452d17fbb0b8d88be81dda82f9a70ca461623464aa846",
+        "sha256": "1b284daac752191a5d3341c3e15aa0867b4a354230c99a650a67b758a008c64a",
         "surfaceCount": 9
       },
       "artifactHashes": {
-        "sha256": "5a1b92f3fa10e410aaa55dbcf5cb51ed9d08caf587797b157bc073f7269b3c95",
+        "sha256": "fa27bfa12193a77e4dd0e84f5f51a1dc7b04bcfdc37cf60fac61a6592443d220",
         "surfaceCount": 9
       },
       "witness": {
@@ -150,9 +150,9 @@
           {
             "name": "kungfu-diagnostics",
             "sourcePath": "framework/runtime/kungfu-diagnostics.contract.json",
-            "sourceSha256": "19bb153fd0e1695e013ab11fa0f55914918a8d2a10d1952b1010c8b9c1a7e7f8",
+            "sourceSha256": "5367d9a3f02c338d7d56874f016f1cbebe1550aebdf6b8fe0e4c6f2a6067b745",
             "artifactPath": "config/kungfu-diagnostics.contract.json",
-            "expectedSha256": "19bb153fd0e1695e013ab11fa0f55914918a8d2a10d1952b1010c8b9c1a7e7f8",
+            "expectedSha256": "5367d9a3f02c338d7d56874f016f1cbebe1550aebdf6b8fe0e4c6f2a6067b745",
             "byteForByte": true
           },
           {
@@ -265,8 +265,8 @@
           {
             "name": "kungfu-diagnostics",
             "sourcePath": "framework/runtime/kungfu-diagnostics.contract.json",
-            "expectedSha256": "19bb153fd0e1695e013ab11fa0f55914918a8d2a10d1952b1010c8b9c1a7e7f8",
-            "actualSha256": "19bb153fd0e1695e013ab11fa0f55914918a8d2a10d1952b1010c8b9c1a7e7f8",
+            "expectedSha256": "5367d9a3f02c338d7d56874f016f1cbebe1550aebdf6b8fe0e4c6f2a6067b745",
+            "actualSha256": "5367d9a3f02c338d7d56874f016f1cbebe1550aebdf6b8fe0e4c6f2a6067b745",
             "status": "passed",
             "reason": ""
           },
@@ -358,10 +358,10 @@
           {
             "name": "kungfu-diagnostics",
             "sourcePath": "framework/runtime/kungfu-diagnostics.contract.json",
-            "sourceSha256": "19bb153fd0e1695e013ab11fa0f55914918a8d2a10d1952b1010c8b9c1a7e7f8",
+            "sourceSha256": "5367d9a3f02c338d7d56874f016f1cbebe1550aebdf6b8fe0e4c6f2a6067b745",
             "artifactPath": "config/kungfu-diagnostics.contract.json",
-            "expectedSha256": "19bb153fd0e1695e013ab11fa0f55914918a8d2a10d1952b1010c8b9c1a7e7f8",
-            "actualSha256": "19bb153fd0e1695e013ab11fa0f55914918a8d2a10d1952b1010c8b9c1a7e7f8",
+            "expectedSha256": "5367d9a3f02c338d7d56874f016f1cbebe1550aebdf6b8fe0e4c6f2a6067b745",
+            "actualSha256": "5367d9a3f02c338d7d56874f016f1cbebe1550aebdf6b8fe0e4c6f2a6067b745",
             "byteForByte": true,
             "status": "passed",
             "reason": ""

--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -6,7 +6,7 @@
   "supportLevel": "release",
   "source": {
     "cwd": ".",
-    "sourceSha": "a65671256a804e6ec3b6c7a484cbc274bcca1e26",
+    "sourceSha": "b5b07414c2ceee7a24dbaf7ee6d0e94be9ebf865",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
     "registryDigest": "sha256:0bc86eb4935b112e181469ac9ba35ceb429f3d064ef0733cac2c3ce97ecfa924"
   },

--- a/developer/sdk/kfd/kfd-1/contract-world.witness.json
+++ b/developer/sdk/kfd/kfd-1/contract-world.witness.json
@@ -85,9 +85,9 @@
     {
       "name": "kungfu-diagnostics",
       "sourcePath": "framework/runtime/kungfu-diagnostics.contract.json",
-      "sourceSha256": "19bb153fd0e1695e013ab11fa0f55914918a8d2a10d1952b1010c8b9c1a7e7f8",
+      "sourceSha256": "5367d9a3f02c338d7d56874f016f1cbebe1550aebdf6b8fe0e4c6f2a6067b745",
       "artifactPath": "config/kungfu-diagnostics.contract.json",
-      "expectedSha256": "19bb153fd0e1695e013ab11fa0f55914918a8d2a10d1952b1010c8b9c1a7e7f8",
+      "expectedSha256": "5367d9a3f02c338d7d56874f016f1cbebe1550aebdf6b8fe0e4c6f2a6067b745",
       "byteForByte": true
     },
     {

--- a/developer/sdk/kfd/kfd-1/release-gate.json
+++ b/developer/sdk/kfd/kfd-1/release-gate.json
@@ -54,13 +54,13 @@
       "standard": "KFD-1",
       "standardKey": "kfd-1",
       "result": "passed",
-      "preBuildWitnessSha256": "85d13b9761e05bbee2a03456d99965863db82726c2e4d981984fd582b5cc1834",
+      "preBuildWitnessSha256": "3ee79275e0c62ad10590eb62c7d07be7d794589944bf9ccba1d654bf58630044",
       "sourceHashes": {
-        "sha256": "45f443b092e93792e3a452d17fbb0b8d88be81dda82f9a70ca461623464aa846",
+        "sha256": "1b284daac752191a5d3341c3e15aa0867b4a354230c99a650a67b758a008c64a",
         "surfaceCount": 9
       },
       "artifactHashes": {
-        "sha256": "5a1b92f3fa10e410aaa55dbcf5cb51ed9d08caf587797b157bc073f7269b3c95",
+        "sha256": "fa27bfa12193a77e4dd0e84f5f51a1dc7b04bcfdc37cf60fac61a6592443d220",
         "surfaceCount": 9
       },
       "witness": {
@@ -150,9 +150,9 @@
           {
             "name": "kungfu-diagnostics",
             "sourcePath": "framework/runtime/kungfu-diagnostics.contract.json",
-            "sourceSha256": "19bb153fd0e1695e013ab11fa0f55914918a8d2a10d1952b1010c8b9c1a7e7f8",
+            "sourceSha256": "5367d9a3f02c338d7d56874f016f1cbebe1550aebdf6b8fe0e4c6f2a6067b745",
             "artifactPath": "config/kungfu-diagnostics.contract.json",
-            "expectedSha256": "19bb153fd0e1695e013ab11fa0f55914918a8d2a10d1952b1010c8b9c1a7e7f8",
+            "expectedSha256": "5367d9a3f02c338d7d56874f016f1cbebe1550aebdf6b8fe0e4c6f2a6067b745",
             "byteForByte": true
           },
           {
@@ -265,8 +265,8 @@
           {
             "name": "kungfu-diagnostics",
             "sourcePath": "framework/runtime/kungfu-diagnostics.contract.json",
-            "expectedSha256": "19bb153fd0e1695e013ab11fa0f55914918a8d2a10d1952b1010c8b9c1a7e7f8",
-            "actualSha256": "19bb153fd0e1695e013ab11fa0f55914918a8d2a10d1952b1010c8b9c1a7e7f8",
+            "expectedSha256": "5367d9a3f02c338d7d56874f016f1cbebe1550aebdf6b8fe0e4c6f2a6067b745",
+            "actualSha256": "5367d9a3f02c338d7d56874f016f1cbebe1550aebdf6b8fe0e4c6f2a6067b745",
             "status": "passed",
             "reason": ""
           },
@@ -358,10 +358,10 @@
           {
             "name": "kungfu-diagnostics",
             "sourcePath": "framework/runtime/kungfu-diagnostics.contract.json",
-            "sourceSha256": "19bb153fd0e1695e013ab11fa0f55914918a8d2a10d1952b1010c8b9c1a7e7f8",
+            "sourceSha256": "5367d9a3f02c338d7d56874f016f1cbebe1550aebdf6b8fe0e4c6f2a6067b745",
             "artifactPath": "config/kungfu-diagnostics.contract.json",
-            "expectedSha256": "19bb153fd0e1695e013ab11fa0f55914918a8d2a10d1952b1010c8b9c1a7e7f8",
-            "actualSha256": "19bb153fd0e1695e013ab11fa0f55914918a8d2a10d1952b1010c8b9c1a7e7f8",
+            "expectedSha256": "5367d9a3f02c338d7d56874f016f1cbebe1550aebdf6b8fe0e4c6f2a6067b745",
+            "actualSha256": "5367d9a3f02c338d7d56874f016f1cbebe1550aebdf6b8fe0e4c6f2a6067b745",
             "byteForByte": true,
             "status": "passed",
             "reason": ""


### PR DESCRIPTION
## Summary

- refresh generated Buildchain KFD-1 witness and release-gate projections after the diagnostics contract advanced to v2
- refresh the SDK mirrors and bind the KFD-3 prebuild witness to the current source baseline
- keep the patch generator-only; no runtime or product behavior changes

## Related issue

- follows the diagnostics contract change merged by #1048
- unblocks trusted Build run 29625242248, which reached 44/45 and failed only on stale KFD release evidence

## Changes

- update the `kungfu-diagnostics` KFD-1 source and artifact digests
- regenerate the derived KFD-1 release gates and SDK mirrors
- refresh the KFD-3 prebuild source coordinate

## Verification

- `./shifu kfd:buildchain:check`
- `./shifu check:source`
- source gate totals: 424 Node/source tests, 6 Python source tests, 76 runtime-upgrade tests, 69 desktop-update tests
- staged commit gate, including Buildchain KFD evidence check

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Refresh generated release evidence after an already-admitted diagnostics contract change; no architecture contract or runtime behavior changes."
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

Boundary: generated release evidence only. The repository generator, KFD check, source acceptance, DCO, and merge-queue checks provide the verification chain.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed (not applicable; behavior is unchanged)