### PR TITLE
feat(buildchain): record candidate timeline telemetry

### DIFF
--- a/.buildchain/alpha-contract-lock.json
+++ b/.buildchain/alpha-contract-lock.json
@@ -3,13 +3,13 @@
   "contract": "kungfu-buildchain-contract-lock",
   "buildchain": {
     "ref": "v2-alpha",
-    "resolvedSha": "c7a066159bf55f3adcb5b7f8b9d383ec19fbdaa7",
+    "resolvedSha": "f6f2428e8de6e7d39ca6177cd0686f16a1258515",
     "contract": "kungfu-buildchain-runtime-contract-world",
-    "contractDigest": "sha256:95680b4596a6e848d6b8cff4b7216b3c560e085298d99587baa4419d4fdc6aef",
+    "contractDigest": "sha256:978eebe7528ea563ff62a2fe1e5b46861b36c510f8e4fda634f9e6a1acb5cdc7",
     "compatibilityDigest": "sha256:cdf588422ec6b460bd6f631400efa6e361a045e052c8967d6c50fadd7aa4dd90",
     "majorLine": "v2",
     "compatibilityPolicy": "major-compatible",
-    "acceptedAt": "2026-07-23T01:07:32.000Z",
+    "acceptedAt": "2026-07-23T02:14:43.000Z",
     "surfaces": [
       {
         "id": "reusable-build",

--- a/.buildchain/alpha-contract-lock.json
+++ b/.buildchain/alpha-contract-lock.json
@@ -3,13 +3,13 @@
   "contract": "kungfu-buildchain-contract-lock",
   "buildchain": {
     "ref": "v2-alpha",
-    "resolvedSha": "3743410384e2f163c04561a4a87270afe9f2574a",
+    "resolvedSha": "c7a066159bf55f3adcb5b7f8b9d383ec19fbdaa7",
     "contract": "kungfu-buildchain-runtime-contract-world",
-    "contractDigest": "sha256:a4efdf326492081d7e015eb2c04355c54c9b68bd45d32a102b8879d112db72a0",
+    "contractDigest": "sha256:95680b4596a6e848d6b8cff4b7216b3c560e085298d99587baa4419d4fdc6aef",
     "compatibilityDigest": "sha256:cdf588422ec6b460bd6f631400efa6e361a045e052c8967d6c50fadd7aa4dd90",
     "majorLine": "v2",
     "compatibilityPolicy": "major-compatible",
-    "acceptedAt": "2026-07-22T02:32:08.000Z",
+    "acceptedAt": "2026-07-23T01:07:32.000Z",
     "surfaces": [
       {
         "id": "reusable-build",

--- a/.github/workflows/affected-native-pr.yml
+++ b/.github/workflows/affected-native-pr.yml
@@ -237,6 +237,8 @@ jobs:
       KUNGFU_AFFECTED_NATIVE_PARTITION_INDEX: ${{ matrix.partition }}
       CC: gcc-14
       CXX: g++-14
+      KUNGFU_CANDIDATE_GATE_ID: source.changed-scope
+      KUNGFU_CANDIDATE_TIMELINE_EVENTS: ${{ github.workspace }}/product/qualification/affected-native/candidate-events.jsonl
     steps:
       - uses: actions/checkout@v4
         with:
@@ -389,7 +391,7 @@ jobs:
         if: ${{ steps.plan.outputs.required == 'true' }}
         shell: bash
         run: ./shifu install --frozen-lockfile
-      - name: Qualify installed four-language SDK wire contract
+      - name: Prepare SDK build toolchain
         if: ${{ steps.plan.outputs.required == 'true' && steps.plan.outputs.sdk-required == 'true' && matrix.partition == 0 }}
         shell: bash
         run: |
@@ -402,13 +404,22 @@ jobs:
             fi
           done
           test -n "$cmake_js_bin"
-          export PATH="$GITHUB_WORKSPACE/$(dirname "$cmake_js_bin"):$PATH"
+          cmake_js_dir="$GITHUB_WORKSPACE/$(dirname "$cmake_js_bin")"
+          echo "$cmake_js_dir" >> "$GITHUB_PATH"
+          export PATH="$cmake_js_dir:$PATH"
           # shifu-entry-contract: allow verifying the Core bootstrap tool before Shifu can build Core
           cmake-js --version
-          ./shifu build:core
-          ./shifu pack:sdk
-          ./shifu layers:qualify:sdk -- \
-            --report product/qualification/affected-native/layered-sdk-report.json
+      - name: Build Core SDK artifacts
+        if: ${{ steps.plan.outputs.required == 'true' && steps.plan.outputs.sdk-required == 'true' && matrix.partition == 0 }}
+        run: ./shifu build:core
+      - name: Pack four-language SDK artifacts
+        if: ${{ steps.plan.outputs.required == 'true' && steps.plan.outputs.sdk-required == 'true' && matrix.partition == 0 }}
+        run: ./shifu pack:sdk
+      - name: Qualify installed four-language SDK wire contract
+        if: ${{ steps.plan.outputs.required == 'true' && steps.plan.outputs.sdk-required == 'true' && matrix.partition == 0 }}
+        run: >-
+          ./shifu layers:qualify:sdk --
+          --report product/qualification/affected-native/layered-sdk-report.json
       - name: Run affected native closure
         if: ${{ steps.plan.outputs.native-required == 'true' }}
         id: native-gate

--- a/docs/adr/SHIFU-ADR-0004-gate-control-plane-contract.md
+++ b/docs/adr/SHIFU-ADR-0004-gate-control-plane-contract.md
@@ -6,7 +6,7 @@ decision_status: accepted
 implementation_status: implemented
 implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/762, https://github.com/kungfu-systems/kungfu/pull/765, https://github.com/kungfu-systems/kungfu/pull/767, https://github.com/kungfu-systems/kungfu/pull/769, https://github.com/kungfu-systems/kungfu/pull/773, https://github.com/kungfu-systems/kungfu/pull/781, https://github.com/kungfu-systems/kungfu/pull/786, https://github.com/kungfu-systems/kungfu/pull/1004, https://github.com/kungfu-systems/kungfu/pull/1014, https://github.com/kungfu-systems/kungfu/pull/1020, https://github.com/kungfu-systems/kungfu/pull/1095, https://github.com/kungfu-systems/kungfu/pull/1128, https://github.com/kungfu-systems/kungfu/pull/1240, https://github.com/kungfu-systems/kungfu/pull/1250]
 closure_pr: https://github.com/kungfu-systems/kungfu/pull/781
-qualification_refs: [scripts/shifu-gate-runtime.test.mjs, scripts/check-kungfu-gate-catalog.test.mjs, scripts/shifu-cache-runtime.test.mjs, scripts/measure-dev-required-latency.test.mjs, scripts/run-core-affected-native.mjs, scripts/affected-native-proof.test.mjs, scripts/write-affected-native-cache-manifests.test.mjs, .github/workflows/affected-native-pr.yml, .github/workflows/core-build-profiles.yml, .github/workflows/dev-verify-patrol.yml]
+qualification_refs: [scripts/shifu-gate-runtime.test.mjs, scripts/check-kungfu-gate-catalog.test.mjs, scripts/shifu-cache-runtime.test.mjs, scripts/candidate-timeline-events.test.mjs, scripts/measure-dev-required-latency.test.mjs, scripts/run-core-affected-native.mjs, scripts/affected-native-proof.test.mjs, scripts/write-affected-native-cache-manifests.test.mjs, .github/workflows/affected-native-pr.yml, .github/workflows/core-build-profiles.yml, .github/workflows/dev-verify-patrol.yml]
 review_state: self-reviewed
 sensitivity: public
 sources: [local-files, user-consensus]
@@ -14,7 +14,7 @@ period: ongoing
 theme: shifu-gate-control-plane
 confidence: high
 evidence_grade: B
-last_reviewed: 2026-07-22
+last_reviewed: 2026-07-23
 ---
 
 # SHIFU-ADR-0004: Gate control plane contract
@@ -247,6 +247,20 @@ planner, staged candidate workflow, proof format, or exact
 base/candidate/toolchain identity boundary. The current staged workflow remains
 the authoritative merge-group producer and does not reuse pull-request native
 proofs.
+
+Buildchain's alpha channel now owns the project-neutral
+`buildchain.candidate-timeline/v1` observation contract, while the stable
+release channel and its contract lock remain independent release authority.
+Kungfu emits bounded, source-bound stage events from the authoritative
+merge-group build and folds provider workflow, job, and step intervals into the
+same candidate timeline without mixing pull-request and queue attempts.
+Critical-path duration is computed from each attempt's interval union so nested
+and parallel spans are not double-counted. Missing provider queue timestamps or
+older artifacts without internal stage receipts remain explicit unknowns; they
+never become inferred zero-duration work. The four-language SDK qualification
+keeps one semantic authority while exposing separate build, pack, adapter, and
+wire intervals so a later optimization can distinguish Core build cost from
+language-specific contract cost.
 
 ## Consequences
 

--- a/docs/qualification/gates/README.md
+++ b/docs/qualification/gates/README.md
@@ -113,6 +113,28 @@ requested-versus-observed build concurrency. Older artifacts without this
 additive evidence remain visible as unknown attribution; they do not fabricate
 phase timings and do not invalidate otherwise complete portable-cache facts.
 
+Each qualifying sample also emits a Buildchain
+`buildchain.candidate-timeline/v1` projection. The projection correlates PR
+admission, every merge-queue round, workflow/job/step provider timing, and the
+source-bound internal Core, SDK, wire-language, and native-closure stages. It
+keeps PR and queue attempts separate and computes wall-clock critical paths per
+attempt; interval unions prevent nested steps or parallel jobs from being
+double-counted. GitHub runner wait remains explicitly unknown because the Jobs
+API does not expose a job `queued_at` timestamp. Historical artifacts without
+the new internal event stream likewise retain explicit unknown stages.
+
+Use repeated `--pull` arguments for exact historical candidates. For a single
+candidate, `--timeline-output` writes the standalone machine contract and emits
+the compact human report on stderr:
+
+```sh
+./shifu gate:latency:measure \
+  --repository kungfu-systems/kungfu \
+  --pull 1254 \
+  --output /tmp/kungfu-pr-1254-latency.json \
+  --timeline-output /tmp/kungfu-pr-1254-candidate-timeline.json
+```
+
 The same report has a separate merge-queue delivery section. Delivery latency
 runs from the first authoritative GitHub `AddedToMergeQueueEvent` through the
 PR `merged_at`, with P50/P90 targets of 15/30 minutes. The dequeue cohort also

--- a/docs/qualification/gates/README.md
+++ b/docs/qualification/gates/README.md
@@ -119,9 +119,14 @@ admission, every merge-queue round, workflow/job/step provider timing, and the
 source-bound internal Core, SDK, wire-language, and native-closure stages. It
 keeps PR and queue attempts separate and computes wall-clock critical paths per
 attempt; interval unions prevent nested steps or parallel jobs from being
-double-counted. GitHub runner wait remains explicitly unknown because the Jobs
-API does not expose a job `queued_at` timestamp. Historical artifacts without
-the new internal event stream likewise retain explicit unknown stages.
+double-counted. Aggregate admission and post-build merge finalization have
+separate phases, while skipped or dependency-blocked jobs remain explicit
+non-executions without invented timestamps. GitHub runner wait remains
+explicitly unknown because the Jobs API does not expose a job `queued_at`
+timestamp. Historical artifacts without the new internal event stream likewise
+retain explicit unknown stages. The compact report ranks actionable spans,
+reports execution-lane skew and cache outcomes, and names one falsifiable next
+optimization target for a repeat of the same source-bound cohort.
 
 Use repeated `--pull` arguments for exact historical candidates. For a single
 candidate, `--timeline-output` writes the standalone machine contract and emits

--- a/docs/qualification/gates/release-admission-policy.json
+++ b/docs/qualification/gates/release-admission-policy.json
@@ -14,8 +14,8 @@
     "runtimes": {
       "alpha": {
         "ref": "v2-alpha",
-        "runtimeSha": "3743410384e2f163c04561a4a87270afe9f2574a",
-        "contractDigest": "sha256:a4efdf326492081d7e015eb2c04355c54c9b68bd45d32a102b8879d112db72a0",
+        "runtimeSha": "c7a066159bf55f3adcb5b7f8b9d383ec19fbdaa7",
+        "contractDigest": "sha256:95680b4596a6e848d6b8cff4b7216b3c560e085298d99587baa4419d4fdc6aef",
         "contractLock": ".buildchain/alpha-contract-lock.json"
       },
       "release": {

--- a/docs/qualification/gates/release-admission-policy.json
+++ b/docs/qualification/gates/release-admission-policy.json
@@ -14,8 +14,8 @@
     "runtimes": {
       "alpha": {
         "ref": "v2-alpha",
-        "runtimeSha": "c7a066159bf55f3adcb5b7f8b9d383ec19fbdaa7",
-        "contractDigest": "sha256:95680b4596a6e848d6b8cff4b7216b3c560e085298d99587baa4419d4fdc6aef",
+        "runtimeSha": "f6f2428e8de6e7d39ca6177cd0686f16a1258515",
+        "contractDigest": "sha256:978eebe7528ea563ff62a2fe1e5b46861b36c510f8e4fda634f9e6a1acb5cdc7",
         "contractLock": ".buildchain/alpha-contract-lock.json"
       },
       "release": {

--- a/docs/qualification/gates/release-admission.md
+++ b/docs/qualification/gates/release-admission.md
@@ -17,7 +17,7 @@ A qualifying capability must bind all of the following exact values:
 | --- | --- |
 | Source | one 40-character Kungfu revision and its release-candidate tree |
 | Gate policy | current `shifu.gates.json`, `release-promotion` matrix digest, complete passing rows and platform receipts |
-| Runtime | Stable release authority remains `@kungfu-tech/buildchain@2.14.1`; dev/MQ telemetry uses the isolated npm alias `@kungfu-tech/buildchain-alpha@npm:@kungfu-tech/buildchain@2.14.17-alpha.2`. `alpha` binds `v2-alpha` at `c7a066159bf55f3adcb5b7f8b9d383ec19fbdaa7`, while `release` remains isolated on `v2` at `bb9ce34b368c6b5a27b00fbdcb0515076abd9744`, each with its exact contract lock and digest; the standalone Shifu tool pin is tracked separately in `.buildchain-version` |
+| Runtime | Stable release authority remains `@kungfu-tech/buildchain@2.14.1`; dev/MQ telemetry uses the isolated npm alias `@kungfu-tech/buildchain-alpha@npm:@kungfu-tech/buildchain@2.14.17-alpha.3`. `alpha` binds `v2-alpha` at `f6f2428e8de6e7d39ca6177cd0686f16a1258515`, while `release` remains isolated on `v2` at `bb9ce34b368c6b5a27b00fbdcb0515076abd9744`, each with its exact contract lock and digest; the standalone Shifu tool pin is tracked separately in `.buildchain-version` |
 | Controller | qualifying source/runtime-bound Buildchain controller receipt referenced by the RC passport |
 | Runner | qualifying ephemeral, reimaged, or measured persistent-runner provenance; unqualified is denied |
 | Control plane | fresh passing Actions, branch/ruleset, Environment, OIDC, publisher, and runner audit facts |

--- a/docs/qualification/gates/release-admission.md
+++ b/docs/qualification/gates/release-admission.md
@@ -17,7 +17,7 @@ A qualifying capability must bind all of the following exact values:
 | --- | --- |
 | Source | one 40-character Kungfu revision and its release-candidate tree |
 | Gate policy | current `shifu.gates.json`, `release-promotion` matrix digest, complete passing rows and platform receipts |
-| Runtime | Buildchain package `2.14.1`; `alpha` binds `v2-alpha` at `3743410384e2f163c04561a4a87270afe9f2574a`, while `release` binds `v2` at `bb9ce34b368c6b5a27b00fbdcb0515076abd9744`, each with its exact contract lock and digest; the standalone Shifu tool pin is tracked separately in `.buildchain-version` |
+| Runtime | Stable release authority remains `@kungfu-tech/buildchain@2.14.1`; dev/MQ telemetry uses the isolated npm alias `@kungfu-tech/buildchain-alpha@npm:@kungfu-tech/buildchain@2.14.17-alpha.2`. `alpha` binds `v2-alpha` at `c7a066159bf55f3adcb5b7f8b9d383ec19fbdaa7`, while `release` remains isolated on `v2` at `bb9ce34b368c6b5a27b00fbdcb0515076abd9744`, each with its exact contract lock and digest; the standalone Shifu tool pin is tracked separately in `.buildchain-version` |
 | Controller | qualifying source/runtime-bound Buildchain controller receipt referenced by the RC passport |
 | Runner | qualifying ephemeral, reimaged, or measured persistent-runner provenance; unqualified is denied |
 | Control plane | fresh passing Actions, branch/ruleset, Environment, OIDC, publisher, and runner audit facts |

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -50,7 +50,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:949e816344773cf9f7a7e61423f09fc1e946ae85bb2d58477ecfebf2b33d1f1d",
+          "definitionDigest": "sha256:073e92994dedc70096f9f7a7bf8444de9c779429d49bbca10263d038f797c4c6",
           "credentials": {
             "githubToken": "read",
             "oidc": false,
@@ -154,42 +154,60 @@
             },
             {
               "index": 15,
-              "label": "name:Qualify installed four-language SDK wire contract",
+              "label": "name:Prepare SDK build toolchain",
               "authority": "qualification",
-              "definitionDigest": "sha256:25fe94d0ebd2852cd72c80f17d75aba489b325e1d6df2ba222cac3fecd20bc74"
+              "definitionDigest": "sha256:22479132a9ef010a296de325c8cb299c8dbdf41f099cfca8a9cc06215b1c9235"
             },
             {
               "index": 16,
+              "label": "name:Build Core SDK artifacts",
+              "authority": "qualification",
+              "definitionDigest": "sha256:5886ce76d2342eba8c96cc2dbbb206bc5214560d9c1d8b3440b2cae85b21a0c6"
+            },
+            {
+              "index": 17,
+              "label": "name:Pack four-language SDK artifacts",
+              "authority": "qualification",
+              "definitionDigest": "sha256:eef82a1fd109643585c05ec1f13f8c13d2356d8a18de6c61204c6217e20cd13e"
+            },
+            {
+              "index": 18,
+              "label": "name:Qualify installed four-language SDK wire contract",
+              "authority": "qualification",
+              "definitionDigest": "sha256:443facbb23ace2ef944c668860e870cc65fcc09ac4172529111dd24aaddac7a1"
+            },
+            {
+              "index": 19,
               "label": "id:native-gate",
               "authority": "qualification",
               "definitionDigest": "sha256:0f38c746599fc0ef9e94c395af8824dcb382ffa5c7d2a4a6b501db9819bc65f7"
             },
             {
-              "index": 17,
+              "index": 20,
               "label": "name:Record compiler cache statistics",
               "authority": "qualification",
               "definitionDigest": "sha256:c6e877f3d7aa334ec0a005ed12cee4d6563781fef5cd62a7d9cda6d7bc4db9f6"
             },
             {
-              "index": 18,
+              "index": 21,
               "label": "name:Seal portable cache receipts",
               "authority": "qualification",
               "definitionDigest": "sha256:4b019f0fc9427abf9f3ee0dd01a7ff189b0478e1a980b93b6a045ebf303ce1ae"
             },
             {
-              "index": 19,
+              "index": 22,
               "label": "name:Save dependency cache",
               "authority": "qualification",
               "definitionDigest": "sha256:8f6eabd31ff9c94980e28ea47b32d2d0c927d23dda497c0c642d5297a6f523c6"
             },
             {
-              "index": 20,
+              "index": 23,
               "label": "name:Save compiler cache",
               "authority": "evidence-publication",
               "definitionDigest": "sha256:01670cfed95efad195e0c2e5451634eeb401468493d46aadbc9c8a329146bbe8"
             },
             {
-              "index": 21,
+              "index": 24,
               "label": "name:Upload raw plan, receipt, and logs",
               "authority": "evidence-publication",
               "definitionDigest": "sha256:69bcddc7d298cf073e4479481e6b810b8cdc33013f012e12f927530ab54d85a0"

--- a/docs/qualification/gates/workflow-authority.md
+++ b/docs/qualification/gates/workflow-authority.md
@@ -40,7 +40,7 @@ without changing and refreshing the manifest fails the Gate catalog check.
 | Workflow | Job | Authority | Publication | Receipt | Credentials | Environment | Steps |
 | --- | --- | --- | --- | --- | --- | --- | ---: |
 | `.github/workflows/adr-release-gate.yml` | `adr-release` | qualification | none | diagnostic | token:read | none | 2 |
-| `.github/workflows/affected-native-pr.yml` | `affected_native_shards` | qualification | none | diagnostic | token:read | none | 21 |
+| `.github/workflows/affected-native-pr.yml` | `affected_native_shards` | qualification | none | diagnostic | token:read | none | 24 |
 | `.github/workflows/affected-native-pr.yml` | `affected-native` | qualification | none | diagnostic | token:read | none | 7 |
 | `.github/workflows/affected-native-pr.yml` | `candidate_preflight` | qualification | none | diagnostic | token:read | none | 6 |
 | `.github/workflows/affected-native-pr.yml` | `dco` | qualification | none | diagnostic | token:read | none | 2 |

--- a/framework/core/.gyp/run-build.js
+++ b/framework/core/.gyp/run-build.js
@@ -10,6 +10,9 @@ const CORE = path.join(__dirname, '..');
 const { copyContractArtifacts } = require(
   path.join(CORE, '..', '..', 'scripts', 'contract-registry.cjs'),
 );
+const { measureCandidateStageSync } = require(
+  path.join(CORE, '..', '..', 'scripts', 'candidate-timeline-events.cjs'),
+);
 
 function selectedBuildBindings() {
   const authority = require('../architecture/build-capabilities.json');
@@ -120,8 +123,15 @@ function stage() {
 function build() {
   const bindings = selectedBuildBindings();
   const { conanInstall, conanBuild } = require('./run-conan');
-  conanInstall();
-  conanBuild();
+  measureCandidateStageSync(
+    'sdk-core-dependencies',
+    'core-dependency-bootstrap',
+    conanInstall,
+    { gateId: 'source.changed-scope' },
+  );
+  measureCandidateStageSync('sdk-core-native', 'core-build', conanBuild, {
+    gateId: 'source.changed-scope',
+  });
   // Colocate the libnode runtime into build/<build_type> before staging, so the
   // staged dist/kungfu is self-contained: pykungfu links @rpath/libnode.*, and
   // dist/kungfu is the single runtime surface that kfx and the platform package
@@ -132,12 +142,22 @@ function build() {
       ['python', 'node', 'electron'].includes(binding),
     )
   ) {
-    require('./run-link-node').main();
+    measureCandidateStageSync(
+      'sdk-core-link-node',
+      'core-link',
+      () => require('./run-link-node').main(),
+      { gateId: 'source.changed-scope' },
+    );
   }
   // With libnode colocated above, pykungfu imports — regenerate its .pyi stubs
   // from the fresh binding so committed stubs/ track the C++ (see gen-stubs.js).
   if (bindings.has('python')) {
-    require('./gen-stubs').main();
+    measureCandidateStageSync(
+      'sdk-core-python-stubs',
+      'sdk-pack-python',
+      () => require('./gen-stubs').main(),
+      { gateId: 'source.changed-scope', language: 'python' },
+    );
   }
   // The pykungfu wheel ships in dist/kungfu/wheels — the product install
   // surface (`kungfu env`) resolves it from there. Build it with the binding
@@ -146,9 +166,21 @@ function build() {
   // without wheels (run-freeze copyWheel warned but could not fail).
   // run-wheel.js ends with process.exit, so spawn it instead of requiring.
   if (bindings.has('python')) {
-    shell.run(process.execPath, [path.join(__dirname, 'run-wheel.js')], true);
+    measureCandidateStageSync(
+      'sdk-core-python-wheel',
+      'sdk-pack-python',
+      () =>
+        shell.run(
+          process.execPath,
+          [path.join(__dirname, 'run-wheel.js')],
+          true,
+        ),
+      { gateId: 'source.changed-scope', language: 'python' },
+    );
   }
-  stage();
+  measureCandidateStageSync('sdk-core-stage', 'sdk-pack-native', stage, {
+    gateId: 'source.changed-scope',
+  });
   cpVsDependencies();
 }
 

--- a/framework/core/conanfile.py
+++ b/framework/core/conanfile.py
@@ -10,12 +10,14 @@ import os
 import pathlib
 import platform
 import datetime
+import time
 import shutil
 import stat
 import subprocess
 import sys
 import re
 from glob import glob
+from contextlib import contextmanager
 from os import environ, path
 
 from conan import ConanFile
@@ -25,6 +27,89 @@ from conan.tools.cmake import CMakeToolchain, CMakeDeps
 from conan.tools.files import copy
 
 _CONANFILE_DIR = path.dirname(path.realpath(__file__))
+
+
+def _candidate_timeline_attempt():
+    event_name = os.environ.get("GITHUB_EVENT_NAME", "local")
+    run_id = os.environ.get("GITHUB_RUN_ID", "local")
+    result = {
+        "id": os.environ.get("KUNGFU_CANDIDATE_ATTEMPT_ID", f"{event_name}-{run_id}"),
+        "kind": (
+            "merge-queue"
+            if event_name == "merge_group"
+            else "pull-request"
+            if event_name == "pull_request"
+            else "local"
+        ),
+    }
+    if event_name == "merge_group" and os.environ.get("GITHUB_SHA"):
+        result["mergeGroupSha"] = os.environ["GITHUB_SHA"]
+    if os.environ.get("GITHUB_RUN_ID"):
+        result["workflowRunId"] = os.environ["GITHUB_RUN_ID"]
+    return result
+
+
+@contextmanager
+def _candidate_timeline_stage(stage, phase, runtime):
+    output = os.environ.get("KUNGFU_CANDIDATE_TIMELINE_EVENTS", "")
+    started_at = (
+        datetime.datetime.now(datetime.timezone.utc).isoformat().replace("+00:00", "Z")
+    )
+    started = time.perf_counter_ns()
+    status = "success"
+    try:
+        yield
+    except BaseException:
+        status = "failure"
+        raise
+    finally:
+        if output:
+            completed_at = (
+                datetime.datetime.now(datetime.timezone.utc)
+                .isoformat()
+                .replace("+00:00", "Z")
+            )
+            attempt = _candidate_timeline_attempt()
+            partition = os.environ.get("KUNGFU_AFFECTED_NATIVE_PARTITION_INDEX", "none")
+            event_id = (
+                f"{attempt['id']}:{platform.system().lower()}:{partition}:{stage}"
+            )
+            event = {
+                "id": event_id,
+                "attempt": attempt,
+                "phase": phase,
+                "category": "stage",
+                "status": status,
+                "gate": {
+                    "id": os.environ.get(
+                        "KUNGFU_CANDIDATE_GATE_ID", "source.changed-scope"
+                    ),
+                    "platform": f"{platform.system().lower()}-{platform.machine().lower()}",
+                    "partition": partition,
+                },
+                "span": {"id": event_id},
+                "execution": {"boundary": "conan-cmake"},
+                "timing": {
+                    "startedAt": started_at,
+                    "completedAt": completed_at,
+                    "durationMs": round(
+                        (time.perf_counter_ns() - started) / 1_000_000, 3
+                    ),
+                    "clock": "monotonic-duration+wall-envelope",
+                    "precisionMs": 1,
+                    "authority": "kungfu-conan-cmake-stage",
+                },
+                "criticalPathEligible": True,
+                "attributes": {
+                    "sourceSha": os.environ.get("GITHUB_SHA", ""),
+                    "runtime": runtime,
+                    "stage": stage,
+                },
+            }
+            output_dir = path.dirname(path.abspath(output))
+            os.makedirs(output_dir, exist_ok=True)
+            with open(output, "a", encoding="utf-8") as timeline_file:
+                timeline_file.write(json.dumps(event, separators=(",", ":")) + "\n")
 
 
 with open(
@@ -416,8 +501,14 @@ class KungfuCoreConan(ConanFile):
         )
         self.__enable_modules(runtime)
         if str(self.options.with_yarn) == "True":
-            self.__run_cmake_js(build_type, "configure", runtime, toolset)
-            self.__run_cmake_js(build_type, "build", runtime, toolset)
+            with _candidate_timeline_stage(
+                f"sdk-core-{runtime}-configure", "core-configure", runtime
+            ):
+                self.__run_cmake_js(build_type, "configure", runtime, toolset)
+            with _candidate_timeline_stage(
+                f"sdk-core-{runtime}-build", "core-build", runtime
+            ):
+                self.__run_cmake_js(build_type, "build", runtime, toolset)
         elif runtime == "node":
             environ["KUNGFU_BUILD_SKIP_KUNGFU_NODE"] = "on"
             environ["KUNGFU_BUILD_SKIP_PYKUNGFU"] = "on"
@@ -427,16 +518,22 @@ class KungfuCoreConan(ConanFile):
                 if cargo_registry
                 else []
             )
-            self.__run_cmake(
-                "-S",
-                ".." if self.gyp_call else ".",
-                "-B",
-                "../build" if self.gyp_call else ".",
-                "-DCMAKE_BUILD_TYPE=Release",
-                f"-DSPDLOG_LOG_LEVEL_COMPILE={self.__spdlog_level()}",
-                *cargo_registry_option,
-            )
-            self.__run_cmake("--build", ".", "--config", "Release", *parallel_opt)
+            with _candidate_timeline_stage(
+                "sdk-core-node-configure", "core-configure", runtime
+            ):
+                self.__run_cmake(
+                    "-S",
+                    ".." if self.gyp_call else ".",
+                    "-B",
+                    "../build" if self.gyp_call else ".",
+                    "-DCMAKE_BUILD_TYPE=Release",
+                    f"-DSPDLOG_LOG_LEVEL_COMPILE={self.__spdlog_level()}",
+                    *cargo_registry_option,
+                )
+            with _candidate_timeline_stage(
+                "sdk-core-node-build", "core-build", runtime
+            ):
+                self.__run_cmake("--build", ".", "--config", "Release", *parallel_opt)
 
     def __run_cmake(self, *args):
         rc = subprocess.Popen([shutil.which("cmake"), *args]).wait()

--- a/framework/core/conanfile.py
+++ b/framework/core/conanfile.py
@@ -102,6 +102,7 @@ def _candidate_timeline_stage(stage, phase, runtime):
                 "criticalPathEligible": True,
                 "attributes": {
                     "sourceSha": os.environ.get("GITHUB_SHA", ""),
+                    "laneId": f"affected-native/partition-{partition}",
                     "runtime": runtime,
                     "stage": stage,
                 },

--- a/package.json
+++ b/package.json
@@ -252,7 +252,7 @@
   "devDependencies": {
     "@biomejs/biome": "1.9.4",
     "@kungfu-tech/buildchain": "2.14.1",
-    "@kungfu-tech/buildchain-alpha": "npm:@kungfu-tech/buildchain@2.14.17-alpha.2",
+    "@kungfu-tech/buildchain-alpha": "npm:@kungfu-tech/buildchain@2.14.17-alpha.3",
     "@kungfu-tech/kfd": "1.0.0-alpha.35",
     "@types/fs-extra": "^11.0.4",
     "@types/markdown-it": "14.1.2",

--- a/package.json
+++ b/package.json
@@ -252,6 +252,7 @@
   "devDependencies": {
     "@biomejs/biome": "1.9.4",
     "@kungfu-tech/buildchain": "2.14.1",
+    "@kungfu-tech/buildchain-alpha": "npm:@kungfu-tech/buildchain@2.14.17-alpha.2",
     "@kungfu-tech/kfd": "1.0.0-alpha.35",
     "@types/fs-extra": "^11.0.4",
     "@types/markdown-it": "14.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       '@kungfu-tech/buildchain':
         specifier: 2.14.1
         version: 2.14.1
+      '@kungfu-tech/buildchain-alpha':
+        specifier: npm:@kungfu-tech/buildchain@2.14.17-alpha.2
+        version: '@kungfu-tech/buildchain@2.14.17-alpha.2'
       '@kungfu-tech/kfd':
         specifier: 1.0.0-alpha.35
         version: 1.0.0-alpha.35
@@ -1393,6 +1396,11 @@ packages:
 
   '@kungfu-tech/buildchain@2.14.1':
     resolution: {integrity: sha512-3wCODPKkIuOWO8Y60uyYM65ABzWvMfU2XCH6/vsixSIHDLtx5aGPtr1RMoKkbAHQ8mC+RHE4xRfUEuA0hMlkvg==}
+    engines: {node: '>=22.14.0'}
+    hasBin: true
+
+  '@kungfu-tech/buildchain@2.14.17-alpha.2':
+    resolution: {integrity: sha512-aAiv5LaTPnbRupIvVCoEZjp+8pjPbPd552zpoa9FFRplgRI318ksksz3gVpYNWYCXH9hNQ03Z2wpHpEOOHlUhA==}
     engines: {node: '>=22.14.0'}
     hasBin: true
 
@@ -5760,6 +5768,11 @@ snapshots:
       smol-toml: 1.7.0
 
   '@kungfu-tech/buildchain@2.14.1':
+    dependencies:
+      '@kungfu-tech/kfd': 1.0.0-alpha.21
+      smol-toml: 1.7.0
+
+  '@kungfu-tech/buildchain@2.14.17-alpha.2':
     dependencies:
       '@kungfu-tech/kfd': 1.0.0-alpha.21
       smol-toml: 1.7.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,8 +36,8 @@ importers:
         specifier: 2.14.1
         version: 2.14.1
       '@kungfu-tech/buildchain-alpha':
-        specifier: npm:@kungfu-tech/buildchain@2.14.17-alpha.2
-        version: '@kungfu-tech/buildchain@2.14.17-alpha.2'
+        specifier: npm:@kungfu-tech/buildchain@2.14.17-alpha.3
+        version: '@kungfu-tech/buildchain@2.14.17-alpha.3'
       '@kungfu-tech/kfd':
         specifier: 1.0.0-alpha.35
         version: 1.0.0-alpha.35
@@ -1399,8 +1399,8 @@ packages:
     engines: {node: '>=22.14.0'}
     hasBin: true
 
-  '@kungfu-tech/buildchain@2.14.17-alpha.2':
-    resolution: {integrity: sha512-aAiv5LaTPnbRupIvVCoEZjp+8pjPbPd552zpoa9FFRplgRI318ksksz3gVpYNWYCXH9hNQ03Z2wpHpEOOHlUhA==}
+  '@kungfu-tech/buildchain@2.14.17-alpha.3':
+    resolution: {integrity: sha512-K1hGc62ti9cWGc8BTqk2UncsEVqFDTPdBcJtjjdBnVuCuFYZxwQXUkjMkMvlDAck1oz0gkImXR/pddBcwtPi1A==}
     engines: {node: '>=22.14.0'}
     hasBin: true
 
@@ -5772,7 +5772,7 @@ snapshots:
       '@kungfu-tech/kfd': 1.0.0-alpha.21
       smol-toml: 1.7.0
 
-  '@kungfu-tech/buildchain@2.14.17-alpha.2':
+  '@kungfu-tech/buildchain@2.14.17-alpha.3':
     dependencies:
       '@kungfu-tech/kfd': 1.0.0-alpha.21
       smol-toml: 1.7.0

--- a/scripts/affected-native-proof.test.mjs
+++ b/scripts/affected-native-proof.test.mjs
@@ -384,6 +384,14 @@ test('workflow keeps one required context while staging authoritative queue buil
   );
   assert.match(
     workflow,
+    /KUNGFU_CANDIDATE_TIMELINE_EVENTS: \$\{\{ github\.workspace \}\}\/product\/qualification\/affected-native\/candidate-events\.jsonl/u,
+  );
+  assert.match(
+    workflow,
+    /Prepare SDK build toolchain[\s\S]*Build Core SDK artifacts[\s\S]*Pack four-language SDK artifacts[\s\S]*Qualify installed four-language SDK wire contract/u,
+  );
+  assert.match(
+    workflow,
     /Run affected native closure[\s\S]*steps\.plan\.outputs\.native-required == 'true'/u,
   );
   assert.match(workflow, /^\s{2}shifu_workspace:$/mu);

--- a/scripts/candidate-timeline-events.cjs
+++ b/scripts/candidate-timeline-events.cjs
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: Apache-2.0
+// @ts-check
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { performance } = require('node:perf_hooks');
+
+function compact(value) {
+  return Object.fromEntries(
+    Object.entries(value).filter(
+      ([, entry]) => entry !== undefined && entry !== '',
+    ),
+  );
+}
+
+function attempt(env = process.env) {
+  const runId = env.GITHUB_RUN_ID || 'local';
+  const eventName = env.GITHUB_EVENT_NAME || 'local';
+  return compact({
+    id: env.KUNGFU_CANDIDATE_ATTEMPT_ID || `${eventName}-${runId}`,
+    index: /^\d+$/.test(env.KUNGFU_CANDIDATE_ATTEMPT_INDEX || '')
+      ? Number(env.KUNGFU_CANDIDATE_ATTEMPT_INDEX)
+      : undefined,
+    kind:
+      eventName === 'merge_group'
+        ? 'merge-queue'
+        : eventName === 'pull_request'
+          ? 'pull-request'
+          : 'local',
+    mergeGroupSha: eventName === 'merge_group' ? env.GITHUB_SHA : undefined,
+    workflowRunId: env.GITHUB_RUN_ID,
+  });
+}
+
+function eventId(id, env = process.env) {
+  const partition = env.KUNGFU_AFFECTED_NATIVE_PARTITION_INDEX || 'none';
+  return `${attempt(env).id}:${process.platform}:${partition}:${id}`;
+}
+
+function appendEvent(event, env = process.env) {
+  const output = env.KUNGFU_CANDIDATE_TIMELINE_EVENTS || '';
+  if (!output) return;
+  const target = path.resolve(output);
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  fs.appendFileSync(target, `${JSON.stringify(event)}\n`);
+}
+
+function buildEvent(id, phase, startedAt, started, status, options = {}) {
+  const env = options.env || process.env;
+  const completedAt = new Date().toISOString();
+  return compact({
+    id: eventId(id, env),
+    attempt: attempt(env),
+    phase,
+    category: options.category || 'stage',
+    status,
+    gate: compact({
+      id: options.gateId || env.KUNGFU_CANDIDATE_GATE_ID || undefined,
+      platform: options.platform || `${process.platform}-${process.arch}`,
+      partition: env.KUNGFU_AFFECTED_NATIVE_PARTITION_INDEX,
+    }),
+    span: options.parentId
+      ? { id: eventId(id, env), parentId: eventId(options.parentId, env) }
+      : { id: eventId(id, env) },
+    execution: compact({
+      boundary: options.boundary || 'process',
+      runner: env.RUNNER_NAME,
+    }),
+    timing: {
+      startedAt,
+      completedAt,
+      durationMs: Math.round((performance.now() - started) * 1000) / 1000,
+      clock: 'monotonic-duration+wall-envelope',
+      precisionMs: 1,
+      authority: 'kungfu-process-stage',
+    },
+    criticalPathEligible: options.criticalPathEligible !== false,
+    attributes: compact({
+      sourceSha: env.GITHUB_SHA,
+      language: options.language,
+      stage: id,
+    }),
+  });
+}
+
+function measureCandidateStageSync(id, phase, callback, options = {}) {
+  const startedAt = new Date().toISOString();
+  const started = performance.now();
+  try {
+    const result = callback();
+    appendEvent(
+      buildEvent(id, phase, startedAt, started, 'success', options),
+      options.env,
+    );
+    return result;
+  } catch (error) {
+    appendEvent(
+      buildEvent(id, phase, startedAt, started, 'failure', options),
+      options.env,
+    );
+    throw error;
+  }
+}
+
+async function measureCandidateStage(id, phase, callback, options = {}) {
+  const startedAt = new Date().toISOString();
+  const started = performance.now();
+  try {
+    const result = await callback();
+    appendEvent(
+      buildEvent(id, phase, startedAt, started, 'success', options),
+      options.env,
+    );
+    return result;
+  } catch (error) {
+    appendEvent(
+      buildEvent(id, phase, startedAt, started, 'failure', options),
+      options.env,
+    );
+    throw error;
+  }
+}
+
+module.exports = {
+  measureCandidateStage,
+  measureCandidateStageSync,
+};

--- a/scripts/candidate-timeline-events.cjs
+++ b/scripts/candidate-timeline-events.cjs
@@ -78,6 +78,10 @@ function buildEvent(id, phase, startedAt, started, status, options = {}) {
     attributes: compact({
       sourceSha: env.GITHUB_SHA,
       language: options.language,
+      laneId:
+        env.KUNGFU_AFFECTED_NATIVE_PARTITION_INDEX === undefined
+          ? undefined
+          : `affected-native/partition-${env.KUNGFU_AFFECTED_NATIVE_PARTITION_INDEX}`,
       stage: id,
     }),
   });

--- a/scripts/candidate-timeline-events.test.mjs
+++ b/scripts/candidate-timeline-events.test.mjs
@@ -5,6 +5,7 @@ import fs from 'node:fs';
 import { createRequire } from 'node:module';
 import os from 'node:os';
 import path from 'node:path';
+import { performance } from 'node:perf_hooks';
 import test from 'node:test';
 
 const require = createRequire(import.meta.url);
@@ -56,9 +57,11 @@ test('candidate stage records bounded source and attempt correlation', () => {
     assert.equal(event.timing.clock, 'monotonic-duration+wall-envelope');
     assert.equal(event.timing.precisionMs, 1);
     assert.deepEqual(Object.keys(event.attributes).sort(), [
+      'laneId',
       'sourceSha',
       'stage',
     ]);
+    assert.equal(event.attributes.laneId, 'affected-native/partition-0');
   } finally {
     fs.rmSync(value.root, { recursive: true, force: true });
   }
@@ -82,6 +85,34 @@ test('candidate stage records failure and rethrows', async () => {
     assert.equal(event.status, 'failure');
     assert.equal(event.attributes.language, 'rust');
     assert.equal(JSON.stringify(event).includes('fixture failure'), false);
+  } finally {
+    fs.rmSync(value.root, { recursive: true, force: true });
+  }
+});
+
+test('candidate stage instrumentation has bounded local overhead and output', () => {
+  const value = fixture();
+  const withoutSink = { ...value.env };
+  withoutSink.KUNGFU_CANDIDATE_TIMELINE_EVENTS = undefined;
+  const noSinkStarted = performance.now();
+  for (let index = 0; index < 1_000; index += 1) {
+    measureCandidateStageSync(`no-sink-${index}`, 'overhead-probe', () => {}, {
+      env: withoutSink,
+    });
+  }
+  const noSinkDurationMs = performance.now() - noSinkStarted;
+
+  try {
+    const sinkStarted = performance.now();
+    for (let index = 0; index < 25; index += 1) {
+      measureCandidateStageSync(`sink-${index}`, 'overhead-probe', () => {}, {
+        env: value.env,
+      });
+    }
+    const sinkDurationMs = performance.now() - sinkStarted;
+    assert.ok(noSinkDurationMs < 1_000, `no-sink=${noSinkDurationMs}ms`);
+    assert.ok(sinkDurationMs < 1_000, `sink=${sinkDurationMs}ms`);
+    assert.ok(fs.statSync(value.output).size < 32 * 1_024);
   } finally {
     fs.rmSync(value.root, { recursive: true, force: true });
   }

--- a/scripts/candidate-timeline-events.test.mjs
+++ b/scripts/candidate-timeline-events.test.mjs
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+const require = createRequire(import.meta.url);
+const {
+  measureCandidateStage,
+  measureCandidateStageSync,
+} = require('./candidate-timeline-events.cjs');
+
+function fixture() {
+  const root = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'kungfu-candidate-events-'),
+  );
+  return {
+    root,
+    output: path.join(root, 'events.jsonl'),
+    env: {
+      KUNGFU_CANDIDATE_TIMELINE_EVENTS: path.join(root, 'events.jsonl'),
+      KUNGFU_CANDIDATE_GATE_ID: 'source.changed-scope',
+      KUNGFU_AFFECTED_NATIVE_PARTITION_INDEX: '0',
+      GITHUB_EVENT_NAME: 'merge_group',
+      GITHUB_RUN_ID: '42',
+      GITHUB_SHA: 'a'.repeat(40),
+    },
+  };
+}
+
+function events(value) {
+  return fs
+    .readFileSync(value.output, 'utf8')
+    .trim()
+    .split('\n')
+    .map((line) => JSON.parse(line));
+}
+
+test('candidate stage records bounded source and attempt correlation', () => {
+  const value = fixture();
+  try {
+    assert.equal(
+      measureCandidateStageSync('core-build', 'core-build', () => 7, {
+        env: value.env,
+      }),
+      7,
+    );
+    const [event] = events(value);
+    assert.equal(event.attempt.id, 'merge_group-42');
+    assert.equal(event.attempt.mergeGroupSha, 'a'.repeat(40));
+    assert.equal(event.gate.partition, '0');
+    assert.equal(event.status, 'success');
+    assert.equal(event.timing.clock, 'monotonic-duration+wall-envelope');
+    assert.equal(event.timing.precisionMs, 1);
+    assert.deepEqual(Object.keys(event.attributes).sort(), [
+      'sourceSha',
+      'stage',
+    ]);
+  } finally {
+    fs.rmSync(value.root, { recursive: true, force: true });
+  }
+});
+
+test('candidate stage records failure and rethrows', async () => {
+  const value = fixture();
+  try {
+    await assert.rejects(
+      measureCandidateStage(
+        'wire-rust',
+        'sdk-wire-rust',
+        async () => {
+          throw new Error('fixture failure');
+        },
+        { env: value.env, language: 'rust' },
+      ),
+      /fixture failure/,
+    );
+    const [event] = events(value);
+    assert.equal(event.status, 'failure');
+    assert.equal(event.attributes.language, 'rust');
+    assert.equal(JSON.stringify(event).includes('fixture failure'), false);
+  } finally {
+    fs.rmSync(value.root, { recursive: true, force: true });
+  }
+});

--- a/scripts/measure-dev-required-latency.mjs
+++ b/scripts/measure-dev-required-latency.mjs
@@ -10,6 +10,11 @@ import path from 'node:path';
 import process from 'node:process';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
+import {
+  createCandidateTimeline,
+  formatCandidateTimelineReport,
+} from '@kungfu-tech/buildchain-alpha/candidate-timeline';
+
 import { planAffectedPaths } from './run-core-affected-native.mjs';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
@@ -30,6 +35,8 @@ function parseArgs(argv) {
     branch: DEFAULT_BRANCH,
     limit: 30,
     output: '',
+    pulls: [],
+    timelineOutput: '',
   };
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
@@ -37,6 +44,9 @@ function parseArgs(argv) {
     else if (arg === '--branch') options.branch = argv[++index];
     else if (arg === '--limit') options.limit = Number(argv[++index]);
     else if (arg === '--output') options.output = argv[++index];
+    else if (arg === '--pull') options.pulls.push(Number(argv[++index]));
+    else if (arg === '--timeline-output')
+      options.timelineOutput = argv[++index];
     else throw new Error(`unknown argument: ${arg}`);
   }
   if (
@@ -45,6 +55,16 @@ function parseArgs(argv) {
     options.limit > 100
   ) {
     throw new Error('--limit must be an integer from 1 to 100');
+  }
+  if (
+    options.pulls.some(
+      (pullNumber) => !Number.isInteger(pullNumber) || pullNumber < 1,
+    )
+  ) {
+    throw new Error('--pull must be a positive integer');
+  }
+  if (options.timelineOutput && options.pulls.length !== 1) {
+    throw new Error('--timeline-output requires exactly one --pull');
   }
   return options;
 }
@@ -228,6 +248,26 @@ function jobDuration(job) {
   return Math.max(0, milliseconds(job.started_at, job.completed_at));
 }
 
+function projectedJob(job) {
+  return {
+    id: job.id,
+    name: job.name,
+    status: job.status,
+    conclusion: job.conclusion,
+    startedAt: job.started_at || null,
+    completedAt: job.completed_at || null,
+    runnerName: job.runner_name || null,
+    steps: (job.steps || []).map((step) => ({
+      number: step.number,
+      name: step.name,
+      status: step.status,
+      conclusion: step.conclusion,
+      startedAt: step.started_at || null,
+      completedAt: step.completed_at || null,
+    })),
+  };
+}
+
 export function mergeQueueEvidence(events, runs, jobsByRun, mergedAt) {
   const orderedEvents = [...events]
     .filter(({ __typename }) =>
@@ -280,6 +320,7 @@ export function mergeQueueEvidence(events, runs, jobsByRun, mergedAt) {
         completedAt: run.updated_at,
         status: run.status,
         conclusion: run.conclusion,
+        jobs: (jobsByRun[String(run.id)] || []).map(projectedJob),
       })),
     });
     current = null;
@@ -738,6 +779,7 @@ export function nativeEvidenceFromMembers(members, classification) {
       outcome: 'not-applicable',
       authority: 'source-planner',
       steps: [],
+      candidateEvents: [],
     };
   }
   if (classification.kind !== 'native') {
@@ -745,6 +787,7 @@ export function nativeEvidenceFromMembers(members, classification) {
       outcome: 'unknown',
       authority: 'classification-unknown',
       steps: [],
+      candidateEvents: [],
     };
   }
   try {
@@ -754,12 +797,28 @@ export function nativeEvidenceFromMembers(members, classification) {
     }
     const receipt = JSON.parse(members['receipt.json']);
     const diagnostics = JSON.parse(members['diagnostics.json']);
+    const candidateEvents = (members['candidate-events.jsonl'] || '')
+      .split(/\r?\n/u)
+      .filter(Boolean)
+      .map((line) => JSON.parse(line));
     if (
       receipt.schema !== 'kungfu.core-affected-native-receipt/v1' ||
       receipt.status !== 'passed' ||
       !Array.isArray(receipt.steps)
     ) {
       throw new Error('invalid native receipt');
+    }
+    if (
+      candidateEvents.some(
+        (event) =>
+          !event.id ||
+          !event.attempt?.id ||
+          !event.phase ||
+          !event.status ||
+          event.attributes?.sourceSha !== receipt.source.head,
+      )
+    ) {
+      throw new Error('invalid candidate timeline event binding');
     }
     if (receipt.plan?.planDigest) {
       const { planDigest, ...planWithoutDigest } = receipt.plan;
@@ -823,6 +882,7 @@ export function nativeEvidenceFromMembers(members, classification) {
       lifecycle: diagnostics.lifecycleObservability || null,
       process: diagnostics.process || null,
       compilerCaches: diagnostics.compilerCaches || {},
+      candidateEvents,
     };
   } catch (error) {
     return {
@@ -830,6 +890,7 @@ export function nativeEvidenceFromMembers(members, classification) {
       authority: 'artifact-invalid-or-incomplete',
       reason: error.message,
       steps: [],
+      candidateEvents: [],
     };
   }
 }
@@ -978,6 +1039,9 @@ export function aggregatePartitionEvidence(entries, classification) {
       process: null,
       compilerCaches: {},
       executionPartitions: lanes,
+      candidateEvents: orderedEntries.flatMap(
+        ({ native }) => native.candidateEvents || [],
+      ),
     },
   };
 }
@@ -1037,6 +1101,7 @@ async function collectAffectedNativeEvidence(
         'cache/compiler-stats.txt',
         'receipt.json',
         'diagnostics.json',
+        'candidate-events.jsonl',
       ]);
       const cache = cacheEvidenceFromMembers(members, classification);
       const native = nativeEvidenceFromMembers(members, classification);
@@ -1183,16 +1248,16 @@ async function collectMergeQueueEvidence(
       {},
       pull.merged_at,
     );
-    const wastedRunIds = [
+    const assignedRunIds = [
       ...new Set(
-        initial.rounds
-          .filter(({ reason }) => reason !== 'merged')
-          .flatMap(({ mergeGroupRuns: runs }) => runs.map(({ id }) => id)),
+        initial.rounds.flatMap(({ mergeGroupRuns: runs }) =>
+          runs.map(({ id }) => id),
+        ),
       ),
     ];
     const jobsByRun = Object.fromEntries(
       await Promise.all(
-        wastedRunIds.map(async (runId) => {
+        assignedRunIds.map(async (runId) => {
           const payload = await githubJson(
             `/repos/${repository}/actions/runs/${runId}/jobs?per_page=100`,
             token,
@@ -1300,12 +1365,15 @@ async function collectSample(
   const affectedNative = checks.find(
     ({ context }) => context === 'affected-native / linux',
   );
+  const mergedQueueRun = mergeQueue?.rounds
+    ?.find(({ reason }) => reason === 'merged')
+    ?.mergeGroupRuns?.at(-1);
   const evidence = await collectAffectedNativeEvidence(
     repository,
-    affectedNative?.finalWorkflowRunId,
+    mergedQueueRun?.id || affectedNative?.finalWorkflowRunId,
     classification,
     token,
-    affectedNative?.finalWorkflowHeadSha || sha,
+    mergedQueueRun?.headSha || affectedNative?.finalWorkflowHeadSha || sha,
   );
   const startedAt = checks.map(({ startedAt }) => startedAt).sort()[0];
   const completedAt = checks
@@ -1358,6 +1426,292 @@ function summarizeSteps(samples) {
       ),
     ]),
   );
+}
+
+function providerStatus(conclusion, measured) {
+  if (!measured) return 'unknown';
+  if (conclusion === 'success') return 'success';
+  if (conclusion === 'cancelled') return 'cancelled';
+  if (conclusion === 'skipped') return 'skipped';
+  return 'failure';
+}
+
+function providerTiming(startedAt, completedAt, authority) {
+  if (!startedAt || !completedAt) return undefined;
+  return {
+    startedAt,
+    completedAt,
+    durationMs: milliseconds(startedAt, completedAt),
+    clock: 'provider-wall',
+    precisionMs: 1000,
+    authority,
+  };
+}
+
+function workflowStepPhase(name = '') {
+  if (/checkout|setup node|resolve affected native revisions/iu.test(name))
+    return 'bootstrap';
+  if (
+    /plan affected|portable cache plan|prepare sdk build toolchain/iu.test(name)
+  )
+    return 'preflight';
+  if (/restore .*cache/iu.test(name)) return 'cache-restore';
+  if (
+    /enable compiler cache|reset compiler cache|compiler cache statistics|seal portable cache/iu.test(
+      name,
+    )
+  )
+    return 'cache-validation';
+  if (
+    /install pinned source acceptance tools|ensure compiler cache tool/iu.test(
+      name,
+    )
+  )
+    return 'tool-bootstrap';
+  if (/install frozen workspace/iu.test(name)) return 'workspace-install';
+  if (/build core sdk artifacts/iu.test(name)) return 'core-build';
+  if (/pack four-language sdk artifacts/iu.test(name)) return 'sdk-pack';
+  if (/qualify installed four-language sdk wire contract/iu.test(name))
+    return 'sdk-wire-contract';
+  if (/run affected native closure/iu.test(name)) return 'native-closure';
+  if (/save .*cache/iu.test(name)) return 'cache-save';
+  if (/upload/iu.test(name)) return 'artifact-upload';
+  return 'workflow-step';
+}
+
+function roundAttempt(pullRequest, round) {
+  const run = round.mergeGroupRuns[0];
+  return {
+    id: `mq-${pullRequest}-${round.index}`,
+    index: round.index + 1,
+    kind: 'merge-queue',
+    mergeGroupSha: run?.headSha,
+    workflowRunId: run?.id,
+  };
+}
+
+function workflowJobGate(job) {
+  const platform = job.name?.match(/\/\s*([^/]+)$/u)?.[1];
+  const partition = job.name?.match(/(?:partition|shard)\s+(\d+)/iu)?.[1];
+  return {
+    id: job.name,
+    ...(platform ? { platform } : {}),
+    ...(partition === undefined ? {} : { partition }),
+  };
+}
+
+export function candidateTimelineInput(repository, branch, sample) {
+  const events = [];
+  const sourceSha = sample.sourceSha;
+  const prAttempt = {
+    id: `pr-${sample.pullRequest}-${sourceSha}`,
+    index: 0,
+    kind: 'pull-request',
+  };
+  for (const check of sample.checks || []) {
+    const timing = providerTiming(
+      check.startedAt,
+      check.completedAt,
+      `${check.startAuthority || 'check.started_at'}+${check.endAuthority || 'check.completed_at'}`,
+    );
+    events.push({
+      id: `${prAttempt.id}:check:${check.context}`,
+      attempt: prAttempt,
+      phase: 'pr-admission',
+      category: 'gate',
+      status: providerStatus(check.status, Boolean(timing)),
+      gate: { id: check.context },
+      timing,
+      attributes: {
+        sourceSha,
+        retryCount: check.retryCount || 0,
+        checkRunId: check.checkRunId || null,
+      },
+    });
+  }
+
+  const rounds = sample.mergeQueue?.rounds || [];
+  const runAttempts = new Map();
+  for (const round of rounds) {
+    const attempt = roundAttempt(sample.pullRequest, round);
+    events.push({
+      id: `${attempt.id}:queue-residence`,
+      attempt,
+      phase: 'queue-residence',
+      category: 'queue',
+      status: round.reason === 'merged' ? 'success' : 'cancelled',
+      timing: providerTiming(
+        round.enqueuedAt,
+        round.removedAt,
+        'github-graphql-merge-queue-events',
+      ),
+      attributes: { sourceSha, dequeueReason: round.reason },
+    });
+    for (const run of round.mergeGroupRuns || []) {
+      const runAttempt = {
+        ...attempt,
+        mergeGroupSha: run.headSha,
+        workflowRunId: run.id,
+      };
+      runAttempts.set(String(run.id), runAttempt);
+      const runTiming = providerTiming(
+        run.createdAt,
+        run.completedAt,
+        'github-actions-workflow-run',
+      );
+      events.push({
+        id: `${attempt.id}:workflow:${run.id}`,
+        attempt: runAttempt,
+        phase: 'authoritative-build',
+        category: 'workflow',
+        status: providerStatus(run.conclusion, Boolean(runTiming)),
+        timing: runTiming,
+        attributes: { sourceSha, workflowRunId: run.id },
+      });
+      for (const job of run.jobs || []) {
+        const gate = workflowJobGate(job);
+        const jobTiming = providerTiming(
+          job.startedAt,
+          job.completedAt,
+          'github-actions-job',
+        );
+        events.push({
+          id: `${attempt.id}:job:${job.id}`,
+          attempt: runAttempt,
+          phase: 'gate-fanout',
+          category: 'job',
+          status: providerStatus(job.conclusion, Boolean(jobTiming)),
+          gate,
+          execution: { boundary: 'github-actions-job', runner: job.runnerName },
+          timing: jobTiming,
+          attributes: { sourceSha, jobId: job.id },
+        });
+        events.push({
+          id: `${attempt.id}:job:${job.id}:runner-wait`,
+          attempt: runAttempt,
+          phase: 'runner-wait',
+          category: 'runner-wait',
+          status: 'unknown',
+          gate,
+          criticalPathEligible: true,
+          attributes: {
+            sourceSha,
+            reason: 'github-actions-jobs-api-does-not-expose-job-queued-at',
+          },
+        });
+        for (const step of job.steps || []) {
+          const stepTiming = providerTiming(
+            step.startedAt,
+            step.completedAt,
+            'github-actions-job-step',
+          );
+          events.push({
+            id: `${attempt.id}:job:${job.id}:step:${step.number}`,
+            attempt: runAttempt,
+            phase: workflowStepPhase(step.name),
+            category: 'workflow-step',
+            status: providerStatus(step.conclusion, Boolean(stepTiming)),
+            gate,
+            span: {
+              id: `${attempt.id}:job:${job.id}:step:${step.number}`,
+              parentId: `${attempt.id}:job:${job.id}`,
+            },
+            execution: {
+              boundary: 'github-actions-step',
+              runner: job.runnerName,
+            },
+            timing: stepTiming,
+            attributes: { sourceSha, stepName: step.name },
+          });
+        }
+      }
+    }
+  }
+
+  const internalEvents = sample.nativeEvidence?.candidateEvents || [];
+  for (const event of internalEvents) {
+    const runId = String(event.attempt?.workflowRunId || '');
+    const observedSourceSha = event.attributes?.sourceSha;
+    events.push({
+      ...event,
+      attempt: runAttempts.get(runId) || event.attempt,
+      attributes: {
+        ...(event.attributes || {}),
+        ...(observedSourceSha && observedSourceSha !== sourceSha
+          ? { observedSourceSha }
+          : {}),
+        sourceSha,
+      },
+    });
+  }
+
+  const observedPhases = new Set(internalEvents.map(({ phase }) => phase));
+  const finalAttempt = rounds.length
+    ? roundAttempt(sample.pullRequest, rounds.at(-1))
+    : null;
+  if (finalAttempt) {
+    for (const [index, layer] of (sample.cache?.layers || []).entries()) {
+      events.push({
+        id: `${finalAttempt.id}:cache:${layer.partitionIndex ?? 'none'}:${layer.layer}:${index}`,
+        attempt: finalAttempt,
+        phase: 'cache-validation',
+        category: 'cache-evidence',
+        status: 'unknown',
+        gate: {
+          id: 'source.changed-scope',
+          partition: layer.partitionIndex,
+        },
+        cache: { layer: layer.layer, outcome: layer.outcome },
+        criticalPathEligible: false,
+        attributes: {
+          sourceSha,
+          observedSourceSha: layer.sourceSha,
+          receiptDigest: layer.receiptDigest,
+          timingReason: 'portable-cache-receipt-has-no-stage-interval',
+        },
+      });
+    }
+  }
+  if (sample.classification?.kind === 'native' && finalAttempt) {
+    for (const phase of [
+      'core-configure',
+      'core-build',
+      'core-link',
+      'sdk-pack',
+      'sdk-wire-cpp',
+      'sdk-wire-python',
+      'sdk-wire-node',
+      'sdk-wire-rust',
+      'native-install',
+      'native-configure',
+      'native-build',
+      'native-test',
+    ]) {
+      if (observedPhases.has(phase)) continue;
+      events.push({
+        id: `${finalAttempt.id}:unobserved:${phase}`,
+        attempt: finalAttempt,
+        phase,
+        category: 'internal-stage',
+        status: 'unknown',
+        attributes: {
+          sourceSha,
+          reason: 'no-source-bound-internal-stage-receipt',
+        },
+      });
+    }
+  }
+
+  return {
+    candidate: {
+      repository,
+      baseBranch: branch,
+      sourceSha,
+      pullRequest: sample.pullRequest,
+      mergedAt: sample.mergedAt,
+    },
+    events,
+  };
 }
 
 export function summarizeNativeAttribution(samples) {
@@ -1446,9 +1800,16 @@ export function report(
   cache.warmRatio = cacheObserved ? cache.warmCount / cacheObserved : null;
   cache.coldRatio = cacheObserved ? cache.coldCount / cacheObserved : null;
   const mergeQueueDelivery = summarizeMergeQueueDelivery(mergeQueueRecords);
+  const generatedAt = new Date().toISOString();
+  const candidateTimelines = samples.map((sample) =>
+    createCandidateTimeline({
+      ...candidateTimelineInput(repository, branch, sample),
+      generatedAt,
+    }),
+  );
   return {
     schema: 'kungfu.dev-required-latency/v1',
-    generatedAt: new Date().toISOString(),
+    generatedAt,
     repository,
     branch,
     metric: {
@@ -1490,6 +1851,11 @@ export function report(
     },
     cache,
     nativeAttribution: summarizeNativeAttribution(samples),
+    candidateTimelines,
+    candidateTimelineReports: candidateTimelines.map((timeline) => ({
+      pullRequest: timeline.candidate.pullRequest,
+      report: formatCandidateTimelineReport(timeline),
+    })),
     verdict: {
       qualified: enoughSamples && meetsTarget && nativeCacheEvidenceComplete,
       reason:
@@ -1520,11 +1886,17 @@ async function main() {
       `/repos/${repository}/branches/${branchPath}/protection/required_status_checks`,
       token,
     ),
-    githubPages(
-      `/repos/${repository}/pulls?state=all&base=${encodeURIComponent(options.branch)}&sort=updated&direction=desc`,
-      token,
-      options.limit * 3,
-    ),
+    options.pulls.length
+      ? Promise.all(
+          options.pulls.map((pullNumber) =>
+            githubJson(`/repos/${repository}/pulls/${pullNumber}`, token),
+          ),
+        )
+      : githubPages(
+          `/repos/${repository}/pulls?state=all&base=${encodeURIComponent(options.branch)}&sort=updated&direction=desc`,
+          token,
+          options.limit * 3,
+        ),
   ]);
   const requiredContexts = [
     ...new Set([
@@ -1534,13 +1906,18 @@ async function main() {
   ].sort();
   if (!requiredContexts.length)
     throw new Error(`no required contexts on ${options.branch}`);
-  validateBaseline(
-    JSON.parse(fs.readFileSync(BASELINE_PATH, 'utf8')),
-    requiredContexts,
-  );
+  if (!options.pulls.length) {
+    validateBaseline(
+      JSON.parse(fs.readFileSync(BASELINE_PATH, 'utf8')),
+      requiredContexts,
+    );
+  }
   const merged = pulls
     .filter(({ merged_at: mergedAt }) => mergedAt)
     .slice(0, options.limit);
+  if (options.pulls.length && merged.length !== options.pulls.length) {
+    throw new Error('every requested --pull must be merged');
+  }
   const earliestPullCreatedAt = merged
     .map(({ created_at: createdAt }) => createdAt)
     .filter(Boolean)
@@ -1614,6 +1991,15 @@ async function main() {
     console.error(`[dev-gate-latency] wrote ${path.relative(ROOT, output)}`);
   } else {
     process.stdout.write(json);
+  }
+  if (options.timelineOutput) {
+    const timeline = value.candidateTimelines[0];
+    if (!timeline) throw new Error('requested pull has no candidate timeline');
+    const output = path.resolve(ROOT, options.timelineOutput);
+    fs.mkdirSync(path.dirname(output), { recursive: true });
+    fs.writeFileSync(output, `${JSON.stringify(timeline, null, 2)}\n`);
+    console.error(`[dev-gate-latency] wrote ${path.relative(ROOT, output)}`);
+    console.error(formatCandidateTimelineReport(timeline));
   }
 }
 

--- a/scripts/measure-dev-required-latency.mjs
+++ b/scripts/measure-dev-required-latency.mjs
@@ -1429,15 +1429,23 @@ function summarizeSteps(samples) {
 }
 
 function providerStatus(conclusion, measured) {
+  if (conclusion === 'skipped') return 'skipped';
   if (!measured) return 'unknown';
   if (conclusion === 'success') return 'success';
   if (conclusion === 'cancelled') return 'cancelled';
-  if (conclusion === 'skipped') return 'skipped';
   return 'failure';
 }
 
 function providerTiming(startedAt, completedAt, authority) {
   if (!startedAt || !completedAt) return undefined;
+  const startedAtMs = Date.parse(startedAt);
+  const completedAtMs = Date.parse(completedAt);
+  if (
+    !Number.isFinite(startedAtMs) ||
+    !Number.isFinite(completedAtMs) ||
+    completedAtMs < startedAtMs
+  )
+    return undefined;
   return {
     startedAt,
     completedAt,
@@ -1474,9 +1482,17 @@ function workflowStepPhase(name = '') {
   if (/qualify installed four-language sdk wire contract/iu.test(name))
     return 'sdk-wire-contract';
   if (/run affected native closure/iu.test(name)) return 'native-closure';
+  if (/aggregate|admission|enforce qualifying/iu.test(name))
+    return 'aggregate-admission';
   if (/save .*cache/iu.test(name)) return 'cache-save';
   if (/upload/iu.test(name)) return 'artifact-upload';
   return 'workflow-step';
+}
+
+function workflowJobPhase(name = '') {
+  return name === 'affected-native / linux'
+    ? 'aggregate-admission'
+    : 'gate-fanout';
 }
 
 function roundAttempt(pullRequest, round) {
@@ -1566,10 +1582,18 @@ export function candidateTimelineInput(repository, branch, sample) {
         category: 'workflow',
         status: providerStatus(run.conclusion, Boolean(runTiming)),
         timing: runTiming,
-        attributes: { sourceSha, workflowRunId: run.id },
+        attributes: {
+          sourceSha,
+          workflowRunId: run.id,
+          runUrl: `https://github.com/${repository}/actions/runs/${run.id}`,
+        },
       });
       for (const job of run.jobs || []) {
         const gate = workflowJobGate(job);
+        const laneId =
+          gate.partition === undefined
+            ? undefined
+            : `affected-native/partition-${gate.partition}`;
         const jobTiming = providerTiming(
           job.startedAt,
           job.completedAt,
@@ -1578,13 +1602,18 @@ export function candidateTimelineInput(repository, branch, sample) {
         events.push({
           id: `${attempt.id}:job:${job.id}`,
           attempt: runAttempt,
-          phase: 'gate-fanout',
+          phase: workflowJobPhase(job.name),
           category: 'job',
           status: providerStatus(job.conclusion, Boolean(jobTiming)),
           gate,
           execution: { boundary: 'github-actions-job', runner: job.runnerName },
           timing: jobTiming,
-          attributes: { sourceSha, jobId: job.id },
+          attributes: {
+            sourceSha,
+            jobId: job.id,
+            jobUrl: `https://github.com/${repository}/actions/runs/${run.id}/job/${job.id}`,
+            laneId,
+          },
         });
         events.push({
           id: `${attempt.id}:job:${job.id}:runner-wait`,
@@ -1597,6 +1626,7 @@ export function candidateTimelineInput(repository, branch, sample) {
           attributes: {
             sourceSha,
             reason: 'github-actions-jobs-api-does-not-expose-job-queued-at',
+            laneId,
           },
         });
         for (const step of job.steps || []) {
@@ -1621,11 +1651,46 @@ export function candidateTimelineInput(repository, branch, sample) {
               runner: job.runnerName,
             },
             timing: stepTiming,
-            attributes: { sourceSha, stepName: step.name },
+            attributes: {
+              sourceSha,
+              stepName: step.name,
+              jobUrl: `https://github.com/${repository}/actions/runs/${run.id}/job/${job.id}`,
+              laneId,
+            },
           });
         }
       }
     }
+  }
+
+  const mergedRound = [...rounds]
+    .reverse()
+    .find(({ reason }) => reason === 'merged');
+  const mergedRun = mergedRound?.mergeGroupRuns?.at(-1);
+  if (mergedRound && mergedRun) {
+    const attempt = {
+      ...roundAttempt(sample.pullRequest, mergedRound),
+      mergeGroupSha: mergedRun.headSha,
+      workflowRunId: mergedRun.id,
+    };
+    const timing = providerTiming(
+      mergedRun.completedAt,
+      sample.mergedAt,
+      'github-actions-workflow-run+github-pull-request-merge',
+    );
+    events.push({
+      id: `${attempt.id}:merge-finalization`,
+      attempt,
+      phase: 'merge-finalization',
+      category: 'merge',
+      status: providerStatus('success', Boolean(timing)),
+      timing,
+      attributes: {
+        sourceSha,
+        pullRequestUrl: `https://github.com/${repository}/pull/${sample.pullRequest}`,
+        runUrl: `https://github.com/${repository}/actions/runs/${mergedRun.id}`,
+      },
+    });
   }
 
   const internalEvents = sample.nativeEvidence?.candidateEvents || [];
@@ -1646,6 +1711,9 @@ export function candidateTimelineInput(repository, branch, sample) {
   }
 
   const observedPhases = new Set(internalEvents.map(({ phase }) => phase));
+  const phaseObserved = (phase) =>
+    observedPhases.has(phase) ||
+    [...observedPhases].some((observed) => observed.startsWith(`${phase}-`));
   const finalAttempt = rounds.length
     ? roundAttempt(sample.pullRequest, rounds.at(-1))
     : null;
@@ -1667,6 +1735,10 @@ export function candidateTimelineInput(repository, branch, sample) {
           sourceSha,
           observedSourceSha: layer.sourceSha,
           receiptDigest: layer.receiptDigest,
+          laneId:
+            layer.partitionIndex === undefined
+              ? undefined
+              : `affected-native/partition-${layer.partitionIndex}`,
           timingReason: 'portable-cache-receipt-has-no-stage-interval',
         },
       });
@@ -1687,7 +1759,7 @@ export function candidateTimelineInput(repository, branch, sample) {
       'native-build',
       'native-test',
     ]) {
-      if (observedPhases.has(phase)) continue;
+      if (phaseObserved(phase)) continue;
       events.push({
         id: `${finalAttempt.id}:unobserved:${phase}`,
         attempt: finalAttempt,

--- a/scripts/measure-dev-required-latency.test.mjs
+++ b/scripts/measure-dev-required-latency.test.mjs
@@ -4,9 +4,12 @@ import assert from 'node:assert/strict';
 import crypto from 'node:crypto';
 import test from 'node:test';
 
+import { createCandidateTimeline } from '@kungfu-tech/buildchain-alpha/candidate-timeline';
+
 import {
   aggregatePartitionEvidence,
   cacheEvidenceFromMembers,
+  candidateTimelineInput,
   mergeGroupPullNumber,
   mergeQueueEvidence,
   nativeEvidenceFromMembers,
@@ -218,6 +221,134 @@ test('merge queue evidence preserves failed dequeue and wasted runner time', () 
   assert.equal(value.repeatedValidationCount, 1);
   assert.equal(value.wastedRunnerMs, 20 * 60 * 1000);
   assert.equal(value.postDequeueRunnerMs, 7 * 60 * 1000);
+  assert.equal(value.rounds[0].mergeGroupRuns[0].jobs.length, 2);
+});
+
+test('candidate timeline input correlates provider and internal events without mixing attempts', () => {
+  const sourceSha = 'a'.repeat(40);
+  const input = candidateTimelineInput('kungfu-systems/kungfu', 'dev/v4/v4.0', {
+    pullRequest: 1262,
+    sourceSha,
+    mergedAt: '2026-07-23T00:30:00Z',
+    classification: { kind: 'native' },
+    checks: [
+      {
+        status: 'success',
+        context: 'affected-native / linux',
+        startedAt: '2026-07-23T00:00:00Z',
+        completedAt: '2026-07-23T00:05:00Z',
+        startAuthority: 'workflow.created_at',
+        endAuthority: 'first-success',
+      },
+    ],
+    mergeQueue: {
+      rounds: [
+        {
+          index: 0,
+          enqueuedAt: '2026-07-23T00:10:00Z',
+          removedAt: '2026-07-23T00:30:00Z',
+          reason: 'merged',
+          mergeGroupRuns: [
+            {
+              id: 42,
+              headSha: 'b'.repeat(40),
+              createdAt: '2026-07-23T00:11:00Z',
+              completedAt: '2026-07-23T00:29:00Z',
+              conclusion: 'success',
+              jobs: [
+                {
+                  id: 7,
+                  name: 'affected-native partition 0 of 2 / linux',
+                  conclusion: 'success',
+                  startedAt: '2026-07-23T00:12:00Z',
+                  completedAt: '2026-07-23T00:28:00Z',
+                  steps: [
+                    {
+                      number: 9,
+                      name: 'Build Core SDK artifacts',
+                      conclusion: 'success',
+                      startedAt: '2026-07-23T00:13:00Z',
+                      completedAt: '2026-07-23T00:20:00Z',
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    nativeEvidence: {
+      candidateEvents: [
+        {
+          id: 'merge_group-42:linux:0:sdk-wire-cpp',
+          attempt: { id: 'merge_group-42', workflowRunId: '42' },
+          phase: 'sdk-wire-cpp',
+          status: 'success',
+          timing: {
+            startedAt: '2026-07-23T00:20:00Z',
+            completedAt: '2026-07-23T00:21:00Z',
+            durationMs: 60000,
+            clock: 'monotonic-duration+wall-envelope',
+            precisionMs: 1,
+          },
+          attributes: { sourceSha },
+        },
+      ],
+    },
+    cache: {
+      layers: [
+        {
+          layer: 'compiler',
+          outcome: 'miss',
+          partitionIndex: 0,
+          sourceSha: 'b'.repeat(40),
+          receiptDigest: 'sha256:cache',
+        },
+      ],
+    },
+  });
+  assert.equal(input.candidate.pullRequest, 1262);
+  assert.equal(
+    input.events.find(({ phase }) => phase === 'sdk-wire-cpp').attempt.id,
+    'mq-1262-0',
+  );
+  assert.equal(
+    input.events.find(({ phase }) => phase === 'core-build').timing.precisionMs,
+    1000,
+  );
+  assert.equal(
+    input.events.find(({ phase }) => phase === 'sdk-wire-rust').status,
+    'unknown',
+  );
+  assert.equal(
+    input.events.find(({ phase }) => phase === 'runner-wait').attributes.reason,
+    'github-actions-jobs-api-does-not-expose-job-queued-at',
+  );
+  assert.deepEqual(
+    input.events.find(({ category }) => category === 'job').gate,
+    {
+      id: 'affected-native partition 0 of 2 / linux',
+      platform: 'linux',
+      partition: '0',
+    },
+  );
+  assert.deepEqual(
+    input.events.find(({ category }) => category === 'cache-evidence').cache,
+    { layer: 'compiler', outcome: 'miss' },
+  );
+  const timeline = createCandidateTimeline(input);
+  assert.equal(timeline.contract, 'buildchain.candidate-timeline/v1');
+  assert.deepEqual(
+    timeline.attempts.map(({ attempt }) => attempt.id),
+    [`pr-1262-${sourceSha}`, 'mq-1262-0'],
+  );
+  assert.equal(timeline.attempts[1].criticalPath.durationMs, 20 * 60 * 1000);
+  assert.equal(
+    timeline.attempts[1].criticalPath.activeIntervalUnionMs,
+    20 * 60 * 1000,
+  );
+  assert.equal(timeline.attempts[1].criticalPath.status, 'incomplete');
 });
 
 test('merge queue evidence fails closed for incomplete queue or runner facts', () => {
@@ -377,6 +508,8 @@ test('queue summary retains dequeued work before eventual merge', () => {
 test('an under-sized passing window remains non-qualifying', () => {
   const sample = {
     excluded: false,
+    pullRequest: 1,
+    sourceSha: 'a'.repeat(40),
     durationMs: 120000,
     classification: { kind: 'native' },
   };
@@ -546,6 +679,8 @@ test('native attribution separates warm and cold phase distributions', () => {
 test('a passing latency window still requires complete native cache evidence', () => {
   const records = Array.from({ length: 20 }, (_, index) => ({
     excluded: false,
+    pullRequest: index + 1,
+    sourceSha: index.toString(16).padStart(40, '0'),
     durationMs: 120000,
     classification: { kind: 'native' },
     cache:

--- a/scripts/measure-dev-required-latency.test.mjs
+++ b/scripts/measure-dev-required-latency.test.mjs
@@ -272,6 +272,30 @@ test('candidate timeline input correlates provider and internal events without m
                     },
                   ],
                 },
+                {
+                  id: 8,
+                  name: 'KFD verifier / linux',
+                  conclusion: 'skipped',
+                  startedAt: null,
+                  completedAt: null,
+                  steps: [],
+                },
+                {
+                  id: 9,
+                  name: 'affected-native / linux',
+                  conclusion: 'success',
+                  startedAt: '2026-07-23T00:28:00Z',
+                  completedAt: '2026-07-23T00:29:00Z',
+                  steps: [
+                    {
+                      number: 1,
+                      name: 'Aggregate affected native evidence',
+                      conclusion: 'success',
+                      startedAt: '2026-07-23T00:28:00Z',
+                      completedAt: '2026-07-23T00:29:00Z',
+                    },
+                  ],
+                },
               ],
             },
           ],
@@ -289,6 +313,20 @@ test('candidate timeline input correlates provider and internal events without m
             startedAt: '2026-07-23T00:20:00Z',
             completedAt: '2026-07-23T00:21:00Z',
             durationMs: 60000,
+            clock: 'monotonic-duration+wall-envelope',
+            precisionMs: 1,
+          },
+          attributes: { sourceSha },
+        },
+        {
+          id: 'merge_group-42:linux:0:sdk-pack-python',
+          attempt: { id: 'merge_group-42', workflowRunId: '42' },
+          phase: 'sdk-pack-python',
+          status: 'success',
+          timing: {
+            startedAt: '2026-07-23T00:19:00Z',
+            completedAt: '2026-07-23T00:20:00Z',
+            durationMs: 60_000,
             clock: 'monotonic-duration+wall-envelope',
             precisionMs: 1,
           },
@@ -322,6 +360,12 @@ test('candidate timeline input correlates provider and internal events without m
     'unknown',
   );
   assert.equal(
+    input.events.some(
+      ({ id, phase }) => id.includes(':unobserved:') && phase === 'sdk-pack',
+    ),
+    false,
+  );
+  assert.equal(
     input.events.find(({ phase }) => phase === 'runner-wait').attributes.reason,
     'github-actions-jobs-api-does-not-expose-job-queued-at',
   );
@@ -332,6 +376,30 @@ test('candidate timeline input correlates provider and internal events without m
       platform: 'linux',
       partition: '0',
     },
+  );
+  assert.equal(
+    input.events.find(
+      ({ category, gate }) =>
+        category === 'job' && gate.id === 'KFD verifier / linux',
+    ).status,
+    'skipped',
+  );
+  assert.equal(
+    input.events.find(
+      ({ category, gate }) =>
+        category === 'job' && gate.id === 'affected-native / linux',
+    ).phase,
+    'aggregate-admission',
+  );
+  assert.equal(
+    input.events.find(({ phase }) => phase === 'merge-finalization').timing
+      .durationMs,
+    60_000,
+  );
+  assert.match(
+    input.events.find(({ category }) => category === 'workflow').attributes
+      .runUrl,
+    /actions\/runs\/42$/,
   );
   assert.deepEqual(
     input.events.find(({ category }) => category === 'cache-evidence').cache,

--- a/scripts/run-core-affected-native.mjs
+++ b/scripts/run-core-affected-native.mjs
@@ -8,7 +8,10 @@ import path from 'node:path';
 import process from 'node:process';
 import { pathToFileURL } from 'node:url';
 
+import telemetry from './candidate-timeline-events.cjs';
 import { writeShifuGateEvidence } from './shifu-gate-evidence.mjs';
+
+const { measureCandidateStage } = telemetry;
 
 const root = process.cwd();
 const coreRoot = path.join(root, 'framework', 'core');
@@ -74,6 +77,7 @@ const sdkQualificationPaths = [
   'pnpm-workspace.yaml',
   'product/scripts/archive.mjs',
   'scripts/affected-native-proof.mjs',
+  'scripts/candidate-timeline-events.cjs',
   'scripts/generate-layered-sdk.mjs',
   'scripts/platform-command.mjs',
   'scripts/run-core-affected-native.mjs',
@@ -803,66 +807,75 @@ async function runStep(
       requestedParallelism,
     },
   };
-  return logger.span(`affected-native.${id}`, details, async () => {
-    const child = spawn(command, args, {
-      cwd,
-      env,
-      stdio: ['inherit', 'pipe', 'pipe'],
-    });
-    const logStream = fs.createWriteStream(log, { flags: 'w' });
-    child.stdout.on('data', (chunk) => {
-      logStream.write(chunk);
-      process.stdout.write(chunk);
-    });
-    child.stderr.on('data', (chunk) => {
-      logStream.write(chunk);
-      process.stderr.write(chunk);
-    });
-    const sampler = sampleProcess
-      ? toolkit.startProcessSampler({
-          rootPid: child.pid,
-          intervalMs: 15000,
-          label: id,
-          command,
-          args,
-          env,
-          requestedParallelism,
+  return measureCandidateStage(
+    `affected-native-${id}`,
+    `native-${phase}`,
+    () =>
+      logger.span(`affected-native.${id}`, details, async () => {
+        const child = spawn(command, args, {
           cwd,
-        })
-      : null;
-    const result = await new Promise((resolve) => {
-      child.once('error', (error) =>
-        resolve({ exitCode: 1, signal: null, error }),
-      );
-      child.once('close', (exitCode, signal) => resolve({ exitCode, signal }));
-    });
-    await new Promise((resolve) => logStream.end(resolve));
-    const processSummary = sampler
-      ? toolkit.summarizeProcessSamples({
-          command,
-          args,
           env,
-          requestedParallelism,
-          samples: sampler.stop(),
-        })
-      : null;
-    const step = {
-      id,
-      command: [command, ...args],
-      durationMs: Date.now() - started,
-      exitCode: result.exitCode ?? 1,
-      signal: result.signal || null,
-      log: path.relative(root, log).split(path.sep).join('/'),
-      ...(processSummary ? { process: processSummary } : {}),
-    };
-    if (step.exitCode !== 0) {
-      throw Object.assign(
-        result.error || new Error(`${id} failed with exit ${step.exitCode}`),
-        { step },
-      );
-    }
-    return step;
-  });
+          stdio: ['inherit', 'pipe', 'pipe'],
+        });
+        const logStream = fs.createWriteStream(log, { flags: 'w' });
+        child.stdout.on('data', (chunk) => {
+          logStream.write(chunk);
+          process.stdout.write(chunk);
+        });
+        child.stderr.on('data', (chunk) => {
+          logStream.write(chunk);
+          process.stderr.write(chunk);
+        });
+        const sampler = sampleProcess
+          ? toolkit.startProcessSampler({
+              rootPid: child.pid,
+              intervalMs: 15000,
+              label: id,
+              command,
+              args,
+              env,
+              requestedParallelism,
+              cwd,
+            })
+          : null;
+        const result = await new Promise((resolve) => {
+          child.once('error', (error) =>
+            resolve({ exitCode: 1, signal: null, error }),
+          );
+          child.once('close', (exitCode, signal) =>
+            resolve({ exitCode, signal }),
+          );
+        });
+        await new Promise((resolve) => logStream.end(resolve));
+        const processSummary = sampler
+          ? toolkit.summarizeProcessSamples({
+              command,
+              args,
+              env,
+              requestedParallelism,
+              samples: sampler.stop(),
+            })
+          : null;
+        const step = {
+          id,
+          command: [command, ...args],
+          durationMs: Date.now() - started,
+          exitCode: result.exitCode ?? 1,
+          signal: result.signal || null,
+          log: path.relative(root, log).split(path.sep).join('/'),
+          ...(processSummary ? { process: processSummary } : {}),
+        };
+        if (step.exitCode !== 0) {
+          throw Object.assign(
+            result.error ||
+              new Error(`${id} failed with exit ${step.exitCode}`),
+            { step },
+          );
+        }
+        return step;
+      }),
+    { gateId: 'source.changed-scope' },
+  );
 }
 
 function toolFact(command, args = ['--version']) {

--- a/scripts/verify-kungfu-release-admission.test.mjs
+++ b/scripts/verify-kungfu-release-admission.test.mjs
@@ -35,11 +35,11 @@ import { verifyKungfuReleaseAdmission } from './verify-kungfu-release-admission.
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const SOURCE_SHA = '1'.repeat(40);
-const RUNTIME_SHA = '3743410384e2f163c04561a4a87270afe9f2574a';
+const RUNTIME_SHA = 'c7a066159bf55f3adcb5b7f8b9d383ec19fbdaa7';
 const STABLE_RUNTIME_SHA = 'bb9ce34b368c6b5a27b00fbdcb0515076abd9744';
 const SOURCE_TREE_SHA = 'a'.repeat(40);
 const CONTRACT_DIGEST =
-  'a4efdf326492081d7e015eb2c04355c54c9b68bd45d32a102b8879d112db72a0';
+  '95680b4596a6e848d6b8cff4b7216b3c560e085298d99587baa4419d4fdc6aef';
 const STABLE_CONTRACT_DIGEST =
   '2cf9ff617ff20598497d214e6e55dc16daab5e353fe39e0d6e41e7c6364c82a4';
 const PREDICATE_COMMAND = 'node scripts/kungfu-release-qualification.mjs';

--- a/scripts/verify-kungfu-release-admission.test.mjs
+++ b/scripts/verify-kungfu-release-admission.test.mjs
@@ -35,11 +35,11 @@ import { verifyKungfuReleaseAdmission } from './verify-kungfu-release-admission.
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const SOURCE_SHA = '1'.repeat(40);
-const RUNTIME_SHA = 'c7a066159bf55f3adcb5b7f8b9d383ec19fbdaa7';
+const RUNTIME_SHA = 'f6f2428e8de6e7d39ca6177cd0686f16a1258515';
 const STABLE_RUNTIME_SHA = 'bb9ce34b368c6b5a27b00fbdcb0515076abd9744';
 const SOURCE_TREE_SHA = 'a'.repeat(40);
 const CONTRACT_DIGEST =
-  '95680b4596a6e848d6b8cff4b7216b3c560e085298d99587baa4419d4fdc6aef';
+  '978eebe7528ea563ff62a2fe1e5b46861b36c510f8e4fda634f9e6a1acb5cdc7';
 const STABLE_CONTRACT_DIGEST =
   '2cf9ff617ff20598497d214e6e55dc16daab5e353fe39e0d6e41e7c6364c82a4';
 const PREDICATE_COMMAND = 'node scripts/kungfu-release-qualification.mjs';

--- a/tests/qualification/layers/sdk/run.mjs
+++ b/tests/qualification/layers/sdk/run.mjs
@@ -9,12 +9,15 @@ import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { extractTarGz } from '../../../../product/scripts/archive.mjs';
+import telemetry from '../../../../scripts/candidate-timeline-events.cjs';
 import {
   platformCommand,
   platformCommandOptions,
   prependEnvironmentPath,
 } from '../../../../scripts/platform-command.mjs';
 import { qualificationHoldMs, runMeasured } from '../process-metrics.mjs';
+
+const { measureCandidateStage, measureCandidateStageSync } = telemetry;
 
 const DIR = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(DIR, '..', '..', '..', '..');
@@ -876,21 +879,65 @@ async function main() {
   try {
     const contractProfile = stageQualificationProfile(temp);
     const semanticAdapters = [
-      setupPython(temp, artifacts.pythonWheel),
-      setupNode(temp, artifacts.npmCore, artifacts.npmPlatform),
-      setupRust(temp, artifacts.nativeDir, artifacts.cargoCrate),
+      measureCandidateStageSync(
+        'sdk-setup-python',
+        'sdk-adapter-setup-python',
+        () => setupPython(temp, artifacts.pythonWheel),
+        { gateId: 'source.changed-scope', language: 'python' },
+      ),
+      measureCandidateStageSync(
+        'sdk-setup-node',
+        'sdk-adapter-setup-node',
+        () => setupNode(temp, artifacts.npmCore, artifacts.npmPlatform),
+        { gateId: 'source.changed-scope', language: 'node' },
+      ),
+      measureCandidateStageSync(
+        'sdk-setup-rust',
+        'sdk-adapter-setup-rust',
+        () => setupRust(temp, artifacts.nativeDir, artifacts.cargoCrate),
+        { gateId: 'source.changed-scope', language: 'rust' },
+      ),
     ];
-    const cppAdapter = setupCpp(temp, artifacts.nativeDir);
+    const cppAdapter = measureCandidateStageSync(
+      'sdk-setup-cpp',
+      'sdk-adapter-setup-cpp',
+      () => setupCpp(temp, artifacts.nativeDir),
+      { gateId: 'source.changed-scope', language: 'cpp' },
+    );
     const qualifications = [];
     for (const adapter of semanticAdapters) {
       console.log(`[layers:qualify:sdk] semantic adapter=${adapter.id}`);
-      qualifications.push(await qualifyAdapter(adapter, fixture, temp));
+      qualifications.push(
+        await measureCandidateStage(
+          `sdk-semantic-${adapter.id}`,
+          `sdk-semantic-${adapter.id}`,
+          () => qualifyAdapter(adapter, fixture, temp),
+          {
+            gateId: 'source.changed-scope',
+            language: adapter.id
+              .replace(/-sdk$/, '')
+              .replace('pypi', 'python')
+              .replace('npm', 'node')
+              .replace('cargo', 'rust'),
+          },
+        ),
+      );
     }
     const wireQualifications = [];
     for (const adapter of [cppAdapter, ...semanticAdapters]) {
       console.log(`[layers:qualify:sdk] wire adapter=${adapter.id}`);
+      const language = adapter.id
+        .replace(/-sdk$/, '')
+        .replace('pypi', 'python')
+        .replace('npm', 'node')
+        .replace('cargo', 'rust');
       wireQualifications.push(
-        await qualifyWireAdapter(adapter, wireFixture, temp, contractProfile),
+        await measureCandidateStage(
+          `sdk-wire-${adapter.id}`,
+          `sdk-wire-${language}`,
+          () => qualifyWireAdapter(adapter, wireFixture, temp, contractProfile),
+          { gateId: 'source.changed-scope', language },
+        ),
       );
     }
     const report = {


### PR DESCRIPTION
## Summary

Adopt Buildchain's `buildchain.candidate-timeline/v1` contract for Kungfu dev candidate telemetry. The change preserves the Buildchain dual-channel boundary: the alpha runtime supplies the observation API, while the stable release runtime and contract lock remain untouched release authority.

## Changes

- emit bounded, source-bound internal stage events from Core configure/build, SDK pack/setup/wire qualification, and affected-native install/configure/build/test
- retain the event JSONL in the authoritative affected-native merge-queue artifact
- split the formerly monolithic four-language SDK workflow step into toolchain, Core build, pack, and wire-contract provider intervals
- collect GitHub queue, workflow, job, and step timing plus internal events into one per-candidate timeline without mixing PR and merge-queue attempts
- compute critical-path duration from interval unions so nested and parallel spans are not double-counted
- preserve missing runner queue time and older internal phase detail as explicit unknowns
- expose focused historical collection through repeated `--pull` and one-pull `--timeline-output`
- consume `@kungfu-tech/buildchain@2.14.17-alpha.2` through an alpha-only package alias while retaining stable `@kungfu-tech/buildchain@2.14.1`

## Verification

- `./shifu check:source`
- staged source/ADR/docs gate during both signed-off commits
- 26 dev required Gate latency/cache contract tests
- candidate event success/failure/source-binding tests
- `./shifu check:gate-catalog`
- `./shifu test:release-admission`
- `./shifu release:promotion:rehearse`
- `./shifu layers:qualify:sdk -- --validate-only`
- historical PR 1254 reconstructed into a valid two-attempt candidate timeline; queue residence 3,013 s, SDK wire provider interval 2,113 s, native closure interval union 1,149 s, with unavailable old internal phases remaining unknown

Fresh source-bound internal stage evidence will be collected from this PR's authoritative merge-queue run after admission.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "stage-ready",
  "adrs": ["SHIFU-ADR-0004"],
  "summary": "Stage source-bound Buildchain candidate timelines for authoritative dev merge-queue builds while preserving separate alpha observation and stable release authority.",
  "verification": ["full ./shifu check:source", "candidate timeline and dev latency contract tests", "release admission and promotion rehearsal", "fresh merge-queue proof required before closeout"]
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The release boundary change is limited to consuming the already-published Buildchain alpha observation API. Stable release admission remains pinned to its existing package and contract lock; this PR publishes no package and performs no deployment.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed
