### PR TITLE
ci: pin build-images alpha.30 verifier

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -151,8 +151,8 @@ jobs:
             --output-dir phase-b-package-output \
             --expected-source-sha "${EXPECTED_SOURCE_SHA}" \
             --expected-version "${expected_version}" \
-            --build-images-ref "v1.2.4-alpha.29" \
-            --build-images-sha "7cf672d83323fdd139ad90b6e8165a56e431cc6c"
+            --build-images-ref "v1.2.4-alpha.30" \
+            --build-images-sha "3056c23e70b83f5bb63062f04027a93e79039e4b"
 
       - name: Resolve retained artifact name
         id: artifact
@@ -173,11 +173,11 @@ jobs:
     permissions:
       actions: read
       contents: read
-    uses: kungfu-systems/build-images/.github/workflows/comparator-kungfu-package-smoke.yml@7cf672d83323fdd139ad90b6e8165a56e431cc6c # v1.2.4-alpha.29
+    uses: kungfu-systems/build-images/.github/workflows/comparator-kungfu-package-smoke.yml@3056c23e70b83f5bb63062f04027a93e79039e4b # v1.2.4-alpha.30
     with:
       package_artifact_name: ${{ needs.phase-b-package.outputs.artifact-name }}
       package_sha256: ${{ needs.phase-b-package.outputs.package-sha256 }}
       package_version: ${{ needs.phase-b-package.outputs.package-version }}
       source_sha: ${{ needs.phase-b-package.outputs.source-sha }}
-      build_images_ref: v1.2.4-alpha.29
-      build_images_sha: 7cf672d83323fdd139ad90b6e8165a56e431cc6c
+      build_images_ref: v1.2.4-alpha.30
+      build_images_sha: 3056c23e70b83f5bb63062f04027a93e79039e4b

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -224,7 +224,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:d43a3754259fa0acc5c37903f33f5c3494a336d76b785634eb8eaa10a0af8f5f",
+          "definitionDigest": "sha256:fe0f6ee58c44cb0e7d830b04da1d95af5548c6a77b1e4928e921c40b6354b909",
           "credentials": {
             "githubToken": "read",
             "oidc": false,
@@ -233,7 +233,7 @@
             "environment": null
           },
           "externalActions": [
-            "kungfu-systems/build-images/.github/workflows/comparator-kungfu-package-smoke.yml@7cf672d83323fdd139ad90b6e8165a56e431cc6c"
+            "kungfu-systems/build-images/.github/workflows/comparator-kungfu-package-smoke.yml@3056c23e70b83f5bb63062f04027a93e79039e4b"
           ],
           "steps": []
         },
@@ -242,7 +242,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:9d031c722707dafa45e2ecc33a92a2a9a1c6a2d3860ccf9a14c289d5be643c4d",
+          "definitionDigest": "sha256:b59f68f94273c218f8ba6d48b00244e46d19447ab7c9ab8ea4a8779c1f8e8ff4",
           "credentials": {
             "githubToken": "read",
             "oidc": false,
@@ -272,7 +272,7 @@
               "index": 3,
               "label": "id:identity",
               "authority": "qualification",
-              "definitionDigest": "sha256:2eea487a24dfcc311a4261342a4ab92471d726fc164e47566b6bc3ac222338f3"
+              "definitionDigest": "sha256:ee60ade761101a3066595a16f784a895d6baaf45e9b01f7db5890aff409538ae"
             },
             {
               "index": 4,

--- a/scripts/source-acceptance.test.mjs
+++ b/scripts/source-acceptance.test.mjs
@@ -424,11 +424,11 @@ test('manual package build is welded to the reviewed Phase B consumer', () => {
   assert.match(workflow, /run-kungfu-phase-b:\n\s+description:/);
   assert.match(
     workflow,
-    /prepare_kungfu_phase_b_package\.py[\s\S]+--build-images-ref "v1\.2\.4-alpha\.29"[\s\S]+--build-images-sha "7cf672d83323fdd139ad90b6e8165a56e431cc6c"/,
+    /prepare_kungfu_phase_b_package\.py[\s\S]+--build-images-ref "v1\.2\.4-alpha\.30"[\s\S]+--build-images-sha "3056c23e70b83f5bb63062f04027a93e79039e4b"/,
   );
   assert.match(
     workflow,
-    /uses: kungfu-systems\/build-images\/\.github\/workflows\/comparator-kungfu-package-smoke\.yml@7cf672d83323fdd139ad90b6e8165a56e431cc6c # v1\.2\.4-alpha\.29/,
+    /uses: kungfu-systems\/build-images\/\.github\/workflows\/comparator-kungfu-package-smoke\.yml@3056c23e70b83f5bb63062f04027a93e79039e4b # v1\.2\.4-alpha\.30/,
   );
   assert.match(
     workflow,


### PR DESCRIPTION
## Summary

- pin the Phase B package identity and reusable workflow to build-images `v1.2.4-alpha.30` / `3056c23e70b83f5bb63062f04027a93e79039e4b`
- refresh the closed-world workflow authority evidence
- keep source-acceptance welded to the exact immutable consumer

## Validation

- `./shifu check:source`
- workflow authority and gate catalog checks

This enables the exact-source three-platform plus Phase B rerun for kungfu-systems/build-images#235 and #995.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This is a bounded immutable dependency pin and generated workflow-authority evidence refresh; it does not change Kungfu product or architecture contracts."
}
-->

## Governance risk check

- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Exact Buildchain release passport verified
