### PR TITLE
fix(shifu): preserve fallback lifecycle argv

### DIFF
--- a/scripts/run-shifu-lifecycle.mjs
+++ b/scripts/run-shifu-lifecycle.mjs
@@ -48,13 +48,10 @@ export function windowsCmdArgs(shim, args) {
     throw new Error(
       'Windows Shifu lifecycle arguments contain unsafe cmd syntax',
     );
-  const quote = (value) => `"${String(value).replaceAll('"', '""')}"`;
-  // `call` gives cmd.exe an explicit batch-file invocation boundary. Without
-  // it, /s /c can execute the shim while dropping the remaining ordinary-task
-  // arguments on self-hosted Windows runners, which makes the launcher build
-  // successfully but never reaches the requested pnpm task.
-  const payload = `call ${[shim, ...args].map(quote).join(' ')}`;
-  return ['/d', '/s', '/c', `"${payload}"`];
+  // Keep the batch command and every task argument discrete so Node owns the
+  // Windows command-line quoting. A hand-built single /c payload survived
+  // launcher-owned verbs but dropped ordinary pnpm tasks in Product Build.
+  return ['/d', '/s', '/c', 'call', shim, ...args];
 }
 
 /** Run the canonical repository shim without assuming bash exists on Windows. */
@@ -92,7 +89,6 @@ export function runShifu(args, options = {}) {
         env,
         stdio: options.stdio || 'inherit',
         shell: false,
-        windowsVerbatimArguments: true,
       },
     );
   } else {

--- a/scripts/run-shifu-lifecycle.test.mjs
+++ b/scripts/run-shifu-lifecycle.test.mjs
@@ -141,7 +141,7 @@ test('quotes a Windows shim payload and rejects expansion syntax', () => {
   );
 });
 
-test('enters a Windows batch shim with one fully quoted cmd payload', () => {
+test('enters a Windows batch shim with discrete cmd arguments', () => {
   assert.deepEqual(
     windowsCmdArgs('C:\\repo path\\shifu.cmd', [
       'cache',
@@ -153,7 +153,12 @@ test('enters a Windows batch shim with one fully quoted cmd payload', () => {
       '/d',
       '/s',
       '/c',
-      '"call "C:\\repo path\\shifu.cmd" "cache" "apply" "--" "C:\\Program Files\\node.exe""',
+      'call',
+      'C:\\repo path\\shifu.cmd',
+      'cache',
+      'apply',
+      '--',
+      'C:\\Program Files\\node.exe',
     ],
   );
   assert.throws(
@@ -266,19 +271,28 @@ test(
   'Windows lifecycle dispatch reaches an ordinary pnpm command',
   { skip: process.platform !== 'win32' },
   (t) => {
-    const evidence = path.join(
-      fs.mkdtempSync(path.join(os.tmpdir(), 'shifu-pnpm-dispatch-')),
-      'evidence.txt',
+    const sandbox = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'shifu-pnpm-dispatch-'),
     );
-    t.after(() =>
-      fs.rmSync(path.dirname(evidence), { recursive: true, force: true }),
+    const evidence = path.join(sandbox, 'evidence.txt');
+    t.after(() => fs.rmSync(sandbox, { recursive: true, force: true }));
+    const isolatedEnv = Object.fromEntries(
+      Object.entries(process.env).filter(
+        ([name]) => name.toUpperCase() !== 'SHIFU_BIN',
+      ),
     );
     const script =
       "require('node:fs').writeFileSync(process.env.SHIFU_TEST_EVIDENCE,'ok')";
     const status = runShifu(['exec', 'node', '-e', script], {
       platform: 'win32',
       root: process.cwd(),
-      env: { ...process.env, SHIFU_TEST_EVIDENCE: evidence },
+      env: {
+        ...isolatedEnv,
+        SHIFU_CACHE_ACTIVE: '1',
+        SHIFU_NATIVE: '1',
+        SHIFU_TEST_EVIDENCE: evidence,
+        XDG_CACHE_HOME: path.join(sandbox, 'cache'),
+      },
       stdio: 'ignore',
     });
     assert.equal(status, 0);


### PR DESCRIPTION
## Summary

Product Build run 29970417379 proved the previous Windows regression test was a false positive: the test process inherited `SHIFU_BIN` from its parent Shifu invocation and bypassed the cmd fallback, while the real cache-active Product Build still ran no ordinary pnpm tasks and produced one artifact.

This patch:

- passes `cmd.exe /d /s /c call`, the batch shim, and every task argument as discrete spawn arguments so Node owns Windows quoting;
- removes `windowsVerbatimArguments`, eliminating the hand-built single command payload that dropped the ordinary task vector;
- makes the Windows regression strip `SHIFU_BIN`, force `SHIFU_CACHE_ACTIVE=1`, use an isolated launcher cache, and require a real `pnpm exec node` filesystem side effect.

## Verification

- `node --test scripts/run-shifu-lifecycle.test.mjs scripts/check-shifu-entry-contract.test.mjs` — 27 pass, 3 Windows-only skips locally
- `corepack pnpm exec biome check scripts/run-shifu-lifecycle.mjs scripts/run-shifu-lifecycle.test.mjs`
- full staged repository gate passed during signed commit

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Repair Windows fallback lifecycle argv without changing any ADR projection."
}
-->