### PR TITLE
fix(shifu): preserve Windows pnpm task dispatch

### DIFF
--- a/scripts/run-shifu-lifecycle.mjs
+++ b/scripts/run-shifu-lifecycle.mjs
@@ -49,7 +49,11 @@ export function windowsCmdArgs(shim, args) {
       'Windows Shifu lifecycle arguments contain unsafe cmd syntax',
     );
   const quote = (value) => `"${String(value).replaceAll('"', '""')}"`;
-  const payload = [shim, ...args].map(quote).join(' ');
+  // `call` gives cmd.exe an explicit batch-file invocation boundary. Without
+  // it, /s /c can execute the shim while dropping the remaining ordinary-task
+  // arguments on self-hosted Windows runners, which makes the launcher build
+  // successfully but never reaches the requested pnpm task.
+  const payload = `call ${[shim, ...args].map(quote).join(' ')}`;
   return ['/d', '/s', '/c', `"${payload}"`];
 }
 

--- a/scripts/run-shifu-lifecycle.test.mjs
+++ b/scripts/run-shifu-lifecycle.test.mjs
@@ -153,7 +153,7 @@ test('enters a Windows batch shim with one fully quoted cmd payload', () => {
       '/d',
       '/s',
       '/c',
-      '""C:\\repo path\\shifu.cmd" "cache" "apply" "--" "C:\\Program Files\\node.exe""',
+      '"call "C:\\repo path\\shifu.cmd" "cache" "apply" "--" "C:\\Program Files\\node.exe""',
     ],
   );
   assert.throws(
@@ -259,5 +259,29 @@ test(
         SHIFU_BIN: sourceBinary,
       }),
     );
+  },
+);
+
+test(
+  'Windows lifecycle dispatch reaches an ordinary pnpm command',
+  { skip: process.platform !== 'win32' },
+  (t) => {
+    const evidence = path.join(
+      fs.mkdtempSync(path.join(os.tmpdir(), 'shifu-pnpm-dispatch-')),
+      'evidence.txt',
+    );
+    t.after(() =>
+      fs.rmSync(path.dirname(evidence), { recursive: true, force: true }),
+    );
+    const script =
+      "require('node:fs').writeFileSync(process.env.SHIFU_TEST_EVIDENCE,'ok')";
+    const status = runShifu(['exec', 'node', '-e', script], {
+      platform: 'win32',
+      root: process.cwd(),
+      env: { ...process.env, SHIFU_TEST_EVIDENCE: evidence },
+      stdio: 'ignore',
+    });
+    assert.equal(status, 0);
+    assert.equal(fs.readFileSync(evidence, 'utf8'), 'ok');
   },
 );


### PR DESCRIPTION
## Summary

Product Build run 29968856850 proved the Windows launcher could build successfully while ordinary lifecycle arguments never reached pnpm: install/build/verify emitted only launcher-build messages, and verify produced one artifact instead of the required eight.

Enter the repository batch shim through an explicit `call` command boundary under `cmd.exe /d /s /c`. This preserves the full ordinary-task argument vector after the batch file returns through nested cache-applied lifecycle execution.

The regression suite now executes a real Windows `pnpm exec node` command and requires a filesystem side effect. Previous coverage only exercised launcher-owned `--version` and `doctor` paths and therefore could not detect a dropped pnpm task.

## Verification

- `node --test scripts/run-shifu-lifecycle.test.mjs` — 11 pass, 3 Windows-only skips locally
- `node --test scripts/check-shifu-entry-contract.test.mjs` — 16/16 pass
- `corepack pnpm exec biome check scripts/run-shifu-lifecycle.mjs scripts/run-shifu-lifecycle.test.mjs`
- full staged repository gate passed during signed commit

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Repair Windows ordinary pnpm task dispatch without changing any ADR projection."
}
-->