### PR TITLE
fix(assignment): bind admitted work to native source

### DIFF
--- a/framework/core/src/python/kungfu/cli/commands/assignment.py
+++ b/framework/core/src/python/kungfu/cli/commands/assignment.py
@@ -234,7 +234,10 @@ def admit(
                 "objective": projected["objective"],
                 "actor": actor,
                 "actorType": actor_type,
-                "source": "atlas",
+                # The Initiative above is created under Kungfu-native authority.
+                # Select that same source family when linking the Assignment;
+                # capture roots preserve the Atlas request provenance.
+                "source": "kungfu",
                 "status": "active",
                 "parentAssignmentId": projected["parent_assignment_id"],
                 "dependsOn": projected["depends_on"],


### PR DESCRIPTION
## Summary

- bind CLI-admitted Assignments to the same Kungfu-native source authority as the Initiative created during admission
- preserve Atlas provenance through the existing content-addressed request and capture receipt roots
- unblock fresh-workspace Assignment admission and avoid conflicts after Atlas imports

## Validation

- `test_assignment_orchestration.py`: 4 passed
- `test_initiative_assignment_reads_legacy_sealed_identity_without_rewrite`: passed
- fresh runtime: real Atlas-captured request admitted, claimed, and kicked off successfully
- repository staged gate passed

Goal: `2026-07-23-agent-hub-binary-kfd123-passport-reference`
Mission: `kungfu-technical-stewardship`

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "stage-ready",
  "adrs": ["KF-ADR-019f87cc-bd1f-786d-896d-07ea9245861e"],
  "summary": "Repair the bounded Assignment admission source-authority stage without changing the accepted state machine.",
  "verification": ["assignment orchestration tests", "legacy sealed identity regression test", "fresh captured-request admission and kickoff"]
}
-->