### PR TITLE
fix(adr): close post-apply migration gates

### DIFF
--- a/scripts/adr-migration.mjs
+++ b/scripts/adr-migration.mjs
@@ -25,6 +25,9 @@ const CURRENT_CONTEXT_QUALITY_CORPUS =
   'crates/xinfa/fixtures/golden/context-quality-corpus-v1.json';
 const CURRENT_CONTEXT_QUALITY_QUALIFICATION =
   'crates/xinfa/qualification/context-quality-v1.json';
+const CONTENT_ROOT_BOUND_ARTIFACTS = [
+  '.xinfa/manifests/legacy-atlas-roots.json',
+];
 const SEMANTIC_LEGACY_FIXTURES = new Set([
   'scripts/adr-audit.test.mjs',
   'scripts/adr-identity.test.mjs',
@@ -206,11 +209,45 @@ function rewrite(text, mappings, options = {}) {
   return result;
 }
 
+/** @param {string} text @param {Map<string, {path: string}>} mappings */
+function retireAdrIndexRows(text, mappings) {
+  const legacyPaths = new Set(
+    [...mappings.values()].map((row) => path.posix.basename(row.path)),
+  );
+  return text
+    .split('\n')
+    .filter((line) => {
+      const match = /^\|\s*\[[^\]]+\]\(([^)]+)\)\s*\|/.exec(line);
+      return !match || !legacyPaths.has(match[1]);
+    })
+    .join('\n');
+}
+
+/**
+ * @param {string} text
+ * @param {Map<string, {id: string, path: string, targetId: string, targetPath: string}>} mappings
+ * @param {string} mode
+ * @param {{beforeRoot: string, afterRoot: string}[]} revisions
+ */
+function rewriteForMode(text, mappings, mode, revisions = []) {
+  if (mode === 'none') return text;
+  if (mode === 'index-retire') {
+    return rewrite(retireAdrIndexRows(text, mappings), mappings, {
+      identities: false,
+    });
+  }
+  return rewrite(text, mappings, {
+    identities: mode === 'full',
+    revisions: mode === 'full' ? revisions : [],
+  });
+}
+
 /** @param {string} rel */
 function rewriteMode(rel) {
   const kind = lifecycle(rel);
   if (kind === 'semantic-fixture') return 'none';
-  if (rel === ADR_INDEX || kind === 'test-fixture') return 'paths-only';
+  if (rel === ADR_INDEX) return 'index-retire';
+  if (kind === 'test-fixture') return 'paths-only';
   return 'full';
 }
 
@@ -314,6 +351,32 @@ export function createAdrMigrationPlan(options = {}) {
     .sort((left, right) =>
       Buffer.compare(Buffer.from(left.id), Buffer.from(right.id)),
     );
+  const artifactRevisionMappings = CONTENT_ROOT_BOUND_ARTIFACTS.filter((rel) =>
+    files.includes(rel),
+  )
+    .map((rel) => {
+      const bytes = snapshot.get(rel);
+      const text = utf8(bytes);
+      if (text === null) {
+        problems.push({ code: 'bound-artifact-not-utf8', path: rel });
+        return null;
+      }
+      return {
+        path: rel,
+        beforeRoot: bytesDigest(bytes),
+        afterRoot: bytesDigest(
+          rewriteForMode(text, mappings, rewriteMode(rel)),
+        ),
+      };
+    })
+    .filter(Boolean)
+    .sort((left, right) =>
+      Buffer.compare(Buffer.from(left.path), Buffer.from(right.path)),
+    );
+  const allRevisionMappings = [
+    ...revisionMappings,
+    ...artifactRevisionMappings,
+  ];
 
   const transformations = [];
   const preserved = [];
@@ -354,13 +417,7 @@ export function createAdrMigrationPlan(options = {}) {
       });
     }
     const mode = rewriteMode(rel);
-    const after =
-      mode === 'none'
-        ? text
-        : rewrite(text, mappings, {
-            identities: mode === 'full',
-            revisions: mode === 'full' ? revisionMappings : [],
-          });
+    const after = rewriteForMode(text, mappings, mode, allRevisionMappings);
     const renamed = mappings.get(identity || '')?.targetPath || rel;
     const mappedReferences = refs.filter((ref) => mappings.has(ref));
     if (after === text && renamed === rel && mappedReferences.length === 0)
@@ -393,6 +450,17 @@ export function createAdrMigrationPlan(options = {}) {
       });
     }
   }
+  for (const revision of artifactRevisionMappings) {
+    const transformation = transformationsByPath.get(revision.path);
+    if (transformation?.afterRoot !== revision.afterRoot) {
+      problems.push({
+        code: 'artifact-revision-closure-nonterminal',
+        path: revision.path,
+        expectedRoot: revision.afterRoot,
+        actualRoot: transformation?.afterRoot || '',
+      });
+    }
+  }
 
   const body = {
     schema: 'kungfu.adr-migration-plan/v1',
@@ -411,12 +479,13 @@ export function createAdrMigrationPlan(options = {}) {
       historicalAppendOnly: 'preserve',
       testFixtures: 'rewrite-paths-only',
       semanticLegacyFixtures: 'preserve',
-      adrIndex: 'rewrite-paths-only',
+      adrIndex: 'retire-legacy-rows',
     },
     mappings: [...mappings.values()].sort((left, right) =>
       Buffer.compare(Buffer.from(left.id), Buffer.from(right.id)),
     ),
     revisionMappings,
+    artifactRevisionMappings,
     transformations: transformations.sort((left, right) =>
       Buffer.compare(Buffer.from(left.path), Buffer.from(right.path)),
     ),
@@ -549,14 +618,14 @@ export function applyAdrMigrationPlan(root, plan, expectedSourceRoot = '') {
   for (const row of plan.transformations) {
     const source = path.join(root, row.path);
     const target = path.join(root, row.targetPath);
-    const rewritten = rewrite(
+    const rewritten = rewriteForMode(
       fs.readFileSync(source, 'utf8'),
       new Map(plan.mappings.map((item) => [item.id, item])),
-      {
-        identities: row.rewriteMode !== 'paths-only',
-        revisions:
-          row.rewriteMode === 'full' ? plan.revisionMappings || [] : [],
-      },
+      row.rewriteMode,
+      [
+        ...(plan.revisionMappings || []),
+        ...(plan.artifactRevisionMappings || []),
+      ],
     );
     if (bytesDigest(rewritten) !== row.afterRoot) {
       throw new Error(`migration algorithm drifted for ${row.path}`);

--- a/scripts/adr-migration.test.mjs
+++ b/scripts/adr-migration.test.mjs
@@ -98,6 +98,14 @@ function fixture() {
       2,
     )}\n`,
   );
+  const legacyAtlasRoots =
+    '{"description":"Legacy roots described by ADR-0001"}\n';
+  write(root, '.xinfa/manifests/legacy-atlas-roots.json', legacyAtlasRoots);
+  write(
+    root,
+    'scripts/pinned-legacy-atlas-roots.mjs',
+    `export const ROOT = '${byteRoot(legacyAtlasRoots)}';\n`,
+  );
   write(
     root,
     'docs/README.md',
@@ -106,7 +114,7 @@ function fixture() {
   write(
     root,
     'docs/adr/README.md',
-    '| [0001](ADR-0001-first.md) | accepted | historical ADR-0001 |\n',
+    '| ADR | Status | Title |\n|---|---|---|\n| [0001](ADR-0001-first.md) | accepted | historical ADR-0001 |\n',
   );
   write(
     root,
@@ -197,6 +205,7 @@ test('plans deterministic ID-only renames from an exact Git tree', () => {
   assert.match(first.source.root, /^sha256:[0-9a-f]{64}$/);
   assert.equal(first.mappings.length, 2);
   assert.equal(first.revisionMappings.length, 2);
+  assert.equal(first.artifactRevisionMappings.length, 1);
   assert.ok(
     first.mappings.every(
       (row) =>
@@ -229,7 +238,7 @@ test('plans deterministic ID-only renames from an exact Git tree', () => {
   assert.equal(
     first.transformations.find((row) => row.path === 'docs/adr/README.md')
       ?.rewriteMode,
-    'paths-only',
+    'index-retire',
   );
   assert.equal(
     first.transformations.find(
@@ -333,9 +342,21 @@ test('applies a reviewed manifest idempotently and preserves historical bytes', 
     );
   }
   const index = fs.readFileSync(path.join(root, 'docs/adr/README.md'), 'utf8');
-  assert.match(index, /\[0001\]/);
-  assert.match(index, /historical ADR-0001/);
-  assert.ok(index.includes(path.posix.basename(plan.mappings[0].targetPath)));
+  assert.match(index, /\| ADR \| Status \| Title \|/);
+  assert.doesNotMatch(index, /\[0001\]/);
+  assert.doesNotMatch(index, /historical ADR-0001/);
+  assert.ok(!index.includes(path.posix.basename(plan.mappings[0].targetPath)));
+  const migratedLegacyAtlasRoots = fs.readFileSync(
+    path.join(root, '.xinfa/manifests/legacy-atlas-roots.json'),
+  );
+  const pinnedLegacyAtlasRoots = fs.readFileSync(
+    path.join(root, 'scripts/pinned-legacy-atlas-roots.mjs'),
+    'utf8',
+  );
+  assert.match(
+    pinnedLegacyAtlasRoots,
+    new RegExp(byteRoot(migratedLegacyAtlasRoots)),
+  );
   const currentTest = fs.readFileSync(
     path.join(root, 'scripts/current-contract.test.mjs'),
     'utf8',


### PR DESCRIPTION
## Summary

Close the two post-apply gaps found by the full ADR corpus migration rehearsal.

## Changes

- retire the frozen legacy ADR index rows instead of projecting UUID rows into the shared index
- close the rewritten legacy Atlas manifest byte root into its pinned live consumer
- keep planning and application on one rewrite algorithm with fail-closed closure checks
- add fixture coverage for both boundaries

## Verification

- ./shifu adr:migrate:test
- ./shifu check:source
- ./shifu check
- independent read-only review: PASS

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This fixes deterministic migration mechanics and preserves the accepted ADR architecture contract."
}
-->

## Governance risk check

- [x] none of the above