### PR TITLE
feat(cut): add Project Cut loop evidence runner

### DIFF
--- a/docs/adr/KF-ADR-019f87e8-6b8b-735c-b036-fa42d7cee8cf.md
+++ b/docs/adr/KF-ADR-019f87e8-6b8b-735c-b036-fa42d7cee8cf.md
@@ -4,8 +4,8 @@ doc_type: architecture-decision
 adr_id: KF-ADR-019f87e8-6b8b-735c-b036-fa42d7cee8cf
 decision_status: accepted
 implementation_status: staged
-implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/1218, https://github.com/kungfu-systems/kungfu/pull/1225, https://github.com/kungfu-systems/kungfu/pull/1234, https://github.com/kungfu-systems/kungfu/pull/1241, https://github.com/kungfu-systems/kungfu/pull/1245]
-qualification_refs: [framework/work-loop/work-api.contract.json, framework/work-loop/project-cut-product-loop.release-contract.json, scripts/project-cut-product-loop-release.mjs, scripts/project-cut-product-loop-release.test.mjs, framework/api/tests/work-loop.test.ts, framework/core/tests/python/test_project_cut_read_model.py, framework/core/tests/python/test_work_facade.py, framework/core/tests/python/test_action_envelope.py, framework/core/tests/python/test_agent_work_state_contract.py, extensions/work-dashboard/tests/work-loop-summary.test.ts, framework/tui/src/work-loop-contribution.test.ts]
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/1218, https://github.com/kungfu-systems/kungfu/pull/1225, https://github.com/kungfu-systems/kungfu/pull/1234, https://github.com/kungfu-systems/kungfu/pull/1241, https://github.com/kungfu-systems/kungfu/pull/1245, https://github.com/kungfu-systems/kungfu/pull/1309]
+qualification_refs: [framework/work-loop/work-api.contract.json, framework/work-loop/project-cut-product-loop.release-contract.json, scripts/project-cut-product-loop-release.mjs, scripts/project-cut-product-loop-release.test.mjs, scripts/run-project-cut-product-loop-release.mjs, framework/api/tests/work-loop.test.ts, framework/core/tests/python/test_project_cut_read_model.py, framework/core/tests/python/test_work_facade.py, framework/core/tests/python/test_action_envelope.py, framework/core/tests/python/test_agent_work_state_contract.py, extensions/work-dashboard/tests/work-loop-summary.test.ts, framework/tui/src/work-loop-contribution.test.ts]
 review_state: self-reviewed
 sensitivity: public
 sources: [local-files, user-consensus]
@@ -13,8 +13,8 @@ period: 2026-07-22
 theme: project-cut-public-work-loop
 confidence: high
 evidence_grade: B
-last_reviewed: 2026-07-22
-ai_provenance: GPT-5 via Codex on 2026-07-22; based on public Kungfu contracts and source tests, without claims about unobserved deployed runtimes
+last_reviewed: 2026-07-23
+ai_provenance: GPT-5 via Codex on 2026-07-23; based on public Kungfu contracts and source tests, without claims about unobserved deployed runtimes
 ---
 
 # KF-ADR-019f87e8-6b8b-735c-b036-fa42d7cee8cf: Project Cut is the public Work loop facade
@@ -61,8 +61,11 @@ gaps, next actions, and recovery plan. Their transports reject mutating Work
 commands, and a missing project workspace fails visibly without substituting
 the app launch directory. The release contract freezes the target Gate id,
 complete scenario inventory, third-party profile proof, and fail-closed
-evidence admission without claiming retained qualification evidence. The Gate
-runner, retained platform campaign, and operations still reported as
+evidence admission without claiming retained qualification evidence. The
+evidence runner now derives a clean tracked source revision, verifies the exact
+release-passport bytes and required platform artifacts, evaluates the complete
+contract, and can retain Shifu Gate evidence. The retained platform campaign,
+Gate measurement and registration, and operations still reported as
 unavailable, degraded, or plan-only remain outside executable qualification.
 
 The portability slice emits byte-stable Work semantics without local

--- a/docs/qualification/project-cut-product-loop.md
+++ b/docs/qualification/project-cut-product-loop.md
@@ -152,19 +152,36 @@ The eventual release Gate must bind:
 - clean-runtime continuation and independent verification reports; and
 - cross-surface parity fixtures.
 
-This document and the contract do not register that Gate or claim current
-release evidence. The target Gate remains `pending`; its runner, retained
-platform campaign, and passport projection must be implemented and reviewed
-before the first qualifying release. Synthetic verifier tests are contract
-tests only and are never qualification evidence.
+The executable runner is available as:
+
+```sh
+./shifu project-cut-loop:qualify -- \
+  --evidence product/release/qualification/project-cut-product-loop.json \
+  --passport product/release/qualification/buildchain.release.json \
+  --json
+```
+
+It derives the exact source commit from the clean tracked checkout, hashes and
+opens the supplied Buildchain passport, verifies its source and platform
+artifact bindings, applies the complete evidence contract, and emits
+digest-bound Shifu evidence when invoked by a Gate executor. It does not create
+or repair campaign evidence.
+
+This document and the contract still do not register the target Gate or claim
+current release evidence. `product.project-cut-loop` remains `pending` until a
+retained three-platform campaign supplies real measurements and the Gate
+catalog change can be reviewed without weakening its closed-world policy.
+Synthetic verifier tests are contract tests only and are never qualification
+evidence.
 
 ## Current status
 
-**Product loop incomplete.** The repository now provides the read-only
+**Product loop incomplete.** The repository now provides the fail-closed
+release evidence runner in addition to the read-only
 `kungfu cut` product entrypoint, a high-level Work read/recovery facade,
 plan-only completion/settlement, managed-run Work binding, and one shared
 CLI/Agent capability manifest. The manifest truthfully reports GUI/TUI,
 executable begin/settlement, portability, and Domain Profile projection as
 unavailable or degraded. Native Initiative/Assignment orchestration and the
-complete end-to-end release evidence defined here remain prerequisites for a
-qualified release claim.
+complete retained cross-platform evidence defined here remain prerequisites
+for Gate registration and a qualified release claim.

--- a/framework/work-loop/project-cut-product-loop.release-contract.json
+++ b/framework/work-loop/project-cut-product-loop.release-contract.json
@@ -6,7 +6,14 @@
   "targetGate": {
     "id": "product.project-cut-loop",
     "registration": "pending",
-    "reason": "the evidence runner and retained platform campaign are not implemented"
+    "reason": "the retained platform campaign and Gate measurement/registration are not complete"
+  },
+  "evidenceRunner": {
+    "status": "implemented",
+    "task": "project-cut-loop:qualify",
+    "path": "scripts/run-project-cut-product-loop-release.mjs",
+    "gateEvidenceSchema": "kungfu.project-cut-product-loop.gate-evidence/v1",
+    "qualifyingEvidenceAvailable": false
   },
   "requiredScenarios": [
     "clean-project-first-minute",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "kfd:agent-runtime:qualify": "node scripts/require-shifu.mjs kfd:agent-runtime:qualify && node framework/core/tests/qualification/kfd-agent-runtime/run.mjs",
     "vendor:opencode:qualify": "node scripts/require-shifu.mjs vendor:opencode:qualify && node examples/opencode-kungfu/qualification/run.mjs",
     "project-cut": "node scripts/require-shifu.mjs project-cut && node framework/project-cut/bin/project-cut.mjs",
+    "project-cut-loop:qualify": "node scripts/require-shifu.mjs project-cut-loop:qualify && node scripts/run-project-cut-product-loop-release.mjs",
     "check:project-cut-settlement": "node scripts/require-shifu.mjs check:project-cut-settlement && node scripts/check-project-cut-settlement.mjs",
     "test:project-cut-settlement": "node scripts/require-shifu.mjs test:project-cut-settlement && node --test scripts/check-project-cut-settlement.test.mjs",
     "test:project-cut-settlement:integration": "node scripts/require-shifu.mjs test:project-cut-settlement:integration && node crates/xinfa/tooling/task.mjs build && node --test scripts/check-project-cut-settlement-integration.test.mjs",

--- a/scripts/project-cut-product-loop-release.mjs
+++ b/scripts/project-cut-product-loop-release.mjs
@@ -47,6 +47,40 @@ function requireCommit(value, code, label) {
   return value;
 }
 
+function normalizeArtifactDigest(value, code, label) {
+  const digest =
+    typeof value === 'string' && /^[0-9a-f]{64}$/u.test(value)
+      ? `sha256:${value}`
+      : value;
+  return requireDigest(digest, code, label);
+}
+
+function passportArtifactMatches(artifact, expectedPlatform, expectedDigest) {
+  if (artifact === null || typeof artifact !== 'object') return false;
+  const platform = String(artifact.platform || '');
+  const prefixes =
+    expectedPlatform === 'win32' ? ['win32', 'windows'] : [expectedPlatform];
+  if (
+    !prefixes.some(
+      (prefix) => platform === prefix || platform.startsWith(`${prefix}-`),
+    )
+  ) {
+    return false;
+  }
+  const digest = artifact.digest || artifact.sha256;
+  try {
+    return (
+      normalizeArtifactDigest(
+        digest,
+        'PASSPORT_ARTIFACT_INVALID',
+        'release passport artifact digest',
+      ) === expectedDigest
+    );
+  } catch {
+    return false;
+  }
+}
+
 function exactIds(items, requiredIds, code, label) {
   if (!Array.isArray(items)) fail(code, `${label} must be an array`);
   const ids = items.map((item, index) => {
@@ -354,4 +388,71 @@ export function verifyProjectCutProductLoopReleaseEvidence(
     fail('RESIDUAL_RISKS', 'qualification evidence contains residual risks');
   }
   return evidence;
+}
+
+export function verifyRetainedProjectCutProductLoopRelease(
+  { evidence, passport, passportDigest, passportRef, sourceCommit },
+  contract = loadProjectCutProductLoopReleaseContract(),
+) {
+  requireObject(passport, 'PASSPORT_DOCUMENT_INVALID', 'release passport');
+  const expectedSourceCommit = requireCommit(
+    sourceCommit,
+    'EXPECTED_SOURCE_REQUIRED',
+    'sourceCommit',
+  );
+  const expectedPassportDigest = requireDigest(
+    passportDigest,
+    'EXPECTED_PASSPORT_REQUIRED',
+    'passportDigest',
+  );
+  const expectedPassportRef = requireString(
+    passportRef,
+    'EXPECTED_PASSPORT_REQUIRED',
+    'passportRef',
+  );
+  const release = requireObject(
+    passport.release,
+    'PASSPORT_DOCUMENT_INVALID',
+    'release passport release',
+  );
+  if (release.sourceSha !== expectedSourceCommit) {
+    fail(
+      'PASSPORT_SOURCE_NOT_CURRENT',
+      'release passport source SHA does not match the current source commit',
+    );
+  }
+
+  const verified = verifyProjectCutProductLoopReleaseEvidence(
+    evidence,
+    contract,
+    {
+      sourceCommit: expectedSourceCommit,
+      releasePassportDigest: expectedPassportDigest,
+    },
+  );
+  if (verified.releasePassport.ref !== expectedPassportRef) {
+    fail(
+      'PASSPORT_REF_MISMATCH',
+      'evidence does not reference the supplied release passport',
+    );
+  }
+  if (!Array.isArray(passport.artifacts)) {
+    fail(
+      'PASSPORT_ARTIFACTS_INVALID',
+      'release passport artifacts must be an array',
+    );
+  }
+  for (const artifact of verified.artifacts) {
+    if (
+      !passport.artifacts.some((candidate) =>
+        passportArtifactMatches(candidate, artifact.id, artifact.digest),
+      )
+    ) {
+      fail(
+        'PASSPORT_ARTIFACT_NOT_BOUND',
+        `${artifact.id} artifact digest is not present in the release passport`,
+      );
+    }
+  }
+  return verified;
 }

--- a/scripts/project-cut-product-loop-release.test.mjs
+++ b/scripts/project-cut-product-loop-release.test.mjs
@@ -1,13 +1,19 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import assert from 'node:assert/strict';
+import childProcess from 'node:child_process';
+import crypto from 'node:crypto';
 import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import test from 'node:test';
 
 import {
   ProjectCutProductLoopReleaseError,
   verifyProjectCutProductLoopReleaseEvidence,
+  verifyRetainedProjectCutProductLoopRelease,
 } from './project-cut-product-loop-release.mjs';
+import { runProjectCutProductLoopRelease } from './run-project-cut-product-loop-release.mjs';
 
 const contract = JSON.parse(
   fs.readFileSync(
@@ -98,6 +104,18 @@ function expectationsFor(evidence) {
   };
 }
 
+function syntheticPassport(evidence) {
+  return {
+    release: { sourceSha: evidence.sourceCommit },
+    artifacts: evidence.artifacts.map((artifact) => ({
+      name: `kungfu-${artifact.id}`,
+      platform:
+        artifact.id === 'win32' ? 'windows-test' : `${artifact.id}-test`,
+      sha256: artifact.digest.slice('sha256:'.length),
+    })),
+  };
+}
+
 function expectCode(mutate, code) {
   const evidence = syntheticEvidence();
   mutate(evidence);
@@ -117,6 +135,8 @@ test('release contract freezes the complete product-loop evidence boundary', () 
   assert.equal(contract.status, 'not-qualified');
   assert.equal(contract.targetGate.id, 'product.project-cut-loop');
   assert.equal(contract.targetGate.registration, 'pending');
+  assert.equal(contract.evidenceRunner.status, 'implemented');
+  assert.equal(contract.evidenceRunner.qualifyingEvidenceAvailable, false);
   assert.equal(contract.currentClaims.qualified, false);
   assert.deepEqual(contract.requiredSurfaces, ['cli', 'agent', 'gui', 'tui']);
   assert.ok(contract.requiredScenarios.includes('third-party-domain-profile'));
@@ -223,5 +243,167 @@ test('expected source and passport are mandatory and exact', () => {
     (error) =>
       error instanceof ProjectCutProductLoopReleaseError &&
       error.code === 'PASSPORT_NOT_CURRENT',
+  );
+});
+
+test('retained release verification binds the actual passport and artifacts', () => {
+  const evidence = syntheticEvidence();
+  assert.equal(
+    verifyRetainedProjectCutProductLoopRelease(
+      {
+        evidence,
+        passport: syntheticPassport(evidence),
+        passportDigest: evidence.releasePassport.digest,
+        passportRef: evidence.releasePassport.ref,
+        sourceCommit: evidence.sourceCommit,
+      },
+      contract,
+    ),
+    evidence,
+  );
+});
+
+test('retained release verification rejects passport source and ref drift', () => {
+  const evidence = syntheticEvidence();
+  const inputs = {
+    evidence,
+    passport: syntheticPassport(evidence),
+    passportDigest: evidence.releasePassport.digest,
+    passportRef: evidence.releasePassport.ref,
+    sourceCommit: evidence.sourceCommit,
+  };
+  assert.throws(
+    () =>
+      verifyRetainedProjectCutProductLoopRelease(
+        {
+          ...inputs,
+          passport: {
+            ...inputs.passport,
+            release: { sourceSha: 'b'.repeat(40) },
+          },
+        },
+        contract,
+      ),
+    (error) =>
+      error instanceof ProjectCutProductLoopReleaseError &&
+      error.code === 'PASSPORT_SOURCE_NOT_CURRENT',
+  );
+  assert.throws(
+    () =>
+      verifyRetainedProjectCutProductLoopRelease(
+        { ...inputs, passportRef: 'other/release-passport.json' },
+        contract,
+      ),
+    (error) =>
+      error instanceof ProjectCutProductLoopReleaseError &&
+      error.code === 'PASSPORT_REF_MISMATCH',
+  );
+});
+
+test('retained release verification rejects unbound platform artifacts', () => {
+  const evidence = syntheticEvidence();
+  const passport = syntheticPassport(evidence);
+  passport.artifacts = passport.artifacts.filter(
+    ({ platform }) => !platform.startsWith('windows-'),
+  );
+  assert.throws(
+    () =>
+      verifyRetainedProjectCutProductLoopRelease(
+        {
+          evidence,
+          passport,
+          passportDigest: evidence.releasePassport.digest,
+          passportRef: evidence.releasePassport.ref,
+          sourceCommit: evidence.sourceCommit,
+        },
+        contract,
+      ),
+    (error) =>
+      error instanceof ProjectCutProductLoopReleaseError &&
+      error.code === 'PASSPORT_ARTIFACT_NOT_BOUND',
+  );
+});
+
+test('executable runner derives source and emits digest-bound Shifu evidence', (t) => {
+  const root = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'kungfu-project-cut-loop-runner-'),
+  );
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  fs.mkdirSync(path.join(root, 'framework', 'work-loop'), { recursive: true });
+  fs.copyFileSync(
+    'framework/work-loop/project-cut-product-loop.release-contract.json',
+    path.join(
+      root,
+      'framework',
+      'work-loop',
+      'project-cut-product-loop.release-contract.json',
+    ),
+  );
+  fs.writeFileSync(path.join(root, 'seed.txt'), 'committed source\n');
+  childProcess.execFileSync('git', ['init', '-q'], { cwd: root });
+  childProcess.execFileSync('git', ['add', 'seed.txt'], { cwd: root });
+  childProcess.execFileSync(
+    'git',
+    [
+      '-c',
+      'user.name=Kungfu Test',
+      '-c',
+      'user.email=test@kungfu.link',
+      'commit',
+      '-q',
+      '-m',
+      'test: seed source',
+    ],
+    { cwd: root },
+  );
+  const sourceCommit = childProcess
+    .execFileSync('git', ['rev-parse', 'HEAD'], { cwd: root, encoding: 'utf8' })
+    .trim();
+  const qualification = path.join(root, 'qualification');
+  fs.mkdirSync(qualification);
+  const evidence = syntheticEvidence();
+  evidence.sourceCommit = sourceCommit;
+  for (const scenario of evidence.scenarios)
+    scenario.sourceCommit = sourceCommit;
+  evidence.releasePassport.sourceCommit = sourceCommit;
+  evidence.releasePassport.ref = 'qualification/buildchain.release.json';
+  const passport = syntheticPassport(evidence);
+  const passportFile = path.join(qualification, 'buildchain.release.json');
+  fs.writeFileSync(passportFile, `${JSON.stringify(passport, null, 2)}\n`);
+  evidence.releasePassport.digest = `sha256:${crypto
+    .createHash('sha256')
+    .update(fs.readFileSync(passportFile))
+    .digest('hex')}`;
+  const evidenceFile = path.join(
+    qualification,
+    'project-cut-product-loop.json',
+  );
+  fs.writeFileSync(evidenceFile, `${JSON.stringify(evidence, null, 2)}\n`);
+  const gateEvidenceFile = path.join(root, '.gate', 'evidence.json');
+
+  const result = runProjectCutProductLoopRelease({
+    root,
+    evidencePath: evidenceFile,
+    passportPath: passportFile,
+    gateEvidenceFile,
+  });
+
+  assert.equal(result.verification, 'pass');
+  assert.equal(result.sourceCommit, sourceCommit);
+  assert.equal(result.targetGate.registration, 'pending');
+  assert.deepEqual(
+    JSON.parse(fs.readFileSync(gateEvidenceFile, 'utf8')).pointers.map(
+      ({ id, ref }) => ({ id, ref }),
+    ),
+    [
+      {
+        id: 'project-cut-product-loop-report',
+        ref: 'qualification/project-cut-product-loop.json',
+      },
+      {
+        id: 'buildchain-release-passport',
+        ref: 'qualification/buildchain.release.json',
+      },
+    ],
   );
 });

--- a/scripts/run-project-cut-product-loop-release.mjs
+++ b/scripts/run-project-cut-product-loop-release.mjs
@@ -1,0 +1,189 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: Apache-2.0
+// @ts-check
+
+import childProcess from 'node:child_process';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import {
+  ProjectCutProductLoopReleaseError,
+  loadProjectCutProductLoopReleaseContract,
+  verifyRetainedProjectCutProductLoopRelease,
+} from './project-cut-product-loop-release.mjs';
+import { writeShifuGateEvidence } from './shifu-gate-evidence.mjs';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+function usage() {
+  return (
+    'usage: node scripts/run-project-cut-product-loop-release.mjs ' +
+    '--evidence FILE --passport FILE [--json]'
+  );
+}
+
+function parseArgs(argv) {
+  const options = { evidence: '', passport: '', json: false };
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === '--json') {
+      options.json = true;
+      continue;
+    }
+    if (argument !== '--evidence' && argument !== '--passport') {
+      throw new Error(`unknown argument '${argument}'`);
+    }
+    const value = argv[index + 1];
+    if (!value || value.startsWith('--')) {
+      throw new Error(`${argument} requires a file`);
+    }
+    options[argument.slice(2)] = value;
+    index += 1;
+  }
+  if (!options.evidence || !options.passport) {
+    throw new Error('--evidence and --passport are required');
+  }
+  return options;
+}
+
+function git(root, args) {
+  const result = childProcess.spawnSync('git', args, {
+    cwd: root,
+    encoding: 'utf8',
+    env: Object.fromEntries(
+      Object.entries(process.env).filter(([key]) => !key.startsWith('GIT_')),
+    ),
+  });
+  if (result.status !== 0) {
+    throw new Error(
+      `git ${args.join(' ')} failed: ${String(result.stderr || '').trim()}`,
+    );
+  }
+  return String(result.stdout || '').trim();
+}
+
+function requireCleanTrackedSource(root) {
+  const unstaged = childProcess.spawnSync('git', ['diff', '--quiet', '--'], {
+    cwd: root,
+  });
+  const staged = childProcess.spawnSync(
+    'git',
+    ['diff', '--cached', '--quiet', '--'],
+    { cwd: root },
+  );
+  if (unstaged.status !== 0 || staged.status !== 0) {
+    throw new Error(
+      'tracked source is dirty; qualify an exact committed source checkout',
+    );
+  }
+}
+
+function repositoryFile(root, value, label) {
+  const absoluteRoot = fs.realpathSync(root);
+  const absolute = fs.realpathSync(path.resolve(root, value));
+  const relative = path.relative(absoluteRoot, absolute).replaceAll('\\', '/');
+  if (!relative || relative === '..' || relative.startsWith('../')) {
+    throw new Error(`${label} must stay inside the repository`);
+  }
+  return { absolute, relative };
+}
+
+function readJson(file, label) {
+  try {
+    return JSON.parse(fs.readFileSync(file, 'utf8'));
+  } catch (error) {
+    throw new Error(
+      `${label} is not valid JSON: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+}
+
+function sha256(file) {
+  return `sha256:${crypto.createHash('sha256').update(fs.readFileSync(file)).digest('hex')}`;
+}
+
+export function runProjectCutProductLoopRelease({
+  root = ROOT,
+  evidencePath,
+  passportPath,
+  gateEvidenceFile = process.env.SHIFU_GATE_EVIDENCE_FILE,
+}) {
+  requireCleanTrackedSource(root);
+  const sourceCommit = git(root, ['rev-parse', 'HEAD']);
+  const evidenceFile = repositoryFile(root, evidencePath, 'evidence');
+  const passportFile = repositoryFile(root, passportPath, 'release passport');
+  const contract = loadProjectCutProductLoopReleaseContract(
+    path.join(
+      root,
+      'framework/work-loop/project-cut-product-loop.release-contract.json',
+    ),
+  );
+  const evidence = readJson(evidenceFile.absolute, 'evidence');
+  verifyRetainedProjectCutProductLoopRelease(
+    {
+      evidence,
+      passport: readJson(passportFile.absolute, 'release passport'),
+      passportDigest: sha256(passportFile.absolute),
+      passportRef: passportFile.relative,
+      sourceCommit,
+    },
+    contract,
+  );
+  writeShifuGateEvidence({
+    schema: 'kungfu.project-cut-product-loop.gate-evidence/v1',
+    pointers: [
+      { id: 'project-cut-product-loop-report', file: evidenceFile.absolute },
+      { id: 'buildchain-release-passport', file: passportFile.absolute },
+    ],
+    root,
+    evidenceFile: gateEvidenceFile,
+  });
+  return {
+    schema: 'kungfu.project-cut-product-loop.release-run/v1',
+    verification: 'pass',
+    sourceCommit,
+    evidence: evidenceFile.relative,
+    releasePassport: {
+      ref: passportFile.relative,
+      digest: sha256(passportFile.absolute),
+    },
+    targetGate: contract.targetGate,
+  };
+}
+
+export function main(argv = process.argv.slice(2), root = ROOT) {
+  let options;
+  try {
+    options = parseArgs(argv);
+    const result = runProjectCutProductLoopRelease({
+      root,
+      evidencePath: options.evidence,
+      passportPath: options.passport,
+    });
+    if (options.json) {
+      console.log(JSON.stringify(result, null, 2));
+    } else {
+      console.log(
+        `[project-cut-product-loop] verification=pass source=${result.sourceCommit} evidence=${result.evidence}`,
+      );
+    }
+    return 0;
+  } catch (error) {
+    const message =
+      error instanceof ProjectCutProductLoopReleaseError
+        ? error.message
+        : error instanceof Error
+          ? error.message
+          : String(error);
+    console.error(`[project-cut-product-loop] ${message}`);
+    console.error(usage());
+    return 2;
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href)
+  process.exit(main());


### PR DESCRIPTION
## Summary

Add the executable, fail-closed evidence runner for the Project Cut product loop without claiming release qualification or prematurely registering the target Gate.

The runner binds retained evidence to the exact committed source checkout, the exact Buildchain release-passport bytes, the passport source SHA, and the three platform artifact digests. It emits digest-bound Shifu evidence when invoked by a Gate executor, but does not create or repair campaign evidence.

## Related issue

Atlas goal `2026-07-22-kungfu-project-cut-product-loop`.

## Changes

- add `project-cut-loop:qualify` and its executable runner
- require a clean tracked checkout and derive the exact Git source commit
- open and hash the supplied Buildchain release passport
- require the passport source SHA and Darwin/Linux/Windows artifact digests to match the evidence report
- emit repository-relative, digest-bound Shifu evidence pointers
- retain `product.project-cut-loop` as pending until real three-platform measurement and registration evidence exists
- document the runner and the remaining qualification boundary

## Verification

- `node --test scripts/project-cut-product-loop-release.test.mjs` — 14/14 passed, including an executable temporary-Git runner fixture
- `./shifu test:work-facade` — 19 Node tests and 20 Python tests passed
- `./shifu check:source` — build-free source gate passed; 534 source-contract tests (531 passed, 3 platform skips), Agent Work 7 Node + 41 Python, upgrade 76, desktop 69
- pre-commit staged gate passed after rebasing onto current `dev/v4/v4.0`

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "stage-ready",
  "adrs": ["KF-ADR-019f87e8-6b8b-735c-b036-fa42d7cee8cf"],
  "summary": "Stage the fail-closed Project Cut product-loop evidence runner while retaining pending Gate registration and an explicit not-qualified boundary.",
  "verification": ["Project Cut release runner tests", "Work facade contract tests", "source acceptance", "staged repository gate"]
}
-->

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

This change verifies retained evidence only. It does not publish artifacts, register the pending Gate, dispatch a campaign, or claim product-loop qualification.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated because the release evidence surface changed
