### PR TITLE
feat(agent): add KFD-7 runtime profiles (linear replacement)

### DIFF
--- a/.buildchain/kfd/kfd-1/contract-world.witness.json
+++ b/.buildchain/kfd/kfd-1/contract-world.witness.json
@@ -35,7 +35,7 @@
   "sourceVerificationRequired": false,
   "canonicalPolicy": {
     "path": "framework/contract/kungfu-agent-first-canonical-policy.json",
-    "sha256": "694351008847264384dbd4096471faebf879358dad0f9be0fb96020cffe03280"
+    "sha256": "0c4d589833840e5bee88fad4bae166b72c3fccfa7001884eb71fbf63364a60bb"
   },
   "registry": {
     "path": "framework/contract/kungfu-contracts.registry.json",
@@ -117,9 +117,9 @@
     {
       "name": "kungfu-fact-cut-kernel",
       "sourcePath": "framework/fact/kungfu-fact-cut-kernel.contract.json",
-      "sourceSha256": "ccd0526781a200efca157bac10ccd41d3bbb614102e65ef335a78fd63176e1e5",
+      "sourceSha256": "dfe1164c6c4b02e2cb5577839f72f44cb572dd8849072de0697fd639f105f50d",
       "artifactPath": "config/kungfu-fact-cut-kernel.contract.json",
-      "expectedSha256": "ccd0526781a200efca157bac10ccd41d3bbb614102e65ef335a78fd63176e1e5",
+      "expectedSha256": "dfe1164c6c4b02e2cb5577839f72f44cb572dd8849072de0697fd639f105f50d",
       "byteForByte": true
     }
   ],

--- a/.buildchain/kfd/kfd-1/release-gate.json
+++ b/.buildchain/kfd/kfd-1/release-gate.json
@@ -54,13 +54,13 @@
       "standard": "KFD-1",
       "standardKey": "kfd-1",
       "result": "passed",
-      "preBuildWitnessSha256": "2de8c3b6af45f9b64763d161d9090d39877d6b75947d9128025446847f577254",
+      "preBuildWitnessSha256": "0f7e9f1336eeb57037622a9369e4a4c3b48b2666e3bca6b18fe437e693389d92",
       "sourceHashes": {
-        "sha256": "d8f88d19090f0e02b922841eddbb34631b2d979e05936c53a1d6e351fb35f66c",
+        "sha256": "cecb0b3542eec5fdb691e4af772eb8439bc76f0026906c1135503aec35d7eb88",
         "surfaceCount": 10
       },
       "artifactHashes": {
-        "sha256": "505b245dc3602f07b328d89d1d06cc4b4756383204a34e46043583aa5106843d",
+        "sha256": "98b28184d1fe5a073af9c5be6df6d3cd7d9885e759b852243ebf45580bcfb905",
         "surfaceCount": 10
       },
       "witness": {
@@ -100,7 +100,7 @@
         "sourceVerificationRequired": true,
         "canonicalPolicy": {
           "path": "framework/contract/kungfu-agent-first-canonical-policy.json",
-          "sha256": "694351008847264384dbd4096471faebf879358dad0f9be0fb96020cffe03280"
+          "sha256": "0c4d589833840e5bee88fad4bae166b72c3fccfa7001884eb71fbf63364a60bb"
         },
         "registry": {
           "path": "framework/contract/kungfu-contracts.registry.json",
@@ -182,9 +182,9 @@
           {
             "name": "kungfu-fact-cut-kernel",
             "sourcePath": "framework/fact/kungfu-fact-cut-kernel.contract.json",
-            "sourceSha256": "ccd0526781a200efca157bac10ccd41d3bbb614102e65ef335a78fd63176e1e5",
+            "sourceSha256": "dfe1164c6c4b02e2cb5577839f72f44cb572dd8849072de0697fd639f105f50d",
             "artifactPath": "config/kungfu-fact-cut-kernel.contract.json",
-            "expectedSha256": "ccd0526781a200efca157bac10ccd41d3bbb614102e65ef335a78fd63176e1e5",
+            "expectedSha256": "dfe1164c6c4b02e2cb5577839f72f44cb572dd8849072de0697fd639f105f50d",
             "byteForByte": true
           }
         ],
@@ -305,8 +305,8 @@
           {
             "name": "kungfu-fact-cut-kernel",
             "sourcePath": "framework/fact/kungfu-fact-cut-kernel.contract.json",
-            "expectedSha256": "ccd0526781a200efca157bac10ccd41d3bbb614102e65ef335a78fd63176e1e5",
-            "actualSha256": "ccd0526781a200efca157bac10ccd41d3bbb614102e65ef335a78fd63176e1e5",
+            "expectedSha256": "dfe1164c6c4b02e2cb5577839f72f44cb572dd8849072de0697fd639f105f50d",
+            "actualSha256": "dfe1164c6c4b02e2cb5577839f72f44cb572dd8849072de0697fd639f105f50d",
             "status": "passed",
             "reason": ""
           }
@@ -418,10 +418,10 @@
           {
             "name": "kungfu-fact-cut-kernel",
             "sourcePath": "framework/fact/kungfu-fact-cut-kernel.contract.json",
-            "sourceSha256": "ccd0526781a200efca157bac10ccd41d3bbb614102e65ef335a78fd63176e1e5",
+            "sourceSha256": "dfe1164c6c4b02e2cb5577839f72f44cb572dd8849072de0697fd639f105f50d",
             "artifactPath": "config/kungfu-fact-cut-kernel.contract.json",
-            "expectedSha256": "ccd0526781a200efca157bac10ccd41d3bbb614102e65ef335a78fd63176e1e5",
-            "actualSha256": "ccd0526781a200efca157bac10ccd41d3bbb614102e65ef335a78fd63176e1e5",
+            "expectedSha256": "dfe1164c6c4b02e2cb5577839f72f44cb572dd8849072de0697fd639f105f50d",
+            "actualSha256": "dfe1164c6c4b02e2cb5577839f72f44cb572dd8849072de0697fd639f105f50d",
             "byteForByte": true,
             "status": "passed",
             "reason": ""

--- a/.buildchain/kfd/kfd-2/claims/agent-onboarding-pack.json
+++ b/.buildchain/kfd/kfd-2/claims/agent-onboarding-pack.json
@@ -16,7 +16,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "63d9f38b97a4b134d19aae73734228fb5c1a87654d4aadb0e29b331902f8c10d"
+        "sha256": "a9b11bf1fb65113a0f32d4ee8e295e8bfa1607ae9d2fb244043d3740cbb42c54"
       },
       "description": "Machine-readable command catalog and mode maturity metadata."
     },
@@ -54,7 +54,7 @@
     "evidenceSha256": [
       {
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "63d9f38b97a4b134d19aae73734228fb5c1a87654d4aadb0e29b331902f8c10d"
+        "sha256": "a9b11bf1fb65113a0f32d4ee8e295e8bfa1607ae9d2fb244043d3740cbb42c54"
       },
       {
         "path": "framework/core/src/python/kungfu/agent/mode-selection.md",
@@ -76,7 +76,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "63d9f38b97a4b134d19aae73734228fb5c1a87654d4aadb0e29b331902f8c10d"
+        "sha256": "a9b11bf1fb65113a0f32d4ee8e295e8bfa1607ae9d2fb244043d3740cbb42c54"
       }
     ]
   },
@@ -90,7 +90,7 @@
     {
       "name": "agent-command-catalog",
       "path": "framework/core/src/python/kungfu/agent/commands.json",
-      "sha256": "63d9f38b97a4b134d19aae73734228fb5c1a87654d4aadb0e29b331902f8c10d",
+      "sha256": "a9b11bf1fb65113a0f32d4ee8e295e8bfa1607ae9d2fb244043d3740cbb42c54",
       "expectedPackagePath": "kungfu/agent/commands.json"
     }
   ],

--- a/.buildchain/kfd/kfd-2/claims/agent-work-state-contract.json
+++ b/.buildchain/kfd/kfd-2/claims/agent-work-state-contract.json
@@ -16,7 +16,7 @@
       "pointer": {
         "kind": "file",
         "path": "docs/adr/ADR-0109-four-object-agent-work-state-contract.md",
-        "sha256": "3a64520e737261ecf31ddccfd29d915d45dabec72237b562892bc8f7613cc1b4"
+        "sha256": "f14305861d5b7a697fbb7acb380a2849569cbef42d26eb6a9953a649b724d26f"
       },
       "description": "Accepted role-separation decision and bounded P17 qualification boundary."
     },
@@ -54,7 +54,7 @@
     "evidenceSha256": [
       {
         "path": "docs/adr/ADR-0109-four-object-agent-work-state-contract.md",
-        "sha256": "3a64520e737261ecf31ddccfd29d915d45dabec72237b562892bc8f7613cc1b4"
+        "sha256": "f14305861d5b7a697fbb7acb380a2849569cbef42d26eb6a9953a649b724d26f"
       },
       {
         "path": "scripts/check-agent-work-state-contract.test.mjs",

--- a/.buildchain/kfd/kfd-2/claims/agent-work-state-contract.json
+++ b/.buildchain/kfd/kfd-2/claims/agent-work-state-contract.json
@@ -34,7 +34,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/tests/python/test_agent_work_state_contract.py",
-        "sha256": "7a4edc5faaac5f143a8711b48ec7e9ce3d600f9890657abc815bdd935a45aa36"
+        "sha256": "8043df1867e82fb772faab9072f8d878538a0a4b9cd1d62b1639f3427795d215"
       },
       "description": "Runtime CLI parity and fail-closed contract-schema checks."
     },
@@ -43,7 +43,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
-        "sha256": "cbd1856533755729cc1b7086019160a989e2810581081a5f150f03c8a21741c1"
+        "sha256": "c9f35d1a267181532952a9603de56d5b6342372ec1848a6ca5afcf841ad0b0b1"
       },
       "description": "Agent collaboration-interface registration for the work-model query."
     }
@@ -62,11 +62,11 @@
       },
       {
         "path": "framework/core/tests/python/test_agent_work_state_contract.py",
-        "sha256": "7a4edc5faaac5f143a8711b48ec7e9ce3d600f9890657abc815bdd935a45aa36"
+        "sha256": "8043df1867e82fb772faab9072f8d878538a0a4b9cd1d62b1639f3427795d215"
       },
       {
         "path": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
-        "sha256": "cbd1856533755729cc1b7086019160a989e2810581081a5f150f03c8a21741c1"
+        "sha256": "c9f35d1a267181532952a9603de56d5b6342372ec1848a6ca5afcf841ad0b0b1"
       }
     ],
     "artifactSha256": [

--- a/.buildchain/kfd/kfd-2/claims/agent-work-state-contract.json
+++ b/.buildchain/kfd/kfd-2/claims/agent-work-state-contract.json
@@ -16,7 +16,7 @@
       "pointer": {
         "kind": "file",
         "path": "docs/adr/ADR-0109-four-object-agent-work-state-contract.md",
-        "sha256": "6cb5a8615cc600b1830672a51c2d29100d9570025bbfec8bf6495535c999c418"
+        "sha256": "3a64520e737261ecf31ddccfd29d915d45dabec72237b562892bc8f7613cc1b4"
       },
       "description": "Accepted role-separation decision and bounded P17 qualification boundary."
     },
@@ -54,7 +54,7 @@
     "evidenceSha256": [
       {
         "path": "docs/adr/ADR-0109-four-object-agent-work-state-contract.md",
-        "sha256": "6cb5a8615cc600b1830672a51c2d29100d9570025bbfec8bf6495535c999c418"
+        "sha256": "3a64520e737261ecf31ddccfd29d915d45dabec72237b562892bc8f7613cc1b4"
       },
       {
         "path": "scripts/check-agent-work-state-contract.test.mjs",

--- a/.buildchain/kfd/kfd-2/claims/agent-work-state-contract.json
+++ b/.buildchain/kfd/kfd-2/claims/agent-work-state-contract.json
@@ -34,7 +34,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/tests/python/test_agent_work_state_contract.py",
-        "sha256": "8043df1867e82fb772faab9072f8d878538a0a4b9cd1d62b1639f3427795d215"
+        "sha256": "f56fbaf7caa54c86bc4e61df74e72bd8e6398d8879b52328b5138d0657f811b5"
       },
       "description": "Runtime CLI parity and fail-closed contract-schema checks."
     },
@@ -62,7 +62,7 @@
       },
       {
         "path": "framework/core/tests/python/test_agent_work_state_contract.py",
-        "sha256": "8043df1867e82fb772faab9072f8d878538a0a4b9cd1d62b1639f3427795d215"
+        "sha256": "f56fbaf7caa54c86bc4e61df74e72bd8e6398d8879b52328b5138d0657f811b5"
       },
       {
         "path": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",

--- a/.buildchain/kfd/kfd-2/claims/remote-fact-boundary.json
+++ b/.buildchain/kfd/kfd-2/claims/remote-fact-boundary.json
@@ -43,7 +43,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/cli/commands/agent.py",
-        "sha256": "fb40dca13f5f5137bd4c0546bd0871974c06ea0586ae9f63db43d8e926464056"
+        "sha256": "4a2c928d7c3bfd84d1883c65dc71f2e9e545febc2a9f8235a58172fac0170bda"
       },
       "description": "Agent command surface including mode selection and bootstrap status."
     }
@@ -66,7 +66,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/cli/commands/agent.py",
-        "sha256": "fb40dca13f5f5137bd4c0546bd0871974c06ea0586ae9f63db43d8e926464056"
+        "sha256": "4a2c928d7c3bfd84d1883c65dc71f2e9e545febc2a9f8235a58172fac0170bda"
       }
     ],
     "artifactSha256": [

--- a/.buildchain/kfd/kfd-2/claims/remote-fact-boundary.json
+++ b/.buildchain/kfd/kfd-2/claims/remote-fact-boundary.json
@@ -34,7 +34,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "63d9f38b97a4b134d19aae73734228fb5c1a87654d4aadb0e29b331902f8c10d"
+        "sha256": "a9b11bf1fb65113a0f32d4ee8e295e8bfa1607ae9d2fb244043d3740cbb42c54"
       },
       "description": "Remote add/sync command declarations and mode metadata."
     },
@@ -43,7 +43,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/cli/commands/agent.py",
-        "sha256": "1893649e2dfab5d9168c3f81cfef625ae1dadb09e298de8fac0f37c58992ef34"
+        "sha256": "fb40dca13f5f5137bd4c0546bd0871974c06ea0586ae9f63db43d8e926464056"
       },
       "description": "Agent command surface including mode selection and bootstrap status."
     }
@@ -62,11 +62,11 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "63d9f38b97a4b134d19aae73734228fb5c1a87654d4aadb0e29b331902f8c10d"
+        "sha256": "a9b11bf1fb65113a0f32d4ee8e295e8bfa1607ae9d2fb244043d3740cbb42c54"
       },
       {
         "path": "framework/core/src/python/kungfu/cli/commands/agent.py",
-        "sha256": "1893649e2dfab5d9168c3f81cfef625ae1dadb09e298de8fac0f37c58992ef34"
+        "sha256": "fb40dca13f5f5137bd4c0546bd0871974c06ea0586ae9f63db43d8e926464056"
       }
     ],
     "artifactSha256": [

--- a/.buildchain/kfd/kfd-2/release-claims.json
+++ b/.buildchain/kfd/kfd-2/release-claims.json
@@ -247,7 +247,7 @@
           "pointer": {
             "kind": "file",
             "path": "docs/adr/ADR-0109-four-object-agent-work-state-contract.md",
-            "sha256": "3a64520e737261ecf31ddccfd29d915d45dabec72237b562892bc8f7613cc1b4"
+            "sha256": "f14305861d5b7a697fbb7acb380a2849569cbef42d26eb6a9953a649b724d26f"
           },
           "description": "Accepted role-separation decision and bounded P17 qualification boundary."
         },

--- a/.buildchain/kfd/kfd-2/release-claims.json
+++ b/.buildchain/kfd/kfd-2/release-claims.json
@@ -29,7 +29,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/commands.json",
-            "sha256": "63d9f38b97a4b134d19aae73734228fb5c1a87654d4aadb0e29b331902f8c10d"
+            "sha256": "a9b11bf1fb65113a0f32d4ee8e295e8bfa1607ae9d2fb244043d3740cbb42c54"
           },
           "description": "Machine-readable command catalog and mode maturity metadata."
         },
@@ -194,7 +194,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/commands.json",
-            "sha256": "63d9f38b97a4b134d19aae73734228fb5c1a87654d4aadb0e29b331902f8c10d"
+            "sha256": "a9b11bf1fb65113a0f32d4ee8e295e8bfa1607ae9d2fb244043d3740cbb42c54"
           },
           "description": "Remote add/sync command declarations and mode metadata."
         },
@@ -203,7 +203,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/cli/commands/agent.py",
-            "sha256": "1893649e2dfab5d9168c3f81cfef625ae1dadb09e298de8fac0f37c58992ef34"
+            "sha256": "fb40dca13f5f5137bd4c0546bd0871974c06ea0586ae9f63db43d8e926464056"
           },
           "description": "Agent command surface including mode selection and bootstrap status."
         }
@@ -265,7 +265,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/tests/python/test_agent_work_state_contract.py",
-            "sha256": "7a4edc5faaac5f143a8711b48ec7e9ce3d600f9890657abc815bdd935a45aa36"
+            "sha256": "8043df1867e82fb772faab9072f8d878538a0a4b9cd1d62b1639f3427795d215"
           },
           "description": "Runtime CLI parity and fail-closed contract-schema checks."
         },
@@ -274,7 +274,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
-            "sha256": "cbd1856533755729cc1b7086019160a989e2810581081a5f150f03c8a21741c1"
+            "sha256": "c9f35d1a267181532952a9603de56d5b6342372ec1848a6ca5afcf841ad0b0b1"
           },
           "description": "Agent collaboration-interface registration for the work-model query."
         }

--- a/.buildchain/kfd/kfd-2/release-claims.json
+++ b/.buildchain/kfd/kfd-2/release-claims.json
@@ -247,7 +247,7 @@
           "pointer": {
             "kind": "file",
             "path": "docs/adr/ADR-0109-four-object-agent-work-state-contract.md",
-            "sha256": "6cb5a8615cc600b1830672a51c2d29100d9570025bbfec8bf6495535c999c418"
+            "sha256": "3a64520e737261ecf31ddccfd29d915d45dabec72237b562892bc8f7613cc1b4"
           },
           "description": "Accepted role-separation decision and bounded P17 qualification boundary."
         },

--- a/.buildchain/kfd/kfd-2/release-claims.json
+++ b/.buildchain/kfd/kfd-2/release-claims.json
@@ -203,7 +203,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/cli/commands/agent.py",
-            "sha256": "fb40dca13f5f5137bd4c0546bd0871974c06ea0586ae9f63db43d8e926464056"
+            "sha256": "4a2c928d7c3bfd84d1883c65dc71f2e9e545febc2a9f8235a58172fac0170bda"
           },
           "description": "Agent command surface including mode selection and bootstrap status."
         }
@@ -265,7 +265,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/tests/python/test_agent_work_state_contract.py",
-            "sha256": "8043df1867e82fb772faab9072f8d878538a0a4b9cd1d62b1639f3427795d215"
+            "sha256": "f56fbaf7caa54c86bc4e61df74e72bd8e6398d8879b52328b5138d0657f811b5"
           },
           "description": "Runtime CLI parity and fail-closed contract-schema checks."
         },

--- a/.buildchain/kfd/kfd-3/capability-query.json
+++ b/.buildchain/kfd/kfd-3/capability-query.json
@@ -539,6 +539,28 @@
       "residualRisk": []
     },
     {
+      "id": "kungfu.agent.work",
+      "kind": "cli-api-gui",
+      "name": "kungfu agent work",
+      "state": "declared",
+      "detected": true,
+      "enforced": false,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "kfd1Basis": {
+        "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+        "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+        "digest": "sha256:63764e57be6185834da23db2a58bf2ac99167599419cb4b6d835b6d789b6d0f8"
+      },
+      "kfd2Trust": {
+        "status": "release-passport-required",
+        "trustImpact": "query-release-passport-for-final-trust",
+        "residualRisk": []
+      },
+      "residualRisk": []
+    },
+    {
       "id": "kungfu.agent.work-model",
       "kind": "cli",
       "name": "kungfu agent work-model --json",
@@ -552,6 +574,72 @@
         "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
         "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
         "digest": "sha256:95cfa8b61701d378bf7b607a2a8ed398a10fffff47d8a0213b0f15ff16279a4e"
+      },
+      "kfd2Trust": {
+        "status": "release-passport-required",
+        "trustImpact": "query-release-passport-for-final-trust",
+        "residualRisk": []
+      },
+      "residualRisk": []
+    },
+    {
+      "id": "kungfu.agent.work.action",
+      "kind": "cli-api-gui",
+      "name": "kungfu agent work action --file <request.json> [--execute] --json",
+      "state": "declared",
+      "detected": true,
+      "enforced": false,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "kfd1Basis": {
+        "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+        "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+        "digest": "sha256:35d54212b2184b83d2052ee3311dc4ca4c3c4b8632861c6715435e10250a1e20"
+      },
+      "kfd2Trust": {
+        "status": "release-passport-required",
+        "trustImpact": "query-release-passport-for-final-trust",
+        "residualRisk": []
+      },
+      "residualRisk": []
+    },
+    {
+      "id": "kungfu.agent.work.capabilities",
+      "kind": "cli-api-gui",
+      "name": "kungfu agent work capabilities --json",
+      "state": "declared",
+      "detected": true,
+      "enforced": false,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "kfd1Basis": {
+        "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+        "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+        "digest": "sha256:f3c47c84066a4c0acc5401dc6517c8a30b0ce23807ef86f243e1e65409002a42"
+      },
+      "kfd2Trust": {
+        "status": "release-passport-required",
+        "trustImpact": "query-release-passport-for-final-trust",
+        "residualRisk": []
+      },
+      "residualRisk": []
+    },
+    {
+      "id": "kungfu.agent.work.inspect",
+      "kind": "cli-api-gui",
+      "name": "kungfu agent work inspect --ref <ref> --json",
+      "state": "declared",
+      "detected": true,
+      "enforced": false,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "kfd1Basis": {
+        "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+        "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+        "digest": "sha256:6af6d64c9de18bca664083e4bed4729f414bdc942dc2eef163c138f0981a4d88"
       },
       "kfd2Trust": {
         "status": "release-passport-required",

--- a/.buildchain/kfd/kfd-3/collaboration-interface.artifact.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.artifact.json
@@ -10,8 +10,8 @@
   "sourceRegistry": {
     "id": "kungfu",
     "path": ".buildchain/kfd/kfd-3/surfaces.json",
-    "sha256": "57f4eb51c818438bf9eba49995a71fa439797009c7852db7b41a145c264092aa",
-    "digest": "sha256:4ce30572ec2c0a3fe8b6ca7432bb2911ea310de7b38571ca6ec22952df62ff77"
+    "sha256": "3fc32178628eca2961d9a57f77b96afec213124804100d0c767916f74b6d4e66",
+    "digest": "sha256:9b3ee34f427674e7fad78556f0bc35f860389fa400a391c51eb51a31ea4ada12"
   },
   "upstreamKfd": {
     "aggregatePath": "developer/sdk/kfd/upstream-aggregate.json",
@@ -28,7 +28,7 @@
     },
     "digest": "sha256:a9e8488f2319ecf9f36ea3e2ab5e6e0fe4c426c74dca07176e1df5988860c103"
   },
-  "collaborationInterfaceDigest": "sha256:c98bc1ba54069f523eb964fcd7ea7d7f372706bd5aa730bba6738f3bc62d7565",
+  "collaborationInterfaceDigest": "sha256:d229baef8d9bd717c4bd85b765301bcc43363b8b7d97ac06fc79847d80e4c9c8",
   "exposedSurfaces": [
     {
       "id": "kungfu.agent",
@@ -511,9 +511,89 @@
       }
     },
     {
+      "id": "kungfu.agent.work",
+      "name": "kungfu agent work",
+      "kind": "cli-api-gui",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
       "id": "kungfu.agent.work-model",
       "name": "kungfu agent work-model --json",
       "kind": "cli",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
+      "id": "kungfu.agent.work.action",
+      "name": "kungfu agent work action --file <request.json> [--execute] --json",
+      "kind": "cli-api-gui",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
+      "id": "kungfu.agent.work.capabilities",
+      "name": "kungfu agent work capabilities --json",
+      "kind": "cli-api-gui",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
+      "id": "kungfu.agent.work.inspect",
+      "name": "kungfu agent work inspect --ref <ref> --json",
+      "kind": "cli-api-gui",
       "participantProfile": "agent-or-developer",
       "state": "declared",
       "availability": "shipped",

--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -6,15 +6,15 @@
   "supportLevel": "release",
   "source": {
     "cwd": ".",
-    "sourceSha": "90bf5d3007a97e6743cdbbe0f17d8dff992e8413",
+    "sourceSha": "3a70adf15a3d1d60929306ac6eefe659834f567a",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
-    "registryDigest": "sha256:4ce30572ec2c0a3fe8b6ca7432bb2911ea310de7b38571ca6ec22952df62ff77"
+    "registryDigest": "sha256:9b3ee34f427674e7fad78556f0bc35f860389fa400a391c51eb51a31ea4ada12"
   },
   "sourceRegistry": {
     "id": "kungfu",
     "path": ".buildchain/kfd/kfd-3/surfaces.json",
-    "sha256": "57f4eb51c818438bf9eba49995a71fa439797009c7852db7b41a145c264092aa",
-    "digest": "sha256:4ce30572ec2c0a3fe8b6ca7432bb2911ea310de7b38571ca6ec22952df62ff77"
+    "sha256": "3fc32178628eca2961d9a57f77b96afec213124804100d0c767916f74b6d4e66",
+    "digest": "sha256:9b3ee34f427674e7fad78556f0bc35f860389fa400a391c51eb51a31ea4ada12"
   },
   "upstreamKfd": {
     "aggregatePath": "developer/sdk/kfd/upstream-aggregate.json",
@@ -34,7 +34,7 @@
   "expectedArtifactVerification": {
     "command": "node scripts/buildchain-kfd-evidence.mjs --artifact-witness --json"
   },
-  "collaborationInterfaceDigest": "sha256:c98bc1ba54069f523eb964fcd7ea7d7f372706bd5aa730bba6738f3bc62d7565",
+  "collaborationInterfaceDigest": "sha256:d229baef8d9bd717c4bd85b765301bcc43363b8b7d97ac06fc79847d80e4c9c8",
   "collaborationInterface": {
     "schemaVersion": 1,
     "contract": "kungfu-buildchain-kfd-3-surface-registry",
@@ -541,9 +541,89 @@
         }
       },
       {
+        "id": "kungfu.agent.work",
+        "name": "kungfu agent work",
+        "kind": "cli-api-gui",
+        "participantProfile": "agent-or-developer",
+        "state": "declared",
+        "availability": "shipped",
+        "visibility": "public",
+        "participantFacing": true,
+        "public": true,
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+        "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+        "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+        "maturity": "experimental",
+        "declaration": {
+          "owner": "kungfu",
+          "source": "scripts/buildchain-kfd-evidence.mjs",
+          "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+        }
+      },
+      {
         "id": "kungfu.agent.work-model",
         "name": "kungfu agent work-model --json",
         "kind": "cli",
+        "participantProfile": "agent-or-developer",
+        "state": "declared",
+        "availability": "shipped",
+        "visibility": "public",
+        "participantFacing": true,
+        "public": true,
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+        "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+        "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+        "maturity": "experimental",
+        "declaration": {
+          "owner": "kungfu",
+          "source": "scripts/buildchain-kfd-evidence.mjs",
+          "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+        }
+      },
+      {
+        "id": "kungfu.agent.work.action",
+        "name": "kungfu agent work action --file <request.json> [--execute] --json",
+        "kind": "cli-api-gui",
+        "participantProfile": "agent-or-developer",
+        "state": "declared",
+        "availability": "shipped",
+        "visibility": "public",
+        "participantFacing": true,
+        "public": true,
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+        "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+        "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+        "maturity": "experimental",
+        "declaration": {
+          "owner": "kungfu",
+          "source": "scripts/buildchain-kfd-evidence.mjs",
+          "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+        }
+      },
+      {
+        "id": "kungfu.agent.work.capabilities",
+        "name": "kungfu agent work capabilities --json",
+        "kind": "cli-api-gui",
+        "participantProfile": "agent-or-developer",
+        "state": "declared",
+        "availability": "shipped",
+        "visibility": "public",
+        "participantFacing": true,
+        "public": true,
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+        "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+        "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+        "maturity": "experimental",
+        "declaration": {
+          "owner": "kungfu",
+          "source": "scripts/buildchain-kfd-evidence.mjs",
+          "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+        }
+      },
+      {
+        "id": "kungfu.agent.work.inspect",
+        "name": "kungfu agent work inspect --ref <ref> --json",
+        "kind": "cli-api-gui",
         "participantProfile": "agent-or-developer",
         "state": "declared",
         "availability": "shipped",
@@ -2628,8 +2708,8 @@
     ],
     "audit": {
       "status": "passed",
-      "declared": 127,
-      "artifactPublic": 127,
+      "declared": 131,
+      "artifactPublic": 131,
       "policy": {
         "sourceOfTruth": ".buildchain/kfd/kfd-3/surfaces.json",
         "detectedButUnregistered": "product-specific-audit",
@@ -3122,9 +3202,89 @@
       }
     },
     {
+      "id": "kungfu.agent.work",
+      "name": "kungfu agent work",
+      "kind": "cli-api-gui",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
       "id": "kungfu.agent.work-model",
       "name": "kungfu agent work-model --json",
       "kind": "cli",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
+      "id": "kungfu.agent.work.action",
+      "name": "kungfu agent work action --file <request.json> [--execute] --json",
+      "kind": "cli-api-gui",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
+      "id": "kungfu.agent.work.capabilities",
+      "name": "kungfu agent work capabilities --json",
+      "kind": "cli-api-gui",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
+      "id": "kungfu.agent.work.inspect",
+      "name": "kungfu agent work inspect --ref <ref> --json",
+      "kind": "cli-api-gui",
       "participantProfile": "agent-or-developer",
       "state": "declared",
       "availability": "shipped",

--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -6,7 +6,7 @@
   "supportLevel": "release",
   "source": {
     "cwd": ".",
-    "sourceSha": "9b62adac9fba7fa4af15f92fc4ca061148279262",
+    "sourceSha": "87e6e8d235f1bf72a10d79d1e1972794b1428de6",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
     "registryDigest": "sha256:9b3ee34f427674e7fad78556f0bc35f860389fa400a391c51eb51a31ea4ada12"
   },

--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -6,7 +6,7 @@
   "supportLevel": "release",
   "source": {
     "cwd": ".",
-    "sourceSha": "3a70adf15a3d1d60929306ac6eefe659834f567a",
+    "sourceSha": "9b62adac9fba7fa4af15f92fc4ca061148279262",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
     "registryDigest": "sha256:9b3ee34f427674e7fad78556f0bc35f860389fa400a391c51eb51a31ea4ada12"
   },

--- a/.buildchain/kfd/kfd-3/surfaces.json
+++ b/.buildchain/kfd/kfd-3/surfaces.json
@@ -549,9 +549,89 @@
       }
     },
     {
+      "id": "kungfu.agent.work",
+      "name": "kungfu agent work",
+      "kind": "cli-api-gui",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
       "id": "kungfu.agent.work-model",
       "name": "kungfu agent work-model --json",
       "kind": "cli",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
+      "id": "kungfu.agent.work.action",
+      "name": "kungfu agent work action --file <request.json> [--execute] --json",
+      "kind": "cli-api-gui",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
+      "id": "kungfu.agent.work.capabilities",
+      "name": "kungfu agent work capabilities --json",
+      "kind": "cli-api-gui",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
+      "id": "kungfu.agent.work.inspect",
+      "name": "kungfu agent work inspect --ref <ref> --json",
+      "kind": "cli-api-gui",
       "participantProfile": "agent-or-developer",
       "state": "declared",
       "availability": "shipped",

--- a/developer/sdk/kfd/kfd-1/contract-world.witness.json
+++ b/developer/sdk/kfd/kfd-1/contract-world.witness.json
@@ -35,7 +35,7 @@
   "sourceVerificationRequired": false,
   "canonicalPolicy": {
     "path": "framework/contract/kungfu-agent-first-canonical-policy.json",
-    "sha256": "694351008847264384dbd4096471faebf879358dad0f9be0fb96020cffe03280"
+    "sha256": "0c4d589833840e5bee88fad4bae166b72c3fccfa7001884eb71fbf63364a60bb"
   },
   "registry": {
     "path": "framework/contract/kungfu-contracts.registry.json",
@@ -117,9 +117,9 @@
     {
       "name": "kungfu-fact-cut-kernel",
       "sourcePath": "framework/fact/kungfu-fact-cut-kernel.contract.json",
-      "sourceSha256": "ccd0526781a200efca157bac10ccd41d3bbb614102e65ef335a78fd63176e1e5",
+      "sourceSha256": "dfe1164c6c4b02e2cb5577839f72f44cb572dd8849072de0697fd639f105f50d",
       "artifactPath": "config/kungfu-fact-cut-kernel.contract.json",
-      "expectedSha256": "ccd0526781a200efca157bac10ccd41d3bbb614102e65ef335a78fd63176e1e5",
+      "expectedSha256": "dfe1164c6c4b02e2cb5577839f72f44cb572dd8849072de0697fd639f105f50d",
       "byteForByte": true
     }
   ],

--- a/developer/sdk/kfd/kfd-1/release-gate.json
+++ b/developer/sdk/kfd/kfd-1/release-gate.json
@@ -54,13 +54,13 @@
       "standard": "KFD-1",
       "standardKey": "kfd-1",
       "result": "passed",
-      "preBuildWitnessSha256": "2de8c3b6af45f9b64763d161d9090d39877d6b75947d9128025446847f577254",
+      "preBuildWitnessSha256": "0f7e9f1336eeb57037622a9369e4a4c3b48b2666e3bca6b18fe437e693389d92",
       "sourceHashes": {
-        "sha256": "d8f88d19090f0e02b922841eddbb34631b2d979e05936c53a1d6e351fb35f66c",
+        "sha256": "cecb0b3542eec5fdb691e4af772eb8439bc76f0026906c1135503aec35d7eb88",
         "surfaceCount": 10
       },
       "artifactHashes": {
-        "sha256": "505b245dc3602f07b328d89d1d06cc4b4756383204a34e46043583aa5106843d",
+        "sha256": "98b28184d1fe5a073af9c5be6df6d3cd7d9885e759b852243ebf45580bcfb905",
         "surfaceCount": 10
       },
       "witness": {
@@ -100,7 +100,7 @@
         "sourceVerificationRequired": true,
         "canonicalPolicy": {
           "path": "framework/contract/kungfu-agent-first-canonical-policy.json",
-          "sha256": "694351008847264384dbd4096471faebf879358dad0f9be0fb96020cffe03280"
+          "sha256": "0c4d589833840e5bee88fad4bae166b72c3fccfa7001884eb71fbf63364a60bb"
         },
         "registry": {
           "path": "framework/contract/kungfu-contracts.registry.json",
@@ -182,9 +182,9 @@
           {
             "name": "kungfu-fact-cut-kernel",
             "sourcePath": "framework/fact/kungfu-fact-cut-kernel.contract.json",
-            "sourceSha256": "ccd0526781a200efca157bac10ccd41d3bbb614102e65ef335a78fd63176e1e5",
+            "sourceSha256": "dfe1164c6c4b02e2cb5577839f72f44cb572dd8849072de0697fd639f105f50d",
             "artifactPath": "config/kungfu-fact-cut-kernel.contract.json",
-            "expectedSha256": "ccd0526781a200efca157bac10ccd41d3bbb614102e65ef335a78fd63176e1e5",
+            "expectedSha256": "dfe1164c6c4b02e2cb5577839f72f44cb572dd8849072de0697fd639f105f50d",
             "byteForByte": true
           }
         ],
@@ -305,8 +305,8 @@
           {
             "name": "kungfu-fact-cut-kernel",
             "sourcePath": "framework/fact/kungfu-fact-cut-kernel.contract.json",
-            "expectedSha256": "ccd0526781a200efca157bac10ccd41d3bbb614102e65ef335a78fd63176e1e5",
-            "actualSha256": "ccd0526781a200efca157bac10ccd41d3bbb614102e65ef335a78fd63176e1e5",
+            "expectedSha256": "dfe1164c6c4b02e2cb5577839f72f44cb572dd8849072de0697fd639f105f50d",
+            "actualSha256": "dfe1164c6c4b02e2cb5577839f72f44cb572dd8849072de0697fd639f105f50d",
             "status": "passed",
             "reason": ""
           }
@@ -418,10 +418,10 @@
           {
             "name": "kungfu-fact-cut-kernel",
             "sourcePath": "framework/fact/kungfu-fact-cut-kernel.contract.json",
-            "sourceSha256": "ccd0526781a200efca157bac10ccd41d3bbb614102e65ef335a78fd63176e1e5",
+            "sourceSha256": "dfe1164c6c4b02e2cb5577839f72f44cb572dd8849072de0697fd639f105f50d",
             "artifactPath": "config/kungfu-fact-cut-kernel.contract.json",
-            "expectedSha256": "ccd0526781a200efca157bac10ccd41d3bbb614102e65ef335a78fd63176e1e5",
-            "actualSha256": "ccd0526781a200efca157bac10ccd41d3bbb614102e65ef335a78fd63176e1e5",
+            "expectedSha256": "dfe1164c6c4b02e2cb5577839f72f44cb572dd8849072de0697fd639f105f50d",
+            "actualSha256": "dfe1164c6c4b02e2cb5577839f72f44cb572dd8849072de0697fd639f105f50d",
             "byteForByte": true,
             "status": "passed",
             "reason": ""

--- a/developer/sdk/kfd/kfd-2/claims/agent-onboarding-pack.json
+++ b/developer/sdk/kfd/kfd-2/claims/agent-onboarding-pack.json
@@ -16,7 +16,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "63d9f38b97a4b134d19aae73734228fb5c1a87654d4aadb0e29b331902f8c10d"
+        "sha256": "a9b11bf1fb65113a0f32d4ee8e295e8bfa1607ae9d2fb244043d3740cbb42c54"
       },
       "description": "Machine-readable command catalog and mode maturity metadata."
     },
@@ -54,7 +54,7 @@
     "evidenceSha256": [
       {
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "63d9f38b97a4b134d19aae73734228fb5c1a87654d4aadb0e29b331902f8c10d"
+        "sha256": "a9b11bf1fb65113a0f32d4ee8e295e8bfa1607ae9d2fb244043d3740cbb42c54"
       },
       {
         "path": "framework/core/src/python/kungfu/agent/mode-selection.md",
@@ -76,7 +76,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "63d9f38b97a4b134d19aae73734228fb5c1a87654d4aadb0e29b331902f8c10d"
+        "sha256": "a9b11bf1fb65113a0f32d4ee8e295e8bfa1607ae9d2fb244043d3740cbb42c54"
       }
     ]
   },
@@ -90,7 +90,7 @@
     {
       "name": "agent-command-catalog",
       "path": "framework/core/src/python/kungfu/agent/commands.json",
-      "sha256": "63d9f38b97a4b134d19aae73734228fb5c1a87654d4aadb0e29b331902f8c10d",
+      "sha256": "a9b11bf1fb65113a0f32d4ee8e295e8bfa1607ae9d2fb244043d3740cbb42c54",
       "expectedPackagePath": "kungfu/agent/commands.json"
     }
   ],

--- a/developer/sdk/kfd/kfd-2/claims/agent-work-state-contract.json
+++ b/developer/sdk/kfd/kfd-2/claims/agent-work-state-contract.json
@@ -16,7 +16,7 @@
       "pointer": {
         "kind": "file",
         "path": "docs/adr/ADR-0109-four-object-agent-work-state-contract.md",
-        "sha256": "3a64520e737261ecf31ddccfd29d915d45dabec72237b562892bc8f7613cc1b4"
+        "sha256": "f14305861d5b7a697fbb7acb380a2849569cbef42d26eb6a9953a649b724d26f"
       },
       "description": "Accepted role-separation decision and bounded P17 qualification boundary."
     },
@@ -54,7 +54,7 @@
     "evidenceSha256": [
       {
         "path": "docs/adr/ADR-0109-four-object-agent-work-state-contract.md",
-        "sha256": "3a64520e737261ecf31ddccfd29d915d45dabec72237b562892bc8f7613cc1b4"
+        "sha256": "f14305861d5b7a697fbb7acb380a2849569cbef42d26eb6a9953a649b724d26f"
       },
       {
         "path": "scripts/check-agent-work-state-contract.test.mjs",

--- a/developer/sdk/kfd/kfd-2/claims/agent-work-state-contract.json
+++ b/developer/sdk/kfd/kfd-2/claims/agent-work-state-contract.json
@@ -34,7 +34,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/tests/python/test_agent_work_state_contract.py",
-        "sha256": "7a4edc5faaac5f143a8711b48ec7e9ce3d600f9890657abc815bdd935a45aa36"
+        "sha256": "8043df1867e82fb772faab9072f8d878538a0a4b9cd1d62b1639f3427795d215"
       },
       "description": "Runtime CLI parity and fail-closed contract-schema checks."
     },
@@ -43,7 +43,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
-        "sha256": "cbd1856533755729cc1b7086019160a989e2810581081a5f150f03c8a21741c1"
+        "sha256": "c9f35d1a267181532952a9603de56d5b6342372ec1848a6ca5afcf841ad0b0b1"
       },
       "description": "Agent collaboration-interface registration for the work-model query."
     }
@@ -62,11 +62,11 @@
       },
       {
         "path": "framework/core/tests/python/test_agent_work_state_contract.py",
-        "sha256": "7a4edc5faaac5f143a8711b48ec7e9ce3d600f9890657abc815bdd935a45aa36"
+        "sha256": "8043df1867e82fb772faab9072f8d878538a0a4b9cd1d62b1639f3427795d215"
       },
       {
         "path": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
-        "sha256": "cbd1856533755729cc1b7086019160a989e2810581081a5f150f03c8a21741c1"
+        "sha256": "c9f35d1a267181532952a9603de56d5b6342372ec1848a6ca5afcf841ad0b0b1"
       }
     ],
     "artifactSha256": [

--- a/developer/sdk/kfd/kfd-2/claims/agent-work-state-contract.json
+++ b/developer/sdk/kfd/kfd-2/claims/agent-work-state-contract.json
@@ -16,7 +16,7 @@
       "pointer": {
         "kind": "file",
         "path": "docs/adr/ADR-0109-four-object-agent-work-state-contract.md",
-        "sha256": "6cb5a8615cc600b1830672a51c2d29100d9570025bbfec8bf6495535c999c418"
+        "sha256": "3a64520e737261ecf31ddccfd29d915d45dabec72237b562892bc8f7613cc1b4"
       },
       "description": "Accepted role-separation decision and bounded P17 qualification boundary."
     },
@@ -54,7 +54,7 @@
     "evidenceSha256": [
       {
         "path": "docs/adr/ADR-0109-four-object-agent-work-state-contract.md",
-        "sha256": "6cb5a8615cc600b1830672a51c2d29100d9570025bbfec8bf6495535c999c418"
+        "sha256": "3a64520e737261ecf31ddccfd29d915d45dabec72237b562892bc8f7613cc1b4"
       },
       {
         "path": "scripts/check-agent-work-state-contract.test.mjs",

--- a/developer/sdk/kfd/kfd-2/claims/agent-work-state-contract.json
+++ b/developer/sdk/kfd/kfd-2/claims/agent-work-state-contract.json
@@ -34,7 +34,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/tests/python/test_agent_work_state_contract.py",
-        "sha256": "8043df1867e82fb772faab9072f8d878538a0a4b9cd1d62b1639f3427795d215"
+        "sha256": "f56fbaf7caa54c86bc4e61df74e72bd8e6398d8879b52328b5138d0657f811b5"
       },
       "description": "Runtime CLI parity and fail-closed contract-schema checks."
     },
@@ -62,7 +62,7 @@
       },
       {
         "path": "framework/core/tests/python/test_agent_work_state_contract.py",
-        "sha256": "8043df1867e82fb772faab9072f8d878538a0a4b9cd1d62b1639f3427795d215"
+        "sha256": "f56fbaf7caa54c86bc4e61df74e72bd8e6398d8879b52328b5138d0657f811b5"
       },
       {
         "path": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",

--- a/developer/sdk/kfd/kfd-2/claims/remote-fact-boundary.json
+++ b/developer/sdk/kfd/kfd-2/claims/remote-fact-boundary.json
@@ -43,7 +43,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/cli/commands/agent.py",
-        "sha256": "fb40dca13f5f5137bd4c0546bd0871974c06ea0586ae9f63db43d8e926464056"
+        "sha256": "4a2c928d7c3bfd84d1883c65dc71f2e9e545febc2a9f8235a58172fac0170bda"
       },
       "description": "Agent command surface including mode selection and bootstrap status."
     }
@@ -66,7 +66,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/cli/commands/agent.py",
-        "sha256": "fb40dca13f5f5137bd4c0546bd0871974c06ea0586ae9f63db43d8e926464056"
+        "sha256": "4a2c928d7c3bfd84d1883c65dc71f2e9e545febc2a9f8235a58172fac0170bda"
       }
     ],
     "artifactSha256": [

--- a/developer/sdk/kfd/kfd-2/claims/remote-fact-boundary.json
+++ b/developer/sdk/kfd/kfd-2/claims/remote-fact-boundary.json
@@ -34,7 +34,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "63d9f38b97a4b134d19aae73734228fb5c1a87654d4aadb0e29b331902f8c10d"
+        "sha256": "a9b11bf1fb65113a0f32d4ee8e295e8bfa1607ae9d2fb244043d3740cbb42c54"
       },
       "description": "Remote add/sync command declarations and mode metadata."
     },
@@ -43,7 +43,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/cli/commands/agent.py",
-        "sha256": "1893649e2dfab5d9168c3f81cfef625ae1dadb09e298de8fac0f37c58992ef34"
+        "sha256": "fb40dca13f5f5137bd4c0546bd0871974c06ea0586ae9f63db43d8e926464056"
       },
       "description": "Agent command surface including mode selection and bootstrap status."
     }
@@ -62,11 +62,11 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "63d9f38b97a4b134d19aae73734228fb5c1a87654d4aadb0e29b331902f8c10d"
+        "sha256": "a9b11bf1fb65113a0f32d4ee8e295e8bfa1607ae9d2fb244043d3740cbb42c54"
       },
       {
         "path": "framework/core/src/python/kungfu/cli/commands/agent.py",
-        "sha256": "1893649e2dfab5d9168c3f81cfef625ae1dadb09e298de8fac0f37c58992ef34"
+        "sha256": "fb40dca13f5f5137bd4c0546bd0871974c06ea0586ae9f63db43d8e926464056"
       }
     ],
     "artifactSha256": [

--- a/developer/sdk/kfd/kfd-2/release-claims.json
+++ b/developer/sdk/kfd/kfd-2/release-claims.json
@@ -247,7 +247,7 @@
           "pointer": {
             "kind": "file",
             "path": "docs/adr/ADR-0109-four-object-agent-work-state-contract.md",
-            "sha256": "3a64520e737261ecf31ddccfd29d915d45dabec72237b562892bc8f7613cc1b4"
+            "sha256": "f14305861d5b7a697fbb7acb380a2849569cbef42d26eb6a9953a649b724d26f"
           },
           "description": "Accepted role-separation decision and bounded P17 qualification boundary."
         },

--- a/developer/sdk/kfd/kfd-2/release-claims.json
+++ b/developer/sdk/kfd/kfd-2/release-claims.json
@@ -29,7 +29,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/commands.json",
-            "sha256": "63d9f38b97a4b134d19aae73734228fb5c1a87654d4aadb0e29b331902f8c10d"
+            "sha256": "a9b11bf1fb65113a0f32d4ee8e295e8bfa1607ae9d2fb244043d3740cbb42c54"
           },
           "description": "Machine-readable command catalog and mode maturity metadata."
         },
@@ -194,7 +194,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/commands.json",
-            "sha256": "63d9f38b97a4b134d19aae73734228fb5c1a87654d4aadb0e29b331902f8c10d"
+            "sha256": "a9b11bf1fb65113a0f32d4ee8e295e8bfa1607ae9d2fb244043d3740cbb42c54"
           },
           "description": "Remote add/sync command declarations and mode metadata."
         },
@@ -203,7 +203,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/cli/commands/agent.py",
-            "sha256": "1893649e2dfab5d9168c3f81cfef625ae1dadb09e298de8fac0f37c58992ef34"
+            "sha256": "fb40dca13f5f5137bd4c0546bd0871974c06ea0586ae9f63db43d8e926464056"
           },
           "description": "Agent command surface including mode selection and bootstrap status."
         }
@@ -265,7 +265,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/tests/python/test_agent_work_state_contract.py",
-            "sha256": "7a4edc5faaac5f143a8711b48ec7e9ce3d600f9890657abc815bdd935a45aa36"
+            "sha256": "8043df1867e82fb772faab9072f8d878538a0a4b9cd1d62b1639f3427795d215"
           },
           "description": "Runtime CLI parity and fail-closed contract-schema checks."
         },
@@ -274,7 +274,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
-            "sha256": "cbd1856533755729cc1b7086019160a989e2810581081a5f150f03c8a21741c1"
+            "sha256": "c9f35d1a267181532952a9603de56d5b6342372ec1848a6ca5afcf841ad0b0b1"
           },
           "description": "Agent collaboration-interface registration for the work-model query."
         }

--- a/developer/sdk/kfd/kfd-2/release-claims.json
+++ b/developer/sdk/kfd/kfd-2/release-claims.json
@@ -247,7 +247,7 @@
           "pointer": {
             "kind": "file",
             "path": "docs/adr/ADR-0109-four-object-agent-work-state-contract.md",
-            "sha256": "6cb5a8615cc600b1830672a51c2d29100d9570025bbfec8bf6495535c999c418"
+            "sha256": "3a64520e737261ecf31ddccfd29d915d45dabec72237b562892bc8f7613cc1b4"
           },
           "description": "Accepted role-separation decision and bounded P17 qualification boundary."
         },

--- a/developer/sdk/kfd/kfd-2/release-claims.json
+++ b/developer/sdk/kfd/kfd-2/release-claims.json
@@ -203,7 +203,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/cli/commands/agent.py",
-            "sha256": "fb40dca13f5f5137bd4c0546bd0871974c06ea0586ae9f63db43d8e926464056"
+            "sha256": "4a2c928d7c3bfd84d1883c65dc71f2e9e545febc2a9f8235a58172fac0170bda"
           },
           "description": "Agent command surface including mode selection and bootstrap status."
         }
@@ -265,7 +265,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/tests/python/test_agent_work_state_contract.py",
-            "sha256": "8043df1867e82fb772faab9072f8d878538a0a4b9cd1d62b1639f3427795d215"
+            "sha256": "f56fbaf7caa54c86bc4e61df74e72bd8e6398d8879b52328b5138d0657f811b5"
           },
           "description": "Runtime CLI parity and fail-closed contract-schema checks."
         },

--- a/developer/sdk/kfd/kfd-3-surfaces.json
+++ b/developer/sdk/kfd/kfd-3-surfaces.json
@@ -549,9 +549,89 @@
       }
     },
     {
+      "id": "kungfu.agent.work",
+      "name": "kungfu agent work",
+      "kind": "cli-api-gui",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
       "id": "kungfu.agent.work-model",
       "name": "kungfu agent work-model --json",
       "kind": "cli",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
+      "id": "kungfu.agent.work.action",
+      "name": "kungfu agent work action --file <request.json> [--execute] --json",
+      "kind": "cli-api-gui",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
+      "id": "kungfu.agent.work.capabilities",
+      "name": "kungfu agent work capabilities --json",
+      "kind": "cli-api-gui",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
+      "id": "kungfu.agent.work.inspect",
+      "name": "kungfu agent work inspect --ref <ref> --json",
+      "kind": "cli-api-gui",
       "participantProfile": "agent-or-developer",
       "state": "declared",
       "availability": "shipped",

--- a/docs/adr/ADR-0109-four-object-agent-work-state-contract.md
+++ b/docs/adr/ADR-0109-four-object-agent-work-state-contract.md
@@ -4,7 +4,7 @@ doc_type: architecture-decision
 adr_id: ADR-0109
 decision_status: accepted
 implementation_status: staged
-implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/1026]
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/1026, https://github.com/kungfu-systems/kungfu/pull/1079]
 qualification_refs: [framework/agent-work/kungfu-agent-work-state.contract.json, scripts/check-agent-work-state-contract.test.mjs, framework/core/tests/python/test_agent_work_state_contract.py, framework/core/src/python/kungfu/agent/kfd3_api.registry.json]
 review_state: self-reviewed
 sensitivity: public
@@ -13,12 +13,12 @@ period: 2026-07-17
 theme: four-object-agent-work-state-contract
 confidence: high
 evidence_grade: B
-last_reviewed: 2026-07-17
+last_reviewed: 2026-07-18
 ---
 
 # ADR-0109: Real-world agent work preserves four independently addressable roles
 
-- Status: accepted; contract and discovery staged, P17 not qualified
+- Status: accepted; provisional runtime Profile staged, P17 not qualified
 - Date: 2026-07-17
 - Category: Agent Work Profile / product contract / KFD-3
 - Related: [ADR-0033](ADR-0033-episode-causal-segment-object.md),

--- a/docs/adr/ADR-0109-four-object-agent-work-state-contract.md
+++ b/docs/adr/ADR-0109-four-object-agent-work-state-contract.md
@@ -4,7 +4,7 @@ doc_type: architecture-decision
 adr_id: ADR-0109
 decision_status: accepted
 implementation_status: staged
-implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/1026, https://github.com/kungfu-systems/kungfu/pull/1079]
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/1026, https://github.com/kungfu-systems/kungfu/pull/1079, https://github.com/kungfu-systems/kungfu/pull/1081]
 qualification_refs: [framework/agent-work/kungfu-agent-work-state.contract.json, scripts/check-agent-work-state-contract.test.mjs, framework/core/tests/python/test_agent_work_state_contract.py, framework/core/src/python/kungfu/agent/kfd3_api.registry.json]
 review_state: self-reviewed
 sensitivity: public

--- a/docs/architecture/fact-episode-action-runtime.md
+++ b/docs/architecture/fact-episode-action-runtime.md
@@ -133,6 +133,22 @@ containment hierarchy.
 The stable kernel should be small enough that every product surface can use the
 same semantics. Product convenience belongs above it.
 
+The first executable outer-ring slice is the KFD-7 Work Profile:
+
+- the generic Fact kernel remains the sole owner of object ids, immutable
+  versions, typed relations, Cuts, ref CAS, and kernel receipts;
+- `kungfu agent work action` validates the five responsibility bindings and
+  the Pursuit, Atlas, Warrant, Episode, or Fact transition before issuing
+  generic kernel writes;
+- one final native ref CAS is the public commit point, while a denied CAS
+  reports any immutable prerequisite records that were already appended; and
+- `kungfu agent work inspect` requests immutable bodies explicitly, so the
+  default generic query stays metadata-only and product-neutral.
+
+The matching action and receipt schemas live under `framework/agent-work/`.
+They are a Kungfu Product Profile, not a second storage stack or a KFD
+normative definition.
+
 ## Semantic identity
 
 Every first-class object requires an identity independent of:

--- a/docs/profiles/agent-work-state.md
+++ b/docs/profiles/agent-work-state.md
@@ -131,6 +131,14 @@ remaining evidence for independent identity, end-to-end action, invalid
 inference rejection, progressive disclosure, human/agent parity, recovery and
 handoff, reality-pressure dogfood, and bounded release claims.
 
+The retained KFD-7 release-gate declaration is
+[`kungfu-kfd-7-release-gate.json`](../../framework/agent-work/kungfu-kfd-7-release-gate.json).
+Buildchain verifies its frozen action contract, positive and negative runtime
+reports, packaged contract surface, and required experiment inventory. The
+current result is deliberately `warning`: export/import, backend migration,
+clean-home continuation, and independent activation review remain explicit
+qualification debt even though the retained evidence is internally closed.
+
 Kungfu does not currently claim that the four names are permanent, that every
 workflow must display all four roles, that the model is universal for every
 organization, or that it is an adopted numbered KFD.

--- a/docs/profiles/agent-work-state.md
+++ b/docs/profiles/agent-work-state.md
@@ -94,9 +94,28 @@ the installed product rather than relying on this summary:
 
 ```sh
 kungfu agent work-model --json
+kungfu agent work capabilities --json
+kungfu agent work inspect --ref profiles/work/main --json
 kungfu contract show agent-work-state --json
 kungfu agent capabilities --json
 ```
+
+The provisional KFD-7 Product Profile adds an independently queryable Fact
+mapping beside Pursuit, Atlas, Warrant, and Episode. Every mutation uses
+`kungfu.kfd7.profile-action/v1` and returns
+`kungfu.kfd7.profile-action-receipt/v1`; the same installed CLI path is used
+by Python, Node, Agent, and GUI adapters. Product transition names remain an
+outer-ring vocabulary and map to KFD-7's closed action geometry in
+[`kungfu-kfd-7-action-contract.json`](../../framework/agent-work/kungfu-kfd-7-action-contract.json).
+The declaration is provisional and non-qualifying until dogfood, migration,
+artifact, and independent-review evidence close.
+
+Projection rebuild is supported from the native Fact journal plus verified
+body bytes. A clean home without a qualified Fact export reports
+`profile-authority-unavailable`; export/import remains explicit loss until a
+Fact bundle that preserves the journal, body namespace, refs, and exact Cuts
+is qualified. Backend switching is delegated to the existing storage service
+and must conserve those identities.
 
 The generic contract query is the KFD-1 route to the welded fact. The
 agent-specific work-model and capabilities commands are KFD-3 collaboration

--- a/framework/agent-work/evidence/kfd-7/backend-migration.json
+++ b/framework/agent-work/evidence/kfd-7/backend-migration.json
@@ -1,0 +1,24 @@
+{
+  "schemaVersion": 1,
+  "contract": "kungfu-buildchain-kfd-7-evidence-report",
+  "profileId": "kungfu-kfd-7-action-profile",
+  "profileVersion": "0.1.0",
+  "stateMachineVersion": "0.1.0",
+  "sourceSha": "466bdc9b089bc06362e0153b7e0d2950bf00f7b0",
+  "category": "backend-migration",
+  "outcome": "fail",
+  "matchedExpectation": true,
+  "checks": [
+    {
+      "id": "storage-backend-switch-delegation-declared",
+      "status": "pass"
+    },
+    {
+      "id": "five-role-identity-conservation-witness",
+      "status": "fail"
+    }
+  ],
+  "observations": {
+    "retainedBoundary": "The shared storage migration mechanism exists, but no five-role Profile witness yet proves object, version, Cut, and ref identity conservation across backends."
+  }
+}

--- a/framework/agent-work/evidence/kfd-7/cold-start-continuation.json
+++ b/framework/agent-work/evidence/kfd-7/cold-start-continuation.json
@@ -1,0 +1,25 @@
+{
+  "schemaVersion": 1,
+  "contract": "kungfu-buildchain-kfd-7-evidence-report",
+  "profileId": "kungfu-kfd-7-action-profile",
+  "profileVersion": "0.1.0",
+  "stateMachineVersion": "0.1.0",
+  "sourceSha": "466bdc9b089bc06362e0153b7e0d2950bf00f7b0",
+  "category": "cold-start-continuation",
+  "outcome": "fail",
+  "matchedExpectation": true,
+  "checks": [
+    {
+      "id": "fresh-home-bootstrap-action",
+      "status": "pass"
+    },
+    {
+      "id": "clean-home-continuation-from-qualified-export",
+      "status": "fail"
+    }
+  ],
+  "observations": {
+    "lossCode": "profile-authority-unavailable",
+    "retainedBoundary": "A fresh home can bootstrap a Profile, but it cannot continue an earlier Profile without a qualified exported Fact authority bundle."
+  }
+}

--- a/framework/agent-work/evidence/kfd-7/export-import-rebuild.json
+++ b/framework/agent-work/evidence/kfd-7/export-import-rebuild.json
@@ -1,0 +1,25 @@
+{
+  "schemaVersion": 1,
+  "contract": "kungfu-buildchain-kfd-7-evidence-report",
+  "profileId": "kungfu-kfd-7-action-profile",
+  "profileVersion": "0.1.0",
+  "stateMachineVersion": "0.1.0",
+  "sourceSha": "466bdc9b089bc06362e0153b7e0d2950bf00f7b0",
+  "category": "export-import-rebuild",
+  "outcome": "fail",
+  "matchedExpectation": true,
+  "checks": [
+    {
+      "id": "projection-rebuild-from-native-journal",
+      "status": "pass"
+    },
+    {
+      "id": "qualified-fact-export-import-bundle",
+      "status": "fail"
+    }
+  ],
+  "observations": {
+    "lossCode": "profile-authority-not-exported",
+    "retainedBoundary": "The Fact journal, body namespace, refs, and exact Cuts are not yet packaged as one qualified export/import bundle."
+  }
+}

--- a/framework/agent-work/evidence/kfd-7/kfd-verifier.json
+++ b/framework/agent-work/evidence/kfd-7/kfd-verifier.json
@@ -1,0 +1,16 @@
+{
+  "schemaVersion": 1,
+  "contract": "kfd.verification-report/v1",
+  "profile": "https://kfd.libkungfu.dev/schemas/kfd-7/action-contract.schema.json",
+  "valid": true,
+  "qualifying": false,
+  "selfCertified": false,
+  "offline": true,
+  "checks": [
+    {
+      "id": "json-schema",
+      "status": "pass"
+    }
+  ],
+  "issues": []
+}

--- a/framework/agent-work/evidence/kfd-7/negative-invalid-transition.json
+++ b/framework/agent-work/evidence/kfd-7/negative-invalid-transition.json
@@ -1,0 +1,30 @@
+{
+  "schemaVersion": 1,
+  "contract": "kungfu-buildchain-kfd-7-evidence-report",
+  "profileId": "kungfu-kfd-7-action-profile",
+  "profileVersion": "0.1.0",
+  "stateMachineVersion": "0.1.0",
+  "sourceSha": "466bdc9b089bc06362e0153b7e0d2950bf00f7b0",
+  "kind": "negative",
+  "outcome": "fail",
+  "matchedExpectation": true,
+  "checks": [
+    {
+      "id": "invalid-transition-denied",
+      "status": "pass"
+    },
+    {
+      "id": "responsibility-gap-denied",
+      "status": "pass"
+    },
+    {
+      "id": "stale-ref-denied",
+      "status": "pass"
+    }
+  ],
+  "observations": {
+    "suite": "framework/core/tests/python/test_agent_work_state_contract.py",
+    "testsPassed": 10,
+    "writeOnDenied": false
+  }
+}

--- a/framework/agent-work/evidence/kfd-7/positive-native-bootstrap.json
+++ b/framework/agent-work/evidence/kfd-7/positive-native-bootstrap.json
@@ -1,0 +1,32 @@
+{
+  "schemaVersion": 1,
+  "contract": "kungfu-buildchain-kfd-7-evidence-report",
+  "profileId": "kungfu-kfd-7-action-profile",
+  "profileVersion": "0.1.0",
+  "stateMachineVersion": "0.1.0",
+  "sourceSha": "466bdc9b089bc06362e0153b7e0d2950bf00f7b0",
+  "kind": "positive",
+  "outcome": "pass",
+  "matchedExpectation": true,
+  "checks": [
+    {
+      "id": "native-binding-python-revision-zero",
+      "status": "pass"
+    },
+    {
+      "id": "disposable-home-cli-action",
+      "status": "pass"
+    },
+    {
+      "id": "ref-cas-commit-point",
+      "status": "pass"
+    }
+  ],
+  "observations": {
+    "receiptStatus": "accepted",
+    "revision": 1,
+    "cutRoot": "sha256:336c142af083cdb6648abf2d85532054e7349baa7babeb8e98ee6c00d46cadca",
+    "kernelReceiptRoot": "sha256:c98ba5ade76cfdcf3cd49fb856fba40f3856649213f82348a30f7b8742b3e895",
+    "roleCount": 5
+  }
+}

--- a/framework/agent-work/fixtures/kfd-7/profile-action.valid.json
+++ b/framework/agent-work/fixtures/kfd-7/profile-action.valid.json
@@ -1,0 +1,96 @@
+{
+  "schema": "kungfu.kfd7.profile-action/v1",
+  "actionId": "kfd-7-real-dogfood-bootstrap",
+  "refName": "profiles/kfd-7/dogfood",
+  "basis": {
+    "cutRoot": null,
+    "revision": 0
+  },
+  "ref": {
+    "cutRoot": null,
+    "revision": 0
+  },
+  "subject": {
+    "role": "fact",
+    "operation": "create",
+    "fromState": "absent",
+    "toState": "declared"
+  },
+  "responsibilities": {
+    "fact": {
+      "objectId": "fact:00000000000000000000000000000001",
+      "expectedVersionRoot": null
+    },
+    "episode": {
+      "objectId": "fact:00000000000000000000000000000002",
+      "expectedVersionRoot": null
+    },
+    "pursuit": {
+      "objectId": "fact:00000000000000000000000000000003",
+      "expectedVersionRoot": null
+    },
+    "atlas": {
+      "objectId": "fact:00000000000000000000000000000004",
+      "expectedVersionRoot": null
+    },
+    "warrant": {
+      "objectId": "fact:00000000000000000000000000000005",
+      "expectedVersionRoot": null
+    }
+  },
+  "roleInputs": {
+    "fact": {
+      "state": "declared",
+      "details": {
+        "cutKind": "retained-runtime-evidence"
+      }
+    },
+    "episode": {
+      "state": "open",
+      "details": {
+        "episodeId": "episode:kfd-7-real-dogfood"
+      }
+    },
+    "pursuit": {
+      "state": "active",
+      "details": {
+        "success": "KFD-7 Profile survives native Fact storage and independent release verification"
+      }
+    },
+    "atlas": {
+      "state": "current",
+      "details": {
+        "validThroughRevision": 10
+      }
+    },
+    "warrant": {
+      "state": "issued",
+      "details": {
+        "validThroughRevision": 10,
+        "allowedOperations": [
+          "*"
+        ]
+      }
+    }
+  },
+  "relations": [
+    {
+      "relationId": "fact:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "relationType": "pursuit-uses-atlas",
+      "sourceRole": "pursuit",
+      "targetRole": "atlas",
+      "attributesRoot": "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+    }
+  ],
+  "support": {
+    "createdByReceiptRoot": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+    "schemaRoot": "sha256:3333333333333333333333333333333333333333333333333333333333333333",
+    "declarationRoots": [
+      "sha256:4444444444444444444444444444444444444444444444444444444444444444"
+    ],
+    "admissionRoots": [
+      "sha256:5555555555555555555555555555555555555555555555555555555555555555"
+    ],
+    "reasonRoot": "sha256:6666666666666666666666666666666666666666666666666666666666666666"
+  }
+}

--- a/framework/agent-work/kungfu-kfd-7-action-contract.json
+++ b/framework/agent-work/kungfu-kfd-7-action-contract.json
@@ -1,0 +1,333 @@
+{
+  "$schema": "https://kfd.libkungfu.dev/schemas/kfd-7/action-contract.schema.json",
+  "schemaVersion": 1,
+  "contract": "kfd-7-action-contract",
+  "standard": "kfd-7",
+  "profile": {
+    "id": "kungfu-kfd-7-action-profile",
+    "version": "0.1.0",
+    "product": "kungfu",
+    "implementation": "source:framework/agent-work/kungfu-kfd-7-action-contract.json",
+    "qualificationStatus": "provisional"
+  },
+  "roles": [
+    {
+      "role": "fact",
+      "identity": "Fact Profile logical object, immutable version root, exact Fact Cut root, and named-ref resolution receipt",
+      "sourceAuthority": "libkungfu Fact kernel over the yijinjing Hana POD journal",
+      "responsibility": "bind the exact admitted state before and after a Profile action without treating a ref as Cut identity",
+      "lifecycleVocabulary": ["absent", "declared", "superseded", "degraded"],
+      "requiredEvidence": ["logical object id and version root", "exact Cut root and ref revision receipt"],
+      "nonClaims": ["does not imply occurrence, authority, complete reality, or completion"]
+    },
+    {
+      "role": "episode",
+      "identity": "Episode Profile logical object plus independently queryable Episode id and sealed content root",
+      "sourceAuthority": "Kungfu Episode manifest journal and sealed Episode evidence",
+      "responsibility": "preserve the bounded causal occurrence mapped by the Profile",
+      "lifecycleVocabulary": ["absent", "open", "sealed", "compensated", "reconciled"],
+      "requiredEvidence": ["Episode identity", "seal or compensation receipt and retained bundle"],
+      "nonClaims": ["does not imply authorization, success, or Pursuit completion"]
+    },
+    {
+      "role": "pursuit",
+      "identity": "Pursuit Profile logical object and immutable version roots",
+      "sourceAuthority": "declared Kungfu Profile intent source such as native Mission and Go facts",
+      "responsibility": "preserve intended-change continuity and explicit success or termination conditions",
+      "lifecycleVocabulary": ["absent", "active", "paused", "completed", "abandoned"],
+      "requiredEvidence": ["intent and acceptance roots", "continuation, completion, or abandonment receipt"],
+      "nonClaims": ["does not grant authority or prove occurrence"]
+    },
+    {
+      "role": "atlas",
+      "identity": "Atlas Profile logical object and immutable version roots bound to a declared perspective and source cut",
+      "sourceAuthority": "Xinfa Atlas, Project Cut, or a declared runtime-query perspective",
+      "responsibility": "bind perspective, sources, scope, freshness, omissions, conflicts, and declared loss",
+      "lifecycleVocabulary": ["absent", "current", "stale", "conflicted", "superseded"],
+      "requiredEvidence": ["accepted sources and perspective root", "freshness revision plus omission, conflict, and loss roots"],
+      "nonClaims": ["does not claim complete reality or grant permission"]
+    },
+    {
+      "role": "warrant",
+      "identity": "Warrant Profile logical object and immutable version roots",
+      "sourceAuthority": "declared issuer, reviewed plan, and exact Profile authorization policy",
+      "responsibility": "bind bounded authority, allowed operations, exact target state, decay, attenuation, and revocation",
+      "lifecycleVocabulary": ["absent", "issued", "attenuated", "expired", "revoked", "denied"],
+      "requiredEvidence": ["issuer and derivation root", "allowed operations, target roots, validity revision, and residual constraints"],
+      "nonClaims": ["does not prove occurrence, success, or transfer of residual responsibility"]
+    }
+  ],
+  "transitions": [
+    {
+      "id": "create-profile",
+      "subjectRole": "fact",
+      "operation": "create",
+      "from": "absent",
+      "to": "declared",
+      "preconditions": ["all five role mappings and exact support roots are supplied"],
+      "effect": "append five independently queryable Profile objects and CAS one named ref",
+      "receipt": "kungfu.kfd7.profile-action-receipt/v1",
+      "evidence": ["five object and version receipts, relation roots, Cut root, and ref-CAS receipt"],
+      "denialReasons": ["responsibility-gap", "invalid-request", "unauthorized"],
+      "residualRisks": ["Episode seal qualification remains independent"]
+    },
+    {
+      "id": "successor-fact",
+      "subjectRole": "fact",
+      "operation": "advance",
+      "from": "declared",
+      "to": "superseded",
+      "preconditions": ["exact basis Cut and expected ref revision remain current"],
+      "effect": "append an immutable successor version and advance the named ref",
+      "receipt": "kungfu.kfd7.profile-action-receipt/v1",
+      "evidence": ["parent version, successor Cut, and ref-CAS receipt"],
+      "denialReasons": ["stale-ref", "replay-mismatch"],
+      "residualRisks": ["successor admission does not prove external truth"]
+    },
+    {
+      "id": "fork-fact",
+      "subjectRole": "fact",
+      "operation": "profile-extension",
+      "from": "declared",
+      "to": "declared",
+      "preconditions": ["source Cut is exact and destination ref expects null revision zero"],
+      "effect": "create a distinct ref without moving the source ref",
+      "receipt": "kungfu.kfd7.profile-action-receipt/v1",
+      "evidence": ["source basis and destination fork receipt"],
+      "denialReasons": ["stale-ref", "invalid-transition"],
+      "residualRisks": ["forks may later conflict and require explicit merge policy"]
+    },
+    {
+      "id": "seal-episode",
+      "subjectRole": "episode",
+      "operation": "seal",
+      "from": "open",
+      "to": "sealed",
+      "preconditions": ["Episode id and seal evidence are independently inspectable"],
+      "effect": "map a sealed bounded occurrence into the successor Profile Cut",
+      "receipt": "kungfu.kfd7.profile-action-receipt/v1 plus Episode seal receipt",
+      "evidence": ["Episode manifest and sealed content root"],
+      "denialReasons": ["body-missing", "invalid-transition"],
+      "residualRisks": ["contracted exports may omit raw evidence with declared loss"]
+    },
+    {
+      "id": "compensate-episode",
+      "subjectRole": "episode",
+      "operation": "reconcile",
+      "from": "sealed",
+      "to": "compensated",
+      "preconditions": ["the original Episode remains immutable and referenced"],
+      "effect": "append a compensation mapping without rewriting occurrence history",
+      "receipt": "kungfu.kfd7.profile-action-receipt/v1",
+      "evidence": ["original and compensating Episode roots"],
+      "denialReasons": ["invalid-transition", "unauthorized"],
+      "residualRisks": ["compensation may not reverse every external consequence"]
+    },
+    {
+      "id": "continue-pursuit",
+      "subjectRole": "pursuit",
+      "operation": "advance",
+      "from": "active",
+      "to": "active",
+      "preconditions": ["current Atlas and unexpired scoped Warrant cover the action"],
+      "effect": "append an explicit continuation decision",
+      "receipt": "kungfu.kfd7.profile-action-receipt/v1",
+      "evidence": ["Pursuit version ancestry and exact basis Cut"],
+      "denialReasons": ["atlas-stale", "warrant-expired", "unauthorized"],
+      "residualRisks": ["continuation does not imply eventual completion"]
+    },
+    {
+      "id": "complete-pursuit",
+      "subjectRole": "pursuit",
+      "operation": "complete",
+      "from": "active",
+      "to": "completed",
+      "preconditions": ["completion evidence is separately reviewed against success conditions"],
+      "effect": "append a completion state without inferring it from command success",
+      "receipt": "kungfu.kfd7.profile-action-receipt/v1",
+      "evidence": ["completion claim, independent review, and consequence evidence"],
+      "denialReasons": ["unauthorized", "responsibility-gap"],
+      "residualRisks": ["release or public claims may require additional gates"]
+    },
+    {
+      "id": "abandon-pursuit",
+      "subjectRole": "pursuit",
+      "operation": "abandon",
+      "from": "active",
+      "to": "abandoned",
+      "preconditions": ["abandonment authority and residual obligations are explicit"],
+      "effect": "terminate intent continuity without deleting prior Episodes or Facts",
+      "receipt": "kungfu.kfd7.profile-action-receipt/v1",
+      "evidence": ["abandonment reason and residual-risk roots"],
+      "denialReasons": ["unauthorized", "stale-ref"],
+      "residualRisks": ["external consequences and cleanup can remain"]
+    },
+    {
+      "id": "refresh-atlas",
+      "subjectRole": "atlas",
+      "operation": "revise",
+      "from": "stale",
+      "to": "current",
+      "preconditions": ["new sources, perspective, freshness revision, omissions, and loss are declared"],
+      "effect": "append a successor Atlas mapping without rewriting the stale version",
+      "receipt": "kungfu.kfd7.profile-action-receipt/v1",
+      "evidence": ["old and new Atlas version roots plus source evidence"],
+      "denialReasons": ["invalid-transition", "responsibility-gap"],
+      "residualRisks": ["declared sources may still be incomplete"]
+    },
+    {
+      "id": "mark-atlas-stale",
+      "subjectRole": "atlas",
+      "operation": "revise",
+      "from": "current",
+      "to": "stale",
+      "preconditions": ["freshness or source invalidation is retained"],
+      "effect": "make unsupported action fail visibly until refresh",
+      "receipt": "kungfu.kfd7.profile-action-receipt/v1",
+      "evidence": ["invalidation or freshness witness"],
+      "denialReasons": ["stale-ref", "unauthorized"],
+      "residualRisks": ["some consumers may retain older projections"]
+    },
+    {
+      "id": "attenuate-warrant",
+      "subjectRole": "warrant",
+      "operation": "attenuate",
+      "from": "issued",
+      "to": "attenuated",
+      "preconditions": ["new scope is a strict subset and issuer derivation remains explicit"],
+      "effect": "append a narrower authority version",
+      "receipt": "kungfu.kfd7.profile-action-receipt/v1",
+      "evidence": ["old and new scopes and validity revisions"],
+      "denialReasons": ["unauthorized", "invalid-transition"],
+      "residualRisks": ["external systems may enforce a different capability boundary"]
+    },
+    {
+      "id": "expire-warrant",
+      "subjectRole": "warrant",
+      "operation": "expire",
+      "from": "issued",
+      "to": "expired",
+      "preconditions": ["declared validity revision has ended or issuer explicitly expires it"],
+      "effect": "deny later actions under this Warrant",
+      "receipt": "kungfu.kfd7.profile-action-receipt/v1",
+      "evidence": ["validity revision and expiry receipt"],
+      "denialReasons": ["stale-ref", "invalid-transition"],
+      "residualRisks": ["expiry does not undo actions already admitted"]
+    },
+    {
+      "id": "revoke-warrant",
+      "subjectRole": "warrant",
+      "operation": "revoke",
+      "from": "issued",
+      "to": "revoked",
+      "preconditions": ["issuer or delegated revoker is explicitly authorized"],
+      "effect": "deny later actions without deleting grant history",
+      "receipt": "kungfu.kfd7.profile-action-receipt/v1",
+      "evidence": ["revocation reason and issuer derivation"],
+      "denialReasons": ["unauthorized", "invalid-transition"],
+      "residualRisks": ["revocation does not prove remote side-effect cancellation"]
+    },
+    {
+      "id": "deny-warrant",
+      "subjectRole": "warrant",
+      "operation": "refuse",
+      "from": "issued",
+      "to": "denied",
+      "preconditions": ["denial reason and exact requested operation are retained"],
+      "effect": "append a queryable denial instead of silently omitting authority",
+      "receipt": "kungfu.kfd7.profile-action-receipt/v1",
+      "evidence": ["requested operation, denial code, and basis Cut"],
+      "denialReasons": ["stale-ref", "replay-mismatch"],
+      "residualRisks": ["a denied operation may be re-requested under a successor Warrant"]
+    }
+  ],
+  "prohibitedInferences": [
+    "authority-from-pursuit",
+    "complete-reality-from-atlas",
+    "occurrence-from-warrant",
+    "authorization-from-episode",
+    "completion-from-episode",
+    "occurrence-from-fact",
+    "child-authority-from-parent",
+    "causal-equivalence-from-equal-endpoints"
+  ],
+  "evidenceObligations": [
+    {
+      "category": "role-deletion-or-fusion",
+      "status": "passed",
+      "artifactRefs": ["framework/core/tests/python/test_agent_work_state_contract.py"],
+      "residualRisk": "long-period role deletion dogfood remains for final qualification"
+    },
+    {
+      "category": "invalid-transition",
+      "status": "passed",
+      "artifactRefs": ["framework/core/tests/python/test_agent_work_state_contract.py", "framework/agent-work/kungfu-kfd-7-profile-receipt.schema.json"],
+      "residualRisk": "native cross-platform fault evidence remains a release gate"
+    },
+    {
+      "category": "export-import-rebuild",
+      "status": "planned",
+      "artifactRefs": [],
+      "residualRisk": "Profile-specific retained rebuild evidence is not yet sealed"
+    },
+    {
+      "category": "backend-migration",
+      "status": "planned",
+      "artifactRefs": [],
+      "residualRisk": "the shared kernel migration exists but the five-role witness is pending"
+    },
+    {
+      "category": "concurrency-retry-compensation",
+      "status": "passed",
+      "artifactRefs": ["framework/core/tests/python/test_agent_work_state_contract.py", "framework/core/tests/storage-node-binding.test.js"],
+      "residualRisk": "multi-process stress and compensation dogfood remain"
+    },
+    {
+      "category": "warrant-decay-revocation",
+      "status": "passed",
+      "artifactRefs": ["framework/core/tests/python/test_agent_work_state_contract.py"],
+      "residualRisk": "issuer diversity and remote enforcement are outside this witness"
+    },
+    {
+      "category": "atlas-staleness-loss",
+      "status": "passed",
+      "artifactRefs": ["framework/core/tests/python/test_agent_work_state_contract.py"],
+      "residualRisk": "lossy export evidence remains pending"
+    },
+    {
+      "category": "pursuit-continuity-settlement",
+      "status": "passed",
+      "artifactRefs": ["framework/core/tests/python/test_agent_work_state_contract.py"],
+      "residualRisk": "independent completion review remains a final qualification gate"
+    },
+    {
+      "category": "episode-replay-contraction",
+      "status": "planned",
+      "artifactRefs": [],
+      "residualRisk": "real Episode replay and contraction evidence is pending"
+    },
+    {
+      "category": "cold-start-continuation",
+      "status": "planned",
+      "artifactRefs": [],
+      "residualRisk": "clean-home installed-artifact continuation is pending"
+    }
+  ],
+  "nonClaims": [
+    "This provisional Kungfu Product Profile does not activate or adopt KFD-7.",
+    "Profile states are product vocabulary rather than universal KFD enums.",
+    "Runtime unit evidence is not a release qualification or authority cutover."
+  ],
+  "extensions": [],
+  "activation": {
+    "decision": "pending",
+    "evidenceCut": "pending-kungfu-runtime-project-cut",
+    "independentReview": "required-after-runtime-dogfood",
+    "productWitnesses": [
+      "framework/agent-work/kungfu-kfd-7-profile-action.schema.json",
+      "framework/agent-work/kungfu-kfd-7-profile-receipt.schema.json",
+      "framework/core/tests/python/test_agent_work_state_contract.py"
+    ],
+    "residualRisk": "Export/import, backend migration, Episode replay, clean-home, installed-artifact parity, and independent review are not yet complete."
+  }
+}

--- a/framework/agent-work/kungfu-kfd-7-profile-action.schema.json
+++ b/framework/agent-work/kungfu-kfd-7-profile-action.schema.json
@@ -1,0 +1,172 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kungfu.link/schema/kungfu-kfd-7-profile-action.schema.json",
+  "title": "Kungfu KFD-7 Product Profile action",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "actionId",
+    "refName",
+    "basis",
+    "ref",
+    "subject",
+    "responsibilities",
+    "support"
+  ],
+  "properties": {
+    "schema": { "const": "kungfu.kfd7.profile-action/v1" },
+    "actionId": { "type": "string", "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$" },
+    "refName": { "type": "string", "pattern": "^[a-z][a-z0-9._/-]{0,127}$" },
+    "basis": { "$ref": "#/$defs/cutCoordinate" },
+    "ref": { "$ref": "#/$defs/cutCoordinate" },
+    "subject": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["role", "operation", "fromState", "toState"],
+      "properties": {
+        "role": { "$ref": "#/$defs/role" },
+        "operation": {
+          "enum": [
+            "create",
+            "successor",
+            "fork",
+            "degrade",
+            "seal",
+            "compensate",
+            "reconcile",
+            "continue",
+            "pause",
+            "complete",
+            "abandon",
+            "refresh",
+            "mark-stale",
+            "mark-conflicted",
+            "supersede",
+            "attenuate",
+            "expire",
+            "revoke",
+            "deny"
+          ]
+        },
+        "fromState": { "type": "string", "minLength": 1 },
+        "toState": { "type": "string", "minLength": 1 }
+      }
+    },
+    "responsibilities": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["fact", "episode", "pursuit", "atlas", "warrant"],
+      "properties": {
+        "fact": { "$ref": "#/$defs/responsibility" },
+        "episode": { "$ref": "#/$defs/responsibility" },
+        "pursuit": { "$ref": "#/$defs/responsibility" },
+        "atlas": { "$ref": "#/$defs/responsibility" },
+        "warrant": { "$ref": "#/$defs/responsibility" }
+      }
+    },
+    "roleInputs": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "fact": { "$ref": "#/$defs/roleInput" },
+        "episode": { "$ref": "#/$defs/roleInput" },
+        "pursuit": { "$ref": "#/$defs/roleInput" },
+        "atlas": { "$ref": "#/$defs/roleInput" },
+        "warrant": { "$ref": "#/$defs/roleInput" }
+      }
+    },
+    "relations": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "relationId",
+          "relationType",
+          "sourceRole",
+          "targetRole",
+          "attributesRoot"
+        ],
+        "properties": {
+          "relationId": { "$ref": "#/$defs/factId" },
+          "relationType": { "type": "string", "minLength": 1 },
+          "sourceRole": { "$ref": "#/$defs/role" },
+          "targetRole": { "$ref": "#/$defs/role" },
+          "attributesRoot": { "$ref": "#/$defs/root" }
+        }
+      }
+    },
+    "payload": { "type": "object" },
+    "episodeFrontier": { "type": "array", "items": { "type": "object" } },
+    "omissionRoots": { "$ref": "#/$defs/rootArray" },
+    "conflictRoots": { "$ref": "#/$defs/rootArray" },
+    "support": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "createdByReceiptRoot",
+        "schemaRoot",
+        "declarationRoots",
+        "admissionRoots",
+        "reasonRoot"
+      ],
+      "properties": {
+        "createdByReceiptRoot": { "$ref": "#/$defs/root" },
+        "schemaRoot": { "$ref": "#/$defs/root" },
+        "declarationRoots": { "$ref": "#/$defs/nonEmptyRootArray" },
+        "admissionRoots": { "$ref": "#/$defs/nonEmptyRootArray" },
+        "reasonRoot": { "$ref": "#/$defs/root" }
+      }
+    }
+  },
+  "$defs": {
+    "root": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+    "factId": { "type": "string", "pattern": "^fact:[0-9a-f]{32}$" },
+    "role": { "enum": ["fact", "episode", "pursuit", "atlas", "warrant"] },
+    "rootArray": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": { "$ref": "#/$defs/root" }
+    },
+    "nonEmptyRootArray": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": { "$ref": "#/$defs/root" }
+    },
+    "cutCoordinate": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["cutRoot", "revision"],
+      "properties": {
+        "cutRoot": { "oneOf": [{ "$ref": "#/$defs/root" }, { "type": "null" }] },
+        "revision": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "responsibility": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["objectId", "expectedVersionRoot"],
+      "properties": {
+        "objectId": { "$ref": "#/$defs/factId" },
+        "expectedVersionRoot": {
+          "oneOf": [{ "$ref": "#/$defs/root" }, { "type": "null" }]
+        }
+      }
+    },
+    "roleInput": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["state", "details"],
+      "properties": {
+        "state": { "type": "string", "minLength": 1 },
+        "details": { "type": "object" },
+        "nonClaims": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        }
+      }
+    }
+  }
+}

--- a/framework/agent-work/kungfu-kfd-7-profile-receipt.schema.json
+++ b/framework/agent-work/kungfu-kfd-7-profile-receipt.schema.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kungfu.link/schema/kungfu-kfd-7-profile-receipt.schema.json",
+  "title": "Kungfu KFD-7 Product Profile action receipt",
+  "type": "object",
+  "additionalProperties": true,
+  "required": [
+    "schema",
+    "actionId",
+    "status",
+    "failureCode",
+    "writeOccurred",
+    "refWriteOccurred"
+  ],
+  "properties": {
+    "schema": { "const": "kungfu.kfd7.profile-action-receipt/v1" },
+    "actionId": { "type": "string", "minLength": 1 },
+    "status": { "enum": ["planned", "accepted", "idempotent-replay", "denied"] },
+    "failureCode": {
+      "oneOf": [
+        { "type": "null" },
+        {
+          "enum": [
+            "responsibility-gap",
+            "invalid-request",
+            "invalid-transition",
+            "profile-state-mismatch",
+            "body-missing",
+            "stale-ref",
+            "replay-mismatch",
+            "unauthorized",
+            "warrant-expired",
+            "warrant-revoked",
+            "atlas-stale",
+            "kernel-rejected"
+          ]
+        }
+      ]
+    },
+    "writeOccurred": { "type": "boolean" },
+    "refWriteOccurred": { "type": "boolean" },
+    "basis": { "type": "object" },
+    "ref": { "type": "object" },
+    "subject": { "type": "object" },
+    "result": { "type": "object" },
+    "details": { "type": "object" },
+    "steps": { "type": "array", "items": { "type": "object" } },
+    "residualRisk": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 }
+    }
+  },
+  "allOf": [
+    {
+      "if": { "properties": { "status": { "const": "denied" } } },
+      "then": {
+        "properties": {
+          "failureCode": { "not": { "type": "null" } },
+          "refWriteOccurred": { "const": false }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": { "status": { "enum": ["accepted", "idempotent-replay"] } }
+      },
+      "then": {
+        "required": ["result", "steps"],
+        "properties": { "failureCode": { "type": "null" } }
+      }
+    }
+  ]
+}

--- a/framework/agent-work/kungfu-kfd-7-release-gate.json
+++ b/framework/agent-work/kungfu-kfd-7-release-gate.json
@@ -1,0 +1,89 @@
+{
+  "schemaVersion": 1,
+  "contract": "kungfu-buildchain-kfd-7-release-gate-input",
+  "standard": "kfd-7",
+  "profile": {
+    "id": "kungfu-kfd-7-action-profile",
+    "version": "0.1.0",
+    "stateMachineVersion": "0.1.0",
+    "actionContract": {
+      "path": "framework/agent-work/kungfu-kfd-7-action-contract.json",
+      "sha256": "68eb48c73dd5f4e999ea80feeff8f4423b6dfb87fb392253db902812f8f81048"
+    },
+    "verifierReport": {
+      "path": "framework/agent-work/evidence/kfd-7/kfd-verifier.json",
+      "sha256": "dc1742cd0192870c4dd20a0f519ba2b1717149ab66cbd55d1deaacc1e7f3e4d2"
+    }
+  },
+  "source": {
+    "sha": "466bdc9b089bc06362e0153b7e0d2950bf00f7b0"
+  },
+  "surfaces": [
+    {
+      "id": "agent-work-state-contract",
+      "sourcePath": "framework/agent-work/kungfu-agent-work-state.contract.json",
+      "artifactPath": "config/kungfu-agent-work-state.contract.json",
+      "sha256": "e1b813a4057a437e8998e5bca3f1f21fcf002d3509a035d13345ceefedbb706d"
+    }
+  ],
+  "testEvidence": [
+    {
+      "id": "native-bootstrap",
+      "kind": "positive",
+      "expectedOutcome": "pass",
+      "path": "framework/agent-work/evidence/kfd-7/positive-native-bootstrap.json",
+      "sha256": "82119283a5841558b43ef7396425132c7e04d0b3899e005e7930cea4a23133fd"
+    },
+    {
+      "id": "invalid-transition",
+      "kind": "negative",
+      "expectedOutcome": "fail",
+      "path": "framework/agent-work/evidence/kfd-7/negative-invalid-transition.json",
+      "sha256": "3ea894af6c08faf8357ce8f67eedc2951efd05243a1f3258be9088e718e959ff"
+    }
+  ],
+  "experiments": [
+    {
+      "id": "export-import-rebuild",
+      "category": "export-import-rebuild",
+      "expectedOutcome": "fail",
+      "path": "framework/agent-work/evidence/kfd-7/export-import-rebuild.json",
+      "sha256": "b04431f51074219289b1c3daac316feb0dc21d6a57df23f6286c45ddf732c222"
+    },
+    {
+      "id": "backend-migration",
+      "category": "backend-migration",
+      "expectedOutcome": "fail",
+      "path": "framework/agent-work/evidence/kfd-7/backend-migration.json",
+      "sha256": "8bcf3cabd3fa3d4f9fd2fe25a2bd08c9b07dcdf486296bebd695bcd12e288e80"
+    },
+    {
+      "id": "cold-start-continuation",
+      "category": "cold-start-continuation",
+      "expectedOutcome": "fail",
+      "path": "framework/agent-work/evidence/kfd-7/cold-start-continuation.json",
+      "sha256": "1423aa513bd576807f4a2dc9510ed30e49e4085298c42fb03d20fb2eb7a691af"
+    }
+  ],
+  "residualRisk": [
+    {
+      "id": "kfd-7-runtime-qualification-pending",
+      "definedBy": "https://kfd.libkungfu.dev/schemas/kfd-2/trust-taxonomy.schema.json#/$defs/residualRisk",
+      "riskType": "natural-language-semantic-risk",
+      "trustImpact": "downgrade-warning",
+      "machineProvability": "not-machine-verifiable",
+      "agentAction": "semantic-review-required",
+      "reason": "The Profile has retained runtime evidence, but export/import, backend migration, clean-home continuation, and independent activation review remain incomplete.",
+      "owner": "kungfu-systems/kungfu"
+    }
+  ],
+  "responsibility": {
+    "profileOwner": "kungfu-systems/kungfu",
+    "evidenceOwner": "Kungfu runtime and product test suites",
+    "proofOwner": "@kungfu-tech/buildchain release passport"
+  },
+  "nonClaims": [
+    "A passing evidence-closure check does not prove real-world work quality.",
+    "This provisional declaration does not activate KFD-7 or qualify the Kungfu Product Profile."
+  ]
+}

--- a/framework/api/src/capability/profile.ts
+++ b/framework/api/src/capability/profile.ts
@@ -329,8 +329,42 @@ export type ProfileContractPlan = {
   decisionCard: Record<string, unknown>;
 };
 
+export type WorkProfileCapabilities = {
+  schema: 'kungfu.kfd7.profile-capabilities/v1';
+  profile: 'kungfu-kfd-7-action-profile';
+  roles: string[];
+  actionSchema: string;
+  receiptSchema: string;
+  [key: string]: unknown;
+};
+
+export type WorkProfileInspection = {
+  schema: 'kungfu.kfd7.profile-inspection/v1';
+  status: 'absent' | 'current' | 'degraded';
+  refName: string;
+  cutRoot: string | null;
+  [key: string]: unknown;
+};
+
+export type WorkProfileReceipt = {
+  schema: 'kungfu.kfd7.profile-action-receipt/v1';
+  actionId: string;
+  status: 'planned' | 'accepted' | 'idempotent-replay' | 'denied';
+  failureCode: string | null;
+  [key: string]: unknown;
+};
+
 export type Profile = {
   runtimeDir: string;
+  workCapabilities: () => WorkProfileCapabilities;
+  workCapabilitiesAsync: () => Promise<WorkProfileCapabilities>;
+  workInspect: (refName: string) => WorkProfileInspection;
+  workInspectAsync: (refName: string) => Promise<WorkProfileInspection>;
+  workAction: (request: unknown, execute?: boolean) => WorkProfileReceipt;
+  workActionAsync: (
+    request: unknown,
+    execute?: boolean,
+  ) => Promise<WorkProfileReceipt>;
   discover: (profileId: string) => ProfileSourceDiscovery;
   discoverAsync: (profileId: string) => Promise<ProfileSourceDiscovery>;
   manager: () => ProfileManagerProjection;
@@ -485,6 +519,27 @@ export function openProfile(options: OpenProfileOptions): Profile {
     });
     return JSON.parse(text) as T;
   };
+  const runWork = <T>(args: string[]): T =>
+    JSON.parse(
+      options.execFileSync(bin, ['agent', 'work', ...args, '--json'], {
+        encoding: 'utf8',
+        env,
+        maxBuffer: 64 * 1024 * 1024,
+      }),
+    ) as T;
+  const runWorkAsync = async <T>(args: string[]): Promise<T> => {
+    if (!options.execFile) return runWork<T>(args);
+    const text = await options.execFile(
+      bin,
+      ['agent', 'work', ...args, '--json'],
+      {
+        encoding: 'utf8',
+        env,
+        maxBuffer: 64 * 1024 * 1024,
+      },
+    );
+    return JSON.parse(text) as T;
+  };
   const catalogArgs = (source: string, requireActive: boolean) => [
     'catalog',
     source,
@@ -522,6 +577,27 @@ export function openProfile(options: OpenProfileOptions): Profile {
   ];
   return {
     runtimeDir: options.runtimeDir,
+    workCapabilities: () => runWork<WorkProfileCapabilities>(['capabilities']),
+    workCapabilitiesAsync: () =>
+      runWorkAsync<WorkProfileCapabilities>(['capabilities']),
+    workInspect: (refName) =>
+      runWork<WorkProfileInspection>(['inspect', '--ref', refName]),
+    workInspectAsync: (refName) =>
+      runWorkAsync<WorkProfileInspection>(['inspect', '--ref', refName]),
+    workAction: (request, execute = false) =>
+      runWork<WorkProfileReceipt>([
+        'action',
+        '--input-base64',
+        encoded(request),
+        ...(execute ? ['--execute'] : []),
+      ]),
+    workActionAsync: (request, execute = false) =>
+      runWorkAsync<WorkProfileReceipt>([
+        'action',
+        '--input-base64',
+        encoded(request),
+        ...(execute ? ['--execute'] : []),
+      ]),
     discover: (profileId) =>
       run<ProfileSourceDiscovery>(['discover', profileId]),
     discoverAsync: (profileId) =>

--- a/framework/api/src/capability/storage.ts
+++ b/framework/api/src/capability/storage.ts
@@ -79,6 +79,10 @@ export type Storage = {
     request: StorageValue,
   ) => StorageValue;
   factLibraryContract: () => StorageValue;
+  factKernel: (
+    action: string,
+    request?: Record<string, unknown>,
+  ) => StorageValue;
   factTypes: () => StorageValue;
   createFactType: (
     definition: FactTypeDefinition,
@@ -176,6 +180,8 @@ export function openStorage(options: OpenStorageOptions): Storage {
       run('kfx_runtime', { action: 'validate', kind, document }),
     kfxRegistry: (action, request) => run('kfx_runtime', { action, request }),
     factLibraryContract: () => run('fact_library_contract'),
+    factKernel: (action, request = {}) =>
+      run('fact_kernel', { action, ...request }),
     factTypes: () => run('fact_type_list'),
     createFactType: (definition, systemTime = 0) =>
       run('fact_type_create', { definition, system_time: systemTime }),

--- a/framework/api/tests/profile.test.ts
+++ b/framework/api/tests/profile.test.ts
@@ -32,6 +32,49 @@ test('Profile capability uses the installed Agent Profile CLI path', async () =>
   ]);
 });
 
+test('Work Profile parity uses the same installed action contract', async () => {
+  const calls: string[][] = [];
+  const profile = openProfile({
+    runtimeDir: '/runtime',
+    execFileSync: (_file, args) => {
+      calls.push(args);
+      return JSON.stringify({
+        schema: 'kungfu.kfd7.profile-action-receipt/v1',
+        actionId: 'continue-1',
+        status: 'planned',
+        failureCode: null,
+      });
+    },
+  });
+  const request = {
+    schema: 'kungfu.kfd7.profile-action/v1',
+    actionId: 'continue-1',
+  };
+  const encoded = Buffer.from(JSON.stringify(request), 'utf8').toString(
+    'base64',
+  );
+
+  profile.workCapabilities();
+  profile.workInspect('profiles/work/main');
+  profile.workAction(request);
+  profile.workAction(request, true);
+
+  assert.deepEqual(calls, [
+    ['agent', 'work', 'capabilities', '--json'],
+    ['agent', 'work', 'inspect', '--ref', 'profiles/work/main', '--json'],
+    ['agent', 'work', 'action', '--input-base64', encoded, '--json'],
+    [
+      'agent',
+      'work',
+      'action',
+      '--input-base64',
+      encoded,
+      '--execute',
+      '--json',
+    ],
+  ]);
+});
+
 test('Profile plans preserve source and exact active-root intent', () => {
   const calls: string[][] = [];
   const profile = openProfile({

--- a/framework/api/tests/storage.test.ts
+++ b/framework/api/tests/storage.test.ts
@@ -91,6 +91,40 @@ test('Episode Admission API is a thin projection over the native destination ope
   ]);
 });
 
+test('Fact kernel API preserves the generic action request without product vocabulary', () => {
+  const calls: unknown[][] = [];
+  const binding = {
+    runStorageServiceOperation: (
+      operation: string,
+      runtimeDir: string,
+      options: Record<string, unknown> = {},
+    ) => {
+      calls.push([operation, runtimeDir, options]);
+      return { ok: true, schema: 'kungfu.fact-kernel.state/v1' };
+    },
+  } as unknown as KfNativeBinding;
+  const storage = openStorage({ binding, locator: { runtimeDir: '/runtime' } });
+
+  assert.deepEqual(
+    storage.factKernel('query', {
+      ref_name: 'profiles/work',
+      include_bodies: true,
+    }),
+    { ok: true, schema: 'kungfu.fact-kernel.state/v1' },
+  );
+  assert.deepEqual(calls, [
+    [
+      'fact_kernel',
+      '/runtime',
+      {
+        action: 'query',
+        ref_name: 'profiles/work',
+        include_bodies: true,
+      },
+    ],
+  ]);
+});
+
 test('GUI and Agent storage edge preserve the published Buildchain KFX projection and Core report root', () => {
   const fixture = JSON.parse(
     fs.readFileSync(

--- a/framework/contract/kungfu-agent-first-canonical-policy.json
+++ b/framework/contract/kungfu-agent-first-canonical-policy.json
@@ -301,13 +301,13 @@
       },
       "source": {
         "path": "framework/fact/kungfu-fact-cut-kernel.contract.json",
-        "sha256": "sha256:ccd0526781a200efca157bac10ccd41d3bbb614102e65ef335a78fd63176e1e5",
-        "renderedSha256": "sha256:ccd0526781a200efca157bac10ccd41d3bbb614102e65ef335a78fd63176e1e5",
+        "sha256": "sha256:dfe1164c6c4b02e2cb5577839f72f44cb572dd8849072de0697fd639f105f50d",
+        "renderedSha256": "sha256:dfe1164c6c4b02e2cb5577839f72f44cb572dd8849072de0697fd639f105f50d",
         "byteForByte": true
       },
       "artifact": {
         "path": "config/kungfu-fact-cut-kernel.contract.json",
-        "expectedSha256": "sha256:ccd0526781a200efca157bac10ccd41d3bbb614102e65ef335a78fd63176e1e5"
+        "expectedSha256": "sha256:dfe1164c6c4b02e2cb5577839f72f44cb572dd8849072de0697fd639f105f50d"
       }
     }
   ]

--- a/framework/core/src/libkungfu/src/runtime/storage/fact_kernel.cpp
+++ b/framework/core/src/libkungfu/src/runtime/storage/fact_kernel.cpp
@@ -632,6 +632,7 @@ nlohmann::json capabilities_document() {
 
 nlohmann::json query_kernel(const std::string &runtime_dir, const kernel_state &state, const nlohmann::json &request) {
   const auto ref_name = text_or(request, "ref_name");
+  const auto include_bodies = request.value("include_bodies", false);
   auto cut_root = text_or(request, "cut_root");
   nlohmann::json resolution = nullptr;
   if (!ref_name.empty()) {
@@ -665,8 +666,25 @@ nlohmann::json query_kernel(const std::string &runtime_dir, const kernel_state &
   for (const auto &member : cut.at("objectVersions")) {
     const auto version_root = member.at(1).get<std::string>();
     const auto version = state.versions.find(version_root);
-    objects.push_back(
-        {{"member", member}, {"version", version == state.versions.end() ? nlohmann::json(nullptr) : version->second}});
+    auto projected = nlohmann::json{
+        {"member", member}, {"version", version == state.versions.end() ? nlohmann::json(nullptr) : version->second}};
+    if (include_bodies) {
+      if (version == state.versions.end()) {
+        projected["body"] = nullptr;
+        projected["body_status"] = "version-missing";
+      } else {
+        try {
+          projected["body"] =
+              content_store_get(runtime_dir, BODY_NAMESPACE, version->second.at("bodyRoot").get<std::string>());
+          projected["body_status"] = "present";
+        } catch (const std::exception &error) {
+          projected["body"] = nullptr;
+          projected["body_status"] = "unavailable";
+          projected["body_error"] = error.what();
+        }
+      }
+    }
+    objects.push_back(std::move(projected));
   }
   auto relations = nlohmann::json::array();
   for (const auto &root : cut.at("activeRelationRoots")) {

--- a/framework/core/src/libkungfu/src/runtime/storage/fact_kernel.cpp
+++ b/framework/core/src/libkungfu/src/runtime/storage/fact_kernel.cpp
@@ -95,9 +95,22 @@ std::string text_or(const nlohmann::json &value, const char *field, const std::s
 }
 
 uint64_t uint64_or(const nlohmann::json &value, const char *field, uint64_t fallback = 0) {
-  return value.is_object() && value.contains(field) && value.at(field).is_number_unsigned()
-             ? value.at(field).get<uint64_t>()
-             : fallback;
+  if (!value.is_object() || !value.contains(field)) {
+    return fallback;
+  }
+  const auto &candidate = value.at(field);
+  if (candidate.is_number_unsigned()) {
+    return candidate.get<uint64_t>();
+  }
+  if (candidate.is_number_integer()) {
+    const auto signed_value = candidate.get<int64_t>();
+    return signed_value >= 0 ? static_cast<uint64_t>(signed_value) : fallback;
+  }
+  return fallback;
+}
+
+bool is_nonnegative_integer(const nlohmann::json &value) {
+  return value.is_number_unsigned() || (value.is_number_integer() && value.get<int64_t>() >= 0);
 }
 
 nlohmann::json array_or_empty(const nlohmann::json &value, const char *field) {
@@ -1035,7 +1048,7 @@ nlohmann::json run_fact_kernel_operation(const std::string &runtime_dir, const n
           input.contains("expected_old_cut_root") &&
           (input.at("expected_old_cut_root").is_null() || input.at("expected_old_cut_root").is_string());
       const auto has_expected_revision =
-          input.contains("expected_old_revision") && input.at("expected_old_revision").is_number_unsigned();
+          input.contains("expected_old_revision") && is_nonnegative_integer(input.at("expected_old_revision"));
       const auto expected_old = text_or(input, "expected_old_cut_root");
       validate_root(expected_old, "expected_old_cut_root", true);
       const auto expected_revision = uint64_or(input, "expected_old_revision");

--- a/framework/core/src/python/kungfu/agent/commands.json
+++ b/framework/core/src/python/kungfu/agent/commands.json
@@ -32,6 +32,24 @@
       "purpose": "Read the public Pursuit, Atlas, Warrant, and Episode contract, current implementation mappings, invalid inferences, and P17 qualification debt."
     },
     {
+      "apiId": "kungfu.agent.work.capabilities",
+      "name": "kungfu agent work capabilities --json",
+      "maturity": "experimental",
+      "purpose": "Discover five responsibility roles, Product Profile transitions, typed denials, and authority boundaries."
+    },
+    {
+      "apiId": "kungfu.agent.work.inspect",
+      "name": "kungfu agent work inspect --ref <ref> --json",
+      "maturity": "experimental",
+      "purpose": "Resolve one exact Fact ref and report all five Profile role identities, states, relations, and typed gaps."
+    },
+    {
+      "apiId": "kungfu.agent.work.action",
+      "name": "kungfu agent work action --file <request.json> [--execute] --json",
+      "maturity": "experimental",
+      "purpose": "Plan or execute one Profile transition through the shared action/receipt contract and native Fact ref CAS."
+    },
+    {
       "apiId": "kungfu.agent.choose-mode",
       "name": "kungfu agent choose-mode --json",
       "maturity": "stable",

--- a/framework/core/src/python/kungfu/agent/kfd3_api.registry.json
+++ b/framework/core/src/python/kungfu/agent/kfd3_api.registry.json
@@ -63,6 +63,46 @@
       "projections": ["commands.json", "capabilities-json", "agent-pack-doc", "provider-skill"]
     },
     {
+      "id": "kungfu.agent.work",
+      "surface": "cli-api-gui",
+      "name": "kungfu agent work",
+      "purpose": "Use the KFD-7 Kungfu Product Profile without replacing Fact or Episode authority.",
+      "maturity": "experimental",
+      "visibility": "public-agent",
+      "anchor": { "kind": "runtime-click", "symbol": "work" },
+      "projections": ["capabilities-json", "provider-skill"]
+    },
+    {
+      "id": "kungfu.agent.work.capabilities",
+      "surface": "cli-api-gui",
+      "name": "kungfu agent work capabilities --json",
+      "purpose": "Discover five responsibility roles, Product Profile transitions, typed denials, and authority boundaries.",
+      "maturity": "experimental",
+      "visibility": "public-agent",
+      "anchor": { "kind": "runtime-click", "symbol": "work_capabilities" },
+      "projections": ["commands.json", "capabilities-json", "provider-skill"]
+    },
+    {
+      "id": "kungfu.agent.work.inspect",
+      "surface": "cli-api-gui",
+      "name": "kungfu agent work inspect --ref <ref> --json",
+      "purpose": "Resolve one exact Fact ref and report all five Profile role identities, states, relations, and typed gaps.",
+      "maturity": "experimental",
+      "visibility": "public-agent",
+      "anchor": { "kind": "runtime-click", "symbol": "work_inspect" },
+      "projections": ["commands.json", "capabilities-json", "provider-skill"]
+    },
+    {
+      "id": "kungfu.agent.work.action",
+      "surface": "cli-api-gui",
+      "name": "kungfu agent work action --file <request.json> [--execute] --json",
+      "purpose": "Plan or execute one Profile transition through the shared action/receipt contract and native Fact ref CAS.",
+      "maturity": "experimental",
+      "visibility": "public-agent",
+      "anchor": { "kind": "runtime-click", "symbol": "work_action" },
+      "projections": ["commands.json", "capabilities-json", "provider-skill"]
+    },
+    {
       "id": "kungfu.agent.choose-mode",
       "surface": "cli",
       "name": "kungfu agent choose-mode --json",

--- a/framework/core/src/python/kungfu/agent/work_profile.py
+++ b/framework/core/src/python/kungfu/agent/work_profile.py
@@ -1,0 +1,742 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""KFD-7 Product Profile over the generic Fact kernel.
+
+This module is an outer-ring Profile. It owns product vocabulary and state
+transitions while every persisted object, version, relation, Cut, ref move, and
+kernel receipt remains owned by the native Fact kernel.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from kungfu.storage import service as storage_service
+
+
+ACTION_SCHEMA = "kungfu.kfd7.profile-action/v1"
+RECEIPT_SCHEMA = "kungfu.kfd7.profile-action-receipt/v1"
+ROLE_BODY_SCHEMA = "kungfu.kfd7.profile-role/v1"
+CAPABILITIES_SCHEMA = "kungfu.kfd7.profile-capabilities/v1"
+INSPECTION_SCHEMA = "kungfu.kfd7.profile-inspection/v1"
+
+ROLES = ("fact", "episode", "pursuit", "atlas", "warrant")
+INITIAL_STATES = {
+    "fact": "declared",
+    "episode": "open",
+    "pursuit": "active",
+    "atlas": "current",
+    "warrant": "issued",
+}
+TRANSITIONS = {
+    "fact": {
+        ("create", "absent", "declared"),
+        ("successor", "declared", "superseded"),
+        ("fork", "declared", "declared"),
+        ("degrade", "declared", "degraded"),
+    },
+    "episode": {
+        ("create", "absent", "open"),
+        ("seal", "open", "sealed"),
+        ("compensate", "sealed", "compensated"),
+        ("reconcile", "sealed", "reconciled"),
+        ("reconcile", "compensated", "reconciled"),
+    },
+    "pursuit": {
+        ("create", "absent", "active"),
+        ("continue", "active", "active"),
+        ("continue", "paused", "active"),
+        ("pause", "active", "paused"),
+        ("complete", "active", "completed"),
+        ("complete", "paused", "completed"),
+        ("abandon", "active", "abandoned"),
+        ("abandon", "paused", "abandoned"),
+    },
+    "atlas": {
+        ("create", "absent", "current"),
+        ("refresh", "current", "current"),
+        ("refresh", "stale", "current"),
+        ("refresh", "conflicted", "current"),
+        ("mark-stale", "current", "stale"),
+        ("mark-conflicted", "current", "conflicted"),
+        ("supersede", "current", "superseded"),
+        ("supersede", "stale", "superseded"),
+    },
+    "warrant": {
+        ("create", "absent", "issued"),
+        ("attenuate", "issued", "attenuated"),
+        ("attenuate", "attenuated", "attenuated"),
+        ("expire", "issued", "expired"),
+        ("expire", "attenuated", "expired"),
+        ("revoke", "issued", "revoked"),
+        ("revoke", "attenuated", "revoked"),
+        ("deny", "issued", "denied"),
+        ("deny", "attenuated", "denied"),
+    },
+}
+
+DENIALS = (
+    "responsibility-gap",
+    "invalid-request",
+    "invalid-transition",
+    "profile-state-mismatch",
+    "body-missing",
+    "stale-ref",
+    "replay-mismatch",
+    "unauthorized",
+    "warrant-expired",
+    "warrant-revoked",
+    "atlas-stale",
+    "kernel-rejected",
+)
+
+_ROOT = re.compile(r"^sha256:[0-9a-f]{64}$")
+_FACT_ID = re.compile(r"^fact:[0-9a-f]{32}$")
+_REF = re.compile(r"^[a-z][a-z0-9._/-]{0,127}$")
+_ACTION_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
+
+Kernel = Callable[[str | Path, str, dict[str, Any] | None], dict[str, Any]]
+
+
+def capabilities() -> dict[str, Any]:
+    return {
+        "schema": CAPABILITIES_SCHEMA,
+        "profile": "kungfu-kfd-7-action-profile",
+        "roles": list(ROLES),
+        "actionSchema": ACTION_SCHEMA,
+        "receiptSchema": RECEIPT_SCHEMA,
+        "roleBodySchema": ROLE_BODY_SCHEMA,
+        "transitions": {
+            role: [
+                {"operation": operation, "from": source, "to": target}
+                for operation, source, target in sorted(TRANSITIONS[role])
+            ]
+            for role in ROLES
+        },
+        "denials": list(DENIALS),
+        "authority": {
+            "profile": "role vocabulary, transition checks, progressive disclosure",
+            "kernel": "identity, immutable versions, relations, Cuts, CAS, receipts",
+            "episode": "causal occurrence and sealed evidence",
+        },
+        "nonClaims": [
+            "A Profile receipt does not adopt KFD-7 or replace KFD authority.",
+            "An accepted action does not prove Pursuit completion or complete reality.",
+        ],
+    }
+
+
+def _kernel(
+    runtime_dir: str | Path,
+    action: str,
+    request: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return storage_service.fact_kernel(runtime_dir, action, request)
+
+
+def _denied(
+    action_id: str,
+    code: str,
+    message: str,
+    *,
+    details: dict[str, Any] | None = None,
+    steps: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    steps = list(steps or [])
+    return {
+        "schema": RECEIPT_SCHEMA,
+        "actionId": action_id,
+        "status": "denied",
+        "failureCode": code,
+        "message": message,
+        "details": details or {},
+        "writeOccurred": any(step.get("writeOccurred") is True for step in steps),
+        "refWriteOccurred": False,
+        "steps": steps,
+        "residualRisk": [
+            "Immutable prerequisite records may exist even when the named ref CAS is denied."
+        ]
+        if any(step.get("writeOccurred") is True for step in steps)
+        else [],
+    }
+
+
+def _require_root(value: Any, field: str, *, nullable: bool = False) -> None:
+    if nullable and value is None:
+        return
+    if not isinstance(value, str) or _ROOT.fullmatch(value) is None:
+        raise ValueError(f"{field} must be a sha256 content root")
+
+
+def _require_root_list(value: Any, field: str) -> list[str]:
+    if not isinstance(value, list) or not value:
+        raise ValueError(f"{field} must be a non-empty root array")
+    for index, root in enumerate(value):
+        _require_root(root, f"{field}[{index}]")
+    if len(value) != len(set(value)):
+        raise ValueError(f"{field} must not contain duplicates")
+    return sorted(value)
+
+
+def _step(action: str, response: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "action": action,
+        "status": response.get("status"),
+        "ok": response.get("ok") is True,
+        "failureCode": response.get("failure_code"),
+        "writeOccurred": response.get("write_occurred") is True,
+        "receiptRoot": response.get("receipt_root"),
+    }
+
+
+def _load_cut(
+    runtime_dir: str | Path,
+    cut_root: str | None,
+    kernel: Kernel,
+) -> tuple[dict[str, Any] | None, dict[str, dict[str, Any]], list[str]]:
+    if cut_root is None:
+        return None, {}, []
+    response = kernel(
+        runtime_dir,
+        "query",
+        {"cut_root": cut_root, "include_bodies": True},
+    )
+    if response.get("ok") is not True:
+        raise RuntimeError(json.dumps(response, sort_keys=True))
+    roles: dict[str, dict[str, Any]] = {}
+    for row in response.get("objects", []):
+        body = row.get("body")
+        if row.get("body_status") != "present" or not isinstance(body, str):
+            continue
+        try:
+            decoded = json.loads(body)
+        except json.JSONDecodeError:
+            continue
+        role = decoded.get("role")
+        if decoded.get("schema") != ROLE_BODY_SCHEMA or role not in ROLES:
+            continue
+        roles[str(role)] = {
+            "objectId": row["member"][0],
+            "versionRoot": row["member"][1],
+            "body": decoded,
+        }
+    relation_roots = [
+        str(row["relation_root"])
+        for row in response.get("relations", [])
+        if isinstance(row, dict) and isinstance(row.get("relation_root"), str)
+    ]
+    return response, roles, relation_roots
+
+
+def inspect(
+    runtime_dir: str | Path,
+    ref_name: str,
+    *,
+    kernel: Kernel | None = None,
+) -> dict[str, Any]:
+    kernel = kernel or _kernel
+    if _REF.fullmatch(ref_name) is None or ".." in ref_name:
+        return _denied("inspect", "invalid-request", "refName is not canonical")
+    catalog = kernel(runtime_dir, "query", {})
+    if catalog.get("ok") is not True:
+        return _denied(
+            "inspect",
+            "kernel-rejected",
+            "Fact kernel catalog query failed",
+            details=catalog,
+        )
+    resolution = (catalog.get("refs") or {}).get(ref_name)
+    if not isinstance(resolution, dict):
+        return {
+            "schema": INSPECTION_SCHEMA,
+            "status": "absent",
+            "refName": ref_name,
+            "cutRoot": None,
+            "revision": 0,
+            "roles": {},
+            "gaps": [{"role": role, "code": "responsibility-gap"} for role in ROLES],
+            "relations": [],
+        }
+    cut_root = resolution.get("cut_root")
+    try:
+        cut, roles, relation_roots = _load_cut(runtime_dir, cut_root, kernel)
+    except RuntimeError as error:
+        return _denied(
+            "inspect",
+            "kernel-rejected",
+            "Fact Cut query failed",
+            details={"error": str(error)},
+        )
+    return {
+        "schema": INSPECTION_SCHEMA,
+        "status": "current" if len(roles) == len(ROLES) else "degraded",
+        "refName": ref_name,
+        "cutRoot": cut_root,
+        "revision": resolution.get("revision", 0),
+        "roles": roles,
+        "gaps": [
+            {"role": role, "code": "responsibility-gap"}
+            for role in ROLES
+            if role not in roles
+        ],
+        "relations": relation_roots,
+        "basis": cut.get("cut") if isinstance(cut, dict) else None,
+    }
+
+
+def _validate_request(request: dict[str, Any]) -> None:
+    if request.get("schema") != ACTION_SCHEMA:
+        raise ValueError(f"schema must be {ACTION_SCHEMA}")
+    action_id = request.get("actionId")
+    if not isinstance(action_id, str) or _ACTION_ID.fullmatch(action_id) is None:
+        raise ValueError("actionId is not canonical")
+    ref_name = request.get("refName")
+    if (
+        not isinstance(ref_name, str)
+        or _REF.fullmatch(ref_name) is None
+        or ".." in ref_name
+    ):
+        raise ValueError("refName is not canonical")
+    subject = request.get("subject")
+    if not isinstance(subject, dict) or subject.get("role") not in ROLES:
+        raise ValueError("subject.role is required")
+    transition = (
+        subject.get("operation"),
+        subject.get("fromState"),
+        subject.get("toState"),
+    )
+    if transition not in TRANSITIONS[str(subject["role"])]:
+        raise ValueError("subject transition is not declared by the Kungfu Profile")
+    basis = request.get("basis")
+    ref = request.get("ref")
+    for field, value in (("basis", basis), ("ref", ref)):
+        if not isinstance(value, dict):
+            raise ValueError(f"{field} is required")
+        _require_root(value.get("cutRoot"), f"{field}.cutRoot", nullable=True)
+        if not isinstance(value.get("revision"), int) or value["revision"] < 0:
+            raise ValueError(f"{field}.revision must be a non-negative integer")
+    responsibilities = request.get("responsibilities")
+    if not isinstance(responsibilities, dict) or set(responsibilities) != set(ROLES):
+        raise ValueError("all five responsibilities are required exactly once")
+    for role in ROLES:
+        value = responsibilities[role]
+        if not isinstance(value, dict) or not isinstance(value.get("objectId"), str):
+            raise ValueError(f"responsibilities.{role}.objectId is required")
+        if _FACT_ID.fullmatch(value["objectId"]) is None:
+            raise ValueError(f"responsibilities.{role}.objectId is not canonical")
+        _require_root(
+            value.get("expectedVersionRoot"),
+            f"responsibilities.{role}.expectedVersionRoot",
+            nullable=True,
+        )
+    support = request.get("support")
+    if not isinstance(support, dict):
+        raise ValueError("support is required")
+    for field in ("createdByReceiptRoot", "schemaRoot", "reasonRoot"):
+        _require_root(support.get(field), f"support.{field}")
+    _require_root_list(support.get("declarationRoots"), "support.declarationRoots")
+    _require_root_list(support.get("admissionRoots"), "support.admissionRoots")
+
+
+def _kernel_failure(
+    action_id: str,
+    response: dict[str, Any],
+    steps: list[dict[str, Any]],
+) -> dict[str, Any]:
+    code = str(response.get("failure_code") or "kernel-rejected")
+    mapped = {
+        "stale-ref": "stale-ref",
+        "transition-id-reused": "replay-mismatch",
+    }.get(code, "kernel-rejected")
+    return _denied(
+        action_id,
+        mapped,
+        str(response.get("message") or "native Fact kernel rejected the action"),
+        details={"kernelFailureCode": code, "kernel": response.get("details", {})},
+        steps=steps,
+    )
+
+
+def apply_action(
+    runtime_dir: str | Path,
+    request: dict[str, Any],
+    *,
+    execute: bool = False,
+    kernel: Kernel | None = None,
+) -> dict[str, Any]:
+    """Validate, plan, and optionally execute one KFD-7 Profile action."""
+
+    kernel = kernel or _kernel
+    action_id = str(request.get("actionId") or "unknown")
+    try:
+        _validate_request(request)
+    except (KeyError, TypeError, ValueError) as error:
+        code = (
+            "responsibility-gap"
+            if "five responsibilities" in str(error)
+            else "invalid-transition"
+            if "transition" in str(error)
+            else "invalid-request"
+        )
+        return _denied(action_id, code, str(error))
+
+    subject = request["subject"]
+    basis = request["basis"]
+    responsibilities = request["responsibilities"]
+    try:
+        cut, current_roles, current_relation_roots = _load_cut(
+            runtime_dir, basis["cutRoot"], kernel
+        )
+    except RuntimeError as error:
+        return _denied(
+            action_id,
+            "kernel-rejected",
+            "declared basis Cut is unavailable",
+            details={"error": str(error)},
+        )
+
+    missing = [role for role in ROLES if role not in current_roles]
+    if basis["cutRoot"] is not None and missing:
+        return _denied(
+            action_id,
+            "body-missing",
+            "the declared Cut does not expose all five Profile role bodies",
+            details={"missingRoles": missing},
+        )
+
+    for role in ROLES:
+        expected = responsibilities[role]["expectedVersionRoot"]
+        current = current_roles.get(role)
+        actual = current["versionRoot"] if current else None
+        if expected != actual:
+            return _denied(
+                action_id,
+                "profile-state-mismatch",
+                f"{role} version does not match the declared basis",
+                details={"role": role, "expected": expected, "actual": actual},
+            )
+        if current and current["objectId"] != responsibilities[role]["objectId"]:
+            return _denied(
+                action_id,
+                "profile-state-mismatch",
+                f"{role} identity does not match the declared basis",
+                details={
+                    "role": role,
+                    "expected": responsibilities[role]["objectId"],
+                    "actual": current["objectId"],
+                },
+            )
+
+    subject_role = str(subject["role"])
+    current_subject = current_roles.get(subject_role)
+    current_state = current_subject["body"]["state"] if current_subject else "absent"
+    if current_state != subject["fromState"]:
+        return _denied(
+            action_id,
+            "profile-state-mismatch",
+            "subject state differs from the declared transition",
+            details={"expected": subject["fromState"], "actual": current_state},
+        )
+
+    role_inputs = request.get("roleInputs") or {}
+    if not isinstance(role_inputs, dict):
+        return _denied(action_id, "invalid-request", "roleInputs must be an object")
+    if basis["cutRoot"] is None:
+        for role in ROLES:
+            value = role_inputs.get(role)
+            if (
+                not isinstance(value, dict)
+                or value.get("state") != INITIAL_STATES[role]
+            ):
+                return _denied(
+                    action_id,
+                    "responsibility-gap",
+                    "bootstrap requires one initial body for every responsibility",
+                    details={"role": role, "requiredState": INITIAL_STATES[role]},
+                )
+
+    atlas_body = (
+        current_roles.get("atlas", {}).get("body") or role_inputs.get("atlas") or {}
+    )
+    atlas_state = atlas_body.get("state")
+    atlas_details = atlas_body.get("details") or {}
+    if not isinstance(atlas_details, dict):
+        return _denied(action_id, "invalid-request", "Atlas details must be an object")
+    if atlas_state != "current" and not (
+        subject_role == "atlas" and subject["operation"] == "refresh"
+    ):
+        return _denied(
+            action_id,
+            "atlas-stale",
+            f"Atlas state {atlas_state!r} cannot support the requested transition",
+        )
+    atlas_valid_through = atlas_details.get("validThroughRevision")
+    if (
+        not isinstance(atlas_valid_through, int)
+        or basis["revision"] > atlas_valid_through
+    ):
+        return _denied(
+            action_id,
+            "atlas-stale",
+            "Atlas freshness does not cover the declared basis revision",
+            details={
+                "basisRevision": basis["revision"],
+                "validThroughRevision": atlas_valid_through,
+            },
+        )
+
+    warrant_body = (
+        current_roles.get("warrant", {}).get("body") or role_inputs.get("warrant") or {}
+    )
+    warrant_state = warrant_body.get("state")
+    warrant_details = warrant_body.get("details") or {}
+    if warrant_state in {"expired", "revoked", "denied"}:
+        code = "warrant-revoked" if warrant_state == "revoked" else "warrant-expired"
+        return _denied(
+            action_id,
+            code,
+            f"Warrant state {warrant_state!r} cannot authorize an action",
+        )
+    valid_through = warrant_details.get("validThroughRevision")
+    if not isinstance(valid_through, int) or basis["revision"] > valid_through:
+        return _denied(
+            action_id,
+            "warrant-expired",
+            "Warrant validity does not cover the declared basis revision",
+            details={
+                "basisRevision": basis["revision"],
+                "validThroughRevision": valid_through,
+            },
+        )
+    allowed = warrant_details.get("allowedOperations")
+    operation_key = f"{subject_role}:{subject['operation']}"
+    if not isinstance(allowed, list) or not any(
+        candidate in allowed for candidate in ("*", subject["operation"], operation_key)
+    ):
+        return _denied(
+            action_id,
+            "unauthorized",
+            "Warrant scope does not authorize the requested transition",
+            details={"operation": operation_key, "allowedOperations": allowed or []},
+        )
+
+    changed_roles = list(ROLES) if basis["cutRoot"] is None else [subject_role]
+    plan = {
+        "schema": RECEIPT_SCHEMA,
+        "actionId": action_id,
+        "status": "planned",
+        "failureCode": None,
+        "writeOccurred": False,
+        "refWriteOccurred": False,
+        "basis": basis,
+        "ref": request["ref"],
+        "subject": subject,
+        "changedRoles": changed_roles,
+        "relationCount": len(request.get("relations") or []),
+        "commitPoint": "native Fact ref CAS",
+        "residualRisk": [
+            "Episode identity and seal roots are Profile mappings until Episode qualification is attached."
+        ],
+    }
+    if not execute:
+        return plan
+
+    support = request["support"]
+    steps: list[dict[str, Any]] = []
+    next_versions = {
+        role: value["versionRoot"] for role, value in current_roles.items()
+    }
+    next_bodies = {role: dict(value["body"]) for role, value in current_roles.items()}
+
+    for role in ROLES:
+        if role in current_roles:
+            continue
+        response = kernel(
+            runtime_dir,
+            "object-put",
+            {
+                "object_id": responsibilities[role]["objectId"],
+                "object_type": f"kfd7.profile.{role}",
+                "created_by_receipt_root": support["createdByReceiptRoot"],
+            },
+        )
+        steps.append(_step("object-put", response))
+        if response.get("ok") is not True:
+            return _kernel_failure(action_id, response, steps)
+
+    for role in changed_roles:
+        if role in current_roles:
+            body = dict(current_roles[role]["body"])
+            details = dict(body.get("details") or {})
+        else:
+            source = role_inputs[role]
+            body = {
+                "schema": ROLE_BODY_SCHEMA,
+                "profile": "kungfu-kfd-7-action-profile",
+                "role": role,
+                "identity": {"objectId": responsibilities[role]["objectId"]},
+                "state": source["state"],
+                "details": dict(source.get("details") or {}),
+                "nonClaims": list(source.get("nonClaims") or []),
+            }
+            details = dict(body["details"])
+        if role == subject_role:
+            body["state"] = subject["toState"]
+            payload = request.get("payload") or {}
+            if not isinstance(payload, dict):
+                return _denied(
+                    action_id,
+                    "invalid-request",
+                    "payload must be an object",
+                    steps=steps,
+                )
+            details.update(payload)
+            body["details"] = details
+        body["lastActionId"] = action_id
+        body["basedOnCutRoot"] = basis["cutRoot"]
+        raw_body = json.dumps(
+            body, ensure_ascii=False, separators=(",", ":"), sort_keys=True
+        )
+        parents = [current_roles[role]["versionRoot"]] if role in current_roles else []
+        response = kernel(
+            runtime_dir,
+            "version-put",
+            {
+                "object_id": responsibilities[role]["objectId"],
+                "body": raw_body,
+                "schema_root": support["schemaRoot"],
+                "parent_version_roots": parents,
+                "declaration_roots": support["declarationRoots"],
+                "admission_roots": support["admissionRoots"],
+            },
+        )
+        steps.append(_step("version-put", response))
+        if response.get("ok") is not True:
+            return _kernel_failure(action_id, response, steps)
+        next_versions[role] = response["result"]["version_root"]
+        next_bodies[role] = body
+
+    relation_roots = set(current_relation_roots)
+    relations = request.get("relations") or []
+    if not isinstance(relations, list):
+        return _denied(
+            action_id, "invalid-request", "relations must be an array", steps=steps
+        )
+    for relation in relations:
+        try:
+            source_role = relation["sourceRole"]
+            target_role = relation["targetRole"]
+            if source_role not in ROLES or target_role not in ROLES:
+                raise ValueError("relation roles must be KFD-7 responsibilities")
+            relation_id = relation["relationId"]
+            if (
+                not isinstance(relation_id, str)
+                or _FACT_ID.fullmatch(relation_id) is None
+            ):
+                raise ValueError("relationId is not canonical")
+            _require_root(relation.get("attributesRoot"), "relation.attributesRoot")
+        except (KeyError, TypeError, ValueError) as error:
+            return _denied(action_id, "invalid-request", str(error), steps=steps)
+        response = kernel(
+            runtime_dir,
+            "relation-add",
+            {
+                "relation_id": relation_id,
+                "relation_type": relation["relationType"],
+                "source": {
+                    "kind": "logical-object",
+                    "id": responsibilities[source_role]["objectId"],
+                },
+                "target": {
+                    "kind": "logical-object",
+                    "id": responsibilities[target_role]["objectId"],
+                },
+                "attributes_root": relation["attributesRoot"],
+                "admission_roots": support["admissionRoots"],
+            },
+        )
+        steps.append(_step("relation-add", response))
+        if response.get("ok") is not True:
+            return _kernel_failure(action_id, response, steps)
+        relation_roots.add(response["result"]["relation_root"])
+
+    base_cut = cut.get("cut", {}) if isinstance(cut, dict) else {}
+    episode_frontier = request.get(
+        "episodeFrontier", base_cut.get("episodeFrontier", [])
+    )
+    response = kernel(
+        runtime_dir,
+        "cut-put",
+        {
+            "parent_cut_roots": [basis["cutRoot"]] if basis["cutRoot"] else [],
+            "object_versions": [
+                {
+                    "object_id": responsibilities[role]["objectId"],
+                    "version_root": next_versions[role],
+                }
+                for role in ROLES
+            ],
+            "active_relation_roots": sorted(relation_roots),
+            "declaration_roots": support["declarationRoots"],
+            "admission_roots": support["admissionRoots"],
+            "episode_frontier": episode_frontier,
+            "omission_roots": request.get("omissionRoots", []),
+            "conflict_roots": request.get("conflictRoots", []),
+        },
+    )
+    steps.append(_step("cut-put", response))
+    if response.get("ok") is not True:
+        return _kernel_failure(action_id, response, steps)
+    next_cut_root = response["result"]["cut_root"]
+
+    ref_kind = (
+        "fork"
+        if subject["operation"] == "fork"
+        else "create"
+        if request["ref"]["cutRoot"] is None
+        else "advance"
+    )
+    response = kernel(
+        runtime_dir,
+        "ref-cas",
+        {
+            "transition_id": action_id,
+            "ref_name": request["refName"],
+            "expected_old_cut_root": request["ref"]["cutRoot"],
+            "expected_old_revision": request["ref"]["revision"],
+            "new_cut_root": next_cut_root,
+            "kind": ref_kind,
+            "reason_root": support["reasonRoot"],
+        },
+    )
+    steps.append(_step("ref-cas", response))
+    if response.get("ok") is not True:
+        return _kernel_failure(action_id, response, steps)
+
+    ref_result = response.get("result") or {}
+    return {
+        "schema": RECEIPT_SCHEMA,
+        "actionId": action_id,
+        "status": response.get("status", "accepted"),
+        "failureCode": None,
+        "writeOccurred": any(step["writeOccurred"] for step in steps),
+        "refWriteOccurred": response.get("write_occurred") is True,
+        "basis": basis,
+        "subject": subject,
+        "result": {
+            "cutRoot": ref_result.get("current_cut_root", next_cut_root),
+            "revision": ref_result.get("current_revision"),
+            "roleVersions": next_versions,
+            "roleStates": {role: next_bodies[role]["state"] for role in ROLES},
+            "relationRoots": sorted(relation_roots),
+        },
+        "kernelReceiptRoot": response.get("receipt_root"),
+        "steps": steps,
+        "residualRisk": [
+            "Profile acceptance does not prove Pursuit completion, complete reality, or KFD-7 activation."
+        ],
+    }

--- a/framework/core/src/python/kungfu/agent/work_profile.py
+++ b/framework/core/src/python/kungfu/agent/work_profile.py
@@ -123,6 +123,30 @@ def capabilities() -> dict[str, Any]:
             "kernel": "identity, immutable versions, relations, Cuts, CAS, receipts",
             "episode": "causal occurrence and sealed evidence",
         },
+        "recovery": {
+            "projectionRebuild": {
+                "status": "supported",
+                "source": "native Fact journal and content-addressed bodies",
+                "identity": "preserved",
+            },
+            "exportImport": {
+                "status": "explicit-loss-until-fact-bundle-qualified",
+                "required": [
+                    "Fact journal",
+                    "body namespace",
+                    "exact ref and Cut roots",
+                ],
+                "lossCode": "profile-authority-not-exported",
+            },
+            "backendMigration": {
+                "status": "delegated-to-storage-backend-switch",
+                "identity": "content roots and journal identities must remain exact",
+            },
+            "cleanHome": {
+                "status": "explicit-loss-without-qualified-export",
+                "lossCode": "profile-authority-unavailable",
+            },
+        },
         "nonClaims": [
             "A Profile receipt does not adopt KFD-7 or replace KFD authority.",
             "An accepted action does not prove Pursuit completion or complete reality.",
@@ -495,7 +519,11 @@ def apply_action(
     warrant_state = warrant_body.get("state")
     warrant_details = warrant_body.get("details") or {}
     if warrant_state in {"expired", "revoked", "denied"}:
-        code = "warrant-revoked" if warrant_state == "revoked" else "warrant-expired"
+        code = {
+            "expired": "warrant-expired",
+            "revoked": "warrant-revoked",
+            "denied": "unauthorized",
+        }[warrant_state]
         return _denied(
             action_id,
             code,

--- a/framework/core/src/python/kungfu/cli/commands/agent.py
+++ b/framework/core/src/python/kungfu/cli/commands/agent.py
@@ -14,6 +14,7 @@ from kungfu import contract as contract_runtime
 from kungfu import durability as durability_contract
 from kungfu.agent import runtime_profiles
 from kungfu.agent import session_surface
+from kungfu.agent import work_profile
 from kungfu.agent import documentation as documentation_pack
 from kungfu.agent.kfd3 import (
     api_help,
@@ -301,6 +302,71 @@ def work_model(ctx, as_json):
     for role in payload["roles"]:
         click.echo(f"- {role['name']}: {role['owns']}")
     click.echo(f"qualification: {payload['qualification']['status']}")
+
+
+@agent.group(name="work", help=api_help("kungfu.agent.work"))
+@kfd3_api("kungfu.agent.work")
+@agent_command_context
+def work(ctx):
+    """Inspect and apply the KFD-7 Kungfu Product Profile."""
+
+
+@work.command(name="capabilities", help=api_help("kungfu.agent.work.capabilities"))
+@click.option("--json", "as_json", is_flag=True, help="machine-readable output")
+@kfd3_api("kungfu.agent.work.capabilities")
+@agent_command_context
+def work_capabilities(ctx, as_json):
+    payload = work_profile.capabilities()
+    if as_json:
+        _json(payload)
+        return
+    click.echo("Kungfu KFD-7 Profile capabilities")
+    for role in payload["roles"]:
+        click.echo(f"- {role}")
+
+
+@work.command(name="inspect", help=api_help("kungfu.agent.work.inspect"))
+@click.option("--ref", "ref_name", required=True, help="exact Fact ref name")
+@click.option("--json", "as_json", is_flag=True, help="machine-readable output")
+@kfd3_api("kungfu.agent.work.inspect")
+@agent_command_context
+def work_inspect(ctx, ref_name, as_json):
+    payload = work_profile.inspect(ctx.runtime_dir, ref_name)
+    if as_json:
+        _json(payload)
+    else:
+        click.echo(json.dumps(payload, indent=2, sort_keys=True))
+    if payload.get("status") == "denied":
+        ctx.exit(2)
+
+
+@work.command(name="action", help=api_help("kungfu.agent.work.action"))
+@click.option(
+    "--file", "file_path", required=True, help="Profile action request JSON path or -"
+)
+@click.option("--execute", is_flag=True, help="append and CAS the action")
+@click.option("--json", "as_json", is_flag=True, help="machine-readable output")
+@kfd3_api("kungfu.agent.work.action")
+@agent_command_context
+def work_action(ctx, file_path, execute, as_json):
+    try:
+        raw = (
+            sys.stdin.read()
+            if file_path == "-"
+            else Path(file_path).read_text(encoding="utf-8")
+        )
+        request = json.loads(raw)
+        if not isinstance(request, dict):
+            raise ValueError("Profile action request must be a JSON object")
+    except (OSError, ValueError, json.JSONDecodeError) as error:
+        raise click.ClickException(str(error)) from error
+    payload = work_profile.apply_action(ctx.runtime_dir, request, execute=execute)
+    if as_json:
+        _json(payload)
+    else:
+        click.echo(json.dumps(payload, indent=2, sort_keys=True))
+    if payload.get("status") == "denied":
+        ctx.exit(2)
 
 
 def _runtime_config_homes(ctx):

--- a/framework/core/src/python/kungfu/cli/commands/agent.py
+++ b/framework/core/src/python/kungfu/cli/commands/agent.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
+import base64
 import json
 import os
 import sys
@@ -341,24 +342,31 @@ def work_inspect(ctx, ref_name, as_json):
 
 
 @work.command(name="action", help=api_help("kungfu.agent.work.action"))
+@click.option("--file", "file_path", help="Profile action request JSON path or -")
 @click.option(
-    "--file", "file_path", required=True, help="Profile action request JSON path or -"
+    "--input-base64",
+    help="base64-encoded Profile action JSON for SDK and GUI adapters",
 )
 @click.option("--execute", is_flag=True, help="append and CAS the action")
 @click.option("--json", "as_json", is_flag=True, help="machine-readable output")
 @kfd3_api("kungfu.agent.work.action")
 @agent_command_context
-def work_action(ctx, file_path, execute, as_json):
+def work_action(ctx, file_path, input_base64, execute, as_json):
     try:
-        raw = (
-            sys.stdin.read()
-            if file_path == "-"
-            else Path(file_path).read_text(encoding="utf-8")
-        )
+        if bool(file_path) == bool(input_base64):
+            raise ValueError("exactly one of --file or --input-base64 is required")
+        if input_base64:
+            raw = base64.b64decode(input_base64, validate=True).decode("utf-8")
+        else:
+            raw = (
+                sys.stdin.read()
+                if file_path == "-"
+                else Path(file_path).read_text(encoding="utf-8")
+            )
         request = json.loads(raw)
         if not isinstance(request, dict):
             raise ValueError("Profile action request must be a JSON object")
-    except (OSError, ValueError, json.JSONDecodeError) as error:
+    except (OSError, UnicodeError, ValueError, json.JSONDecodeError) as error:
         raise click.ClickException(str(error)) from error
     payload = work_profile.apply_action(ctx.runtime_dir, request, execute=execute)
     if as_json:

--- a/framework/core/tests/python/test_agent_work_profile_native.py
+++ b/framework/core/tests/python/test_agent_work_profile_native.py
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+
+
+if importlib.util.find_spec("pykungfu") is None:
+    pytest.skip("native pykungfu binding is not built", allow_module_level=True)
+
+from kungfu.agent import work_profile  # noqa: E402
+
+
+def _root(digit: str) -> str:
+    return "sha256:" + digit * 64
+
+
+def _request():
+    roles = list(work_profile.ROLES)
+    return {
+        "schema": work_profile.ACTION_SCHEMA,
+        "actionId": "native-bootstrap",
+        "refName": "profiles/kfd-7/native-test",
+        "basis": {"cutRoot": None, "revision": 0},
+        "ref": {"cutRoot": None, "revision": 0},
+        "subject": {
+            "role": "fact",
+            "operation": "create",
+            "fromState": "absent",
+            "toState": "declared",
+        },
+        "responsibilities": {
+            role: {
+                "objectId": f"fact:{index:032x}",
+                "expectedVersionRoot": None,
+            }
+            for index, role in enumerate(roles, start=1)
+        },
+        "roleInputs": {
+            "fact": {"state": "declared", "details": {"cutKind": "native-test"}},
+            "episode": {
+                "state": "open",
+                "details": {"episodeId": "episode:native-test"},
+            },
+            "pursuit": {
+                "state": "active",
+                "details": {"success": "native CAS accepts Python revision zero"},
+            },
+            "atlas": {"state": "current", "details": {"validThroughRevision": 10}},
+            "warrant": {
+                "state": "issued",
+                "details": {"validThroughRevision": 10, "allowedOperations": ["*"]},
+            },
+        },
+        "relations": [],
+        "support": {
+            "createdByReceiptRoot": _root("1"),
+            "schemaRoot": _root("2"),
+            "declarationRoots": [_root("3")],
+            "admissionRoots": [_root("4")],
+            "reasonRoot": _root("5"),
+        },
+    }
+
+
+def test_native_profile_bootstrap_accepts_python_revision_zero(tmp_path):
+    runtime_dir = tmp_path / "runtime"
+    request = _request()
+
+    receipt = work_profile.apply_action(runtime_dir, request, execute=True)
+    inspected = work_profile.inspect(runtime_dir, request["refName"])
+
+    assert receipt["status"] == "accepted", receipt
+    assert receipt["result"]["revision"] == 1
+    assert inspected["status"] == "current"
+    assert inspected["revision"] == 1
+    assert set(inspected["roles"]) == set(work_profile.ROLES)

--- a/framework/core/tests/python/test_agent_work_state_contract.py
+++ b/framework/core/tests/python/test_agent_work_state_contract.py
@@ -442,6 +442,11 @@ def test_kfd7_profile_capabilities_and_typed_responsibility_gap():
     capabilities = work_profile.capabilities()
     assert capabilities["roles"] == ["fact", "episode", "pursuit", "atlas", "warrant"]
     assert "stale-ref" in capabilities["denials"]
+    assert capabilities["recovery"]["projectionRebuild"]["identity"] == "preserved"
+    assert (
+        capabilities["recovery"]["cleanHome"]["lossCode"]
+        == "profile-authority-unavailable"
+    )
     request = _profile_request()
     del request["responsibilities"]["warrant"]
 

--- a/framework/core/tests/python/test_agent_work_state_contract.py
+++ b/framework/core/tests/python/test_agent_work_state_contract.py
@@ -5,6 +5,7 @@ import hashlib
 import json
 import sys
 import types
+from pathlib import Path
 
 from click.testing import CliRunner
 from jsonschema import Draft202012Validator
@@ -38,6 +39,7 @@ import kungfu  # noqa: E402
 kungfu._build_info = {"version": "test"}
 
 from kungfu import contract, durability  # noqa: E402
+from kungfu.agent import work_profile  # noqa: E402
 from kungfu.cli.commands import __registry__  # noqa: E402, F401
 from kungfu.cli.commands import kfc  # noqa: E402
 
@@ -176,3 +178,376 @@ def test_agent_work_model_closes_the_kfd3_runtime_interface(tmp_path):
     assert payload["runtimeAnchors"]["missingRuntimeAnchors"] == []
     assert payload["commandCatalog"]["missingRegistryEntries"] == []
     assert payload["commandCatalog"]["missingCatalogEntries"] == []
+
+
+def _root(value):
+    raw = json.dumps(value, separators=(",", ":"), sort_keys=True).encode()
+    return f"sha256:{hashlib.sha256(raw).hexdigest()}"
+
+
+class _MemoryFactKernel:
+    def __init__(self):
+        self.objects = {}
+        self.versions = {}
+        self.relations = {}
+        self.cuts = {}
+        self.refs = {}
+        self.transitions = {}
+
+    @staticmethod
+    def _ok(action, result, *, write=True, status="accepted"):
+        return {
+            "schema": "kungfu.fact-kernel.operation/v1",
+            "ok": True,
+            "action": action,
+            "status": status,
+            "write_occurred": write,
+            "result": result,
+            "receipt_root": _root([action, result]) if write else None,
+        }
+
+    @staticmethod
+    def _fail(action, code, message):
+        return {
+            "schema": "kungfu.fact-kernel.operation/v1",
+            "ok": False,
+            "action": action,
+            "status": "rejected",
+            "failure_code": code,
+            "message": message,
+            "details": {},
+            "write_occurred": False,
+            "receipt": None,
+        }
+
+    def __call__(self, runtime_dir, action, request=None):
+        request = copy.deepcopy(request or {})
+        if action == "query":
+            cut_root = request.get("cut_root")
+            if not cut_root:
+                return {
+                    "schema": "kungfu.fact-kernel.state/v1",
+                    "ok": True,
+                    "refs": copy.deepcopy(self.refs),
+                }
+            cut = self.cuts.get(cut_root)
+            if cut is None:
+                return self._fail(action, "unknown-cut", "missing Cut")
+            objects = []
+            for object_id, version_root in cut["objectVersions"]:
+                version = self.versions[version_root]
+                objects.append(
+                    {
+                        "member": [object_id, version_root],
+                        "version": {"bodyRoot": _root(version["body"])},
+                        "body": version["body"],
+                        "body_status": "present",
+                    }
+                )
+            return {
+                "schema": "kungfu.fact-kernel.state/v1",
+                "ok": True,
+                "cut_root": cut_root,
+                "cut": copy.deepcopy(cut),
+                "objects": objects,
+                "relations": [
+                    {
+                        "relation_root": root,
+                        "relation": copy.deepcopy(self.relations[root]),
+                    }
+                    for root in cut["activeRelationRoots"]
+                ],
+                "ref_resolution": None,
+            }
+        if action == "object-put":
+            object_id = request["object_id"]
+            existing = self.objects.get(object_id)
+            if existing is not None and existing != request:
+                return self._fail(action, "invalid-identity", "object changed")
+            self.objects[object_id] = request
+            return self._ok(
+                action,
+                {"object_id": object_id, "object_root": _root(request)},
+                write=existing is None,
+                status="accepted" if existing is None else "idempotent",
+            )
+        if action == "version-put":
+            version_root = _root(request)
+            existing = version_root in self.versions
+            self.versions[version_root] = copy.deepcopy(request)
+            return self._ok(
+                action,
+                {
+                    "object_id": request["object_id"],
+                    "version_root": version_root,
+                    "body_root": _root(request["body"]),
+                },
+                write=not existing,
+                status="accepted" if not existing else "idempotent",
+            )
+        if action == "relation-add":
+            relation_root = _root(request)
+            existing = relation_root in self.relations
+            self.relations[relation_root] = request
+            return self._ok(
+                action,
+                {
+                    "relation_id": request["relation_id"],
+                    "relation_root": relation_root,
+                },
+                write=not existing,
+                status="accepted" if not existing else "idempotent",
+            )
+        if action == "cut-put":
+            cut_root = _root(request)
+            existing = cut_root in self.cuts
+            self.cuts[cut_root] = {
+                "parentCutRoots": request["parent_cut_roots"],
+                "objectVersions": [
+                    [row["object_id"], row["version_root"]]
+                    for row in request["object_versions"]
+                ],
+                "activeRelationRoots": request["active_relation_roots"],
+                "declarationRoots": request["declaration_roots"],
+                "admissionRoots": request["admission_roots"],
+                "episodeFrontier": request["episode_frontier"],
+                "omissionRoots": request["omission_roots"],
+                "conflictRoots": request["conflict_roots"],
+            }
+            return self._ok(
+                action,
+                {"cut_root": cut_root},
+                write=not existing,
+                status="accepted" if not existing else "idempotent",
+            )
+        if action == "ref-cas":
+            transition_id = request["transition_id"]
+            previous = self.transitions.get(transition_id)
+            if previous is not None:
+                if previous["request"] != request:
+                    return self._fail(
+                        action, "transition-id-reused", "replay bytes differ"
+                    )
+                return self._ok(
+                    action,
+                    copy.deepcopy(previous["result"]),
+                    write=False,
+                    status="idempotent-replay",
+                )
+            current = self.refs.get(request["ref_name"])
+            current_root = current["cut_root"] if current else None
+            current_revision = current["revision"] if current else 0
+            if (
+                current_root != request["expected_old_cut_root"]
+                or current_revision != request["expected_old_revision"]
+            ):
+                return self._fail(action, "stale-ref", "ref changed")
+            result = {
+                "transition_id": transition_id,
+                "ref_name": request["ref_name"],
+                "prior_cut_root": current_root or "",
+                "current_cut_root": request["new_cut_root"],
+                "prior_revision": current_revision,
+                "current_revision": current_revision + 1,
+            }
+            self.refs[request["ref_name"]] = {
+                "cut_root": request["new_cut_root"],
+                "revision": current_revision + 1,
+            }
+            self.transitions[transition_id] = {
+                "request": request,
+                "result": result,
+            }
+            return self._ok(action, result)
+        raise AssertionError(f"unexpected action {action}")
+
+
+def _profile_request():
+    roles = list(work_profile.ROLES)
+    role_ids = {role: f"fact:{index:032x}" for index, role in enumerate(roles, start=1)}
+    support_root = "sha256:" + "1" * 64
+    return {
+        "schema": work_profile.ACTION_SCHEMA,
+        "actionId": "bootstrap-1",
+        "refName": "profiles/work/main",
+        "basis": {"cutRoot": None, "revision": 0},
+        "ref": {"cutRoot": None, "revision": 0},
+        "subject": {
+            "role": "fact",
+            "operation": "create",
+            "fromState": "absent",
+            "toState": "declared",
+        },
+        "responsibilities": {
+            role: {"objectId": role_ids[role], "expectedVersionRoot": None}
+            for role in roles
+        },
+        "roleInputs": {
+            "fact": {"state": "declared", "details": {"cutKind": "input"}},
+            "episode": {"state": "open", "details": {"episodeId": "episode:1"}},
+            "pursuit": {"state": "active", "details": {"success": "tests pass"}},
+            "atlas": {"state": "current", "details": {"validThroughRevision": 10}},
+            "warrant": {
+                "state": "issued",
+                "details": {"validThroughRevision": 10, "allowedOperations": ["*"]},
+            },
+        },
+        "relations": [
+            {
+                "relationId": "fact:" + "a" * 32,
+                "relationType": "pursuit-uses-atlas",
+                "sourceRole": "pursuit",
+                "targetRole": "atlas",
+                "attributesRoot": "sha256:" + "2" * 64,
+            }
+        ],
+        "support": {
+            "createdByReceiptRoot": support_root,
+            "schemaRoot": "sha256:" + "3" * 64,
+            "declarationRoots": ["sha256:" + "4" * 64],
+            "admissionRoots": ["sha256:" + "5" * 64],
+            "reasonRoot": "sha256:" + "6" * 64,
+        },
+    }
+
+
+def _successor_request(previous, *, action_id="continue-1"):
+    request = _profile_request()
+    request["actionId"] = action_id
+    request["basis"] = {
+        "cutRoot": previous["result"]["cutRoot"],
+        "revision": previous["result"]["revision"],
+    }
+    request["ref"] = copy.deepcopy(request["basis"])
+    request["subject"] = {
+        "role": "pursuit",
+        "operation": "continue",
+        "fromState": "active",
+        "toState": "active",
+    }
+    request["responsibilities"] = {
+        role: {
+            "objectId": request["responsibilities"][role]["objectId"],
+            "expectedVersionRoot": previous["result"]["roleVersions"][role],
+        }
+        for role in work_profile.ROLES
+    }
+    request.pop("roleInputs")
+    request["relations"] = []
+    request["payload"] = {"continuation": action_id}
+    return request
+
+
+def test_kfd7_profile_capabilities_and_typed_responsibility_gap():
+    capabilities = work_profile.capabilities()
+    assert capabilities["roles"] == ["fact", "episode", "pursuit", "atlas", "warrant"]
+    assert "stale-ref" in capabilities["denials"]
+    request = _profile_request()
+    del request["responsibilities"]["warrant"]
+
+    denied = work_profile.apply_action("/unused", request, kernel=_MemoryFactKernel())
+
+    assert denied["status"] == "denied"
+    assert denied["failureCode"] == "responsibility-gap"
+    assert denied["writeOccurred"] is False
+
+
+def test_kfd7_profile_action_and_receipt_schemas_cover_runtime_vectors():
+    root = Path(__file__).resolve().parents[4]
+    action_schema = json.loads(
+        (
+            root / "framework/agent-work/kungfu-kfd-7-profile-action.schema.json"
+        ).read_text()
+    )
+    receipt_schema = json.loads(
+        (
+            root / "framework/agent-work/kungfu-kfd-7-profile-receipt.schema.json"
+        ).read_text()
+    )
+    request = _profile_request()
+    planned = work_profile.apply_action("/unused", request, kernel=_MemoryFactKernel())
+
+    assert list(Draft202012Validator(action_schema).iter_errors(request)) == []
+    assert list(Draft202012Validator(receipt_schema).iter_errors(planned)) == []
+
+
+def test_kfd7_profile_bootstrap_continue_inspect_and_replay_fail_closed():
+    kernel = _MemoryFactKernel()
+    request = _profile_request()
+
+    planned = work_profile.apply_action("/runtime", request, kernel=kernel)
+    created = work_profile.apply_action(
+        "/runtime", request, execute=True, kernel=kernel
+    )
+    inspected = work_profile.inspect("/runtime", request["refName"], kernel=kernel)
+
+    assert planned["status"] == "planned"
+    assert created["status"] == "accepted"
+    assert created["result"]["roleStates"] == {
+        "fact": "declared",
+        "episode": "open",
+        "pursuit": "active",
+        "atlas": "current",
+        "warrant": "issued",
+    }
+    assert inspected["status"] == "current"
+    assert set(inspected["roles"]) == set(work_profile.ROLES)
+    assert len(inspected["relations"]) == 1
+
+    continued_request = _successor_request(created)
+    continued = work_profile.apply_action(
+        "/runtime", continued_request, execute=True, kernel=kernel
+    )
+    assert continued["status"] == "accepted"
+    assert continued["result"]["revision"] == 2
+
+    stale_request = _successor_request(created, action_id="stale-writer")
+    stale = work_profile.apply_action(
+        "/runtime", stale_request, execute=True, kernel=kernel
+    )
+    assert stale["status"] == "denied"
+    assert stale["failureCode"] == "stale-ref"
+    assert stale["writeOccurred"] is True
+    assert stale["refWriteOccurred"] is False
+
+    replay_mismatch_request = _successor_request(created)
+    replay_mismatch_request["payload"] = {"continuation": "different-bytes"}
+    replay_mismatch = work_profile.apply_action(
+        "/runtime", replay_mismatch_request, execute=True, kernel=kernel
+    )
+    assert replay_mismatch["status"] == "denied"
+    assert replay_mismatch["failureCode"] == "replay-mismatch"
+
+
+def test_kfd7_profile_rejects_stale_atlas_and_expired_warrant_before_writes():
+    kernel = _MemoryFactKernel()
+    created = work_profile.apply_action(
+        "/runtime", _profile_request(), execute=True, kernel=kernel
+    )
+    stale_atlas_request = _successor_request(created, action_id="atlas-stale")
+    atlas_root = created["result"]["roleVersions"]["atlas"]
+    atlas_body = json.loads(kernel.versions[atlas_root]["body"])
+    atlas_body["state"] = "stale"
+    kernel.versions[atlas_root]["body"] = json.dumps(atlas_body, sort_keys=True)
+
+    stale_atlas = work_profile.apply_action(
+        "/runtime", stale_atlas_request, execute=True, kernel=kernel
+    )
+
+    assert stale_atlas["failureCode"] == "atlas-stale"
+    assert stale_atlas["writeOccurred"] is False
+
+    atlas_body["state"] = "current"
+    kernel.versions[atlas_root]["body"] = json.dumps(atlas_body, sort_keys=True)
+    warrant_root = created["result"]["roleVersions"]["warrant"]
+    warrant_body = json.loads(kernel.versions[warrant_root]["body"])
+    warrant_body["details"]["validThroughRevision"] = 0
+    kernel.versions[warrant_root]["body"] = json.dumps(warrant_body, sort_keys=True)
+    expired = work_profile.apply_action(
+        "/runtime",
+        _successor_request(created, action_id="warrant-expired"),
+        kernel=kernel,
+    )
+
+    assert expired["failureCode"] == "warrant-expired"
+    assert expired["writeOccurred"] is False

--- a/framework/core/tests/storage-node-binding.test.js
+++ b/framework/core/tests/storage-node-binding.test.js
@@ -1148,6 +1148,14 @@ test(
         version.result.version_root,
       ]);
       assert.equal(projected.ref_resolution.revision, 1);
+      assert.equal('body' in projected.objects[0], false);
+
+      const projectedWithBodies = run('query', {
+        ref_name: 'heads/main',
+        include_bodies: true,
+      });
+      assert.equal(projectedWithBodies.objects[0].body_status, 'present');
+      assert.equal(projectedWithBodies.objects[0].body, 'opaque-body');
     } finally {
       fs.rmSync(runtimeDir, { recursive: true, force: true });
     }

--- a/framework/fact/kungfu-fact-cut-kernel.contract.json
+++ b/framework/fact/kungfu-fact-cut-kernel.contract.json
@@ -682,6 +682,7 @@
     "output": [
       "logical object ids",
       "immutable version roots",
+      "immutable bodies and explicit availability when requested",
       "active relation roots",
       "omissions",
       "conflicts",


### PR DESCRIPTION
## Summary

Linear replacement for #1079. Adds the same provisional KFD-7 Kungfu Product Profile without claiming activation; the replacement branch removes merge commits so the required REBASE merge queue can evaluate it.

## Changes

- Adds native Fact-backed Profile actions and receipts for Fact, Episode, Pursuit, Atlas, and Warrant.
- Exposes aligned CLI, Python, Node, API, Agent, and packaged contract surfaces.
- Retains positive bootstrap and negative transition evidence.
- Declares export/import, backend migration, and clean-home continuation as expected failures and keeps the release gate at warning.
- Tree-equivalent to #1079 except the KFD-3 prebuild source SHA bound to this linear history.

## Verification

- ./shifu check
- ./shifu build:core on the source-equivalent #1079 tree
- Native Python Profile regression
- Agent Work contract tests
- API typecheck and tests
- Documentation readonly gate
- Buildchain 2.12.9-alpha.1 real consumer: passport ok=true, trust=pass, KFD-7 downgraded/warning

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "stage-ready",
  "adrs": ["ADR-0109"],
  "summary": "Stage the provisional KFD-7 runtime Profile and retained warning evidence without claiming P17 qualification",
  "verification": ["native core build", "positive and negative Profile evidence", "Buildchain warning passport"]
}
-->

## Governance risk check

- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The release declaration is fail-closed: incomplete recovery and independent-review evidence remains visible as warning debt.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed