### PR TITLE
fix(shifu): forward cold Windows launcher arguments

### DIFF
--- a/.github/workflows/shifu-ci.yml
+++ b/.github/workflows/shifu-ci.yml
@@ -20,8 +20,13 @@ on:
       - "scripts/qualify-xinfa-context-quality.mjs"
       - "scripts/shifu-documentation-*.mjs"
       - "scripts/check-shifu-workspace.mjs"
+      - "scripts/check-shifu-entry-contract.test.mjs"
+      - "scripts/run-shifu-lifecycle.mjs"
+      - "scripts/run-shifu-lifecycle.test.mjs"
       - "scripts/shifu-gate-*.mjs"
       - "package.json"
+      - "shifu"
+      - "shifu.cmd"
       - "shifu.gates.json"
       - ".github/workflows/shifu-ci.yml"
 
@@ -49,6 +54,11 @@ jobs:
       - name: Run Shifu workspace Gate (Windows)
         if: runner.os == 'Windows'
         run: .\shifu.cmd gate run shifu.workspace --capability rust
+      - name: Verify Windows lifecycle dispatch
+        if: runner.os == 'Windows'
+        run: |
+          # shifu-entry-contract: allow lifecycle contract tests to use Shifu's pinned Node
+          .\shifu.cmd --filter @kungfu-tech/workspaces exec node --test scripts/check-shifu-entry-contract.test.mjs scripts/run-shifu-lifecycle.test.mjs
       - name: Verify Xinfa producer contracts (POSIX)
         if: runner.os != 'Windows'
         run: ./shifu xinfa:check

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -1595,14 +1595,14 @@
     {
       "path": ".github/workflows/shifu-ci.yml",
       "authority": "qualification",
-      "definitionDigest": "sha256:e2d9f7801567278f22b292f72c7d7b39d367ff67e7d4d2a7ec6988c43ed96c8c",
+      "definitionDigest": "sha256:a424cb09f33e4c86530ee2b1d2ac1db9e56dcba2998653e42e118d711e228945",
       "jobs": [
         {
           "id": "check",
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:f618105235ca8b4a7c8e9329c3c98436a818bf559de32025e718e1432dcafac8",
+          "definitionDigest": "sha256:d741c088da9db4504cf6f641fc1cb7b459c25a62acbe94d8ec1806073c12bd5c",
           "credentials": {
             "githubToken": "read",
             "oidc": false,
@@ -1641,24 +1641,30 @@
             },
             {
               "index": 5,
+              "label": "name:Verify Windows lifecycle dispatch",
+              "authority": "qualification",
+              "definitionDigest": "sha256:c16232fe9c775062e94c7bc2f50167914d9d4f87b7bbcc7a525dc005cea4ede1"
+            },
+            {
+              "index": 6,
               "label": "name:Verify Xinfa producer contracts (POSIX)",
               "authority": "qualification",
               "definitionDigest": "sha256:15752c37fb68edba03d505347c7aae2e2817db34c555691efefbee3eb4bb4546"
             },
             {
-              "index": 6,
+              "index": 7,
               "label": "name:Verify Xinfa producer contracts (Windows)",
               "authority": "qualification",
               "definitionDigest": "sha256:cf18195970fdb8eb168be74c0c3affcd71b0951a12e6b901f3573e1e9cd2b566"
             },
             {
-              "index": 7,
+              "index": 8,
               "label": "name:Qualify repository context quality (POSIX)",
               "authority": "qualification",
               "definitionDigest": "sha256:c374ee36eff61fa55741ed99fdb994ff3dc78fdee52c0bdd9b3f7a3500718507"
             },
             {
-              "index": 8,
+              "index": 9,
               "label": "name:Qualify repository context quality (Windows)",
               "authority": "qualification",
               "definitionDigest": "sha256:80f3c187a20ae685904dea5732bf0bce3f43779e40eb59d4d7a19855df31bb58"

--- a/docs/qualification/gates/workflow-authority.md
+++ b/docs/qualification/gates/workflow-authority.md
@@ -68,7 +68,7 @@ without changing and refreshing the manifest fails the Gate catalog check.
 | `.github/workflows/release-new-version.yml` | `shifu-launcher-tag` | release-control | channel | none | token:read, repo-secret:KUNGFU_GITHUB_TOKEN | none | 2 |
 | `.github/workflows/release-shifu.yml` | `build` | qualification | none | diagnostic | token:read | none | 8 |
 | `.github/workflows/release-shifu.yml` | `release` | product-publication | product | none | token:write, repo-secret:GITHUB_TOKEN | none | 3 |
-| `.github/workflows/shifu-ci.yml` | `check` | qualification | none | diagnostic | token:read | none | 8 |
+| `.github/workflows/shifu-ci.yml` | `check` | qualification | none | diagnostic | token:read | none | 9 |
 | `.github/workflows/source-acceptance.yml` | `source-acceptance` | qualification | none | qualifying | token:read | none | 0 |
 <!-- END GENERATED WORKFLOW AUTHORITY MATRIX -->
 

--- a/scripts/check-shifu-entry-contract.test.mjs
+++ b/scripts/check-shifu-entry-contract.test.mjs
@@ -164,6 +164,22 @@ test('cold source acquisition copies the binary from its isolated Cargo target',
   assert.doesNotMatch(windowsAcquire, /crates\\target\\release/);
 });
 
+test('Windows freshly resolved launchers dispatch outside parsed build blocks', () => {
+  const windows = fs.readFileSync(path.join(ROOT, 'shifu.cmd'), 'utf8');
+  assert.match(
+    windows,
+    /set "_KFC_RESOLVED_BIN=%_KFC_DEVBIN%"\s+goto runresolved/u,
+  );
+  assert.ok(
+    windows.match(/set "_KFC_RESOLVED_BIN=%_KFC_BIN%"\s+goto runresolved/gu)
+      ?.length >= 2,
+  );
+  assert.match(
+    windows,
+    /:runresolved\s+rem[\s\S]*?"%_KFC_RESOLVED_BIN%" %\*\s+exit \/b !errorlevel!/u,
+  );
+});
+
 test('runtime guard rejects a direct task and accepts Shifu provenance', () => {
   const guard = path.join(ROOT, 'scripts', 'require-shifu.mjs');
   const rejected = spawnSync(process.execPath, [guard, 'build:core'], {

--- a/scripts/run-shifu-lifecycle.test.mjs
+++ b/scripts/run-shifu-lifecycle.test.mjs
@@ -2,6 +2,9 @@
 
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import { test } from 'node:test';
 import { fileURLToPath } from 'node:url';
 
@@ -157,11 +160,42 @@ test(
     );
     const result = spawnSync(
       process.execPath,
-      [lifecycle, 'direct', 'cache', 'schema', 'profile'],
+      [lifecycle, 'direct', '--version'],
       {
         cwd: process.cwd(),
         encoding: 'utf8',
         env: process.env,
+        windowsHide: true,
+      },
+    );
+    assert.equal(result.status, 0, result.stderr || result.error?.message);
+    assert.match(result.stdout, /^shifu \S+ \(git [^)]+\)$/mu);
+  },
+);
+
+test(
+  'Windows cold source launcher forwards the original lifecycle arguments',
+  { skip: process.platform !== 'win32' },
+  (t) => {
+    const cache = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'shifu-cold-dispatch-'),
+    );
+    t.after(() => fs.rmSync(cache, { recursive: true, force: true }));
+    const lifecycle = fileURLToPath(
+      new URL('./run-shifu-lifecycle.mjs', import.meta.url),
+    );
+    const result = spawnSync(
+      process.execPath,
+      [lifecycle, 'direct', 'cache', 'schema', 'profile'],
+      {
+        cwd: process.cwd(),
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          XDG_CACHE_HOME: cache,
+          SHIFU_BIN: '',
+          SHIFU_NATIVE: '1',
+        },
         windowsHide: true,
       },
     );

--- a/shifu.cmd
+++ b/shifu.cmd
@@ -364,8 +364,8 @@ if "!_KFC_BUILD_ERROR!"=="0" (
     rem Source slots are catalog entries. The native catalog retires only
     rem proven ancestors after a successful promotion.
     set "SHIFU_BIN=%_KFC_DEVBIN%"
-    "%_KFC_DEVBIN%" %*
-    exit /b !errorlevel!
+    set "_KFC_RESOLVED_BIN=%_KFC_DEVBIN%"
+    goto runresolved
   )
 )
 set "CARGO_TARGET_DIR="
@@ -394,8 +394,8 @@ where curl >nul 2>nul && (
   if not exist "%_KFC_CACHE%\kungfu\shifu\%_KFC_VER%" mkdir "%_KFC_CACHE%\kungfu\shifu\%_KFC_VER%" >nul 2>nul
   curl -fsSL --retry 2 --connect-timeout 20 -o "%_KFC_BIN%.tmp" "%_KFC_URL%" && (
     move /y "%_KFC_BIN%.tmp" "%_KFC_BIN%" >nul
-    "%_KFC_BIN%" %*
-    exit /b !errorlevel!
+    set "_KFC_RESOLVED_BIN=%_KFC_BIN%"
+    goto runresolved
   )
   del "%_KFC_BIN%.tmp" >nul 2>nul
 )
@@ -414,8 +414,8 @@ where cargo >nul 2>nul && (
       ) else (
         set "CARGO_TARGET_DIR="
       )
-      "%_KFC_BIN%" %*
-      exit /b !errorlevel!
+      set "_KFC_RESOLVED_BIN=%_KFC_BIN%"
+      goto runresolved
     )
   )
   if defined _KFC_ACQUIRE_PREV_CARGO_TARGET_DIR (
@@ -425,6 +425,14 @@ where cargo >nul 2>nul && (
   )
 )
 echo shifu: native launcher unavailable; falling back to the in-script bootstrap 1>&2
+goto inscript
+
+:runresolved
+rem Dispatch outside the parenthesized build/acquire blocks. cmd.exe expands
+rem percent arguments while parsing a block; keeping the final invocation at a
+rem top-level label preserves the original multi-argument lifecycle payload.
+"%_KFC_RESOLVED_BIN%" %*
+exit /b !errorlevel!
 
 :inscript
 rem In-script fallback versions of the launcher-owned flags (the native


### PR DESCRIPTION
## Summary

Preserve the original Windows lifecycle argument vector after a freshly built or acquired Shifu launcher is resolved, and make the cold dispatch path a required Windows CI proof.

## Diagnosis

Alpha Build run 29926184191 built the Windows launcher successfully, then every lifecycle task returned 0 without executing; release qualification retained only its summary and failed the eight-artifact minimum. The prior live test covered the direct `cache` bypass, while `shifu CI` did not activate for `shifu.cmd` or execute lifecycle tests on Windows.

## Changes

- dispatch freshly resolved Windows launchers from a top-level batch label instead of inside parsed build/acquire blocks
- add a static contract for both source-build and acquisition routes
- add a Windows-only live cold-cache test that builds the launcher and proves `--version` survives the handoff
- activate `shifu CI` for Shifu entry/lifecycle changes and run the lifecycle/entry suite on Windows
- refresh the checked-in workflow authority projection

## Verification

- `./shifu check:entry-contract`
- `./shifu --filter @kungfu-tech/workspaces exec node --test scripts/run-shifu-lifecycle.test.mjs`
- `node --test scripts/check-shifu-entry-contract.test.mjs scripts/run-shifu-lifecycle.test.mjs` (25 pass, 2 Windows-only skip on macOS)
- workflow authority refresh and staged repository gates (pass)

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Repair a Windows batch argument-forwarding defect and its CI coverage gap without changing any ADR projection."
}
-->