### PR TITLE
docs(xinfa): admit Fact storage authorities

### DIFF
--- a/.xinfa/project.json
+++ b/.xinfa/project.json
@@ -551,8 +551,12 @@
         "mode": "exact",
         "paths": [
           "docs/architecture/README.md",
+          "docs/adr/ADR-0018-runtime-storage-service-architecture.md",
           "docs/adr/ADR-0026-runtime-greenfield-core-surface.md",
+          "docs/adr/ADR-0047-authoritative-facts-hana-pod-or-flatbuffers.md",
           "docs/adr/ADR-0078-minimal-generic-core-closure-and-membrane-decode-checksum.md",
+          "docs/adr/ADR-0112-backend-neutral-fact-cut-kernel.md",
+          "docs/adr/ADR-0113-authority-atomic-storage-backend-switch.md",
           "framework/core/slices/shared-embedding-membrane/README.md"
         ]
       }
@@ -610,8 +614,12 @@
         "mode": "exact",
         "paths": [
           "docs/architecture/README.md",
+          "docs/adr/ADR-0018-runtime-storage-service-architecture.md",
           "docs/adr/ADR-0026-runtime-greenfield-core-surface.md",
+          "docs/adr/ADR-0047-authoritative-facts-hana-pod-or-flatbuffers.md",
           "docs/adr/ADR-0078-minimal-generic-core-closure-and-membrane-decode-checksum.md",
+          "docs/adr/ADR-0112-backend-neutral-fact-cut-kernel.md",
+          "docs/adr/ADR-0113-authority-atomic-storage-backend-switch.md",
           "framework/core/slices/shared-embedding-membrane/README.md"
         ]
       }


### PR DESCRIPTION
## Summary

Extend the core-development Xinfa route so Fact storage work consumes the accepted storage, Fact Cut, and backend-switch authorities in one verified Task Chart.

## Related issue

Supersedes #1077, which used the wrong feature-branch classification for an ADR-neutral context correction.

## Changes

- include the runtime storage service authority
- include the authoritative Fact and native Fact Cut ADRs
- include the atomic backend-switch ADR
- keep the existing route, capability, ownership, and budget contract unchanged

## Verification

- `./shifu docs:check`
- `./shifu check:source`
- source tree matches the previously validated commit exactly

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This corrects verified Xinfa context selection without changing runtime or architecture contracts"
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] release evidence, provenance, package publishing, or deployment surfaces
- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed
