### PR TITLE
ci: stage dev qualification in merge queue

### DIFF
--- a/.github/workflows/affected-native-pr.yml
+++ b/.github/workflows/affected-native-pr.yml
@@ -3,9 +3,6 @@
 name: Core affected native
 
 on:
-  push:
-    branches:
-      - dev/v*/v*
   pull_request:
     branches:
       - dev/v*/v*
@@ -15,15 +12,141 @@ on:
 permissions:
   actions: read
   contents: read
+  pull-requests: read
 
 jobs:
+  dco:
+    name: Candidate DCO
+    if: ${{ github.event_name == 'pull_request' }}
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Check commit sign-offs
+        env:
+          EXPECTED_EVENT_NAME: pull_request
+        run: |
+          set -euo pipefail
+          if [ "$GITHUB_EVENT_NAME" != "$EXPECTED_EVENT_NAME" ]; then
+            echo "DCO admission only accepts pull_request events." >&2
+            exit 1
+          fi
+          BASE_SHA="$(jq -r '.pull_request.base.sha' "$GITHUB_EVENT_PATH")"
+          HEAD_SHA="$(jq -r '.pull_request.head.sha' "$GITHUB_EVENT_PATH")"
+          missing=0
+          commits="$(git rev-list "${BASE_SHA}..${HEAD_SHA}")"
+          if [ -z "${commits}" ]; then
+            echo "No commits to check."
+            exit 0
+          fi
+          for commit in ${commits}; do
+            subject="$(git log -1 --format=%s "${commit}")"
+            if git log -1 --format=%B "${commit}" | grep -Eiq '^Signed-off-by: .+ <[^<>[:space:]]+@[^<>[:space:]]+>$'; then
+              continue
+            fi
+            parents="$(git log -1 --format=%P "${commit}")"
+            parent_count="$(wc -w <<< "${parents}" | tr -d ' ')"
+            committer="$(git log -1 --format='%cn <%ce>' "${commit}")"
+            if [ "${parent_count}" -eq 2 ] && \
+              [ "${committer}" = "GitHub <noreply@github.com>" ] && \
+              grep -Eq '^Merge pull request #[0-9]+ from kungfu-systems/[A-Za-z0-9._/-]+$' <<< "${subject}"; then
+              continue
+            fi
+            echo "::error title=Missing DCO sign-off::${commit} ${subject}"
+            missing=1
+          done
+          if [ "${missing}" -ne 0 ]; then
+            echo "One or more commits are missing a DCO Signed-off-by line."
+            exit 1
+          fi
+          echo "All commits include DCO sign-offs."
+
+  source_acceptance:
+    name: Candidate source acceptance
+    uses: kungfu-systems/buildchain/.github/workflows/check.yml@ec48c0b311212c5f3a591e0284da6e85a9fdded5 # v2.13.0
+    with:
+      buildchain-ref: v2
+      mode: source
+      upload-artifacts: true
+
+  candidate_preflight:
+    name: Candidate governance preflight / linux
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    outputs:
+      native-required: ${{ steps.plan.outputs.native-required }}
+      sdk-required: ${{ steps.plan.outputs.sdk-required }}
+      shifu-required: ${{ steps.plan.outputs.shifu-required }}
+      kfd-required: ${{ steps.plan.outputs.kfd-required }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Validate .buildchain/buildchain.toml
+        uses: kungfu-systems/buildchain/actions/validate-config@v2
+        with:
+          require-version-state: "true"
+          require-lifecycle-stages: "install,check,build,verify"
+      - name: Verify ADR delivery intent
+        run: ./shifu gate run governance.adr-delivery
+      - name: Rehearse alpha and stable promotion contracts
+        run: ./shifu gate run governance.promotion-rehearsal
+      - name: Plan exact dev candidate qualification
+        id: plan
+        shell: bash
+        run: |
+          set -euo pipefail
+          case "$GITHUB_EVENT_NAME" in
+            pull_request)
+              base_sha="$(jq -r '.pull_request.base.sha' "$GITHUB_EVENT_PATH")"
+              event_head_sha="$(jq -r '.pull_request.head.sha' "$GITHUB_EVENT_PATH")"
+              ;;
+            merge_group)
+              base_sha="$(jq -r '.merge_group.base_sha' "$GITHUB_EVENT_PATH")"
+              event_head_sha="$(jq -r '.merge_group.head_sha' "$GITHUB_EVENT_PATH")"
+              ;;
+            *)
+              echo "unsupported event: $GITHUB_EVENT_NAME" >&2
+              exit 1
+              ;;
+          esac
+          head_sha="$(git rev-parse HEAD)"
+          git merge-base --is-ancestor "$event_head_sha" "$head_sha"
+          mkdir -p product/qualification/dev-candidate
+          export GITHUB_BASE_SHA="$base_sha"
+          export GITHUB_HEAD_SHA="$head_sha"
+          # shifu-entry-contract: allow build-free candidate planning before Gate dependencies are runnable
+          node scripts/run-core-affected-native.mjs \
+            --plan-out product/qualification/dev-candidate/plan.json \
+            --json
+          plan=product/qualification/dev-candidate/plan.json
+          native_required=false
+          if [ "$(jq '.closureComponents | length' "$plan")" -gt 0 ]; then
+            native_required=true
+          fi
+          {
+            echo "native-required=${native_required}"
+            echo "sdk-required=$(jq -r '.sdkQualification.required' "$plan")"
+            echo "shifu-required=$(jq -r '.devQueueQualification.shifuWorkspace.required' "$plan")"
+            echo "kfd-required=$(jq -r '.devQueueQualification.kfdVerifier.required' "$plan")"
+          } >> "$GITHUB_OUTPUT"
+      - name: Upload candidate preflight plan
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: dev-candidate-plan-${{ github.sha }}
+          path: product/qualification/dev-candidate/plan.json
+          if-no-files-found: error
+          retention-days: 14
+
   proof_probe:
     name: affected-native proof probe / linux
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     outputs:
       reuse: ${{ steps.decision.outputs.reuse }}
-      producer-run-id: ${{ steps.lookup.outputs.run-id }}
       artifact-name: ${{ steps.descriptor.outputs.artifact-name }}
       proof-id: ${{ steps.descriptor.outputs.proof-id }}
     steps:
@@ -39,10 +162,6 @@ jobs:
         run: |
           set -euo pipefail
           case "$GITHUB_EVENT_NAME" in
-            push)
-              base_sha="$(jq -r '.before' "$GITHUB_EVENT_PATH")"
-              event_head_sha="$(jq -r '.after' "$GITHUB_EVENT_PATH")"
-              ;;
             pull_request)
               base_sha="$(jq -r '.pull_request.base.sha' "$GITHUB_EVENT_PATH")"
               event_head_sha="$(jq -r '.pull_request.head.sha' "$GITHUB_EVENT_PATH")"
@@ -83,60 +202,29 @@ jobs:
             --plan product/qualification/affected-native/proof-probe/plan.json \
             --output product/qualification/affected-native/proof-probe/descriptor.json \
             --github-output "$GITHUB_OUTPUT"
-      - name: Locate one trusted pull-request proof
-        id: lookup
-        if: ${{ github.event_name == 'merge_group' && steps.descriptor.outputs.native-required == 'true' }}
-        shell: bash
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          # shifu-entry-contract: allow read-only GitHub artifact lookup before Gate dependencies are runnable
-          node scripts/affected-native-proof.mjs lookup \
-            --descriptor product/qualification/affected-native/proof-probe/descriptor.json \
-            --api-url "$GITHUB_API_URL" \
-            --repository "$GITHUB_REPOSITORY" \
-            --github-output "$GITHUB_OUTPUT"
-      - name: Download candidate pull-request proof
-        id: download
-        if: ${{ steps.lookup.outputs.run-id != '' }}
-        continue-on-error: true
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
-        with:
-          name: ${{ steps.descriptor.outputs.artifact-name }}
-          path: product/qualification/affected-native/proof-candidate
-          github-token: ${{ github.token }}
-          run-id: ${{ steps.lookup.outputs.run-id }}
-      - name: Verify proof or select full-run fallback
+      - name: Select authoritative queue execution
         id: decision
         shell: bash
-        env:
-          CANDIDATE_RUN_ID: ${{ steps.lookup.outputs.run-id }}
-          DOWNLOAD_OUTCOME: ${{ steps.download.outcome }}
         run: |
           set -euo pipefail
-          reuse=false
-          if [ "$GITHUB_EVENT_NAME" = "merge_group" ] && \
-             [ -n "$CANDIDATE_RUN_ID" ] && \
-             [ "$DOWNLOAD_OUTCOME" = "success" ]; then
-            # shifu-entry-contract: allow fail-closed proof verification before Gate dependencies are runnable
-            if node scripts/affected-native-proof.mjs verify \
-              --descriptor product/qualification/affected-native/proof-probe/descriptor.json \
-              --bundle product/qualification/affected-native/proof-candidate \
-              --repository "$GITHUB_REPOSITORY" \
-              --producer-run-id "$CANDIDATE_RUN_ID"; then
-              reuse=true
-            else
-              echo "Candidate proof did not verify; running the full native gate."
-            fi
-          fi
-          echo "reuse=${reuse}" >> "$GITHUB_OUTPUT"
-          echo "Affected-native proof reuse: ${reuse}"
+          echo "reuse=false" >> "$GITHUB_OUTPUT"
+          echo "Merge Queue is the authoritative producer; PR proof reuse is disabled."
 
   affected_native_shards:
     name: affected-native shard ${{ matrix.partition }} of 2 / linux
-    needs: proof_probe
-    if: ${{ needs.proof_probe.outputs.reuse != 'true' }}
+    needs:
+      - source_acceptance
+      - candidate_preflight
+      - proof_probe
+    if: >-
+      ${{
+        github.event_name == 'merge_group' &&
+        needs.source_acceptance.result == 'success' &&
+        needs.candidate_preflight.result == 'success' &&
+        needs.proof_probe.result == 'success' &&
+        (needs.candidate_preflight.outputs.native-required == 'true' ||
+         needs.candidate_preflight.outputs.sdk-required == 'true')
+      }}
     runs-on: ubuntu-24.04
     timeout-minutes: 75
     strategy:
@@ -162,10 +250,6 @@ jobs:
         run: |
           set -euo pipefail
           case "$GITHUB_EVENT_NAME" in
-            push)
-              base_sha="$(jq -r '.before' "$GITHUB_EVENT_PATH")"
-              event_head_sha="$(jq -r '.after' "$GITHUB_EVENT_PATH")"
-              ;;
             pull_request)
               base_sha="$(jq -r '.pull_request.base.sha' "$GITHUB_EVENT_PATH")"
               event_head_sha="$(jq -r '.pull_request.head.sha' "$GITHUB_EVENT_PATH")"
@@ -391,12 +475,83 @@ jobs:
           if-no-files-found: warn
           retention-days: 14
 
+  shifu_workspace:
+    name: Shifu workspace / ${{ matrix.os }}
+    needs:
+      - source_acceptance
+      - candidate_preflight
+    if: >-
+      ${{
+        github.event_name == 'merge_group' &&
+        needs.source_acceptance.result == 'success' &&
+        needs.candidate_preflight.result == 'success' &&
+        needs.candidate_preflight.outputs.shifu-required == 'true'
+      }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-14, ubuntu-22.04, windows-2022]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v6.4.0
+        with:
+          node-version: 24
+      - name: Run Shifu workspace Gate (POSIX)
+        if: runner.os != 'Windows'
+        run: ./shifu gate run shifu.workspace --capability rust
+      - name: Run Shifu workspace Gate (Windows)
+        if: runner.os == 'Windows'
+        run: .\shifu.cmd gate run shifu.workspace --capability rust
+      - name: Verify Xinfa producer contracts (POSIX)
+        if: runner.os != 'Windows'
+        run: ./shifu xinfa:check
+      - name: Verify Xinfa producer contracts (Windows)
+        if: runner.os == 'Windows'
+        run: .\shifu.cmd xinfa:check
+      - name: Qualify repository context quality (POSIX)
+        if: runner.os != 'Windows'
+        run: ./shifu xinfa:quality --check
+      - name: Qualify repository context quality (Windows)
+        if: runner.os == 'Windows'
+        run: .\shifu.cmd xinfa:quality --check
+
+  kfd_verifier:
+    name: KFD verifier / linux
+    needs:
+      - source_acceptance
+      - candidate_preflight
+    if: >-
+      ${{
+        github.event_name == 'merge_group' &&
+        needs.source_acceptance.result == 'success' &&
+        needs.candidate_preflight.result == 'success' &&
+        needs.candidate_preflight.outputs.kfd-required == 'true'
+      }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "24"
+      - name: Install frozen workspace
+        run: ./shifu install --frozen-lockfile
+      - name: Verify product-owned fixtures
+        run: ./shifu kfd:verify-owned-fixtures
+
   affected-native:
     name: affected-native / linux
     if: ${{ always() }}
     needs:
+      - dco
+      - source_acceptance
+      - candidate_preflight
       - proof_probe
       - affected_native_shards
+      - shifu_workspace
+      - kfd_verifier
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
@@ -406,6 +561,59 @@ jobs:
       - uses: actions/setup-node@v6.4.0
         with:
           node-version: "24"
+      - name: Admit staged candidate dependency graph
+        shell: bash
+        env:
+          DCO_RESULT: ${{ needs.dco.result }}
+          SOURCE_RESULT: ${{ needs.source_acceptance.result }}
+          PREFLIGHT_RESULT: ${{ needs.candidate_preflight.result }}
+          PROBE_RESULT: ${{ needs.proof_probe.result }}
+          NATIVE_REQUIRED: ${{ needs.candidate_preflight.outputs.native-required }}
+          SDK_REQUIRED: ${{ needs.candidate_preflight.outputs.sdk-required }}
+          SHIFU_REQUIRED: ${{ needs.candidate_preflight.outputs.shifu-required }}
+          KFD_REQUIRED: ${{ needs.candidate_preflight.outputs.kfd-required }}
+          NATIVE_RESULT: ${{ needs.affected_native_shards.result }}
+          SHIFU_RESULT: ${{ needs.shifu_workspace.result }}
+          KFD_RESULT: ${{ needs.kfd_verifier.result }}
+        run: |
+          set -euo pipefail
+          require_result() {
+            label="$1"
+            expected="$2"
+            actual="$3"
+            if [ "$actual" != "$expected" ]; then
+              echo "$label must be $expected, got $actual" >&2
+              exit 1
+            fi
+          }
+          require_result "source acceptance" success "$SOURCE_RESULT"
+          require_result "candidate preflight" success "$PREFLIGHT_RESULT"
+          require_result "impact probe" success "$PROBE_RESULT"
+          if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+            require_result "PR DCO" success "$DCO_RESULT"
+            require_result "PR affected-native" skipped "$NATIVE_RESULT"
+            require_result "PR Shifu workspace" skipped "$SHIFU_RESULT"
+            require_result "PR KFD verifier" skipped "$KFD_RESULT"
+            echo "PR fast admission passed without compiler or installed-artifact work."
+            exit 0
+          fi
+          require_result "queue DCO" skipped "$DCO_RESULT"
+          require_optional_gate() {
+            label="$1"
+            required="$2"
+            actual="$3"
+            expected=skipped
+            if [ "$required" = "true" ]; then expected=success; fi
+            require_result "$label" "$expected" "$actual"
+          }
+          native_or_sdk=false
+          if [ "$NATIVE_REQUIRED" = "true" ] || [ "$SDK_REQUIRED" = "true" ]; then
+            native_or_sdk=true
+          fi
+          require_optional_gate "queue affected-native" "$native_or_sdk" "$NATIVE_RESULT"
+          require_optional_gate "queue Shifu workspace" "$SHIFU_REQUIRED" "$SHIFU_RESULT"
+          require_optional_gate "queue KFD verifier" "$KFD_REQUIRED" "$KFD_RESULT"
+          echo "Merge Queue staged qualification passed."
       - name: Recompute exact affected-native proof identity
         id: descriptor
         shell: bash
@@ -414,10 +622,6 @@ jobs:
         run: |
           set -euo pipefail
           case "$GITHUB_EVENT_NAME" in
-            push)
-              base_sha="$(jq -r '.before' "$GITHUB_EVENT_PATH")"
-              event_head_sha="$(jq -r '.after' "$GITHUB_EVENT_PATH")"
-              ;;
             pull_request)
               base_sha="$(jq -r '.pull_request.base.sha' "$GITHUB_EVENT_PATH")"
               event_head_sha="$(jq -r '.pull_request.head.sha' "$GITHUB_EVENT_PATH")"
@@ -446,38 +650,34 @@ jobs:
             --output product/qualification/affected-native/proof-admission/descriptor.json \
             --github-output "$GITHUB_OUTPUT"
           test "$PROBE_ARTIFACT_NAME" = "$(jq -r '.artifactName' product/qualification/affected-native/proof-admission/descriptor.json)"
-      - name: Download admitted pull-request proof
-        if: ${{ needs.proof_probe.outputs.reuse == 'true' }}
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
-        with:
-          name: ${{ needs.proof_probe.outputs.artifact-name }}
-          path: product/qualification/affected-native/proof-bundle
-          github-token: ${{ github.token }}
-          run-id: ${{ needs.proof_probe.outputs.producer-run-id }}
       - name: Download current partition evidence
-        if: ${{ needs.proof_probe.outputs.reuse != 'true' }}
+        if: >-
+          ${{
+            github.event_name == 'merge_group' &&
+            (needs.candidate_preflight.outputs.native-required == 'true' ||
+             needs.candidate_preflight.outputs.sdk-required == 'true')
+          }}
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           pattern: core-affected-native-${{ github.sha }}-partition-*-of-2
           path: product/qualification/affected-native/proof-input
-      - name: Admit reused proof or complete partition set
+      - name: Admit exact queue partition set
         id: admit
         shell: bash
         env:
           PARTITION_RESULT: ${{ needs.affected_native_shards.result }}
-          PRODUCER_RUN_ID: ${{ needs.proof_probe.outputs.producer-run-id }}
-          REUSE: ${{ needs.proof_probe.outputs.reuse }}
+          NATIVE_REQUIRED: ${{ needs.candidate_preflight.outputs.native-required }}
+          SDK_REQUIRED: ${{ needs.candidate_preflight.outputs.sdk-required }}
         run: |
           set -euo pipefail
           descriptor=product/qualification/affected-native/proof-admission/descriptor.json
-          if [ "$REUSE" = "true" ]; then
-            # shifu-entry-contract: allow fail-closed cross-run proof verification after exact source planning
-            node scripts/affected-native-proof.mjs verify \
-              --descriptor "$descriptor" \
-              --bundle product/qualification/affected-native/proof-bundle \
-              --repository "$GITHUB_REPOSITORY" \
-              --producer-run-id "$PRODUCER_RUN_ID"
-            echo "Reused exact pull-request affected-native proof."
+          if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+            echo "PR admission intentionally has no native proof."
+            echo "proof-created=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ "$NATIVE_REQUIRED" != "true" ] && [ "$SDK_REQUIRED" != "true" ]; then
+            echo "The source-impact plan explicitly requires no native or SDK qualification."
             echo "proof-created=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -494,21 +694,13 @@ jobs:
             --run-id "$GITHUB_RUN_ID" \
             --event "$GITHUB_EVENT_NAME" \
             --checkout-sha "$(git rev-parse HEAD)"
-          if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
-            # shifu-entry-contract: allow same-run proof verification before immutable artifact upload
-            node scripts/affected-native-proof.mjs verify \
-              --descriptor "$descriptor" \
-              --bundle product/qualification/affected-native/proof-bundle \
-              --repository "$GITHUB_REPOSITORY" \
-              --producer-run-id "$GITHUB_RUN_ID"
-          fi
           echo "proof-created=true" >> "$GITHUB_OUTPUT"
           echo "All affected-native partitions passed."
-      - name: Upload immutable pull-request proof
-        if: ${{ github.event_name == 'pull_request' && needs.proof_probe.outputs.reuse != 'true' && steps.admit.outputs.proof-created == 'true' }}
+      - name: Upload authoritative queue proof
+        if: ${{ steps.admit.outputs.proof-created == 'true' }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ${{ needs.proof_probe.outputs.artifact-name }}
           path: product/qualification/affected-native/proof-bundle
           if-no-files-found: error
-          retention-days: 1
+          retention-days: 14

--- a/.github/workflows/buildchain-validate.yml
+++ b/.github/workflows/buildchain-validate.yml
@@ -7,7 +7,6 @@ on:
   pull_request:
   push:
     branches:
-      - "dev/**"
       - "alpha/**"
       - "release/**"
 

--- a/.github/workflows/kfd-verifier-drift.yml
+++ b/.github/workflows/kfd-verifier-drift.yml
@@ -3,24 +3,7 @@
 name: KFD verifier drift
 
 on:
-  push:
-    branches:
-      - dev/v*/v*
-    paths:
-      - "crates/xinfa/**"
-      - "scripts/verify-kfd-owned-fixtures.mjs"
-      - "package.json"
-      - "pnpm-lock.yaml"
-      - ".github/workflows/kfd-verifier-drift.yml"
-  pull_request:
-    branches:
-      - dev/v*/v*
-    paths:
-      - "crates/xinfa/**"
-      - "scripts/verify-kfd-owned-fixtures.mjs"
-      - "package.json"
-      - "pnpm-lock.yaml"
-      - ".github/workflows/kfd-verifier-drift.yml"
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/shifu-ci.yml
+++ b/.github/workflows/shifu-ci.yml
@@ -10,7 +10,6 @@ name: shifu CI
 on:
   pull_request:
     branches:
-      - dev/v*/v*
       - alpha/v*/v*
       - release/v*/v*
     paths:

--- a/docs/adr/SHIFU-ADR-0004-gate-control-plane-contract.md
+++ b/docs/adr/SHIFU-ADR-0004-gate-control-plane-contract.md
@@ -189,15 +189,11 @@ profile runs cannot omit dependencies. Kungfu uses that rule to avoid repeating
 required Source Acceptance workflow. The first compiler-cold cohort completed
 the queue-inclusive aggregate in 480 seconds with both cold fallbacks qualified.
 
-The affected-native aggregate may now reuse one successful same-repository PR
-proof when the merge-group checkout has the exact same Git tree, base revision,
-semantic affected-native plan projection, partition contract, and Linux
-toolchain receipts. The queue still recomputes the descriptor and verifies the
-immutable proof before publishing the required context. Missing, ambiguous,
-expired, cross-fork, failed, or drifted evidence cannot pass the gate and falls
-back to the complete two-partition native run. This removes redundant queue
-execution without treating a cache hit, commit id, or earlier green conclusion
-as qualification evidence by itself.
+The earlier same-tree PR-proof reuse mechanism is now retired. Expensive native
+evidence is no longer produced on pull requests, so a merge group always runs
+the exact impact-selected candidate qualification after its fast preflight.
+This makes the synthetic merge-group source the single authority instead of
+asking PR evidence to survive a later queue ordering decision.
 
 The affected-native source plan also declares whether partition zero must run
 the installed four-language SDK wire qualification. Public ABI, schemas,
@@ -210,6 +206,17 @@ budget. Internal implementation changes retain their affected native closure
 without automatically rebuilding and repackaging all four SDK languages. The
 decision and reasons are part of the source-bound plan digest and therefore of
 the immutable proof identity.
+
+The dev candidate workflow now separates fast admission from authoritative
+candidate execution. Pull requests run only build-free source acceptance,
+governance preflight, and the exact source-impact plan. On `merge_group`, those
+source and governance jobs are hard dependencies of the affected-native
+partitions, the impact-selected three-platform Shifu matrix, and the
+impact-selected KFD verifier. Those independent jobs run in parallel, and one
+stable `affected-native / linux` aggregate validates every required or
+explicitly-not-required result. Candidate-equivalent dev push rebuilds are
+removed: a cold queue run is preferable to duplicated pre-queue and post-merge
+qualification.
 
 ## Consequences
 

--- a/docs/qualification/gates/release-and-promotion.md
+++ b/docs/qualification/gates/release-and-promotion.md
@@ -18,7 +18,7 @@ Each section is bound to the registry id by the catalog meta gate.
 - **Evidence:** unified Gate receipt; artifacts `product/release/qualification/adr-release-admissibility.json`.
 - **Diagnosis:** `./shifu gate explain governance.adr-delivery --profile <profile>`; reproduce with `./shifu gate run governance.adr-delivery` on a capable runner.
 - **Cost:** light; timeout 180 seconds.
-- **Current source:** .github/workflows/adr-release-gate.yml (adr-release; dev pull request); .github/workflows/build.yml (build; alpha or release pull request).
+- **Current source:** .github/workflows/affected-native-pr.yml (candidate_preflight; every dev pull request and merge-group candidate before any expensive queue job); .github/workflows/adr-release-gate.yml (adr-release; dev pull request); .github/workflows/build.yml (build; alpha or release pull request).
 - **Retirement:** remove only after every selecting profile and workflow binding is migrated or explicitly replaced, with the registry and matrix changed in the same review.
 <!-- /gate-doc:governance.adr-delivery -->
 
@@ -36,7 +36,7 @@ Each section is bound to the registry id by the catalog meta gate.
 - **Evidence:** unified Gate receipt; artifacts `product/release/qualification/release-promotion-rehearsal.json`.
 - **Diagnosis:** `./shifu gate explain governance.promotion-rehearsal --profile <profile>`; reproduce with `./shifu gate run governance.promotion-rehearsal` on a capable runner.
 - **Cost:** light; timeout 180 seconds.
-- **Current source:** .github/workflows/buildchain-validate.yml (promotion-rehearsal; pull request or channel push); .github/workflows/release-new-version.yml (promotion-contract; merged alpha or release pull request, or manual source-locked dry-run measurement).
+- **Current source:** .github/workflows/affected-native-pr.yml (candidate_preflight; every dev pull request and merge-group candidate before any expensive queue job); .github/workflows/buildchain-validate.yml (promotion-rehearsal; pull request or channel push); .github/workflows/release-new-version.yml (promotion-contract; merged alpha or release pull request, or manual source-locked dry-run measurement).
 - **Retirement:** remove only after every selecting profile and workflow binding is migrated or explicitly replaced, with the registry and matrix changed in the same review.
 <!-- /gate-doc:governance.promotion-rehearsal -->
 

--- a/docs/qualification/gates/source-and-governance.md
+++ b/docs/qualification/gates/source-and-governance.md
@@ -18,7 +18,7 @@ Each section is bound to the registry id by the catalog meta gate.
 - **Evidence:** unified Gate receipt; no separate artifact is currently required.
 - **Diagnosis:** `./shifu gate explain gate.catalog --profile <profile>`; reproduce with `./shifu gate run gate.catalog` on a capable runner.
 - **Cost:** light; timeout 120 seconds.
-- **Current source:** .github/workflows/source-acceptance.yml (source-acceptance; dev pull request); .github/workflows/dev-verify-patrol.yml (verify; daily or manual on dev); .github/workflows/build.yml (build; alpha or release pull request); .github/workflows/release-new-version.yml (promotion-contract; merged alpha or release pull request, or manual source-locked dry-run measurement).
+- **Current source:** .github/workflows/source-acceptance.yml (source-acceptance; dev pull request); .github/workflows/affected-native-pr.yml (source_acceptance; every dev pull request and merge-group candidate inside the staged required aggregate); .github/workflows/dev-verify-patrol.yml (verify; daily or manual on dev); .github/workflows/build.yml (build; alpha or release pull request); .github/workflows/release-new-version.yml (promotion-contract; merged alpha or release pull request, or manual source-locked dry-run measurement).
 - **Retirement:** remove only after every selecting profile and workflow binding is migrated or explicitly replaced, with the registry and matrix changed in the same review.
 <!-- /gate-doc:gate.catalog -->
 
@@ -36,7 +36,7 @@ Each section is bound to the registry id by the catalog meta gate.
 - **Evidence:** unified Gate receipt; no separate artifact is currently required.
 - **Diagnosis:** `./shifu gate explain governance.dco --profile <profile>`; reproduce with `./shifu gate run governance.dco` on a capable runner.
 - **Cost:** light; timeout 120 seconds.
-- **Current source:** .github/workflows/dco.yml (signoff; all pull requests).
+- **Current source:** .github/workflows/affected-native-pr.yml (dco; every dev pull request inside the staged required aggregate); .github/workflows/dco.yml (signoff; all pull requests).
 - **Retirement:** remove only after every selecting profile and workflow binding is migrated or explicitly replaced, with the registry and matrix changed in the same review.
 <!-- /gate-doc:governance.dco -->
 
@@ -54,7 +54,7 @@ Each section is bound to the registry id by the catalog meta gate.
 - **Evidence:** unified Gate receipt; no separate artifact is currently required.
 - **Diagnosis:** `./shifu gate explain governance.buildchain-config --profile <profile>`; reproduce with `./shifu gate run governance.buildchain-config` on a capable runner.
 - **Cost:** light; timeout 120 seconds.
-- **Current source:** .github/workflows/buildchain-validate.yml (validate; pull request or channel push); .github/workflows/release-new-version.yml (promote; merged alpha or release pull request, or manual source-locked dry-run measurement).
+- **Current source:** .github/workflows/affected-native-pr.yml (candidate_preflight; every dev pull request and merge-group candidate before any expensive queue job); .github/workflows/buildchain-validate.yml (validate; pull request or channel push); .github/workflows/release-new-version.yml (promote; merged alpha or release pull request, or manual source-locked dry-run measurement).
 - **Retirement:** remove only after every selecting profile and workflow binding is migrated or explicitly replaced, with the registry and matrix changed in the same review.
 <!-- /gate-doc:governance.buildchain-config -->
 
@@ -73,7 +73,7 @@ Each section is bound to the registry id by the catalog meta gate.
 - **Diagnosis:** `./shifu gate explain source.acceptance --profile <profile>`; reproduce with `./shifu gate run source.acceptance` on a capable runner.
 - **Cost:** light; timeout 1800 seconds. This budget covers cold shared-runner
   Project Cut composition while retaining a bounded failure signal.
-- **Current source:** .github/workflows/source-acceptance.yml (source-acceptance; dev pull request).
+- **Current source:** .github/workflows/source-acceptance.yml (source-acceptance; dev pull request); .github/workflows/affected-native-pr.yml (source_acceptance; every dev pull request and merge-group candidate inside the staged required aggregate).
 - **Retirement:** remove only after every selecting profile and workflow binding is migrated or explicitly replaced, with the registry and matrix changed in the same review.
 <!-- /gate-doc:source.acceptance -->
 
@@ -88,10 +88,11 @@ Each section is bound to the registry id by the catalog meta gate.
 - **Action:** `./shifu core:affected -- --execute`
 - **Dependencies:** `gate.catalog`, `source.acceptance`.
 - **Workflow execution:** the partition worker uses the explicit diagnostic
-  `--omit-dependency source.acceptance` form. The `dev-pr` matrix independently
-  requires `source.acceptance`, and its distinct source workflow binding is
-  checked alongside this exact invocation, so branch admission still requires
-  both Gates without rerunning the build-free closure inside every partition.
+  `--omit-dependency source.acceptance` form. The staged candidate workflow has
+  a distinct reusable source-acceptance job, and every expensive merge-group
+  job has an explicit `needs` edge to that job and the governance preflight.
+  The partition therefore does not rerun the build-free closure, while the
+  final required aggregate still fails closed if source admission did not pass.
 - **Platforms and runner:** linux; capabilities `native-toolchain`.
 - **Pass:** the resolver validates the authority, selects a supported minimal
   profile, and the selected configure/compile/link/CTest closure passes.
@@ -122,12 +123,11 @@ Each section is bound to the registry id by the catalog meta gate.
   C++ module dependency scanning because the current closure declares no module
   sources; this avoids uncached scan work without changing alpha/release build
   semantics. Contradictory or foreign-key evidence fails closed. Successful
-  native changes on `dev/v*/v*` also run this exact job after merge, placing a
-  compatible baseline in the base-branch cache scope. Pull-request and current
-  default-branch merge-group refs can restore that baseline while retaining
-  source-bound exact keys and always rerunning configure/build/CTest. PR-scoped
-  saves remain useful for same-PR reruns but are not treated as merge-queue
-  baselines.
+  queue candidates may restore a compatible base-branch baseline while
+  retaining source-bound exact keys and always rerunning configure/build/CTest.
+  The workflow does not repeat the candidate-equivalent native build on the
+  resulting dev push. A missing or expired cache therefore spends queue time
+  on the qualified cold path instead of manufacturing a post-merge duplicate.
 - **Cold-path partitioning:** the authoritative target and CTest lists are split
   deterministically across two GitHub-hosted Linux jobs. Each receipt binds its
   zero-based partition index, partition count, selected targets/tests, partition
@@ -144,12 +144,16 @@ Each section is bound to the registry id by the catalog meta gate.
   <base> --head <head> --json`; run mutation fixtures with `./shifu
   core:affected -- --self-test`.
 - **Cost:** heavy; timeout 1500 seconds.
-- **Current source:** .github/workflows/affected-native-pr.yml (affected_native_shards; two deterministic GitHub-hosted Linux partitions on every development pull request and merge group, plus post-merge dev pushes; the stable affected-native aggregator admits only the complete successful set, while outside-Core changes produce partition-bound tier-none receipts so the required check never deadlocks)
+- **Current source:** .github/workflows/affected-native-pr.yml (affected_native_shards; two deterministic GitHub-hosted Linux partitions only on an exact merge-group candidate after source and governance preflight; the stable affected-native aggregator reports fast PR admission and admits the complete impact-selected queue set)
 - **Source-first orchestration:** the workflow first runs the build-free source
   planner with `node scripts/run-core-affected-native.mjs --plan-out <path>
-  --json`. A non-empty, source-bound plan then enters the registered action; a
-  tier-none plan writes the same receipt directly without installing
-  Buildchain, Conan, or the workspace.
+  --json`. Pull requests stop after source/governance admission and this exact
+  impact plan. A merge group starts native/SDK, three-platform Shifu, and KFD
+  jobs in parallel only after both preflight jobs pass; every optional skip is
+  justified by a `required: false` decision retained in the plan. A non-empty,
+  source-bound native plan enters the registered action; a tier-none plan
+  writes the same receipt directly without installing Buildchain, Conan, or
+  the workspace.
 - **Retirement:** remove only with a replacement that consumes the same
   architecture authority and preserves changed-path completeness, raw native
   evidence and the alpha/release responsibility split.
@@ -241,6 +245,6 @@ Each section is bound to the registry id by the catalog meta gate.
 - **Evidence:** unified Gate receipt; no separate artifact is currently required.
 - **Diagnosis:** `./shifu gate explain shifu.workspace --profile <profile>`; reproduce with `./shifu gate run shifu.workspace` on a capable runner.
 - **Cost:** heavy; timeout 1800 seconds.
-- **Current source:** .github/workflows/shifu-ci.yml (check; channel pull request touching crates/**).
+- **Current source:** .github/workflows/shifu-ci.yml (check; alpha or release pull request touching the declared Shifu workspace paths); .github/workflows/affected-native-pr.yml (shifu_workspace; three GitHub-hosted platforms after merge-group preflight when the exact source-impact plan requires Shifu qualification).
 - **Retirement:** remove only after every selecting profile and workflow binding is migrated or explicitly replaced, with the registry and matrix changed in the same review.
 <!-- /gate-doc:shifu.workspace -->

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -43,14 +43,14 @@
     {
       "path": ".github/workflows/affected-native-pr.yml",
       "authority": "qualification",
-      "definitionDigest": "sha256:52f08b01b253862c24fc69d9e215800f7d1b74c75e2fa1da2f0e9f5e26439880",
+      "definitionDigest": "sha256:7b8974d207b5a9616adf6a66448c4a1fd5a3c78f4c980fa0dd97f3ef27bfdc2f",
       "jobs": [
         {
           "id": "affected_native_shards",
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:4d268cdf51c97657c1ff82d65275a931d7f3a2f4f1623077b6179ea59d37fa68",
+          "definitionDigest": "sha256:949e816344773cf9f7a7e61423f09fc1e946ae85bb2d58477ecfebf2b33d1f1d",
           "credentials": {
             "githubToken": "read",
             "oidc": false,
@@ -84,7 +84,7 @@
               "index": 3,
               "label": "id:revisions",
               "authority": "qualification",
-              "definitionDigest": "sha256:fe90908136b386016b063401a251e84622ce26acf1cfc2d92593f19f58ba448b"
+              "definitionDigest": "sha256:ab8831c82e920fa855add48288d2302b4c4e9b0a394e2e5e21e072a739e1de98"
             },
             {
               "index": 4,
@@ -201,7 +201,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:e8260fabd6ce40659b5b7c77eac7aa63476fc66a53ff44e161ede2074c3d0b85",
+          "definitionDigest": "sha256:c111417035bc3992ff263699c3adc151c5a17277f6c04ca4cf73d94e6818fc9d",
           "credentials": {
             "githubToken": "read",
             "oidc": false,
@@ -212,7 +212,6 @@
           "externalActions": [
             "actions/checkout@v4",
             "actions/setup-node@v6.4.0",
-            "actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093",
             "actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093",
             "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02"
           ],
@@ -231,33 +230,165 @@
             },
             {
               "index": 3,
-              "label": "id:descriptor",
+              "label": "name:Admit staged candidate dependency graph",
               "authority": "qualification",
-              "definitionDigest": "sha256:d044401bd6519171c0d6c5fecc077c145b9c1e8fa64cbf0f9d30691d50594f90"
+              "definitionDigest": "sha256:e04abca300a242e43919fd67cbe5b49b07444b925d8733bf94ab0c9f31347db6"
             },
             {
               "index": 4,
-              "label": "name:Download admitted pull-request proof",
+              "label": "id:descriptor",
               "authority": "evidence-publication",
-              "definitionDigest": "sha256:19618e5637ad1ec49d05e3aac467a0051eccffa434f54f3c592307365d0cf668"
+              "definitionDigest": "sha256:f19a5c38f67d7db247a8c925037bdd1fb873c888d8bc8fbae27d686f4fa99f2b"
             },
             {
               "index": 5,
               "label": "name:Download current partition evidence",
               "authority": "evidence-publication",
-              "definitionDigest": "sha256:0ad70a9dfadcb5d2e179c44fb2781f0baddebf627309a48a4d22cfacf06caaac"
+              "definitionDigest": "sha256:9cd571de467f217e1372ab5e1895c638b3435f942cdc5910533ab54e9517c850"
             },
             {
               "index": 6,
               "label": "id:admit",
               "authority": "qualification",
-              "definitionDigest": "sha256:30dfe14e2e8d0bd4955c49623cb956291d7f37c532e7088ed14ff7759df35e8e"
+              "definitionDigest": "sha256:215a615fb0b1a261d44e56499c2576b7db12a14347698b70b78cf078768badf0"
             },
             {
               "index": 7,
-              "label": "name:Upload immutable pull-request proof",
+              "label": "name:Upload authoritative queue proof",
               "authority": "evidence-publication",
-              "definitionDigest": "sha256:3f8f1f0ce219f25ecb654e3ef12c3efae196ad60f3c4446838bcf274fd3daa80"
+              "definitionDigest": "sha256:c74d724fdd216e2d2653d723dd47f7bfecd58d3f044f222add022012500775d2"
+            }
+          ]
+        },
+        {
+          "id": "candidate_preflight",
+          "authority": "qualification",
+          "publication": "none",
+          "receipt": "diagnostic",
+          "definitionDigest": "sha256:0c5180b56e692f7117ab4099080e5aab9e58d0e58bf9445b6215947bdaf12c8d",
+          "credentials": {
+            "githubToken": "read",
+            "oidc": false,
+            "repositorySecrets": [],
+            "inheritedSecrets": false,
+            "environment": null
+          },
+          "externalActions": [
+            "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0",
+            "kungfu-systems/buildchain/actions/validate-config@v2",
+            "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02"
+          ],
+          "steps": [
+            {
+              "index": 1,
+              "label": "uses:actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0",
+              "authority": "qualification",
+              "definitionDigest": "sha256:632ec7dde43669059eab6d285d75746bede178c3eb57b9a15f693b4ac96c355d"
+            },
+            {
+              "index": 2,
+              "label": "name:Validate .buildchain/buildchain.toml",
+              "authority": "qualification",
+              "definitionDigest": "sha256:e4e1d777b76d54a4fb4a5f3b60157a1054e990d194b363266b66264b32f2edfc"
+            },
+            {
+              "index": 3,
+              "label": "name:Verify ADR delivery intent",
+              "authority": "qualification",
+              "definitionDigest": "sha256:48e72bd895c8aa22b8c612709f9293c257b8a12867d2ae22eab5eed5c4f2930a"
+            },
+            {
+              "index": 4,
+              "label": "name:Rehearse alpha and stable promotion contracts",
+              "authority": "qualification",
+              "definitionDigest": "sha256:4d2045f4b3c7579ce197cfeda1d57ccb35a6a23fa10ccd537888359f9b657165"
+            },
+            {
+              "index": 5,
+              "label": "id:plan",
+              "authority": "qualification",
+              "definitionDigest": "sha256:6cb207a1bf071e89ad5d3b8387ae9fda49887f09745e8e498c27a6df8ade834a"
+            },
+            {
+              "index": 6,
+              "label": "name:Upload candidate preflight plan",
+              "authority": "evidence-publication",
+              "definitionDigest": "sha256:0f0f752f45e91760b224bbdd55a062798d67e512c73fdaf4d47529d78258af3a"
+            }
+          ]
+        },
+        {
+          "id": "dco",
+          "authority": "qualification",
+          "publication": "none",
+          "receipt": "diagnostic",
+          "definitionDigest": "sha256:4a8c763d5d530588e7882877dcfb1d911e1bd0097c0da6f6cb3ca2036ddf35fa",
+          "credentials": {
+            "githubToken": "read",
+            "oidc": false,
+            "repositorySecrets": [],
+            "inheritedSecrets": false,
+            "environment": null
+          },
+          "externalActions": [
+            "actions/checkout@v4"
+          ],
+          "steps": [
+            {
+              "index": 1,
+              "label": "uses:actions/checkout@v4",
+              "authority": "qualification",
+              "definitionDigest": "sha256:013f3e07e00504e33bda746183e505021d945acc2dfb178cf1d094ef09ea5c8f"
+            },
+            {
+              "index": 2,
+              "label": "name:Check commit sign-offs",
+              "authority": "qualification",
+              "definitionDigest": "sha256:5b3f435696b22929e85def8c79c95885a7988f6b72f7d617008720011975f91f"
+            }
+          ]
+        },
+        {
+          "id": "kfd_verifier",
+          "authority": "qualification",
+          "publication": "none",
+          "receipt": "diagnostic",
+          "definitionDigest": "sha256:cff226f48ab18774a27feb0ad91f2001f6551a75ad62a68a4fed8c792072dc63",
+          "credentials": {
+            "githubToken": "read",
+            "oidc": false,
+            "repositorySecrets": [],
+            "inheritedSecrets": false,
+            "environment": null
+          },
+          "externalActions": [
+            "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0",
+            "actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e"
+          ],
+          "steps": [
+            {
+              "index": 1,
+              "label": "uses:actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0",
+              "authority": "qualification",
+              "definitionDigest": "sha256:86e974e8ec8e828d53576df6fcf46da9a32d9fccdd6ea0212e28bbcb36cdc2e7"
+            },
+            {
+              "index": 2,
+              "label": "uses:actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e",
+              "authority": "qualification",
+              "definitionDigest": "sha256:a869cc671103a9106dc90b4275a4148de9a5d18cd3578a2642d8ae8076d8dbf0"
+            },
+            {
+              "index": 3,
+              "label": "name:Install frozen workspace",
+              "authority": "qualification",
+              "definitionDigest": "sha256:87d057d2738138405008a036b85811bea2d8f7dadedf7179c773faf5f3d6fb12"
+            },
+            {
+              "index": 4,
+              "label": "name:Verify product-owned fixtures",
+              "authority": "qualification",
+              "definitionDigest": "sha256:2250b93c5189f38bcbac7c7da2220a55e73148d7091e9ab548b01ff58f681654"
             }
           ]
         },
@@ -266,7 +397,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:9db9d3109dae9a6e5cb187fb905f94b977d5f8137e0b683b5aa02fe9ffcb5456",
+          "definitionDigest": "sha256:9fb67e8592fe4eb6db43bb19dbcf38dc6b965c80ff5a306a42d575112056ae09",
           "credentials": {
             "githubToken": "read",
             "oidc": false,
@@ -276,8 +407,7 @@
           },
           "externalActions": [
             "actions/checkout@v4",
-            "actions/setup-node@v6.4.0",
-            "actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093"
+            "actions/setup-node@v6.4.0"
           ],
           "steps": [
             {
@@ -296,7 +426,7 @@
               "index": 3,
               "label": "id:revisions",
               "authority": "qualification",
-              "definitionDigest": "sha256:fe90908136b386016b063401a251e84622ce26acf1cfc2d92593f19f58ba448b"
+              "definitionDigest": "sha256:ab8831c82e920fa855add48288d2302b4c4e9b0a394e2e5e21e072a739e1de98"
             },
             {
               "index": 4,
@@ -306,23 +436,97 @@
             },
             {
               "index": 5,
-              "label": "id:lookup",
+              "label": "id:decision",
               "authority": "qualification",
-              "definitionDigest": "sha256:3a9abd5a956a9f9f0564d606457dd803afcb696ac09a3317ec353cd98cd7c82c"
+              "definitionDigest": "sha256:a63379dae451c35efcc9d59a1dec3b3827a02410df33e6aaa85555023f02e11c"
+            }
+          ]
+        },
+        {
+          "id": "shifu_workspace",
+          "authority": "qualification",
+          "publication": "none",
+          "receipt": "diagnostic",
+          "definitionDigest": "sha256:ed3961a91f8acb6023dfdb5d5219db1339cc87544c735fa7b959526b9d1bbc07",
+          "credentials": {
+            "githubToken": "read",
+            "oidc": false,
+            "repositorySecrets": [],
+            "inheritedSecrets": false,
+            "environment": null
+          },
+          "externalActions": [
+            "actions/checkout@v4",
+            "actions/setup-node@v6.4.0"
+          ],
+          "steps": [
+            {
+              "index": 1,
+              "label": "uses:actions/checkout@v4",
+              "authority": "qualification",
+              "definitionDigest": "sha256:dd0465395fff2eaf34fe466af3f46904442331f18fbcb4d67ae136cd3ae05d18"
+            },
+            {
+              "index": 2,
+              "label": "uses:actions/setup-node@v6.4.0",
+              "authority": "qualification",
+              "definitionDigest": "sha256:c18c6bcd952b8a597d4a32bed3cc75aa1f3e9867ea94ff6bab439a3fd7e28974"
+            },
+            {
+              "index": 3,
+              "label": "name:Run Shifu workspace Gate (POSIX)",
+              "authority": "qualification",
+              "definitionDigest": "sha256:962a4107981fd4e81dc3cc3e95cd25e50621a70856c7d2f5fcfae1def3d30215"
+            },
+            {
+              "index": 4,
+              "label": "name:Run Shifu workspace Gate (Windows)",
+              "authority": "qualification",
+              "definitionDigest": "sha256:f82bc35e53cd3f3c048c0b5f687a7a087c841b3c541802530415c86ee8c7a7fd"
+            },
+            {
+              "index": 5,
+              "label": "name:Verify Xinfa producer contracts (POSIX)",
+              "authority": "qualification",
+              "definitionDigest": "sha256:15752c37fb68edba03d505347c7aae2e2817db34c555691efefbee3eb4bb4546"
             },
             {
               "index": 6,
-              "label": "id:download",
-              "authority": "evidence-publication",
-              "definitionDigest": "sha256:243367e0d92254a0e47159c867bd8e45215ef96ad66488ee5c13f78743eaa9a6"
+              "label": "name:Verify Xinfa producer contracts (Windows)",
+              "authority": "qualification",
+              "definitionDigest": "sha256:cf18195970fdb8eb168be74c0c3affcd71b0951a12e6b901f3573e1e9cd2b566"
             },
             {
               "index": 7,
-              "label": "id:decision",
+              "label": "name:Qualify repository context quality (POSIX)",
               "authority": "qualification",
-              "definitionDigest": "sha256:d3d7ec0fc3d4d583317ad6765b0c20a56541ec83376f20501395c1f9825984c7"
+              "definitionDigest": "sha256:c374ee36eff61fa55741ed99fdb994ff3dc78fdee52c0bdd9b3f7a3500718507"
+            },
+            {
+              "index": 8,
+              "label": "name:Qualify repository context quality (Windows)",
+              "authority": "qualification",
+              "definitionDigest": "sha256:80f3c187a20ae685904dea5732bf0bce3f43779e40eb59d4d7a19855df31bb58"
             }
           ]
+        },
+        {
+          "id": "source_acceptance",
+          "authority": "qualification",
+          "publication": "none",
+          "receipt": "diagnostic",
+          "definitionDigest": "sha256:51a91ae9aa6401831309c83647ef29513628fcff8539941db71c52fc16765d6e",
+          "credentials": {
+            "githubToken": "read",
+            "oidc": false,
+            "repositorySecrets": [],
+            "inheritedSecrets": false,
+            "environment": null
+          },
+          "externalActions": [
+            "kungfu-systems/buildchain/.github/workflows/check.yml@ec48c0b311212c5f3a591e0284da6e85a9fdded5"
+          ],
+          "steps": []
         }
       ]
     },
@@ -427,7 +631,7 @@
     {
       "path": ".github/workflows/buildchain-validate.yml",
       "authority": "qualification",
-      "definitionDigest": "sha256:378ca5c8d9aa0c837b2b29a363753755a1650ad22ce724f21624cddad72ccbcc",
+      "definitionDigest": "sha256:a679c6e5cbea690f75143d850c562cee352317347c954930467df1912d70ca19",
       "jobs": [
         {
           "id": "promotion-rehearsal",
@@ -1094,7 +1298,7 @@
     {
       "path": ".github/workflows/kfd-verifier-drift.yml",
       "authority": "qualification",
-      "definitionDigest": "sha256:28d887b19bfafe4ebdf344276b3dee219a08430ecd1cf8704387dfa9a3f4acea",
+      "definitionDigest": "sha256:79a157f76bb9b366fb646af2179f8a9f9cd780735d0f7179cf27452831f0cabb",
       "jobs": [
         {
           "id": "verify-owned-fixtures",
@@ -1595,7 +1799,7 @@
     {
       "path": ".github/workflows/shifu-ci.yml",
       "authority": "qualification",
-      "definitionDigest": "sha256:e2d9f7801567278f22b292f72c7d7b39d367ff67e7d4d2a7ec6988c43ed96c8c",
+      "definitionDigest": "sha256:544e8ed61cf176f247b994659b0d713238e81a6c8c32b64469f432a9bded1173",
       "jobs": [
         {
           "id": "check",

--- a/docs/qualification/gates/workflow-authority.md
+++ b/docs/qualification/gates/workflow-authority.md
@@ -42,7 +42,12 @@ without changing and refreshing the manifest fails the Gate catalog check.
 | `.github/workflows/adr-release-gate.yml` | `adr-release` | qualification | none | diagnostic | token:read | none | 2 |
 | `.github/workflows/affected-native-pr.yml` | `affected_native_shards` | qualification | none | diagnostic | token:read | none | 21 |
 | `.github/workflows/affected-native-pr.yml` | `affected-native` | qualification | none | diagnostic | token:read | none | 7 |
-| `.github/workflows/affected-native-pr.yml` | `proof_probe` | qualification | none | diagnostic | token:read | none | 7 |
+| `.github/workflows/affected-native-pr.yml` | `candidate_preflight` | qualification | none | diagnostic | token:read | none | 6 |
+| `.github/workflows/affected-native-pr.yml` | `dco` | qualification | none | diagnostic | token:read | none | 2 |
+| `.github/workflows/affected-native-pr.yml` | `kfd_verifier` | qualification | none | diagnostic | token:read | none | 4 |
+| `.github/workflows/affected-native-pr.yml` | `proof_probe` | qualification | none | diagnostic | token:read | none | 5 |
+| `.github/workflows/affected-native-pr.yml` | `shifu_workspace` | qualification | none | diagnostic | token:read | none | 8 |
+| `.github/workflows/affected-native-pr.yml` | `source_acceptance` | qualification | none | diagnostic | token:read | none | 0 |
 | `.github/workflows/build.yml` | `build` | qualification | none | qualifying | token:write, oidc, repo-secret:BUILDCHAIN_ARTIFACT_RELAY_S3_DOWNLOAD_ROLE_ARN+BUILDCHAIN_ARTIFACT_RELAY_S3_ROLE_ARN+BUILDCHAIN_ARTIFACT_RELAY_S3_UPLOAD_ROLE_ARN | none | 0 |
 | `.github/workflows/build.yml` | `kungfu-phase-b` | qualification | none | qualifying | token:read | none | 0 |
 | `.github/workflows/build.yml` | `phase-b-package` | qualification | none | diagnostic | token:read | none | 5 |

--- a/docs/qualification/gates/workflow-bindings.json
+++ b/docs/qualification/gates/workflow-bindings.json
@@ -17,7 +17,7 @@
       ],
       "activation": "dev pull request",
       "adapter": {
-        "type": "buildchain-source",
+        "type": "buildchain-source-staged",
         "kind": "job-uses",
         "uses": "kungfu-systems/buildchain/.github/workflows/check.yml@ec48c0b311212c5f3a591e0284da6e85a9fdded5",
         "with": {
@@ -38,7 +38,7 @@
       "gates": [
         "source.changed-scope"
       ],
-      "activation": "two deterministic GitHub-hosted Linux partitions on every development pull request and merge group, plus post-merge dev pushes; the stable affected-native aggregator admits only the complete successful set, while outside-Core changes produce partition-bound tier-none receipts so the required check never deadlocks",
+      "activation": "two deterministic GitHub-hosted Linux partitions only on an exact merge-group candidate after source and governance preflight; the stable affected-native aggregator reports fast PR admission and admits the complete impact-selected queue set",
       "invocation": {
         "args": [
           "--omit-dependency",
@@ -46,6 +46,114 @@
           "--capability",
           "native-toolchain"
         ]
+      }
+    },
+    {
+      "id": "dev-candidate-source",
+      "execution": "controller",
+      "workflow": ".github/workflows/affected-native-pr.yml",
+      "job": "source_acceptance",
+      "profiles": [
+        "dev-pr"
+      ],
+      "gates": [
+        "gate.catalog",
+        "source.acceptance"
+      ],
+      "activation": "every dev pull request and merge-group candidate inside the staged required aggregate",
+      "adapter": {
+        "type": "buildchain-source",
+        "kind": "job-uses",
+        "uses": "kungfu-systems/buildchain/.github/workflows/check.yml@ec48c0b311212c5f3a591e0284da6e85a9fdded5",
+        "with": {
+          "buildchain-ref": "v2",
+          "mode": "source",
+          "upload-artifacts": true
+        }
+      }
+    },
+    {
+      "id": "dev-candidate-buildchain-config",
+      "execution": "controller",
+      "workflow": ".github/workflows/affected-native-pr.yml",
+      "job": "candidate_preflight",
+      "profiles": [
+        "dev-pr"
+      ],
+      "gates": [
+        "governance.buildchain-config"
+      ],
+      "activation": "every dev pull request and merge-group candidate before any expensive queue job",
+      "adapter": {
+        "type": "buildchain-config-staged",
+        "kind": "step-uses",
+        "uses": "kungfu-systems/buildchain/actions/validate-config@v2",
+        "name": "Validate .buildchain/buildchain.toml",
+        "with": {
+          "require-version-state": "true",
+          "require-lifecycle-stages": "install,check,build,verify"
+        }
+      }
+    },
+    {
+      "id": "dev-candidate-dco",
+      "execution": "controller",
+      "workflow": ".github/workflows/affected-native-pr.yml",
+      "job": "dco",
+      "profiles": [
+        "dev-pr"
+      ],
+      "gates": [
+        "governance.dco"
+      ],
+      "activation": "every dev pull request inside the staged required aggregate",
+      "adapter": {
+        "type": "dco-shell-staged",
+        "kind": "run-step",
+        "name": "Check commit sign-offs",
+        "env": {
+          "EXPECTED_EVENT_NAME": "pull_request"
+        },
+        "runContains": [
+          "GITHUB_EVENT_PATH",
+          "git rev-list",
+          "--format=%B",
+          "^Signed-off-by:",
+          "missing=1",
+          "exit 1"
+        ]
+      }
+    },
+    {
+      "id": "dev-candidate-adr",
+      "execution": "gate",
+      "workflow": ".github/workflows/affected-native-pr.yml",
+      "job": "candidate_preflight",
+      "profiles": [
+        "dev-pr"
+      ],
+      "gates": [
+        "governance.adr-delivery"
+      ],
+      "activation": "every dev pull request and merge-group candidate before any expensive queue job",
+      "invocation": {
+        "args": []
+      }
+    },
+    {
+      "id": "dev-candidate-promotion-rehearsal",
+      "execution": "gate",
+      "workflow": ".github/workflows/affected-native-pr.yml",
+      "job": "candidate_preflight",
+      "profiles": [
+        "dev-pr"
+      ],
+      "gates": [
+        "governance.promotion-rehearsal"
+      ],
+      "activation": "every dev pull request and merge-group candidate before any expensive queue job",
+      "invocation": {
+        "args": []
       }
     },
     {
@@ -164,14 +272,32 @@
       "workflow": ".github/workflows/shifu-ci.yml",
       "job": "check",
       "profiles": [
-        "dev-pr",
         "alpha-pr",
         "release-pr"
       ],
       "gates": [
         "shifu.workspace"
       ],
-      "activation": "channel pull request touching crates/**",
+      "activation": "alpha or release pull request touching the declared Shifu workspace paths",
+      "invocation": {
+        "args": [
+          "--capability",
+          "rust"
+        ]
+      }
+    },
+    {
+      "id": "dev-queue-shifu-workspace",
+      "execution": "gate",
+      "workflow": ".github/workflows/affected-native-pr.yml",
+      "job": "shifu_workspace",
+      "profiles": [
+        "dev-pr"
+      ],
+      "gates": [
+        "shifu.workspace"
+      ],
+      "activation": "three GitHub-hosted platforms after merge-group preflight when the exact source-impact plan requires Shifu qualification",
       "invocation": {
         "args": [
           "--capability",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "check:gate-catalog": "node scripts/require-shifu.mjs check:gate-catalog && node scripts/check-kungfu-gate-catalog.mjs",
     "gate:workflow-authority:refresh": "node scripts/require-shifu.mjs gate:workflow-authority:refresh && node scripts/kungfu-workflow-authority.mjs --refresh",
     "gate:latency:measure": "node scripts/require-shifu.mjs gate:latency:measure && node scripts/measure-dev-required-latency.mjs",
-    "test:gate-latency": "node scripts/require-shifu.mjs test:gate-latency && node --test scripts/affected-native-proof.test.mjs scripts/measure-dev-required-latency.test.mjs scripts/write-affected-native-cache-manifests.test.mjs",
+    "test:gate-latency": "node scripts/require-shifu.mjs test:gate-latency && node --test scripts/affected-native-proof.test.mjs scripts/measure-dev-required-latency.test.mjs scripts/run-core-affected-native.test.mjs scripts/write-affected-native-cache-manifests.test.mjs",
     "test:release-admission": "node scripts/require-shifu.mjs test:release-admission && node --test scripts/verify-kungfu-release-admission.test.mjs",
     "verify:release-admission": "node scripts/require-shifu.mjs verify:release-admission && node scripts/verify-kungfu-release-admission.mjs",
     "check:shifu-workspace": "node scripts/require-shifu.mjs check:shifu-workspace && node scripts/check-shifu-workspace.mjs",

--- a/scripts/affected-native-proof.test.mjs
+++ b/scripts/affected-native-proof.test.mjs
@@ -353,24 +353,31 @@ test('lookup degrades duplicate, fork, failed, and expired artifacts to full run
   assert.equal(rejected.candidateCount, 0);
 });
 
-test('workflow keeps the required queue context while gating heavy shards on verified reuse', () => {
+test('workflow keeps one required context while staging authoritative queue builds', () => {
   const workflow = fs.readFileSync(
     path.join(ROOT, '.github/workflows/affected-native-pr.yml'),
     'utf8',
   );
   assert.match(workflow, /^\s{2}merge_group\s*:/mu);
-  assert.match(workflow, /^\s{2}actions: read$/mu);
+  assert.doesNotMatch(workflow, /^\s{2}push\s*:/mu);
+  assert.match(workflow, /^\s{2}dco:$/mu);
+  assert.match(workflow, /^\s{2}source_acceptance:$/mu);
+  assert.match(workflow, /^\s{2}candidate_preflight:$/mu);
   assert.match(workflow, /^\s{2}proof_probe:$/mu);
   assert.match(
     workflow,
-    /affected_native_shards:[\s\S]*needs: proof_probe[\s\S]*needs\.proof_probe\.outputs\.reuse != 'true'/u,
+    /affected_native_shards:[\s\S]*- source_acceptance[\s\S]*- candidate_preflight[\s\S]*github\.event_name == 'merge_group'/u,
   );
   assert.match(
     workflow,
-    /name: affected-native \/ linux[\s\S]*producer-run-id[\s\S]*affected-native-proof\.mjs verify/u,
+    /name: affected-native \/ linux[\s\S]*DCO_RESULT:[\s\S]*SOURCE_RESULT:[\s\S]*PREFLIGHT_RESULT:[\s\S]*PR fast admission passed without compiler or installed-artifact work/u,
   );
+  assert.doesNotMatch(workflow, /producer-run-id/u);
+  assert.match(workflow, /Merge Queue is the authoritative producer/u);
   assert.match(workflow, /echo "native-required=\$\{native_required\}"/u);
   assert.match(workflow, /echo "sdk-required=\$\{sdk_required\}"/u);
+  assert.match(workflow, /echo "shifu-required=\$\(jq/u);
+  assert.match(workflow, /echo "kfd-required=\$\(jq/u);
   assert.match(
     workflow,
     /Qualify installed four-language SDK wire contract[\s\S]*steps\.plan\.outputs\.sdk-required == 'true'[\s\S]*matrix\.partition == 0/u,
@@ -379,7 +386,9 @@ test('workflow keeps the required queue context while gating heavy shards on ver
     workflow,
     /Run affected native closure[\s\S]*steps\.plan\.outputs\.native-required == 'true'/u,
   );
-  assert.match(workflow, /retention-days: 1/u);
+  assert.match(workflow, /^\s{2}shifu_workspace:$/mu);
+  assert.match(workflow, /^\s{2}kfd_verifier:$/mu);
+  assert.doesNotMatch(workflow, /retention-days: 1$/mu);
   const verifier = fs.readFileSync(
     path.join(ROOT, 'scripts/affected-native-proof.mjs'),
     'utf8',

--- a/scripts/check-kungfu-gate-catalog.test.mjs
+++ b/scripts/check-kungfu-gate-catalog.test.mjs
@@ -93,14 +93,21 @@ test('required dev workflows are merge-queue compatible', () => {
   }
 });
 
-test('affected native seeds a base-branch cache for cross-ref consumers', () => {
+test('dev candidate heavy work is queue-only and depends on both preflights', () => {
   const relative = '.github/workflows/affected-native-pr.yml';
   const source = fs.readFileSync(path.join(ROOT, relative), 'utf8');
-  assert.match(source, /^\s{2}push\s*:/m, relative);
-  assert.match(source, /^\s{6}- dev\/v\*\/v\*$/m, relative);
-  assert.match(source, /^\s{12}push\)$/m, relative);
-  assert.match(source, /base_sha="\$\(jq -r '\.before'/, relative);
-  assert.match(source, /event_head_sha="\$\(jq -r '\.after'/, relative);
+  assert.doesNotMatch(source, /^\s{2}push\s*:/m, relative);
+  assert.match(
+    source,
+    /affected_native_shards:[\s\S]*- source_acceptance[\s\S]*- candidate_preflight[\s\S]*github\.event_name == 'merge_group'/,
+    relative,
+  );
+  assert.match(
+    source,
+    /shifu_workspace:[\s\S]*- source_acceptance[\s\S]*- candidate_preflight/,
+    relative,
+  );
+  assert.match(source, /PR fast admission passed without compiler/, relative);
 });
 
 function readMeasurementCoverage(root) {
@@ -170,7 +177,7 @@ test('current Kungfu catalog, docs, matrix, actions, and workflows align', () =>
   const controllers = result.workflowFacts.filter(
     (fact) => fact.execution === 'controller',
   );
-  assert.equal(controllers.length, 6);
+  assert.equal(controllers.length, 9);
   assert.ok(controllers.every((fact) => fact.gates.length > 0));
   assert.equal(result.workflowAuthority.workflows.length, 17);
 });

--- a/scripts/run-core-affected-native.mjs
+++ b/scripts/run-core-affected-native.mjs
@@ -82,6 +82,27 @@ const sdkQualificationPaths = [
   'tests/qualification/layers/process-metrics.mjs',
   'tests/qualification/layers/sdk/',
 ];
+const shifuWorkspaceQualificationPaths = [
+  { suffix: '.md' },
+  { exact: '.xinfa/project.json' },
+  { prefix: 'crates/' },
+  { exact: 'scripts/qualify-xinfa-context-quality.mjs' },
+  { prefix: 'scripts/shifu-documentation-' },
+  { exact: 'scripts/check-shifu-workspace.mjs' },
+  { prefix: 'scripts/shifu-gate-' },
+  { exact: 'package.json' },
+  { exact: 'shifu.gates.json' },
+  { exact: '.github/workflows/affected-native-pr.yml' },
+  { exact: '.github/workflows/shifu-ci.yml' },
+];
+const kfdVerifierQualificationPaths = [
+  { prefix: 'crates/xinfa/' },
+  { exact: 'scripts/verify-kfd-owned-fixtures.mjs' },
+  { exact: 'package.json' },
+  { exact: 'pnpm-lock.yaml' },
+  { exact: '.github/workflows/affected-native-pr.yml' },
+  { exact: '.github/workflows/kfd-verifier-drift.yml' },
+];
 
 function ordered(value) {
   if (Array.isArray(value)) return value.map(ordered);
@@ -150,6 +171,38 @@ export function rootPackageSdkProjection(document) {
 
 function matchesPathRule(file, rule) {
   return file === rule || (rule.endsWith('/') && file.startsWith(rule));
+}
+
+function matchesQualificationPathRule(file, rule) {
+  return (
+    file === rule.exact ||
+    (rule.prefix && file.startsWith(rule.prefix)) ||
+    (rule.suffix && file.endsWith(rule.suffix))
+  );
+}
+
+function qualificationImpact(changedFiles, rules, kind) {
+  const reasons = unique(changedFiles)
+    .filter((file) =>
+      rules.some((rule) => matchesQualificationPathRule(file, rule)),
+    )
+    .map((file) => ({ path: file, kind }));
+  return { required: reasons.length > 0, reasons };
+}
+
+export function devQueueQualificationImpact(changedFiles) {
+  return {
+    shifuWorkspace: qualificationImpact(
+      changedFiles,
+      shifuWorkspaceQualificationPaths,
+      'shifu-workspace-input',
+    ),
+    kfdVerifier: qualificationImpact(
+      changedFiles,
+      kfdVerifierQualificationPaths,
+      'kfd-verifier-input',
+    ),
+  };
 }
 
 export function sdkQualificationImpact(
@@ -555,6 +608,7 @@ export function planFromChanged(
     ? selectProfile(buildAuthority, closure, forceFull)
     : null;
   const sdkImpact = sdkQualificationImpact(changedFiles, base, head, options);
+  const devQueueImpact = devQueueQualificationImpact(changedFiles);
   const plan = {
     schema: 'kungfu.core-affected-native-plan/v1',
     base,
@@ -574,6 +628,7 @@ export function planFromChanged(
       required: sdkImpact.required,
       reasons: sdkImpact.reasons,
     },
+    devQueueQualification: devQueueImpact,
     reviewRoutes: unique(closure).map((componentId) => ({
       component: componentId,
       ownerRole: componentById.get(componentId)?.owner,

--- a/scripts/run-core-affected-native.test.mjs
+++ b/scripts/run-core-affected-native.test.mjs
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { devQueueQualificationImpact } from './run-core-affected-native.mjs';
+
+test('dev queue impact keeps unrelated source changes out of optional heavy gates', () => {
+  assert.deepEqual(devQueueQualificationImpact(['framework/gui/src/app.ts']), {
+    shifuWorkspace: { required: false, reasons: [] },
+    kfdVerifier: { required: false, reasons: [] },
+  });
+});
+
+test('dev queue impact selects Shifu and KFD from their declared source surfaces', () => {
+  const impact = devQueueQualificationImpact([
+    'docs/development/buildchain.md',
+    'crates/xinfa/src/lib.rs',
+  ]);
+  assert.equal(impact.shifuWorkspace.required, true);
+  assert.deepEqual(
+    impact.shifuWorkspace.reasons.map(({ path }) => path),
+    ['crates/xinfa/src/lib.rs', 'docs/development/buildchain.md'],
+  );
+  assert.equal(impact.kfdVerifier.required, true);
+  assert.deepEqual(
+    impact.kfdVerifier.reasons.map(({ path }) => path),
+    ['crates/xinfa/src/lib.rs'],
+  );
+});
+
+test('the staged workflow remains self-qualifying under both moved gates', () => {
+  const impact = devQueueQualificationImpact([
+    '.github/workflows/affected-native-pr.yml',
+  ]);
+  assert.equal(impact.shifuWorkspace.required, true);
+  assert.equal(impact.kfdVerifier.required, true);
+});


### PR DESCRIPTION
## Summary

Make the development merge queue the single authoritative producer for expensive candidate qualification while keeping pull-request admission fast and fail-closed.

GitHub merge-group formation remains the conflict authority. Pull requests run DCO, source acceptance, Buildchain configuration, ADR/promotion governance, and exact source-impact planning; compiler, installed-artifact, packaging, and three-platform work starts only for the synthetic merge-group candidate after both preflight lanes pass.

## Related issue

Follow-up to the dev required-gate latency and affected-native qualification work.

## Changes

- keep one stable required context, `affected-native / linux`, with distinct PR-admission and merge-group qualification semantics
- make source acceptance and governance preflight explicit dependencies of every expensive queue job
- run affected-native/SDK, impact-selected three-platform Shifu, and impact-selected KFD qualification in parallel after preflight
- run the installed four-language SDK wire contract only when the exact source-bound plan selects it
- retire PR proof reuse because expensive evidence is no longer produced before the queue
- remove candidate-equivalent affected-native, Buildchain-validation, Shifu, and KFD work from dev pushes or dev PR-specific standalone workflows
- preserve alpha and release workflow behavior and retain the old required contexts during the bounded branch-protection transition
- refresh the closed-world workflow authority, bindings, ADR, gate docs, and contract fixtures

## Verification

- `./shifu check:gate-catalog` (38 gates, 6 profiles, 25 structured invocations, 17 workflows)
- `./shifu test:gate-latency` (28 passed)
- focused workflow/catalog contracts (30 passed)
- `./shifu check:source` (passed; documentation 85/85 and source contracts with zero failures)
- staged pre-commit repository gate (passed)
- Project Cut successor kickoff/run gate bound to `39ca45f4495ff3792ff132519fb285f9348e0ec6`

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "implemented",
  "adrs": ["SHIFU-ADR-0004"],
  "summary": "Move expensive dev candidate qualification behind ordered merge-group preflight while preserving one fail-closed required aggregate.",
  "verification": ["./shifu test:gate-latency", "./shifu check:source", "real pull_request and merge_group workflow observation"]
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change alters qualification scheduling and required-context aggregation. It adds no secrets, write permissions, mutable third-party authority, protected-branch bypass, or release-policy weakening. The old required contexts remain in force until the replacement aggregate is observed on both PR and merge-group events.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed

