### PR TITLE
feat(release): gate Class 9 filing evidence

### DIFF
--- a/docs/adr/KF-ADR-019f8cc4-e796-7b0e-9a16-50c08614e848.md
+++ b/docs/adr/KF-ADR-019f8cc4-e796-7b0e-9a16-50c08614e848.md
@@ -4,7 +4,7 @@ doc_type: architecture-decision
 adr_id: KF-ADR-019f8cc4-e796-7b0e-9a16-50c08614e848
 decision_status: accepted
 implementation_status: staged
-implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/1304]
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/1304, https://github.com/kungfu-systems/kungfu/pull/1320]
 qualification_refs: [framework/release/kungfu-trademark-public-use.contract.json, scripts/check-trademark-public-use.mjs, scripts/check-trademark-public-use.test.mjs, docs/qualification/trademark-public-use.md]
 review_state: self-reviewed
 sensitivity: public

--- a/docs/qualification/contracts.md
+++ b/docs/qualification/contracts.md
@@ -569,13 +569,16 @@ The living welded-surface register is [`versioning.md`](../development/versionin
 bundle, Python/Node validators, frozen artifact hash gate, and CLI inspection.
 Marketplace acquisition and permission elevation remain outside this contract.
 
-## First real release carries the mark on acquisition and product surfaces
+## First real release carries the mark and Class 9 capability evidence
 
 **Guarantee.** Kungfu does not claim released-software use while v4 remains
 Coming Soon. A future claim must bind the exact **Kungfu UNGFU™** mark to both a
 real public download or package-install path and at least one stable
 product-controlled surface. Source checkouts, previews, and staging do not
-satisfy the acquisition requirement.
+satisfy the acquisition requirement. The same release must bind every core US
+Class 9 identification to a capability users can exercise in the released
+artifact. Conditional inspection/replay and first-party plug-in identifications
+are admitted only when their release conditions and evidence are present.
 
 **Verify.** Read [Trademark public-use qualification](trademark-public-use.md)
 and
@@ -592,11 +595,14 @@ claims, a replacement primary product name, missing exact-mark surfaces, and
 preview or staging evidence presented as a real release. They also reject
 technical-identifier renames, incomplete or non-public evidence coordinates,
 future access dates, and acquisition/product evidence that does not bind one
-exact release.
+exact release. Class 9 fixtures additionally reject missing core
+identifications, changed identification text, roadmap or source-only evidence,
+and conditional goods selected without released-product evidence.
 
 **Maturity.** The brand surfaces and release gate are implemented. Public
 release artifacts, actual released-software use evidence, a first-use date, and
-legal conclusions are not claimed.
+legal conclusions are not claimed. The Class 9 list is an engineering filing
+candidate that still requires counsel review at the release coordinate.
 
 ## How to read a guarantee here
 

--- a/docs/qualification/trademark-public-use.md
+++ b/docs/qualification/trademark-public-use.md
@@ -36,9 +36,65 @@ provide both:
 - at least one stable product-controlled surface—launch, About, or
   `kungfu --version`—that displays the exact mark.
 
+The same release must also carry public capability evidence for every core US
+Class 9 identification in the machine contract. A roadmap, source-only
+implementation, test fixture, preview, staging deployment, or Coming Soon page
+cannot stand in for a capability that users can exercise in the released
+artifact.
+
 The release gate does not rename the `kungfu` CLI, packages, repositories,
 domains, KFD, Buildchain, or libkungfu. The signature identifies source; it does
 not replace the product name.
+
+## US Class 9 filing-readiness profile
+
+The contract records an engineering candidate for a future Section 1(a)
+application after a genuine public alpha exists. It is not a legal conclusion.
+Counsel must still confirm the final identification text, application basis,
+first-use dates, ownership, and specimen sufficiency.
+
+The six core identifications cover:
+
+- continuity of artificial-intelligence-agent work across sessions,
+  interruptions, and handoffs;
+- recording, storing, querying, inspecting, and replaying runtime event data
+  and Agent work records;
+- creating, exporting, importing, and verifying electronic Agent work records;
+- downloadable workflow-management software;
+- downloadable software-development tools; and
+- a downloadable application programming interface.
+
+Two additional identifications are conditional. Interactive inspection and
+replay may be selected only when a released CLI, TUI, or GUI exposes that
+capability. Downloadable plug-ins may be selected only when Kungfu distributes
+at least one first-party downloadable KFX plug-in under the mark. Merely hosting
+an extension API or allowing third parties to build plug-ins does not satisfy
+that condition.
+
+Each selected identification has a stable `planId`. The two distinct
+`009-506` fill-ins remain separate through those ids even though they use the
+same USPTO Term ID. The release evidence must reproduce the reviewed
+identification exactly; a release PR cannot silently broaden or substitute the
+filing plan.
+
+## Per-identification capability evidence
+
+Every core Class 9 evidence record must identify:
+
+- the stable plan id, USPTO Term ID, and exact reviewed identification;
+- status `released`, never planned or source-only;
+- the public command or product surface that exercises the capability;
+- a public URL, access date, and rendered evidence;
+- the exact source repository and full source commit;
+- the acquisition and product surface ids; and
+- the deployment or release coordinate shared by all of those surfaces.
+
+The strongest acquisition evidence is a public download or package-install page
+that places **Kungfu UNGFU™**, a description of the downloadable software, and
+the actual download or installation path together. The stable product surface
+then shows the same mark from the matching artifact. Internal qualification
+evidence supports the truthfulness of each goods claim, but does not replace
+what the public can actually acquire and use.
 
 ## Public-safe evidence record
 
@@ -66,7 +122,8 @@ advice, a registration claim, or a legal determination of first use.
 ## Review boundary
 
 The implementation PR proves copy, ownership attribution, exact-mark surfaces,
-protected repository/package/domain/CLI identities, and executable negative
-tests. The future release PR proves one source-bound real acquisition and
-product-surface pair. Production publication and any legal conclusion remain
-separate explicit review gates.
+protected repository/package/domain/CLI identities, the bounded Class 9 filing
+plan, and executable negative tests. The future release PR proves one
+source-bound real acquisition and product-surface pair plus released capability
+evidence for every selected Class 9 identification. Production publication and
+any legal conclusion remain separate explicit review gates.

--- a/framework/release/kungfu-trademark-public-use.contract.json
+++ b/framework/release/kungfu-trademark-public-use.contract.json
@@ -34,7 +34,8 @@
     "legalConclusion": "not-made",
     "acquisitionSurfaces": [],
     "productSurfaces": [],
-    "evidenceRecords": []
+    "evidenceRecords": [],
+    "class9GoodsEvidence": []
   },
   "firstPublicReleaseGate": {
     "acquisitionSurface": {
@@ -74,6 +75,92 @@
       ],
       "publicOnly": true,
       "backdatingAllowed": false
+    },
+    "class9FilingReadiness": {
+      "jurisdiction": "US",
+      "internationalClass": "009",
+      "filingBasisCandidate": "Section 1(a)",
+      "legalReviewRequired": true,
+      "coreIdentifications": [
+        {
+          "planId": "continuity-management",
+          "termId": "009-5447",
+          "identification": "Downloadable computer software for monitoring and managing continuity of artificial intelligence agent work across sessions, interruptions, and handoffs"
+        },
+        {
+          "planId": "runtime-event-ledger",
+          "termId": "009-506",
+          "identification": "Downloadable software for recording, storing, querying, inspecting, and replaying runtime event data and records of work performed by artificial intelligence agents"
+        },
+        {
+          "planId": "agent-work-records",
+          "termId": "009-506",
+          "identification": "Downloadable software for creating, exporting, importing, and verifying electronic records of work performed by artificial intelligence agents"
+        },
+        {
+          "planId": "workflow-management",
+          "termId": "009-6548",
+          "identification": "Downloadable workflow management software"
+        },
+        {
+          "planId": "software-development-tools",
+          "termId": "009-5399",
+          "identification": "Downloadable computer software development tools"
+        },
+        {
+          "planId": "application-programming-interface",
+          "termId": "009-5657",
+          "identification": "Downloadable computer software for use as an application programming interface (API)"
+        }
+      ],
+      "conditionalIdentifications": [
+        {
+          "planId": "interactive-inspection-replay",
+          "termId": "009-5754",
+          "identification": "Downloadable interactive software for inspecting and replaying computer software execution and artificial intelligence agent work records",
+          "condition": "A released CLI, TUI, or GUI exposes the claimed inspection and replay capability"
+        },
+        {
+          "planId": "first-party-software-plugins",
+          "termId": "009-7662",
+          "identification": "Downloadable computer software plug-ins for data integration, workflow management, software monitoring, and software development",
+          "condition": "Kungfu distributes at least one first-party downloadable KFX plug-in under the mark"
+        }
+      ],
+      "evidence": {
+        "allCoreClaimsRequired": true,
+        "conditionalClaimsRequireEvidenceWhenSelected": true,
+        "requiredFields": [
+          "id",
+          "planId",
+          "termId",
+          "identification",
+          "status",
+          "capabilityEvidenceKind",
+          "commandOrSurface",
+          "publicUrl",
+          "accessedAt",
+          "sourceRepository",
+          "sourceCommit",
+          "acquisitionSurfaceId",
+          "productSurfaceId",
+          "deploymentOrReleaseCoordinate",
+          "renderedEvidence"
+        ],
+        "allowedCapabilityEvidenceKinds": [
+          "released-cli-capability",
+          "released-sdk-capability",
+          "released-first-party-plugin"
+        ],
+        "disallowedCapabilityEvidenceKinds": [
+          "roadmap",
+          "source-only",
+          "test-fixture",
+          "coming-soon",
+          "preview",
+          "staging"
+        ]
+      }
     }
   }
 }

--- a/scripts/check-trademark-public-use.mjs
+++ b/scripts/check-trademark-public-use.mjs
@@ -13,6 +13,12 @@ if (issues.length) {
   for (const issue of issues) console.error(`[trademark-public-use] ${issue}`);
   process.exit(1);
 }
+const state = contract.currentState.releasedSoftwareUseClaim
+  ? 'released-evidence'
+  : 'pre-release';
+const coreClass9Count =
+  contract.firstPublicReleaseGate.class9FilingReadiness.coreIdentifications
+    .length;
 console.log(
-  `[trademark-public-use] contract=${CONTRACT_PATH} state=pre-release valid=true`,
+  `[trademark-public-use] contract=${CONTRACT_PATH} state=${state} class9-core=${coreClass9Count} valid=true`,
 );

--- a/scripts/check-trademark-public-use.test.mjs
+++ b/scripts/check-trademark-public-use.test.mjs
@@ -13,6 +13,34 @@ function fixture() {
   return structuredClone(loadTrademarkPublicUse());
 }
 
+function addCoreClass9Evidence(candidate, coordinate) {
+  const plans =
+    candidate.contract.firstPublicReleaseGate.class9FilingReadiness
+      .coreIdentifications;
+  candidate.contract.currentState.class9GoodsEvidence = plans.map(
+    (plan, index) => ({
+      id: `class9-${plan.planId}`,
+      planId: plan.planId,
+      termId: plan.termId,
+      identification: plan.identification,
+      status: 'released',
+      capabilityEvidenceKind:
+        plan.planId === 'application-programming-interface'
+          ? 'released-sdk-capability'
+          : 'released-cli-capability',
+      commandOrSurface: `qualification/class9/${plan.planId}`,
+      publicUrl: `https://kungfu.tech/evidence/v4.0.0/class9-${index}.html`,
+      accessedAt: new Date().toISOString().slice(0, 10),
+      sourceRepository: 'https://github.com/kungfu-systems/kungfu',
+      sourceCommit: '0123456789abcdef0123456789abcdef01234567',
+      acquisitionSurfaceId: 'download',
+      productSurfaceId: 'cli-version',
+      deploymentOrReleaseCoordinate: coordinate,
+      renderedEvidence: `https://kungfu.tech/evidence/v4.0.0/class9-${index}.png`,
+    }),
+  );
+}
+
 test('the current pre-release state is truthful and complete', () => {
   const { contract, surfaces } = fixture();
   assert.deepEqual(validateTrademarkPublicUse(contract, surfaces), []);
@@ -232,6 +260,7 @@ test('released use requires source-bound public evidence for one exact release',
         'https://kungfu.tech/evidence/v4.0.0/kungfu-version.png',
     },
   ];
+  addCoreClass9Evidence(candidate, coordinate);
   assert.deepEqual(
     validateTrademarkPublicUse(candidate.contract, candidate.surfaces),
     [],
@@ -266,4 +295,154 @@ test('released use requires source-bound public evidence for one exact release',
       ),
     );
   }
+});
+
+test('released use requires evidence for every core Class 9 identification', () => {
+  const candidate = fixture();
+  candidate.contract.currentState.publicReleaseArtifactsAvailable = true;
+  candidate.contract.currentState.releasedSoftwareUseClaim = true;
+  const coordinate = 'github-release:v4.0.0-alpha.1';
+  candidate.contract.currentState.acquisitionSurfaces = [
+    {
+      id: 'download',
+      kind: 'public-release-download',
+      evidenceKind: 'release',
+      exactMark: EXACT_MARK,
+      publicUrl:
+        'https://github.com/kungfu-systems/kungfu/releases/download/v4.0.0-alpha.1/kungfu-macos.zip',
+      deploymentOrReleaseCoordinate: coordinate,
+    },
+  ];
+  candidate.contract.currentState.productSurfaces = [
+    {
+      id: 'cli-version',
+      kind: 'kungfu --version',
+      exactMark: EXACT_MARK,
+      deploymentOrReleaseCoordinate: coordinate,
+    },
+  ];
+  candidate.contract.currentState.evidenceRecords = [
+    {
+      kind: 'release',
+      acquisitionSurfaceId: 'download',
+      productSurfaceId: 'cli-version',
+      publicUrl:
+        'https://github.com/kungfu-systems/kungfu/releases/download/v4.0.0-alpha.1/kungfu-macos.zip',
+      accessedAt: new Date().toISOString().slice(0, 10),
+      sourceRepository: 'https://github.com/kungfu-systems/kungfu',
+      sourceCommit: '0123456789abcdef0123456789abcdef01234567',
+      deploymentOrReleaseCoordinate: coordinate,
+      renderedEvidence:
+        'https://kungfu.tech/evidence/v4.0.0-alpha.1/kungfu-version.png',
+    },
+  ];
+  addCoreClass9Evidence(candidate, coordinate);
+  assert.deepEqual(
+    validateTrademarkPublicUse(candidate.contract, candidate.surfaces),
+    [],
+  );
+
+  const missing = structuredClone(candidate);
+  missing.contract.currentState.class9GoodsEvidence.pop();
+  assert.ok(
+    validateTrademarkPublicUse(missing.contract, missing.surfaces).some(
+      (item) => item.includes('every core Class 9 identification'),
+    ),
+  );
+
+  const roadmap = structuredClone(candidate);
+  roadmap.contract.currentState.class9GoodsEvidence[0].capabilityEvidenceKind =
+    'roadmap';
+  const roadmapIssues = validateTrademarkPublicUse(
+    roadmap.contract,
+    roadmap.surfaces,
+  );
+  assert.ok(
+    roadmapIssues.some((item) =>
+      item.includes('every core Class 9 identification'),
+    ),
+  );
+  assert.ok(
+    roadmapIssues.some((item) =>
+      item.includes('complete released-product evidence'),
+    ),
+  );
+
+  const drifted = structuredClone(candidate);
+  drifted.contract.currentState.class9GoodsEvidence[1].identification +=
+    ' and future services';
+  assert.ok(
+    validateTrademarkPublicUse(drifted.contract, drifted.surfaces).some(
+      (item) => item.includes('complete released-product evidence'),
+    ),
+  );
+});
+
+test('conditional Class 9 items require released evidence when selected', () => {
+  const candidate = fixture();
+  candidate.contract.currentState.publicReleaseArtifactsAvailable = true;
+  candidate.contract.currentState.releasedSoftwareUseClaim = true;
+  const coordinate = 'github-release:v4.0.0-alpha.1';
+  candidate.contract.currentState.acquisitionSurfaces = [
+    {
+      id: 'download',
+      kind: 'public-release-download',
+      evidenceKind: 'release',
+      exactMark: EXACT_MARK,
+      publicUrl:
+        'https://github.com/kungfu-systems/kungfu/releases/download/v4.0.0-alpha.1/kungfu-macos.zip',
+      deploymentOrReleaseCoordinate: coordinate,
+    },
+  ];
+  candidate.contract.currentState.productSurfaces = [
+    {
+      id: 'cli-version',
+      kind: 'kungfu --version',
+      exactMark: EXACT_MARK,
+      deploymentOrReleaseCoordinate: coordinate,
+    },
+  ];
+  candidate.contract.currentState.evidenceRecords = [
+    {
+      kind: 'release',
+      acquisitionSurfaceId: 'download',
+      productSurfaceId: 'cli-version',
+      publicUrl:
+        'https://github.com/kungfu-systems/kungfu/releases/download/v4.0.0-alpha.1/kungfu-macos.zip',
+      accessedAt: new Date().toISOString().slice(0, 10),
+      sourceRepository: 'https://github.com/kungfu-systems/kungfu',
+      sourceCommit: '0123456789abcdef0123456789abcdef01234567',
+      deploymentOrReleaseCoordinate: coordinate,
+      renderedEvidence:
+        'https://kungfu.tech/evidence/v4.0.0-alpha.1/kungfu-version.png',
+    },
+  ];
+  addCoreClass9Evidence(candidate, coordinate);
+  const conditional =
+    candidate.contract.firstPublicReleaseGate.class9FilingReadiness
+      .conditionalIdentifications[1];
+  candidate.contract.currentState.class9GoodsEvidence.push({
+    id: `class9-${conditional.planId}`,
+    planId: conditional.planId,
+    termId: conditional.termId,
+    identification: conditional.identification,
+    status: 'planned',
+    capabilityEvidenceKind: 'source-only',
+    commandOrSurface: 'framework/kfx',
+    publicUrl:
+      'https://github.com/kungfu-systems/kungfu/tree/dev/v4/v4.0/framework/kfx',
+    accessedAt: new Date().toISOString().slice(0, 10),
+    sourceRepository: 'https://github.com/kungfu-systems/kungfu',
+    sourceCommit: '0123456789abcdef0123456789abcdef01234567',
+    acquisitionSurfaceId: 'download',
+    productSurfaceId: 'cli-version',
+    deploymentOrReleaseCoordinate: coordinate,
+    renderedEvidence:
+      'https://kungfu.tech/evidence/v4.0.0-alpha.1/kfx-source.png',
+  });
+  assert.ok(
+    validateTrademarkPublicUse(candidate.contract, candidate.surfaces).some(
+      (item) => item.includes('complete released-product evidence'),
+    ),
+  );
 });

--- a/scripts/trademark-public-use-contract.mjs
+++ b/scripts/trademark-public-use-contract.mjs
@@ -37,6 +37,90 @@ const REQUIRED_EVIDENCE_FIELDS = [
   'deploymentOrReleaseCoordinate',
   'renderedEvidence',
 ];
+const CLASS9_CORE_IDENTIFICATIONS = [
+  {
+    planId: 'continuity-management',
+    termId: '009-5447',
+    identification:
+      'Downloadable computer software for monitoring and managing continuity of artificial intelligence agent work across sessions, interruptions, and handoffs',
+  },
+  {
+    planId: 'runtime-event-ledger',
+    termId: '009-506',
+    identification:
+      'Downloadable software for recording, storing, querying, inspecting, and replaying runtime event data and records of work performed by artificial intelligence agents',
+  },
+  {
+    planId: 'agent-work-records',
+    termId: '009-506',
+    identification:
+      'Downloadable software for creating, exporting, importing, and verifying electronic records of work performed by artificial intelligence agents',
+  },
+  {
+    planId: 'workflow-management',
+    termId: '009-6548',
+    identification: 'Downloadable workflow management software',
+  },
+  {
+    planId: 'software-development-tools',
+    termId: '009-5399',
+    identification: 'Downloadable computer software development tools',
+  },
+  {
+    planId: 'application-programming-interface',
+    termId: '009-5657',
+    identification:
+      'Downloadable computer software for use as an application programming interface (API)',
+  },
+];
+const CLASS9_CONDITIONAL_IDENTIFICATIONS = [
+  {
+    planId: 'interactive-inspection-replay',
+    termId: '009-5754',
+    identification:
+      'Downloadable interactive software for inspecting and replaying computer software execution and artificial intelligence agent work records',
+    condition:
+      'A released CLI, TUI, or GUI exposes the claimed inspection and replay capability',
+  },
+  {
+    planId: 'first-party-software-plugins',
+    termId: '009-7662',
+    identification:
+      'Downloadable computer software plug-ins for data integration, workflow management, software monitoring, and software development',
+    condition:
+      'Kungfu distributes at least one first-party downloadable KFX plug-in under the mark',
+  },
+];
+const REQUIRED_CLASS9_EVIDENCE_FIELDS = [
+  'id',
+  'planId',
+  'termId',
+  'identification',
+  'status',
+  'capabilityEvidenceKind',
+  'commandOrSurface',
+  'publicUrl',
+  'accessedAt',
+  'sourceRepository',
+  'sourceCommit',
+  'acquisitionSurfaceId',
+  'productSurfaceId',
+  'deploymentOrReleaseCoordinate',
+  'renderedEvidence',
+];
+const ALLOWED_CLASS9_EVIDENCE_KINDS = [
+  'released-cli-capability',
+  'released-sdk-capability',
+  'released-first-party-plugin',
+];
+const DISALLOWED_CLASS9_EVIDENCE_KINDS = [
+  'roadmap',
+  'source-only',
+  'test-fixture',
+  'coming-soon',
+  'preview',
+  'staging',
+];
 
 /** @param {unknown} value */
 function object(value) {
@@ -135,6 +219,8 @@ export function validateTrademarkPublicUse(contract, surfaces) {
   const acquisitionGate = object(gate.acquisitionSurface);
   const productGate = object(gate.productSurface);
   const evidenceGate = object(gate.evidence);
+  const class9Gate = object(gate.class9FilingReadiness);
+  const class9EvidenceGate = object(class9Gate.evidence);
 
   if (contract.schema !== 'kungfu.trademark-public-use/v1')
     issues.push('schema must remain v1');
@@ -179,6 +265,38 @@ export function validateTrademarkPublicUse(contract, surfaces) {
     JSON.stringify(REQUIRED_EVIDENCE_FIELDS)
   ) {
     issues.push('public evidence coordinates are incomplete');
+  }
+  if (
+    class9Gate.jurisdiction !== 'US' ||
+    class9Gate.internationalClass !== '009' ||
+    class9Gate.filingBasisCandidate !== 'Section 1(a)' ||
+    class9Gate.legalReviewRequired !== true
+  ) {
+    issues.push(
+      'Class 9 filing readiness must remain a US Section 1(a) candidate subject to legal review',
+    );
+  }
+  if (
+    JSON.stringify(canonicalJson(array(class9Gate.coreIdentifications))) !==
+      JSON.stringify(canonicalJson(CLASS9_CORE_IDENTIFICATIONS)) ||
+    JSON.stringify(
+      canonicalJson(array(class9Gate.conditionalIdentifications)),
+    ) !== JSON.stringify(canonicalJson(CLASS9_CONDITIONAL_IDENTIFICATIONS))
+  ) {
+    issues.push('Class 9 identification plan changed without review');
+  }
+  if (
+    class9EvidenceGate.allCoreClaimsRequired !== true ||
+    class9EvidenceGate.conditionalClaimsRequireEvidenceWhenSelected !== true ||
+    JSON.stringify(array(class9EvidenceGate.requiredFields)) !==
+      JSON.stringify(REQUIRED_CLASS9_EVIDENCE_FIELDS) ||
+    JSON.stringify(array(class9EvidenceGate.allowedCapabilityEvidenceKinds)) !==
+      JSON.stringify(ALLOWED_CLASS9_EVIDENCE_KINDS) ||
+    JSON.stringify(
+      array(class9EvidenceGate.disallowedCapabilityEvidenceKinds),
+    ) !== JSON.stringify(DISALLOWED_CLASS9_EVIDENCE_KINDS)
+  ) {
+    issues.push('Class 9 per-identification evidence policy is incomplete');
   }
 
   const firstScreen = (surfaces['README.md'] || '').slice(0, 2400);
@@ -270,9 +388,15 @@ export function validateTrademarkPublicUse(contract, surfaces) {
 
   const releasedClaim = state.releasedSoftwareUseClaim === true;
   const releaseAvailable = state.publicReleaseArtifactsAvailable === true;
+  const class9Evidence = array(state.class9GoodsEvidence).map(object);
   if (releasedClaim !== releaseAvailable) {
     issues.push(
       'released-software claim and public artifact availability must change together',
+    );
+  }
+  if (!releasedClaim && class9Evidence.length > 0) {
+    issues.push(
+      'pre-release state must not carry speculative Class 9 goods evidence',
     );
   }
   if (releasedClaim) {
@@ -349,6 +473,69 @@ export function validateTrademarkPublicUse(contract, surfaces) {
     if (completeEvidence.length === 0) {
       issues.push(
         'released use requires one complete public-safe evidence record bound to the acquisition and product surfaces',
+      );
+    }
+
+    const plans = [
+      ...CLASS9_CORE_IDENTIFICATIONS,
+      ...CLASS9_CONDITIONAL_IDENTIFICATIONS,
+    ];
+    const planById = new Map(plans.map((plan) => [plan.planId, plan]));
+    const allowedClass9EvidenceKinds = new Set(
+      array(class9EvidenceGate.allowedCapabilityEvidenceKinds),
+    );
+    const disallowedClass9EvidenceKinds = new Set(
+      array(class9EvidenceGate.disallowedCapabilityEvidenceKinds),
+    );
+    const seenPlanIds = new Set();
+    const qualifyingClass9Evidence = class9Evidence.filter((item) => {
+      const plan = planById.get(String(item.planId));
+      const complete = REQUIRED_CLASS9_EVIDENCE_FIELDS.every(
+        (field) => typeof item[field] === 'string' && item[field].length > 0,
+      );
+      if (!plan || !complete || seenPlanIds.has(String(item.planId))) {
+        return false;
+      }
+      seenPlanIds.add(String(item.planId));
+      const acquisition = qualifyingAcquisitions.find(
+        (surface) => surface.id === item.acquisitionSurfaceId,
+      );
+      const product = qualifyingProducts.find(
+        (surface) => surface.id === item.productSurfaceId,
+      );
+      return (
+        item.termId === plan.termId &&
+        item.identification === plan.identification &&
+        item.status === 'released' &&
+        allowedClass9EvidenceKinds.has(item.capabilityEvidenceKind) &&
+        !disallowedClass9EvidenceKinds.has(item.capabilityEvidenceKind) &&
+        publicUrl(item.publicUrl) &&
+        publicUrl(item.renderedEvidence) &&
+        !preparatoryUrl(item.publicUrl) &&
+        !preparatoryUrl(item.renderedEvidence) &&
+        dateOnly(item.accessedAt) &&
+        item.sourceRepository === SOURCE_REPOSITORY &&
+        /^[0-9a-f]{40}$/u.test(String(item.sourceCommit)) &&
+        acquisition?.deploymentOrReleaseCoordinate ===
+          item.deploymentOrReleaseCoordinate &&
+        product?.deploymentOrReleaseCoordinate ===
+          item.deploymentOrReleaseCoordinate
+      );
+    });
+    const qualifyingPlanIds = new Set(
+      qualifyingClass9Evidence.map((item) => item.planId),
+    );
+    const missingCorePlans = CLASS9_CORE_IDENTIFICATIONS.filter(
+      (plan) => !qualifyingPlanIds.has(plan.planId),
+    ).map((plan) => plan.planId);
+    if (missingCorePlans.length > 0) {
+      issues.push(
+        `released use requires public capability evidence for every core Class 9 identification: ${missingCorePlans.join(', ')}`,
+      );
+    }
+    if (qualifyingClass9Evidence.length !== class9Evidence.length) {
+      issues.push(
+        'every selected Class 9 identification must carry complete released-product evidence for the exact release',
       );
     }
   }


### PR DESCRIPTION
## Summary

Add a fail-closed US Class 9 filing-readiness gate for the future public Kungfu UNGFU alpha. The gate freezes six core identifications, two conditional identifications, and the exact released-product evidence required for each selected item.

This is an engineering evidence boundary, not a first-use, registrability, ownership, or legal-sufficiency conclusion. Counsel review remains required before filing.

## Related issue

None.

## Changes

- require released capability evidence for all six core Class 9 identifications
- admit the interactive and first-party KFX plug-in items only when those downloadable capabilities actually ship
- reject roadmap, source-only, fixture, preview, staging, and Coming Soon evidence
- bind each item to the same public acquisition and product release coordinate
- document the future-alpha filing workflow and specimen boundary

## Verification

- `node scripts/check-trademark-public-use.mjs`
- `node --test scripts/check-trademark-public-use.test.mjs` (8/8)
- `./shifu check:source`
- `./shifu docs:check` (93/93)
- staged pre-commit gate

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "stage-ready",
  "adrs": ["KF-ADR-019f8cc4-e796-7b0e-9a16-50c08614e848"],
  "summary": "Freeze the future public-alpha Class 9 capability evidence contract without claiming legal sufficiency",
  "verification": ["trademark public-use contract tests", "source gate", "documentation gate"]
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [x] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The exact mark and release evidence are governed by the existing trademark public-use ADR. The new negative fixtures fail closed on speculative or altered claims.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed
