### PR TITLE
perf(ci): narrow SDK core build graph

### DIFF
--- a/.github/workflows/affected-native-pr.yml
+++ b/.github/workflows/affected-native-pr.yml
@@ -411,7 +411,7 @@ jobs:
           cmake-js --version
       - name: Build Core SDK artifacts
         if: ${{ steps.plan.outputs.required == 'true' && steps.plan.outputs.sdk-required == 'true' && matrix.partition == 0 }}
-        run: ./shifu build:core
+        run: ./shifu build:core:sdk
       - name: Pack four-language SDK artifacts
         if: ${{ steps.plan.outputs.required == 'true' && steps.plan.outputs.sdk-required == 'true' && matrix.partition == 0 }}
         run: ./shifu pack:sdk

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -50,7 +50,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:073e92994dedc70096f9f7a7bf8444de9c779429d49bbca10263d038f797c4c6",
+          "definitionDigest": "sha256:6367cd62c9eb66f7270eed21e902c4f0c43fcc6d7cd2e2c59ee1c063904b9253",
           "credentials": {
             "githubToken": "read",
             "oidc": false,
@@ -162,7 +162,7 @@
               "index": 16,
               "label": "name:Build Core SDK artifacts",
               "authority": "qualification",
-              "definitionDigest": "sha256:5886ce76d2342eba8c96cc2dbbb206bc5214560d9c1d8b3440b2cae85b21a0c6"
+              "definitionDigest": "sha256:5cfe8adc4432f2addf43c4af1d7c2daf758d3cdfdbd869a698bc5e7e2fe0c538"
             },
             {
               "index": 17,

--- a/framework/core/.gyp/run-build.js
+++ b/framework/core/.gyp/run-build.js
@@ -13,6 +13,7 @@ const { copyContractArtifacts } = require(
 const { measureCandidateStageSync } = require(
   path.join(CORE, '..', '..', 'scripts', 'candidate-timeline-events.cjs'),
 );
+const SDK_BUILD_PLAN = require('../architecture/sdk-build-plan.json');
 
 function selectedBuildBindings() {
   const authority = require('../architecture/build-capabilities.json');
@@ -76,7 +77,10 @@ function cpVsDependencies() {
 // native addons and their sibling shared libraries move together so the
 // addon's @loader_path lookup resolves. libnode is not staged here — it is
 // colocated at install time from @kungfu-tech/libnode (see design decision (1)).
-function stage() {
+/**
+ * @param {Set<string> | null} [requiredArtifacts]
+ */
+function stage(requiredArtifacts = null) {
   const buildType = shell.getConfigValue('build_type') || 'Release';
   const distKungfu = path.join('dist', 'kungfu');
   fs.rmSync(distKungfu, { recursive: true, force: true });
@@ -93,8 +97,15 @@ function stage() {
   const buildDirs = ['build', path.join('build', buildType)];
   const staged = new Set();
   for (const buildDir of buildDirs) {
-    copyBuildInfo(buildDir, distKungfu, staged);
-    copyBuildIdentity(buildDir, distKungfu, staged);
+    if (!requiredArtifacts || requiredArtifacts.has('kungfubuildinfo.json')) {
+      copyBuildInfo(buildDir, distKungfu, staged);
+    }
+    if (
+      !requiredArtifacts ||
+      requiredArtifacts.has('kungfu-core-build-identity.json')
+    ) {
+      copyBuildIdentity(buildDir, distKungfu, staged);
+    }
     for (const pattern of [
       '*.node',
       '*.pyd',
@@ -105,13 +116,59 @@ function stage() {
     ]) {
       for (const rel of glob.sync(pattern, { cwd: buildDir })) {
         const base = path.basename(rel);
+        if (requiredArtifacts && !requiredArtifacts.has(base)) continue;
         if (staged.has(base)) continue;
         staged.add(base);
         fs.copyFileSync(path.join(buildDir, rel), path.join(distKungfu, base));
       }
     }
   }
+  if (requiredArtifacts) {
+    const missing = [...requiredArtifacts].filter((name) => !staged.has(name));
+    if (missing.length > 0) {
+      throw new Error(
+        `SDK Core build omitted required artifacts: ${missing.join(', ')}`,
+      );
+    }
+  }
   copyConfigContract();
+}
+
+function sdkRequiredArtifacts() {
+  let platformArtifacts;
+  switch (process.platform) {
+    case 'darwin':
+    case 'linux':
+    case 'win32':
+      platformArtifacts = SDK_BUILD_PLAN.required_artifacts[process.platform];
+      break;
+    default:
+      throw new Error(
+        `unsupported SDK Core build platform: ${process.platform}-${process.arch}`,
+      );
+  }
+  return new Set([
+    ...SDK_BUILD_PLAN.required_artifacts.common,
+    ...platformArtifacts,
+  ]);
+}
+
+/**
+ * @template T
+ * @param {string} key
+ * @param {string} value
+ * @param {() => T} action
+ * @returns {T}
+ */
+function withEnvironment(key, value, action) {
+  const previous = process.env[key];
+  process.env[key] = value;
+  try {
+    return action();
+  } finally {
+    if (previous === undefined) delete process.env[key];
+    else process.env[key] = previous;
+  }
 }
 
 // Build the native addon directly through the real builder (run-conan.js →
@@ -120,24 +177,50 @@ function stage() {
 // clean `install` stay a no-op while `build` owns compilation + staging.
 // In-process (not a node subprocess) so process.execPath with spaces —
 // e.g. Windows `C:\Program Files\nodejs\node.exe` — cannot break the call.
-function build() {
+function build(scope = 'full') {
   const bindings = selectedBuildBindings();
   const { conanInstall, conanBuild } = require('./run-conan');
+  const sdkBuild = scope === 'sdk';
+  if (sdkBuild) {
+    const profile =
+      process.env.KUNGFU_BUILD_PROFILE ||
+      shell.getConfigValue('build_profile') ||
+      'full';
+    if (profile !== SDK_BUILD_PLAN.profile) {
+      throw new Error(
+        `SDK Core build requires profile ${SDK_BUILD_PLAN.profile}, got ${profile}`,
+      );
+    }
+    for (const binding of ['cxx', 'c', 'node']) {
+      if (!bindings.has(binding)) {
+        throw new Error(`SDK Core build profile omits ${binding} binding`);
+      }
+    }
+  } else if (scope !== 'full') {
+    throw new Error(`unsupported Core build scope: ${scope}`);
+  }
   measureCandidateStageSync(
     'sdk-core-dependencies',
     'core-dependency-bootstrap',
-    conanInstall,
+    () =>
+      withEnvironment('KUNGFU_CORE_BUILD_SCOPE', scope, () => conanInstall()),
     { gateId: 'source.changed-scope' },
   );
-  measureCandidateStageSync('sdk-core-native', 'core-build', conanBuild, {
-    gateId: 'source.changed-scope',
-  });
+  measureCandidateStageSync(
+    'sdk-core-native',
+    'core-build',
+    () => withEnvironment('KUNGFU_CORE_BUILD_SCOPE', scope, () => conanBuild()),
+    {
+      gateId: 'source.changed-scope',
+    },
+  );
   // Colocate the libnode runtime into build/<build_type> before staging, so the
   // staged dist/kungfu is self-contained: pykungfu links @rpath/libnode.*, and
   // dist/kungfu is the single runtime surface that kfx and the platform package
   // both depend on. Require lazily (loads @kungfu-tech/libnode) so non-build
   // commands stay light.
   if (
+    !sdkBuild &&
     [...bindings].some((binding) =>
       ['python', 'node', 'electron'].includes(binding),
     )
@@ -151,7 +234,7 @@ function build() {
   }
   // With libnode colocated above, pykungfu imports — regenerate its .pyi stubs
   // from the fresh binding so committed stubs/ track the C++ (see gen-stubs.js).
-  if (bindings.has('python')) {
+  if (!sdkBuild && bindings.has('python')) {
     measureCandidateStageSync(
       'sdk-core-python-stubs',
       'sdk-pack-python',
@@ -165,7 +248,7 @@ function build() {
   // this only the gyp kfc chain built it, and the product dist chain shipped
   // without wheels (run-freeze copyWheel warned but could not fail).
   // run-wheel.js ends with process.exit, so spawn it instead of requiring.
-  if (bindings.has('python')) {
+  if (!sdkBuild && bindings.has('python')) {
     measureCandidateStageSync(
       'sdk-core-python-wheel',
       'sdk-pack-python',
@@ -178,10 +261,15 @@ function build() {
       { gateId: 'source.changed-scope', language: 'python' },
     );
   }
-  measureCandidateStageSync('sdk-core-stage', 'sdk-pack-native', stage, {
-    gateId: 'source.changed-scope',
-  });
-  cpVsDependencies();
+  measureCandidateStageSync(
+    'sdk-core-stage',
+    'sdk-pack-native',
+    () => stage(sdkBuild ? sdkRequiredArtifacts() : null),
+    {
+      gateId: 'source.changed-scope',
+    },
+  );
+  if (!sdkBuild) cpVsDependencies();
 }
 
 function clean() {
@@ -259,6 +347,7 @@ module.exports = require('../lib/sywac')(
         build();
       })
       .command('build', () => build())
+      .command('build-sdk', () => build('sdk'))
       .command('clean', () => clean())
       .command('rebuild', () => {
         clean();

--- a/framework/core/architecture/sdk-build-plan.json
+++ b/framework/core/architecture/sdk-build-plan.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "kungfu.core-sdk-build-plan/v1",
+  "profile": "full",
+  "runtime": "node",
+  "target": "kungfu_node",
+  "cmake_definitions": {
+    "KUNGFU_WITH_CORE_TESTS": "OFF"
+  },
+  "required_artifacts": {
+    "common": [
+      "kungfu-core-build-identity.json",
+      "kungfubuildinfo.json",
+      "kungfu_node.node"
+    ],
+    "darwin": [
+      "libkungfu.dylib",
+      "libkungfu_runtime.dylib"
+    ],
+    "linux": [
+      "libkungfu.so",
+      "libkungfu_runtime.so"
+    ],
+    "win32": [
+      "kungfu.dll"
+    ]
+  },
+  "excluded_work": [
+    "core-native-tests",
+    "electron-runtime-configure-and-build",
+    "full-default-target",
+    "node-drone-addon",
+    "node-runtime-host",
+    "production-libwasm-dual-engine-build",
+    "pykungfu-binding-stubs-and-wheel",
+    "public-header-self-compilation"
+  ]
+}

--- a/framework/core/conanfile.py
+++ b/framework/core/conanfile.py
@@ -15,7 +15,6 @@ import shutil
 import stat
 import subprocess
 import sys
-import re
 from glob import glob
 from contextlib import contextmanager
 from os import environ, path
@@ -50,7 +49,7 @@ def _candidate_timeline_attempt():
 
 
 @contextmanager
-def _candidate_timeline_stage(stage, phase, runtime):
+def _candidate_timeline_stage(stage, phase, runtime, target=None):
     output = os.environ.get("KUNGFU_CANDIDATE_TIMELINE_EVENTS", "")
     started_at = (
         datetime.datetime.now(datetime.timezone.utc).isoformat().replace("+00:00", "Z")
@@ -105,6 +104,8 @@ def _candidate_timeline_stage(stage, phase, runtime):
                     "laneId": f"affected-native/partition-{partition}",
                     "runtime": runtime,
                     "stage": stage,
+                    "buildScope": os.environ.get("KUNGFU_CORE_BUILD_SCOPE", "full"),
+                    "buildTarget": target or "default",
                 },
             }
             output_dir = path.dirname(path.abspath(output))
@@ -119,6 +120,13 @@ with open(
     encoding="utf-8",
 ) as build_capabilities_file:
     BUILD_CAPABILITIES = json.load(build_capabilities_file)
+
+with open(
+    path.join(_CONANFILE_DIR, "architecture", "sdk-build-plan.json"),
+    "r",
+    encoding="utf-8",
+) as sdk_build_plan_file:
+    SDK_BUILD_PLAN = json.load(sdk_build_plan_file)
 
 BUILD_PROFILES = {profile["id"]: profile for profile in BUILD_CAPABILITIES["profiles"]}
 BUILD_DEPENDENCIES = {
@@ -322,9 +330,26 @@ class KungfuCoreConan(ConanFile):
 
     def build(self):
         build_type = self.__get_build_type()
+        scope = os.environ.get("KUNGFU_CORE_BUILD_SCOPE", "full")
         self.__clean_build_info(build_type)
-        self.__run_build(build_type, "node")
-        self.__run_build(build_type, "electron")
+        if scope == "sdk":
+            profile = str(self.options.build_profile)
+            if profile != SDK_BUILD_PLAN["profile"]:
+                raise ConanInvalidConfiguration(
+                    f"SDK Core build requires profile {SDK_BUILD_PLAN['profile']}, "
+                    f"got {profile}"
+                )
+            self.__run_build(
+                build_type,
+                SDK_BUILD_PLAN["runtime"],
+                target=SDK_BUILD_PLAN["target"],
+                cmake_definitions=SDK_BUILD_PLAN["cmake_definitions"],
+            )
+        elif scope == "full":
+            self.__run_build(build_type, "node")
+            self.__run_build(build_type, "electron")
+        else:
+            raise ConanInvalidConfiguration(f"unsupported Core build scope: {scope}")
         self.__gen_build_info(build_type)
         self.__show_build_info(build_type)
 
@@ -490,7 +515,7 @@ class KungfuCoreConan(ConanFile):
 
         [switch(key) for key in modules.keys()]
 
-    def __run_build(self, build_type, runtime):
+    def __run_build(self, build_type, runtime, target=None, cmake_definitions=None):
         if f"KUNGFU_BUILD_SKIP_RUNTIME_{runtime.upper()}" in environ:
             self.output.warning(f"disabled build for runtime {runtime}")
             return
@@ -505,11 +530,27 @@ class KungfuCoreConan(ConanFile):
             with _candidate_timeline_stage(
                 f"sdk-core-{runtime}-configure", "core-configure", runtime
             ):
-                self.__run_cmake_js(build_type, "configure", runtime, toolset)
+                self.__run_cmake_js(
+                    build_type,
+                    "configure",
+                    runtime,
+                    toolset,
+                    cmake_definitions=cmake_definitions,
+                )
             with _candidate_timeline_stage(
-                f"sdk-core-{runtime}-build", "core-build", runtime
+                f"sdk-core-{runtime}-build",
+                "core-build",
+                runtime,
+                target=target,
             ):
-                self.__run_cmake_js(build_type, "build", runtime, toolset)
+                self.__run_cmake_js(
+                    build_type,
+                    "build",
+                    runtime,
+                    toolset,
+                    target=target,
+                    cmake_definitions=cmake_definitions,
+                )
         elif runtime == "node":
             environ["KUNGFU_BUILD_SKIP_KUNGFU_NODE"] = "on"
             environ["KUNGFU_BUILD_SKIP_PYKUNGFU"] = "on"
@@ -542,14 +583,29 @@ class KungfuCoreConan(ConanFile):
             self.output.error(f"cmake {args} failed with return code {rc}")
             sys.exit(rc)
 
-    def __run_cmake_js(self, build_type, cmd, runtime, toolset):
+    def __run_cmake_js(
+        self,
+        build_type,
+        cmd,
+        runtime,
+        toolset,
+        target=None,
+        cmake_definitions=None,
+    ):
         [
             os.environ.pop(env_key)
             for env_key in list(os.environ)
             if env_key.upper().startswith("NPM_")
         ]  # workaround for msvc
         self.__run_node_bin(
-            *self.__build_cmake_js_cmd(build_type, cmd, runtime, toolset)
+            *self.__build_cmake_js_cmd(
+                build_type,
+                cmd,
+                runtime,
+                toolset,
+                target=target,
+                cmake_definitions=cmake_definitions,
+            )
         )
         self.output.success(f"cmake-js {cmd} done")
 
@@ -574,28 +630,29 @@ class KungfuCoreConan(ConanFile):
             return int(env_jobs)
         return build_jobs(self)
 
-    def __build_cmake_js_cmd(self, build_type, cmd, runtime, toolset):
+    def __build_cmake_js_cmd(
+        self,
+        build_type,
+        cmd,
+        runtime,
+        toolset,
+        target=None,
+        cmake_definitions=None,
+    ):
         log_level = self.__spdlog_level()
         parallel_level = self.__parallel_jobs()
-        # uv 接管 env（S1 阶段 A）：取 uv 项目 venv 的 python，替代 `pipenv --py`。
-        python_path = re.sub(
-            r"(?:\x1B[@-_]|[\x80-\x9F])[0-?]*[ -/]*[@-~]",
-            "",
-            subprocess.Popen(
-                [
-                    "uv",
-                    "run",
-                    "--frozen",
-                    "python",
-                    "-c",
-                    "import sys; print(sys.executable)",
-                ],
-                stdout=subprocess.PIPE,
-                text=True,
-            )
-            .stdout.read()
-            .strip(),
-        )
+        # Conan itself runs under Shifu's pinned `uv run --frozen` interpreter.
+        # Reuse that exact executable instead of nesting another uv invocation:
+        # strict-cache overlays intentionally expose short-lived wrappers, and a
+        # nested wrapper can no longer resolve its parent manifest.
+        python_path = sys.executable
+        ninja_path = shutil.which("ninja")
+        if not ninja_path:
+            raise ConanInvalidConfiguration("Ninja is required for Core builds")
+        # CMake persists CMAKE_MAKE_PROGRAM. Shifu overlays are disposable, so a
+        # build tree reused by a later invocation must rebind Ninja to the current
+        # live overlay rather than trying the retired temporary path.
+        ninja_option = [f"--CDCMAKE_MAKE_PROGRAM={_cmake_path(ninja_path)}"]
         node_arch = self.__node_arch()
         # Windows 改用 Ninja 生成器(取代 VS/MSBuild):VS 生成器忽略 CMAKE_CXX_COMPILER_LAUNCHER,
         # sccache 无法缓存 MSVC(Phase1 DARKHERO 实证:VS gen 0 compile requests / Ninja round2 命中)。
@@ -630,6 +687,11 @@ class KungfuCoreConan(ConanFile):
             if cargo_registry
             else []
         )
+        definition_options = [
+            f"--CD{key}={value}"
+            for key, value in sorted((cmake_definitions or {}).items())
+        ]
+        target_option = ["--target", target] if cmd == "build" and target else []
         return (
             [
                 "cmake-js",
@@ -646,8 +708,11 @@ class KungfuCoreConan(ConanFile):
                 f"--CDCMAKE_BUILD_PARALLEL_LEVEL={parallel_level}",
             ]
             + cargo_registry_option
+            + ninja_option
+            + definition_options
             + build_option
             + debug_option
+            + target_option
             + [cmd]
         )
 

--- a/framework/core/package.json
+++ b/framework/core/package.json
@@ -41,6 +41,7 @@
   "scripts": {
     "install": "node .gyp/noop-install.js",
     "build": "node .gyp/run-build.js build",
+    "build:sdk": "node .gyp/run-build.js build-sdk",
     "clean": "node .gyp/run-build.js clean",
     "package": "node .gyp/run-build.js package",
     "rebuild": "node .gyp/run-build.js rebuild",
@@ -55,7 +56,7 @@
     "format:cpp": "node .gyp/run-format-cpp.js src",
     "format:python": "node .gyp/run-format-python.js . src src/*/*.spec .*/*.py",
     "kungfu": "node lib/kungfu-cli.js",
-    "test:tooling": "node --test tests/shell-exit-code.test.js tests/run-conan.test.js tests/episode-release-evidence.test.mjs",
+    "test:tooling": "node --test tests/shell-exit-code.test.js tests/run-conan.test.js tests/sdk-core-build.test.js tests/episode-release-evidence.test.mjs",
     "test:storage-binding": "node --test tests/storage-node-binding.test.js",
     "dev:kungfu": "uv run --frozen python .devtools/kungfu_cli.py"
   },

--- a/framework/core/tests/sdk-core-build.test.js
+++ b/framework/core/tests/sdk-core-build.test.js
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const CORE = path.resolve(__dirname, '..');
+const ROOT = path.resolve(CORE, '..', '..');
+
+function read(relative) {
+  return fs.readFileSync(path.join(ROOT, relative), 'utf8');
+}
+
+test('SDK Core build freezes the minimum installed-artifact target closure', () => {
+  const plan = JSON.parse(
+    fs.readFileSync(
+      path.join(CORE, 'architecture', 'sdk-build-plan.json'),
+      'utf8',
+    ),
+  );
+
+  assert.equal(plan.$schema, 'kungfu.core-sdk-build-plan/v1');
+  assert.equal(plan.profile, 'full');
+  assert.equal(plan.runtime, 'node');
+  assert.equal(plan.target, 'kungfu_node');
+  assert.deepEqual(plan.cmake_definitions, {
+    KUNGFU_WITH_CORE_TESTS: 'OFF',
+  });
+  assert.deepEqual(plan.required_artifacts.common, [
+    'kungfu-core-build-identity.json',
+    'kungfubuildinfo.json',
+    'kungfu_node.node',
+  ]);
+  assert.deepEqual(plan.required_artifacts.darwin, [
+    'libkungfu.dylib',
+    'libkungfu_runtime.dylib',
+  ]);
+  assert.deepEqual(plan.required_artifacts.linux, [
+    'libkungfu.so',
+    'libkungfu_runtime.so',
+  ]);
+  assert.deepEqual(plan.required_artifacts.win32, ['kungfu.dll']);
+  assert.deepEqual(plan.excluded_work, [
+    'core-native-tests',
+    'electron-runtime-configure-and-build',
+    'full-default-target',
+    'node-drone-addon',
+    'node-runtime-host',
+    'production-libwasm-dual-engine-build',
+    'pykungfu-binding-stubs-and-wheel',
+    'public-header-self-compilation',
+  ]);
+});
+
+test('SDK Core build plan drives both orchestrators and the queue workflow', () => {
+  const rootPackage = JSON.parse(read('package.json'));
+  const corePackage = JSON.parse(read('framework/core/package.json'));
+  const build = read('framework/core/.gyp/run-build.js');
+  const conan = read('framework/core/conanfile.py');
+  const workflow = read('.github/workflows/affected-native-pr.yml');
+
+  assert.equal(
+    rootPackage.scripts['build:core:sdk'],
+    'node scripts/require-shifu.mjs build:core:sdk && pnpm --filter @kungfu-tech/core run build:sdk',
+  );
+  assert.equal(
+    corePackage.scripts['build:sdk'],
+    'node .gyp/run-build.js build-sdk',
+  );
+  assert.match(build, /require\('\.\.\/architecture\/sdk-build-plan\.json'\)/);
+  assert.match(build, /\.command\('build-sdk', \(\) => build\('sdk'\)\)/);
+  assert.match(
+    build,
+    /case 'darwin':[\s\S]*case 'linux':[\s\S]*case 'win32':[\s\S]*default:[\s\S]*unsupported SDK Core build platform/,
+  );
+  assert.match(
+    conan,
+    /sdk-build-plan\.json[\s\S]*target=SDK_BUILD_PLAN\["target"\][\s\S]*cmake_definitions=SDK_BUILD_PLAN\["cmake_definitions"\]/,
+  );
+  assert.match(
+    conan,
+    /target_option = \["--target", target\] if cmd == "build" and target else \[\]/,
+  );
+  assert.match(conan, /python_path = sys\.executable/);
+  assert.match(conan, /--CDCMAKE_MAKE_PROGRAM=\{_cmake_path\(ninja_path\)\}/);
+  assert.match(
+    workflow,
+    /name: Build Core SDK artifacts[\s\S]*run: \.\/shifu build:core:sdk/,
+  );
+  assert.doesNotMatch(
+    workflow,
+    /name: Build Core SDK artifacts[\s\S]{0,300}run: \.\/shifu build:core(?:\s|$)/,
+  );
+});

--- a/package.json
+++ b/package.json
@@ -154,6 +154,7 @@
     "build:app": "node scripts/require-shifu.mjs build:app && pnpm --filter @kungfu-tech/gui run build",
     "build:cli": "node scripts/require-shifu.mjs build:cli && pnpm --filter @kungfu-tech/tui run build",
     "build:core": "node scripts/require-shifu.mjs build:core && pnpm --filter @kungfu-tech/core run build",
+    "build:core:sdk": "node scripts/require-shifu.mjs build:core:sdk && pnpm --filter @kungfu-tech/core run build:sdk",
     "core:affected": "node scripts/require-shifu.mjs core:affected && node scripts/run-core-affected-native.mjs",
     "core:affected:configure": "node scripts/require-shifu.mjs core:affected:configure && pnpm --filter @kungfu-tech/core run configure",
     "pack:sdk": "node scripts/require-shifu.mjs pack:sdk && pnpm --filter @kungfu-tech/storage run pack",

--- a/scripts/affected-native-proof.test.mjs
+++ b/scripts/affected-native-proof.test.mjs
@@ -392,6 +392,10 @@ test('workflow keeps one required context while staging authoritative queue buil
   );
   assert.match(
     workflow,
+    /Build Core SDK artifacts[\s\S]*run: \.\/shifu build:core:sdk/u,
+  );
+  assert.match(
+    workflow,
     /Run affected native closure[\s\S]*steps\.plan\.outputs\.native-required == 'true'/u,
   );
   assert.match(workflow, /^\s{2}shifu_workspace:$/mu);


### PR DESCRIPTION
## Summary

Reduce the authoritative merge-queue SDK Core build from the generic full Core graph to an explicit SDK artifact closure. The new path builds only the Node runtime `kungfu_node` target, stages an exact fail-closed native artifact allowlist, and keeps the installed four-language SDK wire qualification unchanged.

Baseline evidence attributed 1,916,403 ms of the 3,304,000 ms partition-0 tail to the generic Core native build, including unrelated Electron, Python, Wasm, native-test, and public-header targets. Candidate timeline events now identify the selected build scope and target so fresh queue evidence can separate graph reduction from cache effects.

## Related issue

N/A

## Changes

- Add a machine-readable SDK Core build plan with exact target, CMake definitions, required artifacts, and excluded work.
- Add `build:core:sdk` and route merge-queue partition 0 through it.
- Reuse the pinned Shifu Python and current Ninja executable when reconfiguring persistent CMake trees.
- Add fail-closed plan, workflow, platform, and artifact-closure regression tests.
- Refresh the governed workflow authority digest.

## Verification

- `./shifu build:core:sdk`
- `./shifu pack:sdk`
- `./shifu layers:qualify:sdk -- --report /tmp/kungfu-sdk-p0-local-qualification.json` (C++, Python, Node, and Rust wire artifacts passing)
- `./shifu check:gate-catalog`
- `./shifu check`

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This CI-only optimization narrows the existing SDK qualification build graph without changing an architecture or public product contract."
}
-->

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] release evidence, provenance, package publishing, or deployment surfaces
- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed