### PR TITLE
fix(shifu): dispatch after Windows source build

### DIFF
--- a/scripts/check-shifu-entry-contract.test.mjs
+++ b/scripts/check-shifu-entry-contract.test.mjs
@@ -139,7 +139,9 @@ test('source-fresh launchers pin nested Shifu entry to the resolved binary', () 
     posix.match(/SHIFU_BIN="\$kungfu_dev_bin" exec "\$kungfu_dev_bin"/g)
       ?.length >= 2,
   );
-  assert.ok(windows.match(/set "SHIFU_BIN=%_KFC_DEVBIN%"/g)?.length >= 2);
+  assert.match(windows, /set "SHIFU_BIN=%_KFC_DEVBIN%"/u);
+  assert.match(windows, /set "_KFC_SOURCE_BIN=%_KFC_DEVBIN%"/u);
+  assert.match(windows, /set "SHIFU_BIN=%_KFC_SOURCE_BIN%"/u);
 });
 
 test('cold source acquisition copies the binary from its isolated Cargo target', () => {
@@ -164,7 +166,7 @@ test('cold source acquisition copies the binary from its isolated Cargo target',
   assert.doesNotMatch(windowsAcquire, /crates\\target\\release/);
 });
 
-test('Windows launchers dispatch the original arguments at every resolution path', () => {
+test('Windows launchers dispatch after resolution blocks and preserve arguments', () => {
   const windows = fs.readFileSync(path.join(ROOT, 'shifu.cmd'), 'utf8');
   assert.match(
     windows,
@@ -174,7 +176,15 @@ test('Windows launchers dispatch the original arguments at every resolution path
     windows,
     /if not defined _KFC_DIRTY if exist "%_KFC_DEVBIN%" \([\s\S]*?"%_KFC_DEVBIN%" %\*\s+exit \/b !errorlevel!/u,
   );
-  assert.ok(windows.match(/^\s+"!_KFC_DEVBIN!" %\*/gmu)?.length >= 1);
+  assert.match(
+    windows,
+    /set "_KFC_SOURCE_BIN=!_KFC_TGT!\\release\\shifu\.exe"/u,
+  );
+  assert.match(
+    windows,
+    /if not defined _KFC_SOURCE_BIN goto sourcebuildfailed\s+set "SHIFU_BIN=%_KFC_SOURCE_BIN%"\s+"%_KFC_SOURCE_BIN%" %\*\s+exit \/b !errorlevel!/u,
+  );
+  assert.doesNotMatch(windows, /^\s+"!_KFC_DEVBIN!" %\*/gmu);
   assert.ok(windows.match(/^\s+"(?:%|!)_KFC_BIN(?:%|!)" %\*/gmu)?.length >= 3);
   assert.doesNotMatch(windows, /:runresolved/u);
 });

--- a/shifu.cmd
+++ b/shifu.cmd
@@ -330,6 +330,7 @@ rem checkouts build too.
 set "_KFC_TGTKEY=%CD:\=_%"
 set "_KFC_TGTKEY=%_KFC_TGTKEY::=%"
 set "_KFC_TGT=%_KFC_CACHE%\kungfu\shifu\cargo-target\%_KFC_TGTKEY%"
+set "_KFC_SOURCE_BIN="
 echo shifu: building launcher from source ^(cargo build --release^) 1>&2
 set "CARGO_TARGET_DIR=%_KFC_TGT%"
 cargo build --release --locked --manifest-path crates\Cargo.toml -p shifu 1>&2
@@ -347,6 +348,9 @@ if not "!_KFC_BUILD_ERROR!"=="0" (
 )
 if "!_KFC_BUILD_ERROR!"=="0" (
   set "CARGO_TARGET_DIR="
+  rem The just-built target is always runnable. Publishing a warm cache slot
+  rem is an optimization and must not decide whether the original task runs.
+  set "_KFC_SOURCE_BIN=!_KFC_TGT!\release\shifu.exe"
   if not exist "%_KFC_DEVDIR%" mkdir "%_KFC_DEVDIR%" >nul 2>nul
   copy /y "%_KFC_TGT%\release\shifu.exe" "%_KFC_DEVBIN%" >nul && (
     set "_KFC_HEAD="
@@ -373,11 +377,18 @@ if "!_KFC_BUILD_ERROR!"=="0" (
     move /y "%_KFC_DEVDIR%\meta.env.tmp" "%_KFC_DEVDIR%\meta.env" >nul
     rem Source slots are catalog entries. The native catalog retires only
     rem proven ancestors after a successful promotion.
-    set "SHIFU_BIN=%_KFC_DEVBIN%"
-    "!_KFC_DEVBIN!" %*
-    exit /b !errorlevel!
+    set "_KFC_SOURCE_BIN=%_KFC_DEVBIN%"
   )
 )
+rem Dispatch only after the build/cache blocks have closed. This preserves the
+rem batch argument vector and still runs the fresh target when cache publication
+rem was denied by a scanner, lock, or transient filesystem error.
+if not defined _KFC_SOURCE_BIN goto sourcebuildfailed
+set "SHIFU_BIN=%_KFC_SOURCE_BIN%"
+"%_KFC_SOURCE_BIN%" %*
+exit /b !errorlevel!
+
+:sourcebuildfailed
 set "CARGO_TARGET_DIR="
 set "_KFC_BUILD_ERROR="
 echo shifu: source build failed; falling back to the release-pinned launcher 1>&2


### PR DESCRIPTION
## Summary

Separate Windows source-launcher resolution from task dispatch so a successful cold build cannot return 0 before executing the original lifecycle command.

## Diagnosis

Alpha Product Build runs 29959438156 and 29961313640 both showed the same runtime signature: the launcher compiled successfully, no `doctor`/install/dist output followed, every later stage rebuilt the launcher, and `verify` found only one of eight required artifacts. The cache publication and task invocation were nested inside the post-build command block, so that block remained an execution authority and could silently skip the task.

## Changes

- record the fresh target executable inside the build block and dispatch only after the block closes
- treat publishing the warm cache slot as an optimization, not a prerequisite for running the task
- fall back to the just-built target executable when cache publication is unavailable
- ratchet the static contract around top-level post-build dispatch; retain the Windows live `doctor` probe

## Verification

- targeted source-launcher contract tests: 4 passed
- lifecycle tests: 10 passed, 2 Windows-only skipped on macOS
- full staged repository gate, docs gate, Biome formatting, and DCO: passed

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Repair a Windows post-build dispatch defect without changing any ADR projection."
}
-->