### PR TITLE
feat(agent): activate KFD-7 engineering contract

### DIFF
--- a/.buildchain/kfd/kfd-2/claims/agent-onboarding-pack.json
+++ b/.buildchain/kfd/kfd-2/claims/agent-onboarding-pack.json
@@ -16,7 +16,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "a9b11bf1fb65113a0f32d4ee8e295e8bfa1607ae9d2fb244043d3740cbb42c54"
+        "sha256": "583295901ceaddc4a36920bed6a39a710458c124347af40f6ccc30c4ac55efbb"
       },
       "description": "Machine-readable command catalog and mode maturity metadata."
     },
@@ -54,7 +54,7 @@
     "evidenceSha256": [
       {
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "a9b11bf1fb65113a0f32d4ee8e295e8bfa1607ae9d2fb244043d3740cbb42c54"
+        "sha256": "583295901ceaddc4a36920bed6a39a710458c124347af40f6ccc30c4ac55efbb"
       },
       {
         "path": "framework/core/src/python/kungfu/agent/mode-selection.md",
@@ -76,7 +76,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "a9b11bf1fb65113a0f32d4ee8e295e8bfa1607ae9d2fb244043d3740cbb42c54"
+        "sha256": "583295901ceaddc4a36920bed6a39a710458c124347af40f6ccc30c4ac55efbb"
       }
     ]
   },
@@ -90,7 +90,7 @@
     {
       "name": "agent-command-catalog",
       "path": "framework/core/src/python/kungfu/agent/commands.json",
-      "sha256": "a9b11bf1fb65113a0f32d4ee8e295e8bfa1607ae9d2fb244043d3740cbb42c54",
+      "sha256": "583295901ceaddc4a36920bed6a39a710458c124347af40f6ccc30c4ac55efbb",
       "expectedPackagePath": "kungfu/agent/commands.json"
     }
   ],

--- a/.buildchain/kfd/kfd-2/claims/agent-work-state-contract.json
+++ b/.buildchain/kfd/kfd-2/claims/agent-work-state-contract.json
@@ -16,7 +16,7 @@
       "pointer": {
         "kind": "file",
         "path": "docs/adr/ADR-0109-four-object-agent-work-state-contract.md",
-        "sha256": "c4fc13930268ad149a0d179cb0944c8a3236c24e3e03038dac5da3b91c219188"
+        "sha256": "6f30305eed2d1d9f4cc55508fd7014e81aa6846a0608015ea410175dc8fec981"
       },
       "description": "Accepted role-separation decision and bounded P17 qualification boundary."
     },
@@ -34,7 +34,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/tests/python/test_agent_work_state_contract.py",
-        "sha256": "2b1c013a49533d7a6c240b1f05d94c74dba45da0e6d439592ed8885aad7178ac"
+        "sha256": "af68539d3c968e192f5fcbcd9a2d27d2107d5a97c3d8af80ef5f13622de0649c"
       },
       "description": "Runtime CLI parity and fail-closed contract-schema checks."
     },
@@ -43,7 +43,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
-        "sha256": "c9f35d1a267181532952a9603de56d5b6342372ec1848a6ca5afcf841ad0b0b1"
+        "sha256": "91294bb5d359299e2deda1a12d5629b599aaf20d2147816bab9f92098b5c813b"
       },
       "description": "Agent collaboration-interface registration for the work-model query."
     }
@@ -54,7 +54,7 @@
     "evidenceSha256": [
       {
         "path": "docs/adr/ADR-0109-four-object-agent-work-state-contract.md",
-        "sha256": "c4fc13930268ad149a0d179cb0944c8a3236c24e3e03038dac5da3b91c219188"
+        "sha256": "6f30305eed2d1d9f4cc55508fd7014e81aa6846a0608015ea410175dc8fec981"
       },
       {
         "path": "scripts/check-agent-work-state-contract.test.mjs",
@@ -62,11 +62,11 @@
       },
       {
         "path": "framework/core/tests/python/test_agent_work_state_contract.py",
-        "sha256": "2b1c013a49533d7a6c240b1f05d94c74dba45da0e6d439592ed8885aad7178ac"
+        "sha256": "af68539d3c968e192f5fcbcd9a2d27d2107d5a97c3d8af80ef5f13622de0649c"
       },
       {
         "path": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
-        "sha256": "c9f35d1a267181532952a9603de56d5b6342372ec1848a6ca5afcf841ad0b0b1"
+        "sha256": "91294bb5d359299e2deda1a12d5629b599aaf20d2147816bab9f92098b5c813b"
       }
     ],
     "artifactSha256": [

--- a/.buildchain/kfd/kfd-2/claims/remote-fact-boundary.json
+++ b/.buildchain/kfd/kfd-2/claims/remote-fact-boundary.json
@@ -34,7 +34,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "a9b11bf1fb65113a0f32d4ee8e295e8bfa1607ae9d2fb244043d3740cbb42c54"
+        "sha256": "583295901ceaddc4a36920bed6a39a710458c124347af40f6ccc30c4ac55efbb"
       },
       "description": "Remote add/sync command declarations and mode metadata."
     },
@@ -43,7 +43,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/cli/commands/agent.py",
-        "sha256": "4a2c928d7c3bfd84d1883c65dc71f2e9e545febc2a9f8235a58172fac0170bda"
+        "sha256": "bee8cabb2b0840785e2b67cff0c9c9f4643fdb35ded7bb816e0261ce1700d83a"
       },
       "description": "Agent command surface including mode selection and bootstrap status."
     }
@@ -62,11 +62,11 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "a9b11bf1fb65113a0f32d4ee8e295e8bfa1607ae9d2fb244043d3740cbb42c54"
+        "sha256": "583295901ceaddc4a36920bed6a39a710458c124347af40f6ccc30c4ac55efbb"
       },
       {
         "path": "framework/core/src/python/kungfu/cli/commands/agent.py",
-        "sha256": "4a2c928d7c3bfd84d1883c65dc71f2e9e545febc2a9f8235a58172fac0170bda"
+        "sha256": "bee8cabb2b0840785e2b67cff0c9c9f4643fdb35ded7bb816e0261ce1700d83a"
       }
     ],
     "artifactSha256": [

--- a/.buildchain/kfd/kfd-2/release-claims.json
+++ b/.buildchain/kfd/kfd-2/release-claims.json
@@ -29,7 +29,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/commands.json",
-            "sha256": "a9b11bf1fb65113a0f32d4ee8e295e8bfa1607ae9d2fb244043d3740cbb42c54"
+            "sha256": "583295901ceaddc4a36920bed6a39a710458c124347af40f6ccc30c4ac55efbb"
           },
           "description": "Machine-readable command catalog and mode maturity metadata."
         },
@@ -194,7 +194,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/commands.json",
-            "sha256": "a9b11bf1fb65113a0f32d4ee8e295e8bfa1607ae9d2fb244043d3740cbb42c54"
+            "sha256": "583295901ceaddc4a36920bed6a39a710458c124347af40f6ccc30c4ac55efbb"
           },
           "description": "Remote add/sync command declarations and mode metadata."
         },
@@ -203,7 +203,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/cli/commands/agent.py",
-            "sha256": "4a2c928d7c3bfd84d1883c65dc71f2e9e545febc2a9f8235a58172fac0170bda"
+            "sha256": "bee8cabb2b0840785e2b67cff0c9c9f4643fdb35ded7bb816e0261ce1700d83a"
           },
           "description": "Agent command surface including mode selection and bootstrap status."
         }
@@ -247,7 +247,7 @@
           "pointer": {
             "kind": "file",
             "path": "docs/adr/ADR-0109-four-object-agent-work-state-contract.md",
-            "sha256": "c4fc13930268ad149a0d179cb0944c8a3236c24e3e03038dac5da3b91c219188"
+            "sha256": "6f30305eed2d1d9f4cc55508fd7014e81aa6846a0608015ea410175dc8fec981"
           },
           "description": "Accepted role-separation decision and bounded P17 qualification boundary."
         },
@@ -265,7 +265,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/tests/python/test_agent_work_state_contract.py",
-            "sha256": "2b1c013a49533d7a6c240b1f05d94c74dba45da0e6d439592ed8885aad7178ac"
+            "sha256": "af68539d3c968e192f5fcbcd9a2d27d2107d5a97c3d8af80ef5f13622de0649c"
           },
           "description": "Runtime CLI parity and fail-closed contract-schema checks."
         },
@@ -274,7 +274,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
-            "sha256": "c9f35d1a267181532952a9603de56d5b6342372ec1848a6ca5afcf841ad0b0b1"
+            "sha256": "91294bb5d359299e2deda1a12d5629b599aaf20d2147816bab9f92098b5c813b"
           },
           "description": "Agent collaboration-interface registration for the work-model query."
         }

--- a/.buildchain/kfd/kfd-3/capability-query.json
+++ b/.buildchain/kfd/kfd-3/capability-query.json
@@ -627,6 +627,50 @@
       "residualRisk": []
     },
     {
+      "id": "kungfu.agent.work.export-authority",
+      "kind": "cli-api-gui",
+      "name": "kungfu agent work export-authority --json",
+      "state": "declared",
+      "detected": true,
+      "enforced": false,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "kfd1Basis": {
+        "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+        "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+        "digest": "sha256:36ce1377cb2807787be66fe02caafa23557b2000463b47f7ca9a5a20dffd2791"
+      },
+      "kfd2Trust": {
+        "status": "release-passport-required",
+        "trustImpact": "query-release-passport-for-final-trust",
+        "residualRisk": []
+      },
+      "residualRisk": []
+    },
+    {
+      "id": "kungfu.agent.work.import-authority",
+      "kind": "cli-api-gui",
+      "name": "kungfu agent work import-authority --file <bundle.json> [--execute] --json",
+      "state": "declared",
+      "detected": true,
+      "enforced": false,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "kfd1Basis": {
+        "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+        "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+        "digest": "sha256:e037687e970a0ff9bc3354b3910ee102beaf28971f96c238e59b1661c1587b06"
+      },
+      "kfd2Trust": {
+        "status": "release-passport-required",
+        "trustImpact": "query-release-passport-for-final-trust",
+        "residualRisk": []
+      },
+      "residualRisk": []
+    },
+    {
       "id": "kungfu.agent.work.inspect",
       "kind": "cli-api-gui",
       "name": "kungfu agent work inspect --ref <ref> --json",
@@ -640,6 +684,28 @@
         "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
         "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
         "digest": "sha256:6af6d64c9de18bca664083e4bed4729f414bdc942dc2eef163c138f0981a4d88"
+      },
+      "kfd2Trust": {
+        "status": "release-passport-required",
+        "trustImpact": "query-release-passport-for-final-trust",
+        "residualRisk": []
+      },
+      "residualRisk": []
+    },
+    {
+      "id": "kungfu.agent.work.session",
+      "kind": "cli-api-gui",
+      "name": "kungfu agent work session --operation <compressibility|expand|project> --file <session.json> --json",
+      "state": "declared",
+      "detected": true,
+      "enforced": false,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "kfd1Basis": {
+        "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+        "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+        "digest": "sha256:12d0e74117911a9ca20cdbe629d58bf4f57d857a1e05fa8455b20b432ea5afb8"
       },
       "kfd2Trust": {
         "status": "release-passport-required",

--- a/.buildchain/kfd/kfd-3/collaboration-interface.artifact.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.artifact.json
@@ -10,8 +10,8 @@
   "sourceRegistry": {
     "id": "kungfu",
     "path": ".buildchain/kfd/kfd-3/surfaces.json",
-    "sha256": "cc27f23dc20dc847b561043d7cf8a62ba9d5deec221cd2defbd2902a8b2a9926",
-    "digest": "sha256:e79bd45edee60839cd3b3ba58db3824b6ebe53f3ea22a978284c87cc6052140c"
+    "sha256": "feedb1e039eabb2c4562824fd616f612e6c03d41600a2ba60b99908ba4e57cf4",
+    "digest": "sha256:26bf1e17e7bae0b73d43d5be1227c055b24ee678ce9db5b4bad7d2e7cb3f2aa6"
   },
   "upstreamKfd": {
     "aggregatePath": "developer/sdk/kfd/upstream-aggregate.json",
@@ -28,7 +28,7 @@
     },
     "digest": "sha256:e76c3f1d5629c169dc2522ec486ca4c188aaee0739efac6712fb6362fd913cb1"
   },
-  "collaborationInterfaceDigest": "sha256:e3a722f9f775eb457f4d395b108ded0d24f2f1c4f90fcf5eaa1fa5165b423ada",
+  "collaborationInterfaceDigest": "sha256:6d2dae874295a7675c1b5788ee29b536b4c759999a99055d65ee2467e0092a5f",
   "exposedSurfaces": [
     {
       "id": "kungfu.agent",
@@ -591,8 +591,68 @@
       }
     },
     {
+      "id": "kungfu.agent.work.export-authority",
+      "name": "kungfu agent work export-authority --json",
+      "kind": "cli-api-gui",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
+      "id": "kungfu.agent.work.import-authority",
+      "name": "kungfu agent work import-authority --file <bundle.json> [--execute] --json",
+      "kind": "cli-api-gui",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
       "id": "kungfu.agent.work.inspect",
       "name": "kungfu agent work inspect --ref <ref> --json",
+      "kind": "cli-api-gui",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
+      "id": "kungfu.agent.work.session",
+      "name": "kungfu agent work session --operation <compressibility|expand|project> --file <session.json> --json",
       "kind": "cli-api-gui",
       "participantProfile": "agent-or-developer",
       "state": "declared",

--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -6,15 +6,15 @@
   "supportLevel": "release",
   "source": {
     "cwd": ".",
-    "sourceSha": "be9bb805c7d6f35950e48d80bbd397d39d31589f",
+    "sourceSha": "d6fb3879c8f495b6b4e4a1a619ce78358291a6e1",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
-    "registryDigest": "sha256:e79bd45edee60839cd3b3ba58db3824b6ebe53f3ea22a978284c87cc6052140c"
+    "registryDigest": "sha256:26bf1e17e7bae0b73d43d5be1227c055b24ee678ce9db5b4bad7d2e7cb3f2aa6"
   },
   "sourceRegistry": {
     "id": "kungfu",
     "path": ".buildchain/kfd/kfd-3/surfaces.json",
-    "sha256": "cc27f23dc20dc847b561043d7cf8a62ba9d5deec221cd2defbd2902a8b2a9926",
-    "digest": "sha256:e79bd45edee60839cd3b3ba58db3824b6ebe53f3ea22a978284c87cc6052140c"
+    "sha256": "feedb1e039eabb2c4562824fd616f612e6c03d41600a2ba60b99908ba4e57cf4",
+    "digest": "sha256:26bf1e17e7bae0b73d43d5be1227c055b24ee678ce9db5b4bad7d2e7cb3f2aa6"
   },
   "upstreamKfd": {
     "aggregatePath": "developer/sdk/kfd/upstream-aggregate.json",
@@ -34,7 +34,7 @@
   "expectedArtifactVerification": {
     "command": "node scripts/buildchain-kfd-evidence.mjs --artifact-witness --json"
   },
-  "collaborationInterfaceDigest": "sha256:e3a722f9f775eb457f4d395b108ded0d24f2f1c4f90fcf5eaa1fa5165b423ada",
+  "collaborationInterfaceDigest": "sha256:6d2dae874295a7675c1b5788ee29b536b4c759999a99055d65ee2467e0092a5f",
   "collaborationInterface": {
     "schemaVersion": 1,
     "contract": "kungfu-buildchain-kfd-3-surface-registry",
@@ -621,8 +621,68 @@
         }
       },
       {
+        "id": "kungfu.agent.work.export-authority",
+        "name": "kungfu agent work export-authority --json",
+        "kind": "cli-api-gui",
+        "participantProfile": "agent-or-developer",
+        "state": "declared",
+        "availability": "shipped",
+        "visibility": "public",
+        "participantFacing": true,
+        "public": true,
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+        "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+        "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+        "maturity": "experimental",
+        "declaration": {
+          "owner": "kungfu",
+          "source": "scripts/buildchain-kfd-evidence.mjs",
+          "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+        }
+      },
+      {
+        "id": "kungfu.agent.work.import-authority",
+        "name": "kungfu agent work import-authority --file <bundle.json> [--execute] --json",
+        "kind": "cli-api-gui",
+        "participantProfile": "agent-or-developer",
+        "state": "declared",
+        "availability": "shipped",
+        "visibility": "public",
+        "participantFacing": true,
+        "public": true,
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+        "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+        "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+        "maturity": "experimental",
+        "declaration": {
+          "owner": "kungfu",
+          "source": "scripts/buildchain-kfd-evidence.mjs",
+          "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+        }
+      },
+      {
         "id": "kungfu.agent.work.inspect",
         "name": "kungfu agent work inspect --ref <ref> --json",
+        "kind": "cli-api-gui",
+        "participantProfile": "agent-or-developer",
+        "state": "declared",
+        "availability": "shipped",
+        "visibility": "public",
+        "participantFacing": true,
+        "public": true,
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+        "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+        "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+        "maturity": "experimental",
+        "declaration": {
+          "owner": "kungfu",
+          "source": "scripts/buildchain-kfd-evidence.mjs",
+          "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+        }
+      },
+      {
+        "id": "kungfu.agent.work.session",
+        "name": "kungfu agent work session --operation <compressibility|expand|project> --file <session.json> --json",
         "kind": "cli-api-gui",
         "participantProfile": "agent-or-developer",
         "state": "declared",
@@ -2708,8 +2768,8 @@
     ],
     "audit": {
       "status": "passed",
-      "declared": 131,
-      "artifactPublic": 131,
+      "declared": 134,
+      "artifactPublic": 134,
       "policy": {
         "sourceOfTruth": ".buildchain/kfd/kfd-3/surfaces.json",
         "detectedButUnregistered": "product-specific-audit",
@@ -3282,8 +3342,68 @@
       }
     },
     {
+      "id": "kungfu.agent.work.export-authority",
+      "name": "kungfu agent work export-authority --json",
+      "kind": "cli-api-gui",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
+      "id": "kungfu.agent.work.import-authority",
+      "name": "kungfu agent work import-authority --file <bundle.json> [--execute] --json",
+      "kind": "cli-api-gui",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
       "id": "kungfu.agent.work.inspect",
       "name": "kungfu agent work inspect --ref <ref> --json",
+      "kind": "cli-api-gui",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
+      "id": "kungfu.agent.work.session",
+      "name": "kungfu agent work session --operation <compressibility|expand|project> --file <session.json> --json",
       "kind": "cli-api-gui",
       "participantProfile": "agent-or-developer",
       "state": "declared",

--- a/.buildchain/kfd/kfd-3/surfaces.json
+++ b/.buildchain/kfd/kfd-3/surfaces.json
@@ -629,8 +629,68 @@
       }
     },
     {
+      "id": "kungfu.agent.work.export-authority",
+      "name": "kungfu agent work export-authority --json",
+      "kind": "cli-api-gui",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
+      "id": "kungfu.agent.work.import-authority",
+      "name": "kungfu agent work import-authority --file <bundle.json> [--execute] --json",
+      "kind": "cli-api-gui",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
       "id": "kungfu.agent.work.inspect",
       "name": "kungfu agent work inspect --ref <ref> --json",
+      "kind": "cli-api-gui",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
+      "id": "kungfu.agent.work.session",
+      "name": "kungfu agent work session --operation <compressibility|expand|project> --file <session.json> --json",
       "kind": "cli-api-gui",
       "participantProfile": "agent-or-developer",
       "state": "declared",

--- a/developer/sdk/kfd/kfd-2/claims/agent-onboarding-pack.json
+++ b/developer/sdk/kfd/kfd-2/claims/agent-onboarding-pack.json
@@ -16,7 +16,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "a9b11bf1fb65113a0f32d4ee8e295e8bfa1607ae9d2fb244043d3740cbb42c54"
+        "sha256": "583295901ceaddc4a36920bed6a39a710458c124347af40f6ccc30c4ac55efbb"
       },
       "description": "Machine-readable command catalog and mode maturity metadata."
     },
@@ -54,7 +54,7 @@
     "evidenceSha256": [
       {
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "a9b11bf1fb65113a0f32d4ee8e295e8bfa1607ae9d2fb244043d3740cbb42c54"
+        "sha256": "583295901ceaddc4a36920bed6a39a710458c124347af40f6ccc30c4ac55efbb"
       },
       {
         "path": "framework/core/src/python/kungfu/agent/mode-selection.md",
@@ -76,7 +76,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "a9b11bf1fb65113a0f32d4ee8e295e8bfa1607ae9d2fb244043d3740cbb42c54"
+        "sha256": "583295901ceaddc4a36920bed6a39a710458c124347af40f6ccc30c4ac55efbb"
       }
     ]
   },
@@ -90,7 +90,7 @@
     {
       "name": "agent-command-catalog",
       "path": "framework/core/src/python/kungfu/agent/commands.json",
-      "sha256": "a9b11bf1fb65113a0f32d4ee8e295e8bfa1607ae9d2fb244043d3740cbb42c54",
+      "sha256": "583295901ceaddc4a36920bed6a39a710458c124347af40f6ccc30c4ac55efbb",
       "expectedPackagePath": "kungfu/agent/commands.json"
     }
   ],

--- a/developer/sdk/kfd/kfd-2/claims/agent-work-state-contract.json
+++ b/developer/sdk/kfd/kfd-2/claims/agent-work-state-contract.json
@@ -16,7 +16,7 @@
       "pointer": {
         "kind": "file",
         "path": "docs/adr/ADR-0109-four-object-agent-work-state-contract.md",
-        "sha256": "c4fc13930268ad149a0d179cb0944c8a3236c24e3e03038dac5da3b91c219188"
+        "sha256": "6f30305eed2d1d9f4cc55508fd7014e81aa6846a0608015ea410175dc8fec981"
       },
       "description": "Accepted role-separation decision and bounded P17 qualification boundary."
     },
@@ -34,7 +34,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/tests/python/test_agent_work_state_contract.py",
-        "sha256": "2b1c013a49533d7a6c240b1f05d94c74dba45da0e6d439592ed8885aad7178ac"
+        "sha256": "af68539d3c968e192f5fcbcd9a2d27d2107d5a97c3d8af80ef5f13622de0649c"
       },
       "description": "Runtime CLI parity and fail-closed contract-schema checks."
     },
@@ -43,7 +43,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
-        "sha256": "c9f35d1a267181532952a9603de56d5b6342372ec1848a6ca5afcf841ad0b0b1"
+        "sha256": "91294bb5d359299e2deda1a12d5629b599aaf20d2147816bab9f92098b5c813b"
       },
       "description": "Agent collaboration-interface registration for the work-model query."
     }
@@ -54,7 +54,7 @@
     "evidenceSha256": [
       {
         "path": "docs/adr/ADR-0109-four-object-agent-work-state-contract.md",
-        "sha256": "c4fc13930268ad149a0d179cb0944c8a3236c24e3e03038dac5da3b91c219188"
+        "sha256": "6f30305eed2d1d9f4cc55508fd7014e81aa6846a0608015ea410175dc8fec981"
       },
       {
         "path": "scripts/check-agent-work-state-contract.test.mjs",
@@ -62,11 +62,11 @@
       },
       {
         "path": "framework/core/tests/python/test_agent_work_state_contract.py",
-        "sha256": "2b1c013a49533d7a6c240b1f05d94c74dba45da0e6d439592ed8885aad7178ac"
+        "sha256": "af68539d3c968e192f5fcbcd9a2d27d2107d5a97c3d8af80ef5f13622de0649c"
       },
       {
         "path": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
-        "sha256": "c9f35d1a267181532952a9603de56d5b6342372ec1848a6ca5afcf841ad0b0b1"
+        "sha256": "91294bb5d359299e2deda1a12d5629b599aaf20d2147816bab9f92098b5c813b"
       }
     ],
     "artifactSha256": [

--- a/developer/sdk/kfd/kfd-2/claims/remote-fact-boundary.json
+++ b/developer/sdk/kfd/kfd-2/claims/remote-fact-boundary.json
@@ -34,7 +34,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "a9b11bf1fb65113a0f32d4ee8e295e8bfa1607ae9d2fb244043d3740cbb42c54"
+        "sha256": "583295901ceaddc4a36920bed6a39a710458c124347af40f6ccc30c4ac55efbb"
       },
       "description": "Remote add/sync command declarations and mode metadata."
     },
@@ -43,7 +43,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/cli/commands/agent.py",
-        "sha256": "4a2c928d7c3bfd84d1883c65dc71f2e9e545febc2a9f8235a58172fac0170bda"
+        "sha256": "bee8cabb2b0840785e2b67cff0c9c9f4643fdb35ded7bb816e0261ce1700d83a"
       },
       "description": "Agent command surface including mode selection and bootstrap status."
     }
@@ -62,11 +62,11 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "a9b11bf1fb65113a0f32d4ee8e295e8bfa1607ae9d2fb244043d3740cbb42c54"
+        "sha256": "583295901ceaddc4a36920bed6a39a710458c124347af40f6ccc30c4ac55efbb"
       },
       {
         "path": "framework/core/src/python/kungfu/cli/commands/agent.py",
-        "sha256": "4a2c928d7c3bfd84d1883c65dc71f2e9e545febc2a9f8235a58172fac0170bda"
+        "sha256": "bee8cabb2b0840785e2b67cff0c9c9f4643fdb35ded7bb816e0261ce1700d83a"
       }
     ],
     "artifactSha256": [

--- a/developer/sdk/kfd/kfd-2/release-claims.json
+++ b/developer/sdk/kfd/kfd-2/release-claims.json
@@ -29,7 +29,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/commands.json",
-            "sha256": "a9b11bf1fb65113a0f32d4ee8e295e8bfa1607ae9d2fb244043d3740cbb42c54"
+            "sha256": "583295901ceaddc4a36920bed6a39a710458c124347af40f6ccc30c4ac55efbb"
           },
           "description": "Machine-readable command catalog and mode maturity metadata."
         },
@@ -194,7 +194,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/commands.json",
-            "sha256": "a9b11bf1fb65113a0f32d4ee8e295e8bfa1607ae9d2fb244043d3740cbb42c54"
+            "sha256": "583295901ceaddc4a36920bed6a39a710458c124347af40f6ccc30c4ac55efbb"
           },
           "description": "Remote add/sync command declarations and mode metadata."
         },
@@ -203,7 +203,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/cli/commands/agent.py",
-            "sha256": "4a2c928d7c3bfd84d1883c65dc71f2e9e545febc2a9f8235a58172fac0170bda"
+            "sha256": "bee8cabb2b0840785e2b67cff0c9c9f4643fdb35ded7bb816e0261ce1700d83a"
           },
           "description": "Agent command surface including mode selection and bootstrap status."
         }
@@ -247,7 +247,7 @@
           "pointer": {
             "kind": "file",
             "path": "docs/adr/ADR-0109-four-object-agent-work-state-contract.md",
-            "sha256": "c4fc13930268ad149a0d179cb0944c8a3236c24e3e03038dac5da3b91c219188"
+            "sha256": "6f30305eed2d1d9f4cc55508fd7014e81aa6846a0608015ea410175dc8fec981"
           },
           "description": "Accepted role-separation decision and bounded P17 qualification boundary."
         },
@@ -265,7 +265,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/tests/python/test_agent_work_state_contract.py",
-            "sha256": "2b1c013a49533d7a6c240b1f05d94c74dba45da0e6d439592ed8885aad7178ac"
+            "sha256": "af68539d3c968e192f5fcbcd9a2d27d2107d5a97c3d8af80ef5f13622de0649c"
           },
           "description": "Runtime CLI parity and fail-closed contract-schema checks."
         },
@@ -274,7 +274,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
-            "sha256": "c9f35d1a267181532952a9603de56d5b6342372ec1848a6ca5afcf841ad0b0b1"
+            "sha256": "91294bb5d359299e2deda1a12d5629b599aaf20d2147816bab9f92098b5c813b"
           },
           "description": "Agent collaboration-interface registration for the work-model query."
         }

--- a/developer/sdk/kfd/kfd-3-surfaces.json
+++ b/developer/sdk/kfd/kfd-3-surfaces.json
@@ -629,8 +629,68 @@
       }
     },
     {
+      "id": "kungfu.agent.work.export-authority",
+      "name": "kungfu agent work export-authority --json",
+      "kind": "cli-api-gui",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
+      "id": "kungfu.agent.work.import-authority",
+      "name": "kungfu agent work import-authority --file <bundle.json> [--execute] --json",
+      "kind": "cli-api-gui",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
       "id": "kungfu.agent.work.inspect",
       "name": "kungfu agent work inspect --ref <ref> --json",
+      "kind": "cli-api-gui",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
+      "id": "kungfu.agent.work.session",
+      "name": "kungfu agent work session --operation <compressibility|expand|project> --file <session.json> --json",
       "kind": "cli-api-gui",
       "participantProfile": "agent-or-developer",
       "state": "declared",

--- a/docs/adr/ADR-0109-four-object-agent-work-state-contract.md
+++ b/docs/adr/ADR-0109-four-object-agent-work-state-contract.md
@@ -4,8 +4,8 @@ doc_type: architecture-decision
 adr_id: ADR-0109
 decision_status: accepted
 implementation_status: staged
-implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/1026, https://github.com/kungfu-systems/kungfu/pull/1079, https://github.com/kungfu-systems/kungfu/pull/1081]
-qualification_refs: [framework/agent-work/kungfu-agent-work-state.contract.json, framework/agent-work/validate-profile.mjs, framework/agent-work/fixtures/manifest.json, scripts/check-agent-work-state-contract.test.mjs, framework/core/tests/python/test_agent_work_state_contract.py, framework/core/src/python/kungfu/agent/kfd3_api.registry.json]
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/1026, https://github.com/kungfu-systems/kungfu/pull/1079, https://github.com/kungfu-systems/kungfu/pull/1081, https://github.com/kungfu-systems/kungfu/pull/1091]
+qualification_refs: [framework/agent-work/kungfu-agent-work-state.contract.json, framework/agent-work/validate-profile.mjs, framework/agent-work/fixtures/manifest.json, framework/agent-work/kungfu-kfd-7-action-contract.json, framework/agent-work/kungfu-kfd-7-release-gate.json, framework/agent-work/evidence/kfd-7/, scripts/check-agent-work-state-contract.test.mjs, framework/core/tests/python/test_agent_work_state_contract.py, framework/core/tests/python/test_agent_work_profile_native.py, framework/core/src/python/kungfu/agent/kfd3_api.registry.json]
 review_state: self-reviewed
 sensitivity: public
 sources: [local-files, user-consensus]
@@ -18,7 +18,8 @@ last_reviewed: 2026-07-18
 
 # ADR-0109: Real-world agent work preserves four independently addressable roles
 
-- Status: accepted; provisional runtime Profile staged, P17 not qualified
+- Status: accepted; four-role contract v2 staged; KFD-7 Product Profile
+  qualified and activated against KFD alpha.35 at the retained review cut
 - Date: 2026-07-17
 - Category: Agent Work Profile / product contract / KFD-3
 - Related: [ADR-0033](ADR-0033-episode-causal-segment-object.md),
@@ -109,9 +110,10 @@ kungfu contract show agent-work-state --json
 The KFD-3 registry, command catalog, onboarding brief, and provider skills
 declare the agent entrypoint. Neither prose nor the CLI owns a second role
 definition. The bounded KFD-2 release claim audits only that this exact
-contract remains explicitly `P17 not-qualified`, exposes all `FO1`-`FO8`
-evidence debt, and preserves its residual non-claims. It does not upgrade the
-projection into qualification.
+contract preserves its explicit P17 status, exposes all `FO1`-`FO8` evidence
+debt, and retains its residual non-claims. The separate KFD-7 release-gate
+declaration qualifies the provisional product Action Profile against retained
+runtime evidence; it does not silently upgrade the wider welded contract.
 
 ### 6. Exact versions meet at a derived ActionBinding
 
@@ -160,20 +162,22 @@ runtime completion.
 
 ## Qualification boundary
 
-The contract establishes the public vocabulary, current implementation
-mappings, forbidden inferences, and P17 evidence plan. It does not pass P17.
-The contract reports every `FO1`-`FO8` state and residual evidence requirement;
-release qualification still needs persisted cross-role fixtures, an end-to-end
-dogfood loop, negative authority tests, progressive-disclosure usability,
-cross-surface parity, recovery and handoff, and Release Passport evidence.
+The welded Agent Work contract and the KFD-7 Product Profile have distinct
+qualification boundaries. The v2 contract closes the in-repository object
+schema and negative semantic fixtures while continuing to report its own P17
+status and remaining `FO1`-`FO8` debt.
 
-The v2 contract closes the in-repository object schema and negative semantic
-fixtures. It does not close native persistence, recovery, GUI/CLI workflow, or
-reality-pressure dogfood, so P17 remains `not-qualified`.
-
-The KFD Independent Action State work remains a non-normative candidate. This
-decision neither reserves a KFD number nor claims universal organizational
-ontology.
+The Kungfu KFD-7 Product Profile is bound to KFD alpha.35 and an exact
+implementation/evidence cut. Twelve retained categories cover
+positive and negative transitions, export/import and backend recovery, role
+deletion or fusion, Warrant decay, Atlas staleness, Pursuit and Episode
+lifecycle, concurrency, session round-trip refinement, complexity breakpoints,
+and context-insufficiency. The release declaration is `qualified` and its
+activation decision is `activate`, bound to
+[independent review 4728705815](https://github.com/kungfu-systems/kungfu/pull/1091#pullrequestreview-4728705815)
+at exact qualification commit `8f6eff198751af109ddbeead8db4390d35303880`.
+Those facts do not prove universal minimality, provider-wide correctness, or
+completion of the wider P17 program.
 
 ## Consequences
 

--- a/framework/agent-work/evidence/kfd-7/atlas-staleness-loss.json
+++ b/framework/agent-work/evidence/kfd-7/atlas-staleness-loss.json
@@ -1,0 +1,24 @@
+{
+  "schemaVersion": 1,
+  "contract": "kungfu-buildchain-kfd-7-evidence-report",
+  "profileId": "kungfu-kfd-7-action-profile",
+  "profileVersion": "0.1.0",
+  "stateMachineVersion": "0.1.0",
+  "sourceSha": "91a7a2b6f406e996b0b1d69421af260d69be3878",
+  "category": "atlas-staleness-loss",
+  "outcome": "pass",
+  "matchedExpectation": true,
+  "checks": [
+    { "id": "stale-transition-requires-retained-loss-root", "status": "pass" },
+    { "id": "stale-atlas-blocks-action-before-write", "status": "pass" },
+    { "id": "refresh-requires-source-and-loss-roots", "status": "pass" },
+    { "id": "refresh-covers-basis-revision", "status": "pass" }
+  ],
+  "observations": {
+    "unitSuite": "framework/core/tests/python/test_agent_work_state_contract.py",
+    "nativeSuite": "framework/core/tests/python/test_agent_work_profile_native.py",
+    "statePath": ["current", "stale", "current"],
+    "blockedFailureCode": "atlas-stale",
+    "writeOnBlockedAction": false
+  }
+}

--- a/framework/agent-work/evidence/kfd-7/backend-migration.json
+++ b/framework/agent-work/evidence/kfd-7/backend-migration.json
@@ -4,9 +4,9 @@
   "profileId": "kungfu-kfd-7-action-profile",
   "profileVersion": "0.1.0",
   "stateMachineVersion": "0.1.0",
-  "sourceSha": "466bdc9b089bc06362e0153b7e0d2950bf00f7b0",
+  "sourceSha": "91a7a2b6f406e996b0b1d69421af260d69be3878",
   "category": "backend-migration",
-  "outcome": "fail",
+  "outcome": "pass",
   "matchedExpectation": true,
   "checks": [
     {
@@ -15,10 +15,17 @@
     },
     {
       "id": "five-role-identity-conservation-witness",
-      "status": "fail"
+      "status": "pass"
+    },
+    {
+      "id": "file-rocksdb-file-rollback",
+      "status": "pass"
     }
   ],
   "observations": {
-    "retainedBoundary": "The shared storage migration mechanism exists, but no five-role Profile witness yet proves object, version, Cut, and ref identity conservation across backends."
+    "providers": ["content-addressed-file", "rocksdb"],
+    "preserved": ["five role object ids", "version roots", "Cut roots", "named ref roots and revisions", "authority bundle root"],
+    "testPath": "framework/core/tests/python/test_agent_work_profile_native.py",
+    "retainedBoundary": "The witness covers the embedded file-to-RocksDB cut, continued authority on RocksDB, and reverse-sync rollback to file; it does not claim cross-machine consensus."
   }
 }

--- a/framework/agent-work/evidence/kfd-7/cold-start-continuation.json
+++ b/framework/agent-work/evidence/kfd-7/cold-start-continuation.json
@@ -4,9 +4,9 @@
   "profileId": "kungfu-kfd-7-action-profile",
   "profileVersion": "0.1.0",
   "stateMachineVersion": "0.1.0",
-  "sourceSha": "466bdc9b089bc06362e0153b7e0d2950bf00f7b0",
+  "sourceSha": "91a7a2b6f406e996b0b1d69421af260d69be3878",
   "category": "cold-start-continuation",
-  "outcome": "fail",
+  "outcome": "pass",
   "matchedExpectation": true,
   "checks": [
     {
@@ -15,11 +15,18 @@
     },
     {
       "id": "clean-home-continuation-from-qualified-export",
-      "status": "fail"
+      "status": "pass"
+    },
+    {
+      "id": "clean-home-next-revision",
+      "status": "pass"
     }
   ],
   "observations": {
-    "lossCode": "profile-authority-unavailable",
-    "retainedBoundary": "A fresh home can bootstrap a Profile, but it cannot continue an earlier Profile without a qualified exported Fact authority bundle."
+    "bundleSchema": "kungfu.fact-authority-bundle/v1",
+    "sourceRevision": 2,
+    "continuedRevision": 3,
+    "testPath": "framework/core/tests/python/test_agent_work_profile_native.py",
+    "retainedBoundary": "The clean home receives only the qualified authority bundle; prior chat, the old runtime home, and path identity are not inputs."
   }
 }

--- a/framework/agent-work/evidence/kfd-7/concurrency-retry-compensation.json
+++ b/framework/agent-work/evidence/kfd-7/concurrency-retry-compensation.json
@@ -1,0 +1,25 @@
+{
+  "schemaVersion": 1,
+  "contract": "kungfu-buildchain-kfd-7-evidence-report",
+  "profileId": "kungfu-kfd-7-action-profile",
+  "profileVersion": "0.1.0",
+  "stateMachineVersion": "0.1.0",
+  "sourceSha": "91a7a2b6f406e996b0b1d69421af260d69be3878",
+  "category": "concurrency-retry-compensation",
+  "outcome": "pass",
+  "matchedExpectation": true,
+  "checks": [
+    { "id": "stale-ref-cas-denied-before-write", "status": "pass" },
+    { "id": "idempotent-retry-returns-original-receipt", "status": "pass" },
+    { "id": "mismatched-replay-denied", "status": "pass" },
+    { "id": "episode-compensation-preserves-original", "status": "pass" }
+  ],
+  "observations": {
+    "suites": [
+      "framework/core/tests/python/test_agent_work_state_contract.py",
+      "framework/core/tests/storage-node-binding.test.js"
+    ],
+    "authorityBoundary": "named-ref compare-and-swap plus immutable receipts",
+    "compensationModel": "append-only successor mapping"
+  }
+}

--- a/framework/agent-work/evidence/kfd-7/context-insufficiency-counterexample.json
+++ b/framework/agent-work/evidence/kfd-7/context-insufficiency-counterexample.json
@@ -1,0 +1,25 @@
+{
+  "schemaVersion": 1,
+  "contract": "kungfu-buildchain-kfd-7-evidence-report",
+  "profileId": "kungfu-kfd-7-action-profile",
+  "profileVersion": "0.1.0",
+  "stateMachineVersion": "0.1.0",
+  "sourceSha": "91a7a2b6f406e996b0b1d69421af260d69be3878",
+  "category": "context-insufficiency-counterexample",
+  "outcome": "pass",
+  "matchedExpectation": true,
+  "checks": [
+    { "id": "visible-fact-payload-held-constant", "status": "pass" },
+    { "id": "direction-changes-valid-action-set", "status": "pass" },
+    { "id": "authority-changes-valid-action-set", "status": "pass" },
+    { "id": "freshness-changes-valid-action-set", "status": "pass" }
+  ],
+  "observations": {
+    "suite": "framework/core/tests/python/test_agent_work_state_contract.py",
+    "baselineActions": ["episode:seal", "fact:successor"],
+    "differentDirectionActions": ["episode:seal"],
+    "weakerAuthorityActions": ["fact:successor"],
+    "staleContextActions": [],
+    "conclusion": "context-alone-is-not-sufficient"
+  }
+}

--- a/framework/agent-work/evidence/kfd-7/episode-replay-contraction.json
+++ b/framework/agent-work/evidence/kfd-7/episode-replay-contraction.json
@@ -1,0 +1,25 @@
+{
+  "schemaVersion": 1,
+  "contract": "kungfu-buildchain-kfd-7-evidence-report",
+  "profileId": "kungfu-kfd-7-action-profile",
+  "profileVersion": "0.1.0",
+  "stateMachineVersion": "0.1.0",
+  "sourceSha": "91a7a2b6f406e996b0b1d69421af260d69be3878",
+  "category": "episode-replay-contraction",
+  "outcome": "pass",
+  "matchedExpectation": true,
+  "checks": [
+    { "id": "seal-binds-episode-and-causal-roots", "status": "pass" },
+    { "id": "equal-endpoint-does-not-imply-causal-equivalence", "status": "pass" },
+    { "id": "causal-root-mismatch-denied-before-write", "status": "pass" },
+    { "id": "exact-replay-reconciles", "status": "pass" }
+  ],
+  "observations": {
+    "unitSuite": "framework/core/tests/python/test_agent_work_state_contract.py",
+    "nativeSuite": "framework/core/tests/python/test_agent_work_profile_native.py",
+    "beforeEqualsAfter": true,
+    "mismatchFailureCode": "replay-mismatch",
+    "writeOnMismatch": false,
+    "exactReplayState": "reconciled"
+  }
+}

--- a/framework/agent-work/evidence/kfd-7/export-import-rebuild.json
+++ b/framework/agent-work/evidence/kfd-7/export-import-rebuild.json
@@ -4,9 +4,9 @@
   "profileId": "kungfu-kfd-7-action-profile",
   "profileVersion": "0.1.0",
   "stateMachineVersion": "0.1.0",
-  "sourceSha": "466bdc9b089bc06362e0153b7e0d2950bf00f7b0",
+  "sourceSha": "91a7a2b6f406e996b0b1d69421af260d69be3878",
   "category": "export-import-rebuild",
-  "outcome": "fail",
+  "outcome": "pass",
   "matchedExpectation": true,
   "checks": [
     {
@@ -15,11 +15,17 @@
     },
     {
       "id": "qualified-fact-export-import-bundle",
-      "status": "fail"
+      "status": "pass"
+    },
+    {
+      "id": "tampered-bundle-fails-before-write",
+      "status": "pass"
     }
   ],
   "observations": {
-    "lossCode": "profile-authority-not-exported",
-    "retainedBoundary": "The Fact journal, body namespace, refs, and exact Cuts are not yet packaged as one qualified export/import bundle."
+    "bundleSchema": "kungfu.fact-authority-bundle/v1",
+    "authority": "yijinjing-hana-pod-journal",
+    "testPath": "framework/core/tests/python/test_agent_work_profile_native.py",
+    "retainedBoundary": "The bundle replays through the existing native Fact kernel; it does not create a second journal, CAS, schema registry, or query engine."
   }
 }

--- a/framework/agent-work/evidence/kfd-7/negative-invalid-transition.json
+++ b/framework/agent-work/evidence/kfd-7/negative-invalid-transition.json
@@ -4,7 +4,7 @@
   "profileId": "kungfu-kfd-7-action-profile",
   "profileVersion": "0.1.0",
   "stateMachineVersion": "0.1.0",
-  "sourceSha": "466bdc9b089bc06362e0153b7e0d2950bf00f7b0",
+  "sourceSha": "91a7a2b6f406e996b0b1d69421af260d69be3878",
   "kind": "negative",
   "outcome": "fail",
   "matchedExpectation": true,
@@ -24,7 +24,7 @@
   ],
   "observations": {
     "suite": "framework/core/tests/python/test_agent_work_state_contract.py",
-    "testsPassed": 10,
+    "testsPassed": 25,
     "writeOnDenied": false
   }
 }

--- a/framework/agent-work/evidence/kfd-7/positive-native-bootstrap.json
+++ b/framework/agent-work/evidence/kfd-7/positive-native-bootstrap.json
@@ -4,7 +4,7 @@
   "profileId": "kungfu-kfd-7-action-profile",
   "profileVersion": "0.1.0",
   "stateMachineVersion": "0.1.0",
-  "sourceSha": "466bdc9b089bc06362e0153b7e0d2950bf00f7b0",
+  "sourceSha": "91a7a2b6f406e996b0b1d69421af260d69be3878",
   "kind": "positive",
   "outcome": "pass",
   "matchedExpectation": true,

--- a/framework/agent-work/evidence/kfd-7/pursuit-continuity-settlement.json
+++ b/framework/agent-work/evidence/kfd-7/pursuit-continuity-settlement.json
@@ -1,0 +1,24 @@
+{
+  "schemaVersion": 1,
+  "contract": "kungfu-buildchain-kfd-7-evidence-report",
+  "profileId": "kungfu-kfd-7-action-profile",
+  "profileVersion": "0.1.0",
+  "stateMachineVersion": "0.1.0",
+  "sourceSha": "91a7a2b6f406e996b0b1d69421af260d69be3878",
+  "category": "pursuit-continuity-settlement",
+  "outcome": "pass",
+  "matchedExpectation": true,
+  "checks": [
+    { "id": "branch-binds-exact-source-cut", "status": "pass" },
+    { "id": "branch-starts-independent-ref-at-revision-one", "status": "pass" },
+    { "id": "source-ref-remains-unchanged-by-branch", "status": "pass" },
+    { "id": "abandonment-retains-settlement-root-and-outcome", "status": "pass" }
+  ],
+  "observations": {
+    "unitSuite": "framework/core/tests/python/test_agent_work_state_contract.py",
+    "nativeSuite": "framework/core/tests/python/test_agent_work_profile_native.py",
+    "branchRef": "profiles/kfd-7/native-branch",
+    "branchInitialRevision": 1,
+    "terminalState": "abandoned"
+  }
+}

--- a/framework/agent-work/evidence/kfd-7/role-deletion-or-fusion.json
+++ b/framework/agent-work/evidence/kfd-7/role-deletion-or-fusion.json
@@ -1,0 +1,27 @@
+{
+  "schemaVersion": 1,
+  "contract": "kungfu-buildchain-kfd-7-evidence-report",
+  "profileId": "kungfu-kfd-7-action-profile",
+  "profileVersion": "0.1.0",
+  "stateMachineVersion": "0.1.0",
+  "sourceSha": "91a7a2b6f406e996b0b1d69421af260d69be3878",
+  "category": "role-deletion-or-fusion",
+  "outcome": "pass",
+  "matchedExpectation": true,
+  "checks": [
+    { "id": "each-of-five-role-deletions-denied-before-write", "status": "pass" },
+    { "id": "representative-role-fusions-denied-before-write", "status": "pass" },
+    { "id": "context-only-rival-loses-decision-relevant-distinctions", "status": "pass" },
+    { "id": "ordinary-successor-changes-one-role-version", "status": "pass" }
+  ],
+  "observations": {
+    "suite": "framework/core/tests/python/test_agent_work_state_contract.py",
+    "deletionVectors": 5,
+    "fusionVectors": 5,
+    "rivalModel": "context-only same-visible-task projection",
+    "rivalCounterexamples": ["fact-basis", "episode-causality", "pursuit-state", "atlas-freshness", "warrant-scope"],
+    "structuralDenialWrites": 0,
+    "successorChangedRoleCount": 1,
+    "costBoundary": "bootstrap retains five logical roles; ordinary successors append only the changed role version plus one Cut and ref CAS"
+  }
+}

--- a/framework/agent-work/evidence/kfd-7/session-complexity-breakpoint.json
+++ b/framework/agent-work/evidence/kfd-7/session-complexity-breakpoint.json
@@ -1,0 +1,25 @@
+{
+  "schemaVersion": 1,
+  "contract": "kungfu-buildchain-kfd-7-evidence-report",
+  "profileId": "kungfu-kfd-7-action-profile",
+  "profileVersion": "0.1.0",
+  "stateMachineVersion": "0.1.0",
+  "sourceSha": "91a7a2b6f406e996b0b1d69421af260d69be3878",
+  "category": "session-complexity-breakpoint",
+  "outcome": "pass",
+  "matchedExpectation": true,
+  "checks": [
+    { "id": "pursuit-alternatives-break-compression", "status": "pass" },
+    { "id": "atlas-staleness-breaks-compression", "status": "pass" },
+    { "id": "warrant-revocation-breaks-compression", "status": "pass" },
+    { "id": "multiple-episodes-break-compression", "status": "pass" },
+    { "id": "fact-branches-break-compression", "status": "pass" },
+    { "id": "lossy-projection-rejected", "status": "pass" }
+  ],
+  "observations": {
+    "suite": "framework/core/tests/python/test_agent_work_state_contract.py",
+    "revealedRoles": ["fact", "episode", "pursuit", "atlas", "warrant"],
+    "failureCode": "session-complexity-breakpoint",
+    "projectionWrites": 0
+  }
+}

--- a/framework/agent-work/evidence/kfd-7/session-round-trip-refinement.json
+++ b/framework/agent-work/evidence/kfd-7/session-round-trip-refinement.json
@@ -1,0 +1,29 @@
+{
+  "schemaVersion": 1,
+  "contract": "kungfu-buildchain-kfd-7-evidence-report",
+  "profileId": "kungfu-kfd-7-action-profile",
+  "profileVersion": "0.1.0",
+  "stateMachineVersion": "0.1.0",
+  "sourceSha": "91a7a2b6f406e996b0b1d69421af260d69be3878",
+  "category": "session-round-trip-refinement",
+  "outcome": "pass",
+  "matchedExpectation": true,
+  "checks": [
+    { "id": "compressible-session-expands", "status": "pass" },
+    { "id": "all-five-decision-observations-retained", "status": "pass" },
+    { "id": "project-expand-round-trip-equals-session", "status": "pass" },
+    { "id": "cli-python-projection-parity", "status": "pass" }
+  ],
+  "observations": {
+    "suite": "framework/core/tests/python/test_agent_work_state_contract.py",
+    "implementation": "framework/core/src/python/kungfu/agent/work_profile.py",
+    "dimensions": [
+      "direction",
+      "perspective-boundary",
+      "effective-authority",
+      "causal-process",
+      "admitted-result"
+    ],
+    "installedKfd": "1.0.0-alpha.35"
+  }
+}

--- a/framework/agent-work/evidence/kfd-7/warrant-decay-revocation.json
+++ b/framework/agent-work/evidence/kfd-7/warrant-decay-revocation.json
@@ -1,0 +1,24 @@
+{
+  "schemaVersion": 1,
+  "contract": "kungfu-buildchain-kfd-7-evidence-report",
+  "profileId": "kungfu-kfd-7-action-profile",
+  "profileVersion": "0.1.0",
+  "stateMachineVersion": "0.1.0",
+  "sourceSha": "91a7a2b6f406e996b0b1d69421af260d69be3878",
+  "category": "warrant-decay-revocation",
+  "outcome": "pass",
+  "matchedExpectation": true,
+  "checks": [
+    { "id": "attenuation-is-strict-subset", "status": "pass" },
+    { "id": "attenuation-cannot-extend-validity", "status": "pass" },
+    { "id": "out-of-scope-action-denied-before-write", "status": "pass" },
+    { "id": "revoked-warrant-denies-later-action", "status": "pass" }
+  ],
+  "observations": {
+    "unitSuite": "framework/core/tests/python/test_agent_work_state_contract.py",
+    "nativeSuite": "framework/core/tests/python/test_agent_work_profile_native.py",
+    "nativeReceiptStatuses": ["accepted", "accepted", "denied"],
+    "denialCodes": ["unauthorized", "warrant-revoked"],
+    "writeOnDenied": false
+  }
+}

--- a/framework/agent-work/kungfu-kfd-7-action-contract.json
+++ b/framework/agent-work/kungfu-kfd-7-action-contract.json
@@ -1,14 +1,14 @@
 {
   "$schema": "https://kfd.libkungfu.dev/schemas/kfd-7/action-contract.schema.json",
-  "schemaVersion": 1,
+  "schemaVersion": 2,
   "contract": "kfd-7-action-contract",
   "standard": "kfd-7",
   "profile": {
     "id": "kungfu-kfd-7-action-profile",
     "version": "0.1.0",
     "product": "kungfu",
-    "implementation": "source:framework/agent-work/kungfu-kfd-7-action-contract.json",
-    "qualificationStatus": "provisional"
+    "implementation": "git+https://github.com/kungfu-systems/kungfu.git@91a7a2b6f406e996b0b1d69421af260d69be3878#framework/core/src/python/kungfu/agent/work_profile.py",
+    "qualificationStatus": "qualified"
   },
   "roles": [
     {
@@ -124,6 +124,19 @@
       "residualRisks": ["compensation may not reverse every external consequence"]
     },
     {
+      "id": "replay-episode",
+      "subjectRole": "episode",
+      "operation": "reconcile",
+      "from": "sealed",
+      "to": "reconciled",
+      "preconditions": ["Episode identity, before and after Cuts, causal root, and sealed content root remain exact"],
+      "effect": "reconcile only an exact replay and reject equal-endpoint causal substitutions",
+      "receipt": "kungfu.kfd7.profile-action-receipt/v1",
+      "evidence": ["sealed Episode roots and replay comparison receipt"],
+      "denialReasons": ["replay-mismatch", "invalid-request"],
+      "residualRisks": ["external side effects remain outside the retained causal record"]
+    },
+    {
       "id": "continue-pursuit",
       "subjectRole": "pursuit",
       "operation": "advance",
@@ -135,6 +148,19 @@
       "evidence": ["Pursuit version ancestry and exact basis Cut"],
       "denialReasons": ["atlas-stale", "warrant-expired", "unauthorized"],
       "residualRisks": ["continuation does not imply eventual completion"]
+    },
+    {
+      "id": "branch-pursuit",
+      "subjectRole": "pursuit",
+      "operation": "profile-extension",
+      "from": "active",
+      "to": "active",
+      "preconditions": ["the source Cut is exact and the destination ref is absent at revision zero"],
+      "effect": "append a Pursuit successor on an independent ref without moving the source ref",
+      "receipt": "kungfu.kfd7.profile-action-receipt/v1",
+      "evidence": ["source Cut, branch reason root, destination ref receipt, and unchanged source ref"],
+      "denialReasons": ["profile-state-mismatch", "invalid-transition", "stale-ref"],
+      "residualRisks": ["branch reconciliation remains an explicit later decision"]
     },
     {
       "id": "complete-pursuit",
@@ -251,12 +277,46 @@
     "child-authority-from-parent",
     "causal-equivalence-from-equal-endpoints"
   ],
+  "qualificationBasis": {
+    "sessionRoundTrip": {
+      "theoremId": "kfd-7-session-round-trip-preservation",
+      "theoremVersion": 1,
+      "source": "docs/KFD-7-formal.md#session-round-trip-preservation-theorem",
+      "applicability": "session-compressible-only",
+      "semanticDimensions": [
+        "direction",
+        "perspective-boundary",
+        "effective-authority",
+        "causal-process",
+        "admitted-result"
+      ],
+      "implementationRefs": {
+        "expand": "source:framework/core/src/python/kungfu/agent/work_profile.py#expand_session@91a7a2b6f406e996b0b1d69421af260d69be3878",
+        "project": "source:framework/core/src/python/kungfu/agent/work_profile.py#project_session@91a7a2b6f406e996b0b1d69421af260d69be3878",
+        "compressibilityPredicate": "source:framework/core/src/python/kungfu/agent/work_profile.py#session_compressibility@91a7a2b6f406e996b0b1d69421af260d69be3878"
+      }
+    },
+    "contextInsufficiency": {
+      "corollaryId": "kfd-7-context-insufficiency",
+      "corollaryVersion": 1,
+      "source": "docs/KFD-7-formal.md#context-insufficiency-corollary",
+      "conclusion": "context-alone-is-not-sufficient"
+    },
+    "evidenceCategories": {
+      "roundTripRefinement": "session-round-trip-refinement",
+      "complexityBreakpoint": "session-complexity-breakpoint",
+      "contextCounterexample": "context-insufficiency-counterexample"
+    }
+  },
   "evidenceObligations": [
     {
       "category": "role-deletion-or-fusion",
       "status": "passed",
-      "artifactRefs": ["framework/core/tests/python/test_agent_work_state_contract.py"],
-      "residualRisk": "long-period role deletion dogfood remains for final qualification"
+      "artifactRefs": [
+        "framework/core/tests/python/test_agent_work_state_contract.py",
+        "framework/agent-work/evidence/kfd-7/role-deletion-or-fusion.json"
+      ],
+      "residualRisk": "cross-domain minimality remains a KFD activation gate; this evidence is bounded to the Kungfu Profile"
     },
     {
       "category": "invalid-transition",
@@ -266,68 +326,124 @@
     },
     {
       "category": "export-import-rebuild",
-      "status": "planned",
-      "artifactRefs": [],
-      "residualRisk": "Profile-specific retained rebuild evidence is not yet sealed"
+      "status": "passed",
+      "artifactRefs": [
+        "framework/core/tests/python/test_agent_work_profile_native.py",
+        "framework/agent-work/evidence/kfd-7/export-import-rebuild.json"
+      ],
+      "residualRisk": "installed distribution and cross-version bundle compatibility remain separate release gates"
     },
     {
       "category": "backend-migration",
-      "status": "planned",
-      "artifactRefs": [],
-      "residualRisk": "the shared kernel migration exists but the five-role witness is pending"
+      "status": "passed",
+      "artifactRefs": [
+        "framework/core/tests/python/test_agent_work_profile_native.py",
+        "framework/agent-work/evidence/kfd-7/backend-migration.json"
+      ],
+      "residualRisk": "cross-machine consensus is outside the embedded two-provider witness"
     },
     {
       "category": "concurrency-retry-compensation",
       "status": "passed",
-      "artifactRefs": ["framework/core/tests/python/test_agent_work_state_contract.py", "framework/core/tests/storage-node-binding.test.js"],
+      "artifactRefs": [
+        "framework/core/tests/python/test_agent_work_state_contract.py",
+        "framework/core/tests/storage-node-binding.test.js",
+        "framework/agent-work/evidence/kfd-7/concurrency-retry-compensation.json"
+      ],
       "residualRisk": "multi-process stress and compensation dogfood remain"
     },
     {
       "category": "warrant-decay-revocation",
       "status": "passed",
-      "artifactRefs": ["framework/core/tests/python/test_agent_work_state_contract.py"],
+      "artifactRefs": [
+        "framework/core/tests/python/test_agent_work_state_contract.py",
+        "framework/core/tests/python/test_agent_work_profile_native.py",
+        "framework/agent-work/evidence/kfd-7/warrant-decay-revocation.json"
+      ],
       "residualRisk": "issuer diversity and remote enforcement are outside this witness"
     },
     {
       "category": "atlas-staleness-loss",
       "status": "passed",
-      "artifactRefs": ["framework/core/tests/python/test_agent_work_state_contract.py"],
-      "residualRisk": "lossy export evidence remains pending"
+      "artifactRefs": [
+        "framework/core/tests/python/test_agent_work_state_contract.py",
+        "framework/core/tests/python/test_agent_work_profile_native.py",
+        "framework/agent-work/evidence/kfd-7/atlas-staleness-loss.json"
+      ],
+      "residualRisk": "conflict and supersession remain separate from the retained stale-loss-refresh path"
     },
     {
       "category": "pursuit-continuity-settlement",
       "status": "passed",
-      "artifactRefs": ["framework/core/tests/python/test_agent_work_state_contract.py"],
+      "artifactRefs": [
+        "framework/core/tests/python/test_agent_work_state_contract.py",
+        "framework/core/tests/python/test_agent_work_profile_native.py",
+        "framework/agent-work/evidence/kfd-7/pursuit-continuity-settlement.json"
+      ],
       "residualRisk": "independent completion review remains a final qualification gate"
     },
     {
       "category": "episode-replay-contraction",
-      "status": "planned",
-      "artifactRefs": [],
-      "residualRisk": "real Episode replay and contraction evidence is pending"
+      "status": "passed",
+      "artifactRefs": [
+        "framework/core/tests/python/test_agent_work_state_contract.py",
+        "framework/core/tests/python/test_agent_work_profile_native.py",
+        "framework/agent-work/evidence/kfd-7/episode-replay-contraction.json"
+      ],
+      "residualRisk": "the retained Profile mapping does not replace full Episode subsystem qualification"
     },
     {
       "category": "cold-start-continuation",
-      "status": "planned",
-      "artifactRefs": [],
-      "residualRisk": "clean-home installed-artifact continuation is pending"
+      "status": "passed",
+      "artifactRefs": [
+        "framework/core/tests/python/test_agent_work_profile_native.py",
+        "framework/agent-work/evidence/kfd-7/cold-start-continuation.json"
+      ],
+      "residualRisk": "installed-artifact parity is bound separately to @kungfu-tech/kfd@1.0.0-alpha.35"
+    },
+    {
+      "category": "session-round-trip-refinement",
+      "status": "passed",
+      "artifactRefs": [
+        "framework/core/tests/python/test_agent_work_state_contract.py",
+        "framework/agent-work/evidence/kfd-7/session-round-trip-refinement.json"
+      ],
+      "residualRisk": "the theorem applies only while the session-compressibility predicate holds"
+    },
+    {
+      "category": "session-complexity-breakpoint",
+      "status": "passed",
+      "artifactRefs": [
+        "framework/core/tests/python/test_agent_work_state_contract.py",
+        "framework/agent-work/evidence/kfd-7/session-complexity-breakpoint.json"
+      ],
+      "residualRisk": "new product complexity dimensions require new explicit breakpoint witnesses"
+    },
+    {
+      "category": "context-insufficiency-counterexample",
+      "status": "passed",
+      "artifactRefs": [
+        "framework/core/tests/python/test_agent_work_state_contract.py",
+        "framework/agent-work/evidence/kfd-7/context-insufficiency-counterexample.json"
+      ],
+      "residualRisk": "the retained vectors cover direction, authority, and freshness rather than every future policy input"
     }
   ],
   "nonClaims": [
-    "This provisional Kungfu Product Profile does not activate or adopt KFD-7.",
+    "This activation is bounded to the declared Kungfu Product Profile and does not establish universal KFD-7 minimality.",
     "Profile states are product vocabulary rather than universal KFD enums.",
-    "Runtime unit evidence is not a release qualification or authority cutover."
+    "Runtime unit evidence alone is not a release qualification or authority cutover."
   ],
   "extensions": [],
   "activation": {
-    "decision": "pending",
-    "evidenceCut": "pending-kungfu-runtime-project-cut",
-    "independentReview": "required-after-runtime-dogfood",
+    "decision": "activate",
+    "evidenceCut": "git:implementation@91a7a2b6f406e996b0b1d69421af260d69be3878+qualification@8f6eff198751af109ddbeead8db4390d35303880+buildchain@f5a591fc79b84ba1b5809f2523060bcc4fd4739e+npm:@kungfu-tech/kfd@1.0.0-alpha.35",
+    "independentReview": "https://github.com/kungfu-systems/kungfu/pull/1091#pullrequestreview-4728705815",
     "productWitnesses": [
       "framework/agent-work/kungfu-kfd-7-profile-action.schema.json",
       "framework/agent-work/kungfu-kfd-7-profile-receipt.schema.json",
       "framework/core/tests/python/test_agent_work_state_contract.py"
     ],
-    "residualRisk": "Export/import, backend migration, Episode replay, clean-home, installed-artifact parity, and independent review are not yet complete."
+    "residualRisk": "Activation is product-scoped; universal minimality, provider-wide correctness, and completion of the wider P17 program remain unclaimed."
   }
 }

--- a/framework/agent-work/kungfu-kfd-7-profile-action.schema.json
+++ b/framework/agent-work/kungfu-kfd-7-profile-action.schema.json
@@ -36,6 +36,7 @@
             "compensate",
             "reconcile",
             "continue",
+            "branch",
             "pause",
             "complete",
             "abandon",

--- a/framework/agent-work/kungfu-kfd-7-release-gate.json
+++ b/framework/agent-work/kungfu-kfd-7-release-gate.json
@@ -8,7 +8,7 @@
     "stateMachineVersion": "0.1.0",
     "actionContract": {
       "path": "framework/agent-work/kungfu-kfd-7-action-contract.json",
-      "sha256": "68eb48c73dd5f4e999ea80feeff8f4423b6dfb87fb392253db902812f8f81048"
+      "sha256": "b3d788344e93518bb4fecac6fea05a6fea87707c6325e50bcf01980492309ce0"
     },
     "verifierReport": {
       "path": "framework/agent-work/evidence/kfd-7/kfd-verifier.json",
@@ -16,14 +16,14 @@
     }
   },
   "source": {
-    "sha": "466bdc9b089bc06362e0153b7e0d2950bf00f7b0"
+    "sha": "91a7a2b6f406e996b0b1d69421af260d69be3878"
   },
   "surfaces": [
     {
       "id": "agent-work-state-contract",
       "sourcePath": "framework/agent-work/kungfu-agent-work-state.contract.json",
       "artifactPath": "config/kungfu-agent-work-state.contract.json",
-      "sha256": "e1b813a4057a437e8998e5bca3f1f21fcf002d3509a035d13345ceefedbb706d"
+      "sha256": "e89bdbeef7b3015869e27b7a5fb010fd2a697a925f4690cc8dadafd55cf83b20"
     }
   ],
   "testEvidence": [
@@ -32,51 +32,103 @@
       "kind": "positive",
       "expectedOutcome": "pass",
       "path": "framework/agent-work/evidence/kfd-7/positive-native-bootstrap.json",
-      "sha256": "82119283a5841558b43ef7396425132c7e04d0b3899e005e7930cea4a23133fd"
+      "sha256": "d9b2b2b53a522a153d26b8970476f8585b2d6496e08ed77c0f124c1c18070152"
     },
     {
       "id": "invalid-transition",
       "kind": "negative",
       "expectedOutcome": "fail",
       "path": "framework/agent-work/evidence/kfd-7/negative-invalid-transition.json",
-      "sha256": "3ea894af6c08faf8357ce8f67eedc2951efd05243a1f3258be9088e718e959ff"
+      "sha256": "462246bd0724e4bc965bf51baae3a8b98398eaaed059fbd672c52d4269b80283"
     }
   ],
   "experiments": [
     {
       "id": "export-import-rebuild",
       "category": "export-import-rebuild",
-      "expectedOutcome": "fail",
+      "expectedOutcome": "pass",
       "path": "framework/agent-work/evidence/kfd-7/export-import-rebuild.json",
-      "sha256": "b04431f51074219289b1c3daac316feb0dc21d6a57df23f6286c45ddf732c222"
+      "sha256": "aca5911ae2d8dd4e552c278195dff5fbbc72832dd904808fa11df62bdf3ac19e"
     },
     {
       "id": "backend-migration",
       "category": "backend-migration",
-      "expectedOutcome": "fail",
+      "expectedOutcome": "pass",
       "path": "framework/agent-work/evidence/kfd-7/backend-migration.json",
-      "sha256": "8bcf3cabd3fa3d4f9fd2fe25a2bd08c9b07dcdf486296bebd695bcd12e288e80"
+      "sha256": "b86e6639df2312b74c0d76b63c98e09dd21b28e2a24d065eb49fc5d3ef40dd80"
     },
     {
       "id": "cold-start-continuation",
       "category": "cold-start-continuation",
-      "expectedOutcome": "fail",
+      "expectedOutcome": "pass",
       "path": "framework/agent-work/evidence/kfd-7/cold-start-continuation.json",
-      "sha256": "1423aa513bd576807f4a2dc9510ed30e49e4085298c42fb03d20fb2eb7a691af"
-    }
-  ],
-  "residualRisk": [
+      "sha256": "0bfa131c66264269f31350ddbbe98088a6f44242d2a5e0b34d33b7925b7b9d93"
+    },
     {
-      "id": "kfd-7-runtime-qualification-pending",
-      "definedBy": "https://kfd.libkungfu.dev/schemas/kfd-2/trust-taxonomy.schema.json#/$defs/residualRisk",
-      "riskType": "natural-language-semantic-risk",
-      "trustImpact": "downgrade-warning",
-      "machineProvability": "not-machine-verifiable",
-      "agentAction": "semantic-review-required",
-      "reason": "The Profile has retained runtime evidence, but export/import, backend migration, clean-home continuation, and independent activation review remain incomplete.",
-      "owner": "kungfu-systems/kungfu"
+      "id": "role-deletion-or-fusion",
+      "category": "role-deletion-or-fusion",
+      "expectedOutcome": "pass",
+      "path": "framework/agent-work/evidence/kfd-7/role-deletion-or-fusion.json",
+      "sha256": "cf0e8d3b86893ce8f8dd4fc767f9e3b2d836b53427d62f07b5d30b40f3d05b8a"
+    },
+    {
+      "id": "warrant-decay-revocation",
+      "category": "warrant-decay-revocation",
+      "expectedOutcome": "pass",
+      "path": "framework/agent-work/evidence/kfd-7/warrant-decay-revocation.json",
+      "sha256": "0af2b521111d6ce905f8bc72663eee34ad15a0b5255a6577ecd2bc11333f2ce4"
+    },
+    {
+      "id": "atlas-staleness-loss",
+      "category": "atlas-staleness-loss",
+      "expectedOutcome": "pass",
+      "path": "framework/agent-work/evidence/kfd-7/atlas-staleness-loss.json",
+      "sha256": "dee2962750bfd9620a23799b3710476eaf95c5040caf15a2ca9edf0ef2944341"
+    },
+    {
+      "id": "pursuit-continuity-settlement",
+      "category": "pursuit-continuity-settlement",
+      "expectedOutcome": "pass",
+      "path": "framework/agent-work/evidence/kfd-7/pursuit-continuity-settlement.json",
+      "sha256": "1c5c9753f23000362c0f64adc9fe45d37f7cb7e1ef5f596d84c9b3d636d46c98"
+    },
+    {
+      "id": "episode-replay-contraction",
+      "category": "episode-replay-contraction",
+      "expectedOutcome": "pass",
+      "path": "framework/agent-work/evidence/kfd-7/episode-replay-contraction.json",
+      "sha256": "c9aadf59dc91654ddf8376455e3346efc6c16fd6d9f65f15aa395a505ca7d2a4"
+    },
+    {
+      "id": "concurrency-retry-compensation",
+      "category": "concurrency-retry-compensation",
+      "expectedOutcome": "pass",
+      "path": "framework/agent-work/evidence/kfd-7/concurrency-retry-compensation.json",
+      "sha256": "27ae67f3878dede97f4b4ca049684d0179a5981606897384f2c2322117bc14fe"
+    },
+    {
+      "id": "session-round-trip-refinement",
+      "category": "session-round-trip-refinement",
+      "expectedOutcome": "pass",
+      "path": "framework/agent-work/evidence/kfd-7/session-round-trip-refinement.json",
+      "sha256": "08cf2160a6358a64a7490838da92b5ec7978a46a5e38afd847b511bd71836db6"
+    },
+    {
+      "id": "session-complexity-breakpoint",
+      "category": "session-complexity-breakpoint",
+      "expectedOutcome": "pass",
+      "path": "framework/agent-work/evidence/kfd-7/session-complexity-breakpoint.json",
+      "sha256": "6f7e2e62c3c1e496c07fe237c178cfbea9cd6dc0a630608d6a505a303c737add"
+    },
+    {
+      "id": "context-insufficiency-counterexample",
+      "category": "context-insufficiency-counterexample",
+      "expectedOutcome": "pass",
+      "path": "framework/agent-work/evidence/kfd-7/context-insufficiency-counterexample.json",
+      "sha256": "5b84f5eedaa926f0a0767125612f01f7ee6fed738a4d8e736ceba7c621725e06"
     }
   ],
+  "residualRisk": [],
   "responsibility": {
     "profileOwner": "kungfu-systems/kungfu",
     "evidenceOwner": "Kungfu runtime and product test suites",
@@ -84,6 +136,6 @@
   },
   "nonClaims": [
     "A passing evidence-closure check does not prove real-world work quality.",
-    "This provisional declaration does not activate KFD-7 or qualify the Kungfu Product Profile."
+    "Activation is bounded to the declared Kungfu Product Profile and does not establish universal KFD-7 minimality."
   ]
 }

--- a/framework/core/src/libkungfu/src/runtime/storage/fact_kernel.cpp
+++ b/framework/core/src/libkungfu/src/runtime/storage/fact_kernel.cpp
@@ -7,6 +7,7 @@
 #include <filesystem>
 #include <map>
 #include <memory>
+#include <random>
 #include <regex>
 #include <set>
 #include <stdexcept>
@@ -370,6 +371,15 @@ std::string writer_lock_path(const std::string &runtime_dir) {
   return (fs::path(target->locator->layout_dir(target, layout::JOURNAL, true)) / "writer.lock").string();
 }
 
+struct kernel_authority_record {
+  uint32_t tag = 0;
+  uint64_t sequence = 0;
+  std::string key;
+  std::string record_root;
+  nlohmann::json document = nlohmann::json::object();
+  nlohmann::json receipt = nlohmann::json::object();
+};
+
 struct kernel_state {
   uint64_t next_sequence = 1;
   size_t unknown_records = 0;
@@ -377,10 +387,12 @@ struct kernel_state {
   std::map<std::string, nlohmann::json> versions;
   std::map<std::string, nlohmann::json> relations;
   std::set<std::string> revoked_relations;
+  std::map<std::string, nlohmann::json> revocations;
   std::map<std::string, nlohmann::json> cuts;
   std::map<std::string, nlohmann::json> refs;
   std::map<std::string, nlohmann::json> transitions;
   std::map<std::string, nlohmann::json> receipts;
+  std::vector<kernel_authority_record> authority_records;
 };
 
 template <typename T> bool decode_record(const frame_ptr &frame, T &value) {
@@ -392,15 +404,8 @@ template <typename T> bool decode_record(const frame_ptr &frame, T &value) {
 }
 
 kernel_state fold_kernel(const std::string &runtime_dir) {
-  struct pending_record {
-    uint32_t tag;
-    uint64_t sequence;
-    std::string key;
-    std::string record_root;
-    nlohmann::json document;
-  };
   kernel_state state;
-  std::vector<pending_record> pending;
+  std::vector<kernel_authority_record> pending;
   std::set<uint64_t> accepted_sequences;
   const auto target = kernel_location(runtime_dir);
   if (target->locator->list_page_id(target, location::PUBLIC).empty()) {
@@ -511,6 +516,7 @@ kernel_state fold_kernel(const std::string &runtime_dir) {
           break;
         }
         accepted_sequences.insert(pending.back().sequence);
+        pending.back().receipt = receipt;
         state.receipts[fixed_string(record.operation_id)] = std::move(receipt);
         break;
       }
@@ -533,6 +539,7 @@ kernel_state fold_kernel(const std::string &runtime_dir) {
       ++state.unknown_records;
       continue;
     }
+    state.authority_records.push_back(record);
     switch (record.tag) {
     case FactObjectRecorded::tag:
       state.objects[record.key] = record.document;
@@ -545,6 +552,7 @@ kernel_state fold_kernel(const std::string &runtime_dir) {
       break;
     case FactRelationRevoked::tag:
       state.revoked_relations.insert(record.key);
+      state.revocations[record.record_root] = record.document;
       break;
     case FactCutCommitted::tag:
       state.cuts[record.key] = record.document;
@@ -629,18 +637,18 @@ nlohmann::json append_record_with_receipt(const std::string &runtime_dir, kernel
 }
 
 nlohmann::json capabilities_document() {
-  return {
-      {"schema", "kungfu.fact-kernel.capabilities/v1"},
-      {"owner", "libkungfu"},
-      {"authority", "yijinjing-hana-pod-journal"},
-      {"root_protocol", ROOT_PROTOCOL},
-      {"content_namespaces", {{"metadata", METADATA_NAMESPACE}, {"bodies", BODY_NAMESPACE}}},
-      {"actions",
-       {"capabilities", "object-put", "version-put", "relation-add", "relation-revoke", "cut-put", "ref-cas", "query"}},
-      {"cas", {{"mode", "exact-expected-old-and-revision"}, {"stale_write", "no-journal-append"}}},
-      {"projection_role", "rebuildable-edge-only"},
-      {"clock_free_identity", true},
-      {"product_vocabulary", false}};
+  return {{"schema", "kungfu.fact-kernel.capabilities/v1"},
+          {"owner", "libkungfu"},
+          {"authority", "yijinjing-hana-pod-journal"},
+          {"root_protocol", ROOT_PROTOCOL},
+          {"content_namespaces", {{"metadata", METADATA_NAMESPACE}, {"bodies", BODY_NAMESPACE}}},
+          {"actions",
+           {"capabilities", "object-put", "version-put", "relation-add", "relation-revoke", "cut-put", "ref-cas",
+            "query", "authority-export", "authority-import"}},
+          {"cas", {{"mode", "exact-expected-old-and-revision"}, {"stale_write", "no-journal-append"}}},
+          {"projection_role", "rebuildable-edge-only"},
+          {"clock_free_identity", true},
+          {"product_vocabulary", false}};
 }
 
 nlohmann::json query_kernel(const std::string &runtime_dir, const kernel_state &state, const nlohmann::json &request) {
@@ -715,6 +723,145 @@ nlohmann::json query_kernel(const std::string &runtime_dir, const kernel_state &
           {"ref_resolution", resolution}};
 }
 
+nlohmann::json object_version_requests(const nlohmann::json &members) {
+  auto result = nlohmann::json::array();
+  for (const auto &member : members) {
+    if (!member.is_array() || member.size() != 2) {
+      throw std::runtime_error("fact authority bundle contains a malformed Cut member");
+    }
+    result.push_back({{"object_id", member.at(0)}, {"version_root", member.at(1)}});
+  }
+  return result;
+}
+
+nlohmann::json episode_frontier_requests(const nlohmann::json &frontier) {
+  auto result = nlohmann::json::array();
+  for (const auto &entry : frontier) {
+    if (!entry.is_array() || entry.size() != 3) {
+      throw std::runtime_error("fact authority bundle contains a malformed Episode frontier");
+    }
+    result.push_back({{"episode_id", entry.at(0)},
+                      {"sealed_content_root", entry.at(1)},
+                      {"accepted_manifest_frame_uid", entry.at(2)}});
+  }
+  return result;
+}
+
+nlohmann::json authority_operation_request(const std::string &runtime_dir, const kernel_authority_record &record) {
+  const auto &document = record.document;
+  if (record.tag == FactObjectRecorded::tag) {
+    return {{"action", "object-put"},
+            {"object_id", document.at("objectId")},
+            {"object_type", document.at("objectType")},
+            {"created_by_receipt_root", document.at("createdByReceiptRoot")}};
+  }
+  if (record.tag == FactVersionRecorded::tag) {
+    return {{"action", "version-put"},
+            {"object_id", document.at("objectId")},
+            {"body", content_store_get(runtime_dir, BODY_NAMESPACE, document.at("bodyRoot").get<std::string>())},
+            {"schema_root", document.at("schemaRoot")},
+            {"parent_version_roots", document.at("parentVersionRoots")},
+            {"declaration_roots", document.at("declarationRoots")},
+            {"admission_roots", document.at("admissionRoots")}};
+  }
+  if (record.tag == FactRelationAdded::tag) {
+    return {{"action", "relation-add"},
+            {"relation_id", document.at("relationId")},
+            {"relation_type", document.at("relationType")},
+            {"source", document.at("source")},
+            {"target", document.at("target")},
+            {"attributes_root", document.at("attributesRoot")},
+            {"admission_roots", document.at("admissionRoots")}};
+  }
+  if (record.tag == FactRelationRevoked::tag) {
+    return {{"action", "relation-revoke"},
+            {"relation_root", document.at("relationRoot")},
+            {"reason_root", document.at("reasonRoot")}};
+  }
+  if (record.tag == FactCutCommitted::tag) {
+    return {{"action", "cut-put"},
+            {"parent_cut_roots", document.at("parentCutRoots")},
+            {"object_versions", object_version_requests(document.at("objectVersions"))},
+            {"active_relation_roots", document.at("activeRelationRoots")},
+            {"declaration_roots", document.at("declarationRoots")},
+            {"admission_roots", document.at("admissionRoots")},
+            {"episode_frontier", episode_frontier_requests(document.at("episodeFrontier"))},
+            {"omission_roots", document.at("omissionRoots")},
+            {"conflict_roots", document.at("conflictRoots")}};
+  }
+  if (record.tag == FactRefTransition::tag) {
+    const auto transition = load_metadata(runtime_dir, record.record_root, "kungfu.fact.ref-transition/v1");
+    const auto expected_old = transition.at("expectedOldCutRoot").get<std::string>();
+    return {{"action", "ref-cas"},
+            {"transition_id", transition.at("transitionId")},
+            {"ref_name", transition.at("refName")},
+            {"expected_old_cut_root", expected_old.empty() ? nlohmann::json(nullptr) : nlohmann::json(expected_old)},
+            {"expected_old_revision", transition.at("expectedOldRevision")},
+            {"new_cut_root", transition.at("newCutRoot")},
+            {"kind", transition.at("kind")},
+            {"reason_root", transition.at("reasonRoot")}};
+  }
+  throw std::runtime_error("fact authority bundle encountered an unsupported journal record");
+}
+
+std::set<std::string> authority_record_roots(const kernel_state &state) {
+  std::set<std::string> result;
+  for (const auto &record : state.authority_records) {
+    result.insert(record.record_root);
+  }
+  return result;
+}
+
+nlohmann::json authority_bundle(const std::string &runtime_dir, const kernel_state &state) {
+  if (state.unknown_records != 0) {
+    throw std::runtime_error("fact_authority_export_unknown_records");
+  }
+  if (state.authority_records.empty()) {
+    throw std::runtime_error("fact_authority_export_empty");
+  }
+  auto operations = nlohmann::json::array();
+  auto roots = nlohmann::json::array();
+  for (const auto &record : state.authority_records) {
+    if (!record.receipt.is_object() || record.receipt.value("recordRoot", std::string{}) != record.record_root) {
+      throw std::runtime_error("fact_authority_export_receipt_mismatch");
+    }
+    operations.push_back({{"sequence", record.sequence},
+                          {"action", record.receipt.at("operation")},
+                          {"request", authority_operation_request(runtime_dir, record)},
+                          {"recordRoot", record.record_root},
+                          {"sourceReceiptRoot", record.receipt.at("receiptRoot")}});
+    roots.push_back(record.record_root);
+  }
+  auto bundle = nlohmann::json{{"schema", "kungfu.fact-authority-bundle/v1"},
+                               {"authority", "yijinjing-hana-pod-journal"},
+                               {"rootProtocol", ROOT_PROTOCOL},
+                               {"operations", std::move(operations)},
+                               {"recordRoots", std::move(roots)},
+                               {"finalState",
+                                {{"refs", state.refs},
+                                 {"counts",
+                                  {{"objects", state.objects.size()},
+                                   {"versions", state.versions.size()},
+                                   {"relations", state.relations.size()},
+                                   {"revocations", state.revocations.size()},
+                                   {"cuts", state.cuts.size()},
+                                   {"transitions", state.transitions.size()}}}}}};
+  bundle["bundleRoot"] = content_root(canonical_json(bundle));
+  return bundle;
+}
+
+std::string response_record_root(const std::string &action, const nlohmann::json &response) {
+  if (!response.is_object() || !response.value("ok", false)) {
+    return {};
+  }
+  const auto result = response.value("result", nlohmann::json::object());
+  static const std::map<std::string, std::string> fields = {
+      {"object-put", "object_root"},      {"version-put", "version_root"}, {"relation-add", "relation_root"},
+      {"relation-revoke", "revoke_root"}, {"cut-put", "cut_root"},         {"ref-cas", "transition_root"}};
+  const auto field = fields.find(action);
+  return field == fields.end() ? std::string{} : result.value(field->second, std::string{});
+}
+
 } // namespace
 
 nlohmann::json fact_kernel_capabilities() { return capabilities_document(); }
@@ -728,6 +875,220 @@ nlohmann::json run_fact_kernel_operation(const std::string &runtime_dir, const n
     }
     if (action == "query") {
       return query_kernel(runtime_dir, fold_kernel(runtime_dir), input);
+    }
+    if (action == "authority-export") {
+      const auto bundle = authority_bundle(runtime_dir, fold_kernel(runtime_dir));
+      return {{"schema", FACT_KERNEL_SCHEMA_V1},
+              {"ok", true},
+              {"action", action},
+              {"status", "exported"},
+              {"write_occurred", false},
+              {"result", {{"bundle", bundle}, {"bundle_root", bundle.at("bundleRoot")}}},
+              {"receipt", nullptr}};
+    }
+    if (action == "authority-import") {
+      if (!input.contains("bundle") || !input.at("bundle").is_object()) {
+        return failure(action, "bundle-invalid", "Fact authority bundle is required");
+      }
+      const auto &bundle = input.at("bundle");
+      if (text_or(bundle, "schema") != "kungfu.fact-authority-bundle/v1" ||
+          text_or(bundle, "authority") != "yijinjing-hana-pod-journal" ||
+          text_or(bundle, "rootProtocol") != ROOT_PROTOCOL) {
+        return failure(action, "bundle-invalid", "Fact authority bundle contract is unsupported");
+      }
+      const auto declared_bundle_root = required_text(bundle, "bundleRoot");
+      validate_root(declared_bundle_root, "bundleRoot");
+      auto root_material = bundle;
+      root_material.erase("bundleRoot");
+      const auto computed_bundle_root = content_root(canonical_json(root_material));
+      if (computed_bundle_root != declared_bundle_root) {
+        return failure(action, "bundle-root-mismatch", "Fact authority bundle root does not match its content",
+                       {{"declared", declared_bundle_root}, {"computed", computed_bundle_root}});
+      }
+      const auto operations = array_or_empty(bundle, "operations");
+      const auto record_roots = array_or_empty(bundle, "recordRoots");
+      if (operations.empty() || operations.size() != record_roots.size()) {
+        return failure(action, "bundle-invalid",
+                       "Fact authority bundle operations and roots must be non-empty and aligned");
+      }
+      std::set<std::string> expected_roots;
+      for (size_t index = 0; index < operations.size(); ++index) {
+        const auto &operation = operations.at(index);
+        if (!operation.is_object() || !operation.contains("request") || !operation.at("request").is_object()) {
+          return failure(action, "bundle-invalid", "Fact authority bundle operation request is missing",
+                         {{"index", index}});
+        }
+        const auto operation_action = required_text(operation, "action");
+        const auto request_action = text_or(operation.at("request"), "action");
+        const auto record_root = required_text(operation, "recordRoot");
+        const auto source_receipt_root = required_text(operation, "sourceReceiptRoot");
+        validate_root(record_root, "recordRoot");
+        validate_root(source_receipt_root, "sourceReceiptRoot");
+        if (operation_action != request_action || record_roots.at(index) != record_root ||
+            operation_action == "authority-import" || operation_action == "authority-export" ||
+            operation_action == "query" || operation_action == "capabilities" ||
+            !expected_roots.insert(record_root).second) {
+          return failure(action, "bundle-invalid", "Fact authority bundle operation is inconsistent",
+                         {{"index", index}, {"operation", operation_action}});
+        }
+      }
+      auto before = fold_kernel(runtime_dir);
+      if (before.unknown_records != 0) {
+        return failure(action, "destination-diverged", "Destination Fact journal contains unknown records",
+                       {{"unknown_records", before.unknown_records}});
+      }
+      auto current_roots = authority_record_roots(before);
+      if (!std::includes(expected_roots.begin(), expected_roots.end(), current_roots.begin(), current_roots.end())) {
+        return failure(action, "destination-diverged", "Destination Fact authority is not a subset of the bundle");
+      }
+
+      // A valid bundle root authenticates only the supplied bytes. Replay the
+      // complete bundle in an isolated runtime so a later invalid request can
+      // never reject after earlier immutable destination records have landed.
+      const auto preflight_root =
+          fs::temp_directory_path() / ("kungfu-fact-authority-import-" + std::to_string(std::random_device{}()) + "-" +
+                                       std::to_string(std::random_device{}()));
+      nlohmann::json preflight_failure = nullptr;
+      try {
+        for (size_t index = 0; index < operations.size(); ++index) {
+          const auto &operation = operations.at(index);
+          const auto operation_action = operation.at("action").get<std::string>();
+          const auto expected_root = operation.at("recordRoot").get<std::string>();
+          const auto response = run_fact_kernel_operation(preflight_root.string(), operation.at("request"));
+          const auto actual_root = response_record_root(operation_action, response);
+          if (!response.value("ok", false) || actual_root != expected_root) {
+            preflight_failure = failure(action, "import-preflight-operation-mismatch",
+                                        "Fact authority bundle failed isolated replay before destination mutation",
+                                        {{"index", index},
+                                         {"operation", operation_action},
+                                         {"expected_record_root", expected_root},
+                                         {"actual_record_root", actual_root},
+                                         {"kernel_response", response}});
+            break;
+          }
+        }
+        if (preflight_failure.is_null()) {
+          const auto preflight_state = fold_kernel(preflight_root.string());
+          const auto preflight_roots = authority_record_roots(preflight_state);
+          const auto final_state = bundle.value("finalState", nlohmann::json::object());
+          const auto expected_counts = final_state.value("counts", nlohmann::json::object());
+          const auto actual_counts = nlohmann::json{
+              {"objects", preflight_state.objects.size()},     {"versions", preflight_state.versions.size()},
+              {"relations", preflight_state.relations.size()}, {"revocations", preflight_state.revocations.size()},
+              {"cuts", preflight_state.cuts.size()},           {"transitions", preflight_state.transitions.size()}};
+          if (preflight_roots != expected_roots ||
+              nlohmann::json(preflight_state.refs) != final_state.value("refs", nlohmann::json::object()) ||
+              actual_counts != expected_counts) {
+            preflight_failure =
+                failure(action, "import-preflight-final-state-mismatch",
+                        "Fact authority bundle isolated replay did not reproduce its declared final state",
+                        {{"expected_refs", final_state.value("refs", nlohmann::json::object())},
+                         {"actual_refs", preflight_state.refs},
+                         {"expected_counts", expected_counts},
+                         {"actual_counts", actual_counts}});
+          }
+        }
+        std::error_code cleanup_error;
+        fs::remove_all(preflight_root, cleanup_error);
+        if (cleanup_error) {
+          throw std::runtime_error("fact authority import preflight cleanup failed");
+        }
+      } catch (...) {
+        std::error_code cleanup_error;
+        fs::remove_all(preflight_root, cleanup_error);
+        throw;
+      }
+      if (!preflight_failure.is_null()) {
+        return preflight_failure;
+      }
+      if (!input.value("execute", false)) {
+        return {{"schema", FACT_KERNEL_SCHEMA_V1},
+                {"ok", true},
+                {"action", action},
+                {"status", "planned"},
+                {"write_occurred", false},
+                {"result",
+                 {{"bundle_root", declared_bundle_root},
+                  {"operation_count", operations.size()},
+                  {"already_present", current_roots.size()},
+                  {"remaining", expected_roots.size() - current_roots.size()}}},
+                {"receipt", nullptr}};
+      }
+
+      bool write_occurred = false;
+      auto mappings = nlohmann::json::array();
+      for (size_t index = 0; index < operations.size(); ++index) {
+        const auto &operation = operations.at(index);
+        const auto record_root = operation.at("recordRoot").get<std::string>();
+        if (current_roots.count(record_root) != 0) {
+          mappings.push_back({{"recordRoot", record_root},
+                              {"sourceReceiptRoot", operation.at("sourceReceiptRoot")},
+                              {"destinationReceiptRoot", nullptr},
+                              {"status", "already-present"}});
+          continue;
+        }
+        const auto operation_action = operation.at("action").get<std::string>();
+        const auto response = run_fact_kernel_operation(runtime_dir, operation.at("request"));
+        write_occurred = write_occurred || response.value("write_occurred", false);
+        const auto actual_root = response_record_root(operation_action, response);
+        if (!response.value("ok", false) || actual_root != record_root) {
+          return {{"schema", FACT_KERNEL_SCHEMA_V1},
+                  {"ok", false},
+                  {"action", action},
+                  {"status", "rejected"},
+                  {"failure_code", "import-operation-mismatch"},
+                  {"message", "Fact authority import did not reproduce the declared record root"},
+                  {"details",
+                   {{"index", index},
+                    {"operation", operation_action},
+                    {"expected_record_root", record_root},
+                    {"actual_record_root", actual_root},
+                    {"kernel_response", response}}},
+                  {"write_occurred", write_occurred},
+                  {"receipt", nullptr}};
+        }
+        current_roots.insert(record_root);
+        mappings.push_back({{"recordRoot", record_root},
+                            {"sourceReceiptRoot", operation.at("sourceReceiptRoot")},
+                            {"destinationReceiptRoot", response.value("receipt_root", nlohmann::json(nullptr))},
+                            {"status", response.at("status")}});
+      }
+      const auto after = fold_kernel(runtime_dir);
+      const auto final_roots = authority_record_roots(after);
+      const auto final_state = bundle.value("finalState", nlohmann::json::object());
+      const auto expected_counts = final_state.value("counts", nlohmann::json::object());
+      const auto actual_counts =
+          nlohmann::json{{"objects", after.objects.size()},     {"versions", after.versions.size()},
+                         {"relations", after.relations.size()}, {"revocations", after.revocations.size()},
+                         {"cuts", after.cuts.size()},           {"transitions", after.transitions.size()}};
+      if (final_roots != expected_roots ||
+          nlohmann::json(after.refs) != final_state.value("refs", nlohmann::json::object()) ||
+          actual_counts != expected_counts) {
+        return {{"schema", FACT_KERNEL_SCHEMA_V1},
+                {"ok", false},
+                {"action", action},
+                {"status", "rejected"},
+                {"failure_code", "import-final-state-mismatch"},
+                {"message", "Fact authority import did not reproduce the declared final refs and record roots"},
+                {"details",
+                 {{"expected_refs", final_state.value("refs", nlohmann::json::object())},
+                  {"actual_refs", after.refs},
+                  {"expected_counts", expected_counts},
+                  {"actual_counts", actual_counts}}},
+                {"write_occurred", write_occurred},
+                {"receipt", nullptr}};
+      }
+      return {{"schema", FACT_KERNEL_SCHEMA_V1},
+              {"ok", true},
+              {"action", action},
+              {"status", "imported"},
+              {"write_occurred", write_occurred},
+              {"result",
+               {{"bundle_root", declared_bundle_root},
+                {"record_roots_preserved", true},
+                {"refs_preserved", true},
+                {"receipt_mappings", std::move(mappings)}}},
+              {"receipt", nullptr}};
     }
 
     const auto guard = writer_guard(writer_lock_path(runtime_dir));

--- a/framework/core/src/python/kungfu/agent/commands.json
+++ b/framework/core/src/python/kungfu/agent/commands.json
@@ -38,6 +38,12 @@
       "purpose": "Discover five responsibility roles, Product Profile transitions, typed denials, and authority boundaries."
     },
     {
+      "apiId": "kungfu.agent.work.session",
+      "name": "kungfu agent work session --operation <compressibility|expand|project> --file <session.json> --json",
+      "maturity": "experimental",
+      "purpose": "Round-trip a simple work session through the five KFD-7 Profile roles or expose the exact role at a complexity breakpoint."
+    },
+    {
       "apiId": "kungfu.agent.work.inspect",
       "name": "kungfu agent work inspect --ref <ref> --json",
       "maturity": "experimental",
@@ -48,6 +54,18 @@
       "name": "kungfu agent work action --file <request.json> [--execute] --json",
       "maturity": "experimental",
       "purpose": "Plan or execute one Profile transition through the shared action/receipt contract and native Fact ref CAS."
+    },
+    {
+      "apiId": "kungfu.agent.work.export-authority",
+      "name": "kungfu agent work export-authority --json",
+      "maturity": "experimental",
+      "purpose": "Export a content-bound native Fact authority bundle that preserves exact Profile object, version, Cut, and ref roots."
+    },
+    {
+      "apiId": "kungfu.agent.work.import-authority",
+      "name": "kungfu agent work import-authority --file <bundle.json> [--execute] --json",
+      "maturity": "experimental",
+      "purpose": "Validate or replay one qualified Fact authority bundle into a clean runtime home without changing logical Profile roots."
     },
     {
       "apiId": "kungfu.agent.choose-mode",

--- a/framework/core/src/python/kungfu/agent/kfd3_api.registry.json
+++ b/framework/core/src/python/kungfu/agent/kfd3_api.registry.json
@@ -83,6 +83,16 @@
       "projections": ["commands.json", "capabilities-json", "provider-skill"]
     },
     {
+      "id": "kungfu.agent.work.session",
+      "surface": "cli-api-gui",
+      "name": "kungfu agent work session --operation <compressibility|expand|project> --file <session.json> --json",
+      "purpose": "Round-trip a simple work session through the five KFD-7 Profile roles or expose the exact role at a complexity breakpoint.",
+      "maturity": "experimental",
+      "visibility": "public-agent",
+      "anchor": { "kind": "runtime-click", "symbol": "work_session" },
+      "projections": ["commands.json", "capabilities-json", "provider-skill"]
+    },
+    {
       "id": "kungfu.agent.work.inspect",
       "surface": "cli-api-gui",
       "name": "kungfu agent work inspect --ref <ref> --json",
@@ -100,6 +110,26 @@
       "maturity": "experimental",
       "visibility": "public-agent",
       "anchor": { "kind": "runtime-click", "symbol": "work_action" },
+      "projections": ["commands.json", "capabilities-json", "provider-skill"]
+    },
+    {
+      "id": "kungfu.agent.work.export-authority",
+      "surface": "cli-api-gui",
+      "name": "kungfu agent work export-authority --json",
+      "purpose": "Export a content-bound native Fact authority bundle that preserves exact Profile object, version, Cut, and ref roots.",
+      "maturity": "experimental",
+      "visibility": "public-agent",
+      "anchor": { "kind": "runtime-click", "symbol": "work_export_authority" },
+      "projections": ["commands.json", "capabilities-json", "provider-skill"]
+    },
+    {
+      "id": "kungfu.agent.work.import-authority",
+      "surface": "cli-api-gui",
+      "name": "kungfu agent work import-authority --file <bundle.json> [--execute] --json",
+      "purpose": "Validate or replay one qualified Fact authority bundle into a clean runtime home without changing logical Profile roots.",
+      "maturity": "experimental",
+      "visibility": "public-agent",
+      "anchor": { "kind": "runtime-click", "symbol": "work_import_authority" },
       "projections": ["commands.json", "capabilities-json", "provider-skill"]
     },
     {

--- a/framework/core/src/python/kungfu/agent/work_profile.py
+++ b/framework/core/src/python/kungfu/agent/work_profile.py
@@ -23,6 +23,10 @@ RECEIPT_SCHEMA = "kungfu.kfd7.profile-action-receipt/v1"
 ROLE_BODY_SCHEMA = "kungfu.kfd7.profile-role/v1"
 CAPABILITIES_SCHEMA = "kungfu.kfd7.profile-capabilities/v1"
 INSPECTION_SCHEMA = "kungfu.kfd7.profile-inspection/v1"
+AUTHORITY_BUNDLE_SCHEMA = "kungfu.fact-authority-bundle/v1"
+SESSION_SCHEMA = "kungfu.kfd7.session/v1"
+SESSION_EXPANSION_SCHEMA = "kungfu.kfd7.session-expansion/v1"
+SESSION_COMPRESSIBILITY_SCHEMA = "kungfu.kfd7.session-compressibility/v1"
 
 ROLES = ("fact", "episode", "pursuit", "atlas", "warrant")
 INITIAL_STATES = {
@@ -48,6 +52,7 @@ TRANSITIONS = {
     },
     "pursuit": {
         ("create", "absent", "active"),
+        ("branch", "active", "active"),
         ("continue", "active", "active"),
         ("continue", "paused", "active"),
         ("pause", "active", "paused"),
@@ -130,22 +135,41 @@ def capabilities() -> dict[str, Any]:
                 "identity": "preserved",
             },
             "exportImport": {
-                "status": "explicit-loss-until-fact-bundle-qualified",
-                "required": [
-                    "Fact journal",
-                    "body namespace",
-                    "exact ref and Cut roots",
+                "status": "supported",
+                "bundleSchema": AUTHORITY_BUNDLE_SCHEMA,
+                "authority": "native Fact journal replay through the existing kernel",
+                "preserves": [
+                    "logical object ids",
+                    "version and body roots",
+                    "relation and Cut roots",
+                    "named ref roots and revisions",
                 ],
-                "lossCode": "profile-authority-not-exported",
             },
             "backendMigration": {
-                "status": "delegated-to-storage-backend-switch",
-                "identity": "content roots and journal identities must remain exact",
+                "status": "supported-by-storage-backend-switch",
+                "identity": "five-role object, version, Cut, ref, and authority roots remain exact",
+                "rollback": "reverse-sync-and-atomic-binding",
             },
             "cleanHome": {
-                "status": "explicit-loss-without-qualified-export",
+                "status": "supported-from-qualified-authority-bundle",
+                "requires": AUTHORITY_BUNDLE_SCHEMA,
                 "lossCode": "profile-authority-unavailable",
             },
+        },
+        "sessionProjection": {
+            "schema": SESSION_SCHEMA,
+            "expand": "kungfu.agent.work_profile.expand_session",
+            "project": "kungfu.agent.work_profile.project_session",
+            "compressibilityPredicate": (
+                "kungfu.agent.work_profile.session_compressibility"
+            ),
+            "semanticDimensions": [
+                "direction",
+                "perspective-boundary",
+                "effective-authority",
+                "causal-process",
+                "admitted-result",
+            ],
         },
         "nonClaims": [
             "A Profile receipt does not adopt KFD-7 or replace KFD authority.",
@@ -154,12 +178,231 @@ def capabilities() -> dict[str, Any]:
     }
 
 
+def _require_session_component(
+    session: dict[str, Any], field: str, identity_field: str
+) -> dict[str, Any]:
+    value = session.get(field)
+    if not isinstance(value, dict):
+        raise ValueError(f"{field} must be an object")
+    identity = value.get(identity_field)
+    if not isinstance(identity, str) or not identity:
+        raise ValueError(f"{field}.{identity_field} is required")
+    return value
+
+
+def _validate_session(session: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    if not isinstance(session, dict) or session.get("schema") != SESSION_SCHEMA:
+        raise ValueError(f"schema must be {SESSION_SCHEMA}")
+    if not isinstance(session.get("sessionId"), str) or not session["sessionId"]:
+        raise ValueError("sessionId is required")
+    components = {
+        "pursuit": _require_session_component(session, "goal", "pursuitId"),
+        "atlas": _require_session_component(session, "context", "atlasId"),
+        "warrant": _require_session_component(session, "permissions", "warrantId"),
+        "episode": _require_session_component(session, "run", "episodeId"),
+        "fact": _require_session_component(session, "facts", "factId"),
+    }
+    identities = [
+        components["fact"]["factId"],
+        components["episode"]["episodeId"],
+        components["pursuit"]["pursuitId"],
+        components["atlas"]["atlasId"],
+        components["warrant"]["warrantId"],
+    ]
+    if len(identities) != len(set(identities)):
+        raise ValueError("session responsibilities require distinct identities")
+    for field in ("basisRevision", "validThroughRevision"):
+        value = components["atlas"].get(field)
+        if not isinstance(value, int) or value < 0:
+            raise ValueError(f"context.{field} must be a non-negative integer")
+    valid_through = components["warrant"].get("validThroughRevision")
+    if not isinstance(valid_through, int) or valid_through < 0:
+        raise ValueError(
+            "permissions.validThroughRevision must be a non-negative integer"
+        )
+    for field, component in (
+        ("goal.operations", components["pursuit"]),
+        ("permissions.allowedOperations", components["warrant"]),
+    ):
+        key = field.rsplit(".", 1)[1]
+        value = component.get(key)
+        if (
+            not isinstance(value, list)
+            or not value
+            or any(not isinstance(item, str) or not item for item in value)
+        ):
+            raise ValueError(f"{field} must be a non-empty string array")
+    return components
+
+
+def session_compressibility(session: dict[str, Any]) -> dict[str, Any]:
+    """Return the exact roles that make a familiar session projection lossy."""
+
+    components = _validate_session(session)
+    reasons: list[dict[str, str]] = []
+
+    goal = components["pursuit"]
+    if goal.get("state") != "active" or goal.get("alternatives"):
+        reasons.append(
+            {
+                "role": "pursuit",
+                "code": "multiple-or-terminal-direction",
+            }
+        )
+
+    context = components["atlas"]
+    if (
+        context.get("state") != "current"
+        or context["validThroughRevision"] < context["basisRevision"]
+        or context.get("lossRoots")
+        or len(context.get("perspectives", [])) > 1
+    ):
+        reasons.append({"role": "atlas", "code": "perspective-or-freshness-boundary"})
+
+    permissions = components["warrant"]
+    if (
+        permissions.get("state") != "issued"
+        or permissions["validThroughRevision"] < context["basisRevision"]
+        or permissions.get("delegated") is True
+    ):
+        reasons.append({"role": "warrant", "code": "authority-boundary"})
+
+    run = components["episode"]
+    if (
+        run.get("state") not in {"open", "sealed"}
+        or len(run.get("episodeIds", [run["episodeId"]])) != 1
+    ):
+        reasons.append({"role": "episode", "code": "causal-branch"})
+
+    facts = components["fact"]
+    if facts.get("branchRoots") or len(facts.get("resultRoots", [])) > 1:
+        reasons.append({"role": "fact", "code": "fact-branch"})
+
+    return {
+        "schema": SESSION_COMPRESSIBILITY_SCHEMA,
+        "sessionId": session["sessionId"],
+        "compressible": not reasons,
+        "breakpoints": reasons,
+        "revealedRoles": sorted({reason["role"] for reason in reasons}),
+    }
+
+
+def session_valid_actions(session: dict[str, Any]) -> list[str]:
+    """Derive actions only from direction, current context, and authority."""
+
+    components = _validate_session(session)
+    context = components["atlas"]
+    warrant = components["warrant"]
+    pursuit = components["pursuit"]
+    if (
+        pursuit.get("state") != "active"
+        or context.get("state") != "current"
+        or context["validThroughRevision"] < context["basisRevision"]
+        or warrant.get("state") != "issued"
+        or warrant["validThroughRevision"] < context["basisRevision"]
+    ):
+        return []
+    return sorted(set(pursuit["operations"]).intersection(warrant["allowedOperations"]))
+
+
+def expand_session(session: dict[str, Any]) -> dict[str, Any]:
+    """Expand one product session into the existing five Profile role bodies."""
+
+    components = _validate_session(session)
+    compressibility = session_compressibility(session)
+    roles = {
+        role: {
+            "schema": ROLE_BODY_SCHEMA,
+            "role": role,
+            "state": components[role]["state"],
+            "details": json.loads(json.dumps(components[role], sort_keys=True)),
+        }
+        for role in ROLES
+    }
+    return {
+        "schema": SESSION_EXPANSION_SCHEMA,
+        "sessionId": session["sessionId"],
+        "compressibility": compressibility,
+        "roles": roles,
+        "observations": {
+            "direction": roles["pursuit"]["details"],
+            "perspective-boundary": roles["atlas"]["details"],
+            "effective-authority": roles["warrant"]["details"],
+            "causal-process": roles["episode"]["details"],
+            "admitted-result": roles["fact"]["details"],
+        },
+        "validActions": session_valid_actions(session),
+    }
+
+
+def project_session(expansion: dict[str, Any]) -> dict[str, Any]:
+    """Project a compressible five-role expansion back to one session."""
+
+    if (
+        not isinstance(expansion, dict)
+        or expansion.get("schema") != SESSION_EXPANSION_SCHEMA
+    ):
+        raise ValueError(f"schema must be {SESSION_EXPANSION_SCHEMA}")
+    compressibility = expansion.get("compressibility")
+    if not isinstance(compressibility, dict) or not compressibility.get("compressible"):
+        raise ValueError("session-complexity-breakpoint")
+    roles = expansion.get("roles")
+    if not isinstance(roles, dict) or set(roles) != set(ROLES):
+        raise ValueError("all five expanded roles are required exactly once")
+    for role in ROLES:
+        body = roles[role]
+        if (
+            not isinstance(body, dict)
+            or body.get("schema") != ROLE_BODY_SCHEMA
+            or body.get("role") != role
+            or not isinstance(body.get("details"), dict)
+        ):
+            raise ValueError(f"expanded {role} role is invalid")
+    projected = {
+        "schema": SESSION_SCHEMA,
+        "sessionId": expansion.get("sessionId"),
+        "goal": roles["pursuit"]["details"],
+        "context": roles["atlas"]["details"],
+        "permissions": roles["warrant"]["details"],
+        "run": roles["episode"]["details"],
+        "facts": roles["fact"]["details"],
+    }
+    _validate_session(projected)
+    return projected
+
+
 def _kernel(
     runtime_dir: str | Path,
     action: str,
     request: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     return storage_service.fact_kernel(runtime_dir, action, request)
+
+
+def export_authority(
+    runtime_dir: str | Path,
+    *,
+    kernel: Kernel | None = None,
+) -> dict[str, Any]:
+    """Export the native Fact authority required to continue this Profile."""
+
+    return (kernel or _kernel)(runtime_dir, "authority-export", {})
+
+
+def import_authority(
+    runtime_dir: str | Path,
+    bundle: dict[str, Any],
+    *,
+    execute: bool = False,
+    kernel: Kernel | None = None,
+) -> dict[str, Any]:
+    """Validate or replay one qualified Fact authority bundle."""
+
+    return (kernel or _kernel)(
+        runtime_dir,
+        "authority-import",
+        {"bundle": bundle, "execute": execute},
+    )
 
 
 def _denied(
@@ -357,6 +600,11 @@ def _validate_request(request: dict[str, Any]) -> None:
             f"responsibilities.{role}.expectedVersionRoot",
             nullable=True,
         )
+    object_ids = [responsibilities[role]["objectId"] for role in ROLES]
+    if len(set(object_ids)) != len(ROLES):
+        raise ValueError(
+            "all five responsibilities require distinct logical object identities"
+        )
     support = request.get("support")
     if not isinstance(support, dict):
         raise ValueError("support is required")
@@ -364,6 +612,176 @@ def _validate_request(request: dict[str, Any]) -> None:
         _require_root(support.get(field), f"support.{field}")
     _require_root_list(support.get("declarationRoots"), "support.declarationRoots")
     _require_root_list(support.get("admissionRoots"), "support.admissionRoots")
+
+
+def _validate_lifecycle_payload(
+    subject_role: str,
+    subject: dict[str, Any],
+    current_roles: dict[str, dict[str, Any]],
+    payload: dict[str, Any],
+    basis: dict[str, Any],
+    ref: dict[str, Any],
+) -> tuple[str, str, dict[str, Any]] | None:
+    operation = subject["operation"]
+    current_body = current_roles.get(subject_role, {}).get("body") or {}
+    current_details = current_body.get("details") or {}
+    if not isinstance(current_details, dict):
+        return ("invalid-request", f"{subject_role} details must be an object", {})
+
+    try:
+        if subject_role == "episode" and operation == "seal":
+            episode_id = payload.get("episodeId")
+            if episode_id != current_details.get("episodeId"):
+                return (
+                    "replay-mismatch",
+                    "Episode seal identity differs from the open Episode",
+                    {
+                        "expected": current_details.get("episodeId"),
+                        "actual": episode_id,
+                    },
+                )
+            for field in (
+                "beforeCutRoot",
+                "afterCutRoot",
+                "causalRoot",
+                "sealedContentRoot",
+            ):
+                _require_root(payload.get(field), f"payload.{field}")
+
+        if subject_role == "episode" and operation == "reconcile":
+            replay = payload.get("replay")
+            if not isinstance(replay, dict):
+                return (
+                    "invalid-request",
+                    "Episode reconciliation requires replay evidence",
+                    {},
+                )
+            expected = {
+                field: current_details.get(field)
+                for field in (
+                    "episodeId",
+                    "beforeCutRoot",
+                    "afterCutRoot",
+                    "causalRoot",
+                    "sealedContentRoot",
+                )
+            }
+            actual = {field: replay.get(field) for field in expected}
+            for field in (
+                "beforeCutRoot",
+                "afterCutRoot",
+                "causalRoot",
+                "sealedContentRoot",
+            ):
+                _require_root(actual[field], f"payload.replay.{field}")
+            if actual != expected:
+                return (
+                    "replay-mismatch",
+                    "Episode replay evidence differs from the sealed causal record",
+                    {"expected": expected, "actual": actual},
+                )
+
+        if subject_role == "pursuit" and operation == "branch":
+            if ref.get("cutRoot") is not None or ref.get("revision") != 0:
+                return (
+                    "invalid-transition",
+                    "Pursuit branch requires a new destination ref at revision zero",
+                    {},
+                )
+            _require_root(payload.get("branchReasonRoot"), "payload.branchReasonRoot")
+            payload_branch = payload.get("branchOfCutRoot")
+            if payload_branch != basis.get("cutRoot"):
+                return (
+                    "profile-state-mismatch",
+                    "Pursuit branch must bind the exact source Cut",
+                    {"expected": basis.get("cutRoot"), "actual": payload_branch},
+                )
+
+        if subject_role == "pursuit" and operation in {"complete", "abandon"}:
+            _require_root(payload.get("settlementRoot"), "payload.settlementRoot")
+            if not isinstance(payload.get("outcome"), str) or not payload["outcome"]:
+                return (
+                    "invalid-request",
+                    "Pursuit settlement requires a non-empty outcome",
+                    {},
+                )
+
+        if subject_role == "atlas" and operation == "mark-stale":
+            _require_root_list(payload.get("lossRoots"), "payload.lossRoots")
+            if (
+                not isinstance(payload.get("lossReason"), str)
+                or not payload["lossReason"]
+            ):
+                return (
+                    "invalid-request",
+                    "Atlas staleness requires an explicit loss reason",
+                    {},
+                )
+
+        if subject_role == "atlas" and operation == "refresh":
+            _require_root_list(payload.get("sourceRoots"), "payload.sourceRoots")
+            _require_root_list(payload.get("lossRoots"), "payload.lossRoots")
+            valid_through = payload.get("validThroughRevision")
+            if not isinstance(valid_through, int) or valid_through < basis["revision"]:
+                return (
+                    "atlas-stale",
+                    "refreshed Atlas does not cover the declared basis revision",
+                    {
+                        "basisRevision": basis["revision"],
+                        "validThroughRevision": valid_through,
+                    },
+                )
+
+        if subject_role == "warrant" and operation == "attenuate":
+            old_allowed = current_details.get("allowedOperations")
+            new_allowed = payload.get("allowedOperations")
+            if not isinstance(old_allowed, list) or not isinstance(new_allowed, list):
+                return (
+                    "invalid-request",
+                    "Warrant attenuation requires explicit old and new operation scopes",
+                    {},
+                )
+            if not new_allowed or "*" in new_allowed:
+                return (
+                    "invalid-transition",
+                    "attenuated Warrant scope must be a non-empty strict subset",
+                    {},
+                )
+            old_scope = set(old_allowed)
+            new_scope = set(new_allowed)
+            if "*" not in old_scope and not new_scope < old_scope:
+                return (
+                    "unauthorized",
+                    "Warrant attenuation cannot widen or preserve the old scope",
+                    {"old": sorted(old_scope), "new": sorted(new_scope)},
+                )
+            old_valid_through = current_details.get("validThroughRevision")
+            new_valid_through = payload.get("validThroughRevision")
+            if (
+                not isinstance(old_valid_through, int)
+                or not isinstance(new_valid_through, int)
+                or new_valid_through > old_valid_through
+            ):
+                return (
+                    "unauthorized",
+                    "Warrant attenuation cannot extend its validity revision",
+                    {
+                        "old": old_valid_through,
+                        "new": new_valid_through,
+                    },
+                )
+
+        if subject_role == "warrant" and operation in {"expire", "revoke", "deny"}:
+            _require_root(payload.get("reasonRoot"), "payload.reasonRoot")
+            if not isinstance(payload.get("reason"), str) or not payload["reason"]:
+                return (
+                    "invalid-request",
+                    f"Warrant {operation} requires an explicit reason",
+                    {},
+                )
+    except ValueError as error:
+        return ("invalid-request", str(error), {})
+    return None
 
 
 def _kernel_failure(
@@ -552,6 +970,21 @@ def apply_action(
             details={"operation": operation_key, "allowedOperations": allowed or []},
         )
 
+    payload = request.get("payload") or {}
+    if not isinstance(payload, dict):
+        return _denied(action_id, "invalid-request", "payload must be an object")
+    lifecycle_denial = _validate_lifecycle_payload(
+        subject_role,
+        subject,
+        current_roles,
+        payload,
+        basis,
+        request["ref"],
+    )
+    if lifecycle_denial is not None:
+        code, message, details = lifecycle_denial
+        return _denied(action_id, code, message, details=details)
+
     changed_roles = list(ROLES) if basis["cutRoot"] is None else [subject_role]
     plan = {
         "schema": RECEIPT_SCHEMA,
@@ -614,14 +1047,6 @@ def apply_action(
             details = dict(body["details"])
         if role == subject_role:
             body["state"] = subject["toState"]
-            payload = request.get("payload") or {}
-            if not isinstance(payload, dict):
-                return _denied(
-                    action_id,
-                    "invalid-request",
-                    "payload must be an object",
-                    steps=steps,
-                )
             details.update(payload)
             body["details"] = details
         body["lastActionId"] = action_id
@@ -723,7 +1148,7 @@ def apply_action(
 
     ref_kind = (
         "fork"
-        if subject["operation"] == "fork"
+        if subject["operation"] in {"fork", "branch"}
         else "create"
         if request["ref"]["cutRoot"] is None
         else "advance"

--- a/framework/core/src/python/kungfu/cli/commands/agent.py
+++ b/framework/core/src/python/kungfu/cli/commands/agent.py
@@ -326,6 +326,51 @@ def work_capabilities(ctx, as_json):
         click.echo(f"- {role}")
 
 
+@work.command(name="session", help=api_help("kungfu.agent.work.session"))
+@click.option(
+    "--operation",
+    type=click.Choice(["compressibility", "expand", "project"]),
+    required=True,
+)
+@click.option("--file", "file_path", help="session or expansion JSON path or -")
+@click.option(
+    "--input-base64",
+    help="base64-encoded session or expansion JSON for SDK and GUI adapters",
+)
+@click.option("--json", "as_json", is_flag=True, help="machine-readable output")
+@kfd3_api("kungfu.agent.work.session")
+@agent_command_context
+def work_session(ctx, operation, file_path, input_base64, as_json):
+    """Expand, project, or test the complexity boundary of one session."""
+
+    try:
+        if bool(file_path) == bool(input_base64):
+            raise ValueError("exactly one of --file or --input-base64 is required")
+        if input_base64:
+            raw = base64.b64decode(input_base64, validate=True).decode("utf-8")
+        else:
+            raw = (
+                sys.stdin.read()
+                if file_path == "-"
+                else Path(file_path).read_text(encoding="utf-8")
+            )
+        value = json.loads(raw)
+        if not isinstance(value, dict):
+            raise ValueError("session input must be a JSON object")
+        handlers = {
+            "compressibility": work_profile.session_compressibility,
+            "expand": work_profile.expand_session,
+            "project": work_profile.project_session,
+        }
+        payload = handlers[operation](value)
+    except (OSError, UnicodeError, ValueError, json.JSONDecodeError) as error:
+        raise click.ClickException(str(error)) from error
+    if as_json:
+        _json(payload)
+    else:
+        click.echo(json.dumps(payload, indent=2, sort_keys=True))
+
+
 @work.command(name="inspect", help=api_help("kungfu.agent.work.inspect"))
 @click.option("--ref", "ref_name", required=True, help="exact Fact ref name")
 @click.option("--json", "as_json", is_flag=True, help="machine-readable output")
@@ -374,6 +419,64 @@ def work_action(ctx, file_path, input_base64, execute, as_json):
     else:
         click.echo(json.dumps(payload, indent=2, sort_keys=True))
     if payload.get("status") == "denied":
+        ctx.exit(2)
+
+
+@work.command(
+    name="export-authority", help=api_help("kungfu.agent.work.export-authority")
+)
+@click.option("--json", "as_json", is_flag=True, help="machine-readable output")
+@kfd3_api("kungfu.agent.work.export-authority")
+@agent_command_context
+def work_export_authority(ctx, as_json):
+    """Export the native Fact authority required for exact continuation."""
+
+    payload = work_profile.export_authority(ctx.runtime_dir)
+    if as_json:
+        _json(payload)
+    else:
+        click.echo(json.dumps(payload, indent=2, sort_keys=True))
+    if payload.get("ok") is not True:
+        ctx.exit(2)
+
+
+@work.command(
+    name="import-authority", help=api_help("kungfu.agent.work.import-authority")
+)
+@click.option("--file", "file_path", help="authority bundle JSON path or -")
+@click.option(
+    "--input-base64",
+    help="base64-encoded authority bundle JSON for SDK and GUI adapters",
+)
+@click.option("--execute", is_flag=True, help="replay the validated bundle")
+@click.option("--json", "as_json", is_flag=True, help="machine-readable output")
+@kfd3_api("kungfu.agent.work.import-authority")
+@agent_command_context
+def work_import_authority(ctx, file_path, input_base64, execute, as_json):
+    """Validate or replay one qualified Fact authority bundle."""
+
+    try:
+        if bool(file_path) == bool(input_base64):
+            raise ValueError("exactly one of --file or --input-base64 is required")
+        if input_base64:
+            raw = base64.b64decode(input_base64, validate=True).decode("utf-8")
+        else:
+            raw = (
+                sys.stdin.read()
+                if file_path == "-"
+                else Path(file_path).read_text(encoding="utf-8")
+            )
+        bundle = json.loads(raw)
+        if not isinstance(bundle, dict):
+            raise ValueError("authority bundle must be a JSON object")
+    except (OSError, UnicodeError, ValueError, json.JSONDecodeError) as error:
+        raise click.ClickException(str(error)) from error
+    payload = work_profile.import_authority(ctx.runtime_dir, bundle, execute=execute)
+    if as_json:
+        _json(payload)
+    else:
+        click.echo(json.dumps(payload, indent=2, sort_keys=True))
+    if payload.get("ok") is not True:
         ctx.exit(2)
 
 

--- a/framework/core/tests/python/test_agent_work_profile_native.py
+++ b/framework/core/tests/python/test_agent_work_profile_native.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import copy
+import hashlib
 import importlib.util
+import json
 
 import pytest
 
@@ -11,10 +14,22 @@ if importlib.util.find_spec("pykungfu") is None:
     pytest.skip("native pykungfu binding is not built", allow_module_level=True)
 
 from kungfu.agent import work_profile  # noqa: E402
+from kungfu.storage import service  # noqa: E402
+
+
+FILE = "content-addressed-file"
+ROCKS = "rocksdb"
 
 
 def _root(digit: str) -> str:
     return "sha256:" + digit * 64
+
+
+def _reroot_bundle(bundle):
+    material = copy.deepcopy(bundle)
+    material.pop("bundleRoot", None)
+    raw = json.dumps(material, sort_keys=True, separators=(",", ":"))
+    bundle["bundleRoot"] = "sha256:" + hashlib.sha256(raw.encode()).hexdigest()
 
 
 def _request():
@@ -65,6 +80,73 @@ def _request():
     }
 
 
+def _successor_request(previous, *, action_id: str):
+    request = _request()
+    request["actionId"] = action_id
+    request["basis"] = {
+        "cutRoot": previous["result"]["cutRoot"],
+        "revision": previous["result"]["revision"],
+    }
+    request["ref"] = copy.deepcopy(request["basis"])
+    request["subject"] = {
+        "role": "pursuit",
+        "operation": "continue",
+        "fromState": "active",
+        "toState": "active",
+    }
+    request["responsibilities"] = {
+        role: {
+            "objectId": request["responsibilities"][role]["objectId"],
+            "expectedVersionRoot": previous["result"]["roleVersions"][role],
+        }
+        for role in work_profile.ROLES
+    }
+    request.pop("roleInputs")
+    request["payload"] = {"continuation": action_id}
+    return request
+
+
+def _role_transition_request(
+    previous,
+    *,
+    action_id,
+    role,
+    operation,
+    from_state,
+    to_state,
+    payload,
+    ref_name=None,
+    new_ref=False,
+):
+    request = _request()
+    request["actionId"] = action_id
+    request["refName"] = ref_name or request["refName"]
+    request["basis"] = {
+        "cutRoot": previous["result"]["cutRoot"],
+        "revision": previous["result"]["revision"],
+    }
+    request["ref"] = (
+        {"cutRoot": None, "revision": 0} if new_ref else copy.deepcopy(request["basis"])
+    )
+    request["subject"] = {
+        "role": role,
+        "operation": operation,
+        "fromState": from_state,
+        "toState": to_state,
+    }
+    request["responsibilities"] = {
+        current_role: {
+            "objectId": request["responsibilities"][current_role]["objectId"],
+            "expectedVersionRoot": previous["result"]["roleVersions"][current_role],
+        }
+        for current_role in work_profile.ROLES
+    }
+    request.pop("roleInputs")
+    request["relations"] = []
+    request["payload"] = copy.deepcopy(payload)
+    return request
+
+
 def test_native_profile_bootstrap_accepts_python_revision_zero(tmp_path):
     runtime_dir = tmp_path / "runtime"
     request = _request()
@@ -77,3 +159,332 @@ def test_native_profile_bootstrap_accepts_python_revision_zero(tmp_path):
     assert inspected["status"] == "current"
     assert inspected["revision"] == 1
     assert set(inspected["roles"]) == set(work_profile.ROLES)
+
+
+def test_native_profile_authority_bundle_restores_clean_home_exactly(tmp_path):
+    source = tmp_path / "source"
+    destination = tmp_path / "clean-home"
+    request = _request()
+    created = work_profile.apply_action(source, request, execute=True)
+    continued = work_profile.apply_action(
+        source,
+        _successor_request(created, action_id="source-continuation"),
+        execute=True,
+    )
+
+    exported = work_profile.export_authority(source)
+    assert exported["ok"] is True, exported
+    bundle = exported["result"]["bundle"]
+    assert bundle["schema"] == work_profile.AUTHORITY_BUNDLE_SCHEMA
+    assert bundle["finalState"]["refs"][request["refName"]]["revision"] == 2
+
+    tampered = copy.deepcopy(bundle)
+    tampered["operations"][0]["request"]["object_type"] = "tampered"
+    rejected = work_profile.import_authority(destination, tampered)
+    assert rejected["ok"] is False
+    assert rejected["failure_code"] == "bundle-root-mismatch"
+
+    planned = work_profile.import_authority(destination, bundle)
+    assert planned["ok"] is True, planned
+    assert planned["status"] == "planned"
+    assert planned["write_occurred"] is False
+    assert work_profile.inspect(destination, request["refName"])["status"] == "absent"
+
+    imported = work_profile.import_authority(destination, bundle, execute=True)
+    assert imported["ok"] is True, imported
+    assert imported["status"] == "imported"
+    assert imported["result"]["record_roots_preserved"] is True
+    assert imported["result"]["refs_preserved"] is True
+
+    source_state = work_profile.inspect(source, request["refName"])
+    destination_state = work_profile.inspect(destination, request["refName"])
+    assert destination_state == source_state
+    assert destination_state["cutRoot"] == continued["result"]["cutRoot"]
+    assert destination_state["revision"] == 2
+
+    destination_export = work_profile.export_authority(destination)
+    assert destination_export["result"]["bundle_root"] == bundle["bundleRoot"]
+
+    resumed = work_profile.apply_action(
+        destination,
+        _successor_request(continued, action_id="clean-home-continuation"),
+        execute=True,
+    )
+    assert resumed["status"] == "accepted", resumed
+    assert resumed["result"]["revision"] == 3
+
+
+def test_native_profile_authority_import_preflights_all_operations_before_writing(
+    tmp_path,
+):
+    source = tmp_path / "source"
+    destination = tmp_path / "destination"
+    request = _request()
+    created = work_profile.apply_action(source, request, execute=True)
+    work_profile.apply_action(
+        source,
+        _successor_request(created, action_id="source-continuation"),
+        execute=True,
+    )
+    bundle = copy.deepcopy(work_profile.export_authority(source)["result"]["bundle"])
+
+    # The outer bundle root is valid, but a later operation is not executable.
+    # Earlier implementations discovered this only after prior records landed.
+    bundle["operations"][1]["action"] = "unsupported-import-operation"
+    bundle["operations"][1]["request"]["action"] = "unsupported-import-operation"
+    _reroot_bundle(bundle)
+
+    rejected = work_profile.import_authority(destination, bundle, execute=True)
+    assert rejected["ok"] is False
+    assert rejected["failure_code"] == "import-preflight-operation-mismatch"
+    assert rejected["write_occurred"] is False
+    assert work_profile.inspect(destination, request["refName"])["status"] == "absent"
+
+
+def test_native_profile_backend_switch_and_rollback_preserve_five_role_identity(
+    tmp_path, monkeypatch
+):
+    runtime_dir = tmp_path / "runtime"
+    request = _request()
+    monkeypatch.setenv("KUNGFU_STORAGE_PROVIDER", FILE)
+    created = work_profile.apply_action(runtime_dir, request, execute=True)
+    before = work_profile.inspect(runtime_dir, request["refName"])
+    before_bundle = work_profile.export_authority(runtime_dir)["result"]["bundle"]
+
+    switched = service.backend_switch(runtime_dir, target_provider=ROCKS)
+    assert switched["ok"] is True, switched
+    assert switched["source_provider"] == FILE
+    assert switched["target_provider"] == ROCKS
+    assert switched["pre_cut"] == switched["post_cut"]
+    monkeypatch.delenv("KUNGFU_STORAGE_PROVIDER")
+
+    after_switch = work_profile.inspect(runtime_dir, request["refName"])
+    after_switch_bundle = work_profile.export_authority(runtime_dir)["result"]["bundle"]
+    assert after_switch == before
+    assert after_switch_bundle == before_bundle
+    assert set(after_switch["roles"]) == set(work_profile.ROLES)
+
+    continued = work_profile.apply_action(
+        runtime_dir,
+        _successor_request(created, action_id="rocks-continuation"),
+        execute=True,
+    )
+    before_rollback = work_profile.inspect(runtime_dir, request["refName"])
+    before_rollback_bundle = work_profile.export_authority(runtime_dir)["result"][
+        "bundle"
+    ]
+    monkeypatch.setenv("KUNGFU_STORAGE_PROVIDER", FILE)
+    rolled_back = service.backend_rollback(runtime_dir, expected_generation=2)
+    assert rolled_back["source_provider"] == ROCKS
+    assert rolled_back["target_provider"] == FILE
+    assert rolled_back["target_generation"] == 3
+    monkeypatch.delenv("KUNGFU_STORAGE_PROVIDER")
+
+    assert work_profile.inspect(runtime_dir, request["refName"]) == before_rollback
+    assert (
+        work_profile.export_authority(runtime_dir)["result"]["bundle"]
+        == before_rollback_bundle
+    )
+    assert continued["result"]["revision"] == 2
+
+
+def test_native_profile_retains_authority_freshness_direction_and_causality(tmp_path):
+    runtime_dir = tmp_path / "runtime"
+    created = work_profile.apply_action(runtime_dir, _request(), execute=True)
+
+    attenuated = work_profile.apply_action(
+        runtime_dir,
+        _role_transition_request(
+            created,
+            action_id="native-attenuate-warrant",
+            role="warrant",
+            operation="attenuate",
+            from_state="issued",
+            to_state="attenuated",
+            payload={
+                "allowedOperations": [
+                    "atlas:mark-stale",
+                    "atlas:refresh",
+                    "episode:seal",
+                    "episode:reconcile",
+                    "pursuit:branch",
+                    "pursuit:abandon",
+                    "warrant:revoke",
+                ],
+                "validThroughRevision": 10,
+            },
+        ),
+        execute=True,
+    )
+    assert attenuated["status"] == "accepted", attenuated
+
+    stale = work_profile.apply_action(
+        runtime_dir,
+        _role_transition_request(
+            attenuated,
+            action_id="native-atlas-stale",
+            role="atlas",
+            operation="mark-stale",
+            from_state="current",
+            to_state="stale",
+            payload={
+                "lossRoots": [_root("6")],
+                "lossReason": "retained source invalidation",
+            },
+        ),
+        execute=True,
+    )
+    assert stale["status"] == "accepted", stale
+    blocked = work_profile.apply_action(
+        runtime_dir,
+        _role_transition_request(
+            stale,
+            action_id="native-stale-atlas-blocks-action",
+            role="pursuit",
+            operation="continue",
+            from_state="active",
+            to_state="active",
+            payload={"continuation": "must be rejected"},
+        ),
+        execute=True,
+    )
+    assert blocked["failureCode"] == "atlas-stale"
+    assert blocked["writeOccurred"] is False
+
+    refreshed = work_profile.apply_action(
+        runtime_dir,
+        _role_transition_request(
+            stale,
+            action_id="native-atlas-refresh",
+            role="atlas",
+            operation="refresh",
+            from_state="stale",
+            to_state="current",
+            payload={
+                "sourceRoots": [_root("7")],
+                "lossRoots": [_root("6")],
+                "validThroughRevision": 10,
+            },
+        ),
+        execute=True,
+    )
+    assert refreshed["status"] == "accepted", refreshed
+
+    branch = work_profile.apply_action(
+        runtime_dir,
+        _role_transition_request(
+            refreshed,
+            action_id="native-pursuit-branch",
+            role="pursuit",
+            operation="branch",
+            from_state="active",
+            to_state="active",
+            payload={
+                "branchOfCutRoot": refreshed["result"]["cutRoot"],
+                "branchReasonRoot": _root("8"),
+            },
+            ref_name="profiles/kfd-7/native-branch",
+            new_ref=True,
+        ),
+        execute=True,
+    )
+    assert branch["status"] == "accepted", branch
+    abandoned = work_profile.apply_action(
+        runtime_dir,
+        _role_transition_request(
+            branch,
+            action_id="native-pursuit-abandon",
+            role="pursuit",
+            operation="abandon",
+            from_state="active",
+            to_state="abandoned",
+            payload={"settlementRoot": _root("9"), "outcome": "branch terminated"},
+            ref_name="profiles/kfd-7/native-branch",
+        ),
+        execute=True,
+    )
+    assert abandoned["status"] == "accepted", abandoned
+
+    endpoint = _root("a")
+    sealed_payload = {
+        "episodeId": "episode:native-test",
+        "beforeCutRoot": endpoint,
+        "afterCutRoot": endpoint,
+        "causalRoot": _root("b"),
+        "sealedContentRoot": _root("c"),
+    }
+    sealed = work_profile.apply_action(
+        runtime_dir,
+        _role_transition_request(
+            refreshed,
+            action_id="native-episode-seal",
+            role="episode",
+            operation="seal",
+            from_state="open",
+            to_state="sealed",
+            payload=sealed_payload,
+        ),
+        execute=True,
+    )
+    assert sealed["status"] == "accepted", sealed
+    mismatch = copy.deepcopy(sealed_payload)
+    mismatch["causalRoot"] = _root("d")
+    rejected_replay = work_profile.apply_action(
+        runtime_dir,
+        _role_transition_request(
+            sealed,
+            action_id="native-episode-replay-mismatch",
+            role="episode",
+            operation="reconcile",
+            from_state="sealed",
+            to_state="reconciled",
+            payload={"replay": mismatch},
+        ),
+        execute=True,
+    )
+    assert rejected_replay["failureCode"] == "replay-mismatch"
+    assert rejected_replay["writeOccurred"] is False
+    replayed = work_profile.apply_action(
+        runtime_dir,
+        _role_transition_request(
+            sealed,
+            action_id="native-episode-replay-exact",
+            role="episode",
+            operation="reconcile",
+            from_state="sealed",
+            to_state="reconciled",
+            payload={"replay": sealed_payload},
+        ),
+        execute=True,
+    )
+    assert replayed["status"] == "accepted", replayed
+
+    revoked = work_profile.apply_action(
+        runtime_dir,
+        _role_transition_request(
+            replayed,
+            action_id="native-warrant-revoke",
+            role="warrant",
+            operation="revoke",
+            from_state="attenuated",
+            to_state="revoked",
+            payload={"reason": "qualification end", "reasonRoot": _root("e")},
+        ),
+        execute=True,
+    )
+    assert revoked["status"] == "accepted", revoked
+    denied_after_revoke = work_profile.apply_action(
+        runtime_dir,
+        _role_transition_request(
+            revoked,
+            action_id="native-after-revoke",
+            role="pursuit",
+            operation="continue",
+            from_state="active",
+            to_state="active",
+            payload={"continuation": "must fail"},
+        ),
+        execute=True,
+    )
+    assert denied_after_revoke["failureCode"] == "warrant-revoked"
+    assert denied_after_revoke["writeOccurred"] is False

--- a/framework/core/tests/python/test_agent_work_state_contract.py
+++ b/framework/core/tests/python/test_agent_work_state_contract.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import copy
+import base64
 import hashlib
 import json
 import sys
@@ -192,6 +193,61 @@ def test_agent_work_model_closes_the_kfd3_runtime_interface(tmp_path):
     assert payload["runtimeAnchors"]["missingRuntimeAnchors"] == []
     assert payload["commandCatalog"]["missingRegistryEntries"] == []
     assert payload["commandCatalog"]["missingCatalogEntries"] == []
+
+
+def test_kfd7_authority_bundle_cli_exports_and_imports_the_same_public_shape(
+    tmp_path, monkeypatch
+):
+    bundle = {
+        "schema": work_profile.AUTHORITY_BUNDLE_SCHEMA,
+        "bundleRoot": "sha256:" + "a" * 64,
+    }
+    exported = {
+        "ok": True,
+        "status": "exported",
+        "result": {"bundle": bundle},
+    }
+    observed = {}
+    monkeypatch.setattr(work_profile, "export_authority", lambda runtime_dir: exported)
+
+    def import_authority(runtime_dir, candidate, *, execute=False):
+        observed.update(
+            {"runtimeDir": str(runtime_dir), "bundle": candidate, "execute": execute}
+        )
+        return {"ok": True, "status": "imported" if execute else "planned"}
+
+    monkeypatch.setattr(work_profile, "import_authority", import_authority)
+    runner = CliRunner()
+    home = tmp_path / "home"
+    export_result = runner.invoke(
+        kfc,
+        ["--home", str(home), "agent", "work", "export-authority", "--json"],
+    )
+    encoded = base64.b64encode(json.dumps(bundle).encode()).decode()
+    import_result = runner.invoke(
+        kfc,
+        [
+            "--home",
+            str(home),
+            "agent",
+            "work",
+            "import-authority",
+            "--input-base64",
+            encoded,
+            "--execute",
+            "--json",
+        ],
+    )
+
+    assert export_result.exit_code == 0, export_result.output
+    assert json.loads(export_result.output) == exported
+    assert import_result.exit_code == 0, import_result.output
+    assert json.loads(import_result.output)["status"] == "imported"
+    assert observed == {
+        "runtimeDir": str(home / "runtime"),
+        "bundle": bundle,
+        "execute": True,
+    }
 
 
 def _root(value):
@@ -425,6 +481,49 @@ def _profile_request():
     }
 
 
+def _session_fixture():
+    return {
+        "schema": work_profile.SESSION_SCHEMA,
+        "sessionId": "session:release-check",
+        "goal": {
+            "pursuitId": "pursuit:release-check",
+            "state": "active",
+            "summary": "qualify the exact release cut",
+            "operations": ["fact:successor", "episode:seal"],
+            "alternatives": [],
+        },
+        "context": {
+            "atlasId": "atlas:release-check",
+            "state": "current",
+            "perspective": "release-reviewer",
+            "perspectives": ["release-reviewer"],
+            "basisRevision": 4,
+            "validThroughRevision": 4,
+            "lossRoots": [],
+        },
+        "permissions": {
+            "warrantId": "warrant:release-check",
+            "state": "issued",
+            "allowedOperations": ["fact:successor", "episode:seal"],
+            "validThroughRevision": 4,
+            "delegated": False,
+        },
+        "run": {
+            "episodeId": "episode:release-check",
+            "episodeIds": ["episode:release-check"],
+            "state": "open",
+            "causalRoot": "sha256:" + "a" * 64,
+        },
+        "facts": {
+            "factId": "fact:release-check",
+            "state": "declared",
+            "inputRoot": "sha256:" + "b" * 64,
+            "resultRoots": ["sha256:" + "c" * 64],
+            "branchRoots": [],
+        },
+    }
+
+
 def _successor_request(previous, *, action_id="continue-1"):
     request = _profile_request()
     request["actionId"] = action_id
@@ -452,6 +551,47 @@ def _successor_request(previous, *, action_id="continue-1"):
     return request
 
 
+def _role_transition_request(
+    previous,
+    *,
+    action_id,
+    role,
+    operation,
+    from_state,
+    to_state,
+    payload,
+    ref_name=None,
+    new_ref=False,
+):
+    request = _profile_request()
+    request["actionId"] = action_id
+    request["refName"] = ref_name or request["refName"]
+    request["basis"] = {
+        "cutRoot": previous["result"]["cutRoot"],
+        "revision": previous["result"]["revision"],
+    }
+    request["ref"] = (
+        {"cutRoot": None, "revision": 0} if new_ref else copy.deepcopy(request["basis"])
+    )
+    request["subject"] = {
+        "role": role,
+        "operation": operation,
+        "fromState": from_state,
+        "toState": to_state,
+    }
+    request["responsibilities"] = {
+        current_role: {
+            "objectId": request["responsibilities"][current_role]["objectId"],
+            "expectedVersionRoot": previous["result"]["roleVersions"][current_role],
+        }
+        for current_role in work_profile.ROLES
+    }
+    request.pop("roleInputs")
+    request["relations"] = []
+    request["payload"] = copy.deepcopy(payload)
+    return request
+
+
 def test_kfd7_profile_capabilities_and_typed_responsibility_gap():
     capabilities = work_profile.capabilities()
     assert capabilities["roles"] == ["fact", "episode", "pursuit", "atlas", "warrant"]
@@ -463,6 +603,149 @@ def test_kfd7_profile_capabilities_and_typed_responsibility_gap():
     )
     request = _profile_request()
     del request["responsibilities"]["warrant"]
+
+    denied = work_profile.apply_action("/unused", request, kernel=_MemoryFactKernel())
+
+    assert denied["status"] == "denied"
+    assert denied["failureCode"] == "responsibility-gap"
+    assert denied["writeOccurred"] is False
+
+
+def test_kfd7_simple_session_round_trips_all_five_decision_observations():
+    session = _session_fixture()
+    expanded = work_profile.expand_session(session)
+
+    assert expanded["compressibility"] == {
+        "schema": work_profile.SESSION_COMPRESSIBILITY_SCHEMA,
+        "sessionId": session["sessionId"],
+        "compressible": True,
+        "breakpoints": [],
+        "revealedRoles": [],
+    }
+    assert set(expanded["observations"]) == {
+        "direction",
+        "perspective-boundary",
+        "effective-authority",
+        "causal-process",
+        "admitted-result",
+    }
+    assert work_profile.project_session(expanded) == session
+
+
+def test_kfd7_session_cli_and_python_api_share_the_same_projection(tmp_path):
+    session = _session_fixture()
+    encoded = base64.b64encode(json.dumps(session).encode()).decode()
+    result = CliRunner().invoke(
+        kfc,
+        [
+            "--home",
+            str(tmp_path / "home"),
+            "agent",
+            "work",
+            "session",
+            "--operation",
+            "expand",
+            "--input-base64",
+            encoded,
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output) == work_profile.expand_session(session)
+
+
+@pytest.mark.parametrize(
+    ("role", "mutate"),
+    [
+        (
+            "pursuit",
+            lambda value: value["goal"].update({"alternatives": ["pursuit:other"]}),
+        ),
+        (
+            "atlas",
+            lambda value: value["context"].update(
+                {"state": "stale", "lossRoots": ["sha256:" + "d" * 64]}
+            ),
+        ),
+        (
+            "warrant",
+            lambda value: value["permissions"].update({"state": "revoked"}),
+        ),
+        (
+            "episode",
+            lambda value: value["run"].update(
+                {"episodeIds": ["episode:release-check", "episode:retry"]}
+            ),
+        ),
+        (
+            "fact",
+            lambda value: value["facts"].update(
+                {"branchRoots": ["sha256:" + "e" * 64]}
+            ),
+        ),
+    ],
+)
+def test_kfd7_session_complexity_breakpoints_reveal_the_independent_role(role, mutate):
+    session = _session_fixture()
+    mutate(session)
+    expanded = work_profile.expand_session(session)
+
+    assert expanded["compressibility"]["compressible"] is False
+    assert role in expanded["compressibility"]["revealedRoles"]
+    with pytest.raises(ValueError, match="session-complexity-breakpoint"):
+        work_profile.project_session(expanded)
+
+
+def test_kfd7_same_payload_has_different_actions_without_direction_authority_or_freshness():
+    baseline = _session_fixture()
+    payload = copy.deepcopy(baseline["facts"])
+    assert work_profile.session_valid_actions(baseline) == [
+        "episode:seal",
+        "fact:successor",
+    ]
+
+    different_direction = copy.deepcopy(baseline)
+    different_direction["goal"]["operations"] = ["episode:seal"]
+    weaker_authority = copy.deepcopy(baseline)
+    weaker_authority["permissions"]["allowedOperations"] = ["fact:successor"]
+    stale_context = copy.deepcopy(baseline)
+    stale_context["context"]["validThroughRevision"] = 3
+
+    for candidate in (different_direction, weaker_authority, stale_context):
+        assert candidate["facts"] == payload
+    assert work_profile.session_valid_actions(different_direction) == ["episode:seal"]
+    assert work_profile.session_valid_actions(weaker_authority) == ["fact:successor"]
+    assert work_profile.session_valid_actions(stale_context) == []
+
+
+@pytest.mark.parametrize("role", work_profile.ROLES)
+def test_kfd7_profile_role_deletion_fails_before_write(role):
+    request = _profile_request()
+    del request["responsibilities"][role]
+
+    denied = work_profile.apply_action("/unused", request, kernel=_MemoryFactKernel())
+
+    assert denied["status"] == "denied"
+    assert denied["failureCode"] == "responsibility-gap"
+    assert denied["writeOccurred"] is False
+
+
+@pytest.mark.parametrize(
+    ("left", "right"),
+    [
+        ("fact", "episode"),
+        ("episode", "pursuit"),
+        ("pursuit", "atlas"),
+        ("atlas", "warrant"),
+        ("fact", "warrant"),
+    ],
+)
+def test_kfd7_profile_role_fusion_fails_before_write(left, right):
+    request = _profile_request()
+    request["responsibilities"][right]["objectId"] = request["responsibilities"][left][
+        "objectId"
+    ]
 
     denied = work_profile.apply_action("/unused", request, kernel=_MemoryFactKernel())
 
@@ -570,3 +853,354 @@ def test_kfd7_profile_rejects_stale_atlas_and_expired_warrant_before_writes():
 
     assert expired["failureCode"] == "warrant-expired"
     assert expired["writeOccurred"] is False
+
+
+def test_kfd7_profile_warrant_attenuation_and_revocation_are_enforced():
+    kernel = _MemoryFactKernel()
+    created = work_profile.apply_action(
+        "/runtime", _profile_request(), execute=True, kernel=kernel
+    )
+    attenuated = work_profile.apply_action(
+        "/runtime",
+        _role_transition_request(
+            created,
+            action_id="attenuate-warrant",
+            role="warrant",
+            operation="attenuate",
+            from_state="issued",
+            to_state="attenuated",
+            payload={
+                "allowedOperations": ["pursuit:continue", "warrant:revoke"],
+                "validThroughRevision": 5,
+            },
+        ),
+        execute=True,
+        kernel=kernel,
+    )
+    assert attenuated["status"] == "accepted"
+
+    denied = work_profile.apply_action(
+        "/runtime",
+        _role_transition_request(
+            attenuated,
+            action_id="complete-outside-scope",
+            role="pursuit",
+            operation="complete",
+            from_state="active",
+            to_state="completed",
+            payload={"settlementRoot": "sha256:" + "8" * 64, "outcome": "done"},
+        ),
+        execute=True,
+        kernel=kernel,
+    )
+    assert denied["failureCode"] == "unauthorized"
+    assert denied["writeOccurred"] is False
+
+    revoked = work_profile.apply_action(
+        "/runtime",
+        _role_transition_request(
+            attenuated,
+            action_id="revoke-warrant",
+            role="warrant",
+            operation="revoke",
+            from_state="attenuated",
+            to_state="revoked",
+            payload={
+                "reason": "issuer withdrew authority",
+                "reasonRoot": "sha256:" + "9" * 64,
+            },
+        ),
+        execute=True,
+        kernel=kernel,
+    )
+    assert revoked["status"] == "accepted"
+    rejected_after_revoke = work_profile.apply_action(
+        "/runtime",
+        _role_transition_request(
+            revoked,
+            action_id="continue-after-revoke",
+            role="pursuit",
+            operation="continue",
+            from_state="active",
+            to_state="active",
+            payload={"continuation": "must fail"},
+        ),
+        execute=True,
+        kernel=kernel,
+    )
+    assert rejected_after_revoke["failureCode"] == "warrant-revoked"
+    assert rejected_after_revoke["writeOccurred"] is False
+
+
+def test_kfd7_profile_atlas_loss_refresh_and_pursuit_branch_are_explicit():
+    kernel = _MemoryFactKernel()
+    created = work_profile.apply_action(
+        "/runtime", _profile_request(), execute=True, kernel=kernel
+    )
+    stale = work_profile.apply_action(
+        "/runtime",
+        _role_transition_request(
+            created,
+            action_id="mark-atlas-stale",
+            role="atlas",
+            operation="mark-stale",
+            from_state="current",
+            to_state="stale",
+            payload={
+                "lossRoots": ["sha256:" + "a" * 64],
+                "lossReason": "source expired",
+            },
+        ),
+        execute=True,
+        kernel=kernel,
+    )
+    assert stale["status"] == "accepted"
+    blocked = work_profile.apply_action(
+        "/runtime",
+        _role_transition_request(
+            stale,
+            action_id="blocked-by-stale-atlas",
+            role="pursuit",
+            operation="continue",
+            from_state="active",
+            to_state="active",
+            payload={"continuation": "unsafe"},
+        ),
+        execute=True,
+        kernel=kernel,
+    )
+    assert blocked["failureCode"] == "atlas-stale"
+    assert blocked["writeOccurred"] is False
+
+    refreshed = work_profile.apply_action(
+        "/runtime",
+        _role_transition_request(
+            stale,
+            action_id="refresh-atlas",
+            role="atlas",
+            operation="refresh",
+            from_state="stale",
+            to_state="current",
+            payload={
+                "sourceRoots": ["sha256:" + "b" * 64],
+                "lossRoots": ["sha256:" + "a" * 64],
+                "validThroughRevision": 10,
+            },
+        ),
+        execute=True,
+        kernel=kernel,
+    )
+    assert refreshed["status"] == "accepted"
+
+    branched = work_profile.apply_action(
+        "/runtime",
+        _role_transition_request(
+            refreshed,
+            action_id="branch-pursuit",
+            role="pursuit",
+            operation="branch",
+            from_state="active",
+            to_state="active",
+            payload={
+                "branchOfCutRoot": refreshed["result"]["cutRoot"],
+                "branchReasonRoot": "sha256:" + "c" * 64,
+            },
+            ref_name="profiles/work/branch",
+            new_ref=True,
+        ),
+        execute=True,
+        kernel=kernel,
+    )
+    assert branched["status"] == "accepted"
+    assert branched["result"]["revision"] == 1
+    assert (
+        work_profile.inspect("/runtime", "profiles/work/main", kernel=kernel)[
+            "revision"
+        ]
+        == 3
+    )
+
+    abandoned = work_profile.apply_action(
+        "/runtime",
+        _role_transition_request(
+            branched,
+            action_id="abandon-branch",
+            role="pursuit",
+            operation="abandon",
+            from_state="active",
+            to_state="abandoned",
+            payload={
+                "settlementRoot": "sha256:" + "d" * 64,
+                "outcome": "superseded by main",
+            },
+            ref_name="profiles/work/branch",
+        ),
+        execute=True,
+        kernel=kernel,
+    )
+    assert abandoned["status"] == "accepted"
+
+
+def test_kfd7_profile_episode_replay_distinguishes_equal_endpoint_causality():
+    kernel = _MemoryFactKernel()
+    created = work_profile.apply_action(
+        "/runtime", _profile_request(), execute=True, kernel=kernel
+    )
+    endpoint = "sha256:" + "d" * 64
+    sealed_payload = {
+        "episodeId": "episode:1",
+        "beforeCutRoot": endpoint,
+        "afterCutRoot": endpoint,
+        "causalRoot": "sha256:" + "e" * 64,
+        "sealedContentRoot": "sha256:" + "f" * 64,
+    }
+    sealed = work_profile.apply_action(
+        "/runtime",
+        _role_transition_request(
+            created,
+            action_id="seal-equal-endpoint-episode",
+            role="episode",
+            operation="seal",
+            from_state="open",
+            to_state="sealed",
+            payload=sealed_payload,
+        ),
+        execute=True,
+        kernel=kernel,
+    )
+    assert sealed["status"] == "accepted"
+
+    mismatched = copy.deepcopy(sealed_payload)
+    mismatched["causalRoot"] = "sha256:" + "0" * 64
+    replay_denied = work_profile.apply_action(
+        "/runtime",
+        _role_transition_request(
+            sealed,
+            action_id="replay-mismatched-causality",
+            role="episode",
+            operation="reconcile",
+            from_state="sealed",
+            to_state="reconciled",
+            payload={"replay": mismatched},
+        ),
+        execute=True,
+        kernel=kernel,
+    )
+    assert replay_denied["failureCode"] == "replay-mismatch"
+    assert replay_denied["writeOccurred"] is False
+
+    replayed = work_profile.apply_action(
+        "/runtime",
+        _role_transition_request(
+            sealed,
+            action_id="replay-exact-causality",
+            role="episode",
+            operation="reconcile",
+            from_state="sealed",
+            to_state="reconciled",
+            payload={"replay": sealed_payload},
+        ),
+        execute=True,
+        kernel=kernel,
+    )
+    assert replayed["status"] == "accepted"
+
+
+def test_kfd7_context_only_rival_loses_each_decision_relevant_role():
+    baseline_kernel = _MemoryFactKernel()
+    created = work_profile.apply_action(
+        "/baseline", _profile_request(), execute=True, kernel=baseline_kernel
+    )
+    candidate = _successor_request(created, action_id="same-visible-task")
+    visible_task = {
+        "subject": copy.deepcopy(candidate["subject"]),
+        "payload": copy.deepcopy(candidate["payload"]),
+    }
+    baseline_plan = work_profile.apply_action(
+        "/baseline", candidate, kernel=baseline_kernel
+    )
+    assert baseline_plan["status"] == "planned"
+    assert baseline_plan["changedRoles"] == ["pursuit"]
+
+    fact_variant = copy.deepcopy(candidate)
+    fact_variant["responsibilities"]["fact"]["expectedVersionRoot"] = (
+        "sha256:" + "7" * 64
+    )
+    assert {
+        "subject": fact_variant["subject"],
+        "payload": fact_variant["payload"],
+    } == visible_task
+    assert (
+        work_profile.apply_action("/baseline", fact_variant, kernel=baseline_kernel)[
+            "failureCode"
+        ]
+        == "profile-state-mismatch"
+    )
+
+    pursuit_kernel = _MemoryFactKernel()
+    pursuit_created = work_profile.apply_action(
+        "/pursuit", _profile_request(), execute=True, kernel=pursuit_kernel
+    )
+    pursuit_root = pursuit_created["result"]["roleVersions"]["pursuit"]
+    pursuit_body = json.loads(pursuit_kernel.versions[pursuit_root]["body"])
+    pursuit_body["state"] = "completed"
+    pursuit_kernel.versions[pursuit_root]["body"] = json.dumps(
+        pursuit_body, sort_keys=True
+    )
+    pursuit_variant = _successor_request(pursuit_created, action_id="same-visible-task")
+    assert {
+        "subject": pursuit_variant["subject"],
+        "payload": pursuit_variant["payload"],
+    } == visible_task
+    assert (
+        work_profile.apply_action("/pursuit", pursuit_variant, kernel=pursuit_kernel)[
+            "failureCode"
+        ]
+        == "profile-state-mismatch"
+    )
+
+    atlas_kernel = _MemoryFactKernel()
+    atlas_created = work_profile.apply_action(
+        "/atlas", _profile_request(), execute=True, kernel=atlas_kernel
+    )
+    atlas_root = atlas_created["result"]["roleVersions"]["atlas"]
+    atlas_body = json.loads(atlas_kernel.versions[atlas_root]["body"])
+    atlas_body["state"] = "stale"
+    atlas_kernel.versions[atlas_root]["body"] = json.dumps(atlas_body, sort_keys=True)
+    atlas_variant = _successor_request(atlas_created, action_id="same-visible-task")
+    assert {
+        "subject": atlas_variant["subject"],
+        "payload": atlas_variant["payload"],
+    } == visible_task
+    assert (
+        work_profile.apply_action("/atlas", atlas_variant, kernel=atlas_kernel)[
+            "failureCode"
+        ]
+        == "atlas-stale"
+    )
+
+    warrant_kernel = _MemoryFactKernel()
+    warrant_created = work_profile.apply_action(
+        "/warrant", _profile_request(), execute=True, kernel=warrant_kernel
+    )
+    warrant_root = warrant_created["result"]["roleVersions"]["warrant"]
+    warrant_body = json.loads(warrant_kernel.versions[warrant_root]["body"])
+    warrant_body["details"]["allowedOperations"] = ["atlas:refresh"]
+    warrant_kernel.versions[warrant_root]["body"] = json.dumps(
+        warrant_body, sort_keys=True
+    )
+    warrant_variant = _successor_request(warrant_created, action_id="same-visible-task")
+    assert {
+        "subject": warrant_variant["subject"],
+        "payload": warrant_variant["payload"],
+    } == visible_task
+    assert (
+        work_profile.apply_action("/warrant", warrant_variant, kernel=warrant_kernel)[
+            "failureCode"
+        ]
+        == "unauthorized"
+    )
+
+    # A context-only rival also treats equal endpoints as equal. The Profile's
+    # Episode replay fixture above rejects a different causal root, preserving
+    # the fifth role even when beforeCutRoot == afterCutRoot.

--- a/package.json
+++ b/package.json
@@ -198,7 +198,7 @@
   "devDependencies": {
     "@biomejs/biome": "1.9.4",
     "@kungfu-tech/buildchain": "2.14.1",
-    "@kungfu-tech/kfd": "1.0.0-alpha.31",
+    "@kungfu-tech/kfd": "1.0.0-alpha.35",
     "@types/fs-extra": "^11.0.4",
     "@types/markdown-it": "14.1.2",
     "@types/node": "^22.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,8 +36,8 @@ importers:
         specifier: 2.14.1
         version: 2.14.1
       '@kungfu-tech/kfd':
-        specifier: 1.0.0-alpha.31
-        version: 1.0.0-alpha.31
+        specifier: 1.0.0-alpha.35
+        version: 1.0.0-alpha.35
       '@types/fs-extra':
         specifier: ^11.0.4
         version: 11.0.4
@@ -1393,8 +1393,8 @@ packages:
   '@kungfu-tech/kfd@1.0.0-alpha.21':
     resolution: {integrity: sha512-lsr3aJ93pUaO9gxnGBsrTJkTkvpIHPHp9Rxug7WvdS4Zkte3AdFvyCl1DgwQN+/38FAXf8fBozyGkHxxXaN7Dg==}
 
-  '@kungfu-tech/kfd@1.0.0-alpha.31':
-    resolution: {integrity: sha512-Ki5xa9HSw7ZD2TeSkQEVuM+C+ANzbVTE/cKEVtbPrC6Rzqa/sgmmvkLTGL2b15GEBQqvqh6rfQMpr0QTW58G8A==}
+  '@kungfu-tech/kfd@1.0.0-alpha.35':
+    resolution: {integrity: sha512-Kfiu5k+ufGAMGYun4755jxaV4fBd4Xvyupa76wMfptO/WF8/wXG8xrgJr6CJ/gY7r7BMg1MpD36HlJWkhGcyiw==}
     hasBin: true
 
   '@kungfu-tech/libnode-darwin-arm64@22.22.3-kf.3-alpha.16':
@@ -5760,7 +5760,7 @@ snapshots:
 
   '@kungfu-tech/kfd@1.0.0-alpha.21': {}
 
-  '@kungfu-tech/kfd@1.0.0-alpha.31': {}
+  '@kungfu-tech/kfd@1.0.0-alpha.35': {}
 
   '@kungfu-tech/libnode-darwin-arm64@22.22.3-kf.3-alpha.16':
     optional: true


### PR DESCRIPTION
## Summary

Activate the independently qualified Kungfu KFD-7 Product Profile against KFD alpha.35 and the merged Buildchain consumer contract. This is the linear merge-queue delivery of the reviewed tree from #1091 on the current dev baseline.

## Related issue

Atlas goal 2026-07-18-kfd-7-engineering-contract-activation

## Supersedes

- #1091 retained the implementation, evidence, qualification review, and activation review but its merge-commit history could not enter the REBASE merge queue.
- This PR is one linear commit on current `dev/v4/v4.0`; no branch history was rewritten and no protection was bypassed.

## Changes

- restore Fact, Episode, Warrant, Atlas, Pursuit, and Action authority across local and remote homes
- retain twelve positive, negative, recovery, lifecycle, concurrency, and session-refinement evidence categories
- bind the Profile to exact implementation symbols, KFD alpha.35, merged Buildchain evidence, and immutable independent reviews
- activate the qualified Kungfu Product Profile with product-scoped non-claims
- regenerate KFD projections on the current dev baseline

## Verification

- `./shifu check:agent-work-state-contract`
- `./shifu check:source`
- `./shifu docs:check`
- `./shifu kfd:buildchain`
- KFD action-contract schema v2 validation under `@kungfu-tech/kfd@1.0.0-alpha.35`
- Buildchain cross-repository KFD-7 release gate: `passed/pass`, 12/12 evidence categories, zero issues

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "stage-ready",
  "adrs": ["ADR-0109"],
  "summary": "Activate the independently qualified KFD-7 Product Profile with retained runtime and session-refinement evidence",
  "verification": ["./shifu check:agent-work-state-contract", "./shifu check:source", "Buildchain cross-repository KFD-7 release gate"]
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The PR changes retained release evidence and provenance declarations; it performs no publication or deployment.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed
