### PR TITLE
fix(shifu): reuse pinned Windows lifecycle binary

### DIFF
--- a/scripts/run-shifu-lifecycle.mjs
+++ b/scripts/run-shifu-lifecycle.mjs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
@@ -59,6 +60,22 @@ export function runShifu(args, options = {}) {
   const env = options.env || lifecycleEnvironment();
   let result;
   if (platform === 'win32') {
+    const pinnedBinary = env.SHIFU_BIN;
+    if (pinnedBinary && existsSync(pinnedBinary)) {
+      result = spawnSync(pinnedBinary, args, {
+        cwd: root,
+        env: {
+          ...env,
+          SHIFU_ENTRYPOINT: '1',
+          SHIFU_FROM_SHIM: '1',
+        },
+        stdio: options.stdio || 'inherit',
+        shell: false,
+        windowsHide: true,
+      });
+      if (result.error) throw result.error;
+      return result.status ?? 1;
+    }
     const command = options.comspec || env.ComSpec || env.COMSPEC || 'cmd.exe';
     // Match the native launcher's proven cmd.exe raw-argument protocol. The
     // complete /s /c payload needs one outer quote pair in addition to the

--- a/scripts/run-shifu-lifecycle.test.mjs
+++ b/scripts/run-shifu-lifecycle.test.mjs
@@ -115,6 +115,17 @@ test('runs the Unix shim without a shell', () => {
   assert.equal(status, 0);
 });
 
+test('Windows reuses a selected native launcher without a nested cmd shim', () => {
+  const status = runShifu(['--version'], {
+    platform: 'win32',
+    root: process.cwd(),
+    comspec: path.join(os.tmpdir(), 'missing-cmd.exe'),
+    env: { ...process.env, SHIFU_BIN: process.execPath },
+    stdio: 'ignore',
+  });
+  assert.equal(status, 0);
+});
+
 test('quotes a Windows shim payload and rejects expansion syntax', () => {
   assert.equal(
     cmdCommand('shifu.cmd', ['verify', '--fuzz']),


### PR DESCRIPTION
## Summary

Repair nested Windows Shifu lifecycle dispatch after Product Build run 29967583701 (Windows job 89082416060) showed that build and verify re-entered `cmd.exe -> shifu.cmd` even though the cache-active environment had already selected a native launcher in `SHIFU_BIN`.

The lifecycle runner now directly spawns that pinned native binary on Windows when it exists, preserving the selected launcher and avoiding a second batch-parser boundary. The existing `cmd.exe /d /s /c shifu.cmd` path remains the fallback when no pinned binary is available.

## Verification

- `node --test scripts/run-shifu-lifecycle.test.mjs` — 13 tests, 11 passed, 2 platform skips
- `node --test scripts/check-shifu-entry-contract.test.mjs` — 16/16 passed
- `corepack pnpm exec biome check scripts/run-shifu-lifecycle.mjs scripts/run-shifu-lifecycle.test.mjs`
- repository staged validation / commit hooks passed
- new regression test emulates Windows with `SHIFU_BIN` pointing to the current native Node executable and an invalid `ComSpec`, proving the direct path bypasses cmd

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Repair nested Windows lifecycle dispatch without changing any ADR projection."
}
-->