### PR TITLE
fix(core): allow runtime-free query metadata

### DIFF
--- a/framework/core/src/libkungfu/src/runtime/storage/backend_switch.cpp
+++ b/framework/core/src/libkungfu/src/runtime/storage/backend_switch.cpp
@@ -652,6 +652,9 @@ backend_authority_cut_guard::backend_authority_cut_guard(const std::string &runt
 backend_authority_cut_guard::~backend_authority_cut_guard() = default;
 
 provider_selection select_provider_for_runtime(const std::string &runtime_dir, std::string provider) {
+  if (runtime_dir.empty()) {
+    return select_provider(std::move(provider));
+  }
   const auto configured = select_provider(std::move(provider));
   const auto binding = parse_binding(load_json(binding_path(runtime_dir)));
   if (binding.present) {

--- a/framework/core/tests/storage-node-binding.test.js
+++ b/framework/core/tests/storage-node-binding.test.js
@@ -912,6 +912,23 @@ test(
 );
 
 test(
+  'runtime-independent query metadata does not require a storage root',
+  {
+    skip:
+      nativeAvailable || process.env.KUNGFU_REQUIRE_NATIVE === '1'
+        ? false
+        : 'built kungfu_node binding is unavailable',
+  },
+  () => {
+    const examples = kungfu.runStorageServiceOperation('query_plan', '', {
+      action: 'examples',
+    });
+    assert.equal(examples.schema, 'kungfu.query.examples/v1');
+    assert.equal(examples.examples.length > 0, true);
+  },
+);
+
+test(
   'saved query catalog is journal-backed and shared across the Node edge',
   {
     skip:


### PR DESCRIPTION
## Summary

Allow runtime-independent storage query metadata actions to select the configured provider without resolving a filesystem binding from an empty runtime root.

This repairs the deterministic Linux profile-action-admission failure observed in formal Build run 29641966292 and unblocks the same-run build-images Phase B qualification tracked by #995.

## Related issue

- #995

## Changes

- Bypass runtime binding-file lookup when `runtime_dir` is empty while preserving normal provider selection.
- Add a native Node regression for `query_plan` / `examples` with an empty runtime root.

## Verification

- `./shifu check:source`
- `./shifu build:core`
- `KUNGFU_REQUIRE_NATIVE=1 KUNGFU_DIR="$PWD/framework/core/dist/kungfu" ./shifu --filter @kungfu-tech/core test:storage-binding` (17/17 passed)

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This is a bounded bugfix for runtime-independent metadata dispatch and does not change the storage authority or provider contract."
}
-->

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] release evidence, provenance, package publishing, or deployment surfaces
- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed (not applicable: regression-only bugfix)