### PR TITLE
fix(ci): qualify release package with build-images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,8 +20,14 @@ on:
         description: "Optional custom platform matrix for isolated qualification reruns"
         required: false
         default: ""
+      run-kungfu-phase-b:
+        description: "Qualify the Linux CLI package with the reviewed build-images Phase B consumer"
+        required: false
+        type: boolean
+        default: false
 
 permissions:
+  actions: read
   contents: read
   pull-requests: read
   issues: write
@@ -103,3 +109,75 @@ jobs:
       buildchain-contract-lock-path: .buildchain/contract-lock.json
       buildchain-contract-compatibility-policy: major-compatible
       buildchain-contract-drift-issue-mode: compatible-and-breaking
+
+  phase-b-package:
+    name: Prepare Kungfu Phase B package
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.run-kungfu-phase-b }}
+    needs: build
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    permissions:
+      actions: read
+      contents: read
+    outputs:
+      artifact-name: ${{ steps.artifact.outputs.name }}
+      package-sha256: ${{ steps.identity.outputs.package_sha256 }}
+      package-version: ${{ steps.identity.outputs.package_version }}
+      source-sha: ${{ steps.identity.outputs.source_sha }}
+    steps:
+      - name: Check out the exact package source
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+
+      - name: Download the Linux package build
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          pattern: kungfu-linux-x64-*
+          path: phase-b-build-input
+          merge-multiple: true
+
+      - name: Resolve package identity
+        id: identity
+        env:
+          EXPECTED_SOURCE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -euo pipefail
+          # shifu-entry-contract: allow read-only package version resolution before the package identity gate
+          expected_version=$(node -p "require('./lerna.json').version")
+          python3 scripts/prepare_kungfu_phase_b_package.py \
+            --input-root phase-b-build-input \
+            --output-dir phase-b-package-output \
+            --expected-source-sha "${EXPECTED_SOURCE_SHA}" \
+            --expected-version "${expected_version}" \
+            --build-images-ref "v1.2.4-alpha.28" \
+            --build-images-sha "df6056fd2eb1e69a3349e827ede13ba95b6ae6b7"
+
+      - name: Resolve retained artifact name
+        id: artifact
+        run: echo "name=kungfu-phase-b-package-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" >> "${GITHUB_OUTPUT}"
+
+      - name: Retain the exact package input
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: ${{ steps.artifact.outputs.name }}
+          path: phase-b-package-output
+          if-no-files-found: error
+          retention-days: 30
+
+  kungfu-phase-b:
+    name: Qualify Kungfu package with build-images
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.run-kungfu-phase-b }}
+    needs: [build, phase-b-package]
+    permissions:
+      actions: read
+      contents: read
+    uses: kungfu-systems/build-images/.github/workflows/comparator-kungfu-package-smoke.yml@df6056fd2eb1e69a3349e827ede13ba95b6ae6b7 # v1.2.4-alpha.28
+    with:
+      package_artifact_name: ${{ needs.phase-b-package.outputs.artifact-name }}
+      package_sha256: ${{ needs.phase-b-package.outputs.package-sha256 }}
+      package_version: ${{ needs.phase-b-package.outputs.package-version }}
+      source_sha: ${{ needs.phase-b-package.outputs.source-sha }}
+      build_images_ref: v1.2.4-alpha.28
+      build_images_sha: df6056fd2eb1e69a3349e827ede13ba95b6ae6b7

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -195,7 +195,7 @@
     {
       "path": ".github/workflows/build.yml",
       "authority": "qualification",
-      "definitionDigest": "sha256:b65b60b8963ae416588ea7d494e7f96a3a70d0c82d07fbbdd2a0ccabc2327839",
+      "definitionDigest": "sha256:bf6d66665c4d5a14fe9a41ec0eb4b10d1689ed9c84f0b61cedaad279bad0670a",
       "jobs": [
         {
           "id": "build",
@@ -218,6 +218,75 @@
             "kungfu-systems/buildchain/.github/workflows/.build.yml@ec48c0b311212c5f3a591e0284da6e85a9fdded5"
           ],
           "steps": []
+        },
+        {
+          "id": "kungfu-phase-b",
+          "authority": "qualification",
+          "publication": "none",
+          "receipt": "qualifying",
+          "definitionDigest": "sha256:d623d5f0b87fc99c6960d2773418c0df106dbb5c417599d3ceaeff5a3e0168b8",
+          "credentials": {
+            "githubToken": "read",
+            "oidc": false,
+            "repositorySecrets": [],
+            "inheritedSecrets": false,
+            "environment": null
+          },
+          "externalActions": [
+            "kungfu-systems/build-images/.github/workflows/comparator-kungfu-package-smoke.yml@df6056fd2eb1e69a3349e827ede13ba95b6ae6b7"
+          ],
+          "steps": []
+        },
+        {
+          "id": "phase-b-package",
+          "authority": "qualification",
+          "publication": "none",
+          "receipt": "diagnostic",
+          "definitionDigest": "sha256:a915ace29fd809a86895e074cd39a14f92def3f9ca7c9cb246fddd3107b1c736",
+          "credentials": {
+            "githubToken": "read",
+            "oidc": false,
+            "repositorySecrets": [],
+            "inheritedSecrets": false,
+            "environment": null
+          },
+          "externalActions": [
+            "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0",
+            "actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093",
+            "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02"
+          ],
+          "steps": [
+            {
+              "index": 1,
+              "label": "name:Check out the exact package source",
+              "authority": "qualification",
+              "definitionDigest": "sha256:d55d5be1b362cde988ec4232a766b2d4c0ce59ab75de5edd124697e1ec3663b7"
+            },
+            {
+              "index": 2,
+              "label": "name:Download the Linux package build",
+              "authority": "evidence-publication",
+              "definitionDigest": "sha256:87a4e956ac2f9c395f64f86ca1c48d4e33de9c94db1774620d452f82a9cb3ced"
+            },
+            {
+              "index": 3,
+              "label": "id:identity",
+              "authority": "qualification",
+              "definitionDigest": "sha256:c74ae568b0db6dca70e3d2a67f55ba34935e47a9a4cfb29fae4032609f12c617"
+            },
+            {
+              "index": 4,
+              "label": "id:artifact",
+              "authority": "qualification",
+              "definitionDigest": "sha256:fe1b7f26f2caccf537acc4a5850dc82b5f90acc9b180c98f42fa275bef1aaac1"
+            },
+            {
+              "index": 5,
+              "label": "name:Retain the exact package input",
+              "authority": "evidence-publication",
+              "definitionDigest": "sha256:8f578d5beb3702dec261bdea8d8777645ebef7e1134510cf0972c2046731122c"
+            }
+          ]
         }
       ]
     },

--- a/docs/qualification/gates/workflow-authority.md
+++ b/docs/qualification/gates/workflow-authority.md
@@ -42,6 +42,8 @@ without changing and refreshing the manifest fails the Gate catalog check.
 | `.github/workflows/adr-release-gate.yml` | `adr-release` | qualification | none | diagnostic | token:read | none | 2 |
 | `.github/workflows/affected-native-pr.yml` | `affected-native` | qualification | none | diagnostic | token:read | none | 20 |
 | `.github/workflows/build.yml` | `build` | qualification | none | qualifying | token:write, oidc, repo-secret:BUILDCHAIN_ARTIFACT_RELAY_S3_DOWNLOAD_ROLE_ARN+BUILDCHAIN_ARTIFACT_RELAY_S3_ROLE_ARN+BUILDCHAIN_ARTIFACT_RELAY_S3_UPLOAD_ROLE_ARN | none | 0 |
+| `.github/workflows/build.yml` | `kungfu-phase-b` | qualification | none | qualifying | token:read | none | 0 |
+| `.github/workflows/build.yml` | `phase-b-package` | qualification | none | diagnostic | token:read | none | 5 |
 | `.github/workflows/buildchain-validate.yml` | `promotion-rehearsal` | qualification | none | diagnostic | token:read | none | 2 |
 | `.github/workflows/buildchain-validate.yml` | `validate` | qualification | none | diagnostic | token:read | none | 2 |
 | `.github/workflows/core-build-profiles.yml` | `qualify` | qualification | none | diagnostic | token:read | none | 18 |

--- a/scripts/prepare_kungfu_phase_b_package.py
+++ b/scripts/prepare_kungfu_phase_b_package.py
@@ -1,0 +1,273 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Validate and stage the exact Kungfu CLI package consumed by Phase B."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import shutil
+import tarfile
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+PACKAGE_NAME = "kungfu-episodes-cli-linux-x64.tar.gz"
+PACKAGE_ROOT = "kungfu-episodes-cli-linux-x64"
+MAX_METADATA_BYTES = 4 * 1024 * 1024
+SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
+
+
+class PackageIdentityError(RuntimeError):
+    """Raised when the package cannot be bound to the expected identity."""
+
+
+def fail(message: str) -> None:
+    raise PackageIdentityError(message)
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def find_package(input_root: Path) -> Path:
+    matches = sorted(path for path in input_root.rglob(PACKAGE_NAME) if path.is_file())
+    if len(matches) != 1:
+        fail(
+            f"expected exactly one {PACKAGE_NAME} under {input_root}, "
+            f"found {len(matches)}"
+        )
+    return matches[0]
+
+
+def validate_member(member: tarfile.TarInfo) -> None:
+    name = member.name
+    path = PurePosixPath(name)
+    if (
+        not name
+        or name.startswith("/")
+        or "\\" in name
+        or ".." in path.parts
+        or path.parts[0] != PACKAGE_ROOT
+    ):
+        fail(f"unsafe archive member path: {name!r}")
+    if not (member.isfile() or member.isdir()):
+        fail(f"unsupported archive member type: {name!r}")
+
+
+def read_metadata(
+    archive: tarfile.TarFile,
+    members: list[tarfile.TarInfo],
+    relative_path: str,
+) -> dict[str, Any]:
+    expected = f"{PACKAGE_ROOT}/{relative_path}"
+    matches = [member for member in members if member.name == expected]
+    if len(matches) != 1 or not matches[0].isfile():
+        fail(f"expected exactly one regular metadata file: {expected}")
+    member = matches[0]
+    if member.size > MAX_METADATA_BYTES:
+        fail(f"metadata file exceeds {MAX_METADATA_BYTES} bytes: {expected}")
+    source = archive.extractfile(member)
+    if source is None:
+        fail(f"cannot read metadata file: {expected}")
+    try:
+        value = json.loads(source.read().decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        fail(f"invalid JSON metadata in {expected}: {error}")
+    if not isinstance(value, dict):
+        fail(f"metadata root must be an object: {expected}")
+    return value
+
+
+def require_equal(
+    value: dict[str, Any], field: str, expected: Any, document: str
+) -> None:
+    if value.get(field) != expected:
+        fail(
+            f"{document} field {field!r} must be {expected!r}, got {value.get(field)!r}"
+        )
+
+
+def validate_package_metadata(
+    package: Path, expected_source_sha: str, expected_version: str
+) -> None:
+    try:
+        with tarfile.open(package, "r:gz") as archive:
+            members = archive.getmembers()
+            if not members:
+                fail("package archive is empty")
+            for member in members:
+                validate_member(member)
+
+            product = read_metadata(archive, members, "product.json")
+            compatibility = read_metadata(
+                archive, members, "runtime/product-compatibility.json"
+            )
+            upgrade = read_metadata(
+                archive, members, "upgrade/kungfu-release-manifest.json"
+            )
+    except (tarfile.TarError, OSError) as error:
+        fail(f"cannot read package archive {package}: {error}")
+
+    require_equal(product, "schema", "kungfu.product.cli/v1", "product.json")
+    require_equal(product, "product", "cli", "product.json")
+    require_equal(product, "platform", "linux-x64", "product.json")
+    require_equal(product, "archive", PACKAGE_NAME, "product.json")
+    entries = product.get("entries")
+    if not isinstance(entries, dict):
+        fail("product.json field 'entries' must be an object")
+    require_equal(
+        entries,
+        "compatibility",
+        "runtime/product-compatibility.json",
+        "product.json entries",
+    )
+    require_equal(
+        entries,
+        "upgradeManifest",
+        "upgrade/kungfu-release-manifest.json",
+        "product.json entries",
+    )
+
+    require_equal(
+        compatibility,
+        "schema",
+        "kungfu.product.compatibility/v1",
+        "product compatibility",
+    )
+    require_equal(
+        compatibility, "source_commit", expected_source_sha, "product compatibility"
+    )
+    require_equal(compatibility, "platform", "linux-x64", "product compatibility")
+    versions = compatibility.get("versions")
+    if not isinstance(versions, dict):
+        fail("product compatibility field 'versions' must be an object")
+    require_equal(
+        versions,
+        "product",
+        expected_version,
+        "product compatibility versions",
+    )
+
+    require_equal(
+        upgrade,
+        "schema",
+        "kungfu.product-upgrade.manifest/v1",
+        "upgrade manifest",
+    )
+    require_equal(upgrade, "productVersion", expected_version, "upgrade manifest")
+    require_equal(upgrade, "sourceCommit", expected_source_sha, "upgrade manifest")
+    require_equal(upgrade, "platform", "linux", "upgrade manifest")
+    require_equal(upgrade, "architecture", "x64", "upgrade manifest")
+
+
+def write_github_output(path: Path, values: dict[str, str | int]) -> None:
+    with path.open("a", encoding="utf-8") as output:
+        for key, value in values.items():
+            output.write(f"{key}={value}\n")
+
+
+def prepare_package(
+    *,
+    input_root: Path,
+    output_dir: Path,
+    expected_source_sha: str,
+    expected_version: str,
+    build_images_ref: str,
+    build_images_sha: str,
+    github_output: Path | None = None,
+) -> dict[str, Any]:
+    if not SHA_PATTERN.fullmatch(expected_source_sha):
+        fail("expected source SHA must be exactly 40 lowercase hexadecimal characters")
+    if not expected_version.strip():
+        fail("expected version must not be empty")
+    if not build_images_ref.strip():
+        fail("build-images ref must not be empty")
+    if not SHA_PATTERN.fullmatch(build_images_sha):
+        fail("build-images SHA must be exactly 40 lowercase hexadecimal characters")
+    if output_dir.exists():
+        fail(f"output directory already exists: {output_dir}")
+
+    package = find_package(input_root)
+    validate_package_metadata(package, expected_source_sha, expected_version)
+    package_sha256 = sha256_file(package)
+    package_size = package.stat().st_size
+
+    output_dir.mkdir(parents=True)
+    staged_package = output_dir / PACKAGE_NAME
+    shutil.copyfile(package, staged_package)
+    identity = {
+        "schema": "kungfu.phase-b-package-identity/v1",
+        "package": {
+            "filename": PACKAGE_NAME,
+            "sha256": package_sha256,
+            "sizeBytes": package_size,
+            "version": expected_version,
+            "sourceCommit": expected_source_sha,
+            "platform": "linux-x64",
+        },
+        "consumer": {
+            "repository": "kungfu-systems/build-images",
+            "ref": build_images_ref,
+            "commit": build_images_sha,
+        },
+    }
+    identity_path = output_dir / "package-identity.json"
+    identity_path.write_text(
+        json.dumps(identity, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+
+    outputs: dict[str, str | int] = {
+        "package_sha256": package_sha256,
+        "package_size_bytes": package_size,
+        "package_version": expected_version,
+        "source_sha": expected_source_sha,
+    }
+    if github_output is not None:
+        write_github_output(github_output, outputs)
+    print(json.dumps(identity, sort_keys=True))
+    return identity
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input-root", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--expected-source-sha", required=True)
+    parser.add_argument("--expected-version", required=True)
+    parser.add_argument("--build-images-ref", required=True)
+    parser.add_argument("--build-images-sha", required=True)
+    parser.add_argument(
+        "--github-output",
+        type=Path,
+        default=Path(os.environ["GITHUB_OUTPUT"])
+        if os.environ.get("GITHUB_OUTPUT")
+        else None,
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    try:
+        prepare_package(
+            input_root=args.input_root,
+            output_dir=args.output_dir,
+            expected_source_sha=args.expected_source_sha,
+            expected_version=args.expected_version,
+            build_images_ref=args.build_images_ref,
+            build_images_sha=args.build_images_sha,
+            github_output=args.github_output,
+        )
+    except PackageIdentityError as error:
+        raise SystemExit(f"prepare Phase B package: {error}") from error
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/source-acceptance.mjs
+++ b/scripts/source-acceptance.mjs
@@ -320,6 +320,11 @@ export function sourceAcceptancePlan(files) {
       ],
     },
     {
+      label: 'Phase B package identity contract tests',
+      command: 'python3',
+      args: ['-m', 'unittest', 'scripts.test_prepare_kungfu_phase_b_package'],
+    },
+    {
       label: 'agent work state contract and CLI parity',
       command: process.execPath,
       args: ['scripts/run-agent-work-state-tests.mjs'],

--- a/scripts/source-acceptance.test.mjs
+++ b/scripts/source-acceptance.test.mjs
@@ -225,6 +225,14 @@ test('source plan covers representative source-only checks', () => {
       'scripts/check-episode-admission-contract.test.mjs',
     ),
   );
+  const phaseBPackageTests = plan.find(
+    (step) => step.label === 'Phase B package identity contract tests',
+  );
+  assert.deepEqual(phaseBPackageTests.args, [
+    '-m',
+    'unittest',
+    'scripts.test_prepare_kungfu_phase_b_package',
+  ]);
   const upgradeTests = plan.find(
     (step) => step.label === 'runtime upgrade control-plane tests',
   );
@@ -393,6 +401,27 @@ test('reusable workflow is bound to source mode and the pinned stable runtime', 
   assert.match(workflow, /check\.yml@ec48c0b311212c5f3a591e0284da6e85a9fdded5/);
   assert.match(workflow, /buildchain-ref: v2/);
   assert.doesNotMatch(workflow, /self-hosted/);
+});
+
+test('manual package build is welded to the reviewed Phase B consumer', () => {
+  const workflow = fs.readFileSync(
+    path.join(ROOT, '.github/workflows/build.yml'),
+    'utf8',
+  );
+  assert.match(workflow, /run-kungfu-phase-b:\n\s+description:/);
+  assert.match(
+    workflow,
+    /prepare_kungfu_phase_b_package\.py[\s\S]+--build-images-ref "v1\.2\.4-alpha\.28"[\s\S]+--build-images-sha "df6056fd2eb1e69a3349e827ede13ba95b6ae6b7"/,
+  );
+  assert.match(
+    workflow,
+    /uses: kungfu-systems\/build-images\/\.github\/workflows\/comparator-kungfu-package-smoke\.yml@df6056fd2eb1e69a3349e827ede13ba95b6ae6b7 # v1\.2\.4-alpha\.28/,
+  );
+  assert.match(
+    workflow,
+    /package_artifact_name: \$\{\{ needs\.phase-b-package\.outputs\.artifact-name \}\}/,
+  );
+  assert.match(workflow, /retention-days: 30/);
 });
 
 test('the native membrane matrix is a promotion gate, not a dev PR gate', () => {

--- a/scripts/test_prepare_kungfu_phase_b_package.py
+++ b/scripts/test_prepare_kungfu_phase_b_package.py
@@ -1,0 +1,155 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import io
+import json
+import tarfile
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.prepare_kungfu_phase_b_package import (
+    PACKAGE_NAME,
+    PackageIdentityError,
+    prepare_package,
+)
+
+SOURCE_SHA = "a" * 40
+BUILD_IMAGES_SHA = "b" * 40
+VERSION = "4.0.0-alpha.1"
+ROOT = "kungfu-episodes-cli-linux-x64"
+
+
+def metadata_files(
+    *,
+    source_sha: str = SOURCE_SHA,
+    version: str = VERSION,
+) -> dict[str, dict[str, object]]:
+    return {
+        "product.json": {
+            "schema": "kungfu.product.cli/v1",
+            "product": "cli",
+            "platform": "linux-x64",
+            "archive": PACKAGE_NAME,
+            "entries": {
+                "compatibility": "runtime/product-compatibility.json",
+                "upgradeManifest": "upgrade/kungfu-release-manifest.json",
+            },
+        },
+        "runtime/product-compatibility.json": {
+            "schema": "kungfu.product.compatibility/v1",
+            "source_commit": source_sha,
+            "platform": "linux-x64",
+            "versions": {"product": version},
+        },
+        "upgrade/kungfu-release-manifest.json": {
+            "schema": "kungfu.product-upgrade.manifest/v1",
+            "productVersion": version,
+            "sourceCommit": source_sha,
+            "platform": "linux",
+            "architecture": "x64",
+        },
+    }
+
+
+def write_package(
+    path: Path,
+    *,
+    source_sha: str = SOURCE_SHA,
+    version: str = VERSION,
+    unsafe_symlink: bool = False,
+) -> None:
+    with tarfile.open(path, "w:gz") as archive:
+        for relative, value in metadata_files(
+            source_sha=source_sha, version=version
+        ).items():
+            payload = (json.dumps(value) + "\n").encode()
+            info = tarfile.TarInfo(f"{ROOT}/{relative}")
+            info.size = len(payload)
+            info.mode = 0o644
+            archive.addfile(info, io.BytesIO(payload))
+        if unsafe_symlink:
+            info = tarfile.TarInfo(f"{ROOT}/escape")
+            info.type = tarfile.SYMTYPE
+            info.linkname = "../../outside"
+            archive.addfile(info)
+
+
+class PrepareKungfuPhaseBPackageTest(unittest.TestCase):
+    def prepare(self, source: Path, output: Path, github_output: Path | None = None):
+        return prepare_package(
+            input_root=source,
+            output_dir=output,
+            expected_source_sha=SOURCE_SHA,
+            expected_version=VERSION,
+            build_images_ref="v1.2.4-alpha.28",
+            build_images_sha=BUILD_IMAGES_SHA,
+            github_output=github_output,
+        )
+
+    def test_stages_exact_package_and_identity_receipt(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            source = root / "input" / "nested"
+            source.mkdir(parents=True)
+            package = source / PACKAGE_NAME
+            write_package(package)
+            github_output = root / "github-output"
+
+            identity = self.prepare(root / "input", root / "output", github_output)
+
+            self.assertEqual(identity["package"]["sourceCommit"], SOURCE_SHA)
+            self.assertEqual(identity["package"]["version"], VERSION)
+            self.assertEqual(identity["consumer"]["commit"], BUILD_IMAGES_SHA)
+            self.assertEqual(
+                (root / "output" / PACKAGE_NAME).read_bytes(), package.read_bytes()
+            )
+            retained = json.loads(
+                (root / "output" / "package-identity.json").read_text()
+            )
+            self.assertEqual(retained, identity)
+            outputs = github_output.read_text()
+            self.assertIn(f"source_sha={SOURCE_SHA}\n", outputs)
+            self.assertIn(f"package_version={VERSION}\n", outputs)
+            self.assertRegex(outputs, r"package_sha256=[0-9a-f]{64}\n")
+
+    def test_rejects_source_mismatch(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            root.mkdir(exist_ok=True)
+            write_package(root / PACKAGE_NAME, source_sha="c" * 40)
+            with self.assertRaisesRegex(PackageIdentityError, "source_commit.*must be"):
+                self.prepare(root, root / "output")
+
+    def test_rejects_version_mismatch(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            write_package(root / PACKAGE_NAME, version="4.0.0-alpha.0")
+            with self.assertRaisesRegex(
+                PackageIdentityError, "versions.*product.*must be"
+            ):
+                self.prepare(root, root / "output")
+
+    def test_rejects_unsafe_archive_member(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            write_package(root / PACKAGE_NAME, unsafe_symlink=True)
+            with self.assertRaisesRegex(
+                PackageIdentityError, "unsupported archive member type"
+            ):
+                self.prepare(root, root / "output")
+
+    def test_rejects_multiple_candidate_packages(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            for directory in ("one", "two"):
+                target = root / directory
+                target.mkdir()
+                write_package(target / PACKAGE_NAME)
+            with self.assertRaisesRegex(PackageIdentityError, "found 2"):
+                self.prepare(root, root / "output")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Add the missing official same-run orchestration for Kungfu issue #995. An explicit manual Build input now builds the Linux x64 product package through the existing Buildchain lifecycle, validates and retains one source-bound CLI package, and invokes the exact reviewed build-images Phase B consumer.

The ordinary PR and manual build paths remain unchanged unless `run-kungfu-phase-b` is explicitly enabled.

## Related issue

- #995
- kungfu-systems/build-images#222

## Changes

- add a fail-closed package identity gate for the CLI archive, including safe tar member validation and exact product, compatibility, upgrade, source, version, platform, size, and SHA-256 evidence
- retain a single-purpose package artifact and identity receipt for 30 days
- invoke the build-images `v1.2.4-alpha.28` consumer by its exact release commit `df6056fd2eb1e69a3349e827ede13ba95b6ae6b7`
- classify the downstream reusable job as qualifying evidence in the closed-world workflow authority manifest
- add five package identity contract fixtures and weld them into source acceptance

## Verification

- `./shifu check:source` passed after rebasing onto `fa7c61ff39cee1ae01f4ff7e1f0cab5fb5688333`
- pre-commit staged gate passed
- real-package validation passed on agent-120 for the retained 218,490,228-byte candidate; SHA-256 remained `22c7e3989b8b4a6b178b519feef4eb13a08a0d181f66c9178ba78506947429b3`
- `./shifu check` reached the existing SDK baseline drift: the installed KFD/Buildchain versions are newer than `framework/contract/kungfu-agent-first-canonical-policy.json`; no files in that unrelated contract surface are changed here
- the same-run Build + Phase B workflow will be dispatched on the merged exact source before #995 is closed

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This change closes an existing release-evidence orchestration gap without changing a product architecture contract or supported capability claim."
}
-->

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The workflow uses read-only permissions for the package preparation and downstream qualification jobs, pins all authority-bearing external actions to full commits, and records the generated workflow authority digests in the same PR.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed