### PR TITLE
fix(verify): isolate mypy from project sync

### DIFF
--- a/framework/core/pyproject.toml
+++ b/framework/core/pyproject.toml
@@ -36,9 +36,10 @@ repository = "https://github.com/kungfu-systems/kungfu.git"
 dev = [
     # Compiler / checkers
     "ruff~=0.15.0",
-    # static type checker — gradual baseline (see [tool.mypy]); run via
-    # `uv run --frozen mypy` in verify. Lenient by default so untyped modules do
-    # not fail; a module opts into real checking as it gains annotations.
+    # static type checker — gradual baseline (see [tool.mypy]); verify selects
+    # the exact 1.20.2 tool lane without syncing/installing the project. Lenient
+    # by default so untyped modules do not fail; a module opts into real checking
+    # as it gains annotations.
     "mypy~=1.13",
     # clang-format via PyPI wheel, same uv toolchain lane as ruff. Pinned exactly
     # (==) because a version bump changes C++ formatting output; an exact pin keeps

--- a/scripts/source-acceptance.test.mjs
+++ b/scripts/source-acceptance.test.mjs
@@ -48,6 +48,12 @@ test('type baseline covers every Python surface declared by [tool.mypy]', () => 
   }
 });
 
+test('release verification reuses the exact mypy tool lane without project sync', () => {
+  const verify = fs.readFileSync(path.join(ROOT, 'scripts/verify.mjs'), 'utf8');
+  assert.match(verify, /sourceMypyCommand\(\[\]\)/);
+  assert.doesNotMatch(verify, /uv['"], \['run', '--frozen', 'mypy'/);
+});
+
 test('Python source checks use uvx when a bare ruff is unavailable', () => {
   const command = sourcePythonCommand(
     ['format', '--check'],

--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -43,6 +43,7 @@ import {
   runLibwasmArtifactSelfTest,
   runLibwasmExecutionQualification,
 } from '../product/scripts/libwasm-artifact.mjs';
+import { sourceMypyCommand } from './source-acceptance.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -341,7 +342,8 @@ function main() {
   // annotations land, with no big-bang. Read-only; runs in quick and full.
   console.log('\n[verify] stage 0b: python type check (mypy)');
   const coreDir = path.join(ROOT, 'framework', 'core');
-  const mypy = spawnSync('uv', ['run', '--frozen', 'mypy'], {
+  const mypyInvocation = sourceMypyCommand([]);
+  const mypy = spawnSync(mypyInvocation.command, mypyInvocation.args, {
     cwd: coreDir,
     encoding: 'utf8',
     shell: isWin,


### PR DESCRIPTION
## Summary

- reuse the existing exact `sourceMypyCommand` selector in release verification
- run pinned mypy 1.20.2 as an isolated tool instead of `uv run --frozen mypy`, which unnecessarily synchronized and built the full local Kungfu project
- add a regression that rejects restoring the project-sync invocation

## Evidence

- Product Build Linux run 29973981366 job 89101856248: 66/67 checks passed; installed registry smoke verified 16 contracts; the only failure was mypy exiting after project build/install with no mypy diagnostic
- same failure previously reproduced in run 29970417379
- `uvx --from mypy==1.20.2 mypy` — `Success: no issues found in 181 source files`
- `node --test scripts/source-acceptance.test.mjs` — 20/20 pass
- full signed commit gate passed, including 92 documentation/promotion tests

<!-- kungfu-adr-release:v1
{"schema":"kungfu.adr-release-pr/v1","kind":"adr-neutral","reason":"Repair release verification tool isolation without changing runtime architecture or release claims."}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

This repair changes verification execution only; it does not publish artifacts.