### PR TITLE
fix(adr): close migrated publication reachability

### DIFF
--- a/scripts/adr-migration.mjs
+++ b/scripts/adr-migration.mjs
@@ -21,6 +21,11 @@ import { parseFrontmatter } from './document-metadata-contract.mjs';
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const INVENTORY = 'docs/adr/legacy-identities.v1.json';
 const ADR_INDEX = 'docs/adr/README.md';
+const DOCS_CONTRACT = 'docs.contract.json';
+const LEGACY_ADR_PUBLICATION_PATTERN =
+  '^docs/adr/(?:KF|SHIFU)-ADR-[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}-[^/]+\\\\.md$';
+const ID_ONLY_ADR_PUBLICATION_PATTERN =
+  '^docs/adr/(?:KF|SHIFU)-ADR-[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\\\\.md$';
 const CURRENT_CONTEXT_QUALITY_CORPUS =
   'crates/xinfa/fixtures/golden/context-quality-corpus-v1.json';
 const CURRENT_CONTEXT_QUALITY_QUALIFICATION =
@@ -223,6 +228,11 @@ function retireAdrIndexRows(text, mappings) {
     .join('\n');
 }
 
+/** @param {string} text @param {string} needle */
+function occurrenceCount(text, needle) {
+  return text.split(needle).length - 1;
+}
+
 /**
  * @param {string} text
  * @param {Map<string, {id: string, path: string, targetId: string, targetPath: string}>} mappings
@@ -236,6 +246,12 @@ function rewriteForMode(text, mappings, mode, revisions = []) {
       identities: false,
     });
   }
+  if (mode === 'publication-contract') {
+    return text.replace(
+      LEGACY_ADR_PUBLICATION_PATTERN,
+      ID_ONLY_ADR_PUBLICATION_PATTERN,
+    );
+  }
   return rewrite(text, mappings, {
     identities: mode === 'full',
     revisions: mode === 'full' ? revisions : [],
@@ -247,6 +263,7 @@ function rewriteMode(rel) {
   const kind = lifecycle(rel);
   if (kind === 'semantic-fixture') return 'none';
   if (rel === ADR_INDEX) return 'index-retire';
+  if (rel === DOCS_CONTRACT) return 'publication-contract';
   if (kind === 'test-fixture') return 'paths-only';
   return 'full';
 }
@@ -418,6 +435,17 @@ export function createAdrMigrationPlan(options = {}) {
     }
     const mode = rewriteMode(rel);
     const after = rewriteForMode(text, mappings, mode, allRevisionMappings);
+    if (
+      mode === 'publication-contract' &&
+      occurrenceCount(text, LEGACY_ADR_PUBLICATION_PATTERN) !== 1
+    ) {
+      problems.push({
+        code: 'publication-contract-pattern-cardinality',
+        path: rel,
+        expected: 1,
+        actual: occurrenceCount(text, LEGACY_ADR_PUBLICATION_PATTERN),
+      });
+    }
     const renamed = mappings.get(identity || '')?.targetPath || rel;
     const mappedReferences = refs.filter((ref) => mappings.has(ref));
     if (after === text && renamed === rel && mappedReferences.length === 0)
@@ -480,6 +508,7 @@ export function createAdrMigrationPlan(options = {}) {
       testFixtures: 'rewrite-paths-only',
       semanticLegacyFixtures: 'preserve',
       adrIndex: 'retire-legacy-rows',
+      adrPublication: 'id-only-implicit-collection',
     },
     mappings: [...mappings.values()].sort((left, right) =>
       Buffer.compare(Buffer.from(left.id), Buffer.from(right.id)),

--- a/scripts/adr-migration.test.mjs
+++ b/scripts/adr-migration.test.mjs
@@ -118,6 +118,26 @@ function fixture() {
   );
   write(
     root,
+    'docs.contract.json',
+    `${JSON.stringify(
+      {
+        publication: {
+          implicitCollections: [
+            {
+              index: 'docs/adr/README.md',
+              patterns: [
+                '^docs/adr/(?:KF|SHIFU)-ADR-[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}-[^/]+\\.md$',
+              ],
+            },
+          ],
+        },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  write(
+    root,
     'crates/xinfa/fixtures/golden/context-quality-corpus-v1.json',
     '{"critical_sources":["docs/adr/ADR-0001-first.md"]}\n',
   );
@@ -241,6 +261,11 @@ test('plans deterministic ID-only renames from an exact Git tree', () => {
     'index-retire',
   );
   assert.equal(
+    first.transformations.find((row) => row.path === 'docs.contract.json')
+      ?.rewriteMode,
+    'publication-contract',
+  );
+  assert.equal(
     first.transformations.find(
       (row) => row.path === 'scripts/current-contract.test.mjs',
     )?.rewriteMode,
@@ -346,6 +371,14 @@ test('applies a reviewed manifest idempotently and preserves historical bytes', 
   assert.doesNotMatch(index, /\[0001\]/);
   assert.doesNotMatch(index, /historical ADR-0001/);
   assert.ok(!index.includes(path.posix.basename(plan.mappings[0].targetPath)));
+  const docsContract = fs.readFileSync(
+    path.join(root, 'docs.contract.json'),
+    'utf8',
+  );
+  assert.equal(
+    JSON.parse(docsContract).publication.implicitCollections[0].patterns[0],
+    '^docs/adr/(?:KF|SHIFU)-ADR-[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\\.md$',
+  );
   const migratedLegacyAtlasRoots = fs.readFileSync(
     path.join(root, '.xinfa/manifests/legacy-atlas-roots.json'),
   );
@@ -423,6 +456,40 @@ test('fails closed on expected-root or working-file drift', () => {
     () => applyAdrMigrationPlan(root, plan, plan.source.root),
     /differs from both manifest source and result/,
   );
+});
+
+test('fails closed unless the legacy publication pattern occurs exactly once', () => {
+  const legacyPattern =
+    '^docs/adr/(?:KF|SHIFU)-ADR-[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}-[^/]+\\.md$';
+  for (const patterns of [[], [legacyPattern, legacyPattern]]) {
+    const root = fixture();
+    const contractPath = path.join(root, 'docs.contract.json');
+    const contract = JSON.parse(fs.readFileSync(contractPath, 'utf8'));
+    contract.publication.implicitCollections[0].patterns = patterns;
+    fs.writeFileSync(contractPath, `${JSON.stringify(contract, null, 2)}\n`);
+    git(root, ['add', 'docs.contract.json']);
+    git(root, [
+      '-c',
+      'core.hooksPath=/dev/null',
+      'commit',
+      '-q',
+      '-m',
+      'drift publication contract',
+    ]);
+
+    const plan = createAdrMigrationPlan({ root });
+    assert.ok(
+      plan.problems.some(
+        (problem) =>
+          problem.code === 'publication-contract-pattern-cardinality' &&
+          problem.actual === patterns.length,
+      ),
+    );
+    assert.throws(
+      () => applyAdrMigrationPlan(root, plan, plan.source.root),
+      /unresolved problems/,
+    );
+  }
 });
 
 test('fails closed when revision rewriting changes a target ADR root again', () => {


### PR DESCRIPTION
## Summary

Close the publication reachability gap found by the full ID-only ADR corpus migration rehearsal.

## Changes

- migrate the ADR implicit-collection contract from UUID-plus-slug paths to canonical ID-only paths
- require the exact legacy publication pattern to occur once before planning
- include the documentation contract as an explicit reviewed transformation
- cover successful rewrite plus missing and duplicate fail-closed paths

## Verification

- ./shifu adr:migrate:test (6/6)
- ./shifu check:source
- ./shifu check
- independent read-only review: PASS

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This repairs deterministic migration closure for the already accepted ID-only ADR identity contract."
}
-->

## Governance risk check

- [x] none of the above