### PR TITLE
fix(shifu): quote Windows lifecycle payload once

### DIFF
--- a/scripts/run-shifu-lifecycle.mjs
+++ b/scripts/run-shifu-lifecycle.mjs
@@ -48,10 +48,13 @@ export function windowsCmdArgs(shim, args) {
     throw new Error(
       'Windows Shifu lifecycle arguments contain unsafe cmd syntax',
     );
-  // Keep the batch command and every task argument discrete so Node owns the
-  // Windows command-line quoting. A hand-built single /c payload survived
-  // launcher-owned verbs but dropped ordinary pnpm tasks in Product Build.
-  return ['/d', '/s', '/c', 'call', shim, ...args];
+  const quote = (value) => `"${String(value).replaceAll('"', '""')}"`;
+  // cmd.exe owns everything after /c as one command string. Keep that payload
+  // as one spawn argument, but do not add the outer quote pair ourselves:
+  // Node must escape the single argument for CreateProcess. The previous
+  // verbatim outer quotes dropped tasks; discrete post-/c argv exited 255.
+  const payload = `call ${[shim, ...args].map(quote).join(' ')}`;
+  return ['/d', '/s', '/c', payload];
 }
 
 /** Run the canonical repository shim without assuming bash exists on Windows. */

--- a/scripts/run-shifu-lifecycle.test.mjs
+++ b/scripts/run-shifu-lifecycle.test.mjs
@@ -141,7 +141,7 @@ test('quotes a Windows shim payload and rejects expansion syntax', () => {
   );
 });
 
-test('enters a Windows batch shim with discrete cmd arguments', () => {
+test('enters a Windows batch shim with one Node-quoted cmd payload', () => {
   assert.deepEqual(
     windowsCmdArgs('C:\\repo path\\shifu.cmd', [
       'cache',
@@ -153,12 +153,7 @@ test('enters a Windows batch shim with discrete cmd arguments', () => {
       '/d',
       '/s',
       '/c',
-      'call',
-      'C:\\repo path\\shifu.cmd',
-      'cache',
-      'apply',
-      '--',
-      'C:\\Program Files\\node.exe',
+      'call "C:\\repo path\\shifu.cmd" "cache" "apply" "--" "C:\\Program Files\\node.exe"',
     ],
   );
   assert.throws(
@@ -293,7 +288,7 @@ test(
         SHIFU_TEST_EVIDENCE: evidence,
         XDG_CACHE_HOME: path.join(sandbox, 'cache'),
       },
-      stdio: 'ignore',
+      stdio: 'inherit',
     });
     assert.equal(status, 0);
     assert.equal(fs.readFileSync(evidence, 'utf8'), 'ok');


### PR DESCRIPTION
## Summary

The corrected cache-active fallback regression in alpha PR #1294 proved that passing discrete arguments after `cmd.exe /c` exits 255. The earlier single-payload form failed because it combined hand-written outer quotes with `windowsVerbatimArguments`.

This patch uses the Windows-safe middle ground:

- construct one `call "shifu.cmd" "task" ...` payload for `/c`;
- pass that payload as one normal spawn argument with no hand-written outer quote pair;
- let Node escape the single CreateProcess argument;
- retain the corrected regression that removes inherited `SHIFU_BIN`, forces `SHIFU_CACHE_ACTIVE=1`, isolates the cache, and requires a real pnpm filesystem side effect;
- expose child output during the regression so a future failure is diagnostic.

## Verification

- `node --test scripts/run-shifu-lifecycle.test.mjs scripts/check-shifu-entry-contract.test.mjs` — 27 pass, 3 Windows-only skips locally
- `corepack pnpm exec biome check scripts/run-shifu-lifecycle.mjs scripts/run-shifu-lifecycle.test.mjs`
- full staged repository gate passed during signed commit

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Repair Windows lifecycle payload quoting without changing any ADR projection."
}
-->