### PR TITLE
fix(core): resolve canonical ADR records

### DIFF
--- a/framework/core/architecture/query-health.mjs
+++ b/framework/core/architecture/query-health.mjs
@@ -262,6 +262,17 @@ function gitLines(args) {
   return result.stdout.split('\n').filter(Boolean);
 }
 
+function matchesAdrRecordPath(adr, file) {
+  if (path.posix.dirname(file) !== 'docs/adr') return false;
+  const prefix = `docs/adr/${adr}`;
+  return (
+    file === `${prefix}.md` ||
+    (/^(?:ADR|SHIFU-ADR)-\d{4}$/.test(adr) &&
+      file.startsWith(`${prefix}-`) &&
+      file.endsWith('.md'))
+  );
+}
+
 function trackedFiles(layers) {
   return unique(
     layers.tracked_roots.flatMap((trackedRoot) =>
@@ -468,6 +479,7 @@ function renderHealth(report, layers, baseline, observations) {
 
 function validateAuthority(layers, build) {
   const problems = [];
+  const trackedAdrPaths = gitLines(['ls-files', 'docs/adr/*.md']);
   const ids = new Set(layers.components.map((component) => component.id));
   if (layers.components.length < 6 || layers.components.length > 12)
     problems.push('component count is outside the governed 6-12 range');
@@ -482,7 +494,7 @@ function validateAuthority(layers, build) {
         problems.push(`${diagnostic.id}: missing ${file}`);
     }
     for (const adr of diagnostic.adrs) {
-      if (!gitLines(['ls-files', `docs/adr/${adr}-*.md`]).length)
+      if (!trackedAdrPaths.some((file) => matchesAdrRecordPath(adr, file)))
         problems.push(`${diagnostic.id}: missing ${adr}`);
     }
   }
@@ -501,6 +513,27 @@ function validateAuthority(layers, build) {
 }
 
 function selfTest(layers, build) {
+  const adrPathScenarios = [
+    ['ADR-0058', 'docs/adr/ADR-0058-mmap-policy.md', true],
+    [
+      'KF-ADR-019f86da-4f90-7f8a-9bff-e4f7683da35f',
+      'docs/adr/KF-ADR-019f86da-4f90-7f8a-9bff-e4f7683da35f.md',
+      true,
+    ],
+    [
+      'KF-ADR-019f86da-4f90-7f8a-9bff-e4f7683da35f',
+      'docs/adr/KF-ADR-019f86da-4f90-7f8a-9bff-e4f7683da35f-not-canonical.md',
+      false,
+    ],
+    ['ADR-0058', 'docs/adr/ADR-00580-not-the-same-record.md', false],
+    ['ADR-0058', 'docs/adr/archive/ADR-0058-mmap-policy.md', false],
+    ['ADR-0058', 'docs/adr/ADR-0058-archive/nested.md', false],
+  ];
+  for (const [adr, file, expected] of adrPathScenarios) {
+    if (matchesAdrRecordPath(adr, file) !== expected)
+      throw new Error(`${adr}:${file} ADR path classification drifted`);
+  }
+  console.log('  ok: legacy and canonical ADR record paths resolve exactly');
   const scenarios = [
     [
       'path',


### PR DESCRIPTION
## Summary

Allow the Core architecture health authority to resolve both canonical UUIDv7 ADR records and grandfathered legacy slug records without accepting nested or prefix-collision paths.

## Changes

- load tracked ADR Markdown paths once and require direct children of docs/adr
- match canonical identities only by exact filename
- retain bounded legacy slug resolution for ADR-#### and SHIFU-ADR-####
- add positive and adversarial self-test cases

## Verification

- ./shifu core:architecture --self-test
- ./shifu check:source
- staged commit gate
- independent review: PASS

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{"schema":"kungfu.adr-release-pr/v1","kind":"adr-neutral","intent":"bugfix","reason":"Identity-aware architecture health path resolution; no architecture decision or implementation status change"}
-->

## Governance risk check

- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed