### PR TITLE
fix(runtime): bind installed contract search root

### DIFF
--- a/framework/core/src/python/kungfu/storage/service.py
+++ b/framework/core/src/python/kungfu/storage/service.py
@@ -988,8 +988,16 @@ def action_runtime(
     array, so the wrapper preserves non-object results instead of forcing dict().
     """
 
+    operation_request = {"action": action, **(request or {})}
+    if "search_base" not in operation_request:
+        from kungfu import host
+
+        product_root = host.product_root()
+        if product_root is not None:
+            operation_request["search_base"] = str(product_root)
+
     result = _runtime().run_storage_service_operation(
-        "action_runtime", str(runtime_dir), {"action": action, **(request or {})}
+        "action_runtime", str(runtime_dir), operation_request
     )
     return dict(result) if isinstance(result, dict) else result
 

--- a/framework/core/tests/python/test_contract.py
+++ b/framework/core/tests/python/test_contract.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 
 from kungfu import contract
+from kungfu.storage import service as storage_service
 
 
 def test_source_discovery_never_treats_the_module_file_as_a_directory(monkeypatch):
@@ -22,3 +23,48 @@ def test_source_discovery_never_treats_the_module_file_as_a_directory(monkeypatc
     assert registry.name == contract.REGISTRY_FILE
     assert original_is_file(registry)
     assert original_is_file(runtime)
+
+
+def test_action_runtime_passes_the_installed_product_root_to_native(
+    monkeypatch, tmp_path
+):
+    product_root = tmp_path / "runtime"
+    calls = []
+
+    class Runtime:
+        @staticmethod
+        def run_storage_service_operation(operation, runtime_dir, request):
+            calls.append((operation, runtime_dir, request))
+            return {"ok": True}
+
+    monkeypatch.setattr(storage_service, "_runtime", lambda: Runtime())
+    monkeypatch.setattr("kungfu.host.product_root", lambda: product_root)
+
+    assert storage_service.action_runtime("", "capabilities") == {"ok": True}
+    assert calls == [
+        (
+            "action_runtime",
+            "",
+            {"action": "capabilities", "search_base": str(product_root)},
+        )
+    ]
+
+
+def test_action_runtime_preserves_an_explicit_search_base(monkeypatch, tmp_path):
+    calls = []
+
+    class Runtime:
+        @staticmethod
+        def run_storage_service_operation(operation, runtime_dir, request):
+            calls.append(request)
+            return {"ok": True}
+
+    monkeypatch.setattr(storage_service, "_runtime", lambda: Runtime())
+    monkeypatch.setattr(
+        "kungfu.host.product_root", lambda: tmp_path / "installed-runtime"
+    )
+
+    storage_service.action_runtime(
+        "", "capabilities", {"search_base": "/explicit/product"}
+    )
+    assert calls == [{"action": "capabilities", "search_base": "/explicit/product"}]


### PR DESCRIPTION
## Summary

- pass the assembled product root into the native Action Runtime as its default `search_base`
- preserve caller-supplied search roots
- cover both installed-product injection and explicit override behavior

## Diagnosis

Alpha Product Build run 29965568435 successfully assembled and packaged Linux, including the contract registry under `runtime/config`, then failed the installed CLI capability smoke. `work_profile.capabilities()` crosses into the C++ Action Runtime with an empty runtime directory and no `search_base`; native registry discovery therefore searched only the qualification temp cwd. The Python host seam already knows the installed product root, so this patch carries that fact across the Python/native boundary without relying on CI-only environment variables.

## Verification

- `PYTHONPATH=src/python uv run --frozen pytest tests/python/test_contract.py -q` — 3 passed
- Ruff format and lint — passed
- full staged repository gate — passed

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Repair installed-product native contract discovery without changing any ADR projection."
}
-->
