### PR TITLE
fix(adr): close workflow authority regeneration

### DIFF
--- a/scripts/adr-migration.mjs
+++ b/scripts/adr-migration.mjs
@@ -559,6 +559,11 @@ export function createAdrMigrationPlan(options = {}) {
         checkCommand: './shifu xinfa:quality',
         paths: [CURRENT_CONTEXT_QUALITY_QUALIFICATION],
       },
+      {
+        command: './shifu gate:workflow-authority:refresh',
+        checkCommand: './shifu check:gate-catalog',
+        paths: ['docs/qualification/gates/workflow-authority.json'],
+      },
     ],
     problems: problems.sort((left, right) =>
       Buffer.compare(
@@ -724,6 +729,7 @@ function runRegenerationCheck(root, command) {
   const allowed = new Map([
     ['./shifu kfd:buildchain:check', ['kfd:buildchain:check']],
     ['./shifu xinfa:quality', ['xinfa:quality']],
+    ['./shifu check:gate-catalog', ['check:gate-catalog']],
   ]);
   const args = allowed.get(command);
   if (!args) throw new Error(`unrecognized regeneration check: ${command}`);

--- a/scripts/adr-migration.test.mjs
+++ b/scripts/adr-migration.test.mjs
@@ -305,11 +305,16 @@ test('plans deterministic ID-only renames from an exact Git tree', () => {
     [
       './shifu kfd:buildchain',
       './shifu node scripts/qualify-xinfa-context-quality.mjs --write',
+      './shifu gate:workflow-authority:refresh',
     ],
   );
   assert.deepEqual(
     first.regenerations.map((row) => row.checkCommand),
-    ['./shifu kfd:buildchain:check', './shifu xinfa:quality'],
+    [
+      './shifu kfd:buildchain:check',
+      './shifu xinfa:quality',
+      './shifu check:gate-catalog',
+    ],
   );
   assert.deepEqual(first.regenerations[0].paths, [
     '.buildchain/kfd/kfd-3/surfaces.json',
@@ -329,6 +334,9 @@ test('plans deterministic ID-only renames from an exact Git tree', () => {
     '.buildchain/kfd/kfd-3/collaboration-interface.artifact.json',
     '.buildchain/kfd/kfd-3/capability-query.json',
     '.buildchain/kfd/buildchain-kfd-summary.json',
+  ]);
+  assert.deepEqual(first.regenerations[2].paths, [
+    'docs/qualification/gates/workflow-authority.json',
   ]);
 });
 


### PR DESCRIPTION
## Summary

Close the ADR corpus migration regeneration set over workflow authority digests.

## Changes

- declare workflow authority refresh and gate-catalog verification in migration plans
- include the generated authority manifest in completion output roots
- cover the exact command, check, and output contract in migration tests

## Verification

- ./shifu adr:migrate:test
- ./shifu check:source
- ./shifu check
- independent review: PASS

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Fail-closed migration tooling closure; no architecture decision or implementation status changes"
}
-->

## Governance risk check

- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed