### PR TITLE
fix(shifu): inline Windows environment loading

### DIFF
--- a/scripts/check-shifu-entry-contract.test.mjs
+++ b/scripts/check-shifu-entry-contract.test.mjs
@@ -132,6 +132,16 @@ test('Windows source-fresh launcher retries one transient build failure', () => 
   assert.match(sourceBuild, /if "!_KFC_BUILD_ERROR!"=="0" \(/);
 });
 
+test('Windows local environment parsing is inline and label-free', () => {
+  const windows = fs.readFileSync(path.join(ROOT, 'shifu.cmd'), 'utf8');
+  assert.match(
+    windows,
+    /for %%f in \("%_KFC_USERCFG%" "\.\\build-local\.env"\) do if exist "%%~f"/u,
+  );
+  assert.match(windows, /findstr \/b \/c:"export " "%%~f"/u);
+  assert.doesNotMatch(windows, /call :loadenv|^:loadenv$/mu);
+});
+
 test('source-fresh launchers pin nested Shifu entry to the resolved binary', () => {
   const posix = fs.readFileSync(path.join(ROOT, 'shifu'), 'utf8');
   const windows = fs.readFileSync(path.join(ROOT, 'shifu.cmd'), 'utf8');

--- a/shifu.cmd
+++ b/shifu.cmd
@@ -50,8 +50,20 @@ set "_KFC_EXPLICIT_CACHE_SCOPE=%SHIFU_CACHE_SCOPE%"
 set "_KFC_USERCFG=%USERPROFILE%\.config\kungfu\build-local.env"
 if defined XDG_CONFIG_HOME set "_KFC_USERCFG=%XDG_CONFIG_HOME%\kungfu\build-local.env"
 if "%SHIFU_CACHE_ACTIVE%"=="1" goto proxyloaded
-call :loadenv "%_KFC_USERCFG%"
-call :loadenv ".\build-local.env"
+rem Keep this inline: cmd.exe can lose a trailing batch label when the shim is
+rem entered recursively through Node's shell mode, leaking an otherwise benign
+rem "cannot find the batch label" diagnostic into strict child protocols.
+for %%f in ("%_KFC_USERCFG%" ".\build-local.env") do if exist "%%~f" (
+  for /f "usebackq tokens=1,* delims==" %%a in (`findstr /b /c:"export " "%%~f"`) do (
+    set "_kfc_k=%%a"
+    set "_kfc_v=%%b"
+    set "_kfc_k=!_kfc_k:export =!"
+    set "_kfc_v=!_kfc_v:'=!"
+    set "!_kfc_k!=!_kfc_v!"
+  )
+)
+set "_kfc_k="
+set "_kfc_v="
 :proxyloaded
 if defined _KFC_EXPLICIT_CACHE_REF set "SHIFU_CACHE_PROFILE_REF=%_KFC_EXPLICIT_CACHE_REF%"
 if defined _KFC_EXPLICIT_CACHE_DIGEST set "SHIFU_CACHE_PROFILE_DIGEST=%_KFC_EXPLICIT_CACHE_DIGEST%"
@@ -533,19 +545,3 @@ rem NOTE: use corepack.cmd (not bare "corepack"): fnm exec spawns the program di
 rem without applying PATHEXT, so bare "corepack" is not found on Windows (only corepack.cmd is).
 fnm exec --using-file -- corepack.cmd pnpm %*
 exit /b !errorlevel!
-
-rem -- Parse sh-format build-local.env `export KEY='VALUE'` lines -> set KEY=VALUE (pure cmd) --
-rem (Windows cmd cannot source sh; take export lines, strip the export prefix and single quotes;
-rem  mirror URLs have no embedded quotes/equals so this is safe.)
-:loadenv
-if not exist "%~1" goto :eof
-for /f "usebackq tokens=1,* delims==" %%a in (`findstr /b /c:"export " "%~1"`) do (
-  set "_kfc_k=%%a"
-  set "_kfc_v=%%b"
-  set "_kfc_k=!_kfc_k:export =!"
-  set "_kfc_v=!_kfc_v:'=!"
-  set "!_kfc_k!=!_kfc_v!"
-)
-set "_kfc_k="
-set "_kfc_v="
-goto :eof


### PR DESCRIPTION
## Summary

Inline the two Windows build-local.env reads and remove the trailing `:loadenv` batch subroutine. Recursive Node shell entry could make `cmd.exe` lose that label and leak `cannot find the batch label specified - loadenv` into strict child protocols.

## Verification

- entry-contract and lifecycle tests: 26 passed, 2 Windows-only skipped locally
- full staged gate passed
- regression contract requires inline parsing and forbids `call :loadenv` / `:loadenv`
- failure reproduced in alpha promotion PR #1274, Windows shifu CI job 89066975673

ADR-neutral bugfix; no ADR status transition.

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Repair Windows launcher environment parsing without changing any ADR projection."
}
-->