### PR TITLE
fix(shifu): preserve raw Windows lifecycle payload

### DIFF
--- a/scripts/run-shifu-lifecycle.mjs
+++ b/scripts/run-shifu-lifecycle.mjs
@@ -50,9 +50,9 @@ export function windowsCmdArgs(shim, args) {
     );
   const quote = (value) => `"${String(value).replaceAll('"', '""')}"`;
   // cmd.exe owns everything after /c as one command string. Keep that payload
-  // as one spawn argument, but do not add the outer quote pair ourselves:
-  // Node must escape the single argument for CreateProcess. The previous
-  // verbatim outer quotes dropped tasks; discrete post-/c argv exited 255.
+  // as one spawn argument and let its token quotes reach cmd.exe verbatim.
+  // Node's default Windows escaping turns those quotes into literal \" bytes;
+  // an outer quote pair drops tasks, while discrete post-/c argv exits 255.
   const payload = `call ${[shim, ...args].map(quote).join(' ')}`;
   return ['/d', '/s', '/c', payload];
 }
@@ -92,6 +92,7 @@ export function runShifu(args, options = {}) {
         env,
         stdio: options.stdio || 'inherit',
         shell: false,
+        windowsVerbatimArguments: true,
       },
     );
   } else {

--- a/scripts/run-zero-burden-product-qualification.test.mjs
+++ b/scripts/run-zero-burden-product-qualification.test.mjs
@@ -140,7 +140,7 @@ test('Windows suites invoke the repository Shifu shim through ComSpec', () => {
     '/d',
     '/s',
     '/c',
-    '""C:\\kungfu checkout\\shifu.cmd" "--filter" "workspace with spaces" "test""',
+    'call "C:\\kungfu checkout\\shifu.cmd" "--filter" "workspace with spaces" "test"',
   ]);
 });
 


### PR DESCRIPTION
## Summary

- pass the single `call ...` payload to `cmd.exe` with `windowsVerbatimArguments: true` so Node does not turn token quotes into literal backslash-quote bytes
- align Product Qualification coverage with the same raw payload contract
- retain the corrected Windows fallback regression that executes a real pnpm command and requires a filesystem side effect

## Verification

- `node --test scripts/run-shifu-lifecycle.test.mjs scripts/run-zero-burden-product-qualification.test.mjs` — 21 pass, 3 Windows-only skips locally
- Biome passed for both changed files
- full signed commit gate passed, including 92 documentation/promotion tests
- failing exact Windows evidence: run 29973082365, job 89099070087 (`\"...shifu.cmd\" is not recognized`)

<!-- kungfu-adr-release:v1
{"schema":"kungfu.adr-release-pr/v1","kind":"adr-neutral","reason":"Repair Node-to-cmd raw argument transport without changing runtime architecture or release claims."}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

This repair changes qualification invocation only; it does not publish artifacts.