### PR TITLE
fix(core): stage Windows ABI import library

### DIFF
--- a/framework/core/src/libkungfu/CMakeLists.txt
+++ b/framework/core/src/libkungfu/CMakeLists.txt
@@ -120,8 +120,13 @@ set_target_properties(kungfu_abi PROPERTIES
 )
 if(WIN32)
   # Keep the public facade import library distinct from the static core's
-  # kungfu.lib while exposing the same standard kungfu.dll runtime.
-  set_target_properties(kungfu_abi PROPERTIES ARCHIVE_OUTPUT_NAME kungfu_abi)
+  # kungfu.lib while exposing the same standard kungfu.dll runtime. Cargo's
+  # embedding build consumes this import library from KUNGFU_BUILD_DIR, so do
+  # not leave it in CMake's target-local src/libkungfu output directory.
+  set_target_properties(kungfu_abi PROPERTIES
+    ARCHIVE_OUTPUT_NAME kungfu_abi
+    ARCHIVE_OUTPUT_DIRECTORY ${KUNGFU_BUILD_DIR}
+  )
 endif()
 kungfu_strip_release_local_symbols(kungfu_abi)
 

--- a/scripts/check-layered-api-encoding-boundary.test.mjs
+++ b/scripts/check-layered-api-encoding-boundary.test.mjs
@@ -57,6 +57,12 @@ test('the layered API contract projects one public ABI waist', () => {
     nodeCmake,
     /if\(WIN32\)[\s\S]*target_sources\(\$\{KF_NODE_BINDING_NAME\} PRIVATE \$<TARGET_OBJECTS:kungfu_abi_exports>\)/,
   );
+  const coreCmake = read('framework/core/src/libkungfu/CMakeLists.txt');
+  assert.match(
+    coreCmake,
+    /set_target_properties\(kungfu_abi PROPERTIES[\s\S]*ARCHIVE_OUTPUT_NAME kungfu_abi[\s\S]*ARCHIVE_OUTPUT_DIRECTORY \$\{KUNGFU_BUILD_DIR\}[\s\S]*\)/,
+    "the Windows kungfu_abi import library must land in Cargo's native search directory",
+  );
 });
 
 test('identity protocols retain their existing canonical preimages', () => {


### PR DESCRIPTION
## Summary

Place the Windows `kungfu_abi.lib` import library in `KUNGFU_BUILD_DIR`, which is the native search directory consumed by the Rust trunk embedding build.

The Product Build evidence on alpha PR #1313 showed `kungfu.dll` linking successfully, followed by `LNK1181` because Cargo searched `framework/core/build` while CMake left the import library in its target-local directory.

## Verification

- layered API encoding boundary tests: 5/5 passed
- Biome check passed
- full staged commit hook passed, including 93 documentation/promotion tests
- final proof is the fresh three-platform Product Build after this repair enters dev

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{"schema":"kungfu.adr-release-pr/v1","kind":"adr-neutral","intent":"bugfix","reason":"Windows ABI import-library placement repair only"}
-->
