### PR TITLE
fix(profile): bind Assignment orchestration in GUI

### DIFF
--- a/extensions/work-dashboard/src/view/index.tsx
+++ b/extensions/work-dashboard/src/view/index.tsx
@@ -473,6 +473,17 @@ function AtlasProjectionView({
   const [newGoalObjective, setNewGoalObjective] = React.useState('');
   const [claimStatement, setClaimStatement] = React.useState('');
   const [evidenceEpisodes, setEvidenceEpisodes] = React.useState('');
+  const [assignmentAgent, setAssignmentAgent] =
+    React.useState('work-dashboard');
+  const [assignmentSlot, setAssignmentSlot] = React.useState('gui');
+  const [assignmentLeaseId, setAssignmentLeaseId] = React.useState('');
+  const [assignmentLeaseExpiresAt, setAssignmentLeaseExpiresAt] =
+    React.useState('');
+  const [assignmentExpectedPhase, setAssignmentExpectedPhase] =
+    React.useState('claimed');
+  const [assignmentNextPhase, setAssignmentNextPhase] =
+    React.useState('executing');
+  const [assignmentPhaseReason, setAssignmentPhaseReason] = React.useState('');
   const [bundlePath, setBundlePath] = React.useState('');
   const [importBundlePath, setImportBundlePath] = React.useState('');
   const [authorityInspection, setAuthorityInspection] =
@@ -487,6 +498,7 @@ function AtlasProjectionView({
     | 'import'
     | 'bundle'
     | 'claim'
+    | 'orchestrate'
     | 'review'
     | 'authority'
     | null
@@ -1059,6 +1071,77 @@ function AtlasProjectionView({
     }
   };
 
+  const claimAssignmentNow = async () => {
+    if (selectedMission === 'all' || !selectedGoal) {
+      setMessage(
+        'select an Initiative and Assignment before claiming execution',
+      );
+      return;
+    }
+    if (
+      !assignmentAgent.trim() ||
+      !assignmentSlot.trim() ||
+      !assignmentLeaseId.trim() ||
+      !assignmentLeaseExpiresAt.trim()
+    ) {
+      setMessage('agent, slot, lease id, and lease expiry are required');
+      return;
+    }
+    try {
+      const result = await atlas.claimAssignment(
+        selectedMission,
+        selectedGoal,
+        {
+          owner: actor,
+          agent: assignmentAgent,
+          slot: assignmentSlot,
+          leaseId: assignmentLeaseId,
+          leaseExpiresAt: assignmentLeaseExpiresAt,
+          authorizedBy: actor,
+          actorType: 'user',
+        },
+      );
+      setMessage(
+        `claimed ${result.claim.assignment_id}: ${result.claim.lease_id} until ${result.claim.lease_expires_at}`,
+      );
+      dashboardRefresh.request();
+      void refreshAssessment();
+    } catch (error) {
+      setMessage((error as Error).message);
+    }
+  };
+
+  const advanceAssignmentNow = async () => {
+    if (selectedMission === 'all' || !selectedGoal) {
+      setMessage('select an Initiative and Assignment before advancing it');
+      return;
+    }
+    if (!assignmentNextPhase.trim() || !assignmentPhaseReason.trim()) {
+      setMessage('next phase and transition reason are required');
+      return;
+    }
+    try {
+      const result = await atlas.advanceAssignment(
+        selectedMission,
+        selectedGoal,
+        {
+          toPhase: assignmentNextPhase,
+          expectedPhase: assignmentExpectedPhase,
+          actor,
+          actorType: 'user',
+          reason: assignmentPhaseReason,
+        },
+      );
+      setMessage(
+        `advanced ${result.transition.assignment_subject}: ${result.transition.from_phase} -> ${result.transition.to_phase}`,
+      );
+      dashboardRefresh.request();
+      void refreshAssessment();
+    } catch (error) {
+      setMessage((error as Error).message);
+    }
+  };
+
   const reviewCompletionNow = async () => {
     if (selectedMission === 'all' || !selectedGoal) {
       setCompletionError('select a Mission and Go before independent review');
@@ -1566,6 +1649,9 @@ function AtlasProjectionView({
                 <SmallButton onClick={() => setActionPanel('claim')}>
                   claim completion
                 </SmallButton>
+                <SmallButton onClick={() => setActionPanel('orchestrate')}>
+                  orchestrate Assignment
+                </SmallButton>
                 <SmallButton onClick={() => setActionPanel('review')}>
                   independent review
                 </SmallButton>
@@ -1768,6 +1854,54 @@ function AtlasProjectionView({
               />
               <SmallButton onClick={() => void claimAndAssessNow()}>
                 claim and assess
+              </SmallButton>
+            </>
+          )}
+          {actionPanel === 'orchestrate' && (
+            <>
+              <div style={{ ...mono, color: '#858585' }}>
+                Assignment: {selectedGoal ?? 'select one first'}
+              </div>
+              <TextInput
+                value={assignmentAgent}
+                placeholder="acting agent identity"
+                onChange={setAssignmentAgent}
+              />
+              <TextInput
+                value={assignmentSlot}
+                placeholder="execution slot"
+                onChange={setAssignmentSlot}
+              />
+              <TextInput
+                value={assignmentLeaseId}
+                placeholder="stable lease id"
+                onChange={setAssignmentLeaseId}
+              />
+              <TextInput
+                value={assignmentLeaseExpiresAt}
+                placeholder="lease expiry (ISO-8601)"
+                onChange={setAssignmentLeaseExpiresAt}
+              />
+              <SmallButton onClick={() => void claimAssignmentNow()}>
+                claim execution lease
+              </SmallButton>
+              <TextInput
+                value={assignmentExpectedPhase}
+                placeholder="expected phase"
+                onChange={setAssignmentExpectedPhase}
+              />
+              <TextInput
+                value={assignmentNextPhase}
+                placeholder="next phase"
+                onChange={setAssignmentNextPhase}
+              />
+              <TextInput
+                value={assignmentPhaseReason}
+                placeholder="auditable transition reason"
+                onChange={setAssignmentPhaseReason}
+              />
+              <SmallButton onClick={() => void advanceAssignmentNow()}>
+                advance Assignment phase
               </SmallButton>
             </>
           )}

--- a/extensions/work-dashboard/src/view/mission-control-profile.ts
+++ b/extensions/work-dashboard/src/view/mission-control-profile.ts
@@ -357,6 +357,29 @@ export type AssignmentWrite = {
   receipt: AtlasGoWrite['receipt'];
 };
 
+export type AssignmentExecutionClaim = {
+  schema: 'kungfu.assignment-orchestration.execution-claim/v1';
+  claim: {
+    claim_id: string;
+    assignment_id: string;
+    lease_id: string;
+    lease_expires_at: string;
+  };
+  receipt: Record<string, unknown>;
+};
+
+export type AssignmentPhaseTransition = {
+  schema: 'kungfu.assignment-orchestration.phase-transition/v1';
+  transition: {
+    claim_id: string;
+    assignment_subject: string;
+    from_phase: string;
+    to_phase: string;
+    lease_id: string;
+  };
+  receipt: Record<string, unknown>;
+};
+
 export type AtlasMissionBundleExport = {
   schema: 'kungfu.mission-control.bundle-export/v1';
   status: 'portable' | 'degraded';
@@ -535,6 +558,33 @@ export type Atlas = {
       evidenceEpisodeRoots?: string[];
     },
   ) => Promise<AssignmentWrite>;
+  claimAssignment: (
+    initiativeId: string,
+    assignmentId: string,
+    input: {
+      owner: string;
+      agent: string;
+      slot: string;
+      leaseId: string;
+      leaseExpiresAt: string;
+      authorizedBy: string;
+      grantScope?: string;
+      actorType?: 'user' | 'agent';
+      source?: string;
+    },
+  ) => Promise<AssignmentExecutionClaim>;
+  advanceAssignment: (
+    initiativeId: string,
+    assignmentId: string,
+    input: {
+      toPhase: string;
+      expectedPhase?: string;
+      actor: string;
+      actorType?: 'user' | 'agent';
+      reason: string;
+      source?: string;
+    },
+  ) => Promise<AssignmentPhaseTransition>;
   createGo: (
     missionId: string,
     input: {
@@ -760,6 +810,18 @@ export function openMissionControlProfile(
       authorize<AssignmentWrite>(
         'create-assignment',
         { initiativeId, ...input },
+        input.actor,
+      ),
+    claimAssignment: (initiativeId, assignmentId, input) =>
+      authorize<AssignmentExecutionClaim>(
+        'claim-assignment',
+        { initiativeId, assignmentId, ...input },
+        input.authorizedBy,
+      ),
+    advanceAssignment: (initiativeId, assignmentId, input) =>
+      authorize<AssignmentPhaseTransition>(
+        'advance-assignment',
+        { initiativeId, assignmentId, ...input },
         input.actor,
       ),
     createGo: (missionId, input) =>

--- a/extensions/work-dashboard/tests/mission-control-profile.test.ts
+++ b/extensions/work-dashboard/tests/mission-control-profile.test.ts
@@ -28,6 +28,24 @@ test('Mission Control uses the exact-root Profile projection and intent surfaces
     objective: 'Prove the shared intent surface',
     actor: 'test-owner',
   };
+  const executionClaimInput = {
+    initiativeId: 'initiative-a',
+    assignmentId: 'assignment-a',
+    owner: 'test-owner',
+    agent: 'agent-a',
+    slot: 'slot-a',
+    leaseId: 'lease-a',
+    leaseExpiresAt: '2030-01-01T00:00:00Z',
+    authorizedBy: 'test-owner',
+  };
+  const phaseTransitionInput = {
+    initiativeId: 'initiative-a',
+    assignmentId: 'assignment-a',
+    toPhase: 'executing',
+    expectedPhase: 'claimed',
+    actor: 'test-owner',
+    reason: 'begin the bounded execution stage',
+  };
   const snapshot: AtlasDashboardSnapshot = {
     schema: 'kungfu.mission-control.dashboard-snapshot/v1',
     cut: { kind: 'system_time', system_time: '42' },
@@ -117,6 +135,20 @@ test('Mission Control uses the exact-root Profile projection and intent surfaces
     objective: assignmentInput.objective,
     actor: assignmentInput.actor,
   });
+  await missionControl.claimAssignment('initiative-a', 'assignment-a', {
+    owner: executionClaimInput.owner,
+    agent: executionClaimInput.agent,
+    slot: executionClaimInput.slot,
+    leaseId: executionClaimInput.leaseId,
+    leaseExpiresAt: executionClaimInput.leaseExpiresAt,
+    authorizedBy: executionClaimInput.authorizedBy,
+  });
+  await missionControl.advanceAssignment('initiative-a', 'assignment-a', {
+    toPhase: phaseTransitionInput.toPhase,
+    expectedPhase: phaseTransitionInput.expectedPhase,
+    actor: phaseTransitionInput.actor,
+    reason: phaseTransitionInput.reason,
+  });
   const receipt = await missionControl.createMission('mission-a', {
     title: input.title,
     intent: input.intent,
@@ -152,6 +184,13 @@ test('Mission Control uses the exact-root Profile projection and intent surfaces
     { operation: 'authorize:create-initiative', input: initiativeInput },
     { operation: 'plan:create-assignment', input: assignmentInput },
     { operation: 'authorize:create-assignment', input: assignmentInput },
+    { operation: 'plan:claim-assignment', input: executionClaimInput },
+    { operation: 'authorize:claim-assignment', input: executionClaimInput },
+    { operation: 'plan:advance-assignment', input: phaseTransitionInput },
+    {
+      operation: 'authorize:advance-assignment',
+      input: phaseTransitionInput,
+    },
     { operation: 'plan:create-mission', input },
     { operation: 'authorize:create-mission', input },
     {

--- a/framework/core/tests/python/test_agent_profile_sdk.py
+++ b/framework/core/tests/python/test_agent_profile_sdk.py
@@ -594,11 +594,13 @@ def test_system_profile_release_receipt_is_exact_root_and_shared_with_status(
     assert receipt["profileId"] == "kungfu.mission-control"
     assert receipt["qualificationSource"] == "release"
     assert receipt["noBypass"]["policy"] == "release-owned-shared-api-parity/v1"
-    assert len(receipt["clientProbes"]) == 13
+    assert len(receipt["clientProbes"]) == 15
     assert all(row["matched"] for row in receipt["clientProbes"])
     assert {
         "cutover-authority",
         "rollback-authority",
+        "claim-assignment",
+        "advance-assignment",
     }.issubset({row["intentId"] for row in receipt["clientProbes"]})
 
     manifest_path = tmp_path / "profile-kfd3.json"

--- a/scripts/check-shifu-entry-contract.test.mjs
+++ b/scripts/check-shifu-entry-contract.test.mjs
@@ -132,6 +132,16 @@ test('Windows source-fresh launcher retries one transient build failure', () => 
   assert.match(sourceBuild, /if "!_KFC_BUILD_ERROR!"=="0" \(/);
 });
 
+test('Windows local environment parsing is inline and label-free', () => {
+  const windows = fs.readFileSync(path.join(ROOT, 'shifu.cmd'), 'utf8');
+  assert.match(
+    windows,
+    /for %%f in \("%_KFC_USERCFG%" "\.\\build-local\.env"\) do if exist "%%~f"/u,
+  );
+  assert.match(windows, /findstr \/b \/c:"export " "%%~f"/u);
+  assert.doesNotMatch(windows, /call :loadenv|^:loadenv$/mu);
+});
+
 test('source-fresh launchers pin nested Shifu entry to the resolved binary', () => {
   const posix = fs.readFileSync(path.join(ROOT, 'shifu'), 'utf8');
   const windows = fs.readFileSync(path.join(ROOT, 'shifu.cmd'), 'utf8');

--- a/shifu.cmd
+++ b/shifu.cmd
@@ -50,8 +50,20 @@ set "_KFC_EXPLICIT_CACHE_SCOPE=%SHIFU_CACHE_SCOPE%"
 set "_KFC_USERCFG=%USERPROFILE%\.config\kungfu\build-local.env"
 if defined XDG_CONFIG_HOME set "_KFC_USERCFG=%XDG_CONFIG_HOME%\kungfu\build-local.env"
 if "%SHIFU_CACHE_ACTIVE%"=="1" goto proxyloaded
-call :loadenv "%_KFC_USERCFG%"
-call :loadenv ".\build-local.env"
+rem Keep this inline: cmd.exe can lose a trailing batch label when the shim is
+rem entered recursively through Node's shell mode, leaking an otherwise benign
+rem "cannot find the batch label" diagnostic into strict child protocols.
+for %%f in ("%_KFC_USERCFG%" ".\build-local.env") do if exist "%%~f" (
+  for /f "usebackq tokens=1,* delims==" %%a in (`findstr /b /c:"export " "%%~f"`) do (
+    set "_kfc_k=%%a"
+    set "_kfc_v=%%b"
+    set "_kfc_k=!_kfc_k:export =!"
+    set "_kfc_v=!_kfc_v:'=!"
+    set "!_kfc_k!=!_kfc_v!"
+  )
+)
+set "_kfc_k="
+set "_kfc_v="
 :proxyloaded
 if defined _KFC_EXPLICIT_CACHE_REF set "SHIFU_CACHE_PROFILE_REF=%_KFC_EXPLICIT_CACHE_REF%"
 if defined _KFC_EXPLICIT_CACHE_DIGEST set "SHIFU_CACHE_PROFILE_DIGEST=%_KFC_EXPLICIT_CACHE_DIGEST%"
@@ -533,19 +545,3 @@ rem NOTE: use corepack.cmd (not bare "corepack"): fnm exec spawns the program di
 rem without applying PATHEXT, so bare "corepack" is not found on Windows (only corepack.cmd is).
 fnm exec --using-file -- corepack.cmd pnpm %*
 exit /b !errorlevel!
-
-rem -- Parse sh-format build-local.env `export KEY='VALUE'` lines -> set KEY=VALUE (pure cmd) --
-rem (Windows cmd cannot source sh; take export lines, strip the export prefix and single quotes;
-rem  mirror URLs have no embedded quotes/equals so this is safe.)
-:loadenv
-if not exist "%~1" goto :eof
-for /f "usebackq tokens=1,* delims==" %%a in (`findstr /b /c:"export " "%~1"`) do (
-  set "_kfc_k=%%a"
-  set "_kfc_v=%%b"
-  set "_kfc_k=!_kfc_k:export =!"
-  set "_kfc_v=!_kfc_v:'=!"
-  set "!_kfc_k!=!_kfc_v!"
-)
-set "_kfc_k="
-set "_kfc_v="
-goto :eof


### PR DESCRIPTION
## Summary

- bind the declared `claim-assignment` intent to a real Work Dashboard GUI action
- bind the declared `advance-assignment` intent to a real Work Dashboard GUI action
- cover both Profile authorization paths and keep release KFD-3 client probes aligned

## Diagnosis

Alpha promotion Product Build run 29962626774 reached KFD-3 release parity on Linux and macOS, then failed because the GUI did not expose `.claimAssignment(` or `.advanceAssignment(` calls for the two declared intents. This patch adds real operator-facing Assignment orchestration controls instead of weakening the release contract.

## Verification

- `node --test --experimental-strip-types extensions/work-dashboard/tests/mission-control-profile.test.ts` — passed
- `corepack pnpm --filter @kungfu-tech/kfx-view-work-dashboard test` — 28/28 passed
- full staged repository gate — passed
- Biome, Ruff format and Ruff lint — passed

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Repair declared Assignment GUI API parity without changing any ADR projection."
}
-->
