### PR TITLE
fix: harden UNGFU release evidence admission

### DIFF
--- a/docs/adr/KF-ADR-019f8cc4-e796-7b0e-9a16-50c08614e848.md
+++ b/docs/adr/KF-ADR-019f8cc4-e796-7b0e-9a16-50c08614e848.md
@@ -59,7 +59,8 @@ download or package-install surface displays the exact mark beside the actual
 acquisition path and at least one stable product-controlled surface—launch,
 About, or `kungfu --version`—also displays it. Each admitted evidence record
 binds a public URL, access date, source repository and commit, deployment or
-release coordinate, and rendered evidence.
+release coordinate, and rendered evidence. The record names the acquisition
+and product surfaces, and all three bind the same release coordinate.
 
 Coming Soon pages, source checkouts, previews, and staging are explicitly
 ineligible acquisition evidence. The engineering contract does not infer or
@@ -75,7 +76,9 @@ copy and a release-time evidence obligation.
 The current staged implementation provides public source surfaces and the
 executable release gate, but deliberately leaves released-software use false.
 The first real public release must add both required runtime-facing surfaces and
-complete public evidence in a reviewed release change.
+complete public evidence in a reviewed release change. The gate also freezes
+the existing repository, CLI, npm/Python package, domain, KFD, Buildchain, and
+libkungfu identifiers so the source signature cannot become a technical rename.
 
 The decision is falsified if any governed surface uses ®, claims completed
 registration, replaces Kungfu as the product name, omits the exact mark from a

--- a/docs/qualification/contracts.md
+++ b/docs/qualification/contracts.md
@@ -589,7 +589,10 @@ node --test scripts/check-trademark-public-use.test.mjs
 
 The negative fixtures reject the registered symbol, unsupported registration
 claims, a replacement primary product name, missing exact-mark surfaces, and
-preview or staging evidence presented as a real release.
+preview or staging evidence presented as a real release. They also reject
+technical-identifier renames, incomplete or non-public evidence coordinates,
+future access dates, and acquisition/product evidence that does not bind one
+exact release.
 
 **Maturity.** The brand surfaces and release gate are implemented. Public
 release artifacts, actual released-software use evidence, a first-use date, and

--- a/docs/qualification/trademark-public-use.md
+++ b/docs/qualification/trademark-public-use.md
@@ -44,11 +44,18 @@ not replace the product name.
 
 Record only public material. Each evidence record must include:
 
+- stable acquisition-surface and product-surface identifiers;
 - the public URL and access date;
 - source repository and exact source commit;
 - the deployment or release coordinate;
 - rendered evidence showing the mark beside the acquisition path and in the
   selected product surface.
+
+The acquisition surface, product surface, and evidence record must bind the
+same deployment or release coordinate. The acquisition URL and rendered
+evidence must be public HTTPS resources; local files, private-network hosts,
+credentials in URLs, incomplete commit ids, future access dates, and unmatched
+surface references fail closed.
 
 Do not include private applications, searches, counsel correspondence, entity
 records that are not already public, credentials, or unpublished release
@@ -59,6 +66,7 @@ advice, a registration claim, or a legal determination of first use.
 ## Review boundary
 
 The implementation PR proves copy, ownership attribution, exact-mark surfaces,
-and executable negative tests. The future release PR proves real acquisition
-and product surfaces. Production publication and any legal conclusion remain
+protected repository/package/domain/CLI identities, and executable negative
+tests. The future release PR proves one source-bound real acquisition and
+product-surface pair. Production publication and any legal conclusion remain
 separate explicit review gates.

--- a/framework/release/kungfu-trademark-public-use.contract.json
+++ b/framework/release/kungfu-trademark-public-use.contract.json
@@ -6,7 +6,26 @@
     "principle": "Never Guess. Facts Unfold.",
     "owner": "Kungfu Origin Technology Limited",
     "role": "secondary-source-signature",
-    "registrationStatusClaim": "none"
+    "registrationStatusClaim": "none",
+    "protectedTechnicalIdentifiers": {
+      "repository": "kungfu-systems/kungfu",
+      "cli": "kungfu",
+      "npmScope": "@kungfu-tech/",
+      "npmPackages": [
+        "@kungfu-tech/workspaces",
+        "@kungfu-tech/product-kungfu",
+        "@kungfu-tech/core"
+      ],
+      "pythonPackages": [
+        "kungfu",
+        "kungfu-storage"
+      ],
+      "productDomain": "kungfu.tech",
+      "developerDomain": "libkungfu.dev",
+      "protocol": "KFD",
+      "releaseSystem": "Buildchain",
+      "localRuntime": "libkungfu"
+    }
   },
   "currentState": {
     "publicReleaseArtifactsAvailable": false,
@@ -38,6 +57,8 @@
     },
     "evidence": {
       "requiredFields": [
+        "acquisitionSurfaceId",
+        "productSurfaceId",
         "publicUrl",
         "accessedAt",
         "sourceRepository",

--- a/scripts/check-trademark-public-use.test.mjs
+++ b/scripts/check-trademark-public-use.test.mjs
@@ -62,32 +62,115 @@ test('renaming the product or removing an exact-mark surface is rejected', () =>
   );
 });
 
+test('renaming protected technical identifiers or packages is rejected', () => {
+  for (const [field, replacement] of [
+    ['repository', 'ungfu-systems/ungfu'],
+    ['cli', 'ungfu'],
+    ['npmScope', '@ungfu/'],
+    ['productDomain', 'ungfu.example'],
+    ['developerDomain', 'developers.ungfu.example'],
+    ['protocol', 'UNGFU'],
+    ['releaseSystem', 'UNGFU Chain'],
+    ['localRuntime', 'libungfu'],
+  ]) {
+    const renamed = fixture();
+    renamed.contract.brand.protectedTechnicalIdentifiers[field] = replacement;
+    assert.ok(
+      validateTrademarkPublicUse(renamed.contract, renamed.surfaces).some(
+        (item) => item.includes('identifiers must not be renamed'),
+      ),
+      field,
+    );
+  }
+
+  const npmPackage = fixture();
+  npmPackage.surfaces['framework/core/package.json'] = npmPackage.surfaces[
+    'framework/core/package.json'
+  ].replace('@kungfu-tech/core', '@ungfu/core');
+  assert.ok(
+    validateTrademarkPublicUse(npmPackage.contract, npmPackage.surfaces).some(
+      (item) => item.includes('npm package'),
+    ),
+  );
+
+  const cli = fixture();
+  cli.surfaces['framework/core/package.json'] = cli.surfaces[
+    'framework/core/package.json'
+  ].replace('"kungfu": "lib/kungfu-cli.js"', '"ungfu": "lib/kungfu-cli.js"');
+  assert.ok(
+    validateTrademarkPublicUse(cli.contract, cli.surfaces).some((item) =>
+      item.includes('kungfu CLI binding'),
+    ),
+  );
+
+  const pythonPackage = fixture();
+  pythonPackage.surfaces['framework/core/pyproject.toml'] =
+    pythonPackage.surfaces['framework/core/pyproject.toml'].replace(
+      'name = "kungfu"',
+      'name = "ungfu"',
+    );
+  assert.ok(
+    validateTrademarkPublicUse(
+      pythonPackage.contract,
+      pythonPackage.surfaces,
+    ).some((item) => item.includes('Python package')),
+  );
+
+  const publicIdentifier = fixture();
+  publicIdentifier.surfaces['README.md'] = publicIdentifier.surfaces[
+    'README.md'
+  ].replaceAll('libkungfu.dev', 'libungfu.example');
+  assert.ok(
+    validateTrademarkPublicUse(
+      publicIdentifier.contract,
+      publicIdentifier.surfaces,
+    ).some((item) => item.includes('libkungfu identity')),
+  );
+
+  const reordered = fixture();
+  reordered.contract.brand.protectedTechnicalIdentifiers = Object.fromEntries(
+    Object.entries(
+      reordered.contract.brand.protectedTechnicalIdentifiers,
+    ).reverse(),
+  );
+  assert.deepEqual(
+    validateTrademarkPublicUse(reordered.contract, reordered.surfaces),
+    [],
+  );
+});
+
 test('preview or staging cannot satisfy the first real release gate', () => {
   const candidate = fixture();
   candidate.contract.currentState.publicReleaseArtifactsAvailable = true;
   candidate.contract.currentState.releasedSoftwareUseClaim = true;
   candidate.contract.currentState.acquisitionSurfaces = [
     {
+      id: 'download',
       kind: 'public-release-download',
       evidenceKind: 'preview',
       exactMark: EXACT_MARK,
       publicUrl: 'https://preview.example/download',
+      deploymentOrReleaseCoordinate: 'github-release:v4.0.0',
     },
   ];
   candidate.contract.currentState.productSurfaces = [
     {
+      id: 'cli-version',
       kind: 'kungfu --version',
       exactMark: EXACT_MARK,
+      deploymentOrReleaseCoordinate: 'github-release:v4.0.0',
     },
   ];
   candidate.contract.currentState.evidenceRecords = [
     {
       kind: 'staging',
+      acquisitionSurfaceId: 'download',
+      productSurfaceId: 'cli-version',
       publicUrl: 'https://staging.example/download',
       accessedAt: '2026-07-23',
       sourceRepository: 'https://github.com/kungfu-systems/kungfu',
       sourceCommit: '0123456789abcdef0123456789abcdef01234567',
-      deploymentOrReleaseCoordinate: 'preview-1',
+      deploymentOrReleaseCoordinate: 'github-release:v4.0.0',
       renderedEvidence: 'https://staging.example/evidence.png',
     },
   ];
@@ -99,4 +182,88 @@ test('preview or staging cannot satisfy the first real release gate', () => {
   assert.ok(
     issues.some((item) => item.includes('complete public-safe evidence')),
   );
+
+  candidate.contract.currentState.acquisitionSurfaces[0].evidenceKind =
+    'release';
+  candidate.contract.currentState.evidenceRecords[0].kind = 'release';
+  assert.ok(
+    validateTrademarkPublicUse(candidate.contract, candidate.surfaces).some(
+      (item) => item.includes('real public acquisition surface'),
+    ),
+  );
+});
+
+test('released use requires source-bound public evidence for one exact release', () => {
+  const candidate = fixture();
+  candidate.contract.currentState.publicReleaseArtifactsAvailable = true;
+  candidate.contract.currentState.releasedSoftwareUseClaim = true;
+  const coordinate = 'github-release:v4.0.0';
+  candidate.contract.currentState.acquisitionSurfaces = [
+    {
+      id: 'download',
+      kind: 'public-release-download',
+      evidenceKind: 'release',
+      exactMark: EXACT_MARK,
+      publicUrl:
+        'https://github.com/kungfu-systems/kungfu/releases/download/v4.0.0/kungfu-macos.zip',
+      deploymentOrReleaseCoordinate: coordinate,
+    },
+  ];
+  candidate.contract.currentState.productSurfaces = [
+    {
+      id: 'cli-version',
+      kind: 'kungfu --version',
+      exactMark: EXACT_MARK,
+      deploymentOrReleaseCoordinate: coordinate,
+    },
+  ];
+  candidate.contract.currentState.evidenceRecords = [
+    {
+      kind: 'release',
+      acquisitionSurfaceId: 'download',
+      productSurfaceId: 'cli-version',
+      publicUrl:
+        'https://github.com/kungfu-systems/kungfu/releases/download/v4.0.0/kungfu-macos.zip',
+      accessedAt: new Date().toISOString().slice(0, 10),
+      sourceRepository: 'https://github.com/kungfu-systems/kungfu',
+      sourceCommit: '0123456789abcdef0123456789abcdef01234567',
+      deploymentOrReleaseCoordinate: coordinate,
+      renderedEvidence:
+        'https://kungfu.tech/evidence/v4.0.0/kungfu-version.png',
+    },
+  ];
+  assert.deepEqual(
+    validateTrademarkPublicUse(candidate.contract, candidate.surfaces),
+    [],
+  );
+
+  for (const mutate of [
+    (item) => {
+      item.sourceCommit = 'not-a-full-commit';
+    },
+    (item) => {
+      item.sourceRepository = 'https://example.com/not-kungfu';
+    },
+    (item) => {
+      item.accessedAt = '2999-01-01';
+    },
+    (item) => {
+      item.renderedEvidence = 'file:///private/specimen.png';
+    },
+    (item) => {
+      item.deploymentOrReleaseCoordinate = 'github-release:v4.0.1';
+    },
+    (item) => {
+      item.productSurfaceId = 'missing-surface';
+    },
+  ]) {
+    const invalid = structuredClone(candidate);
+    mutate(invalid.contract.currentState.evidenceRecords[0]);
+    assert.ok(
+      validateTrademarkPublicUse(invalid.contract, invalid.surfaces).some(
+        (item) =>
+          item.includes('bound to the acquisition and product surfaces'),
+      ),
+    );
+  }
 });

--- a/scripts/trademark-public-use-contract.mjs
+++ b/scripts/trademark-public-use-contract.mjs
@@ -10,7 +10,26 @@ const CONTRACT_PATH =
   'framework/release/kungfu-trademark-public-use.contract.json';
 const EXACT_MARK = 'Kungfu UNGFU™';
 const OWNER = 'Kungfu Origin Technology Limited';
+const SOURCE_REPOSITORY = 'https://github.com/kungfu-systems/kungfu';
+const PROTECTED_TECHNICAL_IDENTIFIERS = {
+  repository: 'kungfu-systems/kungfu',
+  cli: 'kungfu',
+  npmScope: '@kungfu-tech/',
+  npmPackages: [
+    '@kungfu-tech/workspaces',
+    '@kungfu-tech/product-kungfu',
+    '@kungfu-tech/core',
+  ],
+  pythonPackages: ['kungfu', 'kungfu-storage'],
+  productDomain: 'kungfu.tech',
+  developerDomain: 'libkungfu.dev',
+  protocol: 'KFD',
+  releaseSystem: 'Buildchain',
+  localRuntime: 'libkungfu',
+};
 const REQUIRED_EVIDENCE_FIELDS = [
+  'acquisitionSurfaceId',
+  'productSurfaceId',
   'publicUrl',
   'accessedAt',
   'sourceRepository',
@@ -33,7 +52,74 @@ function array(value) {
 
 /** @param {unknown} value */
 function publicUrl(value) {
-  return typeof value === 'string' && /^https:\/\//u.test(value);
+  if (typeof value !== 'string') return false;
+  try {
+    const url = new URL(value);
+    const host = url.hostname.toLowerCase();
+    return (
+      url.protocol === 'https:' &&
+      !url.username &&
+      !url.password &&
+      host !== 'localhost' &&
+      host !== '127.0.0.1' &&
+      host !== '::1' &&
+      !host.endsWith('.local') &&
+      !host.endsWith('.internal') &&
+      !/^10\./u.test(host) &&
+      !/^192\.168\./u.test(host) &&
+      !/^172\.(?:1[6-9]|2\d|3[01])\./u.test(host)
+    );
+  } catch {
+    return false;
+  }
+}
+
+/** @param {unknown} value */
+function preparatoryUrl(value) {
+  if (!publicUrl(value)) return true;
+  const labels = new URL(String(value)).hostname.toLowerCase().split('.');
+  return labels.some(
+    (label) =>
+      label === 'preview' ||
+      label === 'staging' ||
+      label === 'stage' ||
+      /^pr-\d+$/u.test(label),
+  );
+}
+
+/** @param {unknown} value */
+function canonicalJson(value) {
+  if (Array.isArray(value)) return value.map(canonicalJson);
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, item]) => [key, canonicalJson(item)]),
+    );
+  }
+  return value;
+}
+
+/** @param {unknown} value */
+function dateOnly(value) {
+  if (typeof value !== 'string' || !/^\d{4}-\d{2}-\d{2}$/u.test(value))
+    return false;
+  const parsed = new Date(`${value}T00:00:00Z`);
+  return (
+    Number.isFinite(parsed.valueOf()) &&
+    parsed.toISOString().slice(0, 10) === value &&
+    value <= new Date().toISOString().slice(0, 10)
+  );
+}
+
+/** @param {string} source @param {string} expected */
+function tomlProjectName(source, expected) {
+  const marker = /^\[project\]\s*$/mu.exec(source);
+  if (!marker) return false;
+  const rest = source.slice(marker.index + marker[0].length);
+  const nextSection = rest.search(/\n\[/u);
+  const project = nextSection < 0 ? rest : rest.slice(0, nextSection);
+  return project.match(/^name\s*=\s*"([^"]+)"\s*$/mu)?.[1] === expected;
 }
 
 /**
@@ -45,6 +131,7 @@ export function validateTrademarkPublicUse(contract, surfaces) {
   const brand = object(contract.brand);
   const state = object(contract.currentState);
   const gate = object(contract.firstPublicReleaseGate);
+  const identifiers = object(brand.protectedTechnicalIdentifiers);
   const acquisitionGate = object(gate.acquisitionSurface);
   const productGate = object(gate.productSurface);
   const evidenceGate = object(gate.evidence);
@@ -60,6 +147,14 @@ export function validateTrademarkPublicUse(contract, surfaces) {
     issues.push('mark must remain a secondary source signature');
   if (brand.registrationStatusClaim !== 'none')
     issues.push('registration status must not be claimed');
+  if (
+    JSON.stringify(canonicalJson(identifiers)) !==
+    JSON.stringify(canonicalJson(PROTECTED_TECHNICAL_IDENTIFIERS))
+  ) {
+    issues.push(
+      'repository, CLI, package, domain, KFD, Buildchain, and libkungfu identifiers must not be renamed',
+    );
+  }
   if (state.firstUseDateClaim !== null)
     issues.push('the gate must not infer or backdate first use');
   if (state.legalConclusion !== 'not-made')
@@ -112,6 +207,58 @@ export function validateTrademarkPublicUse(contract, surfaces) {
   ) {
     issues.push('Why Kungfu must preserve the exact mark and product boundary');
   }
+  const rootPackage = JSON.parse(surfaces['package.json'] || '{}');
+  const productPackage = JSON.parse(surfaces['product/package.json'] || '{}');
+  const corePackage = JSON.parse(
+    surfaces['framework/core/package.json'] || '{}',
+  );
+  const canonicalRepository = `${SOURCE_REPOSITORY}.git`;
+  if (
+    rootPackage.name !== PROTECTED_TECHNICAL_IDENTIFIERS.npmPackages[0] ||
+    productPackage.name !== PROTECTED_TECHNICAL_IDENTIFIERS.npmPackages[1] ||
+    corePackage.name !== PROTECTED_TECHNICAL_IDENTIFIERS.npmPackages[2] ||
+    rootPackage.homepage !==
+      `https://${PROTECTED_TECHNICAL_IDENTIFIERS.productDomain}` ||
+    productPackage.homepage !==
+      `https://${PROTECTED_TECHNICAL_IDENTIFIERS.productDomain}` ||
+    productPackage.repository?.url !== canonicalRepository ||
+    corePackage.repository?.url !== canonicalRepository ||
+    corePackage.bin?.kungfu !== 'lib/kungfu-cli.js' ||
+    typeof rootPackage.scripts?.kungfu !== 'string' ||
+    !rootPackage.scripts.kungfu.includes(
+      PROTECTED_TECHNICAL_IDENTIFIERS.npmPackages[2],
+    )
+  ) {
+    issues.push('canonical npm package, domain, or kungfu CLI binding changed');
+  }
+  if (
+    !tomlProjectName(
+      surfaces['framework/core/pyproject.toml'] || '',
+      PROTECTED_TECHNICAL_IDENTIFIERS.pythonPackages[0],
+    ) ||
+    !tomlProjectName(
+      surfaces['framework/sdk/python/pyproject.toml'] || '',
+      PROTECTED_TECHNICAL_IDENTIFIERS.pythonPackages[1],
+    )
+  ) {
+    issues.push('canonical Python package identity changed');
+  }
+  const readme = surfaces['README.md'] || '';
+  const requiredPublicIdentifiers = [
+    `https://github.com/${PROTECTED_TECHNICAL_IDENTIFIERS.repository}`,
+    `https://${PROTECTED_TECHNICAL_IDENTIFIERS.productDomain}`,
+    `https://${PROTECTED_TECHNICAL_IDENTIFIERS.developerDomain}`,
+    PROTECTED_TECHNICAL_IDENTIFIERS.protocol,
+    PROTECTED_TECHNICAL_IDENTIFIERS.releaseSystem,
+    PROTECTED_TECHNICAL_IDENTIFIERS.localRuntime,
+  ];
+  if (
+    requiredPublicIdentifiers.some((identifier) => !readme.includes(identifier))
+  ) {
+    issues.push(
+      'canonical repository, domain, KFD, Buildchain, or libkungfu identity changed',
+    );
+  }
 
   for (const [surfacePath, source] of Object.entries(surfaces)) {
     if (source.includes('®'))
@@ -140,40 +287,68 @@ export function validateTrademarkPublicUse(contract, surfaces) {
       array(evidenceGate.disallowedKinds),
     );
 
-    if (
-      !acquisitions.some(
-        (item) =>
-          allowedAcquisitionKinds.has(item.kind) &&
-          item.exactMark === EXACT_MARK &&
-          publicUrl(item.publicUrl) &&
-          !disallowedEvidenceKinds.has(item.evidenceKind),
-      )
-    ) {
+    const qualifyingAcquisitions = acquisitions.filter(
+      (item) =>
+        typeof item.id === 'string' &&
+        item.id.length > 0 &&
+        allowedAcquisitionKinds.has(item.kind) &&
+        item.exactMark === EXACT_MARK &&
+        publicUrl(item.publicUrl) &&
+        !preparatoryUrl(item.publicUrl) &&
+        typeof item.deploymentOrReleaseCoordinate === 'string' &&
+        item.deploymentOrReleaseCoordinate.length > 0 &&
+        !disallowedEvidenceKinds.has(item.evidenceKind),
+    );
+    if (qualifyingAcquisitions.length === 0) {
       issues.push(
         'released use requires an exact-mark real public acquisition surface',
       );
     }
-    if (
-      !products.some(
-        (item) =>
-          allowedProductKinds.has(item.kind) && item.exactMark === EXACT_MARK,
-      )
-    ) {
+    const qualifyingProducts = products.filter(
+      (item) =>
+        typeof item.id === 'string' &&
+        item.id.length > 0 &&
+        allowedProductKinds.has(item.kind) &&
+        item.exactMark === EXACT_MARK &&
+        typeof item.deploymentOrReleaseCoordinate === 'string' &&
+        item.deploymentOrReleaseCoordinate.length > 0,
+    );
+    if (qualifyingProducts.length === 0) {
       issues.push('released use requires an exact-mark stable product surface');
     }
-    if (
-      !evidence.some(
-        (item) =>
-          REQUIRED_EVIDENCE_FIELDS.every(
-            (field) =>
-              typeof item[field] === 'string' && item[field].length > 0,
-          ) &&
-          publicUrl(item.publicUrl) &&
-          !disallowedEvidenceKinds.has(item.kind),
-      )
-    ) {
+    const completeEvidence = evidence.filter((item) => {
+      if (
+        !REQUIRED_EVIDENCE_FIELDS.every(
+          (field) => typeof item[field] === 'string' && item[field].length > 0,
+        ) ||
+        !publicUrl(item.publicUrl) ||
+        !publicUrl(item.renderedEvidence) ||
+        preparatoryUrl(item.publicUrl) ||
+        preparatoryUrl(item.renderedEvidence) ||
+        !dateOnly(item.accessedAt) ||
+        item.sourceRepository !== SOURCE_REPOSITORY ||
+        !/^[0-9a-f]{40}$/u.test(String(item.sourceCommit)) ||
+        disallowedEvidenceKinds.has(item.kind)
+      ) {
+        return false;
+      }
+      const acquisition = qualifyingAcquisitions.find(
+        (surface) => surface.id === item.acquisitionSurfaceId,
+      );
+      const product = qualifyingProducts.find(
+        (surface) => surface.id === item.productSurfaceId,
+      );
+      return (
+        acquisition?.publicUrl === item.publicUrl &&
+        acquisition?.deploymentOrReleaseCoordinate ===
+          item.deploymentOrReleaseCoordinate &&
+        product?.deploymentOrReleaseCoordinate ===
+          item.deploymentOrReleaseCoordinate
+      );
+    });
+    if (completeEvidence.length === 0) {
       issues.push(
-        'released use requires one complete public-safe evidence record',
+        'released use requires one complete public-safe evidence record bound to the acquisition and product surfaces',
       );
     }
   }
@@ -187,9 +362,16 @@ export function loadTrademarkPublicUse(root = ROOT) {
   return {
     contract: JSON.parse(read(CONTRACT_PATH)),
     surfaces: Object.fromEntries(
-      ['README.md', 'TRADEMARK.md', 'docs/concepts/why-kungfu.md'].map(
-        (item) => [item, read(item)],
-      ),
+      [
+        'README.md',
+        'TRADEMARK.md',
+        'docs/concepts/why-kungfu.md',
+        'package.json',
+        'product/package.json',
+        'framework/core/package.json',
+        'framework/core/pyproject.toml',
+        'framework/sdk/python/pyproject.toml',
+      ].map((item) => [item, read(item)]),
     ),
   };
 }


### PR DESCRIPTION
## Summary

Harden the pending Kungfu UNGFU™ public-use contract so UNGFU cannot become a technical rename and a future released-software claim cannot pass without source-bound, public evidence for one exact release.

## Related issue

Assignment: 2026-07-23-kungfu-ungfu-trademark-public-use
Follow-up completion audit for #1304.

## Changes

- freeze the existing repository, CLI, npm/Python package, domain, KFD, Buildchain, and libkungfu identifiers
- require stable acquisition/product surface ids and one shared release coordinate
- bind public evidence to the canonical repository and a full source commit
- reject private/local URLs, future dates, preview/staging hosts, and mismatched surfaces even when mislabeled as release evidence
- document the exact reviewer and future-release boundary

## Verification

- `./shifu check`
- `./shifu fix`
- `node --test scripts/check-trademark-public-use.test.mjs` (6/6)
- `./shifu check:source` (540 contract tests: 530 passed, 10 platform skips; source gate passed)
- `./shifu docs final-ready --since origin/dev/v4/v4.0 --budget 66560 --json` (no violations; human review required for three changed docs)
- pre-commit staged gate

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "stage-ready",
  "adrs": ["KF-ADR-019f8cc4-e796-7b0e-9a16-50c08614e848"],
  "summary": "Harden the staged Kungfu UNGFU source-signature contract with protected technical identifiers and source-bound evidence for one exact future release.",
  "verification": ["trademark public-use positive and negative fixtures", "full build-free source acceptance", "documentation final-ready parity and human-review obligations"]
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [x] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

This PR publishes no site, creates no downloadable release, records no first-use date, and makes no registration or legal conclusion.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed
