### PR TITLE
fix(core): restore witnessed documentation material

### DIFF
--- a/.buildchain/kfd/kfd-1/documentation-pack.witness.json
+++ b/.buildchain/kfd/kfd-1/documentation-pack.witness.json
@@ -115,8 +115,8 @@
       "weldRationale": "Buildchain attests exact bytes while Xinfa remains the documentation compiler authority.",
       "sourcePath": ".xinfa/product-documentation-pack.json",
       "artifactPath": "agent/documentation-selector.json",
-      "sourceSha256": "38986d571fc5ef54f773cb239cfbd5f6dd516cfd7863616f99b31a9eeb461813",
-      "expectedSha256": "38986d571fc5ef54f773cb239cfbd5f6dd516cfd7863616f99b31a9eeb461813",
+      "sourceSha256": "a4145ec59d43837a26cb9039f793a945e83b6d7008bf39436b449c22dbfe0572",
+      "expectedSha256": "a4145ec59d43837a26cb9039f793a945e83b6d7008bf39436b449c22dbfe0572",
       "byteForByte": true,
       "impactProjection": {
         "breaking": "root mismatch or missing packaged bytes rejects the old passport",

--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -6,7 +6,7 @@
   "supportLevel": "release",
   "source": {
     "cwd": ".",
-    "sourceSha": "7aefdb783021bcfb0779fd3f7cf365a5d7a6201c",
+    "sourceSha": "87a0773ffbb14698b10e78d70aad775f4f5baff8",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
     "registryDigest": "sha256:db8f9095bb2ae7745dae30f015c8f7dcbe2ace6e4d5f200911e2167e20fd7c1e"
   },

--- a/.xinfa/product-documentation-pack.json
+++ b/.xinfa/product-documentation-pack.json
@@ -4,5 +4,9 @@
   "contextPackRoot": "sha256:70f584ba2d28b01d2b76b9fc76582deb791b88dba8eff2f0a5212ed6e941be9b",
   "visibility": "public",
   "compilerAuthority": "xinfa",
-  "runtimeAuthority": "read-only"
+  "runtimeAuthority": "read-only",
+  "materialSource": {
+    "kind": "git-history",
+    "commit": "19915bafad261d8d9357149b53ff584c9db56bcf"
+  }
 }

--- a/framework/core/.gyp/run-freeze.js
+++ b/framework/core/.gyp/run-freeze.js
@@ -152,6 +152,7 @@ function documentationAtlasSource(repository = path.resolve(CORE, '..', '..')) {
       // A normal Buildchain GitHub fallback is deliberately shallow. Fetch the
       // one selector-pinned material commit instead of widening every checkout.
     }
+    /** @type {string[]} */
     let remotes = [];
     try {
       remotes = cp
@@ -200,6 +201,7 @@ function documentationAtlasSource(repository = path.resolve(CORE, '..', '..')) {
     const target = path.join(root, ...relative.split('/'));
     let bytes = fs.existsSync(target) ? fs.readFileSync(target) : null;
     const expected = String(artifact.content_root || '');
+    /** @param {Buffer} value */
     const valid = (value) =>
       value.length === artifact.size &&
       `sha256:${crypto.createHash('sha256').update(value).digest('hex')}` ===

--- a/framework/core/.gyp/run-freeze.js
+++ b/framework/core/.gyp/run-freeze.js
@@ -16,6 +16,7 @@
 // @ts-check
 
 const cp = require('node:child_process');
+const crypto = require('node:crypto');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
@@ -108,8 +109,7 @@ function agentPackDataArgs() {
   return args;
 }
 
-function documentationAtlasSource() {
-  const repository = path.resolve(CORE, '..', '..');
+function documentationAtlasSource(repository = path.resolve(CORE, '..', '..')) {
   const selector = path.join(
     repository,
     '.xinfa',
@@ -121,7 +121,9 @@ function documentationAtlasSource() {
   const contract = JSON.parse(fs.readFileSync(selector, 'utf8'));
   if (
     contract.schema !== 'kungfu.product-documentation-pack/v1' ||
-    !/^sha256:[0-9a-f]{64}$/.test(contract.atlasRoot || '')
+    !/^sha256:[0-9a-f]{64}$/.test(contract.atlasRoot || '') ||
+    contract.materialSource?.kind !== 'git-history' ||
+    !/^[0-9a-f]{40}$/.test(contract.materialSource?.commit || '')
   ) {
     throw new Error('[freeze] invalid product Documentation Atlas selector');
   }
@@ -132,6 +134,109 @@ function documentationAtlasSource() {
     'sha256',
     contract.atlasRoot.slice('sha256:'.length),
   );
+  const manifest = JSON.parse(
+    fs.readFileSync(path.join(root, 'manifest.json'), 'utf8'),
+  );
+  const sourceCommit = contract.materialSource.commit;
+  let sourceCommitAvailable = false;
+  const ensureSourceCommit = () => {
+    if (sourceCommitAvailable) return;
+    try {
+      cp.execFileSync('git', ['cat-file', '-e', `${sourceCommit}^{commit}`], {
+        cwd: repository,
+        stdio: 'ignore',
+      });
+      sourceCommitAvailable = true;
+      return;
+    } catch {
+      // A normal Buildchain GitHub fallback is deliberately shallow. Fetch the
+      // one selector-pinned material commit instead of widening every checkout.
+    }
+    let remotes = [];
+    try {
+      remotes = cp
+        .execFileSync('git', ['remote'], { cwd: repository, encoding: 'utf8' })
+        .split('\n')
+        .filter(Boolean);
+    } catch {
+      // The fail-closed error below also covers a source tree without Git.
+    }
+    const materialRef = `refs/buildchain/documentation-material/${contract.atlasRoot.slice('sha256:'.length)}`;
+    for (const remote of remotes) {
+      try {
+        cp.execFileSync(
+          'git',
+          [
+            'fetch',
+            '--no-tags',
+            '--depth=1',
+            remote,
+            `${sourceCommit}:${materialRef}`,
+          ],
+          { cwd: repository, stdio: 'ignore' },
+        );
+        sourceCommitAvailable = true;
+        return;
+      } catch {
+        // Try the next already-configured repository remote.
+      }
+    }
+    throw new Error(
+      `[freeze] Documentation Atlas material commit is unavailable: ${sourceCommit}`,
+    );
+  };
+  for (const artifact of manifest.artifacts || []) {
+    const relative = String(artifact.path || '');
+    if (
+      !relative ||
+      path.isAbsolute(relative) ||
+      relative.includes('\\') ||
+      relative.split('/').includes('..')
+    ) {
+      throw new Error(
+        `[freeze] invalid Documentation Atlas artifact path: ${relative}`,
+      );
+    }
+    const target = path.join(root, ...relative.split('/'));
+    let bytes = fs.existsSync(target) ? fs.readFileSync(target) : null;
+    const expected = String(artifact.content_root || '');
+    const valid = (value) =>
+      value.length === artifact.size &&
+      `sha256:${crypto.createHash('sha256').update(value).digest('hex')}` ===
+        expected;
+    if (bytes !== null && !valid(bytes)) {
+      throw new Error(
+        `[freeze] Documentation Atlas material differs from its tracked witness: ${relative}`,
+      );
+    }
+    if (bytes === null) {
+      const repositoryRelative = path
+        .relative(repository, target)
+        .split(path.sep)
+        .join('/');
+      ensureSourceCommit();
+      try {
+        const candidate = cp.execFileSync(
+          'git',
+          ['show', `${sourceCommit}:${repositoryRelative}`],
+          { cwd: repository, maxBuffer: 32 * 1024 * 1024 },
+        );
+        if (valid(candidate)) bytes = candidate;
+      } catch {
+        // The exact content-root check below owns the final failure.
+      }
+      if (bytes === null) {
+        throw new Error(
+          `[freeze] Documentation Atlas material source differs from its tracked witness: ${relative}`,
+        );
+      }
+      fs.mkdirSync(path.dirname(target), { recursive: true });
+      fs.writeFileSync(target, bytes);
+      console.log(
+        `[freeze] restored witnessed Documentation Atlas material from Git history: ${relative}`,
+      );
+    }
+  }
   const atlas = JSON.parse(
     fs.readFileSync(path.join(root, 'atlas.json'), 'utf8'),
   );
@@ -839,4 +944,6 @@ function main() {
   copyWheel();
 }
 
-main();
+if (require.main === module) main();
+
+module.exports = { documentationAtlasSource };

--- a/scripts/documentation-product-pack.test.mjs
+++ b/scripts/documentation-product-pack.test.mjs
@@ -2,13 +2,19 @@
 
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
+import crypto from 'node:crypto';
 import fs from 'node:fs';
+import { createRequire } from 'node:module';
 import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
 import { fileURLToPath } from 'node:url';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const require = createRequire(import.meta.url);
+const { documentationAtlasSource } = require(
+  path.join(ROOT, 'framework', 'core', '.gyp', 'run-freeze.js'),
+);
 const SELECTOR = JSON.parse(
   fs.readFileSync(path.join(ROOT, '.xinfa', 'product-documentation-pack.json')),
 );
@@ -19,6 +25,7 @@ const ATLAS = path.join(
   'sha256',
   SELECTOR.atlasRoot.slice('sha256:'.length),
 );
+documentationAtlasSource(ROOT);
 
 function probe(atlas, expression = 'verify(root)') {
   const program = `
@@ -79,4 +86,75 @@ test('freeze assembly stages the selected verified Atlas into the product', () =
   assert.match(source, /documentationAtlasSource\(\)/);
   assert.match(source, /product-documentation-pack\.json/);
   assert.match(source, /agent', 'documentation'/);
+});
+
+test('freeze restores an ignored product Atlas body from exact witnessed Git history', (t) => {
+  const repository = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'kungfu-doc-history-'),
+  );
+  t.after(() => fs.rmSync(repository, { recursive: true, force: true }));
+  const runGit = (...args) => {
+    const result = spawnSync('git', args, {
+      cwd: repository,
+      encoding: 'utf8',
+    });
+    assert.equal(result.status, 0, result.stderr);
+  };
+  runGit('init', '-q');
+  runGit('config', 'user.name', 'Documentation Test');
+  runGit('config', 'user.email', 'documentation-test@example.invalid');
+
+  const atlas = Buffer.from(
+    `${JSON.stringify({
+      atlas_root: SELECTOR.atlasRoot,
+      roots: { context_pack: SELECTOR.contextPackRoot },
+      visibility: 'public',
+    })}\n`,
+  );
+  const relative = `.xinfa/baselines/sha256/${SELECTOR.atlasRoot.slice(7)}`;
+  const baseline = path.join(repository, relative);
+  fs.mkdirSync(baseline, { recursive: true });
+  fs.writeFileSync(path.join(baseline, 'atlas.json'), atlas);
+  fs.writeFileSync(
+    path.join(baseline, 'manifest.json'),
+    `${JSON.stringify({
+      artifacts: [
+        {
+          content_root: `sha256:${crypto.createHash('sha256').update(atlas).digest('hex')}`,
+          path: 'atlas.json',
+          size: atlas.length,
+        },
+      ],
+    })}\n`,
+  );
+  runGit('add', '.');
+  runGit('commit', '-qm', 'test: retain product documentation material');
+  const materialCommit = spawnSync('git', ['rev-parse', 'HEAD'], {
+    cwd: repository,
+    encoding: 'utf8',
+  }).stdout.trim();
+  fs.writeFileSync(
+    path.join(repository, '.xinfa', 'product-documentation-pack.json'),
+    `${JSON.stringify({
+      ...SELECTOR,
+      materialSource: { kind: 'git-history', commit: materialCommit },
+    })}\n`,
+  );
+  fs.rmSync(path.join(baseline, 'atlas.json'));
+  runGit('add', '.');
+  runGit('commit', '-qm', 'test: publish witness only');
+
+  const checkout = path.join(repository, 'shallow');
+  runGit('clone', '--depth=1', `file://${repository}`, checkout);
+  const restoredBaseline = path.join(checkout, relative);
+  assert.equal(documentationAtlasSource(checkout), restoredBaseline);
+  assert.deepEqual(
+    fs.readFileSync(path.join(restoredBaseline, 'atlas.json')),
+    atlas,
+  );
+  fs.appendFileSync(path.join(restoredBaseline, 'atlas.json'), ' ');
+  assert.throws(
+    () => documentationAtlasSource(checkout),
+    /material differs from its tracked witness/,
+  );
 });


### PR DESCRIPTION
Restore the product Documentation Atlas from an immutable selector-pinned Git material commit when Buildchain uses a witness-only or shallow checkout. Verify every restored artifact against its tracked size and SHA-256 witness, add shallow-clone and tamper coverage, and refresh affected KFD evidence.

<!-- kungfu-adr-release:v1 {"schema":"kungfu.adr-release-pr/v1","kind":"adr-neutral","reason":"Repairs release packaging after the accepted witness-only baseline split without changing its architecture contract"} -->