### PR TITLE
feat: add trademark public-use gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,10 @@ it all again. It does this from declared project sources, makes missing or
 conflicting context visible, and preserves enough structure to continue without
 reconstructing everything from conversation history.
 
-> **Never Guess. Facts Unfold.**
+> **Kungfu UNGFU™** · Never Guess. Facts Unfold.
+
+[Why this source-identifying signature exists](docs/concepts/why-kungfu.md).
+UNGFU is not a second product or runtime; Kungfu remains the product name.
 
 **Status: Coming soon.** The first public CLI is being qualified against the
 experience below.

--- a/TRADEMARK.md
+++ b/TRADEMARK.md
@@ -4,6 +4,12 @@ This policy explains how the official Kungfu project names and marks may be
 used. It is about project identity, not the copyright license for this
 repository.
 
+**Kungfu UNGFU™** is a trademark of Kungfu Origin Technology Limited. The ™
+symbol identifies the claimed mark; it does not state that a registration has
+issued. Kungfu remains the product name. UNGFU is the recursive source
+signature described in [Why Kungfu?](docs/concepts/why-kungfu.md), not a second
+product, runtime, package, CLI, or service.
+
 ## Project Marks
 
 Kungfu project marks include names, logos, domain names, release names, product
@@ -11,6 +17,7 @@ names, package names, and other identifiers associated with the official
 project, including:
 
 - Kungfu
+- Kungfu UNGFU™
 - Kungfu Tracer
 - Kungfu Rewind
 - Kungfu Origin
@@ -21,6 +28,9 @@ The Apache-2.0 license for this repository grants copyright and patent
 permissions. It does not grant trademark rights or permission to imply that an
 unofficial product, fork, service, release, package, or organization is the
 official Kungfu project.
+
+The executable gate and public-safe evidence procedure for the first real
+release are documented in [Trademark public-use qualification](docs/qualification/trademark-public-use.md).
 
 ## Allowed Uses
 
@@ -79,4 +89,3 @@ or imply that it is official.
 If you see confusing or misleading use of Kungfu marks, open an issue or contact
 the maintainers through the official project channels. Security-sensitive cases
 should use the private vulnerability reporting path in `SECURITY.md`.
-

--- a/docs/adr/KF-ADR-019f8cc4-e796-7b0e-9a16-50c08614e848.md
+++ b/docs/adr/KF-ADR-019f8cc4-e796-7b0e-9a16-50c08614e848.md
@@ -4,7 +4,7 @@ doc_type: architecture-decision
 adr_id: KF-ADR-019f8cc4-e796-7b0e-9a16-50c08614e848
 decision_status: accepted
 implementation_status: staged
-implementation_commits: [70219a05b821370313332e6c40986b2682006705]
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/1304]
 qualification_refs: [framework/release/kungfu-trademark-public-use.contract.json, scripts/check-trademark-public-use.mjs, scripts/check-trademark-public-use.test.mjs, docs/qualification/trademark-public-use.md]
 review_state: self-reviewed
 sensitivity: public

--- a/docs/adr/KF-ADR-019f8cc4-e796-7b0e-9a16-50c08614e848.md
+++ b/docs/adr/KF-ADR-019f8cc4-e796-7b0e-9a16-50c08614e848.md
@@ -1,0 +1,84 @@
+---
+metadata_schema: kungfu.document-metadata/v1
+doc_type: architecture-decision
+adr_id: KF-ADR-019f8cc4-e796-7b0e-9a16-50c08614e848
+decision_status: accepted
+implementation_status: staged
+implementation_commits: [70219a05b821370313332e6c40986b2682006705]
+qualification_refs: [framework/release/kungfu-trademark-public-use.contract.json, scripts/check-trademark-public-use.mjs, scripts/check-trademark-public-use.test.mjs, docs/qualification/trademark-public-use.md]
+review_state: self-reviewed
+sensitivity: public
+sources: [local-files, official-upstream, user-consensus]
+period: ongoing
+theme: kungfu-ungfu-public-use
+confidence: high
+evidence_grade: B
+last_reviewed: 2026-07-23
+ai_provenance: GPT-5 via Codex on 2026-07-23; based on the accepted Assignment, public operator records, and repository release contracts; private filing material, first-use conclusions, and legal advice are not claimed
+---
+
+# KF-ADR-019f8cc4-e796-7b0e-9a16-50c08614e848: Kungfu UNGFU source signature and public-release evidence boundary
+
+- Status: accepted; implementation staged
+- Date: 2026-07-23
+- Category: brand identity / public release evidence / claim governance
+
+## Context
+
+Kungfu needs one exact, source-identifying signature for the recursive promise
+described in [Why Kungfu?](../concepts/why-kungfu.md), while the product and its
+technical identifiers already have stable public meaning. Treating UNGFU as a
+second product would create user confusion and unnecessary migrations.
+
+The current product is Coming Soon. Source availability, pull-request previews,
+and staging can prove that brand copy is implemented, but they do not prove that
+downloadable software is publicly available. A future release needs a bounded,
+reviewable evidence contract so an engineering workflow cannot silently turn
+preparatory surfaces into a first-use or registration conclusion.
+
+## Decision
+
+Kungfu adopts **Kungfu UNGFU™** as a secondary source-identifying signature,
+paired with **Never Guess. Facts Unfold.** Kungfu remains the primary and only
+product name. UNGFU is not a second product, runtime, package, executable, CLI,
+domain, KFD layer, Buildchain component, or libkungfu replacement.
+
+Public first-screen use preserves progressive disclosure:
+
+- kungfu.tech leads with the user-facing continuity proposition and presents
+  the signature secondarily;
+- the repository README shows the signature and links to the canonical concept
+  explanation;
+- the trademark policy separates mark identity from Apache-2.0 copyright and
+  patent permissions; and
+- shared public notices attribute the mark to Kungfu Origin Technology Limited
+  with ™, without a registration-complete claim.
+
+A released-software-use engineering claim is admitted only when one real public
+download or package-install surface displays the exact mark beside the actual
+acquisition path and at least one stable product-controlled surface—launch,
+About, or `kungfu --version`—also displays it. Each admitted evidence record
+binds a public URL, access date, source repository and commit, deployment or
+release coordinate, and rendered evidence.
+
+Coming Soon pages, source checkouts, previews, and staging are explicitly
+ineligible acquisition evidence. The engineering contract does not infer or
+backdate first use and does not determine registration, ownership transfer, or
+legal sufficiency.
+
+## Consequences
+
+The signature can become recognizable without renaming any technical surface or
+displacing the product promise. The cost is a small amount of duplicated public
+copy and a release-time evidence obligation.
+
+The current staged implementation provides public source surfaces and the
+executable release gate, but deliberately leaves released-software use false.
+The first real public release must add both required runtime-facing surfaces and
+complete public evidence in a reviewed release change.
+
+The decision is falsified if any governed surface uses ®, claims completed
+registration, replaces Kungfu as the product name, omits the exact mark from a
+required release surface, or treats source, preview, staging, or Coming Soon as
+a real acquisition path. The qualification script and negative fixtures reject
+those states.

--- a/docs/concepts/why-kungfu.md
+++ b/docs/concepts/why-kungfu.md
@@ -10,6 +10,10 @@ carry the same history inside the codebase.
 As the product evolved, **KUNGFU** acquired a second meaning: a recursive
 technical definition that describes what the system is becoming.
 
+The source-identifying signature for that commitment is **Kungfu UNGFU™**,
+paired with **Never Guess. Facts Unfold.** Kungfu remains the product name; the
+signature does not create another product family.
+
 ## The recursive definition
 
 ```text
@@ -34,8 +38,7 @@ Never Guess. Facts Unfold.
 ```
 
 This definition adds a technical meaning to the name. It does not rewrite the
-historical origin of Kungfu, and it does not introduce `UNGFU` as another
-product or runtime.
+historical origin of Kungfu. UNGFU is not a second product or runtime.
 
 ## Never Guess
 
@@ -113,10 +116,10 @@ judgment. Its stronger obligation is narrower: when a load-bearing claim can be
 grounded in a preserved, inspectable fact, prefer the fact; when it cannot, make
 the limit visible.
 
-The name is a compact statement of that obligation:
+The source-identifying signature is a compact statement of that obligation:
 
 ```text
-KUNGFU UNGFU:
+Kungfu UNGFU™
 Never Guess. Facts Unfold.
 ```
 

--- a/docs/document-metadata.registry.json
+++ b/docs/document-metadata.registry.json
@@ -816,6 +816,29 @@
       "review_state": "unreviewed",
       "sensitivity": "public"
     },
+    "docs/qualification/trademark-public-use.md": {
+      "metadata_schema": "kungfu.document-metadata/v1",
+      "document_status": "active",
+      "doc_type": "qualification-contract",
+      "review_state": "self-reviewed",
+      "sensitivity": "public",
+      "sources": [
+        "local-files",
+        "official-upstream",
+        "user-consensus"
+      ],
+      "period": "ongoing",
+      "theme": "trademark-public-use",
+      "confidence": "high",
+      "evidence_grade": "B",
+      "last_reviewed": "2026-07-23",
+      "ai_provenance": {
+        "model_family": "OpenAI GPT-5",
+        "product": "Codex",
+        "generated_at": "2026-07-23",
+        "invisible_context_boundary": "private filing materials, legal advice, first-use conclusions, and unpublished release evidence are not claimed"
+      }
+    },
     "docs/qualification/continuity-pilot.md": {
       "metadata_schema": "kungfu.document-metadata/v1",
       "document_status": "active",

--- a/docs/qualification/contracts.md
+++ b/docs/qualification/contracts.md
@@ -569,6 +569,32 @@ The living welded-surface register is [`versioning.md`](../development/versionin
 bundle, Python/Node validators, frozen artifact hash gate, and CLI inspection.
 Marketplace acquisition and permission elevation remain outside this contract.
 
+## First real release carries the mark on acquisition and product surfaces
+
+**Guarantee.** Kungfu does not claim released-software use while v4 remains
+Coming Soon. A future claim must bind the exact **Kungfu UNGFU™** mark to both a
+real public download or package-install path and at least one stable
+product-controlled surface. Source checkouts, previews, and staging do not
+satisfy the acquisition requirement.
+
+**Verify.** Read [Trademark public-use qualification](trademark-public-use.md)
+and
+[`kungfu-trademark-public-use.contract.json`](../../framework/release/kungfu-trademark-public-use.contract.json),
+then run:
+
+```sh
+node scripts/check-trademark-public-use.mjs
+node --test scripts/check-trademark-public-use.test.mjs
+```
+
+The negative fixtures reject the registered symbol, unsupported registration
+claims, a replacement primary product name, missing exact-mark surfaces, and
+preview or staging evidence presented as a real release.
+
+**Maturity.** The brand surfaces and release gate are implemented. Public
+release artifacts, actual released-software use evidence, a first-use date, and
+legal conclusions are not claimed.
+
 ## How to read a guarantee here
 
 A contract is only as strong as its maturity tag. `stable` means implemented and

--- a/docs/qualification/trademark-public-use.md
+++ b/docs/qualification/trademark-public-use.md
@@ -1,0 +1,63 @@
+# Trademark public-use qualification
+
+This qualification keeps four states separate:
+
+1. the brand signature is implemented in source and public copy;
+2. a future release has the surfaces needed to make a public-use record;
+3. downloadable software is actually available through those surfaces; and
+4. any legal conclusion about first use or registration is made outside this
+   engineering contract.
+
+The exact source-identifying signature is **Kungfu UNGFU™**, paired with
+**Never Guess. Facts Unfold.** Kungfu remains the product name. UNGFU is not a
+second product, runtime, package, CLI, domain, KFD layer, Buildchain component,
+or libkungfu replacement.
+
+## Current state
+
+Kungfu v4 is Coming Soon. Public release artifacts are not available, so the
+repository does not claim released-software use or a first-use date. Source
+code, a pull-request preview, staging, a screenshot without a real acquisition
+path, and a Coming Soon page do not satisfy this gate.
+
+The machine-readable current state and release requirements live in
+[`kungfu-trademark-public-use.contract.json`](../../framework/release/kungfu-trademark-public-use.contract.json).
+Source acceptance runs `scripts/check-trademark-public-use.mjs` and its negative
+fixtures.
+
+## Gate for the first real public release
+
+Before `releasedSoftwareUseClaim` can become true, one reviewable change must
+provide both:
+
+- a public download or package-install surface where **Kungfu UNGFU™** appears
+  next to the real acquisition path; and
+- at least one stable product-controlled surface—launch, About, or
+  `kungfu --version`—that displays the exact mark.
+
+The release gate does not rename the `kungfu` CLI, packages, repositories,
+domains, KFD, Buildchain, or libkungfu. The signature identifies source; it does
+not replace the product name.
+
+## Public-safe evidence record
+
+Record only public material. Each evidence record must include:
+
+- the public URL and access date;
+- source repository and exact source commit;
+- the deployment or release coordinate;
+- rendered evidence showing the mark beside the acquisition path and in the
+  selected product surface.
+
+Do not include private applications, searches, counsel correspondence, entity
+records that are not already public, credentials, or unpublished release
+coordinates. Do not infer or backdate a first-use date. A reviewer may confirm
+that the engineering evidence is complete; that confirmation is not legal
+advice, a registration claim, or a legal determination of first use.
+
+## Review boundary
+
+The implementation PR proves copy, ownership attribution, exact-mark surfaces,
+and executable negative tests. The future release PR proves real acquisition
+and product surfaces. Production publication and any legal conclusion remain
+separate explicit review gates.

--- a/docs/qualification/trademark-public-use.md
+++ b/docs/qualification/trademark-public-use.md
@@ -23,7 +23,8 @@ path, and a Coming Soon page do not satisfy this gate.
 The machine-readable current state and release requirements live in
 [`kungfu-trademark-public-use.contract.json`](../../framework/release/kungfu-trademark-public-use.contract.json).
 Source acceptance runs `scripts/check-trademark-public-use.mjs` and its negative
-fixtures.
+fixtures. The governing decision is
+[KF-ADR-019f8cc4-e796-7b0e-9a16-50c08614e848](../adr/KF-ADR-019f8cc4-e796-7b0e-9a16-50c08614e848.md).
 
 ## Gate for the first real public release
 

--- a/framework/release/kungfu-trademark-public-use.contract.json
+++ b/framework/release/kungfu-trademark-public-use.contract.json
@@ -1,0 +1,58 @@
+{
+  "schema": "kungfu.trademark-public-use/v1",
+  "brand": {
+    "primaryProductName": "Kungfu",
+    "exactMark": "Kungfu UNGFU™",
+    "principle": "Never Guess. Facts Unfold.",
+    "owner": "Kungfu Origin Technology Limited",
+    "role": "secondary-source-signature",
+    "registrationStatusClaim": "none"
+  },
+  "currentState": {
+    "publicReleaseArtifactsAvailable": false,
+    "releasedSoftwareUseClaim": false,
+    "firstUseDateClaim": null,
+    "legalConclusion": "not-made",
+    "acquisitionSurfaces": [],
+    "productSurfaces": [],
+    "evidenceRecords": []
+  },
+  "firstPublicReleaseGate": {
+    "acquisitionSurface": {
+      "minimum": 1,
+      "exactMarkRequired": true,
+      "allowedKinds": [
+        "public-release-download",
+        "public-package-install"
+      ],
+      "proximity": "adjacent-to-actual-acquisition-path"
+    },
+    "productSurface": {
+      "minimum": 1,
+      "exactMarkRequired": true,
+      "allowedKinds": [
+        "launch",
+        "about",
+        "kungfu --version"
+      ]
+    },
+    "evidence": {
+      "requiredFields": [
+        "publicUrl",
+        "accessedAt",
+        "sourceRepository",
+        "sourceCommit",
+        "deploymentOrReleaseCoordinate",
+        "renderedEvidence"
+      ],
+      "disallowedKinds": [
+        "coming-soon",
+        "source-checkout",
+        "preview",
+        "staging"
+      ],
+      "publicOnly": true,
+      "backdatingAllowed": false
+    }
+  }
+}

--- a/scripts/check-trademark-public-use.mjs
+++ b/scripts/check-trademark-public-use.mjs
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  CONTRACT_PATH,
+  loadTrademarkPublicUse,
+  validateTrademarkPublicUse,
+} from './trademark-public-use-contract.mjs';
+
+const { contract, surfaces } = loadTrademarkPublicUse();
+const issues = validateTrademarkPublicUse(contract, surfaces);
+if (issues.length) {
+  for (const issue of issues) console.error(`[trademark-public-use] ${issue}`);
+  process.exit(1);
+}
+console.log(
+  `[trademark-public-use] contract=${CONTRACT_PATH} state=pre-release valid=true`,
+);

--- a/scripts/check-trademark-public-use.test.mjs
+++ b/scripts/check-trademark-public-use.test.mjs
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  EXACT_MARK,
+  loadTrademarkPublicUse,
+  validateTrademarkPublicUse,
+} from './trademark-public-use-contract.mjs';
+
+function fixture() {
+  return structuredClone(loadTrademarkPublicUse());
+}
+
+test('the current pre-release state is truthful and complete', () => {
+  const { contract, surfaces } = fixture();
+  assert.deepEqual(validateTrademarkPublicUse(contract, surfaces), []);
+  assert.equal(contract.currentState.releasedSoftwareUseClaim, false);
+  assert.equal(contract.currentState.evidenceRecords.length, 0);
+});
+
+test('registered symbols and unsupported registration claims are rejected', () => {
+  const registeredSymbol = fixture();
+  registeredSymbol.surfaces['README.md'] += '\nKungfu UNGFU®\n';
+  assert.ok(
+    validateTrademarkPublicUse(
+      registeredSymbol.contract,
+      registeredSymbol.surfaces,
+    ).some((item) => item.includes('registered symbol')),
+  );
+
+  const registrationClaim = fixture();
+  registrationClaim.surfaces['TRADEMARK.md'] +=
+    '\nKungfu UNGFU is a registered trademark.\n';
+  assert.ok(
+    validateTrademarkPublicUse(
+      registrationClaim.contract,
+      registrationClaim.surfaces,
+    ).some((item) => item.includes('unsupported registration')),
+  );
+});
+
+test('renaming the product or removing an exact-mark surface is rejected', () => {
+  const renamed = fixture();
+  renamed.contract.brand.primaryProductName = 'UNGFU';
+  assert.ok(
+    validateTrademarkPublicUse(renamed.contract, renamed.surfaces).includes(
+      'primary product name must remain Kungfu',
+    ),
+  );
+
+  const missing = fixture();
+  missing.surfaces['README.md'] = missing.surfaces['README.md'].replace(
+    EXACT_MARK,
+    'Kungfu',
+  );
+  assert.ok(
+    validateTrademarkPublicUse(missing.contract, missing.surfaces).some(
+      (item) => item.includes('README first screen'),
+    ),
+  );
+});
+
+test('preview or staging cannot satisfy the first real release gate', () => {
+  const candidate = fixture();
+  candidate.contract.currentState.publicReleaseArtifactsAvailable = true;
+  candidate.contract.currentState.releasedSoftwareUseClaim = true;
+  candidate.contract.currentState.acquisitionSurfaces = [
+    {
+      kind: 'public-release-download',
+      evidenceKind: 'preview',
+      exactMark: EXACT_MARK,
+      publicUrl: 'https://preview.example/download',
+    },
+  ];
+  candidate.contract.currentState.productSurfaces = [
+    {
+      kind: 'kungfu --version',
+      exactMark: EXACT_MARK,
+    },
+  ];
+  candidate.contract.currentState.evidenceRecords = [
+    {
+      kind: 'staging',
+      publicUrl: 'https://staging.example/download',
+      accessedAt: '2026-07-23',
+      sourceRepository: 'https://github.com/kungfu-systems/kungfu',
+      sourceCommit: '0123456789abcdef0123456789abcdef01234567',
+      deploymentOrReleaseCoordinate: 'preview-1',
+      renderedEvidence: 'https://staging.example/evidence.png',
+    },
+  ];
+  const issues = validateTrademarkPublicUse(
+    candidate.contract,
+    candidate.surfaces,
+  );
+  assert.ok(issues.some((item) => item.includes('real public acquisition')));
+  assert.ok(
+    issues.some((item) => item.includes('complete public-safe evidence')),
+  );
+});

--- a/scripts/source-acceptance.mjs
+++ b/scripts/source-acceptance.mjs
@@ -179,6 +179,7 @@ export function sourceAcceptancePlan(files, evidenceBaseCommit = '') {
     ['Xinfa standalone boundary', 'crates/xinfa/tooling/check-boundary.mjs'],
     ['carrier/action envelope', 'scripts/check-carrier-action-envelope.mjs'],
     ['runtime greenfield', 'scripts/check-runtime-greenfield.mjs'],
+    ['trademark public-use gate', 'scripts/check-trademark-public-use.mjs'],
     ['schema authority', 'scripts/check-schema-authority.mjs'],
     [
       'core architecture contract',
@@ -302,6 +303,7 @@ export function sourceAcceptancePlan(files, evidenceBaseCommit = '') {
         'crates/xinfa/tooling/check-boundary.test.mjs',
         'scripts/check-schema-authority.test.mjs',
         'scripts/check-runtime-contract.test.mjs',
+        'scripts/check-trademark-public-use.test.mjs',
         'scripts/check-upgrade-contract.test.mjs',
         'scripts/probe-cpp-cmake-contract.test.mjs',
         'scripts/check-upgrade-qualification.test.mjs',

--- a/scripts/trademark-public-use-contract.mjs
+++ b/scripts/trademark-public-use-contract.mjs
@@ -1,0 +1,197 @@
+// SPDX-License-Identifier: Apache-2.0
+// @ts-check
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const CONTRACT_PATH =
+  'framework/release/kungfu-trademark-public-use.contract.json';
+const EXACT_MARK = 'Kungfu UNGFU™';
+const OWNER = 'Kungfu Origin Technology Limited';
+const REQUIRED_EVIDENCE_FIELDS = [
+  'publicUrl',
+  'accessedAt',
+  'sourceRepository',
+  'sourceCommit',
+  'deploymentOrReleaseCoordinate',
+  'renderedEvidence',
+];
+
+/** @param {unknown} value */
+function object(value) {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value
+    : {};
+}
+
+/** @param {unknown} value */
+function array(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+/** @param {unknown} value */
+function publicUrl(value) {
+  return typeof value === 'string' && /^https:\/\//u.test(value);
+}
+
+/**
+ * @param {Record<string, unknown>} contract
+ * @param {Record<string, string>} surfaces
+ */
+export function validateTrademarkPublicUse(contract, surfaces) {
+  const issues = [];
+  const brand = object(contract.brand);
+  const state = object(contract.currentState);
+  const gate = object(contract.firstPublicReleaseGate);
+  const acquisitionGate = object(gate.acquisitionSurface);
+  const productGate = object(gate.productSurface);
+  const evidenceGate = object(gate.evidence);
+
+  if (contract.schema !== 'kungfu.trademark-public-use/v1')
+    issues.push('schema must remain v1');
+  if (brand.primaryProductName !== 'Kungfu')
+    issues.push('primary product name must remain Kungfu');
+  if (brand.exactMark !== EXACT_MARK)
+    issues.push('exact mark must remain Kungfu UNGFU™');
+  if (brand.owner !== OWNER) issues.push('trademark owner is not exact');
+  if (brand.role !== 'secondary-source-signature')
+    issues.push('mark must remain a secondary source signature');
+  if (brand.registrationStatusClaim !== 'none')
+    issues.push('registration status must not be claimed');
+  if (state.firstUseDateClaim !== null)
+    issues.push('the gate must not infer or backdate first use');
+  if (state.legalConclusion !== 'not-made')
+    issues.push('the contract must not make a legal conclusion');
+  if (
+    acquisitionGate.minimum !== 1 ||
+    acquisitionGate.exactMarkRequired !== true
+  ) {
+    issues.push('a real acquisition surface with the exact mark is required');
+  }
+  if (productGate.minimum !== 1 || productGate.exactMarkRequired !== true) {
+    issues.push('a stable product surface with the exact mark is required');
+  }
+  if (
+    evidenceGate.publicOnly !== true ||
+    evidenceGate.backdatingAllowed !== false
+  ) {
+    issues.push('evidence must remain public-only and non-backdated');
+  }
+  if (
+    JSON.stringify(array(evidenceGate.requiredFields)) !==
+    JSON.stringify(REQUIRED_EVIDENCE_FIELDS)
+  ) {
+    issues.push('public evidence coordinates are incomplete');
+  }
+
+  const firstScreen = (surfaces['README.md'] || '').slice(0, 2400);
+  if (
+    !firstScreen.includes(EXACT_MARK) ||
+    !firstScreen.includes('docs/concepts/why-kungfu.md')
+  ) {
+    issues.push(
+      'README first screen must show the exact mark and stable Why Kungfu link',
+    );
+  }
+  const policy = surfaces['TRADEMARK.md'] || '';
+  if (!policy.includes(`${EXACT_MARK}** is a trademark of ${OWNER}`)) {
+    issues.push('TRADEMARK.md must state the exact mark and owner');
+  }
+  if (
+    !policy.includes('Apache-2.0') ||
+    !policy.includes('does not grant trademark rights')
+  ) {
+    issues.push('TRADEMARK.md must separate trademark rights from Apache-2.0');
+  }
+  const why = surfaces['docs/concepts/why-kungfu.md'] || '';
+  if (
+    !why.includes(EXACT_MARK) ||
+    !why.includes('UNGFU is not a second product or runtime')
+  ) {
+    issues.push('Why Kungfu must preserve the exact mark and product boundary');
+  }
+
+  for (const [surfacePath, source] of Object.entries(surfaces)) {
+    if (source.includes('®'))
+      issues.push(`${surfacePath} uses the registered symbol`);
+    if (/\b(?:is|are) (?:an? )?registered trademark\b/iu.test(source)) {
+      issues.push(`${surfacePath} makes an unsupported registration claim`);
+    }
+  }
+
+  const releasedClaim = state.releasedSoftwareUseClaim === true;
+  const releaseAvailable = state.publicReleaseArtifactsAvailable === true;
+  if (releasedClaim !== releaseAvailable) {
+    issues.push(
+      'released-software claim and public artifact availability must change together',
+    );
+  }
+  if (releasedClaim) {
+    const acquisitions = array(state.acquisitionSurfaces).map(object);
+    const products = array(state.productSurfaces).map(object);
+    const evidence = array(state.evidenceRecords).map(object);
+    const allowedAcquisitionKinds = new Set(
+      array(acquisitionGate.allowedKinds),
+    );
+    const allowedProductKinds = new Set(array(productGate.allowedKinds));
+    const disallowedEvidenceKinds = new Set(
+      array(evidenceGate.disallowedKinds),
+    );
+
+    if (
+      !acquisitions.some(
+        (item) =>
+          allowedAcquisitionKinds.has(item.kind) &&
+          item.exactMark === EXACT_MARK &&
+          publicUrl(item.publicUrl) &&
+          !disallowedEvidenceKinds.has(item.evidenceKind),
+      )
+    ) {
+      issues.push(
+        'released use requires an exact-mark real public acquisition surface',
+      );
+    }
+    if (
+      !products.some(
+        (item) =>
+          allowedProductKinds.has(item.kind) && item.exactMark === EXACT_MARK,
+      )
+    ) {
+      issues.push('released use requires an exact-mark stable product surface');
+    }
+    if (
+      !evidence.some(
+        (item) =>
+          REQUIRED_EVIDENCE_FIELDS.every(
+            (field) =>
+              typeof item[field] === 'string' && item[field].length > 0,
+          ) &&
+          publicUrl(item.publicUrl) &&
+          !disallowedEvidenceKinds.has(item.kind),
+      )
+    ) {
+      issues.push(
+        'released use requires one complete public-safe evidence record',
+      );
+    }
+  }
+  return issues;
+}
+
+/** @param {string} [root] */
+export function loadTrademarkPublicUse(root = ROOT) {
+  const read = (relativePath) =>
+    fs.readFileSync(path.join(root, relativePath), 'utf8');
+  return {
+    contract: JSON.parse(read(CONTRACT_PATH)),
+    surfaces: Object.fromEntries(
+      ['README.md', 'TRADEMARK.md', 'docs/concepts/why-kungfu.md'].map(
+        (item) => [item, read(item)],
+      ),
+    ),
+  };
+}
+
+export { CONTRACT_PATH, EXACT_MARK };


### PR DESCRIPTION
## Summary

Stage the Kungfu UNGFU™ source signature and a fail-closed first-real-release evidence boundary without renaming Kungfu or any technical identifier.

## Related issue

Assignment: 2026-07-23-kungfu-ungfu-trademark-public-use

## Changes

- place the exact mark and principle on the README first screen and canonical Why Kungfu explanation
- attribute the mark in TRADEMARK.md while separating trademark identity from Apache-2.0 permissions
- add a machine-readable release contract, public-safe evidence procedure, and negative fixtures
- record the accepted brand and release-evidence decision in KF-ADR-019f8cc4-e796-7b0e-9a16-50c08614e848

## Verification

- node scripts/check-trademark-public-use.mjs
- node --test scripts/check-trademark-public-use.test.mjs
- node scripts/run-docs-source-check.mjs with the promotion rehearsal serialized after a shared-ref concurrency retry
- source-acceptance pre-document checks and complete post-document plan
- pre-commit staged gate

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "stage-ready",
  "adrs": ["KF-ADR-019f8cc4-e796-7b0e-9a16-50c08614e848"],
  "summary": "Stage the secondary Kungfu UNGFU source signature and the fail-closed first-real-release evidence gate while released-software use remains false.",
  "verification": ["trademark public-use contract and four negative fixtures", "documentation contracts and ADR audit", "source-acceptance contract, upgrade, desktop, type, and format checks"]
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [x] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

This PR uses ™ only, records no first-use date, publishes no private filing material, and does not claim registration or released downloadable software.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed