### PR TITLE
ci: retire duplicate dev qualification entrypoints

### DIFF
--- a/.github/workflows/adr-release-gate.yml
+++ b/.github/workflows/adr-release-gate.yml
@@ -3,12 +3,7 @@
 name: ADR Release Gate
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review, edited]
-    branches:
-      - dev/v*/v*
-  merge_group:
-    types: [checks_requested]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/buildchain-validate.yml
+++ b/.github/workflows/buildchain-validate.yml
@@ -5,6 +5,8 @@ name: Buildchain Validate
 
 on:
   pull_request:
+    branches-ignore:
+      - "dev/v*/v*"
   push:
     branches:
       - "alpha/**"

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -5,6 +5,8 @@ name: DCO
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+    branches-ignore:
+      - "dev/v*/v*"
 
 permissions:
   contents: read

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -3,54 +3,7 @@
 name: Docs Check
 
 on:
-  pull_request:
-    branches:
-      - dev/v*/v*
-    paths:
-      - "**/*.md"
-      - "**/*.markdown"
-      - ".markdownlint-cli2.mjs"
-      - "docs.contract.json"
-      - "docs/document-metadata.contract.json"
-      - "docs/document-metadata.registry.json"
-      - "docs/adr/legacy-identities.v1.json"
-      - "docs/adr-release.contract.json"
-      - "docs/adr-release-waivers.json"
-      - "docs/release-promotion-rehearsal.contract.json"
-      - "docs/vocabulary.registry.json"
-      - "docs/toolchain.contract.json"
-      - "scripts/check-docs.mjs"
-      - "scripts/adr-release-gate.mjs"
-      - "scripts/adr-release-gate.test.mjs"
-      - "scripts/adr-audit.mjs"
-      - "scripts/adr-audit.test.mjs"
-      - "scripts/adr-identity.mjs"
-      - "scripts/adr-identity.test.mjs"
-      - "scripts/adr-new.mjs"
-      - "scripts/adr-new.test.mjs"
-      - "scripts/release-promotion-rehearsal.mjs"
-      - "scripts/release-promotion-rehearsal.test.mjs"
-      - "scripts/check-docs.test.mjs"
-      - "scripts/check-docs-toolchain.mjs"
-      - "scripts/check-docs-toolchain.test.mjs"
-      - "scripts/document-metadata-contract.mjs"
-      - "scripts/document-metadata-contract.test.mjs"
-      - "scripts/run-docs-check.mjs"
-      - "scripts/run-docs-examples.mjs"
-      - "scripts/run-docs-readonly.mjs"
-      - "scripts/run-docs-prose-check.mjs"
-      - "scripts/vocabulary-contract.mjs"
-      - "scripts/vocabulary-contract.test.mjs"
-      - "scripts/check.mjs"
-      - "package.json"
-      - "pnpm-lock.yaml"
-      - ".github/workflows/docs-check.yml"
-      - ".github/workflows/build.yml"
-      - ".github/workflows/buildchain-validate.yml"
-      - ".github/workflows/release-new-version.yml"
-      - ".buildchain/contract-lock.json"
-      - ".buildchain/alpha-contract-lock.json"
-      - "tests/fixtures/release-promotion/*.json"
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/source-acceptance.yml
+++ b/.github/workflows/source-acceptance.yml
@@ -3,11 +3,7 @@
 name: Source Acceptance
 
 on:
-  pull_request:
-    branches:
-      - dev/v*/v*
-  merge_group:
-    types: [checks_requested]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/docs/adr/SHIFU-ADR-0004-gate-control-plane-contract.md
+++ b/docs/adr/SHIFU-ADR-0004-gate-control-plane-contract.md
@@ -230,6 +230,12 @@ explicitly-not-required result. Candidate-equivalent dev push rebuilds are
 removed: a cold queue run is preferable to duplicated pre-queue and post-merge
 qualification.
 
+After PR 1254 proved the aggregate on both `pull_request` and a real
+`merge_group`, dev branch protection retained only `affected-native / linux` as
+the required context. The standalone Source Acceptance, ADR Release Gate, and
+Docs Check workflows are manual diagnostics; DCO and Buildchain Validate ignore
+dev while retaining their non-dev and alpha/release responsibilities.
+
 ## Consequences
 
 - Developers and agents get one human-readable and machine-readable surface

--- a/docs/qualification/gates/README.md
+++ b/docs/qualification/gates/README.md
@@ -152,8 +152,8 @@ otherwise the machine verdict remains non-qualifying. Rebuild it with:
 ```
 
 Dev admission is intentionally narrower than asynchronous observation. The
-protected branch keeps the three Linux-hosted required contexts as its only
-merge-critical set. Daily/manual patrol and Core-profile workflows retain
+protected branch keeps the single `affected-native / linux` aggregate as its
+only merge-critical context. Daily/manual patrol and Core-profile workflows retain
 macOS, Windows, full-profile, and fault evidence without placing those optional
 jobs in front of required merge-group work. Alpha and release admission remain
 cross-platform and fail closed according to their own matrix rows.

--- a/docs/qualification/gates/release-and-promotion.md
+++ b/docs/qualification/gates/release-and-promotion.md
@@ -18,7 +18,7 @@ Each section is bound to the registry id by the catalog meta gate.
 - **Evidence:** unified Gate receipt; artifacts `product/release/qualification/adr-release-admissibility.json`.
 - **Diagnosis:** `./shifu gate explain governance.adr-delivery --profile <profile>`; reproduce with `./shifu gate run governance.adr-delivery` on a capable runner.
 - **Cost:** light; timeout 180 seconds.
-- **Current source:** .github/workflows/affected-native-pr.yml (candidate_preflight; every dev pull request and merge-group candidate before any expensive queue job); .github/workflows/adr-release-gate.yml (adr-release; dev pull request); .github/workflows/build.yml (build; alpha or release pull request).
+- **Current source:** .github/workflows/affected-native-pr.yml (candidate_preflight; every dev pull request and merge-group candidate before any expensive queue job); .github/workflows/build.yml (build; alpha or release pull request). The standalone .github/workflows/adr-release-gate.yml remains manual-only diagnostic evidence.
 - **Retirement:** remove only after every selecting profile and workflow binding is migrated or explicitly replaced, with the registry and matrix changed in the same review.
 <!-- /gate-doc:governance.adr-delivery -->
 
@@ -36,7 +36,7 @@ Each section is bound to the registry id by the catalog meta gate.
 - **Evidence:** unified Gate receipt; artifacts `product/release/qualification/release-promotion-rehearsal.json`.
 - **Diagnosis:** `./shifu gate explain governance.promotion-rehearsal --profile <profile>`; reproduce with `./shifu gate run governance.promotion-rehearsal` on a capable runner.
 - **Cost:** light; timeout 180 seconds.
-- **Current source:** .github/workflows/affected-native-pr.yml (candidate_preflight; every dev pull request and merge-group candidate before any expensive queue job); .github/workflows/buildchain-validate.yml (promotion-rehearsal; pull request or channel push); .github/workflows/release-new-version.yml (promotion-contract; merged alpha or release pull request, or manual source-locked dry-run measurement).
+- **Current source:** .github/workflows/affected-native-pr.yml (candidate_preflight; every dev pull request and merge-group candidate before any expensive queue job); .github/workflows/buildchain-validate.yml (promotion-rehearsal; pull requests except dev/v*/v*, or alpha/release channel push); .github/workflows/release-new-version.yml (promotion-contract; merged alpha or release pull request, or manual source-locked dry-run measurement).
 - **Retirement:** remove only after every selecting profile and workflow binding is migrated or explicitly replaced, with the registry and matrix changed in the same review.
 <!-- /gate-doc:governance.promotion-rehearsal -->
 

--- a/docs/qualification/gates/source-and-governance.md
+++ b/docs/qualification/gates/source-and-governance.md
@@ -18,7 +18,7 @@ Each section is bound to the registry id by the catalog meta gate.
 - **Evidence:** unified Gate receipt; no separate artifact is currently required.
 - **Diagnosis:** `./shifu gate explain gate.catalog --profile <profile>`; reproduce with `./shifu gate run gate.catalog` on a capable runner.
 - **Cost:** light; timeout 120 seconds.
-- **Current source:** .github/workflows/source-acceptance.yml (source-acceptance; dev pull request); .github/workflows/affected-native-pr.yml (source_acceptance; every dev pull request and merge-group candidate inside the staged required aggregate); .github/workflows/dev-verify-patrol.yml (verify; daily or manual on dev); .github/workflows/build.yml (build; alpha or release pull request); .github/workflows/release-new-version.yml (promotion-contract; merged alpha or release pull request, or manual source-locked dry-run measurement).
+- **Current source:** .github/workflows/affected-native-pr.yml (source_acceptance; every dev pull request and merge-group candidate inside the staged required aggregate); .github/workflows/dev-verify-patrol.yml (verify; daily or manual on dev); .github/workflows/build.yml (build; alpha or release pull request); .github/workflows/release-new-version.yml (promotion-contract; merged alpha or release pull request, or manual source-locked dry-run measurement). The standalone .github/workflows/source-acceptance.yml remains manual-only diagnostic evidence.
 - **Retirement:** remove only after every selecting profile and workflow binding is migrated or explicitly replaced, with the registry and matrix changed in the same review.
 <!-- /gate-doc:gate.catalog -->
 
@@ -36,7 +36,7 @@ Each section is bound to the registry id by the catalog meta gate.
 - **Evidence:** unified Gate receipt; no separate artifact is currently required.
 - **Diagnosis:** `./shifu gate explain governance.dco --profile <profile>`; reproduce with `./shifu gate run governance.dco` on a capable runner.
 - **Cost:** light; timeout 120 seconds.
-- **Current source:** .github/workflows/affected-native-pr.yml (dco; every dev pull request inside the staged required aggregate); .github/workflows/dco.yml (signoff; all pull requests).
+- **Current source:** .github/workflows/affected-native-pr.yml (dco; every dev pull request inside the staged required aggregate); .github/workflows/dco.yml (signoff; pull requests except dev/v*/v*; dev DCO is owned by dev-candidate-dco)
 - **Retirement:** remove only after every selecting profile and workflow binding is migrated or explicitly replaced, with the registry and matrix changed in the same review.
 <!-- /gate-doc:governance.dco -->
 
@@ -54,7 +54,7 @@ Each section is bound to the registry id by the catalog meta gate.
 - **Evidence:** unified Gate receipt; no separate artifact is currently required.
 - **Diagnosis:** `./shifu gate explain governance.buildchain-config --profile <profile>`; reproduce with `./shifu gate run governance.buildchain-config` on a capable runner.
 - **Cost:** light; timeout 120 seconds.
-- **Current source:** .github/workflows/affected-native-pr.yml (candidate_preflight; every dev pull request and merge-group candidate before any expensive queue job); .github/workflows/buildchain-validate.yml (validate; pull request or channel push); .github/workflows/release-new-version.yml (promote; merged alpha or release pull request, or manual source-locked dry-run measurement).
+- **Current source:** .github/workflows/affected-native-pr.yml (candidate_preflight; every dev pull request and merge-group candidate before any expensive queue job); .github/workflows/buildchain-validate.yml (validate; pull requests except dev/v*/v*, or alpha/release channel push); .github/workflows/release-new-version.yml (promote; merged alpha or release pull request, or manual source-locked dry-run measurement).
 - **Retirement:** remove only after every selecting profile and workflow binding is migrated or explicitly replaced, with the registry and matrix changed in the same review.
 <!-- /gate-doc:governance.buildchain-config -->
 
@@ -73,7 +73,7 @@ Each section is bound to the registry id by the catalog meta gate.
 - **Diagnosis:** `./shifu gate explain source.acceptance --profile <profile>`; reproduce with `./shifu gate run source.acceptance` on a capable runner.
 - **Cost:** light; timeout 1800 seconds. This budget covers cold shared-runner
   Project Cut composition while retaining a bounded failure signal.
-- **Current source:** .github/workflows/source-acceptance.yml (source-acceptance; dev pull request); .github/workflows/affected-native-pr.yml (source_acceptance; every dev pull request and merge-group candidate inside the staged required aggregate).
+- **Current source:** .github/workflows/affected-native-pr.yml (source_acceptance; every dev pull request and merge-group candidate inside the staged required aggregate). The standalone .github/workflows/source-acceptance.yml is manual-only.
 - **Retirement:** remove only after every selecting profile and workflow binding is migrated or explicitly replaced, with the registry and matrix changed in the same review.
 <!-- /gate-doc:source.acceptance -->
 
@@ -191,7 +191,7 @@ Each section is bound to the registry id by the catalog meta gate.
 - **Evidence:** unified Gate receipt; no separate artifact is currently required.
 - **Diagnosis:** `./shifu gate explain docs.contracts --profile <profile>`; reproduce with `./shifu gate run docs.contracts` on a capable runner.
 - **Cost:** light; timeout 600 seconds.
-- **Current source:** .github/workflows/docs-check.yml (docs-check; dev pull request touching declared documentation paths); .github/workflows/dev-verify-patrol.yml (verify; daily or manual on dev); .github/workflows/docs-external-links.yml (external-links; daily or manual).
+- **Current source:** .github/workflows/dev-verify-patrol.yml (verify; daily or manual on dev); .github/workflows/docs-external-links.yml (external-links; daily or manual)
 - **Retirement:** remove only after every selecting profile and workflow binding is migrated or explicitly replaced, with the registry and matrix changed in the same review.
 <!-- /gate-doc:docs.contracts -->
 
@@ -209,7 +209,7 @@ Each section is bound to the registry id by the catalog meta gate.
 - **Evidence:** unified Gate receipt; no separate artifact is currently required.
 - **Diagnosis:** `./shifu gate explain docs.prose --profile <profile>`; reproduce with `./shifu gate run docs.prose` on a capable runner.
 - **Cost:** light; timeout 600 seconds.
-- **Current source:** .github/workflows/docs-check.yml (docs-check; dev pull request touching declared documentation paths).
+- **Current source:** independent Shifu task; not selected by a current remote profile.
 - **Retirement:** remove only after every selecting profile and workflow binding is migrated or explicitly replaced, with the registry and matrix changed in the same review.
 <!-- /gate-doc:docs.prose -->
 

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -5,7 +5,7 @@
     {
       "path": ".github/workflows/adr-release-gate.yml",
       "authority": "qualification",
-      "definitionDigest": "sha256:764221a765a63991f974bcf2d4fac01da83071ce4b275267c9395e4241a1b4ac",
+      "definitionDigest": "sha256:c12b805ac55cc6b202f696c0d7475d38e0863e6263101d59c5f41a383213b49a",
       "jobs": [
         {
           "id": "adr-release",
@@ -631,7 +631,7 @@
     {
       "path": ".github/workflows/buildchain-validate.yml",
       "authority": "qualification",
-      "definitionDigest": "sha256:a679c6e5cbea690f75143d850c562cee352317347c954930467df1912d70ca19",
+      "definitionDigest": "sha256:5f04a05b3d1e9741b26f2955c807b450fc958d4b55c1dccd1c7ebf5ac91968c7",
       "jobs": [
         {
           "id": "promotion-rehearsal",
@@ -875,7 +875,7 @@
     {
       "path": ".github/workflows/dco.yml",
       "authority": "qualification",
-      "definitionDigest": "sha256:c34ea72079f35dab0224f1a39865171dbd762b83a2625b5ba2c73caa14de800e",
+      "definitionDigest": "sha256:b48beb8feb2bf80fe8cba620b7b253306f4e4c17f0c7a9417e63ddbaa59332af",
       "jobs": [
         {
           "id": "signoff",
@@ -961,7 +961,7 @@
     {
       "path": ".github/workflows/docs-check.yml",
       "authority": "qualification",
-      "definitionDigest": "sha256:83fc7a3dc00ff895fdc0a761928836ac5c8a45e54d44816a263d42ed1b19b6b4",
+      "definitionDigest": "sha256:fe1473304662a8a1c05428af9ad98a5a9a8861b72aed81393c5a39681fec3b5b",
       "jobs": [
         {
           "id": "docs-check",
@@ -1880,7 +1880,7 @@
     {
       "path": ".github/workflows/source-acceptance.yml",
       "authority": "qualification",
-      "definitionDigest": "sha256:97060b5dd54286d6d8ee81abd2a3e796cdb76bcb4e1d2be6a8ba52883e4c23de",
+      "definitionDigest": "sha256:7a10bc63c635e5597b7b78bd126122d69122ca78c2eee24feb81f93f64536ffc",
       "jobs": [
         {
           "id": "source-acceptance",

--- a/docs/qualification/gates/workflow-bindings.json
+++ b/docs/qualification/gates/workflow-bindings.json
@@ -15,7 +15,8 @@
         "gate.catalog",
         "source.acceptance"
       ],
-      "activation": "dev pull request",
+      "activation": "manual diagnostic only; dev admission is owned by dev-candidate-source",
+      "currentSource": false,
       "adapter": {
         "type": "buildchain-source-staged",
         "kind": "job-uses",
@@ -167,7 +168,8 @@
       "gates": [
         "governance.adr-delivery"
       ],
-      "activation": "dev pull request",
+      "activation": "manual diagnostic only; dev admission is owned by dev-candidate-adr",
+      "currentSource": false,
       "invocation": {
         "args": []
       }
@@ -184,7 +186,8 @@
         "docs.contracts",
         "docs.prose"
       ],
-      "activation": "dev pull request touching declared documentation paths",
+      "activation": "manual diagnostic only; blocking dev documentation closure is included in dev-candidate-source",
+      "currentSource": false,
       "invocation": {
         "args": [
           "--capability",
@@ -198,14 +201,13 @@
       "workflow": ".github/workflows/dco.yml",
       "job": "signoff",
       "profiles": [
-        "dev-pr",
         "alpha-pr",
         "release-pr"
       ],
       "gates": [
         "governance.dco"
       ],
-      "activation": "all pull requests",
+      "activation": "pull requests except dev/v*/v*; dev DCO is owned by dev-candidate-dco",
       "adapter": {
         "type": "dco-shell",
         "kind": "run-step",
@@ -229,14 +231,13 @@
       "workflow": ".github/workflows/buildchain-validate.yml",
       "job": "validate",
       "profiles": [
-        "dev-pr",
         "alpha-pr",
         "release-pr"
       ],
       "gates": [
         "governance.buildchain-config"
       ],
-      "activation": "pull request or channel push",
+      "activation": "pull requests except dev/v*/v*, or alpha/release channel push",
       "adapter": {
         "type": "buildchain-config",
         "kind": "step-uses",
@@ -254,14 +255,13 @@
       "workflow": ".github/workflows/buildchain-validate.yml",
       "job": "promotion-rehearsal",
       "profiles": [
-        "dev-pr",
         "alpha-pr",
         "release-pr"
       ],
       "gates": [
         "governance.promotion-rehearsal"
       ],
-      "activation": "pull request or channel push",
+      "activation": "pull requests except dev/v*/v*, or alpha/release channel push",
       "invocation": {
         "args": []
       }

--- a/scripts/check-kungfu-gate-catalog.test.mjs
+++ b/scripts/check-kungfu-gate-catalog.test.mjs
@@ -80,16 +80,24 @@ function fixture() {
   return root;
 }
 
-test('required dev workflows are merge-queue compatible', () => {
+test('the single required dev workflow is merge-queue compatible', () => {
+  const source = fs.readFileSync(
+    path.join(ROOT, '.github/workflows/affected-native-pr.yml'),
+    'utf8',
+  );
+  assert.match(source, /^\s{2}pull_request\s*:/m);
+  assert.match(source, /^\s{2}merge_group\s*:/m);
+  assert.doesNotMatch(source, /github\.event\.pull_request/);
+
   for (const relative of [
     '.github/workflows/adr-release-gate.yml',
     '.github/workflows/source-acceptance.yml',
-    '.github/workflows/affected-native-pr.yml',
+    '.github/workflows/docs-check.yml',
   ]) {
-    const source = fs.readFileSync(path.join(ROOT, relative), 'utf8');
-    assert.match(source, /^\s{2}pull_request\s*:/m, relative);
-    assert.match(source, /^\s{2}merge_group\s*:/m, relative);
-    assert.doesNotMatch(source, /github\.event\.pull_request/, relative);
+    const diagnostic = fs.readFileSync(path.join(ROOT, relative), 'utf8');
+    assert.match(diagnostic, /^\s{2}workflow_dispatch\s*:/m, relative);
+    assert.doesNotMatch(diagnostic, /^\s{2}pull_request\s*:/m, relative);
+    assert.doesNotMatch(diagnostic, /^\s{2}merge_group\s*:/m, relative);
   }
 });
 

--- a/scripts/document-metadata-contract.test.mjs
+++ b/scripts/document-metadata-contract.test.mjs
@@ -13,6 +13,7 @@ import {
   validateDocumentMetadata,
   validateReachableCommit,
 } from './document-metadata-contract.mjs';
+import { sourceAcceptancePlan } from './source-acceptance.mjs';
 
 const roots = [];
 const REPO_ROOT = path.resolve(
@@ -863,16 +864,13 @@ test('accepts reachable full-SHA implementation and closure evidence', () => {
   assert.deepEqual(findings, []);
 });
 
-test('pins PR evidence reachability to the workflow base SHA', () => {
-  const workflow = fs.readFileSync(
-    path.join(REPO_ROOT, '.github/workflows/docs-check.yml'),
-    'utf8',
+test('pins PR evidence reachability to the source-acceptance base SHA', () => {
+  const base = 'a'.repeat(40);
+  const documentation = sourceAcceptancePlan([], base).find(
+    (step) => step.label === 'documentation contracts',
   );
-  assert.match(workflow, /"scripts\/document-metadata-contract\.mjs"/);
-  assert.match(
-    workflow,
-    /KUNGFU_ADR_EVIDENCE_BASE_SHA:\s*\$\{\{ github\.event\.pull_request\.base\.sha \}\}/,
-  );
+  assert.equal(documentation?.env?.KUNGFU_ADR_EVIDENCE_BASE_SHA, base);
+  assert.deepEqual(documentation?.args, ['scripts/run-docs-source-check.mjs']);
 });
 
 test('runs distributed ADR identity tests in both documentation gates', () => {

--- a/scripts/source-acceptance.mjs
+++ b/scripts/source-acceptance.mjs
@@ -157,8 +157,11 @@ export function sourceChangedFiles() {
   return [...files];
 }
 
-/** @param {string[]} files */
-export function sourceAcceptancePlan(files) {
+/**
+ * @param {string[]} files
+ * @param {string} [evidenceBaseCommit]
+ */
+export function sourceAcceptancePlan(files, evidenceBaseCommit = '') {
   const nodeChecks = [
     ['no Bash scripts', 'scripts/no-bash-guard.mjs'],
     ['Shifu entry contract', 'scripts/check-shifu-entry-contract.mjs'],
@@ -264,6 +267,13 @@ export function sourceAcceptancePlan(files) {
       label,
       command: process.execPath,
       args,
+      env:
+        label === 'documentation contracts' && evidenceBaseCommit
+          ? {
+              ...process.env,
+              KUNGFU_ADR_EVIDENCE_BASE_SHA: evidenceBaseCommit,
+            }
+          : undefined,
     })),
     {
       label: 'source-acceptance contract tests',
@@ -486,7 +496,8 @@ function run(step) {
 function main() {
   const files = sourceChangedFiles();
   console.log(`[source-acceptance] changed files: ${files.length}`);
-  for (const step of sourceAcceptancePlan(files)) run(step);
+  for (const step of sourceAcceptancePlan(files, sourceMergeBase().sha))
+    run(step);
   console.log('\n[source-acceptance] build-free source gate passed');
 }
 


### PR DESCRIPTION
## Summary

Finish the staged dev CI transition proven by #1254: the single `affected-native / linux` aggregate now owns dev pull-request admission and merge-group qualification, while duplicate standalone dev entrypoints are retired.

## Changes

- make Source Acceptance, ADR Release Gate, and Docs Check manual diagnostics
- make DCO and Buildchain Validate ignore `dev/v*/v*` while preserving non-dev and alpha/release responsibilities
- retain the exact PR evidence-base SHA inside aggregate source acceptance
- refresh workflow authority, Gate bindings, ADR/docs, and contract tests
- keep branch protection on the already-proven single required aggregate

## Verification

- `./shifu check:source` (passed; source contract suite 529 passed, 2 platform skips, zero failures)
- `./shifu check:gate-catalog` (38 gates, 6 profiles, 25 structured invocations, 17 workflows)
- focused source/document/catalog contracts (72 passed)
- staged pre-commit repository gate (passed)
- affected-native plan: authoritative native qualification required; four-language SDK wire-contract not required

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "implemented",
  "adrs": ["SHIFU-ADR-0004"],
  "summary": "Retire duplicate dev qualification entrypoints after the staged aggregate was proven on pull_request and merge_group.",
  "verification": ["./shifu check:source", "./shifu check:gate-catalog", "pull_request and merge_group workflow observation"]
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

This only changes scheduling authority and removes redundant dev triggers. It does not weaken source, governance, native, SDK, Shifu, KFD, alpha, or release qualification.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed
