### PR TITLE
fix(shifu): forward cached Windows launcher arguments

### DIFF
--- a/scripts/check-shifu-entry-contract.test.mjs
+++ b/scripts/check-shifu-entry-contract.test.mjs
@@ -168,11 +168,23 @@ test('Windows freshly resolved launchers dispatch outside parsed build blocks', 
   const windows = fs.readFileSync(path.join(ROOT, 'shifu.cmd'), 'utf8');
   assert.match(
     windows,
+    /set "_KFC_RESOLVED_BIN=%SHIFU_BIN%"\s+goto runresolved/u,
+  );
+  assert.match(
+    windows,
     /set "_KFC_RESOLVED_BIN=%_KFC_DEVBIN%"\s+goto runresolved/u,
   );
   assert.ok(
-    windows.match(/set "_KFC_RESOLVED_BIN=%_KFC_BIN%"\s+goto runresolved/gu)
+    windows.match(/set "_KFC_RESOLVED_BIN=%_KFC_DEVBIN%"\s+goto runresolved/gu)
       ?.length >= 2,
+  );
+  assert.ok(
+    windows.match(/set "_KFC_RESOLVED_BIN=%_KFC_BIN%"\s+goto runresolved/gu)
+      ?.length >= 3,
+  );
+  assert.doesNotMatch(
+    windows,
+    /^\s+"%(?:SHIFU_BIN|_KFC_DEVBIN|_KFC_BIN)%" %\*/gmu,
   );
   assert.match(
     windows,

--- a/scripts/run-shifu-lifecycle.test.mjs
+++ b/scripts/run-shifu-lifecycle.test.mjs
@@ -174,7 +174,7 @@ test(
 );
 
 test(
-  'Windows cold source launcher forwards the original lifecycle arguments',
+  'Windows cold, warm, and explicit source launchers forward lifecycle arguments',
   { skip: process.platform !== 'win32' },
   (t) => {
     const cache = fs.mkdtempSync(
@@ -184,10 +184,8 @@ test(
     const lifecycle = fileURLToPath(
       new URL('./run-shifu-lifecycle.mjs', import.meta.url),
     );
-    const result = spawnSync(
-      process.execPath,
-      [lifecycle, 'direct', 'cache', 'schema', 'profile'],
-      {
+    const invoke = (args, extraEnv = {}) =>
+      spawnSync(process.execPath, [lifecycle, ...args], {
         cwd: process.cwd(),
         encoding: 'utf8',
         env: {
@@ -195,14 +193,36 @@ test(
           XDG_CACHE_HOME: cache,
           SHIFU_BIN: '',
           SHIFU_NATIVE: '1',
+          ...extraEnv,
         },
         windowsHide: true,
-      },
+      });
+    const assertProfile = (result) => {
+      assert.equal(result.status, 0, result.stderr || result.error?.message);
+      assert.equal(
+        JSON.parse(result.stdout).$id,
+        'https://libkungfu.dev/schemas/shifu/cache-profile-v1.schema.json',
+      );
+    };
+
+    assertProfile(invoke(['direct', 'cache', 'schema', 'profile']));
+    assertProfile(invoke(['direct', 'cache', 'schema', 'profile']));
+
+    const slotRoot = path.join(cache, 'kungfu', 'shifu');
+    const sourceBinary = fs
+      .readdirSync(slotRoot, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory() && entry.name !== 'cargo-target')
+      .map((entry) => path.join(slotRoot, entry.name, 'shifu.exe'))
+      .find((candidate) => fs.existsSync(candidate));
+    assert.ok(
+      sourceBinary,
+      'cold source launcher did not publish a cache slot',
     );
-    assert.equal(result.status, 0, result.stderr || result.error?.message);
-    assert.equal(
-      JSON.parse(result.stdout).$id,
-      'https://libkungfu.dev/schemas/shifu/cache-profile-v1.schema.json',
+    assertProfile(
+      invoke(['direct', 'cache', 'schema', 'profile'], {
+        SHIFU_BIN: sourceBinary,
+      }),
     );
+    assertProfile(invoke(['cache-apply', 'cache', 'schema', 'profile']));
   },
 );

--- a/scripts/run-shifu-lifecycle.test.mjs
+++ b/scripts/run-shifu-lifecycle.test.mjs
@@ -184,14 +184,26 @@ test(
     const lifecycle = fileURLToPath(
       new URL('./run-shifu-lifecycle.mjs', import.meta.url),
     );
+    const isolatedEnv = Object.fromEntries(
+      Object.entries(process.env).filter(
+        ([name]) =>
+          ![
+            'SHIFU_BIN',
+            'SHIFU_CACHE_ACTIVE',
+            'SHIFU_ENTRYPOINT',
+            'SHIFU_FROM_SHIM',
+            'SHIFU_NATIVE',
+            'XDG_CACHE_HOME',
+          ].includes(name.toUpperCase()),
+      ),
+    );
     const invoke = (args, extraEnv = {}) =>
       spawnSync(process.execPath, [lifecycle, ...args], {
         cwd: process.cwd(),
         encoding: 'utf8',
         env: {
-          ...process.env,
+          ...isolatedEnv,
           XDG_CACHE_HOME: cache,
-          SHIFU_BIN: '',
           SHIFU_NATIVE: '1',
           ...extraEnv,
         },
@@ -205,7 +217,9 @@ test(
       );
     };
 
-    assertProfile(invoke(['direct', 'cache', 'schema', 'profile']));
+    const cold = invoke(['direct', 'cache', 'schema', 'profile']);
+    assertProfile(cold);
+    assert.match(cold.stderr, /building launcher from source/u);
     assertProfile(invoke(['direct', 'cache', 'schema', 'profile']));
 
     const slotRoot = path.join(cache, 'kungfu', 'shifu');

--- a/scripts/run-shifu-lifecycle.test.mjs
+++ b/scripts/run-shifu-lifecycle.test.mjs
@@ -194,6 +194,7 @@ test(
             'SHIFU_FROM_SHIM',
             'SHIFU_NATIVE',
             'XDG_CACHE_HOME',
+            'XDG_CONFIG_HOME',
           ].includes(name.toUpperCase()),
       ),
     );
@@ -204,6 +205,7 @@ test(
         env: {
           ...isolatedEnv,
           XDG_CACHE_HOME: cache,
+          XDG_CONFIG_HOME: path.join(cache, 'config'),
           SHIFU_NATIVE: '1',
           ...extraEnv,
         },

--- a/scripts/run-shifu-lifecycle.test.mjs
+++ b/scripts/run-shifu-lifecycle.test.mjs
@@ -223,7 +223,7 @@ test(
       ([name]) => name.toUpperCase() === 'SHIFU_BIN',
     )?.[1];
     const workspaceBinary = path.join(
-      ROOT,
+      process.cwd(),
       'crates',
       'target',
       'release',

--- a/scripts/run-shifu-lifecycle.test.mjs
+++ b/scripts/run-shifu-lifecycle.test.mjs
@@ -174,7 +174,7 @@ test(
 );
 
 test(
-  'Windows cold, warm, and explicit source launchers forward lifecycle arguments',
+  'Windows explicit launcher survives direct and cache-applied lifecycle re-entry',
   { skip: process.platform !== 'win32' },
   (t) => {
     const cache = fs.mkdtempSync(
@@ -219,26 +219,33 @@ test(
       );
     };
 
-    const cold = invoke(['direct', 'cache', 'schema', 'profile']);
-    assertProfile(cold);
-    assert.match(cold.stderr, /building launcher from source/u);
-    assertProfile(invoke(['direct', 'cache', 'schema', 'profile']));
-
-    const slotRoot = path.join(cache, 'kungfu', 'shifu');
-    const sourceBinary = fs
-      .readdirSync(slotRoot, { withFileTypes: true })
-      .filter((entry) => entry.isDirectory() && entry.name !== 'cargo-target')
-      .map((entry) => path.join(slotRoot, entry.name, 'shifu.exe'))
-      .find((candidate) => fs.existsSync(candidate));
+    const inheritedBinary = Object.entries(process.env).find(
+      ([name]) => name.toUpperCase() === 'SHIFU_BIN',
+    )?.[1];
+    const workspaceBinary = path.join(
+      ROOT,
+      'crates',
+      'target',
+      'release',
+      'shifu.exe',
+    );
+    const sourceBinary =
+      inheritedBinary && fs.existsSync(inheritedBinary)
+        ? inheritedBinary
+        : workspaceBinary;
     assert.ok(
-      sourceBinary,
-      'cold source launcher did not publish a cache slot',
+      fs.existsSync(sourceBinary),
+      'Windows lifecycle test needs the launcher built by shifu.workspace',
     );
     assertProfile(
       invoke(['direct', 'cache', 'schema', 'profile'], {
         SHIFU_BIN: sourceBinary,
       }),
     );
-    assertProfile(invoke(['cache-apply', 'cache', 'schema', 'profile']));
+    assertProfile(
+      invoke(['cache-apply', 'cache', 'schema', 'profile'], {
+        SHIFU_BIN: sourceBinary,
+      }),
+    );
   },
 );

--- a/shifu.cmd
+++ b/shifu.cmd
@@ -278,8 +278,8 @@ rem -- Native launcher resolution ----------------------------------------------
 if "%SHIFU_NATIVE%"=="0" goto inscript
 
 if defined SHIFU_BIN if exist "%SHIFU_BIN%" (
-  "%SHIFU_BIN%" %*
-  exit /b !errorlevel!
+  set "_KFC_RESOLVED_BIN=%SHIFU_BIN%"
+  goto runresolved
 )
 
 set "_KFC_VER="
@@ -312,8 +312,8 @@ set "_KFC_DEVDIR=%_KFC_CACHE%\kungfu\shifu\%_KFC_VER%-%_KFC_SRC%"
 set "_KFC_DEVBIN=%_KFC_DEVDIR%\shifu.exe"
 if not defined _KFC_DIRTY if exist "%_KFC_DEVBIN%" (
   set "SHIFU_BIN=%_KFC_DEVBIN%"
-  "%_KFC_DEVBIN%" %*
-  exit /b !errorlevel!
+  set "_KFC_RESOLVED_BIN=%_KFC_DEVBIN%"
+  goto runresolved
 )
 rem Build with an out-of-repo target dir (keyed per checkout) so read-only
 rem checkouts build too.
@@ -374,8 +374,8 @@ echo shifu: source build failed; falling back to the release-pinned launcher 1>&
 
 :pinslot
 if exist "%_KFC_BIN%" (
-  "%_KFC_BIN%" %*
-  exit /b !errorlevel!
+  set "_KFC_RESOLVED_BIN=%_KFC_BIN%"
+  goto runresolved
 )
 
 rem Machines with both prerequisites keep the proven in-script path below;


### PR DESCRIPTION
## Summary

Route every resolved Windows Shifu launcher through the top-level batch dispatcher, including explicit `SHIFU_BIN`, warm source-cache, and release-pin hits.

## Diagnosis

Alpha promotion Build run 29935225064 proved the cold source build completed, but cache-applied lifecycle re-entry inherited `SHIFU_BIN` and hit a remaining direct invocation inside a parsed batch block. The nested task again returned 0 without executing, leaving only one artifact instead of the required eight.

## Changes

- route explicit `SHIFU_BIN`, warm source-cache, and release-pin hits through `:runresolved`
- statically reject direct native launcher calls inside parsed batch blocks
- extend the Windows live test across cold, warm, explicit override, and cache-apply re-entry paths

## Verification

- combined entry/lifecycle tests: 25 pass, 2 Windows-only skip on macOS
- `./shifu check:entry-contract`
- full staged repository gate, docs gate, Biome formatting, and DCO: pass

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Repair the remaining Windows cached-launcher argument-forwarding defect without changing any ADR projection."
}
-->
