### PR TITLE
fix(adr): close migrated revision bindings

### DIFF
--- a/scripts/adr-migration.mjs
+++ b/scripts/adr-migration.mjs
@@ -173,7 +173,11 @@ function utf8(bytes) {
   return Buffer.from(text, 'utf8').equals(bytes) ? text : null;
 }
 
-/** @param {string} text @param {Map<string, {id: string, path: string, targetId: string, targetPath: string}>} mappings @param {{identities?: boolean}} [options] */
+/**
+ * @param {string} text
+ * @param {Map<string, {id: string, path: string, targetId: string, targetPath: string}>} mappings
+ * @param {{identities?: boolean, revisions?: {beforeRoot: string, afterRoot: string}[]}} [options]
+ */
 function rewrite(text, mappings, options = {}) {
   let result = text;
   const pathReplacements = [];
@@ -195,6 +199,9 @@ function rewrite(text, mappings, options = {}) {
         row.targetId,
       );
     }
+  }
+  for (const row of options.revisions || []) {
+    result = result.replaceAll(row.beforeRoot, row.afterRoot);
   }
   return result;
 }
@@ -283,6 +290,31 @@ export function createAdrMigrationPlan(options = {}) {
     mappings.set(id, { id, path: sourcePath, targetId, targetPath });
   }
 
+  const revisionMappings = [...mappings.values()]
+    .map((row) => {
+      const bytes = snapshot.get(row.path);
+      const text = utf8(bytes);
+      if (text === null) {
+        problems.push({
+          code: 'legacy-record-not-utf8',
+          id: row.id,
+          path: row.path,
+        });
+        return null;
+      }
+      return {
+        id: row.id,
+        path: row.path,
+        targetPath: row.targetPath,
+        beforeRoot: bytesDigest(bytes),
+        afterRoot: bytesDigest(rewrite(text, mappings)),
+      };
+    })
+    .filter(Boolean)
+    .sort((left, right) =>
+      Buffer.compare(Buffer.from(left.id), Buffer.from(right.id)),
+    );
+
   const transformations = [];
   const preserved = [];
   const referenceCounts = new Map();
@@ -325,7 +357,10 @@ export function createAdrMigrationPlan(options = {}) {
     const after =
       mode === 'none'
         ? text
-        : rewrite(text, mappings, { identities: mode === 'full' });
+        : rewrite(text, mappings, {
+            identities: mode === 'full',
+            revisions: mode === 'full' ? revisionMappings : [],
+          });
     const renamed = mappings.get(identity || '')?.targetPath || rel;
     const mappedReferences = refs.filter((ref) => mappings.has(ref));
     if (after === text && renamed === rel && mappedReferences.length === 0)
@@ -342,6 +377,21 @@ export function createAdrMigrationPlan(options = {}) {
     if (kind === 'authored' || (kind === 'test-fixture' && after !== text))
       transformations.push(row);
     else preserved.push({ ...row, lifecycle: kind });
+  }
+  const transformationsByPath = new Map(
+    transformations.map((row) => [row.path, row]),
+  );
+  for (const revision of revisionMappings) {
+    const transformation = transformationsByPath.get(revision.path);
+    if (transformation?.afterRoot !== revision.afterRoot) {
+      problems.push({
+        code: 'adr-revision-closure-nonterminal',
+        id: revision.id,
+        path: revision.path,
+        expectedRoot: revision.afterRoot,
+        actualRoot: transformation?.afterRoot || '',
+      });
+    }
   }
 
   const body = {
@@ -366,6 +416,7 @@ export function createAdrMigrationPlan(options = {}) {
     mappings: [...mappings.values()].sort((left, right) =>
       Buffer.compare(Buffer.from(left.id), Buffer.from(right.id)),
     ),
+    revisionMappings,
     transformations: transformations.sort((left, right) =>
       Buffer.compare(Buffer.from(left.path), Buffer.from(right.path)),
     ),
@@ -501,7 +552,11 @@ export function applyAdrMigrationPlan(root, plan, expectedSourceRoot = '') {
     const rewritten = rewrite(
       fs.readFileSync(source, 'utf8'),
       new Map(plan.mappings.map((item) => [item.id, item])),
-      { identities: row.rewriteMode !== 'paths-only' },
+      {
+        identities: row.rewriteMode !== 'paths-only',
+        revisions:
+          row.rewriteMode === 'full' ? plan.revisionMappings || [] : [],
+      },
     );
     if (bytesDigest(rewritten) !== row.afterRoot) {
       throw new Error(`migration algorithm drifted for ${row.path}`);

--- a/scripts/adr-migration.test.mjs
+++ b/scripts/adr-migration.test.mjs
@@ -2,6 +2,7 @@
 
 import assert from 'node:assert/strict';
 import childProcess from 'node:child_process';
+import crypto from 'node:crypto';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -36,6 +37,10 @@ function write(root, rel, text) {
   const file = path.join(root, rel);
   fs.mkdirSync(path.dirname(file), { recursive: true });
   fs.writeFileSync(file, text);
+}
+
+function byteRoot(value) {
+  return `sha256:${crypto.createHash('sha256').update(value).digest('hex')}`;
 }
 
 function record(id, title) {
@@ -73,6 +78,26 @@ function fixture() {
   );
   write(root, records[0].path, record(records[0].id, 'First'));
   write(root, records[1].path, record(records[1].id, 'Second'));
+  write(
+    root,
+    '.xinfa/project.json',
+    `${JSON.stringify(
+      {
+        bindings: [
+          {
+            targetPath: records[0].path,
+            expectedRevision: byteRoot(record(records[0].id, 'First')),
+          },
+          {
+            targetPath: records[1].path,
+            expectedRevision: byteRoot(record(records[1].id, 'Second')),
+          },
+        ],
+      },
+      null,
+      2,
+    )}\n`,
+  );
   write(
     root,
     'docs/README.md',
@@ -171,6 +196,7 @@ test('plans deterministic ID-only renames from an exact Git tree', () => {
   assert.deepEqual(first, second);
   assert.match(first.source.root, /^sha256:[0-9a-f]{64}$/);
   assert.equal(first.mappings.length, 2);
+  assert.equal(first.revisionMappings.length, 2);
   assert.ok(
     first.mappings.every(
       (row) =>
@@ -296,6 +322,16 @@ test('applies a reviewed manifest idempotently and preserves historical bytes', 
   const docs = fs.readFileSync(path.join(root, 'docs/README.md'), 'utf8');
   assert.ok(plan.mappings.every((row) => docs.includes(row.targetId)));
   assert.match(docs, /ADR-00010/);
+  const project = JSON.parse(
+    fs.readFileSync(path.join(root, '.xinfa/project.json'), 'utf8'),
+  );
+  for (const [index, mapping] of plan.mappings.entries()) {
+    assert.equal(project.bindings[index].targetPath, mapping.targetPath);
+    assert.equal(
+      project.bindings[index].expectedRevision,
+      byteRoot(fs.readFileSync(path.join(root, mapping.targetPath))),
+    );
+  }
   const index = fs.readFileSync(path.join(root, 'docs/adr/README.md'), 'utf8');
   assert.match(index, /\[0001\]/);
   assert.match(index, /historical ADR-0001/);
@@ -365,5 +401,37 @@ test('fails closed on expected-root or working-file drift', () => {
   assert.throws(
     () => applyAdrMigrationPlan(root, plan, plan.source.root),
     /differs from both manifest source and result/,
+  );
+});
+
+test('fails closed when revision rewriting changes a target ADR root again', () => {
+  const root = fixture();
+  const first = 'docs/adr/ADR-0001-first.md';
+  const second = 'docs/adr/SHIFU-ADR-0002-second.md';
+  fs.appendFileSync(
+    path.join(root, first),
+    `\nPinned dependency: ${byteRoot(fs.readFileSync(path.join(root, second)))}\n`,
+  );
+  git(root, ['add', first]);
+  git(root, [
+    '-c',
+    'core.hooksPath=/dev/null',
+    'commit',
+    '-q',
+    '-m',
+    'add revision dependency',
+  ]);
+
+  const plan = createAdrMigrationPlan({ root });
+  assert.ok(
+    plan.problems.some(
+      (problem) =>
+        problem.code === 'adr-revision-closure-nonterminal' &&
+        problem.id === 'ADR-0001',
+    ),
+  );
+  assert.throws(
+    () => applyAdrMigrationPlan(root, plan, plan.source.root),
+    /unresolved problems/,
   );
 });


### PR DESCRIPTION
## Summary

Close the ADR corpus migration revision-binding gap discovered during the reviewed full-corpus rehearsal. The migration plan now binds every legacy ADR byte root to its post-ID/path rewrite root and fails closed if revision rewriting is non-terminal.

## Related issue

Atlas goal: 2026-07-22-kungfu-adr-corpus-identity-rewrite

## Changes

- Add deterministic revisionMappings to the reviewed migration plan.
- Rewrite expectedRevision references only in full live transformations.
- Reject non-terminal ADR root rewrites before apply.
- Cover multiple live revision bindings and fail-closed root dependencies.

## Verification

- ./shifu adr:migrate:test (5/5)
- ./shifu check:source
- ./shifu check
- git diff --check
- Independent read-only review: PASS

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Bugfix closes migration revision bindings without changing the distributed UUIDv7 ADR identity contract"
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The migration manifest remains exact-tree, deterministic, independently reviewed, and fail-closed on source or algorithm drift.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed (no contract change; regression tests cover the fix)