### PR TITLE
fix(ci): consume corrected build-images Phase B workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -151,8 +151,8 @@ jobs:
             --output-dir phase-b-package-output \
             --expected-source-sha "${EXPECTED_SOURCE_SHA}" \
             --expected-version "${expected_version}" \
-            --build-images-ref "v1.2.4-alpha.28" \
-            --build-images-sha "df6056fd2eb1e69a3349e827ede13ba95b6ae6b7"
+            --build-images-ref "v1.2.4-alpha.29" \
+            --build-images-sha "7cf672d83323fdd139ad90b6e8165a56e431cc6c"
 
       - name: Resolve retained artifact name
         id: artifact
@@ -173,11 +173,11 @@ jobs:
     permissions:
       actions: read
       contents: read
-    uses: kungfu-systems/build-images/.github/workflows/comparator-kungfu-package-smoke.yml@df6056fd2eb1e69a3349e827ede13ba95b6ae6b7 # v1.2.4-alpha.28
+    uses: kungfu-systems/build-images/.github/workflows/comparator-kungfu-package-smoke.yml@7cf672d83323fdd139ad90b6e8165a56e431cc6c # v1.2.4-alpha.29
     with:
       package_artifact_name: ${{ needs.phase-b-package.outputs.artifact-name }}
       package_sha256: ${{ needs.phase-b-package.outputs.package-sha256 }}
       package_version: ${{ needs.phase-b-package.outputs.package-version }}
       source_sha: ${{ needs.phase-b-package.outputs.source-sha }}
-      build_images_ref: v1.2.4-alpha.28
-      build_images_sha: df6056fd2eb1e69a3349e827ede13ba95b6ae6b7
+      build_images_ref: v1.2.4-alpha.29
+      build_images_sha: 7cf672d83323fdd139ad90b6e8165a56e431cc6c

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -224,7 +224,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:d623d5f0b87fc99c6960d2773418c0df106dbb5c417599d3ceaeff5a3e0168b8",
+          "definitionDigest": "sha256:d43a3754259fa0acc5c37903f33f5c3494a336d76b785634eb8eaa10a0af8f5f",
           "credentials": {
             "githubToken": "read",
             "oidc": false,
@@ -233,7 +233,7 @@
             "environment": null
           },
           "externalActions": [
-            "kungfu-systems/build-images/.github/workflows/comparator-kungfu-package-smoke.yml@df6056fd2eb1e69a3349e827ede13ba95b6ae6b7"
+            "kungfu-systems/build-images/.github/workflows/comparator-kungfu-package-smoke.yml@7cf672d83323fdd139ad90b6e8165a56e431cc6c"
           ],
           "steps": []
         },
@@ -242,7 +242,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:a915ace29fd809a86895e074cd39a14f92def3f9ca7c9cb246fddd3107b1c736",
+          "definitionDigest": "sha256:9d031c722707dafa45e2ecc33a92a2a9a1c6a2d3860ccf9a14c289d5be643c4d",
           "credentials": {
             "githubToken": "read",
             "oidc": false,
@@ -272,7 +272,7 @@
               "index": 3,
               "label": "id:identity",
               "authority": "qualification",
-              "definitionDigest": "sha256:c74ae568b0db6dca70e3d2a67f55ba34935e47a9a4cfb29fae4032609f12c617"
+              "definitionDigest": "sha256:2eea487a24dfcc311a4261342a4ab92471d726fc164e47566b6bc3ac222338f3"
             },
             {
               "index": 4,

--- a/scripts/source-acceptance.test.mjs
+++ b/scripts/source-acceptance.test.mjs
@@ -411,11 +411,11 @@ test('manual package build is welded to the reviewed Phase B consumer', () => {
   assert.match(workflow, /run-kungfu-phase-b:\n\s+description:/);
   assert.match(
     workflow,
-    /prepare_kungfu_phase_b_package\.py[\s\S]+--build-images-ref "v1\.2\.4-alpha\.28"[\s\S]+--build-images-sha "df6056fd2eb1e69a3349e827ede13ba95b6ae6b7"/,
+    /prepare_kungfu_phase_b_package\.py[\s\S]+--build-images-ref "v1\.2\.4-alpha\.29"[\s\S]+--build-images-sha "7cf672d83323fdd139ad90b6e8165a56e431cc6c"/,
   );
   assert.match(
     workflow,
-    /uses: kungfu-systems\/build-images\/\.github\/workflows\/comparator-kungfu-package-smoke\.yml@df6056fd2eb1e69a3349e827ede13ba95b6ae6b7 # v1\.2\.4-alpha\.28/,
+    /uses: kungfu-systems\/build-images\/\.github\/workflows\/comparator-kungfu-package-smoke\.yml@7cf672d83323fdd139ad90b6e8165a56e431cc6c # v1\.2\.4-alpha\.29/,
   );
   assert.match(
     workflow,


### PR DESCRIPTION
## Summary

- update the official same-run Kungfu Phase B consumer from build-images `v1.2.4-alpha.28` to `v1.2.4-alpha.29`
- pin the corrected reusable workflow by exact release commit `7cf672d83323fdd139ad90b6e8165a56e431cc6c`
- refresh the closed-world workflow authority manifest and source acceptance contract

This is an ADR-neutral CI bug fix. It does not change product behavior or widen qualification authority.

Refs #995 and kungfu-systems/build-images#232.

## Failure and fix evidence

- failed same-run qualification: https://github.com/kungfu-systems/kungfu/actions/runs/29630035045
- package staging passed with exact source `f0f363ab9a32b3e938bf4360f7b6b0001f090ba1`, version `4.0.0-alpha.1`, SHA-256 `5d5c311e7dced3cf825a1be0b2df3f88830860a9bb290305efd09f7a1a2fc442`, and size 218490092 bytes
- downstream failure: the `.28` reusable workflow passed the Actions artifact container name where the fixed package filename was required
- build-images fix: https://github.com/kungfu-systems/build-images/pull/233
- standard Buildchain release promotion: https://github.com/kungfu-systems/build-images/actions/runs/29631251454
- corrected release: https://github.com/kungfu-systems/build-images/releases/tag/v1.2.4-alpha.29

## Verification

- `./shifu gate:workflow-authority:refresh`
- `./shifu check:source`
- 425 source contract tests
- 5 Phase B package identity tests
- 76 runtime upgrade tests
- 69 desktop update tests
- staged pre-commit gate passed

After merge, dispatch the exact merged mainline SHA with `run-kungfu-phase-b=true` and close #995 only after 63/63 execution, 63/63 cleanup, and independent offline bundle verification pass.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This change updates an exact CI qualification dependency after a contract bug fix without changing a product architecture contract or supported capability claim."
}
-->

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change pins the corrected qualification consumer by exact release tag and commit, keeps read-only permissions, and refreshes the closed-world workflow authority digest.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed