### PR TITLE
docs: simplify the first-use README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,95 @@
 # Kungfu
 
-Kungfu is a local-first runtime that records real-world agent work and verifies
-what actually got done. It works alongside the agents and execution surfaces
-you already use.
+**Give your agent verified context. Keep the work when the chat ends.**
+
+Stop re-explaining your project every time a chat resets. Kungfu helps an agent
+understand the work from declared project sources, makes missing or conflicting
+context visible, and preserves enough structure for a later agent session to
+continue without reconstructing everything from conversation history.
 
 > **Never Guess. Facts Unfold.**
 
-**Status: Coming soon.**
+**Status: Coming soon.** The first public CLI is being qualified against the
+experience below.
+
+## The first-release experience
+
+The intended one-command path is:
+
+```sh
+cd your-project
+kungfu run agent
+```
+
+The command is the target first-release entrypoint, not a claim that a public
+artifact is available today. A qualified release must let the agent:
+
+- inspect the project and explain what it understands;
+- show important omissions, conflicts, and decisions instead of guessing;
+- keep the current work coherent across fresh contexts and agent processes;
+- record what happened so progress and the next action do not depend on chat
+  history.
+
+The first visible value should arrive within minutes. The deeper value appears
+over the following days, when the same work survives context loss, changed
+understanding, failed attempts, handoff, and restart.
+
+## Why it matters
+
+- **Less context pressure.** The agent can select verified project context
+  instead of repeatedly loading the whole repository.
+- **Durable work continuity.** Intent, current understanding, action boundaries,
+  and outcomes remain available after the original conversation is gone.
+- **Inspectable understanding.** Sources, omissions, uncertainty, and evidence
+  stay visible to both people and agents.
+
+## Keep using the agents you already have
+
+`kungfu run agent` is the golden path, not a required replacement for Codex,
+Claude Code, VS Code, terminals, or other agent surfaces. The same local
+contracts and work state must remain available through the Kungfu CLI and APIs
+when an agent continues to run elsewhere.
+
+## Go deeper
+
+- [How the complete Kungfu system works](docs/concepts/system-overview.md)
+- [Documentation Guide](docs/README.md)
+- [Documentation Map](docs/MAP.md)
+- [Known Limits](docs/qualification/known-limits.md)
+- [Build and contribute](CONTRIBUTING.md)
+
+Agents working from a source checkout should begin with [AGENTS.md](AGENTS.md)
+and [Verified Context for Agents](docs/guides/xinfa-agent-context.md). An
+installed runtime carries its own local agent brief:
+
+```sh
+kungfu agent brief
+```
+
+## Build from source
+
+Public release artifacts are not available yet. To evaluate the current source
+tree:
+
+```sh
+git clone https://github.com/kungfu-systems/kungfu.git
+cd kungfu
+./shifu doctor
+./shifu sync && ./shifu build
+```
+
+## Project status
+
+Kungfu v4 is **Coming soon**. Source-built capabilities and qualification
+slices exist, but public packaging, cross-platform evidence, strong power-loss
+durability, and the institutional profile remain staged unless linked evidence
+says otherwise.
+
+Design intent, implemented behavior, qualified guarantees, and released
+artifacts are deliberately distinct. Before relying on a claim, check
+[Contracts](docs/qualification/contracts.md),
+[Known Limits](docs/qualification/known-limits.md), and the applicable retained
+qualification evidence.
 
 <!-- buildchain:badges:start -->
 [![KFD-1: declared](https://buildchain.libkungfu.dev/badges/v1/kfd-1/declared.svg)](https://github.com/kungfu-systems/kungfu/releases/latest/download/buildchain.release.json)
@@ -21,156 +104,10 @@ you already use.
 [![DCO](https://github.com/kungfu-systems/kungfu/actions/workflows/dco.yml/badge.svg)](https://github.com/kungfu-systems/kungfu/actions/workflows/dco.yml)
 <!-- buildchain:badges:end -->
 
-Kungfu turns execution into **Episodes**, bounded causal units that bind Facts,
-Artifacts, Receipts, dependencies, and verification roots into one inspectable
-record. Episodes can be sealed, exported, and replayed to support recovery and
-evidence-based Decisions.
-
-```text
-Real-world work happens in Episodes.
-Facts are authoritative. Projections are rebuildable.
-Claims require Proof before they support Decisions.
-```
-
-This open monorepo contains the low-latency runtime, CLI and TUI, desktop GUI,
-language bindings, SDKs, extension system, product assembly, and the shared
-qualification contracts that keep them aligned. The user-facing distribution
-is named **Kungfu Episodes**; the runtime, command, SDKs, and extension system
-use the Kungfu, `libkungfu`, and `kfx` names.
-
-## Why an Episode?
-
-Logs show activity. Traces show calls. Workflows describe intended steps. A
-chat session preserves a conversation. None of them, by itself, is the durable
-object needed to answer:
-
-- What actually happened?
-- Which facts and artifacts belong to the work?
-- What did the runtime acknowledge, and what survived a crash?
-- What evidence supports completion?
-- What may safely happen next?
-
-An Episode gives those questions one stable semantic boundary without making a
-process, UI, mutable database row, or provider session the authority. Read
-[The Episode](docs/concepts/the-episode.md) for the narrative and
-[Vocabulary](docs/concepts/vocabulary.md) for the precise public terms.
-
-## What Kungfu lets you do
-
-- Record typed runtime Facts in an append-only journal with explicit schema
-  ownership and provenance.
-- Inspect Episodes, causal Timelines, Artifacts, Receipts, Cuts, Watermarks, and
-  rebuildable Projections.
-- Query current and historical fact state with proof and lineage attached.
-- Replay recorded Facts, Rewind an Episode for forensic inspection, and qualify
-  Recovery without silently repeating external side effects.
-- Embed `libkungfu`, use one ecosystem SDK, add a `kfx`, or assemble a complete
-  application without adopting every higher layer.
-- Qualify visibility, durability, recovery, and meaning as one end-to-end
-  contract rather than treating ingestion speed as sufficient evidence.
-
-## Start here
-
-- **New to Kungfu:** use the curated [Documentation Guide](docs/README.md).
-- **Choosing a product layer:** read [Choose Your Kungfu](docs/guides/choose-your-kungfu.md).
-- **Evaluating trust or production use:** begin with
-  [Known Limits](docs/qualification/known-limits.md) and the
-  [Single-host institutional trust profile](docs/qualification/single-host-institutional-trust.md).
-- **Looking up one exact question:** use the exhaustive
-  [Documentation Map](docs/MAP.md).
-- **Agent starting repository work:** load a verified Xinfa Task Chart with
-  [Verified Context for Agents](docs/guides/xinfa-agent-context.md).
-- **Contributing:** read [CONTRIBUTING.md](CONTRIBUTING.md).
-
-An installed runtime also carries an agent-readable product brief:
-
-```sh
-kungfu agent brief
-kungfu agent docs --json
-kungfu agent docs --verify --json
-kungfu agent capabilities --json
-kungfu agent choose-mode --json
-```
-
-To evaluate the source tree before public artifacts are available:
-
-```sh
-git clone https://github.com/kungfu-systems/kungfu.git
-cd kungfu
-./shifu doctor
-./shifu sync && ./shifu build
-```
-
-## Adopt only what you need
-
-| Job | Smallest relevant surface |
-| --- | --- |
-| complete official experience | assembled Kungfu App |
-| visual inspection and human workflows | GUI |
-| headless operation and automation | CLI/TUI |
-| one language ecosystem | Python, Node/TypeScript, or Rust SDK |
-| native embedding | `libkungfu` |
-| independent preservation and inspection | `.kungfu` format/spec |
-
-Higher layers add convenience; they do not become a second authority over the
-Facts. [Product Layers](docs/concepts/product-layers.md) defines the independent
-qualification contract behind these choices.
-
-## Incubated standalone products
-
-[Xinfa](xinfa/README.md), **The Verified Context Compiler for Human-Agent
-Software Development**, is incubated in
-this repository with its own CLI, protocol namespace, version, artifacts,
-state/cache roots, release identity, and extraction manifest. Its core has no
-Kungfu or Shifu runtime dependency; those products may integrate only through
-thin public-contract adapters. See
-[ADR-0092](docs/adr/ADR-0092-xinfa-product-and-incubation-boundary.md),
-[ADR-0093](docs/adr/ADR-0093-xinfa-dual-first-verified-context-contract.md),
-[ADR-0094](docs/adr/ADR-0094-xinfa-repository-context-pack.md), and
-[ADR-0095](docs/adr/ADR-0095-xinfa-atlas-primitive-and-compatibility-boundary.md).
-
-## Architecture at a glance
-
-The data plane is `yijinjing`, a low-latency append-only mmap journal shared by
-C++, Python, and Node. Closed kernel records use fixed-layout Hana POD schemas;
-open and domain Facts use FlatBuffers. JSON is an edge rendering or interchange
-format, not a third journal schema.
-
-Live work and Replay use the same frame and runtime semantics. SQLite and GUI
-models are rebuildable Projections over journal-backed authority. The runtime,
-capability SDK, application SDK, reference surfaces, and product assembly remain
-separate layers with explicit contracts. See [Architecture](docs/architecture/overview.md)
-and [Event Model](docs/architecture/event-model.md).
-
-## Why Kungfu?
-
-Kungfu began with the Chinese idea of **功夫**: capability built through
-disciplined practice. As the product evolved, **KUNGFU** acquired a recursive
-technical meaning: `KUNGFU UNGFU: Never Guess. Facts Unfold.`
-
-The name describes the architecture: deeply integrated at the product surface,
-self-bootstrapping from Facts at the core. Read
-[Why Kungfu?](docs/concepts/why-kungfu.md) for the complete recursion and its
-connection to the product's fact-first design.
-
-## Status and guarantees
-
-Kungfu v4 is **Coming soon**. Source-built capabilities and qualification
-slices exist, but public packaging, cross-platform evidence, strong
-power-loss durability, and the institutional profile remain staged unless the
-linked evidence says otherwise.
-
-Design intent, implemented behavior, qualified guarantees, and released
-artifacts are deliberately distinct. Before relying on a claim, check
-[Contracts](docs/qualification/contracts.md),
-[Known Limits](docs/qualification/known-limits.md), and the applicable retained
-qualification evidence.
-
 ## Project links
 
 - Product home: <https://kungfu.tech>
 - Developer and agent surface: <https://libkungfu.dev>
-- Documentation: [docs/README.md](docs/README.md)
 - Issues and questions: [GitHub issue forms](https://github.com/kungfu-systems/kungfu/issues/new/choose)
 - Security reports: [SECURITY.md](SECURITY.md)
 - License: [Apache License 2.0](LICENSE)

--- a/docs/MAP.md
+++ b/docs/MAP.md
@@ -36,7 +36,8 @@ contracts remain in [Shifu](shifu/README.md).
 | Your question | Document | Plane | Status |
 |---|---|---|---|
 | Which documentation route should I follow for my job? | [`README.md`](README.md) | use | current |
-| What is kungfu, in one idea? | [`../README.md`](../README.md) | — | stable |
+| What problem does Kungfu solve for an agent user, and what is the intended first-release experience? | [`../README.md`](../README.md) | use | pre-release |
+| How does the complete Kungfu system fit together behind that simple entry? | [`system-overview.md`](concepts/system-overview.md) | why, use | current |
 | How do journal authority, Fact state, and Episode causal experience fit together, and why can Episode remain the flagship temporal object without becoming the only substrate? | [`fact-episode-action-runtime.md`](architecture/fact-episode-action-runtime.md) + [`the-episode.md`](concepts/the-episode.md) + [`vocabulary.md`](concepts/vocabulary.md) | why, use, verify | current integration model · Fact kernel writer and wider qualification remain staged |
 | Do I need the whole Kungfu App, or which smaller product should I start with? | [`choose-your-kungfu.md`](guides/choose-your-kungfu.md) | use | draft · adoption contract accepted; artifacts qualify independently in stages |
 | What do the implementation terms mean (`kungfu` / `yijinjing` / journal / schema …)? | [`concepts.md`](concepts/implementation-concepts.md) | use | stable |

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,20 +29,23 @@ matches your job, then go deeper only when you need to.
 
 Read these in order for the product model:
 
-1. [Facts Before Trust](concepts/facts-before-trust.md) — why evidence, responsibility,
+1. [System Overview](concepts/system-overview.md) — how the complete runtime,
+   product layers, Episode model, and monorepo fit together after the concise
+   first-use entry.
+2. [Facts Before Trust](concepts/facts-before-trust.md) — why evidence, responsibility,
    and local proof come before control decisions.
-2. [The Episode](concepts/the-episode.md) — why causal experience needs a stable
+3. [The Episode](concepts/the-episode.md) — why causal experience needs a stable
    object beyond a run, process, log, trace, workflow, or chat session, and how
    that object relates to Fact state.
-3. [Fact, Episode, and Action Primitive Runtime](architecture/fact-episode-action-runtime.md)
+4. [Fact, Episode, and Action Primitive Runtime](architecture/fact-episode-action-runtime.md)
    — the canonical integration model for journal authority, the two runtime
    substrates, and Pursuit, Atlas, and Warrant.
-4. [Design Philosophy](concepts/design-philosophy.md) — the principles and trade-offs
+5. [Design Philosophy](concepts/design-philosophy.md) — the principles and trade-offs
    behind the architecture.
-5. [Vocabulary Reference](concepts/vocabulary.md) — canonical definitions for Episode,
+6. [Vocabulary Reference](concepts/vocabulary.md) — canonical definitions for Episode,
    Fact, Artifact, Receipt, Cut, Watermark, Projection, Timeline, Claim, Proof,
    TrustReport, Decision, Replay, Rewind, and Recovery.
-6. [Known Limits](qualification/known-limits.md) — what is not yet implemented, qualified, or
+7. [Known Limits](qualification/known-limits.md) — what is not yet implemented, qualified, or
    released.
 
 For long-running work, [Agent Work State](profiles/agent-work-state.md) separates

--- a/docs/concepts/README.md
+++ b/docs/concepts/README.md
@@ -1,13 +1,16 @@
 # Concepts
 
-This section owns Kungfu's public mental model: journal-backed Fact state,
-Episode causal experience, the fact-first trust boundary, the name's recursive
-technical meaning, canonical vocabulary, implementation concepts, and product
-layers. Start with [Facts Before Trust](facts-before-trust.md), then read
-[The Episode](the-episode.md) and use the
-[Vocabulary Reference](vocabulary.md) for precise terms. The canonical
-integration model is [Fact, Episode, and Action Primitive Runtime](../architecture/fact-episode-action-runtime.md).
+This section owns Kungfu's public mental model: the complete system overview,
+journal-backed Fact state, Episode causal experience, the fact-first trust
+boundary, the name's recursive technical meaning, canonical vocabulary,
+implementation concepts, and product layers. Start with
+[System Overview](system-overview.md), continue with
+[Facts Before Trust](facts-before-trust.md), then read [The Episode](the-episode.md)
+and use the [Vocabulary Reference](vocabulary.md) for precise terms. The
+canonical integration model is
+[Fact, Episode, and Action Primitive Runtime](../architecture/fact-episode-action-runtime.md).
 
+- [System Overview](system-overview.md)
 - [Facts Before Trust](facts-before-trust.md)
 - [The Episode](the-episode.md)
 - [Why Kungfu?](why-kungfu.md)

--- a/docs/concepts/system-overview.md
+++ b/docs/concepts/system-overview.md
@@ -1,0 +1,130 @@
+# Kungfu System Overview
+
+Kungfu is a local-first runtime that records real-world agent work and verifies
+what actually got done. It works alongside the agents and execution surfaces
+you already use.
+
+This page is the second layer behind the concise project
+[README](../../README.md). It explains the complete system model without making
+new users understand that model before they receive value.
+
+Kungfu turns execution into **Episodes**, bounded causal units that bind Facts,
+Artifacts, Receipts, dependencies, and verification roots into one inspectable
+record. Episodes can be sealed, exported, and replayed to support recovery and
+evidence-based Decisions.
+
+```text
+Real-world work happens in Episodes.
+Facts are authoritative. Projections are rebuildable.
+Claims require Proof before they support Decisions.
+```
+
+This open monorepo contains the low-latency runtime, CLI and TUI, desktop GUI,
+language bindings, SDKs, extension system, product assembly, and the shared
+qualification contracts that keep them aligned. The user-facing distribution
+is named **Kungfu Episodes**; the runtime, command, SDKs, and extension system
+use the Kungfu, `libkungfu`, and `kfx` names.
+
+## Why an Episode?
+
+Logs show activity. Traces show calls. Workflows describe intended steps. A
+chat session preserves a conversation. None of them, by itself, is the durable
+object needed to answer:
+
+- What actually happened?
+- Which facts and artifacts belong to the work?
+- What did the runtime acknowledge, and what survived a crash?
+- What evidence supports completion?
+- What may safely happen next?
+
+An Episode gives those questions one stable semantic boundary without making a
+process, UI, mutable database row, or provider session the authority. Read
+[The Episode](the-episode.md) for the narrative and
+[Vocabulary](vocabulary.md) for the precise public terms.
+
+## What Kungfu lets you do
+
+- Record typed runtime Facts in an append-only journal with explicit schema
+  ownership and provenance.
+- Inspect Episodes, causal Timelines, Artifacts, Receipts, Cuts, Watermarks, and
+  rebuildable Projections.
+- Query current and historical fact state with proof and lineage attached.
+- Replay recorded Facts, Rewind an Episode for forensic inspection, and qualify
+  Recovery without silently repeating external side effects.
+- Embed `libkungfu`, use one ecosystem SDK, add a `kfx`, or assemble a complete
+  application without adopting every higher layer.
+- Qualify visibility, durability, recovery, and meaning as one end-to-end
+  contract rather than treating ingestion speed as sufficient evidence.
+
+## Adopt only what you need
+
+| Job | Smallest relevant surface |
+| --- | --- |
+| complete official experience | assembled Kungfu App |
+| visual inspection and human workflows | GUI |
+| headless operation and automation | CLI/TUI |
+| one language ecosystem | Python, Node/TypeScript, or Rust SDK |
+| native embedding | `libkungfu` |
+| independent preservation and inspection | `.kungfu` format/spec |
+
+Higher layers add convenience; they do not become a second authority over the
+Facts. [Product Layers](product-layers.md) defines the independent qualification
+contract behind these choices.
+
+## Incubated standalone products
+
+[Xinfa](../../xinfa/README.md), **The Verified Context Compiler for Human-Agent
+Software Development**, is incubated in this repository with its own CLI,
+protocol namespace, version, artifacts, state/cache roots, release identity,
+and extraction manifest. Its core has no Kungfu or Shifu runtime dependency;
+those products may integrate only through thin public-contract adapters. See
+[ADR-0092](../adr/ADR-0092-xinfa-product-and-incubation-boundary.md),
+[ADR-0093](../adr/ADR-0093-xinfa-dual-first-verified-context-contract.md),
+[ADR-0094](../adr/ADR-0094-xinfa-repository-context-pack.md), and
+[ADR-0095](../adr/ADR-0095-xinfa-atlas-primitive-and-compatibility-boundary.md).
+
+## Architecture at a glance
+
+The data plane is `yijinjing`, a low-latency append-only mmap journal shared by
+C++, Python, and Node. Closed kernel records use fixed-layout Hana POD schemas;
+open and domain Facts use FlatBuffers. JSON is an edge rendering or interchange
+format, not a third journal schema.
+
+Live work and Replay use the same frame and runtime semantics. SQLite and GUI
+models are rebuildable Projections over journal-backed authority. The runtime,
+capability SDK, application SDK, reference surfaces, and product assembly
+remain separate layers with explicit contracts. See
+[Architecture](../architecture/overview.md) and
+[Event Model](../architecture/event-model.md).
+
+## Why Kungfu?
+
+Kungfu began with the Chinese idea of **功夫**: capability built through
+disciplined practice. As the product evolved, **KUNGFU** acquired a recursive
+technical meaning: `KUNGFU UNGFU: Never Guess. Facts Unfold.`
+
+The name describes the architecture: deeply integrated at the product surface,
+self-bootstrapping from Facts at the core. Read [Why Kungfu?](why-kungfu.md)
+for the complete recursion and its connection to the product's fact-first
+design.
+
+## Status and guarantees
+
+Kungfu v4 is **Coming soon**. Source-built capabilities and qualification
+slices exist, but public packaging, cross-platform evidence, strong power-loss
+durability, and the institutional profile remain staged unless linked evidence
+says otherwise.
+
+Design intent, implemented behavior, qualified guarantees, and released
+artifacts are deliberately distinct. Before relying on a claim, check
+[Contracts](../qualification/contracts.md),
+[Known Limits](../qualification/known-limits.md), and the applicable retained
+qualification evidence.
+
+## Continue reading
+
+- [Documentation Guide](../README.md)
+- [Choose Your Kungfu](../guides/choose-your-kungfu.md)
+- [Fact, Episode, and Action Primitive Runtime](../architecture/fact-episode-action-runtime.md)
+- [Agent Work State](../profiles/agent-work-state.md)
+- [Documentation Map](../MAP.md)

--- a/docs/document-metadata.registry.json
+++ b/docs/document-metadata.registry.json
@@ -231,6 +231,18 @@
       "review_state": "unreviewed",
       "sensitivity": "public"
     },
+    "docs/concepts/system-overview.md": {
+      "metadata_schema": "kungfu.document-metadata/v1",
+      "document_status": "active",
+      "doc_type": "public-document",
+      "review_state": "self-reviewed",
+      "sensitivity": "public",
+      "sources": [
+        "local-files",
+        "user-consensus"
+      ],
+      "last_reviewed": "2026-07-19"
+    },
     "docs/concepts/the-episode.md": {
       "metadata_schema": "kungfu.document-metadata/v1",
       "document_status": "active",


### PR DESCRIPTION
## Summary

Make the root README a concise CLI-first entry for new agent users while preserving the complete system model in a canonical second-level concept page.

## Related issue

None.

## Changes

- lead with context pressure, durable continuity, and the intended `kungfu run agent` first-release experience
- state explicitly that the command is a qualification target, not an already published artifact
- move the Episode, architecture, layer, and Xinfa overview to `docs/concepts/system-overview.md`
- wire the new concept page into the documentation guide, map, concept index, and metadata registry
- retain the repository and installed Agent discovery pointers required by the documentation contract

## Verification

- `./shifu docs:check`
- `./shifu docs:prose:required`
- `./shifu check:source`
- `./shifu docs final-ready --since origin/dev/v4/v4.0 --budget 66560 --json` (`review-required`, no violations, parity matched)

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Documentation-only restructuring preserves existing architecture contracts and release claims"
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] release evidence, provenance, package publishing, or deployment surfaces
- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed