### PR TITLE
docs(architecture): clarify KFD-7 terminology boundaries

### DIFF
--- a/docs/adr/ADR-0123-action-geometry-domain-profile-separation.md
+++ b/docs/adr/ADR-0123-action-geometry-domain-profile-separation.md
@@ -45,7 +45,8 @@ appear to require the same fields and lifecycle.
 
 ### 1. Action Geometry is the cross-domain layer
 
-**Action Geometry** owns the stable separation and relationships among:
+**Action Geometry**, the cross-domain responsibility model for real-world
+action, owns the stable separation and relationships among:
 
 - admitted Fact state and causal Episode experience;
 - direction through Pursuit;
@@ -81,7 +82,35 @@ per-role `roleSchemaRoots`. Domain states may refine or map to base geometric
 observations, but they cannot redefine what direction, perspective, authority,
 state, or occurrence mean.
 
-### 3. Authority remains below both layers
+### 3. Canonical terminology is narrower than compatibility terminology
+
+New product documentation, discovery surfaces, and successor interfaces use
+one canonical language:
+
+| Term | Status and meaning |
+| --- | --- |
+| **Action Geometry** | Canonical cross-domain responsibility model. |
+| **Domain Profile** | Canonical adopter-specific specialization. |
+| **Action Geometry Contract** | Canonical machine artifact for geometry identity and invariants. |
+| **Domain Profile Declaration** | Canonical machine artifact for adopter mappings, fields, lifecycle, and evidence policy. |
+| **Action Profile** | Compatibility-only combined-v1 term; deprecated for new authoring. |
+| **Action Contract** | Compatibility-only when retained in an existing path, contract id, or product identifier; unqualified use is prohibited in new prose. |
+
+The existing `kungfu-kfd-7-action-contract.json`, `actionProfile`, Profile
+protocol ids, and related `actionContract` metadata retain their current
+combined-v1 meaning. They are not renamed into the future Action Geometry
+Contract. New writers continue to use them only while the combined-v1
+compatibility entry remains authoritative. Successor writers begin only after
+the separately rooted contracts and adapters qualify.
+
+Deprecation therefore has two distinct meanings:
+
+- compatibility terms are deprecated for new human-facing authoring now; and
+- persisted identifiers and readers have no scheduled removal version and
+  remain supported until an explicit migration decision binds successor
+  availability, differential evidence, retained-data coverage, and rollback.
+
+### 4. Authority remains below both layers
 
 Neither an Action Geometry Contract nor a Domain Profile may:
 
@@ -93,7 +122,7 @@ Neither an Action Geometry Contract nor a Domain Profile may:
 
 They use public Fact, Episode, query, receipt, and ActionBinding interfaces.
 
-### 4. Existing identities are not reinterpreted
+### 5. Existing identities are not reinterpreted
 
 The current identifiers, including `kungfu.kfd7.profile-role/v1`,
 `kungfu.kfd7.profile-action/v1`, `kungfu-kfd-7-action-profile`, and
@@ -105,7 +134,27 @@ A semantic encoding change requires a successor schema or protocol tag,
 preserved legacy readers, explicit mapping, and differential evidence. It must
 not silently relabel an existing root.
 
-### 5. The current implementation is transitional
+### 6. Semantic independence does not require physical separation
+
+Several responsibilities may share one physical record, type, table, API,
+process, service, command, or interface component. They remain independently
+addressable when:
+
+- each responsibility has an inspectable source, cut or version, authority,
+  and derivation;
+- changing, invalidating, expiring, revoking, or making one responsibility
+  stale does not silently mutate another;
+- counterfactual fixtures can vary one responsibility while holding the others
+  fixed and observe a changed valid-action or audit conclusion; and
+- prohibited cross-role inferences fail visibly.
+
+The verifier and qualification gates inspect those semantic mappings,
+transitions, roots, and retained witnesses. They must not infer conformance or
+failure from the number of physical objects, classes, tables, endpoints,
+commands, screens, or services. Five required responsibility declarations are
+five inspectable mappings, not a five-component implementation prescription.
+
+### 7. The current implementation is transitional
 
 `kungfu.agent.work_profile` remains the compatibility entry until the staged
 implementation splits:
@@ -132,7 +181,10 @@ The separation is qualified only when:
   fixtures, roots, receipts, public commands, and recovery behavior;
 - session round-trip refinement and context-insufficiency checks remain valid;
 - a Domain Profile cannot weaken role separation or obtain Fact/Episode
-  authority; and
+  authority;
+- semantic distinguishability is qualified through traceability,
+  counterfactual variation, invalidation or revocation, and fail-visible
+  negative evidence rather than physical component count; and
 - legacy combined-v1 objects remain readable without reinterpretation.
 
 ## Consequences

--- a/docs/architecture/fact-episode-action-runtime.md
+++ b/docs/architecture/fact-episode-action-runtime.md
@@ -138,7 +138,7 @@ containment hierarchy.
 | --- | --- | --- |
 | Storage kernel | immutable bodies, typed records, refs, relations, cuts, receipts, integrity | product workflow vocabulary |
 | Runtime substrate | Fact admission/query and Episode lifecycle/replay | Mission/Go policy or UI defaults |
-| Action Geometry | Pursuit, Atlas, Warrant responsibility boundaries, typed relations, non-substitution invariants, and session refinement | domain field or lifecycle vocabulary |
+| Action Geometry (cross-domain responsibility model) | Pursuit, Atlas, Warrant responsibility boundaries, typed relations, non-substitution invariants, and session refinement | domain field or lifecycle vocabulary |
 | Domain Profiles | Mission/Go and other domain fields, lifecycle, defaults, validation, presentation, and success policy | independent storage semantics or redefinition of Action Geometry |
 | Projections | Git, JSON, CLI, GUI, Python, Node, bundles | hidden authority |
 
@@ -163,6 +163,13 @@ They are the transitional combined-v1 implementation, not a second storage
 stack or a KFD normative definition. ADR-0123 requires future machine
 discovery to expose an exact `actionGeometryRoot`, `domainProfileRoot`, and
 per-role `roleSchemaRoots` without reinterpreting existing roots.
+
+Action Geometry names semantic responsibility, not physical topology. One
+record, type, API, process, or interface may carry several role mappings when
+their sources, cuts, versions, authority, and derivations remain independently
+inspectable and counterfactually distinguishable. Architecture and
+qualification checks therefore test mappings and prohibited inferences, not
+the number of implementation components.
 
 ## Semantic identity
 

--- a/docs/concepts/vocabulary.md
+++ b/docs/concepts/vocabulary.md
@@ -28,6 +28,9 @@ coordinates and perspective
 derivation, trust, and action
   Projection / Timeline / Claim / Proof / Purpose / TrustReport / Decision
 
+action responsibility model
+  Action Geometry / Domain Profile
+
 operations
   Replay / Rewind / Recovery
 
@@ -238,6 +241,32 @@ archive, recover, or reopen.
 
 **Boundary:** Recommendation and authorization remain distinct. Agent prose
 cannot create Facts, expand authority, or silently execute a Decision.
+
+## Action responsibility model
+
+### Action Geometry
+
+**Definition:** The cross-domain responsibility model for real-world action. It
+keeps Fact, Episode, Pursuit, Atlas, and Warrant responsibilities independently
+addressable and defines their non-substitution invariants and conservative
+session projection.
+
+**Boundary:** Action Geometry does not prescribe domain fields, lifecycle
+vocabulary, storage layout, API count, process count, or interface shape.
+Several responsibilities may share one physical representation when their
+sources, cuts, versions, authority, derivations, and invalidation remain
+semantically distinguishable and traceable.
+
+### Domain Profile
+
+**Definition:** A versioned adopter specialization that maps domain objects,
+fields, lifecycle vocabulary, transitions, validation, defaults, presentation,
+and evidence policy onto Action Geometry.
+
+**Boundary:** A Domain Profile cannot redefine Action Geometry, mint Fact or
+Episode authority, or infer one responsibility from another. `Action Profile`
+and unqualified `Action Contract` are combined-v1 compatibility terms, not
+preferred names for new documentation or successor interfaces.
 
 ## Operations
 

--- a/docs/profiles/agent-work-state.md
+++ b/docs/profiles/agent-work-state.md
@@ -1,11 +1,11 @@
 # Agent Work State
 
-Agent Work is Kungfu's first **Domain Profile** over the cross-domain **Action
-Geometry** defined by KFD-7 and ADR-0123. Action Geometry preserves the
-responsibility boundaries and non-substitution invariants below; this Domain
-Profile owns the concrete work fields, lifecycle vocabulary, defaults,
-validation, evidence policy, and presentation. Pursuit, Atlas, and Warrant are
-Action Primitives, not Profiles.
+Agent Work is Kungfu's first **Domain Profile** over **Action Geometry**, the
+cross-domain responsibility model for real-world action defined by KFD-7 and
+ADR-0123. Action Geometry preserves the responsibility boundaries and
+non-substitution invariants below; this Domain Profile owns the concrete work
+fields, lifecycle vocabulary, defaults, validation, evidence policy, and
+presentation. Pursuit, Atlas, and Warrant are Action Primitives, not Profiles.
 
 Real-world agent work stays coherent when four different questions have four
 independently inspectable answers:
@@ -89,6 +89,13 @@ Kungfu must refuse, report uncertainty, or degrade trust when a required role
 is missing or stale. It must not reconstruct the missing fact from chat,
 provider memory, or a nearby object.
 
+Separation here is semantic. A single stored document, service call, command,
+or interface may carry several roles when each mapping remains traceable and
+can be varied, invalidated, expired, revoked, or made stale without silently
+changing the others. Qualification tests those counterfactual and negative
+cases. It does not require four physical objects, APIs, forms, or interface
+components.
+
 ## The work loop
 
 A complete loop selects a Pursuit, declares the Atlas used for the next
@@ -159,6 +166,13 @@ successor must separately expose `actionGeometryRoot`, `domainProfileRoot`, and
 per-role `roleSchemaRoots`; it may not relabel existing roots. The declaration
 remains provisional and non-qualifying until dogfood, migration, artifact, and
 independent-review evidence close.
+
+In new documentation, **Action Geometry Contract** names the future geometry
+artifact and **Domain Profile Declaration** names the adopter artifact.
+`Action Profile`, unqualified `Action Contract`, the existing
+`kungfu-kfd-7-action-contract.json` path, and current Profile protocol ids are
+combined-v1 compatibility terms only. They remain readable with no scheduled
+removal version and are not reused for successor semantics.
 
 Projection rebuild is supported from the native Fact journal plus verified
 body bytes. A clean home without a qualified Fact export reports

--- a/docs/vocabulary.registry.json
+++ b/docs/vocabulary.registry.json
@@ -46,6 +46,14 @@
       ]
     },
     {
+      "id": "action-model",
+      "heading": "Action responsibility model",
+      "terms": [
+        { "name": "Action Geometry" },
+        { "name": "Domain Profile" }
+      ]
+    },
+    {
       "id": "operations",
       "heading": "Operations",
       "terms": [


### PR DESCRIPTION
## Summary

Clarify the KFD-7 architecture language across the ADR, runtime model, Agent Work Domain Profile, and public vocabulary. Action Geometry now carries the plain-language subtitle “cross-domain responsibility model”; canonical terms are separated from combined-v1 compatibility identifiers; and semantic independence is explicitly distinguished from physical decomposition.

## Related issue

None.

## Changes

- define canonical Action Geometry, Domain Profile, Action Geometry Contract, and Domain Profile Declaration terminology
- retain Action Profile and unqualified Action Contract only at existing compatibility identities, with explicit migration conditions
- require traceability, counterfactual distinguishability, and fail-visible prohibited inference rather than five physical components
- project the canonical model into the public vocabulary registry

## Verification

- `./shifu docs:check`
- `./shifu docs:prose:required`
- `./shifu adr:audit -- --json`
- `node scripts/buildchain-kfd-evidence.mjs --check`
- staged source gate executed by the commit hook

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "stage-ready",
  "adrs": ["ADR-0123"],
  "summary": "Clarify canonical and compatibility terminology plus semantic-independence qualification for the staged KFD-7 architecture",
  "verification": ["docs:check", "docs:prose:required", "adr:audit", "buildchain KFD evidence check", "staged source gate"]
}
-->

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] release evidence, provenance, package publishing, or deployment surfaces
- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed