### PR TITLE
fix(ci): tolerate protected process-group probes

### DIFF
--- a/framework/agent-session/tests/runtime-port.native.test.mjs
+++ b/framework/agent-session/tests/runtime-port.native.test.mjs
@@ -84,7 +84,7 @@ function spawnPeer(role, runtimeDir) {
   return child;
 }
 
-export function windowsTreeKillInvocation(pid) {
+function windowsTreeKillInvocation(pid) {
   if (!Number.isSafeInteger(pid) || pid <= 0)
     throw new Error(`invalid test-owned Windows process id: ${pid}`);
   return {
@@ -93,12 +93,13 @@ export function windowsTreeKillInvocation(pid) {
   };
 }
 
-function posixProcessGroupAlive(pid) {
+function posixProcessGroupAlive(pid, kill = process.kill) {
   try {
-    process.kill(-pid, 0);
+    kill(-pid, 0);
     return true;
   } catch (error) {
     if (error?.code === 'ESRCH') return false;
+    if (error?.code === 'EPERM') return true;
     throw error;
   }
 }
@@ -146,6 +147,40 @@ async function stopChild(child) {
     );
   }
 }
+
+test('POSIX process-group probe reports ESRCH as exited', () => {
+  const missing = Object.assign(new Error('missing'), { code: 'ESRCH' });
+  assert.equal(
+    posixProcessGroupAlive(123, () => {
+      throw missing;
+    }),
+    false,
+  );
+});
+
+test('POSIX process-group probe keeps waiting after EPERM', () => {
+  const denied = Object.assign(new Error('denied'), { code: 'EPERM' });
+  let invocation;
+  assert.equal(
+    posixProcessGroupAlive(123, (...args) => {
+      invocation = args;
+      throw denied;
+    }),
+    true,
+  );
+  assert.deepEqual(invocation, [-123, 0]);
+});
+
+test('POSIX process-group probe preserves unexpected failures', () => {
+  const failure = Object.assign(new Error('unexpected'), { code: 'EINVAL' });
+  assert.throws(
+    () =>
+      posixProcessGroupAlive(123, () => {
+        throw failure;
+      }),
+    failure,
+  );
+});
 
 test(
   'POSIX native fixture cleanup escalates when a child ignores SIGTERM',


### PR DESCRIPTION
## Summary

- treat POSIX `kill(-pgid, 0)` `EPERM` as evidence that the process group still exists
- keep `ESRCH` as the only normal exited result and preserve unexpected probe errors
- add focused regression coverage for all three outcomes
- keep test helpers file-private so changed-file lint remains clean

## Failure evidence

Formal Build run [29632945152](https://github.com/kungfu-systems/kungfu/actions/runs/29632945152) failed the macOS ARM64 verify lifecycle while cleaning up the native agent-session fixture. The child ignored `SIGTERM`, the process-group liveness probe returned `EPERM`, and the test aborted before the bounded `SIGKILL` escalation path.

A signal-0 `EPERM` means the process group exists but the caller is not permitted to signal it. It must therefore remain in the bounded wait path rather than be treated as an unexpected probe failure.

## Validation

- `./shifu check:source`
- targeted native runtime-port test: 4/4 passed
- cleanup stress repetition: 8/8 passed
- source acceptance: 432/432 contract tests, 76/76 runtime upgrade tests, 69/69 desktop tests
- changed-file Biome check passed

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Repairs a platform-specific test cleanup probe without changing runtime architecture or release claims."
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

This PR changes qualification cleanup behavior only; it does not publish or deploy artifacts.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Source acceptance is green locally
- [x] No credentials or generated qualification evidence are committed
