### PR TITLE
feat(work): expose Work loop capability parity

### DIFF
--- a/.buildchain/kfd/kfd-2/claims/agent-onboarding-pack.json
+++ b/.buildchain/kfd/kfd-2/claims/agent-onboarding-pack.json
@@ -16,7 +16,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "ebcd87f9dee4e92206cb7cf4eb42a988b93753aee53862798bc8c6a9ccf19ec1"
+        "sha256": "62687c870e8f06bc925450db9107bd3360ee91fef4783b5167b9904c79662582"
       },
       "description": "Machine-readable command catalog and mode maturity metadata."
     },
@@ -25,7 +25,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/cli_surface.catalog.json",
-        "sha256": "fec89b2148326be90b1ceec4ff0e12c20b7dbe30775c227268f7fc2f8294165d"
+        "sha256": "9f6f7b50a106f192f045425ec13cbc46947c7e66d3cc7c89ca40bf4b0223817c"
       },
       "description": "Complete deterministic CLI surface graph shared by offline Agent capabilities and catalog parity checks."
     },
@@ -72,11 +72,11 @@
     "evidenceSha256": [
       {
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "ebcd87f9dee4e92206cb7cf4eb42a988b93753aee53862798bc8c6a9ccf19ec1"
+        "sha256": "62687c870e8f06bc925450db9107bd3360ee91fef4783b5167b9904c79662582"
       },
       {
         "path": "framework/core/src/python/kungfu/agent/cli_surface.catalog.json",
-        "sha256": "fec89b2148326be90b1ceec4ff0e12c20b7dbe30775c227268f7fc2f8294165d"
+        "sha256": "9f6f7b50a106f192f045425ec13cbc46947c7e66d3cc7c89ca40bf4b0223817c"
       },
       {
         "path": "framework/core/src/python/kungfu/agent/mode-selection.md",
@@ -102,11 +102,11 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "ebcd87f9dee4e92206cb7cf4eb42a988b93753aee53862798bc8c6a9ccf19ec1"
+        "sha256": "62687c870e8f06bc925450db9107bd3360ee91fef4783b5167b9904c79662582"
       },
       {
         "path": "framework/core/src/python/kungfu/agent/cli_surface.catalog.json",
-        "sha256": "fec89b2148326be90b1ceec4ff0e12c20b7dbe30775c227268f7fc2f8294165d"
+        "sha256": "9f6f7b50a106f192f045425ec13cbc46947c7e66d3cc7c89ca40bf4b0223817c"
       }
     ]
   },
@@ -120,13 +120,13 @@
     {
       "name": "agent-command-catalog",
       "path": "framework/core/src/python/kungfu/agent/commands.json",
-      "sha256": "ebcd87f9dee4e92206cb7cf4eb42a988b93753aee53862798bc8c6a9ccf19ec1",
+      "sha256": "62687c870e8f06bc925450db9107bd3360ee91fef4783b5167b9904c79662582",
       "expectedPackagePath": "kungfu/agent/commands.json"
     },
     {
       "name": "cli-surface-catalog",
       "path": "framework/core/src/python/kungfu/agent/cli_surface.catalog.json",
-      "sha256": "fec89b2148326be90b1ceec4ff0e12c20b7dbe30775c227268f7fc2f8294165d",
+      "sha256": "9f6f7b50a106f192f045425ec13cbc46947c7e66d3cc7c89ca40bf4b0223817c",
       "expectedPackagePath": "kungfu/agent/cli_surface.catalog.json"
     }
   ],

--- a/.buildchain/kfd/kfd-2/claims/agent-work-state-contract.json
+++ b/.buildchain/kfd/kfd-2/claims/agent-work-state-contract.json
@@ -43,7 +43,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/tests/python/test_agent_work_state_contract.py",
-        "sha256": "eb0cb31109bdbb82022626249fd07c9ee7657ebd1a364e7e608fb8d99b2cb700"
+        "sha256": "a19cdc151a1247af5f25388ac69a20ee8d945872e9a4232ce1e85ff339a62049"
       },
       "description": "Runtime CLI parity and fail-closed contract-schema checks."
     },
@@ -52,7 +52,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
-        "sha256": "f786fd06eadf2a1f7704e7b49e821d689f4b60f73274e4952f5546c96a0e122f"
+        "sha256": "735bf52451494a2f1d7017eedc74e5817bbeb435ee6bfe306a77b385954b27bd"
       },
       "description": "Agent collaboration-interface registration for the work-model query."
     }
@@ -75,11 +75,11 @@
       },
       {
         "path": "framework/core/tests/python/test_agent_work_state_contract.py",
-        "sha256": "eb0cb31109bdbb82022626249fd07c9ee7657ebd1a364e7e608fb8d99b2cb700"
+        "sha256": "a19cdc151a1247af5f25388ac69a20ee8d945872e9a4232ce1e85ff339a62049"
       },
       {
         "path": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
-        "sha256": "f786fd06eadf2a1f7704e7b49e821d689f4b60f73274e4952f5546c96a0e122f"
+        "sha256": "735bf52451494a2f1d7017eedc74e5817bbeb435ee6bfe306a77b385954b27bd"
       }
     ],
     "artifactSha256": [

--- a/.buildchain/kfd/kfd-2/claims/codex-report-receipts.json
+++ b/.buildchain/kfd/kfd-2/claims/codex-report-receipts.json
@@ -52,7 +52,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/skills/codex/SKILL.md",
-        "sha256": "7ee0c3285c1d9a1e1d0108ce802b6976760fba08a22166c0fffa6611d18bbe79"
+        "sha256": "79605a827bd7e8746479a0b486642cbb2a63d1390870003e14bcbeeb0c196046"
       },
       "description": "Codex-side report closeout gate instructions shipped in the agent pack."
     }
@@ -79,7 +79,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/skills/codex/SKILL.md",
-        "sha256": "7ee0c3285c1d9a1e1d0108ce802b6976760fba08a22166c0fffa6611d18bbe79"
+        "sha256": "79605a827bd7e8746479a0b486642cbb2a63d1390870003e14bcbeeb0c196046"
       }
     ],
     "artifactSha256": [
@@ -89,7 +89,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/skills/codex/SKILL.md",
-        "sha256": "7ee0c3285c1d9a1e1d0108ce802b6976760fba08a22166c0fffa6611d18bbe79"
+        "sha256": "79605a827bd7e8746479a0b486642cbb2a63d1390870003e14bcbeeb0c196046"
       }
     ]
   },
@@ -103,7 +103,7 @@
     {
       "name": "codex-agent-skill",
       "path": "framework/core/src/python/kungfu/agent/skills/codex/SKILL.md",
-      "sha256": "7ee0c3285c1d9a1e1d0108ce802b6976760fba08a22166c0fffa6611d18bbe79",
+      "sha256": "79605a827bd7e8746479a0b486642cbb2a63d1390870003e14bcbeeb0c196046",
       "expectedPackagePath": "kungfu/agent/skills/codex/SKILL.md"
     }
   ],

--- a/.buildchain/kfd/kfd-2/claims/remote-fact-boundary.json
+++ b/.buildchain/kfd/kfd-2/claims/remote-fact-boundary.json
@@ -34,7 +34,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "ebcd87f9dee4e92206cb7cf4eb42a988b93753aee53862798bc8c6a9ccf19ec1"
+        "sha256": "62687c870e8f06bc925450db9107bd3360ee91fef4783b5167b9904c79662582"
       },
       "description": "Remote add/sync command declarations and mode metadata."
     },
@@ -43,7 +43,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/cli/commands/agent.py",
-        "sha256": "cfe866fe7aa0a4e4475f6a62d6f085ebf889a1b450756c86ed0d6f4519080ca7"
+        "sha256": "106e58e3fc75e8fa50e21c74552ee01fc1090f55a88a1d551b7590b6a193cb88"
       },
       "description": "Agent command surface including mode selection and bootstrap status."
     }
@@ -62,11 +62,11 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "ebcd87f9dee4e92206cb7cf4eb42a988b93753aee53862798bc8c6a9ccf19ec1"
+        "sha256": "62687c870e8f06bc925450db9107bd3360ee91fef4783b5167b9904c79662582"
       },
       {
         "path": "framework/core/src/python/kungfu/cli/commands/agent.py",
-        "sha256": "cfe866fe7aa0a4e4475f6a62d6f085ebf889a1b450756c86ed0d6f4519080ca7"
+        "sha256": "106e58e3fc75e8fa50e21c74552ee01fc1090f55a88a1d551b7590b6a193cb88"
       }
     ],
     "artifactSha256": [

--- a/.buildchain/kfd/kfd-2/release-claims.json
+++ b/.buildchain/kfd/kfd-2/release-claims.json
@@ -29,7 +29,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/commands.json",
-            "sha256": "ebcd87f9dee4e92206cb7cf4eb42a988b93753aee53862798bc8c6a9ccf19ec1"
+            "sha256": "62687c870e8f06bc925450db9107bd3360ee91fef4783b5167b9904c79662582"
           },
           "description": "Machine-readable command catalog and mode maturity metadata."
         },
@@ -38,7 +38,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/cli_surface.catalog.json",
-            "sha256": "fec89b2148326be90b1ceec4ff0e12c20b7dbe30775c227268f7fc2f8294165d"
+            "sha256": "9f6f7b50a106f192f045425ec13cbc46947c7e66d3cc7c89ca40bf4b0223817c"
           },
           "description": "Complete deterministic CLI surface graph shared by offline Agent capabilities and catalog parity checks."
         },
@@ -152,7 +152,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/skills/codex/SKILL.md",
-            "sha256": "7ee0c3285c1d9a1e1d0108ce802b6976760fba08a22166c0fffa6611d18bbe79"
+            "sha256": "79605a827bd7e8746479a0b486642cbb2a63d1390870003e14bcbeeb0c196046"
           },
           "description": "Codex-side report closeout gate instructions shipped in the agent pack."
         }
@@ -212,7 +212,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/commands.json",
-            "sha256": "ebcd87f9dee4e92206cb7cf4eb42a988b93753aee53862798bc8c6a9ccf19ec1"
+            "sha256": "62687c870e8f06bc925450db9107bd3360ee91fef4783b5167b9904c79662582"
           },
           "description": "Remote add/sync command declarations and mode metadata."
         },
@@ -221,7 +221,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/cli/commands/agent.py",
-            "sha256": "cfe866fe7aa0a4e4475f6a62d6f085ebf889a1b450756c86ed0d6f4519080ca7"
+            "sha256": "106e58e3fc75e8fa50e21c74552ee01fc1090f55a88a1d551b7590b6a193cb88"
           },
           "description": "Agent command surface including mode selection and bootstrap status."
         }
@@ -292,7 +292,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/tests/python/test_agent_work_state_contract.py",
-            "sha256": "eb0cb31109bdbb82022626249fd07c9ee7657ebd1a364e7e608fb8d99b2cb700"
+            "sha256": "a19cdc151a1247af5f25388ac69a20ee8d945872e9a4232ce1e85ff339a62049"
           },
           "description": "Runtime CLI parity and fail-closed contract-schema checks."
         },
@@ -301,7 +301,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
-            "sha256": "f786fd06eadf2a1f7704e7b49e821d689f4b60f73274e4952f5546c96a0e122f"
+            "sha256": "735bf52451494a2f1d7017eedc74e5817bbeb435ee6bfe306a77b385954b27bd"
           },
           "description": "Agent collaboration-interface registration for the work-model query."
         }

--- a/.buildchain/kfd/kfd-3/capability-query.json
+++ b/.buildchain/kfd/kfd-3/capability-query.json
@@ -1155,6 +1155,28 @@
       "residualRisk": []
     },
     {
+      "id": "kungfu.cut.inspect",
+      "kind": "cli-api",
+      "name": "kungfu cut --repo <path> --json",
+      "state": "declared",
+      "detected": true,
+      "enforced": false,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "kfd1Basis": {
+        "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+        "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+        "digest": "sha256:4653d550cbfdb966db7a0abaca1c1b4088ddd281e69ae3662def74770c2d5dfd"
+      },
+      "kfd2Trust": {
+        "status": "release-passport-required",
+        "trustImpact": "query-release-passport-for-final-trust",
+        "residualRisk": []
+      },
+      "residualRisk": []
+    },
+    {
       "id": "kungfu.exit.bundle",
       "kind": "cli",
       "name": "kungfu exit build --file <request.json> --json",
@@ -2739,6 +2761,28 @@
       "residualRisk": []
     },
     {
+      "id": "kungfu.work.complete",
+      "kind": "cli-api",
+      "name": "kungfu work complete <work-id> --repo <path> --json",
+      "state": "declared",
+      "detected": true,
+      "enforced": false,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "kfd1Basis": {
+        "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+        "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+        "digest": "sha256:e0885d5af99c11e0c585c7d4a6a4538504bb7421471f9e0835a229f9dbcad8f4"
+      },
+      "kfd2Trust": {
+        "status": "release-passport-required",
+        "trustImpact": "query-release-passport-for-final-trust",
+        "residualRisk": []
+      },
+      "residualRisk": []
+    },
+    {
       "id": "kungfu.work.create",
       "kind": "cli",
       "name": "kungfu work create <title> --json",
@@ -2752,6 +2796,94 @@
         "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
         "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
         "digest": "sha256:50b002128b600612dceecbd2d0e8b66d177af4df088b8a052a867ea00e6eb871"
+      },
+      "kfd2Trust": {
+        "status": "release-passport-required",
+        "trustImpact": "query-release-passport-for-final-trust",
+        "residualRisk": []
+      },
+      "residualRisk": []
+    },
+    {
+      "id": "kungfu.work.inspect",
+      "kind": "cli-api",
+      "name": "kungfu work inspect --repo <path> --json",
+      "state": "declared",
+      "detected": true,
+      "enforced": false,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "kfd1Basis": {
+        "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+        "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+        "digest": "sha256:3f6224bdea519a3a2bdc08d2fa73e33e4fa81967004992407f7dca9c62509a9d"
+      },
+      "kfd2Trust": {
+        "status": "release-passport-required",
+        "trustImpact": "query-release-passport-for-final-trust",
+        "residualRisk": []
+      },
+      "residualRisk": []
+    },
+    {
+      "id": "kungfu.work.loop",
+      "kind": "cli-api",
+      "name": "kungfu work capabilities --json",
+      "state": "declared",
+      "detected": true,
+      "enforced": false,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "kfd1Basis": {
+        "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+        "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+        "digest": "sha256:4f979652b02c5fe589495633e74c773234d0b3abb69d995a9dda5368897c066a"
+      },
+      "kfd2Trust": {
+        "status": "release-passport-required",
+        "trustImpact": "query-release-passport-for-final-trust",
+        "residualRisk": []
+      },
+      "residualRisk": []
+    },
+    {
+      "id": "kungfu.work.recover",
+      "kind": "cli-api",
+      "name": "kungfu work recover --repo <path> --json",
+      "state": "declared",
+      "detected": true,
+      "enforced": false,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "kfd1Basis": {
+        "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+        "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+        "digest": "sha256:4f8a96da1375ef2dd26260717e7aa47a74419d9fc61cd33211926837ba3f10a6"
+      },
+      "kfd2Trust": {
+        "status": "release-passport-required",
+        "trustImpact": "query-release-passport-for-final-trust",
+        "residualRisk": []
+      },
+      "residualRisk": []
+    },
+    {
+      "id": "kungfu.work.settle",
+      "kind": "cli-api",
+      "name": "kungfu work settle <work-id> --claim-root <root> --review-root <root> --decision-root <root> --project-cut-root <root> --json",
+      "state": "declared",
+      "detected": true,
+      "enforced": false,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "kfd1Basis": {
+        "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+        "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+        "digest": "sha256:c788a77b56c8b916f340d764edd9aec79d3c889911e35f993e9e1f8e55b418cd"
       },
       "kfd2Trust": {
         "status": "release-passport-required",

--- a/.buildchain/kfd/kfd-3/collaboration-interface.artifact.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.artifact.json
@@ -10,8 +10,8 @@
   "sourceRegistry": {
     "id": "kungfu",
     "path": ".buildchain/kfd/kfd-3/surfaces.json",
-    "sha256": "547b069faaed009d7ad6f3f948faf838f2ac13262aefb687a29dad4b09793775",
-    "digest": "sha256:074cfd6d246c6ecaa49dda2d284e3e85d86d3ce967b567f491bd6311b041ca2d"
+    "sha256": "79fa3f2b9acb94eaf0aee8660388b82391ca5e65125a556d3158362a2b071add",
+    "digest": "sha256:8cd991e8d58a38c77eeec1c3e23e69b6b00688d1d8e94baab56790b0f1726f39"
   },
   "upstreamKfd": {
     "aggregatePath": "developer/sdk/kfd/upstream-aggregate.json",
@@ -28,7 +28,7 @@
     },
     "digest": "sha256:38df18c7f118f322bfebdf1ba70628dd6c8ac39512fb1708e10dc6d3c37fadbe"
   },
-  "collaborationInterfaceDigest": "sha256:f66050b6ae9688a6b66b6993cc1f7cf34f011b0539983d340bd502fc6051fec8",
+  "collaborationInterfaceDigest": "sha256:f123976a032f85fbc079316a68e9027219d9db8541dc4e9e53fbe537051e6cc8",
   "exposedSurfaces": [
     {
       "id": "kungfu.agent",
@@ -1064,6 +1064,26 @@
       "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
       "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
       "maturity": "stable",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
+      "id": "kungfu.cut.inspect",
+      "name": "kungfu cut --repo <path> --json",
+      "kind": "cli-api",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
       "declaration": {
         "owner": "kungfu",
         "source": "scripts/buildchain-kfd-evidence.mjs",
@@ -2536,6 +2556,26 @@
       }
     },
     {
+      "id": "kungfu.work.complete",
+      "name": "kungfu work complete <work-id> --repo <path> --json",
+      "kind": "cli-api",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
       "id": "kungfu.work.create",
       "name": "kungfu work create <title> --json",
       "kind": "cli",
@@ -2549,6 +2589,86 @@
       "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
       "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
       "maturity": "stable",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
+      "id": "kungfu.work.inspect",
+      "name": "kungfu work inspect --repo <path> --json",
+      "kind": "cli-api",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
+      "id": "kungfu.work.loop",
+      "name": "kungfu work capabilities --json",
+      "kind": "cli-api",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
+      "id": "kungfu.work.recover",
+      "name": "kungfu work recover --repo <path> --json",
+      "kind": "cli-api",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
+      "id": "kungfu.work.settle",
+      "name": "kungfu work settle <work-id> --claim-root <root> --review-root <root> --decision-root <root> --project-cut-root <root> --json",
+      "kind": "cli-api",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
       "declaration": {
         "owner": "kungfu",
         "source": "scripts/buildchain-kfd-evidence.mjs",

--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -6,15 +6,15 @@
   "supportLevel": "release",
   "source": {
     "cwd": ".",
-    "sourceSha": "78f50c8690947c5a5368aaa984a664f12da9607d",
+    "sourceSha": "da4e284f2c23242008eb222b2b2277cc80c96166",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
-    "registryDigest": "sha256:074cfd6d246c6ecaa49dda2d284e3e85d86d3ce967b567f491bd6311b041ca2d"
+    "registryDigest": "sha256:8cd991e8d58a38c77eeec1c3e23e69b6b00688d1d8e94baab56790b0f1726f39"
   },
   "sourceRegistry": {
     "id": "kungfu",
     "path": ".buildchain/kfd/kfd-3/surfaces.json",
-    "sha256": "547b069faaed009d7ad6f3f948faf838f2ac13262aefb687a29dad4b09793775",
-    "digest": "sha256:074cfd6d246c6ecaa49dda2d284e3e85d86d3ce967b567f491bd6311b041ca2d"
+    "sha256": "79fa3f2b9acb94eaf0aee8660388b82391ca5e65125a556d3158362a2b071add",
+    "digest": "sha256:8cd991e8d58a38c77eeec1c3e23e69b6b00688d1d8e94baab56790b0f1726f39"
   },
   "upstreamKfd": {
     "aggregatePath": "developer/sdk/kfd/upstream-aggregate.json",
@@ -34,7 +34,7 @@
   "expectedArtifactVerification": {
     "command": "node scripts/buildchain-kfd-evidence.mjs --artifact-witness --json"
   },
-  "collaborationInterfaceDigest": "sha256:f66050b6ae9688a6b66b6993cc1f7cf34f011b0539983d340bd502fc6051fec8",
+  "collaborationInterfaceDigest": "sha256:f123976a032f85fbc079316a68e9027219d9db8541dc4e9e53fbe537051e6cc8",
   "collaborationInterface": {
     "schemaVersion": 1,
     "contract": "kungfu-buildchain-kfd-3-surface-registry",
@@ -1094,6 +1094,26 @@
         "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
         "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
         "maturity": "stable",
+        "declaration": {
+          "owner": "kungfu",
+          "source": "scripts/buildchain-kfd-evidence.mjs",
+          "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+        }
+      },
+      {
+        "id": "kungfu.cut.inspect",
+        "name": "kungfu cut --repo <path> --json",
+        "kind": "cli-api",
+        "participantProfile": "agent-or-developer",
+        "state": "declared",
+        "availability": "shipped",
+        "visibility": "public",
+        "participantFacing": true,
+        "public": true,
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+        "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+        "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+        "maturity": "experimental",
         "declaration": {
           "owner": "kungfu",
           "source": "scripts/buildchain-kfd-evidence.mjs",
@@ -2566,6 +2586,26 @@
         }
       },
       {
+        "id": "kungfu.work.complete",
+        "name": "kungfu work complete <work-id> --repo <path> --json",
+        "kind": "cli-api",
+        "participantProfile": "agent-or-developer",
+        "state": "declared",
+        "availability": "shipped",
+        "visibility": "public",
+        "participantFacing": true,
+        "public": true,
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+        "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+        "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+        "maturity": "experimental",
+        "declaration": {
+          "owner": "kungfu",
+          "source": "scripts/buildchain-kfd-evidence.mjs",
+          "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+        }
+      },
+      {
         "id": "kungfu.work.create",
         "name": "kungfu work create <title> --json",
         "kind": "cli",
@@ -2579,6 +2619,86 @@
         "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
         "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
         "maturity": "stable",
+        "declaration": {
+          "owner": "kungfu",
+          "source": "scripts/buildchain-kfd-evidence.mjs",
+          "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+        }
+      },
+      {
+        "id": "kungfu.work.inspect",
+        "name": "kungfu work inspect --repo <path> --json",
+        "kind": "cli-api",
+        "participantProfile": "agent-or-developer",
+        "state": "declared",
+        "availability": "shipped",
+        "visibility": "public",
+        "participantFacing": true,
+        "public": true,
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+        "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+        "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+        "maturity": "experimental",
+        "declaration": {
+          "owner": "kungfu",
+          "source": "scripts/buildchain-kfd-evidence.mjs",
+          "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+        }
+      },
+      {
+        "id": "kungfu.work.loop",
+        "name": "kungfu work capabilities --json",
+        "kind": "cli-api",
+        "participantProfile": "agent-or-developer",
+        "state": "declared",
+        "availability": "shipped",
+        "visibility": "public",
+        "participantFacing": true,
+        "public": true,
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+        "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+        "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+        "maturity": "experimental",
+        "declaration": {
+          "owner": "kungfu",
+          "source": "scripts/buildchain-kfd-evidence.mjs",
+          "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+        }
+      },
+      {
+        "id": "kungfu.work.recover",
+        "name": "kungfu work recover --repo <path> --json",
+        "kind": "cli-api",
+        "participantProfile": "agent-or-developer",
+        "state": "declared",
+        "availability": "shipped",
+        "visibility": "public",
+        "participantFacing": true,
+        "public": true,
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+        "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+        "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+        "maturity": "experimental",
+        "declaration": {
+          "owner": "kungfu",
+          "source": "scripts/buildchain-kfd-evidence.mjs",
+          "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+        }
+      },
+      {
+        "id": "kungfu.work.settle",
+        "name": "kungfu work settle <work-id> --claim-root <root> --review-root <root> --decision-root <root> --project-cut-root <root> --json",
+        "kind": "cli-api",
+        "participantProfile": "agent-or-developer",
+        "state": "declared",
+        "availability": "shipped",
+        "visibility": "public",
+        "participantFacing": true,
+        "public": true,
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+        "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+        "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+        "maturity": "experimental",
         "declaration": {
           "owner": "kungfu",
           "source": "scripts/buildchain-kfd-evidence.mjs",
@@ -2808,8 +2928,8 @@
     ],
     "audit": {
       "status": "passed",
-      "declared": 136,
-      "artifactPublic": 136,
+      "declared": 142,
+      "artifactPublic": 142,
       "policy": {
         "sourceOfTruth": ".buildchain/kfd/kfd-3/surfaces.json",
         "detectedButUnregistered": "product-specific-audit",
@@ -3855,6 +3975,26 @@
       "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
       "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
       "maturity": "stable",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
+      "id": "kungfu.cut.inspect",
+      "name": "kungfu cut --repo <path> --json",
+      "kind": "cli-api",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
       "declaration": {
         "owner": "kungfu",
         "source": "scripts/buildchain-kfd-evidence.mjs",
@@ -5327,6 +5467,26 @@
       }
     },
     {
+      "id": "kungfu.work.complete",
+      "name": "kungfu work complete <work-id> --repo <path> --json",
+      "kind": "cli-api",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
       "id": "kungfu.work.create",
       "name": "kungfu work create <title> --json",
       "kind": "cli",
@@ -5340,6 +5500,86 @@
       "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
       "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
       "maturity": "stable",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
+      "id": "kungfu.work.inspect",
+      "name": "kungfu work inspect --repo <path> --json",
+      "kind": "cli-api",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
+      "id": "kungfu.work.loop",
+      "name": "kungfu work capabilities --json",
+      "kind": "cli-api",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
+      "id": "kungfu.work.recover",
+      "name": "kungfu work recover --repo <path> --json",
+      "kind": "cli-api",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
+      "id": "kungfu.work.settle",
+      "name": "kungfu work settle <work-id> --claim-root <root> --review-root <root> --decision-root <root> --project-cut-root <root> --json",
+      "kind": "cli-api",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
       "declaration": {
         "owner": "kungfu",
         "source": "scripts/buildchain-kfd-evidence.mjs",

--- a/.buildchain/kfd/kfd-3/surfaces.json
+++ b/.buildchain/kfd/kfd-3/surfaces.json
@@ -1109,6 +1109,26 @@
       }
     },
     {
+      "id": "kungfu.cut.inspect",
+      "name": "kungfu cut --repo <path> --json",
+      "kind": "cli-api",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
       "id": "kungfu.exit.bundle",
       "name": "kungfu exit build --file <request.json> --json",
       "kind": "cli",
@@ -2574,6 +2594,26 @@
       }
     },
     {
+      "id": "kungfu.work.complete",
+      "name": "kungfu work complete <work-id> --repo <path> --json",
+      "kind": "cli-api",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
       "id": "kungfu.work.create",
       "name": "kungfu work create <title> --json",
       "kind": "cli",
@@ -2587,6 +2627,86 @@
       "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
       "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
       "maturity": "stable",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
+      "id": "kungfu.work.inspect",
+      "name": "kungfu work inspect --repo <path> --json",
+      "kind": "cli-api",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
+      "id": "kungfu.work.loop",
+      "name": "kungfu work capabilities --json",
+      "kind": "cli-api",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
+      "id": "kungfu.work.recover",
+      "name": "kungfu work recover --repo <path> --json",
+      "kind": "cli-api",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
+      "id": "kungfu.work.settle",
+      "name": "kungfu work settle <work-id> --claim-root <root> --review-root <root> --decision-root <root> --project-cut-root <root> --json",
+      "kind": "cli-api",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
       "declaration": {
         "owner": "kungfu",
         "source": "scripts/buildchain-kfd-evidence.mjs",

--- a/developer/sdk/kfd/kfd-2/claims/agent-onboarding-pack.json
+++ b/developer/sdk/kfd/kfd-2/claims/agent-onboarding-pack.json
@@ -16,7 +16,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "ebcd87f9dee4e92206cb7cf4eb42a988b93753aee53862798bc8c6a9ccf19ec1"
+        "sha256": "62687c870e8f06bc925450db9107bd3360ee91fef4783b5167b9904c79662582"
       },
       "description": "Machine-readable command catalog and mode maturity metadata."
     },
@@ -25,7 +25,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/cli_surface.catalog.json",
-        "sha256": "fec89b2148326be90b1ceec4ff0e12c20b7dbe30775c227268f7fc2f8294165d"
+        "sha256": "9f6f7b50a106f192f045425ec13cbc46947c7e66d3cc7c89ca40bf4b0223817c"
       },
       "description": "Complete deterministic CLI surface graph shared by offline Agent capabilities and catalog parity checks."
     },
@@ -72,11 +72,11 @@
     "evidenceSha256": [
       {
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "ebcd87f9dee4e92206cb7cf4eb42a988b93753aee53862798bc8c6a9ccf19ec1"
+        "sha256": "62687c870e8f06bc925450db9107bd3360ee91fef4783b5167b9904c79662582"
       },
       {
         "path": "framework/core/src/python/kungfu/agent/cli_surface.catalog.json",
-        "sha256": "fec89b2148326be90b1ceec4ff0e12c20b7dbe30775c227268f7fc2f8294165d"
+        "sha256": "9f6f7b50a106f192f045425ec13cbc46947c7e66d3cc7c89ca40bf4b0223817c"
       },
       {
         "path": "framework/core/src/python/kungfu/agent/mode-selection.md",
@@ -102,11 +102,11 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "ebcd87f9dee4e92206cb7cf4eb42a988b93753aee53862798bc8c6a9ccf19ec1"
+        "sha256": "62687c870e8f06bc925450db9107bd3360ee91fef4783b5167b9904c79662582"
       },
       {
         "path": "framework/core/src/python/kungfu/agent/cli_surface.catalog.json",
-        "sha256": "fec89b2148326be90b1ceec4ff0e12c20b7dbe30775c227268f7fc2f8294165d"
+        "sha256": "9f6f7b50a106f192f045425ec13cbc46947c7e66d3cc7c89ca40bf4b0223817c"
       }
     ]
   },
@@ -120,13 +120,13 @@
     {
       "name": "agent-command-catalog",
       "path": "framework/core/src/python/kungfu/agent/commands.json",
-      "sha256": "ebcd87f9dee4e92206cb7cf4eb42a988b93753aee53862798bc8c6a9ccf19ec1",
+      "sha256": "62687c870e8f06bc925450db9107bd3360ee91fef4783b5167b9904c79662582",
       "expectedPackagePath": "kungfu/agent/commands.json"
     },
     {
       "name": "cli-surface-catalog",
       "path": "framework/core/src/python/kungfu/agent/cli_surface.catalog.json",
-      "sha256": "fec89b2148326be90b1ceec4ff0e12c20b7dbe30775c227268f7fc2f8294165d",
+      "sha256": "9f6f7b50a106f192f045425ec13cbc46947c7e66d3cc7c89ca40bf4b0223817c",
       "expectedPackagePath": "kungfu/agent/cli_surface.catalog.json"
     }
   ],

--- a/developer/sdk/kfd/kfd-2/claims/agent-work-state-contract.json
+++ b/developer/sdk/kfd/kfd-2/claims/agent-work-state-contract.json
@@ -43,7 +43,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/tests/python/test_agent_work_state_contract.py",
-        "sha256": "eb0cb31109bdbb82022626249fd07c9ee7657ebd1a364e7e608fb8d99b2cb700"
+        "sha256": "a19cdc151a1247af5f25388ac69a20ee8d945872e9a4232ce1e85ff339a62049"
       },
       "description": "Runtime CLI parity and fail-closed contract-schema checks."
     },
@@ -52,7 +52,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
-        "sha256": "f786fd06eadf2a1f7704e7b49e821d689f4b60f73274e4952f5546c96a0e122f"
+        "sha256": "735bf52451494a2f1d7017eedc74e5817bbeb435ee6bfe306a77b385954b27bd"
       },
       "description": "Agent collaboration-interface registration for the work-model query."
     }
@@ -75,11 +75,11 @@
       },
       {
         "path": "framework/core/tests/python/test_agent_work_state_contract.py",
-        "sha256": "eb0cb31109bdbb82022626249fd07c9ee7657ebd1a364e7e608fb8d99b2cb700"
+        "sha256": "a19cdc151a1247af5f25388ac69a20ee8d945872e9a4232ce1e85ff339a62049"
       },
       {
         "path": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
-        "sha256": "f786fd06eadf2a1f7704e7b49e821d689f4b60f73274e4952f5546c96a0e122f"
+        "sha256": "735bf52451494a2f1d7017eedc74e5817bbeb435ee6bfe306a77b385954b27bd"
       }
     ],
     "artifactSha256": [

--- a/developer/sdk/kfd/kfd-2/claims/codex-report-receipts.json
+++ b/developer/sdk/kfd/kfd-2/claims/codex-report-receipts.json
@@ -52,7 +52,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/skills/codex/SKILL.md",
-        "sha256": "7ee0c3285c1d9a1e1d0108ce802b6976760fba08a22166c0fffa6611d18bbe79"
+        "sha256": "79605a827bd7e8746479a0b486642cbb2a63d1390870003e14bcbeeb0c196046"
       },
       "description": "Codex-side report closeout gate instructions shipped in the agent pack."
     }
@@ -79,7 +79,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/skills/codex/SKILL.md",
-        "sha256": "7ee0c3285c1d9a1e1d0108ce802b6976760fba08a22166c0fffa6611d18bbe79"
+        "sha256": "79605a827bd7e8746479a0b486642cbb2a63d1390870003e14bcbeeb0c196046"
       }
     ],
     "artifactSha256": [
@@ -89,7 +89,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/skills/codex/SKILL.md",
-        "sha256": "7ee0c3285c1d9a1e1d0108ce802b6976760fba08a22166c0fffa6611d18bbe79"
+        "sha256": "79605a827bd7e8746479a0b486642cbb2a63d1390870003e14bcbeeb0c196046"
       }
     ]
   },
@@ -103,7 +103,7 @@
     {
       "name": "codex-agent-skill",
       "path": "framework/core/src/python/kungfu/agent/skills/codex/SKILL.md",
-      "sha256": "7ee0c3285c1d9a1e1d0108ce802b6976760fba08a22166c0fffa6611d18bbe79",
+      "sha256": "79605a827bd7e8746479a0b486642cbb2a63d1390870003e14bcbeeb0c196046",
       "expectedPackagePath": "kungfu/agent/skills/codex/SKILL.md"
     }
   ],

--- a/developer/sdk/kfd/kfd-2/claims/remote-fact-boundary.json
+++ b/developer/sdk/kfd/kfd-2/claims/remote-fact-boundary.json
@@ -34,7 +34,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "ebcd87f9dee4e92206cb7cf4eb42a988b93753aee53862798bc8c6a9ccf19ec1"
+        "sha256": "62687c870e8f06bc925450db9107bd3360ee91fef4783b5167b9904c79662582"
       },
       "description": "Remote add/sync command declarations and mode metadata."
     },
@@ -43,7 +43,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/cli/commands/agent.py",
-        "sha256": "cfe866fe7aa0a4e4475f6a62d6f085ebf889a1b450756c86ed0d6f4519080ca7"
+        "sha256": "106e58e3fc75e8fa50e21c74552ee01fc1090f55a88a1d551b7590b6a193cb88"
       },
       "description": "Agent command surface including mode selection and bootstrap status."
     }
@@ -62,11 +62,11 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "ebcd87f9dee4e92206cb7cf4eb42a988b93753aee53862798bc8c6a9ccf19ec1"
+        "sha256": "62687c870e8f06bc925450db9107bd3360ee91fef4783b5167b9904c79662582"
       },
       {
         "path": "framework/core/src/python/kungfu/cli/commands/agent.py",
-        "sha256": "cfe866fe7aa0a4e4475f6a62d6f085ebf889a1b450756c86ed0d6f4519080ca7"
+        "sha256": "106e58e3fc75e8fa50e21c74552ee01fc1090f55a88a1d551b7590b6a193cb88"
       }
     ],
     "artifactSha256": [

--- a/developer/sdk/kfd/kfd-2/release-claims.json
+++ b/developer/sdk/kfd/kfd-2/release-claims.json
@@ -29,7 +29,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/commands.json",
-            "sha256": "ebcd87f9dee4e92206cb7cf4eb42a988b93753aee53862798bc8c6a9ccf19ec1"
+            "sha256": "62687c870e8f06bc925450db9107bd3360ee91fef4783b5167b9904c79662582"
           },
           "description": "Machine-readable command catalog and mode maturity metadata."
         },
@@ -38,7 +38,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/cli_surface.catalog.json",
-            "sha256": "fec89b2148326be90b1ceec4ff0e12c20b7dbe30775c227268f7fc2f8294165d"
+            "sha256": "9f6f7b50a106f192f045425ec13cbc46947c7e66d3cc7c89ca40bf4b0223817c"
           },
           "description": "Complete deterministic CLI surface graph shared by offline Agent capabilities and catalog parity checks."
         },
@@ -152,7 +152,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/skills/codex/SKILL.md",
-            "sha256": "7ee0c3285c1d9a1e1d0108ce802b6976760fba08a22166c0fffa6611d18bbe79"
+            "sha256": "79605a827bd7e8746479a0b486642cbb2a63d1390870003e14bcbeeb0c196046"
           },
           "description": "Codex-side report closeout gate instructions shipped in the agent pack."
         }
@@ -212,7 +212,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/commands.json",
-            "sha256": "ebcd87f9dee4e92206cb7cf4eb42a988b93753aee53862798bc8c6a9ccf19ec1"
+            "sha256": "62687c870e8f06bc925450db9107bd3360ee91fef4783b5167b9904c79662582"
           },
           "description": "Remote add/sync command declarations and mode metadata."
         },
@@ -221,7 +221,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/cli/commands/agent.py",
-            "sha256": "cfe866fe7aa0a4e4475f6a62d6f085ebf889a1b450756c86ed0d6f4519080ca7"
+            "sha256": "106e58e3fc75e8fa50e21c74552ee01fc1090f55a88a1d551b7590b6a193cb88"
           },
           "description": "Agent command surface including mode selection and bootstrap status."
         }
@@ -292,7 +292,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/tests/python/test_agent_work_state_contract.py",
-            "sha256": "eb0cb31109bdbb82022626249fd07c9ee7657ebd1a364e7e608fb8d99b2cb700"
+            "sha256": "a19cdc151a1247af5f25388ac69a20ee8d945872e9a4232ce1e85ff339a62049"
           },
           "description": "Runtime CLI parity and fail-closed contract-schema checks."
         },
@@ -301,7 +301,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
-            "sha256": "f786fd06eadf2a1f7704e7b49e821d689f4b60f73274e4952f5546c96a0e122f"
+            "sha256": "735bf52451494a2f1d7017eedc74e5817bbeb435ee6bfe306a77b385954b27bd"
           },
           "description": "Agent collaboration-interface registration for the work-model query."
         }

--- a/developer/sdk/kfd/kfd-3-surfaces.json
+++ b/developer/sdk/kfd/kfd-3-surfaces.json
@@ -1109,6 +1109,26 @@
       }
     },
     {
+      "id": "kungfu.cut.inspect",
+      "name": "kungfu cut --repo <path> --json",
+      "kind": "cli-api",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
       "id": "kungfu.exit.bundle",
       "name": "kungfu exit build --file <request.json> --json",
       "kind": "cli",
@@ -2574,6 +2594,26 @@
       }
     },
     {
+      "id": "kungfu.work.complete",
+      "name": "kungfu work complete <work-id> --repo <path> --json",
+      "kind": "cli-api",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
       "id": "kungfu.work.create",
       "name": "kungfu work create <title> --json",
       "kind": "cli",
@@ -2587,6 +2627,86 @@
       "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
       "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
       "maturity": "stable",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
+      "id": "kungfu.work.inspect",
+      "name": "kungfu work inspect --repo <path> --json",
+      "kind": "cli-api",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
+      "id": "kungfu.work.loop",
+      "name": "kungfu work capabilities --json",
+      "kind": "cli-api",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
+      "id": "kungfu.work.recover",
+      "name": "kungfu work recover --repo <path> --json",
+      "kind": "cli-api",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
+      "id": "kungfu.work.settle",
+      "name": "kungfu work settle <work-id> --claim-root <root> --review-root <root> --decision-root <root> --project-cut-root <root> --json",
+      "kind": "cli-api",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
       "declaration": {
         "owner": "kungfu",
         "source": "scripts/buildchain-kfd-evidence.mjs",

--- a/docs/adr/KF-ADR-019f87e8-6b8b-735c-b036-fa42d7cee8cf-project-cut-public-work-loop-facade.md
+++ b/docs/adr/KF-ADR-019f87e8-6b8b-735c-b036-fa42d7cee8cf-project-cut-public-work-loop-facade.md
@@ -4,8 +4,8 @@ doc_type: architecture-decision
 adr_id: KF-ADR-019f87e8-6b8b-735c-b036-fa42d7cee8cf
 decision_status: accepted
 implementation_status: staged
-implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/1218]
-qualification_refs: [framework/work-loop/work-api.contract.json, framework/core/tests/python/test_project_cut_read_model.py, framework/core/tests/python/test_work_facade.py]
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/1218, https://github.com/kungfu-systems/kungfu/pull/1225]
+qualification_refs: [framework/work-loop/work-api.contract.json, framework/core/tests/python/test_project_cut_read_model.py, framework/core/tests/python/test_work_facade.py, framework/core/tests/python/test_agent_work_state_contract.py]
 review_state: self-reviewed
 sensitivity: public
 sources: [local-files, user-consensus]
@@ -52,6 +52,11 @@ This decision is false if a facade read writes runtime state, if multiple Cuts
 or Work items are silently selected, if an Agent self-report settles Work, if
 managed-run accepts an unknown WorkRef, or if CLI and Agent JSON disagree.
 Qualification is owned by the Work API contract and its Cut/Work facade tests.
+
+The current staged multisurface slice projects one complete operation manifest
+through CLI and Agent and tests their exact equality without runtime
+initialization. GUI/TUI adapters and operations reported as unavailable,
+degraded, or plan-only remain outside executable qualification.
 
 ## Consequences
 

--- a/docs/architecture/project-cut-product-loop.md
+++ b/docs/architecture/project-cut-product-loop.md
@@ -84,9 +84,9 @@ Preparation and settlement must not share an implicit commit point. If a
 process exits after preparation, the current cut remains unchanged and
 recovery can verify, settle, supersede, or abandon the candidate explicitly.
 
-## Proposed command surface
+## Command surface
 
-The first public surface is intentionally narrow:
+The target public surface remains intentionally narrow:
 
 ```sh
 kungfu cut
@@ -113,6 +113,14 @@ Behavioral rules:
 The current `./shifu project-cut` command remains the developer and protocol
 implementation surface. The public command should compose it through stable
 contracts, not fork its canonicalization or verification logic.
+
+The first implemented product slice currently provides read-only `kungfu cut`,
+`kungfu work inspect`, and `kungfu work recover`, plus plan-only `complete` and
+`settle`. `kungfu work capabilities --json` is the shared capability manifest:
+it declares all high-level operations, their exact current availability, and
+CLI/Agent/GUI/TUI projection status. `kungfu agent capabilities --json`
+projects the same manifest as `workLoop`; it does not upgrade plan-only or
+unavailable operations into authority.
 
 ## Initiative and Assignment projection
 

--- a/docs/qualification/project-cut-product-loop.md
+++ b/docs/qualification/project-cut-product-loop.md
@@ -141,10 +141,11 @@ release.
 
 ## Current status
 
-**Product loop incomplete.** The repository contains substantial prerequisites,
-including `project.cut/v1`, agent-first settlement, native Mission/Go authority,
-Fact/Episode invariants, and independent completion review. Those prerequisites
-constitute partial implementation of ADR-0127. The repository does not yet
-provide the accepted `kungfu cut` product surface, native
-Initiative/Assignment model, or complete end-to-end release evidence defined
-here.
+**Product loop incomplete.** The repository now provides the read-only
+`kungfu cut` product entrypoint, a high-level Work read/recovery facade,
+plan-only completion/settlement, managed-run Work binding, and one shared
+CLI/Agent capability manifest. The manifest truthfully reports GUI/TUI,
+executable begin/settlement, portability, and Domain Profile projection as
+unavailable or degraded. Native Initiative/Assignment orchestration and the
+complete end-to-end release evidence defined here remain prerequisites for a
+qualified release claim.

--- a/framework/core/src/python/kungfu/agent/brief.md
+++ b/framework/core/src/python/kungfu/agent/brief.md
@@ -17,6 +17,8 @@ kungfu agent console current --json
 kungfu agent runtime list --json
 kungfu agent session capabilities --json
 kungfu agent session list --json
+kungfu cut --repo <path> --json
+kungfu work capabilities --json
 ```
 
 Kungfu has one public executable. Xinfa and all four Action Primitive roles are
@@ -73,6 +75,12 @@ The KFD-3 collaboration interface is declared in `kfd3_api.registry.json`.
 registry. `kungfu agent verify --json` checks the installed runtime command tree
 against the registry so a shipped agent surface cannot quietly expose extra
 `kungfu agent` commands outside the declared interface.
+
+Project-level work starts from the current Cut. `kungfu cut --repo <path>
+--json` is read-only, and `kungfu work capabilities --json` reports every
+high-level operation with its current availability and authority boundary.
+The same manifest appears as `workLoop` in `kungfu agent capabilities --json`;
+an unavailable or plan-only operation must not be inferred to be executable.
 
 For portable Exit packages, use
 `kungfu-exit-verify --file <package.json> --json` (or

--- a/framework/core/src/python/kungfu/agent/cli_surface.catalog.json
+++ b/framework/core/src/python/kungfu/agent/cli_surface.catalog.json
@@ -1,7 +1,7 @@
 {
-  "catalogRoot": "sha256:3b1592038ec51a8abdc401e12ab3cd1c08bc8cb5e1e5eb865add775cf02c0917",
+  "catalogRoot": "sha256:49405f1893d974c83bf805bdb48a954473718ace270443cd3f7899244a5b1b69",
   "contractId": "kungfu-cli-surface",
-  "contractRoot": "sha256:23eb918e2e18a6804b1667cc3270d11bb28aa37fc39f8a05f4c5333d276cb102",
+  "contractRoot": "sha256:56177501b0940ac0d6b3863a4fe4adcd8467bc5b8289bfea6e11852332e54637",
   "kfd3Linkage": [
     {
       "apiIds": [],
@@ -442,6 +442,14 @@
       "reason": "no-agent-first-api-declared",
       "state": "unlinked",
       "surfaceId": "kungfu.cli.commands.contract.verify"
+    },
+    {
+      "apiIds": [
+        "kungfu.cut.inspect"
+      ],
+      "reason": null,
+      "state": "linked",
+      "surfaceId": "kungfu.cli.commands.cut.cut"
     },
     {
       "apiIds": [],
@@ -2375,10 +2383,26 @@
       "surfaceId": "kungfu.cli.commands.work.register.status.verb.locals.cmd.kungfu.work.block"
     },
     {
+      "apiIds": [
+        "kungfu.work.loop"
+      ],
+      "reason": null,
+      "state": "linked",
+      "surfaceId": "kungfu.cli.commands.work.capabilities"
+    },
+    {
       "apiIds": [],
       "reason": "no-agent-first-api-declared",
       "state": "unlinked",
       "surfaceId": "kungfu.cli.commands.work.checkpoint"
+    },
+    {
+      "apiIds": [
+        "kungfu.work.complete"
+      ],
+      "reason": null,
+      "state": "linked",
+      "surfaceId": "kungfu.cli.commands.work.complete"
     },
     {
       "apiIds": [
@@ -2399,6 +2423,14 @@
       "reason": "no-agent-first-api-declared",
       "state": "unlinked",
       "surfaceId": "kungfu.cli.commands.work.register.status.verb.locals.cmd.kungfu.work.done"
+    },
+    {
+      "apiIds": [
+        "kungfu.work.inspect"
+      ],
+      "reason": null,
+      "state": "linked",
+      "surfaceId": "kungfu.cli.commands.work.inspect"
     },
     {
       "apiIds": [],
@@ -2431,10 +2463,26 @@
       "surfaceId": "kungfu.cli.commands.work.register.status.verb.locals.cmd.kungfu.work.ready"
     },
     {
+      "apiIds": [
+        "kungfu.work.recover"
+      ],
+      "reason": null,
+      "state": "linked",
+      "surfaceId": "kungfu.cli.commands.work.recover"
+    },
+    {
       "apiIds": [],
       "reason": "no-agent-first-api-declared",
       "state": "unlinked",
       "surfaceId": "kungfu.cli.commands.work.register.status.verb.locals.cmd.kungfu.work.resume"
+    },
+    {
+      "apiIds": [
+        "kungfu.work.settle"
+      ],
+      "reason": null,
+      "state": "linked",
+      "surfaceId": "kungfu.cli.commands.work.settle"
     },
     {
       "apiIds": [],
@@ -2601,11 +2649,11 @@
       "kfd3Registry": "strict-link",
       "packagedInventory": "required-agent-pack-entry"
     },
-    "expectedSurfaceRoot": "sha256:8fc0cc6646448cb45633446c315804fb00bf1c97b71e574370db62a7dea703fb",
+    "expectedSurfaceRoot": "sha256:0fec5025a38f2cb789405dc73435c22b262affe2082959444372205cfa986660",
     "regeneration": "./shifu fix:cli-catalog-parity",
     "validation": "./shifu check:cli-catalog-parity"
   },
-  "registryRoot": "sha256:c0558df6241ca39b972d8bd52a2041efe29158276b1c08f8b389133cc1467dc3",
+  "registryRoot": "sha256:aae9499944561e4a2f349b0e05e43d60fd215eed4c9a0af145cc4849bdceb2a0",
   "schema": "kungfu.cli-surface-catalog/v1",
   "schemaRoot": "sha256:731eec25990d090067d59651d6c0793934124ac79df4111990bd905e03b605c4",
   "source": {
@@ -2618,7 +2666,7 @@
     "pathAuthority": "live-click-tree",
     "root": "kungfu"
   },
-  "surfaceRoot": "sha256:8fc0cc6646448cb45633446c315804fb00bf1c97b71e574370db62a7dea703fb",
+  "surfaceRoot": "sha256:0fec5025a38f2cb789405dc73435c22b262affe2082959444372205cfa986660",
   "surfaces": [
     {
       "alias_diagnostics": [],
@@ -7000,6 +7048,72 @@
         "symbol": "verify"
       },
       "summary": "validate every registered contract can be loaded",
+      "visibility": "advanced"
+    },
+    {
+      "alias_diagnostics": [],
+      "aliases": [],
+      "approval_policy": {
+        "caller_confirmation_required": false,
+        "mode": "none",
+        "preconditions": []
+      },
+      "audience": [
+        "human",
+        "agent"
+      ],
+      "availability": {
+        "conditions": [
+          "source-runtime"
+        ],
+        "state": "available"
+      },
+      "canonical_path": "kungfu cut",
+      "id": "kungfu.cli.commands.cut.cut",
+      "kfd3_api_id": "kungfu.cut.inspect",
+      "kfd3_api_ids": [
+        "kungfu.cut.inspect"
+      ],
+      "kind": "command",
+      "maturity": "experimental",
+      "mutation_class": "read",
+      "owner": "core",
+      "parameters": [
+        {
+          "arity": 1,
+          "flags": [
+            "--repo"
+          ],
+          "hidden": false,
+          "kind": "option",
+          "name": "repo",
+          "required": false,
+          "type": "directory"
+        },
+        {
+          "arity": 1,
+          "flags": [
+            "--json"
+          ],
+          "hidden": false,
+          "kind": "option",
+          "name": "as_json",
+          "required": false,
+          "type": "boolean"
+        }
+      ],
+      "path_depth": 2,
+      "removal_gate": null,
+      "replacement": null,
+      "schema_refs": [],
+      "section": "advanced-compatibility",
+      "source": {
+        "familyPolicy": false,
+        "kind": "runtime-click",
+        "module": "kungfu.cli.commands.cut",
+        "symbol": "cut"
+      },
+      "summary": "inspect the current Project Cut, confidence, gaps, and next actions",
       "visibility": "advanced"
     },
     {
@@ -27546,6 +27660,17 @@
           "name": "as_json",
           "required": false,
           "type": "boolean"
+        },
+        {
+          "arity": 1,
+          "flags": [
+            "--verify"
+          ],
+          "hidden": false,
+          "kind": "option",
+          "name": "verify",
+          "required": false,
+          "type": "boolean"
         }
       ],
       "path_depth": 3,
@@ -29170,6 +29295,61 @@
         ],
         "state": "available"
       },
+      "canonical_path": "kungfu work capabilities",
+      "id": "kungfu.cli.commands.work.capabilities",
+      "kfd3_api_id": "kungfu.work.loop",
+      "kfd3_api_ids": [
+        "kungfu.work.loop"
+      ],
+      "kind": "command",
+      "maturity": "experimental",
+      "mutation_class": "read",
+      "owner": "core",
+      "parameters": [
+        {
+          "arity": 1,
+          "flags": [
+            "--json"
+          ],
+          "hidden": false,
+          "kind": "option",
+          "name": "as_json",
+          "required": false,
+          "type": "boolean"
+        }
+      ],
+      "path_depth": 3,
+      "removal_gate": null,
+      "replacement": null,
+      "schema_refs": [],
+      "section": "advanced-compatibility",
+      "source": {
+        "familyPolicy": true,
+        "kind": "runtime-click",
+        "module": "kungfu.cli.commands.work",
+        "symbol": "capabilities"
+      },
+      "summary": "discover the shared Work/Cut operations and surface parity",
+      "visibility": "public"
+    },
+    {
+      "alias_diagnostics": [],
+      "aliases": [],
+      "approval_policy": {
+        "caller_confirmation_required": false,
+        "mode": "none",
+        "preconditions": []
+      },
+      "audience": [
+        "human",
+        "agent"
+      ],
+      "availability": {
+        "conditions": [
+          "source-runtime"
+        ],
+        "state": "available"
+      },
       "canonical_path": "kungfu work checkpoint",
       "id": "kungfu.cli.commands.work.checkpoint",
       "kfd3_api_id": null,
@@ -29207,6 +29387,79 @@
       },
       "summary": "record a recovery checkpoint note",
       "visibility": "advanced"
+    },
+    {
+      "alias_diagnostics": [],
+      "aliases": [],
+      "approval_policy": {
+        "caller_confirmation_required": false,
+        "mode": "none",
+        "preconditions": []
+      },
+      "audience": [
+        "human",
+        "agent"
+      ],
+      "availability": {
+        "conditions": [
+          "source-runtime"
+        ],
+        "state": "available"
+      },
+      "canonical_path": "kungfu work complete",
+      "id": "kungfu.cli.commands.work.complete",
+      "kfd3_api_id": "kungfu.work.complete",
+      "kfd3_api_ids": [
+        "kungfu.work.complete"
+      ],
+      "kind": "command",
+      "maturity": "experimental",
+      "mutation_class": "read",
+      "owner": "core",
+      "parameters": [
+        {
+          "arity": 1,
+          "kind": "argument",
+          "name": "work_id",
+          "required": true,
+          "type": "text"
+        },
+        {
+          "arity": 1,
+          "flags": [
+            "--repo"
+          ],
+          "hidden": false,
+          "kind": "option",
+          "name": "repo",
+          "required": false,
+          "type": "directory"
+        },
+        {
+          "arity": 1,
+          "flags": [
+            "--json"
+          ],
+          "hidden": false,
+          "kind": "option",
+          "name": "as_json",
+          "required": false,
+          "type": "boolean"
+        }
+      ],
+      "path_depth": 3,
+      "removal_gate": null,
+      "replacement": null,
+      "schema_refs": [],
+      "section": "advanced-compatibility",
+      "source": {
+        "familyPolicy": true,
+        "kind": "runtime-click",
+        "module": "kungfu.cli.commands.work",
+        "symbol": "complete"
+      },
+      "summary": "prepare a completion candidate without self-settling the Work",
+      "visibility": "public"
     },
     {
       "alias_diagnostics": [],
@@ -29429,6 +29682,72 @@
       },
       "summary": "mark a work item done (-> done)",
       "visibility": "advanced"
+    },
+    {
+      "alias_diagnostics": [],
+      "aliases": [],
+      "approval_policy": {
+        "caller_confirmation_required": false,
+        "mode": "none",
+        "preconditions": []
+      },
+      "audience": [
+        "human",
+        "agent"
+      ],
+      "availability": {
+        "conditions": [
+          "source-runtime"
+        ],
+        "state": "available"
+      },
+      "canonical_path": "kungfu work inspect",
+      "id": "kungfu.cli.commands.work.inspect",
+      "kfd3_api_id": "kungfu.work.inspect",
+      "kfd3_api_ids": [
+        "kungfu.work.inspect"
+      ],
+      "kind": "command",
+      "maturity": "experimental",
+      "mutation_class": "read",
+      "owner": "core",
+      "parameters": [
+        {
+          "arity": 1,
+          "flags": [
+            "--repo"
+          ],
+          "hidden": false,
+          "kind": "option",
+          "name": "repo",
+          "required": false,
+          "type": "directory"
+        },
+        {
+          "arity": 1,
+          "flags": [
+            "--json"
+          ],
+          "hidden": false,
+          "kind": "option",
+          "name": "as_json",
+          "required": false,
+          "type": "boolean"
+        }
+      ],
+      "path_depth": 3,
+      "removal_gate": null,
+      "replacement": null,
+      "schema_refs": [],
+      "section": "advanced-compatibility",
+      "source": {
+        "familyPolicy": true,
+        "kind": "runtime-click",
+        "module": "kungfu.cli.commands.work",
+        "symbol": "inspect"
+      },
+      "summary": "inspect the current Project Cut and Work through one read model",
+      "visibility": "public"
     },
     {
       "alias_diagnostics": [],
@@ -29766,6 +30085,72 @@
         ],
         "state": "available"
       },
+      "canonical_path": "kungfu work recover",
+      "id": "kungfu.cli.commands.work.recover",
+      "kfd3_api_id": "kungfu.work.recover",
+      "kfd3_api_ids": [
+        "kungfu.work.recover"
+      ],
+      "kind": "command",
+      "maturity": "experimental",
+      "mutation_class": "write",
+      "owner": "core",
+      "parameters": [
+        {
+          "arity": 1,
+          "flags": [
+            "--repo"
+          ],
+          "hidden": false,
+          "kind": "option",
+          "name": "repo",
+          "required": false,
+          "type": "directory"
+        },
+        {
+          "arity": 1,
+          "flags": [
+            "--json"
+          ],
+          "hidden": false,
+          "kind": "option",
+          "name": "as_json",
+          "required": false,
+          "type": "boolean"
+        }
+      ],
+      "path_depth": 3,
+      "removal_gate": null,
+      "replacement": null,
+      "schema_refs": [],
+      "section": "advanced-compatibility",
+      "source": {
+        "familyPolicy": true,
+        "kind": "runtime-click",
+        "module": "kungfu.cli.commands.work",
+        "symbol": "recover"
+      },
+      "summary": "classify the exact next recovery action without writing state",
+      "visibility": "public"
+    },
+    {
+      "alias_diagnostics": [],
+      "aliases": [],
+      "approval_policy": {
+        "caller_confirmation_required": false,
+        "mode": "none",
+        "preconditions": []
+      },
+      "audience": [
+        "human",
+        "agent"
+      ],
+      "availability": {
+        "conditions": [
+          "source-runtime"
+        ],
+        "state": "available"
+      },
       "canonical_path": "kungfu work resume",
       "id": "kungfu.cli.commands.work.register.status.verb.locals.cmd.kungfu.work.resume",
       "kfd3_api_id": null,
@@ -29818,6 +30203,112 @@
       },
       "summary": "resume a work item (-> active)",
       "visibility": "advanced"
+    },
+    {
+      "alias_diagnostics": [],
+      "aliases": [],
+      "approval_policy": {
+        "caller_confirmation_required": false,
+        "mode": "none",
+        "preconditions": []
+      },
+      "audience": [
+        "human",
+        "agent"
+      ],
+      "availability": {
+        "conditions": [
+          "source-runtime"
+        ],
+        "state": "available"
+      },
+      "canonical_path": "kungfu work settle",
+      "id": "kungfu.cli.commands.work.settle",
+      "kfd3_api_id": "kungfu.work.settle",
+      "kfd3_api_ids": [
+        "kungfu.work.settle"
+      ],
+      "kind": "command",
+      "maturity": "experimental",
+      "mutation_class": "read",
+      "owner": "core",
+      "parameters": [
+        {
+          "arity": 1,
+          "kind": "argument",
+          "name": "work_id",
+          "required": true,
+          "type": "text"
+        },
+        {
+          "arity": 1,
+          "flags": [
+            "--claim-root"
+          ],
+          "hidden": false,
+          "kind": "option",
+          "name": "claim_root",
+          "required": true,
+          "type": "text"
+        },
+        {
+          "arity": 1,
+          "flags": [
+            "--review-root"
+          ],
+          "hidden": false,
+          "kind": "option",
+          "name": "review_root",
+          "required": true,
+          "type": "text"
+        },
+        {
+          "arity": 1,
+          "flags": [
+            "--decision-root"
+          ],
+          "hidden": false,
+          "kind": "option",
+          "name": "decision_root",
+          "required": true,
+          "type": "text"
+        },
+        {
+          "arity": 1,
+          "flags": [
+            "--project-cut-root"
+          ],
+          "hidden": false,
+          "kind": "option",
+          "name": "project_cut_root",
+          "required": true,
+          "type": "text"
+        },
+        {
+          "arity": 1,
+          "flags": [
+            "--json"
+          ],
+          "hidden": false,
+          "kind": "option",
+          "name": "as_json",
+          "required": false,
+          "type": "boolean"
+        }
+      ],
+      "path_depth": 3,
+      "removal_gate": null,
+      "replacement": null,
+      "schema_refs": [],
+      "section": "advanced-compatibility",
+      "source": {
+        "familyPolicy": true,
+        "kind": "runtime-click",
+        "module": "kungfu.cli.commands.work",
+        "symbol": "settle"
+      },
+      "summary": "prepare settlement from exact claim, review, decision, and Cut roots",
+      "visibility": "public"
     },
     {
       "alias_diagnostics": [],

--- a/framework/core/src/python/kungfu/agent/commands.json
+++ b/framework/core/src/python/kungfu/agent/commands.json
@@ -302,6 +302,42 @@
       "purpose": "Invoke the packaged verifier through the integrated Kungfu CLI when a configured runtime is already available."
     },
     {
+      "apiId": "kungfu.cut.inspect",
+      "name": "kungfu cut --repo <path> --json",
+      "maturity": "experimental",
+      "purpose": "Inspect the current Project Cut, confidence, gaps, and exact next actions without initializing runtime state."
+    },
+    {
+      "apiId": "kungfu.work.loop",
+      "name": "kungfu work capabilities --json",
+      "maturity": "experimental",
+      "purpose": "Discover the shared high-level Work and Cut operations, current availability, authority boundaries, and per-surface parity."
+    },
+    {
+      "apiId": "kungfu.work.inspect",
+      "name": "kungfu work inspect --repo <path> --json",
+      "maturity": "experimental",
+      "purpose": "Inspect the current Cut and open Work through one non-authoritative read model."
+    },
+    {
+      "apiId": "kungfu.work.recover",
+      "name": "kungfu work recover --repo <path> --json",
+      "maturity": "experimental",
+      "purpose": "Classify the exact next Work or Cut recovery action without changing state."
+    },
+    {
+      "apiId": "kungfu.work.complete",
+      "name": "kungfu work complete <work-id> --repo <path> --json",
+      "maturity": "experimental",
+      "purpose": "Prepare a completion candidate and disclose missing evidence without self-settling Work."
+    },
+    {
+      "apiId": "kungfu.work.settle",
+      "name": "kungfu work settle <work-id> --claim-root <root> --review-root <root> --decision-root <root> --project-cut-root <root> --json",
+      "maturity": "experimental",
+      "purpose": "Prepare a root-bound settlement plan while preserving independent review and explicit Project Cut publication authority."
+    },
+    {
       "apiId": "kungfu.work.create",
       "name": "kungfu work create <title> --json",
       "maturity": "stable",

--- a/framework/core/src/python/kungfu/agent/kfd3_api.registry.json
+++ b/framework/core/src/python/kungfu/agent/kfd3_api.registry.json
@@ -498,6 +498,66 @@
       "projections": ["commands.json", "agent-pack-doc"]
     },
     {
+      "id": "kungfu.cut.inspect",
+      "surface": "cli-api",
+      "name": "kungfu cut --repo <path> --json",
+      "purpose": "Inspect the current Project Cut, confidence, gaps, and exact next actions without initializing runtime state.",
+      "maturity": "experimental",
+      "visibility": "public-agent",
+      "anchor": { "kind": "catalog" },
+      "projections": ["commands.json", "agent-pack-doc", "provider-skill"]
+    },
+    {
+      "id": "kungfu.work.loop",
+      "surface": "cli-api",
+      "name": "kungfu work capabilities --json",
+      "purpose": "Discover the shared high-level Work and Cut operations, current availability, authority boundaries, and per-surface parity.",
+      "maturity": "experimental",
+      "visibility": "public-agent",
+      "anchor": { "kind": "catalog" },
+      "projections": ["commands.json", "agent-pack-doc", "provider-skill"]
+    },
+    {
+      "id": "kungfu.work.inspect",
+      "surface": "cli-api",
+      "name": "kungfu work inspect --repo <path> --json",
+      "purpose": "Inspect the current Cut and open Work through one non-authoritative read model.",
+      "maturity": "experimental",
+      "visibility": "public-agent",
+      "anchor": { "kind": "catalog" },
+      "projections": ["commands.json", "agent-pack-doc", "provider-skill"]
+    },
+    {
+      "id": "kungfu.work.recover",
+      "surface": "cli-api",
+      "name": "kungfu work recover --repo <path> --json",
+      "purpose": "Classify the exact next Work or Cut recovery action without changing state.",
+      "maturity": "experimental",
+      "visibility": "public-agent",
+      "anchor": { "kind": "catalog" },
+      "projections": ["commands.json", "agent-pack-doc", "provider-skill"]
+    },
+    {
+      "id": "kungfu.work.complete",
+      "surface": "cli-api",
+      "name": "kungfu work complete <work-id> --repo <path> --json",
+      "purpose": "Prepare a completion candidate and disclose missing evidence without self-settling Work.",
+      "maturity": "experimental",
+      "visibility": "public-agent",
+      "anchor": { "kind": "catalog" },
+      "projections": ["commands.json", "agent-pack-doc", "provider-skill"]
+    },
+    {
+      "id": "kungfu.work.settle",
+      "surface": "cli-api",
+      "name": "kungfu work settle <work-id> --claim-root <root> --review-root <root> --decision-root <root> --project-cut-root <root> --json",
+      "purpose": "Prepare a root-bound settlement plan while preserving independent review and explicit Project Cut publication authority.",
+      "maturity": "experimental",
+      "visibility": "public-agent",
+      "anchor": { "kind": "catalog" },
+      "projections": ["commands.json", "agent-pack-doc", "provider-skill"]
+    },
+    {
       "id": "kungfu.work.create",
       "surface": "cli",
       "name": "kungfu work create <title> --json",

--- a/framework/core/src/python/kungfu/agent/skills/claude/SKILL.md
+++ b/framework/core/src/python/kungfu/agent/skills/claude/SKILL.md
@@ -37,6 +37,8 @@ kungfu agent console current --json
 kungfu agent runtime list --json
 kungfu agent session capabilities --json
 kungfu agent session list --json
+kungfu cut --repo <path> --json
+kungfu work capabilities --json
 ```
 
 For source work, read `AGENTS.md` and `xinfa-context.md`, inspect
@@ -47,6 +49,11 @@ has only a read-only precompiled Atlas; verify it with
 `kungfu agent docs --verify --json`.
 
 Use the smallest mode that preserves evidence:
+
+- Start project-level work with `kungfu cut --repo <path> --json`, then read
+  `kungfu work capabilities --json`. Treat its `unavailable`, `degraded`, and
+  `plan-only` states as hard capability limits; the identical manifest is
+  available at `kungfu agent capabilities --json` under `workLoop`.
 
 - Read `kungfu agent work-model --json` before treating a goal as authority,
   context as complete reality, a plan as occurrence, or an Episode as

--- a/framework/core/src/python/kungfu/agent/skills/codex/SKILL.md
+++ b/framework/core/src/python/kungfu/agent/skills/codex/SKILL.md
@@ -37,6 +37,8 @@ kungfu agent console current --json
 kungfu agent runtime list --json
 kungfu agent session capabilities --json
 kungfu agent session list --json
+kungfu cut --repo <path> --json
+kungfu work capabilities --json
 ```
 
 For source work, read `AGENTS.md` and `xinfa-context.md`, inspect
@@ -47,6 +49,11 @@ has only a read-only precompiled Atlas; verify it with
 `kungfu agent docs --verify --json`.
 
 Use the smallest mode that preserves evidence:
+
+- Start project-level work with `kungfu cut --repo <path> --json`, then read
+  `kungfu work capabilities --json`. Treat its `unavailable`, `degraded`, and
+  `plan-only` states as hard capability limits; the identical manifest is
+  available at `kungfu agent capabilities --json` under `workLoop`.
 
 - Read `kungfu agent work-model --json` before treating a goal as authority,
   context as complete reality, a plan as occurrence, or an Episode as

--- a/framework/core/src/python/kungfu/cli/commands/agent.py
+++ b/framework/core/src/python/kungfu/cli/commands/agent.py
@@ -25,6 +25,7 @@ from kungfu.agent.kfd3 import (
 )
 from kungfu.cli.commands import kfc, PrioritizedCommandGroup
 from kungfu.config import resolve_config
+from kungfu.work_facade import work_loop_capabilities
 
 agent_command_context = kfc.pass_context()
 
@@ -281,6 +282,7 @@ def capabilities(ctx, as_json):
         },
         "actionGeometry": action_geometry,
         "workDomainProfile": work_domain_profile,
+        "workLoop": work_loop_capabilities(),
     }
     if as_json:
         _json(payload)

--- a/framework/core/src/python/kungfu/cli/commands/work.py
+++ b/framework/core/src/python/kungfu/cli/commands/work.py
@@ -22,6 +22,7 @@ from kungfu.work_facade import (
     plan_completion,
     plan_settlement,
     recover_work,
+    work_loop_capabilities,
 )
 
 work_command_context = kfc.pass_context()
@@ -71,6 +72,19 @@ def _echo(payload, as_json, text):
 
 def _inspection(ctx, repo):
     return inspect_work(inspect_project_cut(repo), _load(ctx))
+
+
+@work.command(help="discover the shared Work/Cut operations and surface parity")
+@click.option("--json", "as_json", is_flag=True, help="machine-readable output")
+@work_command_context
+def capabilities(ctx, as_json):
+    del ctx
+    payload = work_loop_capabilities()
+    _echo(
+        payload,
+        as_json,
+        "[work] loop capabilities: CLI and Agent available; GUI and TUI pending",
+    )
 
 
 @work.command(help="inspect the current Project Cut and Work through one read model")

--- a/framework/core/src/python/kungfu/cli/surface_contract.registry.json
+++ b/framework/core/src/python/kungfu/cli/surface_contract.registry.json
@@ -159,7 +159,7 @@
   "catalogProjection": {
     "artifact": "kungfu.agent/cli_surface.catalog.json",
     "authority": "runtime-fold",
-    "expectedSurfaceRoot": "sha256:8fc0cc6646448cb45633446c315804fb00bf1c97b71e574370db62a7dea703fb",
+    "expectedSurfaceRoot": "sha256:0fec5025a38f2cb789405dc73435c22b262affe2082959444372205cfa986660",
     "consumers": {
       "agentCapabilities": "embed-complete",
       "agentCommands": "strict-link",

--- a/framework/core/src/python/kungfu/work_facade.py
+++ b/framework/core/src/python/kungfu/work_facade.py
@@ -6,7 +6,117 @@ from typing import Any
 
 
 OPEN_STATES = {"active", "waiting", "blocked", "ready"}
-READ_ONLY_FACADE_ACTIONS = frozenset({"inspect", "recover", "complete", "settle"})
+READ_ONLY_FACADE_ACTIONS = frozenset(
+    {"capabilities", "inspect", "recover", "complete", "settle"}
+)
+
+
+def work_loop_capabilities() -> dict[str, Any]:
+    """Describe the shared Work/Cut loop without claiming missing authority."""
+
+    operations = [
+        {
+            "id": "inspect",
+            "availability": "available",
+            "command": "kungfu work inspect --repo <path> --json",
+            "resultSchema": "kungfu.work.inspect/v1",
+            "authority": "read-only-projection",
+        },
+        {
+            "id": "begin",
+            "availability": "unavailable",
+            "command": None,
+            "resultSchema": None,
+            "authority": "mission-control.assignment.create",
+            "reason": "native-assignment-orchestration-not-admitted",
+        },
+        {
+            "id": "checkpoint",
+            "availability": "degraded",
+            "command": "kungfu work checkpoint <work-id> <note>",
+            "resultSchema": None,
+            "authority": "kungfu-work-journal",
+            "reason": "legacy-work-receipt-not-yet-projected",
+        },
+        {
+            "id": "complete",
+            "availability": "plan-only",
+            "command": "kungfu work complete <work-id> --repo <path> --json",
+            "resultSchema": "kungfu.work.completion-candidate/v1",
+            "authority": "completion-candidate-planner",
+        },
+        {
+            "id": "settle",
+            "availability": "plan-only",
+            "command": "kungfu work settle <work-id> --claim-root <root> --review-root <root> --decision-root <root> --project-cut-root <root> --json",
+            "resultSchema": "kungfu.work.settlement-plan/v1",
+            "authority": "settlement-planner",
+        },
+        {
+            "id": "resume",
+            "availability": "degraded",
+            "command": "kungfu work resume <work-id> --json",
+            "resultSchema": None,
+            "authority": "kungfu-work-journal",
+            "reason": "assignment-and-cut-binding-not-yet-enforced",
+        },
+        {
+            "id": "recover",
+            "availability": "available",
+            "command": "kungfu work recover --repo <path> --json",
+            "resultSchema": "kungfu.work.recovery-plan/v1",
+            "authority": "read-only-projection",
+        },
+        {
+            "id": "export",
+            "availability": "unavailable",
+            "command": None,
+            "resultSchema": None,
+            "authority": "work-loop-portability",
+            "reason": "portable-work-loop-contract-not-admitted",
+        },
+        {
+            "id": "import",
+            "availability": "unavailable",
+            "command": None,
+            "resultSchema": None,
+            "authority": "work-loop-portability",
+            "reason": "portable-work-loop-contract-not-admitted",
+        },
+    ]
+    return {
+        "schema": "kungfu.work-loop-capabilities/v1",
+        "mentalModel": ["current Cut", "work in progress", "next Cut"],
+        "operations": operations,
+        "surfaces": {
+            "cli": {
+                "availability": "available",
+                "entrypoint": "kungfu work capabilities --json",
+            },
+            "agent": {
+                "availability": "available",
+                "entrypoint": "kungfu agent capabilities --json",
+                "projection": "workLoop",
+            },
+            "gui": {
+                "availability": "unavailable",
+                "reason": "shared-work-loop-adapter-not-implemented",
+            },
+            "tui": {
+                "availability": "unavailable",
+                "reason": "shared-work-loop-adapter-not-implemented",
+            },
+        },
+        "domainProfile": {
+            "availability": "unavailable",
+            "reason": "domain-profile-authoring-contract-not-admitted",
+        },
+        "authority": {
+            "projection": "non-authoritative",
+            "writesRequireDeclaredOperation": True,
+            "settlementRequiresIndependentReview": True,
+        },
+    }
 
 
 def inspect_work(

--- a/framework/core/tests/python/test_agent_work_state_contract.py
+++ b/framework/core/tests/python/test_agent_work_state_contract.py
@@ -43,6 +43,7 @@ kungfu._build_info = {"version": "test"}
 from kungfu import contract, durability  # noqa: E402
 from kungfu.agent import action_geometry, domain_profile, work_profile  # noqa: E402
 from kungfu.cli.commands import __registry__  # noqa: E402, F401
+from kungfu.work_facade import work_loop_capabilities  # noqa: E402
 from kungfu.cli.commands import kfc  # noqa: E402
 
 
@@ -184,11 +185,39 @@ def test_agent_capabilities_discovers_the_same_work_model(tmp_path, monkeypatch)
     assert payload["workDomainProfile"] == contract.contract_metadata(
         "agent-work-domain-profile"
     )
+    assert payload["workLoop"] == work_loop_capabilities()
     assert any(
         row["apiId"] == "kungfu.agent.work-model"
         and row["name"] == "kungfu agent work-model --json"
         for row in payload["commands"]["commands"]
     )
+    assert any(
+        row["apiId"] == "kungfu.work.loop"
+        and row["name"] == "kungfu work capabilities --json"
+        for row in payload["commands"]["commands"]
+    )
+
+
+def test_work_capabilities_are_read_only_and_match_agent_projection(
+    tmp_path, monkeypatch
+):
+    home = tmp_path / "home"
+    work_result = CliRunner().invoke(
+        kfc,
+        ["--home", str(home), "work", "capabilities", "--json"],
+    )
+    monkeypatch.setattr(durability, "capabilities", lambda: {"status": "test"})
+    agent_result = CliRunner().invoke(
+        kfc,
+        ["--home", str(home), "agent", "capabilities", "--json"],
+    )
+
+    assert work_result.exit_code == 0, work_result.output
+    assert agent_result.exit_code == 0, agent_result.output
+    manifest = work_loop_capabilities()
+    assert json.loads(work_result.output) == manifest
+    assert json.loads(agent_result.output)["workLoop"] == manifest
+    assert not home.exists()
 
 
 def test_agent_work_model_closes_the_kfd3_runtime_interface(tmp_path):

--- a/framework/core/tests/python/test_work_facade.py
+++ b/framework/core/tests/python/test_work_facade.py
@@ -7,6 +7,7 @@ from kungfu.work_facade import (
     plan_managed_run_link,
     plan_settlement,
     recover_work,
+    work_loop_capabilities,
 )
 
 
@@ -101,6 +102,36 @@ def test_settlement_requires_four_exact_roots_and_never_self_executes():
 
 
 def test_only_facade_plans_bypass_legacy_runtime_initialization():
-    assert READ_ONLY_FACADE_ACTIONS == {"inspect", "recover", "complete", "settle"}
+    assert READ_ONLY_FACADE_ACTIONS == {
+        "capabilities",
+        "inspect",
+        "recover",
+        "complete",
+        "settle",
+    }
     assert "create" not in READ_ONLY_FACADE_ACTIONS
     assert "checkpoint" not in READ_ONLY_FACADE_ACTIONS
+
+
+def test_work_loop_capabilities_are_complete_and_fail_visible():
+    payload = work_loop_capabilities()
+    operations = {row["id"]: row for row in payload["operations"]}
+    assert set(operations) == {
+        "inspect",
+        "begin",
+        "checkpoint",
+        "complete",
+        "settle",
+        "resume",
+        "recover",
+        "export",
+        "import",
+    }
+    assert operations["inspect"]["availability"] == "available"
+    assert operations["complete"]["availability"] == "plan-only"
+    assert operations["begin"]["availability"] == "unavailable"
+    assert operations["begin"]["command"] is None
+    assert payload["surfaces"]["cli"]["availability"] == "available"
+    assert payload["surfaces"]["agent"]["availability"] == "available"
+    assert payload["surfaces"]["gui"]["availability"] == "unavailable"
+    assert payload["surfaces"]["tui"]["availability"] == "unavailable"


### PR DESCRIPTION
## Summary

Expose one shared, machine-readable Work loop capability manifest through both CLI and Agent surfaces. The manifest covers the complete nine-operation loop and reports each operation as available, degraded, plan-only, or unavailable without upgrading convenience projections into authority.

GUI/TUI adapters, executable `begin`, portable import/export, and Domain Profile projection remain explicitly unavailable until their contracts are admitted.

## Related issue

Atlas goal `2026-07-22-kungfu-project-cut-product-loop`.

## Changes

- add side-effect-free `kungfu work capabilities --json`
- project the exact same manifest from `kungfu agent capabilities --json` as `workLoop`
- register the current Cut/Work public surfaces in KFD-3 and regenerate all governed projections
- document the current multisurface boundary and incomplete release obligations
- prove CLI/Agent equality and prove capability discovery does not initialize runtime state

## Verification

- `./shifu test:work-facade` — 3 Node tests and 15 Python tests passed
- `./shifu check:agent-work-state-contract` — 7 Node tests and 40 Python tests passed
- `./shifu check:agent-pack` — 15 files and 164 commands passed
- `./shifu check:cli-catalog-parity` — generated catalog and declared consumers current
- `./shifu check:source` — build-free source gate passed
- `./shifu check` — changed-scope gate passed
- commit staged gate — passed, including KFD evidence and documentation gates

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "stage-ready",
  "adrs": ["KF-ADR-019f87e8-6b8b-735c-b036-fa42d7cee8cf"],
  "summary": "Stage the shared CLI and Agent Work loop capability manifest with complete operation coverage and fail-visible multisurface limits.",
  "verification": ["Work facade contract tests", "Agent Work state contract", "CLI catalog parity", "source acceptance", "changed-scope gate"]
}
-->

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [x] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The provider-facing change is limited to local CLI and Agent capability discovery. KFD evidence is regenerated; no package is published or deployed.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated because behavior changed
