### PR TITLE
chore(core): upgrade libnode to 22.22.3-kf.4

### DIFF
--- a/.buildchain/kfd/kfd-3/collaboration-interface.artifact.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.artifact.json
@@ -10,8 +10,8 @@
   "sourceRegistry": {
     "id": "kungfu",
     "path": ".buildchain/kfd/kfd-3/surfaces.json",
-    "sha256": "7eee41246c7f3cd00c6ae1a72624314be60c4761deaf7e850d8282d08f6c062b",
-    "digest": "sha256:a50b908be3dff7a1155018101bd610888d489a32d89aefb01a82cd9c16068ff9"
+    "sha256": "547b069faaed009d7ad6f3f948faf838f2ac13262aefb687a29dad4b09793775",
+    "digest": "sha256:074cfd6d246c6ecaa49dda2d284e3e85d86d3ce967b567f491bd6311b041ca2d"
   },
   "upstreamKfd": {
     "aggregatePath": "developer/sdk/kfd/upstream-aggregate.json",
@@ -23,12 +23,12 @@
     ],
     "packageVersions": {
       "kfd": "1.0.0-alpha.21",
-      "libnode": "22.22.3-kf.3-alpha.16",
+      "libnode": "22.22.3-kf.4",
       "buildchain": "2.11.14-alpha.0"
     },
-    "digest": "sha256:8d2a1e2c71cd10c63ae69991fa676380b60734a84631079b1259e8ea0ba32c58"
+    "digest": "sha256:38df18c7f118f322bfebdf1ba70628dd6c8ac39512fb1708e10dc6d3c37fadbe"
   },
-  "collaborationInterfaceDigest": "sha256:3ba2b7c7b98d857852436db04fcb8a09aa68f2ba077a30a22a190775f39f3c18",
+  "collaborationInterfaceDigest": "sha256:f66050b6ae9688a6b66b6993cc1f7cf34f011b0539983d340bd502fc6051fec8",
   "exposedSurfaces": [
     {
       "id": "kungfu.agent",

--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -6,15 +6,15 @@
   "supportLevel": "release",
   "source": {
     "cwd": ".",
-    "sourceSha": "16555023851d44a0876065f762f16914b9859112",
+    "sourceSha": "78f50c8690947c5a5368aaa984a664f12da9607d",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
-    "registryDigest": "sha256:a50b908be3dff7a1155018101bd610888d489a32d89aefb01a82cd9c16068ff9"
+    "registryDigest": "sha256:074cfd6d246c6ecaa49dda2d284e3e85d86d3ce967b567f491bd6311b041ca2d"
   },
   "sourceRegistry": {
     "id": "kungfu",
     "path": ".buildchain/kfd/kfd-3/surfaces.json",
-    "sha256": "7eee41246c7f3cd00c6ae1a72624314be60c4761deaf7e850d8282d08f6c062b",
-    "digest": "sha256:a50b908be3dff7a1155018101bd610888d489a32d89aefb01a82cd9c16068ff9"
+    "sha256": "547b069faaed009d7ad6f3f948faf838f2ac13262aefb687a29dad4b09793775",
+    "digest": "sha256:074cfd6d246c6ecaa49dda2d284e3e85d86d3ce967b567f491bd6311b041ca2d"
   },
   "upstreamKfd": {
     "aggregatePath": "developer/sdk/kfd/upstream-aggregate.json",
@@ -26,15 +26,15 @@
     ],
     "packageVersions": {
       "kfd": "1.0.0-alpha.21",
-      "libnode": "22.22.3-kf.3-alpha.16",
+      "libnode": "22.22.3-kf.4",
       "buildchain": "2.11.14-alpha.0"
     },
-    "digest": "sha256:8d2a1e2c71cd10c63ae69991fa676380b60734a84631079b1259e8ea0ba32c58"
+    "digest": "sha256:38df18c7f118f322bfebdf1ba70628dd6c8ac39512fb1708e10dc6d3c37fadbe"
   },
   "expectedArtifactVerification": {
     "command": "node scripts/buildchain-kfd-evidence.mjs --artifact-witness --json"
   },
-  "collaborationInterfaceDigest": "sha256:3ba2b7c7b98d857852436db04fcb8a09aa68f2ba077a30a22a190775f39f3c18",
+  "collaborationInterfaceDigest": "sha256:f66050b6ae9688a6b66b6993cc1f7cf34f011b0539983d340bd502fc6051fec8",
   "collaborationInterface": {
     "schemaVersion": 1,
     "contract": "kungfu-buildchain-kfd-3-surface-registry",
@@ -54,10 +54,10 @@
       ],
       "packageVersions": {
         "kfd": "1.0.0-alpha.21",
-        "libnode": "22.22.3-kf.3-alpha.16",
+        "libnode": "22.22.3-kf.4",
         "buildchain": "2.11.14-alpha.0"
       },
-      "digest": "sha256:8d2a1e2c71cd10c63ae69991fa676380b60734a84631079b1259e8ea0ba32c58"
+      "digest": "sha256:38df18c7f118f322bfebdf1ba70628dd6c8ac39512fb1708e10dc6d3c37fadbe"
     },
     "surfaces": [
       {

--- a/.buildchain/kfd/kfd-3/surfaces.json
+++ b/.buildchain/kfd/kfd-3/surfaces.json
@@ -62,10 +62,10 @@
     ],
     "packageVersions": {
       "kfd": "1.0.0-alpha.21",
-      "libnode": "22.22.3-kf.3-alpha.16",
+      "libnode": "22.22.3-kf.4",
       "buildchain": "2.11.14-alpha.0"
     },
-    "digest": "sha256:8d2a1e2c71cd10c63ae69991fa676380b60734a84631079b1259e8ea0ba32c58"
+    "digest": "sha256:38df18c7f118f322bfebdf1ba70628dd6c8ac39512fb1708e10dc6d3c37fadbe"
   },
   "surfaces": [
     {

--- a/developer/sdk/kfd/kfd-3-surfaces.json
+++ b/developer/sdk/kfd/kfd-3-surfaces.json
@@ -62,10 +62,10 @@
     ],
     "packageVersions": {
       "kfd": "1.0.0-alpha.21",
-      "libnode": "22.22.3-kf.3-alpha.16",
+      "libnode": "22.22.3-kf.4",
       "buildchain": "2.11.14-alpha.0"
     },
-    "digest": "sha256:8d2a1e2c71cd10c63ae69991fa676380b60734a84631079b1259e8ea0ba32c58"
+    "digest": "sha256:38df18c7f118f322bfebdf1ba70628dd6c8ac39512fb1708e10dc6d3c37fadbe"
   },
   "surfaces": [
     {

--- a/developer/sdk/kfd/upstream-aggregate.json
+++ b/developer/sdk/kfd/upstream-aggregate.json
@@ -73,7 +73,7 @@
       "role": "embedded-node-runtime-provider",
       "package": {
         "name": "@kungfu-tech/libnode",
-        "version": "22.22.3-kf.3-alpha.16"
+        "version": "22.22.3-kf.4"
       },
       "repository": "kungfu-systems/libnode",
       "kfd": {
@@ -87,13 +87,13 @@
         "nodeVersion": "22.22.3",
         "nodeTag": "v22.22.3",
         "nodeCommit": "fdfa0ff0dbaf0fbf4d7d6d89a2ab807f3177fa5c",
-        "libnodeRevision": 3,
-        "npmVersion": "22.22.3-kf.3-alpha.16"
+        "libnodeRevision": 4,
+        "npmVersion": "22.22.3-kf.4"
       },
       "assets": [
         {
           "path": "libnode.release.json",
-          "sha256": "sha256:90555ff4f2b127ecfe552feec55782175e3c227bbb46c400603eee13ff7e6920"
+          "sha256": "sha256:47234b2fe6142db4479d018867274256c19c230169156f22ad067ef7f0ac1c5b"
         }
       ],
       "residualRisk": [
@@ -193,7 +193,7 @@
     ],
     "packageVersions": {
       "kfd": "1.0.0-alpha.21",
-      "libnode": "22.22.3-kf.3-alpha.16",
+      "libnode": "22.22.3-kf.4",
       "buildchain": "2.11.14-alpha.0"
     }
   }

--- a/developer/sdk/tests/contract-cli.test.mjs
+++ b/developer/sdk/tests/contract-cli.test.mjs
@@ -441,8 +441,7 @@ test('kfd upstream exposes aggregated upstream KFD package facts', () => {
   );
   assert.ok(
     data.upstreams.some(
-      (row) =>
-        row.id === 'libnode' && row.package.version === '22.22.3-kf.3-alpha.16',
+      (row) => row.id === 'libnode' && row.package.version === '22.22.3-kf.4',
     ),
   );
   assert.equal(data.ownKfd.kfd1.status, 'supported');

--- a/framework/core/package.json
+++ b/framework/core/package.json
@@ -65,7 +65,7 @@
     "sywac": "^1.3.0"
   },
   "devDependencies": {
-    "@kungfu-tech/libnode": "22.22.3-kf.3-alpha.16",
+    "@kungfu-tech/libnode": "22.22.3-kf.4",
     "@mapbox/node-pre-gyp": "^2.0.3",
     "cmake-js": "^8.0.0",
     "copyfiles": "^2.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -442,8 +442,8 @@ importers:
         version: 1.3.0
     devDependencies:
       '@kungfu-tech/libnode':
-        specifier: 22.22.3-kf.3-alpha.16
-        version: 22.22.3-kf.3-alpha.16
+        specifier: 22.22.3-kf.4
+        version: 22.22.3-kf.4
       '@mapbox/node-pre-gyp':
         specifier: ^2.0.3
         version: 2.0.3(encoding@0.1.13)
@@ -1403,23 +1403,23 @@ packages:
     resolution: {integrity: sha512-Kfiu5k+ufGAMGYun4755jxaV4fBd4Xvyupa76wMfptO/WF8/wXG8xrgJr6CJ/gY7r7BMg1MpD36HlJWkhGcyiw==}
     hasBin: true
 
-  '@kungfu-tech/libnode-darwin-arm64@22.22.3-kf.3-alpha.16':
-    resolution: {integrity: sha512-arC7Vm85nBSRS4Vj5L5RL4XXb5c4xrLmldcf+zA0Qs0d01GW0ZHecthZTK/vf/syFtb4u1CFoHBviOwT3YFazQ==}
+  '@kungfu-tech/libnode-darwin-arm64@22.22.3-kf.4':
+    resolution: {integrity: sha512-HrRmb/0Q41uMOHYLSSpnkuT1US4PvGY1OEzMuGP9wIjbkcxJlXVep5UAzSO0l4KVJnA5iLEoGJTPyTK74IPsYA==}
     cpu: [arm64]
     os: [darwin]
 
-  '@kungfu-tech/libnode-linux-x64@22.22.3-kf.3-alpha.16':
-    resolution: {integrity: sha512-jDhw9oYYA4nHG9nYotDs05IYqKWtBfrybDb4mgbfZlwLPRXBU5b+XEQzT7rUm2H0CDydhBnnIyrZ/TPvyqhD4g==}
+  '@kungfu-tech/libnode-linux-x64@22.22.3-kf.4':
+    resolution: {integrity: sha512-Lu/1NcuS9ZuTiFI1hH2ET5dAJQNV6X2OEbYShHgJObMcoFD67JHX7fE7HdWSQ60vGhLuRKXyXoFS49XSo1S0ig==}
     cpu: [x64]
     os: [linux]
 
-  '@kungfu-tech/libnode-win32-x64@22.22.3-kf.3-alpha.16':
-    resolution: {integrity: sha512-z7NWb8hGXqiEgAqUINr8hkiqJR/VCmo5v0yI4xdRVwQ3caLr785IRfihGHgw8jrs4z8izaoJ+E7p34iy+RM51A==}
+  '@kungfu-tech/libnode-win32-x64@22.22.3-kf.4':
+    resolution: {integrity: sha512-3zkdrh0Js996lfvuQFfaYmTTvxTRt5i3nL/LWxqzXzKBajWC6RuwNirz1NRJ5dgeC/d9EhvFjck135HEa66Vag==}
     cpu: [x64]
     os: [win32]
 
-  '@kungfu-tech/libnode@22.22.3-kf.3-alpha.16':
-    resolution: {integrity: sha512-tctyKXMn4hXWaExDER2OBc+C6C/YPoiirxue8RxYaTpbJz0/KGxK7rIUPwVzK15/UY/FsWgJuXAy6KQzgPdYVw==}
+  '@kungfu-tech/libnode@22.22.3-kf.4':
+    resolution: {integrity: sha512-4Bms90cyuiPaLpX5UOgYtnQCXWjDWSQ6PVpgUviylmEdmz4afSA2ZZNBBm+DhZ/9JFcWH1t5kI1d6AT0VgNSuw==}
 
   '@malept/cross-spawn-promise@2.0.0':
     resolution: {integrity: sha512-1DpKU0Z5ThltBwjNySMC14g0CkbyhCaz9FkhxqNsZI6uAPJXFS8cMXlBKo26FJ8ZuW6S9GCMcR9IO5k2X5/9Fg==}
@@ -5768,20 +5768,20 @@ snapshots:
 
   '@kungfu-tech/kfd@1.0.0-alpha.35': {}
 
-  '@kungfu-tech/libnode-darwin-arm64@22.22.3-kf.3-alpha.16':
+  '@kungfu-tech/libnode-darwin-arm64@22.22.3-kf.4':
     optional: true
 
-  '@kungfu-tech/libnode-linux-x64@22.22.3-kf.3-alpha.16':
+  '@kungfu-tech/libnode-linux-x64@22.22.3-kf.4':
     optional: true
 
-  '@kungfu-tech/libnode-win32-x64@22.22.3-kf.3-alpha.16':
+  '@kungfu-tech/libnode-win32-x64@22.22.3-kf.4':
     optional: true
 
-  '@kungfu-tech/libnode@22.22.3-kf.3-alpha.16':
+  '@kungfu-tech/libnode@22.22.3-kf.4':
     optionalDependencies:
-      '@kungfu-tech/libnode-darwin-arm64': 22.22.3-kf.3-alpha.16
-      '@kungfu-tech/libnode-linux-x64': 22.22.3-kf.3-alpha.16
-      '@kungfu-tech/libnode-win32-x64': 22.22.3-kf.3-alpha.16
+      '@kungfu-tech/libnode-darwin-arm64': 22.22.3-kf.4
+      '@kungfu-tech/libnode-linux-x64': 22.22.3-kf.4
+      '@kungfu-tech/libnode-win32-x64': 22.22.3-kf.4
 
   '@malept/cross-spawn-promise@2.0.0':
     dependencies:


### PR DESCRIPTION
## Summary

Upgrade Kungfu's embedded Node runtime dependency to @kungfu-tech/libnode 22.22.3-kf.4.

## Related issue

None.

## Changes

- Pin @kungfu-tech/libnode to 22.22.3-kf.4.
- Refresh the wrapper and platform package lock entries.
- Regenerate KFD upstream projections for libnode revision 4.

## Verification

- ./shifu kfd:buildchain:check
- ./shifu check
- Runtime resolution probe confirmed the Darwin library path exists.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Dependency maintenance updates an existing embedded runtime pin and generated evidence without changing architecture contracts"
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The KFD release evidence was regenerated from the published package anchor and verified with the repository KFD and full check gates.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed (no user-facing behavior change)