### PR TITLE
fix(core): preserve standard KFD request boundary

### DIFF
--- a/.github/workflows/embedding-membrane-spike.yml
+++ b/.github/workflows/embedding-membrane-spike.yml
@@ -270,10 +270,10 @@ jobs:
             library_pattern="kungfu.dll"
           elif [ "$RUNNER_OS" = "macOS" ]; then
             adapter_name="kungfu-kfd-agent-runtime"
-            library_pattern="libkungfu.dylib"
+            library_pattern="libkungfu_runtime.dylib"
           else
             adapter_name="kungfu-kfd-agent-runtime"
-            library_pattern="libkungfu.so"
+            library_pattern="libkungfu_runtime.so"
           fi
           adapter="$(find "$SOURCE_ROOT/framework/core/build" -type f -name "$adapter_name" -print -quit)"
           library="$(find "$SOURCE_ROOT/framework/core/build" -type f -name "$library_pattern" -print -quit)"

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -744,7 +744,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:5eed8922f646e7b2f9f4f3208708c19d5f9be336b05fe982be6c5a3598483d1e",
+          "definitionDigest": "sha256:c351b7964598c94a365545941fffc08468cdeea87b8540f04bf70e2afe2c1b59",
           "credentials": {
             "githubToken": "read",
             "oidc": false,
@@ -846,7 +846,7 @@
               "index": 15,
               "label": "name:Stage exact KFD Agent Runtime artifact",
               "authority": "qualification",
-              "definitionDigest": "sha256:b60b3ad49a8962162073da3a5135f43fd89dd495b0f627df23005e2f7b806db8"
+              "definitionDigest": "sha256:84690e2b1f7edca30c9956fe80cbe348bbcc6a300d27508837ff40df6da729bd"
             },
             {
               "index": 16,

--- a/framework/core/src/kfd-agent-runtime/kfd-agent-runtime.manifest.json
+++ b/framework/core/src/kfd-agent-runtime/kfd-agent-runtime.manifest.json
@@ -34,8 +34,8 @@
   "languageProjection": {
     "semanticEvaluatorAuthority": "cxx-adapter-only",
     "node": "KFD runner drives the JSONL process boundary; Node does not reimplement evaluator semantics.",
-    "python": "Installed Python projects the same native storage authority for retained-evidence inspection; Python does not reimplement evaluator semantics.",
-    "difference": "KFD semantic evaluate is intentionally not duplicated as Node or Python APIs; parity is asserted at the public process response and native Episode identity surfaces."
+    "python": "Installed Python projects the native storage authority for explicitly bound retained-evidence inspection; Python does not reimplement evaluator semantics.",
+    "difference": "KFD semantic evaluate is intentionally not duplicated as Node or Python APIs. Standard KFD requests do not invent Kungfu ActionBinding roots; native Episode identity is asserted separately for explicitly bound probes."
   },
   "conformance": {
     "reportContract": "kfd.agent-runtime-report/v1",

--- a/framework/core/src/kfd-agent-runtime/main.cpp
+++ b/framework/core/src/kfd-agent-runtime/main.cpp
@@ -601,15 +601,25 @@ int main() {
         continue;
       }
       auto result = evaluate(envelope);
+      std::string storage_retention = "not-applicable";
       if (result.status == "accepted") {
-        std::string storage_code;
-        const auto kfd_operation = envelope.value("input", json::object()).value("operation", "");
-        const auto binding = envelope.value("input", json::object()).value("actionBinding", json::object());
-        if (!boundary.retain_accepted_transition(request_id, kfd_operation, binding, storage_code)) {
-          result = {"error", storage_code};
+        const auto input = envelope.value("input", json::object());
+        if (input.contains("actionBinding")) {
+          std::string storage_code;
+          const auto kfd_operation = input.value("operation", "");
+          if (!boundary.retain_accepted_transition(request_id, kfd_operation, input["actionBinding"], storage_code)) {
+            result = {"error", storage_code};
+          } else {
+            storage_retention = "retained";
+          }
+        } else {
+          storage_retention = "not-requested";
         }
       }
-      const auto observations = result.status == "accepted" ? boundary.observations() : json{{"failClosed", true}};
+      auto observations = result.status == "accepted" ? boundary.observations() : json{{"failClosed", true}};
+      if (result.status == "accepted") {
+        observations["storageRetention"] = storage_retention;
+      }
       std::cout << response(request_id, result, observations).dump() << '\n';
     } catch (const std::exception &) {
       std::cout << response(request_id, {"error", "adapter-request-invalid"}, {{"failClosed", true}}).dump() << '\n';

--- a/framework/core/tests/qualification/kfd-agent-runtime/README.md
+++ b/framework/core/tests/qualification/kfd-agent-runtime/README.md
@@ -9,8 +9,8 @@ period: 2026-07-20
 theme: kfd-agent-runtime-reference-qualification
 confidence: high
 evidence_grade: B
-last_reviewed: 2026-07-20
-ai_provenance: GPT-5 via Codex on 2026-07-20; records the executable qualification boundary and does not claim unobserved platforms or external adoption
+last_reviewed: 2026-07-22
+ai_provenance: GPT-5 via Codex on 2026-07-22; records the executable qualification boundary and does not claim unobserved platforms or external adoption
 ---
 
 # KFD Agent Runtime reference qualification
@@ -22,6 +22,13 @@ invokes the KFD-owned offline verifier, proves that a deliberately invalid
 always-accept adapter fails the named negative vectors, and performs a real
 process termination/reopen/fsck probe over disposable storage.
 
+KFD Runtime 100 owns the standard semantic request and does not provide a
+Kungfu `ActionBinding`. The adapter therefore evaluates those requests without
+inventing storage roots. Native Episode retention is a separate optional
+extension: when `actionBinding` is present it is validated fail-closed, and the
+qualification's two forced-restart probes prove retention and reopen behavior
+through that explicit boundary.
+
 The retained output contains the KFD report, verifier result, negative-fixture
 report, and a Kungfu qualification envelope. The envelope is not a KFD
 certificate: it keeps Core and Experimental partitions separate and binds the
@@ -30,5 +37,5 @@ claim to the observed platform and exact artifact/suite roots.
 The production adapter has one semantic implementation in C++. It starts only
 at `kungfu_get_api` from `kungfu/api.h` and negotiates standard responsibility
 tables. Node owns black-box process orchestration and Python independently
-inspects the Episodes retained by the same native storage authority; neither
+inspects the Episodes retained by the explicitly bound storage probes; neither
 language host reimplements the KFD state machine.

--- a/framework/core/tests/qualification/kfd-agent-runtime/run.mjs
+++ b/framework/core/tests/qualification/kfd-agent-runtime/run.mjs
@@ -175,7 +175,7 @@ function copyRuntimeArtifact(runtimeDist, scratch) {
     if (
       entry === adapterName ||
       entry === 'kfd-agent-runtime.manifest.json' ||
-      /^libkungfu\.(?:dylib|so(?:\..*)?)$/.test(entry) ||
+      /^libkungfu_runtime\.(?:dylib|so(?:\..*)?)$/.test(entry) ||
       /^kungfu\.dll$/i.test(entry) ||
       /^kungfu_(?:embedding|native_storage)\.dll$/i.test(entry)
     ) {
@@ -523,14 +523,11 @@ async function main() {
       path.resolve(options.runtimeDist),
       runtimeDir,
     );
-    const acceptedVectorCount = kfdReport.results.filter(
-      (result) => result.actual.status === 'accepted',
-    ).length;
     const retainedEpisodeCount = inspection.episodes.episodes.length;
     assert.equal(
       retainedEpisodeCount,
-      acceptedVectorCount + 2,
-      'accepted KFD transitions and forced-restart probes must have one retained Episode each',
+      2,
+      'the two explicitly bound forced-restart probes must each retain one Episode',
     );
     assert.equal(inspection.fsck.ok, true);
 
@@ -614,8 +611,10 @@ async function main() {
         disposableRuntime: true,
         processFault,
         retainedEpisodes: {
-          expected: acceptedVectorCount + 2,
+          expected: 2,
           observed: retainedEpisodeCount,
+          boundary:
+            'KFD Runtime 100 evaluates the standard semantic protocol without a Kungfu ActionBinding; only explicitly bound probes request native Episode retention.',
         },
         fsck: {
           ok: inspection.fsck.ok,
@@ -634,7 +633,7 @@ async function main() {
           retainedEpisodeCount,
         },
         difference:
-          'Node and Python intentionally do not expose duplicate KFD evaluators; they meet at the adapter response and the same public native Episode authority.',
+          'Node and Python intentionally do not expose duplicate KFD evaluators; KFD semantic responses are independent of the optional Kungfu ActionBinding extension, while Python inspects Episodes from explicitly bound storage probes.',
       },
       residualRisk: [
         ...kfdReport.residualRisk,

--- a/scripts/check-kfd-agent-runtime-boundary.mjs
+++ b/scripts/check-kfd-agent-runtime-boundary.mjs
@@ -16,8 +16,15 @@ const sourceDir = path.join(
 const mainPath = path.join(sourceDir, 'main.cpp');
 const cmakePath = path.join(sourceDir, 'CMakeLists.txt');
 const manifestPath = path.join(sourceDir, 'kfd-agent-runtime.manifest.json');
+const workflowPath = path.join(
+  root,
+  '.github',
+  'workflows',
+  'embedding-membrane-spike.yml',
+);
 const main = fs.readFileSync(mainPath, 'utf8');
 const cmake = fs.readFileSync(cmakePath, 'utf8');
+const workflow = fs.readFileSync(workflowPath, 'utf8');
 const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
 
 const kungfuIncludes = [...main.matchAll(/#include\s+[<"]([^>"]+)[>"]/g)]
@@ -47,6 +54,9 @@ assert.match(
   /target_link_libraries\(kungfu-kfd-agent-runtime PRIVATE\s+\$\{LIBKUNGFU_NAME\}\s+nlohmann_json::nlohmann_json\s*\)/,
 );
 assert.doesNotMatch(cmake, /src\/libkungfu\/src|PRIVATE\s+.*runtime\/storage/);
+assert.match(workflow, /library_pattern="libkungfu_runtime\.dylib"/);
+assert.match(workflow, /library_pattern="libkungfu_runtime\.so"/);
+assert.doesNotMatch(workflow, /library_pattern="libkungfu\.(?:dylib|so)"/);
 assert.equal(manifest.$schema, 'kungfu.kfd-agent-runtime.manifest/v1');
 assert.equal(manifest.runtimeBoundary.languageHosts, 0);
 assert.equal(manifest.runtimeBoundary.bootstrap, 'kungfu_get_api');

--- a/scripts/check-kfd-agent-runtime-boundary.mjs
+++ b/scripts/check-kfd-agent-runtime-boundary.mjs
@@ -57,6 +57,31 @@ assert.doesNotMatch(cmake, /src\/libkungfu\/src|PRIVATE\s+.*runtime\/storage/);
 assert.match(workflow, /library_pattern="libkungfu_runtime\.dylib"/);
 assert.match(workflow, /library_pattern="libkungfu_runtime\.so"/);
 assert.doesNotMatch(workflow, /library_pattern="libkungfu\.(?:dylib|so)"/);
+assert.match(main, /if \(input\.contains\("actionBinding"\)\)/);
+assert.match(main, /storage_retention = "not-requested"/);
+assert.doesNotMatch(
+  main,
+  /value\("actionBinding", json::object\(\)\)/,
+  'the standard KFD request must not be treated as if it supplied a Kungfu ActionBinding',
+);
+const qualificationHarness = fs.readFileSync(
+  path.join(
+    root,
+    'framework',
+    'core',
+    'tests',
+    'qualification',
+    'kfd-agent-runtime',
+    'run.mjs',
+  ),
+  'utf8',
+);
+assert.match(
+  qualificationHarness,
+  /\^libkungfu_runtime\\\.\(\?:dylib\|so/,
+  'the qualification artifact must carry the standard runtime library',
+);
+assert.doesNotMatch(qualificationHarness, /acceptedVectorCount \+ 2/);
 assert.equal(manifest.$schema, 'kungfu.kfd-agent-runtime.manifest/v1');
 assert.equal(manifest.runtimeBoundary.languageHosts, 0);
 assert.equal(manifest.runtimeBoundary.bootstrap, 'kungfu_get_api');

--- a/scripts/check-shifu-entry-contract.test.mjs
+++ b/scripts/check-shifu-entry-contract.test.mjs
@@ -142,6 +142,28 @@ test('source-fresh launchers pin nested Shifu entry to the resolved binary', () 
   assert.ok(windows.match(/set "SHIFU_BIN=%_KFC_DEVBIN%"/g)?.length >= 2);
 });
 
+test('cold source acquisition copies the binary from its isolated Cargo target', () => {
+  const posix = fs.readFileSync(path.join(ROOT, 'shifu'), 'utf8');
+  const windows = fs.readFileSync(path.join(ROOT, 'shifu.cmd'), 'utf8');
+  const posixAcquire = posix.match(
+    /kungfu_native_acquire\(\) \{[\s\S]*?^\}/mu,
+  )?.[0];
+  const windowsAcquire = windows.match(/:acquire[\s\S]*?:inscript/u)?.[0];
+  assert.ok(posixAcquire, 'POSIX cold-acquire block is missing');
+  assert.ok(windowsAcquire, 'Windows cold-acquire block is missing');
+  assert.match(
+    posixAcquire,
+    /CARGO_TARGET_DIR="\$_tgt" cargo build --release --locked/,
+  );
+  assert.match(posixAcquire, /_built="\$_tgt\/release\//);
+  assert.doesNotMatch(posixAcquire, /crates\/target\/release/);
+  assert.match(windowsAcquire, /_KFC_ACQUIRE_TGT=/);
+  assert.match(windowsAcquire, /set "CARGO_TARGET_DIR=!_KFC_ACQUIRE_TGT!"/);
+  assert.match(windowsAcquire, /cargo build --release --locked/);
+  assert.match(windowsAcquire, /!_KFC_ACQUIRE_TGT!\\release\\shifu\.exe/);
+  assert.doesNotMatch(windowsAcquire, /crates\\target\\release/);
+});
+
 test('runtime guard rejects a direct task and accepts Shifu provenance', () => {
   const guard = path.join(ROOT, 'scripts', 'require-shifu.mjs');
   const rejected = spawnSync(process.execPath, [guard, 'build:core'], {

--- a/shifu
+++ b/shifu
@@ -173,8 +173,9 @@ kungfu_native_acquire() {
   fi
   if command -v cargo >/dev/null 2>&1; then
     echo "shifu: building native launcher from source (cargo build --release)" >&2
-    if cargo build --release --manifest-path crates/Cargo.toml -p shifu >&2; then
-      _built="crates/target/release/$(kungfu_native_binname "$_plat")"
+    _tgt="${XDG_CACHE_HOME:-$HOME/.cache}/kungfu/shifu/cargo-target/acquire-$(printf %s "$PWD" | cksum | cut -d' ' -f1)"
+    if CARGO_TARGET_DIR="$_tgt" cargo build --release --locked --manifest-path crates/Cargo.toml -p shifu >&2; then
+      _built="$_tgt/release/$(kungfu_native_binname "$_plat")"
       cp "$_built" "$_dest" && chmod +x "$_dest" && return 0
     fi
   fi

--- a/shifu.cmd
+++ b/shifu.cmd
@@ -399,14 +399,29 @@ where curl >nul 2>nul && (
   )
   del "%_KFC_BIN%.tmp" >nul 2>nul
 )
+set "_KFC_ACQUIRE_KEY=%CD:\=_%"
+set "_KFC_ACQUIRE_KEY=%_KFC_ACQUIRE_KEY::=%"
+set "_KFC_ACQUIRE_PREV_CARGO_TARGET_DIR=%CARGO_TARGET_DIR%"
 where cargo >nul 2>nul && (
   echo shifu: building native launcher from source ^(cargo build --release^) 1>&2
-  cargo build --release --manifest-path crates\Cargo.toml -p shifu 1>&2 && (
+  set "_KFC_ACQUIRE_TGT=%_KFC_CACHE%\kungfu\shifu\cargo-target\acquire-%_KFC_ACQUIRE_KEY%"
+  set "CARGO_TARGET_DIR=!_KFC_ACQUIRE_TGT!"
+  cargo build --release --locked --manifest-path crates\Cargo.toml -p shifu 1>&2 && (
     if not exist "%_KFC_CACHE%\kungfu\shifu\%_KFC_VER%" mkdir "%_KFC_CACHE%\kungfu\shifu\%_KFC_VER%" >nul 2>nul
-    copy /y crates\target\release\shifu.exe "%_KFC_BIN%" >nul && (
+    copy /y "!_KFC_ACQUIRE_TGT!\release\shifu.exe" "%_KFC_BIN%" >nul && (
+      if defined _KFC_ACQUIRE_PREV_CARGO_TARGET_DIR (
+        set "CARGO_TARGET_DIR=!_KFC_ACQUIRE_PREV_CARGO_TARGET_DIR!"
+      ) else (
+        set "CARGO_TARGET_DIR="
+      )
       "%_KFC_BIN%" %*
       exit /b !errorlevel!
     )
+  )
+  if defined _KFC_ACQUIRE_PREV_CARGO_TARGET_DIR (
+    set "CARGO_TARGET_DIR=!_KFC_ACQUIRE_PREV_CARGO_TARGET_DIR!"
+  ) else (
+    set "CARGO_TARGET_DIR="
   )
 )
 echo shifu: native launcher unavailable; falling back to the in-script bootstrap 1>&2


### PR DESCRIPTION
## Summary

Restore exact KFD Runtime 100 compatibility and reliable promotion lifecycle execution while preserving the standard libkungfu ActionBinding authority.

## Changes

- stage the actual libkungfu_runtime shared library beside the KFD adapter on macOS and Linux
- treat ActionBinding as an explicit Kungfu storage extension instead of a required KFD v1 field
- retain and validate Episodes only for explicitly bound probes; never invent roots for standard KFD requests
- align the frozen-artifact qualification harness and static boundary gate
- make Shifu cold source bootstrap build and copy from one isolated Cargo target on POSIX and Windows

## Verification

- ./shifu check:kfd-agent-runtime-boundary
- ./shifu check:gate-catalog
- ./shifu check:entry-contract
- Shifu entry contract tests: 14/14
- full pre-commit source, documentation, KFD boundary, invariant, and formatting gates

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Fix packaging, protocol compatibility, and cold-bootstrap execution regressions without changing the KFD or libkungfu architecture contracts"
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change repairs the exact qualification artifact and lifecycle execution, while keeping storage retention fail-closed when the optional binding is explicitly requested.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation authority projection refreshed