### PR TITLE
feat(product): expose UNGFU identity surfaces

### DIFF
--- a/crates/trunk/src/main.rs
+++ b/crates/trunk/src/main.rs
@@ -14,6 +14,7 @@ mod help;
 mod launch;
 mod pins;
 mod plans;
+mod product_identity;
 mod status;
 mod variant;
 mod xinfa_command;
@@ -205,10 +206,9 @@ fn main() {
                 launch::launch(&args)
             }
             ProductRoute::Version => {
-                println!(
-                    "{}",
-                    help::version().unwrap_or_else(|| env!("CARGO_PKG_VERSION").to_string())
-                );
+                let version =
+                    help::version().unwrap_or_else(|| env!("CARGO_PKG_VERSION").to_string());
+                println!("{}", product_identity::version_banner(&version));
                 return;
             }
             ProductRoute::Native {

--- a/crates/trunk/src/product_identity.rs
+++ b/crates/trunk/src/product_identity.rs
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+
+pub const SECONDARY_SOURCE_SIGNATURE: &str = "Kungfu UNGFU™";
+pub const SOURCE_PRINCIPLE: &str = "Never Guess. Facts Unfold.";
+
+pub fn version_banner(version: &str) -> String {
+    format!("{version}\n{SECONDARY_SOURCE_SIGNATURE} · {SOURCE_PRINCIPLE}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn version_banner_preserves_the_version_first_line() {
+        let banner = version_banner("4.0.0-alpha.1");
+        let mut lines = banner.lines();
+        assert_eq!(lines.next(), Some("4.0.0-alpha.1"));
+        assert_eq!(
+            lines.next(),
+            Some("Kungfu UNGFU™ · Never Guess. Facts Unfold.")
+        );
+        assert_eq!(lines.next(), None);
+    }
+}

--- a/docs/adr/KF-ADR-019f8cc4-e796-7b0e-9a16-50c08614e848.md
+++ b/docs/adr/KF-ADR-019f8cc4-e796-7b0e-9a16-50c08614e848.md
@@ -4,8 +4,8 @@ doc_type: architecture-decision
 adr_id: KF-ADR-019f8cc4-e796-7b0e-9a16-50c08614e848
 decision_status: accepted
 implementation_status: staged
-implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/1304, https://github.com/kungfu-systems/kungfu/pull/1320]
-qualification_refs: [framework/release/kungfu-trademark-public-use.contract.json, scripts/check-trademark-public-use.mjs, scripts/check-trademark-public-use.test.mjs, docs/qualification/trademark-public-use.md]
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/1304, https://github.com/kungfu-systems/kungfu/pull/1310, https://github.com/kungfu-systems/kungfu/pull/1320, https://github.com/kungfu-systems/kungfu/pull/1321]
+qualification_refs: [framework/release/kungfu-trademark-public-use.contract.json, crates/trunk/src/product_identity.rs, framework/core/src/python/kungfu/product_identity.py, framework/gui/src/main/product-identity.ts, product/scripts/cli-surface-qualification.mjs, scripts/check-trademark-public-use.mjs, scripts/check-trademark-public-use.test.mjs, docs/qualification/trademark-public-use.md]
 review_state: self-reviewed
 sensitivity: public
 sources: [local-files, official-upstream, user-consensus]
@@ -73,9 +73,11 @@ The signature can become recognizable without renaming any technical surface or
 displacing the product promise. The cost is a small amount of duplicated public
 copy and a release-time evidence obligation.
 
-The current staged implementation provides public source surfaces and the
-executable release gate, but deliberately leaves released-software use false.
-The first real public release must add both required runtime-facing surfaces and
+The current staged implementation provides public source surfaces, the
+executable release gate, backward-compatible native and Python
+`kungfu --version` projections, and a packaged GUI About projection, but
+deliberately leaves released-software use false. The first real public release
+must bind these product-controlled surfaces to a real acquisition path and
 complete public evidence in a reviewed release change. The gate also freezes
 the existing repository, CLI, npm/Python package, domain, KFD, Buildchain, and
 libkungfu identifiers so the source signature cannot become a technical rename.

--- a/docs/qualification/trademark-public-use.md
+++ b/docs/qualification/trademark-public-use.md
@@ -26,6 +26,22 @@ Source acceptance runs `scripts/check-trademark-public-use.mjs` and its negative
 fixtures. The governing decision is
 [KF-ADR-019f8cc4-e796-7b0e-9a16-50c08614e848](../adr/KF-ADR-019f8cc4-e796-7b0e-9a16-50c08614e848.md).
 
+## Source-implemented product surfaces
+
+The assembled Rust front door and the Python compatibility path now render
+`kungfu --version` as two stable lines: the existing version remains the first
+line, and **Kungfu UNGFU™ · Never Guess. Facts Unfold.** is the second. Readers
+that need only the version continue to consume the first non-empty line.
+
+The packaged desktop app sets a native About panel for **Kungfu Episodes** with
+**Kungfu UNGFU™** as its secondary signature and **Never Guess. Facts Unfold.**
+as its credits line. Kungfu Episodes remains the application name.
+
+These are source-implemented product surfaces, not release evidence. The
+contract records them separately from `currentState.productSurfaces`, which
+remains empty until a real public artifact binds one of these surfaces to a
+reviewed release coordinate.
+
 ## Gate for the first real public release
 
 Before `releasedSoftwareUseClaim` can become true, one reviewable change must

--- a/framework/core/src/python/kungfu/cli/commands/__init__.py
+++ b/framework/core/src/python/kungfu/cli/commands/__init__.py
@@ -8,6 +8,7 @@ import typing
 from click.globals import get_current_context
 from functools import update_wrapper
 from kungfu.config import default_config_home, default_runtime_home
+from kungfu.product_identity import version_banner
 
 # click 8.1.7+ 移除了私有 TypeVar F；CLI 仅用于装饰器类型标注，改本地定义不依赖 click 内部符号。
 CLI = typing.TypeVar("CLI", bound=typing.Callable[..., typing.Any])
@@ -295,7 +296,9 @@ def _progressive_help(ctx, param, value):
     help="emit the offline discovery contract as JSON and exit",
 )
 @click.help_option("-h", "--help")
-@click.version_option(kungfu.__version__, "--version", message=kungfu.__version__)
+@click.version_option(
+    kungfu.__version__, "--version", message=version_banner(kungfu.__version__)
+)
 @click.pass_context
 def kfc(ctx, home, extension_path, log_level, name, stage, env_verify_location):
     if env_verify_location:

--- a/framework/core/src/python/kungfu/product_identity.py
+++ b/framework/core/src/python/kungfu/product_identity.py
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+
+SECONDARY_SOURCE_SIGNATURE = "Kungfu UNGFU™"
+SOURCE_PRINCIPLE = "Never Guess. Facts Unfold."
+
+
+def version_banner(version: str) -> str:
+    """Keep the compatible version first line and append the source signature."""
+    return f"{version}\n{SECONDARY_SOURCE_SIGNATURE} · {SOURCE_PRINCIPLE}"

--- a/framework/core/tests/python/test_product_identity.py
+++ b/framework/core/tests/python/test_product_identity.py
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from kungfu.product_identity import (
+    SECONDARY_SOURCE_SIGNATURE,
+    SOURCE_PRINCIPLE,
+    version_banner,
+)
+
+
+def test_version_banner_preserves_the_version_first_line():
+    assert version_banner("4.0.0").splitlines() == [
+        "4.0.0",
+        f"{SECONDARY_SOURCE_SIGNATURE} · {SOURCE_PRINCIPLE}",
+    ]

--- a/framework/gui/src/main/index.ts
+++ b/framework/gui/src/main/index.ts
@@ -73,6 +73,11 @@ import {
   installKungfuCliToPath,
   uninstallKungfuCliFromPath,
 } from './installCli';
+import {
+  PRODUCT_NAME,
+  productAboutPanelOptions,
+  versionFirstLine,
+} from './product-identity';
 import { executeProfileCli } from './profile-cli';
 import {
   backupAndResetRuntime,
@@ -97,7 +102,6 @@ import {
   resolveLastDesktopWorkspace,
 } from './workspace-selection';
 
-const PRODUCT_NAME = 'Kungfu Episodes';
 const qualificationMode = process.env.KF_QUALIFICATION_MODE === '1';
 
 // Resolve the kungfu runtime directory that holds libkungfu.dylib and the
@@ -365,7 +369,7 @@ if (
 try {
   const kungfuBin = path.join(path.dirname(process.env.KFE_PATH), 'kungfu');
   const out = execFileSync(kungfuBin, ['--version'], { timeout: 10000 });
-  process.env.KUNGFU_VERSION = out.toString().trim();
+  process.env.KUNGFU_VERSION = versionFirstLine(out.toString());
 } catch {
   process.env.KUNGFU_VERSION = '';
 }
@@ -955,6 +959,15 @@ function buildMenu() {
     }
   };
   const cliSubmenu: Electron.MenuItemConstructorOptions[] = [
+    ...(process.platform === 'darwin'
+      ? []
+      : [
+          {
+            label: `About ${PRODUCT_NAME}`,
+            click: () => app.showAboutPanel(),
+          },
+          { type: 'separator' as const },
+        ]),
     {
       label: 'Settings…',
       accelerator: 'CmdOrCtrl+,',
@@ -1165,6 +1178,7 @@ function createWindow() {
 
 app.whenReady().then(() => {
   app.setName(PRODUCT_NAME);
+  app.setAboutPanelOptions(productAboutPanelOptions(app.getVersion()));
   initializeDesktopUpdateProvider();
   // Menus require a real display backend on Linux. The bounded qualification
   // path keeps them disabled together with the already-disabled Tray.

--- a/framework/gui/src/main/product-identity.ts
+++ b/framework/gui/src/main/product-identity.ts
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+
+export const PRODUCT_NAME = 'Kungfu Episodes';
+export const SECONDARY_SOURCE_SIGNATURE = 'Kungfu UNGFU™';
+export const SOURCE_PRINCIPLE = 'Never Guess. Facts Unfold.';
+
+export function versionFirstLine(output: string): string {
+  return (
+    output
+      .split(/\r?\n/u)
+      .find((line) => line.trim().length > 0)
+      ?.trim() || ''
+  );
+}
+
+export function productAboutPanelOptions(applicationVersion: string) {
+  return {
+    applicationName: PRODUCT_NAME,
+    applicationVersion,
+    version: applicationVersion,
+    credits: `${SECONDARY_SOURCE_SIGNATURE}\n${SOURCE_PRINCIPLE}`,
+    website: 'https://kungfu.tech',
+  };
+}

--- a/framework/release/kungfu-trademark-public-use.contract.json
+++ b/framework/release/kungfu-trademark-public-use.contract.json
@@ -27,6 +27,35 @@
       "localRuntime": "libkungfu"
     }
   },
+  "implementedProductSurfaces": {
+    "status": "source-implemented-release-evidence-pending",
+    "surfaces": [
+      {
+        "id": "cli-version",
+        "kind": "kungfu --version",
+        "exactMark": "Kungfu UNGFU™",
+        "principle": "Never Guess. Facts Unfold.",
+        "sourcePaths": [
+          "crates/trunk/src/product_identity.rs",
+          "framework/core/src/python/kungfu/product_identity.py"
+        ],
+        "compatibility": "version-first-line",
+        "releaseEvidenceStatus": "not-claimed"
+      },
+      {
+        "id": "gui-about",
+        "kind": "about",
+        "exactMark": "Kungfu UNGFU™",
+        "principle": "Never Guess. Facts Unfold.",
+        "sourcePaths": [
+          "framework/gui/src/main/product-identity.ts",
+          "framework/gui/src/main/index.ts"
+        ],
+        "compatibility": "primary-application-name-preserved",
+        "releaseEvidenceStatus": "not-claimed"
+      }
+    ]
+  },
   "currentState": {
     "publicReleaseArtifactsAvailable": false,
     "releasedSoftwareUseClaim": false,

--- a/product/scripts/cli-surface-qualification.mjs
+++ b/product/scripts/cli-surface-qualification.mjs
@@ -30,6 +30,8 @@ const PROFILE_BRIEF = {
   evidence: { strength: 'reported-with-references' },
   migration: { mode: 'additive' },
 };
+const PRODUCT_SIGNATURE = 'Kungfu UNGFU™';
+const PRODUCT_PRINCIPLE = 'Never Guess. Facts Unfold.';
 
 function stable(value) {
   if (Array.isArray(value)) return value.map(stable);
@@ -155,9 +157,23 @@ export function qualifyCliSurface({
   });
 
   try {
-    const version = run(['--version'], 'kungfu --version', {
+    const versionOutput = run(['--version'], 'kungfu --version', {
       withHome: false,
-    }).stdout.trim();
+    }).stdout;
+    const versionLines = versionOutput
+      .split(/\r?\n/u)
+      .map((line) => line.trim())
+      .filter(Boolean);
+    const version = versionLines[0] || '';
+    assert(
+      version.length > 0,
+      'kungfu --version omitted its version first line',
+    );
+    assert(
+      versionLines.slice(1).join('\n').includes(PRODUCT_SIGNATURE) &&
+        versionLines.slice(1).join('\n').includes(PRODUCT_PRINCIPLE),
+      'kungfu --version omitted the secondary product signature',
+    );
     const defaultHelp = run(['--help'], 'kungfu --help', {
       withHome: false,
     }).stdout;

--- a/product/scripts/cli-surface-qualification.test.mjs
+++ b/product/scripts/cli-surface-qualification.test.mjs
@@ -45,8 +45,13 @@ function runner(observed = catalog()) {
       stdout: JSON.stringify(value),
       stderr: '',
     });
-    if (joined.endsWith('--version'))
-      return { status: 0, stdout: '4.0.0\n', stderr: '' };
+    if (joined.endsWith('--version')) {
+      return {
+        status: 0,
+        stdout: '4.0.0\nKungfu UNGFU™ · Never Guess. Facts Unfold.\n',
+        stderr: '',
+      };
+    }
     if (joined.endsWith('--help-json')) {
       return json({
         schema: 'kungfu.cli-help-projection/v1',
@@ -118,9 +123,28 @@ test('qualification binds help, Agent, alias, KFD-3 and mutation receipts', () =
     runCommand: runner(),
   });
   assert.equal(report.qualified, true);
+  assert.equal(report.version, '4.0.0');
   assert.deepEqual(report.roots, roots);
   assert.equal(report.checks.mutationPlanReceipt.receiptVerified, true);
   assert.match(report.qualificationRoot, /^sha256:[0-9a-f]{64}$/u);
+});
+
+test('qualification rejects a product without the secondary signature', () => {
+  const unsignedRunner = runner();
+  assert.throws(
+    () =>
+      qualifyCliSurface({
+        cli: '/fixture/kungfu',
+        expectedCatalog: catalog(),
+        runCommand(input) {
+          if (input.args.join(' ').endsWith('--version')) {
+            return { status: 0, stdout: '4.0.0\n', stderr: '' };
+          }
+          return unsignedRunner(input);
+        },
+      }),
+    /omitted the secondary product signature/u,
+  );
 });
 
 test('qualification fails closed when installed roots drift', () => {

--- a/scripts/check-trademark-public-use.test.mjs
+++ b/scripts/check-trademark-public-use.test.mjs
@@ -4,6 +4,11 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 
 import {
+  PRODUCT_NAME,
+  productAboutPanelOptions,
+  versionFirstLine,
+} from '../framework/gui/src/main/product-identity.ts';
+import {
   EXACT_MARK,
   loadTrademarkPublicUse,
   validateTrademarkPublicUse,
@@ -46,6 +51,25 @@ test('the current pre-release state is truthful and complete', () => {
   assert.deepEqual(validateTrademarkPublicUse(contract, surfaces), []);
   assert.equal(contract.currentState.releasedSoftwareUseClaim, false);
   assert.equal(contract.currentState.evidenceRecords.length, 0);
+  assert.equal(contract.currentState.productSurfaces.length, 0);
+  assert.deepEqual(
+    contract.implementedProductSurfaces.surfaces.map((item) => item.id),
+    ['cli-version', 'gui-about'],
+  );
+});
+
+test('the GUI About projection preserves product and version identity', () => {
+  const options = productAboutPanelOptions('4.0.0-alpha.1');
+  assert.equal(options.applicationName, PRODUCT_NAME);
+  assert.equal(options.applicationVersion, '4.0.0-alpha.1');
+  assert.equal(options.version, '4.0.0-alpha.1');
+  assert.equal(options.credits, 'Kungfu UNGFU™\nNever Guess. Facts Unfold.');
+  assert.equal(
+    versionFirstLine(
+      '\n4.0.0-alpha.1\nKungfu UNGFU™ · Never Guess. Facts Unfold.\n',
+    ),
+    '4.0.0-alpha.1',
+  );
 });
 
 test('registered symbols and unsupported registration claims are rejected', () => {
@@ -66,6 +90,59 @@ test('registered symbols and unsupported registration claims are rejected', () =
       registrationClaim.contract,
       registrationClaim.surfaces,
     ).some((item) => item.includes('unsupported registration')),
+  );
+});
+
+test('removing a source product surface or its runtime wiring is rejected', () => {
+  const missingMark = fixture();
+  missingMark.surfaces['crates/trunk/src/product_identity.rs'] =
+    missingMark.surfaces['crates/trunk/src/product_identity.rs'].replace(
+      EXACT_MARK,
+      'Kungfu',
+    );
+  assert.ok(
+    validateTrademarkPublicUse(missingMark.contract, missingMark.surfaces).some(
+      (item) => item.includes('source identities'),
+    ),
+  );
+
+  const missingCliWiring = fixture();
+  missingCliWiring.surfaces[
+    'framework/core/src/python/kungfu/cli/commands/__init__.py'
+  ] = missingCliWiring.surfaces[
+    'framework/core/src/python/kungfu/cli/commands/__init__.py'
+  ].replace(
+    'message=version_banner(kungfu.__version__)',
+    'message=kungfu.__version__',
+  );
+  assert.ok(
+    validateTrademarkPublicUse(
+      missingCliWiring.contract,
+      missingCliWiring.surfaces,
+    ).some((item) => item.includes('version paths')),
+  );
+
+  const missingAboutWiring = fixture();
+  missingAboutWiring.surfaces['framework/gui/src/main/index.ts'] =
+    missingAboutWiring.surfaces['framework/gui/src/main/index.ts'].replace(
+      'app.showAboutPanel()',
+      'void 0',
+    );
+  assert.ok(
+    validateTrademarkPublicUse(
+      missingAboutWiring.contract,
+      missingAboutWiring.surfaces,
+    ).some((item) => item.includes('packaged GUI About')),
+  );
+
+  const claimedTooEarly = fixture();
+  claimedTooEarly.contract.implementedProductSurfaces.surfaces[0].releaseEvidenceStatus =
+    'claimed';
+  assert.ok(
+    validateTrademarkPublicUse(
+      claimedTooEarly.contract,
+      claimedTooEarly.surfaces,
+    ).some((item) => item.includes('release-evidence pending')),
   );
 });
 

--- a/scripts/document-metadata-contract.test.mjs
+++ b/scripts/document-metadata-contract.test.mjs
@@ -874,12 +874,13 @@ test('pins PR evidence reachability to the source-acceptance base SHA', () => {
   assert.deepEqual(documentation?.args, ['scripts/run-docs-source-check.mjs']);
 });
 
-test('runs distributed ADR identity tests in both documentation gates', () => {
+test('runs Git-sensitive documentation fixtures serially in both gates', () => {
   for (const runner of ['run-docs-check.mjs', 'run-docs-source-check.mjs']) {
     const source = fs.readFileSync(
       path.join(REPO_ROOT, 'scripts', runner),
       'utf8',
     );
+    assert.match(source, /'--test-concurrency=1'/);
     assert.match(source, /path\.join\('scripts', 'adr-identity\.test\.mjs'\)/);
     assert.match(source, /path\.join\('scripts', 'adr-new\.test\.mjs'\)/);
     assert.match(source, /path\.join\('scripts', 'adr-migration\.test\.mjs'\)/);

--- a/scripts/run-docs-check.mjs
+++ b/scripts/run-docs-check.mjs
@@ -36,6 +36,7 @@ try {
   ]);
   run('negative fixtures', [
     '--test',
+    '--test-concurrency=1',
     path.join('scripts', 'adr-identity.test.mjs'),
     path.join('scripts', 'adr-new.test.mjs'),
     path.join('scripts', 'adr-migration.test.mjs'),

--- a/scripts/run-docs-source-check.mjs
+++ b/scripts/run-docs-source-check.mjs
@@ -31,6 +31,7 @@ try {
   ]);
   run('documentation contract fixtures', [
     '--test',
+    '--test-concurrency=1',
     path.join('scripts', 'adr-identity.test.mjs'),
     path.join('scripts', 'adr-new.test.mjs'),
     path.join('scripts', 'adr-migration.test.mjs'),

--- a/scripts/trademark-public-use-contract.mjs
+++ b/scripts/trademark-public-use-contract.mjs
@@ -9,6 +9,7 @@ const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const CONTRACT_PATH =
   'framework/release/kungfu-trademark-public-use.contract.json';
 const EXACT_MARK = 'Kungfu UNGFU™';
+const PRINCIPLE = 'Never Guess. Facts Unfold.';
 const OWNER = 'Kungfu Origin Technology Limited';
 const SOURCE_REPOSITORY = 'https://github.com/kungfu-systems/kungfu';
 const PROTECTED_TECHNICAL_IDENTIFIERS = {
@@ -121,6 +122,35 @@ const DISALLOWED_CLASS9_EVIDENCE_KINDS = [
   'preview',
   'staging',
 ];
+const IMPLEMENTED_PRODUCT_SURFACES = {
+  status: 'source-implemented-release-evidence-pending',
+  surfaces: [
+    {
+      id: 'cli-version',
+      kind: 'kungfu --version',
+      exactMark: EXACT_MARK,
+      principle: PRINCIPLE,
+      sourcePaths: [
+        'crates/trunk/src/product_identity.rs',
+        'framework/core/src/python/kungfu/product_identity.py',
+      ],
+      compatibility: 'version-first-line',
+      releaseEvidenceStatus: 'not-claimed',
+    },
+    {
+      id: 'gui-about',
+      kind: 'about',
+      exactMark: EXACT_MARK,
+      principle: PRINCIPLE,
+      sourcePaths: [
+        'framework/gui/src/main/product-identity.ts',
+        'framework/gui/src/main/index.ts',
+      ],
+      compatibility: 'primary-application-name-preserved',
+      releaseEvidenceStatus: 'not-claimed',
+    },
+  ],
+};
 
 /** @param {unknown} value */
 function object(value) {
@@ -215,6 +245,7 @@ export function validateTrademarkPublicUse(contract, surfaces) {
   const brand = object(contract.brand);
   const state = object(contract.currentState);
   const gate = object(contract.firstPublicReleaseGate);
+  const implemented = object(contract.implementedProductSurfaces);
   const identifiers = object(brand.protectedTechnicalIdentifiers);
   const acquisitionGate = object(gate.acquisitionSurface);
   const productGate = object(gate.productSurface);
@@ -228,11 +259,21 @@ export function validateTrademarkPublicUse(contract, surfaces) {
     issues.push('primary product name must remain Kungfu');
   if (brand.exactMark !== EXACT_MARK)
     issues.push('exact mark must remain Kungfu UNGFU™');
+  if (brand.principle !== PRINCIPLE)
+    issues.push('source principle must remain Never Guess. Facts Unfold.');
   if (brand.owner !== OWNER) issues.push('trademark owner is not exact');
   if (brand.role !== 'secondary-source-signature')
     issues.push('mark must remain a secondary source signature');
   if (brand.registrationStatusClaim !== 'none')
     issues.push('registration status must not be claimed');
+  if (
+    JSON.stringify(canonicalJson(implemented)) !==
+    JSON.stringify(canonicalJson(IMPLEMENTED_PRODUCT_SURFACES))
+  ) {
+    issues.push(
+      'implemented CLI and GUI product surfaces must remain exact and release-evidence pending',
+    );
+  }
   if (
     JSON.stringify(canonicalJson(identifiers)) !==
     JSON.stringify(canonicalJson(PROTECTED_TECHNICAL_IDENTIFIERS))
@@ -324,6 +365,62 @@ export function validateTrademarkPublicUse(contract, surfaces) {
     !why.includes('UNGFU is not a second product or runtime')
   ) {
     issues.push('Why Kungfu must preserve the exact mark and product boundary');
+  }
+  const nativeIdentity = surfaces['crates/trunk/src/product_identity.rs'] || '';
+  const pythonIdentity =
+    surfaces['framework/core/src/python/kungfu/product_identity.py'] || '';
+  const guiIdentity =
+    surfaces['framework/gui/src/main/product-identity.ts'] || '';
+  const principle = String(brand.principle || '');
+  if (
+    !nativeIdentity.includes(
+      `pub const SECONDARY_SOURCE_SIGNATURE: &str = "${EXACT_MARK}";`,
+    ) ||
+    !nativeIdentity.includes(
+      `pub const SOURCE_PRINCIPLE: &str = "${principle}";`,
+    ) ||
+    !pythonIdentity.includes(`SECONDARY_SOURCE_SIGNATURE = "${EXACT_MARK}"`) ||
+    !pythonIdentity.includes(`SOURCE_PRINCIPLE = "${principle}"`) ||
+    !guiIdentity.includes(`SECONDARY_SOURCE_SIGNATURE = '${EXACT_MARK}'`) ||
+    !guiIdentity.includes(`SOURCE_PRINCIPLE = '${principle}'`)
+  ) {
+    issues.push(
+      'CLI and GUI source identities must contain the exact mark and principle',
+    );
+  }
+  const nativeCli = surfaces['crates/trunk/src/main.rs'] || '';
+  const pythonCli =
+    surfaces['framework/core/src/python/kungfu/cli/commands/__init__.py'] || '';
+  if (
+    !nativeCli.includes('product_identity::version_banner(&version)') ||
+    !pythonCli.includes('message=version_banner(kungfu.__version__)')
+  ) {
+    issues.push(
+      'native and Python kungfu --version paths must project the product identity banner',
+    );
+  }
+  const guiMain = surfaces['framework/gui/src/main/index.ts'] || '';
+  if (
+    !guiMain.includes(
+      'app.setAboutPanelOptions(productAboutPanelOptions(app.getVersion()))',
+    ) ||
+    !guiMain.includes('app.showAboutPanel()') ||
+    !guiMain.includes('versionFirstLine(out.toString())')
+  ) {
+    issues.push(
+      'packaged GUI About and version reader must preserve the product identity contract',
+    );
+  }
+  const installedQualification =
+    surfaces['product/scripts/cli-surface-qualification.mjs'] || '';
+  if (
+    !installedQualification.includes(EXACT_MARK) ||
+    !installedQualification.includes(principle) ||
+    !installedQualification.includes('versionLines.slice(1).join')
+  ) {
+    issues.push(
+      'installed-product qualification must require the signature after the compatible version line',
+    );
   }
   const rootPackage = JSON.parse(surfaces['package.json'] || '{}');
   const productPackage = JSON.parse(surfaces['product/package.json'] || '{}');
@@ -558,6 +655,13 @@ export function loadTrademarkPublicUse(root = ROOT) {
         'framework/core/package.json',
         'framework/core/pyproject.toml',
         'framework/sdk/python/pyproject.toml',
+        'crates/trunk/src/product_identity.rs',
+        'crates/trunk/src/main.rs',
+        'framework/core/src/python/kungfu/product_identity.py',
+        'framework/core/src/python/kungfu/cli/commands/__init__.py',
+        'framework/gui/src/main/product-identity.ts',
+        'framework/gui/src/main/index.ts',
+        'product/scripts/cli-surface-qualification.mjs',
       ].map((item) => [item, read(item)]),
     ),
   };


### PR DESCRIPTION
## Summary

Project the exact secondary signature `Kungfu UNGFU™ · Never Guess. Facts Unfold.` from stable CLI and GUI product-controlled surfaces without changing Kungfu's primary identity or making a released-software-use claim.

## Changes

- preserve the existing version as the first line of both native and Python `kungfu --version`, with the secondary signature on the following line
- add the same exact signature to the packaged Kungfu Episodes About panel while keeping the real application version and primary product name
- extend product qualification and the trademark public-use contract to reject drift, primary-brand substitution, renamed executables, or premature release evidence
- serialize Git-sensitive documentation fixtures so source and full documentation gates remain deterministic

## Verification

- `./shifu check:source` (543 contract tests: 533 passed, 10 platform skips; source gate passed)
- `cargo test --manifest-path crates/Cargo.toml -p kungfu-trunk` (46/46)
- `pnpm --filter @kungfu-tech/gui run build`
- `node --test scripts/check-trademark-public-use.test.mjs product/scripts/cli-surface-qualification.test.mjs` (14/14)
- native and Python `kungfu --version` smoke checks
- pre-commit staged gates for both commits

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "stage-ready",
  "adrs": ["KF-ADR-019f8cc4-e796-7b0e-9a16-50c08614e848"],
  "summary": "Project the staged Kungfu UNGFU secondary source signature from stable CLI and GUI surfaces while preserving primary identity and release-evidence boundaries.",
  "verification": ["native and Python version-surface tests", "packaged GUI build", "trademark product-surface contract fixtures", "full build-free source acceptance"]
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [x] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

This PR publishes no site, creates no downloadable release, records no first-use date, and makes no registration or legal conclusion.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed
