### PR TITLE
fix(shifu): dispatch Windows lifecycle after resolution

### DIFF
--- a/scripts/check-shifu-entry-contract.test.mjs
+++ b/scripts/check-shifu-entry-contract.test.mjs
@@ -164,32 +164,19 @@ test('cold source acquisition copies the binary from its isolated Cargo target',
   assert.doesNotMatch(windowsAcquire, /crates\\target\\release/);
 });
 
-test('Windows freshly resolved launchers dispatch outside parsed build blocks', () => {
+test('Windows launchers dispatch the original arguments at every resolution path', () => {
   const windows = fs.readFileSync(path.join(ROOT, 'shifu.cmd'), 'utf8');
   assert.match(
     windows,
-    /set "_KFC_RESOLVED_BIN=%SHIFU_BIN%"\s+goto runresolved/u,
+    /if defined SHIFU_BIN if exist "%SHIFU_BIN%" \(\s+"%SHIFU_BIN%" %\*\s+exit \/b !errorlevel!/u,
   );
   assert.match(
     windows,
-    /set "_KFC_RESOLVED_BIN=%_KFC_DEVBIN%"\s+goto runresolved/u,
+    /if not defined _KFC_DIRTY if exist "%_KFC_DEVBIN%" \([\s\S]*?"%_KFC_DEVBIN%" %\*\s+exit \/b !errorlevel!/u,
   );
-  assert.ok(
-    windows.match(/set "_KFC_RESOLVED_BIN=%_KFC_DEVBIN%"\s+goto runresolved/gu)
-      ?.length >= 2,
-  );
-  assert.ok(
-    windows.match(/set "_KFC_RESOLVED_BIN=%_KFC_BIN%"\s+goto runresolved/gu)
-      ?.length >= 3,
-  );
-  assert.doesNotMatch(
-    windows,
-    /^\s+"%(?:SHIFU_BIN|_KFC_DEVBIN|_KFC_BIN)%" %\*/gmu,
-  );
-  assert.match(
-    windows,
-    /:runresolved\s+rem[\s\S]*?"%_KFC_RESOLVED_BIN%" %\*\s+exit \/b !errorlevel!/u,
-  );
+  assert.ok(windows.match(/^\s+"!_KFC_DEVBIN!" %\*/gmu)?.length >= 1);
+  assert.ok(windows.match(/^\s+"(?:%|!)_KFC_BIN(?:%|!)" %\*/gmu)?.length >= 3);
+  assert.doesNotMatch(windows, /:runresolved/u);
 });
 
 test('runtime guard rejects a direct task and accepts Shifu provenance', () => {

--- a/scripts/run-shifu-lifecycle.test.mjs
+++ b/scripts/run-shifu-lifecycle.test.mjs
@@ -174,7 +174,7 @@ test(
 );
 
 test(
-  'Windows explicit launcher survives direct and cache-applied lifecycle re-entry',
+  'Windows cold, warm, explicit, and cache-applied launchers dispatch ordinary commands',
   { skip: process.platform !== 'win32' },
   (t) => {
     const cache = fs.mkdtempSync(
@@ -211,13 +211,13 @@ test(
         },
         windowsHide: true,
       });
-    const assertProfile = (result) => {
+    const assertDoctor = (result) => {
       assert.equal(result.status, 0, result.stderr || result.error?.message);
-      assert.equal(
-        JSON.parse(result.stdout).$id,
-        'https://libkungfu.dev/schemas/shifu/cache-profile-v1.schema.json',
-      );
+      assert.match(`${result.stdout}\n${result.stderr}`, /shifu doctor/u);
     };
+
+    assertDoctor(invoke(['direct', 'doctor']));
+    assertDoctor(invoke(['direct', 'doctor']));
 
     const inheritedBinary = Object.entries(process.env).find(
       ([name]) => name.toUpperCase() === 'SHIFU_BIN',
@@ -237,13 +237,13 @@ test(
       fs.existsSync(sourceBinary),
       'Windows lifecycle test needs the launcher built by shifu.workspace',
     );
-    assertProfile(
-      invoke(['direct', 'cache', 'schema', 'profile'], {
+    assertDoctor(
+      invoke(['direct', 'doctor'], {
         SHIFU_BIN: sourceBinary,
       }),
     );
-    assertProfile(
-      invoke(['cache-apply', 'cache', 'schema', 'profile'], {
+    assertDoctor(
+      invoke(['cache-apply', 'doctor'], {
         SHIFU_BIN: sourceBinary,
       }),
     );

--- a/shifu.cmd
+++ b/shifu.cmd
@@ -288,8 +288,8 @@ rem -- Native launcher resolution ----------------------------------------------
 if "%SHIFU_NATIVE%"=="0" goto inscript
 
 if defined SHIFU_BIN if exist "%SHIFU_BIN%" (
-  set "_KFC_RESOLVED_BIN=%SHIFU_BIN%"
-  goto runresolved
+  "%SHIFU_BIN%" %*
+  exit /b !errorlevel!
 )
 
 set "_KFC_VER="
@@ -322,8 +322,8 @@ set "_KFC_DEVDIR=%_KFC_CACHE%\kungfu\shifu\%_KFC_VER%-%_KFC_SRC%"
 set "_KFC_DEVBIN=%_KFC_DEVDIR%\shifu.exe"
 if not defined _KFC_DIRTY if exist "%_KFC_DEVBIN%" (
   set "SHIFU_BIN=%_KFC_DEVBIN%"
-  set "_KFC_RESOLVED_BIN=%_KFC_DEVBIN%"
-  goto runresolved
+  "%_KFC_DEVBIN%" %*
+  exit /b !errorlevel!
 )
 rem Build with an out-of-repo target dir (keyed per checkout) so read-only
 rem checkouts build too.
@@ -374,8 +374,8 @@ if "!_KFC_BUILD_ERROR!"=="0" (
     rem Source slots are catalog entries. The native catalog retires only
     rem proven ancestors after a successful promotion.
     set "SHIFU_BIN=%_KFC_DEVBIN%"
-    set "_KFC_RESOLVED_BIN=%_KFC_DEVBIN%"
-    goto runresolved
+    "!_KFC_DEVBIN!" %*
+    exit /b !errorlevel!
   )
 )
 set "CARGO_TARGET_DIR="
@@ -384,8 +384,8 @@ echo shifu: source build failed; falling back to the release-pinned launcher 1>&
 
 :pinslot
 if exist "%_KFC_BIN%" (
-  set "_KFC_RESOLVED_BIN=%_KFC_BIN%"
-  goto runresolved
+  "%_KFC_BIN%" %*
+  exit /b !errorlevel!
 )
 
 rem Machines with both prerequisites keep the proven in-script path below;
@@ -404,8 +404,8 @@ where curl >nul 2>nul && (
   if not exist "%_KFC_CACHE%\kungfu\shifu\%_KFC_VER%" mkdir "%_KFC_CACHE%\kungfu\shifu\%_KFC_VER%" >nul 2>nul
   curl -fsSL --retry 2 --connect-timeout 20 -o "%_KFC_BIN%.tmp" "%_KFC_URL%" && (
     move /y "%_KFC_BIN%.tmp" "%_KFC_BIN%" >nul
-    set "_KFC_RESOLVED_BIN=%_KFC_BIN%"
-    goto runresolved
+    "!_KFC_BIN!" %*
+    exit /b !errorlevel!
   )
   del "%_KFC_BIN%.tmp" >nul 2>nul
 )
@@ -424,8 +424,8 @@ where cargo >nul 2>nul && (
       ) else (
         set "CARGO_TARGET_DIR="
       )
-      set "_KFC_RESOLVED_BIN=%_KFC_BIN%"
-      goto runresolved
+      "!_KFC_BIN!" %*
+      exit /b !errorlevel!
     )
   )
   if defined _KFC_ACQUIRE_PREV_CARGO_TARGET_DIR (
@@ -436,13 +436,6 @@ where cargo >nul 2>nul && (
 )
 echo shifu: native launcher unavailable; falling back to the in-script bootstrap 1>&2
 goto inscript
-
-:runresolved
-rem Dispatch outside the parenthesized build/acquire blocks. cmd.exe expands
-rem percent arguments while parsing a block; keeping the final invocation at a
-rem top-level label preserves the original multi-argument lifecycle payload.
-"%_KFC_RESOLVED_BIN%" %*
-exit /b !errorlevel!
 
 :inscript
 rem In-script fallback versions of the launcher-owned flags (the native


### PR DESCRIPTION
## Summary

Restore direct dispatch at every resolved Windows launcher path so ordinary lifecycle tasks reach pnpm after a cold, warm, explicit, or release-pinned resolution.

## Diagnosis

Alpha promotion Build run 29959438156 compiled the launcher and returned 0 without entering `dist`; the following `verify` found only the qualification summary instead of the required product artifacts. The `:runresolved` repair added after the last successful three-platform Build was the behavioral delta. Its tests exercised `--version` and the build-free `cache` shortcut, not an ordinary command.

## Changes

- dispatch the resolved executable directly with the original `%*` vector
- use delayed expansion only for binary paths first assigned inside parsed blocks
- add a Windows live probe that requires `doctor` output across cold, warm, explicit, and cache-applied paths
- update the static contract to reject reintroduction of the no-op `:runresolved` path

## Verification

- targeted entry tests: 3 passed
- lifecycle tests: 10 passed, 2 Windows-only skipped on macOS
- full staged repository gate, docs gate, Biome formatting, and DCO: passed

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Repair a Windows launcher argument-dispatch regression without changing any ADR projection."
}
-->