### PR TITLE
ci(dco): admit trusted GitHub merge envelopes

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -35,11 +35,27 @@ jobs:
 
           for commit in ${commits}; do
             subject="$(git log -1 --format=%s "${commit}")"
-            if ! git log -1 --format=%B "${commit}" | grep -Eiq '^Signed-off-by: .+ <[^<>[:space:]]+@[^<>[:space:]]+>$'; then
-              echo "::error title=Missing DCO sign-off::${commit} ${subject}"
-              echo "Add a sign-off with: git commit --amend --signoff"
-              missing=1
+            if git log -1 --format=%B "${commit}" | grep -Eiq '^Signed-off-by: .+ <[^<>[:space:]]+@[^<>[:space:]]+>$'; then
+              continue
             fi
+
+            # GitHub creates a two-parent merge commit after the reviewed
+            # content commits have already satisfied DCO. Admit only that
+            # exact platform-authored envelope; every parent/content commit is
+            # still inspected independently by this loop.
+            parents="$(git log -1 --format=%P "${commit}")"
+            parent_count="$(wc -w <<< "${parents}" | tr -d ' ')"
+            committer="$(git log -1 --format='%cn <%ce>' "${commit}")"
+            if [ "${parent_count}" -eq 2 ] && \
+              [ "${committer}" = "GitHub <noreply@github.com>" ] && \
+              grep -Eq '^Merge pull request #[0-9]+ from kungfu-systems/[A-Za-z0-9._/-]+$' <<< "${subject}"; then
+              echo "Trusted GitHub merge envelope: ${commit} ${subject}"
+              continue
+            fi
+
+            echo "::error title=Missing DCO sign-off::${commit} ${subject}"
+            echo "Add a sign-off with: git commit --amend --signoff"
+            missing=1
           done
 
           if [ "${missing}" -ne 0 ]; then

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -573,7 +573,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:1b69a8f3a5a9c87bcfb393e626514db0a02223b9e5baa6ac6f0f304c0a44159e",
+          "definitionDigest": "sha256:faa74aa5ddf066839c122073f42cdc0c6eceab5d7f421eecd213557b3d5d97bd",
           "credentials": {
             "githubToken": "read",
             "oidc": false,
@@ -595,7 +595,7 @@
               "index": 2,
               "label": "name:Check commit sign-offs",
               "authority": "qualification",
-              "definitionDigest": "sha256:6083c50b5f66371374b00892addfb43a13c06b9da7e95c7ead15747b508fd831"
+              "definitionDigest": "sha256:1f3b7930f2560c55246658876d90e21b189e9f047895aafc56a67da5bd8b699e"
             }
           ]
         }


### PR DESCRIPTION
## Summary

Admit only trusted GitHub-generated two-parent merge envelopes without weakening DCO for authored content commits.

## Changes

- keep `Signed-off-by` mandatory for every ordinary commit
- admit an unsigned merge only when it has exactly two parents, the exact GitHub committer identity, and the canonical same-repository PR merge subject
- continue inspecting every parent/content commit independently
- refresh the closed-world workflow authority digests

## Verification

- full alpha-to-dev replay: 1494 signed commits, 4 trusted GitHub merge envelopes, 0 missing
- `./shifu check:gate-catalog`
- `./shifu check:source`
- full pre-commit staged gate

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Tighten DCO handling for platform-authored merge envelopes without changing architecture contracts"
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change narrows the merge-envelope admission shape and does not grant publication authority or bypass content-commit DCO.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation authority projection refreshed
