### PR TITLE
feat(work): make Project Cut-bound Work portable

### DIFF
--- a/.buildchain/kfd/kfd-2/claims/agent-onboarding-pack.json
+++ b/.buildchain/kfd/kfd-2/claims/agent-onboarding-pack.json
@@ -16,7 +16,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "62687c870e8f06bc925450db9107bd3360ee91fef4783b5167b9904c79662582"
+        "sha256": "e6685cd957be33d0667e5c4487368bfd616efad9079111c1c7646cd1e9227a50"
       },
       "description": "Machine-readable command catalog and mode maturity metadata."
     },
@@ -25,7 +25,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/cli_surface.catalog.json",
-        "sha256": "9f6f7b50a106f192f045425ec13cbc46947c7e66d3cc7c89ca40bf4b0223817c"
+        "sha256": "ef2bde08154ec637b3eb2f1a91ac5c54ce568a25be0003616b73ae6855df141d"
       },
       "description": "Complete deterministic CLI surface graph shared by offline Agent capabilities and catalog parity checks."
     },
@@ -72,11 +72,11 @@
     "evidenceSha256": [
       {
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "62687c870e8f06bc925450db9107bd3360ee91fef4783b5167b9904c79662582"
+        "sha256": "e6685cd957be33d0667e5c4487368bfd616efad9079111c1c7646cd1e9227a50"
       },
       {
         "path": "framework/core/src/python/kungfu/agent/cli_surface.catalog.json",
-        "sha256": "9f6f7b50a106f192f045425ec13cbc46947c7e66d3cc7c89ca40bf4b0223817c"
+        "sha256": "ef2bde08154ec637b3eb2f1a91ac5c54ce568a25be0003616b73ae6855df141d"
       },
       {
         "path": "framework/core/src/python/kungfu/agent/mode-selection.md",
@@ -102,11 +102,11 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "62687c870e8f06bc925450db9107bd3360ee91fef4783b5167b9904c79662582"
+        "sha256": "e6685cd957be33d0667e5c4487368bfd616efad9079111c1c7646cd1e9227a50"
       },
       {
         "path": "framework/core/src/python/kungfu/agent/cli_surface.catalog.json",
-        "sha256": "9f6f7b50a106f192f045425ec13cbc46947c7e66d3cc7c89ca40bf4b0223817c"
+        "sha256": "ef2bde08154ec637b3eb2f1a91ac5c54ce568a25be0003616b73ae6855df141d"
       }
     ]
   },
@@ -120,13 +120,13 @@
     {
       "name": "agent-command-catalog",
       "path": "framework/core/src/python/kungfu/agent/commands.json",
-      "sha256": "62687c870e8f06bc925450db9107bd3360ee91fef4783b5167b9904c79662582",
+      "sha256": "e6685cd957be33d0667e5c4487368bfd616efad9079111c1c7646cd1e9227a50",
       "expectedPackagePath": "kungfu/agent/commands.json"
     },
     {
       "name": "cli-surface-catalog",
       "path": "framework/core/src/python/kungfu/agent/cli_surface.catalog.json",
-      "sha256": "9f6f7b50a106f192f045425ec13cbc46947c7e66d3cc7c89ca40bf4b0223817c",
+      "sha256": "ef2bde08154ec637b3eb2f1a91ac5c54ce568a25be0003616b73ae6855df141d",
       "expectedPackagePath": "kungfu/agent/cli_surface.catalog.json"
     }
   ],

--- a/.buildchain/kfd/kfd-2/claims/agent-work-state-contract.json
+++ b/.buildchain/kfd/kfd-2/claims/agent-work-state-contract.json
@@ -43,7 +43,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/tests/python/test_agent_work_state_contract.py",
-        "sha256": "a19cdc151a1247af5f25388ac69a20ee8d945872e9a4232ce1e85ff339a62049"
+        "sha256": "8466506d23519ac721029fdcb2db1febd7125fb07e4b77407e4b1df32336bf89"
       },
       "description": "Runtime CLI parity and fail-closed contract-schema checks."
     },
@@ -52,7 +52,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
-        "sha256": "735bf52451494a2f1d7017eedc74e5817bbeb435ee6bfe306a77b385954b27bd"
+        "sha256": "c5b66e332b6f9144e288851d4d5d434e9353680af5ae3bf3ed171758f88e00d8"
       },
       "description": "Agent collaboration-interface registration for the work-model query."
     }
@@ -75,11 +75,11 @@
       },
       {
         "path": "framework/core/tests/python/test_agent_work_state_contract.py",
-        "sha256": "a19cdc151a1247af5f25388ac69a20ee8d945872e9a4232ce1e85ff339a62049"
+        "sha256": "8466506d23519ac721029fdcb2db1febd7125fb07e4b77407e4b1df32336bf89"
       },
       {
         "path": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
-        "sha256": "735bf52451494a2f1d7017eedc74e5817bbeb435ee6bfe306a77b385954b27bd"
+        "sha256": "c5b66e332b6f9144e288851d4d5d434e9353680af5ae3bf3ed171758f88e00d8"
       }
     ],
     "artifactSha256": [

--- a/.buildchain/kfd/kfd-2/claims/codex-report-receipts.json
+++ b/.buildchain/kfd/kfd-2/claims/codex-report-receipts.json
@@ -52,7 +52,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/skills/codex/SKILL.md",
-        "sha256": "79605a827bd7e8746479a0b486642cbb2a63d1390870003e14bcbeeb0c196046"
+        "sha256": "f751670f2949a85be6d67031737c63d41a086ecc4244676145d397ada20fe280"
       },
       "description": "Codex-side report closeout gate instructions shipped in the agent pack."
     }
@@ -79,7 +79,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/skills/codex/SKILL.md",
-        "sha256": "79605a827bd7e8746479a0b486642cbb2a63d1390870003e14bcbeeb0c196046"
+        "sha256": "f751670f2949a85be6d67031737c63d41a086ecc4244676145d397ada20fe280"
       }
     ],
     "artifactSha256": [
@@ -89,7 +89,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/skills/codex/SKILL.md",
-        "sha256": "79605a827bd7e8746479a0b486642cbb2a63d1390870003e14bcbeeb0c196046"
+        "sha256": "f751670f2949a85be6d67031737c63d41a086ecc4244676145d397ada20fe280"
       }
     ]
   },
@@ -103,7 +103,7 @@
     {
       "name": "codex-agent-skill",
       "path": "framework/core/src/python/kungfu/agent/skills/codex/SKILL.md",
-      "sha256": "79605a827bd7e8746479a0b486642cbb2a63d1390870003e14bcbeeb0c196046",
+      "sha256": "f751670f2949a85be6d67031737c63d41a086ecc4244676145d397ada20fe280",
       "expectedPackagePath": "kungfu/agent/skills/codex/SKILL.md"
     }
   ],

--- a/.buildchain/kfd/kfd-2/claims/remote-fact-boundary.json
+++ b/.buildchain/kfd/kfd-2/claims/remote-fact-boundary.json
@@ -34,7 +34,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "62687c870e8f06bc925450db9107bd3360ee91fef4783b5167b9904c79662582"
+        "sha256": "e6685cd957be33d0667e5c4487368bfd616efad9079111c1c7646cd1e9227a50"
       },
       "description": "Remote add/sync command declarations and mode metadata."
     },
@@ -62,7 +62,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "62687c870e8f06bc925450db9107bd3360ee91fef4783b5167b9904c79662582"
+        "sha256": "e6685cd957be33d0667e5c4487368bfd616efad9079111c1c7646cd1e9227a50"
       },
       {
         "path": "framework/core/src/python/kungfu/cli/commands/agent.py",

--- a/.buildchain/kfd/kfd-2/release-claims.json
+++ b/.buildchain/kfd/kfd-2/release-claims.json
@@ -29,7 +29,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/commands.json",
-            "sha256": "62687c870e8f06bc925450db9107bd3360ee91fef4783b5167b9904c79662582"
+            "sha256": "e6685cd957be33d0667e5c4487368bfd616efad9079111c1c7646cd1e9227a50"
           },
           "description": "Machine-readable command catalog and mode maturity metadata."
         },
@@ -38,7 +38,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/cli_surface.catalog.json",
-            "sha256": "9f6f7b50a106f192f045425ec13cbc46947c7e66d3cc7c89ca40bf4b0223817c"
+            "sha256": "ef2bde08154ec637b3eb2f1a91ac5c54ce568a25be0003616b73ae6855df141d"
           },
           "description": "Complete deterministic CLI surface graph shared by offline Agent capabilities and catalog parity checks."
         },
@@ -152,7 +152,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/skills/codex/SKILL.md",
-            "sha256": "79605a827bd7e8746479a0b486642cbb2a63d1390870003e14bcbeeb0c196046"
+            "sha256": "f751670f2949a85be6d67031737c63d41a086ecc4244676145d397ada20fe280"
           },
           "description": "Codex-side report closeout gate instructions shipped in the agent pack."
         }
@@ -212,7 +212,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/commands.json",
-            "sha256": "62687c870e8f06bc925450db9107bd3360ee91fef4783b5167b9904c79662582"
+            "sha256": "e6685cd957be33d0667e5c4487368bfd616efad9079111c1c7646cd1e9227a50"
           },
           "description": "Remote add/sync command declarations and mode metadata."
         },
@@ -292,7 +292,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/tests/python/test_agent_work_state_contract.py",
-            "sha256": "a19cdc151a1247af5f25388ac69a20ee8d945872e9a4232ce1e85ff339a62049"
+            "sha256": "8466506d23519ac721029fdcb2db1febd7125fb07e4b77407e4b1df32336bf89"
           },
           "description": "Runtime CLI parity and fail-closed contract-schema checks."
         },
@@ -301,7 +301,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
-            "sha256": "735bf52451494a2f1d7017eedc74e5817bbeb435ee6bfe306a77b385954b27bd"
+            "sha256": "c5b66e332b6f9144e288851d4d5d434e9353680af5ae3bf3ed171758f88e00d8"
           },
           "description": "Agent collaboration-interface registration for the work-model query."
         }

--- a/.buildchain/kfd/kfd-3/capability-query.json
+++ b/.buildchain/kfd/kfd-3/capability-query.json
@@ -2805,6 +2805,50 @@
       "residualRisk": []
     },
     {
+      "id": "kungfu.work.export",
+      "kind": "cli-api",
+      "name": "kungfu work export <work-id> --repo <path> --json",
+      "state": "declared",
+      "detected": true,
+      "enforced": false,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "kfd1Basis": {
+        "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+        "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+        "digest": "sha256:0b920bb82646d63295e1aed951c668d1af4a467ec6217690dda56a9da5297552"
+      },
+      "kfd2Trust": {
+        "status": "release-passport-required",
+        "trustImpact": "query-release-passport-for-final-trust",
+        "residualRisk": []
+      },
+      "residualRisk": []
+    },
+    {
+      "id": "kungfu.work.import",
+      "kind": "cli-api",
+      "name": "kungfu work import --file <envelope.json> --repo <path> [--execute] --json",
+      "state": "declared",
+      "detected": true,
+      "enforced": false,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "kfd1Basis": {
+        "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+        "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+        "digest": "sha256:485bf664aba64b7970b444694d66299f9f6e8343652bf48003a950184e8c4a23"
+      },
+      "kfd2Trust": {
+        "status": "release-passport-required",
+        "trustImpact": "query-release-passport-for-final-trust",
+        "residualRisk": []
+      },
+      "residualRisk": []
+    },
+    {
       "id": "kungfu.work.inspect",
       "kind": "cli-api",
       "name": "kungfu work inspect --repo <path> --json",

--- a/.buildchain/kfd/kfd-3/collaboration-interface.artifact.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.artifact.json
@@ -10,8 +10,8 @@
   "sourceRegistry": {
     "id": "kungfu",
     "path": ".buildchain/kfd/kfd-3/surfaces.json",
-    "sha256": "79fa3f2b9acb94eaf0aee8660388b82391ca5e65125a556d3158362a2b071add",
-    "digest": "sha256:8cd991e8d58a38c77eeec1c3e23e69b6b00688d1d8e94baab56790b0f1726f39"
+    "sha256": "1a828bade038ec2d3c6f2ff5325ef15516b85ceaff71b5dcd5533e8f102d35f2",
+    "digest": "sha256:db8f9095bb2ae7745dae30f015c8f7dcbe2ace6e4d5f200911e2167e20fd7c1e"
   },
   "upstreamKfd": {
     "aggregatePath": "developer/sdk/kfd/upstream-aggregate.json",
@@ -28,7 +28,7 @@
     },
     "digest": "sha256:38df18c7f118f322bfebdf1ba70628dd6c8ac39512fb1708e10dc6d3c37fadbe"
   },
-  "collaborationInterfaceDigest": "sha256:f123976a032f85fbc079316a68e9027219d9db8541dc4e9e53fbe537051e6cc8",
+  "collaborationInterfaceDigest": "sha256:33611623314696ac468412d8e556b62c1d6e44af95ac225605548ce9cda25ceb",
   "exposedSurfaces": [
     {
       "id": "kungfu.agent",
@@ -2589,6 +2589,46 @@
       "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
       "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
       "maturity": "stable",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
+      "id": "kungfu.work.export",
+      "name": "kungfu work export <work-id> --repo <path> --json",
+      "kind": "cli-api",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
+      "id": "kungfu.work.import",
+      "name": "kungfu work import --file <envelope.json> --repo <path> [--execute] --json",
+      "kind": "cli-api",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
       "declaration": {
         "owner": "kungfu",
         "source": "scripts/buildchain-kfd-evidence.mjs",

--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -6,15 +6,15 @@
   "supportLevel": "release",
   "source": {
     "cwd": ".",
-    "sourceSha": "da4e284f2c23242008eb222b2b2277cc80c96166",
+    "sourceSha": "57148cf4ffc42b54e871d6f04fe6b43621cd2c18",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
-    "registryDigest": "sha256:8cd991e8d58a38c77eeec1c3e23e69b6b00688d1d8e94baab56790b0f1726f39"
+    "registryDigest": "sha256:db8f9095bb2ae7745dae30f015c8f7dcbe2ace6e4d5f200911e2167e20fd7c1e"
   },
   "sourceRegistry": {
     "id": "kungfu",
     "path": ".buildchain/kfd/kfd-3/surfaces.json",
-    "sha256": "79fa3f2b9acb94eaf0aee8660388b82391ca5e65125a556d3158362a2b071add",
-    "digest": "sha256:8cd991e8d58a38c77eeec1c3e23e69b6b00688d1d8e94baab56790b0f1726f39"
+    "sha256": "1a828bade038ec2d3c6f2ff5325ef15516b85ceaff71b5dcd5533e8f102d35f2",
+    "digest": "sha256:db8f9095bb2ae7745dae30f015c8f7dcbe2ace6e4d5f200911e2167e20fd7c1e"
   },
   "upstreamKfd": {
     "aggregatePath": "developer/sdk/kfd/upstream-aggregate.json",
@@ -34,7 +34,7 @@
   "expectedArtifactVerification": {
     "command": "node scripts/buildchain-kfd-evidence.mjs --artifact-witness --json"
   },
-  "collaborationInterfaceDigest": "sha256:f123976a032f85fbc079316a68e9027219d9db8541dc4e9e53fbe537051e6cc8",
+  "collaborationInterfaceDigest": "sha256:33611623314696ac468412d8e556b62c1d6e44af95ac225605548ce9cda25ceb",
   "collaborationInterface": {
     "schemaVersion": 1,
     "contract": "kungfu-buildchain-kfd-3-surface-registry",
@@ -2626,6 +2626,46 @@
         }
       },
       {
+        "id": "kungfu.work.export",
+        "name": "kungfu work export <work-id> --repo <path> --json",
+        "kind": "cli-api",
+        "participantProfile": "agent-or-developer",
+        "state": "declared",
+        "availability": "shipped",
+        "visibility": "public",
+        "participantFacing": true,
+        "public": true,
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+        "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+        "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+        "maturity": "experimental",
+        "declaration": {
+          "owner": "kungfu",
+          "source": "scripts/buildchain-kfd-evidence.mjs",
+          "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+        }
+      },
+      {
+        "id": "kungfu.work.import",
+        "name": "kungfu work import --file <envelope.json> --repo <path> [--execute] --json",
+        "kind": "cli-api",
+        "participantProfile": "agent-or-developer",
+        "state": "declared",
+        "availability": "shipped",
+        "visibility": "public",
+        "participantFacing": true,
+        "public": true,
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+        "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+        "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+        "maturity": "experimental",
+        "declaration": {
+          "owner": "kungfu",
+          "source": "scripts/buildchain-kfd-evidence.mjs",
+          "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+        }
+      },
+      {
         "id": "kungfu.work.inspect",
         "name": "kungfu work inspect --repo <path> --json",
         "kind": "cli-api",
@@ -2928,8 +2968,8 @@
     ],
     "audit": {
       "status": "passed",
-      "declared": 142,
-      "artifactPublic": 142,
+      "declared": 144,
+      "artifactPublic": 144,
       "policy": {
         "sourceOfTruth": ".buildchain/kfd/kfd-3/surfaces.json",
         "detectedButUnregistered": "product-specific-audit",
@@ -5500,6 +5540,46 @@
       "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
       "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
       "maturity": "stable",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
+      "id": "kungfu.work.export",
+      "name": "kungfu work export <work-id> --repo <path> --json",
+      "kind": "cli-api",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
+      "id": "kungfu.work.import",
+      "name": "kungfu work import --file <envelope.json> --repo <path> [--execute] --json",
+      "kind": "cli-api",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
       "declaration": {
         "owner": "kungfu",
         "source": "scripts/buildchain-kfd-evidence.mjs",

--- a/.buildchain/kfd/kfd-3/surfaces.json
+++ b/.buildchain/kfd/kfd-3/surfaces.json
@@ -2634,6 +2634,46 @@
       }
     },
     {
+      "id": "kungfu.work.export",
+      "name": "kungfu work export <work-id> --repo <path> --json",
+      "kind": "cli-api",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
+      "id": "kungfu.work.import",
+      "name": "kungfu work import --file <envelope.json> --repo <path> [--execute] --json",
+      "kind": "cli-api",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
       "id": "kungfu.work.inspect",
       "name": "kungfu work inspect --repo <path> --json",
       "kind": "cli-api",

--- a/developer/sdk/kfd/kfd-2/claims/agent-onboarding-pack.json
+++ b/developer/sdk/kfd/kfd-2/claims/agent-onboarding-pack.json
@@ -16,7 +16,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "62687c870e8f06bc925450db9107bd3360ee91fef4783b5167b9904c79662582"
+        "sha256": "e6685cd957be33d0667e5c4487368bfd616efad9079111c1c7646cd1e9227a50"
       },
       "description": "Machine-readable command catalog and mode maturity metadata."
     },
@@ -25,7 +25,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/cli_surface.catalog.json",
-        "sha256": "9f6f7b50a106f192f045425ec13cbc46947c7e66d3cc7c89ca40bf4b0223817c"
+        "sha256": "ef2bde08154ec637b3eb2f1a91ac5c54ce568a25be0003616b73ae6855df141d"
       },
       "description": "Complete deterministic CLI surface graph shared by offline Agent capabilities and catalog parity checks."
     },
@@ -72,11 +72,11 @@
     "evidenceSha256": [
       {
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "62687c870e8f06bc925450db9107bd3360ee91fef4783b5167b9904c79662582"
+        "sha256": "e6685cd957be33d0667e5c4487368bfd616efad9079111c1c7646cd1e9227a50"
       },
       {
         "path": "framework/core/src/python/kungfu/agent/cli_surface.catalog.json",
-        "sha256": "9f6f7b50a106f192f045425ec13cbc46947c7e66d3cc7c89ca40bf4b0223817c"
+        "sha256": "ef2bde08154ec637b3eb2f1a91ac5c54ce568a25be0003616b73ae6855df141d"
       },
       {
         "path": "framework/core/src/python/kungfu/agent/mode-selection.md",
@@ -102,11 +102,11 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "62687c870e8f06bc925450db9107bd3360ee91fef4783b5167b9904c79662582"
+        "sha256": "e6685cd957be33d0667e5c4487368bfd616efad9079111c1c7646cd1e9227a50"
       },
       {
         "path": "framework/core/src/python/kungfu/agent/cli_surface.catalog.json",
-        "sha256": "9f6f7b50a106f192f045425ec13cbc46947c7e66d3cc7c89ca40bf4b0223817c"
+        "sha256": "ef2bde08154ec637b3eb2f1a91ac5c54ce568a25be0003616b73ae6855df141d"
       }
     ]
   },
@@ -120,13 +120,13 @@
     {
       "name": "agent-command-catalog",
       "path": "framework/core/src/python/kungfu/agent/commands.json",
-      "sha256": "62687c870e8f06bc925450db9107bd3360ee91fef4783b5167b9904c79662582",
+      "sha256": "e6685cd957be33d0667e5c4487368bfd616efad9079111c1c7646cd1e9227a50",
       "expectedPackagePath": "kungfu/agent/commands.json"
     },
     {
       "name": "cli-surface-catalog",
       "path": "framework/core/src/python/kungfu/agent/cli_surface.catalog.json",
-      "sha256": "9f6f7b50a106f192f045425ec13cbc46947c7e66d3cc7c89ca40bf4b0223817c",
+      "sha256": "ef2bde08154ec637b3eb2f1a91ac5c54ce568a25be0003616b73ae6855df141d",
       "expectedPackagePath": "kungfu/agent/cli_surface.catalog.json"
     }
   ],

--- a/developer/sdk/kfd/kfd-2/claims/agent-work-state-contract.json
+++ b/developer/sdk/kfd/kfd-2/claims/agent-work-state-contract.json
@@ -43,7 +43,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/tests/python/test_agent_work_state_contract.py",
-        "sha256": "a19cdc151a1247af5f25388ac69a20ee8d945872e9a4232ce1e85ff339a62049"
+        "sha256": "8466506d23519ac721029fdcb2db1febd7125fb07e4b77407e4b1df32336bf89"
       },
       "description": "Runtime CLI parity and fail-closed contract-schema checks."
     },
@@ -52,7 +52,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
-        "sha256": "735bf52451494a2f1d7017eedc74e5817bbeb435ee6bfe306a77b385954b27bd"
+        "sha256": "c5b66e332b6f9144e288851d4d5d434e9353680af5ae3bf3ed171758f88e00d8"
       },
       "description": "Agent collaboration-interface registration for the work-model query."
     }
@@ -75,11 +75,11 @@
       },
       {
         "path": "framework/core/tests/python/test_agent_work_state_contract.py",
-        "sha256": "a19cdc151a1247af5f25388ac69a20ee8d945872e9a4232ce1e85ff339a62049"
+        "sha256": "8466506d23519ac721029fdcb2db1febd7125fb07e4b77407e4b1df32336bf89"
       },
       {
         "path": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
-        "sha256": "735bf52451494a2f1d7017eedc74e5817bbeb435ee6bfe306a77b385954b27bd"
+        "sha256": "c5b66e332b6f9144e288851d4d5d434e9353680af5ae3bf3ed171758f88e00d8"
       }
     ],
     "artifactSha256": [

--- a/developer/sdk/kfd/kfd-2/claims/codex-report-receipts.json
+++ b/developer/sdk/kfd/kfd-2/claims/codex-report-receipts.json
@@ -52,7 +52,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/skills/codex/SKILL.md",
-        "sha256": "79605a827bd7e8746479a0b486642cbb2a63d1390870003e14bcbeeb0c196046"
+        "sha256": "f751670f2949a85be6d67031737c63d41a086ecc4244676145d397ada20fe280"
       },
       "description": "Codex-side report closeout gate instructions shipped in the agent pack."
     }
@@ -79,7 +79,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/skills/codex/SKILL.md",
-        "sha256": "79605a827bd7e8746479a0b486642cbb2a63d1390870003e14bcbeeb0c196046"
+        "sha256": "f751670f2949a85be6d67031737c63d41a086ecc4244676145d397ada20fe280"
       }
     ],
     "artifactSha256": [
@@ -89,7 +89,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/skills/codex/SKILL.md",
-        "sha256": "79605a827bd7e8746479a0b486642cbb2a63d1390870003e14bcbeeb0c196046"
+        "sha256": "f751670f2949a85be6d67031737c63d41a086ecc4244676145d397ada20fe280"
       }
     ]
   },
@@ -103,7 +103,7 @@
     {
       "name": "codex-agent-skill",
       "path": "framework/core/src/python/kungfu/agent/skills/codex/SKILL.md",
-      "sha256": "79605a827bd7e8746479a0b486642cbb2a63d1390870003e14bcbeeb0c196046",
+      "sha256": "f751670f2949a85be6d67031737c63d41a086ecc4244676145d397ada20fe280",
       "expectedPackagePath": "kungfu/agent/skills/codex/SKILL.md"
     }
   ],

--- a/developer/sdk/kfd/kfd-2/claims/remote-fact-boundary.json
+++ b/developer/sdk/kfd/kfd-2/claims/remote-fact-boundary.json
@@ -34,7 +34,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "62687c870e8f06bc925450db9107bd3360ee91fef4783b5167b9904c79662582"
+        "sha256": "e6685cd957be33d0667e5c4487368bfd616efad9079111c1c7646cd1e9227a50"
       },
       "description": "Remote add/sync command declarations and mode metadata."
     },
@@ -62,7 +62,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "62687c870e8f06bc925450db9107bd3360ee91fef4783b5167b9904c79662582"
+        "sha256": "e6685cd957be33d0667e5c4487368bfd616efad9079111c1c7646cd1e9227a50"
       },
       {
         "path": "framework/core/src/python/kungfu/cli/commands/agent.py",

--- a/developer/sdk/kfd/kfd-2/release-claims.json
+++ b/developer/sdk/kfd/kfd-2/release-claims.json
@@ -29,7 +29,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/commands.json",
-            "sha256": "62687c870e8f06bc925450db9107bd3360ee91fef4783b5167b9904c79662582"
+            "sha256": "e6685cd957be33d0667e5c4487368bfd616efad9079111c1c7646cd1e9227a50"
           },
           "description": "Machine-readable command catalog and mode maturity metadata."
         },
@@ -38,7 +38,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/cli_surface.catalog.json",
-            "sha256": "9f6f7b50a106f192f045425ec13cbc46947c7e66d3cc7c89ca40bf4b0223817c"
+            "sha256": "ef2bde08154ec637b3eb2f1a91ac5c54ce568a25be0003616b73ae6855df141d"
           },
           "description": "Complete deterministic CLI surface graph shared by offline Agent capabilities and catalog parity checks."
         },
@@ -152,7 +152,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/skills/codex/SKILL.md",
-            "sha256": "79605a827bd7e8746479a0b486642cbb2a63d1390870003e14bcbeeb0c196046"
+            "sha256": "f751670f2949a85be6d67031737c63d41a086ecc4244676145d397ada20fe280"
           },
           "description": "Codex-side report closeout gate instructions shipped in the agent pack."
         }
@@ -212,7 +212,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/commands.json",
-            "sha256": "62687c870e8f06bc925450db9107bd3360ee91fef4783b5167b9904c79662582"
+            "sha256": "e6685cd957be33d0667e5c4487368bfd616efad9079111c1c7646cd1e9227a50"
           },
           "description": "Remote add/sync command declarations and mode metadata."
         },
@@ -292,7 +292,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/tests/python/test_agent_work_state_contract.py",
-            "sha256": "a19cdc151a1247af5f25388ac69a20ee8d945872e9a4232ce1e85ff339a62049"
+            "sha256": "8466506d23519ac721029fdcb2db1febd7125fb07e4b77407e4b1df32336bf89"
           },
           "description": "Runtime CLI parity and fail-closed contract-schema checks."
         },
@@ -301,7 +301,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
-            "sha256": "735bf52451494a2f1d7017eedc74e5817bbeb435ee6bfe306a77b385954b27bd"
+            "sha256": "c5b66e332b6f9144e288851d4d5d434e9353680af5ae3bf3ed171758f88e00d8"
           },
           "description": "Agent collaboration-interface registration for the work-model query."
         }

--- a/developer/sdk/kfd/kfd-3-surfaces.json
+++ b/developer/sdk/kfd/kfd-3-surfaces.json
@@ -2634,6 +2634,46 @@
       }
     },
     {
+      "id": "kungfu.work.export",
+      "name": "kungfu work export <work-id> --repo <path> --json",
+      "kind": "cli-api",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
+      "id": "kungfu.work.import",
+      "name": "kungfu work import --file <envelope.json> --repo <path> [--execute] --json",
+      "kind": "cli-api",
+      "participantProfile": "agent-or-developer",
+      "state": "declared",
+      "availability": "shipped",
+      "visibility": "public",
+      "participantFacing": true,
+      "public": true,
+      "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
+      "evidencePath": "framework/core/src/python/kungfu/agent/commands.json",
+      "artifactPath": "framework/core/src/python/kungfu/agent/commands.json",
+      "maturity": "experimental",
+      "declaration": {
+        "owner": "kungfu",
+        "source": "scripts/buildchain-kfd-evidence.mjs",
+        "sourcePath": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json"
+      }
+    },
+    {
       "id": "kungfu.work.inspect",
       "name": "kungfu work inspect --repo <path> --json",
       "kind": "cli-api",

--- a/docs/adr/KF-ADR-019f87e8-6b8b-735c-b036-fa42d7cee8cf-project-cut-public-work-loop-facade.md
+++ b/docs/adr/KF-ADR-019f87e8-6b8b-735c-b036-fa42d7cee8cf-project-cut-public-work-loop-facade.md
@@ -5,7 +5,7 @@ adr_id: KF-ADR-019f87e8-6b8b-735c-b036-fa42d7cee8cf
 decision_status: accepted
 implementation_status: staged
 implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/1218, https://github.com/kungfu-systems/kungfu/pull/1225, https://github.com/kungfu-systems/kungfu/pull/1234, https://github.com/kungfu-systems/kungfu/pull/1241]
-qualification_refs: [framework/work-loop/work-api.contract.json, framework/work-loop/project-cut-product-loop.release-contract.json, scripts/project-cut-product-loop-release.mjs, scripts/project-cut-product-loop-release.test.mjs, framework/api/tests/work-loop.test.ts, framework/core/tests/python/test_project_cut_read_model.py, framework/core/tests/python/test_work_facade.py, framework/core/tests/python/test_agent_work_state_contract.py, extensions/work-dashboard/tests/work-loop-summary.test.ts, framework/tui/src/work-loop-contribution.test.ts]
+qualification_refs: [framework/work-loop/work-api.contract.json, framework/work-loop/project-cut-product-loop.release-contract.json, scripts/project-cut-product-loop-release.mjs, scripts/project-cut-product-loop-release.test.mjs, framework/api/tests/work-loop.test.ts, framework/core/tests/python/test_project_cut_read_model.py, framework/core/tests/python/test_work_facade.py, framework/core/tests/python/test_action_envelope.py, framework/core/tests/python/test_agent_work_state_contract.py, extensions/work-dashboard/tests/work-loop-summary.test.ts, framework/tui/src/work-loop-contribution.test.ts]
 review_state: self-reviewed
 sensitivity: public
 sources: [local-files, user-consensus]
@@ -65,10 +65,24 @@ evidence admission without claiming retained qualification evidence. The Gate
 runner, retained platform campaign, and operations still reported as
 unavailable, degraded, or plan-only remain outside executable qualification.
 
+The portability slice emits byte-stable Work semantics without local
+timestamps and binds them to the exact tracked current Project Cut. Import is
+verify-first and writes only after `--execute`; replay reuses an exact existing
+Work, an interrupted prefix resumes from its first missing event, and a wrong
+Cut, divergent Work, modified root, signed URL, or obvious credential-like
+text fails before any append. It does not transport source bytes or acquire
+Project Cut publication authority. `portableRoot` proves byte integrity, not
+origin authenticity or that the Work existed in the bound Cut; `--execute` is
+the explicit local admission decision. The envelope preserves the semantic
+Work projection, not local timestamps or cross-type event ordering.
+
 ## Consequences
 
 - Existing Work journal and authority receipts remain canonical.
 - Simple sessions can use Cut and Work without learning the five-role model.
 - Expert projections retain roots, receipts, gaps, and authority ownership.
+- Clean-runtime continuation can restore one verified Work prefix against an
+  already present tracked Project Cut without copying machine-local time or
+  paths.
 - Full `begin` and executable settlement remain gated on the native
   Initiative/Assignment orchestration reaching the shared dev baseline.

--- a/docs/adr/KF-ADR-019f87e8-6b8b-735c-b036-fa42d7cee8cf-project-cut-public-work-loop-facade.md
+++ b/docs/adr/KF-ADR-019f87e8-6b8b-735c-b036-fa42d7cee8cf-project-cut-public-work-loop-facade.md
@@ -4,7 +4,7 @@ doc_type: architecture-decision
 adr_id: KF-ADR-019f87e8-6b8b-735c-b036-fa42d7cee8cf
 decision_status: accepted
 implementation_status: staged
-implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/1218, https://github.com/kungfu-systems/kungfu/pull/1225, https://github.com/kungfu-systems/kungfu/pull/1234, https://github.com/kungfu-systems/kungfu/pull/1241]
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/1218, https://github.com/kungfu-systems/kungfu/pull/1225, https://github.com/kungfu-systems/kungfu/pull/1234, https://github.com/kungfu-systems/kungfu/pull/1241, https://github.com/kungfu-systems/kungfu/pull/1245]
 qualification_refs: [framework/work-loop/work-api.contract.json, framework/work-loop/project-cut-product-loop.release-contract.json, scripts/project-cut-product-loop-release.mjs, scripts/project-cut-product-loop-release.test.mjs, framework/api/tests/work-loop.test.ts, framework/core/tests/python/test_project_cut_read_model.py, framework/core/tests/python/test_work_facade.py, framework/core/tests/python/test_action_envelope.py, framework/core/tests/python/test_agent_work_state_contract.py, extensions/work-dashboard/tests/work-loop-summary.test.ts, framework/tui/src/work-loop-contribution.test.ts]
 review_state: self-reviewed
 sensitivity: public

--- a/framework/core/src/python/kungfu/agent/brief.md
+++ b/framework/core/src/python/kungfu/agent/brief.md
@@ -19,6 +19,8 @@ kungfu agent session capabilities --json
 kungfu agent session list --json
 kungfu cut --repo <path> --json
 kungfu work capabilities --json
+kungfu work export <work-id> --repo <path> --json
+kungfu work import --file <envelope.json> --repo <path> --json
 ```
 
 Kungfu has one public executable. Xinfa and all four Action Primitive roles are
@@ -81,6 +83,10 @@ Project-level work starts from the current Cut. `kungfu cut --repo <path>
 high-level operation with its current availability and authority boundary.
 The same manifest appears as `workLoop` in `kungfu agent capabilities --json`;
 an unavailable or plan-only operation must not be inferred to be executable.
+Portable Work export excludes machine-local timestamps and binds the envelope
+to the verified current Project Cut. Import is read-only unless `--execute` is
+present. Its portable root proves integrity, not origin authenticity; execution
+is the explicit local admission decision.
 
 For portable Exit packages, use
 `kungfu-exit-verify --file <package.json> --json` (or

--- a/framework/core/src/python/kungfu/agent/cli_surface.catalog.json
+++ b/framework/core/src/python/kungfu/agent/cli_surface.catalog.json
@@ -1,7 +1,7 @@
 {
-  "catalogRoot": "sha256:49405f1893d974c83bf805bdb48a954473718ace270443cd3f7899244a5b1b69",
+  "catalogRoot": "sha256:7c3603ba362fec7fff338dede8d91bd4432415f8df40c9e9f0a84df6efa5b1c8",
   "contractId": "kungfu-cli-surface",
-  "contractRoot": "sha256:56177501b0940ac0d6b3863a4fe4adcd8467bc5b8289bfea6e11852332e54637",
+  "contractRoot": "sha256:e12dda19216bacc19f5c58bdbf196ed1fa90116488853ec98e806355fc04b6ea",
   "kfd3Linkage": [
     {
       "apiIds": [],
@@ -2426,6 +2426,22 @@
     },
     {
       "apiIds": [
+        "kungfu.work.export"
+      ],
+      "reason": null,
+      "state": "linked",
+      "surfaceId": "kungfu.cli.commands.work.export.work"
+    },
+    {
+      "apiIds": [
+        "kungfu.work.import"
+      ],
+      "reason": null,
+      "state": "linked",
+      "surfaceId": "kungfu.cli.commands.work.import.work"
+    },
+    {
+      "apiIds": [
         "kungfu.work.inspect"
       ],
       "reason": null,
@@ -2649,11 +2665,11 @@
       "kfd3Registry": "strict-link",
       "packagedInventory": "required-agent-pack-entry"
     },
-    "expectedSurfaceRoot": "sha256:0fec5025a38f2cb789405dc73435c22b262affe2082959444372205cfa986660",
+    "expectedSurfaceRoot": "sha256:a70ce9dffa3d9d0e8cc9658487f3c899b68b53b70acb748afa90deb97cfcaa56",
     "regeneration": "./shifu fix:cli-catalog-parity",
     "validation": "./shifu check:cli-catalog-parity"
   },
-  "registryRoot": "sha256:aae9499944561e4a2f349b0e05e43d60fd215eed4c9a0af145cc4849bdceb2a0",
+  "registryRoot": "sha256:ab46013a80a717721b57068c9254b11ac530e1108d29da76d2f5396ff3bfbcf7",
   "schema": "kungfu.cli-surface-catalog/v1",
   "schemaRoot": "sha256:731eec25990d090067d59651d6c0793934124ac79df4111990bd905e03b605c4",
   "source": {
@@ -2666,7 +2682,7 @@
     "pathAuthority": "live-click-tree",
     "root": "kungfu"
   },
-  "surfaceRoot": "sha256:0fec5025a38f2cb789405dc73435c22b262affe2082959444372205cfa986660",
+  "surfaceRoot": "sha256:a70ce9dffa3d9d0e8cc9658487f3c899b68b53b70acb748afa90deb97cfcaa56",
   "surfaces": [
     {
       "alias_diagnostics": [],
@@ -29682,6 +29698,167 @@
       },
       "summary": "mark a work item done (-> done)",
       "visibility": "advanced"
+    },
+    {
+      "alias_diagnostics": [],
+      "aliases": [],
+      "approval_policy": {
+        "caller_confirmation_required": false,
+        "mode": "none",
+        "preconditions": []
+      },
+      "audience": [
+        "human",
+        "agent"
+      ],
+      "availability": {
+        "conditions": [
+          "source-runtime"
+        ],
+        "state": "available"
+      },
+      "canonical_path": "kungfu work export",
+      "id": "kungfu.cli.commands.work.export.work",
+      "kfd3_api_id": "kungfu.work.export",
+      "kfd3_api_ids": [
+        "kungfu.work.export"
+      ],
+      "kind": "command",
+      "maturity": "experimental",
+      "mutation_class": "read",
+      "owner": "core",
+      "parameters": [
+        {
+          "arity": 1,
+          "kind": "argument",
+          "name": "work_id",
+          "required": true,
+          "type": "text"
+        },
+        {
+          "arity": 1,
+          "flags": [
+            "--repo"
+          ],
+          "hidden": false,
+          "kind": "option",
+          "name": "repo",
+          "required": false,
+          "type": "directory"
+        },
+        {
+          "arity": 1,
+          "flags": [
+            "--json"
+          ],
+          "hidden": false,
+          "kind": "option",
+          "name": "as_json",
+          "required": false,
+          "type": "boolean"
+        }
+      ],
+      "path_depth": 3,
+      "removal_gate": null,
+      "replacement": null,
+      "schema_refs": [],
+      "section": "advanced-compatibility",
+      "source": {
+        "familyPolicy": true,
+        "kind": "runtime-click",
+        "module": "kungfu.cli.commands.work",
+        "symbol": "export_work"
+      },
+      "summary": "export byte-stable Work continuity evidence",
+      "visibility": "public"
+    },
+    {
+      "alias_diagnostics": [],
+      "aliases": [],
+      "approval_policy": {
+        "caller_confirmation_required": false,
+        "mode": "explicit-execute",
+        "preconditions": []
+      },
+      "audience": [
+        "human",
+        "agent"
+      ],
+      "availability": {
+        "conditions": [
+          "source-runtime"
+        ],
+        "state": "available"
+      },
+      "canonical_path": "kungfu work import",
+      "id": "kungfu.cli.commands.work.import.work",
+      "kfd3_api_id": "kungfu.work.import",
+      "kfd3_api_ids": [
+        "kungfu.work.import"
+      ],
+      "kind": "command",
+      "maturity": "experimental",
+      "mutation_class": "write",
+      "owner": "core",
+      "parameters": [
+        {
+          "arity": 1,
+          "flags": [
+            "--file"
+          ],
+          "hidden": false,
+          "kind": "option",
+          "name": "file_path",
+          "required": true,
+          "type": "text"
+        },
+        {
+          "arity": 1,
+          "flags": [
+            "--repo"
+          ],
+          "hidden": false,
+          "kind": "option",
+          "name": "repo",
+          "required": false,
+          "type": "directory"
+        },
+        {
+          "arity": 1,
+          "flags": [
+            "--execute"
+          ],
+          "hidden": false,
+          "kind": "option",
+          "name": "execute",
+          "required": false,
+          "type": "boolean"
+        },
+        {
+          "arity": 1,
+          "flags": [
+            "--json"
+          ],
+          "hidden": false,
+          "kind": "option",
+          "name": "as_json",
+          "required": false,
+          "type": "boolean"
+        }
+      ],
+      "path_depth": 3,
+      "removal_gate": null,
+      "replacement": null,
+      "schema_refs": [],
+      "section": "advanced-compatibility",
+      "source": {
+        "familyPolicy": true,
+        "kind": "runtime-click",
+        "module": "kungfu.cli.commands.work",
+        "symbol": "import_work"
+      },
+      "summary": "verify or replay one portable Work envelope",
+      "visibility": "public"
     },
     {
       "alias_diagnostics": [],

--- a/framework/core/src/python/kungfu/agent/commands.json
+++ b/framework/core/src/python/kungfu/agent/commands.json
@@ -320,6 +320,18 @@
       "purpose": "Inspect the current Cut and open Work through one non-authoritative read model."
     },
     {
+      "apiId": "kungfu.work.export",
+      "name": "kungfu work export <work-id> --repo <path> --json",
+      "maturity": "experimental",
+      "purpose": "Export one byte-stable Work continuity envelope bound to the exact verified current Project Cut."
+    },
+    {
+      "apiId": "kungfu.work.import",
+      "name": "kungfu work import --file <envelope.json> --repo <path> [--execute] --json",
+      "maturity": "experimental",
+      "purpose": "Verify or explicitly append only the missing prefix of one Project Cut-bound portable Work envelope."
+    },
+    {
       "apiId": "kungfu.work.recover",
       "name": "kungfu work recover --repo <path> --json",
       "maturity": "experimental",

--- a/framework/core/src/python/kungfu/agent/kfd3_api.registry.json
+++ b/framework/core/src/python/kungfu/agent/kfd3_api.registry.json
@@ -528,6 +528,26 @@
       "projections": ["commands.json", "agent-pack-doc", "provider-skill"]
     },
     {
+      "id": "kungfu.work.export",
+      "surface": "cli-api",
+      "name": "kungfu work export <work-id> --repo <path> --json",
+      "purpose": "Export one byte-stable Work continuity envelope bound to the exact verified current Project Cut.",
+      "maturity": "experimental",
+      "visibility": "public-agent",
+      "anchor": { "kind": "catalog" },
+      "projections": ["commands.json", "agent-pack-doc", "provider-skill"]
+    },
+    {
+      "id": "kungfu.work.import",
+      "surface": "cli-api",
+      "name": "kungfu work import --file <envelope.json> --repo <path> [--execute] --json",
+      "purpose": "Verify or explicitly append only the missing prefix of one Project Cut-bound portable Work envelope.",
+      "maturity": "experimental",
+      "visibility": "public-agent",
+      "anchor": { "kind": "catalog" },
+      "projections": ["commands.json", "agent-pack-doc", "provider-skill"]
+    },
+    {
       "id": "kungfu.work.recover",
       "surface": "cli-api",
       "name": "kungfu work recover --repo <path> --json",

--- a/framework/core/src/python/kungfu/agent/skills/claude/SKILL.md
+++ b/framework/core/src/python/kungfu/agent/skills/claude/SKILL.md
@@ -39,6 +39,8 @@ kungfu agent session capabilities --json
 kungfu agent session list --json
 kungfu cut --repo <path> --json
 kungfu work capabilities --json
+kungfu work export <work-id> --repo <path> --json
+kungfu work import --file <envelope.json> --repo <path> --json
 ```
 
 For source work, read `AGENTS.md` and `xinfa-context.md`, inspect
@@ -54,6 +56,10 @@ Use the smallest mode that preserves evidence:
   `kungfu work capabilities --json`. Treat its `unavailable`, `degraded`, and
   `plan-only` states as hard capability limits; the identical manifest is
   available at `kungfu agent capabilities --json` under `workLoop`.
+
+- Use `kungfu work export` only against one verified current Project Cut. Treat
+  `kungfu work import` as verification unless the caller explicitly supplies
+  `--execute`; the portable root proves integrity, not origin authenticity.
 
 - Read `kungfu agent work-model --json` before treating a goal as authority,
   context as complete reality, a plan as occurrence, or an Episode as

--- a/framework/core/src/python/kungfu/agent/skills/codex/SKILL.md
+++ b/framework/core/src/python/kungfu/agent/skills/codex/SKILL.md
@@ -39,6 +39,8 @@ kungfu agent session capabilities --json
 kungfu agent session list --json
 kungfu cut --repo <path> --json
 kungfu work capabilities --json
+kungfu work export <work-id> --repo <path> --json
+kungfu work import --file <envelope.json> --repo <path> --json
 ```
 
 For source work, read `AGENTS.md` and `xinfa-context.md`, inspect
@@ -54,6 +56,10 @@ Use the smallest mode that preserves evidence:
   `kungfu work capabilities --json`. Treat its `unavailable`, `degraded`, and
   `plan-only` states as hard capability limits; the identical manifest is
   available at `kungfu agent capabilities --json` under `workLoop`.
+
+- Use `kungfu work export` only against one verified current Project Cut. Treat
+  `kungfu work import` as verification unless the caller explicitly supplies
+  `--execute`; the portable root proves integrity, not origin authenticity.
 
 - Read `kungfu agent work-model --json` before treating a goal as authority,
   context as complete reality, a plan as occurrence, or an Episode as

--- a/framework/core/src/python/kungfu/cli/commands/work.py
+++ b/framework/core/src/python/kungfu/cli/commands/work.py
@@ -17,9 +17,13 @@ from kungfu.cli.commands import (
 )
 from kungfu.project_cut_read_model import inspect_project_cut
 from kungfu.work_facade import (
+    PORTABLE_MAX_BYTES,
     READ_ONLY_FACADE_ACTIONS,
+    WorkPortabilityError,
+    export_portable_work,
     inspect_work,
     plan_completion,
+    plan_portable_import,
     plan_settlement,
     recover_work,
     work_loop_capabilities,
@@ -151,6 +155,86 @@ def settle(work_id, claim_root, review_root, decision_root, project_cut_root, as
     )
     detail = ", ".join(plan["missingRoots"]) or "exact roots bound"
     _echo(plan, as_json, f"[work] settlement {plan['status']}: {detail}")
+
+
+@work.command(name="export", help="export byte-stable Work continuity evidence")
+@click.argument("work_id", type=str)
+@click.option("--repo", default=".", type=click.Path(file_okay=False))
+@click.option("--json", "as_json", is_flag=True, help="machine-readable output")
+@work_command_context
+def export_work(ctx, work_id, repo, as_json):
+    try:
+        envelope = export_portable_work(inspect_project_cut(repo), _load(ctx), work_id)
+    except WorkPortabilityError as error:
+        raise click.ClickException(str(error)) from error
+    _echo(
+        envelope,
+        as_json,
+        f"[work] portable envelope: {envelope['portableRoot']}",
+    )
+
+
+@work.command(name="import", help="verify or replay one portable Work envelope")
+@click.option("--file", "file_path", required=True, help="envelope JSON path or -")
+@click.option("--repo", default=".", type=click.Path(file_okay=False))
+@click.option("--execute", is_flag=True, help="append the verified missing prefix")
+@click.option("--json", "as_json", is_flag=True, help="machine-readable output")
+@work_command_context
+def import_work(ctx, file_path, repo, execute, as_json):
+    try:
+        if file_path == "-":
+            stream = getattr(sys.stdin, "buffer", sys.stdin)
+            raw_value = stream.read(PORTABLE_MAX_BYTES + 1)
+        else:
+            with open(file_path, "rb") as source:
+                raw_value = source.read(PORTABLE_MAX_BYTES + 1)
+        raw_bytes = (
+            raw_value.encode("utf-8") if isinstance(raw_value, str) else raw_value
+        )
+        if len(raw_bytes) > PORTABLE_MAX_BYTES:
+            raise ValueError("portable envelope exceeds 4 MiB")
+        raw = raw_bytes.decode("utf-8")
+        envelope = json.loads(raw)
+        if not isinstance(envelope, dict):
+            raise ValueError("portable envelope must be a JSON object")
+    except (OSError, UnicodeError, ValueError, json.JSONDecodeError) as error:
+        raise click.ClickException(str(error)) from error
+
+    cut_projection = inspect_project_cut(repo)
+    try:
+        plan = plan_portable_import(cut_projection, _load(ctx), envelope)
+        if execute and not plan["reused"]:
+            initialize_runtime_context(ctx)
+            from kungfu.work import store as work_store
+
+            items = _load(ctx)
+            plan = plan_portable_import(inspect_project_cut(repo), items, envelope)
+            action_count = work_store.WorkStore(ctx.runtime_dir).import_portable_item(
+                items.get(plan["workId"]), envelope["work"]
+            )
+            verified = plan_portable_import(
+                inspect_project_cut(repo), _load(ctx), envelope
+            )
+            if verified["status"] != "current":
+                raise WorkPortabilityError(
+                    "PORTABLE_IMPORT_INCOMPLETE",
+                    "the appended Work prefix did not reach the portable root",
+                )
+            plan = {
+                **verified,
+                "status": "imported",
+                "code": "work-imported",
+                "actionTypes": plan["actionTypes"],
+                "writeOccurred": action_count > 0,
+                "reused": False,
+            }
+    except WorkPortabilityError as error:
+        raise click.ClickException(str(error)) from error
+    _echo(
+        plan,
+        as_json,
+        f"[work] import {plan['status']}: {plan['code']}",
+    )
 
 
 @work.command(help="create a work item (a created item starts active)")

--- a/framework/core/src/python/kungfu/cli/surface_contract.registry.json
+++ b/framework/core/src/python/kungfu/cli/surface_contract.registry.json
@@ -159,7 +159,7 @@
   "catalogProjection": {
     "artifact": "kungfu.agent/cli_surface.catalog.json",
     "authority": "runtime-fold",
-    "expectedSurfaceRoot": "sha256:0fec5025a38f2cb789405dc73435c22b262affe2082959444372205cfa986660",
+    "expectedSurfaceRoot": "sha256:a70ce9dffa3d9d0e8cc9658487f3c899b68b53b70acb748afa90deb97cfcaa56",
     "consumers": {
       "agentCapabilities": "embed-complete",
       "agentCommands": "strict-link",

--- a/framework/core/src/python/kungfu/work/store.py
+++ b/framework/core/src/python/kungfu/work/store.py
@@ -109,12 +109,53 @@ class WorkStore:
 
     def create(self, title, kind, summary):
         work_id = new_work_id()
+        self.create_with_id(work_id, title, kind, summary)
+        return work_id
+
+    def create_with_id(self, work_id, title, kind, summary):
+        """Create an item with an already verified portable Work identity."""
+
         self._append(
             ACTION_WORK_ITEM_CREATED,
             events.work_item_created(work_id, title, kind, summary, SCHEMA_VERSION),
         )
         self.emit_manifest()
-        return work_id
+
+    def import_portable_item(self, existing, target):
+        """Append only the missing verified prefix of a portable Work item."""
+
+        from kungfu.work_facade import portable_import_delta
+
+        actions = portable_import_delta(existing, target)
+        for action, value in actions:
+            if action == "create":
+                self.create_with_id(
+                    value["workId"], value["title"], value["kind"], value["summary"]
+                )
+            elif action == "nextAction":
+                self.set_next_action(target["workId"], value)
+            elif action == "checkpoints":
+                self.checkpoint(target["workId"], value["note"])
+            elif action == "decisions":
+                self.decide(target["workId"], value["decision"], value["decidedBy"])
+            elif action == "validations":
+                self.validate(
+                    target["workId"],
+                    RESULT_BY_NAME[value["result"]],
+                    value["command"],
+                    value["note"],
+                )
+            elif action == "artifacts":
+                self.artifact(target["workId"], value["ref"], value["kind"])
+            elif action == "runs":
+                self.link_run(target["workId"], value["runId"])
+            elif action == "status":
+                self.set_status(
+                    target["workId"], STATUS_BY_NAME[value], "portable-import"
+                )
+            else:  # pragma: no cover - delta owns this closed operation set
+                raise ValueError(f"unsupported portable Work action: {action}")
+        return len(actions)
 
     def set_status(self, work_id, status, reason):
         self._append(

--- a/framework/core/src/python/kungfu/work_facade.py
+++ b/framework/core/src/python/kungfu/work_facade.py
@@ -2,13 +2,473 @@
 
 from __future__ import annotations
 
-from typing import Any
+import hashlib
+import json
+import re
+from pathlib import PurePosixPath
+from typing import Any, NoReturn
+from urllib.parse import urlsplit
 
 
 OPEN_STATES = {"active", "waiting", "blocked", "ready"}
 READ_ONLY_FACADE_ACTIONS = frozenset(
-    {"capabilities", "inspect", "recover", "complete", "settle"}
+    {"capabilities", "inspect", "recover", "complete", "settle", "export", "import"}
 )
+PORTABLE_WORK_SCHEMA = "kungfu.work.portable-envelope/v1"
+PORTABLE_IMPORT_SCHEMA = "kungfu.work.import-receipt/v1"
+PORTABLE_MAX_BYTES = 4 * 1024 * 1024
+PORTABLE_MAX_TEXT = 64 * 1024
+PORTABLE_MAX_ROWS = 10_000
+PORTABLE_AUTHORITY = {
+    "work": "kungfu-work-journal",
+    "projectCut": "git-tracked-project-cut",
+    "import": "verify-current-cut-before-append",
+    "timestamps": "excluded-non-semantic",
+}
+_ROOT = re.compile(r"sha256:[0-9a-f]{64}\Z")
+_COMMIT = re.compile(r"[0-9a-f]{40}\Z")
+_WORK_ID = re.compile(r"w[0-9a-f]{8}\Z")
+_SECRET_ASSIGNMENT = re.compile(
+    r"(?i)\b(?:password|passwd|token|secret|api[_-]?key|authorization)\s*[:=]\s*\S+"
+)
+_PRIVATE_KEY = re.compile(r"-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----")
+_AWS_ACCESS_KEY = re.compile(r"\b(?:AKIA|ASIA)[A-Z0-9]{16}\b")
+_COMMON_CREDENTIAL = re.compile(
+    r"\b(?:github_pat_[A-Za-z0-9_]{20,}|gh[pousr]_[A-Za-z0-9]{20,}|"
+    r"glpat-[A-Za-z0-9_-]{20,}|xox[baprs]-[A-Za-z0-9-]{20,}|"
+    r"sk-(?:proj-)?[A-Za-z0-9_-]{20,})\b"
+)
+_BEARER_CREDENTIAL = re.compile(r"(?i)\bbearer\s+[A-Za-z0-9._~+/=-]{16,}")
+
+
+class WorkPortabilityError(ValueError):
+    def __init__(self, code: str, message: str):
+        super().__init__(f"{code}: {message}")
+        self.code = code
+
+
+def _portability_fail(code: str, message: str) -> NoReturn:
+    raise WorkPortabilityError(code, message)
+
+
+def _exact_object(value: Any, fields: set[str], path: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        _portability_fail("PORTABLE_SHAPE_INVALID", f"{path} must be an object")
+    if set(value) != fields:
+        _portability_fail(
+            "PORTABLE_SHAPE_INVALID", f"{path} fields do not match the contract"
+        )
+    return value
+
+
+def _text(value: Any, path: str, *, optional: bool = False) -> str | None:
+    if optional and value is None:
+        return None
+    if not isinstance(value, str) or not value:
+        _portability_fail("PORTABLE_SHAPE_INVALID", f"{path} must be text")
+    if len(value.encode("utf-8")) > PORTABLE_MAX_TEXT:
+        _portability_fail("PORTABLE_TEXT_TOO_LARGE", f"{path} exceeds 64 KiB")
+    return value
+
+
+def _safe_text(value: str | None, path: str) -> None:
+    if value is None:
+        return
+    try:
+        parsed = urlsplit(value)
+    except ValueError as error:
+        _portability_fail("PORTABLE_TEXT_INVALID", f"{path} is not portable: {error}")
+    unsafe_url = parsed.scheme in {"http", "https"} and bool(
+        parsed.username or parsed.password or parsed.query or parsed.fragment
+    )
+    if (
+        unsafe_url
+        or _SECRET_ASSIGNMENT.search(value)
+        or _PRIVATE_KEY.search(value)
+        or _AWS_ACCESS_KEY.search(value)
+        or _COMMON_CREDENTIAL.search(value)
+        or _BEARER_CREDENTIAL.search(value)
+    ):
+        _portability_fail(
+            "PORTABLE_SENSITIVE_TEXT", f"{path} contains non-portable sensitive text"
+        )
+
+
+def _root(value: Any, path: str) -> str:
+    if not isinstance(value, str) or _ROOT.fullmatch(value) is None:
+        _portability_fail("PORTABLE_ROOT_INVALID", f"{path} must be a sha256 root")
+    return value
+
+
+def _root_list(value: Any, path: str) -> list[str]:
+    if not isinstance(value, list):
+        _portability_fail("PORTABLE_SHAPE_INVALID", f"{path} must be an array")
+    return [_root(root, f"{path}[{index}]") for index, root in enumerate(value)]
+
+
+def _project_cut_path(value: Any, path: str) -> str:
+    text = _text(value, path)
+    candidate = PurePosixPath(str(text))
+    if (
+        candidate.is_absolute()
+        or ".." in candidate.parts
+        or "\\" in str(text)
+        or "\0" in str(text)
+        or len(candidate.parts) < 3
+        or candidate.parts[:2] != (".kungfu", "project-cuts")
+    ):
+        _portability_fail(
+            "PORTABLE_PROJECT_CUT_PATH_INVALID",
+            f"{path} must stay below .kungfu/project-cuts",
+        )
+    return str(text)
+
+
+def _validate_portable_cut(value: Any) -> dict[str, Any]:
+    cut = _exact_object(
+        value,
+        {
+            "cutRoot",
+            "parentCutRoots",
+            "sourceRoot",
+            "atlasRoot",
+            "episodeRoots",
+            "manifestPath",
+            "receiptPath",
+            "publicationCommit",
+        },
+        "projectCut",
+    )
+    publication = cut["publicationCommit"]
+    if not isinstance(publication, str) or _COMMIT.fullmatch(publication) is None:
+        _portability_fail(
+            "PORTABLE_PUBLICATION_INVALID", "Project Cut publication is not exact"
+        )
+    return {
+        "cutRoot": _root(cut["cutRoot"], "projectCut.cutRoot"),
+        "parentCutRoots": _root_list(
+            cut["parentCutRoots"], "projectCut.parentCutRoots"
+        ),
+        "sourceRoot": _root(cut["sourceRoot"], "projectCut.sourceRoot"),
+        "atlasRoot": _root(cut["atlasRoot"], "projectCut.atlasRoot"),
+        "episodeRoots": _root_list(cut["episodeRoots"], "projectCut.episodeRoots"),
+        "manifestPath": _project_cut_path(
+            cut["manifestPath"], "projectCut.manifestPath"
+        ),
+        "receiptPath": _project_cut_path(cut["receiptPath"], "projectCut.receiptPath"),
+        "publicationCommit": publication,
+    }
+
+
+def _rows(value: Any, path: str) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        _portability_fail("PORTABLE_SHAPE_INVALID", f"{path} must be an array")
+    if len(value) > PORTABLE_MAX_ROWS:
+        _portability_fail("PORTABLE_ROWS_TOO_LARGE", f"{path} exceeds 10000 rows")
+    if not all(isinstance(row, dict) for row in value):
+        _portability_fail("PORTABLE_SHAPE_INVALID", f"{path} entries must be objects")
+    return value
+
+
+def _validate_portable_work(value: Any) -> dict[str, Any]:
+    item = _exact_object(
+        value,
+        {
+            "workId",
+            "title",
+            "kind",
+            "summary",
+            "status",
+            "nextAction",
+            "checkpoints",
+            "decisions",
+            "validations",
+            "artifacts",
+            "runs",
+        },
+        "work",
+    )
+    work_id = _text(item["workId"], "work.workId")
+    if _WORK_ID.fullmatch(str(work_id)) is None:
+        _portability_fail("PORTABLE_WORK_ID_INVALID", "work.workId is not canonical")
+    title = _text(item["title"], "work.title")
+    kind = _text(item["kind"], "work.kind")
+    summary = _text(item["summary"], "work.summary", optional=True)
+    status = _text(item["status"], "work.status")
+    if status not in {"active", "waiting", "blocked", "ready", "done"}:
+        _portability_fail("PORTABLE_STATUS_INVALID", "work.status is unsupported")
+    next_action = _text(item["nextAction"], "work.nextAction", optional=True)
+    checkpoints = []
+    for index, row in enumerate(_rows(item["checkpoints"], "work.checkpoints")):
+        row = _exact_object(row, {"note"}, f"work.checkpoints[{index}]")
+        checkpoints.append(
+            {"note": _text(row["note"], f"work.checkpoints[{index}].note")}
+        )
+    decisions = []
+    for index, row in enumerate(_rows(item["decisions"], "work.decisions")):
+        row = _exact_object(row, {"decision", "decidedBy"}, f"work.decisions[{index}]")
+        decisions.append(
+            {
+                "decision": _text(row["decision"], f"work.decisions[{index}].decision"),
+                "decidedBy": _text(
+                    row["decidedBy"],
+                    f"work.decisions[{index}].decidedBy",
+                    optional=True,
+                ),
+            }
+        )
+    validations = []
+    for index, row in enumerate(_rows(item["validations"], "work.validations")):
+        row = _exact_object(
+            row, {"result", "command", "note"}, f"work.validations[{index}]"
+        )
+        result = _text(row["result"], f"work.validations[{index}].result")
+        if result not in {"pass", "fail"}:
+            _portability_fail(
+                "PORTABLE_RESULT_INVALID", f"work.validations[{index}] is unsupported"
+            )
+        validations.append(
+            {
+                "result": result,
+                "command": _text(
+                    row["command"],
+                    f"work.validations[{index}].command",
+                    optional=True,
+                ),
+                "note": _text(
+                    row["note"], f"work.validations[{index}].note", optional=True
+                ),
+            }
+        )
+    artifacts = []
+    for index, row in enumerate(_rows(item["artifacts"], "work.artifacts")):
+        row = _exact_object(row, {"ref", "kind"}, f"work.artifacts[{index}]")
+        artifacts.append(
+            {
+                "ref": _text(row["ref"], f"work.artifacts[{index}].ref"),
+                "kind": _text(
+                    row["kind"], f"work.artifacts[{index}].kind", optional=True
+                ),
+            }
+        )
+    runs = []
+    for index, row in enumerate(_rows(item["runs"], "work.runs")):
+        row = _exact_object(row, {"runId"}, f"work.runs[{index}]")
+        runs.append({"runId": _text(row["runId"], f"work.runs[{index}].runId")})
+    normalized = {
+        "workId": work_id,
+        "title": title,
+        "kind": kind,
+        "summary": summary,
+        "status": status,
+        "nextAction": next_action,
+        "checkpoints": checkpoints,
+        "decisions": decisions,
+        "validations": validations,
+        "artifacts": artifacts,
+        "runs": runs,
+    }
+    for path, value in (
+        ("work.title", title),
+        ("work.kind", kind),
+        ("work.summary", summary),
+        ("work.nextAction", next_action),
+    ):
+        _safe_text(value, path)
+    for collection in ("checkpoints", "decisions", "validations", "artifacts", "runs"):
+        for index, row in enumerate(normalized[collection]):
+            for field, value in row.items():
+                _safe_text(value, f"work.{collection}[{index}].{field}")
+    return normalized
+
+
+def portable_work_item(item: dict[str, Any]) -> dict[str, Any]:
+    """Remove local timestamps while preserving the Work semantic projection."""
+
+    return _validate_portable_work(
+        {
+            "workId": item.get("work_id"),
+            "title": item.get("title"),
+            "kind": item.get("kind"),
+            "summary": item.get("summary"),
+            "status": item.get("status"),
+            "nextAction": item.get("next_action"),
+            "checkpoints": [
+                {"note": row.get("note")} for row in item.get("checkpoints", [])
+            ],
+            "decisions": [
+                {
+                    "decision": row.get("decision"),
+                    "decidedBy": row.get("decided_by"),
+                }
+                for row in item.get("decisions", [])
+            ],
+            "validations": [
+                {
+                    "result": row.get("result"),
+                    "command": row.get("command"),
+                    "note": row.get("note"),
+                }
+                for row in item.get("validations", [])
+            ],
+            "artifacts": [
+                {"ref": row.get("ref"), "kind": row.get("kind")}
+                for row in item.get("artifacts", [])
+            ],
+            "runs": [{"runId": row.get("run_id")} for row in item.get("runs", [])],
+        }
+    )
+
+
+def _portable_cut(projection: dict[str, Any]) -> dict[str, Any]:
+    current = projection.get("current")
+    if projection.get("status") != "current" or not isinstance(current, dict):
+        _portability_fail(
+            "PORTABLE_PROJECT_CUT_NOT_CURRENT",
+            "export and import require one clean current Project Cut",
+        )
+    if current.get("receiptValid") is not True:
+        _portability_fail(
+            "PORTABLE_PROJECT_CUT_UNVERIFIED",
+            "the current Project Cut receipt is not valid",
+        )
+    return _validate_portable_cut(
+        {
+            "cutRoot": current.get("cutRoot"),
+            "parentCutRoots": current.get("parentCutRoots"),
+            "sourceRoot": current.get("sourceRoot"),
+            "atlasRoot": current.get("atlasRoot"),
+            "episodeRoots": current.get("episodeRoots"),
+            "manifestPath": current.get("manifest"),
+            "receiptPath": current.get("receipt"),
+            "publicationCommit": current.get("publicationCommit"),
+        }
+    )
+
+
+def _portable_root(value: dict[str, Any]) -> str:
+    encoded = json.dumps(
+        value, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+    ).encode("utf-8")
+    return f"sha256:{hashlib.sha256(encoded).hexdigest()}"
+
+
+def export_portable_work(
+    cut_projection: dict[str, Any],
+    items: dict[str, dict[str, Any]],
+    work_id: str,
+) -> dict[str, Any]:
+    item = items.get(work_id)
+    if item is None:
+        _portability_fail("PORTABLE_WORK_MISSING", "the requested Work does not exist")
+    envelope = {
+        "schema": PORTABLE_WORK_SCHEMA,
+        "projectCut": _portable_cut(cut_projection),
+        "work": portable_work_item(item),
+        "authority": dict(PORTABLE_AUTHORITY),
+    }
+    signed = {**envelope, "portableRoot": _portable_root(envelope)}
+    if (
+        len(json.dumps(signed, indent=2, sort_keys=True).encode("utf-8"))
+        > PORTABLE_MAX_BYTES
+    ):
+        _portability_fail(
+            "PORTABLE_ENVELOPE_TOO_LARGE", "portable envelope exceeds 4 MiB"
+        )
+    return signed
+
+
+def _is_prefix(current: list[Any], target: list[Any]) -> bool:
+    return len(current) <= len(target) and current == target[: len(current)]
+
+
+def portable_import_delta(
+    existing: dict[str, Any] | None, target: dict[str, Any]
+) -> list[tuple[str, Any]]:
+    target = _validate_portable_work(target)
+    actions: list[tuple[str, Any]] = []
+    if existing is None:
+        actions.append(("create", target))
+        current = {
+            **target,
+            "status": "active",
+            "nextAction": None,
+            "checkpoints": [],
+            "decisions": [],
+            "validations": [],
+            "artifacts": [],
+            "runs": [],
+        }
+    else:
+        current = portable_work_item(existing)
+        for field in ("workId", "title", "kind", "summary"):
+            if current[field] != target[field]:
+                _portability_fail(
+                    "PORTABLE_WORK_CONFLICT", f"existing Work differs at {field}"
+                )
+    if current["nextAction"] != target["nextAction"]:
+        if current["nextAction"] is not None:
+            _portability_fail(
+                "PORTABLE_WORK_CONFLICT", "existing Work has a different next action"
+            )
+        if target["nextAction"] is not None:
+            actions.append(("nextAction", target["nextAction"]))
+    for collection in ("checkpoints", "decisions", "validations", "artifacts", "runs"):
+        if not _is_prefix(current[collection], target[collection]):
+            _portability_fail(
+                "PORTABLE_WORK_CONFLICT", f"existing Work diverges at {collection}"
+            )
+        actions.extend(
+            (collection, row) for row in target[collection][len(current[collection]) :]
+        )
+    if current["status"] != target["status"]:
+        if current["status"] != "active":
+            _portability_fail(
+                "PORTABLE_WORK_CONFLICT", "existing Work has a different status"
+            )
+        actions.append(("status", target["status"]))
+    return actions
+
+
+def plan_portable_import(
+    cut_projection: dict[str, Any],
+    items: dict[str, dict[str, Any]],
+    envelope: Any,
+) -> dict[str, Any]:
+    envelope = _exact_object(
+        envelope,
+        {"schema", "projectCut", "work", "authority", "portableRoot"},
+        "envelope",
+    )
+    if envelope["schema"] != PORTABLE_WORK_SCHEMA:
+        _portability_fail("PORTABLE_SCHEMA_MISMATCH", "portable schema differs")
+    if envelope["authority"] != PORTABLE_AUTHORITY:
+        _portability_fail("PORTABLE_AUTHORITY_MISMATCH", "authority contract differs")
+    root = _root(envelope["portableRoot"], "portableRoot")
+    unsigned = {key: value for key, value in envelope.items() if key != "portableRoot"}
+    if _portable_root(unsigned) != root:
+        _portability_fail("PORTABLE_ROOT_MISMATCH", "portable envelope was modified")
+    portable_cut = _validate_portable_cut(envelope["projectCut"])
+    current_cut = _portable_cut(cut_projection)
+    if portable_cut != current_cut:
+        _portability_fail(
+            "PORTABLE_PROJECT_CUT_MISMATCH",
+            "portable Work does not bind the current Project Cut",
+        )
+    target = _validate_portable_work(envelope["work"])
+    existing = items.get(str(target["workId"]))
+    actions = portable_import_delta(existing, target)
+    return {
+        "schema": PORTABLE_IMPORT_SCHEMA,
+        "status": "plan" if actions else "current",
+        "code": "work-import-required" if actions else "work-import-current",
+        "workId": target["workId"],
+        "projectCutRoot": current_cut["cutRoot"],
+        "portableRoot": root,
+        "actionTypes": [name for name, _value in actions],
+        "writeOccurred": False,
+        "reused": not actions,
+    }
 
 
 def work_loop_capabilities() -> dict[str, Any]:
@@ -69,19 +529,17 @@ def work_loop_capabilities() -> dict[str, Any]:
         },
         {
             "id": "export",
-            "availability": "unavailable",
-            "command": None,
-            "resultSchema": None,
+            "availability": "available",
+            "command": "kungfu work export <work-id> --repo <path> --json",
+            "resultSchema": PORTABLE_WORK_SCHEMA,
             "authority": "work-loop-portability",
-            "reason": "portable-work-loop-contract-not-admitted",
         },
         {
             "id": "import",
-            "availability": "unavailable",
-            "command": None,
-            "resultSchema": None,
+            "availability": "available",
+            "command": "kungfu work import --file <envelope.json> --repo <path> [--execute] --json",
+            "resultSchema": PORTABLE_IMPORT_SCHEMA,
             "authority": "work-loop-portability",
-            "reason": "portable-work-loop-contract-not-admitted",
         },
     ]
     return {

--- a/framework/core/src/python/kungfu/work_facade.py
+++ b/framework/core/src/python/kungfu/work_facade.py
@@ -255,7 +255,7 @@ def _validate_portable_work(value: Any) -> dict[str, Any]:
     for index, row in enumerate(_rows(item["runs"], "work.runs")):
         row = _exact_object(row, {"runId"}, f"work.runs[{index}]")
         runs.append({"runId": _text(row["runId"], f"work.runs[{index}].runId")})
-    normalized = {
+    normalized: dict[str, Any] = {
         "workId": work_id,
         "title": title,
         "kind": kind,

--- a/framework/core/tests/python/test_action_envelope.py
+++ b/framework/core/tests/python/test_action_envelope.py
@@ -166,6 +166,34 @@ def test_work_store_empty_runtime_does_not_open_a_missing_native_journal(
     assert load_work(str(tmp_path)) == {}
 
 
+def test_work_store_portable_import_replays_only_the_missing_prefix(tmp_path):
+    target = {
+        "workId": "w1234abcd",
+        "title": "portable",
+        "kind": "test",
+        "summary": "verified prefix",
+        "status": "waiting",
+        "nextAction": "resume",
+        "checkpoints": [{"note": "checkpoint"}],
+        "decisions": [{"decision": "continue", "decidedBy": "reviewer"}],
+        "validations": [{"result": "pass", "command": "check", "note": None}],
+        "artifacts": [{"ref": "commit:abc", "kind": "commit"}],
+        "runs": [{"runId": "run-1"}],
+    }
+    store = WorkStore(str(tmp_path))
+    assert store.import_portable_item(None, target) == 8
+    item = load_work(str(tmp_path))[target["workId"]]
+    assert item["title"] == "portable"
+    assert item["status"] == "waiting"
+    assert item["next_action"] == "resume"
+    assert item["checkpoints"][0]["note"] == "checkpoint"
+    assert item["decisions"][0]["decision"] == "continue"
+    assert item["validations"][0]["result"] == "pass"
+    assert item["artifacts"][0]["ref"] == "commit:abc"
+    assert item["runs"][0]["run_id"] == "run-1"
+    assert store.import_portable_item(item, target) == 0
+
+
 def test_rewind_replay_export_and_fsck_accept_binary_envelopes(tmp_path):
     runtime_dir = str(tmp_path / "runtime")
     run_id = "binary-rewind"

--- a/framework/core/tests/python/test_agent_work_state_contract.py
+++ b/framework/core/tests/python/test_agent_work_state_contract.py
@@ -220,6 +220,105 @@ def test_work_capabilities_are_read_only_and_match_agent_projection(
     assert not home.exists()
 
 
+def test_portable_work_cli_export_and_import_plan_remain_read_only(
+    tmp_path, monkeypatch
+):
+    import importlib
+
+    work_commands = importlib.import_module("kungfu.cli.commands.work")
+    cut_root = f"sha256:{'a' * 64}"
+    cut_projection = {
+        "status": "current",
+        "current": {
+            "cutRoot": cut_root,
+            "parentCutRoots": [],
+            "sourceRoot": f"sha256:{'b' * 64}",
+            "atlasRoot": f"sha256:{'c' * 64}",
+            "episodeRoots": [],
+            "manifest": ".kungfu/project-cuts/current/manifest.json",
+            "receipt": ".kungfu/project-cuts/current/receipt.json",
+            "receiptValid": True,
+            "publicationCommit": "1" * 40,
+        },
+    }
+    item = {
+        "work_id": "w1234abcd",
+        "title": "portable",
+        "kind": "test",
+        "summary": None,
+        "status": "active",
+        "next_action": None,
+        "checkpoints": [],
+        "decisions": [],
+        "validations": [],
+        "artifacts": [],
+        "runs": [],
+    }
+    monkeypatch.setattr(
+        work_commands, "inspect_project_cut", lambda _repo: cut_projection
+    )
+    monkeypatch.setattr(work_commands, "_load", lambda _ctx: {item["work_id"]: item})
+    home = tmp_path / "home"
+    runner = CliRunner()
+    exported = runner.invoke(
+        kfc,
+        [
+            "--home",
+            str(home),
+            "work",
+            "export",
+            item["work_id"],
+            "--repo",
+            str(tmp_path),
+            "--json",
+        ],
+    )
+    assert exported.exit_code == 0, exported.output
+    envelope = json.loads(exported.output)
+    assert envelope["projectCut"]["cutRoot"] == cut_root
+
+    envelope_path = tmp_path / "portable-work.json"
+    envelope_path.write_text(json.dumps(envelope), encoding="utf-8")
+    monkeypatch.setattr(work_commands, "_load", lambda _ctx: {})
+    planned = runner.invoke(
+        kfc,
+        [
+            "--home",
+            str(home),
+            "work",
+            "import",
+            "--file",
+            str(envelope_path),
+            "--repo",
+            str(tmp_path),
+            "--json",
+        ],
+    )
+    assert planned.exit_code == 0, planned.output
+    assert json.loads(planned.output)["status"] == "plan"
+    assert not home.exists()
+
+    oversized_path = tmp_path / "oversized-work.json"
+    oversized_path.write_bytes(b"x" * (4 * 1024 * 1024 + 1))
+    oversized = runner.invoke(
+        kfc,
+        [
+            "--home",
+            str(home),
+            "work",
+            "import",
+            "--file",
+            str(oversized_path),
+            "--repo",
+            str(tmp_path),
+            "--json",
+        ],
+    )
+    assert oversized.exit_code != 0
+    assert "portable envelope exceeds 4 MiB" in oversized.output
+    assert not home.exists()
+
+
 def test_agent_work_model_closes_the_kfd3_runtime_interface(tmp_path):
     result = CliRunner().invoke(
         kfc,

--- a/framework/core/tests/python/test_work_facade.py
+++ b/framework/core/tests/python/test_work_facade.py
@@ -1,10 +1,19 @@
 #  SPDX-License-Identifier: Apache-2.0
 
+import hashlib
+import json
+
+import pytest
+
 from kungfu.work_facade import (
     READ_ONLY_FACADE_ACTIONS,
+    WorkPortabilityError,
+    export_portable_work,
     inspect_work,
     plan_completion,
     plan_managed_run_link,
+    plan_portable_import,
+    portable_import_delta,
     plan_settlement,
     recover_work,
     work_loop_capabilities,
@@ -12,6 +21,7 @@ from kungfu.work_facade import (
 
 
 ROOT = f"sha256:{'f' * 64}"
+CUT_ROOT = f"sha256:{'a' * 64}"
 
 
 def cut(status="current", confidence="high", gaps=None):
@@ -26,6 +36,62 @@ def cut(status="current", confidence="high", gaps=None):
 
 def work(work_id, status, updated=1):
     return {"work_id": work_id, "status": status, "updated_time": updated}
+
+
+def portable_cut(cut_root=CUT_ROOT):
+    return {
+        "status": "current",
+        "confidence": "high",
+        "current": {
+            "cutRoot": cut_root,
+            "parentCutRoots": [f"sha256:{'b' * 64}"],
+            "sourceRoot": f"sha256:{'c' * 64}",
+            "atlasRoot": f"sha256:{'d' * 64}",
+            "episodeRoots": [f"sha256:{'e' * 64}"],
+            "manifest": ".kungfu/project-cuts/current/manifest.json",
+            "receipt": ".kungfu/project-cuts/current/receipt.json",
+            "receiptValid": True,
+            "publicationCommit": "1" * 40,
+        },
+        "gaps": [],
+        "authority": "git-tracked-project-cut",
+    }
+
+
+def portable_item():
+    return {
+        "work_id": "w1234abcd",
+        "title": "Portable work",
+        "kind": "task",
+        "summary": "Continue from an exact Cut",
+        "status": "waiting",
+        "next_action": "resume",
+        "created_time": 10,
+        "updated_time": 20,
+        "checkpoints": [{"time": 11, "note": "source-qualified"}],
+        "decisions": [{"time": 12, "decision": "continue", "decided_by": "review"}],
+        "validations": [
+            {"time": 13, "result": "pass", "command": "./shifu check", "note": None}
+        ],
+        "artifacts": [
+            {
+                "time": 14,
+                "ref": "https://github.com/kungfu-systems/kungfu/pull/1234",
+                "kind": "pull-request",
+            }
+        ],
+        "runs": [{"time": 15, "run_id": "run-1"}],
+        "history": [{"time": 10, "event": "created"}],
+    }
+
+
+def resign(envelope):
+    unsigned = {key: value for key, value in envelope.items() if key != "portableRoot"}
+    encoded = json.dumps(
+        unsigned, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+    ).encode("utf-8")
+    envelope["portableRoot"] = f"sha256:{hashlib.sha256(encoded).hexdigest()}"
+    return envelope
 
 
 def test_simple_session_selects_exactly_one_open_work():
@@ -108,6 +174,8 @@ def test_only_facade_plans_bypass_legacy_runtime_initialization():
         "recover",
         "complete",
         "settle",
+        "export",
+        "import",
     }
     assert "create" not in READ_ONLY_FACADE_ACTIONS
     assert "checkpoint" not in READ_ONLY_FACADE_ACTIONS
@@ -131,9 +199,143 @@ def test_work_loop_capabilities_are_complete_and_fail_visible():
     assert operations["complete"]["availability"] == "plan-only"
     assert operations["begin"]["availability"] == "unavailable"
     assert operations["begin"]["command"] is None
+    assert operations["export"]["availability"] == "available"
+    assert operations["import"]["availability"] == "available"
     assert payload["surfaces"]["cli"]["availability"] == "available"
     assert payload["surfaces"]["agent"]["availability"] == "available"
     assert payload["surfaces"]["gui"]["availability"] == "available"
     assert payload["surfaces"]["gui"]["projection"] == "work-dashboard"
     assert payload["surfaces"]["tui"]["availability"] == "available"
     assert payload["surfaces"]["tui"]["projection"] == "mission-control-profile-shell"
+
+
+def test_portable_export_is_byte_stable_and_excludes_local_time():
+    item = portable_item()
+    first = export_portable_work(
+        portable_cut(), {item["work_id"]: item}, item["work_id"]
+    )
+    second = export_portable_work(
+        portable_cut(), {item["work_id"]: item}, item["work_id"]
+    )
+    assert first == second
+    assert first["schema"] == "kungfu.work.portable-envelope/v1"
+    assert first["projectCut"]["cutRoot"] == CUT_ROOT
+    assert first["portableRoot"].startswith("sha256:")
+    encoded = json.dumps(first)
+    assert "created_time" not in encoded
+    assert "updated_time" not in encoded
+    assert first["work"]["checkpoints"] == [{"note": "source-qualified"}]
+
+
+def test_portable_import_is_verify_first_idempotent_and_prefix_recoverable():
+    item = portable_item()
+    envelope = export_portable_work(
+        portable_cut(), {item["work_id"]: item}, item["work_id"]
+    )
+    plan = plan_portable_import(portable_cut(), {}, envelope)
+    assert plan["status"] == "plan"
+    assert plan["writeOccurred"] is False
+    assert plan["actionTypes"] == [
+        "create",
+        "nextAction",
+        "checkpoints",
+        "decisions",
+        "validations",
+        "artifacts",
+        "runs",
+        "status",
+    ]
+    current = plan_portable_import(portable_cut(), {item["work_id"]: item}, envelope)
+    assert current["status"] == "current"
+    assert current["reused"] is True
+
+    partial = {
+        **portable_item(),
+        "status": "active",
+        "next_action": "resume",
+        "decisions": [],
+        "validations": [],
+        "artifacts": [],
+        "runs": [],
+    }
+    assert [
+        name for name, _value in portable_import_delta(partial, envelope["work"])
+    ] == [
+        "decisions",
+        "validations",
+        "artifacts",
+        "runs",
+        "status",
+    ]
+
+
+def test_portable_import_rejects_tamper_wrong_cut_and_divergence_without_a_plan():
+    item = portable_item()
+    envelope = export_portable_work(
+        portable_cut(), {item["work_id"]: item}, item["work_id"]
+    )
+    tampered = json.loads(json.dumps(envelope))
+    tampered["work"]["summary"] = "modified"
+    with pytest.raises(WorkPortabilityError, match="PORTABLE_ROOT_MISMATCH"):
+        plan_portable_import(portable_cut(), {}, tampered)
+    with pytest.raises(WorkPortabilityError, match="PORTABLE_PROJECT_CUT_MISMATCH"):
+        plan_portable_import(portable_cut(f"sha256:{'9' * 64}"), {}, envelope)
+    divergent = {**item, "title": "different"}
+    with pytest.raises(WorkPortabilityError, match="PORTABLE_WORK_CONFLICT"):
+        plan_portable_import(portable_cut(), {item["work_id"]: divergent}, envelope)
+
+
+def test_portable_import_rejects_self_signed_cut_shape_and_path_escape():
+    item = portable_item()
+    envelope = export_portable_work(
+        portable_cut(), {item["work_id"]: item}, item["work_id"]
+    )
+    extra_field = json.loads(json.dumps(envelope))
+    extra_field["projectCut"]["localHome"] = "/private/runtime"
+    with pytest.raises(WorkPortabilityError, match="PORTABLE_SHAPE_INVALID"):
+        plan_portable_import(portable_cut(), {}, resign(extra_field))
+
+    escaped_path = json.loads(json.dumps(envelope))
+    escaped_path["projectCut"]["receiptPath"] = ".kungfu/project-cuts/../secret"
+    with pytest.raises(WorkPortabilityError, match="PORTABLE_PROJECT_CUT_PATH_INVALID"):
+        plan_portable_import(portable_cut(), {}, resign(escaped_path))
+
+
+def test_portable_export_rejects_sensitive_or_unverified_material():
+    item = portable_item()
+    item["artifacts"][0]["ref"] = "https://example.invalid/file?token=secret"
+    with pytest.raises(WorkPortabilityError, match="PORTABLE_SENSITIVE_TEXT"):
+        export_portable_work(portable_cut(), {item["work_id"]: item}, item["work_id"])
+    for credential in (
+        f"ghp_{'A' * 36}",
+        f"github_pat_{'A' * 82}",
+        f"Bearer {'a' * 32}",
+    ):
+        credential_item = portable_item()
+        credential_item["summary"] = credential
+        with pytest.raises(WorkPortabilityError, match="PORTABLE_SENSITIVE_TEXT"):
+            export_portable_work(
+                portable_cut(),
+                {credential_item["work_id"]: credential_item},
+                credential_item["work_id"],
+            )
+    malformed = portable_item()
+    malformed["title"] = "https://[broken"
+    with pytest.raises(WorkPortabilityError, match="PORTABLE_TEXT_INVALID"):
+        export_portable_work(
+            portable_cut(), {malformed["work_id"]: malformed}, malformed["work_id"]
+        )
+    oversized = portable_item()
+    oversized["summary"] = "x" * 65537
+    with pytest.raises(WorkPortabilityError, match="PORTABLE_TEXT_TOO_LARGE"):
+        export_portable_work(
+            portable_cut(),
+            {oversized["work_id"]: oversized},
+            oversized["work_id"],
+        )
+    cut_projection = portable_cut()
+    cut_projection["current"]["receiptValid"] = False
+    with pytest.raises(WorkPortabilityError, match="PORTABLE_PROJECT_CUT_UNVERIFIED"):
+        export_portable_work(
+            cut_projection, {item["work_id"]: portable_item()}, item["work_id"]
+        )

--- a/framework/work-loop/project-cut-product-loop.release-contract.json
+++ b/framework/work-loop/project-cut-product-loop.release-contract.json
@@ -72,7 +72,7 @@
       "retained clean-install and cross-platform campaign is not available",
       "GUI and TUI Work projections lack retained three-platform parity evidence",
       "third-party Domain Profile qualification is not retained",
-      "executable begin, completion, settlement, export, and import remain incomplete"
+      "executable begin, completion, and settlement remain incomplete"
     ]
   }
 }

--- a/framework/work-loop/work-api.contract.json
+++ b/framework/work-loop/work-api.contract.json
@@ -116,6 +116,17 @@
     "ambiguity": "zero or multiple current Cuts or active Work items fail visibly",
     "hiddenState": false
   },
+  "portability": {
+    "envelopeSchema": "kungfu.work.portable-envelope/v1",
+    "importReceiptSchema": "kungfu.work.import-receipt/v1",
+    "root": "sha256 of canonical JSON before portableRoot",
+    "limits": {"envelopeBytes": 4194304, "textBytes": 65536, "rowsPerCollection": 10000},
+    "requires": ["one clean current Project Cut", "valid tracked Project Cut receipt", "canonical Work identity", "exact portable root"],
+    "excludes": ["local timestamps", "runtime paths", "credentials", "signed URLs", "raw Project Cut mutation authority"],
+    "import": "verify the current Cut and existing Work prefix before an explicit append",
+    "recovery": "an interrupted import may append only the missing verified prefix; divergent Work fails closed",
+    "nonClaims": ["portableRoot is an integrity root, not an origin signature", "matching a Project Cut does not prove the Work existed in that Cut", "the semantic projection does not preserve timestamps or cross-type event ordering", "--execute is the explicit local admission decision"]
+  },
   "safety": {
     "completeIsSettle": false,
     "selfReportIsProof": false,

--- a/scripts/check-work-facade-contract.test.mjs
+++ b/scripts/check-work-facade-contract.test.mjs
@@ -69,3 +69,24 @@ test('GUI and TUI project one read-only shared WorkLoop adapter', () => {
   assert.equal(contract.surfaces.tui.capability, 'workLoop');
   assert.equal(contract.surfaces.tui.status, 'available');
 });
+
+test('portable Work binds one current Cut and remains verify-first', () => {
+  assert.equal(
+    contract.portability.envelopeSchema,
+    'kungfu.work.portable-envelope/v1',
+  );
+  assert.equal(
+    contract.portability.importReceiptSchema,
+    'kungfu.work.import-receipt/v1',
+  );
+  assert.match(contract.portability.import, /verify the current Cut/u);
+  assert.match(contract.portability.recovery, /missing verified prefix/u);
+  assert.ok(contract.portability.excludes.includes('credentials'));
+  assert.ok(contract.portability.excludes.includes('local timestamps'));
+  assert.equal(contract.portability.limits.envelopeBytes, 4 * 1024 * 1024);
+  assert.ok(
+    contract.portability.nonClaims.includes(
+      'portableRoot is an integrity root, not an origin signature',
+    ),
+  );
+});

--- a/scripts/project-cut-product-loop-release.test.mjs
+++ b/scripts/project-cut-product-loop-release.test.mjs
@@ -120,6 +120,16 @@ test('release contract freezes the complete product-loop evidence boundary', () 
   assert.equal(contract.currentClaims.qualified, false);
   assert.deepEqual(contract.requiredSurfaces, ['cli', 'agent', 'gui', 'tui']);
   assert.ok(contract.requiredScenarios.includes('third-party-domain-profile'));
+  assert.ok(
+    contract.currentClaims.blockers.includes(
+      'executable begin, completion, and settlement remain incomplete',
+    ),
+  );
+  assert.ok(
+    contract.currentClaims.blockers.every(
+      (blocker) => !/\b(?:export|import)\b/u.test(blocker),
+    ),
+  );
 });
 
 test('complete synthetic evidence exercises the verifier without claiming qualification', () => {


### PR DESCRIPTION
## Summary

Make one Work item portable across a clean runtime or Agent context while binding it to the exact tracked current Project Cut.

Export emits a byte-stable semantic envelope without machine-local timestamps. Import is verify-first and dry-run by default; only an explicit --execute appends a verified missing prefix. Divergent Work, a wrong Cut, modified roots, path escape, oversized input, signed URLs, and high-confidence credential material fail before any append.

## Related issue

Atlas goal 2026-07-22-kungfu-project-cut-product-loop.

## Changes

- add kungfu work export/import and expose both through the shared Work capability manifest
- bind portable Work to exact Project Cut roots, receipt paths, and publication commit
- preserve Work semantics while explicitly excluding timestamps and cross-type event ordering
- support idempotent exact replay and interrupted-prefix recovery through the existing Work journal
- reject divergent state, tamper, path escape, oversized rows/text/envelopes, signed URLs, labeled secrets, private keys, AWS keys, GitHub/GitLab/Slack/OpenAI-style credentials, and Bearer credentials
- update KFD/Agent/SDK projections and the Work API/ADR contracts
- remove the stale release blocker that claimed export/import were still incomplete while retaining begin/completion/settlement blockers

## Verification

- source/final-base range-diff: exact; patch-id 0bea6ee941b87cb418172fa3c26c30de7b78c7f6
- ./shifu test:work-facade — 15 Node tests and 20 Python tests passed
- ./shifu check — exit 0; changed-scope gate passed on 716d0db01784
- fresh-home dogfood — plan made no target directory; execute restored create/checkpoint/status; exact replay reused without writes
- staged pre-commit gates — passed, including ADR/docs, invariants, schema authority, carrier/action-envelope, and Gate contracts

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "stage-ready",
  "adrs": ["KF-ADR-019f87e8-6b8b-735c-b036-fa42d7cee8cf"],
  "summary": "Deliver Project Cut-bound portable Work export/import with verify-first explicit admission and fail-closed recovery.",
  "verification": ["Work facade contract tests", "fresh-home portability dogfood", "changed-scope gate", "source/final-base range-diff and patch-id"]
}
-->

## Governance risk check

Does this PR touch any of these boundaries?

- [x] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

This PR transports semantic Work evidence but does not transport source bytes, mint Project Cut authority, authenticate origin, register the pending release Gate, or claim retained product-loop qualification.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated because the public Work surface and release boundary changed