### PR TITLE
fix(core): restore full build test scope

### DIFF
--- a/framework/core/conanfile.py
+++ b/framework/core/conanfile.py
@@ -346,8 +346,13 @@ class KungfuCoreConan(ConanFile):
                 cmake_definitions=SDK_BUILD_PLAN["cmake_definitions"],
             )
         elif scope == "full":
-            self.__run_build(build_type, "node")
-            self.__run_build(build_type, "electron")
+            full_cmake_definitions = {"KUNGFU_WITH_CORE_TESTS": "ON"}
+            self.__run_build(
+                build_type, "node", cmake_definitions=full_cmake_definitions
+            )
+            self.__run_build(
+                build_type, "electron", cmake_definitions=full_cmake_definitions
+            )
         else:
             raise ConanInvalidConfiguration(f"unsupported Core build scope: {scope}")
         self.__gen_build_info(build_type)

--- a/framework/core/tests/sdk-core-build.test.js
+++ b/framework/core/tests/sdk-core-build.test.js
@@ -80,6 +80,10 @@ test('SDK Core build plan drives both orchestrators and the queue workflow', () 
   );
   assert.match(
     conan,
+    /scope == "full"[\s\S]*full_cmake_definitions = \{"KUNGFU_WITH_CORE_TESTS": "ON"\}[\s\S]*"node", cmake_definitions=full_cmake_definitions[\s\S]*"electron", cmake_definitions=full_cmake_definitions/,
+  );
+  assert.match(
+    conan,
     /target_option = \["--target", target\] if cmd == "build" and target else \[\]/,
   );
   assert.match(conan, /python_path = sys\.executable/);


### PR DESCRIPTION
## Summary

Make the generic full Core build explicitly restore `KUNGFU_WITH_CORE_TESTS=ON` for both Node and Electron configurations. This prevents an SDK-scoped CMake cache (`OFF`) from leaking into a later full build in a reused worktree or long-lived runner.

## Related issue

N/A

## Changes

- Pass the full-build test definition explicitly to Node and Electron Core configurations.
- Add a regression assertion that both full-build configurations restore the test scope.

## Verification

- `./shifu exec node --test framework/core/tests/sdk-core-build.test.js`
- `./shifu check:types`
- `./shifu check`
- staged commit gates

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bugfix restores the generic full Core build test scope after SDK-specific configuration; it does not change architecture or a public contract."
}
-->

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] release evidence, provenance, package publishing, or deployment surfaces
- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed